### PR TITLE
docs(spec) add 99.md for issue #99, and update 231.md align to issue #99

### DIFF
--- a/.agent/specs/231.md
+++ b/.agent/specs/231.md
@@ -13,7 +13,7 @@
 
 추가로 `DomainPackVersion.summaryJson`은 PostgreSQL `jsonb` 컬럼으로 저장되며, Hibernate 런타임에서도 JSON 타입으로 바인딩되도록 보장한다.
 
-저장 전에 각 workflow의 `graphJson`에 대해 `.agent/specs/226.md`에서 정의한 V1-V6 무결성 규칙을 `validateDraftPayload()` write path에서 강제하며, 위반 시 400 Bad Request를 반환한다.
+저장 전에 각 workflow의 `graphJson`에 대해 V1-V8 무결성 규칙을 `validateDraftPayload()` write path에서 강제하며, 위반 시 400 Bad Request를 반환한다. V8a·V8b(`policyRef` 형식)는 `WorkflowGraphValidator.parseAndValidate` 경유로 검증하고, V8c(`policyRef`가 제출된 `policies`의 `policyCode` 목록 내 존재 여부)는 인메모리 교차 검증으로 처리한다. `validateDraftPayload()` 구현 위치는 `DomainPackDraftPersistenceService`이다.
 
 ---
 
@@ -56,8 +56,9 @@ sequenceDiagram
     uc ->> uc: validateDraftPayload()
     Note over uc: 1. intent/slot/workflow code 중복 검증
     Note over uc: 2. binding 참조 코드 유효성 검증
-    Note over uc: 3. 각 workflow graphJson V1-V6 검증 (위반 시 즉시 400)
-    Note over uc: 4. graphJson → initialState / terminalStatesJson 추출
+    Note over uc: 3. 각 workflow graphJson V1-V8a·V8b 검증 (WorkflowGraphValidator 경유, 위반 시 즉시 400)
+    Note over uc: 4. V8c: ACTION 노드 policyRef 인메모리 교차 검증 (제출된 policies policyCode 목록 기준)
+    Note over uc: 5. graphJson → initialState / terminalStatesJson 추출
     uc ->> versionRepo: findMaxVersionNoByDomainPackId(packId)
     uc ->> versionRepo: saveAndFlush(createDraft(...))
     versionRepo ->> db: INSERT pack.domain_pack_version
@@ -103,7 +104,7 @@ sequenceDiagram
 - `policies`: 최대 200개
 - `risks`: 최대 200개
 - `workflows`: 최대 200개
-- `workflows[].graphJson`: V1-V6 무결성 검증 대상 (`.agent/specs/226.md`). `initialState` / `terminalStatesJson`은 서버가 graphJson V1-V6 검증 후 자동 추출한다. 이 두 필드는 DTO에서 `@Null`로 선언되므로, 클라이언트가 값을 제공하면 400 `VALIDATION_ERROR`를 반환한다.
+- `workflows[].graphJson`: V1-V8 무결성 검증 대상. **ACTION 타입 노드는 `policyRef` 필드 필수** (비어있지 않은 `[A-Za-z0-9_-]+` 문자열, V8a·V8b). **`policyRef` 값은 제출된 `policies`의 `policyCode` 목록 중 하나와 일치해야 한다** (V8c). `initialState` / `terminalStatesJson`은 서버가 V1-V8 검증 후 자동 추출한다. 이 두 필드는 DTO에서 `@Null`로 선언되므로, 클라이언트가 값을 제공하면 400 `VALIDATION_ERROR`를 반환한다.
 - `intentWorkflowBindings`: 최대 500개
 - `riskLevel`: `LOW`, `MEDIUM`, `HIGH`, `CRITICAL` 중 하나
 
@@ -132,11 +133,17 @@ sequenceDiagram
       "isRequired": true
     }
   ],
