### PR TITLE
feat(workspace): implement workspace CRUD API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@
 ```
 backend/
 ├── auth/                 # 인증/인가, JWT 토큰 관리, 리프레시 토큰
+├── workspace/            # 워크스페이스 CRUD, 멤버십 기반 접근 제어
 ├── domain-pack/          # Domain Pack 관리 (intent, slot, policy, risk, workflow)
 │   ├── presentation/     # Controller, DTO, WebSocket Handler
 │   ├── application/      # UseCase, Application Service
@@ -41,15 +42,16 @@ backend/
 
 **계층 구조**: `presentation → application → domain → infrastructure`
 
-**7개 Bounded Context**:
+**8개 Bounded Context**:
 
 1. **auth**: 인증/인가, JWT 토큰 관리, 리프레시 토큰
-2. **domain-pack**: intent/slot/policy/risk/workflow 버전 관리
-3. **review**: AI 초안 검토, 수정, 승인, 반려
-4. **pipeline-job**: Airflow 파이프라인 실행 요청 및 상태 추적
-5. **workflow-runtime**: publish된 domain pack 실행
-6. **chat-demo**: 시연용 채팅 세션
-7. **shared/infra**: 공통 기술 요소
+2. **workspace**: 워크스페이스 생성/조회/수정/보관, 멤버십 기반 접근 제어
+3. **domain-pack**: intent/slot/policy/risk/workflow 버전 관리
+4. **review**: AI 초안 검토, 수정, 승인, 반려
+5. **pipeline-job**: Airflow 파이프라인 실행 요청 및 상태 추적
+6. **workflow-runtime**: publish된 domain pack 실행
+7. **chat-demo**: 시연용 채팅 세션
+8. **shared/infra**: 공통 기술 요소
 
 ### frontend/ — Vite+ FSD (Feature-Sliced Design)
 

--- a/backend/src/main/java/com/init/domainpack/infrastructure/persistence/DomainPackWorkspaceMemberRef.java
+++ b/backend/src/main/java/com/init/domainpack/infrastructure/persistence/DomainPackWorkspaceMemberRef.java
@@ -5,7 +5,9 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
+import java.time.OffsetDateTime;
 
 /**
  * domainpack bounded context의 workspace_member 읽기 전용 참조 모델.
@@ -30,6 +32,9 @@ public class DomainPackWorkspaceMemberRef {
   @Column(name = "member_role", nullable = false)
   private String memberRole;
 
+  @Column(name = "joined_at", nullable = false, updatable = false)
+  private OffsetDateTime joinedAt;
+
   protected DomainPackWorkspaceMemberRef() {}
 
   public Long getWorkspaceId() {
@@ -42,5 +47,12 @@ public class DomainPackWorkspaceMemberRef {
 
   public String getMemberRole() {
     return memberRole;
+  }
+
+  @PrePersist
+  protected void onPersist() {
+    if (joinedAt == null) {
+      joinedAt = OffsetDateTime.now();
+    }
   }
 }

--- a/backend/src/main/java/com/init/shared/infrastructure/security/ApiAuthenticationEntryPoint.java
+++ b/backend/src/main/java/com/init/shared/infrastructure/security/ApiAuthenticationEntryPoint.java
@@ -1,0 +1,25 @@
+package com.init.shared.infrastructure.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ApiAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+  @Override
+  public void commence(
+      HttpServletRequest request,
+      HttpServletResponse response,
+      AuthenticationException authException)
+      throws IOException {
+    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+    response.setCharacterEncoding("UTF-8");
+    response.getWriter().write("{\"code\":\"UNAUTHORIZED\",\"message\":\"인증이 필요합니다.\"}");
+  }
+}

--- a/backend/src/main/java/com/init/shared/infrastructure/security/SecurityConfig.java
+++ b/backend/src/main/java/com/init/shared/infrastructure/security/SecurityConfig.java
@@ -4,7 +4,6 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpStatus;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -12,7 +11,6 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
@@ -23,12 +21,15 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 public class SecurityConfig {
 
   private final JwtAuthenticationFilter jwtAuthenticationFilter;
+  private final ApiAuthenticationEntryPoint apiAuthenticationEntryPoint;
   private final List<String> allowedOrigins;
 
   public SecurityConfig(
       JwtAuthenticationFilter jwtAuthenticationFilter,
+      ApiAuthenticationEntryPoint apiAuthenticationEntryPoint,
       @Value("${cors.allowed-origins}") List<String> allowedOrigins) {
     this.jwtAuthenticationFilter = jwtAuthenticationFilter;
+    this.apiAuthenticationEntryPoint = apiAuthenticationEntryPoint;
     this.allowedOrigins = allowedOrigins;
   }
 
@@ -49,8 +50,7 @@ public class SecurityConfig {
                     .anyRequest()
                     .authenticated())
         .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
-        .exceptionHandling(
-            ex -> ex.authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED)))
+        .exceptionHandling(ex -> ex.authenticationEntryPoint(apiAuthenticationEntryPoint))
         .build();
   }
 

--- a/backend/src/main/java/com/init/workspace/application/ArchiveWorkspaceUseCase.java
+++ b/backend/src/main/java/com/init/workspace/application/ArchiveWorkspaceUseCase.java
@@ -1,0 +1,51 @@
+package com.init.workspace.application;
+
+import com.init.workspace.application.exception.WorkspaceAccessDeniedException;
+import com.init.workspace.application.exception.WorkspaceNotFoundException;
+import com.init.workspace.domain.model.Workspace;
+import com.init.workspace.domain.model.WorkspaceMember;
+import com.init.workspace.domain.model.WorkspaceMemberRole;
+import com.init.workspace.domain.model.WorkspaceStatus;
+import com.init.workspace.domain.repository.WorkspaceMemberRepository;
+import com.init.workspace.domain.repository.WorkspaceRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class ArchiveWorkspaceUseCase {
+
+  private final WorkspaceRepository workspaceRepository;
+  private final WorkspaceMemberRepository workspaceMemberRepository;
+
+  public ArchiveWorkspaceUseCase(
+      WorkspaceRepository workspaceRepository, WorkspaceMemberRepository workspaceMemberRepository) {
+    this.workspaceRepository = workspaceRepository;
+    this.workspaceMemberRepository = workspaceMemberRepository;
+  }
+
+  @Transactional
+  public void execute(Long workspaceId, Long userId) {
+    Workspace workspace =
+        workspaceRepository
+            .findById(workspaceId)
+            .orElseThrow(() -> new WorkspaceNotFoundException("워크스페이스를 찾을 수 없습니다."));
+
+    WorkspaceMember member =
+        workspaceMemberRepository
+            .findByWorkspaceIdAndUserId(workspaceId, userId)
+            .orElseThrow(
+                () -> new WorkspaceAccessDeniedException("워크스페이스에 접근 권한이 없습니다."));
+
+    if (member.getMemberRole() != WorkspaceMemberRole.OWNER) {
+      throw new WorkspaceAccessDeniedException("워크스페이스에 접근 권한이 없습니다.");
+    }
+
+    if (workspace.getStatus() == WorkspaceStatus.ARCHIVED) {
+      return;
+    }
+
+    workspace.archive();
+    workspaceRepository.save(workspace);
+  }
+}

--- a/backend/src/main/java/com/init/workspace/application/ArchiveWorkspaceUseCase.java
+++ b/backend/src/main/java/com/init/workspace/application/ArchiveWorkspaceUseCase.java
@@ -19,7 +19,8 @@ public class ArchiveWorkspaceUseCase {
   private final WorkspaceMemberRepository workspaceMemberRepository;
 
   public ArchiveWorkspaceUseCase(
-      WorkspaceRepository workspaceRepository, WorkspaceMemberRepository workspaceMemberRepository) {
+      WorkspaceRepository workspaceRepository,
+      WorkspaceMemberRepository workspaceMemberRepository) {
     this.workspaceRepository = workspaceRepository;
     this.workspaceMemberRepository = workspaceMemberRepository;
   }
@@ -34,8 +35,7 @@ public class ArchiveWorkspaceUseCase {
     WorkspaceMember member =
         workspaceMemberRepository
             .findByWorkspaceIdAndUserId(workspaceId, userId)
-            .orElseThrow(
-                () -> new WorkspaceAccessDeniedException("워크스페이스에 접근 권한이 없습니다."));
+            .orElseThrow(() -> new WorkspaceAccessDeniedException("워크스페이스에 접근 권한이 없습니다."));
 
     if (member.getMemberRole() != WorkspaceMemberRole.OWNER) {
       throw new WorkspaceAccessDeniedException("워크스페이스에 접근 권한이 없습니다.");

--- a/backend/src/main/java/com/init/workspace/application/CreateWorkspaceCommand.java
+++ b/backend/src/main/java/com/init/workspace/application/CreateWorkspaceCommand.java
@@ -1,0 +1,13 @@
+package com.init.workspace.application;
+
+import java.util.Objects;
+
+public record CreateWorkspaceCommand(
+    String workspaceKey, String name, String description, Long ownerUserId) {
+
+  public CreateWorkspaceCommand {
+    Objects.requireNonNull(workspaceKey, "workspaceKey must not be null");
+    Objects.requireNonNull(name, "name must not be null");
+    Objects.requireNonNull(ownerUserId, "ownerUserId must not be null");
+  }
+}

--- a/backend/src/main/java/com/init/workspace/application/CreateWorkspaceUseCase.java
+++ b/backend/src/main/java/com/init/workspace/application/CreateWorkspaceUseCase.java
@@ -8,6 +8,8 @@ import com.init.workspace.domain.model.WorkspaceMember;
 import com.init.workspace.domain.model.WorkspaceMemberRole;
 import com.init.workspace.domain.repository.WorkspaceMemberRepository;
 import com.init.workspace.domain.repository.WorkspaceRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,6 +17,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @Transactional(readOnly = true)
 public class CreateWorkspaceUseCase {
+
+  private static final Logger logger = LoggerFactory.getLogger(CreateWorkspaceUseCase.class);
 
   private final WorkspaceRepository workspaceRepository;
   private final WorkspaceMemberRepository workspaceMemberRepository;
@@ -41,8 +45,14 @@ public class CreateWorkspaceUseCase {
               Workspace.create(workspaceKey, command.name(), command.description()));
     } catch (DataIntegrityViolationException ex) {
       if (isWorkspaceKeyConstraintViolation(ex)) {
+        logger.warn(
+            "Workspace create failed due to duplicate workspaceKey={}",
+            workspaceKey.getValue(),
+            ex);
         throw new WorkspaceKeyAlreadyExistsException("이미 사용 중인 워크스페이스 키입니다.", ex);
       }
+      logger.warn(
+          "Workspace create failed during save for workspaceKey={}", workspaceKey.getValue(), ex);
       throw ex;
     }
 

--- a/backend/src/main/java/com/init/workspace/application/CreateWorkspaceUseCase.java
+++ b/backend/src/main/java/com/init/workspace/application/CreateWorkspaceUseCase.java
@@ -1,0 +1,74 @@
+package com.init.workspace.application;
+
+import com.init.workspace.application.exception.WorkspaceInvalidKeyException;
+import com.init.workspace.application.exception.WorkspaceKeyAlreadyExistsException;
+import com.init.workspace.domain.model.Workspace;
+import com.init.workspace.domain.model.WorkspaceKey;
+import com.init.workspace.domain.model.WorkspaceMember;
+import com.init.workspace.domain.model.WorkspaceMemberRole;
+import com.init.workspace.domain.repository.WorkspaceMemberRepository;
+import com.init.workspace.domain.repository.WorkspaceRepository;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class CreateWorkspaceUseCase {
+
+  private final WorkspaceRepository workspaceRepository;
+  private final WorkspaceMemberRepository workspaceMemberRepository;
+
+  public CreateWorkspaceUseCase(
+      WorkspaceRepository workspaceRepository, WorkspaceMemberRepository workspaceMemberRepository) {
+    this.workspaceRepository = workspaceRepository;
+    this.workspaceMemberRepository = workspaceMemberRepository;
+  }
+
+  @Transactional
+  public WorkspaceResult execute(CreateWorkspaceCommand command) {
+    WorkspaceKey workspaceKey = parseWorkspaceKey(command.workspaceKey());
+
+    if (workspaceRepository.existsByWorkspaceKey(workspaceKey)) {
+      throw new WorkspaceKeyAlreadyExistsException("이미 사용 중인 워크스페이스 키입니다.");
+    }
+
+    Workspace savedWorkspace;
+    try {
+      savedWorkspace =
+          workspaceRepository.save(
+              Workspace.create(workspaceKey, command.name(), command.description()));
+    } catch (DataIntegrityViolationException ex) {
+      if (isWorkspaceKeyConstraintViolation(ex)) {
+        throw new WorkspaceKeyAlreadyExistsException("이미 사용 중인 워크스페이스 키입니다.", ex);
+      }
+      throw ex;
+    }
+
+    WorkspaceMember ownerMember =
+        workspaceMemberRepository.save(
+            WorkspaceMember.create(
+                savedWorkspace.getId(), command.ownerUserId(), WorkspaceMemberRole.OWNER));
+    return WorkspaceResult.from(savedWorkspace, ownerMember);
+  }
+
+  private WorkspaceKey parseWorkspaceKey(String rawWorkspaceKey) {
+    try {
+      return WorkspaceKey.of(rawWorkspaceKey);
+    } catch (IllegalArgumentException ex) {
+      throw new WorkspaceInvalidKeyException("workspaceKey 형식이 올바르지 않습니다.");
+    }
+  }
+
+  private boolean isWorkspaceKeyConstraintViolation(DataIntegrityViolationException ex) {
+    Throwable cause = ex.getCause();
+    if (cause instanceof org.hibernate.exception.ConstraintViolationException violationException) {
+      String constraintName = violationException.getConstraintName();
+      return constraintName != null && constraintName.contains("workspace_key");
+    }
+
+    Throwable rootCause = ex.getMostSpecificCause();
+    String message = rootCause != null ? rootCause.getMessage() : null;
+    return message != null && message.contains("workspace_key");
+  }
+}

--- a/backend/src/main/java/com/init/workspace/application/CreateWorkspaceUseCase.java
+++ b/backend/src/main/java/com/init/workspace/application/CreateWorkspaceUseCase.java
@@ -20,7 +20,8 @@ public class CreateWorkspaceUseCase {
   private final WorkspaceMemberRepository workspaceMemberRepository;
 
   public CreateWorkspaceUseCase(
-      WorkspaceRepository workspaceRepository, WorkspaceMemberRepository workspaceMemberRepository) {
+      WorkspaceRepository workspaceRepository,
+      WorkspaceMemberRepository workspaceMemberRepository) {
     this.workspaceRepository = workspaceRepository;
     this.workspaceMemberRepository = workspaceMemberRepository;
   }

--- a/backend/src/main/java/com/init/workspace/application/GetWorkspaceListUseCase.java
+++ b/backend/src/main/java/com/init/workspace/application/GetWorkspaceListUseCase.java
@@ -18,7 +18,8 @@ public class GetWorkspaceListUseCase {
   private final WorkspaceRepository workspaceRepository;
 
   public GetWorkspaceListUseCase(
-      WorkspaceMemberRepository workspaceMemberRepository, WorkspaceRepository workspaceRepository) {
+      WorkspaceMemberRepository workspaceMemberRepository,
+      WorkspaceRepository workspaceRepository) {
     this.workspaceMemberRepository = workspaceMemberRepository;
     this.workspaceRepository = workspaceRepository;
   }

--- a/backend/src/main/java/com/init/workspace/application/GetWorkspaceListUseCase.java
+++ b/backend/src/main/java/com/init/workspace/application/GetWorkspaceListUseCase.java
@@ -4,15 +4,21 @@ import com.init.workspace.domain.model.Workspace;
 import com.init.workspace.domain.model.WorkspaceMember;
 import com.init.workspace.domain.repository.WorkspaceMemberRepository;
 import com.init.workspace.domain.repository.WorkspaceRepository;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional(readOnly = true)
 public class GetWorkspaceListUseCase {
+
+  private static final int MEMBERSHIP_PAGE_SIZE = 100;
 
   private final WorkspaceMemberRepository workspaceMemberRepository;
   private final WorkspaceRepository workspaceRepository;
@@ -25,22 +31,34 @@ public class GetWorkspaceListUseCase {
   }
 
   public List<WorkspaceResult> execute(Long userId) {
-    List<WorkspaceMember> memberships = workspaceMemberRepository.findByUserId(userId);
-    if (memberships.isEmpty()) {
-      return List.of();
-    }
+    Pageable pageable = PageRequest.of(0, MEMBERSHIP_PAGE_SIZE);
+    List<WorkspaceResult> results = new ArrayList<>();
 
-    List<Long> workspaceIds = memberships.stream().map(WorkspaceMember::getWorkspaceId).toList();
-    List<Workspace> workspaces = workspaceRepository.findAllByIdIn(workspaceIds);
-    Map<Long, Workspace> workspaceById = new LinkedHashMap<>();
-    for (Workspace workspace : workspaces) {
-      workspaceById.put(workspace.getId(), workspace);
-    }
+    while (true) {
+      Slice<WorkspaceMember> memberships = workspaceMemberRepository.findByUserId(userId, pageable);
+      if (memberships.isEmpty()) {
+        return results;
+      }
 
-    return memberships.stream()
-        .map(member -> toResult(workspaceById, member))
-        .filter(java.util.Objects::nonNull)
-        .toList();
+      List<Long> workspaceIds = memberships.stream().map(WorkspaceMember::getWorkspaceId).toList();
+      List<Workspace> workspaces = workspaceRepository.findAllByIdIn(workspaceIds);
+      Map<Long, Workspace> workspaceById = new LinkedHashMap<>();
+      for (Workspace workspace : workspaces) {
+        workspaceById.put(workspace.getId(), workspace);
+      }
+
+      results.addAll(
+          memberships.stream()
+              .map(member -> toResult(workspaceById, member))
+              .filter(java.util.Objects::nonNull)
+              .toList());
+
+      if (!memberships.hasNext()) {
+        return results;
+      }
+
+      pageable = memberships.nextPageable();
+    }
   }
 
   private WorkspaceResult toResult(Map<Long, Workspace> workspaceById, WorkspaceMember member) {

--- a/backend/src/main/java/com/init/workspace/application/GetWorkspaceListUseCase.java
+++ b/backend/src/main/java/com/init/workspace/application/GetWorkspaceListUseCase.java
@@ -1,0 +1,52 @@
+package com.init.workspace.application;
+
+import com.init.workspace.domain.model.Workspace;
+import com.init.workspace.domain.model.WorkspaceMember;
+import com.init.workspace.domain.repository.WorkspaceMemberRepository;
+import com.init.workspace.domain.repository.WorkspaceRepository;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class GetWorkspaceListUseCase {
+
+  private final WorkspaceMemberRepository workspaceMemberRepository;
+  private final WorkspaceRepository workspaceRepository;
+
+  public GetWorkspaceListUseCase(
+      WorkspaceMemberRepository workspaceMemberRepository, WorkspaceRepository workspaceRepository) {
+    this.workspaceMemberRepository = workspaceMemberRepository;
+    this.workspaceRepository = workspaceRepository;
+  }
+
+  public List<WorkspaceResult> execute(Long userId) {
+    List<WorkspaceMember> memberships = workspaceMemberRepository.findByUserId(userId);
+    if (memberships.isEmpty()) {
+      return List.of();
+    }
+
+    List<Long> workspaceIds = memberships.stream().map(WorkspaceMember::getWorkspaceId).toList();
+    List<Workspace> workspaces = workspaceRepository.findAllByIdIn(workspaceIds);
+    Map<Long, Workspace> workspaceById = new LinkedHashMap<>();
+    for (Workspace workspace : workspaces) {
+      workspaceById.put(workspace.getId(), workspace);
+    }
+
+    return memberships.stream()
+        .map(member -> toResult(workspaceById, member))
+        .filter(java.util.Objects::nonNull)
+        .toList();
+  }
+
+  private WorkspaceResult toResult(Map<Long, Workspace> workspaceById, WorkspaceMember member) {
+    Workspace workspace = workspaceById.get(member.getWorkspaceId());
+    if (workspace == null) {
+      return null;
+    }
+    return WorkspaceResult.from(workspace, member);
+  }
+}

--- a/backend/src/main/java/com/init/workspace/application/GetWorkspaceUseCase.java
+++ b/backend/src/main/java/com/init/workspace/application/GetWorkspaceUseCase.java
@@ -1,0 +1,39 @@
+package com.init.workspace.application;
+
+import com.init.workspace.application.exception.WorkspaceAccessDeniedException;
+import com.init.workspace.application.exception.WorkspaceNotFoundException;
+import com.init.workspace.domain.model.Workspace;
+import com.init.workspace.domain.model.WorkspaceMember;
+import com.init.workspace.domain.repository.WorkspaceMemberRepository;
+import com.init.workspace.domain.repository.WorkspaceRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class GetWorkspaceUseCase {
+
+  private final WorkspaceRepository workspaceRepository;
+  private final WorkspaceMemberRepository workspaceMemberRepository;
+
+  public GetWorkspaceUseCase(
+      WorkspaceRepository workspaceRepository, WorkspaceMemberRepository workspaceMemberRepository) {
+    this.workspaceRepository = workspaceRepository;
+    this.workspaceMemberRepository = workspaceMemberRepository;
+  }
+
+  public WorkspaceResult execute(Long workspaceId, Long userId) {
+    Workspace workspace =
+        workspaceRepository
+            .findById(workspaceId)
+            .orElseThrow(() -> new WorkspaceNotFoundException("워크스페이스를 찾을 수 없습니다."));
+
+    WorkspaceMember member =
+        workspaceMemberRepository
+            .findByWorkspaceIdAndUserId(workspaceId, userId)
+            .orElseThrow(
+                () -> new WorkspaceAccessDeniedException("워크스페이스에 접근 권한이 없습니다."));
+
+    return WorkspaceResult.from(workspace, member);
+  }
+}

--- a/backend/src/main/java/com/init/workspace/application/GetWorkspaceUseCase.java
+++ b/backend/src/main/java/com/init/workspace/application/GetWorkspaceUseCase.java
@@ -17,7 +17,8 @@ public class GetWorkspaceUseCase {
   private final WorkspaceMemberRepository workspaceMemberRepository;
 
   public GetWorkspaceUseCase(
-      WorkspaceRepository workspaceRepository, WorkspaceMemberRepository workspaceMemberRepository) {
+      WorkspaceRepository workspaceRepository,
+      WorkspaceMemberRepository workspaceMemberRepository) {
     this.workspaceRepository = workspaceRepository;
     this.workspaceMemberRepository = workspaceMemberRepository;
   }
@@ -31,8 +32,7 @@ public class GetWorkspaceUseCase {
     WorkspaceMember member =
         workspaceMemberRepository
             .findByWorkspaceIdAndUserId(workspaceId, userId)
-            .orElseThrow(
-                () -> new WorkspaceAccessDeniedException("워크스페이스에 접근 권한이 없습니다."));
+            .orElseThrow(() -> new WorkspaceAccessDeniedException("워크스페이스에 접근 권한이 없습니다."));
 
     return WorkspaceResult.from(workspace, member);
   }

--- a/backend/src/main/java/com/init/workspace/application/UpdateWorkspaceCommand.java
+++ b/backend/src/main/java/com/init/workspace/application/UpdateWorkspaceCommand.java
@@ -1,0 +1,17 @@
+package com.init.workspace.application;
+
+import java.util.Objects;
+
+public record UpdateWorkspaceCommand(
+    Long workspaceId,
+    Long userId,
+    boolean nameProvided,
+    String name,
+    boolean descriptionProvided,
+    String description) {
+
+  public UpdateWorkspaceCommand {
+    Objects.requireNonNull(workspaceId, "workspaceId must not be null");
+    Objects.requireNonNull(userId, "userId must not be null");
+  }
+}

--- a/backend/src/main/java/com/init/workspace/application/UpdateWorkspaceUseCase.java
+++ b/backend/src/main/java/com/init/workspace/application/UpdateWorkspaceUseCase.java
@@ -1,0 +1,69 @@
+package com.init.workspace.application;
+
+import com.init.workspace.application.exception.WorkspaceAccessDeniedException;
+import com.init.workspace.application.exception.WorkspaceInvalidDescriptionException;
+import com.init.workspace.application.exception.WorkspaceInvalidNameException;
+import com.init.workspace.application.exception.WorkspaceNotFoundException;
+import com.init.workspace.domain.model.Workspace;
+import com.init.workspace.domain.model.WorkspaceMember;
+import com.init.workspace.domain.model.WorkspaceMemberRole;
+import com.init.workspace.domain.repository.WorkspaceMemberRepository;
+import com.init.workspace.domain.repository.WorkspaceRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class UpdateWorkspaceUseCase {
+
+  private final WorkspaceRepository workspaceRepository;
+  private final WorkspaceMemberRepository workspaceMemberRepository;
+
+  public UpdateWorkspaceUseCase(
+      WorkspaceRepository workspaceRepository, WorkspaceMemberRepository workspaceMemberRepository) {
+    this.workspaceRepository = workspaceRepository;
+    this.workspaceMemberRepository = workspaceMemberRepository;
+  }
+
+  @Transactional
+  public WorkspaceResult execute(UpdateWorkspaceCommand command) {
+    Workspace workspace =
+        workspaceRepository
+            .findById(command.workspaceId())
+            .orElseThrow(() -> new WorkspaceNotFoundException("워크스페이스를 찾을 수 없습니다."));
+
+    WorkspaceMember member =
+        workspaceMemberRepository
+            .findByWorkspaceIdAndUserId(command.workspaceId(), command.userId())
+            .orElseThrow(
+                () -> new WorkspaceAccessDeniedException("워크스페이스에 접근 권한이 없습니다."));
+
+    if (member.getMemberRole() != WorkspaceMemberRole.OWNER
+        && member.getMemberRole() != WorkspaceMemberRole.ADMIN) {
+      throw new WorkspaceAccessDeniedException("워크스페이스에 접근 권한이 없습니다.");
+    }
+
+    String newName = command.nameProvided() ? command.name() : workspace.getName();
+    if (command.nameProvided() && newName == null) {
+      throw new WorkspaceInvalidNameException("워크스페이스 이름이 올바르지 않습니다.");
+    }
+
+    String newDescription =
+        command.descriptionProvided() ? command.description() : workspace.getDescription();
+
+    validateUpdateFields(newName, newDescription);
+    workspace.update(newName, newDescription);
+
+    Workspace savedWorkspace = workspaceRepository.save(workspace);
+    return WorkspaceResult.from(savedWorkspace, member);
+  }
+
+  private void validateUpdateFields(String name, String description) {
+    if (name == null || name.isBlank() || name.length() > 255) {
+      throw new WorkspaceInvalidNameException("워크스페이스 이름이 올바르지 않습니다.");
+    }
+    if (description != null && description.length() > 2000) {
+      throw new WorkspaceInvalidDescriptionException("워크스페이스 설명은 2000자를 초과할 수 없습니다.");
+    }
+  }
+}

--- a/backend/src/main/java/com/init/workspace/application/UpdateWorkspaceUseCase.java
+++ b/backend/src/main/java/com/init/workspace/application/UpdateWorkspaceUseCase.java
@@ -20,7 +20,8 @@ public class UpdateWorkspaceUseCase {
   private final WorkspaceMemberRepository workspaceMemberRepository;
 
   public UpdateWorkspaceUseCase(
-      WorkspaceRepository workspaceRepository, WorkspaceMemberRepository workspaceMemberRepository) {
+      WorkspaceRepository workspaceRepository,
+      WorkspaceMemberRepository workspaceMemberRepository) {
     this.workspaceRepository = workspaceRepository;
     this.workspaceMemberRepository = workspaceMemberRepository;
   }
@@ -35,8 +36,7 @@ public class UpdateWorkspaceUseCase {
     WorkspaceMember member =
         workspaceMemberRepository
             .findByWorkspaceIdAndUserId(command.workspaceId(), command.userId())
-            .orElseThrow(
-                () -> new WorkspaceAccessDeniedException("워크스페이스에 접근 권한이 없습니다."));
+            .orElseThrow(() -> new WorkspaceAccessDeniedException("워크스페이스에 접근 권한이 없습니다."));
 
     if (member.getMemberRole() != WorkspaceMemberRole.OWNER
         && member.getMemberRole() != WorkspaceMemberRole.ADMIN) {

--- a/backend/src/main/java/com/init/workspace/application/WorkspaceResult.java
+++ b/backend/src/main/java/com/init/workspace/application/WorkspaceResult.java
@@ -1,0 +1,28 @@
+package com.init.workspace.application;
+
+import com.init.workspace.domain.model.Workspace;
+import com.init.workspace.domain.model.WorkspaceMember;
+import java.time.OffsetDateTime;
+
+public record WorkspaceResult(
+    Long workspaceId,
+    String workspaceKey,
+    String name,
+    String description,
+    String status,
+    String myRole,
+    OffsetDateTime createdAt,
+    OffsetDateTime updatedAt) {
+
+  public static WorkspaceResult from(Workspace workspace, WorkspaceMember member) {
+    return new WorkspaceResult(
+        workspace.getId(),
+        workspace.getWorkspaceKey().getValue(),
+        workspace.getName(),
+        workspace.getDescription(),
+        workspace.getStatus().name(),
+        member.getMemberRole().name(),
+        workspace.getCreatedAt(),
+        workspace.getUpdatedAt());
+  }
+}

--- a/backend/src/main/java/com/init/workspace/application/exception/WorkspaceAccessDeniedException.java
+++ b/backend/src/main/java/com/init/workspace/application/exception/WorkspaceAccessDeniedException.java
@@ -1,0 +1,9 @@
+package com.init.workspace.application.exception;
+
+import com.init.shared.application.exception.UnauthorizedException;
+
+public class WorkspaceAccessDeniedException extends UnauthorizedException {
+  public WorkspaceAccessDeniedException(String message) {
+    super("WORKSPACE_ACCESS_DENIED", message);
+  }
+}

--- a/backend/src/main/java/com/init/workspace/application/exception/WorkspaceInvalidDescriptionException.java
+++ b/backend/src/main/java/com/init/workspace/application/exception/WorkspaceInvalidDescriptionException.java
@@ -1,0 +1,9 @@
+package com.init.workspace.application.exception;
+
+import com.init.shared.application.exception.BadRequestException;
+
+public class WorkspaceInvalidDescriptionException extends BadRequestException {
+  public WorkspaceInvalidDescriptionException(String message) {
+    super("WORKSPACE_INVALID_DESCRIPTION", message);
+  }
+}

--- a/backend/src/main/java/com/init/workspace/application/exception/WorkspaceInvalidKeyException.java
+++ b/backend/src/main/java/com/init/workspace/application/exception/WorkspaceInvalidKeyException.java
@@ -1,0 +1,9 @@
+package com.init.workspace.application.exception;
+
+import com.init.shared.application.exception.BadRequestException;
+
+public class WorkspaceInvalidKeyException extends BadRequestException {
+  public WorkspaceInvalidKeyException(String message) {
+    super("WORKSPACE_INVALID_KEY", message);
+  }
+}

--- a/backend/src/main/java/com/init/workspace/application/exception/WorkspaceInvalidNameException.java
+++ b/backend/src/main/java/com/init/workspace/application/exception/WorkspaceInvalidNameException.java
@@ -1,0 +1,9 @@
+package com.init.workspace.application.exception;
+
+import com.init.shared.application.exception.BadRequestException;
+
+public class WorkspaceInvalidNameException extends BadRequestException {
+  public WorkspaceInvalidNameException(String message) {
+    super("WORKSPACE_INVALID_NAME", message);
+  }
+}

--- a/backend/src/main/java/com/init/workspace/application/exception/WorkspaceKeyAlreadyExistsException.java
+++ b/backend/src/main/java/com/init/workspace/application/exception/WorkspaceKeyAlreadyExistsException.java
@@ -1,0 +1,14 @@
+package com.init.workspace.application.exception;
+
+import com.init.shared.application.exception.DuplicateException;
+
+public class WorkspaceKeyAlreadyExistsException extends DuplicateException {
+  public WorkspaceKeyAlreadyExistsException(String message) {
+    super("WORKSPACE_KEY_CONFLICT", message);
+  }
+
+  public WorkspaceKeyAlreadyExistsException(String message, Throwable cause) {
+    super("WORKSPACE_KEY_CONFLICT", message);
+    initCause(cause);
+  }
+}

--- a/backend/src/main/java/com/init/workspace/application/exception/WorkspaceNotFoundException.java
+++ b/backend/src/main/java/com/init/workspace/application/exception/WorkspaceNotFoundException.java
@@ -1,0 +1,9 @@
+package com.init.workspace.application.exception;
+
+import com.init.shared.application.exception.NotFoundException;
+
+public class WorkspaceNotFoundException extends NotFoundException {
+  public WorkspaceNotFoundException(String message) {
+    super("WORKSPACE_NOT_FOUND", message);
+  }
+}

--- a/backend/src/main/java/com/init/workspace/application/package-info.java
+++ b/backend/src/main/java/com/init/workspace/application/package-info.java
@@ -1,0 +1,1 @@
+package com.init.workspace.application;

--- a/backend/src/main/java/com/init/workspace/domain/model/Workspace.java
+++ b/backend/src/main/java/com/init/workspace/domain/model/Workspace.java
@@ -21,14 +21,12 @@ public class Workspace {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @Embedded
-  private WorkspaceKey workspaceKey;
+  @Embedded private WorkspaceKey workspaceKey;
 
   @Column(nullable = false)
   private String name;
 
-  @Column
-  private String description;
+  @Column private String description;
 
   @Enumerated(EnumType.STRING)
   @Column(nullable = false)

--- a/backend/src/main/java/com/init/workspace/domain/model/Workspace.java
+++ b/backend/src/main/java/com/init/workspace/domain/model/Workspace.java
@@ -1,0 +1,128 @@
+package com.init.workspace.domain.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "workspace", schema = "app")
+public class Workspace {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Embedded
+  private WorkspaceKey workspaceKey;
+
+  @Column(nullable = false)
+  private String name;
+
+  @Column
+  private String description;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private WorkspaceStatus status;
+
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private OffsetDateTime createdAt;
+
+  @Column(name = "updated_at", nullable = false)
+  private OffsetDateTime updatedAt;
+
+  protected Workspace() {}
+
+  public static Workspace create(WorkspaceKey workspaceKey, String name, String description) {
+    if (workspaceKey == null) {
+      throw new IllegalArgumentException("workspaceKey must not be null");
+    }
+    validateName(name);
+    validateDescription(description);
+
+    Workspace workspace = new Workspace();
+    workspace.workspaceKey = workspaceKey;
+    workspace.name = name;
+    workspace.description = description;
+    workspace.status = WorkspaceStatus.ACTIVE;
+    return workspace;
+  }
+
+  public void update(String name, String description) {
+    validateName(name);
+    validateDescription(description);
+    this.name = name;
+    this.description = description;
+  }
+
+  public void archive() {
+    if (status == WorkspaceStatus.ARCHIVED) {
+      throw new IllegalStateException("이미 보관된 워크스페이스입니다.");
+    }
+    this.status = WorkspaceStatus.ARCHIVED;
+  }
+
+  @PrePersist
+  protected void onPersist() {
+    OffsetDateTime now = OffsetDateTime.now();
+    this.createdAt = now;
+    this.updatedAt = now;
+  }
+
+  @PreUpdate
+  protected void onUpdate() {
+    this.updatedAt = OffsetDateTime.now();
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public WorkspaceKey getWorkspaceKey() {
+    return workspaceKey;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public WorkspaceStatus getStatus() {
+    return status;
+  }
+
+  public OffsetDateTime getCreatedAt() {
+    return createdAt;
+  }
+
+  public OffsetDateTime getUpdatedAt() {
+    return updatedAt;
+  }
+
+  private static void validateName(String name) {
+    if (name == null || name.isBlank()) {
+      throw new IllegalArgumentException("name must not be null or blank");
+    }
+    if (name.length() > 255) {
+      throw new IllegalArgumentException("name must not exceed 255 characters");
+    }
+  }
+
+  private static void validateDescription(String description) {
+    if (description != null && description.length() > 2000) {
+      throw new IllegalArgumentException("description must not exceed 2000 characters");
+    }
+  }
+}

--- a/backend/src/main/java/com/init/workspace/domain/model/WorkspaceKey.java
+++ b/backend/src/main/java/com/init/workspace/domain/model/WorkspaceKey.java
@@ -1,0 +1,63 @@
+package com.init.workspace.domain.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+@Embeddable
+public class WorkspaceKey {
+
+  private static final int MIN_LENGTH = 3;
+  private static final int MAX_LENGTH = 100;
+  private static final Pattern PATTERN =
+      Pattern.compile("^[a-z0-9]([a-z0-9-]*[a-z0-9])?$");
+
+  @Column(name = "workspace_key", nullable = false, unique = true, length = 100)
+  private String value;
+
+  protected WorkspaceKey() {}
+
+  private WorkspaceKey(String value) {
+    validate(value);
+    this.value = value;
+  }
+
+  public static WorkspaceKey of(String value) {
+    return new WorkspaceKey(value);
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  private static void validate(String value) {
+    if (value == null || value.isBlank()) {
+      throw new IllegalArgumentException("workspaceKey must not be null or blank");
+    }
+    if (value.length() < MIN_LENGTH || value.length() > MAX_LENGTH) {
+      throw new IllegalArgumentException(
+          "workspaceKey length must be between " + MIN_LENGTH + " and " + MAX_LENGTH);
+    }
+    if (!PATTERN.matcher(value).matches()) {
+      throw new IllegalArgumentException(
+          "workspaceKey must match pattern " + PATTERN.pattern());
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof WorkspaceKey that)) {
+      return false;
+    }
+    return Objects.equals(value, that.value);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(value);
+  }
+}

--- a/backend/src/main/java/com/init/workspace/domain/model/WorkspaceKey.java
+++ b/backend/src/main/java/com/init/workspace/domain/model/WorkspaceKey.java
@@ -10,8 +10,7 @@ public class WorkspaceKey {
 
   private static final int MIN_LENGTH = 3;
   private static final int MAX_LENGTH = 100;
-  private static final Pattern PATTERN =
-      Pattern.compile("^[a-z0-9]([a-z0-9-]*[a-z0-9])?$");
+  private static final Pattern PATTERN = Pattern.compile("^[a-z0-9]([a-z0-9-]*[a-z0-9])?$");
 
   @Column(name = "workspace_key", nullable = false, unique = true, length = 100)
   private String value;
@@ -40,8 +39,7 @@ public class WorkspaceKey {
           "workspaceKey length must be between " + MIN_LENGTH + " and " + MAX_LENGTH);
     }
     if (!PATTERN.matcher(value).matches()) {
-      throw new IllegalArgumentException(
-          "workspaceKey must match pattern " + PATTERN.pattern());
+      throw new IllegalArgumentException("workspaceKey must match pattern " + PATTERN.pattern());
     }
   }
 

--- a/backend/src/main/java/com/init/workspace/domain/model/WorkspaceMember.java
+++ b/backend/src/main/java/com/init/workspace/domain/model/WorkspaceMember.java
@@ -34,7 +34,8 @@ public class WorkspaceMember {
 
   protected WorkspaceMember() {}
 
-  public static WorkspaceMember create(Long workspaceId, Long userId, WorkspaceMemberRole memberRole) {
+  public static WorkspaceMember create(
+      Long workspaceId, Long userId, WorkspaceMemberRole memberRole) {
     if (workspaceId == null) {
       throw new IllegalArgumentException("workspaceId must not be null");
     }

--- a/backend/src/main/java/com/init/workspace/domain/model/WorkspaceMember.java
+++ b/backend/src/main/java/com/init/workspace/domain/model/WorkspaceMember.java
@@ -1,0 +1,79 @@
+package com.init.workspace.domain.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "workspace_member", schema = "app")
+public class WorkspaceMember {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "workspace_id", nullable = false)
+  private Long workspaceId;
+
+  @Column(name = "user_id", nullable = false)
+  private Long userId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "member_role", nullable = false)
+  private WorkspaceMemberRole memberRole;
+
+  @Column(name = "joined_at", nullable = false, updatable = false)
+  private OffsetDateTime joinedAt;
+
+  protected WorkspaceMember() {}
+
+  public static WorkspaceMember create(Long workspaceId, Long userId, WorkspaceMemberRole memberRole) {
+    if (workspaceId == null) {
+      throw new IllegalArgumentException("workspaceId must not be null");
+    }
+    if (userId == null) {
+      throw new IllegalArgumentException("userId must not be null");
+    }
+    if (memberRole == null) {
+      throw new IllegalArgumentException("memberRole must not be null");
+    }
+
+    WorkspaceMember member = new WorkspaceMember();
+    member.workspaceId = workspaceId;
+    member.userId = userId;
+    member.memberRole = memberRole;
+    return member;
+  }
+
+  @PrePersist
+  protected void onPersist() {
+    this.joinedAt = OffsetDateTime.now();
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public Long getWorkspaceId() {
+    return workspaceId;
+  }
+
+  public Long getUserId() {
+    return userId;
+  }
+
+  public WorkspaceMemberRole getMemberRole() {
+    return memberRole;
+  }
+
+  public OffsetDateTime getJoinedAt() {
+    return joinedAt;
+  }
+}

--- a/backend/src/main/java/com/init/workspace/domain/model/WorkspaceMemberRole.java
+++ b/backend/src/main/java/com/init/workspace/domain/model/WorkspaceMemberRole.java
@@ -1,0 +1,8 @@
+package com.init.workspace.domain.model;
+
+public enum WorkspaceMemberRole {
+  OWNER,
+  ADMIN,
+  REVIEWER,
+  OPERATOR
+}

--- a/backend/src/main/java/com/init/workspace/domain/model/WorkspaceStatus.java
+++ b/backend/src/main/java/com/init/workspace/domain/model/WorkspaceStatus.java
@@ -1,0 +1,6 @@
+package com.init.workspace.domain.model;
+
+public enum WorkspaceStatus {
+  ACTIVE,
+  ARCHIVED
+}

--- a/backend/src/main/java/com/init/workspace/domain/package-info.java
+++ b/backend/src/main/java/com/init/workspace/domain/package-info.java
@@ -1,0 +1,1 @@
+package com.init.workspace.domain;

--- a/backend/src/main/java/com/init/workspace/domain/repository/WorkspaceMemberRepository.java
+++ b/backend/src/main/java/com/init/workspace/domain/repository/WorkspaceMemberRepository.java
@@ -1,0 +1,13 @@
+package com.init.workspace.domain.repository;
+
+import com.init.workspace.domain.model.WorkspaceMember;
+import java.util.List;
+import java.util.Optional;
+
+public interface WorkspaceMemberRepository {
+  WorkspaceMember save(WorkspaceMember member);
+
+  List<WorkspaceMember> findByUserId(Long userId);
+
+  Optional<WorkspaceMember> findByWorkspaceIdAndUserId(Long workspaceId, Long userId);
+}

--- a/backend/src/main/java/com/init/workspace/domain/repository/WorkspaceMemberRepository.java
+++ b/backend/src/main/java/com/init/workspace/domain/repository/WorkspaceMemberRepository.java
@@ -1,13 +1,14 @@
 package com.init.workspace.domain.repository;
 
 import com.init.workspace.domain.model.WorkspaceMember;
-import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 public interface WorkspaceMemberRepository {
   WorkspaceMember save(WorkspaceMember member);
 
-  List<WorkspaceMember> findByUserId(Long userId);
+  Slice<WorkspaceMember> findByUserId(Long userId, Pageable pageable);
 
   Optional<WorkspaceMember> findByWorkspaceIdAndUserId(Long workspaceId, Long userId);
 }

--- a/backend/src/main/java/com/init/workspace/domain/repository/WorkspaceRepository.java
+++ b/backend/src/main/java/com/init/workspace/domain/repository/WorkspaceRepository.java
@@ -1,0 +1,17 @@
+package com.init.workspace.domain.repository;
+
+import com.init.workspace.domain.model.Workspace;
+import com.init.workspace.domain.model.WorkspaceKey;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+public interface WorkspaceRepository {
+  boolean existsByWorkspaceKey(WorkspaceKey workspaceKey);
+
+  Workspace save(Workspace workspace);
+
+  Optional<Workspace> findById(Long id);
+
+  List<Workspace> findAllByIdIn(Collection<Long> ids);
+}

--- a/backend/src/main/java/com/init/workspace/infrastructure/package-info.java
+++ b/backend/src/main/java/com/init/workspace/infrastructure/package-info.java
@@ -1,0 +1,1 @@
+package com.init.workspace.infrastructure;

--- a/backend/src/main/java/com/init/workspace/infrastructure/persistence/JpaWorkspaceMemberRepository.java
+++ b/backend/src/main/java/com/init/workspace/infrastructure/persistence/JpaWorkspaceMemberRepository.java
@@ -2,8 +2,9 @@ package com.init.workspace.infrastructure.persistence;
 
 import com.init.workspace.domain.model.WorkspaceMember;
 import com.init.workspace.domain.repository.WorkspaceMemberRepository;
-import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -11,7 +12,12 @@ import org.springframework.stereotype.Repository;
 public interface JpaWorkspaceMemberRepository
     extends JpaRepository<WorkspaceMember, Long>, WorkspaceMemberRepository {
 
-  List<WorkspaceMember> findByUserId(Long userId);
+  Slice<WorkspaceMember> findByUserIdOrderByIdAsc(Long userId, Pageable pageable);
+
+  @Override
+  default Slice<WorkspaceMember> findByUserId(Long userId, Pageable pageable) {
+    return findByUserIdOrderByIdAsc(userId, pageable);
+  }
 
   Optional<WorkspaceMember> findByWorkspaceIdAndUserId(Long workspaceId, Long userId);
 }

--- a/backend/src/main/java/com/init/workspace/infrastructure/persistence/JpaWorkspaceMemberRepository.java
+++ b/backend/src/main/java/com/init/workspace/infrastructure/persistence/JpaWorkspaceMemberRepository.java
@@ -1,0 +1,17 @@
+package com.init.workspace.infrastructure.persistence;
+
+import com.init.workspace.domain.model.WorkspaceMember;
+import com.init.workspace.domain.repository.WorkspaceMemberRepository;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface JpaWorkspaceMemberRepository
+    extends JpaRepository<WorkspaceMember, Long>, WorkspaceMemberRepository {
+
+  List<WorkspaceMember> findByUserId(Long userId);
+
+  Optional<WorkspaceMember> findByWorkspaceIdAndUserId(Long workspaceId, Long userId);
+}

--- a/backend/src/main/java/com/init/workspace/infrastructure/persistence/JpaWorkspaceRepository.java
+++ b/backend/src/main/java/com/init/workspace/infrastructure/persistence/JpaWorkspaceRepository.java
@@ -1,0 +1,17 @@
+package com.init.workspace.infrastructure.persistence;
+
+import com.init.workspace.domain.model.Workspace;
+import com.init.workspace.domain.model.WorkspaceKey;
+import com.init.workspace.domain.repository.WorkspaceRepository;
+import java.util.Collection;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface JpaWorkspaceRepository extends JpaRepository<Workspace, Long>, WorkspaceRepository {
+
+  boolean existsByWorkspaceKey(WorkspaceKey workspaceKey);
+
+  List<Workspace> findAllByIdIn(Collection<Long> ids);
+}

--- a/backend/src/main/java/com/init/workspace/infrastructure/persistence/JpaWorkspaceRepository.java
+++ b/backend/src/main/java/com/init/workspace/infrastructure/persistence/JpaWorkspaceRepository.java
@@ -9,7 +9,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface JpaWorkspaceRepository extends JpaRepository<Workspace, Long>, WorkspaceRepository {
+public interface JpaWorkspaceRepository
+    extends JpaRepository<Workspace, Long>, WorkspaceRepository {
 
   boolean existsByWorkspaceKey(WorkspaceKey workspaceKey);
 

--- a/backend/src/main/java/com/init/workspace/presentation/WorkspaceController.java
+++ b/backend/src/main/java/com/init/workspace/presentation/WorkspaceController.java
@@ -1,0 +1,110 @@
+package com.init.workspace.presentation;
+
+import com.init.workspace.application.ArchiveWorkspaceUseCase;
+import com.init.workspace.application.CreateWorkspaceCommand;
+import com.init.workspace.application.CreateWorkspaceUseCase;
+import com.init.workspace.application.GetWorkspaceListUseCase;
+import com.init.workspace.application.GetWorkspaceUseCase;
+import com.init.workspace.application.UpdateWorkspaceCommand;
+import com.init.workspace.application.UpdateWorkspaceUseCase;
+import com.init.workspace.application.WorkspaceResult;
+import com.init.workspace.presentation.dto.CreateWorkspaceRequest;
+import com.init.workspace.presentation.dto.UpdateWorkspaceRequest;
+import com.init.workspace.presentation.dto.WorkspaceResponse;
+import jakarta.validation.Valid;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/workspaces")
+public class WorkspaceController {
+
+  private final CreateWorkspaceUseCase createWorkspaceUseCase;
+  private final GetWorkspaceListUseCase getWorkspaceListUseCase;
+  private final GetWorkspaceUseCase getWorkspaceUseCase;
+  private final UpdateWorkspaceUseCase updateWorkspaceUseCase;
+  private final ArchiveWorkspaceUseCase archiveWorkspaceUseCase;
+
+  public WorkspaceController(
+      CreateWorkspaceUseCase createWorkspaceUseCase,
+      GetWorkspaceListUseCase getWorkspaceListUseCase,
+      GetWorkspaceUseCase getWorkspaceUseCase,
+      UpdateWorkspaceUseCase updateWorkspaceUseCase,
+      ArchiveWorkspaceUseCase archiveWorkspaceUseCase) {
+    this.createWorkspaceUseCase = createWorkspaceUseCase;
+    this.getWorkspaceListUseCase = getWorkspaceListUseCase;
+    this.getWorkspaceUseCase = getWorkspaceUseCase;
+    this.updateWorkspaceUseCase = updateWorkspaceUseCase;
+    this.archiveWorkspaceUseCase = archiveWorkspaceUseCase;
+  }
+
+  @PostMapping
+  public ResponseEntity<WorkspaceResponse> createWorkspace(
+      @Valid @RequestBody CreateWorkspaceRequest request, Authentication authentication) {
+    Long userId = extractUserId(authentication);
+    WorkspaceResult result =
+        createWorkspaceUseCase.execute(
+            new CreateWorkspaceCommand(
+                request.workspaceKey(), request.name(), request.description(), userId));
+    return ResponseEntity.status(HttpStatus.CREATED).body(WorkspaceResponse.from(result));
+  }
+
+  @GetMapping
+  public ResponseEntity<List<WorkspaceResponse>> listWorkspaces(Authentication authentication) {
+    Long userId = extractUserId(authentication);
+    List<WorkspaceResponse> response =
+        getWorkspaceListUseCase.execute(userId).stream().map(WorkspaceResponse::from).toList();
+    return ResponseEntity.ok(response);
+  }
+
+  @GetMapping("/{id}")
+  public ResponseEntity<WorkspaceResponse> getWorkspace(
+      @PathVariable Long id, Authentication authentication) {
+    Long userId = extractUserId(authentication);
+    return ResponseEntity.ok(WorkspaceResponse.from(getWorkspaceUseCase.execute(id, userId)));
+  }
+
+  @PatchMapping("/{id}")
+  public ResponseEntity<WorkspaceResponse> updateWorkspace(
+      @PathVariable Long id,
+      @RequestBody UpdateWorkspaceRequest request,
+      Authentication authentication) {
+    Long userId = extractUserId(authentication);
+    WorkspaceResult result =
+        updateWorkspaceUseCase.execute(
+            new UpdateWorkspaceCommand(
+                id,
+                userId,
+                request.isNameProvided(),
+                request.getName(),
+                request.isDescriptionProvided(),
+                request.getDescription()));
+    return ResponseEntity.ok(WorkspaceResponse.from(result));
+  }
+
+  @DeleteMapping("/{id}")
+  public ResponseEntity<Void> archiveWorkspace(
+      @PathVariable Long id, Authentication authentication) {
+    Long userId = extractUserId(authentication);
+    archiveWorkspaceUseCase.execute(id, userId);
+    return ResponseEntity.noContent().build();
+  }
+
+  private Long extractUserId(Authentication authentication) {
+    if (authentication == null || !(authentication.getPrincipal() instanceof Long userId)) {
+      throw new AuthenticationCredentialsNotFoundException("인증이 필요합니다.");
+    }
+    return userId;
+  }
+}

--- a/backend/src/main/java/com/init/workspace/presentation/dto/CreateWorkspaceRequest.java
+++ b/backend/src/main/java/com/init/workspace/presentation/dto/CreateWorkspaceRequest.java
@@ -1,0 +1,9 @@
+package com.init.workspace.presentation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CreateWorkspaceRequest(
+    @NotBlank String workspaceKey,
+    @NotBlank @Size(max = 255) String name,
+    @Size(max = 2000) String description) {}

--- a/backend/src/main/java/com/init/workspace/presentation/dto/UpdateWorkspaceRequest.java
+++ b/backend/src/main/java/com/init/workspace/presentation/dto/UpdateWorkspaceRequest.java
@@ -1,0 +1,39 @@
+package com.init.workspace.presentation.dto;
+
+import com.fasterxml.jackson.annotation.JsonSetter;
+
+public class UpdateWorkspaceRequest {
+
+  private boolean nameProvided;
+  private String name;
+  private boolean descriptionProvided;
+  private String description;
+
+  public boolean isNameProvided() {
+    return nameProvided;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public boolean isDescriptionProvided() {
+    return descriptionProvided;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  @JsonSetter("name")
+  public void setName(String name) {
+    this.nameProvided = true;
+    this.name = name;
+  }
+
+  @JsonSetter("description")
+  public void setDescription(String description) {
+    this.descriptionProvided = true;
+    this.description = description;
+  }
+}

--- a/backend/src/main/java/com/init/workspace/presentation/dto/WorkspaceResponse.java
+++ b/backend/src/main/java/com/init/workspace/presentation/dto/WorkspaceResponse.java
@@ -1,0 +1,27 @@
+package com.init.workspace.presentation.dto;
+
+import com.init.workspace.application.WorkspaceResult;
+import java.time.OffsetDateTime;
+
+public record WorkspaceResponse(
+    Long id,
+    String workspaceKey,
+    String name,
+    String description,
+    String status,
+    String myRole,
+    OffsetDateTime createdAt,
+    OffsetDateTime updatedAt) {
+
+  public static WorkspaceResponse from(WorkspaceResult result) {
+    return new WorkspaceResponse(
+        result.workspaceId(),
+        result.workspaceKey(),
+        result.name(),
+        result.description(),
+        result.status(),
+        result.myRole(),
+        result.createdAt(),
+        result.updatedAt());
+  }
+}

--- a/backend/src/main/java/com/init/workspace/presentation/package-info.java
+++ b/backend/src/main/java/com/init/workspace/presentation/package-info.java
@@ -1,0 +1,1 @@
+package com.init.workspace.presentation;

--- a/backend/src/test/java/com/init/workspace/application/ArchiveWorkspaceUseCaseTest.java
+++ b/backend/src/test/java/com/init/workspace/application/ArchiveWorkspaceUseCaseTest.java
@@ -1,16 +1,15 @@
 package com.init.workspace.application;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.BDDMockito.given;
 
 import com.init.workspace.application.exception.WorkspaceAccessDeniedException;
 import com.init.workspace.domain.model.Workspace;
 import com.init.workspace.domain.model.WorkspaceKey;
 import com.init.workspace.domain.model.WorkspaceMember;
 import com.init.workspace.domain.model.WorkspaceMemberRole;
-import com.init.workspace.domain.model.WorkspaceStatus;
 import com.init.workspace.domain.repository.WorkspaceMemberRepository;
 import com.init.workspace.domain.repository.WorkspaceRepository;
 import java.util.Optional;

--- a/backend/src/test/java/com/init/workspace/application/ArchiveWorkspaceUseCaseTest.java
+++ b/backend/src/test/java/com/init/workspace/application/ArchiveWorkspaceUseCaseTest.java
@@ -1,0 +1,80 @@
+package com.init.workspace.application;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.BDDMockito.given;
+
+import com.init.workspace.application.exception.WorkspaceAccessDeniedException;
+import com.init.workspace.domain.model.Workspace;
+import com.init.workspace.domain.model.WorkspaceKey;
+import com.init.workspace.domain.model.WorkspaceMember;
+import com.init.workspace.domain.model.WorkspaceMemberRole;
+import com.init.workspace.domain.model.WorkspaceStatus;
+import com.init.workspace.domain.repository.WorkspaceMemberRepository;
+import com.init.workspace.domain.repository.WorkspaceRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ArchiveWorkspaceUseCase")
+class ArchiveWorkspaceUseCaseTest {
+
+  @Mock private WorkspaceRepository workspaceRepository;
+  @Mock private WorkspaceMemberRepository workspaceMemberRepository;
+
+  private ArchiveWorkspaceUseCase useCase;
+
+  @BeforeEach
+  void setUp() {
+    useCase = new ArchiveWorkspaceUseCase(workspaceRepository, workspaceMemberRepository);
+  }
+
+  @Test
+  @DisplayName("OWNER 삭제 → save 호출")
+  void should_save호출_when_owner삭제() {
+    Workspace workspace = Workspace.create(WorkspaceKey.of("cs-team-alpha"), "CS Team", "desc");
+    ReflectionTestUtils.setField(workspace, "id", 1L);
+    given(workspaceRepository.findById(1L)).willReturn(Optional.of(workspace));
+    given(workspaceMemberRepository.findByWorkspaceIdAndUserId(1L, 7L))
+        .willReturn(Optional.of(WorkspaceMember.create(1L, 7L, WorkspaceMemberRole.OWNER)));
+
+    useCase.execute(1L, 7L);
+
+    verify(workspaceRepository).save(workspace);
+  }
+
+  @Test
+  @DisplayName("이미 ARCHIVED 상태 → save 미호출")
+  void should_save미호출_when_이미Archived() {
+    Workspace workspace = Workspace.create(WorkspaceKey.of("cs-team-alpha"), "CS Team", "desc");
+    workspace.archive();
+    ReflectionTestUtils.setField(workspace, "id", 1L);
+    given(workspaceRepository.findById(1L)).willReturn(Optional.of(workspace));
+    given(workspaceMemberRepository.findByWorkspaceIdAndUserId(1L, 7L))
+        .willReturn(Optional.of(WorkspaceMember.create(1L, 7L, WorkspaceMemberRole.OWNER)));
+
+    useCase.execute(1L, 7L);
+
+    verify(workspaceRepository, never()).save(workspace);
+  }
+
+  @Test
+  @DisplayName("ADMIN 삭제 시도 → WorkspaceAccessDeniedException")
+  void should_WorkspaceAccessDeniedException_when_admin삭제시도() {
+    Workspace workspace = Workspace.create(WorkspaceKey.of("cs-team-alpha"), "CS Team", "desc");
+    ReflectionTestUtils.setField(workspace, "id", 1L);
+    given(workspaceRepository.findById(1L)).willReturn(Optional.of(workspace));
+    given(workspaceMemberRepository.findByWorkspaceIdAndUserId(1L, 7L))
+        .willReturn(Optional.of(WorkspaceMember.create(1L, 7L, WorkspaceMemberRole.ADMIN)));
+
+    assertThatThrownBy(() -> useCase.execute(1L, 7L))
+        .isInstanceOf(WorkspaceAccessDeniedException.class);
+  }
+}

--- a/backend/src/test/java/com/init/workspace/application/CreateWorkspaceUseCaseTest.java
+++ b/backend/src/test/java/com/init/workspace/application/CreateWorkspaceUseCaseTest.java
@@ -1,0 +1,101 @@
+package com.init.workspace.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.init.workspace.application.exception.WorkspaceInvalidKeyException;
+import com.init.workspace.application.exception.WorkspaceKeyAlreadyExistsException;
+import com.init.workspace.domain.model.Workspace;
+import com.init.workspace.domain.model.WorkspaceKey;
+import com.init.workspace.domain.model.WorkspaceMember;
+import com.init.workspace.domain.model.WorkspaceMemberRole;
+import com.init.workspace.domain.repository.WorkspaceMemberRepository;
+import com.init.workspace.domain.repository.WorkspaceRepository;
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CreateWorkspaceUseCase")
+class CreateWorkspaceUseCaseTest {
+
+  @Mock private WorkspaceRepository workspaceRepository;
+  @Mock private WorkspaceMemberRepository workspaceMemberRepository;
+
+  private CreateWorkspaceUseCase useCase;
+
+  @BeforeEach
+  void setUp() {
+    useCase = new CreateWorkspaceUseCase(workspaceRepository, workspaceMemberRepository);
+  }
+
+  @Test
+  @DisplayName("정상 요청 → workspace와 OWNER 멤버 저장")
+  void should_workspace와Owner멤버저장_when_정상요청() {
+    Workspace workspace = buildWorkspace(1L, "cs-team-alpha", "CS Team", "desc");
+    WorkspaceMember member = buildMember(1L, 7L, WorkspaceMemberRole.OWNER);
+    given(workspaceRepository.existsByWorkspaceKey(any())).willReturn(false);
+    given(workspaceRepository.save(any())).willReturn(workspace);
+    given(workspaceMemberRepository.save(any())).willReturn(member);
+
+    WorkspaceResult result =
+        useCase.execute(new CreateWorkspaceCommand("cs-team-alpha", "CS Team", "desc", 7L));
+
+    assertThat(result.workspaceId()).isEqualTo(1L);
+    assertThat(result.myRole()).isEqualTo("OWNER");
+    verify(workspaceRepository).save(any());
+    verify(workspaceMemberRepository).save(any());
+  }
+
+  @Test
+  @DisplayName("중복 key 사전 확인 → WorkspaceKeyAlreadyExistsException")
+  void should_WorkspaceKeyAlreadyExistsException_when_existsByKeyTrue() {
+    given(workspaceRepository.existsByWorkspaceKey(any())).willReturn(true);
+
+    assertThatThrownBy(
+            () -> useCase.execute(new CreateWorkspaceCommand("cs-team-alpha", "CS Team", null, 7L)))
+        .isInstanceOf(WorkspaceKeyAlreadyExistsException.class);
+  }
+
+  @Test
+  @DisplayName("잘못된 key 형식 → WorkspaceInvalidKeyException")
+  void should_WorkspaceInvalidKeyException_when_key형식위반() {
+    assertThatThrownBy(() -> useCase.execute(new CreateWorkspaceCommand("BAD_KEY", "CS Team", null, 7L)))
+        .isInstanceOf(WorkspaceInvalidKeyException.class);
+  }
+
+  @Test
+  @DisplayName("저장 시 unique 충돌 → WorkspaceKeyAlreadyExistsException")
+  void should_WorkspaceKeyAlreadyExistsException_when_save시DataIntegrityViolation() {
+    given(workspaceRepository.existsByWorkspaceKey(any())).willReturn(false);
+    given(workspaceRepository.save(any()))
+        .willThrow(new DataIntegrityViolationException("duplicate key value violates workspace_key"));
+
+    assertThatThrownBy(
+            () -> useCase.execute(new CreateWorkspaceCommand("cs-team-alpha", "CS Team", null, 7L)))
+        .isInstanceOf(WorkspaceKeyAlreadyExistsException.class);
+  }
+
+  private Workspace buildWorkspace(Long id, String key, String name, String description) {
+    Workspace workspace = Workspace.create(WorkspaceKey.of(key), name, description);
+    ReflectionTestUtils.setField(workspace, "id", id);
+    ReflectionTestUtils.setField(workspace, "createdAt", OffsetDateTime.parse("2026-04-14T00:00:00Z"));
+    ReflectionTestUtils.setField(workspace, "updatedAt", OffsetDateTime.parse("2026-04-14T00:00:00Z"));
+    return workspace;
+  }
+
+  private WorkspaceMember buildMember(Long workspaceId, Long userId, WorkspaceMemberRole role) {
+    WorkspaceMember member = WorkspaceMember.create(workspaceId, userId, role);
+    ReflectionTestUtils.setField(member, "id", 1L);
+    return member;
+  }
+}

--- a/backend/src/test/java/com/init/workspace/application/CreateWorkspaceUseCaseTest.java
+++ b/backend/src/test/java/com/init/workspace/application/CreateWorkspaceUseCaseTest.java
@@ -69,7 +69,8 @@ class CreateWorkspaceUseCaseTest {
   @Test
   @DisplayName("잘못된 key 형식 → WorkspaceInvalidKeyException")
   void should_WorkspaceInvalidKeyException_when_key형식위반() {
-    assertThatThrownBy(() -> useCase.execute(new CreateWorkspaceCommand("BAD_KEY", "CS Team", null, 7L)))
+    assertThatThrownBy(
+            () -> useCase.execute(new CreateWorkspaceCommand("BAD_KEY", "CS Team", null, 7L)))
         .isInstanceOf(WorkspaceInvalidKeyException.class);
   }
 
@@ -78,7 +79,8 @@ class CreateWorkspaceUseCaseTest {
   void should_WorkspaceKeyAlreadyExistsException_when_save시DataIntegrityViolation() {
     given(workspaceRepository.existsByWorkspaceKey(any())).willReturn(false);
     given(workspaceRepository.save(any()))
-        .willThrow(new DataIntegrityViolationException("duplicate key value violates workspace_key"));
+        .willThrow(
+            new DataIntegrityViolationException("duplicate key value violates workspace_key"));
 
     assertThatThrownBy(
             () -> useCase.execute(new CreateWorkspaceCommand("cs-team-alpha", "CS Team", null, 7L)))
@@ -88,8 +90,10 @@ class CreateWorkspaceUseCaseTest {
   private Workspace buildWorkspace(Long id, String key, String name, String description) {
     Workspace workspace = Workspace.create(WorkspaceKey.of(key), name, description);
     ReflectionTestUtils.setField(workspace, "id", id);
-    ReflectionTestUtils.setField(workspace, "createdAt", OffsetDateTime.parse("2026-04-14T00:00:00Z"));
-    ReflectionTestUtils.setField(workspace, "updatedAt", OffsetDateTime.parse("2026-04-14T00:00:00Z"));
+    ReflectionTestUtils.setField(
+        workspace, "createdAt", OffsetDateTime.parse("2026-04-14T00:00:00Z"));
+    ReflectionTestUtils.setField(
+        workspace, "updatedAt", OffsetDateTime.parse("2026-04-14T00:00:00Z"));
     return workspace;
   }
 

--- a/backend/src/test/java/com/init/workspace/application/GetWorkspaceListUseCaseTest.java
+++ b/backend/src/test/java/com/init/workspace/application/GetWorkspaceListUseCaseTest.java
@@ -1,0 +1,93 @@
+package com.init.workspace.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+import com.init.workspace.domain.model.Workspace;
+import com.init.workspace.domain.model.WorkspaceKey;
+import com.init.workspace.domain.model.WorkspaceMember;
+import com.init.workspace.domain.model.WorkspaceMemberRole;
+import com.init.workspace.domain.repository.WorkspaceMemberRepository;
+import com.init.workspace.domain.repository.WorkspaceRepository;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetWorkspaceListUseCase")
+class GetWorkspaceListUseCaseTest {
+
+  @Mock private WorkspaceMemberRepository workspaceMemberRepository;
+  @Mock private WorkspaceRepository workspaceRepository;
+
+  private GetWorkspaceListUseCase useCase;
+
+  @BeforeEach
+  void setUp() {
+    useCase = new GetWorkspaceListUseCase(workspaceMemberRepository, workspaceRepository);
+  }
+
+  @Test
+  @DisplayName("멤버십이 없으면 빈 목록 반환")
+  void should_returnEmptyList_when_noMemberships() {
+    given(workspaceMemberRepository.findByUserId(eq(7L), any()))
+        .willReturn(new SliceImpl<>(List.of(), PageRequest.of(0, 100), false));
+
+    List<WorkspaceResult> result = useCase.execute(7L);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  @DisplayName("멤버십이 여러 페이지면 모두 조회")
+  void should_returnAllWorkspaces_when_membershipsSpanMultiplePages() {
+    WorkspaceMember firstMembership = buildMember(1L, 7L, WorkspaceMemberRole.OWNER);
+    WorkspaceMember secondMembership = buildMember(2L, 7L, WorkspaceMemberRole.ADMIN);
+    Slice<WorkspaceMember> firstPage =
+        new SliceImpl<>(List.of(firstMembership), PageRequest.of(0, 100), true);
+    Slice<WorkspaceMember> secondPage =
+        new SliceImpl<>(List.of(secondMembership), PageRequest.of(1, 100), false);
+
+    given(workspaceMemberRepository.findByUserId(7L, PageRequest.of(0, 100))).willReturn(firstPage);
+    given(workspaceMemberRepository.findByUserId(7L, PageRequest.of(1, 100)))
+        .willReturn(secondPage);
+    given(workspaceRepository.findAllByIdIn(List.of(1L)))
+        .willReturn(List.of(buildWorkspace(1L, "cs-team-alpha", "Alpha")));
+    given(workspaceRepository.findAllByIdIn(List.of(2L)))
+        .willReturn(List.of(buildWorkspace(2L, "cs-team-beta", "Beta")));
+
+    List<WorkspaceResult> result = useCase.execute(7L);
+
+    assertThat(result).hasSize(2);
+    assertThat(result).extracting(WorkspaceResult::workspaceId).containsExactly(1L, 2L);
+    assertThat(result).extracting(WorkspaceResult::myRole).containsExactly("OWNER", "ADMIN");
+  }
+
+  private Workspace buildWorkspace(Long id, String key, String name) {
+    Workspace workspace = Workspace.create(WorkspaceKey.of(key), name, null);
+    ReflectionTestUtils.setField(workspace, "id", id);
+    ReflectionTestUtils.setField(
+        workspace, "createdAt", OffsetDateTime.parse("2026-04-14T00:00:00Z"));
+    ReflectionTestUtils.setField(
+        workspace, "updatedAt", OffsetDateTime.parse("2026-04-14T00:00:00Z"));
+    return workspace;
+  }
+
+  private WorkspaceMember buildMember(Long workspaceId, Long userId, WorkspaceMemberRole role) {
+    WorkspaceMember member = WorkspaceMember.create(workspaceId, userId, role);
+    ReflectionTestUtils.setField(member, "id", workspaceId);
+    ReflectionTestUtils.setField(member, "joinedAt", OffsetDateTime.parse("2026-04-14T00:00:00Z"));
+    return member;
+  }
+}

--- a/backend/src/test/java/com/init/workspace/application/GetWorkspaceUseCaseTest.java
+++ b/backend/src/test/java/com/init/workspace/application/GetWorkspaceUseCaseTest.java
@@ -1,0 +1,80 @@
+package com.init.workspace.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import com.init.workspace.application.exception.WorkspaceAccessDeniedException;
+import com.init.workspace.application.exception.WorkspaceNotFoundException;
+import com.init.workspace.domain.model.Workspace;
+import com.init.workspace.domain.model.WorkspaceKey;
+import com.init.workspace.domain.model.WorkspaceMember;
+import com.init.workspace.domain.model.WorkspaceMemberRole;
+import com.init.workspace.domain.repository.WorkspaceMemberRepository;
+import com.init.workspace.domain.repository.WorkspaceRepository;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetWorkspaceUseCase")
+class GetWorkspaceUseCaseTest {
+
+  @Mock private WorkspaceRepository workspaceRepository;
+  @Mock private WorkspaceMemberRepository workspaceMemberRepository;
+
+  private GetWorkspaceUseCase useCase;
+
+  @BeforeEach
+  void setUp() {
+    useCase = new GetWorkspaceUseCase(workspaceRepository, workspaceMemberRepository);
+  }
+
+  @Test
+  @DisplayName("멤버인 사용자 → workspace 반환")
+  void should_workspace반환_when_멤버인사용자() {
+    Workspace workspace = buildWorkspace();
+    WorkspaceMember member = WorkspaceMember.create(1L, 7L, WorkspaceMemberRole.ADMIN);
+    given(workspaceRepository.findById(1L)).willReturn(Optional.of(workspace));
+    given(workspaceMemberRepository.findByWorkspaceIdAndUserId(1L, 7L))
+        .willReturn(Optional.of(member));
+
+    WorkspaceResult result = useCase.execute(1L, 7L);
+
+    assertThat(result.workspaceId()).isEqualTo(1L);
+    assertThat(result.myRole()).isEqualTo("ADMIN");
+  }
+
+  @Test
+  @DisplayName("workspace 없음 → WorkspaceNotFoundException")
+  void should_WorkspaceNotFoundException_when_workspace없음() {
+    given(workspaceRepository.findById(1L)).willReturn(Optional.empty());
+
+    assertThatThrownBy(() -> useCase.execute(1L, 7L)).isInstanceOf(WorkspaceNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("멤버 아님 → WorkspaceAccessDeniedException")
+  void should_WorkspaceAccessDeniedException_when_멤버아님() {
+    given(workspaceRepository.findById(1L)).willReturn(Optional.of(buildWorkspace()));
+    given(workspaceMemberRepository.findByWorkspaceIdAndUserId(1L, 7L))
+        .willReturn(Optional.empty());
+
+    assertThatThrownBy(() -> useCase.execute(1L, 7L))
+        .isInstanceOf(WorkspaceAccessDeniedException.class);
+  }
+
+  private Workspace buildWorkspace() {
+    Workspace workspace = Workspace.create(WorkspaceKey.of("cs-team-alpha"), "CS Team", "desc");
+    ReflectionTestUtils.setField(workspace, "id", 1L);
+    ReflectionTestUtils.setField(workspace, "createdAt", OffsetDateTime.parse("2026-04-14T00:00:00Z"));
+    ReflectionTestUtils.setField(workspace, "updatedAt", OffsetDateTime.parse("2026-04-14T00:00:00Z"));
+    return workspace;
+  }
+}

--- a/backend/src/test/java/com/init/workspace/application/GetWorkspaceUseCaseTest.java
+++ b/backend/src/test/java/com/init/workspace/application/GetWorkspaceUseCaseTest.java
@@ -56,7 +56,8 @@ class GetWorkspaceUseCaseTest {
   void should_WorkspaceNotFoundException_when_workspace없음() {
     given(workspaceRepository.findById(1L)).willReturn(Optional.empty());
 
-    assertThatThrownBy(() -> useCase.execute(1L, 7L)).isInstanceOf(WorkspaceNotFoundException.class);
+    assertThatThrownBy(() -> useCase.execute(1L, 7L))
+        .isInstanceOf(WorkspaceNotFoundException.class);
   }
 
   @Test
@@ -73,8 +74,10 @@ class GetWorkspaceUseCaseTest {
   private Workspace buildWorkspace() {
     Workspace workspace = Workspace.create(WorkspaceKey.of("cs-team-alpha"), "CS Team", "desc");
     ReflectionTestUtils.setField(workspace, "id", 1L);
-    ReflectionTestUtils.setField(workspace, "createdAt", OffsetDateTime.parse("2026-04-14T00:00:00Z"));
-    ReflectionTestUtils.setField(workspace, "updatedAt", OffsetDateTime.parse("2026-04-14T00:00:00Z"));
+    ReflectionTestUtils.setField(
+        workspace, "createdAt", OffsetDateTime.parse("2026-04-14T00:00:00Z"));
+    ReflectionTestUtils.setField(
+        workspace, "updatedAt", OffsetDateTime.parse("2026-04-14T00:00:00Z"));
     return workspace;
   }
 }

--- a/backend/src/test/java/com/init/workspace/application/UpdateWorkspaceUseCaseTest.java
+++ b/backend/src/test/java/com/init/workspace/application/UpdateWorkspaceUseCaseTest.java
@@ -73,18 +73,21 @@ class UpdateWorkspaceUseCaseTest {
   @Test
   @DisplayName("name null 명시 전달 → WorkspaceInvalidNameException")
   void should_WorkspaceInvalidNameException_when_nameNull전달() {
-    given(workspaceRepository.findById(1L)).willReturn(Optional.of(buildWorkspace("Old Name", "old")));
+    given(workspaceRepository.findById(1L))
+        .willReturn(Optional.of(buildWorkspace("Old Name", "old")));
     given(workspaceMemberRepository.findByWorkspaceIdAndUserId(1L, 7L))
         .willReturn(Optional.of(WorkspaceMember.create(1L, 7L, WorkspaceMemberRole.OWNER)));
 
-    assertThatThrownBy(() -> useCase.execute(new UpdateWorkspaceCommand(1L, 7L, true, null, false, null)))
+    assertThatThrownBy(
+            () -> useCase.execute(new UpdateWorkspaceCommand(1L, 7L, true, null, false, null)))
         .isInstanceOf(WorkspaceInvalidNameException.class);
   }
 
   @Test
   @DisplayName("description 2000자 초과 → WorkspaceInvalidDescriptionException")
   void should_WorkspaceInvalidDescriptionException_when_description길이초과() {
-    given(workspaceRepository.findById(1L)).willReturn(Optional.of(buildWorkspace("Old Name", "old")));
+    given(workspaceRepository.findById(1L))
+        .willReturn(Optional.of(buildWorkspace("Old Name", "old")));
     given(workspaceMemberRepository.findByWorkspaceIdAndUserId(1L, 7L))
         .willReturn(Optional.of(WorkspaceMember.create(1L, 7L, WorkspaceMemberRole.OWNER)));
 
@@ -98,20 +101,24 @@ class UpdateWorkspaceUseCaseTest {
   @Test
   @DisplayName("REVIEWER 수정 시도 → WorkspaceAccessDeniedException")
   void should_WorkspaceAccessDeniedException_when_reviewer() {
-    given(workspaceRepository.findById(1L)).willReturn(Optional.of(buildWorkspace("Old Name", "old")));
+    given(workspaceRepository.findById(1L))
+        .willReturn(Optional.of(buildWorkspace("Old Name", "old")));
     given(workspaceMemberRepository.findByWorkspaceIdAndUserId(1L, 7L))
         .willReturn(Optional.of(WorkspaceMember.create(1L, 7L, WorkspaceMemberRole.REVIEWER)));
 
     assertThatThrownBy(
-            () -> useCase.execute(new UpdateWorkspaceCommand(1L, 7L, true, "New Name", false, null)))
+            () ->
+                useCase.execute(new UpdateWorkspaceCommand(1L, 7L, true, "New Name", false, null)))
         .isInstanceOf(WorkspaceAccessDeniedException.class);
   }
 
   private Workspace buildWorkspace(String name, String description) {
     Workspace workspace = Workspace.create(WorkspaceKey.of("cs-team-alpha"), name, description);
     ReflectionTestUtils.setField(workspace, "id", 1L);
-    ReflectionTestUtils.setField(workspace, "createdAt", OffsetDateTime.parse("2026-04-14T00:00:00Z"));
-    ReflectionTestUtils.setField(workspace, "updatedAt", OffsetDateTime.parse("2026-04-14T00:00:00Z"));
+    ReflectionTestUtils.setField(
+        workspace, "createdAt", OffsetDateTime.parse("2026-04-14T00:00:00Z"));
+    ReflectionTestUtils.setField(
+        workspace, "updatedAt", OffsetDateTime.parse("2026-04-14T00:00:00Z"));
     return workspace;
   }
 }

--- a/backend/src/test/java/com/init/workspace/application/UpdateWorkspaceUseCaseTest.java
+++ b/backend/src/test/java/com/init/workspace/application/UpdateWorkspaceUseCaseTest.java
@@ -1,0 +1,117 @@
+package com.init.workspace.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import com.init.workspace.application.exception.WorkspaceAccessDeniedException;
+import com.init.workspace.application.exception.WorkspaceInvalidDescriptionException;
+import com.init.workspace.application.exception.WorkspaceInvalidNameException;
+import com.init.workspace.domain.model.Workspace;
+import com.init.workspace.domain.model.WorkspaceKey;
+import com.init.workspace.domain.model.WorkspaceMember;
+import com.init.workspace.domain.model.WorkspaceMemberRole;
+import com.init.workspace.domain.repository.WorkspaceMemberRepository;
+import com.init.workspace.domain.repository.WorkspaceRepository;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UpdateWorkspaceUseCase")
+class UpdateWorkspaceUseCaseTest {
+
+  @Mock private WorkspaceRepository workspaceRepository;
+  @Mock private WorkspaceMemberRepository workspaceMemberRepository;
+
+  private UpdateWorkspaceUseCase useCase;
+
+  @BeforeEach
+  void setUp() {
+    useCase = new UpdateWorkspaceUseCase(workspaceRepository, workspaceMemberRepository);
+  }
+
+  @Test
+  @DisplayName("OWNER 수정 → name과 description 변경")
+  void should_name과Description수정_when_owner() {
+    Workspace workspace = buildWorkspace("Old Name", "old");
+    WorkspaceMember member = WorkspaceMember.create(1L, 7L, WorkspaceMemberRole.OWNER);
+    given(workspaceRepository.findById(1L)).willReturn(Optional.of(workspace));
+    given(workspaceMemberRepository.findByWorkspaceIdAndUserId(1L, 7L))
+        .willReturn(Optional.of(member));
+    given(workspaceRepository.save(workspace)).willReturn(workspace);
+
+    WorkspaceResult result =
+        useCase.execute(new UpdateWorkspaceCommand(1L, 7L, true, "New Name", true, "new"));
+
+    assertThat(result.name()).isEqualTo("New Name");
+    assertThat(result.description()).isEqualTo("new");
+  }
+
+  @Test
+  @DisplayName("description null 명시 전달 → 설명 제거")
+  void should_description제거_when_descriptionNull전달() {
+    Workspace workspace = buildWorkspace("Old Name", "old");
+    WorkspaceMember member = WorkspaceMember.create(1L, 7L, WorkspaceMemberRole.ADMIN);
+    given(workspaceRepository.findById(1L)).willReturn(Optional.of(workspace));
+    given(workspaceMemberRepository.findByWorkspaceIdAndUserId(1L, 7L))
+        .willReturn(Optional.of(member));
+    given(workspaceRepository.save(workspace)).willReturn(workspace);
+
+    WorkspaceResult result =
+        useCase.execute(new UpdateWorkspaceCommand(1L, 7L, false, null, true, null));
+
+    assertThat(result.description()).isNull();
+  }
+
+  @Test
+  @DisplayName("name null 명시 전달 → WorkspaceInvalidNameException")
+  void should_WorkspaceInvalidNameException_when_nameNull전달() {
+    given(workspaceRepository.findById(1L)).willReturn(Optional.of(buildWorkspace("Old Name", "old")));
+    given(workspaceMemberRepository.findByWorkspaceIdAndUserId(1L, 7L))
+        .willReturn(Optional.of(WorkspaceMember.create(1L, 7L, WorkspaceMemberRole.OWNER)));
+
+    assertThatThrownBy(() -> useCase.execute(new UpdateWorkspaceCommand(1L, 7L, true, null, false, null)))
+        .isInstanceOf(WorkspaceInvalidNameException.class);
+  }
+
+  @Test
+  @DisplayName("description 2000자 초과 → WorkspaceInvalidDescriptionException")
+  void should_WorkspaceInvalidDescriptionException_when_description길이초과() {
+    given(workspaceRepository.findById(1L)).willReturn(Optional.of(buildWorkspace("Old Name", "old")));
+    given(workspaceMemberRepository.findByWorkspaceIdAndUserId(1L, 7L))
+        .willReturn(Optional.of(WorkspaceMember.create(1L, 7L, WorkspaceMemberRole.OWNER)));
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdateWorkspaceCommand(1L, 7L, false, null, true, "x".repeat(2001))))
+        .isInstanceOf(WorkspaceInvalidDescriptionException.class);
+  }
+
+  @Test
+  @DisplayName("REVIEWER 수정 시도 → WorkspaceAccessDeniedException")
+  void should_WorkspaceAccessDeniedException_when_reviewer() {
+    given(workspaceRepository.findById(1L)).willReturn(Optional.of(buildWorkspace("Old Name", "old")));
+    given(workspaceMemberRepository.findByWorkspaceIdAndUserId(1L, 7L))
+        .willReturn(Optional.of(WorkspaceMember.create(1L, 7L, WorkspaceMemberRole.REVIEWER)));
+
+    assertThatThrownBy(
+            () -> useCase.execute(new UpdateWorkspaceCommand(1L, 7L, true, "New Name", false, null)))
+        .isInstanceOf(WorkspaceAccessDeniedException.class);
+  }
+
+  private Workspace buildWorkspace(String name, String description) {
+    Workspace workspace = Workspace.create(WorkspaceKey.of("cs-team-alpha"), name, description);
+    ReflectionTestUtils.setField(workspace, "id", 1L);
+    ReflectionTestUtils.setField(workspace, "createdAt", OffsetDateTime.parse("2026-04-14T00:00:00Z"));
+    ReflectionTestUtils.setField(workspace, "updatedAt", OffsetDateTime.parse("2026-04-14T00:00:00Z"));
+    return workspace;
+  }
+}

--- a/backend/src/test/java/com/init/workspace/domain/model/WorkspaceKeyTest.java
+++ b/backend/src/test/java/com/init/workspace/domain/model/WorkspaceKeyTest.java
@@ -1,0 +1,36 @@
+package com.init.workspace.domain.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("WorkspaceKey")
+class WorkspaceKeyTest {
+
+  @Test
+  @DisplayName("유효한 workspaceKey → 생성 성공")
+  void should_생성성공_when_유효한키() {
+    assertThat(WorkspaceKey.of("cs-team-alpha").getValue()).isEqualTo("cs-team-alpha");
+  }
+
+  @Test
+  @DisplayName("null workspaceKey → IllegalArgumentException")
+  void should_IllegalArgumentException_when_null() {
+    assertThatThrownBy(() -> WorkspaceKey.of(null)).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  @DisplayName("대문자 포함 workspaceKey → IllegalArgumentException")
+  void should_IllegalArgumentException_when_대문자포함() {
+    assertThatThrownBy(() -> WorkspaceKey.of("CS-team"))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  @DisplayName("길이 2 이하 workspaceKey → IllegalArgumentException")
+  void should_IllegalArgumentException_when_길이2이하() {
+    assertThatThrownBy(() -> WorkspaceKey.of("ab")).isInstanceOf(IllegalArgumentException.class);
+  }
+}

--- a/backend/src/test/java/com/init/workspace/domain/model/WorkspaceMemberTest.java
+++ b/backend/src/test/java/com/init/workspace/domain/model/WorkspaceMemberTest.java
@@ -1,0 +1,28 @@
+package com.init.workspace.domain.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("WorkspaceMember")
+class WorkspaceMemberTest {
+
+  @Test
+  @DisplayName("유효한 인자 → 생성 성공")
+  void should_생성성공_when_유효한인자() {
+    WorkspaceMember member = WorkspaceMember.create(1L, 2L, WorkspaceMemberRole.OWNER);
+
+    assertThat(member.getWorkspaceId()).isEqualTo(1L);
+    assertThat(member.getUserId()).isEqualTo(2L);
+    assertThat(member.getMemberRole()).isEqualTo(WorkspaceMemberRole.OWNER);
+  }
+
+  @Test
+  @DisplayName("workspaceId null → IllegalArgumentException")
+  void should_IllegalArgumentException_when_workspaceIdNull() {
+    assertThatThrownBy(() -> WorkspaceMember.create(null, 2L, WorkspaceMemberRole.OWNER))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+}

--- a/backend/src/test/java/com/init/workspace/domain/model/WorkspaceMemberTest.java
+++ b/backend/src/test/java/com/init/workspace/domain/model/WorkspaceMemberTest.java
@@ -25,4 +25,18 @@ class WorkspaceMemberTest {
     assertThatThrownBy(() -> WorkspaceMember.create(null, 2L, WorkspaceMemberRole.OWNER))
         .isInstanceOf(IllegalArgumentException.class);
   }
+
+  @Test
+  @DisplayName("userId null → IllegalArgumentException")
+  void should_IllegalArgumentException_when_userIdNull() {
+    assertThatThrownBy(() -> WorkspaceMember.create(1L, null, WorkspaceMemberRole.OWNER))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  @DisplayName("memberRole null → IllegalArgumentException")
+  void should_IllegalArgumentException_when_memberRoleNull() {
+    assertThatThrownBy(() -> WorkspaceMember.create(1L, 2L, null))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
 }

--- a/backend/src/test/java/com/init/workspace/domain/model/WorkspaceTest.java
+++ b/backend/src/test/java/com/init/workspace/domain/model/WorkspaceTest.java
@@ -1,0 +1,59 @@
+package com.init.workspace.domain.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Workspace")
+class WorkspaceTest {
+
+  @Test
+  @DisplayName("유효한 인자 → ACTIVE 상태로 생성")
+  void should_생성성공_when_유효한인자() {
+    Workspace workspace = Workspace.create(WorkspaceKey.of("cs-team-alpha"), "CS Team", "desc");
+
+    assertThat(workspace.getStatus()).isEqualTo(WorkspaceStatus.ACTIVE);
+    assertThat(workspace.getName()).isEqualTo("CS Team");
+  }
+
+  @Test
+  @DisplayName("description null 허용 → update 성공")
+  void should_update성공_when_descriptionNull() {
+    Workspace workspace = Workspace.create(WorkspaceKey.of("cs-team-alpha"), "CS Team", "desc");
+
+    workspace.update("New Name", null);
+
+    assertThat(workspace.getName()).isEqualTo("New Name");
+    assertThat(workspace.getDescription()).isNull();
+  }
+
+  @Test
+  @DisplayName("blank name으로 update → IllegalArgumentException")
+  void should_IllegalArgumentException_when_updateNameBlank() {
+    Workspace workspace = Workspace.create(WorkspaceKey.of("cs-team-alpha"), "CS Team", "desc");
+
+    assertThatThrownBy(() -> workspace.update(" ", "desc"))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  @DisplayName("archive 호출 → ARCHIVED 상태로 변경")
+  void should_archive성공_when_active상태() {
+    Workspace workspace = Workspace.create(WorkspaceKey.of("cs-team-alpha"), "CS Team", "desc");
+
+    workspace.archive();
+
+    assertThat(workspace.getStatus()).isEqualTo(WorkspaceStatus.ARCHIVED);
+  }
+
+  @Test
+  @DisplayName("이미 ARCHIVED 상태에서 archive 호출 → IllegalStateException")
+  void should_IllegalStateException_when_이미Archived() {
+    Workspace workspace = Workspace.create(WorkspaceKey.of("cs-team-alpha"), "CS Team", "desc");
+    workspace.archive();
+
+    assertThatThrownBy(workspace::archive).isInstanceOf(IllegalStateException.class);
+  }
+}

--- a/backend/src/test/java/com/init/workspace/presentation/WorkspaceControllerTest.java
+++ b/backend/src/test/java/com/init/workspace/presentation/WorkspaceControllerTest.java
@@ -1,0 +1,257 @@
+package com.init.workspace.presentation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.init.shared.infrastructure.security.JwtAuthenticationFilter;
+import com.init.workspace.application.ArchiveWorkspaceUseCase;
+import com.init.workspace.application.CreateWorkspaceUseCase;
+import com.init.workspace.application.GetWorkspaceListUseCase;
+import com.init.workspace.application.GetWorkspaceUseCase;
+import com.init.workspace.application.UpdateWorkspaceUseCase;
+import com.init.workspace.application.WorkspaceResult;
+import com.init.workspace.application.exception.WorkspaceAccessDeniedException;
+import com.init.workspace.application.exception.WorkspaceInvalidKeyException;
+import com.init.workspace.application.exception.WorkspaceInvalidNameException;
+import com.init.workspace.application.exception.WorkspaceKeyAlreadyExistsException;
+import com.init.workspace.application.exception.WorkspaceNotFoundException;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(
+    value = WorkspaceController.class,
+    excludeFilters =
+        @ComponentScan.Filter(
+            type = FilterType.ASSIGNABLE_TYPE,
+            classes = JwtAuthenticationFilter.class))
+@AutoConfigureMockMvc(addFilters = false)
+@DisplayName("WorkspaceController")
+class WorkspaceControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private CreateWorkspaceUseCase createWorkspaceUseCase;
+  @MockitoBean private GetWorkspaceListUseCase getWorkspaceListUseCase;
+  @MockitoBean private GetWorkspaceUseCase getWorkspaceUseCase;
+  @MockitoBean private UpdateWorkspaceUseCase updateWorkspaceUseCase;
+  @MockitoBean private ArchiveWorkspaceUseCase archiveWorkspaceUseCase;
+
+  @Test
+  @DisplayName("POST 유효한 요청 → 201 Created")
+  void should_201Created_when_유효한요청() throws Exception {
+    given(createWorkspaceUseCase.execute(any())).willReturn(result("OWNER"));
+
+    mockMvc
+        .perform(
+            post("/api/v1/workspaces")
+                .principal(auth())
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "workspaceKey": "cs-team-alpha",
+                      "name": "CS Team Alpha",
+                      "description": "desc"
+                    }
+                    """))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.workspaceKey").value("cs-team-alpha"))
+        .andExpect(jsonPath("$.myRole").value("OWNER"));
+  }
+
+  @Test
+  @DisplayName("POST 잘못된 key → 400 WORKSPACE_INVALID_KEY")
+  void should_400반환_when_잘못된Key() throws Exception {
+    given(createWorkspaceUseCase.execute(any()))
+        .willThrow(new WorkspaceInvalidKeyException("workspaceKey 형식이 올바르지 않습니다."));
+
+    mockMvc
+        .perform(
+            post("/api/v1/workspaces")
+                .principal(auth())
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "workspaceKey": "BAD_KEY",
+                      "name": "CS Team Alpha"
+                    }
+                    """))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("WORKSPACE_INVALID_KEY"));
+  }
+
+  @Test
+  @DisplayName("POST 인증 누락 → 401 UNAUTHORIZED")
+  void should_401반환_when_인증누락() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/v1/workspaces")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "workspaceKey": "cs-team-alpha",
+                      "name": "CS Team Alpha"
+                    }
+                    """))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.code").value("UNAUTHORIZED"));
+  }
+
+  @Test
+  @DisplayName("GET 목록 조회 → 200 OK")
+  void should_200반환_when_목록조회() throws Exception {
+    given(getWorkspaceListUseCase.execute(7L)).willReturn(List.of(result("OWNER")));
+
+    mockMvc
+        .perform(get("/api/v1/workspaces").principal(auth()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].id").value(1))
+        .andExpect(jsonPath("$[0].myRole").value("OWNER"));
+  }
+
+  @Test
+  @DisplayName("GET 단건 비멤버 → 403 WORKSPACE_ACCESS_DENIED")
+  void should_403반환_when_비멤버() throws Exception {
+    given(getWorkspaceUseCase.execute(1L, 7L))
+        .willThrow(new WorkspaceAccessDeniedException("워크스페이스에 접근 권한이 없습니다."));
+
+    mockMvc
+        .perform(get("/api/v1/workspaces/1").principal(auth()))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.code").value("WORKSPACE_ACCESS_DENIED"));
+  }
+
+  @Test
+  @DisplayName("PATCH description null 전달 → 200 OK")
+  void should_200반환_when_descriptionNull전달() throws Exception {
+    WorkspaceResult result = new WorkspaceResult(1L, "cs-team-alpha", "CS Team", null, "ACTIVE", "OWNER",
+        OffsetDateTime.parse("2026-04-14T00:00:00Z"), OffsetDateTime.parse("2026-04-14T00:00:00Z"));
+    given(updateWorkspaceUseCase.execute(any())).willReturn(result);
+
+    mockMvc
+        .perform(
+            patch("/api/v1/workspaces/1")
+                .principal(auth())
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "description": null
+                    }
+                    """))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.description").value(Matchers.nullValue()));
+  }
+
+  @Test
+  @DisplayName("PATCH 잘못된 name → 400 WORKSPACE_INVALID_NAME")
+  void should_400반환_when_잘못된Name() throws Exception {
+    given(updateWorkspaceUseCase.execute(any()))
+        .willThrow(new WorkspaceInvalidNameException("워크스페이스 이름이 올바르지 않습니다."));
+
+    mockMvc
+        .perform(
+            patch("/api/v1/workspaces/1")
+                .principal(auth())
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "name": null
+                    }
+                    """))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("WORKSPACE_INVALID_NAME"));
+  }
+
+  @Test
+  @DisplayName("DELETE OWNER 삭제 → 204 No Content")
+  void should_204반환_when_owner삭제() throws Exception {
+    willDoNothing().given(archiveWorkspaceUseCase).execute(1L, 7L);
+
+    mockMvc
+        .perform(delete("/api/v1/workspaces/1").principal(auth()).with(csrf()))
+        .andExpect(status().isNoContent());
+  }
+
+  @Test
+  @DisplayName("DELETE 존재하지 않는 workspace → 404 WORKSPACE_NOT_FOUND")
+  void should_404반환_when_workspace없음() throws Exception {
+    org.mockito.BDDMockito.willThrow(new WorkspaceNotFoundException("워크스페이스를 찾을 수 없습니다."))
+        .given(archiveWorkspaceUseCase)
+        .execute(1L, 7L);
+
+    mockMvc
+        .perform(delete("/api/v1/workspaces/1").principal(auth()).with(csrf()))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("WORKSPACE_NOT_FOUND"));
+  }
+
+  @Test
+  @DisplayName("POST 중복 key → 409 WORKSPACE_KEY_CONFLICT")
+  void should_409반환_when_key중복() throws Exception {
+    given(createWorkspaceUseCase.execute(any()))
+        .willThrow(new WorkspaceKeyAlreadyExistsException("이미 사용 중인 워크스페이스 키입니다."));
+
+    mockMvc
+        .perform(
+            post("/api/v1/workspaces")
+                .principal(auth())
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "workspaceKey": "cs-team-alpha",
+                      "name": "CS Team Alpha"
+                    }
+                    """))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("WORKSPACE_KEY_CONFLICT"));
+  }
+
+  private WorkspaceResult result(String role) {
+    return new WorkspaceResult(
+        1L,
+        "cs-team-alpha",
+        "CS Team Alpha",
+        "desc",
+        "ACTIVE",
+        role,
+        OffsetDateTime.parse("2026-04-14T00:00:00Z"),
+        OffsetDateTime.parse("2026-04-14T00:00:00Z"));
+  }
+
+  private UsernamePasswordAuthenticationToken auth() {
+    return new UsernamePasswordAuthenticationToken(
+        7L, null, List.of(new SimpleGrantedAuthority("ROLE_OPERATOR")));
+  }
+}

--- a/backend/src/test/java/com/init/workspace/presentation/WorkspaceControllerTest.java
+++ b/backend/src/test/java/com/init/workspace/presentation/WorkspaceControllerTest.java
@@ -150,8 +150,16 @@ class WorkspaceControllerTest {
   @Test
   @DisplayName("PATCH description null 전달 → 200 OK")
   void should_200반환_when_descriptionNull전달() throws Exception {
-    WorkspaceResult result = new WorkspaceResult(1L, "cs-team-alpha", "CS Team", null, "ACTIVE", "OWNER",
-        OffsetDateTime.parse("2026-04-14T00:00:00Z"), OffsetDateTime.parse("2026-04-14T00:00:00Z"));
+    WorkspaceResult result =
+        new WorkspaceResult(
+            1L,
+            "cs-team-alpha",
+            "CS Team",
+            null,
+            "ACTIVE",
+            "OWNER",
+            OffsetDateTime.parse("2026-04-14T00:00:00Z"),
+            OffsetDateTime.parse("2026-04-14T00:00:00Z"));
     given(updateWorkspaceUseCase.execute(any())).willReturn(result);
 
     mockMvc


### PR DESCRIPTION
## Summary
- add the new workspace bounded context with workspace/workspace_member domain models and CRUD use cases
- expose workspace create, list, detail, update, and archive APIs with role-based access control
- add JSON 401 API entry point, workspace tests, and a small domainpack compatibility fix for joined_at

## Testing
- ./gradlew test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 워크스페이스 관리 기능 추가: 워크스페이스 생성, 조회, 수정, 아카이빙 지원
  * 워크스페이스 멤버십 및 역할 기반 접근 제어(OWNER, ADMIN, REVIEWER, OPERATOR) 추가
  * 인증 실패 시 JSON 형식의 표준화된 오류 응답 제공

* **Tests**
  * 워크스페이스 CRUD 작업 및 멤버 관리에 대한 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->