### PR TITLE
spec/324: [FE] Workflow Node / Edge 수정 기능 구현

### DIFF
--- a/.agent/specs/324.md
+++ b/.agent/specs/324.md
@@ -248,38 +248,40 @@ WorkflowEditSheet
 
 ## 수정 대상 파일
 
+> **경로 기준**: 아래 모든 경로는 `frontend/` 루트 기준 상대 경로다.
+
 ### 신규 생성
 
 | 파일 | 설명 |
 |------|------|
-| `src/entities/workflow/api/index.ts` | `workflowKeys`, `fetchWorkflow`, `patchWorkflow` API 함수 |
-| `src/entities/workflow/lib/graphConverter.ts` | ReactFlow nodes/edges → `WorkflowGraph` 필드 매핑 공유 유틸 (`convertFlowToWorkflowGraph`) |
-| `src/features/update-workflow/model/schema.ts` | zod schema (name 필수 검사) |
-| `src/features/update-workflow/api/useGetWorkflow.ts` | GET workflow useQuery hook |
-| `src/features/update-workflow/api/useUpdateWorkflow.ts` | PATCH workflow useMutation hook |
-| `src/features/update-workflow/ui/WorkflowEditSheet.tsx` | Side sheet 진입점 |
-| `src/features/update-workflow/ui/WorkflowEditForm.tsx` | react-hook-form 기반 편집 폼 |
-| `src/features/update-workflow/ui/InteractiveGraphEditor.tsx` | @xyflow/react 기반 편집기 |
-| `src/features/update-workflow/ui/graphToWorkflow.ts` | ReactFlow → WorkflowGraph 변환 유틸 (`graphConverter` 래퍼) |
-| `src/features/update-workflow/ui/AddNodeToolbar.tsx` | 노드 타입 선택 + 추가 버튼 툴바 |
-| `src/features/update-workflow/ui/nodes/EditableStartNode.tsx` | 편집 가능 START 노드 |
-| `src/features/update-workflow/ui/nodes/EditableActionNode.tsx` | 편집 가능 ACTION 노드 (label + policyRef) |
-| `src/features/update-workflow/ui/nodes/EditableDecisionNode.tsx` | 편집 가능 DECISION 노드 |
-| `src/features/update-workflow/ui/nodes/EditableAnswerNode.tsx` | 편집 가능 ANSWER 노드 |
-| `src/features/update-workflow/ui/nodes/EditableHandoffNode.tsx` | 편집 가능 HANDOFF 노드 |
-| `src/features/update-workflow/ui/nodes/EditableTerminalNode.tsx` | 편집 가능 TERMINAL 노드 |
-| `src/features/update-workflow/index.ts` | barrel export |
+| `frontend/src/entities/workflow/api/index.ts` | `workflowKeys`, `fetchWorkflow`, `patchWorkflow` API 함수 |
+| `frontend/src/entities/workflow/lib/graphConverter.ts` | ReactFlow nodes/edges → `WorkflowGraph` 필드 매핑 공유 유틸 (`convertFlowToWorkflowGraph`) |
+| `frontend/src/features/update-workflow/model/schema.ts` | zod schema (name 필수 검사) |
+| `frontend/src/features/update-workflow/api/useGetWorkflow.ts` | GET workflow useQuery hook |
+| `frontend/src/features/update-workflow/api/useUpdateWorkflow.ts` | PATCH workflow useMutation hook |
+| `frontend/src/features/update-workflow/ui/WorkflowEditSheet.tsx` | Side sheet 진입점 |
+| `frontend/src/features/update-workflow/ui/WorkflowEditForm.tsx` | react-hook-form 기반 편집 폼 |
+| `frontend/src/features/update-workflow/ui/InteractiveGraphEditor.tsx` | @xyflow/react 기반 편집기 |
+| `frontend/src/features/update-workflow/ui/graphToWorkflow.ts` | ReactFlow → WorkflowGraph 변환 유틸 (`graphConverter` 래퍼) |
+| `frontend/src/features/update-workflow/ui/AddNodeToolbar.tsx` | 노드 타입 선택 + 추가 버튼 툴바 |
+| `frontend/src/features/update-workflow/ui/nodes/EditableStartNode.tsx` | 편집 가능 START 노드 |
+| `frontend/src/features/update-workflow/ui/nodes/EditableActionNode.tsx` | 편집 가능 ACTION 노드 (label + policyRef) |
+| `frontend/src/features/update-workflow/ui/nodes/EditableDecisionNode.tsx` | 편집 가능 DECISION 노드 |
+| `frontend/src/features/update-workflow/ui/nodes/EditableAnswerNode.tsx` | 편집 가능 ANSWER 노드 |
+| `frontend/src/features/update-workflow/ui/nodes/EditableHandoffNode.tsx` | 편집 가능 HANDOFF 노드 |
+| `frontend/src/features/update-workflow/ui/nodes/EditableTerminalNode.tsx` | 편집 가능 TERMINAL 노드 |
+| `frontend/src/features/update-workflow/index.ts` | barrel export |
 
 ### 수정 (기존 파일)
 
 | 파일 | 변경 내용 |
 |------|----------|
-| `src/entities/workflow/model/types.ts` | `graph` → `graphJson` rename, `GraphEdge.id` 추가, `GraphNode.policyRef?` 추가, `UpdateWorkflowRequest` 추가 |
-| `src/entities/workflow/index.ts` | 신규 export 추가 (`workflowKeys`, `UpdateWorkflowRequest`) |
-| `src/features/workflow-draft-read/ui/WorkflowDetailPanel.tsx` | `detail.graph` → `detail.graphJson` |
-| `src/features/workflow-draft-read/ui/GraphRenderer.tsx` | `WorkflowDetail` props 타입 반영 (필요 시) |
-| `src/features/workflow-draft-read/ui/graphMapper.ts` | `edge.id` 사용 (기존 자체 생성 ID → `e.id` 사용), `toFlow` 반환 엣지 id 수정; `toFlow`의 역방향 변환이 필요한 경우 `graphConverter.convertFlowToWorkflowGraph` 재사용 |
-| `src/features/workflow-draft-read/ui/graphMapper.test.ts` | edge ID 형식 변경에 따른 테스트 업데이트 |
+| `frontend/src/entities/workflow/model/types.ts` | `graph` → `graphJson` rename, `GraphEdge.id` 추가, `GraphNode.policyRef?` 추가, `UpdateWorkflowRequest` 추가 |
+| `frontend/src/entities/workflow/index.ts` | 신규 export 추가 (`workflowKeys`, `UpdateWorkflowRequest`) |
+| `frontend/src/features/workflow-draft-read/ui/WorkflowDetailPanel.tsx` | `detail.graph` → `detail.graphJson` |
+| `frontend/src/features/workflow-draft-read/ui/GraphRenderer.tsx` | `WorkflowDetail` props 타입 반영 (필요 시) |
+| `frontend/src/features/workflow-draft-read/ui/graphMapper.ts` | `edge.id` 사용 (기존 자체 생성 ID → `e.id` 사용), `toFlow` 반환 엣지 id 수정; `toFlow`의 역방향 변환이 필요한 경우 `graphConverter.convertFlowToWorkflowGraph` 재사용 |
+| `frontend/src/features/workflow-draft-read/ui/graphMapper.test.ts` | edge ID 형식 변경에 따른 테스트 업데이트 |
 
 ---
 
@@ -328,6 +330,8 @@ export function useUpdateWorkflow() {
         WORKFLOW_UNLABELED_BRANCH: 'DECISION 노드의 모든 분기에 label이 필요합니다.',
         WORKFLOW_ACTION_NODE_POLICY_REF_MISSING: 'ACTION 노드의 policyRef 값이 필요합니다.',
         WORKFLOW_ACTION_NODE_POLICY_REF_INVALID_CHARS: 'ACTION 노드의 policyRef 형식이 유효하지 않습니다.',
+        WORKFLOW_EDGE_ID_MISSING: '그래프 구조가 유효하지 않습니다.',
+        WORKFLOW_EDGE_ID_DUPLICATE: '그래프 구조가 유효하지 않습니다.',
       };
       toast.error(errorMessages[error.code] ?? '워크플로우 수정에 실패했습니다.');
     },

