### PR TITLE
spec/31: update backlog 2.3.1(231.md) as issue #31(31.md) was added.

### DIFF
--- a/.agent/specs/231.md
+++ b/.agent/specs/231.md
@@ -13,6 +13,8 @@
 
 추가로 `DomainPackVersion.summaryJson`은 PostgreSQL `jsonb` 컬럼으로 저장되며, Hibernate 런타임에서도 JSON 타입으로 바인딩되도록 보장한다.
 
+저장 전에 각 workflow의 `graphJson`에 대해 `.agent/specs/226.md`에서 정의한 V1-V6 무결성 규칙을 `validateDraftPayload()` write path에서 강제하며, 위반 시 400 Bad Request를 반환한다.
+
 ---
 
 ## Sequence Diagram
@@ -97,6 +99,7 @@ sequenceDiagram
 - `policies`: 최대 200개
 - `risks`: 최대 200개
 - `workflows`: 최대 200개
+- `workflows[].graphJson`: V1-V6 무결성 검증 대상 (`.agent/specs/226.md`). `initialState` / `terminalStatesJson`은 request에 포함하지 않으며, 서버가 graphJson 검증 후 자동 추출하여 저장한다.
 - `intentWorkflowBindings`: 최대 500개
 - `riskLevel`: `LOW`, `MEDIUM`, `HIGH`, `CRITICAL` 중 하나
 
@@ -129,7 +132,7 @@ sequenceDiagram
     {
       "workflowCode": "refund_flow",
       "name": "환불 플로우",
-      "graphJson": "{\"nodes\":[]}"
+      "graphJson": "{\"direction\":\"LR\",\"nodes\":[{\"id\":\"start\",\"label\":\"상담 시작\",\"type\":\"START\"},{\"id\":\"collect_order_id\",\"label\":\"주문번호 수집\",\"type\":\"ACTION\"},{\"id\":\"terminal\",\"label\":\"상담 종료\",\"type\":\"TERMINAL\"}],\"edges\":[{\"from\":\"start\",\"to\":\"collect_order_id\"},{\"from\":\"collect_order_id\",\"to\":\"terminal\"}]}"
     }
   ],
   "intentWorkflowBindings": [
@@ -162,13 +165,24 @@ sequenceDiagram
 }
 ```
 
-**400 Bad Request**
+**400 Bad Request** — 바인딩 참조 코드 오류
 
 ```json
 {
   "code": "DOMAIN_PACK_DRAFT_INVALID_REQUEST",
   "message": "slot 참조를 찾을 수 없습니다. code=missing_slot"
 }
+```
+
+**400 Bad Request** — workflow graphJson 무결성 규칙(V1-V6) 위반
+
+```json
+{ "code": "WORKFLOW_INVALID_START_NODE",    "message": "START 노드가 정확히 1개여야 합니다. workflowCode=refund_flow" }
+{ "code": "WORKFLOW_INVALID_TERMINAL_NODE", "message": "TERMINAL 노드가 1개 이상이어야 합니다. workflowCode=refund_flow" }
+{ "code": "WORKFLOW_DANGLING_EDGE",         "message": "엣지가 존재하지 않는 노드를 참조합니다. workflowCode=refund_flow" }
+{ "code": "WORKFLOW_UNREACHABLE_NODE",      "message": "도달 불가 노드가 존재합니다. workflowCode=refund_flow" }
+{ "code": "WORKFLOW_CYCLE_DETECTED",        "message": "workflow 그래프에 사이클이 있습니다. workflowCode=refund_flow" }
+{ "code": "WORKFLOW_UNLABELED_BRANCH",      "message": "DECISION 노드의 모든 outgoing edge에 label이 필요합니다. workflowCode=refund_flow" }
 ```
 
 **404 Not Found**
@@ -239,6 +253,71 @@ classDiagram
     CreateDomainPackDraftUseCase --> WorkflowDefinition
 ```
 
+### Application Layer — validateDraftPayload
+
+`validateDraftPayload(command)` 내 검증 순서:
+
+1. intent code 중복 검증
+2. slot code 중복 검증
+3. workflow code 중복 검증
+4. `intentSlotBindings` 참조 코드 유효성 (intent/slot code 목록 내 존재 여부)
+5. `intentWorkflowBindings` 참조 코드 유효성 (intent/workflow code 목록 내 존재 여부)
+6. 각 workflow `graphJson` V1-V6 검증 (`.agent/specs/226.md` 참조):
+   - V1: `type == "START"` 노드 **정확히 1개** → `WorkflowInvalidStartNodeException`
+   - V2: `type == "TERMINAL"` 노드 **1개 이상** → `WorkflowInvalidTerminalNodeException`
+   - V3: `edges.from/to` 참조 노드 id 모두 `nodes`에 존재 → `WorkflowDanglingEdgeException`
+   - V4: START에서 모든 노드 BFS/DFS 도달 가능 → `WorkflowUnreachableNodeException`
+   - V5: 사이클 없음 (DAG) → `WorkflowCycleDetectedException`
+   - V6: `DECISION` 노드 outgoing edge 전체에 `label` 존재 → `WorkflowUnlabeledBranchException`
+7. V1-V6 통과 후 graphJson에서 자동 추출:
+   - `initialState` = `type == "START"` 노드의 `id`
+   - `terminalStatesJson` = `type == "TERMINAL"` 노드 `id` 목록을 JSON 배열 문자열로 직렬화 (예: `"[\"terminal\"]"`)
+
+> `WorkflowDraftRequest` 및 `WorkflowDraft` command record에는 `initialState` / `terminalStatesJson` 필드를 포함하지 않는다. 클라이언트는 `graphJson`만 제공하며, 서버가 검증 후 추출하여 `WorkflowDefinition` 엔티티에 저장한다.
+
+### 신규 예외 클래스
+
+```java
+import com.init.shared.application.exception.BadRequestException;
+
+// backend/src/main/java/com/init/domainpack/application/exception/
+public class WorkflowInvalidStartNodeException extends BadRequestException {
+  public WorkflowInvalidStartNodeException(String workflowCode) {
+    super("WORKFLOW_INVALID_START_NODE", "START 노드가 정확히 1개여야 합니다. workflowCode=" + workflowCode);
+  }
+}
+
+public class WorkflowInvalidTerminalNodeException extends BadRequestException {
+  public WorkflowInvalidTerminalNodeException(String workflowCode) {
+    super("WORKFLOW_INVALID_TERMINAL_NODE", "TERMINAL 노드가 1개 이상이어야 합니다. workflowCode=" + workflowCode);
+  }
+}
+
+public class WorkflowDanglingEdgeException extends BadRequestException {
+  public WorkflowDanglingEdgeException(String workflowCode) {
+    super("WORKFLOW_DANGLING_EDGE", "엣지가 존재하지 않는 노드를 참조합니다. workflowCode=" + workflowCode);
+  }
+}
+
+public class WorkflowUnreachableNodeException extends BadRequestException {
+  public WorkflowUnreachableNodeException(String workflowCode) {
+    super("WORKFLOW_UNREACHABLE_NODE", "도달 불가 노드가 존재합니다. workflowCode=" + workflowCode);
+  }
+}
+
+public class WorkflowCycleDetectedException extends BadRequestException {
+  public WorkflowCycleDetectedException(String workflowCode) {
+    super("WORKFLOW_CYCLE_DETECTED", "workflow 그래프에 사이클이 있습니다. workflowCode=" + workflowCode);
+  }
+}
+
+public class WorkflowUnlabeledBranchException extends BadRequestException {
+  public WorkflowUnlabeledBranchException(String workflowCode) {
+    super("WORKFLOW_UNLABELED_BRANCH", "DECISION 노드의 모든 outgoing edge에 label이 필요합니다. workflowCode=" + workflowCode);
+  }
+}
+```
+
 ---
 
 ## Tests
