### PR TITLE
feat(domain-pack): add slot update and slot status update APIs (#326)

### DIFF
--- a/backend/src/main/java/com/init/domainpack/application/SlotDefinitionResponse.java
+++ b/backend/src/main/java/com/init/domainpack/application/SlotDefinitionResponse.java
@@ -1,0 +1,37 @@
+package com.init.domainpack.application;
+
+import com.init.domainpack.domain.model.SlotDefinition;
+import java.time.OffsetDateTime;
+
+public record SlotDefinitionResponse(
+    Long id,
+    Long domainPackVersionId,
+    String slotCode,
+    String name,
+    String description,
+    String dataType,
+    Boolean isSensitive,
+    String validationRuleJson,
+    String defaultValueJson,
+    String metaJson,
+    String status,
+    OffsetDateTime createdAt,
+    OffsetDateTime updatedAt) {
+
+  public static SlotDefinitionResponse from(SlotDefinition slot) {
+    return new SlotDefinitionResponse(
+        slot.getId(),
+        slot.getDomainPackVersionId(),
+        slot.getSlotCode(),
+        slot.getName(),
+        slot.getDescription(),
+        slot.getDataType(),
+        slot.getIsSensitive(),
+        slot.getValidationRuleJson(),
+        slot.getDefaultValueJson(),
+        slot.getMetaJson(),
+        slot.getStatus(),
+        slot.getCreatedAt(),
+        slot.getUpdatedAt());
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/application/UpdateSlotCommand.java
+++ b/backend/src/main/java/com/init/domainpack/application/UpdateSlotCommand.java
@@ -1,0 +1,14 @@
+package com.init.domainpack.application;
+
+public record UpdateSlotCommand(
+    Long workspaceId,
+    Long packId,
+    Long versionId,
+    Long slotId,
+    Long requesterId,
+    String name,
+    String description,
+    Boolean isSensitive,
+    String validationRuleJson,
+    String defaultValueJson,
+    String metaJson) {}

--- a/backend/src/main/java/com/init/domainpack/application/UpdateSlotStatusCommand.java
+++ b/backend/src/main/java/com/init/domainpack/application/UpdateSlotStatusCommand.java
@@ -1,0 +1,4 @@
+package com.init.domainpack.application;
+
+public record UpdateSlotStatusCommand(
+    Long workspaceId, Long packId, Long versionId, Long slotId, Long requesterId, String status) {}

--- a/backend/src/main/java/com/init/domainpack/application/UpdateSlotStatusUseCase.java
+++ b/backend/src/main/java/com/init/domainpack/application/UpdateSlotStatusUseCase.java
@@ -1,0 +1,87 @@
+package com.init.domainpack.application;
+
+import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
+import com.init.domainpack.application.exception.DomainPackWorkspaceNotFoundException;
+import com.init.domainpack.domain.model.DomainPackVersion;
+import com.init.domainpack.domain.model.SlotDefinition;
+import com.init.domainpack.domain.model.WorkspaceMemberRole;
+import com.init.domainpack.domain.repository.DomainPackVersionRepository;
+import com.init.domainpack.domain.repository.SlotDefinitionRepository;
+import com.init.domainpack.domain.repository.WorkspaceExistencePort;
+import com.init.domainpack.domain.repository.WorkspaceMembershipPort;
+import com.init.shared.application.exception.BadRequestException;
+import com.init.shared.application.exception.NotFoundException;
+import java.util.Set;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class UpdateSlotStatusUseCase {
+
+  private static final Set<WorkspaceMemberRole> ALLOWED_ROLES =
+      Set.of(WorkspaceMemberRole.OPERATOR, WorkspaceMemberRole.ADMIN);
+
+  private final SlotDefinitionRepository slotRepository;
+  private final DomainPackVersionRepository versionRepository;
+  private final WorkspaceExistencePort workspaceExistencePort;
+  private final WorkspaceMembershipPort workspaceMembershipPort;
+
+  public UpdateSlotStatusUseCase(
+      SlotDefinitionRepository slotRepository,
+      DomainPackVersionRepository versionRepository,
+      WorkspaceExistencePort workspaceExistencePort,
+      WorkspaceMembershipPort workspaceMembershipPort) {
+    this.slotRepository = slotRepository;
+    this.versionRepository = versionRepository;
+    this.workspaceExistencePort = workspaceExistencePort;
+    this.workspaceMembershipPort = workspaceMembershipPort;
+  }
+
+  @Transactional
+  public SlotDefinitionResponse execute(UpdateSlotStatusCommand command) {
+    if (!workspaceExistencePort.existsById(command.workspaceId())) {
+      throw new DomainPackWorkspaceNotFoundException(
+          "워크스페이스를 찾을 수 없습니다. id=" + command.workspaceId());
+    }
+
+    if (!workspaceMembershipPort.hasAnyRole(
+        command.workspaceId(), command.requesterId(), ALLOWED_ROLES)) {
+      throw new DomainPackUnauthorizedWorkspaceAccessException(
+          "워크스페이스에 접근 권한이 없습니다. workspaceId=" + command.workspaceId());
+    }
+
+    DomainPackVersion version =
+        versionRepository
+            .findById(command.versionId())
+            .orElseThrow(
+                () -> new NotFoundException("NOT_FOUND", "버전을 찾을 수 없습니다: " + command.versionId()));
+
+    if (!version.getDomainPackId().equals(command.packId())) {
+      throw new NotFoundException("NOT_FOUND", "버전을 찾을 수 없습니다: " + command.versionId());
+    }
+
+    if (!DomainPackVersion.STATUS_DRAFT.equals(version.getLifecycleStatus())) {
+      throw new BadRequestException("SLOT_NOT_EDITABLE", "DRAFT 상태의 버전에서만 슬롯을 수정할 수 있습니다.");
+    }
+
+    SlotDefinition slot =
+        slotRepository
+            .findById(command.slotId())
+            .orElseThrow(
+                () -> new NotFoundException("NOT_FOUND", "슬롯을 찾을 수 없습니다: " + command.slotId()));
+
+    if (!slot.getDomainPackVersionId().equals(command.versionId())) {
+      throw new NotFoundException("NOT_FOUND", "슬롯을 찾을 수 없습니다: " + command.slotId());
+    }
+
+    try {
+      slot.changeStatus(command.status());
+    } catch (IllegalArgumentException e) {
+      throw new BadRequestException("VALIDATION_ERROR", e.getMessage());
+    }
+
+    slotRepository.save(slot);
+    return SlotDefinitionResponse.from(slot);
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/application/UpdateSlotUseCase.java
+++ b/backend/src/main/java/com/init/domainpack/application/UpdateSlotUseCase.java
@@ -1,0 +1,93 @@
+package com.init.domainpack.application;
+
+import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
+import com.init.domainpack.application.exception.DomainPackWorkspaceNotFoundException;
+import com.init.domainpack.domain.model.DomainPackVersion;
+import com.init.domainpack.domain.model.SlotDefinition;
+import com.init.domainpack.domain.model.WorkspaceMemberRole;
+import com.init.domainpack.domain.repository.DomainPackVersionRepository;
+import com.init.domainpack.domain.repository.SlotDefinitionRepository;
+import com.init.domainpack.domain.repository.WorkspaceExistencePort;
+import com.init.domainpack.domain.repository.WorkspaceMembershipPort;
+import com.init.shared.application.exception.BadRequestException;
+import com.init.shared.application.exception.NotFoundException;
+import java.util.Set;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class UpdateSlotUseCase {
+
+  private static final Set<WorkspaceMemberRole> ALLOWED_ROLES =
+      Set.of(WorkspaceMemberRole.OPERATOR, WorkspaceMemberRole.ADMIN);
+
+  private final SlotDefinitionRepository slotRepository;
+  private final DomainPackVersionRepository versionRepository;
+  private final WorkspaceExistencePort workspaceExistencePort;
+  private final WorkspaceMembershipPort workspaceMembershipPort;
+
+  public UpdateSlotUseCase(
+      SlotDefinitionRepository slotRepository,
+      DomainPackVersionRepository versionRepository,
+      WorkspaceExistencePort workspaceExistencePort,
+      WorkspaceMembershipPort workspaceMembershipPort) {
+    this.slotRepository = slotRepository;
+    this.versionRepository = versionRepository;
+    this.workspaceExistencePort = workspaceExistencePort;
+    this.workspaceMembershipPort = workspaceMembershipPort;
+  }
+
+  @Transactional
+  public SlotDefinitionResponse execute(UpdateSlotCommand command) {
+    if (!workspaceExistencePort.existsById(command.workspaceId())) {
+      throw new DomainPackWorkspaceNotFoundException(
+          "워크스페이스를 찾을 수 없습니다. id=" + command.workspaceId());
+    }
+
+    if (!workspaceMembershipPort.hasAnyRole(
+        command.workspaceId(), command.requesterId(), ALLOWED_ROLES)) {
+      throw new DomainPackUnauthorizedWorkspaceAccessException(
+          "워크스페이스에 접근 권한이 없습니다. workspaceId=" + command.workspaceId());
+    }
+
+    DomainPackVersion version =
+        versionRepository
+            .findById(command.versionId())
+            .orElseThrow(
+                () -> new NotFoundException("NOT_FOUND", "버전을 찾을 수 없습니다: " + command.versionId()));
+
+    if (!version.getDomainPackId().equals(command.packId())) {
+      throw new NotFoundException("NOT_FOUND", "버전을 찾을 수 없습니다: " + command.versionId());
+    }
+
+    if (!DomainPackVersion.STATUS_DRAFT.equals(version.getLifecycleStatus())) {
+      throw new BadRequestException("SLOT_NOT_EDITABLE", "DRAFT 상태의 버전에서만 슬롯을 수정할 수 있습니다.");
+    }
+
+    SlotDefinition slot =
+        slotRepository
+            .findById(command.slotId())
+            .orElseThrow(
+                () -> new NotFoundException("NOT_FOUND", "슬롯을 찾을 수 없습니다: " + command.slotId()));
+
+    if (!slot.getDomainPackVersionId().equals(command.versionId())) {
+      throw new NotFoundException("NOT_FOUND", "슬롯을 찾을 수 없습니다: " + command.slotId());
+    }
+
+    try {
+      slot.updateFields(
+          command.name(),
+          command.description(),
+          command.isSensitive(),
+          command.validationRuleJson(),
+          command.defaultValueJson(),
+          command.metaJson());
+    } catch (IllegalArgumentException e) {
+      throw new BadRequestException("VALIDATION_ERROR", e.getMessage());
+    }
+
+    slotRepository.save(slot);
+    return SlotDefinitionResponse.from(slot);
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/domain/model/SlotDefinition.java
+++ b/backend/src/main/java/com/init/domainpack/domain/model/SlotDefinition.java
@@ -15,6 +15,9 @@ import java.util.Objects;
 @Table(name = "slot_definition", schema = "pack")
 public class SlotDefinition {
 
+  public static final String STATUS_ACTIVE = "ACTIVE";
+  public static final String STATUS_INACTIVE = "INACTIVE";
+
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
@@ -45,6 +48,9 @@ public class SlotDefinition {
 
   @Column(name = "meta_json", columnDefinition = "jsonb", nullable = false)
   private String metaJson;
+
+  @Column(name = "status", nullable = false)
+  private String status;
 
   @Column(name = "created_at", nullable = false, updatable = false)
   private OffsetDateTime createdAt;
@@ -91,7 +97,34 @@ public class SlotDefinition {
     entity.validationRuleJson = validationRuleJson != null ? validationRuleJson : "{}";
     entity.defaultValueJson = defaultValueJson;
     entity.metaJson = metaJson != null ? metaJson : "{}";
+    entity.status = STATUS_ACTIVE;
     return entity;
+  }
+
+  public void updateFields(
+      String name,
+      String description,
+      Boolean isSensitive,
+      String validationRuleJson,
+      String defaultValueJson,
+      String metaJson) {
+    Objects.requireNonNull(name, "name must not be null");
+    if (name.isBlank()) {
+      throw new IllegalArgumentException("name은 비워둘 수 없습니다.");
+    }
+    this.name = name;
+    this.description = description;
+    if (isSensitive != null) this.isSensitive = isSensitive;
+    if (validationRuleJson != null) this.validationRuleJson = validationRuleJson;
+    this.defaultValueJson = defaultValueJson;
+    if (metaJson != null) this.metaJson = metaJson;
+  }
+
+  public void changeStatus(String newStatus) {
+    if (!STATUS_ACTIVE.equals(newStatus) && !STATUS_INACTIVE.equals(newStatus)) {
+      throw new IllegalArgumentException("허용되지 않는 status 값입니다: " + newStatus);
+    }
+    this.status = newStatus;
   }
 
   public Long getId() {
@@ -132,5 +165,17 @@ public class SlotDefinition {
 
   public String getMetaJson() {
     return metaJson;
+  }
+
+  public String getStatus() {
+    return status;
+  }
+
+  public OffsetDateTime getCreatedAt() {
+    return createdAt;
+  }
+
+  public OffsetDateTime getUpdatedAt() {
+    return updatedAt;
   }
 }

--- a/backend/src/main/java/com/init/domainpack/domain/model/SlotDefinition.java
+++ b/backend/src/main/java/com/init/domainpack/domain/model/SlotDefinition.java
@@ -85,6 +85,9 @@ public class SlotDefinition {
     Objects.requireNonNull(domainPackVersionId, "domainPackVersionId must not be null");
     Objects.requireNonNull(slotCode, "slotCode must not be null");
     Objects.requireNonNull(name, "name must not be null");
+    if (name.isBlank()) {
+      throw new IllegalArgumentException("name은 비워둘 수 없습니다.");
+    }
     Objects.requireNonNull(dataType, "dataType must not be null");
 
     SlotDefinition entity = new SlotDefinition();

--- a/backend/src/main/java/com/init/domainpack/domain/model/SlotDefinition.java
+++ b/backend/src/main/java/com/init/domainpack/domain/model/SlotDefinition.java
@@ -113,10 +113,10 @@ public class SlotDefinition {
       throw new IllegalArgumentException("name은 비워둘 수 없습니다.");
     }
     this.name = name;
-    this.description = description;
+    if (description != null) this.description = description;
     if (isSensitive != null) this.isSensitive = isSensitive;
     if (validationRuleJson != null) this.validationRuleJson = validationRuleJson;
-    this.defaultValueJson = defaultValueJson;
+    if (defaultValueJson != null) this.defaultValueJson = defaultValueJson;
     if (metaJson != null) this.metaJson = metaJson;
   }
 

--- a/backend/src/main/java/com/init/domainpack/domain/repository/SlotDefinitionRepository.java
+++ b/backend/src/main/java/com/init/domainpack/domain/repository/SlotDefinitionRepository.java
@@ -2,8 +2,13 @@ package com.init.domainpack.domain.repository;
 
 import com.init.domainpack.domain.model.SlotDefinition;
 import java.util.List;
+import java.util.Optional;
 
 public interface SlotDefinitionRepository {
 
   <S extends SlotDefinition> List<S> saveAll(Iterable<S> entities);
+
+  Optional<SlotDefinition> findById(Long id);
+
+  SlotDefinition save(SlotDefinition slot);
 }

--- a/backend/src/main/java/com/init/domainpack/presentation/UpdateSlotController.java
+++ b/backend/src/main/java/com/init/domainpack/presentation/UpdateSlotController.java
@@ -1,0 +1,52 @@
+package com.init.domainpack.presentation;
+
+import com.init.domainpack.application.SlotDefinitionResponse;
+import com.init.domainpack.application.UpdateSlotCommand;
+import com.init.domainpack.application.UpdateSlotUseCase;
+import com.init.domainpack.presentation.dto.UpdateSlotRequest;
+import com.init.shared.presentation.AuthenticationUtils;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(
+    "/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/slots/{slotId}")
+public class UpdateSlotController {
+
+  private final UpdateSlotUseCase useCase;
+
+  public UpdateSlotController(UpdateSlotUseCase useCase) {
+    this.useCase = useCase;
+  }
+
+  @PatchMapping
+  public ResponseEntity<SlotDefinitionResponse> updateSlot(
+      @PathVariable Long workspaceId,
+      @PathVariable Long packId,
+      @PathVariable Long versionId,
+      @PathVariable Long slotId,
+      @Valid @RequestBody UpdateSlotRequest request,
+      Authentication authentication) {
+    Long userId = AuthenticationUtils.getUserId(authentication);
+    UpdateSlotCommand command =
+        new UpdateSlotCommand(
+            workspaceId,
+            packId,
+            versionId,
+            slotId,
+            userId,
+            request.name(),
+            request.description(),
+            request.isSensitive(),
+            request.validationRuleJson(),
+            request.defaultValueJson(),
+            request.metaJson());
+    return ResponseEntity.ok(useCase.execute(command));
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/presentation/UpdateSlotStatusController.java
+++ b/backend/src/main/java/com/init/domainpack/presentation/UpdateSlotStatusController.java
@@ -1,0 +1,42 @@
+package com.init.domainpack.presentation;
+
+import com.init.domainpack.application.SlotDefinitionResponse;
+import com.init.domainpack.application.UpdateSlotStatusCommand;
+import com.init.domainpack.application.UpdateSlotStatusUseCase;
+import com.init.domainpack.presentation.dto.UpdateSlotStatusRequest;
+import com.init.shared.presentation.AuthenticationUtils;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(
+    "/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/slots/{slotId}")
+public class UpdateSlotStatusController {
+
+  private final UpdateSlotStatusUseCase useCase;
+
+  public UpdateSlotStatusController(UpdateSlotStatusUseCase useCase) {
+    this.useCase = useCase;
+  }
+
+  @PatchMapping("/status")
+  public ResponseEntity<SlotDefinitionResponse> updateSlotStatus(
+      @PathVariable Long workspaceId,
+      @PathVariable Long packId,
+      @PathVariable Long versionId,
+      @PathVariable Long slotId,
+      @Valid @RequestBody UpdateSlotStatusRequest request,
+      Authentication authentication) {
+    Long userId = AuthenticationUtils.getUserId(authentication);
+    UpdateSlotStatusCommand command =
+        new UpdateSlotStatusCommand(
+            workspaceId, packId, versionId, slotId, userId, request.status());
+    return ResponseEntity.ok(useCase.execute(command));
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/presentation/dto/UpdateSlotRequest.java
+++ b/backend/src/main/java/com/init/domainpack/presentation/dto/UpdateSlotRequest.java
@@ -1,0 +1,11 @@
+package com.init.domainpack.presentation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UpdateSlotRequest(
+    @NotBlank(message = "name은 필수 항목입니다.") String name,
+    String description,
+    Boolean isSensitive,
+    String validationRuleJson,
+    String defaultValueJson,
+    String metaJson) {}

--- a/backend/src/main/java/com/init/domainpack/presentation/dto/UpdateSlotStatusRequest.java
+++ b/backend/src/main/java/com/init/domainpack/presentation/dto/UpdateSlotStatusRequest.java
@@ -1,0 +1,5 @@
+package com.init.domainpack.presentation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UpdateSlotStatusRequest(@NotBlank(message = "status는 필수 항목입니다.") String status) {}

--- a/backend/src/main/resources/db/changelog/db.changelog-master.sql
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.sql
@@ -699,3 +699,8 @@ SELECT setval('app.workspace_id_seq', (SELECT COALESCE(MAX(id), 1) FROM app.work
 SELECT setval('pack.domain_pack_id_seq', (SELECT COALESCE(MAX(id), 1) FROM pack.domain_pack), true);
 SELECT setval('pack.domain_pack_version_id_seq', (SELECT COALESCE(MAX(id), 1) FROM pack.domain_pack_version), true);
 SELECT setval('runtime.chat_session_id_seq', (SELECT COALESCE(MAX(id), 1) FROM runtime.chat_session), true);
+
+--changeset devjhan:20260415-add-status-to-slot-definition
+--comment: Add status column to pack.slot_definition for slot lifecycle management (ACTIVE/INACTIVE)
+ALTER TABLE pack.slot_definition
+    ADD COLUMN status VARCHAR(50) NOT NULL DEFAULT 'ACTIVE';

--- a/backend/src/main/resources/db/changelog/db.changelog-master.sql
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.sql
@@ -703,4 +703,5 @@ SELECT setval('runtime.chat_session_id_seq', (SELECT COALESCE(MAX(id), 1) FROM r
 --changeset devjhan:20260415-add-status-to-slot-definition
 --comment: Add status column to pack.slot_definition for slot lifecycle management (ACTIVE/INACTIVE)
 ALTER TABLE pack.slot_definition
-    ADD COLUMN status VARCHAR(50) NOT NULL DEFAULT 'ACTIVE';
+    ADD COLUMN status VARCHAR(50) NOT NULL DEFAULT 'ACTIVE',
+    ADD CONSTRAINT chk_slot_definition_status CHECK (status IN ('ACTIVE', 'INACTIVE'));

--- a/backend/src/test/java/com/init/domainpack/application/UpdateSlotStatusUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/UpdateSlotStatusUseCaseTest.java
@@ -1,0 +1,143 @@
+package com.init.domainpack.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.init.domainpack.domain.model.DomainPackVersion;
+import com.init.domainpack.domain.model.SlotDefinition;
+import com.init.domainpack.domain.repository.DomainPackVersionRepository;
+import com.init.domainpack.domain.repository.SlotDefinitionRepository;
+import com.init.domainpack.domain.repository.WorkspaceExistencePort;
+import com.init.domainpack.domain.repository.WorkspaceMembershipPort;
+import com.init.shared.application.exception.BadRequestException;
+import com.init.shared.application.exception.NotFoundException;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UpdateSlotStatusUseCase")
+class UpdateSlotStatusUseCaseTest {
+
+  @Mock private SlotDefinitionRepository slotRepository;
+  @Mock private DomainPackVersionRepository versionRepository;
+  @Mock private WorkspaceExistencePort workspaceExistencePort;
+  @Mock private WorkspaceMembershipPort workspaceMembershipPort;
+
+  private UpdateSlotStatusUseCase useCase;
+
+  @BeforeEach
+  void setUp() {
+    useCase =
+        new UpdateSlotStatusUseCase(
+            slotRepository, versionRepository, workspaceExistencePort, workspaceMembershipPort);
+  }
+
+  @Test
+  @DisplayName("정상 전환: ACTIVE → INACTIVE")
+  void should_INACTIVE전환성공_when_DRAFT버전슬롯() {
+    given(workspaceExistencePort.existsById(1L)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(versionRepository.findById(10L)).willReturn(Optional.of(draftVersion(10L, 7L)));
+
+    SlotDefinition slot = slot(99L, 10L);
+    given(slotRepository.findById(99L)).willReturn(Optional.of(slot));
+    given(slotRepository.save(any())).willReturn(slot);
+
+    UpdateSlotStatusCommand command =
+        new UpdateSlotStatusCommand(1L, 7L, 10L, 99L, 5L, SlotDefinition.STATUS_INACTIVE);
+    SlotDefinitionResponse result = useCase.execute(command);
+
+    assertThat(result.status()).isEqualTo(SlotDefinition.STATUS_INACTIVE);
+  }
+
+  @Test
+  @DisplayName("정상 전환: INACTIVE → ACTIVE")
+  void should_ACTIVE전환성공_when_INACTIVE슬롯() {
+    given(workspaceExistencePort.existsById(1L)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(versionRepository.findById(10L)).willReturn(Optional.of(draftVersion(10L, 7L)));
+
+    SlotDefinition slot = slot(99L, 10L);
+    ReflectionTestUtils.setField(slot, "status", SlotDefinition.STATUS_INACTIVE);
+    given(slotRepository.findById(99L)).willReturn(Optional.of(slot));
+    given(slotRepository.save(any())).willReturn(slot);
+
+    UpdateSlotStatusCommand command =
+        new UpdateSlotStatusCommand(1L, 7L, 10L, 99L, 5L, SlotDefinition.STATUS_ACTIVE);
+    SlotDefinitionResponse result = useCase.execute(command);
+
+    assertThat(result.status()).isEqualTo(SlotDefinition.STATUS_ACTIVE);
+  }
+
+  @Test
+  @DisplayName("허용되지 않는 status 값 → BadRequestException(VALIDATION_ERROR)")
+  void should_VALIDATION_ERROR예외_when_잘못된status() {
+    given(workspaceExistencePort.existsById(1L)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(versionRepository.findById(10L)).willReturn(Optional.of(draftVersion(10L, 7L)));
+
+    SlotDefinition slot = slot(99L, 10L);
+    given(slotRepository.findById(99L)).willReturn(Optional.of(slot));
+
+    assertThatThrownBy(
+            () -> useCase.execute(new UpdateSlotStatusCommand(1L, 7L, 10L, 99L, 5L, "DEPRECATED")))
+        .isInstanceOf(BadRequestException.class);
+  }
+
+  @Test
+  @DisplayName("PUBLISHED 버전 → BadRequestException(SLOT_NOT_EDITABLE)")
+  void should_SLOT_NOT_EDITABLE예외_when_PUBLISHED버전() {
+    given(workspaceExistencePort.existsById(1L)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(versionRepository.findById(10L))
+        .willReturn(
+            Optional.of(DomainPackVersion.ofForTest(10L, 7L, DomainPackVersion.STATUS_PUBLISHED)));
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdateSlotStatusCommand(
+                        1L, 7L, 10L, 99L, 5L, SlotDefinition.STATUS_INACTIVE)))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("DRAFT");
+  }
+
+  @Test
+  @DisplayName("슬롯의 versionId 불일치 → NotFoundException")
+  void should_슬롯없음예외_when_versionId불일치() {
+    given(workspaceExistencePort.existsById(1L)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(versionRepository.findById(10L)).willReturn(Optional.of(draftVersion(10L, 7L)));
+
+    SlotDefinition slot = slot(99L, 999L); // 다른 버전에 속한 슬롯
+    given(slotRepository.findById(99L)).willReturn(Optional.of(slot));
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdateSlotStatusCommand(
+                        1L, 7L, 10L, 99L, 5L, SlotDefinition.STATUS_INACTIVE)))
+        .isInstanceOf(NotFoundException.class);
+  }
+
+  // ── factories ──────────────────────────────────────────────────────────────
+
+  private DomainPackVersion draftVersion(Long id, Long domainPackId) {
+    return DomainPackVersion.ofForTest(id, domainPackId, DomainPackVersion.STATUS_DRAFT);
+  }
+
+  private SlotDefinition slot(Long id, Long versionId) {
+    SlotDefinition s =
+        SlotDefinition.create(versionId, "code", "이름", "설명", "STRING", false, "{}", null, "{}");
+    ReflectionTestUtils.setField(s, "id", id);
+    return s;
+  }
+}

--- a/backend/src/test/java/com/init/domainpack/application/UpdateSlotStatusUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/UpdateSlotStatusUseCaseTest.java
@@ -4,7 +4,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
+import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
+import com.init.domainpack.application.exception.DomainPackWorkspaceNotFoundException;
 import com.init.domainpack.domain.model.DomainPackVersion;
 import com.init.domainpack.domain.model.SlotDefinition;
 import com.init.domainpack.domain.repository.DomainPackVersionRepository;
@@ -125,6 +129,80 @@ class UpdateSlotStatusUseCaseTest {
                 useCase.execute(
                     new UpdateSlotStatusCommand(
                         1L, 7L, 10L, 99L, 5L, SlotDefinition.STATUS_INACTIVE)))
+        .isInstanceOf(NotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("workspace 없음 → DomainPackWorkspaceNotFoundException")
+  void should_워크스페이스없음예외_when_워크스페이스없음() {
+    given(workspaceExistencePort.existsById(1L)).willReturn(false);
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdateSlotStatusCommand(1L, 7L, 10L, 99L, 5L, SlotDefinition.STATUS_INACTIVE)))
+        .isInstanceOf(DomainPackWorkspaceNotFoundException.class);
+
+    verify(versionRepository, never()).findById(any());
+  }
+
+  @Test
+  @DisplayName("workspace 비멤버 → DomainPackUnauthorizedWorkspaceAccessException")
+  void should_권한없음예외_when_비멤버() {
+    given(workspaceExistencePort.existsById(1L)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(false);
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdateSlotStatusCommand(1L, 7L, 10L, 99L, 5L, SlotDefinition.STATUS_INACTIVE)))
+        .isInstanceOf(DomainPackUnauthorizedWorkspaceAccessException.class);
+
+    verify(versionRepository, never()).findById(any());
+  }
+
+  @Test
+  @DisplayName("버전 미존재 → NotFoundException")
+  void should_버전없음예외_when_버전미존재() {
+    given(workspaceExistencePort.existsById(1L)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(versionRepository.findById(10L)).willReturn(Optional.empty());
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdateSlotStatusCommand(1L, 7L, 10L, 99L, 5L, SlotDefinition.STATUS_INACTIVE)))
+        .isInstanceOf(NotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("packId 불일치 → NotFoundException")
+  void should_버전없음예외_when_packId불일치() {
+    given(workspaceExistencePort.existsById(1L)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+
+    DomainPackVersion version = draftVersion(10L, 99L); // domainPackId=99, not 7
+    given(versionRepository.findById(10L)).willReturn(Optional.of(version));
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdateSlotStatusCommand(1L, 7L, 10L, 99L, 5L, SlotDefinition.STATUS_INACTIVE)))
+        .isInstanceOf(NotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("슬롯 미존재 → NotFoundException")
+  void should_슬롯없음예외_when_슬롯미존재() {
+    given(workspaceExistencePort.existsById(1L)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(versionRepository.findById(10L)).willReturn(Optional.of(draftVersion(10L, 7L)));
+    given(slotRepository.findById(99L)).willReturn(Optional.empty());
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdateSlotStatusCommand(1L, 7L, 10L, 99L, 5L, SlotDefinition.STATUS_INACTIVE)))
         .isInstanceOf(NotFoundException.class);
   }
 

--- a/backend/src/test/java/com/init/domainpack/application/UpdateSlotStatusUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/UpdateSlotStatusUseCaseTest.java
@@ -140,7 +140,8 @@ class UpdateSlotStatusUseCaseTest {
     assertThatThrownBy(
             () ->
                 useCase.execute(
-                    new UpdateSlotStatusCommand(1L, 7L, 10L, 99L, 5L, SlotDefinition.STATUS_INACTIVE)))
+                    new UpdateSlotStatusCommand(
+                        1L, 7L, 10L, 99L, 5L, SlotDefinition.STATUS_INACTIVE)))
         .isInstanceOf(DomainPackWorkspaceNotFoundException.class);
 
     verify(versionRepository, never()).findById(any());
@@ -155,7 +156,8 @@ class UpdateSlotStatusUseCaseTest {
     assertThatThrownBy(
             () ->
                 useCase.execute(
-                    new UpdateSlotStatusCommand(1L, 7L, 10L, 99L, 5L, SlotDefinition.STATUS_INACTIVE)))
+                    new UpdateSlotStatusCommand(
+                        1L, 7L, 10L, 99L, 5L, SlotDefinition.STATUS_INACTIVE)))
         .isInstanceOf(DomainPackUnauthorizedWorkspaceAccessException.class);
 
     verify(versionRepository, never()).findById(any());
@@ -171,7 +173,8 @@ class UpdateSlotStatusUseCaseTest {
     assertThatThrownBy(
             () ->
                 useCase.execute(
-                    new UpdateSlotStatusCommand(1L, 7L, 10L, 99L, 5L, SlotDefinition.STATUS_INACTIVE)))
+                    new UpdateSlotStatusCommand(
+                        1L, 7L, 10L, 99L, 5L, SlotDefinition.STATUS_INACTIVE)))
         .isInstanceOf(NotFoundException.class);
   }
 
@@ -187,7 +190,8 @@ class UpdateSlotStatusUseCaseTest {
     assertThatThrownBy(
             () ->
                 useCase.execute(
-                    new UpdateSlotStatusCommand(1L, 7L, 10L, 99L, 5L, SlotDefinition.STATUS_INACTIVE)))
+                    new UpdateSlotStatusCommand(
+                        1L, 7L, 10L, 99L, 5L, SlotDefinition.STATUS_INACTIVE)))
         .isInstanceOf(NotFoundException.class);
   }
 
@@ -202,7 +206,8 @@ class UpdateSlotStatusUseCaseTest {
     assertThatThrownBy(
             () ->
                 useCase.execute(
-                    new UpdateSlotStatusCommand(1L, 7L, 10L, 99L, 5L, SlotDefinition.STATUS_INACTIVE)))
+                    new UpdateSlotStatusCommand(
+                        1L, 7L, 10L, 99L, 5L, SlotDefinition.STATUS_INACTIVE)))
         .isInstanceOf(NotFoundException.class);
   }
 

--- a/backend/src/test/java/com/init/domainpack/application/UpdateSlotUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/UpdateSlotUseCaseTest.java
@@ -78,6 +78,7 @@ class UpdateSlotUseCaseTest {
         .isInstanceOf(DomainPackWorkspaceNotFoundException.class);
 
     verify(versionRepository, never()).findById(any());
+    verify(slotRepository, never()).save(any());
   }
 
   @Test
@@ -94,6 +95,7 @@ class UpdateSlotUseCaseTest {
         .isInstanceOf(DomainPackUnauthorizedWorkspaceAccessException.class);
 
     verify(versionRepository, never()).findById(any());
+    verify(slotRepository, never()).save(any());
   }
 
   @Test
@@ -109,6 +111,8 @@ class UpdateSlotUseCaseTest {
                     new UpdateSlotCommand(
                         1L, 7L, 10L, 99L, 5L, "이름", null, null, null, null, null)))
         .isInstanceOf(NotFoundException.class);
+
+    verify(slotRepository, never()).save(any());
   }
 
   @Test
@@ -126,6 +130,8 @@ class UpdateSlotUseCaseTest {
                     new UpdateSlotCommand(
                         1L, 7L, 10L, 99L, 5L, "이름", null, null, null, null, null)))
         .isInstanceOf(NotFoundException.class);
+
+    verify(slotRepository, never()).save(any());
   }
 
   @Test
@@ -144,6 +150,8 @@ class UpdateSlotUseCaseTest {
                         1L, 7L, 10L, 99L, 5L, "이름", null, null, null, null, null)))
         .isInstanceOf(BadRequestException.class)
         .hasMessageContaining("DRAFT");
+
+    verify(slotRepository, never()).save(any());
   }
 
   @Test
@@ -160,6 +168,8 @@ class UpdateSlotUseCaseTest {
                     new UpdateSlotCommand(
                         1L, 7L, 10L, 99L, 5L, "이름", null, null, null, null, null)))
         .isInstanceOf(NotFoundException.class);
+
+    verify(slotRepository, never()).save(any());
   }
 
   @Test
@@ -178,6 +188,8 @@ class UpdateSlotUseCaseTest {
                     new UpdateSlotCommand(
                         1L, 7L, 10L, 99L, 5L, "이름", null, null, null, null, null)))
         .isInstanceOf(NotFoundException.class);
