### PR TITLE
spec/3212: policy/rule 초안 목록 조회 APIs

### DIFF
--- a/.agent/specs/3212.md
+++ b/.agent/specs/3212.md
@@ -89,7 +89,7 @@ Query parameters: 없음 (pagination / filtering 미지원)
 **404 Not Found — workspace not found**
 
 ```json
-{ "code": "DOMAIN_PACK_WORKSPACE_NOT_FOUND", "message": "..." }
+{ "code": "DOMAIN_PACK_WORKSPACE_NOT_FOUND", "message": "워크스페이스를 찾을 수 없습니다. id={workspaceId}" }
 ```
 
 **404 Not Found — pack not found**

--- a/.agent/specs/3212.md
+++ b/.agent/specs/3212.md
@@ -1,0 +1,246 @@
+# [BE] 3.2.12 — Policy / Rule 초안 목록 조회
+
+## Goal
+
+특정 Domain Pack Version에 속한 Policy 초안 전체 목록을 조회하는 READ 전용 엔드포인트를 제공한다.
+
+---
+
+## Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    actor c as Client
+    participant ctrl as PolicyDefinitionController
+    participant uc as GetPolicyDefinitionListUseCase
+    participant validator as DomainPackValidator
+    participant repo as PolicyDefinitionRepository
+    participant db as PostgreSQL
+
+    c ->> ctrl: GET /api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/policies
+    ctrl ->> uc: execute(GetPolicyDefinitionListQuery)
+    uc ->> validator: validateForWorkspacePackVersion(workspaceId, userId, packId, versionId)
+    validator -->> uc: (passes or throws)
+    uc ->> repo: findAllByDomainPackVersionIdOrderByPolicyCodeAsc(versionId)
+    repo ->> db: SELECT ... FROM pack.policy_definition WHERE domain_pack_version_id = ? ORDER BY policy_code ASC
+    db -->> repo: rows
+    repo -->> uc: List<PolicyDefinition>
+    uc -->> ctrl: List<PolicyDefinitionSummary>
+    ctrl -->> c: 200 OK
+```
+
+---
+
+## REST API
+
+### Endpoint
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/policies` | Policy 초안 목록 조회 |
+
+### Request
+
+Path variables:
+- `workspaceId`: Long
+- `packId`: Long
+- `versionId`: Long
+
+Headers:
+- `Authorization: Bearer {jwt-token}` (필수)
+
+Query parameters: 없음 (pagination / filtering 미지원)
+
+### Response
+
+**200 OK**
+
+```json
+[
+  {
+    "id": 1,
+    "domainPackVersionId": 10,
+    "policyCode": "POL_RETURN",
+    "name": "반품 처리 정책",
+    "description": "7일 이내 반품 허용",
+    "severity": "HIGH",
+    "status": "ACTIVE",
+    "createdAt": "2025-04-03T10:00:00Z",
+    "updatedAt": "2025-04-03T10:00:00Z"
+  }
+]
+```
+
+> JSON 필드(`conditionJson`, `actionJson`, `evidenceJson`, `metaJson`)는 목록 응답에서 제외한다.  
+> policy가 없는 version이면 빈 배열 `[]`를 반환한다.
+
+**401 Unauthorized**
+
+```json
+{ "code": "UNAUTHORIZED", "message": "인증이 필요합니다." }
+```
+
+**403 Forbidden**
+
+```json
+{ "code": "FORBIDDEN", "message": "접근 권한이 없습니다." }
+```
+
+**404 Not Found — workspace not found**
+
+```json
+{ "code": "DOMAIN_PACK_WORKSPACE_NOT_FOUND", "message": "..." }
+```
+
+**404 Not Found — pack not found**
+
+```json
+{ "code": "DOMAIN_PACK_NOT_FOUND", "message": "DomainPack not found: {packId}" }
+```
+
+**404 Not Found — version not found**
+
+```json
+{ "code": "DOMAIN_PACK_VERSION_NOT_FOUND", "message": "도메인 팩 버전을 찾을 수 없습니다. id={versionId}" }
+```
+
+---
+
+## Class Design
+
+### 신규 생성 파일
+
+| 파일 | 경로 | 역할 |
+|------|------|------|
+| `GetPolicyDefinitionListQuery.java` | `application/` | UseCase 입력 record |
+| `GetPolicyDefinitionListUseCase.java` | `application/` | 목록 조회 UseCase |
+| `PolicyDefinitionSummary.java` | `application/` | 목록 응답 DTO (JSON 필드 제외) |
+
+### 수정 파일
+
+| 파일 | 변경 내용 |
+|------|-----------|
+| `PolicyDefinitionRepository.java` | `findAllByDomainPackVersionIdOrderByPolicyCodeAsc(Long domainPackVersionId)` 추가 |
+| `JpaPolicyDefinitionRepository.java` | 기존 `findByDomainPackVersionId` 제거 → `findAllByDomainPackVersionIdOrderByPolicyCodeAsc` 선언으로 교체 |
+| `PolicyDefinitionController.java` | `GetPolicyDefinitionListUseCase` 생성자 주입 추가; `@GetMapping listPolicies(...)` 메서드 추가 |
+
+### Pseudo-code
+
+```java
+// GetPolicyDefinitionListQuery.java
+record GetPolicyDefinitionListQuery(
+    Long workspaceId, Long packId, Long versionId, Long userId)
+
+// PolicyDefinitionSummary.java
+record PolicyDefinitionSummary(
+    Long id,
+    Long domainPackVersionId,
+    String policyCode,
+    String name,
+    String description,
+    String severity,
+    String status,
+    OffsetDateTime createdAt,
+    OffsetDateTime updatedAt) {
+
+    static PolicyDefinitionSummary from(PolicyDefinition policy) {
+        return new PolicyDefinitionSummary(
+            policy.getId(),
+            policy.getDomainPackVersionId(),
+            policy.getPolicyCode(),
+            policy.getName(),
+            policy.getDescription(),
+            policy.getSeverity(),
+            policy.getStatus(),
+            policy.getCreatedAt(),
+            policy.getUpdatedAt())
+    }
+}
+
+// GetPolicyDefinitionListUseCase.java
+@Service
+@Transactional(readOnly = true)
+class GetPolicyDefinitionListUseCase {
+    execute(GetPolicyDefinitionListQuery query) {
+        validator.validateForWorkspacePackVersion(
+            query.workspaceId(), query.userId(), query.packId(), query.versionId())
+        return policyDefinitionRepository
+            .findAllByDomainPackVersionIdOrderByPolicyCodeAsc(query.versionId())
+            .stream()
+            .map(PolicyDefinitionSummary::from)
+            .toList()
+    }
+}
+
+// PolicyDefinitionController.java (수정)
+@RestController
+@RequestMapping("/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/policies")
+class PolicyDefinitionController {
+    // listUseCase 추가, detailUseCase 기존 유지
+
+    @GetMapping
+    listPolicies(@PathVariable Long workspaceId, @PathVariable Long packId,
+                 @PathVariable Long versionId, Authentication authentication) {
+        Long userId = AuthenticationUtils.getUserId(authentication)
+        return ResponseEntity.ok(
+            listUseCase.execute(
+                new GetPolicyDefinitionListQuery(workspaceId, packId, versionId, userId)))
+    }
+
+    @GetMapping("/{policyId}")
+    getPolicy(...) { /* 기존 그대로 */ }
+}
+```
+
+---
+
+## Tests
+
+### UseCase 테스트: `GetPolicyDefinitionListUseCaseTest.java`
+
+참조: `GetSlotDefinitionListUseCaseTest.java` 패턴 동일 적용
+
+- `@ExtendWith(MockitoExtension.class)` + `@DisplayName`
+- `@BeforeEach`: `DomainPackValidator` 직접 생성 → `GetPolicyDefinitionListUseCase` 주입
+
+| 시나리오 | 예상 결과 |
+|----------|-----------|
+| 유효한 query → policyCode ASC 순 목록 반환 | `List<PolicyDefinitionSummary>` 반환 (순서 검증) |
+| 목록 응답에 JSON 필드 미포함 | `conditionJson`, `actionJson`, `evidenceJson`, `metaJson` 미포함 (RecordComponent 이름 검증) |
+| policy 없는 version → 빈 목록 반환 | `result.isEmpty()` |
+| workspace 미존재 | `DomainPackWorkspaceNotFoundException` |
+| 접근 권한 없음 | `DomainPackUnauthorizedWorkspaceAccessException` |
+| pack 소속 불일치 | `DomainPackNotFoundException` |
+| version 소속 불일치 | `DomainPackVersionNotFoundException` |
+
+### Controller 테스트: `PolicyDefinitionControllerTest.java`
+
+- `@WebMvcTest(PolicyDefinitionController.class)` + JwtAuthenticationFilter exclude
+- `@WithLongPrincipal(10L)` fixture 사용 (패키지: `com.init.fixtures`)
+- `@MockitoBean`: `GetPolicyDefinitionListUseCase listUseCase`, `GetPolicyDefinitionUseCase detailUseCase`
+
+| 시나리오 | 예상 결과 |
+|----------|-----------|
+| GET .../policies → 200 OK, JSON 필드 미노출 검증 | `$[0].conditionJson doesNotExist()`, `$[0].actionJson doesNotExist()`, `$[0].evidenceJson doesNotExist()`, `$[0].metaJson doesNotExist()` |
+| GET .../policies → policy 없으면 빈 배열 | `$` isArray() isEmpty() |
+| GET .../policies → 403 권한 없음 | 403, `$.code = "FORBIDDEN"` |
+| GET .../policies → 401 미인증 | 401 |
+| GET .../policies → 404 version 소속 불일치 | 404, `$.code = "DOMAIN_PACK_VERSION_NOT_FOUND"` |
+| GET .../policies → 404 pack 미존재 | 404, `$.code = "DOMAIN_PACK_NOT_FOUND"` |
+
+---
+
+## Database
+
+신규 DDL 없음.
+
+`pack.policy_definition` 테이블 및 `idx_policy_version_id` 인덱스 이미 존재 (`.agent/docs/schema.md:480–495, 846`).
+
+---
+
+## Additional Notes
+
+- 구현은 `GetSlotDefinitionListUseCase` + `SlotDefinitionController` 패턴을 그대로 따른다.
+- 기존 `JpaPolicyDefinitionRepository.findByDomainPackVersionId(Long)`는 도메인 인터페이스와 불일치 상태이므로, 이번 작업에서 `findAllByDomainPackVersionIdOrderByPolicyCodeAsc`로 교체하여 인터페이스 일관성을 회복한다.
+- `PolicyDefinitionSummary`는 JSON 대용량 필드(`conditionJson`, `actionJson`, `evidenceJson`, `metaJson`)를 제외하여 목록 페이로드를 줄인다.
+- `PolicyDefinitionController`는 단건 조회(`GetPolicyDefinitionUseCase`)와 목록 조회(`GetPolicyDefinitionListUseCase`)를 하나의 Controller 클래스에서 함께 처리한다 (`SlotDefinitionController` 참조).


