### PR TITLE
docs(specs): Conversation Intent 승인 기능 FE 스펙

### DIFF
--- a/.agent/specs/312.md
+++ b/.agent/specs/312.md
@@ -38,8 +38,7 @@ body: { status: REJECTED }]
     L --> A
     M --> A
 
-    H -.->|Optimistic| N[UI 즉시 갱신 예상]
-    N --> K
+
 ```
 
 ---
@@ -215,7 +214,7 @@ export function useUpdateIntentStatus() {
 ┌──────────────────────────────────────────────────────────────┐
 │                 Shared Layer                                │
 │  ┌──────────────────────────────────────────────────────┐   │
-│  │ @/shared/api/generated/useUpdateIntentStatus         │   │
+│  │ `@/shared/api/generated/endpoints/update-intent-status-controller` │   │
 │  │ @/shared/ui/button, @/shared/ui/alert-dialog         │   │
 │  │ @/shared/ui/badge (IntentStatusBadge)                │   │
 │  │ TanStack Query client config                         │   │
@@ -403,13 +402,16 @@ import { ApproveIntentDialog } from "./ApproveIntentDialog";
 import { useUpdateIntentStatus } from "../api/useUpdateIntentStatus";
 
 interface IntentStatusControlProps {
+  wsId: number;
+  packId: number;
+  versionId: number;
   status: string;
   intentName: string;
   intentId: number;
   versionLifecycleStatus: string;
 }
 
-export function IntentStatusControl({ status, intentName, intentId, versionLifecycleStatus }: IntentStatusControlProps) {
+export function IntentStatusControl({ wsId, packId, versionId, status, intentName, intentId, versionLifecycleStatus }: IntentStatusControlProps) {
   const [dialogAction, setDialogAction] = useState<"PUBLISHED" | "REJECTED" | null>(null);
   const { mutate, isPending } = useUpdateIntentStatus();
 
@@ -420,7 +422,7 @@ export function IntentStatusControl({ status, intentName, intentId, versionLifec
     // mutateAsync + try/catch 패턴: 성공 시에만 다이얼로그 닫기
     // 오류 발생 시 다이얼로그 유지 → 사용자가 재시도 가능
     mutate(
-      { intentId, data: { status: dialogAction } },
+      { workspaceId: wsId, packId, versionId, intentId, data: { status: dialogAction } },
       {
         onSuccess: () => setDialogAction(null),
       }

--- a/.agent/specs/312.md
+++ b/.agent/specs/312.md
@@ -81,7 +81,7 @@ IntentDetailPage (widget)
    └─ JsonCards (sourceClusterRef, entryConditionJson, etc.)
 ```
 
-#### 신규 컴포넌트
+### 신규 컴포넌트
 
 | 컴포넌트 | 위치 | 설명 |
 |---------|------|------|
