### PR TITLE
spec/00120: Frontend 테스트 localStorage 실패 수정

### DIFF
--- a/.agent/specs/00120.md
+++ b/.agent/specs/00120.md
@@ -1,0 +1,132 @@
+# [FE] Fix #00120 — Frontend 테스트 localStorage 실패 수정
+
+> 기반 템플릿: `_TEMPLATE_FE.md`
+> 작업 유형: `fix` (bug fix)
+> Branch: `spec/00120` → `fix/00120-localstorage-test-fix`
+
+---
+
+## Goal
+
+vite-plus 0.1.16 + Node.js v25 환경에서 `localStorage is not a function` 오류로 실패하는 13건의 프론트엔드 테스트를 수정한다.
+
+**근본 원인**: Node.js v25.9.0은 `localStorage`를 전역 스코프에 빈 객체(메서드 없음)로 노출한다. vite-plus-test 0.1.16의 `populateGlobal` 함수는 `localStorage`가 `KEYS` 목록에 없으므로 이 빈 객체를 jsdom의 정상 구현체로 교체하지 않는다. 결과적으로 테스트에서 `localStorage.clear()` / `setItem()` / `getItem()` 호출 시 `is not a function` 오류가 발생한다.
+
+---
+
+## User Flow Chart
+
+N/A — UI 변경 없음. 테스트 인프라 버그 픽스다.
+
+---
+
+## Design Diff
+
+N/A — UI/UX 변경 없음.
+
+---
+
+## Component Tree
+
+N/A
+
+---
+
+## API Integration
+
+N/A
+
+---
+
+## Data Flow
+
+N/A
+
+---
+
+## 수정 대상 파일
+
+| 파일 | 변경 유형 | 설명 |
+|------|----------|------|
+| `frontend/src/test/setup.ts` | modify | `globalThis.localStorage`를 jsdom의 `window.localStorage`로 강제 교체하는 코드 추가 |
+
+---
+
+## State Management
+
+N/A
+
+---
+
+## Tests
+
+### Done Criteria
+
+| 항목 | 기준 |
+|------|------|
+| 실패 테스트 수 | `pnpm test` 기준 13건 → 0건 |
+| `localStorage.clear()` | 정상 동작 |
+| `localStorage.setItem()` | 정상 동작 |
+| `localStorage.getItem()` | 정상 동작 |
+| `localStorage.removeItem()` | 정상 동작 |
+| 기존 통과 테스트 | 74건 유지 (regression 없음) |
+
+### 실패 대상 파일 (현재 총 13건)
+
+| 파일 | 실패 수 | 주요 오류 |
+|------|---------|-----------|
+| `src/app/App.test.tsx` | 3 | `localStorage.clear is not a function` |
+| `src/entities/workspace/api/workspaceApi.test.ts` | 3 | `localStorage.clear is not a function` |
+| `src/shared/lib/auth.test.ts` | 3 | `localStorage.setItem/getItem is not a function` |
+| `src/features/auth/api/authApi.test.ts` | 4 | `localStorage.getItem is not a function` |
+
+### Verification
+
+```bash
+cd frontend && pnpm test
+# 모든 87건 통과 확인
+```
+
+---
+
+## Implementation Example
+
+### `frontend/src/test/setup.ts` 수정
+
+```typescript
+import { vi } from "vite-plus/test";
+import "@testing-library/jest-dom";
+
+// Node.js v25는 localStorage를 전역에 빈 객체로 노출한다.
+// vite-plus-test 0.1.16의 populateGlobal은 KEYS 목록에 없는 기존 전역 키를
+// jsdom 값으로 교체하지 않으므로, 수동으로 jsdom의 정상 구현체를 주입한다.
+Object.defineProperty(globalThis, "localStorage", {
+  value: window.localStorage,
+  writable: true,
+  configurable: true,
+});
+
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+```
+
+**배치 위치**: `matchMedia` 패치 이전, 파일 최상단 (imports 직후)
+
+**전제 조건**: `vite.config.ts`의 `test.environment: "jsdom"`이 유지되어야 한다. jsdom 환경에서만 `window.localStorage`가 정상 구현체다.
+
+---
+
+## Performance Considerations
+
+N/A

