### PR TITLE
feat(frontend): add #214 intent draft read page

### DIFF
--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -21,8 +21,7 @@ export function App() {
         <Route path="/reset-password/complete" element={<PasswordResetCompletePage />} />
         <Route path="/upload" element={<PrivateRoute><UploadPage /></PrivateRoute>} />
         <Route path="/consultation" element={<PrivateRoute><ConsultationPage /></PrivateRoute>} />
-        <Route path="/workspaces/:workspaceId/domain-packs/:packId/versions/:versionId/intents" element={<PrivateRoute><IntentDraftReadPage /></PrivateRoute>} />
-        <Route path="/workspaces/:workspaceId/domain-packs/:packId/versions/:versionId/intents/:intentId" element={<PrivateRoute><IntentDraftReadPage /></PrivateRoute>} />
+        <Route path="/workspaces/:workspaceId/domain-packs/:packId/versions/:versionId/intents/:intentId?" element={<PrivateRoute><IntentDraftReadPage /></PrivateRoute>} />
         <Route path="/workspaces/:workspaceId/domain-packs/:packId/versions/:versionId/workflows" element={<PrivateRoute><WorkflowDraftReadPage /></PrivateRoute>} />
         <Route path="/workspaces/:workspaceId/domain-packs/:packId/versions/:versionId/workflows/:workflowId" element={<PrivateRoute><WorkflowDraftReadPage /></PrivateRoute>} />
         <Route path="*" element={<NotFoundPage />} />

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -6,6 +6,7 @@ import { PasswordResetInitPage } from '../pages/password-reset/ui/PasswordResetI
 import { PasswordResetCompletePage } from '../pages/password-reset/ui/PasswordResetCompletePage';
 import { ConsultationPage } from '../pages/consultation/ui/ConsultationPage';
 import { NotFoundPage } from '../pages/not-found/ui/NotFoundPage';
+import { IntentDraftReadPage } from '../pages/domain-pack/ui/IntentDraftReadPage';
 import { WorkflowDraftReadPage } from '../pages/domain-pack/ui/WorkflowDraftReadPage';
 import { PrivateRoute } from '../shared/ui/PrivateRoute';
 
@@ -20,6 +21,8 @@ export function App() {
         <Route path="/reset-password/complete" element={<PasswordResetCompletePage />} />
         <Route path="/upload" element={<PrivateRoute><UploadPage /></PrivateRoute>} />
         <Route path="/consultation" element={<PrivateRoute><ConsultationPage /></PrivateRoute>} />
+        <Route path="/workspaces/:workspaceId/domain-packs/:packId/versions/:versionId/intents" element={<PrivateRoute><IntentDraftReadPage /></PrivateRoute>} />
+        <Route path="/workspaces/:workspaceId/domain-packs/:packId/versions/:versionId/intents/:intentId" element={<PrivateRoute><IntentDraftReadPage /></PrivateRoute>} />
         <Route path="/workspaces/:workspaceId/domain-packs/:packId/versions/:versionId/workflows" element={<PrivateRoute><WorkflowDraftReadPage /></PrivateRoute>} />
         <Route path="/workspaces/:workspaceId/domain-packs/:packId/versions/:versionId/workflows/:workflowId" element={<PrivateRoute><WorkflowDraftReadPage /></PrivateRoute>} />
         <Route path="*" element={<NotFoundPage />} />

--- a/frontend/src/entities/intent/index.ts
+++ b/frontend/src/entities/intent/index.ts
@@ -1,0 +1,1 @@
+export type { IntentDetail, IntentSummary, IntentTreeNode } from "./model/types";

--- a/frontend/src/entities/intent/model/types.ts
+++ b/frontend/src/entities/intent/model/types.ts
@@ -11,20 +11,10 @@ export interface IntentSummary {
   updatedAt: string;
 }
 
-export interface IntentDetail {
-  id: number;
-  intentCode: string;
-  name: string;
-  description: string | null;
-  taxonomyLevel: number;
-  parentIntentId: number | null;
-  status: string;
-  sourceClusterRef: string;
+export interface IntentDetail extends IntentSummary {
   entryConditionJson: string;
   evidenceJson: string;
   metaJson: string;
-  createdAt: string;
-  updatedAt: string;
 }
 
 export interface IntentTreeNode extends IntentSummary {

--- a/frontend/src/entities/intent/model/types.ts
+++ b/frontend/src/entities/intent/model/types.ts
@@ -1,0 +1,32 @@
+export interface IntentSummary {
+  id: number;
+  intentCode: string;
+  name: string;
+  description: string | null;
+  taxonomyLevel: number;
+  parentIntentId: number | null;
+  status: string;
+  sourceClusterRef: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface IntentDetail {
+  id: number;
+  intentCode: string;
+  name: string;
+  description: string | null;
+  taxonomyLevel: number;
+  parentIntentId: number | null;
+  status: string;
+  sourceClusterRef: string;
+  entryConditionJson: string;
+  evidenceJson: string;
+  metaJson: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface IntentTreeNode extends IntentSummary {
+  children: IntentTreeNode[];
+}

--- a/frontend/src/features/intent-draft-read/api/intentApi.ts
+++ b/frontend/src/features/intent-draft-read/api/intentApi.ts
@@ -1,0 +1,14 @@
+import { apiClient } from "../../../shared/api";
+import type { IntentDetail, IntentSummary } from "../../../entities/intent";
+
+export const intentApi = {
+  list: (wsId: number, packId: number, versionId: number) =>
+    apiClient.get<IntentSummary[]>(
+      `/workspaces/${wsId}/domain-packs/${packId}/versions/${versionId}/intents`,
+    ),
+
+  detail: (wsId: number, packId: number, versionId: number, intentId: number) =>
+    apiClient.get<IntentDetail>(
+      `/workspaces/${wsId}/domain-packs/${packId}/versions/${versionId}/intents/${intentId}`,
+    ),
+};

--- a/frontend/src/features/intent-draft-read/model/buildIntentTree.test.ts
+++ b/frontend/src/features/intent-draft-read/model/buildIntentTree.test.ts
@@ -66,4 +66,24 @@ describe("buildIntentTree", () => {
     expect(tree[0].id).toBe(10);
     expect(tree[0].children[0].id).toBe(20);
   });
+
+  it("다단계 순환이 있으면 순환 링크를 끊고 루트로 유지한다", () => {
+    const tree = buildIntentTree([
+      stub({ id: 10, intentCode: "A", name: "A", parentIntentId: 20 }),
+      stub({ id: 20, intentCode: "B", name: "B", parentIntentId: 10 }),
+    ]);
+
+    expect(tree.map((node) => node.id)).toEqual([10, 20]);
+    expect(tree.every((node) => node.children.length === 0)).toBe(true);
+  });
+
+  it("중복 id는 첫 항목만 유지한다", () => {
+    const tree = buildIntentTree([
+      stub({ id: 10, intentCode: "FIRST", name: "First" }),
+      stub({ id: 10, intentCode: "SECOND", name: "Second" }),
+    ]);
+
+    expect(tree).toHaveLength(1);
+    expect(tree[0].intentCode).toBe("FIRST");
+  });
 });

--- a/frontend/src/features/intent-draft-read/model/buildIntentTree.test.ts
+++ b/frontend/src/features/intent-draft-read/model/buildIntentTree.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { buildIntentTree } from "./buildIntentTree";
+import type { IntentSummary } from "../../../entities/intent";
+
+const stub = (overrides: Partial<IntentSummary>): IntentSummary => ({
+  id: 1,
+  intentCode: "INTENT",
+  name: "Intent",
+  description: null,
+  taxonomyLevel: 1,
+  parentIntentId: null,
+  status: "ACTIVE",
+  sourceClusterRef: "{}",
+  createdAt: "",
+  updatedAt: "",
+  ...overrides,
+});
+
+describe("buildIntentTree", () => {
+  it("parentIntentId 기준으로 부모-자식 트리를 구성한다", () => {
+    const tree = buildIntentTree([
+      stub({ id: 10, intentCode: "ROOT", name: "Root" }),
+      stub({
+        id: 20,
+        intentCode: "CHILD",
+        name: "Child",
+        parentIntentId: 10,
+        taxonomyLevel: 2,
+      }),
+    ]);
+
+    expect(tree).toHaveLength(1);
+    expect(tree[0].id).toBe(10);
+    expect(tree[0].children).toHaveLength(1);
+    expect(tree[0].children[0].id).toBe(20);
+  });
+
+  it("부모가 없으면 루트로 유지한다", () => {
+    const tree = buildIntentTree([
+      stub({ id: 10, intentCode: "ROOT", name: "Root" }),
+      stub({
+        id: 20,
+        intentCode: "ORPHAN",
+        name: "Orphan",
+        parentIntentId: 999,
+        taxonomyLevel: 2,
+      }),
+    ]);
+
+    expect(tree.map((node) => node.id)).toEqual([10, 20]);
+  });
+
+  it("입력 순서가 뒤섞여 있어도 트리를 연결한다", () => {
+    const tree = buildIntentTree([
+      stub({
+        id: 20,
+        intentCode: "CHILD",
+        name: "Child",
+        parentIntentId: 10,
+        taxonomyLevel: 2,
+      }),
+      stub({ id: 10, intentCode: "ROOT", name: "Root" }),
+    ]);
+
+    expect(tree).toHaveLength(1);
+    expect(tree[0].id).toBe(10);
+    expect(tree[0].children[0].id).toBe(20);
+  });
+});

--- a/frontend/src/features/intent-draft-read/model/buildIntentTree.ts
+++ b/frontend/src/features/intent-draft-read/model/buildIntentTree.ts
@@ -1,0 +1,27 @@
+import type { IntentSummary, IntentTreeNode } from "../../../entities/intent";
+
+export function buildIntentTree(items: IntentSummary[]): IntentTreeNode[] {
+  const nodeMap = new Map<number, IntentTreeNode>();
+
+  for (const item of items) {
+    nodeMap.set(item.id, { ...item, children: [] });
+  }
+
+  const roots: IntentTreeNode[] = [];
+
+  for (const item of items) {
+    const node = nodeMap.get(item.id);
+    if (!node) continue;
+
+    const parent = item.parentIntentId === null ? undefined : nodeMap.get(item.parentIntentId);
+
+    if (!parent || parent.id === node.id) {
+      roots.push(node);
+      continue;
+    }
+
+    parent.children.push(node);
+  }
+
+  return roots;
+}

--- a/frontend/src/features/intent-draft-read/model/buildIntentTree.ts
+++ b/frontend/src/features/intent-draft-read/model/buildIntentTree.ts
@@ -2,20 +2,28 @@ import type { IntentSummary, IntentTreeNode } from "../../../entities/intent";
 
 export function buildIntentTree(items: IntentSummary[]): IntentTreeNode[] {
   const nodeMap = new Map<number, IntentTreeNode>();
+  const itemMap = new Map<number, IntentSummary>();
+  const orderedItems: IntentSummary[] = [];
 
   for (const item of items) {
+    if (nodeMap.has(item.id)) {
+      continue;
+    }
+
     nodeMap.set(item.id, { ...item, children: [] });
+    itemMap.set(item.id, item);
+    orderedItems.push(item);
   }
 
   const roots: IntentTreeNode[] = [];
 
-  for (const item of items) {
+  for (const item of orderedItems) {
     const node = nodeMap.get(item.id);
     if (!node) continue;
 
     const parent = item.parentIntentId === null ? undefined : nodeMap.get(item.parentIntentId);
 
-    if (!parent || parent.id === node.id) {
+    if (!parent || createsCycle(parent.id, node.id, itemMap)) {
       roots.push(node);
       continue;
     }
@@ -24,4 +32,24 @@ export function buildIntentTree(items: IntentSummary[]): IntentTreeNode[] {
   }
 
   return roots;
+}
+
+function createsCycle(
+  candidateParentId: number,
+  nodeId: number,
+  itemMap: Map<number, IntentSummary>,
+): boolean {
+  const visited = new Set<number>();
+  let currentId: number | null = candidateParentId;
+
+  while (currentId !== null) {
+    if (currentId === nodeId || visited.has(currentId)) {
+      return true;
+    }
+
+    visited.add(currentId);
+    currentId = itemMap.get(currentId)?.parentIntentId ?? null;
+  }
+
+  return false;
 }

--- a/frontend/src/features/intent-draft-read/model/mapApiError.ts
+++ b/frontend/src/features/intent-draft-read/model/mapApiError.ts
@@ -1,0 +1,13 @@
+import { ApiRequestError } from "../../../shared/api";
+
+export function mapApiError(e: unknown): {
+  status: "error";
+  code: string;
+  message: string;
+  httpStatus?: number;
+} {
+  if (e instanceof ApiRequestError) {
+    return { status: "error", code: e.code, message: e.message, httpStatus: e.status };
+  }
+  return { status: "error", code: "UNKNOWN_ERROR", message: "알 수 없는 오류가 발생했습니다." };
+}

--- a/frontend/src/features/intent-draft-read/model/useIntentDetail.test.ts
+++ b/frontend/src/features/intent-draft-read/model/useIntentDetail.test.ts
@@ -1,0 +1,77 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useIntentDetail } from "./useIntentDetail";
+import { ApiRequestError } from "../../../shared/api";
+
+vi.mock("../api/intentApi", () => ({
+  intentApi: {
+    list: vi.fn(),
+    detail: vi.fn(),
+  },
+}));
+
+import { intentApi } from "../api/intentApi";
+
+const mockedDetail = vi.mocked(intentApi.detail);
+
+const stubDetail = {
+  id: 10,
+  intentCode: "INTENT_001",
+  name: "배송 조회 문의",
+  description: null,
+  taxonomyLevel: 1,
+  parentIntentId: null,
+  status: "ACTIVE",
+  sourceClusterRef: "{}",
+  entryConditionJson: "{}",
+  evidenceJson: "[]",
+  metaJson: "{}",
+  createdAt: "",
+  updatedAt: "",
+};
+
+describe("useIntentDetail", () => {
+  beforeEach(() => {
+    mockedDetail.mockReset();
+  });
+
+  it("intentId가 null이면 idle 상태다", () => {
+    const { result } = renderHook(() => useIntentDetail(1, 2, 3, null));
+    expect(result.current.status).toBe("idle");
+    expect(mockedDetail).not.toHaveBeenCalled();
+  });
+
+  it("intentId가 주어지면 loading 상태로 시작한다", () => {
+    mockedDetail.mockReturnValue(new Promise(() => {}));
+    const { result } = renderHook(() => useIntentDetail(1, 2, 3, 10));
+    expect(result.current.status).toBe("loading");
+  });
+
+  it("성공 시 ready 상태로 전이된다", async () => {
+    mockedDetail.mockResolvedValue(stubDetail);
+    const { result } = renderHook(() => useIntentDetail(1, 2, 3, 10));
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+    if (result.current.status === "ready") {
+      expect(result.current.data).toEqual(stubDetail);
+    }
+  });
+
+  it("404 에러 시 httpStatus를 포함한 error 상태가 된다", async () => {
+    mockedDetail.mockRejectedValue(new ApiRequestError(404, "NOT_FOUND", "없음"));
+    const { result } = renderHook(() => useIntentDetail(1, 2, 3, 99));
+    await waitFor(() => expect(result.current.status).toBe("error"));
+    if (result.current.status === "error") {
+      expect(result.current.httpStatus).toBe(404);
+      expect(result.current.code).toBe("NOT_FOUND");
+    }
+  });
+
+  it("알 수 없는 오류 시 UNKNOWN_ERROR가 된다", async () => {
+    mockedDetail.mockRejectedValue(new Error("unexpected"));
+    const { result } = renderHook(() => useIntentDetail(1, 2, 3, 5));
+    await waitFor(() => expect(result.current.status).toBe("error"));
+    if (result.current.status === "error") {
+      expect(result.current.code).toBe("UNKNOWN_ERROR");
+    }
+  });
+});

--- a/frontend/src/features/intent-draft-read/model/useIntentDetail.ts
+++ b/frontend/src/features/intent-draft-read/model/useIntentDetail.ts
@@ -1,0 +1,63 @@
+import { useEffect, useState } from "react";
+import { intentApi } from "../api/intentApi";
+import { mapApiError } from "./mapApiError";
+import type { IntentDetail } from "../../../entities/intent";
+
+export type IntentDetailState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "error"; code: string; message: string; httpStatus?: number }
+  | { status: "ready"; data: IntentDetail };
+
+export function useIntentDetail(
+  wsId: number,
+  packId: number,
+  versionId: number,
+  intentId: number | null,
+): IntentDetailState {
+  const requestKey = intentId === null ? null : `${wsId}:${packId}:${versionId}:${intentId}`;
+  const [state, setState] = useState<{
+    requestKey: string | null;
+    value: IntentDetailState;
+  }>({
+    requestKey: null,
+    value: { status: "idle" },
+  });
+
+  useEffect(() => {
+    if (intentId === null) {
+      return;
+    }
+
+    let cancelled = false;
+
+    intentApi
+      .detail(wsId, packId, versionId, intentId)
+      .then((data) => {
+        if (!cancelled) {
+          setState({
+            requestKey,
+            value: { status: "ready", data },
+          });
+        }
+      })
+      .catch((e: unknown) => {
+        if (!cancelled) {
+          setState({
+            requestKey,
+            value: mapApiError(e),
+          });
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [intentId, packId, requestKey, versionId, wsId]);
+
+  if (requestKey === null) {
+    return { status: "idle" };
+  }
+
+  return state.requestKey === requestKey ? state.value : { status: "loading" };
+}

--- a/frontend/src/features/intent-draft-read/model/useIntentList.test.ts
+++ b/frontend/src/features/intent-draft-read/model/useIntentList.test.ts
@@ -1,0 +1,77 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useIntentList } from "./useIntentList";
+import { ApiRequestError } from "../../../shared/api";
+
+vi.mock("../api/intentApi", () => ({
+  intentApi: {
+    list: vi.fn(),
+    detail: vi.fn(),
+  },
+}));
+
+import { intentApi } from "../api/intentApi";
+
+const mockedList = vi.mocked(intentApi.list);
+
+const stubIntent = {
+  id: 1,
+  intentCode: "INTENT_001",
+  name: "배송 조회 문의",
+  description: null,
+  taxonomyLevel: 1,
+  parentIntentId: null,
+  status: "ACTIVE",
+  sourceClusterRef: "{}",
+  createdAt: "",
+  updatedAt: "",
+};
+
+describe("useIntentList", () => {
+  beforeEach(() => {
+    mockedList.mockReset();
+  });
+
+  it("초기 상태는 loading이다", () => {
+    mockedList.mockReturnValue(new Promise(() => {}));
+    const { result } = renderHook(() => useIntentList(1, 2, 3));
+    expect(result.current.status).toBe("loading");
+  });
+
+  it("성공 시 ready 상태로 전이된다", async () => {
+    mockedList.mockResolvedValue([stubIntent]);
+    const { result } = renderHook(() => useIntentList(1, 2, 3));
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+    if (result.current.status === "ready") {
+      expect(result.current.data).toEqual([stubIntent]);
+    }
+  });
+
+  it("빈 배열 응답도 ready 상태로 처리한다", async () => {
+    mockedList.mockResolvedValue([]);
+    const { result } = renderHook(() => useIntentList(1, 2, 3));
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+    if (result.current.status === "ready") {
+      expect(result.current.data).toHaveLength(0);
+    }
+  });
+
+  it("ApiRequestError 발생 시 error 상태와 httpStatus를 반환한다", async () => {
+    mockedList.mockRejectedValue(new ApiRequestError(403, "FORBIDDEN", "접근 금지"));
+    const { result } = renderHook(() => useIntentList(1, 2, 3));
+    await waitFor(() => expect(result.current.status).toBe("error"));
+    if (result.current.status === "error") {
+      expect(result.current.httpStatus).toBe(403);
+      expect(result.current.code).toBe("FORBIDDEN");
+    }
+  });
+
+  it("알 수 없는 오류는 UNKNOWN_ERROR로 변환한다", async () => {
+    mockedList.mockRejectedValue(new Error("network fail"));
+    const { result } = renderHook(() => useIntentList(1, 2, 3));
+    await waitFor(() => expect(result.current.status).toBe("error"));
+    if (result.current.status === "error") {
+      expect(result.current.code).toBe("UNKNOWN_ERROR");
+    }
+  });
+});

--- a/frontend/src/features/intent-draft-read/model/useIntentList.ts
+++ b/frontend/src/features/intent-draft-read/model/useIntentList.ts
@@ -1,0 +1,49 @@
+import { useEffect, useState } from "react";
+import { intentApi } from "../api/intentApi";
+import { mapApiError } from "./mapApiError";
+import type { IntentSummary } from "../../../entities/intent";
+
+export type IntentListState =
+  | { status: "loading" }
+  | { status: "error"; code: string; message: string; httpStatus?: number }
+  | { status: "ready"; data: IntentSummary[] };
+
+export function useIntentList(wsId: number, packId: number, versionId: number): IntentListState {
+  const requestKey = `${wsId}:${packId}:${versionId}`;
+  const [state, setState] = useState<{
+    requestKey: string;
+    value: IntentListState;
+  }>({
+    requestKey,
+    value: { status: "loading" },
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+
+    intentApi
+      .list(wsId, packId, versionId)
+      .then((data) => {
+        if (!cancelled) {
+          setState({
+            requestKey,
+            value: { status: "ready", data },
+          });
+        }
+      })
+      .catch((e: unknown) => {
+        if (!cancelled) {
+          setState({
+            requestKey,
+            value: mapApiError(e),
+          });
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [packId, requestKey, versionId, wsId]);
+
+  return state.requestKey === requestKey ? state.value : { status: "loading" };
+}

--- a/frontend/src/features/intent-draft-read/ui/IntentDetailPanel.module.css
+++ b/frontend/src/features/intent-draft-read/ui/IntentDetailPanel.module.css
@@ -1,0 +1,180 @@
+.panel {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-color);
+  overflow: hidden;
+  min-width: 0;
+}
+
+.header {
+  padding: 24px 28px 22px;
+  border-bottom: 1px solid var(--glass-border);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.code {
+  font-family: "Geist Mono", monospace;
+  font-size: 12px;
+  letter-spacing: 0.54px;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.name {
+  font-family: "Pretendard Variable", sans-serif;
+  font-size: 26px;
+  font-weight: 540;
+  line-height: 1.1;
+  letter-spacing: -0.26px;
+  color: var(--text-primary);
+}
+
+.description {
+  max-width: 60ch;
+  font-size: 18px;
+  font-weight: 330;
+  line-height: 1.4;
+  letter-spacing: -0.14px;
+  color: var(--text-secondary);
+}
+
+.updatedAt {
+  font-family: "Geist Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.54px;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.body {
+  flex: 1;
+  overflow: auto;
+  padding: 24px 28px 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.card {
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-lg);
+  background: var(--bg-color);
+  overflow: hidden;
+}
+
+.cardHeader {
+  padding: 12px 14px 0;
+  font-family: "Geist Mono", monospace;
+  font-size: 10px;
+  letter-spacing: 0.54px;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.cardBody {
+  padding: 10px 14px 16px;
+}
+
+.value {
+  font-size: 16px;
+  font-weight: 330;
+  line-height: 1.45;
+  letter-spacing: -0.14px;
+  color: var(--text-primary);
+  word-break: break-word;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  font-family: "Geist Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.54px;
+  text-transform: uppercase;
+  padding: 6px 12px 7px;
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--text-primary);
+  background: var(--text-primary);
+  color: var(--bg-color);
+}
+
+.jsonBlock {
+  background: var(--bg-secondary);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-lg);
+  padding: 18px;
+  font-family: "Geist Mono", monospace;
+  font-size: 12px;
+  line-height: 1.55;
+  color: var(--text-primary);
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.placeholder {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 10px;
+  margin: 20px;
+  padding: 40px 32px;
+  border: 1px dashed rgba(0, 0, 0, 0.14);
+  border-radius: var(--radius-lg);
+  color: var(--text-secondary);
+  font-size: 14px;
+  line-height: 1.5;
+  letter-spacing: -0.14px;
+  text-align: center;
+}
+
+.errorCode {
+  font-family: "Geist Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.54px;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.skeleton {
+  flex: 1;
+  background: var(--bg-secondary);
+  min-height: 240px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-lg);
+}
+
+@media (max-width: 767px) {
+  .header,
+  .body {
+    padding-left: 16px;
+    padding-right: 16px;
+  }
+
+  .name {
+    font-size: 22px;
+  }
+
+  .description {
+    font-size: 16px;
+  }
+
+  .grid {
+    grid-template-columns: 1fr;
+  }
+
+  .panel {
+    border-top: 1px solid var(--glass-border);
+  }
+}

--- a/frontend/src/features/intent-draft-read/ui/IntentDetailPanel.module.css
+++ b/frontend/src/features/intent-draft-read/ui/IntentDetailPanel.module.css
@@ -90,7 +90,7 @@
   line-height: 1.45;
   letter-spacing: -0.14px;
   color: var(--text-primary);
-  word-break: break-word;
+  overflow-wrap: anywhere;
 }
 
 .badge {
@@ -118,7 +118,7 @@
   color: var(--text-primary);
   overflow: auto;
   white-space: pre-wrap;
-  word-break: break-word;
+  overflow-wrap: anywhere;
 }
 
 .placeholder {

--- a/frontend/src/features/intent-draft-read/ui/IntentDetailPanel.tsx
+++ b/frontend/src/features/intent-draft-read/ui/IntentDetailPanel.tsx
@@ -1,0 +1,137 @@
+import { useEffect, type ReactNode } from "react";
+import { toast } from "sonner";
+import { useIntentDetail } from "../model/useIntentDetail";
+import type { IntentDetail } from "../../../entities/intent";
+import styles from "./IntentDetailPanel.module.css";
+
+interface IntentDetailPanelProps {
+  wsId: number;
+  packId: number;
+  versionId: number;
+  intentId: number | null;
+}
+
+export function IntentDetailPanel({ wsId, packId, versionId, intentId }: IntentDetailPanelProps) {
+  const state = useIntentDetail(wsId, packId, versionId, intentId);
+  const errorCode = state.status === "error" ? state.code : undefined;
+  const errorHttpStatus = state.status === "error" ? state.httpStatus : undefined;
+  const errorMessage = state.status === "error" ? state.message : undefined;
+
+  useEffect(() => {
+    if (state.status !== "error") return;
+    toast.error(
+      errorHttpStatus === 404
+        ? "intent를 찾을 수 없습니다."
+        : errorMessage || "상세 정보를 불러오지 못했습니다.",
+    );
+  }, [state.status, errorHttpStatus, errorMessage]);
+
+  if (state.status === "idle") {
+    return (
+      <section className={styles.panel} aria-label="intent 상세">
+        <div className={styles.placeholder}>
+          <span>좌측 목록에서 intent를 선택해 주세요.</span>
+        </div>
+      </section>
+    );
+  }
+
+  if (state.status === "loading") {
+    return (
+      <section className={styles.panel} aria-label="intent 상세">
+        <div className={styles.body}>
+          <div className={styles.skeleton} />
+        </div>
+      </section>
+    );
+  }
+
+  if (state.status === "error") {
+    return (
+      <section className={styles.panel} aria-label="intent 상세">
+        <div className={styles.placeholder}>
+          <span>상세 정보를 불러오지 못했습니다.</span>
+          <span className={styles.errorCode}>{errorCode}</span>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className={styles.panel} aria-label="intent 상세">
+      <DetailHeader detail={state.data} />
+      <div className={styles.body}>
+        <div className={styles.grid}>
+          <InfoCard
+            label="Status"
+            value={<span className={styles.badge}>{state.data.status}</span>}
+          />
+          <InfoCard
+            label="Taxonomy Level"
+            value={<span className={styles.value}>LV {state.data.taxonomyLevel}</span>}
+          />
+          <InfoCard
+            label="Parent Intent Id"
+            value={<span className={styles.value}>{state.data.parentIntentId ?? "—"}</span>}
+          />
+          <InfoCard
+            label="Created At"
+            value={<span className={styles.value}>{formatDate(state.data.createdAt)}</span>}
+          />
+        </div>
+        <JsonCard label="Source Cluster Ref" value={state.data.sourceClusterRef} />
+        <JsonCard label="Entry Condition" value={state.data.entryConditionJson} />
+        <JsonCard label="Evidence" value={state.data.evidenceJson} />
+        <JsonCard label="Meta" value={state.data.metaJson} />
+      </div>
+    </section>
+  );
+}
+
+function DetailHeader({ detail }: { detail: IntentDetail }) {
+  return (
+    <header className={styles.header}>
+      <span className={styles.code}>{detail.intentCode}</span>
+      <span className={styles.name}>{detail.name}</span>
+      {detail.description && <span className={styles.description}>{detail.description}</span>}
+      <span className={styles.updatedAt}>UPDATED · {formatDate(detail.updatedAt)}</span>
+    </header>
+  );
+}
+
+function InfoCard({ label, value }: { label: string; value: ReactNode }) {
+  return (
+    <section className={styles.card}>
+      <header className={styles.cardHeader}>{label}</header>
+      <div className={styles.cardBody}>{value}</div>
+    </section>
+  );
+}
+
+function JsonCard({ label, value }: { label: string; value: string }) {
+  return (
+    <section className={styles.card}>
+      <header className={styles.cardHeader}>{label}</header>
+      <div className={styles.cardBody}>
+        <pre className={styles.jsonBlock}>
+          <code>{formatJsonForDisplay(value)}</code>
+        </pre>
+      </div>
+    </section>
+  );
+}
+
+function formatJsonForDisplay(raw: string): string {
+  if (!raw) return "—";
+  try {
+    return JSON.stringify(JSON.parse(raw), null, 2);
+  } catch {
+    return raw;
+  }
+}
+
+function formatDate(raw: string): string {
+  const date = new Date(raw);
+  if (Number.isNaN(date.getTime())) return raw;
+  return date.toLocaleString();
+}

--- a/frontend/src/features/intent-draft-read/ui/IntentDetailPanel.tsx
+++ b/frontend/src/features/intent-draft-read/ui/IntentDetailPanel.tsx
@@ -19,12 +19,15 @@ export function IntentDetailPanel({ wsId, packId, versionId, intentId }: IntentD
 
   useEffect(() => {
     if (state.status !== "error") return;
-    toast.error(
+    const message =
       errorHttpStatus === 404
         ? "intent를 찾을 수 없습니다."
-        : errorMessage || "상세 정보를 불러오지 못했습니다.",
-    );
-  }, [state.status, errorHttpStatus, errorMessage]);
+        : errorMessage || "상세 정보를 불러오지 못했습니다.";
+
+    toast.error(message, {
+      id: `intent-detail-error-${wsId}-${packId}-${versionId}-${intentId ?? "none"}-${errorCode ?? errorHttpStatus ?? "unknown"}`,
+    });
+  }, [state.status, wsId, packId, versionId, intentId, errorCode, errorHttpStatus, errorMessage]);
 
   if (state.status === "idle") {
     return (

--- a/frontend/src/features/intent-draft-read/ui/IntentTreePanel.module.css
+++ b/frontend/src/features/intent-draft-read/ui/IntentTreePanel.module.css
@@ -92,7 +92,7 @@
   width: 2px;
   background-image: repeating-linear-gradient(
     to bottom,
-    currentColor 0 4px,
+    currentcolor 0 4px,
     transparent 4px 8px
   );
   opacity: 0.22;
@@ -134,7 +134,7 @@
   text-transform: uppercase;
   padding: 4px 10px 5px;
   border-radius: var(--radius-xl);
-  border: 1px solid currentColor;
+  border: 1px solid currentcolor;
   color: inherit;
   background: transparent;
 }

--- a/frontend/src/features/intent-draft-read/ui/IntentTreePanel.module.css
+++ b/frontend/src/features/intent-draft-read/ui/IntentTreePanel.module.css
@@ -1,0 +1,188 @@
+.panel {
+  width: 376px;
+  min-width: 296px;
+  border-right: 1px solid var(--glass-border);
+  background: var(--bg-color);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.header {
+  padding: 18px 20px 14px;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.04);
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.headerTitle {
+  font-family: "Pretendard Variable", sans-serif;
+  font-size: 18px;
+  font-weight: 540;
+  line-height: 1.15;
+  letter-spacing: -0.26px;
+  color: var(--text-primary);
+}
+
+.headerMeta {
+  font-family: "Geist Mono", monospace;
+  font-size: 12px;
+  letter-spacing: 0.54px;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.scroll {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px 16px 20px;
+}
+
+.treeGroup {
+  display: flex;
+  flex-direction: column;
+}
+
+.item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 16px 18px 17px;
+  margin-bottom: 8px;
+  border: 1px solid var(--glass-border);
+  border-radius: 28px;
+  background: var(--bg-color);
+  cursor: pointer;
+  color: var(--text-primary);
+  transition:
+    background var(--transition-fast),
+    border-color var(--transition-fast),
+    transform var(--transition-fast);
+}
+
+.item:hover {
+  background: rgba(0, 0, 0, 0.03);
+  border-color: rgba(0, 0, 0, 0.14);
+}
+
+.itemActive {
+  background: var(--text-primary);
+  color: var(--bg-color);
+  border-color: var(--text-primary);
+}
+
+.itemActive:hover {
+  background: var(--text-primary);
+}
+
+.itemInner {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.depthGuide {
+  position: absolute;
+  left: 0;
+  top: 6px;
+  bottom: 6px;
+  width: 2px;
+  background-image: repeating-linear-gradient(
+    to bottom,
+    currentColor 0 4px,
+    transparent 4px 8px
+  );
+  opacity: 0.22;
+}
+
+.code {
+  display: block;
+  font-family: "Geist Mono", monospace;
+  font-size: 10px;
+  letter-spacing: 0.54px;
+  text-transform: uppercase;
+  color: inherit;
+  opacity: 0.66;
+}
+
+.name {
+  display: block;
+  font-family: "Pretendard Variable", sans-serif;
+  font-size: 15px;
+  font-weight: 450;
+  line-height: 1.35;
+  letter-spacing: -0.14px;
+  color: inherit;
+}
+
+.meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-family: "Geist Mono", monospace;
+  font-size: 10px;
+  letter-spacing: 0.54px;
+  text-transform: uppercase;
+  padding: 4px 10px 5px;
+  border-radius: var(--radius-xl);
+  border: 1px solid currentColor;
+  color: inherit;
+  background: transparent;
+}
+
+.skeletonGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.skeletonRow {
+  height: 58px;
+  border-radius: 28px;
+  background: var(--bg-secondary);
+}
+
+.emptyState {
+  padding: 28px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  border: 1px dashed rgba(0, 0, 0, 0.14);
+  border-radius: var(--radius-lg);
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 1.5;
+  letter-spacing: -0.14px;
+}
+
+@media (max-width: 1023px) {
+  .panel {
+    width: 320px;
+    min-width: 248px;
+  }
+}
+
+@media (max-width: 767px) {
+  .panel {
+    width: 100%;
+    min-width: 0;
+    border-right: 0;
+  }
+
+  .header {
+    padding: 16px 16px 12px;
+  }
+
+  .scroll {
+    padding: 12px 12px 16px;
+  }
+}

--- a/frontend/src/features/intent-draft-read/ui/IntentTreePanel.tsx
+++ b/frontend/src/features/intent-draft-read/ui/IntentTreePanel.tsx
@@ -63,7 +63,7 @@ export function IntentTreePanel({
           </div>
         )}
 
-        {state.status === "ready" && (
+        {state.status === "ready" && state.data.length > 0 && (
           <div className={styles.treeGroup}>
             {tree.map((node) => (
               <IntentTreeRow

--- a/frontend/src/features/intent-draft-read/ui/IntentTreePanel.tsx
+++ b/frontend/src/features/intent-draft-read/ui/IntentTreePanel.tsx
@@ -1,0 +1,129 @@
+import { useEffect, useMemo } from "react";
+import { toast } from "sonner";
+import type { IntentTreeNode } from "../../../entities/intent";
+import { buildIntentTree } from "../model/buildIntentTree";
+import { useIntentList } from "../model/useIntentList";
+import styles from "./IntentTreePanel.module.css";
+
+interface IntentTreePanelProps {
+  wsId: number;
+  packId: number;
+  versionId: number;
+  selectedId: number | null;
+  onSelect: (id: number) => void;
+}
+
+export function IntentTreePanel({
+  wsId,
+  packId,
+  versionId,
+  selectedId,
+  onSelect,
+}: IntentTreePanelProps) {
+  const state = useIntentList(wsId, packId, versionId);
+  const errorMessage = state.status === "error" ? state.message : undefined;
+  const tree = useMemo(
+    () => (state.status === "ready" ? buildIntentTree(state.data) : []),
+    [state],
+  );
+
+  useEffect(() => {
+    if (state.status === "error") {
+      toast.error(errorMessage ?? "목록을 불러오지 못했습니다.");
+    }
+  }, [state.status, errorMessage]);
+
+  return (
+    <aside className={styles.panel} aria-label="intent 목록">
+      <header className={styles.header}>
+        <span className={styles.headerTitle}>Intents</span>
+        <span className={styles.headerMeta}>
+          {state.status === "ready" ? `${state.data.length} · TREE` : "— · TREE"}
+        </span>
+      </header>
+
+      <div className={styles.scroll}>
+        {state.status === "loading" && (
+          <div className={styles.skeletonGroup}>
+            <div className={styles.skeletonRow} />
+            <div className={styles.skeletonRow} />
+            <div className={styles.skeletonRow} />
+          </div>
+        )}
+
+        {state.status === "error" && (
+          <div className={styles.emptyState}>
+            <span>목록을 불러오지 못했습니다.</span>
+          </div>
+        )}
+
+        {state.status === "ready" && state.data.length === 0 && (
+          <div className={styles.emptyState}>
+            <span>해당 버전에 등록된 intent 초안이 없습니다.</span>
+          </div>
+        )}
+
+        {state.status === "ready" && (
+          <div className={styles.treeGroup}>
+            {tree.map((node) => (
+              <IntentTreeRow
+                key={node.id}
+                node={node}
+                depth={0}
+                selectedId={selectedId}
+                onSelect={onSelect}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </aside>
+  );
+}
+
+function IntentTreeRow({
+  node,
+  depth,
+  selectedId,
+  onSelect,
+}: {
+  node: IntentTreeNode;
+  depth: number;
+  selectedId: number | null;
+  onSelect: (id: number) => void;
+}) {
+  const isActive = node.id === selectedId;
+  const paddingLeft = 20 + depth * 18;
+
+  return (
+    <>
+      <button
+        type="button"
+        className={`${styles.item} ${isActive ? styles.itemActive : ""}`}
+        style={{ paddingLeft }}
+        onClick={() => onSelect(node.id)}
+        aria-current={isActive ? "true" : undefined}
+      >
+        <div className={styles.itemInner}>
+          {depth > 0 && <span className={styles.depthGuide} aria-hidden="true" />}
+          <span className={styles.code}>{node.intentCode}</span>
+          <span className={styles.name}>{node.name}</span>
+          <span className={styles.meta}>
+            <span className={styles.badge}>LV · {node.taxonomyLevel}</span>
+            <span className={styles.badge}>{node.status}</span>
+          </span>
+        </div>
+      </button>
+
+      {node.children.map((child) => (
+        <IntentTreeRow
+          key={child.id}
+          node={child}
+          depth={depth + 1}
+          selectedId={selectedId}
+          onSelect={onSelect}
+        />
+      ))}
+    </>
+  );
+}

--- a/frontend/src/features/intent-draft-read/ui/index.ts
+++ b/frontend/src/features/intent-draft-read/ui/index.ts
@@ -1,0 +1,2 @@
+export { IntentTreePanel } from "./IntentTreePanel";
+export { IntentDetailPanel } from "./IntentDetailPanel";

--- a/frontend/src/pages/domain-pack/ui/IntentDraftReadPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/IntentDraftReadPage.tsx
@@ -1,0 +1,74 @@
+import { useNavigate, useParams } from "react-router-dom";
+import { IntentDetailPanel, IntentTreePanel } from "../../../features/intent-draft-read/ui";
+import { parseRouteId } from "../../../shared/lib/parseRouteId";
+import { DashboardLayout } from "../../../shared/ui/layout/DashboardLayout";
+import styles from "./intent-draft-read-page.module.css";
+
+export function IntentDraftReadPage() {
+  const { workspaceId, packId, versionId, intentId } = useParams();
+  const navigate = useNavigate();
+
+  const wsId = parseRouteId(workspaceId);
+  const pId = parseRouteId(packId);
+  const vId = parseRouteId(versionId);
+  const iId = intentId ? parseRouteId(intentId) : null;
+
+  if (wsId === null || pId === null || vId === null || (intentId !== undefined && iId === null)) {
+    return (
+      <DashboardLayout>
+        <div className={styles.invalidParams} role="alert">
+          잘못된 URL 파라미터입니다.
+        </div>
+      </DashboardLayout>
+    );
+  }
+
+  const handleSelect = (id: number) => {
+    navigate(`/workspaces/${wsId}/domain-packs/${pId}/versions/${vId}/intents/${id}`);
+  };
+
+  const handleBack = () => {
+    navigate(`/workspaces/${wsId}/domain-packs/${pId}/versions/${vId}/intents`);
+  };
+
+  const hasSelection = iId !== null;
+
+  return (
+    <DashboardLayout>
+      <div className={styles.pageWrapper}>
+        <header className={styles.pageHeader}>
+          <nav className={styles.breadcrumb} aria-label="경로">
+            <span>WS · {wsId}</span>
+            <span className={styles.breadcrumbSeparator}>/</span>
+            <span>PACK · {pId}</span>
+            <span className={styles.breadcrumbSeparator}>/</span>
+            <span>VER · {vId}</span>
+          </nav>
+          <div className={styles.versionMeta}>
+            <span className={styles.versionTitle}>Intent 초안 조회</span>
+            <span className={styles.versionBadge}>READ ONLY</span>
+          </div>
+        </header>
+        {hasSelection && (
+          <button type="button" className={styles.backButton} onClick={handleBack}>
+            ← 목록
+          </button>
+        )}
+        <div className={`${styles.twoPane} ${hasSelection ? styles.hasSelection : ""}`}>
+          <div className={styles.listSlot}>
+            <IntentTreePanel
+              wsId={wsId}
+              packId={pId}
+              versionId={vId}
+              selectedId={iId}
+              onSelect={handleSelect}
+            />
+          </div>
+          <div className={styles.detailSlot}>
+            <IntentDetailPanel wsId={wsId} packId={pId} versionId={vId} intentId={iId} />
+          </div>
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/frontend/src/pages/domain-pack/ui/intent-draft-read-page.module.css
+++ b/frontend/src/pages/domain-pack/ui/intent-draft-read-page.module.css
@@ -1,0 +1,142 @@
+.pageWrapper {
+  --app-header-height: 72px;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: calc(100vh - var(--app-header-height));
+  overflow: hidden;
+  background: var(--bg-color);
+}
+
+.pageHeader {
+  padding: 20px 28px 18px;
+  border-bottom: 1px solid var(--glass-border);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  background: var(--bg-color);
+}
+
+.breadcrumb {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  font-family: "Geist Mono", monospace;
+  font-size: 12px;
+  line-height: 1;
+  letter-spacing: 0.54px;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.breadcrumbSeparator {
+  color: var(--text-muted);
+}
+
+.versionMeta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+}
+
+.versionTitle {
+  font-family: "Pretendard Variable", sans-serif;
+  font-weight: 540;
+  font-size: 24px;
+  line-height: 1.1;
+  letter-spacing: -0.26px;
+  color: var(--text-primary);
+}
+
+.versionBadge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: "Geist Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.54px;
+  text-transform: uppercase;
+  padding: 6px 12px 7px;
+  border-radius: var(--radius-xl);
+  background: var(--glass-dark);
+  border: 1px solid transparent;
+  color: var(--text-primary);
+}
+
+.twoPane {
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+  min-height: 0;
+}
+
+.invalidParams {
+  padding: 32px;
+  color: var(--text-secondary);
+  font-size: 14px;
+  letter-spacing: -0.14px;
+}
+
+.listSlot,
+.detailSlot {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+}
+
+.listSlot {
+  flex: 0 0 auto;
+}
+
+@media (max-width: 767px) {
+  .pageHeader {
+    padding: 16px 16px 14px;
+    gap: 10px;
+  }
+
+  .versionTitle {
+    font-size: 20px;
+  }
+
+  .twoPane {
+    flex-direction: column;
+  }
+
+  .twoPane.hasSelection .listSlot {
+    display: none;
+  }
+
+  .twoPane:not(.hasSelection) .listSlot {
+    flex: 1;
+    min-height: 0;
+  }
+
+  .twoPane:not(.hasSelection) .detailSlot {
+    display: none;
+  }
+
+  .backButton {
+    display: inline-flex;
+    align-self: flex-start;
+    margin: 12px 16px 0;
+    padding: 8px 16px 9px;
+    border-radius: var(--radius-xl);
+    border: 1px solid var(--text-primary);
+    background: var(--bg-color);
+    color: var(--text-primary);
+    font-family: "Geist Mono", monospace;
+    font-size: 11px;
+    letter-spacing: 0.54px;
+    text-transform: uppercase;
+    cursor: pointer;
+  }
+}
+
+@media (min-width: 768px) {
+  .backButton {
+    display: none;
+  }
+}

--- a/frontend/src/pages/domain-pack/ui/intent-draft-read-page.module.css
+++ b/frontend/src/pages/domain-pack/ui/intent-draft-read-page.module.css
@@ -1,5 +1,6 @@
 .pageWrapper {
   --app-header-height: 72px;
+
   display: flex;
   flex-direction: column;
   width: 100%;


### PR DESCRIPTION
## 요약
- #214 intent 초안 목록/상세 조회 화면을 추가했습니다.
- `domain-pack version` 기준 intent 목록과 단건 상세를 읽어오는 프런트엔드 흐름을 구현했습니다.
- 목록/상세 2-pane UI를 `frontend/DESIGN.md` 방향에 맞춰 214 화면 범위에서 정리했습니다.

## 변경 사항
- `entities/intent` 타입과 트리 노드 모델을 추가했습니다.
- `features/intent-draft-read`에 목록/상세 조회 API, 상태 훅, 트리 구성 로직, UI 패널을 추가했습니다.
- `IntentDraftReadPage`를 추가하고, intent 목록/상세 라우트를 `App.tsx`에 연결했습니다.
- 목록 정렬/계층 구성, 선택 상태, 에러 처리, 빈 상태, 모바일 back 흐름을 포함했습니다.

## 영향 범위
- 새로운 라우트가 추가됩니다.
  - `/workspaces/:workspaceId/domain-packs/:packId/versions/:versionId/intents`
  - `/workspaces/:workspaceId/domain-packs/:packId/versions/:versionId/intents/:intentId`
- 공용 레이아웃이나 공통 디자인 토큰은 수정하지 않았습니다.

## 검증
- `cd frontend && pnpm test -- --run src/features/intent-draft-read/model/buildIntentTree.test.ts src/features/intent-draft-read/model/useIntentList.test.ts src/features/intent-draft-read/model/useIntentDetail.test.ts`
- `cd frontend && pnpm build`
- 실제 backend(`:8080`) + frontend(`:4173`) 실행 후 브라우저에서 목록/상세 렌더링 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 의도 초안 조회 기능 추가: 도메인 팩 버전 내의 의도를 계층 구조 트리로 표시하고 선택한 의도의 상세 정보를 확인할 수 있습니다. 의도 코드, 이름, 설명, 상태, 분류 수준, 부모 의도, 생성/수정 시간 및 관련 JSON 메타데이터를 조회할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->