### PR TITLE
spec/3213: [BE] Risk Factor 초안 목록 조회 API

### DIFF
--- a/.agent/specs/3213.md
+++ b/.agent/specs/3213.md
@@ -1,0 +1,277 @@
+# [BE] 3.2.13 — Risk Factor 초안 목록 조회
+
+## Goal
+
+특정 Domain Pack Version에 속한 Risk Factor 초안 전체 목록을 조회하는 READ 전용 엔드포인트를 제공한다.
+
+---
+
+## Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    actor c as Client
+    participant ctrl as RiskDefinitionController
+    participant uc as GetRiskDefinitionListUseCase
+    participant validator as DomainPackValidator
+    participant repo as RiskDefinitionRepository
+    participant db as PostgreSQL
+
+    c ->> ctrl: GET /api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/risks
+    ctrl ->> uc: execute(GetRiskDefinitionListQuery)
+    uc ->> validator: validateForWorkspacePackVersion(workspaceId, userId, packId, versionId)
+    validator -->> uc: (passes or throws)
+    uc ->> repo: findAllByDomainPackVersionIdOrderByRiskCodeAsc(versionId)
+    repo ->> db: SELECT ... FROM pack.risk_definition WHERE domain_pack_version_id = ? ORDER BY risk_code ASC
+    db -->> repo: rows
+    repo -->> uc: List<RiskDefinition>
+    uc -->> ctrl: List<RiskDefinitionSummary>
+    ctrl -->> c: 200 OK
+```
+
+---
+
+## REST API
+
+### Endpoint
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/risks` | Risk Factor 초안 목록 조회 |
+
+### Request
+
+Path variables:
+- `workspaceId`: Long
+- `packId`: Long
+- `versionId`: Long
+
+Headers:
+- `Authorization: Bearer {jwt-token}` (필수)
+
+Query parameters: 없음 (pagination / filtering 미지원)
+
+### Response
+
+**200 OK**
+
+```json
+[
+  {
+    "id": 1,
+    "domainPackVersionId": 10,
+    "riskCode": "RISK_FRAUD",
+    "name": "사기 거래 위험",
+    "description": "비정상적인 결제 패턴 감지 시 차단",
+    "riskLevel": "HIGH",
+    "status": "ACTIVE",
+    "createdAt": "2025-04-03T10:00:00Z",
+    "updatedAt": "2025-04-03T10:00:00Z"
+  }
+]
+```
+
+> JSON 필드(`triggerConditionJson`, `handlingActionJson`, `evidenceJson`, `metaJson`)는 목록 응답에서 제외한다.
+> risk가 없는 version이면 빈 배열 `[]`를 반환한다.
+
+**401 Unauthorized**
+
+```json
+{ "code": "UNAUTHORIZED", "message": "인증이 필요합니다." }
+```
+
+**403 Forbidden**
+
+```json
+{ "code": "FORBIDDEN", "message": "워크스페이스에 접근 권한이 없습니다." }
+```
+
+**404 Not Found — workspace not found**
+
+```json
+{ "code": "DOMAIN_PACK_WORKSPACE_NOT_FOUND", "message": "워크스페이스를 찾을 수 없습니다. id={workspaceId}" }
+```
+
+**404 Not Found — pack not found**
+
+```json
+{ "code": "DOMAIN_PACK_NOT_FOUND", "message": "DomainPack not found: {packId}" }
+```
+
+**404 Not Found — version not found**
+
+```json
+{ "code": "DOMAIN_PACK_VERSION_NOT_FOUND", "message": "도메인 팩 버전을 찾을 수 없습니다. id={versionId}" }
+```
+
+---
+
+## Class Design
+
+### DDD Layered Structure
+
+```mermaid
+classDiagram
+    class RiskDefinitionController {
+        +listRisks(workspaceId, packId, versionId, auth): ResponseEntity~List~RiskDefinitionSummary~~
+        +getRisk(workspaceId, packId, versionId, riskId, auth): ResponseEntity~RiskDefinitionResponse~
+    }
+
+    class GetRiskDefinitionListUseCase {
+        +execute(GetRiskDefinitionListQuery): List~RiskDefinitionSummary~
+    }
+
+    class GetRiskDefinitionUseCase {
+        +execute(GetRiskDefinitionQuery): RiskDefinitionResponse
+    }
+
+    class RiskDefinitionRepository {
+        <<interface>>
+        +findAllByDomainPackVersionIdOrderByRiskCodeAsc(Long): List~RiskDefinition~
+        +findByIdAndDomainPackVersionId(Long, Long): Optional~RiskDefinition~
+    }
+
+    RiskDefinitionController --> GetRiskDefinitionListUseCase
+    RiskDefinitionController --> GetRiskDefinitionUseCase
+    GetRiskDefinitionListUseCase --> RiskDefinitionRepository
+    GetRiskDefinitionListUseCase --> DomainPackValidator
+    GetRiskDefinitionUseCase --> RiskDefinitionRepository
+    GetRiskDefinitionUseCase --> DomainPackValidator
+```
+
+### 신규 생성 파일
+
+| 파일 | 경로 | 역할 |
+|------|------|------|
+| `GetRiskDefinitionListQuery.java` | `application/` | UseCase 입력 record |
+| `RiskDefinitionSummary.java` | `application/` | 목록 응답 DTO (JSON 필드 제외) |
+| `GetRiskDefinitionListUseCase.java` | `application/` | 목록 조회 UseCase |
+
+### 수정 파일
+
+| 파일 | 변경 내용 |
+|------|-----------|
+| `RiskDefinitionRepository.java` | `findAllByDomainPackVersionIdOrderByRiskCodeAsc(Long)` 추가 |
+| `JpaRiskDefinitionRepository.java` | `findAllByDomainPackVersionIdOrderByRiskCodeAsc` 선언 추가; 기존 `findByDomainPackVersionId` 제거 (도메인 인터페이스 불일치 해소 — 사용처 확인 후) |
+| `RiskDefinitionController.java` | `GetRiskDefinitionListUseCase` 생성자 주입 추가; `@GetMapping listRisks(...)` 메서드 추가 |
+
+### Pseudo-code
+
+```java
+// GetRiskDefinitionListQuery.java
+record GetRiskDefinitionListQuery(
+    Long workspaceId, Long packId, Long versionId, Long userId)
+
+// RiskDefinitionSummary.java
+record RiskDefinitionSummary(
+    Long id,
+    Long domainPackVersionId,
+    String riskCode,
+    String name,
+    String description,
+    String riskLevel,
+    String status,
+    OffsetDateTime createdAt,
+    OffsetDateTime updatedAt) {
+
+    static RiskDefinitionSummary from(RiskDefinition risk) {
+        return new RiskDefinitionSummary(
+            risk.getId(),
+            risk.getDomainPackVersionId(),
+            risk.getRiskCode(),
+            risk.getName(),
+            risk.getDescription(),
+            risk.getRiskLevel(),
+            risk.getStatus(),
+            risk.getCreatedAt(),
+            risk.getUpdatedAt())
+    }
+}
+
+// GetRiskDefinitionListUseCase.java
+@Service
+@Transactional(readOnly = true)
+class GetRiskDefinitionListUseCase {
+    execute(GetRiskDefinitionListQuery query) {
+        validator.validateForWorkspacePackVersion(
+            query.workspaceId(), query.userId(), query.packId(), query.versionId())
+        return riskDefinitionRepository
+            .findAllByDomainPackVersionIdOrderByRiskCodeAsc(query.versionId())
+            .stream()
+            .map(RiskDefinitionSummary::from)
+            .toList()
+    }
+}
+
+// RiskDefinitionController.java (수정 — listRisks 추가)
+@RestController
+@RequestMapping("/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/risks")
+class RiskDefinitionController {
+    // listUseCase 추가, detailUseCase 기존 유지
+
+    @GetMapping
+    listRisks(@PathVariable Long workspaceId, @PathVariable Long packId,
+              @PathVariable Long versionId, Authentication authentication) {
+        Long userId = AuthenticationUtils.getUserId(authentication)
+        return ResponseEntity.ok(
+            listUseCase.execute(
+                new GetRiskDefinitionListQuery(workspaceId, packId, versionId, userId)))
+    }
+
+    @GetMapping("/{riskId}")
+    getRisk(...) { /* 기존 그대로 */ }
+}
+```
+
+---
+
+## Tests
+
+### UseCase 테스트: `GetRiskDefinitionListUseCaseTest.java`
+
+참조: `GetPolicyDefinitionListUseCaseTest.java` 패턴 동일 적용
+
+- `@ExtendWith(MockitoExtension.class)` + `@DisplayName`
+
+| 시나리오 | 예상 결과 |
+|----------|-----------|
+| 유효한 query → riskCode ASC 순 목록 반환 | `List<RiskDefinitionSummary>` 반환 (순서 검증) |
+| 목록 응답에 JSON 필드 미포함 | `triggerConditionJson`, `handlingActionJson`, `evidenceJson`, `metaJson` 미포함 (RecordComponent 이름 검증) |
+| risk 없는 version → 빈 목록 반환 | `result.isEmpty()` |
+| workspace 미존재 | `DomainPackWorkspaceNotFoundException` |
+| 접근 권한 없음 | `DomainPackUnauthorizedWorkspaceAccessException` |
+| pack 소속 불일치 | `DomainPackNotFoundException` |
+| version 소속 불일치 | `DomainPackVersionNotFoundException` |
+
+### Controller 테스트: `RiskDefinitionControllerTest.java`
+
+- `@WebMvcTest(RiskDefinitionController.class)` + JwtAuthenticationFilter exclude
+- `@WithLongPrincipal(10L)` fixture 사용 (패키지: `com.init.fixtures`)
+- `@MockitoBean`: `GetRiskDefinitionListUseCase listUseCase`, `GetRiskDefinitionUseCase detailUseCase`
+
+| 시나리오 | 예상 결과 |
+|----------|-----------|
+| GET .../risks → 200 OK, JSON 필드 미노출 검증 | `$[0].triggerConditionJson doesNotExist()`, `$[0].handlingActionJson doesNotExist()`, `$[0].evidenceJson doesNotExist()`, `$[0].metaJson doesNotExist()` |
+| GET .../risks → risk 없으면 빈 배열 | `$` isArray() isEmpty() |
+| GET .../risks → 403 권한 없음 | 403, `$.code = "FORBIDDEN"` |
+| GET .../risks → 401 미인증 | 401 |
+| GET .../risks → 404 version 소속 불일치 | 404, `$.code = "DOMAIN_PACK_VERSION_NOT_FOUND"` |
+| GET .../risks → 404 pack 미존재 | 404, `$.code = "DOMAIN_PACK_NOT_FOUND"` |
+
+---
+
+## Database
+
+신규 DDL 없음.
+
+`pack.risk_definition` 테이블 및 인덱스 이미 존재 (`.agent/docs/schema.md` 참조).
+
+---
+
+## Additional Notes
+
+- 구현은 `GetPolicyDefinitionListUseCase` + `PolicyDefinitionController` 패턴을 그대로 따른다.
+- `DomainPackValidator.validateForWorkspacePackVersion(workspaceId, userId, packId, versionId)`가 4단계 공통 검증 진입점이다.
+- `findAllByDomainPackVersionIdOrderByRiskCodeAsc`는 `RiskDefinitionRepository`(도메인 인터페이스)와 `JpaRiskDefinitionRepository` 모두에 선언한다.
+- `JpaRiskDefinitionRepository.findByDomainPackVersionId`는 도메인 인터페이스와 불일치 상태이므로, 구현 전 사용처를 확인하고 미사용이면 제거하여 인터페이스 일관성을 회복한다 (3212 Policy 케이스 동일 패턴).
+- `RiskDefinitionController`는 이미 존재하는 컨트롤러이므로 `listRisks` 메서드와 `GetRiskDefinitionListUseCase` 의존성만 추가한다.