+  "policies": [
+    {
+      "policyCode": "collect_order_policy",
+      "name": "주문번호 수집 정책"
+    }
+  ],
   "workflows": [
     {
       "workflowCode": "refund_flow",
       "name": "환불 플로우",
-      "graphJson": "{\"direction\":\"LR\",\"nodes\":[{\"id\":\"start\",\"label\":\"상담 시작\",\"type\":\"START\"},{\"id\":\"collect_order_id\",\"label\":\"주문번호 수집\",\"type\":\"ACTION\"},{\"id\":\"terminal\",\"label\":\"상담 종료\",\"type\":\"TERMINAL\"}],\"edges\":[{\"from\":\"start\",\"to\":\"collect_order_id\"},{\"from\":\"collect_order_id\",\"to\":\"terminal\"}]}"
+      "graphJson": "{\"direction\":\"LR\",\"nodes\":[{\"id\":\"start\",\"label\":\"상담 시작\",\"type\":\"START\"},{\"id\":\"collect_order_id\",\"label\":\"주문번호 수집\",\"type\":\"ACTION\",\"policyRef\":\"collect_order_policy\"},{\"id\":\"terminal\",\"label\":\"상담 종료\",\"type\":\"TERMINAL\"}],\"edges\":[{\"id\":\"e_start_to_collect\",\"from\":\"start\",\"to\":\"collect_order_id\"},{\"id\":\"e_collect_to_terminal\",\"from\":\"collect_order_id\",\"to\":\"terminal\"}]}"
     }
   ],
   "intentWorkflowBindings": [
@@ -232,6 +239,26 @@ public record WorkflowDraftRequest(
 { "code": "WORKFLOW_UNLABELED_BRANCH", "message": "DECISION 노드의 모든 outgoing edge에 label이 필요합니다. workflowCode=refund_flow" }
 ```
 
+```json
+{ "code": "WORKFLOW_EDGE_ID_MISSING", "message": "edge에 id가 필요합니다. workflowCode=refund_flow" }
+```
+
+```json
+{ "code": "WORKFLOW_EDGE_ID_DUPLICATE", "message": "edge id가 중복됩니다. workflowCode=refund_flow" }
+```
+
+```json
+{ "code": "WORKFLOW_ACTION_NODE_POLICY_REF_MISSING", "message": "ACTION 타입 노드에 policyRef가 필요합니다. workflowCode=refund_flow" }
+```
+
+```json
+{ "code": "WORKFLOW_ACTION_NODE_POLICY_REF_INVALID_CHARS", "message": "ACTION 타입 노드의 policyRef가 유효하지 않은 문자를 포함합니다. workflowCode=refund_flow" }
+```
+
+```json
+{ "code": "WORKFLOW_ACTION_NODE_POLICY_REF_NOT_FOUND", "message": "ACTION 타입 노드의 policyRef가 존재하지 않습니다. policyRef=missing_policy" }
+```
+
 **404 Not Found**
 
 ```json
@@ -309,36 +336,52 @@ classDiagram
 3. workflow code 중복 검증
 4. `intentSlotBindings` 참조 코드 유효성 (intent/slot code 목록 내 존재 여부)
 5. `intentWorkflowBindings` 참조 코드 유효성 (intent/workflow code 목록 내 존재 여부)
-6. 각 workflow `graphJson` V1-V6 검증 (`.agent/specs/226.md` 참조):
+6. 각 workflow `graphJson` V1-V8a·V8b 검증 (`WorkflowGraphValidator.parseAndValidate` 경유, fail-fast):
    - V1: `type == "START"` 노드 **정확히 1개** → `WorkflowInvalidStartNodeException`
    - V2: `type == "TERMINAL"` 노드 **1개 이상** → `WorkflowInvalidTerminalNodeException`
    - V3: `edges.from/to` 참조 노드 id 모두 `nodes`에 존재 → `WorkflowDanglingEdgeException`
    - V4: START에서 모든 노드 BFS/DFS 도달 가능 → `WorkflowUnreachableNodeException`
    - V5: 사이클 없음 (DAG) → `WorkflowCycleDetectedException`
    - V6: `DECISION` 노드 outgoing edge 전체에 `label` 존재 → `WorkflowUnlabeledBranchException`
-7. V1-V6 통과 후 graphJson에서 자동 추출:
+   - V7a: 모든 edge에 `id` 필드 존재·비어있지 않음 → `WorkflowEdgeIdMissingException`
+   - V7b: edge `id` 중복 없음 → `WorkflowEdgeIdDuplicateException`
+   - V8a: ACTION 타입 노드에 `policyRef` 필드 존재·비어있지 않음 → `WorkflowActionNodePolicyRefMissingException`
+   - V8b: ACTION 타입 노드 `policyRef`가 `[A-Za-z0-9_-]+` 패턴 충족 → `WorkflowActionNodePolicyRefInvalidCharsException`
+7. **V8c**: 각 workflow ACTION 노드의 `policyRef` 집합을 추출하여, 제출된 `policies`의 `policyCode` 목록에 모두 존재하는지 **인메모리 교차 검증** (위반 시 `WorkflowActionNodePolicyRefNotFoundException`). DB 조회 불필요 — version이 아직 DB에 없으므로 `UpdateWorkflowUseCase`의 `DomainPackValidator.validatePolicyCodes`(DB 방식)와 다름.
+8. V1-V8 통과 후 graphJson에서 자동 추출:
    - `initialState` = `type == "START"` 노드의 `id`
    - `terminalStatesJson` = `type == "TERMINAL"` 노드 `id` 목록을 JSON 배열 문자열로 직렬화 (예: `"[\"terminal\"]"`)
 
 > 클라이언트 요청 DTO인 `WorkflowDraftRequest`에는 `initialState` / `terminalStatesJson` 필드를 클라이언트가 직접 설정할 수 없으며, 포함 시 400으로 거부한다. 서버가 V1-V6 검증 후 `graphJson`에서 자동 추출하여 내부 `WorkflowDraft` command record와 `WorkflowDefinition` 엔티티에 저장한다.
 
-#### validateAndExtractWorkflows 구현 참고
+#### validateAndNormalizeWorkflow 구현 참고 (DomainPackDraftPersistenceService)
 
 ```java
-private List<WorkflowDraft> validateAndExtractWorkflows(CreateDomainPackDraftCommand command) {
-    // 1. workflow code 중복 검증
-    // 2. intentWorkflowBindings 참조 코드 유효성
-    // 3. 각 workflow graphJson V1-V6 검증 후 추출
-    return command.workflows().stream()
-        .map(w -> {
-            WorkflowGraphValidator.ParsedGraph graph =
-                WorkflowGraphValidator.parseAndValidate(w.graphJson(), w.workflowCode()); // V1-V6
-            String initialState = WorkflowGraphValidator.extractInitialState(graph);             // START 노드 id
-            String terminalStatesJson = WorkflowGraphValidator.extractTerminalStatesJson(graph); // TERMINAL 노드 id 배열 JSON
-            return new WorkflowDraft(w.workflowCode(), w.name(), w.graphJson(),
-                                     initialState, terminalStatesJson);
-        })
-        .toList();
+// validateDraftPayload 내 V8c 인메모리 교차 검증
+Set<String> submittedPolicyCodes = safeList(policies).stream()
+    .map(CreateDomainPackDraftCommand.PolicyDraft::policyCode)
+    .collect(Collectors.toSet());
+return safeList(workflows).stream()
+    .map(w -> validateAndNormalizeWorkflow(w, submittedPolicyCodes))
+    .toList();
+
+private CreateDomainPackDraftCommand.WorkflowDraft validateAndNormalizeWorkflow(
+        CreateDomainPackDraftCommand.WorkflowDraft workflow,
+        Set<String> submittedPolicyCodes) {
+    WorkflowGraphValidator.ParsedGraph graph =
+        WorkflowGraphValidator.parseAndValidate(workflow.graphJson(), workflow.workflowCode()); // V1-V8a/V8b
+    // V8c: policyRef 교차 검증 (in-memory)
+    graph.nodes().stream()
+        .filter(n -> "ACTION".equals(n.type()))
+        .map(WorkflowGraphValidator.GraphNode::policyRef)
+        .filter(ref -> !submittedPolicyCodes.contains(ref))
+        .findFirst()
+        .ifPresent(ref -> { throw new WorkflowActionNodePolicyRefNotFoundException(ref); });
+    String initialState = WorkflowGraphValidator.extractInitialState(graph);
+    String terminalStatesJson = WorkflowGraphValidator.extractTerminalStatesJson(graph);
+    return new CreateDomainPackDraftCommand.WorkflowDraft(
+        workflow.workflowCode(), workflow.name(), workflow.description(), workflow.graphJson(),
+        initialState, terminalStatesJson, workflow.evidenceJson(), workflow.metaJson());
 }
 ```
 
@@ -403,6 +446,41 @@ public class WorkflowUnlabeledBranchException extends BadRequestException {
     super("WORKFLOW_UNLABELED_BRANCH", "DECISION 노드의 모든 outgoing edge에 label이 필요합니다. workflowCode=" + workflowCode);
   }
 }
+
+// V7
+public class WorkflowEdgeIdMissingException extends BadRequestException {
+  public WorkflowEdgeIdMissingException(String workflowCode) {
+    super("WORKFLOW_EDGE_ID_MISSING", "edge에 id가 필요합니다. workflowCode=" + workflowCode);
+  }
+}
+
+public class WorkflowEdgeIdDuplicateException extends BadRequestException {
+  public WorkflowEdgeIdDuplicateException(String workflowCode) {
+    super("WORKFLOW_EDGE_ID_DUPLICATE", "edge id가 중복됩니다. workflowCode=" + workflowCode);
+  }
+}
+
+// V8
+public class WorkflowActionNodePolicyRefMissingException extends BadRequestException {
+  public WorkflowActionNodePolicyRefMissingException(String workflowCode) {
+    super("WORKFLOW_ACTION_NODE_POLICY_REF_MISSING",
+          "ACTION 타입 노드에 policyRef가 필요합니다. workflowCode=" + workflowCode);
+  }
+}
+
+public class WorkflowActionNodePolicyRefInvalidCharsException extends BadRequestException {
+  public WorkflowActionNodePolicyRefInvalidCharsException(String workflowCode) {
+    super("WORKFLOW_ACTION_NODE_POLICY_REF_INVALID_CHARS",
+          "ACTION 타입 노드의 policyRef가 유효하지 않은 문자를 포함합니다. workflowCode=" + workflowCode);
+  }
+}
+
+public class WorkflowActionNodePolicyRefNotFoundException extends BadRequestException {
+  public WorkflowActionNodePolicyRefNotFoundException(String policyRef) {
+    super("WORKFLOW_ACTION_NODE_POLICY_REF_NOT_FOUND",
+          "ACTION 타입 노드의 policyRef가 존재하지 않습니다. policyRef=" + policyRef);
+  }
+}
 ```
 
 ---
@@ -411,7 +489,7 @@ public class WorkflowUnlabeledBranchException extends BadRequestException {
 
 ### Unit Tests
 
-- 정상 생성 시 새 `DRAFT` 버전과 하위 정의 저장
+- 정상 생성 시 새 `DRAFT` 버전과 하위 정의 저장 (VALID_GRAPH_JSON policyRef와 일치하는 policy 포함 필수)
 - workspace 없음 → `DomainPackWorkspaceNotFoundException`
 - domain pack 소속 불일치 → `DomainPackNotFoundException`
 - 존재하지 않는 참조 코드 → `DomainPackDraftRequestInvalidException`
@@ -422,8 +500,14 @@ public class WorkflowUnlabeledBranchException extends BadRequestException {
 - graphJson V4 위반: START에서 도달 불가 노드 존재 → `WorkflowUnreachableNodeException`
 - graphJson V5 위반: 사이클 존재 → `WorkflowCycleDetectedException`
 - graphJson V6 위반: DECISION 노드 outgoing edge에 label 없음 → `WorkflowUnlabeledBranchException`
-- graphJson V1-V6 통과 시 `initialState`가 START 노드 id로 추출되어 저장됨
-- graphJson V1-V6 통과 시 `terminalStatesJson`이 TERMINAL 노드 id 배열 JSON으로 추출되어 저장됨
+- graphJson V7a 위반: edge id 없음 → `WorkflowEdgeIdMissingException`
+- graphJson V7b 위반: edge id 중복 → `WorkflowEdgeIdDuplicateException`
+- graphJson V8a 위반: ACTION 노드 policyRef 없음 → `WorkflowActionNodePolicyRefMissingException`
+- graphJson V8b 위반: ACTION 노드 policyRef 유효하지 않은 문자 포함 → `WorkflowActionNodePolicyRefInvalidCharsException`
+- graphJson V8c 위반: ACTION 노드 policyRef가 제출된 policies에 없음 → `WorkflowActionNodePolicyRefNotFoundException`
+- graphJson V8c 통과: ACTION 노드 policyRef가 제출된 policies의 policyCode와 일치하면 정상 저장
+- graphJson V1-V8 통과 시 `initialState`가 START 노드 id로 추출되어 저장됨
+- graphJson V1-V8 통과 시 `terminalStatesJson`이 TERMINAL 노드 id 배열 JSON으로 추출되어 저장됨
 - TERMINAL 노드 복수 개일 때 `terminalStatesJson` 배열에 모두 포함됨
 
 ### Controller Tests
@@ -442,6 +526,11 @@ public class WorkflowUnlabeledBranchException extends BadRequestException {
 - graphJson V4 위반 (unreachable node) → `400 WORKFLOW_UNREACHABLE_NODE`
 - graphJson V5 위반 (cycle) → `400 WORKFLOW_CYCLE_DETECTED`
 - graphJson V6 위반 (unlabeled branch) → `400 WORKFLOW_UNLABELED_BRANCH`
+- graphJson V7a 위반 (edge id 없음) → `400 WORKFLOW_EDGE_ID_MISSING`
+- graphJson V7b 위반 (edge id 중복) → `400 WORKFLOW_EDGE_ID_DUPLICATE`
+- graphJson V8a 위반 (ACTION 노드 policyRef 없음) → `400 WORKFLOW_ACTION_NODE_POLICY_REF_MISSING`
+- graphJson V8b 위반 (ACTION 노드 policyRef 유효하지 않은 문자) → `400 WORKFLOW_ACTION_NODE_POLICY_REF_INVALID_CHARS`
+- graphJson V8c 위반 (policyRef가 제출된 policies에 없음) → `400 WORKFLOW_ACTION_NODE_POLICY_REF_NOT_FOUND`
 - 요청에 `workflows[].initialState` 포함 시 → `400 VALIDATION_ERROR`
 - 요청에 `workflows[].terminalStatesJson` 포함 시 → `400 VALIDATION_ERROR`
 
@@ -455,6 +544,8 @@ public class WorkflowUnlabeledBranchException extends BadRequestException {
 
 ## Additional Notes
 
-- graphJson 파싱 및 V1-V6 검증 로직은 독립 헬퍼 클래스(`WorkflowGraphValidator` 또는 유사)로 분리하는 것을 권장한다 — `validateDraftPayload()` 인라인 구현 시 테스트 격리 어려움.
-- V1-V6은 workflow 단위로 독립 검증하며, 첫 번째 위반 발생 시 즉시 예외를 던진다 (fail-fast).
-- graphJson 스키마 및 V1-V6 규칙 원본 정의: `.agent/specs/226.md`.
+- graphJson 파싱 및 V1-V8a·V8b 검증 로직은 `WorkflowGraphValidator`(package-private 헬퍼)로 분리되어 있다. V8c만 `DomainPackDraftPersistenceService`에서 인메모리로 처리한다.
+- V1-V8a·V8b는 workflow 단위로 독립 검증하며, 첫 번째 위반 발생 시 즉시 예외를 던진다 (fail-fast).
+- **V8c 구현 주의**: `CreateDomainPackDraftUseCase` 맥락에서는 version이 DB에 아직 없으므로, `UpdateWorkflowUseCase`의 `DomainPackValidator.validatePolicyCodes`(DB 조회)를 사용하면 안 된다. 제출된 `policies` 목록을 직접 인메모리 Set으로 검증한다.
+- `validateDraftPayload()` 실제 구현 위치는 `DomainPackDraftPersistenceService`이다. 시퀀스 다이어그램의 `uc` 호출은 내부적으로 `domainPackDraftPersistenceService.persist()` 위임을 통해 처리된다.
+- graphJson 스키마 및 V1-V6 규칙: `.agent/specs/226.md` 참조. V7 규칙: `.agent/specs/3215.md` 참조. V8 규칙: `.agent/specs/3215.md` 참조.

--- a/.agent/specs/99.md
+++ b/.agent/specs/99.md
@@ -1,0 +1,155 @@
+# [BE-99] CreateDomainPackDraftUseCase V8 검증 추가
+
+> **Backlog**: spec 231 `CreateDomainPackDraftUseCase`에 V8 graphJson 검증을 적용하고 policyRef 매핑 전략을 확정한다
+> **Bounded Context**: `domainpack`
+> **Template**: `_TEMPLATE_BE.md`
+> **Branch**: `spec/99`
+> **Base spec**: `.agent/specs/231.md`
+
+---
+
+## Goal
+
+`DomainPackDraftPersistenceService.validateDraftPayload()`에 V8c 인메모리 교차 검증을 추가하여, 초안 생성 시 workflow graphJson ACTION 노드의 `policyRef`가 동일 요청의 `policies` 목록 내 `policyCode`와 일치하는지 강제한다.
+
+- **V8a·V8b** (`policyRef` 존재·형식): `WorkflowGraphValidator.parseAndValidate`에 이미 구현됨 (spec 3215 / issue #98 선행 작업). 추가 구현 불필요.
+- **V8c** (`policyRef` cross-entity 존재 검증): 이 스펙의 직접 구현 대상. DB 조회 없이 제출된 `policies` 목록 기준 인메모리 검증.
+- **policyRef 매핑 전략**: Option B 확정 — `node.id`와 `policyRef`는 독립 관리. ML pipeline `draft-generation` 단계에서 별도 매핑 정보를 통해 policyRef를 결정한다.
+
+---
+
+## Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    participant svc as DomainPackDraftPersistenceService
+    participant val as WorkflowGraphValidator
+    participant db as PostgreSQL
+
+    Note over svc: validateDraftPayload() 내 변경 사항
+    svc ->> svc: submittedPolicyCodes = policies.map(policyCode).toSet()
+    loop 각 workflow
+        svc ->> val: parseAndValidate(graphJson, workflowCode)
+        Note over val: V1-V8a/V8b 검증 (기존)
+        val -->> svc: ParsedGraph
+        svc ->> svc: V8c: ACTION 노드 policyRef ∈ submittedPolicyCodes?
+        alt policyRef 미존재
+            svc -->> svc: WorkflowActionNodePolicyRefNotFoundException
+        end
+        svc ->> svc: extractInitialState / extractTerminalStatesJson
+    end
+    svc ->> db: saveAllAndFlush(...)
+```
+
+---
+
+## REST API
+
+신규 엔드포인트 없음. 기존 `POST /api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/drafts` (spec 231)에 V8c 검증 추가.
+
+### 추가 에러 응답
+
+**400 Bad Request** — V8c 위반 (policyRef가 제출된 policies에 없음)
+
+```json
+{
+  "code": "WORKFLOW_ACTION_NODE_POLICY_REF_NOT_FOUND",
+  "message": "ACTION 타입 노드의 policyRef가 존재하지 않습니다. policyRef=missing_policy"
+}
+```
+
+> V8a/V8b 에러 코드(`WORKFLOW_ACTION_NODE_POLICY_REF_MISSING`, `WORKFLOW_ACTION_NODE_POLICY_REF_INVALID_CHARS`)는 spec 3215 및 issue #98에서 이미 정의됨.
+
+---
+
+## Class Design
+
+### 변경 파일
+
+| 파일 | 변경 내용 |
+|------|-----------|
+| `DomainPackDraftPersistenceService.java` | `validateDraftPayload`에 V8c 인메모리 검증 추가; `validateAndNormalizeWorkflow`에 `submittedPolicyCodes` 파라미터 추가 |
+
+### V8c 구현 (DomainPackDraftPersistenceService)
+
+```java
+// validateDraftPayload 내 V8c 추가
+Set<String> submittedPolicyCodes = safeList(policies).stream()
+    .map(CreateDomainPackDraftCommand.PolicyDraft::policyCode)
+    .collect(Collectors.toSet());
+return safeList(workflows).stream()
+    .map(w -> validateAndNormalizeWorkflow(w, submittedPolicyCodes))
+    .toList();
+
+// validateAndNormalizeWorkflow 시그니처 변경
+private CreateDomainPackDraftCommand.WorkflowDraft validateAndNormalizeWorkflow(
+        CreateDomainPackDraftCommand.WorkflowDraft workflow,
+        Set<String> submittedPolicyCodes) {
+    WorkflowGraphValidator.ParsedGraph graph =
+        WorkflowGraphValidator.parseAndValidate(workflow.graphJson(), workflow.workflowCode()); // V1-V8a/V8b
+    // V8c
+    graph.nodes().stream()
+        .filter(n -> "ACTION".equals(n.type()))
+        .map(WorkflowGraphValidator.GraphNode::policyRef)
+        .filter(ref -> !submittedPolicyCodes.contains(ref))
+        .findFirst()
+        .ifPresent(ref -> { throw new WorkflowActionNodePolicyRefNotFoundException(ref); });
+    return new CreateDomainPackDraftCommand.WorkflowDraft(
+        workflow.workflowCode(), workflow.name(), workflow.description(), workflow.graphJson(),
+        WorkflowGraphValidator.extractInitialState(graph),
+        WorkflowGraphValidator.extractTerminalStatesJson(graph),
+        workflow.evidenceJson(), workflow.metaJson());
+}
+```
+
+> `WorkflowActionNodePolicyRefNotFoundException` 클래스는 이미 존재 (`backend/.../exception/WorkflowActionNodePolicyRefNotFoundException.java`).
+
+### 신규 예외 클래스
+
+없음. V8c에 필요한 `WorkflowActionNodePolicyRefNotFoundException`은 이미 구현됨.
+
+### policyRef 매핑 전략 결정
+
+- **확정**: Option B — `node.id`(그래프 내부 식별자)와 `policyRef`(policy 외부 참조)는 독립적으로 관리
+- **근거**: spec 3215 방침("node.id와 policyRef는 독립 관리") 일관성 유지
+- **영향**: ML pipeline `draft-generation` 단계 스펙 작성 시 node-to-policy 매핑 자료구조 명시 필요. BE spec 231에는 영향 없음.
+- **세부 사항**: `.handoff/99/uncertainty-register-99.md` U1 참조
+
+---
+
+## Tests
+
+### Unit Tests (CreateDomainPackDraftUseCaseTest 확장)
+
+| 시나리오 | 예상 결과 |
+|----------|-----------|
+| V8a 위반: ACTION 노드 policyRef 없음 | `WorkflowActionNodePolicyRefMissingException` |
+| V8b 위반: ACTION 노드 policyRef 유효하지 않은 문자 | `WorkflowActionNodePolicyRefInvalidCharsException` |
+| V8c 위반: ACTION 노드 policyRef가 제출된 policies에 없음 | `WorkflowActionNodePolicyRefNotFoundException` |
+| V8c 통과: policyRef가 제출된 policies의 policyCode와 일치 | 정상 저장 |
+| `validCommand()` 픽스처 수정 | VALID_GRAPH_JSON의 `policyRef: "handle_policy"`와 일치하는 `PolicyDraft(policyCode="handle_policy")` 포함 필수 |
+
+> V1-V7 테스트는 기존 유지. `commandWithGraphJson()` 헬퍼가 `List.of()` policies로 ACTION 노드 없는 그래프를 테스트할 때는 V8c 영향 없음.
+
+### Controller Tests (CreateDomainPackDraftControllerTest 확장)
+
+| 시나리오 | 예상 결과 |
+|----------|-----------|
+| V8a 위반 | `400 WORKFLOW_ACTION_NODE_POLICY_REF_MISSING` |
+| V8b 위반 | `400 WORKFLOW_ACTION_NODE_POLICY_REF_INVALID_CHARS` |
+| V8c 위반 | `400 WORKFLOW_ACTION_NODE_POLICY_REF_NOT_FOUND` |
+
+---
+
+## Database
+
+변경 없음.
+
+---
+
+## Additional Notes
+
+- V8c는 `UpdateWorkflowUseCase`의 `DomainPackValidator.validatePolicyCodes`(DB 조회)와 다르게, 신규 초안 생성 시 version이 DB에 아직 없으므로 **인메모리 검증**이어야 한다.
+- `validateAndNormalizeWorkflow`의 `submittedPolicyCodes` 파라미터는 `validateDraftPayload` 호출 시점에 한 번만 빌드하고 모든 workflow 검증에 재사용한다.
+- V8a/V8b 구현: `WorkflowGraphValidator.validateV8ActionPolicyRef` (spec 3215 / issue #98 완료).
+- V8c 예외 발생 위치: workflow 단위 fail-fast. 첫 번째 미존재 policyRef에서 즉시 throw.


### PR DESCRIPTION
# [BE-99] CreateDomainPackDraftUseCase V8 검증 추가

> **Backlog**: spec 231 `CreateDomainPackDraftUseCase`에 V8 graphJson 검증을 적용하고 policyRef 매핑 전략을 확정한다
> **Bounded Context**: `domainpack`
> **Template**: `_TEMPLATE_BE.md`
> **Branch**: `spec/99`
> **Base spec**: `.agent/specs/231.md`

---

## Goal

`DomainPackDraftPersistenceService.validateDraftPayload()`에 V8c 인메모리 교차 검증을 추가하여, 초안 생성 시 workflow graphJson ACTION 노드의 `policyRef`가 동일 요청의 `policies` 목록 내 `policyCode`와 일치하는지 강제한다.

- **V8a·V8b** (`policyRef` 존재·형식): `WorkflowGraphValidator.parseAndValidate`에 이미 구현됨 (spec 3215 / issue #98 선행 작업). 추가 구현 불필요.
- **V8c** (`policyRef` cross-entity 존재 검증): 이 스펙의 직접 구현 대상. DB 조회 없이 제출된 `policies` 목록 기준 인메모리 검증.
- **policyRef 매핑 전략**: Option B 확정 — `node.id`와 `policyRef`는 독립 관리. ML pipeline `draft-generation` 단계에서 별도 매핑 정보를 통해 policyRef를 결정한다.

---

## Sequence Diagram

```mermaid
sequenceDiagram
    participant svc as DomainPackDraftPersistenceService
    participant val as WorkflowGraphValidator
    participant db as PostgreSQL

    Note over svc: validateDraftPayload() 내 변경 사항
    svc ->> svc: submittedPolicyCodes = policies.map(policyCode).toSet()
    loop 각 workflow
        svc ->> val: parseAndValidate(graphJson, workflowCode)
        Note over val: V1-V8a/V8b 검증 (기존)
        val -->> svc: ParsedGraph
        svc ->> svc: V8c: ACTION 노드 policyRef ∈ submittedPolicyCodes?
        alt policyRef 미존재
            svc -->> svc: WorkflowActionNodePolicyRefNotFoundException
        end
        svc ->> svc: extractInitialState / extractTerminalStatesJson
    end
    svc ->> db: saveAllAndFlush(...)
```

---

## REST API

신규 엔드포인트 없음. 기존 `POST /api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/drafts` (spec 231)에 V8c 검증 추가.

### 추가 에러 응답

**400 Bad Request** — V8c 위반 (policyRef가 제출된 policies에 없음)

```json
{
  "code": "WORKFLOW_ACTION_NODE_POLICY_REF_NOT_FOUND",
  "message": "ACTION 타입 노드의 policyRef가 존재하지 않습니다. policyRef=missing_policy"
}
```

> V8a/V8b 에러 코드(`WORKFLOW_ACTION_NODE_POLICY_REF_MISSING`, `WORKFLOW_ACTION_NODE_POLICY_REF_INVALID_CHARS`)는 spec 3215 및 issue #98에서 이미 정의됨.

---

## Class Design

### 변경 파일

| 파일 | 변경 내용 |
|------|-----------|
| `DomainPackDraftPersistenceService.java` | `validateDraftPayload`에 V8c 인메모리 검증 추가; `validateAndNormalizeWorkflow`에 `submittedPolicyCodes` 파라미터 추가 |

### V8c 구현 (DomainPackDraftPersistenceService)

```java
// validateDraftPayload 내 V8c 추가
Set<String> submittedPolicyCodes = safeList(policies).stream()
    .map(CreateDomainPackDraftCommand.PolicyDraft::policyCode)
    .collect(Collectors.toSet());
return safeList(workflows).stream()
    .map(w -> validateAndNormalizeWorkflow(w, submittedPolicyCodes))
    .toList();

// validateAndNormalizeWorkflow 시그니처 변경
private CreateDomainPackDraftCommand.WorkflowDraft validateAndNormalizeWorkflow(
        CreateDomainPackDraftCommand.WorkflowDraft workflow,
        Set<String> submittedPolicyCodes) {
    WorkflowGraphValidator.ParsedGraph graph =
        WorkflowGraphValidator.parseAndValidate(workflow.graphJson(), workflow.workflowCode()); // V1-V8a/V8b
    // V8c
    graph.nodes().stream()
        .filter(n -> "ACTION".equals(n.type()))
        .map(WorkflowGraphValidator.GraphNode::policyRef)
        .filter(ref -> !submittedPolicyCodes.contains(ref))
        .findFirst()
        .ifPresent(ref -> { throw new WorkflowActionNodePolicyRefNotFoundException(ref); });
    return new CreateDomainPackDraftCommand.WorkflowDraft(
        workflow.workflowCode(), workflow.name(), workflow.description(), workflow.graphJson(),
        WorkflowGraphValidator.extractInitialState(graph),
        WorkflowGraphValidator.extractTerminalStatesJson(graph),
        workflow.evidenceJson(), workflow.metaJson());
}
```

> `WorkflowActionNodePolicyRefNotFoundException` 클래스는 이미 존재 (`backend/.../exception/WorkflowActionNodePolicyRefNotFoundException.java`).

### 신규 예외 클래스

없음. V8c에 필요한 `WorkflowActionNodePolicyRefNotFoundException`은 이미 구현됨.

### policyRef 매핑 전략 결정

- **확정**: Option B — `node.id`(그래프 내부 식별자)와 `policyRef`(policy 외부 참조)는 독립적으로 관리
- **근거**: spec 3215 방침("node.id와 policyRef는 독립 관리") 일관성 유지
- **영향**: ML pipeline `draft-generation` 단계 스펙 작성 시 node-to-policy 매핑 자료구조 명시 필요. BE spec 231에는 영향 없음.
- **세부 사항**: `.handoff/99/uncertainty-register-99.md` U1 참조

---

## Tests

### Unit Tests (CreateDomainPackDraftUseCaseTest 확장)

| 시나리오 | 예상 결과 |
|----------|-----------|
| V8a 위반: ACTION 노드 policyRef 없음 | `WorkflowActionNodePolicyRefMissingException` |
| V8b 위반: ACTION 노드 policyRef 유효하지 않은 문자 | `WorkflowActionNodePolicyRefInvalidCharsException` |
| V8c 위반: ACTION 노드 policyRef가 제출된 policies에 없음 | `WorkflowActionNodePolicyRefNotFoundException` |
| V8c 통과: policyRef가 제출된 policies의 policyCode와 일치 | 정상 저장 |
| `validCommand()` 픽스처 수정 | VALID_GRAPH_JSON의 `policyRef: "handle_policy"`와 일치하는 `PolicyDraft(policyCode="handle_policy")` 포함 필수 |

> V1-V7 테스트는 기존 유지. `commandWithGraphJson()` 헬퍼가 `List.of()` policies로 ACTION 노드 없는 그래프를 테스트할 때는 V8c 영향 없음.

### Controller Tests (CreateDomainPackDraftControllerTest 확장)

| 시나리오 | 예상 결과 |
|----------|-----------|
| V8a 위반 | `400 WORKFLOW_ACTION_NODE_POLICY_REF_MISSING` |
| V8b 위반 | `400 WORKFLOW_ACTION_NODE_POLICY_REF_INVALID_CHARS` |
| V8c 위반 | `400 WORKFLOW_ACTION_NODE_POLICY_REF_NOT_FOUND` |

---

## Database

변경 없음.

---

## Additional Notes

- V8c는 `UpdateWorkflowUseCase`의 `DomainPackValidator.validatePolicyCodes`(DB 조회)와 다르게, 신규 초안 생성 시 version이 DB에 아직 없으므로 **인메모리 검증**이어야 한다.
- `validateAndNormalizeWorkflow`의 `submittedPolicyCodes` 파라미터는 `validateDraftPayload` 호출 시점에 한 번만 빌드하고 모든 workflow 검증에 재사용한다.
- V8a/V8b 구현: `WorkflowGraphValidator.validateV8ActionPolicyRef` (spec 3215 / issue #98 완료).
- V8c 예외 발생 위치: workflow 단위 fail-fast. 첫 번째 미존재 policyRef에서 즉시 throw.
---
# Uncertainty Register — Issue #99

> spec: `.agent/specs/231.md` (BE — CreateDomainPackDraftUseCase V8 검증 + policyRef 매핑 전략)
> branch: `spec/99`

---

## U1 — policyRef 매핑 전략 (ML pipeline)

- **ID**: U1
- **Issue**: AI 파이프라인이 생성하는 workflow graphJson의 ACTION 노드에서 `policyRef` 값을 어떻게 결정하는가
- **Status**: `Confirmed`
- **Decision**: **Option B** — pipeline이 `node.id`(그래프 내부 식별자)와 `policyRef`(policy 외부 참조)를 독립적으로 생성한다. `node.id == policyRef` 제약을 두지 않는다.
- **Decided by**: 사용자 (2026-04-23)
- **Rationale**: spec 3215 기존 방침("node.id와 policyRef는 독립적으로 관리")과 일관성 유지. node.id와 policyCode가 처음부터 독립 네임스페이스를 가지므로 이후 그래프 편집 시 연쇄 변경 없음.
- **User Decision Required**: No (결정 완료)
- **User Question**: N/A
- **Execution Rule**:
  - ML pipeline `draft-generation` 단계 spec 작성 시: ACTION 노드 id와 policyCode를 독립적으로 생성하는 node-to-policy 매핑 자료구조를 명시해야 한다.
  - `node.id == policyRef`를 파이프라인 코드에서 강제하면 안 된다.
- **Affected Spec Section**: ML pipeline `draft-generation` 단계 스펙 (미작성 — 해당 스펙 작성 시 반영 필요). spec 231 (BE) 변경 없음.

---

## U2 — validateDraftPayload 위치 (spec vs 구현 편차)

- **ID**: U2
- **Issue**: spec 231 시퀀스 다이어그램은 `CreateDomainPackDraftUseCase`가 `validateDraftPayload()`를 직접 호출하는 것으로 표현되어 있으나, 실제 구현에서는 `DomainPackDraftPersistenceService.persist()` 내부에서 처리됨
- **Status**: `Confirmed` (구현이 사실상 기준)
- **Why unresolved**: N/A — 기존 구현을 기준으로 spec 231을 업데이트함 (Additional Notes에 반영 완료)
- **Options**: N/A
- **Recommended Default**: N/A
- **Why recommended**: N/A
- **User Decision Required**: No
- **User Question**: N/A
- **Execution Rule**: `validateDraftPayload()` 로직은 `DomainPackDraftPersistenceService`에 구현한다.
- **Affected Spec Section**: `.agent/specs/231.md` § Additional Notes (반영 완료)

---

## 요약

| ID | 항목 | Status | 사용자 결정 필요 |
|----|------|--------|----------------|
| U1 | policyRef 매핑 전략 (ML pipeline) | Confirmed (Option B) | No |
| U2 | validateDraftPayload 위치 편차 | Confirmed | No |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 워크플로우 검증이 더욱 강화되었습니다. Edge ID 중복 검사 및 필수 정책 참조 검증이 추가되었습니다.
  * 정책 코드 목록과의 교차 검증으로 제출된 정책과의 일치성을 확인합니다.

* **설명서**
  * 워크플로우 검증 요구사항 및 새로운 오류 코드에 대한 스펙 문서를 업데이트했습니다.

* **테스트**
  * 강화된 검증 시나리오를 포함한 테스트 케이스를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->