### PR TITLE
spec/219: conversation intent draft read

### DIFF
--- a/.agent/specs/219.md
+++ b/.agent/specs/219.md
@@ -105,16 +105,18 @@ sequenceDiagram
 
 ### Error Responses
 
-**403 Forbidden** — 워크스페이스 접근 권한 없음
+> `code` 필드는 각 예외의 `ex.getCode()`에서 반환된 값이다 (하드코딩된 문자열이 아님).
+
+**403 Forbidden** — 워크스페이스 접근 권한 없음 (예시)
 
 ```json
-{ "code": "UNAUTHORIZED", "message": "워크스페이스 접근 권한이 없습니다." }
+{ "code": "<ex.getCode()>", "message": "워크스페이스 접근 권한이 없습니다." }
 ```
 
-**404 Not Found** — packId / versionId / intentId 미존재
+**404 Not Found** — packId / versionId / intentId 미존재 (예시)
 
 ```json
-{ "code": "NOT_FOUND", "message": "Domain Pack Version을 찾을 수 없습니다: 99" }
+{ "code": "<ex.getCode()>", "message": "Domain Pack Version을 찾을 수 없습니다. id=99" }
 ```
 
 ---
@@ -178,6 +180,7 @@ classDiagram
 | `application/GetIntentDefinitionUseCase.java`                        | 단건 조회 UseCase           |
 | `application/IntentDefinitionSummary.java`                           | 목록 응답 record            |
 | `application/IntentDefinitionDetail.java`                            | 단건 응답 record            |
+| `application/exception/IntentDefinitionNotFoundException.java`       | Intent 단건 조회 실패 예외  |
 
 ### Existing Files to Modify
 
@@ -237,8 +240,8 @@ public class GetIntentDefinitionUseCase {
 
         IntentDefinition intent = intentDefinitionRepository
                 .findByIdAndDomainPackVersionId(query.intentId(), query.versionId())
-                .orElseThrow(() -> new NotFoundException(
-                        "Intent를 찾을 수 없습니다: " + query.intentId()));
+                .orElseThrow(() -> new IntentDefinitionNotFoundException(
+                        query.intentId(), query.versionId()));
 
         return IntentDefinitionDetail.from(intent);
     }
@@ -289,6 +292,17 @@ public class IntentDefinitionController {
                         new GetIntentDefinitionQuery(workspaceId, packId, versionId, intentId, userId));
         return ResponseEntity.ok(result);
     }
