### PR TITLE
spec/328: [BE] Risk / Risk Status 수정 API

### DIFF
--- a/.agent/specs/328.md
+++ b/.agent/specs/328.md
@@ -1,0 +1,224 @@
+# 328: [BE] Risk / Risk Status 수정 API
+
+## Goal
+
+운영자가 특정 `domain_pack_version`의 `risk_definition`을 수정할 수 있도록 두 개의 REST API를 제공한다.
+
+1. Risk 일반 필드 수정
+2. Risk status 전환
+
+두 API 모두 `DomainPackVersion.lifecycle_status = 'DRAFT'`인 경우에만 허용한다.
+
+---
+
+## Endpoints
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `PATCH` | `/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/risks/{riskId}` | Risk 일반 필드 수정 |
+| `PATCH` | `/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/risks/{riskId}/status` | Risk status 전환 |
+
+---
+
+## Request / Response
+
+### 1. Risk 일반 수정
+
+Request
+
+```json
+{
+  "name": "결제 분쟁 위험",
+  "description": "고객의 결제 이슈가 분쟁으로 이어질 수 있는 위험",
+  "riskLevel": "HIGH",
+  "triggerConditionJson": "{}",
+  "handlingActionJson": "{}",
+  "evidenceJson": "[]",
+  "metaJson": "{}"
+}
+```
+
+수정 가능 필드
+- `name`
+- `description`
+- `riskLevel`
+- `triggerConditionJson`
+- `handlingActionJson`
+- `evidenceJson`
+- `metaJson`
+
+수정 불가 필드
+- `riskCode`
+- `domainPackVersionId`
+
+### 2. Risk status 전환
+
+Request
+
+```json
+{
+  "status": "INACTIVE"
+}
+```
+
+허용 값
+- `ACTIVE`
+- `INACTIVE`
+
+### 3. 성공 응답
+
+```json
+{
+  "id": 77,
+  "domainPackVersionId": 10,
+  "riskCode": "payment_dispute_risk",
+  "name": "결제 분쟁 위험",
+  "description": "고객의 결제 이슈가 분쟁으로 이어질 수 있는 위험",
+  "riskLevel": "HIGH",
+  "triggerConditionJson": "{}",
+  "handlingActionJson": "{}",
+  "evidenceJson": "[]",
+  "metaJson": "{}",
+  "status": "ACTIVE",
+  "createdAt": "2026-04-17T10:00:00Z",
+  "updatedAt": "2026-04-17T10:30:00Z"
+}
+```
+
+### 4. 오류 응답
+
+`400 RISK_NOT_EDITABLE`
+
+```json
+{
+  "code": "RISK_NOT_EDITABLE",
+  "message": "DRAFT 상태의 버전에서만 위험요소를 수정할 수 있습니다."
+}
+```
+
+`400 VALIDATION_ERROR`
+
+```json
+{
+  "code": "VALIDATION_ERROR",
+  "errors": ["name은 필수 항목입니다."]
+}
+```
+
+`404 NOT_FOUND`
+
+```json
+{
+  "code": "NOT_FOUND",
+  "message": "위험요소를 찾을 수 없습니다: 77"
+}
+```
+
+---
+
+## Application Flow
+
+두 use case 모두 동일한 검증 순서를 따른다.
+
+1. `workspaceId` 존재 확인
+2. 요청 사용자의 워크스페이스 멤버십/역할 확인
+3. `packId`가 해당 `workspaceId` 소속인지 검증
+4. `versionId`로 `DomainPackVersion` 조회
+5. `version.domainPackId == packId` 검증
+6. `version.lifecycleStatus == DRAFT` 검증
+7. `riskId`로 `RiskDefinition` 조회
+8. `risk.domainPackVersionId == versionId` 검증
+9. 일반 수정이면 `risk.updateFields(...)`
+10. status 수정이면 `risk.changeStatus(...)`
+11. 저장 후 `RiskDefinitionResponse` 반환
+
+핵심 포인트
+- 실제 조회 키는 `versionId`, `riskId`다.
+- `packId`는 경로 일관성 검증용이다.
+- `workspaceId`는 권한 확인에만 쓰이지 않고, `packId`의 워크스페이스 소속 검증에도 사용된다.
+- 다른 version에 속한 risk를 path 조합으로 접근하면 `404`로 처리한다.
+- 다른 workspace에 속한 pack/version/risk를 path 조합으로 접근하면 `404`로 처리한다.
+
+---
+
+## Domain / Persistence Changes
+
+### `RiskDefinition`
+
+추가/변경 사항
+- `status` 필드 추가
+- 기본값 `ACTIVE`
+- `updateFields(...)` 메서드 추가
+- `changeStatus(...)` 메서드 추가
+
+`riskLevel` 규칙
+- `LOW`
+- `MEDIUM`
+- `HIGH`
+- `CRITICAL`
+
+일반 수정 시 `riskLevel`은 기존 `RiskLevel.normalize(...)` 규칙을 그대로 사용한다.
+
+### Repository
+
+`RiskDefinitionRepository`
+- `findById(Long id)`
+- `save(RiskDefinition risk)`
+
+### DB Migration
+
+현재 `pack.risk_definition`에는 `status` 컬럼이 없으므로 추가가 필요하다.
+
+```sql
+ALTER TABLE pack.risk_definition
+    ADD COLUMN status VARCHAR(50) NOT NULL DEFAULT 'ACTIVE',
+    ADD CONSTRAINT chk_risk_definition_status
+        CHECK (status IN ('ACTIVE', 'INACTIVE'));
+```
+
+---
+
+## Test Plan
+
+- `UpdateRiskUseCaseTest`
+  - DRAFT 버전 정상 수정
+  - workspace 없음 / 비멤버
+  - 다른 workspace 소속 pack 접근 차단
+  - version 없음 / packId 불일치
+  - PUBLISHED 버전 수정 시도
+  - risk 없음 / versionId 불일치
+  - 잘못된 `riskLevel` 입력 시 `VALIDATION_ERROR`
+
+- `UpdateRiskStatusUseCaseTest`
+  - `ACTIVE -> INACTIVE`
+  - `INACTIVE -> ACTIVE`
+  - 허용되지 않는 status 값
+  - workspace 없음 / 비멤버
+  - 다른 workspace 소속 pack 접근 차단
+  - version 없음 / packId 불일치
+  - risk 없음 / versionId 불일치
+
+- `UpdateRiskControllerTest`
+  - 정상 요청 200
+  - validation 실패 400
+  - `RISK_NOT_EDITABLE` 400
+  - `NOT_FOUND` 404
+  - 비멤버 403
+  - 인증 없음 401
+
+- `UpdateRiskStatusControllerTest`
+  - 정상 요청 200
+  - validation 실패 400
+  - 잘못된 status 400
+  - `RISK_NOT_EDITABLE` 400
+  - `NOT_FOUND` 404
+  - 비멤버 403
+  - 인증 없음 401
+
+---
+
+## Out of Scope
+
+- review task 자동 생성
+- publish/runtime에서 risk status를 실제 실행 판단에 반영하는 로직
+- risk와 policy/slot/workflow 간 추가 바인딩 설계

