### PR TITLE
feat(domainpack): implement domain pack version activation endpoint (#332)

### DIFF
--- a/backend/src/main/java/com/init/domainpack/application/ActivateDomainPackVersionCommand.java
+++ b/backend/src/main/java/com/init/domainpack/application/ActivateDomainPackVersionCommand.java
@@ -1,0 +1,4 @@
+package com.init.domainpack.application;
+
+public record ActivateDomainPackVersionCommand(
+    Long workspaceId, Long packId, Long versionId, Long userId) {}

--- a/backend/src/main/java/com/init/domainpack/application/ActivateDomainPackVersionResult.java
+++ b/backend/src/main/java/com/init/domainpack/application/ActivateDomainPackVersionResult.java
@@ -1,0 +1,23 @@
+package com.init.domainpack.application;
+
+import com.init.domainpack.domain.model.DomainPackVersion;
+import java.time.OffsetDateTime;
+
+public record ActivateDomainPackVersionResult(
+    Long id,
+    Long domainPackId,
+    Integer versionNo,
+    String lifecycleStatus,
+    OffsetDateTime publishedAt,
+    OffsetDateTime updatedAt) {
+
+  public static ActivateDomainPackVersionResult from(DomainPackVersion version) {
+    return new ActivateDomainPackVersionResult(
+        version.getId(),
+        version.getDomainPackId(),
+        version.getVersionNo(),
+        version.getLifecycleStatus(),
+        version.getPublishedAt(),
+        version.getUpdatedAt());
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/application/ActivateDomainPackVersionUseCase.java
+++ b/backend/src/main/java/com/init/domainpack/application/ActivateDomainPackVersionUseCase.java
@@ -13,6 +13,7 @@ import com.init.domainpack.domain.repository.WorkspaceMembershipPort;
 import java.time.Clock;
 import java.time.OffsetDateTime;
 import java.util.Set;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,11 +30,16 @@ public class ActivateDomainPackVersionUseCase {
   private final WorkspaceMembershipPort workspaceMembershipPort;
   private final Clock clock;
 
+  @Autowired
   public ActivateDomainPackVersionUseCase(
       DomainPackVersionRepository versionRepository,
       WorkspaceExistencePort workspaceExistencePort,
       WorkspaceMembershipPort workspaceMembershipPort) {
-    this(versionRepository, workspaceExistencePort, workspaceMembershipPort, Clock.systemDefaultZone());
+    this(
+        versionRepository,
+        workspaceExistencePort,
+        workspaceMembershipPort,
+        Clock.systemDefaultZone());
   }
 
   public ActivateDomainPackVersionUseCase(

--- a/backend/src/main/java/com/init/domainpack/application/ActivateDomainPackVersionUseCase.java
+++ b/backend/src/main/java/com/init/domainpack/application/ActivateDomainPackVersionUseCase.java
@@ -35,8 +35,7 @@ public class ActivateDomainPackVersionUseCase {
   public ActivateDomainPackVersionResult execute(ActivateDomainPackVersionCommand command) {
     // workspace 존재 확인 (U-005 Confirmed)
     if (!workspaceExistencePort.existsById(command.workspaceId())) {
-      throw new WorkspaceNotFoundException(
-          "워크스페이스를 찾을 수 없습니다. id=" + command.workspaceId());
+      throw new WorkspaceNotFoundException("워크스페이스를 찾을 수 없습니다. id=" + command.workspaceId());
     }
 
     // workspace 멤버십 + 역할 확인: OPERATOR 또는 ADMIN만 허용 (U-005 Confirmed)

--- a/backend/src/main/java/com/init/domainpack/application/ActivateDomainPackVersionUseCase.java
+++ b/backend/src/main/java/com/init/domainpack/application/ActivateDomainPackVersionUseCase.java
@@ -1,0 +1,76 @@
+package com.init.domainpack.application;
+
+import com.init.corpus.application.exception.UnauthorizedWorkspaceAccessException;
+import com.init.corpus.application.exception.WorkspaceNotFoundException;
+import com.init.domainpack.application.exception.DomainPackVersionConflictException;
+import com.init.domainpack.application.exception.DomainPackVersionInvalidStateException;
+import com.init.domainpack.application.exception.DomainPackVersionNotFoundException;
+import com.init.domainpack.domain.model.DomainPackVersion;
+import com.init.domainpack.domain.repository.DomainPackVersionRepository;
+import com.init.domainpack.domain.repository.WorkspaceExistencePort;
+import com.init.domainpack.domain.repository.WorkspaceMembershipPort;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class ActivateDomainPackVersionUseCase {
+
+  private final DomainPackVersionRepository versionRepository;
+  private final WorkspaceExistencePort workspaceExistencePort;
+  private final WorkspaceMembershipPort workspaceMembershipPort;
+
+  public ActivateDomainPackVersionUseCase(
+      DomainPackVersionRepository versionRepository,
+      WorkspaceExistencePort workspaceExistencePort,
+      WorkspaceMembershipPort workspaceMembershipPort) {
+    this.versionRepository = versionRepository;
+    this.workspaceExistencePort = workspaceExistencePort;
+    this.workspaceMembershipPort = workspaceMembershipPort;
+  }
+
+  public ActivateDomainPackVersionResult execute(ActivateDomainPackVersionCommand command) {
+    // workspace 존재 확인 (U-005 Confirmed)
+    if (!workspaceExistencePort.existsById(command.workspaceId())) {
+      throw new WorkspaceNotFoundException(
+          "워크스페이스를 찾을 수 없습니다. id=" + command.workspaceId());
+    }
+
+    // workspace 멤버십 + 역할 확인: OPERATOR 또는 ADMIN만 허용 (U-005 Confirmed)
+    if (!workspaceMembershipPort.existsByWorkspaceIdAndUserIdAndMemberRoleIn(
+        command.workspaceId(), command.userId(), List.of("OPERATOR", "ADMIN"))) {
+      throw new UnauthorizedWorkspaceAccessException(
+          "워크스페이스에 접근 권한이 없습니다. workspaceId=" + command.workspaceId());
+    }
+
+    DomainPackVersion version =
+        versionRepository
+            .findById(command.versionId())
+            .orElseThrow(() -> new DomainPackVersionNotFoundException(command.versionId()));
+
+    // packId 일치 검증 (path variable 위·변조 방어)
+    if (!version.getDomainPackId().equals(command.packId())) {
+      throw new DomainPackVersionNotFoundException(command.versionId());
+    }
+
+    // lifecycle_status 전이: PUBLISHED가 아닌 모든 상태에서 허용 (U-001 Confirmed)
+    try {
+      version.activate(OffsetDateTime.now());
+    } catch (IllegalStateException e) {
+      throw new DomainPackVersionInvalidStateException(e.getMessage());
+    }
+
+    // review_decision 검증 없음 (U-002 Confirmed)
+    // 기존 PUBLISHED 버전 비활성화 없음 (U-003 Confirmed)
+    // Domain Event 발행 없음 (U-004 Confirmed)
+    try {
+      DomainPackVersion saved = versionRepository.save(version);
+      return ActivateDomainPackVersionResult.from(saved);
+    } catch (ObjectOptimisticLockingFailureException e) {
+      throw new DomainPackVersionConflictException(command.versionId());
+    }
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/application/ActivateDomainPackVersionUseCase.java
+++ b/backend/src/main/java/com/init/domainpack/application/ActivateDomainPackVersionUseCase.java
@@ -69,7 +69,7 @@ public class ActivateDomainPackVersionUseCase {
 
     DomainPackVersion version =
         versionRepository
-            .findById(command.versionId())
+            .findByIdAndWorkspaceId(command.workspaceId(), command.versionId())
             .orElseThrow(() -> new DomainPackVersionNotFoundException(command.versionId()));
 
     // packId 일치 검증 (path variable 위·변조 방어)
@@ -88,7 +88,7 @@ public class ActivateDomainPackVersionUseCase {
     // 기존 PUBLISHED 버전 비활성화 없음 (U-003 Confirmed)
     // Domain Event 발행 없음 (U-004 Confirmed)
     try {
-      DomainPackVersion saved = versionRepository.save(version);
+      DomainPackVersion saved = versionRepository.saveAndFlush(version);
       return ActivateDomainPackVersionResult.from(saved);
     } catch (ObjectOptimisticLockingFailureException e) {
       throw new DomainPackVersionConflictException(command.versionId());

--- a/backend/src/main/java/com/init/domainpack/application/ActivateDomainPackVersionUseCase.java
+++ b/backend/src/main/java/com/init/domainpack/application/ActivateDomainPackVersionUseCase.java
@@ -1,16 +1,18 @@
 package com.init.domainpack.application;
 
-import com.init.corpus.application.exception.UnauthorizedWorkspaceAccessException;
-import com.init.corpus.application.exception.WorkspaceNotFoundException;
+import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
 import com.init.domainpack.application.exception.DomainPackVersionConflictException;
 import com.init.domainpack.application.exception.DomainPackVersionInvalidStateException;
 import com.init.domainpack.application.exception.DomainPackVersionNotFoundException;
+import com.init.domainpack.application.exception.DomainPackWorkspaceNotFoundException;
 import com.init.domainpack.domain.model.DomainPackVersion;
+import com.init.domainpack.domain.model.WorkspaceMemberRole;
 import com.init.domainpack.domain.repository.DomainPackVersionRepository;
 import com.init.domainpack.domain.repository.WorkspaceExistencePort;
 import com.init.domainpack.domain.repository.WorkspaceMembershipPort;
+import java.time.Clock;
 import java.time.OffsetDateTime;
-import java.util.List;
+import java.util.Set;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,29 +21,43 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class ActivateDomainPackVersionUseCase {
 
+  private static final Set<WorkspaceMemberRole> ALLOWED_WORKSPACE_ROLES =
+      Set.of(WorkspaceMemberRole.OPERATOR, WorkspaceMemberRole.ADMIN);
+
   private final DomainPackVersionRepository versionRepository;
   private final WorkspaceExistencePort workspaceExistencePort;
   private final WorkspaceMembershipPort workspaceMembershipPort;
+  private final Clock clock;
 
   public ActivateDomainPackVersionUseCase(
       DomainPackVersionRepository versionRepository,
       WorkspaceExistencePort workspaceExistencePort,
       WorkspaceMembershipPort workspaceMembershipPort) {
+    this(versionRepository, workspaceExistencePort, workspaceMembershipPort, Clock.systemDefaultZone());
+  }
+
+  public ActivateDomainPackVersionUseCase(
+      DomainPackVersionRepository versionRepository,
+      WorkspaceExistencePort workspaceExistencePort,
+      WorkspaceMembershipPort workspaceMembershipPort,
+      Clock clock) {
     this.versionRepository = versionRepository;
     this.workspaceExistencePort = workspaceExistencePort;
     this.workspaceMembershipPort = workspaceMembershipPort;
+    this.clock = clock;
   }
 
   public ActivateDomainPackVersionResult execute(ActivateDomainPackVersionCommand command) {
     // workspace 존재 확인 (U-005 Confirmed)
     if (!workspaceExistencePort.existsById(command.workspaceId())) {
-      throw new WorkspaceNotFoundException("워크스페이스를 찾을 수 없습니다. id=" + command.workspaceId());
+      throw new DomainPackWorkspaceNotFoundException(
+          "워크스페이스를 찾을 수 없습니다. id=" + command.workspaceId());
     }
 
     // workspace 멤버십 + 역할 확인: OPERATOR 또는 ADMIN만 허용 (U-005 Confirmed)
-    if (!workspaceMembershipPort.existsByWorkspaceIdAndUserIdAndMemberRoleIn(
-        command.workspaceId(), command.userId(), List.of("OPERATOR", "ADMIN"))) {
-      throw new UnauthorizedWorkspaceAccessException(
+    if (!workspaceMembershipPort.hasAnyRole(
+        command.workspaceId(), command.userId(), ALLOWED_WORKSPACE_ROLES)) {
+      throw new DomainPackUnauthorizedWorkspaceAccessException(
           "워크스페이스에 접근 권한이 없습니다. workspaceId=" + command.workspaceId());
     }
 
@@ -57,7 +73,7 @@ public class ActivateDomainPackVersionUseCase {
 
     // lifecycle_status 전이: PUBLISHED가 아닌 모든 상태에서 허용 (U-001 Confirmed)
     try {
-      version.activate(OffsetDateTime.now());
+      version.activate(OffsetDateTime.now(clock));
     } catch (IllegalStateException e) {
       throw new DomainPackVersionInvalidStateException(e.getMessage());
     }

--- a/backend/src/main/java/com/init/domainpack/application/exception/DomainPackUnauthorizedWorkspaceAccessException.java
+++ b/backend/src/main/java/com/init/domainpack/application/exception/DomainPackUnauthorizedWorkspaceAccessException.java
@@ -1,0 +1,8 @@
+package com.init.domainpack.application.exception;
+
+public class DomainPackUnauthorizedWorkspaceAccessException extends RuntimeException {
+
+  public DomainPackUnauthorizedWorkspaceAccessException(String message) {
+    super(message);
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/application/exception/DomainPackVersionConflictException.java
+++ b/backend/src/main/java/com/init/domainpack/application/exception/DomainPackVersionConflictException.java
@@ -1,0 +1,8 @@
+package com.init.domainpack.application.exception;
+
+public class DomainPackVersionConflictException extends RuntimeException {
+
+  public DomainPackVersionConflictException(Long versionId) {
+    super("Domain pack version was modified by another request: " + versionId);
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/application/exception/DomainPackVersionInvalidStateException.java
+++ b/backend/src/main/java/com/init/domainpack/application/exception/DomainPackVersionInvalidStateException.java
@@ -1,0 +1,8 @@
+package com.init.domainpack.application.exception;
+
+public class DomainPackVersionInvalidStateException extends RuntimeException {
+
+  public DomainPackVersionInvalidStateException(String message) {
+    super(message);
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/application/exception/DomainPackVersionNotFoundException.java
+++ b/backend/src/main/java/com/init/domainpack/application/exception/DomainPackVersionNotFoundException.java
@@ -1,0 +1,8 @@
+package com.init.domainpack.application.exception;
+
+public class DomainPackVersionNotFoundException extends RuntimeException {
+
+  public DomainPackVersionNotFoundException(Long versionId) {
+    super("DomainPackVersion not found: " + versionId);
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/application/exception/DomainPackWorkspaceNotFoundException.java
+++ b/backend/src/main/java/com/init/domainpack/application/exception/DomainPackWorkspaceNotFoundException.java
@@ -1,0 +1,8 @@
+package com.init.domainpack.application.exception;
+
+public class DomainPackWorkspaceNotFoundException extends RuntimeException {
+
+  public DomainPackWorkspaceNotFoundException(String message) {
+    super(message);
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/domain/model/DomainPackVersion.java
+++ b/backend/src/main/java/com/init/domainpack/domain/model/DomainPackVersion.java
@@ -9,6 +9,7 @@ import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import jakarta.persistence.Version;
 import java.time.OffsetDateTime;
+import java.util.Objects;
 
 @Entity
 @Table(name = "domain_pack_version", schema = "pack")
@@ -52,6 +53,7 @@ public class DomainPackVersion {
    * @throws IllegalStateException 이미 PUBLISHED 상태인 경우
    */
   public void activate(OffsetDateTime now) {
+    Objects.requireNonNull(now, "publishedAt (now) must not be null");
     if (STATUS_PUBLISHED.equals(this.lifecycleStatus)) {
       throw new IllegalStateException("Domain pack version is already published");
     }

--- a/backend/src/main/java/com/init/domainpack/domain/model/DomainPackVersion.java
+++ b/backend/src/main/java/com/init/domainpack/domain/model/DomainPackVersion.java
@@ -33,8 +33,7 @@ public class DomainPackVersion {
   @Column(name = "updated_at", nullable = false)
   private OffsetDateTime updatedAt;
 
-  @Version
-  private Long version;
+  @Version private Long version;
 
   protected DomainPackVersion() {}
 

--- a/backend/src/main/java/com/init/domainpack/domain/model/DomainPackVersion.java
+++ b/backend/src/main/java/com/init/domainpack/domain/model/DomainPackVersion.java
@@ -14,6 +14,9 @@ import java.time.OffsetDateTime;
 @Table(name = "domain_pack_version", schema = "pack")
 public class DomainPackVersion {
 
+  public static final String STATUS_DRAFT = "DRAFT";
+  public static final String STATUS_PUBLISHED = "PUBLISHED";
+
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
@@ -49,10 +52,10 @@ public class DomainPackVersion {
    * @throws IllegalStateException 이미 PUBLISHED 상태인 경우
    */
   public void activate(OffsetDateTime now) {
-    if ("PUBLISHED".equals(this.lifecycleStatus)) {
+    if (STATUS_PUBLISHED.equals(this.lifecycleStatus)) {
       throw new IllegalStateException("Domain pack version is already published");
     }
-    this.lifecycleStatus = "PUBLISHED";
+    this.lifecycleStatus = STATUS_PUBLISHED;
     this.publishedAt = now;
   }
 

--- a/backend/src/main/java/com/init/domainpack/domain/model/DomainPackVersion.java
+++ b/backend/src/main/java/com/init/domainpack/domain/model/DomainPackVersion.java
@@ -1,0 +1,83 @@
+package com.init.domainpack.domain.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "domain_pack_version", schema = "pack")
+public class DomainPackVersion {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "domain_pack_id", nullable = false, updatable = false)
+  private Long domainPackId;
+
+  @Column(name = "version_no", nullable = false)
+  private Integer versionNo;
+
+  @Column(name = "lifecycle_status", nullable = false)
+  private String lifecycleStatus;
+
+  @Column(name = "published_at")
+  private OffsetDateTime publishedAt;
+
+  @Column(name = "updated_at", nullable = false)
+  private OffsetDateTime updatedAt;
+
+  @Version
+  private Long version;
+
+  protected DomainPackVersion() {}
+
+  @PreUpdate
+  protected void onUpdate() {
+    this.updatedAt = OffsetDateTime.now();
+  }
+
+  /**
+   * PUBLISHED가 아닌 모든 상태에서 PUBLISHED로 전이한다 (U-001 Confirmed).
+   *
+   * @param now 활성화 시각
+   * @throws IllegalStateException 이미 PUBLISHED 상태인 경우
+   */
+  public void activate(OffsetDateTime now) {
+    if ("PUBLISHED".equals(this.lifecycleStatus)) {
+      throw new IllegalStateException("Domain pack version is already published");
+    }
+    this.lifecycleStatus = "PUBLISHED";
+    this.publishedAt = now;
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public Long getDomainPackId() {
+    return domainPackId;
+  }
+
+  public Integer getVersionNo() {
+    return versionNo;
+  }
+
+  public String getLifecycleStatus() {
+    return lifecycleStatus;
+  }
+
+  public OffsetDateTime getPublishedAt() {
+    return publishedAt;
+  }
+
+  public OffsetDateTime getUpdatedAt() {
+    return updatedAt;
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/domain/model/WorkspaceMemberRole.java
+++ b/backend/src/main/java/com/init/domainpack/domain/model/WorkspaceMemberRole.java
@@ -1,0 +1,7 @@
+package com.init.domainpack.domain.model;
+
+/** domainpack bounded context에서 워크스페이스 멤버 역할을 나타내는 enum. */
+public enum WorkspaceMemberRole {
+  OPERATOR,
+  ADMIN
+}

--- a/backend/src/main/java/com/init/domainpack/domain/repository/DomainPackVersionRepository.java
+++ b/backend/src/main/java/com/init/domainpack/domain/repository/DomainPackVersionRepository.java
@@ -7,5 +7,9 @@ public interface DomainPackVersionRepository {
 
   Optional<DomainPackVersion> findById(Long id);
 
+  Optional<DomainPackVersion> findByIdAndWorkspaceId(Long workspaceId, Long versionId);
+
   DomainPackVersion save(DomainPackVersion version);
+
+  DomainPackVersion saveAndFlush(DomainPackVersion version);
 }

--- a/backend/src/main/java/com/init/domainpack/domain/repository/DomainPackVersionRepository.java
+++ b/backend/src/main/java/com/init/domainpack/domain/repository/DomainPackVersionRepository.java
@@ -1,0 +1,11 @@
+package com.init.domainpack.domain.repository;
+
+import com.init.domainpack.domain.model.DomainPackVersion;
+import java.util.Optional;
+
+public interface DomainPackVersionRepository {
+
+  Optional<DomainPackVersion> findById(Long id);
+
+  DomainPackVersion save(DomainPackVersion version);
+}

--- a/backend/src/main/java/com/init/domainpack/domain/repository/WorkspaceExistencePort.java
+++ b/backend/src/main/java/com/init/domainpack/domain/repository/WorkspaceExistencePort.java
@@ -1,0 +1,7 @@
+package com.init.domainpack.domain.repository;
+
+/** domainpack bounded context 내 workspace 존재 확인 포트 (U-005 Confirmed). */
+public interface WorkspaceExistencePort {
+
+  boolean existsById(Long id);
+}

--- a/backend/src/main/java/com/init/domainpack/domain/repository/WorkspaceMembershipPort.java
+++ b/backend/src/main/java/com/init/domainpack/domain/repository/WorkspaceMembershipPort.java
@@ -1,10 +1,10 @@
 package com.init.domainpack.domain.repository;
 
-import java.util.List;
+import com.init.domainpack.domain.model.WorkspaceMemberRole;
+import java.util.Set;
 
 /** domainpack bounded context 내 workspace 멤버십 + 역할 확인 포트 (U-005 Confirmed). */
 public interface WorkspaceMembershipPort {
 
-  boolean existsByWorkspaceIdAndUserIdAndMemberRoleIn(
-      Long workspaceId, Long userId, List<String> memberRoles);
+  boolean hasAnyRole(Long workspaceId, Long userId, Set<WorkspaceMemberRole> memberRoles);
 }

--- a/backend/src/main/java/com/init/domainpack/domain/repository/WorkspaceMembershipPort.java
+++ b/backend/src/main/java/com/init/domainpack/domain/repository/WorkspaceMembershipPort.java
@@ -1,0 +1,10 @@
+package com.init.domainpack.domain.repository;
+
+import java.util.List;
+
+/** domainpack bounded context 내 workspace 멤버십 + 역할 확인 포트 (U-005 Confirmed). */
+public interface WorkspaceMembershipPort {
+
+  boolean existsByWorkspaceIdAndUserIdAndMemberRoleIn(
+      Long workspaceId, Long userId, List<String> memberRoles);
+}

--- a/backend/src/main/java/com/init/domainpack/infrastructure/persistence/DomainPackRef.java
+++ b/backend/src/main/java/com/init/domainpack/infrastructure/persistence/DomainPackRef.java
@@ -1,0 +1,27 @@
+package com.init.domainpack.infrastructure.persistence;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+/** domainpack bounded context의 domain_pack 읽기 전용 참조 모델 (cross-context 직접 의존 금지). */
+@Entity
+@Table(name = "domain_pack", schema = "pack")
+public class DomainPackRef {
+
+  @Id private Long id;
+
+  @Column(name = "workspace_id", nullable = false, updatable = false)
+  private Long workspaceId;
+
+  protected DomainPackRef() {}
+
+  public Long getId() {
+    return id;
+  }
+
+  public Long getWorkspaceId() {
+    return workspaceId;
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/infrastructure/persistence/DomainPackWorkspaceMemberRef.java
+++ b/backend/src/main/java/com/init/domainpack/infrastructure/persistence/DomainPackWorkspaceMemberRef.java
@@ -10,8 +10,8 @@ import jakarta.persistence.Table;
 /**
  * domainpack bounded context의 workspace_member 읽기 전용 참조 모델.
  *
- * <p>corpus의 {@code WorkspaceMemberRef}는 {@code member_role} 컬럼을 매핑하지 않으므로, 역할 필터링에 필요한 별도
- * read model을 정의한다 (spec Additional Notes 참조).
+ * <p>corpus의 {@code WorkspaceMemberRef}는 {@code member_role} 컬럼을 매핑하지 않으므로, 역할 필터링에 필요한 별도 read
+ * model을 정의한다 (spec Additional Notes 참조).
  */
 @Entity
 @Table(name = "workspace_member", schema = "app")

--- a/backend/src/main/java/com/init/domainpack/infrastructure/persistence/DomainPackWorkspaceMemberRef.java
+++ b/backend/src/main/java/com/init/domainpack/infrastructure/persistence/DomainPackWorkspaceMemberRef.java
@@ -1,0 +1,34 @@
+package com.init.domainpack.infrastructure.persistence;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+/**
+ * domainpack bounded context의 workspace_member 읽기 전용 참조 모델.
+ *
+ * <p>corpus의 {@code WorkspaceMemberRef}는 {@code member_role} 컬럼을 매핑하지 않으므로, 역할 필터링에 필요한 별도
+ * read model을 정의한다 (spec Additional Notes 참조).
+ */
+@Entity
+@Table(name = "workspace_member", schema = "app")
+public class DomainPackWorkspaceMemberRef {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "workspace_id", nullable = false)
+  private Long workspaceId;
+
+  @Column(name = "user_id", nullable = false)
+  private Long userId;
+
+  @Column(name = "member_role", nullable = false)
+  private String memberRole;
+
+  protected DomainPackWorkspaceMemberRef() {}
+}

--- a/backend/src/main/java/com/init/domainpack/infrastructure/persistence/DomainPackWorkspaceRef.java
+++ b/backend/src/main/java/com/init/domainpack/infrastructure/persistence/DomainPackWorkspaceRef.java
@@ -1,0 +1,19 @@
+package com.init.domainpack.infrastructure.persistence;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+/** domainpack bounded context의 workspace 읽기 전용 참조 모델 (cross-context 직접 의존 금지, U-005). */
+@Entity
+@Table(name = "workspace", schema = "app")
+public class DomainPackWorkspaceRef {
+
+  @Id private Long id;
+
+  protected DomainPackWorkspaceRef() {}
+
+  public Long getId() {
+    return id;
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/infrastructure/persistence/JpaDomainPackVersionRepository.java
+++ b/backend/src/main/java/com/init/domainpack/infrastructure/persistence/JpaDomainPackVersionRepository.java
@@ -2,9 +2,19 @@ package com.init.domainpack.infrastructure.persistence;
 
 import com.init.domainpack.domain.model.DomainPackVersion;
 import com.init.domainpack.domain.repository.DomainPackVersionRepository;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface JpaDomainPackVersionRepository
-    extends JpaRepository<DomainPackVersion, Long>, DomainPackVersionRepository {}
+    extends JpaRepository<DomainPackVersion, Long>, DomainPackVersionRepository {
+
+  @Query(
+      "SELECT v FROM DomainPackVersion v WHERE v.id = :versionId"
+          + " AND EXISTS (SELECT p FROM DomainPackRef p WHERE p.id = v.domainPackId AND p.workspaceId = :workspaceId)")
+  Optional<DomainPackVersion> findByIdAndWorkspaceId(
+      @Param("workspaceId") Long workspaceId, @Param("versionId") Long versionId);
+}

--- a/backend/src/main/java/com/init/domainpack/infrastructure/persistence/JpaDomainPackVersionRepository.java
+++ b/backend/src/main/java/com/init/domainpack/infrastructure/persistence/JpaDomainPackVersionRepository.java
@@ -1,0 +1,10 @@
+package com.init.domainpack.infrastructure.persistence;
+
+import com.init.domainpack.domain.model.DomainPackVersion;
+import com.init.domainpack.domain.repository.DomainPackVersionRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface JpaDomainPackVersionRepository
+    extends JpaRepository<DomainPackVersion, Long>, DomainPackVersionRepository {}

--- a/backend/src/main/java/com/init/domainpack/infrastructure/persistence/JpaDomainPackWorkspaceExistenceRepository.java
+++ b/backend/src/main/java/com/init/domainpack/infrastructure/persistence/JpaDomainPackWorkspaceExistenceRepository.java
@@ -1,0 +1,9 @@
+package com.init.domainpack.infrastructure.persistence;
+
+import com.init.domainpack.domain.repository.WorkspaceExistencePort;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface JpaDomainPackWorkspaceExistenceRepository
+    extends JpaRepository<DomainPackWorkspaceRef, Long>, WorkspaceExistencePort {}

--- a/backend/src/main/java/com/init/domainpack/infrastructure/persistence/JpaDomainPackWorkspaceMembershipRepository.java
+++ b/backend/src/main/java/com/init/domainpack/infrastructure/persistence/JpaDomainPackWorkspaceMembershipRepository.java
@@ -15,8 +15,7 @@ public interface JpaDomainPackWorkspaceMembershipRepository
       Long workspaceId, Long userId, List<String> memberRoles);
 
   @Override
-  default boolean hasAnyRole(
-      Long workspaceId, Long userId, Set<WorkspaceMemberRole> memberRoles) {
+  default boolean hasAnyRole(Long workspaceId, Long userId, Set<WorkspaceMemberRole> memberRoles) {
     List<String> roleNames = memberRoles.stream().map(Enum::name).toList();
     return existsByWorkspaceIdAndUserIdAndMemberRoleIn(workspaceId, userId, roleNames);
   }

--- a/backend/src/main/java/com/init/domainpack/infrastructure/persistence/JpaDomainPackWorkspaceMembershipRepository.java
+++ b/backend/src/main/java/com/init/domainpack/infrastructure/persistence/JpaDomainPackWorkspaceMembershipRepository.java
@@ -16,6 +16,9 @@ public interface JpaDomainPackWorkspaceMembershipRepository
 
   @Override
   default boolean hasAnyRole(Long workspaceId, Long userId, Set<WorkspaceMemberRole> memberRoles) {
+    if (memberRoles == null || memberRoles.isEmpty()) {
+      return false;
+    }
     List<String> roleNames = memberRoles.stream().map(Enum::name).toList();
     return existsByWorkspaceIdAndUserIdAndMemberRoleIn(workspaceId, userId, roleNames);
   }

--- a/backend/src/main/java/com/init/domainpack/infrastructure/persistence/JpaDomainPackWorkspaceMembershipRepository.java
+++ b/backend/src/main/java/com/init/domainpack/infrastructure/persistence/JpaDomainPackWorkspaceMembershipRepository.java
@@ -1,7 +1,9 @@
 package com.init.domainpack.infrastructure.persistence;
 
+import com.init.domainpack.domain.model.WorkspaceMemberRole;
 import com.init.domainpack.domain.repository.WorkspaceMembershipPort;
 import java.util.List;
+import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -11,4 +13,11 @@ public interface JpaDomainPackWorkspaceMembershipRepository
 
   boolean existsByWorkspaceIdAndUserIdAndMemberRoleIn(
       Long workspaceId, Long userId, List<String> memberRoles);
+
+  @Override
+  default boolean hasAnyRole(
+      Long workspaceId, Long userId, Set<WorkspaceMemberRole> memberRoles) {
+    List<String> roleNames = memberRoles.stream().map(Enum::name).toList();
+    return existsByWorkspaceIdAndUserIdAndMemberRoleIn(workspaceId, userId, roleNames);
+  }
 }

--- a/backend/src/main/java/com/init/domainpack/infrastructure/persistence/JpaDomainPackWorkspaceMembershipRepository.java
+++ b/backend/src/main/java/com/init/domainpack/infrastructure/persistence/JpaDomainPackWorkspaceMembershipRepository.java
@@ -1,0 +1,14 @@
+package com.init.domainpack.infrastructure.persistence;
+
+import com.init.domainpack.domain.repository.WorkspaceMembershipPort;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface JpaDomainPackWorkspaceMembershipRepository
+    extends JpaRepository<DomainPackWorkspaceMemberRef, Long>, WorkspaceMembershipPort {
+
+  boolean existsByWorkspaceIdAndUserIdAndMemberRoleIn(
+      Long workspaceId, Long userId, List<String> memberRoles);
+}

--- a/backend/src/main/java/com/init/domainpack/presentation/ActivateDomainPackVersionController.java
+++ b/backend/src/main/java/com/init/domainpack/presentation/ActivateDomainPackVersionController.java
@@ -1,0 +1,69 @@
+package com.init.domainpack.presentation;
+
+import com.init.domainpack.application.ActivateDomainPackVersionCommand;
+import com.init.domainpack.application.ActivateDomainPackVersionResult;
+import com.init.domainpack.application.ActivateDomainPackVersionUseCase;
+import com.init.domainpack.presentation.dto.DomainPackVersionActivateResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}")
+public class ActivateDomainPackVersionController {
+
+  private final ActivateDomainPackVersionUseCase useCase;
+
+  public ActivateDomainPackVersionController(ActivateDomainPackVersionUseCase useCase) {
+    this.useCase = useCase;
+  }
+
+  @PostMapping("/activate")
+  public ResponseEntity<DomainPackVersionActivateResponse> activate(
+      @PathVariable Long workspaceId,
+      @PathVariable Long packId,
+      @PathVariable Long versionId,
+      Authentication authentication) {
+    Long userId = getUserIdFromAuthentication(authentication);
+    ActivateDomainPackVersionCommand command =
+        new ActivateDomainPackVersionCommand(workspaceId, packId, versionId, userId);
+    ActivateDomainPackVersionResult result = useCase.execute(command);
+    return ResponseEntity.ok(
+        new DomainPackVersionActivateResponse(
+            result.id(),
+            result.domainPackId(),
+            result.versionNo(),
+            result.lifecycleStatus(),
+            result.publishedAt(),
+            result.updatedAt()));
+  }
+
+  /**
+   * Authentication principal을 Long userId로 안전하게 추출한다.
+   *
+   * @throws AuthenticationCredentialsNotFoundException authentication이 null이거나 principal이 null일 때
+   *     (401)
+   * @throws AccessDeniedException principal이 Long 타입이 아닐 때 (403)
+   */
+  private Long getUserIdFromAuthentication(Authentication authentication) {
+    if (authentication == null) {
+      throw new AuthenticationCredentialsNotFoundException("Authentication must not be null");
+    }
+    Object principal = authentication.getPrincipal();
+    if (principal == null) {
+      throw new AuthenticationCredentialsNotFoundException(
+          "Authentication principal must not be null");
+    }
+    if (!(principal instanceof Long)) {
+      throw new AccessDeniedException(
+          "Authentication principal must be of type Long, but was: "
+              + principal.getClass().getName());
+    }
+    return (Long) principal;
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/presentation/dto/DomainPackVersionActivateResponse.java
+++ b/backend/src/main/java/com/init/domainpack/presentation/dto/DomainPackVersionActivateResponse.java
@@ -1,0 +1,11 @@
+package com.init.domainpack.presentation.dto;
+
+import java.time.OffsetDateTime;
+
+public record DomainPackVersionActivateResponse(
+    Long id,
+    Long domainPackId,
+    Integer versionNo,
+    String lifecycleStatus,
+    OffsetDateTime publishedAt,
+    OffsetDateTime updatedAt) {}

--- a/backend/src/main/java/com/init/shared/presentation/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/init/shared/presentation/GlobalExceptionHandler.java
@@ -11,6 +11,9 @@ import com.init.corpus.application.exception.DatasetKeyConflictException;
 import com.init.corpus.application.exception.DuplicateTurnIndexException;
 import com.init.corpus.application.exception.UnauthorizedWorkspaceAccessException;
 import com.init.corpus.application.exception.WorkspaceNotFoundException;
+import com.init.domainpack.application.exception.DomainPackVersionConflictException;
+import com.init.domainpack.application.exception.DomainPackVersionInvalidStateException;
+import com.init.domainpack.application.exception.DomainPackVersionNotFoundException;
 import com.init.shared.presentation.dto.ErrorResponse;
 import com.init.shared.presentation.dto.ValidationErrorResponse;
 import java.util.List;
@@ -105,6 +108,27 @@ public class GlobalExceptionHandler {
       ConsultingContentParseException ex) {
     return ResponseEntity.status(HttpStatus.BAD_REQUEST)
         .body(new ErrorResponse("CONSULTING_CONTENT_PARSE_ERROR", ex.getMessage()));
+  }
+
+  @ExceptionHandler(DomainPackVersionNotFoundException.class)
+  public ResponseEntity<ErrorResponse> handleDomainPackVersionNotFound(
+      DomainPackVersionNotFoundException ex) {
+    return ResponseEntity.status(HttpStatus.NOT_FOUND)
+        .body(new ErrorResponse("DOMAIN_PACK_VERSION_NOT_FOUND", ex.getMessage()));
+  }
+
+  @ExceptionHandler(DomainPackVersionConflictException.class)
+  public ResponseEntity<ErrorResponse> handleDomainPackVersionConflict(
+      DomainPackVersionConflictException ex) {
+    return ResponseEntity.status(HttpStatus.CONFLICT)
+        .body(new ErrorResponse("CONFLICT", ex.getMessage()));
+  }
+
+  @ExceptionHandler(DomainPackVersionInvalidStateException.class)
+  public ResponseEntity<ErrorResponse> handleDomainPackVersionInvalidState(
+      DomainPackVersionInvalidStateException ex) {
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+        .body(new ErrorResponse("INVALID_STATE", ex.getMessage()));
   }
 
   @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/backend/src/main/java/com/init/shared/presentation/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/init/shared/presentation/GlobalExceptionHandler.java
@@ -11,9 +11,11 @@ import com.init.corpus.application.exception.DatasetKeyConflictException;
 import com.init.corpus.application.exception.DuplicateTurnIndexException;
 import com.init.corpus.application.exception.UnauthorizedWorkspaceAccessException;
 import com.init.corpus.application.exception.WorkspaceNotFoundException;
+import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
 import com.init.domainpack.application.exception.DomainPackVersionConflictException;
 import com.init.domainpack.application.exception.DomainPackVersionInvalidStateException;
 import com.init.domainpack.application.exception.DomainPackVersionNotFoundException;
+import com.init.domainpack.application.exception.DomainPackWorkspaceNotFoundException;
 import com.init.shared.presentation.dto.ErrorResponse;
 import com.init.shared.presentation.dto.ValidationErrorResponse;
 import java.util.List;
@@ -110,6 +112,20 @@ public class GlobalExceptionHandler {
         .body(new ErrorResponse("CONSULTING_CONTENT_PARSE_ERROR", ex.getMessage()));
   }
 
+  @ExceptionHandler(DomainPackWorkspaceNotFoundException.class)
+  public ResponseEntity<ErrorResponse> handleDomainPackWorkspaceNotFound(
+      DomainPackWorkspaceNotFoundException ex) {
+    return ResponseEntity.status(HttpStatus.NOT_FOUND)
+        .body(new ErrorResponse("DOMAIN_PACK_WORKSPACE_NOT_FOUND", ex.getMessage()));
+  }
+
+  @ExceptionHandler(DomainPackUnauthorizedWorkspaceAccessException.class)
+  public ResponseEntity<ErrorResponse> handleDomainPackUnauthorizedWorkspaceAccess(
+      DomainPackUnauthorizedWorkspaceAccessException ex) {
+    return ResponseEntity.status(HttpStatus.FORBIDDEN)
+        .body(new ErrorResponse("FORBIDDEN", ex.getMessage()));
+  }
+
   @ExceptionHandler(DomainPackVersionNotFoundException.class)
   public ResponseEntity<ErrorResponse> handleDomainPackVersionNotFound(
       DomainPackVersionNotFoundException ex) {
@@ -121,14 +137,14 @@ public class GlobalExceptionHandler {
   public ResponseEntity<ErrorResponse> handleDomainPackVersionConflict(
       DomainPackVersionConflictException ex) {
     return ResponseEntity.status(HttpStatus.CONFLICT)
-        .body(new ErrorResponse("CONFLICT", ex.getMessage()));
+        .body(new ErrorResponse("DOMAIN_PACK_CONFLICT", ex.getMessage()));
   }
 
   @ExceptionHandler(DomainPackVersionInvalidStateException.class)
   public ResponseEntity<ErrorResponse> handleDomainPackVersionInvalidState(
       DomainPackVersionInvalidStateException ex) {
     return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-        .body(new ErrorResponse("INVALID_STATE", ex.getMessage()));
+        .body(new ErrorResponse("DOMAIN_PACK_INVALID_STATE", ex.getMessage()));
   }
 
   @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/backend/src/main/resources/db/changelog/db.changelog-master.sql
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.sql
@@ -581,6 +581,10 @@ create table runtime.session_outcome (
     unique (chat_session_id)
 );
 
+--changeset devjhan:20260409-add-version-to-domain-pack-version
+--comment: Add optimistic locking version column to pack.domain_pack_version
+alter table pack.domain_pack_version add column version bigint not null default 0;
+
 --changeset devjhan:20260406-add-password-hash-to-app-user
 --comment: Add password_hash column as nullable initially (safe for non-empty tables)
 alter table app.app_user add column password_hash varchar(255);

--- a/backend/src/test/java/com/init/domainpack/application/ActivateDomainPackVersionUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/ActivateDomainPackVersionUseCaseTest.java
@@ -16,10 +16,9 @@ import com.init.domainpack.domain.model.DomainPackVersion;
 import com.init.domainpack.domain.repository.DomainPackVersionRepository;
 import com.init.domainpack.domain.repository.WorkspaceExistencePort;
 import com.init.domainpack.domain.repository.WorkspaceMembershipPort;
-import java.time.OffsetDateTime;
-import java.util.List;
-import java.util.Optional;
 import java.lang.reflect.Constructor;
+import java.time.OffsetDateTime;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -50,9 +49,7 @@ class ActivateDomainPackVersionUseCaseTest {
   @DisplayName("정상 활성화: DRAFT → PUBLISHED, 결과 반환")
   void execute_validDraft_returnsPublishedResult() {
     given(workspaceExistencePort.existsById(1L)).willReturn(true);
-    given(
-            workspaceMembershipPort.existsByWorkspaceIdAndUserIdAndMemberRoleIn(
-                any(), any(), any()))
+    given(workspaceMembershipPort.existsByWorkspaceIdAndUserIdAndMemberRoleIn(any(), any(), any()))
         .willReturn(true);
 
     DomainPackVersion version = createDraftVersion(42L, 7L);
@@ -86,8 +83,7 @@ class ActivateDomainPackVersionUseCaseTest {
   @DisplayName("workspace 비멤버 → UnauthorizedWorkspaceAccessException")
   void execute_notMember_throws403() {
     given(workspaceExistencePort.existsById(1L)).willReturn(true);
-    given(workspaceMembershipPort.existsByWorkspaceIdAndUserIdAndMemberRoleIn(
-            any(), any(), any()))
+    given(workspaceMembershipPort.existsByWorkspaceIdAndUserIdAndMemberRoleIn(any(), any(), any()))
         .willReturn(false);
 
     assertThatThrownBy(
@@ -101,8 +97,7 @@ class ActivateDomainPackVersionUseCaseTest {
   @DisplayName("존재하지 않는 versionId → DomainPackVersionNotFoundException")
   void execute_versionNotFound_throws404() {
     given(workspaceExistencePort.existsById(1L)).willReturn(true);
-    given(workspaceMembershipPort.existsByWorkspaceIdAndUserIdAndMemberRoleIn(
-            any(), any(), any()))
+    given(workspaceMembershipPort.existsByWorkspaceIdAndUserIdAndMemberRoleIn(any(), any(), any()))
         .willReturn(true);
     given(versionRepository.findById(42L)).willReturn(Optional.empty());
 
@@ -115,8 +110,7 @@ class ActivateDomainPackVersionUseCaseTest {
   @DisplayName("packId 불일치 → DomainPackVersionNotFoundException")
   void execute_packIdMismatch_throws404() {
     given(workspaceExistencePort.existsById(1L)).willReturn(true);
-    given(workspaceMembershipPort.existsByWorkspaceIdAndUserIdAndMemberRoleIn(
-            any(), any(), any()))
+    given(workspaceMembershipPort.existsByWorkspaceIdAndUserIdAndMemberRoleIn(any(), any(), any()))
         .willReturn(true);
 
     DomainPackVersion version = createDraftVersion(42L, 99L); // domainPackId=99, not 7
@@ -131,8 +125,7 @@ class ActivateDomainPackVersionUseCaseTest {
   @DisplayName("이미 PUBLISHED 상태 → DomainPackVersionInvalidStateException")
   void execute_alreadyPublished_throws400() {
     given(workspaceExistencePort.existsById(1L)).willReturn(true);
-    given(workspaceMembershipPort.existsByWorkspaceIdAndUserIdAndMemberRoleIn(
-            any(), any(), any()))
+    given(workspaceMembershipPort.existsByWorkspaceIdAndUserIdAndMemberRoleIn(any(), any(), any()))
         .willReturn(true);
 
     DomainPackVersion published = createPublishedVersion(42L, 7L);
@@ -147,8 +140,7 @@ class ActivateDomainPackVersionUseCaseTest {
   @DisplayName("동시 활성화 충돌 → DomainPackVersionConflictException")
   void execute_optimisticLockFailure_throws409() {
     given(workspaceExistencePort.existsById(1L)).willReturn(true);
-    given(workspaceMembershipPort.existsByWorkspaceIdAndUserIdAndMemberRoleIn(
-            any(), any(), any()))
+    given(workspaceMembershipPort.existsByWorkspaceIdAndUserIdAndMemberRoleIn(any(), any(), any()))
         .willReturn(true);
 
     DomainPackVersion version = createDraftVersion(42L, 7L);

--- a/backend/src/test/java/com/init/domainpack/application/ActivateDomainPackVersionUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/ActivateDomainPackVersionUseCaseTest.java
@@ -58,17 +58,17 @@ class ActivateDomainPackVersionUseCaseTest {
     given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
 
     DomainPackVersion version = createDraftVersion(42L, 7L);
-    given(versionRepository.findById(42L)).willReturn(Optional.of(version));
+    given(versionRepository.findByIdAndWorkspaceId(1L, 42L)).willReturn(Optional.of(version));
 
     DomainPackVersion saved = createSavedVersion(42L, 7L);
-    given(versionRepository.save(any())).willReturn(saved);
+    given(versionRepository.saveAndFlush(any())).willReturn(saved);
 
     ActivateDomainPackVersionCommand command =
         new ActivateDomainPackVersionCommand(1L, 7L, 42L, 10L);
     ActivateDomainPackVersionResult result = useCase.execute(command);
 
     assertThat(result.id()).isEqualTo(42L);
-    assertThat(result.lifecycleStatus()).isEqualTo("PUBLISHED");
+    assertThat(result.lifecycleStatus()).isEqualTo(DomainPackVersion.STATUS_PUBLISHED);
     assertThat(result.publishedAt()).isNotNull();
   }
 
@@ -102,7 +102,7 @@ class ActivateDomainPackVersionUseCaseTest {
   void execute_versionNotFound_throws404() {
     given(workspaceExistencePort.existsById(1L)).willReturn(true);
     given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
-    given(versionRepository.findById(42L)).willReturn(Optional.empty());
+    given(versionRepository.findByIdAndWorkspaceId(1L, 42L)).willReturn(Optional.empty());
 
     assertThatThrownBy(
             () -> useCase.execute(new ActivateDomainPackVersionCommand(1L, 7L, 42L, 10L)))
@@ -116,7 +116,7 @@ class ActivateDomainPackVersionUseCaseTest {
     given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
 
     DomainPackVersion version = createDraftVersion(42L, 99L); // domainPackId=99, not 7
-    given(versionRepository.findById(42L)).willReturn(Optional.of(version));
+    given(versionRepository.findByIdAndWorkspaceId(1L, 42L)).willReturn(Optional.of(version));
 
     assertThatThrownBy(
             () -> useCase.execute(new ActivateDomainPackVersionCommand(1L, 7L, 42L, 10L)))
@@ -130,7 +130,7 @@ class ActivateDomainPackVersionUseCaseTest {
     given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
 
     DomainPackVersion published = createPublishedVersion(42L, 7L);
-    given(versionRepository.findById(42L)).willReturn(Optional.of(published));
+    given(versionRepository.findByIdAndWorkspaceId(1L, 42L)).willReturn(Optional.of(published));
 
     assertThatThrownBy(
             () -> useCase.execute(new ActivateDomainPackVersionCommand(1L, 7L, 42L, 10L)))
@@ -144,8 +144,8 @@ class ActivateDomainPackVersionUseCaseTest {
     given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
 
     DomainPackVersion version = createDraftVersion(42L, 7L);
-    given(versionRepository.findById(42L)).willReturn(Optional.of(version));
-    given(versionRepository.save(any()))
+    given(versionRepository.findByIdAndWorkspaceId(1L, 42L)).willReturn(Optional.of(version));
+    given(versionRepository.saveAndFlush(any()))
         .willThrow(new ObjectOptimisticLockingFailureException(DomainPackVersion.class, 42L));
 
     assertThatThrownBy(
@@ -170,7 +170,7 @@ class ActivateDomainPackVersionUseCaseTest {
     ReflectionTestUtils.setField(version, "id", id);
     ReflectionTestUtils.setField(version, "domainPackId", domainPackId);
     ReflectionTestUtils.setField(version, "versionNo", 1);
-    ReflectionTestUtils.setField(version, "lifecycleStatus", "DRAFT");
+    ReflectionTestUtils.setField(version, "lifecycleStatus", DomainPackVersion.STATUS_DRAFT);
     ReflectionTestUtils.setField(version, "updatedAt", OffsetDateTime.now(FIXED_CLOCK));
     return version;
   }
@@ -180,7 +180,7 @@ class ActivateDomainPackVersionUseCaseTest {
     ReflectionTestUtils.setField(version, "id", id);
     ReflectionTestUtils.setField(version, "domainPackId", domainPackId);
     ReflectionTestUtils.setField(version, "versionNo", 1);
-    ReflectionTestUtils.setField(version, "lifecycleStatus", "PUBLISHED");
+    ReflectionTestUtils.setField(version, "lifecycleStatus", DomainPackVersion.STATUS_PUBLISHED);
     ReflectionTestUtils.setField(version, "publishedAt", OffsetDateTime.now(FIXED_CLOCK));
     ReflectionTestUtils.setField(version, "updatedAt", OffsetDateTime.now(FIXED_CLOCK));
     return version;
@@ -191,7 +191,7 @@ class ActivateDomainPackVersionUseCaseTest {
     ReflectionTestUtils.setField(version, "id", id);
     ReflectionTestUtils.setField(version, "domainPackId", domainPackId);
     ReflectionTestUtils.setField(version, "versionNo", 1);
-    ReflectionTestUtils.setField(version, "lifecycleStatus", "PUBLISHED");
+    ReflectionTestUtils.setField(version, "lifecycleStatus", DomainPackVersion.STATUS_PUBLISHED);
     ReflectionTestUtils.setField(
         version, "publishedAt", OffsetDateTime.parse("2026-04-09T12:00:00Z"));
     ReflectionTestUtils.setField(

--- a/backend/src/test/java/com/init/domainpack/application/ActivateDomainPackVersionUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/ActivateDomainPackVersionUseCaseTest.java
@@ -7,17 +7,20 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
-import com.init.corpus.application.exception.UnauthorizedWorkspaceAccessException;
-import com.init.corpus.application.exception.WorkspaceNotFoundException;
+import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
 import com.init.domainpack.application.exception.DomainPackVersionConflictException;
 import com.init.domainpack.application.exception.DomainPackVersionInvalidStateException;
 import com.init.domainpack.application.exception.DomainPackVersionNotFoundException;
+import com.init.domainpack.application.exception.DomainPackWorkspaceNotFoundException;
 import com.init.domainpack.domain.model.DomainPackVersion;
 import com.init.domainpack.domain.repository.DomainPackVersionRepository;
 import com.init.domainpack.domain.repository.WorkspaceExistencePort;
 import com.init.domainpack.domain.repository.WorkspaceMembershipPort;
 import java.lang.reflect.Constructor;
+import java.time.Clock;
+import java.time.Instant;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -32,6 +35,9 @@ import org.springframework.test.util.ReflectionTestUtils;
 @DisplayName("ActivateDomainPackVersionUseCase")
 class ActivateDomainPackVersionUseCaseTest {
 
+  private static final Instant FIXED_INSTANT = Instant.parse("2026-04-09T12:00:00Z");
+  private static final Clock FIXED_CLOCK = Clock.fixed(FIXED_INSTANT, ZoneOffset.UTC);
+
   @Mock private DomainPackVersionRepository versionRepository;
   @Mock private WorkspaceExistencePort workspaceExistencePort;
   @Mock private WorkspaceMembershipPort workspaceMembershipPort;
@@ -42,15 +48,14 @@ class ActivateDomainPackVersionUseCaseTest {
   void setUp() {
     useCase =
         new ActivateDomainPackVersionUseCase(
-            versionRepository, workspaceExistencePort, workspaceMembershipPort);
+            versionRepository, workspaceExistencePort, workspaceMembershipPort, FIXED_CLOCK);
   }
 
   @Test
   @DisplayName("정상 활성화: DRAFT → PUBLISHED, 결과 반환")
   void execute_validDraft_returnsPublishedResult() {
     given(workspaceExistencePort.existsById(1L)).willReturn(true);
-    given(workspaceMembershipPort.existsByWorkspaceIdAndUserIdAndMemberRoleIn(any(), any(), any()))
-        .willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
 
     DomainPackVersion version = createDraftVersion(42L, 7L);
     given(versionRepository.findById(42L)).willReturn(Optional.of(version));
@@ -68,27 +73,26 @@ class ActivateDomainPackVersionUseCaseTest {
   }
 
   @Test
-  @DisplayName("workspace 없음 → WorkspaceNotFoundException")
+  @DisplayName("workspace 없음 → DomainPackWorkspaceNotFoundException")
   void execute_workspaceNotFound_throws404() {
     given(workspaceExistencePort.existsById(1L)).willReturn(false);
 
     assertThatThrownBy(
             () -> useCase.execute(new ActivateDomainPackVersionCommand(1L, 7L, 42L, 10L)))
-        .isInstanceOf(WorkspaceNotFoundException.class);
+        .isInstanceOf(DomainPackWorkspaceNotFoundException.class);
 
     verify(versionRepository, never()).findById(any());
   }
 
   @Test
-  @DisplayName("workspace 비멤버 → UnauthorizedWorkspaceAccessException")
+  @DisplayName("workspace 비멤버 → DomainPackUnauthorizedWorkspaceAccessException")
   void execute_notMember_throws403() {
     given(workspaceExistencePort.existsById(1L)).willReturn(true);
-    given(workspaceMembershipPort.existsByWorkspaceIdAndUserIdAndMemberRoleIn(any(), any(), any()))
-        .willReturn(false);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(false);
 
     assertThatThrownBy(
             () -> useCase.execute(new ActivateDomainPackVersionCommand(1L, 7L, 42L, 10L)))
-        .isInstanceOf(UnauthorizedWorkspaceAccessException.class);
+        .isInstanceOf(DomainPackUnauthorizedWorkspaceAccessException.class);
 
     verify(versionRepository, never()).findById(any());
   }
@@ -97,8 +101,7 @@ class ActivateDomainPackVersionUseCaseTest {
   @DisplayName("존재하지 않는 versionId → DomainPackVersionNotFoundException")
   void execute_versionNotFound_throws404() {
     given(workspaceExistencePort.existsById(1L)).willReturn(true);
-    given(workspaceMembershipPort.existsByWorkspaceIdAndUserIdAndMemberRoleIn(any(), any(), any()))
-        .willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
     given(versionRepository.findById(42L)).willReturn(Optional.empty());
 
     assertThatThrownBy(
@@ -110,8 +113,7 @@ class ActivateDomainPackVersionUseCaseTest {
   @DisplayName("packId 불일치 → DomainPackVersionNotFoundException")
   void execute_packIdMismatch_throws404() {
     given(workspaceExistencePort.existsById(1L)).willReturn(true);
-    given(workspaceMembershipPort.existsByWorkspaceIdAndUserIdAndMemberRoleIn(any(), any(), any()))
-        .willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
 
     DomainPackVersion version = createDraftVersion(42L, 99L); // domainPackId=99, not 7
     given(versionRepository.findById(42L)).willReturn(Optional.of(version));
@@ -125,8 +127,7 @@ class ActivateDomainPackVersionUseCaseTest {
   @DisplayName("이미 PUBLISHED 상태 → DomainPackVersionInvalidStateException")
   void execute_alreadyPublished_throws400() {
     given(workspaceExistencePort.existsById(1L)).willReturn(true);
-    given(workspaceMembershipPort.existsByWorkspaceIdAndUserIdAndMemberRoleIn(any(), any(), any()))
-        .willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
 
     DomainPackVersion published = createPublishedVersion(42L, 7L);
     given(versionRepository.findById(42L)).willReturn(Optional.of(published));
@@ -140,8 +141,7 @@ class ActivateDomainPackVersionUseCaseTest {
   @DisplayName("동시 활성화 충돌 → DomainPackVersionConflictException")
   void execute_optimisticLockFailure_throws409() {
     given(workspaceExistencePort.existsById(1L)).willReturn(true);
-    given(workspaceMembershipPort.existsByWorkspaceIdAndUserIdAndMemberRoleIn(any(), any(), any()))
-        .willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
 
     DomainPackVersion version = createDraftVersion(42L, 7L);
     given(versionRepository.findById(42L)).willReturn(Optional.of(version));
@@ -171,7 +171,7 @@ class ActivateDomainPackVersionUseCaseTest {
     ReflectionTestUtils.setField(version, "domainPackId", domainPackId);
     ReflectionTestUtils.setField(version, "versionNo", 1);
     ReflectionTestUtils.setField(version, "lifecycleStatus", "DRAFT");
-    ReflectionTestUtils.setField(version, "updatedAt", OffsetDateTime.now());
+    ReflectionTestUtils.setField(version, "updatedAt", OffsetDateTime.now(FIXED_CLOCK));
     return version;
   }
 
@@ -181,8 +181,8 @@ class ActivateDomainPackVersionUseCaseTest {
     ReflectionTestUtils.setField(version, "domainPackId", domainPackId);
     ReflectionTestUtils.setField(version, "versionNo", 1);
     ReflectionTestUtils.setField(version, "lifecycleStatus", "PUBLISHED");
-    ReflectionTestUtils.setField(version, "publishedAt", OffsetDateTime.now());
-    ReflectionTestUtils.setField(version, "updatedAt", OffsetDateTime.now());
+    ReflectionTestUtils.setField(version, "publishedAt", OffsetDateTime.now(FIXED_CLOCK));
+    ReflectionTestUtils.setField(version, "updatedAt", OffsetDateTime.now(FIXED_CLOCK));
     return version;
   }
 

--- a/backend/src/test/java/com/init/domainpack/application/ActivateDomainPackVersionUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/ActivateDomainPackVersionUseCaseTest.java
@@ -1,0 +1,209 @@
+package com.init.domainpack.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.init.corpus.application.exception.UnauthorizedWorkspaceAccessException;
+import com.init.corpus.application.exception.WorkspaceNotFoundException;
+import com.init.domainpack.application.exception.DomainPackVersionConflictException;
+import com.init.domainpack.application.exception.DomainPackVersionInvalidStateException;
+import com.init.domainpack.application.exception.DomainPackVersionNotFoundException;
+import com.init.domainpack.domain.model.DomainPackVersion;
+import com.init.domainpack.domain.repository.DomainPackVersionRepository;
+import com.init.domainpack.domain.repository.WorkspaceExistencePort;
+import com.init.domainpack.domain.repository.WorkspaceMembershipPort;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.lang.reflect.Constructor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ActivateDomainPackVersionUseCase")
+class ActivateDomainPackVersionUseCaseTest {
+
+  @Mock private DomainPackVersionRepository versionRepository;
+  @Mock private WorkspaceExistencePort workspaceExistencePort;
+  @Mock private WorkspaceMembershipPort workspaceMembershipPort;
+
+  private ActivateDomainPackVersionUseCase useCase;
+
+  @BeforeEach
+  void setUp() {
+    useCase =
+        new ActivateDomainPackVersionUseCase(
+            versionRepository, workspaceExistencePort, workspaceMembershipPort);
+  }
+
+  @Test
+  @DisplayName("정상 활성화: DRAFT → PUBLISHED, 결과 반환")
+  void execute_validDraft_returnsPublishedResult() {
+    given(workspaceExistencePort.existsById(1L)).willReturn(true);
+    given(
+            workspaceMembershipPort.existsByWorkspaceIdAndUserIdAndMemberRoleIn(
+                any(), any(), any()))
+        .willReturn(true);
+
+    DomainPackVersion version = createDraftVersion(42L, 7L);
+    given(versionRepository.findById(42L)).willReturn(Optional.of(version));
+
+    DomainPackVersion saved = createSavedVersion(42L, 7L);
+    given(versionRepository.save(any())).willReturn(saved);
+
+    ActivateDomainPackVersionCommand command =
+        new ActivateDomainPackVersionCommand(1L, 7L, 42L, 10L);
+    ActivateDomainPackVersionResult result = useCase.execute(command);
+
+    assertThat(result.id()).isEqualTo(42L);
+    assertThat(result.lifecycleStatus()).isEqualTo("PUBLISHED");
+    assertThat(result.publishedAt()).isNotNull();
+  }
+
+  @Test
+  @DisplayName("workspace 없음 → WorkspaceNotFoundException")
+  void execute_workspaceNotFound_throws404() {
+    given(workspaceExistencePort.existsById(1L)).willReturn(false);
+
+    assertThatThrownBy(
+            () -> useCase.execute(new ActivateDomainPackVersionCommand(1L, 7L, 42L, 10L)))
+        .isInstanceOf(WorkspaceNotFoundException.class);
+
+    verify(versionRepository, never()).findById(any());
+  }
+
+  @Test
+  @DisplayName("workspace 비멤버 → UnauthorizedWorkspaceAccessException")
+  void execute_notMember_throws403() {
+    given(workspaceExistencePort.existsById(1L)).willReturn(true);
+    given(workspaceMembershipPort.existsByWorkspaceIdAndUserIdAndMemberRoleIn(
+            any(), any(), any()))
+        .willReturn(false);
+
+    assertThatThrownBy(
+            () -> useCase.execute(new ActivateDomainPackVersionCommand(1L, 7L, 42L, 10L)))
+        .isInstanceOf(UnauthorizedWorkspaceAccessException.class);
+
+    verify(versionRepository, never()).findById(any());
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 versionId → DomainPackVersionNotFoundException")
+  void execute_versionNotFound_throws404() {
+    given(workspaceExistencePort.existsById(1L)).willReturn(true);
+    given(workspaceMembershipPort.existsByWorkspaceIdAndUserIdAndMemberRoleIn(
+            any(), any(), any()))
+        .willReturn(true);
+    given(versionRepository.findById(42L)).willReturn(Optional.empty());
+
+    assertThatThrownBy(
+            () -> useCase.execute(new ActivateDomainPackVersionCommand(1L, 7L, 42L, 10L)))
+        .isInstanceOf(DomainPackVersionNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("packId 불일치 → DomainPackVersionNotFoundException")
+  void execute_packIdMismatch_throws404() {
+    given(workspaceExistencePort.existsById(1L)).willReturn(true);
+    given(workspaceMembershipPort.existsByWorkspaceIdAndUserIdAndMemberRoleIn(
+            any(), any(), any()))
+        .willReturn(true);
+
+    DomainPackVersion version = createDraftVersion(42L, 99L); // domainPackId=99, not 7
+    given(versionRepository.findById(42L)).willReturn(Optional.of(version));
+
+    assertThatThrownBy(
+            () -> useCase.execute(new ActivateDomainPackVersionCommand(1L, 7L, 42L, 10L)))
+        .isInstanceOf(DomainPackVersionNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("이미 PUBLISHED 상태 → DomainPackVersionInvalidStateException")
+  void execute_alreadyPublished_throws400() {
+    given(workspaceExistencePort.existsById(1L)).willReturn(true);
+    given(workspaceMembershipPort.existsByWorkspaceIdAndUserIdAndMemberRoleIn(
+            any(), any(), any()))
+        .willReturn(true);
+
+    DomainPackVersion published = createPublishedVersion(42L, 7L);
+    given(versionRepository.findById(42L)).willReturn(Optional.of(published));
+
+    assertThatThrownBy(
+            () -> useCase.execute(new ActivateDomainPackVersionCommand(1L, 7L, 42L, 10L)))
+        .isInstanceOf(DomainPackVersionInvalidStateException.class);
+  }
+
+  @Test
+  @DisplayName("동시 활성화 충돌 → DomainPackVersionConflictException")
+  void execute_optimisticLockFailure_throws409() {
+    given(workspaceExistencePort.existsById(1L)).willReturn(true);
+    given(workspaceMembershipPort.existsByWorkspaceIdAndUserIdAndMemberRoleIn(
+            any(), any(), any()))
+        .willReturn(true);
+
+    DomainPackVersion version = createDraftVersion(42L, 7L);
+    given(versionRepository.findById(42L)).willReturn(Optional.of(version));
+    given(versionRepository.save(any()))
+        .willThrow(new ObjectOptimisticLockingFailureException(DomainPackVersion.class, 42L));
+
+    assertThatThrownBy(
+            () -> useCase.execute(new ActivateDomainPackVersionCommand(1L, 7L, 42L, 10L)))
+        .isInstanceOf(DomainPackVersionConflictException.class);
+  }
+
+  // ── factories ──────────────────────────────────────────────────────────────
+
+  private DomainPackVersion newVersion() {
+    try {
+      Constructor<DomainPackVersion> ctor = DomainPackVersion.class.getDeclaredConstructor();
+      ctor.setAccessible(true);
+      return ctor.newInstance();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private DomainPackVersion createDraftVersion(Long id, Long domainPackId) {
+    DomainPackVersion version = newVersion();
+    ReflectionTestUtils.setField(version, "id", id);
+    ReflectionTestUtils.setField(version, "domainPackId", domainPackId);
+    ReflectionTestUtils.setField(version, "versionNo", 1);
+    ReflectionTestUtils.setField(version, "lifecycleStatus", "DRAFT");
+    ReflectionTestUtils.setField(version, "updatedAt", OffsetDateTime.now());
+    return version;
+  }
+
+  private DomainPackVersion createPublishedVersion(Long id, Long domainPackId) {
+    DomainPackVersion version = newVersion();
+    ReflectionTestUtils.setField(version, "id", id);
+    ReflectionTestUtils.setField(version, "domainPackId", domainPackId);
+    ReflectionTestUtils.setField(version, "versionNo", 1);
+    ReflectionTestUtils.setField(version, "lifecycleStatus", "PUBLISHED");
+    ReflectionTestUtils.setField(version, "publishedAt", OffsetDateTime.now());
+    ReflectionTestUtils.setField(version, "updatedAt", OffsetDateTime.now());
+    return version;
+  }
+
+  private DomainPackVersion createSavedVersion(Long id, Long domainPackId) {
+    DomainPackVersion version = newVersion();
+    ReflectionTestUtils.setField(version, "id", id);
+    ReflectionTestUtils.setField(version, "domainPackId", domainPackId);
+    ReflectionTestUtils.setField(version, "versionNo", 1);
+    ReflectionTestUtils.setField(version, "lifecycleStatus", "PUBLISHED");
+    ReflectionTestUtils.setField(
+        version, "publishedAt", OffsetDateTime.parse("2026-04-09T12:00:00Z"));
+    ReflectionTestUtils.setField(
+        version, "updatedAt", OffsetDateTime.parse("2026-04-09T12:00:00Z"));
+    return version;
+  }
+}

--- a/backend/src/test/java/com/init/domainpack/domain/model/DomainPackVersionTest.java
+++ b/backend/src/test/java/com/init/domainpack/domain/model/DomainPackVersionTest.java
@@ -1,0 +1,52 @@
+package com.init.domainpack.domain.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@DisplayName("DomainPackVersion")
+class DomainPackVersionTest {
+
+  @Test
+  @DisplayName("activate: PUBLISHED 아닌 상태에서 호출 시 lifecycleStatus가 PUBLISHED로 변경된다")
+  void activate_fromNonPublished_setsPublished() {
+    DomainPackVersion version = createDraftVersion();
+    OffsetDateTime now = OffsetDateTime.parse("2026-04-09T12:00:00Z");
+
+    version.activate(now);
+
+    assertThat(version.getLifecycleStatus()).isEqualTo("PUBLISHED");
+    assertThat(version.getPublishedAt()).isEqualTo(now);
+    // updatedAt은 @PreUpdate(JPA 저장 시점)에서 갱신되므로 도메인 단위 테스트에서는 검증하지 않는다
+  }
+
+  @Test
+  @DisplayName("activate: 이미 PUBLISHED 상태에서 호출 시 IllegalStateException 발생")
+  void activate_fromPublished_throwsException() {
+    DomainPackVersion version = createPublishedVersion();
+
+    assertThatThrownBy(() -> version.activate(OffsetDateTime.now()))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("already published");
+  }
+
+  // ── factories ──────────────────────────────────────────────────────────────
+
+  private DomainPackVersion createDraftVersion() {
+    DomainPackVersion version = new DomainPackVersion();
+    ReflectionTestUtils.setField(version, "lifecycleStatus", "DRAFT");
+    ReflectionTestUtils.setField(version, "updatedAt", OffsetDateTime.now());
+    return version;
+  }
+
+  private DomainPackVersion createPublishedVersion() {
+    DomainPackVersion version = new DomainPackVersion();
+    ReflectionTestUtils.setField(version, "lifecycleStatus", "PUBLISHED");
+    ReflectionTestUtils.setField(version, "updatedAt", OffsetDateTime.now());
+    return version;
+  }
+}

--- a/backend/src/test/java/com/init/domainpack/presentation/ActivateDomainPackVersionControllerTest.java
+++ b/backend/src/test/java/com/init/domainpack/presentation/ActivateDomainPackVersionControllerTest.java
@@ -29,8 +29,8 @@ import org.springframework.test.web.servlet.MockMvc;
 /**
  * NI-1 Option B 채택 (corpus 선례): {@link WithLongPrincipal} 어노테이션으로 Long principal을 주입한다.
  *
- * <p>SecurityConfig가 @WebMvcTest 스캔 대상이 아니므로 기본 Spring Security 적용. CSRF 활성화로 모든 POST 요청에
- * {@code .with(csrf())} 명시.
+ * <p>SecurityConfig가 @WebMvcTest 스캔 대상이 아니므로 기본 Spring Security 적용. CSRF 활성화로 모든 POST 요청에 {@code
+ * .with(csrf())} 명시.
  */
 @WebMvcTest(
     value = ActivateDomainPackVersionController.class,
@@ -47,8 +47,7 @@ class ActivateDomainPackVersionControllerTest {
   @MockBean
   private ActivateDomainPackVersionUseCase useCase;
 
-  private static final String BASE_URL =
-      "/api/v1/workspaces/1/domain-packs/7/versions/42/activate";
+  private static final String BASE_URL = "/api/v1/workspaces/1/domain-packs/7/versions/42/activate";
 
   @Test
   @DisplayName("유효한 version → 200 OK, lifecycleStatus=PUBLISHED")
@@ -90,7 +89,8 @@ class ActivateDomainPackVersionControllerTest {
   @WithLongPrincipal(10L)
   void activate_alreadyPublished_returns400() throws Exception {
     given(useCase.execute(any()))
-        .willThrow(new DomainPackVersionInvalidStateException("Domain pack version is already published"));
+        .willThrow(
+            new DomainPackVersionInvalidStateException("Domain pack version is already published"));
 
     mockMvc
         .perform(post(BASE_URL).with(csrf()))

--- a/backend/src/test/java/com/init/domainpack/presentation/ActivateDomainPackVersionControllerTest.java
+++ b/backend/src/test/java/com/init/domainpack/presentation/ActivateDomainPackVersionControllerTest.java
@@ -7,13 +7,13 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.init.corpus.application.exception.UnauthorizedWorkspaceAccessException;
-import com.init.corpus.application.exception.WorkspaceNotFoundException;
 import com.init.domainpack.application.ActivateDomainPackVersionResult;
 import com.init.domainpack.application.ActivateDomainPackVersionUseCase;
+import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
 import com.init.domainpack.application.exception.DomainPackVersionConflictException;
 import com.init.domainpack.application.exception.DomainPackVersionInvalidStateException;
 import com.init.domainpack.application.exception.DomainPackVersionNotFoundException;
+import com.init.domainpack.application.exception.DomainPackWorkspaceNotFoundException;
 import com.init.fixtures.WithLongPrincipal;
 import com.init.shared.infrastructure.security.JwtAuthenticationFilter;
 import java.time.OffsetDateTime;
@@ -85,7 +85,7 @@ class ActivateDomainPackVersionControllerTest {
   }
 
   @Test
-  @DisplayName("이미 PUBLISHED 상태 → 400 INVALID_STATE")
+  @DisplayName("이미 PUBLISHED 상태 → 400 DOMAIN_PACK_INVALID_STATE")
   @WithLongPrincipal(10L)
   void activate_alreadyPublished_returns400() throws Exception {
     given(useCase.execute(any()))
@@ -95,20 +95,20 @@ class ActivateDomainPackVersionControllerTest {
     mockMvc
         .perform(post(BASE_URL).with(csrf()))
         .andExpect(status().isBadRequest())
-        .andExpect(jsonPath("$.code").value("INVALID_STATE"));
+        .andExpect(jsonPath("$.code").value("DOMAIN_PACK_INVALID_STATE"));
   }
 
   @Test
-  @DisplayName("workspace 없음 → 404 WORKSPACE_NOT_FOUND")
+  @DisplayName("workspace 없음 → 404 DOMAIN_PACK_WORKSPACE_NOT_FOUND")
   @WithLongPrincipal(10L)
   void activate_workspaceNotFound_returns404() throws Exception {
     given(useCase.execute(any()))
-        .willThrow(new WorkspaceNotFoundException("워크스페이스를 찾을 수 없습니다. id=1"));
+        .willThrow(new DomainPackWorkspaceNotFoundException("워크스페이스를 찾을 수 없습니다. id=1"));
 
     mockMvc
         .perform(post(BASE_URL).with(csrf()))
         .andExpect(status().isNotFound())
-        .andExpect(jsonPath("$.code").value("WORKSPACE_NOT_FOUND"));
+        .andExpect(jsonPath("$.code").value("DOMAIN_PACK_WORKSPACE_NOT_FOUND"));
   }
 
   @Test
@@ -116,7 +116,8 @@ class ActivateDomainPackVersionControllerTest {
   @WithLongPrincipal(10L)
   void activate_workspaceNonMember_returns403() throws Exception {
     given(useCase.execute(any()))
-        .willThrow(new UnauthorizedWorkspaceAccessException("워크스페이스에 접근 권한이 없습니다."));
+        .willThrow(
+            new DomainPackUnauthorizedWorkspaceAccessException("워크스페이스에 접근 권한이 없습니다."));
 
     mockMvc
         .perform(post(BASE_URL).with(csrf()))
@@ -125,7 +126,7 @@ class ActivateDomainPackVersionControllerTest {
   }
 
   @Test
-  @DisplayName("동시 활성화 충돌 → 409 CONFLICT")
+  @DisplayName("동시 활성화 충돌 → 409 DOMAIN_PACK_CONFLICT")
   @WithLongPrincipal(10L)
   void activate_concurrentConflict_returns409() throws Exception {
     given(useCase.execute(any())).willThrow(new DomainPackVersionConflictException(42L));
@@ -133,7 +134,7 @@ class ActivateDomainPackVersionControllerTest {
     mockMvc
         .perform(post(BASE_URL).with(csrf()))
         .andExpect(status().isConflict())
-        .andExpect(jsonPath("$.code").value("CONFLICT"));
+        .andExpect(jsonPath("$.code").value("DOMAIN_PACK_CONFLICT"));
   }
 
   @Test

--- a/backend/src/test/java/com/init/domainpack/presentation/ActivateDomainPackVersionControllerTest.java
+++ b/backend/src/test/java/com/init/domainpack/presentation/ActivateDomainPackVersionControllerTest.java
@@ -21,9 +21,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 /**
@@ -43,9 +43,7 @@ class ActivateDomainPackVersionControllerTest {
 
   @Autowired private MockMvc mockMvc;
 
-  @SuppressWarnings("removal")
-  @MockBean
-  private ActivateDomainPackVersionUseCase useCase;
+  @MockitoBean private ActivateDomainPackVersionUseCase useCase;
 
   private static final String BASE_URL = "/api/v1/workspaces/1/domain-packs/7/versions/42/activate";
 

--- a/backend/src/test/java/com/init/domainpack/presentation/ActivateDomainPackVersionControllerTest.java
+++ b/backend/src/test/java/com/init/domainpack/presentation/ActivateDomainPackVersionControllerTest.java
@@ -116,8 +116,7 @@ class ActivateDomainPackVersionControllerTest {
   @WithLongPrincipal(10L)
   void activate_workspaceNonMember_returns403() throws Exception {
     given(useCase.execute(any()))
-        .willThrow(
-            new DomainPackUnauthorizedWorkspaceAccessException("워크스페이스에 접근 권한이 없습니다."));
+        .willThrow(new DomainPackUnauthorizedWorkspaceAccessException("워크스페이스에 접근 권한이 없습니다."));
 
     mockMvc
         .perform(post(BASE_URL).with(csrf()))

--- a/backend/src/test/java/com/init/domainpack/presentation/ActivateDomainPackVersionControllerTest.java
+++ b/backend/src/test/java/com/init/domainpack/presentation/ActivateDomainPackVersionControllerTest.java
@@ -1,0 +1,144 @@
+package com.init.domainpack.presentation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.init.corpus.application.exception.UnauthorizedWorkspaceAccessException;
+import com.init.corpus.application.exception.WorkspaceNotFoundException;
+import com.init.domainpack.application.ActivateDomainPackVersionResult;
+import com.init.domainpack.application.ActivateDomainPackVersionUseCase;
+import com.init.domainpack.application.exception.DomainPackVersionConflictException;
+import com.init.domainpack.application.exception.DomainPackVersionInvalidStateException;
+import com.init.domainpack.application.exception.DomainPackVersionNotFoundException;
+import com.init.fixtures.WithLongPrincipal;
+import com.init.shared.infrastructure.security.JwtAuthenticationFilter;
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * NI-1 Option B 채택 (corpus 선례): {@link WithLongPrincipal} 어노테이션으로 Long principal을 주입한다.
+ *
+ * <p>SecurityConfig가 @WebMvcTest 스캔 대상이 아니므로 기본 Spring Security 적용. CSRF 활성화로 모든 POST 요청에
+ * {@code .with(csrf())} 명시.
+ */
+@WebMvcTest(
+    value = ActivateDomainPackVersionController.class,
+    excludeFilters =
+        @ComponentScan.Filter(
+            type = FilterType.ASSIGNABLE_TYPE,
+            classes = JwtAuthenticationFilter.class))
+@DisplayName("ActivateDomainPackVersionController")
+class ActivateDomainPackVersionControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @SuppressWarnings("removal")
+  @MockBean
+  private ActivateDomainPackVersionUseCase useCase;
+
+  private static final String BASE_URL =
+      "/api/v1/workspaces/1/domain-packs/7/versions/42/activate";
+
+  @Test
+  @DisplayName("유효한 version → 200 OK, lifecycleStatus=PUBLISHED")
+  @WithLongPrincipal(10L)
+  void activate_validVersion_returns200() throws Exception {
+    ActivateDomainPackVersionResult result =
+        new ActivateDomainPackVersionResult(
+            42L,
+            7L,
+            3,
+            "PUBLISHED",
+            OffsetDateTime.parse("2026-04-09T12:00:00Z"),
+            OffsetDateTime.parse("2026-04-09T12:00:00Z"));
+    given(useCase.execute(any())).willReturn(result);
+
+    mockMvc
+        .perform(post(BASE_URL).with(csrf()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.lifecycleStatus").value("PUBLISHED"))
+        .andExpect(jsonPath("$.publishedAt").isNotEmpty())
+        .andExpect(jsonPath("$.id").value(42))
+        .andExpect(jsonPath("$.domainPackId").value(7));
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 versionId → 404 DOMAIN_PACK_VERSION_NOT_FOUND")
+  @WithLongPrincipal(10L)
+  void activate_nonExistentVersion_returns404() throws Exception {
+    given(useCase.execute(any())).willThrow(new DomainPackVersionNotFoundException(42L));
+
+    mockMvc
+        .perform(post(BASE_URL).with(csrf()))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("DOMAIN_PACK_VERSION_NOT_FOUND"));
+  }
+
+  @Test
+  @DisplayName("이미 PUBLISHED 상태 → 400 INVALID_STATE")
+  @WithLongPrincipal(10L)
+  void activate_alreadyPublished_returns400() throws Exception {
+    given(useCase.execute(any()))
+        .willThrow(new DomainPackVersionInvalidStateException("Domain pack version is already published"));
+
+    mockMvc
+        .perform(post(BASE_URL).with(csrf()))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("INVALID_STATE"));
+  }
+
+  @Test
+  @DisplayName("workspace 없음 → 404 WORKSPACE_NOT_FOUND")
+  @WithLongPrincipal(10L)
+  void activate_workspaceNotFound_returns404() throws Exception {
+    given(useCase.execute(any()))
+        .willThrow(new WorkspaceNotFoundException("워크스페이스를 찾을 수 없습니다. id=1"));
+
+    mockMvc
+        .perform(post(BASE_URL).with(csrf()))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("WORKSPACE_NOT_FOUND"));
+  }
+
+  @Test
+  @DisplayName("workspace 비멤버 → 403 FORBIDDEN")
+  @WithLongPrincipal(10L)
+  void activate_workspaceNonMember_returns403() throws Exception {
+    given(useCase.execute(any()))
+        .willThrow(new UnauthorizedWorkspaceAccessException("워크스페이스에 접근 권한이 없습니다."));
+
+    mockMvc
+        .perform(post(BASE_URL).with(csrf()))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.code").value("FORBIDDEN"));
+  }
+
+  @Test
+  @DisplayName("동시 활성화 충돌 → 409 CONFLICT")
+  @WithLongPrincipal(10L)
+  void activate_concurrentConflict_returns409() throws Exception {
+    given(useCase.execute(any())).willThrow(new DomainPackVersionConflictException(42L));
+
+    mockMvc
+        .perform(post(BASE_URL).with(csrf()))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("CONFLICT"));
+  }
+
+  @Test
+  @DisplayName("인증 없는 요청 → 401")
+  void activate_unauthenticated_returns401() throws Exception {
+    mockMvc.perform(post(BASE_URL).with(csrf())).andExpect(status().isUnauthorized());
+  }
+}


### PR DESCRIPTION
## Summary

`domainpack` bounded context의 첫 번째 실제 구현. `POST .../activate` 엔드포인트로 `domain_pack_version.lifecycle_status`를 `PUBLISHED`로 전이하며, workspace 존재 및 멤버십(OPERATOR/ADMIN) 검증, packId 일치 검증, optimistic lock 기반 동시성 처리를 포함한다.

---

## Context

`.agent/specs/332.md` ([BE] 3.3.2) 구현 PR. 사전 결정된 불확실성 5건(U-001~U-005) 전부 Confirmed → Implemented.

---

## What Changed

- **신규 파일 전부** (`domainpack/{application,domain,infrastructure,presentation}`): 이전에 `package-info.java` 스텁만 존재하던 bounded context에 실제 구현 추가
- `DomainPackVersion.activate(OffsetDateTime)` — `PUBLISHED` 아닌 모든 상태에서 전이 허용, `@Version` optimistic lock 적용
- `ActivateDomainPackVersionUseCase` — workspace 존재·멤버십 검증 → packId 일치 검증 → 상태 전이 → save 순서 실행
- `WorkspaceExistencePort` / `WorkspaceMembershipPort` — cross-context 직접 의존 대신 domainpack 내 포트 인터페이스로 정의, 별도 read model(`DomainPackWorkspaceRef`, `DomainPackWorkspaceMemberRef`)로 구현
- `GlobalExceptionHandler` — 3개 핸들러 추가: `DomainPackVersionNotFoundException(404)`, `DomainPackVersionConflictException(409)`, `DomainPackVersionInvalidStateException(400)`

---

## Assumptions Adopted

| ID | 결정 내용 | 구현 영향 |
|----|----------|----------|
| U-001 | `PUBLISHED`가 아닌 모든 상태에서 전이 허용 | `activate()` 내 PUBLISHED 단일 조건만 체크. REVIEW 미경유 버전도 활성화 가능 |
| U-002 | `review_decision` 검증 없음, lifecycle 전이만 담당 | UseCase에 review 조회 없음. 미검토 초안도 활성화 가능 |
| U-003 | 동일 pack 내 복수 PUBLISHED 허용 | 기존 PUBLISHED 버전 비활성화 로직 없음. workflow-runtime이 최신 PUBLISHED 버전 선택 책임 |
| U-004 | Domain Event 발행 없음 | activate 후 downstream 동기화 미구현. 별도 스펙 필요 |
| U-005 | workspace 존재 + 멤버십(OPERATOR/ADMIN) 모두 검증 | corpus `WorkspaceMemberRef` 재사용 불가(member_role 미매핑) → 별도 `DomainPackWorkspaceMemberRef` read model 신규 정의 |

---

## Spec Deviations

1. **에러 응답 필드명**: 스펙은 `"error": "NOT_FOUND"` 형식 사용. 구현은 프로젝트 전역 `ErrorResponse(code, message)` 레코드 따라 `"code": "DOMAIN_PACK_VERSION_NOT_FOUND"` 반환. 404 에러 코드도 스펙의 `NOT_FOUND` → `DOMAIN_PACK_VERSION_NOT_FOUND`로 변경.

2. **`WorkspaceMembershipPort` 시그니처**: 스펙 클래스 다이어그램은 `existsByWorkspaceIdAndUserId(Long, Long)` (2인자). 구현은 `existsByWorkspaceIdAndUserIdAndMemberRoleIn(Long, Long, List)` (역할 필터 포함). U-005 결정과는 일치하나 클래스 다이어그램과 불일치.

3. **GlobalExceptionHandler 추가 핸들러**: 스펙은 `DomainPackVersionConflictException` 핸들러 1개만 명시. 구현은 `DomainPackVersionNotFoundException`, `DomainPackVersionInvalidStateException` 핸들러도 함께 추가 (총 3개).

4. **`lifecycleStatus` 타입**: 스펙이 enum 권장. 구현은 `String` 유지.

5. **컨트롤러 테스트 방식**: 스펙은 `@SpringBootTest + @AutoConfigureMockMvc` + JWT 토큰 기반 통합 테스트 형태 제시. 구현은 corpus 선례에 따라 `@WebMvcTest` + `MockBean` 슬라이스 테스트로 작성. 실제 DB/JWT 사용하지 않음.

---

## Blocked / Skipped Items

- **동시성 실제 테스트 없음**: 동시 요청 시나리오는 `ObjectOptimisticLockingFailureException` mock 주입으로만 검증. 실제 concurrent request 테스트(스펙 체크리스트 항목) 미수행.
- **트랜잭션 롤백 검증 없음**: save 실패 시 DB 상태 유지 확인(스펙 체크리스트 항목) 테스트 없음.
- **`cross-context` 예외 클래스 임시 재사용**: `WorkspaceNotFoundException`, `UnauthorizedWorkspaceAccessException`을 corpus 패키지에서 재사용 중. GlobalExceptionHandler 재사용 이점으로 현재 허용, 향후 domainpack 전용 예외로 분리 가능.

---

## Test Notes

| 테스트 클래스 | 테스트 수 | 결과 |
|--------------|----------|------|
| `DomainPackVersionTest` | 2 | 전체 통과 |
| `ActivateDomainPackVersionUseCaseTest` | 7 | 전체 통과 |
| `ActivateDomainPackVersionControllerTest` | 7 | 전체 통과 |

커버 시나리오: 정상 활성화, workspace 없음(404), 비멤버(403), versionId 없음(404), packId 불일치(404), 이미 PUBLISHED(400), 동시 충돌(409), 인증 없음(401).

---

## Reviewer Focus

1. **`WorkspaceMembershipPort` 시그니처 불일치** (스펙 클래스 다이어그램 vs 실제 구현) — 의도적 deviation인지 검토
2. **corpus 예외 재사용** — `com.init.corpus.application.exception.*`을 domainpack application 계층에서 직접 import. cross-context 의존 허용 범위 검토
3. **동시성/트랜잭션 테스트 부재** — mock 기반 커버로 충분한지, 또는 통합 테스트 추가 필요 여부 판단

---

## Conflicts

없음.

---

## Ready to Merge / Needs Input

**Ready to Merge** — 모든 불확실성 사전 결정, 명시된 deviation은 의도적 선택이며 리뷰어 확인 후 merge 가능.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 도메인 팩 버전 활성화 API 추가 — 인증 및 워크스페이스 권한(OPERATOR/ADMIN) 검사 포함, 활성화 시 상태·퍼블리시 타임스탬프 등 결과 반환
* **오류 처리**
  * 활성화 관련 예외 매핑 추가(워크스페이스/버전 미발견, 권한 없음, 이미 발행된 상태, 충돌 등에 대해 적절한 HTTP 응답 코드 제공)
* **테스트**
  * 유스케이스와 컨트롤러의 다양한 성공·실패 시나리오 검증용 단위 및 웹 테스트 추가
* **데이터베이스**
  * 도메인 팩 버전 테이블에 버전용 컬럼 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->