### PR TITLE
fix(auth): replace hardcoded timing-prevention literal with UUID.rand()

### DIFF
--- a/backend/src/main/java/com/init/auth/application/AuthService.java
+++ b/backend/src/main/java/com/init/auth/application/AuthService.java
@@ -43,7 +43,7 @@ public class AuthService {
     this.jwtService = jwtService;
     this.passwordEncoder = passwordEncoder;
     this.tokenHasher = tokenHasher;
-    this.dummyHash = passwordEncoder.encode("dummy_password_for_timing_prevention");
+    this.dummyHash = passwordEncoder.encode(UUID.randomUUID().toString());
   }
 
   @Transactional(noRollbackFor = PasswordResetRequiredException.class)

--- a/backend/src/test/java/com/init/auth/application/AuthServiceTest.java
+++ b/backend/src/test/java/com/init/auth/application/AuthServiceTest.java
@@ -43,9 +43,7 @@ class AuthServiceTest {
 
   @BeforeEach
   void setUp() {
-    // dummyHash 생성을 위해 passwordEncoder.encode("dummy_password_for_timing_prevention") 스텁 필요
-    given(passwordEncoder.encode("dummy_password_for_timing_prevention"))
-        .willReturn("$2a$10$dummyhash");
+    given(passwordEncoder.encode(anyString())).willReturn("$2a$10$dummyhash");
     authService =
         new AuthService(
             userRepository, refreshTokenRepository, jwtService, passwordEncoder, tokenHasher);


### PR DESCRIPTION
Replaces the hardcoded string literal dummy_password_for_timing_prevention in AuthService constructor with UUID.randomUUID().toString() to resolve SonarQube java:S2068 VULNERABILITY (CWE-798/259) and unblock CI Quality Gate. Updates AuthServiceTest setUp stub from a fixed literal to anyString() matcher to accommodate the non-deterministic UUID input. Timing-attack prevention logic (AuthService.java:53) is fully preserved.