--- a/.agent/specs/3213.md
+++ b/.agent/specs/3213.md
@@ -143,9 +143,9 @@ classDiagram
 
 | 파일 | 경로 | 역할 |
 |------|------|------|
-| `GetRiskDefinitionListQuery.java` | `application/` | UseCase 입력 record |
-| `RiskDefinitionSummary.java` | `application/` | 목록 응답 DTO (JSON 필드 제외) |
-| `GetRiskDefinitionListUseCase.java` | `application/` | 목록 조회 UseCase |
+| `GetRiskDefinitionListQuery.java` | `backend/src/main/java/com/init/domainpack/application/` | UseCase 입력 record |
+| `RiskDefinitionSummary.java` | `backend/src/main/java/com/init/domainpack/application/` | 목록 응답 DTO (JSON 필드 제외) |
+| `GetRiskDefinitionListUseCase.java` | `backend/src/main/java/com/init/domainpack/application/` | 목록 조회 UseCase |
 
 ### 수정 파일
 
@@ -160,7 +160,7 @@ classDiagram
 ```java
 // GetRiskDefinitionListQuery.java
 record GetRiskDefinitionListQuery(
-    Long workspaceId, Long packId, Long versionId, Long userId)
+    Long workspaceId, Long packId, Long versionId, Long userId) {}
 
 // RiskDefinitionSummary.java
 record RiskDefinitionSummary(
@@ -184,7 +184,7 @@ record RiskDefinitionSummary(
             risk.getRiskLevel(),
             risk.getStatus(),
             risk.getCreatedAt(),
-            risk.getUpdatedAt())
+            risk.getUpdatedAt());
     }
 }
 
@@ -192,14 +192,14 @@ record RiskDefinitionSummary(
 @Service
 @Transactional(readOnly = true)
 class GetRiskDefinitionListUseCase {
-    execute(GetRiskDefinitionListQuery query) {
+    List<RiskDefinitionSummary> execute(GetRiskDefinitionListQuery query) {
         validator.validateForWorkspacePackVersion(
-            query.workspaceId(), query.userId(), query.packId(), query.versionId())
+            query.workspaceId(), query.userId(), query.packId(), query.versionId());
         return riskDefinitionRepository
             .findAllByDomainPackVersionIdOrderByRiskCodeAsc(query.versionId())
             .stream()
             .map(RiskDefinitionSummary::from)
-            .toList()
+            .toList();
     }
 }
 
@@ -207,15 +207,19 @@ class GetRiskDefinitionListUseCase {
 @RestController
 @RequestMapping("/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/risks")
 class RiskDefinitionController {
-    // listUseCase 추가, detailUseCase 기존 유지
+    private final GetRiskDefinitionListUseCase listUseCase; // 추가
+    // detailUseCase 기존 유지
 
     @GetMapping
-    listRisks(@PathVariable Long workspaceId, @PathVariable Long packId,
-              @PathVariable Long versionId, Authentication authentication) {
-        Long userId = AuthenticationUtils.getUserId(authentication)
+    ResponseEntity<List<RiskDefinitionSummary>> listRisks(
+            @PathVariable Long workspaceId,
+            @PathVariable Long packId,
+            @PathVariable Long versionId,
+            Authentication authentication) {
+        Long userId = AuthenticationUtils.getUserId(authentication);
         return ResponseEntity.ok(
             listUseCase.execute(
-                new GetRiskDefinitionListQuery(workspaceId, packId, versionId, userId)))
+                new GetRiskDefinitionListQuery(workspaceId, packId, versionId, userId)));
     }
 
     @GetMapping("/{riskId}")
@@ -236,7 +240,7 @@ class RiskDefinitionController {
 | 시나리오 | 예상 결과 |
 |----------|-----------|
 | 유효한 query → riskCode ASC 순 목록 반환 | `List<RiskDefinitionSummary>` 반환 (순서 검증) |
-| 목록 응답에 JSON 필드 미포함 | `triggerConditionJson`, `handlingActionJson`, `evidenceJson`, `metaJson` 미포함 (RecordComponent 이름 검증) |
+| 목록 응답에 JSON 필드 미포함 | 반환 타입이 `RiskDefinitionSummary`임을 타입 단언으로 검증하거나, 직렬화된 응답에서 `triggerConditionJson`, `handlingActionJson`, `evidenceJson`, `metaJson` 필드가 존재하지 않음을 JSONPath `doesNotExist()` 검증으로 확인 |
 | risk 없는 version → 빈 목록 반환 | `result.isEmpty()` |
 | workspace 미존재 | `DomainPackWorkspaceNotFoundException` |
 | 접근 권한 없음 | `DomainPackUnauthorizedWorkspaceAccessException` |
@@ -273,5 +277,5 @@ class RiskDefinitionController {
 - 구현은 `GetPolicyDefinitionListUseCase` + `PolicyDefinitionController` 패턴을 그대로 따른다.
 - `DomainPackValidator.validateForWorkspacePackVersion(workspaceId, userId, packId, versionId)`가 4단계 공통 검증 진입점이다.
 - `findAllByDomainPackVersionIdOrderByRiskCodeAsc`는 `RiskDefinitionRepository`(도메인 인터페이스)와 `JpaRiskDefinitionRepository` 모두에 선언한다.
-- `JpaRiskDefinitionRepository.findByDomainPackVersionId`는 도메인 인터페이스와 불일치 상태이므로, 구현 전 사용처를 확인하고 미사용이면 제거하여 인터페이스 일관성을 회복한다 (3212 Policy 케이스 동일 패턴).
+- `JpaRiskDefinitionRepository.findByDomainPackVersionId`는 도메인 인터페이스와 불일치 상태이므로, 구현 전 사용처를 확인하고 미사용이면 제거하여 인터페이스 일관성을 회복한다 (3212 Policy 케이스 동일 패턴, UR-3213-01 참조).
 - `RiskDefinitionController`는 이미 존재하는 컨트롤러이므로 `listRisks` 메서드와 `GetRiskDefinitionListUseCase` 의존성만 추가한다.


### PR DESCRIPTION
# [BE] 3.2.13 — Risk Factor 초안 목록 조회

## Goal

특정 Domain Pack Version에 속한 Risk Factor 초안 전체 목록을 조회하는 READ 전용 엔드포인트를 제공한다.

---

## Sequence Diagram

```mermaid
sequenceDiagram
    actor c as Client
    participant ctrl as RiskDefinitionController
    participant uc as GetRiskDefinitionListUseCase
    participant validator as DomainPackValidator
    participant repo as RiskDefinitionRepository
    participant db as PostgreSQL

    c ->> ctrl: GET /api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/risks
    ctrl ->> uc: execute(GetRiskDefinitionListQuery)
    uc ->> validator: validateForWorkspacePackVersion(workspaceId, userId, packId, versionId)
    validator -->> uc: (passes or throws)
    uc ->> repo: findAllByDomainPackVersionIdOrderByRiskCodeAsc(versionId)
    repo ->> db: SELECT ... FROM pack.risk_definition WHERE domain_pack_version_id = ? ORDER BY risk_code ASC
    db -->> repo: rows
    repo -->> uc: List<RiskDefinition>
    uc -->> ctrl: List<RiskDefinitionSummary>
    ctrl -->> c: 200 OK
