### PR TITLE
spec/113: airflow setting

### DIFF
--- a/.agent/specs/113.md
+++ b/.agent/specs/113.md
@@ -82,11 +82,17 @@ flowchart LR
 
 ### 기동 순서
 
+#### A. Airflow 내부 기동 순서
+
 1. `postgres` healthcheck 통과
 2. `airflow-init` 실행 완료
 3. `airflow-apiserver`, `airflow-scheduler`, `airflow-dag-processor` 기동
-4. `backend` 기동
-5. `frontend` 기동
+
+#### B. 애플리케이션 기동 순서
+
+1. `postgres` healthcheck 통과
+2. `backend` 기동
+3. `frontend` 기동
 
 ### Compose 의존 조건
 
@@ -103,12 +109,17 @@ flowchart LR
 - `airflow-dag-processor`
   - `depends_on.postgres.condition = service_healthy`
   - `depends_on.airflow-init.condition = service_completed_successfully`
+- `backend`
+  - `depends_on.postgres.condition = service_healthy`
+- `frontend`
+  - `depends_on.backend.condition = service_started`
 
 원칙:
 
 - Airflow 런타임 서비스는 migration 완료 전 기동하면 안 된다.
 - `airflow-init`는 one-shot init job이다.
 - 다른 Airflow 서비스는 `service_completed_successfully` 없이는 시작하지 않는다.
+- `backend`와 `frontend`는 Airflow 내부 기동 순서에 종속되지 않는다.
 
 ---
 
@@ -376,6 +387,12 @@ sequenceDiagram
 - `ml/src/pipeline/__init__.py` 존재
 - `ml/src/pipeline/common/__init__.py` 존재
 - 각 stage 디렉터리의 `__init__.py` 존재
+
+검증 근거:
+
+- 로컬 확인 명령: `find ml/src/pipeline -maxdepth 3 \( -type f -o -type d \) | sort`
+- 로컬 확인 명령:
+  `test -f ml/src/pipeline/__init__.py && echo yes-pipeline-init; test -f ml/src/pipeline/common/__init__.py && echo yes-common-init; find ml/src/pipeline/stages -mindepth 1 -maxdepth 1 -type d -exec sh -c 'for d; do if [ -f "$d/__init__.py" ]; then echo yes-stage-init:$d; else echo no-stage-init:$d; fi; done' sh {} + | sort`
 
 따라서 현재 기준으로는 `ml/src/pipeline/...` import 구조는 유지 가능하지만, `ml/dags/`와 `ml/airflow/`는 **신규 생성 예정 경로**로 취급해야 한다.
 

--- a/.agent/specs/113.md
+++ b/.agent/specs/113.md
@@ -10,9 +10,13 @@
 
 ## Goal
 
-로컬 개발·검증 환경에서 `docker compose up --build -d` 한 번으로 Airflow 3.1.8 + Python 3.13 기반 파이프라인 실행환경을 초기화하고, DAG 파싱·실행·로그 확인·artifact 저장까지 일관되게 재현할 수 있도록 실행환경 구조와 운영 규칙을 정의한다.
+로컬 개발·검증 환경에서 `docker compose up --build -d` 한 번으로 Airflow 3.1.8 + Python 3.12 기반 파이프라인 실행환경을 초기화하고, DAG 파싱·실행·로그 확인·artifact 저장까지 일관되게 재현할 수 있도록 실행환경 구조와 운영 규칙을 정의한다.
 
 이 스펙은 **운영 배포 문서가 아니며**, Spring `pipeline-job` 기능 구현이나 Airflow↔Spring webhook 구현은 범위에서 제외한다.
+
+> **Airflow Version**: `3.1.8`  
+> **Python Variant**: `python3.12`  
+> **Latest known release at spec time**: `3.2.0` — 로컬 개발 안정성을 위해 의도적으로 `3.1.8`에 고정한다.
 
 ---
 
@@ -36,6 +40,20 @@
 | `airflow-scheduler` | DAG run 스케줄링/태스크 orchestration | 필수 | `LocalExecutor` |
 | `airflow-dag-processor` | DAG 파싱/갱신 | 필수 | Airflow 3 최소 구성 |
 | `airflow-triggerer` | deferrable task 이벤트 루프 | 선택 | v1 최소 구성 제외, optional profile |
+
+### 런타임 권장 정책
+
+- `airflow-apiserver`, `airflow-scheduler`, `airflow-dag-processor`에는 `restart: unless-stopped`를 권장한다.
+- `airflow-apiserver`에는 healthcheck를 둔다.
+
+```yaml
+healthcheck:
+  test: ["CMD", "curl", "--fail", "http://localhost:8080/api/v2/version"]
+  interval: 30s
+  timeout: 10s
+  retries: 5
+  start_period: 30s
+```
 
 ### 토폴로지 다이어그램
 
