### PR TITLE
spec(backend): backend inspection report

### DIFF
--- a/.agent/specs/17.md
+++ b/.agent/specs/17.md
@@ -1,0 +1,409 @@
+# Audit Report — Backend Inspection
+
+**Mode**: Inspection  
+**Date**: 2026-04-10  
+**Branch**: main  
+**Scope**: `backend/src/main/java/com/init/` 전체 (auth, corpus, domainpack, workflowruntime, chatdemo, review, pipelinejob, shared)  
+**Rules Applied**: `java.md`, `error-handling.md`, `testing.md`, `module-creation.md`, `principles.md`, `code-review.md`  
+**Result**: **FAIL**
+
+---
+
+## Summary
+
+| Severity | Count |
+|----------|-------|
+| Critical | 8     |
+| Warning  | 17    |
+| Info     | 6     |
+| Ignored  | 0     |
+
+---
+
+## Violations
+
+### V-001 [Critical] BusinessException 계층 구조 전무 — 전체 bounded context 예외가 RuntimeException 직접 상속
+
+- **Rule**: `error-handling.md:예외 계층 구조`
+- **File**: `backend/src/main/java/com/init/auth/application/exception/AuthException.java:3`, `corpus/application/exception/WorkspaceNotFoundException.java:3` (외 corpus 4개), `domainpack/application/exception/DomainPackVersionNotFoundException.java:3` (외 domainpack 4개)
+- **Description**: `error-handling.md`는 `BusinessException(추상) → NotFoundException / DuplicateException / InvalidCredentialsException / InvalidTokenException / UnauthorizedException / BadRequestException` 계층 구조를 명시한다. 프로젝트 전체에 `BusinessException` 추상 클래스 자체가 존재하지 않으며, auth(6개), corpus(5개), domainpack(5개) 예외 클래스 전부가 `RuntimeException`을 직접 상속한다.
+- **Expected**: `shared` 모듈에 `BusinessException` 추상 클래스 및 하위 계층(`NotFoundException`, `DuplicateException`, `UnauthorizedException`, `BadRequestException` 등) 정의. 각 BC 예외가 의미론적으로 일치하는 base class 상속. 예: `WorkspaceNotFoundException extends NotFoundException`, `DomainPackVersionConflictException extends DuplicateException`
+- **Actual**: 모든 비즈니스 예외가 `extends RuntimeException` 직접 상속. `BusinessException` 계층 없음.
+- **Fix Direction**: `shared/application/exception/BusinessException.java` 추상 클래스 생성 → 하위 base exception(`NotFoundException`, `DuplicateException` 등) 정의 → 각 BC 예외 클래스를 해당 base class 상속으로 변경
+- **Fix Result**: _(Fix Agent가 채움)_
+
+---
+
+### V-002 [Critical] shared.GlobalExceptionHandler가 auth/corpus/domainpack 모듈에 역방향 의존
+
+- **Rule**: `java.md:계층 규칙` / `code-review.md:DDD 컴플라이언스`
+- **File**: `backend/src/main/java/com/init/shared/presentation/GlobalExceptionHandler.java:3-18`
+- **Description**: `GlobalExceptionHandler`(shared)가 `com.init.auth.application.exception.*`(5개), `com.init.corpus.application.exception.*`(5개), `com.init.domainpack.application.exception.*`(5개), `com.init.auth.presentation.dto.PasswordResetRequiredResponse`(1개) — 총 16개 외부 bounded context 심볼을 직접 import한다. shared는 다른 BC가 의존하는 공통 모듈이어야 하며, 역방향 의존은 BC 추가 시마다 shared 수정이 필요한 OCP 위반이자 모듈 경계 붕괴다.
+- **Expected**: `GlobalExceptionHandler`는 shared 내부의 `BusinessException` 계층 타입만 처리. 각 BC의 구체 예외는 BC 내 `@ControllerAdvice` 또는 `BusinessException` 다형성으로 처리.
+- **Actual**: `import com.init.auth.application.exception.BadRequestException;` 등 16개 외부 BC 심볼 직접 참조. `handlePasswordResetRequired()`가 `PasswordResetRequiredResponse`를 반환 타입으로 사용.
+- **Fix Direction**: V-001 완료 후 `GlobalExceptionHandler`를 `BusinessException` 계층 핸들러만 유지하도록 리팩터링. `PasswordResetRequiredResponse`는 `ErrorResponse`로 통일하거나 shared.presentation.dto로 이동. 각 BC 전용 예외는 해당 BC의 `@ControllerAdvice`로 분리.
+- **Fix Result**: _(Fix Agent가 채움)_
+
+---
+
+### V-003 [Critical] auth bounded context 테스트 코드 전무
+
+- **Rule**: `testing.md:커버리지 목표` / `testing.md:필수 테스트 시나리오`
+- **File**: `backend/src/test/java/com/init/auth/` (디렉토리 미존재)
+- **Description**: `testing.md`는 라인 커버리지 70% 이상, 도메인 로직 90% 이상, 새 코드 80% 이상을 요구하며, happy path / validation 실패 / not found / 권한 없음 / 중복 5개 필수 시나리오를 명시한다. auth bounded context에 테스트 디렉토리와 파일이 전혀 없다. `AuthService`(212L), `AppUser`(149L), `RefreshToken`(83L) 등 핵심 도메인 로직 0% 커버리지.
+- **Expected**: `AuthServiceTest.java`(`@ExtendWith(MockitoExtension)`), `AuthControllerTest.java`(`@WebMvcTest`), `AppUserTest.java`(순수 단위), `RefreshTokenTest.java` — 5개 필수 시나리오 포함, `should_결과_when_조건` 네이밍, Given-When-Then 패턴.
+- **Actual**: `src/test/java/com/init/auth/` 디렉토리 미존재. 테스트 파일 0개.
+- **Fix Direction**: auth 모듈 테스트 scaffolding 전체 신규 작성. 최소: signup 중복 이메일(DuplicateException), login 잘못된 비밀번호(InvalidCredentialsException), 만료 토큰 refresh(InvalidTokenException), 비밀번호 재설정 정상 흐름.
+- **Fix Result**: _(Fix Agent가 채움)_
+
+---
+
+### V-004 [Critical] corpus RawDatasetUploadService 서비스 레이어 일반 Exception catch
+
+- **Rule**: `error-handling.md:금지 사항` / `java.md:금지 패턴 5`
+- **File**: `backend/src/main/java/com/init/corpus/application/RawDatasetUploadService.java:119`
+- **Description**: `upload()` 메서드의 배치 플러시 블록에서 `catch (Exception e)`를 사용한다. `error-handling.md`는 서비스/도메인 레이어에서 일반 `Exception` catch를 명시적으로 금지하며, `GlobalExceptionHandler` fallback에서만 허용한다.
+- **Expected**: `catch (RuntimeException e)` 또는 구체 예외 타입(`DataIntegrityViolationException` 등)으로 범위를 좁혀야 한다.
+- **Actual**: `catch (Exception e) { ... throw e; }` — 라인 119에서 보상 로직 후 재던지기.
+- **Fix Direction**: catch 타입을 `RuntimeException`으로 좁히거나, 보상 로직을 `finally` 블록 또는 별도 메서드로 분리.
+- **Fix Result**: _(Fix Agent가 채움)_
+
+---
+
+### V-005 [Critical] workflowruntime ChatSession 도메인 엔티티 public setter 존재
+
+- **Rule**: `java.md:금지 패턴 #1 도메인 엔티티에 public setter 금지`
+- **File**: `backend/src/main/java/com/init/workflowruntime/domain/ChatSession.java:119`
+- **Description**: `java.md`가 이 파일을 anti-pattern 근거 파일로 명시했음에도 `public void setStatus(ChatSessionStatus status)` 메서드가 존재하며, `ConsultationService:131-133`에서 직접 호출된다. public setter는 도메인 불변식(invariant)을 보장하지 못하고 상태 전환 규칙을 외부로 누설한다.
+- **Expected**: 상태 전환은 의미 있는 도메인 메서드(예: `activate()`, `resolve()`, `close()`)로만 허용. `ConsultationService`의 switch 분기도 해당 도메인 메서드 호출로 변경.
+- **Actual**: `public void setStatus(ChatSessionStatus status) { this.status = status; }` — 라인 119, `ConsultationService`에서 직접 호출.
+- **Fix Direction**: `setStatus()` 제거 후 `ChatSessionStatus`별 도메인 메서드 추가. `ConsultationService.updateSessionStatus()` 내 switch 분기도 도메인 메서드 호출로 교체.
+- **Fix Result**: _(Fix Agent가 채움)_
+
+---
+
+### V-006 [Critical] workflowruntime ConsultationService에서 BusinessException 계층 미사용
+
+- **Rule**: `error-handling.md:예외 계층 구조` / `error-handling.md:서비스 레이어 에러 처리 패턴`
+- **File**: `backend/src/main/java/com/init/workflowruntime/application/ConsultationService.java:59, 85, 120, 123-127`
+- **Description**: `getMessages()`, `sendMessage()`, `updateSessionStatus()`의 `orElseThrow`에서 `IllegalArgumentException`을 던지며(59, 85, 120라인), `updateSessionStatus()`의 catch 블록(123-127라인)도 `IllegalArgumentException`을 다시 던진다. `NotFoundException` → HTTP 404가 명확하지만, `IllegalArgumentException`은 `GlobalExceptionHandler`에서 매핑 대상이 아니어서 500 fallback 위험이 있다.
+- **Expected**: `orElseThrow(() -> new NotFoundException("Session not found: " + sessionId))`, valueOf 실패 시 `throw new BadRequestException("Unsupported status: " + status)` 사용.
+- **Actual**: `orElseThrow(() -> new IllegalArgumentException(...))` 3곳, `catch (IllegalArgumentException e) { throw new IllegalArgumentException(...); }` 1곳.
+- **Fix Direction**: 3곳의 `orElseThrow`를 `NotFoundException`으로 교체. `ChatSessionStatus.valueOf()` 실패 catch를 `BadRequestException`으로 교체. V-001 완료 후 적용.
+- **Fix Result**: _(Fix Agent가 채움)_
+
+---
+
+### V-007 [Critical] workflowruntime ConsultationController/Service 인가(Authorization) 체크 없음
+
+- **Rule**: `code-review.md:보안 체크 — 인증/인가가 필요한 엔드포인트에 적용됐는가`
+- **File**: `backend/src/main/java/com/init/workflowruntime/presentation/ConsultationController.java` (전체), `backend/src/main/java/com/init/workflowruntime/application/ConsultationService.java` (전체)
+- **Description**: `code-review.md`가 "주의: `ConsultationService`에는 인가 체크 없음 — 새 서비스는 반드시 추가"라고 명시적으로 경고한다. 상담 대기열 조회/메시지 전송/세션 상태 변경은 운영자 전용 기능이나, `ConsultationController`의 4개 엔드포인트와 `ConsultationService`의 4개 메서드 모두 호출자 identity 검증이 없다.
+- **Expected**: `@PreAuthorize("hasRole('OPERATOR')")` 또는 SecurityContext에서 인증된 사용자를 추출하여 요청된 세션의 워크스페이스 접근 권한 검증.
+- **Actual**: Controller 4개 엔드포인트, Service 4개 메서드 모두 인가 어노테이션 및 SecurityContext 접근 없음.
+- **Fix Direction**: `SecurityConfig`의 인가 규칙에 workflowruntime 엔드포인트 경로 추가. 또는 `ConsultationController`에 `@PreAuthorize` 적용. 세션-워크스페이스 소속 검증 로직 Service에 추가.
+- **Fix Result**: _(Fix Agent가 채움)_
+
+---
+
+### V-008 [Critical] shared JwtAuthenticationFilter 서비스 레이어 일반 Exception catch
+
+- **Rule**: `error-handling.md:금지 사항` / `java.md:금지 패턴 5`
+- **File**: `backend/src/main/java/com/init/shared/infrastructure/security/JwtAuthenticationFilter.java:55`
+- **Description**: `doFilterInternal()` 내부에서 `catch (Exception ex)`로 모든 예외를 단일 핸들러로 처리한다. error-handling.md는 GlobalExceptionHandler fallback 경계 외 일반 Exception catch를 금지한다.
+- **Expected**: JWT 처리 시 발생 가능한 `io.jsonwebtoken.JwtException`, `IllegalArgumentException` 등 구체 예외를 명시적으로 catch.
+- **Actual**: `catch (Exception ex) { SecurityContextHolder.clearContext(); log.warn(...); }` — 라인 55.
+- **Fix Direction**: `catch (JwtException | IllegalArgumentException ex)`로 변경하여 예외 타입을 명시.
+- **Fix Result**: _(Fix Agent가 채움)_
+
+---
+
+### V-009 [Warning] @Transactional(readOnly = true) 기본값 미적용
+
+- **Rule**: `java.md:권장 패턴 — @Transactional(readOnly = true) 기본값 설정`
+- **File**: `backend/src/main/java/com/init/auth/application/AuthService.java:25`, `backend/src/main/java/com/init/corpus/application/DatasetUploadService.java:27`, `backend/src/main/java/com/init/domainpack/application/ActivateDomainPackVersionUseCase.java:22`
+- **Description**: 3개 서비스 클래스의 레벨 `@Transactional`이 `readOnly=false`(기본값)로 설정되어 조회 메서드도 불필요하게 쓰기 트랜잭션으로 실행된다.
+- **Expected**: 클래스 레벨 `@Transactional(readOnly = true)`, 쓰기 메서드만 `@Transactional` 개별 오버라이드.
+- **Actual**: 3개 클래스 모두 `@Transactional` (readOnly=false 기본값) 클래스 레벨 선언.
+- **Fix Direction**: 클래스 어노테이션을 `@Transactional(readOnly = true)`로 변경. 상태 변경 메서드에 `@Transactional` 개별 선언.
+- **Fix Result**: _(Fix Agent가 채움)_
+
+---
+
+### V-010 [Warning] auth 모듈 package-info.java 전 계층 미존재
+
+- **Rule**: `module-creation.md:계층별 필수 파일`
+- **File**: `backend/src/main/java/com/init/auth/` (presentation, application, domain, infrastructure 4개 계층)
+- **Description**: `module-creation.md`는 각 계층에 `package-info.java`를 필수로 요구한다. auth 모듈 전체에 `package-info.java` 파일이 한 개도 존재하지 않는다.
+- **Expected**: `presentation/package-info.java`, `application/package-info.java`, `domain/package-info.java`, `infrastructure/package-info.java` 각각 존재.
+- **Actual**: auth 모듈 전체 `package-info.java` 0개.
+- **Fix Direction**: 각 계층 패키지에 `package-info.java` 생성. domainpack 모듈의 기존 `package-info.java`를 참조.
+- **Fix Result**: _(Fix Agent가 채움)_
+
+---
+
+### V-011 [Warning] corpus 모듈 package-info.java 전 계층 미존재
+
+- **Rule**: `module-creation.md:계층별 필수 파일`
+- **File**: `backend/src/main/java/com/init/corpus/` (presentation, application, domain, infrastructure 4개 계층)
+- **Description**: corpus 모듈 전체에 `package-info.java` 파일이 한 개도 존재하지 않는다.
+- **Expected**: 4개 계층 각각 `package-info.java` 존재.
+- **Actual**: corpus 모듈 전체 `package-info.java` 0개.
+- **Fix Direction**: 각 계층에 `package-info.java` 생성.
+- **Fix Result**: _(Fix Agent가 채움)_
+
+---
+
+### V-012 [Warning] domainpack ActivateDomainPackVersionUseCase에 불필요한 @Autowired 선언
+
+- **Rule**: `java.md:금지 패턴 #2 — @Autowired 필드 주입 금지`
+- **File**: `backend/src/main/java/com/init/domainpack/application/ActivateDomainPackVersionUseCase.java:33`
+- **Description**: `java.md`는 `@Autowired` 사용 자체를 금지하며 생성자 주입 시 어노테이션 없이 단일 생성자만 정의하도록 규정한다(Spring 단일 생성자 자동 감지). 생성자 자체는 올바른 생성자 주입이나 `@Autowired` 어노테이션이 명시되어 있다.
+- **Expected**: public 생성자에서 `@Autowired` 제거. Spring이 단일 public 생성자를 자동으로 주입.
+- **Actual**: `@Autowired public ActivateDomainPackVersionUseCase(...)` — 라인 33.
+- **Fix Direction**: `@Autowired` 어노테이션 제거.
+- **Fix Result**: _(Fix Agent가 채움)_
+
+---
+
+### V-013 [Warning] auth PasswordResetRequiredResponse와 ErrorResponse 불일치
+
+- **Rule**: `error-handling.md:에러 응답 DTO`
+- **File**: `backend/src/main/java/com/init/auth/presentation/dto/PasswordResetRequiredResponse.java`, `backend/src/main/java/com/init/shared/presentation/GlobalExceptionHandler.java`
+- **Description**: `error-handling.md`는 `ErrorResponse(String code, String message)`를 모든 에러 응답의 통일 형식으로 요구한다. `PasswordResetRequiredResponse`는 동일한 `(code, message)` 구조이나 별도 타입으로 존재하며, `GlobalExceptionHandler.handlePasswordResetRequired()`가 `ResponseEntity<PasswordResetRequiredResponse>`를 반환한다.
+- **Expected**: `ErrorResponse`로 통일하거나, `PasswordResetRequiredResponse`가 `ErrorResponse`와 동일 타입으로 교체.
+- **Actual**: `public record PasswordResetRequiredResponse(String code, String message)` — `ErrorResponse`와 구조 동일하나 별도 타입.
+- **Fix Direction**: `PasswordResetRequiredResponse` 제거 후 `ErrorResponse`로 통일. V-002 수정과 함께 처리.
+- **Fix Result**: _(Fix Agent가 채움)_
+
+---
+
+### V-014 [Warning] corpus DatasetUploadService 단위 테스트 없음
+
+- **Rule**: `testing.md:계층별 테스트 전략` / `module-creation.md:테스트 scaffolding`
+- **File**: `backend/src/test/java/com/init/corpus/application/DatasetUploadServiceTest.java` (미존재)
+- **Description**: `testing.md`는 Application(Service) 계층에 `@ExtendWith(MockitoExtension)` 단위 테스트를 요구한다. `RawDatasetUploadServiceTest`는 존재하나 `DatasetUploadService`에 대한 테스트가 없다.
+- **Expected**: `DatasetUploadServiceTest.java` — 워크스페이스 없음, 멤버십 없음, 키 중복, 정상 업로드, 중복 turnIndex 시나리오.
+- **Actual**: `DatasetUploadServiceTest.java` 미존재.
+- **Fix Direction**: `DatasetUploadServiceTest.java` 생성, 5개 필수 시나리오 포함.
+- **Fix Result**: _(Fix Agent가 채움)_
+
+---
+
+### V-015 [Warning] 테스트 메서드명 should_결과_when_조건 규칙 미준수 (corpus, domainpack, workflowruntime)
+
+- **Rule**: `testing.md:네이밍 규칙`
+- **File**: `backend/src/test/java/com/init/corpus/application/ConsultingContentParserTest.java:16`, `backend/src/test/java/com/init/domainpack/application/ActivateDomainPackVersionUseCaseTest.java`, `backend/src/test/java/com/init/domainpack/domain/model/DomainPackVersionTest.java`, `backend/src/test/java/com/init/domainpack/presentation/ActivateDomainPackVersionControllerTest.java`, `backend/src/test/java/com/init/workflowruntime/presentation/ConsultationControllerTest.java:52`
+- **Description**: `testing.md`는 `should_결과_when_조건` 네이밍을 규정한다. 5개 테스트 파일에서 `action_condition_result` 혼합 형식(`execute_validDraft_returnsPublishedResult`, `getActiveQueue_Success` 등)을 사용한다.
+- **Expected**: `should_PUBLISHED반환_when_유효한DRAFT`, `should_404반환_when_세션없음` 형태.
+- **Actual**: `execute_validDraft_returnsPublishedResult`, `getActiveQueue_Success`, `parse_agentPrefix_returnsAgentTurnWithCorrectIndex` 등 혼합 패턴.
+- **Fix Direction**: 메서드명을 `should_결과_when_조건` 형식으로 일괄 변경. `@DisplayName`은 이미 한글로 잘 작성되어 있으므로 메서드명만 수정.
+- **Fix Result**: _(Fix Agent가 채움)_
+
+---
+
+### V-016 [Warning] corpus 테스트에 Given-When-Then 주석 블록 미적용
+
+- **Rule**: `testing.md:BDD 패턴 (Given-When-Then)`
+- **File**: `backend/src/test/java/com/init/corpus/application/ConsultingContentParserTest.java`, `backend/src/test/java/com/init/corpus/application/RawDatasetUploadServiceTest.java`
+- **Description**: `testing.md`는 BDD Given-When-Then 패턴을 필수로 지정한다. `ConsultingContentParserTest`의 모든 테스트에 `// given / // when / // then` 주석 블록이 없다. `RawDatasetUploadServiceTest`도 섹션 주석 없이 given() stubbing 후 바로 assertThatThrownBy() 호출.
+- **Expected**: 각 테스트 메서드에 `// given`, `// when`, `// then` (또는 `// when & then`) 주석 블록 명시.
+- **Actual**: 두 파일 모두 GWT 구분 없는 단순 호출 + assert 구조.
+- **Fix Direction**: 각 테스트 메서드에 `// given`, `// when`, `// then` 주석 추가.
+- **Fix Result**: _(Fix Agent가 채움)_
+
+---
+
+### V-017 [Warning] corpus DatasetController에서 인증 처리 로직 구현 (Controller 비즈니스 로직 금지)
+
+- **Rule**: `java.md:금지 패턴 #3 — Controller에 비즈니스 로직 금지`
+- **File**: `backend/src/main/java/com/init/corpus/presentation/DatasetController.java:44`
+- **Description**: `DatasetController`에 `getUserIdFromAuthentication()` private 메서드가 존재하며, `Authentication` null 체크, principal null 체크, `Long` 타입 캐스팅 검증, 예외 던지기까지 직접 구현한다. 이 로직은 다른 Controller에서도 반복 가능성이 있는 공통 관심사다.
+- **Expected**: `HandlerMethodArgumentResolver` 또는 shared 유틸리티 클래스에서 principal 추출 처리. Controller는 추출된 userId를 파라미터로 받기만 함.
+- **Actual**: `DatasetController.getUserIdFromAuthentication()` — authentication/principal null 체크, Long 캐스팅 검증 직접 구현 (라인 44-59).
+- **Fix Direction**: `@AuthenticationPrincipal`과 `HandlerMethodArgumentResolver`를 활용하거나 shared 계층 유틸리티로 이동.
+- **Fix Result**: _(Fix Agent가 채움)_
+
+---
+
+### V-018 [Warning] workflowruntime ConsultationService 자명한 Javadoc 과다 작성
+
+- **Rule**: `java.md:금지 패턴 #7 — 과도한 Javadoc 금지`
+- **File**: `backend/src/main/java/com/init/workflowruntime/application/ConsultationService.java:37-78, 107-137`
+- **Description**: `java.md`가 이 파일을 과도한 Javadoc 반(反)패턴의 근거 파일로 명시했음에도 모든 메서드에 자명한 `@param/@return/@throws` Javadoc 블록이 그대로 존재한다.
+- **Expected**: 비자명한 동작(상태 전환 규칙, 자동 설정 필드 등)만 간결한 한 줄 주석. 자명한 CRUD 메서드는 Javadoc 생략.
+- **Actual**: `getActiveQueue()`, `getMessages()`, `sendMessage()`, `updateSessionStatus()` 4개 메서드 모두 장황한 `@param/@return/@throws` Javadoc.
+- **Fix Direction**: 자명한 메서드의 Javadoc 블록 전체 제거. 비자명한 동작(NOTE 역할 자동 할당, COMPLETED 시 endedAt 자동 설정)만 인라인 주석으로 유지.
+- **Fix Result**: _(Fix Agent가 채움)_
+
+---
+
+### V-019 [Warning] workflowruntime ConsultationControllerTest 필수 실패 시나리오 누락
+
+- **Rule**: `testing.md:필수 테스트 시나리오`
+- **File**: `backend/src/test/java/com/init/workflowruntime/presentation/ConsultationControllerTest.java`
+- **Description**: `testing.md`는 happy path 외에 validation 실패 / not found / 권한 없음 시나리오를 필수로 요구한다. 현재 4개 테스트 모두 happy path(Success)만 존재한다.
+- **Expected**: `sendMessage_BadRequest_when_contentBlank`, `getMessages_NotFound_when_sessionNotExist`, `updateStatus_BadRequest_when_invalidStatusValue` 등 최소 3개 실패 시나리오 추가.
+- **Actual**: 4개 테스트 모두 Success 케이스만 검증.
+- **Fix Direction**: `@NotBlank` content 위반 시 400 응답 테스트, `NotFoundException` 전파 시 404 응답 테스트 추가.
+- **Fix Result**: _(Fix Agent가 채움)_
+
+---
+
+### V-020 [Warning] workflowruntime ConsultationService 단위 테스트 없음
+
+- **Rule**: `testing.md:계층별 테스트 전략` / `module-creation.md:테스트 scaffolding`
+- **File**: `backend/src/test/java/com/init/workflowruntime/ConsultationServiceTest.java` (미존재)
+- **Description**: Application(Service) 계층 단위 테스트 필수. workflowruntime 테스트 디렉토리에 `ConsultationControllerTest.java`만 존재하고 `ConsultationServiceTest.java`가 없다.
+- **Expected**: `ConsultationServiceTest.java` — `@ExtendWith(MockitoExtension)`, Mock Repository, getMessages/sessionNotFound, sendMessage/success, updateSessionStatus 상태별 분기 테스트.
+- **Actual**: `src/test/java/com/init/workflowruntime/` 에 Controller 테스트만 존재. Service 단위 테스트 없음.
+- **Fix Direction**: `ConsultationServiceTest.java` 신규 작성.
+- **Fix Result**: _(Fix Agent가 채움)_
+
+---
+
+### V-021 [Warning] domainpack DomainPackVersion.onUpdate()에서 Clock 인스턴스 미사용
+
+- **Rule**: `testing.md:금지 사항 — sleep/setTimeout으로 비동기 대기 금지`
+- **File**: `backend/src/main/java/com/init/domainpack/domain/model/DomainPackVersion.java:46`
+- **Description**: `ActivateDomainPackVersionUseCase`는 `Clock` 주입으로 테스트 가능한 시간 처리를 구현했으나, `DomainPackVersion.onUpdate()` (`@PreUpdate`)는 `OffsetDateTime.now()`를 직접 호출하여 `updatedAt` 필드가 테스트에서 제어 불가하다. `DomainPackVersionTest`도 이 문제를 인지하고 `updatedAt` 검증을 포기했다.
+- **Expected**: `activate()` 내에서 `updatedAt`도 `now`로 설정하여 `@PreUpdate`에 의존하지 않거나, `@PreUpdate`를 제거하고 도메인 메서드에서 직접 관리.
+- **Actual**: `@PreUpdate protected void onUpdate() { this.updatedAt = OffsetDateTime.now(); }` — Clock 의존성 없음.
+- **Fix Direction**: `activate(OffsetDateTime now)` 내에서 `this.updatedAt = now;` 추가하여 `@PreUpdate` 의존 제거.
+- **Fix Result**: _(Fix Agent가 채움)_
+
+---
+
+### V-022 [Warning] domainpack infrastructure 계층 @DataJpaTest 테스트 없음
+
+- **Rule**: `testing.md:계층별 테스트 전략`
+- **File**: `backend/src/test/java/com/init/domainpack/infrastructure/` (미존재)
+- **Description**: `JpaDomainPackVersionRepository`의 커스텀 JPQL 쿼리(`findByIdAndWorkspaceId`)와 `JpaDomainPackWorkspaceMembershipRepository.hasAnyRole()` default 메서드가 테스트 없이 미검증 상태다.
+- **Expected**: `JpaDomainPackVersionRepositoryTest.java` (`@DataJpaTest`), `JpaDomainPackWorkspaceMembershipRepositoryTest.java`.
+- **Actual**: domainpack infrastructure 테스트 파일 전무.
+- **Fix Direction**: `@DataJpaTest` 기반 Repository 통합 테스트 작성. `findByIdAndWorkspaceId` workspace 범위 필터링, `hasAnyRole()` 역할 필터링 시나리오 포함.
+- **Fix Result**: _(Fix Agent가 채움)_
+
+---
+
+### V-023 [Warning] domainpack DomainPackWorkspaceMemberRef getter 없음
+
+- **Rule**: `java.md:DDD 패턴 — 캡슐화`
+- **File**: `backend/src/main/java/com/init/domainpack/infrastructure/persistence/DomainPackWorkspaceMemberRef.java`
+- **Description**: `workspaceId`, `userId`, `memberRole` 3개 private 필드에 getter가 없어, 동일 패키지의 `DomainPackRef`, `DomainPackWorkspaceRef` (getter 제공)와 일관성이 없다.
+- **Expected**: `getWorkspaceId()`, `getUserId()`, `getMemberRole()` getter 제공.
+- **Actual**: 3개 private 필드에 getter 없음. protected 기본 생성자만 존재.
+- **Fix Direction**: getter 3개 추가.
+- **Fix Result**: _(Fix Agent가 채움)_
+
+---
+
+### V-024 [Warning] JwtAuthenticationFilter role=null 시 SecurityContext 설정 생략 (silent drop)
+
+- **Rule**: `code-review.md:보안 체크`
+- **File**: `backend/src/main/java/com/init/shared/infrastructure/security/JwtAuthenticationFilter.java:44-53`
+- **Description**: JWT 토큰에서 role이 null인 경우 `SecurityContextHolder`에 아무것도 설정하지 않고 조용히 다음 필터로 통과한다. role이 null인 유효한 토큰이 인증 없이 통과될 수 있어 의도치 않은 권한 상태가 발생할 수 있다.
+- **Expected**: role이 null인 경우 `log.warn()` 추가 또는 token invalid 처리.
+- **Actual**: `if (role != null) { ... }` — role=null 시 아무 처리 없이 `filterChain.doFilter()` 진행.
+- **Fix Direction**: role==null 분기에 `log.warn("JWT token missing role claim, userId={}", userId)` 추가 또는 role을 필수 클레임으로 간주하여 V-008과 함께 처리.
+- **Fix Result**: _(Fix Agent가 채움)_
+
+---
+
+### V-025 [Warning] 다수 bounded context package-info.java 내용 미흡 (설명 없는 패키지 선언만 존재)
+
+- **Rule**: `module-creation.md:계층별 필수 파일`
+- **File**: `workflowruntime/{presentation,application,infrastructure}/package-info.java`, `chatdemo/{application,infrastructure,presentation}/package-info.java`, `shared/{presentation,application,infrastructure}/package-info.java`, `review/{application,infrastructure,presentation}/package-info.java`, `pipelinejob/{application,infrastructure,presentation}/package-info.java`
+- **Description**: 위 12개 `package-info.java` 파일이 패키지 선언 한 줄만 존재하며, `domain/package-info.java` 처럼 계층 역할 Javadoc이 없다. 파일이 존재하므로 체크리스트는 통과하나 문서화 목적을 달성하지 못한다.
+- **Expected**: `domain/package-info.java` 형식으로 각 계층의 책임과 Bounded Context 맥락을 기술하는 Javadoc 포함.
+- **Actual**: `package com.init.{context}.{layer};` 한 줄만 존재.
+- **Fix Direction**: 각 `package-info.java`에 계층 역할 설명 Javadoc 추가.
+- **Fix Result**: _(Fix Agent가 채움)_
+
+---
+
+### V-026 [Info] auth TODO 코드 잔류 — 이메일 발송 미구현
+
+- **Rule**: `principles.md:YAGNI`
+- **File**: `backend/src/main/java/com/init/auth/presentation/AuthController.java:84, 97`
+- **Description**: `passwordResetInit` 관련 `// TODO: emailService.sendPasswordResetEmail(...)` 주석이 2곳에 중복 존재. 이메일 발송 없이 동작 방식이 미결정 상태.
+- **Expected**: 이메일 서비스 구현 또는 API 반환 방식 확정 후 중복 TODO 제거.
+- **Actual**: TODO 주석 2개 중복.
+- **Fix Direction**: 이메일 서비스 구현 또는 설계 결정 후 TODO 제거.
+- **Fix Result**: _(Fix Agent가 채움)_
+
+---
+
+### V-027 [Info] 도메인 엔티티가 JPA 어노테이션에 직접 의존 (프로젝트 전체 관례)
+
+- **Rule**: `java.md:계층 규칙 — domain: 외부 의존성 금지`
+- **File**: `backend/src/main/java/com/init/auth/domain/model/AppUser.java:3-16`, `corpus/domain/model/Dataset.java:5` 외 다수
+- **Description**: `java.md` 계층 규칙은 domain 계층에서 외부 의존성을 금지한다. 그러나 프로젝트 전체 domain/model 엔티티가 `jakarta.persistence.*` 어노테이션을 직접 사용하는 것이 일관된 관례로 적용되고 있다. Spring Data JPA 기반 프로젝트에서 사실상 허용되는 패턴이나, 순수 DDD를 추구하는 경우 위반에 해당한다.
+- **Expected**: 도메인 모델을 순수 POJO로 유지하고 JPA 매핑을 infrastructure 계층의 별도 @Entity 클래스로 분리.
+- **Actual**: 프로젝트 전체 domain/model 클래스에 `jakarta.persistence.*` 어노테이션 직접 사용.
+- **Fix Direction**: 프로젝트 아키텍처 결정 후 일관성 유지. 순수 DDD를 선택할 경우 Infrastructure 계층에 별도 JPA 매핑 클래스 도입.
+- **Fix Result**: _(Fix Agent가 채움)_
+
+---
+
+### V-028 [Info] domainpack package-info.java 하위 패키지 내용 미흡
+
+- **Rule**: `module-creation.md:계층별 필수 파일`
+- **File**: `backend/src/main/java/com/init/domainpack/application/package-info.java`, `infrastructure/package-info.java`, `presentation/package-info.java`
+- **Description**: `application`, `infrastructure`, `presentation` 계층의 `package-info.java`가 패키지 선언 1줄만 포함. `domain/package-info.java`는 설명 Javadoc이 있음. V-025와 동일 범주.
+- **Expected**: 계층 역할 설명 Javadoc 포함.
+- **Actual**: 패키지 선언만 존재.
+- **Fix Direction**: V-025와 함께 처리.
+- **Fix Result**: _(Fix Agent가 채움)_
+
+---
+
+### V-029 [Info] GlobalExceptionHandler BusinessException 공통 핸들러 없음
+
+- **Rule**: `error-handling.md:GlobalExceptionHandler 패턴`
+- **File**: `backend/src/main/java/com/init/shared/presentation/GlobalExceptionHandler.java`
+- **Description**: `error-handling.md` 예시에는 `NotFoundException.class` 등 base exception type 핸들러가 있으나, 현재 구현에는 `BusinessException` fallback 핸들러가 없어 새 BC 예외 추가 시 `GlobalExceptionHandler` 수정이 필요하다.
+- **Expected**: `@ExceptionHandler(BusinessException.class)` fallback 핸들러 추가로 확장성 확보.
+- **Actual**: 모든 핸들러가 구체 예외 타입 직접 처리, 공통 fallback 없음.
+- **Fix Direction**: V-001 완료 후 `@ExceptionHandler(BusinessException.class)` fallback 추가.
+- **Fix Result**: _(Fix Agent가 채움)_
+
+---
+
+### V-030 [Info] review/pipelinejob bounded context 구현 파일 전무 (skeleton 상태)
+
+- **Rule**: `testing.md:커버리지 목표` / `module-creation.md:테스트 scaffolding`
+- **File**: `backend/src/main/java/com/init/review/`, `backend/src/main/java/com/init/pipelinejob/`
+- **Description**: review와 pipelinejob bounded context는 각 계층에 `package-info.java`만 존재하며 실제 구현 파일이 없는 skeleton 상태다. 현재는 개발 미착수 단계로 규칙 위반 아니나, 구현 시작 시 즉시 테스트 scaffolding이 필요하다.
+- **Expected**: 구현 시작 시 `module-creation.md` 체크리스트를 따라 테스트 scaffolding 동시 작성.
+- **Actual**: `src/test/java/com/init/review/`, `src/test/java/com/init/pipelinejob/` 디렉토리 미존재.
+- **Fix Direction**: 구현 착수 시 Service 단위 테스트 + Controller 통합 테스트 동시 작성.
+- **Fix Result**: _(Fix Agent가 채움)_
+
+---
+
+### V-031 [Info] workflowruntime ChatSession/ChatMessageRepository 자명한 Javadoc
+
+- **Rule**: `java.md:금지 패턴 #7 — 과도한 Javadoc 금지`
+- **File**: `backend/src/main/java/com/init/workflowruntime/domain/ChatSession.java:16`, `backend/src/main/java/com/init/workflowruntime/domain/ChatMessageRepository.java:15-40`
+- **Description**: 클래스명/메서드명으로 의도가 자명한 항목에 장황한 `@param/@return` Javadoc이 작성되어 있다.
+- **Expected**: 비자명한 동작만 간결한 주석으로 기술.
+- **Actual**: 4개 메서드 모두 자명한 내용 반복 Javadoc.
+- **Fix Direction**: 자명한 Javadoc 블록 제거.
+- **Fix Result**: _(Fix Agent가 채움)_
+
+---
+
+## Ignored (auditignore)
+
+`.handoff/_inspection/.auditignore` 파일 없음 — 모든 항목 감사 대상.
+
+| Rule ID | File | Reason |
+|---------|------|--------|
+| — | — | — |
+
+---
+
+## Spec Consistency
+
+Inspection Mode — 브랜치 번호(`{number}`) 추출 불가 (`main` 브랜치). Spec-Implementation 일관성 체크 생략.


