### PR TITLE
fix(domain-pack): add graphJson V1-V6 validation and auto-extract workflow state fields (#31)

### DIFF
--- a/.agent/specs/231.md
+++ b/.agent/specs/231.md
@@ -332,8 +332,8 @@ private List<WorkflowDraft> validateAndExtractWorkflows(CreateDomainPackDraftCom
     return command.workflows().stream()
         .map(w -> {
             GraphJson graph = parseAndValidate(w.graphJson(), w.workflowCode()); // V1-V6
-            String initialState = extractInitialState(graph);         // START 노드 id
-            String terminalStatesJson = extractTerminalStates(graph); // TERMINAL 노드 id 배열 JSON
+            String initialState = extractInitialState(graph);             // START 노드 id
+            String terminalStatesJson = extractTerminalStatesJson(graph); // TERMINAL 노드 id 배열 JSON
             return new WorkflowDraft(w.workflowCode(), w.name(), w.graphJson(),
                                      initialState, terminalStatesJson);
         })

--- a/.agent/specs/231.md
+++ b/.agent/specs/231.md
@@ -331,9 +331,10 @@ private List<WorkflowDraft> validateAndExtractWorkflows(CreateDomainPackDraftCom
     // 3. 각 workflow graphJson V1-V6 검증 후 추출
     return command.workflows().stream()
         .map(w -> {
-            GraphJson graph = parseAndValidate(w.graphJson(), w.workflowCode()); // V1-V6
-            String initialState = extractInitialState(graph);             // START 노드 id
-            String terminalStatesJson = extractTerminalStatesJson(graph); // TERMINAL 노드 id 배열 JSON
+            WorkflowGraphValidator.ParsedGraph graph =
+                WorkflowGraphValidator.parseAndValidate(w.graphJson(), w.workflowCode()); // V1-V6
+            String initialState = WorkflowGraphValidator.extractInitialState(graph);             // START 노드 id
+            String terminalStatesJson = WorkflowGraphValidator.extractTerminalStatesJson(graph); // TERMINAL 노드 id 배열 JSON
             return new WorkflowDraft(w.workflowCode(), w.name(), w.graphJson(),
                                      initialState, terminalStatesJson);
         })

--- a/.agent/specs/231.md
+++ b/.agent/specs/231.md
@@ -54,6 +54,10 @@ sequenceDiagram
     end
 
     uc ->> uc: validateDraftPayload()
+    Note over uc: 1. intent/slot/workflow code 중복 검증
+    Note over uc: 2. binding 참조 코드 유효성 검증
+    Note over uc: 3. 각 workflow graphJson V1-V6 검증 (위반 시 즉시 400)
+    Note over uc: 4. graphJson → initialState / terminalStatesJson 추출
     uc ->> versionRepo: findMaxVersionNoByDomainPackId(packId)
     uc ->> versionRepo: saveAndFlush(createDraft(...))
     versionRepo ->> db: INSERT pack.domain_pack_version
@@ -99,7 +103,7 @@ sequenceDiagram
 - `policies`: 최대 200개
 - `risks`: 최대 200개
 - `workflows`: 최대 200개
-- `workflows[].graphJson`: V1-V6 무결성 검증 대상 (`.agent/specs/226.md`). `initialState` / `terminalStatesJson`은 request에 포함하지 않으며, 서버가 graphJson 검증 후 자동 추출하여 저장한다.
+- `workflows[].graphJson`: V1-V6 무결성 검증 대상 (`.agent/specs/226.md`). `initialState` / `terminalStatesJson`은 서버가 graphJson V1-V6 검증 후 자동 추출한다. 이 두 필드는 DTO에서 `@Null`로 선언되므로, 클라이언트가 값을 제공하면 400 `VALIDATION_ERROR`를 반환한다.
 - `intentWorkflowBindings`: 최대 500개
 - `riskLevel`: `LOW`, `MEDIUM`, `HIGH`, `CRITICAL` 중 하나
 
@@ -143,6 +147,34 @@ sequenceDiagram
     }
   ]
 }
+```
+
+### 변경 사항 — `WorkflowDraftRequest` 필드
+
+`WorkflowDraftRequest`에서 `initialState` / `terminalStatesJson` 필드를 `@Null`로 교체한다. 완전히 제거하는 대신 `@Null`로 선언하면, 클라이언트가 값을 포함할 경우 Jackson 역직렬화 → Bean Validation 순서로 400 `VALIDATION_ERROR`를 반환한다.
+
+**변경 전**
+
+```java
+public record WorkflowDraftRequest(
+    @NotBlank String workflowCode,
+    @NotBlank String name,
+    @NotBlank @Size(max = 20000) String graphJson,
+    @Size(max = 100) String initialState,        // @Null로 교체
+    @Size(max = 5000) String terminalStatesJson  // @Null로 교체
+) {}
+```
+
+**변경 후**
+
+```java
+public record WorkflowDraftRequest(
+    @NotBlank String workflowCode,
+    @NotBlank String name,
+    @NotBlank @Size(max = 20000) String graphJson,
+    @Null(message = "initialState는 서버에서 자동 추출됩니다. 요청에 포함하지 마십시오.") String initialState,
+    @Null(message = "terminalStatesJson은 서버에서 자동 추출됩니다. 요청에 포함하지 마십시오.") String terminalStatesJson
+) {}
 ```
 
 ### Response
@@ -290,6 +322,45 @@ classDiagram
 
 > 클라이언트 요청 DTO인 `WorkflowDraftRequest`에는 `initialState` / `terminalStatesJson` 필드를 클라이언트가 직접 설정할 수 없으며, 포함 시 400으로 거부한다. 서버가 V1-V6 검증 후 `graphJson`에서 자동 추출하여 내부 `WorkflowDraft` command record와 `WorkflowDefinition` 엔티티에 저장한다.
 
+#### validateAndExtractWorkflows 구현 참고
+
+```java
+private List<WorkflowDraft> validateAndExtractWorkflows(CreateDomainPackDraftCommand command) {
+    // 1. workflow code 중복 검증
+    // 2. intentWorkflowBindings 참조 코드 유효성
+    // 3. 각 workflow graphJson V1-V6 검증 후 추출
+    return command.workflows().stream()
+        .map(w -> {
+            GraphJson graph = parseAndValidate(w.graphJson(), w.workflowCode()); // V1-V6
+            String initialState = extractInitialState(graph);         // START 노드 id
+            String terminalStatesJson = extractTerminalStates(graph); // TERMINAL 노드 id 배열 JSON
+            return new WorkflowDraft(w.workflowCode(), w.name(), w.graphJson(),
+                                     initialState, terminalStatesJson);
+        })
+        .toList();
+}
+```
+
+`WorkflowDraft` command record (`CreateDomainPackDraftCommand` 내부):
+
+```java
+// 요청에서는 initialState/terminalStatesJson 없음 — validateDraftPayload 이후 생성
+public record WorkflowDraft(
+    String workflowCode,
+    String name,
+    String graphJson,
+    String initialState,        // 서버 추출값
+    String terminalStatesJson   // 서버 추출값
+) {}
+```
+
+**추출 로직 기준 (`.agent/specs/226.md:63-65`)**
+
+| 필드 | 추출 방법 |
+|------|-----------|
+| `initialState` | `nodes[]` 중 `type == "START"` 노드의 `id` |
+| `terminalStatesJson` | `nodes[]` 중 `type == "TERMINAL"` 노드의 `id` 목록 → JSON 배열 직렬화 (예: `"[\"terminal\"]"`) |
+
 ### 신규 예외 클래스
 
 ```java
