### PR TITLE
spec/00114: domain-pack 엔티티 JSONB 컬럼 @JdbcTypeCode(SqlTypes.JSON) 누락 수정

### DIFF
--- a/.agent/specs/00114.md
+++ b/.agent/specs/00114.md
@@ -1,0 +1,120 @@
+# [fix/00114] domain-pack 엔티티 JSONB 컬럼 @JdbcTypeCode(SqlTypes.JSON) 누락 수정
+
+## Goal
+
+`domain-pack` bounded context 하위 6개 엔티티의 JSONB 컬럼에 누락된 `@JdbcTypeCode(SqlTypes.JSON)` 어노테이션을 추가하여, Hibernate가 PostgreSQL `jsonb` 타입을 올바르게 바인딩하도록 수정한다.
+
+---
+
+## Sequence Diagram
+
+N/A — HTTP 요청/응답 경로 변경 없음. 엔티티 어노테이션 추가만 수행한다.
+
+---
+
+## REST API
+
+N/A — API 변경 없음.
+
+---
+
+## Class Design
+
+### 영향 대상
+
+| 엔티티 | JSONB 필드 | 개수 |
+|--------|-----------|------|
+| `IntentDefinition` | `sourceClusterRef`, `entryConditionJson`, `evidenceJson`, `metaJson` | 4 |
+| `SlotDefinition` | `validationRuleJson`, `defaultValueJson`, `metaJson` | 3 |
+| `PolicyDefinition` | `conditionJson`, `actionJson`, `evidenceJson`, `metaJson` | 4 |
+| `RiskDefinition` | `triggerConditionJson`, `handlingActionJson`, `evidenceJson`, `metaJson` | 4 |
+| `IntentSlotBinding` | `conditionJson` | 1 |
+| `IntentWorkflowBinding` | `routeConditionJson` | 1 |
+| **합계** | | **17** |
+
+### 수정 패턴
+
+기준 패턴: `WorkflowDefinition.java:13-14, 36-38`
+
+```java
+// 클래스당 import 2개 추가
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+// 각 JSONB 필드에 어노테이션 선행 추가
+@JdbcTypeCode(SqlTypes.JSON)
+@Column(name = "...", columnDefinition = "jsonb", ...)
+private String ...;
+```
+
+### 수정 대상 파일
+
+- `backend/src/main/java/com/init/domainpack/domain/model/IntentDefinition.java`
+- `backend/src/main/java/com/init/domainpack/domain/model/SlotDefinition.java`
+- `backend/src/main/java/com/init/domainpack/domain/model/PolicyDefinition.java`
+- `backend/src/main/java/com/init/domainpack/domain/model/RiskDefinition.java`
+- `backend/src/main/java/com/init/domainpack/domain/model/IntentSlotBinding.java`
+- `backend/src/main/java/com/init/domainpack/domain/model/IntentWorkflowBinding.java`
+
+### 제외 대상
+
+아래 엔티티는 이미 올바르게 적용되어 있으므로 수정 불필요:
+- `DomainPackVersion.summaryJson` (`:40-41`)
+- `WorkflowDefinition`: `graphJson`, `terminalStatesJson`, `evidenceJson`, `metaJson` (`:36-53`)
+
+---
+
+## Tests
+
+6개 엔티티 전체에 `@DataJpaTest` 기반 JPA 통합 테스트를 신규 작성한다.
+
+### 신규 테스트 파일 목록
+
+| 파일 | 대상 엔티티 |
+|------|------------|
+| `infrastructure/JpaIntentDefinitionRepositoryTest.java` | `IntentDefinition` |
+| `infrastructure/JpaSlotDefinitionRepositoryTest.java` | `SlotDefinition` |
+| `infrastructure/JpaPolicyDefinitionRepositoryTest.java` | `PolicyDefinition` |
+| `infrastructure/JpaRiskDefinitionRepositoryTest.java` | `RiskDefinition` |
+| `infrastructure/JpaIntentSlotBindingRepositoryTest.java` | `IntentSlotBinding` |
+| `infrastructure/JpaIntentWorkflowBindingRepositoryTest.java` | `IntentWorkflowBinding` |
+
+> 위치: `backend/src/test/java/com/init/domainpack/`
+
+### 기존 참조 패턴
+
+`backend/src/test/java/com/init/domainpack/infrastructure/JpaWorkflowDefinitionRepositoryTest.java`
+
+```java
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@TestPropertySource(properties = {
+  "spring.datasource.url=jdbc:h2:mem:testdb-xxx;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE",
+  "spring.datasource.driver-class-name=org.h2.Driver",
+  "spring.datasource.username=sa",
+  "spring.datasource.password=",
+  "spring.jpa.hibernate.ddl-auto=create-drop",
+  "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect",
+  "spring.jpa.properties.hibernate.hbm2ddl.create_namespaces=true",
+  "spring.liquibase.enabled=false"
+})
+```
+
+### Test Checklist
+
+- [ ] 6개 엔티티 각각: JSONB 필드 persist → flush → find 후 값 보존 검증
+- [ ] `SlotDefinition.defaultValueJson` (`nullable=true`): `null` 저장 → 조회 시 `null` 반환 검증
+- [ ] 각 테스트: `TestEntityManager.persistAndFlush()` → `em.clear()` → `repository.findById()` 라이프사이클 준수
+
+---
+
+## Database
+
+N/A — DB 스키마 변경 없음. Liquibase migration 파일 수정 불필요.
+
+---
+
+## Additional Notes
+
+- 이 수정은 어노테이션 추가만이다. 필드 타입, 컬럼명, `nullable`, `columnDefinition` 등 기존 매핑은 일절 변경하지 않는다.
+- `IntentDefinition`에는 `parentIntentId` 상위 참조가 있으나 JSONB와 무관하다.


