### PR TITLE
spec/3215: transition condition 초안 목록 조회 + graphJson 스키마에 policyRef 추가

### DIFF
--- a/.agent/specs/3215.md
+++ b/.agent/specs/3215.md
@@ -1,0 +1,369 @@
+# [BE] 3.2.15 — Transition Condition / Action 초안 목록 조회
+
+## Goal
+
+특정 워크플로우에 속한 모든 Transition(graphJson edge) 초안 목록을 조회하는 READ 전용 엔드포인트를 제공한다.
+각 transition은 edge 정보(`id`, `from`, `to`, `label`)와 함께, 목적지 노드가 ACTION 타입인 경우 해당 노드의 `policyRef`를 `toPolicyRef`로 함께 반환한다.
+
+---
+
+## graphJson ACTION Node Schema 변경
+
+### 기존
+
+```json
+{
+  "nodes": [
+    { "id": "check_refund", "type": "DECISION" },
+    { "id": "answer_refund", "type": "ACTION" }
+  ]
+}
+```
+
+### 변경 후 (policyRef 필드 추가)
+
+```json
+{
+  "nodes": [
+    { "id": "check_refund",  "type": "DECISION" },
+    { "id": "answer_refund", "type": "ACTION", "policyRef": "refund_eligible_policy" },
+    { "id": "handoff",       "type": "ACTION", "policyRef": "handoff_agent_policy"  },
+    { "id": "terminal",      "type": "TERMINAL" }
+  ]
+}
+```
+
+- `policyRef`: ACTION 타입 노드에 **필수**, 비어있지 않은 문자열.
+  - 값은 같은 domain pack version에 존재하는 `policyCode`와 동일해야 한다.
+  - `id`(그래프 내부 식별자)와는 독립적으로 관리된다. 동일한 값으로 지정해도 무방하나 강제하지 않는다.
+- 비 ACTION 타입 노드(`START`, `DECISION`, `TERMINAL`)에는 `policyRef` 불필요.
+
+### 신규 Validation Rule — V8 (write-time)
+
+| # | 규칙 | 위반 시 에러 코드 | 검증 위치 |
+|---|------|-----------------|-----------|
+| V8a | ACTION 타입 노드에 `policyRef` 필드가 존재하며 비어있지 않음 | `WORKFLOW_ACTION_NODE_POLICY_REF_MISSING` | `WorkflowGraphValidator` |
+| V8b | ACTION 타입 노드의 `policyRef`가 `[A-Za-z0-9_-]+` 패턴 충족 | `WORKFLOW_ACTION_NODE_POLICY_REF_INVALID_CHARS` | `WorkflowGraphValidator` |
+| V8c | ACTION 타입 노드의 `policyRef`가 같은 version의 policyCode 중 하나와 일치 | `WORKFLOW_ACTION_NODE_POLICY_REF_NOT_FOUND` | UseCase 레벨 (cross-entity, DB 접근 필요) |
+
+V8a·V8b는 `WorkflowGraphValidator.parseAndValidate`에 추가한다 (graphJson 내부 검증, DB 불필요).  
+V8c는 `UpdateWorkflowUseCase`와 `CreateDomainPackDraftUseCase`에서 별도로 검증한다.
+
+이 스펙은 V8을 **정의**한다. 실제 검증·강제 구현은 `UpdateWorkflowUseCase`(V8 추가)와 `CreateDomainPackDraftUseCase`(spec 231 참조)가 담당한다.
+
+---
+
+## Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    actor c as Client
+    participant ctrl as WorkflowDefinitionController
+    participant uc as GetWorkflowTransitionListUseCase
+    participant validator as DomainPackValidator
+    participant repo as WorkflowDefinitionRepository
+    participant db as PostgreSQL
+
+    c ->> ctrl: GET /api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/workflows/{workflowId}/transitions
+    ctrl ->> uc: execute(GetWorkflowTransitionListQuery)
+    uc ->> validator: validateWorkspaceAccess(workspaceId, userId)
+    validator -->> uc: ok
+    uc ->> validator: validateDomainPack(packId, workspaceId)
+    validator -->> uc: ok
+    uc ->> validator: validateVersion(versionId, packId)
+    validator -->> uc: ok
+    uc ->> repo: findByIdAndDomainPackVersionId(workflowId, versionId)
+    repo ->> db: SELECT * FROM pack.workflow_definition WHERE id = ? AND domain_pack_version_id = ?
+    db -->> repo: row
+    repo -->> uc: Optional<WorkflowDefinition>
+    uc ->> uc: parse graphJson → build nodeType/policyRef map → collect edges with toPolicyRef
+    uc -->> ctrl: List<WorkflowTransitionDetail>
+    ctrl -->> c: 200 OK
+```
+
+---
+
+## REST API
+
+### Endpoint
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/workflows/{workflowId}/transitions` | Transition 초안 목록 조회 |
+
+### Request
+
+Path variables:
+- `workspaceId`: Long
+- `packId`: Long
+- `versionId`: Long
+- `workflowId`: Long
+
+Headers:
+- `Authorization: Bearer {jwt-token}` (필수)
+
+### Response
+
+**200 OK**
+
+```json
+[
+  {
+    "id": "e_check_to_answer",
+    "workflowDefinitionId": 5,
+    "domainPackVersionId": 10,
+    "from": "check_refund",
+    "to": "answer_refund",
+    "label": "eligible",
+    "toPolicyRef": "refund_eligible_policy"
+  },
+  {
+    "id": "e_check_to_handoff",
+    "workflowDefinitionId": 5,
+    "domainPackVersionId": 10,
+    "from": "check_refund",
+    "to": "handoff",
+    "label": "not_eligible",
+    "toPolicyRef": "handoff_agent_policy"
+  },
+  {
+    "id": "e_answer_to_end",
+    "workflowDefinitionId": 5,
+    "domainPackVersionId": 10,
+    "from": "answer_refund",
+    "to": "terminal",
+    "label": null,
+    "toPolicyRef": null
+  }
+]
+```
+
+> transitions 없으면 빈 배열 `[]` 반환.
+> `label`은 DECISION 노드 발신 edge에만 존재하며, 나머지 edge는 `null`로 반환한다.
+> `toPolicyRef`는 `to` 노드 타입이 ACTION인 경우에만 값이 있으며, 나머지는 `null`로 반환한다.
+
+**401 Unauthorized**
+
+```json
+{ "code": "UNAUTHORIZED", "message": "인증이 필요합니다." }
+```
+
+**403 Forbidden**
+
+```json
+{ "code": "FORBIDDEN", "message": "워크스페이스에 접근 권한이 없습니다." }
+```
+
+**404 Not Found — workflow not found**
+
+```json
+{ "code": "WORKFLOW_DEFINITION_NOT_FOUND", "message": "WorkflowDefinition not found: {workflowId}" }
+```
+
+**404 Not Found — workspace not found**
+
+```json
+{ "code": "DOMAIN_PACK_WORKSPACE_NOT_FOUND", "message": "워크스페이스를 찾을 수 없습니다. id={workspaceId}" }
+```
+
+**404 Not Found — pack not found**
+
+```json
+{ "code": "DOMAIN_PACK_NOT_FOUND", "message": "DomainPack not found: {packId}" }
+```
+
+**404 Not Found — version not found**
+
+```json
+{ "code": "DOMAIN_PACK_VERSION_NOT_FOUND", "message": "도메인 팩 버전을 찾을 수 없습니다. id={versionId}" }
+```
+
+**500 Internal Server Error — graphJson 정합성 오류**
+
+```json
+{ "code": "WORKFLOW_GRAPH_JSON_INVALID", "message": "graphJson이 유효하지 않은 JSON입니다. workflowId={workflowId}" }
+```
+
+---
+
+## Class Design
+
+### 신규 생성 파일
+
+| 파일 | 경로 | 역할 |
+|------|------|------|
+| `GetWorkflowTransitionListQuery.java` | `application/` | UseCase 입력 record |
+| `GetWorkflowTransitionListUseCase.java` | `application/` | graphJson 전체 edge 파싱 + 목록 반환 UseCase |
+
+### 수정 파일
+
+| 파일 | 변경 내용 |
+|------|-----------|
+| `WorkflowTransitionDetail.java` | `toPolicyRef` 필드 추가; `listFromGraphJson` 메서드 추가; `fromGraphJson` 메서드도 동일하게 `toPolicyRef` 반영 (**spec 2217 응답 변경**) |
+| `WorkflowGraphValidator.java` | `GraphNode` record에 `policyRef` 파싱 추가; V8a·V8b 검증 메서드 추가 |
+| `WorkflowDefinitionController.java` | `@GetMapping("/{workflowId}/transitions")` 핸들러 추가; `GetWorkflowTransitionListUseCase` 의존성 추가 |
+
+### Pseudo-code
+
+```java
+// GetWorkflowTransitionListQuery.java
+record GetWorkflowTransitionListQuery(
+    Long workspaceId, Long packId, Long versionId,
+    Long workflowId, Long userId)
+
+// GetWorkflowTransitionListUseCase.java
+@Service
+@Transactional(readOnly = true)
+class GetWorkflowTransitionListUseCase {
+    execute(GetWorkflowTransitionListQuery query) {
+        validator.validateWorkspaceAccess(query.workspaceId(), query.userId())
+        validator.validateDomainPack(query.packId(), query.workspaceId())
+        validator.validateVersion(query.versionId(), query.packId())
+
+        WorkflowDefinition workflow = workflowDefinitionRepository
+            .findByIdAndDomainPackVersionId(query.workflowId(), query.versionId())
+            .orElseThrow(() -> new WorkflowDefinitionNotFoundException(query.workflowId()))
+
+        return WorkflowTransitionDetail
+            .listFromGraphJson(workflow.getGraphJson(),
+                               workflow.getId(), workflow.getDomainPackVersionId())
+    }
+}
+
+// WorkflowTransitionDetail.java — record 필드 변경
+record WorkflowTransitionDetail(
+    String id,
+    Long workflowDefinitionId,
+    Long domainPackVersionId,
+    String from,
+    String to,
+    @Nullable String label,
+    @Nullable String toPolicyRef)   // 신규: to 노드가 ACTION 타입인 경우만 값 존재
+
+// listFromGraphJson — 신규 메서드
+static List<WorkflowTransitionDetail> listFromGraphJson(
+        String graphJson, Long workflowId, Long versionId) {
+    if (graphJson == null) throw new WorkflowGraphJsonInvalidException(...)
+    try {
+        JsonNode root = MAPPER.readTree(graphJson)
+
+        // 노드 id → policyRef 맵 (ACTION 타입만)
+        Map<String, String> actionPolicyRefMap = new HashMap<>()
+        for (JsonNode n : root.path("nodes")) {
+            if ("ACTION".equals(n.path("type").asText())) {
+                String policyRef = n.hasNonNull("policyRef") ? n.path("policyRef").asText(null) : null
+                actionPolicyRefMap.put(n.path("id").asText(), policyRef)
+            }
+        }
+
+        List<WorkflowTransitionDetail> result = new ArrayList<>()
+        for (JsonNode e : root.path("edges")) {
+            String edgeId = e.hasNonNull("id") ? e.path("id").asText(null) : null
+            if (edgeId == null || edgeId.isEmpty()) continue  // V7 미충족 edge 스킵
+            String toNodeId = e.path("to").asText()
+            String toPolicyRef = actionPolicyRefMap.get(toNodeId)  // ACTION이 아니면 null
+            String label = e.hasNonNull("label") ? e.path("label").asText(null) : null
+            result.add(new WorkflowTransitionDetail(
+                edgeId, workflowId, versionId,
+                e.path("from").asText(), toNodeId, label, toPolicyRef))
+        }
+        return result
+    } catch (IOException | IllegalArgumentException e) {
+        throw new WorkflowGraphJsonInvalidException(workflowId, e)
+    }
+}
+
+// fromGraphJson — 기존 메서드 수정 (spec 2217 응답에도 toPolicyRef 반영)
+static Optional<WorkflowTransitionDetail> fromGraphJson(
+        String graphJson, String transitionId, Long workflowId, Long versionId) {
+    // 동일하게 actionPolicyRefMap 빌드 후 edge 탐색 → toPolicyRef 포함 반환
+}
+
+// WorkflowGraphValidator — GraphNode record 변경 및 V8 추가
+record GraphNode(String id, String type, @Nullable String policyRef)
+
+private static void validateV8aActionPolicyRefPresence(
+        List<GraphNode> nodes, String workflowCode) {
+    for (GraphNode n : nodes) {
+        if ("ACTION".equals(n.type()) && (n.policyRef() == null || n.policyRef().isBlank())) {
+            throw new WorkflowActionNodePolicyRefMissingException(workflowCode)
+        }
+    }
+}
+
+private static void validateV8bActionPolicyRefChars(
+        List<GraphNode> nodes, String workflowCode) {
+    Pattern VALID = Pattern.compile("[A-Za-z0-9_-]+")
+    for (GraphNode n : nodes) {
+        if ("ACTION".equals(n.type()) && n.policyRef() != null
+                && !VALID.matcher(n.policyRef()).matches()) {
+            throw new WorkflowActionNodePolicyRefInvalidCharsException(workflowCode)
+        }
+    }
+}
+
+// WorkflowDefinitionController.java — 추가 핸들러 및 의존성
+@GetMapping("/{workflowId}/transitions")
+listTransitions(@PathVariable Long workspaceId, @PathVariable Long packId,
+                @PathVariable Long versionId, @PathVariable Long workflowId,
+                Authentication authentication) {
+    Long userId = AuthenticationUtils.getUserId(authentication)
+    return ResponseEntity.ok(
+        transitionListUseCase.execute(new GetWorkflowTransitionListQuery(
+            workspaceId, packId, versionId, workflowId, userId)))
+}
+```
+
+---
+
+## Tests
+
+### UseCase 테스트: `GetWorkflowTransitionListUseCaseTest.java`
+
+- `@ExtendWith(MockitoExtension.class)` + `@DisplayName`
+- `GetWorkflowTransitionUseCaseTest` 픽스처 패턴 동일 적용 (`stubValidWorkspace`, `ReflectionTestUtils`)
+
+| 시나리오 | 예상 결과 |
+|----------|-----------|
+| 정상 조회 — ACTION 목적지 edge | `toPolicyRef` 값 반환 |
+| 정상 조회 — 비ACTION 목적지 edge | `toPolicyRef == null` |
+| label 포함/미포함 혼재 | label null 여부 각각 검증 |
+| transitions 없음 (edges 빈 배열) | 빈 List 반환 |
+| id 없는 edge 혼재 | id 있는 edge만 반환 |
+| `workflowId` 미존재 | `WorkflowDefinitionNotFoundException` |
+| DB 저장된 graphJson 파싱 오류 | `WorkflowGraphJsonInvalidException` |
+| workspace 미존재 | `DomainPackWorkspaceNotFoundException` |
+| 권한 없음 | `DomainPackUnauthorizedWorkspaceAccessException` |
+| pack 소속 불일치 | `DomainPackNotFoundException` |
+| version 소속 불일치 | `DomainPackVersionNotFoundException` |
+
+### Controller 테스트: `WorkflowDefinitionControllerTest.java` (기존 확장)
+
+- `@MockitoBean GetWorkflowTransitionListUseCase transitionListUseCase` 추가
+
+| 시나리오 | 예상 결과 |
+|----------|-----------|
+| 정상 조회 | 200, 전 필드 검증 (`id`, `workflowDefinitionId`, `domainPackVersionId`, `from`, `to`, `label`, `toPolicyRef`) |
+| transitions 없음 | 200, 빈 배열 |
+| `workflowId` 미존재 | 404, `body.code == "WORKFLOW_DEFINITION_NOT_FOUND"` |
+| graphJson 파싱 오류 | 500, `body.code == "WORKFLOW_GRAPH_JSON_INVALID"` |
+| 권한 없음 | 403 |
+| 인증 없음 | 401 |
+| version 미존재 | 404 |
+
+---
+
+## Database
+
+신규 DDL 없음. `pack.workflow_definition.graph_json` JSONB 컬럼 읽기만 수행.
+
+---
+
+## Additional Notes
+
+- `WorkflowGraphValidator.GraphNode` record에 `policyRef` 파싱 추가: `record GraphNode(String id, String type, @Nullable String policyRef)`.
+- V8c(cross-entity 검증)는 `WorkflowGraphValidator` 범위 밖이다. `UpdateWorkflowUseCase`와 `CreateDomainPackDraftUseCase`에서 `policyDefinitionRepository.existsByDomainPackVersionIdAndPolicyCode(...)` 등으로 별도 검증한다.
+- `WorkflowTransitionDetail.fromGraphJson`(단건, spec 2217)도 `toPolicyRef` 포함으로 함께 수정한다. 이는 spec 2217 응답 스키마를 변경한다.
+- `id` 없는 edge는 목록에서 스킵한다 (V7 미충족 legacy).
+- 목록 반환 순서는 graphJson `edges` 배열 선언 순서를 따른다.
+- Validator 호출 순서는 기존 `GetWorkflowTransitionUseCase` 패턴(3단계 개별 호출)을 따른다.

