### PR TITLE
spec/3214: worflow node/edge 초안 목록 조회 API

### DIFF
--- a/.agent/specs/3214.md
+++ b/.agent/specs/3214.md
@@ -1,0 +1,290 @@
+# [BE] 3.2.14 — Workflow(Node/Edge) 초안 목록 조회
+
+> **Backlog**: 운영자가 특정 DomainPackVersion에 저장된 workflow 초안 목록을 조회하고 싶다 → 자동 생성 결과를 운영 가능한 형태로 다듬기 위해
+> **Bounded Context**: `domainpack`
+> **Branch**: `feature/3214-workflow-list-read`
+> **연관 스펙**: 단건 조회 → `.agent/specs/2215.md`; 원본 설계 → `.agent/specs/226.md`
+
+---
+
+## 구현 상태 (Implementation Status)
+
+`GetWorkflowDefinitionListUseCase`, `WorkflowDefinitionController(GET 목록)`, `WorkflowDefinitionSummary`, `WorkflowDefinitionSummaryRow`, 관련 테스트가 **이미 구현·완료**되어 있다.
+
+이 스펙은 기존 구현을 3211~3213 컨벤션에 맞추기 위한 **최소 수정**만 정의한다.
+
+| # | 수정 항목 | 대상 파일 |
+|---|-----------|-----------|
+| M1 | `workflowCode ASC` 정렬 추가 | `WorkflowDefinitionRepository`, `JpaWorkflowDefinitionRepository`, `GetWorkflowDefinitionListUseCase`, 관련 테스트 |
+| M2 | `domainPackVersionId` 필드 추가 (목록 응답) | `WorkflowDefinitionSummaryRow`, `WorkflowDefinitionSummary`, 관련 테스트 |
+
+> 단건 조회 응답(`WorkflowDefinitionDetail`)에 `domainPackVersionId`를 추가하는 작업은 **`.agent/specs/2215.md`** 범위에서 처리한다.
+
+---
+
+## Goal
+
+특정 DomainPackVersion에 속한 `WorkflowDefinition` 초안 목록을 `workflowCode ASC` 순으로 조회하는 GET 엔드포인트를 제공한다. `graphJson`은 목록 응답에서 제외한다(성능).
+
+---
+
+## Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    actor c as Client
+    participant ctrl as WorkflowDefinitionController
+    participant uc as GetWorkflowDefinitionListUseCase
+    participant validator as DomainPackValidator
+    participant repo as WorkflowDefinitionRepository
+    participant db as PostgreSQL
+
+    c ->> ctrl: GET /api/v1/workspaces/{wsId}/domain-packs/{packId}/versions/{versionId}/workflows
+    ctrl ->> uc: execute(GetWorkflowDefinitionListQuery)
+    uc ->> validator: validateWorkspaceAccess(workspaceId, userId)
+    validator -->> uc: ok
+    uc ->> validator: validateDomainPack(packId, workspaceId)
+    validator -->> uc: ok
+    uc ->> validator: validateVersion(versionId, packId)
+    validator -->> uc: ok
+    uc ->> repo: findAllByDomainPackVersionIdOrderByWorkflowCodeAsc(versionId)
+    repo ->> db: SELECT id, domain_pack_version_id, workflow_code, name, description,\ninitial_state, terminal_states_json, created_at, updated_at\nFROM pack.workflow_definition\nWHERE domain_pack_version_id = ?\nORDER BY workflow_code ASC
+    db -->> repo: List<WorkflowDefinitionSummaryRow>
+    repo -->> uc: List<WorkflowDefinitionSummaryRow>
+    uc -->> ctrl: List<WorkflowDefinitionSummary>
+    ctrl -->> c: 200 OK
+```
+
+---
+
+## REST API
+
+### Endpoint
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/workflows` | Workflow 초안 목록 조회 (`workflowCode ASC`, `graphJson` 제외) |
+
+### Request
+
+Path variables: `workspaceId`(Long), `packId`(Long), `versionId`(Long)  
+Headers: `Authorization: Bearer {jwt-token}` (필수)  
+Query parameters: 없음
+
+### Response
+
+**200 OK**
+
+```json
+[
+  {
+    "id": 1,
+    "domainPackVersionId": 10,
+    "workflowCode": "refund_flow",
+    "name": "환불 플로우",
+    "description": "환불 요청 처리 플로우",
+    "initialState": "start",
+    "terminalStatesJson": "[\"terminal\"]",
+    "createdAt": "2026-04-14T10:00:00Z",
+    "updatedAt": "2026-04-14T10:00:00Z"
+  }
+]
+```
+
+> `graphJson`은 포함하지 않는다 (최대 N개 workflow × 대용량 graphJson 방지).  
+> workflow가 없는 version이면 빈 배열 `[]`를 반환한다.
+
+**401 Unauthorized**
+
+```json
+{ "code": "UNAUTHORIZED", "message": "인증이 필요합니다." }
+```
+
+**403 Forbidden**
+
+```json
+{ "code": "FORBIDDEN", "message": "워크스페이스에 접근 권한이 없습니다." }
+```
+
+**404 Not Found**
+
+```json
+{ "code": "DOMAIN_PACK_WORKSPACE_NOT_FOUND", "message": "워크스페이스를 찾을 수 없습니다. id={workspaceId}" }
+{ "code": "DOMAIN_PACK_NOT_FOUND",           "message": "DomainPack not found: {packId}" }
+{ "code": "DOMAIN_PACK_VERSION_NOT_FOUND",   "message": "도메인 팩 버전을 찾을 수 없습니다. id={versionId}" }
+```
+
+---
+
+## Class Design
+
+### DDD Layered Structure
+
+```mermaid
+classDiagram
+    class WorkflowDefinitionController {
+        +listWorkflows(workspaceId, packId, versionId, auth): ResponseEntity~List~WorkflowDefinitionSummary~~
+    }
+
+    class GetWorkflowDefinitionListUseCase {
+        +execute(GetWorkflowDefinitionListQuery): List~WorkflowDefinitionSummary~
+    }
+
+    class WorkflowDefinitionRepository {
+        <<interface>>
+        +findAllByDomainPackVersionIdOrderByWorkflowCodeAsc(Long): List~WorkflowDefinitionSummaryRow~
+    }
+
+    class WorkflowDefinitionSummaryRow {
+        <<interface>>
+        +getId(): Long
+        +getDomainPackVersionId(): Long
+        +getWorkflowCode(): String
+        +getName(): String
+        +getDescription(): String
+        +getInitialState(): String
+        +getTerminalStatesJson(): String
+        +getCreatedAt(): OffsetDateTime
+        +getUpdatedAt(): OffsetDateTime
+    }
+
+    WorkflowDefinitionController --> GetWorkflowDefinitionListUseCase
+    GetWorkflowDefinitionListUseCase --> WorkflowDefinitionRepository
+    GetWorkflowDefinitionListUseCase --> DomainPackValidator
+```
+
+### 수정 파일 (Modified Files)
+
+| 파일 | 변경 내용 |
+|------|-----------|
+| `WorkflowDefinitionRepository.java` | `findAllByDomainPackVersionId` → `findAllByDomainPackVersionIdOrderByWorkflowCodeAsc` rename |
+| `JpaWorkflowDefinitionRepository.java` | 동일 rename; Spring Data JPA 메서드명이 쿼리를 자동 생성하므로 `@Query` 불필요 |
+| `WorkflowDefinitionSummaryRow.java` | `Long getDomainPackVersionId()` getter 추가 |
+| `WorkflowDefinitionSummary.java` | `Long domainPackVersionId` 필드 추가; `from()` 팩토리 업데이트 |
+| `GetWorkflowDefinitionListUseCase.java` | 호출 메서드명 업데이트 |
+| `GetWorkflowDefinitionListUseCaseTest.java` | `domainPackVersionId` 포함 stub 업데이트 |
+| `WorkflowDefinitionControllerTest.java` | `$[0].domainPackVersionId` 검증 추가 |
+
+### Key Code Sketches
+
+```java
+// domain/repository/WorkflowDefinitionSummaryRow.java (변경)
+public interface WorkflowDefinitionSummaryRow {
+  Long getId();
+  Long getDomainPackVersionId();  // 추가
+  String getWorkflowCode();
+  String getName();
+  String getDescription();
+  String getInitialState();
+  String getTerminalStatesJson();
+  OffsetDateTime getCreatedAt();
+  OffsetDateTime getUpdatedAt();
+}
+```
+
+```java
+// application/WorkflowDefinitionSummary.java (변경)
+public record WorkflowDefinitionSummary(
+    Long id,
+    Long domainPackVersionId,  // 추가
+    String workflowCode,
+    String name,
+    String description,
+    String initialState,
+    String terminalStatesJson,
+    OffsetDateTime createdAt,
+    OffsetDateTime updatedAt) {
+
+  public static WorkflowDefinitionSummary from(WorkflowDefinitionSummaryRow row) {
+    return new WorkflowDefinitionSummary(
+        row.getId(),
+        row.getDomainPackVersionId(),  // 추가
+        row.getWorkflowCode(),
+        row.getName(),
+        row.getDescription(),
+        row.getInitialState(),
+        row.getTerminalStatesJson(),
+        row.getCreatedAt(),
+        row.getUpdatedAt());
+  }
+}
+```
+
+```java
+// domain/repository/WorkflowDefinitionRepository.java (변경)
+// 기존: findAllByDomainPackVersionId(Long)
+// 변경:
+List<WorkflowDefinitionSummaryRow> findAllByDomainPackVersionIdOrderByWorkflowCodeAsc(Long domainPackVersionId);
+```
+
+```java
+// infrastructure/persistence/JpaWorkflowDefinitionRepository.java (변경)
+// 기존: findAllByDomainPackVersionId(Long)
+// 변경 (Spring Data JPA 메서드명 자동 쿼리 생성 활용):
+@Override
+List<WorkflowDefinitionSummaryRow> findAllByDomainPackVersionIdOrderByWorkflowCodeAsc(Long domainPackVersionId);
+```
+
+```java
+// application/GetWorkflowDefinitionListUseCase.java (변경)
+public List<WorkflowDefinitionSummary> execute(GetWorkflowDefinitionListQuery query) {
+  validator.validateWorkspaceAccess(query.workspaceId(), query.userId());
+  validator.validateDomainPack(query.packId(), query.workspaceId());
+  validator.validateVersion(query.versionId(), query.packId());
+
+  return workflowDefinitionRepository
+      .findAllByDomainPackVersionIdOrderByWorkflowCodeAsc(query.versionId())  // 변경
+      .stream()
+      .map(WorkflowDefinitionSummary::from)
+      .toList();
+}
+```
+
+---
+
+## Tests
+
+### UseCase 테스트 수정: `GetWorkflowDefinitionListUseCaseTest.java`
+
+기존 5개 테스트 케이스 유지. 아래 항목만 업데이트한다.
+
+| 업데이트 항목 | 내용 |
+|--------------|------|
+| stub 메서드명 | `findAllByDomainPackVersionId` → `findAllByDomainPackVersionIdOrderByWorkflowCodeAsc` |
+| `createSummaryRow()` | `getDomainPackVersionId()` getter 구현 추가 (`return VERSION_ID`) |
+| 결과 검증 | `result.get(0).domainPackVersionId()` 검증 추가 |
+
+### Controller 테스트 수정: `WorkflowDefinitionControllerTest.java`
+
+기존 6개 테스트 케이스 유지. 아래 항목만 업데이트한다.
+
+| 업데이트 항목 | 내용 |
+|--------------|------|
+| `listWorkflows_returnsOk` stub | `WorkflowDefinitionSummary` 생성자에 `domainPackVersionId` 추가 |
+| `listWorkflows_returnsOk` 검증 | `jsonPath("$[0].domainPackVersionId").value(10)` 추가 |
+
+### Test Checklist
+
+- [ ] 목록 응답에 `domainPackVersionId` 포함 확인
+- [ ] 목록 응답에 `graphJson` 미포함 확인 (`$[0].graphJson doesNotExist()`)
+- [ ] 빈 목록: workflow 없는 version → 빈 배열 반환
+- [ ] 403: 권한 없는 사용자
+- [ ] 401: 미인증
+- [ ] 404: workspace/pack/version 미소속
+
+---
+
+## Database
+
+변경 없음. `pack.workflow_definition` 테이블은 이미 존재한다.
+
+`workflowCode ASC` 정렬은 기존 인덱스로 처리한다. 버전당 workflow 수가 50개를 초과하거나 목록 조회 p95가 500ms를 넘는 경우 복합 인덱스 추가를 검토한다.
+
+---
+
+## Additional Notes
+
+- 기존 `GetWorkflowDefinitionListUseCase`는 `validator.validateWorkspaceAccess()`, `validator.validateDomainPack()`, `validator.validateVersion()` 3개 개별 호출 방식을 사용한다. 이는 3211 패턴과 일치하며, 3212/3213의 `validateForWorkspacePackVersion()` 복합 호출 방식과 다르다. 기능상 동일하므로 이 스펙에서는 현재 구현을 그대로 유지한다.
+- 단건 조회(`WorkflowDefinitionDetail`)에 `domainPackVersionId`를 추가하는 작업은 **`.agent/specs/2215.md`** 범위에서 처리한다.
+- graphJson 구조(nodes/edges) 및 유효성 규칙(V1~V6)은 `.agent/specs/226.md` 참조.
+- 3211(Slot), 3212(Policy), 3213(Risk)과 함께 Domain Pack 구성요소 조회 API 패밀리를 형성한다.

