### PR TITLE
fix(frontend): inject jsdom localStorage to fix test failures on Node.js v25

### DIFF
--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,6 +1,18 @@
 import { vi } from "vite-plus/test";
 import "@testing-library/jest-dom";
 
+// Node.js v25 exposes localStorage as an empty object without methods.
+// vite-plus-test's populateGlobal skips keys already present in globalThis,
+// so jsdom's real implementation is never injected. window === globalThis in
+// this runner context, so window.localStorage is also broken. Access jsdom's
+// real implementation via globalThis.jsdom.window (set by populateGlobal).
+const jsdomWindow = (globalThis as any).jsdom?.window;
+Object.defineProperty(globalThis, "localStorage", {
+  value: jsdomWindow?.localStorage ?? window.localStorage,
+  writable: true,
+  configurable: true,
+});
+
 Object.defineProperty(window, "matchMedia", {
   writable: true,
   value: vi.fn().mockImplementation((query: string) => ({

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -6,9 +6,24 @@ import "@testing-library/jest-dom";
 // so jsdom's real implementation is never injected. window === globalThis in
 // this runner context, so window.localStorage is also broken. Access jsdom's
 // real implementation via globalThis.jsdom.window (set by populateGlobal).
-const jsdomWindow = (globalThis as any).jsdom?.window;
+type GlobalWithJsdom = { jsdom?: { window?: { localStorage?: Storage } } };
+const jsdomWindow = (globalThis as unknown as GlobalWithJsdom).jsdom?.window;
+const jsdomLocalStorage = jsdomWindow?.localStorage;
+
+if (
+  !jsdomLocalStorage ||
+  typeof jsdomLocalStorage.clear !== "function" ||
+  typeof jsdomLocalStorage.setItem !== "function" ||
+  typeof jsdomLocalStorage.getItem !== "function"
+) {
+  throw new Error(
+    "jsdom localStorage is unavailable or missing expected methods (clear/setItem/getItem). " +
+      "Ensure globalThis.jsdom.window.localStorage is populated by the test environment.",
+  );
+}
+
 Object.defineProperty(globalThis, "localStorage", {
-  value: jsdomWindow?.localStorage ?? window.localStorage,
+  value: jsdomLocalStorage,
   writable: true,
   configurable: true,
 });


### PR DESCRIPTION
## Summary

Node.js v25 + vite-plus-test 환경에서 `localStorage.clear/setItem/getItem is not a function`으로 실패하던 13건의 테스트를 수정했다. `frontend/src/test/setup.ts` 단일 파일 변경이며 UI/API 변경 없음.

---

## Context

`.agent/specs/00120.md` 구현 PR. 근본 원인은 Node.js v25가 `localStorage`를 전역에 빈 객체로 노출하고, vite-plus-test의 `populateGlobal`이 기존 키를 덮어쓰지 않아 jsdom 구현체가 주입되지 않는 것이다.

---

## What Changed

- `frontend/src/test/setup.ts`에 `Object.defineProperty(globalThis, "localStorage", ...)` 패치 추가
- jsdom의 실제 구현체를 `(globalThis as any).jsdom?.window.localStorage` 경로로 접근하여 주입
- 배치: imports 직후, 기존 `matchMedia` 패치 이전

---

## Assumptions Adopted

| ID | 내용 | 영향 |
|----|------|------|
| U-1 | Done Criteria를 이슈 본문의 9건이 아닌 실측치 13건 기준으로 정의 | 9건 기준 유지 시 4건 잔존했을 것, 13건 전체 수정이 올바른 판단이었음 |

---

## Spec Deviations

| 항목 | Spec | 실제 구현 | 이유 |
|------|------|-----------|------|
| `value` 표현식 | `window.localStorage` | `jsdomWindow?.localStorage ?? window.localStorage` | vite-plus-test runner에서 `window === globalThis`이므로 `window.localStorage`도 broken. `globalThis.jsdom.window`를 통해 jsdom 구현체에 접근해야 동작함 (execution log 기록) |

spec "Implementation Example"은 illustrative 예시이며 Goal(jsdom 구현체 주입)은 동일하게 달성됨.

---

## Blocked / Skipped Items

| ID | 항목 | 이유 |
|----|------|------|
| U-2 | vite-plus 버전 고정 (`pnpm-workspace.yaml`) | Deferred — 별도 `chore` 이슈로 분리 예정 |
| U-3 | pnpm lock file 버전 mismatch 해소 (lock: 0.1.16, 실제: 0.1.19) | Deferred — 이번 패치가 버전 독립적으로 동작함을 확인 후 scope 외 처리 |

---

## Test Notes

- `pnpm test` 87/87 통과 (execution log 기준)
- 수정 전: 13건 실패 (`App.test.tsx` 3, `workspaceApi.test.ts` 3, `auth.test.ts` 3, `authApi.test.ts` 4)
- 독립 검증은 CI 실행 결과로 확인 권장

---

## Reviewer Focus

1. **V-002 (Warning)**: `jsdomWindow?.localStorage ?? window.localStorage` — `jsdomWindow`가 undefined이면 broken 객체로 조용히 폴백한다. vite-plus-test 내부 API(`global.jsdom`) 변경 시 동일 오류가 재발하지만 원인 파악이 어렵다. fail-fast 처리 여부를 검토할 것.
2. **vite-plus-test 실제 버전**: lock file에 0.1.16 기재이나 실제 resolve는 0.1.19. `pnpm install` 재실행 시 동작 변경 가능성 확인.
3. `vite.config.ts`의 `test.environment: "jsdom"` 유지 여부 — 이 패치의 전제 조건.

---

## Conflicts

없음. 모든 uncertainty가 `Assumption` / `Deferred`로 처리되었고, `Needs Input` 항목 없음.

---

## Ready to Merge / Needs Input

**Ready to Merge** — 단, V-002 silent fallback은 병합 전 또는 후속 이슈로 처리 여부를 팀에서 결정 권장.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Tests**
  * 테스트 설정에 런타임 검사 추가: localStorage가 존재하지만 정상 동작하지 않을 때 이를 감지하고 jsdom 제공 구현으로 대체
  * 필요한 메서드가 없으면 빠르게 실패하도록 처리하여 문제를 조기에 발견
  * 기존 matchMedia 모킹 로직은 변경 없음
  * 이로써 테스트 환경에서 저장소 동작 관련 예기치 못한 실패를 줄입니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->