### PR DESCRIPTION
# [BE] 3.2.12 — Policy / Rule 초안 목록 조회

## Goal

특정 Domain Pack Version에 속한 Policy 초안 전체 목록을 조회하는 READ 전용 엔드포인트를 제공한다.

---

## Sequence Diagram

```mermaid
sequenceDiagram
    actor c as Client
    participant ctrl as PolicyDefinitionController
    participant uc as GetPolicyDefinitionListUseCase
    participant validator as DomainPackValidator
    participant repo as PolicyDefinitionRepository
    participant db as PostgreSQL

    c ->> ctrl: GET /api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/policies
    ctrl ->> uc: execute(GetPolicyDefinitionListQuery)
    uc ->> validator: validateForWorkspacePackVersion(workspaceId, userId, packId, versionId)
    validator -->> uc: (passes or throws)
    uc ->> repo: findAllByDomainPackVersionIdOrderByPolicyCodeAsc(versionId)
    repo ->> db: SELECT ... FROM pack.policy_definition WHERE domain_pack_version_id = ? ORDER BY policy_code ASC
    db -->> repo: rows
    repo -->> uc: List<PolicyDefinition>
    uc -->> ctrl: List<PolicyDefinitionSummary>
    ctrl -->> c: 200 OK
```

---

## REST API