--- a/.agent/specs/3214.md
+++ b/.agent/specs/3214.md
@@ -3,28 +3,27 @@
 > **Backlog**: 운영자가 특정 DomainPackVersion에 저장된 workflow 초안 목록을 조회하고 싶다 → 자동 생성 결과를 운영 가능한 형태로 다듬기 위해
 > **Bounded Context**: `domainpack`
 > **Branch**: `feature/3214-workflow-list-read`
-> **연관 스펙**: 단건 조회 → `.agent/specs/2215.md`; 원본 설계 → `.agent/specs/226.md`
+> **연관 스펙**: 원본 설계 → `.agent/specs/226.md`
 
 ---
 
 ## 구현 상태 (Implementation Status)
 
-`GetWorkflowDefinitionListUseCase`, `WorkflowDefinitionController(GET 목록)`, `WorkflowDefinitionSummary`, `WorkflowDefinitionSummaryRow`, 관련 테스트가 **이미 구현·완료**되어 있다.
+spec 226 기반의 `GetWorkflowDefinitionListUseCase`, `WorkflowDefinitionController`(GET 목록·단건), `WorkflowDefinitionSummary`, `WorkflowDefinitionSummaryRow`, `WorkflowDefinitionDetail`, 관련 테스트가 이미 존재한다.
 