```

---

## REST API

### Endpoint

| Method | Path | Description |
|--------|------|-------------|
| GET | `/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/risks` | Risk Factor 초안 목록 조회 |

### Request

Path variables:
- `workspaceId`: Long
- `packId`: Long
- `versionId`: Long

Headers:
- `Authorization: Bearer {jwt-token}` (필수)

Query parameters: 없음 (pagination / filtering 미지원)

### Response

**200 OK**

```json
[
  {
    "id": 1,
    "domainPackVersionId": 10,
    "riskCode": "RISK_FRAUD",
    "name": "사기 거래 위험",
    "description": "비정상적인 결제 패턴 감지 시 차단",
    "riskLevel": "HIGH",
    "status": "ACTIVE",
    "createdAt": "2025-04-03T10:00:00Z",
    "updatedAt": "2025-04-03T10:00:00Z"
  }
]
```

> JSON 필드(`triggerConditionJson`, `handlingActionJson`, `evidenceJson`, `metaJson`)는 목록 응답에서 제외한다.
> risk가 없는 version이면 빈 배열 `[]`를 반환한다.

**401 Unauthorized**

```json
{ "code": "UNAUTHORIZED", "message": "인증이 필요합니다." }
```

**403 Forbidden**

```json
{ "code": "FORBIDDEN", "message": "워크스페이스에 접근 권한이 없습니다." }
```

**404 Not Found — workspace not found**

```json
{ "code": "DOMAIN_PACK_WORKSPACE_NOT_FOUND", "message": "워크스페이스를 찾을 수 없습니다. id={workspaceId}" }
```

**404 Not Found — pack not found**

```json
{ "code": "DOMAIN_PACK_NOT_FOUND", "message": "DomainPack not found: {packId}" }
```

**404 Not Found — version not found**

```json
{ "code": "DOMAIN_PACK_VERSION_NOT_FOUND", "message": "도메인 팩 버전을 찾을 수 없습니다. id={versionId}" }
```

---

## Class Design

### DDD Layered Structure

```mermaid
classDiagram
    class RiskDefinitionController {
        +listRisks(workspaceId, packId, versionId, auth): ResponseEntity~List~RiskDefinitionSummary~~
        +getRisk(workspaceId, packId, versionId, riskId, auth): ResponseEntity~RiskDefinitionResponse~
    }

    class GetRiskDefinitionListUseCase {
        +execute(GetRiskDefinitionListQuery): List~RiskDefinitionSummary~
    }

    class GetRiskDefinitionUseCase {
        +execute(GetRiskDefinitionQuery): RiskDefinitionResponse
    }

    class RiskDefinitionRepository {
        <<interface>>
        +findAllByDomainPackVersionIdOrderByRiskCodeAsc(Long): List~RiskDefinition~
        +findByIdAndDomainPackVersionId(Long, Long): Optional~RiskDefinition~
    }

    RiskDefinitionController --> GetRiskDefinitionListUseCase
    RiskDefinitionController --> GetRiskDefinitionUseCase
    GetRiskDefinitionListUseCase --> RiskDefinitionRepository
    GetRiskDefinitionListUseCase --> DomainPackValidator
    GetRiskDefinitionUseCase --> RiskDefinitionRepository
    GetRiskDefinitionUseCase --> DomainPackValidator
