### PR TITLE
fix(domain-pack): add V8c policyRef cross-entity validation to UpdateWorkflowUseCase (#98)

### DIFF
--- a/backend/src/main/java/com/init/domainpack/application/DomainPackValidator.java
+++ b/backend/src/main/java/com/init/domainpack/application/DomainPackValidator.java
@@ -12,7 +12,7 @@ import com.init.domainpack.domain.repository.DomainPackVersionRepository;
 import com.init.domainpack.domain.repository.PolicyDefinitionRepository;
 import com.init.domainpack.domain.repository.WorkspaceExistencePort;
 import com.init.domainpack.domain.repository.WorkspaceMembershipPort;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import org.springframework.stereotype.Component;
 
@@ -74,10 +74,13 @@ public class DomainPackValidator {
   }
 
   public void validatePolicyCodes(Long versionId, Set<String> policyCodes) {
+    if (policyCodes.isEmpty()) {
+      return;
+    }
+    Set<String> missing = new LinkedHashSet<>(policyCodes);
     Set<String> existing =
         policyDefinitionRepository.findExistingPolicyCodesByVersionIdAndCodes(
             versionId, policyCodes);
-    Set<String> missing = new HashSet<>(policyCodes);
     missing.removeAll(existing);
     if (!missing.isEmpty()) {
       throw new WorkflowActionNodePolicyRefNotFoundException(missing.iterator().next());

--- a/backend/src/main/java/com/init/domainpack/application/DomainPackValidator.java
+++ b/backend/src/main/java/com/init/domainpack/application/DomainPackValidator.java
@@ -12,6 +12,7 @@ import com.init.domainpack.domain.repository.DomainPackVersionRepository;
 import com.init.domainpack.domain.repository.PolicyDefinitionRepository;
 import com.init.domainpack.domain.repository.WorkspaceExistencePort;
 import com.init.domainpack.domain.repository.WorkspaceMembershipPort;
+import java.util.HashSet;
 import java.util.Set;
 import org.springframework.stereotype.Component;
 
@@ -73,11 +74,13 @@ public class DomainPackValidator {
   }
 
   public void validatePolicyCodes(Long versionId, Set<String> policyCodes) {
-    for (String policyCode : policyCodes) {
-      if (!policyDefinitionRepository.existsByDomainPackVersionIdAndPolicyCode(
-          versionId, policyCode)) {
-        throw new WorkflowActionNodePolicyRefNotFoundException(policyCode);
-      }
+    Set<String> existing =
+        policyDefinitionRepository.findExistingPolicyCodesByVersionIdAndCodes(
+            versionId, policyCodes);
+    Set<String> missing = new HashSet<>(policyCodes);
+    missing.removeAll(existing);
+    if (!missing.isEmpty()) {
+      throw new WorkflowActionNodePolicyRefNotFoundException(missing.iterator().next());
     }
   }
 }

--- a/backend/src/main/java/com/init/domainpack/application/DomainPackValidator.java
+++ b/backend/src/main/java/com/init/domainpack/application/DomainPackValidator.java
@@ -4,10 +4,12 @@ import com.init.domainpack.application.exception.DomainPackNotFoundException;
 import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
 import com.init.domainpack.application.exception.DomainPackVersionNotFoundException;
 import com.init.domainpack.application.exception.DomainPackWorkspaceNotFoundException;
+import com.init.domainpack.application.exception.WorkflowActionNodePolicyRefNotFoundException;
 import com.init.domainpack.domain.model.DomainPackVersion;
 import com.init.domainpack.domain.model.WorkspaceMemberRole;
 import com.init.domainpack.domain.repository.DomainPackRepository;
 import com.init.domainpack.domain.repository.DomainPackVersionRepository;
+import com.init.domainpack.domain.repository.PolicyDefinitionRepository;
 import com.init.domainpack.domain.repository.WorkspaceExistencePort;
 import com.init.domainpack.domain.repository.WorkspaceMembershipPort;
 import java.util.Set;
@@ -23,16 +25,19 @@ public class DomainPackValidator {
   private final WorkspaceMembershipPort workspaceMembershipPort;
   private final DomainPackRepository domainPackRepository;
   private final DomainPackVersionRepository domainPackVersionRepository;
+  private final PolicyDefinitionRepository policyDefinitionRepository;
 
   public DomainPackValidator(
       WorkspaceExistencePort workspaceExistencePort,
       WorkspaceMembershipPort workspaceMembershipPort,
       DomainPackRepository domainPackRepository,
-      DomainPackVersionRepository domainPackVersionRepository) {
+      DomainPackVersionRepository domainPackVersionRepository,
+      PolicyDefinitionRepository policyDefinitionRepository) {
     this.workspaceExistencePort = workspaceExistencePort;
     this.workspaceMembershipPort = workspaceMembershipPort;
     this.domainPackRepository = domainPackRepository;
     this.domainPackVersionRepository = domainPackVersionRepository;
+    this.policyDefinitionRepository = policyDefinitionRepository;
   }
 
   public void validateWorkspaceAccess(Long workspaceId, Long userId) {
@@ -65,5 +70,14 @@ public class DomainPackValidator {
     validateWorkspaceAccess(workspaceId, userId);
     validateDomainPack(packId, workspaceId);
     validateVersion(versionId, packId);
+  }
+
+  public void validatePolicyCodes(Long versionId, Set<String> policyCodes) {
+    for (String policyCode : policyCodes) {
+      if (!policyDefinitionRepository.existsByDomainPackVersionIdAndPolicyCode(
+          versionId, policyCode)) {
+        throw new WorkflowActionNodePolicyRefNotFoundException(policyCode);
+      }
+    }
   }
 }

--- a/backend/src/main/java/com/init/domainpack/application/UpdateWorkflowUseCase.java
+++ b/backend/src/main/java/com/init/domainpack/application/UpdateWorkflowUseCase.java
@@ -7,6 +7,7 @@ import com.init.domainpack.domain.repository.DomainPackVersionRepository;
 import com.init.domainpack.domain.repository.WorkflowDefinitionRepository;
 import com.init.shared.application.exception.BadRequestException;
 import com.init.shared.application.exception.NotFoundException;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
@@ -73,7 +74,7 @@ public class UpdateWorkflowUseCase {
         parsed.nodes().stream()
             .filter(n -> "ACTION".equals(n.type()))
             .map(WorkflowGraphValidator.GraphNode::policyRef)
-            .collect(Collectors.toSet());
+            .collect(Collectors.toCollection(LinkedHashSet::new));
     if (!policyRefs.isEmpty()) {
       validator.validatePolicyCodes(command.versionId(), policyRefs);
     }

--- a/backend/src/main/java/com/init/domainpack/application/UpdateWorkflowUseCase.java
+++ b/backend/src/main/java/com/init/domainpack/application/UpdateWorkflowUseCase.java
@@ -7,6 +7,8 @@ import com.init.domainpack.domain.repository.DomainPackVersionRepository;
 import com.init.domainpack.domain.repository.WorkflowDefinitionRepository;
 import com.init.shared.application.exception.BadRequestException;
 import com.init.shared.application.exception.NotFoundException;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -62,9 +64,20 @@ public class UpdateWorkflowUseCase {
                     new NotFoundException(
                         "NOT_FOUND", "워크플로우를 찾을 수 없습니다: " + command.workflowId()));
 
-    // V1–V6 예외는 GlobalExceptionHandler로 전파
+    // V1–V8b 예외는 GlobalExceptionHandler로 전파
     WorkflowGraphValidator.ParsedGraph parsed =
         WorkflowGraphValidator.parseAndValidate(command.graphJson(), workflow.getWorkflowCode());
+
+    // V8c: policyRef cross-entity 검증
+    Set<String> policyRefs =
+        parsed.nodes().stream()
+            .filter(n -> "ACTION".equals(n.type()))
+            .map(WorkflowGraphValidator.GraphNode::policyRef)
+            .collect(Collectors.toSet());
+    if (!policyRefs.isEmpty()) {
+      validator.validatePolicyCodes(command.versionId(), policyRefs);
+    }
+
     String initialState = WorkflowGraphValidator.extractInitialState(parsed);
     String terminalStatesJson;
     try {

--- a/backend/src/main/java/com/init/domainpack/application/exception/WorkflowActionNodePolicyRefNotFoundException.java
+++ b/backend/src/main/java/com/init/domainpack/application/exception/WorkflowActionNodePolicyRefNotFoundException.java
@@ -1,0 +1,11 @@
+package com.init.domainpack.application.exception;
+
+import com.init.shared.application.exception.BadRequestException;
+
+public class WorkflowActionNodePolicyRefNotFoundException extends BadRequestException {
+  public WorkflowActionNodePolicyRefNotFoundException(String policyRef) {
+    super(
+        "WORKFLOW_ACTION_NODE_POLICY_REF_NOT_FOUND",
+        "ACTION 타입 노드의 policyRef가 존재하지 않습니다. policyRef=" + policyRef);
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/domain/repository/PolicyDefinitionRepository.java
+++ b/backend/src/main/java/com/init/domainpack/domain/repository/PolicyDefinitionRepository.java
@@ -3,6 +3,7 @@ package com.init.domainpack.domain.repository;
 import com.init.domainpack.domain.model.PolicyDefinition;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface PolicyDefinitionRepository {
 
@@ -17,4 +18,6 @@ public interface PolicyDefinitionRepository {
   PolicyDefinition save(PolicyDefinition policy);
 
   boolean existsByDomainPackVersionIdAndPolicyCode(Long domainPackVersionId, String policyCode);
+
+  Set<String> findExistingPolicyCodesByVersionIdAndCodes(Long versionId, Set<String> policyCodes);
 }

--- a/backend/src/main/java/com/init/domainpack/domain/repository/PolicyDefinitionRepository.java
+++ b/backend/src/main/java/com/init/domainpack/domain/repository/PolicyDefinitionRepository.java
@@ -15,4 +15,6 @@ public interface PolicyDefinitionRepository {
   List<PolicyDefinition> findAllByDomainPackVersionIdOrderByPolicyCodeAsc(Long domainPackVersionId);
 
   PolicyDefinition save(PolicyDefinition policy);
+
+  boolean existsByDomainPackVersionIdAndPolicyCode(Long domainPackVersionId, String policyCode);
 }

--- a/backend/src/main/java/com/init/domainpack/domain/repository/PolicyDefinitionRepository.java
+++ b/backend/src/main/java/com/init/domainpack/domain/repository/PolicyDefinitionRepository.java
@@ -17,7 +17,5 @@ public interface PolicyDefinitionRepository {
 
   PolicyDefinition save(PolicyDefinition policy);
 
-  boolean existsByDomainPackVersionIdAndPolicyCode(Long domainPackVersionId, String policyCode);
-
   Set<String> findExistingPolicyCodesByVersionIdAndCodes(Long versionId, Set<String> policyCodes);
 }

--- a/backend/src/main/java/com/init/domainpack/infrastructure/persistence/JpaPolicyDefinitionRepository.java
+++ b/backend/src/main/java/com/init/domainpack/infrastructure/persistence/JpaPolicyDefinitionRepository.java
@@ -18,8 +18,6 @@ public interface JpaPolicyDefinitionRepository
 
   Optional<PolicyDefinition> findByIdAndDomainPackVersionId(Long id, Long domainPackVersionId);
 
-  boolean existsByDomainPackVersionIdAndPolicyCode(Long domainPackVersionId, String policyCode);
-
   @Query(
       "SELECT p.policyCode FROM PolicyDefinition p"
           + " WHERE p.domainPackVersionId = :versionId AND p.policyCode IN :policyCodes")

--- a/backend/src/main/java/com/init/domainpack/infrastructure/persistence/JpaPolicyDefinitionRepository.java
+++ b/backend/src/main/java/com/init/domainpack/infrastructure/persistence/JpaPolicyDefinitionRepository.java
@@ -14,4 +14,6 @@ public interface JpaPolicyDefinitionRepository
   List<PolicyDefinition> findAllByDomainPackVersionIdOrderByPolicyCodeAsc(Long domainPackVersionId);
 
   Optional<PolicyDefinition> findByIdAndDomainPackVersionId(Long id, Long domainPackVersionId);
+
+  boolean existsByDomainPackVersionIdAndPolicyCode(Long domainPackVersionId, String policyCode);
 }

--- a/backend/src/main/java/com/init/domainpack/infrastructure/persistence/JpaPolicyDefinitionRepository.java
+++ b/backend/src/main/java/com/init/domainpack/infrastructure/persistence/JpaPolicyDefinitionRepository.java
@@ -4,7 +4,10 @@ import com.init.domainpack.domain.model.PolicyDefinition;
 import com.init.domainpack.domain.repository.PolicyDefinitionRepository;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -16,4 +19,10 @@ public interface JpaPolicyDefinitionRepository
   Optional<PolicyDefinition> findByIdAndDomainPackVersionId(Long id, Long domainPackVersionId);
 
   boolean existsByDomainPackVersionIdAndPolicyCode(Long domainPackVersionId, String policyCode);
+
+  @Query(
+      "SELECT p.policyCode FROM PolicyDefinition p"
+          + " WHERE p.domainPackVersionId = :versionId AND p.policyCode IN :policyCodes")
+  Set<String> findExistingPolicyCodesByVersionIdAndCodes(
+      @Param("versionId") Long versionId, @Param("policyCodes") Set<String> policyCodes);
 }

--- a/backend/src/test/java/com/init/domainpack/application/DomainPackValidatorTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/DomainPackValidatorTest.java
@@ -7,7 +7,11 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.init.domainpack.application.exception.WorkflowActionNodePolicyRefNotFoundException;
+import com.init.domainpack.domain.repository.DomainPackRepository;
+import com.init.domainpack.domain.repository.DomainPackVersionRepository;
 import com.init.domainpack.domain.repository.PolicyDefinitionRepository;
+import com.init.domainpack.domain.repository.WorkspaceExistencePort;
+import com.init.domainpack.domain.repository.WorkspaceMembershipPort;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -24,13 +28,23 @@ class DomainPackValidatorTest {
 
   private static final Long VERSION_ID = 10L;
 
+  @Mock private WorkspaceExistencePort workspaceExistencePort;
+  @Mock private WorkspaceMembershipPort workspaceMembershipPort;
+  @Mock private DomainPackRepository domainPackRepository;
+  @Mock private DomainPackVersionRepository domainPackVersionRepository;
   @Mock private PolicyDefinitionRepository policyDefinitionRepository;
 
   private DomainPackValidator validator;
 
   @BeforeEach
   void setUp() {
-    validator = new DomainPackValidator(null, null, null, null, policyDefinitionRepository);
+    validator =
+        new DomainPackValidator(
+            workspaceExistencePort,
+            workspaceMembershipPort,
+            domainPackRepository,
+            domainPackVersionRepository,
+            policyDefinitionRepository);
   }
 
   @Test

--- a/backend/src/test/java/com/init/domainpack/application/DomainPackValidatorTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/DomainPackValidatorTest.java
@@ -90,6 +90,7 @@ class DomainPackValidatorTest {
 
     assertThatCode(() -> validator.validatePolicyCodes(VERSION_ID, codes))
         .doesNotThrowAnyException();
-    verify(policyDefinitionRepository).findExistingPolicyCodesByVersionIdAndCodes(VERSION_ID, codes);
+    verify(policyDefinitionRepository)
+        .findExistingPolicyCodesByVersionIdAndCodes(VERSION_ID, codes);
   }
 }

--- a/backend/src/test/java/com/init/domainpack/application/DomainPackValidatorTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/DomainPackValidatorTest.java
@@ -1,0 +1,60 @@
+package com.init.domainpack.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.init.domainpack.application.exception.WorkflowActionNodePolicyRefNotFoundException;
+import com.init.domainpack.domain.repository.PolicyDefinitionRepository;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("DomainPackValidator")
+class DomainPackValidatorTest {
+
+  private static final Long VERSION_ID = 10L;
+
+  @Mock private PolicyDefinitionRepository policyDefinitionRepository;
+
+  private DomainPackValidator validator;
+
+  @BeforeEach
+  void setUp() {
+    validator = new DomainPackValidator(null, null, null, null, policyDefinitionRepository);
+  }
+
+  @Test
+  @DisplayName("미존재 policyCode를 만나면 즉시 예외를 던지고 이후 코드는 조회하지 않는다")
+  void should_fail_fast_when_policyCodeMissing() {
+    // given: 순서 보장을 위해 LinkedHashSet 사용 [p-1(valid) → p-2(missing) → p-3]
+    given(policyDefinitionRepository.existsByDomainPackVersionIdAndPolicyCode(VERSION_ID, "p-1"))
+        .willReturn(true);
+    given(policyDefinitionRepository.existsByDomainPackVersionIdAndPolicyCode(VERSION_ID, "p-2"))
+        .willReturn(false);
+    Set<String> codes = new LinkedHashSet<>(List.of("p-1", "p-2", "p-3"));
+
+    // when & then
+    assertThatThrownBy(() -> validator.validatePolicyCodes(VERSION_ID, codes))
+        .isInstanceOf(WorkflowActionNodePolicyRefNotFoundException.class)
+        .satisfies(
+            e -> {
+              WorkflowActionNodePolicyRefNotFoundException typed =
+                  (WorkflowActionNodePolicyRefNotFoundException) e;
+              assertThat(typed.getCode()).isEqualTo("WORKFLOW_ACTION_NODE_POLICY_REF_NOT_FOUND");
+              assertThat(typed.getMessage()).contains("p-2");
+            });
+    // p-2에서 즉시 예외 → p-3는 조회되면 안 됨
+    verify(policyDefinitionRepository, never())
+        .existsByDomainPackVersionIdAndPolicyCode(VERSION_ID, "p-3");
+  }
+}

--- a/backend/src/test/java/com/init/domainpack/application/DomainPackValidatorTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/DomainPackValidatorTest.java
@@ -2,6 +2,7 @@ package com.init.domainpack.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -48,14 +49,12 @@ class DomainPackValidatorTest {
   }
 
   @Test
-  @DisplayName("미존재 policyCode를 만나면 즉시 예외를 던지고 이후 코드는 조회하지 않는다")
-  void should_fail_fast_when_policyCodeMissing() {
-    // given: 순서 보장을 위해 LinkedHashSet 사용 [p-1(valid) → p-2(missing) → p-3]
-    given(policyDefinitionRepository.existsByDomainPackVersionIdAndPolicyCode(VERSION_ID, "p-1"))
-        .willReturn(true);
-    given(policyDefinitionRepository.existsByDomainPackVersionIdAndPolicyCode(VERSION_ID, "p-2"))
-        .willReturn(false);
+  @DisplayName("미존재 policyCode가 있으면 예외를 던지며 단건 exists 쿼리는 호출되지 않는다")
+  void should_throw_when_policyCodeMissing() {
+    // given: p-1만 존재, p-2/p-3은 미존재
     Set<String> codes = new LinkedHashSet<>(List.of("p-1", "p-2", "p-3"));
+    given(policyDefinitionRepository.findExistingPolicyCodesByVersionIdAndCodes(VERSION_ID, codes))
+        .willReturn(Set.of("p-1"));
 
     // when & then
     assertThatThrownBy(() -> validator.validatePolicyCodes(VERSION_ID, codes))
@@ -65,10 +64,10 @@ class DomainPackValidatorTest {
               WorkflowActionNodePolicyRefNotFoundException typed =
                   (WorkflowActionNodePolicyRefNotFoundException) e;
               assertThat(typed.getCode()).isEqualTo("WORKFLOW_ACTION_NODE_POLICY_REF_NOT_FOUND");
-              assertThat(typed.getMessage()).contains("p-2");
+              assertThat(typed.getMessage()).containsAnyOf("p-2", "p-3");
             });
-    // p-2에서 즉시 예외 → p-3는 조회되면 안 됨
+    // 배치 쿼리로 대체됐으므로 단건 exists는 호출되어선 안 됨
     verify(policyDefinitionRepository, never())
-        .existsByDomainPackVersionIdAndPolicyCode(VERSION_ID, "p-3");
+        .existsByDomainPackVersionIdAndPolicyCode(any(), any());
   }
 }

--- a/backend/src/test/java/com/init/domainpack/application/DomainPackValidatorTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/DomainPackValidatorTest.java
@@ -1,6 +1,7 @@
 package com.init.domainpack.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -13,6 +14,7 @@ import com.init.domainpack.domain.repository.DomainPackVersionRepository;
 import com.init.domainpack.domain.repository.PolicyDefinitionRepository;
 import com.init.domainpack.domain.repository.WorkspaceExistencePort;
 import com.init.domainpack.domain.repository.WorkspaceMembershipPort;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -67,7 +69,27 @@ class DomainPackValidatorTest {
               assertThat(typed.getMessage()).containsAnyOf("p-2", "p-3");
             });
     // 배치 쿼리로 대체됐으므로 단건 exists는 호출되어선 안 됨
+    verify(policyDefinitionRepository).findExistingPolicyCodesByVersionIdAndCodes(any(), any());
+  }
+
+  @Test
+  @DisplayName("policyCodes가 비어 있으면 DB를 호출하지 않고 즉시 반환한다")
+  void should_not_call_repository_when_policyCodes_empty() {
+    assertThatCode(() -> validator.validatePolicyCodes(VERSION_ID, Collections.emptySet()))
+        .doesNotThrowAnyException();
     verify(policyDefinitionRepository, never())
-        .existsByDomainPackVersionIdAndPolicyCode(any(), any());
+        .findExistingPolicyCodesByVersionIdAndCodes(any(), any());
+  }
+
+  @Test
+  @DisplayName("모든 policyCode가 존재하면 예외를 던지지 않고 배치 쿼리를 1회 호출한다")
+  void should_not_throw_when_all_policyCodes_exist() {
+    Set<String> codes = new LinkedHashSet<>(List.of("p-1", "p-2"));
+    given(policyDefinitionRepository.findExistingPolicyCodesByVersionIdAndCodes(VERSION_ID, codes))
+        .willReturn(Set.of("p-1", "p-2"));
+
+    assertThatCode(() -> validator.validatePolicyCodes(VERSION_ID, codes))
+        .doesNotThrowAnyException();
+    verify(policyDefinitionRepository).findExistingPolicyCodesByVersionIdAndCodes(VERSION_ID, codes);
   }
 }

--- a/backend/src/test/java/com/init/domainpack/application/GetIntentDefinitionListUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/GetIntentDefinitionListUseCaseTest.java
@@ -14,6 +14,7 @@ import com.init.domainpack.domain.model.IntentDefinition;
 import com.init.domainpack.domain.repository.DomainPackRepository;
 import com.init.domainpack.domain.repository.DomainPackVersionRepository;
 import com.init.domainpack.domain.repository.IntentDefinitionRepository;
+import com.init.domainpack.domain.repository.PolicyDefinitionRepository;
 import com.init.domainpack.domain.repository.WorkspaceExistencePort;
 import com.init.domainpack.domain.repository.WorkspaceMembershipPort;
 import java.time.OffsetDateTime;
@@ -35,6 +36,7 @@ class GetIntentDefinitionListUseCaseTest {
   @Mock private WorkspaceMembershipPort workspaceMembershipPort;
   @Mock private DomainPackRepository domainPackRepository;
   @Mock private DomainPackVersionRepository domainPackVersionRepository;
+  @Mock private PolicyDefinitionRepository policyDefinitionRepository;
   @Mock private IntentDefinitionRepository intentDefinitionRepository;
 
   private GetIntentDefinitionListUseCase useCase;
@@ -52,7 +54,7 @@ class GetIntentDefinitionListUseCaseTest {
             workspaceMembershipPort,
             domainPackRepository,
             domainPackVersionRepository,
-            null);
+            policyDefinitionRepository);
     useCase = new GetIntentDefinitionListUseCase(validator, intentDefinitionRepository);
   }
 

--- a/backend/src/test/java/com/init/domainpack/application/GetIntentDefinitionListUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/GetIntentDefinitionListUseCaseTest.java
@@ -51,7 +51,8 @@ class GetIntentDefinitionListUseCaseTest {
             workspaceExistencePort,
             workspaceMembershipPort,
             domainPackRepository,
-            domainPackVersionRepository);
+            domainPackVersionRepository,
+            null);
     useCase = new GetIntentDefinitionListUseCase(validator, intentDefinitionRepository);
   }
 