+}
+```
+
+### Exception Class
+
+```java
+public class IntentDefinitionNotFoundException extends NotFoundException {
+  public IntentDefinitionNotFoundException(Long intentId, Long versionId) {
+    super("INTENT_DEFINITION_NOT_FOUND",
+          "Intent를 찾을 수 없습니다. intentId=" + intentId + ", versionId=" + versionId);
+  }
 }
 ```
 
@@ -374,7 +388,7 @@ class GetIntentDefinitionListUseCaseTest {
         // given
         var query = new GetIntentDefinitionListQuery(1L, 10L, 100L, 99L);
         var intent = IntentDefinitionFixture.active(100L, "INTENT_001");
-        given(validator.validateVersion(100L, 10L)).willDoNothing();
+        willDoNothing().given(validator).validateVersion(100L, 10L);
         given(repository.findByDomainPackVersionId(100L)).willReturn(List.of(intent));
 
         // when

--- a/.agent/specs/219.md
+++ b/.agent/specs/219.md
@@ -1,0 +1,460 @@
+# [BE] Conversation Intent 초안 조회 (219)
+
+## Goal
+
+특정 Domain Pack 버전에 속한 Conversation Intent 초안 목록 및 단건을 조회하는 API를 제공한다.
+
+---
+
+## Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    actor c as Client
+    participant ctrl as IntentDefinitionController
+    participant uc as GetIntentDefinitionListUseCase
+    participant val as DomainPackValidator
+    participant repo as IntentDefinitionRepository
+    participant db as PostgreSQL
+
+    c ->> ctrl: GET /api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/intents
+    ctrl ->> uc: execute(GetIntentDefinitionListQuery)
+    uc ->> val: validateWorkspaceAccess(workspaceId, userId)
+    val ->> db: SELECT workspace_member
+    db ->> val: ok
+    uc ->> val: validateDomainPack(packId, workspaceId)
+    val ->> db: SELECT domain_pack
+    db ->> val: ok
+    uc ->> val: validateVersion(versionId, packId)
+    val ->> db: SELECT domain_pack_version
+    db ->> val: ok
+    uc ->> repo: findByDomainPackVersionId(versionId)
+    repo ->> db: SELECT intent_definition WHERE domain_pack_version_id = ?
+    db ->> repo: List<IntentDefinition>
+    repo ->> uc: List<IntentDefinition>
+    uc ->> ctrl: List<IntentDefinitionSummary>
+    ctrl ->> c: 200 OK
+```
+
+---
+
+## REST API
+
+### Endpoint
+
+| Method | Path                                                                                                              | Description    |
+|--------|-------------------------------------------------------------------------------------------------------------------|----------------|
+| GET    | `/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/intents`                             | Intent 목록 조회 |
+| GET    | `/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/intents/{intentId}`                  | Intent 단건 조회 |
+
+### Path Variables
+
+| 변수          | 타입 | 설명                         |
+|---------------|------|------------------------------|
+| workspaceId   | Long | 워크스페이스 ID               |
+| packId        | Long | Domain Pack ID                |
+| versionId     | Long | Domain Pack Version ID        |
+| intentId      | Long | Intent Definition ID (단건만) |
+
+### Request
+
+쿼리 파라미터 없음. JWT Bearer 토큰 필수.
+
+### Response — 목록 조회
+
+**200 OK**
+
+```json
+[
+  {
+    "id": 1,
+    "intentCode": "INTENT_001",
+    "name": "배송 조회 문의",
+    "description": "주문 배송 상태를 확인하려는 고객 의도",
+    "taxonomyLevel": 1,
+    "parentIntentId": null,
+    "status": "ACTIVE",
+    "sourceClusterRef": "{\"clusterId\": \"c-001\", \"clusterSize\": 42}",
+    "createdAt": "2026-04-10T10:00:00+09:00",
+    "updatedAt": "2026-04-10T10:00:00+09:00"
+  }
+]
+```
+
+### Response — 단건 조회
+
+**200 OK**
+
+```json
+{
+  "id": 1,
+  "intentCode": "INTENT_001",
+  "name": "배송 조회 문의",
+  "description": "주문 배송 상태를 확인하려는 고객 의도",
+  "taxonomyLevel": 1,
+  "parentIntentId": null,
+  "status": "ACTIVE",
+  "sourceClusterRef": "{\"clusterId\": \"c-001\", \"clusterSize\": 42}",
+  "entryConditionJson": "{\"conditions\": []}",
+  "evidenceJson": "[{\"turnId\": \"t-100\", \"text\": \"배송이 어디까지 왔나요?\"}]",
+  "metaJson": "{}",
+  "createdAt": "2026-04-10T10:00:00+09:00",
+  "updatedAt": "2026-04-10T10:00:00+09:00"
+}
+```
+
+### Error Responses
+
+**403 Forbidden** — 워크스페이스 접근 권한 없음
+
+```json
+{ "code": "UNAUTHORIZED", "message": "워크스페이스 접근 권한이 없습니다." }
+```
+
+**404 Not Found** — packId / versionId / intentId 미존재
+
+```json
+{ "code": "NOT_FOUND", "message": "Domain Pack Version을 찾을 수 없습니다: 99" }
+```
+
+---
+
+## Class Design
+
+### DDD Layered Structure
+
+```mermaid
+classDiagram
+    class IntentDefinitionController {
+        +listIntents(workspaceId, packId, versionId, auth): ResponseEntity
+        +getIntent(workspaceId, packId, versionId, intentId, auth): ResponseEntity
+    }
+
+    class GetIntentDefinitionListUseCase {
+        +execute(query: GetIntentDefinitionListQuery): List~IntentDefinitionSummary~
+    }
+
+    class GetIntentDefinitionUseCase {
+        +execute(query: GetIntentDefinitionQuery): IntentDefinitionDetail
+    }
+
+    class DomainPackValidator {
+        <<existing>>
+        +validateWorkspaceAccess(workspaceId, userId)
+        +validateDomainPack(packId, workspaceId)
+        +validateVersion(versionId, packId)
+    }
+
+    class IntentDefinitionRepository {
+        <<interface, existing + extension>>
+        +findByDomainPackVersionId(Long): List~IntentDefinition~
+        +findByIdAndDomainPackVersionId(Long, Long): Optional~IntentDefinition~
+    }
+
+    class JpaIntentDefinitionRepository {
+        <<existing + extension>>
+    }
+
+    IntentDefinitionController --> GetIntentDefinitionListUseCase
+    IntentDefinitionController --> GetIntentDefinitionUseCase
+    GetIntentDefinitionListUseCase --> DomainPackValidator
+    GetIntentDefinitionListUseCase --> IntentDefinitionRepository
+    GetIntentDefinitionUseCase --> DomainPackValidator
+    GetIntentDefinitionUseCase --> IntentDefinitionRepository
+    IntentDefinitionRepository <|.. JpaIntentDefinitionRepository
+```
+
+### New Files
+
+| 파일 경로 (presentation layer)                                       | 역할                        |
+|----------------------------------------------------------------------|-----------------------------|
+| `presentation/IntentDefinitionController.java`                       | GET 목록 + GET 단건 엔드포인트 |
+
+| 파일 경로 (application layer)                                        | 역할                        |
+|----------------------------------------------------------------------|-----------------------------|
+| `application/GetIntentDefinitionListQuery.java`                      | 목록 조회 Query record      |
+| `application/GetIntentDefinitionListUseCase.java`                    | 목록 조회 UseCase           |
+| `application/GetIntentDefinitionQuery.java`                          | 단건 조회 Query record      |
+| `application/GetIntentDefinitionUseCase.java`                        | 단건 조회 UseCase           |
+| `application/IntentDefinitionSummary.java`                           | 목록 응답 record            |
+| `application/IntentDefinitionDetail.java`                            | 단건 응답 record            |
+
+### Existing Files to Modify
+
+| 파일 경로                                                              | 수정 내용                                                          |
+|------------------------------------------------------------------------|--------------------------------------------------------------------|
+| `domain/repository/IntentDefinitionRepository.java`                    | `findByIdAndDomainPackVersionId(Long, Long)` 메서드 추가           |
+| `infrastructure/persistence/JpaIntentDefinitionRepository.java`        | 동일 메서드 선언 추가 (Spring Data 자동 구현)                       |
+
+### UseCase 구현 예시
+
+```java
+@Service
+@Transactional(readOnly = true)
+public class GetIntentDefinitionListUseCase {
+
+    private final DomainPackValidator validator;
+    private final IntentDefinitionRepository intentDefinitionRepository;
+
+    public GetIntentDefinitionListUseCase(
+            DomainPackValidator validator,
+            IntentDefinitionRepository intentDefinitionRepository) {
+        this.validator = validator;
+        this.intentDefinitionRepository = intentDefinitionRepository;
+    }
+
+    public List<IntentDefinitionSummary> execute(GetIntentDefinitionListQuery query) {
+        validator.validateWorkspaceAccess(query.workspaceId(), query.userId());
+        validator.validateDomainPack(query.packId(), query.workspaceId());
+        validator.validateVersion(query.versionId(), query.packId());
+
+        return intentDefinitionRepository.findByDomainPackVersionId(query.versionId()).stream()
+                .map(IntentDefinitionSummary::from)
+                .toList();
+    }
+}
+```
+
+```java
+@Service
+@Transactional(readOnly = true)
+public class GetIntentDefinitionUseCase {
+
+    private final DomainPackValidator validator;
+    private final IntentDefinitionRepository intentDefinitionRepository;
+
+    public GetIntentDefinitionUseCase(
+            DomainPackValidator validator,
+            IntentDefinitionRepository intentDefinitionRepository) {
+        this.validator = validator;
+        this.intentDefinitionRepository = intentDefinitionRepository;
+    }
+
+    public IntentDefinitionDetail execute(GetIntentDefinitionQuery query) {
+        validator.validateWorkspaceAccess(query.workspaceId(), query.userId());
+        validator.validateDomainPack(query.packId(), query.workspaceId());
+        validator.validateVersion(query.versionId(), query.packId());
+
+        IntentDefinition intent = intentDefinitionRepository
+                .findByIdAndDomainPackVersionId(query.intentId(), query.versionId())
+                .orElseThrow(() -> new NotFoundException(
+                        "Intent를 찾을 수 없습니다: " + query.intentId()));
+
+        return IntentDefinitionDetail.from(intent);
+    }
+}
+```
+
+### Controller 구현 예시
+
+```java
+@RestController
+@RequestMapping(
+    "/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/intents")
+public class IntentDefinitionController {
+
+    private final GetIntentDefinitionListUseCase listUseCase;
+    private final GetIntentDefinitionUseCase detailUseCase;
+
+    public IntentDefinitionController(
+            GetIntentDefinitionListUseCase listUseCase,
+            GetIntentDefinitionUseCase detailUseCase) {
+        this.listUseCase = listUseCase;
+        this.detailUseCase = detailUseCase;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<IntentDefinitionSummary>> listIntents(
+            @PathVariable Long workspaceId,
+            @PathVariable Long packId,
+            @PathVariable Long versionId,
+            Authentication authentication) {
+        Long userId = AuthenticationUtils.getUserId(authentication);
+        List<IntentDefinitionSummary> result =
+                listUseCase.execute(
+                        new GetIntentDefinitionListQuery(workspaceId, packId, versionId, userId));
+        return ResponseEntity.ok(result);
+    }
+
+    @GetMapping("/{intentId}")
+    public ResponseEntity<IntentDefinitionDetail> getIntent(
+            @PathVariable Long workspaceId,
+            @PathVariable Long packId,
+            @PathVariable Long versionId,
+            @PathVariable Long intentId,
+            Authentication authentication) {
+        Long userId = AuthenticationUtils.getUserId(authentication);
+        IntentDefinitionDetail result =
+                detailUseCase.execute(
+                        new GetIntentDefinitionQuery(workspaceId, packId, versionId, intentId, userId));
+        return ResponseEntity.ok(result);
+    }
+}
+```
+
+### Response Records
+
+```java
+// 목록용 — JSONB 세부 필드 제외
+public record IntentDefinitionSummary(
+        Long id,
+        String intentCode,
+        String name,
+        String description,
+        Integer taxonomyLevel,
+        Long parentIntentId,
+        String status,
+        String sourceClusterRef,
+        OffsetDateTime createdAt,
+        OffsetDateTime updatedAt) {
+
+    public static IntentDefinitionSummary from(IntentDefinition entity) {
+        return new IntentDefinitionSummary(
+                entity.getId(),
+                entity.getIntentCode(),
+                entity.getName(),
+                entity.getDescription(),
+                entity.getTaxonomyLevel(),
+                entity.getParentIntentId(),
+                entity.getStatus(),
+                entity.getSourceClusterRef(),
+                entity.getCreatedAt(),
+                entity.getUpdatedAt());
+    }
+}
+
+// 단건용 — 전체 JSONB 필드 포함
+public record IntentDefinitionDetail(
+        Long id,
+        String intentCode,
+        String name,
+        String description,
+        Integer taxonomyLevel,
+        Long parentIntentId,
+        String status,
+        String sourceClusterRef,
+        String entryConditionJson,
+        String evidenceJson,
+        String metaJson,
+        OffsetDateTime createdAt,
+        OffsetDateTime updatedAt) {
+
+    public static IntentDefinitionDetail from(IntentDefinition entity) {
+        return new IntentDefinitionDetail(
+                entity.getId(),
+                entity.getIntentCode(),
+                entity.getName(),
+                entity.getDescription(),
+                entity.getTaxonomyLevel(),
+                entity.getParentIntentId(),
+                entity.getStatus(),
+                entity.getSourceClusterRef(),
+                entity.getEntryConditionJson(),
+                entity.getEvidenceJson(),
+                entity.getMetaJson(),
+                entity.getCreatedAt(),
+                entity.getUpdatedAt());
+    }
+}
+```
+
+---
+
+## Tests
+
+### Unit Tests
+
+```java
+@DisplayName("GetIntentDefinitionListUseCase")
+class GetIntentDefinitionListUseCaseTest {
+
+    @Test
+    @DisplayName("유효한 query로 intent 목록을 반환한다")
+    void execute_withValidQuery_returnsIntentList() {
+        // given
+        var query = new GetIntentDefinitionListQuery(1L, 10L, 100L, 99L);
+        var intent = IntentDefinitionFixture.active(100L, "INTENT_001");
+        given(validator.validateVersion(100L, 10L)).willDoNothing();
+        given(repository.findByDomainPackVersionId(100L)).willReturn(List.of(intent));
+
+        // when
+        var result = useCase.execute(query);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).intentCode()).isEqualTo("INTENT_001");
+    }
+}
+
+@DisplayName("GetIntentDefinitionUseCase")
+class GetIntentDefinitionUseCaseTest {
+
+    @Test
+    @DisplayName("존재하지 않는 intentId로 조회하면 NotFoundException을 던진다")
+    void execute_withUnknownIntentId_throwsNotFoundException() {
+        // given
+        var query = new GetIntentDefinitionQuery(1L, 10L, 100L, 999L, 99L);
+        given(repository.findByIdAndDomainPackVersionId(999L, 100L)).willReturn(Optional.empty());
+
+        // then
+        assertThatThrownBy(() -> useCase.execute(query))
+                .isInstanceOf(NotFoundException.class);
+    }
+}
+```
+
+### Integration Tests
+
+```java
+@SpringBootTest
+@AutoConfigureMockMvc
+@DisplayName("IntentDefinitionController")
+class IntentDefinitionControllerTest {
+
+    @Test
+    @DisplayName("GET /intents - 목록 반환")
+    void listIntents_returnsOk() throws Exception {
+        mockMvc.perform(get("/api/v1/workspaces/1/domain-packs/10/versions/100/intents")
+                .header("Authorization", "Bearer " + validToken))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$").isArray());
+    }
+
+    @Test
+    @DisplayName("GET /intents/{intentId} - 존재하지 않는 ID 404 반환")
+    void getIntent_notFound_returns404() throws Exception {
+        mockMvc.perform(get("/api/v1/workspaces/1/domain-packs/10/versions/100/intents/9999")
+                .header("Authorization", "Bearer " + validToken))
+            .andExpect(status().isNotFound());
+    }
+}
+```
+
+### Test Checklist
+
+- [ ] 정상 시나리오: 유효한 versionId로 목록 반환
+- [ ] 정상 시나리오: 유효한 intentId로 단건 반환
+- [ ] 권한 오류: 워크스페이스 미소속 userId → 403
+- [ ] 404 오류: 존재하지 않는 packId → 404
+- [ ] 404 오류: 존재하지 않는 versionId → 404
+- [ ] 404 오류: 존재하지 않는 intentId → 404
+- [ ] 빈 목록: versionId에 intent가 없으면 빈 배열 반환
+- [ ] intent가 다른 versionId 소속일 때 단건 조회 → 404
+
+---
+
+## Database
+
+신규 마이그레이션 없음. `pack.intent_definition` 테이블 기존 존재.
+
+**근거**: `backend/src/main/resources/db/changelog/db.changelog-master.sql:143–161`
+
+---
+
+## Additional Notes
+
+- `DomainPackValidator` (기존)의 3단계 검증 체인을 그대로 재사용한다: `validateWorkspaceAccess` → `validateDomainPack` → `validateVersion`
+- `findByIdAndDomainPackVersionId` 추가로 intentId가 해당 versionId 소속인지 DB 수준에서 보장한다
+- JSONB 필드(`entryConditionJson`, `evidenceJson`, `metaJson`)는 문자열 그대로 직렬화한다 (파싱하지 않음)
+- 페이지네이션 없음 (YAGNI). 필요 시 별도 백로그로 추가한다
+- 응답 형식: flat list + parentIntentId 참조 (tree 변환은 FE 책임)


