### PR TITLE
feat(frontend): add workflow draft list & detail read page (FE-227)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "@base-ui/react": "^1.3.0",
     "@hookform/resolvers": "^5.2.2",
     "@tailwindcss/vite": "^4.2.2",
+    "@xyflow/react": "^12.10.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
@@ -40,7 +41,6 @@
   "devDependencies": {
     "@eslint/js": "^9.39.4",
     "@playwright/test": "^1.59.1",
-    "vitest": "^3.0.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@types/node": "^24.12.0",
@@ -56,7 +56,8 @@
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.57.0",
     "vite": "catalog:",
-    "vite-plus": "catalog:"
+    "vite-plus": "catalog:",
+    "vitest": "^3.0.0"
   },
   "packageManager": "pnpm@10.33.0"
 }

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(@voidzero-dev/vite-plus-core@0.1.15(@types/node@24.12.0)(jiti@2.6.1)(typescript@5.9.3))
+      '@xyflow/react':
+        specifier: ^12.10.2
+        version: 12.10.2(@types/react@19.2.14)(immer@11.1.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -1564,6 +1567,9 @@ packages:
   '@types/d3-color@3.1.3':
     resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
 
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
   '@types/d3-ease@3.0.2':
     resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
 
@@ -1576,6 +1582,9 @@ packages:
   '@types/d3-scale@4.0.9':
     resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
 
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
   '@types/d3-shape@3.1.8':
     resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
 
@@ -1584,6 +1593,12 @@ packages:
 
   '@types/d3-timer@3.0.2':
     resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
@@ -1877,6 +1892,15 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@xyflow/react@12.10.2':
+    resolution: {integrity: sha512-CgIi6HwlcHXwlkTpr0fxLv/0sRVNZ8IdwKLzzeCscaYBwpvfcH1QFOCeaTCuEn1FQEs/B8CjnTSjhs8udgmBgQ==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+
+  '@xyflow/system@0.0.76':
+    resolution: {integrity: sha512-hvwvnRS1B3REwVDlWexsq7YQaPZeG3/mKo1jv38UmnpWmxihp14bW6VtEOuHEwJX2FvzFw8k77LyKSk/wiZVNA==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1957,6 +1981,9 @@ packages:
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
+  classcat@5.0.5:
+    resolution: {integrity: sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==}
+
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
@@ -2002,6 +2029,14 @@ packages:
     resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
     engines: {node: '>=12'}
 
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
   d3-ease@3.0.1:
     resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
     engines: {node: '>=12'}
@@ -2022,6 +2057,10 @@ packages:
     resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
     engines: {node: '>=12'}
 
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
   d3-shape@3.2.0:
     resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
     engines: {node: '>=12'}
@@ -2036,6 +2075,16 @@ packages:
 
   d3-timer@3.0.1:
     resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
     engines: {node: '>=12'}
 
   data-urls@7.0.0:
@@ -2959,6 +3008,21 @@ packages:
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+  zustand@4.5.7:
+    resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      '@types/react': '>=16.8'
+      immer: '>=9.0.6'
+      react: '>=16.8'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
 
 snapshots:
 
@@ -4278,6 +4342,10 @@ snapshots:
 
   '@types/d3-color@3.1.3': {}
 
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
   '@types/d3-ease@3.0.2': {}
 
   '@types/d3-interpolate@3.0.4':
@@ -4290,6 +4358,8 @@ snapshots:
     dependencies:
       '@types/d3-time': 3.0.4
 
+  '@types/d3-selection@3.0.11': {}
+
   '@types/d3-shape@3.1.8':
     dependencies:
       '@types/d3-path': 3.1.1
@@ -4297,6 +4367,15 @@ snapshots:
   '@types/d3-time@3.0.4': {}
 
   '@types/d3-timer@3.0.2': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
 
   '@types/deep-eql@4.0.2': {}
 
@@ -4502,6 +4581,29 @@ snapshots:
   '@voidzero-dev/vite-plus-win32-x64-msvc@0.1.16':
     optional: true
 
+  '@xyflow/react@12.10.2(@types/react@19.2.14)(immer@11.1.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@xyflow/system': 0.0.76
+      classcat: 5.0.5
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      zustand: 4.5.7(@types/react@19.2.14)(immer@11.1.4)(react@19.2.4)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+
+  '@xyflow/system@0.0.76':
+    dependencies:
+      '@types/d3-drag': 3.0.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-zoom: 3.0.0
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -4575,6 +4677,8 @@ snapshots:
     dependencies:
       clsx: 2.1.1
 
+  classcat@5.0.5: {}
+
   clsx@2.1.1: {}
 
   cmdk@1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
@@ -4620,6 +4724,13 @@ snapshots:
 
   d3-color@3.1.0: {}
 
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
   d3-ease@3.0.1: {}
 
   d3-format@3.1.2: {}
@@ -4638,6 +4749,8 @@ snapshots:
       d3-time: 3.1.0
       d3-time-format: 4.1.0
 
+  d3-selection@3.0.0: {}
+
   d3-shape@3.2.0:
     dependencies:
       d3-path: 3.1.0
@@ -4651,6 +4764,23 @@ snapshots:
       d3-array: 3.2.4
 
   d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   data-urls@7.0.0:
     dependencies:
@@ -5583,3 +5713,11 @@ snapshots:
       zod: 4.3.6
 
   zod@4.3.6: {}
+
+  zustand@4.5.7(@types/react@19.2.14)(immer@11.1.4)(react@19.2.4):
+    dependencies:
+      use-sync-external-store: 1.6.0(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      immer: 11.1.4
+      react: 19.2.4

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -6,6 +6,7 @@ import { PasswordResetInitPage } from '../pages/password-reset/ui/PasswordResetI
 import { PasswordResetCompletePage } from '../pages/password-reset/ui/PasswordResetCompletePage';
 import { ConsultationPage } from '../pages/consultation/ui/ConsultationPage';
 import { NotFoundPage } from '../pages/not-found/ui/NotFoundPage';
+import { WorkflowDraftReadPage } from '../pages/domain-pack/ui/WorkflowDraftReadPage';
 import { PrivateRoute } from '../shared/ui/PrivateRoute';
 
 export function App() {
@@ -19,6 +20,8 @@ export function App() {
         <Route path="/reset-password/complete" element={<PasswordResetCompletePage />} />
         <Route path="/upload" element={<PrivateRoute><UploadPage /></PrivateRoute>} />
         <Route path="/consultation" element={<PrivateRoute><ConsultationPage /></PrivateRoute>} />
+        <Route path="/workspaces/:workspaceId/domain-packs/:packId/versions/:versionId/workflows" element={<PrivateRoute><WorkflowDraftReadPage /></PrivateRoute>} />
+        <Route path="/workspaces/:workspaceId/domain-packs/:packId/versions/:versionId/workflows/:workflowId" element={<PrivateRoute><WorkflowDraftReadPage /></PrivateRoute>} />
         <Route path="*" element={<NotFoundPage />} />
       </Routes>
     </BrowserRouter>

--- a/frontend/src/entities/workflow/index.ts
+++ b/frontend/src/entities/workflow/index.ts
@@ -1,0 +1,8 @@
+export type {
+  WorkflowSummary,
+  WorkflowDetail,
+  WorkflowGraph,
+  GraphNode,
+  GraphEdge,
+  GraphNodeType,
+} from "./model/types";

--- a/frontend/src/entities/workflow/model/types.ts
+++ b/frontend/src/entities/workflow/model/types.ts
@@ -34,7 +34,7 @@ export interface WorkflowDetail {
   workflowCode: string;
   name: string;
   description: string | null;
-  graphJson: WorkflowGraph;
+  graph: WorkflowGraph;
   initialState: string | null;
   terminalStatesJson: string;
   evidenceJson: string;

--- a/frontend/src/entities/workflow/model/types.ts
+++ b/frontend/src/entities/workflow/model/types.ts
@@ -1,0 +1,44 @@
+export interface WorkflowSummary {
+  id: number;
+  workflowCode: string;
+  name: string;
+  description: string | null;
+  initialState: string | null;
+  terminalStatesJson: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type GraphNodeType = "START" | "ACTION" | "DECISION" | "ANSWER" | "HANDOFF" | "TERMINAL";
+
+export interface GraphNode {
+  id: string;
+  label: string;
+  type: GraphNodeType;
+}
+
+export interface GraphEdge {
+  from: string;
+  to: string;
+  label?: string;
+}
+
+export interface WorkflowGraph {
+  direction: "LR" | "TB";
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+}
+
+export interface WorkflowDetail {
+  id: number;
+  workflowCode: string;
+  name: string;
+  description: string | null;
+  graphJson: WorkflowGraph;
+  initialState: string | null;
+  terminalStatesJson: string;
+  evidenceJson: string;
+  metaJson: string;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/frontend/src/features/workflow-draft-read/api/workflowApi.ts
+++ b/frontend/src/features/workflow-draft-read/api/workflowApi.ts
@@ -1,0 +1,14 @@
+import { apiClient } from "../../../shared/api";
+import type { WorkflowDetail, WorkflowSummary } from "../../../entities/workflow";
+
+export const workflowApi = {
+  list: (wsId: number, packId: number, versionId: number) =>
+    apiClient.get<WorkflowSummary[]>(
+      `/workspaces/${wsId}/domain-packs/${packId}/versions/${versionId}/workflows`,
+    ),
+
+  detail: (wsId: number, packId: number, versionId: number, workflowId: number) =>
+    apiClient.get<WorkflowDetail>(
+      `/workspaces/${wsId}/domain-packs/${packId}/versions/${versionId}/workflows/${workflowId}`,
+    ),
+};

--- a/frontend/src/features/workflow-draft-read/model/mapApiError.ts
+++ b/frontend/src/features/workflow-draft-read/model/mapApiError.ts
@@ -1,0 +1,13 @@
+import { ApiRequestError } from "../../../shared/api";
+
+export function mapApiError(e: unknown): {
+  status: "error";
+  code: string;
+  message: string;
+  httpStatus?: number;
+} {
+  if (e instanceof ApiRequestError) {
+    return { status: "error", code: e.code, message: e.message, httpStatus: e.status };
+  }
+  return { status: "error", code: "UNKNOWN_ERROR", message: "알 수 없는 오류가 발생했습니다." };
+}

--- a/frontend/src/features/workflow-draft-read/model/parseTerminalStates.test.ts
+++ b/frontend/src/features/workflow-draft-read/model/parseTerminalStates.test.ts
@@ -14,29 +14,30 @@ describe("parseTerminalStates", () => {
 
   it("문자열로 직렬화된 배열을 string[]로 파싱한다", () => {
     const raw = '["terminal","cancelled"]';
-    expect(parseTerminalStates(raw)).toEqual(["terminal", "cancelled"]);
+    const result = parseTerminalStates(raw);
+    expect(result).toEqual({ ok: true, value: ["terminal", "cancelled"] });
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
   it("빈 배열 문자열을 빈 배열로 파싱한다", () => {
-    expect(parseTerminalStates("[]")).toEqual([]);
+    expect(parseTerminalStates("[]")).toEqual({ ok: true, value: [] });
   });
 
-  it("JSON 파싱에 실패하면 raw 문자열을 반환하고 경고를 남긴다", () => {
+  it("JSON 파싱에 실패하면 ok:false와 raw를 반환하고 경고를 남긴다", () => {
     const broken = "[terminal";
-    expect(parseTerminalStates(broken)).toBe(broken);
+    expect(parseTerminalStates(broken)).toEqual({ ok: false, raw: broken });
     expect(warnSpy).toHaveBeenCalled();
   });
 
-  it("결과가 배열이 아니면 raw 문자열을 반환한다", () => {
+  it("결과가 배열이 아니면 ok:false와 raw를 반환한다", () => {
     const notArray = '{"foo":"bar"}';
-    expect(parseTerminalStates(notArray)).toBe(notArray);
+    expect(parseTerminalStates(notArray)).toEqual({ ok: false, raw: notArray });
     expect(warnSpy).toHaveBeenCalled();
   });
 
-  it("결과가 문자열 아닌 값의 배열이면 raw를 반환한다", () => {
+  it("결과가 문자열 아닌 값의 배열이면 ok:false와 raw를 반환한다", () => {
     const mixed = "[1,2,3]";
-    expect(parseTerminalStates(mixed)).toBe(mixed);
+    expect(parseTerminalStates(mixed)).toEqual({ ok: false, raw: mixed });
     expect(warnSpy).toHaveBeenCalled();
   });
 });

--- a/frontend/src/features/workflow-draft-read/model/parseTerminalStates.test.ts
+++ b/frontend/src/features/workflow-draft-read/model/parseTerminalStates.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { parseTerminalStates } from "./parseTerminalStates";
+
+describe("parseTerminalStates", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("문자열로 직렬화된 배열을 string[]로 파싱한다", () => {
+    const raw = '["terminal","cancelled"]';
+    expect(parseTerminalStates(raw)).toEqual(["terminal", "cancelled"]);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("빈 배열 문자열을 빈 배열로 파싱한다", () => {
+    expect(parseTerminalStates("[]")).toEqual([]);
+  });
+
+  it("JSON 파싱에 실패하면 raw 문자열을 반환하고 경고를 남긴다", () => {
+    const broken = "[terminal";
+    expect(parseTerminalStates(broken)).toBe(broken);
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it("결과가 배열이 아니면 raw 문자열을 반환한다", () => {
+    const notArray = '{"foo":"bar"}';
+    expect(parseTerminalStates(notArray)).toBe(notArray);
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it("결과가 문자열 아닌 값의 배열이면 raw를 반환한다", () => {
+    const mixed = "[1,2,3]";
+    expect(parseTerminalStates(mixed)).toBe(mixed);
+    expect(warnSpy).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/features/workflow-draft-read/model/parseTerminalStates.ts
+++ b/frontend/src/features/workflow-draft-read/model/parseTerminalStates.ts
@@ -1,13 +1,15 @@
-export function parseTerminalStates(json: string): string[] | string {
+export type ParseTerminalStatesResult = { ok: true; value: string[] } | { ok: false; raw: string };
+
+export function parseTerminalStates(json: string): ParseTerminalStatesResult {
   try {
     const parsed: unknown = JSON.parse(json);
     if (Array.isArray(parsed) && parsed.every((v) => typeof v === "string")) {
-      return parsed as string[];
+      return { ok: true, value: parsed as string[] };
     }
     console.warn("[parseTerminalStates] 파싱 결과가 string[]가 아닙니다. raw 반환:", json);
-    return json;
+    return { ok: false, raw: json };
   } catch (e) {
     console.warn("[parseTerminalStates] JSON 파싱 실패. raw 반환:", json, e);
-    return json;
+    return { ok: false, raw: json };
   }
 }

--- a/frontend/src/features/workflow-draft-read/model/parseTerminalStates.ts
+++ b/frontend/src/features/workflow-draft-read/model/parseTerminalStates.ts
@@ -1,0 +1,13 @@
+export function parseTerminalStates(json: string): string[] | string {
+  try {
+    const parsed: unknown = JSON.parse(json);
+    if (Array.isArray(parsed) && parsed.every((v) => typeof v === "string")) {
+      return parsed as string[];
+    }
+    console.warn("[parseTerminalStates] 파싱 결과가 string[]가 아닙니다. raw 반환:", json);
+    return json;
+  } catch (e) {
+    console.warn("[parseTerminalStates] JSON 파싱 실패. raw 반환:", json, e);
+    return json;
+  }
+}

--- a/frontend/src/features/workflow-draft-read/model/useWorkflowDetail.test.ts
+++ b/frontend/src/features/workflow-draft-read/model/useWorkflowDetail.test.ts
@@ -1,0 +1,74 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useWorkflowDetail } from "./useWorkflowDetail";
+import { ApiRequestError } from "../../../shared/api";
+
+vi.mock("../api/workflowApi", () => ({
+  workflowApi: {
+    list: vi.fn(),
+    detail: vi.fn(),
+  },
+}));
+
+import { workflowApi } from "../api/workflowApi";
+
+const mockedDetail = vi.mocked(workflowApi.detail);
+
+const stubDetail = {
+  id: 10,
+  workflowCode: "W001",
+  name: "테스트",
+  description: null,
+  graphJson: { direction: "LR" as const, nodes: [], edges: [] },
+  initialState: null,
+  terminalStatesJson: "[]",
+  evidenceJson: "{}",
+  metaJson: "{}",
+  createdAt: "",
+  updatedAt: "",
+};
+
+describe("useWorkflowDetail", () => {
+  beforeEach(() => {
+    mockedDetail.mockReset();
+  });
+
+  it("workflowId가 null이면 idle 상태다", () => {
+    const { result } = renderHook(() => useWorkflowDetail(1, 2, 3, null));
+    expect(result.current.status).toBe("idle");
+  });
+
+  it("workflowId가 주어지면 loading 상태로 시작한다", () => {
+    mockedDetail.mockReturnValue(new Promise(() => {}));
+    const { result } = renderHook(() => useWorkflowDetail(1, 2, 3, 10));
+    expect(result.current.status).toBe("loading");
+  });
+
+  it("성공 시 ready 상태로 전이된다", async () => {
+    mockedDetail.mockResolvedValue(stubDetail);
+    const { result } = renderHook(() => useWorkflowDetail(1, 2, 3, 10));
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+    if (result.current.status === "ready") {
+      expect(result.current.data).toEqual(stubDetail);
+    }
+  });
+
+  it("404 에러 시 httpStatus 404를 포함한 error 상태가 된다", async () => {
+    mockedDetail.mockRejectedValue(new ApiRequestError(404, "NOT_FOUND", "없음"));
+    const { result } = renderHook(() => useWorkflowDetail(1, 2, 3, 99));
+    await waitFor(() => expect(result.current.status).toBe("error"));
+    if (result.current.status === "error") {
+      expect(result.current.httpStatus).toBe(404);
+      expect(result.current.code).toBe("NOT_FOUND");
+    }
+  });
+
+  it("알 수 없는 오류 시 UNKNOWN_ERROR 코드가 된다", async () => {
+    mockedDetail.mockRejectedValue(new Error("unexpected"));
+    const { result } = renderHook(() => useWorkflowDetail(1, 2, 3, 5));
+    await waitFor(() => expect(result.current.status).toBe("error"));
+    if (result.current.status === "error") {
+      expect(result.current.code).toBe("UNKNOWN_ERROR");
+    }
+  });
+});

--- a/frontend/src/features/workflow-draft-read/model/useWorkflowDetail.test.ts
+++ b/frontend/src/features/workflow-draft-read/model/useWorkflowDetail.test.ts
@@ -19,7 +19,7 @@ const stubDetail = {
   workflowCode: "W001",
   name: "테스트",
   description: null,
-  graphJson: { direction: "LR" as const, nodes: [], edges: [] },
+  graph: { direction: "LR" as const, nodes: [], edges: [] },
   initialState: null,
   terminalStatesJson: "[]",
   evidenceJson: "{}",
@@ -36,6 +36,7 @@ describe("useWorkflowDetail", () => {
   it("workflowId가 null이면 idle 상태다", () => {
     const { result } = renderHook(() => useWorkflowDetail(1, 2, 3, null));
     expect(result.current.status).toBe("idle");
+    expect(mockedDetail).not.toHaveBeenCalled();
   });
 
   it("workflowId가 주어지면 loading 상태로 시작한다", () => {

--- a/frontend/src/features/workflow-draft-read/model/useWorkflowDetail.ts
+++ b/frontend/src/features/workflow-draft-read/model/useWorkflowDetail.ts
@@ -1,0 +1,57 @@
+import { useEffect, useState } from "react";
+import { workflowApi } from "../api/workflowApi";
+import { ApiRequestError } from "../../../shared/api";
+import type { WorkflowDetail } from "../../../entities/workflow";
+
+export type WorkflowDetailState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "error"; code: string; message: string; httpStatus?: number }
+  | { status: "ready"; data: WorkflowDetail };
+
+export function useWorkflowDetail(
+  wsId: number,
+  packId: number,
+  versionId: number,
+  workflowId: number | null,
+): WorkflowDetailState {
+  const [state, setState] = useState<WorkflowDetailState>(
+    workflowId === null ? { status: "idle" } : { status: "loading" },
+  );
+
+  useEffect(() => {
+    if (workflowId === null) {
+      setState({ status: "idle" });
+      return;
+    }
+    let cancelled = false;
+    setState({ status: "loading" });
+    workflowApi
+      .detail(wsId, packId, versionId, workflowId)
+      .then((data) => {
+        if (!cancelled) setState({ status: "ready", data });
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        if (e instanceof ApiRequestError) {
+          setState({
+            status: "error",
+            code: e.code,
+            message: e.message,
+            httpStatus: e.status,
+          });
+        } else {
+          setState({
+            status: "error",
+            code: "UNKNOWN_ERROR",
+            message: "알 수 없는 오류가 발생했습니다.",
+          });
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [wsId, packId, versionId, workflowId]);
+
+  return state;
+}

--- a/frontend/src/features/workflow-draft-read/model/useWorkflowDetail.ts
+++ b/frontend/src/features/workflow-draft-read/model/useWorkflowDetail.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { workflowApi } from "../api/workflowApi";
-import { ApiRequestError } from "../../../shared/api";
+import { mapApiError } from "./mapApiError";
 import type { WorkflowDetail } from "../../../entities/workflow";
 
 export type WorkflowDetailState =
@@ -15,9 +15,7 @@ export function useWorkflowDetail(
   versionId: number,
   workflowId: number | null,
 ): WorkflowDetailState {
-  const [state, setState] = useState<WorkflowDetailState>(
-    workflowId === null ? { status: "idle" } : { status: "loading" },
-  );
+  const [state, setState] = useState<WorkflowDetailState>({ status: "idle" });
 
   useEffect(() => {
     if (workflowId === null) {
@@ -32,21 +30,7 @@ export function useWorkflowDetail(
         if (!cancelled) setState({ status: "ready", data });
       })
       .catch((e: unknown) => {
-        if (cancelled) return;
-        if (e instanceof ApiRequestError) {
-          setState({
-            status: "error",
-            code: e.code,
-            message: e.message,
-            httpStatus: e.status,
-          });
-        } else {
-          setState({
-            status: "error",
-            code: "UNKNOWN_ERROR",
-            message: "알 수 없는 오류가 발생했습니다.",
-          });
-        }
+        if (!cancelled) setState(mapApiError(e));
       });
     return () => {
       cancelled = true;

--- a/frontend/src/features/workflow-draft-read/model/useWorkflowList.test.ts
+++ b/frontend/src/features/workflow-draft-read/model/useWorkflowList.test.ts
@@ -1,0 +1,75 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useWorkflowList } from "./useWorkflowList";
+import { ApiRequestError } from "../../../shared/api";
+
+vi.mock("../api/workflowApi", () => ({
+  workflowApi: {
+    list: vi.fn(),
+    detail: vi.fn(),
+  },
+}));
+
+import { workflowApi } from "../api/workflowApi";
+
+const mockedList = vi.mocked(workflowApi.list);
+
+const stubWorkflow = {
+  id: 1,
+  workflowCode: "W001",
+  name: "테스트 워크플로우",
+  description: null,
+  initialState: null,
+  terminalStatesJson: "[]",
+  createdAt: "",
+  updatedAt: "",
+};
+
+describe("useWorkflowList", () => {
+  beforeEach(() => {
+    mockedList.mockReset();
+  });
+
+  it("초기 상태는 loading이다", () => {
+    mockedList.mockReturnValue(new Promise(() => {}));
+    const { result } = renderHook(() => useWorkflowList(1, 2, 3));
+    expect(result.current.status).toBe("loading");
+  });
+
+  it("성공 시 ready 상태로 전이되고 데이터를 반환한다", async () => {
+    mockedList.mockResolvedValue([stubWorkflow]);
+    const { result } = renderHook(() => useWorkflowList(1, 2, 3));
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+    if (result.current.status === "ready") {
+      expect(result.current.data).toEqual([stubWorkflow]);
+    }
+  });
+
+  it("빈 배열 응답 시 ready 상태로 전이된다", async () => {
+    mockedList.mockResolvedValue([]);
+    const { result } = renderHook(() => useWorkflowList(1, 2, 3));
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+    if (result.current.status === "ready") {
+      expect(result.current.data).toHaveLength(0);
+    }
+  });
+
+  it("ApiRequestError 발생 시 error 상태로 전이되고 httpStatus를 포함한다", async () => {
+    mockedList.mockRejectedValue(new ApiRequestError(403, "FORBIDDEN", "접근 금지"));
+    const { result } = renderHook(() => useWorkflowList(1, 2, 3));
+    await waitFor(() => expect(result.current.status).toBe("error"));
+    if (result.current.status === "error") {
+      expect(result.current.httpStatus).toBe(403);
+      expect(result.current.code).toBe("FORBIDDEN");
+    }
+  });
+
+  it("알 수 없는 오류 발생 시 UNKNOWN_ERROR 코드로 error 상태가 된다", async () => {
+    mockedList.mockRejectedValue(new Error("network fail"));
+    const { result } = renderHook(() => useWorkflowList(1, 2, 3));
+    await waitFor(() => expect(result.current.status).toBe("error"));
+    if (result.current.status === "error") {
+      expect(result.current.code).toBe("UNKNOWN_ERROR");
+    }
+  });
+});

--- a/frontend/src/features/workflow-draft-read/model/useWorkflowList.ts
+++ b/frontend/src/features/workflow-draft-read/model/useWorkflowList.ts
@@ -1,0 +1,49 @@
+import { useEffect, useState } from "react";
+import { workflowApi } from "../api/workflowApi";
+import { ApiRequestError } from "../../../shared/api";
+import type { WorkflowSummary } from "../../../entities/workflow";
+
+export type WorkflowListState =
+  | { status: "loading" }
+  | { status: "error"; code: string; message: string; httpStatus?: number }
+  | { status: "ready"; data: WorkflowSummary[] };
+
+export function useWorkflowList(
+  wsId: number,
+  packId: number,
+  versionId: number,
+): WorkflowListState {
+  const [state, setState] = useState<WorkflowListState>({ status: "loading" });
+
+  useEffect(() => {
+    let cancelled = false;
+    setState({ status: "loading" });
+    workflowApi
+      .list(wsId, packId, versionId)
+      .then((data) => {
+        if (!cancelled) setState({ status: "ready", data });
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        if (e instanceof ApiRequestError) {
+          setState({
+            status: "error",
+            code: e.code,
+            message: e.message,
+            httpStatus: e.status,
+          });
+        } else {
+          setState({
+            status: "error",
+            code: "UNKNOWN_ERROR",
+            message: "알 수 없는 오류가 발생했습니다.",
+          });
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [wsId, packId, versionId]);
+
+  return state;
+}

--- a/frontend/src/features/workflow-draft-read/model/useWorkflowList.ts
+++ b/frontend/src/features/workflow-draft-read/model/useWorkflowList.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { workflowApi } from "../api/workflowApi";
-import { ApiRequestError } from "../../../shared/api";
+import { mapApiError } from "./mapApiError";
 import type { WorkflowSummary } from "../../../entities/workflow";
 
 export type WorkflowListState =
@@ -24,21 +24,7 @@ export function useWorkflowList(
         if (!cancelled) setState({ status: "ready", data });
       })
       .catch((e: unknown) => {
-        if (cancelled) return;
-        if (e instanceof ApiRequestError) {
-          setState({
-            status: "error",
-            code: e.code,
-            message: e.message,
-            httpStatus: e.status,
-          });
-        } else {
-          setState({
-            status: "error",
-            code: "UNKNOWN_ERROR",
-            message: "알 수 없는 오류가 발생했습니다.",
-          });
-        }
+        if (!cancelled) setState(mapApiError(e));
       });
     return () => {
       cancelled = true;

--- a/frontend/src/features/workflow-draft-read/ui/GraphRenderer.module.css
+++ b/frontend/src/features/workflow-draft-read/ui/GraphRenderer.module.css
@@ -1,0 +1,44 @@
+.container {
+  width: 100%;
+  height: 100%;
+  min-height: 420px;
+  background: var(--bg-color);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+.container :global(.react-flow__edge-path) {
+  stroke: var(--text-primary);
+}
+
+.container :global(.react-flow__arrowhead) {
+  fill: var(--text-primary);
+}
+
+.container :global(.react-flow__edge-text) {
+  font-family: "Geist Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.54px;
+  fill: var(--text-primary);
+}
+
+.container :global(.react-flow__edge-textbg) {
+  fill: var(--bg-color);
+}
+
+.container :global(.react-flow__background) {
+  background: var(--bg-secondary);
+}
+
+.container :global(.react-flow__controls) {
+  box-shadow: none;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-md);
+}
+
+.container :global(.react-flow__controls-button) {
+  background: var(--bg-color);
+  color: var(--text-primary);
+  border-bottom: 1px solid var(--glass-border);
+}

--- a/frontend/src/features/workflow-draft-read/ui/GraphRenderer.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/GraphRenderer.tsx
@@ -1,0 +1,43 @@
+import { useMemo } from "react";
+import { ReactFlow, Background, Controls, type NodeTypes } from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+import type { WorkflowGraph } from "../../../entities/workflow";
+import { toFlow } from "./graphMapper";
+import { StartNode } from "./nodes/StartNode";
+import { ActionNode } from "./nodes/ActionNode";
+import { DecisionNode } from "./nodes/DecisionNode";
+import { AnswerNode } from "./nodes/AnswerNode";
+import { HandoffNode } from "./nodes/HandoffNode";
+import { TerminalNode } from "./nodes/TerminalNode";
+import styles from "./GraphRenderer.module.css";
+
+const nodeTypes: NodeTypes = {
+  start: StartNode,
+  action: ActionNode,
+  decision: DecisionNode,
+  answer: AnswerNode,
+  handoff: HandoffNode,
+  terminal: TerminalNode,
+};
+
+interface GraphRendererProps {
+  graph: WorkflowGraph;
+}
+
+export default function GraphRenderer({ graph }: GraphRendererProps) {
+  const { nodes, edges } = useMemo(() => toFlow(graph), [graph]);
+
+  return (
+    <div className={styles.container}>
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        nodeTypes={nodeTypes}
+        fitView
+      >
+        <Background gap={20} size={1} />
+        <Controls showInteractive={false} />
+      </ReactFlow>
+    </div>
+  );
+}

--- a/frontend/src/features/workflow-draft-read/ui/WorkflowDetailPanel.module.css
+++ b/frontend/src/features/workflow-draft-read/ui/WorkflowDetailPanel.module.css
@@ -1,0 +1,187 @@
+.panel {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-color);
+  overflow: hidden;
+  min-width: 0;
+}
+
+.header {
+  padding: 20px 28px;
+  border-bottom: 1px solid var(--glass-border);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.code {
+  font-family: "Geist Mono", monospace;
+  font-size: 12px;
+  letter-spacing: 0.54px;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.name {
+  font-family: "Pretendard Variable", sans-serif;
+  font-weight: 540;
+  font-size: 22px;
+  letter-spacing: -0.26px;
+  color: var(--text-primary);
+}
+
+.description {
+  font-size: 14px;
+  font-weight: 340;
+  letter-spacing: -0.14px;
+  color: var(--text-secondary);
+}
+
+.updatedAt {
+  font-family: "Geist Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.54px;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.tabs {
+  display: flex;
+  gap: 8px;
+  padding: 12px 28px;
+  border-bottom: 1px solid var(--glass-border);
+}
+
+.tab {
+  font-family: "Pretendard Variable", sans-serif;
+  font-size: 13px;
+  font-weight: 450;
+  letter-spacing: -0.14px;
+  padding: 6px 14px;
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--text-primary);
+  background: var(--bg-color);
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.tabActive {
+  background: var(--text-primary);
+  color: var(--bg-color);
+}
+
+.body {
+  flex: 1;
+  padding: 20px 28px;
+  overflow: auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.jsonBlock {
+  flex: 1;
+  background: var(--bg-secondary);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-md);
+  padding: 16px 18px;
+  font-family: "Geist Mono", monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--text-primary);
+  overflow: auto;
+  white-space: pre;
+}
+
+.metaSection {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.metaItem {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.metaLabel {
+  font-family: "Geist Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.54px;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.badgeRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.badge {
+  display: inline-flex;
+  font-family: "Geist Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.54px;
+  text-transform: uppercase;
+  padding: 4px 10px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--text-primary);
+  color: var(--text-primary);
+}
+
+.rawCode {
+  font-family: "Geist Mono", monospace;
+  font-size: 12px;
+  color: var(--text-primary);
+  background: var(--bg-secondary);
+  padding: 8px 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--glass-border);
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.stateMessage,
+.placeholder {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 8px;
+  padding: 32px;
+  color: var(--text-secondary);
+  font-size: 14px;
+  letter-spacing: -0.14px;
+  text-align: center;
+}
+
+.errorCode {
+  font-family: "Geist Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.54px;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.skeleton {
+  flex: 1;
+  background: var(--bg-secondary);
+  border-radius: var(--radius-md);
+}
+
+@media (max-width: 767px) {
+  .panel {
+    border-top: 1px solid var(--glass-border);
+  }
+
+  .header,
+  .tabs,
+  .body {
+    padding-left: 16px;
+    padding-right: 16px;
+  }
+}

--- a/frontend/src/features/workflow-draft-read/ui/WorkflowDetailPanel.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/WorkflowDetailPanel.tsx
@@ -3,6 +3,7 @@ import { toast } from "sonner";
 import { useWorkflowDetail } from "../model/useWorkflowDetail";
 import { parseTerminalStates } from "../model/parseTerminalStates";
 import type { WorkflowDetail } from "../../../entities/workflow";
+import { ErrorBoundary } from "../../../shared/ui/ErrorBoundary";
 import styles from "./WorkflowDetailPanel.module.css";
 
 const GraphRenderer = lazy(() => import("./GraphRenderer"));
@@ -60,6 +61,9 @@ export function WorkflowDetailPanel({
     document.getElementById(`${idPrefix}-tab-${TABS[next]}`)?.focus();
   };
 
+  const detail = state.status === "success" ? state.data : undefined;
+  const jsonText = useMemo(() => JSON.stringify(detail?.graph, null, 2), [detail?.graph]);
+
   if (state.status === "idle") {
     return (
       <section className={styles.panel} aria-label="workflow 상세">
@@ -90,8 +94,7 @@ export function WorkflowDetailPanel({
     );
   }
 
-  const detail = state.data;
-  const jsonText = useMemo(() => JSON.stringify(detail.graph, null, 2), [detail.graph]);
+  if (!detail) return null;
 
   return (
     <section className={styles.panel} aria-label="workflow 상세">
@@ -122,9 +125,11 @@ export function WorkflowDetailPanel({
           aria-labelledby={`${idPrefix}-tab-graph`}
           className={styles.body}
         >
-          <Suspense fallback={<div className={styles.skeleton} />}>
-            <GraphRenderer graph={detail.graph} />
-          </Suspense>
+          <ErrorBoundary fallback={<div className={styles.placeholder}><span>그래프를 표시할 수 없습니다.</span></div>}>
+            <Suspense fallback={<div className={styles.skeleton} />}>
+              <GraphRenderer graph={detail.graph} />
+            </Suspense>
+          </ErrorBoundary>
         </div>
       )}
 

--- a/frontend/src/features/workflow-draft-read/ui/WorkflowDetailPanel.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/WorkflowDetailPanel.tsx
@@ -1,4 +1,4 @@
-import { Suspense, lazy, useState, useEffect } from "react";
+import { Suspense, lazy, useState, useEffect, useId } from "react";
 import { toast } from "sonner";
 import { useWorkflowDetail } from "../model/useWorkflowDetail";
 import { parseTerminalStates } from "../model/parseTerminalStates";
@@ -27,6 +27,11 @@ export function WorkflowDetailPanel({
 }: WorkflowDetailPanelProps) {
   const state = useWorkflowDetail(wsId, packId, versionId, workflowId);
   const [tab, setTab] = useState<Tab>("graph");
+  const idPrefix = useId();
+
+  useEffect(() => {
+    setTab("graph");
+  }, [workflowId]);
 
   const errorCode = state.status === "error" ? state.code : undefined;
   const errorHttpStatus = state.status === "error" ? state.httpStatus : undefined;
@@ -52,7 +57,7 @@ export function WorkflowDetailPanel({
     else return;
     e.preventDefault();
     setTab(TABS[next]);
-    document.getElementById(`tab-${TABS[next]}`)?.focus();
+    document.getElementById(`${idPrefix}-tab-${TABS[next]}`)?.focus();
   };
 
   if (state.status === "idle") {
@@ -94,11 +99,11 @@ export function WorkflowDetailPanel({
         {TABS.map((t, i) => (
           <button
             key={t}
-            id={`tab-${t}`}
+            id={`${idPrefix}-tab-${t}`}
             type="button"
             role="tab"
             aria-selected={tab === t}
-            aria-controls={`panel-${t}`}
+            aria-controls={`${idPrefix}-panel-${t}`}
             tabIndex={tab === t ? 0 : -1}
             className={`${styles.tab} ${tab === t ? styles.tabActive : ""}`}
             onClick={() => setTab(t)}
@@ -110,9 +115,9 @@ export function WorkflowDetailPanel({
       </nav>
 
       <div
-        id="panel-graph"
+        id={`${idPrefix}-panel-graph`}
         role="tabpanel"
-        aria-labelledby="tab-graph"
+        aria-labelledby={`${idPrefix}-tab-graph`}
         className={styles.body}
         hidden={tab !== "graph"}
       >
@@ -122,9 +127,9 @@ export function WorkflowDetailPanel({
       </div>
 
       <div
-        id="panel-json"
+        id={`${idPrefix}-panel-json`}
         role="tabpanel"
-        aria-labelledby="tab-json"
+        aria-labelledby={`${idPrefix}-tab-json`}
         className={styles.body}
         hidden={tab !== "json"}
       >
@@ -134,9 +139,9 @@ export function WorkflowDetailPanel({
       </div>
 
       <div
-        id="panel-meta"
+        id={`${idPrefix}-panel-meta`}
         role="tabpanel"
-        aria-labelledby="tab-meta"
+        aria-labelledby={`${idPrefix}-tab-meta`}
         className={styles.body}
         hidden={tab !== "meta"}
       >

--- a/frontend/src/features/workflow-draft-read/ui/WorkflowDetailPanel.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/WorkflowDetailPanel.tsx
@@ -1,0 +1,152 @@
+import { Suspense, lazy, useState } from "react";
+import { useWorkflowDetail } from "../model/useWorkflowDetail";
+import { parseTerminalStates } from "../model/parseTerminalStates";
+import type { WorkflowDetail } from "../../../entities/workflow";
+import styles from "./WorkflowDetailPanel.module.css";
+
+const GraphRenderer = lazy(() => import("./GraphRenderer"));
+
+type Tab = "graph" | "json" | "meta";
+
+interface WorkflowDetailPanelProps {
+  wsId: number;
+  packId: number;
+  versionId: number;
+  workflowId: number | null;
+}
+
+export function WorkflowDetailPanel({
+  wsId,
+  packId,
+  versionId,
+  workflowId,
+}: WorkflowDetailPanelProps) {
+  const state = useWorkflowDetail(wsId, packId, versionId, workflowId);
+  const [tab, setTab] = useState<Tab>("graph");
+
+  if (state.status === "idle") {
+    return (
+      <section className={styles.panel} aria-label="workflow 상세">
+        <div className={styles.placeholder}>
+          <span>좌측 목록에서 workflow를 선택해 주세요.</span>
+        </div>
+      </section>
+    );
+  }
+
+  if (state.status === "loading") {
+    return (
+      <section className={styles.panel} aria-label="workflow 상세">
+        <div className={styles.body}>
+          <div className={styles.skeleton} />
+        </div>
+      </section>
+    );
+  }
+
+  if (state.status === "error") {
+    return (
+      <section className={styles.panel} aria-label="workflow 상세">
+        <div className={styles.stateMessage} role="alert">
+          <span className={styles.errorCode}>{state.code}</span>
+          <span>
+            {state.httpStatus === 404
+              ? "workflow를 찾을 수 없습니다."
+              : state.code === "WORKFLOW_GRAPH_JSON_INVALID"
+                ? "graphJson이 손상되어 시각화를 표시할 수 없습니다."
+                : state.message || "상세 정보를 불러오지 못했습니다."}
+          </span>
+        </div>
+      </section>
+    );
+  }
+
+  const detail = state.data;
+
+  return (
+    <section className={styles.panel} aria-label="workflow 상세">
+      <DetailHeader detail={detail} />
+      <nav className={styles.tabs} role="tablist" aria-label="workflow 상세 뷰">
+        {(["graph", "json", "meta"] as const).map((t) => (
+          <button
+            key={t}
+            type="button"
+            role="tab"
+            aria-selected={tab === t}
+            className={`${styles.tab} ${tab === t ? styles.tabActive : ""}`}
+            onClick={() => setTab(t)}
+          >
+            {t === "graph" ? "Graph" : t === "json" ? "JSON" : "Meta"}
+          </button>
+        ))}
+      </nav>
+
+      <div className={styles.body} role="tabpanel">
+        {tab === "graph" && (
+          <Suspense fallback={<div className={styles.skeleton} />}>
+            <GraphRenderer graph={detail.graphJson} />
+          </Suspense>
+        )}
+        {tab === "json" && (
+          <pre className={styles.jsonBlock}>
+            <code>{JSON.stringify(detail.graphJson, null, 2)}</code>
+          </pre>
+        )}
+        {tab === "meta" && <MetaTab detail={detail} />}
+      </div>
+    </section>
+  );
+}
+
+function DetailHeader({ detail }: { detail: WorkflowDetail }) {
+  return (
+    <header className={styles.header}>
+      <span className={styles.code}>{detail.workflowCode}</span>
+      <span className={styles.name}>{detail.name}</span>
+      {detail.description && <span className={styles.description}>{detail.description}</span>}
+      <span className={styles.updatedAt}>UPDATED · {detail.updatedAt}</span>
+    </header>
+  );
+}
+
+function MetaTab({ detail }: { detail: WorkflowDetail }) {
+  const terminals = parseTerminalStates(detail.terminalStatesJson);
+  return (
+    <div className={styles.metaSection}>
+      <div className={styles.metaItem}>
+        <span className={styles.metaLabel}>Initial State</span>
+        {detail.initialState ? (
+          <span className={styles.badge}>{detail.initialState}</span>
+        ) : (
+          <span>—</span>
+        )}
+      </div>
+      <div className={styles.metaItem}>
+        <span className={styles.metaLabel}>Terminal States</span>
+        {Array.isArray(terminals) ? (
+          terminals.length === 0 ? (
+            <span>—</span>
+          ) : (
+            <div className={styles.badgeRow}>
+              {terminals.map((t) => (
+                <span key={t} className={styles.badge}>
+                  {t}
+                </span>
+              ))}
+            </div>
+          )
+        ) : (
+          <code className={styles.rawCode}>{terminals}</code>
+        )}
+      </div>
+      <div className={styles.metaItem}>
+        <span className={styles.metaLabel}>Evidence (raw)</span>
+        <code className={styles.rawCode}>{detail.evidenceJson}</code>
+      </div>
+      <div className={styles.metaItem}>
+        <span className={styles.metaLabel}>Meta (raw)</span>
+        <code className={styles.rawCode}>{detail.metaJson}</code>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/workflow-draft-read/ui/WorkflowDetailPanel.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/WorkflowDetailPanel.tsx
@@ -61,7 +61,7 @@ export function WorkflowDetailPanel({
     document.getElementById(`${idPrefix}-tab-${TABS[next]}`)?.focus();
   };
 
-  const detail = state.status === "success" ? state.data : undefined;
+  const detail = state.status === "ready" ? state.data : undefined;
   const jsonText = useMemo(() => JSON.stringify(detail?.graph, null, 2), [detail?.graph]);
 
   if (state.status === "idle") {

--- a/frontend/src/features/workflow-draft-read/ui/WorkflowDetailPanel.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/WorkflowDetailPanel.tsx
@@ -1,4 +1,4 @@
-import { Suspense, lazy, useState, useEffect, useId, type KeyboardEvent } from "react";
+import { Suspense, lazy, useState, useEffect, useId, useMemo, type KeyboardEvent } from "react";
 import { toast } from "sonner";
 import { useWorkflowDetail } from "../model/useWorkflowDetail";
 import { parseTerminalStates } from "../model/parseTerminalStates";
@@ -91,6 +91,7 @@ export function WorkflowDetailPanel({
   }
 
   const detail = state.data;
+  const jsonText = useMemo(() => JSON.stringify(detail.graph, null, 2), [detail.graph]);
 
   return (
     <section className={styles.panel} aria-label="workflow 상세">
@@ -114,39 +115,42 @@ export function WorkflowDetailPanel({
         ))}
       </nav>
 
-      <div
-        id={`${idPrefix}-panel-graph`}
-        role="tabpanel"
-        aria-labelledby={`${idPrefix}-tab-graph`}
-        className={styles.body}
-        hidden={tab !== "graph"}
-      >
-        <Suspense fallback={<div className={styles.skeleton} />}>
-          <GraphRenderer graph={detail.graph} />
-        </Suspense>
-      </div>
+      {tab === "graph" && (
+        <div
+          id={`${idPrefix}-panel-graph`}
+          role="tabpanel"
+          aria-labelledby={`${idPrefix}-tab-graph`}
+          className={styles.body}
+        >
+          <Suspense fallback={<div className={styles.skeleton} />}>
+            <GraphRenderer graph={detail.graph} />
+          </Suspense>
+        </div>
+      )}
 
-      <div
-        id={`${idPrefix}-panel-json`}
-        role="tabpanel"
-        aria-labelledby={`${idPrefix}-tab-json`}
-        className={styles.body}
-        hidden={tab !== "json"}
-      >
-        <pre className={styles.jsonBlock}>
-          <code>{JSON.stringify(detail.graph, null, 2)}</code>
-        </pre>
-      </div>
+      {tab === "json" && (
+        <div
+          id={`${idPrefix}-panel-json`}
+          role="tabpanel"
+          aria-labelledby={`${idPrefix}-tab-json`}
+          className={styles.body}
+        >
+          <pre className={styles.jsonBlock}>
+            <code>{jsonText}</code>
+          </pre>
+        </div>
+      )}
 
-      <div
-        id={`${idPrefix}-panel-meta`}
-        role="tabpanel"
-        aria-labelledby={`${idPrefix}-tab-meta`}
-        className={styles.body}
-        hidden={tab !== "meta"}
-      >
-        <MetaTab detail={detail} />
-      </div>
+      {tab === "meta" && (
+        <div
+          id={`${idPrefix}-panel-meta`}
+          role="tabpanel"
+          aria-labelledby={`${idPrefix}-tab-meta`}
+          className={styles.body}
+        >
+          <MetaTab detail={detail} />
+        </div>
+      )}
     </section>
   );
 }

--- a/frontend/src/features/workflow-draft-read/ui/WorkflowDetailPanel.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/WorkflowDetailPanel.tsx
@@ -1,4 +1,4 @@
-import { Suspense, lazy, useState, useEffect, useId } from "react";
+import { Suspense, lazy, useState, useEffect, useId, type KeyboardEvent } from "react";
 import { toast } from "sonner";
 import { useWorkflowDetail } from "../model/useWorkflowDetail";
 import { parseTerminalStates } from "../model/parseTerminalStates";
@@ -48,7 +48,7 @@ export function WorkflowDetailPanel({
     toast.error(msg);
   }, [state.status, errorCode, errorHttpStatus, errorMessage]);
 
-  const handleTabKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>, index: number) => {
+  const handleTabKeyDown = (e: KeyboardEvent<HTMLButtonElement>, index: number) => {
     let next = index;
     if (e.key === "ArrowRight") next = (index + 1) % TABS.length;
     else if (e.key === "ArrowLeft") next = (index - 1 + TABS.length) % TABS.length;
@@ -157,9 +157,17 @@ function DetailHeader({ detail }: { detail: WorkflowDetail }) {
       <span className={styles.code}>{detail.workflowCode}</span>
       <span className={styles.name}>{detail.name}</span>
       {detail.description && <span className={styles.description}>{detail.description}</span>}
-      <span className={styles.updatedAt}>UPDATED · {detail.updatedAt}</span>
+      <span className={styles.updatedAt}>UPDATED · {new Date(detail.updatedAt).toLocaleString()}</span>
     </header>
   );
+}
+
+function formatJsonForDisplay(raw: string): string {
+  try {
+    return JSON.stringify(JSON.parse(raw), null, 2);
+  } catch {
+    return raw;
+  }
 }
 
 function MetaTab({ detail }: { detail: WorkflowDetail }) {
@@ -194,11 +202,15 @@ function MetaTab({ detail }: { detail: WorkflowDetail }) {
       </div>
       <div className={styles.metaItem}>
         <span className={styles.metaLabel}>Evidence (raw)</span>
-        <code className={styles.rawCode}>{detail.evidenceJson}</code>
+        <pre className={styles.rawCode}>
+          <code>{formatJsonForDisplay(detail.evidenceJson)}</code>
+        </pre>
       </div>
       <div className={styles.metaItem}>
         <span className={styles.metaLabel}>Meta (raw)</span>
-        <code className={styles.rawCode}>{detail.metaJson}</code>
+        <pre className={styles.rawCode}>
+          <code>{formatJsonForDisplay(detail.metaJson)}</code>
+        </pre>
       </div>
     </div>
   );

--- a/frontend/src/features/workflow-draft-read/ui/WorkflowDetailPanel.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/WorkflowDetailPanel.tsx
@@ -125,7 +125,7 @@ export function WorkflowDetailPanel({
           aria-labelledby={`${idPrefix}-tab-graph`}
           className={styles.body}
         >
-          <ErrorBoundary fallback={<div className={styles.placeholder}><span>그래프를 표시할 수 없습니다.</span></div>}>
+          <ErrorBoundary key={workflowId} fallback={<div className={styles.placeholder}><span>그래프를 표시할 수 없습니다.</span></div>}>
             <Suspense fallback={<div className={styles.skeleton} />}>
               <GraphRenderer graph={detail.graph} />
             </Suspense>

--- a/frontend/src/features/workflow-draft-read/ui/WorkflowDetailPanel.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/WorkflowDetailPanel.tsx
@@ -1,4 +1,5 @@
-import { Suspense, lazy, useState } from "react";
+import { Suspense, lazy, useState, useEffect } from "react";
+import { toast } from "sonner";
 import { useWorkflowDetail } from "../model/useWorkflowDetail";
 import { parseTerminalStates } from "../model/parseTerminalStates";
 import type { WorkflowDetail } from "../../../entities/workflow";
@@ -7,6 +8,9 @@ import styles from "./WorkflowDetailPanel.module.css";
 const GraphRenderer = lazy(() => import("./GraphRenderer"));
 
 type Tab = "graph" | "json" | "meta";
+
+const TABS = ["graph", "json", "meta"] as const;
+const TAB_LABELS: Record<Tab, string> = { graph: "Graph", json: "JSON", meta: "Meta" };
 
 interface WorkflowDetailPanelProps {
   wsId: number;
@@ -23,6 +27,33 @@ export function WorkflowDetailPanel({
 }: WorkflowDetailPanelProps) {
   const state = useWorkflowDetail(wsId, packId, versionId, workflowId);
   const [tab, setTab] = useState<Tab>("graph");
+
+  const errorCode = state.status === "error" ? state.code : undefined;
+  const errorHttpStatus = state.status === "error" ? state.httpStatus : undefined;
+  const errorMessage = state.status === "error" ? state.message : undefined;
+
+  useEffect(() => {
+    if (state.status !== "error") return;
+    const msg =
+      errorHttpStatus === 404
+        ? "workflow를 찾을 수 없습니다."
+        : errorCode === "WORKFLOW_GRAPH_JSON_INVALID"
+          ? "graph 데이터가 손상되어 시각화를 표시할 수 없습니다."
+          : errorMessage || "상세 정보를 불러오지 못했습니다.";
+    toast.error(msg);
+  }, [state.status, errorCode, errorHttpStatus, errorMessage]);
+
+  const handleTabKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>, index: number) => {
+    let next = index;
+    if (e.key === "ArrowRight") next = (index + 1) % TABS.length;
+    else if (e.key === "ArrowLeft") next = (index - 1 + TABS.length) % TABS.length;
+    else if (e.key === "Home") next = 0;
+    else if (e.key === "End") next = TABS.length - 1;
+    else return;
+    e.preventDefault();
+    setTab(TABS[next]);
+    document.getElementById(`tab-${TABS[next]}`)?.focus();
+  };
 
   if (state.status === "idle") {
     return (
@@ -47,15 +78,8 @@ export function WorkflowDetailPanel({
   if (state.status === "error") {
     return (
       <section className={styles.panel} aria-label="workflow 상세">
-        <div className={styles.stateMessage} role="alert">
-          <span className={styles.errorCode}>{state.code}</span>
-          <span>
-            {state.httpStatus === 404
-              ? "workflow를 찾을 수 없습니다."
-              : state.code === "WORKFLOW_GRAPH_JSON_INVALID"
-                ? "graphJson이 손상되어 시각화를 표시할 수 없습니다."
-                : state.message || "상세 정보를 불러오지 못했습니다."}
-          </span>
+        <div className={styles.placeholder}>
+          <span>상세 정보를 불러오지 못했습니다.</span>
         </div>
       </section>
     );
@@ -67,32 +91,56 @@ export function WorkflowDetailPanel({
     <section className={styles.panel} aria-label="workflow 상세">
       <DetailHeader detail={detail} />
       <nav className={styles.tabs} role="tablist" aria-label="workflow 상세 뷰">
-        {(["graph", "json", "meta"] as const).map((t) => (
+        {TABS.map((t, i) => (
           <button
             key={t}
+            id={`tab-${t}`}
             type="button"
             role="tab"
             aria-selected={tab === t}
+            aria-controls={`panel-${t}`}
+            tabIndex={tab === t ? 0 : -1}
             className={`${styles.tab} ${tab === t ? styles.tabActive : ""}`}
             onClick={() => setTab(t)}
+            onKeyDown={(e) => handleTabKeyDown(e, i)}
           >
-            {t === "graph" ? "Graph" : t === "json" ? "JSON" : "Meta"}
+            {TAB_LABELS[t]}
           </button>
         ))}
       </nav>
 
-      <div className={styles.body} role="tabpanel">
-        {tab === "graph" && (
-          <Suspense fallback={<div className={styles.skeleton} />}>
-            <GraphRenderer graph={detail.graphJson} />
-          </Suspense>
-        )}
-        {tab === "json" && (
-          <pre className={styles.jsonBlock}>
-            <code>{JSON.stringify(detail.graphJson, null, 2)}</code>
-          </pre>
-        )}
-        {tab === "meta" && <MetaTab detail={detail} />}
+      <div
+        id="panel-graph"
+        role="tabpanel"
+        aria-labelledby="tab-graph"
+        className={styles.body}
+        hidden={tab !== "graph"}
+      >
+        <Suspense fallback={<div className={styles.skeleton} />}>
+          <GraphRenderer graph={detail.graph} />
+        </Suspense>
+      </div>
+
+      <div
+        id="panel-json"
+        role="tabpanel"
+        aria-labelledby="tab-json"
+        className={styles.body}
+        hidden={tab !== "json"}
+      >
+        <pre className={styles.jsonBlock}>
+          <code>{JSON.stringify(detail.graph, null, 2)}</code>
+        </pre>
+      </div>
+
+      <div
+        id="panel-meta"
+        role="tabpanel"
+        aria-labelledby="tab-meta"
+        className={styles.body}
+        hidden={tab !== "meta"}
+      >
+        <MetaTab detail={detail} />
       </div>
     </section>
   );
@@ -123,12 +171,12 @@ function MetaTab({ detail }: { detail: WorkflowDetail }) {
       </div>
       <div className={styles.metaItem}>
         <span className={styles.metaLabel}>Terminal States</span>
-        {Array.isArray(terminals) ? (
-          terminals.length === 0 ? (
+        {terminals.ok ? (
+          terminals.value.length === 0 ? (
             <span>—</span>
           ) : (
             <div className={styles.badgeRow}>
-              {terminals.map((t) => (
+              {terminals.value.map((t) => (
                 <span key={t} className={styles.badge}>
                   {t}
                 </span>
@@ -136,7 +184,7 @@ function MetaTab({ detail }: { detail: WorkflowDetail }) {
             </div>
           )
         ) : (
-          <code className={styles.rawCode}>{terminals}</code>
+          <code className={styles.rawCode}>{terminals.raw}</code>
         )}
       </div>
       <div className={styles.metaItem}>

--- a/frontend/src/features/workflow-draft-read/ui/WorkflowListPanel.module.css
+++ b/frontend/src/features/workflow-draft-read/ui/WorkflowListPanel.module.css
@@ -1,0 +1,152 @@
+.panel {
+  width: 360px;
+  min-width: 280px;
+  border-right: 1px solid var(--glass-border);
+  background: var(--bg-color);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.header {
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--glass-border);
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.headerTitle {
+  font-family: "Pretendard Variable", sans-serif;
+  font-weight: 540;
+  font-size: 15px;
+  color: var(--text-primary);
+  letter-spacing: -0.14px;
+}
+
+.headerMeta {
+  font-family: "Geist Mono", monospace;
+  font-size: 12px;
+  letter-spacing: 0.54px;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.scroll {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 14px 20px;
+  border: 0;
+  border-bottom: 1px solid var(--glass-border);
+  background: var(--bg-color);
+  cursor: pointer;
+  font-family: "Pretendard Variable", sans-serif;
+  color: var(--text-primary);
+}
+
+.item:hover {
+  background: var(--bg-secondary);
+}
+
+.itemActive {
+  background: var(--text-primary);
+  color: var(--bg-color);
+}
+
+.itemActive:hover {
+  background: var(--text-primary);
+}
+
+.code {
+  font-family: "Geist Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.54px;
+  text-transform: uppercase;
+  color: inherit;
+  opacity: 0.7;
+  display: block;
+  margin-bottom: 4px;
+}
+
+.name {
+  font-size: 14px;
+  font-weight: 450;
+  letter-spacing: -0.14px;
+  color: inherit;
+  display: block;
+  margin-bottom: 6px;
+}
+
+.badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-family: "Geist Mono", monospace;
+  font-size: 10px;
+  letter-spacing: 0.54px;
+  text-transform: uppercase;
+  padding: 2px 8px;
+  border-radius: var(--radius-sm);
+  border: 1px solid currentColor;
+  color: inherit;
+}
+
+.skeletonGroup {
+  padding: 16px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.skeletonRow {
+  height: 44px;
+  border-radius: var(--radius-md);
+  background: var(--bg-secondary);
+}
+
+.emptyState,
+.errorState {
+  padding: 24px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  color: var(--text-secondary);
+  font-size: 13px;
+  letter-spacing: -0.14px;
+}
+
+.errorCode {
+  font-family: "Geist Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.54px;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+@media (max-width: 1023px) {
+  .panel {
+    width: 280px;
+    min-width: 240px;
+  }
+}
+
+@media (max-width: 767px) {
+  .panel {
+    width: 100%;
+    min-width: 0;
+    border-right: 0;
+  }
+}

--- a/frontend/src/features/workflow-draft-read/ui/WorkflowListPanel.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/WorkflowListPanel.tsx
@@ -15,7 +15,7 @@ interface WorkflowListPanelProps {
 
 function terminalCount(json: string): number | null {
   const parsed = parseTerminalStates(json);
-  return Array.isArray(parsed) ? parsed.length : null;
+  return parsed.ok ? parsed.value.length : null;
 }
 
 export function WorkflowListPanel({
@@ -26,13 +26,13 @@ export function WorkflowListPanel({
   onSelect,
 }: WorkflowListPanelProps) {
   const state = useWorkflowList(wsId, packId, versionId);
-  const errorHttpStatus = state.status === "error" ? state.httpStatus : undefined;
+  const errorMessage = state.status === "error" ? state.message : undefined;
 
   useEffect(() => {
-    if (state.status === "error" && errorHttpStatus === 403) {
-      toast.error("접근 권한 없음");
+    if (state.status === "error") {
+      toast.error(errorMessage ?? "목록을 불러오지 못했습니다.");
     }
-  }, [state.status, errorHttpStatus]);
+  }, [state.status, errorMessage]);
 
   return (
     <aside className={styles.panel} aria-label="workflow 목록">
@@ -53,9 +53,8 @@ export function WorkflowListPanel({
         )}
 
         {state.status === "error" && (
-          <div className={styles.errorState} role="alert">
-            <span className={styles.errorCode}>{state.code}</span>
-            <span>{state.message || "목록을 불러오지 못했습니다."}</span>
+          <div className={styles.emptyState}>
+            <span>목록을 불러오지 못했습니다.</span>
           </div>
         )}
 

--- a/frontend/src/features/workflow-draft-read/ui/WorkflowListPanel.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/WorkflowListPanel.tsx
@@ -1,0 +1,104 @@
+import { useEffect } from "react";
+import { toast } from "sonner";
+import { useWorkflowList } from "../model/useWorkflowList";
+import { parseTerminalStates } from "../model/parseTerminalStates";
+import type { WorkflowSummary } from "../../../entities/workflow";
+import styles from "./WorkflowListPanel.module.css";
+
+interface WorkflowListPanelProps {
+  wsId: number;
+  packId: number;
+  versionId: number;
+  selectedId: number | null;
+  onSelect: (id: number) => void;
+}
+
+function terminalCount(json: string): number | null {
+  const parsed = parseTerminalStates(json);
+  return Array.isArray(parsed) ? parsed.length : null;
+}
+
+export function WorkflowListPanel({
+  wsId,
+  packId,
+  versionId,
+  selectedId,
+  onSelect,
+}: WorkflowListPanelProps) {
+  const state = useWorkflowList(wsId, packId, versionId);
+  const errorHttpStatus = state.status === "error" ? state.httpStatus : undefined;
+
+  useEffect(() => {
+    if (state.status === "error" && errorHttpStatus === 403) {
+      toast.error("접근 권한 없음");
+    }
+  }, [state.status, errorHttpStatus]);
+
+  return (
+    <aside className={styles.panel} aria-label="workflow 목록">
+      <header className={styles.header}>
+        <span className={styles.headerTitle}>Workflows</span>
+        <span className={styles.headerMeta}>
+          {state.status === "ready" ? `${state.data.length} · CODE` : "— · CODE"}
+        </span>
+      </header>
+
+      <div className={styles.scroll}>
+        {state.status === "loading" && (
+          <div className={styles.skeletonGroup}>
+            <div className={styles.skeletonRow} />
+            <div className={styles.skeletonRow} />
+            <div className={styles.skeletonRow} />
+          </div>
+        )}
+
+        {state.status === "error" && (
+          <div className={styles.errorState} role="alert">
+            <span className={styles.errorCode}>{state.code}</span>
+            <span>{state.message || "목록을 불러오지 못했습니다."}</span>
+          </div>
+        )}
+
+        {state.status === "ready" && state.data.length === 0 && (
+          <div className={styles.emptyState}>
+            <span>해당 버전에 등록된 workflow 초안이 없습니다.</span>
+          </div>
+        )}
+
+        {state.status === "ready" &&
+          state.data.map((w) => (
+            <WorkflowRow key={w.id} workflow={w} active={w.id === selectedId} onSelect={onSelect} />
+          ))}
+      </div>
+    </aside>
+  );
+}
+
+function WorkflowRow({
+  workflow,
+  active,
+  onSelect,
+}: {
+  workflow: WorkflowSummary;
+  active: boolean;
+  onSelect: (id: number) => void;
+}) {
+  const tCount = terminalCount(workflow.terminalStatesJson);
+  return (
+    <button
+      type="button"
+      className={`${styles.item} ${active ? styles.itemActive : ""}`}
+      onClick={() => onSelect(workflow.id)}
+      aria-current={active ? "true" : undefined}
+    >
+      <span className={styles.code}>{workflow.workflowCode}</span>
+      <span className={styles.name}>{workflow.name}</span>
+      <span className={styles.badges}>
+        {workflow.initialState && (
+          <span className={styles.badge}>INIT · {workflow.initialState}</span>
+        )}
+        <span className={styles.badge}>TERM · {tCount === null ? "?" : tCount}</span>
+      </span>
+    </button>
+  );
+}

--- a/frontend/src/features/workflow-draft-read/ui/graphMapper.test.ts
+++ b/frontend/src/features/workflow-draft-read/ui/graphMapper.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { toFlow } from "./graphMapper";
+import type { WorkflowGraph } from "../../../entities/workflow";
+
+const baseGraph: WorkflowGraph = {
+  direction: "LR",
+  nodes: [
+    { id: "n1", label: "Start", type: "START" },
+    { id: "n2", label: "Action", type: "ACTION" },
+  ],
+  edges: [{ from: "n1", to: "n2", label: "next" }],
+};
+
+describe("toFlow", () => {
+  it("노드 type을 소문자로 변환한다", () => {
+    const { nodes } = toFlow(baseGraph);
+    expect(nodes[0].type).toBe("start");
+    expect(nodes[1].type).toBe("action");
+  });
+
+  it("노드 id를 그대로 유지한다", () => {
+    const { nodes } = toFlow(baseGraph);
+    expect(nodes[0].id).toBe("n1");
+    expect(nodes[1].id).toBe("n2");
+  });
+
+  it("엣지 id에 순서 카운터가 포함된다", () => {
+    const { edges } = toFlow(baseGraph);
+    expect(edges[0].id).toBe("n1->n2:next#1");
+  });
+
+  it("동일 source→target+label 엣지가 중복되면 id가 달라진다", () => {
+    const dupGraph: WorkflowGraph = {
+      ...baseGraph,
+      edges: [
+        { from: "n1", to: "n2", label: "retry" },
+        { from: "n1", to: "n2", label: "retry" },
+      ],
+    };
+    const { edges } = toFlow(dupGraph);
+    expect(edges[0].id).toBe("n1->n2:retry#1");
+    expect(edges[1].id).toBe("n1->n2:retry#2");
+  });
+
+  it("label 없는 엣지에 'unlabeled' id가 사용된다", () => {
+    const noLabelGraph: WorkflowGraph = {
+      ...baseGraph,
+      edges: [{ from: "n1", to: "n2" }],
+    };
+    const { edges } = toFlow(noLabelGraph);
+    expect(edges[0].id).toBe("n1->n2:unlabeled#1");
+  });
+
+  it("TB 방향일 때 COLUMNS_FOR_TB(4) 기준으로 격자 위치를 계산한다", () => {
+    const nodes = Array.from({ length: 5 }, (_, i) => ({
+      id: `n${i}`,
+      label: `N${i}`,
+      type: "ACTION" as const,
+    }));
+    const tbGraph: WorkflowGraph = { direction: "TB", nodes, edges: [] };
+    const { nodes: result } = toFlow(tbGraph);
+    // index 4: col = 4 % 4 = 0, row = Math.floor(4/4) = 1
+    expect(result[4].position).toEqual({ x: 0, y: 120 });
+  });
+});

--- a/frontend/src/features/workflow-draft-read/ui/graphMapper.ts
+++ b/frontend/src/features/workflow-draft-read/ui/graphMapper.ts
@@ -4,6 +4,7 @@ import type { WorkflowGraph } from "../../../entities/workflow";
 const NODE_GAP_X = 200;
 const NODE_GAP_Y = 120;
 const COLUMNS_FOR_TB = 4;
+const ROWS_FOR_LR = 4;
 
 function computePosition(
   index: number,
@@ -14,7 +15,9 @@ function computePosition(
     const row = Math.floor(index / COLUMNS_FOR_TB);
     return { x: col * NODE_GAP_X, y: row * NODE_GAP_Y };
   }
-  return { x: index * NODE_GAP_X, y: (index % 2) * NODE_GAP_Y };
+  const col = Math.floor(index / ROWS_FOR_LR);
+  const row = index % ROWS_FOR_LR;
+  return { x: col * NODE_GAP_X, y: row * NODE_GAP_Y };
 }
 
 export function toFlow(graph: WorkflowGraph): { nodes: Node[]; edges: Edge[] } {

--- a/frontend/src/features/workflow-draft-read/ui/graphMapper.ts
+++ b/frontend/src/features/workflow-draft-read/ui/graphMapper.ts
@@ -1,0 +1,43 @@
+import type { Node, Edge } from "@xyflow/react";
+import type { WorkflowGraph } from "../../../entities/workflow";
+
+const NODE_GAP_X = 200;
+const NODE_GAP_Y = 120;
+const COLUMNS_FOR_TB = 4;
+
+function computePosition(
+  index: number,
+  direction: WorkflowGraph["direction"],
+): { x: number; y: number } {
+  if (direction === "TB") {
+    const col = index % COLUMNS_FOR_TB;
+    const row = Math.floor(index / COLUMNS_FOR_TB);
+    return { x: col * NODE_GAP_X, y: row * NODE_GAP_Y };
+  }
+  return { x: index * NODE_GAP_X, y: (index % 2) * NODE_GAP_Y };
+}
+
+export function toFlow(graph: WorkflowGraph): { nodes: Node[]; edges: Edge[] } {
+  const nodes: Node[] = graph.nodes.map((n, i) => ({
+    id: n.id,
+    type: n.type.toLowerCase(),
+    data: { label: n.label },
+    position: computePosition(i, graph.direction),
+  }));
+
+  const edgeIdCounts = new Map<string, number>();
+  const edges: Edge[] = graph.edges.map((e) => {
+    const baseId = `${e.from}->${e.to}:${e.label ?? "unlabeled"}`;
+    const count = edgeIdCounts.get(baseId) ?? 0;
+    edgeIdCounts.set(baseId, count + 1);
+
+    return {
+      id: `${baseId}#${count + 1}`,
+      source: e.from,
+      target: e.to,
+      label: e.label,
+    };
+  });
+
+  return { nodes, edges };
+}

--- a/frontend/src/features/workflow-draft-read/ui/index.ts
+++ b/frontend/src/features/workflow-draft-read/ui/index.ts
@@ -1,0 +1,2 @@
+export { WorkflowListPanel } from "./WorkflowListPanel";
+export { WorkflowDetailPanel } from "./WorkflowDetailPanel";

--- a/frontend/src/features/workflow-draft-read/ui/nodes/ActionNode.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/nodes/ActionNode.tsx
@@ -6,7 +6,7 @@ export function ActionNode({ data }: NodeProps) {
   return (
     <div className={styles.action}>
       <Handle type="target" position={Position.Left} />
-      {label}
+      <span className={styles.label}>{label}</span>
       <Handle type="source" position={Position.Right} />
     </div>
   );

--- a/frontend/src/features/workflow-draft-read/ui/nodes/ActionNode.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/nodes/ActionNode.tsx
@@ -1,0 +1,13 @@
+import { Handle, Position, type NodeProps } from "@xyflow/react";
+import styles from "./nodes.module.css";
+
+export function ActionNode({ data }: NodeProps) {
+  const label = typeof data?.label === "string" ? data.label : "";
+  return (
+    <div className={styles.action}>
+      <Handle type="target" position={Position.Left} />
+      {label}
+      <Handle type="source" position={Position.Right} />
+    </div>
+  );
+}

--- a/frontend/src/features/workflow-draft-read/ui/nodes/AnswerNode.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/nodes/AnswerNode.tsx
@@ -6,7 +6,7 @@ export function AnswerNode({ data }: NodeProps) {
   return (
     <div className={styles.answer}>
       <Handle type="target" position={Position.Left} />
-      {label}
+      <span className={styles.label}>{label}</span>
       <Handle type="source" position={Position.Right} />
     </div>
   );

--- a/frontend/src/features/workflow-draft-read/ui/nodes/AnswerNode.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/nodes/AnswerNode.tsx
@@ -1,0 +1,13 @@
+import { Handle, Position, type NodeProps } from "@xyflow/react";
+import styles from "./nodes.module.css";
+
+export function AnswerNode({ data }: NodeProps) {
+  const label = typeof data?.label === "string" ? data.label : "";
+  return (
+    <div className={styles.answer}>
+      <Handle type="target" position={Position.Left} />
+      {label}
+      <Handle type="source" position={Position.Right} />
+    </div>
+  );
+}

--- a/frontend/src/features/workflow-draft-read/ui/nodes/DecisionNode.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/nodes/DecisionNode.tsx
@@ -1,0 +1,13 @@
+import { Handle, Position, type NodeProps } from "@xyflow/react";
+import styles from "./nodes.module.css";
+
+export function DecisionNode({ data }: NodeProps) {
+  const label = typeof data?.label === "string" ? data.label : "";
+  return (
+    <div className={styles.decision}>
+      <Handle type="target" position={Position.Left} />
+      <span className={styles.decisionLabel}>{label}</span>
+      <Handle type="source" position={Position.Right} />
+    </div>
+  );
+}

--- a/frontend/src/features/workflow-draft-read/ui/nodes/HandoffNode.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/nodes/HandoffNode.tsx
@@ -1,0 +1,13 @@
+import { Handle, Position, type NodeProps } from "@xyflow/react";
+import styles from "./nodes.module.css";
+
+export function HandoffNode({ data }: NodeProps) {
+  const label = typeof data?.label === "string" ? data.label : "";
+  return (
+    <div className={styles.handoff}>
+      <Handle type="target" position={Position.Left} />
+      {label}
+      <Handle type="source" position={Position.Right} />
+    </div>
+  );
+}

--- a/frontend/src/features/workflow-draft-read/ui/nodes/HandoffNode.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/nodes/HandoffNode.tsx
@@ -6,7 +6,7 @@ export function HandoffNode({ data }: NodeProps) {
   return (
     <div className={styles.handoff}>
       <Handle type="target" position={Position.Left} />
-      {label}
+      <span className={styles.label}>{label}</span>
       <Handle type="source" position={Position.Right} />
     </div>
   );

--- a/frontend/src/features/workflow-draft-read/ui/nodes/StartNode.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/nodes/StartNode.tsx
@@ -1,0 +1,12 @@
+import { Handle, Position, type NodeProps } from "@xyflow/react";
+import styles from "./nodes.module.css";
+
+export function StartNode({ data }: NodeProps) {
+  const label = typeof data?.label === "string" ? data.label : "";
+  return (
+    <div className={styles.start}>
+      {label}
+      <Handle type="source" position={Position.Right} />
+    </div>
+  );
+}

--- a/frontend/src/features/workflow-draft-read/ui/nodes/StartNode.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/nodes/StartNode.tsx
@@ -5,7 +5,7 @@ export function StartNode({ data }: NodeProps) {
   const label = typeof data?.label === "string" ? data.label : "";
   return (
     <div className={styles.start}>
-      {label}
+      <span className={styles.label}>{label}</span>
       <Handle type="source" position={Position.Right} />
     </div>
   );

--- a/frontend/src/features/workflow-draft-read/ui/nodes/TerminalNode.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/nodes/TerminalNode.tsx
@@ -1,0 +1,12 @@
+import { Handle, Position, type NodeProps } from "@xyflow/react";
+import styles from "./nodes.module.css";
+
+export function TerminalNode({ data }: NodeProps) {
+  const label = typeof data?.label === "string" ? data.label : "";
+  return (
+    <div className={styles.terminal}>
+      <Handle type="target" position={Position.Left} />
+      {label}
+    </div>
+  );
+}

--- a/frontend/src/features/workflow-draft-read/ui/nodes/TerminalNode.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/nodes/TerminalNode.tsx
@@ -6,7 +6,7 @@ export function TerminalNode({ data }: NodeProps) {
   return (
     <div className={styles.terminal}>
       <Handle type="target" position={Position.Left} />
-      {label}
+      <span className={styles.label}>{label}</span>
     </div>
   );
 }

--- a/frontend/src/features/workflow-draft-read/ui/nodes/nodes.module.css
+++ b/frontend/src/features/workflow-draft-read/ui/nodes/nodes.module.css
@@ -26,7 +26,7 @@
 
 .decision {
   composes: base;
-  transform: rotate(45deg);
+  position: relative;
   width: 96px;
   height: 96px;
   min-width: 0;
@@ -34,11 +34,24 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  border: none;
+  background: transparent;
+  border-radius: 0;
+}
+
+.decision::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  transform: rotate(45deg);
+  background: var(--bg-color);
+  border: 1px solid var(--text-primary);
   border-radius: var(--radius-sm);
 }
 
 .decisionLabel {
-  transform: rotate(-45deg);
+  position: relative;
+  z-index: 1;
   font-size: 12px;
 }
 

--- a/frontend/src/features/workflow-draft-read/ui/nodes/nodes.module.css
+++ b/frontend/src/features/workflow-draft-read/ui/nodes/nodes.module.css
@@ -11,8 +11,13 @@
   max-width: 100%;
   text-align: center;
   white-space: nowrap;
+}
+
+.label {
   overflow: hidden;
+  white-space: nowrap;
   text-overflow: ellipsis;
+  max-width: 100%;
 }
 
 .start {
@@ -88,7 +93,6 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  overflow: hidden;
   background: var(--text-primary);
   color: var(--bg-color);
 }

--- a/frontend/src/features/workflow-draft-read/ui/nodes/nodes.module.css
+++ b/frontend/src/features/workflow-draft-read/ui/nodes/nodes.module.css
@@ -1,0 +1,73 @@
+.base {
+  font-family: "Pretendard Variable", sans-serif;
+  font-weight: 400;
+  font-size: 13px;
+  letter-spacing: -0.14px;
+  color: var(--text-primary);
+  background: var(--bg-color);
+  border: 1px solid var(--text-primary);
+  padding: 8px 16px;
+  min-width: 120px;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.start {
+  composes: base;
+  border-radius: var(--radius-xl);
+  background: var(--text-primary);
+  color: var(--bg-color);
+}
+
+.action {
+  composes: base;
+  border-radius: var(--radius-md);
+}
+
+.decision {
+  composes: base;
+  transform: rotate(45deg);
+  width: 96px;
+  height: 96px;
+  min-width: 0;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-sm);
+}
+
+.decisionLabel {
+  transform: rotate(-45deg);
+  font-size: 12px;
+}
+
+.answer {
+  composes: base;
+  border-radius: var(--radius-md);
+  background: var(--glass-dark);
+  clip-path: polygon(8px 0, 100% 0, 100% 100%, 0 100%);
+  padding-left: 20px;
+}
+
+.handoff {
+  composes: base;
+  border-radius: var(--radius-sm);
+  clip-path: polygon(8px 0, calc(100% - 8px) 0, 100% 100%, 0 100%);
+  padding-left: 18px;
+  padding-right: 18px;
+}
+
+.terminal {
+  composes: base;
+  border-radius: var(--radius-full);
+  width: 80px;
+  height: 80px;
+  min-width: 0;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--text-primary);
+  color: var(--bg-color);
+}

--- a/frontend/src/features/workflow-draft-read/ui/nodes/nodes.module.css
+++ b/frontend/src/features/workflow-draft-read/ui/nodes/nodes.module.css
@@ -8,8 +8,11 @@
   border: 1px solid var(--text-primary);
   padding: 8px 16px;
   min-width: 120px;
+  max-width: 100%;
   text-align: center;
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .start {
@@ -53,6 +56,10 @@
   position: relative;
   z-index: 1;
   font-size: 12px;
+  max-width: 100%;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 .answer {
@@ -81,6 +88,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  overflow: hidden;
   background: var(--text-primary);
   color: var(--bg-color);
 }

--- a/frontend/src/features/workflow-draft-read/ui/nodes/nodes.module.css
+++ b/frontend/src/features/workflow-draft-read/ui/nodes/nodes.module.css
@@ -14,6 +14,7 @@
 }
 
 .label {
+  display: block;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
@@ -50,14 +51,18 @@
 .decision::before {
   content: "";
   position: absolute;
-  inset: 0;
-  transform: rotate(45deg);
+  width: 68px;
+  height: 68px;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) rotate(45deg);
   background: var(--bg-color);
   border: 1px solid var(--text-primary);
   border-radius: var(--radius-sm);
 }
 
 .decisionLabel {
+  display: block;
   position: relative;
   z-index: 1;
   font-size: 12px;
@@ -69,18 +74,40 @@
 
 .answer {
   composes: base;
+  position: relative;
+  border: none;
+  background: transparent;
+  padding-left: 20px;
+}
+
+.answer::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  clip-path: polygon(8px 0, 100% 0, 100% 100%, 0 100%);
   border-radius: var(--radius-md);
   background: var(--glass-dark);
-  clip-path: polygon(8px 0, 100% 0, 100% 100%, 0 100%);
-  padding-left: 20px;
+  border: 1px solid var(--text-primary);
+  z-index: -1;
 }
 
 .handoff {
   composes: base;
-  border-radius: var(--radius-sm);
-  clip-path: polygon(8px 0, calc(100% - 8px) 0, 100% 100%, 0 100%);
+  position: relative;
+  border: none;
+  background: transparent;
   padding-left: 18px;
   padding-right: 18px;
+}
+
+.handoff::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  clip-path: polygon(8px 0, calc(100% - 8px) 0, 100% 100%, 0 100%);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--text-primary);
+  z-index: -1;
 }
 
 .terminal {

--- a/frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.tsx
@@ -1,0 +1,74 @@
+import { useParams, useNavigate } from "react-router-dom";
+import { DashboardLayout } from "../../../shared/ui/layout/DashboardLayout";
+import { WorkflowDetailPanel, WorkflowListPanel } from "../../../features/workflow-draft-read/ui";
+import { parseRouteId } from "../../../shared/lib/parseRouteId";
+import styles from "./workflow-draft-read-page.module.css";
+
+export function WorkflowDraftReadPage() {
+  const { workspaceId, packId, versionId, workflowId } = useParams();
+  const navigate = useNavigate();
+
+  const wsId = parseRouteId(workspaceId);
+  const pId = parseRouteId(packId);
+  const vId = parseRouteId(versionId);
+  const wfId = workflowId ? parseRouteId(workflowId) : null;
+
+  if (wsId === null || pId === null || vId === null) {
+    return (
+      <DashboardLayout>
+        <div className={styles.invalidParams} role="alert">
+          잘못된 URL 파라미터입니다.
+        </div>
+      </DashboardLayout>
+    );
+  }
+
+  const handleSelect = (id: number) => {
+    navigate(`/workspaces/${wsId}/domain-packs/${pId}/versions/${vId}/workflows/${id}`);
+  };
+
+  const handleBack = () => {
+    navigate(`/workspaces/${wsId}/domain-packs/${pId}/versions/${vId}/workflows`);
+  };
+
+  const hasSelection = wfId !== null;
+
+  return (
+    <DashboardLayout>
+      <div className={styles.pageWrapper}>
+        <header className={styles.pageHeader}>
+          <nav className={styles.breadcrumb} aria-label="경로">
+            <span>WS · {wsId}</span>
+            <span className={styles.breadcrumbSeparator}>/</span>
+            <span>PACK · {pId}</span>
+            <span className={styles.breadcrumbSeparator}>/</span>
+            <span>VER · {vId}</span>
+          </nav>
+          <div className={styles.versionMeta}>
+            <span className={styles.versionTitle}>Workflow 초안 조회</span>
+            <span className={styles.versionBadge}>READ ONLY</span>
+          </div>
+        </header>
+        {hasSelection && (
+          <button type="button" className={styles.backButton} onClick={handleBack}>
+            ← 목록
+          </button>
+        )}
+        <div className={`${styles.twoPane} ${hasSelection ? styles.hasSelection : ""}`}>
+          <div className={styles.listSlot}>
+            <WorkflowListPanel
+              wsId={wsId}
+              packId={pId}
+              versionId={vId}
+              selectedId={wfId}
+              onSelect={handleSelect}
+            />
+          </div>
+          <div className={styles.detailSlot}>
+            <WorkflowDetailPanel wsId={wsId} packId={pId} versionId={vId} workflowId={wfId} />
+          </div>
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.tsx
@@ -13,7 +13,7 @@ export function WorkflowDraftReadPage() {
   const vId = parseRouteId(versionId);
   const wfId = workflowId ? parseRouteId(workflowId) : null;
 
-  if (wsId === null || pId === null || vId === null) {
+  if (wsId === null || pId === null || vId === null || (workflowId !== undefined && wfId === null)) {
     return (
       <DashboardLayout>
         <div className={styles.invalidParams} role="alert">

--- a/frontend/src/pages/domain-pack/ui/workflow-draft-read-page.module.css
+++ b/frontend/src/pages/domain-pack/ui/workflow-draft-read-page.module.css
@@ -1,0 +1,119 @@
+.pageWrapper {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: calc(100vh - 72px);
+  overflow: hidden;
+}
+
+.pageHeader {
+  padding: 16px 28px;
+  border-bottom: 1px solid var(--glass-border);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  background: var(--bg-color);
+}
+
+.breadcrumb {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  font-family: "Geist Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.54px;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.breadcrumbSeparator {
+  color: var(--text-muted);
+}
+
+.versionMeta {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.versionTitle {
+  font-family: "Pretendard Variable", sans-serif;
+  font-weight: 540;
+  font-size: 18px;
+  letter-spacing: -0.14px;
+  color: var(--text-primary);
+}
+
+.versionBadge {
+  display: inline-flex;
+  font-family: "Geist Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.54px;
+  text-transform: uppercase;
+  padding: 2px 8px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--text-primary);
+  color: var(--text-primary);
+}
+
+.twoPane {
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+  min-height: 0;
+}
+
+.invalidParams {
+  padding: 32px;
+  color: var(--text-secondary);
+  font-size: 14px;
+  letter-spacing: -0.14px;
+}
+
+@media (max-width: 767px) {
+  .twoPane {
+    flex-direction: column;
+  }
+
+  .twoPane.hasSelection .listSlot {
+    display: none;
+  }
+
+  .twoPane:not(.hasSelection) .detailSlot {
+    display: none;
+  }
+
+  .backButton {
+    display: inline-flex;
+    font-family: "Geist Mono", monospace;
+    font-size: 11px;
+    letter-spacing: 0.54px;
+    text-transform: uppercase;
+    padding: 6px 14px;
+    margin: 12px 16px 0;
+    border-radius: var(--radius-xl);
+    border: 1px solid var(--text-primary);
+    background: var(--bg-color);
+    color: var(--text-primary);
+    cursor: pointer;
+    align-self: flex-start;
+  }
+}
+
+@media (min-width: 768px) {
+  .backButton {
+    display: none;
+  }
+}
+
+.listSlot,
+.detailSlot {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+}
+
+.listSlot {
+  flex: 0 0 auto;
+}

--- a/frontend/src/pages/domain-pack/ui/workflow-draft-read-page.module.css
+++ b/frontend/src/pages/domain-pack/ui/workflow-draft-read-page.module.css
@@ -1,8 +1,9 @@
 .pageWrapper {
+  --app-header-height: 72px;
   display: flex;
   flex-direction: column;
   width: 100%;
-  height: calc(100vh - 72px);
+  height: calc(100vh - var(--app-header-height));
   overflow: hidden;
 }
 
@@ -77,6 +78,11 @@
 
   .twoPane.hasSelection .listSlot {
     display: none;
+  }
+
+  .twoPane:not(.hasSelection) .listSlot {
+    flex: 1;
+    min-height: 0;
   }
 
   .twoPane:not(.hasSelection) .detailSlot {

--- a/frontend/src/shared/lib/parseRouteId.test.ts
+++ b/frontend/src/shared/lib/parseRouteId.test.ts
@@ -21,4 +21,25 @@ describe("parseRouteId", () => {
   it('"0" → 0', () => {
     expect(parseRouteId("0")).toBe(0);
   });
+
+  it('빈 문자열 → null', () => {
+    expect(parseRouteId("")).toBeNull();
+  });
+
+  it('공백 문자열 → null', () => {
+    expect(parseRouteId(" ")).toBeNull();
+    expect(parseRouteId("  ")).toBeNull();
+  });
+
+  it('소수점 → null', () => {
+    expect(parseRouteId("1.5")).toBeNull();
+  });
+
+  it('음수 → null', () => {
+    expect(parseRouteId("-1")).toBeNull();
+  });
+
+  it('지수 표기법 → null', () => {
+    expect(parseRouteId("1e3")).toBeNull();
+  });
 });

--- a/frontend/src/shared/lib/parseRouteId.test.ts
+++ b/frontend/src/shared/lib/parseRouteId.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { parseRouteId } from "./parseRouteId";
+
+describe("parseRouteId", () => {
+  it("undefined → null", () => {
+    expect(parseRouteId(undefined)).toBeNull();
+  });
+
+  it("숫자가 아닌 문자열 → null", () => {
+    expect(parseRouteId("abc")).toBeNull();
+  });
+
+  it('"NaN" 문자열 → null', () => {
+    expect(parseRouteId("NaN")).toBeNull();
+  });
+
+  it("정상 숫자 문자열 → 숫자", () => {
+    expect(parseRouteId("42")).toBe(42);
+  });
+
+  it('"0" → 0', () => {
+    expect(parseRouteId("0")).toBe(0);
+  });
+});

--- a/frontend/src/shared/lib/parseRouteId.test.ts
+++ b/frontend/src/shared/lib/parseRouteId.test.ts
@@ -18,8 +18,8 @@ describe("parseRouteId", () => {
     expect(parseRouteId("42")).toBe(42);
   });
 
-  it('"0" → 0', () => {
-    expect(parseRouteId("0")).toBe(0);
+  it('"0" → null (백엔드 ID는 양의 정수)', () => {
+    expect(parseRouteId("0")).toBeNull();
   });
 
   it('빈 문자열 → null', () => {

--- a/frontend/src/shared/lib/parseRouteId.ts
+++ b/frontend/src/shared/lib/parseRouteId.ts
@@ -2,6 +2,6 @@ export function parseRouteId(id: string | undefined): number | null {
   if (id === undefined) return null;
   if (!/^\d+$/.test(id)) return null;
   const n = parseInt(id, 10);
-  if (!Number.isSafeInteger(n)) return null;
+  if (!Number.isSafeInteger(n) || n <= 0) return null;
   return n;
 }

--- a/frontend/src/shared/lib/parseRouteId.ts
+++ b/frontend/src/shared/lib/parseRouteId.ts
@@ -1,5 +1,7 @@
 export function parseRouteId(id: string | undefined): number | null {
   if (id === undefined) return null;
   if (!/^\d+$/.test(id)) return null;
-  return parseInt(id, 10);
+  const n = parseInt(id, 10);
+  if (!Number.isSafeInteger(n)) return null;
+  return n;
 }

--- a/frontend/src/shared/lib/parseRouteId.ts
+++ b/frontend/src/shared/lib/parseRouteId.ts
@@ -1,5 +1,5 @@
 export function parseRouteId(id: string | undefined): number | null {
   if (id === undefined) return null;
-  const n = Number(id);
-  return Number.isNaN(n) ? null : n;
+  if (!/^\d+$/.test(id)) return null;
+  return parseInt(id, 10);
 }

--- a/frontend/src/shared/lib/parseRouteId.ts
+++ b/frontend/src/shared/lib/parseRouteId.ts
@@ -1,0 +1,5 @@
+export function parseRouteId(id: string | undefined): number | null {
+  if (id === undefined) return null;
+  const n = Number(id);
+  return Number.isNaN(n) ? null : n;
+}

--- a/frontend/src/shared/ui/ErrorBoundary.tsx
+++ b/frontend/src/shared/ui/ErrorBoundary.tsx
@@ -3,17 +3,37 @@ import { Component, type ErrorInfo, type ReactNode } from "react";
 interface Props {
   fallback: ReactNode;
   children: ReactNode;
+  resetKeys?: unknown[];
+  onReset?: () => void;
 }
 
 interface State {
   hasError: boolean;
+  prevResetKeys?: unknown[];
 }
 
 export class ErrorBoundary extends Component<Props, State> {
-  state: State = { hasError: false };
+  state: State = { hasError: false, prevResetKeys: this.props.resetKeys };
 
   static getDerivedStateFromError(): State {
     return { hasError: true };
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    const { resetKeys, onReset } = this.props;
+
+    // Check if resetKeys have changed
+    if (this.state.hasError && resetKeys !== undefined) {
+      const hasResetKeysChanged =
+        prevProps.resetKeys === undefined ||
+        resetKeys.length !== prevProps.resetKeys.length ||
+        resetKeys.some((key, index) => key !== prevProps.resetKeys?.[index]);
+
+      if (hasResetKeysChanged) {
+        this.setState({ hasError: false, prevResetKeys: resetKeys });
+        onReset?.();
+      }
+    }
   }
 
   componentDidCatch(error: Error, info: ErrorInfo) {

--- a/frontend/src/shared/ui/ErrorBoundary.tsx
+++ b/frontend/src/shared/ui/ErrorBoundary.tsx
@@ -1,0 +1,27 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+interface Props {
+  fallback: ReactNode;
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error("[ErrorBoundary]", error, info.componentStack);
+  }
+
+  render() {
+    if (this.state.hasError) return this.props.fallback;
+    return this.props.children;
+  }
+}


### PR DESCRIPTION
## Summary

- 운영자 콘솔에 workflow 초안 목록/상세 조회 페이지 신규 추가
- 좌측 리스트 + 우측 상세 패널 레이아웃, `@xyflow/react` 기반 graphJson 시각화 포함
- BE spec/226 엔드포인트를 소비하는 순수 읽기 전용 FE 화면

---

## Context

`.agent/specs/227.md`(FE-227) 구현 PR이다. 의존 BE API는 spec/226에서 구현된 상태이며, 이 PR은 FE 화면만 추가한다. 디자인 기반은 `ebb9304`(PR #51)에서 main에 반영된 CSS 변수·shadcn 토큰을 그대로 재사용한다.

---

## What Changed

| 영역 | 변경 내용 |
|------|----------|
| 라우팅 | `App.tsx`에 목록(`/workflows`) + 상세(`.../workflows/:workflowId`) 2개 라우트 추가 |
| `entities/workflow` | `WorkflowSummary`, `WorkflowDetail`, `WorkflowGraph`, `GraphNode`, `GraphEdge` 타입 정의 |
| `features/workflow-draft-read/api` | `workflowApi.list / detail` service object |
| `features/workflow-draft-read/model` | `useWorkflowList`, `useWorkflowDetail` discriminated-union 상태 훅; `parseTerminalStates` 파서 |
| `features/workflow-draft-read/ui` | `WorkflowListPanel`, `WorkflowDetailPanel`(Graph/JSON/Meta 탭), `GraphRenderer`(lazy+Suspense), 커스텀 노드 6종, `graphMapper` |
| `shared/lib/parseRouteId` | URL param `string \| undefined` → `number \| null` 변환 유틸 |
| 의존성 | `@xyflow/react ^12.10.2` 추가 |
| 테스트 | `parseTerminalStates`(5), `useWorkflowList`(5), `useWorkflowDetail`(5), `graphMapper`(6), `parseRouteId`(5) — 총 26케이스 |

`GraphRenderer`는 `export default` + `React.lazy`로 코드 스플리팅되어 있다(빌드 시 별도 lazy chunk 분리).

---

## Assumptions Adopted

| ID | 채택 assumption | 영향 |
|----|----------------|------|
| U-FE-2 | 상위 탐색 UX 미포함. 라우트 2건만 추가, DashboardLayout "Workflows" nav는 disabled 유지 | QA·시연 시 URL 직접 입력 필요 |
| U-FE-4 | 모바일 `<768px` 전환: 풀페이지 스택 + "← 목록" 버튼 (드로어 방식 아님) | 모바일 드로어 UX 요구 시 별도 백로그 |
| U-FE-5 | 에러 메시지: BE `message` 기본 표시, 403 목록 에러에만 FE 카피(`"접근 권한 없음"`) + toast | 에러 카피 맵 상수 파일 미도입 |
| U-FE-6 | `entities/workflow`는 타입만 보유, UI/훅 없음 | FSD 준수 |
| U-FE-8 | CSS는 `"Pretendard Variable"` / `"Geist Mono"` 사용, `frontend/DESIGN.md` 미편집 | DESIGN.md 폰트 명칭 교정은 별도 docs/* 백로그 |

---

## Spec Deviations

| 항목 | 스펙 | 구현 | 판단 |
|------|------|------|------|
| `evidenceJson` / `metaJson` 표시 | "terminalStates/evidence/meta 포맷 표시" | raw `<code>` 블록으로 최소 충족. `evidenceJson` 전용 파서/뷰 없음 | U-FE-7 — evidence 구조 확정 전 유예. 별도 백로그 대상 |
| `GraphNode.type` 타입 | spec은 inline union(`'START' \| 'ACTION' \| ...`) | `GraphNodeType` 타입 별칭으로 추출 후 재사용 | 기능 동일, 리팩터링 허용 범위 |
| `graphMapper` TB 방향 컬럼 수 | spec 미명시 | `COLUMNS_FOR_TB = 4` (휴리스틱) | 노드 다수 시 overlap 가능성 있음. 후속 dagre 도입 판단 포인트 |

---

## Blocked / Skipped Items

| 항목 | 이유 |
|------|------|
| Domain Pack / Version 상위 탐색 UX | spec Out of Scope. 별도 백로그 |
| Workflow 편집/수정 UI | spec/329(BE) 이후 별도 FE 백로그 |
| E2E 테스트 | 로컬 BE(spec/226) 기동 전제 — spec이 수동 체크리스트로 분류, 구현 범위 밖 |
| 컴포넌트/패널 렌더 테스트 | spec이 "권장"으로 분류. 핵심 로직 유닛 테스트는 감사 수정 시 추가 완료 |
| `frontend/DESIGN.md` 폰트 명칭 교정 | U-FE-8 Option C 결정 — 별도 docs/* 백로그 |

---

## Test Notes

| 파일 | 케이스 수 | 결과 |
|------|---------|------|
| `parseTerminalStates.test.ts` | 5 | ✅ pass |
| `useWorkflowList.test.ts` | 5 | ✅ pass (감사 V-002 수정으로 추가) |
| `useWorkflowDetail.test.ts` | 5 | ✅ pass (감사 V-002 수정으로 추가) |
| `graphMapper.test.ts` | 6 | ✅ pass (감사 V-002 수정으로 추가) |
| `parseRouteId.test.ts` | 5 | ✅ pass (감사 V-002 수정으로 추가) |

- 기존 `authApi.test.ts` 4건 실패는 이번 변경 이전부터 존재하던 pre-existing 실패이며 본 PR과 무관.
- `proOptions={{ hideAttribution: true }}` 제거(V-003 감사 수정): 라이선스 미보유 확인 후 제거 완료.

---

## Reviewer Focus

1. **`graphMapper.ts` — TB 방향 컬럼 수(`COLUMNS_FOR_TB = 4`)**: spec 미명시 휴리스틱. 노드 많을 때 가독성 이슈 가능성. dagre 도입 필요성 판단 포인트.
2. **커스텀 노드 Handle 좌표**: `Decision/Answer/Handoff` 노드의 `clip-path` / `transform rotate`는 `@xyflow/react` 기본 Handle 위치와 시각적으로 어긋날 수 있음. 실제 graphJson 데이터로 렌더 확인 권장.
3. **`evidenceJson` / `metaJson` raw 표시**: 현재 `<code>` 블록 최소 충족. evidence 구조 확정 시 전용 뷰 별도 작업 필요 여부 합의.
4. **U-FE-2 — 진입 경로 없음**: "Workflows" nav가 disabled이므로 URL 직접 입력 외 진입 불가. 테스트 시 유의.

---

## Conflicts

없음. spec과 구현 간 불일치는 Spec Deviations 섹션에 모두 명시됨.

---

## Ready to Merge / Needs Input

**Ready to Merge** — 감사 4건 수정 완료(V-002 auto, V-003 approved, V-004 auto; V-001은 기존 커밋 소급 불가 deferred). 테스트 26케이스 전부 통과. 리뷰어 확인 포인트는 위 Reviewer Focus 섹션 참조.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 워크플로우 초안 읽기 페이지(목록/상세 2-패널) 및 관련 라우팅 추가
  * 그래프 시각화(노드/엣지 유형, 레이아웃), 그래프 렌더러·노드 컴포넌트·에러 경계 도입
  * 상세 패널에 그래프/JSON/메타 탭(그래프 lazy-load 포함) 추가
  * 데이터 로딩 훅 및 API 연동, 경로 ID 파싱 유틸 추가

* **Bug Fixes / UX**
  * API 오류 매핑과 토스트 메시지 개선
  * 터미널 상태 파싱 안정화 및 에러/빈값 처리 개선

* **Tests**
  * 훅·파서·그래프 매핑 단위 테스트 추가

* **Chores**
  * React 그래프 라이브러리 의존성 추가 및 패키지 파일 형식 정리
<!-- end of auto-generated comment: release notes by coderabbit.ai -->