### PR TITLE
spec/021: [FE] 워크스페이스 CRUD UI

### DIFF
--- a/.agent/specs/021.md
+++ b/.agent/specs/021.md
@@ -9,7 +9,7 @@
 
 ## Goal
 
-콘솔 사용자가 워크스페이스를 생성, 조회, 수정, 보관(아카이브)할 수 있는 CRUD UI를 구현한다.
+콘솔 사용자가 워크스페이스를 생성, 조회, 수정, 삭제할 수 있는 CRUD UI를 구현한다.
 
 ---
 
@@ -52,7 +52,7 @@ flowchart TD
     V -->|403 ACCESS_DENIED| X[toast.error: 권한 없음]
     V -->|네트워크 오류| P
 
-    Q -->|보관 버튼\nOWNER| Y[ArchiveConfirmDialog 열기]
+    Q -->|삭제 버튼\nOWNER| Y[DeleteConfirmDialog 열기]
     Y -->|확인| Z[DELETE /api/v1/workspaces/id]
     Z -->|204 성공| AA[toast.success\n목록에서 제거\n목록 refetch]
     Z -->|403 ACCESS_DENIED| X
@@ -102,7 +102,7 @@ WorkspaceListPage (pages/workspace-list)
         │           │   └── description (truncated)
         │           └── CardFooter — Actions (role 기반 조건부)
         │               ├── Edit 버튼 (OWNER/ADMIN만 표시)
-        │               └── Archive 버튼 (OWNER만 표시)
+        │               └── Delete 버튼 (OWNER만 표시)
         ├── CreateWorkspaceDialog — Dialog (shared/ui/dialog.tsx) 활용
         │   ├── DialogHeader ("워크스페이스 생성")
         │   ├── DialogContent
@@ -121,12 +121,12 @@ WorkspaceListPage (pages/workspace-list)
         │   └── DialogFooter
         │       ├── Button ("취소", variant=secondary)
         │       └── Button ("저장", isLoading)
-        └── ArchiveConfirmDialog — AlertDialog (shared/ui/alert-dialog.tsx) 활용
-            ├── AlertDialogHeader ("워크스페이스 보관")
-            ├── AlertDialogDescription ("정말 보관하시겠습니까?")
+        └── DeleteConfirmDialog — AlertDialog (shared/ui/alert-dialog.tsx) 활용
+            ├── AlertDialogHeader ("워크스페이스 삭제")
+            ├── AlertDialogDescription ("정말 삭제하시겠습니까?")
             └── AlertDialogFooter
                 ├── AlertDialogCancel ("취소")