--- a/backend/src/test/java/com/init/domainpack/application/GetIntentDefinitionUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/GetIntentDefinitionUseCaseTest.java
@@ -52,7 +52,8 @@ class GetIntentDefinitionUseCaseTest {
             workspaceExistencePort,
             workspaceMembershipPort,
             domainPackRepository,
-            domainPackVersionRepository);
+            domainPackVersionRepository,
+            null);
     useCase = new GetIntentDefinitionUseCase(validator, intentDefinitionRepository);
   }
 

--- a/backend/src/test/java/com/init/domainpack/application/GetPolicyDefinitionListUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/GetPolicyDefinitionListUseCaseTest.java
@@ -52,7 +52,7 @@ class GetPolicyDefinitionListUseCaseTest {
             workspaceMembershipPort,
             domainPackRepository,
             domainPackVersionRepository,
-            null);
+            policyDefinitionRepository);
     useCase = new GetPolicyDefinitionListUseCase(validator, policyDefinitionRepository);
   }
 

--- a/backend/src/test/java/com/init/domainpack/application/GetPolicyDefinitionListUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/GetPolicyDefinitionListUseCaseTest.java
@@ -51,7 +51,8 @@ class GetPolicyDefinitionListUseCaseTest {
             workspaceExistencePort,
             workspaceMembershipPort,
             domainPackRepository,
-            domainPackVersionRepository);
+            domainPackVersionRepository,
+            null);
     useCase = new GetPolicyDefinitionListUseCase(validator, policyDefinitionRepository);
   }
 

