### PR TITLE
feat(domain-pack): add workflow node/edge update API (329)

### DIFF
--- a/backend/src/main/java/com/init/domainpack/application/UpdateWorkflowCommand.java
+++ b/backend/src/main/java/com/init/domainpack/application/UpdateWorkflowCommand.java
@@ -1,0 +1,11 @@
+package com.init.domainpack.application;
+
+public record UpdateWorkflowCommand(
+    Long workspaceId,
+    Long packId,
+    Long versionId,
+    Long workflowId,
+    Long requesterId,
+    String name,
+    String description,
+    String graphJson) {}

--- a/backend/src/main/java/com/init/domainpack/application/UpdateWorkflowUseCase.java
+++ b/backend/src/main/java/com/init/domainpack/application/UpdateWorkflowUseCase.java
@@ -1,5 +1,6 @@
 package com.init.domainpack.application;
 
+import com.init.domainpack.application.exception.DomainPackDraftRequestInvalidException;
 import com.init.domainpack.domain.model.DomainPackVersion;
 import com.init.domainpack.domain.model.WorkflowDefinition;
 import com.init.domainpack.domain.repository.DomainPackVersionRepository;
@@ -62,7 +63,12 @@ public class UpdateWorkflowUseCase {
     WorkflowGraphValidator.ParsedGraph parsed =
         WorkflowGraphValidator.parseAndValidate(command.graphJson(), workflow.getWorkflowCode());
     String initialState = WorkflowGraphValidator.extractInitialState(parsed);
-    String terminalStatesJson = WorkflowGraphValidator.extractTerminalStatesJson(parsed);
+    String terminalStatesJson;
+    try {
+      terminalStatesJson = WorkflowGraphValidator.extractTerminalStatesJson(parsed);
+    } catch (IllegalStateException e) {
+      throw new DomainPackDraftRequestInvalidException("Failed to serialize terminal states", e);
+    }
 
     try {
       workflow.updateGraph(

--- a/backend/src/main/java/com/init/domainpack/application/UpdateWorkflowUseCase.java
+++ b/backend/src/main/java/com/init/domainpack/application/UpdateWorkflowUseCase.java
@@ -46,6 +46,9 @@ public class UpdateWorkflowUseCase {
       throw new BadRequestException("WORKFLOW_NOT_EDITABLE", "DRAFT 상태의 버전에서만 수정할 수 있습니다.");
     }
 
+    if (command.graphJson() == null) {
+      throw new BadRequestException("GRAPH_JSON_REQUIRED", "graphJson은 필수입니다.");
+    }
     if (command.graphJson().length() > MAX_GRAPH_JSON_CHARS) {
       throw new BadRequestException(
           "GRAPH_JSON_TOO_LARGE", "graphJson이 허용 크기(" + MAX_GRAPH_JSON_CHARS + "자)를 초과합니다.");

--- a/backend/src/main/java/com/init/domainpack/application/UpdateWorkflowUseCase.java
+++ b/backend/src/main/java/com/init/domainpack/application/UpdateWorkflowUseCase.java
@@ -37,21 +37,17 @@ public class UpdateWorkflowUseCase {
         versionRepository
             .findById(command.versionId())
             .orElseThrow(
-                () ->
-                    new NotFoundException(
-                        "NOT_FOUND", "버전을 찾을 수 없습니다: " + command.versionId()));
+                () -> new NotFoundException("NOT_FOUND", "버전을 찾을 수 없습니다: " + command.versionId()));
     if (!version.getDomainPackId().equals(command.packId())) {
       throw new NotFoundException("NOT_FOUND", "버전을 찾을 수 없습니다: " + command.versionId());
     }
     if (!DomainPackVersion.STATUS_DRAFT.equals(version.getLifecycleStatus())) {
-      throw new BadRequestException(
-          "WORKFLOW_NOT_EDITABLE", "DRAFT 상태의 버전에서만 수정할 수 있습니다.");
+      throw new BadRequestException("WORKFLOW_NOT_EDITABLE", "DRAFT 상태의 버전에서만 수정할 수 있습니다.");
     }
 
     if (command.graphJson().length() > MAX_GRAPH_JSON_CHARS) {
       throw new BadRequestException(
-          "GRAPH_JSON_TOO_LARGE",
-          "graphJson이 허용 크기(" + MAX_GRAPH_JSON_CHARS + "자)를 초과합니다.");
+          "GRAPH_JSON_TOO_LARGE", "graphJson이 허용 크기(" + MAX_GRAPH_JSON_CHARS + "자)를 초과합니다.");
     }
 
     WorkflowDefinition workflow =

--- a/backend/src/main/java/com/init/domainpack/application/UpdateWorkflowUseCase.java
+++ b/backend/src/main/java/com/init/domainpack/application/UpdateWorkflowUseCase.java
@@ -1,0 +1,85 @@
+package com.init.domainpack.application;
+
+import com.init.domainpack.domain.model.DomainPackVersion;
+import com.init.domainpack.domain.model.WorkflowDefinition;
+import com.init.domainpack.domain.repository.DomainPackVersionRepository;
+import com.init.domainpack.domain.repository.WorkflowDefinitionRepository;
+import com.init.shared.application.exception.BadRequestException;
+import com.init.shared.application.exception.NotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class UpdateWorkflowUseCase {
+
+  private static final int MAX_GRAPH_JSON_CHARS = 100_000;
+
+  private final DomainPackValidator validator;
+  private final DomainPackVersionRepository versionRepository;
+  private final WorkflowDefinitionRepository workflowRepository;
+
+  public UpdateWorkflowUseCase(
+      DomainPackValidator validator,
+      DomainPackVersionRepository versionRepository,
+      WorkflowDefinitionRepository workflowRepository) {
+    this.validator = validator;
+    this.versionRepository = versionRepository;
+    this.workflowRepository = workflowRepository;
+  }
+
+  @Transactional
+  public WorkflowDefinitionDetail execute(UpdateWorkflowCommand command) {
+    validator.validateWorkspaceAccess(command.workspaceId(), command.requesterId());
+    validator.validateDomainPack(command.packId(), command.workspaceId());
+
+    DomainPackVersion version =
+        versionRepository
+            .findById(command.versionId())
+            .orElseThrow(
+                () ->
+                    new NotFoundException(
+                        "NOT_FOUND", "버전을 찾을 수 없습니다: " + command.versionId()));
+    if (!version.getDomainPackId().equals(command.packId())) {
+      throw new NotFoundException("NOT_FOUND", "버전을 찾을 수 없습니다: " + command.versionId());
+    }
+    if (!DomainPackVersion.STATUS_DRAFT.equals(version.getLifecycleStatus())) {
+      throw new BadRequestException(
+          "WORKFLOW_NOT_EDITABLE", "DRAFT 상태의 버전에서만 수정할 수 있습니다.");
+    }
+
+    if (command.graphJson().length() > MAX_GRAPH_JSON_CHARS) {
+      throw new BadRequestException(
+          "GRAPH_JSON_TOO_LARGE",
+          "graphJson이 허용 크기(" + MAX_GRAPH_JSON_CHARS + "자)를 초과합니다.");
+    }
+
+    WorkflowDefinition workflow =
+        workflowRepository
+            .findByIdAndDomainPackVersionId(command.workflowId(), command.versionId())
+            .orElseThrow(
+                () ->
+                    new NotFoundException(
+                        "NOT_FOUND", "워크플로우를 찾을 수 없습니다: " + command.workflowId()));
+
+    // V1–V6 예외는 GlobalExceptionHandler로 전파
+    WorkflowGraphValidator.ParsedGraph parsed =
+        WorkflowGraphValidator.parseAndValidate(command.graphJson(), workflow.getWorkflowCode());
+    String initialState = WorkflowGraphValidator.extractInitialState(parsed);
+    String terminalStatesJson = WorkflowGraphValidator.extractTerminalStatesJson(parsed);
+
+    try {
+      workflow.updateGraph(
+          command.name(),
+          command.description(),
+          command.graphJson(),
+          initialState,
+          terminalStatesJson);
+    } catch (IllegalArgumentException e) {
+      throw new BadRequestException("VALIDATION_ERROR", e.getMessage());
+    }
+
+    workflowRepository.save(workflow);
+    return WorkflowDefinitionDetail.from(workflow);
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/domain/model/WorkflowDefinition.java
+++ b/backend/src/main/java/com/init/domainpack/domain/model/WorkflowDefinition.java
@@ -102,6 +102,7 @@ public class WorkflowDefinition {
       String terminalStatesJson) {
     Objects.requireNonNull(name, "name must not be null");
     Objects.requireNonNull(graphJson, "graphJson must not be null");
+    Objects.requireNonNull(terminalStatesJson, "terminalStatesJson must not be null");
     if (name.isBlank()) {
       throw new IllegalArgumentException("name cannot be blank");
     }

--- a/backend/src/main/java/com/init/domainpack/domain/model/WorkflowDefinition.java
+++ b/backend/src/main/java/com/init/domainpack/domain/model/WorkflowDefinition.java
@@ -94,6 +94,24 @@ public class WorkflowDefinition {
     return entity;
   }
 
+  public void updateGraph(
+      String name,
+      String description,
+      String graphJson,
+      String initialState,
+      String terminalStatesJson) {
+    Objects.requireNonNull(name, "name must not be null");
+    Objects.requireNonNull(graphJson, "graphJson must not be null");
+    if (name.isBlank()) {
+      throw new IllegalArgumentException("name cannot be blank");
+    }
+    this.name = name;
+    this.description = description;
+    this.graphJson = graphJson;
+    this.initialState = initialState;
+    this.terminalStatesJson = terminalStatesJson;
+  }
+
   public Long getId() {
     return id;
   }

--- a/backend/src/main/java/com/init/domainpack/domain/repository/WorkflowDefinitionRepository.java
+++ b/backend/src/main/java/com/init/domainpack/domain/repository/WorkflowDefinitionRepository.java
@@ -8,6 +8,8 @@ public interface WorkflowDefinitionRepository {
 
   <S extends WorkflowDefinition> List<S> saveAll(Iterable<S> entities);
 
+  WorkflowDefinition save(WorkflowDefinition workflow);
+
   List<WorkflowDefinitionSummaryRow> findAllByDomainPackVersionId(Long domainPackVersionId);
 
   Optional<WorkflowDefinition> findByIdAndDomainPackVersionId(Long id, Long domainPackVersionId);

--- a/backend/src/main/java/com/init/domainpack/presentation/WorkflowDefinitionController.java
+++ b/backend/src/main/java/com/init/domainpack/presentation/WorkflowDefinitionController.java
@@ -1,7 +1,5 @@
 package com.init.domainpack.presentation;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.init.domainpack.application.GetWorkflowDefinitionListQuery;
 import com.init.domainpack.application.GetWorkflowDefinitionListUseCase;
 import com.init.domainpack.application.GetWorkflowDefinitionQuery;
@@ -31,17 +29,14 @@ public class WorkflowDefinitionController {
   private final GetWorkflowDefinitionListUseCase listUseCase;
   private final GetWorkflowDefinitionUseCase detailUseCase;
   private final UpdateWorkflowUseCase updateUseCase;
-  private final ObjectMapper objectMapper;
 
   public WorkflowDefinitionController(
       GetWorkflowDefinitionListUseCase listUseCase,
       GetWorkflowDefinitionUseCase detailUseCase,
-      UpdateWorkflowUseCase updateUseCase,
-      ObjectMapper objectMapper) {
+      UpdateWorkflowUseCase updateUseCase) {
     this.listUseCase = listUseCase;
     this.detailUseCase = detailUseCase;
     this.updateUseCase = updateUseCase;
-    this.objectMapper = objectMapper;
   }
 
   @GetMapping
@@ -78,10 +73,9 @@ public class WorkflowDefinitionController {
       @PathVariable Long versionId,
       @PathVariable Long workflowId,
       @Valid @RequestBody UpdateWorkflowRequest request,
-      Authentication authentication)
-      throws JsonProcessingException {
+      Authentication authentication) {
     Long userId = AuthenticationUtils.getUserId(authentication);
-    String graphJsonStr = objectMapper.writeValueAsString(request.graphJson());
+    String graphJsonStr = request.graphJson().toString();
     WorkflowDefinitionDetail result =
         updateUseCase.execute(
             new UpdateWorkflowCommand(

--- a/backend/src/main/java/com/init/domainpack/presentation/WorkflowDefinitionController.java
+++ b/backend/src/main/java/com/init/domainpack/presentation/WorkflowDefinitionController.java
@@ -1,17 +1,25 @@
 package com.init.domainpack.presentation;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.init.domainpack.application.GetWorkflowDefinitionListQuery;
 import com.init.domainpack.application.GetWorkflowDefinitionListUseCase;
 import com.init.domainpack.application.GetWorkflowDefinitionQuery;
 import com.init.domainpack.application.GetWorkflowDefinitionUseCase;
+import com.init.domainpack.application.UpdateWorkflowCommand;
+import com.init.domainpack.application.UpdateWorkflowUseCase;
 import com.init.domainpack.application.WorkflowDefinitionDetail;
 import com.init.domainpack.application.WorkflowDefinitionSummary;
+import com.init.domainpack.presentation.dto.UpdateWorkflowRequest;
 import com.init.shared.presentation.AuthenticationUtils;
+import jakarta.validation.Valid;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,11 +30,18 @@ public class WorkflowDefinitionController {
 
   private final GetWorkflowDefinitionListUseCase listUseCase;
   private final GetWorkflowDefinitionUseCase detailUseCase;
+  private final UpdateWorkflowUseCase updateUseCase;
+  private final ObjectMapper objectMapper;
 
   public WorkflowDefinitionController(
-      GetWorkflowDefinitionListUseCase listUseCase, GetWorkflowDefinitionUseCase detailUseCase) {
+      GetWorkflowDefinitionListUseCase listUseCase,
+      GetWorkflowDefinitionUseCase detailUseCase,
+      UpdateWorkflowUseCase updateUseCase,
+      ObjectMapper objectMapper) {
     this.listUseCase = listUseCase;
     this.detailUseCase = detailUseCase;
+    this.updateUseCase = updateUseCase;
+    this.objectMapper = objectMapper;
   }
 
   @GetMapping
@@ -53,6 +68,31 @@ public class WorkflowDefinitionController {
     WorkflowDefinitionDetail result =
         detailUseCase.execute(
             new GetWorkflowDefinitionQuery(workspaceId, packId, versionId, workflowId, userId));
+    return ResponseEntity.ok(result);
+  }
+
+  @PatchMapping("/{workflowId}")
+  public ResponseEntity<WorkflowDefinitionDetail> updateWorkflow(
+      @PathVariable Long workspaceId,
+      @PathVariable Long packId,
+      @PathVariable Long versionId,
+      @PathVariable Long workflowId,
+      @Valid @RequestBody UpdateWorkflowRequest request,
+      Authentication authentication)
+      throws JsonProcessingException {
+    Long userId = AuthenticationUtils.getUserId(authentication);
+    String graphJsonStr = objectMapper.writeValueAsString(request.graphJson());
+    WorkflowDefinitionDetail result =
+        updateUseCase.execute(
+            new UpdateWorkflowCommand(
+                workspaceId,
+                packId,
+                versionId,
+                workflowId,
+                userId,
+                request.name(),
+                request.description(),
+                graphJsonStr));
     return ResponseEntity.ok(result);
   }
 }

--- a/backend/src/main/java/com/init/domainpack/presentation/dto/UpdateWorkflowRequest.java
+++ b/backend/src/main/java/com/init/domainpack/presentation/dto/UpdateWorkflowRequest.java
@@ -1,0 +1,10 @@
+package com.init.domainpack.presentation.dto;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateWorkflowRequest(
+    @NotBlank(message = "name은 필수 항목입니다.") String name,
+    String description,
+    @NotNull(message = "graphJson은 필수 항목입니다.") JsonNode graphJson) {}

--- a/backend/src/test/java/com/init/domainpack/application/UpdateWorkflowUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/UpdateWorkflowUseCaseTest.java
@@ -1,0 +1,322 @@
+package com.init.domainpack.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.init.domainpack.domain.model.DomainPackVersion;
+import com.init.domainpack.domain.model.WorkflowDefinition;
+import com.init.domainpack.domain.repository.DomainPackVersionRepository;
+import com.init.domainpack.domain.repository.WorkflowDefinitionRepository;
+import com.init.domainpack.application.exception.WorkflowCycleDetectedException;
+import com.init.domainpack.application.exception.WorkflowDanglingEdgeException;
+import com.init.domainpack.application.exception.WorkflowInvalidStartNodeException;
+import com.init.domainpack.application.exception.WorkflowInvalidTerminalNodeException;
+import com.init.domainpack.application.exception.WorkflowUnlabeledBranchException;
+import com.init.domainpack.application.exception.WorkflowUnreachableNodeException;
+import com.init.shared.application.exception.BadRequestException;
+import com.init.shared.application.exception.NotFoundException;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UpdateWorkflowUseCase")
+class UpdateWorkflowUseCaseTest {
+
+  private static final String VALID_GRAPH =
+      "{\"direction\":\"LR\","
+          + "\"nodes\":[{\"id\":\"start\",\"type\":\"START\"},{\"id\":\"end\",\"type\":\"TERMINAL\"}],"
+          + "\"edges\":[{\"from\":\"start\",\"to\":\"end\",\"label\":null}]}";
+
+  @Mock private DomainPackValidator validator;
+  @Mock private DomainPackVersionRepository versionRepository;
+  @Mock private WorkflowDefinitionRepository workflowRepository;
+
+  private UpdateWorkflowUseCase useCase;
+
+  @BeforeEach
+  void setUp() {
+    useCase = new UpdateWorkflowUseCase(validator, versionRepository, workflowRepository);
+  }
+
+  @Test
+  @DisplayName("유효한 요청 시 workflow 수정 후 WorkflowDefinitionDetail 반환")
+  void should_수정완료_when_유효한요청() {
+    // given
+    DomainPackVersion version = draftVersion(10L, 7L);
+    given(versionRepository.findById(10L)).willReturn(Optional.of(version));
+
+    WorkflowDefinition workflow = workflow(99L, 10L);
+    given(workflowRepository.findByIdAndDomainPackVersionId(99L, 10L))
+        .willReturn(Optional.of(workflow));
+    given(workflowRepository.save(any())).willReturn(workflow);
+
+    UpdateWorkflowCommand command =
+        new UpdateWorkflowCommand(1L, 7L, 10L, 99L, 5L, "수정된 이름", "새 설명", VALID_GRAPH);
+
+    // when
+    WorkflowDefinitionDetail result = useCase.execute(command);
+
+    // then
+    assertThat(result.name()).isEqualTo("수정된 이름");
+    assertThat(result.description()).isEqualTo("새 설명");
+    assertThat(result.initialState()).isEqualTo("start");
+    verify(workflowRepository).save(workflow);
+  }
+
+  @Test
+  @DisplayName("버전 미존재 시 NotFoundException")
+  void should_버전없음예외_when_버전미존재() {
+    given(versionRepository.findById(10L)).willReturn(Optional.empty());
+
+    assertThatThrownBy(
+            () -> useCase.execute(new UpdateWorkflowCommand(1L, 7L, 10L, 99L, 5L, "이름", null, VALID_GRAPH)))
+        .isInstanceOf(NotFoundException.class);
+
+    verify(workflowRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("packId 불일치 시 NotFoundException")
+  void should_버전없음예외_when_packId불일치() {
+    DomainPackVersion version = draftVersion(10L, 999L); // packId=999, not 7
+    given(versionRepository.findById(10L)).willReturn(Optional.of(version));
+
+    assertThatThrownBy(
+            () -> useCase.execute(new UpdateWorkflowCommand(1L, 7L, 10L, 99L, 5L, "이름", null, VALID_GRAPH)))
+        .isInstanceOf(NotFoundException.class);
+
+    verify(workflowRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("DRAFT가 아닌 버전 수정 시 BadRequestException(WORKFLOW_NOT_EDITABLE)")
+  void should_WORKFLOW_NOT_EDITABLE_when_버전이PUBLISHED() {
+    DomainPackVersion version = publishedVersion(10L, 7L);
+    given(versionRepository.findById(10L)).willReturn(Optional.of(version));
+
+    assertThatThrownBy(
+            () -> useCase.execute(new UpdateWorkflowCommand(1L, 7L, 10L, 99L, 5L, "이름", null, VALID_GRAPH)))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("DRAFT");
+
+    verify(workflowRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("graphJson 크기 초과 시 BadRequestException(GRAPH_JSON_TOO_LARGE)")
+  void should_GRAPH_JSON_TOO_LARGE_when_크기초과() {
+    DomainPackVersion version = draftVersion(10L, 7L);
+    given(versionRepository.findById(10L)).willReturn(Optional.of(version));
+
+    String oversizedGraph = "x".repeat(100_001);
+    assertThatThrownBy(
+            () -> useCase.execute(new UpdateWorkflowCommand(1L, 7L, 10L, 99L, 5L, "이름", null, oversizedGraph)))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("허용 크기");
+
+    verify(workflowRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 workflowId 요청 시 NotFoundException")
+  void should_404_when_workflowNotFound() {
+    DomainPackVersion version = draftVersion(10L, 7L);
+    given(versionRepository.findById(10L)).willReturn(Optional.of(version));
+    given(workflowRepository.findByIdAndDomainPackVersionId(99L, 10L))
+        .willReturn(Optional.empty());
+
+    assertThatThrownBy(
+            () -> useCase.execute(new UpdateWorkflowCommand(1L, 7L, 10L, 99L, 5L, "이름", null, VALID_GRAPH)))
+        .isInstanceOf(NotFoundException.class);
+
+    verify(workflowRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("V1 위반(START 노드 != 1) 시 WorkflowInvalidStartNodeException")
+  void should_V1예외_when_START노드이상() {
+    // given
+    DomainPackVersion version = draftVersion(10L, 7L);
+    given(versionRepository.findById(10L)).willReturn(Optional.of(version));
+    WorkflowDefinition workflow = workflow(99L, 10L);
+    given(workflowRepository.findByIdAndDomainPackVersionId(99L, 10L))
+        .willReturn(Optional.of(workflow));
+    String noStartGraph =
+        "{\"direction\":\"LR\","
+            + "\"nodes\":[{\"id\":\"end\",\"type\":\"TERMINAL\"}],"
+            + "\"edges\":[]}";
+
+    // when & then
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdateWorkflowCommand(1L, 7L, 10L, 99L, 5L, "이름", null, noStartGraph)))
+        .isInstanceOf(WorkflowInvalidStartNodeException.class);
+  }
+
+  @Test
+  @DisplayName("V2 위반(TERMINAL 노드 없음) 시 WorkflowInvalidTerminalNodeException")
+  void should_V2예외_when_TERMINAL노드없음() {
+    // given
+    DomainPackVersion version = draftVersion(10L, 7L);
+    given(versionRepository.findById(10L)).willReturn(Optional.of(version));
+    WorkflowDefinition workflow = workflow(99L, 10L);
+    given(workflowRepository.findByIdAndDomainPackVersionId(99L, 10L))
+        .willReturn(Optional.of(workflow));
+    String noTerminalGraph =
+        "{\"direction\":\"LR\","
+            + "\"nodes\":["
+            + "{\"id\":\"start\",\"type\":\"START\"},"
+            + "{\"id\":\"n1\",\"type\":\"ACTION\"}],"
+            + "\"edges\":[{\"from\":\"start\",\"to\":\"n1\",\"label\":null}]}";
+
+    // when & then
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdateWorkflowCommand(
+                        1L, 7L, 10L, 99L, 5L, "이름", null, noTerminalGraph)))
+        .isInstanceOf(WorkflowInvalidTerminalNodeException.class);
+  }
+
+  @Test
+  @DisplayName("V3 위반(dangling edge) 시 WorkflowDanglingEdgeException")
+  void should_V3예외_when_dangling엣지() {
+    // given
+    DomainPackVersion version = draftVersion(10L, 7L);
+    given(versionRepository.findById(10L)).willReturn(Optional.of(version));
+    WorkflowDefinition workflow = workflow(99L, 10L);
+    given(workflowRepository.findByIdAndDomainPackVersionId(99L, 10L))
+        .willReturn(Optional.of(workflow));
+    String danglingGraph =
+        "{\"direction\":\"LR\","
+            + "\"nodes\":["
+            + "{\"id\":\"start\",\"type\":\"START\"},"
+            + "{\"id\":\"end\",\"type\":\"TERMINAL\"}],"
+            + "\"edges\":[{\"from\":\"start\",\"to\":\"nonexistent\",\"label\":null}]}";
+
+    // when & then
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdateWorkflowCommand(1L, 7L, 10L, 99L, 5L, "이름", null, danglingGraph)))
+        .isInstanceOf(WorkflowDanglingEdgeException.class);
+  }
+
+  @Test
+  @DisplayName("V4 위반(미도달 노드) 시 WorkflowUnreachableNodeException")
+  void should_V4예외_when_미도달노드() {
+    // given
+    DomainPackVersion version = draftVersion(10L, 7L);
+    given(versionRepository.findById(10L)).willReturn(Optional.of(version));
+    WorkflowDefinition workflow = workflow(99L, 10L);
+    given(workflowRepository.findByIdAndDomainPackVersionId(99L, 10L))
+        .willReturn(Optional.of(workflow));
+    String unreachableGraph =
+        "{\"direction\":\"LR\","
+            + "\"nodes\":["
+            + "{\"id\":\"start\",\"type\":\"START\"},"
+            + "{\"id\":\"orphan\",\"type\":\"ACTION\"},"
+            + "{\"id\":\"end\",\"type\":\"TERMINAL\"}],"
+            + "\"edges\":[{\"from\":\"start\",\"to\":\"end\",\"label\":null}]}";
+
+    // when & then
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdateWorkflowCommand(
+                        1L, 7L, 10L, 99L, 5L, "이름", null, unreachableGraph)))
+        .isInstanceOf(WorkflowUnreachableNodeException.class);
+  }
+
+  @Test
+  @DisplayName("V5 위반(사이클) 시 WorkflowCycleDetectedException")
+  void should_V5예외_when_사이클() {
+    // given
+    DomainPackVersion version = draftVersion(10L, 7L);
+    given(versionRepository.findById(10L)).willReturn(Optional.of(version));
+    WorkflowDefinition workflow = workflow(99L, 10L);
+    given(workflowRepository.findByIdAndDomainPackVersionId(99L, 10L))
+        .willReturn(Optional.of(workflow));
+    // n1 → start creates a back-edge (cycle)
+    String cycleGraph =
+        "{\"direction\":\"LR\","
+            + "\"nodes\":["
+            + "{\"id\":\"start\",\"type\":\"START\"},"
+            + "{\"id\":\"n1\",\"type\":\"ACTION\"},"
+            + "{\"id\":\"end\",\"type\":\"TERMINAL\"}],"
+            + "\"edges\":["
+            + "{\"from\":\"start\",\"to\":\"n1\",\"label\":null},"
+            + "{\"from\":\"n1\",\"to\":\"start\",\"label\":null},"
+            + "{\"from\":\"n1\",\"to\":\"end\",\"label\":null}]}";
+
+    // when & then
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdateWorkflowCommand(1L, 7L, 10L, 99L, 5L, "이름", null, cycleGraph)))
+        .isInstanceOf(WorkflowCycleDetectedException.class);
+  }
+
+  @Test
+  @DisplayName("V6 위반(DECISION label 없음) 시 WorkflowUnlabeledBranchException")
+  void should_V6예외_when_DECISION레이블없음() {
+    // given
+    DomainPackVersion version = draftVersion(10L, 7L);
+    given(versionRepository.findById(10L)).willReturn(Optional.of(version));
+    WorkflowDefinition workflow = workflow(99L, 10L);
+    given(workflowRepository.findByIdAndDomainPackVersionId(99L, 10L))
+        .willReturn(Optional.of(workflow));
+    // d1 DECISION node has one unlabeled outgoing edge
+    String unlabeledDecisionGraph =
+        "{\"direction\":\"LR\","
+            + "\"nodes\":["
+            + "{\"id\":\"start\",\"type\":\"START\"},"
+            + "{\"id\":\"d1\",\"type\":\"DECISION\"},"
+            + "{\"id\":\"end1\",\"type\":\"TERMINAL\"},"
+            + "{\"id\":\"end2\",\"type\":\"TERMINAL\"}],"
+            + "\"edges\":["
+            + "{\"from\":\"start\",\"to\":\"d1\",\"label\":null},"
+            + "{\"from\":\"d1\",\"to\":\"end1\",\"label\":\"yes\"},"
+            + "{\"from\":\"d1\",\"to\":\"end2\",\"label\":null}]}";
+
+    // when & then
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdateWorkflowCommand(
+                        1L, 7L, 10L, 99L, 5L, "이름", null, unlabeledDecisionGraph)))
+        .isInstanceOf(WorkflowUnlabeledBranchException.class);
+  }
+
+  // ── factories ──────────────────────────────────────────────────────────────
+
+  private DomainPackVersion draftVersion(Long id, Long domainPackId) {
+    return DomainPackVersion.ofForTest(id, domainPackId, DomainPackVersion.STATUS_DRAFT);
+  }
+
+  private DomainPackVersion publishedVersion(Long id, Long domainPackId) {
+    return DomainPackVersion.ofForTest(id, domainPackId, DomainPackVersion.STATUS_PUBLISHED);
+  }
+
+  private WorkflowDefinition workflow(Long id, Long versionId) {
+    String graph =
+        "{\"direction\":\"LR\","
+            + "\"nodes\":[{\"id\":\"start\",\"type\":\"START\"},{\"id\":\"end\",\"type\":\"TERMINAL\"}],"
+            + "\"edges\":[{\"from\":\"start\",\"to\":\"end\",\"label\":null}]}";
+    WorkflowDefinition wf =
+        WorkflowDefinition.create(versionId, "wf_refund", "환불 플로우", null, graph, "start", "[\"end\"]", "[]", "{}");
+    ReflectionTestUtils.setField(wf, "id", id);
+    return wf;
+  }
+}

--- a/backend/src/test/java/com/init/domainpack/application/UpdateWorkflowUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/UpdateWorkflowUseCaseTest.java
@@ -171,6 +171,7 @@ class UpdateWorkflowUseCaseTest {
                 useCase.execute(
                     new UpdateWorkflowCommand(1L, 7L, 10L, 99L, 5L, "이름", null, noStartGraph)))
         .isInstanceOf(WorkflowInvalidStartNodeException.class);
+    verify(workflowRepository, never()).save(any());
   }
 
   @Test
@@ -195,6 +196,7 @@ class UpdateWorkflowUseCaseTest {
                 useCase.execute(
                     new UpdateWorkflowCommand(1L, 7L, 10L, 99L, 5L, "이름", null, noTerminalGraph)))
         .isInstanceOf(WorkflowInvalidTerminalNodeException.class);
+    verify(workflowRepository, never()).save(any());
   }
 
   @Test
@@ -219,6 +221,7 @@ class UpdateWorkflowUseCaseTest {
                 useCase.execute(
                     new UpdateWorkflowCommand(1L, 7L, 10L, 99L, 5L, "이름", null, danglingGraph)))
         .isInstanceOf(WorkflowDanglingEdgeException.class);
+    verify(workflowRepository, never()).save(any());
   }
 
   @Test
@@ -244,6 +247,7 @@ class UpdateWorkflowUseCaseTest {
                 useCase.execute(
                     new UpdateWorkflowCommand(1L, 7L, 10L, 99L, 5L, "이름", null, unreachableGraph)))
         .isInstanceOf(WorkflowUnreachableNodeException.class);
+    verify(workflowRepository, never()).save(any());
   }
 
   @Test
@@ -273,6 +277,7 @@ class UpdateWorkflowUseCaseTest {
                 useCase.execute(
                     new UpdateWorkflowCommand(1L, 7L, 10L, 99L, 5L, "이름", null, cycleGraph)))
         .isInstanceOf(WorkflowCycleDetectedException.class);
+    verify(workflowRepository, never()).save(any());
   }
 
   @Test
@@ -304,6 +309,7 @@ class UpdateWorkflowUseCaseTest {
                     new UpdateWorkflowCommand(
                         1L, 7L, 10L, 99L, 5L, "이름", null, unlabeledDecisionGraph)))
         .isInstanceOf(WorkflowUnlabeledBranchException.class);
+    verify(workflowRepository, never()).save(any());
   }
 
   // ── factories ──────────────────────────────────────────────────────────────

--- a/backend/src/test/java/com/init/domainpack/application/UpdateWorkflowUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/UpdateWorkflowUseCaseTest.java
@@ -7,16 +7,16 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
-import com.init.domainpack.domain.model.DomainPackVersion;
-import com.init.domainpack.domain.model.WorkflowDefinition;
-import com.init.domainpack.domain.repository.DomainPackVersionRepository;
-import com.init.domainpack.domain.repository.WorkflowDefinitionRepository;
 import com.init.domainpack.application.exception.WorkflowCycleDetectedException;
 import com.init.domainpack.application.exception.WorkflowDanglingEdgeException;
 import com.init.domainpack.application.exception.WorkflowInvalidStartNodeException;
 import com.init.domainpack.application.exception.WorkflowInvalidTerminalNodeException;
 import com.init.domainpack.application.exception.WorkflowUnlabeledBranchException;
 import com.init.domainpack.application.exception.WorkflowUnreachableNodeException;
+import com.init.domainpack.domain.model.DomainPackVersion;
+import com.init.domainpack.domain.model.WorkflowDefinition;
+import com.init.domainpack.domain.repository.DomainPackVersionRepository;
+import com.init.domainpack.domain.repository.WorkflowDefinitionRepository;
 import com.init.shared.application.exception.BadRequestException;
 import com.init.shared.application.exception.NotFoundException;
 import java.util.Optional;
@@ -79,7 +79,9 @@ class UpdateWorkflowUseCaseTest {
     given(versionRepository.findById(10L)).willReturn(Optional.empty());
 
     assertThatThrownBy(
-            () -> useCase.execute(new UpdateWorkflowCommand(1L, 7L, 10L, 99L, 5L, "이름", null, VALID_GRAPH)))
+            () ->
+                useCase.execute(
+                    new UpdateWorkflowCommand(1L, 7L, 10L, 99L, 5L, "이름", null, VALID_GRAPH)))
         .isInstanceOf(NotFoundException.class);
 
     verify(workflowRepository, never()).save(any());
@@ -92,7 +94,9 @@ class UpdateWorkflowUseCaseTest {
     given(versionRepository.findById(10L)).willReturn(Optional.of(version));
 
     assertThatThrownBy(
-            () -> useCase.execute(new UpdateWorkflowCommand(1L, 7L, 10L, 99L, 5L, "이름", null, VALID_GRAPH)))
+            () ->
+                useCase.execute(
+                    new UpdateWorkflowCommand(1L, 7L, 10L, 99L, 5L, "이름", null, VALID_GRAPH)))
         .isInstanceOf(NotFoundException.class);
 
     verify(workflowRepository, never()).save(any());
@@ -105,7 +109,9 @@ class UpdateWorkflowUseCaseTest {
     given(versionRepository.findById(10L)).willReturn(Optional.of(version));
 
     assertThatThrownBy(
-            () -> useCase.execute(new UpdateWorkflowCommand(1L, 7L, 10L, 99L, 5L, "이름", null, VALID_GRAPH)))
+            () ->
+                useCase.execute(
+                    new UpdateWorkflowCommand(1L, 7L, 10L, 99L, 5L, "이름", null, VALID_GRAPH)))
         .isInstanceOf(BadRequestException.class)
         .hasMessageContaining("DRAFT");
 
@@ -120,7 +126,9 @@ class UpdateWorkflowUseCaseTest {
 
     String oversizedGraph = "x".repeat(100_001);
     assertThatThrownBy(
-            () -> useCase.execute(new UpdateWorkflowCommand(1L, 7L, 10L, 99L, 5L, "이름", null, oversizedGraph)))
+            () ->
+                useCase.execute(
+                    new UpdateWorkflowCommand(1L, 7L, 10L, 99L, 5L, "이름", null, oversizedGraph)))
         .isInstanceOf(BadRequestException.class)
         .hasMessageContaining("허용 크기");
 
@@ -132,11 +140,12 @@ class UpdateWorkflowUseCaseTest {
   void should_404_when_workflowNotFound() {
     DomainPackVersion version = draftVersion(10L, 7L);
     given(versionRepository.findById(10L)).willReturn(Optional.of(version));
-    given(workflowRepository.findByIdAndDomainPackVersionId(99L, 10L))
-        .willReturn(Optional.empty());
+    given(workflowRepository.findByIdAndDomainPackVersionId(99L, 10L)).willReturn(Optional.empty());
 
     assertThatThrownBy(
-            () -> useCase.execute(new UpdateWorkflowCommand(1L, 7L, 10L, 99L, 5L, "이름", null, VALID_GRAPH)))
+            () ->
+                useCase.execute(
+                    new UpdateWorkflowCommand(1L, 7L, 10L, 99L, 5L, "이름", null, VALID_GRAPH)))
         .isInstanceOf(NotFoundException.class);
 
     verify(workflowRepository, never()).save(any());
@@ -184,8 +193,7 @@ class UpdateWorkflowUseCaseTest {
     assertThatThrownBy(
             () ->
                 useCase.execute(
-                    new UpdateWorkflowCommand(
-                        1L, 7L, 10L, 99L, 5L, "이름", null, noTerminalGraph)))
+                    new UpdateWorkflowCommand(1L, 7L, 10L, 99L, 5L, "이름", null, noTerminalGraph)))
         .isInstanceOf(WorkflowInvalidTerminalNodeException.class);
   }
 
@@ -234,8 +242,7 @@ class UpdateWorkflowUseCaseTest {
     assertThatThrownBy(
             () ->
                 useCase.execute(
-                    new UpdateWorkflowCommand(
-                        1L, 7L, 10L, 99L, 5L, "이름", null, unreachableGraph)))
+                    new UpdateWorkflowCommand(1L, 7L, 10L, 99L, 5L, "이름", null, unreachableGraph)))
         .isInstanceOf(WorkflowUnreachableNodeException.class);
   }
 
