### PR TITLE
fix: local profile port aligned to 8080

### DIFF
--- a/.agent/specs/162.md
+++ b/.agent/specs/162.md
@@ -1,0 +1,16 @@
+# Spec #162: local 프로필 포트 8080으로 정렬
+
+## Goal
+
+`application-local.yml`의 `server.port`를 8089에서 8080으로 변경하여, 기본 프로필(`application.yml` port 8080)과 일관성을 맞추고 Docker Compose, 프론트엔드 proxy, ML pipeline과의 포트 충돌을 해결한다.
+
+## 변경 범위
+
+- `backend/src/main/resources/application-local.yml`: `server.port` 8089 → 8080
+- `backend/build.gradle.kts`: `openApi.customBootRun`에 `--server.port=8089` 오버라이드 추가 (OpenAPI generation 전용 포트 분리 유지)
+
+## 검증
+
+- `./gradlew build` 통과
+- 로컬에서 `SPRING_PROFILES_ACTIVE=local ./gradlew bootRun` → 8080에서 기동
+- `./gradlew :generateOpenApiDocs` → 8089에서 forked 프로세스 기동, 성공

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -96,6 +96,6 @@ openApi {
     outputFileName.set("openapi.json")
     waitTimeInSeconds.set(60)
     customBootRun {
-        args.set(listOf("--spring.profiles.active=local"))
+        args.set(listOf("--spring.profiles.active=local", "--server.port=8089"))
     }
 }

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -12,7 +12,7 @@ spring:
     enabled: true
 
 server:
-  port: 8089
+  port: 8080
 
 logging:
   level:


### PR DESCRIPTION
## Summary
- `application-local.yml`에서 local profile 포트를 `8080`으로 변경 (기존 `8089` → `8080`)
- default profile(`application.yml`)과 동일한 포트로 통합

## Port 8080 Conflict Note
macOS에서 **AirPlay Receiver**가 port 8080을 이미 사용 중일 수 있습니다.
충돌 시 다음 중 하나를 선택하세요:
1. macOS Settings > General > AirDrop & Handoff > AirPlay Receiver 끄기
2. `application-local.yml`에서 다른 포트(예: 8081)로 변경

Closes #162
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ajou-2026-1-capstone-5/ostone/pull/165" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
