### PR TITLE
feat(domain-pack): implement domain pack summary page (FE-232)

### DIFF
--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -12,6 +12,7 @@ import { PolicyDraftReadPage } from '../pages/domain-pack/ui/PolicyDraftReadPage
 import { RiskDraftReadPage } from '../pages/domain-pack/ui/RiskDraftReadPage';
 import { SlotDraftReadPage } from '../pages/domain-pack/ui/SlotDraftReadPage';
 import { WorkflowDraftReadPage } from '../pages/domain-pack/ui/WorkflowDraftReadPage';
+import { DomainPackSummaryPage } from '../pages/domain-pack/ui/DomainPackSummaryPage';
 import { WorkspaceLayout } from '../pages/workspace/ui/WorkspaceLayout';
 import { WorkspaceUploadPage } from '../pages/workspace/ui/WorkspaceUploadPage';
 import { WorkspaceWorkflowsPage } from '../pages/workspace/ui/WorkspaceWorkflowsPage';
@@ -36,6 +37,7 @@ export function App() {
         </Route>
         <Route path="/upload" element={<PrivateRoute><UploadPage /></PrivateRoute>} />
         <Route path="/consultation" element={<PrivateRoute><ConsultationPage /></PrivateRoute>} />
+        <Route path="/workspaces/:workspaceId/domain-packs/:packId" element={<PrivateRoute><DomainPackSummaryPage /></PrivateRoute>} />
         <Route path="/workspaces/:workspaceId/domain-packs/:packId/versions/:versionId/intents/:intentId?" element={<PrivateRoute><IntentDraftReadPage /></PrivateRoute>} />
         <Route path="/workspaces/:workspaceId/domain-packs/:packId/versions/:versionId/policies/:policyId?" element={<PrivateRoute><PolicyDraftReadPage /></PrivateRoute>} />
         <Route path="/workspaces/:workspaceId/domain-packs/:packId/versions/:versionId/risks/:riskId?" element={<PrivateRoute><RiskDraftReadPage /></PrivateRoute>} />

--- a/frontend/src/app/index.css
+++ b/frontend/src/app/index.css
@@ -57,6 +57,8 @@
   --hover-border: rgba(0, 0, 0, 0.14);
   --divider-subtle: rgba(0, 0, 0, 0.04);
   --app-header-height: 72px;
+  --overlay-bg: rgba(0, 0, 0, 0.45);
+  --error-bg-subtle: rgba(180, 35, 24, 0.06);
 }
 
 * {

--- a/frontend/src/app/index.css
+++ b/frontend/src/app/index.css
@@ -16,6 +16,9 @@
 :root {
   --font-sans: 'pretendard variable', -apple-system, blinkmacsystemfont, 'Segoe UI', sans-serif;
   --font-mono: 'Geist Mono', monospace;
+  --font-size-xs: 11px;
+  --font-size-sm: 13px;
+  --font-size-base: 15px;
   --font-size-label: 12px;
   --font-size-heading-lg: 40px;
   --font-size-body-lg: 18px;
@@ -58,7 +61,6 @@
   --divider-subtle: rgba(0, 0, 0, 0.04);
   --app-header-height: 72px;
   --overlay-bg: rgba(0, 0, 0, 0.45);
-  --error-bg-subtle: rgba(180, 35, 24, 0.06);
 }
 
 * {

--- a/frontend/src/entities/domain-pack/api/index.test.ts
+++ b/frontend/src/entities/domain-pack/api/index.test.ts
@@ -25,4 +25,28 @@ describe("domainPackApi", () => {
       expect.objectContaining({ method: "GET" }),
     );
   });
+
+  it("fetches domain pack detail by wsId and packId", async () => {
+    const response = { packId: 2, workspaceId: 1, code: "CS", name: "고객지원", versions: [] };
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 200, json: async () => response });
+
+    await expect(domainPackApi.detail(1, 2)).resolves.toEqual(response);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/v1/workspaces/1/domain-packs/2",
+      expect.objectContaining({ method: "GET" }),
+    );
+  });
+
+  it("fetches domain pack version detail by wsId, packId and versionId", async () => {
+    const response = { versionId: 3, packId: 2, versionNo: 1, lifecycleStatus: "DRAFT" };
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 200, json: async () => response });
+
+    await expect(domainPackApi.versionDetail(1, 2, 3)).resolves.toEqual(response);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/v1/workspaces/1/domain-packs/2/versions/3",
+      expect.objectContaining({ method: "GET" }),
+    );
+  });
 });

--- a/frontend/src/entities/domain-pack/api/index.ts
+++ b/frontend/src/entities/domain-pack/api/index.ts
@@ -1,12 +1,30 @@
 import { apiClient } from "@/shared/api";
 
-import type { DomainPackDraftEntryResponse } from "../model/types";
+import type { DomainPackDraftEntryResponse, DomainPackDetail, DomainPackVersionDetail } from "../model/types";
 
 export const DOMAIN_PACK_DRAFT_ENTRY_NOT_FOUND = "DOMAIN_PACK_DRAFT_ENTRY_NOT_FOUND";
+
+export const domainPackKeys = {
+  all: ['domain-packs'] as const,
+  detail: (wsId: number, packId: number) =>
+    [...domainPackKeys.all, 'detail', wsId, packId] as const,
+  versionDetail: (wsId: number, packId: number, versionId: number) =>
+    [...domainPackKeys.all, 'version-detail', wsId, packId, versionId] as const,
+};
 
 export const domainPackApi = {
   getDraftEntry: (workspaceId: number) =>
     apiClient.get<DomainPackDraftEntryResponse>(
       `/workspaces/${workspaceId}/domain-packs/draft-entry`,
+    ),
+
+  detail: (wsId: number, packId: number) =>
+    apiClient.get<DomainPackDetail>(
+      `/workspaces/${wsId}/domain-packs/${packId}`,
+    ),
+
+  versionDetail: (wsId: number, packId: number, versionId: number) =>
+    apiClient.get<DomainPackVersionDetail>(
+      `/workspaces/${wsId}/domain-packs/${packId}/versions/${versionId}`,
     ),
 };

--- a/frontend/src/entities/domain-pack/index.ts
+++ b/frontend/src/entities/domain-pack/index.ts
@@ -1,2 +1,3 @@
-export { DOMAIN_PACK_DRAFT_ENTRY_NOT_FOUND, domainPackApi } from "./api";
-export type { DomainPackDraftEntryResponse } from "./model/types";
+export { DOMAIN_PACK_DRAFT_ENTRY_NOT_FOUND, domainPackApi, domainPackKeys } from "./api";
+export type { DomainPackDraftEntryResponse, DomainPackDetail, DomainPackVersionSummary, DomainPackVersionDetail, DomainPackLifecycleStatus } from "./model/types";
+export type { CreateDomainPackDraftRequest, CreateDomainPackDraftResponse } from "./model/createDraft";

--- a/frontend/src/entities/domain-pack/model/createDraft.ts
+++ b/frontend/src/entities/domain-pack/model/createDraft.ts
@@ -1,3 +1,5 @@
+import type { DomainPackLifecycleStatus } from './types';
+
 export interface IntentSlotBindingRequest {
   intentCode: string;
   slotCode: string;
@@ -24,7 +26,7 @@ export interface CreateDomainPackDraftResponse {
   versionId: number;
   domainPackId: number;
   versionNo: number;
-  lifecycleStatus: string;
+  lifecycleStatus: DomainPackLifecycleStatus;
   sourcePipelineJobId: number | null;
   intentCount: number;
   slotCount: number;

--- a/frontend/src/entities/domain-pack/model/createDraft.ts
+++ b/frontend/src/entities/domain-pack/model/createDraft.ts
@@ -1,0 +1,35 @@
+export interface IntentSlotBindingRequest {
+  intentCode: string;
+  slotCode: string;
+}
+
+export interface IntentWorkflowBindingRequest {
+  intentCode: string;
+  workflowCode: string;
+}
+
+export interface CreateDomainPackDraftRequest {
+  summaryJson?: string | null;
+  intents?: unknown[];
+  slots?: unknown[];
+  policies?: unknown[];
+  risks?: unknown[];
+  workflows?: unknown[];
+  intentSlotBindings?: IntentSlotBindingRequest[];
+  intentWorkflowBindings?: IntentWorkflowBindingRequest[];
+  sourcePipelineJobId?: number | null;
+}
+
+export interface CreateDomainPackDraftResponse {
+  versionId: number;
+  domainPackId: number;
+  versionNo: number;
+  lifecycleStatus: string;
+  sourcePipelineJobId: number | null;
+  intentCount: number;
+  slotCount: number;
+  policyCount: number;
+  riskCount: number;
+  workflowCount: number;
+  createdAt: string;
+}

--- a/frontend/src/entities/domain-pack/model/types.ts
+++ b/frontend/src/entities/domain-pack/model/types.ts
@@ -5,3 +5,41 @@ export interface DomainPackDraftEntryResponse {
   packName: string;
   versionNo: number;
 }
+
+export type DomainPackLifecycleStatus = 'DRAFT' | 'PUBLISHED';
+
+export interface DomainPackVersionSummary {
+  versionId: number;
+  versionNo: number;
+  lifecycleStatus: DomainPackLifecycleStatus;
+  sourcePipelineJobId: number | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface DomainPackDetail {
+  packId: number;
+  workspaceId: number;
+  code: string;
+  name: string;
+  description: string | null;
+  versions: DomainPackVersionSummary[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface DomainPackVersionDetail {
+  versionId: number;
+  packId: number;
+  versionNo: number;
+  lifecycleStatus: DomainPackLifecycleStatus;
+  sourcePipelineJobId: number | null;
+  summaryJson: string;
+  intentCount: number;
+  slotCount: number;
+  policyCount: number;
+  riskCount: number;
+  workflowCount: number;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/frontend/src/entities/intent/api/index.ts
+++ b/frontend/src/entities/intent/api/index.ts
@@ -1,0 +1,15 @@
+import { apiClient } from "@/shared/api";
+import type { IntentSummary } from "../model/types";
+
+export const intentKeys = {
+  all: ['intents'] as const,
+  list: (wsId: number, packId: number, versionId: number) =>
+    [...intentKeys.all, 'list', wsId, packId, versionId] as const,
+};
+
+export const intentApi = {
+  list: (wsId: number, packId: number, versionId: number) =>
+    apiClient.get<IntentSummary[]>(
+      `/workspaces/${wsId}/domain-packs/${packId}/versions/${versionId}/intents`,
+    ),
+};

--- a/frontend/src/entities/intent/index.ts
+++ b/frontend/src/entities/intent/index.ts
@@ -1,1 +1,2 @@
 export type { IntentDetail, IntentSummary, IntentTreeNode } from "./model/types";
+export { intentApi, intentKeys } from "./api/index";

--- a/frontend/src/entities/workflow/api/index.ts
+++ b/frontend/src/entities/workflow/api/index.ts
@@ -1,5 +1,5 @@
 import { apiClient } from "@/shared/api";
-import type { WorkflowDetail, UpdateWorkflowRequest } from "../model/types";
+import type { WorkflowDetail, WorkflowSummary, UpdateWorkflowRequest } from "../model/types";
 
 export const workflowQueryKeys = {
   all: ["workflows"] as const,
@@ -30,6 +30,12 @@ export function fetchWorkflow(
 ) {
   return apiClient.get<WorkflowDetail>(
     `/workspaces/${wsId}/domain-packs/${packId}/versions/${versionId}/workflows/${workflowId}`,
+  );
+}
+
+export function fetchWorkflowList(wsId: number, packId: number, versionId: number) {
+  return apiClient.get<WorkflowSummary[]>(
+    `/workspaces/${wsId}/domain-packs/${packId}/versions/${versionId}/workflows`,
   );
 }
 

--- a/frontend/src/entities/workflow/index.ts
+++ b/frontend/src/entities/workflow/index.ts
@@ -8,6 +8,6 @@ export type {
   UpdateWorkflowRequest,
 } from "./model/types";
 
-export { workflowQueryKeys, fetchWorkflow, patchWorkflow } from "./api";
+export { workflowQueryKeys, fetchWorkflow, fetchWorkflowList, patchWorkflow } from "./api";
 
 export { toFlow, convertFlowToWorkflowGraph } from "./lib/graphConverter";

--- a/frontend/src/features/domain-pack-draft-create/api/createDraftApi.ts
+++ b/frontend/src/features/domain-pack-draft-create/api/createDraftApi.ts
@@ -1,0 +1,10 @@
+import { apiClient } from '@/shared/api';
+import type { CreateDomainPackDraftRequest, CreateDomainPackDraftResponse } from '@/entities/domain-pack';
+
+export const createDraftApi = {
+  create: (wsId: number, packId: number, payload: CreateDomainPackDraftRequest) =>
+    apiClient.post<CreateDomainPackDraftResponse>(
+      `/workspaces/${wsId}/domain-packs/${packId}/versions/drafts`,
+      payload,
+    ),
+};

--- a/frontend/src/features/domain-pack-draft-create/index.ts
+++ b/frontend/src/features/domain-pack-draft-create/index.ts
@@ -1,0 +1,2 @@
+export { CreateDraftModal } from './ui';
+export { useCreateDraft } from './model/useCreateDraft';

--- a/frontend/src/features/domain-pack-draft-create/model/useCreateDraft.test.tsx
+++ b/frontend/src/features/domain-pack-draft-create/model/useCreateDraft.test.tsx
@@ -1,0 +1,103 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { toast } from 'sonner';
+import { ApiRequestError } from '@/shared/api';
+import { createDraftApi } from '../api/createDraftApi';
+import { useCreateDraft } from './useCreateDraft';
+
+vi.mock('../api/createDraftApi', () => ({
+  createDraftApi: { create: vi.fn() },
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@/entities/domain-pack', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@/entities/domain-pack')>();
+  return {
+    ...original,
+    domainPackKeys: {
+      ...original.domainPackKeys,
+      detail: (wsId: number, packId: number) => ['domain-packs', 'detail', wsId, packId],
+    },
+  };
+});
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { mutations: { retry: false } },
+  });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+const stubResponse = {
+  versionId: 10,
+  domainPackId: 2,
+  versionNo: 2,
+  lifecycleStatus: 'DRAFT' as const,
+  sourcePipelineJobId: null,
+  intentCount: 0,
+  slotCount: 0,
+  policyCount: 0,
+  riskCount: 0,
+  workflowCount: 0,
+  createdAt: '',
+};
+
+const mutateParams = { wsId: 1, packId: 2, payload: {} };
+
+describe('useCreateDraft', () => {
+  beforeEach(() => {
+    vi.mocked(createDraftApi.create).mockReset();
+    vi.mocked(toast.success).mockReset();
+    vi.mocked(toast.error).mockReset();
+  });
+
+  it('201 성공 시 toast.success를 호출한다', async () => {
+    vi.mocked(createDraftApi.create).mockResolvedValue(stubResponse);
+    const { result } = renderHook(() => useCreateDraft(), { wrapper });
+    result.current.mutate(mutateParams);
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith('새 DRAFT 버전이 생성되었습니다.'));
+  });
+
+  it('403 에러 시 "접근 권한 없음" toast.error를 호출한다', async () => {
+    vi.mocked(createDraftApi.create).mockRejectedValue(
+      new ApiRequestError(403, 'FORBIDDEN', 'forbidden'),
+    );
+    const { result } = renderHook(() => useCreateDraft(), { wrapper });
+    result.current.mutate(mutateParams);
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('접근 권한 없음'));
+  });
+
+  it('409 에러 시 toast를 호출하지 않는다', async () => {
+    vi.mocked(createDraftApi.create).mockRejectedValue(
+      new ApiRequestError(409, 'CONFLICT', 'conflict'),
+    );
+    const { result } = renderHook(() => useCreateDraft(), { wrapper });
+    result.current.mutate(mutateParams);
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it('400 에러 시 "DRAFT 생성에 실패했습니다." toast.error를 호출한다', async () => {
+    vi.mocked(createDraftApi.create).mockRejectedValue(
+      new ApiRequestError(400, 'BAD_REQUEST', '잘못된 요청'),
+    );
+    const { result } = renderHook(() => useCreateDraft(), { wrapper });
+    result.current.mutate(mutateParams);
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith('DRAFT 생성에 실패했습니다.'),
+    );
+  });
+
+  it('비 ApiRequestError 에러 시 "DRAFT 생성에 실패했습니다." toast.error를 호출한다', async () => {
+    vi.mocked(createDraftApi.create).mockRejectedValue(new Error('network error'));
+    const { result } = renderHook(() => useCreateDraft(), { wrapper });
+    result.current.mutate(mutateParams);
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith('DRAFT 생성에 실패했습니다.'),
+    );
+  });
+});

--- a/frontend/src/features/domain-pack-draft-create/model/useCreateDraft.ts
+++ b/frontend/src/features/domain-pack-draft-create/model/useCreateDraft.ts
@@ -1,0 +1,37 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { domainPackKeys } from '@/entities/domain-pack';
+import { ApiRequestError } from '@/shared/api';
+import type { CreateDomainPackDraftRequest } from '@/entities/domain-pack';
+import { createDraftApi } from '../api/createDraftApi';
+
+interface CreateDraftParams {
+  wsId: number;
+  packId: number;
+  payload: CreateDomainPackDraftRequest;
+}
+
+export function useCreateDraft() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ wsId, packId, payload }: CreateDraftParams) =>
+      createDraftApi.create(wsId, packId, payload),
+    onSuccess: (_data, { wsId, packId }) => {
+      queryClient.invalidateQueries({ queryKey: domainPackKeys.detail(wsId, packId) });
+      toast.success('새 DRAFT 버전이 생성되었습니다.');
+    },
+    onError: (error: unknown) => {
+      if (error instanceof ApiRequestError) {
+        if (error.status === 403) {
+          toast.error('접근 권한 없음');
+        } else if (error.status === 409) {
+          // 409는 caller(모달)의 per-call onError에서 처리. toast 없음.
+        } else {
+          toast.error('DRAFT 생성에 실패했습니다.');
+        }
+      } else {
+        toast.error('DRAFT 생성에 실패했습니다.');
+      }
+    },
+  });
+}

