### PR TITLE
spec/114: 상담 데이터 원본 파일 클라우드 스토리지 선정 및 세팅 및 저장

### DIFF
--- a/.agent/specs/114.md
+++ b/.agent/specs/114.md
@@ -1,0 +1,430 @@
+# [Infra] 1.1.4 상담 데이터 raw 파일 클라우드 스토리지 선정 및 세팅 및 저장
+
+**Canonical Number**: `114`
+**Branch**: `spec/114`
+**Template Base**: `_TEMPLATE_BE.md`
+**작성일**: 2026-04-16
+
+---
+
+## Goal
+
+운영자가 `multipart/form-data`로 상담 로그 JSON 파일을 업로드하면, 서버가 AWS S3(로컬 개발: MinIO)에 원본을 저장하고, 파싱하여 PostgreSQL `corpus` 스키마에 적재한 뒤 Airflow ingestion 파이프라인을 트리거하는 신규 엔드포인트와 스토리지 어댑터를 구축한다.
+
+---
+
+## Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    actor op as Operator
+    participant ctrl as DatasetController
+    participant svc as RawFileUploadService
+    participant store as RawFileStoragePort
+    participant rawSvc as RawDatasetUploadService (기존)
+    participant rfRepo as DatasetRawFileRepository
+    participant air as IngestionTriggerPort
+    participant db as PostgreSQL
+
+    op ->> ctrl: POST /raw-file (multipart)
+    ctrl ->> svc: upload(RawFileUploadCommand)
+    Note over svc: validateWorkspace + membership + datasetKey (fail-fast)
+    svc ->> svc: bufferFileBytes + computeChecksumSha256
+    svc ->> store: put(objectKey, bytes, contentType)
+    store -->> svc: objectKey [U-01: 형식 미확정]
+    svc ->> svc: parseJsonToConversations(bytes)
+    svc ->> rawSvc: upload(RawDatasetUploadCommand)
+    rawSvc ->> db: INSERT corpus.dataset + conversation + conversation_turn
+    db -->> rawSvc: ok
+    rawSvc -->> svc: DatasetUploadResult(datasetId)
+    svc ->> rfRepo: save(DatasetRawFile)
+    rfRepo ->> db: INSERT corpus.dataset_raw_file
+    db -->> rfRepo: ok
+    svc ->> air: trigger(datasetId, objectKey) [U-08: payload 미확정]
+    air -->> svc: ack
+    svc -->> ctrl: RawFileUploadResult
+    ctrl -->> op: 201 Created
+```
+
+> **주의**: S3 put 성공 후 DB 실패 시 orphan 파일 처리 정책은 미확정.
+> `.handoff/114/uncertainty-register-114.md` U-05 참조.
+
+---
+
+## REST API
+
+### Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/api/v1/workspaces/{workspaceId}/datasets/raw-file` | multipart 파일 업로드 **(신규)** |
+| POST | `/api/v1/workspaces/{workspaceId}/datasets/raw` | JSON body 직접 업로드 (기존, 유지) |
+
+### Request
+
+**POST /api/v1/workspaces/{workspaceId}/datasets/raw-file**
+
+`Content-Type: multipart/form-data`
+
+| Part | Type | Required | Constraints | Description |
+|------|------|----------|-------------|-------------|
+| `file` | `MultipartFile` | Yes | `.json` 파일 | 상담 로그 JSON 배열 파일 |
+| `datasetKey` | `@RequestParam` | Yes | max 100자 | 데이터셋 식별 키 |
+| `name` | `@RequestParam` | Yes | max 255자 | 데이터셋 이름 |
+| `sourceType` | `@RequestParam` | Yes | max 50자 | 소스 타입 |
+
+> **파일 크기 상한**: 50MB / 파일 1개 per 요청. `spring.servlet.multipart.max-file-size=50MB` 설정 필요.
+
+JSON 파일 포맷 (배열):
+
+```json
+[
+  {
+    "source_id": "40001",
+    "source": "엘지유플러스",
+    "consulting_category": "배송문의",
+    "client_gender": "",
+    "client_age": "",
+    "consulting_turns": "49",
+    "consulting_length": 592,
+    "consulting_content": "상담사: ...\n고객: ..."
+  }
+]
+```
+
+### Response
+
+**201 Created**
+
+```json
+{
+  "datasetId": 42,
+  "datasetKey": "lgu-2026-04",
+  "workspaceId": 1,
+  "objectKey": "workspaces/1/datasets/lgu-2026-04/엘지유플러스_1.json",
+  "originalFilename": "엘지유플러스_1.json",
+  "sizeBytes": 17825792,
+  "status": "READY",
+  "piiRedactionStatus": "PENDING",
+  "conversationCount": 3216
+}
+```
+
+**400 Bad Request** — 파일 없음 / 검증 실패 / JSON 파싱 오류
+
+```json
+{
+  "code": "VALIDATION_ERROR",
+  "message": "파일이 없거나 형식이 올바르지 않습니다."
+}
+```
+
+**403 Forbidden** — 비멤버 접근
+
+```json
+{
+  "code": "UNAUTHORIZED_WORKSPACE_ACCESS",
+  "message": "워크스페이스에 접근 권한이 없습니다."
+}
+```
+
+**404 Not Found** — 워크스페이스 미존재
+
+```json
+{
+  "code": "NOT_FOUND",
+  "message": "워크스페이스를 찾을 수 없습니다. id=999"
+}
+```
+
+**409 Conflict** — datasetKey 중복
+
+```json
+{
+  "code": "DATASET_KEY_CONFLICT",
+  "message": "이미 사용 중인 데이터셋 키입니다: lgu-2026-04"
+}
+```
+
+**500 Internal Server Error**
+
+```json
+{
+  "code": "INTERNAL_SERVER_ERROR",
+  "message": "서버 오류가 발생했습니다."
+}
+```
+
+---
+
+## Class Design
+
+### DDD Layered Structure
+
+```
+corpus/
+├── presentation/
+│   ├── DatasetController.java                    (기존 — 신규 메서드 추가)
+│   └── dto/
+│       └── RawFileUploadResponse.java            (신규)
+├── application/
+│   ├── RawFileUploadService.java                 (신규 — 오케스트레이터)
+│   ├── RawFileUploadCommand.java                 (신규)
+│   └── port/
+│       ├── RawFileStoragePort.java               (신규 — S3 인터페이스)
+│       └── IngestionTriggerPort.java             (신규 — Airflow 트리거 인터페이스)
+├── domain/
+│   ├── model/
+│   │   └── DatasetRawFile.java                   (신규 — corpus.dataset_raw_file 엔티티)
+│   └── repository/
+│       └── DatasetRawFileRepository.java         (신규 인터페이스)
+└── infrastructure/
+    ├── storage/
+    │   └── S3RawFileStorageAdapter.java          (신규 — AWS SDK v2, MinIO 호환)
+    ├── airflow/
+    │   └── AirflowIngestionTriggerAdapter.java   (신규)
+    └── persistence/
+        └── JpaDatasetRawFileRepository.java      (신규)
+```
+
+### Aggregate Design
+
+```java
+// corpus/domain/model/DatasetRawFile.java
+@Entity
+@Table(name = "dataset_raw_file", schema = "corpus")
+public class DatasetRawFile {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "dataset_id", nullable = false)
+    private Long datasetId;
+
+    @Column(name = "object_key", nullable = false, length = 1024)
+    private String objectKey;
+
+    @Column(name = "original_filename", nullable = false, length = 255)
+    private String originalFilename;
+
+    @Column(name = "content_type", nullable = false, length = 100)
+    private String contentType;
+
+    @Column(name = "size_bytes", nullable = false)
+    private Long sizeBytes;
+
+    @Column(name = "checksum_sha256", nullable = false, length = 64)
+    private String checksumSha256;
+
+    @Column(name = "uploaded_at", nullable = false)
+    private Instant uploadedAt;
+
+    // public setter 금지 — 상태 변경은 도메인 메서드로만
+    public static DatasetRawFile create(
+            Long datasetId, String objectKey, String originalFilename,
+            String contentType, Long sizeBytes, String checksumSha256) {
+        // factory method — uploadedAt = Instant.now()
+    }
+}
+```
+
+### Port Interfaces
+
+```java
+// application/port/RawFileStoragePort.java
+public interface RawFileStoragePort {
+    /**
+     * objectKey 위치에 파일 bytes를 저장하고 확정된 objectKey를 반환한다.
+     * endpoint는 프로파일에 따라 AWS S3 또는 MinIO로 전환된다.
+     */
+    String put(String objectKey, byte[] content, String contentType);
+
+    /**
+     * objectKey 위치의 파일을 삭제한다.
+     * S3 put 성공 + DB 실패 시 orphan 보상 처리용.
+     */
+    void delete(String objectKey);
+}
+
+// application/port/IngestionTriggerPort.java
+public interface IngestionTriggerPort {
+    /**
+     * Airflow ingestion 파이프라인을 트리거한다.
+     * payload 스펙은 uncertainty-register-114.md U-08 참조.
+     */
+    void trigger(Long datasetId, String objectKey);
+}
+```
+
+### Command / Response
+
+```java
+// application/RawFileUploadCommand.java
+public record RawFileUploadCommand(
+    Long workspaceId,
+    String datasetKey,
+    String name,
+    String sourceType,
+    Long createdBy,
+    byte[] fileBytes,         // controller가 MultipartFile.getBytes()로 추출
+    String originalFilename,
+    String contentType,
+    long sizeBytes
+) {}
+
+// presentation/dto/RawFileUploadResponse.java
+public record RawFileUploadResponse(
+    Long datasetId,
+    String datasetKey,
+    Long workspaceId,
+    String objectKey,
+    String originalFilename,
+    Long sizeBytes,
+    String status,
+    String piiRedactionStatus,
+    int conversationCount
+) {}
+```
+
+---
+
+## Tests
+
+### Unit Tests
+
+```java
+@DisplayName("RawFileUploadService")
+@ExtendWith(MockitoExtension.class)
+class RawFileUploadServiceTest {
+
+    @Test
+    @DisplayName("should_성공_when_유효한_multipart_파일")
+    void upload_success_returnsRawFileUploadResult() {
+        // given — mock storagePort, mock rawDatasetUploadService, mock repo, mock triggerPort
+        // when
+        // then — storagePort.put() 1회, rawDatasetUploadService.upload() 1회,
+        //         repo.save() 1회, triggerPort.trigger() 1회
+    }
+
+    @Test
+    @DisplayName("should_throw_WorkspaceNotFoundException_when_워크스페이스_없음")
+    void upload_workspaceNotFound_throwsException() { }
+
+    @Test
+    @DisplayName("should_throw_UnauthorizedWorkspaceAccessException_when_비멤버")
+    void upload_notMember_throwsException() { }
+
+    @Test
+    @DisplayName("should_throw_DatasetKeyConflictException_when_키_중복")
+    void upload_datasetKeyConflict_throwsException() { }
+}
+```
+
+```java
+@DisplayName("DatasetRawFile")
+class DatasetRawFileTest {
+    @Test
+    @DisplayName("should_create_with_all_required_fields")
+    void create_withValidFields_returnsEntity() {
+        // given / when / then — all fields set, uploadedAt is non-null
+    }
+}
+```
+
+### Integration Tests
+
+```java
+@WebMvcTest(DatasetController.class)
+@DisplayName("DatasetController — raw-file upload")
+class DatasetControllerRawFileTest {
+
+    @Test
+    @DisplayName("POST /raw-file — 성공 시 201 반환")
+    void uploadRawFile_returns201() throws Exception {
+        // given
+        MockMultipartFile mockFile = new MockMultipartFile(
+            "file", "test.json", "application/json", validJsonBytes);
+        given(rawFileUploadService.upload(any())).willReturn(validResult);
+
+        // when & then
+        mockMvc.perform(multipart("/api/v1/workspaces/1/datasets/raw-file")
+                .file(mockFile)
+                .param("datasetKey", "test-key")
+                .param("name", "테스트 데이터셋")
+                .param("sourceType", "LGU"))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.datasetId").isNumber())
+            .andExpect(jsonPath("$.objectKey").isString());
+    }
+
+    @Test
+    @DisplayName("POST /raw-file — file 파트 없음 시 400")
+    void uploadRawFile_missingFile_returns400() throws Exception { }
+}
+```
+
+### Test Checklist
+
+- [ ] 정상 시나리오: 유효 multipart → 201 + datasetId/objectKey 반환
+- [ ] file 파트 누락 → 400
+- [ ] datasetKey 누락 → 400
+- [ ] 잘못된 JSON 파일 → 400
+- [ ] 워크스페이스 없음 → 404
+- [ ] 비멤버 접근 → 403
+- [ ] datasetKey 중복 → 409
+- [ ] S3RawFileStorageAdapter 단위: MinIO endpoint override + put 동작 검증
+- [ ] 트랜잭션: corpus.dataset_raw_file INSERT 실패 시 롤백 확인
+
+---
+
+## Database
+
+### Migration (Liquibase — `db.changelog-master.sql` 말미에 추가)
+
+```sql
+--changeset devjhan:20260416-create-corpus-dataset-raw-file-table
+--comment: S3 원본 파일 메타데이터 보관 테이블 신설 (archive + audit 목적)
+CREATE TABLE corpus.dataset_raw_file (
+    id                BIGSERIAL     PRIMARY KEY,
+    dataset_id        BIGINT        NOT NULL REFERENCES corpus.dataset(id) ON DELETE CASCADE,
+    object_key        VARCHAR(1024) NOT NULL,
+    original_filename VARCHAR(255)  NOT NULL,
+    content_type      VARCHAR(100)  NOT NULL,
+    size_bytes        BIGINT        NOT NULL,
+    checksum_sha256   VARCHAR(64)   NOT NULL,
+    uploaded_at       TIMESTAMPTZ   NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_dataset_raw_file_dataset_id
+    ON corpus.dataset_raw_file(dataset_id);
+```
+
+> **corpus.dataset 변경 없음** — Confirmed.
+
+---
+
+## Additional Notes
+
+- **계층 의존성**: `presentation → application → domain ← infrastructure` (DDD 표준).
+- `RawDatasetUploadService`는 내부 위임 호출로만 사용. 기존 코드 변경 없음.
+- `S3RawFileStorageAdapter`는 `software.amazon.awssdk:s3` (v2) 사용.
+  `EndpointOverride` 설정으로 MinIO(local)와 AWS S3(prod/dev)를 프로파일별 전환.
+- **S3 object key 형식** (Confirmed): `workspaces/{workspaceId}/datasets/{datasetKey}/{originalFilename}`
+- **버킷 전략** (Confirmed): 환경별 버킷 분리 + 워크스페이스는 object key 경로로 분리.
+  버킷명 예: `init-raw-files-prod`, `init-raw-files-dev`, `init-raw-files-local`.
+  `STORAGE_S3_BUCKET` 환경 변수로 배포 환경별 주입.
+- **파일 크기 상한** (Confirmed): 50MB / 1 파일 per 요청.
+  `spring.servlet.multipart.max-file-size=50MB`, `max-request-size=55MB` 설정 필요.
+- **`consulting_content` 제한** (Confirmed): `/raw-file` 경로는 제한 없음.
+  기존 `/raw` 경로의 `@Size(max = 5000)` 제약은 변경하지 않음.
+- **Orphan 처리** (Confirmed): S3 put 성공 + DB 실패 시, best-effort `S3Client.deleteObject()` 호출.
+  deleteObject 자체 실패 시 WARN 로그 + 원 DB 예외를 caller에게 propagate.
+- **Airflow 트리거** (Assumption — NOOP stub): payload 미확정으로 `AirflowIngestionTriggerAdapter`는
+  NOOP 구현으로 임시 대체. `// TODO: spec/114 U-08` 주석 포함 필수.
+- `@Transactional(readOnly = true)` 기본값 + 쓰기 메서드 개별 오버라이드 패턴 적용.
+- `RawFileUploadService`는 fail-fast를 위해 S3 IO 전에 workspace/membership/datasetKey 검증 선행.
+  (`RawDatasetUploadService` 내부 재검증과 중복되나 불필요한 S3 IO 방지를 위해 유지.)
+- 보조 설계 문서:
+  - ADR: `.agent/specs/114/adr-storage-selection.md`
+  - 인프라 런북: `.agent/specs/114/infra-setup.md`
+  - 불확실성 관리: `.handoff/114/uncertainty-register-114.md`