@@ -249,6 +328,13 @@ classDiagram
 - workspace 없음 → `DomainPackWorkspaceNotFoundException`
 - domain pack 소속 불일치 → `DomainPackNotFoundException`
 - 존재하지 않는 참조 코드 → `DomainPackDraftRequestInvalidException`
+- graphJson V1 위반: START 노드 0개 → `WorkflowInvalidStartNodeException`
+- graphJson V1 위반: START 노드 2개 → `WorkflowInvalidStartNodeException`
+- graphJson V2 위반: TERMINAL 노드 없음 → `WorkflowInvalidTerminalNodeException`
+- graphJson V3 위반: edge가 없는 노드 id 참조 → `WorkflowDanglingEdgeException`
+- graphJson V4 위반: START에서 도달 불가 노드 존재 → `WorkflowUnreachableNodeException`
+- graphJson V5 위반: 사이클 존재 → `WorkflowCycleDetectedException`
+- graphJson V6 위반: DECISION 노드 outgoing edge에 label 없음 → `WorkflowUnlabeledBranchException`
 
 ### Controller Tests
 
@@ -260,6 +346,12 @@ classDiagram
 - 버전 충돌 → `409 DOMAIN_PACK_CONFLICT`
 - 요청 바디 검증 실패 → `400 VALIDATION_ERROR`
 - 인증 없음 → `401 Unauthorized`
+- graphJson V1 위반 (START 0개) → `400 WORKFLOW_INVALID_START_NODE`
+- graphJson V2 위반 (TERMINAL 없음) → `400 WORKFLOW_INVALID_TERMINAL_NODE`
+- graphJson V3 위반 (dangling edge) → `400 WORKFLOW_DANGLING_EDGE`
+- graphJson V4 위반 (unreachable node) → `400 WORKFLOW_UNREACHABLE_NODE`
+- graphJson V5 위반 (cycle) → `400 WORKFLOW_CYCLE_DETECTED`
+- graphJson V6 위반 (unlabeled branch) → `400 WORKFLOW_UNLABELED_BRANCH`
 
 ### Repository Tests
 

--- a/.agent/specs/231.md
+++ b/.agent/specs/231.md
@@ -174,15 +174,30 @@ sequenceDiagram
 }
 ```
 
-**400 Bad Request** — workflow graphJson 무결성 규칙(V1-V6) 위반
+**400 Bad Request** — workflow graphJson 무결성 규칙(V1-V6) 위반 (각 케이스별 독립 응답 예시)
 
 ```json
-{ "code": "WORKFLOW_INVALID_START_NODE",    "message": "START 노드가 정확히 1개여야 합니다. workflowCode=refund_flow" }
+{ "code": "WORKFLOW_INVALID_START_NODE", "message": "START 노드가 정확히 1개여야 합니다. workflowCode=refund_flow" }
+```
+
+```json
 { "code": "WORKFLOW_INVALID_TERMINAL_NODE", "message": "TERMINAL 노드가 1개 이상이어야 합니다. workflowCode=refund_flow" }
