### PR TITLE
feat(domain-pack): implement slot edit sheet and status toggle (#321)

### DIFF
--- a/frontend/src/app/index.tsx
+++ b/frontend/src/app/index.tsx
@@ -2,5 +2,10 @@ import { createRoot } from "react-dom/client";
 import "./index.css";
 import "../index.css";
 import { App } from "./App";
+import { AppProviders } from "./providers";
 
-createRoot(document.getElementById("root")!).render(<App />);
+createRoot(document.getElementById("root")!).render(
+  <AppProviders>
+    <App />
+  </AppProviders>,
+);

--- a/frontend/src/app/providers.tsx
+++ b/frontend/src/app/providers.tsx
@@ -1,3 +1,8 @@
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+const queryClient = new QueryClient();
+
 export function AppProviders({ children }: { children: React.ReactNode }) {
-  return <>{children}</>;
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
 }

--- a/frontend/src/app/providers.tsx
+++ b/frontend/src/app/providers.tsx
@@ -1,7 +1,20 @@
 import React from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 60 * 1000,
+      retry: 0,
+      refetchOnWindowFocus: false,
+      refetchOnMount: false,
+      refetchOnReconnect: false,
+    },
+    mutations: {
+      retry: 0,
+    },
+  },
+});
 
 export function AppProviders({ children }: { children: React.ReactNode }) {
   return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;

--- a/frontend/src/entities/slot/api/index.ts
+++ b/frontend/src/entities/slot/api/index.ts
@@ -1,0 +1,28 @@
+import { apiClient } from "@/shared/api";
+import type { SlotDefinition, SlotSummary, UpdateSlotRequest, UpdateSlotStatusRequest } from "../model/types";
+
+export const slotKeys = {
+  all: ["slots"] as const,
+  lists: () => [...slotKeys.all, "list"] as const,
+  list: (workspaceId: number, packId: number, versionId: number) =>
+    [...slotKeys.lists(), workspaceId, packId, versionId] as const,
+  detail: (workspaceId: number, packId: number, versionId: number, slotId: number) =>
+    [...slotKeys.all, "detail", workspaceId, packId, versionId, slotId] as const,
+};
+
+const basePath = (wsId: number, packId: number, versionId: number) =>
+  `/workspaces/${wsId}/domain-packs/${packId}/versions/${versionId}/slots`;
+
+export const slotApi = {
+  list: (wsId: number, packId: number, versionId: number) =>
+    apiClient.get<SlotSummary[]>(basePath(wsId, packId, versionId)),
+
+  detail: (wsId: number, packId: number, versionId: number, slotId: number) =>
+    apiClient.get<SlotDefinition>(`${basePath(wsId, packId, versionId)}/${slotId}`),
+
+  update: (wsId: number, packId: number, versionId: number, slotId: number, body: UpdateSlotRequest) =>
+    apiClient.patch<SlotDefinition>(`${basePath(wsId, packId, versionId)}/${slotId}`, body),
+
+  updateStatus: (wsId: number, packId: number, versionId: number, slotId: number, body: UpdateSlotStatusRequest) =>
+    apiClient.patch<SlotDefinition>(`${basePath(wsId, packId, versionId)}/${slotId}/status`, body),
+};

--- a/frontend/src/entities/slot/index.ts
+++ b/frontend/src/entities/slot/index.ts
@@ -1,0 +1,2 @@
+export type { SlotDefinition, SlotSummary, UpdateSlotRequest, UpdateSlotStatusRequest } from "./model/types";
+export { slotApi, slotKeys } from "./api/index";

--- a/frontend/src/entities/slot/model/types.ts
+++ b/frontend/src/entities/slot/model/types.ts
@@ -1,0 +1,41 @@
+export interface SlotDefinition {
+  id: number;
+  domainPackVersionId: number;
+  slotCode: string;
+  name: string;
+  description: string | null;
+  dataType: string;
+  isSensitive: boolean;
+  validationRuleJson: string;
+  defaultValueJson: string | null;
+  metaJson: string;
+  status: "ACTIVE" | "INACTIVE";
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface SlotSummary {
+  id: number;
+  domainPackVersionId: number;
+  slotCode: string;
+  name: string;
+  description: string | null;
+  dataType: string;
+  isSensitive: boolean;
+  status: "ACTIVE" | "INACTIVE";
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface UpdateSlotRequest {
+  name: string;
+  description?: string | null;
+  isSensitive?: boolean | null;
+  validationRuleJson?: string | null;
+  defaultValueJson?: string | null;
+  metaJson?: string | null;
+}
+
+export interface UpdateSlotStatusRequest {
+  status: "ACTIVE" | "INACTIVE";
+}

--- a/frontend/src/features/update-slot/api/__tests__/useUpdateSlot.test.ts
+++ b/frontend/src/features/update-slot/api/__tests__/useUpdateSlot.test.ts
@@ -27,7 +27,7 @@ vi.mock("sonner", () => ({
   },
 }));
 
-import { slotApi } from "@/entities/slot";
+import { slotApi, slotKeys } from "@/entities/slot";
 import { toast } from "sonner";
 import { useUpdateSlot } from "../useUpdateSlot";
 import { useUpdateSlotStatus } from "../useUpdateSlotStatus";
@@ -41,6 +41,15 @@ function makeWrapper() {
   });
   return ({ children }: { children: React.ReactNode }) =>
     React.createElement(QueryClientProvider, { client: qc }, children);
+}
+
+function makeWrapperWithClient() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: qc }, children);
+  return { wrapper, qc };
 }
 
 const params = { workspaceId: 1, packId: 2, versionId: 3, slotId: 4 };
@@ -112,9 +121,11 @@ describe("useUpdateSlotStatus", () => {
     vi.mocked(toast.error).mockReset();
   });
 
