### PR TITLE
feat(domain-pack): add #328 risk update APIs

### DIFF
--- a/.agent/docs/schema.md
+++ b/.agent/docs/schema.md
@@ -191,7 +191,7 @@
 
 ### `pack.risk_definition`
 - 위험 요소 정의
-- trigger condition, handling action, risk level 저장
+- trigger condition, handling action, risk level, status 저장
 
 ### `pack.workflow_definition`
 - 상태 기반 graph 정의
@@ -505,6 +505,7 @@ create table pack.risk_definition (
     handling_action_json jsonb not null default '{}'::jsonb,
     evidence_json       jsonb not null default '[]'::jsonb,
     meta_json           jsonb not null default '{}'::jsonb,
+    status              varchar(50) not null default 'ACTIVE',
     created_at          timestamptz not null default now(),
     updated_at          timestamptz not null default now(),
     unique (domain_pack_version_id, risk_code)

--- a/.agent/docs/schema.md
+++ b/.agent/docs/schema.md
@@ -961,10 +961,13 @@ create index idx_taxonomy_drift_pack
 - `PUBLISHED`
 - `ARCHIVED`
 
-### 11.2 `pack.slot_definition.status` / `pack.policy_definition.status`
+### 11.2 `pack.slot_definition.status` / `pack.policy_definition.status` / `pack.risk_definition.status`
 
 - `ACTIVE`
 - `INACTIVE`
+
+위 상태값은 각각 `pack.slot_definition.status`, `pack.policy_definition.status`,
+`pack.risk_definition.status`에 저장된다.
 
 ### 11.3 `review.review_session.status`
 

--- a/.agent/docs/schema.md
+++ b/.agent/docs/schema.md
@@ -508,6 +508,8 @@ create table pack.risk_definition (
     status              varchar(50) not null default 'ACTIVE',
     created_at          timestamptz not null default now(),
     updated_at          timestamptz not null default now(),
+    constraint chk_risk_definition_status
+        check (status in ('ACTIVE', 'INACTIVE')),
     unique (domain_pack_version_id, risk_code)
 );
 

--- a/.agent/specs/328.md
+++ b/.agent/specs/328.md
@@ -1,0 +1,224 @@
+# 328: [BE] Risk / Risk Status 수정 API
+
+## Goal
+
+운영자가 특정 `domain_pack_version`의 `risk_definition`을 수정할 수 있도록 두 개의 REST API를 제공한다.
+
+1. Risk 일반 필드 수정
+2. Risk status 전환
+
+두 API 모두 `DomainPackVersion.lifecycle_status = 'DRAFT'`인 경우에만 허용한다.
+
+---
+
+## Endpoints
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `PATCH` | `/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/risks/{riskId}` | Risk 일반 필드 수정 |
+| `PATCH` | `/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/risks/{riskId}/status` | Risk status 전환 |
+
+---
+
+## Request / Response
+
+### 1. Risk 일반 수정
+
+Request
+
+```json
+{
+  "name": "결제 분쟁 위험",
+  "description": "고객의 결제 이슈가 분쟁으로 이어질 수 있는 위험",
+  "riskLevel": "HIGH",
+  "triggerConditionJson": "{}",
+  "handlingActionJson": "{}",
+  "evidenceJson": "[]",
+  "metaJson": "{}"
+}
+```
+
+수정 가능 필드
+- `name`
+- `description`
+- `riskLevel`
+- `triggerConditionJson`
+- `handlingActionJson`
+- `evidenceJson`
+- `metaJson`
+
+수정 불가 필드
+- `riskCode`
+- `domainPackVersionId`
+
+### 2. Risk status 전환
+
+Request
+
+```json
+{
+  "status": "INACTIVE"
+}
+```
+
+허용 값
+- `ACTIVE`
+- `INACTIVE`
+
+### 3. 성공 응답
+
+```json
+{
+  "id": 77,
+  "domainPackVersionId": 10,
+  "riskCode": "payment_dispute_risk",
+  "name": "결제 분쟁 위험",
+  "description": "고객의 결제 이슈가 분쟁으로 이어질 수 있는 위험",
+  "riskLevel": "HIGH",
+  "triggerConditionJson": "{}",
+  "handlingActionJson": "{}",
+  "evidenceJson": "[]",
+  "metaJson": "{}",
+  "status": "ACTIVE",
+  "createdAt": "2026-04-17T10:00:00Z",
+  "updatedAt": "2026-04-17T10:30:00Z"
+}
+```
+
+### 4. 오류 응답
+
+`400 RISK_NOT_EDITABLE`
+
+```json
+{
+  "code": "RISK_NOT_EDITABLE",
+  "message": "DRAFT 상태의 버전에서만 위험요소를 수정할 수 있습니다."
+}
+```
+
+`400 VALIDATION_ERROR`
+
+```json
+{
+  "code": "VALIDATION_ERROR",
+  "errors": ["name은 필수 항목입니다."]
+}
+```
+
+`404 NOT_FOUND`
+
+```json
+{
+  "code": "NOT_FOUND",
+  "message": "위험요소를 찾을 수 없습니다: 77"
+}
+```
+
+---
+
+## Application Flow
+
+두 use case 모두 동일한 검증 순서를 따른다.
+
+1. `workspaceId` 존재 확인
+2. 요청 사용자의 워크스페이스 멤버십/역할 확인
+3. `packId`가 해당 `workspaceId` 소속인지 검증
+4. `versionId`로 `DomainPackVersion` 조회
+5. `version.domainPackId == packId` 검증
+6. `version.lifecycleStatus == DRAFT` 검증
+7. `riskId`로 `RiskDefinition` 조회
+8. `risk.domainPackVersionId == versionId` 검증
+9. 일반 수정이면 `risk.updateFields(...)`
+10. status 수정이면 `risk.changeStatus(...)`
+11. 저장 후 `RiskDefinitionResponse` 반환
+
+핵심 포인트
+- 실제 조회 키는 `versionId`, `riskId`다.
+- `packId`는 경로 일관성 검증용이다.
+- `workspaceId`는 권한 확인에만 쓰이지 않고, `packId`의 워크스페이스 소속 검증에도 사용된다.
+- 다른 version에 속한 risk를 path 조합으로 접근하면 `404`로 처리한다.
+- 다른 workspace에 속한 pack/version/risk를 path 조합으로 접근하면 `404`로 처리한다.
+
+---
+
+## Domain / Persistence Changes
+
+### `RiskDefinition`
+
+추가/변경 사항
+- `status` 필드 추가
+- 기본값 `ACTIVE`
+- `updateFields(...)` 메서드 추가
+- `changeStatus(...)` 메서드 추가
+
+`riskLevel` 규칙
+- `LOW`
+- `MEDIUM`
+- `HIGH`
+- `CRITICAL`
+
+일반 수정 시 `riskLevel`은 기존 `RiskLevel.normalize(...)` 규칙을 그대로 사용한다.
+
+### Repository
+
+`RiskDefinitionRepository`
+- `findById(Long id)`
+- `save(RiskDefinition risk)`
+
+### DB Migration
+
+현재 `pack.risk_definition`에는 `status` 컬럼이 없으므로 추가가 필요하다.
+
+```sql
+ALTER TABLE pack.risk_definition
+    ADD COLUMN status VARCHAR(50) NOT NULL DEFAULT 'ACTIVE',
+    ADD CONSTRAINT chk_risk_definition_status
+        CHECK (status IN ('ACTIVE', 'INACTIVE'));
+```
+
+---
+
+## Test Plan
+
+- `UpdateRiskUseCaseTest`
+  - DRAFT 버전 정상 수정
+  - workspace 없음 / 비멤버
+  - 다른 workspace 소속 pack 접근 차단
+  - version 없음 / packId 불일치
+  - PUBLISHED 버전 수정 시도
+  - risk 없음 / versionId 불일치
+  - 잘못된 `riskLevel` 입력 시 `VALIDATION_ERROR`
+
+- `UpdateRiskStatusUseCaseTest`
+  - `ACTIVE -> INACTIVE`
+  - `INACTIVE -> ACTIVE`
+  - 허용되지 않는 status 값
+  - workspace 없음 / 비멤버
+  - 다른 workspace 소속 pack 접근 차단
+  - version 없음 / packId 불일치
+  - risk 없음 / versionId 불일치
+
+- `UpdateRiskControllerTest`
+  - 정상 요청 200
+  - validation 실패 400
+  - `RISK_NOT_EDITABLE` 400
+  - `NOT_FOUND` 404
+  - 비멤버 403
+  - 인증 없음 401
+
+- `UpdateRiskStatusControllerTest`
+  - 정상 요청 200
+  - validation 실패 400
+  - 잘못된 status 400
+  - `RISK_NOT_EDITABLE` 400
+  - `NOT_FOUND` 404
+  - 비멤버 403
+  - 인증 없음 401
+
+---
+
+## Out of Scope
+
+- review task 자동 생성
+- publish/runtime에서 risk status를 실제 실행 판단에 반영하는 로직
+- risk와 policy/slot/workflow 간 추가 바인딩 설계

--- a/.agent/specs/328.md
+++ b/.agent/specs/328.md
@@ -122,6 +122,8 @@ Request
 
 1. `workspaceId` 존재 확인
 2. 요청 사용자의 워크스페이스 멤버십/역할 확인
+   - 허용 역할: `OPERATOR`, `ADMIN`
+   - 비허용 역할: 그 외 역할은 `403 FORBIDDEN`
 3. `packId`가 해당 `workspaceId` 소속인지 검증
 4. `versionId`로 `DomainPackVersion` 조회
 5. `version.domainPackId == packId` 검증
@@ -148,6 +150,7 @@ Request
 추가/변경 사항
 - `status` 필드 추가
 - 기본값 `ACTIVE`
+- `create(...)` 메서드에서 `status = STATUS_ACTIVE` 초기화
 - `updateFields(...)` 메서드 추가
 - `changeStatus(...)` 메서드 추가
 
@@ -183,19 +186,26 @@ ALTER TABLE pack.risk_definition
 - `UpdateRiskUseCaseTest`
   - DRAFT 버전 정상 수정
   - workspace 없음 / 비멤버
+  - 허용 역할(`OPERATOR`, `ADMIN`)은 수정 가능
+  - 비허용 역할은 `403`
   - 다른 workspace 소속 pack 접근 차단
   - version 없음 / packId 불일치
   - PUBLISHED 버전 수정 시도
   - risk 없음 / versionId 불일치
   - 잘못된 `riskLevel` 입력 시 `VALIDATION_ERROR`
+  - `name`이 `null`이면 `VALIDATION_ERROR`
+  - `name`이 빈 문자열이면 `VALIDATION_ERROR`
 
 - `UpdateRiskStatusUseCaseTest`
   - `ACTIVE -> INACTIVE`
   - `INACTIVE -> ACTIVE`
   - 허용되지 않는 status 값
   - workspace 없음 / 비멤버
+  - 허용 역할(`OPERATOR`, `ADMIN`)은 수정 가능
+  - 비허용 역할은 `403`
   - 다른 workspace 소속 pack 접근 차단
   - version 없음 / packId 불일치
+  - PUBLISHED 버전 수정 시도
   - risk 없음 / versionId 불일치
 
 - `UpdateRiskControllerTest`

--- a/backend/src/main/java/com/init/domainpack/application/RiskDefinitionResponse.java
+++ b/backend/src/main/java/com/init/domainpack/application/RiskDefinitionResponse.java
@@ -1,0 +1,37 @@
+package com.init.domainpack.application;
+
+import com.init.domainpack.domain.model.RiskDefinition;
+import java.time.OffsetDateTime;
+
+public record RiskDefinitionResponse(
+    Long id,
+    Long domainPackVersionId,
+    String riskCode,
+    String name,
+    String description,
+    String riskLevel,
+    String triggerConditionJson,
+    String handlingActionJson,
+    String evidenceJson,
+    String metaJson,
+    String status,
+    OffsetDateTime createdAt,
+    OffsetDateTime updatedAt) {
+
+  public static RiskDefinitionResponse from(RiskDefinition risk) {
+    return new RiskDefinitionResponse(
+        risk.getId(),
+        risk.getDomainPackVersionId(),
+        risk.getRiskCode(),
+        risk.getName(),
+        risk.getDescription(),
+        risk.getRiskLevel(),
+        risk.getTriggerConditionJson(),
+        risk.getHandlingActionJson(),
+        risk.getEvidenceJson(),
+        risk.getMetaJson(),
+        risk.getStatus(),
+        risk.getCreatedAt(),
+        risk.getUpdatedAt());
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/application/UpdateRiskCommand.java
+++ b/backend/src/main/java/com/init/domainpack/application/UpdateRiskCommand.java
@@ -1,0 +1,15 @@
+package com.init.domainpack.application;
+
+public record UpdateRiskCommand(
+    Long workspaceId,
+    Long packId,
+    Long versionId,
+    Long riskId,
+    Long requesterId,
+    String name,
+    String description,
+    String riskLevel,
+    String triggerConditionJson,
+    String handlingActionJson,
+    String evidenceJson,
+    String metaJson) {}

--- a/backend/src/main/java/com/init/domainpack/application/UpdateRiskStatusCommand.java
+++ b/backend/src/main/java/com/init/domainpack/application/UpdateRiskStatusCommand.java
@@ -1,0 +1,4 @@
+package com.init.domainpack.application;
+
+public record UpdateRiskStatusCommand(
+    Long workspaceId, Long packId, Long versionId, Long riskId, Long requesterId, String status) {}

--- a/backend/src/main/java/com/init/domainpack/application/UpdateRiskStatusUseCase.java
+++ b/backend/src/main/java/com/init/domainpack/application/UpdateRiskStatusUseCase.java
@@ -1,0 +1,67 @@
+package com.init.domainpack.application;
+
+import com.init.domainpack.domain.model.DomainPackVersion;
+import com.init.domainpack.domain.model.RiskDefinition;
+import com.init.domainpack.domain.repository.DomainPackVersionRepository;
+import com.init.domainpack.domain.repository.RiskDefinitionRepository;
+import com.init.shared.application.exception.BadRequestException;
+import com.init.shared.application.exception.NotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class UpdateRiskStatusUseCase {
+
+  private final DomainPackValidator validator;
+  private final RiskDefinitionRepository riskRepository;
+  private final DomainPackVersionRepository versionRepository;
+
+  public UpdateRiskStatusUseCase(
+      DomainPackValidator validator,
+      RiskDefinitionRepository riskRepository,
+      DomainPackVersionRepository versionRepository) {
+    this.validator = validator;
+    this.riskRepository = riskRepository;
+    this.versionRepository = versionRepository;
+  }
+
+  @Transactional
+  public RiskDefinitionResponse execute(UpdateRiskStatusCommand command) {
+    validator.validateWorkspaceAccess(command.workspaceId(), command.requesterId());
+    validator.validateDomainPack(command.packId(), command.workspaceId());
+
+    DomainPackVersion version =
+        versionRepository
+            .findById(command.versionId())
+            .orElseThrow(
+                () -> new NotFoundException("NOT_FOUND", "버전을 찾을 수 없습니다: " + command.versionId()));
+
+    if (!version.getDomainPackId().equals(command.packId())) {
+      throw new NotFoundException("NOT_FOUND", "버전을 찾을 수 없습니다: " + command.versionId());
+    }
+
+    if (!DomainPackVersion.STATUS_DRAFT.equals(version.getLifecycleStatus())) {
+      throw new BadRequestException("RISK_NOT_EDITABLE", "DRAFT 상태의 버전에서만 위험요소를 수정할 수 있습니다.");
+    }
+
+    RiskDefinition risk =
+        riskRepository
+            .findById(command.riskId())
+            .orElseThrow(
+                () -> new NotFoundException("NOT_FOUND", "위험요소를 찾을 수 없습니다: " + command.riskId()));
+
+    if (!risk.getDomainPackVersionId().equals(command.versionId())) {
+      throw new NotFoundException("NOT_FOUND", "위험요소를 찾을 수 없습니다: " + command.riskId());
+    }
+
+    try {
+      risk.changeStatus(command.status());
+    } catch (IllegalArgumentException e) {
+      throw new BadRequestException("VALIDATION_ERROR", e.getMessage());
+    }
+
+    riskRepository.save(risk);
+    return RiskDefinitionResponse.from(risk);
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/application/UpdateRiskUseCase.java
+++ b/backend/src/main/java/com/init/domainpack/application/UpdateRiskUseCase.java
@@ -1,0 +1,74 @@
+package com.init.domainpack.application;
+
+import com.init.domainpack.domain.model.DomainPackVersion;
+import com.init.domainpack.domain.model.RiskDefinition;
+import com.init.domainpack.domain.repository.DomainPackVersionRepository;
+import com.init.domainpack.domain.repository.RiskDefinitionRepository;
+import com.init.shared.application.exception.BadRequestException;
+import com.init.shared.application.exception.NotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class UpdateRiskUseCase {
+
+  private final DomainPackValidator validator;
+  private final RiskDefinitionRepository riskRepository;
+  private final DomainPackVersionRepository versionRepository;
+
+  public UpdateRiskUseCase(
+      DomainPackValidator validator,
+      RiskDefinitionRepository riskRepository,
+      DomainPackVersionRepository versionRepository) {
+    this.validator = validator;
+    this.riskRepository = riskRepository;
+    this.versionRepository = versionRepository;
+  }
+
+  @Transactional
+  public RiskDefinitionResponse execute(UpdateRiskCommand command) {
+    validator.validateWorkspaceAccess(command.workspaceId(), command.requesterId());
+    validator.validateDomainPack(command.packId(), command.workspaceId());
+
+    DomainPackVersion version =
+        versionRepository
+            .findById(command.versionId())
+            .orElseThrow(
+                () -> new NotFoundException("NOT_FOUND", "버전을 찾을 수 없습니다: " + command.versionId()));
+
+    if (!version.getDomainPackId().equals(command.packId())) {
+      throw new NotFoundException("NOT_FOUND", "버전을 찾을 수 없습니다: " + command.versionId());
+    }
+
+    if (!DomainPackVersion.STATUS_DRAFT.equals(version.getLifecycleStatus())) {
+      throw new BadRequestException("RISK_NOT_EDITABLE", "DRAFT 상태의 버전에서만 위험요소를 수정할 수 있습니다.");
+    }
+
+    RiskDefinition risk =
+        riskRepository
+            .findById(command.riskId())
+            .orElseThrow(
+                () -> new NotFoundException("NOT_FOUND", "위험요소를 찾을 수 없습니다: " + command.riskId()));
+
+    if (!risk.getDomainPackVersionId().equals(command.versionId())) {
+      throw new NotFoundException("NOT_FOUND", "위험요소를 찾을 수 없습니다: " + command.riskId());
+    }
+
+    try {
+      risk.updateFields(
+          command.name(),
+          command.description(),
+          command.riskLevel(),
+          command.triggerConditionJson(),
+          command.handlingActionJson(),
+          command.evidenceJson(),
+          command.metaJson());
+    } catch (IllegalArgumentException e) {
+      throw new BadRequestException("VALIDATION_ERROR", e.getMessage());
+    }
+
+    riskRepository.save(risk);
+    return RiskDefinitionResponse.from(risk);
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/domain/model/RiskDefinition.java
+++ b/backend/src/main/java/com/init/domainpack/domain/model/RiskDefinition.java
@@ -15,6 +15,9 @@ import java.util.Objects;
 @Table(name = "risk_definition", schema = "pack")
 public class RiskDefinition {
 
+  public static final String STATUS_ACTIVE = "ACTIVE";
+  public static final String STATUS_INACTIVE = "INACTIVE";
+
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
@@ -45,6 +48,9 @@ public class RiskDefinition {
 
   @Column(name = "meta_json", columnDefinition = "jsonb", nullable = false)
   private String metaJson;
+
+  @Column(name = "status", nullable = false)
+  private String status;
 
   @Column(name = "created_at", nullable = false, updatable = false)
   private OffsetDateTime createdAt;
@@ -78,20 +84,57 @@ public class RiskDefinition {
       String metaJson) {
     Objects.requireNonNull(domainPackVersionId, "domainPackVersionId must not be null");
     Objects.requireNonNull(riskCode, "riskCode must not be null");
-    Objects.requireNonNull(name, "name must not be null");
     Objects.requireNonNull(riskLevel, "riskLevel must not be null");
 
     RiskDefinition entity = new RiskDefinition();
     entity.domainPackVersionId = domainPackVersionId;
     entity.riskCode = riskCode;
-    entity.name = name;
+    entity.name = validateName(name);
     entity.description = description;
     entity.riskLevel = normalizeRiskLevel(riskLevel);
     entity.triggerConditionJson = triggerConditionJson != null ? triggerConditionJson : "{}";
     entity.handlingActionJson = handlingActionJson != null ? handlingActionJson : "{}";
     entity.evidenceJson = evidenceJson != null ? evidenceJson : "[]";
     entity.metaJson = metaJson != null ? metaJson : "{}";
+    entity.status = STATUS_ACTIVE;
     return entity;
+  }
+
+  public void updateFields(
+      String name,
+      String description,
+      String riskLevel,
+      String triggerConditionJson,
+      String handlingActionJson,
+      String evidenceJson,
+      String metaJson) {
+    String validatedName = validateName(name);
+    String normalizedRiskLevel = riskLevel != null ? normalizeRiskLevel(riskLevel) : this.riskLevel;
+
+    this.name = validatedName;
+    if (description != null) this.description = description;
+    this.riskLevel = normalizedRiskLevel;
+    if (triggerConditionJson != null) this.triggerConditionJson = triggerConditionJson;
+    if (handlingActionJson != null) this.handlingActionJson = handlingActionJson;
+    if (evidenceJson != null) this.evidenceJson = evidenceJson;
+    if (metaJson != null) this.metaJson = metaJson;
+  }
+
+  public void changeStatus(String newStatus) {
+    if (!STATUS_ACTIVE.equals(newStatus) && !STATUS_INACTIVE.equals(newStatus)) {
+      throw new IllegalArgumentException("허용되지 않는 status 값입니다: " + newStatus);
+    }
+    this.status = newStatus;
+  }
+
+  private static String validateName(String name) {
+    if (name == null) {
+      throw new IllegalArgumentException("name은 필수 항목입니다.");
+    }
+    if (name.isBlank()) {
+      throw new IllegalArgumentException("name은 비워둘 수 없습니다.");
+    }
+    return name;
   }
 
   private static String normalizeRiskLevel(String riskLevel) {
@@ -140,5 +183,17 @@ public class RiskDefinition {
 
   public String getMetaJson() {
     return metaJson;
+  }
+
+  public String getStatus() {
+    return status;
+  }
+
+  public OffsetDateTime getCreatedAt() {
+    return createdAt;
+  }
+
+  public OffsetDateTime getUpdatedAt() {
+    return updatedAt;
   }
 }

--- a/backend/src/main/java/com/init/domainpack/domain/repository/RiskDefinitionRepository.java
+++ b/backend/src/main/java/com/init/domainpack/domain/repository/RiskDefinitionRepository.java
@@ -2,8 +2,13 @@ package com.init.domainpack.domain.repository;
 
 import com.init.domainpack.domain.model.RiskDefinition;
 import java.util.List;
+import java.util.Optional;
 
 public interface RiskDefinitionRepository {
 
   <S extends RiskDefinition> List<S> saveAll(Iterable<S> entities);
+
+  Optional<RiskDefinition> findById(Long id);
+
+  RiskDefinition save(RiskDefinition risk);
 }

--- a/backend/src/main/java/com/init/domainpack/presentation/UpdateRiskController.java
+++ b/backend/src/main/java/com/init/domainpack/presentation/UpdateRiskController.java
@@ -1,0 +1,53 @@
+package com.init.domainpack.presentation;
+
+import com.init.domainpack.application.RiskDefinitionResponse;
+import com.init.domainpack.application.UpdateRiskCommand;
+import com.init.domainpack.application.UpdateRiskUseCase;
+import com.init.domainpack.presentation.dto.UpdateRiskRequest;
+import com.init.shared.presentation.AuthenticationUtils;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(
+    "/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/risks/{riskId}")
+public class UpdateRiskController {
+
+  private final UpdateRiskUseCase useCase;
+
+  public UpdateRiskController(UpdateRiskUseCase useCase) {
+    this.useCase = useCase;
+  }
+
+  @PatchMapping
+  public ResponseEntity<RiskDefinitionResponse> updateRisk(
+      @PathVariable Long workspaceId,
+      @PathVariable Long packId,
+      @PathVariable Long versionId,
+      @PathVariable Long riskId,
+      @Valid @RequestBody UpdateRiskRequest request,
+      Authentication authentication) {
+    Long userId = AuthenticationUtils.getUserId(authentication);
+    UpdateRiskCommand command =
+        new UpdateRiskCommand(
+            workspaceId,
+            packId,
+            versionId,
+            riskId,
+            userId,
+            request.name(),
+            request.description(),
+            request.riskLevel(),
+            request.triggerConditionJson(),
+            request.handlingActionJson(),
+            request.evidenceJson(),
+            request.metaJson());
+    return ResponseEntity.ok(useCase.execute(command));
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/presentation/UpdateRiskStatusController.java
+++ b/backend/src/main/java/com/init/domainpack/presentation/UpdateRiskStatusController.java
@@ -1,0 +1,42 @@
+package com.init.domainpack.presentation;
+
+import com.init.domainpack.application.RiskDefinitionResponse;
+import com.init.domainpack.application.UpdateRiskStatusCommand;
+import com.init.domainpack.application.UpdateRiskStatusUseCase;
+import com.init.domainpack.presentation.dto.UpdateRiskStatusRequest;
+import com.init.shared.presentation.AuthenticationUtils;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(
+    "/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/risks/{riskId}")
+public class UpdateRiskStatusController {
+
+  private final UpdateRiskStatusUseCase useCase;
+
+  public UpdateRiskStatusController(UpdateRiskStatusUseCase useCase) {
+    this.useCase = useCase;
+  }
+
+  @PatchMapping("/status")
+  public ResponseEntity<RiskDefinitionResponse> updateRiskStatus(
+      @PathVariable Long workspaceId,
+      @PathVariable Long packId,
+      @PathVariable Long versionId,
+      @PathVariable Long riskId,
+      @Valid @RequestBody UpdateRiskStatusRequest request,
+      Authentication authentication) {
+    Long userId = AuthenticationUtils.getUserId(authentication);
+    UpdateRiskStatusCommand command =
+        new UpdateRiskStatusCommand(
+            workspaceId, packId, versionId, riskId, userId, request.status());
+    return ResponseEntity.ok(useCase.execute(command));
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/presentation/dto/UpdateRiskRequest.java
+++ b/backend/src/main/java/com/init/domainpack/presentation/dto/UpdateRiskRequest.java
@@ -1,0 +1,12 @@
+package com.init.domainpack.presentation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UpdateRiskRequest(
+    @NotBlank(message = "name은 필수 항목입니다.") String name,
+    String description,
+    String riskLevel,
+    String triggerConditionJson,
+    String handlingActionJson,
+    String evidenceJson,
+    String metaJson) {}

--- a/backend/src/main/java/com/init/domainpack/presentation/dto/UpdateRiskStatusRequest.java
+++ b/backend/src/main/java/com/init/domainpack/presentation/dto/UpdateRiskStatusRequest.java
@@ -1,0 +1,5 @@
+package com.init.domainpack.presentation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UpdateRiskStatusRequest(@NotBlank(message = "status는 필수 항목입니다.") String status) {}

--- a/backend/src/main/resources/db/changelog/db.changelog-master.sql
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.sql
@@ -715,3 +715,9 @@ ALTER TABLE pack.slot_definition
 ALTER TABLE pack.policy_definition
     ADD COLUMN status VARCHAR(50) NOT NULL DEFAULT 'ACTIVE',
     ADD CONSTRAINT chk_policy_definition_status CHECK (status IN ('ACTIVE', 'INACTIVE'));
+
+--changeset devjhan:20260416-add-status-to-risk-definition
+--comment: Add status column to pack.risk_definition for risk lifecycle management (ACTIVE/INACTIVE)
+ALTER TABLE pack.risk_definition
+    ADD COLUMN status VARCHAR(50) NOT NULL DEFAULT 'ACTIVE',
+    ADD CONSTRAINT chk_risk_definition_status CHECK (status IN ('ACTIVE', 'INACTIVE'));

--- a/backend/src/test/java/com/init/domainpack/application/UpdateRiskStatusUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/UpdateRiskStatusUseCaseTest.java
@@ -1,0 +1,235 @@
+package com.init.domainpack.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.init.domainpack.application.exception.DomainPackNotFoundException;
+import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
+import com.init.domainpack.application.exception.DomainPackWorkspaceNotFoundException;
+import com.init.domainpack.domain.model.DomainPackVersion;
+import com.init.domainpack.domain.model.RiskDefinition;
+import com.init.domainpack.domain.repository.DomainPackVersionRepository;
+import com.init.domainpack.domain.repository.RiskDefinitionRepository;
+import com.init.shared.application.exception.BadRequestException;
+import com.init.shared.application.exception.NotFoundException;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UpdateRiskStatusUseCase")
+class UpdateRiskStatusUseCaseTest {
+
+  @Mock private DomainPackValidator validator;
+  @Mock private RiskDefinitionRepository riskRepository;
+  @Mock private DomainPackVersionRepository versionRepository;
+
+  private UpdateRiskStatusUseCase useCase;
+
+  @BeforeEach
+  void setUp() {
+    useCase = new UpdateRiskStatusUseCase(validator, riskRepository, versionRepository);
+  }
+
+  @Test
+  @DisplayName("정상 전환: ACTIVE → INACTIVE")
+  void should_INACTIVE전환성공_when_DRAFT버전위험요소() {
+    given(versionRepository.findById(10L)).willReturn(Optional.of(draftVersion(10L, 7L)));
+
+    RiskDefinition risk = risk(55L, 10L);
+    given(riskRepository.findById(55L)).willReturn(Optional.of(risk));
+    given(riskRepository.save(any())).willReturn(risk);
+
+    UpdateRiskStatusCommand command =
+        new UpdateRiskStatusCommand(1L, 7L, 10L, 55L, 5L, RiskDefinition.STATUS_INACTIVE);
+
+    RiskDefinitionResponse result = useCase.execute(command);
+
+    assertThat(result.status()).isEqualTo(RiskDefinition.STATUS_INACTIVE);
+    verify(riskRepository).save(risk);
+  }
+
+  @Test
+  @DisplayName("정상 전환: INACTIVE → ACTIVE")
+  void should_ACTIVE전환성공_when_INACTIVE위험요소() {
+    given(versionRepository.findById(10L)).willReturn(Optional.of(draftVersion(10L, 7L)));
+
+    RiskDefinition risk = risk(55L, 10L);
+    ReflectionTestUtils.setField(risk, "status", RiskDefinition.STATUS_INACTIVE);
+    given(riskRepository.findById(55L)).willReturn(Optional.of(risk));
+    given(riskRepository.save(any())).willReturn(risk);
+
+    UpdateRiskStatusCommand command =
+        new UpdateRiskStatusCommand(1L, 7L, 10L, 55L, 5L, RiskDefinition.STATUS_ACTIVE);
+
+    RiskDefinitionResponse result = useCase.execute(command);
+
+    assertThat(result.status()).isEqualTo(RiskDefinition.STATUS_ACTIVE);
+    verify(riskRepository).save(risk);
+  }
+
+  @Test
+  @DisplayName("허용되지 않는 status 값 → BadRequestException(VALIDATION_ERROR)")
+  void should_VALIDATION_ERROR예외_when_잘못된status() {
+    given(versionRepository.findById(10L)).willReturn(Optional.of(draftVersion(10L, 7L)));
+
+    RiskDefinition risk = risk(55L, 10L);
+    given(riskRepository.findById(55L)).willReturn(Optional.of(risk));
+
+    assertThatThrownBy(
+            () -> useCase.execute(new UpdateRiskStatusCommand(1L, 7L, 10L, 55L, 5L, "DEPRECATED")))
+        .isInstanceOf(BadRequestException.class);
+  }
+
+  @Test
+  @DisplayName("PUBLISHED 버전 → BadRequestException(RISK_NOT_EDITABLE)")
+  void should_RISK_NOT_EDITABLE예외_when_PUBLISHED버전() {
+    given(versionRepository.findById(10L)).willReturn(Optional.of(publishedVersion(10L, 7L)));
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdateRiskStatusCommand(
+                        1L, 7L, 10L, 55L, 5L, RiskDefinition.STATUS_INACTIVE)))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("DRAFT");
+
+    verify(riskRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("위험요소의 versionId 불일치 → NotFoundException")
+  void should_위험요소없음예외_when_versionId불일치() {
+    given(versionRepository.findById(10L)).willReturn(Optional.of(draftVersion(10L, 7L)));
+
+    RiskDefinition risk = risk(55L, 999L);
+    given(riskRepository.findById(55L)).willReturn(Optional.of(risk));
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdateRiskStatusCommand(
+                        1L, 7L, 10L, 55L, 5L, RiskDefinition.STATUS_INACTIVE)))
+        .isInstanceOf(NotFoundException.class);
+
+    verify(riskRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("workspace 없음 → DomainPackWorkspaceNotFoundException")
+  void should_워크스페이스없음예외_when_워크스페이스없음() {
+    org.mockito.Mockito.doThrow(new DomainPackWorkspaceNotFoundException("워크스페이스를 찾을 수 없습니다. id=1"))
+        .when(validator)
+        .validateWorkspaceAccess(1L, 5L);
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdateRiskStatusCommand(
+                        1L, 7L, 10L, 55L, 5L, RiskDefinition.STATUS_INACTIVE)))
+        .isInstanceOf(DomainPackWorkspaceNotFoundException.class);
+
+    verify(versionRepository, never()).findById(any());
+  }
+
+  @Test
+  @DisplayName("workspace 비멤버 → DomainPackUnauthorizedWorkspaceAccessException")
+  void should_권한없음예외_when_비멤버() {
+    org.mockito.Mockito.doThrow(
+            new DomainPackUnauthorizedWorkspaceAccessException("워크스페이스에 접근 권한이 없습니다."))
+        .when(validator)
+        .validateWorkspaceAccess(1L, 5L);
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdateRiskStatusCommand(
+                        1L, 7L, 10L, 55L, 5L, RiskDefinition.STATUS_INACTIVE)))
+        .isInstanceOf(DomainPackUnauthorizedWorkspaceAccessException.class);
+
+    verify(versionRepository, never()).findById(any());
+  }
+
+  @Test
+  @DisplayName("pack이 다른 workspace에 속함 → DomainPackNotFoundException")
+  void should_도메인팩없음예외_when_workspace경계위반() {
+    org.mockito.Mockito.doThrow(new DomainPackNotFoundException(7L))
+        .when(validator)
+        .validateDomainPack(7L, 1L);
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdateRiskStatusCommand(
+                        1L, 7L, 10L, 55L, 5L, RiskDefinition.STATUS_INACTIVE)))
+        .isInstanceOf(DomainPackNotFoundException.class);
+
+    verify(versionRepository, never()).findById(any());
+    verify(riskRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("버전 미존재 → NotFoundException")
+  void should_버전없음예외_when_버전미존재() {
+    given(versionRepository.findById(10L)).willReturn(Optional.empty());
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdateRiskStatusCommand(
+                        1L, 7L, 10L, 55L, 5L, RiskDefinition.STATUS_INACTIVE)))
+        .isInstanceOf(NotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("packId 불일치 → NotFoundException")
+  void should_버전없음예외_when_packId불일치() {
+    given(versionRepository.findById(10L)).willReturn(Optional.of(draftVersion(10L, 99L)));
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdateRiskStatusCommand(
+                        1L, 7L, 10L, 55L, 5L, RiskDefinition.STATUS_INACTIVE)))
+        .isInstanceOf(NotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("위험요소 미존재 → NotFoundException")
+  void should_위험요소없음예외_when_위험요소미존재() {
+    given(versionRepository.findById(10L)).willReturn(Optional.of(draftVersion(10L, 7L)));
+    given(riskRepository.findById(55L)).willReturn(Optional.empty());
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdateRiskStatusCommand(
+                        1L, 7L, 10L, 55L, 5L, RiskDefinition.STATUS_INACTIVE)))
+        .isInstanceOf(NotFoundException.class);
+  }
+
+  private DomainPackVersion draftVersion(Long id, Long domainPackId) {
+    return DomainPackVersion.ofForTest(id, domainPackId, DomainPackVersion.STATUS_DRAFT);
+  }
+
+  private DomainPackVersion publishedVersion(Long id, Long domainPackId) {
+    return DomainPackVersion.ofForTest(id, domainPackId, DomainPackVersion.STATUS_PUBLISHED);
+  }
+
+  private RiskDefinition risk(Long id, Long versionId) {
+    RiskDefinition risk =
+        RiskDefinition.create(
+            versionId, "payment_dispute_risk", "결제 분쟁 위험", "설명", "HIGH", "{}", "{}", "[]", "{}");
+    ReflectionTestUtils.setField(risk, "id", id);
+    return risk;
+  }
+}

--- a/backend/src/test/java/com/init/domainpack/application/UpdateRiskUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/UpdateRiskUseCaseTest.java
@@ -1,0 +1,270 @@
+package com.init.domainpack.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.init.domainpack.application.exception.DomainPackNotFoundException;
+import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
+import com.init.domainpack.application.exception.DomainPackWorkspaceNotFoundException;
+import com.init.domainpack.domain.model.DomainPackVersion;
+import com.init.domainpack.domain.model.RiskDefinition;
+import com.init.domainpack.domain.repository.DomainPackVersionRepository;
+import com.init.domainpack.domain.repository.RiskDefinitionRepository;
+import com.init.shared.application.exception.BadRequestException;
+import com.init.shared.application.exception.NotFoundException;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UpdateRiskUseCase")
+class UpdateRiskUseCaseTest {
+
+  @Mock private DomainPackValidator validator;
+  @Mock private RiskDefinitionRepository riskRepository;
+  @Mock private DomainPackVersionRepository versionRepository;
+
+  private UpdateRiskUseCase useCase;
+
+  @BeforeEach
+  void setUp() {
+    useCase = new UpdateRiskUseCase(validator, riskRepository, versionRepository);
+  }
+
+  @Test
+  @DisplayName("정상 수정: DRAFT 버전의 위험요소 → 200 OK, 수정된 위험요소 반환")
+  void should_수정성공_when_DRAFT버전위험요소() {
+    given(versionRepository.findById(10L)).willReturn(Optional.of(draftVersion(10L, 7L)));
+
+    RiskDefinition risk = risk(55L, 10L);
+    given(riskRepository.findById(55L)).willReturn(Optional.of(risk));
+    given(riskRepository.save(any())).willReturn(risk);
+
+    UpdateRiskCommand command =
+        new UpdateRiskCommand(
+            1L, 7L, 10L, 55L, 5L, "결제 분쟁 위험", "설명", "high", "{}", "{}", "[]", "{}");
+
+    RiskDefinitionResponse result = useCase.execute(command);
+
+    assertThat(result.name()).isEqualTo("결제 분쟁 위험");
+    assertThat(result.riskLevel()).isEqualTo("HIGH");
+    verify(riskRepository).save(risk);
+  }
+
+  @Test
+  @DisplayName("workspace 없음 → DomainPackWorkspaceNotFoundException")
+  void should_워크스페이스없음예외_when_워크스페이스없음() {
+    org.mockito.Mockito.doThrow(new DomainPackWorkspaceNotFoundException("워크스페이스를 찾을 수 없습니다. id=1"))
+        .when(validator)
+        .validateWorkspaceAccess(1L, 5L);
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdateRiskCommand(
+                        1L, 7L, 10L, 55L, 5L, "위험요소", null, null, null, null, null, null)))
+        .isInstanceOf(DomainPackWorkspaceNotFoundException.class);
+
+    verify(versionRepository, never()).findById(any());
+    verify(riskRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("workspace 비멤버 → DomainPackUnauthorizedWorkspaceAccessException")
+  void should_권한없음예외_when_비멤버() {
+    org.mockito.Mockito.doThrow(
+            new DomainPackUnauthorizedWorkspaceAccessException("워크스페이스에 접근 권한이 없습니다."))
+        .when(validator)
+        .validateWorkspaceAccess(1L, 5L);
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdateRiskCommand(
+                        1L, 7L, 10L, 55L, 5L, "위험요소", null, null, null, null, null, null)))
+        .isInstanceOf(DomainPackUnauthorizedWorkspaceAccessException.class);
+
+    verify(versionRepository, never()).findById(any());
+    verify(riskRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("pack이 다른 workspace에 속함 → DomainPackNotFoundException")
+  void should_도메인팩없음예외_when_workspace경계위반() {
+    org.mockito.Mockito.doThrow(new DomainPackNotFoundException(7L))
+        .when(validator)
+        .validateDomainPack(7L, 1L);
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdateRiskCommand(
+                        1L, 7L, 10L, 55L, 5L, "위험요소", null, null, null, null, null, null)))
+        .isInstanceOf(DomainPackNotFoundException.class);
+
+    verify(versionRepository, never()).findById(any());
+    verify(riskRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("버전 미존재 → NotFoundException")
+  void should_버전없음예외_when_버전미존재() {
+    given(versionRepository.findById(10L)).willReturn(Optional.empty());
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdateRiskCommand(
+                        1L, 7L, 10L, 55L, 5L, "위험요소", null, null, null, null, null, null)))
+        .isInstanceOf(NotFoundException.class);
+
+    verify(riskRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("packId 불일치 → NotFoundException")
+  void should_버전없음예외_when_packId불일치() {
+    given(versionRepository.findById(10L)).willReturn(Optional.of(draftVersion(10L, 99L)));
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdateRiskCommand(
+                        1L, 7L, 10L, 55L, 5L, "위험요소", null, null, null, null, null, null)))
+        .isInstanceOf(NotFoundException.class);
+
+    verify(riskRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("PUBLISHED 버전 → BadRequestException(RISK_NOT_EDITABLE)")
+  void should_RISK_NOT_EDITABLE예외_when_PUBLISHED버전() {
+    given(versionRepository.findById(10L)).willReturn(Optional.of(publishedVersion(10L, 7L)));
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdateRiskCommand(
+                        1L, 7L, 10L, 55L, 5L, "위험요소", null, null, null, null, null, null)))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("DRAFT");
+
+    verify(riskRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("위험요소 미존재 → NotFoundException")
+  void should_위험요소없음예외_when_위험요소미존재() {
+    given(versionRepository.findById(10L)).willReturn(Optional.of(draftVersion(10L, 7L)));
+    given(riskRepository.findById(55L)).willReturn(Optional.empty());
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdateRiskCommand(
+                        1L, 7L, 10L, 55L, 5L, "위험요소", null, null, null, null, null, null)))
+        .isInstanceOf(NotFoundException.class);
+
+    verify(riskRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("위험요소의 versionId 불일치 → NotFoundException")
+  void should_위험요소없음예외_when_versionId불일치() {
+    given(versionRepository.findById(10L)).willReturn(Optional.of(draftVersion(10L, 7L)));
+
+    RiskDefinition risk = risk(55L, 999L);
+    given(riskRepository.findById(55L)).willReturn(Optional.of(risk));
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdateRiskCommand(
+                        1L, 7L, 10L, 55L, 5L, "위험요소", null, null, null, null, null, null)))
+        .isInstanceOf(NotFoundException.class);
+
+    verify(riskRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("잘못된 riskLevel 입력 → BadRequestException(VALIDATION_ERROR)")
+  void should_VALIDATION_ERROR예외_when_잘못된riskLevel() {
+    given(versionRepository.findById(10L)).willReturn(Optional.of(draftVersion(10L, 7L)));
+
+    RiskDefinition risk = risk(55L, 10L);
+    given(riskRepository.findById(55L)).willReturn(Optional.of(risk));
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdateRiskCommand(
+                        1L, 7L, 10L, 55L, 5L, "위험요소", null, "unknown", null, null, null, null)))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("Invalid riskLevel");
+
+    verify(riskRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("name이 null이면 BadRequestException(VALIDATION_ERROR)")
+  void should_VALIDATION_ERROR예외_when_nameNull() {
+    given(versionRepository.findById(10L)).willReturn(Optional.of(draftVersion(10L, 7L)));
+
+    RiskDefinition risk = risk(55L, 10L);
+    given(riskRepository.findById(55L)).willReturn(Optional.of(risk));
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdateRiskCommand(
+                        1L, 7L, 10L, 55L, 5L, null, null, null, null, null, null, null)))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("name은 필수 항목입니다.");
+
+    verify(riskRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("name이 빈 문자열이면 BadRequestException(VALIDATION_ERROR)")
+  void should_VALIDATION_ERROR예외_when_nameBlank() {
+    given(versionRepository.findById(10L)).willReturn(Optional.of(draftVersion(10L, 7L)));
+
+    RiskDefinition risk = risk(55L, 10L);
+    given(riskRepository.findById(55L)).willReturn(Optional.of(risk));
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdateRiskCommand(
+                        1L, 7L, 10L, 55L, 5L, "", null, null, null, null, null, null)))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("name은 비워둘 수 없습니다.");
+
+    verify(riskRepository, never()).save(any());
+  }
+
+  private DomainPackVersion draftVersion(Long id, Long domainPackId) {
+    return DomainPackVersion.ofForTest(id, domainPackId, DomainPackVersion.STATUS_DRAFT);
+  }
+
+  private DomainPackVersion publishedVersion(Long id, Long domainPackId) {
+    return DomainPackVersion.ofForTest(id, domainPackId, DomainPackVersion.STATUS_PUBLISHED);
+  }
+
+  private RiskDefinition risk(Long id, Long versionId) {
+    RiskDefinition risk =
+        RiskDefinition.create(
+            versionId, "payment_dispute_risk", "결제 분쟁 위험", "설명", "HIGH", "{}", "{}", "[]", "{}");
+    ReflectionTestUtils.setField(risk, "id", id);
+    return risk;
+  }
+}

--- a/backend/src/test/java/com/init/domainpack/domain/model/RiskDefinitionTest.java
+++ b/backend/src/test/java/com/init/domainpack/domain/model/RiskDefinitionTest.java
@@ -16,6 +16,7 @@ class RiskDefinitionTest {
         RiskDefinition.create(1L, "refund_risk", "환불 리스크", null, "high", null, null, null, null);
 
     assertThat(riskDefinition.getRiskLevel()).isEqualTo("HIGH");
+    assertThat(riskDefinition.getStatus()).isEqualTo(RiskDefinition.STATUS_ACTIVE);
   }
 
   @Test
@@ -27,5 +28,41 @@ class RiskDefinitionTest {
                     1L, "refund_risk", "환불 리스크", null, "unknown", null, null, null, null))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Invalid riskLevel");
+  }
+
+  @Test
+  @DisplayName("updateFields는 riskLevel을 정규화하고 필드를 갱신한다")
+  void updateFields_withValidInput_updatesFields() {
+    RiskDefinition riskDefinition =
+        RiskDefinition.create(1L, "refund_risk", "환불 리스크", null, "medium", null, null, null, null);
+
+    riskDefinition.updateFields("결제 분쟁 위험", "설명", "critical", "{\"when\":true}", "{}", "[1]", "{}");
+
+    assertThat(riskDefinition.getName()).isEqualTo("결제 분쟁 위험");
+    assertThat(riskDefinition.getDescription()).isEqualTo("설명");
+    assertThat(riskDefinition.getRiskLevel()).isEqualTo("CRITICAL");
+    assertThat(riskDefinition.getTriggerConditionJson()).isEqualTo("{\"when\":true}");
+  }
+
+  @Test
+  @DisplayName("updateFields에서 name이 null이면 예외를 던진다")
+  void updateFields_withNullName_throwsException() {
+    RiskDefinition riskDefinition =
+        RiskDefinition.create(1L, "refund_risk", "환불 리스크", null, "medium", null, null, null, null);
+
+    assertThatThrownBy(() -> riskDefinition.updateFields(null, null, null, null, null, null, null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("name은 필수 항목입니다.");
+  }
+
+  @Test
+  @DisplayName("changeStatus는 ACTIVE/INACTIVE만 허용한다")
+  void changeStatus_withInvalidValue_throwsException() {
+    RiskDefinition riskDefinition =
+        RiskDefinition.create(1L, "refund_risk", "환불 리스크", null, "medium", null, null, null, null);
+
+    assertThatThrownBy(() -> riskDefinition.changeStatus("DEPRECATED"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("허용되지 않는 status 값");
   }
 }

--- a/backend/src/test/java/com/init/domainpack/domain/model/RiskDefinitionTest.java
+++ b/backend/src/test/java/com/init/domainpack/domain/model/RiskDefinitionTest.java
@@ -56,6 +56,19 @@ class RiskDefinitionTest {
   }
 
   @Test
+  @DisplayName("changeStatus는 유효한 값으로 상태를 변경한다")
+  void changeStatus_withValidValue_updatesStatus() {
+    RiskDefinition riskDefinition =
+        RiskDefinition.create(1L, "refund_risk", "환불 리스크", null, "medium", null, null, null, null);
+
+    riskDefinition.changeStatus(RiskDefinition.STATUS_INACTIVE);
+    assertThat(riskDefinition.getStatus()).isEqualTo(RiskDefinition.STATUS_INACTIVE);
+
+    riskDefinition.changeStatus(RiskDefinition.STATUS_ACTIVE);
+    assertThat(riskDefinition.getStatus()).isEqualTo(RiskDefinition.STATUS_ACTIVE);
+  }
+
+  @Test
   @DisplayName("changeStatus는 ACTIVE/INACTIVE만 허용한다")
   void changeStatus_withInvalidValue_throwsException() {
     RiskDefinition riskDefinition =

--- a/backend/src/test/java/com/init/domainpack/presentation/UpdateRiskControllerTest.java
+++ b/backend/src/test/java/com/init/domainpack/presentation/UpdateRiskControllerTest.java
@@ -1,0 +1,187 @@
+package com.init.domainpack.presentation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.init.domainpack.application.RiskDefinitionResponse;
+import com.init.domainpack.application.UpdateRiskUseCase;
+import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
+import com.init.domainpack.application.exception.DomainPackWorkspaceNotFoundException;
+import com.init.fixtures.WithLongPrincipal;
+import com.init.shared.application.exception.BadRequestException;
+import com.init.shared.application.exception.NotFoundException;
+import com.init.shared.infrastructure.security.JwtAuthenticationFilter;
+import java.time.OffsetDateTime;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(
+    value = UpdateRiskController.class,
+    excludeFilters =
+        @ComponentScan.Filter(
+            type = FilterType.ASSIGNABLE_TYPE,
+            classes = JwtAuthenticationFilter.class))
+@DisplayName("UpdateRiskController")
+class UpdateRiskControllerTest {
+
+  private static final String BASE_URL = "/api/v1/workspaces/1/domain-packs/7/versions/10/risks/55";
+
+  private final MockMvc mockMvc;
+  private final ObjectMapper objectMapper;
+
+  @MockitoBean private UpdateRiskUseCase useCase;
+
+  @Autowired
+  UpdateRiskControllerTest(MockMvc mockMvc, ObjectMapper objectMapper) {
+    this.mockMvc = mockMvc;
+    this.objectMapper = objectMapper;
+  }
+
+  @Test
+  @DisplayName("PATCH /risks/{riskId}: DRAFT 버전 위험요소 정상 수정 → 200")
+  @WithLongPrincipal(5L)
+  void should_200반환_when_정상수정() throws Exception {
+    given(useCase.execute(any())).willReturn(sampleResponse("ACTIVE"));
+
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    objectMapper.writeValueAsString(
+                        Map.of("name", "결제 분쟁 위험", "description", "수정 설명"))))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(55))
+        .andExpect(jsonPath("$.name").value("결제 분쟁 위험"))
+        .andExpect(jsonPath("$.status").value("ACTIVE"));
+  }
+
+  @Test
+  @DisplayName("PATCH /risks/{riskId}: PUBLISHED 버전이면 400 RISK_NOT_EDITABLE")
+  @WithLongPrincipal(5L)
+  void should_400반환_when_PUBLISHED버전() throws Exception {
+    given(useCase.execute(any()))
+        .willThrow(
+            new BadRequestException("RISK_NOT_EDITABLE", "DRAFT 상태의 버전에서만 위험요소를 수정할 수 있습니다."));
+
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of("name", "이름"))))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("RISK_NOT_EDITABLE"));
+  }
+
+  @Test
+  @DisplayName("PATCH /risks/{riskId}: 위험요소 미존재 시 404")
+  @WithLongPrincipal(5L)
+  void should_404반환_when_위험요소미존재() throws Exception {
+    given(useCase.execute(any()))
+        .willThrow(new NotFoundException("NOT_FOUND", "위험요소를 찾을 수 없습니다: 55"));
+
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of("name", "이름"))))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("NOT_FOUND"));
+  }
+
+  @Test
+  @DisplayName("PATCH /risks/{riskId}: name이 빈 값이면 400 VALIDATION_ERROR")
+  @WithLongPrincipal(5L)
+  void should_400반환_when_nameBlank() throws Exception {
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of("name", ""))))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+
+    verifyNoInteractions(useCase);
+  }
+
+  @Test
+  @DisplayName("PATCH /risks/{riskId}: 워크스페이스 멤버십 없을 때 403")
+  @WithLongPrincipal(5L)
+  void should_403반환_when_비멤버() throws Exception {
+    given(useCase.execute(any()))
+        .willThrow(new DomainPackUnauthorizedWorkspaceAccessException("접근 권한이 없습니다."));
+
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of("name", "이름"))))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @DisplayName("PATCH /risks/{riskId}: 워크스페이스 없을 때 404")
+  @WithLongPrincipal(5L)
+  void should_404반환_when_워크스페이스없음() throws Exception {
+    given(useCase.execute(any()))
+        .willThrow(new DomainPackWorkspaceNotFoundException("워크스페이스를 찾을 수 없습니다. id=1"));
+
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of("name", "이름"))))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  @DisplayName("PATCH /risks/{riskId}: 인증 없는 요청 → 401")
+  void should_401반환_when_인증없음() throws Exception {
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of("name", "이름"))))
+        .andExpect(status().isUnauthorized());
+
+    verifyNoInteractions(useCase);
+  }
+
+  private RiskDefinitionResponse sampleResponse(String status) {
+    return new RiskDefinitionResponse(
+        55L,
+        10L,
+        "payment_dispute_risk",
+        "결제 분쟁 위험",
+        "수정 설명",
+        "HIGH",
+        "{}",
+        "{}",
+        "[]",
+        "{}",
+        status,
+        OffsetDateTime.parse("2026-04-16T10:00:00Z"),
+        OffsetDateTime.parse("2026-04-16T10:30:00Z"));
+  }
+}