-                └── AlertDialogAction ("보관", isLoading)
+                └── AlertDialogAction ("삭제", isLoading)
 ```
 
 ---
@@ -141,7 +141,7 @@ WorkspaceListPage (pages/workspace-list)
 | GET | `/api/v1/workspaces/{id}` | 단건 조회 | 200, `WorkspaceResponse` |
 | POST | `/api/v1/workspaces` | 생성 | 201, `WorkspaceResponse` |
 | PATCH | `/api/v1/workspaces/{id}` | 수정 (partial) | 200, `WorkspaceResponse` |
-| DELETE | `/api/v1/workspaces/{id}` | 보관 (soft delete) | 204, No Content |
+| DELETE | `/api/v1/workspaces/{id}` | 삭제 (soft delete) | 204, No Content |
 
 ### Request / Response 타입
 
@@ -248,7 +248,7 @@ export interface UpdateWorkspaceRequest {
 | `src/features/workspace-list/ui/workspace-list.module.css` | new | 그리드 스타일 |
 | `src/features/create-workspace/ui/CreateWorkspaceDialog.tsx` | new | 생성 Dialog |
 | `src/features/update-workspace/ui/EditWorkspaceDialog.tsx` | new | 수정 Dialog |
-| `src/features/archive-workspace/ui/ArchiveConfirmDialog.tsx` | new | 보관 확인 AlertDialog |
+| `src/features/archive-workspace/ui/ArchiveConfirmDialog.tsx` | new | 삭제 확인 AlertDialog |
 | `src/pages/workspace-list/ui/WorkspaceListPage.tsx` | new | 페이지 컴포넌트 |
 | `src/pages/workspace-list/ui/workspace-list-page.module.css` | new | 페이지 스타일 |
 | `src/shared/ui/layout/DashboardLayout.tsx` | modify | Workspaces 네비게이션 링크 추가 |
@@ -321,7 +321,7 @@ const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
 | 역할 | `shared/ui` 파일 |
 |------|-----------------|
 | 생성/수정 모달 | `dialog.tsx` |
-| 보관 확인 모달 | `alert-dialog.tsx` |
+| 삭제 확인 모달 | `alert-dialog.tsx` |
 | 워크스페이스 카드 | `card.tsx` |
 | 역할 뱃지 | `badge.tsx` |
 | 빈 상태 | `empty.tsx` |
@@ -400,7 +400,7 @@ function validateCreateForm(key: string, name: string, description: string): Rec
 | 2 | 빈 상태 표시 | 워크스페이스 0개 | `/workspaces` 진입 | EmptyState + 생성 CTA 표시 |
 | 3 | 워크스페이스 생성 | 로그인 상태 | 생성 Dialog → key: `test-ws`, name: `테스트` 입력 → 생성 | toast.success, Dialog 닫힘, 목록에 추가 |
 | 4 | 워크스페이스 수정 | OWNER/ADMIN 역할 | 수정 Dialog → name 변경 → 저장 | toast.success, Dialog 닫힘, 변경 반영 |
-| 5 | 워크스페이스 보관 | OWNER 역할 | 보관 버튼 → 확인 | toast.success, 목록에서 제거 |
+| 5 | 워크스페이스 삭제 | OWNER 역할 | 삭제 버튼 → 확인 | toast.success, 목록에서 제거 |
 | 6 | description 포함 생성 | 로그인 상태 | 모든 필드 입력 → 생성 | description 포함 저장 |
 
 #### Error & Edge Cases
@@ -414,7 +414,7 @@ function validateCreateForm(key: string, name: string, description: string): Rec
 | 5 | 네트워크 오류 | 서버 다운 상태에서 생성 | toast.error: 연결 실패 |
 | 6 | 로딩 중 중복 클릭 | 생성 버튼 빠르게 두 번 클릭 | 중복 요청 방지 (isSubmitting 가드) |
 | 7 | REVIEWER/OPERATOR 수정 버튼 | 해당 역할로 카드 확인 | 수정 버튼 미표시 |
-| 8 | 비OWNER 보관 버튼 | ADMIN 역할로 카드 확인 | 보관 버튼 미표시 |
+| 8 | 비OWNER 삭제 버튼 | ADMIN 역할로 카드 확인 | 삭제 버튼 미표시 |
 | 9 | 목록 로딩 실패 | API 에러 | Error 상태 + 재시도 버튼 표시 |
 
 #### 접근성
@@ -433,8 +433,8 @@ function validateCreateForm(key: string, name: string, description: string): Rec
 - [ ] 워크스페이스 목록 조회: Loading / Error / Empty 3-state 처리
 - [ ] 워크스페이스 생성: Dialog → POST → toast.success → 목록 refetch
 - [ ] 워크스페이스 수정: Dialog (prefilled) → PATCH (partial) → toast.success → 목록 refetch
-- [ ] 워크스페이스 보관: AlertDialog → DELETE (soft delete) → toast.success → 목록 refetch
-- [ ] role 기반 버튼 표시: Edit (OWNER/ADMIN), Archive (OWNER)
+- [ ] 워크스페이스 삭제: AlertDialog → DELETE (soft delete) → toast.success → 목록 refetch
+- [ ] role 기반 버튼 표시: Edit (OWNER/ADMIN), Delete (OWNER)
 - [ ] 에러 코드별 한국어 메시지 (WORKSPACE_KEY_CONFLICT, WORKSPACE_INVALID_KEY 등)
 - [ ] 클라이언트 유효성 검증: workspaceKey 패턴/길이, name 필수, description 길이
 - [ ] `<Toaster />` App.tsx에 마운트 (`alert()` 미사용)

--- a/.agent/specs/021.md
+++ b/.agent/specs/021.md
@@ -1,0 +1,458 @@
+# Spec 021 — [Console] 워크스페이스 CRUD UI 구현
+
+**Branch**: `spec/021`
+**Canonical Number**: `021`
+**Type**: Frontend (FSD)
+**작성일**: 2026-04-19
+
+---
+
+## Goal
+
+콘솔 사용자가 워크스페이스를 생성, 조회, 수정, 보관(아카이브)할 수 있는 CRUD UI를 구현한다.
+
+---
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A[로그인 완료] --> B[/workspaces 목록 페이지 진입]
+    B --> C{데이터 로딩}
+
+    C -->|로딩 중| D[Spinner 표시]
+    C -->|에러| E[에러 메시지 + 재시도 버튼]
+    C -->|성공 - 0건| F[EmptyState\n워크스페이스 없음 + 생성 CTA]
+    C -->|성공 - N건| G[WorkspaceCard 그리드 표시]
+
+    F -->|생성 버튼 클릭| H[CreateWorkspaceDialog 열기]
+    G -->|생성 버튼 클릭| H
+
+    H --> I[폼 입력\nworkspaceKey, name, description]
+    I --> J{클라이언트 유효성 검증}
+    J -->|실패| K[인라인 에러 표시]
+    K --> I
+    J -->|통과| L[POST /api/v1/workspaces]
+    L -->|201 성공| M[toast.success\nDialog 닫기\n목록 refetch]
+    L -->|409 WORKSPACE_KEY_CONFLICT| N[인라인 에러: 중복 키]
+    L -->|400 WORKSPACE_INVALID_KEY| O[인라인 에러: 키 형식]
+    L -->|네트워크 오류| P[toast.error: 연결 실패]
+    N --> I
+    O --> I
+
+    G --> Q{카드 액션}
+
+    Q -->|수정 버튼\nOWNER/ADMIN| R[EditWorkspaceDialog 열기\n기존 값 채워짐]
+    R --> S[name/description 수정]
+    S --> T{클라이언트 유효성 검증}
+    T -->|실패| U[인라인 에러 표시]
+    U --> S
+    T -->|통과| V[PATCH /api/v1/workspaces/id]
+    V -->|200 성공| W[toast.success\nDialog 닫기\n목록 refetch]
+    V -->|403 ACCESS_DENIED| X[toast.error: 권한 없음]
+    V -->|네트워크 오류| P
+
+    Q -->|보관 버튼\nOWNER| Y[ArchiveConfirmDialog 열기]
+    Y -->|확인| Z[DELETE /api/v1/workspaces/id]
+    Z -->|204 성공| AA[toast.success\n목록에서 제거\n목록 refetch]
+    Z -->|403 ACCESS_DENIED| X
+    Z -->|네트워크 오류| P
+    Y -->|취소| G
+```
+
+---
+
+## Design Diff
+
+### As-is vs To-be
+
+| 영역 | As-is | To-be | 변경 내용 |
+|------|-------|-------|----------|
+| 포스트 로그인 랜딩 | `/upload` | `/workspaces` | 기본 리다이렉트 변경 |
+| 워크스페이스 UI | 없음 | 목록 페이지 + CRUD Dialog | 신규 구현 |
+| DashboardLayout 네비게이션 | 워크스페이스 링크 없음 | Workspaces 링크 추가 | 네비 수정 |
+| ApiClient | `delete` 메서드 없음 | `delete` 메서드 추가 | shared/api 수정 |
+| Toast 인프라 | `<Toaster />` 미마운트 | `App.tsx`에 `<Toaster />` 마운트 | 인프라 추가 |
+
+---
+
+## Component Tree
+
+```
+WorkspaceListPage (pages/workspace-list)
+└── DashboardLayout (shared/ui/layout)
+    └── main content:
+        ├── [Loading 상태] → Spinner (shared/ui/spinner.tsx)
+        ├── [Error 상태] → 에러 메시지 + 재시도 버튼
+        ├── [Empty 상태] → Empty (shared/ui/empty.tsx)
+        │   ├── EmptyHeader
+        │   ├── EmptyTitle ("워크스페이스가 없습니다")
+        │   ├── EmptyDescription
+        │   └── Button ("워크스페이스 생성")
+        ├── [Data 상태] →
+        │   ├── WorkspaceListHeader
+        │   │   ├── 페이지 제목 ("Workspaces")
+        │   │   └── Button ("워크스페이스 생성")
+        │   └── WorkspaceGrid
+        │       └── WorkspaceCard (× N) — Card (shared/ui/card.tsx) 활용
+        │           ├── CardHeader
+        │           │   ├── name
+        │           │   └── Badge (shared/ui/badge.tsx) — myRole 표시
+        │           ├── CardContent
+        │           │   ├── workspaceKey (monospace)
+        │           │   └── description (truncated)
+        │           └── CardFooter — Actions (role 기반 조건부)
+        │               ├── Edit 버튼 (OWNER/ADMIN만 표시)
+        │               └── Archive 버튼 (OWNER만 표시)
+        ├── CreateWorkspaceDialog — Dialog (shared/ui/dialog.tsx) 활용
+        │   ├── DialogHeader ("워크스페이스 생성")
+        │   ├── DialogContent
+        │   │   ├── Input — workspaceKey (label, placeholder, error)
+        │   │   ├── Input — name (label, placeholder, error)
+        │   │   └── Textarea — description (label, placeholder)
+        │   └── DialogFooter
+        │       ├── Button ("취소", variant=secondary)
+        │       └── Button ("생성", isLoading)
+        ├── EditWorkspaceDialog — Dialog (shared/ui/dialog.tsx) 활용
+        │   ├── DialogHeader ("워크스페이스 수정")
+        │   ├── DialogContent
+        │   │   ├── workspaceKey (read-only 텍스트 표시)
+        │   │   ├── Input — name (prefilled)
+        │   │   └── Textarea — description (prefilled)
+        │   └── DialogFooter
+        │       ├── Button ("취소", variant=secondary)
+        │       └── Button ("저장", isLoading)
+        └── ArchiveConfirmDialog — AlertDialog (shared/ui/alert-dialog.tsx) 활용
+            ├── AlertDialogHeader ("워크스페이스 보관")
+            ├── AlertDialogDescription ("정말 보관하시겠습니까?")
+            └── AlertDialogFooter
+                ├── AlertDialogCancel ("취소")
+                └── AlertDialogAction ("보관", isLoading)
+```
+
+---
+
+## API Integration
+
+### Endpoints
+
+| Method | Path | Description | 응답 |
+|--------|------|-------------|------|
+| GET | `/api/v1/workspaces` | 목록 조회 | 200, `WorkspaceResponse[]` |
+| GET | `/api/v1/workspaces/{id}` | 단건 조회 | 200, `WorkspaceResponse` |
+| POST | `/api/v1/workspaces` | 생성 | 201, `WorkspaceResponse` |
+| PATCH | `/api/v1/workspaces/{id}` | 수정 (partial) | 200, `WorkspaceResponse` |
+| DELETE | `/api/v1/workspaces/{id}` | 보관 (soft delete) | 204, No Content |
+
+### Request / Response 타입
+
+```typescript
+// entities/workspace/model/types.ts
+
+export type WorkspaceStatus = 'ACTIVE' | 'ARCHIVED';
+export type WorkspaceMemberRole = 'OWNER' | 'ADMIN' | 'REVIEWER' | 'OPERATOR';
+
+export interface WorkspaceResponse {
+  id: number;
+  workspaceKey: string;
+  name: string;
+  description: string | null;
+  status: WorkspaceStatus;
+  myRole: WorkspaceMemberRole;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateWorkspaceRequest {
+  workspaceKey: string;  // ^[a-z0-9]([a-z0-9-]*[a-z0-9])?$, 3-100자
+  name: string;          // 필수, max 255자
+  description?: string;  // 선택, max 2000자
+}
+
+// body에 포함한 필드만 수정됨 (@JsonSetter partial update)
+export interface UpdateWorkspaceRequest {
+  name?: string;         // max 255자
+  description?: string;  // max 2000자
+}
+```
+
+### 에러 코드 매핑
+
+| 에러 코드 | HTTP | UI 메시지 |
+|----------|------|----------|
+| `WORKSPACE_KEY_CONFLICT` | 409 | 이미 사용 중인 워크스페이스 키입니다. |
+| `WORKSPACE_INVALID_KEY` | 400 | 워크스페이스 키는 소문자, 숫자, 하이픈만 사용할 수 있습니다. |
+| `WORKSPACE_INVALID_NAME` | 400 | 서버 메시지 표시 |
+| `WORKSPACE_INVALID_DESCRIPTION` | 400 | 서버 메시지 표시 |
+| `WORKSPACE_NOT_FOUND` | 404 | 워크스페이스를 찾을 수 없습니다. |
+| `WORKSPACE_ACCESS_DENIED` | 403 | 접근 권한이 없습니다. |
+
+---
+
+## Data Flow
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                     Pages Layer                         │
+│  ┌─────────────────────────────────────────────────┐   │
+│  │ WorkspaceListPage                               │   │
+│  │  state: workspaces[], isLoading, error          │   │
+│  │  handlers: fetchWorkspaces, onCreate, onUpdate, │   │
+│  │            onArchive (→ refetch)                 │   │
+│  └─────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────┘
+                           │
+                           ▼
+┌─────────────────────────────────────────────────────────┐
+│                   Features Layer                        │
+│  ┌──────────────────┐ ┌──────────────────┐             │
+│  │ CreateWorkspace   │ │ UpdateWorkspace   │             │
+│  │ Dialog            │ │ Dialog            │             │
+│  ├──────────────────┤ ├──────────────────┤             │
+│  │ ArchiveWorkspace  │ │ WorkspaceList     │             │
+│  │ Dialog            │ │ (Card grid)       │             │
+│  └──────────────────┘ └──────────────────┘             │
+└─────────────────────────────────────────────────────────┘
+                           │
+                           ▼
+┌─────────────────────────────────────────────────────────┐
+│                   Entities Layer                        │
+│  ┌─────────────────────────────────────────────────┐   │
+│  │ workspace: types, API functions                 │   │
+│  │  listWorkspaces(), createWorkspace(),           │   │
+│  │  updateWorkspace(), archiveWorkspace()           │   │
+│  └─────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────┘
+                           │
+                           ▼
+┌─────────────────────────────────────────────────────────┐
+│                   Shared Layer                          │
+│  ┌─────────────────────────────────────────────────┐   │
+│  │ apiClient (post, get, patch, delete)            │   │
+│  │ UI: Dialog, AlertDialog, Card, Badge, Empty,    │   │
+│  │     Button, Input, Textarea, Spinner, Toaster   │   │
+│  └─────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 수정 대상 파일
+
+| 파일 | 변경 유형 | 설명 |
+|------|----------|------|
+| `src/entities/workspace/model/types.ts` | new | WorkspaceResponse, Request 타입 정의 |
+| `src/entities/workspace/api/workspaceApi.ts` | new | API 함수 (list, create, update, archive) |
+| `src/entities/workspace/index.ts` | new | barrel export |
+| `src/features/workspace-list/ui/WorkspaceList.tsx` | new | 카드 그리드 + 3-state (Loading/Error/Empty) |
+| `src/features/workspace-list/ui/WorkspaceCard.tsx` | new | 단일 워크스페이스 카드 |
+| `src/features/workspace-list/ui/workspace-list.module.css` | new | 그리드 스타일 |
+| `src/features/create-workspace/ui/CreateWorkspaceDialog.tsx` | new | 생성 Dialog |
+| `src/features/update-workspace/ui/EditWorkspaceDialog.tsx` | new | 수정 Dialog |
+| `src/features/archive-workspace/ui/ArchiveConfirmDialog.tsx` | new | 보관 확인 AlertDialog |
+| `src/pages/workspace-list/ui/WorkspaceListPage.tsx` | new | 페이지 컴포넌트 |
+| `src/pages/workspace-list/ui/workspace-list-page.module.css` | new | 페이지 스타일 |
+| `src/shared/api/index.ts` | modify | `delete` 메서드 추가 |
+| `src/shared/ui/layout/DashboardLayout.tsx` | modify | Workspaces 네비게이션 링크 추가 |
+| `src/app/App.tsx` | modify | `/workspaces` 라우트 추가, 기본 리다이렉트 변경, `<Toaster />` 마운트 |
+
+---
+
+## State Management
+
+### Client State (Local useState)
+
+```typescript
+// WorkspaceListPage.tsx — 목록 상태
+const [workspaces, setWorkspaces] = useState<WorkspaceResponse[]>([]);
+const [isLoading, setIsLoading] = useState(true);
+const [error, setError] = useState('');
+
+// fetchWorkspaces — mount 시 + CRUD 성공 후 refetch
+const fetchWorkspaces = async () => {
+  setIsLoading(true);
+  setError('');
+  try {
+    const data = await listWorkspaces();
+    setWorkspaces(data);
+  } catch (err) {
+    if (err instanceof ApiRequestError) {
+      setError(err.message);
+    } else {
+      setError('서버에 연결할 수 없습니다.');
+    }
+  } finally {
+    setIsLoading(false);
+  }
+};
+
+useEffect(() => { fetchWorkspaces(); }, []);
+```
+
+```typescript
+// CreateWorkspaceDialog.tsx — Dialog 폼 상태
+const [workspaceKey, setWorkspaceKey] = useState('');
+const [name, setName] = useState('');
+const [description, setDescription] = useState('');
+const [isSubmitting, setIsSubmitting] = useState(false);
+const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+```
+
+```typescript
+// EditWorkspaceDialog.tsx — 기존 값으로 초기화
+const [name, setName] = useState(workspace.name);
+const [description, setDescription] = useState(workspace.description ?? '');
+const [isSubmitting, setIsSubmitting] = useState(false);
+const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+```
+
+---
+
+## Design Constraints
+
+`frontend/DESIGN.md` 준수:
+- 색상: 모노크롬 (`#000000` / `#ffffff`)
+- 폰트: figmaSans (기존 설정 상속)
+- 버튼: pill geometry (shared/ui/button.tsx)
+- Focus outline: `dashed 2px`
+- Card/Dialog radius: 8px
+- `alert()` 사용 금지 → `toast()` 사용
+
+### 공유 컴포넌트 활용
+
+| 역할 | `shared/ui` 파일 |
+|------|-----------------|
+| 생성/수정 모달 | `dialog.tsx` |
+| 보관 확인 모달 | `alert-dialog.tsx` |
+| 워크스페이스 카드 | `card.tsx` |
+| 역할 뱃지 | `badge.tsx` |
+| 빈 상태 | `empty.tsx` |
+| 텍스트 입력 | `input.tsx` (커스텀) / `input/Input.tsx` (아이콘 지원) |
+| 여러 줄 입력 | `textarea.tsx` |
+| 버튼 | `button.tsx` / `button/Button.tsx` |
+| 로딩 표시 | `spinner.tsx` |
+| Toast 알림 | `sonner.tsx` |
+
+---
+
+## Validation Rules
+
+| 필드 | 클라이언트 검증 | 서버 검증 |
+|------|---------------|----------|
+| workspaceKey | 필수, `^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`, 3-100자 | @NotBlank, 패턴 검증, 중복 체크 |
+| name | 필수, 1-255자 | @NotBlank, @Size(max=255) |
+| description | 선택, max 2000자 | @Size(max=2000) |
+
+### 클라이언트 검증 로직
+
+```typescript
+const WORKSPACE_KEY_PATTERN = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;
+
+function validateCreateForm(key: string, name: string, description: string): Record<string, string> {
+  const errors: Record<string, string> = {};
+
+  if (!key.trim()) {
+    errors.workspaceKey = '워크스페이스 키를 입력해주세요.';
+  } else if (key.length < 3 || key.length > 100) {
+    errors.workspaceKey = '워크스페이스 키는 3~100자여야 합니다.';
+  } else if (!WORKSPACE_KEY_PATTERN.test(key)) {
+    errors.workspaceKey = '소문자, 숫자, 하이픈만 사용할 수 있습니다. (예: my-workspace-1)';
+  }
+
+  if (!name.trim()) {
+    errors.name = '이름을 입력해주세요.';
+  } else if (name.length > 255) {
+    errors.name = '이름은 255자 이하여야 합니다.';
+  }
+
+  if (description.length > 2000) {
+    errors.description = '설명은 2000자 이하여야 합니다.';
+  }
+
+  return errors;
+}
+```
+
+---
+
+## Tests
+
+### Test Strategy
+
+| 구분 | 방법 | 도구 | 비고 |
+|------|------|------|------|
+| 수동 테스트 | 브라우저 직접 확인 | Chrome DevTools | 전체 CRUD 플로우 |
+| 통합 테스트 | Vitest + React Testing Library | `pnpm test` | 핵심 시나리오 |
+
+### Test Environment & 사전 조건
+
+| 항목 | 값 |
+|------|---|
+| 환경 | `pnpm dev` (백엔드 포함) |
+| 사전 조건 | 로그인된 상태 (JWT 토큰 존재) |
+| 역할 | OWNER 계정 (모든 액션 테스트 가능) |
+
+### Test Scenarios
+
+#### Happy Path
+
+| # | 시나리오 | 사전 조건 | 조작 | 기대 결과 |
+|---|---------|---------|------|----------|
+| 1 | 목록 조회 | 워크스페이스 3개 존재 | `/workspaces` 진입 | 3개 카드 표시, 각 role badge 표시 |
+| 2 | 빈 상태 표시 | 워크스페이스 0개 | `/workspaces` 진입 | EmptyState + 생성 CTA 표시 |
+| 3 | 워크스페이스 생성 | 로그인 상태 | 생성 Dialog → key: `test-ws`, name: `테스트` 입력 → 생성 | toast.success, Dialog 닫힘, 목록에 추가 |
+| 4 | 워크스페이스 수정 | OWNER/ADMIN 역할 | 수정 Dialog → name 변경 → 저장 | toast.success, Dialog 닫힘, 변경 반영 |
+| 5 | 워크스페이스 보관 | OWNER 역할 | 보관 버튼 → 확인 | toast.success, 목록에서 제거 |
+| 6 | description 포함 생성 | 로그인 상태 | 모든 필드 입력 → 생성 | description 포함 저장 |
+
+#### Error & Edge Cases
+
+| # | 시나리오 | 조작 | 기대 결과 |
+|---|---------|------|----------|
+| 1 | 필수 필드 누락 | key 또는 name 비워둔 채 생성 | 인라인 에러 표시, API 호출 안 됨 |
+| 2 | key 패턴 불일치 | `My Workspace` 입력 | 인라인 에러: 소문자/숫자/하이픈만 허용 |
+| 3 | key 3자 미만 | `ab` 입력 | 인라인 에러: 3자 이상 |
+| 4 | 중복 key (409) | 이미 존재하는 key 입력 → 생성 | 인라인 에러: 이미 사용 중인 키 |
+| 5 | 네트워크 오류 | 서버 다운 상태에서 생성 | toast.error: 연결 실패 |
+| 6 | 로딩 중 중복 클릭 | 생성 버튼 빠르게 두 번 클릭 | 중복 요청 방지 (isSubmitting 가드) |
+| 7 | REVIEWER/OPERATOR 수정 버튼 | 해당 역할로 카드 확인 | 수정 버튼 미표시 |
+| 8 | 비OWNER 보관 버튼 | ADMIN 역할로 카드 확인 | 보관 버튼 미표시 |
+| 9 | 목록 로딩 실패 | API 에러 | Error 상태 + 재시도 버튼 표시 |
+
+#### 접근성
+
+| # | 확인 항목 | 기대 결과 |
+|---|---------|----------|
+| 1 | 키보드 탐색 | Tab → 각 카드/버튼 순서대로 이동 |
+| 2 | Focus outline | dashed 2px 아웃라인 표시 |
+| 3 | Dialog 포커스 트랩 | Dialog 열리면 내부에 포커스 갇힘 |
+| 4 | Dialog ESC 닫기 | ESC 키로 Dialog 닫힘 |
+
+---
+
+## Done Criteria
+
+- [ ] 워크스페이스 목록 조회: Loading / Error / Empty 3-state 처리
+- [ ] 워크스페이스 생성: Dialog → POST → toast.success → 목록 refetch
+- [ ] 워크스페이스 수정: Dialog (prefilled) → PATCH (partial) → toast.success → 목록 refetch
+- [ ] 워크스페이스 보관: AlertDialog → DELETE (soft delete) → toast.success → 목록 refetch
+- [ ] role 기반 버튼 표시: Edit (OWNER/ADMIN), Archive (OWNER)
+- [ ] 에러 코드별 한국어 메시지 (WORKSPACE_KEY_CONFLICT, WORKSPACE_INVALID_KEY 등)
+- [ ] 클라이언트 유효성 검증: workspaceKey 패턴/길이, name 필수, description 길이
+- [ ] `<Toaster />` App.tsx에 마운트 (`alert()` 미사용)
+- [ ] ApiClient에 `delete` 메서드 추가
+- [ ] FSD 의존성 방향 준수: `pages → features → entities → shared`
+- [ ] DESIGN.md 준수: 모노크롬, dashed focus, shared/ui 컴포넌트 사용
+- [ ] DashboardLayout에 Workspaces 네비게이션 링크 추가
+- [ ] 기본 리다이렉트 `/` → `/workspaces` 변경
+
+---
+
+## Out of Scope (이 스펙 제외)
+
+- 워크스페이스 내부 대시보드 / 상세 페이지
+- 멤버 초대 / 관리 UI
+- 워크스페이스 검색 / 필터링
+- 페이지네이션 (현재 목록이 충분히 작음)
+- ARCHIVED 워크스페이스 복원 기능
+- 워크스페이스 단건 조회 (GET /workspaces/{id}) — 수정 Dialog에서는 목록 데이터 재사용