--- a/.agent/specs/324.md
+++ b/.agent/specs/324.md
@@ -1,0 +1,541 @@
+# Spec 324 — [Console] Workflow Node / Edge 수정 기능 구현
+
+**Branch**: `spec/324`
+**Canonical Number**: `324`
+**Type**: Frontend (FSD)
+**작성일**: 2026-04-24
+**최종 업데이트**: 2026-04-24 (Q1-Q4 결정 확정)
+
+---
+
+## Goal
+
+운영자가 Domain Pack 버전 상세 화면 내 워크플로우 상세 영역에서, Side Sheet를 통해 워크플로우의 `name`, `description`, 그래프(노드/엣지)를 `@xyflow/react` 인터랙티브 편집기로 수정하고 저장할 수 있는 기능을 구현한다.
+
+---
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A[WorkflowEditSheet 열기\nisOpen=true, workflowId 전달] --> B[useGetWorkflow 호출\nenabled: isOpen]
+    B -->|loading| C[Spinner 표시]
+    B -->|error| D[에러 메시지 + 재시도 버튼\nSheet 유지 - Sheet 닫기 금지]
+    B -->|success| E[WorkflowEditForm 렌더링\ndefaultValues 채움]
+
+    E --> F[InteractiveGraphEditor\nReactFlow editable mode]
+    F --> G{사용자 액션}
+
+    G -->|노드 label 클릭| H[인라인 Input 편집]
+    G -->|ACTION 노드 policyRef 클릭| I[policyRef 인라인 Input 편집]
+    G -->|노드 추가 버튼| J[타입 선택 → 신규 노드 캔버스 배치\n빈 label 기본값]
+    G -->|노드 삭제| K[NodeToolbar 삭제 버튼 또는\nDelete 키 — 연결 엣지 함께 삭제]
+    G -->|Handle 드래그| L[새 엣지 생성\nonConnect — 고유 id auto-generate]
+    G -->|엣지 label 클릭| M[label 인라인 Popover 편집]
+    G -->|엣지 삭제| N[엣지 선택 후 Delete 키 또는\n삭제 버튼]
+    G -->|name / description 수정| O[FormField 텍스트 편집]
+
+    G -->|저장 버튼| P{name 유효성 검사 — zod}
+    P -->|실패 - name blank| Q[FormMessage 인라인 에러\nAPI 호출 안 됨]
+    P -->|통과| R[toWorkflowGraph 변환\nuseUpdateWorkflow.mutate]
+    R -->|성공| S[toast.success + Sheet 닫기\nworkflowKeys.detail + workflowKeys.list 무효화]
+    R -->|WORKFLOW_NOT_EDITABLE| T[toast.error 버전 DRAFT 아님]
+    R -->|그래프 검증 오류 V1-V8c| U[toast.error 해당 규칙 메시지]
+    R -->|기타 실패| V[toast.error]
+
+    G -->|취소| W[Sheet 닫기 - 변경 없음]
+```
+
+---
+
+## Design Diff
+
+### As-is vs To-be
+
+| 영역 | As-is | To-be | 변경 내용 |
+|------|-------|-------|----------|
+| 워크플로우 수정 기능 | 없음 | `WorkflowEditSheet` (side sheet) | 신규 구현 |
+| 그래프 편집 UI | Read-only `GraphRenderer` | `InteractiveGraphEditor` (editable ReactFlow) | 신규 구현 |
+| `entities/workflow` 타입 | `graph` 필드명, `GraphEdge.id` 없음, `GraphNode.policyRef` 없음 | `graphJson` 필드명, `GraphEdge.id` 추가, `GraphNode.policyRef?` 추가 | **기존 코드 파괴적 수정** |
+| `workflow-draft-read` | `detail.graph` 참조 | `detail.graphJson` 참조 | 타입 수정 후 동반 수정 필수 |
+| `entities/workflow/api` | 없음 | `workflowKeys` + API 함수 | 신규 구현 |
+
+---
+
+## Prerequisites
+
+### 타입 수정 선행 필수 (기존 코드 파괴)
+
+이 스펙을 구현하기 전에 `entities/workflow/model/types.ts`를 수정해야 하며,
+수정 후 `features/workflow-draft-read` 코드가 컴파일 에러가 발생한다. 동반 수정이 필수다.
+
+### BE API (모두 구현 완료)
+
+| Method | Path | 설명 | 응답 타입 |
+|--------|------|------|-----------|
+| GET | `.../workflows` | 목록 조회 | `WorkflowSummary[]` |
+| GET | `.../workflows/{workflowId}` | 단건 조회 | `WorkflowDefinitionDetail` |
+| PATCH | `.../workflows/{workflowId}` | 필드 + 그래프 수정 | `WorkflowDefinitionDetail` |
+
+공통 path prefix: `/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}`
+
+PATCH request body:
+```json
+{
+  "name": "...",
+  "description": "...",
+  "graphJson": { "direction": "LR", "nodes": [...], "edges": [...] }
+}
+```
+
+PATCH 에러 코드:
+
+| 코드 | 조건 | FE toast 메시지 |
+|------|------|----------------|
+| `WORKFLOW_NOT_EDITABLE` | 버전이 DRAFT 아님 | `DRAFT 상태의 버전에서만 수정할 수 있습니다.` |
+| `GRAPH_JSON_TOO_LARGE` | graphJson > 100,000자 | `그래프 데이터가 너무 큽니다.` |
+| `WORKFLOW_INVALID_START_NODE` | START 노드 ≠ 1개 | `START 노드가 정확히 1개여야 합니다.` |
+| `WORKFLOW_INVALID_TERMINAL_NODE` | TERMINAL 노드 0개 | `TERMINAL 노드가 최소 1개 필요합니다.` |
+| `WORKFLOW_DANGLING_EDGE` | 엣지 끝점 노드 없음 | `엣지의 연결 대상 노드가 존재하지 않습니다.` |
+| `WORKFLOW_UNREACHABLE_NODE` | START에서 도달 불가 노드 | `모든 노드가 START에서 도달 가능해야 합니다.` |
+| `WORKFLOW_CYCLE_DETECTED` | 사이클 존재 | `그래프에 순환 경로가 있습니다.` |
+| `WORKFLOW_UNLABELED_BRANCH` | DECISION 발신 엣지 label 없음 | `DECISION 노드의 모든 분기에 label이 필요합니다.` |
+| `WORKFLOW_EDGE_ID_MISSING` | 엣지 id 없음 | `그래프 구조가 유효하지 않습니다.` |
+| `WORKFLOW_EDGE_ID_DUPLICATE` | 엣지 id 중복 | `그래프 구조가 유효하지 않습니다.` |
+| `WORKFLOW_ACTION_NODE_POLICY_REF_MISSING` | ACTION policyRef 없음 | `ACTION 노드의 policyRef 값이 필요합니다.` |
+| `WORKFLOW_ACTION_NODE_POLICY_REF_INVALID_CHARS` | policyRef 패턴 불일치 | `ACTION 노드의 policyRef 형식이 유효하지 않습니다.` |
+| 기타 | — | `워크플로우 수정에 실패했습니다.` |
+
+---
+
+## Component Tree
+
+```
+[부모: DomainPackVersionDetailPage — 별도 스펙 범위]
+└── WorkflowEditSheet ← [이 스펙 범위]
+     ├── SheetHeader (workflowCode + name 표시)
+     ├── [로딩 상태: Spinner]
+     ├── [에러 상태: 에러 메시지 + 재시도 버튼]
+     └── WorkflowEditForm
+          ├── NameInput (required, @NotBlank)
+          ├── DescriptionInput (optional)
+          ├── WorkflowCodeField (read-only)
+          ├── InteractiveGraphEditor ← 핵심 컴포넌트
+          │    ├── AddNodeToolbar (노드 타입 선택 + 추가 버튼)
+          │    └── ReactFlow (editable)
+          │         ├── EditableStartNode (label 편집)
+          │         ├── EditableActionNode (label + policyRef 편집)
+          │         ├── EditableDecisionNode (label 편집)
+          │         ├── EditableAnswerNode (label 편집)
+          │         ├── EditableHandoffNode (label 편집)
+          │         └── EditableTerminalNode (label 편집)
+          └── SheetFooter
+               ├── 저장 버튼 (PATCH fields + graph)
+               └── 취소 버튼 (Sheet 닫기)
+```
+
+**이 스펙(324) 직접 구현 범위**: `WorkflowEditSheet`, `WorkflowEditForm`, `InteractiveGraphEditor`, 편집 가능 노드 컴포넌트 6종, 관련 hooks, `entities/workflow` 타입·API 추가, `workflow-draft-read` 동반 수정
+
+**이 스펙 범위 외**: 편집 버튼 / 트리거 연결 (부모 페이지 스펙에서 처리), `WorkflowListPanel`/`WorkflowDetailPanel` 편집 진입점 추가
+
+---
+
+## API Integration
+
+### Query Key Pattern
+
+```typescript
+// entities/workflow/api/index.ts  (신규)
+export const workflowKeys = {
+  all: ['workflows'] as const,
+  lists: () => [...workflowKeys.all, 'list'] as const,
+  list: (wsId: number, packId: number, versionId: number) =>
+    [...workflowKeys.lists(), wsId, packId, versionId] as const,
+  detail: (wsId: number, packId: number, versionId: number, workflowId: number) =>
+    [...workflowKeys.all, 'detail', wsId, packId, versionId, workflowId] as const,
+};
+```
+
+### Request / Response 타입
+
+```typescript
+// entities/workflow/model/types.ts — 수정·추가
+
+export type GraphNodeType = 'START' | 'ACTION' | 'DECISION' | 'ANSWER' | 'HANDOFF' | 'TERMINAL';
+
+export interface GraphNode {
+  id: string;
+  label: string;
+  type: GraphNodeType;
+  policyRef?: string; // ADD: ACTION 노드 필수, 나머지 undefined
+}
+
+export interface GraphEdge {
+  id: string;        // ADD: V7a/V7b 검증 필수
+  from: string;
+  to: string;
+  label?: string;
+}
+
+export interface WorkflowGraph {
+  direction: 'LR' | 'TB';
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+}
+
+export interface WorkflowSummary {
+  id: number;
+  workflowCode: string;
+  name: string;
+  description: string | null;
+  initialState: string | null;
+  terminalStatesJson: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface WorkflowDetail {
+  id: number;
+  workflowCode: string;
+  name: string;
+  description: string | null;
+  graphJson: WorkflowGraph; // RENAME: 기존 `graph` → `graphJson` (BE 응답 필드명 일치)
+  initialState: string | null;
+  terminalStatesJson: string;
+  evidenceJson: string;
+  metaJson: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// PATCH request body
+export interface UpdateWorkflowRequest {
+  name: string;
+  description?: string | null;
+  graphJson: WorkflowGraph;
+}
+```
+
+---
+
+## Data Flow
+
+```
+[Parent: DomainPackVersionDetailPage]
+    │  props: { wsId, packId, versionId, workflowId, isOpen, onClose }
+    ▼
+WorkflowEditSheet
+    │  useGetWorkflow(wsId, packId, versionId, workflowId, enabled: isOpen)
+    ├── [loading] → Spinner
+    ├── [error]   → 에러 상태 표시 (Sheet 유지, 재시도 가능)
+    └── [success] → WorkflowEditForm (defaultValues = workflow data)
+                        │  react-hook-form + zod resolver (name 필드)
+                        │  InteractiveGraphEditor
+                        │     useNodesState(initialNodes)
+                        │     useEdgesState(initialEdges)
+                        │     onConnect → 신규 엣지 추가 (crypto.randomUUID() id)
+                        │     노드 label/policyRef 인라인 편집
+                        │  저장 버튼
+                        │     → toWorkflowGraph(nodes, edges, direction)
+                        │     → useUpdateWorkflow.mutate({ wsId, packId, versionId, workflowId, body })
+                        │     → onSuccess: toast.success + onClose + invalidate
+                        │     → onError: 에러 코드별 toast.error
+                        └── 취소 → onClose
+```
+
+---
+
+## 수정 대상 파일
+
+### 신규 생성
+
+| 파일 | 설명 |
+|------|------|
+| `src/entities/workflow/api/index.ts` | `workflowKeys`, `fetchWorkflow`, `patchWorkflow` API 함수 |
+| `src/features/update-workflow/model/schema.ts` | zod schema (name 필수 검사) |
+| `src/features/update-workflow/api/useGetWorkflow.ts` | GET workflow useQuery hook |
+| `src/features/update-workflow/api/useUpdateWorkflow.ts` | PATCH workflow useMutation hook |
+| `src/features/update-workflow/ui/WorkflowEditSheet.tsx` | Side sheet 진입점 |
+| `src/features/update-workflow/ui/WorkflowEditForm.tsx` | react-hook-form 기반 편집 폼 |
+| `src/features/update-workflow/ui/InteractiveGraphEditor.tsx` | @xyflow/react 기반 편집기 |
+| `src/features/update-workflow/ui/graphToWorkflow.ts` | ReactFlow → WorkflowGraph 변환 유틸 |
+| `src/features/update-workflow/ui/AddNodeToolbar.tsx` | 노드 타입 선택 + 추가 버튼 툴바 |
+| `src/features/update-workflow/ui/nodes/EditableStartNode.tsx` | 편집 가능 START 노드 |
+| `src/features/update-workflow/ui/nodes/EditableActionNode.tsx` | 편집 가능 ACTION 노드 (label + policyRef) |
+| `src/features/update-workflow/ui/nodes/EditableDecisionNode.tsx` | 편집 가능 DECISION 노드 |
+| `src/features/update-workflow/ui/nodes/EditableAnswerNode.tsx` | 편집 가능 ANSWER 노드 |
+| `src/features/update-workflow/ui/nodes/EditableHandoffNode.tsx` | 편집 가능 HANDOFF 노드 |
+| `src/features/update-workflow/ui/nodes/EditableTerminalNode.tsx` | 편집 가능 TERMINAL 노드 |
+| `src/features/update-workflow/index.ts` | barrel export |
+
+### 수정 (기존 파일)
+
+| 파일 | 변경 내용 |
+|------|----------|
+| `src/entities/workflow/model/types.ts` | `graph` → `graphJson` rename, `GraphEdge.id` 추가, `GraphNode.policyRef?` 추가, `UpdateWorkflowRequest` 추가 |
+| `src/entities/workflow/index.ts` | 신규 export 추가 (`workflowKeys`, `UpdateWorkflowRequest`) |
+| `src/features/workflow-draft-read/ui/WorkflowDetailPanel.tsx` | `detail.graph` → `detail.graphJson` |
+| `src/features/workflow-draft-read/ui/GraphRenderer.tsx` | `WorkflowDetail` props 타입 반영 (필요 시) |
+| `src/features/workflow-draft-read/ui/graphMapper.ts` | `edge.id` 사용 (기존 자체 생성 ID → `e.id` 사용), `toFlow` 반환 엣지 id 수정 |
+| `src/features/workflow-draft-read/ui/graphMapper.test.ts` | edge ID 형식 변경에 따른 테스트 업데이트 |
+
+---
+
+## State Management
+
+### Server State (TanStack Query)
+
+```typescript
+// features/update-workflow/api/useGetWorkflow.ts
+export function useGetWorkflow(
+  wsId: number,
+  packId: number,
+  versionId: number,
+  workflowId: number,
+  enabled: boolean,
+) {
+  return useQuery({
+    queryKey: workflowKeys.detail(wsId, packId, versionId, workflowId),
+    queryFn: () => fetchWorkflow(wsId, packId, versionId, workflowId),
+    enabled,
+  });
+}
+```
+
+```typescript
+// features/update-workflow/api/useUpdateWorkflow.ts
+export function useUpdateWorkflow() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ wsId, packId, versionId, workflowId, body }: UpdateWorkflowParams) =>
+      patchWorkflow(wsId, packId, versionId, workflowId, body),
+    onSuccess: (_, { wsId, packId, versionId, workflowId }) => {
+      queryClient.invalidateQueries({ queryKey: workflowKeys.detail(wsId, packId, versionId, workflowId) });
+      queryClient.invalidateQueries({ queryKey: workflowKeys.list(wsId, packId, versionId) });
+      toast.success('워크플로우가 수정되었습니다.');
+    },
+    onError: (error: ApiRequestError) => {
+      const errorMessages: Record<string, string> = {
+        WORKFLOW_NOT_EDITABLE: 'DRAFT 상태의 버전에서만 수정할 수 있습니다.',
+        GRAPH_JSON_TOO_LARGE: '그래프 데이터가 너무 큽니다.',
+        WORKFLOW_INVALID_START_NODE: 'START 노드가 정확히 1개여야 합니다.',
+        WORKFLOW_INVALID_TERMINAL_NODE: 'TERMINAL 노드가 최소 1개 필요합니다.',
+        WORKFLOW_DANGLING_EDGE: '엣지의 연결 대상 노드가 존재하지 않습니다.',
+        WORKFLOW_UNREACHABLE_NODE: '모든 노드가 START에서 도달 가능해야 합니다.',
+        WORKFLOW_CYCLE_DETECTED: '그래프에 순환 경로가 있습니다.',
+        WORKFLOW_UNLABELED_BRANCH: 'DECISION 노드의 모든 분기에 label이 필요합니다.',
+        WORKFLOW_ACTION_NODE_POLICY_REF_MISSING: 'ACTION 노드의 policyRef 값이 필요합니다.',
+        WORKFLOW_ACTION_NODE_POLICY_REF_INVALID_CHARS: 'ACTION 노드의 policyRef 형식이 유효하지 않습니다.',
+      };
+      toast.error(errorMessages[error.code] ?? '워크플로우 수정에 실패했습니다.');
+    },
+  });
+}
+```
+
+### Client State (@xyflow/react)
+
+```typescript
+// InteractiveGraphEditor.tsx 내 — ReactFlow 상태 관리
+const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
+const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
+
+const onConnect = useCallback(
+  (params: Connection) =>
+    setEdges((eds) =>
+      addEdge({ ...params, id: crypto.randomUUID() }, eds)
+    ),
+  [setEdges]
+);
+```
+
+### 폼 상태 (react-hook-form + zod)
+
+```typescript
+// features/update-workflow/model/schema.ts
+export const workflowEditSchema = z.object({
+  name: z.string().trim().min(1, '워크플로우 이름은 필수입니다.'),
+  description: z.string().nullable().optional(),
+});
+
+export type WorkflowEditFormValues = z.infer<typeof workflowEditSchema>;
+```
+
+```typescript
+// WorkflowEditForm.tsx 내
+const form = useForm<WorkflowEditFormValues>({
+  resolver: zodResolver(workflowEditSchema),
+  defaultValues: {
+    name: workflow.name,
+    description: workflow.description,
+  },
+});
+```
+
+- Sheet open/close: 부모 컴포넌트에서 관리, `isOpen` props로 전달
+- 그래프 상태(nodes, edges): `InteractiveGraphEditor` 내부 `useNodesState`/`useEdgesState`로 관리
+- 저장 시 `toWorkflowGraph(nodes, edges, direction)` 변환 후 PATCH 전송
+
+---
+
+## graphMapper.ts 수정 사항
+
+```typescript
+// 수정 전 (자체 생성 ID)
+return {
+  id: `${baseId}#${count + 1}`,
+  source: e.from,
+  target: e.to,
+  label: e.label,
+};
+
+// 수정 후 (edge.id 직접 사용)
+return {
+  id: e.id,
+  source: e.from,
+  target: e.to,
+  label: e.label,
+};
+```
+
+단, 테스트 데이터에 `id` 없는 엣지가 있으면 `graphMapper.test.ts`도 함께 수정.
+
+---
+
+## graphToWorkflow.ts
+
+```typescript
+// features/update-workflow/ui/graphToWorkflow.ts
+import type { Node, Edge } from '@xyflow/react';
+import type { WorkflowGraph, GraphNode, GraphNodeType } from '@/entities/workflow';
+
+export function toWorkflowGraph(
+  nodes: Node[],
+  edges: Edge[],
+  direction: WorkflowGraph['direction'],
+): WorkflowGraph {
+  const graphNodes: GraphNode[] = nodes.map((n) => ({
+    id: n.id,
+    type: (n.type?.toUpperCase() ?? 'ACTION') as GraphNodeType,
+    label: typeof n.data?.label === 'string' ? n.data.label : '',
+    policyRef: typeof n.data?.policyRef === 'string' ? n.data.policyRef || undefined : undefined,
+  }));
+
+  const graphEdges = edges.map((e) => ({
+    id: e.id,
+    from: e.source,
+    to: e.target,
+    label: typeof e.label === 'string' ? e.label || undefined : undefined,
+  }));
+
+  return { direction, nodes: graphNodes, edges: graphEdges };
+}
+```
+
+---
+
+## Design Constraints
+
+`frontend/DESIGN.md` 준수:
+- 색상: 모노크롬만 (`#000000` / `#ffffff`)
+- 폰트: figmaSans
+- 버튼: `shared/ui/button.tsx` (pill geometry)
+- Focus outline: `dashed 2px`
+- Sheet radius: 8px
+- `alert()` 사용 금지 → `import { toast } from "sonner"`
+- Sheet 너비: `w-full sm:max-w-4xl` (인터랙티브 그래프 영역 확보)
+
+### 공유 컴포넌트 활용
+
+| 역할 | `shared/ui` 파일 |
+|------|-----------------|
+| Side Sheet | `sheet.tsx` |
+| 텍스트 입력 | `input.tsx` |
+| 저장/취소 버튼 | `button.tsx` |
+| 로딩 표시 | `spinner.tsx` |
+| 폼 레이블/에러 | `form.tsx` |
+| Toast 알림 | `import { toast } from "sonner"` |
+
+---
+
+## Tests
+
+### Test Strategy
+
+| 구분 | 방법 | 도구 | 비고 |
+|------|------|------|------|
+| 수동 테스트 | 브라우저 직접 확인 | Chrome DevTools | 전체 플로우 |
+| 단위 테스트 | Vitest + mock | `pnpm test` | `graphToWorkflow`, `graphMapper` 변환 로직 |
+
+### Test Environment & 사전 조건
+
+| 항목 | 값 |
+|------|---|
+| 환경 | `pnpm dev` (백엔드 포함) |
+| 사전 조건 | DRAFT 상태 Domain Pack Version + 워크플로우 1개 이상 |
+| 역할 | OPERATOR 또는 ADMIN 로그인 상태 |
+
+### Test Scenarios
+
+#### Happy Path
+
+| # | 시나리오 | 사전 조건 | 조작 | 기대 결과 |
+|---|---------|---------|------|----------|
+| 1 | 워크플로우 name 수정 | DRAFT version, 워크플로우 존재 | Sheet 열기 → name 수정 → 저장 | 성공 toast, Sheet 닫힘, 데이터 반영 |
+| 2 | 노드 label 수정 | DRAFT version | Sheet 열기 → 노드 클릭 → label 수정 → 저장 | 성공 toast, Sheet 닫힘 |
+| 3 | 노드 추가 | DRAFT version | Sheet 열기 → 툴바 → 타입 선택 → 추가 → 엣지 연결 → 저장 | 신규 노드 포함한 graph 저장 성공 |
+| 4 | 노드 삭제 | DRAFT version | Sheet 열기 → 노드 선택 → Delete → 저장 | 노드 및 연결 엣지 삭제 후 저장 성공 |
+| 5 | 엣지 추가 | DRAFT version | Handle 드래그 → 엣지 생성 → 저장 | 신규 엣지 포함한 graph 저장 성공 |
+| 6 | 취소 시 변경 없음 | — | Sheet 열기 → 편집 → 취소 | 원본 데이터 그대로 유지 |
+
+#### Error & Edge Cases
+
+| # | 시나리오 | 조작 | 기대 결과 |
+|---|---------|------|----------|
+| 1 | name 빈 문자열로 저장 | name 지우고 저장 | FormMessage 인라인 에러, API 호출 안 됨 |
+| 2 | DRAFT 아닌 버전 수정 시도 | 저장 버튼 | `WORKFLOW_NOT_EDITABLE` → toast.error |
+| 3 | START 노드 삭제 후 저장 | START 삭제 → 저장 | `WORKFLOW_INVALID_START_NODE` → toast.error |
+| 4 | DECISION 엣지 label 없이 저장 | DECISION에서 엣지 추가, label 빈칸 → 저장 | `WORKFLOW_UNLABELED_BRANCH` → toast.error |
+| 5 | ACTION 노드 policyRef 없이 저장 | ACTION 노드 policyRef 공백 → 저장 | `WORKFLOW_ACTION_NODE_POLICY_REF_MISSING` → toast.error |
+| 6 | GET 워크플로우 실패 | Sheet 열기 시 API 에러 | 에러 상태 표시 (Sheet 유지, 재시도 가능) |
+| 7 | workflowCode 필드 | Sheet 내 해당 필드 | read-only, 수정 불가 |
+
+#### 접근성
+
+| # | 확인 항목 | 기대 결과 |
+|---|---------|----------|
+| 1 | 키보드 탐색 | Tab → name, description 순 이동 |
+| 2 | Focus outline | dashed 2px 아웃라인 표시 |
+| 3 | 저장/취소 버튼 aria | button role, 상태에 따른 disabled 표시 |
+
+---
+
+## Done Criteria
+
+- [ ] `entities/workflow/model/types.ts` 수정 완료: `graph` → `graphJson`, `GraphEdge.id` 추가, `GraphNode.policyRef?` 추가, `UpdateWorkflowRequest` 추가
+- [ ] `features/workflow-draft-read` 동반 수정 완료: `detail.graphJson` 참조, `graphMapper.ts` edge id 직접 사용, 테스트 업데이트
+- [ ] `entities/workflow/api/index.ts` 신규: `workflowKeys`, `fetchWorkflow`, `patchWorkflow`
+- [ ] `useGetWorkflow`: TanStack Query `useQuery`, `enabled` prop으로 조건부 활성화
+- [ ] `useUpdateWorkflow`: `useMutation`, onSuccess `workflowKeys.detail` + `workflowKeys.list` 두 캐시 모두 invalidate + toast.success
+- [ ] `useUpdateWorkflow`: 에러 코드별 user-friendly toast.error (V1–V8c 포함)
+- [ ] `WorkflowEditSheet`: Sheet open 시 GET 로딩, loading/error/populated 3종 상태; 에러 시 Sheet 유지 + 재시도 버튼
+- [ ] `WorkflowEditForm`: react-hook-form + zod, name 필수 유효성(FormMessage), PATCH 성공 시 toast + Sheet 닫기
+- [ ] `InteractiveGraphEditor`: `useNodesState` / `useEdgesState`, 노드 label 인라인 편집, ACTION 노드 policyRef 편집, 노드 추가/삭제, 엣지 추가/삭제, 엣지 연결 (`onConnect`)
+- [ ] 신규 엣지 id: `crypto.randomUUID()` 사용
+- [ ] `workflowCode` 필드: read-only
+- [ ] `toWorkflowGraph()`: ReactFlow nodes/edges → `WorkflowGraph` 변환 정확성 (policyRef, edge id 포함)
+- [ ] DESIGN.md 준수: 모노크롬, dashed focus, `shared/ui` 컴포넌트 사용, Sheet `w-full sm:max-w-4xl`
+- [ ] FSD 의존성 방향 준수: `features/update-workflow` → `entities/workflow` → `shared`
+- [ ] `alert()` 미사용, `import { toast } from "sonner"` 사용
+- [ ] `pnpm test` 통과 (graphMapper.test.ts 포함)
+
+---
+
+## Out of Scope (이 스펙 제외)
+
+- 편집 트리거 버튼 연결 (`WorkflowDetailPanel`/`WorkflowListPanel`에 편집 버튼 추가)
+- `DomainPackVersionDetailPage` 통합
+- 노드 위치(position) 서버 저장 — graphJson 스키마에 미포함
+- policyRef autocomplete (valid policy 코드 목록 제공 UI)
+- 워크플로우 생성 / 삭제 기능
+- `workflowCode` 수정 (불변 필드)