@@ -350,6 +421,9 @@ public class WorkflowUnlabeledBranchException extends BadRequestException {
 - graphJson V4 위반: START에서 도달 불가 노드 존재 → `WorkflowUnreachableNodeException`
 - graphJson V5 위반: 사이클 존재 → `WorkflowCycleDetectedException`
 - graphJson V6 위반: DECISION 노드 outgoing edge에 label 없음 → `WorkflowUnlabeledBranchException`
+- graphJson V1-V6 통과 시 `initialState`가 START 노드 id로 추출되어 저장됨
+- graphJson V1-V6 통과 시 `terminalStatesJson`이 TERMINAL 노드 id 배열 JSON으로 추출되어 저장됨
+- TERMINAL 노드 복수 개일 때 `terminalStatesJson` 배열에 모두 포함됨
 
 ### Controller Tests
 
@@ -367,9 +441,19 @@ public class WorkflowUnlabeledBranchException extends BadRequestException {
 - graphJson V4 위반 (unreachable node) → `400 WORKFLOW_UNREACHABLE_NODE`
 - graphJson V5 위반 (cycle) → `400 WORKFLOW_CYCLE_DETECTED`
 - graphJson V6 위반 (unlabeled branch) → `400 WORKFLOW_UNLABELED_BRANCH`
+- 요청에 `workflows[].initialState` 포함 시 → `400 VALIDATION_ERROR`
+- 요청에 `workflows[].terminalStatesJson` 포함 시 → `400 VALIDATION_ERROR`
 
 ### Repository Tests
 
 - `findByIdAndWorkspaceId`: 올바른 `workspaceId`와 `versionId`면 version 반환
 - `findByIdAndWorkspaceId`: 다른 `workspaceId`면 `empty` 반환
 - `DomainPackVersion.createDraft(...)`로 생성한 엔티티를 `saveAndFlush(...)` 했을 때 `createdAt`이 JPA lifecycle로 채워짐
+
+---
+
+## Additional Notes
+
+- graphJson 파싱 및 V1-V6 검증 로직은 독립 헬퍼 클래스(`WorkflowGraphValidator` 또는 유사)로 분리하는 것을 권장한다 — `validateDraftPayload()` 인라인 구현 시 테스트 격리 어려움.
+- V1-V6은 workflow 단위로 독립 검증하며, 첫 번째 위반 발생 시 즉시 예외를 던진다 (fail-fast).
+- graphJson 스키마 및 V1-V6 규칙 원본 정의: `.agent/specs/226.md`.

--- a/backend/src/main/java/com/init/domainpack/application/CreateDomainPackDraftUseCase.java
+++ b/backend/src/main/java/com/init/domainpack/application/CreateDomainPackDraftUseCase.java
@@ -83,7 +83,8 @@ public class CreateDomainPackDraftUseCase {
   public CreateDomainPackDraftResult execute(CreateDomainPackDraftCommand command) {
     validateWorkspaceAccess(command);
     validateDomainPack(command);
-    validateDraftPayload(command);
+    List<CreateDomainPackDraftCommand.WorkflowDraft> validatedWorkflows =
+        validateDraftPayload(command);
 
     int nextVersionNo =
         domainPackVersionRepository.findMaxVersionNoByDomainPackId(command.packId()).orElse(0) + 1;
@@ -197,7 +198,7 @@ public class CreateDomainPackDraftUseCase {
 
     List<WorkflowDefinition> workflows =
         workflowDefinitionRepository.saveAll(
-            safeList(command.workflows()).stream()
+            validatedWorkflows.stream()
                 .map(
                     workflow ->
                         WorkflowDefinition.create(
@@ -266,7 +267,8 @@ public class CreateDomainPackDraftUseCase {
     }
   }
 
-  private void validateDraftPayload(CreateDomainPackDraftCommand command) {
+  private List<CreateDomainPackDraftCommand.WorkflowDraft> validateDraftPayload(
+      CreateDomainPackDraftCommand command) {
     ensureUnique(
         safeList(command.intents()),
         CreateDomainPackDraftCommand.IntentDraft::intentCode,
@@ -292,6 +294,25 @@ public class CreateDomainPackDraftUseCase {
         safeList(command.intentWorkflowBindings()),
         binding -> binding.intentCode() + "::" + binding.workflowCode(),
         "intentWorkflowBinding");
+
+    return safeList(command.workflows()).stream()
+        .map(
+            w -> {
+              WorkflowGraphValidator.ParsedGraph graph =
+                  WorkflowGraphValidator.parseAndValidate(w.graphJson(), w.workflowCode());
+              String initialState = WorkflowGraphValidator.extractInitialState(graph);
+              String terminalStatesJson = WorkflowGraphValidator.extractTerminalStatesJson(graph);
+              return new CreateDomainPackDraftCommand.WorkflowDraft(
+                  w.workflowCode(),
+                  w.name(),
+                  w.description(),
+                  w.graphJson(),
+                  initialState,
+                  terminalStatesJson,
+                  w.evidenceJson(),
+                  w.metaJson());
+            })
+        .toList();
   }
 
   private <T> List<T> safeList(List<T> list) {

--- a/backend/src/main/java/com/init/domainpack/application/WorkflowGraphValidator.java
+++ b/backend/src/main/java/com/init/domainpack/application/WorkflowGraphValidator.java
@@ -1,7 +1,9 @@
 package com.init.domainpack.application;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.init.domainpack.application.exception.DomainPackDraftRequestInvalidException;
 import com.init.domainpack.application.exception.WorkflowCycleDetectedException;
 import com.init.domainpack.application.exception.WorkflowDanglingEdgeException;
 import com.init.domainpack.application.exception.WorkflowInvalidStartNodeException;
@@ -15,6 +17,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Set;
 
 final class WorkflowGraphValidator {
@@ -34,8 +37,9 @@ final class WorkflowGraphValidator {
     JsonNode root;
     try {
       root = OBJECT_MAPPER.readTree(graphJson);
-    } catch (Exception e) {
-      throw new WorkflowInvalidStartNodeException(workflowCode);
+    } catch (JsonProcessingException e) {
+      throw new DomainPackDraftRequestInvalidException(
+          "graphJson 파싱 실패. workflowCode=" + workflowCode, e);
     }
 
     List<GraphNode> nodes = parseNodes(root);
@@ -70,13 +74,11 @@ final class WorkflowGraphValidator {
   static String extractTerminalStatesJson(ParsedGraph graph) {
     List<String> terminalIds =
         graph.nodes().stream().filter(n -> "TERMINAL".equals(n.type())).map(GraphNode::id).toList();
-    StringBuilder sb = new StringBuilder("[");
-    for (int i = 0; i < terminalIds.size(); i++) {
-      if (i > 0) sb.append(",");
-      sb.append("\"").append(terminalIds.get(i)).append("\"");
+    try {
+      return OBJECT_MAPPER.writeValueAsString(terminalIds);
+    } catch (JsonProcessingException e) {
+      throw new IllegalStateException("Failed to serialize terminal states", e);
     }
-    sb.append("]");
-    return sb.toString();
   }
 
   // --- parse helpers ---
@@ -203,6 +205,6 @@ final class WorkflowGraphValidator {
         .filter(n -> "START".equals(n.type()))
         .findFirst()
         .map(GraphNode::id)
-        .orElseThrow();
+        .orElseThrow(() -> new NoSuchElementException("Start node not found in workflow graph"));
   }
 }

--- a/backend/src/main/java/com/init/domainpack/application/WorkflowGraphValidator.java
+++ b/backend/src/main/java/com/init/domainpack/application/WorkflowGraphValidator.java
@@ -1,0 +1,208 @@
+package com.init.domainpack.application;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.init.domainpack.application.exception.WorkflowCycleDetectedException;
+import com.init.domainpack.application.exception.WorkflowDanglingEdgeException;
+import com.init.domainpack.application.exception.WorkflowInvalidStartNodeException;
+import com.init.domainpack.application.exception.WorkflowInvalidTerminalNodeException;
+import com.init.domainpack.application.exception.WorkflowUnlabeledBranchException;
+import com.init.domainpack.application.exception.WorkflowUnreachableNodeException;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+final class WorkflowGraphValidator {
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  private WorkflowGraphValidator() {}
+
+  record ParsedGraph(List<GraphNode> nodes, List<GraphEdge> edges) {}
+
+  record GraphNode(String id, String type) {}
+
+  record GraphEdge(String from, String to, String label) {}
+
+  /** V1-V6 검증 후 ParsedGraph 반환. 위반 시 해당 예외를 throw한다 (fail-fast). */
+  static ParsedGraph parseAndValidate(String graphJson, String workflowCode) {
+    JsonNode root;
+    try {
+      root = OBJECT_MAPPER.readTree(graphJson);
+    } catch (Exception e) {
+      throw new WorkflowInvalidStartNodeException(workflowCode);
+    }
+
+    List<GraphNode> nodes = parseNodes(root);
+    List<GraphEdge> edges = parseEdges(root);
+
+    validateV1StartNode(nodes, workflowCode);
+    validateV2TerminalNode(nodes, workflowCode);
+
+    Set<String> nodeIds = buildNodeIdSet(nodes);
+    validateV3DanglingEdges(edges, nodeIds, workflowCode);
+
+    Map<String, List<String>> adj = buildAdjacencyList(nodes, edges);
+    String startId = findStartNodeId(nodes);
+    validateV4Reachability(nodes, adj, startId, workflowCode);
+    validateV5Cycles(nodes, adj, workflowCode);
+    validateV6DecisionLabels(nodes, edges, workflowCode);
+
+    return new ParsedGraph(nodes, edges);
+  }
+
+  static String extractInitialState(ParsedGraph graph) {
+    return graph.nodes().stream()
+        .filter(n -> "START".equals(n.type()))
+        .findFirst()
+        .map(GraphNode::id)
+        .orElseThrow(
+            () ->
+                new IllegalStateException(
+                    "START node must exist after validation — this is a bug"));
+  }
+
+  static String extractTerminalStatesJson(ParsedGraph graph) {
+    List<String> terminalIds =
+        graph.nodes().stream().filter(n -> "TERMINAL".equals(n.type())).map(GraphNode::id).toList();
+    StringBuilder sb = new StringBuilder("[");
+    for (int i = 0; i < terminalIds.size(); i++) {
+      if (i > 0) sb.append(",");
+      sb.append("\"").append(terminalIds.get(i)).append("\"");
+    }
+    sb.append("]");
+    return sb.toString();
+  }
+
+  // --- parse helpers ---
+
+  private static List<GraphNode> parseNodes(JsonNode root) {
+    List<GraphNode> nodes = new ArrayList<>();
+    for (JsonNode n : root.path("nodes")) {
+      nodes.add(new GraphNode(n.path("id").asText(), n.path("type").asText()));
+    }
+    return nodes;
+  }
+
+  private static List<GraphEdge> parseEdges(JsonNode root) {
+    List<GraphEdge> edges = new ArrayList<>();
+    for (JsonNode e : root.path("edges")) {
+      String label = e.hasNonNull("label") ? e.path("label").asText(null) : null;
+      edges.add(new GraphEdge(e.path("from").asText(), e.path("to").asText(), label));
+    }
+    return edges;
+  }
+
+  // --- validation rules ---
+
+  private static void validateV1StartNode(List<GraphNode> nodes, String workflowCode) {
+    long startCount = nodes.stream().filter(n -> "START".equals(n.type())).count();
+    if (startCount != 1) {
+      throw new WorkflowInvalidStartNodeException(workflowCode);
+    }
+  }
+
+  private static void validateV2TerminalNode(List<GraphNode> nodes, String workflowCode) {
+    long terminalCount = nodes.stream().filter(n -> "TERMINAL".equals(n.type())).count();
+    if (terminalCount < 1) {
+      throw new WorkflowInvalidTerminalNodeException(workflowCode);
+    }
+  }
+
+  private static void validateV3DanglingEdges(
+      List<GraphEdge> edges, Set<String> nodeIds, String workflowCode) {
+    for (GraphEdge edge : edges) {
+      if (!nodeIds.contains(edge.from()) || !nodeIds.contains(edge.to())) {
+        throw new WorkflowDanglingEdgeException(workflowCode);
+      }
+    }
+  }
+
+  private static void validateV4Reachability(
+      List<GraphNode> nodes, Map<String, List<String>> adj, String startId, String workflowCode) {
+    Set<String> reachable = new HashSet<>();
+    Deque<String> queue = new ArrayDeque<>();
+    queue.add(startId);
+    while (!queue.isEmpty()) {
+      String current = queue.poll();
+      if (reachable.add(current)) {
+        adj.getOrDefault(current, List.of()).forEach(queue::add);
+      }
+    }
+    if (reachable.size() != nodes.size()) {
+      throw new WorkflowUnreachableNodeException(workflowCode);
+    }
+  }
+
+  private static void validateV5Cycles(
+      List<GraphNode> nodes, Map<String, List<String>> adj, String workflowCode) {
+    Map<String, Integer> inDegree = new HashMap<>();
+    for (GraphNode n : nodes) inDegree.put(n.id(), 0);
+    for (GraphNode n : nodes) {
+      for (String neighbor : adj.getOrDefault(n.id(), List.of())) {
+        inDegree.merge(neighbor, 1, Integer::sum);
+      }
+    }
+
+    Deque<String> topoQueue = new ArrayDeque<>();
+    inDegree.forEach(
+        (id, degree) -> {
+          if (degree == 0) topoQueue.add(id);
+        });
+
+    int processed = 0;
+    while (!topoQueue.isEmpty()) {
+      String current = topoQueue.poll();
+      processed++;
+      for (String neighbor : adj.getOrDefault(current, List.of())) {
+        int newDegree = inDegree.merge(neighbor, -1, Integer::sum);
+        if (newDegree == 0) topoQueue.add(neighbor);
+      }
+    }
+    if (processed != nodes.size()) {
+      throw new WorkflowCycleDetectedException(workflowCode);
+    }
+  }
+
+  private static void validateV6DecisionLabels(
+      List<GraphNode> nodes, List<GraphEdge> edges, String workflowCode) {
+    Set<String> decisionIds = new HashSet<>();
+    for (GraphNode n : nodes) {
+      if ("DECISION".equals(n.type())) decisionIds.add(n.id());
+    }
+    for (GraphEdge edge : edges) {
+      if (decisionIds.contains(edge.from()) && (edge.label() == null || edge.label().isBlank())) {
+        throw new WorkflowUnlabeledBranchException(workflowCode);
+      }
+    }
+  }
+
+  // --- utility ---
+
+  private static Set<String> buildNodeIdSet(List<GraphNode> nodes) {
+    Set<String> ids = new HashSet<>();
+    for (GraphNode n : nodes) ids.add(n.id());
+    return ids;
+  }
+
+  private static Map<String, List<String>> buildAdjacencyList(
+      List<GraphNode> nodes, List<GraphEdge> edges) {
+    Map<String, List<String>> adj = new HashMap<>();
+    for (GraphNode n : nodes) adj.put(n.id(), new ArrayList<>());
+    for (GraphEdge e : edges) adj.get(e.from()).add(e.to());
+    return adj;
+  }
+
+  private static String findStartNodeId(List<GraphNode> nodes) {
+    return nodes.stream()
+        .filter(n -> "START".equals(n.type()))
+        .findFirst()
+        .map(GraphNode::id)
+        .orElseThrow();
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/application/WorkflowGraphValidator.java
+++ b/backend/src/main/java/com/init/domainpack/application/WorkflowGraphValidator.java
@@ -86,7 +86,13 @@ final class WorkflowGraphValidator {
   private static List<GraphNode> parseNodes(JsonNode root) {
     List<GraphNode> nodes = new ArrayList<>();
     for (JsonNode n : root.path("nodes")) {
-      nodes.add(new GraphNode(n.path("id").asText(), n.path("type").asText()));
+      String id = n.path("id").asText().trim();
+      String type = n.path("type").asText().trim();
+      if (id.isEmpty() || type.isEmpty()) {
+        throw new DomainPackDraftRequestInvalidException(
+            "노드의 id 또는 type이 비어 있습니다. id='" + id + "', type='" + type + "'");
+      }
+      nodes.add(new GraphNode(id, type));
     }
     return nodes;
   }

--- a/backend/src/main/java/com/init/domainpack/application/exception/DomainPackDraftRequestInvalidException.java
+++ b/backend/src/main/java/com/init/domainpack/application/exception/DomainPackDraftRequestInvalidException.java
@@ -7,4 +7,9 @@ public class DomainPackDraftRequestInvalidException extends BadRequestException 
   public DomainPackDraftRequestInvalidException(String message) {
     super("DOMAIN_PACK_DRAFT_INVALID_REQUEST", message);
   }
+
+  public DomainPackDraftRequestInvalidException(String message, Throwable cause) {
+    super("DOMAIN_PACK_DRAFT_INVALID_REQUEST", message);
+    initCause(cause);
+  }
 }

--- a/backend/src/main/java/com/init/domainpack/application/exception/WorkflowCycleDetectedException.java
+++ b/backend/src/main/java/com/init/domainpack/application/exception/WorkflowCycleDetectedException.java
@@ -1,0 +1,9 @@
+package com.init.domainpack.application.exception;
+
+import com.init.shared.application.exception.BadRequestException;
+
+public class WorkflowCycleDetectedException extends BadRequestException {
+  public WorkflowCycleDetectedException(String workflowCode) {
+    super("WORKFLOW_CYCLE_DETECTED", "workflow 그래프에 사이클이 있습니다. workflowCode=" + workflowCode);
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/application/exception/WorkflowDanglingEdgeException.java
+++ b/backend/src/main/java/com/init/domainpack/application/exception/WorkflowDanglingEdgeException.java
@@ -1,0 +1,9 @@
+package com.init.domainpack.application.exception;
+
+import com.init.shared.application.exception.BadRequestException;
+
+public class WorkflowDanglingEdgeException extends BadRequestException {
+  public WorkflowDanglingEdgeException(String workflowCode) {
+    super("WORKFLOW_DANGLING_EDGE", "엣지가 존재하지 않는 노드를 참조합니다. workflowCode=" + workflowCode);
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/application/exception/WorkflowInvalidStartNodeException.java
+++ b/backend/src/main/java/com/init/domainpack/application/exception/WorkflowInvalidStartNodeException.java
@@ -1,0 +1,9 @@
+package com.init.domainpack.application.exception;
+
+import com.init.shared.application.exception.BadRequestException;
+
+public class WorkflowInvalidStartNodeException extends BadRequestException {
+  public WorkflowInvalidStartNodeException(String workflowCode) {
+    super("WORKFLOW_INVALID_START_NODE", "START 노드가 정확히 1개여야 합니다. workflowCode=" + workflowCode);
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/application/exception/WorkflowInvalidTerminalNodeException.java
+++ b/backend/src/main/java/com/init/domainpack/application/exception/WorkflowInvalidTerminalNodeException.java
@@ -1,0 +1,11 @@
+package com.init.domainpack.application.exception;
+
+import com.init.shared.application.exception.BadRequestException;
+
+public class WorkflowInvalidTerminalNodeException extends BadRequestException {
+  public WorkflowInvalidTerminalNodeException(String workflowCode) {
+    super(
+        "WORKFLOW_INVALID_TERMINAL_NODE",
+        "TERMINAL 노드가 1개 이상이어야 합니다. workflowCode=" + workflowCode);
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/application/exception/WorkflowUnlabeledBranchException.java
+++ b/backend/src/main/java/com/init/domainpack/application/exception/WorkflowUnlabeledBranchException.java
@@ -1,0 +1,11 @@
+package com.init.domainpack.application.exception;
+
+import com.init.shared.application.exception.BadRequestException;
+
+public class WorkflowUnlabeledBranchException extends BadRequestException {
+  public WorkflowUnlabeledBranchException(String workflowCode) {
+    super(
+        "WORKFLOW_UNLABELED_BRANCH",
+        "DECISION 노드의 모든 outgoing edge에 label이 필요합니다. workflowCode=" + workflowCode);
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/application/exception/WorkflowUnreachableNodeException.java
+++ b/backend/src/main/java/com/init/domainpack/application/exception/WorkflowUnreachableNodeException.java
@@ -1,0 +1,9 @@
+package com.init.domainpack.application.exception;
+
+import com.init.shared.application.exception.BadRequestException;
+
+public class WorkflowUnreachableNodeException extends BadRequestException {
+  public WorkflowUnreachableNodeException(String workflowCode) {
+    super("WORKFLOW_UNREACHABLE_NODE", "도달 불가 노드가 존재합니다. workflowCode=" + workflowCode);
+  }
+}

--- a/backend/src/test/java/com/init/domainpack/application/CreateDomainPackDraftUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/CreateDomainPackDraftUseCaseTest.java
@@ -10,6 +10,12 @@ import static org.mockito.Mockito.verify;
 import com.init.domainpack.application.exception.DomainPackDraftRequestInvalidException;
 import com.init.domainpack.application.exception.DomainPackNotFoundException;
 import com.init.domainpack.application.exception.DomainPackWorkspaceNotFoundException;
+import com.init.domainpack.application.exception.WorkflowCycleDetectedException;
+import com.init.domainpack.application.exception.WorkflowDanglingEdgeException;
+import com.init.domainpack.application.exception.WorkflowInvalidStartNodeException;
+import com.init.domainpack.application.exception.WorkflowInvalidTerminalNodeException;
+import com.init.domainpack.application.exception.WorkflowUnlabeledBranchException;
+import com.init.domainpack.application.exception.WorkflowUnreachableNodeException;
 import com.init.domainpack.domain.model.DomainPackVersion;
 import com.init.domainpack.domain.model.IntentDefinition;
 import com.init.domainpack.domain.model.SlotDefinition;
@@ -40,6 +46,34 @@ import org.springframework.test.util.ReflectionTestUtils;
 @ExtendWith(MockitoExtension.class)
 @DisplayName("CreateDomainPackDraftUseCase")
 class CreateDomainPackDraftUseCaseTest {
+
+  // START→ACTION→TERMINAL, 사이클 없음, 유효한 V1-V6 그래프
+  private static final String VALID_GRAPH_JSON =
+      "{\"direction\":\"LR\","
+          + "\"nodes\":["
+          + "{\"id\":\"start\",\"label\":\"시작\",\"type\":\"START\"},"
+          + "{\"id\":\"action1\",\"label\":\"처리\",\"type\":\"ACTION\"},"
+          + "{\"id\":\"terminal\",\"label\":\"종료\",\"type\":\"TERMINAL\"}"
+          + "],"
+          + "\"edges\":["
+          + "{\"from\":\"start\",\"to\":\"action1\"},"
+          + "{\"from\":\"action1\",\"to\":\"terminal\"}"
+          + "]}";
+
+  // DECISION 노드 포함 유효한 그래프 (label 있음)
+  private static final String VALID_GRAPH_WITH_DECISION =
+      "{\"direction\":\"LR\","
+          + "\"nodes\":["
+          + "{\"id\":\"start\",\"label\":\"시작\",\"type\":\"START\"},"
+          + "{\"id\":\"dec\",\"label\":\"분기\",\"type\":\"DECISION\"},"
+          + "{\"id\":\"t1\",\"label\":\"종료1\",\"type\":\"TERMINAL\"},"
+          + "{\"id\":\"t2\",\"label\":\"종료2\",\"type\":\"TERMINAL\"}"
+          + "],"
+          + "\"edges\":["
+          + "{\"from\":\"start\",\"to\":\"dec\"},"
+          + "{\"from\":\"dec\",\"to\":\"t1\",\"label\":\"yes\"},"
+          + "{\"from\":\"dec\",\"to\":\"t2\",\"label\":\"no\"}"
+          + "]}";
 
   @Mock private DomainPackVersionRepository domainPackVersionRepository;
   @Mock private DomainPackRepository domainPackRepository;
@@ -178,6 +212,224 @@ class CreateDomainPackDraftUseCaseTest {
         .hasMessageContaining("slot 참조를 찾을 수 없습니다");
   }
 
+  // ──────────────────────────────────────────────────────────────
+  // graphJson V1-V6 위반 테스트
+  // ──────────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("graphJson V1 위반 — START 노드 없으면 WorkflowInvalidStartNodeException")
+  void execute_noStartNode_throwsException() {
+    stubWorkspaceAndPack();
+    String noStart =
+        "{\"direction\":\"LR\","
+            + "\"nodes\":[{\"id\":\"terminal\",\"label\":\"종료\",\"type\":\"TERMINAL\"}],"
+            + "\"edges\":[]}";
+    assertThatThrownBy(() -> useCase.execute(commandWithGraphJson(noStart)))
+        .isInstanceOf(WorkflowInvalidStartNodeException.class);
+  }
+
+  @Test
+  @DisplayName("graphJson V1 위반 — START 노드 2개면 WorkflowInvalidStartNodeException")
+  void execute_multipleStartNodes_throwsException() {
+    stubWorkspaceAndPack();
+    String twoStart =
+        "{\"direction\":\"LR\","
+            + "\"nodes\":["
+            + "{\"id\":\"s1\",\"label\":\"시작1\",\"type\":\"START\"},"
+            + "{\"id\":\"s2\",\"label\":\"시작2\",\"type\":\"START\"},"
+            + "{\"id\":\"t\",\"label\":\"종료\",\"type\":\"TERMINAL\"}"
+            + "],"
+            + "\"edges\":[{\"from\":\"s1\",\"to\":\"t\"},{\"from\":\"s2\",\"to\":\"t\"}]}";
+    assertThatThrownBy(() -> useCase.execute(commandWithGraphJson(twoStart)))
+        .isInstanceOf(WorkflowInvalidStartNodeException.class);
+  }
+
+  @Test
+  @DisplayName("graphJson V2 위반 — TERMINAL 노드 없으면 WorkflowInvalidTerminalNodeException")
+  void execute_noTerminalNode_throwsException() {
+    stubWorkspaceAndPack();
+    String noTerminal =
+        "{\"direction\":\"LR\","
+            + "\"nodes\":[{\"id\":\"start\",\"label\":\"시작\",\"type\":\"START\"}],"
+            + "\"edges\":[]}";
+    assertThatThrownBy(() -> useCase.execute(commandWithGraphJson(noTerminal)))
+        .isInstanceOf(WorkflowInvalidTerminalNodeException.class);
+  }
+
+  @Test
+  @DisplayName("graphJson V3 위반 — 없는 노드 id 참조하면 WorkflowDanglingEdgeException")
+  void execute_danglingEdge_throwsException() {
+    stubWorkspaceAndPack();
+    String dangling =
+        "{\"direction\":\"LR\","
+            + "\"nodes\":["
+            + "{\"id\":\"start\",\"label\":\"시작\",\"type\":\"START\"},"
+            + "{\"id\":\"terminal\",\"label\":\"종료\",\"type\":\"TERMINAL\"}"
+            + "],"
+            + "\"edges\":[{\"from\":\"start\",\"to\":\"ghost\"}]}";
+    assertThatThrownBy(() -> useCase.execute(commandWithGraphJson(dangling)))
+        .isInstanceOf(WorkflowDanglingEdgeException.class);
+  }
+
+  @Test
+  @DisplayName("graphJson V4 위반 — START에서 도달 불가 노드 있으면 WorkflowUnreachableNodeException")
+  void execute_unreachableNode_throwsException() {
+    stubWorkspaceAndPack();
+    String unreachable =
+        "{\"direction\":\"LR\","
+            + "\"nodes\":["
+            + "{\"id\":\"start\",\"label\":\"시작\",\"type\":\"START\"},"
+            + "{\"id\":\"terminal\",\"label\":\"종료\",\"type\":\"TERMINAL\"},"
+            + "{\"id\":\"island\",\"label\":\"고립\",\"type\":\"ACTION\"}"
+            + "],"
+            + "\"edges\":[{\"from\":\"start\",\"to\":\"terminal\"}]}";
+    assertThatThrownBy(() -> useCase.execute(commandWithGraphJson(unreachable)))
+        .isInstanceOf(WorkflowUnreachableNodeException.class);
+  }
+
+  @Test
+  @DisplayName("graphJson V5 위반 — 사이클 존재하면 WorkflowCycleDetectedException")
+  void execute_cycleDetected_throwsException() {
+    stubWorkspaceAndPack();
+    String cycle =
+        "{\"direction\":\"LR\","
+            + "\"nodes\":["
+            + "{\"id\":\"start\",\"label\":\"시작\",\"type\":\"START\"},"
+            + "{\"id\":\"a\",\"label\":\"A\",\"type\":\"ACTION\"},"
+            + "{\"id\":\"b\",\"label\":\"B\",\"type\":\"ACTION\"},"
+            + "{\"id\":\"terminal\",\"label\":\"종료\",\"type\":\"TERMINAL\"}"
+            + "],"
+            + "\"edges\":["
+            + "{\"from\":\"start\",\"to\":\"a\"},"
+            + "{\"from\":\"a\",\"to\":\"b\"},"
+            + "{\"from\":\"b\",\"to\":\"a\"},"
+            + "{\"from\":\"b\",\"to\":\"terminal\"}"
+            + "]}";
+    assertThatThrownBy(() -> useCase.execute(commandWithGraphJson(cycle)))
+        .isInstanceOf(WorkflowCycleDetectedException.class);
+  }
+
+  @Test
+  @DisplayName(
+      "graphJson V6 위반 — DECISION outgoing edge에 label 없으면 WorkflowUnlabeledBranchException")
+  void execute_unlabeledBranch_throwsException() {
+    stubWorkspaceAndPack();
+    String unlabeled =
+        "{\"direction\":\"LR\","
+            + "\"nodes\":["
+            + "{\"id\":\"start\",\"label\":\"시작\",\"type\":\"START\"},"
+            + "{\"id\":\"dec\",\"label\":\"분기\",\"type\":\"DECISION\"},"
+            + "{\"id\":\"terminal\",\"label\":\"종료\",\"type\":\"TERMINAL\"}"
+            + "],"
+            + "\"edges\":["
+            + "{\"from\":\"start\",\"to\":\"dec\"},"
+            + "{\"from\":\"dec\",\"to\":\"terminal\"}"
+            + "]}";
+    assertThatThrownBy(() -> useCase.execute(commandWithGraphJson(unlabeled)))
+        .isInstanceOf(WorkflowUnlabeledBranchException.class);
+  }
+
+  // ──────────────────────────────────────────────────────────────
+  // initialState / terminalStatesJson 추출 검증 테스트
+  // ──────────────────────────────────────────────────────────────
+
+  @Test
+  @SuppressWarnings("unchecked")
+  @DisplayName("V1-V6 통과 시 initialState가 START 노드 id로 저장된다")
+  void execute_validGraph_extractsInitialState() {
+    stubWorkspaceAndPack();
+    stubSaveAll();
+
+    useCase.execute(commandWithGraphJson(VALID_GRAPH_JSON));
+
+    org.mockito.ArgumentCaptor<Iterable<WorkflowDefinition>> captor =
+        org.mockito.ArgumentCaptor.forClass(Iterable.class);
+    verify(workflowDefinitionRepository).saveAll(captor.capture());
+    WorkflowDefinition saved = captor.getValue().iterator().next();
+    assertThat(saved.getInitialState()).isEqualTo("start");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  @DisplayName("V1-V6 통과 시 terminalStatesJson이 TERMINAL 노드 id 배열 JSON으로 저장된다")
+  void execute_validGraph_extractsTerminalStatesJson() {
+    stubWorkspaceAndPack();
+    stubSaveAll();
+
+    useCase.execute(commandWithGraphJson(VALID_GRAPH_JSON));
+
+    org.mockito.ArgumentCaptor<Iterable<WorkflowDefinition>> captor =
+        org.mockito.ArgumentCaptor.forClass(Iterable.class);
+    verify(workflowDefinitionRepository).saveAll(captor.capture());
+    WorkflowDefinition saved = captor.getValue().iterator().next();
+    assertThat(saved.getTerminalStatesJson()).isEqualTo("[\"terminal\"]");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  @DisplayName("TERMINAL 노드 복수 개일 때 terminalStatesJson 배열에 모두 포함된다")
+  void execute_multipleTerminalNodes_allIncludedInJson() {
+    stubWorkspaceAndPack();
+    stubSaveAll();
+
+    useCase.execute(commandWithGraphJson(VALID_GRAPH_WITH_DECISION));
+
+    org.mockito.ArgumentCaptor<Iterable<WorkflowDefinition>> captor =
+        org.mockito.ArgumentCaptor.forClass(Iterable.class);
+    verify(workflowDefinitionRepository).saveAll(captor.capture());
+    WorkflowDefinition saved = captor.getValue().iterator().next();
+    assertThat(saved.getTerminalStatesJson()).contains("\"t1\"").contains("\"t2\"");
+  }
+
+  // ──────────────────────────────────────────────────────────────
+  // 테스트 헬퍼
+  // ──────────────────────────────────────────────────────────────
+
+  private void stubWorkspaceAndPack() {
+    given(workspaceExistencePort.existsById(1L)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(domainPackRepository.existsByIdAndWorkspaceId(7L, 1L)).willReturn(true);
+  }
+
+  private void stubSaveAll() {
+    given(domainPackVersionRepository.findMaxVersionNoByDomainPackId(7L))
+        .willReturn(Optional.of(2));
+    given(domainPackVersionRepository.saveAndFlush(any()))
+        .willAnswer(invocation -> createSavedVersion(101L, 7L, 3));
+    given(intentDefinitionRepository.saveAll(any()))
+        .willAnswer(invocation -> invocation.getArgument(0));
+    given(slotDefinitionRepository.saveAll(any()))
+        .willAnswer(invocation -> invocation.getArgument(0));
+    given(policyDefinitionRepository.saveAll(any()))
+        .willAnswer(invocation -> invocation.getArgument(0));
+    given(riskDefinitionRepository.saveAll(any()))
+        .willAnswer(invocation -> invocation.getArgument(0));
+    given(workflowDefinitionRepository.saveAll(any()))
+        .willAnswer(invocation -> assignWorkflowIds(invocation.getArgument(0), List.of(3001L)));
+    given(intentSlotBindingRepository.saveAll(any()))
+        .willAnswer(invocation -> invocation.getArgument(0));
+    given(intentWorkflowBindingRepository.saveAll(any()))
+        .willAnswer(invocation -> invocation.getArgument(0));
+  }
+
+  private CreateDomainPackDraftCommand commandWithGraphJson(String graphJson) {
+    return new CreateDomainPackDraftCommand(
+        1L,
+        7L,
+        10L,
+        null,
+        "{}",
+        List.of(),
+        List.of(),
+        List.of(),
+        List.of(),
+        List.of(),
+        List.of(
+            new CreateDomainPackDraftCommand.WorkflowDraft(
+                "refund_flow", "환불 플로우", null, graphJson, null, null, null, null)),
+        List.of());
+  }
+
   private CreateDomainPackDraftCommand validCommand() {
     return new CreateDomainPackDraftCommand(
         1L,
@@ -208,14 +460,7 @@ class CreateDomainPackDraftUseCaseTest {
         List.of(),
         List.of(
             new CreateDomainPackDraftCommand.WorkflowDraft(
-                "refund_flow",
-                "환불 플로우",
-                null,
-                "{\"nodes\":[]}",
-                "START",
-                "[\"DONE\"]",
-                null,
-                null)),
+                "refund_flow", "환불 플로우", null, VALID_GRAPH_JSON, null, null, null, null)),
         List.of(
             new CreateDomainPackDraftCommand.IntentWorkflowBindingDraft(
                 "refund_request", "refund_flow", true, null)));

--- a/backend/src/test/java/com/init/domainpack/presentation/CreateDomainPackDraftControllerTest.java
+++ b/backend/src/test/java/com/init/domainpack/presentation/CreateDomainPackDraftControllerTest.java
@@ -205,6 +205,32 @@ class CreateDomainPackDraftControllerTest {
   }
 
   @Test
+  @DisplayName("요청에 terminalStatesJson 필드 포함 시 400을 반환한다")
+  @WithLongPrincipal(10L)
+  void createDraft_unexpectedTerminalStatesJsonField_returns400() throws Exception {
+    mockMvc
+        .perform(
+            post(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "workflows": [
+                        {
+                          "workflowCode": "refund_flow",
+                          "name": "환불 플로우",
+                          "graphJson": "{\\"nodes\\":[]}",
+                          "terminalStatesJson": "[\\"end\\"]"
+                        }
+                      ]
+                    }
+                    """))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+  }
+
+  @Test
   @DisplayName("graphJson V1 위반 (START 노드 없음/복수) 이면 400을 반환한다")
   @WithLongPrincipal(10L)
   void createDraft_invalidStartNode_returns400() throws Exception {

--- a/backend/src/test/java/com/init/domainpack/presentation/CreateDomainPackDraftControllerTest.java
+++ b/backend/src/test/java/com/init/domainpack/presentation/CreateDomainPackDraftControllerTest.java
@@ -14,6 +14,12 @@ import com.init.domainpack.application.exception.DomainPackNotFoundException;
 import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
 import com.init.domainpack.application.exception.DomainPackVersionConflictException;
 import com.init.domainpack.application.exception.DomainPackWorkspaceNotFoundException;
+import com.init.domainpack.application.exception.WorkflowCycleDetectedException;
+import com.init.domainpack.application.exception.WorkflowDanglingEdgeException;
+import com.init.domainpack.application.exception.WorkflowInvalidStartNodeException;
+import com.init.domainpack.application.exception.WorkflowInvalidTerminalNodeException;
+import com.init.domainpack.application.exception.WorkflowUnlabeledBranchException;
+import com.init.domainpack.application.exception.WorkflowUnreachableNodeException;
 import com.init.fixtures.WithLongPrincipal;
 import com.init.shared.infrastructure.security.JwtAuthenticationFilter;
 import java.time.OffsetDateTime;
@@ -196,6 +202,103 @@ class CreateDomainPackDraftControllerTest {
                     """))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+  }
+
+  @Test
+  @DisplayName("graphJson V1 위반 (START 노드 없음/복수) 이면 400을 반환한다")
+  @WithLongPrincipal(10L)
+  void createDraft_invalidStartNode_returns400() throws Exception {
+    given(useCase.execute(any())).willThrow(new WorkflowInvalidStartNodeException("refund_flow"));
+
+    mockMvc
+        .perform(
+            post(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(validRequestJson()))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("WORKFLOW_INVALID_START_NODE"));
+  }
+
+  @Test
+  @DisplayName("graphJson V2 위반 (TERMINAL 노드 없음) 이면 400을 반환한다")
+  @WithLongPrincipal(10L)
+  void createDraft_invalidTerminalNode_returns400() throws Exception {
+    given(useCase.execute(any()))
+        .willThrow(new WorkflowInvalidTerminalNodeException("refund_flow"));
+
+    mockMvc
+        .perform(
+            post(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(validRequestJson()))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("WORKFLOW_INVALID_TERMINAL_NODE"));
+  }
+
+  @Test
+  @DisplayName("graphJson V3 위반 (dangling edge) 이면 400을 반환한다")
+  @WithLongPrincipal(10L)
+  void createDraft_danglingEdge_returns400() throws Exception {
+    given(useCase.execute(any())).willThrow(new WorkflowDanglingEdgeException("refund_flow"));
+
+    mockMvc
+        .perform(
+            post(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(validRequestJson()))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("WORKFLOW_DANGLING_EDGE"));
+  }
+
+  @Test
+  @DisplayName("graphJson V4 위반 (도달 불가 노드) 이면 400을 반환한다")
+  @WithLongPrincipal(10L)
+  void createDraft_unreachableNode_returns400() throws Exception {
+    given(useCase.execute(any())).willThrow(new WorkflowUnreachableNodeException("refund_flow"));
+
+    mockMvc
+        .perform(
+            post(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(validRequestJson()))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("WORKFLOW_UNREACHABLE_NODE"));
+  }
+
+  @Test
+  @DisplayName("graphJson V5 위반 (사이클 존재) 이면 400을 반환한다")
+  @WithLongPrincipal(10L)
+  void createDraft_cycleDetected_returns400() throws Exception {
+    given(useCase.execute(any())).willThrow(new WorkflowCycleDetectedException("refund_flow"));
+
+    mockMvc
+        .perform(
+            post(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(validRequestJson()))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("WORKFLOW_CYCLE_DETECTED"));
+  }
+
+  @Test
+  @DisplayName("graphJson V6 위반 (DECISION 무레이블 분기) 이면 400을 반환한다")
+  @WithLongPrincipal(10L)
+  void createDraft_unlabeledBranch_returns400() throws Exception {
+    given(useCase.execute(any())).willThrow(new WorkflowUnlabeledBranchException("refund_flow"));
+
+    mockMvc
+        .perform(
+            post(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(validRequestJson()))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("WORKFLOW_UNLABELED_BRANCH"));
   }
 
   @Test


### PR DESCRIPTION
## Summary

- `CreateDomainPackDraftUseCase.validateDraftPayload()`에 graphJson 무결성 규칙 V1-V6 검증 추가
- V1-V6 통과 후 graphJson에서 `initialState`(START 노드 id), `terminalStatesJson`(TERMINAL 노드 id 배열) 자동 추출
- `WorkflowDraftRequest` DTO의 두 필드를 `@Size` → `@Null`로 교체 (클라이언트 제공 시 400 반환)
- `.agent/specs/231.md`에 226.md 기반 V1-V6 섹션 반영 (스펙 갱신)

---

## Context

`spec/226.md`가 graphJson 스키마(direction/nodes/edges)와 V1-V6 validation rule을 정의하면서,  
이를 코드로 강제하는 책임을 `spec/231.md`(`CreateDomainPackDraftUseCase` write path)에 위임했다.  
이 PR은 그 구현 책임을 이행하며, 동시에 231.md 스펙 문서가 V1-V6 내용을 포함하지 않았던 상태를 갱신한다.

---

## What Changed

### 문서

| 파일 | 변경 내용 |
|------|-----------|
| `.agent/specs/231.md` | V1-V6 검증 절차(validateDraftPayload 4단계), @Null DTO 변경 섹션, 신규 예외 클래스, 추출 로직 기준 테이블, Unit/Controller 테스트 케이스, Additional Notes 추가 |
| `.agent/specs/31.md` | 신규 delta spec — 31.md가 231.md 위에 적용되는 변경 사항의 canonical 정의 |

### 코드

| 파일 | 변경 내용 |
|------|-----------|
| `WorkflowGraphValidator.java` (신규) | package-private 헬퍼 클래스. graphJson 파싱 + V1-V6 순서대로 검증 (fail-fast). START/TERMINAL 노드 id 추출 포함. |
| 예외 클래스 6종 (신규) | `WorkflowInvalidStartNodeException` 등 — 모두 `BadRequestException` 상속, spec 에러 코드/메시지 일치 |
| `CreateDomainPackDraftUseCase.java` | `validateDraftPayload()` → `validateAndExtractWorkflows()` 로직 전환. graphJson 파싱·V1-V6·추출 수행 후 `WorkflowDraft`(initialState, terminalStatesJson 포함) 반환. |
| `CreateDomainPackDraftRequest.java` | `WorkflowDraftRequest.initialState`, `terminalStatesJson` 필드 `@Size` → `@Null` 교체 |
| `CreateDomainPackDraftController.java` | `WorkflowDraft` command 생성 시 두 필드 `null` 전달 (UseCase 추출값으로 채워짐) |
| `CreateDomainPackDraftUseCaseTest.java` | V1-V6 위반 7케이스 + 추출 정확성 3케이스 (initialState, terminalStatesJson, TERMINAL 복수) 추가 |
| `CreateDomainPackDraftControllerTest.java` | V1-V6 위반 6케이스 + 유효 graphJson 정상 케이스 + initialState 필드 거부 케이스 추가 |

---

## Assumptions Adopted

**U-01 — Option A 채택 (서버 자동 추출)**

- 근거: `226.md:63-65`에서 `initialState`/`terminalStatesJson`이 graphJson 파생 값으로 정의됨
- 결정: `WorkflowDraftRequest` 및 `WorkflowDraft` command record에서 두 필드를 클라이언트 입력 필드로 유지하되 `@Null` 제약으로 거부. V1-V6 통과 후 서버가 graphJson에서 추출하여 저장.
- 영향: 기존에 `initialState`/`terminalStatesJson`을 직접 제공하던 클라이언트가 있다면 400 반환으로 동작 변경됨

---

## Spec Deviations

**`@Null` 교체 vs. 필드 완전 제거**

- Uncertainty Register(U-01 Execution Rule): "필드 제거"로 표현
- 실제 구현 및 spec/31.md: `@Null` annotation으로 교체
- 이유: Jackson 역직렬화 후 Bean Validation이 null 여부를 검증하여, 클라이언트가 값을 제공하는 경우 400 `VALIDATION_ERROR` 반환. spec/31.md가 1차 기준이므로 `@Null` 방식을 적용했으며 동작상 동등함.

이 외 spec 대비 구현 차이 없음.

---

## Blocked / Skipped Items

없음.

---

## Test Notes

**Audit r1 (2026-04-14)**: FAIL — Critical 3개

- V1-V6 검증 로직 미구현
- initialState/terminalStatesJson null 저장
- 예외 클래스 6종 미생성

**Audit r2 (2026-04-14)**: PASS — Warning 2개, Info 1개

| ID | Severity | 내용 |
|----|----------|------|
| V-001 | Warning | `WorkflowGraphValidator.parseAndValidate()` 내 `catch (Exception e)` — `JsonProcessingException\|IOException`으로 좁혀야 함. 현재는 JSON 파싱 실패를 V1 위반(`WORKFLOW_INVALID_START_NODE`)으로 처리하여 오진 가능성 있음. |
| V-002 | Warning | Controller 테스트에 `terminalStatesJson` 필드 포함 시 400 반환 케이스 누락. `initialState` 거부 테스트만 존재. |
| V-003 | Info | UseCase 테스트 메서드 네이밍이 기존 파일의 `execute_condition_throwsException` 스타일을 따름 — 권장 `should_결과_when_조건`과 불일치. 파일 내 일관성은 유지됨. |

---

## Reviewer Focus

1. **`WorkflowGraphValidator.parseAndValidate()`:36** — `catch (Exception e)` 범위. JSON 파싱 실패와 V1 위반을 동일 예외로 처리 중. 별도 `WorkflowGraphInvalidJsonException` 또는 `catch (JsonProcessingException | IOException e)`로 좁히는 것을 검토할 것.

2. **`CreateDomainPackDraftControllerTest.java`** — `terminalStatesJson` 필드 포함 시 400 반환 테스트 누락. spec 체크리스트 항목이 절반만 커버됨.

3. **V1-V6 fail-fast 순서** — spec에서 V1→V2→V3→V4→V5→V6 순서로 위반 검사를 수행하도록 권장. 실제 `WorkflowGraphValidator` 구현 순서가 spec 순서와 일치하는지 확인.

---

## Conflicts

없음.

---

## Ready to Merge / Needs Input

**Needs Attention** — 머지 전 아래 두 항목 결정 필요:

- **V-001 (Warning)**: `catch (Exception e)` 수정 여부 — 이 PR 내 fix 또는 별도 follow-up 이슈 등록
- **V-002 (Warning)**: `terminalStatesJson` 거부 테스트 추가 여부 — spec 체크리스트 완성을 위해 이 PR 내 추가 권장


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 워크플로우 그래프 V1–V6 검증 추가(시작/종료 노드, 연결 유효성, 도달성, 순환, 분기 레이블 등) 및 검증 성공 시 초기 상태·종료 상태 자동 추출·저장.
  * 검증 실패 시 구체적 오류 코드와 400 응답 반환.

* **API 변경**
  * 클라이언트가 initialState 또는 terminalStatesJson을 보내면 400 VALIDATION_ERROR로 거부(서버가 추출하여 관리).

* **Tests**
  * 다양한 그래프 검증 실패/성공 시나리오 테스트 추가 및 기존 테스트 업데이트.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->