-이 스펙은 기존 구현을 3211~3213 컨벤션에 맞추기 위한 **최소 수정**만 정의한다.
+단, 아래 변경사항(M1·M2·M3)은 **이번 PR에서 신규 반영**한다.
 
 | # | 수정 항목 | 대상 파일 |
 |---|-----------|-----------|
 | M1 | `workflowCode ASC` 정렬 추가 | `WorkflowDefinitionRepository`, `JpaWorkflowDefinitionRepository`, `GetWorkflowDefinitionListUseCase`, 관련 테스트 |
 | M2 | `domainPackVersionId` 필드 추가 (목록 응답) | `WorkflowDefinitionSummaryRow`, `WorkflowDefinitionSummary`, 관련 테스트 |
-
-> 단건 조회 응답(`WorkflowDefinitionDetail`)에 `domainPackVersionId`를 추가하는 작업은 **`.agent/specs/2215.md`** 범위에서 처리한다.
+| M3 | `domainPackVersionId` 필드 추가 (단건 응답) | `WorkflowDefinitionDetail`, 관련 테스트 |
 
 ---
 
 ## Goal
 
-특정 DomainPackVersion에 속한 `WorkflowDefinition` 초안 목록을 `workflowCode ASC` 순으로 조회하는 GET 엔드포인트를 제공한다. `graphJson`은 목록 응답에서 제외한다(성능).
+특정 DomainPackVersion에 속한 `WorkflowDefinition` 초안 목록을 `workflowCode ASC` 순으로 조회하는 GET 엔드포인트를 제공한다. `graphJson`은 목록 응답에서 제외한다(성능). 목록·단건 응답 모두 `domainPackVersionId`를 포함한다.
 
 ---
 
@@ -73,7 +72,7 @@ Query parameters: 없음
 
 ### Response
 
-**200 OK**
+**GET /workflows → 200 OK**
 
 ```json
 [
@@ -91,8 +90,31 @@ Query parameters: 없음
 ]
 ```
 
-> `graphJson`은 포함하지 않는다 (최대 N개 workflow × 대용량 graphJson 방지).  
+> `graphJson`은 포함하지 않는다 (대용량 graphJson 다수 포함 방지).  
 > workflow가 없는 version이면 빈 배열 `[]`를 반환한다.
+
+**GET /workflows/{workflowId} → 200 OK** (단건, M3 반영)
+
+```json
+{
+  "id": 1,
+  "domainPackVersionId": 10,
+  "workflowCode": "refund_flow",
+  "name": "환불 플로우",
+  "description": "환불 요청 처리 플로우",
+  "graphJson": {
+    "direction": "LR",
+    "nodes": [],
+    "edges": []
+  },
+  "initialState": "start",
+  "terminalStatesJson": "[\"terminal\"]",
+  "evidenceJson": "[]",
+  "metaJson": "{}",
+  "createdAt": "2026-04-14T10:00:00Z",
+  "updatedAt": "2026-04-14T10:00:00Z"
+}
+```
 
 **401 Unauthorized**
 
