### PR TITLE
feat(domain-pack): add GET /policies/{policyId} single policy definition endpoint

### DIFF
--- a/backend/src/main/java/com/init/domainpack/application/GetPolicyDefinitionQuery.java
+++ b/backend/src/main/java/com/init/domainpack/application/GetPolicyDefinitionQuery.java
@@ -1,0 +1,4 @@
+package com.init.domainpack.application;
+
+public record GetPolicyDefinitionQuery(
+    Long workspaceId, Long packId, Long versionId, Long policyId, Long userId) {}

--- a/backend/src/main/java/com/init/domainpack/application/GetPolicyDefinitionUseCase.java
+++ b/backend/src/main/java/com/init/domainpack/application/GetPolicyDefinitionUseCase.java
@@ -1,0 +1,30 @@
+package com.init.domainpack.application;
+
+import com.init.domainpack.application.exception.PolicyDefinitionNotFoundException;
+import com.init.domainpack.domain.repository.PolicyDefinitionRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class GetPolicyDefinitionUseCase {
+
+  private final DomainPackValidator validator;
+  private final PolicyDefinitionRepository policyDefinitionRepository;
+
+  public GetPolicyDefinitionUseCase(
+      DomainPackValidator validator, PolicyDefinitionRepository policyDefinitionRepository) {
+    this.validator = validator;
+    this.policyDefinitionRepository = policyDefinitionRepository;
+  }
+
+  public PolicyDefinitionResponse execute(GetPolicyDefinitionQuery query) {
+    validator.validateForWorkspacePackVersion(
+        query.workspaceId(), query.userId(), query.packId(), query.versionId());
+
+    return policyDefinitionRepository
+        .findByIdAndDomainPackVersionId(query.policyId(), query.versionId())
+        .map(PolicyDefinitionResponse::from)
+        .orElseThrow(() -> new PolicyDefinitionNotFoundException(query.policyId()));
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/application/exception/PolicyDefinitionNotFoundException.java
+++ b/backend/src/main/java/com/init/domainpack/application/exception/PolicyDefinitionNotFoundException.java
@@ -1,0 +1,9 @@
+package com.init.domainpack.application.exception;
+
+import com.init.shared.application.exception.NotFoundException;
+
+public class PolicyDefinitionNotFoundException extends NotFoundException {
+  public PolicyDefinitionNotFoundException(Long policyId) {
+    super("POLICY_DEFINITION_NOT_FOUND", "PolicyDefinition not found: " + policyId);
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/domain/repository/PolicyDefinitionRepository.java
+++ b/backend/src/main/java/com/init/domainpack/domain/repository/PolicyDefinitionRepository.java
@@ -10,5 +10,7 @@ public interface PolicyDefinitionRepository {
 
   Optional<PolicyDefinition> findById(Long id);
 
+  Optional<PolicyDefinition> findByIdAndDomainPackVersionId(Long id, Long domainPackVersionId);
+
   PolicyDefinition save(PolicyDefinition policy);
 }

--- a/backend/src/main/java/com/init/domainpack/infrastructure/persistence/JpaPolicyDefinitionRepository.java
+++ b/backend/src/main/java/com/init/domainpack/infrastructure/persistence/JpaPolicyDefinitionRepository.java
@@ -3,6 +3,7 @@ package com.init.domainpack.infrastructure.persistence;
 import com.init.domainpack.domain.model.PolicyDefinition;
 import com.init.domainpack.domain.repository.PolicyDefinitionRepository;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -11,4 +12,6 @@ public interface JpaPolicyDefinitionRepository
     extends JpaRepository<PolicyDefinition, Long>, PolicyDefinitionRepository {
 
   List<PolicyDefinition> findByDomainPackVersionId(Long domainPackVersionId);
+
+  Optional<PolicyDefinition> findByIdAndDomainPackVersionId(Long id, Long domainPackVersionId);
 }

--- a/backend/src/main/java/com/init/domainpack/presentation/PolicyDefinitionController.java
+++ b/backend/src/main/java/com/init/domainpack/presentation/PolicyDefinitionController.java
@@ -1,0 +1,37 @@
+package com.init.domainpack.presentation;
+
+import com.init.domainpack.application.GetPolicyDefinitionQuery;
+import com.init.domainpack.application.GetPolicyDefinitionUseCase;
+import com.init.domainpack.application.PolicyDefinitionResponse;
+import com.init.shared.presentation.AuthenticationUtils;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(
+    "/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/policies")
+public class PolicyDefinitionController {
+
+  private final GetPolicyDefinitionUseCase useCase;
+
+  public PolicyDefinitionController(GetPolicyDefinitionUseCase useCase) {
+    this.useCase = useCase;
+  }
+
+  @GetMapping("/{policyId}")
+  public ResponseEntity<PolicyDefinitionResponse> getPolicy(
+      @PathVariable Long workspaceId,
+      @PathVariable Long packId,
+      @PathVariable Long versionId,
+      @PathVariable Long policyId,
+      Authentication authentication) {
+    Long userId = AuthenticationUtils.getUserId(authentication);
+    return ResponseEntity.ok(
+        useCase.execute(
+            new GetPolicyDefinitionQuery(workspaceId, packId, versionId, policyId, userId)));
+  }
+}

--- a/backend/src/test/java/com/init/domainpack/application/GetPolicyDefinitionUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/GetPolicyDefinitionUseCaseTest.java
@@ -75,12 +75,18 @@ class GetPolicyDefinitionUseCaseTest {
 
     // then
     assertThat(result.id()).isEqualTo(POLICY_ID);
+    assertThat(result.domainPackVersionId()).isEqualTo(VERSION_ID);
     assertThat(result.policyCode()).isEqualTo("POL_RETURN");
     assertThat(result.name()).isEqualTo("반품 처리 정책");
+    assertThat(result.description()).isEqualTo("7일 이내 반품 허용");
+    assertThat(result.severity()).isEqualTo("HIGH");
     assertThat(result.conditionJson()).isEqualTo("{}");
     assertThat(result.actionJson()).isEqualTo("{}");
     assertThat(result.evidenceJson()).isEqualTo("[]");
     assertThat(result.metaJson()).isEqualTo("{}");
+    assertThat(result.status()).isEqualTo("ACTIVE");
+    assertThat(result.createdAt()).isEqualTo(OffsetDateTime.parse("2026-04-10T10:00:00Z"));
+    assertThat(result.updatedAt()).isEqualTo(OffsetDateTime.parse("2026-04-10T10:00:00Z"));
   }
 
   @Test
@@ -200,7 +206,8 @@ class GetPolicyDefinitionUseCaseTest {
 
   private PolicyDefinition createPolicy(Long id, String policyCode, String name) {
     PolicyDefinition policy =
-        PolicyDefinition.create(VERSION_ID, policyCode, name, null, "HIGH", "{}", "{}", "[]", "{}");
+        PolicyDefinition.create(
+            VERSION_ID, policyCode, name, "7일 이내 반품 허용", "HIGH", "{}", "{}", "[]", "{}");
     ReflectionTestUtils.setField(policy, "id", id);
     ReflectionTestUtils.setField(policy, "createdAt", OffsetDateTime.parse("2026-04-10T10:00:00Z"));
     ReflectionTestUtils.setField(policy, "updatedAt", OffsetDateTime.parse("2026-04-10T10:00:00Z"));

--- a/backend/src/test/java/com/init/domainpack/application/GetPolicyDefinitionUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/GetPolicyDefinitionUseCaseTest.java
@@ -1,0 +1,209 @@
+package com.init.domainpack.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.init.domainpack.application.exception.DomainPackNotFoundException;
+import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
+import com.init.domainpack.application.exception.DomainPackVersionNotFoundException;
+import com.init.domainpack.application.exception.DomainPackWorkspaceNotFoundException;
+import com.init.domainpack.application.exception.PolicyDefinitionNotFoundException;
+import com.init.domainpack.domain.model.DomainPackVersion;
+import com.init.domainpack.domain.model.PolicyDefinition;
+import com.init.domainpack.domain.repository.DomainPackRepository;
+import com.init.domainpack.domain.repository.DomainPackVersionRepository;
+import com.init.domainpack.domain.repository.PolicyDefinitionRepository;
+import com.init.domainpack.domain.repository.WorkspaceExistencePort;
+import com.init.domainpack.domain.repository.WorkspaceMembershipPort;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetPolicyDefinitionUseCase")
+class GetPolicyDefinitionUseCaseTest {
+
+  @Mock private WorkspaceExistencePort workspaceExistencePort;
+  @Mock private WorkspaceMembershipPort workspaceMembershipPort;
+  @Mock private DomainPackRepository domainPackRepository;
+  @Mock private DomainPackVersionRepository domainPackVersionRepository;
+  @Mock private PolicyDefinitionRepository policyDefinitionRepository;
+
+  private GetPolicyDefinitionUseCase useCase;
+
+  private static final Long WORKSPACE_ID = 1L;
+  private static final Long PACK_ID = 7L;
+  private static final Long VERSION_ID = 101L;
+  private static final Long POLICY_ID = 3001L;
+  private static final Long USER_ID = 10L;
+
+  @BeforeEach
+  void setUp() {
+    DomainPackValidator validator =
+        new DomainPackValidator(
+            workspaceExistencePort,
+            workspaceMembershipPort,
+            domainPackRepository,
+            domainPackVersionRepository);
+    useCase = new GetPolicyDefinitionUseCase(validator, policyDefinitionRepository);
+  }
+
+  @Test
+  @DisplayName("유효한 query → PolicyDefinitionResponse 전체 필드 반환")
+  void should_returnFullResponse_when_validQuery() {
+    // given
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(true);
+    given(domainPackVersionRepository.findById(VERSION_ID))
+        .willReturn(Optional.of(createVersion(VERSION_ID, PACK_ID)));
+    given(policyDefinitionRepository.findByIdAndDomainPackVersionId(POLICY_ID, VERSION_ID))
+        .willReturn(Optional.of(createPolicy(POLICY_ID, "POL_RETURN", "반품 처리 정책")));
+
+    // when
+    PolicyDefinitionResponse result =
+        useCase.execute(
+            new GetPolicyDefinitionQuery(WORKSPACE_ID, PACK_ID, VERSION_ID, POLICY_ID, USER_ID));
+
+    // then
+    assertThat(result.id()).isEqualTo(POLICY_ID);
+    assertThat(result.policyCode()).isEqualTo("POL_RETURN");
+    assertThat(result.name()).isEqualTo("반품 처리 정책");
+    assertThat(result.conditionJson()).isEqualTo("{}");
+    assertThat(result.actionJson()).isEqualTo("{}");
+    assertThat(result.evidenceJson()).isEqualTo("[]");
+    assertThat(result.metaJson()).isEqualTo("{}");
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 policyId → PolicyDefinitionNotFoundException")
+  void should_throwNotFoundException_when_policyNotFound() {
+    // given
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(true);
+    given(domainPackVersionRepository.findById(VERSION_ID))
+        .willReturn(Optional.of(createVersion(VERSION_ID, PACK_ID)));
+    given(policyDefinitionRepository.findByIdAndDomainPackVersionId(POLICY_ID, VERSION_ID))
+        .willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new GetPolicyDefinitionQuery(
+                        WORKSPACE_ID, PACK_ID, VERSION_ID, POLICY_ID, USER_ID)))
+        .isInstanceOf(PolicyDefinitionNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("다른 version 소속 policyId → PolicyDefinitionNotFoundException")
+  void should_throwNotFoundException_when_policyBelongsToOtherVersion() {
+    // given — policyId exists but belongs to a different versionId, so composite lookup returns
+    // empty
+    Long otherVersionId = VERSION_ID + 1L;
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(true);
+    given(domainPackVersionRepository.findById(otherVersionId))
+        .willReturn(Optional.of(createVersion(otherVersionId, PACK_ID)));
+    given(policyDefinitionRepository.findByIdAndDomainPackVersionId(POLICY_ID, otherVersionId))
+        .willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new GetPolicyDefinitionQuery(
+                        WORKSPACE_ID, PACK_ID, otherVersionId, POLICY_ID, USER_ID)))
+        .isInstanceOf(PolicyDefinitionNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("workspace 없음 → DomainPackWorkspaceNotFoundException")
+  void should_throwWorkspaceNotFoundException_when_workspaceNotFound() {
+    // given
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(false);
+
+    // when & then
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new GetPolicyDefinitionQuery(
+                        WORKSPACE_ID, PACK_ID, VERSION_ID, POLICY_ID, USER_ID)))
+        .isInstanceOf(DomainPackWorkspaceNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("접근 권한 없음 → DomainPackUnauthorizedWorkspaceAccessException")
+  void should_throwUnauthorizedException_when_unauthorized() {
+    // given
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(false);
+
+    // when & then
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new GetPolicyDefinitionQuery(
+                        WORKSPACE_ID, PACK_ID, VERSION_ID, POLICY_ID, USER_ID)))
+        .isInstanceOf(DomainPackUnauthorizedWorkspaceAccessException.class);
+  }
+
+  @Test
+  @DisplayName("domain pack 소속 불일치 → DomainPackNotFoundException")
+  void should_throwDomainPackNotFoundException_when_packNotInWorkspace() {
+    // given
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(false);
+
+    // when & then
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new GetPolicyDefinitionQuery(
+                        WORKSPACE_ID, PACK_ID, VERSION_ID, POLICY_ID, USER_ID)))
+        .isInstanceOf(DomainPackNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("version 소속 불일치 → DomainPackVersionNotFoundException")
+  void should_throwVersionNotFoundException_when_versionNotInPack() {
+    // given
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(true);
+    given(domainPackVersionRepository.findById(VERSION_ID))
+        .willReturn(Optional.of(createVersion(VERSION_ID, 999L)));
+
+    // when & then
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new GetPolicyDefinitionQuery(
+                        WORKSPACE_ID, PACK_ID, VERSION_ID, POLICY_ID, USER_ID)))
+        .isInstanceOf(DomainPackVersionNotFoundException.class);
+  }
+
+  private DomainPackVersion createVersion(Long id, Long packId) {
+    return DomainPackVersion.ofForTest(id, packId, DomainPackVersion.STATUS_DRAFT);
+  }
+
+  private PolicyDefinition createPolicy(Long id, String policyCode, String name) {
+    PolicyDefinition policy =
+        PolicyDefinition.create(VERSION_ID, policyCode, name, null, "HIGH", "{}", "{}", "[]", "{}");
+    ReflectionTestUtils.setField(policy, "id", id);
+    ReflectionTestUtils.setField(policy, "createdAt", OffsetDateTime.parse("2026-04-10T10:00:00Z"));
+    ReflectionTestUtils.setField(policy, "updatedAt", OffsetDateTime.parse("2026-04-10T10:00:00Z"));
+    return policy;
+  }
+}

--- a/backend/src/test/java/com/init/domainpack/presentation/PolicyDefinitionControllerTest.java
+++ b/backend/src/test/java/com/init/domainpack/presentation/PolicyDefinitionControllerTest.java
@@ -76,8 +76,8 @@ class PolicyDefinitionControllerTest {
         .andExpect(jsonPath("$.evidenceJson").value("[]"))
         .andExpect(jsonPath("$.metaJson").value("{}"))
         .andExpect(jsonPath("$.status").value("ACTIVE"))
-        .andExpect(jsonPath("$.createdAt").exists())
-        .andExpect(jsonPath("$.updatedAt").exists());
+        .andExpect(jsonPath("$.createdAt").value("2026-04-10T10:00:00Z"))
+        .andExpect(jsonPath("$.updatedAt").value("2026-04-10T10:00:00Z"));
   }
 
   @Test

--- a/backend/src/test/java/com/init/domainpack/presentation/PolicyDefinitionControllerTest.java
+++ b/backend/src/test/java/com/init/domainpack/presentation/PolicyDefinitionControllerTest.java
@@ -1,0 +1,132 @@
+package com.init.domainpack.presentation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.init.domainpack.application.GetPolicyDefinitionUseCase;
+import com.init.domainpack.application.PolicyDefinitionResponse;
+import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
+import com.init.domainpack.application.exception.DomainPackVersionNotFoundException;
+import com.init.domainpack.application.exception.PolicyDefinitionNotFoundException;
+import com.init.fixtures.WithLongPrincipal;
+import com.init.shared.infrastructure.security.JwtAuthenticationFilter;
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(
+    value = PolicyDefinitionController.class,
+    excludeFilters =
+        @ComponentScan.Filter(
+            type = FilterType.ASSIGNABLE_TYPE,
+            classes = JwtAuthenticationFilter.class))
+@DisplayName("PolicyDefinitionController")
+class PolicyDefinitionControllerTest {
+
+  private static final String BASE_URL =
+      "/api/v1/workspaces/1/domain-packs/7/versions/101/policies";
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private GetPolicyDefinitionUseCase useCase;
+
+  @Test
+  @DisplayName("GET .../policies/{policyId} → 200 OK, 전체 필드 반환")
+  @WithLongPrincipal(10L)
+  void should_returnOkWithAllFields_when_policyExists() throws Exception {
+    // given
+    given(useCase.execute(any()))
+        .willReturn(
+            new PolicyDefinitionResponse(
+                3001L,
+                101L,
+                "POL_RETURN",
+                "반품 처리 정책",
+                "7일 이내 반품 허용",
+                "HIGH",
+                "{}",
+                "{}",
+                "[]",
+                "{}",
+                "ACTIVE",
+                OffsetDateTime.parse("2026-04-10T10:00:00Z"),
+                OffsetDateTime.parse("2026-04-10T10:00:00Z")));
+
+    // when & then
+    mockMvc
+        .perform(get(BASE_URL + "/3001"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(3001))
+        .andExpect(jsonPath("$.domainPackVersionId").value(101))
+        .andExpect(jsonPath("$.policyCode").value("POL_RETURN"))
+        .andExpect(jsonPath("$.name").value("반품 처리 정책"))
+        .andExpect(jsonPath("$.description").value("7일 이내 반품 허용"))
+        .andExpect(jsonPath("$.severity").value("HIGH"))
+        .andExpect(jsonPath("$.conditionJson").value("{}"))
+        .andExpect(jsonPath("$.actionJson").value("{}"))
+        .andExpect(jsonPath("$.evidenceJson").value("[]"))
+        .andExpect(jsonPath("$.metaJson").value("{}"))
+        .andExpect(jsonPath("$.status").value("ACTIVE"))
+        .andExpect(jsonPath("$.createdAt").exists())
+        .andExpect(jsonPath("$.updatedAt").exists());
+  }
+
+  @Test
+  @DisplayName("GET .../policies/{policyId} → 404 미존재")
+  @WithLongPrincipal(10L)
+  void should_return404_when_policyNotFound() throws Exception {
+    // given
+    given(useCase.execute(any())).willThrow(new PolicyDefinitionNotFoundException(9999L));
+
+    // when & then
+    mockMvc
+        .perform(get(BASE_URL + "/9999"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("POLICY_DEFINITION_NOT_FOUND"));
+  }
+
+  @Test
+  @DisplayName("GET .../policies/{policyId} → 403 권한 없음")
+  @WithLongPrincipal(10L)
+  void should_return403_when_unauthorized() throws Exception {
+    // given
+    given(useCase.execute(any()))
+        .willThrow(new DomainPackUnauthorizedWorkspaceAccessException("워크스페이스에 접근 권한이 없습니다."));
+
+    // when & then
+    mockMvc
+        .perform(get(BASE_URL + "/3001"))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.code").value("FORBIDDEN"));
+  }
+
+  @Test
+  @DisplayName("GET .../policies/{policyId} → 401 미인증")
+  void should_return401_when_unauthenticated() throws Exception {
+    // when & then
+    mockMvc.perform(get(BASE_URL + "/3001")).andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @DisplayName("GET .../policies/{policyId} → 404 version 미존재")
+  @WithLongPrincipal(10L)
+  void should_return404_when_versionNotFound() throws Exception {
+    // given
+    given(useCase.execute(any())).willThrow(new DomainPackVersionNotFoundException(101L));
+
+    // when & then
+    mockMvc
+        .perform(get(BASE_URL + "/3001"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("DOMAIN_PACK_VERSION_NOT_FOUND"));
+  }
+}


### PR DESCRIPTION
## Summary

`GET /api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/policies/{policyId}` 엔드포인트를 추가한다. Slot 단건 조회 패턴을 그대로 따르는 READ-only 구현이며, 신규 DDL 없이 기존 `pack.policy_definition` 테이블을 활용한다.

---

## Context

- Spec: `.agent/specs/2211.md`
- Branch: `feature/2211-policy-rule-draft-single-get-apis`
- 구현 패턴: `GetSlotDefinitionUseCase` + `SlotDefinitionController` 동일 적용

---

## What Changed

| 파일 | 변경 |
|------|------|
| `application/GetPolicyDefinitionQuery.java` | 신규 — UseCase 입력 record |
| `application/GetPolicyDefinitionUseCase.java` | 신규 — 단건 조회, `@Transactional(readOnly = true)` |
| `application/exception/PolicyDefinitionNotFoundException.java` | 신규 — `NotFoundException` 상속, code `POLICY_DEFINITION_NOT_FOUND` |
| `presentation/PolicyDefinitionController.java` | 신규 — `@GetMapping("/{policyId}")` |
| `domain/repository/PolicyDefinitionRepository.java` | `findByIdAndDomainPackVersionId` 메서드 추가 |
| `infrastructure/persistence/JpaPolicyDefinitionRepository.java` | 동일 메서드 선언 추가 (JPA 이름 기반 자동 구현) |

---

## Assumptions Adopted

**UR-2211-01**: `PolicyDefinition.getDomainPackVersionId()` getter 존재 여부
- 구현 전 `PolicyDefinition.java:135` 직접 확인으로 사실 전환. entity 수정 불필요.

**UR-2211-02**: `PolicyDefinitionController` 별도 파일 분리 vs `UpdatePolicyController` 통합
- `UpdatePolicyController`가 `{policyId}` 포함 base path에 `@PatchMapping`만 보유함을 확인. 충돌 없음.
- Slot 패턴 일관성 우선, 별도 파일로 분리 확정.

---

## Spec Deviations

**UseCase 테스트 케이스 수 차이**

- Spec: 6개 시나리오 (workspace 미존재, 권한 없음, pack 불일치, policyId 미존재, 다른 version 소속, 정상 조회)
- 구현: 7개 — `should_throwVersionNotFoundException_when_versionNotInPack` 케이스 추가
- 영향: spec에 명시 없었던 "version 소속 불일치" 시나리오를 validator 동작 검증 차원에서 추가. 동작 범위 확장이며 기능 변경 없음.

**response JSON 필드 타입: conditionJson / actionJson / evidenceJson / metaJson**

- Spec 예시: `"conditionJson": {}` (JSON object 형태)
- 구현: `"conditionJson": "{}"` (string 형태)
- `PolicyDefinitionResponse`가 DB 저장 값(string)을 그대로 반환하는 기존 설계를 그대로 유지. 파싱 없음.

---

## Blocked / Skipped Items

없음.

---

## Test Notes

**UseCase 테스트** (`GetPolicyDefinitionUseCaseTest.java`): 7개 통과
- 정상 조회 시 response 전체 필드(id, policyCode, name, conditionJson 등) 값 검증 포함
- validator 위임 경로 4종 (workspace 미존재, 권한 없음, pack 불일치, version 불일치) 포함

**Controller 테스트** (`PolicyDefinitionControllerTest.java`): 5개 통과
- 200 정상 응답: 13개 필드 전체 jsonPath 검증
- 404 policy 미존재: code `POLICY_DEFINITION_NOT_FOUND` 검증
- 403 권한 없음: code `FORBIDDEN` 검증
- 401 미인증: `@WithLongPrincipal` 없는 요청으로 검증
- 404 version 미존재: code `DOMAIN_PACK_VERSION_NOT_FOUND` 검증

---

## Reviewer Focus

1. **`PolicyDefinitionController` vs `UpdatePolicyController` 라우팅 비충돌 확인** — base path가 동일(`/policies`)하지만 HTTP 메서드(GET vs PATCH)로 분리됨. Spring MVC 라우팅 우선순위 이슈 없는지 재확인 권장.
2. **JSON 필드 타입 (string vs object)** — `conditionJson` 등이 string으로 직렬화되는 현재 동작이 프론트엔드 소비 방식과 맞는지 확인 필요.
3. **UseCase 추가 테스트 케이스 (`versionNotInPack`)** — spec 범위 초과이나 validator 동작 검증 목적. 유지 여부 판단.

---

## Conflicts

없음.

---

## Ready to Merge / Needs Input

**Ready to Merge** — 구현이 spec을 충족하며, 2개의 assumption이 모두 코드 확인으로 해소됨. Reviewer Focus 항목은 확인 권장이지만 merge blocker 아님.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 정책 정의 조회 기능 추가 - 사용자는 이제 워크스페이스 내 도메인 팩 버전에서 특정 정책 정의를 조회할 수 있습니다. REST API 엔드포인트를 통해 정책 코드, 이름, 설명, 조건, 액션, 증거 및 메타데이터 등 정책의 전체 정보를 확인할 수 있으며, 접근 권한 검증과 오류 처리가 포함되어 있습니다.

* **Tests**
  * 정책 정의 조회 기능에 대한 포괄적인 테스트 추가 - 성공 사례와 오류 시나리오(정책 미존재, 미인증, 접근 권한 없음 등)를 검증합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->