### PR TITLE
fix/60: db.changelog-master.sql changeset author 정정

### DIFF
--- a/backend/src/main/resources/db/changelog/db.changelog-master.sql
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.sql
@@ -710,13 +710,13 @@ ALTER TABLE pack.slot_definition
     ADD COLUMN status VARCHAR(50) NOT NULL DEFAULT 'ACTIVE',
     ADD CONSTRAINT chk_slot_definition_status CHECK (status IN ('ACTIVE', 'INACTIVE'));
 
---changeset devjhan:20260416-add-status-to-policy-definition
+--changeset jhkang0516:20260416-add-status-to-policy-definition
 --comment: Add status column to pack.policy_definition for policy lifecycle management (ACTIVE/INACTIVE)
 ALTER TABLE pack.policy_definition
     ADD COLUMN status VARCHAR(50) NOT NULL DEFAULT 'ACTIVE',
     ADD CONSTRAINT chk_policy_definition_status CHECK (status IN ('ACTIVE', 'INACTIVE'));
 
---changeset devjhan:20260416-add-status-to-risk-definition
+--changeset jhkang0516:20260416-add-status-to-risk-definition
 --comment: Add status column to pack.risk_definition for risk lifecycle management (ACTIVE/INACTIVE)
 ALTER TABLE pack.risk_definition
     ADD COLUMN status VARCHAR(50) NOT NULL DEFAULT 'ACTIVE',


### PR DESCRIPTION
## Summary
- `db.changelog-master.sql`의 policy/risk status changeset author를 실제 작성자 기준으로 정정했습니다.
- Liquibase changeset 메타데이터와 실제 작업 이력의 정합성을 맞췄습니다.

## Why
- 현재 changelog에 기록된 changeset author가 실제 작성자와 달라 추적성이 깨져 있었습니다.
- 작은 수정이지만 DB 변경 이력 파일이므로 메타데이터도 정확히 유지하는 편이 맞습니다.

## Impact
- 애플리케이션 동작이나 스키마 구조에는 영향이 없습니다.
- Liquibase changeset 식별 문자열(author:id)이 바뀌는 변경이라, 이 PR은 팀 기준으로 적용 여부를 확인한 뒤 머지해야 합니다.

## Validation
- `git diff --check`

Fixes #60