--- a/.agent/specs/00120.md
+++ b/.agent/specs/00120.md
@@ -75,10 +75,10 @@ N/A
 
 | 파일 | 실패 수 | 주요 오류 |
 |------|---------|-----------|
-| `src/app/App.test.tsx` | 3 | `localStorage.clear is not a function` |
-| `src/entities/workspace/api/workspaceApi.test.ts` | 3 | `localStorage.clear is not a function` |
-| `src/shared/lib/auth.test.ts` | 3 | `localStorage.setItem/getItem is not a function` |
-| `src/features/auth/api/authApi.test.ts` | 4 | `localStorage.getItem is not a function` |
+| `frontend/src/app/App.test.tsx` | 3 | `localStorage.clear is not a function` |
+| `frontend/src/entities/workspace/api/workspaceApi.test.ts` | 3 | `localStorage.clear is not a function` |
+| `frontend/src/shared/lib/auth.test.ts` | 3 | `localStorage.setItem/getItem is not a function` |
+| `frontend/src/features/auth/api/authApi.test.ts` | 4 | `localStorage.getItem is not a function` |
 
 ### Verification
 


### PR DESCRIPTION
# [FE] Fix #00120 — Frontend 테스트 localStorage 실패 수정

> 기반 템플릿: `_TEMPLATE_FE.md`
> 작업 유형: `fix` (bug fix)
> Branch: `spec/00120` → `fix/00120-localstorage-test-fix`

---

## Goal

vite-plus 0.1.16 + Node.js v25 환경에서 `localStorage is not a function` 오류로 실패하는 13건의 프론트엔드 테스트를 수정한다.

**근본 원인**: Node.js v25.9.0은 `localStorage`를 전역 스코프에 빈 객체(메서드 없음)로 노출한다. vite-plus-test 0.1.16의 `populateGlobal` 함수는 `localStorage`가 `KEYS` 목록에 없으므로 이 빈 객체를 jsdom의 정상 구현체로 교체하지 않는다. 결과적으로 테스트에서 `localStorage.clear()` / `setItem()` / `getItem()` 호출 시 `is not a function` 오류가 발생한다.

---

## User Flow Chart

N/A — UI 변경 없음. 테스트 인프라 버그 픽스다.

---

## Design Diff

N/A — UI/UX 변경 없음.

---

## Component Tree

N/A

---

## API Integration

N/A

---

## Data Flow

N/A

---

## 수정 대상 파일

| 파일 | 변경 유형 | 설명 |
|------|----------|------|
| `frontend/src/test/setup.ts` | modify | `globalThis.localStorage`를 jsdom의 `window.localStorage`로 강제 교체하는 코드 추가 |

---

## State Management

N/A

---

## Tests

### Done Criteria

| 항목 | 기준 |
|------|------|
| 실패 테스트 수 | `pnpm test` 기준 13건 → 0건 |
| `localStorage.clear()` | 정상 동작 |
| `localStorage.setItem()` | 정상 동작 |
| `localStorage.getItem()` | 정상 동작 |
| `localStorage.removeItem()` | 정상 동작 |
| 기존 통과 테스트 | 74건 유지 (regression 없음) |

### 실패 대상 파일 (현재 총 13건)

| 파일 | 실패 수 | 주요 오류 |
|------|---------|-----------|
| `src/app/App.test.tsx` | 3 | `localStorage.clear is not a function` |
| `src/entities/workspace/api/workspaceApi.test.ts` | 3 | `localStorage.clear is not a function` |
| `src/shared/lib/auth.test.ts` | 3 | `localStorage.setItem/getItem is not a function` |
| `src/features/auth/api/authApi.test.ts` | 4 | `localStorage.getItem is not a function` |

### Verification

```bash
cd frontend && pnpm test
# 모든 87건 통과 확인
```

---

