### PR TITLE
chore: align openApi port to 8080 for local BE consistency

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -91,11 +91,11 @@ tasks.named("sonar") {
 }
 
 openApi {
-    apiDocsUrl.set("http://localhost:8089/v3/api-docs")
+    apiDocsUrl.set("http://localhost:8080/v3/api-docs")
     outputDir.set(file("$buildDir"))
     outputFileName.set("openapi.json")
     waitTimeInSeconds.set(60)
     customBootRun {
-        args.set(listOf("--spring.profiles.active=local", "--server.port=8089"))
+        args.set(listOf("--spring.profiles.active=local", "--server.port=8080"))
     }
 }

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -40,7 +40,7 @@ Backend OpenAPI 스펙을 입력으로 TypeScript 타입, TanStack Query hooks, 
 `./gradlew generateOpenApiDocs`는 정적 파일 생성이 아니라 **forked Spring Boot 앱을 실제 기동**하여 `/v3/api-docs`를 호출한다. 다음이 충족되지 않으면 실패한다:
 
 - PostgreSQL 활성: 이미 실행 중인 postgres에 의존 (포트 5432)
-- 포트 8089 사용 가능 (openApi 블록에서 고정)
+- 포트 8080 사용 가능 (openApi 블록에서 고정)
 - Spring 프로필 `local` (build.gradle.kts `customBootRun.args`에 명시됨)
 - `JWT_SECRET` 등 필수 환경 변수 설정됨
 


### PR DESCRIPTION
로컬 BE 포트를 8089에서 8080으로 완전히 정렬합니다.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ajou-2026-1-capstone-5/ostone/pull/169" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **문서**
  * 개발 환경 설정 요구사항 문서를 업데이트했습니다.

* **기타**
  * 서버 포트 구성을 조정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->