### PR TITLE
[4.1.3] feat(domain-pack): demo domain pack mock data and validation test

### DIFF
--- a/backend/src/main/resources/mock/demo-domain-pack.json
+++ b/backend/src/main/resources/mock/demo-domain-pack.json
@@ -1,0 +1,443 @@
+{
+  "domainPack": {
+    "id": 100,
+    "workspaceId": 1,
+    "packKey": "cs-demo-ecommerce",
+    "name": "이커머스 고객센터 데모",
+    "description": "이커머스 CS 시나리오 기반 데모용 도메인 팩",
+    "status": "ACTIVE"
+  },
+  "version": {
+    "id": 101,
+    "domainPackId": 100,
+    "versionNo": 1,
+    "lifecycleStatus": "PUBLISHED",
+    "summaryJson": {}
+  },
+  "intents": [
+    {
+      "id": 110,
+      "intentCode": "cancel_order",
+      "name": "주문 취소",
+      "description": "고객이 배송 전 주문을 취소하려는 의도",
+      "taxonomyLevel": 1,
+      "parentIntentId": null,
+      "status": "PUBLISHED",
+      "requiredSlotIds": [120, 121],
+      "workflowIds": [150],
+      "entryConditionJson": {},
+      "sourceClusterRef": {},
+      "evidenceJson": [],
+      "metaJson": {}
+    },
+    {
+      "id": 111,
+      "intentCode": "change_address",
+      "name": "배송지 변경",
+      "description": "고객이 배송 전 주문의 배송지를 변경하려는 의도",
+      "taxonomyLevel": 1,
+      "parentIntentId": null,
+      "status": "PUBLISHED",
+      "requiredSlotIds": [120, 122],
+      "workflowIds": [151],
+      "entryConditionJson": {},
+      "sourceClusterRef": {},
+      "evidenceJson": [],
+      "metaJson": {}
+    },
+    {
+      "id": 112,
+      "intentCode": "check_refund_status",
+      "name": "환불 상태 조회",
+      "description": "고객이 주문 취소 또는 반품 후 환불 진행 상태를 조회하려는 의도",
+      "taxonomyLevel": 1,
+      "parentIntentId": null,
+      "status": "PUBLISHED",
+      "requiredSlotIds": [120],
+      "workflowIds": [152],
+      "entryConditionJson": {},
+      "sourceClusterRef": {},
+      "evidenceJson": [],
+      "metaJson": {}
+    }
+  ],
+  "slots": [
+    {
+      "id": 120,
+      "slotCode": "order_number",
+      "name": "주문번호",
+      "description": "취소 또는 조회 대상 주문의 식별 번호",
+      "dataType": "STRING",
+      "isSensitive": false,
+      "status": "ACTIVE",
+      "validationRuleJson": {},
+      "defaultValueJson": null,
+      "metaJson": {}
+    },
+    {
+      "id": 121,
+      "slotCode": "cancel_reason",
+      "name": "취소 사유",
+      "description": "고객이 주문을 취소하려는 이유",
+      "dataType": "STRING",
+      "isSensitive": false,
+      "status": "ACTIVE",
+      "validationRuleJson": {},
+      "defaultValueJson": null,
+      "metaJson": {}
+    },
+    {
+      "id": 122,
+      "slotCode": "new_address",
+      "name": "새 배송지",
+      "description": "배송지 변경 요청에 적용할 새 주소",
+      "dataType": "ADDRESS",
+      "isSensitive": true,
+      "status": "ACTIVE",
+      "validationRuleJson": {},
+      "defaultValueJson": null,
+      "metaJson": {}
+    },
+    {
+      "id": 123,
+      "slotCode": "refund_amount",
+      "name": "환불 금액",
+      "description": "주문 취소 또는 반품 후 환불될 금액",
+      "dataType": "NUMBER",
+      "isSensitive": false,
+      "status": "ACTIVE",
+      "validationRuleJson": {},
+      "defaultValueJson": null,
+      "metaJson": {}
+    },
+    {
+      "id": 124,
+      "slotCode": "customer_name",
+      "name": "고객명",
+      "description": "상담 대상 고객의 이름",
+      "dataType": "STRING",
+      "isSensitive": false,
+      "status": "ACTIVE",
+      "validationRuleJson": {},
+      "defaultValueJson": null,
+      "metaJson": {}
+    },
+    {
+      "id": 125,
+      "slotCode": "contact_number",
+      "name": "연락처",
+      "description": "고객에게 안내할 때 사용할 연락처",
+      "dataType": "STRING",
+      "isSensitive": true,
+      "status": "ACTIVE",
+      "validationRuleJson": {},
+      "defaultValueJson": null,
+      "metaJson": {}
+    }
+  ],
+  "policies": [
+    {
+      "id": 130,
+      "policyCode": "check_available",
+      "name": "취소 가능 여부 확인",
+      "description": "배송 전 상태인지 확인하여 취소 가능 여부 판단",
+      "status": "ACTIVE",
+      "conditionJson": {},
+      "actionJson": {},
+      "evidenceJson": [],
+      "metaJson": {}
+    },
+    {
+      "id": 131,
+      "policyCode": "address_change_limit",
+      "name": "배송지 변경 제한",
+      "description": "배송 시작 전까지만 배송지 변경 허용",
+      "status": "ACTIVE",
+      "conditionJson": {},
+      "actionJson": {},
+      "evidenceJson": [],
+      "metaJson": {}
+    },
+    {
+      "id": 132,
+      "policyCode": "refund_amount_check",
+      "name": "환불 금액 확인",
+      "description": "주문 금액에 따른 환불 가능 금액 확인",
+      "status": "ACTIVE",
+      "conditionJson": {},
+      "actionJson": {},
+      "evidenceJson": [],
+      "metaJson": {}
+    },
+    {
+      "id": 133,
+      "policyCode": "high_value_alert",
+      "name": "고액 취소 알림",
+      "description": "일정 금액 이상 취소 시 관리자 알림",
+      "status": "ACTIVE",
+      "conditionJson": {},
+      "actionJson": {},
+      "evidenceJson": [],
+      "metaJson": {}
+    },
+    {
+      "id": 134,
+      "policyCode": "return_deadline_check",
+      "name": "반품 기한 확인",
+      "description": "반품 가능 기한 내 요청인지 확인",
+      "status": "ACTIVE",
+      "conditionJson": {},
+      "actionJson": {},
+      "evidenceJson": [],
+      "metaJson": {}
+    }
+  ],
+  "risks": [
+    {
+      "id": 140,
+      "riskCode": "high_value_cancel",
+      "name": "고액 주문 취소",
+      "description": "고액 주문 취소 시 추가 확인 필요",
+      "riskLevel": "HIGH",
+      "status": "ACTIVE",
+      "triggerConditionJson": {},
+      "handlingActionJson": {},
+      "evidenceJson": [],
+      "metaJson": {}
+    },
+    {
+      "id": 141,
+      "riskCode": "address_fraud",
+      "name": "주소 사기 위험",
+      "description": "반복적인 배송지 변경 시 사기 가능성",
+      "riskLevel": "MEDIUM",
+      "status": "ACTIVE",
+      "triggerConditionJson": {},
+      "handlingActionJson": {},
+      "evidenceJson": [],
+      "metaJson": {}
+    },
+    {
+      "id": 142,
+      "riskCode": "refund_delay",
+      "name": "환불 지연",
+      "description": "결제 수단에 따라 환불 지연 가능성",
+      "riskLevel": "LOW",
+      "status": "ACTIVE",
+      "triggerConditionJson": {},
+      "handlingActionJson": {},
+      "evidenceJson": [],
+      "metaJson": {}
+    }
+  ],
+  "workflows": [
+    {
+      "id": 150,
+      "workflowCode": "cancel_order_flow",
+      "name": "주문 취소 처리",
+      "description": "주문 취소 요청을 접수하고 처리하는 워크플로우",
+      "initialState": "start",
+      "terminalStatesJson": ["cancelled", "rejected"],
+      "graphJson": {
+        "direction": "top-to-bottom",
+        "nodes": [
+          {
+            "id": "start",
+            "type": "START",
+            "label": "시작"
+          },
+          {
+            "id": "n1",
+            "type": "ACTION",
+            "label": "주문 확인",
+            "policyRef": "check_available"
+          },
+          {
+            "id": "n2",
+            "type": "DECISION",
+            "label": "취소 가능?"
+          },
+          {
+            "id": "n3",
+            "type": "ACTION",
+            "label": "취소 처리"
+          },
+          {
+            "id": "end_cancelled",
+            "type": "TERMINAL",
+            "label": "취소 완료",
+            "state": "cancelled"
+          },
+          {
+            "id": "end_rejected",
+            "type": "TERMINAL",
+            "label": "취소 불가",
+            "state": "rejected"
+          }
+        ],
+        "edges": [
+          {
+            "id": "e1",
+            "from": "start",
+            "to": "n1"
+          },
+          {
+            "id": "e2",
+            "from": "n1",
+            "to": "n2"
+          },
+          {
+            "id": "e3",
+            "from": "n2",
+            "to": "n3",
+            "label": "가능"
+          },
+          {
+            "id": "e4",
+            "from": "n2",
+            "to": "end_rejected",
+            "label": "불가능"
+          },
+          {
+            "id": "e5",
+            "from": "n3",
+            "to": "end_cancelled"
+          }
+        ]
+      },
+      "evidenceJson": [],
+      "metaJson": {}
+    },
+    {
+      "id": 151,
+      "workflowCode": "change_address_flow",
+      "name": "배송지 변경",
+      "description": "배송지 변경 요청을 접수하고 처리하는 워크플로우",
+      "initialState": "start",
+      "terminalStatesJson": ["changed", "rejected"],
+      "graphJson": {
+        "direction": "top-to-bottom",
+        "nodes": [
+          {
+            "id": "start",
+            "type": "START",
+            "label": "시작"
+          },
+          {
+            "id": "n1",
+            "type": "ACTION",
+            "label": "주문 상태 확인",
+            "policyRef": "address_change_limit"
+          },
+          {
+            "id": "n2",
+            "type": "DECISION",
+            "label": "변경 가능?"
+          },
+          {
+            "id": "n3",
+            "type": "ACTION",
+            "label": "주소 변경 처리"
+          },
+          {
+            "id": "end_done",
+            "type": "TERMINAL",
+            "label": "변경 완료",
+            "state": "changed"
+          },
+          {
+            "id": "end_rejected",
+            "type": "TERMINAL",
+            "label": "변경 불가",
+            "state": "rejected"
+          }
+        ],
+        "edges": [
+          {
+            "id": "e1",
+            "from": "start",
+            "to": "n1"
+          },
+          {
+            "id": "e2",
+            "from": "n1",
+            "to": "n2"
+          },
+          {
+            "id": "e3",
+            "from": "n2",
+            "to": "n3",
+            "label": "가능"
+          },
+          {
+            "id": "e4",
+            "from": "n2",
+            "to": "end_rejected",
+            "label": "불가"
+          },
+          {
+            "id": "e5",
+            "from": "n3",
+            "to": "end_done"
+          }
+        ]
+      },
+      "evidenceJson": [],
+      "metaJson": {}
+    },
+    {
+      "id": 152,
+      "workflowCode": "check_refund_status_flow",
+      "name": "환불 상태 조회",
+      "description": "환불 상태 조회 요청을 접수하고 안내하는 워크플로우",
+      "initialState": "start",
+      "terminalStatesJson": ["checked"],
+      "graphJson": {
+        "direction": "top-to-bottom",
+        "nodes": [
+          {
+            "id": "start",
+            "type": "START",
+            "label": "시작"
+          },
+          {
+            "id": "n1",
+            "type": "ACTION",
+            "label": "주문 정보 조회",
+            "policyRef": "refund_amount_check"
+          },
+          {
+            "id": "n2",
+            "type": "ACTION",
+            "label": "정보 제공"
+          },
+          {
+            "id": "end_done",
+            "type": "TERMINAL",
+            "label": "조회 완료",
+            "state": "checked"
+          }
+        ],
+        "edges": [
+          {
+            "id": "e1",
+            "from": "start",
+            "to": "n1"
+          },
+          {
+            "id": "e2",
+            "from": "n1",
+            "to": "n2"
+          },
+          {
+            "id": "e3",
+            "from": "n2",
+            "to": "end_done"
+          }
+        ]
+      },
+      "evidenceJson": [],
+      "metaJson": {}
+    }
+  ]
+}