--- a/backend/src/test/java/com/init/domainpack/application/GetPolicyDefinitionUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/GetPolicyDefinitionUseCaseTest.java
@@ -52,7 +52,8 @@ class GetPolicyDefinitionUseCaseTest {
             workspaceExistencePort,
             workspaceMembershipPort,
             domainPackRepository,
-            domainPackVersionRepository);
+            domainPackVersionRepository,
+            null);
     useCase = new GetPolicyDefinitionUseCase(validator, policyDefinitionRepository);
   }
 

--- a/backend/src/test/java/com/init/domainpack/application/GetPolicyDefinitionUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/GetPolicyDefinitionUseCaseTest.java
@@ -53,7 +53,7 @@ class GetPolicyDefinitionUseCaseTest {
             workspaceMembershipPort,
             domainPackRepository,
             domainPackVersionRepository,
-            null);
+            policyDefinitionRepository);
     useCase = new GetPolicyDefinitionUseCase(validator, policyDefinitionRepository);
   }
 

--- a/backend/src/test/java/com/init/domainpack/application/GetRiskDefinitionListUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/GetRiskDefinitionListUseCaseTest.java
@@ -51,7 +51,8 @@ class GetRiskDefinitionListUseCaseTest {
             workspaceExistencePort,
             workspaceMembershipPort,
             domainPackRepository,
-            domainPackVersionRepository);
+            domainPackVersionRepository,
+            null);
     useCase = new GetRiskDefinitionListUseCase(validator, riskDefinitionRepository);
   }
 