--- a/.agent/specs/3215.md
+++ b/.agent/specs/3215.md
@@ -139,8 +139,8 @@ Headers:
 ```
 
 > transitions 없으면 빈 배열 `[]` 반환.
-> `label`은 DECISION 노드 발신 edge에만 존재하며, 나머지 edge는 `null`로 반환한다.
-> `toPolicyRef`는 `to` 노드 타입이 ACTION인 경우에만 값이 있으며, 나머지는 `null`로 반환한다.
+> `label`: `from` 노드 타입이 DECISION인 경우에만 edge JSON의 label 값을 반환한다. 그 외 노드 발신 edge는 JSON에 label이 존재해도 `null`로 반환한다.
+> `toPolicyRef`: `to` 노드 타입이 ACTION인 경우에만 해당 노드의 policyRef를 반환한다. ACTION 노드인데 policyRef가 없으면 `WorkflowGraphJsonInvalidException`(500)을 throw한다. ACTION이 아닌 경우 `null`로 반환한다.
 
 **401 Unauthorized**
 
@@ -247,12 +247,19 @@ static List<WorkflowTransitionDetail> listFromGraphJson(
     try {
         JsonNode root = MAPPER.readTree(graphJson)
 
-        // 노드 id → policyRef 맵 (ACTION 타입만)
+        // 노드 타입 맵(전체) + ACTION policyRef 맵
+        Map<String, String> nodeTypeMap = new HashMap<>()
         Map<String, String> actionPolicyRefMap = new HashMap<>()
         for (JsonNode n : root.path("nodes")) {
-            if ("ACTION".equals(n.path("type").asText())) {
+            String nodeId   = n.path("id").asText()
+            String nodeType = n.path("type").asText()
+            nodeTypeMap.put(nodeId, nodeType)
+            if ("ACTION".equals(nodeType)) {
                 String policyRef = n.hasNonNull("policyRef") ? n.path("policyRef").asText(null) : null
-                actionPolicyRefMap.put(n.path("id").asText(), policyRef)
+                if (policyRef == null || policyRef.isBlank())
+                    throw new WorkflowGraphJsonInvalidException(workflowId,
+                        new IllegalStateException("ACTION node missing policyRef: " + nodeId))
+                actionPolicyRefMap.put(nodeId, policyRef)
             }
         }
 
@@ -260,12 +267,19 @@ static List<WorkflowTransitionDetail> listFromGraphJson(
         for (JsonNode e : root.path("edges")) {
             String edgeId = e.hasNonNull("id") ? e.path("id").asText(null) : null
             if (edgeId == null || edgeId.isEmpty()) continue  // V7 미충족 edge 스킵
-            String toNodeId = e.path("to").asText()
-            String toPolicyRef = actionPolicyRefMap.get(toNodeId)  // ACTION이 아니면 null
-            String label = e.hasNonNull("label") ? e.path("label").asText(null) : null
+            String fromNodeId = e.path("from").asText()
+            String toNodeId   = e.path("to").asText()
+            // label: DECISION 발신 edge에만 노출, 그 외 null 강제
+            String label = "DECISION".equals(nodeTypeMap.get(fromNodeId))
+                ? (e.hasNonNull("label") ? e.path("label").asText(null) : null)
+                : null
+            // toPolicyRef: ACTION 목적 edge에만 노출, 그 외 null 강제
+            String toPolicyRef = "ACTION".equals(nodeTypeMap.get(toNodeId))
+                ? actionPolicyRefMap.get(toNodeId)
+                : null
             result.add(new WorkflowTransitionDetail(
                 edgeId, workflowId, versionId,
-                e.path("from").asText(), toNodeId, label, toPolicyRef))
+                fromNodeId, toNodeId, label, toPolicyRef))
         }
         return result
     } catch (IOException | IllegalArgumentException e) {
@@ -273,10 +287,12 @@ static List<WorkflowTransitionDetail> listFromGraphJson(
     }
 }
 
-// fromGraphJson — 기존 메서드 수정 (spec 2217 응답에도 toPolicyRef 반영)
+// fromGraphJson — 기존 메서드 수정 (spec 2217 응답에도 동일 규칙 적용)
 static Optional<WorkflowTransitionDetail> fromGraphJson(
         String graphJson, String transitionId, Long workflowId, Long versionId) {
-    // 동일하게 actionPolicyRefMap 빌드 후 edge 탐색 → toPolicyRef 포함 반환
+    // listFromGraphJson과 동일하게 nodeTypeMap + actionPolicyRefMap 빌드
+    // ACTION 노드 policyRef 누락 시 WorkflowGraphJsonInvalidException throw
+    // 일치하는 edge 탐색 → label(DECISION 발신만), toPolicyRef(ACTION 목적만) 적용하여 반환
 }
 
 // WorkflowGraphValidator — GraphNode record 변경 및 V8 추가
@@ -331,7 +347,8 @@ listTransitions(@PathVariable Long workspaceId, @PathVariable Long packId,
 | transitions 없음 (edges 빈 배열) | 빈 List 반환 |
 | id 없는 edge 혼재 | id 있는 edge만 반환 |
 | `workflowId` 미존재 | `WorkflowDefinitionNotFoundException` |
-| DB 저장된 graphJson 파싱 오류 | `WorkflowGraphJsonInvalidException` |
+| DB 저장된 graphJson 파싱 오류 (JSON 구문) | `WorkflowGraphJsonInvalidException` |
+| DB 저장된 ACTION 노드에 policyRef 없음 (corrupt data) | `WorkflowGraphJsonInvalidException` |
 | workspace 미존재 | `DomainPackWorkspaceNotFoundException` |
 | 권한 없음 | `DomainPackUnauthorizedWorkspaceAccessException` |
 | pack 소속 불일치 | `DomainPackNotFoundException` |
@@ -346,7 +363,7 @@ listTransitions(@PathVariable Long workspaceId, @PathVariable Long packId,
 | 정상 조회 | 200, 전 필드 검증 (`id`, `workflowDefinitionId`, `domainPackVersionId`, `from`, `to`, `label`, `toPolicyRef`) |
 | transitions 없음 | 200, 빈 배열 |
 | `workflowId` 미존재 | 404, `body.code == "WORKFLOW_DEFINITION_NOT_FOUND"` |
-| graphJson 파싱 오류 | 500, `body.code == "WORKFLOW_GRAPH_JSON_INVALID"` |
+| graphJson 파싱 오류 또는 ACTION 노드 policyRef 누락 | 500, `body.code == "WORKFLOW_GRAPH_JSON_INVALID"` |
 | 권한 없음 | 403 |
 | 인증 없음 | 401 |
 | version 미존재 | 404 |
@@ -363,7 +380,10 @@ listTransitions(@PathVariable Long workspaceId, @PathVariable Long packId,
 
 - `WorkflowGraphValidator.GraphNode` record에 `policyRef` 파싱 추가: `record GraphNode(String id, String type, @Nullable String policyRef)`.
 - V8c(cross-entity 검증)는 `WorkflowGraphValidator` 범위 밖이다. `UpdateWorkflowUseCase`와 `CreateDomainPackDraftUseCase`에서 `policyDefinitionRepository.existsByDomainPackVersionIdAndPolicyCode(...)` 등으로 별도 검증한다.
-- `WorkflowTransitionDetail.fromGraphJson`(단건, spec 2217)도 `toPolicyRef` 포함으로 함께 수정한다. 이는 spec 2217 응답 스키마를 변경한다.
+- `WorkflowTransitionDetail.fromGraphJson`(단건, spec 2217)도 `nodeTypeMap` + `actionPolicyRefMap` 방식으로 동일하게 수정한다. label/toPolicyRef 노출 규칙과 ACTION policyRef 누락 시 throw 규칙을 동일하게 적용한다.
+- `listFromGraphJson`과 `fromGraphJson` 모두 노드 파싱 단계에서 ACTION 노드의 `policyRef` 누락을 감지하여 즉시 `WorkflowGraphJsonInvalidException`을 throw한다. 이는 write-time V8a 검증을 통과했으나 DB에 corrupt된 데이터가 있는 경우를 방어한다.
+- `label`은 `from` 노드 타입이 DECISION인 경우에만 edge JSON에서 읽어 반환하며, 그 외는 JSON 값 무관하게 `null`로 강제한다.
+- `toPolicyRef`는 `to` 노드 타입이 ACTION인 경우에만 `actionPolicyRefMap`에서 읽어 반환하며, 그 외는 `null`로 강제한다.
 - `id` 없는 edge는 목록에서 스킵한다 (V7 미충족 legacy).
 - 목록 반환 순서는 graphJson `edges` 배열 선언 순서를 따른다.
 - Validator 호출 순서는 기존 `GetWorkflowTransitionUseCase` 패턴(3단계 개별 호출)을 따른다.


### PR DESCRIPTION
# [BE] 3.2.15 — Transition Condition / Action 초안 목록 조회

## Goal

특정 워크플로우에 속한 모든 Transition(graphJson edge) 초안 목록을 조회하는 READ 전용 엔드포인트를 제공한다.
각 transition은 edge 정보(`id`, `from`, `to`, `label`)와 함께, 목적지 노드가 ACTION 타입인 경우 해당 노드의 `policyRef`를 `toPolicyRef`로 함께 반환한다.

---

## graphJson ACTION Node Schema 변경

### 기존

```json
{
  "nodes": [
    { "id": "check_refund", "type": "DECISION" },
    { "id": "answer_refund", "type": "ACTION" }
  ]
}
```

### 변경 후 (policyRef 필드 추가)

```json
{
  "nodes": [
    { "id": "check_refund",  "type": "DECISION" },
    { "id": "answer_refund", "type": "ACTION", "policyRef": "refund_eligible_policy" },
    { "id": "handoff",       "type": "ACTION", "policyRef": "handoff_agent_policy"  },
    { "id": "terminal",      "type": "TERMINAL" }
  ]
}
```

- `policyRef`: ACTION 타입 노드에 **필수**, 비어있지 않은 문자열.
  - 값은 같은 domain pack version에 존재하는 `policyCode`와 동일해야 한다.
  - `id`(그래프 내부 식별자)와는 독립적으로 관리된다. 동일한 값으로 지정해도 무방하나 강제하지 않는다.
- 비 ACTION 타입 노드(`START`, `DECISION`, `TERMINAL`)에는 `policyRef` 불필요.

### 신규 Validation Rule — V8 (write-time)

| # | 규칙 | 위반 시 에러 코드 | 검증 위치 |
|---|------|-----------------|-----------|
| V8a | ACTION 타입 노드에 `policyRef` 필드가 존재하며 비어있지 않음 | `WORKFLOW_ACTION_NODE_POLICY_REF_MISSING` | `WorkflowGraphValidator` |
| V8b | ACTION 타입 노드의 `policyRef`가 `[A-Za-z0-9_-]+` 패턴 충족 | `WORKFLOW_ACTION_NODE_POLICY_REF_INVALID_CHARS` | `WorkflowGraphValidator` |
| V8c | ACTION 타입 노드의 `policyRef`가 같은 version의 policyCode 중 하나와 일치 | `WORKFLOW_ACTION_NODE_POLICY_REF_NOT_FOUND` | UseCase 레벨 (cross-entity, DB 접근 필요) |

V8a·V8b는 `WorkflowGraphValidator.parseAndValidate`에 추가한다 (graphJson 내부 검증, DB 불필요).  
V8c는 `UpdateWorkflowUseCase`와 `CreateDomainPackDraftUseCase`에서 별도로 검증한다.

이 스펙은 V8을 **정의**한다. 실제 검증·강제 구현은 `UpdateWorkflowUseCase`(V8 추가)와 `CreateDomainPackDraftUseCase`(spec 231 참조)가 담당한다.

---

## Sequence Diagram

```mermaid
sequenceDiagram
    actor c as Client
    participant ctrl as WorkflowDefinitionController
    participant uc as GetWorkflowTransitionListUseCase
    participant validator as DomainPackValidator
    participant repo as WorkflowDefinitionRepository
    participant db as PostgreSQL

    c ->> ctrl: GET /api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/workflows/{workflowId}/transitions
    ctrl ->> uc: execute(GetWorkflowTransitionListQuery)
    uc ->> validator: validateWorkspaceAccess(workspaceId, userId)
    validator -->> uc: ok
    uc ->> validator: validateDomainPack(packId, workspaceId)
    validator -->> uc: ok
    uc ->> validator: validateVersion(versionId, packId)
    validator -->> uc: ok
    uc ->> repo: findByIdAndDomainPackVersionId(workflowId, versionId)
    repo ->> db: SELECT * FROM pack.workflow_definition WHERE id = ? AND domain_pack_version_id = ?
    db -->> repo: row
    repo -->> uc: Optional<WorkflowDefinition>
    uc ->> uc: parse graphJson → build nodeType/policyRef map → collect edges with toPolicyRef
    uc -->> ctrl: List<WorkflowTransitionDetail>
    ctrl -->> c: 200 OK