+
+    verify(slotRepository, never()).save(any());
   }
 
   // ── factories ──────────────────────────────────────────────────────────────

--- a/backend/src/test/java/com/init/domainpack/application/UpdateSlotUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/UpdateSlotUseCaseTest.java
@@ -183,9 +183,7 @@ class UpdateSlotUseCaseTest {
   // ── factories ──────────────────────────────────────────────────────────────
 
   private DomainPackVersion draftVersion(Long id, Long domainPackId) {
-    DomainPackVersion v =
-        DomainPackVersion.ofForTest(id, domainPackId, DomainPackVersion.STATUS_DRAFT);
-    return v;
+    return DomainPackVersion.ofForTest(id, domainPackId, DomainPackVersion.STATUS_DRAFT);
   }
 
   private DomainPackVersion publishedVersion(Long id, Long domainPackId) {

--- a/backend/src/test/java/com/init/domainpack/application/UpdateSlotUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/UpdateSlotUseCaseTest.java
@@ -1,0 +1,201 @@
+package com.init.domainpack.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
+import com.init.domainpack.application.exception.DomainPackWorkspaceNotFoundException;
+import com.init.domainpack.domain.model.DomainPackVersion;
+import com.init.domainpack.domain.model.SlotDefinition;
+import com.init.domainpack.domain.repository.DomainPackVersionRepository;
+import com.init.domainpack.domain.repository.SlotDefinitionRepository;
+import com.init.domainpack.domain.repository.WorkspaceExistencePort;
+import com.init.domainpack.domain.repository.WorkspaceMembershipPort;
+import com.init.shared.application.exception.BadRequestException;
+import com.init.shared.application.exception.NotFoundException;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UpdateSlotUseCase")
+class UpdateSlotUseCaseTest {
+
+  @Mock private SlotDefinitionRepository slotRepository;
+  @Mock private DomainPackVersionRepository versionRepository;
+  @Mock private WorkspaceExistencePort workspaceExistencePort;
+  @Mock private WorkspaceMembershipPort workspaceMembershipPort;
+
+  private UpdateSlotUseCase useCase;
+
+  @BeforeEach
+  void setUp() {
+    useCase =
+        new UpdateSlotUseCase(
+            slotRepository, versionRepository, workspaceExistencePort, workspaceMembershipPort);
+  }
+
+  @Test
+  @DisplayName("정상 수정: DRAFT 버전의 슬롯 → 200 OK, 수정된 슬롯 반환")
+  void should_수정성공_when_DRAFT버전슬롯() {
+    given(workspaceExistencePort.existsById(1L)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+
+    DomainPackVersion version = draftVersion(10L, 7L);
+    given(versionRepository.findById(10L)).willReturn(Optional.of(version));
+
+    SlotDefinition slot = slot(99L, 10L);
+    given(slotRepository.findById(99L)).willReturn(Optional.of(slot));
+    given(slotRepository.save(any())).willReturn(slot);
+
+    UpdateSlotCommand command =
+        new UpdateSlotCommand(1L, 7L, 10L, 99L, 5L, "수정된 이름", "설명", false, "{}", null, "{}");
+    SlotDefinitionResponse result = useCase.execute(command);
+
+    assertThat(result.name()).isEqualTo("수정된 이름");
+    verify(slotRepository).save(slot);
+  }
+
+  @Test
+  @DisplayName("workspace 없음 → DomainPackWorkspaceNotFoundException")
+  void should_워크스페이스없음예외_when_워크스페이스없음() {
+    given(workspaceExistencePort.existsById(1L)).willReturn(false);
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdateSlotCommand(
+                        1L, 7L, 10L, 99L, 5L, "이름", null, null, null, null, null)))
+        .isInstanceOf(DomainPackWorkspaceNotFoundException.class);
+
+    verify(versionRepository, never()).findById(any());
+  }
+
+  @Test
+  @DisplayName("workspace 비멤버 → DomainPackUnauthorizedWorkspaceAccessException")
+  void should_권한없음예외_when_비멤버() {
+    given(workspaceExistencePort.existsById(1L)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(false);
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdateSlotCommand(
+                        1L, 7L, 10L, 99L, 5L, "이름", null, null, null, null, null)))
+        .isInstanceOf(DomainPackUnauthorizedWorkspaceAccessException.class);
+
+    verify(versionRepository, never()).findById(any());
+  }
+
+  @Test
+  @DisplayName("버전 미존재 → NotFoundException")
+  void should_버전없음예외_when_버전미존재() {
+    given(workspaceExistencePort.existsById(1L)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(versionRepository.findById(10L)).willReturn(Optional.empty());
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdateSlotCommand(
+                        1L, 7L, 10L, 99L, 5L, "이름", null, null, null, null, null)))
+        .isInstanceOf(NotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("packId 불일치 → NotFoundException")
+  void should_버전없음예외_when_packId불일치() {
+    given(workspaceExistencePort.existsById(1L)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+
+    DomainPackVersion version = draftVersion(10L, 99L); // domainPackId=99, not 7
+    given(versionRepository.findById(10L)).willReturn(Optional.of(version));
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdateSlotCommand(
+                        1L, 7L, 10L, 99L, 5L, "이름", null, null, null, null, null)))
+        .isInstanceOf(NotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("PUBLISHED 버전 → BadRequestException(SLOT_NOT_EDITABLE)")
+  void should_SLOT_NOT_EDITABLE예외_when_PUBLISHED버전() {
+    given(workspaceExistencePort.existsById(1L)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+
+    DomainPackVersion version = publishedVersion(10L, 7L);
+    given(versionRepository.findById(10L)).willReturn(Optional.of(version));
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdateSlotCommand(
+                        1L, 7L, 10L, 99L, 5L, "이름", null, null, null, null, null)))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("DRAFT");
+  }
+
+  @Test
+  @DisplayName("슬롯 미존재 → NotFoundException")
+  void should_슬롯없음예외_when_슬롯미존재() {
+    given(workspaceExistencePort.existsById(1L)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(versionRepository.findById(10L)).willReturn(Optional.of(draftVersion(10L, 7L)));
+    given(slotRepository.findById(99L)).willReturn(Optional.empty());
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdateSlotCommand(
+                        1L, 7L, 10L, 99L, 5L, "이름", null, null, null, null, null)))
+        .isInstanceOf(NotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("슬롯의 versionId 불일치 → NotFoundException")
+  void should_슬롯없음예외_when_versionId불일치() {
+    given(workspaceExistencePort.existsById(1L)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(versionRepository.findById(10L)).willReturn(Optional.of(draftVersion(10L, 7L)));
+
+    SlotDefinition slot = slot(99L, 999L); // 다른 버전에 속한 슬롯
+    given(slotRepository.findById(99L)).willReturn(Optional.of(slot));
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdateSlotCommand(
+                        1L, 7L, 10L, 99L, 5L, "이름", null, null, null, null, null)))
+        .isInstanceOf(NotFoundException.class);
+  }
+
+  // ── factories ──────────────────────────────────────────────────────────────
+
+  private DomainPackVersion draftVersion(Long id, Long domainPackId) {
+    DomainPackVersion v =
+        DomainPackVersion.ofForTest(id, domainPackId, DomainPackVersion.STATUS_DRAFT);
+    return v;
+  }
+
+  private DomainPackVersion publishedVersion(Long id, Long domainPackId) {
+    return DomainPackVersion.ofForTest(id, domainPackId, DomainPackVersion.STATUS_PUBLISHED);
+  }
+
+  private SlotDefinition slot(Long id, Long versionId) {
+    SlotDefinition s =
+        SlotDefinition.create(versionId, "code", "이름", "설명", "STRING", false, "{}", null, "{}");
+    ReflectionTestUtils.setField(s, "id", id);
+    return s;
+  }
+}

--- a/backend/src/test/java/com/init/domainpack/domain/model/SlotDefinitionTest.java
+++ b/backend/src/test/java/com/init/domainpack/domain/model/SlotDefinitionTest.java
@@ -1,0 +1,94 @@
+package com.init.domainpack.domain.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@DisplayName("SlotDefinition")
+class SlotDefinitionTest {
+
+  private SlotDefinition slot;
+
+  @BeforeEach
+  void setUp() {
+    slot =
+        SlotDefinition.create(
+            10L, "customer_name", "고객명", "상담 시 수집할 고객 이름", "STRING", false, "{}", null, "{}");
+  }
+
+  @Test
+  @DisplayName("create: 기본 status가 ACTIVE로 설정된다")
+  void create_defaultStatusIsActive() {
+    assertThat(slot.getStatus()).isEqualTo(SlotDefinition.STATUS_ACTIVE);
+  }
+
+  @Test
+  @DisplayName("updateFields: 허용 필드 정상 수정")
+  void updateFields_withValidInput_updatesFields() {
+    slot.updateFields("수정된 이름", "수정된 설명", true, "{\"min\":1}", null, "{\"key\":\"val\"}");
+
+    assertThat(slot.getName()).isEqualTo("수정된 이름");
+    assertThat(slot.getDescription()).isEqualTo("수정된 설명");
+    assertThat(slot.getIsSensitive()).isTrue();
+    assertThat(slot.getValidationRuleJson()).isEqualTo("{\"min\":1}");
+    assertThat(slot.getDefaultValueJson()).isNull();
+    assertThat(slot.getMetaJson()).isEqualTo("{\"key\":\"val\"}");
+  }
+
+  @Test
+  @DisplayName("updateFields: null isSensitive, validationRuleJson, metaJson은 기존 값 유지")
+  void updateFields_nullOptionalFields_keepsExistingValues() {
+    ReflectionTestUtils.setField(slot, "isSensitive", true);
+    ReflectionTestUtils.setField(slot, "validationRuleJson", "{\"existing\":true}");
+    ReflectionTestUtils.setField(slot, "metaJson", "{\"meta\":1}");
+
+    slot.updateFields("이름", null, null, null, null, null);
+
+    assertThat(slot.getIsSensitive()).isTrue();
+    assertThat(slot.getValidationRuleJson()).isEqualTo("{\"existing\":true}");
+    assertThat(slot.getMetaJson()).isEqualTo("{\"meta\":1}");
+  }
+
+  @Test
+  @DisplayName("updateFields: name이 blank이면 IllegalArgumentException")
+  void updateFields_withBlankName_throwsException() {
+    assertThatThrownBy(() -> slot.updateFields("  ", null, null, null, null, null))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  @DisplayName("updateFields: name이 null이면 NullPointerException")
+  void updateFields_withNullName_throwsNullPointerException() {
+    assertThatThrownBy(() -> slot.updateFields(null, null, null, null, null, null))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  @DisplayName("changeStatus: ACTIVE → INACTIVE 정상 전환")
+  void changeStatus_toInactive_changesStatus() {
+    slot.changeStatus(SlotDefinition.STATUS_INACTIVE);
+
+    assertThat(slot.getStatus()).isEqualTo(SlotDefinition.STATUS_INACTIVE);
+  }
+
+  @Test
+  @DisplayName("changeStatus: INACTIVE → ACTIVE 정상 전환")
+  void changeStatus_toActive_changesStatus() {
+    ReflectionTestUtils.setField(slot, "status", SlotDefinition.STATUS_INACTIVE);
+
+    slot.changeStatus(SlotDefinition.STATUS_ACTIVE);
+
+    assertThat(slot.getStatus()).isEqualTo(SlotDefinition.STATUS_ACTIVE);
+  }
+
+  @Test
+  @DisplayName("changeStatus: 허용되지 않는 값이면 IllegalArgumentException")
+  void changeStatus_withInvalidStatus_throwsException() {
+    assertThatThrownBy(() -> slot.changeStatus("DEPRECATED"))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+}

--- a/backend/src/test/java/com/init/domainpack/presentation/UpdateSlotControllerTest.java
+++ b/backend/src/test/java/com/init/domainpack/presentation/UpdateSlotControllerTest.java
@@ -108,7 +108,8 @@ class UpdateSlotControllerTest {
                 .with(csrf())
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(Map.of("name", ""))))
-        .andExpect(status().isBadRequest());
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
   }
 
   @Test

--- a/backend/src/test/java/com/init/domainpack/presentation/UpdateSlotControllerTest.java
+++ b/backend/src/test/java/com/init/domainpack/presentation/UpdateSlotControllerTest.java
@@ -1,0 +1,174 @@
+package com.init.domainpack.presentation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.init.domainpack.application.SlotDefinitionResponse;
+import com.init.domainpack.application.UpdateSlotUseCase;
+import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
+import com.init.domainpack.application.exception.DomainPackWorkspaceNotFoundException;
+import com.init.fixtures.WithLongPrincipal;
+import com.init.shared.application.exception.BadRequestException;
+import com.init.shared.application.exception.NotFoundException;
+import com.init.shared.infrastructure.security.JwtAuthenticationFilter;
+import java.time.OffsetDateTime;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(
+    value = UpdateSlotController.class,
+    excludeFilters =
+        @ComponentScan.Filter(
+            type = FilterType.ASSIGNABLE_TYPE,
+            classes = JwtAuthenticationFilter.class))
+@DisplayName("UpdateSlotController")
+class UpdateSlotControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+  @Autowired private ObjectMapper objectMapper;
+
+  @MockitoBean private UpdateSlotUseCase useCase;
+
+  private static final String BASE_URL = "/api/v1/workspaces/1/domain-packs/7/versions/10/slots/99";
+
+  @Test
+  @DisplayName("PATCH /slots/{slotId}: DRAFT 버전 슬롯 정상 수정 → 200")
+  @WithLongPrincipal(5L)
+  void should_200반환_when_정상수정() throws Exception {
+    SlotDefinitionResponse response = sampleResponse();
+    given(useCase.execute(any())).willReturn(response);
+
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    objectMapper.writeValueAsString(Map.of("name", "고객명", "description", "설명"))))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(99))
+        .andExpect(jsonPath("$.name").value("고객명"))
+        .andExpect(jsonPath("$.status").value("ACTIVE"));
+  }
+
+  @Test
+  @DisplayName("PATCH /slots/{slotId}: PUBLISHED 버전이면 400 SLOT_NOT_EDITABLE")
+  @WithLongPrincipal(5L)
+  void should_400반환_when_PUBLISHED버전() throws Exception {
+    given(useCase.execute(any()))
+        .willThrow(new BadRequestException("SLOT_NOT_EDITABLE", "DRAFT 상태의 버전에서만 슬롯을 수정할 수 있습니다."));
+
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of("name", "이름"))))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("SLOT_NOT_EDITABLE"));
+  }
+
+  @Test
+  @DisplayName("PATCH /slots/{slotId}: 슬롯 미존재 시 404")
+  @WithLongPrincipal(5L)
+  void should_404반환_when_슬롯미존재() throws Exception {
+    given(useCase.execute(any()))
+        .willThrow(new NotFoundException("NOT_FOUND", "슬롯을 찾을 수 없습니다: 99"));
+
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of("name", "이름"))))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("NOT_FOUND"));
+  }
+
+  @Test
+  @DisplayName("PATCH /slots/{slotId}: name이 빈 값이면 400 VALIDATION_ERROR")
+  @WithLongPrincipal(5L)
+  void should_400반환_when_nameBlank() throws Exception {
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of("name", ""))))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("PATCH /slots/{slotId}: 워크스페이스 멤버십 없을 때 403")
+  @WithLongPrincipal(5L)
+  void should_403반환_when_비멤버() throws Exception {
+    given(useCase.execute(any()))
+        .willThrow(new DomainPackUnauthorizedWorkspaceAccessException("접근 권한이 없습니다."));
+
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of("name", "이름"))))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @DisplayName("PATCH /slots/{slotId}: 워크스페이스 없을 때 404")
+  @WithLongPrincipal(5L)
+  void should_404반환_when_워크스페이스없음() throws Exception {
+    given(useCase.execute(any()))
+        .willThrow(new DomainPackWorkspaceNotFoundException("워크스페이스를 찾을 수 없습니다. id=1"));
+
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of("name", "이름"))))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  @DisplayName("PATCH /slots/{slotId}: 인증 없는 요청 → 401")
+  void should_401반환_when_인증없음() throws Exception {
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of("name", "이름"))))
+        .andExpect(status().isUnauthorized());
+  }
+
+  private SlotDefinitionResponse sampleResponse() {
+    return new SlotDefinitionResponse(
+        99L,
+        10L,
+        "customer_name",
+        "고객명",
+        "설명",
+        "STRING",
+        false,
+        "{}",
+        null,
+        "{}",
+        "ACTIVE",
+        OffsetDateTime.parse("2026-04-15T10:00:00Z"),
+        OffsetDateTime.parse("2026-04-15T10:30:00Z"));
+  }
+}