## Implementation Example

### `frontend/src/test/setup.ts` 수정

```typescript
import { vi } from "vite-plus/test";
import "@testing-library/jest-dom";

// Node.js v25는 localStorage를 전역에 빈 객체로 노출한다.
// vite-plus-test 0.1.16의 populateGlobal은 KEYS 목록에 없는 기존 전역 키를
// jsdom 값으로 교체하지 않으므로, 수동으로 jsdom의 정상 구현체를 주입한다.
Object.defineProperty(globalThis, "localStorage", {
  value: window.localStorage,
  writable: true,
  configurable: true,
});

Object.defineProperty(window, "matchMedia", {
  writable: true,
  value: vi.fn().mockImplementation((query: string) => ({
    matches: false,
    media: query,
    onchange: null,
    addListener: vi.fn(),
    removeListener: vi.fn(),
    addEventListener: vi.fn(),
    removeEventListener: vi.fn(),
    dispatchEvent: vi.fn(),
  })),
});
```

**배치 위치**: `matchMedia` 패치 이전, 파일 최상단 (imports 직후)

**전제 조건**: `vite.config.ts`의 `test.environment: "jsdom"`이 유지되어야 한다. jsdom 환경에서만 `window.localStorage`가 정상 구현체다.

---

## Performance Considerations

N/A
---
# Uncertainty Register — Issue #00120

> Frontend 테스트 localStorage 실패 수정
> Decision Agent 산출물 | Branch: `spec/00120`

---

## Summary

| ID | Issue | Status | User Decision Required |
|----|-------|--------|------------------------|
| U-1 | 테스트 실패 건수 불일치 (이슈 9건 vs 현재 13건) | Assumption | No |
| U-2 | vite-plus 버전 고정 여부 | Deferred | No |
| U-3 | vite-plus-core 0.1.15 / vite-plus-test 0.1.16 버전 mismatch 영향 | Deferred | No |

모든 항목이 `Confirmed` / `Assumption` / `Deferred`로 처리되었고, 사용자 결정을 기다리는 `Needs Input` 또는 `Conflict` 항목은 없다.

---

## U-1 테스트 실패 건수 불일치

- **ID**: U-1
- **Issue**: 이슈 본문에는 "9건 실패"로 기재되어 있으나, Recon Agent 실행 기준으로는 13건이 실패한다.
- **Status**: Assumption
- **Why unresolved**: 이슈 작성 시점 이후 추가 테스트가 커밋되었을 가능성이 있으나, 정확한 차이 원인은 미확인이다.
- **Options**:
  1. Done Criteria를 9건 기준으로 정의
  2. Done Criteria를 현재 실측치 13건 기준으로 정의 (Recon 시점 실측)
- **Recommended Default**: Option 2 — 현재 실측치 13건을 기준으로 한다. 이슈 작성 이후 테스트가 추가되었을 가능성이 높고, 실측치가 더 보수적인 기준이다.
- **Why recommended**: 기준을 실측치보다 낮게 잡으면 현재 실패 중인 테스트가 Done Criteria를 만족해도 실제로 실패가 남을 수 있다.
- **User Decision Required**: No
- **User Question**: N/A
- **Execution Rule**:
  - Implementation Agent MUST NOT: 9건을 목표로 삼아 13건 중 일부가 남는 상태를 "완료"로 간주.
  - Implementation Agent MAY: Recommended Default(13건 기준)를 `Assumption adopted from Recommended Default`로 채택.
  - `pnpm test` 전체 결과를 반드시 확인하고, 87건 중 0건 실패를 검증해야 한다.
- **Affected Spec Section**: Tests → Done Criteria

---

## U-2 vite-plus 버전 고정 여부

