### PR TITLE
docs(spec): Transition Condition 단건 조회 + graphJson 검증 규칙 추가 / 

### DIFF
--- a/.agent/specs/2217.md
+++ b/.agent/specs/2217.md
@@ -1,0 +1,298 @@
+# [BE] 2.2.17 — Transition Condition 초안 단건 조회
+
+## Goal
+
+`workflow_definition.graph_json`의 edge 구조에 고유 `id` 필드를 추가하고, 특정 워크플로우에 속한 Transition(graphJson edge) 초안 단건을 조회하는 READ 전용 엔드포인트를 제공한다.
+"Action" 시각화는 이 스펙 범위 밖이며, FE는 policy 단건 조회 API(spec 2211)를 별도로 조합해 사용한다.
+
+---
+
+## graphJson Edge Schema 변경
+
+### 기존
+
+```json
+{
+  "edges": [
+    { "from": "check_refund_policy", "to": "answer_refund", "label": "eligible" },
+    { "from": "check_refund_policy", "to": "handoff_agent", "label": "not_eligible" }
+  ]
+}
+```
+
+### 변경 후 (id 필드 추가)
+
+```json
+{
+  "edges": [
+    { "id": "e_check_to_answer",  "from": "check_refund_policy", "to": "answer_refund",  "label": "eligible"     },
+    { "id": "e_check_to_handoff", "from": "check_refund_policy", "to": "handoff_agent",  "label": "not_eligible" },
+    { "id": "e_answer_to_end",    "from": "answer_refund",       "to": "terminal"                               }
+  ]
+}
+```
+
+- `id`: 필수, 비어있지 않은 문자열, workflow 내 모든 edge 간 고유해야 함.
+- `label`: DECISION 노드 발신 edge에 필수 (기존 V6 규칙 유지). 나머지 edge는 선택.
+
+### 신규 Validation Rule — V7 (write-time)
+
+| # | 규칙 | 위반 시 에러 코드 |
+|---|------|-----------------|
+| V7 | 모든 edge에 `id` 필드가 존재하며 비어있지 않음 | `WORKFLOW_EDGE_ID_MISSING` |
+| V7 | 모든 edge `id`가 workflow 내에서 고유함 | `WORKFLOW_EDGE_ID_DUPLICATE` |
+
+**V7 적용 write path:**
+- `CreateDomainPackDraftUseCase` — spec 231 구현 시 함께 적용한다.
+- `UpdateWorkflowUseCase` — 이미 구현된 코드에 V7 검증을 추가한다.
+
+> 이 스펙은 V7을 **정의**한다. 코드 강제는 write-path 담당 spec(231) 및 UpdateWorkflow 수정 시 적용한다.
+
+---
+
+## Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    actor c as Client
+    participant ctrl as WorkflowDefinitionController
+    participant uc as GetWorkflowTransitionUseCase
+    participant validator as DomainPackValidator
+    participant repo as WorkflowDefinitionRepository
+    participant db as PostgreSQL
+
+    c ->> ctrl: GET /api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/workflows/{workflowId}/transitions/{transitionId}
+    ctrl ->> uc: execute(GetWorkflowTransitionQuery)
+    uc ->> validator: validateWorkspaceAccess(workspaceId, userId)
+    validator -->> uc: ok
+    uc ->> validator: validateDomainPack(packId, workspaceId)
+    validator -->> uc: ok
+    uc ->> validator: validateVersion(versionId, packId)
+    validator -->> uc: ok
+    uc ->> repo: findByIdAndDomainPackVersionId(workflowId, versionId)
+    repo ->> db: SELECT * FROM pack.workflow_definition WHERE id = ? AND domain_pack_version_id = ?
+    db -->> repo: row
+    repo -->> uc: Optional<WorkflowDefinition>
+    uc ->> uc: parse graphJson → find edge where id == transitionId
+    uc -->> ctrl: WorkflowTransitionDetail
+    ctrl -->> c: 200 OK
+```
+
+---
+
+## REST API
+
+### Endpoint
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/workflows/{workflowId}/transitions/{transitionId}` | Transition 초안 단건 조회 |
+
+### Request
+
+Path variables:
+- `workspaceId`: Long
+- `packId`: Long
+- `versionId`: Long
+- `workflowId`: Long
+- `transitionId`: String (edge의 `id` 필드 값)
+
+Headers:
+- `Authorization: Bearer {jwt-token}` (필수)
+
+### Response
+
+**200 OK**
+
+```json
+{
+  "id": "e_check_to_answer",
+  "workflowDefinitionId": 5,
+  "domainPackVersionId": 10,
+  "from": "check_refund_policy",
+  "to": "answer_refund",
+  "label": "eligible"
+}
+```
+
+> `label`은 DECISION 노드 발신 edge에만 존재하며, 나머지 edge는 `null`로 반환한다.
+
+**401 Unauthorized**
+
+```json
+{ "code": "UNAUTHORIZED", "message": "인증이 필요합니다." }
+```
+
+**403 Forbidden**
+
+```json
+{ "code": "FORBIDDEN", "message": "워크스페이스에 접근 권한이 없습니다." }
+```
+
+**404 Not Found — transition not found**
+
+```json
+{ "code": "WORKFLOW_TRANSITION_NOT_FOUND", "message": "Workflow transition not found: {transitionId}" }
+```
+
+**404 Not Found — workflow not found**
+
+```json
+{ "code": "WORKFLOW_DEFINITION_NOT_FOUND", "message": "WorkflowDefinition not found: {workflowId}" }
+```
+
+**404 Not Found — workspace not found**
+
+```json
+{ "code": "DOMAIN_PACK_WORKSPACE_NOT_FOUND", "message": "워크스페이스를 찾을 수 없습니다. id={workspaceId}" }
+```
+
+**404 Not Found — pack not found**
+
+```json
+{ "code": "DOMAIN_PACK_NOT_FOUND", "message": "DomainPack not found: {packId}" }
+```
+
+**404 Not Found — version not found**
+
+```json
+{ "code": "DOMAIN_PACK_VERSION_NOT_FOUND", "message": "도메인 팩 버전을 찾을 수 없습니다. id={versionId}" }
+```
+
+---
+
+## Class Design
+
+### 신규 생성 파일
+
+| 파일 | 경로 | 역할 |
+|------|------|------|
+| `GetWorkflowTransitionQuery.java` | `application/` | UseCase 입력 record |
+| `GetWorkflowTransitionUseCase.java` | `application/` | edge 추출 + 단건 반환 UseCase |
+| `WorkflowTransitionDetail.java` | `application/` | 응답 record + graphJson 파싱 팩토리 |
+| `WorkflowTransitionNotFoundException.java` | `application/exception/` | 404 예외 |
+
+### 수정 파일
+
+| 파일 | 변경 내용 |
+|------|-----------|
+| `WorkflowDefinitionController.java` | `@GetMapping("/{workflowId}/transitions/{transitionId}")` 핸들러 추가 |
+| `UpdateWorkflowUseCase.java` (또는 관련 검증 유틸) | V7 edge id 검증 추가 |
+
+### Pseudo-code
+
+```java
+// GetWorkflowTransitionQuery.java
+record GetWorkflowTransitionQuery(
+    Long workspaceId, Long packId, Long versionId,
+    Long workflowId, String transitionId, Long userId)
+
+// WorkflowTransitionNotFoundException.java
+class WorkflowTransitionNotFoundException extends NotFoundException {
+    WorkflowTransitionNotFoundException(String transitionId) {
+        super("WORKFLOW_TRANSITION_NOT_FOUND",
+              "Workflow transition not found: " + transitionId)
+    }
+}
+
+// WorkflowTransitionDetail.java
+record WorkflowTransitionDetail(
+    String id,
+    Long workflowDefinitionId,
+    Long domainPackVersionId,
+    String from,
+    String to,
+    @Nullable String label) {
+
+    static Optional<WorkflowTransitionDetail> fromGraphJson(
+            String graphJson, String transitionId,
+            Long workflowId, Long versionId) {
+        // Jackson으로 graphJson 파싱
+        // edges[] 순회하여 id == transitionId 인 edge 탐색
+        // 발견 시 WorkflowTransitionDetail 반환, 미발견 시 Optional.empty()
+    }
+}
+
+// GetWorkflowTransitionUseCase.java
+@Service
+@Transactional(readOnly = true)
+class GetWorkflowTransitionUseCase {
+    execute(GetWorkflowTransitionQuery query) {
+        validator.validateWorkspaceAccess(query.workspaceId(), query.userId())
+        validator.validateDomainPack(query.packId(), query.workspaceId())
+        validator.validateVersion(query.versionId(), query.packId())
+
+        WorkflowDefinition workflow = workflowDefinitionRepository
+            .findByIdAndDomainPackVersionId(query.workflowId(), query.versionId())
+            .orElseThrow(() -> new WorkflowDefinitionNotFoundException(query.workflowId()))
+
+        return WorkflowTransitionDetail
+            .fromGraphJson(workflow.getGraphJson(), query.transitionId(),
+                           workflow.getId(), workflow.getDomainPackVersionId())
+            .orElseThrow(() -> new WorkflowTransitionNotFoundException(query.transitionId()))
+    }
+}
+
+// WorkflowDefinitionController.java — 추가 핸들러
+@GetMapping("/{workflowId}/transitions/{transitionId}")
+getTransition(@PathVariable Long workspaceId, @PathVariable Long packId,
+              @PathVariable Long versionId, @PathVariable Long workflowId,
+              @PathVariable String transitionId,
+              Authentication authentication) {
+    Long userId = AuthenticationUtils.getUserId(authentication)
+    return ResponseEntity.ok(
+        transitionUseCase.execute(new GetWorkflowTransitionQuery(
+            workspaceId, packId, versionId, workflowId, transitionId, userId)))
+}
+```
+
+---
+
+## Tests
+
+### UseCase 테스트: `GetWorkflowTransitionUseCaseTest.java`
+
+- `@ExtendWith(MockitoExtension.class)` + `@DisplayName`
+- `WorkflowDefinitionRepository` mock
+
+| 시나리오 | 예상 결과 |
+|----------|-----------|
+| 정상 조회 (label 있음) | `WorkflowTransitionDetail` 반환, 전 필드 검증 |
+| 정상 조회 (label 없음) | `label == null` 반환 |
+| `transitionId` 미존재 | `WorkflowTransitionNotFoundException` |
+| `workflowId` 미존재 | `WorkflowDefinitionNotFoundException` |
+| workspace 미존재 | `DomainPackWorkspaceNotFoundException` (validator 위임) |
+| 권한 없음 | `DomainPackUnauthorizedWorkspaceAccessException` (validator 위임) |
+| pack 소속 불일치 | `DomainPackNotFoundException` (validator 위임) |
+
+### Controller 테스트: `WorkflowDefinitionControllerTest.java` (기존 확장)
+
+- `@WebMvcTest(WorkflowDefinitionController.class)` + JwtAuthenticationFilter exclude
+- `@WithLongPrincipal(10L)` fixture 사용
+
+| 시나리오 | 예상 결과 |
+|----------|-----------|
+| 정상 조회 | 200, 전 필드 검증 (`id`, `workflowDefinitionId`, `domainPackVersionId`, `from`, `to`, `label`) |
+| `transitionId` 미존재 | 404, `body.code == "WORKFLOW_TRANSITION_NOT_FOUND"` |
+| `workflowId` 미존재 | 404, `body.code == "WORKFLOW_DEFINITION_NOT_FOUND"` |
+| 권한 없음 | 403 |
+| 인증 없음 | 401 |
+| version 미존재 | 404 |
+
+---
+
+## Database
+
+신규 DDL 없음. `pack.workflow_definition.graph_json` JSONB 컬럼 내부 구조만 변경된다.
+
+---
+
+## Additional Notes
+
+- `WorkflowDefinitionRepository.findByIdAndDomainPackVersionId`는 이미 존재하므로 재사용한다.
+- graphJson 파싱은 app layer(Jackson)에서 수행한다. PostgreSQL jsonb_path_query는 사용하지 않는다.
+- Validator 호출 순서는 기존 `GetWorkflowDefinitionUseCase` 패턴(3단계 개별 호출)을 따른다.
+- edge `id`의 형식(예: `"e_check_to_answer"`)은 node `id`와 동일한 자유 문자열 규칙을 따른다.
+- V7 검증 코드는 이 스펙이 정의하되, write path 적용은 spec 231(CreateDraft) 및 UpdateWorkflow 담당자가 수행한다.
+- 기존 DB에 저장된 `edge id` 없는 workflow draft는 단건 transition GET이 404를 반환한다. 마이그레이션은 이 스펙 범위 밖이다.
+- FE의 Action 시각화는 spec 2211 policy 단건/목록 API를 별도로 조합해서 구현한다.