@@ -202,6 +220,7 @@ sequenceDiagram
 - `airflow db migrate` 수행
 - `/opt/airflow/logs`, `/opt/airflow/artifacts`, `/opt/airflow/auth` writable 여부 확인
 - 사용자 생성은 수행하지 않음
+- 이유: Simple auth manager는 `airflow-apiserver` 기동 시 비밀번호를 자동 생성하므로, init 단계에서 `airflow users create`를 실행하면 인증 방식과 충돌한다.
 
 ### 로컬 재부트스트랩 절차
 
@@ -209,6 +228,8 @@ sequenceDiagram
 - DB만 남아 있는 꼬임 복구:
   - `postgres` 볼륨 삭제 후 재기동 또는
   - 수동으로 `airflow` DB/role 생성 후 `airflow-init` 재실행
+
+> ⚠️ `docker compose down -v`는 `airflow_artifacts`, `airflow_logs`, `airflow_auth`를 포함한 **모든 named volume**을 삭제한다. 보존이 필요한 artifact와 로그는 사전에 백업한다.
 
 ---
 
@@ -226,7 +247,7 @@ sequenceDiagram
 
 ### Airflow 이미지 정책
 
-- 베이스 이미지: `apache/airflow:3.1.8-python3.13`
+- 베이스 이미지: `apache/airflow:3.1.8-python3.12`
 - 커스텀 이미지는 **항상 이 버전 위에서 확장**
 - `ml/airflow/requirements.txt` 설치 시 `apache-airflow==3.1.8`을 함께 명시해 버전 드리프트를 막는다.
 
@@ -270,11 +291,16 @@ sequenceDiagram
 | `AIRFLOW__CORE__EXECUTION_API_SERVER_URL` | `http://airflow-apiserver:8080/execution/` | execution API URL |
 | `AIRFLOW__API_AUTH__JWT_SECRET` | `<required>` | Scheduler/API Server 공통 JWT secret |
 | `AIRFLOW__CORE__LOAD_EXAMPLES` | `False` | 예제 DAG 비활성화 |
-| `AIRFLOW__CORE__SIMPLE_AUTH_MANAGER_USERS` | `admin:admin,viewer:viewer` | Simple auth 사용자 선언 |
+| `AIRFLOW__CORE__SIMPLE_AUTH_MANAGER_USERS` | `admin:admin,viewer:viewer` | Simple auth 사용자 선언 (형식: `username:role`, 비밀번호는 자동 생성됨) |
 | `AIRFLOW__CORE__SIMPLE_AUTH_MANAGER_PASSWORDS_FILE` | `/opt/airflow/auth/simple_auth_manager_passwords.json.generated` | 자동 생성 비밀번호 저장 파일 |
 | `AIRFLOW__CORE__DAGS_FOLDER` | `/opt/airflow/dags` | DAG 디렉터리 |
 | `AIRFLOW__LOGGING__BASE_LOG_FOLDER` | `/opt/airflow/logs` | 로그 디렉터리 |
 | `PYTHONPATH` | `/opt/airflow/src` | 파이프라인 코드 import 경로 |
+
+`AIRFLOW__SCHEDULER__STANDALONE_DAG_PROCESSOR`는 명시하지 않는다.
+
+- Airflow 3에서는 `dag-processor`가 독립 서비스로 동작하는 구성이 기본 전제다.
+- 따라서 이번 스펙은 `airflow-dag-processor` 서비스 자체를 필수로 두고, 2.x 호환 목적의 추가 env는 넣지 않는다.
 
 ### 앱/파이프라인 env
 
@@ -466,6 +492,11 @@ Airflow UI에서 확인 가능해야 하는 항목:
 - `airflow-triggerer`는 v1 최소 환경에서 제외한다.
 - 다만 deferrable operator 도입 시 optional compose profile로 추가한다.
 - 예시: `profiles: ["deferrable"]`
+
+### DAG 파싱 제외 전략
+
+- 개발용 DAG가 늘어나면 `.airflowignore` 또는 DAG tag 기반 필터링을 후속 규칙으로 도입한다.
+- v1에서는 `dev_bootstrap.py`, `dev_replay.py`를 검증용 DAG로 유지하되, 파싱 대상 제외 전략은 후속 문서에서 확정한다.
 
 ### 참고 테이블
 

