### PR TITLE
feat(domain-pack): add #327 policy update APIs

### DIFF
--- a/.agent/docs/schema.md
+++ b/.agent/docs/schema.md
@@ -951,6 +951,7 @@ create index idx_taxonomy_drift_pack
 ## 11. 상태값 예시
 
 ### 11.1 `domain_pack_version.lifecycle_status`
+
 - `DRAFT`
 - `IN_REVIEW`
 - `APPROVED`
@@ -958,16 +959,19 @@ create index idx_taxonomy_drift_pack
 - `ARCHIVED`
 
 ### 11.2 `pack.slot_definition.status` / `pack.policy_definition.status`
+
 - `ACTIVE`
 - `INACTIVE`
 
 ### 11.3 `review.review_session.status`
+
 - `OPEN`
 - `IN_PROGRESS`
 - `COMPLETED`
 - `CLOSED`
 
 ### 11.4 `pipeline.pipeline_job.status`
+
 - `QUEUED`
 - `RUNNING`
 - `FAILED`
@@ -975,6 +979,7 @@ create index idx_taxonomy_drift_pack
 - `CANCELLED`
 
 ### 11.5 `runtime.workflow_execution.status`
+
 - `RUNNING`
 - `WAITING_INPUT`
 - `COMPLETED`
@@ -983,6 +988,7 @@ create index idx_taxonomy_drift_pack
 - `FAILED`
 
 ### 11.6 `runtime.session_outcome.outcome_type`
+
 - `RESOLVED`
 - `HANDED_OFF`
 - `BLOCKED`