```

---

## REST API

### Endpoint

| Method | Path | Description |
|--------|------|-------------|
| GET | `/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/workflows/{workflowId}/transitions` | Transition 초안 목록 조회 |

### Request

Path variables:
- `workspaceId`: Long
- `packId`: Long
- `versionId`: Long
- `workflowId`: Long

Headers:
- `Authorization: Bearer {jwt-token}` (필수)

### Response

**200 OK**

```json
[
  {
    "id": "e_check_to_answer",
    "workflowDefinitionId": 5,
    "domainPackVersionId": 10,
    "from": "check_refund",
    "to": "answer_refund",
    "label": "eligible",
    "toPolicyRef": "refund_eligible_policy"
  },
  {
    "id": "e_check_to_handoff",
    "workflowDefinitionId": 5,
    "domainPackVersionId": 10,
    "from": "check_refund",
    "to": "handoff",
    "label": "not_eligible",
    "toPolicyRef": "handoff_agent_policy"
  },
  {
    "id": "e_answer_to_end",
    "workflowDefinitionId": 5,
    "domainPackVersionId": 10,
    "from": "answer_refund",
    "to": "terminal",
    "label": null,
    "toPolicyRef": null
  }
]
```

> transitions 없으면 빈 배열 `[]` 반환.
> `label`은 DECISION 노드 발신 edge에만 존재하며, 나머지 edge는 `null`로 반환한다.
> `toPolicyRef`는 `to` 노드 타입이 ACTION인 경우에만 값이 있으며, 나머지는 `null`로 반환한다.

**401 Unauthorized**

```json
{ "code": "UNAUTHORIZED", "message": "인증이 필요합니다." }
```

**403 Forbidden**

```json
{ "code": "FORBIDDEN", "message": "워크스페이스에 접근 권한이 없습니다." }
```

**404 Not Found — workflow not found**

```json
{ "code": "WORKFLOW_DEFINITION_NOT_FOUND", "message": "WorkflowDefinition not found: {workflowId}" }
```

**404 Not Found — workspace not found**

```json
{ "code": "DOMAIN_PACK_WORKSPACE_NOT_FOUND", "message": "워크스페이스를 찾을 수 없습니다. id={workspaceId}" }
```

**404 Not Found — pack not found**

```json
{ "code": "DOMAIN_PACK_NOT_FOUND", "message": "DomainPack not found: {packId}" }
```

**404 Not Found — version not found**

```json
{ "code": "DOMAIN_PACK_VERSION_NOT_FOUND", "message": "도메인 팩 버전을 찾을 수 없습니다. id={versionId}" }
```

**500 Internal Server Error — graphJson 정합성 오류**

```json
{ "code": "WORKFLOW_GRAPH_JSON_INVALID", "message": "graphJson이 유효하지 않은 JSON입니다. workflowId={workflowId}" }
```

---

## Class Design

### 신규 생성 파일

| 파일 | 경로 | 역할 |
|------|------|------|
| `GetWorkflowTransitionListQuery.java` | `application/` | UseCase 입력 record |
| `GetWorkflowTransitionListUseCase.java` | `application/` | graphJson 전체 edge 파싱 + 목록 반환 UseCase |

### 수정 파일

| 파일 | 변경 내용 |
|------|-----------|
| `WorkflowTransitionDetail.java` | `toPolicyRef` 필드 추가; `listFromGraphJson` 메서드 추가; `fromGraphJson` 메서드도 동일하게 `toPolicyRef` 반영 (**spec 2217 응답 변경**) |
| `WorkflowGraphValidator.java` | `GraphNode` record에 `policyRef` 파싱 추가; V8a·V8b 검증 메서드 추가 |
| `WorkflowDefinitionController.java` | `@GetMapping("/{workflowId}/transitions")` 핸들러 추가; `GetWorkflowTransitionListUseCase` 의존성 추가 |

### Pseudo-code

```java
// GetWorkflowTransitionListQuery.java
record GetWorkflowTransitionListQuery(
    Long workspaceId, Long packId, Long versionId,
    Long workflowId, Long userId)