--- a/.agent/specs/2217.md
+++ b/.agent/specs/2217.md
@@ -42,11 +42,7 @@
 | V7 | 모든 edge에 `id` 필드가 존재하며 비어있지 않음 | `WORKFLOW_EDGE_ID_MISSING` |
 | V7 | 모든 edge `id`가 workflow 내에서 고유함 | `WORKFLOW_EDGE_ID_DUPLICATE` |
 
-**V7 적용 write path:**
-- `CreateDomainPackDraftUseCase` — spec 231 구현 시 함께 적용한다.
-- `UpdateWorkflowUseCase` — 이미 구현된 코드에 V7 검증을 추가한다.
-
-> 이 스펙은 V7을 **정의**한다. 코드 강제는 write-path 담당 spec(231) 및 UpdateWorkflow 수정 시 적용한다.
+이 스펙은 V7을 **정의**한다. 실제 검증·강제 구현은 `CreateDomainPackDraftUseCase`(spec 231 참조)와 `UpdateWorkflowUseCase`(기존 구현에 V7 추가)가 담당한다.
 
 ---
 
@@ -159,6 +155,12 @@ Headers:
 { "code": "DOMAIN_PACK_VERSION_NOT_FOUND", "message": "도메인 팩 버전을 찾을 수 없습니다. id={versionId}" }
 ```
 
+**500 Internal Server Error — graphJson 정합성 오류**
+
+```json
+{ "code": "WORKFLOW_GRAPH_JSON_INVALID", "message": "graphJson이 유효하지 않은 JSON입니다. workflowId={workflowId}" }
+```
+
 ---
 
 ## Class Design
@@ -207,9 +209,13 @@ record WorkflowTransitionDetail(
     static Optional<WorkflowTransitionDetail> fromGraphJson(
             String graphJson, String transitionId,
             Long workflowId, Long versionId) {
-        // Jackson으로 graphJson 파싱
-        // edges[] 순회하여 id == transitionId 인 edge 탐색
-        // 발견 시 WorkflowTransitionDetail 반환, 미발견 시 Optional.empty()
+        try {
+            // Jackson으로 graphJson 파싱
+            // edges[] 순회하여 id == transitionId 인 edge 탐색
+            // 발견 시 WorkflowTransitionDetail 반환, 미발견 시 Optional.empty()
+        } catch (IOException | IllegalArgumentException e) {
+            throw new WorkflowGraphJsonInvalidException(workflowId, e);
+        }
     }
 }
 
@@ -261,6 +267,7 @@ getTransition(@PathVariable Long workspaceId, @PathVariable Long packId,
 | 정상 조회 (label 없음) | `label == null` 반환 |
 | `transitionId` 미존재 | `WorkflowTransitionNotFoundException` |
 | `workflowId` 미존재 | `WorkflowDefinitionNotFoundException` |
+| DB 저장된 graphJson 파싱 오류 | `WorkflowGraphJsonInvalidException` |
 | workspace 미존재 | `DomainPackWorkspaceNotFoundException` (validator 위임) |
 | 권한 없음 | `DomainPackUnauthorizedWorkspaceAccessException` (validator 위임) |
 | pack 소속 불일치 | `DomainPackNotFoundException` (validator 위임) |
@@ -275,6 +282,7 @@ getTransition(@PathVariable Long workspaceId, @PathVariable Long packId,
 | 정상 조회 | 200, 전 필드 검증 (`id`, `workflowDefinitionId`, `domainPackVersionId`, `from`, `to`, `label`) |
 | `transitionId` 미존재 | 404, `body.code == "WORKFLOW_TRANSITION_NOT_FOUND"` |
 | `workflowId` 미존재 | 404, `body.code == "WORKFLOW_DEFINITION_NOT_FOUND"` |
+| DB 저장된 graphJson 파싱 오류 | 500, `body.code == "WORKFLOW_GRAPH_JSON_INVALID"` |
 | 권한 없음 | 403 |
 | 인증 없음 | 401 |
 | version 미존재 | 404 |
@@ -293,6 +301,7 @@ getTransition(@PathVariable Long workspaceId, @PathVariable Long packId,
 - graphJson 파싱은 app layer(Jackson)에서 수행한다. PostgreSQL jsonb_path_query는 사용하지 않는다.
 - Validator 호출 순서는 기존 `GetWorkflowDefinitionUseCase` 패턴(3단계 개별 호출)을 따른다.
 - edge `id`의 형식(예: `"e_check_to_answer"`)은 node `id`와 동일한 자유 문자열 규칙을 따른다.
-- V7 검증 코드는 이 스펙이 정의하되, write path 적용은 spec 231(CreateDraft) 및 UpdateWorkflow 담당자가 수행한다.
+- 이 스펙은 V7을 **정의**한다. 실제 검증·강제 구현은 `CreateDomainPackDraftUseCase`(spec 231 참조)와 `UpdateWorkflowUseCase`(기존 구현에 V7 추가)가 담당한다.
+- `WorkflowGraphJsonInvalidException`은 이미 존재한다(`InternalException` 상속). `fromGraphJson` 파싱 오류 시 workflowId를 포함한 메시지를 위해 `WorkflowGraphJsonInvalidException(Long workflowId, Throwable cause)` 생성자를 추가한다.
 - 기존 DB에 저장된 `edge id` 없는 workflow draft는 단건 transition GET이 404를 반환한다. 마이그레이션은 이 스펙 범위 밖이다.
 - FE의 Action 시각화는 spec 2211 policy 단건/목록 API를 별도로 조합해서 구현한다.

--- a/.agent/specs/2217.md
+++ b/.agent/specs/2217.md
@@ -39,8 +39,9 @@
 
 | # | 규칙 | 위반 시 에러 코드 |
 |---|------|-----------------|
-| V7 | 모든 edge에 `id` 필드가 존재하며 비어있지 않음 | `WORKFLOW_EDGE_ID_MISSING` |
-| V7 | 모든 edge `id`가 workflow 내에서 고유함 | `WORKFLOW_EDGE_ID_DUPLICATE` |
+| V7a | 모든 edge에 `id` 필드가 존재하며 비어있지 않음 | `WORKFLOW_EDGE_ID_MISSING` |
+| V7b | 모든 edge `id`가 workflow 내에서 고유함 | `WORKFLOW_EDGE_ID_DUPLICATE` |
+| V7c | 모든 edge `id`가 `[A-Za-z0-9_-]+` 패턴을 만족함 (URL 예약문자 금지) | `WORKFLOW_EDGE_ID_INVALID_CHARS` |
 
 이 스펙은 V7을 **정의**한다. 실제 검증·강제 구현은 `CreateDomainPackDraftUseCase`(spec 231 참조)와 `UpdateWorkflowUseCase`(기존 구현에 V7 추가)가 담당한다.
 
@@ -91,7 +92,7 @@ Path variables:
 - `packId`: Long
 - `versionId`: Long
 - `workflowId`: Long
-- `transitionId`: String (edge의 `id` 필드 값)
+- `transitionId`: String — edge의 `id` 필드 값; URL-safe 문자만 허용 (`[A-Za-z0-9_-]+`)
 
 Headers:
 - `Authorization: Bearer {jwt-token}` (필수)
@@ -300,7 +301,7 @@ getTransition(@PathVariable Long workspaceId, @PathVariable Long packId,
 - `WorkflowDefinitionRepository.findByIdAndDomainPackVersionId`는 이미 존재하므로 재사용한다.
 - graphJson 파싱은 app layer(Jackson)에서 수행한다. PostgreSQL jsonb_path_query는 사용하지 않는다.
 - Validator 호출 순서는 기존 `GetWorkflowDefinitionUseCase` 패턴(3단계 개별 호출)을 따른다.
-- edge `id`의 형식(예: `"e_check_to_answer"`)은 node `id`와 동일한 자유 문자열 규칙을 따른다.
+- edge `id`의 형식은 `[A-Za-z0-9_-]+`(URL-safe)로 제한한다. 예: `"e_check_to_answer"`. `/`, `?`, `#`, `%` 등 URL 예약 문자는 허용하지 않으며 V7c 검증에서 거부한다. `transitionId` PathVariable은 동일 문자 집합을 전제로 설계된다.
 - 이 스펙은 V7을 **정의**한다. 실제 검증·강제 구현은 `CreateDomainPackDraftUseCase`(spec 231 참조)와 `UpdateWorkflowUseCase`(기존 구현에 V7 추가)가 담당한다.
 - `WorkflowGraphJsonInvalidException`은 이미 존재한다(`InternalException` 상속). `fromGraphJson` 파싱 오류 시 workflowId를 포함한 메시지를 위해 `WorkflowGraphJsonInvalidException(Long workflowId, Throwable cause)` 생성자를 추가한다.
 - 기존 DB에 저장된 `edge id` 없는 workflow draft는 단건 transition GET이 404를 반환한다. 마이그레이션은 이 스펙 범위 밖이다.