--- a/backend/src/test/java/com/init/domainpack/presentation/UpdateRiskStatusControllerTest.java
+++ b/backend/src/test/java/com/init/domainpack/presentation/UpdateRiskStatusControllerTest.java
@@ -1,0 +1,200 @@
+package com.init.domainpack.presentation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.init.domainpack.application.RiskDefinitionResponse;
+import com.init.domainpack.application.UpdateRiskStatusUseCase;
+import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
+import com.init.domainpack.application.exception.DomainPackWorkspaceNotFoundException;
+import com.init.fixtures.WithLongPrincipal;
+import com.init.shared.application.exception.BadRequestException;
+import com.init.shared.application.exception.NotFoundException;
+import com.init.shared.infrastructure.security.JwtAuthenticationFilter;
+import java.time.OffsetDateTime;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(
+    value = UpdateRiskStatusController.class,
+    excludeFilters =
+        @ComponentScan.Filter(
+            type = FilterType.ASSIGNABLE_TYPE,
+            classes = JwtAuthenticationFilter.class))
+@DisplayName("UpdateRiskStatusController")
+class UpdateRiskStatusControllerTest {
+
+  private static final String BASE_URL =
+      "/api/v1/workspaces/1/domain-packs/7/versions/10/risks/55/status";
+
+  private final MockMvc mockMvc;
+  private final ObjectMapper objectMapper;
+
+  @MockitoBean private UpdateRiskStatusUseCase useCase;
+
+  @Autowired
+  UpdateRiskStatusControllerTest(MockMvc mockMvc, ObjectMapper objectMapper) {
+    this.mockMvc = mockMvc;
+    this.objectMapper = objectMapper;
+  }
+
+  @Test
+  @DisplayName("PATCH /risks/{riskId}/status: INACTIVE 전환 → 200")
+  @WithLongPrincipal(5L)
+  void should_200반환_when_INACTIVE전환() throws Exception {
+    given(useCase.execute(any())).willReturn(sampleResponse("INACTIVE"));
+
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of("status", "INACTIVE"))))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.status").value("INACTIVE"));
+  }
+
+  @Test
+  @DisplayName("PATCH /risks/{riskId}/status: 허용되지 않는 status 값이면 400")
+  @WithLongPrincipal(5L)
+  void should_400반환_when_잘못된status() throws Exception {
+    given(useCase.execute(any()))
+        .willThrow(new BadRequestException("VALIDATION_ERROR", "허용되지 않는 status 값입니다: DEPRECATED"));
+
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of("status", "DEPRECATED"))))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+  }
+
+  @Test
+  @DisplayName("PATCH /risks/{riskId}/status: PUBLISHED 버전이면 400 RISK_NOT_EDITABLE")
+  @WithLongPrincipal(5L)
+  void should_400반환_when_PUBLISHED버전() throws Exception {
+    given(useCase.execute(any()))
+        .willThrow(
+            new BadRequestException("RISK_NOT_EDITABLE", "DRAFT 상태의 버전에서만 위험요소를 수정할 수 있습니다."));
+
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of("status", "INACTIVE"))))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("RISK_NOT_EDITABLE"));
+  }
+
+  @Test
+  @DisplayName("PATCH /risks/{riskId}/status: 위험요소 미존재 시 404")
+  @WithLongPrincipal(5L)
+  void should_404반환_when_위험요소미존재() throws Exception {
+    given(useCase.execute(any()))
+        .willThrow(new NotFoundException("NOT_FOUND", "위험요소를 찾을 수 없습니다: 55"));
+
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of("status", "INACTIVE"))))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("NOT_FOUND"));
+  }
+
+  @Test
+  @DisplayName("PATCH /risks/{riskId}/status: 워크스페이스 멤버십 없을 때 403")
+  @WithLongPrincipal(5L)
+  void should_403반환_when_비멤버() throws Exception {
+    given(useCase.execute(any()))
+        .willThrow(new DomainPackUnauthorizedWorkspaceAccessException("접근 권한이 없습니다."));
+
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of("status", "INACTIVE"))))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @DisplayName("PATCH /risks/{riskId}/status: 워크스페이스 없을 때 404")
+  @WithLongPrincipal(5L)
+  void should_404반환_when_워크스페이스없음() throws Exception {
+    given(useCase.execute(any()))
+        .willThrow(new DomainPackWorkspaceNotFoundException("워크스페이스를 찾을 수 없습니다. id=1"));
+
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of("status", "INACTIVE"))))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  @DisplayName("PATCH /risks/{riskId}/status: status 미전송 시 400")
+  @WithLongPrincipal(5L)
+  void should_400반환_when_statusBlank() throws Exception {
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of("status", ""))))
+        .andExpect(status().isBadRequest());
+
+    verifyNoInteractions(useCase);
+  }
+
+  @Test
+  @DisplayName("PATCH /risks/{riskId}/status: 인증 없는 요청 → 401")
+  void should_401반환_when_인증없음() throws Exception {
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of("status", "INACTIVE"))))
+        .andExpect(status().isUnauthorized());
+
+    verifyNoInteractions(useCase);
+  }
+
+  private RiskDefinitionResponse sampleResponse(String status) {
+    return new RiskDefinitionResponse(
+        55L,
+        10L,
+        "payment_dispute_risk",
+        "결제 분쟁 위험",
+        "수정 설명",
+        "HIGH",
+        "{}",
+        "{}",
+        "[]",
+        "{}",
+        status,
+        OffsetDateTime.parse("2026-04-16T10:00:00Z"),
+        OffsetDateTime.parse("2026-04-16T10:30:00Z"));
+  }
+}