--- a/backend/src/test/java/com/init/domainpack/application/GetRiskDefinitionListUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/GetRiskDefinitionListUseCaseTest.java
@@ -13,6 +13,7 @@ import com.init.domainpack.domain.model.DomainPackVersion;
 import com.init.domainpack.domain.model.RiskDefinition;
 import com.init.domainpack.domain.repository.DomainPackRepository;
 import com.init.domainpack.domain.repository.DomainPackVersionRepository;
+import com.init.domainpack.domain.repository.PolicyDefinitionRepository;
 import com.init.domainpack.domain.repository.RiskDefinitionRepository;
 import com.init.domainpack.domain.repository.WorkspaceExistencePort;
 import com.init.domainpack.domain.repository.WorkspaceMembershipPort;
@@ -35,6 +36,7 @@ class GetRiskDefinitionListUseCaseTest {
   @Mock private WorkspaceMembershipPort workspaceMembershipPort;
   @Mock private DomainPackRepository domainPackRepository;
   @Mock private DomainPackVersionRepository domainPackVersionRepository;
+  @Mock private PolicyDefinitionRepository policyDefinitionRepository;
   @Mock private RiskDefinitionRepository riskDefinitionRepository;
 
   private GetRiskDefinitionListUseCase useCase;
@@ -52,7 +54,7 @@ class GetRiskDefinitionListUseCaseTest {
             workspaceMembershipPort,
             domainPackRepository,
             domainPackVersionRepository,
-            null);
+            policyDefinitionRepository);
     useCase = new GetRiskDefinitionListUseCase(validator, riskDefinitionRepository);
   }
 

