### PR TITLE
feat(domain-pack): add GET /policies list endpoint with PolicyDefinitionSummary DTO

### DIFF
--- a/backend/src/main/java/com/init/domainpack/application/GetPolicyDefinitionListQuery.java
+++ b/backend/src/main/java/com/init/domainpack/application/GetPolicyDefinitionListQuery.java
@@ -1,0 +1,4 @@
+package com.init.domainpack.application;
+
+public record GetPolicyDefinitionListQuery(
+    Long workspaceId, Long packId, Long versionId, Long userId) {}

--- a/backend/src/main/java/com/init/domainpack/application/GetPolicyDefinitionListUseCase.java
+++ b/backend/src/main/java/com/init/domainpack/application/GetPolicyDefinitionListUseCase.java
@@ -1,0 +1,31 @@
+package com.init.domainpack.application;
+
+import com.init.domainpack.domain.repository.PolicyDefinitionRepository;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class GetPolicyDefinitionListUseCase {
+
+  private final DomainPackValidator validator;
+  private final PolicyDefinitionRepository policyDefinitionRepository;
+
+  public GetPolicyDefinitionListUseCase(
+      DomainPackValidator validator, PolicyDefinitionRepository policyDefinitionRepository) {
+    this.validator = validator;
+    this.policyDefinitionRepository = policyDefinitionRepository;
+  }
+
+  public List<PolicyDefinitionSummary> execute(GetPolicyDefinitionListQuery query) {
+    validator.validateForWorkspacePackVersion(
+        query.workspaceId(), query.userId(), query.packId(), query.versionId());
+
+    return policyDefinitionRepository
+        .findAllByDomainPackVersionIdOrderByPolicyCodeAsc(query.versionId())
+        .stream()
+        .map(PolicyDefinitionSummary::from)
+        .toList();
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/application/PolicyDefinitionSummary.java
+++ b/backend/src/main/java/com/init/domainpack/application/PolicyDefinitionSummary.java
@@ -1,0 +1,29 @@
+package com.init.domainpack.application;
+
+import com.init.domainpack.domain.model.PolicyDefinition;
+import java.time.OffsetDateTime;
+
+public record PolicyDefinitionSummary(
+    Long id,
+    Long domainPackVersionId,
+    String policyCode,
+    String name,
+    String description,
+    String severity,
+    String status,
+    OffsetDateTime createdAt,
+    OffsetDateTime updatedAt) {
+
+  public static PolicyDefinitionSummary from(PolicyDefinition policy) {
+    return new PolicyDefinitionSummary(
+        policy.getId(),
+        policy.getDomainPackVersionId(),
+        policy.getPolicyCode(),
+        policy.getName(),
+        policy.getDescription(),
+        policy.getSeverity(),
+        policy.getStatus(),
+        policy.getCreatedAt(),
+        policy.getUpdatedAt());
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/domain/repository/PolicyDefinitionRepository.java
+++ b/backend/src/main/java/com/init/domainpack/domain/repository/PolicyDefinitionRepository.java
@@ -12,5 +12,7 @@ public interface PolicyDefinitionRepository {
 
   Optional<PolicyDefinition> findByIdAndDomainPackVersionId(Long id, Long domainPackVersionId);
 
+  List<PolicyDefinition> findAllByDomainPackVersionIdOrderByPolicyCodeAsc(Long domainPackVersionId);
+
   PolicyDefinition save(PolicyDefinition policy);
 }

--- a/backend/src/main/java/com/init/domainpack/infrastructure/persistence/JpaPolicyDefinitionRepository.java
+++ b/backend/src/main/java/com/init/domainpack/infrastructure/persistence/JpaPolicyDefinitionRepository.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Repository;
 public interface JpaPolicyDefinitionRepository
     extends JpaRepository<PolicyDefinition, Long>, PolicyDefinitionRepository {
 
-  List<PolicyDefinition> findByDomainPackVersionId(Long domainPackVersionId);
+  List<PolicyDefinition> findAllByDomainPackVersionIdOrderByPolicyCodeAsc(Long domainPackVersionId);
 
   Optional<PolicyDefinition> findByIdAndDomainPackVersionId(Long id, Long domainPackVersionId);
 }

--- a/backend/src/main/java/com/init/domainpack/presentation/PolicyDefinitionController.java
+++ b/backend/src/main/java/com/init/domainpack/presentation/PolicyDefinitionController.java
@@ -1,9 +1,13 @@
 package com.init.domainpack.presentation;
 
+import com.init.domainpack.application.GetPolicyDefinitionListQuery;
+import com.init.domainpack.application.GetPolicyDefinitionListUseCase;
 import com.init.domainpack.application.GetPolicyDefinitionQuery;
 import com.init.domainpack.application.GetPolicyDefinitionUseCase;
 import com.init.domainpack.application.PolicyDefinitionResponse;
+import com.init.domainpack.application.PolicyDefinitionSummary;
 import com.init.shared.presentation.AuthenticationUtils;
+import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,10 +20,25 @@ import org.springframework.web.bind.annotation.RestController;
     "/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/policies")
 public class PolicyDefinitionController {
 
-  private final GetPolicyDefinitionUseCase useCase;
+  private final GetPolicyDefinitionListUseCase listUseCase;
+  private final GetPolicyDefinitionUseCase detailUseCase;
 
-  public PolicyDefinitionController(GetPolicyDefinitionUseCase useCase) {
-    this.useCase = useCase;
+  public PolicyDefinitionController(
+      GetPolicyDefinitionListUseCase listUseCase, GetPolicyDefinitionUseCase detailUseCase) {
+    this.listUseCase = listUseCase;
+    this.detailUseCase = detailUseCase;
+  }
+
+  @GetMapping
+  public ResponseEntity<List<PolicyDefinitionSummary>> listPolicies(
+      @PathVariable Long workspaceId,
+      @PathVariable Long packId,
+      @PathVariable Long versionId,
+      Authentication authentication) {
+    Long userId = AuthenticationUtils.getUserId(authentication);
+    return ResponseEntity.ok(
+        listUseCase.execute(
+            new GetPolicyDefinitionListQuery(workspaceId, packId, versionId, userId)));
   }
 
   @GetMapping("/{policyId}")
@@ -31,7 +50,7 @@ public class PolicyDefinitionController {
       Authentication authentication) {
     Long userId = AuthenticationUtils.getUserId(authentication);
     return ResponseEntity.ok(
-        useCase.execute(
+        detailUseCase.execute(
             new GetPolicyDefinitionQuery(workspaceId, packId, versionId, policyId, userId)));
   }
 }

--- a/backend/src/test/java/com/init/domainpack/application/GetPolicyDefinitionListUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/GetPolicyDefinitionListUseCaseTest.java
@@ -1,0 +1,203 @@
+package com.init.domainpack.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.init.domainpack.application.exception.DomainPackNotFoundException;
+import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
+import com.init.domainpack.application.exception.DomainPackVersionNotFoundException;
+import com.init.domainpack.application.exception.DomainPackWorkspaceNotFoundException;
+import com.init.domainpack.domain.model.DomainPackVersion;
+import com.init.domainpack.domain.model.PolicyDefinition;
+import com.init.domainpack.domain.repository.DomainPackRepository;
+import com.init.domainpack.domain.repository.DomainPackVersionRepository;
+import com.init.domainpack.domain.repository.PolicyDefinitionRepository;
+import com.init.domainpack.domain.repository.WorkspaceExistencePort;
+import com.init.domainpack.domain.repository.WorkspaceMembershipPort;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetPolicyDefinitionListUseCase")
+class GetPolicyDefinitionListUseCaseTest {
+
+  @Mock private WorkspaceExistencePort workspaceExistencePort;
+  @Mock private WorkspaceMembershipPort workspaceMembershipPort;
+  @Mock private DomainPackRepository domainPackRepository;
+  @Mock private DomainPackVersionRepository domainPackVersionRepository;
+  @Mock private PolicyDefinitionRepository policyDefinitionRepository;
+
+  private GetPolicyDefinitionListUseCase useCase;
+
+  private static final Long WORKSPACE_ID = 1L;
+  private static final Long PACK_ID = 7L;
+  private static final Long VERSION_ID = 101L;
+  private static final Long USER_ID = 10L;
+
+  @BeforeEach
+  void setUp() {
+    DomainPackValidator validator =
+        new DomainPackValidator(
+            workspaceExistencePort,
+            workspaceMembershipPort,
+            domainPackRepository,
+            domainPackVersionRepository);
+    useCase = new GetPolicyDefinitionListUseCase(validator, policyDefinitionRepository);
+  }
+
+  @Test
+  @DisplayName("유효한 query → policyCode ASC 순 PolicyDefinitionSummary 목록 반환")
+  void should_returnOrderedSummaryList_when_validQuery() {
+    // given
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(true);
+    given(domainPackVersionRepository.findById(VERSION_ID))
+        .willReturn(Optional.of(createVersion(VERSION_ID, PACK_ID)));
+    given(policyDefinitionRepository.findAllByDomainPackVersionIdOrderByPolicyCodeAsc(VERSION_ID))
+        .willReturn(
+            List.of(
+                createPolicy(1L, "POL_REFUND", "환불 정책"), createPolicy(2L, "POL_RETURN", "반품 정책")));
+
+    // when
+    List<PolicyDefinitionSummary> result =
+        useCase.execute(
+            new GetPolicyDefinitionListQuery(WORKSPACE_ID, PACK_ID, VERSION_ID, USER_ID));
+
+    // then
+    assertThat(result).hasSize(2);
+    assertThat(result.get(0).policyCode()).isEqualTo("POL_REFUND");
+    assertThat(result.get(1).policyCode()).isEqualTo("POL_RETURN");
+  }
+
+  @Test
+  @DisplayName("목록 응답에 conditionJson, actionJson, evidenceJson, metaJson 미포함")
+  void should_notIncludeJsonFields_when_summaryIsReturned() {
+    // given
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(true);
+    given(domainPackVersionRepository.findById(VERSION_ID))
+        .willReturn(Optional.of(createVersion(VERSION_ID, PACK_ID)));
+    given(policyDefinitionRepository.findAllByDomainPackVersionIdOrderByPolicyCodeAsc(VERSION_ID))
+        .willReturn(List.of(createPolicy(1L, "POL_RETURN", "반품 처리 정책")));
+
+    // when
+    List<PolicyDefinitionSummary> result =
+        useCase.execute(
+            new GetPolicyDefinitionListQuery(WORKSPACE_ID, PACK_ID, VERSION_ID, USER_ID));
+
+    // then — PolicyDefinitionSummary record must not expose JSON fields
+    assertThat(result).hasSize(1);
+    assertThat(PolicyDefinitionSummary.class.getRecordComponents())
+        .extracting(java.lang.reflect.RecordComponent::getName)
+        .doesNotContain("conditionJson", "actionJson", "evidenceJson", "metaJson");
+  }
+
+  @Test
+  @DisplayName("policy 없는 version → 빈 목록 반환")
+  void should_returnEmptyList_when_noPoliciesExist() {
+    // given
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(true);
+    given(domainPackVersionRepository.findById(VERSION_ID))
+        .willReturn(Optional.of(createVersion(VERSION_ID, PACK_ID)));
+    given(policyDefinitionRepository.findAllByDomainPackVersionIdOrderByPolicyCodeAsc(VERSION_ID))
+        .willReturn(List.of());
+
+    // when
+    List<PolicyDefinitionSummary> result =
+        useCase.execute(
+            new GetPolicyDefinitionListQuery(WORKSPACE_ID, PACK_ID, VERSION_ID, USER_ID));
+
+    // then
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  @DisplayName("workspace 없음 → DomainPackWorkspaceNotFoundException")
+  void should_throwWorkspaceNotFoundException_when_workspaceNotFound() {
+    // given
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(false);
+
+    // when & then
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new GetPolicyDefinitionListQuery(WORKSPACE_ID, PACK_ID, VERSION_ID, USER_ID)))
+        .isInstanceOf(DomainPackWorkspaceNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("접근 권한 없음 → DomainPackUnauthorizedWorkspaceAccessException")
+  void should_throwUnauthorizedException_when_unauthorized() {
+    // given
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(false);
+
+    // when & then
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new GetPolicyDefinitionListQuery(WORKSPACE_ID, PACK_ID, VERSION_ID, USER_ID)))
+        .isInstanceOf(DomainPackUnauthorizedWorkspaceAccessException.class);
+  }
+
+  @Test
+  @DisplayName("domain pack 소속 불일치 → DomainPackNotFoundException")
+  void should_throwDomainPackNotFoundException_when_packNotInWorkspace() {
+    // given
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(false);
+
+    // when & then
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new GetPolicyDefinitionListQuery(WORKSPACE_ID, PACK_ID, VERSION_ID, USER_ID)))
+        .isInstanceOf(DomainPackNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("version 소속 불일치 → DomainPackVersionNotFoundException")
+  void should_throwVersionNotFoundException_when_versionNotInPack() {
+    // given
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(true);
+    given(domainPackVersionRepository.findById(VERSION_ID))
+        .willReturn(Optional.of(createVersion(VERSION_ID, 999L)));
+
+    // when & then
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new GetPolicyDefinitionListQuery(WORKSPACE_ID, PACK_ID, VERSION_ID, USER_ID)))
+        .isInstanceOf(DomainPackVersionNotFoundException.class);
+  }
+
+  private DomainPackVersion createVersion(Long id, Long packId) {
+    return DomainPackVersion.ofForTest(id, packId, DomainPackVersion.STATUS_DRAFT);
+  }
+
+  private PolicyDefinition createPolicy(Long id, String policyCode, String name) {
+    PolicyDefinition policy =
+        PolicyDefinition.create(VERSION_ID, policyCode, name, "설명", "HIGH", "{}", "{}", "[]", "{}");
+    ReflectionTestUtils.setField(policy, "id", id);
+    ReflectionTestUtils.setField(policy, "createdAt", OffsetDateTime.parse("2026-04-10T10:00:00Z"));
+    ReflectionTestUtils.setField(policy, "updatedAt", OffsetDateTime.parse("2026-04-10T10:00:00Z"));
+    return policy;
+  }
+}

--- a/backend/src/test/java/com/init/domainpack/presentation/PolicyDefinitionControllerTest.java
+++ b/backend/src/test/java/com/init/domainpack/presentation/PolicyDefinitionControllerTest.java
@@ -6,14 +6,18 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.init.domainpack.application.GetPolicyDefinitionListUseCase;
 import com.init.domainpack.application.GetPolicyDefinitionUseCase;
 import com.init.domainpack.application.PolicyDefinitionResponse;
+import com.init.domainpack.application.PolicyDefinitionSummary;
+import com.init.domainpack.application.exception.DomainPackNotFoundException;
 import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
 import com.init.domainpack.application.exception.DomainPackVersionNotFoundException;
 import com.init.domainpack.application.exception.PolicyDefinitionNotFoundException;
 import com.init.fixtures.WithLongPrincipal;
 import com.init.shared.infrastructure.security.JwtAuthenticationFilter;
 import java.time.OffsetDateTime;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,14 +41,15 @@ class PolicyDefinitionControllerTest {
 
   @Autowired private MockMvc mockMvc;
 
-  @MockitoBean private GetPolicyDefinitionUseCase useCase;
+  @MockitoBean private GetPolicyDefinitionListUseCase listUseCase;
+  @MockitoBean private GetPolicyDefinitionUseCase detailUseCase;
 
   @Test
   @DisplayName("GET .../policies/{policyId} → 200 OK, 전체 필드 반환")
   @WithLongPrincipal(10L)
   void should_returnOkWithAllFields_when_policyExists() throws Exception {
     // given
-    given(useCase.execute(any()))
+    given(detailUseCase.execute(any()))
         .willReturn(
             new PolicyDefinitionResponse(
                 3001L,
@@ -85,7 +90,7 @@ class PolicyDefinitionControllerTest {
   @WithLongPrincipal(10L)
   void should_return404_when_policyNotFound() throws Exception {
     // given
-    given(useCase.execute(any())).willThrow(new PolicyDefinitionNotFoundException(9999L));
+    given(detailUseCase.execute(any())).willThrow(new PolicyDefinitionNotFoundException(9999L));
 
     // when & then
     mockMvc
@@ -99,7 +104,7 @@ class PolicyDefinitionControllerTest {
   @WithLongPrincipal(10L)
   void should_return403_when_unauthorized() throws Exception {
     // given
-    given(useCase.execute(any()))
+    given(detailUseCase.execute(any()))
         .willThrow(new DomainPackUnauthorizedWorkspaceAccessException("워크스페이스에 접근 권한이 없습니다."));
 
     // when & then
@@ -121,12 +126,108 @@ class PolicyDefinitionControllerTest {
   @WithLongPrincipal(10L)
   void should_return404_when_versionNotFound() throws Exception {
     // given
-    given(useCase.execute(any())).willThrow(new DomainPackVersionNotFoundException(101L));
+    given(detailUseCase.execute(any())).willThrow(new DomainPackVersionNotFoundException(101L));
 
     // when & then
     mockMvc
         .perform(get(BASE_URL + "/3001"))
         .andExpect(status().isNotFound())
         .andExpect(jsonPath("$.code").value("DOMAIN_PACK_VERSION_NOT_FOUND"));
+  }
+
+  @Test
+  @DisplayName("GET .../policies → 200 OK, JSON 필드 미노출 검증")
+  @WithLongPrincipal(10L)
+  void should_returnOkWithSummaryList_when_validRequest() throws Exception {
+    // given
+    given(listUseCase.execute(any()))
+        .willReturn(
+            List.of(
+                new PolicyDefinitionSummary(
+                    3001L,
+                    101L,
+                    "POL_RETURN",
+                    "반품 처리 정책",
+                    "7일 이내 반품 허용",
+                    "HIGH",
+                    "ACTIVE",
+                    OffsetDateTime.parse("2026-04-10T10:00:00Z"),
+                    OffsetDateTime.parse("2026-04-10T10:00:00Z"))));
+
+    // when & then
+    mockMvc
+        .perform(get(BASE_URL))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].policyCode").value("POL_RETURN"))
+        .andExpect(jsonPath("$[0].name").value("반품 처리 정책"))
+        .andExpect(jsonPath("$[0].conditionJson").doesNotExist())
+        .andExpect(jsonPath("$[0].actionJson").doesNotExist())
+        .andExpect(jsonPath("$[0].evidenceJson").doesNotExist())
+        .andExpect(jsonPath("$[0].metaJson").doesNotExist());
+  }
+
+  @Test
+  @DisplayName("GET .../policies → policy 없으면 빈 배열")
+  @WithLongPrincipal(10L)
+  void should_returnEmptyArray_when_noPoliciesExist() throws Exception {
+    // given
+    given(listUseCase.execute(any())).willReturn(List.of());
+
+    // when & then
+    mockMvc
+        .perform(get(BASE_URL))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$").isEmpty());
+  }
+
+  @Test
+  @DisplayName("GET .../policies → 403 권한 없음")
+  @WithLongPrincipal(10L)
+  void should_return403_when_listUnauthorized() throws Exception {
+    // given
+    given(listUseCase.execute(any()))
+        .willThrow(new DomainPackUnauthorizedWorkspaceAccessException("워크스페이스에 접근 권한이 없습니다."));
+
+    // when & then
+    mockMvc
+        .perform(get(BASE_URL))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.code").value("FORBIDDEN"));
+  }
+
+  @Test
+  @DisplayName("GET .../policies → 401 미인증")
+  void should_return401_when_listUnauthenticated() throws Exception {
+    // when & then
+    mockMvc.perform(get(BASE_URL)).andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @DisplayName("GET .../policies → 404 version 소속 불일치")
+  @WithLongPrincipal(10L)
+  void should_return404_when_listVersionNotFound() throws Exception {
+    // given
+    given(listUseCase.execute(any())).willThrow(new DomainPackVersionNotFoundException(101L));
+
+    // when & then
+    mockMvc
+        .perform(get(BASE_URL))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("DOMAIN_PACK_VERSION_NOT_FOUND"));
+  }
+
+  @Test
+  @DisplayName("GET .../policies → 404 pack 미존재")
+  @WithLongPrincipal(10L)
+  void should_return404_when_listPackNotFound() throws Exception {
+    // given
+    given(listUseCase.execute(any())).willThrow(new DomainPackNotFoundException(7L));
+
+    // when & then
+    mockMvc
+        .perform(get(BASE_URL))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("DOMAIN_PACK_NOT_FOUND"));
   }
 }


### PR DESCRIPTION
## Summary

`GET /api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/policies` 엔드포인트를 추가했다. Domain Pack Version에 속한 Policy 목록을 `policyCode ASC` 정렬로 반환하며, 대용량 JSON 필드(`conditionJson`, `actionJson`, `evidenceJson`, `metaJson`)는 목록 응답에서 제외된다.

---

## Context

`.agent/specs/3212.md`([BE] 3.2.12)의 구현 PR이다. `GetSlotDefinitionListUseCase` / `SlotDefinitionController` 패턴을 그대로 따르는 READ 전용 엔드포인트 추가 작업이다.

---

## What Changed

- **신규 3파일**: `GetPolicyDefinitionListQuery`, `GetPolicyDefinitionListUseCase`, `PolicyDefinitionSummary`
- **Repository 교체**: `JpaPolicyDefinitionRepository.findByDomainPackVersionId` → `findAllByDomainPackVersionIdOrderByPolicyCodeAsc` (도메인 인터페이스 동일 교체)
- **Controller 확장**: `PolicyDefinitionController`에 `listUseCase` 생성자 주입 + `@GetMapping listPolicies(...)` 추가; 기존 `getPolicy` 로직 무수정
- **Test**: `GetPolicyDefinitionListUseCaseTest` 신규(7케이스), `PolicyDefinitionControllerTest` 목록 조회 6케이스 추가
- **Commit 구성**: `feat` (초기 구현) + `refactor` (Audit V-001 수정)

---

## Assumptions Adopted

| ID | 내용 | 잔여 리스크 |
|----|------|------------|
| UR-3212-01 | `PolicyDefinitionSummary` 신규 생성, JSON 4개 필드 제외 | FE가 목록에서 JSON 필드 필요 시 스펙 재협의 필요. 현재 단건 API(`PolicyDefinitionResponse`)는 JSON 필드 포함. |
| UR-3212-02 | `policyCode ASC` 정렬 (`SlotDefinitionRepository` 패턴 일치) | 운영자 요구사항에 따라 다른 정렬 기준 필요 시 스펙 재협의 필요. |
| UR-3212-03 | 기존 `findByDomainPackVersionId` 제거 (Option A) — grep으로 사용처 없음 확인 후 적용 | 없음. 빌드 + 전체 테스트 통과로 미사용 확인. |

---

## Spec Deviations

N/A — 스펙 일치 항목은 Audit Report에서 전부 ✅ 확인됨.

---

## Blocked / Skipped Items

없음.

---

## Test Notes

- `GetPolicyDefinitionListUseCaseTest`: 7개 케이스 모두 통과 (정렬 순서 검증, JSON 필드 미포함 RecordComponent 검증, 빈 목록, 4가지 예외 시나리오 포함)
- `PolicyDefinitionControllerTest`: 6개 케이스 추가 통과 (200 + JSON 필드 미노출, 빈 배열, 403, 401, 404×2)
- 전체 테스트 통과로 `findByDomainPackVersionId` 제거 후 빌드 오류 없음 확인

---

## Reviewer Focus

1. **`PolicyDefinitionSummary`** — `SlotDefinitionSummary`와 구조 일관성 (9개 필드, JSON 4종 제외) 확인
2. **`JpaPolicyDefinitionRepository`** — `findByDomainPackVersionId` 제거 + `findAllByDomainPackVersionIdOrderByPolicyCodeAsc` 교체가 도메인 인터페이스와 일치하는지 확인
3. **`PolicyDefinitionControllerTest`** — Audit V-001 수정 결과: `useCase` → `detailUseCase` 필드명 변경 + 스텁 3곳 일괄 변경 (`@MockitoBean` 타입 기반 주입이므로 런타임 동작 변화 없음)

---

## Conflicts

없음.

---

## Ready to Merge / Needs Input

**Ready to Merge** — Audit PASS (Critical 0, Warning 1 → Fixed), 전체 테스트 통과, Needs Input 항목 없음.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 정책 정의 목록을 요약 정보로 조회할 수 있는 API 추가 - 정책 코드, 이름, 설명, 심각도, 상태 및 타임스탬프 포함

<!-- end of auto-generated comment: release notes by coderabbit.ai -->