### PR DESCRIPTION
# Audit Report — Backend Inspection

**Mode**: Inspection  
**Date**: 2026-04-10  
**Branch**: main  
**Scope**: `backend/src/main/java/com/init/` 전체 (auth, corpus, domainpack, workflowruntime, chatdemo, review, pipelinejob, shared)  
**Rules Applied**: `java.md`, `error-handling.md`, `testing.md`, `module-creation.md`, `principles.md`, `code-review.md`  
**Result**: **FAIL**

---

## Summary

| Severity | Count |
|----------|-------|
| Critical | 8     |
| Warning  | 17    |
| Info     | 6     |
| Ignored  | 0     |

---

## Violations

### V-001 [Critical] BusinessException 계층 구조 전무 — 전체 bounded context 예외가 RuntimeException 직접 상속

- **Rule**: `error-handling.md:예외 계층 구조`
- **File**: `backend/src/main/java/com/init/auth/application/exception/AuthException.java:3`, `corpus/application/exception/WorkspaceNotFoundException.java:3` (외 corpus 4개), `domainpack/application/exception/DomainPackVersionNotFoundException.java:3` (외 domainpack 4개)
- **Description**: `error-handling.md`는 `BusinessException(추상) → NotFoundException / DuplicateException / InvalidCredentialsException / InvalidTokenException / UnauthorizedException / BadRequestException` 계층 구조를 명시한다. 프로젝트 전체에 `BusinessException` 추상 클래스 자체가 존재하지 않으며, auth(6개), corpus(5개), domainpack(5개) 예외 클래스 전부가 `RuntimeException`을 직접 상속한다.
- **Expected**: `shared` 모듈에 `BusinessException` 추상 클래스 및 하위 계층(`NotFoundException`, `DuplicateException`, `UnauthorizedException`, `BadRequestException` 등) 정의. 각 BC 예외가 의미론적으로 일치하는 base class 상속. 예: `WorkspaceNotFoundException extends NotFoundException`, `DomainPackVersionConflictException extends DuplicateException`
- **Actual**: 모든 비즈니스 예외가 `extends RuntimeException` 직접 상속. `BusinessException` 계층 없음.
- **Fix Direction**: `shared/application/exception/BusinessException.java` 추상 클래스 생성 → 하위 base exception(`NotFoundException`, `DuplicateException` 등) 정의 → 각 BC 예외 클래스를 해당 base class 상속으로 변경
- **Fix Result**: _(Fix Agent가 채움)_