--- a/backend/src/test/java/com/init/domainpack/application/GetRiskDefinitionUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/GetRiskDefinitionUseCaseTest.java
@@ -52,7 +52,8 @@ class GetRiskDefinitionUseCaseTest {
             workspaceExistencePort,
             workspaceMembershipPort,
             domainPackRepository,
-            domainPackVersionRepository);
+            domainPackVersionRepository,
+            null);
     useCase = new GetRiskDefinitionUseCase(validator, riskDefinitionRepository);
   }
 

--- a/backend/src/test/java/com/init/domainpack/application/GetSlotDefinitionListUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/GetSlotDefinitionListUseCaseTest.java
@@ -51,7 +51,8 @@ class GetSlotDefinitionListUseCaseTest {
             workspaceExistencePort,
             workspaceMembershipPort,
             domainPackRepository,
-            domainPackVersionRepository);
+            domainPackVersionRepository,
+            null);
     useCase = new GetSlotDefinitionListUseCase(validator, slotDefinitionRepository);
   }
 

--- a/backend/src/test/java/com/init/domainpack/application/GetSlotDefinitionListUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/GetSlotDefinitionListUseCaseTest.java
@@ -13,6 +13,7 @@ import com.init.domainpack.domain.model.DomainPackVersion;
 import com.init.domainpack.domain.model.SlotDefinition;
 import com.init.domainpack.domain.repository.DomainPackRepository;
 import com.init.domainpack.domain.repository.DomainPackVersionRepository;
