### PR TITLE
spec/98: UpdateWorkflowUsecase에 V8c 검증 추가

### DIFF
--- a/.agent/specs/98.md
+++ b/.agent/specs/98.md
@@ -319,6 +319,7 @@ N/A — 스키마 변경 없음. Liquibase 마이그레이션 불필요.
 
 ## Additional Notes
 
+- **policyRef null 필터링 불필요**: `WorkflowGraphValidator.parseAndValidate()`는 반환 전 `validateV8ActionPolicyRef()`를 실행하며, V8a 규칙(`WorkflowActionNodePolicyRefMissingException`)이 ACTION 노드의 `policyRef`가 null 또는 blank인 경우를 이미 거부한다. 따라서 `ParsedGraph`를 반환받은 시점에서 ACTION 타입 노드의 `GraphNode::policyRef`는 반드시 non-null·non-blank가 보장되므로, V8c 추출 스트림(`.filter("ACTION"::equals).map(GraphNode::policyRef)`)에 별도 null 체크가 필요 없다.
 - `DomainPackValidator.validatePolicyCodes`는 fail-fast: 첫 번째 미존재 policyRef에서 즉시 예외 throw.
 - `UpdateWorkflowUseCase`는 ACTION 노드가 없으면 `validatePolicyCodes`를 호출하지 않는다 (불필요 DB 쿼리 방지).
 - `GlobalExceptionHandler` 수정 불필요 — `BadRequestException` 핸들러가 `WorkflowActionNodePolicyRefNotFoundException`을 400으로 처리.

