### PR TITLE
spec/2211: [BE] policy/rule 초안 단건 조회 APIs 

### DIFF
--- a/.agent/specs/2211.md
+++ b/.agent/specs/2211.md
@@ -1,0 +1,208 @@
+# [BE] 2.2.11 — Policy / Rule 초안 단건 조회
+
+## Goal
+
+특정 Domain Pack Version에 속한 Policy 초안 단건을 조회하는 READ 전용 엔드포인트를 제공한다.
+
+---
+
+## Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    actor c as Client
+    participant ctrl as PolicyDefinitionController
+    participant uc as GetPolicyDefinitionUseCase
+    participant validator as DomainPackValidator
+    participant repo as PolicyDefinitionRepository
+    participant db as PostgreSQL
+
+    c ->> ctrl: GET /api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/policies/{policyId}
+    ctrl ->> uc: execute(GetPolicyDefinitionQuery)
+    uc ->> validator: validateForWorkspacePackVersion(workspaceId, userId, packId, versionId)
+    validator -->> uc: (passes or throws)
+    uc ->> repo: findByIdAndDomainPackVersionId(policyId, versionId)
+    repo ->> db: SELECT * FROM pack.policy_definition WHERE id = ? AND domain_pack_version_id = ?
+    db -->> repo: row
+    repo -->> uc: Optional<PolicyDefinition>
+    uc -->> ctrl: PolicyDefinitionResponse
+    ctrl -->> c: 200 OK
+```
+
+---
+
+## REST API
+
+### Endpoint
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/policies/{policyId}` | Policy 초안 단건 조회 |
+
+### Request
+
+Path variables:
+- `workspaceId`: Long
+- `packId`: Long
+- `versionId`: Long
+- `policyId`: Long
+
+Headers:
+- `Authorization: Bearer {jwt-token}` (필수)
+
+### Response
+
+**200 OK**
+
+```json
+{
+  "id": 1,
+  "domainPackVersionId": 10,
+  "policyCode": "POL_RETURN",
+  "name": "반품 처리 정책",
+  "description": "7일 이내 반품 허용",
+  "severity": "HIGH",
+  "conditionJson": {},
+  "actionJson": {},
+  "evidenceJson": [],
+  "metaJson": {},
+  "status": "ACTIVE",
+  "createdAt": "2025-04-03T10:00:00Z",
+  "updatedAt": "2025-04-03T10:00:00Z"
+}
+```
+
+**401 Unauthorized**
+
+```json
+{ "code": "UNAUTHORIZED", "message": "인증이 필요합니다." }
+```
+
+**403 Forbidden**
+
+```json
+{ "code": "FORBIDDEN", "message": "접근 권한이 없습니다." }
+```
+
+**404 Not Found — policy not found**
+
+```json
+{ "code": "POLICY_DEFINITION_NOT_FOUND", "message": "PolicyDefinition not found: {policyId}" }
+```
+
+**404 Not Found — workspace / pack / version not found**
+
+```json
+{ "code": "NOT_FOUND", "message": "..." }
+```
+
+---
+
+## Class Design
+
+### 신규 생성 파일
+
+| 파일 | 경로 | 역할 |
+|------|------|------|
+| `GetPolicyDefinitionQuery.java` | `application/` | UseCase 입력 record |
+| `GetPolicyDefinitionUseCase.java` | `application/` | 단건 조회 UseCase |
+| `PolicyDefinitionNotFoundException.java` | `application/exception/` | 404 예외 |
+| `PolicyDefinitionController.java` | `presentation/` | GET 핸들러 |
+
+### 수정 파일
+
+| 파일 | 변경 내용 |
+|------|-----------|
+| `PolicyDefinitionRepository.java` | `findByIdAndDomainPackVersionId(Long id, Long domainPackVersionId)` 메서드 추가 |
+| `JpaPolicyDefinitionRepository.java` | 동일 메서드 선언 추가 (Spring Data JPA 이름 기반 자동 구현) |
+
+### Pseudo-code
+
+```java
+// GetPolicyDefinitionQuery.java
+record GetPolicyDefinitionQuery(
+    Long workspaceId, Long packId, Long versionId, Long policyId, Long userId)
+
+// PolicyDefinitionNotFoundException.java
+class PolicyDefinitionNotFoundException extends NotFoundException {
+    PolicyDefinitionNotFoundException(Long policyId) {
+        super("POLICY_DEFINITION_NOT_FOUND", "PolicyDefinition not found: " + policyId)
+    }
+}
+
+// GetPolicyDefinitionUseCase.java
+@Service
+@Transactional(readOnly = true)
+class GetPolicyDefinitionUseCase {
+    execute(GetPolicyDefinitionQuery query) {
+        validator.validateForWorkspacePackVersion(
+            query.workspaceId(), query.userId(), query.packId(), query.versionId())
+        return policyDefinitionRepository
+            .findByIdAndDomainPackVersionId(query.policyId(), query.versionId())
+            .map(PolicyDefinitionResponse::from)
+            .orElseThrow(() -> new PolicyDefinitionNotFoundException(query.policyId()))
+    }
+}
+
+// PolicyDefinitionController.java
+@RestController
+@RequestMapping("/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/policies")
+class PolicyDefinitionController {
+    @GetMapping("/{policyId}")
+    getPolicy(@PathVariable Long workspaceId, @PathVariable Long packId,
+              @PathVariable Long versionId, @PathVariable Long policyId,
+              @AuthenticationPrincipal Long userId) {
+        return ResponseEntity.ok(
+            useCase.execute(new GetPolicyDefinitionQuery(workspaceId, packId, versionId, policyId, userId)))
+    }
+}
+```
+
+---
+
+## Tests
+
+### UseCase 테스트: `GetPolicyDefinitionUseCaseTest.java`
+
+참조: `GetSlotDefinitionUseCaseTest.java` 패턴 동일 적용
+
+- `@ExtendWith(MockitoExtension.class)` + `@DisplayName`
+
+| 시나리오 | 예상 결과 |
+|----------|-----------|
+| 정상 조회 | `PolicyDefinitionResponse` 반환 |
+| policyId 미존재 | `PolicyDefinitionNotFoundException` |
+| 다른 version 소속 policy | `PolicyDefinitionNotFoundException` |
+| workspace 미존재 | `WorkspaceNotFoundException` (validator 위임) |
+| 권한 없음 | `UnauthorizedException` (validator 위임) |
+| pack 소속 불일치 | `DomainPackNotFoundException` (validator 위임) |
+
+### Controller 테스트: `PolicyDefinitionControllerTest.java`
+
+- `@WebMvcTest(PolicyDefinitionController.class)` + JwtAuthenticationFilter exclude
+- `@WithLongPrincipal(10L)` fixture 사용 (패키지: `com.init.fixtures`)
+
+| 시나리오 | 예상 결과 |
+|----------|-----------|
+| 단건 정상 조회 | 200, response body 전체 필드 검증 |
+| 단건 미존재 | 404, code `POLICY_DEFINITION_NOT_FOUND` |
+| 권한 없음 | 403 |
+| 인증 없음 | 401 |
+| version 미존재 | 404 |
+
+---
+
+## Database
+
+신규 DDL 없음.
+
+`pack.policy_definition` 테이블 및 인덱스 이미 존재 (`.agent/docs/schema.md:480–495, 848`).
+
+---
+
+## Additional Notes
+
+- 구현은 `GetSlotDefinitionUseCase` + `SlotDefinitionController` 패턴을 그대로 따른다.
+- `DomainPackValidator.validateForWorkspacePackVersion(workspaceId, userId, packId, versionId)`가 4단계 공통 검증 진입점이다.
+- `PolicyDefinitionRepository.findByIdAndDomainPackVersionId` 추가 시 JPA 메서드 이름 자동 구현을 활용한다.
+- `PolicyDefinitionResponse.from(PolicyDefinition)` 팩토리 메서드가 이미 존재하므로 신규 작성 불필요.

