### PR TITLE
feat(domain-pack): add workflow definition read API

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "@base-ui/react": "^1.3.0",
     "@hookform/resolvers": "^5.2.2",
     "@tailwindcss/vite": "^4.2.2",
+    "@xyflow/react": "^12.10.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
@@ -40,7 +41,6 @@
   "devDependencies": {
     "@eslint/js": "^9.39.4",
     "@playwright/test": "^1.59.1",
-    "vitest": "^3.0.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@types/node": "^24.12.0",
@@ -56,7 +56,8 @@
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.57.0",
     "vite": "catalog:",
-    "vite-plus": "catalog:"
+    "vite-plus": "catalog:",
+    "vitest": "^3.0.0"
   },
   "packageManager": "pnpm@10.33.0"
 }

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(@voidzero-dev/vite-plus-core@0.1.15(@types/node@24.12.0)(jiti@2.6.1)(typescript@5.9.3))
+      '@xyflow/react':
+        specifier: ^12.10.2
+        version: 12.10.2(@types/react@19.2.14)(immer@11.1.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -1564,6 +1567,9 @@ packages:
   '@types/d3-color@3.1.3':
     resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
 
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
   '@types/d3-ease@3.0.2':
     resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
 
@@ -1576,6 +1582,9 @@ packages:
   '@types/d3-scale@4.0.9':
     resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
 
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
   '@types/d3-shape@3.1.8':
     resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
 
@@ -1584,6 +1593,12 @@ packages:
 
   '@types/d3-timer@3.0.2':
     resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
@@ -1877,6 +1892,15 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@xyflow/react@12.10.2':
+    resolution: {integrity: sha512-CgIi6HwlcHXwlkTpr0fxLv/0sRVNZ8IdwKLzzeCscaYBwpvfcH1QFOCeaTCuEn1FQEs/B8CjnTSjhs8udgmBgQ==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+
+  '@xyflow/system@0.0.76':
+    resolution: {integrity: sha512-hvwvnRS1B3REwVDlWexsq7YQaPZeG3/mKo1jv38UmnpWmxihp14bW6VtEOuHEwJX2FvzFw8k77LyKSk/wiZVNA==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1957,6 +1981,9 @@ packages:
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
+  classcat@5.0.5:
+    resolution: {integrity: sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==}
+
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
@@ -2002,6 +2029,14 @@ packages:
     resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
     engines: {node: '>=12'}
 
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
   d3-ease@3.0.1:
     resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
     engines: {node: '>=12'}
@@ -2022,6 +2057,10 @@ packages:
     resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
     engines: {node: '>=12'}
 
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
   d3-shape@3.2.0:
     resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
     engines: {node: '>=12'}
@@ -2036,6 +2075,16 @@ packages:
 
   d3-timer@3.0.1:
     resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
     engines: {node: '>=12'}
 
   data-urls@7.0.0:
@@ -2959,6 +3008,21 @@ packages:
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+  zustand@4.5.7:
+    resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      '@types/react': '>=16.8'
+      immer: '>=9.0.6'
+      react: '>=16.8'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
 
 snapshots:
 
@@ -4278,6 +4342,10 @@ snapshots:
 
   '@types/d3-color@3.1.3': {}
 
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
   '@types/d3-ease@3.0.2': {}
 
   '@types/d3-interpolate@3.0.4':
@@ -4290,6 +4358,8 @@ snapshots:
     dependencies:
       '@types/d3-time': 3.0.4
 
+  '@types/d3-selection@3.0.11': {}
+
   '@types/d3-shape@3.1.8':
     dependencies:
       '@types/d3-path': 3.1.1
@@ -4297,6 +4367,15 @@ snapshots:
   '@types/d3-time@3.0.4': {}
 
   '@types/d3-timer@3.0.2': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
 
   '@types/deep-eql@4.0.2': {}
 
@@ -4502,6 +4581,29 @@ snapshots:
   '@voidzero-dev/vite-plus-win32-x64-msvc@0.1.16':
     optional: true
 
+  '@xyflow/react@12.10.2(@types/react@19.2.14)(immer@11.1.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@xyflow/system': 0.0.76
+      classcat: 5.0.5
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      zustand: 4.5.7(@types/react@19.2.14)(immer@11.1.4)(react@19.2.4)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+
+  '@xyflow/system@0.0.76':
+    dependencies:
+      '@types/d3-drag': 3.0.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-zoom: 3.0.0
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -4575,6 +4677,8 @@ snapshots:
     dependencies:
       clsx: 2.1.1
 
+  classcat@5.0.5: {}
+
   clsx@2.1.1: {}
 
   cmdk@1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
@@ -4620,6 +4724,13 @@ snapshots:
 
   d3-color@3.1.0: {}
 
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
   d3-ease@3.0.1: {}
 
   d3-format@3.1.2: {}
@@ -4638,6 +4749,8 @@ snapshots:
       d3-time: 3.1.0
       d3-time-format: 4.1.0
 
+  d3-selection@3.0.0: {}
+
   d3-shape@3.2.0:
     dependencies:
       d3-path: 3.1.0
@@ -4651,6 +4764,23 @@ snapshots:
       d3-array: 3.2.4
 
   d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   data-urls@7.0.0:
     dependencies:
@@ -5583,3 +5713,11 @@ snapshots:
       zod: 4.3.6
 
   zod@4.3.6: {}
+
+  zustand@4.5.7(@types/react@19.2.14)(immer@11.1.4)(react@19.2.4):
+    dependencies:
+      use-sync-external-store: 1.6.0(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      immer: 11.1.4
+      react: 19.2.4

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -1,4 +1,5 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
+import { Toaster } from 'sonner';
 import { LoginPage } from '../pages/login/ui/LoginPage';
 import { SignupPage } from '../pages/signup/ui/SignupPage';
 import { UploadPage } from '../pages/upload/ui/UploadPage';
@@ -6,11 +7,13 @@ import { PasswordResetInitPage } from '../pages/password-reset/ui/PasswordResetI
 import { PasswordResetCompletePage } from '../pages/password-reset/ui/PasswordResetCompletePage';
 import { ConsultationPage } from '../pages/consultation/ui/ConsultationPage';
 import { NotFoundPage } from '../pages/not-found/ui/NotFoundPage';
+import { WorkflowDraftReadPage } from '../pages/domain-pack/ui/WorkflowDraftReadPage';
 import { PrivateRoute } from '../shared/ui/PrivateRoute';
 
 export function App() {
   return (
     <BrowserRouter>
+      <Toaster position="top-right" richColors />
       <Routes>
         <Route path="/" element={<Navigate to="/login" replace />} />
         <Route path="/login" element={<LoginPage />} />
@@ -19,6 +22,14 @@ export function App() {
         <Route path="/reset-password/complete" element={<PasswordResetCompletePage />} />
         <Route path="/upload" element={<PrivateRoute><UploadPage /></PrivateRoute>} />
         <Route path="/consultation" element={<PrivateRoute><ConsultationPage /></PrivateRoute>} />
+        <Route
+          path="/workspaces/:workspaceId/domain-packs/:packId/versions/:versionId/workflows"
+          element={<PrivateRoute><WorkflowDraftReadPage /></PrivateRoute>}
+        />
+        <Route
+          path="/workspaces/:workspaceId/domain-packs/:packId/versions/:versionId/workflows/:workflowId"
+          element={<PrivateRoute><WorkflowDraftReadPage /></PrivateRoute>}
+        />
         <Route path="*" element={<NotFoundPage />} />
       </Routes>
     </BrowserRouter>

--- a/frontend/src/entities/workflow/index.ts
+++ b/frontend/src/entities/workflow/index.ts
@@ -1,0 +1,7 @@
+export type {
+  WorkflowSummary,
+  WorkflowDetail,
+  WorkflowGraph,
+  GraphNode,
+  GraphEdge,
+} from './model/types';

--- a/frontend/src/entities/workflow/model/types.ts
+++ b/frontend/src/entities/workflow/model/types.ts
@@ -1,0 +1,42 @@
+export interface WorkflowSummary {
+  id: number;
+  workflowCode: string;
+  name: string;
+  description: string | null;
+  initialState: string | null;
+  terminalStatesJson: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface GraphNode {
+  id: string;
+  label: string;
+  type: 'START' | 'ACTION' | 'DECISION' | 'ANSWER' | 'HANDOFF' | 'TERMINAL';
+}
+
+export interface GraphEdge {
+  from: string;
+  to: string;
+  label?: string;
+}
+
+export interface WorkflowGraph {
+  direction: 'LR' | 'TB';
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+}
+
+export interface WorkflowDetail {
+  id: number;
+  workflowCode: string;
+  name: string;
+  description: string | null;
+  graphJson: WorkflowGraph;
+  initialState: string | null;
+  terminalStatesJson: string;
+  evidenceJson: string;
+  metaJson: string;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/frontend/src/features/workflow-draft-read/api/workflowApi.ts
+++ b/frontend/src/features/workflow-draft-read/api/workflowApi.ts
@@ -1,0 +1,14 @@
+import { apiClient } from '../../../shared/api';
+import type { WorkflowDetail, WorkflowSummary } from '../../../entities/workflow/model/types';
+
+export const workflowApi = {
+  list: (wsId: number, packId: number, versionId: number) =>
+    apiClient.get<WorkflowSummary[]>(
+      `/workspaces/${wsId}/domain-packs/${packId}/versions/${versionId}/workflows`,
+    ),
+
+  detail: (wsId: number, packId: number, versionId: number, workflowId: number) =>
+    apiClient.get<WorkflowDetail>(
+      `/workspaces/${wsId}/domain-packs/${packId}/versions/${versionId}/workflows/${workflowId}`,
+    ),
+};

--- a/frontend/src/features/workflow-draft-read/model/parseTerminalStates.test.ts
+++ b/frontend/src/features/workflow-draft-read/model/parseTerminalStates.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
+import { parseTerminalStates } from './parseTerminalStates';
+
+describe('parseTerminalStates', () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it('유효한 JSON 배열을 string[]로 반환한다', () => {
+    // given
+    const json = '["resolved", "escalated"]';
+    // when
+    const result = parseTerminalStates(json);
+    // then
+    expect(result).toEqual(['resolved', 'escalated']);
+    expect(consoleSpy).not.toHaveBeenCalled();
+  });
+
+  it('빈 배열 JSON을 빈 string[]로 반환한다', () => {
+    // given
+    const json = '[]';
+    // when
+    const result = parseTerminalStates(json);
+    // then
+    expect(result).toEqual([]);
+    expect(consoleSpy).not.toHaveBeenCalled();
+  });
+
+  it('배열이 아닌 유효한 JSON은 raw 문자열을 반환하고 console.warn을 호출한다', () => {
+    // given
+    const json = '{"key": "value"}';
+    // when
+    const result = parseTerminalStates(json);
+    // then
+    expect(result).toBe(json);
+    expect(consoleSpy).toHaveBeenCalledOnce();
+  });
+
+  it('손상된 JSON은 raw 문자열을 반환하고 console.warn을 호출한다', () => {
+    // given
+    const json = 'invalid-json';
+    // when
+    const result = parseTerminalStates(json);
+    // then
+    expect(result).toBe(json);
+    expect(consoleSpy).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/features/workflow-draft-read/model/parseTerminalStates.ts
+++ b/frontend/src/features/workflow-draft-read/model/parseTerminalStates.ts
@@ -1,7 +1,7 @@
 export function parseTerminalStates(json: string): string[] | string {
   try {
     const parsed: unknown = JSON.parse(json);
-    if (Array.isArray(parsed)) return parsed as string[];
+    if (Array.isArray(parsed) && parsed.every((x) => typeof x === 'string')) return parsed as string[];
     console.warn('[parseTerminalStates] 파싱 결과가 배열이 아닙니다. raw 반환:', json);
     return json;
   } catch (e) {

--- a/frontend/src/features/workflow-draft-read/model/parseTerminalStates.ts
+++ b/frontend/src/features/workflow-draft-read/model/parseTerminalStates.ts
@@ -1,0 +1,11 @@
+export function parseTerminalStates(json: string): string[] | string {
+  try {
+    const parsed: unknown = JSON.parse(json);
+    if (Array.isArray(parsed)) return parsed as string[];
+    console.warn('[parseTerminalStates] 파싱 결과가 배열이 아닙니다. raw 반환:', json);
+    return json;
+  } catch (e) {
+    console.warn('[parseTerminalStates] JSON 파싱 실패. raw 반환:', json, e);
+    return json;
+  }
+}

--- a/frontend/src/features/workflow-draft-read/model/useWorkflowDetail.test.ts
+++ b/frontend/src/features/workflow-draft-read/model/useWorkflowDetail.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { renderHook, waitFor } from '@testing-library/react';
+import { ApiRequestError } from '../../../shared/api';
+
+vi.mock('../api/workflowApi', () => ({
+  workflowApi: {
+    detail: vi.fn(),
+  },
+}));
+
+import { workflowApi } from '../api/workflowApi';
+import { useWorkflowDetail } from './useWorkflowDetail';
+
+const mockDetail = vi.mocked(workflowApi.detail);
+
+const mockWorkflowDetail = {
+  id: 1,
+  workflowCode: 'WF-001',
+  name: '워크플로우 1',
+  description: null,
+  graphJson: { direction: 'LR' as const, nodes: [], edges: [] },
+  initialState: 'START',
+  terminalStatesJson: '["END"]',
+  evidenceJson: '{}',
+  metaJson: '{}',
+  createdAt: '2024-01-01T00:00:00Z',
+  updatedAt: '2024-01-01T00:00:00Z',
+};
+
+describe('useWorkflowDetail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('workflowId가 null이면 idle 상태다', () => {
+    // given / when
+    const { result } = renderHook(() => useWorkflowDetail(1, 2, 3, null));
+    // then
+    expect(result.current.status).toBe('idle');
+  });
+
+  it('workflowId가 주어지면 초기 상태는 loading이다', () => {
+    // given
+    mockDetail.mockResolvedValue(mockWorkflowDetail);
+    // when
+    const { result } = renderHook(() => useWorkflowDetail(1, 2, 3, 1));
+    // then
+    expect(result.current.status).toBe('loading');
+  });
+
+  it('API 성공 시 ready 상태와 데이터를 반환한다', async () => {
+    // given
+    mockDetail.mockResolvedValue(mockWorkflowDetail);
+    // when
+    const { result } = renderHook(() => useWorkflowDetail(1, 2, 3, 1));
+    // then
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+    if (result.current.status === 'ready') {
+      expect(result.current.data.workflowCode).toBe('WF-001');
+    }
+  });
+
+  it('404 ApiRequestError 발생 시 WORKFLOW_DEFINITION_NOT_FOUND 코드를 반환한다', async () => {
+    // given
+    const error = new ApiRequestError(404, 'WORKFLOW_DEFINITION_NOT_FOUND', 'Workflow를 찾을 수 없습니다.');
+    mockDetail.mockRejectedValue(error);
+    // when
+    const { result } = renderHook(() => useWorkflowDetail(1, 2, 3, 999));
+    // then
+    await waitFor(() => expect(result.current.status).toBe('error'));
+    if (result.current.status === 'error') {
+      expect(result.current.code).toBe('WORKFLOW_DEFINITION_NOT_FOUND');
+      expect(result.current.message).toBe('Workflow를 찾을 수 없습니다.');
+    }
+  });
+
+  it('알 수 없는 오류 발생 시 UNKNOWN_ERROR 코드를 반환한다', async () => {
+    // given
+    mockDetail.mockRejectedValue(new Error('network error'));
+    // when
+    const { result } = renderHook(() => useWorkflowDetail(1, 2, 3, 1));
+    // then
+    await waitFor(() => expect(result.current.status).toBe('error'));
+    if (result.current.status === 'error') {
+      expect(result.current.code).toBe('UNKNOWN_ERROR');
+    }
+  });
+});

--- a/frontend/src/features/workflow-draft-read/model/useWorkflowDetail.test.ts
+++ b/frontend/src/features/workflow-draft-read/model/useWorkflowDetail.test.ts
@@ -60,7 +60,7 @@ describe('useWorkflowDetail', () => {
     }
   });
 
-  it('404 ApiRequestError 발생 시 WORKFLOW_DEFINITION_NOT_FOUND 코드를 반환한다', async () => {
+  it('ApiRequestError의 code/message를 그대로 전달한다', async () => {
     // given
     const error = new ApiRequestError(404, 'WORKFLOW_DEFINITION_NOT_FOUND', 'Workflow를 찾을 수 없습니다.');
     mockDetail.mockRejectedValue(error);

--- a/frontend/src/features/workflow-draft-read/model/useWorkflowDetail.ts
+++ b/frontend/src/features/workflow-draft-read/model/useWorkflowDetail.ts
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react';
+import { workflowApi } from '../api/workflowApi';
+import { ApiRequestError } from '../../../shared/api';
+import type { WorkflowDetail } from '../../../entities/workflow/model/types';
+
+type State =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'error'; code: string; message: string }
+  | { status: 'ready'; data: WorkflowDetail };
+
+export function useWorkflowDetail(
+  wsId: number,
+  packId: number,
+  versionId: number,
+  workflowId: number | null,
+) {
+  const [state, setState] = useState<State>({ status: 'idle' });
+
+  useEffect(() => {
+    if (workflowId === null) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setState({ status: 'idle' });
+      return;
+    }
+
+    let cancelled = false;
+    setState({ status: 'loading' });
+    workflowApi
+      .detail(wsId, packId, versionId, workflowId)
+      .then((data) => {
+        if (!cancelled) setState({ status: 'ready', data });
+      })
+      .catch((e) => {
+        if (!cancelled) {
+          if (e instanceof ApiRequestError) {
+            setState({ status: 'error', code: e.code, message: e.message });
+          } else {
+            setState({ status: 'error', code: 'UNKNOWN_ERROR', message: '알 수 없는 오류가 발생했습니다.' });
+          }
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [wsId, packId, versionId, workflowId]);
+
+  return state;
+}

--- a/frontend/src/features/workflow-draft-read/model/useWorkflowList.test.ts
+++ b/frontend/src/features/workflow-draft-read/model/useWorkflowList.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { renderHook, waitFor } from '@testing-library/react';
+import { ApiRequestError } from '../../../shared/api';
+
+vi.mock('../api/workflowApi', () => ({
+  workflowApi: {
+    list: vi.fn(),
+  },
+}));
+
+import { workflowApi } from '../api/workflowApi';
+import { useWorkflowList } from './useWorkflowList';
+
+const mockList = vi.mocked(workflowApi.list);
+
+const mockSummary = {
+  id: 1,
+  workflowCode: 'WF-001',
+  name: '워크플로우 1',
+  description: null,
+  initialState: 'START',
+  terminalStatesJson: '["END"]',
+  createdAt: '2024-01-01T00:00:00Z',
+  updatedAt: '2024-01-01T00:00:00Z',
+};
+
+describe('useWorkflowList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('초기 상태는 loading이다', () => {
+    // given
+    mockList.mockResolvedValue([]);
+    // when
+    const { result } = renderHook(() => useWorkflowList(1, 2, 3));
+    // then
+    expect(result.current.status).toBe('loading');
+  });
+
+  it('API 성공 시 ready 상태와 데이터를 반환한다', async () => {
+    // given
+    mockList.mockResolvedValue([mockSummary]);
+    // when
+    const { result } = renderHook(() => useWorkflowList(1, 2, 3));
+    // then
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+    if (result.current.status === 'ready') {
+      expect(result.current.data).toEqual([mockSummary]);
+    }
+  });
+
+  it('빈 배열 응답 시 ready 상태와 빈 배열을 반환한다', async () => {
+    // given
+    mockList.mockResolvedValue([]);
+    // when
+    const { result } = renderHook(() => useWorkflowList(1, 2, 3));
+    // then
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+    if (result.current.status === 'ready') {
+      expect(result.current.data).toHaveLength(0);
+    }
+  });
+
+  it('ApiRequestError 발생 시 error 상태와 코드/메시지를 반환한다', async () => {
+    // given
+    const error = new ApiRequestError(403, 'FORBIDDEN', '접근 권한이 없습니다.');
+    mockList.mockRejectedValue(error);
+    // when
+    const { result } = renderHook(() => useWorkflowList(1, 2, 3));
+    // then
+    await waitFor(() => expect(result.current.status).toBe('error'));
+    if (result.current.status === 'error') {
+      expect(result.current.code).toBe('FORBIDDEN');
+      expect(result.current.message).toBe('접근 권한이 없습니다.');
+    }
+  });
+
+  it('알 수 없는 오류 발생 시 UNKNOWN_ERROR 코드를 반환한다', async () => {
+    // given
+    mockList.mockRejectedValue(new Error('network error'));
+    // when
+    const { result } = renderHook(() => useWorkflowList(1, 2, 3));
+    // then
+    await waitFor(() => expect(result.current.status).toBe('error'));
+    if (result.current.status === 'error') {
+      expect(result.current.code).toBe('UNKNOWN_ERROR');
+    }
+  });
+});

--- a/frontend/src/features/workflow-draft-read/model/useWorkflowList.ts
+++ b/frontend/src/features/workflow-draft-read/model/useWorkflowList.ts
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react';
+import { workflowApi } from '../api/workflowApi';
+import { ApiRequestError } from '../../../shared/api';
+import type { WorkflowSummary } from '../../../entities/workflow/model/types';
+
+type State =
+  | { status: 'loading' }
+  | { status: 'error'; code: string; message: string }
+  | { status: 'ready'; data: WorkflowSummary[] };
+
+export function useWorkflowList(wsId: number, packId: number, versionId: number) {
+  const [state, setState] = useState<State>({ status: 'loading' });
+
+  useEffect(() => {
+    let cancelled = false;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setState({ status: 'loading' });
+    workflowApi
+      .list(wsId, packId, versionId)
+      .then((data) => {
+        if (!cancelled) setState({ status: 'ready', data });
+      })
+      .catch((e) => {
+        if (!cancelled) {
+          if (e instanceof ApiRequestError) {
+            setState({ status: 'error', code: e.code, message: e.message });
+          } else {
+            setState({ status: 'error', code: 'UNKNOWN_ERROR', message: '알 수 없는 오류가 발생했습니다.' });
+          }
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [wsId, packId, versionId]);
+
+  return state;
+}

--- a/frontend/src/features/workflow-draft-read/ui/GraphRenderer.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/GraphRenderer.tsx
@@ -1,0 +1,49 @@
+import '@xyflow/react/dist/style.css';
+import { ReactFlow, Background, Controls } from '@xyflow/react';
+import type { WorkflowGraph } from '../../../entities/workflow/model/types';
+import { toFlow } from './graphMapper';
+import { StartNode } from './nodes/StartNode';
+import { ActionNode } from './nodes/ActionNode';
+import { DecisionNode } from './nodes/DecisionNode';
+import { AnswerNode } from './nodes/AnswerNode';
+import { HandoffNode } from './nodes/HandoffNode';
+import { TerminalNode } from './nodes/TerminalNode';
+import styles from './graph-renderer.module.css';
+
+const nodeTypes = {
+  start: StartNode,
+  action: ActionNode,
+  decision: DecisionNode,
+  answer: AnswerNode,
+  handoff: HandoffNode,
+  terminal: TerminalNode,
+};
+
+interface GraphRendererProps {
+  graph: WorkflowGraph;
+}
+
+function GraphRenderer({ graph }: GraphRendererProps) {
+  const { nodes, edges } = toFlow(graph);
+
+  return (
+    <div className={styles.container}>
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        nodeTypes={nodeTypes}
+        fitView
+        fitViewOptions={{ padding: 0.2 }}
+        nodesDraggable={false}
+        nodesConnectable={false}
+        elementsSelectable={false}
+        proOptions={{ hideAttribution: true }}
+      >
+        <Background gap={20} color="var(--glass-dark)" />
+        <Controls showInteractive={false} className={styles.controls} />
+      </ReactFlow>
+    </div>
+  );
+}
+
+export default GraphRenderer;

--- a/frontend/src/features/workflow-draft-read/ui/WorkflowDetailPanel.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/WorkflowDetailPanel.tsx
@@ -1,0 +1,195 @@
+import { Suspense, lazy, useState, useEffect } from 'react';
+import { AlertCircle, GitBranch } from 'lucide-react';
+import { toast } from 'sonner';
+import { useWorkflowDetail } from '../model/useWorkflowDetail';
+import { parseTerminalStates } from '../model/parseTerminalStates';
+import styles from './workflow-detail-panel.module.css';
+
+const GraphRenderer = lazy(() => import('./GraphRenderer'));
+
+type Tab = 'graph' | 'json' | 'meta';
+
+interface WorkflowDetailPanelProps {
+  wsId: number;
+  packId: number;
+  versionId: number;
+  workflowId: number | null;
+}
+
+function formatDate(iso: string) {
+  try {
+    return new Date(iso).toLocaleString('ko-KR', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  } catch {
+    return iso;
+  }
+}
+
+function tryParseJson(json: string): unknown {
+  try {
+    return JSON.parse(json);
+  } catch {
+    return null;
+  }
+}
+
+export function WorkflowDetailPanel({
+  wsId,
+  packId,
+  versionId,
+  workflowId,
+}: WorkflowDetailPanelProps) {
+  const [tab, setTab] = useState<Tab>('graph');
+  const detailState = useWorkflowDetail(wsId, packId, versionId, workflowId);
+
+  useEffect(() => {
+    if (detailState.status === 'error' && detailState.code !== 'WORKFLOW_DEFINITION_NOT_FOUND') {
+      toast.error(detailState.message);
+    }
+  }, [detailState.status]);  // eslint-disable-line react-hooks/exhaustive-deps
+
+  if (workflowId === null) {
+    return (
+      <div className={styles.panel}>
+        <div className={styles.placeholder}>
+          <GitBranch size={40} className={styles.placeholderIcon} />
+          <p className={styles.placeholderText}>좌측에서 workflow를 선택하세요</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (detailState.status === 'loading') {
+    return (
+      <div className={styles.panel}>
+        <div className={styles.loadingState}>
+          <div className={styles.spinnerRow}>
+            {[...Array(3)].map((_, i) => (
+              <div key={i} className={styles.skeletonBlock} style={{ animationDelay: `${i * 0.15}s` }} />
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (detailState.status === 'error') {
+    const isNotFound = detailState.code === 'WORKFLOW_DEFINITION_NOT_FOUND';
+    return (
+      <div className={styles.panel}>
+        <div className={styles.errorState}>
+          <AlertCircle size={36} className={styles.errorIcon} />
+          <p className={styles.errorTitle}>
+            {isNotFound ? 'Workflow를 찾을 수 없습니다' : '오류가 발생했습니다'}
+          </p>
+          <p className={styles.errorMessage}>{detailState.message}</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (detailState.status !== 'ready') return null;
+
+  const { data } = detailState;
+  const terminalStates = parseTerminalStates(data.terminalStatesJson);
+  const evidenceParsed = tryParseJson(data.evidenceJson);
+  const metaParsed = tryParseJson(data.metaJson);
+
+  return (
+    <div className={styles.panel}>
+      <div className={styles.detailHeader}>
+        <div className={styles.headerTop}>
+          <span className={styles.workflowCode}>{data.workflowCode}</span>
+          <span className={styles.updatedAt}>수정: {formatDate(data.updatedAt)}</span>
+        </div>
+        <h2 className={styles.workflowName}>{data.name}</h2>
+        {data.description && (
+          <p className={styles.description}>{data.description}</p>
+        )}
+      </div>
+
+      <div className={styles.tabs} role="tablist">
+        {(['graph', 'json', 'meta'] as Tab[]).map((t) => (
+          <button
+            key={t}
+            className={`${styles.tab} ${tab === t ? styles.tabActive : ''}`}
+            onClick={() => setTab(t)}
+            role="tab"
+            aria-selected={tab === t}
+          >
+            {t === 'graph' ? 'Graph' : t === 'json' ? 'JSON' : 'Meta'}
+          </button>
+        ))}
+      </div>
+
+      <div className={styles.tabContent}>
+        {tab === 'graph' && (
+          <Suspense fallback={<div className={styles.graphLoading}>그래프 로드 중...</div>}>
+            <GraphRenderer graph={data.graphJson} />
+          </Suspense>
+        )}
+
+        {tab === 'json' && (
+          <div className={styles.jsonView}>
+            <pre className={styles.jsonPre}>
+              <code>{JSON.stringify(data.graphJson, null, 2)}</code>
+            </pre>
+          </div>
+        )}
+
+        {tab === 'meta' && (
+          <div className={styles.metaView}>
+            <section className={styles.metaSection}>
+              <h3 className={styles.metaSectionTitle}>초기 상태</h3>
+              <p className={styles.metaValue}>{data.initialState ?? '—'}</p>
+            </section>
+
+            <section className={styles.metaSection}>
+              <h3 className={styles.metaSectionTitle}>종료 상태</h3>
+              {Array.isArray(terminalStates) ? (
+                <div className={styles.tagList}>
+                  {terminalStates.length === 0 ? (
+                    <span className={styles.metaMuted}>없음</span>
+                  ) : (
+                    terminalStates.map((s, i) => (
+                      <span key={i} className={styles.tag}>{s}</span>
+                    ))
+                  )}
+                </div>
+              ) : (
+                <code className={styles.rawCode}>{terminalStates}</code>
+              )}
+            </section>
+
+            <section className={styles.metaSection}>
+              <h3 className={styles.metaSectionTitle}>Evidence</h3>
+              {evidenceParsed !== null ? (
+                <pre className={styles.metaPre}>
+                  <code>{JSON.stringify(evidenceParsed, null, 2)}</code>
+                </pre>
+              ) : (
+                <code className={styles.rawCode}>{data.evidenceJson}</code>
+              )}
+            </section>
+
+            <section className={styles.metaSection}>
+              <h3 className={styles.metaSectionTitle}>Meta</h3>
+              {metaParsed !== null ? (
+                <pre className={styles.metaPre}>
+                  <code>{JSON.stringify(metaParsed, null, 2)}</code>
+                </pre>
+              ) : (
+                <code className={styles.rawCode}>{data.metaJson}</code>
+              )}
+            </section>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/workflow-draft-read/ui/WorkflowDetailPanel.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/WorkflowDetailPanel.tsx
@@ -52,8 +52,8 @@ export function WorkflowDetailPanel({
     if (detailState.status === 'error' && detailState.code !== 'WORKFLOW_DEFINITION_NOT_FOUND') {
       toast.error(detailState.message);
     }
-  // discriminated-union: status change always co-changes code/message
-  }, [detailState.status]);  // eslint-disable-line react-hooks/exhaustive-deps
+  // discriminated-union: status/code always change together; message intentionally omitted
+  }, [detailState.status, detailState.code]);  // eslint-disable-line react-hooks/exhaustive-deps
 
   if (workflowId === null) {
     return (
@@ -81,14 +81,14 @@ export function WorkflowDetailPanel({
   }
 
   if (detailState.status === 'error') {
-    const isNotFound = detailState.code === 'WORKFLOW_DEFINITION_NOT_FOUND';
+    if (detailState.code !== 'WORKFLOW_DEFINITION_NOT_FOUND') {
+      return <div className={styles.panel} />;
+    }
     return (
       <div className={styles.panel}>
         <div className={styles.errorState}>
           <AlertCircle size={36} className={styles.errorIcon} />
-          <p className={styles.errorTitle}>
-            {isNotFound ? 'Workflow를 찾을 수 없습니다' : '오류가 발생했습니다'}
-          </p>
+          <p className={styles.errorTitle}>Workflow를 찾을 수 없습니다</p>
           <p className={styles.errorMessage}>{detailState.message}</p>
         </div>
       </div>

--- a/frontend/src/features/workflow-draft-read/ui/WorkflowDetailPanel.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/WorkflowDetailPanel.tsx
@@ -34,7 +34,7 @@ function tryParseJson(json: string): unknown {
   try {
     return JSON.parse(json);
   } catch (e) {
-    console.warn('[tryParseJson] JSON 파싱 실패. raw 반환:', json, e);
+    console.warn('[tryParseJson] JSON parsing failed');
     return null;
   }
 }
@@ -70,7 +70,7 @@ export function WorkflowDetailPanel({
   if (detailState.status === 'loading') {
     return (
       <div className={styles.panel}>
-        <div className={styles.loadingState}>
+        <div className={styles.loadingState} role="status" aria-label="Loading workflow details">
           <div className={styles.spinnerRow}>
             {[...Array(3)].map((_, i) => (
               <div key={i} className={styles.skeletonBlock} style={{ animationDelay: `${i * 0.15}s` }} />

--- a/frontend/src/features/workflow-draft-read/ui/WorkflowDetailPanel.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/WorkflowDetailPanel.tsx
@@ -33,7 +33,8 @@ function formatDate(iso: string) {
 function tryParseJson(json: string): unknown {
   try {
     return JSON.parse(json);
-  } catch {
+  } catch (e) {
+    console.warn('[tryParseJson] JSON 파싱 실패. raw 반환:', json, e);
     return null;
   }
 }
@@ -51,6 +52,7 @@ export function WorkflowDetailPanel({
     if (detailState.status === 'error' && detailState.code !== 'WORKFLOW_DEFINITION_NOT_FOUND') {
       toast.error(detailState.message);
     }
+  // discriminated-union: status change always co-changes code/message
   }, [detailState.status]);  // eslint-disable-line react-hooks/exhaustive-deps
 
   if (workflowId === null) {

--- a/frontend/src/features/workflow-draft-read/ui/WorkflowDetailPanel.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/WorkflowDetailPanel.tsx
@@ -47,13 +47,14 @@ export function WorkflowDetailPanel({
 }: WorkflowDetailPanelProps) {
   const [tab, setTab] = useState<Tab>('graph');
   const detailState = useWorkflowDetail(wsId, packId, versionId, workflowId);
+  const errorCode = detailState.status === 'error' ? detailState.code : undefined;
 
   useEffect(() => {
-    if (detailState.status === 'error' && detailState.code !== 'WORKFLOW_DEFINITION_NOT_FOUND') {
+    if (detailState.status === 'error' && errorCode !== 'WORKFLOW_DEFINITION_NOT_FOUND') {
       toast.error(detailState.message);
     }
-  // discriminated-union: status/code always change together; message intentionally omitted
-  }, [detailState.status, detailState.code]);  // eslint-disable-line react-hooks/exhaustive-deps
+  // discriminated-union: status/errorCode always change together; message intentionally omitted
+  }, [detailState.status, errorCode]);  // eslint-disable-line react-hooks/exhaustive-deps
 
   if (workflowId === null) {
     return (

--- a/frontend/src/features/workflow-draft-read/ui/WorkflowDetailPanel.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/WorkflowDetailPanel.tsx
@@ -115,14 +115,32 @@ export function WorkflowDetailPanel({
         )}
       </div>
 
-      <div className={styles.tabs} role="tablist">
+      <div
+        className={styles.tabs}
+        role="tablist"
+        onKeyDown={(e) => {
+          const allTabs: Tab[] = ['graph', 'json', 'meta'];
+          const idx = allTabs.indexOf(tab);
+          if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
+            e.preventDefault();
+            const dir = e.key === 'ArrowRight' ? 1 : -1;
+            const next = (idx + dir + allTabs.length) % allTabs.length;
+            setTab(allTabs[next]);
+            const tabList = e.currentTarget;
+            (tabList.querySelectorAll('[role="tab"]')[next] as HTMLButtonElement)?.focus();
+          }
+        }}
+      >
         {(['graph', 'json', 'meta'] as Tab[]).map((t) => (
           <button
             key={t}
+            id={`tab-${t}`}
             className={`${styles.tab} ${tab === t ? styles.tabActive : ''}`}
             onClick={() => setTab(t)}
             role="tab"
             aria-selected={tab === t}
+            aria-controls={`panel-${t}`}
+            tabIndex={tab === t ? 0 : -1}
           >
             {t === 'graph' ? 'Graph' : t === 'json' ? 'JSON' : 'Meta'}
           </button>
@@ -131,13 +149,15 @@ export function WorkflowDetailPanel({
 
       <div className={styles.tabContent}>
         {tab === 'graph' && (
-          <Suspense fallback={<div className={styles.graphLoading}>그래프 로드 중...</div>}>
-            <GraphRenderer graph={data.graphJson} />
-          </Suspense>
+          <div role="tabpanel" id="panel-graph" aria-labelledby="tab-graph" tabIndex={0}>
+            <Suspense fallback={<div className={styles.graphLoading}>그래프 로드 중...</div>}>
+              <GraphRenderer graph={data.graphJson} />
+            </Suspense>
+          </div>
         )}
 
         {tab === 'json' && (
-          <div className={styles.jsonView}>
+          <div role="tabpanel" id="panel-json" aria-labelledby="tab-json" tabIndex={0} className={styles.jsonView}>
             <pre className={styles.jsonPre}>
               <code>{JSON.stringify(data.graphJson, null, 2)}</code>
             </pre>
@@ -145,7 +165,7 @@ export function WorkflowDetailPanel({
         )}
 
         {tab === 'meta' && (
-          <div className={styles.metaView}>
+          <div role="tabpanel" id="panel-meta" aria-labelledby="tab-meta" tabIndex={0} className={styles.metaView}>
             <section className={styles.metaSection}>
               <h3 className={styles.metaSectionTitle}>초기 상태</h3>
               <p className={styles.metaValue}>{data.initialState ?? '—'}</p>

--- a/frontend/src/features/workflow-draft-read/ui/WorkflowListPanel.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/WorkflowListPanel.tsx
@@ -62,12 +62,11 @@ export function WorkflowListPanel({
 }: WorkflowListPanelProps) {
   const listState = useWorkflowList(wsId, packId, versionId);
 
-  // discriminated-union: status change always co-changes message
   useEffect(() => {
     if (listState.status === 'error') {
       toast.error(listState.message);
     }
-  }, [listState.status]);  // eslint-disable-line react-hooks/exhaustive-deps
+  }, [listState]);
 
   return (
     <aside className={styles.panel}>

--- a/frontend/src/features/workflow-draft-read/ui/WorkflowListPanel.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/WorkflowListPanel.tsx
@@ -1,0 +1,122 @@
+import { Inbox, AlertCircle } from 'lucide-react';
+import { toast } from 'sonner';
+import { useWorkflowList } from '../model/useWorkflowList';
+import type { WorkflowSummary } from '../../../entities/workflow/model/types';
+import styles from './workflow-list-panel.module.css';
+import { useEffect } from 'react';
+
+interface WorkflowListPanelProps {
+  wsId: number;
+  packId: number;
+  versionId: number;
+  selectedId: number | null;
+  onSelect: (id: number) => void;
+}
+
+function parseTerminalCount(json: string): number {
+  try {
+    const parsed: unknown = JSON.parse(json);
+    return Array.isArray(parsed) ? parsed.length : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function WorkflowListItem({
+  item,
+  isSelected,
+  onSelect,
+}: {
+  item: WorkflowSummary;
+  isSelected: boolean;
+  onSelect: () => void;
+}) {
+  const terminalCount = parseTerminalCount(item.terminalStatesJson);
+
+  return (
+    <div
+      className={`${styles.listItem} ${isSelected ? styles.listItemActive : ''}`}
+      onClick={onSelect}
+      onKeyDown={(e) => e.key === 'Enter' && onSelect()}
+      tabIndex={0}
+      role="button"
+      aria-pressed={isSelected}
+    >
+      <div className={styles.itemCode}>{item.workflowCode}</div>
+      <div className={styles.itemName}>{item.name}</div>
+      <div className={styles.itemBadges}>
+        {item.initialState && (
+          <span className={styles.badge} title="초기 상태">
+            {item.initialState}
+          </span>
+        )}
+        {terminalCount > 0 && (
+          <span className={`${styles.badge} ${styles.badgeMuted}`} title="종료 상태 수">
+            +{terminalCount}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function WorkflowListPanel({
+  wsId,
+  packId,
+  versionId,
+  selectedId,
+  onSelect,
+}: WorkflowListPanelProps) {
+  const listState = useWorkflowList(wsId, packId, versionId);
+
+  useEffect(() => {
+    if (listState.status === 'error') {
+      toast.error(listState.message);
+    }
+  }, [listState.status]);  // eslint-disable-line react-hooks/exhaustive-deps
+
+  return (
+    <aside className={styles.panel}>
+      <div className={styles.header}>
+        <span className={styles.title}>Workflows</span>
+        {listState.status === 'ready' && (
+          <span className={styles.count}>{listState.data.length}개</span>
+        )}
+      </div>
+
+      <div className={styles.listBody}>
+        {listState.status === 'loading' && (
+          <div className={styles.skeleton}>
+            {[...Array(4)].map((_, i) => (
+              <div key={i} className={styles.skeletonItem} />
+            ))}
+          </div>
+        )}
+
+        {listState.status === 'error' && (
+          <div className={styles.errorState}>
+            <AlertCircle size={32} className={styles.errorIcon} />
+            <p className={styles.errorText}>{listState.message}</p>
+          </div>
+        )}
+
+        {listState.status === 'ready' && listState.data.length === 0 && (
+          <div className={styles.emptyState}>
+            <Inbox size={36} className={styles.emptyIcon} />
+            <p className={styles.emptyText}>workflow 초안이 없습니다</p>
+          </div>
+        )}
+
+        {listState.status === 'ready' &&
+          listState.data.map((item) => (
+            <WorkflowListItem
+              key={item.id}
+              item={item}
+              isSelected={selectedId === item.id}
+              onSelect={() => onSelect(item.id)}
+            />
+          ))}
+      </div>
+    </aside>
+  );
+}

--- a/frontend/src/features/workflow-draft-read/ui/WorkflowListPanel.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/WorkflowListPanel.tsx
@@ -1,9 +1,10 @@
+import { useEffect } from 'react';
 import { Inbox, AlertCircle } from 'lucide-react';
 import { toast } from 'sonner';
 import { useWorkflowList } from '../model/useWorkflowList';
+import { parseTerminalStates } from '../model/parseTerminalStates';
 import type { WorkflowSummary } from '../../../entities/workflow/model/types';
 import styles from './workflow-list-panel.module.css';
-import { useEffect } from 'react';
 
 interface WorkflowListPanelProps {
   wsId: number;
@@ -11,15 +12,6 @@ interface WorkflowListPanelProps {
   versionId: number;
   selectedId: number | null;
   onSelect: (id: number) => void;
-}
-
-function parseTerminalCount(json: string): number {
-  try {
-    const parsed: unknown = JSON.parse(json);
-    return Array.isArray(parsed) ? parsed.length : 0;
-  } catch {
-    return 0;
-  }
 }
 
 function WorkflowListItem({
@@ -31,7 +23,8 @@ function WorkflowListItem({
   isSelected: boolean;
   onSelect: () => void;
 }) {
-  const terminalCount = parseTerminalCount(item.terminalStatesJson);
+  const parsed = parseTerminalStates(item.terminalStatesJson);
+  const terminalCount = Array.isArray(parsed) ? parsed.length : 0;
 
   return (
     <div
@@ -69,6 +62,7 @@ export function WorkflowListPanel({
 }: WorkflowListPanelProps) {
   const listState = useWorkflowList(wsId, packId, versionId);
 
+  // discriminated-union: status change always co-changes message
   useEffect(() => {
     if (listState.status === 'error') {
       toast.error(listState.message);

--- a/frontend/src/features/workflow-draft-read/ui/WorkflowListPanel.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/WorkflowListPanel.tsx
@@ -90,7 +90,7 @@ export function WorkflowListPanel({
         {listState.status === 'error' && (
           <div className={styles.errorState}>
             <AlertCircle size={32} className={styles.errorIcon} />
-            <p className={styles.errorText}>{listState.message}</p>
+            <p className={styles.errorText}>워크플로우를 불러오는 중 오류가 발생했습니다. 다시 시도해 주세요.</p>
           </div>
         )}
 

--- a/frontend/src/features/workflow-draft-read/ui/WorkflowListPanel.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/WorkflowListPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { Inbox, AlertCircle } from 'lucide-react';
 import { toast } from 'sonner';
 import { useWorkflowList } from '../model/useWorkflowList';
@@ -23,16 +23,16 @@ function WorkflowListItem({
   isSelected: boolean;
   onSelect: () => void;
 }) {
-  const parsed = parseTerminalStates(item.terminalStatesJson);
-  const terminalCount = Array.isArray(parsed) ? parsed.length : 0;
+  const terminalCount = useMemo(() => {
+    const parsed = parseTerminalStates(item.terminalStatesJson);
+    return Array.isArray(parsed) ? parsed.length : 0;
+  }, [item.terminalStatesJson]);
 
   return (
-    <div
+    <button
+      type="button"
       className={`${styles.listItem} ${isSelected ? styles.listItemActive : ''}`}
       onClick={onSelect}
-      onKeyDown={(e) => e.key === 'Enter' && onSelect()}
-      tabIndex={0}
-      role="button"
       aria-pressed={isSelected}
     >
       <div className={styles.itemCode}>{item.workflowCode}</div>
@@ -49,7 +49,7 @@ function WorkflowListItem({
           </span>
         )}
       </div>
-    </div>
+    </button>
   );
 }
 

--- a/frontend/src/features/workflow-draft-read/ui/graph-renderer.module.css
+++ b/frontend/src/features/workflow-draft-read/ui/graph-renderer.module.css
@@ -1,0 +1,22 @@
+.container {
+  width: 100%;
+  height: 100%;
+  min-height: 400px;
+  background: var(--bg-color);
+}
+
+.controls {
+  background: var(--bg-color) !important;
+  border: 1px solid var(--glass-border) !important;
+  border-radius: var(--radius-md) !important;
+}
+
+.controls button {
+  background: var(--bg-color) !important;
+  border-bottom: 1px solid var(--glass-border) !important;
+  color: var(--text-primary) !important;
+}
+
+.controls button:hover {
+  background: var(--bg-secondary) !important;
+}

--- a/frontend/src/features/workflow-draft-read/ui/graph-renderer.module.css
+++ b/frontend/src/features/workflow-draft-read/ui/graph-renderer.module.css
@@ -3,20 +3,16 @@
   height: 100%;
   min-height: 400px;
   background: var(--bg-color);
+  --xy-controls-button-background-color-default: var(--bg-color);
+  --xy-controls-button-background-color-hover-default: var(--bg-secondary);
+  --xy-controls-button-color-default: var(--text-primary);
+  --xy-controls-button-color-hover-default: var(--text-primary);
+  --xy-controls-button-border-color-default: var(--glass-border);
+  --xy-controls-box-shadow-default: none;
 }
 
 .controls {
-  background: var(--bg-color) !important;
-  border: 1px solid var(--glass-border) !important;
-  border-radius: var(--radius-md) !important;
-}
-
-.controls button {
-  background: var(--bg-color) !important;
-  border-bottom: 1px solid var(--glass-border) !important;
-  color: var(--text-primary) !important;
-}
-
-.controls button:hover {
-  background: var(--bg-secondary) !important;
+  background: var(--bg-color);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-md);
 }

--- a/frontend/src/features/workflow-draft-read/ui/graphMapper.ts
+++ b/frontend/src/features/workflow-draft-read/ui/graphMapper.ts
@@ -1,8 +1,8 @@
 import type { Node, Edge } from '@xyflow/react';
 import type { WorkflowGraph } from '../../../entities/workflow/model/types';
 
-const H_SPACING = 220;
-const V_SPACING = 130;
+const ALONG_FLOW_SPACING = 220;
+const CROSS_FLOW_SPACING = 130;
 
 function layout(i: number, graph: WorkflowGraph): { x: number; y: number } {
   const total = graph.nodes.length;
@@ -10,9 +10,9 @@ function layout(i: number, graph: WorkflowGraph): { x: number; y: number } {
   const col = i % cols;
   const row = Math.floor(i / cols);
   if (graph.direction === 'TB') {
-    return { x: col * V_SPACING, y: row * H_SPACING };
+    return { x: col * CROSS_FLOW_SPACING, y: row * ALONG_FLOW_SPACING };
   }
-  return { x: col * H_SPACING, y: row * V_SPACING };
+  return { x: col * ALONG_FLOW_SPACING, y: row * CROSS_FLOW_SPACING };
 }
 
 const KNOWN_NODE_TYPES = new Set(['start', 'action', 'decision', 'answer', 'handoff', 'terminal']);
@@ -36,7 +36,7 @@ export function toFlow(graph: WorkflowGraph): { nodes: Node[]; edges: Edge[] } {
 
   const edgeIdCounts = new Map<string, number>();
   const edges: Edge[] = graph.edges.map((e) => {
-    const baseId = `${e.from}->${e.to}:${e.label ?? 'unlabeled'}`;
+    const baseId = `${encodeURIComponent(e.from)}->${encodeURIComponent(e.to)}:${encodeURIComponent(e.label ?? 'unlabeled')}`;
     const count = edgeIdCounts.get(baseId) ?? 0;
     edgeIdCounts.set(baseId, count + 1);
 

--- a/frontend/src/features/workflow-draft-read/ui/graphMapper.ts
+++ b/frontend/src/features/workflow-draft-read/ui/graphMapper.ts
@@ -9,6 +9,9 @@ function layout(i: number, graph: WorkflowGraph): { x: number; y: number } {
   const cols = Math.max(1, Math.ceil(Math.sqrt(total)));
   const col = i % cols;
   const row = Math.floor(i / cols);
+  if (graph.direction === 'TB') {
+    return { x: col * V_SPACING, y: row * H_SPACING };
+  }
   return { x: col * H_SPACING, y: row * V_SPACING };
 }
 

--- a/frontend/src/features/workflow-draft-read/ui/graphMapper.ts
+++ b/frontend/src/features/workflow-draft-read/ui/graphMapper.ts
@@ -1,0 +1,40 @@
+import type { Node, Edge } from '@xyflow/react';
+import type { WorkflowGraph } from '../../../entities/workflow/model/types';
+
+const H_SPACING = 220;
+const V_SPACING = 130;
+
+function layout(i: number, graph: WorkflowGraph): { x: number; y: number } {
+  const total = graph.nodes.length;
+  const cols = Math.max(1, Math.ceil(Math.sqrt(total)));
+  const col = i % cols;
+  const row = Math.floor(i / cols);
+  return { x: col * H_SPACING, y: row * V_SPACING };
+}
+
+const mapNodeType = (type: WorkflowGraph['nodes'][number]['type']) => type.toLowerCase();
+
+export function toFlow(graph: WorkflowGraph): { nodes: Node[]; edges: Edge[] } {
+  const nodes: Node[] = graph.nodes.map((n, i) => ({
+    id: n.id,
+    type: mapNodeType(n.type),
+    data: { label: n.label },
+    position: layout(i, graph),
+  }));
+
+  const edgeIdCounts = new Map<string, number>();
+  const edges: Edge[] = graph.edges.map((e) => {
+    const baseId = `${e.from}->${e.to}:${e.label ?? 'unlabeled'}`;
+    const count = edgeIdCounts.get(baseId) ?? 0;
+    edgeIdCounts.set(baseId, count + 1);
+
+    return {
+      id: `${baseId}#${count + 1}`,
+      source: e.from,
+      target: e.to,
+      label: e.label ?? undefined,
+    };
+  });
+
+  return { nodes, edges };
+}

--- a/frontend/src/features/workflow-draft-read/ui/graphMapper.ts
+++ b/frontend/src/features/workflow-draft-read/ui/graphMapper.ts
@@ -12,7 +12,16 @@ function layout(i: number, graph: WorkflowGraph): { x: number; y: number } {
   return { x: col * H_SPACING, y: row * V_SPACING };
 }
 
-const mapNodeType = (type: WorkflowGraph['nodes'][number]['type']) => type.toLowerCase();
+const KNOWN_NODE_TYPES = new Set(['start', 'action', 'decision', 'answer', 'handoff', 'terminal']);
+
+function mapNodeType(type: WorkflowGraph['nodes'][number]['type']): string {
+  const lower = type.toLowerCase();
+  if (!KNOWN_NODE_TYPES.has(lower)) {
+    console.warn('[graphMapper] 알 수 없는 노드 타입:', type);
+    return 'action';
+  }
+  return lower;
+}
 
 export function toFlow(graph: WorkflowGraph): { nodes: Node[]; edges: Edge[] } {
   const nodes: Node[] = graph.nodes.map((n, i) => ({

--- a/frontend/src/features/workflow-draft-read/ui/index.ts
+++ b/frontend/src/features/workflow-draft-read/ui/index.ts
@@ -1,0 +1,2 @@
+export { WorkflowListPanel } from './WorkflowListPanel';
+export { WorkflowDetailPanel } from './WorkflowDetailPanel';

--- a/frontend/src/features/workflow-draft-read/ui/nodes/ActionNode.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/nodes/ActionNode.tsx
@@ -1,0 +1,12 @@
+import { Handle, Position, type NodeProps } from '@xyflow/react';
+import styles from './nodes.module.css';
+
+export function ActionNode({ data }: NodeProps) {
+  return (
+    <div className={`${styles.node} ${styles.action}`}>
+      <Handle type="target" position={Position.Left} isConnectable={false} className={styles.handle} />
+      <span className={styles.label}>{String(data.label)}</span>
+      <Handle type="source" position={Position.Right} isConnectable={false} className={styles.handle} />
+    </div>
+  );
+}

--- a/frontend/src/features/workflow-draft-read/ui/nodes/ActionNode.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/nodes/ActionNode.tsx
@@ -1,12 +1,6 @@
-import { Handle, Position, type NodeProps } from '@xyflow/react';
-import styles from './nodes.module.css';
+import { type NodeProps } from '@xyflow/react';
+import { BasicNode } from './BasicNode';
 
-export function ActionNode({ data }: NodeProps) {
-  return (
-    <div className={`${styles.node} ${styles.action}`}>
-      <Handle type="target" position={Position.Left} isConnectable={false} className={styles.handle} />
-      <span className={styles.label}>{String(data.label)}</span>
-      <Handle type="source" position={Position.Right} isConnectable={false} className={styles.handle} />
-    </div>
-  );
+export function ActionNode(props: NodeProps) {
+  return <BasicNode {...props} variant="action" />;
 }

--- a/frontend/src/features/workflow-draft-read/ui/nodes/AnswerNode.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/nodes/AnswerNode.tsx
@@ -1,0 +1,12 @@
+import { Handle, Position, type NodeProps } from '@xyflow/react';
+import styles from './nodes.module.css';
+
+export function AnswerNode({ data }: NodeProps) {
+  return (
+    <div className={`${styles.node} ${styles.answer}`}>
+      <Handle type="target" position={Position.Left} isConnectable={false} className={styles.handle} />
+      <span className={styles.label}>{String(data.label)}</span>
+      <Handle type="source" position={Position.Right} isConnectable={false} className={styles.handle} />
+    </div>
+  );
+}

--- a/frontend/src/features/workflow-draft-read/ui/nodes/AnswerNode.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/nodes/AnswerNode.tsx
@@ -1,12 +1,6 @@
-import { Handle, Position, type NodeProps } from '@xyflow/react';
-import styles from './nodes.module.css';
+import { type NodeProps } from '@xyflow/react';
+import { BasicNode } from './BasicNode';
 
-export function AnswerNode({ data }: NodeProps) {
-  return (
-    <div className={`${styles.node} ${styles.answer}`}>
-      <Handle type="target" position={Position.Left} isConnectable={false} className={styles.handle} />
-      <span className={styles.label}>{String(data.label)}</span>
-      <Handle type="source" position={Position.Right} isConnectable={false} className={styles.handle} />
-    </div>
-  );
+export function AnswerNode(props: NodeProps) {
+  return <BasicNode {...props} variant="answer" />;
 }

--- a/frontend/src/features/workflow-draft-read/ui/nodes/BasicNode.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/nodes/BasicNode.tsx
@@ -1,0 +1,22 @@
+import { Handle, Position, type NodeProps } from '@xyflow/react';
+import styles from './nodes.module.css';
+
+type Variant = 'start' | 'action' | 'answer' | 'handoff' | 'terminal';
+
+interface BasicNodeProps extends NodeProps {
+  variant: Variant;
+}
+
+export function BasicNode({ data, variant }: BasicNodeProps) {
+  return (
+    <div className={`${styles.node} ${styles[variant]}`}>
+      {variant !== 'start' && (
+        <Handle type="target" position={Position.Left} isConnectable={false} className={styles.handle} />
+      )}
+      <span className={styles.label}>{String(data.label)}</span>
+      {variant !== 'terminal' && (
+        <Handle type="source" position={Position.Right} isConnectable={false} className={styles.handle} />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/workflow-draft-read/ui/nodes/DecisionNode.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/nodes/DecisionNode.tsx
@@ -1,0 +1,14 @@
+import { Handle, Position, type NodeProps } from '@xyflow/react';
+import styles from './nodes.module.css';
+
+export function DecisionNode({ data }: NodeProps) {
+  return (
+    <div className={`${styles.node} ${styles.decisionWrapper}`}>
+      <Handle type="target" position={Position.Left} isConnectable={false} className={styles.handle} />
+      <div className={styles.diamond}>
+        <span className={styles.diamondLabel}>{String(data.label)}</span>
+      </div>
+      <Handle type="source" position={Position.Right} isConnectable={false} className={styles.handle} />
+    </div>
+  );
+}

--- a/frontend/src/features/workflow-draft-read/ui/nodes/HandoffNode.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/nodes/HandoffNode.tsx
@@ -1,0 +1,12 @@
+import { Handle, Position, type NodeProps } from '@xyflow/react';
+import styles from './nodes.module.css';
+
+export function HandoffNode({ data }: NodeProps) {
+  return (
+    <div className={`${styles.node} ${styles.handoff}`}>
+      <Handle type="target" position={Position.Left} isConnectable={false} className={styles.handle} />
+      <span className={styles.label}>{String(data.label)}</span>
+      <Handle type="source" position={Position.Right} isConnectable={false} className={styles.handle} />
+    </div>
+  );
+}

--- a/frontend/src/features/workflow-draft-read/ui/nodes/HandoffNode.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/nodes/HandoffNode.tsx
@@ -1,12 +1,6 @@
-import { Handle, Position, type NodeProps } from '@xyflow/react';
-import styles from './nodes.module.css';
+import { type NodeProps } from '@xyflow/react';
+import { BasicNode } from './BasicNode';
 
-export function HandoffNode({ data }: NodeProps) {
-  return (
-    <div className={`${styles.node} ${styles.handoff}`}>
-      <Handle type="target" position={Position.Left} isConnectable={false} className={styles.handle} />
-      <span className={styles.label}>{String(data.label)}</span>
-      <Handle type="source" position={Position.Right} isConnectable={false} className={styles.handle} />
-    </div>
-  );
+export function HandoffNode(props: NodeProps) {
+  return <BasicNode {...props} variant="handoff" />;
 }

--- a/frontend/src/features/workflow-draft-read/ui/nodes/StartNode.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/nodes/StartNode.tsx
@@ -1,0 +1,12 @@
+import { Handle, Position, type NodeProps } from '@xyflow/react';
+import styles from './nodes.module.css';
+
+export function StartNode({ data }: NodeProps) {
+  return (
+    <div className={`${styles.node} ${styles.start}`}>
+      <Handle type="target" position={Position.Left} isConnectable={false} className={styles.handle} />
+      <span className={styles.label}>{String(data.label)}</span>
+      <Handle type="source" position={Position.Right} isConnectable={false} className={styles.handle} />
+    </div>
+  );
+}

--- a/frontend/src/features/workflow-draft-read/ui/nodes/StartNode.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/nodes/StartNode.tsx
@@ -1,12 +1,6 @@
-import { Handle, Position, type NodeProps } from '@xyflow/react';
-import styles from './nodes.module.css';
+import { type NodeProps } from '@xyflow/react';
+import { BasicNode } from './BasicNode';
 
-export function StartNode({ data }: NodeProps) {
-  return (
-    <div className={`${styles.node} ${styles.start}`}>
-      <Handle type="target" position={Position.Left} isConnectable={false} className={styles.handle} />
-      <span className={styles.label}>{String(data.label)}</span>
-      <Handle type="source" position={Position.Right} isConnectable={false} className={styles.handle} />
-    </div>
-  );
+export function StartNode(props: NodeProps) {
+  return <BasicNode {...props} variant="start" />;
 }

--- a/frontend/src/features/workflow-draft-read/ui/nodes/TerminalNode.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/nodes/TerminalNode.tsx
@@ -1,12 +1,6 @@
-import { Handle, Position, type NodeProps } from '@xyflow/react';
-import styles from './nodes.module.css';
+import { type NodeProps } from '@xyflow/react';
+import { BasicNode } from './BasicNode';
 
-export function TerminalNode({ data }: NodeProps) {
-  return (
-    <div className={`${styles.node} ${styles.terminal}`}>
-      <Handle type="target" position={Position.Left} isConnectable={false} className={styles.handle} />
-      <span className={styles.label}>{String(data.label)}</span>
-      <Handle type="source" position={Position.Right} isConnectable={false} className={styles.handle} />
-    </div>
-  );
+export function TerminalNode(props: NodeProps) {
+  return <BasicNode {...props} variant="terminal" />;
 }

--- a/frontend/src/features/workflow-draft-read/ui/nodes/TerminalNode.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/nodes/TerminalNode.tsx
@@ -1,0 +1,12 @@
+import { Handle, Position, type NodeProps } from '@xyflow/react';
+import styles from './nodes.module.css';
+
+export function TerminalNode({ data }: NodeProps) {
+  return (
+    <div className={`${styles.node} ${styles.terminal}`}>
+      <Handle type="target" position={Position.Left} isConnectable={false} className={styles.handle} />
+      <span className={styles.label}>{String(data.label)}</span>
+      <Handle type="source" position={Position.Right} isConnectable={false} className={styles.handle} />
+    </div>
+  );
+}

--- a/frontend/src/features/workflow-draft-read/ui/nodes/nodes.module.css
+++ b/frontend/src/features/workflow-draft-read/ui/nodes/nodes.module.css
@@ -23,6 +23,8 @@
 }
 
 .label {
+  position: relative;
+  z-index: 1;
   max-width: 140px;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -97,6 +99,7 @@
 .answer::before {
   content: '';
   position: absolute;
+  z-index: 0;
   inset: 1.5px;
   background: var(--bg-color);
   pointer-events: none;
@@ -115,6 +118,7 @@
 .handoff::before {
   content: '';
   position: absolute;
+  z-index: 0;
   inset: 1.5px;
   background: var(--bg-color);
   pointer-events: none;

--- a/frontend/src/features/workflow-draft-read/ui/nodes/nodes.module.css
+++ b/frontend/src/features/workflow-draft-read/ui/nodes/nodes.module.css
@@ -89,7 +89,17 @@
   border-radius: 0;
   clip-path: polygon(14px 0, 100% 0, 100% 100%, 0 100%);
   border: none;
-  outline: 1.5px solid var(--text-primary);
+  outline: none;
+  position: relative;
+  background: var(--text-primary);
+}
+
+.answer::before {
+  content: '';
+  position: absolute;
+  inset: 1.5px;
+  background: var(--bg-color);
+  pointer-events: none;
 }
 
 /* HANDOFF — trapezoid */
@@ -97,7 +107,17 @@
   border-radius: 0;
   clip-path: polygon(0 0, 100% 0, 92% 100%, 8% 100%);
   border: none;
-  outline: 1.5px solid var(--text-primary);
+  outline: none;
+  position: relative;
+  background: var(--text-primary);
+}
+
+.handoff::before {
+  content: '';
+  position: absolute;
+  inset: 1.5px;
+  background: var(--bg-color);
+  pointer-events: none;
 }
 
 /* TERMINAL — circle */

--- a/frontend/src/features/workflow-draft-read/ui/nodes/nodes.module.css
+++ b/frontend/src/features/workflow-draft-read/ui/nodes/nodes.module.css
@@ -1,0 +1,111 @@
+.handle {
+  background: var(--text-primary) !important;
+  border: none !important;
+  width: 6px !important;
+  height: 6px !important;
+}
+
+.node {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg-color);
+  border: 1.5px solid var(--text-primary);
+  color: var(--text-primary);
+  font-family: 'Pretendard Variable', sans-serif;
+  font-size: 0.78rem;
+  font-weight: 500;
+  letter-spacing: -0.1px;
+  padding: 8px 14px;
+  min-width: 100px;
+  text-align: center;
+  cursor: default;
+}
+
+.label {
+  max-width: 140px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: block;
+}
+
+/* START — stadium */
+.start {
+  border-radius: var(--radius-xl);
+  background: var(--text-primary);
+  color: var(--bg-color);
+  min-width: 80px;
+}
+
+/* ACTION — rectangle */
+.action {
+  border-radius: var(--radius-md);
+}
+
+/* DECISION — diamond: outer wrapper is square, inner element rotated 45deg */
+.decisionWrapper {
+  border: none;
+  background: transparent;
+  padding: 0;
+  width: 110px;
+  height: 110px;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: unset;
+}
+
+.diamond {
+  width: 78px;
+  height: 78px;
+  border: 1.5px solid var(--text-primary);
+  background: var(--bg-color);
+  transform: rotate(45deg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.diamondLabel {
+  transform: rotate(-45deg);
+  font-family: 'Pretendard Variable', sans-serif;
+  font-size: 0.72rem;
+  font-weight: 500;
+  letter-spacing: -0.1px;
+  color: var(--text-primary);
+  max-width: 56px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: block;
+  text-align: center;
+}
+
+/* ANSWER — asymmetric rectangle (left cut via clip-path) */
+.answer {
+  border-radius: 0;
+  clip-path: polygon(14px 0, 100% 0, 100% 100%, 0 100%);
+  border: none;
+  outline: 1.5px solid var(--text-primary);
+}
+
+/* HANDOFF — trapezoid */
+.handoff {
+  border-radius: 0;
+  clip-path: polygon(0 0, 100% 0, 92% 100%, 8% 100%);
+  border: none;
+  outline: 1.5px solid var(--text-primary);
+}
+
+/* TERMINAL — circle */
+.terminal {
+  border-radius: var(--radius-full);
+  background: var(--glass-dark);
+  min-width: 80px;
+  width: 80px;
+  height: 80px;
+  padding: 0;
+}

--- a/frontend/src/features/workflow-draft-read/ui/workflow-detail-panel.module.css
+++ b/frontend/src/features/workflow-draft-read/ui/workflow-detail-panel.module.css
@@ -1,0 +1,280 @@
+.panel {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: var(--bg-color);
+  min-width: 0;
+}
+
+/* Placeholder */
+.placeholder {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 48px;
+}
+
+.placeholderIcon {
+  color: var(--text-muted);
+  margin-bottom: 16px;
+}
+
+.placeholderText {
+  font-size: 0.87rem;
+  color: var(--text-muted);
+  letter-spacing: normal;
+}
+
+/* Loading */
+.loadingState {
+  flex: 1;
+  display: flex;
+  align-items: flex-start;
+  padding: 24px;
+}
+
+.spinnerRow {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  width: 100%;
+}
+
+.skeletonBlock {
+  height: 24px;
+  border-radius: var(--radius-md);
+  background: var(--glass-dark);
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+.skeletonBlock:nth-child(1) { width: 40%; }
+.skeletonBlock:nth-child(2) { width: 70%; }
+.skeletonBlock:nth-child(3) { width: 55%; }
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.35; }
+}
+
+/* Error */
+.errorState {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 48px;
+  text-align: center;
+}
+
+.errorIcon {
+  color: var(--text-muted);
+  margin-bottom: 12px;
+}
+
+.errorTitle {
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: -0.14px;
+  color: var(--text-primary);
+  margin-bottom: 8px;
+}
+
+.errorMessage {
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+  letter-spacing: normal;
+}
+
+/* Detail header */
+.detailHeader {
+  padding: 20px 24px 16px;
+  border-bottom: 1px solid var(--glass-border);
+  flex-shrink: 0;
+}
+
+.headerTop {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 6px;
+}
+
+.workflowCode {
+  font-family: 'Geist Mono', monospace;
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  letter-spacing: 0;
+}
+
+.updatedAt {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  letter-spacing: normal;
+}
+
+.workflowName {
+  font-size: 1.05rem;
+  font-weight: 600;
+  letter-spacing: -0.2px;
+  color: var(--text-primary);
+  margin-bottom: 4px;
+}
+
+.description {
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+  letter-spacing: normal;
+  line-height: 1.5;
+}
+
+/* Tabs */
+.tabs {
+  display: flex;
+  border-bottom: 1px solid var(--glass-border);
+  flex-shrink: 0;
+  padding: 0 16px;
+}
+
+.tab {
+  padding: 10px 16px;
+  font-size: 0.82rem;
+  font-weight: 500;
+  letter-spacing: -0.1px;
+  color: var(--text-secondary);
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  margin-bottom: -1px;
+}
+
+.tab:hover {
+  color: var(--text-primary);
+}
+
+.tab:focus-visible {
+  outline: dashed 2px;
+  outline-offset: 2px;
+}
+
+.tabActive {
+  color: var(--text-primary);
+  border-bottom-color: var(--text-primary);
+}
+
+/* Tab content */
+.tabContent {
+  flex: 1;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+/* Graph */
+.graphLoading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+/* JSON */
+.jsonView {
+  flex: 1;
+  overflow: auto;
+  padding: 16px 20px;
+}
+
+.jsonPre {
+  font-family: 'Geist Mono', monospace;
+  font-size: 0.75rem;
+  line-height: 1.6;
+  color: var(--text-primary);
+  background: var(--bg-secondary);
+  padding: 16px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--glass-border);
+  overflow: auto;
+  white-space: pre;
+}
+
+/* Meta */
+.metaView {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px 24px;
+}
+
+.metaSection {
+  margin-bottom: 24px;
+}
+
+.metaSectionTitle {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-bottom: 8px;
+}
+
+.metaValue {
+  font-size: 0.85rem;
+  color: var(--text-primary);
+  letter-spacing: -0.1px;
+}
+
+.metaMuted {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.tagList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.tag {
+  font-family: 'Geist Mono', monospace;
+  font-size: 0.72rem;
+  padding: 3px 9px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--text-primary);
+  color: var(--text-primary);
+  letter-spacing: 0;
+}
+
+.rawCode {
+  font-family: 'Geist Mono', monospace;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  letter-spacing: 0;
+  word-break: break-all;
+}
+
+.metaPre {
+  font-family: 'Geist Mono', monospace;
+  font-size: 0.75rem;
+  line-height: 1.6;
+  color: var(--text-primary);
+  background: var(--bg-secondary);
+  padding: 12px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--glass-border);
+  overflow: auto;
+  white-space: pre;
+}
+
+@media (max-width: 767px) {
+  .panel {
+    width: 100%;
+  }
+}

--- a/frontend/src/features/workflow-draft-read/ui/workflow-detail-panel.module.css
+++ b/frontend/src/features/workflow-draft-read/ui/workflow-detail-panel.module.css
@@ -59,6 +59,13 @@
   50% { opacity: 0.35; }
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .skeletonBlock {
+    animation: none;
+    opacity: 1;
+  }
+}
+
 /* Error */
 .errorState {
   flex: 1;
@@ -159,7 +166,7 @@
 
 .tab:focus-visible {
   outline: dashed 2px;
-  outline-color: var(--text-primary);
+  outline-color: var(--focus-ring, currentColor);
   outline-offset: 2px;
 }
 

--- a/frontend/src/features/workflow-draft-read/ui/workflow-detail-panel.module.css
+++ b/frontend/src/features/workflow-draft-read/ui/workflow-detail-panel.module.css
@@ -159,6 +159,7 @@
 
 .tab:focus-visible {
   outline: dashed 2px;
+  outline-color: var(--text-primary);
   outline-offset: 2px;
 }
 

--- a/frontend/src/features/workflow-draft-read/ui/workflow-list-panel.module.css
+++ b/frontend/src/features/workflow-draft-read/ui/workflow-list-panel.module.css
@@ -57,7 +57,7 @@
 
 .listItemActive {
   background: var(--glass-dark);
-  border-color: rgba(0, 0, 0, 0.12);
+  border-color: var(--glass-border);
 }
 
 .itemCode {

--- a/frontend/src/features/workflow-draft-read/ui/workflow-list-panel.module.css
+++ b/frontend/src/features/workflow-draft-read/ui/workflow-list-panel.module.css
@@ -1,0 +1,160 @@
+.panel {
+  width: 360px;
+  min-width: 360px;
+  border-right: 1px solid var(--glass-border);
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+  background: var(--bg-color);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 20px;
+  border-bottom: 1px solid var(--glass-border);
+  flex-shrink: 0;
+}
+
+.title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: -0.14px;
+  color: var(--text-primary);
+}
+
+.count {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  letter-spacing: normal;
+}
+
+.listBody {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px;
+}
+
+.listItem {
+  padding: 12px 14px;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  border: 1px solid transparent;
+  margin-bottom: 4px;
+  transition: all var(--transition-fast);
+}
+
+.listItem:hover {
+  background: var(--bg-secondary);
+}
+
+.listItem:focus-visible {
+  outline: dashed 2px;
+  outline-offset: 2px;
+}
+
+.listItemActive {
+  background: var(--glass-dark);
+  border-color: rgba(0, 0, 0, 0.12);
+}
+
+.itemCode {
+  font-family: 'Geist Mono', monospace;
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  letter-spacing: 0;
+  margin-bottom: 3px;
+}
+
+.itemName {
+  font-size: 0.87rem;
+  font-weight: 500;
+  letter-spacing: -0.1px;
+  color: var(--text-primary);
+  margin-bottom: 6px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.itemBadges {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.badge {
+  font-size: 0.68rem;
+  font-family: 'Geist Mono', monospace;
+  padding: 2px 7px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--text-primary);
+  color: var(--text-primary);
+  letter-spacing: 0;
+  background: var(--bg-color);
+}
+
+.badgeMuted {
+  border-color: var(--text-muted);
+  color: var(--text-muted);
+}
+
+.skeleton {
+  padding: 4px;
+}
+
+.skeletonItem {
+  height: 70px;
+  border-radius: var(--radius-md);
+  background: var(--glass-dark);
+  margin-bottom: 6px;
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+.errorState,
+.emptyState {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 48px 20px;
+  text-align: center;
+  height: 100%;
+}
+
+.errorIcon,
+.emptyIcon {
+  color: var(--text-muted);
+  margin-bottom: 12px;
+}
+
+.errorText,
+.emptyText {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  letter-spacing: normal;
+}
+
+@media (max-width: 1023px) {
+  .panel {
+    width: 280px;
+    min-width: 280px;
+  }
+}
+
+@media (max-width: 767px) {
+  .panel {
+    width: 100%;
+    min-width: unset;
+    border-right: none;
+    border-bottom: 1px solid var(--glass-border);
+    max-height: 50vh;
+  }
+}

--- a/frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.tsx
@@ -1,0 +1,48 @@
+import { useParams, useNavigate } from 'react-router-dom';
+import { DashboardLayout } from '../../../shared/ui/layout/DashboardLayout';
+import { WorkflowListPanel } from '../../../features/workflow-draft-read/ui/WorkflowListPanel';
+import { WorkflowDetailPanel } from '../../../features/workflow-draft-read/ui/WorkflowDetailPanel';
+import { parseRouteId } from '../../../shared/lib/parseRouteId';
+import styles from './workflow-draft-read-page.module.css';
+
+export function WorkflowDraftReadPage() {
+  const { workspaceId, packId, versionId, workflowId } = useParams();
+  const navigate = useNavigate();
+
+  const wsId = parseRouteId(workspaceId);
+  const pId = parseRouteId(packId);
+  const vId = parseRouteId(versionId);
+  const wfId = workflowId ? parseRouteId(workflowId) : null;
+
+  if (wsId === null || pId === null || vId === null) {
+    return (
+      <DashboardLayout>
+        <div className={styles.invalidParams}>잘못된 URL 파라미터입니다.</div>
+      </DashboardLayout>
+    );
+  }
+
+  const handleSelect = (id: number) => {
+    navigate(`/workspaces/${wsId}/domain-packs/${pId}/versions/${vId}/workflows/${id}`);
+  };
+
+  return (
+    <DashboardLayout>
+      <div className={styles.twoPane}>
+        <WorkflowListPanel
+          wsId={wsId}
+          packId={pId}
+          versionId={vId}
+          selectedId={wfId}
+          onSelect={handleSelect}
+        />
+        <WorkflowDetailPanel
+          wsId={wsId}
+          packId={pId}
+          versionId={vId}
+          workflowId={wfId}
+        />
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.tsx
@@ -2,6 +2,8 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { DashboardLayout } from '../../../shared/ui/layout/DashboardLayout';
 import { WorkflowListPanel } from '../../../features/workflow-draft-read/ui/WorkflowListPanel';
 import { WorkflowDetailPanel } from '../../../features/workflow-draft-read/ui/WorkflowDetailPanel';
+import { ErrorBoundary } from '../../../shared/ui/ErrorBoundary';
+import { PageHeader } from '../../../shared/ui/layout/PageHeader';
 import { parseRouteId } from '../../../shared/lib/parseRouteId';
 import styles from './workflow-draft-read-page.module.css';
 
@@ -29,31 +31,24 @@ export function WorkflowDraftReadPage() {
   return (
     <DashboardLayout>
       <div className={styles.pageWrapper}>
-        <header className={styles.pageHeader}>
-          <nav className={styles.breadcrumb}>
-            <span>워크스페이스 {wsId}</span>
-            <span className={styles.breadcrumbSep}>/</span>
-            <span>팩 {pId}</span>
-            <span className={styles.breadcrumbSep}>/</span>
-            <span>버전 {vId}</span>
-          </nav>
-          <span className={styles.versionBadge}>v{vId}</span>
-        </header>
-        <div className={styles.twoPane}>
-          <WorkflowListPanel
-            wsId={wsId}
-            packId={pId}
-            versionId={vId}
-            selectedId={wfId}
-            onSelect={handleSelect}
-          />
-          <WorkflowDetailPanel
-            wsId={wsId}
-            packId={pId}
-            versionId={vId}
-            workflowId={wfId}
-          />
-        </div>
+        <PageHeader wsId={wsId} pId={pId} vId={vId} />
+        <ErrorBoundary>
+          <div className={styles.twoPane}>
+            <WorkflowListPanel
+              wsId={wsId}
+              packId={pId}
+              versionId={vId}
+              selectedId={wfId}
+              onSelect={handleSelect}
+            />
+            <WorkflowDetailPanel
+              wsId={wsId}
+              packId={pId}
+              versionId={vId}
+              workflowId={wfId}
+            />
+          </div>
+        </ErrorBoundary>
       </div>
     </DashboardLayout>
   );

--- a/frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.tsx
@@ -14,7 +14,7 @@ export function WorkflowDraftReadPage() {
   const vId = parseRouteId(versionId);
   const wfId = workflowId ? parseRouteId(workflowId) : null;
 
-  if (wsId === null || pId === null || vId === null) {
+  if (wsId === null || pId === null || vId === null || (workflowId !== undefined && wfId === null)) {
     return (
       <DashboardLayout>
         <div className={styles.invalidParams}>잘못된 URL 파라미터입니다.</div>

--- a/frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.tsx
@@ -28,20 +28,32 @@ export function WorkflowDraftReadPage() {
 
   return (
     <DashboardLayout>
-      <div className={styles.twoPane}>
-        <WorkflowListPanel
-          wsId={wsId}
-          packId={pId}
-          versionId={vId}
-          selectedId={wfId}
-          onSelect={handleSelect}
-        />
-        <WorkflowDetailPanel
-          wsId={wsId}
-          packId={pId}
-          versionId={vId}
-          workflowId={wfId}
-        />
+      <div className={styles.pageWrapper}>
+        <header className={styles.pageHeader}>
+          <nav className={styles.breadcrumb}>
+            <span>워크스페이스 {wsId}</span>
+            <span className={styles.breadcrumbSep}>/</span>
+            <span>팩 {pId}</span>
+            <span className={styles.breadcrumbSep}>/</span>
+            <span>버전 {vId}</span>
+          </nav>
+          <span className={styles.versionBadge}>v{vId}</span>
+        </header>
+        <div className={styles.twoPane}>
+          <WorkflowListPanel
+            wsId={wsId}
+            packId={pId}
+            versionId={vId}
+            selectedId={wfId}
+            onSelect={handleSelect}
+          />
+          <WorkflowDetailPanel
+            wsId={wsId}
+            packId={pId}
+            versionId={vId}
+            workflowId={wfId}
+          />
+        </div>
       </div>
     </DashboardLayout>
   );

--- a/frontend/src/pages/domain-pack/ui/workflow-draft-read-page.module.css
+++ b/frontend/src/pages/domain-pack/ui/workflow-draft-read-page.module.css
@@ -1,0 +1,22 @@
+.twoPane {
+  display: flex;
+  flex-direction: row;
+  height: 100%;
+  overflow: hidden;
+  width: 100%;
+}
+
+.invalidParams {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+@media (max-width: 767px) {
+  .twoPane {
+    flex-direction: column;
+  }
+}

--- a/frontend/src/pages/domain-pack/ui/workflow-draft-read-page.module.css
+++ b/frontend/src/pages/domain-pack/ui/workflow-draft-read-page.module.css
@@ -4,36 +4,6 @@
   height: 100%;
 }
 
-.pageHeader {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 12px 20px;
-  border-bottom: 1px solid var(--glass-border);
-  flex-shrink: 0;
-}
-
-.breadcrumb {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  font-size: 0.8rem;
-  color: var(--text-secondary);
-}
-
-.breadcrumbSep {
-  color: var(--text-muted);
-}
-
-.versionBadge {
-  font-family: 'Geist Mono', monospace;
-  font-size: 0.72rem;
-  padding: 2px 8px;
-  border-radius: var(--radius-sm);
-  border: 1px solid var(--text-muted);
-  color: var(--text-muted);
-}
-
 .twoPane {
   display: flex;
   flex-direction: row;

--- a/frontend/src/pages/domain-pack/ui/workflow-draft-read-page.module.css
+++ b/frontend/src/pages/domain-pack/ui/workflow-draft-read-page.module.css
@@ -1,7 +1,43 @@
+.pageWrapper {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.pageHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 20px;
+  border-bottom: 1px solid var(--glass-border);
+  flex-shrink: 0;
+}
+
+.breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}
+
+.breadcrumbSep {
+  color: var(--text-muted);
+}
+
+.versionBadge {
+  font-family: 'Geist Mono', monospace;
+  font-size: 0.72rem;
+  padding: 2px 8px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--text-muted);
+  color: var(--text-muted);
+}
+
 .twoPane {
   display: flex;
   flex-direction: row;
-  height: 100%;
+  flex: 1;
   overflow: hidden;
   width: 100%;
 }

--- a/frontend/src/shared/lib/parseRouteId.ts
+++ b/frontend/src/shared/lib/parseRouteId.ts
@@ -1,5 +1,6 @@
 export function parseRouteId(id: string | undefined): number | null {
   if (id === undefined) return null;
+  if (!/^[1-9]\d*$/.test(id)) return null;
   const n = Number(id);
-  return Number.isNaN(n) ? null : n;
+  return Number.isSafeInteger(n) ? n : null;
 }

--- a/frontend/src/shared/lib/parseRouteId.ts
+++ b/frontend/src/shared/lib/parseRouteId.ts
@@ -1,0 +1,5 @@
+export function parseRouteId(id: string | undefined): number | null {
+  if (id === undefined) return null;
+  const n = Number(id);
+  return Number.isNaN(n) ? null : n;
+}

--- a/frontend/src/shared/ui/ErrorBoundary.tsx
+++ b/frontend/src/shared/ui/ErrorBoundary.tsx
@@ -3,20 +3,29 @@ import { Component, type ErrorInfo, type ReactNode } from 'react';
 interface Props {
   children: ReactNode;
   fallback?: ReactNode;
+  resetKeys?: unknown[];
 }
 
 interface State {
   hasError: boolean;
+  prevResetKeys?: unknown[];
 }
 
 export class ErrorBoundary extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
-    this.state = { hasError: false };
+    this.state = { hasError: false, prevResetKeys: props.resetKeys };
   }
 
   static getDerivedStateFromError(): State {
     return { hasError: true };
+  }
+
+  static getDerivedStateFromProps(props: Props, state: State): Partial<State> | null {
+    if (state.hasError && props.resetKeys !== state.prevResetKeys) {
+      return { hasError: false, prevResetKeys: props.resetKeys };
+    }
+    return null;
   }
 
   componentDidCatch(error: Error, info: ErrorInfo) {

--- a/frontend/src/shared/ui/ErrorBoundary.tsx
+++ b/frontend/src/shared/ui/ErrorBoundary.tsx
@@ -1,0 +1,45 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+
+interface Props {
+  children: ReactNode;
+  fallback?: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error('[ErrorBoundary]', error, info.componentStack);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        this.props.fallback ?? (
+          <div
+            style={{
+              padding: '32px',
+              textAlign: 'center',
+              fontSize: '0.9rem',
+              color: 'var(--text-secondary)',
+            }}
+          >
+            오류가 발생했습니다. 페이지를 새로고침해 주세요.
+          </div>
+        )
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/frontend/src/shared/ui/layout/PageHeader.tsx
+++ b/frontend/src/shared/ui/layout/PageHeader.tsx
@@ -9,12 +9,12 @@ interface PageHeaderProps {
 export function PageHeader({ wsId, pId, vId }: PageHeaderProps) {
   return (
     <header className={styles.pageHeader}>
-      <nav className={styles.breadcrumb}>
+      <nav className={styles.breadcrumb} aria-label="breadcrumb">
         <span>워크스페이스 {wsId}</span>
         <span className={styles.breadcrumbSep}>/</span>
         <span>팩 {pId}</span>
         <span className={styles.breadcrumbSep}>/</span>
-        <span>버전 {vId}</span>
+        <span aria-current="page">버전 {vId}</span>
       </nav>
       <span className={styles.versionBadge}>v{vId}</span>
     </header>

--- a/frontend/src/shared/ui/layout/PageHeader.tsx
+++ b/frontend/src/shared/ui/layout/PageHeader.tsx
@@ -1,0 +1,22 @@
+import styles from './page-header.module.css';
+
+interface PageHeaderProps {
+  wsId: number;
+  pId: number;
+  vId: number;
+}
+
+export function PageHeader({ wsId, pId, vId }: PageHeaderProps) {
+  return (
+    <header className={styles.pageHeader}>
+      <nav className={styles.breadcrumb}>
+        <span>워크스페이스 {wsId}</span>
+        <span className={styles.breadcrumbSep}>/</span>
+        <span>팩 {pId}</span>
+        <span className={styles.breadcrumbSep}>/</span>
+        <span>버전 {vId}</span>
+      </nav>
+      <span className={styles.versionBadge}>v{vId}</span>
+    </header>
+  );
+}

--- a/frontend/src/shared/ui/layout/page-header.module.css
+++ b/frontend/src/shared/ui/layout/page-header.module.css
@@ -1,0 +1,29 @@
+.pageHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 20px;
+  border-bottom: 1px solid var(--glass-border);
+  flex-shrink: 0;
+}
+
+.breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}
+
+.breadcrumbSep {
+  color: var(--text-muted);
+}
+
+.versionBadge {
+  font-family: 'Geist Mono', monospace;
+  font-size: 0.72rem;
+  padding: 2px 8px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--text-muted);
+  color: var(--text-muted);
+}


### PR DESCRIPTION
## Summary

운영자 콘솔에 Workflow 초안 목록 + 단건 상세(graphJson 시각화 포함)를 보여주는 two-pane 화면을 추가했다. 초기 구현 후 감사에서 발견된 7개 위반 항목(Critical 1, Warning 4, Info 2)을 전부 수정하여 최종 완료했다.

---

## Context

- **Spec**: `.agent/specs/227.md` (FE-227 — Console Workflow 구성요소 초안 조회)
- **Depends on**: spec/226 BE 읽기 API, `ebb9304` 디자인 시스템 반영 커밋
- **BE 변경 없음**: spec/226에서 구현된 엔드포인트만 소비

---

## What Changed

**신규 파일 (주요)**

| 레이어 | 파일 |
|--------|------|
| entities | `entities/workflow/model/types.ts` — WorkflowSummary, WorkflowDetail, WorkflowGraph, GraphNode, GraphEdge 타입 |
| features/model | `useWorkflowList.ts`, `useWorkflowDetail.ts`, `parseTerminalStates.ts` |
| features/api | `workflowApi.ts` — list / detail |
| features/ui | `GraphRenderer.tsx` (default export, React.lazy 호환), `graphMapper.ts`, `WorkflowListPanel.tsx`, `WorkflowDetailPanel.tsx`, `nodes/` 커스텀 노드 6종 |
| pages | `WorkflowDraftReadPage.tsx` — DashboardLayout + two-pane + 인라인 PageHeader/Breadcrumb |
| shared | `shared/lib/parseRouteId.ts` |
| tests | `parseTerminalStates.test.ts` (4건), `useWorkflowList.test.ts` (5건), `useWorkflowDetail.test.ts` (5건) — 14건 전원 통과 |

**수정 파일**

- `app/App.tsx`: 두 route 등록 (`/workflows`, `/workflows/:workflowId`) + `<Toaster position="top-right" richColors />` 추가
- `package.json`: `@xyflow/react 12.10.2` 추가

**핵심 동작**

- 좌측: workflow 목록(loading/empty/error 3상태), 클릭 시 URL `workflowId` push
- 우측: 상세 패널 Graph / JSON / Meta 탭 전환. GraphRenderer는 React.lazy + Suspense 코드 스플리팅
- 커스텀 노드 6종: start(stadium) / action(rect) / decision(diamond rotate) / answer(asymmetric) / handoff(trapezoid) / terminal(circle)
- 탭 전환 시 API 재요청 없음. workflowId가 null이면 PlaceholderState 표시

---

## Assumptions Adopted

| ID | 채택 내용 | 영향 |
|----|-----------|------|
| U-FE-2 | 상위 탐색 UI 미포함. URL 직접 진입만 가능 | QA/시연 시 URL 직접 입력 필요. 상위 탐색은 별도 백로그 |
| U-FE-4 | 모바일 `<768px`: column 레이아웃, "← 목록" 버튼 없음. 스크롤/뒤로가기로 복귀 | 모바일 UX 명시성 다소 낮음. Drawer 방식은 후속 개선 가능 |
| U-FE-5 | BE `message` 필드 기본 표시. `UNKNOWN_ERROR`만 FE 카피 오버라이드. `WORKFLOW_DEFINITION_NOT_FOUND`에 FE 오버라이드 카피 적용 | BE 에러 메시지가 사용자 노출에 부적합한 내용을 포함할 경우 UX 저하 가능 |

---

## Spec Deviations

감사 전 구현에서 아래 두 항목이 누락되었으나, 감사 수정 커밋(`1c92351`)에서 모두 복원되었다. 최종 코드 기준으로 스펙 일탈 없음.

- **PageHeader/Breadcrumb/VersionMetaStrip 미구현 → 수정**: `WorkflowDraftReadPage.tsx`에 path param 기반 인라인 PageHeader(breadcrumb + versionBadge) 추가
- **evidenceJson/metaJson 파싱 실패 시 `console.warn` 누락 → 수정**: `tryParseJson` catch 블록에 추가

---

## Blocked / Skipped Items

| 항목 | 사유 |
|------|------|
| dagre 레이아웃 | spec이 grid까지만 포함, dagre는 "판단 시점에 후속 결정" 명시 (spec/227.md:205) |
| 모바일 "← 목록" 버튼 | U-FE-4 Assumption A 채택. 스크롤/뒤로가기로 대체 |
| `shared/lib/index.ts` parseRouteId export | spec에 명시 없음, 호출처에서 직접 import (YAGNI) |
| Graph 노드 클릭 드로어 | spec Out of Scope |
| 상위 탐색 UI | spec Out of Scope (별도 백로그) |

---

## Test Notes

초기 구현에 테스트 파일이 없었으며(V-002 감사 위반), 감사 수정 커밋에서 아래 3개 파일을 추가했다.

| 파일 | 케이스 수 | 결과 |
|------|----------|------|
| `parseTerminalStates.test.ts` | 4 | 전원 통과 |
| `useWorkflowList.test.ts` | 5 (loading/error/ready/빈배열/cancel) | 전원 통과 |
| `useWorkflowDetail.test.ts` | 5 (idle/loading/ready/error-404/cancel) | 전원 통과 |

E2E(Playwright) 및 컴포넌트 테스트(testing-library)는 미구현 상태. 수동 테스트(`pnpm dev`)로 골든 패스 확인 완료.

---

## Reviewer Focus

1. **`graphMapper.ts:toFlow()`** — grid 레이아웃 단순성. 복잡한 topology에서 가독성 저하 가능. dagre 교체 시 이 함수만 수정하면 됨
2. **커스텀 노드 CSS** (`nodes.module.css`) — DECISION(rotate 45deg), ANSWER/HANDOFF(clip-path) 형태 근사. Handle이 clip-path 바깥으로 벗어날 수 있음
3. **`WorkflowDetailPanel.tsx` toast useEffect** — `[detailState.status]`만 deps. 동일 `status='error'`에서 code/message만 바뀌는 경우 toast 재발화 안 됨. discriminated-union 불변성 주석으로 사유 명시함
4. **`useWorkflowDetail.ts`** — `workflowId === null` 전환 시 `setState({ status: 'idle' })` 동기 호출(eslint-disable). 정상 동작 확인했으나 리뷰어 눈으로 한 번 더 확인 권장
5. **U-FE-2 진입 경로** — 현재 URL 직접 입력만 가능. 내비게이션 sidebar에서 이 화면으로 도달할 수 없음

---

## Conflicts

없음. 모든 감사 위반 항목이 수정되었으며 unresolved 항목 없음.

---

## Ready to Merge / Needs Input

**Ready to Merge** — 감사 위반 7건 전원 수정 완료, 14개 단위 테스트 통과, spec 일탈 없음.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 워크플로우 초안 읽기 페이지 추가: 목록/상세 패널, 그래프 뷰어, 그래프/JSON/메타 탭, 노드 유형 표시 및 키보드 내비게이션
  * 전역 알림(상단 우측) 및 에러 경계, 페이지 헤더 등 UI 구성요소 추가
* **테스트**
  * 단말 상태 파싱 유닛 테스트 및 워크플로우 목록/상세 훅 동작 검증 테스트 추가
* **작업(Chore)**
  * 프런트엔드 의존성에 그래프 라이브러리 추가 및 패키지 선언 정리 반영
<!-- end of auto-generated comment: release notes by coderabbit.ai -->