### PR DESCRIPTION
# [BE] 2.2.17 — Transition Condition 초안 단건 조회

## Goal

`workflow_definition.graph_json`의 edge 구조에 고유 `id` 필드를 추가하고, 특정 워크플로우에 속한 Transition(graphJson edge) 초안 단건을 조회하는 READ 전용 엔드포인트를 제공한다.
"Action" 시각화는 이 스펙 범위 밖이며, FE는 policy 단건 조회 API(spec 2211)를 별도로 조합해 사용한다.

---

## graphJson Edge Schema 변경

### 기존

```json
{
  "edges": [
    { "from": "check_refund_policy", "to": "answer_refund", "label": "eligible" },
    { "from": "check_refund_policy", "to": "handoff_agent", "label": "not_eligible" }
  ]
}
```

### 변경 후 (id 필드 추가)

```json
{
  "edges": [
    { "id": "e_check_to_answer",  "from": "check_refund_policy", "to": "answer_refund",  "label": "eligible"     },
    { "id": "e_check_to_handoff", "from": "check_refund_policy", "to": "handoff_agent",  "label": "not_eligible" },
    { "id": "e_answer_to_end",    "from": "answer_refund",       "to": "terminal"                               }
  ]
}
```

- `id`: 필수, 비어있지 않은 문자열, workflow 내 모든 edge 간 고유해야 함.
- `label`: DECISION 노드 발신 edge에 필수 (기존 V6 규칙 유지). 나머지 edge는 선택.

