### PR TITLE
feat(shared): add delete method to api client (FE-0131)

### DIFF
--- a/frontend/src/shared/api/index.ts
+++ b/frontend/src/shared/api/index.ts
@@ -72,6 +72,15 @@ class ApiClient {
 
     return this.handleResponse<T>(response);
   }
+
+  async delete<T>(path: string): Promise<T> {
+    const response = await fetch(`${this.baseUrl}${path}`, {
+      method: 'DELETE',
+      headers: this.getHeaders(),
+    });
+
+    return this.handleResponse<T>(response);
+  }
 }
 
 export class ApiRequestError extends Error {


### PR DESCRIPTION
## Summary
- add `delete<T>(path: string)` to the shared api client
- reuse existing `getHeaders()` and `handleResponse()` behavior

## Context
- implementation PR for `.agent/specs/0131.md`
- scope is limited to `frontend/src/shared/api/index.ts`

## What Changed
- added `apiClient.delete()` using `fetch(..., { method: 'DELETE' })`
- kept the existing response handling contract for `204`, `2xx`, and error responses

## Validation
- `pnpm exec eslint src/shared/api/index.ts`
- manual spot checks for DELETE request shape, `204 -> undefined`, `200 -> JSON return`, and `404 -> ApiRequestError`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* API 클라이언트에 DELETE 요청 지원을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->