--- a/backend/src/test/java/com/init/domainpack/presentation/UpdateSlotControllerTest.java
+++ b/backend/src/test/java/com/init/domainpack/presentation/UpdateSlotControllerTest.java
@@ -2,6 +2,7 @@ package com.init.domainpack.presentation;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -37,10 +38,16 @@ import org.springframework.test.web.servlet.MockMvc;
 @DisplayName("UpdateSlotController")
 class UpdateSlotControllerTest {
 
-  @Autowired private MockMvc mockMvc;
-  @Autowired private ObjectMapper objectMapper;
+  private final MockMvc mockMvc;
+  private final ObjectMapper objectMapper;
 
   @MockitoBean private UpdateSlotUseCase useCase;
+
+  @Autowired
+  UpdateSlotControllerTest(MockMvc mockMvc, ObjectMapper objectMapper) {
+    this.mockMvc = mockMvc;
+    this.objectMapper = objectMapper;
+  }
 
   private static final String BASE_URL = "/api/v1/workspaces/1/domain-packs/7/versions/10/slots/99";
 
@@ -110,6 +117,8 @@ class UpdateSlotControllerTest {
                 .content(objectMapper.writeValueAsString(Map.of("name", ""))))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+
+    verifyNoInteractions(useCase);
   }
 
   @Test