--- a/.agent/specs/113.md
+++ b/.agent/specs/113.md
@@ -1,0 +1,490 @@
+# [ML-113] Airflow 실행환경 설정
+
+> **Backlog**: 팀 로컬 개발·검증 환경에서 Airflow 기반 파이프라인을 일관된 방식으로 실행하고 싶다 → 상담 로그 기반 Domain Pack 생성 파이프라인을 재현 가능하게 개발·검증하기 위해
+> **Bounded Context**: `pipeline`
+> **Template**: `_TEMPLATE_ML.md`
+> **Branch**: `spec/113`
+> **PR Title**: `113 airflow setting`
+
+---
+
+## Goal
+
+로컬 개발·검증 환경에서 `docker compose up --build -d` 한 번으로 Airflow 3.1.8 + Python 3.13 기반 파이프라인 실행환경을 초기화하고, DAG 파싱·실행·로그 확인·artifact 저장까지 일관되게 재현할 수 있도록 실행환경 구조와 운영 규칙을 정의한다.
+
+이 스펙은 **운영 배포 문서가 아니며**, Spring `pipeline-job` 기능 구현이나 Airflow↔Spring webhook 구현은 범위에서 제외한다.
+
+---
+
+## Runtime Topology
+
+### 목적
+
+- 루트 `docker-compose.yml` 기준으로 전체 서비스를 같은 방식으로 띄운다.
+- Airflow 3 최소 구성 요소를 빠짐없이 포함한다.
+- metadata migration 이전에 Airflow 런타임 서비스가 먼저 뜨지 않도록 one-shot init 규칙을 강제한다.
+
+### 서비스 구성
+
+| Service | 역할 | 필수 여부 | 비고 |
+|--------|------|-----------|------|
+| `postgres` | 앱 DB + Airflow metadata DB 호스팅 | 필수 | 컨테이너 1개, DB 2개(`init`, `airflow`) |
+| `backend` | Spring Boot 앱 서버 | 필수 | 기존 서비스 유지 |
+| `frontend` | 웹 UI | 필수 | 기존 서비스 유지 |
+| `airflow-init` | metadata migration + writable path 확인 | 필수 | one-shot init job |
+| `airflow-apiserver` | Airflow UI/API 제공 | 필수 | Airflow 3 기준 `api-server` 사용 |
+| `airflow-scheduler` | DAG run 스케줄링/태스크 orchestration | 필수 | `LocalExecutor` |
+| `airflow-dag-processor` | DAG 파싱/갱신 | 필수 | Airflow 3 최소 구성 |
+| `airflow-triggerer` | deferrable task 이벤트 루프 | 선택 | v1 최소 구성 제외, optional profile |
+
+### 토폴로지 다이어그램
+
+```mermaid
+flowchart LR
+    FE["frontend"] --> BE["backend"]
+    BE --> PG1["PostgreSQL / init DB"]
+
+    subgraph Airflow Runtime
+        AI["airflow-init"]
+        AS["airflow-apiserver"]
+        SCH["airflow-scheduler"]
+        DP["airflow-dag-processor"]
+    end
+
+    AI --> PG2["PostgreSQL / airflow DB"]
+    AS --> PG2
+    SCH --> PG2
+    DP --> PG2
+
+    AS --> DAGS["추가 예정: ml/dags/"]
+    SCH --> SRC["기존: ml/src/pipeline/"]
+    DP --> DAGS
+    SCH --> ART["named volume /opt/airflow/artifacts"]
+```
+
+### 기동 순서
+
+1. `postgres` healthcheck 통과
+2. `airflow-init` 실행 완료
+3. `airflow-apiserver`, `airflow-scheduler`, `airflow-dag-processor` 기동
+4. `backend` 기동
+5. `frontend` 기동
+
+### Compose 의존 조건
+
+`docker compose up --build -d` 한 번으로 끝내기 위해 아래 조건을 명시한다.
+
+- `airflow-init`
+  - `depends_on.postgres.condition = service_healthy`
+- `airflow-apiserver`
+  - `depends_on.postgres.condition = service_healthy`
+  - `depends_on.airflow-init.condition = service_completed_successfully`
+- `airflow-scheduler`
+  - `depends_on.postgres.condition = service_healthy`
+  - `depends_on.airflow-init.condition = service_completed_successfully`
+- `airflow-dag-processor`
+  - `depends_on.postgres.condition = service_healthy`
+  - `depends_on.airflow-init.condition = service_completed_successfully`
+
+원칙:
+
+- Airflow 런타임 서비스는 migration 완료 전 기동하면 안 된다.
+- `airflow-init`는 one-shot init job이다.
+- 다른 Airflow 서비스는 `service_completed_successfully` 없이는 시작하지 않는다.
+
+---
+
+## Project Layout
+
+### 현재 확인된 경로
+
+- 기존 ML 루트: `ml/`
+- 기존 파이프라인 코드: `ml/src/pipeline/`
+- 기존 stage 구현: `ml/src/pipeline/stages/`
+- 기존 공용 패키지: `ml/src/pipeline/common/`
+
+### 신규 추가 예정 경로
+
+아래 경로는 **이번 spec 기준 신규 추가 예정 구조**이며, 현재 저장소에는 아직 존재하지 않는다.
+
+```text
+ml/
+├── dags/                         # 추가 예정: Airflow DAG 정의
+│   ├── domain_pack_generation.py
+│   ├── dev_bootstrap.py
+│   └── dev_replay.py
+├── src/pipeline/                 # 기존 경로
+│   ├── common/                   # 기존 경로
+│   │   ├── config.py             # 추가 예정
+│   │   ├── logging.py            # 추가 예정
+│   │   ├── artifacts.py          # 추가 예정
+│   │   ├── context.py            # 추가 예정
+│   │   └── exceptions.py         # 추가 예정
+│   ├── contracts/                # 추가 예정
+│   │   ├── stage_inputs.py
+│   │   ├── stage_outputs.py
+│   │   └── pipeline_events.py
+│   ├── integrations/            # 추가 예정
+│   │   ├── postgres.py
+│   │   ├── backend_client.py
+│   │   └── artifact_store.py
+│   └── stages/                   # 기존 경로
+│       ├── ingestion/
+│       ├── preprocessing/
+│       ├── intent_discovery/
+│       ├── draft_generation/
+│       ├── evaluation/
+│       └── publish_candidate/
+└── airflow/                      # 추가 예정: Airflow 런타임 전용 디렉터리
+    ├── Dockerfile
+    ├── requirements.txt
+    ├── scripts/
+    │   └── init-airflow.sh
+    └── .env.example
+```
+
+### 구조 원칙
+
+- `ml/dags/`는 orchestration only
+- 실제 stage 로직은 `ml/src/pipeline/stages/`
+- 공통 기술은 `ml/src/pipeline/common/`
+- stage 입출력 계약은 `ml/src/pipeline/contracts/`
+- 외부 연동은 `ml/src/pipeline/integrations/`
+- `include/` 같은 범용 디렉터리명은 사용하지 않는다
+- 데모 앱, Streamlit, 벡터 DB 실험용 구조는 최소 실행환경 범위에서 제외한다
+
+---
+
+## Bootstrap Flow
+
+### 초기화 시퀀스
+
+```mermaid
+sequenceDiagram
+    participant dc as docker compose
+    participant pg as postgres
+    participant ai as airflow-init
+    participant ap as airflow-apiserver
+    participant sc as airflow-scheduler
+    participant dp as airflow-dag-processor
+
+    dc->>pg: start
+    pg-->>dc: healthy
+    dc->>ai: start
+    ai->>pg: connect airflow DB
+    ai->>ai: airflow db migrate
+    ai->>ai: logs/artifacts/auth writable check
+    ai-->>dc: exit 0
+    dc->>ap: start
+    dc->>sc: start
+    dc->>dp: start
+    ap->>ap: simple auth password generate
+```
+
+### DB 분리 규칙
+
+- Postgres 컨테이너는 1개만 사용한다.
+- 앱 데이터용 DB는 `init`
+- Airflow metadata 전용 DB는 `airflow`
+- 앱의 기존 스키마 `app/corpus/pack/review/pipeline/runtime`는 `init` DB 안에 유지한다.
+- Airflow metadata 테이블은 `airflow` DB에만 생성한다.
+
+### 초기화 책임
+
+#### `postgres`
+
+- `docker-entrypoint-initdb.d` 기반 bootstrap script로 `airflow` DB와 전용 role을 생성한다.
+- 데이터 볼륨이 이미 존재하면 bootstrap script가 재실행되지 않는 점을 문서에 명시한다.
+
+#### `airflow-init`
+
+- `AIRFLOW__DATABASE__SQL_ALCHEMY_CONN`으로 metadata DB 접속
+- `airflow db migrate` 수행
+- `/opt/airflow/logs`, `/opt/airflow/artifacts`, `/opt/airflow/auth` writable 여부 확인
+- 사용자 생성은 수행하지 않음
+
+### 로컬 재부트스트랩 절차
+
+- 완전 초기화: `docker compose down -v`
+- DB만 남아 있는 꼬임 복구:
+  - `postgres` 볼륨 삭제 후 재기동 또는
+  - 수동으로 `airflow` DB/role 생성 후 `airflow-init` 재실행
+
+---
+
+## Docker Compose And Image Policy
+
+### 표준 명령
+
+- 첫 실행: `docker compose up --build -d`
+- 이후 재실행: `docker compose up -d`
+
+이유:
+
+- 커스텀 Airflow 이미지를 처음부터 빌드해야 한다.
+- 오래된 이미지 캐시나 미빌드 상태로 인한 `ModuleNotFoundError`, provider 누락, 버전 불일치를 줄인다.
+
+### Airflow 이미지 정책
+
+- 베이스 이미지: `apache/airflow:3.1.8-python3.13`
+- 커스텀 이미지는 **항상 이 버전 위에서 확장**
+- `ml/airflow/requirements.txt` 설치 시 `apache-airflow==3.1.8`을 함께 명시해 버전 드리프트를 막는다.
+
+예시 정책:
+
+- `apache-airflow==3.1.8`
+- `asyncpg`
+- 필요한 provider/client 패키지
+
+금지:
+
+- `_PIP_ADDITIONAL_REQUIREMENTS` 사용
+- Airflow 버전 미고정 상태에서 provider만 추가 설치
+
+---
+
+## Environment Contract
+
+### 필수 prerequisites
+
+- Docker Engine 설치
+- Docker Compose v2 사용
+- Docker 메모리 최소 4GB, 권장 8GB
+
+### 호스트별 주의사항
+
+- Linux: `.env`에 `AIRFLOW_UID=$(id -u)`를 넣는 것을 필수 prerequisite로 둔다.
+- macOS / Windows: 기본값 사용 가능
+- SELinux / AppArmor의 `:z` 마운트는 기본 스펙이 아니라 트러블슈팅 항목으로 둔다.
+
+### Airflow 필수 env
+
+| Key | Value / Example | 설명 |
+|-----|-----------------|------|
+| `AIRFLOW__CORE__EXECUTOR` | `LocalExecutor` | 실행기 고정 |
+| `AIRFLOW__DATABASE__SQL_ALCHEMY_CONN` | `postgresql+psycopg2://airflow:${AIRFLOW_DB_PASSWORD}@postgres:5432/airflow` | sync metadata DB 연결 |
+| `AIRFLOW__DATABASE__SQL_ALCHEMY_CONN_ASYNC` | `postgresql+asyncpg://airflow:${AIRFLOW_DB_PASSWORD}@postgres:5432/airflow` | async metadata DB 연결 |
+| `AIRFLOW__CORE__FERNET_KEY` | `<required>` | 암호화 키 |
+| `AIRFLOW__API__SECRET_KEY` | `<required>` | API secret key |
+| `AIRFLOW__API__BASE_URL` | `http://airflow-apiserver:8080` | 내부 API base URL |
+| `AIRFLOW__CORE__EXECUTION_API_SERVER_URL` | `http://airflow-apiserver:8080/execution/` | execution API URL |
+| `AIRFLOW__API_AUTH__JWT_SECRET` | `<required>` | Scheduler/API Server 공통 JWT secret |
+| `AIRFLOW__CORE__LOAD_EXAMPLES` | `False` | 예제 DAG 비활성화 |
+| `AIRFLOW__CORE__SIMPLE_AUTH_MANAGER_USERS` | `admin:admin,viewer:viewer` | Simple auth 사용자 선언 |
+| `AIRFLOW__CORE__SIMPLE_AUTH_MANAGER_PASSWORDS_FILE` | `/opt/airflow/auth/simple_auth_manager_passwords.json.generated` | 자동 생성 비밀번호 저장 파일 |
+| `AIRFLOW__CORE__DAGS_FOLDER` | `/opt/airflow/dags` | DAG 디렉터리 |
+| `AIRFLOW__LOGGING__BASE_LOG_FOLDER` | `/opt/airflow/logs` | 로그 디렉터리 |
+| `PYTHONPATH` | `/opt/airflow/src` | 파이프라인 코드 import 경로 |
+
+### 앱/파이프라인 env
+
+| Key | Value / Example | 설명 |
+|-----|-----------------|------|
+| `DB_NAME` | `init` | 앱 DB 이름 |
+| `DB_USER` | `init` | 앱 DB 계정 |
+| `DB_PASSWORD` | `<required>` | 앱 DB 비밀번호 |
+| `AIRFLOW_DB_PASSWORD` | `<required>` | Airflow metadata DB 비밀번호 |
+| `PIPELINE_BACKEND_BASE_URL` | `http://backend:8080` | backend 연동 base URL |
+| `PIPELINE_ARTIFACT_ROOT` | `/opt/airflow/artifacts` | artifact 루트 |
+| `AIRFLOW_UID` | `501` 등 | Linux host 권한 문제 방지 |
+
+### 인증 규칙
+
+- 인증은 Simple auth manager로 고정한다.
+- 사용하지 않는 방식:
+  - `airflow users create`
+  - `AIRFLOW_ADMIN_*`
+- 비밀번호는 `airflow-apiserver` 시작 시 자동 생성된다.
+- 확인 위치:
+  - `airflow-apiserver` 로그
+  - `/opt/airflow/auth/simple_auth_manager_passwords.json.generated`
+
+---
+
+## Volumes And Import Rules
+
+### 마운트 규칙
+
+- `./ml/dags:/opt/airflow/dags`
+- `./ml/src:/opt/airflow/src`
+- `airflow_logs:/opt/airflow/logs`
+- `airflow_artifacts:/opt/airflow/artifacts`
+- `airflow_auth:/opt/airflow/auth`
+
+### Python import 규칙
+
+- `PYTHONPATH=/opt/airflow/src`
+- DAG에서는 `from pipeline.stages...` 사용
+- relative import 금지
+- DAG에서 import하는 모든 패키지 디렉터리에는 `__init__.py`가 있어야 한다.
+
+### 현재 저장소 확인 사항
+
+- `ml/src/pipeline/__init__.py` 존재
+- `ml/src/pipeline/common/__init__.py` 존재
+- 각 stage 디렉터리의 `__init__.py` 존재
+
+따라서 현재 패키지 구조는 유지 가능하다.
+
+---
+
+## Artifact-First Contract
+
+### 원칙
+
+- stage 간 데이터 전달은 XCom 중심이 아니라 artifact-first로 설계한다.
+- XCom에는 경량 제어 정보만 넣는다.
+
+### v1 최소 artifact 저장소
+
+- 별도 object storage는 도입하지 않는다.
+- named volume 기반 로컬 artifact 저장소를 사용한다.
+- artifact 루트: `/opt/airflow/artifacts`
+
+### 경로 규칙
+
+```text
+/opt/airflow/artifacts/{dag_id}/{run_id}/{stage_name}/
+```
+
+### XCom 전달 범위
+
+- artifact manifest 경로
+- 요약 메타데이터
+- 다음 stage 제어 정보
+
+`pipeline.pipeline_artifact` 등 서비스 DB 기록은 후속 구현 범위로 넘긴다.
+
+---
+
+## DAG Runtime Defaults
+
+개발 기본값은 아래로 고정한다.
+
+| 설정 | 값 |
+|------|----|
+| `retries` | `1` |
+| `retry_delay` | `timedelta(minutes=5)` |
+| `execution_timeout` | `timedelta(minutes=30)` |
+| `dagrun_timeout` | `timedelta(hours=2)` |
+| `max_active_runs` | `1` |
+| `catchup` | `False` |
+
+이유:
+
+- 로컬 개발에서는 무한 재시도보다 빠른 실패 확인이 우선
+- 동일 DAG 중복 실행 충돌을 줄임
+- 너무 오래 걸리는 태스크를 조기에 식별
+
+---
+
+## Airflow UI And Runtime Observability
+
+Airflow UI에서 확인 가능해야 하는 항목:
+
+- DAG import 오류
+- DAG 파싱 반영 여부
+- stage별 성공/실패
+- retry 상태
+- timeout 상태
+- task duration
+- task logs
+- 최근 DAG run 이력
+
+추가 로그 확인 대상:
+
+- `airflow-dag-processor` 로그
+- `airflow-scheduler` 로그
+- `airflow-apiserver` 로그
+
+실행 API 진단 포인트:
+
+- `airflow-scheduler`가 `http://airflow-apiserver:8080/execution/`에 도달 가능한가
+- `AIRFLOW__API_AUTH__JWT_SECRET`가 모든 Airflow 서비스에 동일하게 주입되는가
+
+태스크 로그 공통 필드 권장:
+
+- `workspace_id`
+- `dataset_id`
+- `pipeline_job_id`
+- `stage_name`
+- `artifact_root`
+
+한계:
+
+- Airflow UI는 orchestration 상태와 task 로그 확인에는 충분하다.
+- backend 반영 성공 여부나 `pipeline.*` 테이블 write 성공 여부는 이번 범위에서 직접 보장하지 않는다.
+
+---
+
+## Test Plan
+
+### Acceptance Criteria
+
+- 첫 실행에서 `docker compose up --build -d` 한 번으로 전체 서비스가 기동된다.
+- `airflow-init`가 먼저 성공 종료한 뒤 `airflow-apiserver`, `airflow-scheduler`, `airflow-dag-processor`가 기동된다.
+- migration 이전에 Airflow 런타임 서비스가 먼저 뜨지 않는다.
+- Airflow UI 접속이 가능하다.
+- `admin` 사용자의 자동 생성 비밀번호가 로그 또는 passwords file에서 확인된다.
+- 주 실행 DAG가 import error 없이 표시된다.
+- DAG 수정 후 `dag-processor`를 통해 UI 반영이 갱신된다.
+- smoke-test DAG 1회 실행이 성공한다.
+- failure-test DAG 1회 실행에서 `retry` / `failed` 상태가 UI에 표시된다.
+- execution API 통신 오류 없이 task가 시작된다.
+- `/opt/airflow/artifacts/...` 경로가 생성되고 manifest가 남는다.
+- Linux host에서 `AIRFLOW_UID` 적용 시 마운트 경로가 root 소유 문제 없이 동작한다.
+- `AIRFLOW__DATABASE__SQL_ALCHEMY_CONN_ASYNC`를 명시한 상태에서 metadata DB 연결이 정상 동작한다.
+
+### 검증용 보조 DAG
+
+아래 파일은 **신규 추가 예정** 검증용 DAG다.
+
+- `ml/dags/dev_bootstrap.py`
+  - 최소 import smoke test
+  - artifact 경로 생성 확인
+- `ml/dags/dev_replay.py`
+  - 의도적 실패 태스크 포함
+  - retry / failed 상태 확인
+
+---
+
+## Out Of Scope
+
+- Spring `pipeline-job` BC 구현
+- Airflow↔Spring webhook consumer 구현
+- `pipeline.pipeline_job_event`, `pipeline.pipeline_artifact` 등 서비스 DB write path 구현
+- object storage / vector DB / 문서 저장소 도입
+- 운영 배포용 Compose/Kubernetes 설계
+- `pipeline` top-level 패키지명 변경
+
+---
+
+## Additional Notes
+
+### 선택 컴포넌트
+
+- `airflow-triggerer`는 v1 최소 환경에서 제외한다.
+- 다만 deferrable operator 도입 시 optional compose profile로 추가한다.
+- 예시: `profiles: ["deferrable"]`
+
+### 참고 테이블
+
+이번 실행환경은 향후 아래 `pipeline` 스키마와 연계될 수 있도록 설계한다.
+
+- `pipeline_job`
+- `pipeline_job_event`
+- `pipeline_artifact`
+- `webhook_receipt`
+- `evaluation_run`
+- `evaluation_metric`
+- `cluster_evaluation`
+- `novel_intent_candidate`
+- `taxonomy_drift_log`
+
+### 참고 문서
+
+- [Airflow 3.1.8 Docker Compose](https://airflow.apache.org/docs/apache-airflow/3.1.8/howto/docker-compose/index.html)
+- [Airflow Docker image build guide](https://airflow.apache.org/docs/docker-stack/build.html)
+- [Airflow 3.1.8 Configuration Reference](https://airflow.apache.org/docs/apache-airflow/3.1.8/configurations-ref.html)
+- [Airflow 3.1.8 Modules Management](https://airflow.apache.org/docs/apache-airflow/3.1.8/administration-and-deployment/modules_management.html)
+- [Airflow 3.1.8 DAG File Processing](https://airflow.apache.org/docs/apache-airflow/3.1.8/administration-and-deployment/dagfile-processing.html)

--- a/.agent/specs/113.md
+++ b/.agent/specs/113.md
@@ -10,13 +10,13 @@
 
 ## Goal
 
-로컬 개발·검증 환경에서 `docker compose up --build -d` 한 번으로 Airflow 3.1.8 + Python 3.12 기반 파이프라인 실행환경을 초기화하고, DAG 파싱·실행·로그 확인·artifact 저장까지 일관되게 재현할 수 있도록 실행환경 구조와 운영 규칙을 정의한다.
+로컬 개발·검증 환경에서 `docker compose up --build -d` 한 번으로 Airflow 3.1.7 + Python 3.13 기반 파이프라인 실행환경을 초기화하고, DAG 파싱·실행·로그 확인·artifact 저장까지 일관되게 재현할 수 있도록 실행환경 구조와 운영 규칙을 정의한다.
 
 이 스펙은 **운영 배포 문서가 아니며**, Spring `pipeline-job` 기능 구현이나 Airflow↔Spring webhook 구현은 범위에서 제외한다.
 
-> **Airflow Version**: `3.1.8`  
-> **Python Variant**: `python3.12`  
-> **Latest known release at spec time**: `3.2.0` — 로컬 개발 안정성을 위해 의도적으로 `3.1.8`에 고정한다.
+> **Airflow Version**: `3.1.7`  
+> **Python Variant**: `python3.13`  
+> **Latest known release at spec time**: `3.2.0` — 로컬 개발 안정성과 Python 3.13 계약 정렬을 위해 의도적으로 `3.1.7`에 고정한다.
 
 ---
 
@@ -247,13 +247,14 @@ sequenceDiagram
 
 ### Airflow 이미지 정책
 
-- 베이스 이미지: `apache/airflow:3.1.8-python3.12`
+- 베이스 이미지: `apache/airflow:3.1.7-python3.13`
 - 커스텀 이미지는 **항상 이 버전 위에서 확장**
-- `ml/airflow/requirements.txt` 설치 시 `apache-airflow==3.1.8`을 함께 명시해 버전 드리프트를 막는다.
+- `추가 예정: ml/airflow/requirements.txt` 설치 시 `apache-airflow==3.1.7`을 함께 명시해 버전 드리프트를 막는다.
+- 현재 저장소에는 `ml/airflow/` 디렉터리가 없으므로, 이 경로는 **이번 스펙에서 새로 생성할 예정인 런타임 전용 디렉터리**로 취급한다.
 
 예시 정책:
 
-- `apache-airflow==3.1.8`
+- `apache-airflow==3.1.7`
 - `asyncpg`
 - 필요한 provider/client 패키지
 
@@ -261,6 +262,24 @@ sequenceDiagram
 
 - `_PIP_ADDITIONAL_REQUIREMENTS` 사용
 - Airflow 버전 미고정 상태에서 provider만 추가 설치
+
+### Python 버전 계약
+
+- 현재 저장소의 [ml/pyproject.toml](/Users/yeon_seong/coding/ostone/ml/pyproject.toml:1)은 `requires-python = ">=3.13"`을 사용한다.
+- Airflow 런타임 이미지는 `python3.13`에 고정한다.
+- 따라서 Airflow 런타임 Python과 ML 프로젝트의 최소 Python 계약을 일치시킨다.
+
+이유:
+
+- Airflow 컨테이너는 로컬 `ml` 프로젝트를 패키지로 설치하지 않는다.
+- 대신 `./ml/src`를 `/opt/airflow/src`로 bind mount 하고, `PYTHONPATH=/opt/airflow/src`로 모듈을 import 한다.
+- 즉 Airflow 런타임은 `pyproject.toml`의 build/install 계약을 직접 사용하지 않고, `ml/src/pipeline/...` 소스 import만 사용한다.
+- 그럼에도 런타임 Python을 `>=3.13` 계약과 맞춤으로써, 향후 3.13 전용 문법/stdlib 사용으로 인한 import 실패 가능성을 줄인다.
+
+추가 원칙:
+
+- Airflow 컨테이너 안에서 `pip install -e ./ml` 또는 동등한 방식으로 로컬 `ml` 패키지를 설치하지 않는다.
+- 향후 Airflow 이미지에서 `ml` 패키지 설치가 필요해져도, 현재 스펙 기준 Python 버전 계약 충돌은 없다.
 
 ---
 
@@ -331,11 +350,17 @@ sequenceDiagram
 
 ### 마운트 규칙
 
-- `./ml/dags:/opt/airflow/dags`
+- `추가 예정: ./ml/dags:/opt/airflow/dags`
 - `./ml/src:/opt/airflow/src`
 - `airflow_logs:/opt/airflow/logs`
 - `airflow_artifacts:/opt/airflow/artifacts`
 - `airflow_auth:/opt/airflow/auth`
+
+주의:
+
+- 현재 저장소에는 `ml/dags/` 디렉터리가 존재하지 않는다.
+- 따라서 `./ml/dags:/opt/airflow/dags` 마운트는 **Airflow DAG 디렉터리 생성 이후 적용할 예정인 목표 상태**다.
+- 현재 존재하는 경로 중 이번 스펙에서 바로 활용 가능한 것은 `./ml/src:/opt/airflow/src` 마운트다.
 
 ### Python import 규칙
 
@@ -346,11 +371,13 @@ sequenceDiagram
 
 ### 현재 저장소 확인 사항
 
+- `ml/dags/` 없음
+- `ml/airflow/` 없음
 - `ml/src/pipeline/__init__.py` 존재
 - `ml/src/pipeline/common/__init__.py` 존재
 - 각 stage 디렉터리의 `__init__.py` 존재
 
-따라서 현재 패키지 구조는 유지 가능하다.
+따라서 현재 기준으로는 `ml/src/pipeline/...` import 구조는 유지 가능하지만, `ml/dags/`와 `ml/airflow/`는 **신규 생성 예정 경로**로 취급해야 한다.
 
 ---
 
@@ -514,8 +541,8 @@ Airflow UI에서 확인 가능해야 하는 항목:
 
 ### 참고 문서
 
-- [Airflow 3.1.8 Docker Compose](https://airflow.apache.org/docs/apache-airflow/3.1.8/howto/docker-compose/index.html)
+- [Airflow 3.1.7 Docker Compose](https://airflow.apache.org/docs/apache-airflow/3.1.7/howto/docker-compose/index.html)
 - [Airflow Docker image build guide](https://airflow.apache.org/docs/docker-stack/build.html)
-- [Airflow 3.1.8 Configuration Reference](https://airflow.apache.org/docs/apache-airflow/3.1.8/configurations-ref.html)
-- [Airflow 3.1.8 Modules Management](https://airflow.apache.org/docs/apache-airflow/3.1.8/administration-and-deployment/modules_management.html)
-- [Airflow 3.1.8 DAG File Processing](https://airflow.apache.org/docs/apache-airflow/3.1.8/administration-and-deployment/dagfile-processing.html)
+- [Airflow 3.1.7 Configuration Reference](https://airflow.apache.org/docs/apache-airflow/3.1.7/configurations-ref.html)
+- [Airflow 3.1.7 Modules Management](https://airflow.apache.org/docs/apache-airflow/3.1.7/administration-and-deployment/modules_management.html)
+- [Airflow 3.1.7 DAG File Processing](https://airflow.apache.org/docs/apache-airflow/3.1.7/administration-and-deployment/dagfile-processing.html)


### PR DESCRIPTION
## Summary
- add ML-113 Airflow local setup spec under .agent/specs/113.md
- define Airflow 3.1.8 + Python 3.13 local runtime topology and bootstrap rules
- document compose, auth, DB, artifact, import, and validation defaults for local development


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * 로컬 개발 환경 구성을 위한 사양서가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->