-{ "code": "WORKFLOW_DANGLING_EDGE",         "message": "엣지가 존재하지 않는 노드를 참조합니다. workflowCode=refund_flow" }
-{ "code": "WORKFLOW_UNREACHABLE_NODE",      "message": "도달 불가 노드가 존재합니다. workflowCode=refund_flow" }
-{ "code": "WORKFLOW_CYCLE_DETECTED",        "message": "workflow 그래프에 사이클이 있습니다. workflowCode=refund_flow" }
-{ "code": "WORKFLOW_UNLABELED_BRANCH",      "message": "DECISION 노드의 모든 outgoing edge에 label이 필요합니다. workflowCode=refund_flow" }
+```
+
+```json
+{ "code": "WORKFLOW_DANGLING_EDGE", "message": "엣지가 존재하지 않는 노드를 참조합니다. workflowCode=refund_flow" }
+```
+
+```json
+{ "code": "WORKFLOW_UNREACHABLE_NODE", "message": "도달 불가 노드가 존재합니다. workflowCode=refund_flow" }
+```
+
+```json
+{ "code": "WORKFLOW_CYCLE_DETECTED", "message": "workflow 그래프에 사이클이 있습니다. workflowCode=refund_flow" }
+```
+
+```json
+{ "code": "WORKFLOW_UNLABELED_BRANCH", "message": "DECISION 노드의 모든 outgoing edge에 label이 필요합니다. workflowCode=refund_flow" }
 ```
 
 **404 Not Found**
@@ -273,7 +288,7 @@ classDiagram
    - `initialState` = `type == "START"` 노드의 `id`
    - `terminalStatesJson` = `type == "TERMINAL"` 노드 `id` 목록을 JSON 배열 문자열로 직렬화 (예: `"[\"terminal\"]"`)
 
-> `WorkflowDraftRequest` 및 `WorkflowDraft` command record에는 `initialState` / `terminalStatesJson` 필드를 포함하지 않는다. 클라이언트는 `graphJson`만 제공하며, 서버가 검증 후 추출하여 `WorkflowDefinition` 엔티티에 저장한다.
+> 클라이언트 요청 DTO인 `WorkflowDraftRequest`에는 `initialState` / `terminalStatesJson` 필드를 클라이언트가 직접 설정할 수 없으며, 포함 시 400으로 거부한다. 서버가 V1-V6 검증 후 `graphJson`에서 자동 추출하여 내부 `WorkflowDraft` command record와 `WorkflowDefinition` 엔티티에 저장한다.
 
 ### 신규 예외 클래스
 

--- a/.agent/specs/31.md
+++ b/.agent/specs/31.md
@@ -1,0 +1,324 @@
+# [BE-31] CreateDomainPackDraft — graphJson V1-V6 검증 및 `initialState` 자동 추출
+
+> **Backlog**: spec/226에서 확정된 graphJson 무결성 규칙을 `CreateDomainPackDraftUseCase` write path에 적용하고, `initialState` / `terminalStatesJson`을 클라이언트 제공에서 서버 자동 추출로 전환한다
+> **Bounded Context**: `domainpack`
+> **Template**: `_TEMPLATE_BE.md`
+> **Amends**: `.agent/specs/231.md` (기존 스펙 델타)
+> **Branch**: `feature/231-domain-pack-draft-creation`
+
+---
+
+## Goal
+
+`CreateDomainPackDraftUseCase.validateDraftPayload()` write path에 graphJson 무결성 규칙 V1-V6(`.agent/specs/226.md` 정의)를 추가한다.
+V1-V6 통과 후 graphJson nodes에서 `initialState`(START 노드 id)와 `terminalStatesJson`(TERMINAL 노드 id 배열)을 서버가 자동 추출하여 `WorkflowDefinition`에 저장한다.
+이에 따라 `WorkflowDraftRequest` DTO와 `WorkflowDraft` command record에서 두 필드를 제거한다.
+
+---
+
+## Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    actor op as Operator
+    participant ctrl as CreateDomainPackDraftController
+    participant uc as CreateDomainPackDraftUseCase
+    participant validator as validateDraftPayload
+    participant db as PostgreSQL
+
+    op ->> ctrl: POST .../versions/drafts
+    ctrl ->> uc: execute(CreateDomainPackDraftCommand)
+    Note over uc: workspace/pack 검증 (231.md 참조)
+
+    uc ->> validator: validateDraftPayload(command)
+
+    Note over validator: 1. intent/slot/workflow code 중복 검증
+    Note over validator: 2. binding 참조 코드 유효성 검증
+    Note over validator: 3. 각 workflow graphJson V1-V6 검증
+
+    alt V1 위반: START 노드 != 1
+        validator -->> uc: WorkflowInvalidStartNodeException
+        uc -->> ctrl: 400 WORKFLOW_INVALID_START_NODE
+    end
+    alt V2 위반: TERMINAL 노드 없음
+        validator -->> uc: WorkflowInvalidTerminalNodeException
+        uc -->> ctrl: 400 WORKFLOW_INVALID_TERMINAL_NODE
+    end
+    alt V3 위반: dangling edge
+        validator -->> uc: WorkflowDanglingEdgeException
+        uc -->> ctrl: 400 WORKFLOW_DANGLING_EDGE
+    end
+    alt V4 위반: 도달 불가 노드
+        validator -->> uc: WorkflowUnreachableNodeException
+        uc -->> ctrl: 400 WORKFLOW_UNREACHABLE_NODE
+    end
+    alt V5 위반: 사이클 존재
+        validator -->> uc: WorkflowCycleDetectedException
+        uc -->> ctrl: 400 WORKFLOW_CYCLE_DETECTED
+    end
+    alt V6 위반: DECISION outgoing edge label 없음
+        validator -->> uc: WorkflowUnlabeledBranchException
+        uc -->> ctrl: 400 WORKFLOW_UNLABELED_BRANCH
+    end
+
+    Note over validator: 4. graphJson → initialState / terminalStatesJson 추출
+    validator -->> uc: 검증 완료 + 추출값 포함 WorkflowDraft 목록
+
+    uc ->> db: saveAll(WorkflowDefinition) — 추출된 initialState/terminalStatesJson 저장
+    uc -->> ctrl: CreateDomainPackDraftResult
+    ctrl -->> op: 201 Created
+```
+
+---
+
+## REST API
+
+### 변경 사항 — `workflows` 요청 필드
+
+`WorkflowDraftRequest`에서 `initialState`, `terminalStatesJson` 필드를 **제거**한다.
+클라이언트는 `graphJson`만 제공하며, 서버가 V1-V6 검증 후 자동 추출한다.
+
+**변경 전 (기존 DTO)**
+
+```java
+public record WorkflowDraftRequest(
+    @NotBlank String workflowCode,
+    @NotBlank String name,
+    @NotBlank @Size(max = 20000) String graphJson,
+    @Size(max = 100) String initialState,        // 제거
+    @Size(max = 5000) String terminalStatesJson  // 제거
+) {}
+```
+
+**변경 후 (이 스펙 적용)**
+
+```java
+public record WorkflowDraftRequest(
+    @NotBlank String workflowCode,
+    @NotBlank String name,
+    @NotBlank @Size(max = 20000) String graphJson
+) {}
+```
+
+**Request 예시 (workflows 부분)**
+
+```json
+"workflows": [
+  {
+    "workflowCode": "refund_flow",
+    "name": "환불 플로우",
+    "graphJson": "{\"direction\":\"LR\",\"nodes\":[{\"id\":\"start\",\"label\":\"상담 시작\",\"type\":\"START\"},{\"id\":\"collect_order_id\",\"label\":\"주문번호 수집\",\"type\":\"ACTION\"},{\"id\":\"terminal\",\"label\":\"상담 종료\",\"type\":\"TERMINAL\"}],\"edges\":[{\"from\":\"start\",\"to\":\"collect_order_id\"},{\"from\":\"collect_order_id\",\"to\":\"terminal\"}]}"
+  }
+]
+```
+
+### Errors — V1-V6 위반 (400 Bad Request)
+
+```json
+{ "code": "WORKFLOW_INVALID_START_NODE",    "message": "START 노드가 정확히 1개여야 합니다. workflowCode=refund_flow" }
+{ "code": "WORKFLOW_INVALID_TERMINAL_NODE", "message": "TERMINAL 노드가 1개 이상이어야 합니다. workflowCode=refund_flow" }
+{ "code": "WORKFLOW_DANGLING_EDGE",         "message": "엣지가 존재하지 않는 노드를 참조합니다. workflowCode=refund_flow" }
+{ "code": "WORKFLOW_UNREACHABLE_NODE",      "message": "도달 불가 노드가 존재합니다. workflowCode=refund_flow" }
+{ "code": "WORKFLOW_CYCLE_DETECTED",        "message": "workflow 그래프에 사이클이 있습니다. workflowCode=refund_flow" }
+{ "code": "WORKFLOW_UNLABELED_BRANCH",      "message": "DECISION 노드의 모든 outgoing edge에 label이 필요합니다. workflowCode=refund_flow" }
+```
+
+---
+
+## Class Design
+
+### validateDraftPayload — 검증 및 추출 절차
+
+```java
+private List<WorkflowDraft> validateAndExtractWorkflows(CreateDomainPackDraftCommand command) {
+    // 1. workflow code 중복 검증
+    // 2. intentWorkflowBindings 참조 코드 유효성
+    // 3. 각 workflow graphJson V1-V6 검증 후 추출
+    return command.workflows().stream()
+        .map(w -> {
+            GraphJson graph = parseAndValidate(w.graphJson(), w.workflowCode()); // V1-V6
+            String initialState = extractInitialState(graph);        // START 노드 id
+            String terminalStatesJson = extractTerminalStates(graph); // TERMINAL 노드 id 배열 JSON
+            return new WorkflowDraft(w.workflowCode(), w.name(), w.graphJson(),
+                                     initialState, terminalStatesJson);
+        })
+        .toList();
+}
+```
+
+`WorkflowDraft` command record (내부 사용, 추출값 포함):
+
+```java
+// CreateDomainPackDraftCommand 내부 record
+// 요청에서는 initialState/terminalStatesJson 없음 — validateDraftPayload 이후 생성
+public record WorkflowDraft(
+    String workflowCode,
+    String name,
+    String graphJson,
+    String initialState,        // 서버 추출값
+    String terminalStatesJson   // 서버 추출값
+) {}
+```
+
+### 추출 로직 기준 (`.agent/specs/226.md:63-65`)
+
+| 필드 | 추출 방법 |
+|------|-----------|
+| `initialState` | `nodes[]` 중 `type == "START"` 노드의 `id` |
+| `terminalStatesJson` | `nodes[]` 중 `type == "TERMINAL"` 노드의 `id` 목록 → JSON 배열 직렬화 (예: `"[\"terminal\"]"`) |
+
+### 신규 예외 클래스
+
+```java
+import com.init.shared.application.exception.BadRequestException;
+
+// backend/src/main/java/com/init/domainpack/application/exception/
+public class WorkflowInvalidStartNodeException extends BadRequestException {
+  public WorkflowInvalidStartNodeException(String workflowCode) {
+    super("WORKFLOW_INVALID_START_NODE", "START 노드가 정확히 1개여야 합니다. workflowCode=" + workflowCode);
+  }
+}
+
+public class WorkflowInvalidTerminalNodeException extends BadRequestException {
+  public WorkflowInvalidTerminalNodeException(String workflowCode) {
+    super("WORKFLOW_INVALID_TERMINAL_NODE", "TERMINAL 노드가 1개 이상이어야 합니다. workflowCode=" + workflowCode);
+  }
+}
+
+public class WorkflowDanglingEdgeException extends BadRequestException {
+  public WorkflowDanglingEdgeException(String workflowCode) {
+    super("WORKFLOW_DANGLING_EDGE", "엣지가 존재하지 않는 노드를 참조합니다. workflowCode=" + workflowCode);
+  }
+}
+
+public class WorkflowUnreachableNodeException extends BadRequestException {
+  public WorkflowUnreachableNodeException(String workflowCode) {
+    super("WORKFLOW_UNREACHABLE_NODE", "도달 불가 노드가 존재합니다. workflowCode=" + workflowCode);
+  }
+}
+
+public class WorkflowCycleDetectedException extends BadRequestException {
+  public WorkflowCycleDetectedException(String workflowCode) {
+    super("WORKFLOW_CYCLE_DETECTED", "workflow 그래프에 사이클이 있습니다. workflowCode=" + workflowCode);
+  }
+}
+
+public class WorkflowUnlabeledBranchException extends BadRequestException {
+  public WorkflowUnlabeledBranchException(String workflowCode) {
+    super("WORKFLOW_UNLABELED_BRANCH", "DECISION 노드의 모든 outgoing edge에 label이 필요합니다. workflowCode=" + workflowCode);
+  }
+}
+```
+
+---
+
+## Tests
+
+### Unit Tests
+
+```java
+@DisplayName("CreateDomainPackDraftUseCase — graphJson V1-V6 검증")
+class CreateDomainPackDraftUseCaseGraphValidationTest {
+
+    @Test
+    @DisplayName("V1 위반: START 노드 없음 → WorkflowInvalidStartNodeException")
+    void validate_noStartNode_throwsException() { ... }
+
+    @Test
+    @DisplayName("V1 위반: START 노드 2개 → WorkflowInvalidStartNodeException")
+    void validate_multipleStartNodes_throwsException() { ... }
+
+    @Test
+    @DisplayName("V2 위반: TERMINAL 노드 없음 → WorkflowInvalidTerminalNodeException")
+    void validate_noTerminalNode_throwsException() { ... }
+
+    @Test
+    @DisplayName("V3 위반: edge가 없는 노드 id 참조 → WorkflowDanglingEdgeException")
+    void validate_danglingEdge_throwsException() { ... }
+
+    @Test
+    @DisplayName("V4 위반: START에서 도달 불가 노드 → WorkflowUnreachableNodeException")
+    void validate_unreachableNode_throwsException() { ... }
+
+    @Test
+    @DisplayName("V5 위반: 사이클 존재 → WorkflowCycleDetectedException")
+    void validate_cycleDetected_throwsException() { ... }
+
+    @Test
+    @DisplayName("V6 위반: DECISION outgoing edge에 label 없음 → WorkflowUnlabeledBranchException")
+    void validate_unlabeledBranch_throwsException() { ... }
+
+    @Test
+    @DisplayName("V1-V6 통과 시 initialState가 START 노드 id로 추출됨")
+    void validate_valid_extractsInitialState() { ... }
+
+    @Test
+    @DisplayName("V1-V6 통과 시 terminalStatesJson이 TERMINAL 노드 id 배열 JSON으로 추출됨")
+    void validate_valid_extractsTerminalStatesJson() { ... }
+}
+```
+
+### Controller Tests
+
+```java
+@SpringBootTest
+@AutoConfigureMockMvc
+@DisplayName("CreateDomainPackDraftController — graphJson V1-V6")
+class CreateDomainPackDraftControllerGraphValidationTest {
+
+    @Test
+    @DisplayName("V1 위반: START 노드 없음 → 400 WORKFLOW_INVALID_START_NODE")
+    void createDraft_noStartNode_returns400() throws Exception { ... }
+
+    @Test
+    @DisplayName("V2 위반: TERMINAL 노드 없음 → 400 WORKFLOW_INVALID_TERMINAL_NODE")
+    void createDraft_noTerminalNode_returns400() throws Exception { ... }
+
+    @Test
+    @DisplayName("V3 위반: dangling edge → 400 WORKFLOW_DANGLING_EDGE")
+    void createDraft_danglingEdge_returns400() throws Exception { ... }
+
+    @Test
+    @DisplayName("V4 위반: 도달 불가 노드 → 400 WORKFLOW_UNREACHABLE_NODE")
+    void createDraft_unreachableNode_returns400() throws Exception { ... }
+
+    @Test
+    @DisplayName("V5 위반: 사이클 → 400 WORKFLOW_CYCLE_DETECTED")
+    void createDraft_cycle_returns400() throws Exception { ... }
+
+    @Test
+    @DisplayName("V6 위반: DECISION unlabeled branch → 400 WORKFLOW_UNLABELED_BRANCH")
+    void createDraft_unlabeledBranch_returns400() throws Exception { ... }
+
+    @Test
+    @DisplayName("유효한 graphJson + initialState/terminalStatesJson 미제공 → 201 Created")
+    void createDraft_validGraphJsonOnly_returns201() throws Exception { ... }
+
+    @Test
+    @DisplayName("요청에 initialState 필드 포함 시 무시되거나 400 처리됨")
+    void createDraft_unexpectedInitialStateField_ignored() throws Exception { ... }
+}
+```
+
+### Test Checklist
+
+- [ ] V1-V6 각 규칙 위반 시 대응 에러 코드로 400 반환
+- [ ] V1-V6 통과 시 `initialState`가 START 노드 id로 DB에 저장됨
+- [ ] V1-V6 통과 시 `terminalStatesJson`이 TERMINAL 노드 id 배열 JSON으로 DB에 저장됨
+- [ ] 요청에 `workflows[].initialState` / `terminalStatesJson` 포함 시 무시 또는 400 처리
+- [ ] TERMINAL 노드 복수 개일 때 `terminalStatesJson` 배열에 모두 포함됨
+
+---
+
+## Database
+
+변경 없음. `pack.workflow_definition` 테이블의 `initial_state`, `terminal_states_json` 컬럼은 서버 추출값으로 채워진다.
+
+---
+
+## Additional Notes
+
+- 전체 스펙 맥락: `.agent/specs/231.md`
+- graphJson 스키마 및 V1-V6 규칙 정의: `.agent/specs/226.md`
+- graphJson 파싱 및 V1-V6 검증 로직은 독립 헬퍼 클래스(`WorkflowGraphValidator` 또는 유사)로 분리하는 것을 권장한다 — `validateDraftPayload()` 인라인 구현 시 테스트 격리 어려움.
+- V1-V6은 workflow 단위로 독립 검증하며, 첫 번째 위반 발생 시 즉시 예외를 던진다 (fail-fast).