@@ -154,6 +163,8 @@ class UpdateSlotControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(Map.of("name", "이름"))))
         .andExpect(status().isUnauthorized());
+
+    verifyNoInteractions(useCase);
   }
 
   private SlotDefinitionResponse sampleResponse() {

--- a/backend/src/test/java/com/init/domainpack/presentation/UpdateSlotStatusControllerTest.java
+++ b/backend/src/test/java/com/init/domainpack/presentation/UpdateSlotStatusControllerTest.java
@@ -20,6 +20,7 @@ import java.time.OffsetDateTime;
 import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
@@ -36,15 +37,10 @@ import org.springframework.test.web.servlet.MockMvc;
 @DisplayName("UpdateSlotStatusController")
 class UpdateSlotStatusControllerTest {
 
-  private final MockMvc mockMvc;
-  private final ObjectMapper objectMapper;
+  @Autowired private MockMvc mockMvc;
+  @Autowired private ObjectMapper objectMapper;
 
   @MockitoBean private UpdateSlotStatusUseCase useCase;
-
-  public UpdateSlotStatusControllerTest(MockMvc mockMvc, ObjectMapper objectMapper) {
-    this.mockMvc = mockMvc;
-    this.objectMapper = objectMapper;
-  }
 
   private static final String BASE_URL =
       "/api/v1/workspaces/1/domain-packs/7/versions/10/slots/99/status";

--- a/backend/src/test/java/com/init/domainpack/presentation/UpdateSlotStatusControllerTest.java
+++ b/backend/src/test/java/com/init/domainpack/presentation/UpdateSlotStatusControllerTest.java
@@ -2,6 +2,7 @@ package com.init.domainpack.presentation;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -19,7 +20,6 @@ import java.time.OffsetDateTime;
 import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
@@ -36,10 +36,15 @@ import org.springframework.test.web.servlet.MockMvc;
 @DisplayName("UpdateSlotStatusController")
 class UpdateSlotStatusControllerTest {
 
-  @Autowired private MockMvc mockMvc;
-  @Autowired private ObjectMapper objectMapper;
+  private final MockMvc mockMvc;
+  private final ObjectMapper objectMapper;
 
   @MockitoBean private UpdateSlotStatusUseCase useCase;
+
+  public UpdateSlotStatusControllerTest(MockMvc mockMvc, ObjectMapper objectMapper) {
+    this.mockMvc = mockMvc;
+    this.objectMapper = objectMapper;
+  }
 
   private static final String BASE_URL =
       "/api/v1/workspaces/1/domain-packs/7/versions/10/slots/99/status";
@@ -139,6 +144,7 @@ class UpdateSlotStatusControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(Map.of("status", ""))))
         .andExpect(status().isBadRequest());
+    verifyNoInteractions(useCase);
   }
 
   @Test
