### PR TITLE
feat(ml): implement workflow graph generation per intent (002218)

### DIFF
--- a/ml/src/pipeline/stages/draft_generation/main.py
+++ b/ml/src/pipeline/stages/draft_generation/main.py
@@ -13,6 +13,7 @@ from pipeline.common.context import StageContext
 from pipeline.common.exceptions import PipelineStageError
 from pipeline.common.logging import get_stage_logger
 from pipeline.stages.draft_generation.workflow_graph import (
+    DUMMY_POLICY_CODE,
     ClusterContext,
     serialize_graph_json,
     signal_based_generator,
@@ -202,7 +203,7 @@ def _derive_pack_identity(stage_context: StageContext) -> tuple[str, str]:
 
 def _default_dummy_policy() -> dict[str, Any]:
     return {
-        "policyCode": "default_policy",
+        "policyCode": DUMMY_POLICY_CODE,
         "name": "Default policy (Dummy)",
         "description": (
             "Workflow ACTION 노드의 V8c policyRef 검증을 충족하기 위한 "

--- a/ml/src/pipeline/stages/draft_generation/main.py
+++ b/ml/src/pipeline/stages/draft_generation/main.py
@@ -11,6 +11,11 @@ from pipeline.common.config import PipelineRuntimeConfig
 from pipeline.common.context import StageContext
 from pipeline.common.exceptions import PipelineStageError
 from pipeline.common.logging import get_stage_logger
+from pipeline.stages.draft_generation.workflow_graph import (
+    ClusterContext,
+    serialize_graph_json,
+    signal_based_generator,
+)
 from pipeline.stages.preprocessing.io import read_stage_context
 
 DEFAULT_CANDIDATE_ARTIFACT = "candidate.json"
@@ -42,7 +47,23 @@ def run(upstream_manifest_path: str | None = None) -> dict[str, object]:
         metrics["intents_with_zero_cases"],
     )
 
-    candidate = _build_candidate(intents)
+    candidate = _build_candidate(intents, clusters, stage_context)
+    logger.info(
+        "draft_generation.pack_identity pack_key=%s pack_name=%s",
+        candidate["domainPackDraft"]["packKey"],
+        candidate["domainPackDraft"]["packName"],
+    )
+
+    workflow_metrics = _build_workflow_metrics(clusters)
+    metrics.update(workflow_metrics)
+    logger.info(
+        "draft_generation.workflow_built workflow_count=%d identify_count=%d payment_count=%d escalation_count=%d",
+        workflow_metrics["workflow_count"],
+        workflow_metrics["workflow_with_identify_count"],
+        workflow_metrics["workflow_with_payment_check_count"],
+        workflow_metrics["workflow_with_escalation_count"],
+    )
+
     candidate_path = _write_candidate(stage_context, runtime_config, candidate)
 
     metrics["processing_duration_seconds"] = time.monotonic() - start
@@ -168,17 +189,118 @@ def _hydrate_case(conv: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _build_candidate(intents: list[dict[str, Any]]) -> dict[str, Any]:
+def _derive_pack_identity(stage_context: StageContext) -> tuple[str, str]:
+    if stage_context.workspace_id is None or stage_context.dataset_id is None:
+        raise PipelineStageError("packKey requires both workspace_id and dataset_id in StageContext.")
+    pack_key = f"pack_ws{stage_context.workspace_id}_ds{stage_context.dataset_id}"
+    pack_name = f"Pack ws{stage_context.workspace_id}/ds{stage_context.dataset_id}"
+    return pack_key, pack_name
+
+
+def _default_dummy_policy() -> dict[str, Any]:
+    return {
+        "policyCode": "default_policy",
+        "name": "Default policy (Dummy)",
+        "description": (
+            "Workflow ACTION 노드의 V8c policyRef 검증을 충족하기 위한 "
+            "placeholder dummy policy. 후속 backlog spec(별도 2.2.x)에서 "
+            "cluster context 기반 실제 policy로 대체 예정."
+        ),
+        "severity": "LOW",
+        "conditionJson": "{}",
+        "actionJson": "{}",
+        "evidenceJson": "[]",
+        "metaJson": "{}",
+    }
+
+
+def _build_workflow_draft(
+    clusters: list[dict[str, Any]],
+) -> dict[str, Any]:
+    workflows: list[dict[str, Any]] = []
+    bindings: list[dict[str, Any]] = []
+
+    for cluster in clusters:
+        if not isinstance(cluster, dict):
+            continue
+        cluster_id = cluster["cluster_id"]
+        suggested_name = cluster.get("suggested_name") or f"INTENT_{cluster_id}"
+        context = ClusterContext(
+            cluster_id=cluster_id,
+            suggested_name=suggested_name,
+            workflow_signal=cluster.get("workflow_signal") or {},
+        )
+        graph_spec = signal_based_generator(context)
+        workflows.append(
+            {
+                "workflowCode": f"WORKFLOW_{cluster_id}",
+                "name": suggested_name,
+                "description": f"{suggested_name} 자동 생성 workflow",
+                "graphJson": serialize_graph_json(graph_spec),
+                "evidenceJson": "[]",
+                "metaJson": "{}",
+            }
+        )
+        bindings.append(
+            {
+                "intentCode": f"INTENT_{cluster_id}",
+                "workflowCode": f"WORKFLOW_{cluster_id}",
+                "isPrimary": True,
+                "routeConditionJson": "{}",
+            }
+        )
+
+    return {
+        "slots": [],
+        "policies": [_default_dummy_policy()],
+        "risks": [],
+        "workflows": workflows,
+        "intentSlotBindings": [],
+        "intentWorkflowBindings": bindings,
+    }
+
+
+def _build_workflow_metrics(clusters: list[dict[str, Any]]) -> dict[str, Any]:
+    workflow_count = 0
+    identify_count = 0
+    payment_count = 0
+    escalation_count = 0
+    for cluster in clusters:
+        if not isinstance(cluster, dict):
+            continue
+        workflow_count += 1
+        signal = cluster.get("workflow_signal") or {}
+        if signal.get("requires_user_identification"):
+            identify_count += 1
+        if signal.get("requires_payment_check"):
+            payment_count += 1
+        if signal.get("has_escalation_cases"):
+            escalation_count += 1
+    return {
+        "workflow_count": workflow_count,
+        "workflow_with_identify_count": identify_count,
+        "workflow_with_payment_check_count": payment_count,
+        "workflow_with_escalation_count": escalation_count,
+    }
+
+
+def _build_candidate(
+    intents: list[dict[str, Any]],
+    clusters: list[dict[str, Any]],
+    stage_context: StageContext,
+) -> dict[str, Any]:
+    pack_key, pack_name = _derive_pack_identity(stage_context)
+    workflow_draft = _build_workflow_draft(clusters)
     return {
         "schemaVersion": "1.0",
         "domainPackDraft": {
-            "packKey": None,
-            "packName": None,
+            "packKey": pack_key,
+            "packName": pack_name,
         },
         "intentDraft": {
             "intents": intents,
         },
-        "workflowDraft": {},
+        "workflowDraft": workflow_draft,
     }
 
 

--- a/ml/src/pipeline/stages/draft_generation/main.py
+++ b/ml/src/pipeline/stages/draft_generation/main.py
@@ -50,14 +50,7 @@ def run(upstream_manifest_path: str | None = None) -> dict[str, object]:
         metrics["intents_with_zero_cases"],
     )
 
-    candidate = _build_candidate(intents, clusters, stage_context)
-    logger.info(
-        "draft_generation.pack_identity pack_key=%s pack_name=%s",
-        candidate["domainPackDraft"]["packKey"],
-        candidate["domainPackDraft"]["packName"],
-    )
-
-    workflow_metrics = _build_workflow_metrics(clusters)
+    workflow_draft, workflow_metrics = _build_workflow_draft(clusters)
     metrics.update(workflow_metrics)
     logger.info(
         "draft_generation.workflow_summary workflow_count=%d identify_count=%d payment_count=%d escalation_count=%d",
@@ -65,6 +58,13 @@ def run(upstream_manifest_path: str | None = None) -> dict[str, object]:
         workflow_metrics["workflow_with_identify_count"],
         workflow_metrics["workflow_with_payment_check_count"],
         workflow_metrics["workflow_with_escalation_count"],
+    )
+
+    candidate = _build_candidate(intents, workflow_draft, stage_context)
+    logger.info(
+        "draft_generation.pack_identity pack_key=%s pack_name=%s",
+        candidate["domainPackDraft"]["packKey"],
+        candidate["domainPackDraft"]["packName"],
     )
 
     candidate_path = _write_candidate(stage_context, runtime_config, candidate)
@@ -219,9 +219,13 @@ def _default_dummy_policy() -> dict[str, Any]:
 
 def _build_workflow_draft(
     clusters: list[dict[str, Any]],
-) -> dict[str, Any]:
+) -> tuple[dict[str, Any], dict[str, Any]]:
     workflows: list[dict[str, Any]] = []
     bindings: list[dict[str, Any]] = []
+    workflow_count = 0
+    identify_count = 0
+    payment_count = 0
+    escalation_count = 0
 
     for cluster in clusters:
         if not isinstance(cluster, dict):
@@ -264,8 +268,15 @@ def _build_workflow_draft(
                 "routeConditionJson": "{}",
             }
         )