--- a/frontend/src/features/domain-pack-draft-create/ui/CreateDraftModal.module.css
+++ b/frontend/src/features/domain-pack-draft-create/ui/CreateDraftModal.module.css
@@ -1,0 +1,202 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: var(--overlay-bg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+  padding: 16px;
+}
+
+.dialog {
+  background: var(--bg-color);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-card-hover);
+  width: 100%;
+  max-width: 560px;
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.header {
+  padding: 18px 20px 14px;
+  border-bottom: 1px solid var(--glass-border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.title {
+  font-size: 15px;
+  font-weight: var(--font-weight-heading);
+  color: var(--text-primary);
+}
+
+.closeBtn {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--text-muted);
+  font-size: 18px;
+  line-height: 1;
+  padding: 2px 6px;
+  border-radius: var(--radius-sm);
+  transition: color var(--transition-fast);
+}
+
+.closeBtn:hover {
+  color: var(--text-primary);
+}
+
+.tabBar {
+  display: flex;
+  border-bottom: 1px solid var(--glass-border);
+}
+
+.tab {
+  flex: 1;
+  padding: 10px;
+  background: transparent;
+  border: none;
+  font-size: 13px;
+  font-weight: var(--font-weight-base);
+  color: var(--text-muted);
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  transition: color var(--transition-fast), border-color var(--transition-fast);
+}
+
+.tab.active {
+  color: var(--text-primary);
+  border-bottom-color: var(--text-primary);
+  font-weight: var(--font-weight-heading);
+}
+
+.tab:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.label {
+  font-size: 12px;
+  font-weight: var(--font-weight-heading);
+  color: var(--text-secondary);
+  margin-bottom: 4px;
+  display: block;
+}
+
+.textarea {
+  width: 100%;
+  min-height: 200px;
+  padding: 10px 12px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-md);
+  background: var(--bg-color);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-primary);
+  resize: vertical;
+  transition: border-color var(--transition-fast);
+}
+
+.textarea:focus {
+  border-color: var(--text-primary);
+}
+
+.fileUploadHint {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.fileInput {
+  display: none;
+}
+
+.fileLabel {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 5px 10px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-md);
+  font-size: 11px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.fileLabel:hover {
+  background: var(--hover-bg);
+}
+
+.disabledTab {
+  padding: 24px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.inlineError {
+  font-size: 12px;
+  color: var(--error-color);
+  background: var(--error-bg-subtle);
+  border-radius: var(--radius-md);
+  padding: 8px 12px;
+}
+
+.footer {
+  padding: 14px 20px;
+  border-top: 1px solid var(--glass-border);
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.cancelBtn {
+  padding: 7px 16px;
+  background: transparent;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-md);
+  font-size: 13px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.cancelBtn:hover {
+  background: var(--hover-bg);
+}
+
+.submitBtn {
+  padding: 7px 16px;
+  background: var(--text-primary);
+  border: none;
+  border-radius: var(--radius-md);
+  font-size: 13px;
+  font-weight: var(--font-weight-heading);
+  color: var(--bg-color);
+  cursor: pointer;
+  transition: opacity var(--transition-fast);
+}
+
+.submitBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.submitBtn:not(:disabled):hover {
+  opacity: 0.85;
+}

--- a/frontend/src/features/domain-pack-draft-create/ui/CreateDraftModal.module.css
+++ b/frontend/src/features/domain-pack-draft-create/ui/CreateDraftModal.module.css
@@ -169,7 +169,7 @@
   padding: 7px 16px;
   background: transparent;
   border: 1px solid var(--glass-border);
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-xl);
   font-size: 13px;
   color: var(--text-secondary);
   cursor: pointer;
@@ -184,7 +184,7 @@
   padding: 7px 16px;
   background: var(--text-primary);
   border: none;
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-xl);
   font-size: 13px;
   font-weight: var(--font-weight-heading);
   color: var(--bg-color);

--- a/frontend/src/features/domain-pack-draft-create/ui/CreateDraftModal.module.css
+++ b/frontend/src/features/domain-pack-draft-create/ui/CreateDraftModal.module.css
@@ -31,7 +31,7 @@
 }
 
 .title {
-  font-size: 15px;
+  font-size: var(--font-size-base);
   font-weight: var(--font-weight-heading);
   color: var(--text-primary);
 }
@@ -41,7 +41,7 @@
   border: none;
   cursor: pointer;
   color: var(--text-muted);
-  font-size: 18px;
+  font-size: var(--font-size-body-lg);
   line-height: 1;
   padding: 2px 6px;
   border-radius: var(--radius-sm);
@@ -62,7 +62,7 @@
   padding: 10px;
   background: transparent;
   border: none;
-  font-size: 13px;
+  font-size: var(--font-size-sm);
   font-weight: var(--font-weight-base);
   color: var(--text-muted);
   cursor: pointer;
@@ -91,7 +91,7 @@
 }
 
 .label {
-  font-size: 12px;
+  font-size: var(--font-size-label);
   font-weight: var(--font-weight-heading);
   color: var(--text-secondary);
   margin-bottom: 4px;
@@ -106,7 +106,7 @@
   border-radius: var(--radius-md);
   background: var(--bg-color);
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--font-size-label);
   color: var(--text-primary);
   resize: vertical;
   transition: border-color var(--transition-fast);
@@ -117,7 +117,7 @@
 }
 
 .fileUploadHint {
-  font-size: 11px;
+  font-size: var(--font-size-xs);
   color: var(--text-muted);
 }
 
@@ -132,7 +132,7 @@
   padding: 5px 10px;
   border: 1px solid var(--glass-border);
   border-radius: var(--radius-md);
-  font-size: 11px;
+  font-size: var(--font-size-xs);
   color: var(--text-secondary);
   cursor: pointer;
   transition: background var(--transition-fast);
@@ -146,13 +146,12 @@
   padding: 24px;
   text-align: center;
   color: var(--text-muted);
-  font-size: 13px;
+  font-size: var(--font-size-sm);
 }
 
 .inlineError {
-  font-size: 12px;
+  font-size: var(--font-size-label);
   color: var(--error-color);
-  background: var(--error-bg-subtle);
   border-radius: var(--radius-md);
   padding: 8px 12px;
 }
@@ -170,7 +169,7 @@
   background: transparent;
   border: 1px solid var(--glass-border);
   border-radius: var(--radius-xl);
-  font-size: 13px;
+  font-size: var(--font-size-sm);
   color: var(--text-secondary);
   cursor: pointer;
   transition: background var(--transition-fast);
@@ -185,7 +184,7 @@
   background: var(--text-primary);
   border: none;
   border-radius: var(--radius-xl);
-  font-size: 13px;
+  font-size: var(--font-size-sm);
   font-weight: var(--font-weight-heading);
   color: var(--bg-color);
   cursor: pointer;

--- a/frontend/src/features/domain-pack-draft-create/ui/CreateDraftModal.test.tsx
+++ b/frontend/src/features/domain-pack-draft-create/ui/CreateDraftModal.test.tsx
@@ -1,0 +1,115 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ApiRequestError } from '@/shared/api';
+import { useCreateDraft } from '../model/useCreateDraft';
+import { CreateDraftModal } from './CreateDraftModal';
+
+vi.mock('../model/useCreateDraft', () => ({
+  useCreateDraft: vi.fn(),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+const mockedUseCreateDraft = vi.mocked(useCreateDraft);
+
+function makeMutation(overrides: Record<string, unknown> = {}) {
+  return {
+    isPending: false,
+    isError: false,
+    mutate: vi.fn(),
+    ...overrides,
+  } as unknown as ReturnType<typeof useCreateDraft>;
+}
+
+function renderModal(props: Partial<React.ComponentProps<typeof CreateDraftModal>> = {}) {
+  const defaults = {
+    wsId: 1,
+    packId: 2,
+    onClose: vi.fn(),
+    onSuccess: vi.fn(),
+  };
+  render(<CreateDraftModal {...defaults} {...props} />);
+  return defaults;
+}
+
+describe('CreateDraftModal', () => {
+  beforeEach(() => {
+    mockedUseCreateDraft.mockReset();
+    mockedUseCreateDraft.mockReturnValue(makeMutation());
+    // jsdom does not implement showModal — simulate by setting the open attribute
+    HTMLDialogElement.prototype.showModal = function(this: HTMLDialogElement) {
+      this.setAttribute('open', '');
+    };
+  });
+
+  afterEach(() => {
+    delete (HTMLDialogElement.prototype as { showModal?: unknown }).showModal;
+  });
+
+  it('모달 제목과 textarea를 렌더링한다', () => {
+    renderModal();
+    expect(screen.getByText('새 DRAFT 묶기')).toBeInTheDocument();
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+  });
+
+  it('취소 버튼 클릭 시 onClose를 호출한다', () => {
+    const onClose = vi.fn();
+    renderModal({ onClose });
+    fireEvent.click(screen.getByRole('button', { name: '취소' }));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('닫기(✕) 버튼 클릭 시 onClose를 호출한다', () => {
+    const onClose = vi.fn();
+    renderModal({ onClose });
+    fireEvent.click(screen.getByRole('button', { name: '닫기' }));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('유효하지 않은 JSON 제출 시 인라인 에러를 표시한다', () => {
+    renderModal();
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: '{bad}' } });
+    fireEvent.click(screen.getByRole('button', { name: '묶기' }));
+    expect(screen.getByRole('alert')).toHaveTextContent('유효하지 않은 JSON입니다');
+  });
+
+  it('409 에러 응답 시 인라인 에러 "동일 Pack 묶기 충돌"을 표시한다', async () => {
+    const mutate = vi.fn(
+      (_params: unknown, callbacks: { onError: (e: unknown) => void }) => {
+        callbacks.onError(new ApiRequestError(409, 'CONFLICT', 'conflict'));
+      },
+    );
+    mockedUseCreateDraft.mockReturnValue(makeMutation({ mutate }));
+    renderModal();
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: '{}' } });
+    fireEvent.click(screen.getByRole('button', { name: '묶기' }));
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent('동일 Pack 묶기 충돌'),
+    );
+  });
+
+  it('400 에러 응답 시 인라인 에러 "요청 검증 실패"를 표시한다', async () => {
+    const mutate = vi.fn(
+      (_params: unknown, callbacks: { onError: (e: unknown) => void }) => {
+        callbacks.onError(
+          new ApiRequestError(400, 'BAD_REQUEST', '요청 검증 실패. 입력을 확인해 주세요.'),
+        );
+      },
+    );
+    mockedUseCreateDraft.mockReturnValue(makeMutation({ mutate }));
+    renderModal();
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: '{}' } });
+    fireEvent.click(screen.getByRole('button', { name: '묶기' }));
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent('요청 검증 실패'),
+    );
+  });
+
+  it('isPending 상태에서 묶기 버튼이 비활성화된다', () => {
+    mockedUseCreateDraft.mockReturnValue(makeMutation({ isPending: true }));
+    renderModal();
+    expect(screen.getByRole('button', { name: '생성 중...' })).toBeDisabled();
+  });
+});

--- a/frontend/src/features/domain-pack-draft-create/ui/CreateDraftModal.test.tsx
+++ b/frontend/src/features/domain-pack-draft-create/ui/CreateDraftModal.test.tsx
@@ -112,4 +112,32 @@ describe('CreateDraftModal', () => {
     renderModal();
     expect(screen.getByRole('button', { name: '생성 중...' })).toBeDisabled();
   });
+
+  it('FileReader onerror 발화 시 인라인 에러를 표시한다', async () => {
+    renderModal();
+    const file = new File([''], 'test.json', { type: 'application/json' });
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+
+    let capturedReader: FileReader | null = null;
+    const OriginalFileReader = globalThis.FileReader;
+    globalThis.FileReader = class extends OriginalFileReader {
+      constructor() {
+        super();
+        capturedReader = this;
+      }
+    } as typeof FileReader;
+
+    fireEvent.change(input, { target: { files: [file] } });
+
+    globalThis.FileReader = OriginalFileReader;
+
+    if (capturedReader) {
+      Object.defineProperty(capturedReader, 'error', { value: new DOMException('read error') });
+      (capturedReader as FileReader).dispatchEvent(new ProgressEvent('error'));
+    }
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent('파일을 읽는 중 오류가 발생했습니다.'),
+    );
+  });
 });

--- a/frontend/src/features/domain-pack-draft-create/ui/CreateDraftModal.tsx
+++ b/frontend/src/features/domain-pack-draft-create/ui/CreateDraftModal.tsx
@@ -33,6 +33,9 @@ export function CreateDraftModal({ wsId, packId, onClose, onSuccess }: CreateDra
     reader.onload = (ev) => {
       setJsonText((ev.target?.result as string) ?? '');
     };
+    reader.onerror = () => {
+      setInlineError('파일을 읽는 중 오류가 발생했습니다.');
+    };
     reader.readAsText(file);
   };
 
@@ -70,7 +73,9 @@ export function CreateDraftModal({ wsId, packId, onClose, onSuccess }: CreateDra
   return (
     <div
       className={styles.overlay}
+      role="presentation"
       onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+      onKeyDown={(e) => { if (e.key === 'Escape') onClose(); }}
     >
       <dialog
         ref={dialogRef}

--- a/frontend/src/features/domain-pack-draft-create/ui/CreateDraftModal.tsx
+++ b/frontend/src/features/domain-pack-draft-create/ui/CreateDraftModal.tsx
@@ -19,8 +19,10 @@ export function CreateDraftModal({ wsId, packId, onClose, onSuccess }: CreateDra
   const [jsonText, setJsonText] = useState('');
   const [inlineError, setInlineError] = useState<string | null>(null);
   const firstInputRef = useRef<HTMLTextAreaElement>(null);
+  const dialogRef = useRef<HTMLDialogElement>(null);
 
   useEffect(() => {
+    dialogRef.current?.showModal();
     firstInputRef.current?.focus();
   }, []);
 
@@ -79,11 +81,12 @@ export function CreateDraftModal({ wsId, packId, onClose, onSuccess }: CreateDra
       onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
     >
       <dialog
+        ref={dialogRef}
         className={styles.dialog}
-        open
         role="dialog"
         aria-modal="true"
         aria-labelledby="create-draft-title"
+        onCancel={(e) => { e.preventDefault(); onClose(); }}
       >
         <div className={styles.header}>
           <span id="create-draft-title" className={styles.title}>새 DRAFT 묶기</span>

--- a/frontend/src/features/domain-pack-draft-create/ui/CreateDraftModal.tsx
+++ b/frontend/src/features/domain-pack-draft-create/ui/CreateDraftModal.tsx
@@ -1,0 +1,175 @@
+import { useState, useEffect, useRef } from 'react';
+import { ApiRequestError } from '@/shared/api';
+import type { CreateDomainPackDraftRequest } from '@/entities/domain-pack';
+import { useCreateDraft } from '../model/useCreateDraft';
+import styles from './CreateDraftModal.module.css';
+
+interface CreateDraftModalProps {
+  wsId: number;
+  packId: number;
+  onClose: () => void;
+  onSuccess: (newVersionId: number) => void;
+}
+
+type InputTab = 'paste' | 'pipeline';
+
+export function CreateDraftModal({ wsId, packId, onClose, onSuccess }: CreateDraftModalProps) {
+  const mutation = useCreateDraft();
+  const [activeTab, setActiveTab] = useState<InputTab>('paste');
+  const [jsonText, setJsonText] = useState('');
+  const [inlineError, setInlineError] = useState<string | null>(null);
+  const firstInputRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    firstInputRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+      setJsonText((ev.target?.result as string) ?? '');
+    };
+    reader.readAsText(file);
+  };
+
+  const handleSubmit = () => {
+    setInlineError(null);
+
+    let payload: CreateDomainPackDraftRequest;
+    try {
+      const parsed = JSON.parse(jsonText || '{}') as CreateDomainPackDraftRequest;
+      payload = parsed;
+    } catch {
+      setInlineError('유효하지 않은 JSON입니다. 내용을 확인해 주세요.');
+      return;
+    }
+
+    mutation.mutate(
+      { wsId, packId, payload },
+      {
+        onSuccess: (data) => {
+          onSuccess(data.versionId);
+        },
+        onError: (error: unknown) => {
+          if (error instanceof ApiRequestError) {
+            if (error.status === 409) {
+              setInlineError('동일 Pack 묶기 충돌. 잠시 후 재시도하세요.');
+            } else if (error.status === 400) {
+              setInlineError(error.message || '요청 검증 실패. 입력을 확인해 주세요.');
+            }
+          }
+        },
+      },
+    );
+  };
+
+  return (
+    <div
+      className={styles.overlay}
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <dialog
+        className={styles.dialog}
+        open
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="create-draft-title"
+      >
+        <div className={styles.header}>
+          <span id="create-draft-title" className={styles.title}>새 DRAFT 묶기</span>
+          <button type="button" className={styles.closeBtn} onClick={onClose} aria-label="닫기">
+            ✕
+          </button>
+        </div>
+
+        <div className={styles.tabBar} role="tablist">
+          <button
+            type="button"
+            role="tab"
+            aria-selected={activeTab === 'paste'}
+            className={`${styles.tab} ${activeTab === 'paste' ? styles.active : ''}`}
+            onClick={() => setActiveTab('paste')}
+          >
+            직접 입력
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={activeTab === 'pipeline'}
+            className={`${styles.tab} ${activeTab === 'pipeline' ? styles.active : ''}`}
+            onClick={() => setActiveTab('pipeline')}
+            title="파이프라인 import 기능 준비 중"
+          >
+            파이프라인 import
+          </button>
+        </div>
+
+        <div className={styles.body}>
+          {activeTab === 'paste' ? (
+            <>
+              <div>
+                <label className={styles.label} htmlFor="draft-json-input">
+                  페이로드 JSON
+                </label>
+                <textarea
+                  id="draft-json-input"
+                  ref={firstInputRef}
+                  className={styles.textarea}
+                  value={jsonText}
+                  onChange={(e) => setJsonText(e.target.value)}
+                  placeholder={'{\n  "summaryJson": "{}",\n  "intents": [],\n  ...\n}'}
+                  spellCheck={false}
+                />
+              </div>
+              <div>
+                <label className={styles.fileLabel}>
+                  JSON 파일 업로드
+                  <input
+                    type="file"
+                    accept=".json"
+                    className={styles.fileInput}
+                    onChange={handleFileChange}
+                  />
+                </label>
+                <span className={styles.fileUploadHint}> — 파일 내용이 위 입력란에 채워집니다.</span>
+              </div>
+            </>
+          ) : (
+            <div className={styles.disabledTab} role="tabpanel">
+              파이프라인 import 기능은 준비 중입니다.<br />
+              Backend 엔드포인트 추가 후 활성화됩니다.
+            </div>
+          )}
+
+          {inlineError && (
+            <p className={styles.inlineError} role="alert">{inlineError}</p>
+          )}
+        </div>
+
+        <div className={styles.footer}>
+          <button type="button" className={styles.cancelBtn} onClick={onClose}>
+            취소
+          </button>
+          <button
+            type="button"
+            className={styles.submitBtn}
+            onClick={handleSubmit}
+            disabled={mutation.isPending || activeTab === 'pipeline'}
+          >
+            {mutation.isPending ? '생성 중...' : '묶기'}
+          </button>
+        </div>
+      </dialog>
+    </div>
+  );
+}

--- a/frontend/src/features/domain-pack-draft-create/ui/CreateDraftModal.tsx
+++ b/frontend/src/features/domain-pack-draft-create/ui/CreateDraftModal.tsx
@@ -26,14 +26,6 @@ export function CreateDraftModal({ wsId, packId, onClose, onSuccess }: CreateDra
     firstInputRef.current?.focus();
   }, []);
 
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
-    };
-    document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [onClose]);
-
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;