### Endpoint

| Method | Path | Description |
|--------|------|-------------|
| GET | `/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/policies` | Policy 초안 목록 조회 |

### Request

Path variables:
- `workspaceId`: Long
- `packId`: Long
- `versionId`: Long

Headers:
- `Authorization: Bearer {jwt-token}` (필수)

Query parameters: 없음 (pagination / filtering 미지원)

### Response

**200 OK**

```json
[
  {
    "id": 1,
    "domainPackVersionId": 10,
    "policyCode": "POL_RETURN",
    "name": "반품 처리 정책",
    "description": "7일 이내 반품 허용",
    "severity": "HIGH",
    "status": "ACTIVE",
    "createdAt": "2025-04-03T10:00:00Z",
    "updatedAt": "2025-04-03T10:00:00Z"
  }
]
```

> JSON 필드(`conditionJson`, `actionJson`, `evidenceJson`, `metaJson`)는 목록 응답에서 제외한다.  
> policy가 없는 version이면 빈 배열 `[]`를 반환한다.

**401 Unauthorized**

```json
{ "code": "UNAUTHORIZED", "message": "인증이 필요합니다." }
```

**403 Forbidden**

```json
{ "code": "FORBIDDEN", "message": "접근 권한이 없습니다." }
```

**404 Not Found — workspace not found**