--- a/.agent/specs/31.md
+++ b/.agent/specs/31.md
@@ -85,18 +85,22 @@ public record WorkflowDraftRequest(
     @NotBlank String workflowCode,
     @NotBlank String name,
     @NotBlank @Size(max = 20000) String graphJson,
-    @Size(max = 100) String initialState,        // 제거
-    @Size(max = 5000) String terminalStatesJson  // 제거
+    @Size(max = 100) String initialState,        // @Null로 교체
+    @Size(max = 5000) String terminalStatesJson  // @Null로 교체
 ) {}
 ```
 
 **변경 후 (이 스펙 적용)**
 
+클라이언트가 이 필드를 제공하면 400을 반환해야 하므로, 필드를 완전히 제거하는 대신 `@Null`로 교체한다. Jackson이 값을 역직렬화한 후 Bean Validation이 null 여부를 검증하여, 값이 제공된 경우 400 `VALIDATION_ERROR`를 반환한다.
+
 ```java
 public record WorkflowDraftRequest(
     @NotBlank String workflowCode,
     @NotBlank String name,
-    @NotBlank @Size(max = 20000) String graphJson
+    @NotBlank @Size(max = 20000) String graphJson,
+    @Null(message = "initialState는 서버에서 자동 추출됩니다. 요청에 포함하지 마십시오.") String initialState,
+    @Null(message = "terminalStatesJson은 서버에서 자동 추출됩니다. 요청에 포함하지 마십시오.") String terminalStatesJson
 ) {}
 ```
 
@@ -112,15 +116,30 @@ public record WorkflowDraftRequest(
 ]
 ```
 