@@ -415,7 +415,8 @@ export function IntentStatusControl({ status, intentName, intentId, versionLifec
     setDialogAction(null);
   };
 
-  if (!isEditable) return null; // 또는 disabled 버튼 표시 (면담 결정 → disabled)
+  // 면담 결정: 항상 표시하되 편집 불가 시 disabled 처리
+  const disabled = !isEditable || isPending;
 
   return (
     <div className="intent-actions">
@@ -423,7 +424,7 @@ export function IntentStatusControl({ status, intentName, intentId, versionLifec
         variant="outline"
         aria-label="Intent 승인"
         onClick={() => setDialogAction("PUBLISHED")}
-        disabled={isPending}
+        disabled={disabled}
       >
         승인
       </Button>
@@ -431,7 +432,7 @@ export function IntentStatusControl({ status, intentName, intentId, versionLifec
         variant="outline"
         aria-label="Intent 반려"
         onClick={() => setDialogAction("REJECTED")}
-        disabled={isPending}
+        disabled={disabled}
       >
         반려
       </Button>
@@ -452,11 +453,13 @@ export function IntentStatusControl({ status, intentName, intentId, versionLifec
 
 ## Performance Considerations
 
-- 캐시 최적화: mutation `onSuccess`에서 intent detail query key만 `invalidateQueries` — 전체 목록은 불필요한 경우 재조회 회피
+- 캐시 최적화: intent detail이 TanStack Query 기반으로 전환된 경우 intent detail query key만 `invalidateQueries`. 기존 effect/local-state 기반 hook을 유지하는 경우 explicit refetch 또는 local state sync가 필요하다. 전체 목록은 불필요한 경우 재조회를 회피한다.
 - 낙관적 업데이트: 별도 구현하지 않음 (패널 유지 + 상세 재조회로 충분, BE 응답 속도 100ms 내외 예상)
 - 버튼 debounce: mutation `isPending` 상태로 중복 클릭 방지
 - Dialog lazy render: `ApproveIntentDialog`는 open 상태일 때만 자식 렌더링 (React Portal 기반이므로 기본적으로 최적화됨)
 - Bundle impact: `@/shared/ui/alert-dialog`, `@/shared/ui/button`은 이미 사용 중 (`ArchiveConfirmDialog` 포함) — 새로운 청크 추가 없음
+
+- Status badge 동기화: [TBD: 구현 단계에서 해소] 현재 기존 `useIntentDetail`은 `useEffect + useState` 기반이며 TanStack Query 구독 기반이 아니므로, `invalidateQueries`만으로는 intent detail panel/status badge 갱신이 보장되지 않는다. 구현 시 1) `useIntentDetail`을 generated `useGetIntent` 기반 query hook으로 전환하고 `invalidateQueries`를 사용하거나, 2) 기존 hook을 유지하는 경우 mutation 성공 후 explicit refetch 또는 local state update를 수행해야 한다.
 
 ---
 

--- a/.agent/specs/312.md
+++ b/.agent/specs/312.md
@@ -1,0 +1,492 @@
+# 312: [FE] Conversation Intent 승인 기능
+
+> Issue: #312 (Burndown Studio)
+> Branch: spec/312
+> Template: _TEMPLATE_FE.md
+
+---
+
+## Goal
+
+Domain Pack 버전의 Intent Definition 상세 패널에서 DRAFT 상태인 Intent를 승인(PUBLISHED) 또는 반려(REJECTED)할 수 있는 FE UI를 구현한다.
+
+---
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A[Intent 상세 패널 진입] --> B{Status이 DRAFT?}
+    B -->|Yes| C[승인/반려 버튼 표시 active 상태]
+    B -->|No| D[승인/반려 버튼 비활성화]
+
+    C --> E[사용자 승인 또는 반려 버튼 클릭]
+    E --> F[확인 다이얼로그 열기]
+    F --> G{사용자 확인}
+    G -->|승인| H[PATCH /.../status
+body: { status: PUBLISHED }]
+    G -->|반려| I[PATCH /.../status
+body: { status: REJECTED }]
+    G -->|취소| J[다이얼로그 닫기]
+    J --> A
+
+    H --> K{API 응답}
+    I --> K
+    K -->|200 OK| L[패널 유지 + 상태 Badge 갱신]
+    K -->|400/403/404| M[에러 토스트 표시]
+    K -->|네트워크 오류| M
+    L --> A
+    M --> A
+
+    H -.->|Optimistic| N[UI 즉시 갱신 예상]
+    N --> K
+```
+
+---
+
+## Design Diff
+
+### As-is vs To-be
+
+| 영역 | As-is | To-be | 변경 내용 |
+|------|-------|-------|-----------|
+| Intent 상세 패널 | 읽기 전용 (Status Badge만 표시) | 승인/반려 액션 버튼 + 확인 다이얼로그 추가 | 기능 활성화 |
+| 상태 표시 | 텍스트 Badge만 | 상태에 따라 액션 가능 여부 표시 | UX 개선 |
+| 상태 전환 피드백 | 없음 | Toast 성공/실패 + 패널 내 Badge 자동 갱신 | 피드백 강화 |
+| 권한 처리 | 없음 | 비DRAFT 버전이면 버튼 비활성화 | 안전성 향상 |
+
+---
+
+## Component Tree
+
+```
+IntentDetailPage (widget)
+└─ IntentDetailPanel (features/intent-draft-read/ui/)
+   ├─ DetailHeader (header)
+   │   ├─ intentCode Badge
+   │   ├─ intentName Text
+   │   ├─ description Text
+   │   └─ updatedAt Text
+   ├─ StatusSection (body section)
+   │   ├─ IntentStatusBadge (기존)
+   │   └─ IntentStatusControl [NEW]
+   │        ├─ ApproveButton
+   │        ├─ RejectButton
+   │        └─ ApproveIntentDialog [NEW] → AlertDialog
+   │             ├─ DialogTitle ("Intent 승인" / "Intent 반려")
+   │             ├─ IntentInfoPreview
+   │             ├─ ConfirmDescription
+   │             └─ DialogActions (확인 / 취소)
+   ├─ InfoCards (4-grid)
+   └─ JsonCards (sourceClusterRef, entryConditionJson, etc.)
+```
+
+#### 신규 컴포넌트
+
+| 컴포넌트 | 위치 | 설명 |
+|---------|------|------|
+| `ApproveIntentDialog` | `features/intent-draft-read/ui/ApproveIntentDialog.tsx` | 승인/반려 확인 AlertDialog |
+| `IntentStatusControl` | `features/intent-draft-read/ui/IntentStatusControl.tsx` | DRAFT 상태에서만 보이는 승인/반려 버튼 래퍼 |
+| `useUpdateIntentStatus` | `features/intent-draft-read/api/useUpdateIntentStatus.ts` | generated hook 래핑 (mutation + cache invalidate) |
+
+---
+
+## API Integration
+
+### Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `PATCH` | `/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/intents/{intentId}/status` | Intent 승인/반려 상태 전환 |
+
+### Request Body
+
+```typescript
+interface UpdateIntentStatusRequest {
+  status: "PUBLISHED" | "REJECTED";
+}
+```
+
+### Response (200 OK)
+
+```typescript
+interface IntentDefinitionStatusResponse {
+  id: number;
+  domainPackVersionId: number;
+  intentCode: string;
+  name: string;
+  description: string;
+  taxonomyLevel: number;
+  status: string; // "PUBLISHED" 또는 "REJECTED"
+  createdAt: string;
+  updatedAt: string;
+}
+```
+
+### Error Responses
+
+| Status | Error Code | Description | FE 처리 |
+|--------|-----------|-------------|---------|
+| `400` | `INTENT_NOT_EDITABLE` | DRAFT 상태가 아닌 버전에서 요청 시 | 버튼 disabled 처리로 사전 방지 |
+| `400` | `VALIDATION_ERROR` | 허용되지 않은 status 값 또는 필수 필드 누락 | 입력 제한으로 방지, fallback은 토스트 |
+| `403` | `FORBIDDEN` | OPERATOR/ADMIN 권한 부족 | 인증 에러 토스트 |
+| `404` | `NOT_FOUND` | 존재하지 않는 intentId | 토스트 에러 메시지 표시 |
+
+### Query Key Pattern
+
+```typescript
+// entities/intent/api/index.ts
+export const intentKeys = {
+  all: ["intents"] as const,
+  lists: () => [...intentKeys.all, "list"] as const,
+  list: (packId: number, versionId: number) =>
+    [...intentKeys.lists(), packId, versionId] as const,
+  details: () => [...intentKeys.all, "detail"] as const,
+  detail: (intentId: number) => [...intentKeys.details(), intentId] as const,
+};
+
+// features/intent-draft-read/api/useUpdateIntentStatus.ts
+import { useUpdateIntentStatus as useGeneratedUpdateIntentStatus } from "@/shared/api/generated/endpoints/update-intent-status-controller";
+import { useQueryClient } from "@tanstack/react-query";
+
+export function useUpdateIntentStatus() {
+  const queryClient = useQueryClient();
+  return useGeneratedUpdateIntentStatus({
+    mutation: {
+      onMutate: (variables) => {
+        // [TBD: 구현 단계에서 해소] Optimistic UI 또는 로딩 상태 처리
+      },
+      onSuccess: (_data, variables) => {
+        queryClient.invalidateQueries({
+          queryKey: intentKeys.detail(variables.intentId),
+        });
+        // [TBD: 구현 단계에서 해소] 버전 전체 리스트 갱신이 필요한지 확인
+      },
+      onError: (error) => {
+        // [TBD: 구현 단계에서 해소] 에러 코드에 따른 토스트 메시지 매핑
+      },
+    },
+  });
+}
+```
+
+---
+
+## Data Flow
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│                    UI Layer                                 │
+│  ┌──────────────────────────────────────────────────────┐   │
+│  │ IntentDetailPanel                                    │   │
+│  │  props: { wsId, packId, versionId, intentId }       │   │
+│  │  ├─ DetailHeader                                    │   │
+│  │  │  └─ IntentStatusBadge                           │   │
+│  │  └─ IntentStatusControl [NEW]                       │   │
+│  │     ├─ ApproveButton                               │   │
+│  │     ├─ RejectButton                                │   │
+│  │     └─ ApproveIntentDialog                          │   │
+│  └──────────────────────────────────────────────────────┘   │
+└──────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌──────────────────────────────────────────────────────────────┐
+│                 Feature Layer                               │
+│  ┌──────────────────────────────────────────────────────┐   │
+│  │ useUpdateIntentStatus (mutation + cache invalidate)  │   │
+│  │ useIntentDetail (query)                              │   │
+│  └──────────────────────────────────────────────────────┘   │
+└──────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌──────────────────────────────────────────────────────────────┐
+│                 Entity Layer                                │
+│  ┌──────────────────────────────────────────────────────┐   │
+│  │ IntentDetail type (from entities/intent)             │   │
+│  │ Intent status type guards (DRAFT | PUBLISHED | ...)│   │
+│  └──────────────────────────────────────────────────────┘   │
+└──────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌──────────────────────────────────────────────────────────────┐
+│                 Shared Layer                                │
+│  ┌──────────────────────────────────────────────────────┐   │
+│  │ @/shared/api/generated/useUpdateIntentStatus         │   │
+│  │ @/shared/ui/button, @/shared/ui/alert-dialog         │   │
+│  │ @/shared/ui/badge (IntentStatusBadge)                │   │
+│  │ TanStack Query client config                         │   │
+│  └─── ──────────────────────────────────────────────────┘   │
+└──────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 수정 대상 파일
+
+| 파일 | 변경 유형 | 설명 |
+|------|----------|------|
+| `frontend/src/features/intent-draft-read/ui/IntentStatusControl.tsx` | new | DRAFT 상태일 때만 표시되는 승인/반려 버튼 래퍼 |
+| `frontend/src/features/intent-draft-read/ui/ApproveIntentDialog.tsx` | new | 승인/반려 확인 AlertDialog 컴포넌트 |
+| `frontend/src/features/intent-draft-read/ui/IntentDetailPanel.tsx` | modify | IntentStatusControl 컴포넌트 추가 (Status Badge 우측) |
+| `frontend/src/features/intent-draft-read/api/useUpdateIntentStatus.ts` | new | generated hook 래핑 + onSuccess 캐시 invalidate |
+| `frontend/src/features/intent-draft-read/ui/IntentDetailPanel.module.css` | modify | 버튼 배치용 스타일 추가 가능 |
+
+---
+
+## State Management
+
+### Server State (TanStack Query)
+
+**Query**
+
+```typescript
+// features/intent-draft-read/model/useIntentDetail.ts
+// (기존 유지 — 변경 없음)
+```
+
+**Mutation**
+
+```typescript
+// features/intent-draft-read/api/useUpdateIntentStatus.ts
+import { useUpdateIntentStatus as useGenerated } from "@/shared/api/generated/endpoints/update-intent-status-controller";
+import { toast } from "sonner";
+
+export function useUpdateIntentStatus() {
+  return useGenerated({
+    mutation: {
+      onSuccess: (_data, variables) => {
+        const action =
+          variables.data.status === "PUBLISHED" ? "승인" : "반려";
+        toast.success(`Intent가 ${action}되었습니다.`);
+      },
+      onError: (error) => {
+        if (error.response?.status === 403) {
+          toast.error("권한이 없습니다. OPERATOR 이상 권한이 필요합니다.");
+        } else if (error.response?.status === 404) {
+          toast.error("Intent를 찾을 수 없습니다.");
+        } else if (error.response?.data?.code === "INTENT_NOT_EDITABLE") {
+          toast.error("DRAFT 상태의 버전에서만 승인/반려할 수 있습니다.");
+        } else {
+          toast.error("상태 변경 중 오류가 발생했습니다.");
+        }
+      },
+    },
+  });
+}
+```
+
+### Client State (Local State)
+
+```typescript
+// features/intent-draft-read/ui/ApproveIntentDialog.tsx
+const [open, setOpen] = useState(false);
+const [pendingStatus, setPendingStatus] = useState<"PUBLISHED" | "REJECTED" | null>(null);
+// AlertDialog 열림 닫힘 + 어떤 상태로 변경할지 client state에만 보관
+// 서버 상태는 TanStack Query mutation으로 처리
+```
+
+---
+
+## Tests
+
+### Test Strategy
+
+| 구분 | 방법 | 도구 | 비고 |
+|------|------|------|------|
+| 수동 테스트 | 브라우저 직접 확인 | Chrome DevTools | 주요 플로우 |
+| 컴포넌트 테스트 | Vitest + Testing Library | `pnpm test` | UI 렌더링, 상태 전환 |
+| 통합 테스트 | MSW + Vitest | `pnpm test` | API mocking, error case |
+
+### Test Environment & 사전 조건
+
+| 항목 | 값 |
+|------|-----|
+| 환경 | `pnpm dev` |
+| API Mock | MSW (Mock Service Worker) |
+| 사전 조건 | DRAFT 상태의 DomainPackVersion 1개, Intent 1개 이상 존재 |
+
+### Test Scenarios
+
+#### Happy Path
+
+| # | 시나리오 | 사전 조건 | 조작 | 기대 결과 | Figma |
+|---|---------|---------|------|----------|-------|
+| 1 | Intent 승인 | Status = DRAFT, version = DRAFT | "승인" 버튼 클릭 → 확인 다이얼로그 "확인" 클릭 | 성공 토스트, Badge가 PUBLISHED로 변경, 패널 유지 | [링크] |
+| 2 | Intent 반려 | Status = DRAFT, version = DRAFT | "반려" 버튼 클릭 → 확인 다이얼로그 "확인" 클릭 | 성공 토스트, Badge가 REJECTED로 변경, 패널 유지 | [링크] |
+| 3 | 승인 취소 | Status = DRAFT | "승인" 버튼 클릭 → "취소" 클릭 | 다이얼로그 닫기, 상태 무 변경 | [링크] |
+| 4 | Status 자동 갱신 | 승인/반려 완료 후 | — | intent detail query 재조회, Badge 자동 갱신 | [링크] |
+
+#### Error & Edge Cases
+
+| # | 시나리오 | 조작 | 기대 결과 |
+|---|---------|------|----------|
+| 1 | 비DRAFT 버전에서 버튼 표시 | version lifecycleStatus ≠ DRAFT | 승인/반려 버튼 비활성화(disabled) 또는 미표시 |
+| 2 | 권한 부족 (403) | OPERATOR 이하 권한 사용자 클릭 | FORBIDDEN 토스트 메시지 |
+| 3 | 존재하지 않는 Intent 삭제 후 요청 (404) | 동시성 문제 등 | NOT_FOUND 토스트 메시지 |
+| 4 | 네트워크 오류 | WiFi 끊김 | 에러 토스트, 상태 변경 없음 |
+| 5 | 동시 수정 (INTENT_NOT_EDITABLE) | 다른 사용자가 이미 변경 | INTENT_NOT_EDITABLE 토스트, 상태 변경 없음 |
+| 6 | Intent 선택 안 함 | intentId = null | 승인/반려 컨트롤 미표시 (기존 동작 유지) |
+
+#### 반응형 & 접근성
+
+| # | 확인 항목 | 기대 결과 |
+|---|---------|----------|
+| 1 | 키보드 탐색 | Tab으로 버튼 포커스 → Enter/Space로 다이얼로그 열기 |
+| 2 | 스크린 리더 | 버튼 aria-label "Intent 승인"/"Intent 반려" 읽힘 |
+| 3 | 다이얼로그 포커스 트랩 | 다이얼로그 열릴 때 확인/취소 버튼 중 하나로 포커스 이동 |
+| 4 | 컬러 대비 | 버튼 텍스트/배경 색상 대비 4.5:1 이상 |
+| 5 | 로딩 상태 | mutation pending 시 버튼 disabled + spinner |
+| 6 | 색맹 구분 | 승인/반려 버튼이 색상 외에 라벨/아이콘으로 구분 |
+
+---
+
+## Implementation Example
+
+### ApproveIntentDialog (의사 코드)
+
+```typescript
+// features/intent-draft-read/ui/ApproveIntentDialog.tsx
+import { AlertDialog, AlertDialogContent, AlertDialogFooter, AlertDialogTitle } from "@/shared/ui/alert-dialog";
+import { Button } from "@/shared/ui/button";
+
+interface ApproveIntentDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  action: "PUBLISHED" | "REJECTED";
+  intentName: string;
+  onConfirm: () => void;
+  isSubmitting: boolean;
+}
+
+export function ApproveIntentDialog({
+  open, onOpenChange, action, intentName, onConfirm, isSubmitting,
+}: ApproveIntentDialogProps) {
+  const isApprove = action === "PUBLISHED";
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogTitle>
+          {isApprove ? "Intent 승인" : "Intent 반려"}
+        </AlertDialogTitle>
+        <p>
+          <strong>{intentName}</strong>을(를){" "}
+          {isApprove ? "승인" : "반려"}하시겠습니까?
+          DRAFT 상태의 버전에서만 허용됩니다.
+        </p>
+        <AlertDialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isSubmitting}>
+            취소
+          </Button>
+          <Button variant={isApprove ? "default" : "destructive"} onClick={onConfirm} disabled={isSubmitting}>
+            {isSubmitting ? "처리 중..." : isApprove ? "승인" : "반려"}
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+```
+
+### IntentStatusControl (의사 코드)
+
+```typescript
+// features/intent-draft-read/ui/IntentStatusControl.tsx
+import { useState } from "react";
+import { Button } from "@/shared/ui/button";
+import { ApproveIntentDialog } from "./ApproveIntentDialog";
+import { useUpdateIntentStatus } from "../api/useUpdateIntentStatus";
+
+interface IntentStatusControlProps {
+  status: string;
+  intentName: string;
+  intentId: number;
+  versionLifecycleStatus: string;
+}
+
+export function IntentStatusControl({ status, intentName, intentId, versionLifecycleStatus }: IntentStatusControlProps) {
+  const [dialogAction, setDialogAction] = useState<"PUBLISHED" | "REJECTED" | null>(null);
+  const { mutate, isPending } = useUpdateIntentStatus();
+
+  const isEditable = status === "DRAFT" && versionLifecycleStatus === "DRAFT";
+
+  const handleConfirm = () => {
+    if (!dialogAction) return;
+    mutate({ intentId, data: { status: dialogAction } });
+    setDialogAction(null);
+  };
+
+  if (!isEditable) return null; // 또는 disabled 버튼 표시 (면담 결정 → disabled)
+
+  return (
+    <div className="intent-actions">
+      <Button
+        variant="outline"
+        aria-label="Intent 승인"
+        onClick={() => setDialogAction("PUBLISHED")}
+        disabled={isPending}
+      >
+        승인
+      </Button>
+      <Button
+        variant="outline"
+        aria-label="Intent 반려"
+        onClick={() => setDialogAction("REJECTED")}
+        disabled={isPending}
+      >
+        반려
+      </Button>
+      <ApproveIntentDialog
+        open={!!dialogAction}
+        onOpenChange={(open) => !open && setDialogAction(null)}
+        action={dialogAction!}
+        intentName={intentName}
+        onConfirm={handleConfirm}
+        isSubmitting={isPending}
+      />
+    </div>
+  );
+}
+```
+
+---
+
+## Performance Considerations
+
+- 캐시 최적화: mutation `onSuccess`에서 intent detail query key만 `invalidateQueries` — 전체 목록은 불필요한 경우 재조회 회피
+- 낙관적 업데이트: 별도 구현하지 않음 (패널 유지 + 상세 재조회로 충분, BE 응답 속도 100ms 내외 예상)
+- 버튼 debounce: mutation `isPending` 상태로 중복 클릭 방지
+- Dialog lazy render: `ApproveIntentDialog`는 open 상태일 때만 자식 렌더링 (React Portal 기반이므로 기본적으로 최적화됨)
+- Bundle impact: `@/shared/ui/alert-dialog`, `@/shared/ui/button`은 이미 사용 중 (`ArchiveConfirmDialog` 포함) — 새로운 청크 추가 없음
+
+---
+
+## Additional Notes
+
+### Must Have
+
+- [ ] PATCH endpoint 호출 시 path parameter 4개 전달 (workspaceId, packId, versionId, intentId)
+- [ ] 상태 전환 성공 시 "성공" Toast + intent detail query 재조회
+- [ ] 에러 응답 시 각 에러 코드별 적절한 Toast 메시지
+- [ ] Non-DRAFT 버전 또는 이미 non-DRAFT 상태인 intent 버튼 **비활성화(disabled)**
+- [ ] 실패 시 패널 유지 + 상태 변경 없음
+
+### Must NOT Have
+
+- [x] 반려 사유 (`reason`) 필드 입력 UI — BE 스펙 #313에서 out of scope
+- [x] Bulk 승인/반려 UI — 단일 intent만 처리
+- [x] 상태 전환 시 다른 화면으로 navigate — 패널 유지
+- [x] Optimistic UI (낙관적 업데이트) — 패널 재조회로 충분
+- [x] 별도의 entities 레벨 수정 — feature 레벨에서 generated hook 직접 사용
+- [x] Intent Mapping 승인 UI — 별도 테이블 없음, 별도 endpoint 예정
+- [x] 페이지 refresh 또는 redirect — 패널 상태만 갱신
+
+### Key Decisions
+
+1. **UI 배치**: `IntentDetailPanel` 내부 `DetailHeader` 하단에 `IntentStatusControl` 배치 (면담 확정)
+2. **확인 다이얼로그**: `AlertDialog` 컴포넌트 재사용 (`ArchiveConfirmDialog` 패턴 상속)
+3. **Post-action**: 성공 시 패널 유지 + 상태 Badge 갱신, navigate 없음
+4. **버튼 활성화 조건**: `version.lifecycleStatus === "DRAFT" && intent.status === "DRAFT"` 일 때만 active, 이외 disabled
+5. **Mutation wrap 레벨**: feature 레벨에서 generated hook을 직접 import + onSuccess/onError 래핑 (entities 수정 없음)
+6. **반려 사유**: out of scope (차기 스펙에서 별도 필드로 논의 예정)
+7. **권한 표시**: 버튼은 항상 표시, disabled로 방지 (권한 없을 시 403 토스트 fallback)
+8. **Query Key Invalidation**: intent detail 단일 조회만 invalidate, 버전 전체 리스트 invalidate 여부는 [TBD: 구현 단계에서 해소]

--- a/.agent/specs/312.md
+++ b/.agent/specs/312.md
@@ -157,6 +157,10 @@ export function useUpdateIntentStatus() {
         // [TBD: 구현 단계에서 해소] Optimistic UI 또는 로딩 상태 처리
       },
       onSuccess: (_data, variables) => {
+        // [TBD: 구현 단계에서 해소] useIntentDetail을 intentKeys.detail(intentId) 기반
+        // TanStack Query hook으로 전환하거나, mutation 성공 후 명시적 refetch/state sync를 수행해야
+        // status badge 갱신이 보장된다. invalidateQueries만으로는 effect/local-state 기반
+        // 기존 hook에서 UI 갱신이 트리거되지 않는다.
         queryClient.invalidateQueries({
           queryKey: intentKeys.detail(variables.intentId),
         });
@@ -266,6 +270,8 @@ export function useUpdateIntentStatus() {
           toast.error("Intent를 찾을 수 없습니다.");
         } else if (error.response?.data?.code === "INTENT_NOT_EDITABLE") {
           toast.error("DRAFT 상태의 버전에서만 승인/반려할 수 있습니다.");
+        } else if (error.response?.data?.code === "VALIDATION_ERROR") {
+          toast.error("허용되지 않은 상태 값입니다.");
         } else {
           toast.error("상태 변경 중 오류가 발생했습니다.");
         }
@@ -411,8 +417,14 @@ export function IntentStatusControl({ status, intentName, intentId, versionLifec
 
   const handleConfirm = () => {
     if (!dialogAction) return;
-    mutate({ intentId, data: { status: dialogAction } });
-    setDialogAction(null);
+    // mutateAsync + try/catch 패턴: 성공 시에만 다이얼로그 닫기
+    // 오류 발생 시 다이얼로그 유지 → 사용자가 재시도 가능
+    mutate(
+      { intentId, data: { status: dialogAction } },
+      {
+        onSuccess: () => setDialogAction(null),
+      }
+    );
   };
 
   // 면담 결정: 항상 표시하되 편집 불가 시 disabled 처리


### PR DESCRIPTION
## Summary
- Conversation Intent 승인(PUBLISHED)/반려(REJECTED) 기능 FE 스펙 작성
- Issue #312 (Burndown Studio)의 스펙 단계 산출물
- 구현은 별도의 `feature/312-conversation-intent-approve` 브랜치에서 진행

## Spec Location
- `.agent/specs/312.md`

## 구현 계획
- 본 spec PR 머지 후 `312-implementation` 플랜 시작
- BE API는 #313에서 이미 완료됨
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ajou-2026-1-capstone-5/ostone/pull/172" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **문서화**
  * 도메인 팩 의도 상세 패널의 DRAFT 의도 승인(Publish)/거절(Reject) UI 사양 추가
  * 승인·거절 버튼은 의도 상태와 버전 라이프사이클이 모두 DRAFT일 때만 활성화되도록 조건 규정
  * 승인/거절별 확인 대화상자 흐름과 취소 동작 명세
  * 성공 시 패널 유지, 상태 배지 갱신, 상세 새로고침 및 성공 토스트 동작 규정
  * HTTP 오류 코드별 사용자 토스트 메시지 매핑 및 오류 처리 명세
  * 테스트 시나리오(정상/오류/접근성/반응형) 및 성능·상태 동기화 주의사항 포함
<!-- end of auto-generated comment: release notes by coderabbit.ai -->