```

### 신규 생성 파일

| 파일 | 경로 | 역할 |
|------|------|------|
| `GetRiskDefinitionListQuery.java` | `application/` | UseCase 입력 record |
| `RiskDefinitionSummary.java` | `application/` | 목록 응답 DTO (JSON 필드 제외) |
| `GetRiskDefinitionListUseCase.java` | `application/` | 목록 조회 UseCase |

### 수정 파일

| 파일 | 변경 내용 |
|------|-----------|
| `RiskDefinitionRepository.java` | `findAllByDomainPackVersionIdOrderByRiskCodeAsc(Long)` 추가 |
| `JpaRiskDefinitionRepository.java` | `findAllByDomainPackVersionIdOrderByRiskCodeAsc` 선언 추가; 기존 `findByDomainPackVersionId` 제거 (도메인 인터페이스 불일치 해소 — 사용처 확인 후) |
| `RiskDefinitionController.java` | `GetRiskDefinitionListUseCase` 생성자 주입 추가; `@GetMapping listRisks(...)` 메서드 추가 |

### Pseudo-code

```java
// GetRiskDefinitionListQuery.java
record GetRiskDefinitionListQuery(
    Long workspaceId, Long packId, Long versionId, Long userId)

// RiskDefinitionSummary.java
record RiskDefinitionSummary(
    Long id,
    Long domainPackVersionId,
    String riskCode,
    String name,
    String description,
    String riskLevel,
    String status,
    OffsetDateTime createdAt,
    OffsetDateTime updatedAt) {

    static RiskDefinitionSummary from(RiskDefinition risk) {
        return new RiskDefinitionSummary(
            risk.getId(),
            risk.getDomainPackVersionId(),
            risk.getRiskCode(),
            risk.getName(),
            risk.getDescription(),
            risk.getRiskLevel(),
            risk.getStatus(),
            risk.getCreatedAt(),
            risk.getUpdatedAt())
    }
}

