### PR TITLE
feat(domain-pack): add workflow definition read API

### DIFF
--- a/backend/src/main/java/com/init/domainpack/application/DomainPackValidator.java
+++ b/backend/src/main/java/com/init/domainpack/application/DomainPackValidator.java
@@ -1,0 +1,62 @@
+package com.init.domainpack.application;
+
+import com.init.domainpack.application.exception.DomainPackNotFoundException;
+import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
+import com.init.domainpack.application.exception.DomainPackVersionNotFoundException;
+import com.init.domainpack.application.exception.DomainPackWorkspaceNotFoundException;
+import com.init.domainpack.domain.model.DomainPackVersion;
+import com.init.domainpack.domain.model.WorkspaceMemberRole;
+import com.init.domainpack.domain.repository.DomainPackRepository;
+import com.init.domainpack.domain.repository.DomainPackVersionRepository;
+import com.init.domainpack.domain.repository.WorkspaceExistencePort;
+import com.init.domainpack.domain.repository.WorkspaceMembershipPort;
+import java.util.Set;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DomainPackValidator {
+
+  private static final Set<WorkspaceMemberRole> ALLOWED_ROLES =
+      Set.of(WorkspaceMemberRole.OPERATOR, WorkspaceMemberRole.ADMIN);
+
+  private final WorkspaceExistencePort workspaceExistencePort;
+  private final WorkspaceMembershipPort workspaceMembershipPort;
+  private final DomainPackRepository domainPackRepository;
+  private final DomainPackVersionRepository domainPackVersionRepository;
+
+  public DomainPackValidator(
+      WorkspaceExistencePort workspaceExistencePort,
+      WorkspaceMembershipPort workspaceMembershipPort,
+      DomainPackRepository domainPackRepository,
+      DomainPackVersionRepository domainPackVersionRepository) {
+    this.workspaceExistencePort = workspaceExistencePort;
+    this.workspaceMembershipPort = workspaceMembershipPort;
+    this.domainPackRepository = domainPackRepository;
+    this.domainPackVersionRepository = domainPackVersionRepository;
+  }
+
+  public void validateWorkspaceAccess(Long workspaceId, Long userId) {
+    if (!workspaceExistencePort.existsById(workspaceId)) {
+      throw new DomainPackWorkspaceNotFoundException("워크스페이스를 찾을 수 없습니다. id=" + workspaceId);
+    }
+    if (!workspaceMembershipPort.hasAnyRole(workspaceId, userId, ALLOWED_ROLES)) {
+      throw new DomainPackUnauthorizedWorkspaceAccessException("워크스페이스에 접근 권한이 없습니다.");
+    }
+  }
+
+  public void validateDomainPack(Long packId, Long workspaceId) {
+    if (!domainPackRepository.existsByIdAndWorkspaceId(packId, workspaceId)) {
+      throw new DomainPackNotFoundException(packId);
+    }
+  }
+
+  public void validateVersion(Long versionId, Long packId) {
+    DomainPackVersion version =
+        domainPackVersionRepository
+            .findById(versionId)
+            .orElseThrow(() -> new DomainPackVersionNotFoundException(versionId));
+    if (!version.getDomainPackId().equals(packId)) {
+      throw new DomainPackVersionNotFoundException(versionId);
+    }
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/application/GetWorkflowDefinitionListQuery.java
+++ b/backend/src/main/java/com/init/domainpack/application/GetWorkflowDefinitionListQuery.java
@@ -1,0 +1,4 @@
+package com.init.domainpack.application;
+
+public record GetWorkflowDefinitionListQuery(
+    Long workspaceId, Long packId, Long versionId, Long userId) {}

--- a/backend/src/main/java/com/init/domainpack/application/GetWorkflowDefinitionListUseCase.java
+++ b/backend/src/main/java/com/init/domainpack/application/GetWorkflowDefinitionListUseCase.java
@@ -1,18 +1,7 @@
 package com.init.domainpack.application;
 
-import com.init.domainpack.application.exception.DomainPackNotFoundException;
-import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
-import com.init.domainpack.application.exception.DomainPackVersionNotFoundException;
-import com.init.domainpack.application.exception.DomainPackWorkspaceNotFoundException;
-import com.init.domainpack.domain.model.DomainPackVersion;
-import com.init.domainpack.domain.model.WorkspaceMemberRole;
-import com.init.domainpack.domain.repository.DomainPackRepository;
-import com.init.domainpack.domain.repository.DomainPackVersionRepository;
 import com.init.domainpack.domain.repository.WorkflowDefinitionRepository;
-import com.init.domainpack.domain.repository.WorkspaceExistencePort;
-import com.init.domainpack.domain.repository.WorkspaceMembershipPort;
 import java.util.List;
-import java.util.Set;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,60 +9,22 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class GetWorkflowDefinitionListUseCase {
 
-  private static final Set<WorkspaceMemberRole> ALLOWED_ROLES =
-      Set.of(WorkspaceMemberRole.OPERATOR, WorkspaceMemberRole.ADMIN);
-
-  private final WorkspaceExistencePort workspaceExistencePort;
-  private final WorkspaceMembershipPort workspaceMembershipPort;
-  private final DomainPackRepository domainPackRepository;
-  private final DomainPackVersionRepository domainPackVersionRepository;
+  private final DomainPackValidator validator;
   private final WorkflowDefinitionRepository workflowDefinitionRepository;
 
   public GetWorkflowDefinitionListUseCase(
-      WorkspaceExistencePort workspaceExistencePort,
-      WorkspaceMembershipPort workspaceMembershipPort,
-      DomainPackRepository domainPackRepository,
-      DomainPackVersionRepository domainPackVersionRepository,
-      WorkflowDefinitionRepository workflowDefinitionRepository) {
-    this.workspaceExistencePort = workspaceExistencePort;
-    this.workspaceMembershipPort = workspaceMembershipPort;
-    this.domainPackRepository = domainPackRepository;
-    this.domainPackVersionRepository = domainPackVersionRepository;
+      DomainPackValidator validator, WorkflowDefinitionRepository workflowDefinitionRepository) {
+    this.validator = validator;
     this.workflowDefinitionRepository = workflowDefinitionRepository;
   }
 
   public List<WorkflowDefinitionSummary> execute(GetWorkflowDefinitionListQuery query) {
-    validateWorkspaceAccess(query.workspaceId(), query.userId());
-    validateDomainPack(query.packId(), query.workspaceId());
-    validateVersion(query.versionId(), query.packId());
+    validator.validateWorkspaceAccess(query.workspaceId(), query.userId());
+    validator.validateDomainPack(query.packId(), query.workspaceId());
+    validator.validateVersion(query.versionId(), query.packId());
 
     return workflowDefinitionRepository.findAllByDomainPackVersionId(query.versionId()).stream()
         .map(WorkflowDefinitionSummary::from)
         .toList();
-  }
-
-  private void validateWorkspaceAccess(Long workspaceId, Long userId) {
-    if (!workspaceExistencePort.existsById(workspaceId)) {
-      throw new DomainPackWorkspaceNotFoundException("워크스페이스를 찾을 수 없습니다. id=" + workspaceId);
-    }
-    if (!workspaceMembershipPort.hasAnyRole(workspaceId, userId, ALLOWED_ROLES)) {
-      throw new DomainPackUnauthorizedWorkspaceAccessException("워크스페이스에 접근 권한이 없습니다.");
-    }
-  }
-
-  private void validateDomainPack(Long packId, Long workspaceId) {
-    if (!domainPackRepository.existsByIdAndWorkspaceId(packId, workspaceId)) {
-      throw new DomainPackNotFoundException(packId);
-    }
-  }
-
-  private void validateVersion(Long versionId, Long packId) {
-    DomainPackVersion version =
-        domainPackVersionRepository
-            .findById(versionId)
-            .orElseThrow(() -> new DomainPackVersionNotFoundException(versionId));
-    if (!version.getDomainPackId().equals(packId)) {
-      throw new DomainPackVersionNotFoundException(versionId);
-    }
   }
 }

--- a/backend/src/main/java/com/init/domainpack/application/GetWorkflowDefinitionListUseCase.java
+++ b/backend/src/main/java/com/init/domainpack/application/GetWorkflowDefinitionListUseCase.java
@@ -1,0 +1,79 @@
+package com.init.domainpack.application;
+
+import com.init.domainpack.application.exception.DomainPackNotFoundException;
+import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
+import com.init.domainpack.application.exception.DomainPackVersionNotFoundException;
+import com.init.domainpack.application.exception.DomainPackWorkspaceNotFoundException;
+import com.init.domainpack.domain.model.DomainPackVersion;
+import com.init.domainpack.domain.model.WorkspaceMemberRole;
+import com.init.domainpack.domain.repository.DomainPackRepository;
+import com.init.domainpack.domain.repository.DomainPackVersionRepository;
+import com.init.domainpack.domain.repository.WorkflowDefinitionRepository;
+import com.init.domainpack.domain.repository.WorkspaceExistencePort;
+import com.init.domainpack.domain.repository.WorkspaceMembershipPort;
+import java.util.List;
+import java.util.Set;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class GetWorkflowDefinitionListUseCase {
+
+  private static final Set<WorkspaceMemberRole> ALLOWED_ROLES =
+      Set.of(WorkspaceMemberRole.OPERATOR, WorkspaceMemberRole.ADMIN);
+
+  private final WorkspaceExistencePort workspaceExistencePort;
+  private final WorkspaceMembershipPort workspaceMembershipPort;
+  private final DomainPackRepository domainPackRepository;
+  private final DomainPackVersionRepository domainPackVersionRepository;
+  private final WorkflowDefinitionRepository workflowDefinitionRepository;
+
+  public GetWorkflowDefinitionListUseCase(
+      WorkspaceExistencePort workspaceExistencePort,
+      WorkspaceMembershipPort workspaceMembershipPort,
+      DomainPackRepository domainPackRepository,
+      DomainPackVersionRepository domainPackVersionRepository,
+      WorkflowDefinitionRepository workflowDefinitionRepository) {
+    this.workspaceExistencePort = workspaceExistencePort;
+    this.workspaceMembershipPort = workspaceMembershipPort;
+    this.domainPackRepository = domainPackRepository;
+    this.domainPackVersionRepository = domainPackVersionRepository;
+    this.workflowDefinitionRepository = workflowDefinitionRepository;
+  }
+
+  public List<WorkflowDefinitionSummary> execute(GetWorkflowDefinitionListQuery query) {
+    validateWorkspaceAccess(query.workspaceId(), query.userId());
+    validateDomainPack(query.packId(), query.workspaceId());
+    validateVersion(query.versionId(), query.packId());
+
+    return workflowDefinitionRepository.findAllByDomainPackVersionId(query.versionId()).stream()
+        .map(WorkflowDefinitionSummary::from)
+        .toList();
+  }
+
+  private void validateWorkspaceAccess(Long workspaceId, Long userId) {
+    if (!workspaceExistencePort.existsById(workspaceId)) {
+      throw new DomainPackWorkspaceNotFoundException("워크스페이스를 찾을 수 없습니다. id=" + workspaceId);
+    }
+    if (!workspaceMembershipPort.hasAnyRole(workspaceId, userId, ALLOWED_ROLES)) {
+      throw new DomainPackUnauthorizedWorkspaceAccessException("워크스페이스에 접근 권한이 없습니다.");
+    }
+  }
+
+  private void validateDomainPack(Long packId, Long workspaceId) {
+    if (!domainPackRepository.existsByIdAndWorkspaceId(packId, workspaceId)) {
+      throw new DomainPackNotFoundException(packId);
+    }
+  }
+
+  private void validateVersion(Long versionId, Long packId) {
+    DomainPackVersion version =
+        domainPackVersionRepository
+            .findById(versionId)
+            .orElseThrow(() -> new DomainPackVersionNotFoundException(versionId));
+    if (!version.getDomainPackId().equals(packId)) {
+      throw new DomainPackVersionNotFoundException(versionId);
+    }
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/application/GetWorkflowDefinitionQuery.java
+++ b/backend/src/main/java/com/init/domainpack/application/GetWorkflowDefinitionQuery.java
@@ -1,0 +1,4 @@
+package com.init.domainpack.application;
+
+public record GetWorkflowDefinitionQuery(
+    Long workspaceId, Long packId, Long versionId, Long workflowId, Long userId) {}

--- a/backend/src/main/java/com/init/domainpack/application/GetWorkflowDefinitionUseCase.java
+++ b/backend/src/main/java/com/init/domainpack/application/GetWorkflowDefinitionUseCase.java
@@ -1,0 +1,80 @@
+package com.init.domainpack.application;
+
+import com.init.domainpack.application.exception.DomainPackNotFoundException;
+import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
+import com.init.domainpack.application.exception.DomainPackVersionNotFoundException;
+import com.init.domainpack.application.exception.DomainPackWorkspaceNotFoundException;
+import com.init.domainpack.application.exception.WorkflowDefinitionNotFoundException;
+import com.init.domainpack.domain.model.DomainPackVersion;
+import com.init.domainpack.domain.model.WorkspaceMemberRole;
+import com.init.domainpack.domain.repository.DomainPackRepository;
+import com.init.domainpack.domain.repository.DomainPackVersionRepository;
+import com.init.domainpack.domain.repository.WorkflowDefinitionRepository;
+import com.init.domainpack.domain.repository.WorkspaceExistencePort;
+import com.init.domainpack.domain.repository.WorkspaceMembershipPort;
+import java.util.Set;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class GetWorkflowDefinitionUseCase {
+
+  private static final Set<WorkspaceMemberRole> ALLOWED_ROLES =
+      Set.of(WorkspaceMemberRole.OPERATOR, WorkspaceMemberRole.ADMIN);
+
+  private final WorkspaceExistencePort workspaceExistencePort;
+  private final WorkspaceMembershipPort workspaceMembershipPort;
+  private final DomainPackRepository domainPackRepository;
+  private final DomainPackVersionRepository domainPackVersionRepository;
+  private final WorkflowDefinitionRepository workflowDefinitionRepository;
+
+  public GetWorkflowDefinitionUseCase(
+      WorkspaceExistencePort workspaceExistencePort,
+      WorkspaceMembershipPort workspaceMembershipPort,
+      DomainPackRepository domainPackRepository,
+      DomainPackVersionRepository domainPackVersionRepository,
+      WorkflowDefinitionRepository workflowDefinitionRepository) {
+    this.workspaceExistencePort = workspaceExistencePort;
+    this.workspaceMembershipPort = workspaceMembershipPort;
+    this.domainPackRepository = domainPackRepository;
+    this.domainPackVersionRepository = domainPackVersionRepository;
+    this.workflowDefinitionRepository = workflowDefinitionRepository;
+  }
+
+  public WorkflowDefinitionDetail execute(GetWorkflowDefinitionQuery query) {
+    validateWorkspaceAccess(query.workspaceId(), query.userId());
+    validateDomainPack(query.packId(), query.workspaceId());
+    validateVersion(query.versionId(), query.packId());
+
+    return workflowDefinitionRepository
+        .findByIdAndDomainPackVersionId(query.workflowId(), query.versionId())
+        .map(WorkflowDefinitionDetail::from)
+        .orElseThrow(() -> new WorkflowDefinitionNotFoundException(query.workflowId()));
+  }
+
+  private void validateWorkspaceAccess(Long workspaceId, Long userId) {
+    if (!workspaceExistencePort.existsById(workspaceId)) {
+      throw new DomainPackWorkspaceNotFoundException("워크스페이스를 찾을 수 없습니다. id=" + workspaceId);
+    }
+    if (!workspaceMembershipPort.hasAnyRole(workspaceId, userId, ALLOWED_ROLES)) {
+      throw new DomainPackUnauthorizedWorkspaceAccessException("워크스페이스에 접근 권한이 없습니다.");
+    }
+  }
+
+  private void validateDomainPack(Long packId, Long workspaceId) {
+    if (!domainPackRepository.existsByIdAndWorkspaceId(packId, workspaceId)) {
+      throw new DomainPackNotFoundException(packId);
+    }
+  }
+
+  private void validateVersion(Long versionId, Long packId) {
+    DomainPackVersion version =
+        domainPackVersionRepository
+            .findById(versionId)
+            .orElseThrow(() -> new DomainPackVersionNotFoundException(versionId));
+    if (!version.getDomainPackId().equals(packId)) {
+      throw new DomainPackVersionNotFoundException(versionId);
+    }
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/application/GetWorkflowDefinitionUseCase.java
+++ b/backend/src/main/java/com/init/domainpack/application/GetWorkflowDefinitionUseCase.java
@@ -1,18 +1,7 @@
 package com.init.domainpack.application;
 
-import com.init.domainpack.application.exception.DomainPackNotFoundException;
-import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
-import com.init.domainpack.application.exception.DomainPackVersionNotFoundException;
-import com.init.domainpack.application.exception.DomainPackWorkspaceNotFoundException;
 import com.init.domainpack.application.exception.WorkflowDefinitionNotFoundException;
-import com.init.domainpack.domain.model.DomainPackVersion;
-import com.init.domainpack.domain.model.WorkspaceMemberRole;
-import com.init.domainpack.domain.repository.DomainPackRepository;
-import com.init.domainpack.domain.repository.DomainPackVersionRepository;
 import com.init.domainpack.domain.repository.WorkflowDefinitionRepository;
-import com.init.domainpack.domain.repository.WorkspaceExistencePort;
-import com.init.domainpack.domain.repository.WorkspaceMembershipPort;
-import java.util.Set;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,61 +9,23 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class GetWorkflowDefinitionUseCase {
 
-  private static final Set<WorkspaceMemberRole> ALLOWED_ROLES =
-      Set.of(WorkspaceMemberRole.OPERATOR, WorkspaceMemberRole.ADMIN);
-
-  private final WorkspaceExistencePort workspaceExistencePort;
-  private final WorkspaceMembershipPort workspaceMembershipPort;
-  private final DomainPackRepository domainPackRepository;
-  private final DomainPackVersionRepository domainPackVersionRepository;
+  private final DomainPackValidator validator;
   private final WorkflowDefinitionRepository workflowDefinitionRepository;
 
   public GetWorkflowDefinitionUseCase(
-      WorkspaceExistencePort workspaceExistencePort,
-      WorkspaceMembershipPort workspaceMembershipPort,
-      DomainPackRepository domainPackRepository,
-      DomainPackVersionRepository domainPackVersionRepository,
-      WorkflowDefinitionRepository workflowDefinitionRepository) {
-    this.workspaceExistencePort = workspaceExistencePort;
-    this.workspaceMembershipPort = workspaceMembershipPort;
-    this.domainPackRepository = domainPackRepository;
-    this.domainPackVersionRepository = domainPackVersionRepository;
+      DomainPackValidator validator, WorkflowDefinitionRepository workflowDefinitionRepository) {
+    this.validator = validator;
     this.workflowDefinitionRepository = workflowDefinitionRepository;
   }
 
   public WorkflowDefinitionDetail execute(GetWorkflowDefinitionQuery query) {
-    validateWorkspaceAccess(query.workspaceId(), query.userId());
-    validateDomainPack(query.packId(), query.workspaceId());
-    validateVersion(query.versionId(), query.packId());
+    validator.validateWorkspaceAccess(query.workspaceId(), query.userId());
+    validator.validateDomainPack(query.packId(), query.workspaceId());
+    validator.validateVersion(query.versionId(), query.packId());
 
     return workflowDefinitionRepository
         .findByIdAndDomainPackVersionId(query.workflowId(), query.versionId())
         .map(WorkflowDefinitionDetail::from)
         .orElseThrow(() -> new WorkflowDefinitionNotFoundException(query.workflowId()));
-  }
-
-  private void validateWorkspaceAccess(Long workspaceId, Long userId) {
-    if (!workspaceExistencePort.existsById(workspaceId)) {
-      throw new DomainPackWorkspaceNotFoundException("워크스페이스를 찾을 수 없습니다. id=" + workspaceId);
-    }
-    if (!workspaceMembershipPort.hasAnyRole(workspaceId, userId, ALLOWED_ROLES)) {
-      throw new DomainPackUnauthorizedWorkspaceAccessException("워크스페이스에 접근 권한이 없습니다.");
-    }
-  }
-
-  private void validateDomainPack(Long packId, Long workspaceId) {
-    if (!domainPackRepository.existsByIdAndWorkspaceId(packId, workspaceId)) {
-      throw new DomainPackNotFoundException(packId);
-    }
-  }
-
-  private void validateVersion(Long versionId, Long packId) {
-    DomainPackVersion version =
-        domainPackVersionRepository
-            .findById(versionId)
-            .orElseThrow(() -> new DomainPackVersionNotFoundException(versionId));
-    if (!version.getDomainPackId().equals(packId)) {
-      throw new DomainPackVersionNotFoundException(versionId);
-    }
   }
 }

--- a/backend/src/main/java/com/init/domainpack/application/WorkflowDefinitionDetail.java
+++ b/backend/src/main/java/com/init/domainpack/application/WorkflowDefinitionDetail.java
@@ -40,9 +40,12 @@ public record WorkflowDefinitionDetail(
   }
 
   private static void validateGraphJson(String graphJson) {
+    if (graphJson == null || graphJson.isBlank()) {
+      throw new WorkflowGraphJsonInvalidException();
+    }
     try {
       JsonNode root = MAPPER.readTree(graphJson);
-      if (!root.isObject()) {
+      if (root == null || !root.isObject()) {
         throw new WorkflowGraphJsonInvalidException();
       }
       JsonNode direction = root.get("direction");
@@ -59,7 +62,7 @@ public record WorkflowDefinitionDetail(
       }
     } catch (WorkflowGraphJsonInvalidException e) {
       throw e;
-    } catch (IOException e) {
+    } catch (IOException | IllegalArgumentException | NullPointerException e) {
       throw new WorkflowGraphJsonInvalidException(e);
     }
   }

--- a/backend/src/main/java/com/init/domainpack/application/WorkflowDefinitionDetail.java
+++ b/backend/src/main/java/com/init/domainpack/application/WorkflowDefinitionDetail.java
@@ -1,0 +1,65 @@
+package com.init.domainpack.application;
+
+import com.fasterxml.jackson.annotation.JsonRawValue;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.init.domainpack.application.exception.WorkflowGraphJsonInvalidException;
+import com.init.domainpack.domain.model.WorkflowDefinition;
+import java.time.OffsetDateTime;
+
+public record WorkflowDefinitionDetail(
+    Long id,
+    String workflowCode,
+    String name,
+    String description,
+    @JsonRawValue String graphJson,
+    String initialState,
+    String terminalStatesJson,
+    String evidenceJson,
+    String metaJson,
+    OffsetDateTime createdAt,
+    OffsetDateTime updatedAt) {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  public static WorkflowDefinitionDetail from(WorkflowDefinition entity) {
+    validateGraphJson(entity.getGraphJson());
+    return new WorkflowDefinitionDetail(
+        entity.getId(),
+        entity.getWorkflowCode(),
+        entity.getName(),
+        entity.getDescription(),
+        entity.getGraphJson(),
+        entity.getInitialState(),
+        entity.getTerminalStatesJson(),
+        entity.getEvidenceJson(),
+        entity.getMetaJson(),
+        entity.getCreatedAt(),
+        entity.getUpdatedAt());
+  }
+
+  private static void validateGraphJson(String graphJson) {
+    try {
+      JsonNode root = MAPPER.readTree(graphJson);
+      if (!root.isObject()) {
+        throw new WorkflowGraphJsonInvalidException();
+      }
+      JsonNode direction = root.get("direction");
+      if (direction == null || !direction.isTextual()) {
+        throw new WorkflowGraphJsonInvalidException();
+      }
+      JsonNode nodes = root.get("nodes");
+      if (nodes == null || !nodes.isArray()) {
+        throw new WorkflowGraphJsonInvalidException();
+      }
+      JsonNode edges = root.get("edges");
+      if (edges == null || !edges.isArray()) {
+        throw new WorkflowGraphJsonInvalidException();
+      }
+    } catch (WorkflowGraphJsonInvalidException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new WorkflowGraphJsonInvalidException();
+    }
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/application/WorkflowDefinitionDetail.java
+++ b/backend/src/main/java/com/init/domainpack/application/WorkflowDefinitionDetail.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.init.domainpack.application.exception.WorkflowGraphJsonInvalidException;
 import com.init.domainpack.domain.model.WorkflowDefinition;
+import java.io.IOException;
 import java.time.OffsetDateTime;
 
 public record WorkflowDefinitionDetail(
@@ -58,8 +59,8 @@ public record WorkflowDefinitionDetail(
       }
     } catch (WorkflowGraphJsonInvalidException e) {
       throw e;
-    } catch (Exception e) {
-      throw new WorkflowGraphJsonInvalidException();
+    } catch (IOException e) {
+      throw new WorkflowGraphJsonInvalidException(e);
     }
   }
 }

--- a/backend/src/main/java/com/init/domainpack/application/WorkflowDefinitionSummary.java
+++ b/backend/src/main/java/com/init/domainpack/application/WorkflowDefinitionSummary.java
@@ -1,0 +1,27 @@
+package com.init.domainpack.application;
+
+import com.init.domainpack.domain.repository.WorkflowDefinitionSummaryRow;
+import java.time.OffsetDateTime;
+
+public record WorkflowDefinitionSummary(
+    Long id,
+    String workflowCode,
+    String name,
+    String description,
+    String initialState,
+    String terminalStatesJson,
+    OffsetDateTime createdAt,
+    OffsetDateTime updatedAt) {
+
+  public static WorkflowDefinitionSummary from(WorkflowDefinitionSummaryRow row) {
+    return new WorkflowDefinitionSummary(
+        row.getId(),
+        row.getWorkflowCode(),
+        row.getName(),
+        row.getDescription(),
+        row.getInitialState(),
+        row.getTerminalStatesJson(),
+        row.getCreatedAt(),
+        row.getUpdatedAt());
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/application/exception/WorkflowDefinitionNotFoundException.java
+++ b/backend/src/main/java/com/init/domainpack/application/exception/WorkflowDefinitionNotFoundException.java
@@ -1,0 +1,9 @@
+package com.init.domainpack.application.exception;
+
+import com.init.shared.application.exception.NotFoundException;
+
+public class WorkflowDefinitionNotFoundException extends NotFoundException {
+  public WorkflowDefinitionNotFoundException(Long workflowId) {
+    super("WORKFLOW_DEFINITION_NOT_FOUND", "WorkflowDefinition not found: " + workflowId);
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/application/exception/WorkflowGraphJsonInvalidException.java
+++ b/backend/src/main/java/com/init/domainpack/application/exception/WorkflowGraphJsonInvalidException.java
@@ -6,4 +6,9 @@ public class WorkflowGraphJsonInvalidException extends InternalException {
   public WorkflowGraphJsonInvalidException() {
     super("WORKFLOW_GRAPH_JSON_INVALID", "graphJson이 유효하지 않은 JSON입니다.");
   }
+
+  public WorkflowGraphJsonInvalidException(Throwable cause) {
+    super("WORKFLOW_GRAPH_JSON_INVALID", "graphJson이 유효하지 않은 JSON입니다.");
+    initCause(cause);
+  }
 }

--- a/backend/src/main/java/com/init/domainpack/application/exception/WorkflowGraphJsonInvalidException.java
+++ b/backend/src/main/java/com/init/domainpack/application/exception/WorkflowGraphJsonInvalidException.java
@@ -1,0 +1,9 @@
+package com.init.domainpack.application.exception;
+
+import com.init.shared.application.exception.InternalException;
+
+public class WorkflowGraphJsonInvalidException extends InternalException {
+  public WorkflowGraphJsonInvalidException() {
+    super("WORKFLOW_GRAPH_JSON_INVALID", "graphJson이 유효하지 않은 JSON입니다.");
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/domain/model/DomainPackVersion.java
+++ b/backend/src/main/java/com/init/domainpack/domain/model/DomainPackVersion.java
@@ -75,6 +75,15 @@ public class DomainPackVersion {
     }
   }
 
+  /** For test use only — creates a minimal instance with id, domainPackId, lifecycleStatus set. */
+  public static DomainPackVersion ofForTest(Long id, Long domainPackId, String lifecycleStatus) {
+    DomainPackVersion v = new DomainPackVersion();
+    v.id = id;
+    v.domainPackId = domainPackId;
+    v.lifecycleStatus = lifecycleStatus;
+    return v;
+  }
+
   /**
    * 새로운 DRAFT 버전을 생성한다.
    *

--- a/backend/src/main/java/com/init/domainpack/domain/model/WorkflowDefinition.java
+++ b/backend/src/main/java/com/init/domainpack/domain/model/WorkflowDefinition.java
@@ -133,4 +133,12 @@ public class WorkflowDefinition {
   public String getMetaJson() {
     return metaJson;
   }
+
+  public OffsetDateTime getCreatedAt() {
+    return createdAt;
+  }
+
+  public OffsetDateTime getUpdatedAt() {
+    return updatedAt;
+  }
 }

--- a/backend/src/main/java/com/init/domainpack/presentation/ActivateDomainPackVersionController.java
+++ b/backend/src/main/java/com/init/domainpack/presentation/ActivateDomainPackVersionController.java
@@ -4,9 +4,8 @@ import com.init.domainpack.application.ActivateDomainPackVersionCommand;
 import com.init.domainpack.application.ActivateDomainPackVersionResult;
 import com.init.domainpack.application.ActivateDomainPackVersionUseCase;
 import com.init.domainpack.presentation.dto.DomainPackVersionActivateResponse;
+import com.init.shared.presentation.AuthenticationUtils;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.AccessDeniedException;
-import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -29,7 +28,7 @@ public class ActivateDomainPackVersionController {
       @PathVariable Long packId,
       @PathVariable Long versionId,
       Authentication authentication) {
-    Long userId = getUserIdFromAuthentication(authentication);
+    Long userId = AuthenticationUtils.getUserId(authentication);
     ActivateDomainPackVersionCommand command =
         new ActivateDomainPackVersionCommand(workspaceId, packId, versionId, userId);
     ActivateDomainPackVersionResult result = useCase.execute(command);
@@ -41,29 +40,5 @@ public class ActivateDomainPackVersionController {
             result.lifecycleStatus(),
             result.publishedAt(),
             result.updatedAt()));
-  }
-
-  /**
-   * Authentication principal을 Long userId로 안전하게 추출한다.
-   *
-   * @throws AuthenticationCredentialsNotFoundException authentication이 null이거나 principal이 null일 때
-   *     (401)
-   * @throws AccessDeniedException principal이 Long 타입이 아닐 때 (403)
-   */
-  private Long getUserIdFromAuthentication(Authentication authentication) {
-    if (authentication == null) {
-      throw new AuthenticationCredentialsNotFoundException("Authentication must not be null");
-    }
-    Object principal = authentication.getPrincipal();
-    if (principal == null) {
-      throw new AuthenticationCredentialsNotFoundException(
-          "Authentication principal must not be null");
-    }
-    if (!(principal instanceof Long)) {
-      throw new AccessDeniedException(
-          "Authentication principal must be of type Long, but was: "
-              + principal.getClass().getName());
-    }
-    return (Long) principal;
   }
 }

--- a/backend/src/main/java/com/init/domainpack/presentation/CreateDomainPackDraftController.java
+++ b/backend/src/main/java/com/init/domainpack/presentation/CreateDomainPackDraftController.java
@@ -5,12 +5,11 @@ import com.init.domainpack.application.CreateDomainPackDraftResult;
 import com.init.domainpack.application.CreateDomainPackDraftUseCase;
 import com.init.domainpack.presentation.dto.CreateDomainPackDraftRequest;
 import com.init.domainpack.presentation.dto.CreateDomainPackDraftResponse;
+import com.init.shared.presentation.AuthenticationUtils;
 import jakarta.validation.Valid;
 import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.AccessDeniedException;
-import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -34,7 +33,7 @@ public class CreateDomainPackDraftController {
       @PathVariable Long packId,
       @Valid @RequestBody CreateDomainPackDraftRequest request,
       Authentication authentication) {
-    Long userId = getUserIdFromAuthentication(authentication);
+    Long userId = AuthenticationUtils.getUserId(authentication);
     CreateDomainPackDraftResult result =
         useCase.execute(
             new CreateDomainPackDraftCommand(
@@ -148,22 +147,5 @@ public class CreateDomainPackDraftController {
 
   private <T> List<T> safeList(List<T> values) {
     return values == null ? List.of() : values;
-  }
-
-  private Long getUserIdFromAuthentication(Authentication authentication) {
-    if (authentication == null) {
-      throw new AuthenticationCredentialsNotFoundException("Authentication must not be null");
-    }
-    Object principal = authentication.getPrincipal();
-    if (principal == null) {
-      throw new AuthenticationCredentialsNotFoundException(
-          "Authentication principal must not be null");
-    }
-    if (!(principal instanceof Long)) {
-      throw new AccessDeniedException(
-          "Authentication principal must be of type Long, but was: "
-              + principal.getClass().getName());
-    }
-    return (Long) principal;
   }
 }

--- a/backend/src/main/java/com/init/domainpack/presentation/WorkflowDefinitionController.java
+++ b/backend/src/main/java/com/init/domainpack/presentation/WorkflowDefinitionController.java
@@ -1,0 +1,76 @@
+package com.init.domainpack.presentation;
+
+import com.init.domainpack.application.GetWorkflowDefinitionListQuery;
+import com.init.domainpack.application.GetWorkflowDefinitionListUseCase;
+import com.init.domainpack.application.GetWorkflowDefinitionQuery;
+import com.init.domainpack.application.GetWorkflowDefinitionUseCase;
+import com.init.domainpack.application.WorkflowDefinitionDetail;
+import com.init.domainpack.application.WorkflowDefinitionSummary;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(
+    "/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/workflows")
+public class WorkflowDefinitionController {
+
+  private final GetWorkflowDefinitionListUseCase listUseCase;
+  private final GetWorkflowDefinitionUseCase detailUseCase;
+
+  public WorkflowDefinitionController(
+      GetWorkflowDefinitionListUseCase listUseCase, GetWorkflowDefinitionUseCase detailUseCase) {
+    this.listUseCase = listUseCase;
+    this.detailUseCase = detailUseCase;
+  }
+
+  @GetMapping
+  public ResponseEntity<List<WorkflowDefinitionSummary>> listWorkflows(
+      @PathVariable Long workspaceId,
+      @PathVariable Long packId,
+      @PathVariable Long versionId,
+      Authentication authentication) {
+    Long userId = getUserId(authentication);
+    List<WorkflowDefinitionSummary> result =
+        listUseCase.execute(
+            new GetWorkflowDefinitionListQuery(workspaceId, packId, versionId, userId));
+    return ResponseEntity.ok(result);
+  }
+
+  @GetMapping("/{workflowId}")
+  public ResponseEntity<WorkflowDefinitionDetail> getWorkflow(
+      @PathVariable Long workspaceId,
+      @PathVariable Long packId,
+      @PathVariable Long versionId,
+      @PathVariable Long workflowId,
+      Authentication authentication) {
+    Long userId = getUserId(authentication);
+    WorkflowDefinitionDetail result =
+        detailUseCase.execute(
+            new GetWorkflowDefinitionQuery(workspaceId, packId, versionId, workflowId, userId));
+    return ResponseEntity.ok(result);
+  }
+
+  private Long getUserId(Authentication authentication) {
+    if (authentication == null) {
+      throw new AuthenticationCredentialsNotFoundException("Authentication must not be null");
+    }
+    Object principal = authentication.getPrincipal();
+    if (principal == null) {
+      throw new AuthenticationCredentialsNotFoundException(
+          "Authentication principal must not be null");
+    }
+    if (!(principal instanceof Long)) {
+      throw new AccessDeniedException(
+          "Authentication principal must be of type Long, but was: "
+              + principal.getClass().getName());
+    }
+    return (Long) principal;
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/presentation/WorkflowDefinitionController.java
+++ b/backend/src/main/java/com/init/domainpack/presentation/WorkflowDefinitionController.java
@@ -6,10 +6,9 @@ import com.init.domainpack.application.GetWorkflowDefinitionQuery;
 import com.init.domainpack.application.GetWorkflowDefinitionUseCase;
 import com.init.domainpack.application.WorkflowDefinitionDetail;
 import com.init.domainpack.application.WorkflowDefinitionSummary;
+import com.init.shared.presentation.AuthenticationUtils;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.AccessDeniedException;
-import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -36,7 +35,7 @@ public class WorkflowDefinitionController {
       @PathVariable Long packId,
       @PathVariable Long versionId,
       Authentication authentication) {
-    Long userId = getUserId(authentication);
+    Long userId = AuthenticationUtils.getUserId(authentication);
     List<WorkflowDefinitionSummary> result =
         listUseCase.execute(
             new GetWorkflowDefinitionListQuery(workspaceId, packId, versionId, userId));
@@ -50,27 +49,10 @@ public class WorkflowDefinitionController {
       @PathVariable Long versionId,
       @PathVariable Long workflowId,
       Authentication authentication) {
-    Long userId = getUserId(authentication);
+    Long userId = AuthenticationUtils.getUserId(authentication);
     WorkflowDefinitionDetail result =
         detailUseCase.execute(
             new GetWorkflowDefinitionQuery(workspaceId, packId, versionId, workflowId, userId));
     return ResponseEntity.ok(result);
-  }
-
-  private Long getUserId(Authentication authentication) {
-    if (authentication == null) {
-      throw new AuthenticationCredentialsNotFoundException("Authentication must not be null");
-    }
-    Object principal = authentication.getPrincipal();
-    if (principal == null) {
-      throw new AuthenticationCredentialsNotFoundException(
-          "Authentication principal must not be null");
-    }
-    if (!(principal instanceof Long)) {
-      throw new AccessDeniedException(
-          "Authentication principal must be of type Long, but was: "
-              + principal.getClass().getName());
-    }
-    return (Long) principal;
   }
 }

--- a/backend/src/main/java/com/init/shared/application/exception/InternalException.java
+++ b/backend/src/main/java/com/init/shared/application/exception/InternalException.java
@@ -1,0 +1,7 @@
+package com.init.shared.application.exception;
+
+public class InternalException extends BusinessException {
+  public InternalException(String code, String message) {
+    super(code, message);
+  }
+}

--- a/backend/src/main/java/com/init/shared/presentation/AuthenticationUtils.java
+++ b/backend/src/main/java/com/init/shared/presentation/AuthenticationUtils.java
@@ -1,0 +1,27 @@
+package com.init.shared.presentation;
+
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+import org.springframework.security.core.Authentication;
+
+public final class AuthenticationUtils {
+
+  private AuthenticationUtils() {}
+
+  public static Long getUserId(Authentication authentication) {
+    if (authentication == null) {
+      throw new AuthenticationCredentialsNotFoundException("Authentication must not be null");
+    }
+    Object principal = authentication.getPrincipal();
+    if (principal == null) {
+      throw new AuthenticationCredentialsNotFoundException(
+          "Authentication principal must not be null");
+    }
+    if (!(principal instanceof Long)) {
+      throw new AccessDeniedException(
+          "Authentication principal must be of type Long, but was: "
+              + principal.getClass().getName());
+    }
+    return (Long) principal;
+  }
+}

--- a/backend/src/main/java/com/init/shared/presentation/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/init/shared/presentation/GlobalExceptionHandler.java
@@ -79,9 +79,9 @@ public class GlobalExceptionHandler {
 
   @ExceptionHandler(InternalException.class)
   public ResponseEntity<ErrorResponse> handleInternal(InternalException ex) {
-    log.error("Internal exception: {}", ex.getCode(), ex);
+    log.error("Internal exception: {}, message={}", ex.getCode(), ex.getMessage(), ex);
     return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-        .body(new ErrorResponse(ex.getCode(), ex.getMessage()));
+        .body(new ErrorResponse(ex.getCode(), "Internal server error"));
   }
 
   @ExceptionHandler(BusinessException.class)

--- a/backend/src/main/java/com/init/shared/presentation/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/init/shared/presentation/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.init.shared.presentation;
 import com.init.shared.application.exception.BadRequestException;
 import com.init.shared.application.exception.BusinessException;
 import com.init.shared.application.exception.DuplicateException;
+import com.init.shared.application.exception.InternalException;
 import com.init.shared.application.exception.InvalidCredentialsException;
 import com.init.shared.application.exception.InvalidTokenException;
 import com.init.shared.application.exception.NotFoundException;
@@ -73,6 +74,13 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(BadRequestException.class)
   public ResponseEntity<ErrorResponse> handleBadRequest(BadRequestException ex) {
     return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+        .body(new ErrorResponse(ex.getCode(), ex.getMessage()));
+  }
+
+  @ExceptionHandler(InternalException.class)
+  public ResponseEntity<ErrorResponse> handleInternal(InternalException ex) {
+    log.error("Internal exception: {}", ex.getCode(), ex);
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
         .body(new ErrorResponse(ex.getCode(), ex.getMessage()));
   }
 

--- a/backend/src/test/java/com/init/domainpack/application/GetWorkflowDefinitionListUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/GetWorkflowDefinitionListUseCaseTest.java
@@ -1,0 +1,209 @@
+package com.init.domainpack.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.init.domainpack.application.exception.DomainPackNotFoundException;
+import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
+import com.init.domainpack.application.exception.DomainPackVersionNotFoundException;
+import com.init.domainpack.application.exception.DomainPackWorkspaceNotFoundException;
+import com.init.domainpack.domain.model.DomainPackVersion;
+import com.init.domainpack.domain.repository.DomainPackRepository;
+import com.init.domainpack.domain.repository.DomainPackVersionRepository;
+import com.init.domainpack.domain.repository.WorkflowDefinitionRepository;
+import com.init.domainpack.domain.repository.WorkflowDefinitionSummaryRow;
+import com.init.domainpack.domain.repository.WorkspaceExistencePort;
+import com.init.domainpack.domain.repository.WorkspaceMembershipPort;
+import java.lang.reflect.Constructor;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetWorkflowDefinitionListUseCase")
+class GetWorkflowDefinitionListUseCaseTest {
+
+  @Mock private WorkspaceExistencePort workspaceExistencePort;
+  @Mock private WorkspaceMembershipPort workspaceMembershipPort;
+  @Mock private DomainPackRepository domainPackRepository;
+  @Mock private DomainPackVersionRepository domainPackVersionRepository;
+  @Mock private WorkflowDefinitionRepository workflowDefinitionRepository;
+
+  private GetWorkflowDefinitionListUseCase useCase;
+
+  private static final Long WORKSPACE_ID = 1L;
+  private static final Long PACK_ID = 7L;
+  private static final Long VERSION_ID = 101L;
+  private static final Long USER_ID = 10L;
+
+  @BeforeEach
+  void setUp() {
+    useCase =
+        new GetWorkflowDefinitionListUseCase(
+            workspaceExistencePort,
+            workspaceMembershipPort,
+            domainPackRepository,
+            domainPackVersionRepository,
+            workflowDefinitionRepository);
+  }
+
+  @Test
+  @DisplayName("정상 조회 시 version 내 workflow 목록 반환")
+  void execute_withValidQuery_returnsWorkflowList() {
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(true);
+    given(domainPackVersionRepository.findById(VERSION_ID))
+        .willReturn(Optional.of(createVersion(VERSION_ID, PACK_ID)));
+    given(workflowDefinitionRepository.findAllByDomainPackVersionId(VERSION_ID))
+        .willReturn(List.of(createSummaryRow(1L, "refund_flow", "환불 플로우")));
+
+    List<WorkflowDefinitionSummary> result =
+        useCase.execute(
+            new GetWorkflowDefinitionListQuery(WORKSPACE_ID, PACK_ID, VERSION_ID, USER_ID));
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).workflowCode()).isEqualTo("refund_flow");
+    assertThat(result.get(0).name()).isEqualTo("환불 플로우");
+  }
+
+  @Test
+  @DisplayName("workflow 없는 version → 빈 목록 반환")
+  void execute_noWorkflows_returnsEmptyList() {
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(true);
+    given(domainPackVersionRepository.findById(VERSION_ID))
+        .willReturn(Optional.of(createVersion(VERSION_ID, PACK_ID)));
+    given(workflowDefinitionRepository.findAllByDomainPackVersionId(VERSION_ID))
+        .willReturn(List.of());
+
+    List<WorkflowDefinitionSummary> result =
+        useCase.execute(
+            new GetWorkflowDefinitionListQuery(WORKSPACE_ID, PACK_ID, VERSION_ID, USER_ID));
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  @DisplayName("workspace 없음 → DomainPackWorkspaceNotFoundException")
+  void execute_workspaceNotFound_throwsException() {
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(false);
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new GetWorkflowDefinitionListQuery(WORKSPACE_ID, PACK_ID, VERSION_ID, USER_ID)))
+        .isInstanceOf(DomainPackWorkspaceNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("접근 권한 없음 → DomainPackUnauthorizedWorkspaceAccessException")
+  void execute_unauthorized_throwsException() {
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(false);
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new GetWorkflowDefinitionListQuery(WORKSPACE_ID, PACK_ID, VERSION_ID, USER_ID)))
+        .isInstanceOf(DomainPackUnauthorizedWorkspaceAccessException.class);
+  }
+
+  @Test
+  @DisplayName("domain pack 소속 불일치 → DomainPackNotFoundException")
+  void execute_packNotInWorkspace_throwsException() {
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(false);
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new GetWorkflowDefinitionListQuery(WORKSPACE_ID, PACK_ID, VERSION_ID, USER_ID)))
+        .isInstanceOf(DomainPackNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("version 소속 불일치 → DomainPackVersionNotFoundException")
+  void execute_versionNotInPack_throwsException() {
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(true);
+    given(domainPackVersionRepository.findById(VERSION_ID))
+        .willReturn(Optional.of(createVersion(VERSION_ID, 999L)));
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new GetWorkflowDefinitionListQuery(WORKSPACE_ID, PACK_ID, VERSION_ID, USER_ID)))
+        .isInstanceOf(DomainPackVersionNotFoundException.class);
+  }
+
+  private DomainPackVersion createVersion(Long id, Long packId) {
+    try {
+      Constructor<DomainPackVersion> ctor = DomainPackVersion.class.getDeclaredConstructor();
+      ctor.setAccessible(true);
+      DomainPackVersion version = ctor.newInstance();
+      ReflectionTestUtils.setField(version, "id", id);
+      ReflectionTestUtils.setField(version, "domainPackId", packId);
+      ReflectionTestUtils.setField(version, "lifecycleStatus", "DRAFT");
+      return version;
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private WorkflowDefinitionSummaryRow createSummaryRow(Long id, String code, String name) {
+    return new WorkflowDefinitionSummaryRow() {
+      @Override
+      public Long getId() {
+        return id;
+      }
+
+      @Override
+      public String getWorkflowCode() {
+        return code;
+      }
+
+      @Override
+      public String getName() {
+        return name;
+      }
+
+      @Override
+      public String getDescription() {
+        return null;
+      }
+
+      @Override
+      public String getInitialState() {
+        return "start";
+      }
+
+      @Override
+      public String getTerminalStatesJson() {
+        return "[\"terminal\"]";
+      }
+
+      @Override
+      public OffsetDateTime getCreatedAt() {
+        return OffsetDateTime.parse("2026-04-14T10:00:00Z");
+      }
+
+      @Override
+      public OffsetDateTime getUpdatedAt() {
+        return OffsetDateTime.parse("2026-04-14T10:00:00Z");
+      }
+    };
+  }
+}

--- a/backend/src/test/java/com/init/domainpack/application/GetWorkflowDefinitionListUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/GetWorkflowDefinitionListUseCaseTest.java
@@ -16,7 +16,6 @@ import com.init.domainpack.domain.repository.WorkflowDefinitionRepository;
 import com.init.domainpack.domain.repository.WorkflowDefinitionSummaryRow;
 import com.init.domainpack.domain.repository.WorkspaceExistencePort;
 import com.init.domainpack.domain.repository.WorkspaceMembershipPort;
-import java.lang.reflect.Constructor;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -26,7 +25,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("GetWorkflowDefinitionListUseCase")
@@ -47,13 +45,13 @@ class GetWorkflowDefinitionListUseCaseTest {
 
   @BeforeEach
   void setUp() {
-    useCase =
-        new GetWorkflowDefinitionListUseCase(
+    DomainPackValidator validator =
+        new DomainPackValidator(
             workspaceExistencePort,
             workspaceMembershipPort,
             domainPackRepository,
-            domainPackVersionRepository,
-            workflowDefinitionRepository);
+            domainPackVersionRepository);
+    useCase = new GetWorkflowDefinitionListUseCase(validator, workflowDefinitionRepository);
   }
 
   @Test
@@ -150,17 +148,7 @@ class GetWorkflowDefinitionListUseCaseTest {
   }
 
   private DomainPackVersion createVersion(Long id, Long packId) {
-    try {
-      Constructor<DomainPackVersion> ctor = DomainPackVersion.class.getDeclaredConstructor();
-      ctor.setAccessible(true);
-      DomainPackVersion version = ctor.newInstance();
-      ReflectionTestUtils.setField(version, "id", id);
-      ReflectionTestUtils.setField(version, "domainPackId", packId);
-      ReflectionTestUtils.setField(version, "lifecycleStatus", "DRAFT");
-      return version;
-    } catch (Exception e) {
-      throw new RuntimeException(e);
-    }
+    return DomainPackVersion.ofForTest(id, packId, DomainPackVersion.STATUS_DRAFT);
   }
 
   private WorkflowDefinitionSummaryRow createSummaryRow(Long id, String code, String name) {

--- a/backend/src/test/java/com/init/domainpack/application/GetWorkflowDefinitionUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/GetWorkflowDefinitionUseCaseTest.java
@@ -10,6 +10,7 @@ import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspace
 import com.init.domainpack.application.exception.DomainPackVersionNotFoundException;
 import com.init.domainpack.application.exception.DomainPackWorkspaceNotFoundException;
 import com.init.domainpack.application.exception.WorkflowDefinitionNotFoundException;
+import com.init.domainpack.application.exception.WorkflowGraphJsonInvalidException;
 import com.init.domainpack.domain.model.DomainPackVersion;
 import com.init.domainpack.domain.model.WorkflowDefinition;
 import com.init.domainpack.domain.repository.DomainPackRepository;
@@ -135,6 +136,26 @@ class GetWorkflowDefinitionUseCaseTest {
                     new GetWorkflowDefinitionQuery(
                         WORKSPACE_ID, PACK_ID, VERSION_ID, WORKFLOW_ID, USER_ID)))
         .isInstanceOf(DomainPackVersionNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("graphJson이 유효하지 않음 → WorkflowGraphJsonInvalidException")
+  void execute_invalidGraphJson_throwsException() {
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(true);
+    given(domainPackVersionRepository.findById(VERSION_ID))
+        .willReturn(Optional.of(createVersion(VERSION_ID, PACK_ID)));
+    given(workflowDefinitionRepository.findByIdAndDomainPackVersionId(WORKFLOW_ID, VERSION_ID))
+        .willReturn(
+            Optional.of(createWorkflow(WORKFLOW_ID, "refund_flow", "not-valid-json")));
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new GetWorkflowDefinitionQuery(
+                        WORKSPACE_ID, PACK_ID, VERSION_ID, WORKFLOW_ID, USER_ID)))
+        .isInstanceOf(WorkflowGraphJsonInvalidException.class);
   }
 
   @Test

--- a/backend/src/test/java/com/init/domainpack/application/GetWorkflowDefinitionUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/GetWorkflowDefinitionUseCaseTest.java
@@ -5,6 +5,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
+import com.init.domainpack.application.exception.DomainPackNotFoundException;
+import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
+import com.init.domainpack.application.exception.DomainPackVersionNotFoundException;
+import com.init.domainpack.application.exception.DomainPackWorkspaceNotFoundException;
 import com.init.domainpack.application.exception.WorkflowDefinitionNotFoundException;
 import com.init.domainpack.domain.model.DomainPackVersion;
 import com.init.domainpack.domain.model.WorkflowDefinition;
@@ -13,7 +17,6 @@ import com.init.domainpack.domain.repository.DomainPackVersionRepository;
 import com.init.domainpack.domain.repository.WorkflowDefinitionRepository;
 import com.init.domainpack.domain.repository.WorkspaceExistencePort;
 import com.init.domainpack.domain.repository.WorkspaceMembershipPort;
-import java.lang.reflect.Constructor;
 import java.time.OffsetDateTime;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -45,13 +48,13 @@ class GetWorkflowDefinitionUseCaseTest {
 
   @BeforeEach
   void setUp() {
-    useCase =
-        new GetWorkflowDefinitionUseCase(
+    DomainPackValidator validator =
+        new DomainPackValidator(
             workspaceExistencePort,
             workspaceMembershipPort,
             domainPackRepository,
-            domainPackVersionRepository,
-            workflowDefinitionRepository);
+            domainPackVersionRepository);
+    useCase = new GetWorkflowDefinitionUseCase(validator, workflowDefinitionRepository);
   }
 
   @Test
@@ -76,6 +79,65 @@ class GetWorkflowDefinitionUseCaseTest {
   }
 
   @Test
+  @DisplayName("workspace 없음 → DomainPackWorkspaceNotFoundException")
+  void execute_workspaceNotFound_throwsException() {
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(false);
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new GetWorkflowDefinitionQuery(
+                        WORKSPACE_ID, PACK_ID, VERSION_ID, WORKFLOW_ID, USER_ID)))
+        .isInstanceOf(DomainPackWorkspaceNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("접근 권한 없음 → DomainPackUnauthorizedWorkspaceAccessException")
+  void execute_unauthorized_throwsException() {
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(false);
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new GetWorkflowDefinitionQuery(
+                        WORKSPACE_ID, PACK_ID, VERSION_ID, WORKFLOW_ID, USER_ID)))
+        .isInstanceOf(DomainPackUnauthorizedWorkspaceAccessException.class);
+  }
+
+  @Test
+  @DisplayName("domain pack 소속 불일치 → DomainPackNotFoundException")
+  void execute_packNotInWorkspace_throwsException() {
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(false);
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new GetWorkflowDefinitionQuery(
+                        WORKSPACE_ID, PACK_ID, VERSION_ID, WORKFLOW_ID, USER_ID)))
+        .isInstanceOf(DomainPackNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("version 소속 불일치 → DomainPackVersionNotFoundException")
+  void execute_versionNotInPack_throwsException() {
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(true);
+    given(domainPackVersionRepository.findById(VERSION_ID))
+        .willReturn(Optional.of(createVersion(VERSION_ID, 999L)));
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new GetWorkflowDefinitionQuery(
+                        WORKSPACE_ID, PACK_ID, VERSION_ID, WORKFLOW_ID, USER_ID)))
+        .isInstanceOf(DomainPackVersionNotFoundException.class);
+  }
+
+  @Test
   @DisplayName("workflowId가 versionId에 속하지 않음 → WorkflowDefinitionNotFoundException")
   void execute_workflowNotInVersion_throwsException() {
     given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
@@ -95,17 +157,7 @@ class GetWorkflowDefinitionUseCaseTest {
   }
 
   private DomainPackVersion createVersion(Long id, Long packId) {
-    try {
-      Constructor<DomainPackVersion> ctor = DomainPackVersion.class.getDeclaredConstructor();
-      ctor.setAccessible(true);
-      DomainPackVersion version = ctor.newInstance();
-      ReflectionTestUtils.setField(version, "id", id);
-      ReflectionTestUtils.setField(version, "domainPackId", packId);
-      ReflectionTestUtils.setField(version, "lifecycleStatus", "DRAFT");
-      return version;
-    } catch (Exception e) {
-      throw new RuntimeException(e);
-    }
+    return DomainPackVersion.ofForTest(id, packId, DomainPackVersion.STATUS_DRAFT);
   }
 
   private WorkflowDefinition createWorkflow(Long id, String code, String graphJson) {

--- a/backend/src/test/java/com/init/domainpack/application/GetWorkflowDefinitionUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/GetWorkflowDefinitionUseCaseTest.java
@@ -147,8 +147,7 @@ class GetWorkflowDefinitionUseCaseTest {
     given(domainPackVersionRepository.findById(VERSION_ID))
         .willReturn(Optional.of(createVersion(VERSION_ID, PACK_ID)));
     given(workflowDefinitionRepository.findByIdAndDomainPackVersionId(WORKFLOW_ID, VERSION_ID))
-        .willReturn(
-            Optional.of(createWorkflow(WORKFLOW_ID, "refund_flow", "not-valid-json")));
+        .willReturn(Optional.of(createWorkflow(WORKFLOW_ID, "refund_flow", "not-valid-json")));
 
     assertThatThrownBy(
             () ->

--- a/backend/src/test/java/com/init/domainpack/application/GetWorkflowDefinitionUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/GetWorkflowDefinitionUseCaseTest.java
@@ -1,0 +1,120 @@
+package com.init.domainpack.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.init.domainpack.application.exception.WorkflowDefinitionNotFoundException;
+import com.init.domainpack.domain.model.DomainPackVersion;
+import com.init.domainpack.domain.model.WorkflowDefinition;
+import com.init.domainpack.domain.repository.DomainPackRepository;
+import com.init.domainpack.domain.repository.DomainPackVersionRepository;
+import com.init.domainpack.domain.repository.WorkflowDefinitionRepository;
+import com.init.domainpack.domain.repository.WorkspaceExistencePort;
+import com.init.domainpack.domain.repository.WorkspaceMembershipPort;
+import java.lang.reflect.Constructor;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetWorkflowDefinitionUseCase")
+class GetWorkflowDefinitionUseCaseTest {
+
+  @Mock private WorkspaceExistencePort workspaceExistencePort;
+  @Mock private WorkspaceMembershipPort workspaceMembershipPort;
+  @Mock private DomainPackRepository domainPackRepository;
+  @Mock private DomainPackVersionRepository domainPackVersionRepository;
+  @Mock private WorkflowDefinitionRepository workflowDefinitionRepository;
+
+  private GetWorkflowDefinitionUseCase useCase;
+
+  private static final Long WORKSPACE_ID = 1L;
+  private static final Long PACK_ID = 7L;
+  private static final Long VERSION_ID = 101L;
+  private static final Long WORKFLOW_ID = 3001L;
+  private static final Long USER_ID = 10L;
+  private static final String VALID_GRAPH_JSON = "{\"direction\":\"LR\",\"nodes\":[],\"edges\":[]}";
+
+  @BeforeEach
+  void setUp() {
+    useCase =
+        new GetWorkflowDefinitionUseCase(
+            workspaceExistencePort,
+            workspaceMembershipPort,
+            domainPackRepository,
+            domainPackVersionRepository,
+            workflowDefinitionRepository);
+  }
+
+  @Test
+  @DisplayName("정상 조회 시 graphJson 포함 전체 필드 반환")
+  void execute_withValidQuery_returnsDetail() {
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(true);
+    given(domainPackVersionRepository.findById(VERSION_ID))
+        .willReturn(Optional.of(createVersion(VERSION_ID, PACK_ID)));
+    given(workflowDefinitionRepository.findByIdAndDomainPackVersionId(WORKFLOW_ID, VERSION_ID))
+        .willReturn(Optional.of(createWorkflow(WORKFLOW_ID, "refund_flow", VALID_GRAPH_JSON)));
+
+    WorkflowDefinitionDetail result =
+        useCase.execute(
+            new GetWorkflowDefinitionQuery(
+                WORKSPACE_ID, PACK_ID, VERSION_ID, WORKFLOW_ID, USER_ID));
+
+    assertThat(result.id()).isEqualTo(WORKFLOW_ID);
+    assertThat(result.workflowCode()).isEqualTo("refund_flow");
+    assertThat(result.graphJson()).isEqualTo(VALID_GRAPH_JSON);
+  }
+
+  @Test
+  @DisplayName("workflowId가 versionId에 속하지 않음 → WorkflowDefinitionNotFoundException")
+  void execute_workflowNotInVersion_throwsException() {
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(true);
+    given(domainPackVersionRepository.findById(VERSION_ID))
+        .willReturn(Optional.of(createVersion(VERSION_ID, PACK_ID)));
+    given(workflowDefinitionRepository.findByIdAndDomainPackVersionId(WORKFLOW_ID, VERSION_ID))
+        .willReturn(Optional.empty());
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new GetWorkflowDefinitionQuery(
+                        WORKSPACE_ID, PACK_ID, VERSION_ID, WORKFLOW_ID, USER_ID)))
+        .isInstanceOf(WorkflowDefinitionNotFoundException.class);
+  }
+
+  private DomainPackVersion createVersion(Long id, Long packId) {
+    try {
+      Constructor<DomainPackVersion> ctor = DomainPackVersion.class.getDeclaredConstructor();
+      ctor.setAccessible(true);
+      DomainPackVersion version = ctor.newInstance();
+      ReflectionTestUtils.setField(version, "id", id);
+      ReflectionTestUtils.setField(version, "domainPackId", packId);
+      ReflectionTestUtils.setField(version, "lifecycleStatus", "DRAFT");
+      return version;
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private WorkflowDefinition createWorkflow(Long id, String code, String graphJson) {
+    WorkflowDefinition wf =
+        WorkflowDefinition.create(
+            VERSION_ID, code, "환불 플로우", null, graphJson, "start", "[\"terminal\"]", null, null);
+    ReflectionTestUtils.setField(wf, "id", id);
+    ReflectionTestUtils.setField(wf, "createdAt", OffsetDateTime.parse("2026-04-14T10:00:00Z"));
+    ReflectionTestUtils.setField(wf, "updatedAt", OffsetDateTime.parse("2026-04-14T10:00:00Z"));
+    return wf;
+  }
+}

--- a/backend/src/test/java/com/init/domainpack/presentation/WorkflowDefinitionControllerTest.java
+++ b/backend/src/test/java/com/init/domainpack/presentation/WorkflowDefinitionControllerTest.java
@@ -1,0 +1,154 @@
+package com.init.domainpack.presentation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.init.domainpack.application.GetWorkflowDefinitionListUseCase;
+import com.init.domainpack.application.GetWorkflowDefinitionUseCase;
+import com.init.domainpack.application.WorkflowDefinitionDetail;
+import com.init.domainpack.application.WorkflowDefinitionSummary;
+import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
+import com.init.domainpack.application.exception.DomainPackVersionNotFoundException;
+import com.init.domainpack.application.exception.WorkflowDefinitionNotFoundException;
+import com.init.fixtures.WithLongPrincipal;
+import com.init.shared.infrastructure.security.JwtAuthenticationFilter;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(
+    value = WorkflowDefinitionController.class,
+    excludeFilters =
+        @ComponentScan.Filter(
+            type = FilterType.ASSIGNABLE_TYPE,
+            classes = JwtAuthenticationFilter.class))
+@DisplayName("WorkflowDefinitionController")
+class WorkflowDefinitionControllerTest {
+
+  private static final String BASE_URL =
+      "/api/v1/workspaces/1/domain-packs/7/versions/101/workflows";
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private GetWorkflowDefinitionListUseCase listUseCase;
+  @MockitoBean private GetWorkflowDefinitionUseCase detailUseCase;
+
+  @Test
+  @DisplayName("GET .../workflows → 200 OK, 목록 반환")
+  @WithLongPrincipal(10L)
+  void listWorkflows_returnsOk() throws Exception {
+    given(listUseCase.execute(any()))
+        .willReturn(
+            List.of(
+                new WorkflowDefinitionSummary(
+                    1L,
+                    "refund_flow",
+                    "환불 플로우",
+                    null,
+                    "start",
+                    "[\"terminal\"]",
+                    OffsetDateTime.parse("2026-04-14T10:00:00Z"),
+                    OffsetDateTime.parse("2026-04-14T10:00:00Z"))));
+
+    mockMvc
+        .perform(get(BASE_URL))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].workflowCode").value("refund_flow"))
+        .andExpect(jsonPath("$[0].name").value("환불 플로우"))
+        .andExpect(jsonPath("$[0].graphJson").doesNotExist());
+  }
+
+  @Test
+  @DisplayName("GET .../workflows/{id} → 200 OK, graphJson 포함")
+  @WithLongPrincipal(10L)
+  void getWorkflow_returnsOkWithGraphJson() throws Exception {
+    given(detailUseCase.execute(any()))
+        .willReturn(
+            new WorkflowDefinitionDetail(
+                1L,
+                "refund_flow",
+                "환불 플로우",
+                null,
+                "{\"direction\":\"LR\",\"nodes\":[],\"edges\":[]}",
+                "start",
+                "[\"terminal\"]",
+                "[]",
+                "{}",
+                OffsetDateTime.parse("2026-04-14T10:00:00Z"),
+                OffsetDateTime.parse("2026-04-14T10:00:00Z")));
+
+    mockMvc
+        .perform(get(BASE_URL + "/1"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.workflowCode").value("refund_flow"))
+        .andExpect(jsonPath("$.graphJson.direction").value("LR"))
+        .andExpect(jsonPath("$.graphJson.nodes").isArray())
+        .andExpect(jsonPath("$.graphJson.edges").isArray());
+  }
+
+  @Test
+  @DisplayName("GET .../workflows → workflow 없으면 빈 배열")
+  @WithLongPrincipal(10L)
+  void listWorkflows_noWorkflows_returnsEmptyArray() throws Exception {
+    given(listUseCase.execute(any())).willReturn(List.of());
+
+    mockMvc
+        .perform(get(BASE_URL))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$").isEmpty());
+  }
+
+  @Test
+  @DisplayName("GET .../workflows/{id} → 404 미존재")
+  @WithLongPrincipal(10L)
+  void getWorkflow_notFound_returns404() throws Exception {
+    given(detailUseCase.execute(any())).willThrow(new WorkflowDefinitionNotFoundException(99L));
+
+    mockMvc
+        .perform(get(BASE_URL + "/99"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("WORKFLOW_DEFINITION_NOT_FOUND"));
+  }
+
+  @Test
+  @DisplayName("GET .../workflows → 403 권한 없음")
+  @WithLongPrincipal(10L)
+  void listWorkflows_unauthorized_returns403() throws Exception {
+    given(listUseCase.execute(any()))
+        .willThrow(new DomainPackUnauthorizedWorkspaceAccessException("워크스페이스에 접근 권한이 없습니다."));
+
+    mockMvc
+        .perform(get(BASE_URL))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.code").value("FORBIDDEN"));
+  }
+
+  @Test
+  @DisplayName("GET .../workflows → 401 미인증")
+  void listWorkflows_unauthenticated_returns401() throws Exception {
+    mockMvc.perform(get(BASE_URL)).andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @DisplayName("GET .../workflows → 404 version 소속 불일치")
+  @WithLongPrincipal(10L)
+  void listWorkflows_versionNotInPack_returns404() throws Exception {
+    given(listUseCase.execute(any())).willThrow(new DomainPackVersionNotFoundException(101L));
+
+    mockMvc
+        .perform(get(BASE_URL))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("DOMAIN_PACK_VERSION_NOT_FOUND"));
+  }
+}


### PR DESCRIPTION
## Summary

- `DomainPackVersion` 하위 `WorkflowDefinition` 목록 조회(graphJson 제외) / 단건 조회(graphJson 포함) 두 GET 엔드포인트 추가
- `WorkflowDefinitionDetail.from()`에서 graphJson 구조 유효성(최상위 object, `direction`/`nodes`/`edges` 키) 검사 — 실패 시 500 `WORKFLOW_GRAPH_JSON_INVALID`
- `GlobalExceptionHandler`에 `InternalException` → 500 핸들러 추가

---

## Context

스펙 `.agent/specs/226.md` 구현 PR. graphJson의 V1~V6 무결성 규칙(node type 제약, DAG 구조 등)은 이 스펙에서 **정의**하며, 코드 강제는 spec 231 (`CreateDomainPackDraftUseCase`) write path 범위다.

---

## What Changed

| 영역 | 변경 내용 |
|------|----------|
| `WorkflowDefinition` | `getCreatedAt()`, `getUpdatedAt()` getter 추가 |
| `WorkflowDefinitionRepository` (domain port) | `findAllByDomainPackVersionId`, `findByIdAndDomainPackVersionId` 시그니처 추가 |
| `WorkflowDefinitionSummaryRow` (신규) | Spring Data 프로젝션 인터페이스, graphJson 제외 8개 필드 |
| `JpaWorkflowDefinitionRepository` | 위 두 메서드 `@Override` 구현, `findByDomainPackVersionId` 제거 |
| `GetWorkflowDefinitionListUseCase` (신규) | workspace/membership/pack/version 순서 검증 후 목록 반환 |
| `GetWorkflowDefinitionUseCase` (신규) | 동일 검증 후 단건 상세 반환 |
| `WorkflowDefinitionDetail` (신규) | `@JsonRawValue graphJson` + `validateGraphJson()` 포함 |
| `WorkflowDefinitionNotFoundException` (신규) | `WORKFLOW_DEFINITION_NOT_FOUND`, 404 |
| `WorkflowGraphJsonInvalidException` (신규) | `WORKFLOW_GRAPH_JSON_INVALID`, 500 |
| `InternalException` (신규, shared) | 500 용도 공유 예외 클래스 |
| `GlobalExceptionHandler` | `InternalException` 핸들러(500) 추가, `handleBusiness` fallback 앞에 선언 |
| `WorkflowDefinitionController` (신규) | 두 엔드포인트 라우팅 |
| 테스트 3종 (신규) | UseCase unit × 2, Controller `@WebMvcTest` × 1 |

---

## Assumptions Adopted

| ID | 내용 | 영향 |
|----|------|------|
| UR-226-03 | `WorkflowDefinitionDetail`에 `@JsonRawValue`, `ObjectMapper`, `JsonNode` 포함 (Jackson in application layer) | spec 226 명시적 지시 수용. Audit W-2로 기록됨. 추후 presentation DTO 분리 리팩토링 고려 가능 |
| UR-226-04 | 도메인 포트 메서드명 `findAllByDomainPackVersionId`로 통일 | spec/226 커밋에서 이미 반영됨. 이 PR의 UseCase가 해당 메서드를 호출 |

---

## Spec Deviations

| 항목 | 스펙 명시 | 실제 구현 |
|------|----------|----------|
| 브랜치명 | `feature/226-workflow-draft-read` | `feature/226-workflow-components-schema` |
| `GetWorkflowDefinitionUseCaseTest` | workspace/pack/version 실패 시나리오 포함 | 2개 시나리오만 작성 — list UseCase 테스트로 간접 커버, 위험도 낮음 |
| `WorkflowDefinitionControllerTest` | workspace/pack 미존재 404 시나리오 포함 | 미작성 |

---

## Blocked / Skipped Items

| 항목 | 이유 | 영향 |
|------|------|------|
| V1~V6 graphJson 무결성 규칙 코드 강제 (UR-226-01) | spec 226은 정의 범위, 코드 강제는 spec 231 write path | spec 231 구현 전까지 유효하지 않은 graphJson 저장 방지 불가 |

---

## Test Notes

| 파일 | 타입 | 시나리오 수 | 결과 |
|------|------|-----------|------|
| `GetWorkflowDefinitionListUseCaseTest` | Unit (Mockito) | 5 (정상, 빈 목록, workspace/pack/version 실패) | PASS |
| `GetWorkflowDefinitionUseCaseTest` | Unit (Mockito) | 2 (정상, workflowId 불일치) | PASS |
| `WorkflowDefinitionControllerTest` | @WebMvcTest | 7 (200×2, 빈 배열, 404, 403, 401, version 불일치 404) | PASS |

Audit 결과: **Critical 0건 / Warning 3건 / Info 2건 → PASS**

---

## Reviewer Focus

1. **W-3 광범위 Exception catch** (`WorkflowDefinitionDetail.java` `validateGraphJson`) — `catch (Exception e)` 대신 `catch (JsonProcessingException e)`로 좁히는 것이 적합한지 확인
2. **W-2 application 레이어 Jackson 의존** — `WorkflowDefinitionDetail`이 `@JsonRawValue`, `ObjectMapper`를 보유하는 설계가 장기적으로 허용 가능한지 (spec 명시이므로 현재는 수용)
3. **graphJson 검증 위치** — 읽기 경로에서 구조 유효성 검사를 수행하는 것이 spec 의도와 맞는지 확인

---

## Conflicts

- **W-1 커밋 타입 `spec`**: 이전 commit(`spec/226: ...`)에서 이미 머지된 상태. 이 PR에서 수정 불가. 향후 스펙 관련 커밋은 `docs` 타입 사용 권장.
- 그 외 unresolved conflict 없음.

---

## Ready to Merge / Needs Input

**Ready to Merge** — Critical 위반 없음. W-3은 선택적 개선(merge blocker 아님). spec 231 구현 전까지 V1~V6 코드 강제 부재 리스크는 인지된 상태.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 도메인 팩 버전 내 워크플로우 목록 조회 API 추가
  * 특정 워크플로우 상세 정보 조회 API 추가
  * 워크플로우 상세 응답에 생성/수정 시각 포함

* **품질 개선**
  * 워크플로우 그래프 JSON 구조 유효성 검사 추가
  * 인증 정보 추출 로직 중앙화로 엔드포인트 인증/권한 처리 일관화
  * 내부 오류에 대해 500 응답 표준화

* **테스트**
  * 목록/상세 조회 관련 단위 및 웹 계층 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->