--- a/.agent/specs/324.md
+++ b/.agent/specs/324.md
@@ -80,6 +80,7 @@ flowchart TD
 공통 path prefix: `/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}`
 
 PATCH request body:
+
 ```json
 {
   "name": "...",
@@ -252,13 +253,14 @@ WorkflowEditSheet
 | 파일 | 설명 |
 |------|------|
 | `src/entities/workflow/api/index.ts` | `workflowKeys`, `fetchWorkflow`, `patchWorkflow` API 함수 |
+| `src/entities/workflow/lib/graphConverter.ts` | ReactFlow nodes/edges → `WorkflowGraph` 필드 매핑 공유 유틸 (`convertFlowToWorkflowGraph`) |
 | `src/features/update-workflow/model/schema.ts` | zod schema (name 필수 검사) |
 | `src/features/update-workflow/api/useGetWorkflow.ts` | GET workflow useQuery hook |
 | `src/features/update-workflow/api/useUpdateWorkflow.ts` | PATCH workflow useMutation hook |
 | `src/features/update-workflow/ui/WorkflowEditSheet.tsx` | Side sheet 진입점 |
 | `src/features/update-workflow/ui/WorkflowEditForm.tsx` | react-hook-form 기반 편집 폼 |
 | `src/features/update-workflow/ui/InteractiveGraphEditor.tsx` | @xyflow/react 기반 편집기 |
-| `src/features/update-workflow/ui/graphToWorkflow.ts` | ReactFlow → WorkflowGraph 변환 유틸 |
+| `src/features/update-workflow/ui/graphToWorkflow.ts` | ReactFlow → WorkflowGraph 변환 유틸 (`graphConverter` 래퍼) |
 | `src/features/update-workflow/ui/AddNodeToolbar.tsx` | 노드 타입 선택 + 추가 버튼 툴바 |
 | `src/features/update-workflow/ui/nodes/EditableStartNode.tsx` | 편집 가능 START 노드 |
 | `src/features/update-workflow/ui/nodes/EditableActionNode.tsx` | 편집 가능 ACTION 노드 (label + policyRef) |
@@ -276,7 +278,7 @@ WorkflowEditSheet
 | `src/entities/workflow/index.ts` | 신규 export 추가 (`workflowKeys`, `UpdateWorkflowRequest`) |
 | `src/features/workflow-draft-read/ui/WorkflowDetailPanel.tsx` | `detail.graph` → `detail.graphJson` |
 | `src/features/workflow-draft-read/ui/GraphRenderer.tsx` | `WorkflowDetail` props 타입 반영 (필요 시) |
-| `src/features/workflow-draft-read/ui/graphMapper.ts` | `edge.id` 사용 (기존 자체 생성 ID → `e.id` 사용), `toFlow` 반환 엣지 id 수정 |
+| `src/features/workflow-draft-read/ui/graphMapper.ts` | `edge.id` 사용 (기존 자체 생성 ID → `e.id` 사용), `toFlow` 반환 엣지 id 수정; `toFlow`의 역방향 변환이 필요한 경우 `graphConverter.convertFlowToWorkflowGraph` 재사용 |
 | `src/features/workflow-draft-read/ui/graphMapper.test.ts` | edge ID 형식 변경에 따른 테스트 업데이트 |
 
 ---
@@ -402,18 +404,21 @@ return {
 
 ---
 
-## graphToWorkflow.ts
+## graphConverter.ts (공유 유틸)
+
+`toFlow` (WorkflowGraph → ReactFlow)의 역방향 변환인 ReactFlow → WorkflowGraph 필드 매핑은
+`graphMapper.ts`와 `graphToWorkflow.ts` 양쪽에서 재사용된다. 중복을 막기 위해 해당 변환을
+`entities/workflow/lib/graphConverter.ts`에 분리한다.
 
 ```typescript
