### PR TITLE
spec/0131: [FE] 공용 API 클라이언트 DELETE 메서드 추가

### DIFF
--- a/.agent/specs/0131.md
+++ b/.agent/specs/0131.md
@@ -1,0 +1,164 @@
+# [FE-0131] 공용 API 클라이언트 DELETE 메서드 추가
+
+> **Backlog**: 프론트엔드 공용 API 클라이언트가 `DELETE` 요청을 지원하지 않아, 삭제/보관 성격의 REST API를 일관된 방식으로 호출하기 어렵다.
+> **Bounded Context**: `frontend/shared`
+> **Template**: `_TEMPLATE_FE.md`
+> **Branch**: `spec/0131`
+
+---
+
+## Goal
+
+프론트엔드 공용 API 클라이언트에 `DELETE` 메서드를 추가해 삭제/보관 성격의 REST API를 `get/post/patch`와 동일한 규칙으로 호출할 수 있게 한다.
+
+---
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A[Feature or entity layer] --> B["apiClient.delete(path) 호출"]
+    B --> C["fetch(..., method: DELETE)"]
+    C --> D{응답 상태}
+    D -->|204 No Content| E[undefined 반환]
+    D -->|2xx with body| F[JSON 파싱 후 반환]
+    D -->|4xx or 5xx| G[ApiRequestError throw]
+```
+
+---
+
+## Design Diff
+
+### As-is vs To-be
+
+| 영역 | As-is | To-be | 변경 내용 |
+|------|-------|-------|----------|
+| 공용 API 메서드 | `get`, `post`, `patch`만 제공 | `delete` 추가 | REST 삭제/보관 API 공통 지원 |
+| 삭제 요청 호출부 | 개별 `fetch` 작성 필요 | `apiClient.delete()` 재사용 | 중복 제거 |
+| 204 응답 처리 | 호출부별로 직접 처리 필요 | `handleResponse()` 재사용 | 성공 처리 규칙 일관화 |
+
+---
+
+## Component Tree
+
+```text
+shared/api
+└─ ApiClient
+   ├─ get()
+   ├─ post()
+   ├─ patch()
+   └─ delete()
+```
+
+이번 작업은 UI 컴포넌트 추가 없이 `shared` 계층의 공용 인프라만 수정한다.
+
+---
+
+## API Integration
+
+### 대상 호출 패턴
+
+| Method | Path Example | Description |
+|--------|--------------|-------------|
+| DELETE | `/api/v1/{resource}/{id}` | 리소스 삭제/보관 요청 |
+
+### Client Contract
+
+```typescript
+async delete<T>(path: string): Promise<T>
+```
+
+- 인증 헤더는 기존 `get/post/patch`와 동일하게 `getHeaders()`를 사용한다.
+- 성공 응답 처리는 기존 `handleResponse()`를 그대로 재사용한다.
+- `204 No Content`는 `undefined as T`를 반환한다.
+- 실패 응답은 기존과 동일하게 `ApiRequestError`를 던진다.
+
+---
+
+## Data Flow
+
+```text
+feature/entity hook
+  -> shared/api/apiClient.delete(path)
+  -> fetch DELETE request
+  -> handleResponse()
+  -> success value or ApiRequestError
+```
+
+---
+
+## 수정 대상 파일
+
+| 파일 | 변경 유형 | 설명 |
+|------|----------|------|
+| `frontend/src/shared/api/index.ts` | update | `ApiClient.delete()` 메서드 추가 |
+
+이번 스펙 범위에는 특정 도메인 전용 훅/서비스 추가나 UI 연결은 포함하지 않는다.
+
+---
+
+## State Management
+
+별도 상태 관리 변경 없음.
+
+---
+
+## Tests
+
+### Test Strategy
+
+| 구분 | 방법 | 도구 | 비고 |
+|------|------|------|------|
+| 정적 검토 | 타입 시그니처 확인 | TypeScript | 기존 메서드와 일관성 확인 |
+| 수동 테스트 | DELETE API 호출 연결 확인 | 브라우저 DevTools | 204/에러 응답 처리 확인 |
+
+### Test Scenarios
+
+#### Happy Path
+
+| # | 시나리오 | 조작 | 기대 결과 |
+|---|---------|------|----------|
+| 1 | 204 응답 DELETE 호출 | `apiClient.delete('/workspaces/1')` | 예외 없이 종료, `undefined` 반환 |
+| 2 | JSON body를 가진 2xx DELETE 호출 | mock API 연결 | JSON body 반환 |
+
+#### Error & Edge Cases
+
+| # | 시나리오 | 조작 | 기대 결과 |
+|---|---------|------|----------|
+| 1 | 404 응답 | 존재하지 않는 리소스 삭제 | `ApiRequestError` throw |
+| 2 | 403 응답 | 권한 없는 삭제 시도 | `ApiRequestError` throw |
+| 3 | 인증 토큰 없음 | 보호된 DELETE 호출 | 기존과 동일한 인증 에러 처리 |
+
+---
+
+## Implementation Example
+
+```typescript
+class ApiClient {
+  async delete<T>(path: string): Promise<T> {
+    const response = await fetch(`${this.baseUrl}${path}`, {
+      method: 'DELETE',
+      headers: this.getHeaders(),
+    });
+
+    return this.handleResponse<T>(response);
+  }
+}
+```
+
+---
+
+## Notes
+
+- `DELETE` 메서드 추가는 특정 도메인 API를 위한 예외 처리나 우회가 아니라, 기존 REST 계약을 프론트 공용 클라이언트가 지원하도록 맞추는 작업이다.
+- 공용 API 클라이언트는 `shared` 계층에 위치하므로 특정 도메인 기능에 종속된 로직을 포함하지 않는다.
+- 필요 시 후속 구현 브랜치에서 각 feature/entity 레이어가 이 메서드를 사용하도록 연결할 수 있다.
+
+---
+
+## Out of Scope
+
+- 특정 도메인 UI 구현
+- TanStack Query mutation 추가
+- `put`, `head`, `options` 등 다른 HTTP 메서드 확장
+- backend API 계약 변경

--- a/.agent/specs/0131.md
+++ b/.agent/specs/0131.md
@@ -69,9 +69,9 @@ async delete<T>(path: string): Promise<T>
 ```
 
 - 인증 헤더는 기존 `get/post/patch`와 동일하게 `getHeaders()`를 사용한다.
