### PR TITLE
feat(domain-pack): implement policy edit flow

### DIFF
--- a/.agent/specs/322.md
+++ b/.agent/specs/322.md
@@ -1,0 +1,512 @@
+# Spec 322 — [Console] Policy 수정 기능 구현
+
+**Branch**: `spec/322`
+**Canonical Number**: `322`
+**Type**: Frontend (FSD)
+**작성일**: 2026-04-27
+
+---
+
+## Goal
+
+운영자가 Domain Pack Version의 Policy 초안을 목록/상세로 확인하고, `327.md`의 Policy 수정 API를 사용해 Policy 일반 필드와 status를 수정할 수 있는 프런트엔드 화면을 구현한다.
+
+---
+
+## Scope Decision
+
+### 324 화면에 붙이지 않고 별도 Policy 화면으로 구현한다
+
+`324.md`의 Workflow 편집 화면은 ACTION 노드의 `policyRef`를 입력/검증하는 워크플로우 그래프 편집 책임을 가진다. Policy 자체의 `name`, `severity`, JSON 조건/액션, status 수정은 별도 도메인 구성요소 편집 책임이므로 `PolicyDraftReadPage + PolicyEditSheet`로 분리한다.
+
+이 결정의 기준:
+- Workflow 편집기는 `workflow_definition.graphJson` 전체 교체가 핵심이고, Policy 편집기는 `policy_definition` 단건 수정이 핵심이다.
+- `policyCode`는 immutable이며 Workflow의 `policyRef`가 참조하는 값이다. 같은 화면에서 policy 본문 수정과 graph 수정을 섞으면 저장 책임과 에러 복구가 복잡해진다.
+- 이미 구현된 `update-slot`의 Sheet/Form/StatusToggle 패턴이 Policy 수정에 더 직접적으로 재사용 가능하다.
+- 추후 Workflow ACTION 노드의 `policyRef`에서 Policy 상세 화면으로 이동하거나 Policy picker/autocomplete를 붙이는 작업은 별도 스펙으로 분리한다.
+
+---
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A[PolicyDraftReadPage 진입\n/workspaces/:wsId/domain-packs/:packId/versions/:versionId/policies] --> B[usePolicyList 호출]
+    B -->|loading| C[목록 skeleton]
+    B -->|error| D[toast.error + 재시도 버튼]
+    B -->|empty| E[빈 상태 표시]
+    B -->|success| F[PolicyListPanel 표시]
+
+    F --> G{Policy 선택}
+    G -->|선택 없음| H[상세 placeholder]
+    G -->|선택| I[URL /policies/:policyId 이동]
+    I --> J[usePolicyDetail 호출]
+    J -->|loading| K[상세 skeleton]
+    J -->|error| L[toast.error + 재시도 버튼]
+    J -->|success| M[PolicyDetailPanel 표시]
+
+    M --> N[수정 버튼 클릭]
+    N --> O[PolicyEditSheet 열기]
+    O --> P[useGetPolicy 호출\nenabled: isOpen]
+    P -->|loading| Q[Sheet spinner]
+    P -->|error| R[Sheet 유지 + 재시도 버튼]
+    P -->|success| S[PolicyEditForm 렌더링]
+
+    S --> T{사용자 액션}
+    T -->|일반 필드 수정 후 저장| U[zod: name + JSON 필드 검증]
+    U -->|실패| V[FormMessage 표시\nAPI 호출 없음]
+    U -->|통과| W[PATCH /policies/{policyId}]
+    W -->|success| X[toast.success + Sheet 닫기\nlist/detail invalidate]
+    W -->|POLICY_NOT_EDITABLE| Y[toast.error DRAFT 안내]
+    W -->|VALIDATION_ERROR| Z[toast.error 또는 FormMessage]
+    W -->|기타 실패| AA[toast.error]
+
+    T -->|status switch 변경| AB[PATCH /policies/{policyId}/status]
+    AB -->|success| AC[detail/list optimistic update 후 invalidate]
+    AB -->|POLICY_CODE_REFERENCED_BY_WORKFLOW| AD[toast.error 참조 workflow 안내 + rollback]
+    AB -->|POLICY_NOT_EDITABLE| AE[toast.error DRAFT 안내 + rollback]
+    AB -->|기타 실패| AF[toast.error + rollback]
+```
+
+---
+
+## Design Diff
+
+### As-is vs To-be
+
+| 영역 | As-is | To-be | 변경 내용 |
+|------|-------|-------|----------|
+| Policy FE 화면 | 없음 | `PolicyDraftReadPage` | 신규 라우트와 2-pane 목록/상세 화면 추가 |
+| Policy 조회 | BE GET API만 존재 | `policyApi.list/detail` + hooks | 3212/2211 API를 FE에서 사용 |
+| Policy 일반 수정 | BE PATCH API만 존재 | `PolicyEditSheet` + `PolicyEditForm` | 327 API 연동 |
+| Policy status 수정 | BE PATCH API만 존재 | `PolicyStatusToggle` | 327 API + 100 에러 처리 |
+| Workflow 편집 화면 | ACTION `policyRef` 직접 입력 | 그대로 유지 | Policy 자체 편집은 이 화면에 넣지 않음 |
+| Slot 수정 화면 | 구현됨 | Policy 수정의 기준 패턴 | `update-slot` 구조 재사용 |
+
+---
+
+## Prerequisites
+
+### BE API
+
+| Source | Method | Path | Description |
+|--------|--------|------|-------------|
+| 3212 | GET | `/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/policies` | Policy 목록 조회 |
+| 2211 | GET | `/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/policies/{policyId}` | Policy 단건 조회 |
+| 327 | PATCH | `/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/policies/{policyId}` | Policy 일반 필드 수정 |
+| 327 | PATCH | `/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/policies/{policyId}/status` | Policy status 전환 |
+| 100 | PATCH | 동일 status endpoint | INACTIVE 전환 시 workflow `policyRef` 역참조 차단 |
+
+### Existing FE Patterns
+
+구현 시 아래 기존 파일의 패턴을 따른다.
+
+| Existing file | 재사용 기준 |
+|---------------|------------|
+| `frontend/src/pages/domain-pack/ui/SlotDraftReadPage.tsx` | 목록/상세 2-pane 라우팅 구조 |
+| `frontend/src/features/slot-draft-read/ui/SlotListPanel.tsx` | 목록 loading/error/empty/ready 상태 |
+| `frontend/src/features/slot-draft-read/ui/SlotDetailPanel.tsx` | 상세 loading/error/idle/ready 상태 |
+| `frontend/src/features/update-slot/ui/SlotEditSheet.tsx` | Sheet open 시 detail query, error retry |
+| `frontend/src/features/update-slot/ui/SlotEditForm.tsx` | react-hook-form + zod + status toggle 배치 |
+| `frontend/src/features/update-slot/api/useUpdateSlot.ts` | PATCH 성공 시 detail/list invalidate + toast |
+| `frontend/src/features/update-slot/api/useUpdateSlotStatus.ts` | status optimistic update + rollback |
+| `frontend/src/features/update-workflow/ui/WorkflowEditSheet.tsx` | 큰 편집 컨텍스트에서 Sheet 상태 유지 방식 |
+
+---
+
+## Component Tree
+
+```
+App
+└── Route /workspaces/:workspaceId/domain-packs/:packId/versions/:versionId/policies/:policyId?
+    └── PolicyDraftReadPage
+        ├── DashboardLayout
+        ├── PageHeader
+        ├── PolicyListPanel
+        │   ├── loading skeleton
+        │   ├── error + retry
+        │   ├── empty state
+        │   └── PolicyListRow[]
+        └── PolicyDetailPanel
+            ├── idle placeholder
+            ├── loading skeleton
+            ├── error + retry
+            └── ready
+                ├── DetailHeader
+                │   └── EditButton
+                ├── InfoCard grid
+                ├── JsonCard(condition/action/evidence/meta)
+                └── PolicyEditSheet
+                    ├── SheetHeader
+                    ├── loading spinner
+                    ├── error + retry
+                    └── PolicyEditForm
+                        ├── name input
+                        ├── description input
+                        ├── severity select/input
+                        ├── policyCode read-only
+                        ├── PolicyJsonFields
+                        ├── PolicyStatusToggle
+                        └── save/cancel buttons
+```
+
+---
+
+## API Integration
+
+### Query Key Pattern
+
+```typescript
+// frontend/src/entities/policy/api/index.ts
+export const policyKeys = {
+  all: ["policies"] as const,
+  lists: () => [...policyKeys.all, "list"] as const,
+  list: (workspaceId: number, packId: number, versionId: number) =>
+    [...policyKeys.lists(), workspaceId, packId, versionId] as const,
+  detail: (workspaceId: number, packId: number, versionId: number, policyId: number) =>
+    [...policyKeys.all, "detail", workspaceId, packId, versionId, policyId] as const,
+};
+```
+
+### Types
+
+```typescript
+// frontend/src/entities/policy/model/types.ts
+export type PolicyStatus = "ACTIVE" | "INACTIVE";
+
+export interface PolicySummary {
+  id: number;
+  domainPackVersionId: number;
+  policyCode: string;
+  name: string;
+  description: string | null;
+  severity: string | null;
+  status: PolicyStatus;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface PolicyDefinition extends PolicySummary {
+  conditionJson: string;
+  actionJson: string;
+  evidenceJson: string;
+  metaJson: string;
+}
+
+export interface UpdatePolicyRequest {
+  name: string;
+  description?: string | null;
+  severity?: string | null;
+  conditionJson?: string | null;
+  actionJson?: string | null;
+  evidenceJson?: string | null;
+  metaJson?: string | null;
+}
+
+export interface UpdatePolicyStatusRequest {
+  status: PolicyStatus;
+}
+```
+
+### API Functions
+
+```typescript
+const basePath = (workspaceId: number, packId: number, versionId: number) =>
+  `/workspaces/${workspaceId}/domain-packs/${packId}/versions/${versionId}/policies`;
+
+export const policyApi = {
+  list: (workspaceId: number, packId: number, versionId: number) =>
+    apiClient.get<PolicySummary[]>(basePath(workspaceId, packId, versionId)),
+
+  detail: (workspaceId: number, packId: number, versionId: number, policyId: number) =>
+    apiClient.get<PolicyDefinition>(`${basePath(workspaceId, packId, versionId)}/${policyId}`),
+
+  update: (
+    workspaceId: number,
+    packId: number,
+    versionId: number,
+    policyId: number,
+    body: UpdatePolicyRequest,
+  ) =>
+    apiClient.patch<PolicyDefinition>(
+      `${basePath(workspaceId, packId, versionId)}/${policyId}`,
+      body,
+    ),
+
+  updateStatus: (
+    workspaceId: number,
+    packId: number,
+    versionId: number,
+    policyId: number,
+    body: UpdatePolicyStatusRequest,
+  ) =>
+    apiClient.patch<PolicyDefinition>(
+      `${basePath(workspaceId, packId, versionId)}/${policyId}/status`,
+      body,
+    ),
+};
+```
+
+### Error Messages
+
+```typescript
+export const POLICY_ERROR_MESSAGES = {
+  POLICY_NOT_EDITABLE: "DRAFT 상태의 버전에서만 정책을 수정할 수 있습니다.",
+  POLICY_CODE_REFERENCED_BY_WORKFLOW:
+    "이 정책을 참조하는 워크플로우가 있어 비활성화할 수 없습니다.",
+  UPDATE_FAILED: "정책 수정에 실패했습니다.",
+  STATUS_FAILED: "정책 상태 변경에 실패했습니다.",
+  LOAD_FAILED: "정책 정보를 불러오지 못했습니다.",
+} as const;
+```
+
+---
+
+## Data Flow
+
+```
+PolicyDraftReadPage
+    │ parseRouteId(workspaceId, packId, versionId, policyId?)
+    ├── PolicyListPanel
+    │     usePolicyList(wsId, packId, versionId, retryKey)
+    │     └── policyApi.list → policyKeys.list
+    └── PolicyDetailPanel
+          usePolicyDetail(wsId, packId, versionId, policyId, retryKey)
+          ├── idle/loading/error/ready
+          └── EditButton → PolicyEditSheet open
+
+PolicyEditSheet
+    │ useGetPolicy({ workspaceId, packId, versionId, policyId, enabled: isOpen })
+    ├── loading/error/ready
+    └── PolicyEditForm
+          react-hook-form + zod
+          ├── submit → useUpdatePolicy.mutate
+          │            ├── onSuccess: invalidate detail/list, toast.success, onClose
+          │            └── onError: ApiRequestError code별 toast.error
+          └── PolicyStatusToggle
+                       └── useUpdatePolicyStatus.mutate
+                            ├── onMutate: detail/list optimistic status update
+                            ├── onError: rollback + toast.error
+                            └── onSuccess: invalidate detail/list
+```
+
+---
+
+## Form Rules
+
+### Editable fields
+
+| Field | UI | Rule |
+|-------|----|------|
+| `name` | Input | required, trim 후 빈 문자열 금지 |
+| `description` | Input 또는 Textarea | 빈 문자열은 `null`로 전송 |
+| `severity` | Select 또는 Input | `LOW`, `MEDIUM`, `HIGH`, `CRITICAL` 중 선택 권장. BE는 문자열 필드이므로 기존 값 보존 가능 |
+| `conditionJson` | JSON textarea | 유효한 JSON object 문자열 |
+| `actionJson` | JSON textarea | 유효한 JSON object 문자열 |
+| `evidenceJson` | JSON textarea | 유효한 JSON array 문자열 |
+| `metaJson` | JSON textarea | 유효한 JSON object 문자열 |
+| `status` | Switch | `ACTIVE` ↔ `INACTIVE` |
+
+### Read-only fields
+
+| Field | Reason |
+|-------|--------|
+| `policyCode` | Workflow ACTION node의 `policyRef`가 참조하는 immutable key |
+| `domainPackVersionId` | URL context로 고정 |
+| `createdAt`, `updatedAt` | server-managed audit fields |
+
+### zod schema
+
+```typescript
+export const policyEditSchema = z.object({
+  name: z.string().trim().min(1, "정책 이름은 필수입니다."),
+  description: z.string().nullable().optional(),
+  severity: z.string().nullable().optional(),
+  conditionJson: jsonObjectString("조건 JSON은 객체여야 합니다."),
+  actionJson: jsonObjectString("액션 JSON은 객체여야 합니다."),
+  evidenceJson: jsonArrayString("근거 JSON은 배열이어야 합니다."),
+  metaJson: jsonObjectString("메타 JSON은 객체여야 합니다."),
+});
+```
+
+JSON textarea는 저장 전 `JSON.parse`로 검증하되, 전송 값은 BE 계약에 맞춰 문자열 그대로 유지한다.
+
+---
+
+## 수정 대상 파일
+
+> 경로 기준: 아래 모든 경로는 repository root 기준이다.
+
+### 신규 생성 예정
+
+| 파일 | 설명 |
+|------|------|
+| `frontend/src/entities/policy/model/types.ts` | `PolicySummary`, `PolicyDefinition`, update request/status 타입 |
+| `frontend/src/entities/policy/api/index.ts` | `policyKeys`, `policyApi` |
+| `frontend/src/entities/policy/index.ts` | entity barrel export |
+| `frontend/src/features/policy-draft-read/model/mapApiError.ts` | list/detail 조회 에러 매핑 |
+| `frontend/src/features/policy-draft-read/model/usePolicyList.ts` | Policy 목록 조회 hook |
+| `frontend/src/features/policy-draft-read/model/usePolicyDetail.ts` | Policy 단건 조회 hook |
+| `frontend/src/features/policy-draft-read/ui/PolicyListPanel.tsx` | 목록 패널 |
+| `frontend/src/features/policy-draft-read/ui/PolicyListPanel.module.css` | 목록 패널 스타일 |
+| `frontend/src/features/policy-draft-read/ui/PolicyDetailPanel.tsx` | 상세 패널 + 수정 Sheet trigger |
+| `frontend/src/features/policy-draft-read/ui/PolicyDetailPanel.module.css` | 상세 패널 스타일 |
+| `frontend/src/features/policy-draft-read/ui/index.ts` | UI barrel export |
+| `frontend/src/features/update-policy/api/messages.ts` | Policy 수정 에러 메시지 |
+| `frontend/src/features/update-policy/api/useGetPolicy.ts` | Sheet용 단건 조회 hook |
+| `frontend/src/features/update-policy/api/useUpdatePolicy.ts` | 일반 필드 PATCH mutation |
+| `frontend/src/features/update-policy/api/useUpdatePolicyStatus.ts` | status PATCH mutation |
+| `frontend/src/features/update-policy/api/__tests__/useUpdatePolicy.test.ts` | mutation hook 테스트 |
+| `frontend/src/features/update-policy/model/schema.ts` | zod schema + JSON validator |
+| `frontend/src/features/update-policy/ui/JsonTextarea.tsx` | JSON textarea 공통 컴포넌트 |
+| `frontend/src/features/update-policy/ui/PolicyJsonFields.tsx` | condition/action/evidence/meta 필드 묶음 |
+| `frontend/src/features/update-policy/ui/PolicyStatusToggle.tsx` | ACTIVE/INACTIVE Switch |
+| `frontend/src/features/update-policy/ui/PolicyEditForm.tsx` | react-hook-form 기반 수정 폼 |
+| `frontend/src/features/update-policy/ui/PolicyEditSheet.tsx` | Sheet 진입점 |
+| `frontend/src/features/update-policy/index.ts` | feature barrel export |
+| `frontend/src/pages/domain-pack/ui/PolicyDraftReadPage.tsx` | Policy 목록/상세 페이지 |
+| `frontend/src/pages/domain-pack/ui/policy-draft-read-page.module.css` | 페이지 스타일 |
+
+### 수정 예정
+
+| 파일 | 변경 내용 |
+|------|----------|
+| `frontend/src/app/App.tsx` | `/workspaces/:workspaceId/domain-packs/:packId/versions/:versionId/policies/:policyId?` 라우트 추가 |
+| `frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.tsx` | 변경 없음. Policy 수정 기능과 직접 결합하지 않음 |
+| `frontend/src/features/update-workflow/ui/WorkflowEditSheet.tsx` | 변경 없음. `policyRef` 편집은 유지하고 Policy 본문 수정은 제외 |
+
+---
+
+## State Management
+
+### `useUpdatePolicy`
+
+```typescript
+export function useUpdatePolicy() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ workspaceId, packId, versionId, policyId, body }: UpdatePolicyParams) =>
+      policyApi.update(workspaceId, packId, versionId, policyId, body),
+    onSuccess: (_, { workspaceId, packId, versionId, policyId }) => {
+      queryClient.invalidateQueries({
+        queryKey: policyKeys.detail(workspaceId, packId, versionId, policyId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: policyKeys.list(workspaceId, packId, versionId),
+      });
+      toast.success("정책이 수정되었습니다.");
+    },
+    onError: (error: unknown) => {
+      if (error instanceof ApiRequestError && error.code === "POLICY_NOT_EDITABLE") {
+        toast.error(POLICY_ERROR_MESSAGES.POLICY_NOT_EDITABLE);
+        return;
+      }
+      toast.error(POLICY_ERROR_MESSAGES.UPDATE_FAILED);
+    },
+  });
+}
+```
+
+### `useUpdatePolicyStatus`
+
+- mutation key: `["updatePolicyStatus"] as const`
+- `onMutate`: `policyKeys.detail`과 `policyKeys.list`의 status를 optimistic update
+- `onError`: 이전 detail/list snapshot으로 rollback
+- `POLICY_CODE_REFERENCED_BY_WORKFLOW`: 참조 workflow 때문에 INACTIVE 전환 불가 toast 표시
+- `POLICY_NOT_EDITABLE`: DRAFT 아님 toast 표시
+- `onSuccess`: detail/list invalidate
+
+---
+
+## Design Constraints
+
+`frontend/DESIGN.md`를 따른다.
+
+- 색상은 기존 화면처럼 모노크롬 기반으로 유지한다.
+- 버튼/입력/Switch/Sheet는 `shared/ui` 컴포넌트를 우선 사용한다.
+- focus outline은 dashed 패턴을 유지한다.
+- 페이지 레이아웃은 Slot/Workflow draft read 화면의 2-pane 구조와 반응형 동작을 따른다.
+- `alert()`는 사용하지 않고 `sonner` toast를 사용한다.
+- 카드 중첩을 만들지 않고, 상세 정보 카드는 반복 정보 표시 단위에만 사용한다.
+- 긴 JSON 문자열은 `pre`/textarea 내부에서 줄바꿈 처리해 모바일/데스크톱 모두 overflow를 제어한다.
+
+---
+
+## Tests
+
+### Test Strategy
+
+| 구분 | 방법 | 도구 | 비고 |
+|------|------|------|------|
+| 단위 테스트 | hook mutation 테스트 | Vitest + Testing Library | `useUpdatePolicy`, `useUpdatePolicyStatus` |
+| 단위 테스트 | JSON validator 테스트 | Vitest | object/array 필드 검증 |
+| 컴포넌트 테스트 | list/detail 상태 렌더링 | Vitest + mock | loading/error/empty/ready |
+| 수동 테스트 | 브라우저 직접 확인 | `pnpm dev` | 실제 BE와 연동 |
+
+### Test Scenarios
+
+#### Happy Path
+
+| # | 시나리오 | 사전 조건 | 조작 | 기대 결과 |
+|---|---------|---------|------|----------|
+| 1 | Policy 목록 조회 | DRAFT version에 policy 2개 이상 | `/policies` 진입 | policyCode ASC 목록 표시 |
+| 2 | Policy 상세 조회 | policy 존재 | 목록 row 클릭 | URL에 policyId 반영, 상세 표시 |
+| 3 | 일반 필드 수정 | DRAFT version | 수정 Sheet 열기 → name/severity/JSON 수정 → 저장 | 성공 toast, Sheet 닫힘, 목록/상세 갱신 |
+| 4 | status 비활성화 | 참조 workflow 없음 | Switch OFF | status `INACTIVE`, list/detail 갱신 |
+| 5 | status 활성화 | `INACTIVE` policy | Switch ON | status `ACTIVE`, list/detail 갱신 |
+| 6 | 취소 | Sheet에서 값 수정 | 취소 클릭 | API 호출 없음, 원본 유지 |
+
+#### Error & Edge Cases
+
+| # | 시나리오 | 조작 | 기대 결과 |
+|---|---------|------|----------|
+| 1 | name 빈 문자열 | name 삭제 후 저장 | FormMessage, PATCH 호출 없음 |
+| 2 | conditionJson invalid | `{` 입력 후 저장 | FormMessage, PATCH 호출 없음 |
+| 3 | evidenceJson object 입력 | `{}` 입력 후 저장 | 배열 필요 FormMessage |
+| 4 | DRAFT 아닌 버전 수정 | 저장 또는 status 변경 | `POLICY_NOT_EDITABLE` toast |
+| 5 | 참조 workflow 있는 policy 비활성화 | ACTIVE → INACTIVE | `POLICY_CODE_REFERENCED_BY_WORKFLOW` toast, Switch rollback |
+| 6 | policyId 미존재 | URL 직접 진입 | 404 toast + 상세 error state |
+| 7 | 목록 조회 실패 | 네트워크/API 실패 | toast + 재시도 버튼 |
+| 8 | Sheet detail 조회 실패 | 수정 버튼 클릭 후 실패 | Sheet 유지 + 재시도 버튼 |
+
+#### 접근성
+
+| # | 확인 항목 | 기대 결과 |
+|---|---------|----------|
+| 1 | 목록 row 키보드 선택 | Tab 이동 후 Enter/Space로 선택 |
+| 2 | 수정 버튼 aria-label | policyCode 포함한 label 제공 |
+| 3 | Status Switch aria-label | "정책 상태" label 제공 |
+| 4 | JSON textarea label | 각 JSON 필드 label과 에러 메시지 연결 |
+| 5 | Focus outline | dashed outline 표시 |
+
+---
+
+## Done Criteria
+
+- [ ] `entities/policy` 타입/API/query key 추가
+- [ ] `PolicyDraftReadPage` 라우트 추가 및 잘못된 URL 파라미터 처리
+- [ ] `PolicyListPanel` loading/error/empty/ready 상태 구현
+- [ ] `PolicyDetailPanel` idle/loading/error/ready 상태 구현
+- [ ] 상세 화면에서 수정 버튼으로 `PolicyEditSheet` open
+- [ ] `PolicyEditSheet`는 open 시 detail query를 수행하고 실패 시 Sheet를 닫지 않음
+- [ ] `PolicyEditForm`은 react-hook-form + zod로 name/JSON 검증 수행
+- [ ] `policyCode`, `domainPackVersionId`는 read-only로 표시
+- [ ] 일반 수정 성공 시 `policyKeys.detail` + `policyKeys.list` invalidate 및 toast.success
+- [ ] status 수정은 optimistic update + 실패 rollback 적용
+- [ ] `POLICY_NOT_EDITABLE`, `POLICY_CODE_REFERENCED_BY_WORKFLOW` 전용 toast 메시지 처리
+- [ ] `alert()` 미사용, `sonner` toast 사용
+- [ ] FSD 의존성 방향 준수: `pages → features → entities → shared`
+- [ ] `frontend/DESIGN.md` 준수
+- [ ] `pnpm test` 통과
+
+---
+
+## Out of Scope
+
+- Policy 생성/삭제 기능
+- `policyCode` 수정 기능
+- Workflow editor 내부에서 Policy 본문을 직접 수정하는 기능
+- ACTION 노드 `policyRef` autocomplete/picker
+- Policy 변경 시 연관 Workflow 영향도 시각화
+- Risk/Slot/Workflow와 묶은 통합 Domain Pack 구성요소 탭 화면

--- a/.agent/specs/322.md
+++ b/.agent/specs/322.md
@@ -254,6 +254,7 @@ export const POLICY_ERROR_MESSAGES = {
   POLICY_NOT_EDITABLE: "DRAFT 상태의 버전에서만 정책을 수정할 수 있습니다.",
   POLICY_CODE_REFERENCED_BY_WORKFLOW:
     "이 정책을 참조하는 워크플로우가 있어 비활성화할 수 없습니다.",
+  VALIDATION_ERROR: "정책 데이터 검증에 실패했습니다. 입력값을 확인해주세요.",
   UPDATE_FAILED: "정책 수정에 실패했습니다.",
   STATUS_FAILED: "정책 상태 변경에 실패했습니다.",
   LOAD_FAILED: "정책 정보를 불러오지 못했습니다.",
@@ -329,7 +330,11 @@ export const policyEditSchema = z.object({
 });
 ```
 
-JSON textarea는 저장 전 `JSON.parse`로 검증하되, 전송 값은 BE 계약에 맞춰 문자열 그대로 유지한다.
+`frontend/src/features/update-policy/model/schema.ts`의 `jsonObjectString(message)`와 `jsonArrayString(message)`는 `policyEditSchema`에서 사용하는 사용자 정의 Zod refinement로 구현한다. 두 validator 모두 입력 타입을 `string`으로 유지해야 하며, 저장 전 `JSON.parse`로 검증하되 전송 값은 BE 계약에 맞춰 문자열 그대로 유지한다.
+
+- `jsonObjectString(message)`: 문자열을 `JSON.parse`한 결과가 `null`이 아니고 배열이 아닌 plain object인지 검증한다.
+- `jsonArrayString(message)`: 문자열을 `JSON.parse`한 결과가 array인지 검증한다.
+- 파싱 실패 또는 타입 불일치 시 전달받은 `message`를 Zod refinement 에러 메시지로 사용한다.
 
 ---
 
@@ -398,9 +403,15 @@ export function useUpdatePolicy() {
       toast.success("정책이 수정되었습니다.");
     },
     onError: (error: unknown) => {
-      if (error instanceof ApiRequestError && error.code === "POLICY_NOT_EDITABLE") {
-        toast.error(POLICY_ERROR_MESSAGES.POLICY_NOT_EDITABLE);
-        return;
+      if (error instanceof ApiRequestError) {
+        if (error.code === "POLICY_NOT_EDITABLE") {
+          toast.error(POLICY_ERROR_MESSAGES.POLICY_NOT_EDITABLE);
+          return;
+        }
+        if (error.code === "VALIDATION_ERROR") {
+          toast.error(POLICY_ERROR_MESSAGES.VALIDATION_ERROR);
+          return;
+        }
       }
       toast.error(POLICY_ERROR_MESSAGES.UPDATE_FAILED);
     },

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ agent-local-status.sh
 
 # Playwright MCP 파일
 .playwright-mcp
+.playwright-cli/

--- a/backend/src/main/java/com/init/domainpack/application/DomainPackDraftEntryResult.java
+++ b/backend/src/main/java/com/init/domainpack/application/DomainPackDraftEntryResult.java
@@ -1,0 +1,16 @@
+package com.init.domainpack.application;
+
+import com.init.domainpack.domain.repository.DomainPackDraftEntryRow;
+
+public record DomainPackDraftEntryResult(
+    Long workspaceId, Long packId, Long versionId, String packName, Integer versionNo) {
+
+  public static DomainPackDraftEntryResult from(DomainPackDraftEntryRow row) {
+    return new DomainPackDraftEntryResult(
+        row.getWorkspaceId(),
+        row.getPackId(),
+        row.getVersionId(),
+        row.getPackName(),
+        row.getVersionNo());
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/application/GetDomainPackDraftEntryQuery.java
+++ b/backend/src/main/java/com/init/domainpack/application/GetDomainPackDraftEntryQuery.java
@@ -1,4 +1,3 @@
 package com.init.domainpack.application;
 
-public record GetDomainPackDraftEntryQuery(Long workspaceId, Long userId) {
-}
+public record GetDomainPackDraftEntryQuery(Long workspaceId, Long userId) {}

--- a/backend/src/main/java/com/init/domainpack/application/GetDomainPackDraftEntryQuery.java
+++ b/backend/src/main/java/com/init/domainpack/application/GetDomainPackDraftEntryQuery.java
@@ -1,0 +1,4 @@
+package com.init.domainpack.application;
+
+public record GetDomainPackDraftEntryQuery(Long workspaceId, Long userId) {
+}

--- a/backend/src/main/java/com/init/domainpack/application/GetDomainPackDraftEntryUseCase.java
+++ b/backend/src/main/java/com/init/domainpack/application/GetDomainPackDraftEntryUseCase.java
@@ -1,0 +1,29 @@
+package com.init.domainpack.application;
+
+import com.init.domainpack.application.exception.DomainPackDraftEntryNotFoundException;
+import com.init.domainpack.domain.repository.DomainPackRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class GetDomainPackDraftEntryUseCase {
+
+  private final DomainPackValidator validator;
+  private final DomainPackRepository domainPackRepository;
+
+  public GetDomainPackDraftEntryUseCase(
+      DomainPackValidator validator, DomainPackRepository domainPackRepository) {
+    this.validator = validator;
+    this.domainPackRepository = domainPackRepository;
+  }
+
+  public DomainPackDraftEntryResult execute(GetDomainPackDraftEntryQuery query) {
+    validator.validateWorkspaceAccess(query.workspaceId(), query.userId());
+
+    return domainPackRepository
+        .findLatestDraftEntryByWorkspaceId(query.workspaceId())
+        .map(DomainPackDraftEntryResult::from)
+        .orElseThrow(() -> new DomainPackDraftEntryNotFoundException(query.workspaceId()));
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/application/exception/DomainPackDraftEntryNotFoundException.java
+++ b/backend/src/main/java/com/init/domainpack/application/exception/DomainPackDraftEntryNotFoundException.java
@@ -2,6 +2,7 @@ package com.init.domainpack.application.exception;
 
 import com.init.shared.application.exception.NotFoundException;
 
+@SuppressWarnings("java:S110")
 public class DomainPackDraftEntryNotFoundException extends NotFoundException {
 
   public DomainPackDraftEntryNotFoundException(Long workspaceId) {

--- a/backend/src/main/java/com/init/domainpack/application/exception/DomainPackDraftEntryNotFoundException.java
+++ b/backend/src/main/java/com/init/domainpack/application/exception/DomainPackDraftEntryNotFoundException.java
@@ -1,0 +1,12 @@
+package com.init.domainpack.application.exception;
+
+import com.init.shared.application.exception.NotFoundException;
+
+public class DomainPackDraftEntryNotFoundException extends NotFoundException {
+
+  public DomainPackDraftEntryNotFoundException(Long workspaceId) {
+    super(
+        "DOMAIN_PACK_DRAFT_ENTRY_NOT_FOUND",
+        "Draft domain pack version not found for workspace: " + workspaceId);
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/domain/repository/DomainPackDraftEntryRow.java
+++ b/backend/src/main/java/com/init/domainpack/domain/repository/DomainPackDraftEntryRow.java
@@ -1,0 +1,14 @@
+package com.init.domainpack.domain.repository;
+
+public interface DomainPackDraftEntryRow {
+
+  Long getWorkspaceId();
+
+  Long getPackId();
+
+  Long getVersionId();
+
+  String getPackName();
+
+  Integer getVersionNo();
+}

--- a/backend/src/main/java/com/init/domainpack/domain/repository/DomainPackRepository.java
+++ b/backend/src/main/java/com/init/domainpack/domain/repository/DomainPackRepository.java
@@ -1,6 +1,10 @@
 package com.init.domainpack.domain.repository;
 
+import java.util.Optional;
+
 public interface DomainPackRepository {
 
   boolean existsByIdAndWorkspaceId(Long packId, Long workspaceId);
+
+  Optional<DomainPackDraftEntryRow> findLatestDraftEntryByWorkspaceId(Long workspaceId);
 }

--- a/backend/src/main/java/com/init/domainpack/infrastructure/persistence/JpaDomainPackRepository.java
+++ b/backend/src/main/java/com/init/domainpack/infrastructure/persistence/JpaDomainPackRepository.java
@@ -17,6 +17,7 @@ public interface JpaDomainPackRepository
   @Query(
       value =
           """
+          -- Keep status literals aligned with DomainPack.STATUS_ACTIVE and draft lifecycle values.
           SELECT
             p.workspace_id AS "workspaceId",
             p.id AS "packId",

--- a/backend/src/main/java/com/init/domainpack/infrastructure/persistence/JpaDomainPackRepository.java
+++ b/backend/src/main/java/com/init/domainpack/infrastructure/persistence/JpaDomainPackRepository.java
@@ -1,7 +1,11 @@
 package com.init.domainpack.infrastructure.persistence;
 
+import com.init.domainpack.domain.repository.DomainPackDraftEntryRow;
 import com.init.domainpack.domain.repository.DomainPackRepository;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -9,4 +13,25 @@ public interface JpaDomainPackRepository
     extends JpaRepository<DomainPackRef, Long>, DomainPackRepository {
 
   boolean existsByIdAndWorkspaceId(Long id, Long workspaceId);
+
+  @Query(
+      value =
+          """
+          SELECT
+            p.workspace_id AS "workspaceId",
+            p.id AS "packId",
+            v.id AS "versionId",
+            p.name AS "packName",
+            v.version_no AS "versionNo"
+          FROM pack.domain_pack p
+          JOIN pack.domain_pack_version v ON v.domain_pack_id = p.id
+          WHERE p.workspace_id = :workspaceId
+            AND p.status = 'ACTIVE'
+            AND v.lifecycle_status = 'DRAFT'
+          ORDER BY v.created_at DESC, v.id DESC
+          LIMIT 1
+          """,
+      nativeQuery = true)
+  Optional<DomainPackDraftEntryRow> findLatestDraftEntryByWorkspaceId(
+      @Param("workspaceId") Long workspaceId);
 }

--- a/backend/src/main/java/com/init/domainpack/infrastructure/persistence/JpaWorkflowDefinitionRepository.java
+++ b/backend/src/main/java/com/init/domainpack/infrastructure/persistence/JpaWorkflowDefinitionRepository.java
@@ -26,7 +26,7 @@ public interface JpaWorkflowDefinitionRepository
       value =
           """
           SELECT CASE WHEN COUNT(*) > 0 THEN TRUE ELSE FALSE END
-          FROM workflow_definition
+          FROM pack.workflow_definition
           WHERE domain_pack_version_id = :versionId
             AND graph_json -> 'nodes' @> jsonb_build_array(jsonb_build_object('policyRef', :policyCode))
           """,

--- a/backend/src/main/java/com/init/domainpack/presentation/DomainPackDraftEntryController.java
+++ b/backend/src/main/java/com/init/domainpack/presentation/DomainPackDraftEntryController.java
@@ -1,0 +1,40 @@
+package com.init.domainpack.presentation;
+
+import com.init.domainpack.application.DomainPackDraftEntryResult;
+import com.init.domainpack.application.GetDomainPackDraftEntryQuery;
+import com.init.domainpack.application.GetDomainPackDraftEntryUseCase;
+import com.init.domainpack.presentation.dto.DomainPackDraftEntryResponse;
+import com.init.shared.presentation.AuthenticationUtils;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/workspaces/{workspaceId}/domain-packs")
+public class DomainPackDraftEntryController {
+
+  private final GetDomainPackDraftEntryUseCase useCase;
+
+  public DomainPackDraftEntryController(GetDomainPackDraftEntryUseCase useCase) {
+    this.useCase = useCase;
+  }
+
+  @GetMapping("/draft-entry")
+  public ResponseEntity<DomainPackDraftEntryResponse> getDraftEntry(
+      @PathVariable Long workspaceId, Authentication authentication) {
+    Long userId = AuthenticationUtils.getUserId(authentication);
+    DomainPackDraftEntryResult result =
+        useCase.execute(new GetDomainPackDraftEntryQuery(workspaceId, userId));
+
+    return ResponseEntity.ok(
+        new DomainPackDraftEntryResponse(
+            result.workspaceId(),
+            result.packId(),
+            result.versionId(),
+            result.packName(),
+            result.versionNo()));
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/presentation/dto/DomainPackDraftEntryResponse.java
+++ b/backend/src/main/java/com/init/domainpack/presentation/dto/DomainPackDraftEntryResponse.java
@@ -1,5 +1,4 @@
 package com.init.domainpack.presentation.dto;
 
 public record DomainPackDraftEntryResponse(
-    Long workspaceId, Long packId, Long versionId, String packName, Integer versionNo) {
-}
+    Long workspaceId, Long packId, Long versionId, String packName, Integer versionNo) {}

--- a/backend/src/main/java/com/init/domainpack/presentation/dto/DomainPackDraftEntryResponse.java
+++ b/backend/src/main/java/com/init/domainpack/presentation/dto/DomainPackDraftEntryResponse.java
@@ -1,0 +1,5 @@
+package com.init.domainpack.presentation.dto;
+
+public record DomainPackDraftEntryResponse(
+    Long workspaceId, Long packId, Long versionId, String packName, Integer versionNo) {
+}

--- a/backend/src/test/java/com/init/domainpack/application/GetDomainPackDraftEntryUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/GetDomainPackDraftEntryUseCaseTest.java
@@ -58,9 +58,9 @@ class GetDomainPackDraftEntryUseCaseTest {
   void shouldThrowNotFoundWhenDraftEntryMissing() {
     given(domainPackRepository.findLatestDraftEntryByWorkspaceId(WORKSPACE_ID))
         .willReturn(Optional.empty());
+    GetDomainPackDraftEntryQuery query = new GetDomainPackDraftEntryQuery(WORKSPACE_ID, USER_ID);
 
-    assertThatThrownBy(
-            () -> useCase.execute(new GetDomainPackDraftEntryQuery(WORKSPACE_ID, USER_ID)))
+    assertThatThrownBy(() -> useCase.execute(query))
         .isInstanceOf(DomainPackDraftEntryNotFoundException.class);
   }
 
@@ -70,9 +70,9 @@ class GetDomainPackDraftEntryUseCaseTest {
     willThrow(new DomainPackWorkspaceNotFoundException("워크스페이스를 찾을 수 없습니다."))
         .given(validator)
         .validateWorkspaceAccess(WORKSPACE_ID, USER_ID);
+    GetDomainPackDraftEntryQuery query = new GetDomainPackDraftEntryQuery(WORKSPACE_ID, USER_ID);
 
-    assertThatThrownBy(
-            () -> useCase.execute(new GetDomainPackDraftEntryQuery(WORKSPACE_ID, USER_ID)))
+    assertThatThrownBy(() -> useCase.execute(query))
         .isInstanceOf(DomainPackWorkspaceNotFoundException.class);
     verifyNoInteractions(domainPackRepository);
   }

--- a/backend/src/test/java/com/init/domainpack/application/GetDomainPackDraftEntryUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/GetDomainPackDraftEntryUseCaseTest.java
@@ -1,0 +1,107 @@
+package com.init.domainpack.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import com.init.domainpack.application.exception.DomainPackDraftEntryNotFoundException;
+import com.init.domainpack.application.exception.DomainPackWorkspaceNotFoundException;
+import com.init.domainpack.domain.repository.DomainPackDraftEntryRow;
+import com.init.domainpack.domain.repository.DomainPackRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetDomainPackDraftEntryUseCase")
+class GetDomainPackDraftEntryUseCaseTest {
+
+  private static final Long WORKSPACE_ID = 1L;
+  private static final Long USER_ID = 10L;
+
+  @Mock private DomainPackValidator validator;
+  @Mock private DomainPackRepository domainPackRepository;
+
+  private GetDomainPackDraftEntryUseCase useCase;
+
+  @BeforeEach
+  void setUp() {
+    useCase = new GetDomainPackDraftEntryUseCase(validator, domainPackRepository);
+  }
+
+  @Test
+  @DisplayName("접근 가능한 workspace의 최신 DRAFT domain pack entry를 반환한다")
+  void shouldReturnLatestDraftEntryWhenExists() {
+    given(domainPackRepository.findLatestDraftEntryByWorkspaceId(WORKSPACE_ID))
+        .willReturn(Optional.of(new StubDraftEntryRow()));
+
+    DomainPackDraftEntryResult result =
+        useCase.execute(new GetDomainPackDraftEntryQuery(WORKSPACE_ID, USER_ID));
+
+    assertThat(result.workspaceId()).isEqualTo(WORKSPACE_ID);
+    assertThat(result.packId()).isEqualTo(7L);
+    assertThat(result.versionId()).isEqualTo(101L);
+    assertThat(result.packName()).isEqualTo("CS 정책팩");
+    assertThat(result.versionNo()).isEqualTo(3);
+    verify(validator).validateWorkspaceAccess(WORKSPACE_ID, USER_ID);
+  }
+
+  @Test
+  @DisplayName("DRAFT domain pack version이 없으면 not found 예외를 던진다")
+  void shouldThrowNotFoundWhenDraftEntryMissing() {
+    given(domainPackRepository.findLatestDraftEntryByWorkspaceId(WORKSPACE_ID))
+        .willReturn(Optional.empty());
+
+    assertThatThrownBy(
+            () -> useCase.execute(new GetDomainPackDraftEntryQuery(WORKSPACE_ID, USER_ID)))
+        .isInstanceOf(DomainPackDraftEntryNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("workspace 접근 검증 실패 시 repository를 조회하지 않는다")
+  void shouldNotQueryRepositoryWhenWorkspaceValidationFails() {
+    willThrow(new DomainPackWorkspaceNotFoundException("워크스페이스를 찾을 수 없습니다."))
+        .given(validator)
+        .validateWorkspaceAccess(WORKSPACE_ID, USER_ID);
+
+    assertThatThrownBy(
+            () -> useCase.execute(new GetDomainPackDraftEntryQuery(WORKSPACE_ID, USER_ID)))
+        .isInstanceOf(DomainPackWorkspaceNotFoundException.class);
+    verifyNoInteractions(domainPackRepository);
+  }
+
+  private static class StubDraftEntryRow implements DomainPackDraftEntryRow {
+
+    @Override
+    public Long getWorkspaceId() {
+      return WORKSPACE_ID;
+    }
+
+    @Override
+    public Long getPackId() {
+      return 7L;
+    }
+
+    @Override
+    public Long getVersionId() {
+      return 101L;
+    }
+
+    @Override
+    public String getPackName() {
+      return "CS 정책팩";
+    }
+
+    @Override
+    public Integer getVersionNo() {
+      return 3;
+    }
+  }
+}

--- a/backend/src/test/java/com/init/domainpack/presentation/DomainPackDraftEntryControllerTest.java
+++ b/backend/src/test/java/com/init/domainpack/presentation/DomainPackDraftEntryControllerTest.java
@@ -1,0 +1,80 @@
+package com.init.domainpack.presentation;
+
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.init.domainpack.application.DomainPackDraftEntryResult;
+import com.init.domainpack.application.GetDomainPackDraftEntryQuery;
+import com.init.domainpack.application.GetDomainPackDraftEntryUseCase;
+import com.init.domainpack.application.exception.DomainPackDraftEntryNotFoundException;
+import com.init.fixtures.WithLongPrincipal;
+import com.init.shared.infrastructure.security.JwtAuthenticationFilter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(
+    value = DomainPackDraftEntryController.class,
+    excludeFilters =
+        @ComponentScan.Filter(
+            type = FilterType.ASSIGNABLE_TYPE,
+            classes = JwtAuthenticationFilter.class))
+@DisplayName("DomainPackDraftEntryController")
+class DomainPackDraftEntryControllerTest {
+
+  private static final String URL = "/api/v1/workspaces/1/domain-packs/draft-entry";
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private GetDomainPackDraftEntryUseCase useCase;
+
+  @Test
+  @DisplayName("GET draft-entry → 200 OK, 최신 draft entry 반환")
+  @WithLongPrincipal(10L)
+  void shouldReturnDraftEntryWhenExists() throws Exception {
+    given(
+            useCase.execute(
+                argThat(query -> query.workspaceId().equals(1L) && query.userId().equals(10L))))
+        .willReturn(new DomainPackDraftEntryResult(1L, 7L, 101L, "CS 정책팩", 3));
+
+    mockMvc
+        .perform(get(URL))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.workspaceId").value(1))
+        .andExpect(jsonPath("$.packId").value(7))
+        .andExpect(jsonPath("$.versionId").value(101))
+        .andExpect(jsonPath("$.packName").value("CS 정책팩"))
+        .andExpect(jsonPath("$.versionNo").value(3));
+
+    verify(useCase)
+        .execute(argThat(query -> query.workspaceId().equals(1L) && query.userId().equals(10L)));
+  }
+
+  @Test
+  @DisplayName("GET draft-entry → draft가 없으면 404")
+  @WithLongPrincipal(10L)
+  void shouldReturnNotFoundWhenDraftEntryMissing() throws Exception {
+    given(useCase.execute(new GetDomainPackDraftEntryQuery(1L, 10L)))
+        .willThrow(new DomainPackDraftEntryNotFoundException(1L));
+
+    mockMvc
+        .perform(get(URL))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("DOMAIN_PACK_DRAFT_ENTRY_NOT_FOUND"));
+  }
+
+  @Test
+  @DisplayName("GET draft-entry → 미인증이면 401")
+  void shouldReturnUnauthorizedWithoutPrincipal() throws Exception {
+    mockMvc.perform(get(URL)).andExpect(status().isUnauthorized());
+  }
+}

--- a/frontend/sonar-project.properties
+++ b/frontend/sonar-project.properties
@@ -4,4 +4,5 @@ sonar.host.url=https://sonarcloud.io
 sonar.sources=src/
 sonar.exclusions=node_modules/**,dist/**,**/*.d.ts,**/coverage/**,**/lcov-report/**
 sonar.coverage.exclusions=**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx,**/mocks/**,**/test/**,**/__tests__/**
+sonar.cpd.exclusions=**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx,**/mocks/**,**/test/**,**/__tests__/**
 sonar.javascript.lcov.reportPaths=coverage/lcov.info

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -8,6 +8,7 @@ import { PasswordResetCompletePage } from '../pages/password-reset/ui/PasswordRe
 import { ConsultationPage } from '../pages/consultation/ui/ConsultationPage';
 import { NotFoundPage } from '../pages/not-found/ui/NotFoundPage';
 import { IntentDraftReadPage } from '../pages/domain-pack/ui/IntentDraftReadPage';
+import { PolicyDraftReadPage } from '../pages/domain-pack/ui/PolicyDraftReadPage';
 import { SlotDraftReadPage } from '../pages/domain-pack/ui/SlotDraftReadPage';
 import { WorkflowDraftReadPage } from '../pages/domain-pack/ui/WorkflowDraftReadPage';
 import { WorkspaceLayout } from '../pages/workspace/ui/WorkspaceLayout';
@@ -35,6 +36,7 @@ export function App() {
         <Route path="/upload" element={<PrivateRoute><UploadPage /></PrivateRoute>} />
         <Route path="/consultation" element={<PrivateRoute><ConsultationPage /></PrivateRoute>} />
         <Route path="/workspaces/:workspaceId/domain-packs/:packId/versions/:versionId/intents/:intentId?" element={<PrivateRoute><IntentDraftReadPage /></PrivateRoute>} />
+        <Route path="/workspaces/:workspaceId/domain-packs/:packId/versions/:versionId/policies/:policyId?" element={<PrivateRoute><PolicyDraftReadPage /></PrivateRoute>} />
         <Route path="/workspaces/:workspaceId/domain-packs/:packId/versions/:versionId/slots/:slotId?" element={<PrivateRoute><SlotDraftReadPage /></PrivateRoute>} />
         <Route path="/workspaces/:workspaceId/domain-packs/:packId/versions/:versionId/workflows" element={<PrivateRoute><WorkflowDraftReadPage /></PrivateRoute>} />
         <Route path="/workspaces/:workspaceId/domain-packs/:packId/versions/:versionId/workflows/:workflowId" element={<PrivateRoute><WorkflowDraftReadPage /></PrivateRoute>} />

--- a/frontend/src/entities/domain-pack/api/index.test.ts
+++ b/frontend/src/entities/domain-pack/api/index.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { domainPackApi } from "./index";
+
+describe("domainPackApi", () => {
+  const mockFetch = vi.fn();
+
+  beforeEach(() => {
+    mockFetch.mockReset();
+    vi.stubGlobal("fetch", mockFetch);
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("loads latest draft entry for a workspace", async () => {
+    const response = { workspaceId: 1, packId: 2, versionId: 3, packName: "CS", versionNo: 4 };
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 200, json: async () => response });
+
+    await expect(domainPackApi.getDraftEntry(1)).resolves.toEqual(response);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/v1/workspaces/1/domain-packs/draft-entry",
+      expect.objectContaining({ method: "GET" }),
+    );
+  });
+});

--- a/frontend/src/entities/domain-pack/api/index.ts
+++ b/frontend/src/entities/domain-pack/api/index.ts
@@ -1,0 +1,10 @@
+import { apiClient } from "@/shared/api";
+
+import type { DomainPackDraftEntryResponse } from "../model/types";
+
+export const domainPackApi = {
+  getDraftEntry: (workspaceId: number) =>
+    apiClient.get<DomainPackDraftEntryResponse>(
+      `/workspaces/${workspaceId}/domain-packs/draft-entry`,
+    ),
+};

--- a/frontend/src/entities/domain-pack/api/index.ts
+++ b/frontend/src/entities/domain-pack/api/index.ts
@@ -2,6 +2,8 @@ import { apiClient } from "@/shared/api";
 
 import type { DomainPackDraftEntryResponse } from "../model/types";
 
+export const DOMAIN_PACK_DRAFT_ENTRY_NOT_FOUND = "DOMAIN_PACK_DRAFT_ENTRY_NOT_FOUND";
+
 export const domainPackApi = {
   getDraftEntry: (workspaceId: number) =>
     apiClient.get<DomainPackDraftEntryResponse>(

--- a/frontend/src/entities/domain-pack/index.ts
+++ b/frontend/src/entities/domain-pack/index.ts
@@ -1,0 +1,2 @@
+export { domainPackApi } from "./api";
+export type { DomainPackDraftEntryResponse } from "./model/types";

--- a/frontend/src/entities/domain-pack/index.ts
+++ b/frontend/src/entities/domain-pack/index.ts
@@ -1,2 +1,2 @@
-export { domainPackApi } from "./api";
+export { DOMAIN_PACK_DRAFT_ENTRY_NOT_FOUND, domainPackApi } from "./api";
 export type { DomainPackDraftEntryResponse } from "./model/types";

--- a/frontend/src/entities/domain-pack/model/types.ts
+++ b/frontend/src/entities/domain-pack/model/types.ts
@@ -1,0 +1,7 @@
+export interface DomainPackDraftEntryResponse {
+  workspaceId: number;
+  packId: number;
+  versionId: number;
+  packName: string;
+  versionNo: number;
+}

--- a/frontend/src/entities/policy/api/index.test.ts
+++ b/frontend/src/entities/policy/api/index.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { policyApi, policyKeys } from "./index";
+
+describe("policyApi", () => {
+  const mockFetch = vi.fn();
+
+  beforeEach(() => {
+    mockFetch.mockReset();
+    vi.stubGlobal("fetch", mockFetch);
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("uses stable query keys for list and detail", () => {
+    expect(policyKeys.list(1, 2, 3)).toEqual(["policies", "list", 1, 2, 3]);
+    expect(policyKeys.detail(1, 2, 3, 4)).toEqual(["policies", "detail", 1, 2, 3, 4]);
+  });
+
+  it("loads policy list and detail from policy endpoints", async () => {
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => [] })
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ id: 4 }) });
+
+    await expect(policyApi.list(1, 2, 3)).resolves.toEqual([]);
+    await expect(policyApi.detail(1, 2, 3, 4)).resolves.toEqual({ id: 4 });
+
+    expect(mockFetch).toHaveBeenNthCalledWith(
+      1,
+      "/api/v1/workspaces/1/domain-packs/2/versions/3/policies",
+      expect.objectContaining({ method: "GET" }),
+    );
+    expect(mockFetch).toHaveBeenNthCalledWith(
+      2,
+      "/api/v1/workspaces/1/domain-packs/2/versions/3/policies/4",
+      expect.objectContaining({ method: "GET" }),
+    );
+  });
+
+  it("updates policy body and status through patch endpoints", async () => {
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ id: 4 }) })
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ id: 4 }) });
+
+    await policyApi.update(1, 2, 3, 4, { name: "새 정책" });
+    await policyApi.updateStatus(1, 2, 3, 4, { status: "INACTIVE" });
+
+    expect(mockFetch).toHaveBeenNthCalledWith(
+      1,
+      "/api/v1/workspaces/1/domain-packs/2/versions/3/policies/4",
+      expect.objectContaining({
+        method: "PATCH",
+        body: JSON.stringify({ name: "새 정책" }),
+      }),
+    );
+    expect(mockFetch).toHaveBeenNthCalledWith(
+      2,
+      "/api/v1/workspaces/1/domain-packs/2/versions/3/policies/4/status",
+      expect.objectContaining({
+        method: "PATCH",
+        body: JSON.stringify({ status: "INACTIVE" }),
+      }),
+    );
+  });
+});

--- a/frontend/src/entities/policy/api/index.ts
+++ b/frontend/src/entities/policy/api/index.ts
@@ -1,0 +1,51 @@
+import { apiClient } from "@/shared/api";
+import type {
+  PolicyDefinition,
+  PolicySummary,
+  UpdatePolicyRequest,
+  UpdatePolicyStatusRequest,
+} from "../model/types";
+
+export const policyKeys = {
+  all: ["policies"] as const,
+  lists: () => [...policyKeys.all, "list"] as const,
+  list: (workspaceId: number, packId: number, versionId: number) =>
+    [...policyKeys.lists(), workspaceId, packId, versionId] as const,
+  detail: (workspaceId: number, packId: number, versionId: number, policyId: number) =>
+    [...policyKeys.all, "detail", workspaceId, packId, versionId, policyId] as const,
+};
+
+const basePath = (workspaceId: number, packId: number, versionId: number) =>
+  `/workspaces/${workspaceId}/domain-packs/${packId}/versions/${versionId}/policies`;
+
+export const policyApi = {
+  list: (workspaceId: number, packId: number, versionId: number) =>
+    apiClient.get<PolicySummary[]>(basePath(workspaceId, packId, versionId)),
+
+  detail: (workspaceId: number, packId: number, versionId: number, policyId: number) =>
+    apiClient.get<PolicyDefinition>(`${basePath(workspaceId, packId, versionId)}/${policyId}`),
+
+  update: (
+    workspaceId: number,
+    packId: number,
+    versionId: number,
+    policyId: number,
+    body: UpdatePolicyRequest,
+  ) =>
+    apiClient.patch<PolicyDefinition>(
+      `${basePath(workspaceId, packId, versionId)}/${policyId}`,
+      body,
+    ),
+
+  updateStatus: (
+    workspaceId: number,
+    packId: number,
+    versionId: number,
+    policyId: number,
+    body: UpdatePolicyStatusRequest,
+  ) =>
+    apiClient.patch<PolicyDefinition>(
+      `${basePath(workspaceId, packId, versionId)}/${policyId}/status`,
+      body,
+    ),
+};

--- a/frontend/src/entities/policy/index.ts
+++ b/frontend/src/entities/policy/index.ts
@@ -1,0 +1,8 @@
+export type {
+  PolicyDefinition,
+  PolicyStatus,
+  PolicySummary,
+  UpdatePolicyRequest,
+  UpdatePolicyStatusRequest,
+} from "./model/types";
+export { policyApi, policyKeys } from "./api/index";

--- a/frontend/src/entities/policy/model/types.ts
+++ b/frontend/src/entities/policy/model/types.ts
@@ -1,0 +1,34 @@
+export type PolicyStatus = "ACTIVE" | "INACTIVE";
+
+export interface PolicySummary {
+  id: number;
+  domainPackVersionId: number;
+  policyCode: string;
+  name: string;
+  description: string | null;
+  severity: string | null;
+  status: PolicyStatus;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface PolicyDefinition extends PolicySummary {
+  conditionJson: string;
+  actionJson: string;
+  evidenceJson: string;
+  metaJson: string;
+}
+
+export interface UpdatePolicyRequest {
+  name: string;
+  description?: string | null;
+  severity?: string | null;
+  conditionJson?: string | null;
+  actionJson?: string | null;
+  evidenceJson?: string | null;
+  metaJson?: string | null;
+}
+
+export interface UpdatePolicyStatusRequest {
+  status: PolicyStatus;
+}

--- a/frontend/src/features/policy-draft-read/model/mapApiError.test.ts
+++ b/frontend/src/features/policy-draft-read/model/mapApiError.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { ApiRequestError } from "@/shared/api";
+import { mapApiError } from "./mapApiError";
+
+describe("mapApiError", () => {
+  it("ApiRequestError의 상태와 코드를 유지한다", () => {
+    expect(mapApiError(new ApiRequestError(404, "POLICY_NOT_FOUND", "없음"))).toEqual({
+      status: "error",
+      code: "POLICY_NOT_FOUND",
+      message: "없음",
+      httpStatus: 404,
+    });
+  });
+
+  it("알 수 없는 오류는 UNKNOWN_ERROR로 변환한다", () => {
+    expect(mapApiError(new Error("network"))).toEqual({
+      status: "error",
+      code: "UNKNOWN_ERROR",
+      message: "알 수 없는 오류가 발생했습니다.",
+    });
+  });
+});

--- a/frontend/src/features/policy-draft-read/model/mapApiError.ts
+++ b/frontend/src/features/policy-draft-read/model/mapApiError.ts
@@ -1,0 +1,13 @@
+import { ApiRequestError } from "@/shared/api";
+
+export function mapApiError(e: unknown): {
+  status: "error";
+  code: string;
+  message: string;
+  httpStatus?: number;
+} {
+  if (e instanceof ApiRequestError) {
+    return { status: "error", code: e.code, message: e.message, httpStatus: e.status };
+  }
+  return { status: "error", code: "UNKNOWN_ERROR", message: "알 수 없는 오류가 발생했습니다." };
+}

--- a/frontend/src/features/policy-draft-read/model/usePolicyDetail.test.ts
+++ b/frontend/src/features/policy-draft-read/model/usePolicyDetail.test.ts
@@ -1,0 +1,89 @@
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { policyApi } from "@/entities/policy";
+import { ApiRequestError } from "@/shared/api";
+import { usePolicyDetail } from "./usePolicyDetail";
+
+vi.mock("@/entities/policy", () => ({
+  policyApi: {
+    list: vi.fn(),
+    detail: vi.fn(),
+  },
+  policyKeys: {
+    all: ["policies"],
+    lists: () => ["policies", "list"],
+    list: (...args: number[]) => ["policies", "list", ...args],
+    detail: (...args: number[]) => ["policies", "detail", ...args],
+  },
+}));
+
+const mockedDetail = vi.mocked(policyApi.detail);
+
+const stubPolicy = {
+  id: 4,
+  domainPackVersionId: 3,
+  policyCode: "POL_REFUND",
+  name: "환불 정책",
+  description: "환불 조건",
+  severity: "HIGH",
+  conditionJson: "{}",
+  actionJson: "{}",
+  evidenceJson: "[]",
+  metaJson: "{}",
+  status: "ACTIVE" as const,
+  createdAt: "2026-04-16T10:00:00Z",
+  updatedAt: "2026-04-16T10:00:00Z",
+};
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+describe("usePolicyDetail", () => {
+  beforeEach(() => {
+    mockedDetail.mockReset();
+  });
+
+  it("policyId가 없으면 idle 상태를 반환한다", () => {
+    const { result } = renderHook(() => usePolicyDetail(1, 2, 3, null), {
+      wrapper: makeWrapper(),
+    });
+
+    expect(result.current.status).toBe("idle");
+    expect(mockedDetail).not.toHaveBeenCalled();
+  });
+
+  it("성공 시 ready 상태와 상세 데이터를 반환한다", async () => {
+    mockedDetail.mockResolvedValue(stubPolicy);
+    const { result } = renderHook(() => usePolicyDetail(1, 2, 3, 4), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+
+    if (result.current.status === "ready") {
+      expect(result.current.data.policyCode).toBe("POL_REFUND");
+    }
+  });
+
+  it("ApiRequestError를 error 상태로 변환한다", async () => {
+    mockedDetail.mockRejectedValue(new ApiRequestError(404, "POLICY_NOT_FOUND", "없음"));
+    const { result } = renderHook(() => usePolicyDetail(1, 2, 3, 404), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.status).toBe("error"));
+
+    if (result.current.status === "error") {
+      expect(result.current.httpStatus).toBe(404);
+      expect(result.current.code).toBe("POLICY_NOT_FOUND");
+    }
+  });
+});

--- a/frontend/src/features/policy-draft-read/model/usePolicyDetail.ts
+++ b/frontend/src/features/policy-draft-read/model/usePolicyDetail.ts
@@ -32,7 +32,7 @@ export function usePolicyDetail(
 
   useEffect(() => {
     if (policyId !== null && retryKey > 0) {
-      void refetch();
+      refetch().catch(() => undefined);
     }
   }, [policyId, refetch, retryKey]);
 

--- a/frontend/src/features/policy-draft-read/model/usePolicyDetail.ts
+++ b/frontend/src/features/policy-draft-read/model/usePolicyDetail.ts
@@ -1,0 +1,56 @@
+import { useEffect } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { policyApi, policyKeys } from "@/entities/policy";
+import { mapApiError } from "./mapApiError";
+import type { PolicyDefinition } from "@/entities/policy";
+
+export type PolicyDetailState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "error"; code: string; message: string; httpStatus?: number }
+  | { status: "ready"; data: PolicyDefinition };
+
+export function usePolicyDetail(
+  workspaceId: number,
+  packId: number,
+  versionId: number,
+  policyId: number | null,
+  retryKey = 0,
+): PolicyDetailState {
+  const query = useQuery({
+    queryKey: policyKeys.detail(workspaceId, packId, versionId, policyId ?? 0),
+    queryFn: () => {
+      if (policyId === null) {
+        throw new Error("policyId is required");
+      }
+      return policyApi.detail(workspaceId, packId, versionId, policyId);
+    },
+    enabled: policyId !== null,
+  });
+
+  const { refetch } = query;
+
+  useEffect(() => {
+    if (policyId !== null && retryKey > 0) {
+      void refetch();
+    }
+  }, [policyId, refetch, retryKey]);
+
+  if (policyId === null) {
+    return { status: "idle" };
+  }
+
+  if (query.isLoading) {
+    return { status: "loading" };
+  }
+
+  if (query.isError) {
+    return mapApiError(query.error);
+  }
+
+  if (!query.data) {
+    return { status: "loading" };
+  }
+
+  return { status: "ready", data: query.data };
+}

--- a/frontend/src/features/policy-draft-read/model/usePolicyDetail.ts
+++ b/frontend/src/features/policy-draft-read/model/usePolicyDetail.ts
@@ -17,8 +17,13 @@ export function usePolicyDetail(
   policyId: number | null,
   retryKey = 0,
 ): PolicyDetailState {
+  const queryKey =
+    policyId === null
+      ? [...policyKeys.all, "detail", workspaceId, packId, versionId, "idle"] as const
+      : policyKeys.detail(workspaceId, packId, versionId, policyId);
+
   const query = useQuery({
-    queryKey: policyKeys.detail(workspaceId, packId, versionId, policyId ?? 0),
+    queryKey,
     queryFn: () => {
       if (policyId === null) {
         throw new Error("policyId is required");
@@ -40,7 +45,7 @@ export function usePolicyDetail(
     return { status: "idle" };
   }
 
-  if (query.isLoading) {
+  if (query.isLoading || (query.isFetching && !query.data)) {
     return { status: "loading" };
   }
 

--- a/frontend/src/features/policy-draft-read/model/usePolicyList.test.ts
+++ b/frontend/src/features/policy-draft-read/model/usePolicyList.test.ts
@@ -1,0 +1,78 @@
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { policyApi } from "@/entities/policy";
+import { ApiRequestError } from "@/shared/api";
+import { usePolicyList } from "./usePolicyList";
+
+vi.mock("@/entities/policy", () => ({
+  policyApi: {
+    list: vi.fn(),
+    detail: vi.fn(),
+  },
+  policyKeys: {
+    all: ["policies"],
+    lists: () => ["policies", "list"],
+    list: (...args: number[]) => ["policies", "list", ...args],
+    detail: (...args: number[]) => ["policies", "detail", ...args],
+  },
+}));
+
+const mockedList = vi.mocked(policyApi.list);
+
+const stubPolicy = {
+  id: 1,
+  domainPackVersionId: 3,
+  policyCode: "POL_REFUND",
+  name: "환불 정책",
+  description: null,
+  severity: "HIGH",
+  status: "ACTIVE" as const,
+  createdAt: "",
+  updatedAt: "",
+};
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+describe("usePolicyList", () => {
+  beforeEach(() => {
+    mockedList.mockReset();
+  });
+
+  it("초기 상태는 loading이다", () => {
+    mockedList.mockReturnValue(new Promise(() => {}));
+    const { result } = renderHook(() => usePolicyList(1, 2, 3), { wrapper: makeWrapper() });
+    expect(result.current.status).toBe("loading");
+  });
+
+  it("성공 시 ready 상태와 정책 목록을 반환한다", async () => {
+    mockedList.mockResolvedValue([stubPolicy]);
+    const { result } = renderHook(() => usePolicyList(1, 2, 3), { wrapper: makeWrapper() });
+
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+
+    if (result.current.status === "ready") {
+      expect(result.current.data).toEqual([stubPolicy]);
+    }
+  });
+
+  it("ApiRequestError를 error 상태로 변환한다", async () => {
+    mockedList.mockRejectedValue(new ApiRequestError(403, "FORBIDDEN", "접근 금지"));
+    const { result } = renderHook(() => usePolicyList(1, 2, 3), { wrapper: makeWrapper() });
+
+    await waitFor(() => expect(result.current.status).toBe("error"));
+
+    if (result.current.status === "error") {
+      expect(result.current.httpStatus).toBe(403);
+      expect(result.current.code).toBe("FORBIDDEN");
+    }
+  });
+});

--- a/frontend/src/features/policy-draft-read/model/usePolicyList.ts
+++ b/frontend/src/features/policy-draft-read/model/usePolicyList.ts
@@ -24,7 +24,7 @@ export function usePolicyList(
 
   useEffect(() => {
     if (retryKey > 0) {
-      void refetch();
+      refetch().catch(() => undefined);
     }
   }, [refetch, retryKey]);
 

--- a/frontend/src/features/policy-draft-read/model/usePolicyList.ts
+++ b/frontend/src/features/policy-draft-read/model/usePolicyList.ts
@@ -1,0 +1,40 @@
+import { useEffect } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { policyApi, policyKeys } from "@/entities/policy";
+import { mapApiError } from "./mapApiError";
+import type { PolicySummary } from "@/entities/policy";
+
+export type PolicyListState =
+  | { status: "loading" }
+  | { status: "error"; code: string; message: string; httpStatus?: number }
+  | { status: "ready"; data: PolicySummary[] };
+
+export function usePolicyList(
+  workspaceId: number,
+  packId: number,
+  versionId: number,
+  retryKey = 0,
+): PolicyListState {
+  const query = useQuery({
+    queryKey: policyKeys.list(workspaceId, packId, versionId),
+    queryFn: () => policyApi.list(workspaceId, packId, versionId),
+  });
+
+  const { refetch } = query;
+
+  useEffect(() => {
+    if (retryKey > 0) {
+      void refetch();
+    }
+  }, [refetch, retryKey]);
+
+  if (query.isLoading) {
+    return { status: "loading" };
+  }
+
+  if (query.isError) {
+    return mapApiError(query.error);
+  }
+
+  return { status: "ready", data: query.data ?? [] };
+}

--- a/frontend/src/features/policy-draft-read/ui/PolicyDetailPanel.module.css
+++ b/frontend/src/features/policy-draft-read/ui/PolicyDetailPanel.module.css
@@ -1,0 +1,271 @@
+.panel {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-color);
+  overflow-y: auto;
+  min-width: 0;
+}
+
+.header {
+  padding: 24px 28px 22px;
+  border-bottom: 1px solid var(--glass-border);
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 18px;
+}
+
+.headerText {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.code {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.54px;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.name {
+  font-family: var(--font-sans);
+  font-size: 26px;
+  font-weight: 540;
+  line-height: 1.1;
+  letter-spacing: -0.26px;
+  color: var(--text-primary);
+  overflow-wrap: anywhere;
+}
+
+.description {
+  max-width: 60ch;
+  font-size: 18px;
+  font-weight: 330;
+  line-height: 1.4;
+  letter-spacing: -0.14px;
+  color: var(--text-secondary);
+}
+
+.updatedAt {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.54px;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.editButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  min-height: 36px;
+  padding: 8px 16px 9px;
+  border: 1px solid var(--text-primary);
+  border-radius: var(--radius-xl);
+  background: var(--text-primary);
+  color: var(--bg-color);
+  font-family: var(--font-sans);
+  font-size: 13px;
+  font-weight: 450;
+  letter-spacing: -0.14px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.editButton:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.editButton svg {
+  width: 14px;
+  height: 14px;
+}
+
+.editButton:focus-visible {
+  outline: 2px dashed var(--text-primary);
+  outline-offset: 2px;
+}
+
+.body {
+  padding: 24px 28px 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.card {
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-lg);
+  background: var(--bg-color);
+  overflow: hidden;
+}
+
+.cardHeader {
+  padding: 12px 14px 0;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.54px;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  border-left: 3px solid rgba(0, 0, 0, 0.12);
+  margin-left: 14px;
+  padding-left: 10px;
+}
+
+.cardBody {
+  padding: 10px 14px 16px;
+}
+
+.value {
+  font-size: 16px;
+  font-weight: 330;
+  line-height: 1.45;
+  letter-spacing: -0.14px;
+  color: var(--text-primary);
+  overflow-wrap: anywhere;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.54px;
+  text-transform: uppercase;
+  padding: 6px 12px 7px;
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--text-primary);
+  background: var(--text-primary);
+  color: var(--bg-color);
+  transition: all var(--transition-fast);
+}
+
+.badgeActive {
+  background: var(--text-primary);
+  color: var(--bg-color);
+  border-color: var(--text-primary);
+}
+
+.badgeInactive {
+  background: transparent;
+  color: var(--text-muted);
+  border-color: var(--text-muted);
+  border-style: dashed;
+}
+
+.jsonBlock {
+  background: var(--bg-secondary);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-lg);
+  padding: 18px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.55;
+  color: var(--text-primary);
+  overflow: auto;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.placeholder {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 10px;
+  margin: 20px;
+  padding: 40px 32px;
+  border: 1px dashed var(--hover-border);
+  border-radius: var(--radius-lg);
+  color: var(--text-secondary);
+  font-size: 14px;
+  line-height: 1.5;
+  letter-spacing: -0.14px;
+  text-align: center;
+}
+
+.errorCode {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.54px;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.skeleton {
+  flex: 1;
+  background: var(--bg-secondary);
+  min-height: 240px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-lg);
+}
+
+.retryButton {
+  margin-top: 4px;
+  padding: 8px 18px 9px;
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--text-primary);
+  background: transparent;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.54px;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+@media (max-width: 767px) {
+  .header {
+    padding: 20px 16px 18px;
+    flex-direction: column;
+  }
+
+  .body {
+    padding: 20px 16px 24px;
+  }
+
+  .name {
+    font-size: 22px;
+  }
+
+  .description {
+    font-size: 16px;
+  }
+
+  .grid {
+    grid-template-columns: 1fr;
+  }
+
+  .panel {
+    border-top: 1px solid var(--glass-border);
+  }
+}
+
+@media (max-width: 1100px) {
+  .header {
+    flex-direction: column;
+  }
+
+  .editButton {
+    align-self: flex-start;
+  }
+
+  .grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/features/policy-draft-read/ui/PolicyDetailPanel.test.tsx
+++ b/frontend/src/features/policy-draft-read/ui/PolicyDetailPanel.test.tsx
@@ -1,0 +1,86 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { toast } from "sonner";
+import { usePolicyDetail } from "../model/usePolicyDetail";
+import { PolicyDetailPanel } from "./PolicyDetailPanel";
+
+vi.mock("../model/usePolicyDetail", () => ({
+  usePolicyDetail: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+  },
+}));
+
+const mockedUsePolicyDetail = vi.mocked(usePolicyDetail);
+
+const stubPolicy = {
+  id: 4,
+  domainPackVersionId: 3,
+  policyCode: "POL_REFUND",
+  name: "환불 정책",
+  description: "환불 조건",
+  severity: "HIGH",
+  conditionJson: '{"channel":"web"}',
+  actionJson: '{"type":"REFUND_REVIEW"}',
+  evidenceJson: "[]",
+  metaJson: "{}",
+  status: "ACTIVE" as const,
+  createdAt: "2026-04-16T10:00:00Z",
+  updatedAt: "2026-04-16T10:00:00Z",
+};
+
+function renderPanel(onEdit = vi.fn()) {
+  render(
+    <PolicyDetailPanel workspaceId={1} packId={2} versionId={3} policyId={4} onEdit={onEdit} />,
+  );
+  return { onEdit };
+}
+
+describe("PolicyDetailPanel", () => {
+  beforeEach(() => {
+    mockedUsePolicyDetail.mockReset();
+    vi.mocked(toast.error).mockReset();
+  });
+
+  it("idle 상태에서는 선택 안내를 보여준다", () => {
+    mockedUsePolicyDetail.mockReturnValue({ status: "idle" });
+
+    renderPanel();
+
+    expect(screen.getByText("정책을 선택하세요.")).toBeInTheDocument();
+  });
+
+  it("ready 상태에서는 정책 상세와 수정 액션을 보여준다", () => {
+    mockedUsePolicyDetail.mockReturnValue({ status: "ready", data: stubPolicy });
+    const { onEdit } = renderPanel();
+
+    expect(screen.getAllByText("POL_REFUND")).toHaveLength(2);
+    expect(screen.getByText("환불 정책")).toBeInTheDocument();
+    expect(screen.getByText(/REFUND_REVIEW/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /POL_REFUND 정책 수정/ }));
+
+    expect(onEdit).toHaveBeenCalledWith(4);
+  });
+
+  it("error 상태에서는 toast와 재시도 버튼을 보여준다", () => {
+    mockedUsePolicyDetail.mockReturnValue({
+      status: "error",
+      code: "POLICY_NOT_FOUND",
+      message: "없음",
+      httpStatus: 404,
+    });
+
+    renderPanel();
+
+    expect(screen.getByText("상세 정보를 불러오지 못했습니다.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "다시 시도" })).toBeInTheDocument();
+    expect(toast.error).toHaveBeenCalledWith(
+      "정책을 찾을 수 없습니다.",
+      expect.objectContaining({ id: expect.stringContaining("policy-detail-error") }),
+    );
+  });
+});

--- a/frontend/src/features/policy-draft-read/ui/PolicyDetailPanel.tsx
+++ b/frontend/src/features/policy-draft-read/ui/PolicyDetailPanel.tsx
@@ -1,0 +1,204 @@
+import { useEffect, useState, type ReactNode } from "react";
+import { PencilIcon } from "lucide-react";
+import { toast } from "sonner";
+import { usePolicyDetail } from "../model/usePolicyDetail";
+import type { PolicyDefinition } from "@/entities/policy";
+import styles from "./PolicyDetailPanel.module.css";
+
+interface PolicyDetailPanelProps {
+  workspaceId: number;
+  packId: number;
+  versionId: number;
+  policyId: number | null;
+  onEdit: (policyId: number) => void;
+}
+
+export function PolicyDetailPanel({
+  workspaceId,
+  packId,
+  versionId,
+  policyId,
+  onEdit,
+}: PolicyDetailPanelProps) {
+  const [retryKey, setRetryKey] = useState(0);
+  const state = usePolicyDetail(workspaceId, packId, versionId, policyId, retryKey);
+  const errorCode = state.status === "error" ? state.code : undefined;
+  const errorHttpStatus = state.status === "error" ? state.httpStatus : undefined;
+  const errorMessage = state.status === "error" ? state.message : undefined;
+
+  useEffect(() => {
+    if (state.status !== "error") return;
+    const message =
+      errorHttpStatus === 404
+        ? "정책을 찾을 수 없습니다."
+        : errorMessage || "정책 상세 정보를 불러오지 못했습니다.";
+
+    toast.error(message, {
+      id: `policy-detail-error-${workspaceId}-${packId}-${versionId}-${policyId ?? "none"}-${errorCode ?? errorHttpStatus ?? "unknown"}`,
+    });
+  }, [
+    state.status,
+    workspaceId,
+    packId,
+    versionId,
+    policyId,
+    errorCode,
+    errorHttpStatus,
+    errorMessage,
+  ]);
+
+  if (state.status === "idle") {
+    return (
+      <section className={styles.panel} aria-label="정책 상세">
+        <div className={styles.placeholder}>
+          <span>정책을 선택하세요.</span>
+        </div>
+      </section>
+    );
+  }
+
+  if (state.status === "loading") {
+    return (
+      <section className={styles.panel} aria-label="정책 상세">
+        <div className={styles.body}>
+          <div className={styles.skeleton} />
+        </div>
+      </section>
+    );
+  }
+
+  if (state.status === "error") {
+    return (
+      <section className={styles.panel} aria-label="정책 상세">
+        <div className={styles.placeholder}>
+          <span>상세 정보를 불러오지 못했습니다.</span>
+          <span className={styles.errorCode}>{errorCode}</span>
+          <button
+            type="button"
+            className={styles.retryButton}
+            onClick={() => setRetryKey((key) => key + 1)}
+          >
+            다시 시도
+          </button>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className={styles.panel} aria-label="정책 상세">
+      <DetailHeader detail={state.data} onEdit={() => onEdit(state.data.id)} />
+      <div className={styles.body}>
+        <div className={styles.grid}>
+          <InfoCard
+            label="Policy Code"
+            value={<span className={styles.value}>{state.data.policyCode}</span>}
+          />
+          <InfoCard
+            label="Severity"
+            value={<span className={styles.value}>{state.data.severity ?? "—"}</span>}
+          />
+          <InfoCard
+            label="Status"
+            value={
+              <span
+                className={`${styles.badge} ${
+                  state.data.status === "ACTIVE" ? styles.badgeActive : styles.badgeInactive
+                }`}
+              >
+                {state.data.status === "ACTIVE" ? "● ACTIVE" : "○ INACTIVE"}
+              </span>
+            }
+          />
+          <InfoCard
+            label="Version Id"
+            value={<span className={styles.value}>{state.data.domainPackVersionId}</span>}
+          />
+          <InfoCard
+            label="Created At"
+            value={<span className={styles.value}>{formatDate(state.data.createdAt)}</span>}
+          />
+          <InfoCard
+            label="Updated At"
+            value={<span className={styles.value}>{formatDate(state.data.updatedAt)}</span>}
+          />
+        </div>
+        <JsonCard label="Condition" value={state.data.conditionJson} />
+        <JsonCard label="Action" value={state.data.actionJson} />
+        <JsonCard label="Evidence" value={state.data.evidenceJson} />
+        <JsonCard label="Meta" value={state.data.metaJson} />
+      </div>
+    </section>
+  );
+}
+
+function DetailHeader({
+  detail,
+  onEdit,
+}: {
+  detail: PolicyDefinition;
+  onEdit: () => void;
+}) {
+  return (
+    <header className={styles.header}>
+      <div className={styles.headerText}>
+        <span className={styles.code}>{detail.policyCode}</span>
+        <span className={styles.name}>{detail.name}</span>
+        {detail.description && <span className={styles.description}>{detail.description}</span>}
+        <span className={styles.updatedAt}>UPDATED · {formatDate(detail.updatedAt)}</span>
+      </div>
+      <button
+        type="button"
+        className={styles.editButton}
+        onClick={onEdit}
+        aria-label={`${detail.policyCode} 정책 수정`}
+      >
+        <PencilIcon aria-hidden="true" />
+        <span>수정</span>
+      </button>
+    </header>
+  );
+}
+
+function InfoCard({ label, value }: { label: string; value: ReactNode }) {
+  return (
+    <section className={styles.card}>
+      <header className={styles.cardHeader}>{label}</header>
+      <div className={styles.cardBody}>{value}</div>
+    </section>
+  );
+}
+
+function JsonCard({ label, value }: { label: string; value: string }) {
+  return (
+    <section className={styles.card}>
+      <header className={styles.cardHeader}>{label}</header>
+      <div className={styles.cardBody}>
+        <pre className={styles.jsonBlock}>
+          <code>{formatJsonForDisplay(value)}</code>
+        </pre>
+      </div>
+    </section>
+  );
+}
+
+function formatJsonForDisplay(raw: string): string {
+  if (!raw) return "—";
+  try {
+    return JSON.stringify(JSON.parse(raw), null, 2);
+  } catch {
+    return raw;
+  }
+}
+
+function formatDate(raw: string): string {
+  const date = new Date(raw);
+  if (Number.isNaN(date.getTime())) return raw;
+  return date.toLocaleString("ko-KR", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}

--- a/frontend/src/features/policy-draft-read/ui/PolicyDetailPanel.tsx
+++ b/frontend/src/features/policy-draft-read/ui/PolicyDetailPanel.tsx
@@ -5,6 +5,11 @@ import { usePolicyDetail } from "../model/usePolicyDetail";
 import type { PolicyDefinition } from "@/entities/policy";
 import styles from "./PolicyDetailPanel.module.css";
 
+type PolicyJsonField = Readonly<{
+  label: string;
+  value: string;
+}>;
+
 interface PolicyDetailPanelProps {
   workspaceId: number;
   packId: number;
@@ -19,7 +24,7 @@ export function PolicyDetailPanel({
   versionId,
   policyId,
   onEdit,
-}: PolicyDetailPanelProps) {
+}: Readonly<PolicyDetailPanelProps>) {
   const [retryKey, setRetryKey] = useState(0);
   const state = usePolicyDetail(workspaceId, packId, versionId, policyId, retryKey);
   const errorCode = state.status === "error" ? state.code : undefined;
@@ -85,6 +90,13 @@ export function PolicyDetailPanel({
     );
   }
 
+  const jsonFields: PolicyJsonField[] = [
+    { label: "Condition", value: state.data.conditionJson },
+    { label: "Action", value: state.data.actionJson },
+    { label: "Evidence", value: state.data.evidenceJson },
+    { label: "Meta", value: state.data.metaJson },
+  ];
+
   return (
     <section className={styles.panel} aria-label="정책 상세">
       <DetailHeader detail={state.data} onEdit={() => onEdit(state.data.id)} />
@@ -123,10 +135,9 @@ export function PolicyDetailPanel({
             value={<span className={styles.value}>{formatDate(state.data.updatedAt)}</span>}
           />
         </div>
-        <JsonCard label="Condition" value={state.data.conditionJson} />
-        <JsonCard label="Action" value={state.data.actionJson} />
-        <JsonCard label="Evidence" value={state.data.evidenceJson} />
-        <JsonCard label="Meta" value={state.data.metaJson} />
+        {jsonFields.map((field) => (
+          <JsonCard key={field.label} label={field.label} value={field.value} />
+        ))}
       </div>
     </section>
   );
@@ -135,10 +146,10 @@ export function PolicyDetailPanel({
 function DetailHeader({
   detail,
   onEdit,
-}: {
+}: Readonly<{
   detail: PolicyDefinition;
   onEdit: () => void;
-}) {
+}>) {
   return (
     <header className={styles.header}>
       <div className={styles.headerText}>
@@ -160,22 +171,26 @@ function DetailHeader({
   );
 }
 
-function InfoCard({ label, value }: { label: string; value: ReactNode }) {
+function InfoCard({ label, value }: Readonly<{ label: string; value: ReactNode }>) {
   return (
-    <section className={styles.card}>
-      <header className={styles.cardHeader}>{label}</header>
+    <section className={styles.card} aria-labelledby={`policy-info-${label}`}>
+      <header id={`policy-info-${label}`} className={styles.cardHeader}>
+        {label}
+      </header>
       <div className={styles.cardBody}>{value}</div>
     </section>
   );
 }
 
-function JsonCard({ label, value }: { label: string; value: string }) {
+function JsonCard({ label, value }: Readonly<PolicyJsonField>) {
+  const formattedValue = formatJsonForDisplay(value);
+
   return (
-    <section className={styles.card}>
+    <section className={styles.card} data-json-field={label.toLowerCase()}>
       <header className={styles.cardHeader}>{label}</header>
       <div className={styles.cardBody}>
         <pre className={styles.jsonBlock}>
-          <code>{formatJsonForDisplay(value)}</code>
+          <code>{formattedValue}</code>
         </pre>
       </div>
     </section>

--- a/frontend/src/features/policy-draft-read/ui/PolicyDetailPanel.tsx
+++ b/frontend/src/features/policy-draft-read/ui/PolicyDetailPanel.tsx
@@ -77,6 +77,7 @@ export function PolicyDetailPanel({
       <section className={styles.panel} aria-label="정책 상세">
         <div className={styles.placeholder}>
           <span>상세 정보를 불러오지 못했습니다.</span>
+          <span>{errorHttpStatus === 404 ? "정책을 찾을 수 없습니다." : errorMessage}</span>
           <span className={styles.errorCode}>{errorCode}</span>
           <button
             type="button"

--- a/frontend/src/features/policy-draft-read/ui/PolicyListPanel.module.css
+++ b/frontend/src/features/policy-draft-read/ui/PolicyListPanel.module.css
@@ -191,12 +191,6 @@
   cursor: pointer;
 }
 
-@media (max-width: 959px) {
-  .panel {
-    min-width: 248px;
-  }
-}
-
 @media (max-width: 1599px) {
   .panel {
     width: 100%;

--- a/frontend/src/features/policy-draft-read/ui/PolicyListPanel.module.css
+++ b/frontend/src/features/policy-draft-read/ui/PolicyListPanel.module.css
@@ -1,0 +1,216 @@
+.panel {
+  width: 100%;
+  min-width: 296px;
+  max-width: clamp(248px, 28vw, 376px);
+  border-right: 1px solid var(--glass-border);
+  background: var(--bg-color);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.header {
+  padding: 18px 20px 14px;
+  border-bottom: 1px solid var(--divider-subtle);
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+  flex-shrink: 0;
+}
+
+.headerTitle {
+  font-family: var(--font-sans);
+  font-size: 18px;
+  font-weight: 540;
+  line-height: 1.15;
+  letter-spacing: -0.26px;
+  color: var(--text-primary);
+}
+
+.headerMeta {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.54px;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.scroll {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px 16px 20px;
+  min-height: 0;
+}
+
+.listGroup {
+  display: flex;
+  flex-direction: column;
+}
+
+.item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 16px 18px 17px;
+  margin-bottom: 8px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-pill-row);
+  background: var(--bg-color);
+  cursor: pointer;
+  color: var(--text-primary);
+  transition:
+    background var(--transition-fast),
+    border-color var(--transition-fast);
+}
+
+.item:hover {
+  background: var(--hover-bg);
+  border-color: var(--hover-border);
+}
+
+.item:focus-visible {
+  outline: 2px dashed var(--text-primary);
+  outline-offset: 2px;
+}
+
+.itemActive {
+  background: var(--text-primary);
+  color: var(--bg-color);
+  border-color: var(--text-primary);
+}
+
+.itemActive:hover {
+  background: var(--text-primary);
+}
+
+.itemInner {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.code {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.54px;
+  text-transform: uppercase;
+  color: inherit;
+  opacity: 0.66;
+}
+
+.name {
+  display: block;
+  font-family: var(--font-sans);
+  font-size: 15px;
+  font-weight: 450;
+  line-height: 1.35;
+  letter-spacing: -0.14px;
+  color: inherit;
+}
+
+.meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.54px;
+  text-transform: uppercase;
+  padding: 4px 10px 5px;
+  border-radius: var(--radius-xl);
+  border: 1px solid currentcolor;
+  color: inherit;
+  background: transparent;
+  transition: all var(--transition-fast);
+}
+
+/* ACTIVE status: filled black badge */
+.badgeActive {
+  background: var(--text-primary);
+  color: var(--bg-color);
+  border-color: var(--text-primary);
+}
+
+/* INACTIVE status: dashed border, muted */
+.badgeInactive {
+  border-style: dashed;
+  opacity: 0.5;
+}
+
+/* High severity: thicker border for emphasis */
+.badgeSeverityHigh {
+  border-width: 2px;
+  font-weight: 600;
+}
+
+.skeletonGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.skeletonRow {
+  height: 58px;
+  border-radius: var(--radius-pill-row);
+  background: var(--bg-secondary);
+}
+
+.emptyState {
+  padding: 28px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  border: 1px dashed var(--hover-border);
+  border-radius: var(--radius-lg);
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 1.5;
+  letter-spacing: -0.14px;
+}
+
+.retryButton {
+  align-self: flex-start;
+  margin-top: 4px;
+  padding: 6px 14px 7px;
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--text-primary);
+  background: transparent;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.54px;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+@media (max-width: 959px) {
+  .panel {
+    min-width: 248px;
+  }
+}
+
+@media (max-width: 1599px) {
+  .panel {
+    width: 100%;
+    min-width: 0;
+    max-width: none;
+    max-height: none;
+    border-right: 0;
+  }
+
+  .header {
+    padding: 16px 16px 12px;
+  }
+
+  .scroll {
+    padding: 12px 12px 16px;
+  }
+}

--- a/frontend/src/features/policy-draft-read/ui/PolicyListPanel.test.tsx
+++ b/frontend/src/features/policy-draft-read/ui/PolicyListPanel.test.tsx
@@ -1,0 +1,74 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { usePolicyList } from "../model/usePolicyList";
+import { PolicyListPanel } from "./PolicyListPanel";
+
+vi.mock("../model/usePolicyList", () => ({
+  usePolicyList: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+  },
+}));
+
+const mockedUsePolicyList = vi.mocked(usePolicyList);
+
+const stubPolicy = {
+  id: 4,
+  domainPackVersionId: 3,
+  policyCode: "POL_REFUND",
+  name: "환불 정책",
+  description: null,
+  severity: "HIGH",
+  status: "INACTIVE" as const,
+  createdAt: "",
+  updatedAt: "",
+};
+
+function renderPanel(onSelect = vi.fn()) {
+  render(
+    <PolicyListPanel workspaceId={1} packId={2} versionId={3} selectedId={4} onSelect={onSelect} />,
+  );
+  return { onSelect };
+}
+
+describe("PolicyListPanel", () => {
+  beforeEach(() => {
+    mockedUsePolicyList.mockReset();
+  });
+
+  it("loading 상태에서는 skeleton 목록을 렌더링한다", () => {
+    mockedUsePolicyList.mockReturnValue({ status: "loading" });
+
+    renderPanel();
+
+    expect(screen.getByLabelText("정책 목록")).toBeInTheDocument();
+    expect(screen.getByText("— · LIST")).toBeInTheDocument();
+  });
+
+  it("ready 상태에서는 목록을 렌더링하고 선택 이벤트를 전달한다", () => {
+    mockedUsePolicyList.mockReturnValue({ status: "ready", data: [stubPolicy] });
+    const { onSelect } = renderPanel();
+
+    fireEvent.click(screen.getByRole("button", { name: /POL_REFUND/ }));
+
+    expect(screen.getByText("1 · LIST")).toBeInTheDocument();
+    expect(screen.getByText("환불 정책")).toBeInTheDocument();
+    expect(onSelect).toHaveBeenCalledWith(4);
+  });
+
+  it("error 상태에서는 재시도 버튼을 제공한다", () => {
+    mockedUsePolicyList.mockReturnValue({
+      status: "error",
+      code: "UNKNOWN_ERROR",
+      message: "실패",
+    });
+
+    renderPanel();
+
+    expect(screen.getByText("정책 목록을 불러오지 못했습니다.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "다시 시도" })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/policy-draft-read/ui/PolicyListPanel.tsx
+++ b/frontend/src/features/policy-draft-read/ui/PolicyListPanel.tsx
@@ -18,7 +18,7 @@ export function PolicyListPanel({
   versionId,
   selectedId,
   onSelect,
-}: PolicyListPanelProps) {
+}: Readonly<PolicyListPanelProps>) {
   const [retryKey, setRetryKey] = useState(0);
   const state = usePolicyList(workspaceId, packId, versionId, retryKey);
   const errorMessage = state.status === "error" ? state.message : undefined;
@@ -39,47 +39,68 @@ export function PolicyListPanel({
       </header>
 
       <div className={styles.scroll}>
-        {state.status === "loading" && (
-          <div className={styles.skeletonGroup}>
-            <div className={styles.skeletonRow} />
-            <div className={styles.skeletonRow} />
-            <div className={styles.skeletonRow} />
-          </div>
-        )}
-
-        {state.status === "error" && (
-          <div className={styles.emptyState}>
-            <span>정책 목록을 불러오지 못했습니다.</span>
-            <button
-              type="button"
-              className={styles.retryButton}
-              onClick={() => setRetryKey((key) => key + 1)}
-            >
-              다시 시도
-            </button>
-          </div>
-        )}
-
-        {state.status === "ready" && state.data.length === 0 && (
-          <div className={styles.emptyState}>
-            <span>등록된 정책 초안이 없습니다.</span>
-          </div>
-        )}
-
-        {state.status === "ready" && state.data.length > 0 && (
-          <div className={styles.listGroup}>
-            {state.data.map((policy) => (
-              <PolicyListRow
-                key={policy.id}
-                policy={policy}
-                isActive={policy.id === selectedId}
-                onSelect={onSelect}
-              />
-            ))}
-          </div>
-        )}
+        <PolicyListContent
+          state={state}
+          selectedId={selectedId}
+          onRetry={() => setRetryKey((key) => key + 1)}
+          onSelect={onSelect}
+        />
       </div>
     </aside>
+  );
+}
+
+function PolicyListContent({
+  state,
+  selectedId,
+  onRetry,
+  onSelect,
+}: Readonly<{
+  state: ReturnType<typeof usePolicyList>;
+  selectedId: number | null;
+  onRetry: () => void;
+  onSelect: (id: number) => void;
+}>) {
+  if (state.status === "loading") {
+    return (
+      <div className={styles.skeletonGroup}>
+        {Array.from({ length: 3 }, (_, index) => (
+          <div key={index} className={styles.skeletonRow} />
+        ))}
+      </div>
+    );
+  }
+
+  if (state.status === "error") {
+    return (
+      <div className={styles.emptyState}>
+        <span>정책 목록을 불러오지 못했습니다.</span>
+        <button type="button" className={styles.retryButton} onClick={onRetry}>
+          다시 시도
+        </button>
+      </div>
+    );
+  }
+
+  if (state.data.length === 0) {
+    return (
+      <div className={styles.emptyState}>
+        <span>등록된 정책 초안이 없습니다.</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.listGroup}>
+      {state.data.map((policy) => (
+        <PolicyListRow
+          key={policy.id}
+          policy={policy}
+          isActive={policy.id === selectedId}
+          onSelect={onSelect}
+        />
+      ))}
+    </div>
   );
 }
 
@@ -87,11 +108,11 @@ function PolicyListRow({
   policy,
   isActive,
   onSelect,
-}: {
+}: Readonly<{
   policy: PolicySummary;
   isActive: boolean;
   onSelect: (id: number) => void;
-}) {
+}>) {
   return (
     <button
       type="button"

--- a/frontend/src/features/policy-draft-read/ui/PolicyListPanel.tsx
+++ b/frontend/src/features/policy-draft-read/ui/PolicyListPanel.tsx
@@ -1,0 +1,126 @@
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { usePolicyList } from "../model/usePolicyList";
+import type { PolicySummary } from "@/entities/policy";
+import styles from "./PolicyListPanel.module.css";
+
+interface PolicyListPanelProps {
+  workspaceId: number;
+  packId: number;
+  versionId: number;
+  selectedId: number | null;
+  onSelect: (id: number) => void;
+}
+
+export function PolicyListPanel({
+  workspaceId,
+  packId,
+  versionId,
+  selectedId,
+  onSelect,
+}: PolicyListPanelProps) {
+  const [retryKey, setRetryKey] = useState(0);
+  const state = usePolicyList(workspaceId, packId, versionId, retryKey);
+  const errorMessage = state.status === "error" ? state.message : undefined;
+
+  useEffect(() => {
+    if (state.status === "error") {
+      toast.error(errorMessage ?? "정책 목록을 불러오지 못했습니다.");
+    }
+  }, [state.status, errorMessage]);
+
+  return (
+    <aside className={styles.panel} aria-label="정책 목록">
+      <header className={styles.header}>
+        <span className={styles.headerTitle}>Policies</span>
+        <span className={styles.headerMeta}>
+          {state.status === "ready" ? `${state.data.length} · LIST` : "— · LIST"}
+        </span>
+      </header>
+
+      <div className={styles.scroll}>
+        {state.status === "loading" && (
+          <div className={styles.skeletonGroup}>
+            <div className={styles.skeletonRow} />
+            <div className={styles.skeletonRow} />
+            <div className={styles.skeletonRow} />
+          </div>
+        )}
+
+        {state.status === "error" && (
+          <div className={styles.emptyState}>
+            <span>정책 목록을 불러오지 못했습니다.</span>
+            <button
+              type="button"
+              className={styles.retryButton}
+              onClick={() => setRetryKey((key) => key + 1)}
+            >
+              다시 시도
+            </button>
+          </div>
+        )}
+
+        {state.status === "ready" && state.data.length === 0 && (
+          <div className={styles.emptyState}>
+            <span>등록된 정책 초안이 없습니다.</span>
+          </div>
+        )}
+
+        {state.status === "ready" && state.data.length > 0 && (
+          <div className={styles.listGroup}>
+            {state.data.map((policy) => (
+              <PolicyListRow
+                key={policy.id}
+                policy={policy}
+                isActive={policy.id === selectedId}
+                onSelect={onSelect}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </aside>
+  );
+}
+
+function PolicyListRow({
+  policy,
+  isActive,
+  onSelect,
+}: {
+  policy: PolicySummary;
+  isActive: boolean;
+  onSelect: (id: number) => void;
+}) {
+  return (
+    <button
+      type="button"
+      className={`${styles.item} ${isActive ? styles.itemActive : ""}`}
+      onClick={() => onSelect(policy.id)}
+      aria-pressed={isActive}
+    >
+      <div className={styles.itemInner}>
+        <span className={styles.code}>{policy.policyCode}</span>
+        <span className={styles.name}>{policy.name}</span>
+        <span className={styles.meta}>
+          <span
+            className={`${styles.badge} ${
+              policy.status === "ACTIVE" ? styles.badgeActive : styles.badgeInactive
+            }`}
+          >
+            {policy.status === "ACTIVE" ? "● ACTIVE" : "○ INACTIVE"}
+          </span>
+          <span
+            className={`${styles.badge} ${
+              policy.severity === "HIGH" || policy.severity === "CRITICAL"
+                ? styles.badgeSeverityHigh
+                : ""
+            }`}
+          >
+            {policy.severity ?? "NO SEVERITY"}
+          </span>
+        </span>
+      </div>
+    </button>
+  );
+}

--- a/frontend/src/features/policy-draft-read/ui/index.ts
+++ b/frontend/src/features/policy-draft-read/ui/index.ts
@@ -1,0 +1,2 @@
+export { PolicyDetailPanel } from "./PolicyDetailPanel";
+export { PolicyListPanel } from "./PolicyListPanel";

--- a/frontend/src/features/update-policy/api/__tests__/useUpdatePolicy.test.ts
+++ b/frontend/src/features/update-policy/api/__tests__/useUpdatePolicy.test.ts
@@ -139,7 +139,7 @@ describe("useUpdatePolicyStatus", () => {
     vi.mocked(toast.error).mockReset();
   });
 
-  it("성공 시 detail/list query cache를 갱신하고 invalidate한다", async () => {
+  it("성공 시 detail/list query cache를 갱신한다", async () => {
     mockedUpdateStatus.mockResolvedValue({ ...stubPolicy, status: "INACTIVE" });
     const { wrapper, queryClient } = makeWrapperWithClient();
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
@@ -160,12 +160,7 @@ describe("useUpdatePolicyStatus", () => {
         policyKeys.detail(params.workspaceId, params.packId, params.versionId, params.policyId),
       )?.status,
     ).toBe("INACTIVE");
-    expect(invalidateSpy).toHaveBeenCalledWith({
-      queryKey: policyKeys.detail(params.workspaceId, params.packId, params.versionId, params.policyId),
-    });
-    expect(invalidateSpy).toHaveBeenCalledWith({
-      queryKey: policyKeys.list(params.workspaceId, params.packId, params.versionId),
-    });
+    expect(invalidateSpy).not.toHaveBeenCalled();
   });
 
   it("POLICY_CODE_REFERENCED_BY_WORKFLOW 오류 시 rollback 후 전용 메시지를 표시한다", async () => {

--- a/frontend/src/features/update-policy/api/__tests__/useUpdatePolicy.test.ts
+++ b/frontend/src/features/update-policy/api/__tests__/useUpdatePolicy.test.ts
@@ -1,0 +1,215 @@
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { policyApi, policyKeys } from "@/entities/policy";
+import type { PolicyDefinition, PolicySummary } from "@/entities/policy";
+import { ApiRequestError } from "@/shared/api";
+import { toast } from "sonner";
+import { POLICY_ERROR_MESSAGES } from "../messages";
+import { useUpdatePolicy } from "../useUpdatePolicy";
+import { useUpdatePolicyStatus } from "../useUpdatePolicyStatus";
+
+vi.mock("@/entities/policy", () => ({
+  policyApi: {
+    update: vi.fn(),
+    updateStatus: vi.fn(),
+    list: vi.fn(),
+    detail: vi.fn(),
+  },
+  policyKeys: {
+    all: ["policies"],
+    lists: () => ["policies", "list"],
+    list: (...args: number[]) => ["policies", "list", ...args],
+    detail: (...args: number[]) => ["policies", "detail", ...args],
+  },
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const mockedUpdate = vi.mocked(policyApi.update);
+const mockedUpdateStatus = vi.mocked(policyApi.updateStatus);
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+function makeWrapperWithClient() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+
+  return { wrapper, queryClient };
+}
+
+const params = { workspaceId: 1, packId: 2, versionId: 3, policyId: 4 };
+
+const stubPolicy: PolicyDefinition = {
+  id: 4,
+  domainPackVersionId: 3,
+  policyCode: "POL_REFUND",
+  name: "환불 정책",
+  description: null,
+  severity: "HIGH",
+  conditionJson: "{}",
+  actionJson: "{}",
+  evidenceJson: "[]",
+  metaJson: "{}",
+  status: "ACTIVE",
+  createdAt: "2026-04-16T10:00:00Z",
+  updatedAt: "2026-04-16T10:00:00Z",
+};
+
+describe("useUpdatePolicy", () => {
+  beforeEach(() => {
+    mockedUpdate.mockReset();
+    mockedUpdateStatus.mockReset();
+    vi.mocked(toast.success).mockReset();
+    vi.mocked(toast.error).mockReset();
+  });
+
+  it("성공 시 toast.success를 호출한다", async () => {
+    mockedUpdate.mockResolvedValue({ ...stubPolicy, name: "새 정책" });
+    const { result } = renderHook(() => useUpdatePolicy(), { wrapper: makeWrapper() });
+
+    act(() => {
+      result.current.mutate({ ...params, body: { name: "새 정책" } });
+    });
+
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith("정책이 수정되었습니다."));
+  });
+
+  it("POLICY_NOT_EDITABLE 에러 시 전용 안내 메시지를 표시한다", async () => {
+    mockedUpdate.mockRejectedValue(new ApiRequestError(400, "POLICY_NOT_EDITABLE", "수정 불가"));
+    const { result } = renderHook(() => useUpdatePolicy(), { wrapper: makeWrapper() });
+
+    act(() => {
+      result.current.mutate({ ...params, body: { name: "새 정책" } });
+    });
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(POLICY_ERROR_MESSAGES.POLICY_NOT_EDITABLE),
+    );
+  });
+
+  it("VALIDATION_ERROR 에러 시 검증 안내 메시지를 표시한다", async () => {
+    mockedUpdate.mockRejectedValue(new ApiRequestError(400, "VALIDATION_ERROR", "검증 실패"));
+    const { result } = renderHook(() => useUpdatePolicy(), { wrapper: makeWrapper() });
+
+    act(() => {
+      result.current.mutate({ ...params, body: { name: "새 정책" } });
+    });
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(POLICY_ERROR_MESSAGES.VALIDATION_ERROR),
+    );
+  });
+
+  it("일반 오류 시 UPDATE_FAILED 메시지를 표시한다", async () => {
+    mockedUpdate.mockRejectedValue(new Error("network error"));
+    const { result } = renderHook(() => useUpdatePolicy(), { wrapper: makeWrapper() });
+
+    act(() => {
+      result.current.mutate({ ...params, body: { name: "새 정책" } });
+    });
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(POLICY_ERROR_MESSAGES.UPDATE_FAILED),
+    );
+  });
+});
+
+describe("useUpdatePolicyStatus", () => {
+  beforeEach(() => {
+    mockedUpdate.mockReset();
+    mockedUpdateStatus.mockReset();
+    vi.mocked(toast.success).mockReset();
+    vi.mocked(toast.error).mockReset();
+  });
+
+  it("성공 시 detail/list query cache를 갱신하고 invalidate한다", async () => {
+    mockedUpdateStatus.mockResolvedValue({ ...stubPolicy, status: "INACTIVE" });
+    const { wrapper, queryClient } = makeWrapperWithClient();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    queryClient.setQueryData<PolicyDefinition>(
+      policyKeys.detail(params.workspaceId, params.packId, params.versionId, params.policyId),
+      stubPolicy,
+    );
+
+    const { result } = renderHook(() => useUpdatePolicyStatus(), { wrapper });
+
+    act(() => {
+      result.current.mutate({ ...params, status: "INACTIVE" });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(
+      queryClient.getQueryData<PolicyDefinition>(
+        policyKeys.detail(params.workspaceId, params.packId, params.versionId, params.policyId),
+      )?.status,
+    ).toBe("INACTIVE");
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: policyKeys.detail(params.workspaceId, params.packId, params.versionId, params.policyId),
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: policyKeys.list(params.workspaceId, params.packId, params.versionId),
+    });
+  });
+
+  it("POLICY_CODE_REFERENCED_BY_WORKFLOW 오류 시 rollback 후 전용 메시지를 표시한다", async () => {
+    mockedUpdateStatus.mockRejectedValue(
+      new ApiRequestError(400, "POLICY_CODE_REFERENCED_BY_WORKFLOW", "참조 중"),
+    );
+    const { wrapper, queryClient } = makeWrapperWithClient();
+    const listKey = policyKeys.list(params.workspaceId, params.packId, params.versionId);
+    const detailKey = policyKeys.detail(
+      params.workspaceId,
+      params.packId,
+      params.versionId,
+      params.policyId,
+    );
+    queryClient.setQueryData<PolicyDefinition>(detailKey, stubPolicy);
+    queryClient.setQueryData<PolicySummary[]>(listKey, [stubPolicy]);
+
+    const { result } = renderHook(() => useUpdatePolicyStatus(), { wrapper });
+
+    act(() => {
+      result.current.mutate({ ...params, status: "INACTIVE" });
+    });
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(
+        POLICY_ERROR_MESSAGES.POLICY_CODE_REFERENCED_BY_WORKFLOW,
+      ),
+    );
+    expect(queryClient.getQueryData<PolicyDefinition>(detailKey)?.status).toBe("ACTIVE");
+    expect(queryClient.getQueryData<PolicySummary[]>(listKey)?.[0]?.status).toBe("ACTIVE");
+  });
+
+  it("POLICY_NOT_EDITABLE 오류 시 전용 메시지를 표시한다", async () => {
+    mockedUpdateStatus.mockRejectedValue(
+      new ApiRequestError(400, "POLICY_NOT_EDITABLE", "수정 불가"),
+    );
+    const { result } = renderHook(() => useUpdatePolicyStatus(), { wrapper: makeWrapper() });
+
+    act(() => {
+      result.current.mutate({ ...params, status: "INACTIVE" });
+    });
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(POLICY_ERROR_MESSAGES.POLICY_NOT_EDITABLE),
+    );
+  });
+});

--- a/frontend/src/features/update-policy/api/messages.ts
+++ b/frontend/src/features/update-policy/api/messages.ts
@@ -1,0 +1,10 @@
+export const POLICY_ERROR_MESSAGES = {
+  POLICY_NOT_EDITABLE: "DRAFT 상태의 버전에서만 정책을 수정할 수 있습니다.",
+  POLICY_CODE_REFERENCED_BY_WORKFLOW:
+    "이 정책을 참조하는 워크플로우가 있어 비활성화할 수 없습니다.",
+  VALIDATION_ERROR: "정책 데이터 검증에 실패했습니다. 입력값을 확인해주세요.",
+  NOT_FOUND: "정책을 찾을 수 없습니다.",
+  UPDATE_FAILED: "정책 수정에 실패했습니다.",
+  STATUS_FAILED: "정책 상태 변경에 실패했습니다.",
+  LOAD_FAILED: "정책 정보를 불러오지 못했습니다.",
+} as const;

--- a/frontend/src/features/update-policy/api/useGetPolicy.test.ts
+++ b/frontend/src/features/update-policy/api/useGetPolicy.test.ts
@@ -1,0 +1,67 @@
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { policyApi } from "@/entities/policy";
+import { useGetPolicy } from "./useGetPolicy";
+
+vi.mock("@/entities/policy", () => ({
+  policyApi: {
+    detail: vi.fn(),
+  },
+  policyKeys: {
+    detail: (...args: number[]) => ["policies", "detail", ...args],
+  },
+}));
+
+const mockedDetail = vi.mocked(policyApi.detail);
+
+const stubPolicy = {
+  id: 4,
+  domainPackVersionId: 3,
+  policyCode: "POL_REFUND",
+  name: "환불 정책",
+  description: null,
+  severity: "HIGH",
+  conditionJson: "{}",
+  actionJson: "{}",
+  evidenceJson: "[]",
+  metaJson: "{}",
+  status: "ACTIVE" as const,
+  createdAt: "",
+  updatedAt: "",
+};
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+describe("useGetPolicy", () => {
+  beforeEach(() => {
+    mockedDetail.mockReset();
+  });
+
+  it("enabled 상태면 정책 상세를 조회한다", async () => {
+    mockedDetail.mockResolvedValue(stubPolicy);
+
+    const { result } = renderHook(
+      () =>
+        useGetPolicy({
+          workspaceId: 1,
+          packId: 2,
+          versionId: 3,
+          policyId: 4,
+          enabled: true,
+        }),
+      { wrapper: makeWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.data).toEqual(stubPolicy));
+    expect(mockedDetail).toHaveBeenCalledWith(1, 2, 3, 4);
+  });
+});

--- a/frontend/src/features/update-policy/api/useGetPolicy.ts
+++ b/frontend/src/features/update-policy/api/useGetPolicy.ts
@@ -1,0 +1,24 @@
+import { useQuery } from "@tanstack/react-query";
+import { policyApi, policyKeys } from "@/entities/policy";
+
+export interface UseGetPolicyParams {
+  workspaceId: number;
+  packId: number;
+  versionId: number;
+  policyId: number;
+  enabled: boolean;
+}
+
+export function useGetPolicy({
+  workspaceId,
+  packId,
+  versionId,
+  policyId,
+  enabled,
+}: UseGetPolicyParams) {
+  return useQuery({
+    queryKey: policyKeys.detail(workspaceId, packId, versionId, policyId),
+    queryFn: () => policyApi.detail(workspaceId, packId, versionId, policyId),
+    enabled,
+  });
+}

--- a/frontend/src/features/update-policy/api/useUpdatePolicy.ts
+++ b/frontend/src/features/update-policy/api/useUpdatePolicy.ts
@@ -1,0 +1,65 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { policyApi, policyKeys } from "@/entities/policy";
+import type { PolicySummary, UpdatePolicyRequest } from "@/entities/policy";
+import { ApiRequestError } from "@/shared/api";
+import { POLICY_ERROR_MESSAGES } from "./messages";
+
+interface UpdatePolicyParams {
+  workspaceId: number;
+  packId: number;
+  versionId: number;
+  policyId: number;
+  body: UpdatePolicyRequest;
+}
+
+export function useUpdatePolicy() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ workspaceId, packId, versionId, policyId, body }: UpdatePolicyParams) =>
+      policyApi.update(workspaceId, packId, versionId, policyId, body),
+    onSuccess: (updatedPolicy, { workspaceId, packId, versionId, policyId }) => {
+      queryClient.setQueryData(
+        policyKeys.detail(workspaceId, packId, versionId, policyId),
+        updatedPolicy,
+      );
+      queryClient.setQueryData<PolicySummary[]>(
+        policyKeys.list(workspaceId, packId, versionId),
+        (old) =>
+          old?.map((item) =>
+            item.id === policyId
+              ? {
+                  ...item,
+                  name: updatedPolicy.name,
+                  description: updatedPolicy.description,
+                  severity: updatedPolicy.severity,
+                  status: updatedPolicy.status,
+                  updatedAt: updatedPolicy.updatedAt,
+                }
+              : item,
+          ),
+      );
+      queryClient.invalidateQueries({
+        queryKey: policyKeys.detail(workspaceId, packId, versionId, policyId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: policyKeys.list(workspaceId, packId, versionId),
+      });
+      toast.success("정책이 수정되었습니다.");
+    },
+    onError: (error: unknown) => {
+      if (error instanceof ApiRequestError) {
+        if (error.code === "POLICY_NOT_EDITABLE") {
+          toast.error(POLICY_ERROR_MESSAGES.POLICY_NOT_EDITABLE);
+          return;
+        }
+        if (error.code === "VALIDATION_ERROR") {
+          toast.error(POLICY_ERROR_MESSAGES.VALIDATION_ERROR);
+          return;
+        }
+      }
+      toast.error(POLICY_ERROR_MESSAGES.UPDATE_FAILED);
+    },
+  });
+}

--- a/frontend/src/features/update-policy/api/useUpdatePolicy.ts
+++ b/frontend/src/features/update-policy/api/useUpdatePolicy.ts
@@ -40,12 +40,6 @@ export function useUpdatePolicy() {
               : item,
           ),
       );
-      queryClient.invalidateQueries({
-        queryKey: policyKeys.detail(workspaceId, packId, versionId, policyId),
-      });
-      queryClient.invalidateQueries({
-        queryKey: policyKeys.list(workspaceId, packId, versionId),
-      });
       toast.success("정책이 수정되었습니다.");
     },
     onError: (error: unknown) => {

--- a/frontend/src/features/update-policy/api/useUpdatePolicyStatus.ts
+++ b/frontend/src/features/update-policy/api/useUpdatePolicyStatus.ts
@@ -78,12 +78,6 @@ export function useUpdatePolicyStatus() {
               : item,
           ),
       );
-      queryClient.invalidateQueries({
-        queryKey: policyKeys.detail(workspaceId, packId, versionId, policyId),
-      });
-      queryClient.invalidateQueries({
-        queryKey: policyKeys.list(workspaceId, packId, versionId),
-      });
     },
   });
 }

--- a/frontend/src/features/update-policy/api/useUpdatePolicyStatus.ts
+++ b/frontend/src/features/update-policy/api/useUpdatePolicyStatus.ts
@@ -1,0 +1,89 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { policyApi, policyKeys } from "@/entities/policy";
+import type { PolicyDefinition, PolicyStatus, PolicySummary } from "@/entities/policy";
+import { ApiRequestError } from "@/shared/api";
+import { POLICY_ERROR_MESSAGES } from "./messages";
+
+interface UpdatePolicyStatusParams {
+  workspaceId: number;
+  packId: number;
+  versionId: number;
+  policyId: number;
+  status: PolicyStatus;
+}
+
+export const UPDATE_POLICY_STATUS_MUTATION_KEY = ["updatePolicyStatus"] as const;
+
+export function useUpdatePolicyStatus() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationKey: UPDATE_POLICY_STATUS_MUTATION_KEY,
+    mutationFn: ({ workspaceId, packId, versionId, policyId, status }: UpdatePolicyStatusParams) =>
+      policyApi.updateStatus(workspaceId, packId, versionId, policyId, { status }),
+    onMutate: async ({ workspaceId, packId, versionId, policyId, status }) => {
+      const detailKey = policyKeys.detail(workspaceId, packId, versionId, policyId);
+      const listKey = policyKeys.list(workspaceId, packId, versionId);
+
+      await queryClient.cancelQueries({ queryKey: detailKey });
+      await queryClient.cancelQueries({ queryKey: listKey });
+
+      const previousDetail = queryClient.getQueryData<PolicyDefinition>(detailKey);
+      const previousList = queryClient.getQueryData<PolicySummary[]>(listKey);
+
+      queryClient.setQueryData<PolicyDefinition>(detailKey, (old) =>
+        old ? { ...old, status } : old,
+      );
+      queryClient.setQueryData<PolicySummary[]>(listKey, (old) =>
+        old?.map((item) => (item.id === policyId ? { ...item, status } : item)),
+      );
+
+      return { previousDetail, previousList, detailKey, listKey };
+    },
+    onError: (error, _vars, context) => {
+      if (context) {
+        queryClient.setQueryData(context.detailKey, context.previousDetail);
+        queryClient.setQueryData(context.listKey, context.previousList);
+      }
+
+      if (error instanceof ApiRequestError) {
+        if (error.code === "POLICY_CODE_REFERENCED_BY_WORKFLOW") {
+          toast.error(POLICY_ERROR_MESSAGES.POLICY_CODE_REFERENCED_BY_WORKFLOW);
+          return;
+        }
+        if (error.code === "POLICY_NOT_EDITABLE") {
+          toast.error(POLICY_ERROR_MESSAGES.POLICY_NOT_EDITABLE);
+          return;
+        }
+      }
+
+      toast.error(POLICY_ERROR_MESSAGES.STATUS_FAILED);
+    },
+    onSuccess: (updatedPolicy, { workspaceId, packId, versionId, policyId }) => {
+      queryClient.setQueryData(
+        policyKeys.detail(workspaceId, packId, versionId, policyId),
+        updatedPolicy,
+      );
+      queryClient.setQueryData<PolicySummary[]>(
+        policyKeys.list(workspaceId, packId, versionId),
+        (old) =>
+          old?.map((item) =>
+            item.id === policyId
+              ? {
+                  ...item,
+                  status: updatedPolicy.status,
+                  updatedAt: updatedPolicy.updatedAt,
+                }
+              : item,
+          ),
+      );
+      queryClient.invalidateQueries({
+        queryKey: policyKeys.detail(workspaceId, packId, versionId, policyId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: policyKeys.list(workspaceId, packId, versionId),
+      });
+    },
+  });
+}

--- a/frontend/src/features/update-policy/index.ts
+++ b/frontend/src/features/update-policy/index.ts
@@ -1,0 +1,2 @@
+export { PolicyEditPanel } from "./ui/PolicyEditPanel";
+export { PolicyEditSheet } from "./ui/PolicyEditSheet";

--- a/frontend/src/features/update-policy/model/schema.test.ts
+++ b/frontend/src/features/update-policy/model/schema.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { policyEditSchema } from "./schema";
+
+const validPolicyValues = {
+  name: "환불 정책",
+  description: null,
+  severity: "HIGH",
+  conditionJson: "{}",
+  actionJson: "{}",
+  evidenceJson: "[]",
+  metaJson: "{}",
+};
+
+describe("policyEditSchema", () => {
+  it("유효한 policy 수정 값을 통과시킨다", () => {
+    const result = policyEditSchema.safeParse(validPolicyValues);
+    expect(result.success).toBe(true);
+  });
+
+  it("name이 공백이면 실패한다", () => {
+    const result = policyEditSchema.safeParse({ ...validPolicyValues, name: "   " });
+    expect(result.success).toBe(false);
+  });
+
+  it("conditionJson은 JSON object 문자열이어야 한다", () => {
+    const result = policyEditSchema.safeParse({
+      ...validPolicyValues,
+      conditionJson: "[]",
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toBe("조건 JSON은 객체여야 합니다.");
+    }
+  });
+
+  it("evidenceJson은 JSON array 문자열이어야 한다", () => {
+    const result = policyEditSchema.safeParse({
+      ...validPolicyValues,
+      evidenceJson: "{}",
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toBe("근거 JSON은 배열이어야 합니다.");
+    }
+  });
+});

--- a/frontend/src/features/update-policy/model/schema.test.ts
+++ b/frontend/src/features/update-policy/model/schema.test.ts
@@ -45,4 +45,40 @@ describe("policyEditSchema", () => {
       expect(result.error.issues[0]?.message).toBe("근거 JSON은 배열이어야 합니다.");
     }
   });
+
+  it("actionJson은 JSON object 문자열이어야 한다", () => {
+    const result = policyEditSchema.safeParse({
+      ...validPolicyValues,
+      actionJson: "[]",
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toBe("액션 JSON은 객체여야 합니다.");
+    }
+  });
+
+  it("metaJson은 JSON object 문자열이어야 한다", () => {
+    const result = policyEditSchema.safeParse({
+      ...validPolicyValues,
+      metaJson: "[]",
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toBe("메타 JSON은 객체여야 합니다.");
+    }
+  });
+
+  it("잘못된 JSON 문자열이면 실패한다", () => {
+    const result = policyEditSchema.safeParse({
+      ...validPolicyValues,
+      conditionJson: "{",
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toBe("조건 JSON은 객체여야 합니다.");
+    }
+  });
 });

--- a/frontend/src/features/update-policy/model/schema.ts
+++ b/frontend/src/features/update-policy/model/schema.ts
@@ -1,0 +1,38 @@
+import { z } from "zod";
+
+function isJsonObjectString(value: string): boolean {
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed);
+  } catch {
+    return false;
+  }
+}
+
+function isJsonArrayString(value: string): boolean {
+  try {
+    return Array.isArray(JSON.parse(value) as unknown);
+  } catch {
+    return false;
+  }
+}
+
+export function jsonObjectString(message: string) {
+  return z.string().refine(isJsonObjectString, { message });
+}
+
+export function jsonArrayString(message: string) {
+  return z.string().refine(isJsonArrayString, { message });
+}
+
+export const policyEditSchema = z.object({
+  name: z.string().trim().min(1, "정책 이름은 필수입니다."),
+  description: z.string().nullable().optional(),
+  severity: z.string().nullable().optional(),
+  conditionJson: jsonObjectString("조건 JSON은 객체여야 합니다."),
+  actionJson: jsonObjectString("액션 JSON은 객체여야 합니다."),
+  evidenceJson: jsonArrayString("근거 JSON은 배열이어야 합니다."),
+  metaJson: jsonObjectString("메타 JSON은 객체여야 합니다."),
+});
+
+export type PolicyEditFormValues = z.infer<typeof policyEditSchema>;

--- a/frontend/src/features/update-policy/ui/JsonTextarea.test.tsx
+++ b/frontend/src/features/update-policy/ui/JsonTextarea.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { JsonTextarea } from "./JsonTextarea";
+
+describe("JsonTextarea", () => {
+  it("renders as a monospace textarea with spellcheck disabled", () => {
+    render(<JsonTextarea aria-label="JSON 입력" className="custom-class" />);
+
+    const textarea = screen.getByLabelText("JSON 입력");
+    expect(textarea).toHaveClass("font-mono");
+    expect(textarea).toHaveClass("custom-class");
+    expect(textarea).toHaveAttribute("spellcheck", "false");
+  });
+});

--- a/frontend/src/features/update-policy/ui/JsonTextarea.tsx
+++ b/frontend/src/features/update-policy/ui/JsonTextarea.tsx
@@ -1,4 +1,5 @@
 import { Textarea } from "@/shared/ui/textarea";
+import { cn } from "@/shared/lib/utils";
 import type { ComponentProps } from "react";
 
 type JsonTextareaProps = ComponentProps<typeof Textarea>;
@@ -6,7 +7,7 @@ type JsonTextareaProps = ComponentProps<typeof Textarea>;
 export function JsonTextarea({ className, ...props }: JsonTextareaProps) {
   return (
     <Textarea
-      className={`min-h-32 resize-y font-mono text-xs leading-relaxed ${className ?? ""}`}
+      className={cn("min-h-32 resize-y font-mono text-xs leading-relaxed", className)}
       spellCheck={false}
       {...props}
     />

--- a/frontend/src/features/update-policy/ui/JsonTextarea.tsx
+++ b/frontend/src/features/update-policy/ui/JsonTextarea.tsx
@@ -1,0 +1,14 @@
+import { Textarea } from "@/shared/ui/textarea";
+import type { ComponentProps } from "react";
+
+type JsonTextareaProps = ComponentProps<typeof Textarea>;
+
+export function JsonTextarea({ className, ...props }: JsonTextareaProps) {
+  return (
+    <Textarea
+      className={`min-h-32 resize-y font-mono text-xs leading-relaxed ${className ?? ""}`}
+      spellCheck={false}
+      {...props}
+    />
+  );
+}

--- a/frontend/src/features/update-policy/ui/PolicyEditForm.test.tsx
+++ b/frontend/src/features/update-policy/ui/PolicyEditForm.test.tsx
@@ -1,0 +1,126 @@
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { useUpdatePolicy } from "../api/useUpdatePolicy";
+import { useUpdatePolicyStatus } from "../api/useUpdatePolicyStatus";
+import { PolicyEditForm } from "./PolicyEditForm";
+
+vi.mock("../api/useUpdatePolicy", () => ({
+  useUpdatePolicy: vi.fn(),
+}));
+
+vi.mock("../api/useUpdatePolicyStatus", async () => {
+  const actual = await vi.importActual<typeof import("../api/useUpdatePolicyStatus")>(
+    "../api/useUpdatePolicyStatus",
+  );
+  return {
+    ...actual,
+    useUpdatePolicyStatus: vi.fn(),
+  };
+});
+
+const mutatePolicy = vi.fn();
+const mutateStatus = vi.fn();
+const mockedUseUpdatePolicy = vi.mocked(useUpdatePolicy);
+const mockedUseUpdatePolicyStatus = vi.mocked(useUpdatePolicyStatus);
+
+const stubPolicy = {
+  id: 4,
+  domainPackVersionId: 3,
+  policyCode: "POL_REFUND",
+  name: "환불 정책",
+  description: "환불 조건",
+  severity: "HIGH",
+  conditionJson: '{"channel":"web"}',
+  actionJson: '{"type":"REFUND_REVIEW"}',
+  evidenceJson: "[]",
+  metaJson: "{}",
+  status: "ACTIVE" as const,
+  createdAt: "",
+  updatedAt: "",
+};
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+function renderForm(onClose = vi.fn()) {
+  render(
+    <PolicyEditForm
+      policy={stubPolicy}
+      workspaceId={1}
+      packId={2}
+      versionId={3}
+      onClose={onClose}
+    />,
+    { wrapper: makeWrapper() },
+  );
+  return { onClose };
+}
+
+describe("PolicyEditForm", () => {
+  beforeAll(() => {
+    globalThis.ResizeObserver = class ResizeObserver {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  });
+
+  beforeEach(() => {
+    mutatePolicy.mockReset();
+    mutateStatus.mockReset();
+    mockedUseUpdatePolicy.mockReturnValue({
+      mutate: mutatePolicy,
+      isPending: false,
+    } as unknown as ReturnType<typeof useUpdatePolicy>);
+    mockedUseUpdatePolicyStatus.mockReturnValue({
+      mutate: mutateStatus,
+      isPending: false,
+    } as unknown as ReturnType<typeof useUpdatePolicyStatus>);
+  });
+
+  it("기존 정책 값을 폼에 채운다", () => {
+    renderForm();
+
+    expect(screen.getByDisplayValue("환불 정책")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("환불 조건")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("POL_REFUND")).toBeDisabled();
+    expect(screen.getByDisplayValue("3")).toBeDisabled();
+  });
+
+  it("저장 시 수정 mutation을 호출한다", async () => {
+    renderForm();
+
+    fireEvent.change(screen.getByDisplayValue("환불 정책"), {
+      target: { value: "환불 정책 수정본" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "저장" }));
+
+    await waitFor(() => expect(mutatePolicy).toHaveBeenCalled());
+    expect(mutatePolicy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: 1,
+        packId: 2,
+        versionId: 3,
+        policyId: 4,
+        body: expect.objectContaining({ name: "환불 정책 수정본" }),
+      }),
+      expect.objectContaining({ onSuccess: expect.any(Function) }),
+    );
+  });
+
+  it("취소 시 onClose를 호출한다", () => {
+    const { onClose } = renderForm();
+
+    fireEvent.click(screen.getByRole("button", { name: "취소" }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/features/update-policy/ui/PolicyEditForm.test.tsx
+++ b/frontend/src/features/update-policy/ui/PolicyEditForm.test.tsx
@@ -67,9 +67,9 @@ function renderForm(onClose = vi.fn()) {
 describe("PolicyEditForm", () => {
   beforeAll(() => {
     globalThis.ResizeObserver = class ResizeObserver {
-      observe() {}
-      unobserve() {}
-      disconnect() {}
+      observe = vi.fn();
+      unobserve = vi.fn();
+      disconnect = vi.fn();
     };
   });
 

--- a/frontend/src/features/update-policy/ui/PolicyEditForm.tsx
+++ b/frontend/src/features/update-policy/ui/PolicyEditForm.tsx
@@ -1,0 +1,206 @@
+import { useMemo } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useIsMutating } from "@tanstack/react-query";
+import {
+  Form,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormMessage,
+} from "@/shared/ui/form";
+import { Input } from "@/shared/ui/input";
+import { Button } from "@/shared/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/shared/ui/select";
+import { policyEditSchema, type PolicyEditFormValues } from "../model/schema";
+import { useUpdatePolicy } from "../api/useUpdatePolicy";
+import { UPDATE_POLICY_STATUS_MUTATION_KEY } from "../api/useUpdatePolicyStatus";
+import { PolicyJsonFields } from "./PolicyJsonFields";
+import { PolicyStatusToggle } from "./PolicyStatusToggle";
+import type { PolicyDefinition, UpdatePolicyRequest } from "@/entities/policy";
+
+const SEVERITY_OPTIONS = ["LOW", "MEDIUM", "HIGH", "CRITICAL"] as const;
+
+interface PolicyEditFormProps {
+  policy: PolicyDefinition;
+  workspaceId: number;
+  packId: number;
+  versionId: number;
+  onClose: () => void;
+}
+
+export function PolicyEditForm({
+  policy,
+  workspaceId,
+  packId,
+  versionId,
+  onClose,
+}: PolicyEditFormProps) {
+  const { mutate, isPending } = useUpdatePolicy();
+  const isStatusPending =
+    useIsMutating({ mutationKey: UPDATE_POLICY_STATUS_MUTATION_KEY }) > 0;
+  const isAnyPending = isPending || isStatusPending;
+
+  const customSeverity = useMemo(() => {
+    if (!policy.severity) return null;
+    return SEVERITY_OPTIONS.includes(policy.severity as (typeof SEVERITY_OPTIONS)[number])
+      ? null
+      : policy.severity;
+  }, [policy.severity]);
+
+  const form = useForm<PolicyEditFormValues>({
+    resolver: zodResolver(policyEditSchema),
+    defaultValues: {
+      name: policy.name,
+      description: policy.description,
+      severity: policy.severity,
+      conditionJson: formatJsonInput(policy.conditionJson),
+      actionJson: formatJsonInput(policy.actionJson),
+      evidenceJson: formatJsonInput(policy.evidenceJson),
+      metaJson: formatJsonInput(policy.metaJson),
+    },
+  });
+
+  const onSubmit = (values: PolicyEditFormValues) => {
+    const body: UpdatePolicyRequest = {
+      name: values.name,
+      description: normalizeNullableString(values.description),
+      severity: normalizeNullableString(values.severity),
+      conditionJson: values.conditionJson,
+      actionJson: values.actionJson,
+      evidenceJson: values.evidenceJson,
+      metaJson: values.metaJson,
+    };
+
+    mutate(
+      { workspaceId, packId, versionId, policyId: policy.id, body },
+      { onSuccess: onClose },
+    );
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="flex w-full flex-col gap-4">
+        <FormField
+          control={form.control}
+          name="name"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>이름 *</FormLabel>
+              <FormControl>
+                <Input {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="description"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>설명</FormLabel>
+              <FormControl>
+                <Input
+                  {...field}
+                  value={field.value ?? ""}
+                  onChange={(e) => field.onChange(e.target.value || null)}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="severity"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>심각도</FormLabel>
+              <Select
+                value={field.value ?? "NONE"}
+                onValueChange={(value) => field.onChange(value === "NONE" ? null : value)}
+              >
+                <FormControl>
+                  <SelectTrigger className="w-full" aria-label="정책 심각도">
+                    <SelectValue placeholder="선택 안 함" />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent
+                  position="popper"
+                  align="start"
+                  className="z-[80] w-[var(--radix-select-trigger-width)]"
+                >
+                  <SelectItem value="NONE">선택 안 함</SelectItem>
+                  {SEVERITY_OPTIONS.map((severity) => (
+                    <SelectItem key={severity} value={severity}>
+                      {severity}
+                    </SelectItem>
+                  ))}
+                  {customSeverity && <SelectItem value={customSeverity}>{customSeverity}</SelectItem>}
+                </SelectContent>
+              </Select>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <div className="grid gap-2">
+          <span className="text-sm font-medium leading-none">정책 코드</span>
+          <Input value={policy.policyCode} readOnly disabled />
+        </div>
+
+        <div className="grid gap-2">
+          <span className="text-sm font-medium leading-none">버전 ID</span>
+          <Input value={policy.domainPackVersionId} readOnly disabled />
+        </div>
+
+        <PolicyJsonFields />
+
+        <div className="flex flex-row items-center justify-between border-t pt-4">
+          <span className="text-sm font-medium leading-none">상태</span>
+          <PolicyStatusToggle
+            workspaceId={workspaceId}
+            packId={packId}
+            versionId={versionId}
+            policyId={policy.id}
+            currentStatus={policy.status}
+            disabled={isAnyPending}
+          />
+        </div>
+
+        <div className="flex gap-2 justify-end border-t pt-4">
+          <Button type="button" variant="outline" onClick={onClose} disabled={isAnyPending}>
+            취소
+          </Button>
+          <Button type="submit" disabled={isAnyPending}>
+            저장
+          </Button>
+        </div>
+      </form>
+    </Form>
+  );
+}
+
+function normalizeNullableString(value: string | null | undefined): string | null {
+  const trimmed = value?.trim() ?? "";
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function formatJsonInput(raw: string): string {
+  if (!raw) return raw;
+  try {
+    return JSON.stringify(JSON.parse(raw), null, 2);
+  } catch {
+    return raw;
+  }
+}

--- a/frontend/src/features/update-policy/ui/PolicyEditForm.tsx
+++ b/frontend/src/features/update-policy/ui/PolicyEditForm.tsx
@@ -2,23 +2,10 @@ import { useMemo } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useIsMutating } from "@tanstack/react-query";
-import {
-  Form,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormControl,
-  FormMessage,
-} from "@/shared/ui/form";
+import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from "@/shared/ui/form";
 import { Input } from "@/shared/ui/input";
 import { Button } from "@/shared/ui/button";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/shared/ui/select";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/shared/ui/select";
 import { policyEditSchema, type PolicyEditFormValues } from "../model/schema";
 import { useUpdatePolicy } from "../api/useUpdatePolicy";
 import { UPDATE_POLICY_STATUS_MUTATION_KEY } from "../api/useUpdatePolicyStatus";
@@ -27,6 +14,8 @@ import { PolicyStatusToggle } from "./PolicyStatusToggle";
 import type { PolicyDefinition, UpdatePolicyRequest } from "@/entities/policy";
 
 const SEVERITY_OPTIONS = ["LOW", "MEDIUM", "HIGH", "CRITICAL"] as const;
+
+type TextInputName = "name" | "description";
 
 interface PolicyEditFormProps {
   policy: PolicyDefinition;
@@ -42,10 +31,9 @@ export function PolicyEditForm({
   packId,
   versionId,
   onClose,
-}: PolicyEditFormProps) {
+}: Readonly<PolicyEditFormProps>) {
   const { mutate, isPending } = useUpdatePolicy();
-  const isStatusPending =
-    useIsMutating({ mutationKey: UPDATE_POLICY_STATUS_MUTATION_KEY }) > 0;
+  const isStatusPending = useIsMutating({ mutationKey: UPDATE_POLICY_STATUS_MUTATION_KEY }) > 0;
   const isAnyPending = isPending || isStatusPending;
 
   const customSeverity = useMemo(() => {
@@ -79,46 +67,43 @@ export function PolicyEditForm({
       metaJson: values.metaJson,
     };
 
-    mutate(
-      { workspaceId, packId, versionId, policyId: policy.id, body },
-      { onSuccess: onClose },
-    );
+    mutate({ workspaceId, packId, versionId, policyId: policy.id, body }, { onSuccess: onClose });
   };
+
+  const textFields: ReadonlyArray<
+    Readonly<{ name: TextInputName; label: string; required?: boolean }>
+  > = [
+    { name: "name", label: "이름 *", required: true },
+    { name: "description", label: "설명" },
+  ];
 
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)} className="flex w-full flex-col gap-4">
-        <FormField
-          control={form.control}
-          name="name"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>이름 *</FormLabel>
-              <FormControl>
-                <Input {...field} />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-
-        <FormField
-          control={form.control}
-          name="description"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>설명</FormLabel>
-              <FormControl>
-                <Input
-                  {...field}
-                  value={field.value ?? ""}
-                  onChange={(e) => field.onChange(e.target.value || null)}
-                />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
+        {textFields.map((textField) => (
+          <FormField
+            key={textField.name}
+            control={form.control}
+            name={textField.name}
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>{textField.label}</FormLabel>
+                <FormControl>
+                  <Input
+                    {...field}
+                    value={field.value ?? ""}
+                    onChange={(event) =>
+                      field.onChange(
+                        textField.required ? event.target.value : event.target.value || null,
+                      )
+                    }
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        ))}
 
         <FormField
           control={form.control}
@@ -146,7 +131,9 @@ export function PolicyEditForm({
                       {severity}
                     </SelectItem>
                   ))}
-                  {customSeverity && <SelectItem value={customSeverity}>{customSeverity}</SelectItem>}
+                  {customSeverity && (
+                    <SelectItem value={customSeverity}>{customSeverity}</SelectItem>
+                  )}
                 </SelectContent>
               </Select>
               <FormMessage />
@@ -154,15 +141,8 @@ export function PolicyEditForm({
           )}
         />
 
-        <div className="grid gap-2">
-          <span className="text-sm font-medium leading-none">정책 코드</span>
-          <Input value={policy.policyCode} readOnly disabled />
-        </div>
-
-        <div className="grid gap-2">
-          <span className="text-sm font-medium leading-none">버전 ID</span>
-          <Input value={policy.domainPackVersionId} readOnly disabled />
-        </div>
+        <ReadonlyPolicyValue label="정책 코드" value={policy.policyCode} />
+        <ReadonlyPolicyValue label="버전 ID" value={policy.domainPackVersionId} />
 
         <PolicyJsonFields />
 
@@ -188,6 +168,18 @@ export function PolicyEditForm({
         </div>
       </form>
     </Form>
+  );
+}
+
+function ReadonlyPolicyValue({
+  label,
+  value,
+}: Readonly<{ label: string; value: string | number }>) {
+  return (
+    <div className="grid gap-2">
+      <span className="text-sm font-medium leading-none">{label}</span>
+      <Input value={value} readOnly disabled />
+    </div>
   );
 }
 

--- a/frontend/src/features/update-policy/ui/PolicyEditForm.tsx
+++ b/frontend/src/features/update-policy/ui/PolicyEditForm.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useIsMutating } from "@tanstack/react-query";
@@ -37,24 +37,21 @@ export function PolicyEditForm({
   const isAnyPending = isPending || isStatusPending;
 
   const customSeverity = useMemo(() => {
-    if (!policy.severity) return null;
-    return SEVERITY_OPTIONS.includes(policy.severity as (typeof SEVERITY_OPTIONS)[number])
+    const normalizedSeverity = normalizeSeverity(policy.severity);
+    if (!normalizedSeverity) return null;
+    return SEVERITY_OPTIONS.includes(normalizedSeverity as (typeof SEVERITY_OPTIONS)[number])
       ? null
-      : policy.severity;
+      : normalizedSeverity;
   }, [policy.severity]);
 
   const form = useForm<PolicyEditFormValues>({
     resolver: zodResolver(policyEditSchema),
-    defaultValues: {
-      name: policy.name,
-      description: policy.description,
-      severity: policy.severity,
-      conditionJson: formatJsonInput(policy.conditionJson),
-      actionJson: formatJsonInput(policy.actionJson),
-      evidenceJson: formatJsonInput(policy.evidenceJson),
-      metaJson: formatJsonInput(policy.metaJson),
-    },
+    defaultValues: getPolicyDefaultValues(policy),
   });
+
+  useEffect(() => {
+    form.reset(getPolicyDefaultValues(policy));
+  }, [form, policy]);
 
   const onSubmit = (values: PolicyEditFormValues) => {
     const body: UpdatePolicyRequest = {
@@ -195,4 +192,21 @@ function formatJsonInput(raw: string): string {
   } catch {
     return raw;
   }
+}
+
+function normalizeSeverity(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed.toUpperCase() : null;
+}
+
+function getPolicyDefaultValues(policy: PolicyDefinition): PolicyEditFormValues {
+  return {
+    name: policy.name,
+    description: policy.description,
+    severity: normalizeSeverity(policy.severity),
+    conditionJson: formatJsonInput(policy.conditionJson),
+    actionJson: formatJsonInput(policy.actionJson),
+    evidenceJson: formatJsonInput(policy.evidenceJson),
+    metaJson: formatJsonInput(policy.metaJson),
+  };
 }

--- a/frontend/src/features/update-policy/ui/PolicyEditPanel.test.tsx
+++ b/frontend/src/features/update-policy/ui/PolicyEditPanel.test.tsx
@@ -1,0 +1,89 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useGetPolicy } from "../api/useGetPolicy";
+import { PolicyEditPanel } from "./PolicyEditPanel";
+
+vi.mock("../api/useGetPolicy", () => ({
+  useGetPolicy: vi.fn(),
+}));
+
+vi.mock("./PolicyEditForm", () => ({
+  PolicyEditForm: () => <div data-testid="policy-edit-form">form</div>,
+}));
+
+const mockedUseGetPolicy = vi.mocked(useGetPolicy);
+const refetch = vi.fn();
+
+const stubPolicy = {
+  id: 4,
+  domainPackVersionId: 3,
+  policyCode: "POL_REFUND",
+  name: "환불 정책",
+  description: null,
+  severity: "HIGH",
+  conditionJson: "{}",
+  actionJson: "{}",
+  evidenceJson: "[]",
+  metaJson: "{}",
+  status: "ACTIVE" as const,
+  createdAt: "",
+  updatedAt: "",
+};
+
+describe("PolicyEditPanel", () => {
+  beforeEach(() => {
+    refetch.mockReset();
+    mockedUseGetPolicy.mockReset();
+  });
+
+  it("policy 조회 성공 시 수정 폼을 보여준다", () => {
+    mockedUseGetPolicy.mockReturnValue({
+      data: stubPolicy,
+      isLoading: false,
+      isError: false,
+      refetch,
+    } as unknown as ReturnType<typeof useGetPolicy>);
+
+    render(
+      <PolicyEditPanel workspaceId={1} packId={2} versionId={3} policyId={4} onClose={vi.fn()} />,
+    );
+
+    expect(screen.getByText("POL_REFUND · 환불 정책")).toBeInTheDocument();
+    expect(screen.getByTestId("policy-edit-form")).toBeInTheDocument();
+  });
+
+  it("닫기 버튼을 누르면 onClose를 호출한다", () => {
+    const onClose = vi.fn();
+    mockedUseGetPolicy.mockReturnValue({
+      data: stubPolicy,
+      isLoading: false,
+      isError: false,
+      refetch,
+    } as unknown as ReturnType<typeof useGetPolicy>);
+
+    render(
+      <PolicyEditPanel workspaceId={1} packId={2} versionId={3} policyId={4} onClose={onClose} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "수정 닫기" }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("조회 실패 시 재시도 버튼을 제공한다", () => {
+    mockedUseGetPolicy.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      refetch,
+    } as unknown as ReturnType<typeof useGetPolicy>);
+
+    render(
+      <PolicyEditPanel workspaceId={1} packId={2} versionId={3} policyId={4} onClose={vi.fn()} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "다시 시도" }));
+
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/features/update-policy/ui/PolicyEditPanel.tsx
+++ b/frontend/src/features/update-policy/ui/PolicyEditPanel.tsx
@@ -1,0 +1,78 @@
+import { XIcon } from "lucide-react";
+
+import { Button } from "@/shared/ui/button";
+import { Spinner } from "@/shared/ui/spinner";
+
+import { POLICY_ERROR_MESSAGES } from "../api/messages";
+import { useGetPolicy } from "../api/useGetPolicy";
+import { PolicyEditForm } from "./PolicyEditForm";
+import styles from "./policy-edit-panel.module.css";
+
+interface PolicyEditPanelProps {
+  workspaceId: number;
+  packId: number;
+  versionId: number;
+  policyId: number;
+  onClose: () => void;
+}
+
+export function PolicyEditPanel({
+  workspaceId,
+  packId,
+  versionId,
+  policyId,
+  onClose,
+}: PolicyEditPanelProps) {
+  const { data: policy, isLoading, isError, refetch } = useGetPolicy({
+    workspaceId,
+    packId,
+    versionId,
+    policyId,
+    enabled: true,
+  });
+
+  return (
+    <section className={styles.panel} aria-label="정책 수정">
+      <header className={styles.header}>
+        <div className={styles.headerText}>
+          <span className={styles.eyebrow}>EDIT POLICY</span>
+          <h2 className={styles.title}>
+            {policy ? `${policy.policyCode} · ${policy.name}` : "정책 수정"}
+          </h2>
+          <p className={styles.description}>정책 필드와 상태를 수정합니다.</p>
+        </div>
+        <button type="button" className={styles.closeButton} onClick={onClose} aria-label="수정 닫기">
+          <XIcon aria-hidden="true" />
+          <span>닫기</span>
+        </button>
+      </header>
+
+      {isLoading && (
+        <div className={styles.statePanel}>
+          <Spinner className={styles.spinner} />
+        </div>
+      )}
+
+      {isError && (
+        <div className={styles.statePanel}>
+          <span>{POLICY_ERROR_MESSAGES.LOAD_FAILED}</span>
+          <Button variant="outline" size="sm" onClick={() => refetch()}>
+            다시 시도
+          </Button>
+        </div>
+      )}
+
+      {policy && !isLoading && !isError && (
+        <div className={styles.body}>
+          <PolicyEditForm
+            policy={policy}
+            workspaceId={workspaceId}
+            packId={packId}
+            versionId={versionId}
+            onClose={onClose}
+          />
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/features/update-policy/ui/PolicyEditPanel.tsx
+++ b/frontend/src/features/update-policy/ui/PolicyEditPanel.tsx
@@ -22,8 +22,13 @@ export function PolicyEditPanel({
   versionId,
   policyId,
   onClose,
-}: PolicyEditPanelProps) {
-  const { data: policy, isLoading, isError, refetch } = useGetPolicy({
+}: Readonly<PolicyEditPanelProps>) {
+  const {
+    data: policy,
+    isLoading,
+    isError,
+    refetch,
+  } = useGetPolicy({
     workspaceId,
     packId,
     versionId,
@@ -41,7 +46,12 @@ export function PolicyEditPanel({
           </h2>
           <p className={styles.description}>정책 필드와 상태를 수정합니다.</p>
         </div>
-        <button type="button" className={styles.closeButton} onClick={onClose} aria-label="수정 닫기">
+        <button
+          type="button"
+          className={styles.closeButton}
+          onClick={onClose}
+          aria-label="수정 닫기"
+        >
           <XIcon aria-hidden="true" />
           <span>닫기</span>
         </button>

--- a/frontend/src/features/update-policy/ui/PolicyEditSheet.test.tsx
+++ b/frontend/src/features/update-policy/ui/PolicyEditSheet.test.tsx
@@ -1,0 +1,85 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useGetPolicy } from "../api/useGetPolicy";
+import { PolicyEditSheet } from "./PolicyEditSheet";
+
+vi.mock("../api/useGetPolicy", () => ({
+  useGetPolicy: vi.fn(),
+}));
+
+vi.mock("./PolicyEditForm", () => ({
+  PolicyEditForm: () => <div data-testid="sheet-policy-edit-form">form</div>,
+}));
+
+const mockedUseGetPolicy = vi.mocked(useGetPolicy);
+const refetch = vi.fn();
+
+const stubPolicy = {
+  id: 4,
+  domainPackVersionId: 3,
+  policyCode: "POL_REFUND",
+  name: "환불 정책",
+  description: null,
+  severity: "HIGH",
+  conditionJson: "{}",
+  actionJson: "{}",
+  evidenceJson: "[]",
+  metaJson: "{}",
+  status: "ACTIVE" as const,
+  createdAt: "",
+  updatedAt: "",
+};
+
+describe("PolicyEditSheet", () => {
+  beforeEach(() => {
+    refetch.mockReset();
+    mockedUseGetPolicy.mockReset();
+  });
+
+  it("열렸을 때 정책 수정 폼을 표시한다", () => {
+    mockedUseGetPolicy.mockReturnValue({
+      data: stubPolicy,
+      isLoading: false,
+      isError: false,
+      refetch,
+    } as unknown as ReturnType<typeof useGetPolicy>);
+
+    render(
+      <PolicyEditSheet
+        workspaceId={1}
+        packId={2}
+        versionId={3}
+        policyId={4}
+        isOpen
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("POL_REFUND · 환불 정책")).toBeInTheDocument();
+    expect(screen.getByTestId("sheet-policy-edit-form")).toBeInTheDocument();
+  });
+
+  it("조회 실패 시 재시도한다", () => {
+    mockedUseGetPolicy.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      refetch,
+    } as unknown as ReturnType<typeof useGetPolicy>);
+
+    render(
+      <PolicyEditSheet
+        workspaceId={1}
+        packId={2}
+        versionId={3}
+        policyId={4}
+        isOpen
+        onClose={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "다시 시도" }));
+
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/features/update-policy/ui/PolicyEditSheet.tsx
+++ b/frontend/src/features/update-policy/ui/PolicyEditSheet.tsx
@@ -1,0 +1,81 @@
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from "@/shared/ui/sheet";
+import { Spinner } from "@/shared/ui/spinner";
+import { Button } from "@/shared/ui/button";
+import { useGetPolicy } from "../api/useGetPolicy";
+import { PolicyEditForm } from "./PolicyEditForm";
+import { POLICY_ERROR_MESSAGES } from "../api/messages";
+
+interface PolicyEditSheetProps {
+  workspaceId: number;
+  packId: number;
+  versionId: number;
+  policyId: number;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function PolicyEditSheet({
+  workspaceId,
+  packId,
+  versionId,
+  policyId,
+  isOpen,
+  onClose,
+}: PolicyEditSheetProps) {
+  const { data: policy, isLoading, isError, refetch } = useGetPolicy({
+    workspaceId,
+    packId,
+    versionId,
+    policyId,
+    enabled: isOpen,
+  });
+
+  return (
+    <Sheet
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <SheetContent side="right" className="w-full overflow-y-auto sm:max-w-xl">
+        <SheetHeader className="px-4 pt-4">
+          <SheetTitle>
+            {policy ? `${policy.policyCode} · ${policy.name}` : "정책 수정"}
+          </SheetTitle>
+          <SheetDescription>정책 필드와 상태를 수정합니다.</SheetDescription>
+        </SheetHeader>
+
+        {isLoading && (
+          <div className="flex items-center justify-center py-12">
+            <Spinner className="size-6" />
+          </div>
+        )}
+
+        {isError && (
+          <div className="flex flex-col items-center justify-center gap-4 px-4 py-12 text-sm text-muted-foreground">
+            <span>{POLICY_ERROR_MESSAGES.LOAD_FAILED}</span>
+            <Button variant="outline" size="sm" onClick={() => refetch()}>
+              다시 시도
+            </Button>
+          </div>
+        )}
+
+        {policy && !isLoading && !isError && (
+          <PolicyEditForm
+            policy={policy}
+            workspaceId={workspaceId}
+            packId={packId}
+            versionId={versionId}
+            onClose={onClose}
+          />
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/frontend/src/features/update-policy/ui/PolicyEditSheet.tsx
+++ b/frontend/src/features/update-policy/ui/PolicyEditSheet.tsx
@@ -1,10 +1,4 @@
-import {
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-  SheetDescription,
-} from "@/shared/ui/sheet";
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetDescription } from "@/shared/ui/sheet";
 import { Spinner } from "@/shared/ui/spinner";
 import { Button } from "@/shared/ui/button";
 import { useGetPolicy } from "../api/useGetPolicy";
@@ -27,8 +21,13 @@ export function PolicyEditSheet({
   policyId,
   isOpen,
   onClose,
-}: PolicyEditSheetProps) {
-  const { data: policy, isLoading, isError, refetch } = useGetPolicy({
+}: Readonly<PolicyEditSheetProps>) {
+  const {
+    data: policy,
+    isLoading,
+    isError,
+    refetch,
+  } = useGetPolicy({
     workspaceId,
     packId,
     versionId,
@@ -45,9 +44,7 @@ export function PolicyEditSheet({
     >
       <SheetContent side="right" className="w-full overflow-y-auto sm:max-w-xl">
         <SheetHeader className="px-4 pt-4">
-          <SheetTitle>
-            {policy ? `${policy.policyCode} · ${policy.name}` : "정책 수정"}
-          </SheetTitle>
+          <SheetTitle>{policy ? `${policy.policyCode} · ${policy.name}` : "정책 수정"}</SheetTitle>
           <SheetDescription>정책 필드와 상태를 수정합니다.</SheetDescription>
         </SheetHeader>
 

--- a/frontend/src/features/update-policy/ui/PolicyJsonFields.tsx
+++ b/frontend/src/features/update-policy/ui/PolicyJsonFields.tsx
@@ -3,66 +3,42 @@ import { FormField, FormItem, FormLabel, FormControl, FormMessage } from "@/shar
 import { JsonTextarea } from "./JsonTextarea";
 import type { PolicyEditFormValues } from "../model/schema";
 
+const JSON_FIELDS: ReadonlyArray<
+  Readonly<{
+    name: keyof Pick<
+      PolicyEditFormValues,
+      "conditionJson" | "actionJson" | "evidenceJson" | "metaJson"
+    >;
+    label: string;
+  }>
+> = [
+  { name: "conditionJson", label: "조건 JSON" },
+  { name: "actionJson", label: "액션 JSON" },
+  { name: "evidenceJson", label: "근거 JSON" },
+  { name: "metaJson", label: "메타 JSON" },
+];
+
 export function PolicyJsonFields() {
   const { control } = useFormContext<PolicyEditFormValues>();
 
   return (
     <>
-      <FormField
-        control={control}
-        name="conditionJson"
-        render={({ field }) => (
-          <FormItem>
-            <FormLabel>조건 JSON</FormLabel>
-            <FormControl>
-              <JsonTextarea {...field} aria-label="조건 JSON" />
-            </FormControl>
-            <FormMessage />
-          </FormItem>
-        )}
-      />
-
-      <FormField
-        control={control}
-        name="actionJson"
-        render={({ field }) => (
-          <FormItem>
-            <FormLabel>액션 JSON</FormLabel>
-            <FormControl>
-              <JsonTextarea {...field} aria-label="액션 JSON" />
-            </FormControl>
-            <FormMessage />
-          </FormItem>
-        )}
-      />
-
-      <FormField
-        control={control}
-        name="evidenceJson"
-        render={({ field }) => (
-          <FormItem>
-            <FormLabel>근거 JSON</FormLabel>
-            <FormControl>
-              <JsonTextarea {...field} aria-label="근거 JSON" />
-            </FormControl>
-            <FormMessage />
-          </FormItem>
-        )}
-      />
-
-      <FormField
-        control={control}
-        name="metaJson"
-        render={({ field }) => (
-          <FormItem>
-            <FormLabel>메타 JSON</FormLabel>
-            <FormControl>
-              <JsonTextarea {...field} aria-label="메타 JSON" />
-            </FormControl>
-            <FormMessage />
-          </FormItem>
-        )}
-      />
+      {JSON_FIELDS.map((jsonField) => (
+        <FormField
+          key={jsonField.name}
+          control={control}
+          name={jsonField.name}
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>{jsonField.label}</FormLabel>
+              <FormControl>
+                <JsonTextarea {...field} aria-label={jsonField.label} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      ))}
     </>
   );
 }

--- a/frontend/src/features/update-policy/ui/PolicyJsonFields.tsx
+++ b/frontend/src/features/update-policy/ui/PolicyJsonFields.tsx
@@ -1,0 +1,68 @@
+import { useFormContext } from "react-hook-form";
+import { FormField, FormItem, FormLabel, FormControl, FormMessage } from "@/shared/ui/form";
+import { JsonTextarea } from "./JsonTextarea";
+import type { PolicyEditFormValues } from "../model/schema";
+
+export function PolicyJsonFields() {
+  const { control } = useFormContext<PolicyEditFormValues>();
+
+  return (
+    <>
+      <FormField
+        control={control}
+        name="conditionJson"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>조건 JSON</FormLabel>
+            <FormControl>
+              <JsonTextarea {...field} aria-label="조건 JSON" />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      <FormField
+        control={control}
+        name="actionJson"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>액션 JSON</FormLabel>
+            <FormControl>
+              <JsonTextarea {...field} aria-label="액션 JSON" />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      <FormField
+        control={control}
+        name="evidenceJson"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>근거 JSON</FormLabel>
+            <FormControl>
+              <JsonTextarea {...field} aria-label="근거 JSON" />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      <FormField
+        control={control}
+        name="metaJson"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>메타 JSON</FormLabel>
+            <FormControl>
+              <JsonTextarea {...field} aria-label="메타 JSON" />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+    </>
+  );
+}

--- a/frontend/src/features/update-policy/ui/PolicyStatusToggle.test.tsx
+++ b/frontend/src/features/update-policy/ui/PolicyStatusToggle.test.tsx
@@ -1,0 +1,57 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useUpdatePolicyStatus } from "../api/useUpdatePolicyStatus";
+import { PolicyStatusToggle } from "./PolicyStatusToggle";
+
+vi.mock("../api/useUpdatePolicyStatus", () => ({
+  useUpdatePolicyStatus: vi.fn(),
+}));
+
+const mutate = vi.fn();
+const mockedUseUpdatePolicyStatus = vi.mocked(useUpdatePolicyStatus);
+
+describe("PolicyStatusToggle", () => {
+  beforeEach(() => {
+    mutate.mockReset();
+    mockedUseUpdatePolicyStatus.mockReturnValue({
+      mutate,
+      isPending: false,
+    } as unknown as ReturnType<typeof useUpdatePolicyStatus>);
+  });
+
+  it("ACTIVE 상태를 checked switch로 표시한다", () => {
+    render(
+      <PolicyStatusToggle
+        workspaceId={1}
+        packId={2}
+        versionId={3}
+        policyId={4}
+        currentStatus="ACTIVE"
+      />,
+    );
+
+    expect(screen.getByRole("switch", { name: "정책 상태" })).toBeChecked();
+  });
+
+  it("상태 변경 시 update mutation을 호출한다", () => {
+    render(
+      <PolicyStatusToggle
+        workspaceId={1}
+        packId={2}
+        versionId={3}
+        policyId={4}
+        currentStatus="INACTIVE"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("switch", { name: "정책 상태" }));
+
+    expect(mutate).toHaveBeenCalledWith({
+      workspaceId: 1,
+      packId: 2,
+      versionId: 3,
+      policyId: 4,
+      status: "ACTIVE",
+    });
+  });
+});

--- a/frontend/src/features/update-policy/ui/PolicyStatusToggle.tsx
+++ b/frontend/src/features/update-policy/ui/PolicyStatusToggle.tsx
@@ -18,7 +18,7 @@ export function PolicyStatusToggle({
   policyId,
   currentStatus,
   disabled,
-}: PolicyStatusToggleProps) {
+}: Readonly<PolicyStatusToggleProps>) {
   const { mutate, isPending } = useUpdatePolicyStatus();
 
   const handleCheckedChange = (checked: boolean) => {

--- a/frontend/src/features/update-policy/ui/PolicyStatusToggle.tsx
+++ b/frontend/src/features/update-policy/ui/PolicyStatusToggle.tsx
@@ -1,0 +1,42 @@
+import { Switch } from "@/shared/ui/switch";
+import { useUpdatePolicyStatus } from "../api/useUpdatePolicyStatus";
+import type { PolicyStatus } from "@/entities/policy";
+
+interface PolicyStatusToggleProps {
+  workspaceId: number;
+  packId: number;
+  versionId: number;
+  policyId: number;
+  currentStatus: PolicyStatus;
+  disabled?: boolean;
+}
+
+export function PolicyStatusToggle({
+  workspaceId,
+  packId,
+  versionId,
+  policyId,
+  currentStatus,
+  disabled,
+}: PolicyStatusToggleProps) {
+  const { mutate, isPending } = useUpdatePolicyStatus();
+
+  const handleCheckedChange = (checked: boolean) => {
+    mutate({
+      workspaceId,
+      packId,
+      versionId,
+      policyId,
+      status: checked ? "ACTIVE" : "INACTIVE",
+    });
+  };
+
+  return (
+    <Switch
+      aria-label="정책 상태"
+      checked={currentStatus === "ACTIVE"}
+      onCheckedChange={handleCheckedChange}
+      disabled={disabled || isPending}
+    />
+  );
+}

--- a/frontend/src/features/update-policy/ui/policy-edit-panel.module.css
+++ b/frontend/src/features/update-policy/ui/policy-edit-panel.module.css
@@ -1,0 +1,135 @@
+.panel {
+  flex: 1;
+  width: 100%;
+  min-width: 0;
+  background: var(--bg-color);
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+}
+
+.header {
+  padding: 24px 28px 22px;
+  border-bottom: 1px solid var(--glass-border);
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 18px;
+}
+
+.headerText {
+  min-width: 0;
+  display: grid;
+  gap: 10px;
+}
+
+.eyebrow {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1;
+  letter-spacing: 0.54px;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.title {
+  margin: 0;
+  font-size: 24px;
+  font-weight: 540;
+  line-height: 1.16;
+  letter-spacing: -0.26px;
+  color: var(--text-primary);
+  overflow-wrap: anywhere;
+}
+
+.description {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 330;
+  line-height: 1.45;
+  letter-spacing: -0.14px;
+  color: var(--text-secondary);
+}
+
+.closeButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  min-height: 36px;
+  padding: 8px 16px 9px;
+  border: 1px solid var(--text-primary);
+  border-radius: var(--radius-xl);
+  background: var(--bg-color);
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 450;
+  letter-spacing: -0.14px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.closeButton svg {
+  width: 14px;
+  height: 14px;
+}
+
+.body {
+  width: 100%;
+  padding: 24px 28px 28px;
+}
+
+.statePanel {
+  min-height: 240px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  margin: 24px 28px;
+  padding: 40px 32px;
+  border: 1px dashed var(--hover-border);
+  border-radius: var(--radius-lg);
+  color: var(--text-secondary);
+  font-size: 14px;
+  line-height: 1.5;
+  letter-spacing: -0.14px;
+  text-align: center;
+}
+
+.spinner {
+  width: 24px;
+  height: 24px;
+}
+
+@media (max-width: 1100px) {
+  .header {
+    flex-direction: column;
+  }
+
+  .closeButton {
+    align-self: flex-start;
+  }
+}
+
+@media (max-width: 767px) {
+  .panel {
+    border-top: 1px solid var(--glass-border);
+  }
+
+  .header {
+    padding: 20px 16px 18px;
+  }
+
+  .title {
+    font-size: 22px;
+  }
+
+  .body {
+    padding: 20px 16px 24px;
+  }
+
+  .statePanel {
+    margin: 20px 16px;
+  }
+}

--- a/frontend/src/features/workspace/ui/WorkspaceCard.test.tsx
+++ b/frontend/src/features/workspace/ui/WorkspaceCard.test.tsx
@@ -22,6 +22,8 @@ describe("WorkspaceCard", () => {
       <WorkspaceCard
         workspace={baseWorkspace}
         onOpen={vi.fn()}
+        onOpenPolicyDraft={vi.fn()}
+        isPolicyDraftLoading={false}
         onEdit={vi.fn()}
         onDelete={vi.fn()}
       />,
@@ -39,6 +41,8 @@ describe("WorkspaceCard", () => {
           myRole: "UNEXPECTED_ROLE" as unknown as WorkspaceResponse["myRole"],
         }}
         onOpen={vi.fn()}
+        onOpenPolicyDraft={vi.fn()}
+        isPolicyDraftLoading={false}
         onEdit={vi.fn()}
         onDelete={vi.fn()}
       />,
@@ -54,6 +58,8 @@ describe("WorkspaceCard", () => {
       <WorkspaceCard
         workspace={baseWorkspace}
         onOpen={onOpen}
+        onOpenPolicyDraft={vi.fn()}
+        isPolicyDraftLoading={false}
         onEdit={vi.fn()}
         onDelete={vi.fn()}
       />,
@@ -67,5 +73,38 @@ describe("WorkspaceCard", () => {
         name: "CS Team Alpha",
       }),
     );
+  });
+
+  it("invokes onOpenPolicyDraft with the workspace when the policy edit button is clicked", () => {
+    const onOpenPolicyDraft = vi.fn();
+    render(
+      <WorkspaceCard
+        workspace={baseWorkspace}
+        onOpen={vi.fn()}
+        onOpenPolicyDraft={onOpenPolicyDraft}
+        isPolicyDraftLoading={false}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Policy 편집/ }));
+
+    expect(onOpenPolicyDraft).toHaveBeenCalledWith(baseWorkspace);
+  });
+
+  it("disables the policy edit button while draft entry navigation is loading", () => {
+    render(
+      <WorkspaceCard
+        workspace={baseWorkspace}
+        onOpen={vi.fn()}
+        onOpenPolicyDraft={vi.fn()}
+        isPolicyDraftLoading
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /이동 중/ })).toBeDisabled();
   });
 });

--- a/frontend/src/features/workspace/ui/WorkspaceCard.test.tsx
+++ b/frontend/src/features/workspace/ui/WorkspaceCard.test.tsx
@@ -24,6 +24,7 @@ describe("WorkspaceCard", () => {
         onOpen={vi.fn()}
         onOpenPolicyDraft={vi.fn()}
         isPolicyDraftLoading={false}
+        isPolicyDraftDisabled={false}
         onEdit={vi.fn()}
         onDelete={vi.fn()}
       />,
@@ -43,6 +44,7 @@ describe("WorkspaceCard", () => {
         onOpen={vi.fn()}
         onOpenPolicyDraft={vi.fn()}
         isPolicyDraftLoading={false}
+        isPolicyDraftDisabled={false}
         onEdit={vi.fn()}
         onDelete={vi.fn()}
       />,
@@ -60,6 +62,7 @@ describe("WorkspaceCard", () => {
         onOpen={onOpen}
         onOpenPolicyDraft={vi.fn()}
         isPolicyDraftLoading={false}
+        isPolicyDraftDisabled={false}
         onEdit={vi.fn()}
         onDelete={vi.fn()}
       />,
@@ -83,6 +86,7 @@ describe("WorkspaceCard", () => {
         onOpen={vi.fn()}
         onOpenPolicyDraft={onOpenPolicyDraft}
         isPolicyDraftLoading={false}
+        isPolicyDraftDisabled={false}
         onEdit={vi.fn()}
         onDelete={vi.fn()}
       />,
@@ -100,6 +104,7 @@ describe("WorkspaceCard", () => {
         onOpen={vi.fn()}
         onOpenPolicyDraft={vi.fn()}
         isPolicyDraftLoading
+        isPolicyDraftDisabled={false}
         onEdit={vi.fn()}
         onDelete={vi.fn()}
       />,

--- a/frontend/src/features/workspace/ui/WorkspaceCard.tsx
+++ b/frontend/src/features/workspace/ui/WorkspaceCard.tsx
@@ -12,6 +12,7 @@ interface WorkspaceCardProps {
   onOpen: (workspace: WorkspaceResponse) => void;
   onOpenPolicyDraft: (workspace: WorkspaceResponse) => void;
   isPolicyDraftLoading: boolean;
+  isPolicyDraftDisabled: boolean;
   onEdit: (workspace: WorkspaceResponse) => void;
   onDelete: (workspace: WorkspaceResponse) => void;
 }
@@ -23,6 +24,7 @@ export function WorkspaceCard({
   onOpen,
   onOpenPolicyDraft,
   isPolicyDraftLoading,
+  isPolicyDraftDisabled,
   onEdit,
   onDelete,
 }: WorkspaceCardProps) {
@@ -55,7 +57,7 @@ export function WorkspaceCard({
             variant="outline"
             className={styles.policyButton}
             onClick={handleOpenPolicyDraft}
-            disabled={isPolicyDraftLoading}
+            disabled={isPolicyDraftLoading || isPolicyDraftDisabled}
             aria-busy={isPolicyDraftLoading}
           >
             {isPolicyDraftLoading ? <Spinner className="size-4" /> : <FilePenLineIcon className="size-4" />}

--- a/frontend/src/features/workspace/ui/WorkspaceCard.tsx
+++ b/frontend/src/features/workspace/ui/WorkspaceCard.tsx
@@ -1,14 +1,17 @@
-import { ArrowRightIcon, PencilIcon, Trash2Icon } from "lucide-react";
+import { ArrowRightIcon, FilePenLineIcon, PencilIcon, Trash2Icon } from "lucide-react";
 
 import { normalizeWorkspaceMemberRole, type WorkspaceResponse } from "@/entities/workspace";
 import { Button } from "@/shared/ui/button";
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/shared/ui/card";
+import { Spinner } from "@/shared/ui/spinner";
 
 import styles from "./workspace-list.module.css";
 
 interface WorkspaceCardProps {
   workspace: WorkspaceResponse;
   onOpen: (workspace: WorkspaceResponse) => void;
+  onOpenPolicyDraft: (workspace: WorkspaceResponse) => void;
+  isPolicyDraftLoading: boolean;
   onEdit: (workspace: WorkspaceResponse) => void;
   onDelete: (workspace: WorkspaceResponse) => void;
 }
@@ -18,10 +21,13 @@ const EDITABLE_ROLES = new Set(["OWNER", "ADMIN"]);
 export function WorkspaceCard({
   workspace,
   onOpen,
+  onOpenPolicyDraft,
+  isPolicyDraftLoading,
   onEdit,
   onDelete,
 }: WorkspaceCardProps) {
   const handleOpen = () => onOpen(workspace);
+  const handleOpenPolicyDraft = () => onOpenPolicyDraft(workspace);
 
   const normalizedRole = normalizeWorkspaceMemberRole(workspace.myRole);
   const canEdit = normalizedRole !== null && EDITABLE_ROLES.has(normalizedRole);
@@ -40,10 +46,22 @@ export function WorkspaceCard({
       </CardHeader>
       <CardContent className={styles.workspaceCardContent} />
       <CardFooter className={styles.workspaceCardFooter}>
-        <Button variant="ghost" className={styles.openButton} onClick={handleOpen}>
-          Open Workspace
-          <ArrowRightIcon className="size-4" />
-        </Button>
+        <div className={styles.primaryActions}>
+          <Button variant="ghost" className={styles.openButton} onClick={handleOpen}>
+            Open Workspace
+            <ArrowRightIcon className="size-4" />
+          </Button>
+          <Button
+            variant="outline"
+            className={styles.policyButton}
+            onClick={handleOpenPolicyDraft}
+            disabled={isPolicyDraftLoading}
+            aria-busy={isPolicyDraftLoading}
+          >
+            {isPolicyDraftLoading ? <Spinner className="size-4" /> : <FilePenLineIcon className="size-4" />}
+            {isPolicyDraftLoading ? "이동 중" : "Policy 편집"}
+          </Button>
+        </div>
         <div className={styles.cardActions}>
           {canEdit && (
             <Button variant="outline" size="sm" className={styles.actionButton} onClick={() => onEdit(workspace)}>

--- a/frontend/src/features/workspace/ui/WorkspaceList.test.tsx
+++ b/frontend/src/features/workspace/ui/WorkspaceList.test.tsx
@@ -24,6 +24,8 @@ describe("WorkspaceList", () => {
         onRetry={vi.fn()}
         onCreate={vi.fn()}
         onOpen={vi.fn()}
+        onOpenPolicyDraft={vi.fn()}
+        policyDraftLoadingWorkspaceId={null}
         onEdit={vi.fn()}
         onDelete={vi.fn()}
       />,
@@ -42,6 +44,8 @@ describe("WorkspaceList", () => {
         onRetry={onRetry}
         onCreate={vi.fn()}
         onOpen={vi.fn()}
+        onOpenPolicyDraft={vi.fn()}
+        policyDraftLoadingWorkspaceId={null}
         onEdit={vi.fn()}
         onDelete={vi.fn()}
       />,
@@ -63,6 +67,8 @@ describe("WorkspaceList", () => {
         onRetry={vi.fn()}
         onCreate={onCreate}
         onOpen={vi.fn()}
+        onOpenPolicyDraft={vi.fn()}
+        policyDraftLoadingWorkspaceId={null}
         onEdit={vi.fn()}
         onDelete={vi.fn()}
       />,
@@ -84,6 +90,8 @@ describe("WorkspaceList", () => {
         onRetry={vi.fn()}
         onCreate={vi.fn()}
         onOpen={onOpen}
+        onOpenPolicyDraft={vi.fn()}
+        policyDraftLoadingWorkspaceId={null}
         onEdit={vi.fn()}
         onDelete={vi.fn()}
       />,
@@ -93,5 +101,27 @@ describe("WorkspaceList", () => {
 
     expect(screen.getByText("CS Team Alpha")).toBeInTheDocument();
     expect(onOpen).toHaveBeenCalledWith(activeWorkspace);
+  });
+
+  it("opens policy draft editing for a selected workspace", () => {
+    const onOpenPolicyDraft = vi.fn();
+    render(
+      <WorkspaceList
+        workspaces={[activeWorkspace]}
+        isLoading={false}
+        error=""
+        onRetry={vi.fn()}
+        onCreate={vi.fn()}
+        onOpen={vi.fn()}
+        onOpenPolicyDraft={onOpenPolicyDraft}
+        policyDraftLoadingWorkspaceId={null}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Policy 편집/ }));
+
+    expect(onOpenPolicyDraft).toHaveBeenCalledWith(activeWorkspace);
   });
 });

--- a/frontend/src/features/workspace/ui/WorkspaceList.tsx
+++ b/frontend/src/features/workspace/ui/WorkspaceList.tsx
@@ -15,6 +15,8 @@ interface WorkspaceListProps {
   onRetry: () => void;
   onCreate: () => void;
   onOpen: (workspace: WorkspaceResponse) => void;
+  onOpenPolicyDraft: (workspace: WorkspaceResponse) => void;
+  policyDraftLoadingWorkspaceId: number | null;
   onEdit: (workspace: WorkspaceResponse) => void;
   onDelete: (workspace: WorkspaceResponse) => void;
 }
@@ -26,6 +28,8 @@ export function WorkspaceList({
   onRetry,
   onCreate,
   onOpen,
+  onOpenPolicyDraft,
+  policyDraftLoadingWorkspaceId,
   onEdit,
   onDelete,
 }: WorkspaceListProps) {
@@ -77,6 +81,8 @@ export function WorkspaceList({
           key={workspace.id}
           workspace={workspace}
           onOpen={onOpen}
+          onOpenPolicyDraft={onOpenPolicyDraft}
+          isPolicyDraftLoading={policyDraftLoadingWorkspaceId === workspace.id}
           onEdit={onEdit}
           onDelete={onDelete}
         />

--- a/frontend/src/features/workspace/ui/WorkspaceList.tsx
+++ b/frontend/src/features/workspace/ui/WorkspaceList.tsx
@@ -33,6 +33,8 @@ export function WorkspaceList({
   onEdit,
   onDelete,
 }: WorkspaceListProps) {
+  const isPolicyDraftDisabled = policyDraftLoadingWorkspaceId !== null;
+
   if (isLoading) {
     return (
       <div className={styles.statePanel} aria-live="polite">
@@ -83,6 +85,7 @@ export function WorkspaceList({
           onOpen={onOpen}
           onOpenPolicyDraft={onOpenPolicyDraft}
           isPolicyDraftLoading={policyDraftLoadingWorkspaceId === workspace.id}
+          isPolicyDraftDisabled={isPolicyDraftDisabled}
           onEdit={onEdit}
           onDelete={onDelete}
         />

--- a/frontend/src/features/workspace/ui/workspace-list.module.css
+++ b/frontend/src/features/workspace/ui/workspace-list.module.css
@@ -1,7 +1,9 @@
 .workspaceGrid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(min(100%, 320px), 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 320px), min(100%, 420px)));
   justify-content: flex-start;
+  min-width: 0;
+  width: 100%;
   gap: 32px;
   padding: 12px 6px 24px;
 }
@@ -14,7 +16,7 @@
   gap: 0;
   width: 100%;
   max-width: 420px;
-  min-height: 400px;
+  min-height: 360px;
   padding-block: 0;
   border-radius: var(--radius-lg);
   border: 1px solid var(--glass-border);
@@ -60,6 +62,7 @@
   line-height: 0.98;
   letter-spacing: -0.95px;
   text-wrap: balance;
+  overflow-wrap: anywhere;
 }
 
 .workspaceCard .workspaceCardContent {
@@ -82,14 +85,25 @@
 }
 
 .workspaceCard .workspaceCardFooter {
-  justify-content: space-between;
-  align-items: center;
-  gap: 16px;
+  flex-direction: column;
+  justify-content: flex-end;
+  align-items: stretch;
+  gap: 14px;
   margin-top: auto;
   padding: 20px 34px 30px;
 }
 
+.primaryActions {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 10px;
+  width: 100%;
+  min-width: 0;
+}
+
 .openButton {
+  width: 100%;
+  min-width: 0;
   min-height: 46px;
   padding: 0 20px;
   border-radius: 999px;
@@ -108,6 +122,22 @@
 
 .workspaceCard:hover .openButton {
   transform: translateX(2px);
+}
+
+.policyButton {
+  width: 100%;
+  min-width: 0;
+  min-height: 46px;
+  padding: 0 18px;
+  border-radius: 999px;
+  border-color: rgba(0, 0, 0, 0.14);
+  background: rgba(255, 255, 255, 0.92);
+  color: var(--text-primary);
+  font-size: 0.92rem;
+}
+
+.policyButton:hover {
+  background: rgba(0, 0, 0, 0.06);
 }
 
 .cardActions {
@@ -172,6 +202,29 @@
   border: 1px dashed var(--glass-border);
 }
 
+@media (max-width: 960px) {
+  .workspaceGrid {
+    gap: 24px;
+    padding-top: 8px;
+  }
+
+  .workspaceCard {
+    min-height: 320px;
+  }
+
+  .workspaceCard .workspaceCardHeader {
+    padding: 28px 28px 0;
+  }
+
+  .workspaceCard .workspaceCardContent {
+    padding: 0 28px;
+  }
+
+  .workspaceCard .workspaceCardFooter {
+    padding: 18px 28px 24px;
+  }
+}
+
 @media (max-width: 768px) {
   .workspaceGrid {
     grid-template-columns: 1fr;
@@ -181,7 +234,7 @@
   .workspaceCard {
     width: 100%;
     height: auto;
-    min-height: 360px;
+    min-height: 340px;
     max-height: none;
   }
 
@@ -190,7 +243,30 @@
     align-items: stretch;
   }
 
+  .primaryActions {
+    grid-template-columns: 1fr;
+  }
+
   .cardActions {
     justify-content: flex-start;
+  }
+}
+
+@media (max-width: 560px) {
+  .workspaceGrid {
+    gap: 20px;
+    padding-inline: 0;
+  }
+
+  .workspaceCard .workspaceCardHeader {
+    padding: 28px 28px 0;
+  }
+
+  .workspaceCard .workspaceCardContent {
+    padding: 0 28px;
+  }
+
+  .workspaceCard .workspaceCardFooter {
+    padding: 18px 28px 26px;
   }
 }

--- a/frontend/src/features/workspace/ui/workspace-list.module.css
+++ b/frontend/src/features/workspace/ui/workspace-list.module.css
@@ -258,15 +258,7 @@
     padding-inline: 0;
   }
 
-  .workspaceCard .workspaceCardHeader {
-    padding: 28px 28px 0;
-  }
-
-  .workspaceCard .workspaceCardContent {
-    padding: 0 28px;
-  }
-
   .workspaceCard .workspaceCardFooter {
-    padding: 18px 28px 26px;
+    padding-bottom: 26px;
   }
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -46,6 +46,25 @@
 }
 
 @theme inline {
+  --color-background: hsl(var(--background));
+  --color-foreground: hsl(var(--foreground));
+  --color-card: hsl(var(--card));
+  --color-card-foreground: hsl(var(--card-foreground));
+  --color-popover: hsl(var(--popover));
+  --color-popover-foreground: hsl(var(--popover-foreground));
+  --color-primary: hsl(var(--primary));
+  --color-primary-foreground: hsl(var(--primary-foreground));
+  --color-secondary: hsl(var(--secondary));
+  --color-secondary-foreground: hsl(var(--secondary-foreground));
+  --color-muted: hsl(var(--muted));
+  --color-muted-foreground: hsl(var(--muted-foreground));
+  --color-accent: hsl(var(--accent));
+  --color-accent-foreground: hsl(var(--accent-foreground));
+  --color-destructive: hsl(var(--destructive));
+  --color-destructive-foreground: hsl(var(--destructive-foreground));
+  --color-border: hsl(var(--border));
+  --color-input: hsl(var(--input));
+  --color-ring: hsl(var(--ring));
   --color-sidebar: var(--sidebar);
   --color-sidebar-foreground: var(--sidebar-foreground);
   --color-sidebar-primary: var(--sidebar-primary);

--- a/frontend/src/pages/domain-pack/ui/PolicyDraftReadPage.test.tsx
+++ b/frontend/src/pages/domain-pack/ui/PolicyDraftReadPage.test.tsx
@@ -13,7 +13,7 @@ vi.mock("react-router-dom", async () => {
   };
 });
 
-vi.mock("../../../features/policy-draft-read/ui", () => ({
+vi.mock("@/features/policy-draft-read/ui", () => ({
   PolicyListPanel: ({ onSelect }: { onSelect: (id: number) => void }) => (
     <button type="button" onClick={() => onSelect(4)}>
       select policy
@@ -26,7 +26,7 @@ vi.mock("../../../features/policy-draft-read/ui", () => ({
   ),
 }));
 
-vi.mock("../../../features/update-policy", () => ({
+vi.mock("@/features/update-policy", () => ({
   PolicyEditPanel: ({ onClose }: { onClose: () => void }) => (
     <button type="button" onClick={onClose}>
       close editor

--- a/frontend/src/pages/domain-pack/ui/PolicyDraftReadPage.test.tsx
+++ b/frontend/src/pages/domain-pack/ui/PolicyDraftReadPage.test.tsx
@@ -1,0 +1,67 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+import { PolicyDraftReadPage } from "./PolicyDraftReadPage";
+
+const navigate = vi.fn();
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => navigate,
+  };
+});
+
+vi.mock("../../../features/policy-draft-read/ui", () => ({
+  PolicyListPanel: ({ onSelect }: { onSelect: (id: number) => void }) => (
+    <button type="button" onClick={() => onSelect(4)}>
+      select policy
+    </button>
+  ),
+  PolicyDetailPanel: ({ onEdit }: { onEdit: (id: number) => void }) => (
+    <button type="button" onClick={() => onEdit(4)}>
+      edit policy
+    </button>
+  ),
+}));
+
+vi.mock("../../../features/update-policy", () => ({
+  PolicyEditPanel: ({ onClose }: { onClose: () => void }) => (
+    <button type="button" onClick={onClose}>
+      close editor
+    </button>
+  ),
+}));
+
+function renderPage(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route
+          path="/workspaces/:workspaceId/domain-packs/:packId/versions/:versionId/policies/:policyId?"
+          element={<PolicyDraftReadPage />}
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("PolicyDraftReadPage", () => {
+  it("정책 선택과 수정 화면 전환을 처리한다", () => {
+    navigate.mockReset();
+    renderPage("/workspaces/1/domain-packs/7/versions/101/policies");
+
+    fireEvent.click(screen.getByRole("button", { name: "select policy" }));
+    fireEvent.click(screen.getByRole("button", { name: "edit policy" }));
+
+    expect(navigate).toHaveBeenCalledWith("/workspaces/1/domain-packs/7/versions/101/policies/4");
+    expect(screen.getByRole("button", { name: "close editor" })).toBeInTheDocument();
+  });
+
+  it("잘못된 URL 파라미터면 alert를 표시한다", () => {
+    renderPage("/workspaces/abc/domain-packs/7/versions/101/policies");
+
+    expect(screen.getByRole("alert")).toHaveTextContent("잘못된 URL 파라미터입니다.");
+  });
+});

--- a/frontend/src/pages/domain-pack/ui/PolicyDraftReadPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/PolicyDraftReadPage.tsx
@@ -1,0 +1,100 @@
+import { useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { PolicyDetailPanel, PolicyListPanel } from "../../../features/policy-draft-read/ui";
+import { PolicyEditPanel } from "../../../features/update-policy";
+import { parseRouteId } from "../../../shared/lib/parseRouteId";
+import { DashboardLayout } from "../../../shared/ui/layout/DashboardLayout";
+import styles from "./policy-draft-read-page.module.css";
+
+export function PolicyDraftReadPage() {
+  const { workspaceId, packId, versionId, policyId } = useParams();
+  const navigate = useNavigate();
+  const [editingPolicyId, setEditingPolicyId] = useState<number | null>(null);
+
+  const wsId = parseRouteId(workspaceId);
+  const pId = parseRouteId(packId);
+  const vId = parseRouteId(versionId);
+  const selectedPolicyId = policyId ? parseRouteId(policyId) : null;
+
+  if (
+    wsId === null ||
+    pId === null ||
+    vId === null ||
+    (policyId !== undefined && selectedPolicyId === null)
+  ) {
+    return (
+      <DashboardLayout>
+        <div className={styles.invalidParams} role="alert">
+          잘못된 URL 파라미터입니다.
+        </div>
+      </DashboardLayout>
+    );
+  }
+
+  const handleSelect = (id: number) => {
+    setEditingPolicyId(null);
+    navigate(`/workspaces/${wsId}/domain-packs/${pId}/versions/${vId}/policies/${id}`);
+  };
+
+  const handleBack = () => {
+    setEditingPolicyId(null);
+    navigate(`/workspaces/${wsId}/domain-packs/${pId}/versions/${vId}/policies`);
+  };
+
+  const hasSelection = selectedPolicyId !== null;
+
+  return (
+    <DashboardLayout>
+      <div className={styles.pageWrapper}>
+        <header className={styles.pageHeader}>
+          <nav className={styles.breadcrumb} aria-label="경로">
+            <span>WS · {wsId}</span>
+            <span className={styles.breadcrumbSeparator}>/</span>
+            <span>PACK · {pId}</span>
+            <span className={styles.breadcrumbSeparator}>/</span>
+            <span>VER · {vId}</span>
+          </nav>
+          <div className={styles.versionMeta}>
+            <span className={styles.versionTitle}>Policy 초안 편집</span>
+            <span className={styles.versionBadge}>READ / EDIT</span>
+          </div>
+        </header>
+        {hasSelection && (
+          <button type="button" className={styles.backButton} onClick={handleBack}>
+            ← 목록
+          </button>
+        )}
+        <div className={`${styles.twoPane} ${hasSelection ? styles.hasSelection : ""}`}>
+          <div className={styles.listSlot}>
+            <PolicyListPanel
+              workspaceId={wsId}
+              packId={pId}
+              versionId={vId}
+              selectedId={selectedPolicyId}
+              onSelect={handleSelect}
+            />
+          </div>
+          <div className={styles.detailSlot}>
+            {editingPolicyId !== null ? (
+              <PolicyEditPanel
+                workspaceId={wsId}
+                packId={pId}
+                versionId={vId}
+                policyId={editingPolicyId}
+                onClose={() => setEditingPolicyId(null)}
+              />
+            ) : (
+              <PolicyDetailPanel
+                workspaceId={wsId}
+                packId={pId}
+                versionId={vId}
+                policyId={selectedPolicyId}
+                onEdit={setEditingPolicyId}
+              />
+            )}
+          </div>
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/frontend/src/pages/domain-pack/ui/PolicyDraftReadPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/PolicyDraftReadPage.tsx
@@ -15,13 +15,9 @@ export function PolicyDraftReadPage() {
   const pId = parseRouteId(packId);
   const vId = parseRouteId(versionId);
   const selectedPolicyId = policyId ? parseRouteId(policyId) : null;
+  const hasInvalidPolicyId = policyId !== undefined && selectedPolicyId === null;
 
-  if (
-    wsId === null ||
-    pId === null ||
-    vId === null ||
-    (policyId !== undefined && selectedPolicyId === null)
-  ) {
+  if (wsId === null || pId === null || vId === null || hasInvalidPolicyId) {
     return (
       <DashboardLayout>
         <div className={styles.invalidParams} role="alert">
@@ -75,21 +71,21 @@ export function PolicyDraftReadPage() {
             />
           </div>
           <div className={styles.detailSlot}>
-            {editingPolicyId !== null ? (
-              <PolicyEditPanel
-                workspaceId={wsId}
-                packId={pId}
-                versionId={vId}
-                policyId={editingPolicyId}
-                onClose={() => setEditingPolicyId(null)}
-              />
-            ) : (
+            {editingPolicyId === null ? (
               <PolicyDetailPanel
                 workspaceId={wsId}
                 packId={pId}
                 versionId={vId}
                 policyId={selectedPolicyId}
                 onEdit={setEditingPolicyId}
+              />
+            ) : (
+              <PolicyEditPanel
+                workspaceId={wsId}
+                packId={pId}
+                versionId={vId}
+                policyId={editingPolicyId}
+                onClose={() => setEditingPolicyId(null)}
               />
             )}
           </div>

--- a/frontend/src/pages/domain-pack/ui/PolicyDraftReadPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/PolicyDraftReadPage.tsx
@@ -1,9 +1,9 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import { PolicyDetailPanel, PolicyListPanel } from "../../../features/policy-draft-read/ui";
-import { PolicyEditPanel } from "../../../features/update-policy";
-import { parseRouteId } from "../../../shared/lib/parseRouteId";
-import { DashboardLayout } from "../../../shared/ui/layout/DashboardLayout";
+import { PolicyDetailPanel, PolicyListPanel } from "@/features/policy-draft-read/ui";
+import { PolicyEditPanel } from "@/features/update-policy";
+import { parseRouteId } from "@/shared/lib/parseRouteId";
+import { DashboardLayout } from "@/shared/ui/layout/DashboardLayout";
 import styles from "./policy-draft-read-page.module.css";
 
 export function PolicyDraftReadPage() {
@@ -16,6 +16,10 @@ export function PolicyDraftReadPage() {
   const vId = parseRouteId(versionId);
   const selectedPolicyId = policyId ? parseRouteId(policyId) : null;
   const hasInvalidPolicyId = policyId !== undefined && selectedPolicyId === null;
+
+  useEffect(() => {
+    setEditingPolicyId(null);
+  }, [selectedPolicyId]);
 
   if (wsId === null || pId === null || vId === null || hasInvalidPolicyId) {
     return (

--- a/frontend/src/pages/domain-pack/ui/policy-draft-read-page.module.css
+++ b/frontend/src/pages/domain-pack/ui/policy-draft-read-page.module.css
@@ -1,0 +1,149 @@
+.pageWrapper {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: calc(100vh - var(--app-header-height));
+  height: calc(100dvh - var(--app-header-height));
+  overflow: hidden;
+  background: var(--bg-color);
+}
+
+.pageHeader {
+  padding: 20px 28px 18px;
+  border-bottom: 1px solid var(--glass-border);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  background: var(--bg-color);
+  flex-shrink: 0;
+}
+
+.breadcrumb {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1;
+  letter-spacing: 0.54px;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.breadcrumbSeparator {
+  color: var(--text-muted);
+}
+
+.versionMeta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+}
+
+.versionTitle {
+  font-family: var(--font-sans);
+  font-weight: 540;
+  font-size: 24px;
+  line-height: 1.1;
+  letter-spacing: -0.26px;
+  color: var(--text-primary);
+}
+
+.versionBadge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.54px;
+  text-transform: uppercase;
+  padding: 6px 12px 7px;
+  border-radius: var(--radius-xl);
+  background: var(--glass-dark);
+  border: 1px solid transparent;
+  color: var(--text-primary);
+}
+
+.twoPane {
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+  min-height: 0;
+  width: 100%;
+}
+
+.invalidParams {
+  padding: 32px;
+  color: var(--text-secondary);
+  font-size: 14px;
+  letter-spacing: -0.14px;
+}
+
+.listSlot,
+.detailSlot {
+  display: flex;
+  min-width: 0;
+  min-height: 0;
+}
+
+.listSlot {
+  flex: 0 0 auto;
+  align-self: stretch;
+}
+
+.detailSlot {
+  flex: 1;
+}
+
+@media (max-width: 1599px) {
+  .pageHeader {
+    padding: 16px 16px 14px;
+    gap: 10px;
+  }
+
+  .versionTitle {
+    font-size: 20px;
+  }
+
+  .twoPane {
+    flex-direction: column;
+  }
+
+  .twoPane.hasSelection .listSlot {
+    display: none;
+  }
+
+  .twoPane:not(.hasSelection) .listSlot {
+    flex: 1;
+    min-height: 0;
+  }
+
+  .twoPane:not(.hasSelection) .detailSlot {
+    display: none;
+  }
+
+  .backButton {
+    display: inline-flex;
+    align-self: flex-start;
+    margin: 12px 16px 0;
+    padding: 8px 16px 9px;
+    border-radius: var(--radius-xl);
+    border: 1px solid var(--text-primary);
+    background: var(--bg-color);
+    color: var(--text-primary);
+    font-family: var(--font-mono);
+    font-size: 11px;
+    letter-spacing: 0.54px;
+    text-transform: uppercase;
+    cursor: pointer;
+    flex-shrink: 0;
+  }
+}
+
+@media (min-width: 1600px) {
+  .backButton {
+    display: none;
+  }
+}

--- a/frontend/src/pages/workspace-list/ui/WorkspaceListPage.test.tsx
+++ b/frontend/src/pages/workspace-list/ui/WorkspaceListPage.test.tsx
@@ -1,0 +1,132 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { toast } from "sonner";
+import { domainPackApi } from "@/entities/domain-pack";
+import { workspaceApi } from "@/entities/workspace";
+import { ApiRequestError } from "@/shared/api";
+import { WorkspaceListPage } from "./WorkspaceListPage";
+import type { WorkspaceResponse } from "@/entities/workspace";
+
+const navigate = vi.fn();
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => navigate,
+  };
+});
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("@/entities/domain-pack", () => ({
+  domainPackApi: {
+    getDraftEntry: vi.fn(),
+  },
+}));
+
+vi.mock("@/entities/workspace", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/entities/workspace")>("@/entities/workspace");
+  return {
+    ...actual,
+    workspaceApi: {
+      list: vi.fn(),
+    },
+  };
+});
+
+vi.mock("@/features/workspace", () => ({
+  WorkspaceList: ({
+    onOpen,
+    onOpenPolicyDraft,
+    workspaces,
+  }: {
+    onOpen: (workspace: WorkspaceResponse) => void;
+    onOpenPolicyDraft: (workspace: WorkspaceResponse) => void;
+    workspaces: WorkspaceResponse[];
+  }) => (
+    <div>
+      <button type="button" onClick={() => onOpen(workspaces[0])}>
+        open workspace
+      </button>
+      <button type="button" onClick={() => onOpenPolicyDraft(workspaces[0])}>
+        open policy draft
+      </button>
+    </div>
+  ),
+  ArchiveConfirmDialog: () => null,
+  CreateWorkspaceDialog: () => null,
+  EditWorkspaceDialog: () => null,
+}));
+
+const activeWorkspace = {
+  id: 1,
+  workspaceKey: "cs-team",
+  name: "CS Team",
+  description: null,
+  status: "ACTIVE" as const,
+  myRole: "OWNER" as const,
+  createdAt: "",
+  updatedAt: "",
+};
+
+describe("WorkspaceListPage", () => {
+  beforeEach(() => {
+    navigate.mockReset();
+    vi.mocked(workspaceApi.list).mockReset();
+    vi.mocked(domainPackApi.getDraftEntry).mockReset();
+    vi.mocked(toast.error).mockReset();
+  });
+
+  it("워크스페이스와 정책 편집 진입 경로를 연결한다", async () => {
+    vi.mocked(workspaceApi.list).mockResolvedValue([activeWorkspace]);
+    vi.mocked(domainPackApi.getDraftEntry).mockResolvedValue({
+      workspaceId: 1,
+      packId: 7,
+      versionId: 101,
+      packName: "CS Pack",
+      versionNo: 2,
+    });
+
+    render(
+      <MemoryRouter>
+        <WorkspaceListPage />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(workspaceApi.list).toHaveBeenCalled());
+    fireEvent.click(screen.getByRole("button", { name: "open workspace" }));
+    fireEvent.click(screen.getByRole("button", { name: "open policy draft" }));
+
+    await waitFor(() =>
+      expect(navigate).toHaveBeenCalledWith("/workspaces/1/domain-packs/7/versions/101/policies"),
+    );
+    expect(navigate).toHaveBeenCalledWith("/workspaces/1/workflows");
+  });
+
+  it("정책 초안이 없으면 전용 toast를 표시한다", async () => {
+    vi.mocked(workspaceApi.list).mockResolvedValue([activeWorkspace]);
+    vi.mocked(domainPackApi.getDraftEntry).mockRejectedValue(
+      new ApiRequestError(404, "DOMAIN_PACK_DRAFT_ENTRY_NOT_FOUND", "없음"),
+    );
+
+    render(
+      <MemoryRouter>
+        <WorkspaceListPage />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(workspaceApi.list).toHaveBeenCalled());
+    fireEvent.click(screen.getByRole("button", { name: "open policy draft" }));
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith("수정 가능한 정책 초안이 없습니다."),
+    );
+  });
+});

--- a/frontend/src/pages/workspace-list/ui/WorkspaceListPage.test.tsx
+++ b/frontend/src/pages/workspace-list/ui/WorkspaceListPage.test.tsx
@@ -25,6 +25,7 @@ vi.mock("sonner", () => ({
 }));
 
 vi.mock("@/entities/domain-pack", () => ({
+  DOMAIN_PACK_DRAFT_ENTRY_NOT_FOUND: "DOMAIN_PACK_DRAFT_ENTRY_NOT_FOUND",
   domainPackApi: {
     getDraftEntry: vi.fn(),
   },

--- a/frontend/src/pages/workspace-list/ui/WorkspaceListPage.tsx
+++ b/frontend/src/pages/workspace-list/ui/WorkspaceListPage.tsx
@@ -1,7 +1,10 @@
 import { useCallback, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { toast } from "sonner";
 
+import { domainPackApi } from "@/entities/domain-pack";
 import { mapWorkspaceActionError, workspaceApi, type WorkspaceResponse } from "@/entities/workspace";
+import { ApiRequestError } from "@/shared/api";
 import {
   ArchiveConfirmDialog,
   CreateWorkspaceDialog,
@@ -21,6 +24,8 @@ export function WorkspaceListPage() {
   const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [editTarget, setEditTarget] = useState<WorkspaceResponse | null>(null);
   const [archiveTarget, setArchiveTarget] = useState<WorkspaceResponse | null>(null);
+  const [policyDraftLoadingWorkspaceId, setPolicyDraftLoadingWorkspaceId] =
+    useState<number | null>(null);
 
   const fetchWorkspaces = useCallback(async () => {
     setIsLoading(true);
@@ -41,6 +46,30 @@ export function WorkspaceListPage() {
 
   const handleOpenWorkspace = (workspace: WorkspaceResponse) => {
     navigate(`/workspaces/${workspace.id}/workflows`);
+  };
+
+  const handleOpenPolicyDraft = (workspace: WorkspaceResponse) => {
+    if (policyDraftLoadingWorkspaceId !== null) {
+      return;
+    }
+
+    setPolicyDraftLoadingWorkspaceId(workspace.id);
+    void (async () => {
+      try {
+        const entry = await domainPackApi.getDraftEntry(workspace.id);
+        navigate(
+          `/workspaces/${workspace.id}/domain-packs/${entry.packId}/versions/${entry.versionId}/policies`,
+        );
+      } catch (err) {
+        if (err instanceof ApiRequestError && err.code === "DOMAIN_PACK_DRAFT_ENTRY_NOT_FOUND") {
+          toast.error("수정 가능한 정책 초안이 없습니다.");
+          return;
+        }
+        toast.error("정책 편집 화면으로 이동하지 못했습니다.");
+      } finally {
+        setPolicyDraftLoadingWorkspaceId(null);
+      }
+    })();
   };
 
   return (
@@ -72,6 +101,8 @@ export function WorkspaceListPage() {
             onRetry={() => void fetchWorkspaces()}
             onCreate={() => setIsCreateOpen(true)}
             onOpen={handleOpenWorkspace}
+            onOpenPolicyDraft={handleOpenPolicyDraft}
+            policyDraftLoadingWorkspaceId={policyDraftLoadingWorkspaceId}
             onEdit={(workspace) => setEditTarget(workspace)}
             onDelete={(workspace) => setArchiveTarget(workspace)}
           />

--- a/frontend/src/pages/workspace-list/ui/WorkspaceListPage.tsx
+++ b/frontend/src/pages/workspace-list/ui/WorkspaceListPage.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { toast } from "sonner";
 
-import { domainPackApi } from "@/entities/domain-pack";
+import { DOMAIN_PACK_DRAFT_ENTRY_NOT_FOUND, domainPackApi } from "@/entities/domain-pack";
 import { mapWorkspaceActionError, workspaceApi, type WorkspaceResponse } from "@/entities/workspace";
 import { ApiRequestError } from "@/shared/api";
 import {
@@ -61,7 +61,7 @@ export function WorkspaceListPage() {
           `/workspaces/${workspace.id}/domain-packs/${entry.packId}/versions/${entry.versionId}/policies`,
         );
       } catch (err) {
-        if (err instanceof ApiRequestError && err.code === "DOMAIN_PACK_DRAFT_ENTRY_NOT_FOUND") {
+        if (err instanceof ApiRequestError && err.code === DOMAIN_PACK_DRAFT_ENTRY_NOT_FOUND) {
           toast.error("수정 가능한 정책 초안이 없습니다.");
           return;
         }

--- a/frontend/src/pages/workspace-list/ui/workspace-list-page.module.css
+++ b/frontend/src/pages/workspace-list/ui/workspace-list-page.module.css
@@ -1,16 +1,21 @@
 .page {
   width: 100%;
+  min-width: 0;
+  min-height: 0;
   padding: clamp(24px, 4vw, 40px);
   display: grid;
+  align-content: start;
   gap: 34px;
-  overflow-y: auto;
+  overflow: auto;
 }
 
 .hero {
   display: flex;
-  align-items: end;
+  flex-wrap: wrap;
+  align-items: flex-start;
   justify-content: space-between;
   gap: 24px;
+  min-width: 0;
   padding: clamp(28px, 4vw, 40px);
   border-radius: var(--radius-lg);
   border: 1px solid var(--glass-border);
@@ -22,6 +27,8 @@
 }
 
 .heroCopy {
+  flex: 1 1 520px;
+  min-width: 0;
   max-width: 760px;
   display: grid;
   gap: 12px;
@@ -38,6 +45,7 @@
   font-weight: 400;
   line-height: 1.02;
   letter-spacing: -1px;
+  overflow-wrap: anywhere;
 }
 
 .description {
@@ -48,7 +56,9 @@
 }
 
 .createButton {
+  flex: 0 1 auto;
   min-width: 208px;
+  max-width: 100%;
   min-height: 54px;
   padding-inline: 24px;
   border-radius: var(--radius-xl);
@@ -71,11 +81,13 @@
 
 .listSection {
   display: grid;
+  min-width: 0;
   gap: 20px;
 }
 
 .sectionHeader {
   display: flex;
+  flex-wrap: wrap;
   justify-content: space-between;
   gap: 18px;
   align-items: end;
@@ -84,15 +96,64 @@
 .sectionTitle {
   font-size: 1.68rem;
   letter-spacing: -0.46px;
+  overflow-wrap: anywhere;
+}
+
+@media (max-width: 960px) {
+  .page {
+    padding: 24px;
+    gap: 26px;
+  }
+
+  .hero {
+    padding: 24px;
+  }
+
+  .title {
+    font-size: 2.6rem;
+  }
+
+  .description {
+    font-size: 0.98rem;
+    line-height: 1.5;
+  }
+
+  .createButton {
+    min-width: 180px;
+    min-height: 46px;
+  }
 }
 
 @media (max-width: 768px) {
   .page {
     padding: 20px;
+    gap: 26px;
   }
 
   .hero {
     align-items: stretch;
     flex-direction: column;
+  }
+
+  .heroCopy {
+    flex-basis: auto;
+  }
+}
+
+@media (max-width: 560px) {
+  .page {
+    padding: 16px;
+  }
+
+  .hero {
+    padding: 24px;
+  }
+
+  .title {
+    font-size: 2rem;
+  }
+
+  .createButton {
+    width: 100%;
   }
 }

--- a/frontend/src/shared/ui/layout/dashboard-layout.module.css
+++ b/frontend/src/shared/ui/layout/dashboard-layout.module.css
@@ -1,5 +1,6 @@
 .wrapper {
-  min-height: 100vh;
+  height: 100vh;
+  height: 100dvh;
   display: flex;
   flex-direction: column;
   position: relative;
@@ -113,6 +114,8 @@
   display: flex;
   position: relative;
   z-index: 10;
+  min-width: 0;
+  min-height: 0;
   overflow: hidden;
 }
 

--- a/frontend/src/shared/ui/native-select.tsx
+++ b/frontend/src/shared/ui/native-select.tsx
@@ -10,7 +10,7 @@ function NativeSelect({
 }: Omit<React.ComponentProps<"select">, "size"> & { size?: "sm" | "default" }) {
   return (
     <div
-      className="group/native-select relative w-fit has-[select:disabled]:opacity-50"
+      className="group/native-select relative w-full has-[select:disabled]:opacity-50"
       data-slot="native-select-wrapper"
     >
       <select

--- a/frontend/src/shared/ui/select.tsx
+++ b/frontend/src/shared/ui/select.tsx
@@ -56,7 +56,7 @@ function SelectContent({
       <SelectPrimitive.Content
         data-slot="select-content"
         className={cn(
-          "relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          "relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover text-popover-foreground shadow-md bg-white text-black border-black/10 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
           position === "popper" &&
             "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
           className,

--- a/frontend/src/shared/ui/select.tsx
+++ b/frontend/src/shared/ui/select.tsx
@@ -56,7 +56,7 @@ function SelectContent({
       <SelectPrimitive.Content
         data-slot="select-content"
         className={cn(
-          "relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover text-popover-foreground shadow-md bg-white text-black border-black/10 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          "relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
           position === "popper" &&
             "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
           className,


### PR DESCRIPTION
## Summary
- Implement policy draft read/edit flow for domain pack versions.
- Add backend draft-entry lookup API so workspace cards can enter the policy editor.
- Add responsive fixes for `/workspaces` and policy edit/detail screens, including solid Select dropdown backgrounds.
- Ignore local `.playwright-cli/` artifacts.

## Why
Policy editing needed a real entry path from the workspace list and a usable detail/edit UI backed by actual API data. The previous responsive layout also allowed key controls and panels to be clipped in smaller browser windows.

## Validation
- `cd frontend && pnpm build`
- `cd frontend && pnpm test -- --run src/features/update-policy/model/schema.test.ts src/features/update-policy/api/__tests__/useUpdatePolicy.test.ts src/features/workspace/ui/WorkspaceCard.test.tsx src/features/workspace/ui/WorkspaceList.test.tsx`
- `cd backend && ./gradlew test --tests com.init.domainpack.application.GetDomainPackDraftEntryUseCaseTest --tests com.init.domainpack.infrastructure.JpaWorkflowDefinitionRepositoryPolicyRefTest`
- Browser checked `/workspaces` and policy edit/detail at desktop, small desktop, and mobile widths.

## Notes
- Left unrelated local duplicate files with spaces untracked and excluded from this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 정책 초안 읽기 및 편집 인터페이스 추가
  * 정책 목록 및 상세 정보 패널 구현
  * 정책 상태(활성/비활성) 전환 기능 추가
  * JSON 형식의 정책 조건, 액션, 증거, 메타데이터 편집 기능
  * 워크스페이스 카드에 정책 편집 버튼 추가
  * 정책 초안 항목 조회 API 엔드포인트 추가

* **개선 사항**
  * 정책 편집 폼 검증 및 에러 처리 강화
  * 반응형 레이아웃 개선
  * 사용자 친화적 에러 알림 메시지 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->