### PR TITLE
spec/217: Airflow Workflow Draft Callback spec문서 수정

### DIFF
--- a/.agent/specs/217.md
+++ b/.agent/specs/217.md
@@ -49,7 +49,9 @@
   - 기존 `persist(...)` 의 slot/policy/risk/workflow + binding 적재 로직과 동일한 검증 / 저장 흐름을 사용한다 (DRY)
   - graphJson 은 `WorkflowGraphValidator.parseAndValidate(...)` 로 V1~V7b + V8a/V8b 검증 후 `initialState` / `terminalStatesJson` 추출
   - V8c(policyRef 존재 여부)는 `persistWorkflowDraft(...)` 에서 이번 callback payload 와 DB 의 같은 version policy 를 대상으로 별도 교차 검증
-- `webhook_receipt` 기반 멱등 처리 (213 와 동일 패턴, `webhook_type = WORKFLOW_DRAFT_CALLBACK`)
+- `webhook_receipt` 기반 멱등 처리 (213 와 동일 패턴, `externalEventId` 단독 idempotency key 유지)
+  - `webhook_type = WORKFLOW_DRAFT_CALLBACK` 는 receipt 분류/감사용 값이며 idempotency key 에 포함하지 않는다
+  - Airflow 는 callback 수신 단위마다 전역 unique 한 `externalEventId` 를 전송해야 한다
 - `pipeline_job.version` 기반 optimistic locking 으로 동시 callback 경쟁을 409 충돌로 차단
 - `pipeline_artifact` 에 callback payload 원문 저장
   - `stage_name = "publish-candidate"`, `artifact_type = "WORKFLOW_DRAFT_PAYLOAD"`
@@ -62,6 +64,7 @@
 - `domain-pack-drafts` / `intent-drafts` callback request DTO 변경
 - workflow callback 으로 받지 못한 누락 binding 에 대한 자동 재시도
 - intent_workflow_binding 의 `is_primary` 충돌 해결 로직 (KISS — DB unique 제약과 단일 callback 내부 검증으로만 처리)
+- `pipeline.webhook_receipt` schema / unique constraint 변경 (`unique (external_event_id)` 유지)
 
 ---
 
@@ -158,7 +161,7 @@
 
 | 필드 | 제약 |
 |------|------|
-| `externalEventId` | 필수, 최대 255자 |
+| `externalEventId` | 필수, 최대 255자. callback type 과 무관하게 `pipeline.webhook_receipt.external_event_id` 기준 전역 unique 해야 하며, Airflow 는 단계별 callback 마다 서로 다른 값을 전송해야 한다. |
 | `domainPackVersionId` | 필수, > 0 |
 | `slots` | optional, 0 ~ 200 개 |
 | `policies` | optional, 0 ~ 200 개 |
@@ -198,7 +201,7 @@
 
 ### Duplicate response (200 OK)
 