--- a/.agent/specs/98.md
+++ b/.agent/specs/98.md
@@ -1,0 +1,284 @@
+# [BE] #98 — UpdateWorkflowUseCase에 V8c 검증 추가
+
+> **Scope**: ACTION 노드 `policyRef`가 같은 version의 `policyCode`에 실제로 존재하는지 DB 조회로 검증 (cross-entity).  
+> **In scope**: `UpdateWorkflowUseCase` V8c 검증 추가. 관련 `DomainPackValidator` 메서드 추가, repository 메서드 추가, 예외 클래스 신규 생성, 테스트 추가.  
+> **Out of scope**: `CreateDomainPackDraftUseCase` (spec 231 별도 이슈).
+
+---
+
+## Goal
+
+`UpdateWorkflowUseCase.execute()`에서 V8c 규칙을 적용한다: ACTION 타입 노드의 `policyRef`가 같은 `domainPackVersionId`에 속한 `policyCode` 중 하나와 일치해야 한다. 불일치 시 `WORKFLOW_ACTION_NODE_POLICY_REF_NOT_FOUND` 에러를 반환한다.
+
+---
+
+## Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    actor c as Client
+    participant ctrl as WorkflowController
+    participant uc as UpdateWorkflowUseCase
+    participant wgv as WorkflowGraphValidator
+    participant val as DomainPackValidator
+    participant repo as PolicyDefinitionRepository
+    participant db as PostgreSQL
+
+    c ->> ctrl: PATCH /api/v1/.../workflows/{id}
+    ctrl ->> uc: execute(command)
+    uc ->> wgv: parseAndValidate(graphJson, workflowCode)
+    wgv -->> uc: ParsedGraph (V8a·V8b 통과)
+    uc ->> uc: extract policyRefs from ACTION nodes
+    alt policyRefs is not empty
+        uc ->> val: validatePolicyCodes(versionId, policyRefs)
+        loop 각 policyRef
+            val ->> repo: existsByDomainPackVersionIdAndPolicyCode(versionId, policyRef)
+            repo ->> db: SELECT EXISTS(...)
+            db -->> repo: boolean
+            alt not found
+                val -->> uc: throw WorkflowActionNodePolicyRefNotFoundException
+                uc -->> ctrl: propagate
+                ctrl -->> c: 400 Bad Request
+            end
+        end
+    end
+    uc ->> uc: workflow.updateGraph(...)
+    uc ->> repo: save(workflow)
+    uc -->> ctrl: WorkflowDefinitionDetail
+    ctrl -->> c: 200 OK
+```
+
+---
+
+## REST API
+
+### Endpoint
+
+기존 workflow 수정 엔드포인트를 그대로 사용한다. 새 엔드포인트 없음.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| PATCH | `/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/workflows/{workflowId}` | 워크플로우 graphJson 수정 (기존) |
+
+### Request / Response 변경
+
+추가 필드 없음. V8c 위반 시 아래 에러가 새로 발생한다.
+
+**400 Bad Request — V8c 위반**
+
+```json
+{
+  "code": "WORKFLOW_ACTION_NODE_POLICY_REF_NOT_FOUND",
+  "message": "ACTION 타입 노드의 policyRef가 존재하지 않습니다. policyRef=<값>"
+}
+```
+
+---
+
+## Class Design
+
+### 신규 파일
+
+#### `WorkflowActionNodePolicyRefNotFoundException`
+
+```
+backend/src/main/java/com/init/domainpack/application/exception/WorkflowActionNodePolicyRefNotFoundException.java
+```
+
+```java
+package com.init.domainpack.application.exception;
+
+import com.init.shared.application.exception.BadRequestException;
+
+public class WorkflowActionNodePolicyRefNotFoundException extends BadRequestException {
+  public WorkflowActionNodePolicyRefNotFoundException(String policyRef) {
+    super(
+        "WORKFLOW_ACTION_NODE_POLICY_REF_NOT_FOUND",
+        "ACTION 타입 노드의 policyRef가 존재하지 않습니다. policyRef=" + policyRef);
+  }
+}
+```
+
+### 수정 파일
+
+#### `PolicyDefinitionRepository` — 메서드 추가
+
+```
+backend/src/main/java/com/init/domainpack/domain/repository/PolicyDefinitionRepository.java
+```
+
+```java
+boolean existsByDomainPackVersionIdAndPolicyCode(Long domainPackVersionId, String policyCode);
+```
+
+참조 패턴: `IntentDefinitionRepository.existsByDomainPackVersionIdAndIntentCode(Long, String)`
+
+#### `JpaPolicyDefinitionRepository` — 메서드 추가
+
+```
+backend/src/main/java/com/init/domainpack/infrastructure/persistence/JpaPolicyDefinitionRepository.java
+```
+
+Spring Data JPA 자동 파생 쿼리. 메서드 선언만 추가하면 된다.
+
+```java
+boolean existsByDomainPackVersionIdAndPolicyCode(Long domainPackVersionId, String policyCode);
+```
+
+#### `DomainPackValidator` — 의존성 + 메서드 추가
+
+```
+backend/src/main/java/com/init/domainpack/application/DomainPackValidator.java
+```
+
+```java
+// 추가 필드
+private final PolicyDefinitionRepository policyDefinitionRepository;
+
+// 생성자에 파라미터 추가 (기존 4개 → 5개)
+public DomainPackValidator(
+    WorkspaceExistencePort workspaceExistencePort,
+    WorkspaceMembershipPort workspaceMembershipPort,
+    DomainPackRepository domainPackRepository,
+    DomainPackVersionRepository domainPackVersionRepository,
+    PolicyDefinitionRepository policyDefinitionRepository) {
+    ...
+    this.policyDefinitionRepository = policyDefinitionRepository;
+}
+
+// 신규 메서드
+public void validatePolicyCodes(Long versionId, Set<String> policyCodes) {
+    for (String policyCode : policyCodes) {
+        if (!policyDefinitionRepository.existsByDomainPackVersionIdAndPolicyCode(versionId, policyCode)) {
+            throw new WorkflowActionNodePolicyRefNotFoundException(policyCode);
+        }
+    }
+}
+```
+
+#### `UpdateWorkflowUseCase` — V8c 호출 추가
+
+```
+backend/src/main/java/com/init/domainpack/application/UpdateWorkflowUseCase.java
+```
+
+`WorkflowGraphValidator.parseAndValidate()` 호출 직후에 아래를 추가한다.
+
+```java
+WorkflowGraphValidator.ParsedGraph parsed =
+    WorkflowGraphValidator.parseAndValidate(command.graphJson(), workflow.getWorkflowCode());
+
+// V8c: policyRef cross-entity 검증
+Set<String> policyRefs = parsed.nodes().stream()
+    .filter(n -> "ACTION".equals(n.type()))
+    .map(WorkflowGraphValidator.GraphNode::policyRef)
+    .collect(Collectors.toSet());
+if (!policyRefs.isEmpty()) {
+    validator.validatePolicyCodes(command.versionId(), policyRefs);
+}
+```
+
+`GlobalExceptionHandler`는 기존 `BadRequestException` 핸들러(`@ExceptionHandler(BadRequestException.class)`)가 `WorkflowActionNodePolicyRefNotFoundException`을 처리하므로 수정 불필요.
+
+---
+
+## Tests
+
+### 테스트 대상 파일
+
+```
+backend/src/test/java/com/init/domainpack/application/UpdateWorkflowUseCaseTest.java
+```
+
+기존 mock 3개(`DomainPackValidator`, `DomainPackVersionRepository`, `WorkflowDefinitionRepository`)를 그대로 사용한다.  
+`DomainPackValidator`는 이미 mock 처리됐으므로 `PolicyDefinitionRepository` mock 추가 불필요.
+
+### 신규 테스트 픽스처
+
+ACTION 노드를 포함한 graphJson 픽스처를 추가한다.
+
+```java
+private static final String GRAPH_WITH_ACTION_NODE = """
+    {
+      "nodes": [
+        {"id": "n1", "type": "START"},
+        {"id": "n2", "type": "ACTION", "policyRef": "policy-1"},
+        {"id": "n3", "type": "TERMINAL"}
+      ],
+      "edges": [
+        {"id": "e1", "from": "n1", "to": "n2"},
+        {"id": "e2", "from": "n2", "to": "n3"}
+      ]
+    }
+    """;
+```
+
+### 신규 테스트 케이스
+
+```java
+@Test
+@DisplayName("ACTION 노드 policyRef가 version에 존재하면 성공한다")
+void execute_withValidPolicyRef_succeeds() {
+    // given: validator.validatePolicyCodes()는 void이므로 기본 doNothing() 동작
+    // (Mockito 기본값: void 메서드는 아무것도 안 함)
+    // ... 기존 정상 경로 setup (version DRAFT, workflow 존재)
+    given(command.graphJson()).willReturn(GRAPH_WITH_ACTION_NODE);
+
+    // when
+    WorkflowDefinitionDetail result = useCase.execute(command);
+
+    // then
+    assertThat(result).isNotNull();
+    verify(validator).validatePolicyCodes(eq(COMMAND_VERSION_ID), eq(Set.of("policy-1")));
+}
+
+@Test
+@DisplayName("ACTION 노드 policyRef가 version에 없으면 WorkflowActionNodePolicyRefNotFoundException을 던진다")
+void execute_withNonExistentPolicyRef_throwsException() {
+    // given
+    doThrow(new WorkflowActionNodePolicyRefNotFoundException("policy-1"))
+        .when(validator).validatePolicyCodes(anyLong(), anySet());
+    given(command.graphJson()).willReturn(GRAPH_WITH_ACTION_NODE);
+    // ... 기존 정상 경로 setup (version DRAFT, workflow 존재)
+
+    // when & then
+    assertThatThrownBy(() -> useCase.execute(command))
+        .isInstanceOf(WorkflowActionNodePolicyRefNotFoundException.class)
+        .hasMessageContaining("policy-1");
+}
+
+@Test
+@DisplayName("ACTION 노드가 없으면 validatePolicyCodes를 호출하지 않는다")
+void execute_withNoActionNodes_doesNotCallValidatePolicyCodes() {
+    // given: VALID_GRAPH (기존 픽스처 — START + TERMINAL만 포함)
+    // ... 기존 정상 경로 setup
+
+    // when
+    useCase.execute(command);
+
+    // then
+    verify(validator, never()).validatePolicyCodes(anyLong(), anySet());
+}
+```
+
+### 테스트 체크리스트
+
+- [ ] ACTION 노드 policyRef 유효 → 성공 (validatePolicyCodes 1회 호출 검증)
+- [ ] ACTION 노드 policyRef 미존재 → `WorkflowActionNodePolicyRefNotFoundException` (에러코드 검증)
+- [ ] ACTION 노드 없음 → `validatePolicyCodes` 미호출 (불필요 DB 쿼리 없음)
+- [ ] ACTION 노드 복수, 일부 유효/일부 무효 → fail-fast (첫 번째 무효 policyRef에서 예외)
+
+---
+
+## Database
+
+N/A — 스키마 변경 없음. Liquibase 마이그레이션 불필요.
+
+---
+
+## Additional Notes
+
+- `DomainPackValidator.validatePolicyCodes`는 fail-fast: 첫 번째 미존재 policyRef에서 즉시 예외 throw.
+- `UpdateWorkflowUseCase`는 ACTION 노드가 없으면 `validatePolicyCodes`를 호출하지 않는다 (불필요 DB 쿼리 방지).
+- `GlobalExceptionHandler` 수정 불필요 — `BadRequestException` 핸들러가 `WorkflowActionNodePolicyRefNotFoundException`을 400으로 처리.
+- `DomainPackValidator` 생성자 파라미터 추가로 기존 Spring Bean 연결이 변경됨 — Spring Boot auto-wiring으로 자동 처리되나, 관련 `@Bean` 수동 설정이 있으면 확인 필요.

--- a/.agent/specs/98.md
+++ b/.agent/specs/98.md
@@ -21,7 +21,8 @@ sequenceDiagram
     participant uc as UpdateWorkflowUseCase
     participant wgv as WorkflowGraphValidator
     participant val as DomainPackValidator
-    participant repo as PolicyDefinitionRepository
+    participant policyRepo as PolicyDefinitionRepository
+    participant workflowRepo as WorkflowDefinitionRepository
     participant db as PostgreSQL
 
     c ->> ctrl: PATCH /api/v1/.../workflows/{id}
@@ -32,9 +33,9 @@ sequenceDiagram
     alt policyRefs is not empty
         uc ->> val: validatePolicyCodes(versionId, policyRefs)
         loop 각 policyRef
-            val ->> repo: existsByDomainPackVersionIdAndPolicyCode(versionId, policyRef)
-            repo ->> db: SELECT EXISTS(...)
-            db -->> repo: boolean
+            val ->> policyRepo: existsByDomainPackVersionIdAndPolicyCode(versionId, policyRef)
+            policyRepo ->> db: SELECT EXISTS(...)
+            db -->> policyRepo: boolean
             alt not found
                 val -->> uc: throw WorkflowActionNodePolicyRefNotFoundException
                 uc -->> ctrl: propagate
@@ -43,7 +44,7 @@ sequenceDiagram
         end
     end
     uc ->> uc: workflow.updateGraph(...)
-    uc ->> repo: save(workflow)
+    uc ->> workflowRepo: save(workflow)
     uc -->> ctrl: WorkflowDefinitionDetail
     ctrl -->> c: 200 OK
 ```