+import com.init.domainpack.domain.repository.PolicyDefinitionRepository;
 import com.init.domainpack.domain.repository.SlotDefinitionRepository;
 import com.init.domainpack.domain.repository.WorkspaceExistencePort;
 import com.init.domainpack.domain.repository.WorkspaceMembershipPort;
@@ -35,6 +36,7 @@ class GetSlotDefinitionListUseCaseTest {
   @Mock private WorkspaceMembershipPort workspaceMembershipPort;
   @Mock private DomainPackRepository domainPackRepository;
   @Mock private DomainPackVersionRepository domainPackVersionRepository;
+  @Mock private PolicyDefinitionRepository policyDefinitionRepository;
   @Mock private SlotDefinitionRepository slotDefinitionRepository;
 
   private GetSlotDefinitionListUseCase useCase;
@@ -52,7 +54,7 @@ class GetSlotDefinitionListUseCaseTest {
             workspaceMembershipPort,
             domainPackRepository,
             domainPackVersionRepository,
-            null);
+            policyDefinitionRepository);
     useCase = new GetSlotDefinitionListUseCase(validator, slotDefinitionRepository);
   }
 

--- a/backend/src/test/java/com/init/domainpack/application/GetSlotDefinitionUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/GetSlotDefinitionUseCaseTest.java
@@ -14,6 +14,7 @@ import com.init.domainpack.domain.model.DomainPackVersion;
 import com.init.domainpack.domain.model.SlotDefinition;
 import com.init.domainpack.domain.repository.DomainPackRepository;
 import com.init.domainpack.domain.repository.DomainPackVersionRepository;
+import com.init.domainpack.domain.repository.PolicyDefinitionRepository;
 import com.init.domainpack.domain.repository.SlotDefinitionRepository;
 import com.init.domainpack.domain.repository.WorkspaceExistencePort;
 import com.init.domainpack.domain.repository.WorkspaceMembershipPort;
@@ -35,6 +36,7 @@ class GetSlotDefinitionUseCaseTest {
   @Mock private WorkspaceMembershipPort workspaceMembershipPort;
   @Mock private DomainPackRepository domainPackRepository;
   @Mock private DomainPackVersionRepository domainPackVersionRepository;
+  @Mock private PolicyDefinitionRepository policyDefinitionRepository;
   @Mock private SlotDefinitionRepository slotDefinitionRepository;
 
   private GetSlotDefinitionUseCase useCase;
@@ -53,7 +55,7 @@ class GetSlotDefinitionUseCaseTest {
             workspaceMembershipPort,
             domainPackRepository,
             domainPackVersionRepository,
-            null);
+            policyDefinitionRepository);
     useCase = new GetSlotDefinitionUseCase(validator, slotDefinitionRepository);
   }
 

--- a/backend/src/test/java/com/init/domainpack/application/GetSlotDefinitionUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/GetSlotDefinitionUseCaseTest.java
@@ -52,7 +52,8 @@ class GetSlotDefinitionUseCaseTest {
             workspaceExistencePort,
             workspaceMembershipPort,
             domainPackRepository,
-            domainPackVersionRepository);
+            domainPackVersionRepository,
+            null);
     useCase = new GetSlotDefinitionUseCase(validator, slotDefinitionRepository);
   }
 

--- a/backend/src/test/java/com/init/domainpack/application/GetWorkflowDefinitionListUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/GetWorkflowDefinitionListUseCaseTest.java
@@ -50,7 +50,8 @@ class GetWorkflowDefinitionListUseCaseTest {
             workspaceExistencePort,
             workspaceMembershipPort,
             domainPackRepository,
-            domainPackVersionRepository);
+            domainPackVersionRepository,
+            null);
     useCase = new GetWorkflowDefinitionListUseCase(validator, workflowDefinitionRepository);
   }
 

--- a/backend/src/test/java/com/init/domainpack/application/GetWorkflowDefinitionUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/GetWorkflowDefinitionUseCaseTest.java
@@ -54,7 +54,8 @@ class GetWorkflowDefinitionUseCaseTest {
             workspaceExistencePort,
             workspaceMembershipPort,
             domainPackRepository,
-            domainPackVersionRepository);
+            domainPackVersionRepository,
+            null);
     useCase = new GetWorkflowDefinitionUseCase(validator, workflowDefinitionRepository);
   }
 

