### PR TITLE
docs(rules): .agent/rules 규칙 문서 강화 — 테스트 전략·모듈 생성·에러 핸들링 신규 + Java·TS·코드리뷰 보강

### DIFF
--- a/.agent/rules/code-review.md
+++ b/.agent/rules/code-review.md
@@ -15,3 +15,50 @@
 - [ ] 중첩 depth가 3 이하인가?
 - [ ] 변수명이 의도를 드러내는가?
 - [ ] 에러 처리가 적절한가?
+
+## 보안 체크
+
+- [ ] 인증/인가가 필요한 엔드포인트에 적용됐는가?
+  - 참조: `backend/src/main/java/com/init/shared/infrastructure/security/SecurityConfig.java` — JWT 필터, CORS 설정
+  - 주의: `ConsultationService`에는 인가 체크 없음 — 새 서비스는 반드시 추가
+- [ ] 사용자 입력이 `@Valid`로 검증되는가?
+- [ ] 민감 정보(비밀번호, 토큰)가 응답에 노출되지 않는가?
+- [ ] SQL injection 방지: 파라미터 바인딩 사용하는가?
+- [ ] CORS 설정이 허용된 origin만 포함하는가?
+- [ ] 에러 응답에 스택 트레이스가 노출되지 않는가?
+
+## 성능 체크
+
+- [ ] N+1 쿼리 문제가 없는가? (fetch join 또는 batch size 확인)
+- [ ] 대량 데이터에 페이지네이션이 적용됐는가?
+- [ ] 불필요한 전체 조회(`findAll`)가 없는가?
+- [ ] 프론트엔드: 불필요한 리렌더링이 없는가?
+- [ ] 이미지/파일 크기 제한이 있는가?
+  - 참조: `frontend/src/pages/consultation/ui/ConsultationPage.tsx` — 5초 폴링 패턴 주의
+
+## DDD 컴플라이언스
+
+- [ ] 도메인 로직이 Entity/Value Object 안에 있는가? (Service에 도메인 로직 금지)
+- [ ] Repository 인터페이스가 domain 패키지에 있는가?
+- [ ] Application Service가 오케스트레이션만 하는가?
+- [ ] Controller에 비즈니스 로직이 없는가?
+- [ ] 계층 간 의존성 방향이 올바른가? (`presentation → application → domain ← infrastructure`)
+- [ ] Aggregate Root만 Repository를 가지는가?
+  - 참조: `backend/src/main/java/com/init/auth/domain/model/AppUser.java` — 도메인 메서드 패턴 모범
+
+## FSD 컴플라이언스 (Frontend)
+
+- [ ] 의존성 방향이 올바른가? (`app → pages → widgets → features → entities → shared`, 상위 → 하위만 허용)
+- [ ] feature 간 직접 import가 없는가? (cross-slice 금지)
+- [ ] shared에서 feature/entity import가 없는가?
+- [ ] 각 feature가 단일 사용자 시나리오에 대응하는가?
+- [ ] 공통 컴포넌트가 `shared/ui`에 있는가?
+  - 참조: `frontend/src/features/consultation/ui/ChatPanel.tsx` — features 내부 구조
+
+## 테스트 체크
+
+- [ ] 새 기능에 대한 테스트가 추가됐는가?
+- [ ] 테스트가 Given-When-Then 패턴을 따르는가?
+  - 참조: `.agent/rules/testing.md` — BDD 패턴 상세
+- [ ] Happy path + 실패 시나리오 모두 커버하는가?
+- [ ] 테스트가 독립적으로 실행 가능한가? (다른 테스트에 의존 금지)

--- a/.agent/rules/error-handling.md
+++ b/.agent/rules/error-handling.md
@@ -22,18 +22,20 @@ BusinessException (추상) — 비즈니스 규칙 위반
 
 ### HTTP 상태 코드 매핑
 
-| Exception                              | HTTP Status | 사용 시점                                                  |
-| -------------------------------------- | ----------- | ---------------------------------------------------------- |
-| `NotFoundException`                    | 404         | findById 실패                                              |
-| `DuplicateException`                   | 409         | unique constraint 위반 (예: `EmailAlreadyExistsException`) |
-| `InvalidCredentialsException`          | 401         | 로그인 실패                                                |
-| `InvalidTokenException`                | 401         | 토큰 검증 실패                                             |
-| `UnauthorizedWorkspaceAccessException` | 403         | 권한 부족                                                  |
-| `BadRequestException`                  | 400         | 비즈니스 검증 실패                                         |
-| `MethodArgumentNotValidException`      | 400         | @Valid 실패                                                |
-| `Exception` (fallback)                 | 500         | 예상치 못한 오류                                           |
+아래 표는 base exception class 기준이다. 구체 예외는 해당 base class를 상속하여 세분화한다.
 