```json
{ "code": "DOMAIN_PACK_WORKSPACE_NOT_FOUND", "message": "..." }
```

**404 Not Found — pack not found**

```json
{ "code": "DOMAIN_PACK_NOT_FOUND", "message": "DomainPack not found: {packId}" }
```

**404 Not Found — version not found**

```json
{ "code": "DOMAIN_PACK_VERSION_NOT_FOUND", "message": "도메인 팩 버전을 찾을 수 없습니다. id={versionId}" }
```

---

## Class Design

### 신규 생성 파일

| 파일 | 경로 | 역할 |
|------|------|------|
| `GetPolicyDefinitionListQuery.java` | `application/` | UseCase 입력 record |
| `GetPolicyDefinitionListUseCase.java` | `application/` | 목록 조회 UseCase |
| `PolicyDefinitionSummary.java` | `application/` | 목록 응답 DTO (JSON 필드 제외) |

### 수정 파일

| 파일 | 변경 내용 |
|------|-----------|
| `PolicyDefinitionRepository.java` | `findAllByDomainPackVersionIdOrderByPolicyCodeAsc(Long domainPackVersionId)` 추가 |
| `JpaPolicyDefinitionRepository.java` | 기존 `findByDomainPackVersionId` 제거 → `findAllByDomainPackVersionIdOrderByPolicyCodeAsc` 선언으로 교체 |
| `PolicyDefinitionController.java` | `GetPolicyDefinitionListUseCase` 생성자 주입 추가; `@GetMapping listPolicies(...)` 메서드 추가 |

### Pseudo-code

```java
// GetPolicyDefinitionListQuery.java
record GetPolicyDefinitionListQuery(
    Long workspaceId, Long packId, Long versionId, Long userId)

// PolicyDefinitionSummary.java
record PolicyDefinitionSummary(
    Long id,
    Long domainPackVersionId,
    String policyCode,
    String name,
    String description,
    String severity,
    String status,
    OffsetDateTime createdAt,
    OffsetDateTime updatedAt) {

    static PolicyDefinitionSummary from(PolicyDefinition policy) {
        return new PolicyDefinitionSummary(
            policy.getId(),
            policy.getDomainPackVersionId(),
            policy.getPolicyCode(),
            policy.getName(),
            policy.getDescription(),
            policy.getSeverity(),
            policy.getStatus(),
            policy.getCreatedAt(),
            policy.getUpdatedAt())
    }
}

// GetPolicyDefinitionListUseCase.java
@Service
@Transactional(readOnly = true)
class GetPolicyDefinitionListUseCase {
    execute(GetPolicyDefinitionListQuery query) {
        validator.validateForWorkspacePackVersion(
            query.workspaceId(), query.userId(), query.packId(), query.versionId())
        return policyDefinitionRepository
            .findAllByDomainPackVersionIdOrderByPolicyCodeAsc(query.versionId())
            .stream()
            .map(PolicyDefinitionSummary::from)
            .toList()
    }
}

// PolicyDefinitionController.java (수정)
@RestController
@RequestMapping("/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/policies")
class PolicyDefinitionController {
    // listUseCase 추가, detailUseCase 기존 유지

    @GetMapping
    listPolicies(@PathVariable Long workspaceId, @PathVariable Long packId,
                 @PathVariable Long versionId, Authentication authentication) {
        Long userId = AuthenticationUtils.getUserId(authentication)
        return ResponseEntity.ok(
            listUseCase.execute(
                new GetPolicyDefinitionListQuery(workspaceId, packId, versionId, userId)))
    }

    @GetMapping("/{policyId}")
    getPolicy(...) { /* 기존 그대로 */ }
}
```

---

## Tests

### UseCase 테스트: `GetPolicyDefinitionListUseCaseTest.java`

참조: `GetSlotDefinitionListUseCaseTest.java` 패턴 동일 적용

- `@ExtendWith(MockitoExtension.class)` + `@DisplayName`
- `@BeforeEach`: `DomainPackValidator` 직접 생성 → `GetPolicyDefinitionListUseCase` 주입