-### Errors — V1-V6 위반 (400 Bad Request)
+### Errors — V1-V6 위반 (400 Bad Request, 각 케이스별 독립 응답 예시)
 
 ```json
-{ "code": "WORKFLOW_INVALID_START_NODE",    "message": "START 노드가 정확히 1개여야 합니다. workflowCode=refund_flow" }
+{ "code": "WORKFLOW_INVALID_START_NODE", "message": "START 노드가 정확히 1개여야 합니다. workflowCode=refund_flow" }
+```
+
+```json
 { "code": "WORKFLOW_INVALID_TERMINAL_NODE", "message": "TERMINAL 노드가 1개 이상이어야 합니다. workflowCode=refund_flow" }
-{ "code": "WORKFLOW_DANGLING_EDGE",         "message": "엣지가 존재하지 않는 노드를 참조합니다. workflowCode=refund_flow" }
-{ "code": "WORKFLOW_UNREACHABLE_NODE",      "message": "도달 불가 노드가 존재합니다. workflowCode=refund_flow" }
-{ "code": "WORKFLOW_CYCLE_DETECTED",        "message": "workflow 그래프에 사이클이 있습니다. workflowCode=refund_flow" }
-{ "code": "WORKFLOW_UNLABELED_BRANCH",      "message": "DECISION 노드의 모든 outgoing edge에 label이 필요합니다. workflowCode=refund_flow" }
+```
+
+```json
+{ "code": "WORKFLOW_DANGLING_EDGE", "message": "엣지가 존재하지 않는 노드를 참조합니다. workflowCode=refund_flow" }
+```
+
+```json
+{ "code": "WORKFLOW_UNREACHABLE_NODE", "message": "도달 불가 노드가 존재합니다. workflowCode=refund_flow" }
+```
+
+```json
+{ "code": "WORKFLOW_CYCLE_DETECTED", "message": "workflow 그래프에 사이클이 있습니다. workflowCode=refund_flow" }
+```
+
+```json
+{ "code": "WORKFLOW_UNLABELED_BRANCH", "message": "DECISION 노드의 모든 outgoing edge에 label이 필요합니다. workflowCode=refund_flow" }
 ```
 
 ---