@@ -151,6 +157,7 @@ class UpdateSlotStatusControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(Map.of("status", "INACTIVE"))))
         .andExpect(status().isUnauthorized());
+    verifyNoInteractions(useCase);
   }
 
   private SlotDefinitionResponse sampleResponse(String status) {

--- a/backend/src/test/java/com/init/domainpack/presentation/UpdateSlotStatusControllerTest.java
+++ b/backend/src/test/java/com/init/domainpack/presentation/UpdateSlotStatusControllerTest.java
@@ -37,10 +37,16 @@ import org.springframework.test.web.servlet.MockMvc;
 @DisplayName("UpdateSlotStatusController")
 class UpdateSlotStatusControllerTest {
 
-  @Autowired private MockMvc mockMvc;
-  @Autowired private ObjectMapper objectMapper;
+  private final MockMvc mockMvc;
+  private final ObjectMapper objectMapper;
 
   @MockitoBean private UpdateSlotStatusUseCase useCase;
+
+  @Autowired
+  UpdateSlotStatusControllerTest(MockMvc mockMvc, ObjectMapper objectMapper) {
+    this.mockMvc = mockMvc;
+    this.objectMapper = objectMapper;
+  }
 
   private static final String BASE_URL =
       "/api/v1/workspaces/1/domain-packs/7/versions/10/slots/99/status";

--- a/backend/src/test/java/com/init/domainpack/presentation/UpdateSlotStatusControllerTest.java
+++ b/backend/src/test/java/com/init/domainpack/presentation/UpdateSlotStatusControllerTest.java
@@ -1,0 +1,172 @@
+package com.init.domainpack.presentation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.init.domainpack.application.SlotDefinitionResponse;
+import com.init.domainpack.application.UpdateSlotStatusUseCase;
+import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
+import com.init.fixtures.WithLongPrincipal;
+import com.init.shared.application.exception.BadRequestException;
+import com.init.shared.application.exception.NotFoundException;
+import com.init.shared.infrastructure.security.JwtAuthenticationFilter;
+import java.time.OffsetDateTime;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(
+    value = UpdateSlotStatusController.class,
+    excludeFilters =
+        @ComponentScan.Filter(
+            type = FilterType.ASSIGNABLE_TYPE,
+            classes = JwtAuthenticationFilter.class))
+@DisplayName("UpdateSlotStatusController")
+class UpdateSlotStatusControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+  @Autowired private ObjectMapper objectMapper;
+
+  @MockitoBean private UpdateSlotStatusUseCase useCase;
+
+  private static final String BASE_URL =
+      "/api/v1/workspaces/1/domain-packs/7/versions/10/slots/99/status";
+
+  @Test
+  @DisplayName("PATCH /slots/{slotId}/status: INACTIVE 전환 → 200")
+  @WithLongPrincipal(5L)
+  void should_200반환_when_INACTIVE전환() throws Exception {
+    SlotDefinitionResponse response = sampleResponse("INACTIVE");
+    given(useCase.execute(any())).willReturn(response);
+
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of("status", "INACTIVE"))))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.status").value("INACTIVE"));
+  }
+
+  @Test
+  @DisplayName("PATCH /slots/{slotId}/status: 허용되지 않는 status 값이면 400")
+  @WithLongPrincipal(5L)
+  void should_400반환_when_잘못된status() throws Exception {
+    given(useCase.execute(any()))
+        .willThrow(new BadRequestException("VALIDATION_ERROR", "허용되지 않는 status 값입니다: DEPRECATED"));
+
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of("status", "DEPRECATED"))))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+  }
+
+  @Test
+  @DisplayName("PATCH /slots/{slotId}/status: PUBLISHED 버전이면 400 SLOT_NOT_EDITABLE")
+  @WithLongPrincipal(5L)
+  void should_400반환_when_PUBLISHED버전() throws Exception {
+    given(useCase.execute(any()))
+        .willThrow(new BadRequestException("SLOT_NOT_EDITABLE", "DRAFT 상태의 버전에서만 슬롯을 수정할 수 있습니다."));
+
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of("status", "INACTIVE"))))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("SLOT_NOT_EDITABLE"));
+  }
+
+  @Test
+  @DisplayName("PATCH /slots/{slotId}/status: 슬롯 미존재 시 404")
+  @WithLongPrincipal(5L)
+  void should_404반환_when_슬롯미존재() throws Exception {
+    given(useCase.execute(any()))
+        .willThrow(new NotFoundException("NOT_FOUND", "슬롯을 찾을 수 없습니다: 99"));
+
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of("status", "INACTIVE"))))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("NOT_FOUND"));
+  }
+
+  @Test
+  @DisplayName("PATCH /slots/{slotId}/status: 워크스페이스 멤버십 없을 때 403")
+  @WithLongPrincipal(5L)
+  void should_403반환_when_비멤버() throws Exception {
+    given(useCase.execute(any()))
+        .willThrow(new DomainPackUnauthorizedWorkspaceAccessException("접근 권한이 없습니다."));
+
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of("status", "INACTIVE"))))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @DisplayName("PATCH /slots/{slotId}/status: status 미전송 시 400")
+  @WithLongPrincipal(5L)
+  void should_400반환_when_statusBlank() throws Exception {
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of("status", ""))))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("PATCH /slots/{slotId}/status: 인증 없는 요청 → 401")
+  void should_401반환_when_인증없음() throws Exception {
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of("status", "INACTIVE"))))
+        .andExpect(status().isUnauthorized());
+  }
+
+  private SlotDefinitionResponse sampleResponse(String status) {
+    return new SlotDefinitionResponse(
+        99L,
+        10L,
+        "customer_name",
+        "고객명",
+        "설명",
+        "STRING",
+        false,
+        "{}",
+        null,
+        "{}",
+        status,
+        OffsetDateTime.parse("2026-04-15T10:00:00Z"),
+        OffsetDateTime.parse("2026-04-15T10:30:00Z"));
+  }
+}


