### PR TITLE
feat(domain-pack): add GET risk definition list endpoint (#3213)

### DIFF
--- a/backend/src/main/java/com/init/domainpack/application/GetRiskDefinitionListQuery.java
+++ b/backend/src/main/java/com/init/domainpack/application/GetRiskDefinitionListQuery.java
@@ -1,0 +1,4 @@
+package com.init.domainpack.application;
+
+public record GetRiskDefinitionListQuery(
+    Long workspaceId, Long packId, Long versionId, Long userId) {}

--- a/backend/src/main/java/com/init/domainpack/application/GetRiskDefinitionListUseCase.java
+++ b/backend/src/main/java/com/init/domainpack/application/GetRiskDefinitionListUseCase.java
@@ -1,0 +1,31 @@
+package com.init.domainpack.application;
+
+import com.init.domainpack.domain.repository.RiskDefinitionRepository;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class GetRiskDefinitionListUseCase {
+
+  private final DomainPackValidator validator;
+  private final RiskDefinitionRepository riskDefinitionRepository;
+
+  public GetRiskDefinitionListUseCase(
+      DomainPackValidator validator, RiskDefinitionRepository riskDefinitionRepository) {
+    this.validator = validator;
+    this.riskDefinitionRepository = riskDefinitionRepository;
+  }
+
+  public List<RiskDefinitionSummary> execute(GetRiskDefinitionListQuery query) {
+    validator.validateForWorkspacePackVersion(
+        query.workspaceId(), query.userId(), query.packId(), query.versionId());
+
+    return riskDefinitionRepository
+        .findAllByDomainPackVersionIdOrderByRiskCodeAsc(query.versionId())
+        .stream()
+        .map(RiskDefinitionSummary::from)
+        .toList();
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/application/RiskDefinitionSummary.java
+++ b/backend/src/main/java/com/init/domainpack/application/RiskDefinitionSummary.java
@@ -1,0 +1,29 @@
+package com.init.domainpack.application;
+
+import com.init.domainpack.domain.model.RiskDefinition;
+import java.time.OffsetDateTime;
+
+public record RiskDefinitionSummary(
+    Long id,
+    Long domainPackVersionId,
+    String riskCode,
+    String name,
+    String description,
+    String riskLevel,
+    String status,
+    OffsetDateTime createdAt,
+    OffsetDateTime updatedAt) {
+
+  public static RiskDefinitionSummary from(RiskDefinition risk) {
+    return new RiskDefinitionSummary(
+        risk.getId(),
+        risk.getDomainPackVersionId(),
+        risk.getRiskCode(),
+        risk.getName(),
+        risk.getDescription(),
+        risk.getRiskLevel(),
+        risk.getStatus(),
+        risk.getCreatedAt(),
+        risk.getUpdatedAt());
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/domain/repository/RiskDefinitionRepository.java
+++ b/backend/src/main/java/com/init/domainpack/domain/repository/RiskDefinitionRepository.java
@@ -12,5 +12,7 @@ public interface RiskDefinitionRepository {
 
   Optional<RiskDefinition> findByIdAndDomainPackVersionId(Long id, Long domainPackVersionId);
 
+  List<RiskDefinition> findAllByDomainPackVersionIdOrderByRiskCodeAsc(Long domainPackVersionId);
+
   RiskDefinition save(RiskDefinition risk);
 }

--- a/backend/src/main/java/com/init/domainpack/infrastructure/persistence/JpaRiskDefinitionRepository.java
+++ b/backend/src/main/java/com/init/domainpack/infrastructure/persistence/JpaRiskDefinitionRepository.java
@@ -10,5 +10,5 @@ import org.springframework.stereotype.Repository;
 public interface JpaRiskDefinitionRepository
     extends JpaRepository<RiskDefinition, Long>, RiskDefinitionRepository {
 
-  List<RiskDefinition> findByDomainPackVersionId(Long domainPackVersionId);
+  List<RiskDefinition> findAllByDomainPackVersionIdOrderByRiskCodeAsc(Long domainPackVersionId);
 }

--- a/backend/src/main/java/com/init/domainpack/presentation/RiskDefinitionController.java
+++ b/backend/src/main/java/com/init/domainpack/presentation/RiskDefinitionController.java
@@ -1,9 +1,13 @@
 package com.init.domainpack.presentation;
 
+import com.init.domainpack.application.GetRiskDefinitionListQuery;
+import com.init.domainpack.application.GetRiskDefinitionListUseCase;
 import com.init.domainpack.application.GetRiskDefinitionQuery;
 import com.init.domainpack.application.GetRiskDefinitionUseCase;
 import com.init.domainpack.application.RiskDefinitionResponse;
+import com.init.domainpack.application.RiskDefinitionSummary;
 import com.init.shared.presentation.AuthenticationUtils;
+import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,10 +19,25 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/risks")
 public class RiskDefinitionController {
 
-  private final GetRiskDefinitionUseCase useCase;
+  private final GetRiskDefinitionListUseCase listUseCase;
+  private final GetRiskDefinitionUseCase detailUseCase;
 
-  public RiskDefinitionController(GetRiskDefinitionUseCase useCase) {
-    this.useCase = useCase;
+  public RiskDefinitionController(
+      GetRiskDefinitionListUseCase listUseCase, GetRiskDefinitionUseCase detailUseCase) {
+    this.listUseCase = listUseCase;
+    this.detailUseCase = detailUseCase;
+  }
+
+  @GetMapping
+  public ResponseEntity<List<RiskDefinitionSummary>> listRisks(
+      @PathVariable Long workspaceId,
+      @PathVariable Long packId,
+      @PathVariable Long versionId,
+      Authentication authentication) {
+    Long userId = AuthenticationUtils.getUserId(authentication);
+    return ResponseEntity.ok(
+        listUseCase.execute(
+            new GetRiskDefinitionListQuery(workspaceId, packId, versionId, userId)));
   }
 
   @GetMapping("/{riskId}")
@@ -30,7 +49,7 @@ public class RiskDefinitionController {
       Authentication authentication) {
     Long userId = AuthenticationUtils.getUserId(authentication);
     return ResponseEntity.ok(
-        useCase.execute(
+        detailUseCase.execute(
             new GetRiskDefinitionQuery(workspaceId, packId, versionId, riskId, userId)));
   }
 }

--- a/backend/src/test/java/com/init/domainpack/application/GetRiskDefinitionListUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/GetRiskDefinitionListUseCaseTest.java
@@ -94,11 +94,8 @@ class GetRiskDefinitionListUseCaseTest {
     List<RiskDefinitionSummary> result =
         useCase.execute(new GetRiskDefinitionListQuery(WORKSPACE_ID, PACK_ID, VERSION_ID, USER_ID));
 
-    // then — RiskDefinitionSummary record must not expose JSON fields
+    // then
     assertThat(result).hasSize(1);
-    assertThat(RiskDefinitionSummary.class.getRecordComponents())
-        .extracting(java.lang.reflect.RecordComponent::getName)
-        .doesNotContain("triggerConditionJson", "handlingActionJson", "evidenceJson", "metaJson");
   }
 
   @Test

--- a/backend/src/test/java/com/init/domainpack/application/GetRiskDefinitionListUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/GetRiskDefinitionListUseCaseTest.java
@@ -1,0 +1,199 @@
+package com.init.domainpack.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.init.domainpack.application.exception.DomainPackNotFoundException;
+import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
+import com.init.domainpack.application.exception.DomainPackVersionNotFoundException;
+import com.init.domainpack.application.exception.DomainPackWorkspaceNotFoundException;
+import com.init.domainpack.domain.model.DomainPackVersion;
+import com.init.domainpack.domain.model.RiskDefinition;
+import com.init.domainpack.domain.repository.DomainPackRepository;
+import com.init.domainpack.domain.repository.DomainPackVersionRepository;
+import com.init.domainpack.domain.repository.RiskDefinitionRepository;
+import com.init.domainpack.domain.repository.WorkspaceExistencePort;
+import com.init.domainpack.domain.repository.WorkspaceMembershipPort;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetRiskDefinitionListUseCase")
+class GetRiskDefinitionListUseCaseTest {
+
+  @Mock private WorkspaceExistencePort workspaceExistencePort;
+  @Mock private WorkspaceMembershipPort workspaceMembershipPort;
+  @Mock private DomainPackRepository domainPackRepository;
+  @Mock private DomainPackVersionRepository domainPackVersionRepository;
+  @Mock private RiskDefinitionRepository riskDefinitionRepository;
+
+  private GetRiskDefinitionListUseCase useCase;
+
+  private static final Long WORKSPACE_ID = 1L;
+  private static final Long PACK_ID = 7L;
+  private static final Long VERSION_ID = 101L;
+  private static final Long USER_ID = 10L;
+
+  @BeforeEach
+  void setUp() {
+    DomainPackValidator validator =
+        new DomainPackValidator(
+            workspaceExistencePort,
+            workspaceMembershipPort,
+            domainPackRepository,
+            domainPackVersionRepository);
+    useCase = new GetRiskDefinitionListUseCase(validator, riskDefinitionRepository);
+  }
+
+  @Test
+  @DisplayName("유효한 query → riskCode ASC 순 RiskDefinitionSummary 목록 반환")
+  void should_returnOrderedSummaryList_when_validQuery() {
+    // given
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(true);
+    given(domainPackVersionRepository.findById(VERSION_ID))
+        .willReturn(Optional.of(createVersion(VERSION_ID, PACK_ID)));
+    given(riskDefinitionRepository.findAllByDomainPackVersionIdOrderByRiskCodeAsc(VERSION_ID))
+        .willReturn(
+            List.of(createRisk(1L, "RISK_FRAUD", "사기 위험"), createRisk(2L, "RISK_RETURN", "반품 위험")));
+
+    // when
+    List<RiskDefinitionSummary> result =
+        useCase.execute(new GetRiskDefinitionListQuery(WORKSPACE_ID, PACK_ID, VERSION_ID, USER_ID));
+
+    // then
+    assertThat(result).hasSize(2);
+    assertThat(result.get(0).riskCode()).isEqualTo("RISK_FRAUD");
+    assertThat(result.get(1).riskCode()).isEqualTo("RISK_RETURN");
+  }
+
+  @Test
+  @DisplayName("목록 응답에 triggerConditionJson, handlingActionJson, evidenceJson, metaJson 미포함")
+  void should_notIncludeJsonFields_when_summaryIsReturned() {
+    // given
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(true);
+    given(domainPackVersionRepository.findById(VERSION_ID))
+        .willReturn(Optional.of(createVersion(VERSION_ID, PACK_ID)));
+    given(riskDefinitionRepository.findAllByDomainPackVersionIdOrderByRiskCodeAsc(VERSION_ID))
+        .willReturn(List.of(createRisk(1L, "RISK_FRAUD", "사기 위험")));
+
+    // when
+    List<RiskDefinitionSummary> result =
+        useCase.execute(new GetRiskDefinitionListQuery(WORKSPACE_ID, PACK_ID, VERSION_ID, USER_ID));
+
+    // then — RiskDefinitionSummary record must not expose JSON fields
+    assertThat(result).hasSize(1);
+    assertThat(RiskDefinitionSummary.class.getRecordComponents())
+        .extracting(java.lang.reflect.RecordComponent::getName)
+        .doesNotContain("triggerConditionJson", "handlingActionJson", "evidenceJson", "metaJson");
+  }
+
+  @Test
+  @DisplayName("risk 없는 version → 빈 목록 반환")
+  void should_returnEmptyList_when_noRisksExist() {
+    // given
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(true);
+    given(domainPackVersionRepository.findById(VERSION_ID))
+        .willReturn(Optional.of(createVersion(VERSION_ID, PACK_ID)));
+    given(riskDefinitionRepository.findAllByDomainPackVersionIdOrderByRiskCodeAsc(VERSION_ID))
+        .willReturn(List.of());
+
+    // when
+    List<RiskDefinitionSummary> result =
+        useCase.execute(new GetRiskDefinitionListQuery(WORKSPACE_ID, PACK_ID, VERSION_ID, USER_ID));
+
+    // then
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  @DisplayName("workspace 없음 → DomainPackWorkspaceNotFoundException")
+  void should_throwWorkspaceNotFoundException_when_workspaceNotFound() {
+    // given
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(false);
+
+    // when & then
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new GetRiskDefinitionListQuery(WORKSPACE_ID, PACK_ID, VERSION_ID, USER_ID)))
+        .isInstanceOf(DomainPackWorkspaceNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("접근 권한 없음 → DomainPackUnauthorizedWorkspaceAccessException")
+  void should_throwUnauthorizedException_when_unauthorized() {
+    // given
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(false);
+
+    // when & then
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new GetRiskDefinitionListQuery(WORKSPACE_ID, PACK_ID, VERSION_ID, USER_ID)))
+        .isInstanceOf(DomainPackUnauthorizedWorkspaceAccessException.class);
+  }
+
+  @Test
+  @DisplayName("domain pack 소속 불일치 → DomainPackNotFoundException")
+  void should_throwDomainPackNotFoundException_when_packNotInWorkspace() {
+    // given
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(false);
+
+    // when & then
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new GetRiskDefinitionListQuery(WORKSPACE_ID, PACK_ID, VERSION_ID, USER_ID)))
+        .isInstanceOf(DomainPackNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("version 소속 불일치 → DomainPackVersionNotFoundException")
+  void should_throwVersionNotFoundException_when_versionNotInPack() {
+    // given
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(true);
+    given(domainPackVersionRepository.findById(VERSION_ID))
+        .willReturn(Optional.of(createVersion(VERSION_ID, 999L)));
+
+    // when & then
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new GetRiskDefinitionListQuery(WORKSPACE_ID, PACK_ID, VERSION_ID, USER_ID)))
+        .isInstanceOf(DomainPackVersionNotFoundException.class);
+  }
+
+  private DomainPackVersion createVersion(Long id, Long packId) {
+    return DomainPackVersion.ofForTest(id, packId, DomainPackVersion.STATUS_DRAFT);
+  }
+
+  private RiskDefinition createRisk(Long id, String riskCode, String name) {
+    RiskDefinition risk =
+        RiskDefinition.create(VERSION_ID, riskCode, name, "설명", "HIGH", "{}", "{}", "[]", "{}");
+    ReflectionTestUtils.setField(risk, "id", id);
+    ReflectionTestUtils.setField(risk, "createdAt", OffsetDateTime.parse("2026-04-10T10:00:00Z"));
+    ReflectionTestUtils.setField(risk, "updatedAt", OffsetDateTime.parse("2026-04-10T10:00:00Z"));
+    return risk;
+  }
+}

--- a/backend/src/test/java/com/init/domainpack/presentation/RiskDefinitionControllerTest.java
+++ b/backend/src/test/java/com/init/domainpack/presentation/RiskDefinitionControllerTest.java
@@ -6,14 +6,18 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.init.domainpack.application.GetRiskDefinitionListUseCase;
 import com.init.domainpack.application.GetRiskDefinitionUseCase;
 import com.init.domainpack.application.RiskDefinitionResponse;
+import com.init.domainpack.application.RiskDefinitionSummary;
+import com.init.domainpack.application.exception.DomainPackNotFoundException;
 import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
 import com.init.domainpack.application.exception.DomainPackVersionNotFoundException;
 import com.init.domainpack.application.exception.RiskDefinitionNotFoundException;
 import com.init.fixtures.WithLongPrincipal;
 import com.init.shared.infrastructure.security.JwtAuthenticationFilter;
 import java.time.OffsetDateTime;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,14 +40,15 @@ class RiskDefinitionControllerTest {
 
   @Autowired private MockMvc mockMvc;
 
-  @MockitoBean private GetRiskDefinitionUseCase useCase;
+  @MockitoBean private GetRiskDefinitionListUseCase listUseCase;
+  @MockitoBean private GetRiskDefinitionUseCase detailUseCase;
 
   @Test
   @DisplayName("GET .../risks/{riskId} → 200 OK, 전체 필드 반환")
   @WithLongPrincipal(10L)
   void should_returnOkWithAllFields_when_riskExists() throws Exception {
     // given
-    given(useCase.execute(any()))
+    given(detailUseCase.execute(any()))
         .willReturn(
             new RiskDefinitionResponse(
                 5001L,
@@ -84,7 +89,7 @@ class RiskDefinitionControllerTest {
   @WithLongPrincipal(10L)
   void should_return404_when_riskNotFound() throws Exception {
     // given
-    given(useCase.execute(any())).willThrow(new RiskDefinitionNotFoundException(9999L));
+    given(detailUseCase.execute(any())).willThrow(new RiskDefinitionNotFoundException(9999L));
 
     // when & then
     mockMvc
@@ -98,7 +103,7 @@ class RiskDefinitionControllerTest {
   @WithLongPrincipal(10L)
   void should_return403_when_unauthorized() throws Exception {
     // given
-    given(useCase.execute(any()))
+    given(detailUseCase.execute(any()))
         .willThrow(new DomainPackUnauthorizedWorkspaceAccessException("워크스페이스에 접근 권한이 없습니다."));
 
     // when & then
@@ -120,12 +125,108 @@ class RiskDefinitionControllerTest {
   @WithLongPrincipal(10L)
   void should_return404_when_versionNotFound() throws Exception {
     // given
-    given(useCase.execute(any())).willThrow(new DomainPackVersionNotFoundException(101L));
+    given(detailUseCase.execute(any())).willThrow(new DomainPackVersionNotFoundException(101L));
 
     // when & then
     mockMvc
         .perform(get(BASE_URL + "/5001"))
         .andExpect(status().isNotFound())
         .andExpect(jsonPath("$.code").value("DOMAIN_PACK_VERSION_NOT_FOUND"));
+  }
+
+  @Test
+  @DisplayName("GET .../risks → 200 OK, JSON 필드 미노출 검증")
+  @WithLongPrincipal(10L)
+  void should_returnOkWithSummaryList_when_validRequest() throws Exception {
+    // given
+    given(listUseCase.execute(any()))
+        .willReturn(
+            List.of(
+                new RiskDefinitionSummary(
+                    5001L,
+                    101L,
+                    "RISK_FRAUD",
+                    "사기 거래 위험",
+                    "비정상적인 결제 패턴 감지 시 차단",
+                    "HIGH",
+                    "ACTIVE",
+                    OffsetDateTime.parse("2026-04-10T10:00:00Z"),
+                    OffsetDateTime.parse("2026-04-10T10:00:00Z"))));
+
+    // when & then
+    mockMvc
+        .perform(get(BASE_URL))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].riskCode").value("RISK_FRAUD"))
+        .andExpect(jsonPath("$[0].name").value("사기 거래 위험"))
+        .andExpect(jsonPath("$[0].triggerConditionJson").doesNotExist())
+        .andExpect(jsonPath("$[0].handlingActionJson").doesNotExist())
+        .andExpect(jsonPath("$[0].evidenceJson").doesNotExist())
+        .andExpect(jsonPath("$[0].metaJson").doesNotExist());
+  }
+
+  @Test
+  @DisplayName("GET .../risks → risk 없으면 빈 배열")
+  @WithLongPrincipal(10L)
+  void should_returnEmptyArray_when_noRisksExist() throws Exception {
+    // given
+    given(listUseCase.execute(any())).willReturn(List.of());
+
+    // when & then
+    mockMvc
+        .perform(get(BASE_URL))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$").isEmpty());
+  }
+
+  @Test
+  @DisplayName("GET .../risks → 403 권한 없음")
+  @WithLongPrincipal(10L)
+  void should_return403_when_listUnauthorized() throws Exception {
+    // given
+    given(listUseCase.execute(any()))
+        .willThrow(new DomainPackUnauthorizedWorkspaceAccessException("워크스페이스에 접근 권한이 없습니다."));
+
+    // when & then
+    mockMvc
+        .perform(get(BASE_URL))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.code").value("FORBIDDEN"));
+  }
+
+  @Test
+  @DisplayName("GET .../risks → 401 미인증")
+  void should_return401_when_listUnauthenticated() throws Exception {
+    // when & then
+    mockMvc.perform(get(BASE_URL)).andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @DisplayName("GET .../risks → 404 version 소속 불일치")
+  @WithLongPrincipal(10L)
+  void should_return404_when_listVersionNotFound() throws Exception {
+    // given
+    given(listUseCase.execute(any())).willThrow(new DomainPackVersionNotFoundException(101L));
+
+    // when & then
+    mockMvc
+        .perform(get(BASE_URL))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("DOMAIN_PACK_VERSION_NOT_FOUND"));
+  }
+
+  @Test
+  @DisplayName("GET .../risks → 404 pack 미존재")
+  @WithLongPrincipal(10L)
+  void should_return404_when_listPackNotFound() throws Exception {
+    // given
+    given(listUseCase.execute(any())).willThrow(new DomainPackNotFoundException(7L));
+
+    // when & then
+    mockMvc
+        .perform(get(BASE_URL))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("DOMAIN_PACK_NOT_FOUND"));
   }
 }


### PR DESCRIPTION
## Summary

특정 Domain Pack Version에 속한 Risk Factor 초안 목록을 `riskCode ASC` 순으로 반환하는 `GET /risks` 엔드포인트를 추가했다. 신규 파일 3개(Query, Summary DTO, UseCase)와 기존 파일 3개(Repository 인터페이스, JPA 구현체, Controller) 수정으로 구성된다.

---

## Context

`.agent/specs/3213.md` — `[BE] 3.2.13 Risk Factor 초안 목록 조회` 구현 PR.

`GetPolicyDefinitionList*` 구현 패턴을 그대로 따랐으며, 이미 존재하는 `RiskDefinitionController` / `RiskDefinitionRepository` 위에 목록 조회 기능을 추가하는 구조다.

---

## What Changed

| 대상 | 변경 내용 |
|------|-----------|
| `GetRiskDefinitionListQuery` | 신규 — UseCase 입력 record (workspaceId, packId, versionId, userId) |
| `RiskDefinitionSummary` | 신규 — 목록 응답 DTO, JSON 4개 필드(`triggerConditionJson` 등) 제외 |
| `GetRiskDefinitionListUseCase` | 신규 — `@Transactional(readOnly = true)`, validator 4단계 검증 후 riskCode ASC 목록 반환 |
| `RiskDefinitionRepository` | `findAllByDomainPackVersionIdOrderByRiskCodeAsc` 추가 |
| `JpaRiskDefinitionRepository` | `findByDomainPackVersionId` 제거 + `findAllByDomainPackVersionIdOrderByRiskCodeAsc` 추가 |
| `RiskDefinitionController` | `listRisks(@GetMapping)` 추가, `GetRiskDefinitionListUseCase` 생성자 주입 추가 |
| `GetRiskDefinitionListUseCaseTest` | 신규 — 7개 시나리오 (정상, 빈 목록, 4종 예외) |
| `RiskDefinitionControllerTest` | 기존 5개 유지 + 신규 6개 추가 → 11개 |

---

## Assumptions Adopted

### UR-3213-01 — `findByDomainPackVersionId` 제거

- `JpaRiskDefinitionRepository.findByDomainPackVersionId`는 도메인 인터페이스에 없는 상태였음
- 구현 전 `grep`으로 Risk 도메인 내 호출처 없음 확인 후 제거
- 동명 메서드가 `JpaIntentDefinitionRepository`에도 존재하나 별개 도메인이므로 영향 없음
- **잠재 리스크**: 다른 브랜치에서 `findByDomainPackVersionId` 호출 코드가 병합될 경우 컴파일 오류 발생 — merge 시 충돌 확인 필요

---

## Spec Deviations

N/A — 모든 spec 항목이 구현과 일치함(audit Spec Consistency 전 항목 ✅).

---

## Blocked / Skipped Items

없음.

---

## Test Notes

- `./gradlew test --tests "com.init.domainpack.*"` → `BUILD SUCCESSFUL`
- UseCase 테스트 7개 통과 / Controller 테스트 11개 통과
- V-001(RecordComponent 리플렉션 검증) Auto Fix 적용: `should_notIncludeJsonFields_when_summaryIsReturned` 내 reflection 3줄 제거. Controller 테스트의 `doesNotExist()` JSONPath가 동일 요건을 커버함.
- V-002(`ReflectionTestUtils.setField`): 코드베이스 33개 테스트 파일에서 동일 패턴 사용 중이므로 스킵. 전체 통일은 별도 리팩토링 범위.

---

## Reviewer Focus

1. **`JpaRiskDefinitionRepository` 메서드 교체** — `findByDomainPackVersionId` 제거가 다른 브랜치 코드와 충돌할 가능성 확인
2. **`RiskDefinitionSummary.from()`** — JSON 4개 필드가 DTO에서 정확히 누락되어 있는지 재확인
3. **Controller `listRisks` 메서드** — 기존 `getRisk` 메서드 동작에 영향이 없는지 확인

---

## Conflicts

없음.

---

## Ready to Merge / Needs Input

**Ready to Merge** — 모든 uncertainty 항목 처리 완료, audit PASS(Critical 0 / Warning 0), 테스트 전 통과.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 위험 목록 조회 API 엔드포인트 추가: 패키지 버전별 모든 위험을 위험 코드 기준 정렬 상태로 조회할 수 있습니다.

* **개선사항**
  * 위험 정보 조회 시 워크스페이스 존재 여부, 사용자 권한, 패키지/버전 유효성 검증 강화
  * 위험 정보 조회 정렬 기준 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->