--- a/.agent/specs/328.md
+++ b/.agent/specs/328.md
@@ -122,6 +122,8 @@ Request
 
 1. `workspaceId` 존재 확인
 2. 요청 사용자의 워크스페이스 멤버십/역할 확인
+   - 허용 역할: `OPERATOR`, `ADMIN`
+   - 비허용 역할: 그 외 역할은 `403 FORBIDDEN`
 3. `packId`가 해당 `workspaceId` 소속인지 검증
 4. `versionId`로 `DomainPackVersion` 조회
 5. `version.domainPackId == packId` 검증
@@ -148,6 +150,7 @@ Request
 추가/변경 사항
 - `status` 필드 추가
 - 기본값 `ACTIVE`
+- `create(...)` 메서드에서 `status = STATUS_ACTIVE` 초기화
 - `updateFields(...)` 메서드 추가
 - `changeStatus(...)` 메서드 추가
 
@@ -183,19 +186,26 @@ ALTER TABLE pack.risk_definition
 - `UpdateRiskUseCaseTest`
   - DRAFT 버전 정상 수정
   - workspace 없음 / 비멤버
+  - 허용 역할(`OPERATOR`, `ADMIN`)은 수정 가능
+  - 비허용 역할은 `403`
   - 다른 workspace 소속 pack 접근 차단
   - version 없음 / packId 불일치
   - PUBLISHED 버전 수정 시도
   - risk 없음 / versionId 불일치
   - 잘못된 `riskLevel` 입력 시 `VALIDATION_ERROR`
+  - `name`이 `null`이면 `VALIDATION_ERROR`
+  - `name`이 빈 문자열이면 `VALIDATION_ERROR`
 
 - `UpdateRiskStatusUseCaseTest`
   - `ACTIVE -> INACTIVE`
   - `INACTIVE -> ACTIVE`
   - 허용되지 않는 status 값
   - workspace 없음 / 비멤버
+  - 허용 역할(`OPERATOR`, `ADMIN`)은 수정 가능
+  - 비허용 역할은 `403`
   - 다른 workspace 소속 pack 접근 차단
   - version 없음 / packId 불일치
+  - PUBLISHED 버전 수정 시도
   - risk 없음 / versionId 불일치
 
 - `UpdateRiskControllerTest`


### PR DESCRIPTION
## Summary
- add spec #328 for risk update and risk status update APIs
- define request/response, workspace-boundary validation, and DRAFT-only edit rules
- document the gap between current `RiskDefinition` model and the required `status` field for status transitions

## What Changed
- added `.agent/specs/328.md`
- mirrored the slot/policy update pattern for risk APIs
- specified risk-specific fields such as `riskLevel`, `triggerConditionJson`, and `handlingActionJson`
- included test scope and DB migration requirements for `risk_definition.status`

## Why
The team can review and agree on the risk update API contract before implementation, keeping the spec PR and feature PR separated under the existing SDD workflow.

## Validation
- spec document only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서화**
  * Risk 정보 수정 및 상태 전환을 위한 새로운 API 요구사항 문서화가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->