### PR DESCRIPTION
## Summary

- `PATCH .../slots/{slotId}` — Slot 일반 필드 수정 엔드포인트 추가
- `PATCH .../slots/{slotId}/status` — Slot Status 전환 엔드포인트 추가
- `SlotDefinition` 도메인 모델에 `status` 필드 및 도메인 메서드(`updateFields`, `changeStatus`) 추가
- DB 마이그레이션: `pack.slot_definition`에 `status VARCHAR(50) NOT NULL DEFAULT 'ACTIVE'` 컬럼 추가

---

## Context

`.agent/specs/326.md` 구현 PR. 운영자(OPERATOR/ADMIN)가 DRAFT 상태의 Domain Pack Version에서 Slot 구성요소를 수정할 수 있도록 한다.

---

## What Changed

**신규 파일 (9개)**
- `application/SlotDefinitionResponse.java` — record 기반 응답 DTO, `from(SlotDefinition)` 팩토리 포함
- `application/UpdateSlotCommand.java`, `UpdateSlotStatusCommand.java` — Command record
- `application/UpdateSlotUseCase.java`, `UpdateSlotStatusUseCase.java` — 각각 필드 수정 / status 전환 유스케이스
- `presentation/UpdateSlotController.java`, `UpdateSlotStatusController.java` — 기능별 1파일 패턴
- `presentation/dto/UpdateSlotRequest.java`, `UpdateSlotStatusRequest.java` — request DTO