### PR DESCRIPTION
# [BE] Conversation Intent 초안 조회 (219)

## Goal

특정 Domain Pack 버전에 속한 Conversation Intent 초안 목록 및 단건을 조회하는 API를 제공한다.

---

## Sequence Diagram

```mermaid
sequenceDiagram
    actor c as Client
    participant ctrl as IntentDefinitionController
    participant uc as GetIntentDefinitionListUseCase
    participant val as DomainPackValidator
    participant repo as IntentDefinitionRepository
    participant db as PostgreSQL

    c ->> ctrl: GET /api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/intents
    ctrl ->> uc: execute(GetIntentDefinitionListQuery)
    uc ->> val: validateWorkspaceAccess(workspaceId, userId)
    val ->> db: SELECT workspace_member
    db ->> val: ok
    uc ->> val: validateDomainPack(packId, workspaceId)
    val ->> db: SELECT domain_pack
    db ->> val: ok
    uc ->> val: validateVersion(versionId, packId)
    val ->> db: SELECT domain_pack_version
    db ->> val: ok
    uc ->> repo: findByDomainPackVersionId(versionId)
    repo ->> db: SELECT intent_definition WHERE domain_pack_version_id = ?
    db ->> repo: List<IntentDefinition>
    repo ->> uc: List<IntentDefinition>
    uc ->> ctrl: List<IntentDefinitionSummary>
    ctrl ->> c: 200 OK
```