-  it("성공 시 toast.error를 호출하지 않는다", async () => {
+  it("성공 시 toast.error를 호출하지 않고 invalidateQueries를 호출한다", async () => {
     mockedUpdateStatus.mockResolvedValue({ ...stubSlot, status: "INACTIVE" });
-    const { result } = renderHook(() => useUpdateSlotStatus(), { wrapper: makeWrapper() });
+    const { wrapper, qc } = makeWrapperWithClient();
+    const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+    const { result } = renderHook(() => useUpdateSlotStatus(), { wrapper });
 
     act(() => {
       result.current.mutate({ ...params, status: "INACTIVE" });
@@ -122,6 +133,12 @@ describe("useUpdateSlotStatus", () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(toast.error).not.toHaveBeenCalled();
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: slotKeys.detail(params.workspaceId, params.packId, params.versionId, params.slotId),
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: slotKeys.list(params.workspaceId, params.packId, params.versionId),
+    });
   });
 
   it("오류 시 STATUS_FAILED 메시지를 toast.error로 표시한다", async () => {

--- a/frontend/src/features/update-slot/api/__tests__/useUpdateSlot.test.ts
+++ b/frontend/src/features/update-slot/api/__tests__/useUpdateSlot.test.ts
@@ -1,0 +1,139 @@
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+import { ApiRequestError } from "@/shared/api";
+import { SLOT_ERROR_MESSAGES } from "../messages";
+
+vi.mock("@/entities/slot", () => ({
+  slotApi: {
+    update: vi.fn(),
+    updateStatus: vi.fn(),
+    list: vi.fn(),
+    detail: vi.fn(),
+  },
+  slotKeys: {
+    all: ["slots"],
+    lists: () => ["slots", "list"],
+    list: (...args: number[]) => ["slots", "list", ...args],
+    detail: (...args: number[]) => ["slots", "detail", ...args],
+  },
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { slotApi } from "@/entities/slot";
+import { toast } from "sonner";
+import { useUpdateSlot } from "../useUpdateSlot";
+import { useUpdateSlotStatus } from "../useUpdateSlotStatus";
+
+const mockedUpdate = vi.mocked(slotApi.update);
+const mockedUpdateStatus = vi.mocked(slotApi.updateStatus);
+
+function makeWrapper() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: qc }, children);
+}
+
+const params = { workspaceId: 1, packId: 2, versionId: 3, slotId: 4 };
+
+const stubSlot = {
+  id: 4,
+  domainPackVersionId: 3,
+  slotCode: "S001",
+  name: "테스트 슬롯",
+  description: null,
+  dataType: "STRING",
+  isSensitive: false,
+  validationRuleJson: "{}",
+  defaultValueJson: null,
+  metaJson: "{}",
+  status: "ACTIVE" as const,
+  createdAt: "",
+  updatedAt: "",
+};
+
+describe("useUpdateSlot", () => {
+  beforeEach(() => {
+    mockedUpdate.mockReset();
+    vi.mocked(toast.success).mockReset();
+    vi.mocked(toast.error).mockReset();
+  });
+
+  it("성공 시 toast.success를 호출한다", async () => {
+    mockedUpdate.mockResolvedValue(stubSlot);
+    const { result } = renderHook(() => useUpdateSlot(), { wrapper: makeWrapper() });
+
+    act(() => {
+      result.current.mutate({ ...params, body: { name: "새 이름" } });
+    });
+
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith("슬롯이 수정되었습니다."));
+  });
+
+  it("SLOT_NOT_EDITABLE 에러 시 전용 안내 메시지를 toast.error로 표시한다", async () => {
+    mockedUpdate.mockRejectedValue(new ApiRequestError(422, "SLOT_NOT_EDITABLE", "수정 불가"));
+    const { result } = renderHook(() => useUpdateSlot(), { wrapper: makeWrapper() });
+
+    act(() => {
+      result.current.mutate({ ...params, body: { name: "새 이름" } });
+    });
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(SLOT_ERROR_MESSAGES.SLOT_NOT_EDITABLE),
+    );
+  });
+
+  it("네트워크 오류 시 일반 실패 메시지를 toast.error로 표시한다", async () => {
+    mockedUpdate.mockRejectedValue(new Error("network error"));
+    const { result } = renderHook(() => useUpdateSlot(), { wrapper: makeWrapper() });
+
+    act(() => {
+      result.current.mutate({ ...params, body: { name: "새 이름" } });
+    });
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(SLOT_ERROR_MESSAGES.UPDATE_FAILED),
+    );
+  });
+});
+
+describe("useUpdateSlotStatus", () => {
+  beforeEach(() => {
+    mockedUpdateStatus.mockReset();
+    vi.mocked(toast.error).mockReset();
+  });
+
+  it("성공 시 toast.error를 호출하지 않는다", async () => {
+    mockedUpdateStatus.mockResolvedValue({ ...stubSlot, status: "INACTIVE" });
+    const { result } = renderHook(() => useUpdateSlotStatus(), { wrapper: makeWrapper() });
+
+    act(() => {
+      result.current.mutate({ ...params, status: "INACTIVE" });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it("오류 시 STATUS_FAILED 메시지를 toast.error로 표시한다", async () => {
+    mockedUpdateStatus.mockRejectedValue(new Error("fail"));
+    const { result } = renderHook(() => useUpdateSlotStatus(), { wrapper: makeWrapper() });
+
+    act(() => {
+      result.current.mutate({ ...params, status: "INACTIVE" });
+    });
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(SLOT_ERROR_MESSAGES.STATUS_FAILED),
+    );
+  });
+});

--- a/frontend/src/features/update-slot/api/messages.ts
+++ b/frontend/src/features/update-slot/api/messages.ts
@@ -1,0 +1,6 @@
+export const SLOT_ERROR_MESSAGES = {
+  SLOT_NOT_EDITABLE: "DRAFT 상태의 버전에서만 수정할 수 있습니다.",
+  NOT_FOUND: "슬롯을 찾을 수 없습니다.",
+  UPDATE_FAILED: "슬롯 수정에 실패했습니다.",
+  STATUS_FAILED: "상태 변경에 실패했습니다.",
+} as const;

--- a/frontend/src/features/update-slot/api/useGetSlot.ts
+++ b/frontend/src/features/update-slot/api/useGetSlot.ts
@@ -1,13 +1,15 @@
 import { useQuery } from "@tanstack/react-query";
 import { slotApi, slotKeys } from "@/entities/slot";
 
-export function useGetSlot(
-  workspaceId: number,
-  packId: number,
-  versionId: number,
-  slotId: number,
-  enabled: boolean,
-) {
+export interface UseGetSlotParams {
+  workspaceId: number;
+  packId: number;
+  versionId: number;
+  slotId: number;
+  enabled: boolean;
+}
+
+export function useGetSlot({ workspaceId, packId, versionId, slotId, enabled }: UseGetSlotParams) {
   return useQuery({
     queryKey: slotKeys.detail(workspaceId, packId, versionId, slotId),
     queryFn: () => slotApi.detail(workspaceId, packId, versionId, slotId),

--- a/frontend/src/features/update-slot/api/useGetSlot.ts
+++ b/frontend/src/features/update-slot/api/useGetSlot.ts
@@ -1,0 +1,16 @@
+import { useQuery } from "@tanstack/react-query";
+import { slotApi, slotKeys } from "@/entities/slot";
+
+export function useGetSlot(
+  workspaceId: number,
+  packId: number,
+  versionId: number,
+  slotId: number,
+  enabled: boolean,
+) {
+  return useQuery({
+    queryKey: slotKeys.detail(workspaceId, packId, versionId, slotId),
+    queryFn: () => slotApi.detail(workspaceId, packId, versionId, slotId),
+    enabled,
+  });
+}

--- a/frontend/src/features/update-slot/api/useUpdateSlot.ts
+++ b/frontend/src/features/update-slot/api/useUpdateSlot.ts
@@ -1,0 +1,38 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { slotApi, slotKeys } from "@/entities/slot";
+import type { UpdateSlotRequest } from "@/entities/slot";
+import { ApiRequestError } from "@/shared/api";
+import { SLOT_ERROR_MESSAGES } from "./messages";
+
+interface UpdateSlotParams {
+  workspaceId: number;
+  packId: number;
+  versionId: number;
+  slotId: number;
+  body: UpdateSlotRequest;
+}
+
+export function useUpdateSlot() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ workspaceId, packId, versionId, slotId, body }: UpdateSlotParams) =>
+      slotApi.update(workspaceId, packId, versionId, slotId, body),
+    onSuccess: (_, { workspaceId, packId, versionId, slotId }) => {
+      queryClient.invalidateQueries({
+        queryKey: slotKeys.detail(workspaceId, packId, versionId, slotId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: slotKeys.list(workspaceId, packId, versionId),
+      });
+      toast.success("슬롯이 수정되었습니다.");
+    },
+    onError: (error: unknown) => {
+      if (error instanceof ApiRequestError && error.code === "SLOT_NOT_EDITABLE") {
+        toast.error(SLOT_ERROR_MESSAGES.SLOT_NOT_EDITABLE);
+      } else {
+        toast.error(SLOT_ERROR_MESSAGES.UPDATE_FAILED);
+      }
+    },
+  });
+}

--- a/frontend/src/features/update-slot/api/useUpdateSlotStatus.ts
+++ b/frontend/src/features/update-slot/api/useUpdateSlotStatus.ts
@@ -1,0 +1,31 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { slotApi, slotKeys } from "@/entities/slot";
+import { SLOT_ERROR_MESSAGES } from "./messages";
+
+interface UpdateSlotStatusParams {
+  workspaceId: number;
+  packId: number;
+  versionId: number;
+  slotId: number;
+  status: "ACTIVE" | "INACTIVE";
+}
+
+export function useUpdateSlotStatus() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ workspaceId, packId, versionId, slotId, status }: UpdateSlotStatusParams) =>
+      slotApi.updateStatus(workspaceId, packId, versionId, slotId, { status }),
+    onSuccess: (_, { workspaceId, packId, versionId, slotId }) => {
+      queryClient.invalidateQueries({
+        queryKey: slotKeys.detail(workspaceId, packId, versionId, slotId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: slotKeys.list(workspaceId, packId, versionId),
+      });
+    },
+    onError: () => {
+      toast.error(SLOT_ERROR_MESSAGES.STATUS_FAILED);
+    },
+  });
+}

--- a/frontend/src/features/update-slot/api/useUpdateSlotStatus.ts
+++ b/frontend/src/features/update-slot/api/useUpdateSlotStatus.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { slotApi, slotKeys } from "@/entities/slot";
+import type { SlotDefinition, SlotSummary } from "@/entities/slot";
 import { SLOT_ERROR_MESSAGES } from "./messages";
 
 interface UpdateSlotStatusParams {
@@ -11,11 +12,37 @@ interface UpdateSlotStatusParams {
   status: "ACTIVE" | "INACTIVE";
 }
 
+export const UPDATE_SLOT_STATUS_MUTATION_KEY = ["updateSlotStatus"] as const;
+
 export function useUpdateSlotStatus() {
   const queryClient = useQueryClient();
   return useMutation({
+    mutationKey: UPDATE_SLOT_STATUS_MUTATION_KEY,
     mutationFn: ({ workspaceId, packId, versionId, slotId, status }: UpdateSlotStatusParams) =>
       slotApi.updateStatus(workspaceId, packId, versionId, slotId, { status }),
+    onMutate: async ({ workspaceId, packId, versionId, slotId, status }) => {
+      const detailKey = slotKeys.detail(workspaceId, packId, versionId, slotId);
+      const listKey = slotKeys.list(workspaceId, packId, versionId);
+
+      const previousDetail = queryClient.getQueryData<SlotDefinition>(detailKey);
+      const previousList = queryClient.getQueryData<SlotSummary[]>(listKey);
+
+      queryClient.setQueryData<SlotDefinition>(detailKey, (old) =>
+        old ? { ...old, status } : old,
+      );
+      queryClient.setQueryData<SlotSummary[]>(listKey, (old) =>
+        old?.map((item) => (item.id === slotId ? { ...item, status } : item)),
+      );
+
+      return { previousDetail, previousList, detailKey, listKey };
+    },
+    onError: (_err, _vars, context) => {
+      if (context) {
+        queryClient.setQueryData(context.detailKey, context.previousDetail);
+        queryClient.setQueryData(context.listKey, context.previousList);
+      }
+      toast.error(SLOT_ERROR_MESSAGES.STATUS_FAILED);
+    },
     onSuccess: (_, { workspaceId, packId, versionId, slotId }) => {
       queryClient.invalidateQueries({
         queryKey: slotKeys.detail(workspaceId, packId, versionId, slotId),
@@ -23,9 +50,6 @@ export function useUpdateSlotStatus() {
       queryClient.invalidateQueries({
         queryKey: slotKeys.list(workspaceId, packId, versionId),
       });
-    },
-    onError: () => {
-      toast.error(SLOT_ERROR_MESSAGES.STATUS_FAILED);
     },
   });
 }

--- a/frontend/src/features/update-slot/index.ts
+++ b/frontend/src/features/update-slot/index.ts
@@ -1,0 +1,2 @@
+export { SlotEditSheet } from "./ui/SlotEditSheet";
+export { SlotStatusToggle } from "./ui/SlotStatusToggle";

--- a/frontend/src/features/update-slot/model/schema.ts
+++ b/frontend/src/features/update-slot/model/schema.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+
+export const slotEditSchema = z.object({
+  name: z.string().trim().min(1, "슬롯 이름은 필수입니다."),
+  description: z.string().nullable().optional(),
+  isSensitive: z.boolean().optional(),
+  validationRuleJson: z.string().nullable().optional(),
+  defaultValueJson: z.string().nullable().optional(),
+  metaJson: z.string().nullable().optional(),
+});
+
+export type SlotEditFormValues = z.infer<typeof slotEditSchema>;

--- a/frontend/src/features/update-slot/ui/JsonTextarea.tsx
+++ b/frontend/src/features/update-slot/ui/JsonTextarea.tsx
@@ -1,0 +1,8 @@
+import { Textarea } from "@/shared/ui/textarea";
+import type { ComponentProps } from "react";
+
+type JsonTextareaProps = ComponentProps<typeof Textarea>;
+
+export function JsonTextarea(props: JsonTextareaProps) {
+  return <Textarea {...props} />;
+}

--- a/frontend/src/features/update-slot/ui/SlotEditForm.tsx
+++ b/frontend/src/features/update-slot/ui/SlotEditForm.tsx
@@ -1,11 +1,13 @@
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { useIsMutating } from "@tanstack/react-query";
 import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from "@/shared/ui/form";
 import { Input } from "@/shared/ui/input";
 import { Button } from "@/shared/ui/button";
 import { Switch } from "@/shared/ui/switch";
 import { slotEditSchema, type SlotEditFormValues } from "../model/schema";
 import { useUpdateSlot } from "../api/useUpdateSlot";
+import { UPDATE_SLOT_STATUS_MUTATION_KEY } from "../api/useUpdateSlotStatus";
 import { SlotStatusToggle } from "./SlotStatusToggle";
 import { SlotJsonFields } from "./SlotJsonFields";
 import type { SlotDefinition } from "@/entities/slot";
@@ -20,6 +22,8 @@ interface SlotEditFormProps {
 
 export function SlotEditForm({ slot, workspaceId, packId, versionId, onClose }: SlotEditFormProps) {
   const { mutate, isPending } = useUpdateSlot();
+  const isStatusPending = useIsMutating({ mutationKey: UPDATE_SLOT_STATUS_MUTATION_KEY }) > 0;
+  const isAnyPending = isPending || isStatusPending;
 
   const form = useForm<SlotEditFormValues>({
     resolver: zodResolver(slotEditSchema),
@@ -110,14 +114,15 @@ export function SlotEditForm({ slot, workspaceId, packId, versionId, onClose }: 
             versionId={versionId}
             slotId={slot.id}
             currentStatus={slot.status}
+            disabled={isAnyPending}
           />
         </div>
 
         <div className="flex gap-2 justify-end border-t pt-4">
-          <Button type="button" variant="outline" onClick={onClose} disabled={isPending}>
+          <Button type="button" variant="outline" onClick={onClose} disabled={isAnyPending}>
             취소
           </Button>
-          <Button type="submit" disabled={isPending}>
+          <Button type="submit" disabled={isAnyPending}>
             저장
           </Button>
         </div>

--- a/frontend/src/features/update-slot/ui/SlotEditForm.tsx
+++ b/frontend/src/features/update-slot/ui/SlotEditForm.tsx
@@ -6,8 +6,8 @@ import { Button } from "@/shared/ui/button";
 import { Switch } from "@/shared/ui/switch";
 import { slotEditSchema, type SlotEditFormValues } from "../model/schema";
 import { useUpdateSlot } from "../api/useUpdateSlot";
-import { JsonTextarea } from "./JsonTextarea";
 import { SlotStatusToggle } from "./SlotStatusToggle";
+import { SlotJsonFields } from "./SlotJsonFields";
 import type { SlotDefinition } from "@/entities/slot";
 
 interface SlotEditFormProps {
@@ -100,56 +100,7 @@ export function SlotEditForm({ slot, workspaceId, packId, versionId, onClose }: 
           )}
         />
 
-        <FormField
-          control={form.control}
-          name="validationRuleJson"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>유효성 검사 규칙 (JSON)</FormLabel>
-              <FormControl>
-                <JsonTextarea
-                  {...field}
-                  value={field.value ?? ""}
-                  onChange={(e) => field.onChange(e.target.value || null)}
-                />
-              </FormControl>
-            </FormItem>
-          )}
-        />
-
-        <FormField
-          control={form.control}
-          name="defaultValueJson"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>기본값 (JSON)</FormLabel>
-              <FormControl>
-                <JsonTextarea
-                  {...field}
-                  value={field.value ?? ""}
-                  onChange={(e) => field.onChange(e.target.value || null)}
-                />
-              </FormControl>
-            </FormItem>
-          )}
-        />
-
-        <FormField
-          control={form.control}
-          name="metaJson"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>메타 (JSON)</FormLabel>
-              <FormControl>
-                <JsonTextarea
-                  {...field}
-                  value={field.value ?? ""}
-                  onChange={(e) => field.onChange(e.target.value || null)}
-                />
-              </FormControl>
-            </FormItem>
-          )}
-        />
+        <SlotJsonFields />
 
         <div className="flex flex-row items-center justify-between border-t pt-4">
           <span className="text-sm font-medium leading-none">상태</span>

--- a/frontend/src/features/update-slot/ui/SlotEditForm.tsx
+++ b/frontend/src/features/update-slot/ui/SlotEditForm.tsx
@@ -1,0 +1,176 @@
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from "@/shared/ui/form";
+import { Input } from "@/shared/ui/input";
+import { Button } from "@/shared/ui/button";
+import { Switch } from "@/shared/ui/switch";
+import { slotEditSchema, type SlotEditFormValues } from "../model/schema";
+import { useUpdateSlot } from "../api/useUpdateSlot";
+import { JsonTextarea } from "./JsonTextarea";
+import { SlotStatusToggle } from "./SlotStatusToggle";
+import type { SlotDefinition } from "@/entities/slot";
+
+interface SlotEditFormProps {
+  slot: SlotDefinition;
+  workspaceId: number;
+  packId: number;
+  versionId: number;
+  onClose: () => void;
+}
+
+export function SlotEditForm({ slot, workspaceId, packId, versionId, onClose }: SlotEditFormProps) {
+  const { mutate, isPending } = useUpdateSlot();
+
+  const form = useForm<SlotEditFormValues>({
+    resolver: zodResolver(slotEditSchema),
+    defaultValues: {
+      name: slot.name,
+      description: slot.description,
+      isSensitive: slot.isSensitive,
+      validationRuleJson: slot.validationRuleJson,
+      defaultValueJson: slot.defaultValueJson,
+      metaJson: slot.metaJson,
+    },
+  });
+
+  const onSubmit = (values: SlotEditFormValues) => {
+    mutate(
+      { workspaceId, packId, versionId, slotId: slot.id, body: values },
+      { onSuccess: onClose },
+    );
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col gap-4 px-4 pb-4">
+        <FormField
+          control={form.control}
+          name="name"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>이름 *</FormLabel>
+              <FormControl>
+                <Input {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="description"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>설명</FormLabel>
+              <FormControl>
+                <Input
+                  {...field}
+                  value={field.value ?? ""}
+                  onChange={(e) => field.onChange(e.target.value || null)}
+                />
+              </FormControl>
+            </FormItem>
+          )}
+        />
+
+        <div className="grid gap-2">
+          <span className="text-sm font-medium leading-none">데이터 타입</span>
+          <Input value={slot.dataType} readOnly disabled />
+        </div>
+
+        <div className="grid gap-2">
+          <span className="text-sm font-medium leading-none">슬롯 코드</span>
+          <Input value={slot.slotCode} readOnly disabled />
+        </div>
+
+        <FormField
+          control={form.control}
+          name="isSensitive"
+          render={({ field }) => (
+            <FormItem className="flex flex-row items-center justify-between">
+              <FormLabel>민감 정보</FormLabel>
+              <FormControl>
+                <Switch
+                  checked={field.value ?? false}
+                  onCheckedChange={field.onChange}
+                />
+              </FormControl>
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="validationRuleJson"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>유효성 검사 규칙 (JSON)</FormLabel>
+              <FormControl>
+                <JsonTextarea
+                  {...field}
+                  value={field.value ?? ""}
+                  onChange={(e) => field.onChange(e.target.value || null)}
+                />
+              </FormControl>
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="defaultValueJson"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>기본값 (JSON)</FormLabel>
+              <FormControl>
+                <JsonTextarea
+                  {...field}
+                  value={field.value ?? ""}
+                  onChange={(e) => field.onChange(e.target.value || null)}
+                />
+              </FormControl>
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="metaJson"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>메타 (JSON)</FormLabel>
+              <FormControl>
+                <JsonTextarea
+                  {...field}
+                  value={field.value ?? ""}
+                  onChange={(e) => field.onChange(e.target.value || null)}
+                />
+              </FormControl>
+            </FormItem>
+          )}
+        />
+
+        <div className="flex flex-row items-center justify-between border-t pt-4">
+          <span className="text-sm font-medium leading-none">상태</span>
+          <SlotStatusToggle
+            workspaceId={workspaceId}
+            packId={packId}
+            versionId={versionId}
+            slotId={slot.id}
+            currentStatus={slot.status}
+          />
+        </div>
+
+        <div className="flex gap-2 justify-end border-t pt-4">
+          <Button type="button" variant="outline" onClick={onClose} disabled={isPending}>
+            취소
+          </Button>
+          <Button type="submit" disabled={isPending}>
+            저장
+          </Button>
+        </div>
+      </form>
+    </Form>
+  );
+}

--- a/frontend/src/features/update-slot/ui/SlotEditSheet.tsx
+++ b/frontend/src/features/update-slot/ui/SlotEditSheet.tsx
@@ -27,13 +27,13 @@ export function SlotEditSheet({
   isOpen,
   onClose,
 }: SlotEditSheetProps) {
-  const { data: slot, isLoading, isError, refetch } = useGetSlot(
+  const { data: slot, isLoading, isError, refetch } = useGetSlot({
     workspaceId,
     packId,
     versionId,
     slotId,
-    isOpen,
-  );
+    enabled: isOpen,
+  });
 
   return (
     <Sheet open={isOpen} onOpenChange={(open) => { if (!open) onClose(); }}>
@@ -60,7 +60,7 @@ export function SlotEditSheet({
           </div>
         )}
 
-        {slot && !isLoading && (
+        {slot && !isLoading && !isError && (
           <SlotEditForm
             slot={slot}
             workspaceId={workspaceId}

--- a/frontend/src/features/update-slot/ui/SlotEditSheet.tsx
+++ b/frontend/src/features/update-slot/ui/SlotEditSheet.tsx
@@ -1,0 +1,72 @@
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from "@/shared/ui/sheet";
+import { Spinner } from "@/shared/ui/spinner";
+import { useGetSlot } from "../api/useGetSlot";
+import { SlotEditForm } from "./SlotEditForm";
+
+interface SlotEditSheetProps {
+  workspaceId: number;
+  packId: number;
+  versionId: number;
+  slotId: number;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function SlotEditSheet({
+  workspaceId,
+  packId,
+  versionId,
+  slotId,
+  isOpen,
+  onClose,
+}: SlotEditSheetProps) {
+  const { data: slot, isLoading, isError } = useGetSlot(
+    workspaceId,
+    packId,
+    versionId,
+    slotId,
+    isOpen,
+  );
+
+  return (
+    <Sheet open={isOpen} onOpenChange={(open) => { if (!open) onClose(); }}>
+      <SheetContent side="right" className="w-full sm:max-w-md overflow-y-auto">
+        <SheetHeader className="px-4 pt-4">
+          <SheetTitle>
+            {slot ? `${slot.slotCode} · ${slot.name}` : "슬롯 수정"}
+          </SheetTitle>
+          <SheetDescription>슬롯 필드와 상태를 수정합니다.</SheetDescription>
+        </SheetHeader>
+
+        {isLoading && (
+          <div className="flex items-center justify-center py-12">
+            <Spinner className="size-6" />
+          </div>
+        )}
+
+        {isError && (
+          <div className="flex flex-col items-center justify-center gap-2 py-12 px-4 text-sm text-muted-foreground">
+            <span>슬롯 정보를 불러오지 못했습니다.</span>
+            <span>Sheet를 닫고 다시 시도해 주세요.</span>
+          </div>
+        )}
+
+        {slot && !isLoading && (
+          <SlotEditForm
+            slot={slot}
+            workspaceId={workspaceId}
+            packId={packId}
+            versionId={versionId}
+            onClose={onClose}
+          />
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/frontend/src/features/update-slot/ui/SlotEditSheet.tsx
+++ b/frontend/src/features/update-slot/ui/SlotEditSheet.tsx
@@ -6,6 +6,7 @@ import {
   SheetDescription,
 } from "@/shared/ui/sheet";
 import { Spinner } from "@/shared/ui/spinner";
+import { Button } from "@/shared/ui/button";
 import { useGetSlot } from "../api/useGetSlot";
 import { SlotEditForm } from "./SlotEditForm";
 
@@ -26,7 +27,7 @@ export function SlotEditSheet({
   isOpen,
   onClose,
 }: SlotEditSheetProps) {
-  const { data: slot, isLoading, isError } = useGetSlot(
+  const { data: slot, isLoading, isError, refetch } = useGetSlot(
     workspaceId,
     packId,
     versionId,
@@ -51,9 +52,11 @@ export function SlotEditSheet({
         )}
 
         {isError && (
-          <div className="flex flex-col items-center justify-center gap-2 py-12 px-4 text-sm text-muted-foreground">
+          <div className="flex flex-col items-center justify-center gap-4 py-12 px-4 text-sm text-muted-foreground">
             <span>슬롯 정보를 불러오지 못했습니다.</span>
-            <span>Sheet를 닫고 다시 시도해 주세요.</span>
+            <Button variant="outline" size="sm" onClick={() => refetch()}>
+              다시 시도
+            </Button>
           </div>
         )}
 

--- a/frontend/src/features/update-slot/ui/SlotJsonFields.tsx
+++ b/frontend/src/features/update-slot/ui/SlotJsonFields.tsx
@@ -1,0 +1,63 @@
+import { useFormContext } from "react-hook-form";
+import { FormField, FormItem, FormLabel, FormControl } from "@/shared/ui/form";
+import { JsonTextarea } from "./JsonTextarea";
+import type { SlotEditFormValues } from "../model/schema";
+
+export function SlotJsonFields() {
+  const { control } = useFormContext<SlotEditFormValues>();
+
+  return (
+    <>
+      <FormField
+        control={control}
+        name="validationRuleJson"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>유효성 검사 규칙 (JSON)</FormLabel>
+            <FormControl>
+              <JsonTextarea
+                {...field}
+                value={field.value ?? ""}
+                onChange={(e) => field.onChange(e.target.value || null)}
+              />
+            </FormControl>
+          </FormItem>
+        )}
+      />
+
+      <FormField
+        control={control}
+        name="defaultValueJson"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>기본값 (JSON)</FormLabel>
+            <FormControl>
+              <JsonTextarea
+                {...field}
+                value={field.value ?? ""}
+                onChange={(e) => field.onChange(e.target.value || null)}
+              />
+            </FormControl>
+          </FormItem>
+        )}
+      />
+
+      <FormField
+        control={control}
+        name="metaJson"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>메타 (JSON)</FormLabel>
+            <FormControl>
+              <JsonTextarea
+                {...field}
+                value={field.value ?? ""}
+                onChange={(e) => field.onChange(e.target.value || null)}
+              />
+            </FormControl>
+          </FormItem>
+        )}
+      />
+    </>
+  );
+}

--- a/frontend/src/features/update-slot/ui/SlotJsonFields.tsx
+++ b/frontend/src/features/update-slot/ui/SlotJsonFields.tsx
@@ -1,5 +1,5 @@
 import { useFormContext } from "react-hook-form";
-import { FormField, FormItem, FormLabel, FormControl } from "@/shared/ui/form";
+import { FormField, FormItem, FormLabel, FormControl, FormMessage } from "@/shared/ui/form";
 import { JsonTextarea } from "./JsonTextarea";
 import type { SlotEditFormValues } from "../model/schema";
 
@@ -21,6 +21,7 @@ export function SlotJsonFields() {
                 onChange={(e) => field.onChange(e.target.value || null)}
               />
             </FormControl>
+            <FormMessage />
           </FormItem>
         )}
       />
@@ -38,6 +39,7 @@ export function SlotJsonFields() {
                 onChange={(e) => field.onChange(e.target.value || null)}
               />
             </FormControl>
+            <FormMessage />
           </FormItem>
         )}
       />
@@ -55,6 +57,7 @@ export function SlotJsonFields() {
                 onChange={(e) => field.onChange(e.target.value || null)}
               />
             </FormControl>
+            <FormMessage />
           </FormItem>
         )}
       />

--- a/frontend/src/features/update-slot/ui/SlotStatusToggle.tsx
+++ b/frontend/src/features/update-slot/ui/SlotStatusToggle.tsx
@@ -1,0 +1,41 @@
+import { Switch } from "@/shared/ui/switch";
+import { useUpdateSlotStatus } from "../api/useUpdateSlotStatus";
+
+interface SlotStatusToggleProps {
+  workspaceId: number;
+  packId: number;
+  versionId: number;
+  slotId: number;
+  currentStatus: "ACTIVE" | "INACTIVE";
+  disabled?: boolean;
+}
+
+export function SlotStatusToggle({
+  workspaceId,
+  packId,
+  versionId,
+  slotId,
+  currentStatus,
+  disabled,
+}: SlotStatusToggleProps) {
+  const { mutate, isPending } = useUpdateSlotStatus();
+
+  const handleCheckedChange = (checked: boolean) => {
+    mutate({
+      workspaceId,
+      packId,
+      versionId,
+      slotId,
+      status: checked ? "ACTIVE" : "INACTIVE",
+    });
+  };
+
+  return (
+    <Switch
+      aria-label="슬롯 상태"
+      checked={currentStatus === "ACTIVE"}
+      onCheckedChange={handleCheckedChange}
+      disabled={disabled || isPending}
+    />
+  );
+}


### PR DESCRIPTION
## Summary

- `features/update-slot` 슬라이스 신규 구현: `SlotEditSheet`, `SlotEditForm`, `SlotStatusToggle` 및 관련 hooks
- `entities/slot` 슬라이스 신규 구현: 타입 정의 + API 함수 + `slotKeys`
- `app/providers.tsx`에 `QueryClientProvider` 추가 (TanStack Query 전역 등록)
- Vitest 통합 테스트 5개 추가 (audit V-002 fix)
- `SlotJsonFields.tsx` 서브컴포넌트 추출 (audit V-001 fix)
- 에러 상태에 `refetch` 버튼 추가 (audit V-003 fix)

---

## Context

Spec 321은 Domain Pack 버전 상세 화면 내 슬롯 목록의 인라인 Status 토글과 Side Sheet 기반 슬롯 필드 수정 기능을 구현하는 FE 스펙이다. BE API(GET/PATCH slot, PATCH status)는 이미 구현 완료 상태였고, 이번 PR은 FE 레이어(entities + feature)만 대상으로 한다.

---

## What Changed

| 파일 | 변경 |
|------|------|
| `entities/slot/model/types.ts` | `SlotDefinition`, `SlotSummary`, 요청 타입 정의 |
| `entities/slot/api/index.ts` | API 함수 + `slotKeys` |
| `entities/slot/index.ts` | barrel export |
| `features/update-slot/model/schema.ts` | `slotEditSchema` (zod, name 필수) |
| `features/update-slot/api/useGetSlot.ts` | GET slot — `enabled: isOpen` 조건부 쿼리 |
| `features/update-slot/api/useUpdateSlot.ts` | PATCH fields — onSuccess invalidate + toast |
| `features/update-slot/api/useUpdateSlotStatus.ts` | PATCH status — onSuccess invalidate |
| `features/update-slot/api/messages.ts` | 에러 메시지 상수 (`SLOT_ERROR_MESSAGES`) |
| `features/update-slot/ui/SlotEditSheet.tsx` | Sheet 진입점, loading/error/form 3종 상태 |
| `features/update-slot/ui/SlotEditForm.tsx` | react-hook-form + zod, read-only 필드 포함 |
| `features/update-slot/ui/SlotStatusToggle.tsx` | 인라인 및 폼 내 재사용 toggle |
| `features/update-slot/ui/JsonTextarea.tsx` | JSON 필드용 Textarea wrapper |
| `features/update-slot/ui/SlotJsonFields.tsx` | JSON 3개 FormField 묶음 서브컴포넌트 (V-001 fix) |
| `features/update-slot/index.ts` | barrel export |
| `features/update-slot/api/__tests__/useUpdateSlot.test.ts` | 통합 테스트 5개 (V-002 fix) |
| `app/providers.tsx` | `QueryClientProvider` 추가 |
| `app/index.tsx` | `AppProviders`로 최상위 래핑 |

---

## Assumptions Adopted

| ID |가정 | 영향 |
|----|------|------|
| UR-003 | 에러 메시지 텍스트를 `messages.ts`의 `SLOT_ERROR_MESSAGES` 상수로 분리 | 텍스트 변경 시 단일 파일 수정으로 일괄 반영 가능. 기획/UX 확정 전이므로 추후 변경 가능성 있음. |
| UR-005 | `JsonTextarea.tsx`를 단순 Textarea wrapper로 구현 | 추후 JSON Editor 라이브러리 도입 시 이 파일만 교체. 폼 내 JSON 파싱 로직 없음. |
| UR-006 | `@tanstack/react-query` v5.100.1이 이미 설치돼 있어 `pnpm add` 생략 | spec 전제 조건(`pnpm add @tanstack/react-query`)은 이미 충족 상태. `QueryClientProvider`는 신규 추가. |
| UR-007 | `defaultValues`는 Sheet open 시점에 고정 | status toggle 후 refetch로 slot 데이터가 바뀌어도 폼 필드 값은 재설정되지 않음. 의도된 동작(편집 중 덮어쓰기 방지). |

---

## Spec Deviations

| 항목 | spec | 구현 |
|------|------|------|
| `messages.ts` | 명시 없음 | UR-003 assumption으로 신규 추가 |
| `JsonTextarea.tsx` | spec §Done Criteria에 "JsonTextarea wrapper 컴포넌트"로 언급 | 구현됨 (spec과 일치) |
| `SlotJsonFields.tsx` | 명시 없음 | V-001 audit fix로 신규 추출 |
| `__tests__/useUpdateSlot.test.ts` | spec §Tests에 명시됨 | V-002 audit fix로 추가 |
| `SlotEditSheet.tsx` 에러 블록 | "재시도 가능" 명시 | 초기 구현에 재시도 버튼 없음 → V-003 audit fix로 `refetch` 버튼 추가 |

---

## Blocked / Skipped Items

| 항목 | 이유 |
|------|------|
| `SlotListSection`, `SlotListItem` | 이 스펙 범위 외 (부모 페이지 스펙에서 처리) |
| `DomainPackVersionDetailPage`, `EditButton` | 이 스펙 범위 외 |
| `SlotStatusToggle` 인라인 연결 | 부모 페이지 스펙 구현 시 `workspaceId`, `packId`, `versionId`, `slotId`, `currentStatus` props를 전달해야 함 |

---

## Test Notes

**Vitest 통합 테스트** (`features/update-slot/api/__tests__/useUpdateSlot.test.ts`):

| 테스트 | 대상 | 결과 |
|--------|------|------|
| 슬롯 수정 성공 | `useUpdateSlot` | PASS |
| SLOT_NOT_EDITABLE 에러 | `useUpdateSlot` | PASS |
| 네트워크 오류 | `useUpdateSlot` | PASS |
| 상태 변경 성공 | `useUpdateSlotStatus` | PASS |
| 상태 변경 오류 | `useUpdateSlotStatus` | PASS |

- 도구: `QueryClient` wrapper + `vi.mock` 패턴
- 수동 브라우저 테스트: 감사 보고서에서 빌드 성공 확인 (코드 import/타입 정합성 기준)

---

## Reviewer Focus

1. **`app/providers.tsx` — QueryClientProvider 추가**: 기존 코드(intent, workflow feature)는 custom fetch hook 패턴을 사용 중. `QueryClientProvider` 추가로 공존 가능 여부 확인 필요.
2. **`SlotStatusToggle` 재사용성**: 인라인(SlotListItem)과 폼 내(SlotEditForm) 두 곳에서 동일 컴포넌트 사용. props 계약(`workspaceId`, `packId`, `versionId`, `slotId`, `currentStatus`) 확인.
3. **`SlotEditSheet` 에러 UX**: GET slot 실패 시 Sheet 유지 + `refetch()` 버튼 표시. `useQuery` retry(3회) 소진 후 수동 재시도 트리거.
4. **`I-001` `text-muted-foreground` 클래스**: DESIGN.md "모노크롬만 사용" 요건과 잠재적 충돌. 기존 shared/ui 컴포넌트가 동일 변수를 사용 중이면 전체 프로젝트 범위 이슈 — 이번 PR 단독 문제는 아님.
5. **`I-002` QueryClient 모듈 레벨 인스턴스**: 테스트 환경에서 전역 상태 공유 이슈 가능성. 현재 테스트 파일은 자체 QueryClient를 래핑하므로 즉각 문제는 없음.

---

## Conflicts

없음. 모든 uncertainty가 execution rule에 따라 처리됐고, user decision이 필요한 항목 없음.

---

## Ready to Merge / Needs Input

**Ready to Merge** — audit PASS, 3건 warning 모두 auto-fix 완료, user decision 필요 항목 없음.

단, 부모 페이지 스펙(`SlotListSection`, `SlotListItem`, `DomainPackVersionDetailPage`) 구현 전까지 이 PR의 컴포넌트는 실제 화면에 노출되지 않음.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 슬롯 편집 기능 추가: 이름, 설명, JSON 설정 필드 수정 가능
  * 슬롯 상태 토글 기능 추가: 활성/비활성 상태 변경 지원
  * 슬롯 데이터 조회 및 캐싱 시스템 구현
  * 편집 시 오류 처리 및 사용자 피드백 추가

* **Tests**
  * 슬롯 업데이트 훅 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->