@@ -110,8 +132,20 @@ Query parameters: 없음
 
 ```json
 { "code": "DOMAIN_PACK_WORKSPACE_NOT_FOUND", "message": "워크스페이스를 찾을 수 없습니다. id={workspaceId}" }
-{ "code": "DOMAIN_PACK_NOT_FOUND",           "message": "DomainPack not found: {packId}" }
-{ "code": "DOMAIN_PACK_VERSION_NOT_FOUND",   "message": "도메인 팩 버전을 찾을 수 없습니다. id={versionId}" }
+```
+
+```json
+{ "code": "DOMAIN_PACK_NOT_FOUND", "message": "DomainPack not found: {packId}" }
+```
+
+```json
+{ "code": "DOMAIN_PACK_VERSION_NOT_FOUND", "message": "도메인 팩 버전을 찾을 수 없습니다. id={versionId}" }
+```
+
+**500 Internal Server Error** (단건 조회 시 DB 저장된 graphJson 정합성 오류)
+
+```json
+{ "code": "WORKFLOW_GRAPH_JSON_INVALID", "message": "graphJson이 유효하지 않은 JSON입니다." }
 ```
 
 ---
@@ -157,18 +191,19 @@ classDiagram
 
 | 파일 | 변경 내용 |
 |------|-----------|