**수정 파일 (3개)**
- `domain/model/SlotDefinition.java` — `status` 필드, 상수(`STATUS_ACTIVE/INACTIVE`), `updateFields()`, `changeStatus()` 추가; `create()`에 기본값 `STATUS_ACTIVE` 세팅 추가
- `domain/repository/SlotDefinitionRepository.java` — `findById(Long)`, `save(SlotDefinition)` 메서드 추가
- `resources/db/changelog/db.changelog-master.sql` — changeset `devjhan:20260415-add-status-to-slot-definition` 추가

---

## Assumptions Adopted

| ID  | Assumption | 영향 |
|-----|-----------|------|
| U-06 | `DomainPackVersionRepository.findById(Long)`는 기존 인터페이스에 이미 선언되어 있음 → 추가 선언 없이 재사용 | 인터페이스 변경 없음 |
| U-07 | 기존 `presentation/` 패키지의 기능별 1파일 패턴을 따라 Controller 2개로 분리 | 코드베이스 일관성 유지 |

---

## Spec Deviations

### 1. 도메인 메서드 예외 타입: `BadRequestException` → `IllegalArgumentException`

**스펙 pseudo-code**:
```java
// SlotDefinition.updateFields()
throw new BadRequestException("VALIDATION_ERROR", "name은 비워둘 수 없습니다.");

// SlotDefinition.changeStatus()
throw new BadRequestException("VALIDATION_ERROR", "허용되지 않는 status 값입니다: " + newStatus);
```