@@ -244,7 +245,12 @@ void execute_withNonExistentPolicyRef_throwsException() {
     // when & then
     assertThatThrownBy(() -> useCase.execute(command))
         .isInstanceOf(WorkflowActionNodePolicyRefNotFoundException.class)
-        .hasMessageContaining("policy-1");
+        .satisfies(e -> {
+            WorkflowActionNodePolicyRefNotFoundException typed =
+                (WorkflowActionNodePolicyRefNotFoundException) e;
+            assertThat(typed.getCode()).isEqualTo("WORKFLOW_ACTION_NODE_POLICY_REF_NOT_FOUND");
+            assertThat(typed.getMessage()).contains("policy-1");
+        });
 }
 
 @Test

--- a/.agent/specs/98.md
+++ b/.agent/specs/98.md
@@ -267,12 +267,47 @@ void execute_withNoActionNodes_doesNotCallValidatePolicyCodes() {
 }
 ```
 
+### `DomainPackValidatorTest` — fail-fast 테스트
+
+fail-fast 동작은 `DomainPackValidator.validatePolicyCodes` 내부 반복에서 발생한다.  
+`UpdateWorkflowUseCaseTest`에서는 validator가 mock이므로 검증 불가 → `DomainPackValidatorTest`에서 다룬다.
+
+```java
+@Test
+@DisplayName("미존재 policyCode를 만나면 즉시 예외를 던지고 이후 코드는 조회하지 않는다")
+void validatePolicyCodes_failsFastOnFirstMissing() {
+    // given: LinkedHashSet으로 순서 보장 [p-1(valid) → p-2(missing) → p-3(valid)]
+    given(policyDefinitionRepository.existsByDomainPackVersionIdAndPolicyCode(VERSION_ID, "p-1"))
+        .willReturn(true);
+    given(policyDefinitionRepository.existsByDomainPackVersionIdAndPolicyCode(VERSION_ID, "p-2"))
+        .willReturn(false);
+    given(policyDefinitionRepository.existsByDomainPackVersionIdAndPolicyCode(VERSION_ID, "p-3"))
+        .willReturn(true);
+    Set<String> codes = new LinkedHashSet<>(List.of("p-1", "p-2", "p-3"));
+
+    // when & then
+    assertThatThrownBy(() -> validator.validatePolicyCodes(VERSION_ID, codes))
+        .isInstanceOf(WorkflowActionNodePolicyRefNotFoundException.class)
+        .satisfies(e -> {
+            WorkflowActionNodePolicyRefNotFoundException typed =
+                (WorkflowActionNodePolicyRefNotFoundException) e;
+            assertThat(typed.getCode()).isEqualTo("WORKFLOW_ACTION_NODE_POLICY_REF_NOT_FOUND");
+            assertThat(typed.getMessage()).contains("p-2");
+        });
+    // p-2에서 예외 throw → p-3는 조회되지 않아야 함
+    verify(policyDefinitionRepository, never())
+        .existsByDomainPackVersionIdAndPolicyCode(VERSION_ID, "p-3");
+}
+```
+
 ### 테스트 체크리스트
 
-- [ ] ACTION 노드 policyRef 유효 → 성공 (validatePolicyCodes 1회 호출 검증)
-- [ ] ACTION 노드 policyRef 미존재 → `WorkflowActionNodePolicyRefNotFoundException` (에러코드 검증)
-- [ ] ACTION 노드 없음 → `validatePolicyCodes` 미호출 (불필요 DB 쿼리 없음)
-- [ ] ACTION 노드 복수, 일부 유효/일부 무효 → fail-fast (첫 번째 무효 policyRef에서 예외)
+| 테스트 위치 | 시나리오 | 검증 포인트 |
+|------------|---------|------------|
+| `UpdateWorkflowUseCaseTest` | ACTION 노드 policyRef 유효 → 성공 | `validatePolicyCodes` 1회 호출, 올바른 Set 전달 |
+| `UpdateWorkflowUseCaseTest` | ACTION 노드 policyRef 미존재 → 예외 | `WorkflowActionNodePolicyRefNotFoundException`, 에러코드 `WORKFLOW_ACTION_NODE_POLICY_REF_NOT_FOUND` |
+| `UpdateWorkflowUseCaseTest` | ACTION 노드 없음 → 성공 | `validatePolicyCodes` 미호출 |
+| `DomainPackValidatorTest` | ACTION 노드 복수, 일부 무효 → fail-fast | 첫 번째 미존재 코드에서 예외, 이후 코드 미조회 |
 
 ---
 


### PR DESCRIPTION
# [BE] #98 — UpdateWorkflowUseCase에 V8c 검증 추가

> **Scope**: ACTION 노드 `policyRef`가 같은 version의 `policyCode`에 실제로 존재하는지 DB 조회로 검증 (cross-entity).  
> **In scope**: `UpdateWorkflowUseCase` V8c 검증 추가. 관련 `DomainPackValidator` 메서드 추가, repository 메서드 추가, 예외 클래스 신규 생성, 테스트 추가.  
> **Out of scope**: `CreateDomainPackDraftUseCase` (spec 231 별도 이슈).

---

## Goal

`UpdateWorkflowUseCase.execute()`에서 V8c 규칙을 적용한다: ACTION 타입 노드의 `policyRef`가 같은 `domainPackVersionId`에 속한 `policyCode` 중 하나와 일치해야 한다. 불일치 시 `WORKFLOW_ACTION_NODE_POLICY_REF_NOT_FOUND` 에러를 반환한다.

---

## Sequence Diagram

```mermaid
sequenceDiagram
    actor c as Client
    participant ctrl as WorkflowController
    participant uc as UpdateWorkflowUseCase
    participant wgv as WorkflowGraphValidator
    participant val as DomainPackValidator
    participant repo as PolicyDefinitionRepository
    participant db as PostgreSQL

    c ->> ctrl: PATCH /api/v1/.../workflows/{id}
    ctrl ->> uc: execute(command)
    uc ->> wgv: parseAndValidate(graphJson, workflowCode)
    wgv -->> uc: ParsedGraph (V8a·V8b 통과)
    uc ->> uc: extract policyRefs from ACTION nodes
    alt policyRefs is not empty
        uc ->> val: validatePolicyCodes(versionId, policyRefs)
        loop 각 policyRef
            val ->> repo: existsByDomainPackVersionIdAndPolicyCode(versionId, policyRef)
            repo ->> db: SELECT EXISTS(...)
            db -->> repo: boolean
            alt not found
                val -->> uc: throw WorkflowActionNodePolicyRefNotFoundException
                uc -->> ctrl: propagate
                ctrl -->> c: 400 Bad Request
            end
        end
    end
    uc ->> uc: workflow.updateGraph(...)
    uc ->> repo: save(workflow)
    uc -->> ctrl: WorkflowDefinitionDetail
    ctrl -->> c: 200 OK
