### PR TITLE
feat(domain-pack): add conversation intent draft read endpoints (spec/219)

### DIFF
--- a/backend/src/main/java/com/init/domainpack/application/DomainPackDraftPersistenceService.java
+++ b/backend/src/main/java/com/init/domainpack/application/DomainPackDraftPersistenceService.java
@@ -130,7 +130,7 @@ public class DomainPackDraftPersistenceService {
                 + ", parentIntentCode="
                 + draft.parentIntentCode());
       }
-      child.setParentIntentId(parent.getId());
+      child.assignParent(parent.getId());
     }
     if (hasParentIntent) {
       intentDefinitionRepository.saveAllAndFlush(savedIntents);
@@ -210,7 +210,7 @@ public class DomainPackDraftPersistenceService {
                 + ", parentIntentCode="
                 + draft.parentIntentCode());
       }
-      child.setParentIntentId(parent.getId());
+      child.assignParent(parent.getId());
     }
     if (hasParentIntent) {
       savedIntents = intentDefinitionRepository.saveAllAndFlush(savedIntents);

--- a/backend/src/main/java/com/init/domainpack/application/GetIntentDefinitionListQuery.java
+++ b/backend/src/main/java/com/init/domainpack/application/GetIntentDefinitionListQuery.java
@@ -1,0 +1,4 @@
+package com.init.domainpack.application;
+
+public record GetIntentDefinitionListQuery(
+    Long workspaceId, Long packId, Long versionId, Long userId) {}

--- a/backend/src/main/java/com/init/domainpack/application/GetIntentDefinitionListUseCase.java
+++ b/backend/src/main/java/com/init/domainpack/application/GetIntentDefinitionListUseCase.java
@@ -1,0 +1,30 @@
+package com.init.domainpack.application;
+
+import com.init.domainpack.domain.repository.IntentDefinitionRepository;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class GetIntentDefinitionListUseCase {
+
+  private final DomainPackValidator validator;
+  private final IntentDefinitionRepository intentDefinitionRepository;
+
+  public GetIntentDefinitionListUseCase(
+      DomainPackValidator validator, IntentDefinitionRepository intentDefinitionRepository) {
+    this.validator = validator;
+    this.intentDefinitionRepository = intentDefinitionRepository;
+  }
+
+  public List<IntentDefinitionSummary> execute(GetIntentDefinitionListQuery query) {
+    validator.validateWorkspaceAccess(query.workspaceId(), query.userId());
+    validator.validateDomainPack(query.packId(), query.workspaceId());
+    validator.validateVersion(query.versionId(), query.packId());
+
+    return intentDefinitionRepository.findByDomainPackVersionId(query.versionId()).stream()
+        .map(IntentDefinitionSummary::from)
+        .toList();
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/application/GetIntentDefinitionQuery.java
+++ b/backend/src/main/java/com/init/domainpack/application/GetIntentDefinitionQuery.java
@@ -1,0 +1,4 @@
+package com.init.domainpack.application;
+
+public record GetIntentDefinitionQuery(
+    Long workspaceId, Long packId, Long versionId, Long intentId, Long userId) {}

--- a/backend/src/main/java/com/init/domainpack/application/GetIntentDefinitionUseCase.java
+++ b/backend/src/main/java/com/init/domainpack/application/GetIntentDefinitionUseCase.java
@@ -1,0 +1,32 @@
+package com.init.domainpack.application;
+
+import com.init.domainpack.application.exception.IntentDefinitionNotFoundException;
+import com.init.domainpack.domain.repository.IntentDefinitionRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class GetIntentDefinitionUseCase {
+
+  private final DomainPackValidator validator;
+  private final IntentDefinitionRepository intentDefinitionRepository;
+
+  public GetIntentDefinitionUseCase(
+      DomainPackValidator validator, IntentDefinitionRepository intentDefinitionRepository) {
+    this.validator = validator;
+    this.intentDefinitionRepository = intentDefinitionRepository;
+  }
+
+  public IntentDefinitionDetail execute(GetIntentDefinitionQuery query) {
+    validator.validateWorkspaceAccess(query.workspaceId(), query.userId());
+    validator.validateDomainPack(query.packId(), query.workspaceId());
+    validator.validateVersion(query.versionId(), query.packId());
+
+    return intentDefinitionRepository
+        .findByIdAndDomainPackVersionId(query.intentId(), query.versionId())
+        .map(IntentDefinitionDetail::from)
+        .orElseThrow(
+            () -> new IntentDefinitionNotFoundException(query.intentId(), query.versionId()));
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/application/IntentDefinitionDetail.java
+++ b/backend/src/main/java/com/init/domainpack/application/IntentDefinitionDetail.java
@@ -1,0 +1,37 @@
+package com.init.domainpack.application;
+
+import com.init.domainpack.domain.model.IntentDefinition;
+import java.time.OffsetDateTime;
+
+public record IntentDefinitionDetail(
+    Long id,
+    String intentCode,
+    String name,
+    String description,
+    Integer taxonomyLevel,
+    Long parentIntentId,
+    String status,
+    String sourceClusterRef,
+    String entryConditionJson,
+    String evidenceJson,
+    String metaJson,
+    OffsetDateTime createdAt,
+    OffsetDateTime updatedAt) {
+
+  public static IntentDefinitionDetail from(IntentDefinition entity) {
+    return new IntentDefinitionDetail(
+        entity.getId(),
+        entity.getIntentCode(),
+        entity.getName(),
+        entity.getDescription(),
+        entity.getTaxonomyLevel(),
+        entity.getParentIntentId(),
+        entity.getStatus(),
+        entity.getSourceClusterRef(),
+        entity.getEntryConditionJson(),
+        entity.getEvidenceJson(),
+        entity.getMetaJson(),
+        entity.getCreatedAt(),
+        entity.getUpdatedAt());
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/application/IntentDefinitionSummary.java
+++ b/backend/src/main/java/com/init/domainpack/application/IntentDefinitionSummary.java
@@ -1,0 +1,31 @@
+package com.init.domainpack.application;
+
+import com.init.domainpack.domain.model.IntentDefinition;
+import java.time.OffsetDateTime;
+
+public record IntentDefinitionSummary(
+    Long id,
+    String intentCode,
+    String name,
+    String description,
+    Integer taxonomyLevel,
+    Long parentIntentId,
+    String status,
+    String sourceClusterRef,
+    OffsetDateTime createdAt,
+    OffsetDateTime updatedAt) {
+
+  public static IntentDefinitionSummary from(IntentDefinition entity) {
+    return new IntentDefinitionSummary(
+        entity.getId(),
+        entity.getIntentCode(),
+        entity.getName(),
+        entity.getDescription(),
+        entity.getTaxonomyLevel(),
+        entity.getParentIntentId(),
+        entity.getStatus(),
+        entity.getSourceClusterRef(),
+        entity.getCreatedAt(),
+        entity.getUpdatedAt());
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/application/exception/IntentDefinitionNotFoundException.java
+++ b/backend/src/main/java/com/init/domainpack/application/exception/IntentDefinitionNotFoundException.java
@@ -1,0 +1,11 @@
+package com.init.domainpack.application.exception;
+
+import com.init.shared.application.exception.NotFoundException;
+
+public class IntentDefinitionNotFoundException extends NotFoundException {
+  public IntentDefinitionNotFoundException(Long intentId, Long versionId) {
+    super(
+        "INTENT_DEFINITION_NOT_FOUND",
+        "Intent를 찾을 수 없습니다. intentId=" + intentId + ", versionId=" + versionId);
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/domain/model/IntentDefinition.java
+++ b/backend/src/main/java/com/init/domainpack/domain/model/IntentDefinition.java
@@ -152,6 +152,14 @@ public class IntentDefinition {
     return metaJson;
   }
 
+  public OffsetDateTime getCreatedAt() {
+    return createdAt;
+  }
+
+  public OffsetDateTime getUpdatedAt() {
+    return updatedAt;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/backend/src/main/java/com/init/domainpack/domain/model/IntentDefinition.java
+++ b/backend/src/main/java/com/init/domainpack/domain/model/IntentDefinition.java
@@ -128,7 +128,10 @@ public class IntentDefinition {
     return parentIntentId;
   }
 
-  public void setParentIntentId(Long parentIntentId) {
+  public void assignParent(Long parentIntentId) {
+    if (Objects.equals(this.id, parentIntentId)) {
+      throw new IllegalArgumentException("Intent cannot be its own parent: id=" + this.id);
+    }
     this.parentIntentId = parentIntentId;
   }
 

--- a/backend/src/main/java/com/init/domainpack/domain/repository/IntentDefinitionRepository.java
+++ b/backend/src/main/java/com/init/domainpack/domain/repository/IntentDefinitionRepository.java
@@ -16,4 +16,8 @@ public interface IntentDefinitionRepository {
 
   Optional<IntentDefinition> findByDomainPackVersionIdAndIntentCode(
       Long domainPackVersionId, String intentCode);
+
+  List<IntentDefinition> findByDomainPackVersionId(Long domainPackVersionId);
+
+  Optional<IntentDefinition> findByIdAndDomainPackVersionId(Long id, Long domainPackVersionId);
 }

--- a/backend/src/main/java/com/init/domainpack/infrastructure/persistence/JpaIntentDefinitionRepository.java
+++ b/backend/src/main/java/com/init/domainpack/infrastructure/persistence/JpaIntentDefinitionRepository.java
@@ -3,6 +3,7 @@ package com.init.domainpack.infrastructure.persistence;
 import com.init.domainpack.domain.model.IntentDefinition;
 import com.init.domainpack.domain.repository.IntentDefinitionRepository;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -11,4 +12,6 @@ public interface JpaIntentDefinitionRepository
     extends JpaRepository<IntentDefinition, Long>, IntentDefinitionRepository {
 
   List<IntentDefinition> findByDomainPackVersionId(Long domainPackVersionId);
+
+  Optional<IntentDefinition> findByIdAndDomainPackVersionId(Long id, Long domainPackVersionId);
 }

--- a/backend/src/main/java/com/init/domainpack/presentation/IntentDefinitionController.java
+++ b/backend/src/main/java/com/init/domainpack/presentation/IntentDefinitionController.java
@@ -1,0 +1,58 @@
+package com.init.domainpack.presentation;
+
+import com.init.domainpack.application.GetIntentDefinitionListQuery;
+import com.init.domainpack.application.GetIntentDefinitionListUseCase;
+import com.init.domainpack.application.GetIntentDefinitionQuery;
+import com.init.domainpack.application.GetIntentDefinitionUseCase;
+import com.init.domainpack.application.IntentDefinitionDetail;
+import com.init.domainpack.application.IntentDefinitionSummary;
+import com.init.shared.presentation.AuthenticationUtils;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(
+    "/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/intents")
+public class IntentDefinitionController {
+
+  private final GetIntentDefinitionListUseCase listUseCase;
+  private final GetIntentDefinitionUseCase detailUseCase;
+
+  public IntentDefinitionController(
+      GetIntentDefinitionListUseCase listUseCase, GetIntentDefinitionUseCase detailUseCase) {
+    this.listUseCase = listUseCase;
+    this.detailUseCase = detailUseCase;
+  }
+
+  @GetMapping
+  public ResponseEntity<List<IntentDefinitionSummary>> listIntents(
+      @PathVariable Long workspaceId,
+      @PathVariable Long packId,
+      @PathVariable Long versionId,
+      Authentication authentication) {
+    Long userId = AuthenticationUtils.getUserId(authentication);
+    List<IntentDefinitionSummary> result =
+        listUseCase.execute(
+            new GetIntentDefinitionListQuery(workspaceId, packId, versionId, userId));
+    return ResponseEntity.ok(result);
+  }
+
+  @GetMapping("/{intentId}")
+  public ResponseEntity<IntentDefinitionDetail> getIntent(
+      @PathVariable Long workspaceId,
+      @PathVariable Long packId,
+      @PathVariable Long versionId,
+      @PathVariable Long intentId,
+      Authentication authentication) {
+    Long userId = AuthenticationUtils.getUserId(authentication);
+    IntentDefinitionDetail result =
+        detailUseCase.execute(
+            new GetIntentDefinitionQuery(workspaceId, packId, versionId, intentId, userId));
+    return ResponseEntity.ok(result);
+  }
+}

--- a/backend/src/test/java/com/init/domainpack/application/GetIntentDefinitionListUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/GetIntentDefinitionListUseCaseTest.java
@@ -57,7 +57,8 @@ class GetIntentDefinitionListUseCaseTest {
 
   @Test
   @DisplayName("유효한 query로 intent 목록 반환")
-  void execute_withValidQuery_returnsIntentList() {
+  void should_returnIntentList_when_validQuery() {
+    // given
     given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
     given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
     given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(true);
@@ -66,10 +67,12 @@ class GetIntentDefinitionListUseCaseTest {
     given(intentDefinitionRepository.findByDomainPackVersionId(VERSION_ID))
         .willReturn(List.of(createIntent(1L, "INTENT_001", "배송 조회 문의")));
 
+    // when
     List<IntentDefinitionSummary> result =
         useCase.execute(
             new GetIntentDefinitionListQuery(WORKSPACE_ID, PACK_ID, VERSION_ID, USER_ID));
 
+    // then
     assertThat(result).hasSize(1);
     assertThat(result.get(0).intentCode()).isEqualTo("INTENT_001");
     assertThat(result.get(0).name()).isEqualTo("배송 조회 문의");
@@ -77,7 +80,8 @@ class GetIntentDefinitionListUseCaseTest {
 
   @Test
   @DisplayName("intent 없는 version → 빈 목록 반환")
-  void execute_noIntents_returnsEmptyList() {
+  void should_returnEmptyList_when_noIntentsExist() {
+    // given
     given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
     given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
     given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(true);
@@ -85,18 +89,22 @@ class GetIntentDefinitionListUseCaseTest {
         .willReturn(Optional.of(createVersion(VERSION_ID, PACK_ID)));
     given(intentDefinitionRepository.findByDomainPackVersionId(VERSION_ID)).willReturn(List.of());
 
+    // when
     List<IntentDefinitionSummary> result =
         useCase.execute(
             new GetIntentDefinitionListQuery(WORKSPACE_ID, PACK_ID, VERSION_ID, USER_ID));
 
+    // then
     assertThat(result).isEmpty();
   }
 
   @Test
   @DisplayName("workspace 없음 → DomainPackWorkspaceNotFoundException")
-  void execute_workspaceNotFound_throwsException() {
+  void should_throwWorkspaceNotFoundException_when_workspaceNotFound() {
+    // given
     given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(false);
 
+    // when & then
     assertThatThrownBy(
             () ->
                 useCase.execute(
@@ -106,10 +114,12 @@ class GetIntentDefinitionListUseCaseTest {
 
   @Test
   @DisplayName("접근 권한 없음 → DomainPackUnauthorizedWorkspaceAccessException")
-  void execute_unauthorized_throwsException() {
+  void should_throwUnauthorizedException_when_unauthorized() {
+    // given
     given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
     given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(false);
 
+    // when & then
     assertThatThrownBy(
             () ->
                 useCase.execute(
@@ -119,11 +129,13 @@ class GetIntentDefinitionListUseCaseTest {
 
   @Test
   @DisplayName("domain pack 소속 불일치 → DomainPackNotFoundException")
-  void execute_packNotInWorkspace_throwsException() {
+  void should_throwDomainPackNotFoundException_when_packNotInWorkspace() {
+    // given
     given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
     given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
     given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(false);
 
+    // when & then
     assertThatThrownBy(
             () ->
                 useCase.execute(
@@ -133,13 +145,15 @@ class GetIntentDefinitionListUseCaseTest {
 
   @Test
   @DisplayName("version 소속 불일치 → DomainPackVersionNotFoundException")
-  void execute_versionNotInPack_throwsException() {
+  void should_throwVersionNotFoundException_when_versionNotInPack() {
+    // given
     given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
     given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
     given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(true);
     given(domainPackVersionRepository.findById(VERSION_ID))
         .willReturn(Optional.of(createVersion(VERSION_ID, 999L)));
 
+    // when & then
     assertThatThrownBy(
             () ->
                 useCase.execute(

--- a/backend/src/test/java/com/init/domainpack/application/GetIntentDefinitionListUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/GetIntentDefinitionListUseCaseTest.java
@@ -1,0 +1,162 @@
+package com.init.domainpack.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.init.domainpack.application.exception.DomainPackNotFoundException;
+import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
+import com.init.domainpack.application.exception.DomainPackVersionNotFoundException;
+import com.init.domainpack.application.exception.DomainPackWorkspaceNotFoundException;
+import com.init.domainpack.domain.model.DomainPackVersion;
+import com.init.domainpack.domain.model.IntentDefinition;
+import com.init.domainpack.domain.repository.DomainPackRepository;
+import com.init.domainpack.domain.repository.DomainPackVersionRepository;
+import com.init.domainpack.domain.repository.IntentDefinitionRepository;
+import com.init.domainpack.domain.repository.WorkspaceExistencePort;
+import com.init.domainpack.domain.repository.WorkspaceMembershipPort;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetIntentDefinitionListUseCase")
+class GetIntentDefinitionListUseCaseTest {
+
+  @Mock private WorkspaceExistencePort workspaceExistencePort;
+  @Mock private WorkspaceMembershipPort workspaceMembershipPort;
+  @Mock private DomainPackRepository domainPackRepository;
+  @Mock private DomainPackVersionRepository domainPackVersionRepository;
+  @Mock private IntentDefinitionRepository intentDefinitionRepository;
+
+  private GetIntentDefinitionListUseCase useCase;
+
+  private static final Long WORKSPACE_ID = 1L;
+  private static final Long PACK_ID = 7L;
+  private static final Long VERSION_ID = 101L;
+  private static final Long USER_ID = 10L;
+
+  @BeforeEach
+  void setUp() {
+    DomainPackValidator validator =
+        new DomainPackValidator(
+            workspaceExistencePort,
+            workspaceMembershipPort,
+            domainPackRepository,
+            domainPackVersionRepository);
+    useCase = new GetIntentDefinitionListUseCase(validator, intentDefinitionRepository);
+  }
+
+  @Test
+  @DisplayName("유효한 query로 intent 목록 반환")
+  void execute_withValidQuery_returnsIntentList() {
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(true);
+    given(domainPackVersionRepository.findById(VERSION_ID))
+        .willReturn(Optional.of(createVersion(VERSION_ID, PACK_ID)));
+    given(intentDefinitionRepository.findByDomainPackVersionId(VERSION_ID))
+        .willReturn(List.of(createIntent(1L, "INTENT_001", "배송 조회 문의")));
+
+    List<IntentDefinitionSummary> result =
+        useCase.execute(
+            new GetIntentDefinitionListQuery(WORKSPACE_ID, PACK_ID, VERSION_ID, USER_ID));
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).intentCode()).isEqualTo("INTENT_001");
+    assertThat(result.get(0).name()).isEqualTo("배송 조회 문의");
+  }
+
+  @Test
+  @DisplayName("intent 없는 version → 빈 목록 반환")
+  void execute_noIntents_returnsEmptyList() {
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(true);
+    given(domainPackVersionRepository.findById(VERSION_ID))
+        .willReturn(Optional.of(createVersion(VERSION_ID, PACK_ID)));
+    given(intentDefinitionRepository.findByDomainPackVersionId(VERSION_ID)).willReturn(List.of());
+
+    List<IntentDefinitionSummary> result =
+        useCase.execute(
+            new GetIntentDefinitionListQuery(WORKSPACE_ID, PACK_ID, VERSION_ID, USER_ID));
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  @DisplayName("workspace 없음 → DomainPackWorkspaceNotFoundException")
+  void execute_workspaceNotFound_throwsException() {
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(false);
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new GetIntentDefinitionListQuery(WORKSPACE_ID, PACK_ID, VERSION_ID, USER_ID)))
+        .isInstanceOf(DomainPackWorkspaceNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("접근 권한 없음 → DomainPackUnauthorizedWorkspaceAccessException")
+  void execute_unauthorized_throwsException() {
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(false);
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new GetIntentDefinitionListQuery(WORKSPACE_ID, PACK_ID, VERSION_ID, USER_ID)))
+        .isInstanceOf(DomainPackUnauthorizedWorkspaceAccessException.class);
+  }
+
+  @Test
+  @DisplayName("domain pack 소속 불일치 → DomainPackNotFoundException")
+  void execute_packNotInWorkspace_throwsException() {
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(false);
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new GetIntentDefinitionListQuery(WORKSPACE_ID, PACK_ID, VERSION_ID, USER_ID)))
+        .isInstanceOf(DomainPackNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("version 소속 불일치 → DomainPackVersionNotFoundException")
+  void execute_versionNotInPack_throwsException() {
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(true);
+    given(domainPackVersionRepository.findById(VERSION_ID))
+        .willReturn(Optional.of(createVersion(VERSION_ID, 999L)));
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new GetIntentDefinitionListQuery(WORKSPACE_ID, PACK_ID, VERSION_ID, USER_ID)))
+        .isInstanceOf(DomainPackVersionNotFoundException.class);
+  }
+
+  private DomainPackVersion createVersion(Long id, Long packId) {
+    return DomainPackVersion.ofForTest(id, packId, DomainPackVersion.STATUS_DRAFT);
+  }
+
+  private IntentDefinition createIntent(Long id, String code, String name) {
+    IntentDefinition intent =
+        IntentDefinition.create(VERSION_ID, code, name, null, 1, "{}", "{}", "[]", "{}");
+    ReflectionTestUtils.setField(intent, "id", id);
+    ReflectionTestUtils.setField(intent, "createdAt", OffsetDateTime.parse("2026-04-10T10:00:00Z"));
+    ReflectionTestUtils.setField(intent, "updatedAt", OffsetDateTime.parse("2026-04-10T10:00:00Z"));
+    return intent;
+  }
+}

--- a/backend/src/test/java/com/init/domainpack/application/GetIntentDefinitionUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/GetIntentDefinitionUseCaseTest.java
@@ -58,7 +58,8 @@ class GetIntentDefinitionUseCaseTest {
 
   @Test
   @DisplayName("유효한 query로 intent 단건 전체 필드 반환")
-  void execute_withValidQuery_returnsDetail() {
+  void should_returnDetail_when_validQuery() {
+    // given
     given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
     given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
     given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(true);
@@ -67,10 +68,12 @@ class GetIntentDefinitionUseCaseTest {
     given(intentDefinitionRepository.findByIdAndDomainPackVersionId(INTENT_ID, VERSION_ID))
         .willReturn(Optional.of(createIntent(INTENT_ID, "INTENT_001", "배송 조회 문의")));
 
+    // when
     IntentDefinitionDetail result =
         useCase.execute(
             new GetIntentDefinitionQuery(WORKSPACE_ID, PACK_ID, VERSION_ID, INTENT_ID, USER_ID));
 
+    // then
     assertThat(result.id()).isEqualTo(INTENT_ID);
     assertThat(result.intentCode()).isEqualTo("INTENT_001");
     assertThat(result.entryConditionJson()).isEqualTo("{}");
@@ -80,7 +83,8 @@ class GetIntentDefinitionUseCaseTest {
 
   @Test
   @DisplayName("존재하지 않는 intentId → IntentDefinitionNotFoundException")
-  void execute_withUnknownIntentId_throwsNotFoundException() {
+  void should_throwNotFoundException_when_unknownIntentId() {
+    // given
     given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
     given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
     given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(true);
@@ -89,6 +93,7 @@ class GetIntentDefinitionUseCaseTest {
     given(intentDefinitionRepository.findByIdAndDomainPackVersionId(INTENT_ID, VERSION_ID))
         .willReturn(Optional.empty());
 
+    // when & then
     assertThatThrownBy(
             () ->
                 useCase.execute(
@@ -99,9 +104,11 @@ class GetIntentDefinitionUseCaseTest {
 
   @Test
   @DisplayName("workspace 없음 → DomainPackWorkspaceNotFoundException")
-  void execute_workspaceNotFound_throwsException() {
+  void should_throwWorkspaceNotFoundException_when_workspaceNotFound() {
+    // given
     given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(false);
 
+    // when & then
     assertThatThrownBy(
             () ->
                 useCase.execute(
@@ -112,10 +119,12 @@ class GetIntentDefinitionUseCaseTest {
 
   @Test
   @DisplayName("접근 권한 없음 → DomainPackUnauthorizedWorkspaceAccessException")
-  void execute_unauthorized_throwsException() {
+  void should_throwUnauthorizedException_when_unauthorized() {
+    // given
     given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
     given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(false);
 
+    // when & then
     assertThatThrownBy(
             () ->
                 useCase.execute(
@@ -126,11 +135,13 @@ class GetIntentDefinitionUseCaseTest {
 
   @Test
   @DisplayName("domain pack 소속 불일치 → DomainPackNotFoundException")
-  void execute_packNotInWorkspace_throwsException() {
+  void should_throwDomainPackNotFoundException_when_packNotInWorkspace() {
+    // given
     given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
     given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
     given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(false);
 
+    // when & then
     assertThatThrownBy(
             () ->
                 useCase.execute(
@@ -141,13 +152,15 @@ class GetIntentDefinitionUseCaseTest {
 
   @Test
   @DisplayName("version 소속 불일치 → DomainPackVersionNotFoundException")
-  void execute_versionNotInPack_throwsException() {
+  void should_throwVersionNotFoundException_when_versionNotInPack() {
+    // given
     given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
     given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
     given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(true);
     given(domainPackVersionRepository.findById(VERSION_ID))
         .willReturn(Optional.of(createVersion(VERSION_ID, 999L)));
 
+    // when & then
     assertThatThrownBy(
             () ->
                 useCase.execute(

--- a/backend/src/test/java/com/init/domainpack/application/GetIntentDefinitionUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/GetIntentDefinitionUseCaseTest.java
@@ -1,0 +1,171 @@
+package com.init.domainpack.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.init.domainpack.application.exception.DomainPackNotFoundException;
+import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
+import com.init.domainpack.application.exception.DomainPackVersionNotFoundException;
+import com.init.domainpack.application.exception.DomainPackWorkspaceNotFoundException;
+import com.init.domainpack.application.exception.IntentDefinitionNotFoundException;
+import com.init.domainpack.domain.model.DomainPackVersion;
+import com.init.domainpack.domain.model.IntentDefinition;
+import com.init.domainpack.domain.repository.DomainPackRepository;
+import com.init.domainpack.domain.repository.DomainPackVersionRepository;
+import com.init.domainpack.domain.repository.IntentDefinitionRepository;
+import com.init.domainpack.domain.repository.WorkspaceExistencePort;
+import com.init.domainpack.domain.repository.WorkspaceMembershipPort;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetIntentDefinitionUseCase")
+class GetIntentDefinitionUseCaseTest {
+
+  @Mock private WorkspaceExistencePort workspaceExistencePort;
+  @Mock private WorkspaceMembershipPort workspaceMembershipPort;
+  @Mock private DomainPackRepository domainPackRepository;
+  @Mock private DomainPackVersionRepository domainPackVersionRepository;
+  @Mock private IntentDefinitionRepository intentDefinitionRepository;
+
+  private GetIntentDefinitionUseCase useCase;
+
+  private static final Long WORKSPACE_ID = 1L;
+  private static final Long PACK_ID = 7L;
+  private static final Long VERSION_ID = 101L;
+  private static final Long INTENT_ID = 2001L;
+  private static final Long USER_ID = 10L;
+
+  @BeforeEach
+  void setUp() {
+    DomainPackValidator validator =
+        new DomainPackValidator(
+            workspaceExistencePort,
+            workspaceMembershipPort,
+            domainPackRepository,
+            domainPackVersionRepository);
+    useCase = new GetIntentDefinitionUseCase(validator, intentDefinitionRepository);
+  }
+
+  @Test
+  @DisplayName("유효한 query로 intent 단건 전체 필드 반환")
+  void execute_withValidQuery_returnsDetail() {
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(true);
+    given(domainPackVersionRepository.findById(VERSION_ID))
+        .willReturn(Optional.of(createVersion(VERSION_ID, PACK_ID)));
+    given(intentDefinitionRepository.findByIdAndDomainPackVersionId(INTENT_ID, VERSION_ID))
+        .willReturn(Optional.of(createIntent(INTENT_ID, "INTENT_001", "배송 조회 문의")));
+
+    IntentDefinitionDetail result =
+        useCase.execute(
+            new GetIntentDefinitionQuery(WORKSPACE_ID, PACK_ID, VERSION_ID, INTENT_ID, USER_ID));
+
+    assertThat(result.id()).isEqualTo(INTENT_ID);
+    assertThat(result.intentCode()).isEqualTo("INTENT_001");
+    assertThat(result.entryConditionJson()).isEqualTo("{}");
+    assertThat(result.evidenceJson()).isEqualTo("[]");
+    assertThat(result.metaJson()).isEqualTo("{}");
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 intentId → IntentDefinitionNotFoundException")
+  void execute_withUnknownIntentId_throwsNotFoundException() {
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(true);
+    given(domainPackVersionRepository.findById(VERSION_ID))
+        .willReturn(Optional.of(createVersion(VERSION_ID, PACK_ID)));
+    given(intentDefinitionRepository.findByIdAndDomainPackVersionId(INTENT_ID, VERSION_ID))
+        .willReturn(Optional.empty());
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new GetIntentDefinitionQuery(
+                        WORKSPACE_ID, PACK_ID, VERSION_ID, INTENT_ID, USER_ID)))
+        .isInstanceOf(IntentDefinitionNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("workspace 없음 → DomainPackWorkspaceNotFoundException")
+  void execute_workspaceNotFound_throwsException() {
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(false);
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new GetIntentDefinitionQuery(
+                        WORKSPACE_ID, PACK_ID, VERSION_ID, INTENT_ID, USER_ID)))
+        .isInstanceOf(DomainPackWorkspaceNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("접근 권한 없음 → DomainPackUnauthorizedWorkspaceAccessException")
+  void execute_unauthorized_throwsException() {
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(false);
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new GetIntentDefinitionQuery(
+                        WORKSPACE_ID, PACK_ID, VERSION_ID, INTENT_ID, USER_ID)))
+        .isInstanceOf(DomainPackUnauthorizedWorkspaceAccessException.class);
+  }
+
+  @Test
+  @DisplayName("domain pack 소속 불일치 → DomainPackNotFoundException")
+  void execute_packNotInWorkspace_throwsException() {
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(false);
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new GetIntentDefinitionQuery(
+                        WORKSPACE_ID, PACK_ID, VERSION_ID, INTENT_ID, USER_ID)))
+        .isInstanceOf(DomainPackNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("version 소속 불일치 → DomainPackVersionNotFoundException")
+  void execute_versionNotInPack_throwsException() {
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(true);
+    given(domainPackVersionRepository.findById(VERSION_ID))
+        .willReturn(Optional.of(createVersion(VERSION_ID, 999L)));
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new GetIntentDefinitionQuery(
+                        WORKSPACE_ID, PACK_ID, VERSION_ID, INTENT_ID, USER_ID)))
+        .isInstanceOf(DomainPackVersionNotFoundException.class);
+  }
+
+  private DomainPackVersion createVersion(Long id, Long packId) {
+    return DomainPackVersion.ofForTest(id, packId, DomainPackVersion.STATUS_DRAFT);
+  }
+
+  private IntentDefinition createIntent(Long id, String code, String name) {
+    IntentDefinition intent =
+        IntentDefinition.create(VERSION_ID, code, name, null, 1, "{}", "{}", "[]", "{}");
+    ReflectionTestUtils.setField(intent, "id", id);
+    ReflectionTestUtils.setField(intent, "createdAt", OffsetDateTime.parse("2026-04-10T10:00:00Z"));
+    ReflectionTestUtils.setField(intent, "updatedAt", OffsetDateTime.parse("2026-04-10T10:00:00Z"));
+    return intent;
+  }
+}

--- a/backend/src/test/java/com/init/domainpack/presentation/IntentDefinitionControllerTest.java
+++ b/backend/src/test/java/com/init/domainpack/presentation/IntentDefinitionControllerTest.java
@@ -10,6 +10,7 @@ import com.init.domainpack.application.GetIntentDefinitionListUseCase;
 import com.init.domainpack.application.GetIntentDefinitionUseCase;
 import com.init.domainpack.application.IntentDefinitionDetail;
 import com.init.domainpack.application.IntentDefinitionSummary;
+import com.init.domainpack.application.exception.DomainPackNotFoundException;
 import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
 import com.init.domainpack.application.exception.DomainPackVersionNotFoundException;
 import com.init.domainpack.application.exception.IntentDefinitionNotFoundException;
@@ -45,7 +46,8 @@ class IntentDefinitionControllerTest {
   @Test
   @DisplayName("GET .../intents → 200 OK, 목록 반환")
   @WithLongPrincipal(10L)
-  void listIntents_returnsOk() throws Exception {
+  void should_returnOkWithList_when_validRequest() throws Exception {
+    // given
     given(listUseCase.execute(any()))
         .willReturn(
             List.of(
@@ -61,6 +63,7 @@ class IntentDefinitionControllerTest {
                     OffsetDateTime.parse("2026-04-10T10:00:00Z"),
                     OffsetDateTime.parse("2026-04-10T10:00:00Z"))));
 
+    // when & then
     mockMvc
         .perform(get(BASE_URL))
         .andExpect(status().isOk())
@@ -74,9 +77,11 @@ class IntentDefinitionControllerTest {
   @Test
   @DisplayName("GET .../intents → intent 없으면 빈 배열")
   @WithLongPrincipal(10L)
-  void listIntents_noIntents_returnsEmptyArray() throws Exception {
+  void should_returnEmptyArray_when_noIntentsExist() throws Exception {
+    // given
     given(listUseCase.execute(any())).willReturn(List.of());
 
+    // when & then
     mockMvc
         .perform(get(BASE_URL))
         .andExpect(status().isOk())
@@ -87,7 +92,8 @@ class IntentDefinitionControllerTest {
   @Test
   @DisplayName("GET .../intents/{id} → 200 OK, JSONB 필드 포함")
   @WithLongPrincipal(10L)
-  void getIntent_returnsOkWithJsonbFields() throws Exception {
+  void should_returnOkWithJsonbFields_when_intentExists() throws Exception {
+    // given
     given(detailUseCase.execute(any()))
         .willReturn(
             new IntentDefinitionDetail(
@@ -105,6 +111,7 @@ class IntentDefinitionControllerTest {
                 OffsetDateTime.parse("2026-04-10T10:00:00Z"),
                 OffsetDateTime.parse("2026-04-10T10:00:00Z")));
 
+    // when & then
     mockMvc
         .perform(get(BASE_URL + "/1"))
         .andExpect(status().isOk())
@@ -117,10 +124,12 @@ class IntentDefinitionControllerTest {
   @Test
   @DisplayName("GET .../intents/{id} → 404 미존재")
   @WithLongPrincipal(10L)
-  void getIntent_notFound_returns404() throws Exception {
+  void should_return404_when_intentNotFound() throws Exception {
+    // given
     given(detailUseCase.execute(any()))
         .willThrow(new IntentDefinitionNotFoundException(9999L, 101L));
 
+    // when & then
     mockMvc
         .perform(get(BASE_URL + "/9999"))
         .andExpect(status().isNotFound())
@@ -128,12 +137,29 @@ class IntentDefinitionControllerTest {
   }
 
   @Test
+  @DisplayName("GET .../intents/{id} → 404 다른 versionId 소속 intent")
+  @WithLongPrincipal(10L)
+  void should_return404_when_intentBelongsToWrongVersion() throws Exception {
+    // given
+    given(detailUseCase.execute(any()))
+        .willThrow(new IntentDefinitionNotFoundException(1L, 101L));
+
+    // when & then
+    mockMvc
+        .perform(get(BASE_URL + "/1"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("INTENT_DEFINITION_NOT_FOUND"));
+  }
+
+  @Test
   @DisplayName("GET .../intents → 403 권한 없음")
   @WithLongPrincipal(10L)
-  void listIntents_unauthorized_returns403() throws Exception {
+  void should_return403_when_unauthorized() throws Exception {
+    // given
     given(listUseCase.execute(any()))
         .willThrow(new DomainPackUnauthorizedWorkspaceAccessException("워크스페이스에 접근 권한이 없습니다."));
 
+    // when & then
     mockMvc
         .perform(get(BASE_URL))
         .andExpect(status().isForbidden())
@@ -142,19 +168,36 @@ class IntentDefinitionControllerTest {
 
   @Test
   @DisplayName("GET .../intents → 401 미인증")
-  void listIntents_unauthenticated_returns401() throws Exception {
+  void should_return401_when_unauthenticated() throws Exception {
+    // when & then
     mockMvc.perform(get(BASE_URL)).andExpect(status().isUnauthorized());
   }
 
   @Test
   @DisplayName("GET .../intents → 404 version 소속 불일치")
   @WithLongPrincipal(10L)
-  void listIntents_versionNotInPack_returns404() throws Exception {
+  void should_return404_when_versionNotInPack() throws Exception {
+    // given
     given(listUseCase.execute(any())).willThrow(new DomainPackVersionNotFoundException(101L));
 
+    // when & then
     mockMvc
         .perform(get(BASE_URL))
         .andExpect(status().isNotFound())
         .andExpect(jsonPath("$.code").value("DOMAIN_PACK_VERSION_NOT_FOUND"));
+  }
+
+  @Test
+  @DisplayName("GET .../intents → 404 존재하지 않는 packId")
+  @WithLongPrincipal(10L)
+  void should_return404_when_packNotFound() throws Exception {
+    // given
+    given(listUseCase.execute(any())).willThrow(new DomainPackNotFoundException(7L));
+
+    // when & then
+    mockMvc
+        .perform(get(BASE_URL))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("DOMAIN_PACK_NOT_FOUND"));
   }
 }

--- a/backend/src/test/java/com/init/domainpack/presentation/IntentDefinitionControllerTest.java
+++ b/backend/src/test/java/com/init/domainpack/presentation/IntentDefinitionControllerTest.java
@@ -1,0 +1,160 @@
+package com.init.domainpack.presentation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.init.domainpack.application.GetIntentDefinitionListUseCase;
+import com.init.domainpack.application.GetIntentDefinitionUseCase;
+import com.init.domainpack.application.IntentDefinitionDetail;
+import com.init.domainpack.application.IntentDefinitionSummary;
+import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
+import com.init.domainpack.application.exception.DomainPackVersionNotFoundException;
+import com.init.domainpack.application.exception.IntentDefinitionNotFoundException;
+import com.init.fixtures.WithLongPrincipal;
+import com.init.shared.infrastructure.security.JwtAuthenticationFilter;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(
+    value = IntentDefinitionController.class,
+    excludeFilters =
+        @ComponentScan.Filter(
+            type = FilterType.ASSIGNABLE_TYPE,
+            classes = JwtAuthenticationFilter.class))
+@DisplayName("IntentDefinitionController")
+class IntentDefinitionControllerTest {
+
+  private static final String BASE_URL = "/api/v1/workspaces/1/domain-packs/7/versions/101/intents";
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private GetIntentDefinitionListUseCase listUseCase;
+  @MockitoBean private GetIntentDefinitionUseCase detailUseCase;
+
+  @Test
+  @DisplayName("GET .../intents → 200 OK, 목록 반환")
+  @WithLongPrincipal(10L)
+  void listIntents_returnsOk() throws Exception {
+    given(listUseCase.execute(any()))
+        .willReturn(
+            List.of(
+                new IntentDefinitionSummary(
+                    1L,
+                    "INTENT_001",
+                    "배송 조회 문의",
+                    "주문 배송 상태를 확인하려는 고객 의도",
+                    1,
+                    null,
+                    "ACTIVE",
+                    "{}",
+                    OffsetDateTime.parse("2026-04-10T10:00:00Z"),
+                    OffsetDateTime.parse("2026-04-10T10:00:00Z"))));
+
+    mockMvc
+        .perform(get(BASE_URL))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].intentCode").value("INTENT_001"))
+        .andExpect(jsonPath("$[0].name").value("배송 조회 문의"))
+        .andExpect(jsonPath("$[0].entryConditionJson").doesNotExist())
+        .andExpect(jsonPath("$[0].evidenceJson").doesNotExist())
+        .andExpect(jsonPath("$[0].metaJson").doesNotExist());
+  }
+
+  @Test
+  @DisplayName("GET .../intents → intent 없으면 빈 배열")
+  @WithLongPrincipal(10L)
+  void listIntents_noIntents_returnsEmptyArray() throws Exception {
+    given(listUseCase.execute(any())).willReturn(List.of());
+
+    mockMvc
+        .perform(get(BASE_URL))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$").isEmpty());
+  }
+
+  @Test
+  @DisplayName("GET .../intents/{id} → 200 OK, JSONB 필드 포함")
+  @WithLongPrincipal(10L)
+  void getIntent_returnsOkWithJsonbFields() throws Exception {
+    given(detailUseCase.execute(any()))
+        .willReturn(
+            new IntentDefinitionDetail(
+                1L,
+                "INTENT_001",
+                "배송 조회 문의",
+                "주문 배송 상태를 확인하려는 고객 의도",
+                1,
+                null,
+                "ACTIVE",
+                "{}",
+                "{\"conditions\": []}",
+                "[{\"turnId\": \"t-100\"}]",
+                "{}",
+                OffsetDateTime.parse("2026-04-10T10:00:00Z"),
+                OffsetDateTime.parse("2026-04-10T10:00:00Z")));
+
+    mockMvc
+        .perform(get(BASE_URL + "/1"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.intentCode").value("INTENT_001"))
+        .andExpect(jsonPath("$.entryConditionJson").exists())
+        .andExpect(jsonPath("$.evidenceJson").exists())
+        .andExpect(jsonPath("$.metaJson").exists());
+  }
+
+  @Test
+  @DisplayName("GET .../intents/{id} → 404 미존재")
+  @WithLongPrincipal(10L)
+  void getIntent_notFound_returns404() throws Exception {
+    given(detailUseCase.execute(any()))
+        .willThrow(new IntentDefinitionNotFoundException(9999L, 101L));
+
+    mockMvc
+        .perform(get(BASE_URL + "/9999"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("INTENT_DEFINITION_NOT_FOUND"));
+  }
+
+  @Test
+  @DisplayName("GET .../intents → 403 권한 없음")
+  @WithLongPrincipal(10L)
+  void listIntents_unauthorized_returns403() throws Exception {
+    given(listUseCase.execute(any()))
+        .willThrow(new DomainPackUnauthorizedWorkspaceAccessException("워크스페이스에 접근 권한이 없습니다."));
+
+    mockMvc
+        .perform(get(BASE_URL))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.code").value("FORBIDDEN"));
+  }
+
+  @Test
+  @DisplayName("GET .../intents → 401 미인증")
+  void listIntents_unauthenticated_returns401() throws Exception {
+    mockMvc.perform(get(BASE_URL)).andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @DisplayName("GET .../intents → 404 version 소속 불일치")
+  @WithLongPrincipal(10L)
+  void listIntents_versionNotInPack_returns404() throws Exception {
+    given(listUseCase.execute(any())).willThrow(new DomainPackVersionNotFoundException(101L));
+
+    mockMvc
+        .perform(get(BASE_URL))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("DOMAIN_PACK_VERSION_NOT_FOUND"));
+  }
+}

--- a/backend/src/test/java/com/init/domainpack/presentation/IntentDefinitionControllerTest.java
+++ b/backend/src/test/java/com/init/domainpack/presentation/IntentDefinitionControllerTest.java
@@ -141,8 +141,7 @@ class IntentDefinitionControllerTest {
   @WithLongPrincipal(10L)
   void should_return404_when_intentBelongsToWrongVersion() throws Exception {
     // given
-    given(detailUseCase.execute(any()))
-        .willThrow(new IntentDefinitionNotFoundException(1L, 101L));
+    given(detailUseCase.execute(any())).willThrow(new IntentDefinitionNotFoundException(1L, 101L));
 
     // when & then
     mockMvc


### PR DESCRIPTION
## Summary

- Intent 목록 / 단건 조회 API 2개 추가
- Audit에서 발견된 위반 4건 (Critical 1, Warning 3) 모두 수정 완료

---

## Context

`.agent/specs/219.md` 구현 PR. `domain-pack` bounded context에서 특정 Domain Pack 버전에 속한 `IntentDefinition` 초안을 조회하는 읽기 전용 엔드포인트다. 기존 `DomainPackValidator` 3단계 검증 체인을 재사용한다.

---

## What Changed

**신규 파일 (8개)**
- `application/`: `GetIntentDefinitionListQuery`, `GetIntentDefinitionListUseCase`, `GetIntentDefinitionQuery`, `GetIntentDefinitionUseCase`, `IntentDefinitionSummary`, `IntentDefinitionDetail`, `exception/IntentDefinitionNotFoundException`
- `presentation/IntentDefinitionController`

**기존 파일 수정**
- `domain/repository/IntentDefinitionRepository`: `findByDomainPackVersionId`, `findByIdAndDomainPackVersionId` 2개 메서드 추가 (A-01 포함)
- `infrastructure/persistence/JpaIntentDefinitionRepository`: 동일 메서드 선언 추가
- `domain/model/IntentDefinition`: `getCreatedAt()`, `getUpdatedAt()` getter 추가(A-02) + `setParentIntentId` 제거 → `assignParent()` 도메인 메서드로 교체(V-001 fix)
- `application/DomainPackDraftPersistenceService`: `setParentIntentId` 호출부 2곳을 `assignParent()`로 교체

---

## Assumptions Adopted

| ID | 결정 내용 | 영향 |
|----|-----------|------|
| U-01 | flat list + `parentIntentId` 필드. tree 중첩 구조 미구현 | FE가 tree 렌더링 필요 시 별도 백로그 |
| U-02 | 페이지네이션 없이 전체 반환 | intent 수 급증 시 성능 저하 가능 |
| U-04 | `IntentDefinitionSummary`는 `sourceClusterRef`까지만, `IntentDefinitionDetail`은 JSONB 3필드 전체 포함 | — |
| U-05 | `findByIdAndDomainPackVersionId`를 domain interface + JPA 모두에 선언 | DDD 계층 준수 |

---

## Spec Deviations

**A-01**: spec은 `findByIdAndDomainPackVersionId`만 domain interface 추가를 명시했으나, `findByDomainPackVersionId`도 domain interface에 존재하지 않아 함께 추가했다. JPA 구현체에는 이미 존재하는 메서드.

**A-02**: spec에 명시 없이 `IntentDefinition` 엔티티에 `getCreatedAt()`, `getUpdatedAt()` getter를 추가했다. `IntentDefinitionSummary::from`, `IntentDefinitionDetail::from`이 해당 필드를 필요로 해서 추가.

**V-001 fix (범위 초과)**: Audit에서 발견된 pre-existing `setParentIntentId()` public setter를 제거하고 `assignParent(Long parentIntentId)` 도메인 메서드를 도입했다. 이번 PR의 신규 코드가 해당 setter를 호출하지 않지만, `IntentDefinition.java`가 diff 대상 파일이 되면서 감사 대상에 포함됐다. `DomainPackDraftPersistenceService`의 기존 호출부 2곳도 교체했다.

---

## Blocked / Skipped Items

| 항목 | 사유 |
|------|------|
| 페이지네이션 | YAGNI (U-02). 필요 시 별도 백로그 |
| tree 구조 응답 | FE 책임 위임 (U-01). FE가 `parentIntentId`로 변환 |
| lifecycle_status 검증 | 이 스펙 범위 외 (U-03 Conflict). `validateVersion()` 기존 구현에 위임 |
| DB 마이그레이션 | 기존 `pack.intent_definition` 테이블 재사용 |

---

## Test Notes

**Audit 전 기준**: 19 tests (ListUseCaseTest 6 + UseCaseTest 6 + ControllerTest 7), 0 failures

**V-004 fix 후 추가**: `should_return404_when_packNotFound`, `should_return404_when_intentBelongsToWrongVersion` 2건 추가 → 총 21 tests

**Audit 위반 수정 내역**:
- V-002: 전체 테스트 메서드명 `should_결과_when_조건` 패턴으로 일괄 변경
- V-003: 모든 테스트 메서드에 `// given`, `// when`, `// then` (또는 `// when & then`) 구분 주석 추가
- V-004: Controller 레벨 `packNotFound 404`, `wrongVersion 404` 케이스 각 1건 추가

---

## Reviewer Focus

1. **`IntentDefinition.assignParent()` 불변식** — spec 범위 밖 수정. `setParentIntentId` 호출부였던 `DomainPackDraftPersistenceService:133,213` 교체 여부 확인.
2. **`IntentDefinitionRepository` domain interface** — `findByDomainPackVersionId` 시그니처가 JPA 구현체와 일치하는지 확인.
3. **`IntentDefinition` getter 추가** — `getCreatedAt()`, `getUpdatedAt()`만 추가됐고 다른 변경이 없는지 확인 (A-02).

---

## Conflicts

**U-03 (lifecycle_status)**: 스펙과 다른 문서 간 허용값 불일치가 확인됐으나, 이 스펙에서는 lifecycle_status를 비교하거나 필터링하지 않으므로 영향 없음. 해당 불일치는 별도 백로그에서 해소 필요.

---

## Ready to Merge / Needs Input

**Ready to Merge** — Audit 위반 4건 모두 수정 완료. 테스트 전체 통과.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

**새로운 기능**
- 인텐트 정의 조회 기능 추가: 도메인 팩 버전 내의 모든 인텐트를 조회하거나 특정 인텐트의 상세 정보(코드, 이름, 설명, 상태, 분류 수준 등)를 조회할 수 있는 기능이 추가되었습니다.

**테스트**
- 인텐트 정의 조회 기능에 대한 포괄적인 테스트 추가로 안정성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->