### PR TITLE
spec/100: policyCode rename/삭제 시 graphJson policyRef 역참조 무결성 처리

### DIFF
--- a/.agent/specs/100.md
+++ b/.agent/specs/100.md
@@ -107,7 +107,7 @@ public class PolicyCodeReferencedByWorkflowException extends BadRequestException
 
     public PolicyCodeReferencedByWorkflowException(String policyCode) {
         super("POLICY_CODE_REFERENCED_BY_WORKFLOW",
-              "해당 정책 코드를 참조하는 워크플로우가 존재하여 비활성화할 수 없습니다. policyCode=" + policyCode);
+              "해당 정책 코드를 참조하는 워크플로우가 존재하여 비활성화할 수 없습니다.");
     }
 }
 ```
@@ -122,6 +122,7 @@ boolean existsByDomainPackVersionIdAndPolicyRef(Long versionId, String policyCod
 ### JPA 구현 — JSONB 역참조 쿼리
 
 graphJson 구조:
+
 ```json
 {
   "nodes": [

--- a/.agent/specs/100.md
+++ b/.agent/specs/100.md
@@ -1,0 +1,264 @@
+# [BE] policyCode INACTIVE 전환 시 graphJson policyRef 역참조 무결성 처리
+
+> Issue: #100
+> Branch: `spec/100`
+> Template: `_TEMPLATE_BE.md`
+> Scope: `UpdatePolicyStatusUseCase` — INACTIVE 전환 시 graphJson 역참조 체크 추가
+
+---
+
+## Goal
+
+policy를 INACTIVE로 전환할 때, 같은 버전 내 workflow의 graphJson에 해당 policyCode가 `policyRef`로 참조되고 있으면 전환을 거부하여 stale policyRef 발생을 원천 차단한다.
+
+---
+
+## Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    actor c as Client
+    participant ctrl as UpdatePolicyStatusController
+    participant uc as UpdatePolicyStatusUseCase
+    participant wRepo as WorkflowDefinitionRepository
+    participant pRepo as PolicyDefinitionRepository
+    participant db as PostgreSQL
+
+    c ->> ctrl: PATCH /api/v1/workspaces/{wsId}/domain-packs/{packId}/versions/{vId}/policies/{pId}/status
+    ctrl ->> uc: execute(command)
+    uc ->> uc: validateWorkspaceAccess, validateDomainPack
+    uc ->> pRepo: findById(policyId)
+    pRepo ->> db: SELECT policy_definition
+    db ->> pRepo: PolicyDefinition
+    pRepo ->> uc: policy
+    uc ->> uc: INACTIVE 전환인가?
+    alt status == INACTIVE
+        uc ->> wRepo: existsByVersionIdAndPolicyRef(versionId, policyCode)
+        wRepo ->> db: SELECT EXISTS (JSONB 역참조 쿼리)
+        db ->> wRepo: true / false
+        alt 참조 있음
+            wRepo ->> uc: true
+            uc -->> ctrl: throw PolicyCodeReferencedByWorkflowException
+            ctrl -->> c: 400 Bad Request
+        end
+    end
+    uc ->> pRepo: save(policy.changeStatus(INACTIVE))
+    pRepo ->> db: UPDATE
+    db ->> pRepo: ok
+    uc ->> ctrl: PolicyDefinitionResponse
+    ctrl ->> c: 200 OK
+```
+
+---
+
+## REST API
+
+### Endpoint
+
+| Method | Path | Description |
+|--------|------|-------------|
+| PATCH | `/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/policies/{policyId}/status` | policy 상태 변경 |
+
+기존 엔드포인트 유지. 신규 에러 케이스만 추가.
+
+### Request
+
+```json
+{ "status": "INACTIVE" }
+```
+
+### Response
+
+**200 OK** — 기존과 동일 (`PolicyDefinitionResponse`)
+
+**400 Bad Request** — INACTIVE 전환 시 policyRef 참조 workflow 존재
+
+```json
+{
+  "code": "POLICY_CODE_REFERENCED_BY_WORKFLOW",
+  "message": "해당 정책 코드를 참조하는 워크플로우가 존재하여 비활성화할 수 없습니다."
+}
+```
+
+---
+
+## Class Design
+
+### 변경 대상 파일
+
+```
+application/
+  UpdatePolicyStatusUseCase.java        — INACTIVE 분기에 역참조 체크 추가
+  exception/
+    PolicyCodeReferencedByWorkflowException.java   — 신규
+
+domain/repository/
+  WorkflowDefinitionRepository.java    — existsByVersionIdAndPolicyRef 메서드 추가
+
+infrastructure/persistence/
+  JpaWorkflowDefinitionRepository.java — @Query(JSONB) 구현 추가
+```
+
+### 신규 예외
+
+```java
+// BadRequestException 계열 (HTTP 400)
+public class PolicyCodeReferencedByWorkflowException extends BadRequestException {
+
+    public PolicyCodeReferencedByWorkflowException(String policyCode) {
+        super("POLICY_CODE_REFERENCED_BY_WORKFLOW",
+              "해당 정책 코드를 참조하는 워크플로우가 존재하여 비활성화할 수 없습니다. policyCode=" + policyCode);
+    }
+}
+```
+
+### Repository 인터페이스 변경
+
+```java
+// WorkflowDefinitionRepository.java 에 추가
+boolean existsByDomainPackVersionIdAndPolicyRef(Long versionId, String policyCode);
+```
+
+### JPA 구현 — JSONB 역참조 쿼리
+
+graphJson 구조:
+```json
+{
+  "nodes": [
+    { "id": "n1", "type": "ACTION", "policyRef": "refund_check" },
+    ...
+  ]
+}
+```
+
+```java
+// JpaWorkflowDefinitionRepository.java 에 추가
+@Query(
+  value = """
+    SELECT CASE WHEN COUNT(*) > 0 THEN TRUE ELSE FALSE END
+    FROM pack.workflow_definition
+    WHERE domain_pack_version_id = :versionId
+      AND graph_json -> 'nodes' @> jsonb_build_array(jsonb_build_object('policyRef', :policyCode))
+    """,
+  nativeQuery = true)
+boolean existsByDomainPackVersionIdAndPolicyRef(
+    @Param("versionId") Long versionId,
+    @Param("policyCode") String policyCode);
+```
+
+### UseCase 변경 포인트
+
+```java
+// UpdatePolicyStatusUseCase.execute() 내 changeStatus 호출 직전에 삽입
+if (PolicyDefinition.STATUS_INACTIVE.equals(command.status())) {
+    String policyCode = policy.getPolicyCode();
+    if (workflowRepository.existsByDomainPackVersionIdAndPolicyRef(command.versionId(), policyCode)) {
+        throw new PolicyCodeReferencedByWorkflowException(policyCode);
+    }
+}
+```
+
+`UpdatePolicyStatusUseCase`에 `WorkflowDefinitionRepository` 생성자 주입 추가 필요.
+
+---
+
+## Tests
+
+### Unit Tests — `UpdatePolicyStatusUseCaseTest`
+
+기존 테스트에 아래 케이스 추가:
+
+```java
+@Test
+@DisplayName("INACTIVE 전환 시 policyRef 참조 workflow 존재 → PolicyCodeReferencedByWorkflowException")
+void should_역참조예외_when_INACTIVE전환시참조workflow존재() {
+    given(versionRepository.findById(10L)).willReturn(Optional.of(draftVersion(10L, 7L)));
+    PolicyDefinition policy = policy(55L, 10L);  // policyCode = "refund_check"
+    given(policyRepository.findById(55L)).willReturn(Optional.of(policy));
+    given(workflowRepository.existsByDomainPackVersionIdAndPolicyRef(10L, "refund_check"))
+        .willReturn(true);
+
+    assertThatThrownBy(() ->
+        useCase.execute(new UpdatePolicyStatusCommand(1L, 7L, 10L, 55L, 5L, PolicyDefinition.STATUS_INACTIVE)))
+        .isInstanceOf(PolicyCodeReferencedByWorkflowException.class);
+    verify(policyRepository, never()).save(any());
+}
+
+@Test
+@DisplayName("INACTIVE 전환 시 참조 workflow 없음 → 정상 전환")
+void should_INACTIVE전환성공_when_참조workflow없음() {
+    given(versionRepository.findById(10L)).willReturn(Optional.of(draftVersion(10L, 7L)));
+    PolicyDefinition policy = policy(55L, 10L);
+    given(policyRepository.findById(55L)).willReturn(Optional.of(policy));
+    given(workflowRepository.existsByDomainPackVersionIdAndPolicyRef(10L, "refund_check"))
+        .willReturn(false);
+    given(policyRepository.save(any())).willReturn(policy);
+
+    PolicyDefinitionResponse result =
+        useCase.execute(new UpdatePolicyStatusCommand(1L, 7L, 10L, 55L, 5L, PolicyDefinition.STATUS_INACTIVE));
+
+    assertThat(result.status()).isEqualTo(PolicyDefinition.STATUS_INACTIVE);
+}
+
+@Test
+@DisplayName("ACTIVE 전환 시 역참조 체크 스킵")
+void should_역참조체크스킵_when_ACTIVE전환() {
+    given(versionRepository.findById(10L)).willReturn(Optional.of(draftVersion(10L, 7L)));
+    PolicyDefinition policy = policy(55L, 10L);
+    ReflectionTestUtils.setField(policy, "status", PolicyDefinition.STATUS_INACTIVE);
+    given(policyRepository.findById(55L)).willReturn(Optional.of(policy));
+    given(policyRepository.save(any())).willReturn(policy);
+
+    useCase.execute(new UpdatePolicyStatusCommand(1L, 7L, 10L, 55L, 5L, PolicyDefinition.STATUS_ACTIVE));
+
+    verify(workflowRepository, never()).existsByDomainPackVersionIdAndPolicyRef(any(), any());
+}
+```
+
+### Integration Tests — `UpdatePolicyStatusControllerTest`
+
+기존 테스트 파일에 추가:
+
+```java
+@Test
+@DisplayName("INACTIVE 전환 시 policyRef 참조 workflow 존재 → 400")
+void updatePolicyStatus_inactiveWithReferencedWorkflow_returns400() throws Exception {
+    // given: workflow가 해당 policyCode를 policyRef로 참조하는 상태 세팅
+    // 구체적 픽스처는 기존 테스트 헬퍼 패턴 따름
+
+    mockMvc.perform(patch(".../{policyId}/status")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"status\": \"INACTIVE\"}"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("POLICY_CODE_REFERENCED_BY_WORKFLOW"));
+}
+```
+
+### Test Checklist
+
+- [x] INACTIVE 전환 시 참조 있음 → `PolicyCodeReferencedByWorkflowException` 발생, save 미호출
+- [x] INACTIVE 전환 시 참조 없음 → 정상 INACTIVE 전환
+- [x] ACTIVE 전환 시 역참조 체크 스킵
+- [ ] 통합 테스트: INACTIVE + 참조 있음 → 400 + 에러 코드 `POLICY_CODE_REFERENCED_BY_WORKFLOW`
+- [ ] 통합 테스트: INACTIVE + 참조 없음 → 200
+
+---
+
+## Database
+
+### Migration
+
+신규 DDL 없음. 기존 `pack.workflow_definition.graph_json` JSONB 컬럼을 PostgreSQL `@>` 연산자로 조회.
+
+### JSONB 쿼리 전제 조건
+
+`graph_json -> 'nodes'` 경로가 배열이고, 각 노드 객체에 `policyRef` 키가 존재함.
+spec 3215에서 확정된 graphJson 구조 기준.
+
+---
+
+## Additional Notes
+
+- policyCode rename은 현재 미지원 (policyCode immutable) → 이번 scope 외
+- `UpdatePolicyStatusUseCase`에 `WorkflowDefinitionRepository` 의존성 추가 시 생성자 주입 규칙 준수
+- GlobalExceptionHandler에 `PolicyCodeReferencedByWorkflowException` 핸들러 추가 필요 (BadRequestException 계열이면 기존 fallback으로 처리 가능하지만 명시적 핸들러 권장)


### PR DESCRIPTION
# [BE] policyCode INACTIVE 전환 시 graphJson policyRef 역참조 무결성 처리

> Issue: #100
> Branch: `spec/100`
> Template: `_TEMPLATE_BE.md`
> Scope: `UpdatePolicyStatusUseCase` — INACTIVE 전환 시 graphJson 역참조 체크 추가

---

## Goal

policy를 INACTIVE로 전환할 때, 같은 버전 내 workflow의 graphJson에 해당 policyCode가 `policyRef`로 참조되고 있으면 전환을 거부하여 stale policyRef 발생을 원천 차단한다.

---

## Sequence Diagram

```mermaid
sequenceDiagram
    actor c as Client
    participant ctrl as UpdatePolicyStatusController
    participant uc as UpdatePolicyStatusUseCase
    participant wRepo as WorkflowDefinitionRepository
    participant pRepo as PolicyDefinitionRepository
    participant db as PostgreSQL

    c ->> ctrl: PATCH /api/v1/workspaces/{wsId}/domain-packs/{packId}/versions/{vId}/policies/{pId}/status
    ctrl ->> uc: execute(command)
    uc ->> uc: validateWorkspaceAccess, validateDomainPack
    uc ->> pRepo: findById(policyId)
    pRepo ->> db: SELECT policy_definition
    db ->> pRepo: PolicyDefinition
    pRepo ->> uc: policy
    uc ->> uc: INACTIVE 전환인가?
    alt status == INACTIVE
        uc ->> wRepo: existsByVersionIdAndPolicyRef(versionId, policyCode)
        wRepo ->> db: SELECT EXISTS (JSONB 역참조 쿼리)
        db ->> wRepo: true / false
        alt 참조 있음
            wRepo ->> uc: true
            uc -->> ctrl: throw PolicyCodeReferencedByWorkflowException
            ctrl -->> c: 400 Bad Request
        end
    end
    uc ->> pRepo: save(policy.changeStatus(INACTIVE))
    pRepo ->> db: UPDATE
    db ->> pRepo: ok
    uc ->> ctrl: PolicyDefinitionResponse
    ctrl ->> c: 200 OK
```

---

## REST API

### Endpoint

| Method | Path | Description |
|--------|------|-------------|
| PATCH | `/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/policies/{policyId}/status` | policy 상태 변경 |

기존 엔드포인트 유지. 신규 에러 케이스만 추가.

### Request

```json
{ "status": "INACTIVE" }
```

### Response

**200 OK** — 기존과 동일 (`PolicyDefinitionResponse`)

**400 Bad Request** — INACTIVE 전환 시 policyRef 참조 workflow 존재

```json
{
  "code": "POLICY_CODE_REFERENCED_BY_WORKFLOW",
  "message": "해당 정책 코드를 참조하는 워크플로우가 존재하여 비활성화할 수 없습니다."
}
```

---

## Class Design

### 변경 대상 파일

```
application/
  UpdatePolicyStatusUseCase.java        — INACTIVE 분기에 역참조 체크 추가
  exception/
    PolicyCodeReferencedByWorkflowException.java   — 신규

domain/repository/
  WorkflowDefinitionRepository.java    — existsByVersionIdAndPolicyRef 메서드 추가

infrastructure/persistence/
  JpaWorkflowDefinitionRepository.java — @Query(JSONB) 구현 추가
```

### 신규 예외

```java
// BadRequestException 계열 (HTTP 400)
public class PolicyCodeReferencedByWorkflowException extends BadRequestException {

    public PolicyCodeReferencedByWorkflowException(String policyCode) {
        super("POLICY_CODE_REFERENCED_BY_WORKFLOW",
              "해당 정책 코드를 참조하는 워크플로우가 존재하여 비활성화할 수 없습니다. policyCode=" + policyCode);
    }
}
```

### Repository 인터페이스 변경

```java
// WorkflowDefinitionRepository.java 에 추가
boolean existsByDomainPackVersionIdAndPolicyRef(Long versionId, String policyCode);
```

### JPA 구현 — JSONB 역참조 쿼리

graphJson 구조:
```json
{
  "nodes": [
    { "id": "n1", "type": "ACTION", "policyRef": "refund_check" },
    ...
  ]
}
```

```java
// JpaWorkflowDefinitionRepository.java 에 추가
@Query(
  value = """
    SELECT CASE WHEN COUNT(*) > 0 THEN TRUE ELSE FALSE END
    FROM pack.workflow_definition
    WHERE domain_pack_version_id = :versionId
      AND graph_json -> 'nodes' @> jsonb_build_array(jsonb_build_object('policyRef', :policyCode))
    """,
  nativeQuery = true)
boolean existsByDomainPackVersionIdAndPolicyRef(
    @Param("versionId") Long versionId,
    @Param("policyCode") String policyCode);
```

### UseCase 변경 포인트

```java
// UpdatePolicyStatusUseCase.execute() 내 changeStatus 호출 직전에 삽입
if (PolicyDefinition.STATUS_INACTIVE.equals(command.status())) {
    String policyCode = policy.getPolicyCode();
    if (workflowRepository.existsByDomainPackVersionIdAndPolicyRef(command.versionId(), policyCode)) {
        throw new PolicyCodeReferencedByWorkflowException(policyCode);
    }
}
```

`UpdatePolicyStatusUseCase`에 `WorkflowDefinitionRepository` 생성자 주입 추가 필요.

---

## Tests

### Unit Tests — `UpdatePolicyStatusUseCaseTest`

기존 테스트에 아래 케이스 추가:

```java
@Test
@DisplayName("INACTIVE 전환 시 policyRef 참조 workflow 존재 → PolicyCodeReferencedByWorkflowException")
void should_역참조예외_when_INACTIVE전환시참조workflow존재() {
    given(versionRepository.findById(10L)).willReturn(Optional.of(draftVersion(10L, 7L)));
    PolicyDefinition policy = policy(55L, 10L);  // policyCode = "refund_check"
    given(policyRepository.findById(55L)).willReturn(Optional.of(policy));
    given(workflowRepository.existsByDomainPackVersionIdAndPolicyRef(10L, "refund_check"))
        .willReturn(true);

    assertThatThrownBy(() ->
        useCase.execute(new UpdatePolicyStatusCommand(1L, 7L, 10L, 55L, 5L, PolicyDefinition.STATUS_INACTIVE)))
        .isInstanceOf(PolicyCodeReferencedByWorkflowException.class);
    verify(policyRepository, never()).save(any());
}

@Test
@DisplayName("INACTIVE 전환 시 참조 workflow 없음 → 정상 전환")
void should_INACTIVE전환성공_when_참조workflow없음() {
    given(versionRepository.findById(10L)).willReturn(Optional.of(draftVersion(10L, 7L)));
    PolicyDefinition policy = policy(55L, 10L);
    given(policyRepository.findById(55L)).willReturn(Optional.of(policy));
    given(workflowRepository.existsByDomainPackVersionIdAndPolicyRef(10L, "refund_check"))
        .willReturn(false);
    given(policyRepository.save(any())).willReturn(policy);

    PolicyDefinitionResponse result =
        useCase.execute(new UpdatePolicyStatusCommand(1L, 7L, 10L, 55L, 5L, PolicyDefinition.STATUS_INACTIVE));

    assertThat(result.status()).isEqualTo(PolicyDefinition.STATUS_INACTIVE);
}

@Test
@DisplayName("ACTIVE 전환 시 역참조 체크 스킵")
void should_역참조체크스킵_when_ACTIVE전환() {
    given(versionRepository.findById(10L)).willReturn(Optional.of(draftVersion(10L, 7L)));
    PolicyDefinition policy = policy(55L, 10L);
    ReflectionTestUtils.setField(policy, "status", PolicyDefinition.STATUS_INACTIVE);
    given(policyRepository.findById(55L)).willReturn(Optional.of(policy));
    given(policyRepository.save(any())).willReturn(policy);

    useCase.execute(new UpdatePolicyStatusCommand(1L, 7L, 10L, 55L, 5L, PolicyDefinition.STATUS_ACTIVE));

    verify(workflowRepository, never()).existsByDomainPackVersionIdAndPolicyRef(any(), any());
}
```

### Integration Tests — `UpdatePolicyStatusControllerTest`

기존 테스트 파일에 추가:

```java
@Test
@DisplayName("INACTIVE 전환 시 policyRef 참조 workflow 존재 → 400")
void updatePolicyStatus_inactiveWithReferencedWorkflow_returns400() throws Exception {
    // given: workflow가 해당 policyCode를 policyRef로 참조하는 상태 세팅
    // 구체적 픽스처는 기존 테스트 헬퍼 패턴 따름

    mockMvc.perform(patch(".../{policyId}/status")
            .contentType(MediaType.APPLICATION_JSON)
            .content("{\"status\": \"INACTIVE\"}"))
        .andExpect(status().isBadRequest())
        .andExpect(jsonPath("$.code").value("POLICY_CODE_REFERENCED_BY_WORKFLOW"));
}
```

### Test Checklist

- [x] INACTIVE 전환 시 참조 있음 → `PolicyCodeReferencedByWorkflowException` 발생, save 미호출
- [x] INACTIVE 전환 시 참조 없음 → 정상 INACTIVE 전환
- [x] ACTIVE 전환 시 역참조 체크 스킵
- [ ] 통합 테스트: INACTIVE + 참조 있음 → 400 + 에러 코드 `POLICY_CODE_REFERENCED_BY_WORKFLOW`
- [ ] 통합 테스트: INACTIVE + 참조 없음 → 200

---

## Database

### Migration

신규 DDL 없음. 기존 `pack.workflow_definition.graph_json` JSONB 컬럼을 PostgreSQL `@>` 연산자로 조회.

### JSONB 쿼리 전제 조건

`graph_json -> 'nodes'` 경로가 배열이고, 각 노드 객체에 `policyRef` 키가 존재함.
spec 3215에서 확정된 graphJson 구조 기준.

---

## Additional Notes

- policyCode rename은 현재 미지원 (policyCode immutable) → 이번 scope 외
- `UpdatePolicyStatusUseCase`에 `WorkflowDefinitionRepository` 의존성 추가 시 생성자 주입 규칙 준수
- GlobalExceptionHandler에 `PolicyCodeReferencedByWorkflowException` 핸들러 추가 필요 (BadRequestException 계열이면 기존 fallback으로 처리 가능하지만 명시적 핸들러 권장)
---
# Uncertainty Register — Issue #100

> spec: policyCode INACTIVE 전환 시 graphJson policyRef 역참조 무결성 처리
> 작성: Decision Agent (spec/100 branch)

---

## U1 — 처리 방식 선택 (A/B/C)

- **ID**: U1
- **Issue**: 옵션 A(거부), B(소프트 경고), C(미처리) 중 무엇을 구현하는가
- **Status**: `Confirmed`
- **Resolution**: 사용자 결정 — **Option A (강한 무결성)**: INACTIVE 전환 거부
- **Affected Spec Section**: Sequence Diagram, REST API (400 에러), UseCase 변경 포인트
- **User Decision Required**: No (확정)

---

## U2 — policyCode rename 범위

- **ID**: U2
- **Issue**: policyCode rename 기능을 이번 이슈에서 함께 구현하는가
- **Status**: `Confirmed`
- **Resolution**: 사용자 결정 — **Out of scope**. 현재 policyCode는 immutable. rename은 별도 이슈에서 처리.
- **Affected Spec Section**: Goal, Additional Notes
- **User Decision Required**: No (확정)

---

## U3 — INACTIVE = 삭제 정의

- **ID**: U3
- **Issue**: `UpdatePolicyStatusUseCase`로 status → INACTIVE 전환이 역참조 처리 대상인가
- **Status**: `Confirmed`
- **Resolution**: Yes. INACTIVE 전환이 "삭제"에 해당하며 policyRef 역참조 체크 트리거.
- **Affected Spec Section**: Sequence Diagram, UseCase 변경 포인트
- **User Decision Required**: No (확정)

---

## U4 — JSONB 역참조 쿼리 granularity

- **ID**: U4
- **Issue**: JSONB 역참조 조회를 PostgreSQL 쿼리로 할 것인가 vs Java 파싱으로 할 것인가
- **Status**: `Confirmed`
- **Resolution**: 사용자 결정 — **PostgreSQL JSONB `@>` 연산자** 사용 (native query)
- **Affected Spec Section**: JPA 구현, Database
- **User Decision Required**: No (확정)

---

## U5 — GlobalExceptionHandler 핸들러 추가 필요 여부

- **ID**: U5
- **Issue**: `PolicyCodeReferencedByWorkflowException`이 `BadRequestException`을 상속하면 기존 fallback 핸들러로 처리 가능하지만 명시적 핸들러를 추가할지 여부
- **Status**: `Assumption`
- **Why unresolved**: 기존 GlobalExceptionHandler 패턴을 보면 구체 예외마다 핸들러를 두는 경향이 있으나, BadRequestException fallback으로 처리될 수도 있음
- **Options**:
  - A) 명시적 `@ExceptionHandler(PolicyCodeReferencedByWorkflowException.class)` 추가
  - B) `BadRequestException` fallback에 위임 (에러 코드는 exception 생성자에서 설정)
- **Recommended Default**: A (명시적 핸들러) — 에러 코드 가시성과 일관성
- **Why recommended**: 기존 패턴(EmailAlreadyExistsException 등) 과 일관성 유지
- **User Decision Required**: No
- **Execution Rule**:
  - Implementation Agent MAY: `BadRequestException` fallback으로만 처리 (`Assumption adopted from Recommended Default`)
  - Implementation Agent MUST track: 명시적 핸들러 없이 처리 시 에러 코드가 응답에 올바르게 전달되는지 테스트 필수
- **Affected Spec Section**: Additional Notes

---

## U6 — policyRef가 없는 graphJson (spec 3215 이전 데이터)

- **ID**: U6
- **Issue**: spec 3215 이전에 저장된 workflow graphJson에는 ACTION 노드에 `policyRef`가 없을 수 있음. 이 경우 JSONB 쿼리 결과는 false (역참조 없음)로 처리됨.
- **Status**: `Assumption`
- **Why unresolved**: 레거시 데이터의 존재 여부와 처리 방침 확인 안 됨
- **Options**:
  - A) JSONB `@>` 연산자 특성상 키 없는 노드는 매칭 안 됨 → 자동으로 false 처리 (별도 처리 불필요)
  - B) 레거시 데이터에 `policyRef: null` 명시 필요
- **Recommended Default**: A (쿼리 의미상 자동 처리)
- **Why recommended**: PostgreSQL `@>` 연산자는 지정한 key-value를 포함하는 객체만 매칭하므로 policyRef 없는 노드는 자연스럽게 제외됨
- **User Decision Required**: No
- **Execution Rule**:
  - Implementation Agent MUST: 통합 테스트에서 policyRef 없는 workflow가 있어도 INACTIVE 전환이 허용되는지 확인
- **Affected Spec Section**: Database (JSONB 쿼리 전제 조건) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 정책 상태를 비활성(INACTIVE)으로 변경할 때 워크플로우 정의 내 참조 여부를 검증하여, 참조 중인 경우 변경을 거부하고 오류(HTTP 400, POLICY_CODE_REFERENCED_BY_WORKFLOW)를 반환하도록 명세화
  * ACTIVE 등 비-비활성 전환인 경우 검증을 건너뜀

* **테스트**
  * 예외 발생, 저장 미실행, 컨트롤러 응답 코드/페이로드 등 유닛/통합 테스트 시나리오가 추가됨
<!-- end of auto-generated comment: release notes by coderabbit.ai -->