@@ -315,7 +322,8 @@ class UpdateWorkflowUseCaseTest {
             + "\"nodes\":[{\"id\":\"start\",\"type\":\"START\"},{\"id\":\"end\",\"type\":\"TERMINAL\"}],"
             + "\"edges\":[{\"from\":\"start\",\"to\":\"end\",\"label\":null}]}";
     WorkflowDefinition wf =
-        WorkflowDefinition.create(versionId, "wf_refund", "환불 플로우", null, graph, "start", "[\"end\"]", "[]", "{}");
+        WorkflowDefinition.create(
+            versionId, "wf_refund", "환불 플로우", null, graph, "start", "[\"end\"]", "[]", "{}");
     ReflectionTestUtils.setField(wf, "id", id);
     return wf;
   }

--- a/backend/src/test/java/com/init/domainpack/domain/model/WorkflowDefinitionUpdateGraphTest.java
+++ b/backend/src/test/java/com/init/domainpack/domain/model/WorkflowDefinitionUpdateGraphTest.java
@@ -1,0 +1,80 @@
+package com.init.domainpack.domain.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("WorkflowDefinition.updateGraph()")
+class WorkflowDefinitionUpdateGraphTest {
+
+  private static final String VALID_GRAPH =
+      "{\"direction\":\"LR\",\"nodes\":[{\"id\":\"start\",\"type\":\"START\"},{\"id\":\"end\",\"type\":\"TERMINAL\"}],"
+          + "\"edges\":[{\"from\":\"start\",\"to\":\"end\",\"label\":null}]}";
+
+  private WorkflowDefinition workflow;
+
+  @BeforeEach
+  void setUp() {
+    workflow =
+        WorkflowDefinition.create(
+            1L, "wf_refund", "환불 워크플로우", "설명", VALID_GRAPH, "start", "[\"end\"]", "[]", "{}");
+  }
+
+  @Test
+  @DisplayName("유효한 인자로 호출 시 name, description, graphJson, initialState, terminalStatesJson이 수정된다")
+  void should_필드수정_when_유효한인자() {
+    String newGraph =
+        "{\"direction\":\"LR\",\"nodes\":[{\"id\":\"s\",\"type\":\"START\"},{\"id\":\"e\",\"type\":\"TERMINAL\"}],"
+            + "\"edges\":[{\"from\":\"s\",\"to\":\"e\",\"label\":null}]}";
+
+    workflow.updateGraph("새 이름", "새 설명", newGraph, "s", "[\"e\"]");
+
+    assertThat(workflow.getName()).isEqualTo("새 이름");
+    assertThat(workflow.getDescription()).isEqualTo("새 설명");
+    assertThat(workflow.getGraphJson()).isEqualTo(newGraph);
+    assertThat(workflow.getInitialState()).isEqualTo("s");
+    assertThat(workflow.getTerminalStatesJson()).isEqualTo("[\"e\"]");
+  }
+
+  @Test
+  @DisplayName("description이 null이면 null로 수정된다")
+  void should_descriptionNull_when_nullPassed() {
+    workflow.updateGraph("이름", null, VALID_GRAPH, "start", "[\"end\"]");
+
+    assertThat(workflow.getDescription()).isNull();
+  }
+
+  @Test
+  @DisplayName("name이 blank이면 IllegalArgumentException")
+  void should_예외_when_nameBlank() {
+    assertThatThrownBy(() -> workflow.updateGraph("  ", null, VALID_GRAPH, "start", "[\"end\"]"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("blank");
+  }
+
+  @Test
+  @DisplayName("name이 null이면 NullPointerException")
+  void should_예외_when_nameNull() {
+    assertThatThrownBy(() -> workflow.updateGraph(null, null, VALID_GRAPH, "start", "[\"end\"]"))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  @DisplayName("graphJson이 null이면 NullPointerException")
+  void should_예외_when_graphJsonNull() {
+    assertThatThrownBy(() -> workflow.updateGraph("이름", null, null, "start", "[\"end\"]"))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  @DisplayName("workflowCode, domainPackVersionId는 수정되지 않는다")
+  void should_불변필드유지_when_updateGraph() {
+    workflow.updateGraph("새 이름", "새 설명", VALID_GRAPH, "start", "[\"end\"]");
+
+    assertThat(workflow.getWorkflowCode()).isEqualTo("wf_refund");
+    assertThat(workflow.getDomainPackVersionId()).isEqualTo(1L);
+  }
+}

--- a/backend/src/test/java/com/init/domainpack/domain/model/WorkflowDefinitionUpdateGraphTest.java
+++ b/backend/src/test/java/com/init/domainpack/domain/model/WorkflowDefinitionUpdateGraphTest.java
@@ -70,6 +70,13 @@ class WorkflowDefinitionUpdateGraphTest {
   }
 
   @Test
+  @DisplayName("terminalStatesJson이 null이면 NullPointerException")
+  void should_예외_when_terminalStatesJsonNull() {
+    assertThatThrownBy(() -> workflow.updateGraph("이름", null, VALID_GRAPH, "start", null))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
   @DisplayName("workflowCode, domainPackVersionId는 수정되지 않는다")
   void should_불변필드유지_when_updateGraph() {
     workflow.updateGraph("새 이름", "새 설명", VALID_GRAPH, "start", "[\"end\"]");

--- a/backend/src/test/java/com/init/domainpack/presentation/WorkflowDefinitionControllerTest.java
+++ b/backend/src/test/java/com/init/domainpack/presentation/WorkflowDefinitionControllerTest.java
@@ -8,6 +8,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.init.domainpack.application.GetWorkflowDefinitionListUseCase;
 import com.init.domainpack.application.GetWorkflowDefinitionUseCase;
+import com.init.domainpack.application.UpdateWorkflowUseCase;
 import com.init.domainpack.application.WorkflowDefinitionDetail;
 import com.init.domainpack.application.WorkflowDefinitionSummary;
 import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
@@ -42,6 +43,7 @@ class WorkflowDefinitionControllerTest {
 
   @MockitoBean private GetWorkflowDefinitionListUseCase listUseCase;
   @MockitoBean private GetWorkflowDefinitionUseCase detailUseCase;
+  @MockitoBean private UpdateWorkflowUseCase updateUseCase;
 
   @Test
   @DisplayName("GET .../workflows → 200 OK, 목록 반환")

--- a/backend/src/test/java/com/init/domainpack/presentation/WorkflowDefinitionUpdateControllerTest.java
+++ b/backend/src/test/java/com/init/domainpack/presentation/WorkflowDefinitionUpdateControllerTest.java
@@ -1,7 +1,9 @@
 package com.init.domainpack.presentation;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -12,6 +14,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.init.domainpack.application.GetWorkflowDefinitionListUseCase;
 import com.init.domainpack.application.GetWorkflowDefinitionUseCase;
+import com.init.domainpack.application.UpdateWorkflowCommand;
 import com.init.domainpack.application.UpdateWorkflowUseCase;
 import com.init.domainpack.application.WorkflowDefinitionDetail;
 import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
@@ -22,6 +25,7 @@ import com.init.shared.infrastructure.security.JwtAuthenticationFilter;
 import java.time.OffsetDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.ComponentScan;
@@ -59,6 +63,8 @@ class WorkflowDefinitionUpdateControllerTest {
   @DisplayName("유효한 요청 시 200 OK + WorkflowDefinitionDetail 반환")
   @WithLongPrincipal(5L)
   void should_200OK_when_유효한요청() throws Exception {
+    ArgumentCaptor<UpdateWorkflowCommand> captor =
+        ArgumentCaptor.forClass(UpdateWorkflowCommand.class);
     given(updateUseCase.execute(any())).willReturn(sampleDetail());
 
     mockMvc
@@ -71,6 +77,15 @@ class WorkflowDefinitionUpdateControllerTest {
         .andExpect(jsonPath("$.id").value(99))
         .andExpect(jsonPath("$.name").value("수정된 이름"))
         .andExpect(jsonPath("$.workflowCode").value("wf_refund"));
+
+    verify(updateUseCase).execute(captor.capture());
+    UpdateWorkflowCommand cmd = captor.getValue();
+    assertThat(cmd.workspaceId()).isEqualTo(1L);
+    assertThat(cmd.packId()).isEqualTo(7L);
+    assertThat(cmd.versionId()).isEqualTo(10L);
+    assertThat(cmd.workflowId()).isEqualTo(99L);
+    assertThat(cmd.requesterId()).isEqualTo(5L);
+    assertThat(cmd.name()).isEqualTo("수정된 이름");
   }
 
   @Test
@@ -177,7 +192,8 @@ class WorkflowDefinitionUpdateControllerTest {
                 .with(csrf())
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(validRequestBody()))
-        .andExpect(status().isForbidden());
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.code").value("FORBIDDEN"));
   }
 
   @Test

--- a/backend/src/test/java/com/init/domainpack/presentation/WorkflowDefinitionUpdateControllerTest.java
+++ b/backend/src/test/java/com/init/domainpack/presentation/WorkflowDefinitionUpdateControllerTest.java
@@ -42,8 +42,14 @@ class WorkflowDefinitionUpdateControllerTest {
   private static final String BASE_URL =
       "/api/v1/workspaces/1/domain-packs/7/versions/10/workflows/99";
 
-  @Autowired private MockMvc mockMvc;
-  @Autowired private ObjectMapper objectMapper;
+  private final MockMvc mockMvc;
+  private final ObjectMapper objectMapper;
+
+  @Autowired
+  WorkflowDefinitionUpdateControllerTest(MockMvc mockMvc, ObjectMapper objectMapper) {
+    this.mockMvc = mockMvc;
+    this.objectMapper = objectMapper;
+  }
 
   @MockitoBean private GetWorkflowDefinitionListUseCase listUseCase;
   @MockitoBean private GetWorkflowDefinitionUseCase detailUseCase;

--- a/backend/src/test/java/com/init/domainpack/presentation/WorkflowDefinitionUpdateControllerTest.java
+++ b/backend/src/test/java/com/init/domainpack/presentation/WorkflowDefinitionUpdateControllerTest.java
@@ -1,0 +1,219 @@
+package com.init.domainpack.presentation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.init.domainpack.application.GetWorkflowDefinitionListUseCase;
+import com.init.domainpack.application.GetWorkflowDefinitionUseCase;
+import com.init.domainpack.application.UpdateWorkflowUseCase;
+import com.init.domainpack.application.WorkflowDefinitionDetail;
+import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
+import com.init.fixtures.WithLongPrincipal;
+import com.init.shared.application.exception.BadRequestException;
+import com.init.shared.application.exception.NotFoundException;
+import com.init.shared.infrastructure.security.JwtAuthenticationFilter;
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(
+    value = WorkflowDefinitionController.class,
+    excludeFilters =
+        @ComponentScan.Filter(
+            type = FilterType.ASSIGNABLE_TYPE,
+            classes = JwtAuthenticationFilter.class))
+@DisplayName("WorkflowDefinitionController PATCH /{workflowId}")
+class WorkflowDefinitionUpdateControllerTest {
+
+  private static final String BASE_URL =
+      "/api/v1/workspaces/1/domain-packs/7/versions/10/workflows/99";
+
+  @Autowired private MockMvc mockMvc;
+  @Autowired private ObjectMapper objectMapper;
+
+  @MockitoBean private GetWorkflowDefinitionListUseCase listUseCase;
+  @MockitoBean private GetWorkflowDefinitionUseCase detailUseCase;
+  @MockitoBean private UpdateWorkflowUseCase updateUseCase;
+
+  @Test
+  @DisplayName("유효한 요청 시 200 OK + WorkflowDefinitionDetail 반환")
+  @WithLongPrincipal(5L)
+  void should_200OK_when_유효한요청() throws Exception {
+    given(updateUseCase.execute(any())).willReturn(sampleDetail());
+
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(validRequestBody()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(99))
+        .andExpect(jsonPath("$.name").value("수정된 이름"))
+        .andExpect(jsonPath("$.workflowCode").value("wf_refund"));
+  }
+
+  @Test
+  @DisplayName("name 누락 시 400 VALIDATION_ERROR")
+  @WithLongPrincipal(5L)
+  void should_400_when_name누락() throws Exception {
+    ObjectNode body = objectMapper.createObjectNode();
+    body.set("graphJson", objectMapper.readTree("{\"direction\":\"LR\",\"nodes\":[],\"edges\":[]}"));
+
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(body)))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+
+    verifyNoInteractions(updateUseCase);
+  }
+
+  @Test
+  @DisplayName("name이 빈 값이면 400 VALIDATION_ERROR")
+  @WithLongPrincipal(5L)
+  void should_400_when_nameBlank() throws Exception {
+    ObjectNode body = objectMapper.createObjectNode();
+    body.put("name", "");
+    body.set("graphJson", objectMapper.readTree("{\"direction\":\"LR\",\"nodes\":[],\"edges\":[]}"));
+
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(body)))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+
+    verifyNoInteractions(updateUseCase);
+  }
+
+  @Test
+  @DisplayName("graphJson 누락 시 400 VALIDATION_ERROR")
+  @WithLongPrincipal(5L)
+  void should_400_when_graphJson누락() throws Exception {
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"name\":\"이름\"}"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+
+    verifyNoInteractions(updateUseCase);
+  }
+
+  @Test
+  @DisplayName("DRAFT 아닌 버전 → 400 WORKFLOW_NOT_EDITABLE")
+  @WithLongPrincipal(5L)
+  void should_400_when_PUBLISHED버전() throws Exception {
+    given(updateUseCase.execute(any()))
+        .willThrow(new BadRequestException("WORKFLOW_NOT_EDITABLE", "DRAFT 상태의 버전에서만 수정할 수 있습니다."));
+
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(validRequestBody()))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("WORKFLOW_NOT_EDITABLE"));
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 workflowId → 404")
+  @WithLongPrincipal(5L)
+  void should_404_when_workflowNotFound() throws Exception {
+    given(updateUseCase.execute(any()))
+        .willThrow(new NotFoundException("NOT_FOUND", "워크플로우를 찾을 수 없습니다: 99"));
+
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(validRequestBody()))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("NOT_FOUND"));
+  }
+
+  @Test
+  @DisplayName("권한 없는 사용자 → 403")
+  @WithLongPrincipal(5L)
+  void should_403_when_권한없음() throws Exception {
+    given(updateUseCase.execute(any()))
+        .willThrow(new DomainPackUnauthorizedWorkspaceAccessException("접근 권한이 없습니다."));
+
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(validRequestBody()))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @DisplayName("인증 없는 요청 → 401")
+  void should_401_when_인증없음() throws Exception {
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(validRequestBody()))
+        .andExpect(status().isUnauthorized());
+
+    verifyNoInteractions(updateUseCase);
+  }
+
+  // ── helpers ────────────────────────────────────────────────────────────────
+
+  private String validRequestBody() throws Exception {
+    ObjectNode graphJson = objectMapper.createObjectNode();
+    graphJson.put("direction", "LR");
+    graphJson.set("nodes", objectMapper.readTree(
+        "[{\"id\":\"start\",\"type\":\"START\"},{\"id\":\"end\",\"type\":\"TERMINAL\"}]"));
+    graphJson.set("edges", objectMapper.readTree(
+        "[{\"from\":\"start\",\"to\":\"end\",\"label\":null}]"));
+
+    ObjectNode body = objectMapper.createObjectNode();
+    body.put("name", "수정된 이름");
+    body.set("graphJson", graphJson);
+    return objectMapper.writeValueAsString(body);
+  }
+
+  private WorkflowDefinitionDetail sampleDetail() {
+    return new WorkflowDefinitionDetail(
+        99L,
+        "wf_refund",
+        "수정된 이름",
+        null,
+        "{\"direction\":\"LR\",\"nodes\":[],\"edges\":[]}",
+        "start",
+        "[\"end\"]",
+        "[]",
+        "{}",
+        OffsetDateTime.parse("2026-04-14T10:00:00Z"),
+        OffsetDateTime.parse("2026-04-15T12:00:00Z"));
+  }
+}

--- a/backend/src/test/java/com/init/domainpack/presentation/WorkflowDefinitionUpdateControllerTest.java
+++ b/backend/src/test/java/com/init/domainpack/presentation/WorkflowDefinitionUpdateControllerTest.java
@@ -72,7 +72,8 @@ class WorkflowDefinitionUpdateControllerTest {
   @WithLongPrincipal(5L)
   void should_400_when_name누락() throws Exception {
     ObjectNode body = objectMapper.createObjectNode();
-    body.set("graphJson", objectMapper.readTree("{\"direction\":\"LR\",\"nodes\":[],\"edges\":[]}"));
+    body.set(
+        "graphJson", objectMapper.readTree("{\"direction\":\"LR\",\"nodes\":[],\"edges\":[]}"));
 
     mockMvc
         .perform(
@@ -92,7 +93,8 @@ class WorkflowDefinitionUpdateControllerTest {
   void should_400_when_nameBlank() throws Exception {
     ObjectNode body = objectMapper.createObjectNode();
     body.put("name", "");
-    body.set("graphJson", objectMapper.readTree("{\"direction\":\"LR\",\"nodes\":[],\"edges\":[]}"));
+    body.set(
+        "graphJson", objectMapper.readTree("{\"direction\":\"LR\",\"nodes\":[],\"edges\":[]}"));
 
     mockMvc
         .perform(
@@ -191,10 +193,12 @@ class WorkflowDefinitionUpdateControllerTest {
   private String validRequestBody() throws Exception {
     ObjectNode graphJson = objectMapper.createObjectNode();
     graphJson.put("direction", "LR");
-    graphJson.set("nodes", objectMapper.readTree(
-        "[{\"id\":\"start\",\"type\":\"START\"},{\"id\":\"end\",\"type\":\"TERMINAL\"}]"));
-    graphJson.set("edges", objectMapper.readTree(
-        "[{\"from\":\"start\",\"to\":\"end\",\"label\":null}]"));
+    graphJson.set(
+        "nodes",
+        objectMapper.readTree(
+            "[{\"id\":\"start\",\"type\":\"START\"},{\"id\":\"end\",\"type\":\"TERMINAL\"}]"));
+    graphJson.set(
+        "edges", objectMapper.readTree("[{\"from\":\"start\",\"to\":\"end\",\"label\":null}]"));
 
     ObjectNode body = objectMapper.createObjectNode();
     body.put("name", "수정된 이름");


### PR DESCRIPTION
## Summary

DRAFT 상태 버전의 Workflow `graph_json`을 전체 교체(full replacement)하는 PATCH API를 추가했다.
`WorkflowGraphValidator`의 V1–V6 검증 및 `initialState` / `terminalStatesJson` 자동 추출을 포함한다.
DB 스키마 변경 없음.

---

## Context

스펙 `.agent/specs/329.md` 구현. `pack.workflow_definition` 테이블의 기존 컬럼(`name`, `description`, `graph_json`, `initial_state`, `terminal_states_json`)을 갱신하는 단일 PATCH 엔드포인트이다.

---

## What Changed

| 대상 | 변경 내용 |
|------|-----------|
| `WorkflowDefinition` (domain) | `updateGraph()` 도메인 메서드 추가 |
| `WorkflowDefinitionRepository` (domain) | `save(WorkflowDefinition)` 명시 선언 추가 |
| `UpdateWorkflowCommand` (application) | 신규 record |
| `UpdateWorkflowUseCase` (application) | 신규 service. V1–V6 검증, 크기 제한, DRAFT 확인 포함 |
| `UpdateWorkflowRequest` (presentation/dto) | 신규 record (`JsonNode graphJson`) |
| `WorkflowDefinitionController` (presentation) | `@PatchMapping("/{workflowId}")` 추가, ObjectMapper 주입 |

---

## Assumptions Adopted

| ID | 결정 | 영향 |
|----|------|------|
| U-329-01 | `MAX_GRAPH_JSON_CHARS = 100_000` 확정 | `UpdateWorkflowUseCase` 상수로 관리 |
| U-329-02 | 기존 `WorkflowDefinitionController`에 PATCH 엔드포인트 추가. 별도 컨트롤러 미생성 | 동일 URL base GET/PATCH 한 클래스 관리. Slot 패턴(별도 컨트롤러)과 일관성 낮아지지만 KISS 우선 |
| U-329-03 | `UpdateWorkflowRequest.graphJson` 필드를 `JsonNode`로 수신, Controller에서 String 변환 | API 요청 시 JSON-in-JSON 이중 직렬화 불필요. FE와 계약 일치 여부는 FE 팀 확인 필요 |
| U-329-04 | `WorkflowDefinitionRepository`에 `save()` 명시 선언 추가 | `SlotDefinitionRepository` 기존 패턴 일치. `JpaWorkflowDefinitionRepository`가 `JpaRepository` 상속하므로 별도 구현 불필요 |

---

## Spec Deviations

스펙 통합 테스트 예시는 "기존 `WorkflowDefinitionControllerTest` 파일 확장"으로 제시했지만, 구현에서는 PATCH 전용 `WorkflowDefinitionUpdateControllerTest`를 별도 신규 파일로 분리했다. 기존 `WorkflowDefinitionControllerTest`에는 `@MockitoBean UpdateWorkflowUseCase`만 추가했다. U-329-02 결정 사항이며 스펙 의미 변경은 없다.

---

## Blocked / Skipped Items

N/A

---

## Test Notes

**단위 테스트 — 도메인** (`WorkflowDefinitionUpdateGraphTest`, 5개)
- 유효한 인자 → 필드 수정 확인
- `description` null 허용 확인
- `name` blank → `IllegalArgumentException`
- `name` null → `NullPointerException`
- `graphJson` null → `NullPointerException`
- `workflowCode`, `domainPackVersionId` 불변 확인

**단위 테스트 — UseCase** (`UpdateWorkflowUseCaseTest`, 10개)
- 정상 수정 → `WorkflowDefinitionDetail` 반환, `save()` 호출 확인
- 버전 미존재 → `NotFoundException`
- packId 불일치 → `NotFoundException`
- DRAFT 아닌 버전 → `BadRequestException(WORKFLOW_NOT_EDITABLE)`
- graphJson 크기 초과 → `BadRequestException(GRAPH_JSON_TOO_LARGE)`
- 존재하지 않는 workflowId → `NotFoundException`
- V1–V6 각각 → 해당 예외 타입으로 전파 확인

**통합 테스트 — Controller** (`WorkflowDefinitionUpdateControllerTest`, 7개)
- 정상 → 200 OK + `WorkflowDefinitionDetail`
- `name` 누락 → 400 `VALIDATION_ERROR`
- `name` blank → 400 `VALIDATION_ERROR`
- `graphJson` 누락 → 400 `VALIDATION_ERROR`
- DRAFT 아닌 버전 → 400 `WORKFLOW_NOT_EDITABLE`
- workflowId 미존재 → 404 `NOT_FOUND`
- 권한 없음 → 403
- 인증 없음 → 401 (스펙 체크리스트 외 추가)

---

## Reviewer Focus

1. **U-329-02 Controller 구조**: Slot API가 별도 컨트롤러를 사용하는 반면 이 PR은 기존 `WorkflowDefinitionController`에 PATCH를 추가했다. 팀 일관성 관점에서 방향 확인 필요.
2. **U-329-03 FE 계약**: `graphJson`을 `JsonNode`로 수신하는 방식이 FE 팀의 요청 형식과 일치하는지 확인 필요.
3. **V1–V6 예외 전파**: `WorkflowGraphValidator` 예외가 `GlobalExceptionHandler`의 `BusinessException` fallback으로 처리되는지 확인.

---

## Conflicts

없음.

---

## Ready to Merge / Needs Input

- FE 팀과 `graphJson` 필드 타입(`JsonNode` 방식) 계약 확인 후 merge 권장 (U-329-03).
- 위 확인 완료 시 merge 가능.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 워크플로우 이름·설명·그래프를 편집할 수 있는 API가 추가되었습니다(PATCH). 입력 유효성 검사, 페이로드 크기 제한, 변경 가능 상태 검증 및 오류 코드 매핑을 포함합니다.

* **테스트**
  * 편집 흐름의 성공/실패 경로(권한·상태·유효성·크기 제한 등)를 검증하는 유닛·컨트롤러 테스트들이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->