```

---

## REST API

### Endpoint

기존 workflow 수정 엔드포인트를 그대로 사용한다. 새 엔드포인트 없음.

| Method | Path | Description |
|--------|------|-------------|
| PATCH | `/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/workflows/{workflowId}` | 워크플로우 graphJson 수정 (기존) |

### Request / Response 변경

추가 필드 없음. V8c 위반 시 아래 에러가 새로 발생한다.

**400 Bad Request — V8c 위반**

```json
{
  "code": "WORKFLOW_ACTION_NODE_POLICY_REF_NOT_FOUND",
  "message": "ACTION 타입 노드의 policyRef가 존재하지 않습니다. policyRef=<값>"
}
```

---

## Class Design

### 신규 파일

#### `WorkflowActionNodePolicyRefNotFoundException`

```
backend/src/main/java/com/init/domainpack/application/exception/WorkflowActionNodePolicyRefNotFoundException.java
```

```java
package com.init.domainpack.application.exception;

import com.init.shared.application.exception.BadRequestException;

public class WorkflowActionNodePolicyRefNotFoundException extends BadRequestException {
  public WorkflowActionNodePolicyRefNotFoundException(String policyRef) {
    super(
        "WORKFLOW_ACTION_NODE_POLICY_REF_NOT_FOUND",
        "ACTION 타입 노드의 policyRef가 존재하지 않습니다. policyRef=" + policyRef);
  }
}
```

### 수정 파일

#### `PolicyDefinitionRepository` — 메서드 추가

```
backend/src/main/java/com/init/domainpack/domain/repository/PolicyDefinitionRepository.java
```

```java
boolean existsByDomainPackVersionIdAndPolicyCode(Long domainPackVersionId, String policyCode);
```

참조 패턴: `IntentDefinitionRepository.existsByDomainPackVersionIdAndIntentCode(Long, String)`

#### `JpaPolicyDefinitionRepository` — 메서드 추가

```
backend/src/main/java/com/init/domainpack/infrastructure/persistence/JpaPolicyDefinitionRepository.java
```

Spring Data JPA 자동 파생 쿼리. 메서드 선언만 추가하면 된다.

```java
boolean existsByDomainPackVersionIdAndPolicyCode(Long domainPackVersionId, String policyCode);
```

#### `DomainPackValidator` — 의존성 + 메서드 추가

```
backend/src/main/java/com/init/domainpack/application/DomainPackValidator.java
```

```java
// 추가 필드
private final PolicyDefinitionRepository policyDefinitionRepository;