-- 성공 응답 처리는 기존 `handleResponse()`를 그대로 재사용한다.
-- `204 No Content`는 `undefined as T`를 반환한다.
-- 실패 응답은 기존과 동일하게 `ApiRequestError`를 던진다.
+- 성공 응답과 실패 응답의 해석은 기존 `handleResponse()`를 그대로 재사용한다.
+- `204 No Content`는 `delete()` 내부에서 별도 분기하지 않고, `handleResponse()`가 `undefined as T`를 반환하도록 처리한다.
+- 실패 응답은 `delete()`가 별도 예외 변환을 하지 않고, `handleResponse()`가 기존과 동일하게 `ApiRequestError`를 던진다.
 
 ---
 
@@ -109,8 +109,18 @@ feature/entity hook
 
 | 구분 | 방법 | 도구 | 비고 |
 |------|------|------|------|
+| 단위/통합 테스트 | `fetch` mocking 기반 API 테스트 | `vite-plus/test`, `vi.stubGlobal('fetch', ...)` | 기존 `frontend/src/features/auth/api/authApi.test.ts` 패턴 준용 |
 | 정적 검토 | 타입 시그니처 확인 | TypeScript | 기존 메서드와 일관성 확인 |
-| 수동 테스트 | DELETE API 호출 연결 확인 | 브라우저 DevTools | 204/에러 응답 처리 확인 |
+| 수동 테스트 | DELETE API 호출 연결 확인 | 브라우저 DevTools | 자동화 테스트로 커버하지 않는 실제 연결만 확인 |
+
+자동화 테스트는 최소 1개 이상이 아니라, 아래 핵심 응답 계약을 모두 포함하도록 작성한다.
+
+- `204 No Content` 응답 시 `handleResponse()`를 통해 `undefined`를 반환한다.
+- JSON body가 있는 `2xx` 응답 시 파싱된 값을 반환한다.
+- `4xx` 응답 시 `ApiRequestError`를 던진다.
+- `5xx` 응답 시 `ApiRequestError`를 던진다.
+
+테스트 위치는 `frontend/src/shared/api/index.test.ts` 또는 이에 준하는 shared API 테스트 파일로 두고, HTTP 계층은 `fetch` mocking으로 제어한다.
 
 ### Test Scenarios
 
