### PR TITLE
fix(domain-pack): add V8c policyRef cross-entity validation to CreateDomainPackDraftUseCase (#99)

### DIFF
--- a/backend/src/main/java/com/init/domainpack/application/DomainPackDraftPersistenceService.java
+++ b/backend/src/main/java/com/init/domainpack/application/DomainPackDraftPersistenceService.java
@@ -4,6 +4,7 @@ import com.init.domainpack.application.exception.DomainPackDraftRequestInvalidEx
 import com.init.domainpack.application.exception.DomainPackVersionConflictException;
 import com.init.domainpack.application.exception.DomainPackVersionNotDraftException;
 import com.init.domainpack.application.exception.DomainPackVersionNotFoundException;
+import com.init.domainpack.application.exception.WorkflowActionNodePolicyRefNotFoundException;
 import com.init.domainpack.domain.model.DomainPackVersion;
 import com.init.domainpack.domain.model.IntentDefinition;
 import com.init.domainpack.domain.model.IntentSlotBinding;
@@ -24,7 +25,9 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
@@ -346,13 +349,28 @@ public class DomainPackDraftPersistenceService {
         binding -> binding.intentCode() + "::" + binding.workflowCode(),
         "intentWorkflowBinding");
 
-    return safeList(workflows).stream().map(this::validateAndNormalizeWorkflow).toList();
+    Set<String> submittedPolicyCodes =
+        safeList(policies).stream()
+            .map(CreateDomainPackDraftCommand.PolicyDraft::policyCode)
+            .collect(Collectors.toSet());
+    return safeList(workflows).stream()
+        .map(w -> validateAndNormalizeWorkflow(w, submittedPolicyCodes))
+        .toList();
   }
 
   private CreateDomainPackDraftCommand.WorkflowDraft validateAndNormalizeWorkflow(
-      CreateDomainPackDraftCommand.WorkflowDraft workflow) {
+      CreateDomainPackDraftCommand.WorkflowDraft workflow, Set<String> submittedPolicyCodes) {
     WorkflowGraphValidator.ParsedGraph graph =
         WorkflowGraphValidator.parseAndValidate(workflow.graphJson(), workflow.workflowCode());
+    graph.nodes().stream()
+        .filter(n -> "ACTION".equals(n.type()))
+        .map(WorkflowGraphValidator.GraphNode::policyRef)
+        .filter(ref -> !submittedPolicyCodes.contains(ref))
+        .findFirst()
+        .ifPresent(
+            ref -> {
+              throw new WorkflowActionNodePolicyRefNotFoundException(ref);
+            });
     return new CreateDomainPackDraftCommand.WorkflowDraft(
         workflow.workflowCode(),
         workflow.name(),

--- a/backend/src/test/java/com/init/domainpack/application/CreateDomainPackDraftUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/CreateDomainPackDraftUseCaseTest.java
@@ -117,7 +117,7 @@ class CreateDomainPackDraftUseCaseTest {
 
   @Test
   @DisplayName("정상 생성 시 새 DRAFT 버전과 하위 정의를 저장한다")
-  void execute_validCommand_returnsCreatedDraft() {
+  void should_saveNewDraftVersionAndDefinitions_when_validCommand() {
     given(workspaceExistencePort.existsById(1L)).willReturn(true);
     given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
     given(domainPackRepository.existsByIdAndWorkspaceId(7L, 1L)).willReturn(true);
@@ -156,7 +156,7 @@ class CreateDomainPackDraftUseCaseTest {
 
   @Test
   @DisplayName("workspace가 없으면 예외를 던지고 저장하지 않는다")
-  void execute_workspaceNotFound_throwsException() {
+  void should_throwWorkspaceNotFoundException_when_workspaceNotFound() {
     given(workspaceExistencePort.existsById(1L)).willReturn(false);
 
     assertThatThrownBy(() -> useCase.execute(validCommand()))
@@ -167,7 +167,7 @@ class CreateDomainPackDraftUseCaseTest {
 
   @Test
   @DisplayName("domain pack이 workspace에 없으면 예외를 던진다")
-  void execute_domainPackNotFound_throwsException() {
+  void should_throwDomainPackNotFoundException_when_domainPackNotFound() {
     given(workspaceExistencePort.existsById(1L)).willReturn(true);
     given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
     given(domainPackRepository.existsByIdAndWorkspaceId(7L, 1L)).willReturn(false);
@@ -178,7 +178,7 @@ class CreateDomainPackDraftUseCaseTest {
 
   @Test
   @DisplayName("존재하지 않는 참조 코드가 있으면 예외를 던진다")
-  void execute_missingBindingReference_throwsException() {
+  void should_throwDraftRequestInvalidException_when_bindingReferenceNotFound() {
     given(workspaceExistencePort.existsById(1L)).willReturn(true);
     given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
     given(domainPackRepository.existsByIdAndWorkspaceId(7L, 1L)).willReturn(true);
@@ -224,7 +224,7 @@ class CreateDomainPackDraftUseCaseTest {
 
   @Test
   @DisplayName("graphJson V1 위반 — START 노드 없으면 WorkflowInvalidStartNodeException")
-  void execute_noStartNode_throwsException() {
+  void should_throwInvalidStartNodeException_when_startNodeMissing() {
     stubWorkspaceAndPack();
     String noStart =
         "{\"direction\":\"LR\","
@@ -236,7 +236,7 @@ class CreateDomainPackDraftUseCaseTest {
 
   @Test
   @DisplayName("graphJson V1 위반 — START 노드 2개면 WorkflowInvalidStartNodeException")
-  void execute_multipleStartNodes_throwsException() {
+  void should_throwInvalidStartNodeException_when_multipleStartNodes() {
     stubWorkspaceAndPack();
     String twoStart =
         "{\"direction\":\"LR\","
@@ -252,7 +252,7 @@ class CreateDomainPackDraftUseCaseTest {
 
   @Test
   @DisplayName("graphJson V2 위반 — TERMINAL 노드 없으면 WorkflowInvalidTerminalNodeException")
-  void execute_noTerminalNode_throwsException() {
+  void should_throwInvalidTerminalNodeException_when_terminalNodeMissing() {
     stubWorkspaceAndPack();
     String noTerminal =
         "{\"direction\":\"LR\","
@@ -264,7 +264,7 @@ class CreateDomainPackDraftUseCaseTest {
 
   @Test
   @DisplayName("graphJson V3 위반 — 없는 노드 id 참조하면 WorkflowDanglingEdgeException")
-  void execute_danglingEdge_throwsException() {
+  void should_throwDanglingEdgeException_when_edgeReferencesNonExistentNode() {
     stubWorkspaceAndPack();
     String dangling =
         "{\"direction\":\"LR\","
@@ -279,7 +279,7 @@ class CreateDomainPackDraftUseCaseTest {
 
   @Test
   @DisplayName("graphJson V4 위반 — START에서 도달 불가 노드 있으면 WorkflowUnreachableNodeException")
-  void execute_unreachableNode_throwsException() {
+  void should_throwUnreachableNodeException_when_nodeUnreachableFromStart() {
     stubWorkspaceAndPack();
     String unreachable =
         "{\"direction\":\"LR\","
@@ -295,7 +295,7 @@ class CreateDomainPackDraftUseCaseTest {
 
   @Test
   @DisplayName("graphJson V5 위반 — 사이클 존재하면 WorkflowCycleDetectedException")
-  void execute_cycleDetected_throwsException() {
+  void should_throwCycleDetectedException_when_cycleExists() {
     stubWorkspaceAndPack();
     String cycle =
         "{\"direction\":\"LR\","
@@ -318,7 +318,7 @@ class CreateDomainPackDraftUseCaseTest {
   @Test
   @DisplayName(
       "graphJson V6 위반 — DECISION outgoing edge에 label 없으면 WorkflowUnlabeledBranchException")
-  void execute_unlabeledBranch_throwsException() {
+  void should_throwUnlabeledBranchException_when_decisionEdgeHasNoLabel() {
     stubWorkspaceAndPack();
     String unlabeled =
         "{\"direction\":\"LR\","
@@ -337,7 +337,7 @@ class CreateDomainPackDraftUseCaseTest {
 
   @Test
   @DisplayName("graphJson V7a 위반 — edge id 누락 시 WorkflowEdgeIdMissingException")
-  void execute_v7a_missingEdgeId_throwsException() {
+  void should_throwEdgeIdMissingException_when_edgeIdMissing() {
     stubWorkspaceAndPack();
     String missingEdgeIdGraph =
         "{\"direction\":\"LR\","
@@ -356,7 +356,7 @@ class CreateDomainPackDraftUseCaseTest {
 
   @Test
   @DisplayName("graphJson V7a 위반 — edge id 공백 시 WorkflowEdgeIdMissingException")
-  void execute_v7a_blankEdgeId_throwsException() {
+  void should_throwEdgeIdMissingException_when_edgeIdBlank() {
     stubWorkspaceAndPack();
     String blankEdgeIdGraph =
         "{\"direction\":\"LR\","
@@ -375,7 +375,7 @@ class CreateDomainPackDraftUseCaseTest {
 
   @Test
   @DisplayName("graphJson V7b 위반 — edge id 중복 시 WorkflowEdgeIdDuplicateException")
-  void execute_v7b_duplicateEdgeId_throwsException() {
+  void should_throwEdgeIdDuplicateException_when_edgeIdDuplicated() {
     stubWorkspaceAndPack();
     String duplicateEdgeIdGraph =
         "{\"direction\":\"LR\","
@@ -401,7 +401,7 @@ class CreateDomainPackDraftUseCaseTest {
   @Test
   @DisplayName(
       "graphJson V8a 위반 — ACTION 노드 policyRef 없으면 WorkflowActionNodePolicyRefMissingException")
-  void execute_v8a_missingPolicyRef_throwsException() {
+  void should_throwPolicyRefMissingException_when_actionNodePolicyRefMissing() {
     stubWorkspaceAndPack();
     String missingPolicyRefGraph =
         "{\"direction\":\"LR\","
@@ -421,7 +421,7 @@ class CreateDomainPackDraftUseCaseTest {
   @Test
   @DisplayName(
       "graphJson V8b 위반 — ACTION 노드 policyRef에 유효하지 않은 문자 포함 시 WorkflowActionNodePolicyRefInvalidCharsException")
-  void execute_v8b_invalidPolicyRefChars_throwsException() {
+  void should_throwPolicyRefInvalidCharsException_when_policyRefContainsInvalidChars() {
     stubWorkspaceAndPack();
     String invalidCharsGraph =
         "{\"direction\":\"LR\","
@@ -441,7 +441,7 @@ class CreateDomainPackDraftUseCaseTest {
   @Test
   @DisplayName(
       "graphJson V8c 위반 — ACTION 노드 policyRef가 제출된 policies에 없으면 WorkflowActionNodePolicyRefNotFoundException")
-  void execute_v8c_policyRefNotFound_throwsException() {
+  void should_throwPolicyRefNotFoundException_when_policyRefNotInSubmittedPolicies() {
     stubWorkspaceAndPack();
     String policyRefNotFoundGraph =
         "{\"direction\":\"LR\","
@@ -478,7 +478,7 @@ class CreateDomainPackDraftUseCaseTest {
   @Test
   @SuppressWarnings("unchecked")
   @DisplayName("graphJson V8c 통과 — ACTION 노드 policyRef가 제출된 policies policyCode와 일치하면 정상 저장")
-  void execute_v8c_policyRefMatchesSubmittedPolicy_savesSuccessfully() {
+  void should_saveWorkflow_when_policyRefMatchesSubmittedPolicyCode() {
     stubWorkspaceAndPack();
     stubSaveAll();
 
@@ -497,7 +497,7 @@ class CreateDomainPackDraftUseCaseTest {
   @Test
   @SuppressWarnings("unchecked")
   @DisplayName("V1-V6 통과 시 initialState가 START 노드 id로 저장된다")
-  void execute_validGraph_extractsInitialState() {
+  void should_saveInitialStateAsStartNodeId_when_graphIsValid() {
     stubWorkspaceAndPack();
     stubSaveAll();
 
@@ -513,7 +513,7 @@ class CreateDomainPackDraftUseCaseTest {
   @Test
   @SuppressWarnings("unchecked")
   @DisplayName("V1-V6 통과 시 terminalStatesJson이 TERMINAL 노드 id 배열 JSON으로 저장된다")
-  void execute_validGraph_extractsTerminalStatesJson() {
+  void should_saveTerminalStatesJsonAsTerminalNodeIds_when_graphIsValid() {
     stubWorkspaceAndPack();
     stubSaveAll();
 
@@ -529,7 +529,7 @@ class CreateDomainPackDraftUseCaseTest {
   @Test
   @SuppressWarnings("unchecked")
   @DisplayName("TERMINAL 노드 복수 개일 때 terminalStatesJson 배열에 모두 포함된다")
-  void execute_multipleTerminalNodes_allIncludedInJson() {
+  void should_includeAllTerminalNodesInTerminalStatesJson_when_multipleTerminalNodes() {
     stubWorkspaceAndPack();
     stubSaveAll();
 

--- a/backend/src/test/java/com/init/domainpack/application/CreateDomainPackDraftUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/CreateDomainPackDraftUseCaseTest.java
@@ -10,6 +10,9 @@ import static org.mockito.Mockito.verify;
 import com.init.domainpack.application.exception.DomainPackDraftRequestInvalidException;
 import com.init.domainpack.application.exception.DomainPackNotFoundException;
 import com.init.domainpack.application.exception.DomainPackWorkspaceNotFoundException;
+import com.init.domainpack.application.exception.WorkflowActionNodePolicyRefInvalidCharsException;
+import com.init.domainpack.application.exception.WorkflowActionNodePolicyRefMissingException;
+import com.init.domainpack.application.exception.WorkflowActionNodePolicyRefNotFoundException;
 import com.init.domainpack.application.exception.WorkflowCycleDetectedException;
 import com.init.domainpack.application.exception.WorkflowDanglingEdgeException;
 import com.init.domainpack.application.exception.WorkflowEdgeIdDuplicateException;
@@ -392,6 +395,102 @@ class CreateDomainPackDraftUseCaseTest {
   }
 
   // ──────────────────────────────────────────────────────────────
+  // graphJson V8 위반 테스트
+  // ──────────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName(
+      "graphJson V8a 위반 — ACTION 노드 policyRef 없으면 WorkflowActionNodePolicyRefMissingException")
+  void execute_v8a_missingPolicyRef_throwsException() {
+    stubWorkspaceAndPack();
+    String missingPolicyRefGraph =
+        "{\"direction\":\"LR\","
+            + "\"nodes\":["
+            + "{\"id\":\"start\",\"label\":\"시작\",\"type\":\"START\"},"
+            + "{\"id\":\"action1\",\"label\":\"처리\",\"type\":\"ACTION\"},"
+            + "{\"id\":\"terminal\",\"label\":\"종료\",\"type\":\"TERMINAL\"}"
+            + "],"
+            + "\"edges\":["
+            + "{\"id\":\"e1\",\"from\":\"start\",\"to\":\"action1\"},"
+            + "{\"id\":\"e2\",\"from\":\"action1\",\"to\":\"terminal\"}"
+            + "]}";
+    assertThatThrownBy(() -> useCase.execute(commandWithGraphJson(missingPolicyRefGraph)))
+        .isInstanceOf(WorkflowActionNodePolicyRefMissingException.class);
+  }
+
+  @Test
+  @DisplayName(
+      "graphJson V8b 위반 — ACTION 노드 policyRef에 유효하지 않은 문자 포함 시 WorkflowActionNodePolicyRefInvalidCharsException")
+  void execute_v8b_invalidPolicyRefChars_throwsException() {
+    stubWorkspaceAndPack();
+    String invalidCharsGraph =
+        "{\"direction\":\"LR\","
+            + "\"nodes\":["
+            + "{\"id\":\"start\",\"label\":\"시작\",\"type\":\"START\"},"
+            + "{\"id\":\"action1\",\"label\":\"처리\",\"type\":\"ACTION\",\"policyRef\":\"invalid policy!\"},"
+            + "{\"id\":\"terminal\",\"label\":\"종료\",\"type\":\"TERMINAL\"}"
+            + "],"
+            + "\"edges\":["
+            + "{\"id\":\"e1\",\"from\":\"start\",\"to\":\"action1\"},"
+            + "{\"id\":\"e2\",\"from\":\"action1\",\"to\":\"terminal\"}"
+            + "]}";
+    assertThatThrownBy(() -> useCase.execute(commandWithGraphJson(invalidCharsGraph)))
+        .isInstanceOf(WorkflowActionNodePolicyRefInvalidCharsException.class);
+  }
+
+  @Test
+  @DisplayName(
+      "graphJson V8c 위반 — ACTION 노드 policyRef가 제출된 policies에 없으면 WorkflowActionNodePolicyRefNotFoundException")
+  void execute_v8c_policyRefNotFound_throwsException() {
+    stubWorkspaceAndPack();
+    String policyRefNotFoundGraph =
+        "{\"direction\":\"LR\","
+            + "\"nodes\":["
+            + "{\"id\":\"start\",\"label\":\"시작\",\"type\":\"START\"},"
+            + "{\"id\":\"action1\",\"label\":\"처리\",\"type\":\"ACTION\",\"policyRef\":\"missing_policy\"},"
+            + "{\"id\":\"terminal\",\"label\":\"종료\",\"type\":\"TERMINAL\"}"
+            + "],"
+            + "\"edges\":["
+            + "{\"id\":\"e1\",\"from\":\"start\",\"to\":\"action1\"},"
+            + "{\"id\":\"e2\",\"from\":\"action1\",\"to\":\"terminal\"}"
+            + "]}";
+    CreateDomainPackDraftCommand command =
+        new CreateDomainPackDraftCommand(
+            1L,
+            7L,
+            10L,
+            null,
+            "{}",
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of(
+                new CreateDomainPackDraftCommand.WorkflowDraft(
+                    "refund_flow", "환불 플로우", null, policyRefNotFoundGraph, null, null, null, null)),
+            List.of());
+    assertThatThrownBy(() -> useCase.execute(command))
+        .isInstanceOf(WorkflowActionNodePolicyRefNotFoundException.class)
+        .hasMessageContaining("missing_policy");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  @DisplayName("graphJson V8c 통과 — ACTION 노드 policyRef가 제출된 policies policyCode와 일치하면 정상 저장")
+  void execute_v8c_policyRefMatchesSubmittedPolicy_savesSuccessfully() {
+    stubWorkspaceAndPack();
+    stubSaveAll();
+
+    useCase.execute(commandWithGraphJson(VALID_GRAPH_JSON));
+
+    org.mockito.ArgumentCaptor<Iterable<WorkflowDefinition>> captor =
+        org.mockito.ArgumentCaptor.forClass(Iterable.class);
+    verify(workflowDefinitionRepository).saveAll(captor.capture());
+    assertThat(captor.getValue().iterator().hasNext()).isTrue();
+  }
+
+  // ──────────────────────────────────────────────────────────────
   // initialState / terminalStatesJson 추출 검증 테스트
   // ──────────────────────────────────────────────────────────────
 
@@ -484,7 +583,9 @@ class CreateDomainPackDraftUseCaseTest {
         List.of(),
         List.of(),
         List.of(),
-        List.of(),
+        List.of(
+            new CreateDomainPackDraftCommand.PolicyDraft(
+                "handle_policy", "처리 정책", null, null, null, null, null, null)),
         List.of(),
         List.of(
             new CreateDomainPackDraftCommand.WorkflowDraft(
@@ -517,7 +618,9 @@ class CreateDomainPackDraftUseCaseTest {
         List.of(
             new CreateDomainPackDraftCommand.IntentSlotBindingDraft(
                 "refund_request", "order_id", true, 1, "주문번호를 알려주세요", null)),
-        List.of(),
+        List.of(
+            new CreateDomainPackDraftCommand.PolicyDraft(
+                "handle_policy", "처리 정책", null, null, null, null, null, null)),
         List.of(),
         List.of(
             new CreateDomainPackDraftCommand.WorkflowDraft(

--- a/backend/src/test/java/com/init/domainpack/presentation/CreateDomainPackDraftControllerTest.java
+++ b/backend/src/test/java/com/init/domainpack/presentation/CreateDomainPackDraftControllerTest.java
@@ -14,6 +14,9 @@ import com.init.domainpack.application.exception.DomainPackNotFoundException;
 import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
 import com.init.domainpack.application.exception.DomainPackVersionConflictException;
 import com.init.domainpack.application.exception.DomainPackWorkspaceNotFoundException;
+import com.init.domainpack.application.exception.WorkflowActionNodePolicyRefInvalidCharsException;
+import com.init.domainpack.application.exception.WorkflowActionNodePolicyRefMissingException;
+import com.init.domainpack.application.exception.WorkflowActionNodePolicyRefNotFoundException;
 import com.init.domainpack.application.exception.WorkflowCycleDetectedException;
 import com.init.domainpack.application.exception.WorkflowDanglingEdgeException;
 import com.init.domainpack.application.exception.WorkflowInvalidStartNodeException;
@@ -325,6 +328,57 @@ class CreateDomainPackDraftControllerTest {
                 .content(validRequestJson()))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.code").value("WORKFLOW_UNLABELED_BRANCH"));
+  }
+
+  @Test
+  @DisplayName("graphJson V8a 위반 (ACTION 노드 policyRef 누락) 이면 400을 반환한다")
+  @WithLongPrincipal(10L)
+  void createDraft_actionNodePolicyRefMissing_returns400() throws Exception {
+    given(useCase.execute(any()))
+        .willThrow(new WorkflowActionNodePolicyRefMissingException("refund_flow"));
+
+    mockMvc
+        .perform(
+            post(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(validRequestJson()))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("WORKFLOW_ACTION_NODE_POLICY_REF_MISSING"));
+  }
+
+  @Test
+  @DisplayName("graphJson V8b 위반 (ACTION 노드 policyRef 유효하지 않은 문자) 이면 400을 반환한다")
+  @WithLongPrincipal(10L)
+  void createDraft_actionNodePolicyRefInvalidChars_returns400() throws Exception {
+    given(useCase.execute(any()))
+        .willThrow(new WorkflowActionNodePolicyRefInvalidCharsException("refund_flow"));
+
+    mockMvc
+        .perform(
+            post(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(validRequestJson()))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("WORKFLOW_ACTION_NODE_POLICY_REF_INVALID_CHARS"));
+  }
+
+  @Test
+  @DisplayName("graphJson V8c 위반 (policyRef가 제출된 policies에 없음) 이면 400을 반환한다")
+  @WithLongPrincipal(10L)
+  void createDraft_actionNodePolicyRefNotFound_returns400() throws Exception {
+    given(useCase.execute(any()))
+        .willThrow(new WorkflowActionNodePolicyRefNotFoundException("missing_policy"));
+
+    mockMvc
+        .perform(
+            post(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(validRequestJson()))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("WORKFLOW_ACTION_NODE_POLICY_REF_NOT_FOUND"));
   }
 
   @Test


### PR DESCRIPTION
## Summary

`CreateDomainPackDraftUseCase` 초안 생성 경로에 V8c 인메모리 교차 검증을 추가했다. ACTION 노드의 `policyRef`가 동일 요청의 `policies` 목록에 없으면 `400 WORKFLOW_ACTION_NODE_POLICY_REF_NOT_FOUND`를 반환한다. 감사(audit) 과정에서 누락 Controller 테스트 3건과 테스트 메서드 네이밍 비준수를 함께 수정했다.

---

## Context

- Spec: `.agent/specs/99.md` (base: `.agent/specs/231.md`)
- V8a/V8b(`policyRef` 존재·형식 검증)는 issue #98에서 선행 완료. 이 PR은 V8c(cross-entity 존재 검증)만 담당.
- `UpdateWorkflowUseCase`의 동일 검증(DB 조회 기반)과 달리, 초안 생성 시점에는 version이 DB에 없으므로 인메모리 검증이어야 한다.

---

## What Changed

| 파일 | 변경 내용 |
|------|-----------|
| `DomainPackDraftPersistenceService.java` | `validateDraftPayload`에 `submittedPolicyCodes` Set 빌드 추가; `validateAndNormalizeWorkflow` 시그니처에 `Set<String> submittedPolicyCodes` 파라미터 추가; V8c 스트림 검증 로직 삽입 |
| `CreateDomainPackDraftUseCaseTest.java` | V8a/V8b/V8c Unit Test 4건 추가; 전체 21개 메서드명 `should_결과_when_조건` 패턴으로 통일 (audit V-003 수정) |
| `CreateDomainPackDraftControllerTest.java` | V8a/V8b/V8c Controller Test 3건 추가 (audit V-001/V-002 수정) |

**커밋 요약**:
1. `74ccc02` — V8c 검증 로직 구현
2. `611cd35` — V8a/V8b/V8c Controller 테스트 추가 (audit V-001/V-002 fix)
3. `6345f11` — 테스트 메서드 네이밍 리팩토링 (audit V-003 fix)

---

## Assumptions Adopted

| ID | 내용 | 영향 |
|----|------|------|
| U1 | policyRef 매핑 전략 Option B 확정 — `node.id`와 `policyRef`는 독립 관리. `submittedPolicyCodes`(제출된 policies의 policyCode Set)만 비교 기준. | BE 구현에서 `node.id == policyRef` 제약 없음 |
| U2 | `validateDraftPayload` 구현 위치 = `DomainPackDraftPersistenceService` | UseCase 직접 구현 아님. spec 231 Additional Notes 기준 |

---

## Spec Deviations

N/A — 모든 spec 섹션 일치 확인. (audit Spec Consistency 표 참조)

---

## Blocked / Skipped Items

- ML pipeline `draft-generation` 단계의 node-to-policy 매핑 자료구조 명시: 이 PR 범위 밖. 별도 ML spec 작성 시 처리.

---

## Test Notes

**Audit Result**: PASS (Critical 0, Warning 1, Info 2 — 전부 수정 완료)

| 항목 | 결과 |
|------|------|
| Unit Tests (V8a/V8b/V8c 포함, 총 21개) | 통과 |
| Controller Tests (V8a/V8b/V8c) | 통과 (audit 중 추가, 통과 확인) |
| 테스트 메서드 네이밍 리팩토링 후 전체 재실행 | 통과 |

**Audit 수정 내역**:
- V-001 [Warning] V8c Controller 테스트 누락 → Fixed (auto)
- V-002 [Info] V8a/V8b Controller 테스트 누락 (이번 PR 이전 발생) → V-001과 함께 Fixed (auto)
- V-003 [Info] 테스트 메서드 네이밍 비준수 → Fixed (approved by user)

---

## Reviewer Focus

1. `DomainPackDraftPersistenceService.validateDraftPayload` — `submittedPolicyCodes` Set 빌드 위치와 재사용 범위 (workflow 루프 외부에서 한 번만 생성)
2. `validateAndNormalizeWorkflow` — 시그니처 변경으로 기존 호출부 영향 없는지 확인
3. V8c 스트림 처리 — `filter(n -> "ACTION".equals(n.type())) → map(policyRef) → filter(!contains) → findFirst → ifPresent throw` fail-fast 패턴
4. Controller 테스트 3건 — V8a/V8b는 `WorkflowGraphValidator` 수준에서 throw, V8c는 `DomainPackDraftPersistenceService` 수준에서 throw하는 레이어 차이 주의

---

## Conflicts

없음. 모든 uncertainty Confirmed 상태이며 unresolved 항목 없음.

---

## Ready to Merge / Needs Input

**Ready to Merge** — 모든 audit 항목 수정 완료, 테스트 통과, spec 일치 확인.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 워크플로우 정의 검증이 강화되어 액션 노드의 정책 참조가 제출된 정책 목록에 존재하는지 확인합니다.
  * 누락되거나 유효하지 않은 정책 참조가 있을 경우 명확한 오류 메시지를 제공합니다.

* **테스트**
  * 워크플로우 액션 노드 정책 참조 검증 시나리오에 대한 테스트 케이스를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->