@@ -295,8 +314,8 @@ class CreateDomainPackDraftControllerGraphValidationTest {
     void createDraft_validGraphJsonOnly_returns201() throws Exception { ... }
 
     @Test
-    @DisplayName("요청에 initialState 필드 포함 시 무시되거나 400 처리됨")
-    void createDraft_unexpectedInitialStateField_ignored() throws Exception { ... }
+    @DisplayName("요청에 initialState 필드 포함 시 400 처리됨")
+    void createDraft_unexpectedInitialStateField_returns400() throws Exception { ... }
 }
 ```
 
@@ -305,7 +324,7 @@ class CreateDomainPackDraftControllerGraphValidationTest {
 - [ ] V1-V6 각 규칙 위반 시 대응 에러 코드로 400 반환
 - [ ] V1-V6 통과 시 `initialState`가 START 노드 id로 DB에 저장됨
 - [ ] V1-V6 통과 시 `terminalStatesJson`이 TERMINAL 노드 id 배열 JSON으로 DB에 저장됨
-- [ ] 요청에 `workflows[].initialState` / `terminalStatesJson` 포함 시 무시 또는 400 처리
+- [ ] 요청에 `workflows[].initialState` / `terminalStatesJson` 포함 시 400 처리
 - [ ] TERMINAL 노드 복수 개일 때 `terminalStatesJson` 배열에 모두 포함됨
 
 ---

--- a/backend/src/main/java/com/init/domainpack/presentation/CreateDomainPackDraftController.java
+++ b/backend/src/main/java/com/init/domainpack/presentation/CreateDomainPackDraftController.java
@@ -114,8 +114,8 @@ public class CreateDomainPackDraftController {
                                 workflow.name(),
                                 workflow.description(),
                                 workflow.graphJson(),
-                                workflow.initialState(),
-                                workflow.terminalStatesJson(),
+                                null, // server-extracted from graphJson post-validation
+                                null, // server-extracted from graphJson post-validation
                                 workflow.evidenceJson(),
                                 workflow.metaJson()))
                     .toList(),

--- a/backend/src/main/java/com/init/domainpack/presentation/dto/CreateDomainPackDraftRequest.java
+++ b/backend/src/main/java/com/init/domainpack/presentation/dto/CreateDomainPackDraftRequest.java
@@ -1,6 +1,7 @@
 package com.init.domainpack.presentation.dto;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Null;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import java.util.List;
@@ -99,8 +100,10 @@ public record CreateDomainPackDraftRequest(
       @NotBlank(message = "graphJson은 필수입니다.")
           @Size(max = 20000, message = "graphJson은 20000자 이하여야 합니다.")
           String graphJson,
-      @Size(max = 100, message = "initialState는 100자 이하여야 합니다.") String initialState,
-      @Size(max = 5000, message = "terminalStatesJson은 5000자 이하여야 합니다.") String terminalStatesJson,
+      @Null(message = "initialState는 서버에서 자동 추출됩니다. 요청에 포함하지 마십시오.")
+          String initialState,
+      @Null(message = "terminalStatesJson은 서버에서 자동 추출됩니다. 요청에 포함하지 마십시오.")
+          String terminalStatesJson,
       @Size(max = 5000, message = "evidenceJson은 5000자 이하여야 합니다.") String evidenceJson,
       @Size(max = 5000, message = "metaJson은 5000자 이하여야 합니다.") String metaJson) {}
 

--- a/backend/src/main/java/com/init/domainpack/presentation/dto/CreateDomainPackDraftRequest.java
+++ b/backend/src/main/java/com/init/domainpack/presentation/dto/CreateDomainPackDraftRequest.java
@@ -1,8 +1,8 @@
 package com.init.domainpack.presentation.dto;
 
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Null;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Null;
 import jakarta.validation.constraints.Size;
 import java.util.List;
 
@@ -100,8 +100,7 @@ public record CreateDomainPackDraftRequest(
       @NotBlank(message = "graphJson은 필수입니다.")
           @Size(max = 20000, message = "graphJson은 20000자 이하여야 합니다.")
           String graphJson,
-      @Null(message = "initialState는 서버에서 자동 추출됩니다. 요청에 포함하지 마십시오.")
-          String initialState,
+      @Null(message = "initialState는 서버에서 자동 추출됩니다. 요청에 포함하지 마십시오.") String initialState,
       @Null(message = "terminalStatesJson은 서버에서 자동 추출됩니다. 요청에 포함하지 마십시오.")
           String terminalStatesJson,
       @Size(max = 5000, message = "evidenceJson은 5000자 이하여야 합니다.") String evidenceJson,

--- a/backend/src/test/java/com/init/domainpack/presentation/CreateDomainPackDraftControllerTest.java
+++ b/backend/src/test/java/com/init/domainpack/presentation/CreateDomainPackDraftControllerTest.java
@@ -173,6 +173,32 @@ class CreateDomainPackDraftControllerTest {
   }
 
   @Test
+  @DisplayName("요청에 initialState 필드 포함 시 400을 반환한다")
+  @WithLongPrincipal(10L)
+  void createDraft_unexpectedInitialStateField_returns400() throws Exception {
+    mockMvc
+        .perform(
+            post(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "workflows": [
+                        {
+                          "workflowCode": "refund_flow",
+                          "name": "환불 플로우",
+                          "graphJson": "{\\"nodes\\":[]}",
+                          "initialState": "start"
+                        }
+                      ]
+                    }
+                    """))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+  }
+
+  @Test
   @DisplayName("인증 없는 요청이면 401을 반환한다")
   void createDraft_unauthenticated_returns401() throws Exception {
     mockMvc


### PR DESCRIPTION
# [BE-31] CreateDomainPackDraft — graphJson V1-V6 검증 및 `initialState` 자동 추출

> **Backlog**: spec/226에서 확정된 graphJson 무결성 규칙을 `CreateDomainPackDraftUseCase` write path에 적용하고, `initialState` / `terminalStatesJson`을 클라이언트 제공에서 서버 자동 추출로 전환한다
> **Bounded Context**: `domainpack`
> **Template**: `_TEMPLATE_BE.md`
> **Amends**: `.agent/specs/231.md` (기존 스펙 델타)
> **Branch**: `feature/231-domain-pack-draft-creation`

---

## Goal

`CreateDomainPackDraftUseCase.validateDraftPayload()` write path에 graphJson 무결성 규칙 V1-V6(`.agent/specs/226.md` 정의)를 추가한다.
V1-V6 통과 후 graphJson nodes에서 `initialState`(START 노드 id)와 `terminalStatesJson`(TERMINAL 노드 id 배열)을 서버가 자동 추출하여 `WorkflowDefinition`에 저장한다.
이에 따라 `WorkflowDraftRequest` DTO와 `WorkflowDraft` command record에서 두 필드를 제거한다.

---

## Sequence Diagram

```mermaid
sequenceDiagram
    actor op as Operator
    participant ctrl as CreateDomainPackDraftController
    participant uc as CreateDomainPackDraftUseCase
    participant validator as validateDraftPayload
    participant db as PostgreSQL

    op ->> ctrl: POST .../versions/drafts
    ctrl ->> uc: execute(CreateDomainPackDraftCommand)
    Note over uc: workspace/pack 검증 (231.md 참조)

    uc ->> validator: validateDraftPayload(command)

    Note over validator: 1. intent/slot/workflow code 중복 검증
    Note over validator: 2. binding 참조 코드 유효성 검증
    Note over validator: 3. 각 workflow graphJson V1-V6 검증

    alt V1 위반: START 노드 != 1
        validator -->> uc: WorkflowInvalidStartNodeException
        uc -->> ctrl: 400 WORKFLOW_INVALID_START_NODE
    end
    alt V2 위반: TERMINAL 노드 없음
        validator -->> uc: WorkflowInvalidTerminalNodeException
        uc -->> ctrl: 400 WORKFLOW_INVALID_TERMINAL_NODE
    end
    alt V3 위반: dangling edge
        validator -->> uc: WorkflowDanglingEdgeException
        uc -->> ctrl: 400 WORKFLOW_DANGLING_EDGE
    end
    alt V4 위반: 도달 불가 노드
        validator -->> uc: WorkflowUnreachableNodeException
        uc -->> ctrl: 400 WORKFLOW_UNREACHABLE_NODE
    end
    alt V5 위반: 사이클 존재
        validator -->> uc: WorkflowCycleDetectedException
        uc -->> ctrl: 400 WORKFLOW_CYCLE_DETECTED
    end
    alt V6 위반: DECISION outgoing edge label 없음
        validator -->> uc: WorkflowUnlabeledBranchException
        uc -->> ctrl: 400 WORKFLOW_UNLABELED_BRANCH
    end

    Note over validator: 4. graphJson → initialState / terminalStatesJson 추출
    validator -->> uc: 검증 완료 + 추출값 포함 WorkflowDraft 목록

    uc ->> db: saveAll(WorkflowDefinition) — 추출된 initialState/terminalStatesJson 저장
    uc -->> ctrl: CreateDomainPackDraftResult
    ctrl -->> op: 201 Created