// GetWorkflowTransitionListUseCase.java
@Service
@Transactional(readOnly = true)
class GetWorkflowTransitionListUseCase {
    execute(GetWorkflowTransitionListQuery query) {
        validator.validateWorkspaceAccess(query.workspaceId(), query.userId())
        validator.validateDomainPack(query.packId(), query.workspaceId())
        validator.validateVersion(query.versionId(), query.packId())

        WorkflowDefinition workflow = workflowDefinitionRepository
            .findByIdAndDomainPackVersionId(query.workflowId(), query.versionId())
            .orElseThrow(() -> new WorkflowDefinitionNotFoundException(query.workflowId()))

        return WorkflowTransitionDetail
            .listFromGraphJson(workflow.getGraphJson(),
                               workflow.getId(), workflow.getDomainPackVersionId())
    }
}

// WorkflowTransitionDetail.java — record 필드 변경
record WorkflowTransitionDetail(
    String id,
    Long workflowDefinitionId,
    Long domainPackVersionId,
    String from,
    String to,
    @Nullable String label,
    @Nullable String toPolicyRef)   // 신규: to 노드가 ACTION 타입인 경우만 값 존재

// listFromGraphJson — 신규 메서드
static List<WorkflowTransitionDetail> listFromGraphJson(
        String graphJson, Long workflowId, Long versionId) {
    if (graphJson == null) throw new WorkflowGraphJsonInvalidException(...)
    try {
        JsonNode root = MAPPER.readTree(graphJson)

        // 노드 id → policyRef 맵 (ACTION 타입만)
        Map<String, String> actionPolicyRefMap = new HashMap<>()
        for (JsonNode n : root.path("nodes")) {
            if ("ACTION".equals(n.path("type").asText())) {
                String policyRef = n.hasNonNull("policyRef") ? n.path("policyRef").asText(null) : null
                actionPolicyRefMap.put(n.path("id").asText(), policyRef)
            }
        }

        List<WorkflowTransitionDetail> result = new ArrayList<>()
        for (JsonNode e : root.path("edges")) {
            String edgeId = e.hasNonNull("id") ? e.path("id").asText(null) : null
            if (edgeId == null || edgeId.isEmpty()) continue  // V7 미충족 edge 스킵
            String toNodeId = e.path("to").asText()
            String toPolicyRef = actionPolicyRefMap.get(toNodeId)  // ACTION이 아니면 null
            String label = e.hasNonNull("label") ? e.path("label").asText(null) : null
            result.add(new WorkflowTransitionDetail(
                edgeId, workflowId, versionId,
                e.path("from").asText(), toNodeId, label, toPolicyRef))
        }
        return result
    } catch (IOException | IllegalArgumentException e) {
        throw new WorkflowGraphJsonInvalidException(workflowId, e)
    }
}