- **ID**: U-2
- **Issue**: `pnpm-workspace.yaml`의 catalog가 `vite-plus: latest`, `vitest: npm:@voidzero-dev/vite-plus-test@latest`로 설정되어 있어, 미래 버전 업그레이드 시 동일 혹은 새로운 호환성 문제가 재발할 수 있다.
- **Status**: Deferred
- **Why unresolved**: 이번 fix의 핵심 수정(`setup.ts` 패치)은 버전 고정 없이도 독립적으로 문제를 해결한다. 버전 고정은 추가적인 방어 조치이므로 이번 fix 범위와 분리 가능하다.
- **Options**:
  1. 버전 고정 없이 `setup.ts` 패치만 진행
  2. `pnpm-workspace.yaml`에서 `vite-plus-test`를 특정 버전으로 고정 후 패치
- **Recommended Default**: Option 1 — 이번 fix 범위에서는 `setup.ts` 패치만 진행. 버전 고정은 별도 `chore` 이슈로 분리한다. `setup.ts` 패치는 버전 독립적이며 vite-plus가 upstream에서 수정하더라도 무해하다.
- **Why recommended**: `@latest`를 고정 버전으로 교체하려면 "어떤 버전이 안전한가"를 별도로 검증해야 한다. 이번 fix에서 그 검증까지 포함하면 범위가 커진다.
- **User Decision Required**: No
- **User Question**: N/A
- **Execution Rule**:
  - Implementation Agent MUST NOT: 버전 고정을 이번 fix의 Done Criteria로 간주.
  - Implementation Agent MAY: Option 1을 `Assumption adopted from Recommended Default`로 채택.
  - 버전 고정이 필요하다고 판단되면 별도 `chore` 브랜치로 분리할 것.
- **Affected Spec Section**: 해당 없음 (스펙 본문 외 항목)

---

## U-3 vite-plus-core 0.1.15 / vite-plus-test 0.1.16 버전 mismatch 영향

- **ID**: U-3
- **Issue**: `pnpm-lock.yaml` 기준으로 `vite-plus-core`는 `0.1.15`, `vite-plus-test`는 `0.1.16`으로 resolve되어 버전 mismatch가 존재한다. 이 mismatch가 현재 실패에 추가적으로 기여하는지 미확인이다.
- **Status**: Deferred
- **Why unresolved**: Recon Agent가 소스 수준에서 mismatch와 실패의 연관 관계를 확인하지 못했다. 근본 원인(Node.js v25 + KEYS 목록 누락)은 mismatch와 독립적으로 설명 가능하다.
- **Options**: N/A
- **Recommended Default**: 이번 fix에서는 mismatch를 직접 수정하지 않는다. `setup.ts` 패치 후 전체 테스트 통과 여부로 충분성을 검증한다.
- **Why recommended**: 근본 원인이 mismatch 없이도 충분히 설명되며, 패치 후 전체 테스트가 통과하면 mismatch는 추가 영향이 없다고 판단 가능하다.
- **User Decision Required**: No
- **User Question**: N/A
- **Execution Rule**:
  - Implementation Agent MUST NOT: mismatch 해소를 이번 fix의 선행 조건으로 간주.
  - Implementation Agent MAY: 패치 후에도 실패가 남으면 U-3를 재조사 트리거로 사용.
  - `pnpm test` 전체 통과 시 U-3는 무관한 것으로 처리.
- **Affected Spec Section**: Tests → Done Criteria

---

## Decision Log

| 날짜 | 항목 | 결정 | 근거 |
|------|------|------|------|
| 2026-04-25 | Done Criteria 기준 | 13건 (Assumption) | Recon 실측치 우선 |
| 2026-04-25 | 버전 고정 | 이번 범위 제외 (Deferred) | setup.ts 패치만으로 충분 |
| 2026-04-25 | 버전 mismatch 조치 | 이번 범위 제외 (Deferred) | 근본 원인이 독립적으로 설명됨 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **문서**
  * 프론트엔드 테스트 실패 사례를 기록한 새 사양 문서가 추가되었습니다. 특정 빌드 환경과 최신 Node.js 조합에서 발생하는 테스트 불일치를 분석하고, 영향을 받는 테스트 목록과 재현·검증 절차(로컬 테스트 통과 기준)를 포함한 구체적 수정 방안을 제시합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->