---

### V-002 [Critical] shared.GlobalExceptionHandler가 auth/corpus/domainpack 모듈에 역방향 의존

- **Rule**: `java.md:계층 규칙` / `code-review.md:DDD 컴플라이언스`
- **File**: `backend/src/main/java/com/init/shared/presentation/GlobalExceptionHandler.java:3-18`
- **Description**: `GlobalExceptionHandler`(shared)가 `com.init.auth.application.exception.*`(5개), `com.init.corpus.application.exception.*`(5개), `com.init.domainpack.application.exception.*`(5개), `com.init.auth.presentation.dto.PasswordResetRequiredResponse`(1개) — 총 16개 외부 bounded context 심볼을 직접 import한다. shared는 다른 BC가 의존하는 공통 모듈이어야 하며, 역방향 의존은 BC 추가 시마다 shared 수정이 필요한 OCP 위반이자 모듈 경계 붕괴다.
- **Expected**: `GlobalExceptionHandler`는 shared 내부의 `BusinessException` 계층 타입만 처리. 각 BC의 구체 예외는 BC 내 `@ControllerAdvice` 또는 `BusinessException` 다형성으로 처리.
- **Actual**: `import com.init.auth.application.exception.BadRequestException;` 등 16개 외부 BC 심볼 직접 참조. `handlePasswordResetRequired()`가 `PasswordResetRequiredResponse`를 반환 타입으로 사용.
- **Fix Direction**: V-001 완료 후 `GlobalExceptionHandler`를 `BusinessException` 계층 핸들러만 유지하도록 리팩터링. `PasswordResetRequiredResponse`는 `ErrorResponse`로 통일하거나 shared.presentation.dto로 이동. 각 BC 전용 예외는 해당 BC의 `@ControllerAdvice`로 분리.
- **Fix Result**: _(Fix Agent가 채움)_

