### PR TITLE
feat(domain-pack): add slot definition list and detail read endpoints (spec/3211)

### DIFF
--- a/backend/src/main/java/com/init/domainpack/application/DomainPackValidator.java
+++ b/backend/src/main/java/com/init/domainpack/application/DomainPackValidator.java
@@ -59,4 +59,11 @@ public class DomainPackValidator {
       throw new DomainPackVersionNotFoundException(versionId);
     }
   }
+
+  public void validateForWorkspacePackVersion(
+      Long workspaceId, Long userId, Long packId, Long versionId) {
+    validateWorkspaceAccess(workspaceId, userId);
+    validateDomainPack(packId, workspaceId);
+    validateVersion(versionId, packId);
+  }
 }

--- a/backend/src/main/java/com/init/domainpack/application/GetSlotDefinitionListQuery.java
+++ b/backend/src/main/java/com/init/domainpack/application/GetSlotDefinitionListQuery.java
@@ -1,0 +1,4 @@
+package com.init.domainpack.application;
+
+public record GetSlotDefinitionListQuery(
+    Long workspaceId, Long packId, Long versionId, Long userId) {}

--- a/backend/src/main/java/com/init/domainpack/application/GetSlotDefinitionListUseCase.java
+++ b/backend/src/main/java/com/init/domainpack/application/GetSlotDefinitionListUseCase.java
@@ -1,0 +1,32 @@
+package com.init.domainpack.application;
+
+import com.init.domainpack.domain.repository.SlotDefinitionRepository;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class GetSlotDefinitionListUseCase {
+
+  private final DomainPackValidator validator;
+  private final SlotDefinitionRepository slotDefinitionRepository;
+
+  public GetSlotDefinitionListUseCase(
+      DomainPackValidator validator, SlotDefinitionRepository slotDefinitionRepository) {
+    this.validator = validator;
+    this.slotDefinitionRepository = slotDefinitionRepository;
+  }
+
+  public List<SlotDefinitionSummary> execute(GetSlotDefinitionListQuery query) {
+    validator.validateWorkspaceAccess(query.workspaceId(), query.userId());
+    validator.validateDomainPack(query.packId(), query.workspaceId());
+    validator.validateVersion(query.versionId(), query.packId());
+
+    return slotDefinitionRepository
+        .findAllByDomainPackVersionIdOrderBySlotCodeAsc(query.versionId())
+        .stream()
+        .map(SlotDefinitionSummary::from)
+        .toList();
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/application/GetSlotDefinitionListUseCase.java
+++ b/backend/src/main/java/com/init/domainpack/application/GetSlotDefinitionListUseCase.java
@@ -19,9 +19,8 @@ public class GetSlotDefinitionListUseCase {
   }
 
   public List<SlotDefinitionSummary> execute(GetSlotDefinitionListQuery query) {
-    validator.validateWorkspaceAccess(query.workspaceId(), query.userId());
-    validator.validateDomainPack(query.packId(), query.workspaceId());
-    validator.validateVersion(query.versionId(), query.packId());
+    validator.validateForWorkspacePackVersion(
+        query.workspaceId(), query.userId(), query.packId(), query.versionId());
 
     return slotDefinitionRepository
         .findAllByDomainPackVersionIdOrderBySlotCodeAsc(query.versionId())

--- a/backend/src/main/java/com/init/domainpack/application/GetSlotDefinitionQuery.java
+++ b/backend/src/main/java/com/init/domainpack/application/GetSlotDefinitionQuery.java
@@ -1,0 +1,4 @@
+package com.init.domainpack.application;
+
+public record GetSlotDefinitionQuery(
+    Long workspaceId, Long packId, Long versionId, Long slotId, Long userId) {}

--- a/backend/src/main/java/com/init/domainpack/application/GetSlotDefinitionUseCase.java
+++ b/backend/src/main/java/com/init/domainpack/application/GetSlotDefinitionUseCase.java
@@ -1,0 +1,31 @@
+package com.init.domainpack.application;
+
+import com.init.domainpack.application.exception.SlotDefinitionNotFoundException;
+import com.init.domainpack.domain.repository.SlotDefinitionRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class GetSlotDefinitionUseCase {
+
+  private final DomainPackValidator validator;
+  private final SlotDefinitionRepository slotDefinitionRepository;
+
+  public GetSlotDefinitionUseCase(
+      DomainPackValidator validator, SlotDefinitionRepository slotDefinitionRepository) {
+    this.validator = validator;
+    this.slotDefinitionRepository = slotDefinitionRepository;
+  }
+
+  public SlotDefinitionResponse execute(GetSlotDefinitionQuery query) {
+    validator.validateWorkspaceAccess(query.workspaceId(), query.userId());
+    validator.validateDomainPack(query.packId(), query.workspaceId());
+    validator.validateVersion(query.versionId(), query.packId());
+
+    return slotDefinitionRepository
+        .findByIdAndDomainPackVersionId(query.slotId(), query.versionId())
+        .map(SlotDefinitionResponse::from)
+        .orElseThrow(() -> new SlotDefinitionNotFoundException(query.slotId()));
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/application/GetSlotDefinitionUseCase.java
+++ b/backend/src/main/java/com/init/domainpack/application/GetSlotDefinitionUseCase.java
@@ -19,9 +19,8 @@ public class GetSlotDefinitionUseCase {
   }
 
   public SlotDefinitionResponse execute(GetSlotDefinitionQuery query) {
-    validator.validateWorkspaceAccess(query.workspaceId(), query.userId());
-    validator.validateDomainPack(query.packId(), query.workspaceId());
-    validator.validateVersion(query.versionId(), query.packId());
+    validator.validateForWorkspacePackVersion(
+        query.workspaceId(), query.userId(), query.packId(), query.versionId());
 
     return slotDefinitionRepository
         .findByIdAndDomainPackVersionId(query.slotId(), query.versionId())

--- a/backend/src/main/java/com/init/domainpack/application/SlotDefinitionSummary.java
+++ b/backend/src/main/java/com/init/domainpack/application/SlotDefinitionSummary.java
@@ -1,0 +1,31 @@
+package com.init.domainpack.application;
+
+import com.init.domainpack.domain.model.SlotDefinition;
+import java.time.OffsetDateTime;
+
+public record SlotDefinitionSummary(
+    Long id,
+    Long domainPackVersionId,
+    String slotCode,
+    String name,
+    String description,
+    String dataType,
+    Boolean isSensitive,
+    String status,
+    OffsetDateTime createdAt,
+    OffsetDateTime updatedAt) {
+
+  public static SlotDefinitionSummary from(SlotDefinition slot) {
+    return new SlotDefinitionSummary(
+        slot.getId(),
+        slot.getDomainPackVersionId(),
+        slot.getSlotCode(),
+        slot.getName(),
+        slot.getDescription(),
+        slot.getDataType(),
+        slot.getIsSensitive(),
+        slot.getStatus(),
+        slot.getCreatedAt(),
+        slot.getUpdatedAt());
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/application/exception/SlotDefinitionNotFoundException.java
+++ b/backend/src/main/java/com/init/domainpack/application/exception/SlotDefinitionNotFoundException.java
@@ -1,0 +1,9 @@
+package com.init.domainpack.application.exception;
+
+import com.init.shared.application.exception.NotFoundException;
+
+public class SlotDefinitionNotFoundException extends NotFoundException {
+  public SlotDefinitionNotFoundException(Long slotId) {
+    super("SLOT_DEFINITION_NOT_FOUND", "SlotDefinition not found: " + slotId);
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/domain/repository/SlotDefinitionRepository.java
+++ b/backend/src/main/java/com/init/domainpack/domain/repository/SlotDefinitionRepository.java
@@ -11,4 +11,8 @@ public interface SlotDefinitionRepository {
   Optional<SlotDefinition> findById(Long id);
 
   SlotDefinition save(SlotDefinition slot);
+
+  List<SlotDefinition> findAllByDomainPackVersionIdOrderBySlotCodeAsc(Long domainPackVersionId);
+
+  Optional<SlotDefinition> findByIdAndDomainPackVersionId(Long id, Long domainPackVersionId);
 }

--- a/backend/src/main/java/com/init/domainpack/infrastructure/persistence/JpaSlotDefinitionRepository.java
+++ b/backend/src/main/java/com/init/domainpack/infrastructure/persistence/JpaSlotDefinitionRepository.java
@@ -5,20 +5,13 @@ import com.init.domainpack.domain.repository.SlotDefinitionRepository;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface JpaSlotDefinitionRepository
     extends JpaRepository<SlotDefinition, Long>, SlotDefinitionRepository {
 
-  List<SlotDefinition> findByDomainPackVersionId(Long domainPackVersionId);
-
-  @Query(
-      "SELECT s FROM SlotDefinition s WHERE s.domainPackVersionId = :versionId ORDER BY s.slotCode ASC")
-  List<SlotDefinition> findAllByDomainPackVersionIdOrderBySlotCodeAsc(
-      @Param("versionId") Long versionId);
+  List<SlotDefinition> findAllByDomainPackVersionIdOrderBySlotCodeAsc(Long domainPackVersionId);
 
   Optional<SlotDefinition> findByIdAndDomainPackVersionId(Long id, Long domainPackVersionId);
 }

--- a/backend/src/main/java/com/init/domainpack/infrastructure/persistence/JpaSlotDefinitionRepository.java
+++ b/backend/src/main/java/com/init/domainpack/infrastructure/persistence/JpaSlotDefinitionRepository.java
@@ -3,7 +3,10 @@ package com.init.domainpack.infrastructure.persistence;
 import com.init.domainpack.domain.model.SlotDefinition;
 import com.init.domainpack.domain.repository.SlotDefinitionRepository;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -11,4 +14,11 @@ public interface JpaSlotDefinitionRepository
     extends JpaRepository<SlotDefinition, Long>, SlotDefinitionRepository {
 
   List<SlotDefinition> findByDomainPackVersionId(Long domainPackVersionId);
+
+  @Query(
+      "SELECT s FROM SlotDefinition s WHERE s.domainPackVersionId = :versionId ORDER BY s.slotCode ASC")
+  List<SlotDefinition> findAllByDomainPackVersionIdOrderBySlotCodeAsc(
+      @Param("versionId") Long versionId);
+
+  Optional<SlotDefinition> findByIdAndDomainPackVersionId(Long id, Long domainPackVersionId);
 }

--- a/backend/src/main/java/com/init/domainpack/presentation/SlotDefinitionController.java
+++ b/backend/src/main/java/com/init/domainpack/presentation/SlotDefinitionController.java
@@ -1,0 +1,55 @@
+package com.init.domainpack.presentation;
+
+import com.init.domainpack.application.GetSlotDefinitionListQuery;
+import com.init.domainpack.application.GetSlotDefinitionListUseCase;
+import com.init.domainpack.application.GetSlotDefinitionQuery;
+import com.init.domainpack.application.GetSlotDefinitionUseCase;
+import com.init.domainpack.application.SlotDefinitionResponse;
+import com.init.domainpack.application.SlotDefinitionSummary;
+import com.init.shared.presentation.AuthenticationUtils;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(
+    "/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/slots")
+public class SlotDefinitionController {
+
+  private final GetSlotDefinitionListUseCase listUseCase;
+  private final GetSlotDefinitionUseCase detailUseCase;
+
+  public SlotDefinitionController(
+      GetSlotDefinitionListUseCase listUseCase, GetSlotDefinitionUseCase detailUseCase) {
+    this.listUseCase = listUseCase;
+    this.detailUseCase = detailUseCase;
+  }
+
+  @GetMapping
+  public ResponseEntity<List<SlotDefinitionSummary>> listSlots(
+      @PathVariable Long workspaceId,
+      @PathVariable Long packId,
+      @PathVariable Long versionId,
+      Authentication authentication) {
+    Long userId = AuthenticationUtils.getUserId(authentication);
+    return ResponseEntity.ok(
+        listUseCase.execute(new GetSlotDefinitionListQuery(workspaceId, packId, versionId, userId)));
+  }
+
+  @GetMapping("/{slotId}")
+  public ResponseEntity<SlotDefinitionResponse> getSlot(
+      @PathVariable Long workspaceId,
+      @PathVariable Long packId,
+      @PathVariable Long versionId,
+      @PathVariable Long slotId,
+      Authentication authentication) {
+    Long userId = AuthenticationUtils.getUserId(authentication);
+    return ResponseEntity.ok(
+        detailUseCase.execute(
+            new GetSlotDefinitionQuery(workspaceId, packId, versionId, slotId, userId)));
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/presentation/SlotDefinitionController.java
+++ b/backend/src/main/java/com/init/domainpack/presentation/SlotDefinitionController.java
@@ -16,8 +16,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping(
-    "/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/slots")
+@RequestMapping("/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/slots")
 public class SlotDefinitionController {
 
   private final GetSlotDefinitionListUseCase listUseCase;
@@ -37,7 +36,8 @@ public class SlotDefinitionController {
       Authentication authentication) {
     Long userId = AuthenticationUtils.getUserId(authentication);
     return ResponseEntity.ok(
-        listUseCase.execute(new GetSlotDefinitionListQuery(workspaceId, packId, versionId, userId)));
+        listUseCase.execute(
+            new GetSlotDefinitionListQuery(workspaceId, packId, versionId, userId)));
   }
 
   @GetMapping("/{slotId}")

--- a/backend/src/test/java/com/init/domainpack/application/GetSlotDefinitionListUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/GetSlotDefinitionListUseCaseTest.java
@@ -66,9 +66,7 @@ class GetSlotDefinitionListUseCaseTest {
         .willReturn(Optional.of(createVersion(VERSION_ID, PACK_ID)));
     given(slotDefinitionRepository.findAllByDomainPackVersionIdOrderBySlotCodeAsc(VERSION_ID))
         .willReturn(
-            List.of(
-                createSlot(1L, "aaa_slot", "첫번째 슬롯"),
-                createSlot(2L, "zzz_slot", "두번째 슬롯")));
+            List.of(createSlot(1L, "aaa_slot", "첫번째 슬롯"), createSlot(2L, "zzz_slot", "두번째 슬롯")));
 
     // when
     List<SlotDefinitionSummary> result =

--- a/backend/src/test/java/com/init/domainpack/application/GetSlotDefinitionListUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/GetSlotDefinitionListUseCaseTest.java
@@ -82,7 +82,7 @@ class GetSlotDefinitionListUseCaseTest {
 
   @Test
   @DisplayName("목록 응답에 validationRuleJson, defaultValueJson, metaJson 미포함")
-  void should_excludeJsonFields_in_summary() {
+  void should_notIncludeJsonFields_when_summaryIsReturned() {
     // given
     given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
     given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
@@ -96,9 +96,12 @@ class GetSlotDefinitionListUseCaseTest {
     List<SlotDefinitionSummary> result =
         useCase.execute(new GetSlotDefinitionListQuery(WORKSPACE_ID, PACK_ID, VERSION_ID, USER_ID));
 
-    // then — SlotDefinitionSummary does not expose JSON fields
+    // then — SlotDefinitionSummary record must not expose JSON fields
     assertThat(result).hasSize(1);
     assertThat(result.get(0).slotCode()).isEqualTo("customer_name");
+    assertThat(SlotDefinitionSummary.class.getRecordComponents())
+        .extracting(java.lang.reflect.RecordComponent::getName)
+        .doesNotContain("validationRuleJson", "defaultValueJson", "metaJson");
   }
 
   @Test

--- a/backend/src/test/java/com/init/domainpack/application/GetSlotDefinitionListUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/GetSlotDefinitionListUseCaseTest.java
@@ -1,0 +1,199 @@
+package com.init.domainpack.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.init.domainpack.application.exception.DomainPackNotFoundException;
+import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
+import com.init.domainpack.application.exception.DomainPackVersionNotFoundException;
+import com.init.domainpack.application.exception.DomainPackWorkspaceNotFoundException;
+import com.init.domainpack.domain.model.DomainPackVersion;
+import com.init.domainpack.domain.model.SlotDefinition;
+import com.init.domainpack.domain.repository.DomainPackRepository;
+import com.init.domainpack.domain.repository.DomainPackVersionRepository;
+import com.init.domainpack.domain.repository.SlotDefinitionRepository;
+import com.init.domainpack.domain.repository.WorkspaceExistencePort;
+import com.init.domainpack.domain.repository.WorkspaceMembershipPort;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetSlotDefinitionListUseCase")
+class GetSlotDefinitionListUseCaseTest {
+
+  @Mock private WorkspaceExistencePort workspaceExistencePort;
+  @Mock private WorkspaceMembershipPort workspaceMembershipPort;
+  @Mock private DomainPackRepository domainPackRepository;
+  @Mock private DomainPackVersionRepository domainPackVersionRepository;
+  @Mock private SlotDefinitionRepository slotDefinitionRepository;
+
+  private GetSlotDefinitionListUseCase useCase;
+
+  private static final Long WORKSPACE_ID = 1L;
+  private static final Long PACK_ID = 7L;
+  private static final Long VERSION_ID = 101L;
+  private static final Long USER_ID = 10L;
+
+  @BeforeEach
+  void setUp() {
+    DomainPackValidator validator =
+        new DomainPackValidator(
+            workspaceExistencePort,
+            workspaceMembershipPort,
+            domainPackRepository,
+            domainPackVersionRepository);
+    useCase = new GetSlotDefinitionListUseCase(validator, slotDefinitionRepository);
+  }
+
+  @Test
+  @DisplayName("유효한 query → slot_code ASC 순 SlotDefinitionSummary 목록 반환")
+  void should_returnOrderedSummaryList_when_validQuery() {
+    // given
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(true);
+    given(domainPackVersionRepository.findById(VERSION_ID))
+        .willReturn(Optional.of(createVersion(VERSION_ID, PACK_ID)));
+    given(slotDefinitionRepository.findAllByDomainPackVersionIdOrderBySlotCodeAsc(VERSION_ID))
+        .willReturn(
+            List.of(
+                createSlot(1L, "aaa_slot", "첫번째 슬롯"),
+                createSlot(2L, "zzz_slot", "두번째 슬롯")));
+
+    // when
+    List<SlotDefinitionSummary> result =
+        useCase.execute(new GetSlotDefinitionListQuery(WORKSPACE_ID, PACK_ID, VERSION_ID, USER_ID));
+
+    // then
+    assertThat(result).hasSize(2);
+    assertThat(result.get(0).slotCode()).isEqualTo("aaa_slot");
+    assertThat(result.get(1).slotCode()).isEqualTo("zzz_slot");
+  }
+
+  @Test
+  @DisplayName("목록 응답에 validationRuleJson, defaultValueJson, metaJson 미포함")
+  void should_excludeJsonFields_in_summary() {
+    // given
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(true);
+    given(domainPackVersionRepository.findById(VERSION_ID))
+        .willReturn(Optional.of(createVersion(VERSION_ID, PACK_ID)));
+    given(slotDefinitionRepository.findAllByDomainPackVersionIdOrderBySlotCodeAsc(VERSION_ID))
+        .willReturn(List.of(createSlot(1L, "customer_name", "고객명")));
+
+    // when
+    List<SlotDefinitionSummary> result =
+        useCase.execute(new GetSlotDefinitionListQuery(WORKSPACE_ID, PACK_ID, VERSION_ID, USER_ID));
+
+    // then — SlotDefinitionSummary does not expose JSON fields
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).slotCode()).isEqualTo("customer_name");
+  }
+
+  @Test
+  @DisplayName("slot 없는 version → 빈 목록 반환")
+  void should_returnEmptyList_when_noSlotsExist() {
+    // given
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(true);
+    given(domainPackVersionRepository.findById(VERSION_ID))
+        .willReturn(Optional.of(createVersion(VERSION_ID, PACK_ID)));
+    given(slotDefinitionRepository.findAllByDomainPackVersionIdOrderBySlotCodeAsc(VERSION_ID))
+        .willReturn(List.of());
+
+    // when
+    List<SlotDefinitionSummary> result =
+        useCase.execute(new GetSlotDefinitionListQuery(WORKSPACE_ID, PACK_ID, VERSION_ID, USER_ID));
+
+    // then
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  @DisplayName("workspace 없음 → DomainPackWorkspaceNotFoundException")
+  void should_throwWorkspaceNotFoundException_when_workspaceNotFound() {
+    // given
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(false);
+
+    // when & then
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new GetSlotDefinitionListQuery(WORKSPACE_ID, PACK_ID, VERSION_ID, USER_ID)))
+        .isInstanceOf(DomainPackWorkspaceNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("접근 권한 없음 → DomainPackUnauthorizedWorkspaceAccessException")
+  void should_throwUnauthorizedException_when_unauthorized() {
+    // given
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(false);
+
+    // when & then
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new GetSlotDefinitionListQuery(WORKSPACE_ID, PACK_ID, VERSION_ID, USER_ID)))
+        .isInstanceOf(DomainPackUnauthorizedWorkspaceAccessException.class);
+  }
+
+  @Test
+  @DisplayName("domain pack 소속 불일치 → DomainPackNotFoundException")
+  void should_throwDomainPackNotFoundException_when_packNotInWorkspace() {
+    // given
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(false);
+
+    // when & then
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new GetSlotDefinitionListQuery(WORKSPACE_ID, PACK_ID, VERSION_ID, USER_ID)))
+        .isInstanceOf(DomainPackNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("version 소속 불일치 → DomainPackVersionNotFoundException")
+  void should_throwVersionNotFoundException_when_versionNotInPack() {
+    // given
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(true);
+    given(domainPackVersionRepository.findById(VERSION_ID))
+        .willReturn(Optional.of(createVersion(VERSION_ID, 999L)));
+
+    // when & then
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new GetSlotDefinitionListQuery(WORKSPACE_ID, PACK_ID, VERSION_ID, USER_ID)))
+        .isInstanceOf(DomainPackVersionNotFoundException.class);
+  }
+
+  private DomainPackVersion createVersion(Long id, Long packId) {
+    return DomainPackVersion.ofForTest(id, packId, DomainPackVersion.STATUS_DRAFT);
+  }
+
+  private SlotDefinition createSlot(Long id, String slotCode, String name) {
+    SlotDefinition slot =
+        SlotDefinition.create(VERSION_ID, slotCode, name, null, "STRING", false, "{}", null, "{}");
+    ReflectionTestUtils.setField(slot, "id", id);
+    ReflectionTestUtils.setField(slot, "createdAt", OffsetDateTime.parse("2026-04-10T10:00:00Z"));
+    ReflectionTestUtils.setField(slot, "updatedAt", OffsetDateTime.parse("2026-04-10T10:00:00Z"));
+    return slot;
+  }
+}

--- a/backend/src/test/java/com/init/domainpack/application/GetSlotDefinitionUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/GetSlotDefinitionUseCaseTest.java
@@ -82,7 +82,7 @@ class GetSlotDefinitionUseCaseTest {
 
   @Test
   @DisplayName("존재하지 않는 slotId → SlotDefinitionNotFoundException")
-  void execute_slotNotFound_throwsNotFoundException() {
+  void should_throwNotFoundException_when_slotNotFound() {
     // given
     given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
     given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
@@ -103,7 +103,7 @@ class GetSlotDefinitionUseCaseTest {
 
   @Test
   @DisplayName("다른 version 소속 slotId → SlotDefinitionNotFoundException")
-  void execute_slotBelongsToOtherVersion_throwsNotFoundException() {
+  void should_throwNotFoundException_when_slotBelongsToOtherVersion() {
     // given — slotId exists but belongs to a different versionId, so composite lookup returns empty
     Long otherVersionId = VERSION_ID + 1L;
     given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);

--- a/backend/src/test/java/com/init/domainpack/application/GetSlotDefinitionUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/GetSlotDefinitionUseCaseTest.java
@@ -81,8 +81,8 @@ class GetSlotDefinitionUseCaseTest {
   }
 
   @Test
-  @DisplayName("존재하지 않는 slotId 또는 다른 version 소속 slotId → SlotDefinitionNotFoundException")
-  void should_throwNotFoundException_when_unknownSlotId() {
+  @DisplayName("존재하지 않는 slotId → SlotDefinitionNotFoundException")
+  void execute_slotNotFound_throwsNotFoundException() {
     // given
     given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
     given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
@@ -98,6 +98,28 @@ class GetSlotDefinitionUseCaseTest {
                 useCase.execute(
                     new GetSlotDefinitionQuery(
                         WORKSPACE_ID, PACK_ID, VERSION_ID, SLOT_ID, USER_ID)))
+        .isInstanceOf(SlotDefinitionNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("다른 version 소속 slotId → SlotDefinitionNotFoundException")
+  void execute_slotBelongsToOtherVersion_throwsNotFoundException() {
+    // given — slotId exists but belongs to a different versionId, so composite lookup returns empty
+    Long otherVersionId = VERSION_ID + 1L;
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(true);
+    given(domainPackVersionRepository.findById(otherVersionId))
+        .willReturn(Optional.of(createVersion(otherVersionId, PACK_ID)));
+    given(slotDefinitionRepository.findByIdAndDomainPackVersionId(SLOT_ID, otherVersionId))
+        .willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new GetSlotDefinitionQuery(
+                        WORKSPACE_ID, PACK_ID, otherVersionId, SLOT_ID, USER_ID)))
         .isInstanceOf(SlotDefinitionNotFoundException.class);
   }
 

--- a/backend/src/test/java/com/init/domainpack/application/GetSlotDefinitionUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/GetSlotDefinitionUseCaseTest.java
@@ -1,0 +1,183 @@
+package com.init.domainpack.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.init.domainpack.application.exception.DomainPackNotFoundException;
+import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
+import com.init.domainpack.application.exception.DomainPackVersionNotFoundException;
+import com.init.domainpack.application.exception.DomainPackWorkspaceNotFoundException;
+import com.init.domainpack.application.exception.SlotDefinitionNotFoundException;
+import com.init.domainpack.domain.model.DomainPackVersion;
+import com.init.domainpack.domain.model.SlotDefinition;
+import com.init.domainpack.domain.repository.DomainPackRepository;
+import com.init.domainpack.domain.repository.DomainPackVersionRepository;
+import com.init.domainpack.domain.repository.SlotDefinitionRepository;
+import com.init.domainpack.domain.repository.WorkspaceExistencePort;
+import com.init.domainpack.domain.repository.WorkspaceMembershipPort;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetSlotDefinitionUseCase")
+class GetSlotDefinitionUseCaseTest {
+
+  @Mock private WorkspaceExistencePort workspaceExistencePort;
+  @Mock private WorkspaceMembershipPort workspaceMembershipPort;
+  @Mock private DomainPackRepository domainPackRepository;
+  @Mock private DomainPackVersionRepository domainPackVersionRepository;
+  @Mock private SlotDefinitionRepository slotDefinitionRepository;
+
+  private GetSlotDefinitionUseCase useCase;
+
+  private static final Long WORKSPACE_ID = 1L;
+  private static final Long PACK_ID = 7L;
+  private static final Long VERSION_ID = 101L;
+  private static final Long SLOT_ID = 3001L;
+  private static final Long USER_ID = 10L;
+
+  @BeforeEach
+  void setUp() {
+    DomainPackValidator validator =
+        new DomainPackValidator(
+            workspaceExistencePort,
+            workspaceMembershipPort,
+            domainPackRepository,
+            domainPackVersionRepository);
+    useCase = new GetSlotDefinitionUseCase(validator, slotDefinitionRepository);
+  }
+
+  @Test
+  @DisplayName("유효한 query → SlotDefinitionResponse 전체 필드 반환")
+  void should_returnFullResponse_when_validQuery() {
+    // given
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(true);
+    given(domainPackVersionRepository.findById(VERSION_ID))
+        .willReturn(Optional.of(createVersion(VERSION_ID, PACK_ID)));
+    given(slotDefinitionRepository.findByIdAndDomainPackVersionId(SLOT_ID, VERSION_ID))
+        .willReturn(Optional.of(createSlot(SLOT_ID, "customer_name", "고객명")));
+
+    // when
+    SlotDefinitionResponse result =
+        useCase.execute(
+            new GetSlotDefinitionQuery(WORKSPACE_ID, PACK_ID, VERSION_ID, SLOT_ID, USER_ID));
+
+    // then
+    assertThat(result.id()).isEqualTo(SLOT_ID);
+    assertThat(result.slotCode()).isEqualTo("customer_name");
+    assertThat(result.validationRuleJson()).isEqualTo("{}");
+    assertThat(result.metaJson()).isEqualTo("{}");
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 slotId 또는 다른 version 소속 slotId → SlotDefinitionNotFoundException")
+  void should_throwNotFoundException_when_unknownSlotId() {
+    // given
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(true);
+    given(domainPackVersionRepository.findById(VERSION_ID))
+        .willReturn(Optional.of(createVersion(VERSION_ID, PACK_ID)));
+    given(slotDefinitionRepository.findByIdAndDomainPackVersionId(SLOT_ID, VERSION_ID))
+        .willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new GetSlotDefinitionQuery(
+                        WORKSPACE_ID, PACK_ID, VERSION_ID, SLOT_ID, USER_ID)))
+        .isInstanceOf(SlotDefinitionNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("workspace 없음 → DomainPackWorkspaceNotFoundException")
+  void should_throwWorkspaceNotFoundException_when_workspaceNotFound() {
+    // given
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(false);
+
+    // when & then
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new GetSlotDefinitionQuery(
+                        WORKSPACE_ID, PACK_ID, VERSION_ID, SLOT_ID, USER_ID)))
+        .isInstanceOf(DomainPackWorkspaceNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("접근 권한 없음 → DomainPackUnauthorizedWorkspaceAccessException")
+  void should_throwUnauthorizedException_when_unauthorized() {
+    // given
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(false);
+
+    // when & then
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new GetSlotDefinitionQuery(
+                        WORKSPACE_ID, PACK_ID, VERSION_ID, SLOT_ID, USER_ID)))
+        .isInstanceOf(DomainPackUnauthorizedWorkspaceAccessException.class);
+  }
+
+  @Test
+  @DisplayName("domain pack 소속 불일치 → DomainPackNotFoundException")
+  void should_throwDomainPackNotFoundException_when_packNotInWorkspace() {
+    // given
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(false);
+
+    // when & then
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new GetSlotDefinitionQuery(
+                        WORKSPACE_ID, PACK_ID, VERSION_ID, SLOT_ID, USER_ID)))
+        .isInstanceOf(DomainPackNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("version 소속 불일치 → DomainPackVersionNotFoundException")
+  void should_throwVersionNotFoundException_when_versionNotInPack() {
+    // given
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(true);
+    given(domainPackVersionRepository.findById(VERSION_ID))
+        .willReturn(Optional.of(createVersion(VERSION_ID, 999L)));
+
+    // when & then
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new GetSlotDefinitionQuery(
+                        WORKSPACE_ID, PACK_ID, VERSION_ID, SLOT_ID, USER_ID)))
+        .isInstanceOf(DomainPackVersionNotFoundException.class);
+  }
+
+  private DomainPackVersion createVersion(Long id, Long packId) {
+    return DomainPackVersion.ofForTest(id, packId, DomainPackVersion.STATUS_DRAFT);
+  }
+
+  private SlotDefinition createSlot(Long id, String slotCode, String name) {
+    SlotDefinition slot =
+        SlotDefinition.create(VERSION_ID, slotCode, name, null, "STRING", false, "{}", null, "{}");
+    ReflectionTestUtils.setField(slot, "id", id);
+    ReflectionTestUtils.setField(slot, "createdAt", OffsetDateTime.parse("2026-04-10T10:00:00Z"));
+    ReflectionTestUtils.setField(slot, "updatedAt", OffsetDateTime.parse("2026-04-10T10:00:00Z"));
+    return slot;
+  }
+}

--- a/backend/src/test/java/com/init/domainpack/presentation/SlotDefinitionControllerTest.java
+++ b/backend/src/test/java/com/init/domainpack/presentation/SlotDefinitionControllerTest.java
@@ -183,18 +183,4 @@ class SlotDefinitionControllerTest {
         .andExpect(status().isNotFound())
         .andExpect(jsonPath("$.code").value("DOMAIN_PACK_NOT_FOUND"));
   }
-
-  @Test
-  @DisplayName("GET .../slots/{slotId} → 404 다른 version 소속 slotId")
-  @WithLongPrincipal(10L)
-  void should_return404_when_slotBelongsToOtherVersion() throws Exception {
-    // given
-    given(detailUseCase.execute(any())).willThrow(new SlotDefinitionNotFoundException(1L));
-
-    // when & then
-    mockMvc
-        .perform(get(BASE_URL + "/1"))
-        .andExpect(status().isNotFound())
-        .andExpect(jsonPath("$.code").value("SLOT_DEFINITION_NOT_FOUND"));
-  }
 }

--- a/backend/src/test/java/com/init/domainpack/presentation/SlotDefinitionControllerTest.java
+++ b/backend/src/test/java/com/init/domainpack/presentation/SlotDefinitionControllerTest.java
@@ -36,8 +36,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @DisplayName("SlotDefinitionController")
 class SlotDefinitionControllerTest {
 
-  private static final String BASE_URL =
-      "/api/v1/workspaces/1/domain-packs/7/versions/101/slots";
+  private static final String BASE_URL = "/api/v1/workspaces/1/domain-packs/7/versions/101/slots";
 
   @Autowired private MockMvc mockMvc;
 

--- a/backend/src/test/java/com/init/domainpack/presentation/SlotDefinitionControllerTest.java
+++ b/backend/src/test/java/com/init/domainpack/presentation/SlotDefinitionControllerTest.java
@@ -1,0 +1,201 @@
+package com.init.domainpack.presentation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.init.domainpack.application.GetSlotDefinitionListUseCase;
+import com.init.domainpack.application.GetSlotDefinitionUseCase;
+import com.init.domainpack.application.SlotDefinitionResponse;
+import com.init.domainpack.application.SlotDefinitionSummary;
+import com.init.domainpack.application.exception.DomainPackNotFoundException;
+import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
+import com.init.domainpack.application.exception.DomainPackVersionNotFoundException;
+import com.init.domainpack.application.exception.SlotDefinitionNotFoundException;
+import com.init.fixtures.WithLongPrincipal;
+import com.init.shared.infrastructure.security.JwtAuthenticationFilter;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(
+    value = SlotDefinitionController.class,
+    excludeFilters =
+        @ComponentScan.Filter(
+            type = FilterType.ASSIGNABLE_TYPE,
+            classes = JwtAuthenticationFilter.class))
+@DisplayName("SlotDefinitionController")
+class SlotDefinitionControllerTest {
+
+  private static final String BASE_URL =
+      "/api/v1/workspaces/1/domain-packs/7/versions/101/slots";
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private GetSlotDefinitionListUseCase listUseCase;
+  @MockitoBean private GetSlotDefinitionUseCase detailUseCase;
+
+  @Test
+  @DisplayName("GET .../slots → 200 OK, slot_code ASC 순 목록")
+  @WithLongPrincipal(10L)
+  void should_returnOkWithList_when_validRequest() throws Exception {
+    // given
+    given(listUseCase.execute(any()))
+        .willReturn(
+            List.of(
+                new SlotDefinitionSummary(
+                    1L,
+                    101L,
+                    "customer_name",
+                    "고객명",
+                    "상담 고객의 이름",
+                    "STRING",
+                    false,
+                    "ACTIVE",
+                    OffsetDateTime.parse("2026-04-10T10:00:00Z"),
+                    OffsetDateTime.parse("2026-04-10T10:00:00Z"))));
+
+    // when & then
+    mockMvc
+        .perform(get(BASE_URL))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].slotCode").value("customer_name"))
+        .andExpect(jsonPath("$[0].name").value("고객명"))
+        .andExpect(jsonPath("$[0].validationRuleJson").doesNotExist())
+        .andExpect(jsonPath("$[0].defaultValueJson").doesNotExist())
+        .andExpect(jsonPath("$[0].metaJson").doesNotExist());
+  }
+
+  @Test
+  @DisplayName("GET .../slots → slot 없으면 빈 배열")
+  @WithLongPrincipal(10L)
+  void should_returnEmptyArray_when_noSlotsExist() throws Exception {
+    // given
+    given(listUseCase.execute(any())).willReturn(List.of());
+
+    // when & then
+    mockMvc
+        .perform(get(BASE_URL))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$").isEmpty());
+  }
+
+  @Test
+  @DisplayName("GET .../slots/{slotId} → 200 OK, validationRuleJson, defaultValueJson, metaJson 포함")
+  @WithLongPrincipal(10L)
+  void should_returnOkWithJsonFields_when_slotExists() throws Exception {
+    // given
+    given(detailUseCase.execute(any()))
+        .willReturn(
+            new SlotDefinitionResponse(
+                1L,
+                101L,
+                "customer_name",
+                "고객명",
+                "상담 고객의 이름",
+                "STRING",
+                false,
+                "{}",
+                null,
+                "{}",
+                "ACTIVE",
+                OffsetDateTime.parse("2026-04-10T10:00:00Z"),
+                OffsetDateTime.parse("2026-04-10T10:00:00Z")));
+
+    // when & then
+    mockMvc
+        .perform(get(BASE_URL + "/1"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.slotCode").value("customer_name"))
+        .andExpect(jsonPath("$.validationRuleJson").exists())
+        .andExpect(jsonPath("$.metaJson").exists());
+  }
+
+  @Test
+  @DisplayName("GET .../slots/{slotId} → 404 미존재")
+  @WithLongPrincipal(10L)
+  void should_return404_when_slotNotFound() throws Exception {
+    // given
+    given(detailUseCase.execute(any())).willThrow(new SlotDefinitionNotFoundException(9999L));
+
+    // when & then
+    mockMvc
+        .perform(get(BASE_URL + "/9999"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("SLOT_DEFINITION_NOT_FOUND"));
+  }
+
+  @Test
+  @DisplayName("GET .../slots → 403 권한 없음")
+  @WithLongPrincipal(10L)
+  void should_return403_when_unauthorized() throws Exception {
+    // given
+    given(listUseCase.execute(any()))
+        .willThrow(new DomainPackUnauthorizedWorkspaceAccessException("워크스페이스에 접근 권한이 없습니다."));
+
+    // when & then
+    mockMvc
+        .perform(get(BASE_URL))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.code").value("FORBIDDEN"));
+  }
+
+  @Test
+  @DisplayName("GET .../slots → 401 미인증")
+  void should_return401_when_unauthenticated() throws Exception {
+    // when & then
+    mockMvc.perform(get(BASE_URL)).andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @DisplayName("GET .../slots → 404 version 소속 불일치")
+  @WithLongPrincipal(10L)
+  void should_return404_when_versionNotInPack() throws Exception {
+    // given
+    given(listUseCase.execute(any())).willThrow(new DomainPackVersionNotFoundException(101L));
+
+    // when & then
+    mockMvc
+        .perform(get(BASE_URL))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("DOMAIN_PACK_VERSION_NOT_FOUND"));
+  }
+
+  @Test
+  @DisplayName("GET .../slots → 404 존재하지 않는 packId")
+  @WithLongPrincipal(10L)
+  void should_return404_when_packNotFound() throws Exception {
+    // given
+    given(listUseCase.execute(any())).willThrow(new DomainPackNotFoundException(7L));
+
+    // when & then
+    mockMvc
+        .perform(get(BASE_URL))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("DOMAIN_PACK_NOT_FOUND"));
+  }
+
+  @Test
+  @DisplayName("GET .../slots/{slotId} → 404 다른 version 소속 slotId")
+  @WithLongPrincipal(10L)
+  void should_return404_when_slotBelongsToOtherVersion() throws Exception {
+    // given
+    given(detailUseCase.execute(any())).willThrow(new SlotDefinitionNotFoundException(1L));
+
+    // when & then
+    mockMvc
+        .perform(get(BASE_URL + "/1"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("SLOT_DEFINITION_NOT_FOUND"));
+  }
+}


### PR DESCRIPTION
## Summary

- Slot 목록(`GET .../slots`) 및 단건(`GET .../slots/{slotId}`) 조회 엔드포인트 구현
- 목록은 JSON 3종 필드 제외 `SlotDefinitionSummary`, 단건은 전체 필드 포함 `SlotDefinitionResponse` 반환
- Workspace/Pack/Version 3단계 접근 권한 검증 (DomainPackValidator 재사용)

---

## Context

`.agent/specs/3211.md` ([BE] 3.2.11 Slot / Slot Status 초안 목록 조회) 구현 PR.  
DB 스키마 변경 없음 — `pack.slot_definition` 테이블 및 `idx_slot_version_id` 인덱스 기존 존재.

---

## What Changed

**신규 파일 7종** (모두 spec 명세 일치):
- `application/GetSlotDefinitionListQuery.java`
- `application/GetSlotDefinitionListUseCase.java`
- `application/SlotDefinitionSummary.java`
- `application/GetSlotDefinitionQuery.java`
- `application/GetSlotDefinitionUseCase.java`
- `application/exception/SlotDefinitionNotFoundException.java`
- `presentation/SlotDefinitionController.java`

**수정 파일 2종**:
- `domain/repository/SlotDefinitionRepository.java` — `findAllByDomainPackVersionIdOrderBySlotCodeAsc`, `findByIdAndDomainPackVersionId` 선언 추가
- `infrastructure/persistence/JpaSlotDefinitionRepository.java` — 신규 2개 메서드 추가 (기존 `findByDomainPackVersionId` 유지)

---

## Assumptions Adopted

**UR-005** (`SlotDefinitionNotFoundException` 에러 코드):  
- Recommended Default가 `"NOT_FOUND"`로 표기했으나, `GlobalExceptionHandler`는 `ex.getCode()`를 그대로 사용함을 확인. 스펙 응답 예시(`"SLOT_DEFINITION_NOT_FOUND"`)와 기존 도메인 패턴(`"DOMAIN_PACK_VERSION_NOT_FOUND"` 등)을 기준으로 `"SLOT_DEFINITION_NOT_FOUND"` 채택.

**UR-006** (기존 `findByDomainPackVersionId` 처리):  
- 기존 메서드(`AddIntentsToDraftVersionUseCase` 등 사용 중) 삭제하지 않고 신규 메서드 2개 병존. 사용처 영향 없음 확인.

---

## Spec Deviations

**테스트 레벨 편차 (Audit V-003, auto-fixed)**:  
- Implementation 초기에 `GetSlotDefinitionUseCaseTest`의 "slot 미존재"와 "다른 version 소속 slotId" 시나리오를 단일 케이스로 병합.  
- Audit에서 스펙 위반으로 감지, 두 케이스로 재분리 완료.  
- 컨트롤러 테스트에서는 처음부터 2개 분리 구현.

그 외 스펙 대비 차이 없음.

---

## Blocked / Skipped Items

**UR-007** (`idx_slot_version_slot_code` 인덱스):  
- 스펙 명시 기준(버전당 slot > 50개, 전체 행 > 10,000, p95 > 500ms) 미달로 미추가.  
- 현재 `idx_slot_version_id` 인덱스로 충분. 임계값 도달 시 별도 migration 티켓 필요.

---

## Test Notes

| 테스트 클래스 | 케이스 수 | 결과 |
|---|---|---|
| `GetSlotDefinitionListUseCaseTest` | 7 | PASS |
| `GetSlotDefinitionUseCaseTest` | 6 | PASS |
| `SlotDefinitionControllerTest` | 9 | PASS |
| **합계** | **22** | **BUILD SUCCESSFUL** |

Audit에서 발견된 3개 Warning 모두 auto-fix 완료:
- **V-001**: 테스트 메서드명 `_when_` 세그먼트 누락 → 수정
- **V-002**: `SlotDefinitionSummary` JSON 필드 부재 assertion 누락 → `getRecordComponents()` 기반 구조 검증 추가
- **V-003**: UseCase 테스트 2개 병합 → 2개로 재분리

---

## Reviewer Focus

1. `JpaSlotDefinitionRepository` — 기존 `findByDomainPackVersionId`와 신규 `findAllByDomainPackVersionIdOrderBySlotCodeAsc` 공존이 의도적임. (UR-006)
2. `SlotDefinitionNotFoundException` — `NotFoundException` 상속으로 `GlobalExceptionHandler`가 404 + `"SLOT_DEFINITION_NOT_FOUND"` 코드 반환. (UR-005)
3. `GetSlotDefinitionListUseCaseTest` — `getRecordComponents()` 기반 필드 부재 구조 검증 패턴이 기존 테스트와 다른 스타일임 (V-002 대응).

---

## Conflicts

없음.

---

## Ready to Merge / Needs Input

**Ready to Merge** — 모든 테스트 통과, Audit Warning 3종 auto-fix 완료, User Decision Required 항목 없음.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 슬롯 정의 조회 API 추가: 특정 도메인 팩 버전의 슬롯 목록(코드 기준 정렬)과 개별 슬롯 상세 조회를 제공합니다.
* **향상된 오류 처리**
  * 권한·존재성·버전 불일치 등 상황에 대해 명확한 HTTP 응답 코드와 오류 코드를 반환합니다.
* **테스트**
  * 목록·상세 경로 및 각종 오류 매핑을 검증하는 단위/통합 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->