--- a/.agent/specs/2211.md
+++ b/.agent/specs/2211.md
@@ -90,10 +90,22 @@ Headers:
 { "code": "POLICY_DEFINITION_NOT_FOUND", "message": "PolicyDefinition not found: {policyId}" }
 ```
 
-**404 Not Found — workspace / pack / version not found**
+**404 Not Found — workspace not found**
 
 ```json
-{ "code": "NOT_FOUND", "message": "..." }
+{ "code": "DOMAIN_PACK_WORKSPACE_NOT_FOUND", "message": "..." }
+```
+
+**404 Not Found — pack not found**
+
+```json
+{ "code": "DOMAIN_PACK_NOT_FOUND", "message": "DomainPack not found: {packId}" }
+```
+
+**404 Not Found — version not found**
+
+```json
+{ "code": "DOMAIN_PACK_VERSION_NOT_FOUND", "message": "도메인 팩 버전을 찾을 수 없습니다. id={versionId}" }
 ```
 
 ---
@@ -151,7 +163,8 @@ class PolicyDefinitionController {
     @GetMapping("/{policyId}")
     getPolicy(@PathVariable Long workspaceId, @PathVariable Long packId,
               @PathVariable Long versionId, @PathVariable Long policyId,
-              @AuthenticationPrincipal Long userId) {
+              Authentication authentication) {
+        Long userId = AuthenticationUtils.getUserId(authentication)
         return ResponseEntity.ok(
             useCase.execute(new GetPolicyDefinitionQuery(workspaceId, packId, versionId, policyId, userId)))
     }


### PR DESCRIPTION
# [BE] 2.2.11 — Policy / Rule 초안 단건 조회

## Goal

특정 Domain Pack Version에 속한 Policy 초안 단건을 조회하는 READ 전용 엔드포인트를 제공한다.

---

## Sequence Diagram

```mermaid
sequenceDiagram
    actor c as Client
    participant ctrl as PolicyDefinitionController
    participant uc as GetPolicyDefinitionUseCase
    participant validator as DomainPackValidator
    participant repo as PolicyDefinitionRepository
    participant db as PostgreSQL

    c ->> ctrl: GET /api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/policies/{policyId}
    ctrl ->> uc: execute(GetPolicyDefinitionQuery)
    uc ->> validator: validateForWorkspacePackVersion(workspaceId, userId, packId, versionId)
    validator -->> uc: (passes or throws)
    uc ->> repo: findByIdAndDomainPackVersionId(policyId, versionId)
    repo ->> db: SELECT * FROM pack.policy_definition WHERE id = ? AND domain_pack_version_id = ?
    db -->> repo: row
    repo -->> uc: Optional<PolicyDefinition>
    uc -->> ctrl: PolicyDefinitionResponse
    ctrl -->> c: 200 OK
