### PR TITLE
spec/323: [FE] Risk Factor 수정 기능 구현

### DIFF
--- a/.agent/specs/323.md
+++ b/.agent/specs/323.md
@@ -118,7 +118,7 @@ flowchart TD
 
 ## Component Tree
 
-```
+```text
 App
 └── Route /workspaces/:workspaceId/domain-packs/:packId/versions/:versionId/risks/:riskId?
     └── RiskDraftReadPage
@@ -270,7 +270,7 @@ export const RISK_ERROR_MESSAGES = {
 
 ## Data Flow
 
-```
+```text
 RiskDraftReadPage
     │ parseRouteId(workspaceId, packId, versionId, riskId?)
     ├── RiskListPanel

--- a/.agent/specs/323.md
+++ b/.agent/specs/323.md
@@ -1,0 +1,548 @@
+# Spec 323 — [Console] Risk Factor 수정 기능 구현
+
+**Branch**: `spec/323`
+**Canonical Number**: `323`
+**Type**: Frontend (FSD)
+**작성일**: 2026-04-27
+
+---
+
+## Goal
+
+운영자가 Domain Pack Version의 Risk Factor 초안을 목록/상세로 확인하고, `328.md`의 Risk 수정 API를 사용해 Risk 일반 필드와 status를 수정할 수 있는 프런트엔드 화면을 구현한다.
+
+---
+
+## Scope Decision
+
+### Risk Factor는 Policy 화면과 분리된 전용 화면으로 구현한다
+
+Risk Factor는 `risk_definition` 단건의 위험도, 트리거 조건, 처리 액션, 근거, 메타 정보를 수정하는 책임을 가진다. Policy/Workflow 화면에 함께 넣지 않고 `RiskDraftReadPage + RiskEditPanel`로 분리한다.
+
+이 결정의 기준:
+- Risk 수정은 `risk_definition` 단건 PATCH가 핵심이고, Workflow 그래프나 Policy 본문 수정과 저장 책임이 다르다.
+- `riskCode`는 immutable key이며 수정 대상이 아니다.
+- `triggerConditionJson`, `handlingActionJson`, `evidenceJson`, `metaJson`은 Risk 전용 JSON 필드이므로 별도 form 검증이 필요하다.
+- 이미 구현된 Policy 화면의 2-pane 목록/상세/편집 패널 패턴을 Risk에 직접 적용할 수 있다.
+- 추후 Domain Pack 구성요소를 탭으로 통합하는 작업은 별도 스펙에서 처리한다.
+
+---
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A[RiskDraftReadPage 진입\n/workspaces/:wsId/domain-packs/:packId/versions/:versionId/risks] --> B[useRiskList 호출]
+    B -->|loading| C[목록 skeleton]
+    B -->|error| D[toast.error + 재시도 버튼]
+    B -->|empty| E[빈 상태 표시]
+    B -->|success| F[RiskListPanel 표시]
+
+    F --> G{Risk 선택}
+    G -->|선택 없음| H[상세 placeholder]
+    G -->|선택| I[URL /risks/:riskId 이동]
+    I --> J[useRiskDetail 호출]
+    J -->|loading| K[상세 skeleton]
+    J -->|error| L[toast.error + 재시도 버튼]
+    J -->|success| M[RiskDetailPanel 표시]
+
+    M --> N[수정 버튼 클릭]
+    N --> O[RiskEditPanel 표시]
+    O --> P[useGetRisk 호출]
+    P -->|loading| Q[편집 panel spinner]
+    P -->|error| R[편집 panel 유지 + 재시도 버튼]
+    P -->|success| S[RiskEditForm 렌더링]
+
+    S --> T{사용자 액션}
+    T -->|일반 필드 수정 후 저장| U[zod: name + riskLevel + JSON 필드 검증]
+    U -->|실패| V[FormMessage 표시\nAPI 호출 없음]
+    U -->|통과| W[PATCH /risks/{riskId}]
+    W -->|success| X[toast.success + 편집 panel 닫기\nlist/detail 갱신]
+    W -->|RISK_NOT_EDITABLE| Y[toast.error DRAFT 안내]
+    W -->|VALIDATION_ERROR| Z[toast.error 또는 FormMessage]
+    W -->|기타 실패| AA[toast.error]
+
+    T -->|status switch 변경| AB[PATCH /risks/{riskId}/status]
+    AB -->|success| AC[detail/list optimistic update 후 서버 응답 반영]
+    AB -->|RISK_NOT_EDITABLE| AD[toast.error DRAFT 안내 + rollback]
+    AB -->|기타 실패| AE[toast.error + rollback]
+```
+
+---
+
+## Design Diff
+
+### As-is vs To-be
+
+| 영역 | As-is | To-be | 변경 내용 |
+|------|-------|-------|----------|
+| Risk FE 화면 | 없음 | `RiskDraftReadPage` | 신규 라우트와 2-pane 목록/상세 화면 추가 |
+| Risk 조회 | BE GET API만 존재 | `riskApi.list/detail` + hooks | 3213/2213 API를 FE에서 사용 |
+| Risk 일반 수정 | BE PATCH API만 존재 | `RiskEditPanel` + `RiskEditForm` | 328 API 연동 |
+| Risk status 수정 | BE PATCH API만 존재 | `RiskStatusToggle` | 328 status API 연동 |
+| Policy 수정 화면 | 구현됨 | Risk 수정의 기준 패턴 | `policy-draft-read`, `update-policy` 구조 재사용 |
+| Workflow 편집 화면 | 그래프/노드 수정 책임 | 변경 없음 | Risk 본문 수정은 Workflow 화면에 넣지 않음 |
+
+---
+
+## Prerequisites
+
+### BE API
+
+| Source | Method | Path | Description |
+|--------|--------|------|-------------|
+| 3213 | GET | `/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/risks` | Risk Factor 목록 조회 |
+| 2213 | GET | `/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/risks/{riskId}` | Risk Factor 단건 조회 |
+| 328 | PATCH | `/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/risks/{riskId}` | Risk 일반 필드 수정 |
+| 328 | PATCH | `/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/risks/{riskId}/status` | Risk status 전환 |
+
+`frontend/src/shared/api/index.ts`의 `apiClient`는 기본 base URL이 `/api/v1`이므로 FE API 함수에서는 `/workspaces/...`부터 path를 작성한다.
+
+### Existing FE Patterns
+
+구현 시 아래 기존 파일의 패턴을 따른다.
+
+| Existing file | 재사용 기준 |
+|---------------|------------|
+| `frontend/src/pages/domain-pack/ui/PolicyDraftReadPage.tsx` | 목록/상세/편집 패널 전환 구조 |
+| `frontend/src/features/policy-draft-read/ui/PolicyListPanel.tsx` | 목록 loading/error/empty/ready 상태 |
+| `frontend/src/features/policy-draft-read/ui/PolicyDetailPanel.tsx` | 상세 loading/error/idle/ready 상태와 수정 버튼 |
+| `frontend/src/features/update-policy/ui/PolicyEditPanel.tsx` | detail slot 안에서 편집 패널로 전환하는 패턴 |
+| `frontend/src/features/update-policy/ui/PolicyEditForm.tsx` | react-hook-form + zod + status toggle 배치 |
+| `frontend/src/features/update-policy/api/useUpdatePolicy.ts` | PATCH 성공 시 detail/list 갱신 + toast |
+| `frontend/src/features/update-policy/api/useUpdatePolicyStatus.ts` | status optimistic update + rollback |
+| `frontend/src/features/update-policy/model/schema.ts` | JSON object/array 문자열 validator 패턴 |
+| `frontend/src/features/update-slot/ui/SlotEditForm.tsx` | 기존 수정 form의 기본 배치 참고 |
+
+---
+
+## Component Tree
+
+```
+App
+└── Route /workspaces/:workspaceId/domain-packs/:packId/versions/:versionId/risks/:riskId?
+    └── RiskDraftReadPage
+        ├── DashboardLayout
+        ├── PageHeader
+        ├── BackButton (mobile/detail 선택 상태)
+        └── twoPane
+            ├── RiskListPanel
+            │   ├── loading skeleton
+            │   ├── error + retry
+            │   ├── empty state
+            │   └── RiskListRow[]
+            └── detailSlot
+                ├── RiskDetailPanel
+                │   ├── idle placeholder
+                │   ├── loading skeleton
+                │   ├── error + retry
+                │   └── ready
+                │       ├── DetailHeader
+                │       │   └── EditButton
+                │       ├── InfoCard grid
+                │       └── JsonCard(triggerCondition/handlingAction/evidence/meta)
+                └── RiskEditPanel
+                    ├── PanelHeader
+                    ├── loading spinner
+                    ├── error + retry
+                    └── RiskEditForm
+                        ├── name input
+                        ├── description textarea
+                        ├── riskLevel select
+                        ├── riskCode read-only
+                        ├── RiskJsonFields
+                        ├── RiskStatusToggle
+                        └── save/cancel buttons
+```
+
+---
+
+## API Integration
+
+### Query Key Pattern
+
+```typescript
+// frontend/src/entities/risk/api/index.ts
+export const riskKeys = {
+  all: ["risks"] as const,
+  lists: () => [...riskKeys.all, "list"] as const,
+  list: (workspaceId: number, packId: number, versionId: number) =>
+    [...riskKeys.lists(), workspaceId, packId, versionId] as const,
+  detail: (workspaceId: number, packId: number, versionId: number, riskId: number) =>
+    [...riskKeys.all, "detail", workspaceId, packId, versionId, riskId] as const,
+};
+```
+
+### Types
+
+```typescript
+// frontend/src/entities/risk/model/types.ts
+export type RiskStatus = "ACTIVE" | "INACTIVE";
+export type RiskLevel = "LOW" | "MEDIUM" | "HIGH" | "CRITICAL";
+
+export interface RiskSummary {
+  id: number;
+  domainPackVersionId: number;
+  riskCode: string;
+  name: string;
+  description: string | null;
+  riskLevel: RiskLevel;
+  status: RiskStatus;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface RiskDefinition extends RiskSummary {
+  triggerConditionJson: string;
+  handlingActionJson: string;
+  evidenceJson: string;
+  metaJson: string;
+}
+
+export interface UpdateRiskRequest {
+  name: string;
+  description?: string | null;
+  riskLevel: RiskLevel;
+  triggerConditionJson?: string | null;
+  handlingActionJson?: string | null;
+  evidenceJson?: string | null;
+  metaJson?: string | null;
+}
+
+export interface UpdateRiskStatusRequest {
+  status: RiskStatus;
+}
+```
+
+### API Functions
+
+```typescript
+const basePath = (workspaceId: number, packId: number, versionId: number) =>
+  `/workspaces/${workspaceId}/domain-packs/${packId}/versions/${versionId}/risks`;
+
+export const riskApi = {
+  list: (workspaceId: number, packId: number, versionId: number) =>
+    apiClient.get<RiskSummary[]>(basePath(workspaceId, packId, versionId)),
+
+  detail: (workspaceId: number, packId: number, versionId: number, riskId: number) =>
+    apiClient.get<RiskDefinition>(`${basePath(workspaceId, packId, versionId)}/${riskId}`),
+
+  update: (
+    workspaceId: number,
+    packId: number,
+    versionId: number,
+    riskId: number,
+    body: UpdateRiskRequest,
+  ) =>
+    apiClient.patch<RiskDefinition>(
+      `${basePath(workspaceId, packId, versionId)}/${riskId}`,
+      body,
+    ),
+
+  updateStatus: (
+    workspaceId: number,
+    packId: number,
+    versionId: number,
+    riskId: number,
+    body: UpdateRiskStatusRequest,
+  ) =>
+    apiClient.patch<RiskDefinition>(
+      `${basePath(workspaceId, packId, versionId)}/${riskId}/status`,
+      body,
+    ),
+};
+```
+
+### Error Messages
+
+```typescript
+export const RISK_ERROR_MESSAGES = {
+  RISK_NOT_EDITABLE: "DRAFT 상태의 버전에서만 위험요소를 수정할 수 있습니다.",
+  VALIDATION_ERROR: "위험요소 데이터 검증에 실패했습니다. 입력값을 확인해주세요.",
+  NOT_FOUND: "위험요소를 찾을 수 없습니다.",
+  UPDATE_FAILED: "위험요소 수정에 실패했습니다.",
+  STATUS_FAILED: "위험요소 상태 변경에 실패했습니다.",
+  LOAD_FAILED: "위험요소 정보를 불러오지 못했습니다.",
+} as const;
+```
+
+---
+
+## Data Flow
+
+```
+RiskDraftReadPage
+    │ parseRouteId(workspaceId, packId, versionId, riskId?)
+    ├── RiskListPanel
+    │     useRiskList(wsId, packId, versionId, retryKey)
+    │     └── riskApi.list → riskKeys.list
+    └── RiskDetailPanel
+          useRiskDetail(wsId, packId, versionId, riskId, retryKey)
+          ├── idle/loading/error/ready
+          └── EditButton → RiskEditPanel 표시
+
+RiskEditPanel
+    │ useGetRisk({ workspaceId, packId, versionId, riskId, enabled: true })
+    ├── loading/error/ready
+    └── RiskEditForm
+          react-hook-form + zod
+          ├── submit → useUpdateRisk.mutate
+          │            ├── onSuccess: set detail/list query data, toast.success, onClose
+          │            └── onError: ApiRequestError code별 toast.error
+          └── RiskStatusToggle
+                       └── useUpdateRiskStatus.mutate
+                            ├── onMutate: detail/list optimistic status update
+                            ├── onError: rollback + toast.error
+                            └── onSuccess: set detail/list query data
+```
+
+---
+
+## Form Rules
+
+### Editable fields
+
+| Field | UI | Rule |
+|-------|----|------|
+| `name` | Input | required, trim 후 빈 문자열 금지 |
+| `description` | Textarea | 빈 문자열은 `null`로 전송 |
+| `riskLevel` | Select | `LOW`, `MEDIUM`, `HIGH`, `CRITICAL` 중 하나 |
+| `triggerConditionJson` | JSON textarea | 유효한 JSON object 문자열 |
+| `handlingActionJson` | JSON textarea | 유효한 JSON object 문자열 |
+| `evidenceJson` | JSON textarea | 유효한 JSON array 문자열 |
+| `metaJson` | JSON textarea | 유효한 JSON object 문자열 |
+| `status` | Switch | `ACTIVE` ↔ `INACTIVE` |
+
+### Read-only fields
+
+| Field | Reason |
+|-------|--------|
+| `riskCode` | immutable key, 수정 API 대상 아님 |
+| `domainPackVersionId` | URL context로 고정 |
+| `createdAt`, `updatedAt` | server-managed audit fields |
+
+### zod schema
+
+```typescript
+export const riskLevelSchema = z.enum(["LOW", "MEDIUM", "HIGH", "CRITICAL"]);
+
+export const riskEditSchema = z.object({
+  name: z.string().trim().min(1, "위험요소 이름은 필수입니다."),
+  description: z.string().nullable().optional(),
+  riskLevel: riskLevelSchema,
+  triggerConditionJson: jsonObjectString("트리거 조건 JSON은 객체여야 합니다."),
+  handlingActionJson: jsonObjectString("처리 액션 JSON은 객체여야 합니다."),
+  evidenceJson: jsonArrayString("근거 JSON은 배열이어야 합니다."),
+  metaJson: jsonObjectString("메타 JSON은 객체여야 합니다."),
+});
+```
+
+`jsonObjectString(message)`와 `jsonArrayString(message)`는 `frontend/src/features/update-policy/model/schema.ts`의 구현 패턴을 따른다. Feature 간 직접 import는 하지 않고 `update-risk/model/schema.ts` 내부에 구현한다.
+
+---
+
+## 수정 대상 파일
+
+> 경로 기준: 아래 모든 경로는 repository root 기준이다.
+
+### 신규 생성 예정
+
+| 파일 | 설명 |
+|------|------|
+| `frontend/src/entities/risk/model/types.ts` | `RiskSummary`, `RiskDefinition`, update request/status 타입 |
+| `frontend/src/entities/risk/api/index.ts` | `riskKeys`, `riskApi` |
+| `frontend/src/entities/risk/index.ts` | entity barrel export |
+| `frontend/src/features/risk-draft-read/model/mapApiError.ts` | list/detail 조회 에러 매핑 |
+| `frontend/src/features/risk-draft-read/model/useRiskList.ts` | Risk 목록 조회 hook |
+| `frontend/src/features/risk-draft-read/model/useRiskDetail.ts` | Risk 단건 조회 hook |
+| `frontend/src/features/risk-draft-read/ui/RiskListPanel.tsx` | 목록 패널 |
+| `frontend/src/features/risk-draft-read/ui/RiskListPanel.module.css` | 목록 패널 스타일 |
+| `frontend/src/features/risk-draft-read/ui/RiskDetailPanel.tsx` | 상세 패널 + 수정 trigger |
+| `frontend/src/features/risk-draft-read/ui/RiskDetailPanel.module.css` | 상세 패널 스타일 |
+| `frontend/src/features/risk-draft-read/ui/index.ts` | UI barrel export |
+| `frontend/src/features/update-risk/api/messages.ts` | Risk 수정 에러 메시지 |
+| `frontend/src/features/update-risk/api/useGetRisk.ts` | 편집 패널용 단건 조회 hook |
+| `frontend/src/features/update-risk/api/useUpdateRisk.ts` | 일반 필드 PATCH mutation |
+| `frontend/src/features/update-risk/api/useUpdateRiskStatus.ts` | status PATCH mutation |
+| `frontend/src/features/update-risk/model/schema.ts` | zod schema + JSON validator |
+| `frontend/src/features/update-risk/ui/JsonTextarea.tsx` | JSON textarea wrapper |
+| `frontend/src/features/update-risk/ui/RiskJsonFields.tsx` | trigger/action/evidence/meta 필드 묶음 |
+| `frontend/src/features/update-risk/ui/RiskStatusToggle.tsx` | ACTIVE/INACTIVE Switch |
+| `frontend/src/features/update-risk/ui/RiskEditForm.tsx` | react-hook-form 기반 수정 폼 |
+| `frontend/src/features/update-risk/ui/RiskEditPanel.tsx` | detail slot 안의 편집 패널 |
+| `frontend/src/features/update-risk/ui/risk-edit-panel.module.css` | 편집 패널 스타일 |
+| `frontend/src/features/update-risk/index.ts` | feature barrel export |
+| `frontend/src/pages/domain-pack/ui/RiskDraftReadPage.tsx` | Risk 목록/상세/편집 페이지 |
+| `frontend/src/pages/domain-pack/ui/risk-draft-read-page.module.css` | 페이지 스타일 |
+
+### 수정 예정
+
+| 파일 | 변경 내용 |
+|------|----------|
+| `frontend/src/app/App.tsx` | `/workspaces/:workspaceId/domain-packs/:packId/versions/:versionId/risks/:riskId?` 라우트 추가 |
+| `frontend/src/pages/domain-pack/ui/PolicyDraftReadPage.tsx` | 변경 없음. Risk 구현의 참조 패턴으로만 사용 |
+| `frontend/src/features/update-policy/ui/PolicyEditPanel.tsx` | 변경 없음. Risk 전용 feature에서 별도 구현 |
+
+### 테스트 신규 생성 예정
+
+| 파일 | 설명 |
+|------|------|
+| `frontend/src/entities/risk/api/index.test.ts` | `riskApi` path/query key 테스트 |
+| `frontend/src/features/risk-draft-read/model/mapApiError.test.ts` | 조회 에러 매핑 테스트 |
+| `frontend/src/features/risk-draft-read/model/useRiskList.test.ts` | 목록 hook 상태 테스트 |
+| `frontend/src/features/risk-draft-read/model/useRiskDetail.test.ts` | 상세 hook 상태 테스트 |
+| `frontend/src/features/risk-draft-read/ui/RiskListPanel.test.tsx` | 목록 패널 상태 렌더링 테스트 |
+| `frontend/src/features/risk-draft-read/ui/RiskDetailPanel.test.tsx` | 상세 패널 상태 렌더링 테스트 |
+| `frontend/src/features/update-risk/api/useGetRisk.test.ts` | 편집용 조회 hook 테스트 |
+| `frontend/src/features/update-risk/api/useUpdateRisk.test.ts` | 일반 수정 mutation 테스트 |
+| `frontend/src/features/update-risk/api/useUpdateRiskStatus.test.ts` | status optimistic update/rollback 테스트 |
+| `frontend/src/features/update-risk/model/schema.test.ts` | riskLevel/JSON validator 테스트 |
+| `frontend/src/features/update-risk/ui/RiskEditForm.test.tsx` | form validation/submit 테스트 |
+| `frontend/src/features/update-risk/ui/RiskStatusToggle.test.tsx` | status switch 테스트 |
+| `frontend/src/pages/domain-pack/ui/RiskDraftReadPage.test.tsx` | route param/page 전환 테스트 |
+
+---
+
+## State Management
+
+### `useUpdateRisk`
+
+```typescript
+export function useUpdateRisk() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ workspaceId, packId, versionId, riskId, body }: UpdateRiskParams) =>
+      riskApi.update(workspaceId, packId, versionId, riskId, body),
+    onSuccess: (updatedRisk, { workspaceId, packId, versionId, riskId }) => {
+      queryClient.setQueryData(
+        riskKeys.detail(workspaceId, packId, versionId, riskId),
+        updatedRisk,
+      );
+      queryClient.setQueryData<RiskSummary[]>(
+        riskKeys.list(workspaceId, packId, versionId),
+        (old) => old?.map((item) => (item.id === riskId ? toRiskSummary(updatedRisk) : item)),
+      );
+      toast.success("위험요소가 수정되었습니다.");
+    },
+    onError: (error: unknown) => {
+      if (error instanceof ApiRequestError) {
+        if (error.code === "RISK_NOT_EDITABLE") {
+          toast.error(RISK_ERROR_MESSAGES.RISK_NOT_EDITABLE);
+          return;
+        }
+        if (error.code === "VALIDATION_ERROR") {
+          toast.error(RISK_ERROR_MESSAGES.VALIDATION_ERROR);
+          return;
+        }
+      }
+      toast.error(RISK_ERROR_MESSAGES.UPDATE_FAILED);
+    },
+  });
+}
+```
+
+### `useUpdateRiskStatus`
+
+- mutation key: `["updateRiskStatus"] as const`
+- `onMutate`: `riskKeys.detail`과 `riskKeys.list`의 status를 optimistic update
+- `onError`: 이전 detail/list snapshot으로 rollback
+- `RISK_NOT_EDITABLE`: DRAFT 아님 toast 표시
+- `onSuccess`: 서버 응답의 `status`, `updatedAt`을 detail/list cache에 반영
+
+---
+
+## Design Constraints
+
+`frontend/DESIGN.md`를 따른다.
+
+- 색상은 기존 Domain Pack 구성요소 화면처럼 모노크롬 기반으로 유지한다.
+- 버튼/입력/Select/Switch는 `shared/ui` 컴포넌트를 우선 사용한다.
+- focus outline은 dashed 패턴을 유지한다.
+- 페이지 레이아웃은 Policy/Slot draft read 화면의 2-pane 구조와 반응형 동작을 따른다.
+- `alert()`는 사용하지 않고 `sonner` toast를 사용한다.
+- 카드 중첩을 만들지 않고, 상세 정보 카드는 반복 정보 표시 단위에만 사용한다.
+- 긴 JSON 문자열은 `pre`/textarea 내부에서 줄바꿈 처리해 모바일/데스크톱 모두 overflow를 제어한다.
+- `riskLevel`은 Select로 제공해 허용 값 외 입력을 원천 차단한다.
+
+---
+
+## Tests
+
+### Test Strategy
+
+| 구분 | 방법 | 도구 | 비고 |
+|------|------|------|------|
+| 단위 테스트 | API path/query key 테스트 | Vitest | `riskApi`, `riskKeys` |
+| 단위 테스트 | hook mutation 테스트 | Vitest + Testing Library | `useUpdateRisk`, `useUpdateRiskStatus` |
+| 단위 테스트 | JSON validator 테스트 | Vitest | object/array 필드 검증 |
+| 컴포넌트 테스트 | list/detail/edit 상태 렌더링 | Vitest + mock | loading/error/empty/ready |
+| 수동 테스트 | 브라우저 직접 확인 | `pnpm dev` | 실제 BE와 연동 |
+
+### Test Scenarios
+
+#### Happy Path
+
+| # | 시나리오 | 사전 조건 | 조작 | 기대 결과 |
+|---|---------|---------|------|----------|
+| 1 | Risk 목록 조회 | DRAFT version에 risk 2개 이상 | `/risks` 진입 | riskCode ASC 목록 표시 |
+| 2 | Risk 상세 조회 | risk 존재 | 목록 row 클릭 | URL에 riskId 반영, 상세 표시 |
+| 3 | 일반 필드 수정 | DRAFT version | 수정 패널 열기 → name/riskLevel/JSON 수정 → 저장 | 성공 toast, 편집 패널 닫힘, 목록/상세 갱신 |
+| 4 | status 비활성화 | ACTIVE risk | Switch OFF | status `INACTIVE`, list/detail 갱신 |
+| 5 | status 활성화 | INACTIVE risk | Switch ON | status `ACTIVE`, list/detail 갱신 |
+| 6 | 취소 | 편집 패널에서 값 수정 | 취소 클릭 | API 호출 없음, 원본 유지 |
+
+#### Error & Edge Cases
+
+| # | 시나리오 | 조작 | 기대 결과 |
+|---|---------|------|----------|
+| 1 | name 빈 문자열 | name 삭제 후 저장 | FormMessage, PATCH 호출 없음 |
+| 2 | riskLevel 미선택/비정상 값 | form submit | FormMessage, PATCH 호출 없음 |
+| 3 | triggerConditionJson invalid | `{` 입력 후 저장 | FormMessage, PATCH 호출 없음 |
+| 4 | handlingActionJson array 입력 | `[]` 입력 후 저장 | 객체 필요 FormMessage |
+| 5 | evidenceJson object 입력 | `{}` 입력 후 저장 | 배열 필요 FormMessage |
+| 6 | DRAFT 아닌 버전 수정 | 저장 또는 status 변경 | `RISK_NOT_EDITABLE` toast |
+| 7 | riskId 미존재 | URL 직접 진입 | 404 toast + 상세 error state |
+| 8 | 목록 조회 실패 | 네트워크/API 실패 | toast + 재시도 버튼 |
+| 9 | 편집 패널 detail 조회 실패 | 수정 버튼 클릭 후 실패 | 패널 유지 + 재시도 버튼 |
+
+#### 접근성
+
+| # | 확인 항목 | 기대 결과 |
+|---|---------|----------|
+| 1 | 목록 row 키보드 선택 | Tab 이동 후 Enter/Space로 선택 |
+| 2 | 수정 버튼 aria-label | riskCode 포함한 label 제공 |
+| 3 | Status Switch aria-label | "위험요소 상태" label 제공 |
+| 4 | JSON textarea label | 각 JSON 필드 label과 에러 메시지 연결 |
+| 5 | Focus outline | dashed outline 표시 |
+
+---
+
+## Done Criteria
+
+- [ ] `entities/risk` 타입/API/query key 추가
+- [ ] `RiskDraftReadPage` 라우트 추가 및 잘못된 URL 파라미터 처리
+- [ ] `RiskListPanel` loading/error/empty/ready 상태 구현
+- [ ] `RiskDetailPanel` idle/loading/error/ready 상태 구현
+- [ ] 상세 화면에서 수정 버튼으로 `RiskEditPanel` 전환
+- [ ] `RiskEditPanel`은 detail query 실패 시 패널을 닫지 않고 재시도 버튼을 제공
+- [ ] `RiskEditForm`은 react-hook-form + zod로 name/riskLevel/JSON 검증 수행
+- [ ] `riskCode`, `domainPackVersionId`는 read-only로 표시
+- [ ] 일반 수정 성공 시 `riskKeys.detail` + `riskKeys.list` cache 갱신 및 toast.success
+- [ ] status 수정은 optimistic update + 실패 rollback 적용
+- [ ] `RISK_NOT_EDITABLE`, `VALIDATION_ERROR` 전용 toast 메시지 처리
+- [ ] `alert()` 미사용, `sonner` toast 사용
+- [ ] FSD 의존성 방향 준수: `pages → features → entities → shared`
+- [ ] `frontend/DESIGN.md` 준수
+- [ ] `pnpm test` 통과
+- [ ] `pnpm lint` 통과
+
+---
+
+## Out of Scope
+
+- Risk Factor 생성/삭제 기능
+- `riskCode` 수정 기능
+- Risk와 Policy/Workflow 간 바인딩 설계
+- publish/runtime에서 risk status를 실제 실행 판단에 반영하는 로직
+- Domain Pack 구성요소 통합 탭 화면


### PR DESCRIPTION
## Summary
- Add Spec 323 for the frontend Risk Factor edit flow.
- Document the FSD page, entity, feature, API integration, form validation, cache update, and status toggle plan.
- Tie the frontend work to the existing Risk GET APIs and the 328 Risk PATCH APIs.

## Validation
- `git diff --cached --check`
- Commit hook ran; `lint-staged` had no matching staged files for this doc-only change.

## Notes
- Full frontend tests were not run because this PR only adds a spec document.
- Existing untracked Intent draft files in the local worktree were left untouched and are not included in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * Domain Pack Version의 Risk Factor 초안 조회 및 수정 화면 스펙 추가
  * 목록/상세 2-pane 인터페이스 및 상태 관리 흐름 정의
  * 폼 검증, 캐시 동기화, 에러 처리 전략 명시

<!-- end of auto-generated comment: release notes by coderabbit.ai -->