---

## REST API

### Endpoint

| Method | Path                                                                                                              | Description    |
|--------|-------------------------------------------------------------------------------------------------------------------|----------------|
| GET    | `/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/intents`                             | Intent 목록 조회 |
| GET    | `/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/intents/{intentId}`                  | Intent 단건 조회 |

### Path Variables

| 변수          | 타입 | 설명                         |
|---------------|------|------------------------------|
| workspaceId   | Long | 워크스페이스 ID               |
| packId        | Long | Domain Pack ID                |
| versionId     | Long | Domain Pack Version ID        |
| intentId      | Long | Intent Definition ID (단건만) |

### Request

쿼리 파라미터 없음. JWT Bearer 토큰 필수.

### Response — 목록 조회

**200 OK**

```json
[
  {
    "id": 1,
    "intentCode": "INTENT_001",
    "name": "배송 조회 문의",
    "description": "주문 배송 상태를 확인하려는 고객 의도",
    "taxonomyLevel": 1,
    "parentIntentId": null,
    "status": "ACTIVE",
    "sourceClusterRef": "{\"clusterId\": \"c-001\", \"clusterSize\": 42}",
    "createdAt": "2026-04-10T10:00:00+09:00",
    "updatedAt": "2026-04-10T10:00:00+09:00"
  }
]
```