### PR DESCRIPTION
# [fix/00114] domain-pack 엔티티 JSONB 컬럼 @JdbcTypeCode(SqlTypes.JSON) 누락 수정

## Goal

`domain-pack` bounded context 하위 6개 엔티티의 JSONB 컬럼에 누락된 `@JdbcTypeCode(SqlTypes.JSON)` 어노테이션을 추가하여, Hibernate가 PostgreSQL `jsonb` 타입을 올바르게 바인딩하도록 수정한다.

---

## Sequence Diagram

N/A — HTTP 요청/응답 경로 변경 없음. 엔티티 어노테이션 추가만 수행한다.

---

## REST API

N/A — API 변경 없음.

---

## Class Design

### 영향 대상

| 엔티티 | JSONB 필드 | 개수 |
|--------|-----------|------|
| `IntentDefinition` | `sourceClusterRef`, `entryConditionJson`, `evidenceJson`, `metaJson` | 4 |
| `SlotDefinition` | `validationRuleJson`, `defaultValueJson`, `metaJson` | 3 |
| `PolicyDefinition` | `conditionJson`, `actionJson`, `evidenceJson`, `metaJson` | 4 |
| `RiskDefinition` | `triggerConditionJson`, `handlingActionJson`, `evidenceJson`, `metaJson` | 4 |
| `IntentSlotBinding` | `conditionJson` | 1 |
| `IntentWorkflowBinding` | `routeConditionJson` | 1 |
| **합계** | | **17** |

### 수정 패턴

기준 패턴: `WorkflowDefinition.java:13-14, 36-38`

```java
// 클래스당 import 2개 추가
import org.hibernate.annotations.JdbcTypeCode;
import org.hibernate.type.SqlTypes;

// 각 JSONB 필드에 어노테이션 선행 추가
@JdbcTypeCode(SqlTypes.JSON)
@Column(name = "...", columnDefinition = "jsonb", ...)
private String ...;
```

### 수정 대상 파일

- `backend/src/main/java/com/init/domainpack/domain/model/IntentDefinition.java`
- `backend/src/main/java/com/init/domainpack/domain/model/SlotDefinition.java`
- `backend/src/main/java/com/init/domainpack/domain/model/PolicyDefinition.java`
- `backend/src/main/java/com/init/domainpack/domain/model/RiskDefinition.java`
- `backend/src/main/java/com/init/domainpack/domain/model/IntentSlotBinding.java`
- `backend/src/main/java/com/init/domainpack/domain/model/IntentWorkflowBinding.java`

### 제외 대상

아래 엔티티는 이미 올바르게 적용되어 있으므로 수정 불필요:
- `DomainPackVersion.summaryJson` (`:40-41`)
- `WorkflowDefinition`: `graphJson`, `terminalStatesJson`, `evidenceJson`, `metaJson` (`:36-53`)

---

## Tests

6개 엔티티 전체에 `@DataJpaTest` 기반 JPA 통합 테스트를 신규 작성한다.

### 신규 테스트 파일 목록

| 파일 | 대상 엔티티 |
|------|------------|
| `infrastructure/JpaIntentDefinitionRepositoryTest.java` | `IntentDefinition` |
| `infrastructure/JpaSlotDefinitionRepositoryTest.java` | `SlotDefinition` |
| `infrastructure/JpaPolicyDefinitionRepositoryTest.java` | `PolicyDefinition` |
| `infrastructure/JpaRiskDefinitionRepositoryTest.java` | `RiskDefinition` |
| `infrastructure/JpaIntentSlotBindingRepositoryTest.java` | `IntentSlotBinding` |
| `infrastructure/JpaIntentWorkflowBindingRepositoryTest.java` | `IntentWorkflowBinding` |

> 위치: `backend/src/test/java/com/init/domainpack/`

### 기존 참조 패턴

`backend/src/test/java/com/init/domainpack/infrastructure/JpaWorkflowDefinitionRepositoryTest.java`

```java
@DataJpaTest
@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
@TestPropertySource(properties = {
  "spring.datasource.url=jdbc:h2:mem:testdb-xxx;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE",
  "spring.datasource.driver-class-name=org.h2.Driver",
  "spring.datasource.username=sa",
  "spring.datasource.password=",
  "spring.jpa.hibernate.ddl-auto=create-drop",
  "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect",
  "spring.jpa.properties.hibernate.hbm2ddl.create_namespaces=true",
  "spring.liquibase.enabled=false"
})
```

### Test Checklist