```

---

## REST API

### 변경 사항 — `workflows` 요청 필드

`WorkflowDraftRequest`에서 `initialState`, `terminalStatesJson` 필드를 **제거**한다.
클라이언트는 `graphJson`만 제공하며, 서버가 V1-V6 검증 후 자동 추출한다.

**변경 전 (기존 DTO)**

```java
public record WorkflowDraftRequest(
    @NotBlank String workflowCode,
    @NotBlank String name,
    @NotBlank @Size(max = 20000) String graphJson,
    @Size(max = 100) String initialState,        // 제거
    @Size(max = 5000) String terminalStatesJson  // 제거
) {}
```

**변경 후 (이 스펙 적용)**

```java
public record WorkflowDraftRequest(
    @NotBlank String workflowCode,
    @NotBlank String name,
    @NotBlank @Size(max = 20000) String graphJson
) {}
```

**Request 예시 (workflows 부분)**

```json
"workflows": [
  {
    "workflowCode": "refund_flow",
    "name": "환불 플로우",
    "graphJson": "{\"direction\":\"LR\",\"nodes\":[{\"id\":\"start\",\"label\":\"상담 시작\",\"type\":\"START\"},{\"id\":\"collect_order_id\",\"label\":\"주문번호 수집\",\"type\":\"ACTION\"},{\"id\":\"terminal\",\"label\":\"상담 종료\",\"type\":\"TERMINAL\"}],\"edges\":[{\"from\":\"start\",\"to\":\"collect_order_id\"},{\"from\":\"collect_order_id\",\"to\":\"terminal\"}]}"
  }
]
```

### Errors — V1-V6 위반 (400 Bad Request)

```json
{ "code": "WORKFLOW_INVALID_START_NODE",    "message": "START 노드가 정확히 1개여야 합니다. workflowCode=refund_flow" }
{ "code": "WORKFLOW_INVALID_TERMINAL_NODE", "message": "TERMINAL 노드가 1개 이상이어야 합니다. workflowCode=refund_flow" }
{ "code": "WORKFLOW_DANGLING_EDGE",         "message": "엣지가 존재하지 않는 노드를 참조합니다. workflowCode=refund_flow" }
{ "code": "WORKFLOW_UNREACHABLE_NODE",      "message": "도달 불가 노드가 존재합니다. workflowCode=refund_flow" }
{ "code": "WORKFLOW_CYCLE_DETECTED",        "message": "workflow 그래프에 사이클이 있습니다. workflowCode=refund_flow" }
{ "code": "WORKFLOW_UNLABELED_BRANCH",      "message": "DECISION 노드의 모든 outgoing edge에 label이 필요합니다. workflowCode=refund_flow" }
```

---

## Class Design

### validateDraftPayload — 검증 및 추출 절차

```java
private List<WorkflowDraft> validateAndExtractWorkflows(CreateDomainPackDraftCommand command) {
    // 1. workflow code 중복 검증
    // 2. intentWorkflowBindings 참조 코드 유효성
    // 3. 각 workflow graphJson V1-V6 검증 후 추출
    return command.workflows().stream()
        .map(w -> {
            GraphJson graph = parseAndValidate(w.graphJson(), w.workflowCode()); // V1-V6
            String initialState = extractInitialState(graph);        // START 노드 id
            String terminalStatesJson = extractTerminalStates(graph); // TERMINAL 노드 id 배열 JSON
            return new WorkflowDraft(w.workflowCode(), w.name(), w.graphJson(),
                                     initialState, terminalStatesJson);
        })
        .toList();
}
```

`WorkflowDraft` command record (내부 사용, 추출값 포함):

```java
// CreateDomainPackDraftCommand 내부 record
// 요청에서는 initialState/terminalStatesJson 없음 — validateDraftPayload 이후 생성
public record WorkflowDraft(
    String workflowCode,
    String name,
    String graphJson,
    String initialState,        // 서버 추출값
    String terminalStatesJson   // 서버 추출값
) {}
```

### 추출 로직 기준 (`.agent/specs/226.md:63-65`)

| 필드 | 추출 방법 |
|------|-----------|
| `initialState` | `nodes[]` 중 `type == "START"` 노드의 `id` |
| `terminalStatesJson` | `nodes[]` 중 `type == "TERMINAL"` 노드의 `id` 목록 → JSON 배열 직렬화 (예: `"[\"terminal\"]"`) |

### 신규 예외 클래스

```java
import com.init.shared.application.exception.BadRequestException;

// backend/src/main/java/com/init/domainpack/application/exception/
public class WorkflowInvalidStartNodeException extends BadRequestException {
  public WorkflowInvalidStartNodeException(String workflowCode) {
    super("WORKFLOW_INVALID_START_NODE", "START 노드가 정확히 1개여야 합니다. workflowCode=" + workflowCode);
  }
}

public class WorkflowInvalidTerminalNodeException extends BadRequestException {
  public WorkflowInvalidTerminalNodeException(String workflowCode) {
    super("WORKFLOW_INVALID_TERMINAL_NODE", "TERMINAL 노드가 1개 이상이어야 합니다. workflowCode=" + workflowCode);
  }
}