---

### V-003 [Critical] auth bounded context 테스트 코드 전무

- **Rule**: `testing.md:커버리지 목표` / `testing.md:필수 테스트 시나리오`
- **File**: `backend/src/test/java/com/init/auth/` (디렉토리 미존재)
- **Description**: `testing.md`는 라인 커버리지 70% 이상, 도메인 로직 90% 이상, 새 코드 80% 이상을 요구하며, happy path / validation 실패 / not found / 권한 없음 / 중복 5개 필수 시나리오를 명시한다. auth bounded context에 테스트 디렉토리와 파일이 전혀 없다. `AuthService`(212L), `AppUser`(149L), `RefreshToken`(83L) 등 핵심 도메인 로직 0% 커버리지.
- **Expected**: `AuthServiceTest.java`(`@ExtendWith(MockitoExtension)`), `AuthControllerTest.java`(`@WebMvcTest`), `AppUserTest.java`(순수 단위), `RefreshTokenTest.java` — 5개 필수 시나리오 포함, `should_결과_when_조건` 네이밍, Given-When-Then 패턴.
- **Actual**: `src/test/java/com/init/auth/` 디렉토리 미존재. 테스트 파일 0개.
- **Fix Direction**: auth 모듈 테스트 scaffolding 전체 신규 작성. 최소: signup 중복 이메일(DuplicateException), login 잘못된 비밀번호(InvalidCredentialsException), 만료 토큰 refresh(InvalidTokenException), 비밀번호 재설정 정상 흐름.
- **Fix Result**: _(Fix Agent가 채움)_