// 생성자에 파라미터 추가 (기존 4개 → 5개)
public DomainPackValidator(
    WorkspaceExistencePort workspaceExistencePort,
    WorkspaceMembershipPort workspaceMembershipPort,
    DomainPackRepository domainPackRepository,
    DomainPackVersionRepository domainPackVersionRepository,
    PolicyDefinitionRepository policyDefinitionRepository) {
    ...
    this.policyDefinitionRepository = policyDefinitionRepository;
}

// 신규 메서드
public void validatePolicyCodes(Long versionId, Set<String> policyCodes) {
    for (String policyCode : policyCodes) {
        if (!policyDefinitionRepository.existsByDomainPackVersionIdAndPolicyCode(versionId, policyCode)) {
            throw new WorkflowActionNodePolicyRefNotFoundException(policyCode);
        }
    }
}
```

#### `UpdateWorkflowUseCase` — V8c 호출 추가

```
backend/src/main/java/com/init/domainpack/application/UpdateWorkflowUseCase.java
```

`WorkflowGraphValidator.parseAndValidate()` 호출 직후에 아래를 추가한다.

```java
WorkflowGraphValidator.ParsedGraph parsed =
    WorkflowGraphValidator.parseAndValidate(command.graphJson(), workflow.getWorkflowCode());