+        workflow_count += 1
+        if signal.get("requires_user_identification"):
+            identify_count += 1
+        if signal.get("requires_payment_check"):
+            payment_count += 1
+        if signal.get("has_escalation_cases"):
+            escalation_count += 1
 
-    return {
+    draft = {
         "slots": [],
         "policies": [_default_dummy_policy()],
         "risks": [],
@@ -273,39 +284,21 @@ def _build_workflow_draft(
         "intentSlotBindings": [],
         "intentWorkflowBindings": bindings,
     }
-
-
-def _build_workflow_metrics(clusters: list[dict[str, Any]]) -> dict[str, Any]:
-    workflow_count = 0
-    identify_count = 0
-    payment_count = 0
-    escalation_count = 0
-    for cluster in clusters:
-        if not isinstance(cluster, dict):
-            continue
-        workflow_count += 1
-        signal = cluster.get("workflow_signal") or {}
-        if signal.get("requires_user_identification"):
-            identify_count += 1
-        if signal.get("requires_payment_check"):
-            payment_count += 1
-        if signal.get("has_escalation_cases"):
-            escalation_count += 1
-    return {
+    workflow_metrics = {
         "workflow_count": workflow_count,
         "workflow_with_identify_count": identify_count,
         "workflow_with_payment_check_count": payment_count,
         "workflow_with_escalation_count": escalation_count,
     }
+    return draft, workflow_metrics
 
 
 def _build_candidate(
     intents: list[dict[str, Any]],
-    clusters: list[dict[str, Any]],
+    workflow_draft: dict[str, Any],
     stage_context: StageContext,
 ) -> dict[str, Any]:
     pack_key, pack_name = _derive_pack_identity(stage_context)
-    workflow_draft = _build_workflow_draft(clusters)
     return {
         "schemaVersion": "1.0",
         "domainPackDraft": {

--- a/ml/src/pipeline/stages/draft_generation/main.py
+++ b/ml/src/pipeline/stages/draft_generation/main.py
@@ -60,7 +60,7 @@ def run(upstream_manifest_path: str | None = None) -> dict[str, object]:
     workflow_metrics = _build_workflow_metrics(clusters)
     metrics.update(workflow_metrics)
     logger.info(
-        "draft_generation.workflow_built workflow_count=%d identify_count=%d payment_count=%d escalation_count=%d",
+        "draft_generation.workflow_summary workflow_count=%d identify_count=%d payment_count=%d escalation_count=%d",
         workflow_metrics["workflow_count"],
         workflow_metrics["workflow_with_identify_count"],
         workflow_metrics["workflow_with_payment_check_count"],
@@ -226,7 +226,7 @@ def _build_workflow_draft(
     for cluster in clusters:
         if not isinstance(cluster, dict):
             continue
-        cluster_id = cluster["cluster_id"]
+        cluster_id = cluster.get("cluster_id")
         suggested_name = cluster.get("suggested_name") or f"INTENT_{cluster_id}"
         context = ClusterContext(
             cluster_id=cluster_id,

--- a/ml/src/pipeline/stages/draft_generation/main.py
+++ b/ml/src/pipeline/stages/draft_generation/main.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import time
 from pathlib import Path
@@ -17,6 +18,8 @@ from pipeline.stages.draft_generation.workflow_graph import (
     signal_based_generator,
 )
 from pipeline.stages.preprocessing.io import read_stage_context
+
+_logger = logging.getLogger("pipeline.draft_generation")
 
 DEFAULT_CANDIDATE_ARTIFACT = "candidate.json"
 DEFAULT_CLUSTERS_ARTIFACT = "clusters.json"
@@ -231,6 +234,18 @@ def _build_workflow_draft(
             workflow_signal=cluster.get("workflow_signal") or {},
         )
         graph_spec = signal_based_generator(context)
+        signal = context.workflow_signal or {}
+        _logger.info(
+            "draft_generation.workflow_built cluster_id=%s workflow_code=%s"
+            " identify=%s payment=%s escalation=%s node_count=%d edge_count=%d",
+            cluster_id,
+            f"WORKFLOW_{cluster_id}",
+            bool(signal.get("requires_user_identification")),
+            bool(signal.get("requires_payment_check")),
+            bool(signal.get("has_escalation_cases")),
+            len(graph_spec.nodes),
+            len(graph_spec.edges),
+        )
         workflows.append(
             {
                 "workflowCode": f"WORKFLOW_{cluster_id}",

--- a/ml/src/pipeline/stages/draft_generation/workflow_graph.py
+++ b/ml/src/pipeline/stages/draft_generation/workflow_graph.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Protocol
+
+
+@dataclass(frozen=True)
+class ClusterContext:
+    cluster_id: int
+    suggested_name: str
+    workflow_signal: dict[str, bool]
+
+
+@dataclass(frozen=True)
+class GraphNodeSpec:
+    id: str
+    type: str
+    label: str
+    policy_ref: str | None = None
+
+
+@dataclass(frozen=True)
+class GraphEdgeSpec:
+    id: str
+    from_node: str
+    to_node: str
+    label: str | None = None
+
+
+@dataclass(frozen=True)
+class WorkflowGraphSpec:
+    direction: str
+    nodes: tuple[GraphNodeSpec, ...]
+    edges: tuple[GraphEdgeSpec, ...]
+
+
+class WorkflowGraphGenerator(Protocol):
+    def __call__(self, context: ClusterContext) -> WorkflowGraphSpec: ...
+
+
+def signal_based_generator(context: ClusterContext) -> WorkflowGraphSpec:
+    cid = context.cluster_id
+    signal = context.workflow_signal or {}
+    requires_identification = bool(signal.get("requires_user_identification"))
+    requires_payment = bool(signal.get("requires_payment_check"))
+    has_escalation = bool(signal.get("has_escalation_cases"))
+
+    pre_chain: list[GraphNodeSpec] = [GraphNodeSpec(id="start", type="START", label="시작")]
+    if requires_identification:
+        pre_chain.append(GraphNodeSpec(id="identify", type="ACTION", label="본인인증", policy_ref="default_policy"))
+    if requires_payment:
+        pre_chain.append(
+            GraphNodeSpec(id="payment_check", type="ACTION", label="결제 확인", policy_ref="default_policy")
+        )
+    action = GraphNodeSpec(id="action", type="ACTION", label=context.suggested_name, policy_ref="default_policy")
+    full_chain = pre_chain + [action]
+
+    all_nodes: list[GraphNodeSpec] = list(full_chain)
+    all_edges: list[GraphEdgeSpec] = []
+    counter = [1]
+
+    def _next_id() -> str:
+        eid = f"e_{cid}_{counter[0]}"
+        counter[0] += 1
+        return eid
+
+    for i in range(len(full_chain) - 1):
+        all_edges.append(GraphEdgeSpec(id=_next_id(), from_node=full_chain[i].id, to_node=full_chain[i + 1].id))
+
+    if has_escalation:
+        decision = GraphNodeSpec(id="decision", type="DECISION", label="분기")
+        terminal = GraphNodeSpec(id="terminal", type="TERMINAL", label="종료")
+        handoff = GraphNodeSpec(id="handoff", type="HANDOFF", label="상담원 연결")
+        terminal_alt = GraphNodeSpec(id="terminal_alt", type="TERMINAL", label="종료")
+        all_nodes.extend([decision, terminal, handoff, terminal_alt])
+        all_edges.append(GraphEdgeSpec(id=_next_id(), from_node="action", to_node="decision"))
+        all_edges.append(GraphEdgeSpec(id=_next_id(), from_node="decision", to_node="terminal", label="resolved"))
+        all_edges.append(GraphEdgeSpec(id=_next_id(), from_node="decision", to_node="handoff", label="escalated"))
+        all_edges.append(GraphEdgeSpec(id=_next_id(), from_node="handoff", to_node="terminal_alt"))
+    else:
+        terminal = GraphNodeSpec(id="terminal", type="TERMINAL", label="종료")
+        all_nodes.append(terminal)
+        all_edges.append(GraphEdgeSpec(id=_next_id(), from_node="action", to_node="terminal"))
+
+    return WorkflowGraphSpec(direction="LR", nodes=tuple(all_nodes), edges=tuple(all_edges))
+
+
+def serialize_graph_json(spec: WorkflowGraphSpec) -> str:
+    nodes_list: list[dict[str, object]] = []
+    for node in spec.nodes:
+        node_dict: dict[str, object] = {"id": node.id, "type": node.type, "label": node.label}
+        if node.policy_ref is not None:
+            node_dict["policyRef"] = node.policy_ref
+        nodes_list.append(node_dict)
+
+    edges_list: list[dict[str, object]] = []
+    for edge in spec.edges:
+        edge_dict: dict[str, object] = {"id": edge.id, "from": edge.from_node, "to": edge.to_node}
+        if edge.label is not None:
+            edge_dict["label"] = edge.label
+        edges_list.append(edge_dict)
+
+    return json.dumps({"direction": spec.direction, "nodes": nodes_list, "edges": edges_list}, ensure_ascii=False)

--- a/ml/src/pipeline/stages/draft_generation/workflow_graph.py
+++ b/ml/src/pipeline/stages/draft_generation/workflow_graph.py
@@ -4,6 +4,8 @@ import json
 from dataclasses import dataclass
 from typing import Protocol
 
+DUMMY_POLICY_CODE = "default_policy"
+
 
 @dataclass(frozen=True)
 class ClusterContext:
@@ -48,12 +50,12 @@ def signal_based_generator(context: ClusterContext) -> WorkflowGraphSpec:
 
     pre_chain: list[GraphNodeSpec] = [GraphNodeSpec(id="start", type="START", label="시작")]
     if requires_identification:
-        pre_chain.append(GraphNodeSpec(id="identify", type="ACTION", label="본인인증", policy_ref="default_policy"))
+        pre_chain.append(GraphNodeSpec(id="identify", type="ACTION", label="본인인증", policy_ref=DUMMY_POLICY_CODE))
     if requires_payment:
         pre_chain.append(
-            GraphNodeSpec(id="payment_check", type="ACTION", label="결제 확인", policy_ref="default_policy")
+            GraphNodeSpec(id="payment_check", type="ACTION", label="결제 확인", policy_ref=DUMMY_POLICY_CODE)
         )
-    action = GraphNodeSpec(id="action", type="ACTION", label=context.suggested_name, policy_ref="default_policy")
+    action = GraphNodeSpec(id="action", type="ACTION", label=context.suggested_name, policy_ref=DUMMY_POLICY_CODE)
     full_chain = pre_chain + [action]
 
     all_nodes: list[GraphNodeSpec] = list(full_chain)

--- a/ml/src/pipeline/stages/draft_generation/workflow_graph.py
+++ b/ml/src/pipeline/stages/draft_generation/workflow_graph.py
@@ -65,8 +65,8 @@ def signal_based_generator(context: ClusterContext) -> WorkflowGraphSpec:
         counter[0] += 1
         return eid
 
-    for i in range(len(full_chain) - 1):
-        all_edges.append(GraphEdgeSpec(id=_next_id(), from_node=full_chain[i].id, to_node=full_chain[i + 1].id))
+    for cur, nxt in zip(full_chain, full_chain[1:]):
+        all_edges.append(GraphEdgeSpec(id=_next_id(), from_node=cur.id, to_node=nxt.id))
 
     if has_escalation:
         decision = GraphNodeSpec(id="decision", type="DECISION", label="분기")

--- a/ml/src/pipeline/stages/evaluation/main.py
+++ b/ml/src/pipeline/stages/evaluation/main.py
@@ -111,9 +111,9 @@ def _build_development_candidate() -> dict[str, Any]:
                     "name": "Default flow",
                     "description": "Development default workflow.",
                     "graphJson": (
-                        '{"nodes":[{"id":"start","type":"START"},'
-                        '{"id":"answer","type":"ACTION","policyRef":"default_policy"},'
-                        '{"id":"terminal","type":"TERMINAL"}],'
+                        '{"direction":"LR","nodes":[{"id":"start","type":"START","label":"시작"},'
+                        '{"id":"answer","type":"ACTION","label":"Default flow","policyRef":"default_policy"},'
+                        '{"id":"terminal","type":"TERMINAL","label":"종료"}],'
                         '"edges":[{"id":"e1","from":"start","to":"answer"},'
                         '{"id":"e2","from":"answer","to":"terminal"}]}'
                     ),

--- a/ml/tests/dags/test_pipeline_smoke.py
+++ b/ml/tests/dags/test_pipeline_smoke.py
@@ -1,0 +1,92 @@
+"""Integration smoke: draft_generation → publish_candidate via dev_bootstrap fixture.
+
+Uses the dev_bootstrap artifact fixture to verify the pipeline chain
+intent_discovery → draft_generation → publish_candidate(callback_disabled).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from pipeline.stages.draft_generation.main import run
+from pipeline.stages.publish_candidate.main import validate_candidate
+
+
+@pytest.fixture
+def dev_bootstrap_artifacts(tmp_path: Path) -> Path:
+    dag_id = "dev_bootstrap"
+    run_id = "smoke_run"
+
+    preprocessed_dir = tmp_path / dag_id / run_id / "preprocessing"
+    preprocessed_dir.mkdir(parents=True)
+    conversations = [
+        {
+            "id": f"conv_{i}",
+            "canonical_text": f"상담 내용 {i}",
+            "customer_problem_text": f"고객 문제 {i}",
+            "ended_status": "resolved",
+        }
+        for i in range(3)
+    ]
+    (preprocessed_dir / "preprocessed_data.json").write_text(
+        json.dumps({"schema_version": "1.0", "conversations": conversations}),
+        encoding="utf-8",
+    )
+
+    intent_dir = tmp_path / dag_id / run_id / "intent_discovery"
+    intent_dir.mkdir(parents=True)
+    clusters = [
+        {
+            "cluster_id": 0,
+            "suggested_name": "환불 문의",
+            "suggested_description": "환불 관련",
+            "exemplar_conv_ids": ["conv_0", "conv_1", "conv_2"],
+            "workflow_signal": {
+                "requires_user_identification": False,
+                "requires_payment_check": True,
+                "has_escalation_cases": False,
+            },
+        }
+    ]
+    (intent_dir / "clusters.json").write_text(
+        json.dumps({"schema_version": "1.0", "clusters": clusters}),
+        encoding="utf-8",
+    )
+    manifest_path = intent_dir / "manifest.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "dag_id": dag_id,
+                "run_id": run_id,
+                "stage_name": "intent_discovery",
+                "workspace_id": "ws-bootstrap",
+                "dataset_id": "ds-bootstrap",
+                "pipeline_job_id": None,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return manifest_path
+
+
+def test_dev_bootstrap_draft_to_publish_smoke(
+    dev_bootstrap_artifacts: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("PIPELINE_ARTIFACT_ROOT", str(tmp_path))
+    monkeypatch.setenv("PIPELINE_BACKEND_BASE_URL", "http://backend:8080")
+    monkeypatch.setenv("PIPELINE_CALLBACK_ENABLED", "false")
+
+    result = run(upstream_manifest_path=str(dev_bootstrap_artifacts))
+
+    candidate = json.loads(Path(cast(str, result["candidateArtifactPath"])).read_text(encoding="utf-8"))
+    validate_candidate(candidate)
+
+    assert candidate["domainPackDraft"]["packKey"] == "pack_wsws-bootstrap_dsds-bootstrap"
+    assert len(candidate["workflowDraft"]["workflows"]) >= 1
+    assert len(candidate["workflowDraft"]["intentWorkflowBindings"]) == len(candidate["intentDraft"]["intents"])

--- a/ml/tests/stages/test_draft_generation_main.py
+++ b/ml/tests/stages/test_draft_generation_main.py
@@ -12,6 +12,9 @@ from pipeline.common.exceptions import PipelineStageError
 from pipeline.stages.draft_generation.main import (
     _build_candidate,
     _build_intents,
+    _build_workflow_draft,
+    _build_workflow_metrics,
+    _derive_pack_identity,
     _hydrate_case,
     _read_clusters,
     _read_preprocessed_index,
@@ -25,8 +28,14 @@ def _runtime_config(tmp_path: Path) -> PipelineRuntimeConfig:
     return PipelineRuntimeConfig(artifact_root=tmp_path / "artifacts", backend_base_url="http://backend:8080")
 
 
-def _stage_context() -> StageContext:
-    return StageContext(dag_id="dag", run_id="run1", stage_name="draft_generation", workspace_id="ws1")
+def _stage_context(workspace_id: str | None = "ws1", dataset_id: str | None = None) -> StageContext:
+    return StageContext(
+        dag_id="dag",
+        run_id="run1",
+        stage_name="draft_generation",
+        workspace_id=workspace_id,
+        dataset_id=dataset_id,
+    )
 
 
 def _preprocessed_conv(conv_id: str, canonical: str = "text", problem: str = "problem") -> dict[str, Any]:
@@ -265,10 +274,14 @@ def test_build_intents_avg_per_intent() -> None:
 
 def _write_upstream_manifest(tmp_path: Path) -> Path:
     manifest_path = tmp_path / "upstream_manifest.json"
-    manifest_path.write_text(
-        '{"dag_id": "dag", "run_id": "run1", "stage_name": "intent_discovery"}',
-        encoding="utf-8",
-    )
+    manifest_payload = {
+        "dag_id": "dag",
+        "run_id": "run1",
+        "stage_name": "intent_discovery",
+        "workspace_id": "ws1",
+        "dataset_id": "ds1",
+    }
+    manifest_path.write_text(json.dumps(manifest_payload), encoding="utf-8")
     return manifest_path
 
 
@@ -284,6 +297,7 @@ def test_run_success(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
                 "suggested_name": "환불 문의",
                 "suggested_description": "환불 관련",
                 "exemplar_conv_ids": ["c1", "c2"],
+                "workflow_signal": {},
             }
         ],
     )
@@ -302,19 +316,134 @@ def test_run_success(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     assert candidate["schemaVersion"] == "1.0"
     assert len(candidate["intentDraft"]["intents"]) == 1
     assert candidate["intentDraft"]["intents"][0]["intentCode"] == "INTENT_0"
-    assert candidate["domainPackDraft"]["packKey"] is None
+    assert candidate["domainPackDraft"]["packKey"] == "pack_wsws1_dsds1"
+    assert len(candidate["workflowDraft"]["workflows"]) == 1
+    assert candidate["workflowDraft"]["workflows"][0]["workflowCode"] == "WORKFLOW_0"
 
 
 def test_build_candidate_structure() -> None:
     intents = [{"intentCode": "INTENT_0", "name": "환불", "representativeCases": []}]
+    clusters = [{"cluster_id": 0, "suggested_name": "환불", "workflow_signal": {}}]
+    context = _stage_context(workspace_id="ws1", dataset_id="ds1")
 
-    candidate = _build_candidate(intents)
+    candidate = _build_candidate(intents, clusters, context)
 
     assert candidate["schemaVersion"] == "1.0"
     assert candidate["intentDraft"]["intents"] == intents
-    assert candidate["domainPackDraft"]["packKey"] is None
-    assert candidate["domainPackDraft"]["packName"] is None
-    assert candidate["workflowDraft"] == {}
+    assert candidate["domainPackDraft"]["packKey"] == "pack_wsws1_dsds1"
+    assert candidate["domainPackDraft"]["packName"] == "Pack wsws1/dsds1"
+    wf_draft = candidate["workflowDraft"]
+    assert len(wf_draft["workflows"]) == 1
+    assert wf_draft["workflows"][0]["workflowCode"] == "WORKFLOW_0"
+    assert len(wf_draft["policies"]) == 1
+    assert wf_draft["policies"][0]["policyCode"] == "default_policy"
+    assert len(wf_draft["intentWorkflowBindings"]) == 1
+    assert wf_draft["intentWorkflowBindings"][0]["intentCode"] == "INTENT_0"
+    assert wf_draft["intentWorkflowBindings"][0]["workflowCode"] == "WORKFLOW_0"
+
+
+def test_build_candidate_raises_when_workspace_id_missing() -> None:
+    context = _stage_context(workspace_id=None, dataset_id="ds1")
+    with pytest.raises(PipelineStageError, match="packKey requires both"):
+        _build_candidate([], [], context)
+
+
+def test_build_candidate_raises_when_dataset_id_missing() -> None:
+    context = _stage_context(workspace_id="ws1", dataset_id=None)
+    with pytest.raises(PipelineStageError, match="packKey requires both"):
+        _build_candidate([], [], context)
+
+
+def test_derive_pack_identity_formats_correctly() -> None:
+    context = _stage_context(workspace_id="ws42", dataset_id="ds7")
+    pack_key, pack_name = _derive_pack_identity(context)
+    assert pack_key == "pack_wsws42_dsds7"
+    assert pack_name == "Pack wsws42/dsds7"
+
+
+def test_derive_pack_identity_raises_on_none_workspace() -> None:
+    context = _stage_context(workspace_id=None, dataset_id="ds1")
+    with pytest.raises(PipelineStageError, match="packKey requires both workspace_id and dataset_id"):
+        _derive_pack_identity(context)
+
+
+def test_derive_pack_identity_raises_on_none_dataset() -> None:
+    context = _stage_context(workspace_id="ws1", dataset_id=None)
+    with pytest.raises(PipelineStageError, match="packKey requires both workspace_id and dataset_id"):
+        _derive_pack_identity(context)
+
+
+def test_build_workflow_draft_single_cluster() -> None:
+    clusters = [{"cluster_id": 0, "suggested_name": "환불 문의", "workflow_signal": {}}]
+    draft = _build_workflow_draft(clusters)
+
+    assert len(draft["workflows"]) == 1
+    assert len(draft["policies"]) == 1
+    assert len(draft["intentWorkflowBindings"]) == 1
+    assert draft["workflows"][0]["workflowCode"] == "WORKFLOW_0"
+    assert draft["intentWorkflowBindings"][0]["intentCode"] == "INTENT_0"
+    assert draft["intentWorkflowBindings"][0]["workflowCode"] == "WORKFLOW_0"
+    assert draft["intentWorkflowBindings"][0]["isPrimary"] is True
+    assert draft["intentWorkflowBindings"][0]["routeConditionJson"] == "{}"
+    assert draft["slots"] == []
+    assert draft["risks"] == []
+    assert draft["intentSlotBindings"] == []
+
+
+def test_build_workflow_draft_empty_clusters() -> None:
+    draft = _build_workflow_draft([])
+    assert draft["workflows"] == []
+    assert draft["intentWorkflowBindings"] == []
+    assert len(draft["policies"]) == 1
+
+
+def test_build_workflow_draft_intent_workflow_1to1_mapping() -> None:
+    clusters = [
+        {"cluster_id": 0, "suggested_name": "A", "workflow_signal": {}},
+        {"cluster_id": 1, "suggested_name": "B", "workflow_signal": {}},
+    ]
+    draft = _build_workflow_draft(clusters)
+
+    intent_codes = {b["intentCode"] for b in draft["intentWorkflowBindings"]}
+    workflow_codes = {w["workflowCode"] for w in draft["workflows"]}
+    bound_workflow_codes = {b["workflowCode"] for b in draft["intentWorkflowBindings"]}
+    assert intent_codes == {"INTENT_0", "INTENT_1"}
+    assert workflow_codes == {"WORKFLOW_0", "WORKFLOW_1"}
+    assert bound_workflow_codes == workflow_codes
+
+
+def test_build_workflow_draft_default_policy_is_dummy() -> None:
+    draft = _build_workflow_draft([{"cluster_id": 0, "suggested_name": "X", "workflow_signal": {}}])
+    policy = draft["policies"][0]
+    assert policy["policyCode"] == "default_policy"
+    assert "Dummy" in policy["name"]
+
+
+def test_build_workflow_metrics_counts_signals() -> None:
+    clusters = [
+        {
+            "cluster_id": 0,
+            "workflow_signal": {
+                "requires_user_identification": True,
+                "requires_payment_check": False,
+                "has_escalation_cases": False,
+            },
+        },
+        {
+            "cluster_id": 1,
+            "workflow_signal": {
+                "requires_user_identification": True,
+                "requires_payment_check": True,
+                "has_escalation_cases": True,
+            },
+        },
+        {"cluster_id": 2, "workflow_signal": {}},
+    ]
+    m = _build_workflow_metrics(clusters)
+    assert m["workflow_count"] == 3
+    assert m["workflow_with_identify_count"] == 2
+    assert m["workflow_with_payment_check_count"] == 1
+    assert m["workflow_with_escalation_count"] == 1
 
 
 def test_write_candidate_creates_file(tmp_path: Path) -> None:

--- a/ml/tests/stages/test_draft_generation_main.py
+++ b/ml/tests/stages/test_draft_generation_main.py
@@ -13,7 +13,6 @@ from pipeline.stages.draft_generation.main import (
     _build_candidate,
     _build_intents,
     _build_workflow_draft,
-    _build_workflow_metrics,
     _derive_pack_identity,
     _hydrate_case,
     _read_clusters,
@@ -325,8 +324,9 @@ def test_build_candidate_structure() -> None:
     intents = [{"intentCode": "INTENT_0", "name": "환불", "representativeCases": []}]
     clusters = [{"cluster_id": 0, "suggested_name": "환불", "workflow_signal": {}}]
     context = _stage_context(workspace_id="ws1", dataset_id="ds1")
+    workflow_draft, _ = _build_workflow_draft(clusters)
 
-    candidate = _build_candidate(intents, clusters, context)
+    candidate = _build_candidate(intents, workflow_draft, context)
 
     assert candidate["schemaVersion"] == "1.0"
     assert candidate["intentDraft"]["intents"] == intents
@@ -345,13 +345,13 @@ def test_build_candidate_structure() -> None:
 def test_build_candidate_raises_when_workspace_id_missing() -> None:
     context = _stage_context(workspace_id=None, dataset_id="ds1")
     with pytest.raises(PipelineStageError, match="packKey requires both"):
-        _build_candidate([], [], context)
+        _build_candidate([], {}, context)
 
 
 def test_build_candidate_raises_when_dataset_id_missing() -> None:
     context = _stage_context(workspace_id="ws1", dataset_id=None)
     with pytest.raises(PipelineStageError, match="packKey requires both"):
-        _build_candidate([], [], context)
+        _build_candidate([], {}, context)
 
 
 def test_derive_pack_identity_formats_correctly() -> None:
@@ -375,7 +375,7 @@ def test_derive_pack_identity_raises_on_none_dataset() -> None:
 
 def test_build_workflow_draft_single_cluster() -> None:
     clusters = [{"cluster_id": 0, "suggested_name": "환불 문의", "workflow_signal": {}}]
-    draft = _build_workflow_draft(clusters)
+    draft, _ = _build_workflow_draft(clusters)
 
     assert len(draft["workflows"]) == 1
     assert len(draft["policies"]) == 1
@@ -391,7 +391,7 @@ def test_build_workflow_draft_single_cluster() -> None:
 
 
 def test_build_workflow_draft_empty_clusters() -> None:
-    draft = _build_workflow_draft([])
+    draft, _ = _build_workflow_draft([])
     assert draft["workflows"] == []
     assert draft["intentWorkflowBindings"] == []
     assert len(draft["policies"]) == 1
@@ -402,7 +402,7 @@ def test_build_workflow_draft_intent_workflow_1to1_mapping() -> None:
         {"cluster_id": 0, "suggested_name": "A", "workflow_signal": {}},
         {"cluster_id": 1, "suggested_name": "B", "workflow_signal": {}},
     ]
-    draft = _build_workflow_draft(clusters)
+    draft, _ = _build_workflow_draft(clusters)
 
     intent_codes = {b["intentCode"] for b in draft["intentWorkflowBindings"]}
     workflow_codes = {w["workflowCode"] for w in draft["workflows"]}
@@ -413,13 +413,13 @@ def test_build_workflow_draft_intent_workflow_1to1_mapping() -> None:
 
 
 def test_build_workflow_draft_default_policy_is_dummy() -> None:
-    draft = _build_workflow_draft([{"cluster_id": 0, "suggested_name": "X", "workflow_signal": {}}])
+    draft, _ = _build_workflow_draft([{"cluster_id": 0, "suggested_name": "X", "workflow_signal": {}}])
     policy = draft["policies"][0]
     assert policy["policyCode"] == "default_policy"
     assert "Dummy" in policy["name"]
 
 
-def test_build_workflow_metrics_counts_signals() -> None:
+def test_build_workflow_draft_metrics_counts_signals() -> None:
     clusters = [
         {
             "cluster_id": 0,
@@ -439,7 +439,7 @@ def test_build_workflow_metrics_counts_signals() -> None:
         },
         {"cluster_id": 2, "workflow_signal": {}},
     ]
-    m = _build_workflow_metrics(clusters)
+    _, m = _build_workflow_draft(clusters)
     assert m["workflow_count"] == 3
     assert m["workflow_with_identify_count"] == 2
     assert m["workflow_with_payment_check_count"] == 1

--- a/ml/tests/stages/test_draft_generation_smoke.py
+++ b/ml/tests/stages/test_draft_generation_smoke.py
@@ -1,11 +1,9 @@
-"""Integration smoke: intent_discovery → draft_generation pipeline path.
+"""Integration smoke: intent_discovery → draft_generation → publish_candidate pipeline path.
 
 Verifies that draft_generation produces a candidate.json whose
 intentDraft.intents[*].representativeCases contains up to 3 cases,
-each with all required fields.
-
-publish_candidate is excluded from this smoke because packKey=None (U-006 Deferred)
-causes validate_candidate to raise before the SKIPPED path is reachable.
+each with all required fields, and that the candidate passes
+publish_candidate.validate_candidate.
 """
 
 from __future__ import annotations
@@ -16,6 +14,7 @@ from pathlib import Path
 import pytest
 
 from pipeline.stages.draft_generation.main import run
+from pipeline.stages.publish_candidate.main import validate_candidate
 
 
 def _write_upstream_artifacts(artifact_root: Path) -> Path:
@@ -46,6 +45,11 @@ def _write_upstream_artifacts(artifact_root: Path) -> Path:
             "suggested_name": "환불 문의",
             "suggested_description": "환불 관련",
             "exemplar_conv_ids": ["conv_0", "conv_1", "conv_2"],
+            "workflow_signal": {
+                "requires_user_identification": False,
+                "requires_payment_check": True,
+                "has_escalation_cases": False,
+            },
         }
     ]
     (intent_dir / "clusters.json").write_text(
@@ -61,7 +65,7 @@ def _write_upstream_artifacts(artifact_root: Path) -> Path:
                 "run_id": run_id,
                 "stage_name": "intent_discovery",
                 "workspace_id": "ws-smoke",
-                "dataset_id": None,
+                "dataset_id": "ds-smoke",
                 "pipeline_job_id": None,
             }
         ),
@@ -70,9 +74,7 @@ def _write_upstream_artifacts(artifact_root: Path) -> Path:
     return manifest_path
 
 
-def test_draft_generation_produces_representative_cases(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_draft_generation_produces_representative_cases(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     artifact_root = tmp_path / "artifacts"
     manifest_path = _write_upstream_artifacts(artifact_root)
 
@@ -98,29 +100,62 @@ def test_draft_generation_produces_representative_cases(
         assert not missing, f"필드 누락: {missing}, case: {case}"
 
 
-def test_draft_generation_partial_hydration_smoke(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_draft_generation_publish_candidate_passes(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    artifact_root = tmp_path / "artifacts"
+    manifest_path = _write_upstream_artifacts(artifact_root)
+
+    monkeypatch.setenv("PIPELINE_ARTIFACT_ROOT", str(artifact_root))
+    monkeypatch.setenv("PIPELINE_BACKEND_BASE_URL", "http://backend:8080")
+    monkeypatch.setenv("PIPELINE_CALLBACK_ENABLED", "false")
+
+    result = run(upstream_manifest_path=str(manifest_path))
+
+    candidate = json.loads(Path(result["candidateArtifactPath"]).read_text(encoding="utf-8"))
+    validate_candidate(candidate)
+
+    assert candidate["domainPackDraft"]["packKey"] == "pack_wsws-smoke_dsds-smoke"
+    assert len(candidate["workflowDraft"]["workflows"]) >= 1
+    assert len(candidate["workflowDraft"]["intentWorkflowBindings"]) == len(candidate["intentDraft"]["intents"])
+
+
+def test_draft_generation_partial_hydration_smoke(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     artifact_root = tmp_path / "artifacts"
     dag_id = "smoke2"
     run_id = "run1"
 
     preprocessed_dir = artifact_root / dag_id / run_id / "preprocessing"
     preprocessed_dir.mkdir(parents=True)
+    convs = [{"id": "c1", "canonical_text": "t", "customer_problem_text": "p", "ended_status": None}]
     (preprocessed_dir / "preprocessed_data.json").write_text(
-        json.dumps({"schema_version": "1.0", "conversations": [{"id": "c1", "canonical_text": "t", "customer_problem_text": "p", "ended_status": None}]}),
+        json.dumps({"schema_version": "1.0", "conversations": convs}),
         encoding="utf-8",
     )
 
     intent_dir = artifact_root / dag_id / run_id / "intent_discovery"
     intent_dir.mkdir(parents=True)
+    partial_cluster = {
+        "cluster_id": 0,
+        "suggested_name": "테스트",
+        "suggested_description": None,
+        "exemplar_conv_ids": ["c1", "missing_id"],
+        "workflow_signal": {},
+    }
     (intent_dir / "clusters.json").write_text(
-        json.dumps({"schema_version": "1.0", "clusters": [{"cluster_id": 0, "suggested_name": "테스트", "suggested_description": None, "exemplar_conv_ids": ["c1", "missing_id"]}]}),
+        json.dumps({"schema_version": "1.0", "clusters": [partial_cluster]}),
         encoding="utf-8",
     )
     manifest_path = intent_dir / "manifest.json"
     manifest_path.write_text(
-        json.dumps({"dag_id": dag_id, "run_id": run_id, "stage_name": "intent_discovery", "workspace_id": None, "dataset_id": None, "pipeline_job_id": None}),
+        json.dumps(
+            {
+                "dag_id": dag_id,
+                "run_id": run_id,
+                "stage_name": "intent_discovery",
+                "workspace_id": "ws2",
+                "dataset_id": "ds2",
+                "pipeline_job_id": None,
+            }
+        ),
         encoding="utf-8",
     )
 

--- a/ml/tests/stages/test_draft_generation_smoke.py
+++ b/ml/tests/stages/test_draft_generation_smoke.py
@@ -1,9 +1,8 @@
-"""Integration smoke: intent_discovery → draft_generation → publish_candidate pipeline path.
+"""Integration smoke: intent_discovery → draft_generation pipeline path.
 
 Verifies that draft_generation produces a candidate.json whose
 intentDraft.intents[*].representativeCases contains up to 3 cases,
-each with all required fields, and that the candidate passes
-publish_candidate.validate_candidate.
+each with all required fields.
 """
 
 from __future__ import annotations
@@ -14,7 +13,6 @@ from pathlib import Path
 import pytest
 
 from pipeline.stages.draft_generation.main import run
-from pipeline.stages.publish_candidate.main import validate_candidate
 
 
 def _write_upstream_artifacts(artifact_root: Path) -> Path:
@@ -98,24 +96,6 @@ def test_draft_generation_produces_representative_cases(monkeypatch: pytest.Monk
     for case in cases:
         missing = required_fields - set(case.keys())
         assert not missing, f"필드 누락: {missing}, case: {case}"
-
-
-def test_draft_generation_publish_candidate_passes(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    artifact_root = tmp_path / "artifacts"
-    manifest_path = _write_upstream_artifacts(artifact_root)
-
-    monkeypatch.setenv("PIPELINE_ARTIFACT_ROOT", str(artifact_root))
-    monkeypatch.setenv("PIPELINE_BACKEND_BASE_URL", "http://backend:8080")
-    monkeypatch.setenv("PIPELINE_CALLBACK_ENABLED", "false")
-
-    result = run(upstream_manifest_path=str(manifest_path))
-
-    candidate = json.loads(Path(result["candidateArtifactPath"]).read_text(encoding="utf-8"))
-    validate_candidate(candidate)
-
-    assert candidate["domainPackDraft"]["packKey"] == "pack_wsws-smoke_dsds-smoke"
-    assert len(candidate["workflowDraft"]["workflows"]) >= 1
-    assert len(candidate["workflowDraft"]["intentWorkflowBindings"]) == len(candidate["intentDraft"]["intents"])
 
 
 def test_draft_generation_partial_hydration_smoke(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/ml/tests/stages/test_draft_generation_workflow_graph.py
+++ b/ml/tests/stages/test_draft_generation_workflow_graph.py
@@ -1,0 +1,467 @@
+"""Unit tests for draft_generation workflow_graph module.
+
+Covers: signal_based_generator (8 signal combinations), V1~V8 graph validation,
+serialize_graph_json, and graph structure assertions.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections import deque
+
+from pipeline.stages.draft_generation.workflow_graph import (
+    ClusterContext,
+    WorkflowGraphSpec,
+    serialize_graph_json,
+    signal_based_generator,
+)
+
+# ---------------------------------------------------------------------------
+# V1~V8 graph validation helper
+# ---------------------------------------------------------------------------
+
+
+def _validate_graph(spec: WorkflowGraphSpec, policy_codes: set[str] | None = None) -> None:
+    """Raises AssertionError if spec violates any of V1~V8."""
+    if policy_codes is None:
+        policy_codes = {"default_policy"}
+
+    node_ids = {n.id for n in spec.nodes}
+    start_nodes = [n for n in spec.nodes if n.type == "START"]
+    terminal_nodes = [n for n in spec.nodes if n.type == "TERMINAL"]
+
+    # V1: exactly 1 START
+    assert len(start_nodes) == 1, f"V1 violation: {len(start_nodes)} START nodes"
+
+    # V2: ≥1 TERMINAL
+    assert len(terminal_nodes) >= 1, "V2 violation: no TERMINAL node"
+
+    # V3: no dangling edges
+    for edge in spec.edges:
+        assert edge.from_node in node_ids, f"V3 violation: from_node '{edge.from_node}' not in nodes"
+        assert edge.to_node in node_ids, f"V3 violation: to_node '{edge.to_node}' not in nodes"
+
+    # V4: all nodes reachable from START via BFS
+    adjacency: dict[str, list[str]] = {n.id: [] for n in spec.nodes}
+    for edge in spec.edges:
+        adjacency[edge.from_node].append(edge.to_node)
+
+    visited: set[str] = set()
+    queue: deque[str] = deque([start_nodes[0].id])
+    while queue:
+        current = queue.popleft()
+        if current in visited:
+            continue
+        visited.add(current)
+        for neighbor in adjacency[current]:
+            queue.append(neighbor)
+    unreachable = node_ids - visited
+    assert not unreachable, f"V4 violation: unreachable nodes {unreachable}"
+
+    # V5: no cycle (DFS-based)
+    def _has_cycle(node: str, visiting: set[str], visited_set: set[str]) -> bool:
+        visiting.add(node)
+        for neighbor in adjacency[node]:
+            if neighbor in visiting:
+                return True
+            if neighbor not in visited_set and _has_cycle(neighbor, visiting, visited_set):
+                return True
+        visiting.discard(node)
+        visited_set.add(node)
+        return False
+
+    visited_dfs: set[str] = set()
+    for node_id in node_ids:
+        if node_id not in visited_dfs:
+            assert not _has_cycle(node_id, set(), visited_dfs), "V5 violation: cycle detected"
+
+    # V6: DECISION outgoing edges must have labels
+    decision_ids = {n.id for n in spec.nodes if n.type == "DECISION"}
+    for edge in spec.edges:
+        if edge.from_node in decision_ids:
+            assert edge.label, f"V6 violation: DECISION edge {edge.id} missing label"
+
+    # V7a: all edges have non-blank id
+    for edge in spec.edges:
+        assert edge.id and edge.id.strip(), "V7a violation: edge missing id"
+
+    # V7b: edge ids unique within workflow
+    edge_ids = [edge.id for edge in spec.edges]
+    assert len(edge_ids) == len(set(edge_ids)), f"V7b violation: duplicate edge ids {edge_ids}"
+
+    # V7c: edge id pattern [A-Za-z0-9_-]+
+    pattern = re.compile(r"^[A-Za-z0-9_\-]+$")
+    for edge in spec.edges:
+        assert pattern.match(edge.id), f"V7c violation: invalid edge id '{edge.id}'"
+
+    # V8a: ACTION nodes must have policyRef
+    for node in spec.nodes:
+        if node.type == "ACTION":
+            assert node.policy_ref is not None, f"V8a violation: ACTION node '{node.id}' missing policyRef"
+
+    # V8b: policyRef valid chars (non-blank, no spaces)
+    for node in spec.nodes:
+        if node.policy_ref is not None:
+            assert node.policy_ref.strip(), f"V8b violation: blank policyRef on '{node.id}'"
+
+    # V8c: policyRef ∈ policy_codes
+    for node in spec.nodes:
+        if node.policy_ref is not None:
+            assert node.policy_ref in policy_codes, (
+                f"V8c violation: policyRef '{node.policy_ref}' not in {policy_codes}"
+            )
+
+
+def _make_context(
+    cluster_id: int = 0,
+    suggested_name: str = "테스트",
+    *,
+    identify: bool = False,
+    payment: bool = False,
+    escalation: bool = False,
+) -> ClusterContext:
+    return ClusterContext(
+        cluster_id=cluster_id,
+        suggested_name=suggested_name,
+        workflow_signal={
+            "requires_user_identification": identify,
+            "requires_payment_check": payment,
+            "has_escalation_cases": escalation,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Baseline (all signals false)
+# ---------------------------------------------------------------------------
+
+
+def test_baseline_node_edge_count() -> None:
+    spec = signal_based_generator(_make_context())
+    assert len(spec.nodes) == 3
+    assert len(spec.edges) == 2
+
+
+def test_baseline_node_types() -> None:
+    spec = signal_based_generator(_make_context())
+    types = [n.type for n in spec.nodes]
+    assert types.count("START") == 1
+    assert types.count("ACTION") == 1
+    assert types.count("TERMINAL") == 1
+
+
+def test_baseline_direction_is_lr() -> None:
+    spec = signal_based_generator(_make_context())
+    assert spec.direction == "LR"
+
+
+def test_baseline_start_label() -> None:
+    spec = signal_based_generator(_make_context())
+    start = next(n for n in spec.nodes if n.type == "START")
+    assert start.label == "시작"
+
+
+def test_baseline_terminal_label() -> None:
+    spec = signal_based_generator(_make_context())
+    terminal = next(n for n in spec.nodes if n.type == "TERMINAL")
+    assert terminal.label == "종료"
+
+
+def test_baseline_action_label_uses_suggested_name() -> None:
+    spec = signal_based_generator(_make_context(suggested_name="환불 문의"))
+    action = next(n for n in spec.nodes if n.type == "ACTION")
+    assert action.label == "환불 문의"
+
+
+def test_baseline_passes_v1_to_v8() -> None:
+    spec = signal_based_generator(_make_context())
+    _validate_graph(spec)
+
+
+def test_baseline_edge_ids_sequential() -> None:
+    spec = signal_based_generator(_make_context(cluster_id=3))
+    assert spec.edges[0].id == "e_3_1"
+    assert spec.edges[1].id == "e_3_2"
+
+
+# ---------------------------------------------------------------------------
+# requires_user_identification only
+# ---------------------------------------------------------------------------
+
+
+def test_identify_only_node_edge_count() -> None:
+    spec = signal_based_generator(_make_context(identify=True))
+    assert len(spec.nodes) == 4
+    assert len(spec.edges) == 3
+
+
+def test_identify_only_has_identify_action() -> None:
+    spec = signal_based_generator(_make_context(identify=True))
+    action_ids = [n.id for n in spec.nodes if n.type == "ACTION"]
+    assert "identify" in action_ids
+
+
+def test_identify_only_identify_label() -> None:
+    spec = signal_based_generator(_make_context(identify=True))
+    identify_node = next(n for n in spec.nodes if n.id == "identify")
+    assert identify_node.label == "본인인증"
+
+
+def test_identify_only_topology() -> None:
+    spec = signal_based_generator(_make_context(identify=True))
+    edge_pairs = [(e.from_node, e.to_node) for e in spec.edges]
+    assert ("start", "identify") in edge_pairs
+    assert ("identify", "action") in edge_pairs
+    assert ("action", "terminal") in edge_pairs
+
+
+def test_identify_only_passes_v1_to_v8() -> None:
+    spec = signal_based_generator(_make_context(identify=True))
+    _validate_graph(spec)
+
+
+# ---------------------------------------------------------------------------
+# requires_payment_check only
+# ---------------------------------------------------------------------------
+
+
+def test_payment_only_node_edge_count() -> None:
+    spec = signal_based_generator(_make_context(payment=True))
+    assert len(spec.nodes) == 4
+    assert len(spec.edges) == 3
+
+
+def test_payment_only_has_payment_check_action() -> None:
+    spec = signal_based_generator(_make_context(payment=True))
+    action_ids = [n.id for n in spec.nodes if n.type == "ACTION"]
+    assert "payment_check" in action_ids
+
+
+def test_payment_only_payment_check_label() -> None:
+    spec = signal_based_generator(_make_context(payment=True))
+    node = next(n for n in spec.nodes if n.id == "payment_check")
+    assert node.label == "결제 확인"
+
+
+def test_payment_only_topology() -> None:
+    spec = signal_based_generator(_make_context(payment=True))
+    edge_pairs = [(e.from_node, e.to_node) for e in spec.edges]
+    assert ("start", "payment_check") in edge_pairs
+    assert ("payment_check", "action") in edge_pairs
+    assert ("action", "terminal") in edge_pairs
+
+
+def test_payment_only_passes_v1_to_v8() -> None:
+    spec = signal_based_generator(_make_context(payment=True))
+    _validate_graph(spec)
+
+
+# ---------------------------------------------------------------------------
+# has_escalation_cases only
+# ---------------------------------------------------------------------------
+
+
+def test_escalation_only_node_edge_count() -> None:
+    spec = signal_based_generator(_make_context(escalation=True))
+    assert len(spec.nodes) == 6
+    assert len(spec.edges) == 5
+
+
+def test_escalation_only_has_decision_and_handoff() -> None:
+    spec = signal_based_generator(_make_context(escalation=True))
+    types = {n.type for n in spec.nodes}
+    assert "DECISION" in types
+    assert "HANDOFF" in types
+
+
+def test_escalation_only_decision_label() -> None:
+    spec = signal_based_generator(_make_context(escalation=True))
+    decision = next(n for n in spec.nodes if n.type == "DECISION")
+    assert decision.label == "분기"
+
+
+def test_escalation_only_handoff_label() -> None:
+    spec = signal_based_generator(_make_context(escalation=True))
+    handoff = next(n for n in spec.nodes if n.type == "HANDOFF")
+    assert handoff.label == "상담원 연결"
+
+
+def test_escalation_only_two_terminals() -> None:
+    spec = signal_based_generator(_make_context(escalation=True))
+    terminals = [n for n in spec.nodes if n.type == "TERMINAL"]
+    assert len(terminals) == 2
+
+
+def test_escalation_only_decision_edges_have_labels() -> None:
+    spec = signal_based_generator(_make_context(escalation=True))
+    decision_id = next(n.id for n in spec.nodes if n.type == "DECISION")
+    decision_edges = [e for e in spec.edges if e.from_node == decision_id]
+    assert len(decision_edges) == 2
+    labels = {e.label for e in decision_edges}
+    assert "resolved" in labels
+    assert "escalated" in labels
+
+
+def test_escalation_only_passes_v1_to_v8() -> None:
+    spec = signal_based_generator(_make_context(escalation=True))
+    _validate_graph(spec)
+
+
+# ---------------------------------------------------------------------------
+# identify + payment (no escalation)
+# ---------------------------------------------------------------------------
+
+
+def test_identify_payment_node_edge_count() -> None:
+    spec = signal_based_generator(_make_context(identify=True, payment=True))
+    assert len(spec.nodes) == 5
+    assert len(spec.edges) == 4
+
+
+def test_identify_payment_topology() -> None:
+    spec = signal_based_generator(_make_context(identify=True, payment=True))
+    edge_pairs = [(e.from_node, e.to_node) for e in spec.edges]
+    assert ("start", "identify") in edge_pairs
+    assert ("identify", "payment_check") in edge_pairs
+    assert ("payment_check", "action") in edge_pairs
+    assert ("action", "terminal") in edge_pairs
+
+
+def test_identify_payment_passes_v1_to_v8() -> None:
+    spec = signal_based_generator(_make_context(identify=True, payment=True))
+    _validate_graph(spec)
+
+
+# ---------------------------------------------------------------------------
+# identify + escalation (no payment)
+# ---------------------------------------------------------------------------
+
+
+def test_identify_escalation_passes_v1_to_v8() -> None:
+    spec = signal_based_generator(_make_context(identify=True, escalation=True))
+    _validate_graph(spec)
+
+
+def test_identify_escalation_node_count() -> None:
+    spec = signal_based_generator(_make_context(identify=True, escalation=True))
+    assert len(spec.nodes) == 7
+
+
+# ---------------------------------------------------------------------------
+# payment + escalation (no identify)
+# ---------------------------------------------------------------------------
+
+
+def test_payment_escalation_passes_v1_to_v8() -> None:
+    spec = signal_based_generator(_make_context(payment=True, escalation=True))
+    _validate_graph(spec)
+
+
+def test_payment_escalation_topology() -> None:
+    spec = signal_based_generator(_make_context(payment=True, escalation=True))
+    edge_pairs = [(e.from_node, e.to_node) for e in spec.edges]
+    assert ("start", "payment_check") in edge_pairs
+    assert ("payment_check", "action") in edge_pairs
+    assert ("action", "decision") in edge_pairs
+
+
+# ---------------------------------------------------------------------------
+# All 3 signals true
+# ---------------------------------------------------------------------------
+
+
+def test_all_signals_node_count() -> None:
+    spec = signal_based_generator(_make_context(identify=True, payment=True, escalation=True))
+    assert len(spec.nodes) == 8
+
+
+def test_all_signals_topology() -> None:
+    spec = signal_based_generator(_make_context(identify=True, payment=True, escalation=True))
+    edge_pairs = [(e.from_node, e.to_node) for e in spec.edges]
+    assert ("start", "identify") in edge_pairs
+    assert ("identify", "payment_check") in edge_pairs
+    assert ("payment_check", "action") in edge_pairs
+    assert ("action", "decision") in edge_pairs
+
+
+def test_all_signals_passes_v1_to_v8() -> None:
+    spec = signal_based_generator(_make_context(identify=True, payment=True, escalation=True))
+    _validate_graph(spec)
+
+
+# ---------------------------------------------------------------------------
+# Edge-case inputs
+# ---------------------------------------------------------------------------
+
+
+def test_missing_workflow_signal_falls_back_to_baseline() -> None:
+    ctx = ClusterContext(cluster_id=0, suggested_name="테스트", workflow_signal={})
+    spec = signal_based_generator(ctx)
+    assert len(spec.nodes) == 3
+    assert len(spec.edges) == 2
+
+
+def test_suggested_name_fallback_used_in_action_label() -> None:
+    ctx = ClusterContext(cluster_id=5, suggested_name="주문 취소", workflow_signal={})
+    spec = signal_based_generator(ctx)
+    action = next(n for n in spec.nodes if n.id == "action")
+    assert action.label == "주문 취소"
+
+
+# ---------------------------------------------------------------------------
+# serialize_graph_json
+# ---------------------------------------------------------------------------
+
+
+def test_serialize_includes_direction() -> None:
+    spec = signal_based_generator(_make_context())
+    result = json.loads(serialize_graph_json(spec))
+    assert result["direction"] == "LR"
+
+
+def test_serialize_all_nodes_have_label() -> None:
+    spec = signal_based_generator(_make_context(identify=True, payment=True, escalation=True))
+    result = json.loads(serialize_graph_json(spec))
+    for node in result["nodes"]:
+        assert "label" in node, f"node {node['id']} missing label"
+
+
+def test_serialize_action_nodes_have_policy_ref() -> None:
+    spec = signal_based_generator(_make_context())
+    result = json.loads(serialize_graph_json(spec))
+    action_nodes = [n for n in result["nodes"] if n["type"] == "ACTION"]
+    for node in action_nodes:
+        assert "policyRef" in node, f"ACTION node {node['id']} missing policyRef"
+
+
+def test_serialize_non_action_nodes_no_policy_ref() -> None:
+    spec = signal_based_generator(_make_context())
+    result = json.loads(serialize_graph_json(spec))
+    non_action = [n for n in result["nodes"] if n["type"] != "ACTION"]
+    for node in non_action:
+        assert "policyRef" not in node, f"non-ACTION node {node['id']} should not have policyRef"
+
+
+def test_serialize_edge_from_to_keys() -> None:
+    spec = signal_based_generator(_make_context())
+    result = json.loads(serialize_graph_json(spec))
+    for edge in result["edges"]:
+        assert "from" in edge
+        assert "to" in edge
+        assert "id" in edge
+
+
+def test_serialize_decision_edges_have_labels() -> None:
+    spec = signal_based_generator(_make_context(escalation=True))
+    result = json.loads(serialize_graph_json(spec))
+    decision_id = next(n["id"] for n in result["nodes"] if n["type"] == "DECISION")
+    decision_edges = [e for e in result["edges"] if e["from"] == decision_id]
+    for edge in decision_edges:
+        assert "label" in edge, f"DECISION outgoing edge {edge['id']} missing label"
+
+
+def test_serialize_length_within_20000() -> None:
+    spec = signal_based_generator(_make_context(identify=True, payment=True, escalation=True))
+    serialized = serialize_graph_json(spec)
+    assert len(serialized) <= 20000

--- a/ml/tests/stages/test_evaluation_main.py
+++ b/ml/tests/stages/test_evaluation_main.py
@@ -101,3 +101,13 @@ def test_load_candidate_requires_candidate_object(tmp_path: Path) -> None:
 
     with pytest.raises(PipelineStageError, match="Candidate artifact must be a JSON object"):
         evaluation._load_or_create_candidate(str(manifest_path))
+
+
+def test_build_development_candidate_graph_json_has_direction_and_labels() -> None:
+    candidate = evaluation._build_development_candidate()
+    workflows = candidate["workflowDraft"]["workflows"]
+    assert len(workflows) >= 1
+    graph = json.loads(workflows[0]["graphJson"])
+    assert graph["direction"] == "LR"
+    for node in graph["nodes"]:
+        assert "label" in node, f"node missing label: {node}"


### PR DESCRIPTION
## Summary

- `draft_generation` 스테이지의 `workflowDraft` stub을 실제 구현으로 교체 — 각 intent cluster마다 state 기반 workflow graph 1개 생성
- `workflow_graph.py` 신규 모듈: `WorkflowGraphGenerator` Protocol + `signal_based_generator` 구현 (LLM generator 교체 대비 callable interface)
- `_derive_pack_identity`로 `packKey`/`packName` 도출, `_default_dummy_policy` 삽입
- `evaluation/main.py` dev candidate graphJson에 `direction:"LR"` + node label 추가 (U-017)
- codeRemediator fix run 1회 완료: W-001(per-cluster 로그), W-002(graphJson 검증 테스트), W-003(dev_bootstrap fixture 통합 smoke)

## Context

구현 대상: `.agent/specs/002218.md` — **[ML] 2.2.18 Intent별 Workflow Graph 생성**

본 PR 이전까지 `publish_candidate.validate_candidate`는 `workflowDraft`가 빈 stub이어서 항상 실패했다. 이 PR 이후 ML pipeline의 end-to-end publish가 처음으로 통과한다.

## What Changed

| 파일 | 종류 | 핵심 변화 |
|---|---|---|
| `ml/src/pipeline/stages/draft_generation/workflow_graph.py` | 신규 | `ClusterContext`, `GraphNodeSpec`, `GraphEdgeSpec`, `WorkflowGraphSpec`, `WorkflowGraphGenerator` Protocol, `signal_based_generator`, `serialize_graph_json` |
| `ml/src/pipeline/stages/draft_generation/main.py` | 수정 | `_build_candidate` signature 변경 `(intents, clusters, stage_context)`, `_derive_pack_identity`, `_build_workflow_draft`, `_default_dummy_policy`, `_build_workflow_metrics` 추가 |
| `ml/src/pipeline/stages/evaluation/main.py` | 수정 | `_build_development_candidate` graphJson에 `direction:"LR"` + node label 추가 |
| `ml/tests/stages/test_draft_generation_workflow_graph.py` | 신규 | `signal_based_generator` 8 signal 조합(V1~V8) 검증, `serialize_graph_json` 테스트 |
| `ml/tests/stages/test_draft_generation_main.py` | 수정 | `_derive_pack_identity`, `_build_workflow_draft`, `_build_workflow_metrics` unit test 추가 |
| `ml/tests/stages/test_draft_generation_smoke.py` | 수정 | publish_candidate exclude 제거, fixture `workspace_id`/`dataset_id` 갱신 |
| `ml/tests/stages/test_evaluation_main.py` | 수정 (W-002 fix) | `test_build_development_candidate_graph_json_has_direction_and_labels` 추가 |
| `ml/tests/dags/test_pipeline_smoke.py` | 신규 (W-003 fix) | `dev_bootstrap_artifacts` fixture 기반 `draft_generation → publish_candidate` 통합 smoke |

## Assumptions Adopted

- **ASS-001** (Assumption adopted from topology diagram): spec §변형 조합 예시의 "3 signals all true: 8 edges"는 spec 카운팅 오류로 판단. 토폴로지 다이어그램 기준 **7 edges**로 구현 확정. V1~V8 테스트 모두 통과. 다른 케이스(baseline 2, identify-only 3, payment-only 3, escalation-only 5)가 spec과 정확히 일치하므로 "8"만 오기임이 명백함. (execution-log ASS-001 참조)

## Spec Deviations

- **§Monitoring (W-001, Fixed)**: 초기 구현은 집계 로그(`workflow_count`, `identify_count` 등)만 loop 외부에서 출력. 스펙은 cluster loop 내 per-workflow `cluster_id`, `workflow_code`, `signal_flags`, `node_count`, `edge_count` 포함 로그를 요구. → codeRemediator가 `_build_workflow_draft` cluster loop 내 per-cluster INFO 로그 추가 (집계 로그 유지).
- **§Tests / Test Checklist (W-002, Fixed)**: `_build_development_candidate` graphJson direction+label 검증 테스트 미구현. → `test_evaluation_main.py`에 `test_build_development_candidate_graph_json_has_direction_and_labels` 추가.
- **§Integration Tests (W-003, Fixed)**: 직접 함수 호출 방식 smoke 구현 → spec은 `tests/dags/` dev_bootstrap fixture 사용을 명시. → `ml/tests/dags/test_pipeline_smoke.py` 신규 생성 + `test_draft_generation_smoke.py`의 `test_draft_generation_publish_candidate_passes` 제거.

## Blocked / Skipped Items

- **U-013 (workflowSeparability)**: spec 결정에 따라 Deferred. `evaluation/main.py:26` `workflowSeparability: None` stub 그대로 유지. 별도 스펙에서 다룸.

## Test Notes

- **Unit tests**: 81 tests passed (0 failed) — `ruff check`, `ruff format`, `mypy` clean (codeBuilder 보고)
- **Coverage**: newCoverage 98.4% (sonar-pseudo-check local measure 기준, threshold 80% — PASS)
- **V1~V8 검증**: `test_draft_generation_workflow_graph.py` — 8 signal 조합 (baseline / identify / payment / escalation / 복합 4종) 모두 통과
- **Integration smoke**: `test_pipeline_smoke.py` — `dev_bootstrap_artifacts` fixture → `draft_generation.run()` + `publish_candidate.validate_candidate()` 통과
- 공식 `test-results-002218.json` artifact 없음 (codeBuilder 직접 실행 결과 보고 기준)

---

## Validation Evidence Matrix

| Check | Artifact | Verdict | Notes |
|---|---|---|---|
| Spec consistency | `.handoff/002218/spec-consistency-report-002218.json` | CONSISTENT | ML mode, SC-M1~M8 전체 SKIPPED (feature branch 기준 diff 적용) |
| Sonar MCP pseudo-check | `.handoff/002218/sonar-pseudo-check-report-002218.json` | PASS_WITH_WARNINGS | SONAR-001 MINOR CODE_SMELL 1건 (non-blocking). Sonar MCP pseudo-check passed. Final SonarQube Cloud Quality Gate is handled by CI. |
| FE pre-review | N/A | N/A | ML 작업 |
| Playwright MCP runtime | N/A | N/A | ML 작업 |
| Tests | codeBuilder 직접 보고 (artifact 미생성) | 81 passed | ruff + mypy clean |
| Final Audit | `.handoff/002218/audit-report-002218-2026-05-04-2148.md` | **PASS** | Critical=0, Warning=3 (all Fixed), Info=4 |

## Audit Input Reduction

- audit-preprocess verdict: READY_WITH_WARNINGS
- blocking findings after deduplication: 0
- warnings after deduplication: 1 (SONAR-001 MINOR, non-blocking)
- stale artifacts: 0
- missing artifacts: 6 (fe-review / playwright-mcp / playwright-test / test-results / frontend-test-results / verify-fe-summary — ML 작업이므로 모두 expected absent)

> Note: registry stale=7 보고는 preprocess 스크립트 경로 해석 오류(project root 기준 relative path resolve 실패). 실제 파일 누락 없음 — codeAuditor 직접 확인 완료.

---

## Reviewer Focus

1. **`workflow_graph.py` — `signal_based_generator` topology 로직**: identify → payment → escalation 결정적 순서. 각 signal 분기가 spec §graphJson Generation Rule의 V1~V8 케이스와 일치하는지 확인 권장.
2. **`_derive_pack_identity` — `PipelineStageError` 분기**: `workspace_id` 또는 `dataset_id`가 None일 때 예외 발생. smoke fixture가 non-None 값을 주입하므로 stage context 전달 경로의 누락 가능성 리뷰 권장.
3. **`_next_id()` 클로저 카운터 패턴** (`workflow_graph.py`): `counter = [1]` + `counter[0] += 1` list-based closure 우회. Python `nonlocal` 대안 검토 가능 (Info I-002, non-blocking).
4. **W-003 fix — `test_pipeline_smoke.py`**: DAG fixture 기반이나 실제 Airflow DAG orchestration은 아닌 직접 호출 방식. 스펙 의도 충족 여부 확인.
5. **ASS-001 (edge count 7 vs spec "8")**: spec의 8 edges 기술이 오기라는 판단이 맞는지 topology 다이어그램과 대조 확인 권장.

## Conflicts

없음.

## Ready to Merge

**Final Audit verdict: PASS** (`audit-report-002218-2026-05-04-2148.md`)

Critical 0건. Warning 3건 모두 codeRemediator fix run 1회에서 완료 (`d95412a`). Sonar MCP pseudo-check PASS_WITH_WARNINGS (MINOR 1건, non-blocking). 실제 SonarQube Cloud CI Quality Gate는 CI에서 처리.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ajou-2026-1-capstone-5/ostone/pull/179" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 입력 클러스터로부터 신호 기반 워크플로우 초안 자동 생성 및 의도↔워크플로우 바인딩 생성

* **개선 사항**
  * 워크플로우 그래프에 방향(LR) 및 모든 노드 라벨 추가, 액션 노드에 기본(더미) 정책 참조 포함
  * 후보 생성 시 도메인 팩 식별자(packKey/packName) 완전 채움

* **테스트**
  * 파이프라인 통합 스모크 테스트 추가
  * 워크플로우 그래프 생성 및 후보 생성 관련 단위/통합 테스트 다수 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->