public class WorkflowDanglingEdgeException extends BadRequestException {
  public WorkflowDanglingEdgeException(String workflowCode) {
    super("WORKFLOW_DANGLING_EDGE", "엣지가 존재하지 않는 노드를 참조합니다. workflowCode=" + workflowCode);
  }
}

public class WorkflowUnreachableNodeException extends BadRequestException {
  public WorkflowUnreachableNodeException(String workflowCode) {
    super("WORKFLOW_UNREACHABLE_NODE", "도달 불가 노드가 존재합니다. workflowCode=" + workflowCode);
  }
}

public class WorkflowCycleDetectedException extends BadRequestException {
  public WorkflowCycleDetectedException(String workflowCode) {
    super("WORKFLOW_CYCLE_DETECTED", "workflow 그래프에 사이클이 있습니다. workflowCode=" + workflowCode);
  }
}

public class WorkflowUnlabeledBranchException extends BadRequestException {
  public WorkflowUnlabeledBranchException(String workflowCode) {
    super("WORKFLOW_UNLABELED_BRANCH", "DECISION 노드의 모든 outgoing edge에 label이 필요합니다. workflowCode=" + workflowCode);
  }
}
```

---

## Tests

### Unit Tests

```java
@DisplayName("CreateDomainPackDraftUseCase — graphJson V1-V6 검증")
class CreateDomainPackDraftUseCaseGraphValidationTest {

    @Test
    @DisplayName("V1 위반: START 노드 없음 → WorkflowInvalidStartNodeException")
    void validate_noStartNode_throwsException() { ... }

    @Test
    @DisplayName("V1 위반: START 노드 2개 → WorkflowInvalidStartNodeException")
    void validate_multipleStartNodes_throwsException() { ... }

    @Test
    @DisplayName("V2 위반: TERMINAL 노드 없음 → WorkflowInvalidTerminalNodeException")
    void validate_noTerminalNode_throwsException() { ... }

    @Test
    @DisplayName("V3 위반: edge가 없는 노드 id 참조 → WorkflowDanglingEdgeException")
    void validate_danglingEdge_throwsException() { ... }

    @Test
    @DisplayName("V4 위반: START에서 도달 불가 노드 → WorkflowUnreachableNodeException")
    void validate_unreachableNode_throwsException() { ... }

    @Test
    @DisplayName("V5 위반: 사이클 존재 → WorkflowCycleDetectedException")
    void validate_cycleDetected_throwsException() { ... }

    @Test
    @DisplayName("V6 위반: DECISION outgoing edge에 label 없음 → WorkflowUnlabeledBranchException")
    void validate_unlabeledBranch_throwsException() { ... }

    @Test
    @DisplayName("V1-V6 통과 시 initialState가 START 노드 id로 추출됨")
    void validate_valid_extractsInitialState() { ... }

    @Test
    @DisplayName("V1-V6 통과 시 terminalStatesJson이 TERMINAL 노드 id 배열 JSON으로 추출됨")
    void validate_valid_extractsTerminalStatesJson() { ... }
}
```

### Controller Tests

```java
@SpringBootTest
@AutoConfigureMockMvc
@DisplayName("CreateDomainPackDraftController — graphJson V1-V6")
class CreateDomainPackDraftControllerGraphValidationTest {

    @Test
    @DisplayName("V1 위반: START 노드 없음 → 400 WORKFLOW_INVALID_START_NODE")
    void createDraft_noStartNode_returns400() throws Exception { ... }

    @Test
    @DisplayName("V2 위반: TERMINAL 노드 없음 → 400 WORKFLOW_INVALID_TERMINAL_NODE")
    void createDraft_noTerminalNode_returns400() throws Exception { ... }

    @Test
    @DisplayName("V3 위반: dangling edge → 400 WORKFLOW_DANGLING_EDGE")
    void createDraft_danglingEdge_returns400() throws Exception { ... }

    @Test
    @DisplayName("V4 위반: 도달 불가 노드 → 400 WORKFLOW_UNREACHABLE_NODE")
    void createDraft_unreachableNode_returns400() throws Exception { ... }

    @Test
    @DisplayName("V5 위반: 사이클 → 400 WORKFLOW_CYCLE_DETECTED")
    void createDraft_cycle_returns400() throws Exception { ... }

    @Test
    @DisplayName("V6 위반: DECISION unlabeled branch → 400 WORKFLOW_UNLABELED_BRANCH")
    void createDraft_unlabeledBranch_returns400() throws Exception { ... }

    @Test
    @DisplayName("유효한 graphJson + initialState/terminalStatesJson 미제공 → 201 Created")
    void createDraft_validGraphJsonOnly_returns201() throws Exception { ... }

    @Test
    @DisplayName("요청에 initialState 필드 포함 시 무시되거나 400 처리됨")
    void createDraft_unexpectedInitialStateField_ignored() throws Exception { ... }
}
```

### Test Checklist

- [ ] V1-V6 각 규칙 위반 시 대응 에러 코드로 400 반환
- [ ] V1-V6 통과 시 `initialState`가 START 노드 id로 DB에 저장됨
- [ ] V1-V6 통과 시 `terminalStatesJson`이 TERMINAL 노드 id 배열 JSON으로 DB에 저장됨
- [ ] 요청에 `workflows[].initialState` / `terminalStatesJson` 포함 시 무시 또는 400 처리
- [ ] TERMINAL 노드 복수 개일 때 `terminalStatesJson` 배열에 모두 포함됨

---

## Database

변경 없음. `pack.workflow_definition` 테이블의 `initial_state`, `terminal_states_json` 컬럼은 서버 추출값으로 채워진다.

---

## Additional Notes

- 전체 스펙 맥락: `.agent/specs/231.md`
- graphJson 스키마 및 V1-V6 규칙 정의: `.agent/specs/226.md`
- graphJson 파싱 및 V1-V6 검증 로직은 독립 헬퍼 클래스(`WorkflowGraphValidator` 또는 유사)로 분리하는 것을 권장한다 — `validateDraftPayload()` 인라인 구현 시 테스트 격리 어려움.
- V1-V6은 workflow 단위로 독립 검증하며, 첫 번째 위반 발생 시 즉시 예외를 던진다 (fail-fast).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes (한국어)

* **버그 수정**
  * 워크플로우 graphJson에 대한 V1–V6 무결성 검증을 저장 시점에 강제 적용하고, 위반 시 즉시 400 응답으로 처리
  * 각 무결성 위반에 대해 구체적이고 구분된 400 오류 코드/메시지 제공

* **API 개선**
  * 클라이언트에서 initialState 및 terminalStatesJson 전송 불가 — 서버가 graphJson 통과 후 자동 계산·저장

* **테스트**
  * 클라이언트 제공 불필요 필드 및 각 V1–V6 실패 케이스에 대한 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->