### PR TITLE
feat(frontend): implement login to workspace entry flow

### DIFF
--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { LoginPage } from '../pages/login/ui/LoginPage';
 import { SignupPage } from '../pages/signup/ui/SignupPage';
 import { UploadPage } from '../pages/upload/ui/UploadPage';
+import { WorkspaceListPage } from '../pages/workspace-list/ui/WorkspaceListPage';
 import { PasswordResetInitPage } from '../pages/password-reset/ui/PasswordResetInitPage';
 import { PasswordResetCompletePage } from '../pages/password-reset/ui/PasswordResetCompletePage';
 import { ConsultationPage } from '../pages/consultation/ui/ConsultationPage';
@@ -14,11 +15,12 @@ export function App() {
   return (
     <BrowserRouter>
       <Routes>
-        <Route path="/" element={<Navigate to="/login" replace />} />
+        <Route path="/" element={<Navigate to="/workspaces" replace />} />
         <Route path="/login" element={<LoginPage />} />
         <Route path="/signup" element={<SignupPage />} />
         <Route path="/reset-password" element={<PasswordResetInitPage />} />
         <Route path="/reset-password/complete" element={<PasswordResetCompletePage />} />
+        <Route path="/workspaces" element={<PrivateRoute><WorkspaceListPage /></PrivateRoute>} />
         <Route path="/upload" element={<PrivateRoute><UploadPage /></PrivateRoute>} />
         <Route path="/consultation" element={<PrivateRoute><ConsultationPage /></PrivateRoute>} />
         <Route path="/workspaces/:workspaceId/domain-packs/:packId/versions/:versionId/intents/:intentId?" element={<PrivateRoute><IntentDraftReadPage /></PrivateRoute>} />

--- a/frontend/src/app/index.css
+++ b/frontend/src/app/index.css
@@ -14,6 +14,14 @@
 }
 
 :root {
+  --font-sans: 'Pretendard Variable', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-mono: 'Geist Mono', monospace;
+  --font-size-label: 12px;
+  --font-size-heading-lg: 40px;
+  --font-size-body-lg: 18px;
+  --font-weight-body: 330;
+  --font-weight-base: 340;
+  --font-weight-heading: 540;
   --bg-color: #ffffff;
   --bg-secondary: rgba(0, 0, 0, 0.02);
   --text-primary: #000000;
@@ -53,8 +61,8 @@
 }
 
 body {
-  font-family: 'Pretendard Variable', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  font-weight: 340;
+  font-family: var(--font-sans);
+  font-weight: var(--font-weight-base);
   font-feature-settings: "kern";
   letter-spacing: -0.14px;
   background-color: var(--bg-color);

--- a/frontend/src/app/index.css
+++ b/frontend/src/app/index.css
@@ -14,7 +14,7 @@
 }
 
 :root {
-  --font-sans: 'Pretendard Variable', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-sans: 'pretendard variable', -apple-system, blinkmacsystemfont, 'Segoe UI', sans-serif;
   --font-mono: 'Geist Mono', monospace;
   --font-size-label: 12px;
   --font-size-heading-lg: 40px;

--- a/frontend/src/features/auth/model/resolvePostLoginDestination.test.ts
+++ b/frontend/src/features/auth/model/resolvePostLoginDestination.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { resolvePostLoginDestination } from './resolvePostLoginDestination';
+
+describe('resolvePostLoginDestination', () => {
+  it('allows /workspaces paths', () => {
+    expect(
+      resolvePostLoginDestination({
+        from: { pathname: '/workspaces/1/upload', search: '?tab=logs' },
+      }),
+    ).toBe('/workspaces/1/upload?tab=logs');
+  });
+
+  it('falls back for auth routes', () => {
+    expect(resolvePostLoginDestination({ from: { pathname: '/login' } })).toBe(
+      '/workspaces',
+    );
+    expect(resolvePostLoginDestination({ from: { pathname: '/signup' } })).toBe(
+      '/workspaces',
+    );
+  });
+
+  it('falls back for paths outside the workspace route boundary', () => {
+    expect(
+      resolvePostLoginDestination({ from: { pathname: '/workspaces-public' } }),
+    ).toBe('/workspaces');
+  });
+
+  it('falls back for external URLs', () => {
+    expect(
+      resolvePostLoginDestination({
+        from: { pathname: 'https://example.com/workspaces' },
+      }),
+    ).toBe('/workspaces');
+    expect(
+      resolvePostLoginDestination({
+        from: { pathname: '//example.com/workspaces' },
+      }),
+    ).toBe('/workspaces');
+  });
+
+  it('falls back when pathname is missing', () => {
+    expect(resolvePostLoginDestination(undefined)).toBe('/workspaces');
+    expect(resolvePostLoginDestination({ from: {} })).toBe('/workspaces');
+  });
+
+  it('ignores malformed search values', () => {
+    expect(
+      resolvePostLoginDestination({
+        from: { pathname: '/workspaces/1', search: 'next=/login' },
+      }),
+    ).toBe('/workspaces/1');
+  });
+});

--- a/frontend/src/features/auth/model/resolvePostLoginDestination.test.ts
+++ b/frontend/src/features/auth/model/resolvePostLoginDestination.test.ts
@@ -5,6 +5,11 @@ describe('resolvePostLoginDestination', () => {
   it('allows /workspaces paths', () => {
     expect(
       resolvePostLoginDestination({
+        from: { pathname: '/workspaces', search: '?tab=logs' },
+      }),
+    ).toBe('/workspaces?tab=logs');
+    expect(
+      resolvePostLoginDestination({
         from: { pathname: '/workspaces/1/upload', search: '?tab=logs' },
       }),
     ).toBe('/workspaces/1/upload?tab=logs');
@@ -22,6 +27,17 @@ describe('resolvePostLoginDestination', () => {
   it('falls back for paths outside the workspace route boundary', () => {
     expect(
       resolvePostLoginDestination({ from: { pathname: '/workspaces-public' } }),
+    ).toBe('/workspaces');
+  });
+
+  it('falls back for dot-segment workspace paths', () => {
+    expect(
+      resolvePostLoginDestination({ from: { pathname: '/workspaces/../login' } }),
+    ).toBe('/workspaces');
+    expect(
+      resolvePostLoginDestination({
+        from: { pathname: '/workspaces/%2e%2e/login' },
+      }),
     ).toBe('/workspaces');
   });
 

--- a/frontend/src/features/auth/model/resolvePostLoginDestination.ts
+++ b/frontend/src/features/auth/model/resolvePostLoginDestination.ts
@@ -34,6 +34,17 @@ function isAllowedPath(pathname: string): boolean {
   );
 }
 
+function hasDotSegment(pathname: string): boolean {
+  return pathname.split('/').some((segment) => {
+    try {
+      const decoded = decodeURIComponent(segment);
+      return decoded === '.' || decoded === '..';
+    } catch {
+      return true;
+    }
+  });
+}
+
 function extractSearch(location: ReturnLocation): string {
   if (typeof location.search !== 'string') {
     return '';
@@ -47,6 +58,10 @@ export function resolvePostLoginDestination(state: unknown): string {
   const pathname = location?.pathname;
 
   if (typeof pathname !== 'string' || !pathname || isExternalUrl(pathname)) {
+    return DEFAULT_POST_LOGIN_PATH;
+  }
+
+  if (hasDotSegment(pathname)) {
     return DEFAULT_POST_LOGIN_PATH;
   }
 

--- a/frontend/src/features/auth/model/resolvePostLoginDestination.ts
+++ b/frontend/src/features/auth/model/resolvePostLoginDestination.ts
@@ -1,0 +1,58 @@
+const DEFAULT_POST_LOGIN_PATH = '/workspaces';
+const ALLOWED_RETURN_PREFIXES = ['/workspaces'];
+
+interface ReturnLocation {
+  pathname?: unknown;
+  search?: unknown;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function extractReturnLocation(state: unknown): ReturnLocation | null {
+  if (!isRecord(state)) {
+    return null;
+  }
+
+  const from = state.from;
+
+  if (!isRecord(from)) {
+    return null;
+  }
+
+  return from;
+}
+
+function isExternalUrl(pathname: string): boolean {
+  return /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(pathname) || pathname.startsWith('//');
+}
+
+function isAllowedPath(pathname: string): boolean {
+  return ALLOWED_RETURN_PREFIXES.some(
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+  );
+}
+
+function extractSearch(location: ReturnLocation): string {
+  if (typeof location.search !== 'string') {
+    return '';
+  }
+
+  return location.search.startsWith('?') ? location.search : '';
+}
+
+export function resolvePostLoginDestination(state: unknown): string {
+  const location = extractReturnLocation(state);
+  const pathname = location?.pathname;
+
+  if (typeof pathname !== 'string' || !pathname || isExternalUrl(pathname)) {
+    return DEFAULT_POST_LOGIN_PATH;
+  }
+
+  if (!isAllowedPath(pathname)) {
+    return DEFAULT_POST_LOGIN_PATH;
+  }
+
+  return `${pathname}${extractSearch(location)}`;
+}

--- a/frontend/src/features/auth/ui/login-form/LoginForm.tsx
+++ b/frontend/src/features/auth/ui/login-form/LoginForm.tsx
@@ -1,9 +1,10 @@
 import React, { useState } from 'react';
 import { Mail, Lock } from 'lucide-react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { Input } from '../../../../shared/ui/input/Input';
 import { Button } from '../../../../shared/ui/button/Button';
 import { loginApi } from '../../api/authApi';
+import { resolvePostLoginDestination } from '../../model/resolvePostLoginDestination';
 import { saveAuthSession } from '../../../../shared/lib/auth';
 import { ApiRequestError } from '../../../../shared/api';
 import styles from './login-form.module.css';
@@ -16,6 +17,7 @@ import styles from './login-form.module.css';
  */
 export const LoginForm: React.FC = () => {
   const navigate = useNavigate();
+  const location = useLocation();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [isLoading, setIsLoading] = useState(false);
@@ -50,7 +52,7 @@ export const LoginForm: React.FC = () => {
         result.user,
       );
 
-      navigate('/upload');
+      navigate(resolvePostLoginDestination(location.state), { replace: true });
     } catch (err) {
       if (err instanceof ApiRequestError) {
         if (err.code === 'INVALID_CREDENTIALS') {
@@ -99,10 +101,6 @@ export const LoginForm: React.FC = () => {
       </div>
 
       <div className={styles.options}>
-        <label className={styles.checkboxLabel}>
-          <input type="checkbox" className={styles.checkbox} />
-          <span>아이디 저장</span>
-        </label>
         <Link to="/reset-password" className={styles.forgotLink}>
           비밀번호 찾기
         </Link>

--- a/frontend/src/features/auth/ui/login-form/login-form.module.css
+++ b/frontend/src/features/auth/ui/login-form/login-form.module.css
@@ -32,30 +32,10 @@
 
 .options {
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-end;
   align-items: center;
   font-size: 0.875rem;
   letter-spacing: -0.1px;
-}
-
-.checkboxLabel {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  color: var(--text-secondary);
-  cursor: pointer;
-  transition: color var(--transition-fast);
-}
-
-.checkboxLabel:hover {
-  color: var(--text-primary);
-}
-
-.checkbox {
-  accent-color: var(--brand-primary);
-  width: 16px;
-  height: 16px;
-  cursor: pointer;
 }
 
 .forgotLink {

--- a/frontend/src/pages/login/ui/LoginPage.tsx
+++ b/frontend/src/pages/login/ui/LoginPage.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
+import { Navigate } from 'react-router-dom';
 import { AuthLayout } from '../../../shared/ui/layout/AuthLayout';
 import { LoginForm } from '../../../features/auth/ui/login-form/LoginForm';
+import { isAuthenticated } from '../../../shared/lib/auth';
 
 /**
  * 운영자 로그인 화면을 구성하는 페이지 컴포넌트입니다.
@@ -9,6 +11,10 @@ import { LoginForm } from '../../../features/auth/ui/login-form/LoginForm';
  * @returns {JSX.Element} 로그인 페이지
  */
 export const LoginPage: React.FC = () => {
+  if (isAuthenticated()) {
+    return <Navigate to="/workspaces" replace />;
+  }
+
   return (
     <AuthLayout>
       <LoginForm />

--- a/frontend/src/pages/workspace-list/ui/WorkspaceListPage.tsx
+++ b/frontend/src/pages/workspace-list/ui/WorkspaceListPage.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { DashboardLayout } from '../../../shared/ui/layout/DashboardLayout';
+import styles from './workspace-list-page.module.css';
+
+export const WorkspaceListPage: React.FC = () => {
+  return (
+    <DashboardLayout>
+      <section className={styles.container} aria-labelledby="workspace-list-title">
+        <p className={styles.label}>Workspace</p>
+        <h1 id="workspace-list-title" className={styles.title}>
+          워크스페이스
+        </h1>
+        <p className={styles.description}>
+          로그인 이후 기본 진입점입니다. 워크스페이스 목록과 선택 흐름은 별도 작업에서 연결됩니다.
+        </p>
+      </section>
+    </DashboardLayout>
+  );
+};

--- a/frontend/src/pages/workspace-list/ui/workspace-list-page.module.css
+++ b/frontend/src/pages/workspace-list/ui/workspace-list-page.module.css
@@ -1,0 +1,31 @@
+.container {
+  max-width: 720px;
+}
+
+.label {
+  margin: 0 0 12px;
+  color: #000000;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 12px;
+  letter-spacing: 0.6px;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.title {
+  margin: 0;
+  color: #000000;
+  font-size: 40px;
+  font-weight: 540;
+  letter-spacing: -0.26px;
+  line-height: 1.1;
+}
+
+.description {
+  margin: 16px 0 0;
+  color: #000000;
+  font-size: 18px;
+  font-weight: 330;
+  letter-spacing: -0.14px;
+  line-height: 1.45;
+}

--- a/frontend/src/pages/workspace-list/ui/workspace-list-page.module.css
+++ b/frontend/src/pages/workspace-list/ui/workspace-list-page.module.css
@@ -4,9 +4,9 @@
 
 .label {
   margin: 0 0 12px;
-  color: #000000;
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
-  font-size: 12px;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-label);
   letter-spacing: 0.6px;
   line-height: 1;
   text-transform: uppercase;
@@ -14,18 +14,18 @@
 
 .title {
   margin: 0;
-  color: #000000;
-  font-size: 40px;
-  font-weight: 540;
+  color: var(--text-primary);
+  font-size: var(--font-size-heading-lg);
+  font-weight: var(--font-weight-heading);
   letter-spacing: -0.26px;
   line-height: 1.1;
 }
 
 .description {
   margin: 16px 0 0;
-  color: #000000;
-  font-size: 18px;
-  font-weight: 330;
+  color: var(--text-secondary);
+  font-size: var(--font-size-body-lg);
+  font-weight: var(--font-weight-body);
   letter-spacing: -0.14px;
   line-height: 1.45;
 }

--- a/frontend/src/shared/lib/auth.test.ts
+++ b/frontend/src/shared/lib/auth.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+import { clearAuthSession, isAuthenticated } from './auth';
+
+function createToken(payload: Record<string, unknown>): string {
+  return ['header', btoa(JSON.stringify(payload)), 'signature'].join('.');
+}
+
+describe('isAuthenticated', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    clearAuthSession();
+  });
+
+  it('returns true only when access token has a future numeric exp', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-23T00:00:00Z'));
+    localStorage.setItem('accessToken', createToken({ exp: Date.now() / 1000 + 60 }));
+
+    expect(isAuthenticated()).toBe(true);
+  });
+
+  it('returns false when exp is missing or invalid', () => {
+    localStorage.setItem('accessToken', createToken({}));
+    expect(isAuthenticated()).toBe(false);
+
+    localStorage.setItem('accessToken', createToken({ exp: '9999999999' }));
+    expect(isAuthenticated()).toBe(false);
+  });
+
+  it('returns false when token is expired or malformed', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-23T00:00:00Z'));
+    localStorage.setItem('accessToken', createToken({ exp: Date.now() / 1000 - 60 }));
+    expect(isAuthenticated()).toBe(false);
+
+    localStorage.setItem('accessToken', 'not-a-jwt');
+    expect(isAuthenticated()).toBe(false);
+  });
+});

--- a/frontend/src/shared/lib/auth.test.ts
+++ b/frontend/src/shared/lib/auth.test.ts
@@ -1,8 +1,12 @@
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 import { clearAuthSession, isAuthenticated } from './auth';
 
+function toBase64Url(value: string): string {
+  return btoa(value).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
 function createToken(payload: Record<string, unknown>): string {
-  return ['header', btoa(JSON.stringify(payload)), 'signature'].join('.');
+  return ['header', toBase64Url(JSON.stringify(payload)), 'signature'].join('.');
 }
 
 describe('isAuthenticated', () => {

--- a/frontend/src/shared/lib/auth.ts
+++ b/frontend/src/shared/lib/auth.ts
@@ -51,16 +51,11 @@ export function isAuthenticated(): boolean {
   if (!token) return false;
 
   try {
-    // Decode JWT payload (base64)
     const payload = JSON.parse(atob(token.split('.')[1]));
     const exp = payload.exp;
 
-    if (!exp) return true; // No expiry claim, assume valid
-
-    // Check if token is expired (exp is in seconds, Date.now() is in ms)
-    return exp * 1000 > Date.now();
-  } catch (err) {
-    // If token parsing fails, consider it invalid
+    return typeof exp === 'number' && exp > Date.now() / 1000;
+  } catch {
     return false;
   }
 }

--- a/frontend/src/shared/lib/auth.ts
+++ b/frontend/src/shared/lib/auth.ts
@@ -46,12 +46,19 @@ export function getAuthUser(): AuthUser | null {
   }
 }
 
+function normalizeBase64Url(value: string): string {
+  const base64 = value.replace(/-/g, '+').replace(/_/g, '/');
+  const paddingLength = (4 - (base64.length % 4)) % 4;
+
+  return `${base64}${'='.repeat(paddingLength)}`;
+}
+
 export function isAuthenticated(): boolean {
   const token = getAccessToken();
   if (!token) return false;
 
   try {
-    const payload = JSON.parse(atob(token.split('.')[1]));
+    const payload = JSON.parse(atob(normalizeBase64Url(token.split('.')[1] ?? '')));
     const exp = payload.exp;
 
     return typeof exp === 'number' && exp > Date.now() / 1000;

--- a/frontend/src/shared/ui/PrivateRoute.tsx
+++ b/frontend/src/shared/ui/PrivateRoute.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
-import { getAuthUser } from '../lib/auth';
+import { clearAuthSession, isAuthenticated } from '../lib/auth';
 
 interface PrivateRouteProps {
   children: React.ReactNode;
@@ -11,11 +11,10 @@ interface PrivateRouteProps {
  * 인증되지 않은 사용자는 로그인 페이지로 리다이렉트됩니다.
  */
 export const PrivateRoute: React.FC<PrivateRouteProps> = ({ children }) => {
-  const user = getAuthUser();
   const location = useLocation();
 
-  if (!user) {
-    // 현재 위치를 state에 저장하여 로그인 후 다시 돌아올 수 있게 함
+  if (!isAuthenticated()) {
+    clearAuthSession();
     return <Navigate to="/login" state={{ from: location }} replace />;
   }
 


### PR DESCRIPTION
## 요약

로그인 이후 운영 콘솔의 기본 진입점을 `/workspaces`로 정렬하고, private route에서 로그인으로 이동한 사용자가 로그인 성공 후 안전한 workspace 하위 경로로만 복귀하도록 정리했습니다.

## 변경사항

- `/` route를 `/workspaces`로 redirect하도록 변경했습니다.
- `/workspaces` route를 `PrivateRoute`로 보호했습니다.
- 인증된 사용자가 `/login`에 접근하면 `/workspaces`로 replace 이동하도록 했습니다.
- 로그인 성공 후 hardcoded `/upload` 이동을 제거했습니다.
- `state.from` 기반 post-login destination을 처리하도록 했습니다.
- 로그인 후 복귀 경로는 `/workspaces` 및 그 하위 경로만 허용하도록 제한했습니다.
- external URL, auth route, pathname 누락, allowlist 밖 경로는 `/workspaces`로 fallback하도록 했습니다.
- `PrivateRoute`의 인증 판단 기준을 저장된 user JSON에서 access token 유효성으로 변경했습니다.
- 비인증 또는 유효하지 않은 session이면 session을 정리하고 `/login`으로 redirect하며 현재 location을 `state.from`에 저장하도록 했습니다.
- workspace 목록 구현 전에도 `/workspaces` route가 깨지지 않도록 최소 placeholder를 추가했습니다.
- 실제 저장 로직이 없는 `아이디 저장` checkbox를 제거했습니다.
- safe return destination helper 테스트를 추가했습니다.

## 범위

이 PR은 login/auth routing 연결만 다룹니다.

포함하지 않습니다:
- workspace 목록 조회
- workspace 선택 flow
- `/workspaces/:workspaceId` 및 `/workspaces/:workspaceId/workflows` 구현
- upload / consultation 화면 구조 개편
- backend auth API contract 변경

## 검증

통과:
- `cd frontend && pnpm test`
- `cd frontend && pnpm build`
- pre-commit hook: `pnpm run lint`
- pre-commit hook: `pnpm run format`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 로그인 후 워크스페이스 목록 페이지로 동적 라우팅 추가
* 새로운 워크스페이스 관리 페이지 추가

## 버그 수정
* JWT 인증 검증 강화 (만료 시간 기반 정확도 개선)

## UI/UX 개선
* 로그인 폼에서 아이디 저장 체크박스 제거
* 앱 기본 경로를 워크스페이스로 변경
* 로그인 폼 레이아웃 최적화

## 스타일
* 타이포그래피 CSS 변수 시스템 도입
* 워크스페이스 페이지 스타일링 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->