// fromGraphJson — 기존 메서드 수정 (spec 2217 응답에도 toPolicyRef 반영)
static Optional<WorkflowTransitionDetail> fromGraphJson(
        String graphJson, String transitionId, Long workflowId, Long versionId) {
    // 동일하게 actionPolicyRefMap 빌드 후 edge 탐색 → toPolicyRef 포함 반환
}

// WorkflowGraphValidator — GraphNode record 변경 및 V8 추가
record GraphNode(String id, String type, @Nullable String policyRef)

private static void validateV8aActionPolicyRefPresence(
        List<GraphNode> nodes, String workflowCode) {
    for (GraphNode n : nodes) {
        if ("ACTION".equals(n.type()) && (n.policyRef() == null || n.policyRef().isBlank())) {
            throw new WorkflowActionNodePolicyRefMissingException(workflowCode)
        }
    }
}

private static void validateV8bActionPolicyRefChars(
        List<GraphNode> nodes, String workflowCode) {
    Pattern VALID = Pattern.compile("[A-Za-z0-9_-]+")
    for (GraphNode n : nodes) {
        if ("ACTION".equals(n.type()) && n.policyRef() != null
                && !VALID.matcher(n.policyRef()).matches()) {
            throw new WorkflowActionNodePolicyRefInvalidCharsException(workflowCode)
        }
    }
}