-| `WorkflowDefinitionRepository.java` | `findAllByDomainPackVersionId` → `findAllByDomainPackVersionIdOrderByWorkflowCodeAsc` rename |
-| `JpaWorkflowDefinitionRepository.java` | 동일 rename; Spring Data JPA 메서드명이 쿼리를 자동 생성하므로 `@Query` 불필요 |
-| `WorkflowDefinitionSummaryRow.java` | `Long getDomainPackVersionId()` getter 추가 |
-| `WorkflowDefinitionSummary.java` | `Long domainPackVersionId` 필드 추가; `from()` 팩토리 업데이트 |
-| `GetWorkflowDefinitionListUseCase.java` | 호출 메서드명 업데이트 |
-| `GetWorkflowDefinitionListUseCaseTest.java` | `domainPackVersionId` 포함 stub 업데이트 |
-| `WorkflowDefinitionControllerTest.java` | `$[0].domainPackVersionId` 검증 추가 |
+| `WorkflowDefinitionRepository.java` | `findAllByDomainPackVersionId` → `findAllByDomainPackVersionIdOrderByWorkflowCodeAsc` rename (M1) |
+| `JpaWorkflowDefinitionRepository.java` | 동일 rename; Spring Data JPA 메서드명이 쿼리를 자동 생성하므로 `@Query` 불필요 (M1) |
+| `WorkflowDefinitionSummaryRow.java` | `Long getDomainPackVersionId()` getter 추가 (M2) |
+| `WorkflowDefinitionSummary.java` | `Long domainPackVersionId` 필드 추가; `from()` 팩토리 업데이트 (M2) |
+| `WorkflowDefinitionDetail.java` | `Long domainPackVersionId` 필드 추가; `from()` 팩토리 업데이트 (M3) |
+| `GetWorkflowDefinitionListUseCase.java` | 호출 메서드명 업데이트 (M1) |
+| `GetWorkflowDefinitionListUseCaseTest.java` | stub 메서드명 + `domainPackVersionId` stub·검증 업데이트 (M1·M2) |
+| `WorkflowDefinitionControllerTest.java` | `domainPackVersionId` 검증 추가 — 목록·단건 (M2·M3) |
 
 ### Key Code Sketches
 
 ```java
-// domain/repository/WorkflowDefinitionSummaryRow.java (변경)
+// domain/repository/WorkflowDefinitionSummaryRow.java (M2)
 public interface WorkflowDefinitionSummaryRow {
   Long getId();
   Long getDomainPackVersionId();  // 추가
@@ -183,7 +218,7 @@ public interface WorkflowDefinitionSummaryRow {
 ```
 
 ```java
-// application/WorkflowDefinitionSummary.java (변경)
+// application/WorkflowDefinitionSummary.java (M2)
 public record WorkflowDefinitionSummary(
     Long id,
     Long domainPackVersionId,  // 추가
@@ -211,22 +246,57 @@ public record WorkflowDefinitionSummary(
 ```
 
 ```java
-// domain/repository/WorkflowDefinitionRepository.java (변경)
+// application/WorkflowDefinitionDetail.java (M3)
+public record WorkflowDefinitionDetail(
+    Long id,
+    Long domainPackVersionId,  // 추가
+    String workflowCode,
+    String name,
+    String description,
+    @JsonRawValue String graphJson,
+    String initialState,
+    String terminalStatesJson,
+    String evidenceJson,
+    String metaJson,
+    OffsetDateTime createdAt,
+    OffsetDateTime updatedAt) {
+
+  public static WorkflowDefinitionDetail from(WorkflowDefinition entity) {
+    validateGraphJson(entity.getGraphJson());
+    return new WorkflowDefinitionDetail(
+        entity.getId(),
+        entity.getDomainPackVersionId(),  // 추가
+        entity.getWorkflowCode(),
+        entity.getName(),
+        entity.getDescription(),
+        entity.getGraphJson(),
+        entity.getInitialState(),
+        entity.getTerminalStatesJson(),
+        entity.getEvidenceJson(),
+        entity.getMetaJson(),
+        entity.getCreatedAt(),
+        entity.getUpdatedAt());
+  }
+  // validateGraphJson() 기존 유지
+}
+```
+
+```java
+// domain/repository/WorkflowDefinitionRepository.java (M1)
 // 기존: findAllByDomainPackVersionId(Long)
 // 변경:
 List<WorkflowDefinitionSummaryRow> findAllByDomainPackVersionIdOrderByWorkflowCodeAsc(Long domainPackVersionId);
 ```
 
 ```java
-// infrastructure/persistence/JpaWorkflowDefinitionRepository.java (변경)
-// 기존: findAllByDomainPackVersionId(Long)
-// 변경 (Spring Data JPA 메서드명 자동 쿼리 생성 활용):
+// infrastructure/persistence/JpaWorkflowDefinitionRepository.java (M1)
+// Spring Data JPA 메서드명 자동 쿼리 생성 활용 (@Query 불필요):
 @Override
 List<WorkflowDefinitionSummaryRow> findAllByDomainPackVersionIdOrderByWorkflowCodeAsc(Long domainPackVersionId);
 ```
 
 ```java
-// application/GetWorkflowDefinitionListUseCase.java (변경)
+// application/GetWorkflowDefinitionListUseCase.java (M1)
 public List<WorkflowDefinitionSummary> execute(GetWorkflowDefinitionListQuery query) {
   validator.validateWorkspaceAccess(query.workspaceId(), query.userId());
   validator.validateDomainPack(query.packId(), query.workspaceId());
@@ -250,9 +320,9 @@ public List<WorkflowDefinitionSummary> execute(GetWorkflowDefinitionListQuery qu
 
 | 업데이트 항목 | 내용 |
 |--------------|------|
-| stub 메서드명 | `findAllByDomainPackVersionId` → `findAllByDomainPackVersionIdOrderByWorkflowCodeAsc` |
-| `createSummaryRow()` | `getDomainPackVersionId()` getter 구현 추가 (`return VERSION_ID`) |
-| 결과 검증 | `result.get(0).domainPackVersionId()` 검증 추가 |
+| stub 메서드명 (M1) | `findAllByDomainPackVersionId` → `findAllByDomainPackVersionIdOrderByWorkflowCodeAsc` |
+| `createSummaryRow()` (M2) | `getDomainPackVersionId()` getter 구현 추가 (`return VERSION_ID`) |
+| 결과 검증 (M2) | `result.get(0).domainPackVersionId()` 검증 추가 |
 
 ### Controller 테스트 수정: `WorkflowDefinitionControllerTest.java`
 
@@ -260,13 +330,16 @@ public List<WorkflowDefinitionSummary> execute(GetWorkflowDefinitionListQuery qu
 
 | 업데이트 항목 | 내용 |
 |--------------|------|
-| `listWorkflows_returnsOk` stub | `WorkflowDefinitionSummary` 생성자에 `domainPackVersionId` 추가 |
-| `listWorkflows_returnsOk` 검증 | `jsonPath("$[0].domainPackVersionId").value(10)` 추가 |
+| 목록 stub (M2) | `WorkflowDefinitionSummary` 생성자에 `domainPackVersionId` 인수 추가 |
+| 목록 검증 (M2) | `jsonPath("$[0].domainPackVersionId").value(10)` 추가 |
+| 단건 stub (M3) | `WorkflowDefinitionDetail` 생성자에 `domainPackVersionId` 인수 추가 |
+| 단건 검증 (M3) | `jsonPath("$.domainPackVersionId").value(10)` 추가 |
 
 ### Test Checklist
 
-- [ ] 목록 응답에 `domainPackVersionId` 포함 확인
+- [ ] 목록 응답에 `domainPackVersionId` 포함 확인 (M2)
 - [ ] 목록 응답에 `graphJson` 미포함 확인 (`$[0].graphJson doesNotExist()`)
+- [ ] 단건 응답에 `domainPackVersionId` 포함 확인 (M3)
 - [ ] 빈 목록: workflow 없는 version → 빈 배열 반환
 - [ ] 403: 권한 없는 사용자
 - [ ] 401: 미인증
@@ -284,7 +357,6 @@ public List<WorkflowDefinitionSummary> execute(GetWorkflowDefinitionListQuery qu
 
 ## Additional Notes
 
-- 기존 `GetWorkflowDefinitionListUseCase`는 `validator.validateWorkspaceAccess()`, `validator.validateDomainPack()`, `validator.validateVersion()` 3개 개별 호출 방식을 사용한다. 이는 3211 패턴과 일치하며, 3212/3213의 `validateForWorkspacePackVersion()` 복합 호출 방식과 다르다. 기능상 동일하므로 이 스펙에서는 현재 구현을 그대로 유지한다.
-- 단건 조회(`WorkflowDefinitionDetail`)에 `domainPackVersionId`를 추가하는 작업은 **`.agent/specs/2215.md`** 범위에서 처리한다.
+- 기존 `GetWorkflowDefinitionListUseCase`는 `validator.validateWorkspaceAccess()`, `validator.validateDomainPack()`, `validator.validateVersion()` 3개 개별 호출 방식을 사용한다. 이는 3211 패턴과 일치하며 기능상 `validateForWorkspacePackVersion()` 복합 호출과 동일하므로 현재 구현을 유지한다.
 - graphJson 구조(nodes/edges) 및 유효성 규칙(V1~V6)은 `.agent/specs/226.md` 참조.
 - 3211(Slot), 3212(Policy), 3213(Risk)과 함께 Domain Pack 구성요소 조회 API 패밀리를 형성한다.


### PR DESCRIPTION
# [BE] 3.2.14 — Workflow(Node/Edge) 초안 목록 조회

> **Backlog**: 운영자가 특정 DomainPackVersion에 저장된 workflow 초안 목록을 조회하고 싶다 → 자동 생성 결과를 운영 가능한 형태로 다듬기 위해
> **Bounded Context**: `domainpack`
> **Branch**: `feature/3214-workflow-list-read`
> **연관 스펙**: 단건 조회 → `.agent/specs/2215.md`; 원본 설계 → `.agent/specs/226.md`

---

## 구현 상태 (Implementation Status)

`GetWorkflowDefinitionListUseCase`, `WorkflowDefinitionController(GET 목록)`, `WorkflowDefinitionSummary`, `WorkflowDefinitionSummaryRow`, 관련 테스트가 **이미 구현·완료**되어 있다.

이 스펙은 기존 구현을 3211~3213 컨벤션에 맞추기 위한 **최소 수정**만 정의한다.

| # | 수정 항목 | 대상 파일 |
|---|-----------|-----------|
| M1 | `workflowCode ASC` 정렬 추가 | `WorkflowDefinitionRepository`, `JpaWorkflowDefinitionRepository`, `GetWorkflowDefinitionListUseCase`, 관련 테스트 |
| M2 | `domainPackVersionId` 필드 추가 (목록 응답) | `WorkflowDefinitionSummaryRow`, `WorkflowDefinitionSummary`, 관련 테스트 |

> 단건 조회 응답(`WorkflowDefinitionDetail`)에 `domainPackVersionId`를 추가하는 작업은 **`.agent/specs/2215.md`** 범위에서 처리한다.

---

## Goal

특정 DomainPackVersion에 속한 `WorkflowDefinition` 초안 목록을 `workflowCode ASC` 순으로 조회하는 GET 엔드포인트를 제공한다. `graphJson`은 목록 응답에서 제외한다(성능).

---

## Sequence Diagram

```mermaid
sequenceDiagram
    actor c as Client
    participant ctrl as WorkflowDefinitionController
    participant uc as GetWorkflowDefinitionListUseCase
    participant validator as DomainPackValidator
    participant repo as WorkflowDefinitionRepository
    participant db as PostgreSQL

    c ->> ctrl: GET /api/v1/workspaces/{wsId}/domain-packs/{packId}/versions/{versionId}/workflows
    ctrl ->> uc: execute(GetWorkflowDefinitionListQuery)
    uc ->> validator: validateWorkspaceAccess(workspaceId, userId)
    validator -->> uc: ok
    uc ->> validator: validateDomainPack(packId, workspaceId)
    validator -->> uc: ok
    uc ->> validator: validateVersion(versionId, packId)
    validator -->> uc: ok
    uc ->> repo: findAllByDomainPackVersionIdOrderByWorkflowCodeAsc(versionId)
    repo ->> db: SELECT id, domain_pack_version_id, workflow_code, name, description,\ninitial_state, terminal_states_json, created_at, updated_at\nFROM pack.workflow_definition\nWHERE domain_pack_version_id = ?\nORDER BY workflow_code ASC
    db -->> repo: List<WorkflowDefinitionSummaryRow>
    repo -->> uc: List<WorkflowDefinitionSummaryRow>
    uc -->> ctrl: List<WorkflowDefinitionSummary>
    ctrl -->> c: 200 OK
