### PR TITLE
fix/00156: AuthService S2068 — 하드코딩 리터럴 제거

### DIFF
--- a/.agent/specs/00156.md
+++ b/.agent/specs/00156.md
@@ -1,0 +1,107 @@
+# [fix] AuthService S2068 — 하드코딩 리터럴 제거
+
+## Goal
+
+`AuthService.java:46`의 하드코딩된 리터럴 문자열 `"dummy_password_for_timing_prevention"`을
+`UUID.randomUUID().toString()`으로 교체하여 SonarQube java:S2068 VULNERABILITY 플래그를 해소하고,
+CI Quality Gate 차단을 방지한다.
+
+---
+
+## Sequence Diagram
+
+N/A — HTTP 요청/응답 흐름 변경 없음.
+
+---
+
+## REST API
+
+N/A — API contract 변경 없음.
+
+---
+
+## Class Design
+
+### 변경 대상
+
+| 파일 | 라인 | 변경 전 | 변경 후 |
+|------|------|---------|---------|
+| `backend/src/main/java/com/init/auth/application/AuthService.java` | L46 | `passwordEncoder.encode("dummy_password_for_timing_prevention")` | `passwordEncoder.encode(UUID.randomUUID().toString())` |
+
+### 변경 후 생성자 (AuthService.java)
+
+```java
+public AuthService(
+    AppUserRepository userRepository,
+    RefreshTokenRepository refreshTokenRepository,
+    JwtService jwtService,
+    PasswordEncoder passwordEncoder,
+    TokenHasher tokenHasher) {
+  this.userRepository = userRepository;
+  this.refreshTokenRepository = refreshTokenRepository;
+  this.jwtService = jwtService;
+  this.passwordEncoder = passwordEncoder;
+  this.tokenHasher = tokenHasher;
+  this.dummyHash = passwordEncoder.encode(UUID.randomUUID().toString());
+}
+```
+
+**추가 import 불필요**: `import java.util.UUID;`가 `AuthService.java:18`에 이미 선언됨.
+
+**변경 없는 항목**:
+- `private final String dummyHash;` 필드 선언 (L33) — 유지
+- `userOpt.map(AppUser::getPasswordHash).orElse(dummyHash)` 사용처 (L53) — 유지
+- 타이밍 공격 방지 목적: BCrypt hash of a random UUID는 실제 사용자 hash와 동일한 연산 비용을 유지함
+
+---
+
+## Tests
+
+### 변경 대상
+
+| 파일 | 라인 | 변경 전 | 변경 후 |
+|------|------|---------|---------|
+| `backend/src/test/java/com/init/auth/application/AuthServiceTest.java` | L46–48 | `given(passwordEncoder.encode("dummy_password_for_timing_prevention")).willReturn("$2a$10$dummyhash")` | `given(passwordEncoder.encode(anyString())).willReturn("$2a$10$dummyhash")` |
+
+### 변경 후 setUp (AuthServiceTest.java)
+
+```java
+@BeforeEach
+void setUp() {
+  given(passwordEncoder.encode(anyString())).willReturn("$2a$10$dummyhash");
+  authService =
+      new AuthService(
+          userRepository, refreshTokenRepository, jwtService, passwordEncoder, tokenHasher);
+}
+```
+
+**추가 import 불필요**: `import static org.mockito.ArgumentMatchers.anyString;`가 `AuthServiceTest.java:8`에 이미 선언됨.
+
+**스텁 동작 규칙**: 개별 테스트에서 `passwordEncoder.encode("password123")` 등 특정 인자 스텁을 추가하면
+Mockito LIFO 순서에 따라 해당 스텁이 우선 적용됨. setUp의 `anyString()` 스텁은 constructor 호출 시
+소비되므로 strict stubbing 위반(`UnnecessaryStubbingException`) 미발생.
+
+**기존 주석 제거**: `// dummyHash 생성을 위해 passwordEncoder.encode("dummy_password_for_timing_prevention") 스텁 필요`
+주석은 더 이상 유효하지 않으므로 삭제한다.
+
+### Test Checklist
+
+- [ ] setUp 변경 후 AuthServiceTest 전체 테스트 통과
+- [ ] 생성자 호출 시 `passwordEncoder.encode(anyString())` 스텁이 정상 작동함
+- [ ] 개별 테스트의 specific encode 스텁과 충돌 없음 (login, signup 시나리오 포함)
+
+---
+
+## Database
+
+N/A — 스키마 변경 없음.
+
+---
+
+## Acceptance Criteria
+
+1. `AuthService.java:46`에 리터럴 문자열이 없음 (`"dummy_password_for_timing_prevention"` 제거됨)
+2. SonarQube CI 파이프라인에서 java:S2068 VULNERABILITY 플래그가 미발생
+3. CI Quality Gate 통과 (`sonar.qualitygate.wait=true`, `.github/workflows/ci.yml` `backend-sonar` job)
+4. `./gradlew test` (AuthServiceTest 포함) 전체 통과
+5. 기존 로그인 타이밍 공격 방지 로직 (`AuthService.java:53`) 동작 유지