--- a/frontend/src/features/domain-pack-draft-create/ui/index.ts
+++ b/frontend/src/features/domain-pack-draft-create/ui/index.ts
@@ -1,0 +1,1 @@
+export { CreateDraftModal } from './CreateDraftModal';

--- a/frontend/src/features/domain-pack-summary-read/index.ts
+++ b/frontend/src/features/domain-pack-summary-read/index.ts
@@ -1,0 +1,10 @@
+export { usePackDetail, useVersionDetail, parseSummaryJson } from './model';
+export type { ParsedSummary } from './model';
+export {
+  useIntentPreview,
+  useSlotPreview,
+  usePolicyPreview,
+  useRiskPreview,
+  useWorkflowPreview,
+} from './model';
+export { VersionListPanel, SummaryDetailPanel, SummaryJsonCard, ComponentCountGrid } from './ui';

--- a/frontend/src/features/domain-pack-summary-read/model/index.ts
+++ b/frontend/src/features/domain-pack-summary-read/model/index.ts
@@ -1,0 +1,11 @@
+export { usePackDetail } from './usePackDetail';
+export { useVersionDetail } from './useVersionDetail';
+export { parseSummaryJson } from './parseSummaryJson';
+export type { ParsedSummary } from './parseSummaryJson';
+export {
+  useIntentPreview,
+  useSlotPreview,
+  usePolicyPreview,
+  useRiskPreview,
+  useWorkflowPreview,
+} from './usePreviewLists';

--- a/frontend/src/features/domain-pack-summary-read/model/parseSummaryJson.test.ts
+++ b/frontend/src/features/domain-pack-summary-read/model/parseSummaryJson.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { parseSummaryJson } from './parseSummaryJson';
+
+describe('parseSummaryJson', () => {
+  it('정상 JSON 객체를 파싱하면 ok:true와 data를 반환한다', () => {
+    const result = parseSummaryJson('{"intent": "greeting"}');
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.data).toEqual({ intent: 'greeting' });
+  });
+
+  it('빈 객체는 ok:true를 반환한다', () => {
+    const result = parseSummaryJson('{}');
+    expect(result.ok).toBe(true);
+  });
+
+  it('JSON 배열은 ok:false와 raw 원문을 반환한다', () => {
+    const result = parseSummaryJson('[1,2]');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.raw).toBe('[1,2]');
+  });
+
+  it('null JSON은 ok:false를 반환한다', () => {
+    const result = parseSummaryJson('null');
+    expect(result.ok).toBe(false);
+  });
+
+  it('손상된 JSON은 ok:false와 raw 원문을 반환한다', () => {
+    const bad = '{bad}';
+    const result = parseSummaryJson(bad);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.raw).toBe(bad);
+  });
+
+  it('빈 문자열은 ok:false를 반환한다', () => {
+    expect(parseSummaryJson('').ok).toBe(false);
+  });
+});

--- a/frontend/src/features/domain-pack-summary-read/model/parseSummaryJson.ts
+++ b/frontend/src/features/domain-pack-summary-read/model/parseSummaryJson.ts
@@ -8,10 +8,8 @@ export function parseSummaryJson(json: string): ParsedSummary {
     if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
       return { ok: true, data: parsed as Record<string, unknown> };
     }
-    console.warn('[parseSummaryJson] object가 아님. raw fallback:', json);
     return { ok: false, raw: json };
-  } catch (e) {
-    console.warn('[parseSummaryJson] 파싱 실패. raw fallback:', json, e);
+  } catch {
     return { ok: false, raw: json };
   }
 }

--- a/frontend/src/features/domain-pack-summary-read/model/parseSummaryJson.ts
+++ b/frontend/src/features/domain-pack-summary-read/model/parseSummaryJson.ts
@@ -1,0 +1,17 @@
+export type ParsedSummary =
+  | { ok: true; data: Record<string, unknown> }
+  | { ok: false; raw: string };
+
+export function parseSummaryJson(json: string): ParsedSummary {
+  try {
+    const parsed: unknown = JSON.parse(json);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return { ok: true, data: parsed as Record<string, unknown> };
+    }
+    console.warn('[parseSummaryJson] object가 아님. raw fallback:', json);
+    return { ok: false, raw: json };
+  } catch (e) {
+    console.warn('[parseSummaryJson] 파싱 실패. raw fallback:', json, e);
+    return { ok: false, raw: json };
+  }
+}

--- a/frontend/src/features/domain-pack-summary-read/model/usePackDetail.test.ts
+++ b/frontend/src/features/domain-pack-summary-read/model/usePackDetail.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { useQuery } from '@tanstack/react-query';
+import { domainPackApi, domainPackKeys } from '@/entities/domain-pack';
+import { usePackDetail } from './usePackDetail';
+
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock('@/entities/domain-pack', () => ({
+  domainPackApi: { detail: vi.fn() },
+  domainPackKeys: {
+    detail: (wsId: number, packId: number) => ['domain-packs', 'detail', wsId, packId],
+  },
+}));
+
+const mockedUseQuery = vi.mocked(useQuery);
+
+describe('usePackDetail', () => {
+  beforeEach(() => mockedUseQuery.mockClear());
+
+  it('올바른 queryKey로 useQuery를 호출한다', () => {
+    usePackDetail(1, 2);
+    const [opts] = mockedUseQuery.mock.calls[0] as [{ queryKey: unknown }];
+    expect(opts.queryKey).toEqual(['domain-packs', 'detail', 1, 2]);
+  });
+
+  it('queryFn이 domainPackApi.detail을 호출한다', () => {
+    usePackDetail(1, 2);
+    const [opts] = mockedUseQuery.mock.calls[0] as [{ queryFn: () => void }];
+    opts.queryFn();
+    expect(domainPackApi.detail).toHaveBeenCalledWith(1, 2);
+  });
+
+  it('loading 상태를 전달받아 반환한다', () => {
+    mockedUseQuery.mockReturnValueOnce({ isLoading: true, isFetching: true } as ReturnType<typeof useQuery>);
+    const result = usePackDetail(1, 2);
+    expect(result.isLoading).toBe(true);
+    expect(result.isFetching).toBe(true);
+  });
+
+  it('error 상태를 전달받아 반환한다', () => {
+    const err = new Error('fail');
+    mockedUseQuery.mockReturnValueOnce({ isError: true, error: err } as ReturnType<typeof useQuery>);
+    const result = usePackDetail(1, 2);
+    expect(result.isError).toBe(true);
+    expect(result.error).toBe(err);
+  });
+
+  it('성공 상태를 전달받아 반환한다', () => {
+    const data = { packId: 2, versions: [] };
+    mockedUseQuery.mockReturnValueOnce({ isSuccess: true, data } as ReturnType<typeof useQuery>);
+    const result = usePackDetail(1, 2);
+    expect(result.isSuccess).toBe(true);
+    expect(result.data).toBe(data);
+  });
+
+  it('queryKey에 wsId와 packId가 반영된다', () => {
+    usePackDetail(5, 99);
+    const [opts] = mockedUseQuery.mock.calls[0] as [{ queryKey: unknown[] }];
+    expect(opts.queryKey).toContain(5);
+    expect(opts.queryKey).toContain(99);
+  });
+
+  // domainPackKeys factory is exercised by the queryKey tests above
+  it('domainPackKeys.detail이 useQuery에 전달된다', () => {
+    usePackDetail(3, 7);
+    const [opts] = mockedUseQuery.mock.calls[0] as [{ queryKey: unknown }];
+    expect(opts.queryKey).toEqual(domainPackKeys.detail(3, 7));
+  });
+});