```

---

## REST API

### Endpoint

| Method | Path | Description |
|--------|------|-------------|
| GET | `/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/policies/{policyId}` | Policy 초안 단건 조회 |

### Request

Path variables:
- `workspaceId`: Long
- `packId`: Long
- `versionId`: Long
- `policyId`: Long

Headers:
- `Authorization: Bearer {jwt-token}` (필수)

### Response

**200 OK**

```json
{
  "id": 1,
  "domainPackVersionId": 10,
  "policyCode": "POL_RETURN",
  "name": "반품 처리 정책",
  "description": "7일 이내 반품 허용",
  "severity": "HIGH",
  "conditionJson": {},
  "actionJson": {},
  "evidenceJson": [],
  "metaJson": {},
  "status": "ACTIVE",
  "createdAt": "2025-04-03T10:00:00Z",
  "updatedAt": "2025-04-03T10:00:00Z"
}
```

**401 Unauthorized**

```json
{ "code": "UNAUTHORIZED", "message": "인증이 필요합니다." }
```

**403 Forbidden**

```json
{ "code": "FORBIDDEN", "message": "접근 권한이 없습니다." }
```

**404 Not Found — policy not found**

```json
{ "code": "POLICY_DEFINITION_NOT_FOUND", "message": "PolicyDefinition not found: {policyId}" }
```

**404 Not Found — workspace / pack / version not found**

```json
{ "code": "NOT_FOUND", "message": "..." }
```

---

## Class Design

### 신규 생성 파일

| 파일 | 경로 | 역할 |
|------|------|------|
| `GetPolicyDefinitionQuery.java` | `application/` | UseCase 입력 record |
| `GetPolicyDefinitionUseCase.java` | `application/` | 단건 조회 UseCase |
| `PolicyDefinitionNotFoundException.java` | `application/exception/` | 404 예외 |
| `PolicyDefinitionController.java` | `presentation/` | GET 핸들러 |

### 수정 파일

| 파일 | 변경 내용 |
|------|-----------|
| `PolicyDefinitionRepository.java` | `findByIdAndDomainPackVersionId(Long id, Long domainPackVersionId)` 메서드 추가 |
| `JpaPolicyDefinitionRepository.java` | 동일 메서드 선언 추가 (Spring Data JPA 이름 기반 자동 구현) |

### Pseudo-code

```java
// GetPolicyDefinitionQuery.java
record GetPolicyDefinitionQuery(
    Long workspaceId, Long packId, Long versionId, Long policyId, Long userId)