| 시나리오 | 예상 결과 |
|----------|-----------|
| 유효한 query → policyCode ASC 순 목록 반환 | `List<PolicyDefinitionSummary>` 반환 (순서 검증) |
| 목록 응답에 JSON 필드 미포함 | `conditionJson`, `actionJson`, `evidenceJson`, `metaJson` 미포함 (RecordComponent 이름 검증) |
| policy 없는 version → 빈 목록 반환 | `result.isEmpty()` |
| workspace 미존재 | `DomainPackWorkspaceNotFoundException` |
| 접근 권한 없음 | `DomainPackUnauthorizedWorkspaceAccessException` |
| pack 소속 불일치 | `DomainPackNotFoundException` |
| version 소속 불일치 | `DomainPackVersionNotFoundException` |

### Controller 테스트: `PolicyDefinitionControllerTest.java`

- `@WebMvcTest(PolicyDefinitionController.class)` + JwtAuthenticationFilter exclude
- `@WithLongPrincipal(10L)` fixture 사용 (패키지: `com.init.fixtures`)
- `@MockitoBean`: `GetPolicyDefinitionListUseCase listUseCase`, `GetPolicyDefinitionUseCase detailUseCase`

| 시나리오 | 예상 결과 |
|----------|-----------|
| GET .../policies → 200 OK, JSON 필드 미노출 검증 | `$[0].conditionJson doesNotExist()`, `$[0].actionJson doesNotExist()`, `$[0].evidenceJson doesNotExist()`, `$[0].metaJson doesNotExist()` |
| GET .../policies → policy 없으면 빈 배열 | `$` isArray() isEmpty() |
| GET .../policies → 403 권한 없음 | 403, `$.code = "FORBIDDEN"` |
| GET .../policies → 401 미인증 | 401 |
| GET .../policies → 404 version 소속 불일치 | 404, `$.code = "DOMAIN_PACK_VERSION_NOT_FOUND"` |
| GET .../policies → 404 pack 미존재 | 404, `$.code = "DOMAIN_PACK_NOT_FOUND"` |

---

## Database

신규 DDL 없음.

`pack.policy_definition` 테이블 및 `idx_policy_version_id` 인덱스 이미 존재 (`.agent/docs/schema.md:480–495, 846`).

---

## Additional Notes

- 구현은 `GetSlotDefinitionListUseCase` + `SlotDefinitionController` 패턴을 그대로 따른다.
- 기존 `JpaPolicyDefinitionRepository.findByDomainPackVersionId(Long)`는 도메인 인터페이스와 불일치 상태이므로, 이번 작업에서 `findAllByDomainPackVersionIdOrderByPolicyCodeAsc`로 교체하여 인터페이스 일관성을 회복한다.
- `PolicyDefinitionSummary`는 JSON 대용량 필드(`conditionJson`, `actionJson`, `evidenceJson`, `metaJson`)를 제외하여 목록 페이로드를 줄인다.
- `PolicyDefinitionController`는 단건 조회(`GetPolicyDefinitionUseCase`)와 목록 조회(`GetPolicyDefinitionListUseCase`)를 하나의 Controller 클래스에서 함께 처리한다 (`SlotDefinitionController` 참조).
---
# Uncertainty Register — 3212: [BE] Policy / Rule 초안 목록 조회

**Branch:** `spec/3212`  
**Date:** 2026-04-20  
**Spec:** `.agent/specs/3212.md`

---

## Items

### UR-3212-01

- **ID:** UR-3212-01
- **Issue:** 목록 응답 DTO — `PolicyDefinitionSummary` 신규 생성 vs `PolicyDefinitionResponse` 재사용
- **Status:** Assumption
- **Why unresolved:** 스펙 요청에 목록 응답 DTO 형태가 명시되지 않았다. 단건 조회에서는 `PolicyDefinitionResponse`(full DTO)가 사용되고 있으나, 목록 조회의 DTO 분리 여부는 선행 구현 패턴에서 추론해야 한다.
- **Options:**
  - A. `PolicyDefinitionSummary` 신규 생성 — JSON 필드(`conditionJson`, `actionJson`, `evidenceJson`, `metaJson`) 제외
  - B. `PolicyDefinitionResponse` 그대로 사용 — JSON 필드 포함 full DTO
