### PR TITLE
fix(domain-pack): reject INACTIVE transition when graphJson policyRef references exist (#100)

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -35,7 +35,6 @@ dependencies {
     testImplementation("com.h2database:h2")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.security:spring-security-test")
-    testImplementation("org.springframework.boot:spring-boot-testcontainers")
     testImplementation("org.testcontainers:junit-jupiter")
     testImplementation("org.testcontainers:postgresql")
 }

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -35,6 +35,9 @@ dependencies {
     testImplementation("com.h2database:h2")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.security:spring-security-test")
+    testImplementation("org.springframework.boot:spring-boot-testcontainers")
+    testImplementation("org.testcontainers:junit-jupiter")
+    testImplementation("org.testcontainers:postgresql")
 }
 
 tasks.withType<Test> {

--- a/backend/src/main/java/com/init/domainpack/application/UpdatePolicyStatusUseCase.java
+++ b/backend/src/main/java/com/init/domainpack/application/UpdatePolicyStatusUseCase.java
@@ -62,7 +62,8 @@ public class UpdatePolicyStatusUseCase {
 
     if (PolicyDefinition.STATUS_INACTIVE.equals(command.status())) {
       String policyCode = policy.getPolicyCode();
-      if (workflowRepository.existsByDomainPackVersionIdAndPolicyRef(command.versionId(), policyCode)) {
+      if (workflowRepository.existsByDomainPackVersionIdAndPolicyRef(
+          command.versionId(), policyCode)) {
         throw new PolicyCodeReferencedByWorkflowException(policyCode);
       }
     }

--- a/backend/src/main/java/com/init/domainpack/application/UpdatePolicyStatusUseCase.java
+++ b/backend/src/main/java/com/init/domainpack/application/UpdatePolicyStatusUseCase.java
@@ -60,7 +60,8 @@ public class UpdatePolicyStatusUseCase {
       throw new NotFoundException("NOT_FOUND", "정책을 찾을 수 없습니다: " + command.policyId());
     }
 
-    if (PolicyDefinition.STATUS_INACTIVE.equals(command.status())) {
+    if (PolicyDefinition.STATUS_INACTIVE.equals(command.status())
+        && PolicyDefinition.STATUS_ACTIVE.equals(policy.getStatus())) {
       String policyCode = policy.getPolicyCode();
       if (workflowRepository.existsByDomainPackVersionIdAndPolicyRef(
           command.versionId(), policyCode)) {

--- a/backend/src/main/java/com/init/domainpack/application/UpdatePolicyStatusUseCase.java
+++ b/backend/src/main/java/com/init/domainpack/application/UpdatePolicyStatusUseCase.java
@@ -1,9 +1,11 @@
 package com.init.domainpack.application;
 
+import com.init.domainpack.application.exception.PolicyCodeReferencedByWorkflowException;
 import com.init.domainpack.domain.model.DomainPackVersion;
 import com.init.domainpack.domain.model.PolicyDefinition;
 import com.init.domainpack.domain.repository.DomainPackVersionRepository;
 import com.init.domainpack.domain.repository.PolicyDefinitionRepository;
+import com.init.domainpack.domain.repository.WorkflowDefinitionRepository;
 import com.init.shared.application.exception.BadRequestException;
 import com.init.shared.application.exception.NotFoundException;
 import org.springframework.stereotype.Service;
@@ -16,14 +18,17 @@ public class UpdatePolicyStatusUseCase {
   private final DomainPackValidator validator;
   private final PolicyDefinitionRepository policyRepository;
   private final DomainPackVersionRepository versionRepository;
+  private final WorkflowDefinitionRepository workflowRepository;
 
   public UpdatePolicyStatusUseCase(
       DomainPackValidator validator,
       PolicyDefinitionRepository policyRepository,
-      DomainPackVersionRepository versionRepository) {
+      DomainPackVersionRepository versionRepository,
+      WorkflowDefinitionRepository workflowRepository) {
     this.validator = validator;
     this.policyRepository = policyRepository;
     this.versionRepository = versionRepository;
+    this.workflowRepository = workflowRepository;
   }
 
   @Transactional
@@ -53,6 +58,13 @@ public class UpdatePolicyStatusUseCase {
 
     if (!policy.getDomainPackVersionId().equals(command.versionId())) {
       throw new NotFoundException("NOT_FOUND", "정책을 찾을 수 없습니다: " + command.policyId());
+    }
+
+    if (PolicyDefinition.STATUS_INACTIVE.equals(command.status())) {
+      String policyCode = policy.getPolicyCode();
+      if (workflowRepository.existsByDomainPackVersionIdAndPolicyRef(command.versionId(), policyCode)) {
+        throw new PolicyCodeReferencedByWorkflowException(policyCode);
+      }
     }
 
     try {

--- a/backend/src/main/java/com/init/domainpack/application/exception/PolicyCodeReferencedByWorkflowException.java
+++ b/backend/src/main/java/com/init/domainpack/application/exception/PolicyCodeReferencedByWorkflowException.java
@@ -1,0 +1,12 @@
+package com.init.domainpack.application.exception;
+
+import com.init.shared.application.exception.BadRequestException;
+
+public class PolicyCodeReferencedByWorkflowException extends BadRequestException {
+
+  public PolicyCodeReferencedByWorkflowException(String policyCode) {
+    super(
+        "POLICY_CODE_REFERENCED_BY_WORKFLOW",
+        "해당 정책 코드를 참조하는 워크플로우가 존재하여 비활성화할 수 없습니다.");
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/application/exception/PolicyCodeReferencedByWorkflowException.java
+++ b/backend/src/main/java/com/init/domainpack/application/exception/PolicyCodeReferencedByWorkflowException.java
@@ -7,6 +7,6 @@ public class PolicyCodeReferencedByWorkflowException extends BadRequestException
   public PolicyCodeReferencedByWorkflowException(String policyCode) {
     super(
         "POLICY_CODE_REFERENCED_BY_WORKFLOW",
-        "해당 정책 코드를 참조하는 워크플로우가 존재하여 비활성화할 수 없습니다.");
+        "'" + policyCode + "' 정책 코드를 참조하는 워크플로우가 존재하여 비활성화할 수 없습니다.");
   }
 }

--- a/backend/src/main/java/com/init/domainpack/domain/model/WorkflowDefinition.java
+++ b/backend/src/main/java/com/init/domainpack/domain/model/WorkflowDefinition.java
@@ -10,6 +10,8 @@ import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import java.time.OffsetDateTime;
 import java.util.Objects;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 @Entity
 @Table(name = "workflow_definition", schema = "pack")
@@ -31,18 +33,22 @@ public class WorkflowDefinition {
   @Column(name = "description")
   private String description;
 
+  @JdbcTypeCode(SqlTypes.JSON)
   @Column(name = "graph_json", columnDefinition = "jsonb", nullable = false)
   private String graphJson;
 
   @Column(name = "initial_state")
   private String initialState;
 
+  @JdbcTypeCode(SqlTypes.JSON)
   @Column(name = "terminal_states_json", columnDefinition = "jsonb", nullable = false)
   private String terminalStatesJson;
 
+  @JdbcTypeCode(SqlTypes.JSON)
   @Column(name = "evidence_json", columnDefinition = "jsonb", nullable = false)
   private String evidenceJson;
 
+  @JdbcTypeCode(SqlTypes.JSON)
   @Column(name = "meta_json", columnDefinition = "jsonb", nullable = false)
   private String metaJson;
 

--- a/backend/src/main/java/com/init/domainpack/domain/repository/WorkflowDefinitionRepository.java
+++ b/backend/src/main/java/com/init/domainpack/domain/repository/WorkflowDefinitionRepository.java
@@ -14,4 +14,6 @@ public interface WorkflowDefinitionRepository {
       Long domainPackVersionId);
 
   Optional<WorkflowDefinition> findByIdAndDomainPackVersionId(Long id, Long domainPackVersionId);
+
+  boolean existsByDomainPackVersionIdAndPolicyRef(Long versionId, String policyCode);
 }

--- a/backend/src/main/java/com/init/domainpack/infrastructure/persistence/JpaWorkflowDefinitionRepository.java
+++ b/backend/src/main/java/com/init/domainpack/infrastructure/persistence/JpaWorkflowDefinitionRepository.java
@@ -6,6 +6,8 @@ import com.init.domainpack.domain.repository.WorkflowDefinitionSummaryRow;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -18,4 +20,17 @@ public interface JpaWorkflowDefinitionRepository
 
   @Override
   Optional<WorkflowDefinition> findByIdAndDomainPackVersionId(Long id, Long domainPackVersionId);
+
+  @Override
+  @Query(
+      value =
+          """
+          SELECT CASE WHEN COUNT(*) > 0 THEN TRUE ELSE FALSE END
+          FROM pack.workflow_definition
+          WHERE domain_pack_version_id = :versionId
+            AND graph_json -> 'nodes' @> jsonb_build_array(jsonb_build_object('policyRef', :policyCode))
+          """,
+      nativeQuery = true)
+  boolean existsByDomainPackVersionIdAndPolicyRef(
+      @Param("versionId") Long versionId, @Param("policyCode") String policyCode);
 }

--- a/backend/src/main/java/com/init/domainpack/infrastructure/persistence/JpaWorkflowDefinitionRepository.java
+++ b/backend/src/main/java/com/init/domainpack/infrastructure/persistence/JpaWorkflowDefinitionRepository.java
@@ -26,7 +26,7 @@ public interface JpaWorkflowDefinitionRepository
       value =
           """
           SELECT CASE WHEN COUNT(*) > 0 THEN TRUE ELSE FALSE END
-          FROM pack.workflow_definition
+          FROM workflow_definition
           WHERE domain_pack_version_id = :versionId
             AND graph_json -> 'nodes' @> jsonb_build_array(jsonb_build_object('policyRef', :policyCode))
           """,

--- a/backend/src/test/java/com/init/domainpack/application/UpdatePolicyStatusUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/UpdatePolicyStatusUseCaseTest.java
@@ -41,7 +41,8 @@ class UpdatePolicyStatusUseCaseTest {
   @BeforeEach
   void setUp() {
     useCase =
-        new UpdatePolicyStatusUseCase(validator, policyRepository, versionRepository, workflowRepository);
+        new UpdatePolicyStatusUseCase(
+            validator, policyRepository, versionRepository, workflowRepository);
   }
 
   @Test
@@ -250,7 +251,8 @@ class UpdatePolicyStatusUseCaseTest {
     given(policyRepository.findById(55L)).willReturn(Optional.of(policy));
     given(policyRepository.save(any())).willReturn(policy);
 
-    useCase.execute(new UpdatePolicyStatusCommand(1L, 7L, 10L, 55L, 5L, PolicyDefinition.STATUS_ACTIVE));
+    useCase.execute(
+        new UpdatePolicyStatusCommand(1L, 7L, 10L, 55L, 5L, PolicyDefinition.STATUS_ACTIVE));
 
     verify(workflowRepository, never()).existsByDomainPackVersionIdAndPolicyRef(any(), any());
   }

--- a/backend/src/test/java/com/init/domainpack/application/UpdatePolicyStatusUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/UpdatePolicyStatusUseCaseTest.java
@@ -10,10 +10,12 @@ import static org.mockito.Mockito.verify;
 import com.init.domainpack.application.exception.DomainPackNotFoundException;
 import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
 import com.init.domainpack.application.exception.DomainPackWorkspaceNotFoundException;
+import com.init.domainpack.application.exception.PolicyCodeReferencedByWorkflowException;
 import com.init.domainpack.domain.model.DomainPackVersion;
 import com.init.domainpack.domain.model.PolicyDefinition;
 import com.init.domainpack.domain.repository.DomainPackVersionRepository;
 import com.init.domainpack.domain.repository.PolicyDefinitionRepository;
+import com.init.domainpack.domain.repository.WorkflowDefinitionRepository;
 import com.init.shared.application.exception.BadRequestException;
 import com.init.shared.application.exception.NotFoundException;
 import java.util.Optional;
@@ -32,12 +34,14 @@ class UpdatePolicyStatusUseCaseTest {
   @Mock private DomainPackValidator validator;
   @Mock private PolicyDefinitionRepository policyRepository;
   @Mock private DomainPackVersionRepository versionRepository;
+  @Mock private WorkflowDefinitionRepository workflowRepository;
 
   private UpdatePolicyStatusUseCase useCase;
 
   @BeforeEach
   void setUp() {
-    useCase = new UpdatePolicyStatusUseCase(validator, policyRepository, versionRepository);
+    useCase =
+        new UpdatePolicyStatusUseCase(validator, policyRepository, versionRepository, workflowRepository);
   }
 
   @Test
@@ -47,6 +51,8 @@ class UpdatePolicyStatusUseCaseTest {
 
     PolicyDefinition policy = policy(55L, 10L);
     given(policyRepository.findById(55L)).willReturn(Optional.of(policy));
+    given(workflowRepository.existsByDomainPackVersionIdAndPolicyRef(10L, "refund_check"))
+        .willReturn(false);
     given(policyRepository.save(any())).willReturn(policy);
 
     UpdatePolicyStatusCommand command =
@@ -198,6 +204,55 @@ class UpdatePolicyStatusUseCaseTest {
                     new UpdatePolicyStatusCommand(
                         1L, 7L, 10L, 55L, 5L, PolicyDefinition.STATUS_INACTIVE)))
         .isInstanceOf(NotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("INACTIVE 전환 시 policyRef 참조 workflow 존재 → PolicyCodeReferencedByWorkflowException")
+  void should_역참조예외_when_INACTIVE전환시참조workflow존재() {
+    given(versionRepository.findById(10L)).willReturn(Optional.of(draftVersion(10L, 7L)));
+    PolicyDefinition policy = policy(55L, 10L);
+    given(policyRepository.findById(55L)).willReturn(Optional.of(policy));
+    given(workflowRepository.existsByDomainPackVersionIdAndPolicyRef(10L, "refund_check"))
+        .willReturn(true);
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new UpdatePolicyStatusCommand(
+                        1L, 7L, 10L, 55L, 5L, PolicyDefinition.STATUS_INACTIVE)))
+        .isInstanceOf(PolicyCodeReferencedByWorkflowException.class);
+    verify(policyRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("INACTIVE 전환 시 참조 workflow 없음 → 정상 전환")
+  void should_INACTIVE전환성공_when_참조workflow없음() {
+    given(versionRepository.findById(10L)).willReturn(Optional.of(draftVersion(10L, 7L)));
+    PolicyDefinition policy = policy(55L, 10L);
+    given(policyRepository.findById(55L)).willReturn(Optional.of(policy));
+    given(workflowRepository.existsByDomainPackVersionIdAndPolicyRef(10L, "refund_check"))
+        .willReturn(false);
+    given(policyRepository.save(any())).willReturn(policy);
+
+    PolicyDefinitionResponse result =
+        useCase.execute(
+            new UpdatePolicyStatusCommand(1L, 7L, 10L, 55L, 5L, PolicyDefinition.STATUS_INACTIVE));
+
+    assertThat(result.status()).isEqualTo(PolicyDefinition.STATUS_INACTIVE);
+  }
+
+  @Test
+  @DisplayName("ACTIVE 전환 시 역참조 체크 스킵")
+  void should_역참조체크스킵_when_ACTIVE전환() {
+    given(versionRepository.findById(10L)).willReturn(Optional.of(draftVersion(10L, 7L)));
+    PolicyDefinition policy = policy(55L, 10L);
+    ReflectionTestUtils.setField(policy, "status", PolicyDefinition.STATUS_INACTIVE);
+    given(policyRepository.findById(55L)).willReturn(Optional.of(policy));
+    given(policyRepository.save(any())).willReturn(policy);
+
+    useCase.execute(new UpdatePolicyStatusCommand(1L, 7L, 10L, 55L, 5L, PolicyDefinition.STATUS_ACTIVE));
+
+    verify(workflowRepository, never()).existsByDomainPackVersionIdAndPolicyRef(any(), any());
   }
 
   @Test

--- a/backend/src/test/java/com/init/domainpack/infrastructure/JpaWorkflowDefinitionRepositoryPolicyRefTest.java
+++ b/backend/src/test/java/com/init/domainpack/infrastructure/JpaWorkflowDefinitionRepositoryPolicyRefTest.java
@@ -36,6 +36,8 @@ class JpaWorkflowDefinitionRepositoryPolicyRefTest {
         "spring.jpa.properties.hibernate.dialect", () -> "org.hibernate.dialect.PostgreSQLDialect");
     registry.add("spring.jpa.properties.hibernate.hbm2ddl.create_namespaces", () -> "true");
     registry.add("spring.liquibase.enabled", () -> "false");
+    registry.add(
+        "spring.datasource.hikari.connection-init-sql", () -> "CREATE SCHEMA IF NOT EXISTS pack");
   }
 
   @Autowired private JpaWorkflowDefinitionRepository repository;

--- a/backend/src/test/java/com/init/domainpack/infrastructure/JpaWorkflowDefinitionRepositoryPolicyRefTest.java
+++ b/backend/src/test/java/com/init/domainpack/infrastructure/JpaWorkflowDefinitionRepositoryPolicyRefTest.java
@@ -1,0 +1,83 @@
+package com.init.domainpack.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.init.domainpack.domain.model.WorkflowDefinition;
+import com.init.domainpack.infrastructure.persistence.JpaWorkflowDefinitionRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Testcontainers(disabledWithoutDocker = true)
+@DisplayName("JpaWorkflowDefinitionRepository — JSONB policyRef (PostgreSQL)")
+class JpaWorkflowDefinitionRepositoryPolicyRefTest {
+
+  @Container
+  static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
+
+  @DynamicPropertySource
+  static void configureDataSource(DynamicPropertyRegistry registry) {
+    registry.add("spring.datasource.url", postgres::getJdbcUrl);
+    registry.add("spring.datasource.username", postgres::getUsername);
+    registry.add("spring.datasource.password", postgres::getPassword);
+    registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+    registry.add("spring.jpa.hibernate.ddl-auto", () -> "create-drop");
+    registry.add(
+        "spring.jpa.properties.hibernate.dialect", () -> "org.hibernate.dialect.PostgreSQLDialect");
+    registry.add("spring.jpa.properties.hibernate.hbm2ddl.create_namespaces", () -> "true");
+    registry.add("spring.liquibase.enabled", () -> "false");
+  }
+
+  @Autowired private JpaWorkflowDefinitionRepository repository;
+
+  @Autowired private TestEntityManager em;
+
+  @Test
+  @DisplayName("policyRef 없는 노드만 있는 graphJson → false")
+  void should_false_when_policyRef없는노드만존재() {
+    String graphJson = "{\"nodes\":[{\"id\":\"n1\",\"type\":\"ACTION\"}]}";
+    em.persistAndFlush(workflow(1L, "refund_flow", graphJson));
+
+    boolean result = repository.existsByDomainPackVersionIdAndPolicyRef(1L, "refund_check");
+
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  @DisplayName("policyRef 포함 노드 있는 graphJson → true")
+  void should_true_when_policyRef포함노드존재() {
+    String graphJson =
+        "{\"nodes\":[{\"id\":\"n1\",\"type\":\"ACTION\",\"policyRef\":\"refund_check\"}]}";
+    em.persistAndFlush(workflow(2L, "refund_flow", graphJson));
+
+    boolean result = repository.existsByDomainPackVersionIdAndPolicyRef(2L, "refund_check");
+
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  @DisplayName("nodes 배열이 없는 graphJson → false")
+  void should_false_when_nodes없는graphJson() {
+    String graphJson = "{\"direction\":\"LR\"}";
+    em.persistAndFlush(workflow(3L, "empty_flow", graphJson));
+
+    boolean result = repository.existsByDomainPackVersionIdAndPolicyRef(3L, "refund_check");
+
+    assertThat(result).isFalse();
+  }
+
+  private WorkflowDefinition workflow(Long versionId, String code, String graphJson) {
+    return WorkflowDefinition.create(
+        versionId, code, code + "_name", null, graphJson, "start", "[\"done\"]", "[]", "{}");
+  }
+}

--- a/backend/src/test/java/com/init/domainpack/infrastructure/JpaWorkflowDefinitionRepositoryPolicyRefTest.java
+++ b/backend/src/test/java/com/init/domainpack/infrastructure/JpaWorkflowDefinitionRepositoryPolicyRefTest.java
@@ -12,6 +12,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.jdbc.Sql;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -19,6 +20,9 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Testcontainers(disabledWithoutDocker = true)
+@Sql(
+    scripts = "classpath:policyref-workflow-table.sql",
+    executionPhase = Sql.ExecutionPhase.BEFORE_TEST_CLASS)
 @DisplayName("JpaWorkflowDefinitionRepository — JSONB policyRef (PostgreSQL)")
 class JpaWorkflowDefinitionRepositoryPolicyRefTest {
 
@@ -31,13 +35,10 @@ class JpaWorkflowDefinitionRepositoryPolicyRefTest {
     registry.add("spring.datasource.username", postgres::getUsername);
     registry.add("spring.datasource.password", postgres::getPassword);
     registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
-    registry.add("spring.jpa.hibernate.ddl-auto", () -> "create-drop");
+    registry.add("spring.jpa.hibernate.ddl-auto", () -> "none");
     registry.add(
         "spring.jpa.properties.hibernate.dialect", () -> "org.hibernate.dialect.PostgreSQLDialect");
-    registry.add("spring.jpa.properties.hibernate.hbm2ddl.create_namespaces", () -> "true");
     registry.add("spring.liquibase.enabled", () -> "false");
-    registry.add(
-        "spring.datasource.hikari.connection-init-sql", () -> "CREATE SCHEMA IF NOT EXISTS pack");
   }
 
   @Autowired private JpaWorkflowDefinitionRepository repository;

--- a/backend/src/test/java/com/init/domainpack/infrastructure/JpaWorkflowDefinitionRepositoryPolicyRefTest.java
+++ b/backend/src/test/java/com/init/domainpack/infrastructure/JpaWorkflowDefinitionRepositoryPolicyRefTest.java
@@ -39,6 +39,12 @@ class JpaWorkflowDefinitionRepositoryPolicyRefTest {
     registry.add(
         "spring.jpa.properties.hibernate.dialect", () -> "org.hibernate.dialect.PostgreSQLDialect");
     registry.add("spring.liquibase.enabled", () -> "false");
+    // Defensive dual schema-creation: Hikari's connection-init-sql runs per connection before
+    // Hibernate creates namespaces, so both settings ensure the 'pack' schema exists and is on
+    // the search_path regardless of initialization order.
+    registry.add("spring.jpa.properties.hibernate.hbm2ddl.create_namespaces", () -> "true");
+    registry.add(
+        "spring.datasource.hikari.connection-init-sql", () -> "SET search_path TO pack, public");
   }
 
   @Autowired private JpaWorkflowDefinitionRepository repository;

--- a/backend/src/test/java/com/init/domainpack/infrastructure/JpaWorkflowDefinitionRepositoryPolicyRefTest.java
+++ b/backend/src/test/java/com/init/domainpack/infrastructure/JpaWorkflowDefinitionRepositoryPolicyRefTest.java
@@ -29,6 +29,15 @@ class JpaWorkflowDefinitionRepositoryPolicyRefTest {
   @Container
   static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
 
+  static {
+    // Start the container eagerly in the class initializer so it is ready before
+    // SpringExtension evaluates @DynamicPropertySource. Without this, extension
+    // registration order (@DataJpaTest above @Testcontainers) lets Spring load the
+    // context first and call postgres::getJdbcUrl before TestcontainersExtension
+    // starts the container, which fails with IllegalStateException on slower CI runners.
+    postgres.start();
+  }
+
   @DynamicPropertySource
   static void configureDataSource(DynamicPropertyRegistry registry) {
     registry.add("spring.datasource.url", postgres::getJdbcUrl);

--- a/backend/src/test/java/com/init/domainpack/presentation/UpdatePolicyStatusControllerTest.java
+++ b/backend/src/test/java/com/init/domainpack/presentation/UpdatePolicyStatusControllerTest.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.init.domainpack.application.PolicyDefinitionResponse;
 import com.init.domainpack.application.UpdatePolicyStatusUseCase;
 import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
+import com.init.domainpack.application.exception.PolicyCodeReferencedByWorkflowException;
 import com.init.fixtures.WithLongPrincipal;
 import com.init.shared.application.exception.BadRequestException;
 import com.init.shared.application.exception.NotFoundException;
@@ -148,6 +149,23 @@ class UpdatePolicyStatusControllerTest {
         .andExpect(status().isBadRequest());
 
     verifyNoInteractions(useCase);
+  }
+
+  @Test
+  @DisplayName("PATCH /policies/{policyId}/status: INACTIVE 전환 시 policyRef 참조 workflow 존재 → 400")
+  @WithLongPrincipal(5L)
+  void should_400반환_when_INACTIVE전환시참조workflow존재() throws Exception {
+    given(useCase.execute(any()))
+        .willThrow(new PolicyCodeReferencedByWorkflowException("refund_check"));
+
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of("status", "INACTIVE"))))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("POLICY_CODE_REFERENCED_BY_WORKFLOW"));
   }
 
   @Test

--- a/backend/src/test/resources/policyref-workflow-table.sql
+++ b/backend/src/test/resources/policyref-workflow-table.sql
@@ -1,0 +1,15 @@
+CREATE SCHEMA IF NOT EXISTS pack;
+CREATE TABLE IF NOT EXISTS pack.workflow_definition (
+    id BIGSERIAL PRIMARY KEY,
+    domain_pack_version_id BIGINT NOT NULL,
+    workflow_code VARCHAR(255) NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    description VARCHAR(255),
+    graph_json JSONB NOT NULL,
+    initial_state VARCHAR(255),
+    terminal_states_json JSONB NOT NULL,
+    evidence_json JSONB NOT NULL,
+    meta_json JSONB NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL
+);


### PR DESCRIPTION
## Summary

`UpdatePolicyStatusUseCase`에 INACTIVE 전환 전 graphJson policyRef 역참조 체크를 추가하여, 참조 중인 policy가 비활성화되어 stale policyRef가 발생하는 경로를 차단한다.

---

## Context

spec/100 — `UpdatePolicyStatusUseCase`에 INACTIVE 전환 시 역참조 무결성 보호 로직 추가. 기존 엔드포인트(`PATCH .../policies/{policyId}/status`)에 신규 400 에러 케이스 추가.

---

## What Changed

- `UpdatePolicyStatusUseCase`: `WorkflowDefinitionRepository` 의존성 추가, INACTIVE 전환 분기에 역참조 체크 삽입
- `PolicyCodeReferencedByWorkflowException`: 신규 예외 클래스 (`BadRequestException` 계열, HTTP 400)
- `WorkflowDefinitionRepository`: `existsByDomainPackVersionIdAndPolicyRef` 인터페이스 추가
- `JpaWorkflowDefinitionRepository`: PostgreSQL `@>` 연산자를 사용한 JSONB 역참조 native query 구현
- `UpdatePolicyStatusUseCaseTest`: 역참조 관련 3개 케이스 추가 (참조 있음 → 예외, 참조 없음 → 정상, ACTIVE 전환 → 체크 스킵)
- `UpdatePolicyStatusControllerTest`: INACTIVE + 참조 있음 → 400 + `POLICY_CODE_REFERENCED_BY_WORKFLOW` 케이스 추가

---

## Assumptions Adopted

**U5 — GlobalExceptionHandler 명시적 핸들러 추가 여부**

- **Spec 권장**: Option A (명시적 `@ExceptionHandler` 추가)
- **채택**: Option B — 기존 `BadRequestException` fallback 핸들러 재사용
- **근거**: `GlobalExceptionHandler`의 기존 `BadRequestException` 핸들러가 `ex.getCode()`, `ex.getMessage()`를 그대로 전달하므로 `POLICY_CODE_REFERENCED_BY_WORKFLOW` 에러 코드가 응답에 정확히 전달됨. 컨트롤러 테스트 `jsonPath("$.code").value("POLICY_CODE_REFERENCED_BY_WORKFLOW")` 통과로 검증.
- **잔여 리스크**: 향후 에러 코드별 다른 HTTP status가 필요해지면 명시적 핸들러 추가 필요. 현재 요건(400 고정)에서는 문제 없음.

**U6 — policyRef 없는 레거시 graphJson 처리**

- **채택**: 별도 분기 없음. PostgreSQL `@>` 연산자 특성상 `policyRef` 키 없는 노드는 자연스럽게 불일치 처리.
- **잔여 리스크**: `nodes` 배열 자체가 null인 레거시 데이터는 `graph_json -> 'nodes'`가 NULL 반환 → `@>` false 처리 → INACTIVE 허용. 안전한 방향으로 동작 수용.

---

## Spec Deviations

**에러 메시지 포맷**

- Spec: `"해당 정책 코드를 참조하는 워크플로우가 존재하여 비활성화할 수 없습니다."`
- 구현: `"'{policyCode}' 정책 코드를 참조하는 워크플로우가 존재하여 비활성화할 수 없습니다."` — policyCode를 메시지에 포함하는 방향으로 확장. 에러 `code` 값(`POLICY_CODE_REFERENCED_BY_WORKFLOW`)은 스펙 일치.

---

## Blocked / Skipped Items

- **policyCode rename 지원 (U2)**: Out of scope. policyCode는 현재 immutable이므로 이번 구현과 무관. 스펙 명시적 제외 항목.

---

## Test Notes

**Unit Tests** (`UpdatePolicyStatusUseCaseTest`) — 전부 통과

| 케이스 | 결과 |
|--------|------|
| INACTIVE 전환 + 참조 있음 → `PolicyCodeReferencedByWorkflowException`, save 미호출 | ✅ |
| INACTIVE 전환 + 참조 없음 → 정상 INACTIVE 전환 | ✅ |
| ACTIVE 전환 → 역참조 체크 스킵 | ✅ |

**Controller Tests** (`UpdatePolicyStatusControllerTest`) — 전부 통과

| 케이스 | 결과 |
|--------|------|
| INACTIVE + 참조 있음 → 400 + `POLICY_CODE_REFERENCED_BY_WORKFLOW` | ✅ |

스펙 Test Checklist의 통합 테스트 항목(`[ ]`)이 실제로는 `@WebMvcTest` 기반 컨트롤러 테스트로 구현 및 통과됨.

---

## Reviewer Focus

1. **U5 assumption 수용 여부**: `GlobalExceptionHandler`에 명시적 핸들러를 추가하지 않고 `BadRequestException` fallback을 재사용한 결정. 현재 요건에서 동작은 동일하나, 팀 컨벤션상 명시적 핸들러를 선호한다면 추가 필요.
2. **JSONB 쿼리 정확성**: `graph_json -> 'nodes' @> jsonb_build_array(jsonb_build_object('policyRef', :policyCode))` — `nodes` 배열의 임의 요소에 `policyRef: {policyCode}` 쌍이 존재하면 true. 다른 필드(`type`, `id` 등)와 무관하게 policyRef 키만 매칭하는 것이 의도와 일치하는지 확인 필요.
3. **에러 메시지 policyCode 노출**: 구현이 스펙 메시지 문자열보다 확장됨. 클라이언트에 policyCode를 노출해도 되는지 확인.

---

## Conflicts

없음.

---

## Ready to Merge

구현, 유닛 테스트, 컨트롤러 테스트 모두 완료. U5 assumption에 대한 리뷰어 확인 후 머지 가능.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 정책을 비활성화하기 전에 워크플로우에서 해당 정책이 참조되는지 검사하여, 참조 중이면 비활성화를 차단하고 명확한 오류 응답을 반환합니다.

* **테스트**
  * 해당 검증 로직에 대한 단위·컨트롤러 테스트 추가
  * PostgreSQL 컨테이너 기반 통합 테스트 추가로 리포지토리 동작 검증 강화

* **작업**
  * 테스트용 컨테이너 의존성 추가 및 테스트 인프라 설정 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->