-구체 예외는 `DuplicateException` 계층 아래에서 세분화할 수 있다.
+| Exception                         | HTTP Status | 사용 시점              |
+| --------------------------------- | ----------- | ---------------------- |
+| `NotFoundException`               | 404         | findById 실패          |
+| `DuplicateException`              | 409         | unique constraint 위반 |
+| `InvalidCredentialsException`     | 401         | 로그인 실패            |
+| `InvalidTokenException`           | 401         | 토큰 검증 실패         |
+| `UnauthorizedException`           | 403         | 권한 부족              |
+| `BadRequestException`             | 400         | 비즈니스 검증 실패     |
+| `MethodArgumentNotValidException` | 400         | @Valid 실패            |
+| `Exception` (fallback)            | 500         | 예상치 못한 오류       |
+
+예: `DuplicateException` → `EmailAlreadyExistsException`, `UnauthorizedException` → `UnauthorizedWorkspaceAccessException`와 같이 구체 예외를 정의한다.
 
 ### 에러 응답 DTO
 

--- a/.agent/rules/error-handling.md
+++ b/.agent/rules/error-handling.md
@@ -10,7 +10,7 @@
 
 ### 예외 계층 구조
 
-```
+```text
 BusinessException (추상) — 비즈니스 규칙 위반
 ├── NotFoundException — 404: 리소스 없음
 ├── DuplicateException — 409: 중복
@@ -22,16 +22,18 @@ BusinessException (추상) — 비즈니스 규칙 위반
 
 ### HTTP 상태 코드 매핑
 
-| Exception                              | HTTP Status | 사용 시점              |
-| -------------------------------------- | ----------- | ---------------------- |
-| `NotFoundException`                    | 404         | findById 실패          |
-| `EmailAlreadyExistsException`          | 409         | unique constraint 위반 |
-| `InvalidCredentialsException`          | 401         | 로그인 실패            |
-| `InvalidTokenException`                | 401         | 토큰 검증 실패         |
-| `UnauthorizedWorkspaceAccessException` | 403         | 권한 부족              |
-| `BadRequestException`                  | 400         | 비즈니스 검증 실패     |
-| `MethodArgumentNotValidException`      | 400         | @Valid 실패            |
-| `Exception` (fallback)                 | 500         | 예상치 못한 오류       |
+| Exception                              | HTTP Status | 사용 시점                                                  |
+| -------------------------------------- | ----------- | ---------------------------------------------------------- |
+| `NotFoundException`                    | 404         | findById 실패                                              |
+| `DuplicateException`                   | 409         | unique constraint 위반 (예: `EmailAlreadyExistsException`) |
+| `InvalidCredentialsException`          | 401         | 로그인 실패                                                |
+| `InvalidTokenException`                | 401         | 토큰 검증 실패                                             |
+| `UnauthorizedWorkspaceAccessException` | 403         | 권한 부족                                                  |
+| `BadRequestException`                  | 400         | 비즈니스 검증 실패                                         |
+| `MethodArgumentNotValidException`      | 400         | @Valid 실패                                                |
+| `Exception` (fallback)                 | 500         | 예상치 못한 오류                                           |
+
+구체 예외는 `DuplicateException` 계층 아래에서 세분화할 수 있다.
 
 ### 에러 응답 DTO
 
@@ -61,6 +63,7 @@ public class GlobalExceptionHandler {
         .body(new ErrorResponse("EMAIL_ALREADY_EXISTS", ex.getMessage()));
   }
 