- **Recommended Default:** Option A (`PolicyDefinitionSummary` 신규 생성)
- **Why recommended:** `SlotDefinitionSummary`가 `validationRuleJson`, `defaultValueJson`, `metaJson` 3개 JSON 필드를 제외하는 것과 동일하게, `PolicyDefinitionSummary`도 4개 JSON 필드를 제외하는 것이 패턴 일관성 및 페이로드 최적화 측면에서 타당하다.
- **User Decision Required:** No
- **User Question:** N/A
- **Execution Rule:**
  - Implementation Agent MUST NOT: DTO 종류 확정 없이 두 가지를 혼용하거나 임의 선택
  - Implementation Agent MAY: `Assumption adopted from Recommended Default`로만 채택 가능; risks — 목록 응답에서 JSON 필드가 필요한 FE 시나리오가 있다면 추후 스펙 재협의 필요
  - If unsafe: N/A
- **Affected Spec Section:** Class Design, Tests

---

### UR-3212-02

- **ID:** UR-3212-02
- **Issue:** 목록 정렬 기준 — `policyCode ASC` 여부
- **Status:** Assumption
- **Why unresolved:** 스펙 요청에 정렬 기준이 명시되어 있지 않다. `SlotDefinition`의 `slotCode ASC` 정렬 패턴에서 유추한다.
- **Options:**
  - A. `policyCode ASC` (SlotDefinition 패턴 동일 적용)
  - B. `id ASC` (삽입 순서)
  - C. 정렬 없음
- **Recommended Default:** Option A (`policyCode ASC`)
- **Why recommended:** `findAllByDomainPackVersionIdOrderBySlotCodeAsc` 패턴과 일관성을 유지한다. policyCode는 운영자가 목록을 탐색할 때 자연 식별자 역할을 한다.
- **User Decision Required:** No
- **User Question:** N/A
- **Execution Rule:**
  - Implementation Agent MUST NOT: 정렬 기준 확정 없이 임의 순서로 구현
  - Implementation Agent MAY: `Assumption adopted from Recommended Default`로만 채택 가능; risks — 운영자 요구사항에 따라 다른 정렬이 필요할 수 있음
  - If unsafe: N/A
- **Affected Spec Section:** Class Design (repository method name), Tests

---

### UR-3212-03

- **ID:** UR-3212-03
- **Issue:** `JpaPolicyDefinitionRepository.findByDomainPackVersionId` ↔ 도메인 인터페이스 불일치 (사전 존재하는 충돌)
- **Status:** Confirmed (Action Required)
- **Why unresolved:** 구현 착수 전부터 존재하는 상태 불일치다. `JpaPolicyDefinitionRepository.java` line 14에 `findByDomainPackVersionId(Long domainPackVersionId)` 메서드가 선언되어 있으나, 도메인 인터페이스 `PolicyDefinitionRepository.java`에는 해당 메서드가 없다.
- **Options:**
  - A. 도메인 인터페이스에 `findAllByDomainPackVersionIdOrderByPolicyCodeAsc` 추가 + JPA 어댑터의 기존 `findByDomainPackVersionId` 교체 (권장)
  - B. 도메인 인터페이스에 기존 `findByDomainPackVersionId` 그대로 추가 후 별도 정렬 메서드를 추가 선언
- **Recommended Default:** Option A
- **Why recommended:** 사용되지 않는 메서드를 도메인 인터페이스에 남기지 않는다. 정렬 의도를 메서드 이름에 명시하여 SlotDefinitionRepository 패턴과 일관성을 유지한다.
- **User Decision Required:** No
- **User Question:** N/A
- **Execution Rule:**
  - Implementation Agent MUST NOT: 기존 불일치를 그대로 둔 채 새 메서드만 추가
  - Implementation Agent MAY: Option A 적용; risks — `findByDomainPackVersionId`를 다른 UseCase에서 직접 호출하는 경우 빌드 오류 발생. grep으로 사용처 확인 후 교체 필요
  - If unsafe: `findByDomainPackVersionId` 사용처가 발견되면 해당 UseCase도 함께 수정
- **Affected Spec Section:** Class Design (수정 파일)

---

*Artifact path: `.handoff/3212/uncertainty-register-3212.md`*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 도메인 팩 버전의 정책 목록을 조회하는 신규 API 추가: GET /api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/policies
  * 정책 목록을 policyCode 오름차순으로 반환하며, 대용량 JSON 필드(조건/동작/증거/메타)는 목록에서 제외되어 응답 경량화
  * 정책이 없으면 빈 배열 반환, 인증·권한·존재성 오류에 대해 401/403/404 응답 명시적 처리
<!-- end of auto-generated comment: release notes by coderabbit.ai -->