```

---

## REST API

### Endpoint

| Method | Path | Description |
|--------|------|-------------|
| GET | `/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/workflows` | Workflow 초안 목록 조회 (`workflowCode ASC`, `graphJson` 제외) |

### Request

Path variables: `workspaceId`(Long), `packId`(Long), `versionId`(Long)  
Headers: `Authorization: Bearer {jwt-token}` (필수)  
Query parameters: 없음

### Response

**200 OK**

```json
[
  {
    "id": 1,
    "domainPackVersionId": 10,
    "workflowCode": "refund_flow",
    "name": "환불 플로우",
    "description": "환불 요청 처리 플로우",
    "initialState": "start",
    "terminalStatesJson": "[\"terminal\"]",
    "createdAt": "2026-04-14T10:00:00Z",
    "updatedAt": "2026-04-14T10:00:00Z"
  }
]
```

> `graphJson`은 포함하지 않는다 (최대 N개 workflow × 대용량 graphJson 방지).  
> workflow가 없는 version이면 빈 배열 `[]`를 반환한다.

**401 Unauthorized**

```json
{ "code": "UNAUTHORIZED", "message": "인증이 필요합니다." }
```

**403 Forbidden**

```json
{ "code": "FORBIDDEN", "message": "워크스페이스에 접근 권한이 없습니다." }
```

**404 Not Found**

```json
{ "code": "DOMAIN_PACK_WORKSPACE_NOT_FOUND", "message": "워크스페이스를 찾을 수 없습니다. id={workspaceId}" }
{ "code": "DOMAIN_PACK_NOT_FOUND",           "message": "DomainPack not found: {packId}" }
{ "code": "DOMAIN_PACK_VERSION_NOT_FOUND",   "message": "도메인 팩 버전을 찾을 수 없습니다. id={versionId}" }
```

---

## Class Design

### DDD Layered Structure

```mermaid
classDiagram
    class WorkflowDefinitionController {
        +listWorkflows(workspaceId, packId, versionId, auth): ResponseEntity~List~WorkflowDefinitionSummary~~
    }

    class GetWorkflowDefinitionListUseCase {
        +execute(GetWorkflowDefinitionListQuery): List~WorkflowDefinitionSummary~
    }

    class WorkflowDefinitionRepository {
        <<interface>>
        +findAllByDomainPackVersionIdOrderByWorkflowCodeAsc(Long): List~WorkflowDefinitionSummaryRow~
    }

    class WorkflowDefinitionSummaryRow {
        <<interface>>
        +getId(): Long
        +getDomainPackVersionId(): Long
        +getWorkflowCode(): String
        +getName(): String
        +getDescription(): String
        +getInitialState(): String
        +getTerminalStatesJson(): String
        +getCreatedAt(): OffsetDateTime
        +getUpdatedAt(): OffsetDateTime
    }

    WorkflowDefinitionController --> GetWorkflowDefinitionListUseCase
    GetWorkflowDefinitionListUseCase --> WorkflowDefinitionRepository
    GetWorkflowDefinitionListUseCase --> DomainPackValidator