### 신규 Validation Rule — V7 (write-time)

| # | 규칙 | 위반 시 에러 코드 |
|---|------|-----------------|
| V7 | 모든 edge에 `id` 필드가 존재하며 비어있지 않음 | `WORKFLOW_EDGE_ID_MISSING` |
| V7 | 모든 edge `id`가 workflow 내에서 고유함 | `WORKFLOW_EDGE_ID_DUPLICATE` |

**V7 적용 write path:**
- `CreateDomainPackDraftUseCase` — spec 231 구현 시 함께 적용한다.
- `UpdateWorkflowUseCase` — 이미 구현된 코드에 V7 검증을 추가한다.

> 이 스펙은 V7을 **정의**한다. 코드 강제는 write-path 담당 spec(231) 및 UpdateWorkflow 수정 시 적용한다.

---

## Sequence Diagram

```mermaid
sequenceDiagram
    actor c as Client
    participant ctrl as WorkflowDefinitionController
    participant uc as GetWorkflowTransitionUseCase
    participant validator as DomainPackValidator
    participant repo as WorkflowDefinitionRepository
    participant db as PostgreSQL

    c ->> ctrl: GET /api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/workflows/{workflowId}/transitions/{transitionId}
    ctrl ->> uc: execute(GetWorkflowTransitionQuery)
    uc ->> validator: validateWorkspaceAccess(workspaceId, userId)
    validator -->> uc: ok
    uc ->> validator: validateDomainPack(packId, workspaceId)
    validator -->> uc: ok
    uc ->> validator: validateVersion(versionId, packId)
    validator -->> uc: ok
    uc ->> repo: findByIdAndDomainPackVersionId(workflowId, versionId)
    repo ->> db: SELECT * FROM pack.workflow_definition WHERE id = ? AND domain_pack_version_id = ?
    db -->> repo: row
    repo -->> uc: Optional<WorkflowDefinition>
    uc ->> uc: parse graphJson → find edge where id == transitionId
    uc -->> ctrl: WorkflowTransitionDetail
    ctrl -->> c: 200 OK
```

