### PR TITLE
docs(spec): add policy edit frontend spec

### DIFF
--- a/.agent/specs/322.md
+++ b/.agent/specs/322.md
@@ -1,0 +1,512 @@
+# Spec 322 — [Console] Policy 수정 기능 구현
+
+**Branch**: `spec/322`
+**Canonical Number**: `322`
+**Type**: Frontend (FSD)
+**작성일**: 2026-04-27
+
+---
+
+## Goal
+
+운영자가 Domain Pack Version의 Policy 초안을 목록/상세로 확인하고, `327.md`의 Policy 수정 API를 사용해 Policy 일반 필드와 status를 수정할 수 있는 프런트엔드 화면을 구현한다.
+
+---
+
+## Scope Decision
+
+### 324 화면에 붙이지 않고 별도 Policy 화면으로 구현한다
+
+`324.md`의 Workflow 편집 화면은 ACTION 노드의 `policyRef`를 입력/검증하는 워크플로우 그래프 편집 책임을 가진다. Policy 자체의 `name`, `severity`, JSON 조건/액션, status 수정은 별도 도메인 구성요소 편집 책임이므로 `PolicyDraftReadPage + PolicyEditSheet`로 분리한다.
+
+이 결정의 기준:
+- Workflow 편집기는 `workflow_definition.graphJson` 전체 교체가 핵심이고, Policy 편집기는 `policy_definition` 단건 수정이 핵심이다.
+- `policyCode`는 immutable이며 Workflow의 `policyRef`가 참조하는 값이다. 같은 화면에서 policy 본문 수정과 graph 수정을 섞으면 저장 책임과 에러 복구가 복잡해진다.
+- 이미 구현된 `update-slot`의 Sheet/Form/StatusToggle 패턴이 Policy 수정에 더 직접적으로 재사용 가능하다.
+- 추후 Workflow ACTION 노드의 `policyRef`에서 Policy 상세 화면으로 이동하거나 Policy picker/autocomplete를 붙이는 작업은 별도 스펙으로 분리한다.
+
+---
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A[PolicyDraftReadPage 진입\n/workspaces/:wsId/domain-packs/:packId/versions/:versionId/policies] --> B[usePolicyList 호출]
+    B -->|loading| C[목록 skeleton]
+    B -->|error| D[toast.error + 재시도 버튼]
+    B -->|empty| E[빈 상태 표시]
+    B -->|success| F[PolicyListPanel 표시]
+
+    F --> G{Policy 선택}
+    G -->|선택 없음| H[상세 placeholder]
+    G -->|선택| I[URL /policies/:policyId 이동]
+    I --> J[usePolicyDetail 호출]
+    J -->|loading| K[상세 skeleton]
+    J -->|error| L[toast.error + 재시도 버튼]
+    J -->|success| M[PolicyDetailPanel 표시]
+
+    M --> N[수정 버튼 클릭]
+    N --> O[PolicyEditSheet 열기]
+    O --> P[useGetPolicy 호출\nenabled: isOpen]
+    P -->|loading| Q[Sheet spinner]
+    P -->|error| R[Sheet 유지 + 재시도 버튼]
+    P -->|success| S[PolicyEditForm 렌더링]
+
+    S --> T{사용자 액션}
+    T -->|일반 필드 수정 후 저장| U[zod: name + JSON 필드 검증]
+    U -->|실패| V[FormMessage 표시\nAPI 호출 없음]
+    U -->|통과| W[PATCH /policies/{policyId}]
+    W -->|success| X[toast.success + Sheet 닫기\nlist/detail invalidate]
+    W -->|POLICY_NOT_EDITABLE| Y[toast.error DRAFT 안내]
+    W -->|VALIDATION_ERROR| Z[toast.error 또는 FormMessage]
+    W -->|기타 실패| AA[toast.error]
+
+    T -->|status switch 변경| AB[PATCH /policies/{policyId}/status]
+    AB -->|success| AC[detail/list optimistic update 후 invalidate]
+    AB -->|POLICY_CODE_REFERENCED_BY_WORKFLOW| AD[toast.error 참조 workflow 안내 + rollback]
+    AB -->|POLICY_NOT_EDITABLE| AE[toast.error DRAFT 안내 + rollback]
+    AB -->|기타 실패| AF[toast.error + rollback]
+```
+
+---
+
+## Design Diff
+
+### As-is vs To-be
+
+| 영역 | As-is | To-be | 변경 내용 |
+|------|-------|-------|----------|
+| Policy FE 화면 | 없음 | `PolicyDraftReadPage` | 신규 라우트와 2-pane 목록/상세 화면 추가 |
+| Policy 조회 | BE GET API만 존재 | `policyApi.list/detail` + hooks | 3212/2211 API를 FE에서 사용 |
+| Policy 일반 수정 | BE PATCH API만 존재 | `PolicyEditSheet` + `PolicyEditForm` | 327 API 연동 |
+| Policy status 수정 | BE PATCH API만 존재 | `PolicyStatusToggle` | 327 API + 100 에러 처리 |
+| Workflow 편집 화면 | ACTION `policyRef` 직접 입력 | 그대로 유지 | Policy 자체 편집은 이 화면에 넣지 않음 |
+| Slot 수정 화면 | 구현됨 | Policy 수정의 기준 패턴 | `update-slot` 구조 재사용 |
+
+---
+
+## Prerequisites
+
+### BE API
+
+| Source | Method | Path | Description |
+|--------|--------|------|-------------|
+| 3212 | GET | `/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/policies` | Policy 목록 조회 |
+| 2211 | GET | `/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/policies/{policyId}` | Policy 단건 조회 |
+| 327 | PATCH | `/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/policies/{policyId}` | Policy 일반 필드 수정 |
+| 327 | PATCH | `/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/policies/{policyId}/status` | Policy status 전환 |
+| 100 | PATCH | 동일 status endpoint | INACTIVE 전환 시 workflow `policyRef` 역참조 차단 |
+
+### Existing FE Patterns
+
+구현 시 아래 기존 파일의 패턴을 따른다.
+
+| Existing file | 재사용 기준 |
+|---------------|------------|
+| `frontend/src/pages/domain-pack/ui/SlotDraftReadPage.tsx` | 목록/상세 2-pane 라우팅 구조 |
+| `frontend/src/features/slot-draft-read/ui/SlotListPanel.tsx` | 목록 loading/error/empty/ready 상태 |
+| `frontend/src/features/slot-draft-read/ui/SlotDetailPanel.tsx` | 상세 loading/error/idle/ready 상태 |
+| `frontend/src/features/update-slot/ui/SlotEditSheet.tsx` | Sheet open 시 detail query, error retry |
+| `frontend/src/features/update-slot/ui/SlotEditForm.tsx` | react-hook-form + zod + status toggle 배치 |
+| `frontend/src/features/update-slot/api/useUpdateSlot.ts` | PATCH 성공 시 detail/list invalidate + toast |
+| `frontend/src/features/update-slot/api/useUpdateSlotStatus.ts` | status optimistic update + rollback |
+| `frontend/src/features/update-workflow/ui/WorkflowEditSheet.tsx` | 큰 편집 컨텍스트에서 Sheet 상태 유지 방식 |
+
+---
+
+## Component Tree
+
+```
+App
+└── Route /workspaces/:workspaceId/domain-packs/:packId/versions/:versionId/policies/:policyId?
+    └── PolicyDraftReadPage
+        ├── DashboardLayout
+        ├── PageHeader
+        ├── PolicyListPanel
+        │   ├── loading skeleton
+        │   ├── error + retry
+        │   ├── empty state
+        │   └── PolicyListRow[]
+        └── PolicyDetailPanel
+            ├── idle placeholder
+            ├── loading skeleton
+            ├── error + retry
+            └── ready
+                ├── DetailHeader
+                │   └── EditButton
+                ├── InfoCard grid
+                ├── JsonCard(condition/action/evidence/meta)
+                └── PolicyEditSheet
+                    ├── SheetHeader
+                    ├── loading spinner
+                    ├── error + retry
+                    └── PolicyEditForm
+                        ├── name input
+                        ├── description input
+                        ├── severity select/input
+                        ├── policyCode read-only
+                        ├── PolicyJsonFields
+                        ├── PolicyStatusToggle
+                        └── save/cancel buttons
+```
+
+---
+
+## API Integration
+
+### Query Key Pattern
+
+```typescript
+// frontend/src/entities/policy/api/index.ts
+export const policyKeys = {
+  all: ["policies"] as const,
+  lists: () => [...policyKeys.all, "list"] as const,
+  list: (workspaceId: number, packId: number, versionId: number) =>
+    [...policyKeys.lists(), workspaceId, packId, versionId] as const,
+  detail: (workspaceId: number, packId: number, versionId: number, policyId: number) =>
+    [...policyKeys.all, "detail", workspaceId, packId, versionId, policyId] as const,
+};
+```
+
+### Types
+
+```typescript
+// frontend/src/entities/policy/model/types.ts
+export type PolicyStatus = "ACTIVE" | "INACTIVE";
+
+export interface PolicySummary {
+  id: number;
+  domainPackVersionId: number;
+  policyCode: string;
+  name: string;
+  description: string | null;
+  severity: string | null;
+  status: PolicyStatus;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface PolicyDefinition extends PolicySummary {
+  conditionJson: string;
+  actionJson: string;
+  evidenceJson: string;
+  metaJson: string;
+}
+
+export interface UpdatePolicyRequest {
+  name: string;
+  description?: string | null;
+  severity?: string | null;
+  conditionJson?: string | null;
+  actionJson?: string | null;
+  evidenceJson?: string | null;
+  metaJson?: string | null;
+}
+
+export interface UpdatePolicyStatusRequest {
+  status: PolicyStatus;
+}
+```
+
+### API Functions
+
+```typescript
+const basePath = (workspaceId: number, packId: number, versionId: number) =>
+  `/workspaces/${workspaceId}/domain-packs/${packId}/versions/${versionId}/policies`;
+
+export const policyApi = {
+  list: (workspaceId: number, packId: number, versionId: number) =>
+    apiClient.get<PolicySummary[]>(basePath(workspaceId, packId, versionId)),
+
+  detail: (workspaceId: number, packId: number, versionId: number, policyId: number) =>
+    apiClient.get<PolicyDefinition>(`${basePath(workspaceId, packId, versionId)}/${policyId}`),
+
+  update: (
+    workspaceId: number,
+    packId: number,
+    versionId: number,
+    policyId: number,
+    body: UpdatePolicyRequest,
+  ) =>
+    apiClient.patch<PolicyDefinition>(
+      `${basePath(workspaceId, packId, versionId)}/${policyId}`,
+      body,
+    ),
+
+  updateStatus: (
+    workspaceId: number,
+    packId: number,
+    versionId: number,
+    policyId: number,
+    body: UpdatePolicyStatusRequest,
+  ) =>
+    apiClient.patch<PolicyDefinition>(
+      `${basePath(workspaceId, packId, versionId)}/${policyId}/status`,
+      body,
+    ),
+};
+```
+
+### Error Messages
+
+```typescript
+export const POLICY_ERROR_MESSAGES = {
+  POLICY_NOT_EDITABLE: "DRAFT 상태의 버전에서만 정책을 수정할 수 있습니다.",
+  POLICY_CODE_REFERENCED_BY_WORKFLOW:
+    "이 정책을 참조하는 워크플로우가 있어 비활성화할 수 없습니다.",
+  UPDATE_FAILED: "정책 수정에 실패했습니다.",
+  STATUS_FAILED: "정책 상태 변경에 실패했습니다.",
+  LOAD_FAILED: "정책 정보를 불러오지 못했습니다.",
+} as const;
+```
+
+---
+
+## Data Flow
+
+```
+PolicyDraftReadPage
+    │ parseRouteId(workspaceId, packId, versionId, policyId?)
+    ├── PolicyListPanel
+    │     usePolicyList(wsId, packId, versionId, retryKey)
+    │     └── policyApi.list → policyKeys.list
+    └── PolicyDetailPanel
+          usePolicyDetail(wsId, packId, versionId, policyId, retryKey)
+          ├── idle/loading/error/ready
+          └── EditButton → PolicyEditSheet open
+
+PolicyEditSheet
+    │ useGetPolicy({ workspaceId, packId, versionId, policyId, enabled: isOpen })
+    ├── loading/error/ready
+    └── PolicyEditForm
+          react-hook-form + zod
+          ├── submit → useUpdatePolicy.mutate
+          │            ├── onSuccess: invalidate detail/list, toast.success, onClose
+          │            └── onError: ApiRequestError code별 toast.error
+          └── PolicyStatusToggle
+                       └── useUpdatePolicyStatus.mutate
+                            ├── onMutate: detail/list optimistic status update
+                            ├── onError: rollback + toast.error
+                            └── onSuccess: invalidate detail/list
+```
+
+---
+
+## Form Rules
+
+### Editable fields
+
+| Field | UI | Rule |
+|-------|----|------|
+| `name` | Input | required, trim 후 빈 문자열 금지 |
+| `description` | Input 또는 Textarea | 빈 문자열은 `null`로 전송 |
+| `severity` | Select 또는 Input | `LOW`, `MEDIUM`, `HIGH`, `CRITICAL` 중 선택 권장. BE는 문자열 필드이므로 기존 값 보존 가능 |
+| `conditionJson` | JSON textarea | 유효한 JSON object 문자열 |
+| `actionJson` | JSON textarea | 유효한 JSON object 문자열 |
+| `evidenceJson` | JSON textarea | 유효한 JSON array 문자열 |
+| `metaJson` | JSON textarea | 유효한 JSON object 문자열 |
+| `status` | Switch | `ACTIVE` ↔ `INACTIVE` |
+
+### Read-only fields
+
+| Field | Reason |
+|-------|--------|
+| `policyCode` | Workflow ACTION node의 `policyRef`가 참조하는 immutable key |
+| `domainPackVersionId` | URL context로 고정 |
+| `createdAt`, `updatedAt` | server-managed audit fields |
+
+### zod schema
+
+```typescript
+export const policyEditSchema = z.object({
+  name: z.string().trim().min(1, "정책 이름은 필수입니다."),
+  description: z.string().nullable().optional(),
+  severity: z.string().nullable().optional(),
+  conditionJson: jsonObjectString("조건 JSON은 객체여야 합니다."),
+  actionJson: jsonObjectString("액션 JSON은 객체여야 합니다."),
+  evidenceJson: jsonArrayString("근거 JSON은 배열이어야 합니다."),
+  metaJson: jsonObjectString("메타 JSON은 객체여야 합니다."),
+});
+```
+
+JSON textarea는 저장 전 `JSON.parse`로 검증하되, 전송 값은 BE 계약에 맞춰 문자열 그대로 유지한다.
+
+---
+
+## 수정 대상 파일
+
+> 경로 기준: 아래 모든 경로는 repository root 기준이다.
+
+### 신규 생성 예정
+
+| 파일 | 설명 |
+|------|------|
+| `frontend/src/entities/policy/model/types.ts` | `PolicySummary`, `PolicyDefinition`, update request/status 타입 |
+| `frontend/src/entities/policy/api/index.ts` | `policyKeys`, `policyApi` |
+| `frontend/src/entities/policy/index.ts` | entity barrel export |
+| `frontend/src/features/policy-draft-read/model/mapApiError.ts` | list/detail 조회 에러 매핑 |
+| `frontend/src/features/policy-draft-read/model/usePolicyList.ts` | Policy 목록 조회 hook |
+| `frontend/src/features/policy-draft-read/model/usePolicyDetail.ts` | Policy 단건 조회 hook |
+| `frontend/src/features/policy-draft-read/ui/PolicyListPanel.tsx` | 목록 패널 |
+| `frontend/src/features/policy-draft-read/ui/PolicyListPanel.module.css` | 목록 패널 스타일 |
+| `frontend/src/features/policy-draft-read/ui/PolicyDetailPanel.tsx` | 상세 패널 + 수정 Sheet trigger |
+| `frontend/src/features/policy-draft-read/ui/PolicyDetailPanel.module.css` | 상세 패널 스타일 |
+| `frontend/src/features/policy-draft-read/ui/index.ts` | UI barrel export |
+| `frontend/src/features/update-policy/api/messages.ts` | Policy 수정 에러 메시지 |
+| `frontend/src/features/update-policy/api/useGetPolicy.ts` | Sheet용 단건 조회 hook |
+| `frontend/src/features/update-policy/api/useUpdatePolicy.ts` | 일반 필드 PATCH mutation |
+| `frontend/src/features/update-policy/api/useUpdatePolicyStatus.ts` | status PATCH mutation |
+| `frontend/src/features/update-policy/api/__tests__/useUpdatePolicy.test.ts` | mutation hook 테스트 |
+| `frontend/src/features/update-policy/model/schema.ts` | zod schema + JSON validator |
+| `frontend/src/features/update-policy/ui/JsonTextarea.tsx` | JSON textarea 공통 컴포넌트 |
+| `frontend/src/features/update-policy/ui/PolicyJsonFields.tsx` | condition/action/evidence/meta 필드 묶음 |
+| `frontend/src/features/update-policy/ui/PolicyStatusToggle.tsx` | ACTIVE/INACTIVE Switch |
+| `frontend/src/features/update-policy/ui/PolicyEditForm.tsx` | react-hook-form 기반 수정 폼 |
+| `frontend/src/features/update-policy/ui/PolicyEditSheet.tsx` | Sheet 진입점 |
+| `frontend/src/features/update-policy/index.ts` | feature barrel export |
+| `frontend/src/pages/domain-pack/ui/PolicyDraftReadPage.tsx` | Policy 목록/상세 페이지 |
+| `frontend/src/pages/domain-pack/ui/policy-draft-read-page.module.css` | 페이지 스타일 |
+
+### 수정 예정
+
+| 파일 | 변경 내용 |
+|------|----------|
+| `frontend/src/app/App.tsx` | `/workspaces/:workspaceId/domain-packs/:packId/versions/:versionId/policies/:policyId?` 라우트 추가 |
+| `frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.tsx` | 변경 없음. Policy 수정 기능과 직접 결합하지 않음 |
+| `frontend/src/features/update-workflow/ui/WorkflowEditSheet.tsx` | 변경 없음. `policyRef` 편집은 유지하고 Policy 본문 수정은 제외 |
+
+---
+
+## State Management
+
+### `useUpdatePolicy`
+
+```typescript
+export function useUpdatePolicy() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ workspaceId, packId, versionId, policyId, body }: UpdatePolicyParams) =>
+      policyApi.update(workspaceId, packId, versionId, policyId, body),
+    onSuccess: (_, { workspaceId, packId, versionId, policyId }) => {
+      queryClient.invalidateQueries({
+        queryKey: policyKeys.detail(workspaceId, packId, versionId, policyId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: policyKeys.list(workspaceId, packId, versionId),
+      });
+      toast.success("정책이 수정되었습니다.");
+    },
+    onError: (error: unknown) => {
+      if (error instanceof ApiRequestError && error.code === "POLICY_NOT_EDITABLE") {
+        toast.error(POLICY_ERROR_MESSAGES.POLICY_NOT_EDITABLE);
+        return;
+      }
+      toast.error(POLICY_ERROR_MESSAGES.UPDATE_FAILED);
+    },
+  });
+}
+```
+
+### `useUpdatePolicyStatus`
+
+- mutation key: `["updatePolicyStatus"] as const`
+- `onMutate`: `policyKeys.detail`과 `policyKeys.list`의 status를 optimistic update
+- `onError`: 이전 detail/list snapshot으로 rollback
+- `POLICY_CODE_REFERENCED_BY_WORKFLOW`: 참조 workflow 때문에 INACTIVE 전환 불가 toast 표시
+- `POLICY_NOT_EDITABLE`: DRAFT 아님 toast 표시
+- `onSuccess`: detail/list invalidate
+
+---
+
+## Design Constraints
+
+`frontend/DESIGN.md`를 따른다.
+
+- 색상은 기존 화면처럼 모노크롬 기반으로 유지한다.
+- 버튼/입력/Switch/Sheet는 `shared/ui` 컴포넌트를 우선 사용한다.
+- focus outline은 dashed 패턴을 유지한다.
+- 페이지 레이아웃은 Slot/Workflow draft read 화면의 2-pane 구조와 반응형 동작을 따른다.
+- `alert()`는 사용하지 않고 `sonner` toast를 사용한다.
+- 카드 중첩을 만들지 않고, 상세 정보 카드는 반복 정보 표시 단위에만 사용한다.
+- 긴 JSON 문자열은 `pre`/textarea 내부에서 줄바꿈 처리해 모바일/데스크톱 모두 overflow를 제어한다.
+
+---
+
+## Tests
+
+### Test Strategy
+
+| 구분 | 방법 | 도구 | 비고 |
+|------|------|------|------|
+| 단위 테스트 | hook mutation 테스트 | Vitest + Testing Library | `useUpdatePolicy`, `useUpdatePolicyStatus` |
+| 단위 테스트 | JSON validator 테스트 | Vitest | object/array 필드 검증 |
+| 컴포넌트 테스트 | list/detail 상태 렌더링 | Vitest + mock | loading/error/empty/ready |
+| 수동 테스트 | 브라우저 직접 확인 | `pnpm dev` | 실제 BE와 연동 |
+
+### Test Scenarios
+
+#### Happy Path
+
+| # | 시나리오 | 사전 조건 | 조작 | 기대 결과 |
+|---|---------|---------|------|----------|
+| 1 | Policy 목록 조회 | DRAFT version에 policy 2개 이상 | `/policies` 진입 | policyCode ASC 목록 표시 |
+| 2 | Policy 상세 조회 | policy 존재 | 목록 row 클릭 | URL에 policyId 반영, 상세 표시 |
+| 3 | 일반 필드 수정 | DRAFT version | 수정 Sheet 열기 → name/severity/JSON 수정 → 저장 | 성공 toast, Sheet 닫힘, 목록/상세 갱신 |
+| 4 | status 비활성화 | 참조 workflow 없음 | Switch OFF | status `INACTIVE`, list/detail 갱신 |
+| 5 | status 활성화 | `INACTIVE` policy | Switch ON | status `ACTIVE`, list/detail 갱신 |
+| 6 | 취소 | Sheet에서 값 수정 | 취소 클릭 | API 호출 없음, 원본 유지 |
+
+#### Error & Edge Cases
+
+| # | 시나리오 | 조작 | 기대 결과 |
+|---|---------|------|----------|
+| 1 | name 빈 문자열 | name 삭제 후 저장 | FormMessage, PATCH 호출 없음 |
+| 2 | conditionJson invalid | `{` 입력 후 저장 | FormMessage, PATCH 호출 없음 |
+| 3 | evidenceJson object 입력 | `{}` 입력 후 저장 | 배열 필요 FormMessage |
+| 4 | DRAFT 아닌 버전 수정 | 저장 또는 status 변경 | `POLICY_NOT_EDITABLE` toast |
+| 5 | 참조 workflow 있는 policy 비활성화 | ACTIVE → INACTIVE | `POLICY_CODE_REFERENCED_BY_WORKFLOW` toast, Switch rollback |
+| 6 | policyId 미존재 | URL 직접 진입 | 404 toast + 상세 error state |
+| 7 | 목록 조회 실패 | 네트워크/API 실패 | toast + 재시도 버튼 |
+| 8 | Sheet detail 조회 실패 | 수정 버튼 클릭 후 실패 | Sheet 유지 + 재시도 버튼 |
+
+#### 접근성
+
+| # | 확인 항목 | 기대 결과 |
+|---|---------|----------|
+| 1 | 목록 row 키보드 선택 | Tab 이동 후 Enter/Space로 선택 |
+| 2 | 수정 버튼 aria-label | policyCode 포함한 label 제공 |
+| 3 | Status Switch aria-label | "정책 상태" label 제공 |
+| 4 | JSON textarea label | 각 JSON 필드 label과 에러 메시지 연결 |
+| 5 | Focus outline | dashed outline 표시 |
+
+---
+
+## Done Criteria
+
+- [ ] `entities/policy` 타입/API/query key 추가
+- [ ] `PolicyDraftReadPage` 라우트 추가 및 잘못된 URL 파라미터 처리
+- [ ] `PolicyListPanel` loading/error/empty/ready 상태 구현
+- [ ] `PolicyDetailPanel` idle/loading/error/ready 상태 구현
+- [ ] 상세 화면에서 수정 버튼으로 `PolicyEditSheet` open
+- [ ] `PolicyEditSheet`는 open 시 detail query를 수행하고 실패 시 Sheet를 닫지 않음
+- [ ] `PolicyEditForm`은 react-hook-form + zod로 name/JSON 검증 수행
+- [ ] `policyCode`, `domainPackVersionId`는 read-only로 표시
+- [ ] 일반 수정 성공 시 `policyKeys.detail` + `policyKeys.list` invalidate 및 toast.success
+- [ ] status 수정은 optimistic update + 실패 rollback 적용
+- [ ] `POLICY_NOT_EDITABLE`, `POLICY_CODE_REFERENCED_BY_WORKFLOW` 전용 toast 메시지 처리
+- [ ] `alert()` 미사용, `sonner` toast 사용
+- [ ] FSD 의존성 방향 준수: `pages → features → entities → shared`
+- [ ] `frontend/DESIGN.md` 준수
+- [ ] `pnpm test` 통과
+
+---
+
+## Out of Scope
+
+- Policy 생성/삭제 기능
+- `policyCode` 수정 기능
+- Workflow editor 내부에서 Policy 본문을 직접 수정하는 기능
+- ACTION 노드 `policyRef` autocomplete/picker
+- Policy 변경 시 연관 Workflow 영향도 시각화
+- Risk/Slot/Workflow와 묶은 통합 Domain Pack 구성요소 탭 화면

--- a/.agent/specs/322.md
+++ b/.agent/specs/322.md
@@ -254,6 +254,7 @@ export const POLICY_ERROR_MESSAGES = {
   POLICY_NOT_EDITABLE: "DRAFT 상태의 버전에서만 정책을 수정할 수 있습니다.",
   POLICY_CODE_REFERENCED_BY_WORKFLOW:
     "이 정책을 참조하는 워크플로우가 있어 비활성화할 수 없습니다.",
+  VALIDATION_ERROR: "정책 데이터 검증에 실패했습니다. 입력값을 확인해주세요.",
   UPDATE_FAILED: "정책 수정에 실패했습니다.",
   STATUS_FAILED: "정책 상태 변경에 실패했습니다.",
   LOAD_FAILED: "정책 정보를 불러오지 못했습니다.",
@@ -329,7 +330,11 @@ export const policyEditSchema = z.object({
 });
 ```
 
-JSON textarea는 저장 전 `JSON.parse`로 검증하되, 전송 값은 BE 계약에 맞춰 문자열 그대로 유지한다.
+`frontend/src/features/update-policy/model/schema.ts`의 `jsonObjectString(message)`와 `jsonArrayString(message)`는 `policyEditSchema`에서 사용하는 사용자 정의 Zod refinement로 구현한다. 두 validator 모두 입력 타입을 `string`으로 유지해야 하며, 저장 전 `JSON.parse`로 검증하되 전송 값은 BE 계약에 맞춰 문자열 그대로 유지한다.
+
+- `jsonObjectString(message)`: 문자열을 `JSON.parse`한 결과가 `null`이 아니고 배열이 아닌 plain object인지 검증한다.
+- `jsonArrayString(message)`: 문자열을 `JSON.parse`한 결과가 array인지 검증한다.
+- 파싱 실패 또는 타입 불일치 시 전달받은 `message`를 Zod refinement 에러 메시지로 사용한다.
 
 ---
 
@@ -398,9 +403,15 @@ export function useUpdatePolicy() {
       toast.success("정책이 수정되었습니다.");
     },
     onError: (error: unknown) => {
-      if (error instanceof ApiRequestError && error.code === "POLICY_NOT_EDITABLE") {
-        toast.error(POLICY_ERROR_MESSAGES.POLICY_NOT_EDITABLE);
-        return;
+      if (error instanceof ApiRequestError) {
+        if (error.code === "POLICY_NOT_EDITABLE") {
+          toast.error(POLICY_ERROR_MESSAGES.POLICY_NOT_EDITABLE);
+          return;
+        }
+        if (error.code === "VALIDATION_ERROR") {
+          toast.error(POLICY_ERROR_MESSAGES.VALIDATION_ERROR);
+          return;
+        }
       }
       toast.error(POLICY_ERROR_MESSAGES.UPDATE_FAILED);
     },


### PR DESCRIPTION
## Summary

- Add `.agent/specs/322.md` for the Policy edit frontend feature.
- Define a separate Policy draft read/edit screen instead of extending the Workflow editor from spec 324.
- Base the FE API contract on the Policy update/status APIs from spec 327, plus existing policy list/detail APIs and the policyRef reverse-reference error from spec 100.

## Validation

- `git diff --cached --check`
- pre-commit ran during commit; lint-staged found no matching staged files because this is a docs-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **설명서**
  * 정책 수정 기능에 대한 사양이 추가되었습니다. 정책 초안 검토, 편집 인터페이스, 폼 검증, 상태 변경, 오류 처리 및 사용자 알림 시스템을 포함합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->