- [ ] 6개 엔티티 각각: JSONB 필드 persist → flush → find 후 값 보존 검증
- [ ] `SlotDefinition.defaultValueJson` (`nullable=true`): `null` 저장 → 조회 시 `null` 반환 검증
- [ ] 각 테스트: `TestEntityManager.persistAndFlush()` → `em.clear()` → `repository.findById()` 라이프사이클 준수

---

## Database

N/A — DB 스키마 변경 없음. Liquibase migration 파일 수정 불필요.

---

## Additional Notes

- 이 수정은 어노테이션 추가만이다. 필드 타입, 컬럼명, `nullable`, `columnDefinition` 등 기존 매핑은 일절 변경하지 않는다.
- `IntentDefinition`에는 `parentIntentId` 상위 참조가 있으나 JSONB와 무관하다.
---
# Uncertainty Register — fix/00114

**이슈**: domain-pack 엔티티 JSONB 컬럼 `@JdbcTypeCode(SqlTypes.JSON)` 누락  
**작성일**: 2026-04-24  
**Spec**: `.agent/specs/00114.md`

---

## U-001

- **ID**: U-001
- **Issue**: 영향 6개 엔티티에 대한 JPA 통합 테스트 신규 작성 여부
- **Status**: `Confirmed`
- **Decision**: 영향 6개 엔티티 모두 `@DataJpaTest` 기반 JPA 통합 테스트 신규 작성 (2026-04-24 사용자 확정)
- **Options**:
  1. ✅ 6개 엔티티 전체에 `@DataJpaTest` 기반 JPA 통합 테스트 추가
  2. ~~어노테이션 추가만 수행하고 테스트는 추가하지 않음~~
- **Recommended Default**: N/A (확정)
- **Why recommended**: N/A (확정)
- **User Decision Required**: `No`
- **User Question**: N/A
- **Execution Rule**:
  - Implementation Agent MUST: 6개 엔티티 각각에 대해 `JpaXxxRepositoryTest.java` (또는 엔티티 직접 `@DataJpaTest`) 파일을 신규 작성할 것
  - 기준 패턴: `JpaWorkflowDefinitionRepositoryTest.java` (H2+PostgreSQL 모드, `create-drop`, `liquibase.enabled=false`)
  - 각 테스트는 최소한 persist → flush → find 후 JSONB 필드 값 보존을 검증할 것
  - `SlotDefinition.defaultValueJson`(`nullable=true`)의 `null` 저장/조회도 포함할 것
- **Affected Spec Section**: Tests

---

## U-002

- **ID**: U-002
- **Issue**: `@JdbcTypeCode` 누락이 H2 테스트 환경에서 실패를 재현하는지 여부
- **Status**: `Assumption`
- **Why unresolved**: GitHub Issue #114 본문에서 서술하는 실제 런타임 증상(오류 메시지, 스택 트레이스 등)을 직접 확인하지 못했다. H2는 `jsonb`를 PostgreSQL과 동일하게 처리하지 않으며, `@JdbcTypeCode` 유무가 H2 환경에서 테스트 실패로 이어지는지 불분명하다.
- **Options**:
  1. H2 환경에서도 `@JdbcTypeCode` 누락이 바인딩 오류를 유발한다고 가정
  2. H2 환경에서는 문제없이 동작하나 PostgreSQL 런타임에서만 타입 불일치가 발생한다고 가정
- **Recommended Default**: Option 2 채택. 기존 `JpaWorkflowDefinitionRepositoryTest`가 `@JdbcTypeCode`를 적용한 채로 H2에서 정상 동작하는 것이 확인되므로, 적용하지 않은 쪽의 테스트가 H2에서 실패할 가능성은 낮다. 수정의 근거는 PostgreSQL 타입 바인딩 정합성 및 참조 패턴 일관성이다.
- **Why recommended**: `WorkflowDefinition`과 `DomainPackVersion`에 이미 적용된 패턴과의 일관성이 핵심 이유이며, H2 재현 여부와 무관하게 수정은 올바르다.
- **User Decision Required**: `No`
- **User Question**: N/A
- **Execution Rule**:
  - Implementation Agent MUST NOT: H2에서 실패를 확인해야만 수정 진행이 가능하다고 판단할 것
  - Implementation Agent MAY: Option 2 `Assumption adopted from Recommended Default`로 진행. 어노테이션 추가는 기존 패턴과의 일관성 근거로 충분하다.
  - If unsafe: N/A — 어노테이션 추가는 기존 매핑을 변경하지 않으므로 회귀 위험이 낮다.
- **Affected Spec Section**: Tests → Test Checklist

---

## 결정 필요 질문 목록

> 모든 항목이 확정되었습니다. Implementation Agent가 추측 없이 진행할 수 있습니다.

~~**Q1 (U-001)**: 영향 6개 엔티티에 대해 `@DataJpaTest` 기반 JPA 통합 테스트를 이번 fix에 함께 추가할까요?~~ → **확정: 전체 6개 추가** 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **내부 개선**
  * 기술 사양 문서 추가

**참고:** 이 릴리스는 사용자에게 직접적인 영향을 주지 않는 내부 구현 문서입니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->