---

## REST API

### Endpoint

| Method | Path | Description |
|--------|------|-------------|
| GET | `/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/workflows/{workflowId}/transitions/{transitionId}` | Transition 초안 단건 조회 |

### Request

Path variables:
- `workspaceId`: Long
- `packId`: Long
- `versionId`: Long
- `workflowId`: Long
- `transitionId`: String (edge의 `id` 필드 값)

Headers:
- `Authorization: Bearer {jwt-token}` (필수)

### Response

**200 OK**

```json
{
  "id": "e_check_to_answer",
  "workflowDefinitionId": 5,
  "domainPackVersionId": 10,
  "from": "check_refund_policy",
  "to": "answer_refund",
  "label": "eligible"
}
```

> `label`은 DECISION 노드 발신 edge에만 존재하며, 나머지 edge는 `null`로 반환한다.

**401 Unauthorized**

```json
{ "code": "UNAUTHORIZED", "message": "인증이 필요합니다." }
```

**403 Forbidden**

```json
{ "code": "FORBIDDEN", "message": "워크스페이스에 접근 권한이 없습니다." }
```

**404 Not Found — transition not found**

```json
{ "code": "WORKFLOW_TRANSITION_NOT_FOUND", "message": "Workflow transition not found: {transitionId}" }
```