--- a/backend/src/test/java/com/init/domainpack/presentation/UpdateRiskStatusControllerTest.java
+++ b/backend/src/test/java/com/init/domainpack/presentation/UpdateRiskStatusControllerTest.java
@@ -69,6 +69,22 @@ class UpdateRiskStatusControllerTest {
   }
 
   @Test
+  @DisplayName("PATCH /risks/{riskId}/status: ACTIVE 전환 → 200")
+  @WithLongPrincipal(5L)
+  void should_200반환_when_ACTIVE전환() throws Exception {
+    given(useCase.execute(any())).willReturn(sampleResponse("ACTIVE"));
+
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of("status", "ACTIVE"))))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.status").value("ACTIVE"));
+  }
+
+  @Test
   @DisplayName("PATCH /risks/{riskId}/status: 허용되지 않는 status 값이면 400")
   @WithLongPrincipal(5L)
   void should_400반환_when_잘못된status() throws Exception {
@@ -153,7 +169,7 @@ class UpdateRiskStatusControllerTest {
   }
 
   @Test
-  @DisplayName("PATCH /risks/{riskId}/status: status 미전송 시 400")
+  @DisplayName("PATCH /risks/{riskId}/status: status 공백값이면 400")
   @WithLongPrincipal(5L)
   void should_400반환_when_statusBlank() throws Exception {
     mockMvc
@@ -162,6 +178,21 @@ class UpdateRiskStatusControllerTest {
                 .with(csrf())
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(Map.of("status", ""))))
+        .andExpect(status().isBadRequest());
+
+    verifyNoInteractions(useCase);
+  }
+
+  @Test
+  @DisplayName("PATCH /risks/{riskId}/status: status 키 누락 시 400")
+  @WithLongPrincipal(5L)
+  void should_400반환_when_statusMissing() throws Exception {
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"))
         .andExpect(status().isBadRequest());
 
     verifyNoInteractions(useCase);

--- a/backend/src/test/java/com/init/domainpack/presentation/UpdateRiskStatusControllerTest.java
+++ b/backend/src/test/java/com/init/domainpack/presentation/UpdateRiskStatusControllerTest.java
@@ -188,11 +188,7 @@ class UpdateRiskStatusControllerTest {
   @WithLongPrincipal(5L)
   void should_400반환_when_statusMissing() throws Exception {
     mockMvc
-        .perform(
-            patch(BASE_URL)
-                .with(csrf())
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("{}"))
+        .perform(patch(BASE_URL).with(csrf()).contentType(MediaType.APPLICATION_JSON).content("{}"))
         .andExpect(status().isBadRequest());
 
     verifyNoInteractions(useCase);


### PR DESCRIPTION
## 요약
- 328 spec 기준으로 risk 일반 수정 API와 risk status 전환 API를 구현했습니다.
- `RiskDefinition`에 `status`, 수정 메서드, 상태 전환 메서드를 추가하고 `pack.risk_definition`용 migration을 반영했습니다.
- application/presentation/test 계층을 `policy`/`slot` 패턴에 맞춰 추가했습니다.

## 변경 사항
- `UpdateRiskUseCase`, `UpdateRiskStatusUseCase` 추가
- `UpdateRiskController`, `UpdateRiskStatusController` 및 request DTO 추가
- `RiskDefinitionResponse`, command 객체 추가
- `RiskDefinitionRepository` 읽기/쓰기 메서드 확장
- `RiskDefinition` 도메인 로직 확장
- `pack.risk_definition.status` Liquibase changeset 추가
- `.agent/docs/schema.md`에 risk status 반영
- use case / controller / domain 테스트 추가

## 검증
- `cd backend && ./gradlew spotlessApply`
- `cd backend && ./gradlew test --tests 'com.init.domainpack.domain.model.RiskDefinitionTest' --tests 'com.init.domainpack.application.UpdateRiskUseCaseTest' --tests 'com.init.domainpack.application.UpdateRiskStatusUseCaseTest' --tests 'com.init.domainpack.presentation.UpdateRiskControllerTest' --tests 'com.init.domainpack.presentation.UpdateRiskStatusControllerTest'`

## 참고
- `spec/328` PR이 `main`에 머지된 뒤, 현재 feature 브랜치는 최신 `origin/main`을 병합해 코드 diff만 남기도록 정리했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 위험요소에 상태(status: ACTIVE/INACTIVE) 필드 추가 및 기본값 ACTIVE 적용
  * 위험요소 상태 변경용 PATCH API 추가
  * 위험요소 세부정보 수정용 PATCH API 추가
  * 응답에 위험요소 상태와 타임스탬프 포함

* **문서**
  * 위험 정의 스키마 문서에 status 필드 및 제약사항(허용값) 반영

* **테스트**
  * 상태 변경 및 수정 흐름에 대한 단위/웹 계층 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->