@@ -118,16 +128,16 @@ feature/entity hook
 
 | # | 시나리오 | 조작 | 기대 결과 |
 |---|---------|------|----------|
-| 1 | 204 응답 DELETE 호출 | `apiClient.delete('/workspaces/1')` | 예외 없이 종료, `undefined` 반환 |
-| 2 | JSON body를 가진 2xx DELETE 호출 | mock API 연결 | JSON body 반환 |
+| 1 | 204 응답 DELETE 호출 | mocked `fetch`가 `status: 204`, `ok: true` 반환 | `apiClient.delete(...)`가 `undefined` 반환 |
+| 2 | JSON body를 가진 2xx DELETE 호출 | mocked `fetch`가 `status: 200`, `ok: true`, `json()` 반환 | JSON body 반환 |
 
 #### Error & Edge Cases
 
 | # | 시나리오 | 조작 | 기대 결과 |
 |---|---------|------|----------|
-| 1 | 404 응답 | 존재하지 않는 리소스 삭제 | `ApiRequestError` throw |
-| 2 | 403 응답 | 권한 없는 삭제 시도 | `ApiRequestError` throw |
-| 3 | 인증 토큰 없음 | 보호된 DELETE 호출 | 기존과 동일한 인증 에러 처리 |
+| 1 | 4xx 응답 | mocked `fetch`가 `status: 404` 또는 `403`, `ok: false`, 에러 JSON 반환 | `ApiRequestError` throw |
+| 2 | 5xx 응답 | mocked `fetch`가 `status: 500`, `ok: false`, 에러 JSON 반환 | `ApiRequestError` throw |
+| 3 | 에러 바디 파싱 실패 | mocked `fetch`가 `ok: false`, `json()` reject | `UNKNOWN_ERROR` 기본값으로 `ApiRequestError` throw |
 
 ---
 


### PR DESCRIPTION
# [FE-0131] 공용 API 클라이언트 DELETE 메서드 추가

> **Backlog**: 프론트엔드 공용 API 클라이언트가 `DELETE` 요청을 지원하지 않아, 삭제/보관 성격의 REST API를 일관된 방식으로 호출하기 어렵다.
> **Bounded Context**: `frontend/shared`
> **Template**: `_TEMPLATE_FE.md`
> **Branch**: `spec/0131`

---

## Goal

프론트엔드 공용 API 클라이언트에 `DELETE` 메서드를 추가해 삭제/보관 성격의 REST API를 `get/post/patch`와 동일한 규칙으로 호출할 수 있게 한다.

---

## User Flow Chart

```mermaid
flowchart TD
    A[Feature or entity layer] --> B["apiClient.delete(path) 호출"]
    B --> C["fetch(..., method: DELETE)"]
    C --> D{응답 상태}
    D -->|204 No Content| E[undefined 반환]
    D -->|2xx with body| F[JSON 파싱 후 반환]
    D -->|4xx or 5xx| G[ApiRequestError throw]
```

---

## Design Diff

### As-is vs To-be

| 영역 | As-is | To-be | 변경 내용 |
|------|-------|-------|----------|
| 공용 API 메서드 | `get`, `post`, `patch`만 제공 | `delete` 추가 | REST 삭제/보관 API 공통 지원 |
| 삭제 요청 호출부 | 개별 `fetch` 작성 필요 | `apiClient.delete()` 재사용 | 중복 제거 |
| 204 응답 처리 | 호출부별로 직접 처리 필요 | `handleResponse()` 재사용 | 성공 처리 규칙 일관화 |

---

## Component Tree

```text
shared/api
└─ ApiClient
   ├─ get()
   ├─ post()
   ├─ patch()
   └─ delete()
```