### PR DESCRIPTION
# [fix] AuthService S2068 — 하드코딩 리터럴 제거

## Goal

`AuthService.java:46`의 하드코딩된 리터럴 문자열 `"dummy_password_for_timing_prevention"`을
`UUID.randomUUID().toString()`으로 교체하여 SonarQube java:S2068 VULNERABILITY 플래그를 해소하고,
CI Quality Gate 차단을 방지한다.

---

## Sequence Diagram

N/A — HTTP 요청/응답 흐름 변경 없음.

---

## REST API

N/A — API contract 변경 없음.

---

## Class Design

### 변경 대상

| 파일 | 라인 | 변경 전 | 변경 후 |
|------|------|---------|---------|
| `backend/src/main/java/com/init/auth/application/AuthService.java` | L46 | `passwordEncoder.encode("dummy_password_for_timing_prevention")` | `passwordEncoder.encode(UUID.randomUUID().toString())` |

### 변경 후 생성자 (AuthService.java)

```java
public AuthService(
    AppUserRepository userRepository,
    RefreshTokenRepository refreshTokenRepository,
    JwtService jwtService,
    PasswordEncoder passwordEncoder,
    TokenHasher tokenHasher) {
  this.userRepository = userRepository;
  this.refreshTokenRepository = refreshTokenRepository;
  this.jwtService = jwtService;
  this.passwordEncoder = passwordEncoder;
  this.tokenHasher = tokenHasher;
  this.dummyHash = passwordEncoder.encode(UUID.randomUUID().toString());
}
```

**추가 import 불필요**: `import java.util.UUID;`가 `AuthService.java:18`에 이미 선언됨.

**변경 없는 항목**:
- `private final String dummyHash;` 필드 선언 (L33) — 유지
- `userOpt.map(AppUser::getPasswordHash).orElse(dummyHash)` 사용처 (L53) — 유지
- 타이밍 공격 방지 목적: BCrypt hash of a random UUID는 실제 사용자 hash와 동일한 연산 비용을 유지함

---

## Tests

### 변경 대상

| 파일 | 라인 | 변경 전 | 변경 후 |
|------|------|---------|---------|
| `backend/src/test/java/com/init/auth/application/AuthServiceTest.java` | L46–48 | `given(passwordEncoder.encode("dummy_password_for_timing_prevention")).willReturn("$2a$10$dummyhash")` | `given(passwordEncoder.encode(anyString())).willReturn("$2a$10$dummyhash")` |

### 변경 후 setUp (AuthServiceTest.java)

```java
@BeforeEach
void setUp() {
  given(passwordEncoder.encode(anyString())).willReturn("$2a$10$dummyhash");
  authService =
      new AuthService(
          userRepository, refreshTokenRepository, jwtService, passwordEncoder, tokenHasher);
}
```

**추가 import 불필요**: `import static org.mockito.ArgumentMatchers.anyString;`가 `AuthServiceTest.java:8`에 이미 선언됨.

**스텁 동작 규칙**: 개별 테스트에서 `passwordEncoder.encode("password123")` 등 특정 인자 스텁을 추가하면
Mockito LIFO 순서에 따라 해당 스텁이 우선 적용됨. setUp의 `anyString()` 스텁은 constructor 호출 시
소비되므로 strict stubbing 위반(`UnnecessaryStubbingException`) 미발생.

**기존 주석 제거**: `// dummyHash 생성을 위해 passwordEncoder.encode("dummy_password_for_timing_prevention") 스텁 필요`
주석은 더 이상 유효하지 않으므로 삭제한다.

### Test Checklist

- [ ] setUp 변경 후 AuthServiceTest 전체 테스트 통과
- [ ] 생성자 호출 시 `passwordEncoder.encode(anyString())` 스텁이 정상 작동함
- [ ] 개별 테스트의 specific encode 스텁과 충돌 없음 (login, signup 시나리오 포함)

---

## Database

N/A — 스키마 변경 없음.

---

## Acceptance Criteria

1. `AuthService.java:46`에 리터럴 문자열이 없음 (`"dummy_password_for_timing_prevention"` 제거됨)
2. SonarQube CI 파이프라인에서 java:S2068 VULNERABILITY 플래그가 미발생
3. CI Quality Gate 통과 (`sonar.qualitygate.wait=true`, `.github/workflows/ci.yml` `backend-sonar` job)
4. `./gradlew test` (AuthServiceTest 포함) 전체 통과
5. 기존 로그인 타이밍 공격 방지 로직 (`AuthService.java:53`) 동작 유지

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서**
  * 인증 서비스 사양 문서를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->