// V8c: policyRef cross-entity 검증
Set<String> policyRefs = parsed.nodes().stream()
    .filter(n -> "ACTION".equals(n.type()))
    .map(WorkflowGraphValidator.GraphNode::policyRef)
    .collect(Collectors.toSet());
if (!policyRefs.isEmpty()) {
    validator.validatePolicyCodes(command.versionId(), policyRefs);
}
```

`GlobalExceptionHandler`는 기존 `BadRequestException` 핸들러(`@ExceptionHandler(BadRequestException.class)`)가 `WorkflowActionNodePolicyRefNotFoundException`을 처리하므로 수정 불필요.

---

## Tests

### 테스트 대상 파일

```
backend/src/test/java/com/init/domainpack/application/UpdateWorkflowUseCaseTest.java
```

기존 mock 3개(`DomainPackValidator`, `DomainPackVersionRepository`, `WorkflowDefinitionRepository`)를 그대로 사용한다.  
`DomainPackValidator`는 이미 mock 처리됐으므로 `PolicyDefinitionRepository` mock 추가 불필요.

### 신규 테스트 픽스처

ACTION 노드를 포함한 graphJson 픽스처를 추가한다.

```java
private static final String GRAPH_WITH_ACTION_NODE = """
    {
      "nodes": [
        {"id": "n1", "type": "START"},
        {"id": "n2", "type": "ACTION", "policyRef": "policy-1"},
        {"id": "n3", "type": "TERMINAL"}
      ],
      "edges": [
        {"id": "e1", "from": "n1", "to": "n2"},
        {"id": "e2", "from": "n2", "to": "n3"}
      ]
    }
    """;