--- a/.agent/docs/schema.md
+++ b/.agent/docs/schema.md
@@ -460,6 +460,7 @@ create table pack.slot_definition (
     validation_rule_json jsonb not null default '{}'::jsonb,
     default_value_json  jsonb,
     meta_json           jsonb not null default '{}'::jsonb,
+    status              varchar(50) not null default 'ACTIVE',
     created_at          timestamptz not null default now(),
     updated_at          timestamptz not null default now(),
     unique (domain_pack_version_id, slot_code)
@@ -487,6 +488,7 @@ create table pack.policy_definition (
     action_json         jsonb not null default '{}'::jsonb,
     evidence_json       jsonb not null default '[]'::jsonb,
     meta_json           jsonb not null default '{}'::jsonb,
+    status              varchar(50) not null default 'ACTIVE',
     created_at          timestamptz not null default now(),
     updated_at          timestamptz not null default now(),
     unique (domain_pack_version_id, policy_code)
@@ -955,20 +957,24 @@ create index idx_taxonomy_drift_pack
 - `PUBLISHED`
 - `ARCHIVED`
 
-### 11.2 `review.review_session.status`
+### 11.2 `pack.slot_definition.status` / `pack.policy_definition.status`
+- `ACTIVE`
+- `INACTIVE`
+
+### 11.3 `review.review_session.status`
 - `OPEN`
 - `IN_PROGRESS`
 - `COMPLETED`
 - `CLOSED`
 
-### 11.3 `pipeline.pipeline_job.status`
+### 11.4 `pipeline.pipeline_job.status`
 - `QUEUED`
 - `RUNNING`
 - `FAILED`
 - `SUCCEEDED`
 - `CANCELLED`
 
-### 11.4 `runtime.workflow_execution.status`
+### 11.5 `runtime.workflow_execution.status`
 - `RUNNING`
 - `WAITING_INPUT`
 - `COMPLETED`
@@ -976,7 +982,7 @@ create index idx_taxonomy_drift_pack
 - `BLOCKED`
 - `FAILED`
 
-### 11.5 `runtime.session_outcome.outcome_type`
+### 11.6 `runtime.session_outcome.outcome_type`
 - `RESOLVED`
 - `HANDED_OFF`
 - `BLOCKED`

--- a/.agent/specs/327.md
+++ b/.agent/specs/327.md
@@ -122,19 +122,22 @@ Request
 
 1. `workspaceId` 존재 확인
 2. 요청 사용자의 워크스페이스 멤버십/역할 확인
-3. `versionId`로 `DomainPackVersion` 조회
-4. `version.domainPackId == packId` 검증
-5. `version.lifecycleStatus == DRAFT` 검증
-6. `policyId`로 `PolicyDefinition` 조회
-7. `policy.domainPackVersionId == versionId` 검증
-8. 일반 수정이면 `policy.updateFields(...)`
-9. status 수정이면 `policy.changeStatus(...)`
-10. 저장 후 `PolicyDefinitionResponse` 반환
+3. `packId`가 해당 `workspaceId` 소속인지 검증
+4. `versionId`로 `DomainPackVersion` 조회
+5. `version.domainPackId == packId` 검증
+6. `version.lifecycleStatus == DRAFT` 검증
+7. `policyId`로 `PolicyDefinition` 조회
+8. `policy.domainPackVersionId == versionId` 검증
+9. 일반 수정이면 `policy.updateFields(...)`
+10. status 수정이면 `policy.changeStatus(...)`
+11. 저장 후 `PolicyDefinitionResponse` 반환
 
 핵심 포인트
 - 실제 조회 키는 `versionId`, `policyId`다.
 - `packId`는 경로 일관성 검증용이다.
+- `workspaceId`는 권한 확인에만 쓰이지 않고, `packId`의 워크스페이스 소속 검증에도 사용된다.
 - 다른 version에 속한 policy를 path 조합으로 접근하면 `404`로 처리한다.
+- 다른 workspace에 속한 pack/version/policy를 path 조합으로 접근하면 `404`로 처리한다.
 
 ---
 
@@ -176,6 +179,7 @@ ALTER TABLE pack.policy_definition
 - `UpdatePolicyUseCaseTest`
   - DRAFT 버전 정상 수정
   - workspace 없음 / 비멤버
+  - 다른 workspace 소속 pack 접근 차단
   - version 없음 / packId 불일치
   - PUBLISHED 버전 수정 시도
   - policy 없음 / versionId 불일치
@@ -185,6 +189,7 @@ ALTER TABLE pack.policy_definition
   - `INACTIVE -> ACTIVE`
   - 허용되지 않는 status 값
   - workspace 없음 / 비멤버
+  - 다른 workspace 소속 pack 접근 차단
   - version 없음 / packId 불일치
   - policy 없음 / versionId 불일치
 

--- a/.agent/specs/327.md
+++ b/.agent/specs/327.md
@@ -1,0 +1,206 @@
+# 327: [BE] Policy / Policy Status 수정 API
+
+## Goal
+
+운영자가 특정 `domain_pack_version`의 `policy_definition`을 수정할 수 있도록 두 개의 REST API를 제공한다.
+
+1. Policy 일반 필드 수정
+2. Policy status 전환
+
+두 API 모두 `DomainPackVersion.lifecycle_status = 'DRAFT'`인 경우에만 허용한다.
+
+---
+
+## Endpoints
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `PATCH` | `/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/policies/{policyId}` | Policy 일반 필드 수정 |
+| `PATCH` | `/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/policies/{policyId}/status` | Policy status 전환 |
+
+---
+
+## Request / Response
+
+### 1. Policy 일반 수정
+
+Request
+
+```json
+{
+  "name": "환불 정책",
+  "description": "환불 가능 여부를 검증하는 정책",
+  "severity": "HIGH",
+  "conditionJson": "{}",
+  "actionJson": "{}",
+  "evidenceJson": "[]",
+  "metaJson": "{}"
+}
+```
+
+수정 가능 필드
+- `name`
+- `description`
+- `severity`
+- `conditionJson`
+- `actionJson`
+- `evidenceJson`
+- `metaJson`
+
+수정 불가 필드
+- `policyCode`
+- `domainPackVersionId`
+
+### 2. Policy status 전환
+
+Request
+
+```json
+{
+  "status": "INACTIVE"
+}
+```
+
+허용 값
+- `ACTIVE`
+- `INACTIVE`
+
+### 3. 성공 응답
+
+```json
+{
+  "id": 55,
+  "domainPackVersionId": 10,
+  "policyCode": "refund_check",
+  "name": "환불 정책",
+  "description": "환불 가능 여부를 검증하는 정책",
+  "severity": "HIGH",
+  "conditionJson": "{}",
+  "actionJson": "{}",
+  "evidenceJson": "[]",
+  "metaJson": "{}",
+  "status": "ACTIVE",
+  "createdAt": "2026-04-16T10:00:00Z",
+  "updatedAt": "2026-04-16T10:30:00Z"
+}
+```
+
+### 4. 오류 응답
+
+`400 POLICY_NOT_EDITABLE`
+
+```json
+{
+  "code": "POLICY_NOT_EDITABLE",
+  "message": "DRAFT 상태의 버전에서만 정책을 수정할 수 있습니다."
+}
+```
+
+`400 VALIDATION_ERROR`
+
+```json
+{
+  "code": "VALIDATION_ERROR",
+  "errors": ["name은 필수 항목입니다."]
+}
+```
+
+`404 NOT_FOUND`
+
+```json
+{
+  "code": "NOT_FOUND",
+  "message": "정책을 찾을 수 없습니다: 55"
+}
+```
+
+---
+
+## Application Flow
+
+두 use case 모두 동일한 검증 순서를 따른다.
+
+1. `workspaceId` 존재 확인
+2. 요청 사용자의 워크스페이스 멤버십/역할 확인
+3. `versionId`로 `DomainPackVersion` 조회
+4. `version.domainPackId == packId` 검증
+5. `version.lifecycleStatus == DRAFT` 검증
+6. `policyId`로 `PolicyDefinition` 조회
+7. `policy.domainPackVersionId == versionId` 검증
+8. 일반 수정이면 `policy.updateFields(...)`
+9. status 수정이면 `policy.changeStatus(...)`
+10. 저장 후 `PolicyDefinitionResponse` 반환
+
+핵심 포인트
+- 실제 조회 키는 `versionId`, `policyId`다.
+- `packId`는 경로 일관성 검증용이다.
+- 다른 version에 속한 policy를 path 조합으로 접근하면 `404`로 처리한다.
+
+---
+
+## Domain / Persistence Changes
+
+### `PolicyDefinition`
+
+추가/변경 사항
+- `status` 필드 추가
+- 기본값 `ACTIVE`
+- `updateFields(...)` 메서드 추가
+- `changeStatus(...)` 메서드 추가
+
+허용 status
+- `ACTIVE`
+- `INACTIVE`
+
+### Repository
+
+`PolicyDefinitionRepository`
+- `findById(Long id)`
+- `save(PolicyDefinition policy)`
+
+### DB Migration
+
+`pack.policy_definition`에 `status` 컬럼과 체크 제약을 추가한다.
+
+```sql
+ALTER TABLE pack.policy_definition
+    ADD COLUMN status VARCHAR(50) NOT NULL DEFAULT 'ACTIVE',
+    ADD CONSTRAINT chk_policy_definition_status
+        CHECK (status IN ('ACTIVE', 'INACTIVE'));
+```
+
+---
+
+## Test Plan
+
+- `UpdatePolicyUseCaseTest`
+  - DRAFT 버전 정상 수정
+  - workspace 없음 / 비멤버
+  - version 없음 / packId 불일치
+  - PUBLISHED 버전 수정 시도
+  - policy 없음 / versionId 불일치
+
+- `UpdatePolicyStatusUseCaseTest`
+  - `ACTIVE -> INACTIVE`
+  - `INACTIVE -> ACTIVE`
+  - 허용되지 않는 status 값
+  - workspace 없음 / 비멤버
+  - version 없음 / packId 불일치
+  - policy 없음 / versionId 불일치
+
+- `UpdatePolicyControllerTest`
+  - 정상 요청 200
+  - validation 실패 400
+  - `POLICY_NOT_EDITABLE` 400
+  - `NOT_FOUND` 404
+  - 비멤버 403
+  - 인증 없음 401
+
+- `UpdatePolicyStatusControllerTest`
+  - 정상 요청 200
+  - validation 실패 400
+  - 잘못된 status 400
+  - `POLICY_NOT_EDITABLE` 400
+  - `NOT_FOUND` 404
+  - 비멤버 403
+  - 인증 없음 401

--- a/backend/src/main/java/com/init/domainpack/application/PolicyDefinitionResponse.java
+++ b/backend/src/main/java/com/init/domainpack/application/PolicyDefinitionResponse.java
@@ -1,0 +1,37 @@
+package com.init.domainpack.application;
+
+import com.init.domainpack.domain.model.PolicyDefinition;
+import java.time.OffsetDateTime;
+
+public record PolicyDefinitionResponse(
+    Long id,
+    Long domainPackVersionId,
+    String policyCode,
+    String name,
+    String description,
+    String severity,
+    String conditionJson,
+    String actionJson,
+    String evidenceJson,
+    String metaJson,
+    String status,
+    OffsetDateTime createdAt,
+    OffsetDateTime updatedAt) {
+
+  public static PolicyDefinitionResponse from(PolicyDefinition policy) {
+    return new PolicyDefinitionResponse(
+        policy.getId(),
+        policy.getDomainPackVersionId(),
+        policy.getPolicyCode(),
+        policy.getName(),
+        policy.getDescription(),
+        policy.getSeverity(),
+        policy.getConditionJson(),
+        policy.getActionJson(),
+        policy.getEvidenceJson(),
+        policy.getMetaJson(),
+        policy.getStatus(),
+        policy.getCreatedAt(),
+        policy.getUpdatedAt());
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/application/UpdatePolicyCommand.java
+++ b/backend/src/main/java/com/init/domainpack/application/UpdatePolicyCommand.java
@@ -1,0 +1,15 @@
+package com.init.domainpack.application;
+
+public record UpdatePolicyCommand(
+    Long workspaceId,
+    Long packId,
+    Long versionId,
+    Long policyId,
+    Long requesterId,
+    String name,
+    String description,
+    String severity,
+    String conditionJson,
+    String actionJson,
+    String evidenceJson,
+    String metaJson) {}

--- a/backend/src/main/java/com/init/domainpack/application/UpdatePolicyStatusCommand.java
+++ b/backend/src/main/java/com/init/domainpack/application/UpdatePolicyStatusCommand.java
@@ -1,0 +1,9 @@
+package com.init.domainpack.application;
+
+public record UpdatePolicyStatusCommand(
+    Long workspaceId,
+    Long packId,
+    Long versionId,
+    Long policyId,
+    Long requesterId,
+    String status) {}

--- a/backend/src/main/java/com/init/domainpack/application/UpdatePolicyStatusUseCase.java
+++ b/backend/src/main/java/com/init/domainpack/application/UpdatePolicyStatusUseCase.java
@@ -1,0 +1,87 @@
+package com.init.domainpack.application;
+
+import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
+import com.init.domainpack.application.exception.DomainPackWorkspaceNotFoundException;
+import com.init.domainpack.domain.model.DomainPackVersion;
+import com.init.domainpack.domain.model.PolicyDefinition;
+import com.init.domainpack.domain.model.WorkspaceMemberRole;
+import com.init.domainpack.domain.repository.DomainPackVersionRepository;
+import com.init.domainpack.domain.repository.PolicyDefinitionRepository;
+import com.init.domainpack.domain.repository.WorkspaceExistencePort;
+import com.init.domainpack.domain.repository.WorkspaceMembershipPort;
+import com.init.shared.application.exception.BadRequestException;
+import com.init.shared.application.exception.NotFoundException;
+import java.util.Set;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class UpdatePolicyStatusUseCase {
+
+  private static final Set<WorkspaceMemberRole> ALLOWED_ROLES =
+      Set.of(WorkspaceMemberRole.OPERATOR, WorkspaceMemberRole.ADMIN);
+
+  private final PolicyDefinitionRepository policyRepository;
+  private final DomainPackVersionRepository versionRepository;
+  private final WorkspaceExistencePort workspaceExistencePort;
+  private final WorkspaceMembershipPort workspaceMembershipPort;
+
+  public UpdatePolicyStatusUseCase(
+      PolicyDefinitionRepository policyRepository,
+      DomainPackVersionRepository versionRepository,
+      WorkspaceExistencePort workspaceExistencePort,
+      WorkspaceMembershipPort workspaceMembershipPort) {
+    this.policyRepository = policyRepository;
+    this.versionRepository = versionRepository;
+    this.workspaceExistencePort = workspaceExistencePort;
+    this.workspaceMembershipPort = workspaceMembershipPort;
+  }
+
+  @Transactional
+  public PolicyDefinitionResponse execute(UpdatePolicyStatusCommand command) {
+    if (!workspaceExistencePort.existsById(command.workspaceId())) {
+      throw new DomainPackWorkspaceNotFoundException(
+          "워크스페이스를 찾을 수 없습니다. id=" + command.workspaceId());
+    }
+
+    if (!workspaceMembershipPort.hasAnyRole(
+        command.workspaceId(), command.requesterId(), ALLOWED_ROLES)) {
+      throw new DomainPackUnauthorizedWorkspaceAccessException(
+          "워크스페이스에 접근 권한이 없습니다. workspaceId=" + command.workspaceId());
+    }
+
+    DomainPackVersion version =
+        versionRepository
+            .findById(command.versionId())
+            .orElseThrow(
+                () -> new NotFoundException("NOT_FOUND", "버전을 찾을 수 없습니다: " + command.versionId()));
+
+    if (!version.getDomainPackId().equals(command.packId())) {
+      throw new NotFoundException("NOT_FOUND", "버전을 찾을 수 없습니다: " + command.versionId());
+    }
+
+    if (!DomainPackVersion.STATUS_DRAFT.equals(version.getLifecycleStatus())) {
+      throw new BadRequestException("POLICY_NOT_EDITABLE", "DRAFT 상태의 버전에서만 정책을 수정할 수 있습니다.");
+    }
+
+    PolicyDefinition policy =
+        policyRepository
+            .findById(command.policyId())
+            .orElseThrow(
+                () -> new NotFoundException("NOT_FOUND", "정책을 찾을 수 없습니다: " + command.policyId()));
+
+    if (!policy.getDomainPackVersionId().equals(command.versionId())) {
+      throw new NotFoundException("NOT_FOUND", "정책을 찾을 수 없습니다: " + command.policyId());
+    }
+
+    try {
+      policy.changeStatus(command.status());
+    } catch (IllegalArgumentException e) {
+      throw new BadRequestException("VALIDATION_ERROR", e.getMessage());
+    }
+
+    policyRepository.save(policy);
+    return PolicyDefinitionResponse.from(policy);
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/application/UpdatePolicyStatusUseCase.java
+++ b/backend/src/main/java/com/init/domainpack/application/UpdatePolicyStatusUseCase.java
@@ -1,17 +1,11 @@
 package com.init.domainpack.application;
 
-import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
-import com.init.domainpack.application.exception.DomainPackWorkspaceNotFoundException;
 import com.init.domainpack.domain.model.DomainPackVersion;
 import com.init.domainpack.domain.model.PolicyDefinition;
-import com.init.domainpack.domain.model.WorkspaceMemberRole;
 import com.init.domainpack.domain.repository.DomainPackVersionRepository;
 import com.init.domainpack.domain.repository.PolicyDefinitionRepository;
-import com.init.domainpack.domain.repository.WorkspaceExistencePort;
-import com.init.domainpack.domain.repository.WorkspaceMembershipPort;
 import com.init.shared.application.exception.BadRequestException;
 import com.init.shared.application.exception.NotFoundException;
-import java.util.Set;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,37 +13,23 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class UpdatePolicyStatusUseCase {
 
-  private static final Set<WorkspaceMemberRole> ALLOWED_ROLES =
-      Set.of(WorkspaceMemberRole.OPERATOR, WorkspaceMemberRole.ADMIN);
-
+  private final DomainPackValidator validator;
   private final PolicyDefinitionRepository policyRepository;
   private final DomainPackVersionRepository versionRepository;
-  private final WorkspaceExistencePort workspaceExistencePort;
-  private final WorkspaceMembershipPort workspaceMembershipPort;
 
   public UpdatePolicyStatusUseCase(
+      DomainPackValidator validator,
       PolicyDefinitionRepository policyRepository,
-      DomainPackVersionRepository versionRepository,
-      WorkspaceExistencePort workspaceExistencePort,
-      WorkspaceMembershipPort workspaceMembershipPort) {
+      DomainPackVersionRepository versionRepository) {
+    this.validator = validator;
     this.policyRepository = policyRepository;
     this.versionRepository = versionRepository;
-    this.workspaceExistencePort = workspaceExistencePort;
-    this.workspaceMembershipPort = workspaceMembershipPort;
   }
 
   @Transactional
   public PolicyDefinitionResponse execute(UpdatePolicyStatusCommand command) {
-    if (!workspaceExistencePort.existsById(command.workspaceId())) {
-      throw new DomainPackWorkspaceNotFoundException(
-          "워크스페이스를 찾을 수 없습니다. id=" + command.workspaceId());
-    }
-
-    if (!workspaceMembershipPort.hasAnyRole(
-        command.workspaceId(), command.requesterId(), ALLOWED_ROLES)) {
-      throw new DomainPackUnauthorizedWorkspaceAccessException(
-          "워크스페이스에 접근 권한이 없습니다. workspaceId=" + command.workspaceId());
-    }
+    validator.validateWorkspaceAccess(command.workspaceId(), command.requesterId());
+    validator.validateDomainPack(command.packId(), command.workspaceId());
 
     DomainPackVersion version =
         versionRepository

--- a/backend/src/main/java/com/init/domainpack/application/UpdatePolicyUseCase.java
+++ b/backend/src/main/java/com/init/domainpack/application/UpdatePolicyUseCase.java
@@ -1,0 +1,94 @@
+package com.init.domainpack.application;
+
+import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
+import com.init.domainpack.application.exception.DomainPackWorkspaceNotFoundException;
+import com.init.domainpack.domain.model.DomainPackVersion;
+import com.init.domainpack.domain.model.PolicyDefinition;
+import com.init.domainpack.domain.model.WorkspaceMemberRole;
+import com.init.domainpack.domain.repository.DomainPackVersionRepository;
+import com.init.domainpack.domain.repository.PolicyDefinitionRepository;
+import com.init.domainpack.domain.repository.WorkspaceExistencePort;
+import com.init.domainpack.domain.repository.WorkspaceMembershipPort;
+import com.init.shared.application.exception.BadRequestException;
+import com.init.shared.application.exception.NotFoundException;
+import java.util.Set;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class UpdatePolicyUseCase {
+
+  private static final Set<WorkspaceMemberRole> ALLOWED_ROLES =
+      Set.of(WorkspaceMemberRole.OPERATOR, WorkspaceMemberRole.ADMIN);
+
+  private final PolicyDefinitionRepository policyRepository;
+  private final DomainPackVersionRepository versionRepository;
+  private final WorkspaceExistencePort workspaceExistencePort;
+  private final WorkspaceMembershipPort workspaceMembershipPort;
+
+  public UpdatePolicyUseCase(
+      PolicyDefinitionRepository policyRepository,
+      DomainPackVersionRepository versionRepository,
+      WorkspaceExistencePort workspaceExistencePort,
+      WorkspaceMembershipPort workspaceMembershipPort) {
+    this.policyRepository = policyRepository;
+    this.versionRepository = versionRepository;
+    this.workspaceExistencePort = workspaceExistencePort;
+    this.workspaceMembershipPort = workspaceMembershipPort;
+  }
+
+  @Transactional
+  public PolicyDefinitionResponse execute(UpdatePolicyCommand command) {
+    if (!workspaceExistencePort.existsById(command.workspaceId())) {
+      throw new DomainPackWorkspaceNotFoundException(
+          "워크스페이스를 찾을 수 없습니다. id=" + command.workspaceId());
+    }
+
+    if (!workspaceMembershipPort.hasAnyRole(
+        command.workspaceId(), command.requesterId(), ALLOWED_ROLES)) {
+      throw new DomainPackUnauthorizedWorkspaceAccessException(
+          "워크스페이스에 접근 권한이 없습니다. workspaceId=" + command.workspaceId());
+    }
+
+    DomainPackVersion version =
+        versionRepository
+            .findById(command.versionId())
+            .orElseThrow(
+                () -> new NotFoundException("NOT_FOUND", "버전을 찾을 수 없습니다: " + command.versionId()));
+
+    if (!version.getDomainPackId().equals(command.packId())) {
+      throw new NotFoundException("NOT_FOUND", "버전을 찾을 수 없습니다: " + command.versionId());
+    }
+
+    if (!DomainPackVersion.STATUS_DRAFT.equals(version.getLifecycleStatus())) {
+      throw new BadRequestException("POLICY_NOT_EDITABLE", "DRAFT 상태의 버전에서만 정책을 수정할 수 있습니다.");
+    }
+
+    PolicyDefinition policy =
+        policyRepository
+            .findById(command.policyId())
+            .orElseThrow(
+                () -> new NotFoundException("NOT_FOUND", "정책을 찾을 수 없습니다: " + command.policyId()));
+
+    if (!policy.getDomainPackVersionId().equals(command.versionId())) {
+      throw new NotFoundException("NOT_FOUND", "정책을 찾을 수 없습니다: " + command.policyId());
+    }
+
+    try {
+      policy.updateFields(
+          command.name(),
+          command.description(),
+          command.severity(),
+          command.conditionJson(),
+          command.actionJson(),
+          command.evidenceJson(),
+          command.metaJson());
+    } catch (IllegalArgumentException e) {
+      throw new BadRequestException("VALIDATION_ERROR", e.getMessage());
+    }
+
+    policyRepository.save(policy);
+    return PolicyDefinitionResponse.from(policy);
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/application/UpdatePolicyUseCase.java
+++ b/backend/src/main/java/com/init/domainpack/application/UpdatePolicyUseCase.java
@@ -1,17 +1,11 @@
 package com.init.domainpack.application;
 
-import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
-import com.init.domainpack.application.exception.DomainPackWorkspaceNotFoundException;
 import com.init.domainpack.domain.model.DomainPackVersion;
 import com.init.domainpack.domain.model.PolicyDefinition;
-import com.init.domainpack.domain.model.WorkspaceMemberRole;
 import com.init.domainpack.domain.repository.DomainPackVersionRepository;
 import com.init.domainpack.domain.repository.PolicyDefinitionRepository;
-import com.init.domainpack.domain.repository.WorkspaceExistencePort;
-import com.init.domainpack.domain.repository.WorkspaceMembershipPort;
 import com.init.shared.application.exception.BadRequestException;
 import com.init.shared.application.exception.NotFoundException;
-import java.util.Set;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,37 +13,23 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class UpdatePolicyUseCase {
 
-  private static final Set<WorkspaceMemberRole> ALLOWED_ROLES =
-      Set.of(WorkspaceMemberRole.OPERATOR, WorkspaceMemberRole.ADMIN);
-
+  private final DomainPackValidator validator;
   private final PolicyDefinitionRepository policyRepository;
   private final DomainPackVersionRepository versionRepository;
-  private final WorkspaceExistencePort workspaceExistencePort;
-  private final WorkspaceMembershipPort workspaceMembershipPort;
 
   public UpdatePolicyUseCase(
+      DomainPackValidator validator,
       PolicyDefinitionRepository policyRepository,
-      DomainPackVersionRepository versionRepository,
-      WorkspaceExistencePort workspaceExistencePort,
-      WorkspaceMembershipPort workspaceMembershipPort) {
+      DomainPackVersionRepository versionRepository) {
+    this.validator = validator;
     this.policyRepository = policyRepository;
     this.versionRepository = versionRepository;
-    this.workspaceExistencePort = workspaceExistencePort;
-    this.workspaceMembershipPort = workspaceMembershipPort;
   }
 
   @Transactional
   public PolicyDefinitionResponse execute(UpdatePolicyCommand command) {
-    if (!workspaceExistencePort.existsById(command.workspaceId())) {
-      throw new DomainPackWorkspaceNotFoundException(
-          "워크스페이스를 찾을 수 없습니다. id=" + command.workspaceId());
-    }
-
-    if (!workspaceMembershipPort.hasAnyRole(
-        command.workspaceId(), command.requesterId(), ALLOWED_ROLES)) {
-      throw new DomainPackUnauthorizedWorkspaceAccessException(
-          "워크스페이스에 접근 권한이 없습니다. workspaceId=" + command.workspaceId());
-    }
+    validator.validateWorkspaceAccess(command.workspaceId(), command.requesterId());
+    validator.validateDomainPack(command.packId(), command.workspaceId());
 
     DomainPackVersion version =
         versionRepository

--- a/backend/src/main/java/com/init/domainpack/domain/model/PolicyDefinition.java
+++ b/backend/src/main/java/com/init/domainpack/domain/model/PolicyDefinition.java
@@ -15,6 +15,9 @@ import java.util.Objects;
 @Table(name = "policy_definition", schema = "pack")
 public class PolicyDefinition {
 
+  public static final String STATUS_ACTIVE = "ACTIVE";
+  public static final String STATUS_INACTIVE = "INACTIVE";
+
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
@@ -45,6 +48,9 @@ public class PolicyDefinition {
 
   @Column(name = "meta_json", columnDefinition = "jsonb", nullable = false)
   private String metaJson;
+
+  @Column(name = "status", nullable = false)
+  private String status;
 
   @Column(name = "created_at", nullable = false, updatable = false)
   private OffsetDateTime createdAt;
@@ -90,7 +96,36 @@ public class PolicyDefinition {
     entity.actionJson = actionJson != null ? actionJson : "{}";
     entity.evidenceJson = evidenceJson != null ? evidenceJson : "[]";
     entity.metaJson = metaJson != null ? metaJson : "{}";
+    entity.status = STATUS_ACTIVE;
     return entity;
+  }
+
+  public void updateFields(
+      String name,
+      String description,
+      String severity,
+      String conditionJson,
+      String actionJson,
+      String evidenceJson,
+      String metaJson) {
+    Objects.requireNonNull(name, "name must not be null");
+    if (name.isBlank()) {
+      throw new IllegalArgumentException("name은 비워둘 수 없습니다.");
+    }
+    this.name = name;
+    if (description != null) this.description = description;
+    if (severity != null) this.severity = severity;
+    if (conditionJson != null) this.conditionJson = conditionJson;
+    if (actionJson != null) this.actionJson = actionJson;
+    if (evidenceJson != null) this.evidenceJson = evidenceJson;
+    if (metaJson != null) this.metaJson = metaJson;
+  }
+
+  public void changeStatus(String newStatus) {
+    if (!STATUS_ACTIVE.equals(newStatus) && !STATUS_INACTIVE.equals(newStatus)) {
+      throw new IllegalArgumentException("허용되지 않는 status 값입니다: " + newStatus);
+    }
+    this.status = newStatus;
   }
 
   public Long getId() {
@@ -131,5 +166,17 @@ public class PolicyDefinition {
 
   public String getMetaJson() {
     return metaJson;
+  }
+
+  public String getStatus() {
+    return status;
+  }
+
+  public OffsetDateTime getCreatedAt() {
+    return createdAt;
+  }
+
+  public OffsetDateTime getUpdatedAt() {
+    return updatedAt;
   }
 }

--- a/backend/src/main/java/com/init/domainpack/domain/repository/PolicyDefinitionRepository.java
+++ b/backend/src/main/java/com/init/domainpack/domain/repository/PolicyDefinitionRepository.java
@@ -2,8 +2,13 @@ package com.init.domainpack.domain.repository;
 
 import com.init.domainpack.domain.model.PolicyDefinition;
 import java.util.List;
+import java.util.Optional;
 
 public interface PolicyDefinitionRepository {
 
   <S extends PolicyDefinition> List<S> saveAll(Iterable<S> entities);
+
+  Optional<PolicyDefinition> findById(Long id);
+
+  PolicyDefinition save(PolicyDefinition policy);
 }

--- a/backend/src/main/java/com/init/domainpack/presentation/UpdatePolicyController.java
+++ b/backend/src/main/java/com/init/domainpack/presentation/UpdatePolicyController.java
@@ -1,0 +1,53 @@
+package com.init.domainpack.presentation;
+
+import com.init.domainpack.application.PolicyDefinitionResponse;
+import com.init.domainpack.application.UpdatePolicyCommand;
+import com.init.domainpack.application.UpdatePolicyUseCase;
+import com.init.domainpack.presentation.dto.UpdatePolicyRequest;
+import com.init.shared.presentation.AuthenticationUtils;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(
+    "/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/policies/{policyId}")
+public class UpdatePolicyController {
+
+  private final UpdatePolicyUseCase useCase;
+
+  public UpdatePolicyController(UpdatePolicyUseCase useCase) {
+    this.useCase = useCase;
+  }
+
+  @PatchMapping
+  public ResponseEntity<PolicyDefinitionResponse> updatePolicy(
+      @PathVariable Long workspaceId,
+      @PathVariable Long packId,
+      @PathVariable Long versionId,
+      @PathVariable Long policyId,
+      @Valid @RequestBody UpdatePolicyRequest request,
+      Authentication authentication) {
+    Long userId = AuthenticationUtils.getUserId(authentication);
+    UpdatePolicyCommand command =
+        new UpdatePolicyCommand(
+            workspaceId,
+            packId,
+            versionId,
+            policyId,
+            userId,
+            request.name(),
+            request.description(),
+            request.severity(),
+            request.conditionJson(),
+            request.actionJson(),
+            request.evidenceJson(),
+            request.metaJson());
+    return ResponseEntity.ok(useCase.execute(command));
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/presentation/UpdatePolicyStatusController.java
+++ b/backend/src/main/java/com/init/domainpack/presentation/UpdatePolicyStatusController.java
@@ -1,0 +1,42 @@
+package com.init.domainpack.presentation;
+
+import com.init.domainpack.application.PolicyDefinitionResponse;
+import com.init.domainpack.application.UpdatePolicyStatusCommand;
+import com.init.domainpack.application.UpdatePolicyStatusUseCase;
+import com.init.domainpack.presentation.dto.UpdatePolicyStatusRequest;
+import com.init.shared.presentation.AuthenticationUtils;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(
+    "/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/policies/{policyId}")
+public class UpdatePolicyStatusController {
+
+  private final UpdatePolicyStatusUseCase useCase;
+
+  public UpdatePolicyStatusController(UpdatePolicyStatusUseCase useCase) {
+    this.useCase = useCase;
+  }
+
+  @PatchMapping("/status")
+  public ResponseEntity<PolicyDefinitionResponse> updatePolicyStatus(
+      @PathVariable Long workspaceId,
+      @PathVariable Long packId,
+      @PathVariable Long versionId,
+      @PathVariable Long policyId,
+      @Valid @RequestBody UpdatePolicyStatusRequest request,
+      Authentication authentication) {
+    Long userId = AuthenticationUtils.getUserId(authentication);
+    UpdatePolicyStatusCommand command =
+        new UpdatePolicyStatusCommand(
+            workspaceId, packId, versionId, policyId, userId, request.status());
+    return ResponseEntity.ok(useCase.execute(command));
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/presentation/dto/UpdatePolicyRequest.java
+++ b/backend/src/main/java/com/init/domainpack/presentation/dto/UpdatePolicyRequest.java
@@ -1,0 +1,12 @@
+package com.init.domainpack.presentation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UpdatePolicyRequest(
+    @NotBlank(message = "name은 필수 항목입니다.") String name,
+    String description,
+    String severity,
+    String conditionJson,
+    String actionJson,
+    String evidenceJson,
+    String metaJson) {}

--- a/backend/src/main/java/com/init/domainpack/presentation/dto/UpdatePolicyStatusRequest.java
+++ b/backend/src/main/java/com/init/domainpack/presentation/dto/UpdatePolicyStatusRequest.java
@@ -1,0 +1,5 @@
+package com.init.domainpack.presentation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UpdatePolicyStatusRequest(@NotBlank(message = "status는 필수 항목입니다.") String status) {}

--- a/backend/src/main/resources/db/changelog/db.changelog-master.sql
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.sql
@@ -709,3 +709,9 @@ SELECT setval('runtime.chat_session_id_seq', (SELECT COALESCE(MAX(id), 1) FROM r
 ALTER TABLE pack.slot_definition
     ADD COLUMN status VARCHAR(50) NOT NULL DEFAULT 'ACTIVE',
     ADD CONSTRAINT chk_slot_definition_status CHECK (status IN ('ACTIVE', 'INACTIVE'));
+
+--changeset devjhan:20260416-add-status-to-policy-definition
+--comment: Add status column to pack.policy_definition for policy lifecycle management (ACTIVE/INACTIVE)
+ALTER TABLE pack.policy_definition
+    ADD COLUMN status VARCHAR(50) NOT NULL DEFAULT 'ACTIVE',
+    ADD CONSTRAINT chk_policy_definition_status CHECK (status IN ('ACTIVE', 'INACTIVE'));

--- a/backend/src/test/java/com/init/domainpack/application/UpdatePolicyStatusUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/UpdatePolicyStatusUseCaseTest.java
@@ -1,0 +1,228 @@
+package com.init.domainpack.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
+import com.init.domainpack.application.exception.DomainPackWorkspaceNotFoundException;
+import com.init.domainpack.domain.model.DomainPackVersion;
+import com.init.domainpack.domain.model.PolicyDefinition;
+import com.init.domainpack.domain.repository.DomainPackVersionRepository;
+import com.init.domainpack.domain.repository.PolicyDefinitionRepository;
+import com.init.domainpack.domain.repository.WorkspaceExistencePort;
+import com.init.domainpack.domain.repository.WorkspaceMembershipPort;
+import com.init.shared.application.exception.BadRequestException;
+import com.init.shared.application.exception.NotFoundException;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UpdatePolicyStatusUseCase")
+class UpdatePolicyStatusUseCaseTest {
+
+  @Mock private PolicyDefinitionRepository policyRepository;
+  @Mock private DomainPackVersionRepository versionRepository;
+  @Mock private WorkspaceExistencePort workspaceExistencePort;
+  @Mock private WorkspaceMembershipPort workspaceMembershipPort;
+
+  private UpdatePolicyStatusUseCase useCase;
+
+  @BeforeEach
+  void setUp() {
+    useCase =
+        new UpdatePolicyStatusUseCase(
+            policyRepository, versionRepository, workspaceExistencePort, workspaceMembershipPort);
+  }
+
+  @Test
+  @DisplayName("정상 전환: ACTIVE → INACTIVE")
+  void should_INACTIVE전환성공_when_DRAFT버전정책() {
+    given(workspaceExistencePort.existsById(1L)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(versionRepository.findById(10L)).willReturn(Optional.of(draftVersion(10L, 7L)));
+
+    PolicyDefinition policy = policy(55L, 10L);
+    given(policyRepository.findById(55L)).willReturn(Optional.of(policy));
+    given(policyRepository.save(any())).willReturn(policy);
+
+    UpdatePolicyStatusCommand command =
+        new UpdatePolicyStatusCommand(1L, 7L, 10L, 55L, 5L, PolicyDefinition.STATUS_INACTIVE);
+
+    PolicyDefinitionResponse result = useCase.execute(command);
+
+    assertThat(result.status()).isEqualTo(PolicyDefinition.STATUS_INACTIVE);
+  }
+
+  @Test
+  @DisplayName("정상 전환: INACTIVE → ACTIVE")
+  void should_ACTIVE전환성공_when_INACTIVE정책() {
+    given(workspaceExistencePort.existsById(1L)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(versionRepository.findById(10L)).willReturn(Optional.of(draftVersion(10L, 7L)));
+
+    PolicyDefinition policy = policy(55L, 10L);
+    ReflectionTestUtils.setField(policy, "status", PolicyDefinition.STATUS_INACTIVE);
+    given(policyRepository.findById(55L)).willReturn(Optional.of(policy));
+    given(policyRepository.save(any())).willReturn(policy);
+
+    UpdatePolicyStatusCommand command =
+        new UpdatePolicyStatusCommand(1L, 7L, 10L, 55L, 5L, PolicyDefinition.STATUS_ACTIVE);
+
+    PolicyDefinitionResponse result = useCase.execute(command);
+
+    assertThat(result.status()).isEqualTo(PolicyDefinition.STATUS_ACTIVE);
+  }
+
+  @Test
+  @DisplayName("허용되지 않는 status 값 → BadRequestException(VALIDATION_ERROR)")
+  void should_VALIDATION_ERROR예외_when_잘못된status() {
+    given(workspaceExistencePort.existsById(1L)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(versionRepository.findById(10L)).willReturn(Optional.of(draftVersion(10L, 7L)));
+
+    PolicyDefinition policy = policy(55L, 10L);
+    given(policyRepository.findById(55L)).willReturn(Optional.of(policy));
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(new UpdatePolicyStatusCommand(1L, 7L, 10L, 55L, 5L, "DEPRECATED")))
+        .isInstanceOf(BadRequestException.class);
+  }
+
+  @Test
+  @DisplayName("PUBLISHED 버전 → BadRequestException(POLICY_NOT_EDITABLE)")
+  void should_POLICY_NOT_EDITABLE예외_when_PUBLISHED버전() {
+    given(workspaceExistencePort.existsById(1L)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(versionRepository.findById(10L)).willReturn(Optional.of(publishedVersion(10L, 7L)));
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdatePolicyStatusCommand(
+                        1L, 7L, 10L, 55L, 5L, PolicyDefinition.STATUS_INACTIVE)))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("DRAFT");
+  }
+
+  @Test
+  @DisplayName("정책의 versionId 불일치 → NotFoundException")
+  void should_정책없음예외_when_versionId불일치() {
+    given(workspaceExistencePort.existsById(1L)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(versionRepository.findById(10L)).willReturn(Optional.of(draftVersion(10L, 7L)));
+
+    PolicyDefinition policy = policy(55L, 999L);
+    given(policyRepository.findById(55L)).willReturn(Optional.of(policy));
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdatePolicyStatusCommand(
+                        1L, 7L, 10L, 55L, 5L, PolicyDefinition.STATUS_INACTIVE)))
+        .isInstanceOf(NotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("workspace 없음 → DomainPackWorkspaceNotFoundException")
+  void should_워크스페이스없음예외_when_워크스페이스없음() {
+    given(workspaceExistencePort.existsById(1L)).willReturn(false);
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdatePolicyStatusCommand(
+                        1L, 7L, 10L, 55L, 5L, PolicyDefinition.STATUS_INACTIVE)))
+        .isInstanceOf(DomainPackWorkspaceNotFoundException.class);
+
+    verify(versionRepository, never()).findById(any());
+  }
+
+  @Test
+  @DisplayName("workspace 비멤버 → DomainPackUnauthorizedWorkspaceAccessException")
+  void should_권한없음예외_when_비멤버() {
+    given(workspaceExistencePort.existsById(1L)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(false);
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdatePolicyStatusCommand(
+                        1L, 7L, 10L, 55L, 5L, PolicyDefinition.STATUS_INACTIVE)))
+        .isInstanceOf(DomainPackUnauthorizedWorkspaceAccessException.class);
+
+    verify(versionRepository, never()).findById(any());
+  }
+
+  @Test
+  @DisplayName("버전 미존재 → NotFoundException")
+  void should_버전없음예외_when_버전미존재() {
+    given(workspaceExistencePort.existsById(1L)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(versionRepository.findById(10L)).willReturn(Optional.empty());
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdatePolicyStatusCommand(
+                        1L, 7L, 10L, 55L, 5L, PolicyDefinition.STATUS_INACTIVE)))
+        .isInstanceOf(NotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("packId 불일치 → NotFoundException")
+  void should_버전없음예외_when_packId불일치() {
+    given(workspaceExistencePort.existsById(1L)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(versionRepository.findById(10L)).willReturn(Optional.of(draftVersion(10L, 99L)));
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdatePolicyStatusCommand(
+                        1L, 7L, 10L, 55L, 5L, PolicyDefinition.STATUS_INACTIVE)))
+        .isInstanceOf(NotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("정책 미존재 → NotFoundException")
+  void should_정책없음예외_when_정책미존재() {
+    given(workspaceExistencePort.existsById(1L)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(versionRepository.findById(10L)).willReturn(Optional.of(draftVersion(10L, 7L)));
+    given(policyRepository.findById(55L)).willReturn(Optional.empty());
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdatePolicyStatusCommand(
+                        1L, 7L, 10L, 55L, 5L, PolicyDefinition.STATUS_INACTIVE)))
+        .isInstanceOf(NotFoundException.class);
+  }
+
+  private DomainPackVersion draftVersion(Long id, Long domainPackId) {
+    return DomainPackVersion.ofForTest(id, domainPackId, DomainPackVersion.STATUS_DRAFT);
+  }
+
+  private DomainPackVersion publishedVersion(Long id, Long domainPackId) {
+    return DomainPackVersion.ofForTest(id, domainPackId, DomainPackVersion.STATUS_PUBLISHED);
+  }
+
+  private PolicyDefinition policy(Long id, Long versionId) {
+    PolicyDefinition policy =
+        PolicyDefinition.create(
+            versionId, "refund_check", "환불 검증", "설명", "MEDIUM", "{}", "{}", "[]", "{}");
+    ReflectionTestUtils.setField(policy, "id", id);
+    return policy;
+  }
+}

--- a/backend/src/test/java/com/init/domainpack/application/UpdatePolicyStatusUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/UpdatePolicyStatusUseCaseTest.java
@@ -7,14 +7,13 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
+import com.init.domainpack.application.exception.DomainPackNotFoundException;
 import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
 import com.init.domainpack.application.exception.DomainPackWorkspaceNotFoundException;
 import com.init.domainpack.domain.model.DomainPackVersion;
 import com.init.domainpack.domain.model.PolicyDefinition;
 import com.init.domainpack.domain.repository.DomainPackVersionRepository;
 import com.init.domainpack.domain.repository.PolicyDefinitionRepository;
-import com.init.domainpack.domain.repository.WorkspaceExistencePort;
-import com.init.domainpack.domain.repository.WorkspaceMembershipPort;
 import com.init.shared.application.exception.BadRequestException;
 import com.init.shared.application.exception.NotFoundException;
 import java.util.Optional;
@@ -30,25 +29,20 @@ import org.springframework.test.util.ReflectionTestUtils;
 @DisplayName("UpdatePolicyStatusUseCase")
 class UpdatePolicyStatusUseCaseTest {
 
+  @Mock private DomainPackValidator validator;
   @Mock private PolicyDefinitionRepository policyRepository;
   @Mock private DomainPackVersionRepository versionRepository;
-  @Mock private WorkspaceExistencePort workspaceExistencePort;
-  @Mock private WorkspaceMembershipPort workspaceMembershipPort;
 
   private UpdatePolicyStatusUseCase useCase;
 
   @BeforeEach
   void setUp() {
-    useCase =
-        new UpdatePolicyStatusUseCase(
-            policyRepository, versionRepository, workspaceExistencePort, workspaceMembershipPort);
+    useCase = new UpdatePolicyStatusUseCase(validator, policyRepository, versionRepository);
   }
 
   @Test
   @DisplayName("정상 전환: ACTIVE → INACTIVE")
   void should_INACTIVE전환성공_when_DRAFT버전정책() {
-    given(workspaceExistencePort.existsById(1L)).willReturn(true);
-    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
     given(versionRepository.findById(10L)).willReturn(Optional.of(draftVersion(10L, 7L)));
 
     PolicyDefinition policy = policy(55L, 10L);
@@ -66,8 +60,6 @@ class UpdatePolicyStatusUseCaseTest {
   @Test
   @DisplayName("정상 전환: INACTIVE → ACTIVE")
   void should_ACTIVE전환성공_when_INACTIVE정책() {
-    given(workspaceExistencePort.existsById(1L)).willReturn(true);
-    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
     given(versionRepository.findById(10L)).willReturn(Optional.of(draftVersion(10L, 7L)));
 
     PolicyDefinition policy = policy(55L, 10L);
@@ -86,8 +78,6 @@ class UpdatePolicyStatusUseCaseTest {
   @Test
   @DisplayName("허용되지 않는 status 값 → BadRequestException(VALIDATION_ERROR)")
   void should_VALIDATION_ERROR예외_when_잘못된status() {
-    given(workspaceExistencePort.existsById(1L)).willReturn(true);
-    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
     given(versionRepository.findById(10L)).willReturn(Optional.of(draftVersion(10L, 7L)));
 
     PolicyDefinition policy = policy(55L, 10L);
@@ -102,8 +92,6 @@ class UpdatePolicyStatusUseCaseTest {
   @Test
   @DisplayName("PUBLISHED 버전 → BadRequestException(POLICY_NOT_EDITABLE)")
   void should_POLICY_NOT_EDITABLE예외_when_PUBLISHED버전() {
-    given(workspaceExistencePort.existsById(1L)).willReturn(true);
-    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
     given(versionRepository.findById(10L)).willReturn(Optional.of(publishedVersion(10L, 7L)));
 
     assertThatThrownBy(
@@ -118,8 +106,6 @@ class UpdatePolicyStatusUseCaseTest {
   @Test
   @DisplayName("정책의 versionId 불일치 → NotFoundException")
   void should_정책없음예외_when_versionId불일치() {
-    given(workspaceExistencePort.existsById(1L)).willReturn(true);
-    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
     given(versionRepository.findById(10L)).willReturn(Optional.of(draftVersion(10L, 7L)));
 
     PolicyDefinition policy = policy(55L, 999L);
@@ -136,7 +122,9 @@ class UpdatePolicyStatusUseCaseTest {
   @Test
   @DisplayName("workspace 없음 → DomainPackWorkspaceNotFoundException")
   void should_워크스페이스없음예외_when_워크스페이스없음() {
-    given(workspaceExistencePort.existsById(1L)).willReturn(false);
+    org.mockito.Mockito.doThrow(new DomainPackWorkspaceNotFoundException("워크스페이스를 찾을 수 없습니다. id=1"))
+        .when(validator)
+        .validateWorkspaceAccess(1L, 5L);
 
     assertThatThrownBy(
             () ->
@@ -151,8 +139,10 @@ class UpdatePolicyStatusUseCaseTest {
   @Test
   @DisplayName("workspace 비멤버 → DomainPackUnauthorizedWorkspaceAccessException")
   void should_권한없음예외_when_비멤버() {
-    given(workspaceExistencePort.existsById(1L)).willReturn(true);
-    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(false);
+    org.mockito.Mockito.doThrow(
+            new DomainPackUnauthorizedWorkspaceAccessException("워크스페이스에 접근 권한이 없습니다."))
+        .when(validator)
+        .validateWorkspaceAccess(1L, 5L);
 
     assertThatThrownBy(
             () ->
@@ -165,10 +155,26 @@ class UpdatePolicyStatusUseCaseTest {
   }
 
   @Test
+  @DisplayName("pack이 다른 workspace에 속함 → DomainPackNotFoundException")
+  void should_도메인팩없음예외_when_workspace경계위반() {
+    org.mockito.Mockito.doThrow(new DomainPackNotFoundException(7L))
+        .when(validator)
+        .validateDomainPack(7L, 1L);
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdatePolicyStatusCommand(
+                        1L, 7L, 10L, 55L, 5L, PolicyDefinition.STATUS_INACTIVE)))
+        .isInstanceOf(DomainPackNotFoundException.class);
+
+    verify(versionRepository, never()).findById(any());
+    verify(policyRepository, never()).save(any());
+  }
+
+  @Test
   @DisplayName("버전 미존재 → NotFoundException")
   void should_버전없음예외_when_버전미존재() {
-    given(workspaceExistencePort.existsById(1L)).willReturn(true);
-    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
     given(versionRepository.findById(10L)).willReturn(Optional.empty());
 
     assertThatThrownBy(
@@ -182,8 +188,6 @@ class UpdatePolicyStatusUseCaseTest {
   @Test
   @DisplayName("packId 불일치 → NotFoundException")
   void should_버전없음예외_when_packId불일치() {
-    given(workspaceExistencePort.existsById(1L)).willReturn(true);
-    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
     given(versionRepository.findById(10L)).willReturn(Optional.of(draftVersion(10L, 99L)));
 
     assertThatThrownBy(
@@ -197,8 +201,6 @@ class UpdatePolicyStatusUseCaseTest {
   @Test
   @DisplayName("정책 미존재 → NotFoundException")
   void should_정책없음예외_when_정책미존재() {
-    given(workspaceExistencePort.existsById(1L)).willReturn(true);
-    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
     given(versionRepository.findById(10L)).willReturn(Optional.of(draftVersion(10L, 7L)));
     given(policyRepository.findById(55L)).willReturn(Optional.empty());
 

--- a/backend/src/test/java/com/init/domainpack/application/UpdatePolicyStatusUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/UpdatePolicyStatusUseCaseTest.java
@@ -55,6 +55,7 @@ class UpdatePolicyStatusUseCaseTest {
     PolicyDefinitionResponse result = useCase.execute(command);
 
     assertThat(result.status()).isEqualTo(PolicyDefinition.STATUS_INACTIVE);
+    verify(policyRepository).save(policy);
   }
 
   @Test
@@ -73,6 +74,7 @@ class UpdatePolicyStatusUseCaseTest {
     PolicyDefinitionResponse result = useCase.execute(command);
 
     assertThat(result.status()).isEqualTo(PolicyDefinition.STATUS_ACTIVE);
+    verify(policyRepository).save(policy);
   }
 
   @Test

--- a/backend/src/test/java/com/init/domainpack/application/UpdatePolicyUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/UpdatePolicyUseCaseTest.java
@@ -7,14 +7,13 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
+import com.init.domainpack.application.exception.DomainPackNotFoundException;
 import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
 import com.init.domainpack.application.exception.DomainPackWorkspaceNotFoundException;
 import com.init.domainpack.domain.model.DomainPackVersion;
 import com.init.domainpack.domain.model.PolicyDefinition;
 import com.init.domainpack.domain.repository.DomainPackVersionRepository;
 import com.init.domainpack.domain.repository.PolicyDefinitionRepository;
-import com.init.domainpack.domain.repository.WorkspaceExistencePort;
-import com.init.domainpack.domain.repository.WorkspaceMembershipPort;
 import com.init.shared.application.exception.BadRequestException;
 import com.init.shared.application.exception.NotFoundException;
 import java.util.Optional;
@@ -30,25 +29,20 @@ import org.springframework.test.util.ReflectionTestUtils;
 @DisplayName("UpdatePolicyUseCase")
 class UpdatePolicyUseCaseTest {
 
+  @Mock private DomainPackValidator validator;
   @Mock private PolicyDefinitionRepository policyRepository;
   @Mock private DomainPackVersionRepository versionRepository;
-  @Mock private WorkspaceExistencePort workspaceExistencePort;
-  @Mock private WorkspaceMembershipPort workspaceMembershipPort;
 
   private UpdatePolicyUseCase useCase;
 
   @BeforeEach
   void setUp() {
-    useCase =
-        new UpdatePolicyUseCase(
-            policyRepository, versionRepository, workspaceExistencePort, workspaceMembershipPort);
+    useCase = new UpdatePolicyUseCase(validator, policyRepository, versionRepository);
   }
 
   @Test
   @DisplayName("정상 수정: DRAFT 버전의 정책 → 200 OK, 수정된 정책 반환")
   void should_수정성공_when_DRAFT버전정책() {
-    given(workspaceExistencePort.existsById(1L)).willReturn(true);
-    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
     given(versionRepository.findById(10L)).willReturn(Optional.of(draftVersion(10L, 7L)));
 
     PolicyDefinition policy = policy(55L, 10L);
@@ -69,7 +63,9 @@ class UpdatePolicyUseCaseTest {
   @Test
   @DisplayName("workspace 없음 → DomainPackWorkspaceNotFoundException")
   void should_워크스페이스없음예외_when_워크스페이스없음() {
-    given(workspaceExistencePort.existsById(1L)).willReturn(false);
+    org.mockito.Mockito.doThrow(new DomainPackWorkspaceNotFoundException("워크스페이스를 찾을 수 없습니다. id=1"))
+        .when(validator)
+        .validateWorkspaceAccess(1L, 5L);
 
     assertThatThrownBy(
             () ->
@@ -85,8 +81,10 @@ class UpdatePolicyUseCaseTest {
   @Test
   @DisplayName("workspace 비멤버 → DomainPackUnauthorizedWorkspaceAccessException")
   void should_권한없음예외_when_비멤버() {
-    given(workspaceExistencePort.existsById(1L)).willReturn(true);
-    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(false);
+    org.mockito.Mockito.doThrow(
+            new DomainPackUnauthorizedWorkspaceAccessException("워크스페이스에 접근 권한이 없습니다."))
+        .when(validator)
+        .validateWorkspaceAccess(1L, 5L);
 
     assertThatThrownBy(
             () ->
@@ -100,10 +98,26 @@ class UpdatePolicyUseCaseTest {
   }
 
   @Test
+  @DisplayName("pack이 다른 workspace에 속함 → DomainPackNotFoundException")
+  void should_도메인팩없음예외_when_workspace경계위반() {
+    org.mockito.Mockito.doThrow(new DomainPackNotFoundException(7L))
+        .when(validator)
+        .validateDomainPack(7L, 1L);
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdatePolicyCommand(
+                        1L, 7L, 10L, 55L, 5L, "정책", null, null, null, null, null, null)))
+        .isInstanceOf(DomainPackNotFoundException.class);
+
+    verify(versionRepository, never()).findById(any());
+    verify(policyRepository, never()).save(any());
+  }
+
+  @Test
   @DisplayName("버전 미존재 → NotFoundException")
   void should_버전없음예외_when_버전미존재() {
-    given(workspaceExistencePort.existsById(1L)).willReturn(true);
-    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
     given(versionRepository.findById(10L)).willReturn(Optional.empty());
 
     assertThatThrownBy(
@@ -119,8 +133,6 @@ class UpdatePolicyUseCaseTest {
   @Test
   @DisplayName("packId 불일치 → NotFoundException")
   void should_버전없음예외_when_packId불일치() {
-    given(workspaceExistencePort.existsById(1L)).willReturn(true);
-    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
     given(versionRepository.findById(10L)).willReturn(Optional.of(draftVersion(10L, 99L)));
 
     assertThatThrownBy(
@@ -136,8 +148,6 @@ class UpdatePolicyUseCaseTest {
   @Test
   @DisplayName("PUBLISHED 버전 → BadRequestException(POLICY_NOT_EDITABLE)")
   void should_POLICY_NOT_EDITABLE예외_when_PUBLISHED버전() {
-    given(workspaceExistencePort.existsById(1L)).willReturn(true);
-    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
     given(versionRepository.findById(10L)).willReturn(Optional.of(publishedVersion(10L, 7L)));
 
     assertThatThrownBy(
@@ -154,8 +164,6 @@ class UpdatePolicyUseCaseTest {
   @Test
   @DisplayName("정책 미존재 → NotFoundException")
   void should_정책없음예외_when_정책미존재() {
-    given(workspaceExistencePort.existsById(1L)).willReturn(true);
-    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
     given(versionRepository.findById(10L)).willReturn(Optional.of(draftVersion(10L, 7L)));
     given(policyRepository.findById(55L)).willReturn(Optional.empty());
 
@@ -172,8 +180,6 @@ class UpdatePolicyUseCaseTest {
   @Test
   @DisplayName("정책의 versionId 불일치 → NotFoundException")
   void should_정책없음예외_when_versionId불일치() {
-    given(workspaceExistencePort.existsById(1L)).willReturn(true);
-    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
     given(versionRepository.findById(10L)).willReturn(Optional.of(draftVersion(10L, 7L)));
 
     PolicyDefinition policy = policy(55L, 999L);

--- a/backend/src/test/java/com/init/domainpack/application/UpdatePolicyUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/UpdatePolicyUseCaseTest.java
@@ -1,0 +1,207 @@
+package com.init.domainpack.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
+import com.init.domainpack.application.exception.DomainPackWorkspaceNotFoundException;
+import com.init.domainpack.domain.model.DomainPackVersion;
+import com.init.domainpack.domain.model.PolicyDefinition;
+import com.init.domainpack.domain.repository.DomainPackVersionRepository;
+import com.init.domainpack.domain.repository.PolicyDefinitionRepository;
+import com.init.domainpack.domain.repository.WorkspaceExistencePort;
+import com.init.domainpack.domain.repository.WorkspaceMembershipPort;
+import com.init.shared.application.exception.BadRequestException;
+import com.init.shared.application.exception.NotFoundException;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UpdatePolicyUseCase")
+class UpdatePolicyUseCaseTest {
+
+  @Mock private PolicyDefinitionRepository policyRepository;
+  @Mock private DomainPackVersionRepository versionRepository;
+  @Mock private WorkspaceExistencePort workspaceExistencePort;
+  @Mock private WorkspaceMembershipPort workspaceMembershipPort;
+
+  private UpdatePolicyUseCase useCase;
+
+  @BeforeEach
+  void setUp() {
+    useCase =
+        new UpdatePolicyUseCase(
+            policyRepository, versionRepository, workspaceExistencePort, workspaceMembershipPort);
+  }
+
+  @Test
+  @DisplayName("정상 수정: DRAFT 버전의 정책 → 200 OK, 수정된 정책 반환")
+  void should_수정성공_when_DRAFT버전정책() {
+    given(workspaceExistencePort.existsById(1L)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(versionRepository.findById(10L)).willReturn(Optional.of(draftVersion(10L, 7L)));
+
+    PolicyDefinition policy = policy(55L, 10L);
+    given(policyRepository.findById(55L)).willReturn(Optional.of(policy));
+    given(policyRepository.save(any())).willReturn(policy);
+
+    UpdatePolicyCommand command =
+        new UpdatePolicyCommand(
+            1L, 7L, 10L, 55L, 5L, "수정된 정책", "설명", "HIGH", "{}", "{}", "[]", "{}");
+
+    PolicyDefinitionResponse result = useCase.execute(command);
+
+    assertThat(result.name()).isEqualTo("수정된 정책");
+    assertThat(result.severity()).isEqualTo("HIGH");
+    verify(policyRepository).save(policy);
+  }
+
+  @Test
+  @DisplayName("workspace 없음 → DomainPackWorkspaceNotFoundException")
+  void should_워크스페이스없음예외_when_워크스페이스없음() {
+    given(workspaceExistencePort.existsById(1L)).willReturn(false);
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdatePolicyCommand(
+                        1L, 7L, 10L, 55L, 5L, "정책", null, null, null, null, null, null)))
+        .isInstanceOf(DomainPackWorkspaceNotFoundException.class);
+
+    verify(versionRepository, never()).findById(any());
+    verify(policyRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("workspace 비멤버 → DomainPackUnauthorizedWorkspaceAccessException")
+  void should_권한없음예외_when_비멤버() {
+    given(workspaceExistencePort.existsById(1L)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(false);
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdatePolicyCommand(
+                        1L, 7L, 10L, 55L, 5L, "정책", null, null, null, null, null, null)))
+        .isInstanceOf(DomainPackUnauthorizedWorkspaceAccessException.class);
+
+    verify(versionRepository, never()).findById(any());
+    verify(policyRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("버전 미존재 → NotFoundException")
+  void should_버전없음예외_when_버전미존재() {
+    given(workspaceExistencePort.existsById(1L)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(versionRepository.findById(10L)).willReturn(Optional.empty());
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdatePolicyCommand(
+                        1L, 7L, 10L, 55L, 5L, "정책", null, null, null, null, null, null)))
+        .isInstanceOf(NotFoundException.class);
+
+    verify(policyRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("packId 불일치 → NotFoundException")
+  void should_버전없음예외_when_packId불일치() {
+    given(workspaceExistencePort.existsById(1L)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(versionRepository.findById(10L)).willReturn(Optional.of(draftVersion(10L, 99L)));
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdatePolicyCommand(
+                        1L, 7L, 10L, 55L, 5L, "정책", null, null, null, null, null, null)))
+        .isInstanceOf(NotFoundException.class);
+
+    verify(policyRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("PUBLISHED 버전 → BadRequestException(POLICY_NOT_EDITABLE)")
+  void should_POLICY_NOT_EDITABLE예외_when_PUBLISHED버전() {
+    given(workspaceExistencePort.existsById(1L)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(versionRepository.findById(10L)).willReturn(Optional.of(publishedVersion(10L, 7L)));
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdatePolicyCommand(
+                        1L, 7L, 10L, 55L, 5L, "정책", null, null, null, null, null, null)))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("DRAFT");
+
+    verify(policyRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("정책 미존재 → NotFoundException")
+  void should_정책없음예외_when_정책미존재() {
+    given(workspaceExistencePort.existsById(1L)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(versionRepository.findById(10L)).willReturn(Optional.of(draftVersion(10L, 7L)));
+    given(policyRepository.findById(55L)).willReturn(Optional.empty());
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdatePolicyCommand(
+                        1L, 7L, 10L, 55L, 5L, "정책", null, null, null, null, null, null)))
+        .isInstanceOf(NotFoundException.class);
+
+    verify(policyRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("정책의 versionId 불일치 → NotFoundException")
+  void should_정책없음예외_when_versionId불일치() {
+    given(workspaceExistencePort.existsById(1L)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(versionRepository.findById(10L)).willReturn(Optional.of(draftVersion(10L, 7L)));
+
+    PolicyDefinition policy = policy(55L, 999L);
+    given(policyRepository.findById(55L)).willReturn(Optional.of(policy));
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdatePolicyCommand(
+                        1L, 7L, 10L, 55L, 5L, "정책", null, null, null, null, null, null)))
+        .isInstanceOf(NotFoundException.class);
+
+    verify(policyRepository, never()).save(any());
+  }
+
+  private DomainPackVersion draftVersion(Long id, Long domainPackId) {
+    return DomainPackVersion.ofForTest(id, domainPackId, DomainPackVersion.STATUS_DRAFT);
+  }
+
+  private DomainPackVersion publishedVersion(Long id, Long domainPackId) {
+    return DomainPackVersion.ofForTest(id, domainPackId, DomainPackVersion.STATUS_PUBLISHED);
+  }
+
+  private PolicyDefinition policy(Long id, Long versionId) {
+    PolicyDefinition policy =
+        PolicyDefinition.create(
+            versionId, "refund_check", "환불 검증", "설명", "MEDIUM", "{}", "{}", "[]", "{}");
+    ReflectionTestUtils.setField(policy, "id", id);
+    return policy;
+  }
+}

--- a/backend/src/test/java/com/init/domainpack/presentation/UpdatePolicyControllerTest.java
+++ b/backend/src/test/java/com/init/domainpack/presentation/UpdatePolicyControllerTest.java
@@ -1,0 +1,188 @@
+package com.init.domainpack.presentation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.init.domainpack.application.PolicyDefinitionResponse;
+import com.init.domainpack.application.UpdatePolicyUseCase;
+import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
+import com.init.domainpack.application.exception.DomainPackWorkspaceNotFoundException;
+import com.init.fixtures.WithLongPrincipal;
+import com.init.shared.application.exception.BadRequestException;
+import com.init.shared.application.exception.NotFoundException;
+import com.init.shared.infrastructure.security.JwtAuthenticationFilter;
+import java.time.OffsetDateTime;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(
+    value = UpdatePolicyController.class,
+    excludeFilters =
+        @ComponentScan.Filter(
+            type = FilterType.ASSIGNABLE_TYPE,
+            classes = JwtAuthenticationFilter.class))
+@DisplayName("UpdatePolicyController")
+class UpdatePolicyControllerTest {
+
+  private static final String BASE_URL =
+      "/api/v1/workspaces/1/domain-packs/7/versions/10/policies/55";
+
+  private final MockMvc mockMvc;
+  private final ObjectMapper objectMapper;
+
+  @MockitoBean private UpdatePolicyUseCase useCase;
+
+  @Autowired
+  UpdatePolicyControllerTest(MockMvc mockMvc, ObjectMapper objectMapper) {
+    this.mockMvc = mockMvc;
+    this.objectMapper = objectMapper;
+  }
+
+  @Test
+  @DisplayName("PATCH /policies/{policyId}: DRAFT 버전 정책 정상 수정 → 200")
+  @WithLongPrincipal(5L)
+  void should_200반환_when_정상수정() throws Exception {
+    given(useCase.execute(any())).willReturn(sampleResponse("ACTIVE"));
+
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    objectMapper.writeValueAsString(
+                        Map.of("name", "환불 정책", "description", "수정 설명"))))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(55))
+        .andExpect(jsonPath("$.name").value("환불 정책"))
+        .andExpect(jsonPath("$.status").value("ACTIVE"));
+  }
+
+  @Test
+  @DisplayName("PATCH /policies/{policyId}: PUBLISHED 버전이면 400 POLICY_NOT_EDITABLE")
+  @WithLongPrincipal(5L)
+  void should_400반환_when_PUBLISHED버전() throws Exception {
+    given(useCase.execute(any()))
+        .willThrow(
+            new BadRequestException("POLICY_NOT_EDITABLE", "DRAFT 상태의 버전에서만 정책을 수정할 수 있습니다."));
+
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of("name", "이름"))))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("POLICY_NOT_EDITABLE"));
+  }
+
+  @Test
+  @DisplayName("PATCH /policies/{policyId}: 정책 미존재 시 404")
+  @WithLongPrincipal(5L)
+  void should_404반환_when_정책미존재() throws Exception {
+    given(useCase.execute(any()))
+        .willThrow(new NotFoundException("NOT_FOUND", "정책을 찾을 수 없습니다: 55"));
+
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of("name", "이름"))))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("NOT_FOUND"));
+  }
+
+  @Test
+  @DisplayName("PATCH /policies/{policyId}: name이 빈 값이면 400 VALIDATION_ERROR")
+  @WithLongPrincipal(5L)
+  void should_400반환_when_nameBlank() throws Exception {
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of("name", ""))))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+
+    verifyNoInteractions(useCase);
+  }
+
+  @Test
+  @DisplayName("PATCH /policies/{policyId}: 워크스페이스 멤버십 없을 때 403")
+  @WithLongPrincipal(5L)
+  void should_403반환_when_비멤버() throws Exception {
+    given(useCase.execute(any()))
+        .willThrow(new DomainPackUnauthorizedWorkspaceAccessException("접근 권한이 없습니다."));
+
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of("name", "이름"))))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @DisplayName("PATCH /policies/{policyId}: 워크스페이스 없을 때 404")
+  @WithLongPrincipal(5L)
+  void should_404반환_when_워크스페이스없음() throws Exception {
+    given(useCase.execute(any()))
+        .willThrow(new DomainPackWorkspaceNotFoundException("워크스페이스를 찾을 수 없습니다. id=1"));
+
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of("name", "이름"))))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  @DisplayName("PATCH /policies/{policyId}: 인증 없는 요청 → 401")
+  void should_401반환_when_인증없음() throws Exception {
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of("name", "이름"))))
+        .andExpect(status().isUnauthorized());
+
+    verifyNoInteractions(useCase);
+  }
+
+  private PolicyDefinitionResponse sampleResponse(String status) {
+    return new PolicyDefinitionResponse(
+        55L,
+        10L,
+        "refund_check",
+        "환불 정책",
+        "수정 설명",
+        "HIGH",
+        "{}",
+        "{}",
+        "[]",
+        "{}",
+        status,
+        OffsetDateTime.parse("2026-04-16T10:00:00Z"),
+        OffsetDateTime.parse("2026-04-16T10:30:00Z"));
+  }
+}

--- a/backend/src/test/java/com/init/domainpack/presentation/UpdatePolicyStatusControllerTest.java
+++ b/backend/src/test/java/com/init/domainpack/presentation/UpdatePolicyStatusControllerTest.java
@@ -1,0 +1,183 @@
+package com.init.domainpack.presentation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.init.domainpack.application.PolicyDefinitionResponse;
+import com.init.domainpack.application.UpdatePolicyStatusUseCase;
+import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
+import com.init.fixtures.WithLongPrincipal;
+import com.init.shared.application.exception.BadRequestException;
+import com.init.shared.application.exception.NotFoundException;
+import com.init.shared.infrastructure.security.JwtAuthenticationFilter;
+import java.time.OffsetDateTime;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(
+    value = UpdatePolicyStatusController.class,
+    excludeFilters =
+        @ComponentScan.Filter(
+            type = FilterType.ASSIGNABLE_TYPE,
+            classes = JwtAuthenticationFilter.class))
+@DisplayName("UpdatePolicyStatusController")
+class UpdatePolicyStatusControllerTest {
+
+  private static final String BASE_URL =
+      "/api/v1/workspaces/1/domain-packs/7/versions/10/policies/55/status";
+
+  private final MockMvc mockMvc;
+  private final ObjectMapper objectMapper;
+
+  @MockitoBean private UpdatePolicyStatusUseCase useCase;
+
+  @Autowired
+  UpdatePolicyStatusControllerTest(MockMvc mockMvc, ObjectMapper objectMapper) {
+    this.mockMvc = mockMvc;
+    this.objectMapper = objectMapper;
+  }
+
+  @Test
+  @DisplayName("PATCH /policies/{policyId}/status: INACTIVE 전환 → 200")
+  @WithLongPrincipal(5L)
+  void should_200반환_when_INACTIVE전환() throws Exception {
+    given(useCase.execute(any())).willReturn(sampleResponse("INACTIVE"));
+
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of("status", "INACTIVE"))))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.status").value("INACTIVE"));
+  }
+
+  @Test
+  @DisplayName("PATCH /policies/{policyId}/status: 허용되지 않는 status 값이면 400")
+  @WithLongPrincipal(5L)
+  void should_400반환_when_잘못된status() throws Exception {
+    given(useCase.execute(any()))
+        .willThrow(new BadRequestException("VALIDATION_ERROR", "허용되지 않는 status 값입니다: DEPRECATED"));
+
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of("status", "DEPRECATED"))))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+  }
+
+  @Test
+  @DisplayName("PATCH /policies/{policyId}/status: PUBLISHED 버전이면 400 POLICY_NOT_EDITABLE")
+  @WithLongPrincipal(5L)
+  void should_400반환_when_PUBLISHED버전() throws Exception {
+    given(useCase.execute(any()))
+        .willThrow(
+            new BadRequestException("POLICY_NOT_EDITABLE", "DRAFT 상태의 버전에서만 정책을 수정할 수 있습니다."));
+
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of("status", "INACTIVE"))))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("POLICY_NOT_EDITABLE"));
+  }
+
+  @Test
+  @DisplayName("PATCH /policies/{policyId}/status: 정책 미존재 시 404")
+  @WithLongPrincipal(5L)
+  void should_404반환_when_정책미존재() throws Exception {
+    given(useCase.execute(any()))
+        .willThrow(new NotFoundException("NOT_FOUND", "정책을 찾을 수 없습니다: 55"));
+
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of("status", "INACTIVE"))))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("NOT_FOUND"));
+  }
+
+  @Test
+  @DisplayName("PATCH /policies/{policyId}/status: 워크스페이스 멤버십 없을 때 403")
+  @WithLongPrincipal(5L)
+  void should_403반환_when_비멤버() throws Exception {
+    given(useCase.execute(any()))
+        .willThrow(new DomainPackUnauthorizedWorkspaceAccessException("접근 권한이 없습니다."));
+
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of("status", "INACTIVE"))))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @DisplayName("PATCH /policies/{policyId}/status: status 미전송 시 400")
+  @WithLongPrincipal(5L)
+  void should_400반환_when_statusBlank() throws Exception {
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of("status", ""))))
+        .andExpect(status().isBadRequest());
+
+    verifyNoInteractions(useCase);
+  }
+
+  @Test
+  @DisplayName("PATCH /policies/{policyId}/status: 인증 없는 요청 → 401")
+  void should_401반환_when_인증없음() throws Exception {
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of("status", "INACTIVE"))))
+        .andExpect(status().isUnauthorized());
+
+    verifyNoInteractions(useCase);
+  }
+
+  private PolicyDefinitionResponse sampleResponse(String status) {
+    return new PolicyDefinitionResponse(
+        55L,
+        10L,
+        "refund_check",
+        "환불 정책",
+        "수정 설명",
+        "HIGH",
+        "{}",
+        "{}",
+        "[]",
+        "{}",
+        status,
+        OffsetDateTime.parse("2026-04-16T10:00:00Z"),
+        OffsetDateTime.parse("2026-04-16T10:30:00Z"));
+  }
+}


### PR DESCRIPTION
## Summary
- add #327 policy update and policy status update endpoints under `domain-pack`
- add `PolicyDefinition.status` persistence and domain methods for `ACTIVE` / `INACTIVE`
- enforce workspace boundary validation so pack access is checked against the requested workspace
- add application/controller tests and document the behavior in `327.md` and `schema.md`

## What Changed
- added `PATCH /api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/policies/{policyId}`
- added `PATCH /api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/policies/{policyId}/status`
- updated `PolicyDefinition` and `policy_definition` schema to support policy status management
- reused `DomainPackValidator` in policy update flows to validate workspace access and pack ownership together
- added unit tests and controller tests for success, validation, authorization, workspace boundary, and not-found cases

## Why
This adds the #327 policy editing flow at the same operator level as slot editing, while keeping the same `DRAFT`-only edit rule and closing the workspace-boundary gap between workspace authorization and actual pack access.

## Validation
- `cd backend && ./gradlew spotlessApply test`
- `cd backend && ./gradlew test --tests 'com.init.domainpack.application.UpdatePolicyUseCaseTest' --tests 'com.init.domainpack.application.UpdatePolicyStatusUseCaseTest'`