**404 Not Found — workflow not found**

```json
{ "code": "WORKFLOW_DEFINITION_NOT_FOUND", "message": "WorkflowDefinition not found: {workflowId}" }
```

**404 Not Found — workspace not found**

```json
{ "code": "DOMAIN_PACK_WORKSPACE_NOT_FOUND", "message": "워크스페이스를 찾을 수 없습니다. id={workspaceId}" }
```

**404 Not Found — pack not found**

```json
{ "code": "DOMAIN_PACK_NOT_FOUND", "message": "DomainPack not found: {packId}" }
```

**404 Not Found — version not found**

```json
{ "code": "DOMAIN_PACK_VERSION_NOT_FOUND", "message": "도메인 팩 버전을 찾을 수 없습니다. id={versionId}" }
```

---

## Class Design

### 신규 생성 파일

| 파일 | 경로 | 역할 |
|------|------|------|
| `GetWorkflowTransitionQuery.java` | `application/` | UseCase 입력 record |
| `GetWorkflowTransitionUseCase.java` | `application/` | edge 추출 + 단건 반환 UseCase |
| `WorkflowTransitionDetail.java` | `application/` | 응답 record + graphJson 파싱 팩토리 |
| `WorkflowTransitionNotFoundException.java` | `application/exception/` | 404 예외 |

### 수정 파일

| 파일 | 변경 내용 |
|------|-----------|
| `WorkflowDefinitionController.java` | `@GetMapping("/{workflowId}/transitions/{transitionId}")` 핸들러 추가 |
| `UpdateWorkflowUseCase.java` (또는 관련 검증 유틸) | V7 edge id 검증 추가 |

### Pseudo-code

```java
// GetWorkflowTransitionQuery.java
record GetWorkflowTransitionQuery(
    Long workspaceId, Long packId, Long versionId,
    Long workflowId, String transitionId, Long userId)

// WorkflowTransitionNotFoundException.java
class WorkflowTransitionNotFoundException extends NotFoundException {
    WorkflowTransitionNotFoundException(String transitionId) {
        super("WORKFLOW_TRANSITION_NOT_FOUND",
              "Workflow transition not found: " + transitionId)
    }
}

// WorkflowTransitionDetail.java
record WorkflowTransitionDetail(
    String id,
    Long workflowDefinitionId,
    Long domainPackVersionId,
    String from,
    String to,
    @Nullable String label) {

    static Optional<WorkflowTransitionDetail> fromGraphJson(
            String graphJson, String transitionId,
            Long workflowId, Long versionId) {
        // Jackson으로 graphJson 파싱
        // edges[] 순회하여 id == transitionId 인 edge 탐색
        // 발견 시 WorkflowTransitionDetail 반환, 미발견 시 Optional.empty()
    }
}

// GetWorkflowTransitionUseCase.java
@Service
@Transactional(readOnly = true)
class GetWorkflowTransitionUseCase {
    execute(GetWorkflowTransitionQuery query) {
        validator.validateWorkspaceAccess(query.workspaceId(), query.userId())
        validator.validateDomainPack(query.packId(), query.workspaceId())
        validator.validateVersion(query.versionId(), query.packId())

        WorkflowDefinition workflow = workflowDefinitionRepository
            .findByIdAndDomainPackVersionId(query.workflowId(), query.versionId())
            .orElseThrow(() -> new WorkflowDefinitionNotFoundException(query.workflowId()))

        return WorkflowTransitionDetail
            .fromGraphJson(workflow.getGraphJson(), query.transitionId(),
                           workflow.getId(), workflow.getDomainPackVersionId())
            .orElseThrow(() -> new WorkflowTransitionNotFoundException(query.transitionId()))
    }
}

// WorkflowDefinitionController.java — 추가 핸들러
@GetMapping("/{workflowId}/transitions/{transitionId}")
getTransition(@PathVariable Long workspaceId, @PathVariable Long packId,
              @PathVariable Long versionId, @PathVariable Long workflowId,
              @PathVariable String transitionId,
              Authentication authentication) {
    Long userId = AuthenticationUtils.getUserId(authentication)
    return ResponseEntity.ok(
        transitionUseCase.execute(new GetWorkflowTransitionQuery(
            workspaceId, packId, versionId, workflowId, transitionId, userId)))
}
```

---

## Tests

### UseCase 테스트: `GetWorkflowTransitionUseCaseTest.java`