--- a/.agent/specs/114.md
+++ b/.agent/specs/114.md
@@ -46,8 +46,8 @@ sequenceDiagram
     ctrl -->> op: 201 Created
 ```
 
-> **주의**: S3 put 성공 후 DB 실패 시 orphan 파일 처리 정책은 미확정.
-> `.handoff/114/uncertainty-register-114.md` U-05 참조.
+> **확정**: S3 put 성공 후 DB 실패 시 orphan 파일 처리 정책: best-effort delete + WARN 로그 + 원예외 전파.
+> 상세 결정 근거는 `.handoff/114/uncertainty-register-114.md` U-05 참조.
 
 ---
 
@@ -101,7 +101,7 @@ JSON 파일 포맷 (배열):
   "datasetId": 42,
   "datasetKey": "lgu-2026-04",
   "workspaceId": 1,
-  "objectKey": "workspaces/1/datasets/lgu-2026-04/엘지유플러스_1.json",
+  "objectKey": "workspaces/1/datasets/lgu-2026-04/a1b2c3d4-e5f6-7890-abcd-ef1234567890_lgu-2026-04_1.json",
   "originalFilename": "엘지유플러스_1.json",
   "sizeBytes": 17825792,
   "status": "READY",
@@ -409,7 +409,11 @@ CREATE INDEX idx_dataset_raw_file_dataset_id
 - `RawDatasetUploadService`는 내부 위임 호출로만 사용. 기존 코드 변경 없음.
 - `S3RawFileStorageAdapter`는 `software.amazon.awssdk:s3` (v2) 사용.
   `EndpointOverride` 설정으로 MinIO(local)와 AWS S3(prod/dev)를 프로파일별 전환.
-- **S3 object key 형식** (Confirmed): `workspaces/{workspaceId}/datasets/{datasetKey}/{originalFilename}`
+- **S3 object key 형식** (Confirmed): `workspaces/{workspaceId}/datasets/{datasetKey}/{uniquePrefix}_{normalizedFilename}`
+  - `normalizedFilename`: `originalFilename`에서 허용 문자(`[a-zA-Z0-9._-]`) 외 문자(슬래시, 제어 문자 등) 제거/치환한 결과
+  - `uniquePrefix`: UUID v4 또는 SHA-256 콘텐츠 해시 앞 8자 — key 충돌 방지 및 동명 파일 재업로드 허용
+  - 예: `a1b2c3d4-e5f6-7890-abcd-ef1234567890_lgu-2026-04_1.json`
+  - **raw `originalFilename`을 objectKey에 직접 사용 금지** — 경로 순회(`../`), 특수문자, URL 인코딩 문제 방지
 - **버킷 전략** (Confirmed): 환경별 버킷 분리 + 워크스페이스는 object key 경로로 분리.
   버킷명 예: `init-raw-files-prod`, `init-raw-files-dev`, `init-raw-files-local`.
   `STORAGE_S3_BUCKET` 환경 변수로 배포 환경별 주입.

--- a/.agent/specs/114/adr-storage-selection.md
+++ b/.agent/specs/114/adr-storage-selection.md
@@ -1,0 +1,88 @@
+# ADR-114: 클라우드 스토리지 Provider 선정 및 로컬 개발 전략
+
+**Status**: Accepted
+**Date**: 2026-04-16
+**Context**: spec/114 — [Infra] 1.1.4 상담 데이터 raw 파일 클라우드 스토리지
+
+---
+
+## Context
+
+상담 로그 원본 JSON 파일을 서버 proxy 방식으로 수신하여 클라우드 오브젝트 스토리지에 영구 보관해야 한다.
+
+아키텍처 의도:
+- S3는 원본 아카이브 및 감사(audit) 목적으로 사용
+- Airflow는 PostgreSQL DB를 주입력으로 사용하며, S3는 재처리·감사용 아카이브
+- 운영자가 multipart 업로드 → 서버가 S3에 저장 + 파싱하여 DB 적재 + Airflow 웹훅
+
+로컬 개발 환경에서 실제 클라우드 의존 없이 개발/테스트 가능한 에뮬레이터가 필요하다.
+
+---
+
+## Decision
+
+**Cloud Provider**: AWS S3
+
+**로컬 개발 에뮬레이터**: MinIO (docker-compose 서비스로 추가)
+
+---
+
+## Rationale
+
+### AWS S3 선택 이유
+
+| 기준 | 근거 |
+|------|------|
+| 스택 일관성 | Airflow를 AWS Fargate에서 구동 예정 → AWS 생태계 일원화 |
+| IAM 통합 | Fargate Task Role로 cross-service 자격증명 관리 가능, 별도 Key 관리 불필요 |
+| SDK 성숙도 | `software.amazon.awssdk:s3` (v2)는 Spring Boot 3.x + Java 21 호환 |
+| 운영 경험 | 팀 AWS 인프라 경험 우선 |
+
+### MinIO 선택 이유 (로컬 개발)
+
+- AWS S3 API 완전 호환 → 동일 SDK, 동일 코드로 전환 가능
+- docker-compose 단일 서비스로 추가 (공식 이미지: `minio/minio`)
+- 로컬/CI에서 실제 AWS 자격증명 불필요
+- 무료 오픈소스
+
+---
+
+## Alternatives Considered
+
+| Provider | 기각 이유 |
+|----------|----------|
+| Google Cloud Storage | Fargate(AWS) 사용 시 cross-cloud 복잡도 증가; GCS SDK는 별도 의존성 |
+| Azure Blob Storage | 팀 Azure 경험 부재; 스택 불일치 |
+| 자가 호스팅 MinIO (전용, 운영) | 고가용성 및 운영 부담 증가; S3 대비 생태계 지원 부족 |
+| LocalStack | MinIO 대비 설정 복잡; 유료 기능 필요 가능성 |
+
+---
+
+## Implementation Notes
+
+- `RawFileStoragePort` 인터페이스 → `S3RawFileStorageAdapter` 구현체
+- `S3Client` 빌더에서 `endpointOverride` 설정으로 MinIO/AWS 전환:
+  ```java
+  S3Client.builder()
+      .endpointOverride(URI.create(endpoint))  // 비어있으면 AWS 기본값
+      .credentialsProvider(...)
+      .forcePathStyle(pathStyleAccess)          // MinIO는 true 필수
+      .build()
+  ```
+- 프로파일별 전환: `application-local.yml`에서 MinIO 엔드포인트/자격증명 주입
+- 실제 AWS 버킷 생성 및 IAM 설정은 이 스펙의 **out-of-scope** (인프라팀 별도 작업)
+
+---
+
+## Consequences
+
+### 긍정적
+- AWS Fargate + S3 동일 생태계로 IAM Role 자격증명 관리 단순화
+- MinIO로 로컬 개발/CI에서 실제 AWS 자격증명 없이 완전한 스토리지 테스트 가능
+- `EndpointOverride` 패턴으로 프로파일별 전환이 코드 변경 없이 설정만으로 가능
+
+### 부정적 / 주의
+- `software.amazon.awssdk:s3` 의존성 추가 필요 (build.gradle)
+- 실제 AWS 버킷 생성/IAM Role 설정은 별도 인프라 작업 필요
+- MinIO와 AWS S3 간 edge case 차이 (복합 업로드, presigned URL 등) 주의 필요
+  (이 스펙은 단순 `putObject` 사용으로 해당 없음)

--- a/.agent/specs/114/adr-storage-selection.md
+++ b/.agent/specs/114/adr-storage-selection.md
@@ -40,8 +40,13 @@
 
 ### MinIO 선택 이유 (로컬 개발)
 
-- AWS S3 API 완전 호환 → 동일 SDK, 동일 코드로 전환 가능
-- docker-compose 단일 서비스로 추가 (공식 이미지: `minio/minio`)
+- AWS S3 API **높은 호환성** → 동일 SDK(`software.amazon.awssdk:s3`), 동일 코드로 전환 가능
+  - **호환성 주의 사항**:
+    - Presigned URL: 헤더/서명 방식 일부 차이 — MinIO는 `x-amz-*` 헤더 처리 방식이 S3와 상이할 수 있음
+    - Multipart Upload 제한: `ListMultipartUploads`는 정확한 object name 필요, `AbortIncompleteMultipartUpload` 정책 미지원, `aws-chunked` 인코딩 16 MiB 초과 시 업로드 오류 가능
+    - `putObject` 메타데이터/헤더 권한: 커스텀 헤더(`x-amz-meta-*`) 처리 및 권한 모델 일부 차이 있음
+  - **이 스펙 범위(단순 `putObject`)는 위 edge case 해당 없음** — 향후 presigned URL·multipart 도입 시 재검토 필요
+- docker-compose 단일 서비스로 추가 (공식 이미지: `minio/minio`, 호환성 주의 사항은 위 참조)
 - 로컬/CI에서 실제 AWS 자격증명 불필요
 - 무료 오픈소스
 

--- a/.agent/specs/114/infra-setup.md
+++ b/.agent/specs/114/infra-setup.md
@@ -1,0 +1,128 @@
+# 인프라 런북: spec/114 스토리지 로컬 개발 세팅
+
+**Scope**: docker-compose MinIO 서비스 추가, application.yml 프로파일별 스토리지 설정 주입
+**Out of Scope**: 실제 AWS S3 버킷 생성, IAM 정책/Role 설정, KMS 암호화, Lifecycle 정책 — 별도 인프라 작업으로 분리
+
+---
+
+## 1. docker-compose.yml — MinIO 서비스 추가
+
+기존 `docker-compose.yml`의 `services:` 블록에 아래를 추가한다.
+
+```yaml
+  minio:
+    image: minio/minio:latest
+    container_name: init-minio
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
+    ports:
+      - "9000:9000"   # S3 API 포트
+      - "9001:9001"   # Web Console 포트
+    volumes:
+      - minio_data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - init-network
+```
+
+`volumes:` 블록에 추가:
+
+```yaml
+  minio_data:
+```
+
+---
+
+## 2. application.yml — 스토리지 공통 설정 추가
+
+`backend/src/main/resources/application.yml`에 아래 섹션을 추가한다.
+
+```yaml
+storage:
+  s3:
+    # 환경별 버킷 분리 전략: init-raw-files-prod / init-raw-files-dev / init-raw-files-local
+    bucket-name: ${STORAGE_S3_BUCKET:init-raw-files-dev}
+    region: ${STORAGE_S3_REGION:ap-northeast-2}
+    endpoint: ${STORAGE_S3_ENDPOINT:}           # 비어있으면 AWS 기본 엔드포인트 사용
+    access-key: ${STORAGE_S3_ACCESS_KEY:}
+    secret-key: ${STORAGE_S3_SECRET_KEY:}
+    path-style-access: ${STORAGE_S3_PATH_STYLE:false}
+```
+
+---
+
+## 3. application-local.yml — MinIO 로컬 오버라이드
+
+`backend/src/main/resources/application-local.yml`에 아래를 추가한다.
+
+```yaml
+storage:
+  s3:
+    bucket-name: init-raw-files-local          # 로컬 전용 버킷
+    region: us-east-1                          # MinIO는 region 무관
+    endpoint: http://localhost:9000
+    access-key: ${MINIO_ROOT_USER:minioadmin}
+    secret-key: ${MINIO_ROOT_PASSWORD:minioadmin}
+    path-style-access: true                    # MinIO는 path-style 필수
+```
+
+> **버킷 전략 요약**:
+> - `init-raw-files-local` — MinIO (docker-compose 로컬)
+> - `init-raw-files-dev` — AWS S3 개발 환경
+> - `init-raw-files-prod` — AWS S3 운영 환경
+>
+> 워크스페이스 격리는 object key 경로로 처리: `workspaces/{workspaceId}/datasets/{datasetKey}/{filename}`
+
+---
+
+## 4. 환경 변수 목록
+
+| 변수 | 설명 | 기본값 | 사용 프로파일 |
+|------|------|--------|--------------|
+| `STORAGE_S3_BUCKET` | S3/MinIO 버킷 이름 (환경별 상이) | `init-raw-files-dev` | 환경별 주입 |
+| `STORAGE_S3_REGION` | AWS 리전 | `ap-northeast-2` | default (prod) |
+| `STORAGE_S3_ENDPOINT` | 커스텀 엔드포인트 | 비어있음 (AWS 기본) | local: MinIO URL |
+| `STORAGE_S3_ACCESS_KEY` | AWS Access Key / MinIO User | — | prod: IAM Role 권장 |
+| `STORAGE_S3_SECRET_KEY` | AWS Secret Key / MinIO Pass | — | prod: IAM Role 권장 |
+| `STORAGE_S3_PATH_STYLE` | Path-style access 여부 | `false` | local: `true` (MinIO) |
+| `MINIO_ROOT_USER` | MinIO 루트 사용자 | `minioadmin` | local only |
+| `MINIO_ROOT_PASSWORD` | MinIO 루트 비밀번호 | `minioadmin` | local only |
+
+> **보안 주의**: `STORAGE_S3_ACCESS_KEY`, `STORAGE_S3_SECRET_KEY`는 `.env` 파일에만 저장하며
+> git에 커밋하지 않는다. AWS prod 환경에서는 Fargate IAM Task Role 사용 권장.
+
+---
+
+## 5. docker-compose 시작 및 MinIO 버킷 초기화 (로컬)
+
+```bash
+# docker-compose 전체 시작 (MinIO 포함)
+docker-compose up -d minio
+
+# MinIO Web Console로 버킷 생성: http://localhost:9001
+# admin 계정: minioadmin / minioadmin
+
+# 또는 mc CLI (MinIO Client) 사용:
+# mc alias set local http://localhost:9000 minioadmin minioadmin
+# mc mb local/init-raw-files-local
+```
+
+---
+
+## 6. Out of Scope — 실제 AWS 작업 (별도 인프라 작업)
+
+아래 항목은 이 스펙의 범위 밖이며 인프라 담당자가 별도로 수행한다.
+
+- `aws s3api create-bucket --bucket init-raw-files --region ap-northeast-2`
+- IAM Policy 생성 (`s3:PutObject`, `s3:GetObject` on `init-raw-files/*`)
+- Fargate Task Role에 위 Policy attach
+- KMS 서버 사이드 암호화 (SSE-S3 or SSE-KMS) 설정
+- S3 Lifecycle 정책 (장기 보관 → Glacier 전환 등) 설정
+- VPC Endpoint 설정 (Fargate → S3 트래픽 비용 최적화)
+- 버킷 versioning/접근 제어 설정

--- a/.agent/specs/114/infra-setup.md
+++ b/.agent/specs/114/infra-setup.md
@@ -11,7 +11,7 @@
 
 ```yaml
   minio:
-    image: minio/minio:latest
+    image: minio/minio:RELEASE.2025-01-20T14-49-07Z   # floating :latest 금지 — 재현성 보장을 위해 버전 고정
     container_name: init-minio
     command: server /data --console-address ":9001"
     environment:
@@ -23,8 +23,8 @@
     volumes:
       - minio_data:/data
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
-      interval: 10s
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 5s
       timeout: 5s
       retries: 5
     networks:
@@ -102,7 +102,7 @@ storage:
 ## 5. docker-compose 시작 및 MinIO 버킷 초기화 (로컬)
 
 ```bash
-# docker-compose 전체 시작 (MinIO 포함)
+# docker-compose MinIO 시작
 docker-compose up -d minio
 
 # MinIO Web Console로 버킷 생성: http://localhost:9001
@@ -119,8 +119,17 @@ docker-compose up -d minio
 
 아래 항목은 이 스펙의 범위 밖이며 인프라 담당자가 별도로 수행한다.
 
-- `aws s3api create-bucket --bucket init-raw-files --region ap-northeast-2`
-- IAM Policy 생성 (`s3:PutObject`, `s3:GetObject` on `init-raw-files/*`)
+- 환경별 버킷 생성 (환경에 따라 해당 명령 실행):
+  ```bash
+  # 개발 환경
+  aws s3api create-bucket --bucket init-raw-files-dev --region ap-northeast-2 \
+      --create-bucket-configuration LocationConstraint=ap-northeast-2
+  # 운영 환경
+  aws s3api create-bucket --bucket init-raw-files-prod --region ap-northeast-2 \
+      --create-bucket-configuration LocationConstraint=ap-northeast-2
+  # (로컬 MinIO 버킷 init-raw-files-local은 위 섹션 5의 mc 명령으로 생성)
+  ```
+- IAM Policy 생성 (개발: `s3:PutObject`, `s3:GetObject` on `init-raw-files-dev/*`; 운영: 동일 패턴으로 `init-raw-files-prod/*`)
 - Fargate Task Role에 위 Policy attach
 - KMS 서버 사이드 암호화 (SSE-S3 or SSE-KMS) 설정
 - S3 Lifecycle 정책 (장기 보관 → Glacier 전환 등) 설정


### PR DESCRIPTION
# ADR-114: 클라우드 스토리지 Provider 선정 및 로컬 개발 전략

**Status**: Accepted
**Date**: 2026-04-16
**Context**: spec/114 — [Infra] 1.1.4 상담 데이터 raw 파일 클라우드 스토리지

---

## Context

상담 로그 원본 JSON 파일을 서버 proxy 방식으로 수신하여 클라우드 오브젝트 스토리지에 영구 보관해야 한다.

아키텍처 의도:
- S3는 원본 아카이브 및 감사(audit) 목적으로 사용
- Airflow는 PostgreSQL DB를 주입력으로 사용하며, S3는 재처리·감사용 아카이브
- 운영자가 multipart 업로드 → 서버가 S3에 저장 + 파싱하여 DB 적재 + Airflow 웹훅

로컬 개발 환경에서 실제 클라우드 의존 없이 개발/테스트 가능한 에뮬레이터가 필요하다.

---

## Decision

**Cloud Provider**: AWS S3

**로컬 개발 에뮬레이터**: MinIO (docker-compose 서비스로 추가)

---

## Rationale

### AWS S3 선택 이유

| 기준 | 근거 |
|------|------|
| 스택 일관성 | Airflow를 AWS Fargate에서 구동 예정 → AWS 생태계 일원화 |
| IAM 통합 | Fargate Task Role로 cross-service 자격증명 관리 가능, 별도 Key 관리 불필요 |
| SDK 성숙도 | `software.amazon.awssdk:s3` (v2)는 Spring Boot 3.x + Java 21 호환 |
| 운영 경험 | 팀 AWS 인프라 경험 우선 |

### MinIO 선택 이유 (로컬 개발)

- AWS S3 API 완전 호환 → 동일 SDK, 동일 코드로 전환 가능
- docker-compose 단일 서비스로 추가 (공식 이미지: `minio/minio`)
- 로컬/CI에서 실제 AWS 자격증명 불필요
- 무료 오픈소스

---

## Alternatives Considered

| Provider | 기각 이유 |
|----------|----------|
| Google Cloud Storage | Fargate(AWS) 사용 시 cross-cloud 복잡도 증가; GCS SDK는 별도 의존성 |
| Azure Blob Storage | 팀 Azure 경험 부재; 스택 불일치 |
| 자가 호스팅 MinIO (전용, 운영) | 고가용성 및 운영 부담 증가; S3 대비 생태계 지원 부족 |
| LocalStack | MinIO 대비 설정 복잡; 유료 기능 필요 가능성 |

---

## Implementation Notes

- `RawFileStoragePort` 인터페이스 → `S3RawFileStorageAdapter` 구현체
- `S3Client` 빌더에서 `endpointOverride` 설정으로 MinIO/AWS 전환:
  ```java
  S3Client.builder()
      .endpointOverride(URI.create(endpoint))  // 비어있으면 AWS 기본값
      .credentialsProvider(...)
      .forcePathStyle(pathStyleAccess)          // MinIO는 true 필수
      .build()
  ```
- 프로파일별 전환: `application-local.yml`에서 MinIO 엔드포인트/자격증명 주입
- 실제 AWS 버킷 생성 및 IAM 설정은 이 스펙의 **out-of-scope** (인프라팀 별도 작업)

---

## Consequences

### 긍정적
- AWS Fargate + S3 동일 생태계로 IAM Role 자격증명 관리 단순화
- MinIO로 로컬 개발/CI에서 실제 AWS 자격증명 없이 완전한 스토리지 테스트 가능
- `EndpointOverride` 패턴으로 프로파일별 전환이 코드 변경 없이 설정만으로 가능

### 부정적 / 주의
- `software.amazon.awssdk:s3` 의존성 추가 필요 (build.gradle)
- 실제 AWS 버킷 생성/IAM Role 설정은 별도 인프라 작업 필요
- MinIO와 AWS S3 간 edge case 차이 (복합 업로드, presigned URL 등) 주의 필요
  (이 스펙은 단순 `putObject` 사용으로 해당 없음)
---
# 인프라 런북: spec/114 스토리지 로컬 개발 세팅

**Scope**: docker-compose MinIO 서비스 추가, application.yml 프로파일별 스토리지 설정 주입
**Out of Scope**: 실제 AWS S3 버킷 생성, IAM 정책/Role 설정, KMS 암호화, Lifecycle 정책 — 별도 인프라 작업으로 분리

---

## 1. docker-compose.yml — MinIO 서비스 추가

기존 `docker-compose.yml`의 `services:` 블록에 아래를 추가한다.

```yaml
  minio:
    image: minio/minio:latest
    container_name: init-minio
    command: server /data --console-address ":9001"
    environment:
      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
    ports:
      - "9000:9000"   # S3 API 포트
      - "9001:9001"   # Web Console 포트
    volumes:
      - minio_data:/data
    healthcheck:
      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
      interval: 10s
      timeout: 5s
      retries: 5
    networks:
      - init-network
```

`volumes:` 블록에 추가:

```yaml
  minio_data:
```

---

## 2. application.yml — 스토리지 공통 설정 추가

`backend/src/main/resources/application.yml`에 아래 섹션을 추가한다.

```yaml
storage:
  s3:
    # 환경별 버킷 분리 전략: init-raw-files-prod / init-raw-files-dev / init-raw-files-local
    bucket-name: ${STORAGE_S3_BUCKET:init-raw-files-dev}
    region: ${STORAGE_S3_REGION:ap-northeast-2}
    endpoint: ${STORAGE_S3_ENDPOINT:}           # 비어있으면 AWS 기본 엔드포인트 사용
    access-key: ${STORAGE_S3_ACCESS_KEY:}
    secret-key: ${STORAGE_S3_SECRET_KEY:}
    path-style-access: ${STORAGE_S3_PATH_STYLE:false}
```

---

## 3. application-local.yml — MinIO 로컬 오버라이드

`backend/src/main/resources/application-local.yml`에 아래를 추가한다.

```yaml
storage:
  s3:
    bucket-name: init-raw-files-local          # 로컬 전용 버킷
    region: us-east-1                          # MinIO는 region 무관
    endpoint: http://localhost:9000
    access-key: ${MINIO_ROOT_USER:minioadmin}
    secret-key: ${MINIO_ROOT_PASSWORD:minioadmin}
    path-style-access: true                    # MinIO는 path-style 필수
```

> **버킷 전략 요약**:
> - `init-raw-files-local` — MinIO (docker-compose 로컬)
> - `init-raw-files-dev` — AWS S3 개발 환경
> - `init-raw-files-prod` — AWS S3 운영 환경
>
> 워크스페이스 격리는 object key 경로로 처리: `workspaces/{workspaceId}/datasets/{datasetKey}/{filename}`

---

## 4. 환경 변수 목록

| 변수 | 설명 | 기본값 | 사용 프로파일 |
|------|------|--------|--------------|
| `STORAGE_S3_BUCKET` | S3/MinIO 버킷 이름 (환경별 상이) | `init-raw-files-dev` | 환경별 주입 |
| `STORAGE_S3_REGION` | AWS 리전 | `ap-northeast-2` | default (prod) |
| `STORAGE_S3_ENDPOINT` | 커스텀 엔드포인트 | 비어있음 (AWS 기본) | local: MinIO URL |
| `STORAGE_S3_ACCESS_KEY` | AWS Access Key / MinIO User | — | prod: IAM Role 권장 |
| `STORAGE_S3_SECRET_KEY` | AWS Secret Key / MinIO Pass | — | prod: IAM Role 권장 |
| `STORAGE_S3_PATH_STYLE` | Path-style access 여부 | `false` | local: `true` (MinIO) |
| `MINIO_ROOT_USER` | MinIO 루트 사용자 | `minioadmin` | local only |
| `MINIO_ROOT_PASSWORD` | MinIO 루트 비밀번호 | `minioadmin` | local only |

> **보안 주의**: `STORAGE_S3_ACCESS_KEY`, `STORAGE_S3_SECRET_KEY`는 `.env` 파일에만 저장하며
> git에 커밋하지 않는다. AWS prod 환경에서는 Fargate IAM Task Role 사용 권장.

---

## 5. docker-compose 시작 및 MinIO 버킷 초기화 (로컬)

```bash
# docker-compose 전체 시작 (MinIO 포함)
docker-compose up -d minio

# MinIO Web Console로 버킷 생성: http://localhost:9001
# admin 계정: minioadmin / minioadmin

# 또는 mc CLI (MinIO Client) 사용:
# mc alias set local http://localhost:9000 minioadmin minioadmin
# mc mb local/init-raw-files-local
```

---

## 6. Out of Scope — 실제 AWS 작업 (별도 인프라 작업)

아래 항목은 이 스펙의 범위 밖이며 인프라 담당자가 별도로 수행한다.

- `aws s3api create-bucket --bucket init-raw-files --region ap-northeast-2`
- IAM Policy 생성 (`s3:PutObject`, `s3:GetObject` on `init-raw-files/*`)
- Fargate Task Role에 위 Policy attach
- KMS 서버 사이드 암호화 (SSE-S3 or SSE-KMS) 설정
- S3 Lifecycle 정책 (장기 보관 → Glacier 전환 등) 설정
- VPC Endpoint 설정 (Fargate → S3 트래픽 비용 최적화)
- 버킷 versioning/접근 제어 설정
---
# [Infra] 1.1.4 상담 데이터 raw 파일 클라우드 스토리지 선정 및 세팅 및 저장

**Canonical Number**: `114`
**Branch**: `spec/114`
**Template Base**: `_TEMPLATE_BE.md`
**작성일**: 2026-04-16

---

## Goal

운영자가 `multipart/form-data`로 상담 로그 JSON 파일을 업로드하면, 서버가 AWS S3(로컬 개발: MinIO)에 원본을 저장하고, 파싱하여 PostgreSQL `corpus` 스키마에 적재한 뒤 Airflow ingestion 파이프라인을 트리거하는 신규 엔드포인트와 스토리지 어댑터를 구축한다.

---

## Sequence Diagram

```mermaid
sequenceDiagram
    actor op as Operator
    participant ctrl as DatasetController
    participant svc as RawFileUploadService
    participant store as RawFileStoragePort
    participant rawSvc as RawDatasetUploadService (기존)
    participant rfRepo as DatasetRawFileRepository
    participant air as IngestionTriggerPort
    participant db as PostgreSQL

    op ->> ctrl: POST /raw-file (multipart)
    ctrl ->> svc: upload(RawFileUploadCommand)
    Note over svc: validateWorkspace + membership + datasetKey (fail-fast)
    svc ->> svc: bufferFileBytes + computeChecksumSha256
    svc ->> store: put(objectKey, bytes, contentType)
    store -->> svc: objectKey [U-01: 형식 미확정]
    svc ->> svc: parseJsonToConversations(bytes)
    svc ->> rawSvc: upload(RawDatasetUploadCommand)
    rawSvc ->> db: INSERT corpus.dataset + conversation + conversation_turn
    db -->> rawSvc: ok
    rawSvc -->> svc: DatasetUploadResult(datasetId)
    svc ->> rfRepo: save(DatasetRawFile)
    rfRepo ->> db: INSERT corpus.dataset_raw_file
    db -->> rfRepo: ok
    svc ->> air: trigger(datasetId, objectKey) [U-08: payload 미확정]
    air -->> svc: ack
    svc -->> ctrl: RawFileUploadResult
    ctrl -->> op: 201 Created
```

> **주의**: S3 put 성공 후 DB 실패 시 orphan 파일 처리 정책은 미확정.
> `.handoff/114/uncertainty-register-114.md` U-05 참조.

---

## REST API

### Endpoints

| Method | Path | Description |
|--------|------|-------------|
| POST | `/api/v1/workspaces/{workspaceId}/datasets/raw-file` | multipart 파일 업로드 **(신규)** |
| POST | `/api/v1/workspaces/{workspaceId}/datasets/raw` | JSON body 직접 업로드 (기존, 유지) |

### Request

**POST /api/v1/workspaces/{workspaceId}/datasets/raw-file**

`Content-Type: multipart/form-data`

| Part | Type | Required | Constraints | Description |
|------|------|----------|-------------|-------------|
| `file` | `MultipartFile` | Yes | `.json` 파일 | 상담 로그 JSON 배열 파일 |
| `datasetKey` | `@RequestParam` | Yes | max 100자 | 데이터셋 식별 키 |
| `name` | `@RequestParam` | Yes | max 255자 | 데이터셋 이름 |
| `sourceType` | `@RequestParam` | Yes | max 50자 | 소스 타입 |

> **파일 크기 상한**: 50MB / 파일 1개 per 요청. `spring.servlet.multipart.max-file-size=50MB` 설정 필요.

JSON 파일 포맷 (배열):

```json
[
  {
    "source_id": "40001",
    "source": "엘지유플러스",
    "consulting_category": "배송문의",
    "client_gender": "",
    "client_age": "",
    "consulting_turns": "49",
    "consulting_length": 592,
    "consulting_content": "상담사: ...\n고객: ..."
  }
]
```

### Response

**201 Created**

```json
{
  "datasetId": 42,
  "datasetKey": "lgu-2026-04",
  "workspaceId": 1,
  "objectKey": "workspaces/1/datasets/lgu-2026-04/엘지유플러스_1.json",
  "originalFilename": "엘지유플러스_1.json",
  "sizeBytes": 17825792,
  "status": "READY",
  "piiRedactionStatus": "PENDING",
  "conversationCount": 3216
}
```

**400 Bad Request** — 파일 없음 / 검증 실패 / JSON 파싱 오류

```json
{
  "code": "VALIDATION_ERROR",
  "message": "파일이 없거나 형식이 올바르지 않습니다."
}
```

**403 Forbidden** — 비멤버 접근

```json
{
  "code": "UNAUTHORIZED_WORKSPACE_ACCESS",
  "message": "워크스페이스에 접근 권한이 없습니다."
}
```

**404 Not Found** — 워크스페이스 미존재

```json
{
  "code": "NOT_FOUND",
  "message": "워크스페이스를 찾을 수 없습니다. id=999"
}
```

**409 Conflict** — datasetKey 중복

```json
{
  "code": "DATASET_KEY_CONFLICT",
  "message": "이미 사용 중인 데이터셋 키입니다: lgu-2026-04"
}
```

**500 Internal Server Error**

```json
{
  "code": "INTERNAL_SERVER_ERROR",
  "message": "서버 오류가 발생했습니다."
}
```

---

## Class Design

### DDD Layered Structure

```
corpus/
├── presentation/
│   ├── DatasetController.java                    (기존 — 신규 메서드 추가)
│   └── dto/
│       └── RawFileUploadResponse.java            (신규)
├── application/
│   ├── RawFileUploadService.java                 (신규 — 오케스트레이터)
│   ├── RawFileUploadCommand.java                 (신규)
│   └── port/
│       ├── RawFileStoragePort.java               (신규 — S3 인터페이스)
│       └── IngestionTriggerPort.java             (신규 — Airflow 트리거 인터페이스)
├── domain/
│   ├── model/
│   │   └── DatasetRawFile.java                   (신규 — corpus.dataset_raw_file 엔티티)
│   └── repository/
│       └── DatasetRawFileRepository.java         (신규 인터페이스)
└── infrastructure/
    ├── storage/
    │   └── S3RawFileStorageAdapter.java          (신규 — AWS SDK v2, MinIO 호환)
    ├── airflow/
    │   └── AirflowIngestionTriggerAdapter.java   (신규)
    └── persistence/
        └── JpaDatasetRawFileRepository.java      (신규)
```

### Aggregate Design

```java
// corpus/domain/model/DatasetRawFile.java
@Entity
@Table(name = "dataset_raw_file", schema = "corpus")
public class DatasetRawFile {
    @Id
    @GeneratedValue(strategy = GenerationType.IDENTITY)
    private Long id;

    @Column(name = "dataset_id", nullable = false)
    private Long datasetId;

    @Column(name = "object_key", nullable = false, length = 1024)
    private String objectKey;

    @Column(name = "original_filename", nullable = false, length = 255)
    private String originalFilename;

    @Column(name = "content_type", nullable = false, length = 100)
    private String contentType;

    @Column(name = "size_bytes", nullable = false)
    private Long sizeBytes;

    @Column(name = "checksum_sha256", nullable = false, length = 64)
    private String checksumSha256;

    @Column(name = "uploaded_at", nullable = false)
    private Instant uploadedAt;

    // public setter 금지 — 상태 변경은 도메인 메서드로만
    public static DatasetRawFile create(
            Long datasetId, String objectKey, String originalFilename,
            String contentType, Long sizeBytes, String checksumSha256) {
        // factory method — uploadedAt = Instant.now()
    }
}
```

### Port Interfaces

```java
// application/port/RawFileStoragePort.java
public interface RawFileStoragePort {
    /**
     * objectKey 위치에 파일 bytes를 저장하고 확정된 objectKey를 반환한다.
     * endpoint는 프로파일에 따라 AWS S3 또는 MinIO로 전환된다.
     */
    String put(String objectKey, byte[] content, String contentType);

    /**
     * objectKey 위치의 파일을 삭제한다.
     * S3 put 성공 + DB 실패 시 orphan 보상 처리용.
     */
    void delete(String objectKey);
}