// WorkflowDefinitionController.java — 추가 핸들러 및 의존성
@GetMapping("/{workflowId}/transitions")
listTransitions(@PathVariable Long workspaceId, @PathVariable Long packId,
                @PathVariable Long versionId, @PathVariable Long workflowId,
                Authentication authentication) {
    Long userId = AuthenticationUtils.getUserId(authentication)
    return ResponseEntity.ok(
        transitionListUseCase.execute(new GetWorkflowTransitionListQuery(
            workspaceId, packId, versionId, workflowId, userId)))
}
```

---

## Tests

### UseCase 테스트: `GetWorkflowTransitionListUseCaseTest.java`

- `@ExtendWith(MockitoExtension.class)` + `@DisplayName`
- `GetWorkflowTransitionUseCaseTest` 픽스처 패턴 동일 적용 (`stubValidWorkspace`, `ReflectionTestUtils`)

| 시나리오 | 예상 결과 |
|----------|-----------|
| 정상 조회 — ACTION 목적지 edge | `toPolicyRef` 값 반환 |
| 정상 조회 — 비ACTION 목적지 edge | `toPolicyRef == null` |
| label 포함/미포함 혼재 | label null 여부 각각 검증 |
| transitions 없음 (edges 빈 배열) | 빈 List 반환 |
| id 없는 edge 혼재 | id 있는 edge만 반환 |
| `workflowId` 미존재 | `WorkflowDefinitionNotFoundException` |
| DB 저장된 graphJson 파싱 오류 | `WorkflowGraphJsonInvalidException` |
| workspace 미존재 | `DomainPackWorkspaceNotFoundException` |
| 권한 없음 | `DomainPackUnauthorizedWorkspaceAccessException` |
| pack 소속 불일치 | `DomainPackNotFoundException` |
| version 소속 불일치 | `DomainPackVersionNotFoundException` |

### Controller 테스트: `WorkflowDefinitionControllerTest.java` (기존 확장)

- `@MockitoBean GetWorkflowTransitionListUseCase transitionListUseCase` 추가

| 시나리오 | 예상 결과 |
|----------|-----------|
| 정상 조회 | 200, 전 필드 검증 (`id`, `workflowDefinitionId`, `domainPackVersionId`, `from`, `to`, `label`, `toPolicyRef`) |
| transitions 없음 | 200, 빈 배열 |
| `workflowId` 미존재 | 404, `body.code == "WORKFLOW_DEFINITION_NOT_FOUND"` |
| graphJson 파싱 오류 | 500, `body.code == "WORKFLOW_GRAPH_JSON_INVALID"` |
| 권한 없음 | 403 |
| 인증 없음 | 401 |
| version 미존재 | 404 |

---

## Database

신규 DDL 없음. `pack.workflow_definition.graph_json` JSONB 컬럼 읽기만 수행.

---

## Additional Notes

- `WorkflowGraphValidator.GraphNode` record에 `policyRef` 파싱 추가: `record GraphNode(String id, String type, @Nullable String policyRef)`.
- V8c(cross-entity 검증)는 `WorkflowGraphValidator` 범위 밖이다. `UpdateWorkflowUseCase`와 `CreateDomainPackDraftUseCase`에서 `policyDefinitionRepository.existsByDomainPackVersionIdAndPolicyCode(...)` 등으로 별도 검증한다.
- `WorkflowTransitionDetail.fromGraphJson`(단건, spec 2217)도 `toPolicyRef` 포함으로 함께 수정한다. 이는 spec 2217 응답 스키마를 변경한다.
- `id` 없는 edge는 목록에서 스킵한다 (V7 미충족 legacy).
- 목록 반환 순서는 graphJson `edges` 배열 선언 순서를 따른다.
- Validator 호출 순서는 기존 `GetWorkflowTransitionUseCase` 패턴(3단계 개별 호출)을 따른다.
---
# Uncertainty Register — 3215: [BE] Transition Condition / Action 초안 목록 조회

> Artifact path: `.handoff/3215/uncertainty-register-3215.md`
> Branch: `spec/3215`
> Created by: Decision Agent

---

## Entries

---

### U-01: "Action" 응답 포함 범위

- **ID**: U-01
- **Issue**: 스펙 제목의 "Action"이 응답 필드에 액션/정책 데이터를 포함해야 하는지 여부
- **Status**: Assumption
- **Why unresolved**: 사용자 입력에서 "Action"을 명시했으나, spec 2217은 "Action 시각화는 이 스펙 범위 밖이며, FE는 policy 단건 조회 API(spec 2211)를 별도로 조합해 사용한다"고 정의함. 3215도 같은 원칙이 적용된다고 가정함.
- **Options**:
  - A) 액션 데이터 미포함 — 현재 edge 구조(`id, from, to, label`)만 반환 (KISS, spec 2217 패턴 유지)
  - B) 액션 참조 포함 — graphJson edge에 action/policy 참조 필드 추가 (schema 변경 필요)
- **Recommended Default**: A — spec 2217 선례 및 KISS 원칙 준수
- **Why recommended**: spec 2217에 이미 "Action 시각화는 FE 책임"으로 명시됨. 별도 근거 없이 BE 응답에 policy 데이터를 추가하면 spec 2217과 충돌함.
- **User Decision Required**: No
- **User Question**: N/A
- **Execution Rule**:
  - Implementation Agent MUST NOT: 사용자 확인 없이 액션/정책 데이터를 응답에 추가
  - Implementation Agent MAY: Assumption A 기준으로 구현 (spec 2217 패턴 동일 적용)
  - If unsafe: 사용자가 B를 원하면 spec 2217 변경 및 graphJson 스키마 변경이 선행되어야 함
- **Affected Spec Section**: REST API > Response, Additional Notes

---

### U-02: id 없는 edge 처리 방식

- **ID**: U-02
- **Issue**: graphJson에 `id` 필드가 없는 legacy edge가 포함된 경우 목록 조회에서 처리 방법
- **Status**: Assumption
- **Why unresolved**: spec 2217은 "기존 DB에 저장된 edge id 없는 workflow draft는 단건 transition GET이 404를 반환한다"고 정의함. 목록 조회 케이스는 별도 정의 없음.
- **Options**:
  - A) 스킵(skip) — id 없는 edge는 결과 목록에서 제외
  - B) 에러 — id 없는 edge가 존재하면 `WorkflowGraphJsonInvalidException` throw
  - C) 포함(null id) — id가 null인 상태로 목록에 포함
- **Recommended Default**: A — spec 2217 패턴과 일관성 유지
- **Why recommended**: 목록은 단건 조회 집합의 합집합이므로, 단건에서 404인 edge는 목록에서도 제외하는 것이 일관적임. 500(B)은 과도; null id(C)는 클라이언트 혼란 야기.
- **User Decision Required**: No
- **User Question**: N/A
- **Execution Rule**:
  - Implementation Agent MUST NOT: null id edge를 응답에 포함
  - Implementation Agent MAY: Assumption A 기준으로 id 없는 edge 스킵 구현
- **Affected Spec Section**: Class Design > Pseudo-code, Additional Notes

---

### U-03: 목록 반환 순서

- **ID**: U-03
- **Issue**: 반환되는 transition 목록의 정렬 순서
- **Status**: Assumption
- **Why unresolved**: 스펙에 명시된 정렬 기준 없음. FE가 표시 순서를 직접 제어할 수도 있음.
- **Options**:
  - A) graphJson `edges` 배열 선언 순서 (삽입 순서 보존)
  - B) `id` 알파벳 오름차순
- **Recommended Default**: A — 최소 구현; graphJson 구조 보존
- **Why recommended**: graphJson 배열 순서는 작성자 의도를 반영함. 정렬 추가는 YAGNI 위반. 기존 workflow definition list(`findAllByDomainPackVersionIdOrderByWorkflowCodeAsc`)는 외부 정렬이지만, 여기서는 in-memory 파싱이므로 추가 정렬 불필요.
- **User Decision Required**: No
- **User Question**: N/A
- **Execution Rule**:
  - Implementation Agent MUST NOT: 임의 정렬 기준 추가
  - Implementation Agent MAY: Assumption A 기준으로 순서 보존
- **Affected Spec Section**: Additional Notes

---

### U-04 (Conflict, Deferred): WorkflowTransitionNotFoundException 메시지 불일치

- **ID**: U-04
- **Issue**: spec 2217 문서(`"Workflow transition not found: {transitionId}"`)와 실제 구현(`"워크플로우 전환을 찾을 수 없습니다: " + transitionId`) 간 에러 메시지 불일치
- **Status**: Deferred
- **Why unresolved**: 이 스펙(3215) 범위 밖. 단건 조회(spec 2217) 구현 중 발생한 불일치로, 목록 조회(3215)에서는 `WorkflowTransitionNotFoundException`이 사용되지 않음.
- **Options**: 영어 메시지로 통일 / 한글 메시지로 통일 (spec 2217 수정 필요)
- **Recommended Default**: N/A (이 스펙 범위 밖)
- **Why recommended**: N/A
- **User Decision Required**: No (3215 범위 밖; spec 2217 수정 작업으로 분리 처리 권장)
- **User Question**: N/A
- **Execution Rule**:
  - Implementation Agent MUST NOT: 3215 구현 범위에서 이 불일치를 수정하려 시도
  - If unsafe: N/A
- **Affected Spec Section**: N/A (3215 미관련)
---
# Cross-Spec Impact — 3215: policyRef 도입에 따른 변경 사항

> 결정: graphJson ACTION 노드에 `policyRef` 필드 도입 (Option B — 역할 분리)
> - `node.id` = 그래프 내부 식별자 (edge의 from/to 참조용)
> - `node.policyRef` = 실행할 policy의 policyCode (외부 참조)

---

## 1. spec 2217 — Transition 단건 조회 응답 변경

**파일**: `.agent/specs/2217.md`

**변경 내용**:
- `WorkflowTransitionDetail` 응답 스키마에 `toPolicyRef` 필드 추가
- `fromGraphJson` 메서드가 nodes도 파싱하여 `to` 노드의 policyRef를 함께 반환해야 함

**변경 전 응답**:
```json
{ "id": "e_check_to_answer", "workflowDefinitionId": 5, "domainPackVersionId": 10,
  "from": "check_refund_policy", "to": "answer_refund", "label": "eligible" }