-// features/update-workflow/ui/graphToWorkflow.ts
+// entities/workflow/lib/graphConverter.ts
 import type { Node, Edge } from '@xyflow/react';
-import type { WorkflowGraph, GraphNode, GraphNodeType } from '@/entities/workflow';
+import type { GraphNode, GraphEdge, GraphNodeType } from '../model/types';
 
-export function toWorkflowGraph(
+export function convertFlowToWorkflowGraph(
   nodes: Node[],
   edges: Edge[],
-  direction: WorkflowGraph['direction'],
-): WorkflowGraph {
+): { nodes: GraphNode[]; edges: GraphEdge[] } {
   const graphNodes: GraphNode[] = nodes.map((n) => ({
     id: n.id,
     type: (n.type?.toUpperCase() ?? 'ACTION') as GraphNodeType,
@@ -421,13 +426,33 @@ export function toWorkflowGraph(
     policyRef: typeof n.data?.policyRef === 'string' ? n.data.policyRef || undefined : undefined,
   }));
 
-  const graphEdges = edges.map((e) => ({
+  const graphEdges: GraphEdge[] = edges.map((e) => ({
     id: e.id,
     from: e.source,
     to: e.target,
     label: typeof e.label === 'string' ? e.label || undefined : undefined,
   }));
 
+  return { nodes: graphNodes, edges: graphEdges };
+}
+```
+
+## graphToWorkflow.ts
+
+`graphConverter.convertFlowToWorkflowGraph`를 호출하는 얇은 래퍼.
+
+```typescript
+// features/update-workflow/ui/graphToWorkflow.ts
+import type { Node, Edge } from '@xyflow/react';
+import type { WorkflowGraph } from '@/entities/workflow';
+import { convertFlowToWorkflowGraph } from '@/entities/workflow/lib/graphConverter';
+
+export function toWorkflowGraph(
+  nodes: Node[],
+  edges: Edge[],
+  direction: WorkflowGraph['direction'],
+): WorkflowGraph {
+  const { nodes: graphNodes, edges: graphEdges } = convertFlowToWorkflowGraph(nodes, edges);
   return { direction, nodes: graphNodes, edges: graphEdges };
 }
 ```
@@ -523,6 +548,7 @@ export function toWorkflowGraph(
 - [ ] `InteractiveGraphEditor`: `useNodesState` / `useEdgesState`, 노드 label 인라인 편집, ACTION 노드 policyRef 편집, 노드 추가/삭제, 엣지 추가/삭제, 엣지 연결 (`onConnect`)
 - [ ] 신규 엣지 id: `crypto.randomUUID()` 사용
 - [ ] `workflowCode` 필드: read-only
+- [ ] `entities/workflow/lib/graphConverter.ts` 신규: `convertFlowToWorkflowGraph` 구현, `toWorkflowGraph`에서 호출
 - [ ] `toWorkflowGraph()`: ReactFlow nodes/edges → `WorkflowGraph` 변환 정확성 (policyRef, edge id 포함)
 - [ ] DESIGN.md 준수: 모노크롬, dashed focus, `shared/ui` 컴포넌트 사용, Sheet `w-full sm:max-w-4xl`
 - [ ] FSD 의존성 방향 준수: `features/update-workflow` → `entities/workflow` → `shared`


### PR DESCRIPTION
# Spec 324 — [Console] Workflow Node / Edge 수정 기능 구현

**Branch**: `spec/324`
**Canonical Number**: `324`
**Type**: Frontend (FSD)
**작성일**: 2026-04-24
**최종 업데이트**: 2026-04-24 (Q1-Q4 결정 확정)

---

## Goal

운영자가 Domain Pack 버전 상세 화면 내 워크플로우 상세 영역에서, Side Sheet를 통해 워크플로우의 `name`, `description`, 그래프(노드/엣지)를 `@xyflow/react` 인터랙티브 편집기로 수정하고 저장할 수 있는 기능을 구현한다.

---

## User Flow Chart

```mermaid
flowchart TD
    A[WorkflowEditSheet 열기\nisOpen=true, workflowId 전달] --> B[useGetWorkflow 호출\nenabled: isOpen]
    B -->|loading| C[Spinner 표시]
    B -->|error| D[에러 메시지 + 재시도 버튼\nSheet 유지 - Sheet 닫기 금지]
    B -->|success| E[WorkflowEditForm 렌더링\ndefaultValues 채움]

    E --> F[InteractiveGraphEditor\nReactFlow editable mode]
    F --> G{사용자 액션}

    G -->|노드 label 클릭| H[인라인 Input 편집]
    G -->|ACTION 노드 policyRef 클릭| I[policyRef 인라인 Input 편집]
    G -->|노드 추가 버튼| J[타입 선택 → 신규 노드 캔버스 배치\n빈 label 기본값]
    G -->|노드 삭제| K[NodeToolbar 삭제 버튼 또는\nDelete 키 — 연결 엣지 함께 삭제]
    G -->|Handle 드래그| L[새 엣지 생성\nonConnect — 고유 id auto-generate]
    G -->|엣지 label 클릭| M[label 인라인 Popover 편집]
    G -->|엣지 삭제| N[엣지 선택 후 Delete 키 또는\n삭제 버튼]
    G -->|name / description 수정| O[FormField 텍스트 편집]

    G -->|저장 버튼| P{name 유효성 검사 — zod}
    P -->|실패 - name blank| Q[FormMessage 인라인 에러\nAPI 호출 안 됨]
    P -->|통과| R[toWorkflowGraph 변환\nuseUpdateWorkflow.mutate]
    R -->|성공| S[toast.success + Sheet 닫기\nworkflowKeys.detail + workflowKeys.list 무효화]
    R -->|WORKFLOW_NOT_EDITABLE| T[toast.error 버전 DRAFT 아님]
    R -->|그래프 검증 오류 V1-V8c| U[toast.error 해당 규칙 메시지]
    R -->|기타 실패| V[toast.error]

    G -->|취소| W[Sheet 닫기 - 변경 없음]
```

---

## Design Diff

### As-is vs To-be

| 영역 | As-is | To-be | 변경 내용 |
|------|-------|-------|----------|
| 워크플로우 수정 기능 | 없음 | `WorkflowEditSheet` (side sheet) | 신규 구현 |
| 그래프 편집 UI | Read-only `GraphRenderer` | `InteractiveGraphEditor` (editable ReactFlow) | 신규 구현 |
| `entities/workflow` 타입 | `graph` 필드명, `GraphEdge.id` 없음, `GraphNode.policyRef` 없음 | `graphJson` 필드명, `GraphEdge.id` 추가, `GraphNode.policyRef?` 추가 | **기존 코드 파괴적 수정** |
| `workflow-draft-read` | `detail.graph` 참조 | `detail.graphJson` 참조 | 타입 수정 후 동반 수정 필수 |
| `entities/workflow/api` | 없음 | `workflowKeys` + API 함수 | 신규 구현 |

---

## Prerequisites

### 타입 수정 선행 필수 (기존 코드 파괴)

이 스펙을 구현하기 전에 `entities/workflow/model/types.ts`를 수정해야 하며,
수정 후 `features/workflow-draft-read` 코드가 컴파일 에러가 발생한다. 동반 수정이 필수다.

### BE API (모두 구현 완료)

| Method | Path | 설명 | 응답 타입 |
|--------|------|------|-----------|
| GET | `.../workflows` | 목록 조회 | `WorkflowSummary[]` |
| GET | `.../workflows/{workflowId}` | 단건 조회 | `WorkflowDefinitionDetail` |
| PATCH | `.../workflows/{workflowId}` | 필드 + 그래프 수정 | `WorkflowDefinitionDetail` |

공통 path prefix: `/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}`

PATCH request body:
```json
{
  "name": "...",
  "description": "...",
  "graphJson": { "direction": "LR", "nodes": [...], "edges": [...] }
}
```

PATCH 에러 코드:

| 코드 | 조건 | FE toast 메시지 |
|------|------|----------------|
| `WORKFLOW_NOT_EDITABLE` | 버전이 DRAFT 아님 | `DRAFT 상태의 버전에서만 수정할 수 있습니다.` |
| `GRAPH_JSON_TOO_LARGE` | graphJson > 100,000자 | `그래프 데이터가 너무 큽니다.` |
| `WORKFLOW_INVALID_START_NODE` | START 노드 ≠ 1개 | `START 노드가 정확히 1개여야 합니다.` |
| `WORKFLOW_INVALID_TERMINAL_NODE` | TERMINAL 노드 0개 | `TERMINAL 노드가 최소 1개 필요합니다.` |
| `WORKFLOW_DANGLING_EDGE` | 엣지 끝점 노드 없음 | `엣지의 연결 대상 노드가 존재하지 않습니다.` |
| `WORKFLOW_UNREACHABLE_NODE` | START에서 도달 불가 노드 | `모든 노드가 START에서 도달 가능해야 합니다.` |
| `WORKFLOW_CYCLE_DETECTED` | 사이클 존재 | `그래프에 순환 경로가 있습니다.` |
| `WORKFLOW_UNLABELED_BRANCH` | DECISION 발신 엣지 label 없음 | `DECISION 노드의 모든 분기에 label이 필요합니다.` |
| `WORKFLOW_EDGE_ID_MISSING` | 엣지 id 없음 | `그래프 구조가 유효하지 않습니다.` |
| `WORKFLOW_EDGE_ID_DUPLICATE` | 엣지 id 중복 | `그래프 구조가 유효하지 않습니다.` |
| `WORKFLOW_ACTION_NODE_POLICY_REF_MISSING` | ACTION policyRef 없음 | `ACTION 노드의 policyRef 값이 필요합니다.` |
| `WORKFLOW_ACTION_NODE_POLICY_REF_INVALID_CHARS` | policyRef 패턴 불일치 | `ACTION 노드의 policyRef 형식이 유효하지 않습니다.` |
| 기타 | — | `워크플로우 수정에 실패했습니다.` |

---

## Component Tree

```
[부모: DomainPackVersionDetailPage — 별도 스펙 범위]
└── WorkflowEditSheet ← [이 스펙 범위]
     ├── SheetHeader (workflowCode + name 표시)
     ├── [로딩 상태: Spinner]
     ├── [에러 상태: 에러 메시지 + 재시도 버튼]
     └── WorkflowEditForm
          ├── NameInput (required, @NotBlank)
          ├── DescriptionInput (optional)
          ├── WorkflowCodeField (read-only)
          ├── InteractiveGraphEditor ← 핵심 컴포넌트
          │    ├── AddNodeToolbar (노드 타입 선택 + 추가 버튼)
          │    └── ReactFlow (editable)
          │         ├── EditableStartNode (label 편집)
          │         ├── EditableActionNode (label + policyRef 편집)
          │         ├── EditableDecisionNode (label 편집)
          │         ├── EditableAnswerNode (label 편집)
          │         ├── EditableHandoffNode (label 편집)
          │         └── EditableTerminalNode (label 편집)
          └── SheetFooter
               ├── 저장 버튼 (PATCH fields + graph)
               └── 취소 버튼 (Sheet 닫기)
```

**이 스펙(324) 직접 구현 범위**: `WorkflowEditSheet`, `WorkflowEditForm`, `InteractiveGraphEditor`, 편집 가능 노드 컴포넌트 6종, 관련 hooks, `entities/workflow` 타입·API 추가, `workflow-draft-read` 동반 수정

**이 스펙 범위 외**: 편집 버튼 / 트리거 연결 (부모 페이지 스펙에서 처리), `WorkflowListPanel`/`WorkflowDetailPanel` 편집 진입점 추가

---

## API Integration

### Query Key Pattern

```typescript
// entities/workflow/api/index.ts  (신규)
export const workflowKeys = {
  all: ['workflows'] as const,
  lists: () => [...workflowKeys.all, 'list'] as const,
  list: (wsId: number, packId: number, versionId: number) =>
    [...workflowKeys.lists(), wsId, packId, versionId] as const,
  detail: (wsId: number, packId: number, versionId: number, workflowId: number) =>
    [...workflowKeys.all, 'detail', wsId, packId, versionId, workflowId] as const,
};
```

### Request / Response 타입

```typescript
// entities/workflow/model/types.ts — 수정·추가

export type GraphNodeType = 'START' | 'ACTION' | 'DECISION' | 'ANSWER' | 'HANDOFF' | 'TERMINAL';

export interface GraphNode {
  id: string;
  label: string;
  type: GraphNodeType;
  policyRef?: string; // ADD: ACTION 노드 필수, 나머지 undefined
}

export interface GraphEdge {
  id: string;        // ADD: V7a/V7b 검증 필수
  from: string;
  to: string;
  label?: string;
}

export interface WorkflowGraph {
  direction: 'LR' | 'TB';
  nodes: GraphNode[];
  edges: GraphEdge[];
}

export interface WorkflowSummary {
  id: number;
  workflowCode: string;
  name: string;
  description: string | null;
  initialState: string | null;
  terminalStatesJson: string;
  createdAt: string;
  updatedAt: string;
}

export interface WorkflowDetail {
  id: number;
  workflowCode: string;
  name: string;
  description: string | null;
  graphJson: WorkflowGraph; // RENAME: 기존 `graph` → `graphJson` (BE 응답 필드명 일치)
  initialState: string | null;
  terminalStatesJson: string;
  evidenceJson: string;
  metaJson: string;
  createdAt: string;
  updatedAt: string;
}

// PATCH request body
export interface UpdateWorkflowRequest {
  name: string;
  description?: string | null;
  graphJson: WorkflowGraph;
}
```

---

## Data Flow

```
[Parent: DomainPackVersionDetailPage]
    │  props: { wsId, packId, versionId, workflowId, isOpen, onClose }
    ▼
WorkflowEditSheet
    │  useGetWorkflow(wsId, packId, versionId, workflowId, enabled: isOpen)
    ├── [loading] → Spinner
    ├── [error]   → 에러 상태 표시 (Sheet 유지, 재시도 가능)
    └── [success] → WorkflowEditForm (defaultValues = workflow data)
                        │  react-hook-form + zod resolver (name 필드)
                        │  InteractiveGraphEditor
                        │     useNodesState(initialNodes)
                        │     useEdgesState(initialEdges)
                        │     onConnect → 신규 엣지 추가 (crypto.randomUUID() id)
                        │     노드 label/policyRef 인라인 편집
                        │  저장 버튼
                        │     → toWorkflowGraph(nodes, edges, direction)
                        │     → useUpdateWorkflow.mutate({ wsId, packId, versionId, workflowId, body })
                        │     → onSuccess: toast.success + onClose + invalidate
                        │     → onError: 에러 코드별 toast.error
                        └── 취소 → onClose
```

---

## 수정 대상 파일

### 신규 생성

| 파일 | 설명 |
|------|------|
| `src/entities/workflow/api/index.ts` | `workflowKeys`, `fetchWorkflow`, `patchWorkflow` API 함수 |
| `src/features/update-workflow/model/schema.ts` | zod schema (name 필수 검사) |
| `src/features/update-workflow/api/useGetWorkflow.ts` | GET workflow useQuery hook |
| `src/features/update-workflow/api/useUpdateWorkflow.ts` | PATCH workflow useMutation hook |
| `src/features/update-workflow/ui/WorkflowEditSheet.tsx` | Side sheet 진입점 |
| `src/features/update-workflow/ui/WorkflowEditForm.tsx` | react-hook-form 기반 편집 폼 |
| `src/features/update-workflow/ui/InteractiveGraphEditor.tsx` | @xyflow/react 기반 편집기 |
| `src/features/update-workflow/ui/graphToWorkflow.ts` | ReactFlow → WorkflowGraph 변환 유틸 |
| `src/features/update-workflow/ui/AddNodeToolbar.tsx` | 노드 타입 선택 + 추가 버튼 툴바 |
| `src/features/update-workflow/ui/nodes/EditableStartNode.tsx` | 편집 가능 START 노드 |
| `src/features/update-workflow/ui/nodes/EditableActionNode.tsx` | 편집 가능 ACTION 노드 (label + policyRef) |
| `src/features/update-workflow/ui/nodes/EditableDecisionNode.tsx` | 편집 가능 DECISION 노드 |
| `src/features/update-workflow/ui/nodes/EditableAnswerNode.tsx` | 편집 가능 ANSWER 노드 |
| `src/features/update-workflow/ui/nodes/EditableHandoffNode.tsx` | 편집 가능 HANDOFF 노드 |
| `src/features/update-workflow/ui/nodes/EditableTerminalNode.tsx` | 편집 가능 TERMINAL 노드 |
| `src/features/update-workflow/index.ts` | barrel export |

### 수정 (기존 파일)

| 파일 | 변경 내용 |
|------|----------|
| `src/entities/workflow/model/types.ts` | `graph` → `graphJson` rename, `GraphEdge.id` 추가, `GraphNode.policyRef?` 추가, `UpdateWorkflowRequest` 추가 |
| `src/entities/workflow/index.ts` | 신규 export 추가 (`workflowKeys`, `UpdateWorkflowRequest`) |
| `src/features/workflow-draft-read/ui/WorkflowDetailPanel.tsx` | `detail.graph` → `detail.graphJson` |
| `src/features/workflow-draft-read/ui/GraphRenderer.tsx` | `WorkflowDetail` props 타입 반영 (필요 시) |
| `src/features/workflow-draft-read/ui/graphMapper.ts` | `edge.id` 사용 (기존 자체 생성 ID → `e.id` 사용), `toFlow` 반환 엣지 id 수정 |
| `src/features/workflow-draft-read/ui/graphMapper.test.ts` | edge ID 형식 변경에 따른 테스트 업데이트 |

---

## State Management

### Server State (TanStack Query)

```typescript
// features/update-workflow/api/useGetWorkflow.ts
export function useGetWorkflow(
  wsId: number,
  packId: number,
  versionId: number,
  workflowId: number,
  enabled: boolean,
) {
  return useQuery({
    queryKey: workflowKeys.detail(wsId, packId, versionId, workflowId),
    queryFn: () => fetchWorkflow(wsId, packId, versionId, workflowId),
    enabled,
  });
}
```

```typescript
// features/update-workflow/api/useUpdateWorkflow.ts
export function useUpdateWorkflow() {
  const queryClient = useQueryClient();
  return useMutation({
    mutationFn: ({ wsId, packId, versionId, workflowId, body }: UpdateWorkflowParams) =>
      patchWorkflow(wsId, packId, versionId, workflowId, body),
    onSuccess: (_, { wsId, packId, versionId, workflowId }) => {
      queryClient.invalidateQueries({ queryKey: workflowKeys.detail(wsId, packId, versionId, workflowId) });
      queryClient.invalidateQueries({ queryKey: workflowKeys.list(wsId, packId, versionId) });
      toast.success('워크플로우가 수정되었습니다.');
    },
    onError: (error: ApiRequestError) => {
      const errorMessages: Record<string, string> = {
        WORKFLOW_NOT_EDITABLE: 'DRAFT 상태의 버전에서만 수정할 수 있습니다.',
        GRAPH_JSON_TOO_LARGE: '그래프 데이터가 너무 큽니다.',
        WORKFLOW_INVALID_START_NODE: 'START 노드가 정확히 1개여야 합니다.',
        WORKFLOW_INVALID_TERMINAL_NODE: 'TERMINAL 노드가 최소 1개 필요합니다.',
        WORKFLOW_DANGLING_EDGE: '엣지의 연결 대상 노드가 존재하지 않습니다.',
        WORKFLOW_UNREACHABLE_NODE: '모든 노드가 START에서 도달 가능해야 합니다.',
        WORKFLOW_CYCLE_DETECTED: '그래프에 순환 경로가 있습니다.',
        WORKFLOW_UNLABELED_BRANCH: 'DECISION 노드의 모든 분기에 label이 필요합니다.',
        WORKFLOW_ACTION_NODE_POLICY_REF_MISSING: 'ACTION 노드의 policyRef 값이 필요합니다.',
        WORKFLOW_ACTION_NODE_POLICY_REF_INVALID_CHARS: 'ACTION 노드의 policyRef 형식이 유효하지 않습니다.',
      };
      toast.error(errorMessages[error.code] ?? '워크플로우 수정에 실패했습니다.');
    },
  });
}
```

### Client State (@xyflow/react)

```typescript
// InteractiveGraphEditor.tsx 내 — ReactFlow 상태 관리
const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);

const onConnect = useCallback(
  (params: Connection) =>
    setEdges((eds) =>
      addEdge({ ...params, id: crypto.randomUUID() }, eds)
    ),
  [setEdges]
);
```

### 폼 상태 (react-hook-form + zod)

```typescript
// features/update-workflow/model/schema.ts
export const workflowEditSchema = z.object({
  name: z.string().trim().min(1, '워크플로우 이름은 필수입니다.'),
  description: z.string().nullable().optional(),
});

export type WorkflowEditFormValues = z.infer<typeof workflowEditSchema>;
```

```typescript
// WorkflowEditForm.tsx 내
const form = useForm<WorkflowEditFormValues>({
  resolver: zodResolver(workflowEditSchema),
  defaultValues: {
    name: workflow.name,
    description: workflow.description,
  },
});
```

- Sheet open/close: 부모 컴포넌트에서 관리, `isOpen` props로 전달
- 그래프 상태(nodes, edges): `InteractiveGraphEditor` 내부 `useNodesState`/`useEdgesState`로 관리
- 저장 시 `toWorkflowGraph(nodes, edges, direction)` 변환 후 PATCH 전송

---

## graphMapper.ts 수정 사항

```typescript
// 수정 전 (자체 생성 ID)
return {
  id: `${baseId}#${count + 1}`,
  source: e.from,
  target: e.to,
  label: e.label,
};

// 수정 후 (edge.id 직접 사용)
return {
  id: e.id,
  source: e.from,
  target: e.to,
  label: e.label,
};
```

단, 테스트 데이터에 `id` 없는 엣지가 있으면 `graphMapper.test.ts`도 함께 수정.

---

## graphToWorkflow.ts

```typescript
// features/update-workflow/ui/graphToWorkflow.ts
import type { Node, Edge } from '@xyflow/react';
import type { WorkflowGraph, GraphNode, GraphNodeType } from '@/entities/workflow';

export function toWorkflowGraph(
  nodes: Node[],
  edges: Edge[],
  direction: WorkflowGraph['direction'],
): WorkflowGraph {
  const graphNodes: GraphNode[] = nodes.map((n) => ({
    id: n.id,
    type: (n.type?.toUpperCase() ?? 'ACTION') as GraphNodeType,
    label: typeof n.data?.label === 'string' ? n.data.label : '',
    policyRef: typeof n.data?.policyRef === 'string' ? n.data.policyRef || undefined : undefined,
  }));

  const graphEdges = edges.map((e) => ({
    id: e.id,
    from: e.source,
    to: e.target,
    label: typeof e.label === 'string' ? e.label || undefined : undefined,
  }));

  return { direction, nodes: graphNodes, edges: graphEdges };
}
```

---

## Design Constraints

`frontend/DESIGN.md` 준수:
- 색상: 모노크롬만 (`#000000` / `#ffffff`)
- 폰트: figmaSans
- 버튼: `shared/ui/button.tsx` (pill geometry)
- Focus outline: `dashed 2px`
- Sheet radius: 8px
- `alert()` 사용 금지 → `import { toast } from "sonner"`
- Sheet 너비: `w-full sm:max-w-4xl` (인터랙티브 그래프 영역 확보)

### 공유 컴포넌트 활용

| 역할 | `shared/ui` 파일 |
|------|-----------------|
| Side Sheet | `sheet.tsx` |
| 텍스트 입력 | `input.tsx` |
| 저장/취소 버튼 | `button.tsx` |
| 로딩 표시 | `spinner.tsx` |
| 폼 레이블/에러 | `form.tsx` |
| Toast 알림 | `import { toast } from "sonner"` |

---

## Tests

### Test Strategy

| 구분 | 방법 | 도구 | 비고 |
|------|------|------|------|
| 수동 테스트 | 브라우저 직접 확인 | Chrome DevTools | 전체 플로우 |
| 단위 테스트 | Vitest + mock | `pnpm test` | `graphToWorkflow`, `graphMapper` 변환 로직 |

### Test Environment & 사전 조건

| 항목 | 값 |
|------|---|
| 환경 | `pnpm dev` (백엔드 포함) |
| 사전 조건 | DRAFT 상태 Domain Pack Version + 워크플로우 1개 이상 |
| 역할 | OPERATOR 또는 ADMIN 로그인 상태 |

### Test Scenarios

#### Happy Path

| # | 시나리오 | 사전 조건 | 조작 | 기대 결과 |
|---|---------|---------|------|----------|
| 1 | 워크플로우 name 수정 | DRAFT version, 워크플로우 존재 | Sheet 열기 → name 수정 → 저장 | 성공 toast, Sheet 닫힘, 데이터 반영 |
| 2 | 노드 label 수정 | DRAFT version | Sheet 열기 → 노드 클릭 → label 수정 → 저장 | 성공 toast, Sheet 닫힘 |
| 3 | 노드 추가 | DRAFT version | Sheet 열기 → 툴바 → 타입 선택 → 추가 → 엣지 연결 → 저장 | 신규 노드 포함한 graph 저장 성공 |
| 4 | 노드 삭제 | DRAFT version | Sheet 열기 → 노드 선택 → Delete → 저장 | 노드 및 연결 엣지 삭제 후 저장 성공 |
| 5 | 엣지 추가 | DRAFT version | Handle 드래그 → 엣지 생성 → 저장 | 신규 엣지 포함한 graph 저장 성공 |
| 6 | 취소 시 변경 없음 | — | Sheet 열기 → 편집 → 취소 | 원본 데이터 그대로 유지 |

#### Error & Edge Cases

| # | 시나리오 | 조작 | 기대 결과 |
|---|---------|------|----------|
| 1 | name 빈 문자열로 저장 | name 지우고 저장 | FormMessage 인라인 에러, API 호출 안 됨 |
| 2 | DRAFT 아닌 버전 수정 시도 | 저장 버튼 | `WORKFLOW_NOT_EDITABLE` → toast.error |
| 3 | START 노드 삭제 후 저장 | START 삭제 → 저장 | `WORKFLOW_INVALID_START_NODE` → toast.error |
| 4 | DECISION 엣지 label 없이 저장 | DECISION에서 엣지 추가, label 빈칸 → 저장 | `WORKFLOW_UNLABELED_BRANCH` → toast.error |
| 5 | ACTION 노드 policyRef 없이 저장 | ACTION 노드 policyRef 공백 → 저장 | `WORKFLOW_ACTION_NODE_POLICY_REF_MISSING` → toast.error |
| 6 | GET 워크플로우 실패 | Sheet 열기 시 API 에러 | 에러 상태 표시 (Sheet 유지, 재시도 가능) |
| 7 | workflowCode 필드 | Sheet 내 해당 필드 | read-only, 수정 불가 |

#### 접근성

| # | 확인 항목 | 기대 결과 |
|---|---------|----------|
| 1 | 키보드 탐색 | Tab → name, description 순 이동 |
| 2 | Focus outline | dashed 2px 아웃라인 표시 |
| 3 | 저장/취소 버튼 aria | button role, 상태에 따른 disabled 표시 |

---

## Done Criteria

- [ ] `entities/workflow/model/types.ts` 수정 완료: `graph` → `graphJson`, `GraphEdge.id` 추가, `GraphNode.policyRef?` 추가, `UpdateWorkflowRequest` 추가
- [ ] `features/workflow-draft-read` 동반 수정 완료: `detail.graphJson` 참조, `graphMapper.ts` edge id 직접 사용, 테스트 업데이트
- [ ] `entities/workflow/api/index.ts` 신규: `workflowKeys`, `fetchWorkflow`, `patchWorkflow`
- [ ] `useGetWorkflow`: TanStack Query `useQuery`, `enabled` prop으로 조건부 활성화
- [ ] `useUpdateWorkflow`: `useMutation`, onSuccess `workflowKeys.detail` + `workflowKeys.list` 두 캐시 모두 invalidate + toast.success
- [ ] `useUpdateWorkflow`: 에러 코드별 user-friendly toast.error (V1–V8c 포함)
- [ ] `WorkflowEditSheet`: Sheet open 시 GET 로딩, loading/error/populated 3종 상태; 에러 시 Sheet 유지 + 재시도 버튼
- [ ] `WorkflowEditForm`: react-hook-form + zod, name 필수 유효성(FormMessage), PATCH 성공 시 toast + Sheet 닫기
- [ ] `InteractiveGraphEditor`: `useNodesState` / `useEdgesState`, 노드 label 인라인 편집, ACTION 노드 policyRef 편집, 노드 추가/삭제, 엣지 추가/삭제, 엣지 연결 (`onConnect`)
- [ ] 신규 엣지 id: `crypto.randomUUID()` 사용
- [ ] `workflowCode` 필드: read-only
- [ ] `toWorkflowGraph()`: ReactFlow nodes/edges → `WorkflowGraph` 변환 정확성 (policyRef, edge id 포함)
- [ ] DESIGN.md 준수: 모노크롬, dashed focus, `shared/ui` 컴포넌트 사용, Sheet `w-full sm:max-w-4xl`
- [ ] FSD 의존성 방향 준수: `features/update-workflow` → `entities/workflow` → `shared`
- [ ] `alert()` 미사용, `import { toast } from "sonner"` 사용
- [ ] `pnpm test` 통과 (graphMapper.test.ts 포함)

---

## Out of Scope (이 스펙 제외)

- 편집 트리거 버튼 연결 (`WorkflowDetailPanel`/`WorkflowListPanel`에 편집 버튼 추가)
- `DomainPackVersionDetailPage` 통합
- 노드 위치(position) 서버 저장 — graphJson 스키마에 미포함
- policyRef autocomplete (valid policy 코드 목록 제공 UI)
- 워크플로우 생성 / 삭제 기능
- `workflowCode` 수정 (불변 필드)
---
# Uncertainty Register — 324: [Console] Workflow Node / Edge 수정 기능 구현

**Branch**: `spec/324`
**작성일**: 2026-04-24
**상태**: 모든 사용자 결정 완료 (Q1–Q4 확정)

---

## 확정된 사용자 결정 (2026-04-24)

| 항목 | 결정 |
|------|------|
| Q1. graphJson 편집 방식 | **C — @xyflow/react interactive graph** |
| Q2. 구조 변경 범위 | **구조 변경 포함** (노드/엣지 추가·삭제) |
| Q3. FE 타입 불일치 수정 | **spec 324에 포함** |
| Q4. WorkflowEditSheet 진입점 | **C — Sheet 컴포넌트만 구현, 연결은 별도 스펙** |

---

## 항목 목록

---

### UR-001

- **ID**: UR-001
- **Issue**: `WorkflowDetail.graph` vs BE 응답 필드명 `graphJson` 불일치
- **Status**: `Confirmed`
- **Why unresolved**: 사용자 결정 Q3으로 해소됨
- **Resolution**: `entities/workflow/model/types.ts`에서 `graph` → `graphJson` rename; `features/workflow-draft-read` 동반 수정 필수
- **Affected Spec Section**: 수정 대상 파일, 타입 정의
- **User Decision Required**: No

---

### UR-002

- **ID**: UR-002
- **Issue**: 백엔드 `GraphEdge.id` 필수 검증(V7a/V7b) vs 프론트엔드 `GraphEdge` 타입에 `id` 없음
- **Status**: `Confirmed`
- **Why unresolved**: 사용자 결정 Q3으로 해소됨
- **Resolution**: `GraphEdge`에 `id: string` 추가; `graphMapper.ts`에서 `e.id` 직접 사용; 신규 엣지 생성 시 `crypto.randomUUID()`
- **Affected Spec Section**: 타입 정의, graphMapper 수정, graphToWorkflow
- **User Decision Required**: No

---

### UR-003

- **ID**: UR-003
- **Issue**: 백엔드 `GraphNode.policyRef` 필수(ACTION 노드) vs 프론트엔드 `GraphNode` 타입에 `policyRef` 없음
- **Status**: `Confirmed`
- **Why unresolved**: 사용자 결정 Q3으로 해소됨
- **Resolution**: `GraphNode`에 `policyRef?: string` 추가; `EditableActionNode`에 policyRef 인라인 편집 필드 추가; `toWorkflowGraph()`에서 policyRef 변환 포함
- **Affected Spec Section**: 타입 정의, EditableActionNode, graphToWorkflow
- **User Decision Required**: No

---

### UR-004

- **ID**: UR-004
- **Issue**: Sheet 너비 — 인터랙티브 그래프 편집에 `sm:max-w-md` (spec 321 표준)는 협소
- **Status**: `Assumption`
- **Why unresolved**: DESIGN.md에 Sheet 너비 기준 미정의; 사용자 확인 없음
- **Options**:
  - A: `w-full sm:max-w-4xl` — 넓은 side sheet
  - B: full-screen modal/dialog
- **Recommended Default**: A — `w-full sm:max-w-4xl`
- **Why recommended**: side sheet UX 유지하면서 그래프 편집 영역 확보; dialog로 전환 시 sheet.tsx 외 컴포넌트 필요
- **User Decision Required**: No
- **User Question**: N/A
- **Execution Rule**:
  - Implementation Agent MUST NOT: `sm:max-w-md` 그대로 사용 (그래프 영역 불충분)
  - Implementation Agent MAY: `Assumption adopted from Recommended Default` — `w-full sm:max-w-4xl` 적용; 실제 렌더링 확인 후 조정
- **Affected Spec Section**: Design Constraints, WorkflowEditSheet

---

### UR-005

- **ID**: UR-005
- **Issue**: 신규 노드의 캔버스 배치 위치
- **Status**: `Assumption`
- **Why unresolved**: 사용자 지정 없음
- **Options**:
  - A: 현재 viewport 중앙에 배치
  - B: 마지막 노드 위치에서 오프셋
- **Recommended Default**: A — viewport 중앙 배치 (`{ x: viewportCenter.x, y: viewportCenter.y }`)
- **Why recommended**: 예측 가능한 위치, ReactFlow `getViewport()` 활용 가능
- **User Decision Required**: No
- **User Question**: N/A
- **Execution Rule**:
  - Implementation Agent MAY: `Assumption adopted from Recommended Default` — viewport 중앙 계산; `useReactFlow().getViewport()` 사용
- **Affected Spec Section**: InteractiveGraphEditor, AddNodeToolbar

---

### UR-006

- **ID**: UR-006
- **Issue**: 노드 위치(position) 서버 비저장 — 편집 중 이동한 위치가 재로딩 시 초기화됨
- **Status**: `Deferred`
- **Why unresolved**: 백엔드 `graphJson` 스키마에 position 필드 없음; 별도 BE 스펙 필요
- **Options**:
  - A: position 비저장 (현재 스펙 — `graphMapper`가 재계산)
  - B: `graphJson` 스키마 확장 (별도 스펙 필요)
- **Recommended Default**: A — 현재 스펙에서는 position 비저장; 추후 확장
- **User Decision Required**: No
- **Execution Rule**:
  - Implementation Agent MUST NOT: position을 graphJson에 포함하여 PATCH 요청 (BE 검증 오류 아니지만, 스펙 범위 초과)
  - Implementation Agent MAY: position 무시 — `toWorkflowGraph()`에서 position 미포함
- **Affected Spec Section**: graphToWorkflow, Out of Scope

---

### UR-007

- **ID**: UR-007
- **Issue**: policyRef 값의 autocomplete / validation UI — ACTION 노드 편집 시 유효한 policy 코드 목록을 제공하는 UI
- **Status**: `Deferred`
- **Why unresolved**: BE에 "버전 내 policy 코드 목록" 조회 API가 FE에서 활용 가능한지 확인 미완료; 현재 스펙 범위 초과
- **Recommended Default**: 단순 text input (autocomplete 없음); 저장 시 BE `WORKFLOW_ACTION_NODE_POLICY_REF_*` 에러로 검증
- **User Decision Required**: No
- **Execution Rule**:
  - Implementation Agent MUST NOT: policyRef autocomplete 구현 (이 스펙 out of scope)
  - Implementation Agent MAY: plain text `<Input>` 사용; BE 에러 코드로 사용자 피드백
- **Affected Spec Section**: EditableActionNode, Out of Scope

---

### UR-008

- **ID**: UR-008
- **Issue**: `useGetWorkflow`가 기존 `workflowApi.detail()` 재사용 vs 신규 API 함수 정의
- **Status**: `Confirmed`
- **Resolution**: `entities/workflow/api/index.ts` (신규)에서 `fetchWorkflow()` 정의; `features/update-workflow/api/useGetWorkflow.ts`에서 이를 호출. 기존 `features/workflow-draft-read/api/workflowApi.ts`는 별도 유지 (Read-only 기능 분리 유지)
- **User Decision Required**: No
- **Affected Spec Section**: API Integration, 수정 대상 파일

---

### UR-009

- **ID**: UR-009
- **Issue**: DECISION 노드 발신 엣지 생성 시 label 즉시 입력 필요 (V6: label 필수)
- **Status**: `Assumption`
- **Why unresolved**: 즉시 입력 강제 vs 저장 시 BE 오류로 처리 — UX 선택
- **Recommended Default**: 엣지 생성 후 label 비어있어도 허용; 저장 시 BE `WORKFLOW_UNLABELED_BRANCH` 에러 toast로 처리
- **Why recommended**: 구현 단순화; BE 검증이 최종 가이드 역할
- **User Decision Required**: No
- **Execution Rule**:
  - Implementation Agent MAY: `Assumption adopted from Recommended Default` — 엣지 생성 시 label 강제 입력 팝업 생략; BE 오류로 피드백
- **Affected Spec Section**: InteractiveGraphEditor, Error Cases

---

## 요약

| ID | 항목 | Status | User Decision Required |
|----|------|--------|----------------------|
| UR-001 | `graph` → `graphJson` rename | Confirmed | No |
| UR-002 | `GraphEdge.id` 추가 | Confirmed | No |
| UR-003 | `GraphNode.policyRef` 추가 | Confirmed | No |
| UR-004 | Sheet 너비 `sm:max-w-4xl` | Assumption | No |
| UR-005 | 신규 노드 배치 위치 | Assumption | No |
| UR-006 | Position 비저장 | Deferred | No |
| UR-007 | policyRef autocomplete | Deferred | No |
| UR-008 | fetchWorkflow 위치 | Confirmed | No |
| UR-009 | DECISION 엣지 label 강제 입력 | Assumption | No |

**모든 사용자 결정 항목(Q1–Q4) 해소 완료. Implementation Agent가 추측 없이 진행 가능.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * 워크플로우 이름·설명과 그래프(노드·엣지)를 사이드 시트에서 편집하는 콘솔 동작에 대한 상세 사양 추가
  * 로딩·오류·성공 흐름, 인라인 레이블 편집, 노드/엣지 추가·삭제 동작, 저장 시 유효성 검사 및 성공 토스트 표시 등 사용자 관점의 UI 흐름 문서화
  * 저장 후 데이터 동기화 및 관련 테스트·수용 기준 명시
<!-- end of auto-generated comment: release notes by coderabbit.ai -->