---

### V-004 [Critical] corpus RawDatasetUploadService 서비스 레이어 일반 Exception catch

- **Rule**: `error-handling.md:금지 사항` / `java.md:금지 패턴 5`
- **File**: `backend/src/main/java/com/init/corpus/application/RawDatasetUploadService.java:119`
- **Description**: `upload()` 메서드의 배치 플러시 블록에서 `catch (Exception e)`를 사용한다. `error-handling.md`는 서비스/도메인 레이어에서 일반 `Exception` catch를 명시적으로 금지하며, `GlobalExceptionHandler` fallback에서만 허용한다.
- **Expected**: `catch (RuntimeException e)` 또는 구체 예외 타입(`DataIntegrityViolationException` 등)으로 범위를 좁혀야 한다.
- **Actual**: `catch (Exception e) { ... throw e; }` — 라인 119에서 보상 로직 후 재던지기.
- **Fix Direction**: catch 타입을 `RuntimeException`으로 좁히거나, 보상 로직을 `finally` 블록 또는 별도 메서드로 분리.
- **Fix Result**: _(Fix Agent가 채움)_

---

### V-005 [Critical] workflowruntime ChatSession 도메인 엔티티 public setter 존재

- **Rule**: `java.md:금지 패턴 #1 도메인 엔티티에 public setter 금지`
- **File**: `backend/src/main/java/com/init/workflowruntime/domain/ChatSession.java:119`
- **Description**: `java.md`가 이 파일을 anti-pattern 근거 파일로 명시했음에도 `public void setStatus(ChatSessionStatus status)` 메서드가 존재하며, `ConsultationService:131-133`에서 직접 호출된다. public setter는 도메인 불변식(invariant)을 보장하지 못하고 상태 전환 규칙을 외부로 누설한다.
- **Expected**: 상태 전환은 의미 있는 도메인 메서드(예: `activate()`, `resolve()`, `close()`)로만 허용. `ConsultationService`의 switch 분기도 해당 도메인 메서드 호출로 변경.
- **Actual**: `public void setStatus(ChatSessionStatus status) { this.status = status; }` — 라인 119, `ConsultationService`에서 직접 호출.
- **Fix Direction**: `setStatus()` 제거 후 `ChatSessionStatus`별 도메인 메서드 추가. `ConsultationService.updateSessionStatus()` 내 switch 분기도 도메인 메서드 호출로 교체.
- **Fix Result**: _(Fix Agent가 채움)_

---

### V-006 [Critical] workflowruntime ConsultationService에서 BusinessException 계층 미사용