-`webhook_receipt.processing_status = PROCESSED` 인 동일 `(externalEventId, webhookType)` 재요청.
+`webhook_receipt.processing_status = PROCESSED` 인 동일 `externalEventId` 재요청.
 
 ```json
 {
@@ -322,7 +325,7 @@ sequenceDiagram
     airflow ->> ctrl: POST /callbacks/workflow-drafts
     ctrl ->> cb: execute(command)
     cb ->> cb: webhook secret 상수시간 비교
-    cb ->> receiptRepo: findByExternalEventIdAndWebhookType()
+    cb ->> receiptRepo: findByExternalEventId()
     alt receipt == PROCESSED
         cb -->> ctrl: 200 DUPLICATE_IGNORED
     end
@@ -405,10 +408,7 @@ classDiagram
 | `pipelinejob/domain/model/PipelineJob.java` | `STATUS_WAITING_WORKFLOW_CALLBACK` 상수 / `canAcceptWorkflowDraftCallback()` / `markAwaitingWorkflowCallback(...)` 추가. `canAcceptIntentDraftCallback()` 의 허용 상태는 그대로 `WAITING_INTENT_CALLBACK` 유지. |
 | `pipelinejob/application/ReceiveIntentDraftCallbackUseCase.java` | `processCallback(...)` 의 `job.markSucceeded(...)` → `job.markAwaitingWorkflowCallback(...)` 로 교체. `finishedAt` 기록 제거. summary JSON 빌더는 그대로. |
 | `pipelinejob/application/exception/PipelineJobCallbackNotAllowedException.java` | 메시지 포맷 그대로 (`type` 인자만 `WORKFLOW_DRAFT_CALLBACK` 추가). |
-| `pipelinejob/domain/model/WebhookReceipt.java` | idempotency key 를 `externalEventId` 단독이 아니라 `(externalEventId, webhookType)` tuple 로 본다는 ORM unique constraint 를 추가한다. |
-| `pipelinejob/domain/repository/WebhookReceiptRepository.java` / `pipelinejob/infrastructure/persistence/JpaWebhookReceiptRepository.java` | `findByExternalEventId(...)` 를 `findByExternalEventIdAndWebhookType(...)` 로 교체한다. 기존 domain-pack / intent callback use case 도 같은 tuple lookup 을 사용하도록 함께 수정한다. |
 | `domainpack/application/DomainPackDraftPersistenceService.java` | `persistWorkflowDraft(domainPackVersionId, slots, policies, risks, workflows, intentSlotBindings, intentWorkflowBindings)` 신규. 기존 `persist(...)` 의 slot/policy/risk/workflow 적재 코드 블록을 추출해 공유한다. |
-| `backend/src/main/resources/db/changelog/db.changelog-master.sql` | `pipeline.webhook_receipt` 의 unique constraint 를 `external_event_id` 단독에서 `(external_event_id, webhook_type)` tuple 로 변경하는 changeset 추가 |
 | `shared/infrastructure/web/SecurityConfig` 류 (이미 213 에서 callback 경로 `permitAll` 처리) | `/api/v1/pipeline-jobs/*/callbacks/workflow-drafts` POST 경로를 `permitAll` 목록에 추가 |
 | `shared/infrastructure/web/CorsConfig` 류 | 변경 없음 (`X-Airflow-Webhook-Secret` 는 213 에서 이미 추가) |
 
@@ -429,8 +429,7 @@ public class ReceiveWorkflowDraftCallbackUseCase {
     validateWebhookSecret(command.providedWebhookSecret());
 
     Optional<WebhookReceipt> existing =
-        webhookReceiptRepository.findByExternalEventIdAndWebhookType(
-            command.externalEventId(), WEBHOOK_TYPE);
+        webhookReceiptRepository.findByExternalEventId(command.externalEventId());
     if (isProcessed(existing.orElse(null))) {
       return ReceiveWorkflowDraftCallbackResult.duplicateIgnored(command.externalEventId());
     }
@@ -499,7 +498,7 @@ public class ReceiveWorkflowDraftCallbackUseCase {
     savePipelineJobOrThrowConflict(job, command.jobId());
 
     WebhookReceipt receipt = webhookReceiptRepository
-        .findByExternalEventIdAndWebhookType(command.externalEventId(), WEBHOOK_TYPE)
+        .findByExternalEventId(command.externalEventId())
         .orElseThrow(() -> new IllegalStateException("Webhook receipt가 존재하지 않습니다."));
     receipt.markProcessed(now);
     webhookReceiptRepository.saveAndFlush(receipt);
@@ -519,11 +518,11 @@ public class ReceiveWorkflowDraftCallbackUseCase {
 
   // ensureReceivedReceipt(...), validateWebhookSecret(...), isProcessed(...),
   // savePipelineJobOrThrowConflict(...), markFailure(...), buildSuccessSummaryJson(...) 는
-  // ReceiveIntentDraftCallbackUseCase 와 동일 형태로 구현한다 (DRY 가 정당화될 만큼 분량이
-  // 많지 않으면 두 use case 에 직접 작성하고, 3 번째 callback 이 추가되는 시점에
-  // CallbackProcessingSupport 같은 헬퍼로 추출한다 — Rule of Three).
-  // 단, receipt 조회와 concurrent 재조회는 항상
-  // findByExternalEventIdAndWebhookType(externalEventId, WEBHOOK_TYPE) 을 사용한다.
+  // ReceiveIntentDraftCallbackUseCase 와 동일 형태로 구현한다.
+  // 본 스펙에서는 DB/schema 변경을 피하기 위해 receipt 조회와 concurrent 재조회 모두
+  // 213 패턴과 동일하게 findByExternalEventId(externalEventId) 를 사용한다.
+  // header masking 처럼 작은 중복은 package-private helper 추출을 허용하지만,
+  // callback orchestration 전체를 새 추상화로 분리하지는 않는다.
 }
 ```
 
@@ -610,8 +609,9 @@ job.markAwaitingWorkflowCallback(
 
 ### Race condition / 멱등성
 
-- `(external_event_id, webhook_type)` tuple 을 idempotency key 로 사용한다.
-- receipt insert 중 `DataIntegrityViolationException` → 동일 `(external_event_id, webhook_type)` tuple 로 재조회 (concurrent 처리 보강).
+- `external_event_id` 단독을 idempotency key 로 사용한다 (213 및 `schema.md` 의 `unique (external_event_id)` 유지).
+- Airflow 는 `domain-pack-drafts`, `intent-drafts`, `workflow-drafts` 를 포함한 모든 callback 수신 단위마다 전역 unique 한 `externalEventId` 를 생성해야 한다.
+- receipt insert 중 `DataIntegrityViolationException` → 동일 `external_event_id` 로 재조회 (concurrent 처리 보강).
 - `PROCESSED` receipt 만 duplicate 로 간주, `FAILED` / `RECEIVED` 는 재처리 대상.
 - `pipeline_job.@Version` optimistic locking 으로 동시 callback 경쟁을 409 충돌로 차단.
 - `webhook_receipt` insert 는 별도 트랜잭션 (`TransactionTemplate.execute(...)`) 으로 처리해, persist 단계 실패 시에도 receipt 가 `FAILED` 로 남도록 한다 (213 의 `markFailure(...)` 패턴 그대로).
@@ -640,7 +640,7 @@ job.markAwaitingWorkflowCallback(
 | `pipeline_job_id` | `jobId` |
 | `external_event_id` | command.externalEventId |
 | `webhook_type` | `"WORKFLOW_DRAFT_CALLBACK"` |
-| unique key | `(external_event_id, webhook_type)` |
+| unique key | `external_event_id` |
 | `request_headers_json` | secret 마스킹된 header JSON |
 | `request_body_json` | request body 원문 |
 | `processing_status` | 초기 `RECEIVED` → 성공 시 `PROCESSED` / 실패 시 `FAILED` |
@@ -679,9 +679,9 @@ job.markAwaitingWorkflowCallback(
 
 `ReceiveWorkflowDraftCallbackUseCaseTest`
 - 정상 callback 처리 → 201 CREATED + `pipeline_job.status = SUCCEEDED` + `result_summary_json` 저장
-- duplicate ignored (동일 `(externalEventId, webhookType)` 의 `PROCESSED` receipt)
+- duplicate ignored (동일 `externalEventId` 의 `PROCESSED` receipt)
 - `FAILED` receipt 재처리 성공
-- receipt insert 충돌 후 `(externalEventId, webhookType)` tuple 재조회 duplicate 처리
+- receipt insert 충돌 후 `externalEventId` 재조회 duplicate 처리
 - receipt insert 비중복 예외 전파
 - 잘못된 secret → `UNAUTHORIZED`
 - 없는 job → `PIPELINE_JOB_NOT_FOUND`
@@ -721,11 +721,11 @@ job.markAwaitingWorkflowCallback(
 ### Test Checklist
 
 - [ ] 정상 시나리오: workflow callback 1 회로 slot/policy/risk/workflow + binding 모두 적재 + `SUCCEEDED` 종료
-- [ ] 멱등성: 동일 `(externalEventId, webhookType)` 재요청 시 duplicate ignored
+- [ ] 멱등성: 동일 `externalEventId` 재요청 시 duplicate ignored
 - [ ] 권한: secret 불일치 시 401
 - [ ] 상태머신: `QUEUED` / `RUNNING` / `WAITING_INTENT_CALLBACK` / `SUCCEEDED` / `FAILED` / `CANCELLED` 에서 모두 409
 - [ ] 동시성: 같은 job 에 서로 다른 `externalEventId` 를 가진 workflow callback 2 개가 동시에 들어오면 → 1 개는 201, 다른 1 개는 409 (optimistic locking)
-- [ ] 동시성: 같은 job 에 동일한 `(externalEventId, webhookType)` 를 가진 workflow callback 2 개가 동시에 들어오면 → 먼저 처리 완료된 요청은 201, 이후 재요청은 200 `DUPLICATE_IGNORED` (동시 insert 충돌 시 tuple 재조회 후 processed 여부에 따라 duplicate 처리)
+- [ ] 동시성: 같은 job 에 동일한 `externalEventId` 를 가진 workflow callback 2 개가 동시에 들어오면 → 먼저 처리 완료된 요청은 201, 이후 재요청은 200 `DUPLICATE_IGNORED` (동시 insert 충돌 시 `externalEventId` 재조회 후 processed 여부에 따라 duplicate 처리)
 - [ ] graphJson 검증: V1~V7b / V8a~V8c 각 위반 케이스에 대응되는 에러 코드
 - [ ] 트랜잭션: persist 도중 예외 시 slot/policy/risk/workflow 모두 롤백, `pipeline_job = FAILED`, `webhook_receipt = FAILED`
 - [ ] 213 회귀: intent callback 응답 스키마 / endpoint / receipt 처리 모두 변경 없음
@@ -734,7 +734,8 @@ job.markAwaitingWorkflowCallback(
 
 ## Database
 
-`pipeline.webhook_receipt` 의 idempotency unique key 변경을 위한 DDL 변경이 필요하다.
+본 스펙은 DB schema / constraint 변경을 요구하지 않는다.
+`pipeline.webhook_receipt` 의 idempotency unique key 는 기존 `unique (external_event_id)` 를 유지한다.
 
 | 테이블 | 비고 |
 |--------|------|
@@ -746,13 +747,14 @@ job.markAwaitingWorkflowCallback(
 | `pack.intent_workflow_binding` | 기존 (`backend/src/main/resources/db/changelog/db.changelog-master.sql:248-257`, verified) |
 | `pipeline.pipeline_job` | 기존 (`backend/src/main/resources/db/changelog/db.changelog-master.sql:354-373`, verified). `status` 컬럼 값에 `WAITING_WORKFLOW_CALLBACK` 추가. 컬럼 정의는 enum 이 아니므로 schema 변경 없음. `chk_pipeline_job_status` CHECK 제약은 현 schema 에 없음(verified). |
 | `pipeline.pipeline_artifact` | 기존 (`backend/src/main/resources/db/changelog/db.changelog-master.sql:386-397`, verified) |
-| `pipeline.webhook_receipt` | 기존 (`backend/src/main/resources/db/changelog/db.changelog-master.sql:399-412`, verified). 기존 `unique (external_event_id)` 를 `(external_event_id, webhook_type)` unique 로 변경하는 별도 changeset 필요. |
+| `pipeline.webhook_receipt` | 기존 (`backend/src/main/resources/db/changelog/db.changelog-master.sql:399-412`, verified). `unique (external_event_id)` 유지. 별도 changeset 없음. |
 
 ---
 
 ## Additional Notes
 
 - 이 스펙은 213 의 후속이다. 213 의 endpoint / 응답 스키마는 변경하지 않고, intent callback 의 종료 전이만 `SUCCEEDED` → `WAITING_WORKFLOW_CALLBACK` 으로 바꾼다. 따라서 이미 production 에서 `WAITING_INTENT_CALLBACK` 까지 진행된 job 은 본 변경 후에도 호환되며, 그 이후의 job 은 workflow callback 을 반드시 받아야 종료된다.
+- `externalEventId` 는 callback type 과 무관하게 전역 unique 해야 한다. 예: `run-123:domain-pack-drafts`, `run-123:intent-drafts`, `run-123:workflow-drafts`.
 - workflow graphJson 의 V1~V7b + V8a/V8b 구조 검증은 `WorkflowGraphValidator.parseAndValidate(...)` 와 그 예외 클래스를 재사용한다.
 - V7c(edge id 문자셋 검증)는 본 스펙 범위 밖이다. 따라서 `workflow-drafts` callback 구현은 V7c 검증 또는 `WORKFLOW_EDGE_ID_INVALID_CHARS` 응답을 새로 요구하지 않는다.
 - V8c(policyRef 가 실제 policyCode 로 해소되는지)는 `CreateDomainPackDraftUseCase`(spec 231 / 99) 의 write path 와 같은 의미가 되도록 `persistWorkflowDraft(...)` 에서 별도로 교차 검증한다.


### PR DESCRIPTION
## 요약
- BE-217의 webhook receipt 멱등성 기준을 기존 `externalEventId` 단독 기준으로 유지하도록 정리
- `(externalEventId, webhookType)` tuple lookup 및 DB unique constraint 변경 계획을 제거
- Airflow가 callback 단계마다 전역 unique한 `externalEventId`를 보내야 한다는 계약을 명시

## 배경
현재 schema는 `pipeline.webhook_receipt.external_event_id`를 unique key로 사용
BE-217 스펙을 기존 schema와 맞추고, 불필요한 DB constraint 변경 없이 workflow callback 구현을 진행하기 위한 정리

## 검증
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

이 업데이트는 내부 명세 문서 및 예시 코드 스니펫에 대한 변경 사항입니다. 최종 사용자에게 보이는 기능 변화는 없습니다.

* **문서**
  * 웹훅 처리 명세 및 관련 예시 코드 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->