--- a/.agent/specs/021.md
+++ b/.agent/specs/021.md
@@ -138,7 +138,6 @@ WorkspaceListPage (pages/workspace-list)
 | Method | Path | Description | 응답 |
 |--------|------|-------------|------|
 | GET | `/api/v1/workspaces` | 목록 조회 | 200, `WorkspaceResponse[]` |
-| GET | `/api/v1/workspaces/{id}` | 단건 조회 | 200, `WorkspaceResponse` |
 | POST | `/api/v1/workspaces` | 생성 | 201, `WorkspaceResponse` |
 | PATCH | `/api/v1/workspaces/{id}` | 수정 (partial) | 200, `WorkspaceResponse` |
 | DELETE | `/api/v1/workspaces/{id}` | 삭제 (soft delete) | 204, No Content |
@@ -240,19 +239,19 @@ export interface UpdateWorkspaceRequest {
 
 | 파일 | 변경 유형 | 설명 |
 |------|----------|------|
-| `src/entities/workspace/model/types.ts` | new | WorkspaceResponse, Request 타입 정의 |
-| `src/entities/workspace/api/workspaceApi.ts` | new | API 함수 (list, create, update, archive) |
-| `src/entities/workspace/index.ts` | new | barrel export |
-| `src/features/workspace-list/ui/WorkspaceList.tsx` | new | 카드 그리드 + 3-state (Loading/Error/Empty) |
-| `src/features/workspace-list/ui/WorkspaceCard.tsx` | new | 단일 워크스페이스 카드 |
-| `src/features/workspace-list/ui/workspace-list.module.css` | new | 그리드 스타일 |
-| `src/features/create-workspace/ui/CreateWorkspaceDialog.tsx` | new | 생성 Dialog |
-| `src/features/update-workspace/ui/EditWorkspaceDialog.tsx` | new | 수정 Dialog |
-| `src/features/archive-workspace/ui/ArchiveConfirmDialog.tsx` | new | 삭제 확인 AlertDialog |
-| `src/pages/workspace-list/ui/WorkspaceListPage.tsx` | new | 페이지 컴포넌트 |
-| `src/pages/workspace-list/ui/workspace-list-page.module.css` | new | 페이지 스타일 |
-| `src/shared/ui/layout/DashboardLayout.tsx` | modify | Workspaces 네비게이션 링크 추가 |
-| `src/app/App.tsx` | modify | `/workspaces` 라우트 추가, 기본 리다이렉트 변경, `<Toaster />` 마운트 |
+| `frontend/src/entities/workspace/model/types.ts` | new | WorkspaceResponse, Request 타입 정의 |
+| `frontend/src/entities/workspace/api/workspaceApi.ts` | new | API 함수 (list, create, update, archive) |
+| `frontend/src/entities/workspace/index.ts` | new | barrel export |
+| `frontend/src/features/workspace-list/ui/WorkspaceList.tsx` | new | 카드 그리드 + 3-state (Loading/Error/Empty) |
+| `frontend/src/features/workspace-list/ui/WorkspaceCard.tsx` | new | 단일 워크스페이스 카드 |
+| `frontend/src/features/workspace-list/ui/workspace-list.module.css` | new | 그리드 스타일 |
+| `frontend/src/features/create-workspace/ui/CreateWorkspaceDialog.tsx` | new | 생성 Dialog |
+| `frontend/src/features/update-workspace/ui/EditWorkspaceDialog.tsx` | new | 수정 Dialog |
+| `frontend/src/features/archive-workspace/ui/ArchiveConfirmDialog.tsx` | new | 삭제 확인 AlertDialog |
+| `frontend/src/pages/workspace-list/ui/WorkspaceListPage.tsx` | new | 페이지 컴포넌트 |
+| `frontend/src/pages/workspace-list/ui/workspace-list-page.module.css` | new | 페이지 스타일 |
+| `frontend/src/shared/ui/layout/DashboardLayout.tsx` | modify | Workspaces 네비게이션 링크 추가 |
+| `frontend/src/app/App.tsx` | modify | `/workspaces` 라우트 추가, 기본 리다이렉트 변경, `<Toaster />` 마운트 |
 
 ---
 
@@ -452,4 +451,4 @@ function validateCreateForm(key: string, name: string, description: string): Rec
 - 워크스페이스 검색 / 필터링
 - 페이지네이션 (현재 목록이 충분히 작음)
 - ARCHIVED 워크스페이스 복원 기능
-- 워크스페이스 단건 조회 (GET /workspaces/{id}) — 수정 Dialog에서는 목록 데이터 재사용
+- 워크스페이스 단건 조회 (`GET /api/v1/workspaces/{id}`) — 백엔드 엔드포인트는 존재하지만 이번 UI 스펙에서는 사용하지 않음. 수정 Dialog에서는 목록 데이터 재사용

--- a/.agent/specs/021.md
+++ b/.agent/specs/021.md
@@ -71,7 +71,6 @@ flowchart TD
 | 포스트 로그인 랜딩 | `/upload` | `/workspaces` | 기본 리다이렉트 변경 |
 | 워크스페이스 UI | 없음 | 목록 페이지 + CRUD Dialog | 신규 구현 |
 | DashboardLayout 네비게이션 | 워크스페이스 링크 없음 | Workspaces 링크 추가 | 네비 수정 |
-| ApiClient | `delete` 메서드 없음 | `delete` 메서드 추가 | shared/api 수정 |
 | Toast 인프라 | `<Toaster />` 미마운트 | `App.tsx`에 `<Toaster />` 마운트 | 인프라 추가 |
 
 ---
@@ -252,7 +251,6 @@ export interface UpdateWorkspaceRequest {
 | `src/features/archive-workspace/ui/ArchiveConfirmDialog.tsx` | new | 보관 확인 AlertDialog |
 | `src/pages/workspace-list/ui/WorkspaceListPage.tsx` | new | 페이지 컴포넌트 |
 | `src/pages/workspace-list/ui/workspace-list-page.module.css` | new | 페이지 스타일 |
-| `src/shared/api/index.ts` | modify | `delete` 메서드 추가 |
 | `src/shared/ui/layout/DashboardLayout.tsx` | modify | Workspaces 네비게이션 링크 추가 |
 | `src/app/App.tsx` | modify | `/workspaces` 라우트 추가, 기본 리다이렉트 변경, `<Toaster />` 마운트 |
 
@@ -440,7 +438,6 @@ function validateCreateForm(key: string, name: string, description: string): Rec
 - [ ] 에러 코드별 한국어 메시지 (WORKSPACE_KEY_CONFLICT, WORKSPACE_INVALID_KEY 등)
 - [ ] 클라이언트 유효성 검증: workspaceKey 패턴/길이, name 필수, description 길이
 - [ ] `<Toaster />` App.tsx에 마운트 (`alert()` 미사용)
-- [ ] ApiClient에 `delete` 메서드 추가
 - [ ] FSD 의존성 방향 준수: `pages → features → entities → shared`
 - [ ] DESIGN.md 준수: 모노크롬, dashed focus, shared/ui 컴포넌트 사용
 - [ ] DashboardLayout에 Workspaces 네비게이션 링크 추가


### PR DESCRIPTION
## Goal
콘솔에서 워크스페이스 CRUD UI를 정의한다.

## Scope
- 워크스페이스 목록 페이지
- 워크스페이스 생성 Dialog
- 워크스페이스 수정 Dialog
- 워크스페이스 삭제 확인 Dialog
- DashboardLayout에 Workspaces 링크 추가
- `/workspaces` 라우트 추가
- Toast 기반 성공/실패 피드백 적용

## API Contract
- `GET /api/v1/workspaces`
- `POST /api/v1/workspaces`
- `PATCH /api/v1/workspaces/{id}`
- `DELETE /api/v1/workspaces/{id}`

## Validation
- `workspaceKey`: 필수, 3~100자, 소문자/숫자/하이픈
- `name`: 필수, 1~255자
- `description`: 선택, 최대 2000자

## Out of Scope
- 워크스페이스 내부 대시보드 / 상세 페이지
- 멤버 초대 / 관리 UI
- 검색 / 필터 / 페이지네이션
- ARCHIVED 워크스페이스 복원 기능

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **문서화**
  * 콘솔용 "워크스페이스" CRUD UI에 대한 신규 프론트엔드 사양(Spec 021)이 추가되었습니다. /workspaces 경로 흐름, 로딩/오류/빈 상태, 역할 기반 카드 그리드, 생성/편집/삭제 대화상자, 입력 검증(키 패턴·길이, 이름 필수, 설명 길이), 필드별 인라인 오류, 서버 오류 코드 매핑, 토스트 알림 및 리페치 동작, 필요한 API 엔드포인트 및 컴포넌트 구조가 정의되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->