// PolicyDefinitionNotFoundException.java
class PolicyDefinitionNotFoundException extends NotFoundException {
    PolicyDefinitionNotFoundException(Long policyId) {
        super("POLICY_DEFINITION_NOT_FOUND", "PolicyDefinition not found: " + policyId)
    }
}

// GetPolicyDefinitionUseCase.java
@Service
@Transactional(readOnly = true)
class GetPolicyDefinitionUseCase {
    execute(GetPolicyDefinitionQuery query) {
        validator.validateForWorkspacePackVersion(
            query.workspaceId(), query.userId(), query.packId(), query.versionId())
        return policyDefinitionRepository
            .findByIdAndDomainPackVersionId(query.policyId(), query.versionId())
            .map(PolicyDefinitionResponse::from)
            .orElseThrow(() -> new PolicyDefinitionNotFoundException(query.policyId()))
    }
}

// PolicyDefinitionController.java
@RestController
@RequestMapping("/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/policies")
class PolicyDefinitionController {
    @GetMapping("/{policyId}")
    getPolicy(@PathVariable Long workspaceId, @PathVariable Long packId,
              @PathVariable Long versionId, @PathVariable Long policyId,
              @AuthenticationPrincipal Long userId) {
        return ResponseEntity.ok(
            useCase.execute(new GetPolicyDefinitionQuery(workspaceId, packId, versionId, policyId, userId)))
    }
}
```

---

## Tests

### UseCase 테스트: `GetPolicyDefinitionUseCaseTest.java`

참조: `GetSlotDefinitionUseCaseTest.java` 패턴 동일 적용

- `@ExtendWith(MockitoExtension.class)` + `@DisplayName`

| 시나리오 | 예상 결과 |
|----------|-----------|
| 정상 조회 | `PolicyDefinitionResponse` 반환 |
| policyId 미존재 | `PolicyDefinitionNotFoundException` |
| 다른 version 소속 policy | `PolicyDefinitionNotFoundException` |
| workspace 미존재 | `WorkspaceNotFoundException` (validator 위임) |
| 권한 없음 | `UnauthorizedException` (validator 위임) |
| pack 소속 불일치 | `DomainPackNotFoundException` (validator 위임) |

### Controller 테스트: `PolicyDefinitionControllerTest.java`

- `@WebMvcTest(PolicyDefinitionController.class)` + JwtAuthenticationFilter exclude
- `@WithLongPrincipal(10L)` fixture 사용 (패키지: `com.init.fixtures`)

| 시나리오 | 예상 결과 |
|----------|-----------|
| 단건 정상 조회 | 200, response body 전체 필드 검증 |
| 단건 미존재 | 404, code `POLICY_DEFINITION_NOT_FOUND` |
| 권한 없음 | 403 |
| 인증 없음 | 401 |
| version 미존재 | 404 |

---

## Database

신규 DDL 없음.

`pack.policy_definition` 테이블 및 인덱스 이미 존재 (`.agent/docs/schema.md:480–495, 848`).

---

## Additional Notes

- 구현은 `GetSlotDefinitionUseCase` + `SlotDefinitionController` 패턴을 그대로 따른다.
- `DomainPackValidator.validateForWorkspacePackVersion(workspaceId, userId, packId, versionId)`가 4단계 공통 검증 진입점이다.
- `PolicyDefinitionRepository.findByIdAndDomainPackVersionId` 추가 시 JPA 메서드 이름 자동 구현을 활용한다.
- `PolicyDefinitionResponse.from(PolicyDefinition)` 팩토리 메서드가 이미 존재하므로 신규 작성 불필요.
---
# Uncertainty Register — 2211: [BE] Policy / Rule 초안 단건 조회

---

## UR-2211-01

- **ID**: UR-2211-01
- **Issue**: `PolicyDefinition.getDomainPackVersionId()` getter 직접 확인 미완료
- **Status**: `Assumption`
- **Why unresolved**: Recon에서 entity 파일 내부를 직접 열람하지 않았음. `UpdatePolicyUseCase:54`에서 `policy.getDomainPackVersionId()` 호출이 확인되어 존재 추정 가능.
- **Options**:
  - (1) getter 존재 (현재 추정)
  - (2) getter 미존재 → entity 수정 필요
- **Recommended Default**: getter 존재 가정 (UpdatePolicyUseCase 실제 호출 근거)
- **Why recommended**: 현재 빌드 및 운영 중인 코드에서 이미 사용 중이므로 존재하지 않으면 컴파일 오류
- **User Decision Required**: No
- **User Question**: N/A
- **Execution Rule**:
  - Implementation Agent MUST NOT: getter 미존재를 가정하고 entity에 임의 getter를 추가
  - Implementation Agent MAY: `Assumption adopted from Recommended Default`로 채택, 구현 전 entity 파일 직접 확인 필수
  - If unsafe: getter 미존재 확인 시 즉시 보고 — entity 수정 범위를 이 백로그에 포함할지 결정 필요
- **Affected Spec Section**: Class Design — `GetPolicyDefinitionUseCase` 구현

---

## UR-2211-02

- **ID**: UR-2211-02
- **Issue**: GET 전용 Controller를 별도 파일로 생성할지, 기존 `UpdatePolicyController`에 추가할지
- **Status**: `Assumption`
- **Why unresolved**: 컨벤션 기반 추론. `SlotDefinitionController`가 별도 파일로 분리되어 있으나 Policy의 경우 직접 대조 확인을 수행하지 않음.
- **Options**:
  - (1) 별도 `PolicyDefinitionController.java` 생성 (Slot 패턴 일관성)
  - (2) 기존 `UpdatePolicyController.java`에 `@GetMapping` 추가
- **Recommended Default**: 별도 `PolicyDefinitionController.java` 생성
- **Why recommended**: Slot 참조 구현이 별도 파일 분리 패턴을 사용하며, 단일 책임 원칙에 부합
- **User Decision Required**: No
- **User Question**: N/A
- **Execution Rule**:
  - Implementation Agent MUST NOT: 두 옵션을 혼합하거나 선택 후 기록 없이 진행
  - Implementation Agent MAY: `Assumption adopted from Recommended Default`로 별도 파일 생성
  - If unsafe: `UpdatePolicyController` 구조 확인 후 충돌 시 즉시 보고
- **Affected Spec Section**: Class Design — `PolicyDefinitionController.java`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 워크스페이스 내 도메인 팩 버전별로 개별 정책을 조회하는 읽기 전용 API 엔드포인트 추가 (GET)
  * Bearer JWT 기반 인증/권한 검증 포함

* **오류 처리**
  * 누락된 정책·워크스페이스·팩·버전에 대해 명확한 404 변별 응답 추가
  * 인증/권한 실패에 대한 표준화된 오류 응답 제공

* **테스트**
  * 인증, 권한, 리소스 누락 등 다양한 시나리오에 대한 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->