**구현**:
```java
// SlotDefinition — domain layer
throw new IllegalArgumentException("name은 비워둘 수 없습니다.");

// UpdateSlotUseCase — application layer (변환)
} catch (IllegalArgumentException e) {
  throw new BadRequestException("VALIDATION_ERROR", e.getMessage());
}
```

**이유**: `SlotDefinition`(domain layer)에서 `BadRequestException`(application layer 예외)을 직접 참조하면 `domain → application` 의존성이 생겨 DDD 계층 규칙 위반. `IllegalArgumentException`은 표준 Java 예외이므로 도메인에서 사용 가능하며, application layer에서 변환한다. 동작 결과(HTTP 400 + `VALIDATION_ERROR`)는 스펙과 동일.

### 2. 인가 패턴: 단일 `validateMembership()` → existence + role 2단계 확인

**스펙 pseudo-code**: `membershipPort.validateMembership(workspaceId, requesterId)`

**구현**:
```java
// 1단계: workspace 존재 확인
if (!workspaceExistencePort.existsById(command.workspaceId())) { ... }
// 2단계: 역할 기반 멤버십 확인 (OPERATOR, ADMIN만 허용)
if (!workspaceMembershipPort.hasAnyRole(workspaceId, requesterId, ALLOWED_ROLES)) { ... }
```

**이유**: 기존 `ActivateDomainPackVersionUseCase` 패턴과 일관성. 워크스페이스 부재(404)와 권한 없음(403)을 에러 코드 레벨에서 분리.

---

## Blocked / Skipped Items

없음. 스펙 범위 전체 구현 완료.

---

## Test Notes

**실행 가능한 테스트 구조** (`@WebMvcTest` + `@ExtendWith(MockitoExtension.class)` + H2 unit)

| 파일 | 케이스 수 | 주요 커버리지 |
|------|---------|-------------|
| `SlotDefinitionTest` | 7 | `create` 기본값, `updateFields` 정상/null 보존/blank/null, `changeStatus` 정상/허용불가 |
| `UpdateSlotUseCaseTest` | 7 | 정상 수정, workspace 없음, 비멤버, 버전 없음, packId 불일치, PUBLISHED 버전, 슬롯 없음, versionId 불일치 |
| `UpdateSlotStatusUseCaseTest` | 5 | ACTIVE→INACTIVE, INACTIVE→ACTIVE, 잘못된 status, PUBLISHED 버전, versionId 불일치 |
| `UpdateSlotControllerTest` | 7 | 200 정상, 400 SLOT_NOT_EDITABLE, 404 슬롯없음, 400 blank name, 403 비멤버, 404 워크스페이스없음, 401 인증없음 |
| `UpdateSlotStatusControllerTest` | (미확인) | — |

**스펙 체크리스트 대비 추가된 케이스** (spec에 없던 케이스):
- `create_defaultStatusIsActive` — `status` 기본값 회귀 방지
- `updateFields_nullOptionalFields_keepsExistingValues` — null 입력 시 기존 값 보존 동작 명시
- `updateFields_withNullName_throwsNullPointerException` — NPE 경계 명시
- Controller: 401 인증 없음, 404 워크스페이스 없음

> 테스트 실행 결과는 별도 CI 확인 필요. 로컬 수동 실행 결과는 기록 없음.

---

## Reviewer Focus

1. **도메인 예외 변환 패턴** (`SlotDefinition` → `IllegalArgumentException` → UseCase → `BadRequestException`): DDD 계층 규칙 준수 여부 확인
2. **인가 2단계 구조**: `ALLOWED_ROLES = {OPERATOR, ADMIN}`가 이 API의 접근 요건과 일치하는지 확인
3. **DB 마이그레이션**: 기존 `slot_definition` 레코드에 `DEFAULT 'ACTIVE'` 백필 동작이 운영 환경에서 안전한지 확인
4. **`SlotDefinitionResponse` 위치**: `application` 패키지에 있음 (presentation/dto가 아님). 기존 패턴(`WorkflowDefinitionDetail` 등)과 일치하나, 명시적 확인 권장

---

## Conflicts

없음.

---

## Ready to Merge / Needs Input

**Needs Input (선택적)**:
- `UpdateSlotStatusControllerTest` 커버리지 항목 미확인 (파일 존재 확인됨, 내용 미독). 리뷰어가 테스트 범위 검토 권장.
- 인가 역할 범위(`OPERATOR, ADMIN`)가 이 도메인의 다른 수정 API(`ActivateDomainPackVersion` 등)와 일관된지 확인 필요.

위 두 항목이 확인되면 **Ready to Merge**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 슬롯 정보 수정 기능 추가: 이름, 설명, 민감도, 검증 규칙, 기본값, 메타 정보를 업데이트할 수 있습니다.
  * 슬롯 상태 관리 추가: 슬롯을 ACTIVE/INACTIVE로 전환할 수 있습니다. 상태 변경은 서버 검증을 거칩니다.

* **Validation**
  * 요청 검증 추가: name과 status 필드는 필수 입력입니다(빈값 허용 안 함).

* **Tests**
  * 슬롯 수정 및 상태 변경 흐름에 대한 단위 및 컨트롤러 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->