```

### 신규 테스트 케이스

```java
@Test
@DisplayName("ACTION 노드 policyRef가 version에 존재하면 성공한다")
void execute_withValidPolicyRef_succeeds() {
    // given: validator.validatePolicyCodes()는 void이므로 기본 doNothing() 동작
    // (Mockito 기본값: void 메서드는 아무것도 안 함)
    // ... 기존 정상 경로 setup (version DRAFT, workflow 존재)
    given(command.graphJson()).willReturn(GRAPH_WITH_ACTION_NODE);

    // when
    WorkflowDefinitionDetail result = useCase.execute(command);

    // then
    assertThat(result).isNotNull();
    verify(validator).validatePolicyCodes(eq(COMMAND_VERSION_ID), eq(Set.of("policy-1")));
}

@Test
@DisplayName("ACTION 노드 policyRef가 version에 없으면 WorkflowActionNodePolicyRefNotFoundException을 던진다")
void execute_withNonExistentPolicyRef_throwsException() {
    // given
    doThrow(new WorkflowActionNodePolicyRefNotFoundException("policy-1"))
        .when(validator).validatePolicyCodes(anyLong(), anySet());
    given(command.graphJson()).willReturn(GRAPH_WITH_ACTION_NODE);
    // ... 기존 정상 경로 setup (version DRAFT, workflow 존재)

    // when & then
    assertThatThrownBy(() -> useCase.execute(command))
        .isInstanceOf(WorkflowActionNodePolicyRefNotFoundException.class)
        .hasMessageContaining("policy-1");
}