```

### 수정 파일 (Modified Files)

| 파일 | 변경 내용 |
|------|-----------|
| `WorkflowDefinitionRepository.java` | `findAllByDomainPackVersionId` → `findAllByDomainPackVersionIdOrderByWorkflowCodeAsc` rename |
| `JpaWorkflowDefinitionRepository.java` | 동일 rename; Spring Data JPA 메서드명이 쿼리를 자동 생성하므로 `@Query` 불필요 |
| `WorkflowDefinitionSummaryRow.java` | `Long getDomainPackVersionId()` getter 추가 |
| `WorkflowDefinitionSummary.java` | `Long domainPackVersionId` 필드 추가; `from()` 팩토리 업데이트 |
| `GetWorkflowDefinitionListUseCase.java` | 호출 메서드명 업데이트 |
| `GetWorkflowDefinitionListUseCaseTest.java` | `domainPackVersionId` 포함 stub 업데이트 |
| `WorkflowDefinitionControllerTest.java` | `$[0].domainPackVersionId` 검증 추가 |

### Key Code Sketches

```java
// domain/repository/WorkflowDefinitionSummaryRow.java (변경)
public interface WorkflowDefinitionSummaryRow {
  Long getId();
  Long getDomainPackVersionId();  // 추가
  String getWorkflowCode();
  String getName();
  String getDescription();
  String getInitialState();
  String getTerminalStatesJson();
  OffsetDateTime getCreatedAt();
  OffsetDateTime getUpdatedAt();
}
```

```java
// application/WorkflowDefinitionSummary.java (변경)
public record WorkflowDefinitionSummary(
    Long id,
    Long domainPackVersionId,  // 추가
    String workflowCode,
    String name,
    String description,
    String initialState,
    String terminalStatesJson,
    OffsetDateTime createdAt,
    OffsetDateTime updatedAt) {

  public static WorkflowDefinitionSummary from(WorkflowDefinitionSummaryRow row) {
    return new WorkflowDefinitionSummary(
        row.getId(),
        row.getDomainPackVersionId(),  // 추가
        row.getWorkflowCode(),
        row.getName(),
        row.getDescription(),
        row.getInitialState(),
        row.getTerminalStatesJson(),
        row.getCreatedAt(),
        row.getUpdatedAt());
  }
}
```

```java
// domain/repository/WorkflowDefinitionRepository.java (변경)
// 기존: findAllByDomainPackVersionId(Long)
// 변경:
List<WorkflowDefinitionSummaryRow> findAllByDomainPackVersionIdOrderByWorkflowCodeAsc(Long domainPackVersionId);
```

```java
// infrastructure/persistence/JpaWorkflowDefinitionRepository.java (변경)
// 기존: findAllByDomainPackVersionId(Long)
// 변경 (Spring Data JPA 메서드명 자동 쿼리 생성 활용):
@Override
List<WorkflowDefinitionSummaryRow> findAllByDomainPackVersionIdOrderByWorkflowCodeAsc(Long domainPackVersionId);
```

```java
// application/GetWorkflowDefinitionListUseCase.java (변경)
public List<WorkflowDefinitionSummary> execute(GetWorkflowDefinitionListQuery query) {
  validator.validateWorkspaceAccess(query.workspaceId(), query.userId());
  validator.validateDomainPack(query.packId(), query.workspaceId());
  validator.validateVersion(query.versionId(), query.packId());

  return workflowDefinitionRepository
      .findAllByDomainPackVersionIdOrderByWorkflowCodeAsc(query.versionId())  // 변경
      .stream()
      .map(WorkflowDefinitionSummary::from)
      .toList();
}
```

---

## Tests

### UseCase 테스트 수정: `GetWorkflowDefinitionListUseCaseTest.java`

기존 5개 테스트 케이스 유지. 아래 항목만 업데이트한다.

| 업데이트 항목 | 내용 |
|--------------|------|
| stub 메서드명 | `findAllByDomainPackVersionId` → `findAllByDomainPackVersionIdOrderByWorkflowCodeAsc` |
| `createSummaryRow()` | `getDomainPackVersionId()` getter 구현 추가 (`return VERSION_ID`) |
| 결과 검증 | `result.get(0).domainPackVersionId()` 검증 추가 |

### Controller 테스트 수정: `WorkflowDefinitionControllerTest.java`

기존 6개 테스트 케이스 유지. 아래 항목만 업데이트한다.

| 업데이트 항목 | 내용 |
|--------------|------|
| `listWorkflows_returnsOk` stub | `WorkflowDefinitionSummary` 생성자에 `domainPackVersionId` 추가 |
| `listWorkflows_returnsOk` 검증 | `jsonPath("$[0].domainPackVersionId").value(10)` 추가 |

### Test Checklist

- [ ] 목록 응답에 `domainPackVersionId` 포함 확인
- [ ] 목록 응답에 `graphJson` 미포함 확인 (`$[0].graphJson doesNotExist()`)
- [ ] 빈 목록: workflow 없는 version → 빈 배열 반환
- [ ] 403: 권한 없는 사용자
- [ ] 401: 미인증
- [ ] 404: workspace/pack/version 미소속

---

## Database

변경 없음. `pack.workflow_definition` 테이블은 이미 존재한다.

`workflowCode ASC` 정렬은 기존 인덱스로 처리한다. 버전당 workflow 수가 50개를 초과하거나 목록 조회 p95가 500ms를 넘는 경우 복합 인덱스 추가를 검토한다.

---

## Additional Notes

- 기존 `GetWorkflowDefinitionListUseCase`는 `validator.validateWorkspaceAccess()`, `validator.validateDomainPack()`, `validator.validateVersion()` 3개 개별 호출 방식을 사용한다. 이는 3211 패턴과 일치하며, 3212/3213의 `validateForWorkspacePackVersion()` 복합 호출 방식과 다르다. 기능상 동일하므로 이 스펙에서는 현재 구현을 그대로 유지한다.
- 단건 조회(`WorkflowDefinitionDetail`)에 `domainPackVersionId`를 추가하는 작업은 **`.agent/specs/2215.md`** 범위에서 처리한다.
- graphJson 구조(nodes/edges) 및 유효성 규칙(V1~V6)은 `.agent/specs/226.md` 참조.
- 3211(Slot), 3212(Policy), 3213(Risk)과 함께 Domain Pack 구성요소 조회 API 패밀리를 형성한다.
---
# Uncertainty Register — 3214: Workflow(Node/Edge) 초안 목록 조회

**Branch**: `spec/3214`  
**Canonical Number**: `3214`  
**Spec**: `.agent/specs/3214.md`  
**Last Updated**: 2026-04-21

---

## Summary

| ID | Issue | Status | User Decision Required |
|----|-------|--------|----------------------|
| U1 | workflowCode ASC 정렬 추가 여부 | Confirmed | No (Yes로 결정됨) |
| U2 | WorkflowDefinitionSummary에 domainPackVersionId 포함 여부 | Confirmed | No (Yes로 결정됨) |
| U3 | WorkflowDefinitionDetail에 domainPackVersionId 포함 여부 | Confirmed (2215 범위) | No |
| U4 | validateForWorkspacePackVersion vs 개별 호출 방식 | Assumption | No |
| U5 | Node·Edge 전용 sub-resource 엔드포인트 필요 여부 | Confirmed | No (범위 외) |

---

## Items

### U1 — workflowCode ASC 정렬 추가

- **ID**: U1
- **Issue**: 기존 `findAllByDomainPackVersionId(Long)` 메서드는 정렬 없음. 3211/3212/3213은 코드 ASC 정렬 적용.
- **Status**: `Confirmed`
- **Why unresolved**: 기존 spec 226 구현에서 정렬이 누락되어 있었음.
- **Options**: (a) `workflowCode ASC` 추가 | (b) 현재 상태 유지
- **Recommended Default**: (a) workflowCode ASC 추가
- **Why recommended**: 3211/3212/3213 모두 코드 ASC 정렬 적용. 목록 응답 순서 결정론적 보장 필요.
- **User Decision Required**: No
- **User Question**: N/A
- **Execution Rule**: `findAllByDomainPackVersionIdOrderByWorkflowCodeAsc` rename 적용. Repository 도메인 인터페이스 + JPA 구현 모두 rename.
- **Affected Spec Section**: Class Design > 수정 파일, Tests

---

### U2 — WorkflowDefinitionSummary에 domainPackVersionId 포함

- **ID**: U2
- **Issue**: 기존 `WorkflowDefinitionSummary`에 `domainPackVersionId` 없음. 3211/3212/3213은 모두 포함.
- **Status**: `Confirmed`
- **Why unresolved**: spec 226 초기 설계 시 누락.
- **Options**: (a) 추가 | (b) 현재 상태 유지
- **Recommended Default**: (a) 추가
- **Why recommended**: 3211/3212/3213 컨벤션 일치. 클라이언트가 소속 버전을 응답으로 확인 가능.
- **User Decision Required**: No
- **User Question**: N/A
- **Execution Rule**: `WorkflowDefinitionSummaryRow`에 `getDomainPackVersionId()` 추가; `WorkflowDefinitionSummary` record에 `Long domainPackVersionId` 추가; `from()` 팩토리 업데이트; 관련 테스트 stub·assertion 업데이트.
- **Affected Spec Section**: Class Design > Key Code Sketches, Tests

---

### U3 — WorkflowDefinitionDetail에 domainPackVersionId 포함

- **ID**: U3
- **Issue**: 단건 조회 응답 `WorkflowDefinitionDetail`에도 `domainPackVersionId` 추가 요청됨.
- **Status**: `Confirmed`
- **Why unresolved**: 3214 스펙 작성 시 사용자 결정으로 확정.
- **Options**: N/A (확정)
- **Recommended Default**: N/A
- **Why recommended**: N/A
- **User Decision Required**: No
- **User Question**: N/A
- **Execution Rule**: `WorkflowDefinitionDetail` record에 `Long domainPackVersionId` 추가; `from(WorkflowDefinition entity)` 팩토리 업데이트. **이 변경은 `.agent/specs/2215.md` 구현 범위에서 처리한다.** 3214 구현 범위에 포함하지 않는다.
- **Affected Spec Section**: Additional Notes

---

### U4 — validateForWorkspacePackVersion vs 개별 호출 방식

- **ID**: U4
- **Issue**: 기존 `GetWorkflowDefinitionListUseCase`는 `validateWorkspaceAccess`, `validateDomainPack`, `validateVersion` 3개 개별 호출. 3212/3213은 `validateForWorkspacePackVersion()` 복합 호출.
- **Status**: `Assumption`
- **Why unresolved**: 기능상 동일하며 3211도 개별 호출 방식 사용. 변경 이유가 없음.
- **Options**: (a) 현재 개별 호출 유지 | (b) `validateForWorkspacePackVersion()` 복합 호출로 전환
- **Recommended Default**: (a) 현재 개별 호출 유지
- **Why recommended**: 3211과 일치. 기능 차이 없음. 불필요한 기존 코드 수정 방지.
- **User Decision Required**: No
- **User Question**: N/A
- **Execution Rule**:
  - Implementation Agent MUST NOT: 이를 변경 필수로 간주
  - Implementation Agent MAY: 팀 일관성 확보가 필요하다고 판단되면 `validateForWorkspacePackVersion()` 전환 가능 (단, 테스트 통과 확인 필수)
  - 이 항목은 3214 구현 범위에 포함하지 않는다
- **Affected Spec Section**: Additional Notes

---

### U5 — Node·Edge 전용 sub-resource 엔드포인트

- **ID**: U5
- **Issue**: Recon Report에서 3214 제목("Workflow Node / Edge")이 graphJson 내부 nodes·edges를 별도 엔드포인트로 노출하는 것을 의미할 수 있다는 가능성이 제기됨.
- **Status**: `Confirmed`
- **Why unresolved**: 제목의 "Node/Edge"가 WorkflowDefinition의 내부 구조를 설명하는 것인지, 별도 sub-resource를 의미하는지 불명확했음.
- **Options**: (a) WorkflowDefinition 목록 조회 (현 범위) | (b) nodes·edges 전용 엔드포인트 추가
- **Recommended Default**: (a) WorkflowDefinition 목록 조회
- **Why recommended**: 사용자 지시: "목록 조회로서의 컨벤션은 3211/3212/3213 참조". 이는 WorkflowDefinition 레벨 목록 조회임을 명확히 한다.
- **User Decision Required**: No
- **User Question**: N/A
- **Execution Rule**: Node·Edge 전용 엔드포인트는 3214 범위 외. 필요 시 별도 스펙으로 정의.
- **Affected Spec Section**: Goal

---

## Decision Log

| 날짜 | 결정자 | 항목 | 결정 |
|------|--------|------|------|
| 2026-04-21 | 사용자 | U1 | Yes — workflowCode ASC 정렬 추가 |
| 2026-04-21 | 사용자 | U2 | Yes — domainPackVersionId 추가 (목록 응답) |
| 2026-04-21 | 사용자 | U3 | Yes — domainPackVersionId 추가 (단건 응답, spec 2215 범위) |
| 2026-04-21 | Decision Agent | U4 | Assumption 채택 — 개별 호출 유지 (기능 동일, 3211 일치) |
| 2026-04-21 | 사용자 | U5 | 범위 외 확정 — WorkflowDefinition 목록 조회만 처리 |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 특정 도메인 팩 버전의 워크플로우 초안 목록을 조회하는 새 GET 엔드포인트 추가
  * 워크플로우 목록을 워크플로우 코드 기준 오름차순으로 정렬
  * 목록 응답에서는 상세 그래프 데이터를 제외해 성능 개선
  * 단일 워크플로우 응답에 도메인 팩 버전 식별자(domainPackVersionId) 포함

* **문서**
  * 엔드포인트 동작, 빈 배열 반환 및 표준 오류 응답(권한/미존재/서버 오류 등)을 명세 문서로 문서화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->