// application/port/IngestionTriggerPort.java
public interface IngestionTriggerPort {
    /**
     * Airflow ingestion 파이프라인을 트리거한다.
     * payload 스펙은 uncertainty-register-114.md U-08 참조.
     */
    void trigger(Long datasetId, String objectKey);
}
```

### Command / Response

```java
// application/RawFileUploadCommand.java
public record RawFileUploadCommand(
    Long workspaceId,
    String datasetKey,
    String name,
    String sourceType,
    Long createdBy,
    byte[] fileBytes,         // controller가 MultipartFile.getBytes()로 추출
    String originalFilename,
    String contentType,
    long sizeBytes
) {}

// presentation/dto/RawFileUploadResponse.java
public record RawFileUploadResponse(
    Long datasetId,
    String datasetKey,
    Long workspaceId,
    String objectKey,
    String originalFilename,
    Long sizeBytes,
    String status,
    String piiRedactionStatus,
    int conversationCount
) {}
```

---

## Tests

### Unit Tests

```java
@DisplayName("RawFileUploadService")
@ExtendWith(MockitoExtension.class)
class RawFileUploadServiceTest {

    @Test
    @DisplayName("should_성공_when_유효한_multipart_파일")
    void upload_success_returnsRawFileUploadResult() {
        // given — mock storagePort, mock rawDatasetUploadService, mock repo, mock triggerPort
        // when
        // then — storagePort.put() 1회, rawDatasetUploadService.upload() 1회,
        //         repo.save() 1회, triggerPort.trigger() 1회
    }