- **Rule**: `error-handling.md:예외 계층 구조` / `error-handling.md:서비스 레이어 에러 처리 패턴`
- **File**: `backend/src/main/java/com/init/workflowruntime/application/ConsultationService.java:59, 85, 120, 123-127`
- **Description**: `getMessages()`, `sendMessage()`, `updateSessionStatus()`의 `orElseThrow`에서 `IllegalArgumentException`을 던지며(59, 85, 120라인), `updateSessionStatus()`의 catch 블록(123-127라인)도 `IllegalArgumentException`을 다시 던진다. `NotFoundException` → HTTP 404가 명확하지만, `IllegalArgumentException`은 `GlobalExceptionHandler`에서 매핑 대상이 아니어서 500 fallback 위험이 있다.
- **Expected**: `orElseThrow(() -> new NotFoundException("Session not found: " + sessionId))`, valueOf 실패 시 `throw new BadRequestException("Unsupported status: " + status)` 사용.
- **Actual**: `orElseThrow(() -> new IllegalArgumentException(...))` 3곳, `catch (IllegalArgumentException e) { throw new IllegalArgumentException(...); }` 1곳.
- **Fix Direction**: 3곳의 `orElseThrow`를 `NotFoundException`으로 교체. `ChatSessionStatus.valueOf()` 실패 catch를 `BadRequestException`으로 교체. V-001 완료 후 적용.
- **Fix Result**: _(Fix Agent가 채움)_

---

### V-007 [Critical] workflowruntime ConsultationController/Service 인가(Authorization) 체크 없음

- **Rule**: `code-review.md:보안 체크 — 인증/인가가 필요한 엔드포인트에 적용됐는가`
- **File**: `backend/src/main/java/com/init/workflowruntime/presentation/ConsultationController.java` (전체), `backend/src/main/java/com/init/workflowruntime/application/ConsultationService.java` (전체)
- **Description**: `code-review.md`가 "주의: `ConsultationService`에는 인가 체크 없음 — 새 서비스는 반드시 추가"라고 명시적으로 경고한다. 상담 대기열 조회/메시지 전송/세션 상태 변경은 운영자 전용 기능이나, `ConsultationController`의 4개 엔드포인트와 `ConsultationService`의 4개 메서드 모두 호출자 identity 검증이 없다.
- **Expected**: `@PreAuthorize("hasRole('OPERATOR')")` 또는 SecurityContext에서 인증된 사용자를 추출하여 요청된 세션의 워크스페이스 접근 권한 검증.
- **Actual**: Controller 4개 엔드포인트, Service 4개 메서드 모두 인가 어노테이션 및 SecurityContext 접근 없음.
- **Fix Direction**: `SecurityConfig`의 인가 규칙에 workflowruntime 엔드포인트 경로 추가. 또는 `ConsultationController`에 `@PreAuthorize` 적용. 세션-워크스페이스 소속 검증 로직 Service에 추가.
- **Fix Result**: _(Fix Agent가 채움)_

---

### V-008 [Critical] shared JwtAuthenticationFilter 서비스 레이어 일반 Exception catch

- **Rule**: `error-handling.md:금지 사항` / `java.md:금지 패턴 5`
- **File**: `backend/src/main/java/com/init/shared/infrastructure/security/JwtAuthenticationFilter.java:55`
- **Description**: `doFilterInternal()` 내부에서 `catch (Exception ex)`로 모든 예외를 단일 핸들러로 처리한다. error-handling.md는 GlobalExceptionHandler fallback 경계 외 일반 Exception catch를 금지한다.
- **Expected**: JWT 처리 시 발생 가능한 `io.jsonwebtoken.JwtException`, `IllegalArgumentException` 등 구체 예외를 명시적으로 catch.
- **Actual**: `catch (Exception ex) { SecurityContextHolder.clearContext(); log.warn(...); }` — 라인 55.
- **Fix Direction**: `catch (JwtException | IllegalArgumentException ex)`로 변경하여 예외 타입을 명시.
- **Fix Result**: _(Fix Agent가 채움)_

---

### V-009 [Warning] @Transactional(readOnly = true) 기본값 미적용

- **Rule**: `java.md:권장 패턴 — @Transactional(readOnly = true) 기본값 설정`
- **File**: `backend/src/main/java/com/init/auth/application/AuthService.java:25`, `backend/src/main/java/com/init/corpus/application/DatasetUploadService.java:27`, `backend/src/main/java/com/init/domainpack/application/ActivateDomainPackVersionUseCase.java:22`
- **Description**: 3개 서비스 클래스의 레벨 `@Transactional`이 `readOnly=false`(기본값)로 설정되어 조회 메서드도 불필요하게 쓰기 트랜잭션으로 실행된다.
- **Expected**: 클래스 레벨 `@Transactional(readOnly = true)`, 쓰기 메서드만 `@Transactional` 개별 오버라이드.
- **Actual**: 3개 클래스 모두 `@Transactional` (readOnly=false 기본값) 클래스 레벨 선언.
- **Fix Direction**: 클래스 어노테이션을 `@Transactional(readOnly = true)`로 변경. 상태 변경 메서드에 `@Transactional` 개별 선언.
- **Fix Result**: _(Fix Agent가 채움)_

---

### V-010 [Warning] auth 모듈 package-info.java 전 계층 미존재

- **Rule**: `module-creation.md:계층별 필수 파일`
- **File**: `backend/src/main/java/com/init/auth/` (presentation, application, domain, infrastructure 4개 계층)
- **Description**: `module-creation.md`는 각 계층에 `package-info.java`를 필수로 요구한다. auth 모듈 전체에 `package-info.java` 파일이 한 개도 존재하지 않는다.
- **Expected**: `presentation/package-info.java`, `application/package-info.java`, `domain/package-info.java`, `infrastructure/package-info.java` 각각 존재.
- **Actual**: auth 모듈 전체 `package-info.java` 0개.
- **Fix Direction**: 각 계층 패키지에 `package-info.java` 생성. domainpack 모듈의 기존 `package-info.java`를 참조.
- **Fix Result**: _(Fix Agent가 채움)_

---

### V-011 [Warning] corpus 모듈 package-info.java 전 계층 미존재

- **Rule**: `module-creation.md:계층별 필수 파일`
- **File**: `backend/src/main/java/com/init/corpus/` (presentation, application, domain, infrastructure 4개 계층)
- **Description**: corpus 모듈 전체에 `package-info.java` 파일이 한 개도 존재하지 않는다.
- **Expected**: 4개 계층 각각 `package-info.java` 존재.
- **Actual**: corpus 모듈 전체 `package-info.java` 0개.
- **Fix Direction**: 각 계층에 `package-info.java` 생성.
- **Fix Result**: _(Fix Agent가 채움)_

---

### V-012 [Warning] domainpack ActivateDomainPackVersionUseCase에 불필요한 @Autowired 선언

- **Rule**: `java.md:금지 패턴 #2 — @Autowired 필드 주입 금지`
- **File**: `backend/src/main/java/com/init/domainpack/application/ActivateDomainPackVersionUseCase.java:33`
- **Description**: `java.md`는 `@Autowired` 사용 자체를 금지하며 생성자 주입 시 어노테이션 없이 단일 생성자만 정의하도록 규정한다(Spring 단일 생성자 자동 감지). 생성자 자체는 올바른 생성자 주입이나 `@Autowired` 어노테이션이 명시되어 있다.
- **Expected**: public 생성자에서 `@Autowired` 제거. Spring이 단일 public 생성자를 자동으로 주입.
- **Actual**: `@Autowired public ActivateDomainPackVersionUseCase(...)` — 라인 33.
- **Fix Direction**: `@Autowired` 어노테이션 제거.
- **Fix Result**: _(Fix Agent가 채움)_

---

### V-013 [Warning] auth PasswordResetRequiredResponse와 ErrorResponse 불일치

- **Rule**: `error-handling.md:에러 응답 DTO`
- **File**: `backend/src/main/java/com/init/auth/presentation/dto/PasswordResetRequiredResponse.java`, `backend/src/main/java/com/init/shared/presentation/GlobalExceptionHandler.java`
- **Description**: `error-handling.md`는 `ErrorResponse(String code, String message)`를 모든 에러 응답의 통일 형식으로 요구한다. `PasswordResetRequiredResponse`는 동일한 `(code, message)` 구조이나 별도 타입으로 존재하며, `GlobalExceptionHandler.handlePasswordResetRequired()`가 `ResponseEntity<PasswordResetRequiredResponse>`를 반환한다.
- **Expected**: `ErrorResponse`로 통일하거나, `PasswordResetRequiredResponse`가 `ErrorResponse`와 동일 타입으로 교체.
- **Actual**: `public record PasswordResetRequiredResponse(String code, String message)` — `ErrorResponse`와 구조 동일하나 별도 타입.
- **Fix Direction**: `PasswordResetRequiredResponse` 제거 후 `ErrorResponse`로 통일. V-002 수정과 함께 처리.
- **Fix Result**: _(Fix Agent가 채움)_

---

### V-014 [Warning] corpus DatasetUploadService 단위 테스트 없음

- **Rule**: `testing.md:계층별 테스트 전략` / `module-creation.md:테스트 scaffolding`
- **File**: `backend/src/test/java/com/init/corpus/application/DatasetUploadServiceTest.java` (미존재)
- **Description**: `testing.md`는 Application(Service) 계층에 `@ExtendWith(MockitoExtension)` 단위 테스트를 요구한다. `RawDatasetUploadServiceTest`는 존재하나 `DatasetUploadService`에 대한 테스트가 없다.
- **Expected**: `DatasetUploadServiceTest.java` — 워크스페이스 없음, 멤버십 없음, 키 중복, 정상 업로드, 중복 turnIndex 시나리오.
- **Actual**: `DatasetUploadServiceTest.java` 미존재.
- **Fix Direction**: `DatasetUploadServiceTest.java` 생성, 5개 필수 시나리오 포함.
- **Fix Result**: _(Fix Agent가 채움)_

