### PR TITLE
feat(domain-pack): [FE] Transition Condition / Action 초안 조회 (#2216)

### DIFF
--- a/frontend/src/entities/workflow/api/index.ts
+++ b/frontend/src/entities/workflow/api/index.ts
@@ -1,5 +1,5 @@
 import { apiClient } from "@/shared/api";
-import type { WorkflowDetail, WorkflowSummary, UpdateWorkflowRequest } from "../model/types";
+import type { WorkflowDetail, WorkflowSummary, UpdateWorkflowRequest, WorkflowTransitionDetail } from "../model/types";
 
 export const workflowQueryKeys = {
   all: ["workflows"] as const,
@@ -36,6 +36,24 @@ export function fetchWorkflow(
 export function fetchWorkflowList(wsId: number, packId: number, versionId: number) {
   return apiClient.get<WorkflowSummary[]>(
     `/workspaces/${wsId}/domain-packs/${packId}/versions/${versionId}/workflows`,
+  );
+}
+
+export const transitionQueryKeys = {
+  all: ["transitions"] as const,
+  lists: () => [...transitionQueryKeys.all, "list"] as const,
+  list: (wsId: number, packId: number, versionId: number, workflowId: number) =>
+    [...transitionQueryKeys.lists(), wsId, packId, versionId, workflowId] as const,
+};
+
+export function fetchTransitionList(
+  wsId: number,
+  packId: number,
+  versionId: number,
+  workflowId: number,
+) {
+  return apiClient.get<WorkflowTransitionDetail[]>(
+    `/workspaces/${wsId}/domain-packs/${packId}/versions/${versionId}/workflows/${workflowId}/transitions`,
   );
 }
 

--- a/frontend/src/entities/workflow/index.ts
+++ b/frontend/src/entities/workflow/index.ts
@@ -6,8 +6,16 @@ export type {
   GraphEdge,
   GraphNodeType,
   UpdateWorkflowRequest,
+  WorkflowTransitionDetail,
 } from "./model/types";
 
-export { workflowQueryKeys, fetchWorkflow, fetchWorkflowList, patchWorkflow } from "./api";
+export {
+  workflowQueryKeys,
+  fetchWorkflow,
+  fetchWorkflowList,
+  patchWorkflow,
+  transitionQueryKeys,
+  fetchTransitionList,
+} from "./api";
 
 export { toFlow, convertFlowToWorkflowGraph } from "./lib/graphConverter";

--- a/frontend/src/entities/workflow/model/types.ts
+++ b/frontend/src/entities/workflow/model/types.ts
@@ -51,3 +51,13 @@ export interface UpdateWorkflowRequest {
   description?: string | null;
   graphJson: WorkflowGraph;
 }
+
+export interface WorkflowTransitionDetail {
+  id: string;
+  workflowDefinitionId: number;
+  domainPackVersionId: number;
+  from: string;
+  to: string;
+  label: string | null;
+  toPolicyRef: string | null;
+}

--- a/frontend/src/features/workflow-draft-read/model/useTransitionList.test.tsx
+++ b/frontend/src/features/workflow-draft-read/model/useTransitionList.test.tsx
@@ -1,0 +1,60 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { ReactNode } from "react";
+import { fetchTransitionList } from "@/entities/workflow";
+import { useTransitionList } from "./useTransitionList";
+
+vi.mock("@/entities/workflow", () => ({
+  fetchTransitionList: vi.fn(),
+  transitionQueryKeys: {
+    all: ["transitions"] as const,
+    lists: () => ["transitions", "list"] as const,
+    list: (wsId: number, packId: number, versionId: number, workflowId: number) =>
+      ["transitions", "list", wsId, packId, versionId, workflowId] as const,
+  },
+}));
+
+const mockedFetch = vi.mocked(fetchTransitionList);
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+describe("useTransitionList", () => {
+  beforeEach(() => {
+    mockedFetch.mockReset();
+  });
+
+  it("workflowId=null이면 쿼리가 비활성화되어 fetch를 호출하지 않는다", () => {
+    const { result } = renderHook(() => useTransitionList(1, 2, 3, null), { wrapper });
+    expect(result.current.isPending).toBe(true);
+    expect(mockedFetch).not.toHaveBeenCalled();
+  });
+
+  it("workflowId가 있으면 fetchTransitionList를 호출하고 데이터를 반환한다", async () => {
+    const stub = [
+      {
+        id: "edge-1",
+        workflowDefinitionId: 10,
+        domainPackVersionId: 3,
+        from: "A",
+        to: "B",
+        label: null,
+        toPolicyRef: null,
+      },
+    ];
+    mockedFetch.mockResolvedValue(stub);
+    const { result } = renderHook(() => useTransitionList(1, 2, 3, 10), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(stub);
+    expect(mockedFetch).toHaveBeenCalledWith(1, 2, 3, 10);
+  });
+
+  it("fetch 실패 시 isError=true가 된다", async () => {
+    mockedFetch.mockRejectedValue(new Error("network error"));
+    const { result } = renderHook(() => useTransitionList(1, 2, 3, 10), { wrapper });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});

--- a/frontend/src/features/workflow-draft-read/model/useTransitionList.ts
+++ b/frontend/src/features/workflow-draft-read/model/useTransitionList.ts
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, skipToken } from "@tanstack/react-query";
 import { transitionQueryKeys, fetchTransitionList } from "@/entities/workflow";
 import type { WorkflowTransitionDetail } from "@/entities/workflow";
 
@@ -9,8 +9,13 @@ export function useTransitionList(
   workflowId: number | null,
 ) {
   return useQuery<WorkflowTransitionDetail[]>({
-    queryKey: transitionQueryKeys.list(wsId, packId, versionId, workflowId!),
-    queryFn: () => fetchTransitionList(wsId, packId, versionId, workflowId!),
-    enabled: workflowId != null,
+    queryKey:
+      workflowId != null
+        ? transitionQueryKeys.list(wsId, packId, versionId, workflowId)
+        : (["transitions", "disabled"] as const),
+    queryFn:
+      workflowId != null
+        ? () => fetchTransitionList(wsId, packId, versionId, workflowId)
+        : skipToken,
   });
 }

--- a/frontend/src/features/workflow-draft-read/model/useTransitionList.ts
+++ b/frontend/src/features/workflow-draft-read/model/useTransitionList.ts
@@ -1,0 +1,16 @@
+import { useQuery } from "@tanstack/react-query";
+import { transitionQueryKeys, fetchTransitionList } from "@/entities/workflow";
+import type { WorkflowTransitionDetail } from "@/entities/workflow";
+
+export function useTransitionList(
+  wsId: number,
+  packId: number,
+  versionId: number,
+  workflowId: number | null,
+) {
+  return useQuery<WorkflowTransitionDetail[]>({
+    queryKey: transitionQueryKeys.list(wsId, packId, versionId, workflowId!),
+    queryFn: () => fetchTransitionList(wsId, packId, versionId, workflowId!),
+    enabled: workflowId != null,
+  });
+}

--- a/frontend/src/features/workflow-draft-read/ui/GraphRenderer.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/GraphRenderer.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import { ReactFlow, Background, Controls, type NodeTypes } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
-import type { WorkflowGraph } from "../../../entities/workflow";
+import type { WorkflowGraph } from "@/entities/workflow";
 import { toFlow } from "./graphMapper";
 import { StartNode } from "./nodes/StartNode";
 import { ActionNode } from "./nodes/ActionNode";

--- a/frontend/src/features/workflow-draft-read/ui/GraphRenderer.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/GraphRenderer.tsx
@@ -22,9 +22,11 @@ const nodeTypes: NodeTypes = {
 
 interface GraphRendererProps {
   graph: WorkflowGraph;
+  onEdgeClick?: (edgeId: string) => void;
+  onPaneClick?: () => void;
 }
 
-export default function GraphRenderer({ graph }: GraphRendererProps) {
+export default function GraphRenderer({ graph, onEdgeClick, onPaneClick }: GraphRendererProps) {
   const { nodes, edges } = useMemo(() => toFlow(graph), [graph]);
 
   return (
@@ -39,6 +41,8 @@ export default function GraphRenderer({ graph }: GraphRendererProps) {
         nodesDraggable={false}
         nodesConnectable={false}
         elementsSelectable={false}
+        onEdgeClick={(_, edge) => onEdgeClick?.(edge.id)}
+        onPaneClick={onPaneClick}
       >
         <Background gap={20} size={1} />
         <Controls showInteractive={false} />

--- a/frontend/src/features/workflow-draft-read/ui/TransitionListPanel.module.css
+++ b/frontend/src/features/workflow-draft-read/ui/TransitionListPanel.module.css
@@ -1,0 +1,94 @@
+.stateWrap {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
+  gap: 8px;
+  color: var(--text-secondary);
+  font-size: 13px;
+  letter-spacing: -0.14px;
+}
+
+.skeleton {
+  width: 100%;
+  flex: 1;
+  background: var(--bg-secondary);
+  border-radius: var(--radius-md);
+}
+
+.retryButton {
+  padding: 6px 14px 7px;
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--text-primary);
+  background: transparent;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.54px;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.retryButton:focus-visible {
+  outline: dashed 2px var(--text-primary);
+  outline-offset: 2px;
+}
+
+.list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  width: 100%;
+}
+
+.item {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 14px 0;
+  border-bottom: 1px solid var(--glass-border);
+}
+
+.item:last-child {
+  border-bottom: none;
+}
+
+.id {
+  font-family: "Geist Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.54px;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.route {
+  font-size: 13px;
+  font-weight: 450;
+  letter-spacing: -0.14px;
+  color: var(--text-primary);
+}
+
+.badge {
+  display: inline-flex;
+  align-self: flex-start;
+  font-family: "Geist Mono", monospace;
+  font-size: 10px;
+  letter-spacing: 0.54px;
+  text-transform: uppercase;
+  padding: 2px 8px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--text-primary);
+  color: var(--text-primary);
+}
+
+.policyCode {
+  font-family: "Geist Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.54px;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+}

--- a/frontend/src/features/workflow-draft-read/ui/TransitionListPanel.test.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/TransitionListPanel.test.tsx
@@ -1,0 +1,122 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { toast } from "sonner";
+import { ApiRequestError } from "@/shared/api";
+import type { WorkflowTransitionDetail } from "@/entities/workflow";
+import { TransitionListPanel } from "./TransitionListPanel";
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn() },
+}));
+
+const stubTransitions: WorkflowTransitionDetail[] = [
+  {
+    id: "edge-1",
+    workflowDefinitionId: 10,
+    domainPackVersionId: 3,
+    from: "A",
+    to: "B",
+    label: "조건",
+    toPolicyRef: "POL_001",
+  },
+  {
+    id: "edge-2",
+    workflowDefinitionId: 10,
+    domainPackVersionId: 3,
+    from: "B",
+    to: "C",
+    label: null,
+    toPolicyRef: null,
+  },
+];
+
+describe("TransitionListPanel", () => {
+  beforeEach(() => {
+    vi.mocked(toast.error).mockReset();
+  });
+
+  it("loading 상태에서 skeleton을 표시한다", () => {
+    const { container } = render(
+      <TransitionListPanel
+        transitions={undefined}
+        isLoading={true}
+        isError={false}
+        error={null}
+        refetch={vi.fn()}
+      />,
+    );
+    expect(container.querySelector('[class*="skeleton"]')).toBeInTheDocument();
+  });
+
+  it("error 상태에서 에러 메시지와 재시도 버튼을 표시한다", () => {
+    const refetch = vi.fn();
+    render(
+      <TransitionListPanel
+        transitions={undefined}
+        isLoading={false}
+        isError={true}
+        error={null}
+        refetch={refetch}
+      />,
+    );
+    expect(screen.getByText("목록을 불러오지 못했습니다.")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "다시 시도" }));
+    expect(refetch).toHaveBeenCalled();
+  });
+
+  it("error 상태에서 ApiRequestError 메시지로 toast를 호출한다", async () => {
+    const err = new ApiRequestError(500, "SERVER_ERROR", "서버 장애");
+    render(
+      <TransitionListPanel
+        transitions={undefined}
+        isLoading={false}
+        isError={true}
+        error={err}
+        refetch={vi.fn()}
+      />,
+    );
+    expect(toast.error).toHaveBeenCalledWith("서버 장애");
+  });
+
+  it("transitions가 비어있으면 빈 상태 메시지를 표시한다", () => {
+    render(
+      <TransitionListPanel
+        transitions={[]}
+        isLoading={false}
+        isError={false}
+        error={null}
+        refetch={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("등록된 transition이 없습니다.")).toBeInTheDocument();
+  });
+
+  it("transitions 목록을 렌더링한다", () => {
+    render(
+      <TransitionListPanel
+        transitions={stubTransitions}
+        isLoading={false}
+        isError={false}
+        error={null}
+        refetch={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("edge-1")).toBeInTheDocument();
+    expect(screen.getByText("A → B")).toBeInTheDocument();
+    expect(screen.getByText("edge-2")).toBeInTheDocument();
+    expect(screen.getByText("B → C")).toBeInTheDocument();
+  });
+
+  it("toPolicyRef가 있는 항목에는 policy code를 표시한다", () => {
+    render(
+      <TransitionListPanel
+        transitions={stubTransitions}
+        isLoading={false}
+        isError={false}
+        error={null}
+        refetch={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("POL_001")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/workflow-draft-read/ui/TransitionListPanel.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/TransitionListPanel.tsx
@@ -1,0 +1,82 @@
+import { useEffect } from "react";
+import { toast } from "sonner";
+import { ApiRequestError } from "@/shared/api";
+import type { WorkflowTransitionDetail } from "@/entities/workflow";
+import styles from "./TransitionListPanel.module.css";
+
+interface TransitionListPanelProps {
+  transitions: WorkflowTransitionDetail[] | undefined;
+  isLoading: boolean;
+  isError: boolean;
+  error: unknown;
+  refetch: () => void;
+}
+
+export function TransitionListPanel({
+  transitions,
+  isLoading,
+  isError,
+  error,
+  refetch,
+}: TransitionListPanelProps) {
+  const errorMessage =
+    isError && error instanceof ApiRequestError ? error.message : undefined;
+
+  useEffect(() => {
+    if (isError) {
+      toast.error(errorMessage ?? "transition 목록을 불러오지 못했습니다.");
+    }
+  }, [isError, errorMessage]);
+
+  if (isLoading) {
+    return (
+      <div className={styles.stateWrap}>
+        <div className={styles.skeleton} />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className={styles.stateWrap}>
+        <span>목록을 불러오지 못했습니다.</span>
+        <button type="button" className={styles.retryButton} onClick={() => void refetch()}>
+          다시 시도
+        </button>
+      </div>
+    );
+  }
+
+  if (!transitions || transitions.length === 0) {
+    return (
+      <div className={styles.stateWrap}>
+        <span>등록된 transition이 없습니다.</span>
+      </div>
+    );
+  }
+
+  return (
+    <ul className={styles.list}>
+      {transitions.map((t) => (
+        <TransitionItem key={t.id} transition={t} />
+      ))}
+    </ul>
+  );
+}
+
+function TransitionItem({ transition }: { transition: WorkflowTransitionDetail }) {
+  return (
+    <li className={styles.item}>
+      <span className={styles.id}>{transition.id}</span>
+      <span className={styles.route}>
+        {transition.from} → {transition.to}
+      </span>
+      {transition.label != null && (
+        <span className={styles.badge}>{transition.label}</span>
+      )}
+      {transition.toPolicyRef != null && (
+        <span className={styles.policyCode}>{transition.toPolicyRef}</span>
+      )}
+    </li>
+  );
+}

--- a/frontend/src/features/workflow-draft-read/ui/TransitionListPanel.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/TransitionListPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { toast } from "sonner";
 import { ApiRequestError } from "@/shared/api";
 import type { WorkflowTransitionDetail } from "@/entities/workflow";
@@ -22,9 +22,14 @@ export function TransitionListPanel({
   const errorMessage =
     isError && error instanceof ApiRequestError ? error.message : undefined;
 
+  const toastFiredRef = useRef(false);
   useEffect(() => {
-    if (isError) {
+    if (isError && !toastFiredRef.current) {
+      toastFiredRef.current = true;
       toast.error(errorMessage ?? "transition 목록을 불러오지 못했습니다.");
+    }
+    if (!isError) {
+      toastFiredRef.current = false;
     }
   }, [isError, errorMessage]);
 

--- a/frontend/src/features/workflow-draft-read/ui/TransitionPopover.module.css
+++ b/frontend/src/features/workflow-draft-read/ui/TransitionPopover.module.css
@@ -1,0 +1,108 @@
+.popover {
+  position: absolute;
+  right: 12px;
+  top: 12px;
+  width: 272px;
+  background: var(--bg-color);
+  border: 1px solid var(--text-primary);
+  border-radius: var(--radius-md);
+  padding: 16px;
+  z-index: 10;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.id {
+  font-family: "Geist Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.54px;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  word-break: break-all;
+}
+
+.closeButton {
+  flex-shrink: 0;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  border: 1px solid var(--glass-border);
+  background: var(--bg-color);
+  color: var(--text-secondary);
+  font-size: 11px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+}
+
+.closeButton:focus-visible {
+  outline: dashed 2px var(--text-primary);
+  outline-offset: 2px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.label {
+  font-family: "Geist Mono", monospace;
+  font-size: 10px;
+  letter-spacing: 0.54px;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.value {
+  font-size: 13px;
+  font-weight: 450;
+  letter-spacing: -0.14px;
+  color: var(--text-primary);
+}
+
+.badge {
+  display: inline-flex;
+  font-family: "Geist Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.54px;
+  text-transform: uppercase;
+  padding: 3px 8px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--text-primary);
+  color: var(--text-primary);
+  align-self: flex-start;
+}
+
+.policySection {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding-top: 4px;
+  border-top: 1px solid var(--glass-border);
+}
+
+.policyName {
+  font-size: 13px;
+  font-weight: 450;
+  letter-spacing: -0.14px;
+  color: var(--text-primary);
+}
+
+.policyDesc {
+  font-size: 12px;
+  font-weight: 340;
+  letter-spacing: -0.14px;
+  color: var(--text-secondary);
+  line-height: 1.4;
+}

--- a/frontend/src/features/workflow-draft-read/ui/TransitionPopover.test.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/TransitionPopover.test.tsx
@@ -1,0 +1,74 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import type { WorkflowTransitionDetail } from "@/entities/workflow";
+import type { PolicySummary } from "@/entities/policy";
+import { TransitionPopover } from "./TransitionPopover";
+
+const stubTransition: WorkflowTransitionDetail = {
+  id: "edge-1",
+  workflowDefinitionId: 10,
+  domainPackVersionId: 3,
+  from: "STATE_A",
+  to: "STATE_B",
+  label: "조건A",
+  toPolicyRef: "POL_001",
+};
+
+const stubPolicy: PolicySummary = {
+  id: 1,
+  domainPackVersionId: 3,
+  policyCode: "POL_001",
+  name: "정책 이름",
+  description: "정책 설명",
+  severity: null,
+  status: "ACTIVE",
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-01T00:00:00Z",
+};
+
+describe("TransitionPopover", () => {
+  it("transition 기본 정보를 표시한다", () => {
+    render(<TransitionPopover transition={stubTransition} policy={null} onClose={vi.fn()} />);
+    expect(screen.getByRole("dialog", { name: "transition 상세" })).toBeInTheDocument();
+    expect(screen.getByText("STATE_A → STATE_B")).toBeInTheDocument();
+    expect(screen.getByText("조건A")).toBeInTheDocument();
+  });
+
+  it("policy가 있으면 policy 섹션을 표시한다", () => {
+    render(<TransitionPopover transition={stubTransition} policy={stubPolicy} onClose={vi.fn()} />);
+    expect(screen.getByText("정책 이름")).toBeInTheDocument();
+    expect(screen.getByText("정책 설명")).toBeInTheDocument();
+  });
+
+  it("policy=null이면 policy 섹션을 표시하지 않는다", () => {
+    render(<TransitionPopover transition={stubTransition} policy={null} onClose={vi.fn()} />);
+    expect(screen.queryByText("정책 이름")).not.toBeInTheDocument();
+  });
+
+  it("닫기 버튼 클릭 시 onClose를 호출한다", () => {
+    const onClose = vi.fn();
+    render(<TransitionPopover transition={stubTransition} policy={null} onClose={onClose} />);
+    fireEvent.click(screen.getByRole("button", { name: "닫기" }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("Escape 키 입력 시 onClose를 호출한다", () => {
+    const onClose = vi.fn();
+    render(<TransitionPopover transition={stubTransition} policy={null} onClose={onClose} />);
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("팝오버 외부 클릭 시 onClose를 호출한다", () => {
+    const onClose = vi.fn();
+    render(<TransitionPopover transition={stubTransition} policy={null} onClose={onClose} />);
+    fireEvent.mouseDown(document.body);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("label=null이면 label 섹션을 표시하지 않는다", () => {
+    const noLabel = { ...stubTransition, label: null };
+    render(<TransitionPopover transition={noLabel} policy={null} onClose={vi.fn()} />);
+    expect(screen.queryByText("Label")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/workflow-draft-read/ui/TransitionPopover.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/TransitionPopover.tsx
@@ -1,0 +1,72 @@
+import { useEffect, useRef } from "react";
+import type { WorkflowTransitionDetail } from "@/entities/workflow";
+import type { PolicySummary } from "@/entities/policy";
+import styles from "./TransitionPopover.module.css";
+
+interface TransitionPopoverProps {
+  transition: WorkflowTransitionDetail;
+  policy: PolicySummary | null;
+  onClose: () => void;
+}
+
+export function TransitionPopover({ transition, policy, onClose }: TransitionPopoverProps) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleKeyDown = (e: globalThis.KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
+
+  useEffect(() => {
+    const handleMouseDown = (e: globalThis.MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+    document.addEventListener("mousedown", handleMouseDown);
+    return () => document.removeEventListener("mousedown", handleMouseDown);
+  }, [onClose]);
+
+  return (
+    <div ref={ref} className={styles.popover} role="dialog" aria-label="transition 상세">
+      <div className={styles.header}>
+        <span className={styles.id}>{transition.id}</span>
+        <button
+          type="button"
+          className={styles.closeButton}
+          onClick={onClose}
+          aria-label="닫기"
+        >
+          ✕
+        </button>
+      </div>
+
+      <div className={styles.field}>
+        <span className={styles.label}>Route</span>
+        <span className={styles.value}>
+          {transition.from} → {transition.to}
+        </span>
+      </div>
+
+      {transition.label != null && (
+        <div className={styles.field}>
+          <span className={styles.label}>Label</span>
+          <span className={styles.badge}>{transition.label}</span>
+        </div>
+      )}
+
+      {policy != null && (
+        <div className={styles.policySection}>
+          <span className={styles.label}>Policy</span>
+          <span className={styles.policyName}>{policy.name}</span>
+          {policy.description && (
+            <span className={styles.policyDesc}>{policy.description}</span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/workflow-draft-read/ui/WorkflowDetailPanel.module.css
+++ b/frontend/src/features/workflow-draft-read/ui/WorkflowDetailPanel.module.css
@@ -108,6 +108,11 @@
   min-height: 0;
   display: flex;
   flex-direction: column;
+  position: relative;
+}
+
+.graphBody {
+  padding: 0;
 }
 
 .jsonBlock {

--- a/frontend/src/features/workflow-draft-read/ui/WorkflowDetailPanel.test.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/WorkflowDetailPanel.test.tsx
@@ -1,12 +1,23 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { toast } from "sonner";
 import { ApiRequestError } from "@/shared/api";
 import { useWorkflowDetail } from "../model/useWorkflowDetail";
+import { useTransitionList } from "../model/useTransitionList";
 import { WorkflowDetailPanel } from "./WorkflowDetailPanel";
 
 vi.mock("../model/useWorkflowDetail", () => ({
   useWorkflowDetail: vi.fn(),
+}));
+
+vi.mock("../model/useTransitionList", () => ({
+  useTransitionList: vi.fn(),
+}));
+
+vi.mock("@/entities/policy", () => ({
+  policyApi: { list: vi.fn().mockResolvedValue([]) },
+  policyKeys: { list: (...args: unknown[]) => ["policies", "list", ...args] },
 }));
 
 vi.mock("sonner", () => ({
@@ -22,6 +33,7 @@ vi.mock("@/shared/ui/ErrorBoundary", () => ({
 }));
 
 const mockedUseWorkflowDetail = vi.mocked(useWorkflowDetail);
+const mockedUseTransitionList = vi.mocked(useTransitionList);
 
 const stubDetail = {
   id: 10,
@@ -37,7 +49,16 @@ const stubDetail = {
   updatedAt: "2026-04-01T00:00:00Z",
 };
 
+const stubTransitionResult = {
+  data: undefined,
+  isLoading: false,
+  isError: false,
+  error: null,
+  refetch: vi.fn(),
+} as unknown as ReturnType<typeof useTransitionList>;
+
 function renderPanel(props: Partial<React.ComponentProps<typeof WorkflowDetailPanel>> = {}) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   const defaults = {
     wsId: 1,
     packId: 2,
@@ -45,14 +66,20 @@ function renderPanel(props: Partial<React.ComponentProps<typeof WorkflowDetailPa
     workflowId: 10 as number | null,
     onEdit: vi.fn(),
   };
-  render(<WorkflowDetailPanel {...defaults} {...props} />);
+  render(
+    <QueryClientProvider client={queryClient}>
+      <WorkflowDetailPanel {...defaults} {...props} />
+    </QueryClientProvider>,
+  );
   return defaults;
 }
 
 describe("WorkflowDetailPanel", () => {
   beforeEach(() => {
     mockedUseWorkflowDetail.mockReset();
+    mockedUseTransitionList.mockReset();
     vi.mocked(toast.error).mockReset();
+    mockedUseTransitionList.mockReturnValue(stubTransitionResult);
   });
 
   it("workflowId=null이면 선택 안내를 보여준다", () => {
@@ -234,7 +261,7 @@ describe("WorkflowDetailPanel", () => {
     expect(screen.getByRole("tab", { name: "Graph" })).toHaveAttribute("aria-selected", "true");
   });
 
-  it("End 키로 마지막 탭(Meta)으로 이동한다", () => {
+  it("End 키로 마지막 탭(Transitions)으로 이동한다", () => {
     mockedUseWorkflowDetail.mockReturnValue({
       data: stubDetail,
       isLoading: false,
@@ -244,7 +271,7 @@ describe("WorkflowDetailPanel", () => {
     } as unknown as ReturnType<typeof useWorkflowDetail>);
     renderPanel();
     fireEvent.keyDown(screen.getByRole("tab", { name: "Graph" }), { key: "End" });
-    expect(screen.getByRole("tab", { name: "Meta" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("tab", { name: "Transitions" })).toHaveAttribute("aria-selected", "true");
   });
 
   it("Meta 탭 — evidenceJson이 malformed JSON이면 raw 문자열을 표시한다", () => {

--- a/frontend/src/features/workflow-draft-read/ui/WorkflowDetailPanel.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/WorkflowDetailPanel.tsx
@@ -1,18 +1,37 @@
-import { Suspense, lazy, useState, useEffect, useId, useMemo, type KeyboardEvent } from "react";
+import {
+  Suspense,
+  lazy,
+  useState,
+  useEffect,
+  useId,
+  useMemo,
+  type KeyboardEvent,
+} from "react";
+import { useQuery } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { useWorkflowDetail } from "../model/useWorkflowDetail";
+import { useTransitionList } from "../model/useTransitionList";
 import { parseTerminalStates } from "../model/parseTerminalStates";
 import { ApiRequestError } from "@/shared/api";
 import type { WorkflowDetail } from "@/entities/workflow";
+import { policyApi, policyKeys } from "@/entities/policy";
+import type { PolicySummary } from "@/entities/policy";
 import { ErrorBoundary } from "@/shared/ui/ErrorBoundary";
+import { TransitionPopover } from "./TransitionPopover";
+import { TransitionListPanel } from "./TransitionListPanel";
 import styles from "./WorkflowDetailPanel.module.css";
 
 const GraphRenderer = lazy(() => import("./GraphRenderer"));
 
-type Tab = "graph" | "json" | "meta";
+type Tab = "graph" | "json" | "meta" | "transitions";
 
-const TABS = ["graph", "json", "meta"] as const;
-const TAB_LABELS: Record<Tab, string> = { graph: "Graph", json: "JSON", meta: "Meta" };
+const TABS = ["graph", "json", "meta", "transitions"] as const;
+const TAB_LABELS: Record<Tab, string> = {
+  graph: "Graph",
+  json: "JSON",
+  meta: "Meta",
+  transitions: "Transitions",
+};
 
 interface WorkflowDetailPanelProps {
   wsId: number;
@@ -29,13 +48,53 @@ export function WorkflowDetailPanel({
   workflowId,
   onEdit,
 }: WorkflowDetailPanelProps) {
-  const { data: detail, isLoading, isError, error, refetch } = useWorkflowDetail(wsId, packId, versionId, workflowId);
+  const { data: detail, isLoading, isError, error, refetch } = useWorkflowDetail(
+    wsId,
+    packId,
+    versionId,
+    workflowId,
+  );
   const [tab, setTab] = useState<Tab>("graph");
+  const [selectedEdgeId, setSelectedEdgeId] = useState<string | null>(null);
   const idPrefix = useId();
 
   useEffect(() => {
     setTab("graph");
+    setSelectedEdgeId(null);
   }, [workflowId]);
+
+  const {
+    data: transitionList,
+    isLoading: transitionLoading,
+    isError: transitionError,
+    error: transitionErr,
+    refetch: refetchTransitions,
+  } = useTransitionList(wsId, packId, versionId, workflowId);
+
+  const { data: policyList } = useQuery({
+    queryKey: policyKeys.list(wsId, packId, versionId),
+    queryFn: () => policyApi.list(wsId, packId, versionId),
+    enabled: workflowId != null,
+  });
+
+  const policyByCode = useMemo(
+    () =>
+      new Map<string, PolicySummary>(policyList?.map((p) => [p.policyCode, p]) ?? []),
+    [policyList],
+  );
+
+  const selectedTransition = useMemo(
+    () => transitionList?.find((t) => t.id === selectedEdgeId) ?? null,
+    [transitionList, selectedEdgeId],
+  );
+
+  const selectedPolicy = useMemo(
+    () =>
+      selectedTransition?.toPolicyRef != null
+        ? (policyByCode.get(selectedTransition.toPolicyRef) ?? null)
+        : null,
+    [selectedTransition, policyByCode],
+  );
 
   const apiError = isError && error instanceof ApiRequestError ? error : null;
   const apiErrorCode = apiError?.code;
@@ -129,13 +188,31 @@ export function WorkflowDetailPanel({
           id={`${idPrefix}-panel-graph`}
           role="tabpanel"
           aria-labelledby={`${idPrefix}-tab-graph`}
-          className={styles.body}
+          className={`${styles.body} ${styles.graphBody}`}
         >
-          <ErrorBoundary key={workflowId} fallback={<div className={styles.placeholder}><span>그래프를 표시할 수 없습니다.</span></div>}>
+          <ErrorBoundary
+            key={workflowId}
+            fallback={
+              <div className={styles.placeholder}>
+                <span>그래프를 표시할 수 없습니다.</span>
+              </div>
+            }
+          >
             <Suspense fallback={<div className={styles.skeleton} />}>
-              <GraphRenderer graph={detail.graphJson} />
+              <GraphRenderer
+                graph={detail.graphJson}
+                onEdgeClick={setSelectedEdgeId}
+                onPaneClick={() => setSelectedEdgeId(null)}
+              />
             </Suspense>
           </ErrorBoundary>
+          {selectedEdgeId !== null && selectedTransition !== null && (
+            <TransitionPopover
+              transition={selectedTransition}
+              policy={selectedPolicy}
+              onClose={() => setSelectedEdgeId(null)}
+            />
+          )}
         </div>
       )}
 
@@ -162,6 +239,23 @@ export function WorkflowDetailPanel({
           <MetaTab detail={detail} />
         </div>
       )}
+
+      {tab === "transitions" && (
+        <div
+          id={`${idPrefix}-panel-transitions`}
+          role="tabpanel"
+          aria-labelledby={`${idPrefix}-tab-transitions`}
+          className={styles.body}
+        >
+          <TransitionListPanel
+            transitions={transitionList}
+            isLoading={transitionLoading}
+            isError={transitionError}
+            error={transitionErr}
+            refetch={refetchTransitions}
+          />
+        </div>
+      )}
     </section>
   );
 }
@@ -173,8 +267,12 @@ function DetailHeader({ detail, onEdit }: { detail: WorkflowDetail; onEdit?: () 
         <div className={styles.headerInfo}>
           <span className={styles.code}>{detail.workflowCode}</span>
           <span className={styles.name}>{detail.name}</span>
-          {detail.description && <span className={styles.description}>{detail.description}</span>}
-          <span className={styles.updatedAt}>UPDATED · {new Date(detail.updatedAt).toLocaleString()}</span>
+          {detail.description && (
+            <span className={styles.description}>{detail.description}</span>
+          )}
+          <span className={styles.updatedAt}>
+            UPDATED · {new Date(detail.updatedAt).toLocaleString()}
+          </span>
         </div>
         {onEdit && (
           <button type="button" className={styles.editButton} onClick={onEdit}>


### PR DESCRIPTION
#### Summary

- `WorkflowDetailPanel`에 Transitions 탭 추가 — `useTransitionList` hook을 통해 workflow transitions 목록 조회 및 표시
- Graph 화면에서 edge 클릭 시 `TransitionPopover` 표시 — transition id/route/label/policyRef 정보 확인
- `toPolicyRef`에 대응하는 policy 이름·설명을 `policyApi.list()` 결합으로 표시 (graceful degradation 포함)
- `entities/workflow` entity layer에 `WorkflowTransitionDetail` 타입 + `fetchTransitionList` API 함수 추가
- 신규 단위 테스트 3종 추가 (`useTransitionList`, `TransitionPopover`, `TransitionListPanel`) 및 기존 테스트 수정

#### Context

스펙: `.agent/specs/2216.md` — [FE] 2.2.16 Transition Condition / Action 초안 조회
구현 브랜치: `feature/2216-transition-cond-action-draft-view`

#### What Changed

- `entities/workflow`: `WorkflowTransitionDetail` 인터페이스(7필드), `transitionQueryKeys`, `fetchTransitionList` 추가 및 re-export
- `features/workflow-draft-read/model/useTransitionList.ts`: 신규 TanStack Query hook — `workflowId != null` 조건부 enabled + skipToken 패턴으로 조건부 queryKey/queryFn
- `features/workflow-draft-read/ui/TransitionPopover.tsx`: edge 클릭 시 나타나는 Popover — click-outside + Escape dismiss, policy 섹션 조건부 표시
- `features/workflow-draft-read/ui/TransitionListPanel.tsx`: Transitions 탭 목록 UI — loading/error/empty/list 4종 상태, toast 중복 방지 useRef guard 적용
- `features/workflow-draft-read/ui/GraphRenderer.tsx`: `onEdgeClick`, `onPaneClick` prop 추가, `@/entities/workflow` alias import
- `features/workflow-draft-read/ui/WorkflowDetailPanel.tsx`: Transitions 탭 추가, `selectedEdgeId` state, `policyByCode` Map 구성, `TransitionPopover` 렌더링

#### Assumptions Adopted

**From Builder Discretion (U1~U5):**

| ID | Decision |
|----|----------|
| U1 | Popover: graph container 우측 상단 고정 (`position: absolute; right: 12px; top: 12px`). `clientX/Y` 절대 위치 방식 대신 선택. 좁은 화면에서 그래프 콘텐츠를 가릴 수 있음 (known tradeoff). |
| U2 | Popover dismiss: `document mousedown` + `keydown Escape` useEffect 구현. mousedown이 `onEdgeClick`보다 먼저 발화하여 edge 재클릭 시 닫힘 후 재열림 동작 — UX 무결함 확인. |
| U3 | `toPolicyRef` 있으나 policyByCode Map 미매칭 시 policy 섹션 무음 미표시 (silent graceful degradation). |
| U4 | Popover 표시 순서: id(mono) / Route(from → to) / Label(badge, 조건부) / Policy(구분선 + name + desc, 조건부) |
| U5 | Transitions 탭 항목 행: id(mono muted) / route / label badge / policyCode mono |

#### Spec Deviations

없음 — C1~C6 CONSISTENT. 단, 아래 항목은 codeRemediator fix로 spec에 맞춰 수정됨:

- `useTransitionList.ts` queryKey/queryFn: `workflowId!` 비null 단언 → spec 명시 조건부 패턴 (`skipToken`) 으로 수정 (V-003, V-004 fix)

#### Blocked / Skipped Items

- **V-009 (Info) — 테스트 결과 artifact 부재**: `playwright-test-report`, `test-results`, `frontend-test-results` 아티팩트가 GateRunner verify-fe 파이프라인에서 생성되지 않음. 파이프라인 레벨 개선 사항 — 이번 구현 범위 외로 Deferred.
- **Spec scenario 4 happy path** (policy display): 로컬 DB에 policy 데이터 없어 Playwright 검증 불가. DB 데이터 제약이며 구현 결함 아님. FE graceful degradation은 별도 시나리오에서 확인됨.
- **Workflow 2 transitions 400 오류**: DB에 `WORKFLOW_ACTION_NODE_POLICY_REF_MISSING` 조건 존재 — 테스트 데이터 이슈. FE error state + 다시 시도 버튼 정상 표시 확인.

#### Test Notes

**단위 테스트 (Vitest):**
- fix run #1 후 전체 412 테스트 PASS (기존 14 실패 → PASS, 신규 15케이스 추가)
- `useTransitionList.test.tsx` (3케이스): renderHook + QueryClientProvider, enabled/disabled 분기
- `TransitionPopover.test.tsx` (7케이스): Escape/click-outside dismiss, policy 섹션 조건부 표시
- `TransitionListPanel.test.tsx` (5케이스): loading/error/empty/list 4종 + toast 중복 방지
- `WorkflowDetailPanel.test.tsx` 수정: QueryClientProvider wrapper 추가, useTransitionList mock, End key assertion → Transitions 탭으로 수정

**Playwright MCP (local):**
- Happy path: 5/6 PASS (scenario 4 SKIPPED_DATA_GAP — DB policy 데이터 없음)
- Error cases: 2/4 PASS, 1 SKIPPED_DATA_GAP, 1 NOT_TESTED
- Routes tested: 11
- Console errors: 2 (pre-existing CDN 404, workflow 2 테스트 데이터 400 — 모두 비blocking)

---
#### Reviewer Focus

1. **`useTransitionList.ts` skipToken 패턴** — spec 명시 조건부 queryKey 패턴 (`workflowId != null ? transitionQueryKeys.list(...) : skipToken`) 준수 여부. V-003/V-004 fix 결과.
2. **`TransitionListPanel.tsx` toast useRef guard** — `toastFiredRef` 패턴으로 remount 시 중복 toast 방지. isError=false 시 ref reset 로직 포함.
3. **`WorkflowDetailPanel.tsx` policy pre-fetch 범위** — `policyApi.list(wsId, packId, versionId)` 를 Transitions 탭 진입 시 항상 호출. 탭 진입 전 불필요한 네트워크 요청 여부 점검.
4. **Popover position 전략 (U1)** — `position: absolute; right/top` 고정 방식. 좁은 viewport에서 graph 콘텐츠 overlap 가능성. 현재 MVP 범위 내 허용된 tradeoff.
5. **V-009 deferred** — GateRunner 파이프라인에서 Vitest 결과 JSON artifact가 미생성됨. CI coverage 추적 개선 필요 (별도 파이프라인 태스크).

#### Conflicts

없음.

---
#### Screenshots
<img width="1200" height="717" alt="2216__workflow-detail__edge-click-label" src="https://github.com/user-attachments/assets/646a6bb1-63d7-4684-80ac-4af1fef1f1b0" />
<img width="1200" height="717" alt="2216__workflow-detail__edge-click-no-label" src="https://github.com/user-attachments/assets/741eec75-de5a-455c-8dec-c46e7ca7bcae" />
<img width="1200" height="717" alt="2216__workflow-detail__edge-click-policyref-graceful" src="https://github.com/user-attachments/assets/50e438bf-ec72-4c89-8d95-ea9d1a02f115" />

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ajou-2026-1-capstone-5/ostone/pull/188" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 워크플로우에서 전환(Transition) 목록을 조회할 수 있는 기능 추가
  * 워크플로우 그래프의 엣지 클릭 시 전환 상세 정보를 팝오버로 표시
  * 전환 목록 패널 추가 (로딩/에러 상태 및 재시도 기능 포함)
  * 전환 정보에 정책 참조 및 라벨 표시 지원

* **문서화**
  * 전환 목록 조회 및 상세 정보 표시 관련 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->