    @Test
    @DisplayName("should_throw_WorkspaceNotFoundException_when_워크스페이스_없음")
    void upload_workspaceNotFound_throwsException() { }

    @Test
    @DisplayName("should_throw_UnauthorizedWorkspaceAccessException_when_비멤버")
    void upload_notMember_throwsException() { }

    @Test
    @DisplayName("should_throw_DatasetKeyConflictException_when_키_중복")
    void upload_datasetKeyConflict_throwsException() { }
}
```

```java
@DisplayName("DatasetRawFile")
class DatasetRawFileTest {
    @Test
    @DisplayName("should_create_with_all_required_fields")
    void create_withValidFields_returnsEntity() {
        // given / when / then — all fields set, uploadedAt is non-null
    }
}
```

### Integration Tests

```java
@WebMvcTest(DatasetController.class)
@DisplayName("DatasetController — raw-file upload")
class DatasetControllerRawFileTest {

    @Test
    @DisplayName("POST /raw-file — 성공 시 201 반환")
    void uploadRawFile_returns201() throws Exception {
        // given
        MockMultipartFile mockFile = new MockMultipartFile(
            "file", "test.json", "application/json", validJsonBytes);
        given(rawFileUploadService.upload(any())).willReturn(validResult);

        // when & then
        mockMvc.perform(multipart("/api/v1/workspaces/1/datasets/raw-file")
                .file(mockFile)
                .param("datasetKey", "test-key")
                .param("name", "테스트 데이터셋")
                .param("sourceType", "LGU"))
            .andExpect(status().isCreated())
            .andExpect(jsonPath("$.datasetId").isNumber())
            .andExpect(jsonPath("$.objectKey").isString());
    }

