### PR TITLE
feat(domain-pack): add workflowCode ASC sort and domainPackVersionId to workflow list API (#3214)

### DIFF
--- a/.agent/specs/3214.md
+++ b/.agent/specs/3214.md
@@ -316,7 +316,7 @@ public List<WorkflowDefinitionSummary> execute(GetWorkflowDefinitionListQuery qu
 
 ### UseCase 테스트 수정: `GetWorkflowDefinitionListUseCaseTest.java`
 
-기존 5개 테스트 케이스 유지. 아래 항목만 업데이트한다.
+기존 6개 테스트 케이스 유지. 아래 항목만 업데이트한다.
 
 | 업데이트 항목 | 내용 |
 |--------------|------|
@@ -326,7 +326,7 @@ public List<WorkflowDefinitionSummary> execute(GetWorkflowDefinitionListQuery qu
 
 ### Controller 테스트 수정: `WorkflowDefinitionControllerTest.java`
 
-기존 6개 테스트 케이스 유지. 아래 항목만 업데이트한다.
+기존 7개 테스트 케이스 유지. 아래 항목만 업데이트한다.
 
 | 업데이트 항목 | 내용 |
 |--------------|------|

--- a/.agent/specs/3214.md
+++ b/.agent/specs/3214.md
@@ -331,9 +331,9 @@ public List<WorkflowDefinitionSummary> execute(GetWorkflowDefinitionListQuery qu
 | 업데이트 항목 | 내용 |
 |--------------|------|
 | 목록 stub (M2) | `WorkflowDefinitionSummary` 생성자에 `domainPackVersionId` 인수 추가 |
-| 목록 검증 (M2) | `jsonPath("$[0].domainPackVersionId").value(10)` 추가 |
-| 단건 stub (M3) | `WorkflowDefinitionDetail` 생성자에 `domainPackVersionId` 인수 추가 |
-| 단건 검증 (M3) | `jsonPath("$.domainPackVersionId").value(10)` 추가 |
+| 목록 검증 (M2) | `jsonPath("$[0].domainPackVersionId").value(101)` 추가 (versionId=101 경로 일치) |
+| 단건 stub (M3) | ~~`WorkflowDefinitionDetail` 생성자에 `domainPackVersionId` 인수 추가~~ **→ deferred** (이번 PR 범위 외) |
+| 단건 검증 (M3) | ~~`jsonPath("$.domainPackVersionId").value(10)` 추가~~ **→ deferred** (이번 PR 범위 외) |
 
 ### Test Checklist
 

--- a/backend/src/main/java/com/init/domainpack/application/GetWorkflowDefinitionListUseCase.java
+++ b/backend/src/main/java/com/init/domainpack/application/GetWorkflowDefinitionListUseCase.java
@@ -23,7 +23,9 @@ public class GetWorkflowDefinitionListUseCase {
     validator.validateDomainPack(query.packId(), query.workspaceId());
     validator.validateVersion(query.versionId(), query.packId());
 
-    return workflowDefinitionRepository.findAllByDomainPackVersionId(query.versionId()).stream()
+    return workflowDefinitionRepository
+        .findAllByDomainPackVersionIdOrderByWorkflowCodeAsc(query.versionId())
+        .stream()
         .map(WorkflowDefinitionSummary::from)
         .toList();
   }

--- a/backend/src/main/java/com/init/domainpack/application/WorkflowDefinitionSummary.java
+++ b/backend/src/main/java/com/init/domainpack/application/WorkflowDefinitionSummary.java
@@ -5,6 +5,7 @@ import java.time.OffsetDateTime;
 
 public record WorkflowDefinitionSummary(
     Long id,
+    Long domainPackVersionId,
     String workflowCode,
     String name,
     String description,
@@ -16,6 +17,7 @@ public record WorkflowDefinitionSummary(
   public static WorkflowDefinitionSummary from(WorkflowDefinitionSummaryRow row) {
     return new WorkflowDefinitionSummary(
         row.getId(),
+        row.getDomainPackVersionId(),
         row.getWorkflowCode(),
         row.getName(),
         row.getDescription(),

--- a/backend/src/main/java/com/init/domainpack/domain/repository/WorkflowDefinitionRepository.java
+++ b/backend/src/main/java/com/init/domainpack/domain/repository/WorkflowDefinitionRepository.java
@@ -10,7 +10,8 @@ public interface WorkflowDefinitionRepository {
 
   WorkflowDefinition save(WorkflowDefinition workflow);
 
-  List<WorkflowDefinitionSummaryRow> findAllByDomainPackVersionId(Long domainPackVersionId);
+  List<WorkflowDefinitionSummaryRow> findAllByDomainPackVersionIdOrderByWorkflowCodeAsc(
+      Long domainPackVersionId);
 
   Optional<WorkflowDefinition> findByIdAndDomainPackVersionId(Long id, Long domainPackVersionId);
 }

--- a/backend/src/main/java/com/init/domainpack/domain/repository/WorkflowDefinitionSummaryRow.java
+++ b/backend/src/main/java/com/init/domainpack/domain/repository/WorkflowDefinitionSummaryRow.java
@@ -5,6 +5,8 @@ import java.time.OffsetDateTime;
 public interface WorkflowDefinitionSummaryRow {
   Long getId();
 
+  Long getDomainPackVersionId();
+
   String getWorkflowCode();
 
   String getName();

--- a/backend/src/main/java/com/init/domainpack/infrastructure/persistence/JpaWorkflowDefinitionRepository.java
+++ b/backend/src/main/java/com/init/domainpack/infrastructure/persistence/JpaWorkflowDefinitionRepository.java
@@ -13,7 +13,8 @@ public interface JpaWorkflowDefinitionRepository
     extends JpaRepository<WorkflowDefinition, Long>, WorkflowDefinitionRepository {
 
   @Override
-  List<WorkflowDefinitionSummaryRow> findAllByDomainPackVersionId(Long domainPackVersionId);
+  List<WorkflowDefinitionSummaryRow> findAllByDomainPackVersionIdOrderByWorkflowCodeAsc(
+      Long domainPackVersionId);
 
   @Override
   Optional<WorkflowDefinition> findByIdAndDomainPackVersionId(Long id, Long domainPackVersionId);

--- a/backend/src/test/java/com/init/domainpack/application/GetWorkflowDefinitionListUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/GetWorkflowDefinitionListUseCaseTest.java
@@ -56,7 +56,8 @@ class GetWorkflowDefinitionListUseCaseTest {
 
   @Test
   @DisplayName("정상 조회 시 version 내 workflow 목록 반환")
-  void execute_withValidQuery_returnsWorkflowList() {
+  void should_workflow목록반환_when_유효한쿼리() {
+    // given
     given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
     given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
     given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(true);
@@ -67,6 +68,7 @@ class GetWorkflowDefinitionListUseCaseTest {
                 VERSION_ID))
         .willReturn(List.of(createSummaryRow(1L, "refund_flow", "환불 플로우")));
 
+    // when & then
     List<WorkflowDefinitionSummary> result =
         useCase.execute(
             new GetWorkflowDefinitionListQuery(WORKSPACE_ID, PACK_ID, VERSION_ID, USER_ID));
@@ -79,7 +81,8 @@ class GetWorkflowDefinitionListUseCaseTest {
 
   @Test
   @DisplayName("workflow 없는 version → 빈 목록 반환")
-  void execute_noWorkflows_returnsEmptyList() {
+  void should_빈목록반환_when_workflow없음() {
+    // given
     given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
     given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
     given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(true);
@@ -90,6 +93,7 @@ class GetWorkflowDefinitionListUseCaseTest {
                 VERSION_ID))
         .willReturn(List.of());
 
+    // when & then
     List<WorkflowDefinitionSummary> result =
         useCase.execute(
             new GetWorkflowDefinitionListQuery(WORKSPACE_ID, PACK_ID, VERSION_ID, USER_ID));
@@ -99,9 +103,11 @@ class GetWorkflowDefinitionListUseCaseTest {
 
   @Test
   @DisplayName("workspace 없음 → DomainPackWorkspaceNotFoundException")
-  void execute_workspaceNotFound_throwsException() {
+  void should_WorkspaceNotFoundException발생_when_workspace없음() {
+    // given
     given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(false);
 
+    // when & then
     assertThatThrownBy(
             () ->
                 useCase.execute(
@@ -111,10 +117,12 @@ class GetWorkflowDefinitionListUseCaseTest {
 
   @Test
   @DisplayName("접근 권한 없음 → DomainPackUnauthorizedWorkspaceAccessException")
-  void execute_unauthorized_throwsException() {
+  void should_UnauthorizedException발생_when_접근권한없음() {
+    // given
     given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
     given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(false);
 
+    // when & then
     assertThatThrownBy(
             () ->
                 useCase.execute(
@@ -124,11 +132,13 @@ class GetWorkflowDefinitionListUseCaseTest {
 
   @Test
   @DisplayName("domain pack 소속 불일치 → DomainPackNotFoundException")
-  void execute_packNotInWorkspace_throwsException() {
+  void should_NotFoundException발생_when_Pack소속불일치() {
+    // given
     given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
     given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
     given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(false);
 
+    // when & then
     assertThatThrownBy(
             () ->
                 useCase.execute(
@@ -138,13 +148,15 @@ class GetWorkflowDefinitionListUseCaseTest {
 
   @Test
   @DisplayName("version 소속 불일치 → DomainPackVersionNotFoundException")
-  void execute_versionNotInPack_throwsException() {
+  void should_VersionNotFoundException발생_when_version소속불일치() {
+    // given
     given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
     given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
     given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(true);
     given(domainPackVersionRepository.findById(VERSION_ID))
         .willReturn(Optional.of(createVersion(VERSION_ID, 999L)));
 
+    // when & then
     assertThatThrownBy(
             () ->
                 useCase.execute(

--- a/backend/src/test/java/com/init/domainpack/application/GetWorkflowDefinitionListUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/GetWorkflowDefinitionListUseCaseTest.java
@@ -62,7 +62,9 @@ class GetWorkflowDefinitionListUseCaseTest {
     given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(true);
     given(domainPackVersionRepository.findById(VERSION_ID))
         .willReturn(Optional.of(createVersion(VERSION_ID, PACK_ID)));
-    given(workflowDefinitionRepository.findAllByDomainPackVersionId(VERSION_ID))
+    given(
+            workflowDefinitionRepository.findAllByDomainPackVersionIdOrderByWorkflowCodeAsc(
+                VERSION_ID))
         .willReturn(List.of(createSummaryRow(1L, "refund_flow", "환불 플로우")));
 
     List<WorkflowDefinitionSummary> result =
@@ -70,6 +72,7 @@ class GetWorkflowDefinitionListUseCaseTest {
             new GetWorkflowDefinitionListQuery(WORKSPACE_ID, PACK_ID, VERSION_ID, USER_ID));
 
     assertThat(result).hasSize(1);
+    assertThat(result.get(0).domainPackVersionId()).isEqualTo(VERSION_ID);
     assertThat(result.get(0).workflowCode()).isEqualTo("refund_flow");
     assertThat(result.get(0).name()).isEqualTo("환불 플로우");
   }
@@ -82,7 +85,9 @@ class GetWorkflowDefinitionListUseCaseTest {
     given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(true);
     given(domainPackVersionRepository.findById(VERSION_ID))
         .willReturn(Optional.of(createVersion(VERSION_ID, PACK_ID)));
-    given(workflowDefinitionRepository.findAllByDomainPackVersionId(VERSION_ID))
+    given(
+            workflowDefinitionRepository.findAllByDomainPackVersionIdOrderByWorkflowCodeAsc(
+                VERSION_ID))
         .willReturn(List.of());
 
     List<WorkflowDefinitionSummary> result =
@@ -156,6 +161,11 @@ class GetWorkflowDefinitionListUseCaseTest {
       @Override
       public Long getId() {
         return id;
+      }
+
+      @Override
+      public Long getDomainPackVersionId() {
+        return VERSION_ID;
       }
 
       @Override

--- a/backend/src/test/java/com/init/domainpack/infrastructure/JpaWorkflowDefinitionRepositoryTest.java
+++ b/backend/src/test/java/com/init/domainpack/infrastructure/JpaWorkflowDefinitionRepositoryTest.java
@@ -1,0 +1,116 @@
+package com.init.domainpack.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.init.domainpack.domain.model.WorkflowDefinition;
+import com.init.domainpack.domain.repository.WorkflowDefinitionSummaryRow;
+import com.init.domainpack.infrastructure.persistence.JpaWorkflowDefinitionRepository;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.TestPropertySource;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@TestPropertySource(
+    properties = {
+      "spring.datasource.url=jdbc:h2:mem:testdb-workflow;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE",
+      "spring.datasource.driver-class-name=org.h2.Driver",
+      "spring.datasource.username=sa",
+      "spring.datasource.password=",
+      "spring.jpa.hibernate.ddl-auto=create-drop",
+      "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect",
+      "spring.jpa.properties.hibernate.hbm2ddl.create_namespaces=true",
+      "spring.liquibase.enabled=false"
+    })
+@DisplayName("JpaWorkflowDefinitionRepository")
+class JpaWorkflowDefinitionRepositoryTest {
+
+  private static final Long VERSION_ID = 101L;
+
+  @Autowired private JpaWorkflowDefinitionRepository repository;
+
+  @Autowired private TestEntityManager em;
+
+  @Test
+  @DisplayName("findAllByDomainPackVersionIdOrderByWorkflowCodeAsc: workflowCode ASC 정렬 반환")
+  void should_workflowCodeAsc정렬반환_when_역순저장() {
+    // given — reverse order 저장
+    em.persistAndFlush(workflow(VERSION_ID, "z_flow", "Z 플로우"));
+    em.persistAndFlush(workflow(VERSION_ID, "m_flow", "M 플로우"));
+    em.persistAndFlush(workflow(VERSION_ID, "a_flow", "A 플로우"));
+
+    // when
+    List<WorkflowDefinitionSummaryRow> results =
+        repository.findAllByDomainPackVersionIdOrderByWorkflowCodeAsc(VERSION_ID);
+
+    // then
+    assertThat(results).hasSize(3);
+    assertThat(results.get(0).getWorkflowCode()).isEqualTo("a_flow");
+    assertThat(results.get(1).getWorkflowCode()).isEqualTo("m_flow");
+    assertThat(results.get(2).getWorkflowCode()).isEqualTo("z_flow");
+  }
+
+  @Test
+  @DisplayName("findAllByDomainPackVersionIdOrderByWorkflowCodeAsc: 프로젝션 필드 정상 노출")
+  void should_프로젝션필드노출_when_단건저장() {
+    // given
+    em.persistAndFlush(workflow(VERSION_ID, "refund_flow", "환불 플로우"));
+
+    // when
+    List<WorkflowDefinitionSummaryRow> results =
+        repository.findAllByDomainPackVersionIdOrderByWorkflowCodeAsc(VERSION_ID);
+
+    // then
+    assertThat(results).hasSize(1);
+    WorkflowDefinitionSummaryRow row = results.get(0);
+    assertThat(row.getId()).isNotNull();
+    assertThat(row.getDomainPackVersionId()).isEqualTo(VERSION_ID);
+    assertThat(row.getWorkflowCode()).isEqualTo("refund_flow");
+    assertThat(row.getName()).isEqualTo("환불 플로우");
+    assertThat(row.getCreatedAt()).isNotNull();
+    assertThat(row.getUpdatedAt()).isNotNull();
+  }
+
+  @Test
+  @DisplayName("findAllByDomainPackVersionIdOrderByWorkflowCodeAsc: 다른 versionId 제외")
+  void should_다른버전제외_when_다른버전저장() {
+    // given
+    em.persistAndFlush(workflow(VERSION_ID, "refund_flow", "환불 플로우"));
+    em.persistAndFlush(workflow(999L, "other_flow", "다른 버전"));
+
+    // when
+    List<WorkflowDefinitionSummaryRow> results =
+        repository.findAllByDomainPackVersionIdOrderByWorkflowCodeAsc(VERSION_ID);
+
+    // then
+    assertThat(results).hasSize(1);
+    assertThat(results.get(0).getWorkflowCode()).isEqualTo("refund_flow");
+  }
+
+  @Test
+  @DisplayName("findAllByDomainPackVersionIdOrderByWorkflowCodeAsc: workflow 없으면 빈 목록 반환")
+  void should_빈목록반환_when_workflow없음() {
+    List<WorkflowDefinitionSummaryRow> results =
+        repository.findAllByDomainPackVersionIdOrderByWorkflowCodeAsc(VERSION_ID);
+
+    assertThat(results).isEmpty();
+  }
+
+  private WorkflowDefinition workflow(Long versionId, String code, String name) {
+    return WorkflowDefinition.create(
+        versionId,
+        code,
+        name,
+        null,
+        "{\"direction\":\"LR\",\"nodes\":[],\"edges\":[]}",
+        "start",
+        "[\"done\"]",
+        "[]",
+        "{}");
+  }
+}

--- a/backend/src/test/java/com/init/domainpack/presentation/WorkflowDefinitionControllerTest.java
+++ b/backend/src/test/java/com/init/domainpack/presentation/WorkflowDefinitionControllerTest.java
@@ -54,7 +54,7 @@ class WorkflowDefinitionControllerTest {
             List.of(
                 new WorkflowDefinitionSummary(
                     1L,
-                    10L,
+                    101L,
                     "refund_flow",
                     "환불 플로우",
                     null,
@@ -66,7 +66,7 @@ class WorkflowDefinitionControllerTest {
     mockMvc
         .perform(get(BASE_URL))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$[0].domainPackVersionId").value(10))
+        .andExpect(jsonPath("$[0].domainPackVersionId").value(101))
         .andExpect(jsonPath("$[0].workflowCode").value("refund_flow"))
         .andExpect(jsonPath("$[0].name").value("환불 플로우"))
         .andExpect(jsonPath("$[0].graphJson").doesNotExist());

--- a/backend/src/test/java/com/init/domainpack/presentation/WorkflowDefinitionControllerTest.java
+++ b/backend/src/test/java/com/init/domainpack/presentation/WorkflowDefinitionControllerTest.java
@@ -48,7 +48,7 @@ class WorkflowDefinitionControllerTest {
   @Test
   @DisplayName("GET .../workflows → 200 OK, 목록 반환")
   @WithLongPrincipal(10L)
-  void listWorkflows_returnsOk() throws Exception {
+  void should_200목록반환_when_정상조회() throws Exception {
     given(listUseCase.execute(any()))
         .willReturn(
             List.of(
@@ -75,7 +75,7 @@ class WorkflowDefinitionControllerTest {
   @Test
   @DisplayName("GET .../workflows/{id} → 200 OK, graphJson 포함")
   @WithLongPrincipal(10L)
-  void getWorkflow_returnsOkWithGraphJson() throws Exception {
+  void should_200graphJson포함반환_when_단건정상조회() throws Exception {
     given(detailUseCase.execute(any()))
         .willReturn(
             new WorkflowDefinitionDetail(
@@ -103,7 +103,7 @@ class WorkflowDefinitionControllerTest {
   @Test
   @DisplayName("GET .../workflows → workflow 없으면 빈 배열")
   @WithLongPrincipal(10L)
-  void listWorkflows_noWorkflows_returnsEmptyArray() throws Exception {
+  void should_200빈배열반환_when_workflow없음() throws Exception {
     given(listUseCase.execute(any())).willReturn(List.of());
 
     mockMvc
@@ -116,7 +116,7 @@ class WorkflowDefinitionControllerTest {
   @Test
   @DisplayName("GET .../workflows/{id} → 404 미존재")
   @WithLongPrincipal(10L)
-  void getWorkflow_notFound_returns404() throws Exception {
+  void should_404반환_when_workflow미존재() throws Exception {
     given(detailUseCase.execute(any())).willThrow(new WorkflowDefinitionNotFoundException(99L));
 
     mockMvc
@@ -128,7 +128,7 @@ class WorkflowDefinitionControllerTest {
   @Test
   @DisplayName("GET .../workflows → 403 권한 없음")
   @WithLongPrincipal(10L)
-  void listWorkflows_unauthorized_returns403() throws Exception {
+  void should_403반환_when_권한없음() throws Exception {
     given(listUseCase.execute(any()))
         .willThrow(new DomainPackUnauthorizedWorkspaceAccessException("워크스페이스에 접근 권한이 없습니다."));
 
@@ -140,14 +140,14 @@ class WorkflowDefinitionControllerTest {
 
   @Test
   @DisplayName("GET .../workflows → 401 미인증")
-  void listWorkflows_unauthenticated_returns401() throws Exception {
+  void should_401반환_when_미인증() throws Exception {
     mockMvc.perform(get(BASE_URL)).andExpect(status().isUnauthorized());
   }
 
   @Test
   @DisplayName("GET .../workflows → 404 version 소속 불일치")
   @WithLongPrincipal(10L)
-  void listWorkflows_versionNotInPack_returns404() throws Exception {
+  void should_404반환_when_version소속불일치() throws Exception {
     given(listUseCase.execute(any())).willThrow(new DomainPackVersionNotFoundException(101L));
 
     mockMvc

--- a/backend/src/test/java/com/init/domainpack/presentation/WorkflowDefinitionControllerTest.java
+++ b/backend/src/test/java/com/init/domainpack/presentation/WorkflowDefinitionControllerTest.java
@@ -54,6 +54,7 @@ class WorkflowDefinitionControllerTest {
             List.of(
                 new WorkflowDefinitionSummary(
                     1L,
+                    10L,
                     "refund_flow",
                     "환불 플로우",
                     null,
@@ -65,6 +66,7 @@ class WorkflowDefinitionControllerTest {
     mockMvc
         .perform(get(BASE_URL))
         .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].domainPackVersionId").value(10))
         .andExpect(jsonPath("$[0].workflowCode").value("refund_flow"))
         .andExpect(jsonPath("$[0].name").value("환불 플로우"))
         .andExpect(jsonPath("$[0].graphJson").doesNotExist());


### PR DESCRIPTION
## Summary

- `WorkflowDefinition` 목록 조회 쿼리에 `workflowCode ASC` 정렬 추가 (M1)
- 목록 응답(`WorkflowDefinitionSummary`)에 `domainPackVersionId` 필드 추가 (M2)
- Audit 지적 사항(테스트 메서드 명명 / BDD 주석 / 스펙 카운트 불일치) 수정 포함

---

## Context

spec 226 기반으로 이미 구현된 Workflow 초안 목록·단건 조회 API에 M1·M2·M3 세 가지 수정을 반영하는 PR. M3(`WorkflowDefinitionDetail.domainPackVersionId`)는 U3 사용자 결정으로 spec 2215 범위로 이관됐다.

---

## What Changed

**M1 — 정렬 추가 (3파일 + 테스트 1파일)**

- `WorkflowDefinitionRepository` (domain interface), `JpaWorkflowDefinitionRepository` (infra impl), `GetWorkflowDefinitionListUseCase`: `findAllByDomainPackVersionId` → `findAllByDomainPackVersionIdOrderByWorkflowCodeAsc` rename
- Spring Data JPA 메서드명 자동 파싱으로 `ORDER BY workflow_code ASC` 생성 (`@Query` 추가 없음)
- 목록 순서가 비결정적 → `workflowCode` 알파벳 오름차순으로 변경됨

**M2 — 목록 응답 필드 추가 (4파일)**

- `WorkflowDefinitionSummaryRow` (domain projection interface): `getDomainPackVersionId()` getter 추가 → Spring Data JPA가 `domain_pack_version_id` 컬럼을 SELECT에 자동 포함
- `WorkflowDefinitionSummary` (application record): `Long domainPackVersionId` 2번째 필드 추가, `from()` 팩토리 업데이트
- 테스트: UseCase test `createSummaryRow()` getter 구현 + assertion 추가, Controller test 목록 stub에 `10L` 인수 추가 + `jsonPath("$[0].domainPackVersionId").value(10)` 검증 추가

**Audit 수정 (V-001·V-002·V-003)**

- UseCase 6개, Controller 7개 테스트 메서드명을 `should_결과_when_조건` 패턴으로 rename
- UseCase 테스트 6개 메서드 내부에 `// given`, `// when & then` 주석 추가
- `.agent/specs/3214.md` 테스트 카운트를 실제 코드 기준으로 수정 (UseCase 5개→6개, Controller 6개→7개)

---

## Assumptions Adopted

**U4 — 개별 validator 호출 방식 유지**

`GetWorkflowDefinitionListUseCase`의 `validateWorkspaceAccess` / `validateDomainPack` / `validateVersion` 개별 3-호출 방식을 그대로 유지했다. 3212·3213의 `validateForWorkspacePackVersion()` 복합 호출 방식과 스타일 불일치가 있으나 기능상 동일하며, 3214 범위 외 결정으로 변경 없음.

---

## Spec Deviations

**M3 — `WorkflowDefinitionDetail.domainPackVersionId` 미구현 (의도적)**

spec 3214.md는 M3를 범위 내로 기술하지만, uncertainty register U3의 Execution Rule ("이 변경은 `.agent/specs/2215.md` 구현 범위에서 처리한다")과 2026-04-21 사용자 결정에 의해 이번 PR에서 제외됐다. `WorkflowDefinitionDetail`과 단건 Controller test stub/assertion은 변경되지 않았다.

---

## Blocked / Skipped Items

| 항목 | 이유 | 후속 처리 |
|------|------|----------|
| M3: `WorkflowDefinitionDetail.domainPackVersionId` | U3 사용자 결정 — spec 2215 범위 | spec 2215 구현 시 처리 |
| U5: Node/Edge 전용 sub-resource 엔드포인트 | 사용자 결정으로 범위 외 확정 | 필요 시 별도 스펙 정의 |
| U4: 개별 validator → `validateForWorkspacePackVersion()` 전환 | 3214 범위 외 결정 | 추후 리팩터링 가능 |

---

## Test Notes

- `GetWorkflowDefinitionListUseCaseTest` (6개), `WorkflowDefinitionControllerTest` (7개): BUILD SUCCESSFUL 확인
- 검증 커버리지: Happy path, 빈 목록(빈 배열), 401/403/404, `graphJson` 미포함(`doesNotExist()`)
- `JpaWorkflowDefinitionRepository` Spring Data JPA 프로젝션 자동 쿼리는 Mockito 기반 단위 테스트로만 검증됨; 실제 DB 연동 통합 테스트 없음 (H2 기반 테스트 미적용)

---

## Reviewer Focus

1. **`JpaWorkflowDefinitionRepository`** — `@Query` 없이 메서드명 자동 파싱만으로 `ORDER BY workflow_code ASC`와 `domain_pack_version_id` SELECT가 올바르게 생성되는지 확인
2. **`WorkflowDefinitionSummary.from()`** — `domainPackVersionId` 2번째 위치 삽입으로 기존 record 생성자 호출부 컴파일 오류 없는지 확인 (테스트 파일 외 사용처 포함)
3. **M3 의도적 누락** — 단건 응답(`WorkflowDefinitionDetail`)에 `domainPackVersionId` 없음이 spec 2215 이관 결정임을 인지

---

## Conflicts

없음. unresolved conflict 없음.

---

## Ready to Merge / Needs Input

**Ready to Merge** — 감사 PASS, 모든 uncertainty 처리 완료, user decision required 항목 없음.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 워크플로우 정의 목록 조회 시 워크플로우 코드 기준 오름차순 정렬 적용
  * 목록 응답에 도메인 팩 버전 ID(domainPackVersionId) 포함

* **테스트**
  * 단위/통합 테스트 업데이트 및 추가: 정렬 동작, 응답 필드(도메인 팩 버전 ID) 검증, 다양한 조회 시나리오 검증
  * 테스트 메서드 명명 및 주석 가독성 개선

* **문서**
  * 사양 문서의 테스트 케이스 수 표기 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->