### PR TITLE
feat(domain-pack): add transition GET endpoint and V7 edge id validation (#2217)

### DIFF
--- a/backend/src/main/java/com/init/domainpack/application/GetWorkflowTransitionQuery.java
+++ b/backend/src/main/java/com/init/domainpack/application/GetWorkflowTransitionQuery.java
@@ -1,0 +1,4 @@
+package com.init.domainpack.application;
+
+public record GetWorkflowTransitionQuery(
+    Long workspaceId, Long packId, Long versionId, Long workflowId, String transitionId, Long userId) {}

--- a/backend/src/main/java/com/init/domainpack/application/GetWorkflowTransitionQuery.java
+++ b/backend/src/main/java/com/init/domainpack/application/GetWorkflowTransitionQuery.java
@@ -1,4 +1,9 @@
 package com.init.domainpack.application;
 
 public record GetWorkflowTransitionQuery(
-    Long workspaceId, Long packId, Long versionId, Long workflowId, String transitionId, Long userId) {}
+    Long workspaceId,
+    Long packId,
+    Long versionId,
+    Long workflowId,
+    String transitionId,
+    Long userId) {}

--- a/backend/src/main/java/com/init/domainpack/application/GetWorkflowTransitionUseCase.java
+++ b/backend/src/main/java/com/init/domainpack/application/GetWorkflowTransitionUseCase.java
@@ -1,0 +1,40 @@
+package com.init.domainpack.application;
+
+import com.init.domainpack.application.exception.WorkflowDefinitionNotFoundException;
+import com.init.domainpack.application.exception.WorkflowTransitionNotFoundException;
+import com.init.domainpack.domain.repository.WorkflowDefinitionRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class GetWorkflowTransitionUseCase {
+
+  private final DomainPackValidator validator;
+  private final WorkflowDefinitionRepository workflowDefinitionRepository;
+
+  public GetWorkflowTransitionUseCase(
+      DomainPackValidator validator,
+      WorkflowDefinitionRepository workflowDefinitionRepository) {
+    this.validator = validator;
+    this.workflowDefinitionRepository = workflowDefinitionRepository;
+  }
+
+  public WorkflowTransitionDetail execute(GetWorkflowTransitionQuery query) {
+    validator.validateWorkspaceAccess(query.workspaceId(), query.userId());
+    validator.validateDomainPack(query.packId(), query.workspaceId());
+    validator.validateVersion(query.versionId(), query.packId());
+
+    var workflow =
+        workflowDefinitionRepository
+            .findByIdAndDomainPackVersionId(query.workflowId(), query.versionId())
+            .orElseThrow(() -> new WorkflowDefinitionNotFoundException(query.workflowId()));
+
+    return WorkflowTransitionDetail.fromGraphJson(
+            workflow.getGraphJson(),
+            query.transitionId(),
+            workflow.getId(),
+            workflow.getDomainPackVersionId())
+        .orElseThrow(() -> new WorkflowTransitionNotFoundException(query.transitionId()));
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/application/GetWorkflowTransitionUseCase.java
+++ b/backend/src/main/java/com/init/domainpack/application/GetWorkflowTransitionUseCase.java
@@ -14,8 +14,7 @@ public class GetWorkflowTransitionUseCase {
   private final WorkflowDefinitionRepository workflowDefinitionRepository;
 
   public GetWorkflowTransitionUseCase(
-      DomainPackValidator validator,
-      WorkflowDefinitionRepository workflowDefinitionRepository) {
+      DomainPackValidator validator, WorkflowDefinitionRepository workflowDefinitionRepository) {
     this.validator = validator;
     this.workflowDefinitionRepository = workflowDefinitionRepository;
   }

--- a/backend/src/main/java/com/init/domainpack/application/WorkflowGraphValidator.java
+++ b/backend/src/main/java/com/init/domainpack/application/WorkflowGraphValidator.java
@@ -6,6 +6,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.init.domainpack.application.exception.DomainPackDraftRequestInvalidException;
 import com.init.domainpack.application.exception.WorkflowCycleDetectedException;
 import com.init.domainpack.application.exception.WorkflowDanglingEdgeException;
+import com.init.domainpack.application.exception.WorkflowEdgeIdDuplicateException;
+import com.init.domainpack.application.exception.WorkflowEdgeIdMissingException;
 import com.init.domainpack.application.exception.WorkflowInvalidStartNodeException;
 import com.init.domainpack.application.exception.WorkflowInvalidTerminalNodeException;
 import com.init.domainpack.application.exception.WorkflowUnlabeledBranchException;
@@ -30,7 +32,7 @@ final class WorkflowGraphValidator {
 
   record GraphNode(String id, String type) {}
 
-  record GraphEdge(String from, String to, String label) {}
+  record GraphEdge(String id, String from, String to, String label) {}
 
   /** V1-V6 검증 후 ParsedGraph 반환. 위반 시 해당 예외를 throw한다 (fail-fast). */
   static ParsedGraph parseAndValidate(String graphJson, String workflowCode) {
@@ -56,6 +58,8 @@ final class WorkflowGraphValidator {
     validateV4Reachability(nodes, adj, startId, workflowCode);
     validateV5Cycles(nodes, adj, workflowCode);
     validateV6DecisionLabels(nodes, edges, workflowCode);
+    validateV7aEdgeIdPresence(edges, workflowCode);
+    validateV7bEdgeIdUniqueness(edges, workflowCode);
 
     return new ParsedGraph(nodes, edges);
   }
@@ -100,8 +104,9 @@ final class WorkflowGraphValidator {
   private static List<GraphEdge> parseEdges(JsonNode root) {
     List<GraphEdge> edges = new ArrayList<>();
     for (JsonNode e : root.path("edges")) {
+      String id = e.hasNonNull("id") ? e.path("id").asText(null) : null;
       String label = e.hasNonNull("label") ? e.path("label").asText(null) : null;
-      edges.add(new GraphEdge(e.path("from").asText(), e.path("to").asText(), label));
+      edges.add(new GraphEdge(id, e.path("from").asText(), e.path("to").asText(), label));
     }
     return edges;
   }
@@ -186,6 +191,23 @@ final class WorkflowGraphValidator {
     for (GraphEdge edge : edges) {
       if (decisionIds.contains(edge.from()) && (edge.label() == null || edge.label().isBlank())) {
         throw new WorkflowUnlabeledBranchException(workflowCode);
+      }
+    }
+  }
+
+  private static void validateV7aEdgeIdPresence(List<GraphEdge> edges, String workflowCode) {
+    for (GraphEdge edge : edges) {
+      if (edge.id() == null || edge.id().isBlank()) {
+        throw new WorkflowEdgeIdMissingException(workflowCode);
+      }
+    }
+  }
+
+  private static void validateV7bEdgeIdUniqueness(List<GraphEdge> edges, String workflowCode) {
+    Set<String> seen = new HashSet<>();
+    for (GraphEdge edge : edges) {
+      if (!seen.add(edge.id())) {
+        throw new WorkflowEdgeIdDuplicateException(workflowCode);
       }
     }
   }

--- a/backend/src/main/java/com/init/domainpack/application/WorkflowTransitionDetail.java
+++ b/backend/src/main/java/com/init/domainpack/application/WorkflowTransitionDetail.java
@@ -18,6 +18,10 @@ public record WorkflowTransitionDetail(
 
   static Optional<WorkflowTransitionDetail> fromGraphJson(
       String graphJson, String transitionId, Long workflowId, Long versionId) {
+    if (graphJson == null) {
+      throw new WorkflowGraphJsonInvalidException(
+          workflowId, new IllegalArgumentException("graphJson is null"));
+    }
     try {
       JsonNode root = MAPPER.readTree(graphJson);
       for (JsonNode e : root.path("edges")) {

--- a/backend/src/main/java/com/init/domainpack/application/WorkflowTransitionDetail.java
+++ b/backend/src/main/java/com/init/domainpack/application/WorkflowTransitionDetail.java
@@ -1,0 +1,42 @@
+package com.init.domainpack.application;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.init.domainpack.application.exception.WorkflowGraphJsonInvalidException;
+import java.io.IOException;
+import java.util.Optional;
+
+public record WorkflowTransitionDetail(
+    String id,
+    Long workflowDefinitionId,
+    Long domainPackVersionId,
+    String from,
+    String to,
+    String label) {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  static Optional<WorkflowTransitionDetail> fromGraphJson(
+      String graphJson, String transitionId, Long workflowId, Long versionId) {
+    try {
+      JsonNode root = MAPPER.readTree(graphJson);
+      for (JsonNode e : root.path("edges")) {
+        String edgeId = e.hasNonNull("id") ? e.path("id").asText(null) : null;
+        if (transitionId.equals(edgeId)) {
+          String label = e.hasNonNull("label") ? e.path("label").asText(null) : null;
+          return Optional.of(
+              new WorkflowTransitionDetail(
+                  edgeId,
+                  workflowId,
+                  versionId,
+                  e.path("from").asText(),
+                  e.path("to").asText(),
+                  label));
+        }
+      }
+      return Optional.empty();
+    } catch (IOException | IllegalArgumentException e) {
+      throw new WorkflowGraphJsonInvalidException(workflowId, e);
+    }
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/application/exception/WorkflowEdgeIdDuplicateException.java
+++ b/backend/src/main/java/com/init/domainpack/application/exception/WorkflowEdgeIdDuplicateException.java
@@ -1,0 +1,9 @@
+package com.init.domainpack.application.exception;
+
+import com.init.shared.application.exception.BadRequestException;
+
+public class WorkflowEdgeIdDuplicateException extends BadRequestException {
+  public WorkflowEdgeIdDuplicateException(String workflowCode) {
+    super("WORKFLOW_EDGE_ID_DUPLICATE", "edge id가 중복되었습니다. workflowCode=" + workflowCode);
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/application/exception/WorkflowEdgeIdMissingException.java
+++ b/backend/src/main/java/com/init/domainpack/application/exception/WorkflowEdgeIdMissingException.java
@@ -1,0 +1,9 @@
+package com.init.domainpack.application.exception;
+
+import com.init.shared.application.exception.BadRequestException;
+
+public class WorkflowEdgeIdMissingException extends BadRequestException {
+  public WorkflowEdgeIdMissingException(String workflowCode) {
+    super("WORKFLOW_EDGE_ID_MISSING", "모든 edge에 id 필드가 필요합니다. workflowCode=" + workflowCode);
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/application/exception/WorkflowGraphJsonInvalidException.java
+++ b/backend/src/main/java/com/init/domainpack/application/exception/WorkflowGraphJsonInvalidException.java
@@ -13,9 +13,7 @@ public class WorkflowGraphJsonInvalidException extends InternalException {
   }
 
   public WorkflowGraphJsonInvalidException(Long workflowId, Throwable cause) {
-    super(
-        "WORKFLOW_GRAPH_JSON_INVALID",
-        "graphJson이 유효하지 않은 JSON입니다. workflowId=" + workflowId);
+    super("WORKFLOW_GRAPH_JSON_INVALID", "graphJson이 유효하지 않은 JSON입니다. workflowId=" + workflowId);
     initCause(cause);
   }
 }

--- a/backend/src/main/java/com/init/domainpack/application/exception/WorkflowGraphJsonInvalidException.java
+++ b/backend/src/main/java/com/init/domainpack/application/exception/WorkflowGraphJsonInvalidException.java
@@ -3,17 +3,19 @@ package com.init.domainpack.application.exception;
 import com.init.shared.application.exception.InternalException;
 
 public class WorkflowGraphJsonInvalidException extends InternalException {
+  private static final String DEFAULT_MESSAGE = "graphJson이 유효하지 않은 JSON입니다.";
+
   public WorkflowGraphJsonInvalidException() {
-    super("WORKFLOW_GRAPH_JSON_INVALID", "graphJson이 유효하지 않은 JSON입니다.");
+    super("WORKFLOW_GRAPH_JSON_INVALID", DEFAULT_MESSAGE);
   }
 
   public WorkflowGraphJsonInvalidException(Throwable cause) {
-    super("WORKFLOW_GRAPH_JSON_INVALID", "graphJson이 유효하지 않은 JSON입니다.");
+    this();
     initCause(cause);
   }
 
   public WorkflowGraphJsonInvalidException(Long workflowId, Throwable cause) {
-    super("WORKFLOW_GRAPH_JSON_INVALID", "graphJson이 유효하지 않은 JSON입니다. workflowId=" + workflowId);
+    super("WORKFLOW_GRAPH_JSON_INVALID", DEFAULT_MESSAGE + " workflowId=" + workflowId);
     initCause(cause);
   }
 }

--- a/backend/src/main/java/com/init/domainpack/application/exception/WorkflowGraphJsonInvalidException.java
+++ b/backend/src/main/java/com/init/domainpack/application/exception/WorkflowGraphJsonInvalidException.java
@@ -11,4 +11,11 @@ public class WorkflowGraphJsonInvalidException extends InternalException {
     super("WORKFLOW_GRAPH_JSON_INVALID", "graphJson이 유효하지 않은 JSON입니다.");
     initCause(cause);
   }
+
+  public WorkflowGraphJsonInvalidException(Long workflowId, Throwable cause) {
+    super(
+        "WORKFLOW_GRAPH_JSON_INVALID",
+        "graphJson이 유효하지 않은 JSON입니다. workflowId=" + workflowId);
+    initCause(cause);
+  }
 }

--- a/backend/src/main/java/com/init/domainpack/application/exception/WorkflowTransitionNotFoundException.java
+++ b/backend/src/main/java/com/init/domainpack/application/exception/WorkflowTransitionNotFoundException.java
@@ -4,6 +4,6 @@ import com.init.shared.application.exception.NotFoundException;
 
 public class WorkflowTransitionNotFoundException extends NotFoundException {
   public WorkflowTransitionNotFoundException(String transitionId) {
-    super("WORKFLOW_TRANSITION_NOT_FOUND", "Workflow transition not found: " + transitionId);
+    super("WORKFLOW_TRANSITION_NOT_FOUND", "워크플로우 전환을 찾을 수 없습니다: " + transitionId);
   }
 }

--- a/backend/src/main/java/com/init/domainpack/application/exception/WorkflowTransitionNotFoundException.java
+++ b/backend/src/main/java/com/init/domainpack/application/exception/WorkflowTransitionNotFoundException.java
@@ -1,0 +1,9 @@
+package com.init.domainpack.application.exception;
+
+import com.init.shared.application.exception.NotFoundException;
+
+public class WorkflowTransitionNotFoundException extends NotFoundException {
+  public WorkflowTransitionNotFoundException(String transitionId) {
+    super("WORKFLOW_TRANSITION_NOT_FOUND", "Workflow transition not found: " + transitionId);
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/presentation/WorkflowDefinitionController.java
+++ b/backend/src/main/java/com/init/domainpack/presentation/WorkflowDefinitionController.java
@@ -4,10 +4,13 @@ import com.init.domainpack.application.GetWorkflowDefinitionListQuery;
 import com.init.domainpack.application.GetWorkflowDefinitionListUseCase;
 import com.init.domainpack.application.GetWorkflowDefinitionQuery;
 import com.init.domainpack.application.GetWorkflowDefinitionUseCase;
+import com.init.domainpack.application.GetWorkflowTransitionQuery;
+import com.init.domainpack.application.GetWorkflowTransitionUseCase;
 import com.init.domainpack.application.UpdateWorkflowCommand;
 import com.init.domainpack.application.UpdateWorkflowUseCase;
 import com.init.domainpack.application.WorkflowDefinitionDetail;
 import com.init.domainpack.application.WorkflowDefinitionSummary;
+import com.init.domainpack.application.WorkflowTransitionDetail;
 import com.init.domainpack.presentation.dto.UpdateWorkflowRequest;
 import com.init.shared.presentation.AuthenticationUtils;
 import jakarta.validation.Valid;
@@ -29,14 +32,17 @@ public class WorkflowDefinitionController {
   private final GetWorkflowDefinitionListUseCase listUseCase;
   private final GetWorkflowDefinitionUseCase detailUseCase;
   private final UpdateWorkflowUseCase updateUseCase;
+  private final GetWorkflowTransitionUseCase transitionUseCase;
 
   public WorkflowDefinitionController(
       GetWorkflowDefinitionListUseCase listUseCase,
       GetWorkflowDefinitionUseCase detailUseCase,
-      UpdateWorkflowUseCase updateUseCase) {
+      UpdateWorkflowUseCase updateUseCase,
+      GetWorkflowTransitionUseCase transitionUseCase) {
     this.listUseCase = listUseCase;
     this.detailUseCase = detailUseCase;
     this.updateUseCase = updateUseCase;
+    this.transitionUseCase = transitionUseCase;
   }
 
   @GetMapping
@@ -64,6 +70,21 @@ public class WorkflowDefinitionController {
         detailUseCase.execute(
             new GetWorkflowDefinitionQuery(workspaceId, packId, versionId, workflowId, userId));
     return ResponseEntity.ok(result);
+  }
+
+  @GetMapping("/{workflowId}/transitions/{transitionId}")
+  public ResponseEntity<WorkflowTransitionDetail> getTransition(
+      @PathVariable Long workspaceId,
+      @PathVariable Long packId,
+      @PathVariable Long versionId,
+      @PathVariable Long workflowId,
+      @PathVariable String transitionId,
+      Authentication authentication) {
+    Long userId = AuthenticationUtils.getUserId(authentication);
+    return ResponseEntity.ok(
+        transitionUseCase.execute(
+            new GetWorkflowTransitionQuery(
+                workspaceId, packId, versionId, workflowId, transitionId, userId)));
   }
 
   @PatchMapping("/{workflowId}")

--- a/backend/src/test/java/com/init/domainpack/application/CreateDomainPackDraftUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/CreateDomainPackDraftUseCaseTest.java
@@ -56,8 +56,8 @@ class CreateDomainPackDraftUseCaseTest {
           + "{\"id\":\"terminal\",\"label\":\"종료\",\"type\":\"TERMINAL\"}"
           + "],"
           + "\"edges\":["
-          + "{\"from\":\"start\",\"to\":\"action1\"},"
-          + "{\"from\":\"action1\",\"to\":\"terminal\"}"
+          + "{\"id\":\"e_start_to_action1\",\"from\":\"start\",\"to\":\"action1\"},"
+          + "{\"id\":\"e_action1_to_terminal\",\"from\":\"action1\",\"to\":\"terminal\"}"
           + "]}";
 
   // DECISION 노드 포함 유효한 그래프 (label 있음)
@@ -70,9 +70,9 @@ class CreateDomainPackDraftUseCaseTest {
           + "{\"id\":\"t2\",\"label\":\"종료2\",\"type\":\"TERMINAL\"}"
           + "],"
           + "\"edges\":["
-          + "{\"from\":\"start\",\"to\":\"dec\"},"
-          + "{\"from\":\"dec\",\"to\":\"t1\",\"label\":\"yes\"},"
-          + "{\"from\":\"dec\",\"to\":\"t2\",\"label\":\"no\"}"
+          + "{\"id\":\"e_start_to_dec\",\"from\":\"start\",\"to\":\"dec\"},"
+          + "{\"id\":\"e_dec_to_t1\",\"from\":\"dec\",\"to\":\"t1\",\"label\":\"yes\"},"
+          + "{\"id\":\"e_dec_to_t2\",\"from\":\"dec\",\"to\":\"t2\",\"label\":\"no\"}"
           + "]}";
 
   @Mock private DomainPackVersionRepository domainPackVersionRepository;

--- a/backend/src/test/java/com/init/domainpack/application/CreateDomainPackDraftUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/CreateDomainPackDraftUseCaseTest.java
@@ -12,6 +12,8 @@ import com.init.domainpack.application.exception.DomainPackNotFoundException;
 import com.init.domainpack.application.exception.DomainPackWorkspaceNotFoundException;
 import com.init.domainpack.application.exception.WorkflowCycleDetectedException;
 import com.init.domainpack.application.exception.WorkflowDanglingEdgeException;
+import com.init.domainpack.application.exception.WorkflowEdgeIdDuplicateException;
+import com.init.domainpack.application.exception.WorkflowEdgeIdMissingException;
 import com.init.domainpack.application.exception.WorkflowInvalidStartNodeException;
 import com.init.domainpack.application.exception.WorkflowInvalidTerminalNodeException;
 import com.init.domainpack.application.exception.WorkflowUnlabeledBranchException;
@@ -328,6 +330,46 @@ class CreateDomainPackDraftUseCaseTest {
             + "]}";
     assertThatThrownBy(() -> useCase.execute(commandWithGraphJson(unlabeled)))
         .isInstanceOf(WorkflowUnlabeledBranchException.class);
+  }
+
+  @Test
+  @DisplayName("graphJson V7a 위반 — edge id 누락 시 WorkflowEdgeIdMissingException")
+  void execute_v7a_missingEdgeId_throwsException() {
+    stubWorkspaceAndPack();
+    String missingEdgeIdGraph =
+        "{\"direction\":\"LR\","
+            + "\"nodes\":["
+            + "{\"id\":\"start\",\"label\":\"시작\",\"type\":\"START\"},"
+            + "{\"id\":\"action1\",\"label\":\"처리\",\"type\":\"ACTION\"},"
+            + "{\"id\":\"terminal\",\"label\":\"종료\",\"type\":\"TERMINAL\"}"
+            + "],"
+            + "\"edges\":["
+            + "{\"from\":\"start\",\"to\":\"action1\"},"
+            + "{\"id\":\"e_action1_to_terminal\",\"from\":\"action1\",\"to\":\"terminal\"}"
+            + "]}";
+    assertThatThrownBy(() -> useCase.execute(commandWithGraphJson(missingEdgeIdGraph)))
+        .isInstanceOf(WorkflowEdgeIdMissingException.class);
+  }
+
+  @Test
+  @DisplayName("graphJson V7b 위반 — edge id 중복 시 WorkflowEdgeIdDuplicateException")
+  void execute_v7b_duplicateEdgeId_throwsException() {
+    stubWorkspaceAndPack();
+    String duplicateEdgeIdGraph =
+        "{\"direction\":\"LR\","
+            + "\"nodes\":["
+            + "{\"id\":\"start\",\"label\":\"시작\",\"type\":\"START\"},"
+            + "{\"id\":\"dec\",\"label\":\"분기\",\"type\":\"DECISION\"},"
+            + "{\"id\":\"t1\",\"label\":\"종료1\",\"type\":\"TERMINAL\"},"
+            + "{\"id\":\"t2\",\"label\":\"종료2\",\"type\":\"TERMINAL\"}"
+            + "],"
+            + "\"edges\":["
+            + "{\"id\":\"dup\",\"from\":\"start\",\"to\":\"dec\"},"
+            + "{\"id\":\"dup\",\"from\":\"dec\",\"to\":\"t1\",\"label\":\"yes\"},"
+            + "{\"id\":\"e_dec_to_t2\",\"from\":\"dec\",\"to\":\"t2\",\"label\":\"no\"}"
+            + "]}";
+    assertThatThrownBy(() -> useCase.execute(commandWithGraphJson(duplicateEdgeIdGraph)))
+        .isInstanceOf(WorkflowEdgeIdDuplicateException.class);
   }
 
   // ──────────────────────────────────────────────────────────────

--- a/backend/src/test/java/com/init/domainpack/application/CreateDomainPackDraftUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/CreateDomainPackDraftUseCaseTest.java
@@ -352,6 +352,25 @@ class CreateDomainPackDraftUseCaseTest {
   }
 
   @Test
+  @DisplayName("graphJson V7a 위반 — edge id 공백 시 WorkflowEdgeIdMissingException")
+  void execute_v7a_blankEdgeId_throwsException() {
+    stubWorkspaceAndPack();
+    String blankEdgeIdGraph =
+        "{\"direction\":\"LR\","
+            + "\"nodes\":["
+            + "{\"id\":\"start\",\"label\":\"시작\",\"type\":\"START\"},"
+            + "{\"id\":\"action1\",\"label\":\"처리\",\"type\":\"ACTION\"},"
+            + "{\"id\":\"terminal\",\"label\":\"종료\",\"type\":\"TERMINAL\"}"
+            + "],"
+            + "\"edges\":["
+            + "{\"id\":\"   \",\"from\":\"start\",\"to\":\"action1\"},"
+            + "{\"id\":\"e_action1_to_terminal\",\"from\":\"action1\",\"to\":\"terminal\"}"
+            + "]}";
+    assertThatThrownBy(() -> useCase.execute(commandWithGraphJson(blankEdgeIdGraph)))
+        .isInstanceOf(WorkflowEdgeIdMissingException.class);
+  }
+
+  @Test
   @DisplayName("graphJson V7b 위반 — edge id 중복 시 WorkflowEdgeIdDuplicateException")
   void execute_v7b_duplicateEdgeId_throwsException() {
     stubWorkspaceAndPack();

--- a/backend/src/test/java/com/init/domainpack/application/GetWorkflowTransitionUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/GetWorkflowTransitionUseCaseTest.java
@@ -1,0 +1,209 @@
+package com.init.domainpack.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.init.domainpack.application.exception.DomainPackNotFoundException;
+import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
+import com.init.domainpack.application.exception.DomainPackVersionNotFoundException;
+import com.init.domainpack.application.exception.DomainPackWorkspaceNotFoundException;
+import com.init.domainpack.application.exception.WorkflowDefinitionNotFoundException;
+import com.init.domainpack.application.exception.WorkflowGraphJsonInvalidException;
+import com.init.domainpack.application.exception.WorkflowTransitionNotFoundException;
+import com.init.domainpack.domain.model.DomainPackVersion;
+import com.init.domainpack.domain.model.WorkflowDefinition;
+import com.init.domainpack.domain.repository.DomainPackRepository;
+import com.init.domainpack.domain.repository.DomainPackVersionRepository;
+import com.init.domainpack.domain.repository.WorkflowDefinitionRepository;
+import com.init.domainpack.domain.repository.WorkspaceExistencePort;
+import com.init.domainpack.domain.repository.WorkspaceMembershipPort;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetWorkflowTransitionUseCase")
+class GetWorkflowTransitionUseCaseTest {
+
+  @Mock private WorkspaceExistencePort workspaceExistencePort;
+  @Mock private WorkspaceMembershipPort workspaceMembershipPort;
+  @Mock private DomainPackRepository domainPackRepository;
+  @Mock private DomainPackVersionRepository domainPackVersionRepository;
+  @Mock private WorkflowDefinitionRepository workflowDefinitionRepository;
+
+  private GetWorkflowTransitionUseCase useCase;
+
+  private static final Long WORKSPACE_ID = 1L;
+  private static final Long PACK_ID = 7L;
+  private static final Long VERSION_ID = 101L;
+  private static final Long WORKFLOW_ID = 3001L;
+  private static final Long USER_ID = 10L;
+  private static final String TRANSITION_ID = "e_check_to_answer";
+
+  private static final String GRAPH_WITH_LABEL =
+      "{\"direction\":\"LR\","
+          + "\"nodes\":["
+          + "{\"id\":\"check\",\"type\":\"DECISION\"},"
+          + "{\"id\":\"answer\",\"type\":\"ACTION\"},"
+          + "{\"id\":\"end\",\"type\":\"TERMINAL\"}],"
+          + "\"edges\":["
+          + "{\"id\":\"e_check_to_answer\",\"from\":\"check\",\"to\":\"answer\",\"label\":\"eligible\"},"
+          + "{\"id\":\"e_answer_to_end\",\"from\":\"answer\",\"to\":\"end\"}]}";
+
+  private static final String GRAPH_WITHOUT_LABEL =
+      "{\"direction\":\"LR\","
+          + "\"nodes\":["
+          + "{\"id\":\"start\",\"type\":\"START\"},"
+          + "{\"id\":\"end\",\"type\":\"TERMINAL\"}],"
+          + "\"edges\":["
+          + "{\"id\":\"e_check_to_answer\",\"from\":\"start\",\"to\":\"end\"}]}";
+
+  @BeforeEach
+  void setUp() {
+    DomainPackValidator validator =
+        new DomainPackValidator(
+            workspaceExistencePort,
+            workspaceMembershipPort,
+            domainPackRepository,
+            domainPackVersionRepository);
+    useCase = new GetWorkflowTransitionUseCase(validator, workflowDefinitionRepository);
+  }
+
+  @Test
+  @DisplayName("정상 조회 (label 있음) — 전 필드 반환")
+  void execute_withLabel_returnsDetail() {
+    stubValidWorkspace();
+    given(workflowDefinitionRepository.findByIdAndDomainPackVersionId(WORKFLOW_ID, VERSION_ID))
+        .willReturn(Optional.of(createWorkflow(WORKFLOW_ID, GRAPH_WITH_LABEL)));
+
+    WorkflowTransitionDetail result =
+        useCase.execute(query(TRANSITION_ID));
+
+    assertThat(result.id()).isEqualTo("e_check_to_answer");
+    assertThat(result.workflowDefinitionId()).isEqualTo(WORKFLOW_ID);
+    assertThat(result.domainPackVersionId()).isEqualTo(VERSION_ID);
+    assertThat(result.from()).isEqualTo("check");
+    assertThat(result.to()).isEqualTo("answer");
+    assertThat(result.label()).isEqualTo("eligible");
+  }
+
+  @Test
+  @DisplayName("정상 조회 (label 없음) — label == null")
+  void execute_withoutLabel_returnsNullLabel() {
+    stubValidWorkspace();
+    given(workflowDefinitionRepository.findByIdAndDomainPackVersionId(WORKFLOW_ID, VERSION_ID))
+        .willReturn(Optional.of(createWorkflow(WORKFLOW_ID, GRAPH_WITHOUT_LABEL)));
+
+    WorkflowTransitionDetail result =
+        useCase.execute(query(TRANSITION_ID));
+
+    assertThat(result.label()).isNull();
+  }
+
+  @Test
+  @DisplayName("transitionId 미존재 → WorkflowTransitionNotFoundException")
+  void execute_transitionNotFound_throwsException() {
+    stubValidWorkspace();
+    given(workflowDefinitionRepository.findByIdAndDomainPackVersionId(WORKFLOW_ID, VERSION_ID))
+        .willReturn(Optional.of(createWorkflow(WORKFLOW_ID, GRAPH_WITH_LABEL)));
+
+    assertThatThrownBy(() -> useCase.execute(query("non_existent_edge")))
+        .isInstanceOf(WorkflowTransitionNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("workflowId 미존재 → WorkflowDefinitionNotFoundException")
+  void execute_workflowNotFound_throwsException() {
+    stubValidWorkspace();
+    given(workflowDefinitionRepository.findByIdAndDomainPackVersionId(WORKFLOW_ID, VERSION_ID))
+        .willReturn(Optional.empty());
+
+    assertThatThrownBy(() -> useCase.execute(query(TRANSITION_ID)))
+        .isInstanceOf(WorkflowDefinitionNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("DB 저장된 graphJson 파싱 오류 → WorkflowGraphJsonInvalidException")
+  void execute_invalidGraphJson_throwsException() {
+    stubValidWorkspace();
+    given(workflowDefinitionRepository.findByIdAndDomainPackVersionId(WORKFLOW_ID, VERSION_ID))
+        .willReturn(Optional.of(createWorkflow(WORKFLOW_ID, "not-valid-json{")));
+
+    assertThatThrownBy(() -> useCase.execute(query(TRANSITION_ID)))
+        .isInstanceOf(WorkflowGraphJsonInvalidException.class);
+  }
+
+  @Test
+  @DisplayName("workspace 미존재 → DomainPackWorkspaceNotFoundException")
+  void execute_workspaceNotFound_throwsException() {
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(false);
+
+    assertThatThrownBy(() -> useCase.execute(query(TRANSITION_ID)))
+        .isInstanceOf(DomainPackWorkspaceNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("접근 권한 없음 → DomainPackUnauthorizedWorkspaceAccessException")
+  void execute_unauthorized_throwsException() {
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(false);
+
+    assertThatThrownBy(() -> useCase.execute(query(TRANSITION_ID)))
+        .isInstanceOf(DomainPackUnauthorizedWorkspaceAccessException.class);
+  }
+
+  @Test
+  @DisplayName("pack 소속 불일치 → DomainPackNotFoundException")
+  void execute_packNotInWorkspace_throwsException() {
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(false);
+
+    assertThatThrownBy(() -> useCase.execute(query(TRANSITION_ID)))
+        .isInstanceOf(DomainPackNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("version 소속 불일치 → DomainPackVersionNotFoundException")
+  void execute_versionNotInPack_throwsException() {
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(true);
+    given(domainPackVersionRepository.findById(VERSION_ID))
+        .willReturn(Optional.of(DomainPackVersion.ofForTest(VERSION_ID, 999L, DomainPackVersion.STATUS_DRAFT)));
+
+    assertThatThrownBy(() -> useCase.execute(query(TRANSITION_ID)))
+        .isInstanceOf(DomainPackVersionNotFoundException.class);
+  }
+
+  // ── helpers ─────────────────────────────────────────────────────────────────
+
+  private GetWorkflowTransitionQuery query(String transitionId) {
+    return new GetWorkflowTransitionQuery(
+        WORKSPACE_ID, PACK_ID, VERSION_ID, WORKFLOW_ID, transitionId, USER_ID);
+  }
+
+  private void stubValidWorkspace() {
+    given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(true);
+    given(domainPackVersionRepository.findById(VERSION_ID))
+        .willReturn(
+            Optional.of(DomainPackVersion.ofForTest(VERSION_ID, PACK_ID, DomainPackVersion.STATUS_DRAFT)));
+  }
+
+  private WorkflowDefinition createWorkflow(Long id, String graphJson) {
+    WorkflowDefinition wf =
+        WorkflowDefinition.create(
+            VERSION_ID, "wf_refund", "환불 플로우", null, graphJson, "start", "[\"end\"]", null, null);
+    ReflectionTestUtils.setField(wf, "id", id);
+    return wf;
+  }
+}

--- a/backend/src/test/java/com/init/domainpack/application/GetWorkflowTransitionUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/GetWorkflowTransitionUseCaseTest.java
@@ -85,8 +85,7 @@ class GetWorkflowTransitionUseCaseTest {
         .willReturn(Optional.of(createWorkflow(WORKFLOW_ID, GRAPH_WITH_LABEL)));
 
     // when
-    WorkflowTransitionDetail result =
-        useCase.execute(query(TRANSITION_ID));
+    WorkflowTransitionDetail result = useCase.execute(query(TRANSITION_ID));
 
     // then
     assertThat(result.id()).isEqualTo("e_check_to_answer");
@@ -106,8 +105,7 @@ class GetWorkflowTransitionUseCaseTest {
         .willReturn(Optional.of(createWorkflow(WORKFLOW_ID, GRAPH_WITHOUT_LABEL)));
 
     // when
-    WorkflowTransitionDetail result =
-        useCase.execute(query(TRANSITION_ID));
+    WorkflowTransitionDetail result = useCase.execute(query(TRANSITION_ID));
 
     // then
     assertThat(result.label()).isNull();
@@ -196,7 +194,9 @@ class GetWorkflowTransitionUseCaseTest {
     given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
     given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(true);
     given(domainPackVersionRepository.findById(VERSION_ID))
-        .willReturn(Optional.of(DomainPackVersion.ofForTest(VERSION_ID, 999L, DomainPackVersion.STATUS_DRAFT)));
+        .willReturn(
+            Optional.of(
+                DomainPackVersion.ofForTest(VERSION_ID, 999L, DomainPackVersion.STATUS_DRAFT)));
 
     // when & then
     assertThatThrownBy(() -> useCase.execute(query(TRANSITION_ID)))
@@ -216,7 +216,8 @@ class GetWorkflowTransitionUseCaseTest {
     given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(true);
     given(domainPackVersionRepository.findById(VERSION_ID))
         .willReturn(
-            Optional.of(DomainPackVersion.ofForTest(VERSION_ID, PACK_ID, DomainPackVersion.STATUS_DRAFT)));
+            Optional.of(
+                DomainPackVersion.ofForTest(VERSION_ID, PACK_ID, DomainPackVersion.STATUS_DRAFT)));
   }
 
   private WorkflowDefinition createWorkflow(Long id, String graphJson) {

--- a/backend/src/test/java/com/init/domainpack/application/GetWorkflowTransitionUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/GetWorkflowTransitionUseCaseTest.java
@@ -78,14 +78,17 @@ class GetWorkflowTransitionUseCaseTest {
 
   @Test
   @DisplayName("정상 조회 (label 있음) — 전 필드 반환")
-  void execute_withLabel_returnsDetail() {
+  void should_detail반환_when_label있음() {
+    // given
     stubValidWorkspace();
     given(workflowDefinitionRepository.findByIdAndDomainPackVersionId(WORKFLOW_ID, VERSION_ID))
         .willReturn(Optional.of(createWorkflow(WORKFLOW_ID, GRAPH_WITH_LABEL)));
 
+    // when
     WorkflowTransitionDetail result =
         useCase.execute(query(TRANSITION_ID));
 
+    // then
     assertThat(result.id()).isEqualTo("e_check_to_answer");
     assertThat(result.workflowDefinitionId()).isEqualTo(WORKFLOW_ID);
     assertThat(result.domainPackVersionId()).isEqualTo(VERSION_ID);
@@ -96,89 +99,106 @@ class GetWorkflowTransitionUseCaseTest {
 
   @Test
   @DisplayName("정상 조회 (label 없음) — label == null")
-  void execute_withoutLabel_returnsNullLabel() {
+  void should_label이null_when_label없음() {
+    // given
     stubValidWorkspace();
     given(workflowDefinitionRepository.findByIdAndDomainPackVersionId(WORKFLOW_ID, VERSION_ID))
         .willReturn(Optional.of(createWorkflow(WORKFLOW_ID, GRAPH_WITHOUT_LABEL)));
 
+    // when
     WorkflowTransitionDetail result =
         useCase.execute(query(TRANSITION_ID));
 
+    // then
     assertThat(result.label()).isNull();
   }
 
   @Test
   @DisplayName("transitionId 미존재 → WorkflowTransitionNotFoundException")
-  void execute_transitionNotFound_throwsException() {
+  void should_WorkflowTransitionNotFoundException발생_when_transitionId미존재() {
+    // given
     stubValidWorkspace();
     given(workflowDefinitionRepository.findByIdAndDomainPackVersionId(WORKFLOW_ID, VERSION_ID))
         .willReturn(Optional.of(createWorkflow(WORKFLOW_ID, GRAPH_WITH_LABEL)));
 
+    // when & then
     assertThatThrownBy(() -> useCase.execute(query("non_existent_edge")))
         .isInstanceOf(WorkflowTransitionNotFoundException.class);
   }
 
   @Test
   @DisplayName("workflowId 미존재 → WorkflowDefinitionNotFoundException")
-  void execute_workflowNotFound_throwsException() {
+  void should_WorkflowDefinitionNotFoundException발생_when_workflowId미존재() {
+    // given
     stubValidWorkspace();
     given(workflowDefinitionRepository.findByIdAndDomainPackVersionId(WORKFLOW_ID, VERSION_ID))
         .willReturn(Optional.empty());
 
+    // when & then
     assertThatThrownBy(() -> useCase.execute(query(TRANSITION_ID)))
         .isInstanceOf(WorkflowDefinitionNotFoundException.class);
   }
 
   @Test
   @DisplayName("DB 저장된 graphJson 파싱 오류 → WorkflowGraphJsonInvalidException")
-  void execute_invalidGraphJson_throwsException() {
+  void should_WorkflowGraphJsonInvalidException발생_when_graphJson파싱오류() {
+    // given
     stubValidWorkspace();
     given(workflowDefinitionRepository.findByIdAndDomainPackVersionId(WORKFLOW_ID, VERSION_ID))
         .willReturn(Optional.of(createWorkflow(WORKFLOW_ID, "not-valid-json{")));
 
+    // when & then
     assertThatThrownBy(() -> useCase.execute(query(TRANSITION_ID)))
         .isInstanceOf(WorkflowGraphJsonInvalidException.class);
   }
 
   @Test
   @DisplayName("workspace 미존재 → DomainPackWorkspaceNotFoundException")
-  void execute_workspaceNotFound_throwsException() {
+  void should_DomainPackWorkspaceNotFoundException발생_when_workspace미존재() {
+    // given
     given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(false);
 
+    // when & then
     assertThatThrownBy(() -> useCase.execute(query(TRANSITION_ID)))
         .isInstanceOf(DomainPackWorkspaceNotFoundException.class);
   }
 
   @Test
   @DisplayName("접근 권한 없음 → DomainPackUnauthorizedWorkspaceAccessException")
-  void execute_unauthorized_throwsException() {
+  void should_DomainPackUnauthorizedWorkspaceAccessException발생_when_접근권한없음() {
+    // given
     given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
     given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(false);
 
+    // when & then
     assertThatThrownBy(() -> useCase.execute(query(TRANSITION_ID)))
         .isInstanceOf(DomainPackUnauthorizedWorkspaceAccessException.class);
   }
 
   @Test
   @DisplayName("pack 소속 불일치 → DomainPackNotFoundException")
-  void execute_packNotInWorkspace_throwsException() {
+  void should_DomainPackNotFoundException발생_when_pack소속불일치() {
+    // given
     given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
     given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
     given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(false);
 
+    // when & then
     assertThatThrownBy(() -> useCase.execute(query(TRANSITION_ID)))
         .isInstanceOf(DomainPackNotFoundException.class);
   }
 
   @Test
   @DisplayName("version 소속 불일치 → DomainPackVersionNotFoundException")
-  void execute_versionNotInPack_throwsException() {
+  void should_DomainPackVersionNotFoundException발생_when_version소속불일치() {
+    // given
     given(workspaceExistencePort.existsById(WORKSPACE_ID)).willReturn(true);
     given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
     given(domainPackRepository.existsByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID)).willReturn(true);
     given(domainPackVersionRepository.findById(VERSION_ID))
         .willReturn(Optional.of(DomainPackVersion.ofForTest(VERSION_ID, 999L, DomainPackVersion.STATUS_DRAFT)));
 
+    // when & then
     assertThatThrownBy(() -> useCase.execute(query(TRANSITION_ID)))
         .isInstanceOf(DomainPackVersionNotFoundException.class);
   }

--- a/backend/src/test/java/com/init/domainpack/application/UpdateWorkflowUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/UpdateWorkflowUseCaseTest.java
@@ -9,6 +9,8 @@ import static org.mockito.Mockito.verify;
 
 import com.init.domainpack.application.exception.WorkflowCycleDetectedException;
 import com.init.domainpack.application.exception.WorkflowDanglingEdgeException;
+import com.init.domainpack.application.exception.WorkflowEdgeIdDuplicateException;
+import com.init.domainpack.application.exception.WorkflowEdgeIdMissingException;
 import com.init.domainpack.application.exception.WorkflowInvalidStartNodeException;
 import com.init.domainpack.application.exception.WorkflowInvalidTerminalNodeException;
 import com.init.domainpack.application.exception.WorkflowUnlabeledBranchException;
@@ -35,7 +37,7 @@ class UpdateWorkflowUseCaseTest {
   private static final String VALID_GRAPH =
       "{\"direction\":\"LR\","
           + "\"nodes\":[{\"id\":\"start\",\"type\":\"START\"},{\"id\":\"end\",\"type\":\"TERMINAL\"}],"
-          + "\"edges\":[{\"from\":\"start\",\"to\":\"end\",\"label\":null}]}";
+          + "\"edges\":[{\"id\":\"e_start_to_end\",\"from\":\"start\",\"to\":\"end\",\"label\":null}]}";
 
   @Mock private DomainPackValidator validator;
   @Mock private DomainPackVersionRepository versionRepository;
@@ -309,6 +311,54 @@ class UpdateWorkflowUseCaseTest {
                     new UpdateWorkflowCommand(
                         1L, 7L, 10L, 99L, 5L, "이름", null, unlabeledDecisionGraph)))
         .isInstanceOf(WorkflowUnlabeledBranchException.class);
+    verify(workflowRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("V7a 위반(edge id 누락) 시 WorkflowEdgeIdMissingException")
+  void should_V7a예외_when_edge아이디누락() {
+    DomainPackVersion version = draftVersion(10L, 7L);
+    given(versionRepository.findById(10L)).willReturn(Optional.of(version));
+    WorkflowDefinition workflow = workflow(99L, 10L);
+    given(workflowRepository.findByIdAndDomainPackVersionId(99L, 10L))
+        .willReturn(Optional.of(workflow));
+    String noEdgeIdGraph =
+        "{\"direction\":\"LR\","
+            + "\"nodes\":[{\"id\":\"start\",\"type\":\"START\"},{\"id\":\"end\",\"type\":\"TERMINAL\"}],"
+            + "\"edges\":[{\"from\":\"start\",\"to\":\"end\",\"label\":null}]}";
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdateWorkflowCommand(1L, 7L, 10L, 99L, 5L, "이름", null, noEdgeIdGraph)))
+        .isInstanceOf(WorkflowEdgeIdMissingException.class);
+    verify(workflowRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("V7b 위반(edge id 중복) 시 WorkflowEdgeIdDuplicateException")
+  void should_V7b예외_when_edge아이디중복() {
+    DomainPackVersion version = draftVersion(10L, 7L);
+    given(versionRepository.findById(10L)).willReturn(Optional.of(version));
+    WorkflowDefinition workflow = workflow(99L, 10L);
+    given(workflowRepository.findByIdAndDomainPackVersionId(99L, 10L))
+        .willReturn(Optional.of(workflow));
+    String duplicateEdgeIdGraph =
+        "{\"direction\":\"LR\","
+            + "\"nodes\":["
+            + "{\"id\":\"start\",\"type\":\"START\"},"
+            + "{\"id\":\"mid\",\"type\":\"ACTION\"},"
+            + "{\"id\":\"end\",\"type\":\"TERMINAL\"}],"
+            + "\"edges\":["
+            + "{\"id\":\"dup\",\"from\":\"start\",\"to\":\"mid\",\"label\":null},"
+            + "{\"id\":\"dup\",\"from\":\"mid\",\"to\":\"end\",\"label\":null}]}";
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdateWorkflowCommand(
+                        1L, 7L, 10L, 99L, 5L, "이름", null, duplicateEdgeIdGraph)))
+        .isInstanceOf(WorkflowEdgeIdDuplicateException.class);
     verify(workflowRepository, never()).save(any());
   }
 

--- a/backend/src/test/java/com/init/domainpack/presentation/WorkflowDefinitionControllerTest.java
+++ b/backend/src/test/java/com/init/domainpack/presentation/WorkflowDefinitionControllerTest.java
@@ -8,12 +8,16 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.init.domainpack.application.GetWorkflowDefinitionListUseCase;
 import com.init.domainpack.application.GetWorkflowDefinitionUseCase;
+import com.init.domainpack.application.GetWorkflowTransitionUseCase;
 import com.init.domainpack.application.UpdateWorkflowUseCase;
 import com.init.domainpack.application.WorkflowDefinitionDetail;
 import com.init.domainpack.application.WorkflowDefinitionSummary;
+import com.init.domainpack.application.WorkflowTransitionDetail;
 import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
 import com.init.domainpack.application.exception.DomainPackVersionNotFoundException;
 import com.init.domainpack.application.exception.WorkflowDefinitionNotFoundException;
+import com.init.domainpack.application.exception.WorkflowGraphJsonInvalidException;
+import com.init.domainpack.application.exception.WorkflowTransitionNotFoundException;
 import com.init.fixtures.WithLongPrincipal;
 import com.init.shared.infrastructure.security.JwtAuthenticationFilter;
 import java.time.OffsetDateTime;
@@ -44,6 +48,7 @@ class WorkflowDefinitionControllerTest {
   @MockitoBean private GetWorkflowDefinitionListUseCase listUseCase;
   @MockitoBean private GetWorkflowDefinitionUseCase detailUseCase;
   @MockitoBean private UpdateWorkflowUseCase updateUseCase;
+  @MockitoBean private GetWorkflowTransitionUseCase transitionUseCase;
 
   @Test
   @DisplayName("GET .../workflows → 200 OK, 목록 반환")
@@ -152,6 +157,97 @@ class WorkflowDefinitionControllerTest {
 
     mockMvc
         .perform(get(BASE_URL))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("DOMAIN_PACK_VERSION_NOT_FOUND"));
+  }
+
+  @Test
+  @DisplayName("GET .../workflows/{id}/transitions/{transitionId} → 200 전 필드 검증")
+  @WithLongPrincipal(10L)
+  void should_200반환_when_transition정상조회() throws Exception {
+    given(transitionUseCase.execute(any()))
+        .willReturn(
+            new WorkflowTransitionDetail(
+                "e_check_to_answer", 1L, 101L, "check_refund_policy", "answer_refund", "eligible"));
+
+    mockMvc
+        .perform(get(BASE_URL + "/1/transitions/e_check_to_answer"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value("e_check_to_answer"))
+        .andExpect(jsonPath("$.workflowDefinitionId").value(1))
+        .andExpect(jsonPath("$.domainPackVersionId").value(101))
+        .andExpect(jsonPath("$.from").value("check_refund_policy"))
+        .andExpect(jsonPath("$.to").value("answer_refund"))
+        .andExpect(jsonPath("$.label").value("eligible"));
+  }
+
+  @Test
+  @DisplayName("GET .../workflows/{id}/transitions/{transitionId} → 404 transition 미존재")
+  @WithLongPrincipal(10L)
+  void should_404반환_when_transition미존재() throws Exception {
+    given(transitionUseCase.execute(any()))
+        .willThrow(new WorkflowTransitionNotFoundException("e_missing"));
+
+    mockMvc
+        .perform(get(BASE_URL + "/1/transitions/e_missing"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("WORKFLOW_TRANSITION_NOT_FOUND"));
+  }
+
+  @Test
+  @DisplayName("GET .../workflows/{id}/transitions/{transitionId} → 404 workflow 미존재")
+  @WithLongPrincipal(10L)
+  void should_404반환_when_workflow미존재_transition조회() throws Exception {
+    given(transitionUseCase.execute(any())).willThrow(new WorkflowDefinitionNotFoundException(99L));
+
+    mockMvc
+        .perform(get(BASE_URL + "/99/transitions/e_any"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("WORKFLOW_DEFINITION_NOT_FOUND"));
+  }
+
+  @Test
+  @DisplayName("GET .../workflows/{id}/transitions/{transitionId} → 500 graphJson 파싱 오류")
+  @WithLongPrincipal(10L)
+  void should_500반환_when_graphJson파싱오류() throws Exception {
+    given(transitionUseCase.execute(any()))
+        .willThrow(new WorkflowGraphJsonInvalidException(1L, new RuntimeException("bad json")));
+
+    mockMvc
+        .perform(get(BASE_URL + "/1/transitions/e_any"))
+        .andExpect(status().isInternalServerError())
+        .andExpect(jsonPath("$.code").value("WORKFLOW_GRAPH_JSON_INVALID"));
+  }
+
+  @Test
+  @DisplayName("GET .../workflows/{id}/transitions/{transitionId} → 403 권한 없음")
+  @WithLongPrincipal(10L)
+  void should_403반환_when_권한없음_transition() throws Exception {
+    given(transitionUseCase.execute(any()))
+        .willThrow(new DomainPackUnauthorizedWorkspaceAccessException("접근 권한이 없습니다."));
+
+    mockMvc
+        .perform(get(BASE_URL + "/1/transitions/e_any"))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.code").value("FORBIDDEN"));
+  }
+
+  @Test
+  @DisplayName("GET .../workflows/{id}/transitions/{transitionId} → 401 미인증")
+  void should_401반환_when_미인증_transition() throws Exception {
+    mockMvc
+        .perform(get(BASE_URL + "/1/transitions/e_any"))
+        .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @DisplayName("GET .../workflows/{id}/transitions/{transitionId} → 404 version 미존재")
+  @WithLongPrincipal(10L)
+  void should_404반환_when_version미존재_transition() throws Exception {
+    given(transitionUseCase.execute(any())).willThrow(new DomainPackVersionNotFoundException(101L));
+
+    mockMvc
+        .perform(get(BASE_URL + "/1/transitions/e_any"))
         .andExpect(status().isNotFound())
         .andExpect(jsonPath("$.code").value("DOMAIN_PACK_VERSION_NOT_FOUND"));
   }

--- a/backend/src/test/java/com/init/domainpack/presentation/WorkflowDefinitionControllerTest.java
+++ b/backend/src/test/java/com/init/domainpack/presentation/WorkflowDefinitionControllerTest.java
@@ -235,9 +235,7 @@ class WorkflowDefinitionControllerTest {
   @Test
   @DisplayName("GET .../workflows/{id}/transitions/{transitionId} → 401 미인증")
   void should_401반환_when_미인증_transition() throws Exception {
-    mockMvc
-        .perform(get(BASE_URL + "/1/transitions/e_any"))
-        .andExpect(status().isUnauthorized());
+    mockMvc.perform(get(BASE_URL + "/1/transitions/e_any")).andExpect(status().isUnauthorized());
   }
 
   @Test

--- a/backend/src/test/java/com/init/domainpack/presentation/WorkflowDefinitionUpdateControllerTest.java
+++ b/backend/src/test/java/com/init/domainpack/presentation/WorkflowDefinitionUpdateControllerTest.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.init.domainpack.application.GetWorkflowDefinitionListUseCase;
 import com.init.domainpack.application.GetWorkflowDefinitionUseCase;
+import com.init.domainpack.application.GetWorkflowTransitionUseCase;
 import com.init.domainpack.application.UpdateWorkflowCommand;
 import com.init.domainpack.application.UpdateWorkflowUseCase;
 import com.init.domainpack.application.WorkflowDefinitionDetail;
@@ -58,6 +59,7 @@ class WorkflowDefinitionUpdateControllerTest {
   @MockitoBean private GetWorkflowDefinitionListUseCase listUseCase;
   @MockitoBean private GetWorkflowDefinitionUseCase detailUseCase;
   @MockitoBean private UpdateWorkflowUseCase updateUseCase;
+  @MockitoBean private GetWorkflowTransitionUseCase transitionUseCase;
 
   @Test
   @DisplayName("유효한 요청 시 200 OK + WorkflowDefinitionDetail 반환")


### PR DESCRIPTION
## Summary

- `GET …/workflows/{workflowId}/transitions/{transitionId}` 엔드포인트 신규 추가 (READ 전용)
- `WorkflowGraphValidator.parseAndValidate()`에 V7a(edge id 존재·비어있지 않음), V7b(edge id 고유) 검증 추가
- V7c(정규식 패턴 검증)는 U-03 결정에 따라 이번 PR에 미포함

---

## Context

`.agent/specs/2217.md` ([BE] 2.2.17) 구현 PR.  
`graph_json` edge에 고유 `id` 필드를 추가하고, 특정 workflow에 속한 transition 초안을 단건 조회하는 엔드포인트를 제공한다.

---

## What Changed

- **신규**: `GetWorkflowTransitionQuery`, `GetWorkflowTransitionUseCase`, `WorkflowTransitionDetail`, `WorkflowTransitionNotFoundException`
- **신규 예외**: `WorkflowEdgeIdMissingException` (`WORKFLOW_EDGE_ID_MISSING`), `WorkflowEdgeIdDuplicateException` (`WORKFLOW_EDGE_ID_DUPLICATE`)
- **수정**: `WorkflowGraphJsonInvalidException` — `(Long workflowId, Throwable cause)` 생성자 추가
- **수정**: `WorkflowGraphValidator` — V7a/V7b 메서드 추가 (`parseAndValidate()` 끝에 체이닝)
- **수정**: `WorkflowDefinitionController` — `@GetMapping("/{workflowId}/transitions/{transitionId}")` 핸들러 추가
- **테스트 수정**: `UpdateWorkflowUseCaseTest` VALID_GRAPH에 edge id 추가 + V7a/V7b 케이스 2개 추가
- **테스트 수정**: `CreateDomainPackDraftUseCaseTest` 픽스처에 edge id 추가
- **테스트 신규**: `GetWorkflowTransitionUseCaseTest` (9개), `WorkflowDefinitionControllerTest` 추가분 (7개)
- **DDL 변경 없음** — `pack.workflow_definition.graph_json` JSONB 내부 구조만 변경

---

## Assumptions Adopted

| ID | 채택 내용 | 영향 |
|----|-----------|------|
| U-01 | V7 write-path를 `WorkflowGraphValidator.parseAndValidate()`에 추가하여 `UpdateWorkflowUseCase`, `CreateDomainPackDraftUseCase` 양쪽 자동 적용 | 기존 edge id 없는 draft를 UpdateWorkflow로 수정하면 V7a 예외 발생. 운영자는 신규 pipeline 재실행 필요 |
| U-02 | 마이그레이션 스크립트 없음 (spec Additional Notes 일치) | 기존 edge id 없는 draft의 GET transition은 404 반환 |
| U-03 | V7a에서 null/blank 체크만 구현. V7c 정규식(`[A-Za-z0-9_-]+`) 미구현 | URL 예약문자 포함 edge id가 저장될 수 있음. 후속 spec에서 V7c 추가 필요 |

---

## Spec Deviations

N/A — 모든 spec 요구사항과 Spec Consistency 체크 전항목 Pass.

---

## Blocked / Skipped Items

| 항목 | 이유 |
|------|------|
| V7c 정규식 검증 | U-03 결정: MAY 허용, 이번 PR에서 non-empty만 구현. 후속 PR에서 추가 필요 |
| ACTION ↔ policy 연결 (`policyRef`) | U-04: spec 범위 외 (FE는 spec 2211 policy API 별도 조합) |
| 기존 draft edge id 마이그레이션 | U-02: spec 명시 범위 외 |

---

## Test Notes

| 레이어 | 케이스 수 | 결과 |
|--------|-----------|------|
| `GetWorkflowTransitionUseCaseTest` | 9개 (spec 8 + version 미존재 1개 추가) | 전체 통과 |
| `WorkflowDefinitionControllerTest` (추가분) | 7개 | 전체 통과 |
| `UpdateWorkflowUseCaseTest` (V7a/V7b 추가분) | 2개 | 전체 통과 |

Audit V-001(테스트 메서드 네이밍), V-002(Given-When-Then 주석) 위반 사항은 Fix Agent에서 자동 수정 완료.  
V-003(`WorkflowTransitionDetail` static ObjectMapper)는 Info 수준, 기능 위험 없어 Skipped.

---

## Reviewer Focus

1. **`WorkflowGraphValidator`** V7a/V7b 추가 위치 — `parseAndValidate()` 끝에 체이닝되어 기존 V6 이후 적용되는지 확인
2. **`WorkflowTransitionDetail.fromGraphJson()`** — Jackson 파싱 예외 처리 경로 (`WorkflowGraphJsonInvalidException` 생성자 추가분) 확인
3. **U-03 리스크 인지** — V7c 미구현으로 URL 예약문자 포함 edge id가 저장될 수 있음. transitionId PathVariable 매핑 시 잠재 오류 경로 존재

---

## Conflicts (if any)

없음.

---

## Ready to Merge / Needs Input

**Ready to Merge** — Audit PASS, 모든 테스트 통과, User Decision 필요 항목 없음.  
V7c는 후속 PR에서 처리 예정.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * 워크플로우 전환 세부 정보 조회 API 및 해당 조회 처리 로직 추가

* **Bug Fixes**
  * 워크플로우 그래프 엣지 검증 강화: 모든 엣지는 non-blank ID 필수 및 ID 중복 금지

* **Tests**
  * 그래프 엣지 ID 요구사항 반영한 테스트 픽스처 수정 및 누락/중복 케이스에 대한 신규 단위 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->