    @Test
    @DisplayName("POST /raw-file — file 파트 없음 시 400")
    void uploadRawFile_missingFile_returns400() throws Exception { }
}
```

### Test Checklist

- [ ] 정상 시나리오: 유효 multipart → 201 + datasetId/objectKey 반환
- [ ] file 파트 누락 → 400
- [ ] datasetKey 누락 → 400
- [ ] 잘못된 JSON 파일 → 400
- [ ] 워크스페이스 없음 → 404
- [ ] 비멤버 접근 → 403
- [ ] datasetKey 중복 → 409
- [ ] S3RawFileStorageAdapter 단위: MinIO endpoint override + put 동작 검증
- [ ] 트랜잭션: corpus.dataset_raw_file INSERT 실패 시 롤백 확인

---

## Database

### Migration (Liquibase — `db.changelog-master.sql` 말미에 추가)

```sql
--changeset devjhan:20260416-create-corpus-dataset-raw-file-table
--comment: S3 원본 파일 메타데이터 보관 테이블 신설 (archive + audit 목적)
CREATE TABLE corpus.dataset_raw_file (
    id                BIGSERIAL     PRIMARY KEY,
    dataset_id        BIGINT        NOT NULL REFERENCES corpus.dataset(id) ON DELETE CASCADE,
    object_key        VARCHAR(1024) NOT NULL,
    original_filename VARCHAR(255)  NOT NULL,
    content_type      VARCHAR(100)  NOT NULL,
    size_bytes        BIGINT        NOT NULL,
    checksum_sha256   VARCHAR(64)   NOT NULL,
    uploaded_at       TIMESTAMPTZ   NOT NULL DEFAULT NOW()
);

