### PR TITLE
Spec/113: Airflow requirements 계약 정리

### DIFF
--- a/.agent/specs/113.md
+++ b/.agent/specs/113.md
@@ -263,7 +263,7 @@ sequenceDiagram
 - Airflow provider/client/ML 의존성은 호환 가능한 minor/patch 업데이트를 허용하는 범위 지정으로 둔다.
 - `ml/airflow/`는 Airflow 런타임 전용 디렉터리로 저장소에 포함한다.
 
-`ml/airflow/requirements.txt` 계약:
+`ml/airflow/requirements.txt`에 포함되어야 할 최소 의존성 계약:
 
 ```txt
 apache-airflow==3.2.0

--- a/.agent/specs/113.md
+++ b/.agent/specs/113.md
@@ -258,19 +258,39 @@ sequenceDiagram
 
 - 베이스 이미지: `apache/airflow:3.2.0-python3.13`
 - 커스텀 이미지는 **항상 이 버전 위에서 확장**
-- `ml/airflow/requirements.txt`를 함께 포함하고, `apache-airflow==3.2.0`을 명시해 버전 드리프트를 막는다.
+- `ml/airflow/requirements.txt`를 함께 포함하고, Airflow 런타임에서 DAG import와 pipeline stage 실행에 필요한 패키지를 명시한다.
+- `apache-airflow==3.2.0`은 정확히 고정해 Airflow core 버전 드리프트를 막는다.
+- Airflow provider/client/ML 의존성은 호환 가능한 minor/patch 업데이트를 허용하는 범위 지정으로 둔다.
 - `ml/airflow/`는 Airflow 런타임 전용 디렉터리로 저장소에 포함한다.
 
-예시 정책:
+`ml/airflow/requirements.txt` 계약:
 
-- `apache-airflow==3.2.0`
-- `asyncpg`
-- 필요한 provider/client 패키지
+```txt
+apache-airflow==3.2.0
+asyncpg>=0.30,<1.0
+psycopg2-binary>=2.9,<3.0
+httpx>=0.27
+igraph>=0.11
+leidenalg>=0.10
+numpy>=2.1
+orjson>=3.10.7
+scikit-learn>=1.5
+scipy>=1.14
+```
+
+의존성 구분:
+
+- `asyncpg`, `psycopg2-binary`: Airflow metadata DB의 async/sync PostgreSQL connection
+- `httpx`: Spring Backend callback/API 호출
+- `igraph`, `leidenalg`: intent discovery graph clustering
+- `numpy`, `scikit-learn`, `scipy`: embedding/clustering/evaluation 계산
+- `orjson`: pipeline artifact JSON serialization
 
 금지:
 
 - `_PIP_ADDITIONAL_REQUIREMENTS` 사용
 - Airflow 버전 미고정 상태에서 provider만 추가 설치
+- DAG에서 import하는 pipeline stage 의존성을 `requirements.txt`에 누락
 
 ### Python 버전 계약
 


### PR DESCRIPTION
## Summary

- Airflow 실행환경 스펙에서 `ml/airflow/requirements.txt` 의존성 계약을 명시
- `apache-airflow==3.2.0`은 core 버전 드리프트 방지를 위해 정확히 고정하도록 정리
- DAG/stage 런타임에 필요한 PostgreSQL, callback, graph clustering, numeric/ML, JSON serialization 의존성을 구분

## Why

Airflow 컨테이너는 `ml/src`를 bind mount 해서 pipeline 코드를 import하지만, 외부 패키지는 이미지에 설치되어 있어야 함

## Changes

- `asyncpg`, `psycopg2-binary`: Airflow metadata DB 연결
- `httpx`: Spring Backend callback/API 호출
- `igraph`, `leidenalg`: intent discovery graph clustering
- `numpy`, `scikit-learn`, `scipy`: embedding/clustering/evaluation 계산
- `orjson`: pipeline artifact JSON serialization

## Validation

- 실제 `ml/airflow/requirements.txt` 파일은 변경하지 않음
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ajou-2026-1-capstone-5/ostone/pull/184" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **문서**
  * Airflow 이미지 정책이 체계적으로 정의되었습니다.
  * Apache Airflow 버전 관리 및 의존성 계약 조건이 명확하게 문서화되었습니다.
  * Airflow 런타임 환경 구성을 위한 필수 및 금지 사항이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->