```

**변경 후 응답**:
```json
{ "id": "e_check_to_answer", "workflowDefinitionId": 5, "domainPackVersionId": 10,
  "from": "check_refund_policy", "to": "answer_refund", "label": "eligible",
  "toPolicyRef": "refund_eligible_policy" }
```

**영향 파일**:
- `WorkflowTransitionDetail.java` — `toPolicyRef` 필드 추가, `fromGraphJson` 수정
- `GetWorkflowTransitionUseCaseTest.java` — `toPolicyRef` 필드 검증 추가
- `WorkflowDefinitionControllerTest.java` — transition 단건 조회 테스트 응답 검증 업데이트

---

## 2. WorkflowGraphValidator — V8 추가

**파일**: `backend/src/main/java/com/init/domainpack/application/WorkflowGraphValidator.java`

**변경 내용**:
- `GraphNode` record에 `policyRef` 파싱 추가
  ```java
  // 변경 전
  record GraphNode(String id, String type)
  // 변경 후
  record GraphNode(String id, String type, @Nullable String policyRef)
  ```
- `parseNodes` 메서드에서 `policyRef` 필드 파싱 추가
- `parseAndValidate`에 V8a, V8b 검증 호출 추가
- 신규 예외 클래스 2개 필요:
  - `WorkflowActionNodePolicyRefMissingException` (`DomainPackDraftRequestInvalidException` 상속 또는 신규 예외)
  - `WorkflowActionNodePolicyRefInvalidCharsException`

**에러 코드**:
| 예외 | 에러 코드 |
|------|-----------|
| `WorkflowActionNodePolicyRefMissingException` | `WORKFLOW_ACTION_NODE_POLICY_REF_MISSING` |
| `WorkflowActionNodePolicyRefInvalidCharsException` | `WORKFLOW_ACTION_NODE_POLICY_REF_INVALID_CHARS` |

**참고**: `WorkflowGraphValidator`는 package-private이므로 예외를 어떤 타입으로 throw할지 결정 필요.  
기존 V7 위반(`WorkflowEdgeIdMissingException` 등)이 `NotFoundException`이 아닌 별도 예외임을 확인 후 동일 패턴 적용.

---

## 3. UpdateWorkflowUseCase — V8c 추가

**파일**: `backend/src/main/java/com/init/domainpack/application/UpdateWorkflowUseCase.java`

**변경 내용**:
- graphJson 파싱 후 ACTION 노드의 `policyRef` 목록 추출
- 같은 `versionId`에 해당 policyCode들이 실제로 존재하는지 확인
- 미존재 시 `WORKFLOW_ACTION_NODE_POLICY_REF_NOT_FOUND` 에러

**구현 방안 (택일)**:
- A) `UpdateWorkflowUseCase`에 `PolicyDefinitionRepository` 직접 주입
- B) `DomainPackValidator`에 `validatePolicyCodes(versionId, Set<String> policyCodes)` 메서드 추가 → UseCase에서 호출

B 권장: 검증 책임이 `DomainPackValidator`로 집중되어 패턴 일관성 유지.

**에러 코드**: `WORKFLOW_ACTION_NODE_POLICY_REF_NOT_FOUND`

---

## 4. spec 231 — CreateDomainPackDraftUseCase

**파일**: `.agent/specs/231.md`

**변경 내용**:
- AI 파이프라인이 생성한 workflow graphJson의 ACTION 노드에 `policyRef` 필드가 포함되어야 함
- 파이프라인 출력 스펙(ML 측) 또는 CreateDomainPackDraftUseCase의 graphJson 가공 단계에서 `policyRef` 자동 매핑 필요
- V8 검증이 CreateDomainPackDraftUseCase에도 적용됨 (기존 V7과 동일 방식)

**미결 사항**: AI 파이프라인이 ACTION 노드의 policyRef를 어떻게 결정하는가?  
- 옵션 A: `node.id`와 policyCode를 동일하게 설정 (pipeline 측 단순화, 이후 id rename 시 분리)
- 옵션 B: pipeline이 별도 매핑 정보를 제공
→ **별도 결정 필요. spec 231 또는 ML pipeline spec에서 확정.**

---

## 5. 신규 이슈 — policyCode 변경/삭제 시 역방향 영향

**현재 상태**: Policy 수정(`UpdatePolicyUseCase`) 및 삭제 플로우에 graphJson 역참조 처리가 없음.

**문제**:
- policyCode가 rename되거나 policy가 삭제되면, 해당 policyCode를 `policyRef`로 가진 ACTION 노드들이 stale 상태가 됨
- V8c는 write-time(workflow 저장 시점)만 검증하므로, 이후 policy 변경은 탐지하지 못함

**처리 방안 (택일, 별도 스펙)**:
- A) Policy 삭제/rename 시 참조 중인 workflow graphJson이 있으면 거부 (강한 무결성)
- B) Policy 삭제/rename 시 참조 workflow 목록을 경고로만 노출 (soft 경고)
- C) 미처리 — stale policyRef는 runtime에서 처리 (현재와 동일)

→ **이 스펙 범위 밖. 별도 이슈/스펙으로 추적 필요.**

---

## 요약표

| 대상 | 변경 유형 | 필수 여부 | 관련 파일 |
|------|-----------|-----------|-----------|
| spec 2217 응답 | `toPolicyRef` 추가 | **필수** (spec 3215와 동일 record 공유) | `WorkflowTransitionDetail.java`, spec 2217 테스트 |
| `WorkflowGraphValidator` | V8a·V8b 추가, `GraphNode` 수정 | **필수** | `WorkflowGraphValidator.java`, 신규 예외 2개 |
| `UpdateWorkflowUseCase` | V8c 추가 | **필수** | `UpdateWorkflowUseCase.java`, `DomainPackValidator.java` (방안 B) |
| spec 231 | `policyRef` 매핑 전략 확정 | **필수** | `.agent/specs/231.md`, ML pipeline spec |
| Policy 역참조 처리 | 신규 스펙 | 권장 (미처리 시 data integrity 위험) | 별도 이슈 등록 필요 |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 워크플로우 전환(엣지) 초안 목록을 읽기 전용으로 조회하는 새 API 엔드포인트 추가
  * 각 전환에 대해 출발/도착 노드, 레이블(의사결정 출발 엣지에만 표시), 액션 도착 시 정책 참조값 노출

* **문서**
  * 엔드포인트 동작, 요청/응답 스펙 및 오류 코드 설명을 포함한 사양 문서 추가

* **테스트**
  * 엔드포인트 및 그래프 유효성검증 시나리오를 위한 테스트 계획 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->