- `@ExtendWith(MockitoExtension.class)` + `@DisplayName`
- `WorkflowDefinitionRepository` mock

| 시나리오 | 예상 결과 |
|----------|-----------|
| 정상 조회 (label 있음) | `WorkflowTransitionDetail` 반환, 전 필드 검증 |
| 정상 조회 (label 없음) | `label == null` 반환 |
| `transitionId` 미존재 | `WorkflowTransitionNotFoundException` |
| `workflowId` 미존재 | `WorkflowDefinitionNotFoundException` |
| workspace 미존재 | `DomainPackWorkspaceNotFoundException` (validator 위임) |
| 권한 없음 | `DomainPackUnauthorizedWorkspaceAccessException` (validator 위임) |
| pack 소속 불일치 | `DomainPackNotFoundException` (validator 위임) |

### Controller 테스트: `WorkflowDefinitionControllerTest.java` (기존 확장)

- `@WebMvcTest(WorkflowDefinitionController.class)` + JwtAuthenticationFilter exclude
- `@WithLongPrincipal(10L)` fixture 사용

| 시나리오 | 예상 결과 |
|----------|-----------|
| 정상 조회 | 200, 전 필드 검증 (`id`, `workflowDefinitionId`, `domainPackVersionId`, `from`, `to`, `label`) |
| `transitionId` 미존재 | 404, `body.code == "WORKFLOW_TRANSITION_NOT_FOUND"` |
| `workflowId` 미존재 | 404, `body.code == "WORKFLOW_DEFINITION_NOT_FOUND"` |
| 권한 없음 | 403 |
| 인증 없음 | 401 |
| version 미존재 | 404 |

---

## Database

신규 DDL 없음. `pack.workflow_definition.graph_json` JSONB 컬럼 내부 구조만 변경된다.

---

## Additional Notes

- `WorkflowDefinitionRepository.findByIdAndDomainPackVersionId`는 이미 존재하므로 재사용한다.
- graphJson 파싱은 app layer(Jackson)에서 수행한다. PostgreSQL jsonb_path_query는 사용하지 않는다.
- Validator 호출 순서는 기존 `GetWorkflowDefinitionUseCase` 패턴(3단계 개별 호출)을 따른다.
- edge `id`의 형식(예: `"e_check_to_answer"`)은 node `id`와 동일한 자유 문자열 규칙을 따른다.
- V7 검증 코드는 이 스펙이 정의하되, write path 적용은 spec 231(CreateDraft) 및 UpdateWorkflow 담당자가 수행한다.
- 기존 DB에 저장된 `edge id` 없는 workflow draft는 단건 transition GET이 404를 반환한다. 마이그레이션은 이 스펙 범위 밖이다.
- FE의 Action 시각화는 spec 2211 policy 단건/목록 API를 별도로 조합해서 구현한다.
---
# Uncertainty Register — 2217: [BE] Transition Condition 초안 단건 조회

---

## U-01 V7 write-path 적용 시점

- **ID**: U-01
- **Issue**: V7(edge id 필수·고유) 검증을 CreateDomainPackDraftUseCase(spec 231)와 UpdateWorkflowUseCase에 추가하는 코드 작업은 이 스펙의 직접 범위가 아니다.
- **Status**: Deferred
- **Why unresolved**: CreateDraft는 spec 231 담당자가 구현하며, UpdateWorkflow는 이미 구현된 코드다. 별도 PR에서 처리 필요.
- **Options**:
  - A) 이 spec PR에서 UpdateWorkflow V7 검증까지 함께 수정
  - B) 이 spec PR은 단건 GET만, V7 적용은 후속 PR로 분리
- **Recommended Default**: A — read/write 일관성 확보를 위해 UpdateWorkflow V7 추가를 이 PR에 포함
- **Why recommended**: edge id 없는 workflow가 저장되면 단건 GET이 항상 404 반환. write 방어 없이 read만 구현하면 기능이 반쪽.
- **User Decision Required**: No (Recommended Default 채택 가능)
- **User Question**: N/A
- **Execution Rule**:
  - Implementation Agent MUST NOT: V7 검증 없이 단건 GET만 구현한 채 PR을 닫으면 안 됨
  - Implementation Agent MAY: Deferred로 처리 시 PR 설명에 "V7 미적용, 후속 PR 필요" 명시
- **Affected Spec Section**: graphJson Edge Schema 변경 / Additional Notes

---

## U-02 기존 workflow draft 마이그레이션

- **ID**: U-02
- **Issue**: 현재 DB에 저장된 `workflow_definition.graph_json`에는 edge `id` 필드가 없다. 이 데이터에 대해 단건 transition GET을 호출하면 항상 404가 반환된다.
- **Status**: Deferred
- **Why unresolved**: 마이그레이션 여부와 방법이 미결정.
- **Options**:
  - A) 마이그레이션 없음 — 기존 draft는 새 pipeline 재실행으로 대체
  - B) Liquibase migration script로 기존 graph_json의 각 edge에 자동 id 부여