--- a/backend/src/main/resources/mock/demo-domain-pack.json
+++ b/backend/src/main/resources/mock/demo-domain-pack.json
@@ -142,6 +142,7 @@
       "name": "취소 가능 여부 확인",
       "description": "배송 전 상태인지 확인하여 취소 가능 여부 판단",
       "status": "ACTIVE",
+      "severity": "LOW",
       "conditionJson": {},
       "actionJson": {},
       "evidenceJson": [],
@@ -153,6 +154,7 @@
       "name": "배송지 변경 제한",
       "description": "배송 시작 전까지만 배송지 변경 허용",
       "status": "ACTIVE",
+      "severity": "LOW",
       "conditionJson": {},
       "actionJson": {},
       "evidenceJson": [],
@@ -164,6 +166,7 @@
       "name": "환불 금액 확인",
       "description": "주문 금액에 따른 환불 가능 금액 확인",
       "status": "ACTIVE",
+      "severity": "MEDIUM",
       "conditionJson": {},
       "actionJson": {},
       "evidenceJson": [],
@@ -175,6 +178,7 @@
       "name": "고액 취소 알림",
       "description": "일정 금액 이상 취소 시 관리자 알림",
       "status": "ACTIVE",
+      "severity": "HIGH",
       "conditionJson": {},
       "actionJson": {},
       "evidenceJson": [],