+  // ✅ GlobalExceptionHandler 전용: fallback 경계에서만 허용
   @ExceptionHandler(Exception.class)
   public ResponseEntity<ErrorResponse> handleGeneric(Exception ex) {
     log.error("Unhandled exception", ex);
@@ -149,6 +152,6 @@ try {
 
 - **catch 블록 비우기 금지**: 최소 로깅 필요
 - **예외 삼키기 금지**: catch 후 무시하지 않음
-- **일반 Exception catch 금지**: 구체적 예외 사용
+- **서비스/도메인 레이어에서 일반 Exception catch 금지**: 구체적 예외 사용. `GlobalExceptionHandler`의 fallback `@ExceptionHandler(Exception.class)` 전용 경계에서만 허용.
 - **에러 메시지에 기술 용어 금지**: 사용자 친화적 한글
 - **console.log를 프로덕션 에러 처리로 사용 금지**: 적절한 로깅 프레임워크 사용

--- a/.agent/rules/error-handling.md
+++ b/.agent/rules/error-handling.md
@@ -1,0 +1,154 @@
+# 에러 핸들링 패턴
+
+## 원칙
+
+- 에러는 사용자에게 의미 있는 메시지로 전달한다
+- 시스템 내부 정보(스택 트레이스, DB 쿼리)는 노출하지 않는다
+- 에러 응답 형식을 통일한다
+
+## Backend 에러 처리
+
+### 예외 계층 구조
+
+```
+BusinessException (추상) — 비즈니스 규칙 위반
+├── NotFoundException — 404: 리소스 없음
+├── DuplicateException — 409: 중복
+├── InvalidCredentialsException — 401: 인증 실패
+├── InvalidTokenException — 401: 토큰 무효
+├── UnauthorizedException — 403: 권한 없음
+└── BadRequestException — 400: 잘못된 요청
+```
+
+### HTTP 상태 코드 매핑
+
+| Exception                              | HTTP Status | 사용 시점              |
+| -------------------------------------- | ----------- | ---------------------- |
+| `NotFoundException`                    | 404         | findById 실패          |
+| `EmailAlreadyExistsException`          | 409         | unique constraint 위반 |
+| `InvalidCredentialsException`          | 401         | 로그인 실패            |
+| `InvalidTokenException`                | 401         | 토큰 검증 실패         |
+| `UnauthorizedWorkspaceAccessException` | 403         | 권한 부족              |
+| `BadRequestException`                  | 400         | 비즈니스 검증 실패     |
+| `MethodArgumentNotValidException`      | 400         | @Valid 실패            |
+| `Exception` (fallback)                 | 500         | 예상치 못한 오류       |
+
+### 에러 응답 DTO
+
+```java
+// 모든 에러 응답의 통일된 형식
+public record ErrorResponse(
+    String code,      // "NOT_FOUND", "DUPLICATE" 등
+    String message    // 사용자 친화적 메시지 (한글)
+) {}
+```
+
+### GlobalExceptionHandler 패턴
+
+```java
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+  @ExceptionHandler(NotFoundException.class)
+  public ResponseEntity<ErrorResponse> handleNotFound(NotFoundException ex) {
+    return ResponseEntity.status(HttpStatus.NOT_FOUND)
+        .body(new ErrorResponse("NOT_FOUND", ex.getMessage()));
+  }
+
+  @ExceptionHandler(EmailAlreadyExistsException.class)
+  public ResponseEntity<ErrorResponse> handleEmailAlreadyExists(EmailAlreadyExistsException ex) {
+    return ResponseEntity.status(HttpStatus.CONFLICT)
+        .body(new ErrorResponse("EMAIL_ALREADY_EXISTS", ex.getMessage()));
+  }
+
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<ErrorResponse> handleGeneric(Exception ex) {
+    log.error("Unhandled exception", ex);
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+        .body(new ErrorResponse("INTERNAL_SERVER_ERROR", "서버 오류가 발생했습니다."));
+  }
+}
+```
+
+**참조**: `backend/src/main/java/com/init/shared/presentation/GlobalExceptionHandler.java` (105L)
+
+### 서비스 레이어 에러 처리 패턴
+
+```java
+// 도메인 예외 사용 (적절)
+public User findById(Long id) {
+    return repository.findById(id)
+        .orElseThrow(() -> new NotFoundException("사용자를 찾을 수 없습니다: " + id));
+}
+
+// DataIntegrityViolation catch (중복 처리)
+public void signup(SignupCommand command) {
+    try {
+        repository.save(new AppUser(command));
+    } catch (DataIntegrityViolationException e) {
+        throw new EmailAlreadyExistsException("이미 가입된 이메일입니다");
+    }
+}
+```
+
+**참조**: `backend/src/main/java/com/init/auth/application/AuthService.java:88`
+
+## Frontend 에러 처리
+
+### 금지: alert() 사용
+
+alert()는 UX를 해치므로 프로덕션 코드에서 금지한다. 대신 Toast/Notification 컴포넌트를 사용한다.
+
+**안티패턴** (`frontend/src/pages/consultation/ui/ConsultationPage.tsx:133,142,147`):
+
+```tsx
+// ❌ 금지
+catch (error) {
+  alert('오류가 발생했습니다');  // UX 저하
+}
+```
+
+### API 에러 처리 패턴
+
+```tsx
+// API 호출 시 try-catch
+try {
+  const data = await api.getData();
+  // 성공 처리
+} catch (error) {
+  if (error instanceof ApiError) {
+    toast.error(error.message); // 서버 에러 메시지 표시
+  } else {
+    toast.error("알 수 없는 오류가 발생했습니다");
+    console.error(error); // 개발자 디버깅용
+  }
+}
+```
+
+### 컴포넌트 에러 경계
+
+- React ErrorBoundary로 렌더링 에러 포착
+- 사용자에게 "문제 발생" 화면 표시 + 새로고침 버튼
+
+### 로딩/에러/빈 상태 3종 세트
+
+- 모든 데이터 fetching 컴포넌트는 loading/error/empty 상태 처리 필수
+- skeleton UI 또는 spinner로 로딩 표시
+- 에러 시 재시도 버튼 제공
+
+## 로깅 기준
+
+| 레벨  | 사용 시점              | 예시                        |
+| ----- | ---------------------- | --------------------------- |
+| ERROR | 시스템 장애, 복구 불가 | DB 연결 실패, 외부 API 다운 |
+| WARN  | 비정상이나 복구 가능   | 재시도 성공, 폴백 사용      |
+| INFO  | 중요 비즈니스 이벤트   | 로그인, 결제, 배포          |
+| DEBUG | 디버깅 정보            | 쿼리 파라미터, 중간 계산값  |
+
+## 금지 사항
+
+- **catch 블록 비우기 금지**: 최소 로깅 필요
+- **예외 삼키기 금지**: catch 후 무시하지 않음
+- **일반 Exception catch 금지**: 구체적 예외 사용
+- **에러 메시지에 기술 용어 금지**: 사용자 친화적 한글
+- **console.log를 프로덕션 에러 처리로 사용 금지**: 적절한 로깅 프레임워크 사용

--- a/.agent/rules/java.md
+++ b/.agent/rules/java.md
@@ -205,7 +205,9 @@ public void initiatePasswordReset() { ... }
 
 근거: `backend/src/main/java/com/init/workflowruntime/application/ConsultationService.java` — 모든 메서드에 자명한 Javadoc이 달려있음. 가독성 저하.
 
-### 8. @Transactional(readOnly=true) 권장 패턴
+## 권장 패턴
+
+### @Transactional(readOnly = true) 기본값 설정
 
 ```java
 // ✅ 올바름: 클래스 기본 readOnly=true, 쓰기 메서드만 개별 오버라이드

--- a/.agent/rules/java.md
+++ b/.agent/rules/java.md
@@ -83,6 +83,144 @@ public class DomainPack {
 
 ---
 
+## 금지 패턴 (Anti-Patterns)
+
+### 1. 도메인 엔티티에 public setter 금지
+
+```java
+// ❌ 금지: 외부에서 상태를 직접 변경
+public void setStatus(SessionStatus status) {
+    this.status = status;
+}
+
+// ✅ 올바름: 의미 있는 도메인 메서드로 상태 변경
+public void close() {
+    if (this.status == SessionStatus.CLOSED) {
+        throw new IllegalStateException("이미 종료된 세션입니다");
+    }
+    this.status = SessionStatus.CLOSED;
+}
+```
+
+근거: `backend/src/main/java/com/init/workflowruntime/domain/ChatSession.java` — `setStatus()` public setter가 캡슐화를 위반함. 불변식 보장 불가.
+
+### 2. @Autowired 필드 주입 금지
+
+```java
+// ❌ 금지
+@Autowired
+private UserRepository userRepository;
+
+// ✅ 올바름: 생성자 주입
+private final UserRepository userRepository;
+public MyService(UserRepository userRepository) {
+    this.userRepository = userRepository;
+}
+```
+
+근거: 필드 주입은 테스트 어려움, 순환 의존 감지 불가, `final` 불가. `backend/src/main/java/com/init/auth/application/AuthService.java` — 생성자 주입 모범 사례.
+
+### 3. Controller에 비즈니스 로직 금지
+
+```java
+// ❌ 금지: Controller에서 직접 비즈니스 규칙 판단
+@PostMapping
+public ResponseEntity<Void> process(@RequestBody Request req) {
+    if (req.amount() > 10000) { // 비즈니스 규칙이 Controller에!
+        throw new BadRequestException("한도 초과");
+    }
+    repository.save(new Entity(req));
+    return ResponseEntity.ok().build();
+}
+
+// ✅ 올바름: Service에 위임
+@PostMapping
+public ResponseEntity<Void> process(@Valid @RequestBody Request req) {
+    service.process(req);
+    return ResponseEntity.status(201).build();
+}
+```
+
+### 4. JPA 엔티티를 API 응답으로 직접 반환 금지
+
+```java
+// ❌ 금지: 엔티티 직접 노출
+@GetMapping("/{id}")
+public AppUser getUser(@PathVariable Long id) {
+    return userRepository.findById(id).orElseThrow();
+}
+
+// ✅ 올바름: DTO로 변환
+@GetMapping("/{id}")
+public UserResponse getUser(@PathVariable Long id) {
+    AppUser user = service.findById(id);
+    return UserResponse.from(user);
+}
+```
+
+근거: 내부 구조 노출, lazy loading 문제, 순환 참조 발생. `backend/src/main/java/com/init/auth/presentation/dto/` — DTO 변환 모범 사례.
+
+### 5. 일반 Exception catch 금지
+
+```java
+// ❌ 금지
+try { ... } catch (Exception e) { ... }
+
+// ✅ 올바름: 구체적 예외 사용
+try { ... } catch (DataIntegrityViolationException e) {
+    throw new DuplicateException("이미 존재하는 항목입니다");
+}
+```
+
+근거: `backend/src/main/java/com/init/auth/application/AuthService.java:88` — `DataIntegrityViolationException` catch 패턴 참조.
+
+### 6. 빈 catch 블록 금지
+
+```java
+// ❌ 금지: 예외 삼키기
+try { ... } catch (IOException e) { }
+
+// ✅ 올바름: 최소 로깅
+try { ... } catch (IOException e) {
+    log.warn("파일 처리 실패", e);
+}
+```
+
+### 7. 과도한 Javadoc 금지
+
+```java
+// ❌ 금지: 자명한 내용을 장황하게 반복
+/**
+ * 사용자를 ID로 조회합니다.
+ * @param id 사용자 ID
+ * @return 사용자 엔티티
+ * @throws NotFoundException 사용자를 찾을 수 없는 경우
+ */
+public User findById(Long id) { ... }
+
+// ✅ 올바름: 비자명한 동작에만 간결하게
+/** 비밀번호 재설정 토큰은 30분 후 만료된다 */
+public void initiatePasswordReset() { ... }
+```
+
+근거: `backend/src/main/java/com/init/workflowruntime/application/ConsultationService.java` — 모든 메서드에 자명한 Javadoc이 달려있음. 가독성 저하.
+
+### 8. @Transactional(readOnly=true) 권장 패턴
+
+```java
+// ✅ 올바름: 클래스 기본 readOnly=true, 쓰기 메서드만 개별 오버라이드
+@Service
+@Transactional(readOnly = true)
+public class MyService {
+    public Thing findById(Long id) { ... }  // readOnly 상속
+
+    @Transactional  // 쓰기 메서드만 개별 오버라이드
+    public Thing create(CreateRequest req) { ... }
+}
+```
+
+근거: 읽기 전용 트랜잭션은 flush skip, dirty checking skip으로 성능 향상.
+
 ## 참고
 
 - [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)

--- a/.agent/rules/module-creation.md
+++ b/.agent/rules/module-creation.md
@@ -12,8 +12,8 @@
 
 ## 디렉토리 구조
 
-```
-backend/src/main/java/com/init/{module-name}/
+```text
+backend/src/main/java/com/init/{module}/
 ├── presentation/       # Controller, DTO, WebSocket Handler
 │   ├── {Module}Controller.java
 │   ├── dto/
@@ -89,7 +89,7 @@ backend/src/main/java/com/init/{module-name}/
 
 ### auth 모듈 (완성된 모범 사례)
 
-```
+```text
 backend/src/main/java/com/init/auth/
 ├── presentation/
 │   ├── AuthController.java (99L) — @Valid, HTTP 상태 코드
@@ -116,7 +116,7 @@ backend/src/main/java/com/init/auth/
 
 ### domainpack 모듈 (스켈레톤 상태)
 
-```
+```text
 backend/src/main/java/com/init/domainpack/
 ├── presentation/package-info.java (1L)
 ├── application/package-info.java (1L)

--- a/.agent/rules/module-creation.md
+++ b/.agent/rules/module-creation.md
@@ -1,0 +1,127 @@
+# 모듈 생성 가이드
+
+## 개요
+
+새 Bounded Context(모듈) 생성 시 따라야 할 체크리스트. auth 모듈을 참조 구현으로 사용한다.
+
+## 사전 확인
+
+- [ ] 새 모듈이 기존 모듈과 책임이 겹치지 않는가?
+- [ ] Bounded Context 이름이 도메인 용어와 일치하는가?
+- [ ] AGENTS.md의 Bounded Context 목록에 추가할 준비가 됐는가?
+
+## 디렉토리 구조
+
+```
+backend/src/main/java/com/init/{module-name}/
+├── presentation/       # Controller, DTO, WebSocket Handler
+│   ├── {Module}Controller.java
+│   ├── dto/
+│   │   ├── {Action}Request.java
+│   │   └── {Action}Response.java
+│   └── package-info.java
+├── application/        # UseCase, Application Service
+│   ├── {Module}Service.java
+│   ├── exception/      # 비즈니스 예외
+│   └── package-info.java
+├── domain/             # Aggregate, Entity, Value Object
+│   ├── model/
+│   │   ├── {AggregateRoot}.java
+│   │   └── {ValueObject}.java
+│   ├── repository/
+│   │   └── {Repository}.java  (interface)
+│   └── package-info.java
+└── infrastructure/     # JPA Repository, External Client
+    ├── persistence/
+    │   └── Jpa{Repository}.java
+    └── package-info.java
+```
+
+## 계층별 필수 파일 (체크리스트)
+
+### Domain 계층 (먼저 작성)
+
+- [ ] Aggregate Root 엔티티 (`@Entity`, `@Table(schema="...")`)
+- [ ] Repository 인터페이스 (domain 패키지에, JPA 의존성 없이)
+- [ ] 도메인 예외 (BusinessException 상속)
+- [ ] Value Object (필요시 `@Embeddable`)
+- [ ] package-info.java
+
+### Application 계층
+
+- [ ] Service 클래스 (`@Service`, `@Transactional`)
+- [ ] 생성자 주입 (final 필드 + 생성자)
+- [ ] 도메인 Repository 인터페이스 의존
+- [ ] package-info.java
+
+### Presentation 계층
+
+- [ ] Controller (`@RestController`, `@RequestMapping`)
+- [ ] Request/Response DTO (record 사용 권장)
+- [ ] `@Valid` 어노테이션으로 입력 검증
+- [ ] 적절한 HTTP 상태 코드 (201 생성, 204 삭제 등)
+- [ ] package-info.java
+
+### Infrastructure 계층
+
+- [ ] JPA Repository 구현 (`JpaRepository<Entity, Long>` 상속)
+- [ ] DB 마이그레이션 (Liquibase changeset)
+- [ ] package-info.java
+
+## DB 스키마 추가
+
+- [ ] 새 PostgreSQL schema 또는 기존 schema에 테이블 추가
+- [ ] Liquibase changeset 작성 (`backend/src/main/resources/db/changelog/`)
+- [ ] FK 제약, unique index, check constraint 포함
+
+## 테스트 scaffolding
+
+- [ ] Service 단위 테스트 (`@ExtendWith(MockitoExtension)`)
+- [ ] Controller 통합 테스트 (`@WebMvcTest` + MockMvc)
+- [ ] 최소 happy path + validation 실패 시나리오
+
+## 문서 업데이트
+
+- [ ] AGENTS.md Bounded Context 목록 업데이트
+- [ ] 필요시 `.agent/docs/schema.md` 업데이트
+
+## 참조 구현
+
+### auth 모듈 (완성된 모범 사례)
+
+```
+backend/src/main/java/com/init/auth/
+├── presentation/
+│   ├── AuthController.java (99L) — @Valid, HTTP 상태 코드
+│   └── dto/ — 11개 DTO (LoginRequest, LoginResponse 등)
+├── application/
+│   ├── AuthService.java (212L) — 생성자 주입, @Transactional
+│   ├── JwtService.java (98L)
+│   ├── exception/ — 6개 예외 클래스
+│   └── *Command.java, *Result.java — 6개 Command/Result
+├── domain/
+│   ├── model/
+│   │   ├── AppUser.java (149L) — 도메인 메서드 (initiatePasswordReset)
+│   │   ├── RefreshToken.java (83L) — revoke(), isValid()
+│   │   ├── UserRole.java
+│   │   └── UserStatus.java
+│   └── repository/
+│       ├── AppUserRepository.java
+│       └── RefreshTokenRepository.java
+└── infrastructure/
+    └── persistence/
+        ├── JpaAppUserRepository.java
+        └── JpaRefreshTokenRepository.java
+```
+
+### domainpack 모듈 (스켈레톤 상태)
+
+```
+backend/src/main/java/com/init/domainpack/
+├── presentation/package-info.java (1L)
+├── application/package-info.java (1L)
+├── domain/package-info.java (6L)
+└── infrastructure/package-info.java (1L)
+```
+
+→ 새 모듈은 domainpack처럼 package-info.java만 있는 상태에서 시작하여 auth처럼 완성해 나간다.

--- a/.agent/rules/testing.md
+++ b/.agent/rules/testing.md
@@ -18,6 +18,15 @@
 - **도메인 로직**: 90% 이상 (비즈니스 규칙은 반드시)
 - **새 코드**: 80% 이상 (레거시 제외)
 
+### 커버리지 측정 절차
+
+| 스택              | 로컬 실행 명령                    | 생성되는 리포트                             |
+| ----------------- | --------------------------------- | ------------------------------------------- |
+| Backend (JaCoCo)  | `./gradlew test jacocoTestReport` | `build/reports/jacoco/test/html/index.html` |
+| Frontend (Vitest) | `vp test --coverage`              | `coverage/index.html`, `coverage/lcov.info` |
+
+**PR 체크포인트**: CI에서 `./gradlew test jacocoTestCoverageVerification`(Backend) 및 `vp test --coverage`(Frontend) 통과 여부 확인. 커버리지 미달 시 빌드 실패로 처리한다.
+
 ## Backend (JUnit 5 + Spring Boot Test)
 
 ### 테스트 파일 위치

--- a/.agent/rules/testing.md
+++ b/.agent/rules/testing.md
@@ -35,7 +35,7 @@
 ```java
 @Test
 @DisplayName("GET /api/v1/consultation/queue - 대기열 조회 성공")
-void getActiveQueue_Success() throws Exception {
+void should_대기열반환_when_인증된사용자요청() throws Exception {
     // given
     ChatSessionResponse response = new ChatSessionResponse();
     response.setId(1L);

--- a/.agent/rules/testing.md
+++ b/.agent/rules/testing.md
@@ -1,0 +1,161 @@
+# 테스트 전략
+
+## 철학
+
+- **BDD (Behavior-Driven Development) 기반**: 사용자 행동 중심 테스트
+- **Given-When-Then 패턴**: 시나리오를 명확하게 기술
+- **"무엇을 테스트하는가"가 명확해야 함**: 구현이 아닌 동작 검증
+
+## 테스트 피라미드
+
+- **Unit (60%)**: 도메인 로직, 유틸리티 — 빠르고 격리된 테스트
+- **Integration (30%)**: Service + Repository, Controller + MockMvc
+- **E2E (10%)**: 핵심 사용자 시나리오 — 느리지만 신뢰성 높음
+
+## 커버리지 목표
+
+- **라인 커버리지**: 70% 이상 (캡스톤 현실 고려)
+- **도메인 로직**: 90% 이상 (비즈니스 규칙은 반드시)
+- **새 코드**: 80% 이상 (레거시 제외)
+
+## Backend (JUnit 5 + Spring Boot Test)
+
+### 테스트 파일 위치
+
+- `src/test/java`에 프로덕션 코드와 동일 패키지 구조
+- 파일명: `{대상클래스}Test.java`
+
+### 네이밍 규칙
+
+- 메서드명: `should_결과_when_조건` (한글 혼용 가능)
+- `@DisplayName`: 한글로 시나리오 설명
+
+### BDD 패턴 (Given-When-Then)
+
+```java
+@Test
+@DisplayName("GET /api/v1/consultation/queue - 대기열 조회 성공")
+void getActiveQueue_Success() throws Exception {
+    // given
+    ChatSessionResponse response = new ChatSessionResponse();
+    response.setId(1L);
+    response.setStatus("OPEN");
+    given(consultationService.getActiveQueue()).willReturn(List.of(response));
+
+    // when & then
+    mockMvc.perform(get("/api/v1/consultation/queue"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].id").value(1));
+}
+```
+
+### 계층별 테스트 전략
+
+| 계층                        | 테스트 방식                     | 의존성                    |
+| --------------------------- | ------------------------------- | ------------------------- |
+| Domain (Entity/VO)          | 순수 단위 테스트                | 없음                      |
+| Application (Service)       | `@ExtendWith(MockitoExtension)` | Mock Repository           |
+| Presentation (Controller)   | `@WebMvcTest` + MockMvc         | Mock Service              |
+| Infrastructure (Repository) | `@DataJpaTest`                  | 실 DB (H2/TestContainers) |
+
+### 필수 테스트 시나리오
+
+1. Happy path (정상 흐름)
+2. Validation 실패 (잘못된 입력)
+3. Not found (존재하지 않는 리소스)
+4. 권한 없음 (인가 실패)
+5. 중복 (unique constraint 위반)
+
+### 참조 구현
+
+- `backend/src/test/java/com/init/workflowruntime/presentation/ConsultationControllerTest.java`: MockMvc + @WebMvcTest 패턴
+
+## Frontend (Vitest + React Testing Library)
+
+### 테스트 파일 위치
+
+- 대상 파일과 동일 디렉토리에 `{파일명}.test.ts(x)`
+
+### API 테스트 패턴
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from "vite-plus/test";
+
+describe("Auth API Integration Tests", () => {
+  const mockFetch = vi.fn();
+  vi.stubGlobal("fetch", mockFetch);
+
+  beforeEach(() => {
+    mockFetch.mockClear();
+  });
+
+  it("loginApi 메서드가 올바른 URL과 데이터를 사용하여 fetch를 호출하는지 확인한다", async () => {
+    // given
+    const mockResponse = {
+      accessToken: "dummy-access",
+      user: { id: 1, email: "test@test.com" },
+    };
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockResponse,
+    });
+
+    // when
+    const result = await loginApi({
+      email: "test@test.com",
+      password: "password123",
+    });
+
+    // then
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/v1/auth/login",
+      expect.objectContaining({
+        method: "POST",
+      }),
+    );
+    expect(result.accessToken).toEqual("dummy-access");
+  });
+});
+```
+
+### 컴포넌트 테스트 패턴
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+describe("LoginForm", () => {
+  it("유효한 이메일과 비밀번호로 제출하면 로그인 API를 호출한다", async () => {
+    // given
+    const mockLogin = vi.fn();
+    render(<LoginForm onLogin={mockLogin} />);
+
+    // when
+    await userEvent.type(screen.getByLabelText("이메일"), "user@test.com");
+    await userEvent.type(screen.getByLabelText("비밀번호"), "password123");
+    await userEvent.click(screen.getByRole("button", { name: "로그인" }));
+
+    // then
+    expect(mockLogin).toHaveBeenCalledWith({
+      email: "user@test.com",
+      password: "password123",
+    });
+  });
+});
+```
+
+### 참조 구현
+
+- `frontend/src/features/auth/api/authApi.test.ts`: Vitest API 테스트 패턴
+
+## 금지 사항
+
+- **구현 세부사항 테스트 금지**: 내부 상태, private 메서드 테스트하지 않음
+- **sleep/setTimeout으로 비동기 대기 금지**: `waitFor`/`awaitility` 사용
+- **테스트 간 상태 공유 금지**: 각 테스트는 독립적이어야 함
+- **테스트에서 프로덕션 DB 접근 금지**: H2 또는 TestContainers 사용
+
+## 검증 방법
+
+- **PR 리뷰**: `.agent/rules/code-review.md` 테스트 체크리스트 참조
+- **CI**: `./gradlew test` (Backend), `vp test` (Frontend)

--- a/.agent/rules/typescript.md
+++ b/.agent/rules/typescript.md
@@ -74,6 +74,69 @@ import { DomainPack } from "@/entities/domain-pack";
 import { usePublishPack } from "@/features/publish-pack";
 ```
 
+## FSD 의존성 방향 규칙
+
+### 계층 방향 (상위 → 하위만 허용)
+
+```
+app → pages → widgets → features → entities → shared
+```
+
+- 상위 계층은 하위 계층을 import할 수 있다
+- **하위 계층이 상위 계층을 import하는 것은 금지**
+- 같은 계층 내 다른 슬라이스 간 import도 금지 (cross-slice)
+
+### 허용되는 import
+
+```typescript
+// ✅ pages → features (상위 → 하위)
+// frontend/src/pages/consultation/ui/ConsultationPage.tsx
+import { ChatPanel } from "@/features/consultation";
+
+// ✅ features → shared (상위 → 하위)
+// frontend/src/features/auth/api/authApi.ts
+import { apiClient } from "@/shared/api";
+
+// ✅ 같은 슬라이스 내 (internal)
+// features/auth/ui/LoginForm.tsx
+import { useAuth } from "../model/useAuth";
+```
+
+### 금지되는 import
+
+```typescript
+// ❌ shared → features (하위 → 상위)
+// shared/ui/Header.tsx
+import { useAuth } from "@/features/auth";
+
+// ❌ feature 간 cross-import (같은 계층 cross-slice)
+// features/consultation/ui/ChatPanel.tsx
+import { useAuth } from "@/features/auth";
+
+// ❌ entities → features (하위 → 상위)
+// entities/user/model.ts
+import { loginApi } from "@/features/auth";
+
+// ❌ feature → pages (하위 → 상위)
+// features/auth/ui/LoginForm.tsx
+import { Layout } from "@/pages/layout";
+```
+
+### Cross-Slice 통신 방법
+
+feature 간 데이터가 필요하면:
+
+1. **공통 entity 사용**: entities 계층에 공유 모델 정의
+2. **props로 전달**: pages에서 두 feature를 조합할 때 props로 연결
+3. **shared 이벤트**: shared/lib에 이벤트 버스 정의 (복잡한 경우)
+
+### ESLint 검증 (향후 적용)
+
+- `@feature-sliced/layers-slices` 규칙으로 자동 검증 가능
+- 현재는 코드 리뷰로 수동 확인 (`.agent/rules/code-review.md` FSD 컴플라이언스 섹션 참조)
+  - 참조: `frontend/src/features/consultation/ui/ChatPanel.tsx` — features 내부 구조 예시
+  - 참조: `frontend/src/shared/api/index.ts` — shared 계층 API 클라이언트 예시
+
 ---
 
 ## 참고


### PR DESCRIPTION
## 요약

기존 코드베이스를 전수 분석하여 발견한 패턴과 안티패턴을 `.agent/rules/` 규칙 문서로 문서화합니다.
4명 팀원이 동일 영역에서 작업할 때 일관된 코드를 생산하도록 가드레일을 설정합니다.

## 변경 내용

### 신규 문서 (3개)

| 파일 | 내용 |
|------|------|
| `.agent/rules/testing.md` | BDD Given-When-Then 전략, JUnit5/Vitest 계층별 테스트, 커버리지 목표 |
| `.agent/rules/module-creation.md` | DDD 모듈 생성 체크리스트 (auth 모듈 참조 구현 기반) |
| `.agent/rules/error-handling.md` | Backend GlobalExceptionHandler 패턴 + Frontend alert() → Toast 전환 규칙 |

### 기존 문서 강화 (3개)

| 파일 | 추가 내용 |
|------|---------|
| `.agent/rules/code-review.md` | 보안/성능/DDD 컴플라이언스/FSD 컴플라이언스/테스트 체크 섹션 (17줄 → 64줄) |
| `.agent/rules/java.md` | 금지 패턴 8개 (public setter, @Autowired, Controller 비즈니스 로직, 엔티티 직접 반환 등) + 근거 (88줄 → 226줄) |
| `.agent/rules/typescript.md` | FSD 의존성 방향 규칙 (`app → pages → widgets → features → entities → shared`) + cross-slice 금지 (81줄 → 144줄) |

## 코드 기반 근거

모든 규칙은 실제 코드베이스 분석에서 추출한 근거 기반:
- `ChatSession.setStatus()` → public setter 금지 규칙
- `ConsultationService` 장황한 Javadoc → Javadoc 금지 패턴
- `ConsultationPage.tsx` 3곳의 `alert()` → Frontend 에러 처리 규칙
- `auth` 모듈 → DDD 모범 사례 참조 구현

## 검증 결과

Final Verification Wave 4개 에이전트 전원 **APPROVE**:
- F1 (Plan Compliance): Must Have [6/6] | Must NOT Have [6/6]
- F2 (Code Quality): Consistency/Slop/References/Coherence 전부 PASS
- F3 (Manual QA): Scenarios [11/12 pass] | Cross-refs [6/6 valid]
- F4 (Scope Fidelity): 변경 파일 정확히 6개, 기존 내용 삭제 0줄

## 참고

- 코드 파일 변경 없음 (`.agent/rules/` 문서만)
- `python.md` 변경 없음 (ML 0% 구현, 범위 외)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * 코드리뷰 체크리스트 확장(보안·성능·테스트·DDD·FSD 준수 항목 추가)
  * 일관된 에러 처리 규칙 및 예외→응답 매핑 가이드 제정(백엔드/프론트엔드 포함)
  * Java 금지/권장 패턴 문서화(안티패턴·트랜잭션 권장 등)
  * 모듈(바운디드 컨텍스트) 생성 절차 및 템플릿 안내 추가
  * 테스트 전략·규칙(BDD, 피라미드, 커버리지 목표 등) 및 프론트/백엔드 테스트 가이드
  * TypeScript FSD 의존성 규칙 명문화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->