### PR TITLE
chore: add codegen meta for 5stone codegen sync gate

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -35,6 +35,17 @@ Backend OpenAPI 스펙을 입력으로 TypeScript 타입, TanStack Query hooks, 
 
 3. **변경 확인 + 커밋**: `git diff frontend/src/shared/api/generated/`
 
+> **주의**: `pnpm api:gen` 실행 전에 반드시 1단계(`./gradlew generateOpenApiDocs`)를 선행해야 한다. backend openapi.json이 부재하면 codegen 자체는 동작하지 않으며, hash metadata(`.codegen-meta.json`)도 갱신되지 않는다.
+
+### .codegen-meta.json (codegen 정합성 metadata)
+
+Orval `afterAllFilesWrite` hook이 `pnpm api:gen` 실행 시 자동 갱신하는 metadata 파일.
+
+- 위치: `frontend/src/shared/api/generated/.codegen-meta.json` (commit 대상)
+- 포함 필드: `schemaVersion`, `openapiHash`(sha256), `openapiPathsCount`, `generatedAt`, `orvalVersion`, `openapiSourcePath`
+- 용도: 5stone 파이프라인의 specGatekeeper C7 검사가 본 파일의 `openapiHash`와 `backend/build/openapi.json`의 sha256을 비교하여 BE↔FE codegen drift를 탐지한다.
+- 직접 수정 금지: 사람이 손대지 않는다. 매 codegen 실행마다 덮어써진다.
+
 ### 운영 전제 (generateOpenApiDocs)
 
 `./gradlew generateOpenApiDocs`는 정적 파일 생성이 아니라 **forked Spring Boot 앱을 실제 기동**하여 `/v3/api-docs`를 호출한다. 다음이 충족되지 않으면 실패한다:

--- a/frontend/orval.config.ts
+++ b/frontend/orval.config.ts
@@ -1,4 +1,54 @@
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
 import { defineConfig } from "orval";
+
+const OPENAPI_PATH = resolve(__dirname, "../backend/build/openapi.json");
+const META_PATH = resolve(
+  __dirname,
+  "./src/shared/api/generated/.codegen-meta.json",
+);
+const PACKAGE_PATH = resolve(__dirname, "./package.json");
+
+const writeCodegenMeta = (): void => {
+  if (!existsSync(OPENAPI_PATH)) {
+    process.stderr.write(
+      `[orval hook] WARN: ${OPENAPI_PATH} not found — skipping .codegen-meta.json update.\n` +
+        `             Run \`./gradlew generateOpenApiDocs\` in backend/ before \`pnpm api:gen\`.\n`,
+    );
+    return;
+  }
+  const raw = readFileSync(OPENAPI_PATH);
+  const hash = `sha256:${createHash("sha256").update(raw).digest("hex")}`;
+  let pathsCount = 0;
+  try {
+    const parsed = JSON.parse(raw.toString("utf8"));
+    pathsCount = Object.keys(parsed.paths ?? {}).length;
+  } catch {
+    pathsCount = 0;
+  }
+  let orvalVersion = "unknown";
+  try {
+    const pkg = JSON.parse(readFileSync(PACKAGE_PATH, "utf8"));
+    orvalVersion =
+      pkg.devDependencies?.orval ?? pkg.dependencies?.orval ?? "unknown";
+  } catch {
+    /* keep default */
+  }
+  const meta = {
+    schemaVersion: 1,
+    openapiHash: hash,
+    openapiPathsCount: pathsCount,
+    generatedAt: new Date().toISOString(),
+    orvalVersion,
+    openapiSourcePath: "backend/build/openapi.json",
+  };
+  writeFileSync(META_PATH, `${JSON.stringify(meta, null, 2)}\n`, "utf8");
+  process.stdout.write(
+    `[orval hook] wrote ${META_PATH} (paths=${pathsCount}, hash=${hash.slice(0, 19)}…)\n`,
+  );
+};
 
 export default defineConfig({
   api: {
@@ -30,6 +80,9 @@ export default defineConfig({
           },
         },
       },
+    },
+    hooks: {
+      afterAllFilesWrite: writeCodegenMeta,
     },
   },
 });

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -58,6 +58,7 @@
     "jsdom": "^29.0.1",
     "orval": "^8.9.0",
     "playwright": "^1.59.1",
+    "ts-morph": "^28.0.0",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.57.0",
     "vite": "catalog:",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -148,6 +148,9 @@ importers:
       playwright:
         specifier: ^1.59.1
         version: 1.59.1
