### PR TITLE
feat(3.1.2): conversation intent 승인 기능 구현

### DIFF
--- a/frontend/src/features/approve-intent/api/useApproveIntent.test.ts
+++ b/frontend/src/features/approve-intent/api/useApproveIntent.test.ts
@@ -1,0 +1,73 @@
+import { renderHook, act } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useApproveIntent } from "./useApproveIntent";
+
+const mockMutate = vi.fn();
+const mockMutateAsync = vi.fn();
+
+vi.mock("@/shared/api/generated/endpoints/update-intent-status-controller/update-intent-status-controller", () => ({
+  useUpdateIntentStatus: () => ({
+    mutate: mockMutate,
+    mutateAsync: mockMutateAsync,
+    isPending: false,
+  }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe("useApproveIntent", () => {
+  beforeEach(() => {
+    mockMutate.mockReset();
+    mockMutateAsync.mockReset();
+  });
+
+  it("mutate('PUBLISHED') 호출 시 generated mutation에 올바른 variables 전달", () => {
+    const { result } = renderHook(() =>
+      useApproveIntent({ wsId: 1, packId: 2, versionId: 3, intentId: 4 })
+    );
+
+    act(() => { result.current.mutate("PUBLISHED"); });
+
+    expect(mockMutate).toHaveBeenCalledWith(
+      { workspaceId: 1, packId: 2, versionId: 3, intentId: 4, data: { status: "PUBLISHED" } },
+      expect.objectContaining({
+        onSuccess: expect.any(Function),
+      })
+    );
+  });
+
+  it("mutate 성공 시 onStatusChanged 콜백 호출", () => {
+    const onStatusChanged = vi.fn();
+    const { result } = renderHook(() =>
+      useApproveIntent({ wsId: 1, packId: 2, versionId: 3, intentId: 4, onStatusChanged })
+    );
+
+    act(() => { result.current.mutate("PUBLISHED"); });
+
+    const callArgs = mockMutate.mock.calls[0];
+    const options = callArgs[1];
+    options.onSuccess();
+
+    expect(onStatusChanged).toHaveBeenCalledWith("PUBLISHED");
+  });
+
+  it("mutateAsync('REJECTED')를 호출할 수 있다", async () => {
+    mockMutateAsync.mockResolvedValue(undefined);
+    const { result } = renderHook(() =>
+      useApproveIntent({ wsId: 1, packId: 2, versionId: 3, intentId: 5 })
+    );
+
+    await act(async () => {
+      await result.current.mutateAsync("REJECTED");
+    });
+
+    expect(mockMutateAsync).toHaveBeenCalledWith(
+      { workspaceId: 1, packId: 2, versionId: 3, intentId: 5, data: { status: "REJECTED" } },
+    );
+  });
+});

--- a/frontend/src/features/approve-intent/api/useApproveIntent.ts
+++ b/frontend/src/features/approve-intent/api/useApproveIntent.ts
@@ -1,0 +1,56 @@
+import { toast } from "sonner";
+import { useUpdateIntentStatus } from "@/shared/api/generated/endpoints/update-intent-status-controller/update-intent-status-controller";
+import { ApiRequestError } from "@/shared/api";
+import type { IntentApprovalStatus } from "../model/types";
+
+export interface UseApproveIntentProps {
+  wsId: number;
+  packId: number;
+  versionId: number;
+  intentId: number;
+  onStatusChanged?: (status: IntentApprovalStatus) => void;
+}
+
+const INTENT_ERROR_MESSAGES = {
+  INTENT_NOT_EDITABLE: "편집할 수 없는 상태의 intent입니다.",
+} as const;
+
+export function useApproveIntent({ wsId, packId, versionId, intentId, onStatusChanged }: UseApproveIntentProps) {
+  const mutation = useUpdateIntentStatus();
+
+  const mutate = (status: IntentApprovalStatus) => {
+    mutation.mutate(
+      { workspaceId: wsId, packId, versionId, intentId, data: { status } },
+      {
+        onSuccess: () => {
+          onStatusChanged?.(status);
+          toast.success("intent 상태가 변경되었습니다.");
+        },
+        onError: (error) => {
+          if (error instanceof ApiRequestError) {
+            if (error.code === "INTENT_NOT_EDITABLE") {
+              toast.error(INTENT_ERROR_MESSAGES.INTENT_NOT_EDITABLE);
+              return;
+            }
+          }
+          toast.error("intent 상태 변경에 실패했습니다.");
+        },
+      }
+    );
+  };
+
+  const mutateAsync = (status: IntentApprovalStatus) =>
+    mutation.mutateAsync({
+      workspaceId: wsId,
+      packId,
+      versionId,
+      intentId,
+      data: { status },
+    });
+
+  return {
+    mutate,
+    mutateAsync,
+    isPending: mutation.isPending,
+  };
+}

--- a/frontend/src/features/approve-intent/index.ts
+++ b/frontend/src/features/approve-intent/index.ts
@@ -1,0 +1,4 @@
+export { useApproveIntent } from "./api/useApproveIntent";
+export type { IntentApprovalStatus, IntentApprovalAction } from "./model/types";
+export { ApproveIntentDialog } from "./ui/ApproveIntentDialog";
+export { IntentStatusControl } from "./ui/IntentStatusControl";

--- a/frontend/src/features/approve-intent/index.ts
+++ b/frontend/src/features/approve-intent/index.ts
@@ -2,3 +2,4 @@ export { useApproveIntent } from "./api/useApproveIntent";
 export type { IntentApprovalStatus, IntentApprovalAction } from "./model/types";
 export { ApproveIntentDialog } from "./ui/ApproveIntentDialog";
 export { IntentStatusControl } from "./ui/IntentStatusControl";
+export { IntentDetailWithApproval } from "./ui/IntentDetailWithApproval";

--- a/frontend/src/features/approve-intent/model/types.ts
+++ b/frontend/src/features/approve-intent/model/types.ts
@@ -1,0 +1,2 @@
+export type IntentApprovalStatus = "PUBLISHED" | "REJECTED";
+export type IntentApprovalAction = "publish" | "reject";

--- a/frontend/src/features/approve-intent/ui/ApproveIntentDialog.test.tsx
+++ b/frontend/src/features/approve-intent/ui/ApproveIntentDialog.test.tsx
@@ -1,0 +1,92 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ApproveIntentDialog } from "./ApproveIntentDialog";
+
+describe("ApproveIntentDialog", () => {
+  const onOpenChange = vi.fn();
+  const onConfirm = vi.fn();
+
+  beforeEach(() => {
+    onOpenChange.mockReset();
+    onConfirm.mockReset();
+  });
+
+  it("publish action일 때 confirm 버튼 텍스트가 '승인'이다", () => {
+    render(
+      <ApproveIntentDialog
+        intentName="order_cancel"
+        action="publish"
+        open={true}
+        onOpenChange={onOpenChange}
+        onConfirm={onConfirm}
+        isLoading={false}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "승인" })).toBeInTheDocument();
+  });
+
+  it("reject action일 때 confirm 버튼 텍스트가 '반려'이다", () => {
+    render(
+      <ApproveIntentDialog
+        intentName="order_cancel"
+        action="reject"
+        open={true}
+        onOpenChange={onOpenChange}
+        onConfirm={onConfirm}
+        isLoading={false}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "반려" })).toBeInTheDocument();
+  });
+
+  it("isLoading=true일 때 confirm 버튼이 disabled이고 '처리 중...' 텍스트를 표시한다", () => {
+    render(
+      <ApproveIntentDialog
+        intentName="order_cancel"
+        action="publish"
+        open={true}
+        onOpenChange={onOpenChange}
+        onConfirm={onConfirm}
+        isLoading={true}
+      />,
+    );
+
+    const confirmButton = screen.getByRole("button", { name: "처리 중..." });
+    expect(confirmButton).toBeDisabled();
+  });
+
+  it("isLoading=true일 때 onOpenChange가 무시된다", () => {
+    render(
+      <ApproveIntentDialog
+        intentName="order_cancel"
+        action="publish"
+        open={true}
+        onOpenChange={onOpenChange}
+        onConfirm={onConfirm}
+        isLoading={true}
+      />,
+    );
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it("intentName이 다이얼로그 제목과 설명에 표시된다", () => {
+    render(
+      <ApproveIntentDialog
+        intentName="order_cancel"
+        action="publish"
+        open={true}
+        onOpenChange={onOpenChange}
+        onConfirm={onConfirm}
+        isLoading={false}
+      />,
+    );
+
+    expect(screen.getByText(/intent publish하기/)).toBeInTheDocument();
+    expect(screen.getByText(/order_cancel/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/approve-intent/ui/ApproveIntentDialog.tsx
+++ b/frontend/src/features/approve-intent/ui/ApproveIntentDialog.tsx
@@ -1,0 +1,76 @@
+import { Button } from "@/shared/ui/button";
+import { Spinner } from "@/shared/ui/spinner";
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogTitle,
+} from "@/shared/ui/alert-dialog";
+
+import type { IntentApprovalAction } from "../model/types";
+import styles from "./approve-intent-dialog.module.css";
+
+interface ApproveIntentDialogProps {
+  intentName: string;
+  action: IntentApprovalAction;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+  isLoading: boolean;
+}
+
+export function ApproveIntentDialog({
+  intentName,
+  action,
+  open,
+  onOpenChange,
+  onConfirm,
+  isLoading,
+}: ApproveIntentDialogProps) {
+  const confirmLabel = action === "publish" ? "승인" : "반려";
+  const confirmVariant = action === "publish" ? "default" : "destructive";
+
+  return (
+    <AlertDialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!isLoading) onOpenChange(next);
+      }}
+    >
+      <AlertDialogContent size="sm" className={styles.dialogContent}>
+        <AlertDialogTitle className={styles.title}>
+          intent {action}하기
+        </AlertDialogTitle>
+        <AlertDialogDescription className={styles.description}>
+          <strong>{intentName}</strong> intent를 {action} 처리합니다.
+        </AlertDialogDescription>
+        <AlertDialogFooter className={styles.buttonRow}>
+          <Button
+            variant="outline"
+            className={styles.cancelButton}
+            onClick={() => onOpenChange(false)}
+            disabled={isLoading}
+          >
+            취소
+          </Button>
+          <Button
+            variant={confirmVariant}
+            className={styles.confirmButton}
+            onClick={onConfirm}
+            disabled={isLoading}
+          >
+            {isLoading ? (
+              <>
+                <Spinner />
+                처리 중...
+              </>
+            ) : (
+              confirmLabel
+            )}
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/frontend/src/features/approve-intent/ui/IntentDetailWithApproval.test.tsx
+++ b/frontend/src/features/approve-intent/ui/IntentDetailWithApproval.test.tsx
@@ -1,0 +1,128 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { IntentDetailWithApproval } from "./IntentDetailWithApproval";
+
+vi.mock("../../intent-draft-read/ui", () => ({
+  IntentDetailPanel: ({ children }: any) => children({ name: "test_intent", status: "DRAFT" }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const mockMutate = vi.fn();
+
+vi.mock("../api/useApproveIntent", () => ({
+  useApproveIntent: vi.fn(({ onStatusChanged }: any) => ({
+    mutate: (status: string) => {
+      mockMutate(status);
+      onStatusChanged?.(status === "PUBLISHED" ? "PUBLISHED" : "REJECTED");
+    },
+    isPending: false,
+  })),
+}));
+
+vi.mock("../ui/ApproveIntentDialog", () => ({
+  ApproveIntentDialog: ({ open, onConfirm, onOpenChange, intentName, action, isLoading }: any) => {
+    if (!open) return null;
+    return (
+      <div role="dialog">
+        <span>intentName: {intentName}</span>
+        <span>action: {action}</span>
+        <button onClick={onConfirm} disabled={isLoading}>
+          {action === "publish" ? "승인" : "반려"}
+        </button>
+        <button onClick={() => onOpenChange(false)}>취소</button>
+      </div>
+    );
+  },
+}));
+
+vi.mock("../ui/IntentStatusControl", () => ({
+  IntentStatusControl: ({ intentStatus, onPublish, onReject, isPending }: any) => (
+    <div>
+      <button onClick={onPublish} disabled={isPending || intentStatus !== "DRAFT"}>
+        {isPending ? "처리 중..." : "승인"}
+      </button>
+      <button onClick={onReject} disabled={isPending || intentStatus !== "DRAFT"}>
+        {isPending ? "처리 중..." : "반려"}
+      </button>
+    </div>
+  ),
+}));
+
+describe("IntentDetailWithApproval", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("DRAFT intent에서 publish 버튼 클릭 → dialog 열림", () => {
+    render(<IntentDetailWithApproval wsId={1} pId={2} vId={3} iId={4} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "승인" }));
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText(/test_intent/)).toBeInTheDocument();
+  });
+
+  it("DRAFT intent에서 reject 버튼 클릭 → dialog 열림", () => {
+    render(<IntentDetailWithApproval wsId={1} pId={2} vId={3} iId={4} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "반려" }));
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText(/action: reject/)).toBeInTheDocument();
+  });
+
+  it("dialog에서 취소 버튼 클릭 → dialog 닫힘", () => {
+    render(<IntentDetailWithApproval wsId={1} pId={2} vId={3} iId={4} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "승인" }));
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "취소" }));
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("publish confirm 시 mutate('PUBLISHED')가 호출된다", () => {
+    render(<IntentDetailWithApproval wsId={1} pId={2} vId={3} iId={4} />);
+
+    const publishButtons = screen.getAllByRole("button", { name: "승인" });
+    fireEvent.click(publishButtons[0]);
+
+    const dialog = screen.getByRole("dialog");
+    fireEvent.click(within(dialog).getByRole("button", { name: "승인" }));
+
+    expect(mockMutate).toHaveBeenCalledWith("PUBLISHED");
+  });
+
+  it("reject confirm 시 mutate('REJECTED')가 호출된다", () => {
+    render(<IntentDetailWithApproval wsId={1} pId={2} vId={3} iId={4} />);
+
+    const rejectButtons = screen.getAllByRole("button", { name: "반려" });
+    fireEvent.click(rejectButtons[0]);
+
+    const dialog = screen.getByRole("dialog");
+    fireEvent.click(within(dialog).getByRole("button", { name: "반려" }));
+
+    expect(mockMutate).toHaveBeenCalledWith("REJECTED");
+  });
+
+  it("iId가 변경되면 상태가 초기화된다", () => {
+    const { rerender } = render(
+      <IntentDetailWithApproval wsId={1} pId={2} vId={3} iId={4} />,
+    );
+
+    const publishButtons = screen.getAllByRole("button", { name: "승인" });
+    fireEvent.click(publishButtons[0]);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    rerender(<IntentDetailWithApproval wsId={1} pId={2} vId={3} iId={5} />);
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/approve-intent/ui/IntentDetailWithApproval.tsx
+++ b/frontend/src/features/approve-intent/ui/IntentDetailWithApproval.tsx
@@ -10,7 +10,7 @@ import {
 
 function normalizeIntentStatus(
   raw: string,
-  override: string | null
+  override: IntentApprovalStatus | null
 ): "DRAFT" | IntentApprovalStatus {
   const effective = override ?? raw;
   if (effective === "DRAFT" || effective === "PUBLISHED" || effective === "REJECTED") {
@@ -31,7 +31,7 @@ export function IntentDetailWithApproval({
   iId: number;
 }) {
   const [dialogAction, setDialogAction] = useState<IntentApprovalAction | null>(null);
-  const [statusOverride, setStatusOverride] = useState<string | null>(null);
+  const [statusOverride, setStatusOverride] = useState<IntentApprovalStatus | null>(null);
   const [detailRefreshKey, setDetailRefreshKey] = useState(0);
 
   useEffect(() => {

--- a/frontend/src/features/approve-intent/ui/IntentDetailWithApproval.tsx
+++ b/frontend/src/features/approve-intent/ui/IntentDetailWithApproval.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useState } from "react";
+import { IntentDetailPanel } from "../../intent-draft-read/ui";
+import {
+  useApproveIntent,
+  type IntentApprovalStatus,
+  type IntentApprovalAction,
+  ApproveIntentDialog,
+  IntentStatusControl,
+} from "../index";
+
+function normalizeIntentStatus(
+  raw: string,
+  override: string | null
+): "DRAFT" | IntentApprovalStatus {
+  const effective = override ?? raw;
+  if (effective === "DRAFT" || effective === "PUBLISHED" || effective === "REJECTED") {
+    return effective as IntentApprovalStatus;
+  }
+  return "DRAFT";
+}
+
+export function IntentDetailWithApproval({
+  wsId,
+  pId,
+  vId,
+  iId,
+}: {
+  wsId: number;
+  pId: number;
+  vId: number;
+  iId: number;
+}) {
+  const [dialogAction, setDialogAction] = useState<IntentApprovalAction | null>(null);
+  const [statusOverride, setStatusOverride] = useState<string | null>(null);
+  const [detailRefreshKey, setDetailRefreshKey] = useState(0);
+
+  useEffect(() => {
+    setDialogAction(null);
+    setStatusOverride(null);
+    setDetailRefreshKey(0);
+  }, [iId]);
+
+  const mutation = useApproveIntent({
+    wsId,
+    packId: pId,
+    versionId: vId,
+    intentId: iId,
+    onStatusChanged: (status) => {
+      setStatusOverride(status);
+      setDialogAction(null);
+      setDetailRefreshKey((k) => k + 1);
+    },
+  });
+
+  const handleDialogOpenChange = (next: boolean) => {
+    if (!mutation.isPending) setDialogAction(next ? dialogAction : null);
+  };
+
+  const handleConfirm = () => {
+    if (dialogAction === null) return;
+    const status: IntentApprovalStatus =
+      dialogAction === "publish" ? "PUBLISHED" : "REJECTED";
+    mutation.mutate(status);
+  };
+
+  return (
+    <IntentDetailPanel
+      wsId={wsId}
+      packId={pId}
+      versionId={vId}
+      intentId={iId}
+      refreshKey={detailRefreshKey}
+    >
+      {(detail) => (
+        <>
+          <IntentStatusControl
+            intentStatus={normalizeIntentStatus(detail.status, statusOverride)}
+            onPublish={() => setDialogAction("publish")}
+            onReject={() => setDialogAction("reject")}
+            isPending={mutation.isPending}
+          />
+          <ApproveIntentDialog
+            intentName={detail.name}
+            action={dialogAction ?? "publish"}
+            open={dialogAction !== null}
+            onOpenChange={handleDialogOpenChange}
+            onConfirm={handleConfirm}
+            isLoading={mutation.isPending}
+          />
+        </>
+      )}
+    </IntentDetailPanel>
+  );
+}

--- a/frontend/src/features/approve-intent/ui/IntentStatusControl.test.tsx
+++ b/frontend/src/features/approve-intent/ui/IntentStatusControl.test.tsx
@@ -6,6 +6,10 @@ describe("IntentStatusControl", () => {
   const onPublish = vi.fn();
   const onReject = vi.fn();
 
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("intentStatus='DRAFT'일 때 publish/reject 버튼이 모두 enabled", () => {
     render(
       <IntentStatusControl

--- a/frontend/src/features/approve-intent/ui/IntentStatusControl.test.tsx
+++ b/frontend/src/features/approve-intent/ui/IntentStatusControl.test.tsx
@@ -1,0 +1,108 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { IntentStatusControl } from "./IntentStatusControl";
+
+describe("IntentStatusControl", () => {
+  const onPublish = vi.fn();
+  const onReject = vi.fn();
+
+  it("intentStatus='DRAFT'일 때 publish/reject 버튼이 모두 enabled", () => {
+    render(
+      <IntentStatusControl
+        intentStatus="DRAFT"
+        onPublish={onPublish}
+        onReject={onReject}
+        isPending={false}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "승인" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "반려" })).toBeEnabled();
+  });
+
+  it("intentStatus='PUBLISHED'일 때 publish 버튼이 disabled", () => {
+    render(
+      <IntentStatusControl
+        intentStatus="PUBLISHED"
+        onPublish={onPublish}
+        onReject={onReject}
+        isPending={false}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "승인" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "반려" })).toBeDisabled();
+  });
+
+  it("intentStatus='REJECTED'일 때 두 버튼이 모두 disabled", () => {
+    render(
+      <IntentStatusControl
+        intentStatus="REJECTED"
+        onPublish={onPublish}
+        onReject={onReject}
+        isPending={false}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "승인" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "반려" })).toBeDisabled();
+  });
+
+  it("isPending=true일 때 두 버튼이 모두 disabled", () => {
+    render(
+      <IntentStatusControl
+        intentStatus="DRAFT"
+        onPublish={onPublish}
+        onReject={onReject}
+        isPending={true}
+      />,
+    );
+
+    const buttons = screen.getAllByRole("button");
+    expect(buttons).toHaveLength(2);
+    expect(buttons[0]).toBeDisabled();
+    expect(buttons[1]).toBeDisabled();
+  });
+
+  it("publish 버튼 클릭 시 onPublish 호출", () => {
+    render(
+      <IntentStatusControl
+        intentStatus="DRAFT"
+        onPublish={onPublish}
+        onReject={onReject}
+        isPending={false}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "승인" }));
+    expect(onPublish).toHaveBeenCalledTimes(1);
+  });
+
+  it("reject 버튼 클릭 시 onReject 호출", () => {
+    render(
+      <IntentStatusControl
+        intentStatus="DRAFT"
+        onPublish={onPublish}
+        onReject={onReject}
+        isPending={false}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "반려" }));
+    expect(onReject).toHaveBeenCalledTimes(1);
+  });
+
+  it("isPending=true일 때 버튼 텍스트가 '처리 중...'", () => {
+    render(
+      <IntentStatusControl
+        intentStatus="DRAFT"
+        onPublish={onPublish}
+        onReject={onReject}
+        isPending={true}
+      />,
+    );
+
+    const buttons = screen.getAllByRole("button", { name: "처리 중..." });
+    expect(buttons).toHaveLength(2);
+  });
+});

--- a/frontend/src/features/approve-intent/ui/IntentStatusControl.tsx
+++ b/frontend/src/features/approve-intent/ui/IntentStatusControl.tsx
@@ -1,0 +1,56 @@
+import { Button } from "@/shared/ui/button";
+import { Spinner } from "@/shared/ui/spinner";
+import type { IntentApprovalStatus } from "../model/types";
+import styles from "./intent-status-control.module.css";
+
+interface IntentStatusControlProps {
+  intentStatus: "DRAFT" | IntentApprovalStatus;
+  onPublish: () => void;
+  onReject: () => void;
+  isPending: boolean;
+}
+
+export function IntentStatusControl({
+  intentStatus,
+  onPublish,
+  onReject,
+  isPending,
+}: Readonly<IntentStatusControlProps>) {
+  const isDisabled = intentStatus !== "DRAFT" || isPending;
+
+  const renderButtonContent = (label: string) => {
+    if (isPending) {
+      return (
+        <>
+          <Spinner />
+          처리 중...
+        </>
+      );
+    }
+    return label;
+  };
+
+  return (
+    <div className={styles.container}>
+      <span className={styles.header}>intent 상태 관리</span>
+      <div className={styles.buttonGroup}>
+        <Button
+          variant="default"
+          size="sm"
+          onClick={onPublish}
+          disabled={isDisabled}
+        >
+          {renderButtonContent("승인")}
+        </Button>
+        <Button
+          variant="destructive"
+          size="sm"
+          onClick={onReject}
+          disabled={isDisabled}
+        >
+          {renderButtonContent("반려")}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/approve-intent/ui/approve-intent-dialog.module.css
+++ b/frontend/src/features/approve-intent/ui/approve-intent-dialog.module.css
@@ -1,0 +1,55 @@
+.dialogContent {
+  border-radius: 8px;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  background:
+    radial-gradient(circle at top right, rgba(0, 0, 0, 0.05), transparent 34%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.985), #ffffff);
+  box-shadow: 0 28px 80px rgba(0, 0, 0, 0.16);
+  padding: 24px !important;
+  gap: 16px;
+}
+
+.title {
+  font-size: 1.25rem;
+  font-weight: 540;
+  letter-spacing: -0.32px;
+  line-height: 1.2;
+  text-wrap: balance;
+}
+
+.description {
+  color: rgba(0, 0, 0, 0.62);
+  font-size: 0.92rem;
+  line-height: 1.6;
+  letter-spacing: -0.14px;
+}
+
+.buttonRow {
+  margin-top: 4px;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+.cancelButton {
+  min-height: 40px;
+  border-radius: 999px;
+  border-color: rgba(0, 0, 0, 0.12) !important;
+  background: rgba(0, 0, 0, 0.04) !important;
+  color: rgba(0, 0, 0, 0.78) !important;
+  font-size: 0.94rem;
+  letter-spacing: -0.14px;
+}
+
+.cancelButton:hover {
+  background: rgba(0, 0, 0, 0.08) !important;
+}
+
+.confirmButton {
+  min-height: 40px;
+  border-radius: 999px;
+  font-size: 0.94rem;
+  font-weight: 540;
+  letter-spacing: -0.14px;
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.16);
+}

--- a/frontend/src/features/approve-intent/ui/intent-status-control.module.css
+++ b/frontend/src/features/approve-intent/ui/intent-status-control.module.css
@@ -1,0 +1,17 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.header {
+  font-size: 0.875rem;
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+.buttonGroup {
+  display: flex;
+  flex-direction: row;
+  gap: 8px;
+}

--- a/frontend/src/features/intent-draft-read/model/useIntentDetail.ts
+++ b/frontend/src/features/intent-draft-read/model/useIntentDetail.ts
@@ -14,6 +14,7 @@ export function useIntentDetail(
   packId: number,
   versionId: number,
   intentId: number | null,
+  refreshKey?: number,
 ): IntentDetailState {
   const requestKey = intentId === null ? null : `${wsId}:${packId}:${versionId}:${intentId}`;
   const [state, setState] = useState<{
@@ -53,7 +54,7 @@ export function useIntentDetail(
     return () => {
       cancelled = true;
     };
-  }, [intentId, packId, requestKey, versionId, wsId]);
+  }, [intentId, packId, refreshKey, requestKey, versionId, wsId]);
 
   if (requestKey === null) {
     return { status: "idle" };

--- a/frontend/src/features/intent-draft-read/ui/IntentDetailPanel.test.tsx
+++ b/frontend/src/features/intent-draft-read/ui/IntentDetailPanel.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { toast } from "sonner";
+import { useIntentDetail } from "../model/useIntentDetail";
+import { IntentDetailPanel } from "./IntentDetailPanel";
+
+vi.mock("../model/useIntentDetail", () => ({
+  useIntentDetail: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn() },
+}));
+
+const mockedUseIntentDetail = vi.mocked(useIntentDetail);
+
+const stubDetail = {
+  id: 10,
+  intentCode: "INTENT_001",
+  name: "배송 조회 문의",
+  description: null,
+  taxonomyLevel: 1,
+  parentIntentId: null,
+  status: "ACTIVE",
+  sourceClusterRef: "{}",
+  entryConditionJson: "{}",
+  evidenceJson: "[]",
+  metaJson: "{}",
+  createdAt: "",
+  updatedAt: "",
+};
+
+function renderPanel(props: Partial<React.ComponentProps<typeof IntentDetailPanel>> = {}) {
+  const defaults = {
+    wsId: 1,
+    packId: 2,
+    versionId: 3,
+    intentId: 10 as number | null,
+  };
+  render(<IntentDetailPanel {...defaults} {...props} />);
+}
+
+describe("IntentDetailPanel", () => {
+  beforeEach(() => {
+    mockedUseIntentDetail.mockReset();
+    vi.mocked(toast.error).mockReset();
+  });
+
+  it("idle 상태에서는 children render-prop을 호출하지 않는다", () => {
+    mockedUseIntentDetail.mockReturnValue({ status: "idle" });
+    const childrenFn = vi.fn(() => <div data-testid="children">children</div>);
+
+    renderPanel({ intentId: null, children: childrenFn });
+
+    expect(childrenFn).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("children")).not.toBeInTheDocument();
+  });
+
+  it("loading 상태에서는 children render-prop을 호출하지 않는다", () => {
+    mockedUseIntentDetail.mockReturnValue({ status: "loading" });
+    const childrenFn = vi.fn(() => <div data-testid="children">children</div>);
+
+    renderPanel({ children: childrenFn });
+
+    expect(childrenFn).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("children")).not.toBeInTheDocument();
+  });
+
+  it("error 상태에서는 children render-prop을 호출하지 않는다", () => {
+    mockedUseIntentDetail.mockReturnValue({
+      status: "error",
+      code: "NOT_FOUND",
+      message: "없음",
+      httpStatus: 404,
+    });
+    const childrenFn = vi.fn(() => <div data-testid="children">children</div>);
+
+    renderPanel({ children: childrenFn });
+
+    expect(childrenFn).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("children")).not.toBeInTheDocument();
+  });
+
+  it("ready 상태에서 children이 없으면 기존 렌더링을 유지한다", () => {
+    mockedUseIntentDetail.mockReturnValue({ status: "ready", data: stubDetail });
+
+    renderPanel();
+
+    expect(screen.getByText("INTENT_001")).toBeInTheDocument();
+    expect(screen.getByText("배송 조회 문의")).toBeInTheDocument();
+    expect(screen.getByText("ACTIVE")).toBeInTheDocument();
+  });
+
+  it("ready 상태에서 children render-prop을 호출하고 detail.data를 전달한다", () => {
+    mockedUseIntentDetail.mockReturnValue({ status: "ready", data: stubDetail });
+    const childrenFn = vi.fn((detail) => (
+      <div data-testid="children">{detail.name}</div>
+    ));
+
+    renderPanel({ children: childrenFn });
+
+    expect(childrenFn).toHaveBeenCalledTimes(1);
+    expect(childrenFn).toHaveBeenCalledWith(stubDetail);
+    expect(screen.getByTestId("children")).toHaveTextContent("배송 조회 문의");
+    expect(screen.getByText("INTENT_001")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/intent-draft-read/ui/IntentDetailPanel.tsx
+++ b/frontend/src/features/intent-draft-read/ui/IntentDetailPanel.tsx
@@ -9,10 +9,12 @@ interface IntentDetailPanelProps {
   packId: number;
   versionId: number;
   intentId: number | null;
+  refreshKey?: number;
+  children?: (detail: IntentDetail) => ReactNode;
 }
 
-export function IntentDetailPanel({ wsId, packId, versionId, intentId }: IntentDetailPanelProps) {
-  const state = useIntentDetail(wsId, packId, versionId, intentId);
+export function IntentDetailPanel({ wsId, packId, versionId, intentId, refreshKey, children }: IntentDetailPanelProps) {
+  const state = useIntentDetail(wsId, packId, versionId, intentId, refreshKey);
   const errorCode = state.status === "error" ? state.code : undefined;
   const errorHttpStatus = state.status === "error" ? state.httpStatus : undefined;
   const errorMessage = state.status === "error" ? state.message : undefined;
@@ -87,6 +89,7 @@ export function IntentDetailPanel({ wsId, packId, versionId, intentId }: IntentD
         <JsonCard label="Evidence" value={state.data.evidenceJson} />
         <JsonCard label="Meta" value={state.data.metaJson} />
       </div>
+      {children?.(state.data)}
     </section>
   );
 }

--- a/frontend/src/pages/domain-pack/ui/IntentDraftReadPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/IntentDraftReadPage.tsx
@@ -1,90 +1,9 @@
-import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { IntentDetailPanel, IntentTreePanel } from "../../../features/intent-draft-read/ui";
-import {
-  useApproveIntent,
-  type IntentApprovalStatus,
-  type IntentApprovalAction,
-  ApproveIntentDialog,
-  IntentStatusControl,
-} from "../../../features/approve-intent";
+import { IntentDetailWithApproval } from "../../../features/approve-intent";
 import { parseRouteId } from "../../../shared/lib/parseRouteId";
 import { DashboardLayout } from "../../../shared/ui/layout/DashboardLayout";
 import styles from "./intent-draft-read-page.module.css";
-
-function IntentDetailWithApproval({
-  wsId,
-  pId,
-  vId,
-  iId,
-}: {
-  wsId: number;
-  pId: number;
-  vId: number;
-  iId: number;
-}) {
-  const [dialogAction, setDialogAction] = useState<IntentApprovalAction | null>(null);
-  const [statusOverride, setStatusOverride] = useState<string | null>(null);
-  const [detailRefreshKey, setDetailRefreshKey] = useState(0);
-
-  useEffect(() => {
-    setDialogAction(null);
-    setStatusOverride(null);
-    setDetailRefreshKey(0);
-  }, [iId]);
-
-  const mutation = useApproveIntent({
-    wsId,
-    packId: pId,
-    versionId: vId,
-    intentId: iId,
-    onStatusChanged: (status) => {
-      setStatusOverride(status);
-      setDialogAction(null);
-      setDetailRefreshKey((k) => k + 1);
-    },
-  });
-
-  const handleDialogOpenChange = (next: boolean) => {
-    if (!mutation.isPending) setDialogAction(next ? dialogAction : null);
-  };
-
-  const handleConfirm = () => {
-    if (dialogAction === null) return;
-    const status: IntentApprovalStatus =
-      dialogAction === "publish" ? "PUBLISHED" : "REJECTED";
-    mutation.mutate(status);
-  };
-
-  return (
-    <IntentDetailPanel
-      wsId={wsId}
-      packId={pId}
-      versionId={vId}
-      intentId={iId}
-      refreshKey={detailRefreshKey}
-    >
-      {(detail) => (
-        <>
-          <IntentStatusControl
-            intentStatus={(statusOverride ?? detail.status) as "DRAFT" | IntentApprovalStatus}
-            onPublish={() => setDialogAction("publish")}
-            onReject={() => setDialogAction("reject")}
-            isPending={mutation.isPending}
-          />
-          <ApproveIntentDialog
-            intentName={detail.name}
-            action={dialogAction ?? "publish"}
-            open={dialogAction !== null}
-            onOpenChange={handleDialogOpenChange}
-            onConfirm={handleConfirm}
-            isLoading={mutation.isPending}
-          />
-        </>
-      )}
-    </IntentDetailPanel>
-  );
-}
 
 export function IntentDraftReadPage() {
   const { workspaceId, packId, versionId, intentId } = useParams();
@@ -148,7 +67,7 @@ export function IntentDraftReadPage() {
           </div>
           <div className={styles.detailSlot}>
             {iId !== null ? (
-              <IntentDetailWithApproval wsId={wsId} pId={pId} vId={vId} iId={iId} />
+              <IntentDetailWithApproval key={iId} wsId={wsId} pId={pId} vId={vId} iId={iId} />
             ) : (
               <IntentDetailPanel wsId={wsId} packId={pId} versionId={vId} intentId={null} />
             )}

--- a/frontend/src/pages/domain-pack/ui/IntentDraftReadPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/IntentDraftReadPage.tsx
@@ -1,8 +1,90 @@
+import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { IntentDetailPanel, IntentTreePanel } from "../../../features/intent-draft-read/ui";
+import {
+  useApproveIntent,
+  type IntentApprovalStatus,
+  type IntentApprovalAction,
+  ApproveIntentDialog,
+  IntentStatusControl,
+} from "../../../features/approve-intent";
 import { parseRouteId } from "../../../shared/lib/parseRouteId";
 import { DashboardLayout } from "../../../shared/ui/layout/DashboardLayout";
 import styles from "./intent-draft-read-page.module.css";
+
+function IntentDetailWithApproval({
+  wsId,
+  pId,
+  vId,
+  iId,
+}: {
+  wsId: number;
+  pId: number;
+  vId: number;
+  iId: number;
+}) {
+  const [dialogAction, setDialogAction] = useState<IntentApprovalAction | null>(null);
+  const [statusOverride, setStatusOverride] = useState<string | null>(null);
+  const [detailRefreshKey, setDetailRefreshKey] = useState(0);
+
+  useEffect(() => {
+    setDialogAction(null);
+    setStatusOverride(null);
+    setDetailRefreshKey(0);
+  }, [iId]);
+
+  const mutation = useApproveIntent({
+    wsId,
+    packId: pId,
+    versionId: vId,
+    intentId: iId,
+    onStatusChanged: (status) => {
+      setStatusOverride(status);
+      setDialogAction(null);
+      setDetailRefreshKey((k) => k + 1);
+    },
+  });
+
+  const handleDialogOpenChange = (next: boolean) => {
+    if (!mutation.isPending) setDialogAction(next ? dialogAction : null);
+  };
+
+  const handleConfirm = () => {
+    if (dialogAction === null) return;
+    const status: IntentApprovalStatus =
+      dialogAction === "publish" ? "PUBLISHED" : "REJECTED";
+    mutation.mutate(status);
+  };
+
+  return (
+    <IntentDetailPanel
+      wsId={wsId}
+      packId={pId}
+      versionId={vId}
+      intentId={iId}
+      refreshKey={detailRefreshKey}
+    >
+      {(detail) => (
+        <>
+          <IntentStatusControl
+            intentStatus={(statusOverride ?? detail.status) as "DRAFT" | IntentApprovalStatus}
+            onPublish={() => setDialogAction("publish")}
+            onReject={() => setDialogAction("reject")}
+            isPending={mutation.isPending}
+          />
+          <ApproveIntentDialog
+            intentName={detail.name}
+            action={dialogAction ?? "publish"}
+            open={dialogAction !== null}
+            onOpenChange={handleDialogOpenChange}
+            onConfirm={handleConfirm}
+            isLoading={mutation.isPending}
+          />
+        </>
+      )}
+    </IntentDetailPanel>
+  );
+}
 
 export function IntentDraftReadPage() {
   const { workspaceId, packId, versionId, intentId } = useParams();
@@ -65,7 +147,11 @@ export function IntentDraftReadPage() {
             />
           </div>
           <div className={styles.detailSlot}>
-            <IntentDetailPanel wsId={wsId} packId={pId} versionId={vId} intentId={iId} />
+            {iId !== null ? (
+              <IntentDetailWithApproval wsId={wsId} pId={pId} vId={vId} iId={iId} />
+            ) : (
+              <IntentDetailPanel wsId={wsId} packId={pId} versionId={vId} intentId={null} />
+            )}
           </div>
         </div>
       </div>

--- a/frontend/src/shared/api/mutator.test.ts
+++ b/frontend/src/shared/api/mutator.test.ts
@@ -86,4 +86,24 @@ describe("customFetch", () => {
       customFetch("/test", { method: "GET" }),
     ).rejects.toThrow("Network error");
   });
+
+  it("URL에 /api/v1 prefix가 있으면 제거하여 apiClient.request에 전달한다", async () => {
+    vi.mocked(apiClient.request).mockResolvedValueOnce({});
+
+    await customFetch("/api/v1/test", { method: "GET" });
+
+    expect(apiClient.request).toHaveBeenCalledWith("/test", {
+      method: "GET",
+    });
+  });
+
+  it("URL에 /api/v1 prefix가 없으면 그대로 전달한다", async () => {
+    vi.mocked(apiClient.request).mockResolvedValueOnce({});
+
+    await customFetch("/test", { method: "GET" });
+
+    expect(apiClient.request).toHaveBeenCalledWith("/test", {
+      method: "GET",
+    });
+  });
 });

--- a/frontend/src/shared/api/mutator.test.ts
+++ b/frontend/src/shared/api/mutator.test.ts
@@ -10,7 +10,7 @@ vi.mock("./index", () => ({
 
 describe("customFetch", () => {
   afterEach(() => {
-    vi.restoreAllMocks();
+    vi.clearAllMocks();
   });
 
   it("apiClient.request에 URL과 options를 전달한다", async () => {
@@ -117,12 +117,22 @@ describe("customFetch", () => {
     });
   });
 
-  it("URL에 /api/v1 prefix가 있고 남은 경로에 /가 없으면 추가한다", async () => {
+  it("URL에 /api/v1/ prefix가 있으면 제거하여 apiClient.request에 전달한다", async () => {
     vi.mocked(apiClient.request).mockResolvedValueOnce({});
 
-    await customFetch("/api/v1items", { method: "GET" });
+    await customFetch("/api/v1/items", { method: "GET" });
 
     expect(apiClient.request).toHaveBeenCalledWith("/items", {
+      method: "GET",
+    });
+  });
+
+  it("URL이 /api/v10/test면 prefix를 제거하지 않고 그대로 전달한다", async () => {
+    vi.mocked(apiClient.request).mockResolvedValueOnce({});
+
+    await customFetch("/api/v10/test", { method: "GET" });
+
+    expect(apiClient.request).toHaveBeenCalledWith("/api/v10/test", {
       method: "GET",
     });
   });

--- a/frontend/src/shared/api/mutator.test.ts
+++ b/frontend/src/shared/api/mutator.test.ts
@@ -106,4 +106,24 @@ describe("customFetch", () => {
       method: "GET",
     });
   });
+
+  it("URL이 정확히 /api/v1이면 '/'로 정규화한다", async () => {
+    vi.mocked(apiClient.request).mockResolvedValueOnce({});
+
+    await customFetch("/api/v1", { method: "GET" });
+
+    expect(apiClient.request).toHaveBeenCalledWith("/", {
+      method: "GET",
+    });
+  });
+
+  it("URL에 /api/v1 prefix가 있고 남은 경로에 /가 없으면 추가한다", async () => {
+    vi.mocked(apiClient.request).mockResolvedValueOnce({});
+
+    await customFetch("/api/v1items", { method: "GET" });
+
+    expect(apiClient.request).toHaveBeenCalledWith("/items", {
+      method: "GET",
+    });
+  });
 });

--- a/frontend/src/shared/api/mutator.ts
+++ b/frontend/src/shared/api/mutator.ts
@@ -1,10 +1,17 @@
 import { apiClient } from './index';
 
+const API_PREFIX = "/api/v1";
+
 export async function customFetch<T>(
   url: string,
   options: RequestInit,
 ): Promise<T> {
   const normalizedUrl = url.startsWith('/') ? url : `/${url}`;
 
-  return apiClient.request<T>(normalizedUrl, options);
+  // Strip API prefix if present (generated URLs include /api/v1 but apiClient already adds it)
+  const normalizedPath = normalizedUrl.startsWith(`${API_PREFIX}/`)
+    ? normalizedUrl.slice(API_PREFIX.length)
+    : normalizedUrl;
+
+  return apiClient.request<T>(normalizedPath, options);
 }

--- a/frontend/src/shared/api/mutator.ts
+++ b/frontend/src/shared/api/mutator.ts
@@ -9,9 +9,16 @@ export async function customFetch<T>(
   const normalizedUrl = url.startsWith('/') ? url : `/${url}`;
 
   // Strip API prefix if present (generated URLs include /api/v1 but apiClient already adds it)
-  const normalizedPath = normalizedUrl.startsWith(`${API_PREFIX}/`)
+  const stripped = normalizedUrl.startsWith(API_PREFIX)
     ? normalizedUrl.slice(API_PREFIX.length)
-    : normalizedUrl;
+    : null;
+  const normalizedPath = stripped === ""
+    ? "/"
+    : stripped !== null
+      ? stripped.startsWith("/")
+        ? stripped
+        : `/${stripped}`
+      : normalizedUrl;
 
   return apiClient.request<T>(normalizedPath, options);
 }

--- a/frontend/src/shared/api/mutator.ts
+++ b/frontend/src/shared/api/mutator.ts
@@ -9,16 +9,10 @@ export async function customFetch<T>(
   const normalizedUrl = url.startsWith('/') ? url : `/${url}`;
 
   // Strip API prefix if present (generated URLs include /api/v1 but apiClient already adds it)
-  const stripped = normalizedUrl.startsWith(API_PREFIX)
-    ? normalizedUrl.slice(API_PREFIX.length)
-    : null;
-  const normalizedPath = stripped === ""
-    ? "/"
-    : stripped !== null
-      ? stripped.startsWith("/")
-        ? stripped
-        : `/${stripped}`
-      : normalizedUrl;
+  const hasExactPrefix =
+    normalizedUrl === API_PREFIX || normalizedUrl.startsWith(API_PREFIX + "/");
+  const stripped = hasExactPrefix ? normalizedUrl.slice(API_PREFIX.length) : null;
+  const normalizedPath = stripped === "" ? "/" : stripped ?? normalizedUrl;
 
   return apiClient.request<T>(normalizedPath, options);
 }

--- a/frontend/src/shared/ui/spinner.tsx
+++ b/frontend/src/shared/ui/spinner.tsx
@@ -6,7 +6,7 @@ function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
   return (
     <Loader2Icon
       role="status"
-      aria-label="Loading"
+      aria-hidden="true"
       className={cn("size-4 animate-spin", className)}
       {...props}
     />


### PR DESCRIPTION
## Summary
- 신규 feature: `approve-intent` — intent 승인/반려 기능 구현
- Dialog: `ApproveIntentDialog` (AlertDialog 기반, controlled pattern)
- Control: `IntentStatusControl` (DRAFT/non-DRAFT 상태별 버튼 활성화)
- Hook: `useApproveIntent` (generated `useUpdateIntentStatus` wrapper)
- `IntentDetailPanel`: `refreshKey` prop + children render-prop slot 추가
- `IntentDraftReadPage`: `IntentDetailWithApproval` inline component로 통합
- `mutator.ts`: `/api/v1` prefix 정규화
- Spinner, toast success/error, error handling 포함
- TDD: 387 tests ALL PASSED, build 성공
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ajou-2026-1-capstone-5/ostone/pull/173" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Intent 승인/반려 UI 추가: 상태 제어 버튼, 확인 다이얼로그, 상세 패널 통합 및 상태 갱신 흐름 제공
  * 승인/반려 훅 추가: mutate/mutateAsync와 대기/성공 콜백 노출
  * 상태 관련 타입과 재수출 모듈 추가

* **Improvements**
  * 상세 조회 컴포넌트에 강제 새로고침 키와 렌더 프로프 지원 추가
  * API 경로 정규화 로직 개선 및 스피너 접근성 속성 개선
  * 다이얼로그/컨트롤용 스타일시트 추가

* **Tests**
  * 컴포넌트·훅·유닛 테스트 대거 추가 및 기존 테스트 정리 적용
<!-- end of auto-generated comment: release notes by coderabbit.ai -->