@Test
@DisplayName("ACTION 노드가 없으면 validatePolicyCodes를 호출하지 않는다")
void execute_withNoActionNodes_doesNotCallValidatePolicyCodes() {
    // given: VALID_GRAPH (기존 픽스처 — START + TERMINAL만 포함)
    // ... 기존 정상 경로 setup

    // when
    useCase.execute(command);

    // then
    verify(validator, never()).validatePolicyCodes(anyLong(), anySet());
}
```

### 테스트 체크리스트

- [ ] ACTION 노드 policyRef 유효 → 성공 (validatePolicyCodes 1회 호출 검증)
- [ ] ACTION 노드 policyRef 미존재 → `WorkflowActionNodePolicyRefNotFoundException` (에러코드 검증)
- [ ] ACTION 노드 없음 → `validatePolicyCodes` 미호출 (불필요 DB 쿼리 없음)
- [ ] ACTION 노드 복수, 일부 유효/일부 무효 → fail-fast (첫 번째 무효 policyRef에서 예외)

---

## Database

N/A — 스키마 변경 없음. Liquibase 마이그레이션 불필요.

---

## Additional Notes

- `DomainPackValidator.validatePolicyCodes`는 fail-fast: 첫 번째 미존재 policyRef에서 즉시 예외 throw.
- `UpdateWorkflowUseCase`는 ACTION 노드가 없으면 `validatePolicyCodes`를 호출하지 않는다 (불필요 DB 쿼리 방지).
- `GlobalExceptionHandler` 수정 불필요 — `BadRequestException` 핸들러가 `WorkflowActionNodePolicyRefNotFoundException`을 400으로 처리.
- `DomainPackValidator` 생성자 파라미터 추가로 기존 Spring Bean 연결이 변경됨 — Spring Boot auto-wiring으로 자동 처리되나, 관련 `@Bean` 수동 설정이 있으면 확인 필요.
---
# Uncertainty Register — Issue #98

## feat(domain-pack): UpdateWorkflowUseCase V8c 검증 추가

---

## UR-98-01

- **ID**: UR-98-01
- **Issue**: `WorkflowActionNodePolicyRefNotFoundException`의 base class — `BadRequestException` vs `NotFoundException`
- **Status**: Confirmed (사용자 결정 완료)
- **Why unresolved**: 에러코드 `WORKFLOW_ACTION_NODE_POLICY_REF_NOT_FOUND`의 `NOT_FOUND` 명칭이 `NotFoundException`(404)을 암시할 수 있으나, 이슈·스펙 어디에도 HTTP 상태 코드가 명시되지 않았음.
- **Options**:
  - A) `BadRequestException` → HTTP 400
  - B) `NotFoundException` → HTTP 404
- **Recommended Default**: A (`BadRequestException`, 400)
- **Why recommended**: V8a(`PolicyRefMissing`), V8b(`PolicyRefInvalidChars`)와 동일 검증 계열이며 요청 본문 validation 실패 의미론에 부합. `GlobalExceptionHandler`에 별도 핸들러 추가 불필요.
- **User Decision Required**: Yes
- **User Question**: `WorkflowActionNodePolicyRefNotFoundException`의 base class를 무엇으로 정할까요? (A: BadRequestException/400, B: NotFoundException/404)
- **Resolution**: **A 선택 (BadRequestException, 400)** — 사용자 명시 결정 (2026-04-23)
- **Execution Rule**: `.agent/specs/98.md`의 예외 클래스 정의는 `BadRequestException` 상속 기준으로 작성 완료. 구현 시 변경 없이 그대로 따름.
- **Affected Spec Section**: Class Design — `WorkflowActionNodePolicyRefNotFoundException`

---

## UR-98-02

- **ID**: UR-98-02
- **Issue**: `GlobalExceptionHandler`에 `WorkflowActionNodePolicyRefNotFoundException` 별도 핸들러 등록 필요 여부
- **Status**: Confirmed (소스 직접 확인 후 해소)
- **Why unresolved**: Recon 단계에서 GlobalExceptionHandler 파일을 직접 조회하지 않아 미확인 상태로 기록됨.
- **Options**:
  - A) 별도 핸들러 필요
  - B) 기존 base class 핸들러로 커버 (변경 불필요)
- **Recommended Default**: B
- **Why recommended**: `GlobalExceptionHandler`는 `BadRequestException` 클래스 레벨 핸들러(`@ExceptionHandler(BadRequestException.class)`)를 보유. 서브클래스인 `WorkflowActionNodePolicyRefNotFoundException`은 자동으로 이 핸들러에 포착됨. 소스 확인 완료(`GlobalExceptionHandler.java:77-81`).
- **User Decision Required**: No
- **User Question**: N/A
- **Resolution**: Confirmed — `GlobalExceptionHandler` 수정 불필요.
- **Execution Rule**: Implementation Agent는 `GlobalExceptionHandler`를 수정하면 안 됨.
- **Affected Spec Section**: Additional Notes

---

## UR-98-03

- **ID**: UR-98-03
- **Issue**: `UpdateWorkflowUseCaseTest`에서 `PolicyDefinitionRepository` mock 추가 필요 여부
- **Status**: Confirmed (아키텍처 분석으로 해소)
- **Why unresolved**: Recon에서 "UpdateWorkflowUseCaseTest에서 PolicyDefinitionRepository mock 추가 여부 미확인"으로 기록됨.
- **Options**:
  - A) `UpdateWorkflowUseCaseTest`에 `PolicyDefinitionRepository` mock 추가 필요
  - B) 추가 불필요 — `DomainPackValidator` 자체가 이미 mock 처리됨
- **Recommended Default**: B
- **Why recommended**: `UpdateWorkflowUseCase`는 `PolicyDefinitionRepository`를 직접 의존하지 않음. `DomainPackValidator`가 이를 의존하며, `UpdateWorkflowUseCaseTest`에서 `DomainPackValidator`는 이미 mock 대상임. `validatePolicyCodes()`는 mock validator를 통해 stub/verify 처리 가능.
- **User Decision Required**: No
- **User Question**: N/A
- **Resolution**: Confirmed — `UpdateWorkflowUseCaseTest`에 `PolicyDefinitionRepository` mock 추가 불필요.
- **Execution Rule**: Implementation Agent는 `UpdateWorkflowUseCaseTest`의 mock 목록에 `PolicyDefinitionRepository`를 추가하면 안 됨. `DomainPackValidator.validatePolicyCodes()`를 `doThrow`/`doNothing`/`verify`로 처리함.
- **Affected Spec Section**: Tests

---

## Summary

| ID | Issue | Status | User Decision Required |
|----|-------|--------|----------------------|
| UR-98-01 | Exception base class | Confirmed (A 선택) | Yes → 완료 |
| UR-98-02 | GlobalExceptionHandler 핸들러 등록 | Confirmed (불필요) | No |
| UR-98-03 | Test mock 추가 여부 | Confirmed (불필요) | No |

모든 불확실성 해소 완료. Implementation Agent는 `.agent/specs/98.md` 기준으로 추가 확인 없이 구현 가능.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * 워크플로우 업데이트 시 ACTION 타입 작업 노드의 정책 참조(policyRef) 유효성 검증 절차를 정의한 신규 스펙 문서 추가 — 파싱 후 ACTION 노드에서 정책 참조를 수집하고, 비어있지 않으면 DB 기반 존재 여부를 검사하여 누락 시 400 응답으로 중단하도록 명시. ACTION 노드가 없으면 검증을 호출하지 않음. 기존 Bad Request 처리와 연동되며, 성공·예외·미호출 케이스에 대한 테스트 체크리스트 포함.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->