+      ts-morph:
+        specifier: ^28.0.0
+        version: 28.0.0
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
@@ -1842,6 +1845,9 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@ts-morph/common@0.29.0':
+    resolution: {integrity: sha512-35oUmphHbJvQ/+UTwFNme/t2p3FoKiGJ5auTjjpNTop2dyREspirjMy82PLSC1pnDJ8ah1GU98hwpVt64YXQsg==}
+
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
@@ -2426,6 +2432,9 @@ packages:
     peerDependencies:
       react: ^18 || ^19 || ^19.0.0-rc
       react-dom: ^18 || ^19 || ^19.0.0-rc
+
+  code-block-writer@13.0.3:
+    resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -3191,6 +3200,9 @@ packages:
   parse5@8.0.0:
     resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
 
+  path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -3544,6 +3556,9 @@ packages:
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
+
+  ts-morph@28.0.0:
+    resolution: {integrity: sha512-Wp3tnZ2bzwxyTZMtgWVzXDfm7lB1Drz+y9DmmYH/L702PQhPyVrp3pkou3yIz4qjS14GY9kcpmLiOOMvl8oG1g==}
 
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
@@ -5337,6 +5352,12 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@ts-morph/common@0.29.0':
+    dependencies:
+      minimatch: 10.2.5
+      path-browserify: 1.0.1
+      tinyglobby: 0.2.15
+
   '@types/aria-query@5.0.4': {}
 
   '@types/chai@5.2.3':
@@ -5815,6 +5836,8 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
+
+  code-block-writer@13.0.3: {}
 
   color-convert@2.0.1:
     dependencies:
@@ -6615,6 +6638,8 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
+  path-browserify@1.0.1: {}
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
@@ -6952,6 +6977,11 @@ snapshots:
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
+
+  ts-morph@28.0.0:
+    dependencies:
+      '@ts-morph/common': 0.29.0
+      code-block-writer: 13.0.3
 
   tsconfck@3.1.6(typescript@5.9.3):
     optionalDependencies:

--- a/frontend/src/shared/api/generated/.codegen-meta.json
+++ b/frontend/src/shared/api/generated/.codegen-meta.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": 1,
+  "openapiHash": "sha256:5c93d5809f38dd38529a4205ebe5043091e2e342c7ac6bde383c8137b4fea5db",
+  "openapiPathsCount": 38,
+  "generatedAt": "2026-05-01T03:23:11.905Z",
+  "orvalVersion": "^8.9.0",
+  "openapiSourcePath": "backend/build/openapi.json"
+}


### PR DESCRIPTION
## Summary

codegen metadata 도입.

- `frontend/orval.config.ts`에 `hooks.afterAllFilesWrite` 추가 — 매 `pnpm api:gen` 실행 시 `backend/build/openapi.json`의 sha256 hash, paths count, orval version 등을 자동으로 `.codegen-meta.json`에 기록
- `frontend/src/shared/api/generated/.codegen-meta.json` 첫 산출 (commit 대상)
- `ts-morph` devDependency 추가 — specGatekeeper C7이 manual API client 신규 추가를 정적 분석할 때 사용
- `frontend/README.md`에 backend openapi 빌드 선행 필요성 + `.codegen-meta.json` 의미 1~2 문단 추가

## Codegen Status

- backend openapi paths: 38 (reused existing `backend/build/openapi.json`)
- regenerate command 실행: ✓ (`pnpm api:gen`)
- manual layer (`mutator.ts` / `index.ts`) 변경: ✗
- `.codegen-meta.json` hash sync: PASS

## Test plan

- [x] `pnpm api:gen` 실행 — codegen + `.codegen-meta.json` 자동 생성 확인
- [x] `pnpm test` (vitest) — 70 files, 365 tests passed
- [x] `npx tsc --noEmit` — typecheck passed
- [x] `pnpm build` — passed
- [ ] (사용자 수동) 후속 PR에서 첫 verify-fe + audit 사이클로 새 게이트 dry-run 권고

## Known follow-up

orval v8.9.0 재실행이 `frontend/src/shared/api/generated/zod/index.ts`에서 `./uploadRawFileBody` re-export 한 줄을 자동으로 제거하는데, 그 결과 같은 디렉토리의 `dataset-controller.ts`가 import하는 `UploadRawFileBody` 타입이 미해결되어 build 오류가 발생한다. 이는 PR #131에서 commit된 generated/ 의 사전 inconsistency가 본 codegen 재실행으로 드러난 것으로, 본 PR 범위 밖. 별도 chore 또는 BE 컨트롤러 다음 변경 시점에 BE openapi.json을 새로 빌드하여 한꺼번에 정합성 회복할 것을 권장한다. 본 PR은 그 drift를 staging에서 제외하여 build를 유지한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ajou-2026-1-capstone-5/ostone/pull/171" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