CREATE INDEX idx_dataset_raw_file_dataset_id
    ON corpus.dataset_raw_file(dataset_id);
```

> **corpus.dataset 변경 없음** — Confirmed.

---

## Additional Notes

- **계층 의존성**: `presentation → application → domain ← infrastructure` (DDD 표준).
- `RawDatasetUploadService`는 내부 위임 호출로만 사용. 기존 코드 변경 없음.
- `S3RawFileStorageAdapter`는 `software.amazon.awssdk:s3` (v2) 사용.
  `EndpointOverride` 설정으로 MinIO(local)와 AWS S3(prod/dev)를 프로파일별 전환.
- **S3 object key 형식** (Confirmed): `workspaces/{workspaceId}/datasets/{datasetKey}/{originalFilename}`
- **버킷 전략** (Confirmed): 환경별 버킷 분리 + 워크스페이스는 object key 경로로 분리.
  버킷명 예: `init-raw-files-prod`, `init-raw-files-dev`, `init-raw-files-local`.
  `STORAGE_S3_BUCKET` 환경 변수로 배포 환경별 주입.
- **파일 크기 상한** (Confirmed): 50MB / 1 파일 per 요청.
  `spring.servlet.multipart.max-file-size=50MB`, `max-request-size=55MB` 설정 필요.
- **`consulting_content` 제한** (Confirmed): `/raw-file` 경로는 제한 없음.
  기존 `/raw` 경로의 `@Size(max = 5000)` 제약은 변경하지 않음.
- **Orphan 처리** (Confirmed): S3 put 성공 + DB 실패 시, best-effort `S3Client.deleteObject()` 호출.
  deleteObject 자체 실패 시 WARN 로그 + 원 DB 예외를 caller에게 propagate.
- **Airflow 트리거** (Assumption — NOOP stub): payload 미확정으로 `AirflowIngestionTriggerAdapter`는
  NOOP 구현으로 임시 대체. `// TODO: spec/114 U-08` 주석 포함 필수.
- `@Transactional(readOnly = true)` 기본값 + 쓰기 메서드 개별 오버라이드 패턴 적용.
- `RawFileUploadService`는 fail-fast를 위해 S3 IO 전에 workspace/membership/datasetKey 검증 선행.
  (`RawDatasetUploadService` 내부 재검증과 중복되나 불필요한 S3 IO 방지를 위해 유지.)
- 보조 설계 문서:
  - ADR: `.agent/specs/114/adr-storage-selection.md`
  - 인프라 런북: `.agent/specs/114/infra-setup.md`
  - 불확실성 관리: `.handoff/114/uncertainty-register-114.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 데이터셋 원본 파일 업로드 기능 추가
  * 상담 로그 JSON 파일을 직접 업로드할 수 있습니다
  * 최대 파일 크기 제한: 50MB
  * 업로드된 파일은 자동으로 처리 및 데이터베이스에 저장됩니다
  * 멀티파트 폼 데이터 형식으로 지원됩니다

<!-- end of auto-generated comment: release notes by coderabbit.ai -->