--- a/frontend/src/features/domain-pack-summary-read/model/usePackDetail.test.ts
+++ b/frontend/src/features/domain-pack-summary-read/model/usePackDetail.test.ts
@@ -27,7 +27,7 @@ describe('usePackDetail', () => {
 
   it('queryFn이 domainPackApi.detail을 호출한다', () => {
     usePackDetail(1, 2);
-    const [opts] = mockedUseQuery.mock.calls[0] as [{ queryFn: () => void }];
+    const [opts] = mockedUseQuery.mock.calls[0] as unknown as [{ queryFn: () => void }];
     opts.queryFn();
     expect(domainPackApi.detail).toHaveBeenCalledWith(1, 2);
   });

--- a/frontend/src/features/domain-pack-summary-read/model/usePackDetail.ts
+++ b/frontend/src/features/domain-pack-summary-read/model/usePackDetail.ts
@@ -1,0 +1,9 @@
+import { useQuery } from '@tanstack/react-query';
+import { domainPackApi, domainPackKeys } from '@/entities/domain-pack';
+
+export function usePackDetail(wsId: number, packId: number) {
+  return useQuery({
+    queryKey: domainPackKeys.detail(wsId, packId),
+    queryFn: () => domainPackApi.detail(wsId, packId),
+  });
+}

--- a/frontend/src/features/domain-pack-summary-read/model/usePreviewLists.test.ts
+++ b/frontend/src/features/domain-pack-summary-read/model/usePreviewLists.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { useQuery } from '@tanstack/react-query';
+import { intentApi, intentKeys } from '@/entities/intent';
+import { slotApi, slotKeys } from '@/entities/slot';
+import { policyApi, policyKeys } from '@/entities/policy';
+import { riskApi, riskKeys } from '@/entities/risk';
+import { fetchWorkflowList, workflowQueryKeys } from '@/entities/workflow';
+import {
+  useIntentPreview,
+  useSlotPreview,
+  usePolicyPreview,
+  useRiskPreview,
+  useWorkflowPreview,
+} from './usePreviewLists';
+
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock('@/entities/intent', () => ({
+  intentApi: { list: vi.fn() },
+  intentKeys: {
+    list: (wsId: number, packId: number, versionId: number) =>
+      ['intents', 'list', wsId, packId, versionId],
+  },
+}));
+
+vi.mock('@/entities/slot', () => ({
+  slotApi: { list: vi.fn() },
+  slotKeys: {
+    list: (workspaceId: number, packId: number, versionId: number) =>
+      ['slots', 'list', workspaceId, packId, versionId],
+  },
+}));
+
+vi.mock('@/entities/policy', () => ({
+  policyApi: { list: vi.fn() },
+  policyKeys: {
+    list: (workspaceId: number, packId: number, versionId: number) =>
+      ['policies', 'list', workspaceId, packId, versionId],
+  },
+}));
+
+vi.mock('@/entities/risk', () => ({
+  riskApi: { list: vi.fn() },
+  riskKeys: {
+    list: (workspaceId: number, packId: number, versionId: number) =>
+      ['risks', 'list', workspaceId, packId, versionId],
+  },
+}));
+
+vi.mock('@/entities/workflow', () => ({
+  fetchWorkflowList: vi.fn(),
+  workflowQueryKeys: {
+    list: (workspaceId: number, packId: number, versionId: number) =>
+      ['workflows', 'list', workspaceId, packId, versionId],
+  },
+}));
+
+const mockedUseQuery = vi.mocked(useQuery);
+
+describe('useIntentPreview', () => {
+  beforeEach(() => mockedUseQuery.mockClear());
+
+  it('versionId가 null이면 enabled:false로 useQuery를 호출한다', () => {
+    useIntentPreview(1, 2, null);
+    const [opts] = mockedUseQuery.mock.calls[0] as unknown as [{ enabled: boolean }];
+    expect(opts.enabled).toBe(false);
+  });
+
+  it('versionId가 있으면 enabled:true로 useQuery를 호출한다', () => {
+    useIntentPreview(1, 2, 3);
+    const [opts] = mockedUseQuery.mock.calls[0] as unknown as [{ enabled: boolean }];
+    expect(opts.enabled).toBe(true);
+  });
+
+  it('올바른 queryKey로 useQuery를 호출한다', () => {
+    useIntentPreview(1, 2, 3);
+    const [opts] = mockedUseQuery.mock.calls[0] as [{ queryKey: unknown }];
+    expect(opts.queryKey).toEqual(intentKeys.list(1, 2, 3));
+  });
+
+  it('queryFn이 intentApi.list를 호출한다', () => {
+    useIntentPreview(1, 2, 3);
+    const [opts] = mockedUseQuery.mock.calls[0] as unknown as [{ queryFn: () => void }];
+    opts.queryFn();
+    expect(intentApi.list).toHaveBeenCalledWith(1, 2, 3);
+  });
+});
+
+describe('useSlotPreview', () => {
+  beforeEach(() => mockedUseQuery.mockClear());
+
+  it('versionId가 null이면 enabled:false로 useQuery를 호출한다', () => {
+    useSlotPreview(1, 2, null);
+    const [opts] = mockedUseQuery.mock.calls[0] as unknown as [{ enabled: boolean }];
+    expect(opts.enabled).toBe(false);
+  });
+
+  it('versionId가 있으면 enabled:true로 useQuery를 호출한다', () => {
+    useSlotPreview(1, 2, 3);
+    const [opts] = mockedUseQuery.mock.calls[0] as unknown as [{ enabled: boolean }];
+    expect(opts.enabled).toBe(true);
+  });
+
+  it('올바른 queryKey로 useQuery를 호출한다', () => {
+    useSlotPreview(1, 2, 3);
+    const [opts] = mockedUseQuery.mock.calls[0] as [{ queryKey: unknown }];
+    expect(opts.queryKey).toEqual(slotKeys.list(1, 2, 3));
+  });
+
+  it('queryFn이 slotApi.list를 호출한다', () => {
+    useSlotPreview(1, 2, 3);
+    const [opts] = mockedUseQuery.mock.calls[0] as unknown as [{ queryFn: () => void }];
+    opts.queryFn();
+    expect(slotApi.list).toHaveBeenCalledWith(1, 2, 3);
+  });
+});
+
+describe('usePolicyPreview', () => {
+  beforeEach(() => mockedUseQuery.mockClear());
+
+  it('versionId가 null이면 enabled:false로 useQuery를 호출한다', () => {
+    usePolicyPreview(1, 2, null);
+    const [opts] = mockedUseQuery.mock.calls[0] as unknown as [{ enabled: boolean }];
+    expect(opts.enabled).toBe(false);
+  });
+
+  it('versionId가 있으면 enabled:true로 useQuery를 호출한다', () => {
+    usePolicyPreview(1, 2, 3);
+    const [opts] = mockedUseQuery.mock.calls[0] as unknown as [{ enabled: boolean }];
+    expect(opts.enabled).toBe(true);
+  });
+
+  it('올바른 queryKey로 useQuery를 호출한다', () => {
+    usePolicyPreview(1, 2, 3);
+    const [opts] = mockedUseQuery.mock.calls[0] as [{ queryKey: unknown }];
+    expect(opts.queryKey).toEqual(policyKeys.list(1, 2, 3));
+  });
+
+  it('queryFn이 policyApi.list를 호출한다', () => {
+    usePolicyPreview(1, 2, 3);
+    const [opts] = mockedUseQuery.mock.calls[0] as unknown as [{ queryFn: () => void }];
+    opts.queryFn();
+    expect(policyApi.list).toHaveBeenCalledWith(1, 2, 3);
+  });
+});
+
+describe('useRiskPreview', () => {
+  beforeEach(() => mockedUseQuery.mockClear());
+
+  it('versionId가 null이면 enabled:false로 useQuery를 호출한다', () => {
+    useRiskPreview(1, 2, null);
+    const [opts] = mockedUseQuery.mock.calls[0] as unknown as [{ enabled: boolean }];
+    expect(opts.enabled).toBe(false);
+  });
+
+  it('versionId가 있으면 enabled:true로 useQuery를 호출한다', () => {
+    useRiskPreview(1, 2, 3);
+    const [opts] = mockedUseQuery.mock.calls[0] as unknown as [{ enabled: boolean }];
+    expect(opts.enabled).toBe(true);
+  });
+
+  it('올바른 queryKey로 useQuery를 호출한다', () => {
+    useRiskPreview(1, 2, 3);
+    const [opts] = mockedUseQuery.mock.calls[0] as [{ queryKey: unknown }];
+    expect(opts.queryKey).toEqual(riskKeys.list(1, 2, 3));
+  });
+
+  it('queryFn이 riskApi.list를 호출한다', () => {
+    useRiskPreview(1, 2, 3);
+    const [opts] = mockedUseQuery.mock.calls[0] as unknown as [{ queryFn: () => void }];
+    opts.queryFn();
+    expect(riskApi.list).toHaveBeenCalledWith(1, 2, 3);
+  });
+});
+
+describe('useWorkflowPreview', () => {
+  beforeEach(() => mockedUseQuery.mockClear());
+
+  it('versionId가 null이면 enabled:false로 useQuery를 호출한다', () => {
+    useWorkflowPreview(1, 2, null);
+    const [opts] = mockedUseQuery.mock.calls[0] as unknown as [{ enabled: boolean }];
+    expect(opts.enabled).toBe(false);
+  });
+
+  it('versionId가 있으면 enabled:true로 useQuery를 호출한다', () => {
+    useWorkflowPreview(1, 2, 3);
+    const [opts] = mockedUseQuery.mock.calls[0] as unknown as [{ enabled: boolean }];
+    expect(opts.enabled).toBe(true);
+  });
+
+  it('올바른 queryKey로 useQuery를 호출한다', () => {
+    useWorkflowPreview(1, 2, 3);
+    const [opts] = mockedUseQuery.mock.calls[0] as [{ queryKey: unknown }];
+    expect(opts.queryKey).toEqual(workflowQueryKeys.list(1, 2, 3));
+  });
+
+  it('queryFn이 fetchWorkflowList를 호출한다', () => {
+    useWorkflowPreview(1, 2, 3);
+    const [opts] = mockedUseQuery.mock.calls[0] as unknown as [{ queryFn: () => void }];
+    opts.queryFn();
+    expect(fetchWorkflowList).toHaveBeenCalledWith(1, 2, 3);
+  });
+});

--- a/frontend/src/features/domain-pack-summary-read/model/usePreviewLists.ts
+++ b/frontend/src/features/domain-pack-summary-read/model/usePreviewLists.ts
@@ -1,0 +1,51 @@
+import { useQuery } from '@tanstack/react-query';
+import { intentApi, intentKeys } from '@/entities/intent';
+import { slotApi, slotKeys } from '@/entities/slot';
+import { policyApi, policyKeys } from '@/entities/policy';
+import { riskApi, riskKeys } from '@/entities/risk';
+import { fetchWorkflowList, workflowQueryKeys } from '@/entities/workflow';
+
+export function useIntentPreview(wsId: number, packId: number, versionId: number | null) {
+  return useQuery({
+    queryKey: intentKeys.list(wsId, packId, versionId ?? -1),
+    queryFn: () => intentApi.list(wsId, packId, versionId!),
+    enabled: versionId !== null,
+    select: (data) => data.slice(0, 5),
+  });
+}
+
+export function useSlotPreview(wsId: number, packId: number, versionId: number | null) {
+  return useQuery({
+    queryKey: slotKeys.list(wsId, packId, versionId ?? -1),
+    queryFn: () => slotApi.list(wsId, packId, versionId!),
+    enabled: versionId !== null,
+    select: (data) => data.slice(0, 5),
+  });
+}
+
+export function usePolicyPreview(wsId: number, packId: number, versionId: number | null) {
+  return useQuery({
+    queryKey: policyKeys.list(wsId, packId, versionId ?? -1),
+    queryFn: () => policyApi.list(wsId, packId, versionId!),
+    enabled: versionId !== null,
+    select: (data) => data.slice(0, 5),
+  });
+}
+
+export function useRiskPreview(wsId: number, packId: number, versionId: number | null) {
+  return useQuery({
+    queryKey: riskKeys.list(wsId, packId, versionId ?? -1),
+    queryFn: () => riskApi.list(wsId, packId, versionId!),
+    enabled: versionId !== null,
+    select: (data) => data.slice(0, 5),
+  });
+}
+
+export function useWorkflowPreview(wsId: number, packId: number, versionId: number | null) {
+  return useQuery({
+    queryKey: workflowQueryKeys.list(wsId, packId, versionId ?? -1),
+    queryFn: () => fetchWorkflowList(wsId, packId, versionId!),
+    enabled: versionId !== null,
+    select: (data) => data.slice(0, 5),
+  });
+}

--- a/frontend/src/features/domain-pack-summary-read/model/useVersionDetail.test.ts
+++ b/frontend/src/features/domain-pack-summary-read/model/useVersionDetail.test.ts
@@ -34,19 +34,19 @@ describe('useVersionDetail', () => {
 
   it('versionId가 null이면 enabled:false로 useQuery를 호출한다', () => {
     useVersionDetail(1, 2, null);
-    const [opts] = mockedUseQuery.mock.calls[0] as [{ enabled: boolean }];
+    const [opts] = mockedUseQuery.mock.calls[0] as unknown as [{ enabled: boolean }];
     expect(opts.enabled).toBe(false);
   });
 
   it('versionId가 있으면 enabled:true로 useQuery를 호출한다', () => {
     useVersionDetail(1, 2, 3);
-    const [opts] = mockedUseQuery.mock.calls[0] as [{ enabled: boolean }];
+    const [opts] = mockedUseQuery.mock.calls[0] as unknown as [{ enabled: boolean }];
     expect(opts.enabled).toBe(true);
   });
 
   it('queryFn이 domainPackApi.versionDetail을 호출한다', () => {
     useVersionDetail(1, 2, 3);
-    const [opts] = mockedUseQuery.mock.calls[0] as [{ queryFn: () => void }];
+    const [opts] = mockedUseQuery.mock.calls[0] as unknown as [{ queryFn: () => void }];
     opts.queryFn();
     expect(domainPackApi.versionDetail).toHaveBeenCalledWith(1, 2, 3);
   });

--- a/frontend/src/features/domain-pack-summary-read/model/useVersionDetail.test.ts
+++ b/frontend/src/features/domain-pack-summary-read/model/useVersionDetail.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { useQuery } from '@tanstack/react-query';
+import { domainPackApi, domainPackKeys } from '@/entities/domain-pack';
+import { ApiRequestError } from '@/shared/api';
+import { useVersionDetail } from './useVersionDetail';
+
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock('@/entities/domain-pack', () => ({
+  domainPackApi: { versionDetail: vi.fn() },
+  domainPackKeys: {
+    versionDetail: (wsId: number, packId: number, versionId: number) =>
+      ['domain-packs', 'version-detail', wsId, packId, versionId],
+  },
+}));
+
+vi.mock('@/shared/api', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@/shared/api')>();
+  return { ...original };
+});
+
+const mockedUseQuery = vi.mocked(useQuery);
+
+describe('useVersionDetail', () => {
+  beforeEach(() => mockedUseQuery.mockClear());
+
+  it('올바른 queryKey로 useQuery를 호출한다', () => {
+    useVersionDetail(1, 2, 3);
+    const [opts] = mockedUseQuery.mock.calls[0] as [{ queryKey: unknown }];
+    expect(opts.queryKey).toEqual(domainPackKeys.versionDetail(1, 2, 3));
+  });
+
+  it('versionId가 null이면 enabled:false로 useQuery를 호출한다', () => {
+    useVersionDetail(1, 2, null);
+    const [opts] = mockedUseQuery.mock.calls[0] as [{ enabled: boolean }];
+    expect(opts.enabled).toBe(false);
+  });
+
+  it('versionId가 있으면 enabled:true로 useQuery를 호출한다', () => {
+    useVersionDetail(1, 2, 3);
+    const [opts] = mockedUseQuery.mock.calls[0] as [{ enabled: boolean }];
+    expect(opts.enabled).toBe(true);
+  });
+
+  it('queryFn이 domainPackApi.versionDetail을 호출한다', () => {
+    useVersionDetail(1, 2, 3);
+    const [opts] = mockedUseQuery.mock.calls[0] as [{ queryFn: () => void }];
+    opts.queryFn();
+    expect(domainPackApi.versionDetail).toHaveBeenCalledWith(1, 2, 3);
+  });
+
+  it('loading 상태를 전달받아 반환한다', () => {
+    mockedUseQuery.mockReturnValueOnce({ isLoading: true, isFetching: true } as ReturnType<typeof useQuery>);
+    const result = useVersionDetail(1, 2, 3);
+    expect(result.isLoading).toBe(true);
+  });
+
+  it('404 ApiRequestError 에러 상태를 전달받아 반환한다', () => {
+    const err = new ApiRequestError(404, 'NOT_FOUND', '버전을 찾을 수 없습니다.');
+    mockedUseQuery.mockReturnValueOnce({ isError: true, error: err } as ReturnType<typeof useQuery>);
+    const result = useVersionDetail(1, 2, 3);
+    expect(result.isError).toBe(true);
+    expect((result.error as ApiRequestError).status).toBe(404);
+  });
+
+  it('성공 상태를 전달받아 반환한다', () => {
+    const data = { versionId: 3, versionNo: 1 };
+    mockedUseQuery.mockReturnValueOnce({ isSuccess: true, data } as ReturnType<typeof useQuery>);
+    const result = useVersionDetail(1, 2, 3);
+    expect(result.isSuccess).toBe(true);
+    expect(result.data).toBe(data);
+  });
+});

--- a/frontend/src/features/domain-pack-summary-read/model/useVersionDetail.ts
+++ b/frontend/src/features/domain-pack-summary-read/model/useVersionDetail.ts
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query';
+import { domainPackApi, domainPackKeys } from '@/entities/domain-pack';
+
+export function useVersionDetail(
+  wsId: number,
+  packId: number,
+  versionId: number | null,
+) {
+  return useQuery({
+    queryKey: domainPackKeys.versionDetail(wsId, packId, versionId ?? -1),
+    queryFn: () => domainPackApi.versionDetail(wsId, packId, versionId!),
+    enabled: versionId !== null,
+  });
+}

--- a/frontend/src/features/domain-pack-summary-read/ui/ComponentCountGrid.module.css
+++ b/frontend/src/features/domain-pack-summary-read/ui/ComponentCountGrid.module.css
@@ -38,7 +38,7 @@
 .countNumber {
   font-family: var(--font-mono);
   font-size: 24px;
-  font-weight: 600;
+  font-weight: 540;
   color: var(--text-primary);
   line-height: 1;
 }

--- a/frontend/src/features/domain-pack-summary-read/ui/ComponentCountGrid.module.css
+++ b/frontend/src/features/domain-pack-summary-read/ui/ComponentCountGrid.module.css
@@ -1,0 +1,87 @@
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 12px;
+}
+
+.countCard {
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-lg);
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  transition: box-shadow var(--transition-fast);
+}
+
+.countCard:not(.disabled) {
+  cursor: pointer;
+}
+
+.countCard:not(.disabled):hover {
+  box-shadow: var(--shadow-card);
+}
+
+.countCard.disabled {
+  opacity: 0.7;
+  cursor: default;
+}
+
+.cardLabel {
+  font-size: var(--font-size-label);
+  font-weight: var(--font-weight-heading);
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.countNumber {
+  font-family: var(--font-mono);
+  font-size: 24px;
+  font-weight: 600;
+  color: var(--text-primary);
+  line-height: 1;
+}
+
+.previewList {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  margin: 0;
+  padding: 0;
+}
+
+.previewItem {
+  font-size: 11px;
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  padding: 1px 0;
+  border-radius: var(--radius-sm);
+}
+
+.previewItem.clickable {
+  cursor: pointer;
+  color: var(--text-secondary);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.previewItem.clickable:hover {
+  color: var(--text-primary);
+}
+
+.disabledNote {
+  font-size: 11px;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.skeletonLine {
+  height: 12px;
+  background: var(--hover-bg);
+  border-radius: var(--radius-sm);
+  margin-bottom: 3px;
+}

--- a/frontend/src/features/domain-pack-summary-read/ui/ComponentCountGrid.test.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/ComponentCountGrid.test.tsx
@@ -118,4 +118,26 @@ describe('ComponentCountGrid', () => {
     render(<ComponentCountGrid {...defaultProps} />);
     expect(screen.getByText('intent-1')).toBeInTheDocument();
   });
+
+  it('workflow 미리보기 항목에서 Enter 키 입력 시 해당 id로 navigate를 호출한다', () => {
+    vi.mocked(previewLists.useWorkflowPreview).mockReturnValue(
+      makeHook({ data: [{ id: 10, name: 'wf-alpha' }] }),
+    );
+    render(<ComponentCountGrid {...defaultProps} />);
+    fireEvent.keyDown(screen.getByText('wf-alpha'), { key: 'Enter' });
+    expect(mockNavigate).toHaveBeenCalledWith(
+      '/workspaces/1/domain-packs/2/versions/3/workflows/10',
+    );
+  });
+
+  it('workflow 미리보기 항목에서 Space 키 입력 시 해당 id로 navigate를 호출한다', () => {
+    vi.mocked(previewLists.useWorkflowPreview).mockReturnValue(
+      makeHook({ data: [{ id: 10, name: 'wf-alpha' }] }),
+    );
+    render(<ComponentCountGrid {...defaultProps} />);
+    fireEvent.keyDown(screen.getByText('wf-alpha'), { key: ' ' });
+    expect(mockNavigate).toHaveBeenCalledWith(
+      '/workspaces/1/domain-packs/2/versions/3/workflows/10',
+    );
+  });
 });

--- a/frontend/src/features/domain-pack-summary-read/ui/ComponentCountGrid.test.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/ComponentCountGrid.test.tsx
@@ -1,0 +1,121 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { toast } from 'sonner';
+import * as previewLists from '../model/usePreviewLists';
+import { ComponentCountGrid } from './ComponentCountGrid';
+
+const mockNavigate = vi.fn();
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+vi.mock('../model/usePreviewLists', () => ({
+  useIntentPreview: vi.fn(),
+  useSlotPreview: vi.fn(),
+  usePolicyPreview: vi.fn(),
+  useRiskPreview: vi.fn(),
+  useWorkflowPreview: vi.fn(),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn() },
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function makeHook(overrides: Record<string, unknown> = {}): any {
+  return { data: undefined, isLoading: false, isError: false, error: null, ...overrides };
+}
+
+const defaultProps = {
+  wsId: 1,
+  packId: 2,
+  versionId: 3,
+  intentCount: 2,
+  slotCount: 3,
+  policyCount: 1,
+  riskCount: 0,
+  workflowCount: 4,
+};
+
+describe('ComponentCountGrid', () => {
+  beforeEach(() => {
+    mockNavigate.mockReset();
+    vi.mocked(toast.error).mockReset();
+    vi.mocked(previewLists.useIntentPreview).mockReturnValue(makeHook());
+    vi.mocked(previewLists.useSlotPreview).mockReturnValue(makeHook());
+    vi.mocked(previewLists.usePolicyPreview).mockReturnValue(makeHook());
+    vi.mocked(previewLists.useRiskPreview).mockReturnValue(makeHook());
+    vi.mocked(previewLists.useWorkflowPreview).mockReturnValue(makeHook());
+  });
+
+  it('카드 레이블과 카운트를 렌더링한다', () => {
+    render(<ComponentCountGrid {...defaultProps} />);
+    expect(screen.getByText('Intent')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText('Workflow')).toBeInTheDocument();
+    expect(screen.getByText('4')).toBeInTheDocument();
+  });
+
+  it('disabled 카드는 "준비 중" 안내를 4개 표시한다', () => {
+    render(<ComponentCountGrid {...defaultProps} />);
+    expect(screen.getAllByText('준비 중')).toHaveLength(4);
+  });
+
+  it('로딩 중일 때 스켈레톤을 렌더링한다', () => {
+    vi.mocked(previewLists.useWorkflowPreview).mockReturnValue(makeHook({ isLoading: true }));
+    render(<ComponentCountGrid {...defaultProps} />);
+    expect(document.querySelectorAll('[aria-hidden="true"]').length).toBeGreaterThan(0);
+  });
+
+  it('intent isError 시 toast.error를 호출한다', async () => {
+    vi.mocked(previewLists.useIntentPreview).mockReturnValue(makeHook({ isError: true }));
+    render(<ComponentCountGrid {...defaultProps} />);
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith('Intent 미리보기 로드 실패'),
+    );
+  });
+
+  it('slot isError 시 toast.error를 호출한다', async () => {
+    vi.mocked(previewLists.useSlotPreview).mockReturnValue(makeHook({ isError: true }));
+    render(<ComponentCountGrid {...defaultProps} />);
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith('Slot 미리보기 로드 실패'),
+    );
+  });
+
+  it('workflow isError 시 toast.error를 호출한다', async () => {
+    vi.mocked(previewLists.useWorkflowPreview).mockReturnValue(makeHook({ isError: true }));
+    render(<ComponentCountGrid {...defaultProps} />);
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith('Workflow 미리보기 로드 실패'),
+    );
+  });
+
+  it('workflow previewItems가 있으면 이름 목록을 렌더링한다', () => {
+    vi.mocked(previewLists.useWorkflowPreview).mockReturnValue(
+      makeHook({ data: [{ id: 10, name: 'wf-alpha' }] }),
+    );
+    render(<ComponentCountGrid {...defaultProps} />);
+    expect(screen.getByText('wf-alpha')).toBeInTheDocument();
+  });
+
+  it('workflow 미리보기 항목 클릭 시 해당 id로 navigate를 호출한다', () => {
+    vi.mocked(previewLists.useWorkflowPreview).mockReturnValue(
+      makeHook({ data: [{ id: 10, name: 'wf-alpha' }] }),
+    );
+    render(<ComponentCountGrid {...defaultProps} />);
+    fireEvent.click(screen.getByText('wf-alpha'));
+    expect(mockNavigate).toHaveBeenCalledWith(
+      '/workspaces/1/domain-packs/2/versions/3/workflows/10',
+    );
+  });
+
+  it('intent previewNames가 있으면 이름 목록을 렌더링한다', () => {
+    vi.mocked(previewLists.useIntentPreview).mockReturnValue(
+      makeHook({ data: [{ name: 'intent-1' }] }),
+    );
+    render(<ComponentCountGrid {...defaultProps} />);
+    expect(screen.getByText('intent-1')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/domain-pack-summary-read/ui/ComponentCountGrid.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/ComponentCountGrid.tsx
@@ -1,0 +1,153 @@
+import { useNavigate } from 'react-router-dom';
+import {
+  useIntentPreview,
+  useSlotPreview,
+  usePolicyPreview,
+  useRiskPreview,
+  useWorkflowPreview,
+} from '../model/usePreviewLists';
+import styles from './ComponentCountGrid.module.css';
+
+interface ComponentCountGridProps {
+  wsId: number;
+  packId: number;
+  versionId: number;
+  intentCount: number;
+  slotCount: number;
+  policyCount: number;
+  riskCount: number;
+  workflowCount: number;
+}
+
+export function ComponentCountGrid({
+  wsId,
+  packId,
+  versionId,
+  intentCount,
+  slotCount,
+  policyCount,
+  riskCount,
+  workflowCount,
+}: ComponentCountGridProps) {
+  const navigate = useNavigate();
+  const basePath = `/workspaces/${wsId}/domain-packs/${packId}/versions/${versionId}`;
+
+  const intentPreview = useIntentPreview(wsId, packId, versionId);
+  const slotPreview = useSlotPreview(wsId, packId, versionId);
+  const policyPreview = usePolicyPreview(wsId, packId, versionId);
+  const riskPreview = useRiskPreview(wsId, packId, versionId);
+  const workflowPreview = useWorkflowPreview(wsId, packId, versionId);
+
+  return (
+    <div className={styles.grid}>
+      <CountCard
+        label="Intent"
+        count={intentCount}
+        disabled
+        tooltip="상세 화면 준비 중"
+        previewNames={intentPreview.data?.map((i) => i.name)}
+        isLoadingPreview={intentPreview.isLoading}
+      />
+      <CountCard
+        label="Slot"
+        count={slotCount}
+        disabled
+        tooltip="상세 화면 준비 중"
+        previewNames={slotPreview.data?.map((s) => s.name)}
+        isLoadingPreview={slotPreview.isLoading}
+      />
+      <CountCard
+        label="Policy"
+        count={policyCount}
+        disabled
+        tooltip="상세 화면 준비 중"
+        previewNames={policyPreview.data?.map((p) => p.name)}
+        isLoadingPreview={policyPreview.isLoading}
+      />
+      <CountCard
+        label="Risk"
+        count={riskCount}
+        disabled
+        tooltip="상세 화면 준비 중"
+        previewNames={riskPreview.data?.map((r) => r.name)}
+        isLoadingPreview={riskPreview.isLoading}
+      />
+      <CountCard
+        label="Workflow"
+        count={workflowCount}
+        disabled={false}
+        onNavigate={() => navigate(`${basePath}/workflows`)}
+        previewNames={workflowPreview.data?.map((w) => w.name)}
+        isLoadingPreview={workflowPreview.isLoading}
+        onPreviewItemClick={(name) => {
+          const found = workflowPreview.data?.find((w) => w.name === name);
+          if (found) navigate(`${basePath}/workflows/${found.id}`);
+        }}
+      />
+    </div>
+  );
+}
+
+interface CountCardProps {
+  label: string;
+  count: number;
+  disabled: boolean;
+  tooltip?: string;
+  onNavigate?: () => void;
+  previewNames?: string[];
+  isLoadingPreview: boolean;
+  onPreviewItemClick?: (name: string) => void;
+}
+
+function CountCard({
+  label,
+  count,
+  disabled,
+  tooltip,
+  onNavigate,
+  previewNames,
+  isLoadingPreview,
+  onPreviewItemClick,
+}: CountCardProps) {
+  const handleClick = () => {
+    if (!disabled && onNavigate) onNavigate();
+  };
+
+  return (
+    <div
+      className={`${styles.countCard} ${disabled ? styles.disabled : ''}`}
+      title={disabled ? tooltip : undefined}
+      onClick={handleClick}
+      role={!disabled ? 'button' : undefined}
+      tabIndex={!disabled ? 0 : undefined}
+      onKeyDown={!disabled ? (e) => {
+        if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleClick(); }
+      } : undefined}
+    >
+      <span className={styles.cardLabel}>{label}</span>
+      <span className={styles.countNumber}>{count}</span>
+      {isLoadingPreview ? (
+        <div>
+          {[0, 1, 2].map((i) => <div key={i} className={styles.skeletonLine} aria-hidden />)}
+        </div>
+      ) : previewNames && previewNames.length > 0 ? (
+        <ul className={styles.previewList}>
+          {previewNames.map((name) => (
+            <li
+              key={name}
+              className={`${styles.previewItem} ${!disabled && onPreviewItemClick ? styles.clickable : ''}`}
+              onClick={!disabled && onPreviewItemClick ? (e) => {
+                e.stopPropagation();
+                onPreviewItemClick(name);
+              } : undefined}
+            >
+              {name}
+            </li>
+          ))}
+        </ul>
+      ) : disabled ? (
+        <span className={styles.disabledNote}>준비 중</span>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/features/domain-pack-summary-read/ui/ComponentCountGrid.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/ComponentCountGrid.tsx
@@ -161,6 +161,12 @@ function CountCard({
                 e.stopPropagation();
                 onPreviewItemClick(item.id);
               } : undefined}
+              onKeyDown={!disabled && onPreviewItemClick ? (e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  onPreviewItemClick(item.id);
+                }
+              } : undefined}
             >
               {item.name}
             </li>
@@ -168,8 +174,8 @@ function CountCard({
         </ul>
       ) : previewNames && previewNames.length > 0 ? (
         <ul className={styles.previewList}>
-          {previewNames.map((name) => (
-            <li key={name} className={styles.previewItem}>
+          {previewNames.map((name, idx) => (
+            <li key={`${name}-${idx}`} className={styles.previewItem}>
               {name}
             </li>
           ))}

--- a/frontend/src/features/domain-pack-summary-read/ui/ComponentCountGrid.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/ComponentCountGrid.tsx
@@ -1,4 +1,6 @@
+import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
 import {
   useIntentPreview,
   useSlotPreview,
@@ -37,6 +39,26 @@ export function ComponentCountGrid({
   const policyPreview = usePolicyPreview(wsId, packId, versionId);
   const riskPreview = useRiskPreview(wsId, packId, versionId);
   const workflowPreview = useWorkflowPreview(wsId, packId, versionId);
+
+  useEffect(() => {
+    if (intentPreview.isError) toast.error('Intent 미리보기 로드 실패');
+  }, [intentPreview.isError]);
+
+  useEffect(() => {
+    if (slotPreview.isError) toast.error('Slot 미리보기 로드 실패');
+  }, [slotPreview.isError]);
+
+  useEffect(() => {
+    if (policyPreview.isError) toast.error('Policy 미리보기 로드 실패');
+  }, [policyPreview.isError]);
+
+  useEffect(() => {
+    if (riskPreview.isError) toast.error('Risk 미리보기 로드 실패');
+  }, [riskPreview.isError]);
+
+  useEffect(() => {
+    if (workflowPreview.isError) toast.error('Workflow 미리보기 로드 실패');
+  }, [workflowPreview.isError]);
 
   return (
     <div className={styles.grid}>
@@ -77,12 +99,9 @@ export function ComponentCountGrid({
         count={workflowCount}
         disabled={false}
         onNavigate={() => navigate(`${basePath}/workflows`)}
-        previewNames={workflowPreview.data?.map((w) => w.name)}
+        previewItems={workflowPreview.data?.map((w) => ({ id: w.id, name: w.name }))}
         isLoadingPreview={workflowPreview.isLoading}
-        onPreviewItemClick={(name) => {
-          const found = workflowPreview.data?.find((w) => w.name === name);
-          if (found) navigate(`${basePath}/workflows/${found.id}`);
-        }}
+        onPreviewItemClick={(id) => navigate(`${basePath}/workflows/${id}`)}
       />
     </div>
   );
@@ -95,8 +114,9 @@ interface CountCardProps {
   tooltip?: string;
   onNavigate?: () => void;
   previewNames?: string[];
+  previewItems?: Array<{ id: number; name: string }>;
   isLoadingPreview: boolean;
-  onPreviewItemClick?: (name: string) => void;
+  onPreviewItemClick?: (id: number) => void;
 }
 
 function CountCard({
@@ -106,6 +126,7 @@ function CountCard({
   tooltip,
   onNavigate,
   previewNames,
+  previewItems,
   isLoadingPreview,
   onPreviewItemClick,
 }: CountCardProps) {
@@ -130,17 +151,25 @@ function CountCard({
         <div>
           {[0, 1, 2].map((i) => <div key={i} className={styles.skeletonLine} aria-hidden />)}
         </div>
-      ) : previewNames && previewNames.length > 0 ? (
+      ) : previewItems && previewItems.length > 0 ? (
         <ul className={styles.previewList}>
-          {previewNames.map((name) => (
+          {previewItems.map((item) => (
             <li
-              key={name}
+              key={item.id}
               className={`${styles.previewItem} ${!disabled && onPreviewItemClick ? styles.clickable : ''}`}
               onClick={!disabled && onPreviewItemClick ? (e) => {
                 e.stopPropagation();
-                onPreviewItemClick(name);
+                onPreviewItemClick(item.id);
               } : undefined}
             >
+              {item.name}
+            </li>
+          ))}
+        </ul>
+      ) : previewNames && previewNames.length > 0 ? (
+        <ul className={styles.previewList}>
+          {previewNames.map((name) => (
+            <li key={name} className={styles.previewItem}>
               {name}
             </li>
           ))}

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.module.css
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.module.css
@@ -33,6 +33,26 @@
   border-radius: var(--radius-lg);
   color: var(--error-color);
   font-size: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  align-items: flex-start;
+}
+
+.errorRetryBtn {
+  padding: 6px 14px;
+  background: var(--text-primary);
+  color: var(--bg-color);
+  border: none;
+  border-radius: var(--radius-xl);
+  font-size: 12px;
+  font-weight: var(--font-weight-heading);
+  cursor: pointer;
+  transition: opacity var(--transition-fast);
+}
+
+.errorRetryBtn:hover {
+  opacity: 0.8;
 }
 
 .metaCard {
@@ -51,7 +71,7 @@
 .versionNoLabel {
   font-family: var(--font-mono);
   font-size: 16px;
-  font-weight: 600;
+  font-weight: 540;
   color: var(--text-primary);
 }
 

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.module.css
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.module.css
@@ -1,0 +1,100 @@
+.panel {
+  flex: 1;
+  overflow-y: auto;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.placeholder {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+  font-size: 14px;
+}
+
+.skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.skeletonBlock {
+  border-radius: var(--radius-lg);
+  background: var(--hover-bg);
+}
+
+.error {
+  padding: 20px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-lg);
+  color: var(--error-color);
+  font-size: 14px;
+}
+
+.metaCard {
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-lg);
+  padding: 14px;
+}
+
+.metaHeader {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.versionNoLabel {
+  font-family: var(--font-mono);
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: var(--radius-sm);
+  font-size: 11px;
+  font-weight: var(--font-weight-heading);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  border: 1px solid var(--glass-border);
+  color: var(--text-secondary);
+}
+
+.badgePublished {
+  background: var(--text-primary);
+  color: var(--bg-color);
+  border-color: var(--text-primary);
+}
+
+.metaGrid {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 4px 16px;
+  font-size: 12px;
+}
+
+.metaKey {
+  color: var(--text-muted);
+}
+
+.metaValue {
+  font-family: var(--font-mono);
+  color: var(--text-secondary);
+}
+
+.sectionTitle {
+  font-size: var(--font-size-label);
+  font-weight: var(--font-weight-heading);
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: 8px;
+}

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.test.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.test.tsx
@@ -1,0 +1,111 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import type { UseQueryResult } from '@tanstack/react-query';
+import type { DomainPackVersionDetail } from '@/entities/domain-pack';
+import { ApiRequestError } from '@/shared/api';
+import { SummaryDetailPanel } from './SummaryDetailPanel';
+
+vi.mock('./SummaryJsonCard', () => ({
+  SummaryJsonCard: ({ summaryJson }: { summaryJson: string }) => (
+    <div data-testid="summary-json-card">{summaryJson}</div>
+  ),
+}));
+
+vi.mock('./ComponentCountGrid', () => ({
+  ComponentCountGrid: () => <div data-testid="component-count-grid" />,
+}));
+
+function makeQuery(
+  overrides: Partial<UseQueryResult<DomainPackVersionDetail>>,
+): UseQueryResult<DomainPackVersionDetail> {
+  return {
+    isLoading: false,
+    isError: false,
+    isFetching: false,
+    data: undefined,
+    error: null,
+    refetch: vi.fn(),
+    ...overrides,
+  } as unknown as UseQueryResult<DomainPackVersionDetail>;
+}
+
+const stubDetail: DomainPackVersionDetail = {
+  versionId: 3,
+  packId: 2,
+  versionNo: 1,
+  lifecycleStatus: 'DRAFT',
+  sourcePipelineJobId: null,
+  summaryJson: '{"key":"val"}',
+  intentCount: 5,
+  slotCount: 2,
+  policyCount: 1,
+  riskCount: 0,
+  workflowCount: 3,
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+};
+
+describe('SummaryDetailPanel', () => {
+  it('data 없고 로딩/에러 없으면 "버전을 선택하세요." 안내를 표시한다', () => {
+    render(<SummaryDetailPanel query={makeQuery({})} wsId={1} packId={2} />);
+    expect(screen.getByText('버전을 선택하세요.')).toBeInTheDocument();
+  });
+
+  it('loading 상태에서 "로딩 중" aria-label을 렌더링한다', () => {
+    render(
+      <SummaryDetailPanel query={makeQuery({ isLoading: true })} wsId={1} packId={2} />,
+    );
+    expect(screen.getByLabelText('로딩 중')).toBeInTheDocument();
+  });
+
+  it('일반 에러 시 에러 메시지를 alert role로 표시한다', () => {
+    render(
+      <SummaryDetailPanel
+        query={makeQuery({ isError: true, error: new Error('fail') })}
+        wsId={1}
+        packId={2}
+      />,
+    );
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      '버전 상세 정보를 불러오지 못했습니다.',
+    );
+  });
+
+  it('404 에러 시 "버전을 찾을 수 없습니다." 메시지를 표시하고 다시 시도 버튼은 없다', () => {
+    const error404 = new ApiRequestError(404, 'NOT_FOUND', 'not found');
+    render(
+      <SummaryDetailPanel
+        query={makeQuery({ isError: true, error: error404 })}
+        wsId={1}
+        packId={2}
+      />,
+    );
+    expect(screen.getByRole('alert')).toHaveTextContent('버전을 찾을 수 없습니다.');
+    expect(screen.queryByRole('button', { name: '다시 시도' })).not.toBeInTheDocument();
+  });
+
+  it('일반 에러 시 다시 시도 버튼을 표시하고 클릭 시 refetch를 호출한다', () => {
+    const refetch = vi.fn();
+    render(
+      <SummaryDetailPanel
+        query={makeQuery({ isError: true, error: new Error('fail'), refetch })}
+        wsId={1}
+        packId={2}
+      />,
+    );
+    const retryBtn = screen.getByRole('button', { name: '다시 시도' });
+    expect(retryBtn).toBeInTheDocument();
+    fireEvent.click(retryBtn);
+    expect(refetch).toHaveBeenCalled();
+  });
+
+  it('정상 데이터 시 버전 번호와 라이프사이클 상태를 렌더링한다', () => {
+    render(
+      <SummaryDetailPanel query={makeQuery({ data: stubDetail })} wsId={1} packId={2} />,
+    );
+    expect(screen.getByText('v1')).toBeInTheDocument();
+    expect(screen.getByText('DRAFT')).toBeInTheDocument();
+    expect(screen.getByTestId('summary-json-card')).toBeInTheDocument();
+    expect(screen.getByTestId('component-count-grid')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.tsx
@@ -1,0 +1,101 @@
+import type { UseQueryResult } from '@tanstack/react-query';
+import type { DomainPackVersionDetail } from '@/entities/domain-pack';
+import { ApiRequestError } from '@/shared/api';
+import { SummaryJsonCard } from './SummaryJsonCard';
+import { ComponentCountGrid } from './ComponentCountGrid';
+import styles from './SummaryDetailPanel.module.css';
+
+interface SummaryDetailPanelProps {
+  query: UseQueryResult<DomainPackVersionDetail>;
+  wsId: number;
+  packId: number;
+}
+
+export function SummaryDetailPanel({ query, wsId, packId }: SummaryDetailPanelProps) {
+  if (!query.isFetching && !query.data && !query.isLoading && !query.isError) {
+    return (
+      <div className={styles.panel}>
+        <div className={styles.placeholder}>버전을 선택하세요.</div>
+      </div>
+    );
+  }
+
+  if (query.isLoading) {
+    return (
+      <div className={styles.panel}>
+        <div className={styles.skeleton} aria-label="로딩 중">
+          <div className={styles.skeletonBlock} style={{ height: 80 }} aria-hidden />
+          <div className={styles.skeletonBlock} style={{ height: 160 }} aria-hidden />
+          <div className={styles.skeletonBlock} style={{ height: 200 }} aria-hidden />
+        </div>
+      </div>
+    );
+  }
+
+  if (query.isError) {
+    const is404 = query.error instanceof ApiRequestError && query.error.status === 404;
+    return (
+      <div className={styles.panel}>
+        <div className={styles.error} role="alert">
+          {is404 ? '버전을 찾을 수 없습니다.' : '버전 상세 정보를 불러오지 못했습니다.'}
+        </div>
+      </div>
+    );
+  }
+
+  const v = query.data!;
+
+  return (
+    <div className={styles.panel}>
+      <div className={styles.metaCard}>
+        <div className={styles.metaHeader}>
+          <span className={styles.versionNoLabel}>v{v.versionNo}</span>
+          <span
+            className={`${styles.badge} ${
+              v.lifecycleStatus === 'PUBLISHED' ? styles.badgePublished : ''
+            }`}
+          >
+            {v.lifecycleStatus}
+          </span>
+        </div>
+        <div className={styles.metaGrid}>
+          <span className={styles.metaKey}>생성</span>
+          <span className={styles.metaValue}>{formatDate(v.createdAt)}</span>
+          {v.sourcePipelineJobId !== null && (
+            <>
+              <span className={styles.metaKey}>Pipeline Job</span>
+              <span className={styles.metaValue}>{v.sourcePipelineJobId}</span>
+            </>
+          )}
+        </div>
+      </div>
+
+      <div>
+        <div className={styles.sectionTitle}>Summary JSON</div>
+        <SummaryJsonCard summaryJson={v.summaryJson} />
+      </div>
+
+      <div>
+        <div className={styles.sectionTitle}>구성요소</div>
+        <ComponentCountGrid
+          wsId={wsId}
+          packId={packId}
+          versionId={v.versionId}
+          intentCount={v.intentCount}
+          slotCount={v.slotCount}
+          policyCount={v.policyCount}
+          riskCount={v.riskCount}
+          workflowCount={v.workflowCount}
+        />
+      </div>
+    </div>
+  );
+}
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString('ko-KR');
+  } catch {
+    return iso;
+  }
+}

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.tsx
@@ -37,13 +37,19 @@ export function SummaryDetailPanel({ query, wsId, packId }: SummaryDetailPanelPr
     return (
       <div className={styles.panel}>
         <div className={styles.error} role="alert">
-          {is404 ? '버전을 찾을 수 없습니다.' : '버전 상세 정보를 불러오지 못했습니다.'}
+          <span>{is404 ? '버전을 찾을 수 없습니다.' : '버전 상세 정보를 불러오지 못했습니다.'}</span>
+          {!is404 && (
+            <button type="button" className={styles.errorRetryBtn} onClick={() => query.refetch()}>
+              다시 시도
+            </button>
+          )}
         </div>
       </div>
     );
   }
 
-  const v = query.data!;
+  if (!query.data) return null;
+  const v = query.data;
 
   return (
     <div className={styles.panel}>

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryJsonCard.module.css
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryJsonCard.module.css
@@ -67,7 +67,7 @@
 
 .value {
   color: var(--text-primary);
-  word-break: break-word;
+  overflow-wrap: anywhere;
 }
 
 .rawPre {

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryJsonCard.module.css
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryJsonCard.module.css
@@ -1,0 +1,95 @@
+.card {
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.cardHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--glass-border);
+  background: var(--bg-secondary);
+}
+
+.cardTitle {
+  font-size: var(--font-size-label);
+  font-weight: var(--font-weight-heading);
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.toggleGroup {
+  display: flex;
+  gap: 2px;
+  background: var(--glass-dark-soft);
+  border-radius: var(--radius-sm);
+  padding: 2px;
+}
+
+.toggleBtn {
+  padding: 3px 10px;
+  border: none;
+  background: transparent;
+  border-radius: var(--radius-sm);
+  font-size: 11px;
+  font-weight: var(--font-weight-heading);
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.toggleBtn.active {
+  background: var(--bg-color);
+  color: var(--text-primary);
+  box-shadow: var(--shadow-card);
+}
+
+.cardBody {
+  padding: 14px;
+}
+
+.keyValueGrid {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 6px 12px;
+  font-size: 13px;
+}
+
+.key {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+.value {
+  color: var(--text-primary);
+  word-break: break-word;
+}
+
+.rawPre {
+  margin: 0;
+  padding: 0;
+  background: transparent;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-primary);
+  white-space: pre-wrap;
+  word-break: break-all;
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.fallbackWarning {
+  font-size: 11px;
+  color: var(--error-color);
+  margin-bottom: 8px;
+}
+
+.empty {
+  color: var(--text-muted);
+  font-size: 13px;
+}

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryJsonCard.module.css
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryJsonCard.module.css
@@ -34,7 +34,7 @@
   border: none;
   background: transparent;
   border-radius: var(--radius-sm);
-  font-size: 11px;
+  font-size: var(--font-size-xs);
   font-weight: var(--font-weight-heading);
   color: var(--text-muted);
   cursor: pointer;
@@ -55,12 +55,12 @@
   display: grid;
   grid-template-columns: auto 1fr;
   gap: 6px 12px;
-  font-size: 13px;
+  font-size: var(--font-size-sm);
 }
 
 .key {
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--font-size-label);
   color: var(--text-secondary);
   white-space: nowrap;
 }
@@ -75,7 +75,7 @@
   padding: 0;
   background: transparent;
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--font-size-label);
   color: var(--text-primary);
   white-space: pre-wrap;
   word-break: break-all;
@@ -84,12 +84,12 @@
 }
 
 .fallbackWarning {
-  font-size: 11px;
+  font-size: var(--font-size-xs);
   color: var(--error-color);
   margin-bottom: 8px;
 }
 
 .empty {
   color: var(--text-muted);
-  font-size: 13px;
+  font-size: var(--font-size-sm);
 }

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryJsonCard.test.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryJsonCard.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { SummaryJsonCard } from './SummaryJsonCard';
+
+describe('SummaryJsonCard', () => {
+  it('유효한 JSON 객체를 카드 모드로 렌더링한다', () => {
+    render(<SummaryJsonCard summaryJson='{"name":"test"}' />);
+    expect(screen.getByText('name')).toBeInTheDocument();
+    expect(screen.getByText('test')).toBeInTheDocument();
+  });
+
+  it('중첩 객체 값을 JSON.stringify로 렌더링한다', () => {
+    render(<SummaryJsonCard summaryJson='{"nested":{"a":1}}' />);
+    expect(screen.getByText('nested')).toBeInTheDocument();
+    expect(screen.getByText('{"a":1}')).toBeInTheDocument();
+  });
+
+  it('null 값을 "null" 문자열로 렌더링한다', () => {
+    render(<SummaryJsonCard summaryJson='{"k":null}' />);
+    expect(screen.getByText('null')).toBeInTheDocument();
+  });
+
+  it('빈 객체 시 "내용 없음"을 표시한다', () => {
+    render(<SummaryJsonCard summaryJson='{}' />);
+    expect(screen.getByText('내용 없음')).toBeInTheDocument();
+  });
+
+  it('파싱 실패 시 경고 메시지를 alert role로 표시한다', () => {
+    render(<SummaryJsonCard summaryJson='{bad json}' />);
+    expect(screen.getByRole('alert')).toHaveTextContent('JSON 파싱 실패');
+  });
+
+  it('"Raw JSON" 버튼 클릭 시 원문 JSON을 표시한다', () => {
+    const json = '{"key":"val"}';
+    render(<SummaryJsonCard summaryJson={json} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Raw JSON' }));
+    expect(screen.getByText(json)).toBeInTheDocument();
+  });
+
+  it('Raw 모드에서 "카드" 버튼 클릭 시 카드 모드로 전환한다', () => {
+    render(<SummaryJsonCard summaryJson='{"k":"v"}' />);
+    fireEvent.click(screen.getByRole('button', { name: 'Raw JSON' }));
+    fireEvent.click(screen.getByRole('button', { name: '카드' }));
+    expect(screen.getByText('k')).toBeInTheDocument();
+  });
+
+  it('초기 상태에서 "카드" 버튼이 aria-pressed=true, "Raw JSON" 버튼이 aria-pressed=false다', () => {
+    render(<SummaryJsonCard summaryJson='{}' />);
+    expect(screen.getByRole('button', { name: '카드' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: 'Raw JSON' })).toHaveAttribute('aria-pressed', 'false');
+  });
+});

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryJsonCard.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryJsonCard.tsx
@@ -1,0 +1,68 @@
+import { useState, useMemo, Fragment } from 'react';
+import { parseSummaryJson } from '../model/parseSummaryJson';
+import styles from './SummaryJsonCard.module.css';
+
+interface SummaryJsonCardProps {
+  summaryJson: string;
+}
+
+export function SummaryJsonCard({ summaryJson }: SummaryJsonCardProps) {
+  const [mode, setMode] = useState<'card' | 'raw'>('card');
+
+  const parsed = useMemo(() => parseSummaryJson(summaryJson), [summaryJson]);
+
+  return (
+    <div className={styles.card}>
+      <div className={styles.cardHeader}>
+        <span className={styles.cardTitle}>Summary JSON</span>
+        <div className={styles.toggleGroup} role="group" aria-label="보기 방식">
+          <button
+            type="button"
+            className={`${styles.toggleBtn} ${mode === 'card' ? styles.active : ''}`}
+            onClick={() => setMode('card')}
+            aria-pressed={mode === 'card'}
+          >
+            카드
+          </button>
+          <button
+            type="button"
+            className={`${styles.toggleBtn} ${mode === 'raw' ? styles.active : ''}`}
+            onClick={() => setMode('raw')}
+            aria-pressed={mode === 'raw'}
+          >
+            Raw JSON
+          </button>
+        </div>
+      </div>
+      <div className={styles.cardBody}>
+        {mode === 'card' ? (
+          <>
+            {!parsed.ok && (
+              <p className={styles.fallbackWarning} role="alert">
+                JSON 파싱 실패 — 원문 표시
+              </p>
+            )}
+            {parsed.ok ? (
+              Object.keys(parsed.data).length === 0 ? (
+                <span className={styles.empty}>내용 없음</span>
+              ) : (
+                <div className={styles.keyValueGrid}>
+                  {Object.entries(parsed.data).map(([k, v]) => (
+                    <Fragment key={k}>
+                      <span className={styles.key}>{k}</span>
+                      <span className={styles.value}>{String(v)}</span>
+                    </Fragment>
+                  ))}
+                </div>
+              )
+            ) : (
+              <pre className={styles.rawPre}><code>{parsed.raw}</code></pre>
+            )}
+          </>
+        ) : (
+          <pre className={styles.rawPre}><code>{summaryJson}</code></pre>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryJsonCard.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryJsonCard.tsx
@@ -2,6 +2,12 @@ import { useState, useMemo, Fragment } from 'react';
 import { parseSummaryJson } from '../model/parseSummaryJson';
 import styles from './SummaryJsonCard.module.css';
 
+function renderValue(v: unknown): string {
+  if (v === null || v === undefined) return String(v);
+  if (typeof v === 'object') return JSON.stringify(v);
+  return String(v);
+}
+
 interface SummaryJsonCardProps {
   summaryJson: string;
 }
@@ -50,7 +56,7 @@ export function SummaryJsonCard({ summaryJson }: SummaryJsonCardProps) {
                   {Object.entries(parsed.data).map(([k, v]) => (
                     <Fragment key={k}>
                       <span className={styles.key}>{k}</span>
-                      <span className={styles.value}>{String(v)}</span>
+                      <span className={styles.value}>{renderValue(v)}</span>
                     </Fragment>
                   ))}
                 </div>

--- a/frontend/src/features/domain-pack-summary-read/ui/VersionListPanel.module.css
+++ b/frontend/src/features/domain-pack-summary-read/ui/VersionListPanel.module.css
@@ -1,0 +1,144 @@
+.panel {
+  width: 320px;
+  min-width: 220px;
+  border-right: 1px solid var(--glass-border);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.header {
+  padding: 16px;
+  border-bottom: 1px solid var(--glass-border);
+  font-size: var(--font-size-label);
+  font-weight: var(--font-weight-heading);
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px 0;
+}
+
+.item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 10px 16px;
+  cursor: pointer;
+  border-left: 2px solid transparent;
+  transition: background var(--transition-fast), border-color var(--transition-fast);
+}
+
+.item:hover {
+  background: var(--hover-bg);
+}
+
+.item.active {
+  border-left-color: var(--text-primary);
+  background: var(--bg-secondary);
+}
+
+.itemRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.versionNo {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 6px;
+  border-radius: var(--radius-sm);
+  font-size: 10px;
+  font-weight: var(--font-weight-heading);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  border: 1px solid var(--glass-border);
+  color: var(--text-secondary);
+}
+
+.badgeDraft {
+  border-color: var(--glass-border);
+}
+
+.badgePublished {
+  background: var(--text-primary);
+  color: var(--bg-color);
+  border-color: var(--text-primary);
+}
+
+.sourceBadge {
+  composes: badge;
+  color: var(--text-muted);
+  font-size: 9px;
+}
+
+.createdAt {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.skeleton {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.skeletonItem {
+  height: 48px;
+  background: var(--hover-bg);
+  border-radius: var(--radius-md);
+}
+
+.empty {
+  padding: 24px 16px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 13px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  align-items: center;
+}
+
+.ctaButton {
+  padding: 6px 12px;
+  background: var(--text-primary);
+  color: var(--bg-color);
+  border: none;
+  border-radius: var(--radius-md);
+  font-size: 12px;
+  font-weight: var(--font-weight-heading);
+  cursor: pointer;
+  transition: opacity var(--transition-fast);
+}
+
+.ctaButton:hover {
+  opacity: 0.8;
+}
+
+@media (max-width: 1023px) {
+  .panel {
+    width: 260px;
+  }
+}
+
+@media (max-width: 767px) {
+  .panel {
+    width: 100%;
+    border-right: none;
+    border-bottom: 1px solid var(--glass-border);
+  }
+}

--- a/frontend/src/features/domain-pack-summary-read/ui/VersionListPanel.module.css
+++ b/frontend/src/features/domain-pack-summary-read/ui/VersionListPanel.module.css
@@ -24,21 +24,32 @@
 }
 
 .item {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  padding: 10px 16px;
-  cursor: pointer;
   border-left: 2px solid transparent;
-  transition: background var(--transition-fast), border-color var(--transition-fast);
-}
-
-.item:hover {
-  background: var(--hover-bg);
+  transition: border-color var(--transition-fast);
 }
 
 .item.active {
   border-left-color: var(--text-primary);
+}
+
+.itemBtn {
+  width: 100%;
+  background: transparent;
+  border: none;
+  padding: 10px 16px;
+  cursor: pointer;
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  transition: background var(--transition-fast);
+}
+
+.itemBtn:hover {
+  background: var(--hover-bg);
+}
+
+.item.active .itemBtn {
   background: var(--bg-secondary);
 }
 
@@ -51,7 +62,7 @@
 .versionNo {
   font-family: var(--font-mono);
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 480;
   color: var(--text-primary);
 }
 
@@ -118,7 +129,7 @@
   background: var(--text-primary);
   color: var(--bg-color);
   border: none;
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-xl);
   font-size: 12px;
   font-weight: var(--font-weight-heading);
   cursor: pointer;

--- a/frontend/src/features/domain-pack-summary-read/ui/VersionListPanel.test.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/VersionListPanel.test.tsx
@@ -1,0 +1,132 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { UseQueryResult } from '@tanstack/react-query';
+import type { DomainPackDetail } from '@/entities/domain-pack';
+import { VersionListPanel } from './VersionListPanel';
+
+function makeQuery(
+  overrides: Partial<UseQueryResult<DomainPackDetail>>,
+): UseQueryResult<DomainPackDetail> {
+  return {
+    isLoading: false,
+    isError: false,
+    isFetching: false,
+    data: undefined,
+    error: null,
+    refetch: vi.fn(),
+    ...overrides,
+  } as unknown as UseQueryResult<DomainPackDetail>;
+}
+
+const stubVersion = {
+  versionId: 1,
+  versionNo: 1,
+  lifecycleStatus: 'DRAFT' as const,
+  sourcePipelineJobId: null,
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+};
+
+const stubPack: DomainPackDetail = {
+  packId: 2,
+  workspaceId: 1,
+  code: 'CS',
+  name: '고객지원',
+  description: null,
+  versions: [stubVersion],
+  createdAt: '',
+  updatedAt: '',
+};
+
+describe('VersionListPanel', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('loading 상태에서 버전 목록을 렌더링하지 않는다', () => {
+    render(
+      <VersionListPanel
+        query={makeQuery({ isLoading: true })}
+        selectedId={null}
+        onSelect={vi.fn()}
+      />,
+    );
+    expect(screen.queryByRole('list')).not.toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('error 상태에서 에러 메시지와 다시 시도 버튼을 표시한다', () => {
+    const refetch = vi.fn();
+    render(
+      <VersionListPanel
+        query={makeQuery({ isError: true, error: new Error('fail'), refetch })}
+        selectedId={null}
+        onSelect={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('alert')).toHaveTextContent('버전 목록을 불러오지 못했습니다.');
+    const retryBtn = screen.getByRole('button', { name: '다시 시도' });
+    fireEvent.click(retryBtn);
+    expect(refetch).toHaveBeenCalled();
+  });
+
+  it('빈 버전 목록 시 안내 메시지를 표시한다', () => {
+    render(
+      <VersionListPanel
+        query={makeQuery({ data: { ...stubPack, versions: [] } })}
+        selectedId={null}
+        onSelect={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('버전이 없습니다.')).toBeInTheDocument();
+  });
+
+  it('onCreateDraft 전달 시 "새 DRAFT 묶기" 버튼을 표시하고 클릭 시 호출한다', () => {
+    const onCreateDraft = vi.fn();
+    render(
+      <VersionListPanel
+        query={makeQuery({ data: { ...stubPack, versions: [] } })}
+        selectedId={null}
+        onSelect={vi.fn()}
+        onCreateDraft={onCreateDraft}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: '새 DRAFT 묶기' }));
+    expect(onCreateDraft).toHaveBeenCalled();
+  });
+
+  it('버전 목록을 렌더링하고 클릭 시 onSelect를 호출한다', () => {
+    const onSelect = vi.fn();
+    render(
+      <VersionListPanel
+        query={makeQuery({ data: stubPack })}
+        selectedId={null}
+        onSelect={onSelect}
+      />,
+    );
+    expect(screen.getByText('버전 1개')).toBeInTheDocument();
+    const btn = screen.getByRole('button', { name: /v1/ });
+    fireEvent.click(btn);
+    expect(onSelect).toHaveBeenCalledWith(1);
+  });
+
+  it('active 버전 button에 aria-current="true"가 부여된다', () => {
+    render(
+      <VersionListPanel
+        query={makeQuery({ data: stubPack })}
+        selectedId={1}
+        onSelect={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('button', { name: /v1/ })).toHaveAttribute('aria-current', 'true');
+  });
+
+  it('inactive 버전 button에는 tabIndex=-1이 부여된다', () => {
+    render(
+      <VersionListPanel
+        query={makeQuery({ data: stubPack })}
+        selectedId={null}
+        onSelect={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('button', { name: /v1/ })).toHaveAttribute('tabindex', '-1');
+  });
+});

--- a/frontend/src/features/domain-pack-summary-read/ui/VersionListPanel.test.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/VersionListPanel.test.tsx
@@ -27,6 +27,15 @@ const stubVersion = {
   updatedAt: '2026-01-01T00:00:00Z',
 };
 
+const stubVersion2 = {
+  versionId: 2,
+  versionNo: 2,
+  lifecycleStatus: 'DRAFT' as const,
+  sourcePipelineJobId: null,
+  createdAt: '2026-01-02T00:00:00Z',
+  updatedAt: '2026-01-02T00:00:00Z',
+};
+
 const stubPack: DomainPackDetail = {
   packId: 2,
   workspaceId: 1,
@@ -36,6 +45,11 @@ const stubPack: DomainPackDetail = {
   versions: [stubVersion],
   createdAt: '',
   updatedAt: '',
+};
+
+const stubPackMulti: DomainPackDetail = {
+  ...stubPack,
+  versions: [stubVersion, stubVersion2],
 };
 
 describe('VersionListPanel', () => {
@@ -119,14 +133,15 @@ describe('VersionListPanel', () => {
     expect(screen.getByRole('button', { name: /v1/ })).toHaveAttribute('aria-current', 'true');
   });
 
-  it('inactive 버전 button에는 tabIndex=-1이 부여된다', () => {
+  it('selectedId=null 시 첫 번째 버전 button에 tabIndex=0, 나머지에는 tabIndex=-1이 부여된다', () => {
     render(
       <VersionListPanel
-        query={makeQuery({ data: stubPack })}
+        query={makeQuery({ data: stubPackMulti })}
         selectedId={null}
         onSelect={vi.fn()}
       />,
     );
-    expect(screen.getByRole('button', { name: /v1/ })).toHaveAttribute('tabindex', '-1');
+    expect(screen.getByRole('button', { name: /v1/ })).toHaveAttribute('tabindex', '0');
+    expect(screen.getByRole('button', { name: /v2/ })).toHaveAttribute('tabindex', '-1');
   });
 });

--- a/frontend/src/features/domain-pack-summary-read/ui/VersionListPanel.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/VersionListPanel.tsx
@@ -1,0 +1,119 @@
+import type { UseQueryResult } from '@tanstack/react-query';
+import type { DomainPackDetail, DomainPackVersionSummary } from '@/entities/domain-pack';
+import styles from './VersionListPanel.module.css';
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleDateString('ko-KR', {
+      year: 'numeric', month: '2-digit', day: '2-digit',
+    });
+  } catch {
+    return iso;
+  }
+}
+
+interface VersionListPanelProps {
+  query: UseQueryResult<DomainPackDetail>;
+  selectedId: number | null;
+  onSelect: (versionId: number) => void;
+  onCreateDraft?: () => void;
+}
+
+export function VersionListPanel({ query, selectedId, onSelect, onCreateDraft }: VersionListPanelProps) {
+  if (query.isLoading) {
+    return (
+      <div className={styles.panel}>
+        <div className={styles.skeleton}>
+          {[0, 1, 2].map((i) => (
+            <div key={i} className={styles.skeletonItem} aria-hidden />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (query.isError) {
+    return (
+      <div className={styles.panel}>
+        <div className={styles.empty} role="alert">
+          <span>버전 목록을 불러오지 못했습니다.</span>
+          <button type="button" className={styles.ctaButton} onClick={() => query.refetch()}>
+            다시 시도
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const versions = query.data?.versions ?? [];
+
+  if (versions.length === 0) {
+    return (
+      <div className={styles.panel}>
+        <div className={styles.empty}>
+          <span>버전이 없습니다.</span>
+          {onCreateDraft && (
+            <button className={styles.ctaButton} type="button" onClick={onCreateDraft}>
+              새 DRAFT 묶기
+            </button>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.panel}>
+      <div className={styles.header}>버전 {versions.length}개</div>
+      <ul className={styles.list} role="listbox" aria-label="버전 목록">
+        {versions.map((v) => (
+          <VersionListItem
+            key={v.versionId}
+            version={v}
+            isActive={v.versionId === selectedId}
+            onSelect={onSelect}
+          />
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+interface VersionListItemProps {
+  version: DomainPackVersionSummary;
+  isActive: boolean;
+  onSelect: (versionId: number) => void;
+}
+
+function VersionListItem({ version, isActive, onSelect }: VersionListItemProps) {
+  return (
+    <li
+      className={`${styles.item} ${isActive ? styles.active : ''}`}
+      role="option"
+      aria-selected={isActive}
+      tabIndex={0}
+      onClick={() => onSelect(version.versionId)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onSelect(version.versionId);
+        }
+      }}
+    >
+      <div className={styles.itemRow}>
+        <span className={styles.versionNo}>v{version.versionNo}</span>
+        <span
+          className={`${styles.badge} ${
+            version.lifecycleStatus === 'PUBLISHED' ? styles.badgePublished : styles.badgeDraft
+          }`}
+        >
+          {version.lifecycleStatus}
+        </span>
+        {version.sourcePipelineJobId !== null && (
+          <span className={styles.sourceBadge}>PIPELINE</span>
+        )}
+      </div>
+      <span className={styles.createdAt}>{formatDate(version.createdAt)}</span>
+    </li>
+  );
+}

--- a/frontend/src/features/domain-pack-summary-read/ui/VersionListPanel.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/VersionListPanel.tsx
@@ -65,7 +65,7 @@ export function VersionListPanel({ query, selectedId, onSelect, onCreateDraft }:
   return (
     <div className={styles.panel}>
       <div className={styles.header}>버전 {versions.length}개</div>
-      <ul className={styles.list} role="listbox" aria-label="버전 목록">
+      <ul className={styles.list} role="list" aria-label="버전 목록">
         {versions.map((v) => (
           <VersionListItem
             key={v.versionId}
@@ -87,33 +87,29 @@ interface VersionListItemProps {
 
 function VersionListItem({ version, isActive, onSelect }: VersionListItemProps) {
   return (
-    <li
-      className={`${styles.item} ${isActive ? styles.active : ''}`}
-      role="option"
-      aria-selected={isActive}
-      tabIndex={0}
-      onClick={() => onSelect(version.versionId)}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault();
-          onSelect(version.versionId);
-        }
-      }}
-    >
-      <div className={styles.itemRow}>
-        <span className={styles.versionNo}>v{version.versionNo}</span>
-        <span
-          className={`${styles.badge} ${
-            version.lifecycleStatus === 'PUBLISHED' ? styles.badgePublished : styles.badgeDraft
-          }`}
-        >
-          {version.lifecycleStatus}
-        </span>
-        {version.sourcePipelineJobId !== null && (
-          <span className={styles.sourceBadge}>PIPELINE</span>
-        )}
-      </div>
-      <span className={styles.createdAt}>{formatDate(version.createdAt)}</span>
+    <li className={`${styles.item} ${isActive ? styles.active : ''}`}>
+      <button
+        type="button"
+        className={styles.itemBtn}
+        tabIndex={isActive ? 0 : -1}
+        aria-current={isActive || undefined}
+        onClick={() => onSelect(version.versionId)}
+      >
+        <div className={styles.itemRow}>
+          <span className={styles.versionNo}>v{version.versionNo}</span>
+          <span
+            className={`${styles.badge} ${
+              version.lifecycleStatus === 'PUBLISHED' ? styles.badgePublished : styles.badgeDraft
+            }`}
+          >
+            {version.lifecycleStatus}
+          </span>
+          {version.sourcePipelineJobId !== null && (
+            <span className={styles.sourceBadge}>PIPELINE</span>
+          )}
+        </div>
+        <span className={styles.createdAt}>{formatDate(version.createdAt)}</span>
+      </button>
     </li>
   );
 }

--- a/frontend/src/features/domain-pack-summary-read/ui/VersionListPanel.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/VersionListPanel.tsx
@@ -46,6 +46,7 @@ export function VersionListPanel({ query, selectedId, onSelect, onCreateDraft }:
   }
 
   const versions = query.data?.versions ?? [];
+  const effectiveSelectedId = selectedId ?? (versions[0]?.versionId ?? null);
 
   if (versions.length === 0) {
     return (
@@ -71,6 +72,7 @@ export function VersionListPanel({ query, selectedId, onSelect, onCreateDraft }:
             key={v.versionId}
             version={v}
             isActive={v.versionId === selectedId}
+            isTabStop={v.versionId === effectiveSelectedId}
             onSelect={onSelect}
           />
         ))}
@@ -82,16 +84,17 @@ export function VersionListPanel({ query, selectedId, onSelect, onCreateDraft }:
 interface VersionListItemProps {
   version: DomainPackVersionSummary;
   isActive: boolean;
+  isTabStop: boolean;
   onSelect: (versionId: number) => void;
 }
 
-function VersionListItem({ version, isActive, onSelect }: VersionListItemProps) {
+function VersionListItem({ version, isActive, isTabStop, onSelect }: VersionListItemProps) {
   return (
     <li className={`${styles.item} ${isActive ? styles.active : ''}`}>
       <button
         type="button"
         className={styles.itemBtn}
-        tabIndex={isActive ? 0 : -1}
+        tabIndex={isTabStop ? 0 : -1}
         aria-current={isActive || undefined}
         onClick={() => onSelect(version.versionId)}
       >

--- a/frontend/src/features/domain-pack-summary-read/ui/index.ts
+++ b/frontend/src/features/domain-pack-summary-read/ui/index.ts
@@ -1,0 +1,4 @@
+export { VersionListPanel } from './VersionListPanel';
+export { SummaryDetailPanel } from './SummaryDetailPanel';
+export { SummaryJsonCard } from './SummaryJsonCard';
+export { ComponentCountGrid } from './ComponentCountGrid';

--- a/frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.test.tsx
+++ b/frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.test.tsx
@@ -1,0 +1,121 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { ApiRequestError } from '@/shared/api';
+import { usePackDetail, useVersionDetail } from '@/features/domain-pack-summary-read';
+import { DomainPackSummaryPage } from './DomainPackSummaryPage';
+
+const ROUTE = '/workspaces/:workspaceId/domain-packs/:packId';
+
+vi.mock('@/shared/ui/layout/DashboardLayout', () => ({
+  DashboardLayout: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/features/domain-pack-summary-read', () => ({
+  usePackDetail: vi.fn(),
+  useVersionDetail: vi.fn(),
+  VersionListPanel: () => <div data-testid="version-list-panel" />,
+  SummaryDetailPanel: () => <div data-testid="summary-detail-panel" />,
+}));
+
+vi.mock('@/features/domain-pack-draft-create', () => ({
+  CreateDraftModal: ({ onClose }: { onClose: () => void }) => (
+    <div data-testid="create-draft-modal">
+      <button type="button" onClick={onClose}>모달 닫기</button>
+    </div>
+  ),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function makePackQuery(overrides: Record<string, unknown> = {}): any {
+  return {
+    isLoading: false,
+    isError: false,
+    isFetching: false,
+    data: undefined,
+    error: null,
+    refetch: vi.fn(),
+    ...overrides,
+  };
+}
+
+function renderPage(path = '/workspaces/1/domain-packs/2') {
+  render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path={ROUTE} element={<DomainPackSummaryPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('DomainPackSummaryPage', () => {
+  beforeEach(() => {
+    vi.mocked(usePackDetail).mockReturnValue(makePackQuery());
+    vi.mocked(useVersionDetail).mockReturnValue(makePackQuery());
+  });
+
+  it('유효하지 않은 workspaceId 시 에러 메시지를 표시한다', () => {
+    renderPage('/workspaces/abc/domain-packs/2');
+    expect(screen.getByRole('alert')).toHaveTextContent('잘못된 URL 파라미터');
+  });
+
+  it('packDetail 에러(비404) 시 에러 카드와 다시 시도 버튼을 표시한다', () => {
+    const refetch = vi.fn();
+    vi.mocked(usePackDetail).mockReturnValue(
+      makePackQuery({ isError: true, error: new Error('fail'), refetch }),
+    );
+    renderPage();
+    expect(screen.getByRole('alert')).toHaveTextContent('Pack 정보를 불러오지 못했습니다.');
+    fireEvent.click(screen.getByRole('button', { name: '다시 시도' }));
+    expect(refetch).toHaveBeenCalled();
+  });
+
+  it('packDetail 404 에러 시 "Pack을 찾을 수 없습니다." 메시지를 표시한다', () => {
+    const error404 = new ApiRequestError(404, 'NOT_FOUND', 'not found');
+    vi.mocked(usePackDetail).mockReturnValue(
+      makePackQuery({ isError: true, error: error404 }),
+    );
+    renderPage();
+    expect(screen.getByRole('alert')).toHaveTextContent('Pack을 찾을 수 없습니다.');
+  });
+
+  it('정상 상태에서 VersionListPanel과 SummaryDetailPanel을 렌더링한다', () => {
+    vi.mocked(usePackDetail).mockReturnValue(
+      makePackQuery({ data: { packId: 2, name: 'CS Pack', code: 'CS', versions: [] } }),
+    );
+    renderPage();
+    expect(screen.getByTestId('version-list-panel')).toBeInTheDocument();
+    expect(screen.getByTestId('summary-detail-panel')).toBeInTheDocument();
+  });
+
+  it('"새 DRAFT 묶기" 버튼 클릭 시 CreateDraftModal을 표시한다', async () => {
+    vi.mocked(usePackDetail).mockReturnValue(
+      makePackQuery({ data: { packId: 2, name: 'CS Pack', code: 'CS', versions: [] } }),
+    );
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: '새 DRAFT 묶기' }));
+    await waitFor(() =>
+      expect(screen.getByTestId('create-draft-modal')).toBeInTheDocument(),
+    );
+  });
+
+  it('CreateDraftModal의 onClose 호출 시 모달이 닫힌다', async () => {
+    vi.mocked(usePackDetail).mockReturnValue(
+      makePackQuery({ data: { packId: 2, name: 'CS Pack', code: 'CS', versions: [] } }),
+    );
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: '새 DRAFT 묶기' }));
+    await waitFor(() => expect(screen.getByTestId('create-draft-modal')).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: '모달 닫기' }));
+    await waitFor(() =>
+      expect(screen.queryByTestId('create-draft-modal')).not.toBeInTheDocument(),
+    );
+  });
+
+  it('packDetail 로딩 중에도 VersionListPanel을 렌더링한다', () => {
+    vi.mocked(usePackDetail).mockReturnValue(makePackQuery({ isLoading: true }));
+    renderPage();
+    expect(screen.getByTestId('version-list-panel')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.test.tsx
+++ b/frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.test.tsx
@@ -1,9 +1,14 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { toast } from 'sonner';
 import { ApiRequestError } from '@/shared/api';
 import { usePackDetail, useVersionDetail } from '@/features/domain-pack-summary-read';
 import { DomainPackSummaryPage } from './DomainPackSummaryPage';
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
 
 const ROUTE = '/workspaces/:workspaceId/domain-packs/:packId';
 
@@ -53,6 +58,7 @@ describe('DomainPackSummaryPage', () => {
   beforeEach(() => {
     vi.mocked(usePackDetail).mockReturnValue(makePackQuery());
     vi.mocked(useVersionDetail).mockReturnValue(makePackQuery());
+    vi.mocked(toast.error).mockReset();
   });
 
   it('유효하지 않은 workspaceId 시 에러 메시지를 표시한다', () => {
@@ -117,5 +123,36 @@ describe('DomainPackSummaryPage', () => {
     vi.mocked(usePackDetail).mockReturnValue(makePackQuery({ isLoading: true }));
     renderPage();
     expect(screen.getByTestId('version-list-panel')).toBeInTheDocument();
+  });
+
+  it('packDetail 비404 에러 시 toast.error를 1회 호출한다', async () => {
+    vi.mocked(usePackDetail).mockReturnValue(
+      makePackQuery({ isError: true, error: new Error('fail') }),
+    );
+    renderPage();
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith('Pack 정보를 불러오지 못했습니다.'),
+    );
+    expect(toast.error).toHaveBeenCalledTimes(1);
+  });
+
+  it('packDetail 404 에러 시 toast.error를 "Pack을 찾을 수 없습니다."로 호출한다', async () => {
+    const error404 = new ApiRequestError(404, 'NOT_FOUND', 'not found');
+    vi.mocked(usePackDetail).mockReturnValue(
+      makePackQuery({ isError: true, error: error404 }),
+    );
+    renderPage();
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith('Pack을 찾을 수 없습니다.'),
+    );
+  });
+
+  it('packDetail 404 에러 시 "다시 시도" 버튼을 표시하지 않는다', () => {
+    const error404 = new ApiRequestError(404, 'NOT_FOUND', 'not found');
+    vi.mocked(usePackDetail).mockReturnValue(
+      makePackQuery({ isError: true, error: error404 }),
+    );
+    renderPage();
+    expect(screen.queryByRole('button', { name: '다시 시도' })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.tsx
@@ -3,9 +3,8 @@ import { useParams, useSearchParams } from 'react-router-dom';
 import { ApiRequestError } from '@/shared/api';
 import { DashboardLayout } from '@/shared/ui/layout/DashboardLayout';
 import { parseRouteId } from '@/shared/lib/parseRouteId';
-import { usePackDetail, useVersionDetail } from '@/features/domain-pack-summary-read/model';
-import { VersionListPanel, SummaryDetailPanel } from '@/features/domain-pack-summary-read/ui';
-import { CreateDraftModal } from '@/features/domain-pack-draft-create/ui';
+import { usePackDetail, useVersionDetail, VersionListPanel, SummaryDetailPanel } from '@/features/domain-pack-summary-read';
+import { CreateDraftModal } from '@/features/domain-pack-draft-create';
 import styles from './domain-pack-summary-page.module.css';
 
 export function DomainPackSummaryPage() {

--- a/frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.tsx
@@ -45,7 +45,7 @@ function DomainPackSummaryPageContent({ wsId, packId, search, setSearch, isCreat
 
   useEffect(() => {
     if (!packQuery.data) return;
-    if (search.get('versionId') !== null) return;
+    if (selectedVersionId !== null) return;
     if (packQuery.data.versions.length === 0) return;
     const latest = packQuery.data.versions.reduce((a, b) =>
       a.versionNo >= b.versionNo ? a : b,

--- a/frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
+import { toast } from 'sonner';
 import { ApiRequestError } from '@/shared/api';
 import { DashboardLayout } from '@/shared/ui/layout/DashboardLayout';
 import { parseRouteId } from '@/shared/lib/parseRouteId';
@@ -39,6 +40,12 @@ interface ContentProps {
 
 function DomainPackSummaryPageContent({ wsId, packId, search, setSearch, isCreateOpen, setCreateOpen }: ContentProps) {
   const packQuery = usePackDetail(wsId, packId);
+
+  useEffect(() => {
+    if (!packQuery.isError) return;
+    const is404 = packQuery.error instanceof ApiRequestError && packQuery.error.status === 404;
+    toast.error(is404 ? 'Pack을 찾을 수 없습니다.' : 'Pack 정보를 불러오지 못했습니다.');
+  }, [packQuery.isError, packQuery.error]);
 
   const rawVersionId = search.get('versionId');
   const selectedVersionId = rawVersionId !== null ? parseRouteId(rawVersionId) : null;
@@ -87,9 +94,11 @@ function DomainPackSummaryPageContent({ wsId, packId, search, setSearch, isCreat
       <DashboardLayout>
         <div className={styles.errorCard} role="alert">
           <span>{is404 ? 'Pack을 찾을 수 없습니다.' : 'Pack 정보를 불러오지 못했습니다.'}</span>
-          <button type="button" className={styles.retryBtn} onClick={() => packQuery.refetch()}>
-            다시 시도
-          </button>
+          {!is404 && (
+            <button type="button" className={styles.retryBtn} onClick={() => packQuery.refetch()}>
+              다시 시도
+            </button>
+          )}
         </div>
       </DashboardLayout>
     );

--- a/frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.tsx
@@ -1,0 +1,152 @@
+import { useState, useEffect } from 'react';
+import { useParams, useSearchParams } from 'react-router-dom';
+import { ApiRequestError } from '../../../shared/api';
+import { DashboardLayout } from '../../../shared/ui/layout/DashboardLayout';
+import { parseRouteId } from '../../../shared/lib/parseRouteId';
+import { usePackDetail, useVersionDetail } from '../../../features/domain-pack-summary-read/model';
+import { VersionListPanel, SummaryDetailPanel } from '../../../features/domain-pack-summary-read/ui';
+import { CreateDraftModal } from '../../../features/domain-pack-draft-create/ui';
+import styles from './domain-pack-summary-page.module.css';
+
+export function DomainPackSummaryPage() {
+  const { workspaceId, packId } = useParams();
+  const [search, setSearch] = useSearchParams();
+  const [isCreateOpen, setCreateOpen] = useState(false);
+
+  const wsId = parseRouteId(workspaceId);
+  const pId = parseRouteId(packId);
+
+  if (wsId === null || pId === null) {
+    return (
+      <DashboardLayout>
+        <div className={styles.invalidParams} role="alert">
+          잘못된 URL 파라미터입니다.
+        </div>
+      </DashboardLayout>
+    );
+  }
+
+  return <DomainPackSummaryPageContent wsId={wsId} packId={pId} search={search} setSearch={setSearch} isCreateOpen={isCreateOpen} setCreateOpen={setCreateOpen} />;
+}
+
+interface ContentProps {
+  wsId: number;
+  packId: number;
+  search: URLSearchParams;
+  setSearch: (updater: ((prev: URLSearchParams) => URLSearchParams) | URLSearchParams, options?: { replace?: boolean }) => void;
+  isCreateOpen: boolean;
+  setCreateOpen: (open: boolean) => void;
+}
+
+function DomainPackSummaryPageContent({ wsId, packId, search, setSearch, isCreateOpen, setCreateOpen }: ContentProps) {
+  const packQuery = usePackDetail(wsId, packId);
+
+  const rawVersionId = search.get('versionId');
+  const selectedVersionId = rawVersionId !== null ? parseRouteId(rawVersionId) : null;
+
+  useEffect(() => {
+    if (!packQuery.data) return;
+    if (search.get('versionId') !== null) return;
+    if (packQuery.data.versions.length === 0) return;
+    const latest = packQuery.data.versions.reduce((a, b) =>
+      a.versionNo >= b.versionNo ? a : b,
+    );
+    setSearch(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        next.set('versionId', String(latest.versionId));
+        return next;
+      },
+      { replace: true },
+    );
+  }, [packQuery.data, search, setSearch]);
+
+  const versionQuery = useVersionDetail(wsId, packId, selectedVersionId);
+
+  const handleSelectVersion = (versionId: number) => {
+    setSearch((prev) => {
+      const next = new URLSearchParams(prev);
+      next.set('versionId', String(versionId));
+      return next;
+    });
+  };
+
+  const handleCreateSuccess = (newVersionId: number) => {
+    setCreateOpen(false);
+    setSearch((prev) => {
+      const next = new URLSearchParams(prev);
+      next.set('versionId', String(newVersionId));
+      return next;
+    });
+  };
+
+  const pack = packQuery.data;
+
+  if (packQuery.isError) {
+    const is404 = packQuery.error instanceof ApiRequestError && packQuery.error.status === 404;
+    return (
+      <DashboardLayout>
+        <div className={styles.errorCard} role="alert">
+          <span>{is404 ? 'Pack을 찾을 수 없습니다.' : 'Pack 정보를 불러오지 못했습니다.'}</span>
+          <button type="button" className={styles.retryBtn} onClick={() => packQuery.refetch()}>
+            다시 시도
+          </button>
+        </div>
+      </DashboardLayout>
+    );
+  }
+
+  return (
+    <DashboardLayout>
+      <div className={styles.page}>
+        <header className={styles.pageHeader}>
+          <div>
+            <nav className={styles.breadcrumb} aria-label="경로">
+              <span>WS · {wsId}</span>
+              <span className={styles.breadcrumbSep}>/</span>
+              <span>PACK · {packId}</span>
+            </nav>
+            {pack && (
+              <div className={styles.packMeta}>
+                <span className={styles.packName}>{pack.name}</span>
+                <span className={styles.packCode}>{pack.code}</span>
+              </div>
+            )}
+          </div>
+          <div className={styles.headerActions}>
+            <button
+              type="button"
+              className={styles.createBtn}
+              onClick={() => setCreateOpen(true)}
+            >
+              새 DRAFT 묶기
+            </button>
+          </div>
+        </header>
+
+        <div className={styles.twoPane}>
+          <VersionListPanel
+            query={packQuery}
+            selectedId={selectedVersionId}
+            onSelect={handleSelectVersion}
+            onCreateDraft={() => setCreateOpen(true)}
+          />
+          <SummaryDetailPanel
+            query={versionQuery}
+            wsId={wsId}
+            packId={packId}
+          />
+        </div>
+      </div>
+
+      {isCreateOpen && (
+        <CreateDraftModal
+          wsId={wsId}
+          packId={packId}
+          onClose={() => setCreateOpen(false)}
+          onSuccess={handleCreateSuccess}
+        />
+      )}
+    </DashboardLayout>
+  );
+}

--- a/frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.tsx
@@ -1,11 +1,11 @@
 import { useState, useEffect } from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
-import { ApiRequestError } from '../../../shared/api';
-import { DashboardLayout } from '../../../shared/ui/layout/DashboardLayout';
-import { parseRouteId } from '../../../shared/lib/parseRouteId';
-import { usePackDetail, useVersionDetail } from '../../../features/domain-pack-summary-read/model';
-import { VersionListPanel, SummaryDetailPanel } from '../../../features/domain-pack-summary-read/ui';
-import { CreateDraftModal } from '../../../features/domain-pack-draft-create/ui';
+import { ApiRequestError } from '@/shared/api';
+import { DashboardLayout } from '@/shared/ui/layout/DashboardLayout';
+import { parseRouteId } from '@/shared/lib/parseRouteId';
+import { usePackDetail, useVersionDetail } from '@/features/domain-pack-summary-read/model';
+import { VersionListPanel, SummaryDetailPanel } from '@/features/domain-pack-summary-read/ui';
+import { CreateDraftModal } from '@/features/domain-pack-draft-create/ui';
 import styles from './domain-pack-summary-page.module.css';
 
 export function DomainPackSummaryPage() {

--- a/frontend/src/pages/domain-pack/ui/domain-pack-summary-page.module.css
+++ b/frontend/src/pages/domain-pack/ui/domain-pack-summary-page.module.css
@@ -58,7 +58,7 @@
   background: var(--text-primary);
   color: var(--bg-color);
   border: none;
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-xl);
   font-size: 12px;
   font-weight: var(--font-weight-heading);
   cursor: pointer;
@@ -98,7 +98,7 @@
   background: var(--text-primary);
   color: var(--bg-color);
   border: none;
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-xl);
   font-size: 12px;
   font-weight: var(--font-weight-heading);
   cursor: pointer;

--- a/frontend/src/pages/domain-pack/ui/domain-pack-summary-page.module.css
+++ b/frontend/src/pages/domain-pack/ui/domain-pack-summary-page.module.css
@@ -1,0 +1,116 @@
+.page {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+.pageHeader {
+  padding: 16px 20px 12px;
+  border-bottom: 1px solid var(--glass-border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+}
+
+.breadcrumbSep {
+  color: var(--glass-border);
+}
+
+.packMeta {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.packName {
+  font-size: 18px;
+  font-weight: var(--font-weight-heading);
+  color: var(--text-primary);
+  letter-spacing: -0.14px;
+}
+
+.packCode {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.headerActions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.createBtn {
+  padding: 7px 14px;
+  background: var(--text-primary);
+  color: var(--bg-color);
+  border: none;
+  border-radius: var(--radius-md);
+  font-size: 12px;
+  font-weight: var(--font-weight-heading);
+  cursor: pointer;
+  transition: opacity var(--transition-fast);
+}
+
+.createBtn:hover {
+  opacity: 0.8;
+}
+
+.twoPane {
+  flex: 1;
+  display: flex;
+  overflow: hidden;
+}
+
+.invalidParams {
+  padding: 24px;
+  color: var(--error-color);
+}
+
+.errorCard {
+  padding: 24px;
+  margin: 20px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-lg);
+  color: var(--error-color);
+  font-size: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  align-items: flex-start;
+}
+
+.retryBtn {
+  padding: 6px 14px;
+  background: var(--text-primary);
+  color: var(--bg-color);
+  border: none;
+  border-radius: var(--radius-md);
+  font-size: 12px;
+  font-weight: var(--font-weight-heading);
+  cursor: pointer;
+  transition: opacity var(--transition-fast);
+}
+
+.retryBtn:hover {
+  opacity: 0.8;
+}
+
+@media (max-width: 767px) {
+  .twoPane {
+    flex-direction: column;
+  }
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
   server: {
     proxy: {
       "/api": {
-        target: "http://localhost:8080",
+        target: "http://localhost:8089",
         changeOrigin: true,
       },
     },

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
   server: {
     proxy: {
       "/api": {
-        target: "http://localhost:8089",
+        target: "http://localhost:8080",
         changeOrigin: true,
       },
     },


### PR DESCRIPTION

| ID | 결정 | 요약 |
|----|------|------|
| U-FE-232-2 | Implemented (A) | policy 카운트 카드 `disabled=true` + "상세 화면 준비 중" tooltip |
| U-FE-232-3 | Implemented (A) | risk 카운트 카드 동일 패턴 |
| U-FE-232-4 | Implemented (A) | summaryJson: `Object.entries` 키-값 그리드, 파싱 실패 시 raw fallback + `console.warn` |
| U-FE-232-5 | A 구현 / B disabled | CreateDraftModal Tab A(직접 입력) 완전 구현, Tab B(파이프라인 import) disabled (BE 엔드포인트 부재) |
| U-FE-232-6 | Implemented (B) | 각 카운트 카드에 상위 5개 미리보기 — `usePreviewLists` 훅 |
| U-FE-232-8 | Assumption (Recommended Default) | 버전 선택 `?versionId=N` query param SSOT — 스펙 미확정, path 확장 미채택 |
| CSC-001 (C6) | Resolved | `domainPackApi`를 `entities/domain-pack/api`에만 정의 — features 이중 정의 방지 |

---

#### Spec Deviations

| 항목 | 내용 |
|------|------|
| feature root index.ts | `features/domain-pack-summary-read/`, `features/domain-pack-draft-create/` root `index.ts` 미생성. pages가 서브 배럴(`/ui`, `/model`) 직접 import (FE-007, Low) |
| DomainPackLifecycleStatus | 스펙의 IN_REVIEW/APPROVED/ARCHIVED 제외 — BE 실제 값 'DRAFT'|'PUBLISHED' 2종만 채택 (U-FE-232-7 Confirmed A) |
| intent list API 중복 | `entities/intent/api/index.ts` 신규 생성 — `features/intent-draft-read/api/intentApi.ts`와 list API 중복. entities가 정규 위치이므로 허용 |

---

#### Blocked / Skipped Items

| 항목 | 사유 |
|------|------|
| CreateDraftModal Tab B | BE `pipeline-jobs` artifacts 엔드포인트 부재 (U-FE-232-5-B) — disabled 처리 |
| policy/risk 카드 클릭 navigate | FE 상세 화면(2.2.10/2.2.12) 미구현 — `disabled=true` |
| Playwright 프록시 테스트 | vite proxy target 8080 (CLAUDE.md 표준) vs 로컬 BE 8089 포트 불일치로 FE-proxied API 502. 사용자 override로 audit 진행 (playwright 실패 무시) |
| feature root index.ts | Fix iteration skipped — YAGNI (FE-007 Low, 비블로킹) |

---

#### Test Notes

- **단위 테스트**: `usePackDetail.test.ts`, `useVersionDetail.test.ts` 추가. vitest 실행 시 315 tests pass (af32710 fix 기록 기준)
- **TS 빌드**: `af32710`에서 TS2352 4건 발생 → `ea7a993` `as unknown as` 중간 캐스트로 수정. `pnpm build` 통과 여부는 로컬 확인 필요 (audit 미수행)
- **Direct API 검증 (8089 직접)**: API-001~008 8개 모두 200 OK
- **Playwright MCP flows** (d5048ea 기준, proxy 포트 불일치 환경):
  - PW-001 (login render): 부분 PASS (form 렌더, 버튼 클릭 502)
  - PW-002 (summary page): error state 정상 렌더 확인
  - PW-003 (CreateDraftModal): 모달 열기·탭 전환 PASS
  - PW-004 (ComponentCountGrid): 카운트 그리드 렌더 PASS
  - 스크린샷 19장: `.handoff/232/playwright_screenshots/`

---

#### Reviewer Focus

1. **`pnpm build` 재확인 필수**: 마지막 Audit(1800)이 `af32710` FAIL(TS2352). `ea7a993` fix 이후 공식 Audit 미수행. 로컬에서 `pnpm build` 통과 확인 후 re-audit 권장
2. **vite proxy 포트**: `vite.config.ts` proxy target = 8080 (CLAUDE.md 표준). 로컬 BE가 8089라면 `.env.agents` 또는 docker-compose 포트를 8080으로 맞춰야 FE proxy API 작동
3. **FE-001 (High)**: `VersionListPanel ul[role=listbox]` — roving tabindex 미구현, AT 사용자 화살표키 내비게이션 파손. 별도 이슈 등록 또는 현 PR 수정 여부 팀 결정
4. **FE-003 (Medium)**: `CreateDraftModal` — `<dialog open>` 정적 속성 방식, `showModal()` 미사용으로 네이티브 focus trap 미작동. Tab으로 모달 외부 포커스 이동 가능
5. **U-FE-232-8 assumption**: 버전 선택 `?versionId=N` query param 방식 — FE-227 path param 패턴과 다름. 팀 동의 필요
6. **`.env.agents` gitignore 확인**: 시크릿/토큰이 포함된 `.env.agents`가 `.gitignore`에 등록되어 있어야 함

---

#### Conflicts

없음.

---

#### Ready to Merge / Needs Input

**Needs Input** — 마지막 공식 Audit(`audit-report-232-2026-04-30-1800.md`)이 `af32710` 기준 FAIL(TS2352 x4). `ea7a993` fix로 해소 예상이나 Audit 미확인. `pnpm build` 통과 확인 + re-audit 또는 빌드 성공 증거 첨부 후 merge 가능.

---

## FE Gate Summary

| Gate | Verdict | Notes |
|------|---------|-------|
| Spec consistency | CONSISTENT | spec-consistency-report-232.json (C6 LOW → 구현에서 해소) |
| FE pre-review | PASS_WITH_WARNINGS | fe-review-report-232.json (d5048ea — stale). Critical:0, High:1, Medium:3, Low:5. shouldBlockAudit: false |
| Sonar MCP pseudo-check | PASS_WITH_WARNINGS | sonar-pseudo-check-report-232.json (d5048ea — stale). Blocking:0, Warning:6 (S4325 MINOR false positives) |
| Playwright MCP runtime | FAIL | playwright-mcp-report-232.json (d5048ea — stale). 프록시 포트 불일치(8080 vs BE 8089). 사용자 override |
| Playwright Test (E2E) | SKIPPED | playwright-test-report N/A |
| verify-fe (batch) | FAIL | verify-fe-summary-232.json (d5048ea — stale). playwright FAIL 주도 |
| audit-preprocess | BLOCKED | audit-input-232.json (d5048ea — stale). PW-FAIL-001 blocking |
| Critical issues | 0 | review-fe 기준 |
| High issues | 1 | FE-001 listbox roving tabindex |
| Test evidence | 있음 | Direct API 8/8 PASS; playwright flows 부분; Vitest 315 tests |
| Remaining warnings | FE-001(High), FE-002/FE-003/FE-004(Medium), FE-005~FE-009(Low) | |

---

## Verification Batch

- verify-fe verdict: FAIL (headSha=d5048ea — stale)
- review-fe: PASS_WITH_WARNINGS
- sonar-pseudo-check: PASS_WITH_WARNINGS
- test-fe-playwright (local): FAIL — vite proxy 8080 vs BE 8089 포트 불일치. 사용자 override로 audit 진행 (shouldBlockAudit 무시)

verify-fe completed the configured FE verification batch. Verdict은 playwright FAIL에 의해 결정됨. Final Audit verdict는 `audit-report-232-2026-04-30-1800.md`를 source of truth로 한다.

---

## Audit Input Reduction

- audit-preprocess verdict: BLOCKED (d5048ea 기준 — stale)
- blocking findings after deduplication: 1 (PW-FAIL-001)
- warnings after deduplication: 18
- stale artifacts: 3 (playwright-mcp-report, verify-fe-summary, audit-input — d5048ea 기준)
- missing artifacts: 0

audit-preprocess generated compact input for the final Audit Agent. Final Audit verdict: **FAIL** (`audit-report-232-2026-04-30-1800.md`, headSha=af32710).

---

## Quality Gate Precheck

- Sonar MCP pseudo-check: PASS_WITH_WARNINGS (headSha=d5048ea — stale)
- Blocking Sonar issues: 0
- Warning Sonar issues: 6 (S4325 MINOR — `!` assertion in `enabled` guard pattern, false positive)
- Not covered by pseudo-check:
  - coverage (단위 테스트 추가됨, Sonar 커버리지 측정은 CI에서)
  - duplication
  - security hotspot review state
- Final source of truth: SonarQube Cloud CI Quality Gate

Sonar MCP pseudo-check passed (PASS_WITH_WARNINGS). Final SonarQube Cloud Quality Gate is handled by CI.

---

## FE Runtime Validation

- Target: local
- Frontend URL: http://localhost:5173
- Backend/API URL: http://localhost:8089
- Playwright MCP verdict: FAIL (headSha=d5048ea — stale, 포트 불일치)
- Tested routes: `/login`, `/workspaces/1/domain-packs/1`
- Direct API checks: 8/8 PASS (localhost:8089 direct bypass)
- Console errors: 2 (CDN Pretendard 404 — pre-existing; proxy 502)
- Network failures: 1 (`/api/v1/auth/login` 502 — proxy 8080 → BE 8089 불일치)
- Screenshots: `.handoff/232/playwright_screenshots/` (19장)
- Skipped authenticated flows: login flow (proxy 502로 token injection으로 대체)
- Render cold start recovered: N/A (local target)
- Remaining warnings: vite proxy 8080 vs 로컬 BE 8089 포트 불일치 (코드 이슈 아님 — 환경 설정)

---
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ajou-2026-1-capstone-5/ostone/pull/167" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 도메인 팩 요약 페이지 추가 — 버전 목록, 버전 세부정보, JSON 요약 카드 및 구성요소 미리보기 제공
  * 드래프트 생성 UI 및 훅 추가 — JSON 입력/파일 업로드로 드래프트 생성 가능, 생성 시 버전 자동 반영
  * 워크플로우·의도 등 미리보기 훅과 컴포넌트 카운트 그리드 추가
  * 라우팅 경로 및 테마 글꼴/오버레이 CSS 토큰 추가

* **테스트**
  * 신규 컴포넌트·훅·유틸에 대한 광범위한 단위/통합 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->