--- a/backend/src/test/java/com/init/domainpack/application/GetWorkflowTransitionListUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/GetWorkflowTransitionListUseCaseTest.java
@@ -88,7 +88,8 @@ class GetWorkflowTransitionListUseCaseTest {
             workspaceExistencePort,
             workspaceMembershipPort,
             domainPackRepository,
-            domainPackVersionRepository);
+            domainPackVersionRepository,
+            null);
     useCase = new GetWorkflowTransitionListUseCase(validator, workflowDefinitionRepository);
   }
 

--- a/backend/src/test/java/com/init/domainpack/application/GetWorkflowTransitionUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/GetWorkflowTransitionUseCaseTest.java
@@ -72,7 +72,8 @@ class GetWorkflowTransitionUseCaseTest {
             workspaceExistencePort,
             workspaceMembershipPort,
             domainPackRepository,
-            domainPackVersionRepository);
+            domainPackVersionRepository,
+            null);
     useCase = new GetWorkflowTransitionUseCase(validator, workflowDefinitionRepository);
   }
 

--- a/backend/src/test/java/com/init/domainpack/application/UpdateWorkflowUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/UpdateWorkflowUseCaseTest.java
@@ -3,10 +3,15 @@ package com.init.domainpack.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
+import com.init.domainpack.application.exception.WorkflowActionNodePolicyRefNotFoundException;
 import com.init.domainpack.application.exception.WorkflowCycleDetectedException;
 import com.init.domainpack.application.exception.WorkflowDanglingEdgeException;
 import com.init.domainpack.application.exception.WorkflowEdgeIdDuplicateException;