---

### V-015 [Warning] 테스트 메서드명 should_결과_when_조건 규칙 미준수 (corpus, domainpack, workflowruntime)

- **Rule**: `testing.md:네이밍 규칙`
- **File**: `backend/src/test/java/com/init/corpus/application/ConsultingContentParserTest.java:16`, `backend/src/test/java/com/init/domainpack/application/ActivateDomainPackVersionUseCaseTest.java`, `backend/src/test/java/com/init/domainpack/domain/model/DomainPackVersionTest.java`, `backend/src/test/java/com/init/domainpack/presentation/ActivateDomainPackVersionControllerTest.java`, `backend/src/test/java/com/init/workflowruntime/presentation/ConsultationControllerTest.java:52`
- **Description**: `testing.md`는 `should_결과_when_조건` 네이밍을 규정한다. 5개 테스트 파일에서 `action_condition_result` 혼합 형식(`execute_validDraft_returnsPublishedResult`, `getActiveQueue_Success` 등)을 사용한다.
- **Expected**: `should_PUBLISHED반환_when_유효한DRAFT`, `should_404반환_when_세션없음` 형태.
- **Actual**: `execute_validDraft_returnsPublishedResult`, `getActiveQueue_Success`, `parse_agentPrefix_returnsAgentTurnWithCorrectIndex` 등 혼합 패턴.
- **Fix Direction**: 메서드명을 `should_결과_when_조건` 형식으로 일괄 변경. `@DisplayName`은 이미 한글로 잘 작성되어 있으므로 메서드명만 수정.
- **Fix Result**: _(Fix Agent가 채움)_

---

### V-016 [Warning] corpus 테스트에 Given-When-Then 주석 블록 미적용

- **Rule**: `testing.md:BDD 패턴 (Given-When-Then)`
- **File**: `backend/src/test/java/com/init/corpus/application/ConsultingContentParserTest.java`, `backend/src/test/java/com/init/corpus/application/RawDatasetUploadServiceTest.java`
- **Description**: `testing.md`는 BDD Given-When-Then 패턴을 필수로 지정한다. `ConsultingContentParserTest`의 모든 테스트에 `// given / // when / // then` 주석 블록이 없다. `RawDatasetUploadServiceTest`도 섹션 주석 없이 given() stubbing 후 바로 assertThatThrownBy() 호출.
- **Expected**: 각 테스트 메서드에 `// given`, `// when`, `// then` (또는 `// when & then`) 주석 블록 명시.
- **Actual**: 두 파일 모두 GWT 구분 없는 단순 호출 + assert 구조.
- **Fix Direction**: 각 테스트 메서드에 `// given`, `// when`, `// then` 주석 추가.
- **Fix Result**: _(Fix Agent가 채움)_

---

### V-017 [Warning] corpus DatasetController에서 인증 처리 로직 구현 (Controller 비즈니스 로직 금지)

- **Rule**: `java.md:금지 패턴 #3 — Controller에 비즈니스 로직 금지`
- **File**: `backend/src/main/java/com/init/corpus/presentation/DatasetController.java:44`
- **Description**: `DatasetController`에 `getUserIdFromAuthentication()` private 메서드가 존재하며, `Authentication` null 체크, principal null 체크, `Long` 타입 캐스팅 검증, 예외 던지기까지 직접 구현한다. 이 로직은 다른 Controller에서도 반복 가능성이 있는 공통 관심사다.
- **Expected**: `HandlerMethodArgumentResolver` 또는 shared 유틸리티 클래스에서 principal 추출 처리. Controller는 추출된 userId를 파라미터로 받기만 함.
- **Actual**: `DatasetController.getUserIdFromAuthentication()` — authentication/principal null 체크, Long 캐스팅 검증 직접 구현 (라인 44-59).
- **Fix Direction**: `@AuthenticationPrincipal`과 `HandlerMethodArgumentResolver`를 활용하거나 shared 계층 유틸리티로 이동.
- **Fix Result**: _(Fix Agent가 채움)_

---

### V-018 [Warning] workflowruntime ConsultationService 자명한 Javadoc 과다 작성

- **Rule**: `java.md:금지 패턴 #7 — 과도한 Javadoc 금지`
- **File**: `backend/src/main/java/com/init/workflowruntime/application/ConsultationService.java:37-78, 107-137`
- **Description**: `java.md`가 이 파일을 과도한 Javadoc 반(反)패턴의 근거 파일로 명시했음에도 모든 메서드에 자명한 `@param/@return/@throws` Javadoc 블록이 그대로 존재한다.
- **Expected**: 비자명한 동작(상태 전환 규칙, 자동 설정 필드 등)만 간결한 한 줄 주석. 자명한 CRUD 메서드는 Javadoc 생략.
- **Actual**: `getActiveQueue()`, `getMessages()`, `sendMessage()`, `updateSessionStatus()` 4개 메서드 모두 장황한 `@param/@return/@throws` Javadoc.
- **Fix Direction**: 자명한 메서드의 Javadoc 블록 전체 제거. 비자명한 동작(NOTE 역할 자동 할당, COMPLETED 시 endedAt 자동 설정)만 인라인 주석으로 유지.
- **Fix Result**: _(Fix Agent가 채움)_

---

### V-019 [Warning] workflowruntime ConsultationControllerTest 필수 실패 시나리오 누락

- **Rule**: `testing.md:필수 테스트 시나리오`
- **File**: `backend/src/test/java/com/init/workflowruntime/presentation/ConsultationControllerTest.java`
- **Description**: `testing.md`는 happy path 외에 validation 실패 / not found / 권한 없음 시나리오를 필수로 요구한다. 현재 4개 테스트 모두 happy path(Success)만 존재한다.
- **Expected**: `sendMessage_BadRequest_when_contentBlank`, `getMessages_NotFound_when_sessionNotExist`, `updateStatus_BadRequest_when_invalidStatusValue` 등 최소 3개 실패 시나리오 추가.
- **Actual**: 4개 테스트 모두 Success 케이스만 검증.
- **Fix Direction**: `@NotBlank` content 위반 시 400 응답 테스트, `NotFoundException` 전파 시 404 응답 테스트 추가.
- **Fix Result**: _(Fix Agent가 채움)_

---

### V-020 [Warning] workflowruntime ConsultationService 단위 테스트 없음

- **Rule**: `testing.md:계층별 테스트 전략` / `module-creation.md:테스트 scaffolding`
- **File**: `backend/src/test/java/com/init/workflowruntime/ConsultationServiceTest.java` (미존재)
- **Description**: Application(Service) 계층 단위 테스트 필수. workflowruntime 테스트 디렉토리에 `ConsultationControllerTest.java`만 존재하고 `ConsultationServiceTest.java`가 없다.
- **Expected**: `ConsultationServiceTest.java` — `@ExtendWith(MockitoExtension)`, Mock Repository, getMessages/sessionNotFound, sendMessage/success, updateSessionStatus 상태별 분기 테스트.
- **Actual**: `src/test/java/com/init/workflowruntime/` 에 Controller 테스트만 존재. Service 단위 테스트 없음.
- **Fix Direction**: `ConsultationServiceTest.java` 신규 작성.
- **Fix Result**: _(Fix Agent가 채움)_

---

### V-021 [Warning] domainpack DomainPackVersion.onUpdate()에서 Clock 인스턴스 미사용

- **Rule**: `testing.md:금지 사항 — sleep/setTimeout으로 비동기 대기 금지`
- **File**: `backend/src/main/java/com/init/domainpack/domain/model/DomainPackVersion.java:46`
- **Description**: `ActivateDomainPackVersionUseCase`는 `Clock` 주입으로 테스트 가능한 시간 처리를 구현했으나, `DomainPackVersion.onUpdate()` (`@PreUpdate`)는 `OffsetDateTime.now()`를 직접 호출하여 `updatedAt` 필드가 테스트에서 제어 불가하다. `DomainPackVersionTest`도 이 문제를 인지하고 `updatedAt` 검증을 포기했다.
- **Expected**: `activate()` 내에서 `updatedAt`도 `now`로 설정하여 `@PreUpdate`에 의존하지 않거나, `@PreUpdate`를 제거하고 도메인 메서드에서 직접 관리.
- **Actual**: `@PreUpdate protected void onUpdate() { this.updatedAt = OffsetDateTime.now(); }` — Clock 의존성 없음.
- **Fix Direction**: `activate(OffsetDateTime now)` 내에서 `this.updatedAt = now;` 추가하여 `@PreUpdate` 의존 제거.
- **Fix Result**: _(Fix Agent가 채움)_

---

### V-022 [Warning] domainpack infrastructure 계층 @DataJpaTest 테스트 없음

- **Rule**: `testing.md:계층별 테스트 전략`
- **File**: `backend/src/test/java/com/init/domainpack/infrastructure/` (미존재)
- **Description**: `JpaDomainPackVersionRepository`의 커스텀 JPQL 쿼리(`findByIdAndWorkspaceId`)와 `JpaDomainPackWorkspaceMembershipRepository.hasAnyRole()` default 메서드가 테스트 없이 미검증 상태다.
- **Expected**: `JpaDomainPackVersionRepositoryTest.java` (`@DataJpaTest`), `JpaDomainPackWorkspaceMembershipRepositoryTest.java`.
- **Actual**: domainpack infrastructure 테스트 파일 전무.
- **Fix Direction**: `@DataJpaTest` 기반 Repository 통합 테스트 작성. `findByIdAndWorkspaceId` workspace 범위 필터링, `hasAnyRole()` 역할 필터링 시나리오 포함.
- **Fix Result**: _(Fix Agent가 채움)_

