### PR TITLE
refactor(be): fix audit violations per .agent/rules (V-001~V-009)

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -83,7 +83,12 @@ sonar {
         property("sonar.coverage.exclusions",
             "**/dto/**/*,**/entity/**/*,**/config/**,**/*Application.java,**/infrastructure/**/*")
         property("sonar.cpd.exclusions",
-            "**/pipelinejob/application/AddWorkflowDraftPortCommand.java")
+            "**/pipelinejob/application/AddWorkflowDraftPortCommand.java," +
+            "**/pipelinejob/application/CreateDomainPackDraftPortCommand.java," +
+            "**/pipelinejob/application/CreateDomainPackDraftPortResult.java," +
+            "**/pipelinejob/application/AddIntentsToDraftVersionPortCommand.java," +
+            "**/pipelinejob/application/AddIntentsToDraftVersionPortResult.java," +
+            "**/pipelinejob/application/IntentDraftInput.java")
     }
 }
 

--- a/backend/src/main/java/com/init/corpus/application/RawDatasetUploadService.java
+++ b/backend/src/main/java/com/init/corpus/application/RawDatasetUploadService.java
@@ -29,6 +29,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
 
+// NOTE: 선언적 @Transactional 대신 TransactionTemplate을 사용한다.
+// Dataset 저장 → conversation 배치 flush → 실패 시 보상 트랜잭션(compensation)을
+// 독립된 트랜잭션 경계로 interleave해야 하므로 클래스 레벨 @Transactional(readOnly = true)
+// 컨벤션의 의도적 예외.
 @Service
 public class RawDatasetUploadService {
 

--- a/backend/src/main/java/com/init/domainpack/application/AddIntentsToDraftVersionUseCase.java
+++ b/backend/src/main/java/com/init/domainpack/application/AddIntentsToDraftVersionUseCase.java
@@ -9,7 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 /** 기존 DRAFT 버전에 intent를 추가 저장한다. Airflow 파이프라인 콜백의 2단계에서 사용한다. */
 @Service
-@Transactional
+@Transactional(readOnly = true)
 public class AddIntentsToDraftVersionUseCase {
 
   private final DomainPackVersionRepository domainPackVersionRepository;
@@ -22,6 +22,7 @@ public class AddIntentsToDraftVersionUseCase {
     this.domainPackDraftPersistenceService = domainPackDraftPersistenceService;
   }
 
+  @Transactional
   public AddIntentsToDraftVersionResult execute(AddIntentsToDraftVersionCommand command) {
     DomainPackVersion version =
         domainPackVersionRepository

--- a/backend/src/main/java/com/init/domainpack/application/AddWorkflowDraftToVersionUseCase.java
+++ b/backend/src/main/java/com/init/domainpack/application/AddWorkflowDraftToVersionUseCase.java
@@ -4,7 +4,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional
+@Transactional(readOnly = true)
 public class AddWorkflowDraftToVersionUseCase {
 
   private final DomainPackDraftPersistenceService domainPackDraftPersistenceService;
@@ -14,6 +14,7 @@ public class AddWorkflowDraftToVersionUseCase {
     this.domainPackDraftPersistenceService = domainPackDraftPersistenceService;
   }
 
+  @Transactional
   public AddWorkflowDraftToVersionResult execute(AddWorkflowDraftToVersionCommand command) {
     return domainPackDraftPersistenceService.persistWorkflowDraft(
         command.domainPackVersionId(),

--- a/backend/src/main/java/com/init/domainpack/application/CreateDomainPackDraftFromPipelineUseCase.java
+++ b/backend/src/main/java/com/init/domainpack/application/CreateDomainPackDraftFromPipelineUseCase.java
@@ -10,7 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 /** Airflow 파이프라인 콜백에서 DomainPack(없으면 생성) + DRAFT Version을 생성한다. Intent는 별도 API에서 추가한다. */
 @Service
-@Transactional
+@Transactional(readOnly = true)
 public class CreateDomainPackDraftFromPipelineUseCase {
 
   private final DomainPackCommandRepository domainPackCommandRepository;
@@ -23,6 +23,7 @@ public class CreateDomainPackDraftFromPipelineUseCase {
     this.domainPackDraftPersistenceService = domainPackDraftPersistenceService;
   }
 
+  @Transactional
   public CreateDomainPackDraftFromPipelineResult execute(
       CreateDomainPackDraftFromPipelineCommand command) {
     DomainPackResolution resolution = resolveDomainPack(command);

--- a/backend/src/main/java/com/init/domainpack/application/CreateDomainPackDraftUseCase.java
+++ b/backend/src/main/java/com/init/domainpack/application/CreateDomainPackDraftUseCase.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional
+@Transactional(readOnly = true)
 public class CreateDomainPackDraftUseCase {
 
   private static final Set<WorkspaceMemberRole> ALLOWED_WORKSPACE_ROLES =
@@ -34,6 +34,7 @@ public class CreateDomainPackDraftUseCase {
     this.domainPackDraftPersistenceService = domainPackDraftPersistenceService;
   }
 
+  @Transactional
   public CreateDomainPackDraftResult execute(CreateDomainPackDraftCommand command) {
     validateWorkspaceAccess(command);
     validateDomainPack(command);

--- a/backend/src/main/java/com/init/domainpack/application/DomainPackDraftPersistenceService.java
+++ b/backend/src/main/java/com/init/domainpack/application/DomainPackDraftPersistenceService.java
@@ -35,7 +35,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional
+@Transactional(readOnly = true)
 public class DomainPackDraftPersistenceService {
 
   private final DomainPackVersionRepository domainPackVersionRepository;
@@ -67,6 +67,7 @@ public class DomainPackDraftPersistenceService {
   }
 
   /** DRAFT 버전만 생성한다 (intent/slot/policy 등은 저장하지 않음). Airflow 파이프라인 콜백의 1단계에서 사용한다. */
+  @Transactional
   public DomainPackVersion persistVersion(
       Long packId, Long createdBy, Long sourcePipelineJobId, String summaryJson) {
     int nextVersionNo =
@@ -84,6 +85,7 @@ public class DomainPackDraftPersistenceService {
   }
 
   /** 기존 DRAFT 버전에 intent를 추가 저장한다. 이미 존재하는 intentCode는 건너뛴다. Airflow 파이프라인 콜백의 2단계에서 사용한다. */
+  @Transactional
   public AddIntentsToDraftVersionResult persistIntents(
       Long domainPackVersionId, List<IntentDraft> intents) {
     DomainPackVersion version = requireDraftVersion(domainPackVersionId);
@@ -150,6 +152,7 @@ public class DomainPackDraftPersistenceService {
   }
 
   /** UI에서 수동으로 전체 draft를 한 번에 저장할 때 사용한다. */
+  @Transactional
   public CreateDomainPackDraftResult persist(
       Long packId,
       Long createdBy,
@@ -172,13 +175,14 @@ public class DomainPackDraftPersistenceService {
             toIntentWorkflowBindingInputs(intentWorkflowBindings));
     List<WorkflowInput> validatedWorkflows =
         validateDraftPayload(
-            intents,
-            components.slots(),
-            components.intentSlotBindings(),
-            components.policies(),
-            components.risks(),
-            components.workflows(),
-            components.intentWorkflowBindings(),
+            new DraftPayload(
+                intents,
+                components.slots(),
+                components.intentSlotBindings(),
+                components.policies(),
+                components.risks(),
+                components.workflows(),
+                components.intentWorkflowBindings()),
             Set.of());
 
     int nextVersionNo =
@@ -257,6 +261,7 @@ public class DomainPackDraftPersistenceService {
   }
 
   /** 기존 DRAFT 버전에 workflow 관련 초안을 추가 저장한다. intent는 새로 만들지 않고 기존 row를 참조한다. */
+  @Transactional
   public AddWorkflowDraftToVersionResult persistWorkflowDraft(
       Long domainPackVersionId,
       List<AddWorkflowDraftToVersionCommand.SlotDraft> slots,
@@ -434,19 +439,27 @@ public class DomainPackDraftPersistenceService {
   }
 
   private List<WorkflowInput> validateDraftPayload(
+      DraftPayload payload, Set<String> allowedPolicyCodes) {
+    ensureDraftPayloadUnique(
+        payload.intents(),
+        payload.slots(),
+        payload.intentSlotBindings(),
+        payload.policies(),
+        payload.risks(),
+        payload.workflows(),
+        payload.intentWorkflowBindings());
+    return validateParsedWorkflows(
+        parseWorkflowInputs(safeList(payload.workflows())), payload.policies(), allowedPolicyCodes);
+  }
+
+  private record DraftPayload(
       List<IntentDraft> intents,
       List<SlotInput> slots,
       List<IntentSlotBindingInput> intentSlotBindings,
       List<PolicyInput> policies,
       List<RiskInput> risks,
       List<WorkflowInput> workflows,
-      List<IntentWorkflowBindingInput> intentWorkflowBindings,
-      Set<String> allowedPolicyCodes) {
-    ensureDraftPayloadUnique(
-        intents, slots, intentSlotBindings, policies, risks, workflows, intentWorkflowBindings);
-    return validateParsedWorkflows(
-        parseWorkflowInputs(safeList(workflows)), policies, allowedPolicyCodes);
-  }
+      List<IntentWorkflowBindingInput> intentWorkflowBindings) {}
 
   private void ensureDraftPayloadUnique(
       List<IntentDraft> intents,

--- a/backend/src/main/java/com/init/domainpack/infrastructure/AddIntentsToDraftVersionPortAdapter.java
+++ b/backend/src/main/java/com/init/domainpack/infrastructure/AddIntentsToDraftVersionPortAdapter.java
@@ -1,0 +1,53 @@
+package com.init.domainpack.infrastructure;
+
+import com.init.domainpack.application.AddIntentsToDraftVersionCommand;
+import com.init.domainpack.application.AddIntentsToDraftVersionUseCase;
+import com.init.domainpack.application.IntentDraft;
+import com.init.pipelinejob.application.AddIntentsToDraftVersionPort;
+import com.init.pipelinejob.application.AddIntentsToDraftVersionPortCommand;
+import com.init.pipelinejob.application.AddIntentsToDraftVersionPortResult;
+import com.init.pipelinejob.application.IntentDraftInput;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AddIntentsToDraftVersionPortAdapter implements AddIntentsToDraftVersionPort {
+
+  private final AddIntentsToDraftVersionUseCase addIntentsToDraftVersionUseCase;
+
+  public AddIntentsToDraftVersionPortAdapter(
+      AddIntentsToDraftVersionUseCase addIntentsToDraftVersionUseCase) {
+    this.addIntentsToDraftVersionUseCase = addIntentsToDraftVersionUseCase;
+  }
+
+  @Override
+  public AddIntentsToDraftVersionPortResult execute(AddIntentsToDraftVersionPortCommand command) {
+    var result =
+        addIntentsToDraftVersionUseCase.execute(
+            new AddIntentsToDraftVersionCommand(
+                command.domainPackVersionId(), toIntentDrafts(command.intents())));
+    return new AddIntentsToDraftVersionPortResult(
+        result.domainPackVersionId(),
+        result.domainPackId(),
+        result.addedIntentCount(),
+        result.skippedIntentCount(),
+        result.totalIntentCount());
+  }
+
+  private List<IntentDraft> toIntentDrafts(List<IntentDraftInput> inputs) {
+    return inputs.stream()
+        .map(
+            i ->
+                new IntentDraft(
+                    i.intentCode(),
+                    i.name(),
+                    i.description(),
+                    i.taxonomyLevel(),
+                    i.parentIntentCode(),
+                    i.sourceClusterRef(),
+                    i.entryConditionJson(),
+                    i.evidenceJson(),
+                    i.metaJson()))
+        .toList();
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/infrastructure/CreateDomainPackDraftPortAdapter.java
+++ b/backend/src/main/java/com/init/domainpack/infrastructure/CreateDomainPackDraftPortAdapter.java
@@ -1,0 +1,38 @@
+package com.init.domainpack.infrastructure;
+
+import com.init.domainpack.application.CreateDomainPackDraftFromPipelineCommand;
+import com.init.domainpack.application.CreateDomainPackDraftFromPipelineUseCase;
+import com.init.pipelinejob.application.CreateDomainPackDraftPort;
+import com.init.pipelinejob.application.CreateDomainPackDraftPortCommand;
+import com.init.pipelinejob.application.CreateDomainPackDraftPortResult;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CreateDomainPackDraftPortAdapter implements CreateDomainPackDraftPort {
+
+  private final CreateDomainPackDraftFromPipelineUseCase createDomainPackDraftFromPipelineUseCase;
+
+  public CreateDomainPackDraftPortAdapter(
+      CreateDomainPackDraftFromPipelineUseCase createDomainPackDraftFromPipelineUseCase) {
+    this.createDomainPackDraftFromPipelineUseCase = createDomainPackDraftFromPipelineUseCase;
+  }
+
+  @Override
+  public CreateDomainPackDraftPortResult execute(CreateDomainPackDraftPortCommand command) {
+    var result =
+        createDomainPackDraftFromPipelineUseCase.execute(
+            new CreateDomainPackDraftFromPipelineCommand(
+                command.workspaceId(),
+                command.packKey(),
+                command.packName(),
+                command.sourcePipelineJobId(),
+                command.summaryJson()));
+    return new CreateDomainPackDraftPortResult(
+        result.domainPackId(),
+        result.domainPackVersionId(),
+        result.versionNo(),
+        result.packKey(),
+        result.createdPack(),
+        result.sourcePipelineJobId());
+  }
+}

--- a/backend/src/main/java/com/init/pipelinejob/application/AddIntentsToDraftVersionPort.java
+++ b/backend/src/main/java/com/init/pipelinejob/application/AddIntentsToDraftVersionPort.java
@@ -1,0 +1,6 @@
+package com.init.pipelinejob.application;
+
+public interface AddIntentsToDraftVersionPort {
+
+  AddIntentsToDraftVersionPortResult execute(AddIntentsToDraftVersionPortCommand command);
+}

--- a/backend/src/main/java/com/init/pipelinejob/application/AddIntentsToDraftVersionPortCommand.java
+++ b/backend/src/main/java/com/init/pipelinejob/application/AddIntentsToDraftVersionPortCommand.java
@@ -1,0 +1,6 @@
+package com.init.pipelinejob.application;
+
+import java.util.List;
+
+public record AddIntentsToDraftVersionPortCommand(
+    Long domainPackVersionId, List<IntentDraftInput> intents) {}

--- a/backend/src/main/java/com/init/pipelinejob/application/AddIntentsToDraftVersionPortResult.java
+++ b/backend/src/main/java/com/init/pipelinejob/application/AddIntentsToDraftVersionPortResult.java
@@ -1,0 +1,8 @@
+package com.init.pipelinejob.application;
+
+public record AddIntentsToDraftVersionPortResult(
+    Long domainPackVersionId,
+    Long domainPackId,
+    int addedIntentCount,
+    int skippedIntentCount,
+    int totalIntentCount) {}

--- a/backend/src/main/java/com/init/pipelinejob/application/CreateDomainPackDraftPort.java
+++ b/backend/src/main/java/com/init/pipelinejob/application/CreateDomainPackDraftPort.java
@@ -1,0 +1,6 @@
+package com.init.pipelinejob.application;
+
+public interface CreateDomainPackDraftPort {
+
+  CreateDomainPackDraftPortResult execute(CreateDomainPackDraftPortCommand command);
+}

--- a/backend/src/main/java/com/init/pipelinejob/application/CreateDomainPackDraftPortCommand.java
+++ b/backend/src/main/java/com/init/pipelinejob/application/CreateDomainPackDraftPortCommand.java
@@ -1,0 +1,8 @@
+package com.init.pipelinejob.application;
+
+public record CreateDomainPackDraftPortCommand(
+    Long workspaceId,
+    String packKey,
+    String packName,
+    Long sourcePipelineJobId,
+    String summaryJson) {}

--- a/backend/src/main/java/com/init/pipelinejob/application/CreateDomainPackDraftPortResult.java
+++ b/backend/src/main/java/com/init/pipelinejob/application/CreateDomainPackDraftPortResult.java
@@ -1,0 +1,9 @@
+package com.init.pipelinejob.application;
+
+public record CreateDomainPackDraftPortResult(
+    Long domainPackId,
+    Long domainPackVersionId,
+    Integer versionNo,
+    String packKey,
+    boolean createdPack,
+    Long sourcePipelineJobId) {}

--- a/backend/src/main/java/com/init/pipelinejob/application/IntentDraftInput.java
+++ b/backend/src/main/java/com/init/pipelinejob/application/IntentDraftInput.java
@@ -1,0 +1,12 @@
+package com.init.pipelinejob.application;
+
+public record IntentDraftInput(
+    String intentCode,
+    String name,
+    String description,
+    Integer taxonomyLevel,
+    String parentIntentCode,
+    String sourceClusterRef,
+    String entryConditionJson,
+    String evidenceJson,
+    String metaJson) {}

--- a/backend/src/main/java/com/init/pipelinejob/application/PipelineJobCallbackSupportService.java
+++ b/backend/src/main/java/com/init/pipelinejob/application/PipelineJobCallbackSupportService.java
@@ -22,6 +22,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
 
+// NOTE: 선언적 @Transactional 대신 TransactionTemplate을 사용한다.
+// webhook receipt 저장과 pipeline job 상태 갱신을 독립된 트랜잭션으로 분리해야 하므로
+// 클래스 레벨 @Transactional(readOnly = true) 컨벤션의 의도적 예외.
 @Service
 public class PipelineJobCallbackSupportService {
 

--- a/backend/src/main/java/com/init/pipelinejob/application/ReceiveDomainPackDraftCallbackUseCase.java
+++ b/backend/src/main/java/com/init/pipelinejob/application/ReceiveDomainPackDraftCallbackUseCase.java
@@ -3,9 +3,6 @@ package com.init.pipelinejob.application;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.init.domainpack.application.CreateDomainPackDraftFromPipelineCommand;
-import com.init.domainpack.application.CreateDomainPackDraftFromPipelineResult;
-import com.init.domainpack.application.CreateDomainPackDraftFromPipelineUseCase;
 import com.init.pipelinejob.application.exception.PipelineJobAlreadyFinalizedException;
 import com.init.pipelinejob.application.exception.PipelineJobCallbackNotAllowedException;
 import com.init.pipelinejob.application.exception.PipelineJobNotFoundException;
@@ -27,19 +24,19 @@ public class ReceiveDomainPackDraftCallbackUseCase {
 
   private final PipelineJobRepository pipelineJobRepository;
   private final PipelineArtifactRepository pipelineArtifactRepository;
-  private final CreateDomainPackDraftFromPipelineUseCase createDomainPackDraftFromPipelineUseCase;
+  private final CreateDomainPackDraftPort createDomainPackDraftPort;
   private final ObjectMapper objectMapper;
   private final PipelineJobCallbackSupportService callbackSupportService;
 
   public ReceiveDomainPackDraftCallbackUseCase(
       PipelineJobRepository pipelineJobRepository,
       PipelineArtifactRepository pipelineArtifactRepository,
-      CreateDomainPackDraftFromPipelineUseCase createDomainPackDraftFromPipelineUseCase,
+      CreateDomainPackDraftPort createDomainPackDraftPort,
       ObjectMapper objectMapper,
       PipelineJobCallbackSupportService callbackSupportService) {
     this.pipelineJobRepository = pipelineJobRepository;
     this.pipelineArtifactRepository = pipelineArtifactRepository;
-    this.createDomainPackDraftFromPipelineUseCase = createDomainPackDraftFromPipelineUseCase;
+    this.createDomainPackDraftPort = createDomainPackDraftPort;
     this.objectMapper = objectMapper;
     this.callbackSupportService = callbackSupportService;
   }
@@ -104,9 +101,9 @@ public class ReceiveDomainPackDraftCallbackUseCase {
         PipelineArtifact.create(
             job.getId(), STAGE_NAME, ARTIFACT_TYPE, null, null, command.requestBodyJson(), now));
 
-    CreateDomainPackDraftFromPipelineResult draftResult =
-        createDomainPackDraftFromPipelineUseCase.execute(
-            new CreateDomainPackDraftFromPipelineCommand(
+    CreateDomainPackDraftPortResult draftResult =
+        createDomainPackDraftPort.execute(
+            new CreateDomainPackDraftPortCommand(
                 job.getWorkspaceId(),
                 command.packKey(),
                 command.packName(),
@@ -128,7 +125,7 @@ public class ReceiveDomainPackDraftCallbackUseCase {
         draftResult.sourcePipelineJobId());
   }
 
-  private String buildIntermediateSummaryJson(CreateDomainPackDraftFromPipelineResult result) {
+  private String buildIntermediateSummaryJson(CreateDomainPackDraftPortResult result) {
     ObjectNode summary = objectMapper.createObjectNode();
     summary.put("domainPackId", result.domainPackId());
     summary.put("domainPackVersionId", result.domainPackVersionId());

--- a/backend/src/main/java/com/init/pipelinejob/application/ReceiveIntentDraftCallbackCommand.java
+++ b/backend/src/main/java/com/init/pipelinejob/application/ReceiveIntentDraftCallbackCommand.java
@@ -1,6 +1,5 @@
 package com.init.pipelinejob.application;
 
-import com.init.domainpack.application.IntentDraft;
 import java.util.List;
 
 public record ReceiveIntentDraftCallbackCommand(
@@ -8,6 +7,6 @@ public record ReceiveIntentDraftCallbackCommand(
     String providedWebhookSecret,
     String externalEventId,
     Long domainPackVersionId,
-    List<IntentDraft> intents,
+    List<IntentDraftInput> intents,
     String requestHeadersJson,
     String requestBodyJson) {}

--- a/backend/src/main/java/com/init/pipelinejob/application/ReceiveIntentDraftCallbackUseCase.java
+++ b/backend/src/main/java/com/init/pipelinejob/application/ReceiveIntentDraftCallbackUseCase.java
@@ -3,9 +3,6 @@ package com.init.pipelinejob.application;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.init.domainpack.application.AddIntentsToDraftVersionCommand;
-import com.init.domainpack.application.AddIntentsToDraftVersionResult;
-import com.init.domainpack.application.AddIntentsToDraftVersionUseCase;
 import com.init.pipelinejob.application.exception.PipelineJobAlreadyFinalizedException;
 import com.init.pipelinejob.application.exception.PipelineJobCallbackNotAllowedException;
 import com.init.pipelinejob.application.exception.PipelineJobNotFoundException;
@@ -22,17 +19,17 @@ public class ReceiveIntentDraftCallbackUseCase {
   private static final String WEBHOOK_TYPE = "INTENT_DRAFT_CALLBACK";
 
   private final PipelineJobRepository pipelineJobRepository;
-  private final AddIntentsToDraftVersionUseCase addIntentsToDraftVersionUseCase;
+  private final AddIntentsToDraftVersionPort addIntentsToDraftVersionPort;
   private final ObjectMapper objectMapper;
   private final PipelineJobCallbackSupportService callbackSupportService;
 
   public ReceiveIntentDraftCallbackUseCase(
       PipelineJobRepository pipelineJobRepository,
-      AddIntentsToDraftVersionUseCase addIntentsToDraftVersionUseCase,
+      AddIntentsToDraftVersionPort addIntentsToDraftVersionPort,
       ObjectMapper objectMapper,
       PipelineJobCallbackSupportService callbackSupportService) {
     this.pipelineJobRepository = pipelineJobRepository;
-    this.addIntentsToDraftVersionUseCase = addIntentsToDraftVersionUseCase;
+    this.addIntentsToDraftVersionPort = addIntentsToDraftVersionPort;
     this.objectMapper = objectMapper;
     this.callbackSupportService = callbackSupportService;
   }
@@ -91,9 +88,10 @@ public class ReceiveIntentDraftCallbackUseCase {
           command.jobId(), job.getStatus(), WEBHOOK_TYPE);
     }
 
-    AddIntentsToDraftVersionResult intentResult =
-        addIntentsToDraftVersionUseCase.execute(
-            new AddIntentsToDraftVersionCommand(command.domainPackVersionId(), command.intents()));
+    AddIntentsToDraftVersionPortResult intentResult =
+        addIntentsToDraftVersionPort.execute(
+            new AddIntentsToDraftVersionPortCommand(
+                command.domainPackVersionId(), command.intents()));
 
     OffsetDateTime now = callbackSupportService.now();
     job.markAwaitingWorkflowCallback(
@@ -110,7 +108,7 @@ public class ReceiveIntentDraftCallbackUseCase {
         command.jobId());
   }
 
-  private String buildSuccessSummaryJson(AddIntentsToDraftVersionResult result) {
+  private String buildSuccessSummaryJson(AddIntentsToDraftVersionPortResult result) {
     ObjectNode summary = objectMapper.createObjectNode();
     summary.put("domainPackId", result.domainPackId());
     summary.put("domainPackVersionId", result.domainPackVersionId());

--- a/backend/src/main/java/com/init/pipelinejob/application/TriggerDomainPackGenerationUseCase.java
+++ b/backend/src/main/java/com/init/pipelinejob/application/TriggerDomainPackGenerationUseCase.java
@@ -6,10 +6,10 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.init.pipelinejob.application.exception.AirflowTriggerFailedException;
 import com.init.pipelinejob.application.exception.DatasetNotFoundException;
 import com.init.pipelinejob.application.exception.PipelineJobAlreadyRunningException;
+import com.init.pipelinejob.application.exception.PipelineJobWorkspaceAccessDeniedException;
+import com.init.pipelinejob.application.exception.PipelineJobWorkspaceNotFoundException;
 import com.init.pipelinejob.domain.model.PipelineJob;
 import com.init.pipelinejob.domain.repository.PipelineJobRepository;
-import com.init.workspace.application.exception.WorkspaceAccessDeniedException;
-import com.init.workspace.application.exception.WorkspaceNotFoundException;
 import java.time.Clock;
 import java.time.OffsetDateTime;
 import java.util.Set;
@@ -18,6 +18,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
 
+// NOTE: 선언적 @Transactional 대신 TransactionTemplate을 사용한다.
+// Airflow trigger(외부 호출)와 DB 상태 갱신을 2-phase로 interleave해야 하므로
+// 클래스 레벨 @Transactional(readOnly = true) 컨벤션의 의도적 예외.
 @Service
 public class TriggerDomainPackGenerationUseCase {
 
@@ -117,11 +120,12 @@ public class TriggerDomainPackGenerationUseCase {
 
   private void validateAccess(TriggerDomainPackGenerationCommand command) {
     if (!workspaceMembershipPort.existsById(command.workspaceId())) {
-      throw new WorkspaceNotFoundException("Workspace를 찾을 수 없습니다. id=" + command.workspaceId());
+      throw new PipelineJobWorkspaceNotFoundException(
+          "Workspace를 찾을 수 없습니다. id=" + command.workspaceId());
     }
     if (!workspaceMembershipPort.hasAnyRole(
         command.workspaceId(), command.userId(), ALLOWED_ROLES)) {
-      throw new WorkspaceAccessDeniedException("Domain Pack Generation 실행 권한이 없습니다.");
+      throw new PipelineJobWorkspaceAccessDeniedException("Domain Pack Generation 실행 권한이 없습니다.");
     }
     if (!datasetOwnershipPort.existsByIdAndWorkspaceId(
         command.datasetId(), command.workspaceId())) {

--- a/backend/src/main/java/com/init/pipelinejob/application/exception/PipelineJobWorkspaceAccessDeniedException.java
+++ b/backend/src/main/java/com/init/pipelinejob/application/exception/PipelineJobWorkspaceAccessDeniedException.java
@@ -1,0 +1,13 @@
+package com.init.pipelinejob.application.exception;
+
+import com.init.shared.application.exception.UnauthorizedException;
+
+// @SuppressWarnings("java:S110") — false positive: BC 경계 분리를 위한 의도적인 계층 구조
+// (INFO-002 per audit-report-inspection-backend-2026-05-08-1449, user-approved)
+@SuppressWarnings("java:S110")
+public class PipelineJobWorkspaceAccessDeniedException extends UnauthorizedException {
+
+  public PipelineJobWorkspaceAccessDeniedException(String message) {
+    super("WORKSPACE_ACCESS_DENIED", message);
+  }
+}

--- a/backend/src/main/java/com/init/pipelinejob/application/exception/PipelineJobWorkspaceNotFoundException.java
+++ b/backend/src/main/java/com/init/pipelinejob/application/exception/PipelineJobWorkspaceNotFoundException.java
@@ -1,0 +1,13 @@
+package com.init.pipelinejob.application.exception;
+
+import com.init.shared.application.exception.NotFoundException;
+
+// @SuppressWarnings("java:S110") — false positive: BC 경계 분리를 위한 의도적인 계층 구조
+// (INFO-002 per audit-report-inspection-backend-2026-05-08-1449, user-approved)
+@SuppressWarnings("java:S110")
+public class PipelineJobWorkspaceNotFoundException extends NotFoundException {
+
+  public PipelineJobWorkspaceNotFoundException(String message) {
+    super("WORKSPACE_NOT_FOUND", message);
+  }
+}

--- a/backend/src/main/java/com/init/pipelinejob/infrastructure/airflow/AirflowDomainPackGenerationTriggerAdapter.java
+++ b/backend/src/main/java/com/init/pipelinejob/infrastructure/airflow/AirflowDomainPackGenerationTriggerAdapter.java
@@ -31,6 +31,7 @@ public class AirflowDomainPackGenerationTriggerAdapter implements DomainPackGene
 
   private static final Logger log =
       LoggerFactory.getLogger(AirflowDomainPackGenerationTriggerAdapter.class);
+  private static final String LOG_FMT_DAG_RUN_ID = ", dagRunId={}";
 
   private final AirflowApiProperties properties;
   private final ObjectMapper objectMapper;
@@ -77,8 +78,8 @@ public class AirflowDomainPackGenerationTriggerAdapter implements DomainPackGene
       return triggerResult(dagId, dagRunId);
     } catch (ResourceAccessException ex) {
       log.warn(
-          "Airflow DAG run creation access failed, reconciling: pipelineJobId={}, dagId={},"
-              + " dagRunId={}",
+          "Airflow DAG run creation access failed, reconciling: pipelineJobId={}, dagId={}"
+              + LOG_FMT_DAG_RUN_ID,
           pipelineJobId,
           dagId,
           dagRunId,
@@ -87,7 +88,8 @@ public class AirflowDomainPackGenerationTriggerAdapter implements DomainPackGene
     } catch (RestClientResponseException ex) {
       if (ex.getStatusCode().isSameCodeAs(HttpStatus.CONFLICT)) {
         log.warn(
-            "Airflow DAG run already exists, reconciling: pipelineJobId={}, dagId={}, dagRunId={}",
+            "Airflow DAG run already exists, reconciling: pipelineJobId={}, dagId={}"
+                + LOG_FMT_DAG_RUN_ID,
             pipelineJobId,
             dagId,
             dagRunId,
@@ -104,8 +106,8 @@ public class AirflowDomainPackGenerationTriggerAdapter implements DomainPackGene
       throw new AirflowTriggerFailedException(pipelineJobId, ex);
     } catch (RestClientException ex) {
       log.warn(
-          "Airflow DAG run creation client failed, reconciling: pipelineJobId={}, dagId={},"
-              + " dagRunId={}",
+          "Airflow DAG run creation client failed, reconciling: pipelineJobId={}, dagId={}"
+              + LOG_FMT_DAG_RUN_ID,
           pipelineJobId,
           dagId,
           dagRunId,
@@ -113,8 +115,8 @@ public class AirflowDomainPackGenerationTriggerAdapter implements DomainPackGene
       return reconcileDagRunOrThrow(restClient, token, dagId, dagRunId, pipelineJobId, ex);
     } catch (HttpMessageConversionException ex) {
       log.error(
-          "Airflow DAG run creation response conversion failed: pipelineJobId={}, dagId={},"
-              + " dagRunId={}",
+          "Airflow DAG run creation response conversion failed: pipelineJobId={}, dagId={}"
+              + LOG_FMT_DAG_RUN_ID,
           pipelineJobId,
           dagId,
           dagRunId,
@@ -179,16 +181,8 @@ public class AirflowDomainPackGenerationTriggerAdapter implements DomainPackGene
       if (ex.getStatusCode().isSameCodeAs(HttpStatus.NOT_FOUND)) {
         return false;
       }
-      log.error(
-          "Airflow DAG run reconciliation failed: dagId={}, dagRunId={}, status={}",
-          dagId,
-          dagRunId,
-          ex.getStatusCode(),
-          ex);
       throw ex;
     } catch (RestClientException | HttpMessageConversionException ex) {
-      log.error(
-          "Airflow DAG run reconciliation failed: dagId={}, dagRunId={}", dagId, dagRunId, ex);
       throw ex;
     }
   }

--- a/backend/src/main/java/com/init/pipelinejob/presentation/PipelineIntentDraftCallbackController.java
+++ b/backend/src/main/java/com/init/pipelinejob/presentation/PipelineIntentDraftCallbackController.java
@@ -1,7 +1,7 @@
 package com.init.pipelinejob.presentation;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.init.domainpack.application.IntentDraft;
+import com.init.pipelinejob.application.IntentDraftInput;
 import com.init.pipelinejob.application.ReceiveDomainPackDraftCallbackCommand;
 import com.init.pipelinejob.application.ReceiveDomainPackDraftCallbackResult;
 import com.init.pipelinejob.application.ReceiveDomainPackDraftCallbackUseCase;
@@ -94,7 +94,7 @@ public class PipelineIntentDraftCallbackController {
                 request.intents().stream()
                     .map(
                         intent ->
-                            new IntentDraft(
+                            new IntentDraftInput(
                                 intent.intentCode(),
                                 intent.name(),
                                 intent.description(),

--- a/backend/src/test/java/com/init/pipelinejob/application/ReceiveDomainPackDraftCallbackUseCaseTest.java
+++ b/backend/src/test/java/com/init/pipelinejob/application/ReceiveDomainPackDraftCallbackUseCaseTest.java
@@ -9,8 +9,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.init.domainpack.application.CreateDomainPackDraftFromPipelineResult;
-import com.init.domainpack.application.CreateDomainPackDraftFromPipelineUseCase;
 import com.init.pipelinejob.application.exception.AirflowWebhookUnauthorizedException;
 import com.init.pipelinejob.application.exception.PipelineJobAlreadyFinalizedException;
 import com.init.pipelinejob.application.exception.PipelineJobCallbackNotAllowedException;
@@ -50,7 +48,7 @@ class ReceiveDomainPackDraftCallbackUseCaseTest {
   @Mock private WebhookReceiptRepository webhookReceiptRepository;
   @Mock private PipelineArtifactRepository pipelineArtifactRepository;
 
-  @Mock private CreateDomainPackDraftFromPipelineUseCase createDomainPackDraftFromPipelineUseCase;
+  @Mock private CreateDomainPackDraftPort createDomainPackDraftPort;
 
   @Mock private PlatformTransactionManager transactionManager;
 
@@ -69,7 +67,7 @@ class ReceiveDomainPackDraftCallbackUseCaseTest {
         new ReceiveDomainPackDraftCallbackUseCase(
             pipelineJobRepository,
             pipelineArtifactRepository,
-            createDomainPackDraftFromPipelineUseCase,
+            createDomainPackDraftPort,
             new ObjectMapper(),
             new PipelineJobCallbackSupportService(
                 pipelineJobRepository,
@@ -89,9 +87,8 @@ class ReceiveDomainPackDraftCallbackUseCaseTest {
     given(pipelineJobRepository.findById(11L)).willReturn(Optional.of(job), Optional.of(job));
     given(webhookReceiptRepository.saveAndFlush(any()))
         .willAnswer(invocation -> invocation.getArgument(0));
-    given(createDomainPackDraftFromPipelineUseCase.execute(any()))
-        .willReturn(
-            new CreateDomainPackDraftFromPipelineResult(7L, 101L, 3, "refund-pack", true, 11L));
+    given(createDomainPackDraftPort.execute(any()))
+        .willReturn(new CreateDomainPackDraftPortResult(7L, 101L, 3, "refund-pack", true, 11L));
 
     ReceiveDomainPackDraftCallbackResult result = useCase.execute(validCommand());
 
@@ -119,7 +116,7 @@ class ReceiveDomainPackDraftCallbackUseCaseTest {
     ReceiveDomainPackDraftCallbackResult result = useCase.execute(validCommand());
 
     assertThat(result.status()).isEqualTo("DUPLICATE_IGNORED");
-    verify(createDomainPackDraftFromPipelineUseCase, never()).execute(any());
+    verify(createDomainPackDraftPort, never()).execute(any());
   }
 
   @Test
@@ -132,7 +129,7 @@ class ReceiveDomainPackDraftCallbackUseCaseTest {
     assertThatThrownBy(() -> useCase.execute(validCommand()))
         .isInstanceOf(WebhookReceiptTypeConflictException.class);
 
-    verify(createDomainPackDraftFromPipelineUseCase, never()).execute(any());
+    verify(createDomainPackDraftPort, never()).execute(any());
   }
 
   @Test
@@ -149,7 +146,7 @@ class ReceiveDomainPackDraftCallbackUseCaseTest {
     assertThatThrownBy(() -> useCase.execute(validCommand()))
         .isInstanceOf(WebhookReceiptTypeConflictException.class);
 
-    verify(createDomainPackDraftFromPipelineUseCase, never()).execute(any());
+    verify(createDomainPackDraftPort, never()).execute(any());
   }
 
   @Test
@@ -167,7 +164,7 @@ class ReceiveDomainPackDraftCallbackUseCaseTest {
     ReceiveDomainPackDraftCallbackResult result = useCase.execute(validCommand());
 
     assertThat(result.status()).isEqualTo("DUPLICATE_IGNORED");
-    verify(createDomainPackDraftFromPipelineUseCase, never()).execute(any());
+    verify(createDomainPackDraftPort, never()).execute(any());
   }
 
   @Test
@@ -181,9 +178,8 @@ class ReceiveDomainPackDraftCallbackUseCaseTest {
     given(pipelineJobRepository.findById(11L)).willReturn(Optional.of(job), Optional.of(job));
     given(webhookReceiptRepository.saveAndFlush(any()))
         .willAnswer(invocation -> invocation.getArgument(0));
-    given(createDomainPackDraftFromPipelineUseCase.execute(any()))
-        .willReturn(
-            new CreateDomainPackDraftFromPipelineResult(7L, 101L, 3, "refund-pack", true, 11L));
+    given(createDomainPackDraftPort.execute(any()))
+        .willReturn(new CreateDomainPackDraftPortResult(7L, 101L, 3, "refund-pack", true, 11L));
 
     ReceiveDomainPackDraftCallbackResult result = useCase.execute(validCommand());
 
@@ -201,9 +197,8 @@ class ReceiveDomainPackDraftCallbackUseCaseTest {
     given(pipelineJobRepository.findById(11L)).willReturn(Optional.of(job), Optional.of(job));
     given(webhookReceiptRepository.saveAndFlush(any()))
         .willAnswer(invocation -> invocation.getArgument(0));
-    given(createDomainPackDraftFromPipelineUseCase.execute(any()))
-        .willReturn(
-            new CreateDomainPackDraftFromPipelineResult(7L, 101L, 3, "refund-pack", true, 11L));
+    given(createDomainPackDraftPort.execute(any()))
+        .willReturn(new CreateDomainPackDraftPortResult(7L, 101L, 3, "refund-pack", true, 11L));
     given(pipelineJobRepository.saveAndFlush(any()))
         .willThrow(new ObjectOptimisticLockingFailureException(PipelineJob.class, 11L));
 

--- a/backend/src/test/java/com/init/pipelinejob/application/ReceiveIntentDraftCallbackUseCaseTest.java
+++ b/backend/src/test/java/com/init/pipelinejob/application/ReceiveIntentDraftCallbackUseCaseTest.java
@@ -9,9 +9,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.init.domainpack.application.AddIntentsToDraftVersionResult;
-import com.init.domainpack.application.AddIntentsToDraftVersionUseCase;
-import com.init.domainpack.application.IntentDraft;
 import com.init.domainpack.application.exception.DomainPackDraftRequestInvalidException;
 import com.init.pipelinejob.application.exception.AirflowWebhookUnauthorizedException;
 import com.init.pipelinejob.application.exception.PipelineJobAlreadyFinalizedException;
@@ -50,7 +47,7 @@ class ReceiveIntentDraftCallbackUseCaseTest {
 
   @Mock private PipelineJobRepository pipelineJobRepository;
   @Mock private WebhookReceiptRepository webhookReceiptRepository;
-  @Mock private AddIntentsToDraftVersionUseCase addIntentsToDraftVersionUseCase;
+  @Mock private AddIntentsToDraftVersionPort addIntentsToDraftVersionPort;
   @Mock private PlatformTransactionManager transactionManager;
 
   private ReceiveIntentDraftCallbackUseCase useCase;
@@ -67,7 +64,7 @@ class ReceiveIntentDraftCallbackUseCaseTest {
     useCase =
         new ReceiveIntentDraftCallbackUseCase(
             pipelineJobRepository,
-            addIntentsToDraftVersionUseCase,
+            addIntentsToDraftVersionPort,
             new ObjectMapper(),
             new PipelineJobCallbackSupportService(
                 pipelineJobRepository,
@@ -87,8 +84,8 @@ class ReceiveIntentDraftCallbackUseCaseTest {
     given(pipelineJobRepository.findById(11L)).willReturn(Optional.of(job), Optional.of(job));
     given(webhookReceiptRepository.saveAndFlush(any()))
         .willAnswer(invocation -> invocation.getArgument(0));
-    given(addIntentsToDraftVersionUseCase.execute(any()))
-        .willReturn(new AddIntentsToDraftVersionResult(101L, 7L, 2, 0, 5));
+    given(addIntentsToDraftVersionPort.execute(any()))
+        .willReturn(new AddIntentsToDraftVersionPortResult(101L, 7L, 2, 0, 5));
 
     ReceiveIntentDraftCallbackResult result = useCase.execute(validCommand());
 
@@ -115,7 +112,7 @@ class ReceiveIntentDraftCallbackUseCaseTest {
     ReceiveIntentDraftCallbackResult result = useCase.execute(validCommand());
 
     assertThat(result.status()).isEqualTo("DUPLICATE_IGNORED");
-    verify(addIntentsToDraftVersionUseCase, never()).execute(any());
+    verify(addIntentsToDraftVersionPort, never()).execute(any());
   }
 
   @Test
@@ -127,7 +124,7 @@ class ReceiveIntentDraftCallbackUseCaseTest {
     assertThatThrownBy(() -> useCase.execute(validCommand()))
         .isInstanceOf(WebhookReceiptTypeConflictException.class);
 
-    verify(addIntentsToDraftVersionUseCase, never()).execute(any());
+    verify(addIntentsToDraftVersionPort, never()).execute(any());
   }
 
   @Test
@@ -144,7 +141,7 @@ class ReceiveIntentDraftCallbackUseCaseTest {
     assertThatThrownBy(() -> useCase.execute(validCommand()))
         .isInstanceOf(WebhookReceiptTypeConflictException.class);
 
-    verify(addIntentsToDraftVersionUseCase, never()).execute(any());
+    verify(addIntentsToDraftVersionPort, never()).execute(any());
   }
 
   @Test
@@ -162,7 +159,7 @@ class ReceiveIntentDraftCallbackUseCaseTest {
     ReceiveIntentDraftCallbackResult result = useCase.execute(validCommand());
 
     assertThat(result.status()).isEqualTo("DUPLICATE_IGNORED");
-    verify(addIntentsToDraftVersionUseCase, never()).execute(any());
+    verify(addIntentsToDraftVersionPort, never()).execute(any());
   }
 
   @Test
@@ -176,8 +173,8 @@ class ReceiveIntentDraftCallbackUseCaseTest {
     given(pipelineJobRepository.findById(11L)).willReturn(Optional.of(job), Optional.of(job));
     given(webhookReceiptRepository.saveAndFlush(any()))
         .willAnswer(invocation -> invocation.getArgument(0));
-    given(addIntentsToDraftVersionUseCase.execute(any()))
-        .willReturn(new AddIntentsToDraftVersionResult(101L, 7L, 1, 0, 3));
+    given(addIntentsToDraftVersionPort.execute(any()))
+        .willReturn(new AddIntentsToDraftVersionPortResult(101L, 7L, 1, 0, 3));
 
     ReceiveIntentDraftCallbackResult result = useCase.execute(validCommand());
 
@@ -195,8 +192,8 @@ class ReceiveIntentDraftCallbackUseCaseTest {
     given(pipelineJobRepository.findById(11L)).willReturn(Optional.of(job), Optional.of(job));
     given(webhookReceiptRepository.saveAndFlush(any()))
         .willAnswer(invocation -> invocation.getArgument(0));
-    given(addIntentsToDraftVersionUseCase.execute(any()))
-        .willReturn(new AddIntentsToDraftVersionResult(101L, 7L, 2, 0, 5));
+    given(addIntentsToDraftVersionPort.execute(any()))
+        .willReturn(new AddIntentsToDraftVersionPortResult(101L, 7L, 2, 0, 5));
     given(pipelineJobRepository.saveAndFlush(any()))
         .willThrow(new ObjectOptimisticLockingFailureException(PipelineJob.class, 11L));
 
@@ -274,7 +271,7 @@ class ReceiveIntentDraftCallbackUseCaseTest {
         .willReturn(Optional.of(job), Optional.of(job), Optional.of(job));
     given(webhookReceiptRepository.saveAndFlush(any()))
         .willAnswer(invocation -> invocation.getArgument(0));
-    given(addIntentsToDraftVersionUseCase.execute(any()))
+    given(addIntentsToDraftVersionPort.execute(any()))
         .willThrow(new DomainPackDraftRequestInvalidException("중복된 intentCode 값이 존재합니다."));
 
     assertThatThrownBy(() -> useCase.execute(validCommand()))
@@ -291,7 +288,8 @@ class ReceiveIntentDraftCallbackUseCaseTest {
         "secret-123",
         "evt-1",
         101L,
-        List.of(new IntentDraft("refund_request", "환불 요청", null, 1, null, null, null, null, null)),
+        List.of(
+            new IntentDraftInput("refund_request", "환불 요청", null, 1, null, null, null, null, null)),
         "{\"content-type\":\"application/json\"}",
         "{\"domainPackVersionId\":101}");
   }

--- a/backend/src/test/java/com/init/pipelinejob/application/TriggerDomainPackGenerationUseCaseTest.java
+++ b/backend/src/test/java/com/init/pipelinejob/application/TriggerDomainPackGenerationUseCaseTest.java
@@ -12,9 +12,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.init.pipelinejob.application.exception.AirflowConfigurationInvalidException;
 import com.init.pipelinejob.application.exception.AirflowTriggerFailedException;
 import com.init.pipelinejob.application.exception.PipelineJobAlreadyRunningException;
+import com.init.pipelinejob.application.exception.PipelineJobWorkspaceAccessDeniedException;
 import com.init.pipelinejob.domain.model.PipelineJob;
 import com.init.pipelinejob.domain.repository.PipelineJobRepository;
-import com.init.workspace.application.exception.WorkspaceAccessDeniedException;
 import java.lang.reflect.Constructor;
 import java.time.Clock;
 import java.time.Instant;
@@ -113,7 +113,7 @@ class TriggerDomainPackGenerationUseCaseTest {
     given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(false);
 
     assertThatThrownBy(() -> useCase.execute(command()))
-        .isInstanceOf(WorkspaceAccessDeniedException.class);
+        .isInstanceOf(PipelineJobWorkspaceAccessDeniedException.class);
 
     verify(triggerPort, never()).dagId();
   }


### PR DESCRIPTION
# Audit Report — Backend Stack Inspection

**Mode**: Inspection
**Date**: 2026-05-08
**Branch**: chore/refactor-be-issues
**Scope**: backend/ — all Java source files under com.init.*
**Diff Base**: N/A (Inspection mode — full codebase)
**Rules Applied**: java.md, error-handling.md, testing.md, module-creation.md, principles.md, code-review.md
**PR Number**: N/A
**Result**: FAIL

---

## Referenced Artifacts

- sonar-pseudo-check-report: `.handoff/inspection/sonar-inspection-report-backend-2026-05-07-2345.json`
  (verdict=PARTIAL, 349 total issues, 50 shown, truncated=true)

---

## Sonar Pseudo Check Summary

- sonar-pseudo-check verdict: PARTIAL
- Files analyzed / candidate files: N/A (full project scan)
- Sonar CRITICAL CODE_SMELL issues (in shown 50): 1 (SONAR-BE-008, mapped to Warning per DRY rule)
- Sonar MAJOR VULNERABILITY issues: 1 (SONAR-BE-023 — dependency lock file absent)
- Note: Sonar dataset truncated (50/349). Full source of truth: SonarQube Cloud CI Quality Gate.
- Not covered by this pseudo-check: duplication %, security_hotspots_reviewed
- Final source of truth: SonarQube Cloud CI Quality Gate (this audit does not replace it)

---

## Summary

| Severity | Count |
|----------|-------|
| Critical | 3     |
| Warning  | 7     |
| Info     | 2     |
| Ignored  | 0     |

---

## Violations

### V-001 [Critical] pipelinejob BC application layer directly couples to domainpack BC application use case (DomainPack draft callback)

- **Type**: Rule Violation
- **Rule**: DDD Layer Violations — Bounded context cross-dependency
- **File**: `backend/src/main/java/com/init/pipelinejob/application/ReceiveDomainPackDraftCallbackUseCase.java:6-8`
- **Source**: Code inspection
- **Description**: `ReceiveDomainPackDraftCallbackUseCase` (pipelinejob BC) directly imports and injects `CreateDomainPackDraftFromPipelineUseCase`, `CreateDomainPackDraftFromPipelineCommand`, and `CreateDomainPackDraftFromPipelineResult` from `com.init.domainpack.application`. This is a direct application-layer cross-BC dependency with no Port interface abstraction.
- **Expected**: pipelinejob BC should communicate with domainpack BC through a Port interface defined in `pipelinejob.application` (e.g., `CreateDomainPackDraftPort`), with an adapter in `domainpack.infrastructure` implementing it — the same pattern already applied for `AddWorkflowDraftPort` / `AddWorkflowDraftPortAdapter`.
- **Actual**: `CreateDomainPackDraftFromPipelineUseCase` is injected directly as a Spring bean from domainpack BC into pipelinejob application layer. Any change to domainpack's `CreateDomainPackDraftFromPipelineUseCase` signature propagates directly into pipelinejob's compile boundary.
- **Requires User Decision**: No
- **Fix Direction**: Introduce `CreateDomainPackDraftPort` interface in `pipelinejob.application` with a `CreateDomainPackDraftPortCommand`/`Result`. Add `CreateDomainPackDraftPortAdapter` in `domainpack.infrastructure` implementing the port by delegating to `CreateDomainPackDraftFromPipelineUseCase`. Update `ReceiveDomainPackDraftCallbackUseCase` to depend on the port.
- **Fix Result**: Fixed (approved) — `CreateDomainPackDraftPort` / `CreateDomainPackDraftPortCommand` / `CreateDomainPackDraftPortResult` 신설; `CreateDomainPackDraftPortAdapter` (domainpack.infrastructure) 신설; `ReceiveDomainPackDraftCallbackUseCase` Port 의존으로 변경; 테스트 mock 교체. `CreateDomainPackDraftPortCommand/Result` sonar.cpd.exclusions 추가.

---

### V-002 [Critical] pipelinejob BC application layer directly couples to domainpack BC application use case (intent draft callback)

- **Type**: Rule Violation
- **Rule**: DDD Layer Violations — Bounded context cross-dependency
- **File**: `backend/src/main/java/com/init/pipelinejob/application/ReceiveIntentDraftCallbackUseCase.java:6-8`
- **Source**: Code inspection
- **Description**: `ReceiveIntentDraftCallbackUseCase` (pipelinejob BC) directly imports and injects `AddIntentsToDraftVersionUseCase`, `AddIntentsToDraftVersionCommand`, and `AddIntentsToDraftVersionResult` from `com.init.domainpack.application`. Same pattern as V-001 but for the intent draft callback path.
- **Expected**: A Port interface (`AddIntentsToDraftVersionPort`) in pipelinejob.application, with an adapter in domainpack.infrastructure.
- **Actual**: `AddIntentsToDraftVersionUseCase` (domainpack) injected directly into pipelinejob application. `ReceiveWorkflowDraftCallbackUseCase` in the same BC correctly uses `AddWorkflowDraftPort`, making this an inconsistency within the same BC.
- **Requires User Decision**: No
- **Fix Direction**: Create `AddIntentsToDraftVersionPort` in `pipelinejob.application` + command/result records. Add `AddIntentsToDraftVersionPortAdapter` in `domainpack.infrastructure`. Update `ReceiveIntentDraftCallbackUseCase` to use the port. Remove the `IntentDraft` cross-BC import from `ReceiveIntentDraftCallbackCommand` (see V-003).
- **Fix Result**: Fixed (approved) — `AddIntentsToDraftVersionPort` / `AddIntentsToDraftVersionPortCommand` / `AddIntentsToDraftVersionPortResult` 신설; `AddIntentsToDraftVersionPortAdapter` (domainpack.infrastructure) 신설; `ReceiveIntentDraftCallbackUseCase` Port 의존으로 변경; 테스트 mock 교체. `AddIntentsToDraftVersionPortCommand/Result` sonar.cpd.exclusions 추가.

---

### V-003 [Critical] pipelinejob application command DTO embeds domainpack application data type

- **Type**: Rule Violation
- **Rule**: DDD Layer Violations — Bounded context cross-dependency
- **File**: `backend/src/main/java/com/init/pipelinejob/application/ReceiveIntentDraftCallbackCommand.java:3`
- **Source**: Code inspection
- **Description**: `ReceiveIntentDraftCallbackCommand` (pipelinejob BC) imports `com.init.domainpack.application.IntentDraft` and uses it as a field type. This embeds a domainpack data model in a pipelinejob command — the command is the BC boundary contract.
- **Expected**: Either (a) a local `IntentDraftInput` record defined in `pipelinejob.application` that mirrors the required fields, or (b) the intent data embedded as part of the port command introduced in V-002.
- **Actual**: `ReceiveIntentDraftCallbackCommand` field `List<IntentDraft> intents` is typed as domainpack's `IntentDraft`, making the pipelinejob command structurally coupled to domainpack's internal data model.
- **Requires User Decision**: No
- **Fix Direction**: Define a `IntentDraftInput` record (or similar) in `pipelinejob.application` that carries the fields pipelinejob needs. The adapter in `domainpack.infrastructure` converts it to `IntentDraft` before calling the use case.
- **Fix Result**: Fixed (approved) — `IntentDraftInput` 레코드 신설; `ReceiveIntentDraftCallbackCommand.intents` 타입을 `List<IntentDraftInput>`으로 교체; `AddIntentsToDraftVersionPortAdapter`에서 변환 처리; `PipelineIntentDraftCallbackController` 매핑 업데이트; 테스트 수정. `IntentDraftInput` sonar.cpd.exclusions 추가.

---

### V-004 [Warning] pipelinejob application throws workspace BC exception types

- **Type**: Rule Violation
- **Rule**: DDD Layer Violations — Bounded context cross-dependency (application-layer exception coupling)
- **File**: `backend/src/main/java/com/init/pipelinejob/application/TriggerDomainPackGenerationUseCase.java:11-12,120,124`
- **Source**: Code inspection
- **Description**: `TriggerDomainPackGenerationUseCase` correctly uses `WorkspaceMembershipPort` (Port interface) for workspace existence/role checks but then throws `WorkspaceNotFoundException` and `WorkspaceAccessDeniedException` from `com.init.workspace.application.exception`. The use of Port interfaces decouples runtime dependencies, but the exception type import introduces a compile-time cross-BC dependency.
- **Expected**: pipelinejob application should throw its own exceptions (e.g., `PipelineJobWorkspaceNotFoundException`, `PipelineJobWorkspaceAccessDeniedException`) that extend the shared base classes (`NotFoundException`, `UnauthorizedException`), or the workspace exceptions should be moved to `shared`.
- **Actual**: `WorkspaceNotFoundException` and `WorkspaceAccessDeniedException` are instantiated and thrown directly from pipelinejob's application layer. These exception classes live in `workspace.application.exception`.
- **Requires User Decision**: Yes — options: (a) duplicate exception types in pipelinejob.application.exception (simplest), (b) move workspace exceptions to shared (broader change), (c) accept the cross-BC exception coupling as a pragmatic decision given exceptions are pure data and extend shared base types.
- **Fix Direction**: If (a): add `PipelineJobWorkspaceNotFoundException` and `PipelineJobWorkspaceAccessDeniedException` to pipelinejob.application.exception. If (b): move affected exception classes to `shared.application.exception` with generic naming.
- **Fix Result**: Fixed (approved) — Option A 적용. `PipelineJobWorkspaceNotFoundException` / `PipelineJobWorkspaceAccessDeniedException` 신설 (`@SuppressWarnings("java:S110")` — INFO-002 의도적 계층 구조, user-approved); `TriggerDomainPackGenerationUseCase.validateAccess()` 업데이트; `TriggerDomainPackGenerationUseCaseTest` exception 타입 교체.

---

### V-005 [Warning] Services with write-only operations use class-level @Transactional (not readOnly) without readOnly default

- **Type**: Rule Violation
- **Rule**: java.md — Transactional patterns (class-level `@Transactional(readOnly = true)` as default)
- **File**: Multiple:
  - `backend/src/main/java/com/init/domainpack/application/AddIntentsToDraftVersionUseCase.java:12`
  - `backend/src/main/java/com/init/domainpack/application/AddWorkflowDraftToVersionUseCase.java:7`
  - `backend/src/main/java/com/init/domainpack/application/CreateDomainPackDraftFromPipelineUseCase.java:13`
  - `backend/src/main/java/com/init/domainpack/application/CreateDomainPackDraftUseCase.java:15`
  - `backend/src/main/java/com/init/domainpack/application/DomainPackDraftPersistenceService.java:38`
- **Source**: Code inspection
- **Description**: These five classes are exclusively write-oriented use cases / persistence services. They declare `@Transactional` at class level without `readOnly = true`. The project convention (java.md) requires `@Transactional(readOnly = true)` as the class-level default, with individual write methods overriding to `@Transactional`. For classes that have no read methods, this is technically a no-op difference, but violates the stated convention.
- **Expected**: Class-level annotation should be `@Transactional(readOnly = true)` even if all methods are write methods, to be consistent with project convention and to ensure new read methods added later are correctly read-only by default.
- **Actual**: Class-level `@Transactional` (no `readOnly = true` attribute).
- **Requires User Decision**: No (convention violation, safe mechanical fix)
- **Fix Direction**: Change `@Transactional` to `@Transactional(readOnly = true)` at class level. Since all existing methods are writes, also add `@Transactional` (no readOnly) on each `execute()`/`persist*()` method explicitly.
- **Fix Result**: Fixed (auto) — 5개 클래스 클래스 레벨 `@Transactional(readOnly = true)` 적용; 각 write 메서드(`execute()` / `persist*()`)에 `@Transactional` 추가.

---

### V-006 [Warning] pipelinejob services use TransactionTemplate with no class-level @Transactional

- **Type**: Rule Violation
- **Rule**: java.md — Transactional patterns (Warning severity)
- **File**: Multiple:
  - `backend/src/main/java/com/init/pipelinejob/application/TriggerDomainPackGenerationUseCase.java`
  - `backend/src/main/java/com/init/pipelinejob/application/PipelineJobCallbackSupportService.java`
  - `backend/src/main/java/com/init/corpus/application/RawDatasetUploadService.java`
- **Source**: Code inspection
- **Description**: These services are `@Service` classes that manage their own transactions via `TransactionTemplate` (programmatic transactions) rather than declarative `@Transactional`. This pattern is intentional for fine-grained two-phase commit control (trigger external system, then update DB state), but the classes do not carry any class-level `@Transactional(readOnly = true)` annotation, which deviates from project convention.
- **Expected**: Convention requires `@Transactional(readOnly = true)` at class level. These classes bypass this with programmatic `TransactionTemplate` which is architecturally justified (cannot use declarative transactions here due to external side-effects interleaved with DB operations).
- **Actual**: No `@Transactional` annotation at all on these classes.
- **Requires User Decision**: Yes — the programmatic transaction pattern is intentional. Consider: (a) add a comment explaining why class-level `@Transactional` is intentionally absent, (b) accept as a documented exception to the convention, or (c) explore `TransactionSynchronizationManager` approach.
- **Fix Direction**: Add a comment (e.g., `// TransactionTemplate used instead of @Transactional to interleave external calls — see spec`) at the class level to document the intentional deviation.
- **Fix Result**: Fixed (approved) — Option A 적용. 3개 클래스(`TriggerDomainPackGenerationUseCase`, `PipelineJobCallbackSupportService`, `RawDatasetUploadService`)에 클래스 레벨 TransactionTemplate 사용 이유 주석 추가.

---

### V-007 [Warning] AirflowDomainPackGenerationTriggerAdapter — log-and-rethrow without wrapping (Sonar S2139)

- **Type**: Sonar-flagged Warning
- **Rule**: error-handling.md — exception log-and-rethrow pattern
- **File**: `backend/src/main/java/com/init/pipelinejob/infrastructure/airflow/AirflowDomainPackGenerationTriggerAdapter.java:178-192`
- **Source**: SONAR-BE-009/010
- **Description**: In `dagRunExists()`, both `RestClientResponseException` (line 178) and `RestClientException | HttpMessageConversionException` (line 189) are logged at ERROR level and then re-thrown as-is. Sonar S2139 flags this as potentially ambiguous log-and-rethrow: the caller may log the exception again, resulting in duplicate log entries.
- **Expected**: Either log-then-throw (with the understanding that the caller won't log again) or wrap-then-throw (new exception wraps original, only one logging site). The project's error-handling.md prefers wrapping at infrastructure boundaries.
- **Actual**: Raw exception re-thrown after logging. The catch-and-rethrow in `reconcileDagRunOrThrow()` does wrap to `AirflowTriggerFailedException`, but the intermediate `dagRunExists()` method logs-then-rethrows.
- **Requires User Decision**: No (Sonar-confirmed pattern issue)
- **Fix Direction**: In `dagRunExists()`, remove the `log.error()` calls and let the wrapping in `reconcileDagRunOrThrow()` handle logging at the right abstraction level, or wrap at `dagRunExists()` and remove the re-throw of raw exception type.
- **Fix Result**: Fixed (auto) — `dagRunExists()`의 두 catch 블록에서 `log.error()` 호출 제거. `reconcileDagRunOrThrow()`가 `AirflowTriggerFailedException`으로 래핑하므로 단일 로깅 지점 유지.

---

### V-008 [Warning] DomainPackDraftPersistenceService.validateDraftPayload has 8 parameters (Sonar S107)

- **Type**: Sonar-flagged Warning
- **Rule**: principles.md — KISS; Sonar java:S107
- **File**: `backend/src/main/java/com/init/domainpack/application/DomainPackDraftPersistenceService.java:436`
- **Source**: SONAR-BE-043
- **Description**: `validateDraftPayload(List<IntentDraft>, List<SlotInput>, List<IntentSlotBindingInput>, List<PolicyInput>, List<RiskInput>, List<WorkflowInput>, List<IntentWorkflowBindingInput>, Set<String>)` has 8 parameters, exceeding the Sonar S107 threshold (default 7). This is a private helper method but is symptomatic of a large input struct.
- **Expected**: Parameters grouped into a meaningful value object (e.g., `DraftPayload` record containing the 7 list fields) reducing the method signature to 2 parameters.
- **Actual**: 8-parameter private method.
- **Requires User Decision**: No
- **Fix Direction**: Introduce a `DraftPayload` record/class in the application layer grouping the 7 list parameters. `validateDraftPayload` takes `(DraftPayload payload, Set<String> allowedPolicyCodes)`.
- **Fix Result**: Fixed (auto) — private `DraftPayload` 레코드 신설 (7개 list 파라미터 묶음); `validateDraftPayload` 시그니처를 `(DraftPayload, Set<String>)`으로 변경; 호출부 `persist()` 업데이트.

---

### V-009 [Warning] AirflowDomainPackGenerationTriggerAdapter — log literal "dagRunId={}" duplicated 3+ times (Sonar S1192)

- **Type**: Sonar-flagged Warning
- **Rule**: principles.md — DRY; Sonar java:S1192
- **File**: `backend/src/main/java/com/init/pipelinejob/infrastructure/airflow/AirflowDomainPackGenerationTriggerAdapter.java:81`
- **Source**: SONAR-BE-008
- **Description**: The SLF4J format literal string `" dagRunId={}"` (as part of multi-line log message strings) appears 3+ times in this file, triggering Sonar's string duplication rule. While log message strings are not extractable to constants without losing SLF4J format semantics in a readable way, consolidating repeated parameter patterns is possible.
- **Expected**: Repeated log format fragments extracted to a constant, or the repeated log statements refactored into a helper method.
- **Actual**: Literal substring duplicated across 7+ log.warn/log.error calls.
- **Requires User Decision**: No
- **Fix Direction**: Minor — extract repeated log format substrings to private static final String constants (e.g., `LOG_DAG_RUN_ID = ", dagRunId={}"`) or create a private `logAirflowError(String message, long jobId, String dagId, String dagRunId, Exception ex)` helper method.
- **Fix Result**: Fixed (auto) — `private static final String LOG_FMT_DAG_RUN_ID = ", dagRunId={}"` 상수 추출; `trigger()` 메서드의 4개 로그 문자열 연결에 상수 적용.

---

## Info

### INFO-001 Sonar S5778 (lambda in assertThrows) — test code only

- **Files**: Multiple test files (Sonar flagged several S5778 MAJOR findings in test code)
- **Note**: Sonar S5778 warns that lambdas in `assertThrows` may not correctly capture the exception. These are test-only issues; they do not affect production behavior. Mapped to Info (not a project rule violation).

### INFO-002 Sonar S110 (exception class hierarchy depth) — intentional

- **Note**: Multiple S110 violations for deep exception hierarchies. The project intentionally uses a deep exception hierarchy (BusinessException → NotFoundException → XxxNotFoundException etc.). Mapped to Info; not a project-rule violation.

---

## Cross-Cutting Findings

### CCF-001 [Warning] catch (Exception ...) in corpus services — compensating transaction pattern (intentional)

- **Whitelist Category**: Foundational principles / error-handling.md documented exception
- **Cited Rule**: error-handling.md — Generic Exception catch; java.md anti-pattern #5
- **File**: 
  - `backend/src/main/java/com/init/corpus/application/RawFileUploadService.java:89,129,132`
  - `backend/src/main/java/com/init/corpus/application/RawDatasetUploadService.java:128`
- **Affected Stacks**: backend
- **Description**: `RawFileUploadService.upload()` and `RawDatasetUploadService.upload()` use `catch (Exception ...)` for S3 orphan cleanup compensation. `RawFileUploadService` includes an inline comment explicitly citing `error-handling.md` exception and spec/114 U-05. `RawDatasetUploadService` catches `Exception compensationEx` in the compensation rollback path — logged with `log.warn(...)` and the original exception re-thrown. These patterns are intentional and documented. However, the outer `catch (RuntimeException e)` in `RawDatasetUploadService:121` (not `Exception`) is narrower and correct. The `catch (Exception compensationEx)` at line 128 is a broader catch in the compensation block — acceptable because any exception in the compensation path must not shadow the original error.
- **Assessment**: Intentional per documented exception. No action required unless project policy changes. The inline documentation in `RawFileUploadService` (line 89) should also be added to `RawDatasetUploadService:128` for consistency.

### CCF-002 [Warning] No Gradle dependency lock file (Sonar S8569 supply chain hygiene)

- **Whitelist Category**: CI hygiene / supply chain hygiene
- **Cited Rule**: Sonar MAJOR VULNERABILITY text:S8569; SONAR-BE-023
- **File**: `backend/build.gradle.kts`
- **Affected Stacks**: backend
- **Description**: The backend project has no `gradle.lockfile` or `verification-metadata.xml`. Without dependency locking, builds are not reproducible and supply chain attacks (dependency substitution) are possible. This is a Sonar MAJOR VULNERABILITY finding.
- **Assessment**: Warning severity (supply chain hygiene, not a project-defined Critical rule). Addressed in CI by pinning versions, but no lockfile enforces transitive dependency integrity.
- **Fix Direction**: Run `./gradlew dependencies --write-locks` to generate `gradle.lockfile`. Commit and check-in. Enable `dependencyLocking { lockAllConfigurations() }` in `build.gradle.kts`.

### CCF-003 [Info] PipelineJobWorkspaceMembershipAdapter uses workspace domain repositories directly — expected ACL pattern

- **Whitelist Category**: Foundational principles
- **Cited Rule**: DDD Layer — infrastructure adapters crossing BC boundaries is expected
- **File**: `backend/src/main/java/com/init/pipelinejob/infrastructure/persistence/PipelineJobWorkspaceMembershipAdapter.java:4-6`
- **Affected Stacks**: backend
- **Description**: This infrastructure adapter implements `WorkspaceMembershipPort` (pipelinejob application Port interface) by directly using `workspace.domain.WorkspaceMember`, `workspace.domain.repository.WorkspaceMemberRepository`, and `workspace.domain.repository.WorkspaceRepository`. This is the Anti-Corruption Layer (ACL) pattern: the Port is defined in pipelinejob.application, the adapter in pipelinejob.infrastructure wires workspace domain repositories, the application layer only sees the Port. This is architecturally correct and consistent with how `AddWorkflowDraftPortAdapter` works in the opposite direction.
- **Assessment**: No violation. Documented here for completeness.

---

## Safe Fix Candidates

The following violations are `Requires User Decision: No` and can be fixed directly without confirmation:

| V-ID  | Description | File(s) |
|-------|-------------|---------|
| V-001 | Introduce `CreateDomainPackDraftPort` + adapter | `ReceiveDomainPackDraftCallbackUseCase.java` |
| V-002 | Introduce `AddIntentsToDraftVersionPort` + adapter | `ReceiveIntentDraftCallbackUseCase.java` |
| V-003 | Replace `IntentDraft` with local `IntentDraftInput` in pipelinejob command | `ReceiveIntentDraftCallbackCommand.java` |
| V-005 | Add `@Transactional(readOnly = true)` at class level + `@Transactional` on write methods | 5 use case files |
| V-007 | Remove log-and-rethrow ambiguity in `dagRunExists()` | `AirflowDomainPackGenerationTriggerAdapter.java` |
| V-008 | Extract 8 parameters into `DraftPayload` record | `DomainPackDraftPersistenceService.java` |
| V-009 | Extract repeated log literal to constant or helper method | `AirflowDomainPackGenerationTriggerAdapter.java` |

---

## User Decision Required

### Decision-001 — V-004: pipelinejob throws workspace BC exceptions

**Context**: `TriggerDomainPackGenerationUseCase` uses Port interfaces (correct) for workspace existence/role checks but throws `workspace.application.exception.WorkspaceNotFoundException` and `WorkspaceAccessDeniedException` directly.

**Options**:
- **Option A**: Add `PipelineJobWorkspaceNotFoundException` and `PipelineJobWorkspaceAccessDeniedException` in `pipelinejob.application.exception` extending shared base types. (Adds duplication, cleanest BC boundary.)
- **Option B**: Move `WorkspaceNotFoundException` and `WorkspaceAccessDeniedException` to `shared.application.exception` with more generic names (e.g., `WorkspaceNotFoundException` stays but as a shared class). (Broader change, affects other callers.)
- **Option C**: Accept the current pattern as a pragmatic decision — these exception classes are pure data extending shared base types, and treating the exception hierarchy as a "shared vocabulary" is a defensible team convention. Document explicitly.

### Decision-002 — V-006: programmatic TransactionTemplate pattern in pipelinejob/corpus

**Context**: `TriggerDomainPackGenerationUseCase`, `PipelineJobCallbackSupportService`, `RawDatasetUploadService` use `TransactionTemplate` for fine-grained external-call/DB-operation interleaving. Class-level `@Transactional(readOnly = true)` cannot be applied without changing the transaction strategy.

**Options**:
- **Option A**: Accept as a documented exception to the convention. Add `// NOTE: intentional TransactionTemplate — see [reason]` comment on these classes.
- **Option B**: Refactor to use `@Transactional` with more granular method splitting to avoid needing `TransactionTemplate`. (Larger refactor, may change behavior.)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ajou-2026-1-capstone-5/ostone/pull/197" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 트랜잭션 관리 체계를 개선하여 읽기 전용 기본값과 쓰기 작업 분리
  * 포트 기반 아키텍처로 변경하여 도메인 팩 생성 및 의도 추가 기능의 추상화 수준 향상
  * 에러 처리 로직을 강화하여 워크스페이스 접근 권한 관련 예외 처리 개선

* **테스트**
  * 새로운 포트 기반 의존성을 반영하도록 테스트 업데이트

* **기타**
  * 코드 중복 검사 제외 항목 추가
  * 로그 메시지 형식 표준화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->