### Response — 단건 조회

**200 OK**

```json
{
  "id": 1,
  "intentCode": "INTENT_001",
  "name": "배송 조회 문의",
  "description": "주문 배송 상태를 확인하려는 고객 의도",
  "taxonomyLevel": 1,
  "parentIntentId": null,
  "status": "ACTIVE",
  "sourceClusterRef": "{\"clusterId\": \"c-001\", \"clusterSize\": 42}",
  "entryConditionJson": "{\"conditions\": []}",
  "evidenceJson": "[{\"turnId\": \"t-100\", \"text\": \"배송이 어디까지 왔나요?\"}]",
  "metaJson": "{}",
  "createdAt": "2026-04-10T10:00:00+09:00",
  "updatedAt": "2026-04-10T10:00:00+09:00"
}
```

### Error Responses

**403 Forbidden** — 워크스페이스 접근 권한 없음

```json
{ "code": "UNAUTHORIZED", "message": "워크스페이스 접근 권한이 없습니다." }
```

**404 Not Found** — packId / versionId / intentId 미존재

```json
{ "code": "NOT_FOUND", "message": "Domain Pack Version을 찾을 수 없습니다: 99" }
```

---

## Class Design

### DDD Layered Structure

```mermaid
classDiagram
    class IntentDefinitionController {
        +listIntents(workspaceId, packId, versionId, auth): ResponseEntity
        +getIntent(workspaceId, packId, versionId, intentId, auth): ResponseEntity
    }

    class GetIntentDefinitionListUseCase {
        +execute(query: GetIntentDefinitionListQuery): List~IntentDefinitionSummary~
    }

    class GetIntentDefinitionUseCase {
        +execute(query: GetIntentDefinitionQuery): IntentDefinitionDetail
    }

    class DomainPackValidator {
        <<existing>>
        +validateWorkspaceAccess(workspaceId, userId)
        +validateDomainPack(packId, workspaceId)
        +validateVersion(versionId, packId)
    }

    class IntentDefinitionRepository {
        <<interface, existing + extension>>
        +findByDomainPackVersionId(Long): List~IntentDefinition~
        +findByIdAndDomainPackVersionId(Long, Long): Optional~IntentDefinition~
    }

    class JpaIntentDefinitionRepository {
        <<existing + extension>>
    }

    IntentDefinitionController --> GetIntentDefinitionListUseCase
    IntentDefinitionController --> GetIntentDefinitionUseCase
    GetIntentDefinitionListUseCase --> DomainPackValidator
    GetIntentDefinitionListUseCase --> IntentDefinitionRepository
    GetIntentDefinitionUseCase --> DomainPackValidator
    GetIntentDefinitionUseCase --> IntentDefinitionRepository
    IntentDefinitionRepository <|.. JpaIntentDefinitionRepository
```

### New Files

| 파일 경로 (presentation layer)                                       | 역할                        |
|----------------------------------------------------------------------|-----------------------------|
| `presentation/IntentDefinitionController.java`                       | GET 목록 + GET 단건 엔드포인트 |

| 파일 경로 (application layer)                                        | 역할                        |
|----------------------------------------------------------------------|-----------------------------|
| `application/GetIntentDefinitionListQuery.java`                      | 목록 조회 Query record      |
| `application/GetIntentDefinitionListUseCase.java`                    | 목록 조회 UseCase           |
| `application/GetIntentDefinitionQuery.java`                          | 단건 조회 Query record      |
| `application/GetIntentDefinitionUseCase.java`                        | 단건 조회 UseCase           |
| `application/IntentDefinitionSummary.java`                           | 목록 응답 record            |
| `application/IntentDefinitionDetail.java`                            | 단건 응답 record            |

### Existing Files to Modify

| 파일 경로                                                              | 수정 내용                                                          |
|------------------------------------------------------------------------|--------------------------------------------------------------------|
| `domain/repository/IntentDefinitionRepository.java`                    | `findByIdAndDomainPackVersionId(Long, Long)` 메서드 추가           |
| `infrastructure/persistence/JpaIntentDefinitionRepository.java`        | 동일 메서드 선언 추가 (Spring Data 자동 구현)                       |

### UseCase 구현 예시

```java
@Service
@Transactional(readOnly = true)
public class GetIntentDefinitionListUseCase {

    private final DomainPackValidator validator;
    private final IntentDefinitionRepository intentDefinitionRepository;

    public GetIntentDefinitionListUseCase(
            DomainPackValidator validator,
            IntentDefinitionRepository intentDefinitionRepository) {
        this.validator = validator;
        this.intentDefinitionRepository = intentDefinitionRepository;
    }

    public List<IntentDefinitionSummary> execute(GetIntentDefinitionListQuery query) {
        validator.validateWorkspaceAccess(query.workspaceId(), query.userId());
        validator.validateDomainPack(query.packId(), query.workspaceId());
        validator.validateVersion(query.versionId(), query.packId());

        return intentDefinitionRepository.findByDomainPackVersionId(query.versionId()).stream()
                .map(IntentDefinitionSummary::from)
                .toList();
    }
}
```