@@ -22,6 +27,7 @@ import com.init.domainpack.domain.repository.WorkflowDefinitionRepository;
 import com.init.shared.application.exception.BadRequestException;
 import com.init.shared.application.exception.NotFoundException;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -38,6 +44,16 @@ class UpdateWorkflowUseCaseTest {
       "{\"direction\":\"LR\","
           + "\"nodes\":[{\"id\":\"start\",\"type\":\"START\"},{\"id\":\"end\",\"type\":\"TERMINAL\"}],"
           + "\"edges\":[{\"id\":\"e_start_to_end\",\"from\":\"start\",\"to\":\"end\",\"label\":null}]}";
+
+  private static final String GRAPH_WITH_ACTION_NODE =
+      "{\"direction\":\"LR\","
+          + "\"nodes\":["
+          + "{\"id\":\"n1\",\"type\":\"START\"},"
+          + "{\"id\":\"n2\",\"type\":\"ACTION\",\"policyRef\":\"policy-1\"},"
+          + "{\"id\":\"n3\",\"type\":\"TERMINAL\"}],"
+          + "\"edges\":["
+          + "{\"id\":\"e1\",\"from\":\"n1\",\"to\":\"n2\",\"label\":null},"
+          + "{\"id\":\"e2\",\"from\":\"n2\",\"to\":\"n3\",\"label\":null}]}";
 
   @Mock private DomainPackValidator validator;
   @Mock private DomainPackVersionRepository versionRepository;
@@ -360,6 +376,76 @@ class UpdateWorkflowUseCaseTest {
                         1L, 7L, 10L, 99L, 5L, "이름", null, duplicateEdgeIdGraph)))
         .isInstanceOf(WorkflowEdgeIdDuplicateException.class);
     verify(workflowRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("ACTION 노드 policyRef가 version에 존재하면 성공한다")
+  void should_성공_when_ACTION노드policyRef유효() {
+    // given
+    DomainPackVersion version = draftVersion(10L, 7L);
+    given(versionRepository.findById(10L)).willReturn(Optional.of(version));
+    WorkflowDefinition workflow = workflow(99L, 10L);
+    given(workflowRepository.findByIdAndDomainPackVersionId(99L, 10L))
+        .willReturn(Optional.of(workflow));
+    given(workflowRepository.save(any())).willReturn(workflow);
+    UpdateWorkflowCommand command =
+        new UpdateWorkflowCommand(1L, 7L, 10L, 99L, 5L, "이름", null, GRAPH_WITH_ACTION_NODE);
+
+    // when
+    WorkflowDefinitionDetail result = useCase.execute(command);
+
+    // then
+    assertThat(result).isNotNull();
+    verify(validator).validatePolicyCodes(eq(10L), eq(Set.of("policy-1")));
+  }
+
+  @Test
+  @DisplayName(
+      "ACTION 노드 policyRef가 version에 없으면 WorkflowActionNodePolicyRefNotFoundException을 던진다")
+  void should_예외_when_ACTION노드policyRef미존재() {
+    // given
+    DomainPackVersion version = draftVersion(10L, 7L);
+    given(versionRepository.findById(10L)).willReturn(Optional.of(version));
+    WorkflowDefinition workflow = workflow(99L, 10L);
+    given(workflowRepository.findByIdAndDomainPackVersionId(99L, 10L))
+        .willReturn(Optional.of(workflow));
+    doThrow(new WorkflowActionNodePolicyRefNotFoundException("policy-1"))
+        .when(validator)
+        .validatePolicyCodes(anyLong(), anySet());
+    UpdateWorkflowCommand command =
+        new UpdateWorkflowCommand(1L, 7L, 10L, 99L, 5L, "이름", null, GRAPH_WITH_ACTION_NODE);
+
+    // when & then
+    assertThatThrownBy(() -> useCase.execute(command))
+        .isInstanceOf(WorkflowActionNodePolicyRefNotFoundException.class)
+        .satisfies(
+            e -> {
+              WorkflowActionNodePolicyRefNotFoundException typed =
+                  (WorkflowActionNodePolicyRefNotFoundException) e;
+              assertThat(typed.getCode()).isEqualTo("WORKFLOW_ACTION_NODE_POLICY_REF_NOT_FOUND");
+              assertThat(typed.getMessage()).contains("policy-1");
+            });
+    verify(workflowRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("ACTION 노드가 없으면 validatePolicyCodes를 호출하지 않는다")
+  void should_validatePolicyCodes미호출_when_ACTION노드없음() {
+    // given
+    DomainPackVersion version = draftVersion(10L, 7L);
+    given(versionRepository.findById(10L)).willReturn(Optional.of(version));
+    WorkflowDefinition workflow = workflow(99L, 10L);
+    given(workflowRepository.findByIdAndDomainPackVersionId(99L, 10L))
+        .willReturn(Optional.of(workflow));
+    given(workflowRepository.save(any())).willReturn(workflow);
+    UpdateWorkflowCommand command =
+        new UpdateWorkflowCommand(1L, 7L, 10L, 99L, 5L, "이름", null, VALID_GRAPH);
+
+    // when
+    useCase.execute(command);
+
+    // then
+    verify(validator, never()).validatePolicyCodes(anyLong(), anySet());
   }
 
   // ── factories ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

`UpdateWorkflowUseCase`에 V8c 검증을 추가한다. ACTION 타입 노드의 `policyRef`가 같은 `domainPackVersionId`에 속한 `policyCode` 중 하나와 일치하는지 DB 조회로 검증한다. 불일치 시 `WORKFLOW_ACTION_NODE_POLICY_REF_NOT_FOUND` (400)을 반환한다.

---

## Context

- `[BE] #98` — Backend 전용, 스키마 변경 없음
- 기존 PATCH workflow 엔드포인트에 검증 로직만 추가됨
- `CreateDomainPackDraftUseCase` 동일 검증은 spec #231 별도 이슈

---

## What Changed

| 파일 | 변경 유형 | 내용 |
|------|-----------|------|
| `WorkflowActionNodePolicyRefNotFoundException` | 신규 | `BadRequestException` 상속, code=`WORKFLOW_ACTION_NODE_POLICY_REF_NOT_FOUND` |
| `PolicyDefinitionRepository` | 메서드 추가 | `existsByDomainPackVersionIdAndPolicyCode(Long, String)` |
| `JpaPolicyDefinitionRepository` | 메서드 추가 | Spring Data JPA 파생 쿼리 선언 |
| `DomainPackValidator` | 수정 | 생성자 4인자→5인자, `validatePolicyCodes(Long, Set<String>)` 신규 (fail-fast) |
| `UpdateWorkflowUseCase` | 수정 | `parseAndValidate()` 직후 V8c 호출 삽입 |
| `DomainPackValidatorTest` | 신규 | fail-fast 테스트 1개 |
| `UpdateWorkflowUseCaseTest` | 수정 | 신규 3개 테스트 케이스 추가 |
| 기존 테스트 12개 파일 | 수정 | `DomainPackValidator` 생성자 5번째 인자(`null`) 추가 — 필수 cascading |

---

## Assumptions Adopted

| ID | 내용 | 영향 |
|----|------|------|
| UR-98-01 | `WorkflowActionNodePolicyRefNotFoundException`을 `BadRequestException` 상속으로 구현 (사용자 확정 A) | HTTP 400 자동 보장 |
| UR-98-02 | `GlobalExceptionHandler` 미수정 — 기존 `@ExceptionHandler(BadRequestException.class)`가 서브클래스 자동 처리 (사용자 확정) | 핸들러 변경 없음 |
| UR-98-03 | `UpdateWorkflowUseCaseTest`에 `PolicyDefinitionRepository` mock 추가 불필요 (사용자 확정) — `DomainPackValidator` mock으로 `doThrow`/`verify` 처리 | 테스트 범위 최소화 |

---

## Spec Deviations

N/A — 전 항목 spec과 일치.

---

## Blocked / Skipped Items

없음.

---

## Test Notes

- **`UpdateWorkflowUseCaseTest`**: 신규 3개 케이스 추가
  - ACTION 노드 policyRef 유효 → 성공, `validatePolicyCodes` 1회 호출 및 Set 내용 검증
  - ACTION 노드 policyRef 미존재 → `WorkflowActionNodePolicyRefNotFoundException`, 에러코드 확인
  - ACTION 노드 없음 → `validatePolicyCodes` 미호출(`verify(never())`)
- **`DomainPackValidatorTest`**: 신규 생성, fail-fast 1개 테스트
  - spec 의사코드에 p-3 stub 등록이 포함되어 있었으나, `STRICT_STUBS` 모드에서 `UnnecessaryStubbingException` 유발하는 latent bug — 구현체에서 p-3 stub 제거로 올바르게 수정
- **`./gradlew test`**: BUILD SUCCESSFUL
- **Audit V-001 수정**: `DomainPackValidatorTest` 생성자 null literal 4개 → `@Mock` 필드 교체 (audit auto-fix, 기능 영향 없음)

---

## Reviewer Focus

1. **`UpdateWorkflowUseCase` V8c 호출 위치** — `parseAndValidate()` 직후, `extractInitialState()` 이전인지 확인
2. **`DomainPackValidatorTest` `@Mock` 필드 4개** — audit V-001 수정으로 교체됨, null literal 없음 확인
3. **기존 12개 테스트 파일** — `DomainPackValidator` 5번째 인자 위치와 null 값 확인 (cascading 수정)
4. **`validatePolicyCodes` skip 가드** — `policyRefs.isEmpty()` 조건이 있어야 ACTION 노드 없을 때 불필요 DB 쿼리 방지

---

## Conflicts

없음.

---

## Ready to Merge / Needs Input

**Ready to Merge**

- 모든 uncertainty 구현 전 사용자 확정 완료
- Audit: Critical 0, Warning 0, Info 1 (V-001 auto-fixed)
- Spec 전 항목 일치
- 미결 사용자 결정 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 워크플로우의 ACTION 노드에 설정된 정책 참조(policyRef)에 대한 서버측 검증 추가
  * 존재하지 않는 정책 참조를 식별하고 명확한 오류 코드와 메시지로 응답

* **테스트**
  * 정책 참조 검증 동작(정상/오류/미존재 케이스)에 대한 단위 테스트 및 사용 사례 테스트 추가 및 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->