// GetRiskDefinitionListUseCase.java
@Service
@Transactional(readOnly = true)
class GetRiskDefinitionListUseCase {
    execute(GetRiskDefinitionListQuery query) {
        validator.validateForWorkspacePackVersion(
            query.workspaceId(), query.userId(), query.packId(), query.versionId())
        return riskDefinitionRepository
            .findAllByDomainPackVersionIdOrderByRiskCodeAsc(query.versionId())
            .stream()
            .map(RiskDefinitionSummary::from)
            .toList()
    }
}

// RiskDefinitionController.java (수정 — listRisks 추가)
@RestController
@RequestMapping("/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/risks")
class RiskDefinitionController {
    // listUseCase 추가, detailUseCase 기존 유지

    @GetMapping
    listRisks(@PathVariable Long workspaceId, @PathVariable Long packId,
              @PathVariable Long versionId, Authentication authentication) {
        Long userId = AuthenticationUtils.getUserId(authentication)
        return ResponseEntity.ok(
            listUseCase.execute(
                new GetRiskDefinitionListQuery(workspaceId, packId, versionId, userId)))
    }

    @GetMapping("/{riskId}")
    getRisk(...) { /* 기존 그대로 */ }
}
```

---

## Tests

### UseCase 테스트: `GetRiskDefinitionListUseCaseTest.java`

참조: `GetPolicyDefinitionListUseCaseTest.java` 패턴 동일 적용

- `@ExtendWith(MockitoExtension.class)` + `@DisplayName`

| 시나리오 | 예상 결과 |
|----------|-----------|
| 유효한 query → riskCode ASC 순 목록 반환 | `List<RiskDefinitionSummary>` 반환 (순서 검증) |
| 목록 응답에 JSON 필드 미포함 | `triggerConditionJson`, `handlingActionJson`, `evidenceJson`, `metaJson` 미포함 (RecordComponent 이름 검증) |
| risk 없는 version → 빈 목록 반환 | `result.isEmpty()` |
| workspace 미존재 | `DomainPackWorkspaceNotFoundException` |
| 접근 권한 없음 | `DomainPackUnauthorizedWorkspaceAccessException` |
| pack 소속 불일치 | `DomainPackNotFoundException` |
| version 소속 불일치 | `DomainPackVersionNotFoundException` |

### Controller 테스트: `RiskDefinitionControllerTest.java`

- `@WebMvcTest(RiskDefinitionController.class)` + JwtAuthenticationFilter exclude
- `@WithLongPrincipal(10L)` fixture 사용 (패키지: `com.init.fixtures`)
- `@MockitoBean`: `GetRiskDefinitionListUseCase listUseCase`, `GetRiskDefinitionUseCase detailUseCase`

| 시나리오 | 예상 결과 |
|----------|-----------|
| GET .../risks → 200 OK, JSON 필드 미노출 검증 | `$[0].triggerConditionJson doesNotExist()`, `$[0].handlingActionJson doesNotExist()`, `$[0].evidenceJson doesNotExist()`, `$[0].metaJson doesNotExist()` |
| GET .../risks → risk 없으면 빈 배열 | `$` isArray() isEmpty() |
| GET .../risks → 403 권한 없음 | 403, `$.code = "FORBIDDEN"` |
| GET .../risks → 401 미인증 | 401 |
| GET .../risks → 404 version 소속 불일치 | 404, `$.code = "DOMAIN_PACK_VERSION_NOT_FOUND"` |
| GET .../risks → 404 pack 미존재 | 404, `$.code = "DOMAIN_PACK_NOT_FOUND"` |

---

## Database

신규 DDL 없음.

`pack.risk_definition` 테이블 및 인덱스 이미 존재 (`.agent/docs/schema.md` 참조).

---

## Additional Notes

- 구현은 `GetPolicyDefinitionListUseCase` + `PolicyDefinitionController` 패턴을 그대로 따른다.
- `DomainPackValidator.validateForWorkspacePackVersion(workspaceId, userId, packId, versionId)`가 4단계 공통 검증 진입점이다.
- `findAllByDomainPackVersionIdOrderByRiskCodeAsc`는 `RiskDefinitionRepository`(도메인 인터페이스)와 `JpaRiskDefinitionRepository` 모두에 선언한다.
- `JpaRiskDefinitionRepository.findByDomainPackVersionId`는 도메인 인터페이스와 불일치 상태이므로, 구현 전 사용처를 확인하고 미사용이면 제거하여 인터페이스 일관성을 회복한다 (3212 Policy 케이스 동일 패턴).
- `RiskDefinitionController`는 이미 존재하는 컨트롤러이므로 `listRisks` 메서드와 `GetRiskDefinitionListUseCase` 의존성만 추가한다.
---
# Uncertainty Register — 3213

**백로그**: [BE] 3.2.13 — Risk Factor 초안 목록 조회
**스펙 문서**: `.agent/specs/3213.md`
**작성일**: 2026-04-21

---

## Summary

| ID | Issue | Status | User Decision Required |
|----|-------|--------|------------------------|
| UR-3213-01 | `JpaRiskDefinitionRepository.findByDomainPackVersionId` 제거 여부 | Assumption | No |

모든 항목이 Assumption 수준으로 처리되어 사용자 결정 없이 진행 가능하다.

---

## Item Registry

---

### UR-3213-01

- **ID**: UR-3213-01
- **Issue**: `JpaRiskDefinitionRepository.findByDomainPackVersionId` 제거 여부
- **Status**: Assumption
- **Why unresolved**: Recon에서 해당 메서드가 현재 코드베이스 내 다른 곳에서 사용 중인지 명시적으로 확인하지 못했음. 3212(Policy) 케이스에서는 동일한 도메인 인터페이스 불일치를 이번 작업 범위 내 제거로 처리한 선례가 있음.
- **Options**:
  1. 제거: 도메인 인터페이스에 없는 메서드이므로 정리 (3212 Policy 패턴 동일 적용)
  2. 유지: 다른 곳에서 사용 중일 경우 제거하지 않고 새 메서드만 추가
- **Recommended Default**: Option 1 (제거) — 구현 전 `findByDomainPackVersionId` 사용처를 grep으로 확인 후, 미사용이면 제거
- **Why recommended**: 3212 spec에서 동일 패턴을 제거로 처리했으며, 도메인 인터페이스와 JPA 구현의 일관성 유지가 코드베이스 표준임.
- **User Decision Required**: No
- **User Question**: N/A
- **Execution Rule**:
  - Implementation Agent MUST: 구현 전 `findByDomainPackVersionId` 사용처를 프로젝트 전체에서 grep으로 확인한다.
  - Implementation Agent MAY: 미사용이 확인되면 `Assumption adopted from Recommended Default`로 제거한다.
  - Implementation Agent MUST NOT: 사용처 확인 없이 제거한다.
  - If unsafe: 다른 곳에서 사용 중이면 제거하지 않고 기존 메서드를 유지한 채 새 메서드만 추가한다.
- **Affected Spec Section**: Class Design > 수정 파일


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 특정 작업공간, 도메인팩, 버전에 속한 위험요소 초안 목록을 조회하는 새로운 API 엔드포인트가 추가되었습니다. 결과는 위험요소 코드 기준으로 자동 정렬되며, 인증 및 권한 검증이 적용되어 적절한 오류 처리를 지원합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->