- **Recommended Default**: A — YAGNI. Draft는 pipeline 재실행으로 갱신 가능. 마이그레이션 스크립트 복잡도 불필요.
- **Why recommended**: 초안 데이터는 재생성 가능한 성격. 마이그레이션 스크립트 작성 비용 대비 이득이 작다.
- **User Decision Required**: No (Recommended Default 채택 가능)
- **User Question**: N/A
- **Execution Rule**:
  - Implementation Agent MUST NOT: 마이그레이션 스크립트를 자의적으로 추가하면 안 됨
  - Implementation Agent MAY: A 채택 시 API 문서 또는 Additional Notes에 "기존 draft edge id 없는 경우 404" 명시
- **Affected Spec Section**: Database / Additional Notes

---

## U-03 edge id 형식 제약

- **ID**: U-03
- **Issue**: edge `id` 필드의 허용 문자, 최대 길이 등 형식 제약이 명시되지 않았다.
- **Status**: Assumption
- **Why unresolved**: node `id`도 동일하게 자유 문자열 규칙이며, 226.md에 별도 형식 제약이 없다.
- **Options**:
  - A) node `id`와 동일: non-empty string, 길이·문자 제약 없음 (단, workflow 내 고유)
  - B) 명시적 형식 제약 추가 (예: alphanumeric + underscore, max 100자)
- **Recommended Default**: A — node id와 동일 규칙 적용. 추가 제약은 필요 시 후속 spec에서 정의.
- **Why recommended**: YAGNI. 현재 사용 패턴(pipeline 자동 생성)에서 충분.
- **User Decision Required**: No
- **User Question**: N/A
- **Execution Rule**:
  - Implementation Agent MAY: V7 검증에서 non-empty 체크만 구현. 형식 정규식 추가는 불필요.
- **Affected Spec Section**: graphJson Edge Schema 변경 / V7 Validation

---

## U-04 ACTION 노드와 policy_definition 연결 메커니즘

- **ID**: U-04
- **Issue**: FE Action 시각화 시, graphJson의 ACTION 노드가 어떤 policy_definition과 연결되는지 매핑 방식이 정의되지 않았다.
- **Status**: Deferred
- **Why unresolved**: 이 스펙 범위 밖. FE는 policy 목록 API(spec 2211 계열)를 별도 조합해서 사용하도록 결정됨.
- **Options**:
  - A) 현재: FE가 policy 목록 API + workflow graphJson을 조합해서 시각화
  - B) 미래: graphJson edge 또는 node에 `policyRef` 필드를 추가해 명시적 연결
- **Recommended Default**: A — 현재 요구사항으로는 충분.
- **Why recommended**: 2.2.17 범위는 Transition 단건 GET. Policy 연결 체계는 별도 설계 필요.
- **User Decision Required**: No
- **User Question**: N/A
- **Execution Rule**:
  - Implementation Agent MUST NOT: `policyRef` 또는 관련 필드를 자의적으로 graphJson schema에 추가하면 안 됨
  - Implementation Agent MAY: Additional Notes에 "Action 시각화는 2211 API 조합으로 처리" 명시
- **Affected Spec Section**: Additional Notes

---

## U-05 WorkflowTransitionDetail의 `label` 필드명

- **ID**: U-05
- **Issue**: 응답 DTO에서 edge 조건을 `label`로 반환할지 `conditionLabel` 또는 `condition`으로 표현할지.
- **Status**: Confirmed
- **Why unresolved**: N/A — 사용자 결정 없이 graphJson 용어 일관성으로 확정 가능.
- **Options**:
  - A) `label` — graphJson 원본 필드명과 동일, 일관성 ↑
  - B) `conditionLabel` / `condition` — 도메인 의미 명확성 ↑
- **Recommended Default**: A (Confirmed 채택)
- **Why recommended**: graphJson과 응답 DTO 간 필드명 불일치는 FE 혼란 유발. 현 시점에 의미 재명명 이득 없음.
- **User Decision Required**: No
- **User Question**: N/A
- **Execution Rule**:
  - Implementation Agent MUST: `WorkflowTransitionDetail` record에서 필드명을 `label`로 정의
- **Affected Spec Section**: REST API Response / Class Design

---

## 결정 요약

| ID | 항목 | 상태 | 결정 |
|----|------|------|------|
| U-01 | V7 write-path 적용 범위 | Deferred | UpdateWorkflow V7 추가를 이 PR에 포함 권장 |
| U-02 | 기존 draft 마이그레이션 | Deferred | 마이그레이션 없음, 재생성으로 대체 |
| U-03 | edge id 형식 제약 | Assumption | non-empty string, node id와 동일 규칙 |
| U-04 | ACTION ↔ policy 연결 메커니즘 | Deferred | 이 spec 범위 외, 후속 설계 |
| U-05 | 응답 label 필드명 | Confirmed | `label` 유지 |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 워크플로우 전환(transition)을 ID로 조회하는 읽기 전용 API가 추가되었습니다. 전환의 ID, 워크플로우, 버전, 출발/도착 노드 및 레이블(없을 수 있음)을 반환합니다.
  * 모든 전환(간선)에 워크플로우 내에서 고유하고 비어있지 않으며 URL-안전한 문자로 구성된 ID가 요구됩니다.

* **문서**
  * 쓰기 시 검증 규칙(V7)과 오류 코드(존재/중복/문자제약 등), 조회 동작과 예외(미발견/잘못된 그래프 JSON 등) 흐름이 명세에 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->