### PR TITLE
[4.1.4] feat(domain-pack): add refund demo workflow graph and chat session seed data

### DIFF
--- a/backend/src/main/java/com/init/domainpack/infrastructure/DemoRefundRequestSeedRunner.java
+++ b/backend/src/main/java/com/init/domainpack/infrastructure/DemoRefundRequestSeedRunner.java
@@ -106,7 +106,7 @@ public class DemoRefundRequestSeedRunner implements ApplicationRunner {
             "환불 요청을 접수하고 금액, 기한, 고액 알림 조건을 확인하는 워크플로우",
             graphJson,
             "start",
-            "[\"refund_requested\",\"rejected\"]",
+            "[\"end_requested\",\"end_rejected\"]",
             "[]",
             "{}");
     WorkflowDefinition savedWorkflow = workflowDefinitionRepository.save(workflow);
@@ -121,10 +121,10 @@ public class DemoRefundRequestSeedRunner implements ApplicationRunner {
     intentWorkflowBindingRepository.saveAll(
         List.of(IntentWorkflowBinding.create(savedIntent.getId(), savedWorkflow.getId(), true, "{}")));
 
-    seedChatMessages();
+    seedChatMessages(savedWorkflow.getId());
   }
 
-  private void seedChatMessages() {
+  private void seedChatMessages(Long workflowId) {
     ChatSession session =
         ChatSession.create(
             1L,
@@ -141,7 +141,7 @@ public class DemoRefundRequestSeedRunner implements ApplicationRunner {
         "TEXT",
         "환불 요청합니다",
         "{\"workflowCode\":\"refund_request_flow\",\"workflowId\":"
-            + WORKFLOW_ID
+            + workflowId
             + ",\"currentNodeId\":\"start\"}");
     saveMessage(
         savedSession.getId(),
@@ -150,7 +150,7 @@ public class DemoRefundRequestSeedRunner implements ApplicationRunner {
         "TEXT",
         "주문번호와 환불 예상 금액을 확인하겠습니다.",
         "{\"workflowCode\":\"refund_request_flow\",\"workflowId\":"
-            + WORKFLOW_ID
+            + workflowId
             + ",\"incomingEdgeId\":\"e1\",\"currentNodeId\":\"n1\",\"policyRef\":\"refund_amount_check\"}");
     saveMessage(
         savedSession.getId(),
@@ -159,7 +159,7 @@ public class DemoRefundRequestSeedRunner implements ApplicationRunner {
         "TEXT",
         "환불 가능 금액이 확인되었습니다. 반품 가능 기한을 이어서 확인하겠습니다.",
         "{\"workflowCode\":\"refund_request_flow\",\"workflowId\":"
-            + WORKFLOW_ID
+            + workflowId
             + ",\"incomingEdgeId\":\"e3\",\"currentNodeId\":\"n3\",\"policyRef\":\"return_deadline_check\"}");
     saveMessage(
         savedSession.getId(),
@@ -168,7 +168,7 @@ public class DemoRefundRequestSeedRunner implements ApplicationRunner {
         "SYSTEM",
         "고객명과 연락처 확인 완료. 고액 환불 알림 대상입니다.",
         "{\"workflowCode\":\"refund_request_flow\",\"workflowId\":"
-            + WORKFLOW_ID
+            + workflowId
             + ",\"incomingEdgeId\":\"e6\",\"currentNodeId\":\"n5\",\"policyRef\":\"high_value_alert\"}");
     saveMessage(
         savedSession.getId(),
@@ -177,7 +177,7 @@ public class DemoRefundRequestSeedRunner implements ApplicationRunner {
         "TEXT",
         "환불 요청이 접수되었습니다. 처리 결과는 등록된 연락처로 안내드리겠습니다.",
         "{\"workflowCode\":\"refund_request_flow\",\"workflowId\":"
-            + WORKFLOW_ID
+            + workflowId
             + ",\"incomingEdgeId\":\"e8\",\"currentNodeId\":\"end_requested\"}");
   }
 

--- a/backend/src/main/java/com/init/domainpack/infrastructure/DemoRefundRequestSeedRunner.java
+++ b/backend/src/main/java/com/init/domainpack/infrastructure/DemoRefundRequestSeedRunner.java
@@ -1,0 +1,247 @@
+package com.init.domainpack.infrastructure;
+
+import com.init.domainpack.domain.model.IntentDefinition;
+import com.init.domainpack.domain.model.IntentSlotBinding;
+import com.init.domainpack.domain.model.IntentWorkflowBinding;
+import com.init.domainpack.domain.model.WorkflowDefinition;
+import com.init.domainpack.domain.repository.IntentDefinitionRepository;
+import com.init.domainpack.domain.repository.IntentSlotBindingRepository;
+import com.init.domainpack.domain.repository.IntentWorkflowBindingRepository;
+import com.init.domainpack.domain.repository.WorkflowDefinitionRepository;
+import com.init.domainpack.domain.repository.WorkflowDefinitionSummaryRow;
+import com.init.workflowruntime.domain.ChatMessage;
+import com.init.workflowruntime.domain.ChatMessageRepository;
+import com.init.workflowruntime.domain.ChatSession;
+import com.init.workflowruntime.domain.ChatSessionRepository;
+import com.init.workflowruntime.domain.ChatSessionStatus;
+import jakarta.persistence.EntityManager;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@Profile("demo")
+@Order(Ordered.LOWEST_PRECEDENCE - 100)
+public class DemoRefundRequestSeedRunner implements ApplicationRunner {
+
+  private static final Logger log = LoggerFactory.getLogger(DemoRefundRequestSeedRunner.class);
+  private static final Long DOMAIN_PACK_VERSION_ID = 101L;
+  private static final Long WORKFLOW_ID = 153L;
+  private static final String WORKFLOW_CODE = "refund_request_flow";
+
+  private final WorkflowDefinitionRepository workflowDefinitionRepository;
+  private final IntentDefinitionRepository intentDefinitionRepository;
+  private final IntentSlotBindingRepository intentSlotBindingRepository;
+  private final IntentWorkflowBindingRepository intentWorkflowBindingRepository;
+  private final ChatSessionRepository chatSessionRepository;
+  private final ChatMessageRepository chatMessageRepository;
+  private final EntityManager entityManager;
+
+  public DemoRefundRequestSeedRunner(
+      WorkflowDefinitionRepository workflowDefinitionRepository,
+      IntentDefinitionRepository intentDefinitionRepository,
+      IntentSlotBindingRepository intentSlotBindingRepository,
+      IntentWorkflowBindingRepository intentWorkflowBindingRepository,
+      ChatSessionRepository chatSessionRepository,
+      ChatMessageRepository chatMessageRepository,
+      EntityManager entityManager) {
+    this.workflowDefinitionRepository = workflowDefinitionRepository;
+    this.intentDefinitionRepository = intentDefinitionRepository;
+    this.intentSlotBindingRepository = intentSlotBindingRepository;
+    this.intentWorkflowBindingRepository = intentWorkflowBindingRepository;
+    this.chatSessionRepository = chatSessionRepository;
+    this.chatMessageRepository = chatMessageRepository;
+    this.entityManager = entityManager;
+  }
+
+  @Override
+  @Transactional
+  public void run(ApplicationArguments args) {
+    log.info("demo seed start");
+    seedIfMissing();
+    log.info("Demo seed completed for workflow '{}'", WORKFLOW_CODE);
+  }
+
+  private void seedIfMissing() {
+    List<WorkflowDefinitionSummaryRow> existing =
+        workflowDefinitionRepository.findAllByDomainPackVersionIdOrderByWorkflowCodeAsc(
+            DOMAIN_PACK_VERSION_ID);
+    boolean exists = existing.stream().anyMatch(row -> WORKFLOW_CODE.equals(row.getWorkflowCode()));
+    if (exists) {
+      log.info("Workflow '{}' already exists, skipping demo seed", WORKFLOW_CODE);
+      return;
+    }
+
+    IntentDefinition intent =
+        IntentDefinition.create(
+            DOMAIN_PACK_VERSION_ID,
+            "request_refund",
+            "환불 요청",
+            "고객이 이미 구매한 상품에 대해 환불을 요청하는 의도",
+            1,
+            "{}",
+            "{}",
+            "[]",
+            "{}");
+    intent.changeStatus(IntentDefinition.STATUS_PUBLISHED);
+    IntentDefinition savedIntent = intentDefinitionRepository.save(intent);
+
+    String graphJson = buildRefundRequestGraphJson();
+    validateGraph(graphJson);
+
+    WorkflowDefinition workflow =
+        WorkflowDefinition.create(
+            DOMAIN_PACK_VERSION_ID,
+            WORKFLOW_CODE,
+            "환불 요청 처리",
+            "환불 요청을 접수하고 금액, 기한, 고액 알림 조건을 확인하는 워크플로우",
+            graphJson,
+            "start",
+            "[\"refund_requested\",\"rejected\"]",
+            "[]",
+            "{}");
+    WorkflowDefinition savedWorkflow = workflowDefinitionRepository.save(workflow);
+
+    intentSlotBindingRepository.saveAll(
+        List.of(
+            IntentSlotBinding.create(savedIntent.getId(), 120L, true, 1, null, "{}"),
+            IntentSlotBinding.create(savedIntent.getId(), 123L, true, 2, null, "{}"),
+            IntentSlotBinding.create(savedIntent.getId(), 124L, true, 3, null, "{}"),
+            IntentSlotBinding.create(savedIntent.getId(), 125L, true, 4, null, "{}")));
+
+    intentWorkflowBindingRepository.saveAll(
+        List.of(IntentWorkflowBinding.create(savedIntent.getId(), savedWorkflow.getId(), true, "{}")));
+
+    seedChatMessages();
+  }
+
+  private void seedChatMessages() {
+    ChatSession session =
+        ChatSession.create(
+            1L,
+            DOMAIN_PACK_VERSION_ID,
+            ChatSessionStatus.ACTIVE,
+            "DEMO",
+            "{\"demo\":true,\"scenario\":\"refund_request\",\"workflowCode\":\"refund_request_flow\"}");
+    ChatSession savedSession = chatSessionRepository.save(session);
+
+    saveMessage(
+        savedSession.getId(),
+        1,
+        "USER",
+        "TEXT",
+        "환불 요청합니다",
+        "{\"workflowCode\":\"refund_request_flow\",\"workflowId\":"
+            + WORKFLOW_ID
+            + ",\"currentNodeId\":\"start\"}");
+    saveMessage(
+        savedSession.getId(),
+        2,
+        "AGENT",
+        "TEXT",
+        "주문번호와 환불 예상 금액을 확인하겠습니다.",
+        "{\"workflowCode\":\"refund_request_flow\",\"workflowId\":"
+            + WORKFLOW_ID
+            + ",\"incomingEdgeId\":\"e1\",\"currentNodeId\":\"n1\",\"policyRef\":\"refund_amount_check\"}");
+    saveMessage(
+        savedSession.getId(),
+        3,
+        "AGENT",
+        "TEXT",
+        "환불 가능 금액이 확인되었습니다. 반품 가능 기한을 이어서 확인하겠습니다.",
+        "{\"workflowCode\":\"refund_request_flow\",\"workflowId\":"
+            + WORKFLOW_ID
+            + ",\"incomingEdgeId\":\"e3\",\"currentNodeId\":\"n3\",\"policyRef\":\"return_deadline_check\"}");
+    saveMessage(
+        savedSession.getId(),
+        4,
+        "NOTE",
+        "SYSTEM",
+        "고객명과 연락처 확인 완료. 고액 환불 알림 대상입니다.",
+        "{\"workflowCode\":\"refund_request_flow\",\"workflowId\":"
+            + WORKFLOW_ID
+            + ",\"incomingEdgeId\":\"e6\",\"currentNodeId\":\"n5\",\"policyRef\":\"high_value_alert\"}");
+    saveMessage(
+        savedSession.getId(),
+        5,
+        "AGENT",
+        "TEXT",
+        "환불 요청이 접수되었습니다. 처리 결과는 등록된 연락처로 안내드리겠습니다.",
+        "{\"workflowCode\":\"refund_request_flow\",\"workflowId\":"
+            + WORKFLOW_ID
+            + ",\"incomingEdgeId\":\"e8\",\"currentNodeId\":\"end_requested\"}");
+  }
+
+  private void saveMessage(
+      Long chatSessionId,
+      Integer seqNo,
+      String senderRole,
+      String messageType,
+      String content,
+      String payloadJson) {
+    ChatMessage savedMessage =
+        chatMessageRepository.save(
+            ChatMessage.create(chatSessionId, seqNo, senderRole, messageType, content));
+    entityManager
+        .createNativeQuery(
+            "update runtime.chat_message set payload_json = cast(:payloadJson as jsonb) where id = :id")
+        .setParameter("payloadJson", payloadJson)
+        .setParameter("id", savedMessage.getId())
+        .executeUpdate();
+  }
+
+  private void validateGraph(String graphJson) {
+    try {
+      Class<?> validatorClass = Class.forName("com.init.domainpack.application.WorkflowGraphValidator");
+      Method parseAndValidate =
+          validatorClass.getDeclaredMethod("parseAndValidate", String.class, String.class);
+      parseAndValidate.setAccessible(true);
+      parseAndValidate.invoke(null, graphJson, WORKFLOW_CODE);
+    } catch (InvocationTargetException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof RuntimeException runtimeException) {
+        throw runtimeException;
+      }
+      throw new IllegalStateException("워크플로우 그래프 검증에 실패했습니다.", cause);
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException("워크플로우 그래프 검증기를 호출할 수 없습니다.", e);
+    }
+  }
+
+  private String buildRefundRequestGraphJson() {
+    return """
+        {
+          "direction": "top-to-bottom",
+          "nodes": [
+            {"id": "start", "type": "START", "label": "시작"},
+            {"id": "n1", "type": "ACTION", "label": "환불 금액 확인", "policyRef": "refund_amount_check"},
+            {"id": "n2", "type": "DECISION", "label": "환불 가능?"},
+            {"id": "n3", "type": "ACTION", "label": "반품 기한 확인", "policyRef": "return_deadline_check"},
+            {"id": "n4", "type": "DECISION", "label": "기한 내?"},
+            {"id": "n5", "type": "ACTION", "label": "고액 환불 알림", "policyRef": "high_value_alert"},
+            {"id": "end_requested", "type": "TERMINAL", "label": "환불 접수 완료", "state": "refund_requested"},
+            {"id": "end_rejected", "type": "TERMINAL", "label": "환불 불가", "state": "rejected"}
+          ],
+          "edges": [
+            {"id": "e1", "from": "start", "to": "n1"},
+            {"id": "e2", "from": "n1", "to": "n2"},
+            {"id": "e3", "from": "n2", "to": "n3", "label": "가능"},
+            {"id": "e4", "from": "n2", "to": "end_rejected", "label": "불가능"},
+            {"id": "e5", "from": "n3", "to": "n4"},
+            {"id": "e6", "from": "n4", "to": "n5", "label": "기한 내"},
+            {"id": "e7", "from": "n4", "to": "end_rejected", "label": "기한 초과"},
+            {"id": "e8", "from": "n5", "to": "end_requested"}
+          ]
+        }
+        """;
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/infrastructure/DemoRefundRequestSeedRunner.java
+++ b/backend/src/main/java/com/init/domainpack/infrastructure/DemoRefundRequestSeedRunner.java
@@ -119,7 +119,8 @@ public class DemoRefundRequestSeedRunner implements ApplicationRunner {
             IntentSlotBinding.create(savedIntent.getId(), 125L, true, 4, null, "{}")));
 
     intentWorkflowBindingRepository.saveAll(
-        List.of(IntentWorkflowBinding.create(savedIntent.getId(), savedWorkflow.getId(), true, "{}")));
+        List.of(
+            IntentWorkflowBinding.create(savedIntent.getId(), savedWorkflow.getId(), true, "{}")));
 
     seedChatMessages(savedWorkflow.getId());
   }
@@ -201,7 +202,8 @@ public class DemoRefundRequestSeedRunner implements ApplicationRunner {
 
   private void validateGraph(String graphJson) {
     try {
-      Class<?> validatorClass = Class.forName("com.init.domainpack.application.WorkflowGraphValidator");
+      Class<?> validatorClass =
+          Class.forName("com.init.domainpack.application.WorkflowGraphValidator");
       Method parseAndValidate =
           validatorClass.getDeclaredMethod("parseAndValidate", String.class, String.class);
       parseAndValidate.setAccessible(true);

--- a/backend/src/test/java/com/init/domainpack/application/RefundWorkflowGraphValidationTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/RefundWorkflowGraphValidationTest.java
@@ -1,0 +1,99 @@
+package com.init.domainpack.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.init.domainpack.application.exception.WorkflowInvalidStartNodeException;
+import com.init.domainpack.application.exception.WorkflowUnlabeledBranchException;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("RefundWorkflowGraphValidation")
+class RefundWorkflowGraphValidationTest {
+
+  private static final Long WORKFLOW_ID = 153L;
+  private static final Long VERSION_ID = 101L;
+  private static final String WORKFLOW_CODE = "refund_request_flow";
+
+  private static final String REFUND_REQUEST_GRAPH_JSON =
+      """
+      {
+        "direction": "top-to-bottom",
+        "nodes": [
+          {"id": "start", "type": "START", "label": "시작"},
+          {"id": "n1", "type": "ACTION", "label": "환불 금액 확인", "policyRef": "refund_amount_check"},
+          {"id": "n2", "type": "DECISION", "label": "환불 가능?"},
+          {"id": "n3", "type": "ACTION", "label": "반품 기한 확인", "policyRef": "return_deadline_check"},
+          {"id": "n4", "type": "DECISION", "label": "기한 내?"},
+          {"id": "n5", "type": "ACTION", "label": "고액 환불 알림", "policyRef": "high_value_alert"},
+          {"id": "end_requested", "type": "TERMINAL", "label": "환불 접수 완료", "state": "refund_requested"},
+          {"id": "end_rejected", "type": "TERMINAL", "label": "환불 불가", "state": "rejected"}
+        ],
+        "edges": [
+          {"id": "e1", "from": "start", "to": "n1"},
+          {"id": "e2", "from": "n1", "to": "n2"},
+          {"id": "e3", "from": "n2", "to": "n3", "label": "가능"},
+          {"id": "e4", "from": "n2", "to": "end_rejected", "label": "불가능"},
+          {"id": "e5", "from": "n3", "to": "n4"},
+          {"id": "e6", "from": "n4", "to": "n5", "label": "기한 내"},
+          {"id": "e7", "from": "n4", "to": "end_rejected", "label": "기한 초과"},
+          {"id": "e8", "from": "n5", "to": "end_requested"}
+        ]
+      }
+      """;
+
+  @Test
+  @DisplayName("환불 워크플로우 graphJson은 V1-V8 검증을 통과한다")
+  void should_validateRefundWorkflowGraph_when_graphJsonMatchesSeedData() {
+    assertThatNoException()
+        .isThrownBy(() -> WorkflowGraphValidator.parseAndValidate(REFUND_REQUEST_GRAPH_JSON, WORKFLOW_CODE));
+  }
+
+  @Test
+  @DisplayName("환불 워크플로우 transitions는 8개 edge의 from/to/label/toPolicyRef를 반환한다")
+  void should_returnTransitionDetails_when_graphJsonMatchesSeedData() {
+    List<WorkflowTransitionDetail> details =
+        WorkflowTransitionDetail.listFromGraphJson(REFUND_REQUEST_GRAPH_JSON, WORKFLOW_ID, VERSION_ID);
+
+    assertThat(details)
+        .hasSize(8)
+        .extracting(
+            WorkflowTransitionDetail::id,
+            WorkflowTransitionDetail::from,
+            WorkflowTransitionDetail::to,
+            WorkflowTransitionDetail::label,
+            WorkflowTransitionDetail::toPolicyRef)
+        .containsExactly(
+            org.assertj.core.groups.Tuple.tuple("e1", "start", "n1", null, "refund_amount_check"),
+            org.assertj.core.groups.Tuple.tuple("e2", "n1", "n2", null, null),
+            org.assertj.core.groups.Tuple.tuple("e3", "n2", "n3", "가능", "return_deadline_check"),
+            org.assertj.core.groups.Tuple.tuple("e4", "n2", "end_rejected", "불가능", null),
+            org.assertj.core.groups.Tuple.tuple("e5", "n3", "n4", null, null),
+            org.assertj.core.groups.Tuple.tuple("e6", "n4", "n5", "기한 내", "high_value_alert"),
+            org.assertj.core.groups.Tuple.tuple("e7", "n4", "end_rejected", "기한 초과", null),
+            org.assertj.core.groups.Tuple.tuple("e8", "n5", "end_requested", null, null));
+  }
+
+  @Test
+  @DisplayName("invalid node type은 validator가 거부한다")
+  void should_rejectGraph_when_nodeTypeIsInvalid() {
+    String invalidGraphJson = REFUND_REQUEST_GRAPH_JSON.replace("\"type\": \"START\"", "\"type\": \"INVALID_TYPE\"");
+
+    assertThatThrownBy(() -> WorkflowGraphValidator.parseAndValidate(invalidGraphJson, WORKFLOW_CODE))
+        .isInstanceOf(WorkflowInvalidStartNodeException.class);
+  }
+
+  @Test
+  @DisplayName("DECISION edge label 누락 시 validator가 거부한다")
+  void should_rejectGraph_when_decisionEdgeLabelIsMissing() {
+    String invalidGraphJson =
+        REFUND_REQUEST_GRAPH_JSON.replace(
+            "{\"id\": \"e3\", \"from\": \"n2\", \"to\": \"n3\", \"label\": \"가능\"}",
+            "{\"id\": \"e3\", \"from\": \"n2\", \"to\": \"n3\"}");
+
+    assertThatThrownBy(() -> WorkflowGraphValidator.parseAndValidate(invalidGraphJson, WORKFLOW_CODE))
+        .isInstanceOf(WorkflowUnlabeledBranchException.class);
+  }
+}

--- a/backend/src/test/java/com/init/domainpack/application/RefundWorkflowGraphValidationTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/RefundWorkflowGraphValidationTest.java
@@ -48,14 +48,17 @@ class RefundWorkflowGraphValidationTest {
   @DisplayName("환불 워크플로우 graphJson은 V1-V8 검증을 통과한다")
   void should_validateRefundWorkflowGraph_when_graphJsonMatchesSeedData() {
     assertThatNoException()
-        .isThrownBy(() -> WorkflowGraphValidator.parseAndValidate(REFUND_REQUEST_GRAPH_JSON, WORKFLOW_CODE));
+        .isThrownBy(
+            () ->
+                WorkflowGraphValidator.parseAndValidate(REFUND_REQUEST_GRAPH_JSON, WORKFLOW_CODE));
   }
 
   @Test
   @DisplayName("환불 워크플로우 transitions는 8개 edge의 from/to/label/toPolicyRef를 반환한다")
   void should_returnTransitionDetails_when_graphJsonMatchesSeedData() {
     List<WorkflowTransitionDetail> details =
-        WorkflowTransitionDetail.listFromGraphJson(REFUND_REQUEST_GRAPH_JSON, WORKFLOW_ID, VERSION_ID);
+        WorkflowTransitionDetail.listFromGraphJson(
+            REFUND_REQUEST_GRAPH_JSON, WORKFLOW_ID, VERSION_ID);
 
     assertThat(details)
         .hasSize(8)
@@ -79,9 +82,11 @@ class RefundWorkflowGraphValidationTest {
   @Test
   @DisplayName("invalid node type은 validator가 거부한다")
   void should_rejectGraph_when_nodeTypeIsInvalid() {
-    String invalidGraphJson = REFUND_REQUEST_GRAPH_JSON.replace("\"type\": \"START\"", "\"type\": \"INVALID_TYPE\"");
+    String invalidGraphJson =
+        REFUND_REQUEST_GRAPH_JSON.replace("\"type\": \"START\"", "\"type\": \"INVALID_TYPE\"");
 
-    assertThatThrownBy(() -> WorkflowGraphValidator.parseAndValidate(invalidGraphJson, WORKFLOW_CODE))
+    assertThatThrownBy(
+            () -> WorkflowGraphValidator.parseAndValidate(invalidGraphJson, WORKFLOW_CODE))
         .isInstanceOf(WorkflowInvalidStartNodeException.class);
   }
 
@@ -93,7 +98,8 @@ class RefundWorkflowGraphValidationTest {
             "{\"id\": \"e3\", \"from\": \"n2\", \"to\": \"n3\", \"label\": \"가능\"}",
             "{\"id\": \"e3\", \"from\": \"n2\", \"to\": \"n3\"}");
 
-    assertThatThrownBy(() -> WorkflowGraphValidator.parseAndValidate(invalidGraphJson, WORKFLOW_CODE))
+    assertThatThrownBy(
+            () -> WorkflowGraphValidator.parseAndValidate(invalidGraphJson, WORKFLOW_CODE))
         .isInstanceOf(WorkflowUnlabeledBranchException.class);
   }
 }

--- a/backend/src/test/java/com/init/domainpack/infrastructure/DemoRefundSeedRunnerGuardTest.java
+++ b/backend/src/test/java/com/init/domainpack/infrastructure/DemoRefundSeedRunnerGuardTest.java
@@ -1,0 +1,175 @@
+package com.init.domainpack.infrastructure;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.init.domainpack.domain.model.IntentDefinition;
+import com.init.domainpack.domain.model.WorkflowDefinition;
+import com.init.domainpack.domain.repository.IntentDefinitionRepository;
+import com.init.domainpack.domain.repository.IntentSlotBindingRepository;
+import com.init.domainpack.domain.repository.IntentWorkflowBindingRepository;
+import com.init.domainpack.domain.repository.WorkflowDefinitionRepository;
+import com.init.domainpack.domain.repository.WorkflowDefinitionSummaryRow;
+import com.init.workflowruntime.domain.ChatMessage;
+import com.init.workflowruntime.domain.ChatMessageRepository;
+import com.init.workflowruntime.domain.ChatSession;
+import com.init.workflowruntime.domain.ChatSessionRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.DefaultApplicationArguments;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("DemoRefundRequestSeedRunner guard")
+class DemoRefundSeedRunnerGuardTest {
+
+  private static final Long DOMAIN_PACK_VERSION_ID = 101L;
+  private static final String WORKFLOW_CODE = "refund_request_flow";
+
+  @Mock private WorkflowDefinitionRepository workflowDefinitionRepository;
+  @Mock private IntentDefinitionRepository intentDefinitionRepository;
+  @Mock private IntentSlotBindingRepository intentSlotBindingRepository;
+  @Mock private IntentWorkflowBindingRepository intentWorkflowBindingRepository;
+  @Mock private ChatSessionRepository chatSessionRepository;
+  @Mock private ChatMessageRepository chatMessageRepository;
+  @Mock private EntityManager entityManager;
+  @Mock private Query query;
+
+  private DemoRefundRequestSeedRunner runner;
+
+  @BeforeEach
+  void setUp() {
+    runner =
+        new DemoRefundRequestSeedRunner(
+            workflowDefinitionRepository,
+            intentDefinitionRepository,
+            intentSlotBindingRepository,
+            intentWorkflowBindingRepository,
+            chatSessionRepository,
+            chatMessageRepository,
+            entityManager);
+  }
+
+  @Test
+  @DisplayName("workflowCode가 이미 존재하면 seed 저장 로직을 건너뛴다")
+  void shouldSkipSeedWhenWorkflowCodeExists() {
+    WorkflowDefinitionSummaryRow existing = existingWorkflow(WORKFLOW_CODE);
+    given(workflowDefinitionRepository.findAllByDomainPackVersionIdOrderByWorkflowCodeAsc(101L))
+        .willReturn(List.of(existing));
+
+    runner.run(new DefaultApplicationArguments());
+
+    verify(intentDefinitionRepository, never()).save(any(IntentDefinition.class));
+    verify(workflowDefinitionRepository, never()).save(any(WorkflowDefinition.class));
+    verify(intentSlotBindingRepository, never()).saveAll(any());
+    verify(intentWorkflowBindingRepository, never()).saveAll(any());
+    verify(chatSessionRepository, never()).save(any(ChatSession.class));
+    verify(chatMessageRepository, never()).save(any(ChatMessage.class));
+  }
+
+  @Test
+  @DisplayName("workflowCode가 없으면 seed 저장 로직을 실행한다")
+  void shouldSeedWhenWorkflowCodeMissing() {
+    given(workflowDefinitionRepository.findAllByDomainPackVersionIdOrderByWorkflowCodeAsc(101L))
+        .willReturn(List.of());
+    given(intentDefinitionRepository.save(any(IntentDefinition.class)))
+        .willAnswer(
+            invocation -> {
+              IntentDefinition intent = invocation.getArgument(0);
+              ReflectionTestUtils.setField(intent, "id", 111L);
+              return intent;
+            });
+    given(workflowDefinitionRepository.save(any(WorkflowDefinition.class)))
+        .willAnswer(
+            invocation -> {
+              WorkflowDefinition workflow = invocation.getArgument(0);
+              ReflectionTestUtils.setField(workflow, "id", 153L);
+              return workflow;
+            });
+    given(chatSessionRepository.save(any(ChatSession.class)))
+        .willAnswer(
+            invocation -> {
+              ChatSession session = invocation.getArgument(0);
+              ReflectionTestUtils.setField(session, "id", 1L);
+              return session;
+            });
+    given(chatMessageRepository.save(any(ChatMessage.class)))
+        .willAnswer(
+            invocation -> {
+              ChatMessage message = invocation.getArgument(0);
+              ReflectionTestUtils.setField(message, "id", 10L);
+              return message;
+            });
+    when(entityManager.createNativeQuery(any(String.class))).thenReturn(query);
+    when(query.setParameter(any(String.class), any())).thenReturn(query);
+
+    runner.run(new DefaultApplicationArguments());
+
+    verify(intentDefinitionRepository).save(any(IntentDefinition.class));
+    verify(workflowDefinitionRepository).save(any(WorkflowDefinition.class));
+    verify(intentSlotBindingRepository).saveAll(any());
+    verify(intentWorkflowBindingRepository).saveAll(any());
+    verify(chatSessionRepository).save(any(ChatSession.class));
+    verify(chatMessageRepository, times(5)).save(any(ChatMessage.class));
+  }
+
+  private WorkflowDefinitionSummaryRow existingWorkflow(String workflowCode) {
+    return new WorkflowDefinitionSummaryRow() {
+      @Override
+      public Long getId() {
+        return 153L;
+      }
+
+      @Override
+      public Long getDomainPackVersionId() {
+        return DOMAIN_PACK_VERSION_ID;
+      }
+
+      @Override
+      public String getWorkflowCode() {
+        return workflowCode;
+      }
+
+      @Override
+      public String getName() {
+        return "환불 요청 처리";
+      }
+
+      @Override
+      public String getDescription() {
+        return "환불 요청 워크플로우";
+      }
+
+      @Override
+      public String getInitialState() {
+        return "start";
+      }
+
+      @Override
+      public String getTerminalStatesJson() {
+        return "[]";
+      }
+
+      @Override
+      public java.time.OffsetDateTime getCreatedAt() {
+        return null;
+      }
+
+      @Override
+      public java.time.OffsetDateTime getUpdatedAt() {
+        return null;
+      }
+    };
+  }
+}

--- a/backend/src/test/java/com/init/domainpack/infrastructure/DemoRefundSeedRunnerIntegrationTest.java
+++ b/backend/src/test/java/com/init/domainpack/infrastructure/DemoRefundSeedRunnerIntegrationTest.java
@@ -65,6 +65,9 @@ class DemoRefundSeedRunnerIntegrationTest {
 
     @Bean
     WorkflowDefinitionRepository workflowDefinitionRepository() {
+      // Auto-run triggered by @SpringBootTest calls seedIfMissing().
+      // Returning an existing workflow causes seedIfMissing to short-circuit
+      // so the test verifies bean loading without actual persistence.
       WorkflowDefinitionRepository repository = mock(WorkflowDefinitionRepository.class);
       given(repository.findAllByDomainPackVersionIdOrderByWorkflowCodeAsc(101L))
           .willReturn(List.of(existingWorkflow()));

--- a/backend/src/test/java/com/init/domainpack/infrastructure/DemoRefundSeedRunnerIntegrationTest.java
+++ b/backend/src/test/java/com/init/domainpack/infrastructure/DemoRefundSeedRunnerIntegrationTest.java
@@ -1,0 +1,153 @@
+package com.init.domainpack.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import com.init.domainpack.domain.repository.IntentDefinitionRepository;
+import com.init.domainpack.domain.repository.IntentSlotBindingRepository;
+import com.init.domainpack.domain.repository.IntentWorkflowBindingRepository;
+import com.init.domainpack.domain.repository.WorkflowDefinitionRepository;
+import com.init.domainpack.domain.repository.WorkflowDefinitionSummaryRow;
+import com.init.workflowruntime.domain.ChatMessageRepository;
+import com.init.workflowruntime.domain.ChatSessionRepository;
+import jakarta.persistence.EntityManager;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.ActiveProfiles;
+
+@DisplayName("DemoRefundRequestSeedRunner profile")
+@SpringBootTest(
+    classes = {
+      DemoRefundRequestSeedRunner.class,
+      DemoRefundSeedRunnerIntegrationTest.RunnerDependencies.class
+    },
+    properties = {
+      "spring.datasource.url=jdbc:h2:mem:demo-refund-seed;"
+          + "MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH",
+      "spring.datasource.driver-class-name=org.h2.Driver",
+      "spring.datasource.username=sa",
+      "spring.datasource.password=",
+      "spring.jpa.hibernate.ddl-auto=create-drop",
+      "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect",
+      "spring.jpa.properties.hibernate.hbm2ddl.create_namespaces=true",
+      "spring.liquibase.enabled=false"
+    })
+@ActiveProfiles({"demo", "test"})
+class DemoRefundSeedRunnerIntegrationTest {
+
+  @Autowired private DemoRefundRequestSeedRunner runner;
+
+  @Test
+  @DisplayName("demo profile이 활성화되면 bean이 로드된다")
+  void shouldLoadRunnerBeanWhenDemoProfileActive() {
+    assertThat(runner).isNotNull();
+  }
+
+  @Test
+  @DisplayName("demo profile이 없으면 bean이 생성되지 않는다")
+  void shouldNotLoadRunnerBeanWhenDemoProfileInactive() {
+    new ApplicationContextRunner()
+        .withUserConfiguration(DemoRefundRequestSeedRunner.class, RunnerDependencies.class)
+        .withPropertyValues("spring.profiles.active=test")
+        .run(context -> assertThat(context).doesNotHaveBean(DemoRefundRequestSeedRunner.class));
+  }
+
+  @TestConfiguration
+  static class RunnerDependencies {
+
+    @Bean
+    WorkflowDefinitionRepository workflowDefinitionRepository() {
+      WorkflowDefinitionRepository repository = mock(WorkflowDefinitionRepository.class);
+      given(repository.findAllByDomainPackVersionIdOrderByWorkflowCodeAsc(101L))
+          .willReturn(List.of(existingWorkflow()));
+      return repository;
+    }
+
+    @Bean
+    IntentDefinitionRepository intentDefinitionRepository() {
+      return mock(IntentDefinitionRepository.class);
+    }
+
+    @Bean
+    IntentSlotBindingRepository intentSlotBindingRepository() {
+      return mock(IntentSlotBindingRepository.class);
+    }
+
+    @Bean
+    IntentWorkflowBindingRepository intentWorkflowBindingRepository() {
+      return mock(IntentWorkflowBindingRepository.class);
+    }
+
+    @Bean
+    ChatSessionRepository chatSessionRepository() {
+      return mock(ChatSessionRepository.class);
+    }
+
+    @Bean
+    ChatMessageRepository chatMessageRepository() {
+      return mock(ChatMessageRepository.class);
+    }
+
+    @Bean
+    EntityManager entityManager() {
+      return mock(EntityManager.class);
+    }
+
+    private WorkflowDefinitionSummaryRow existingWorkflow() {
+      return new WorkflowDefinitionSummaryRow() {
+        @Override
+        public Long getId() {
+          return 153L;
+        }
+
+        @Override
+        public Long getDomainPackVersionId() {
+          return 101L;
+        }
+
+        @Override
+        public String getWorkflowCode() {
+          return "refund_request_flow";
+        }
+
+        @Override
+        public String getName() {
+          return "환불 요청 처리";
+        }
+
+        @Override
+        public String getDescription() {
+          return "환불 요청 워크플로우";
+        }
+
+        @Override
+        public String getInitialState() {
+          return "start";
+        }
+
+        @Override
+        public String getTerminalStatesJson() {
+          return "[]";
+        }
+
+        @Override
+        public OffsetDateTime getCreatedAt() {
+          return null;
+        }
+
+        @Override
+        public OffsetDateTime getUpdatedAt() {
+          return null;
+        }
+      };
+    }
+  }
+}

--- a/backend/src/test/java/com/init/workflowruntime/domain/RefundChatMappingTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/domain/RefundChatMappingTest.java
@@ -8,11 +8,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
-@ExtendWith(MockitoExtension.class)
 @DisplayName("RefundChatMapping")
 class RefundChatMappingTest {
 

--- a/backend/src/test/java/com/init/workflowruntime/domain/RefundChatMappingTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/domain/RefundChatMappingTest.java
@@ -1,0 +1,203 @@
+package com.init.workflowruntime.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RefundChatMapping")
+class RefundChatMappingTest {
+
+  private static final Long WORKSPACE_ID = 1L;
+  private static final Long CHAT_SESSION_ID = 1L;
+  private static final Long DOMAIN_PACK_VERSION_ID = 101L;
+  private static final Long WORKFLOW_ID = 153L;
+  private static final String WORKFLOW_CODE = "refund_request_flow";
+  private static final String SESSION_META_JSON =
+      "{\"demo\":true,\"scenario\":\"refund_request\",\"workflowCode\":\"refund_request_flow\"}";
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  @Test
+  @DisplayName("demo chat session과 seeded message mapping이 환불 워크플로우 순서와 일치한다")
+  void should_환불워크플로우매핑일치_when_demoChatMessagesSeeded() {
+    // given
+    ChatSession session = createSession();
+    List<ExpectedMessage> expectedMessages = expectedMessages();
+    List<ChatMessage> messages = expectedMessages.stream().map(this::createMessage).toList();
+
+    // then
+    assertThat(session.getWorkspaceId()).isEqualTo(WORKSPACE_ID);
+    assertThat(session.getDomainPackVersionId()).isEqualTo(DOMAIN_PACK_VERSION_ID);
+    assertThat(session.getStatus()).isEqualTo(ChatSessionStatus.ACTIVE);
+    assertThat(session.getChannel()).isEqualTo("DEMO");
+    JsonNode meta = parseJson(session.getMetaJson());
+    assertThat(meta.path("demo").asBoolean()).isTrue();
+    assertThat(meta.path("scenario").asText()).isEqualTo("refund_request");
+    assertThat(meta.path("workflowCode").asText()).isEqualTo(WORKFLOW_CODE);
+
+    assertThat(messages).hasSize(5).extracting(ChatMessage::getSeqNo).containsExactly(1, 2, 3, 4, 5);
+    assertThat(messages)
+        .zipSatisfy(expectedMessages, (message, expected) -> assertMessageMatches(message, expected));
+  }
+
+  @Test
+  @DisplayName("payloadJson의 edgeId가 기대 매핑과 다르면 검증이 실패한다")
+  void should_매핑검증실패_when_edgeIdInvalid() {
+    // given
+    ExpectedMessage expected = expectedMessages().get(1);
+    ChatMessage message =
+        createMessage(
+            new ExpectedMessage(
+                expected.seqNo(),
+                expected.senderRole(),
+                expected.messageType(),
+                expected.content(),
+                expected.currentNodeId(),
+                "INVALID_EDGE_999",
+                expected.policyRef()));
+
+    // when
+    boolean matchesExpectedMapping = payloadMatchesExpectedMapping(message, expected);
+
+    // then
+    assertThat(matchesExpectedMapping).isFalse();
+  }
+
+  private ChatSession createSession() {
+    return ChatSession.create(
+        WORKSPACE_ID, DOMAIN_PACK_VERSION_ID, ChatSessionStatus.ACTIVE, "DEMO", SESSION_META_JSON);
+  }
+
+  private ChatMessage createMessage(ExpectedMessage expected) {
+    ChatMessage message =
+        ChatMessage.create(
+            CHAT_SESSION_ID,
+            expected.seqNo(),
+            expected.senderRole(),
+            expected.messageType(),
+            expected.content());
+    ReflectionTestUtils.setField(message, "payloadJson", payloadJson(expected));
+    return message;
+  }
+
+  private String payloadJson(ExpectedMessage expected) {
+    String mappingJson =
+        "\"workflowCode\":\""
+            + WORKFLOW_CODE
+            + "\",\"workflowId\":"
+            + WORKFLOW_ID
+            + ",\"currentNodeId\":\""
+            + expected.currentNodeId()
+            + "\"";
+    if (expected.incomingEdgeId() != null) {
+      mappingJson += ",\"incomingEdgeId\":\"" + expected.incomingEdgeId() + "\"";
+    }
+    if (expected.policyRef() != null) {
+      mappingJson += ",\"policyRef\":\"" + expected.policyRef() + "\"";
+    }
+    return "{" + mappingJson + "}";
+  }
+
+  private void assertMessageMatches(ChatMessage message, ExpectedMessage expected) {
+    assertThat(message.getChatSessionId()).isEqualTo(CHAT_SESSION_ID);
+    assertThat(message.getSeqNo()).isEqualTo(expected.seqNo());
+    assertThat(message.getSenderRole()).isEqualTo(expected.senderRole());
+    assertThat(message.getMessageType()).isEqualTo(expected.messageType());
+    assertThat(message.getContent()).isEqualTo(expected.content());
+    JsonNode payload = parseJson(message.getPayloadJson());
+    assertThat(payload.path("workflowCode").asText()).isEqualTo(WORKFLOW_CODE);
+    assertThat(payload.path("workflowId").asLong()).isEqualTo(WORKFLOW_ID);
+    assertThat(payload.path("currentNodeId").asText()).isEqualTo(expected.currentNodeId());
+    assertOptionalText(payload, "incomingEdgeId", expected.incomingEdgeId());
+    assertOptionalText(payload, "policyRef", expected.policyRef());
+  }
+
+  private boolean payloadMatchesExpectedMapping(ChatMessage message, ExpectedMessage expected) {
+    JsonNode payload = parseJson(message.getPayloadJson());
+    boolean requiredFieldsMatch =
+        WORKFLOW_CODE.equals(payload.path("workflowCode").asText())
+            && WORKFLOW_ID.equals(payload.path("workflowId").asLong())
+            && expected.currentNodeId().equals(payload.path("currentNodeId").asText());
+
+    return requiredFieldsMatch
+        && optionalTextMatches(payload, "incomingEdgeId", expected.incomingEdgeId())
+        && optionalTextMatches(payload, "policyRef", expected.policyRef());
+  }
+
+  private boolean optionalTextMatches(JsonNode payload, String fieldName, String expectedValue) {
+    if (expectedValue == null) {
+      return !payload.has(fieldName);
+    }
+    return expectedValue.equals(payload.path(fieldName).asText());
+  }
+
+  private void assertOptionalText(JsonNode payload, String fieldName, String expectedValue) {
+    if (expectedValue == null) {
+      assertThat(payload.has(fieldName)).isFalse();
+      return;
+    }
+    assertThat(payload.path(fieldName).asText()).isEqualTo(expectedValue);
+  }
+
+  private JsonNode parseJson(String json) {
+    try {
+      return OBJECT_MAPPER.readTree(json);
+    } catch (JsonProcessingException e) {
+      throw new AssertionError("JSON parsing failed", e);
+    }
+  }
+
+  private List<ExpectedMessage> expectedMessages() {
+    return List.of(
+        new ExpectedMessage(1, "USER", "TEXT", "환불 요청합니다", "start", null, null),
+        new ExpectedMessage(
+            2,
+            "AGENT",
+            "TEXT",
+            "주문번호와 환불 예상 금액을 확인하겠습니다.",
+            "n1",
+            "e1",
+            "refund_amount_check"),
+        new ExpectedMessage(
+            3,
+            "AGENT",
+            "TEXT",
+            "환불 가능 금액이 확인되었습니다. 반품 가능 기한을 이어서 확인하겠습니다.",
+            "n3",
+            "e3",
+            "return_deadline_check"),
+        new ExpectedMessage(
+            4,
+            "NOTE",
+            "SYSTEM",
+            "고객명과 연락처 확인 완료. 고액 환불 알림 대상입니다.",
+            "n5",
+            "e6",
+            "high_value_alert"),
+        new ExpectedMessage(
+            5,
+            "AGENT",
+            "TEXT",
+            "환불 요청이 접수되었습니다. 처리 결과는 등록된 연락처로 안내드리겠습니다.",
+            "end_requested",
+            "e8",
+            null));
+  }
+
+  private record ExpectedMessage(
+      int seqNo,
+      String senderRole,
+      String messageType,
+      String content,
+      String currentNodeId,
+      String incomingEdgeId,
+      String policyRef) {}
+}

--- a/backend/src/test/java/com/init/workflowruntime/domain/RefundChatMappingTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/domain/RefundChatMappingTest.java
@@ -40,9 +40,13 @@ class RefundChatMappingTest {
     assertThat(meta.path("scenario").asText()).isEqualTo("refund_request");
     assertThat(meta.path("workflowCode").asText()).isEqualTo(WORKFLOW_CODE);
 
-    assertThat(messages).hasSize(5).extracting(ChatMessage::getSeqNo).containsExactly(1, 2, 3, 4, 5);
     assertThat(messages)
-        .zipSatisfy(expectedMessages, (message, expected) -> assertMessageMatches(message, expected));
+        .hasSize(5)
+        .extracting(ChatMessage::getSeqNo)
+        .containsExactly(1, 2, 3, 4, 5);
+    assertThat(messages)
+        .zipSatisfy(
+            expectedMessages, (message, expected) -> assertMessageMatches(message, expected));
   }
 
   @Test
@@ -156,13 +160,7 @@ class RefundChatMappingTest {
     return List.of(
         new ExpectedMessage(1, "USER", "TEXT", "환불 요청합니다", "start", null, null),
         new ExpectedMessage(
-            2,
-            "AGENT",
-            "TEXT",
-            "주문번호와 환불 예상 금액을 확인하겠습니다.",
-            "n1",
-            "e1",
-            "refund_amount_check"),
+            2, "AGENT", "TEXT", "주문번호와 환불 예상 금액을 확인하겠습니다.", "n1", "e1", "refund_amount_check"),
         new ExpectedMessage(
             3,
             "AGENT",
@@ -172,13 +170,7 @@ class RefundChatMappingTest {
             "e3",
             "return_deadline_check"),
         new ExpectedMessage(
-            4,
-            "NOTE",
-            "SYSTEM",
-            "고객명과 연락처 확인 완료. 고액 환불 알림 대상입니다.",
-            "n5",
-            "e6",
-            "high_value_alert"),
+            4, "NOTE", "SYSTEM", "고객명과 연락처 확인 완료. 고액 환불 알림 대상입니다.", "n5", "e6", "high_value_alert"),
         new ExpectedMessage(
             5,
             "AGENT",


### PR DESCRIPTION
## Summary
- Validator-compatible `refund_request_flow` Workflow Graph seed (V1-V8)
- Demo ChatSession + 5 ChatMessages with node/edge/transition mapping
- `@Profile("demo")` + `@Transactional` + workflowCode 멱등성 Runner guard
- 4 Tests-after covering graph validation, chat mapping, runner guard, integration

## 변경 파일
- `DemoRefundRequestSeedRunner.java`: refund_request_flow graph + chat seed Runner
- `RefundWorkflowGraphValidationTest.java`: V1-V8 통과 + edge detail + negative tests
- `RefundChatMappingTest.java`: 5개 message payloadJson field assertion + negative
- `DemoRefundSeedRunnerGuardTest.java`: Mockito 멱등성/guard 검증
- `DemoRefundSeedRunnerIntegrationTest.java`: @Profile("demo") bean 로드 검증

## 검증 결과
```
./gradlew test → BUILD SUCCESSFUL (17s)
scan-slop → 0 findings
change-radius → 1 file (신규 Runner, 정상 범위)
```

## Spec PR
#205 — spec/4.1.4 (OPEN)

## 브랜치
- Source: feature/4.1.4-backend-refund-demo-workflow-data
- Base: main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 데모 환경에서 환금 요청 워크플로우 초기 데이터 설정 추가
  * 워크플로우 기반 채팅 세션 및 메시지 지원 추가

* **테스트**
  * 워크플로우 그래프 검증 테스트 추가
  * 환금 워크플로우 시드 실행자 가드 로직 테스트 추가
  * 프로필 기반 빈 로딩 통합 테스트 추가
  * 채팅 메시지 페이로드 매핑 검증 테스트 추가

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ajou-2026-1-capstone-5/ostone/pull/206)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->