이번 작업은 UI 컴포넌트 추가 없이 `shared` 계층의 공용 인프라만 수정한다.

---

## API Integration

### 대상 호출 패턴

| Method | Path Example | Description |
|--------|--------------|-------------|
| DELETE | `/api/v1/{resource}/{id}` | 리소스 삭제/보관 요청 |

### Client Contract

```typescript
async delete<T>(path: string): Promise<T>
```

- 인증 헤더는 기존 `get/post/patch`와 동일하게 `getHeaders()`를 사용한다.
- 성공 응답 처리는 기존 `handleResponse()`를 그대로 재사용한다.
- `204 No Content`는 `undefined as T`를 반환한다.
- 실패 응답은 기존과 동일하게 `ApiRequestError`를 던진다.

---

## Data Flow

```text
feature/entity hook
  -> shared/api/apiClient.delete(path)
  -> fetch DELETE request
  -> handleResponse()
  -> success value or ApiRequestError
```

---

## 수정 대상 파일

| 파일 | 변경 유형 | 설명 |
|------|----------|------|
| `frontend/src/shared/api/index.ts` | update | `ApiClient.delete()` 메서드 추가 |

이번 스펙 범위에는 특정 도메인 전용 훅/서비스 추가나 UI 연결은 포함하지 않는다.

---

## State Management

별도 상태 관리 변경 없음.

---

## Tests

### Test Strategy

| 구분 | 방법 | 도구 | 비고 |
|------|------|------|------|
| 정적 검토 | 타입 시그니처 확인 | TypeScript | 기존 메서드와 일관성 확인 |
| 수동 테스트 | DELETE API 호출 연결 확인 | 브라우저 DevTools | 204/에러 응답 처리 확인 |

### Test Scenarios

#### Happy Path

| # | 시나리오 | 조작 | 기대 결과 |
|---|---------|------|----------|
| 1 | 204 응답 DELETE 호출 | `apiClient.delete('/workspaces/1')` | 예외 없이 종료, `undefined` 반환 |
| 2 | JSON body를 가진 2xx DELETE 호출 | mock API 연결 | JSON body 반환 |

#### Error & Edge Cases

| # | 시나리오 | 조작 | 기대 결과 |
|---|---------|------|----------|
| 1 | 404 응답 | 존재하지 않는 리소스 삭제 | `ApiRequestError` throw |
| 2 | 403 응답 | 권한 없는 삭제 시도 | `ApiRequestError` throw |
| 3 | 인증 토큰 없음 | 보호된 DELETE 호출 | 기존과 동일한 인증 에러 처리 |

---

## Implementation Example

```typescript
class ApiClient {
  async delete<T>(path: string): Promise<T> {
    const response = await fetch(`${this.baseUrl}${path}`, {
      method: 'DELETE',
      headers: this.getHeaders(),
    });

    return this.handleResponse<T>(response);
  }
}
```

---

## Notes

- `DELETE` 메서드 추가는 특정 도메인 API를 위한 예외 처리나 우회가 아니라, 기존 REST 계약을 프론트 공용 클라이언트가 지원하도록 맞추는 작업이다.
- 공용 API 클라이언트는 `shared` 계층에 위치하므로 특정 도메인 기능에 종속된 로직을 포함하지 않는다.
- 필요 시 후속 구현 브랜치에서 각 feature/entity 레이어가 이 메서드를 사용하도록 연결할 수 있다.

---

## Out of Scope

- 특정 도메인 UI 구현
- TanStack Query mutation 추가
- `put`, `head`, `options` 등 다른 HTTP 메서드 확장
- backend API 계약 변경


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * API를 통한 데이터 삭제 기능이 도입될 예정입니다. 기존 조회/생성과 동일한 방식으로 안정적으로 삭제할 수 있습니다.

* **문서화**
  * 삭제 동작에 대한 사용 계약(성공/오류 처리, 204 응답 동작 등)과 컴포넌트 인터페이스 변경에 대한 설계 문서가 추가되었습니다.

* **테스트**
  * 삭제 동작을 위한 테스트 전략(성공/오류 경로 및 목 처리)이 명시되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->