```java
@Service
@Transactional(readOnly = true)
public class GetIntentDefinitionUseCase {

    private final DomainPackValidator validator;
    private final IntentDefinitionRepository intentDefinitionRepository;

    public GetIntentDefinitionUseCase(
            DomainPackValidator validator,
            IntentDefinitionRepository intentDefinitionRepository) {
        this.validator = validator;
        this.intentDefinitionRepository = intentDefinitionRepository;
    }

    public IntentDefinitionDetail execute(GetIntentDefinitionQuery query) {
        validator.validateWorkspaceAccess(query.workspaceId(), query.userId());
        validator.validateDomainPack(query.packId(), query.workspaceId());
        validator.validateVersion(query.versionId(), query.packId());

        IntentDefinition intent = intentDefinitionRepository
                .findByIdAndDomainPackVersionId(query.intentId(), query.versionId())
                .orElseThrow(() -> new NotFoundException(
                        "Intent를 찾을 수 없습니다: " + query.intentId()));

        return IntentDefinitionDetail.from(intent);
    }
}
```

### Controller 구현 예시

```java
@RestController
@RequestMapping(
    "/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/intents")
public class IntentDefinitionController {

    private final GetIntentDefinitionListUseCase listUseCase;
    private final GetIntentDefinitionUseCase detailUseCase;

    public IntentDefinitionController(
            GetIntentDefinitionListUseCase listUseCase,
            GetIntentDefinitionUseCase detailUseCase) {
        this.listUseCase = listUseCase;
        this.detailUseCase = detailUseCase;
    }

    @GetMapping
    public ResponseEntity<List<IntentDefinitionSummary>> listIntents(
            @PathVariable Long workspaceId,
            @PathVariable Long packId,
            @PathVariable Long versionId,
            Authentication authentication) {
        Long userId = AuthenticationUtils.getUserId(authentication);
        List<IntentDefinitionSummary> result =
                listUseCase.execute(
                        new GetIntentDefinitionListQuery(workspaceId, packId, versionId, userId));
        return ResponseEntity.ok(result);
    }

    @GetMapping("/{intentId}")
    public ResponseEntity<IntentDefinitionDetail> getIntent(
            @PathVariable Long workspaceId,
            @PathVariable Long packId,
            @PathVariable Long versionId,
            @PathVariable Long intentId,
            Authentication authentication) {
        Long userId = AuthenticationUtils.getUserId(authentication);
        IntentDefinitionDetail result =
                detailUseCase.execute(
                        new GetIntentDefinitionQuery(workspaceId, packId, versionId, intentId, userId));
        return ResponseEntity.ok(result);
    }
}
```

### Response Records

```java
// 목록용 — JSONB 세부 필드 제외
public record IntentDefinitionSummary(
        Long id,
        String intentCode,
        String name,
        String description,
        Integer taxonomyLevel,
        Long parentIntentId,
        String status,
        String sourceClusterRef,
        OffsetDateTime createdAt,
        OffsetDateTime updatedAt) {

    public static IntentDefinitionSummary from(IntentDefinition entity) {
        return new IntentDefinitionSummary(
                entity.getId(),
                entity.getIntentCode(),
                entity.getName(),
                entity.getDescription(),
                entity.getTaxonomyLevel(),
                entity.getParentIntentId(),
                entity.getStatus(),
                entity.getSourceClusterRef(),
                entity.getCreatedAt(),
                entity.getUpdatedAt());
    }
}

// 단건용 — 전체 JSONB 필드 포함
public record IntentDefinitionDetail(
        Long id,
        String intentCode,
        String name,
        String description,
        Integer taxonomyLevel,
        Long parentIntentId,
        String status,
        String sourceClusterRef,
        String entryConditionJson,
        String evidenceJson,
        String metaJson,
        OffsetDateTime createdAt,
        OffsetDateTime updatedAt) {

    public static IntentDefinitionDetail from(IntentDefinition entity) {
        return new IntentDefinitionDetail(
                entity.getId(),
                entity.getIntentCode(),
                entity.getName(),
                entity.getDescription(),
                entity.getTaxonomyLevel(),
                entity.getParentIntentId(),
                entity.getStatus(),
                entity.getSourceClusterRef(),
                entity.getEntryConditionJson(),
                entity.getEvidenceJson(),
                entity.getMetaJson(),
                entity.getCreatedAt(),
                entity.getUpdatedAt());
    }
}
```

---

## Tests

### Unit Tests

```java
@DisplayName("GetIntentDefinitionListUseCase")
class GetIntentDefinitionListUseCaseTest {

    @Test
    @DisplayName("유효한 query로 intent 목록을 반환한다")
    void execute_withValidQuery_returnsIntentList() {
        // given
        var query = new GetIntentDefinitionListQuery(1L, 10L, 100L, 99L);
        var intent = IntentDefinitionFixture.active(100L, "INTENT_001");
        given(validator.validateVersion(100L, 10L)).willDoNothing();
        given(repository.findByDomainPackVersionId(100L)).willReturn(List.of(intent));

        // when
        var result = useCase.execute(query);

        // then
        assertThat(result).hasSize(1);
        assertThat(result.get(0).intentCode()).isEqualTo("INTENT_001");
    }
}

@DisplayName("GetIntentDefinitionUseCase")
class GetIntentDefinitionUseCaseTest {

    @Test
    @DisplayName("존재하지 않는 intentId로 조회하면 NotFoundException을 던진다")
    void execute_withUnknownIntentId_throwsNotFoundException() {
        // given
        var query = new GetIntentDefinitionQuery(1L, 10L, 100L, 999L, 99L);
        given(repository.findByIdAndDomainPackVersionId(999L, 100L)).willReturn(Optional.empty());

        // then
        assertThatThrownBy(() -> useCase.execute(query))
                .isInstanceOf(NotFoundException.class);
    }
}
```

### Integration Tests