---

### V-023 [Warning] domainpack DomainPackWorkspaceMemberRef getter 없음

- **Rule**: `java.md:DDD 패턴 — 캡슐화`
- **File**: `backend/src/main/java/com/init/domainpack/infrastructure/persistence/DomainPackWorkspaceMemberRef.java`
- **Description**: `workspaceId`, `userId`, `memberRole` 3개 private 필드에 getter가 없어, 동일 패키지의 `DomainPackRef`, `DomainPackWorkspaceRef` (getter 제공)와 일관성이 없다.
- **Expected**: `getWorkspaceId()`, `getUserId()`, `getMemberRole()` getter 제공.
- **Actual**: 3개 private 필드에 getter 없음. protected 기본 생성자만 존재.
- **Fix Direction**: getter 3개 추가.
- **Fix Result**: _(Fix Agent가 채움)_

---

### V-024 [Warning] JwtAuthenticationFilter role=null 시 SecurityContext 설정 생략 (silent drop)

- **Rule**: `code-review.md:보안 체크`
- **File**: `backend/src/main/java/com/init/shared/infrastructure/security/JwtAuthenticationFilter.java:44-53`
- **Description**: JWT 토큰에서 role이 null인 경우 `SecurityContextHolder`에 아무것도 설정하지 않고 조용히 다음 필터로 통과한다. role이 null인 유효한 토큰이 인증 없이 통과될 수 있어 의도치 않은 권한 상태가 발생할 수 있다.
- **Expected**: role이 null인 경우 `log.warn()` 추가 또는 token invalid 처리.
- **Actual**: `if (role != null) { ... }` — role=null 시 아무 처리 없이 `filterChain.doFilter()` 진행.
- **Fix Direction**: role==null 분기에 `log.warn("JWT token missing role claim, userId={}", userId)` 추가 또는 role을 필수 클레임으로 간주하여 V-008과 함께 처리.
- **Fix Result**: _(Fix Agent가 채움)_

---

### V-025 [Warning] 다수 bounded context package-info.java 내용 미흡 (설명 없는 패키지 선언만 존재)

- **Rule**: `module-creation.md:계층별 필수 파일`
- **File**: `workflowruntime/{presentation,application,infrastructure}/package-info.java`, `chatdemo/{application,infrastructure,presentation}/package-info.java`, `shared/{presentation,application,infrastructure}/package-info.java`, `review/{application,infrastructure,presentation}/package-info.java`, `pipelinejob/{application,infrastructure,presentation}/package-info.java`
- **Description**: 위 12개 `package-info.java` 파일이 패키지 선언 한 줄만 존재하며, `domain/package-info.java` 처럼 계층 역할 Javadoc이 없다. 파일이 존재하므로 체크리스트는 통과하나 문서화 목적을 달성하지 못한다.
- **Expected**: `domain/package-info.java` 형식으로 각 계층의 책임과 Bounded Context 맥락을 기술하는 Javadoc 포함.
- **Actual**: `package com.init.{context}.{layer};` 한 줄만 존재.
- **Fix Direction**: 각 `package-info.java`에 계층 역할 설명 Javadoc 추가.
- **Fix Result**: _(Fix Agent가 채움)_

---

### V-026 [Info] auth TODO 코드 잔류 — 이메일 발송 미구현

- **Rule**: `principles.md:YAGNI`
- **File**: `backend/src/main/java/com/init/auth/presentation/AuthController.java:84, 97`
- **Description**: `passwordResetInit` 관련 `// TODO: emailService.sendPasswordResetEmail(...)` 주석이 2곳에 중복 존재. 이메일 발송 없이 동작 방식이 미결정 상태.
- **Expected**: 이메일 서비스 구현 또는 API 반환 방식 확정 후 중복 TODO 제거.
- **Actual**: TODO 주석 2개 중복.
- **Fix Direction**: 이메일 서비스 구현 또는 설계 결정 후 TODO 제거.
- **Fix Result**: _(Fix Agent가 채움)_

---

### V-027 [Info] 도메인 엔티티가 JPA 어노테이션에 직접 의존 (프로젝트 전체 관례)

- **Rule**: `java.md:계층 규칙 — domain: 외부 의존성 금지`
- **File**: `backend/src/main/java/com/init/auth/domain/model/AppUser.java:3-16`, `corpus/domain/model/Dataset.java:5` 외 다수
- **Description**: `java.md` 계층 규칙은 domain 계층에서 외부 의존성을 금지한다. 그러나 프로젝트 전체 domain/model 엔티티가 `jakarta.persistence.*` 어노테이션을 직접 사용하는 것이 일관된 관례로 적용되고 있다. Spring Data JPA 기반 프로젝트에서 사실상 허용되는 패턴이나, 순수 DDD를 추구하는 경우 위반에 해당한다.
- **Expected**: 도메인 모델을 순수 POJO로 유지하고 JPA 매핑을 infrastructure 계층의 별도 @Entity 클래스로 분리.
- **Actual**: 프로젝트 전체 domain/model 클래스에 `jakarta.persistence.*` 어노테이션 직접 사용.
- **Fix Direction**: 프로젝트 아키텍처 결정 후 일관성 유지. 순수 DDD를 선택할 경우 Infrastructure 계층에 별도 JPA 매핑 클래스 도입.
- **Fix Result**: _(Fix Agent가 채움)_

---

### V-028 [Info] domainpack package-info.java 하위 패키지 내용 미흡

- **Rule**: `module-creation.md:계층별 필수 파일`
- **File**: `backend/src/main/java/com/init/domainpack/application/package-info.java`, `infrastructure/package-info.java`, `presentation/package-info.java`
- **Description**: `application`, `infrastructure`, `presentation` 계층의 `package-info.java`가 패키지 선언 1줄만 포함. `domain/package-info.java`는 설명 Javadoc이 있음. V-025와 동일 범주.
- **Expected**: 계층 역할 설명 Javadoc 포함.
- **Actual**: 패키지 선언만 존재.
- **Fix Direction**: V-025와 함께 처리.
- **Fix Result**: _(Fix Agent가 채움)_

---

### V-029 [Info] GlobalExceptionHandler BusinessException 공통 핸들러 없음

- **Rule**: `error-handling.md:GlobalExceptionHandler 패턴`
- **File**: `backend/src/main/java/com/init/shared/presentation/GlobalExceptionHandler.java`
- **Description**: `error-handling.md` 예시에는 `NotFoundException.class` 등 base exception type 핸들러가 있으나, 현재 구현에는 `BusinessException` fallback 핸들러가 없어 새 BC 예외 추가 시 `GlobalExceptionHandler` 수정이 필요하다.
- **Expected**: `@ExceptionHandler(BusinessException.class)` fallback 핸들러 추가로 확장성 확보.
- **Actual**: 모든 핸들러가 구체 예외 타입 직접 처리, 공통 fallback 없음.
- **Fix Direction**: V-001 완료 후 `@ExceptionHandler(BusinessException.class)` fallback 추가.
- **Fix Result**: _(Fix Agent가 채움)_

---

### V-030 [Info] review/pipelinejob bounded context 구현 파일 전무 (skeleton 상태)

- **Rule**: `testing.md:커버리지 목표` / `module-creation.md:테스트 scaffolding`
- **File**: `backend/src/main/java/com/init/review/`, `backend/src/main/java/com/init/pipelinejob/`
- **Description**: review와 pipelinejob bounded context는 각 계층에 `package-info.java`만 존재하며 실제 구현 파일이 없는 skeleton 상태다. 현재는 개발 미착수 단계로 규칙 위반 아니나, 구현 시작 시 즉시 테스트 scaffolding이 필요하다.
- **Expected**: 구현 시작 시 `module-creation.md` 체크리스트를 따라 테스트 scaffolding 동시 작성.
- **Actual**: `src/test/java/com/init/review/`, `src/test/java/com/init/pipelinejob/` 디렉토리 미존재.
- **Fix Direction**: 구현 착수 시 Service 단위 테스트 + Controller 통합 테스트 동시 작성.
- **Fix Result**: _(Fix Agent가 채움)_

---

### V-031 [Info] workflowruntime ChatSession/ChatMessageRepository 자명한 Javadoc

- **Rule**: `java.md:금지 패턴 #7 — 과도한 Javadoc 금지`
- **File**: `backend/src/main/java/com/init/workflowruntime/domain/ChatSession.java:16`, `backend/src/main/java/com/init/workflowruntime/domain/ChatMessageRepository.java:15-40`
- **Description**: 클래스명/메서드명으로 의도가 자명한 항목에 장황한 `@param/@return` Javadoc이 작성되어 있다.
- **Expected**: 비자명한 동작만 간결한 주석으로 기술.
- **Actual**: 4개 메서드 모두 자명한 내용 반복 Javadoc.
- **Fix Direction**: 자명한 Javadoc 블록 제거.
- **Fix Result**: _(Fix Agent가 채움)_

---

## Ignored (auditignore)

`.handoff/_inspection/.auditignore` 파일 없음 — 모든 항목 감사 대상.

| Rule ID | File | Reason |
|---------|------|--------|
| — | — | — |

---

## Spec Consistency

Inspection Mode — 브랜치 번호(`{number}`) 추출 불가 (`main` 브랜치). Spec-Implementation 일관성 체크 생략.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* 내부 감시 보고서 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->