@@ -186,6 +190,7 @@
       "name": "반품 기한 확인",
       "description": "반품 가능 기한 내 요청인지 확인",
       "status": "ACTIVE",
+      "severity": "MEDIUM",
       "conditionJson": {},
       "actionJson": {},
       "evidenceJson": [],
@@ -260,7 +265,8 @@
           {
             "id": "n3",
             "type": "ACTION",
-            "label": "취소 처리"
+            "label": "고액 취소 알림",
+            "policyRef": "high_value_alert"
           },
           {
             "id": "end_cancelled",

--- a/backend/src/test/java/com/init/domainpack/application/DemoDomainPackMockTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/DemoDomainPackMockTest.java
@@ -237,7 +237,8 @@ class DemoDomainPackMockTest {
     assertThat(terminalStates).containsExactlyInAnyOrderElementsOf(terminalNodeStates);
     assertThat(collectTextValues(nodes, "id")).doesNotHaveDuplicates();
     assertThat(collectTextValues(nodes, "type"))
-        .allSatisfy(type -> assertThat(Set.of("START", "TERMINAL", "DECISION", "ACTION")).contains(type));
+        .allSatisfy(
+            type -> assertThat(Set.of("START", "TERMINAL", "DECISION", "ACTION")).contains(type));
     assertThat(nodeIds).allSatisfy(nodeId -> assertThat(nodeId).matches("^[a-z][a-z0-9_]*$"));
     assertThat(collectTextValues(edges, "id")).doesNotHaveDuplicates();
     assertEdgesReferenceExistingNodes(edges, nodeIds);

--- a/backend/src/test/java/com/init/domainpack/application/DemoDomainPackMockTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/DemoDomainPackMockTest.java
@@ -1,0 +1,323 @@
+package com.init.domainpack.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.InputStream;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("데모 도메인 팩 목 JSON")
+class DemoDomainPackMockTest {
+
+  private static final String RESOURCE_PATH = "/mock/demo-domain-pack.json";
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final List<String> TOP_LEVEL_FIELDS =
+      List.of("domainPack", "version", "intents", "slots", "policies", "risks", "workflows");
+  private static final List<String> COLLECTION_FIELDS =
+      List.of("intents", "slots", "policies", "risks", "workflows");
+  private static final Map<String, String> CODE_FIELDS =
+      Map.of(
+          "intents", "intentCode",
+          "slots", "slotCode",
+          "policies", "policyCode",
+          "risks", "riskCode",
+          "workflows", "workflowCode");
+  private static final Map<String, int[]> ID_RANGES =
+      Map.of(
+          "intents", new int[] {110, 119},
+          "slots", new int[] {120, 129},
+          "policies", new int[] {130, 139},
+          "risks", new int[] {140, 149},
+          "workflows", new int[] {150, 159});
+  private static final Map<String, String> RISK_POLICY_CODES =
+      Map.of(
+          "high_value_cancel", "high_value_alert",
+          "address_fraud", "address_change_limit",
+          "refund_delay", "refund_amount_check");
+
+  @Test
+  @DisplayName("데모 도메인 팩 JSON을 파싱할 수 있다")
+  void should_parseJsonSuccessfully() throws Exception {
+    JsonNode root = loadRoot();
+
+    assertThat(root).isNotNull();
+    assertThat(root.isObject()).isTrue();
+  }
+
+  @Test
+  @DisplayName("최상위 필드가 계약과 일치한다")
+  void should_haveTopLevelFields() throws Exception {
+    JsonNode root = loadRoot();
+
+    assertThat(fieldNames(root)).containsExactlyInAnyOrderElementsOf(TOP_LEVEL_FIELDS);
+    assertThat(root.path("domainPack").isObject()).isTrue();
+    assertThat(root.path("version").isObject()).isTrue();
+    COLLECTION_FIELDS.forEach(field -> assertThat(root.path(field).isArray()).isTrue());
+  }
+
+  @Test
+  @DisplayName("엔티티 컬렉션이 비어 있지 않고 기대 개수와 일치한다")
+  void should_haveNonEmptyCollections() throws Exception {
+    JsonNode root = loadRoot();
+
+    assertArraySize(root, "intents", 3);
+    assertArraySize(root, "slots", 6);
+    assertArraySize(root, "policies", 5);
+    assertArraySize(root, "risks", 3);
+    assertArraySize(root, "workflows", 3);
+  }
+
+  @Test
+  @DisplayName("엔티티 ID가 타입별로 유일하고 타입 간에도 충돌하지 않는다")
+  void should_haveUniqueIds() throws Exception {
+    JsonNode root = loadRoot();
+    List<Long> allIds = new ArrayList<>();
+
+    COLLECTION_FIELDS.forEach(
+        field -> {
+          List<Long> ids = collectLongValues(root.path(field), "id");
+
+          assertThat(ids).doesNotHaveDuplicates();
+          allIds.addAll(ids);
+        });
+
+    assertThat(allIds).doesNotHaveDuplicates();
+  }
+
+  @Test
+  @DisplayName("엔티티 코드가 타입별로 유일하다")
+  void should_haveUniqueCodes() throws Exception {
+    JsonNode root = loadRoot();
+
+    CODE_FIELDS.forEach(
+        (entityType, codeField) -> {
+          List<String> codes = collectTextValues(root.path(entityType), codeField);
+
+          assertThat(codes).doesNotHaveDuplicates();
+        });
+  }
+
+  @Test
+  @DisplayName("엔티티 간 참조가 존재하는 대상만 가리킨다")
+  void should_haveValidCrossReferences() throws Exception {
+    JsonNode root = loadRoot();
+    Set<Long> slotIds = collectLongValuesAsSet(root.path("slots"), "id");
+    Set<Long> workflowIds = collectLongValuesAsSet(root.path("workflows"), "id");
+    Set<String> policyCodes = collectTextValuesAsSet(root.path("policies"), "policyCode");
+    Set<Long> referencedSlotIds = new HashSet<>();
+    Set<Long> referencedWorkflowIds = new HashSet<>();
+
+    for (JsonNode intent : root.path("intents")) {
+      Set<Long> requiredSlotIds = collectLongValuesAsSet(intent.path("requiredSlotIds"));
+      Set<Long> intentWorkflowIds = collectLongValuesAsSet(intent.path("workflowIds"));
+
+      assertThat(requiredSlotIds).isSubsetOf(slotIds);
+      assertThat(intentWorkflowIds).isSubsetOf(workflowIds);
+      referencedSlotIds.addAll(requiredSlotIds);
+      referencedWorkflowIds.addAll(intentWorkflowIds);
+    }
+
+    // 모든 workflow는 적어도 하나의 intent에서 참조되어야 함
+    assertThat(referencedWorkflowIds).containsAll(workflowIds);
+    // 슬롯은 선택적일 수 있으므로 참조 무결성만 검증 (위 isSubsetOf에서 검증 완료)
+    root.path("risks")
+        .forEach(
+            risk -> assertThat(policyCodes).contains(RISK_POLICY_CODES.get(risk.path("riskCode").asText())));
+  }
+
+  @Test
+  @DisplayName("워크플로우 그래프 구조가 유효하다")
+  void should_haveValidWorkflowGraphs() throws Exception {
+    JsonNode root = loadRoot();
+    Set<String> policyCodes = collectTextValuesAsSet(root.path("policies"), "policyCode");
+
+    for (JsonNode workflow : root.path("workflows")) {
+      assertWorkflowGraph(workflow, policyCodes);
+    }
+  }
+
+  @Test
+  @DisplayName("의도 상태는 폐기된 ACTIVE를 사용하지 않고 허용된 상태만 사용한다")
+  void should_notUseForbiddenIntentStatus() throws Exception {
+    JsonNode root = loadRoot();
+    Set<String> allowedStatuses = Set.of("DRAFT", "PUBLISHED", "REJECTED");
+
+    root.path("intents")
+        .forEach(
+            intent -> {
+              String status = intent.path("status").asText();
+
+              assertThat(status).isNotEqualTo("ACTIVE");
+              assertThat(allowedStatuses).contains(status);
+            });
+  }
+
+  @Test
+  @DisplayName("버전이 같은 도메인 팩을 참조한다")
+  void should_haveConsistentVersionReference() throws Exception {
+    JsonNode root = loadRoot();
+
+    assertThat(root.path("version").path("domainPackId").asLong())
+        .isEqualTo(root.path("domainPack").path("id").asLong());
+  }
+
+  @Test
+  @DisplayName("데모 데이터 ID는 결정적인 100번대 범위를 사용한다")
+  void should_haveDeterministicIds() throws Exception {
+    JsonNode root = loadRoot();
+    List<Long> allIds = new ArrayList<>();
+
+    assertThat(root.path("domainPack").path("id").asLong()).isEqualTo(100L);
+    assertThat(root.path("version").path("id").asLong()).isEqualTo(101L);
+    allIds.add(root.path("domainPack").path("id").asLong());
+    allIds.add(root.path("version").path("id").asLong());
+    ID_RANGES.forEach(
+        (field, range) ->
+            collectLongValues(root.path(field), "id")
+                .forEach(id -> assertThat(id).isBetween((long) range[0], (long) range[1])));
+    COLLECTION_FIELDS.forEach(field -> allIds.addAll(collectLongValues(root.path(field), "id")));
+
+    assertThat(allIds).allSatisfy(id -> assertThat(id).isBetween(100L, 199L));
+  }
+
+  private static JsonNode loadRoot() throws Exception {
+    try (InputStream inputStream = DemoDomainPackMockTest.class.getResourceAsStream(RESOURCE_PATH)) {
+      assertThat(inputStream).isNotNull();
+      return OBJECT_MAPPER.readTree(inputStream);
+    }
+  }
+
+  private static void assertArraySize(JsonNode root, String field, int expectedSize) {
+    JsonNode array = root.path(field);
+
+    assertThat(array.isArray()).isTrue();
+    assertThat(array).hasSizeGreaterThan(0).hasSize(expectedSize);
+  }
+
+  private static void assertWorkflowGraph(JsonNode workflow, Set<String> policyCodes) {
+    JsonNode graphJson = workflow.path("graphJson");
+    JsonNode nodes = graphJson.path("nodes");
+    JsonNode edges = graphJson.path("edges");
+    List<String> terminalNodeIds = collectNodeIdsByType(nodes, "TERMINAL");
+    List<String> startNodeIds = collectNodeIdsByType(nodes, "START");
+    Set<String> nodeIds = collectTextValuesAsSet(nodes, "id");
+
+    assertThat(nodes.isArray()).isTrue();
+    assertThat(edges.isArray()).isTrue();
+    assertThat(startNodeIds).hasSize(1);
+    assertThat(terminalNodeIds).isNotEmpty();
+    assertThat(collectTextValues(nodes, "id")).doesNotHaveDuplicates();
+    assertThat(collectTextValues(edges, "id")).doesNotHaveDuplicates();
+    assertEdgesReferenceExistingNodes(edges, nodeIds);
+    assertTerminalNodesHaveNoOutgoingEdges(edges, terminalNodeIds);
+    assertDecisionNodesHaveValidOutgoingEdges(nodes, edges);
+    assertActionPolicyRefsAreValid(nodes, policyCodes);
+    assertThat(reachableNodeIds(startNodeIds.get(0), edges)).containsAll(nodeIds);
+  }
+
+  private static void assertEdgesReferenceExistingNodes(JsonNode edges, Set<String> nodeIds) {
+    edges.forEach(
+        edge -> {
+          assertThat(nodeIds).contains(edge.path("from").asText());
+          assertThat(nodeIds).contains(edge.path("to").asText());
+        });
+  }
+
+  private static void assertTerminalNodesHaveNoOutgoingEdges(JsonNode edges, List<String> terminalNodeIds) {
+    edges.forEach(edge -> assertThat(terminalNodeIds).doesNotContain(edge.path("from").asText()));
+  }
+
+  private static void assertDecisionNodesHaveValidOutgoingEdges(JsonNode nodes, JsonNode edges) {
+    collectNodeIdsByType(nodes, "DECISION")
+        .forEach(
+            decisionNodeId -> {
+              List<JsonNode> outgoingEdges = outgoingEdges(edges, decisionNodeId);
+
+              assertThat(outgoingEdges).hasSizeGreaterThanOrEqualTo(2);
+              outgoingEdges.forEach(edge -> assertThat(edge.path("label").asText()).isNotBlank());
+            });
+  }
+
+  private static void assertActionPolicyRefsAreValid(JsonNode nodes, Set<String> policyCodes) {
+    stream(nodes)
+        .filter(node -> "ACTION".equals(node.path("type").asText()))
+        .filter(node -> node.hasNonNull("policyRef"))
+        .forEach(node -> assertThat(policyCodes).contains(node.path("policyRef").asText()));
+  }
+
+  private static Set<String> reachableNodeIds(String startNodeId, JsonNode edges) {
+    Map<String, List<String>> nextNodeIdsByNodeId = new HashMap<>();
+    edges.forEach(
+        edge ->
+            nextNodeIdsByNodeId
+                .computeIfAbsent(edge.path("from").asText(), ignored -> new ArrayList<>())
+                .add(edge.path("to").asText()));
+
+    Set<String> visited = new HashSet<>();
+    ArrayDeque<String> queue = new ArrayDeque<>();
+    queue.add(startNodeId);
+    while (!queue.isEmpty()) {
+      String nodeId = queue.removeFirst();
+      if (!visited.add(nodeId)) {
+        continue;
+      }
+      nextNodeIdsByNodeId.getOrDefault(nodeId, List.of()).forEach(queue::addLast);
+    }
+    return visited;
+  }
+
+  private static List<JsonNode> outgoingEdges(JsonNode edges, String nodeId) {
+    return stream(edges).filter(edge -> nodeId.equals(edge.path("from").asText())).toList();
+  }
+
+  private static List<String> collectNodeIdsByType(JsonNode nodes, String type) {
+    return stream(nodes)
+        .filter(node -> type.equals(node.path("type").asText()))
+        .map(node -> node.path("id").asText())
+        .toList();
+  }
+
+  private static List<Long> collectLongValues(JsonNode array, String field) {
+    return stream(array).map(node -> node.path(field).asLong()).toList();
+  }
+
+  private static Set<Long> collectLongValuesAsSet(JsonNode array, String field) {
+    return new HashSet<>(collectLongValues(array, field));
+  }
+
+  private static Set<Long> collectLongValuesAsSet(JsonNode array) {
+    return stream(array).map(JsonNode::asLong).collect(Collectors.toSet());
+  }
+
+  private static List<String> collectTextValues(JsonNode array, String field) {
+    return stream(array).map(node -> node.path(field).asText()).toList();
+  }
+
+  private static Set<String> collectTextValuesAsSet(JsonNode array, String field) {
+    return new HashSet<>(collectTextValues(array, field));
+  }
+
+  private static List<String> fieldNames(JsonNode node) {
+    return stream(node.fieldNames()).toList();
+  }
+
+  private static <T> java.util.stream.Stream<T> stream(Iterator<T> iterator) {
+    return StreamSupport.stream(((Iterable<T>) () -> iterator).spliterator(), false);
+  }
+
+  private static <T> java.util.stream.Stream<T> stream(Iterable<T> iterable) {
+    return StreamSupport.stream(iterable.spliterator(), false);
+  }
+}

--- a/backend/src/test/java/com/init/domainpack/application/DemoDomainPackMockTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/DemoDomainPackMockTest.java
@@ -134,7 +134,9 @@ class DemoDomainPackMockTest {
     // 슬롯은 선택적일 수 있으므로 참조 무결성만 검증 (위 isSubsetOf에서 검증 완료)
     root.path("risks")
         .forEach(
-            risk -> assertThat(policyCodes).contains(RISK_POLICY_CODES.get(risk.path("riskCode").asText())));
+            risk ->
+                assertThat(policyCodes)
+                    .contains(RISK_POLICY_CODES.get(risk.path("riskCode").asText())));
   }
 
   @Test
@@ -193,7 +195,8 @@ class DemoDomainPackMockTest {
   }
 
   private static JsonNode loadRoot() throws Exception {
-    try (InputStream inputStream = DemoDomainPackMockTest.class.getResourceAsStream(RESOURCE_PATH)) {
+    try (InputStream inputStream =
+        DemoDomainPackMockTest.class.getResourceAsStream(RESOURCE_PATH)) {
       assertThat(inputStream).isNotNull();
       return OBJECT_MAPPER.readTree(inputStream);
     }
@@ -235,7 +238,8 @@ class DemoDomainPackMockTest {
         });
   }
 
-  private static void assertTerminalNodesHaveNoOutgoingEdges(JsonNode edges, List<String> terminalNodeIds) {
+  private static void assertTerminalNodesHaveNoOutgoingEdges(
+      JsonNode edges, List<String> terminalNodeIds) {
     edges.forEach(edge -> assertThat(terminalNodeIds).doesNotContain(edge.path("from").asText()));
   }
 

--- a/backend/src/test/java/com/init/domainpack/application/DemoDomainPackMockTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/DemoDomainPackMockTest.java
@@ -43,7 +43,7 @@ class DemoDomainPackMockTest {
           "workflows", new int[] {150, 159});
   private static final Map<String, String> RISK_POLICY_CODES =
       Map.of(
-          "high_value_cancel", "high_value_alert",
+          "high_value_cancel", "check_available",
           "address_fraud", "address_change_limit",
           "refund_delay", "refund_amount_check");
 
@@ -85,6 +85,8 @@ class DemoDomainPackMockTest {
     JsonNode root = loadRoot();
     List<Long> allIds = new ArrayList<>();
 
+    allIds.add(root.path("domainPack").path("id").asLong());
+    allIds.add(root.path("version").path("id").asLong());
     COLLECTION_FIELDS.forEach(
         field -> {
           List<Long> ids = collectLongValues(root.path(field), "id");
@@ -134,9 +136,17 @@ class DemoDomainPackMockTest {
     // 슬롯은 선택적일 수 있으므로 참조 무결성만 검증 (위 isSubsetOf에서 검증 완료)
     root.path("risks")
         .forEach(
-            risk ->
-                assertThat(policyCodes)
-                    .contains(RISK_POLICY_CODES.get(risk.path("riskCode").asText())));
+            risk -> {
+              String riskCode = risk.path("riskCode").asText();
+              String policyCode = RISK_POLICY_CODES.get(riskCode);
+
+              assertThat(policyCode)
+                  .withFailMessage(
+                      "Unknown risk code %s: no matching policy mapping in RISK_POLICY_CODES",
+                      riskCode)
+                  .isNotNull();
+              assertThat(policyCodes).contains(policyCode);
+            });
   }
 
   @Test
@@ -215,18 +225,26 @@ class DemoDomainPackMockTest {
     JsonNode edges = graphJson.path("edges");
     List<String> terminalNodeIds = collectNodeIdsByType(nodes, "TERMINAL");
     List<String> startNodeIds = collectNodeIdsByType(nodes, "START");
+    Set<String> terminalStates = collectTextValuesAsSet(workflow.path("terminalStatesJson"));
+    Set<String> terminalNodeStates = collectNodeStatesByType(nodes, "TERMINAL");
     Set<String> nodeIds = collectTextValuesAsSet(nodes, "id");
 
+    assertThat(graphJson.path("direction").asText()).isEqualTo("top-to-bottom");
     assertThat(nodes.isArray()).isTrue();
     assertThat(edges.isArray()).isTrue();
     assertThat(startNodeIds).hasSize(1);
     assertThat(terminalNodeIds).isNotEmpty();
+    assertThat(terminalStates).containsExactlyInAnyOrderElementsOf(terminalNodeStates);
     assertThat(collectTextValues(nodes, "id")).doesNotHaveDuplicates();
+    assertThat(collectTextValues(nodes, "type"))
+        .allSatisfy(type -> assertThat(Set.of("START", "TERMINAL", "DECISION", "ACTION")).contains(type));
+    assertThat(nodeIds).allSatisfy(nodeId -> assertThat(nodeId).matches("^[a-z][a-z0-9_]*$"));
     assertThat(collectTextValues(edges, "id")).doesNotHaveDuplicates();
     assertEdgesReferenceExistingNodes(edges, nodeIds);
     assertTerminalNodesHaveNoOutgoingEdges(edges, terminalNodeIds);
     assertDecisionNodesHaveValidOutgoingEdges(nodes, edges);
     assertActionPolicyRefsAreValid(nodes, policyCodes);
+    assertGraphHasNoCycle(startNodeIds.get(0), edges);
     assertThat(reachableNodeIds(startNodeIds.get(0), edges)).containsAll(nodeIds);
   }
 
@@ -262,12 +280,7 @@ class DemoDomainPackMockTest {
   }
 
   private static Set<String> reachableNodeIds(String startNodeId, JsonNode edges) {
-    Map<String, List<String>> nextNodeIdsByNodeId = new HashMap<>();
-    edges.forEach(
-        edge ->
-            nextNodeIdsByNodeId
-                .computeIfAbsent(edge.path("from").asText(), ignored -> new ArrayList<>())
-                .add(edge.path("to").asText()));
+    Map<String, List<String>> nextNodeIdsByNodeId = nextNodeIdsByNodeId(edges);
 
     Set<String> visited = new HashSet<>();
     ArrayDeque<String> queue = new ArrayDeque<>();
@@ -282,6 +295,43 @@ class DemoDomainPackMockTest {
     return visited;
   }
 
+  private static void assertGraphHasNoCycle(String startNodeId, JsonNode edges) {
+    assertThat(hasCycle(startNodeId, nextNodeIdsByNodeId(edges), new HashSet<>(), new HashSet<>()))
+        .isFalse();
+  }
+
+  private static boolean hasCycle(
+      String nodeId,
+      Map<String, List<String>> nextNodeIdsByNodeId,
+      Set<String> visited,
+      Set<String> stack) {
+    if (stack.contains(nodeId)) {
+      return true;
+    }
+    if (!visited.add(nodeId)) {
+      return false;
+    }
+
+    stack.add(nodeId);
+    for (String nextNodeId : nextNodeIdsByNodeId.getOrDefault(nodeId, List.of())) {
+      if (hasCycle(nextNodeId, nextNodeIdsByNodeId, visited, stack)) {
+        return true;
+      }
+    }
+    stack.remove(nodeId);
+    return false;
+  }
+
+  private static Map<String, List<String>> nextNodeIdsByNodeId(JsonNode edges) {
+    Map<String, List<String>> nextNodeIdsByNodeId = new HashMap<>();
+    edges.forEach(
+        edge ->
+            nextNodeIdsByNodeId
+                .computeIfAbsent(edge.path("from").asText(), ignored -> new ArrayList<>())
+                .add(edge.path("to").asText()));
+    return nextNodeIdsByNodeId;
+  }
+
   private static List<JsonNode> outgoingEdges(JsonNode edges, String nodeId) {
     return stream(edges).filter(edge -> nodeId.equals(edge.path("from").asText())).toList();
   }
@@ -291,6 +341,13 @@ class DemoDomainPackMockTest {
         .filter(node -> type.equals(node.path("type").asText()))
         .map(node -> node.path("id").asText())
         .toList();
+  }
+
+  private static Set<String> collectNodeStatesByType(JsonNode nodes, String type) {
+    return stream(nodes)
+        .filter(node -> type.equals(node.path("type").asText()))
+        .map(node -> node.path("state").asText())
+        .collect(Collectors.toSet());
   }
 
   private static List<Long> collectLongValues(JsonNode array, String field) {
@@ -303,6 +360,10 @@ class DemoDomainPackMockTest {
 
   private static Set<Long> collectLongValuesAsSet(JsonNode array) {
     return stream(array).map(JsonNode::asLong).collect(Collectors.toSet());
+  }
+
+  private static Set<String> collectTextValuesAsSet(JsonNode array) {
+    return stream(array).map(JsonNode::asText).collect(Collectors.toSet());
   }
 
   private static List<String> collectTextValues(JsonNode array, String field) {

--- a/backend/src/test/java/com/init/domainpack/application/DemoDomainPackMockTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/DemoDomainPackMockTest.java
@@ -259,6 +259,7 @@ class DemoDomainPackMockTest {
 
   private static void assertTerminalNodesHaveNoOutgoingEdges(
       JsonNode edges, List<String> terminalNodeIds) {
+    assertThat(terminalNodeIds).isNotEmpty();
     edges.forEach(edge -> assertThat(terminalNodeIds).doesNotContain(edge.path("from").asText()));
   }
 

--- a/backend/src/test/java/com/init/domainpack/application/DemoDomainPackMockTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/DemoDomainPackMockTest.java
@@ -48,8 +48,8 @@ class DemoDomainPackMockTest {
           "refund_delay", "refund_amount_check");
 
   @Test
-  @DisplayName("데모 도메인 팩 JSON을 파싱할 수 있다")
-  void should_parseJsonSuccessfully() throws Exception {
+  @DisplayName("JSON 파싱 성공")
+  void should_JSON파싱성공_when_리소스읽기() throws Exception {
     JsonNode root = loadRoot();
 
     assertThat(root).isNotNull();
@@ -57,8 +57,8 @@ class DemoDomainPackMockTest {
   }
 
   @Test
-  @DisplayName("최상위 필드가 계약과 일치한다")
-  void should_haveTopLevelFields() throws Exception {
+  @DisplayName("최상위 필드 일치")
+  void should_최상위필드일치_when_JSON파싱() throws Exception {
     JsonNode root = loadRoot();
 
     assertThat(fieldNames(root)).containsExactlyInAnyOrderElementsOf(TOP_LEVEL_FIELDS);
@@ -68,8 +68,8 @@ class DemoDomainPackMockTest {
   }
 
   @Test
-  @DisplayName("엔티티 컬렉션이 비어 있지 않고 기대 개수와 일치한다")
-  void should_haveNonEmptyCollections() throws Exception {
+  @DisplayName("컬렉션이 비어 있지 않음")
+  void should_컬렉션이비어있지않음_when_JSON파싱() throws Exception {
     JsonNode root = loadRoot();
 
     assertArraySize(root, "intents", 3);
@@ -80,8 +80,8 @@ class DemoDomainPackMockTest {
   }
 
   @Test
-  @DisplayName("엔티티 ID가 타입별로 유일하고 타입 간에도 충돌하지 않는다")
-  void should_haveUniqueIds() throws Exception {
+  @DisplayName("모든 엔티티 ID 유일")
+  void should_ID가유일함_when_모든엔티티검사() throws Exception {
     JsonNode root = loadRoot();
     List<Long> allIds = new ArrayList<>();
 
@@ -97,8 +97,8 @@ class DemoDomainPackMockTest {
   }
 
   @Test
-  @DisplayName("엔티티 코드가 타입별로 유일하다")
-  void should_haveUniqueCodes() throws Exception {
+  @DisplayName("모든 엔티티 코드 유일")
+  void should_코드가유일함_when_모든엔티티검사() throws Exception {
     JsonNode root = loadRoot();
 
     CODE_FIELDS.forEach(
@@ -110,8 +110,8 @@ class DemoDomainPackMockTest {
   }
 
   @Test
-  @DisplayName("엔티티 간 참조가 존재하는 대상만 가리킨다")
-  void should_haveValidCrossReferences() throws Exception {
+  @DisplayName("엔티티 간 참조 무결성")
+  void should_참조무결성성립_when_엔티티간참조검사() throws Exception {
     JsonNode root = loadRoot();
     Set<Long> slotIds = collectLongValuesAsSet(root.path("slots"), "id");
     Set<Long> workflowIds = collectLongValuesAsSet(root.path("workflows"), "id");
@@ -138,8 +138,8 @@ class DemoDomainPackMockTest {
   }
 
   @Test
-  @DisplayName("워크플로우 그래프 구조가 유효하다")
-  void should_haveValidWorkflowGraphs() throws Exception {
+  @DisplayName("워크플로우 그래프 일관성")
+  void should_워크플로우그래프일관_when_그래프검증() throws Exception {
     JsonNode root = loadRoot();
     Set<String> policyCodes = collectTextValuesAsSet(root.path("policies"), "policyCode");
 
@@ -149,8 +149,8 @@ class DemoDomainPackMockTest {
   }
 
   @Test
-  @DisplayName("의도 상태는 폐기된 ACTIVE를 사용하지 않고 허용된 상태만 사용한다")
-  void should_notUseForbiddenIntentStatus() throws Exception {
+  @DisplayName("금지된 intent status 미사용")
+  void should_금지된상태미사용_when_intent상태검사() throws Exception {
     JsonNode root = loadRoot();
     Set<String> allowedStatuses = Set.of("DRAFT", "PUBLISHED", "REJECTED");
 
@@ -165,8 +165,8 @@ class DemoDomainPackMockTest {
   }
 
   @Test
-  @DisplayName("버전이 같은 도메인 팩을 참조한다")
-  void should_haveConsistentVersionReference() throws Exception {
+  @DisplayName("버전 참조 일관성")
+  void should_버전참조일관_when_버전필드검사() throws Exception {
     JsonNode root = loadRoot();
 
     assertThat(root.path("version").path("domainPackId").asLong())
@@ -174,8 +174,8 @@ class DemoDomainPackMockTest {
   }
 
   @Test
-  @DisplayName("데모 데이터 ID는 결정적인 100번대 범위를 사용한다")
-  void should_haveDeterministicIds() throws Exception {
+  @DisplayName("결정론적 ID 범위")
+  void should_결정론적ID범위_when_ID검사() throws Exception {
     JsonNode root = loadRoot();
     List<Long> allIds = new ArrayList<>();
 


### PR DESCRIPTION
## Summary

- Add canonical Domain Pack mock JSON for Korean e-commerce CS demo scenario
- Add `DemoDomainPackMockTest` validating JSON contract (structure, IDs, cross-references, workflow graph consistency)
- Spec PR: #202

## Changes

| File | Type | Description |
|------|------|-------------|
| `backend/src/main/resources/mock/demo-domain-pack.json` | New | Mock data: 3 intents, 6 slots, 5 policies, 3 risks, 3 workflows |
| `backend/src/test/java/com/init/domainpack/application/DemoDomainPackMockTest.java` | New | 10 test methods validating JSON contract |

## Test Validation

- **Targeted test**: `./gradlew test --tests "*DemoDomainPackMockTest*"` → BUILD SUCCESSFUL
- **Full backend test**: `./gradlew test` → BUILD SUCCESSFUL
- All 10 validation tests pass: JSON parsing, top-level structure, entity counts, ID/code uniqueness, cross-reference integrity, workflow graph consistency (BFS reachability), forbidden status check, deterministic ID ranges

## Scope Guard

- [x] No new dependencies added
- [x] No production helper/loader class created
- [x] No controller/DTO/service/repository/entity changes
- [x] No Spring context in test (plain JUnit 5 + Jackson)
- [x] No FE/DB/API/Runtime changes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ajou-2026-1-capstone-5/ostone/pull/203" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **테스트**
  * 데모 도메인 팩의 구조 및 데이터 무결성을 검증하는 종합 테스트 추가

* **기타**
  * 개발 및 테스트 인프라 개선

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ajou-2026-1-capstone-5/ostone/pull/203)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->