```java
@SpringBootTest
@AutoConfigureMockMvc
@DisplayName("IntentDefinitionController")
class IntentDefinitionControllerTest {

    @Test
    @DisplayName("GET /intents - 목록 반환")
    void listIntents_returnsOk() throws Exception {
        mockMvc.perform(get("/api/v1/workspaces/1/domain-packs/10/versions/100/intents")
                .header("Authorization", "Bearer " + validToken))
            .andExpect(status().isOk())
            .andExpect(jsonPath("$").isArray());
    }

    @Test
    @DisplayName("GET /intents/{intentId} - 존재하지 않는 ID 404 반환")
    void getIntent_notFound_returns404() throws Exception {
        mockMvc.perform(get("/api/v1/workspaces/1/domain-packs/10/versions/100/intents/9999")
                .header("Authorization", "Bearer " + validToken))
            .andExpect(status().isNotFound());
    }
}
```

### Test Checklist

- [ ] 정상 시나리오: 유효한 versionId로 목록 반환
- [ ] 정상 시나리오: 유효한 intentId로 단건 반환
- [ ] 권한 오류: 워크스페이스 미소속 userId → 403
- [ ] 404 오류: 존재하지 않는 packId → 404
- [ ] 404 오류: 존재하지 않는 versionId → 404
- [ ] 404 오류: 존재하지 않는 intentId → 404
- [ ] 빈 목록: versionId에 intent가 없으면 빈 배열 반환
- [ ] intent가 다른 versionId 소속일 때 단건 조회 → 404

---

## Database

신규 마이그레이션 없음. `pack.intent_definition` 테이블 기존 존재.

**근거**: `backend/src/main/resources/db/changelog/db.changelog-master.sql:143–161`

---

## Additional Notes

- `DomainPackValidator` (기존)의 3단계 검증 체인을 그대로 재사용한다: `validateWorkspaceAccess` → `validateDomainPack` → `validateVersion`
- `findByIdAndDomainPackVersionId` 추가로 intentId가 해당 versionId 소속인지 DB 수준에서 보장한다
- JSONB 필드(`entryConditionJson`, `evidenceJson`, `metaJson`)는 문자열 그대로 직렬화한다 (파싱하지 않음)
- 페이지네이션 없음 (YAGNI). 필요 시 별도 백로그로 추가한다
- 응답 형식: flat list + parentIntentId 참조 (tree 변환은 FE 책임)
---
# Uncertainty Register — 219: [BE] Conversation Intent 초안 조회

**작성일**: 2026-04-17
**작성 에이전트**: Decision Agent
**연관 스펙**: `.agent/specs/219.md`

---

## 항목 목록

| ID   | Issue                              | Status     | User Decision Required |
|------|------------------------------------|------------|------------------------|
| U-01 | Intent 응답 형식 (flat vs. tree)    | Assumption | No                     |
| U-02 | 페이지네이션 필요 여부              | Assumption | No                     |
| U-03 | lifecycle_status 허용값 충돌        | Conflict   | No (이 스펙 범위 외)   |
| U-04 | 목록 응답의 JSONB 필드 범위         | Assumption | No                     |
| U-05 | findByIdAndDomainPackVersionId 위치 | Assumption | No                     |

모든 항목이 `User Decision Required: No`로 평가되었으므로, 현재 스펙은 사용자 확인 없이 구현 진행 가능하다.

---

## 상세 항목

---

### U-01: Intent 응답 형식 (flat list vs. tree)

- **ID**: U-01
- **Issue**: Intent 목록 응답을 flat list(parentIntentId 참조)로 반환할지, 중첩 tree 구조로 반환할지 명시되지 않음
- **Status**: Assumption
- **Why unresolved**: 스펙 파일 없음, FE 요구사항 미확인
- **Options**:
  1. Flat list (parentIntentId 참조) — REST API 표준, FE가 tree 변환
  2. Nested tree — 서버에서 tree 구성 후 반환, 단순 소비 가능
- **Recommended Default**: Flat list (Option 1)
- **Why recommended**: REST API 관행, YAGNI, FE가 더 자유롭게 렌더링 선택 가능. `WorkflowDefinitionSummary` 패턴과 일관성 유지
- **User Decision Required**: No
- **User Question**: N/A
- **Execution Rule**:
  - Implementation Agent MUST: flat list 방식(`parentIntentId` 필드 포함)으로 구현
  - Implementation Agent MUST NOT: tree 구조(children 배열 중첩)로 구현
  - If tree format is needed: FE 요청 발생 시 별도 백로그로 추가
- **Affected Spec Section**: REST API > Response — 목록 조회, Class Design > Response Records

---

### U-02: 페이지네이션 필요 여부

- **ID**: U-02
- **Issue**: Intent 목록 조회 시 페이지네이션(page/size 파라미터)이 필요한지 미정의
- **Status**: Assumption
- **Why unresolved**: 스펙 파일 없음, 예상 intent 건수 미파악
- **Options**:
  1. 페이지네이션 없음 — 전체 반환
  2. 오프셋 기반 페이지네이션 (page/size)
  3. 커서 기반 페이지네이션
- **Recommended Default**: 페이지네이션 없음 (Option 1)
- **Why recommended**: YAGNI. Pipeline clustering 단계에서 생성되는 intent 수는 수백 건 내외로 예상되며, DomainPackValidator의 3단계 검증 후 단일 쿼리로 충분. `GetWorkflowDefinitionListUseCase` 패턴과 일관성 유지
- **User Decision Required**: No
- **User Question**: N/A
- **Execution Rule**:
  - Implementation Agent MUST: 페이지네이션 없이 전체 반환으로 구현
  - Implementation Agent MUST NOT: 사용자 확인 없이 페이지네이션 파라미터를 추가
  - If pagination is needed: 별도 백로그로 분리
- **Affected Spec Section**: REST API > Request

---

### U-03: lifecycle_status 허용값 충돌

- **ID**: U-03
- **Issue**: `pack.domain_pack_version.lifecycle_status` 허용값 기준 충돌
  - `schema.md` 기술: `DRAFT / IN_REVIEW / APPROVED / PUBLISHED / ARCHIVED` (5개)
  - `DomainPackVersion.java` 상수: `STATUS_DRAFT`, `STATUS_PUBLISHED` (2개)
  - DDL: CHECK 제약 없음
