### PR TITLE
feat(domain-pack): add GET single risk definition endpoint (#2213)

### DIFF
--- a/backend/src/main/java/com/init/domainpack/application/GetRiskDefinitionQuery.java
+++ b/backend/src/main/java/com/init/domainpack/application/GetRiskDefinitionQuery.java
@@ -1,0 +1,4 @@
+package com.init.domainpack.application;
+
+public record GetRiskDefinitionQuery(
+    Long workspaceId, Long packId, Long versionId, Long riskId, Long userId) {}

--- a/backend/src/main/java/com/init/domainpack/application/GetRiskDefinitionUseCase.java
+++ b/backend/src/main/java/com/init/domainpack/application/GetRiskDefinitionUseCase.java
@@ -1,0 +1,30 @@
+package com.init.domainpack.application;
+
+import com.init.domainpack.application.exception.RiskDefinitionNotFoundException;
+import com.init.domainpack.domain.repository.RiskDefinitionRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class GetRiskDefinitionUseCase {
+
+  private final DomainPackValidator validator;
+  private final RiskDefinitionRepository riskDefinitionRepository;
+
+  public GetRiskDefinitionUseCase(
+      DomainPackValidator validator, RiskDefinitionRepository riskDefinitionRepository) {
+    this.validator = validator;
+    this.riskDefinitionRepository = riskDefinitionRepository;
+  }
+
+  public RiskDefinitionResponse execute(GetRiskDefinitionQuery query) {
+    validator.validateForWorkspacePackVersion(
+        query.workspaceId(), query.userId(), query.packId(), query.versionId());
+
+    return riskDefinitionRepository
+        .findByIdAndDomainPackVersionId(query.riskId(), query.versionId())
+        .map(RiskDefinitionResponse::from)
+        .orElseThrow(() -> new RiskDefinitionNotFoundException(query.riskId()));
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/application/exception/RiskDefinitionNotFoundException.java
+++ b/backend/src/main/java/com/init/domainpack/application/exception/RiskDefinitionNotFoundException.java
@@ -1,0 +1,9 @@
+package com.init.domainpack.application.exception;
+
+import com.init.shared.application.exception.NotFoundException;
+
+public class RiskDefinitionNotFoundException extends NotFoundException {
+  public RiskDefinitionNotFoundException(Long riskId) {
+    super("RISK_DEFINITION_NOT_FOUND", "RiskDefinition not found: " + riskId);
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/domain/repository/RiskDefinitionRepository.java
+++ b/backend/src/main/java/com/init/domainpack/domain/repository/RiskDefinitionRepository.java
@@ -10,5 +10,7 @@ public interface RiskDefinitionRepository {
 
   Optional<RiskDefinition> findById(Long id);
 
+  Optional<RiskDefinition> findByIdAndDomainPackVersionId(Long id, Long domainPackVersionId);
+
   RiskDefinition save(RiskDefinition risk);
 }

--- a/backend/src/main/java/com/init/domainpack/presentation/RiskDefinitionController.java
+++ b/backend/src/main/java/com/init/domainpack/presentation/RiskDefinitionController.java
@@ -12,8 +12,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping(
-    "/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/risks")
+@RequestMapping("/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/risks")
 public class RiskDefinitionController {
 
   private final GetRiskDefinitionUseCase useCase;

--- a/backend/src/main/java/com/init/domainpack/presentation/RiskDefinitionController.java
+++ b/backend/src/main/java/com/init/domainpack/presentation/RiskDefinitionController.java
@@ -1,0 +1,37 @@
+package com.init.domainpack.presentation;
+
+import com.init.domainpack.application.GetRiskDefinitionQuery;
+import com.init.domainpack.application.GetRiskDefinitionUseCase;
+import com.init.domainpack.application.RiskDefinitionResponse;
+import com.init.shared.presentation.AuthenticationUtils;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(
+    "/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/risks")
+public class RiskDefinitionController {
+
+  private final GetRiskDefinitionUseCase useCase;
+
+  public RiskDefinitionController(GetRiskDefinitionUseCase useCase) {
+    this.useCase = useCase;
+  }
+
+  @GetMapping("/{riskId}")
+  public ResponseEntity<RiskDefinitionResponse> getRisk(
+      @PathVariable Long workspaceId,
+      @PathVariable Long packId,
+      @PathVariable Long versionId,
+      @PathVariable Long riskId,
+      Authentication authentication) {
+    Long userId = AuthenticationUtils.getUserId(authentication);
+    return ResponseEntity.ok(
+        useCase.execute(
+            new GetRiskDefinitionQuery(workspaceId, packId, versionId, riskId, userId)));
+  }
+}

--- a/backend/src/test/java/com/init/domainpack/application/GetRiskDefinitionUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/GetRiskDefinitionUseCaseTest.java
@@ -1,0 +1,215 @@
+package com.init.domainpack.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.init.domainpack.application.exception.DomainPackNotFoundException;
+import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
+import com.init.domainpack.application.exception.DomainPackVersionNotFoundException;
+import com.init.domainpack.application.exception.DomainPackWorkspaceNotFoundException;
+import com.init.domainpack.application.exception.RiskDefinitionNotFoundException;
+import com.init.domainpack.domain.model.DomainPackVersion;
+import com.init.domainpack.domain.model.RiskDefinition;
+import com.init.domainpack.domain.repository.DomainPackRepository;
+import com.init.domainpack.domain.repository.DomainPackVersionRepository;
+import com.init.domainpack.domain.repository.RiskDefinitionRepository;
+import com.init.domainpack.domain.repository.WorkspaceExistencePort;
+import com.init.domainpack.domain.repository.WorkspaceMembershipPort;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetRiskDefinitionUseCase")
+class GetRiskDefinitionUseCaseTest {
+
+  @Mock private WorkspaceExistencePort workspaceExistencePort;
+  @Mock private WorkspaceMembershipPort workspaceMembershipPort;
+  @Mock private DomainPackRepository domainPackRepository;
+  @Mock private DomainPackVersionRepository domainPackVersionRepository;
+  @Mock private RiskDefinitionRepository riskDefinitionRepository;
+
+  private GetRiskDefinitionUseCase useCase;
+
+  private static final Long WORKSPACE_ID = 1L;
+  private static final Long PACK_ID = 7L;
+  private static final Long VERSION_ID = 101L;
+  private static final Long RISK_ID = 5001L;
+  private static final Long USER_ID = 10L;
+
+  @BeforeEach
+  void setUp() {
+    DomainPackValidator validator =
+        new DomainPackValidator(
+            workspaceExistencePort,
+            workspaceMembershipPort,
+            domainPackRepository,
+            domainPackVersionRepository);
+    useCase = new GetRiskDefinitionUseCase(validator, riskDefinitionRepository);
+  }
+
+  @Test
+  @DisplayName("유효한 query → RiskDefinitionResponse 전체 필드 반환")
+  void should_returnFullResponse_when_validQuery() {
+    // given
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(true);
+    given(domainPackVersionRepository.findById(VERSION_ID))
+        .willReturn(Optional.of(createVersion(VERSION_ID, PACK_ID)));
+    given(riskDefinitionRepository.findByIdAndDomainPackVersionId(RISK_ID, VERSION_ID))
+        .willReturn(Optional.of(createRisk(RISK_ID, "RISK_FRAUD", "사기 거래 위험")));
+
+    // when
+    RiskDefinitionResponse result =
+        useCase.execute(
+            new GetRiskDefinitionQuery(WORKSPACE_ID, PACK_ID, VERSION_ID, RISK_ID, USER_ID));
+
+    // then
+    assertThat(result.id()).isEqualTo(RISK_ID);
+    assertThat(result.domainPackVersionId()).isEqualTo(VERSION_ID);
+    assertThat(result.riskCode()).isEqualTo("RISK_FRAUD");
+    assertThat(result.name()).isEqualTo("사기 거래 위험");
+    assertThat(result.description()).isEqualTo("비정상적인 결제 패턴 감지 시 차단");
+    assertThat(result.riskLevel()).isEqualTo("HIGH");
+    assertThat(result.triggerConditionJson()).isEqualTo("{}");
+    assertThat(result.handlingActionJson()).isEqualTo("{}");
+    assertThat(result.evidenceJson()).isEqualTo("[]");
+    assertThat(result.metaJson()).isEqualTo("{}");
+    assertThat(result.status()).isEqualTo("ACTIVE");
+    assertThat(result.createdAt()).isEqualTo(OffsetDateTime.parse("2026-04-10T10:00:00Z"));
+    assertThat(result.updatedAt()).isEqualTo(OffsetDateTime.parse("2026-04-10T10:00:00Z"));
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 riskId → RiskDefinitionNotFoundException")
+  void should_throwNotFoundException_when_riskNotFound() {
+    // given
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(true);
+    given(domainPackVersionRepository.findById(VERSION_ID))
+        .willReturn(Optional.of(createVersion(VERSION_ID, PACK_ID)));
+    given(riskDefinitionRepository.findByIdAndDomainPackVersionId(RISK_ID, VERSION_ID))
+        .willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new GetRiskDefinitionQuery(
+                        WORKSPACE_ID, PACK_ID, VERSION_ID, RISK_ID, USER_ID)))
+        .isInstanceOf(RiskDefinitionNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("다른 version 소속 riskId → RiskDefinitionNotFoundException")
+  void should_throwNotFoundException_when_riskBelongsToOtherVersion() {
+    // given — riskId exists but belongs to a different versionId, so composite lookup returns empty
+    Long otherVersionId = VERSION_ID + 1L;
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(true);
+    given(domainPackVersionRepository.findById(otherVersionId))
+        .willReturn(Optional.of(createVersion(otherVersionId, PACK_ID)));
+    given(riskDefinitionRepository.findByIdAndDomainPackVersionId(RISK_ID, otherVersionId))
+        .willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new GetRiskDefinitionQuery(
+                        WORKSPACE_ID, PACK_ID, otherVersionId, RISK_ID, USER_ID)))
+        .isInstanceOf(RiskDefinitionNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("workspace 없음 → DomainPackWorkspaceNotFoundException")
+  void should_throwWorkspaceNotFoundException_when_workspaceNotFound() {
+    // given
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(false);
+
+    // when & then
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new GetRiskDefinitionQuery(
+                        WORKSPACE_ID, PACK_ID, VERSION_ID, RISK_ID, USER_ID)))
+        .isInstanceOf(DomainPackWorkspaceNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("접근 권한 없음 → DomainPackUnauthorizedWorkspaceAccessException")
+  void should_throwUnauthorizedException_when_unauthorized() {
+    // given
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(false);
+
+    // when & then
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new GetRiskDefinitionQuery(
+                        WORKSPACE_ID, PACK_ID, VERSION_ID, RISK_ID, USER_ID)))
+        .isInstanceOf(DomainPackUnauthorizedWorkspaceAccessException.class);
+  }
+
+  @Test
+  @DisplayName("domain pack 소속 불일치 → DomainPackNotFoundException")
+  void should_throwDomainPackNotFoundException_when_packNotInWorkspace() {
+    // given
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(false);
+
+    // when & then
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new GetRiskDefinitionQuery(
+                        WORKSPACE_ID, PACK_ID, VERSION_ID, RISK_ID, USER_ID)))
+        .isInstanceOf(DomainPackNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("version 소속 불일치 → DomainPackVersionNotFoundException")
+  void should_throwVersionNotFoundException_when_versionNotInPack() {
+    // given
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(true);
+    given(domainPackVersionRepository.findById(VERSION_ID))
+        .willReturn(Optional.of(createVersion(VERSION_ID, 999L)));
+
+    // when & then
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new GetRiskDefinitionQuery(
+                        WORKSPACE_ID, PACK_ID, VERSION_ID, RISK_ID, USER_ID)))
+        .isInstanceOf(DomainPackVersionNotFoundException.class);
+  }
+
+  private DomainPackVersion createVersion(Long id, Long packId) {
+    return DomainPackVersion.ofForTest(id, packId, DomainPackVersion.STATUS_DRAFT);
+  }
+
+  private RiskDefinition createRisk(Long id, String riskCode, String name) {
+    RiskDefinition risk =
+        RiskDefinition.create(
+            VERSION_ID, riskCode, name, "비정상적인 결제 패턴 감지 시 차단", "HIGH", "{}", "{}", "[]", "{}");
+    ReflectionTestUtils.setField(risk, "id", id);
+    ReflectionTestUtils.setField(risk, "createdAt", OffsetDateTime.parse("2026-04-10T10:00:00Z"));
+    ReflectionTestUtils.setField(risk, "updatedAt", OffsetDateTime.parse("2026-04-10T10:00:00Z"));
+    return risk;
+  }
+}

--- a/backend/src/test/java/com/init/domainpack/presentation/RiskDefinitionControllerTest.java
+++ b/backend/src/test/java/com/init/domainpack/presentation/RiskDefinitionControllerTest.java
@@ -8,7 +8,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.init.domainpack.application.GetRiskDefinitionUseCase;
 import com.init.domainpack.application.RiskDefinitionResponse;
-import com.init.domainpack.application.exception.DomainPackNotFoundException;
 import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
 import com.init.domainpack.application.exception.DomainPackVersionNotFoundException;
 import com.init.domainpack.application.exception.RiskDefinitionNotFoundException;
@@ -33,8 +32,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @DisplayName("RiskDefinitionController")
 class RiskDefinitionControllerTest {
 
-  private static final String BASE_URL =
-      "/api/v1/workspaces/1/domain-packs/7/versions/101/risks";
+  private static final String BASE_URL = "/api/v1/workspaces/1/domain-packs/7/versions/101/risks";
 
   @Autowired private MockMvc mockMvc;
 

--- a/backend/src/test/java/com/init/domainpack/presentation/RiskDefinitionControllerTest.java
+++ b/backend/src/test/java/com/init/domainpack/presentation/RiskDefinitionControllerTest.java
@@ -1,0 +1,133 @@
+package com.init.domainpack.presentation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.init.domainpack.application.GetRiskDefinitionUseCase;
+import com.init.domainpack.application.RiskDefinitionResponse;
+import com.init.domainpack.application.exception.DomainPackNotFoundException;
+import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
+import com.init.domainpack.application.exception.DomainPackVersionNotFoundException;
+import com.init.domainpack.application.exception.RiskDefinitionNotFoundException;
+import com.init.fixtures.WithLongPrincipal;
+import com.init.shared.infrastructure.security.JwtAuthenticationFilter;
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(
+    value = RiskDefinitionController.class,
+    excludeFilters =
+        @ComponentScan.Filter(
+            type = FilterType.ASSIGNABLE_TYPE,
+            classes = JwtAuthenticationFilter.class))
+@DisplayName("RiskDefinitionController")
+class RiskDefinitionControllerTest {
+
+  private static final String BASE_URL =
+      "/api/v1/workspaces/1/domain-packs/7/versions/101/risks";
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private GetRiskDefinitionUseCase useCase;
+
+  @Test
+  @DisplayName("GET .../risks/{riskId} → 200 OK, 전체 필드 반환")
+  @WithLongPrincipal(10L)
+  void should_returnOkWithAllFields_when_riskExists() throws Exception {
+    // given
+    given(useCase.execute(any()))
+        .willReturn(
+            new RiskDefinitionResponse(
+                5001L,
+                101L,
+                "RISK_FRAUD",
+                "사기 거래 위험",
+                "비정상적인 결제 패턴 감지 시 차단",
+                "HIGH",
+                "{}",
+                "{}",
+                "[]",
+                "{}",
+                "ACTIVE",
+                OffsetDateTime.parse("2026-04-10T10:00:00Z"),
+                OffsetDateTime.parse("2026-04-10T10:00:00Z")));
+
+    // when & then
+    mockMvc
+        .perform(get(BASE_URL + "/5001"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(5001))
+        .andExpect(jsonPath("$.domainPackVersionId").value(101))
+        .andExpect(jsonPath("$.riskCode").value("RISK_FRAUD"))
+        .andExpect(jsonPath("$.name").value("사기 거래 위험"))
+        .andExpect(jsonPath("$.description").value("비정상적인 결제 패턴 감지 시 차단"))
+        .andExpect(jsonPath("$.riskLevel").value("HIGH"))
+        .andExpect(jsonPath("$.triggerConditionJson").value("{}"))
+        .andExpect(jsonPath("$.handlingActionJson").value("{}"))
+        .andExpect(jsonPath("$.evidenceJson").value("[]"))
+        .andExpect(jsonPath("$.metaJson").value("{}"))
+        .andExpect(jsonPath("$.status").value("ACTIVE"))
+        .andExpect(jsonPath("$.createdAt").value("2026-04-10T10:00:00Z"))
+        .andExpect(jsonPath("$.updatedAt").value("2026-04-10T10:00:00Z"));
+  }
+
+  @Test
+  @DisplayName("GET .../risks/{riskId} → 404 미존재")
+  @WithLongPrincipal(10L)
+  void should_return404_when_riskNotFound() throws Exception {
+    // given
+    given(useCase.execute(any())).willThrow(new RiskDefinitionNotFoundException(9999L));
+
+    // when & then
+    mockMvc
+        .perform(get(BASE_URL + "/9999"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("RISK_DEFINITION_NOT_FOUND"));
+  }
+
+  @Test
+  @DisplayName("GET .../risks/{riskId} → 403 권한 없음")
+  @WithLongPrincipal(10L)
+  void should_return403_when_unauthorized() throws Exception {
+    // given
+    given(useCase.execute(any()))
+        .willThrow(new DomainPackUnauthorizedWorkspaceAccessException("워크스페이스에 접근 권한이 없습니다."));
+
+    // when & then
+    mockMvc
+        .perform(get(BASE_URL + "/5001"))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.code").value("FORBIDDEN"));
+  }
+
+  @Test
+  @DisplayName("GET .../risks/{riskId} → 401 미인증")
+  void should_return401_when_unauthenticated() throws Exception {
+    // when & then
+    mockMvc.perform(get(BASE_URL + "/5001")).andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @DisplayName("GET .../risks/{riskId} → 404 version 미존재")
+  @WithLongPrincipal(10L)
+  void should_return404_when_versionNotFound() throws Exception {
+    // given
+    given(useCase.execute(any())).willThrow(new DomainPackVersionNotFoundException(101L));
+
+    // when & then
+    mockMvc
+        .perform(get(BASE_URL + "/5001"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("DOMAIN_PACK_VERSION_NOT_FOUND"));
+  }
+}


### PR DESCRIPTION
## Summary

`GET /api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/risks/{riskId}` 엔드포인트를 신규 추가. `GetPolicyDefinition` 패턴을 그대로 따라 Controller / UseCase / Query / Exception 4파일 신규 생성, `RiskDefinitionRepository`에 도메인 메서드 1개 추가.

---

## Context

스펙: `.agent/specs/2213.md` ([BE] 2.2.13 — Risk Factor 초안 단건 조회)  
감사: `.handoff/2213/audit-report-2213-2026-04-21.md` — **PASS** (Critical 0 / Warning 0 / Info 1)

---

## What Changed

- `RiskDefinitionController.java` (신규): `GET /{riskId}` 핸들러. `@RequestMapping` prefix를 `/risks`로 설정해 기존 `UpdateRiskController`(`/risks/{riskId}`) / `UpdateRiskStatusController`(`/risks/{riskId}/status`)와 경로 충돌 없음.
- `GetRiskDefinitionUseCase.java` (신규): 4단계 validator → `findByIdAndDomainPackVersionId` → `RiskDefinitionResponse::from` 파이프라인.
- `GetRiskDefinitionQuery.java` (신규): record 입력 객체.
- `RiskDefinitionNotFoundException.java` (신규): `NotFoundException` 상속, code = `"RISK_DEFINITION_NOT_FOUND"`.
- `RiskDefinitionRepository.java` (수정): `findByIdAndDomainPackVersionId(Long id, Long domainPackVersionId)` 도메인 인터페이스에만 추가. `JpaRiskDefinitionRepository` 재선언 없음.

---

## Assumptions Adopted

| ID | 내용 | 영향 |
|----|------|------|
| U-01 | `RiskDefinitionController`를 신규 파일로 분리 (기존 Update 컨트롤러에 추가하지 않음) | 경로 충돌 없음, 향후 목록 엔드포인트 추가 시 이 파일에 자연스럽게 통합 가능 |
| U-02 | `riskLevel` 응답은 `getRiskLevel()` 반환값(String) 그대로 사용, 별도 변환 없음 | `RiskDefinitionResponse`, `RiskDefinition` 수정 없음 |

---

## Spec Deviations

N/A

---

## Blocked / Skipped Items

없음.

---

## Test Notes

감사 기준 실제 테스트 수 확인:

| 클래스 | 시나리오 수 | 비고 |
|--------|------------|------|
| `GetRiskDefinitionUseCaseTest` | 7개 | 스펙 표에는 6개 나열. 7번째(`should_throwVersionNotFoundException_when_versionNotInPack`)는 레퍼런스 `GetPolicyDefinitionUseCaseTest`와 동일한 추가 케이스 — scope overrun 아님 |
| `RiskDefinitionControllerTest` | 5개 | 스펙 표 5개 정확 일치 (200 / 404-RISK / 403 / 401 / 404-VERSION) |

모든 테스트 통과, DB 신규 DDL 없음.

---

## Reviewer Focus

1. `RiskDefinitionController`의 `@RequestMapping` prefix가 `/risks`인지 확인 — 기존 Update 컨트롤러 경로와 겹치지 않아야 함.
2. `RiskDefinitionRepository` 도메인 인터페이스에만 `findByIdAndDomainPackVersionId` 선언, `JpaRiskDefinitionRepository`에 재선언이 없는지 확인.
3. `GetRiskDefinitionUseCase`에 `@Transactional(readOnly = true)` 클래스 레벨 적용 여부.

---

## Conflicts

없음.

---

## Ready to Merge / Needs Input

**Ready to Merge** — 감사 PASS, 사용자 결정 필요 항목 없음.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 워크스페이스 내 도메인 팩 버전에서 위험 정의를 조회하는 새로운 API 엔드포인트 추가
  * 사용자 권한 검증 및 세부 오류 처리(미존재 시 404, 권한 불일치 시 403 등) 포함

* **테스트**
  * 새로운 기능에 대한 포괄적인 통합 및 단위 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->