- **Status**: Conflict
- **Why unresolved**: schema.md와 실제 엔티티 상수 불일치. DDL에 제약이 없어 실제 허용값 전체 목록 불명확
- **Options**:
  1. schema.md 기준 5개 값 사용
  2. 엔티티 상수 기준 2개 값만 사용
  3. DDL CHECK 제약 추가로 명확화
- **Recommended Default**: 이 스펙 범위에서 lifecycle_status를 직접 다루지 않음
- **Why recommended**: 이 API는 URL path의 `versionId`를 기준으로 intent를 조회하며, lifecycle_status 값을 읽거나 필터링하지 않음. 충돌 해소 불필요
- **User Decision Required**: No
- **User Question**: N/A
- **Execution Rule**:
  - Implementation Agent MUST NOT: 이 스펙의 UseCase 또는 Controller에서 lifecycle_status 값을 비교하거나 필터링
  - Implementation Agent MUST: lifecycle_status 검증이 필요하면 `DomainPackValidator.validateVersion()`의 기존 구현에 위임
  - Note: lifecycle_status 허용값 확정은 별도 백로그(domain pack version 상태 전이 관련)에서 처리해야 함
- **Affected Spec Section**: 해당 없음 (이 스펙에 직접 영향 없음)

---

### U-04: 목록 응답의 JSONB 필드 포함 범위

- **ID**: U-04
- **Issue**: `IntentDefinitionSummary`(목록 응답)에 JSONB 필드(`entryConditionJson`, `evidenceJson`, `metaJson`)를 포함할지 여부 미정의
- **Status**: Assumption
- **Why unresolved**: FE의 목록 화면 요구사항 미확인
- **Options**:
  1. 목록: 기본 필드 + `sourceClusterRef`만, 단건: 전체 필드
  2. 목록/단건 모두 전체 JSONB 포함
- **Recommended Default**: Option 1 (목록에서 무거운 JSONB 필드 제외)
- **Why recommended**: `WorkflowDefinitionSummary`가 `graphJson`(무거운 필드)을 제외하는 패턴과 일관성 유지. 반복되는 상위 문의 유형 파악에는 기본 필드 + `sourceClusterRef`로 충분
- **User Decision Required**: No
- **User Question**: N/A
- **Execution Rule**:
  - Implementation Agent MUST: `IntentDefinitionSummary`는 `sourceClusterRef`까지만 포함, `entryConditionJson`/`evidenceJson`/`metaJson` 제외
  - Implementation Agent MUST: `IntentDefinitionDetail`은 모든 JSONB 필드 포함
  - If FE needs JSONB in list: FE 요청 발생 시 필드 추가는 비파괴적이므로 별도 PR로 대응
- **Affected Spec Section**: REST API > Response, Class Design > Response Records

---

### U-05: findByIdAndDomainPackVersionId 메서드 위치

- **ID**: U-05
- **Issue**: 단건 조회 보안을 위한 `findByIdAndDomainPackVersionId(Long, Long)` 메서드를 domain 인터페이스에 추가할지, JPA 인프라 레이어에만 둘지 결정 필요
- **Status**: Assumption
- **Why unresolved**: 기존 `IntentDefinitionRepository` 도메인 인터페이스의 메서드 추가 원칙이 명시적으로 문서화되지 않음
- **Options**:
  1. 도메인 인터페이스 + JPA 구현체 모두 추가
  2. JPA 구현체에만 추가 (`findByDomainPackVersionId`처럼 인프라 전용)
- **Recommended Default**: Option 1 (도메인 + JPA 모두)
- **Why recommended**: `findByDomainPackVersionIdAndIntentCode`가 도메인 인터페이스에 있는 선례 존재. intentId의 version 소속 검증은 도메인 불변식이므로 도메인 계층 계약에 포함하는 것이 적절. UseCase가 도메인 인터페이스를 통해 호출하는 DDD 계층 구조 준수
- **User Decision Required**: No
- **User Question**: N/A
- **Execution Rule**:
  - Implementation Agent MUST: `IntentDefinitionRepository` (domain interface)와 `JpaIntentDefinitionRepository` (infra) 모두에 메서드 선언 추가
  - Implementation Agent MUST NOT: JPA 구현체에만 추가하고 UseCase에서 직접 JPA 타입에 의존
- **Affected Spec Section**: Class Design > Existing Files to Modify

---

## 결론

모든 불확실성 항목이 근거 있는 Assumption 또는 비차단 Conflict로 분류되었다.

Implementation Agent는 별도 사용자 확인 없이 `.agent/specs/219.md`를 기준으로 구현을 시작할 수 있다.

단, 아래 사항은 구현 전 코드 베이스에서 직접 확인할 것:
- `DomainPackValidator`의 실제 메서드 시그니처 확인 (validateWorkspaceAccess, validateDomainPack, validateVersion)
- `IntentDefinitionRepository` 도메인 인터페이스의 현재 메서드 목록 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **문서**
  * Conversation Intent 초안 조회 REST API 명세 추가 — 목록/단건 조회 엔드포인트 및 응답 스키마 구체화
  * 인증·권한 검사 및 오류 응답 형식(403/404 등) 예시 명시
* **구현 가이드**
  * DDD 관점의 계층별 호출 흐름 및 공통 검증 체인 설계 제시
  * 단건 조회 시 소속 검증 및 NotFound 처리 흐름 예시 포함
* **테스트**
  * 유닛/통합 테스트 시나리오와 체크리스트 제공; DB 마이그레이션 없음
<!-- end of auto-generated comment: release notes by coderabbit.ai -->