### PR TITLE
[4.1.5] feat(chat-demo): add demo runtime mock api

### DIFF
--- a/backend/src/main/java/com/init/chatdemo/application/DemoRuntimeFixture.java
+++ b/backend/src/main/java/com/init/chatdemo/application/DemoRuntimeFixture.java
@@ -26,46 +26,111 @@ public class DemoRuntimeFixture {
           "CS Support Domain Pack",
           "1.0.0",
           "PUBLISHED",
-          List.of(new DemoIntentResponse("intent-1", "delivery_status", "배송 상태 확인")),
-          List.of(new DemoPolicyResponse("policy-1", "배송 조회 정책", "주문번호로 배송 조회", "medium")),
-          List.of(new DemoRiskResponse("risk-1", "개인정보 노출", "민감 정보 노출 여부", "low")));
+          List.of(
+              new DemoIntentResponse("intent-1", "환불 요청", "고객이 제품 환불을 요청하는 경우"),
+              new DemoIntentResponse("intent-2", "배송 조회", "고객이 배송 상태를 문의하는 경우")),
+          List.of(new DemoPolicyResponse("policy-1", "환불 가능 기간", "구매일로부터 14일 이내 환불 가능", "HARD")),
+          List.of(new DemoRiskResponse("risk-1", "고액 환불", "100만원 이상 환불 요청 시 리뷰 필요", "HIGH")));
   private static final DemoWorkflowResponse WORKFLOW =
       new DemoWorkflowResponse(
           "workflow-1",
-          "배송 문의 처리",
-          "배송 문의를 확인하고 정책과 위험을 점검합니다.",
-          List.of("start", "slot_filling", "resolved"),
-          List.of(new DemoTransitionResponse("start", "slot_filling", "INTENT_DETECTED")));
+          "환불 처리 워크플로우",
+          "고객 환불 요청을 처리하는 워크플로우",
+          List.of(
+              "INITIAL",
+              "INTENT_DETECTED",
+              "SLOT_COLLECTING",
+              "POLICY_CHECKING",
+              "RISK_CHECKING",
+              "DECIDING",
+              "COMPLETED",
+              "HANDOFF"),
+          List.of(
+              new DemoTransitionResponse("INITIAL", "INTENT_DETECTED", "INTENT_DETECTED"),
+              new DemoTransitionResponse("INTENT_DETECTED", "SLOT_COLLECTING", "SLOT_FILLED"),
+              new DemoTransitionResponse("SLOT_COLLECTING", "POLICY_CHECKING", "POLICY_CHECKED"),
+              new DemoTransitionResponse("POLICY_CHECKING", "RISK_CHECKING", "RISK_CHECKED"),
+              new DemoTransitionResponse("RISK_CHECKING", "DECIDING", "STATE_TRANSITIONED"),
+              new DemoTransitionResponse("DECIDING", "COMPLETED", "ANSWER_GENERATED"),
+              new DemoTransitionResponse("DECIDING", "HANDOFF", "HANDOFF_TRIGGERED")));
   private static final DemoChatSessionResponse CHAT_SESSION =
       new DemoChatSessionResponse(
           "session-1", "completed", "2026-05-10T09:00:00Z", "2026-05-10T09:05:30Z");
   private static final List<DemoMessageResponse> MESSAGES =
       List.of(
+          new DemoMessageResponse("msg-1", "user", "제품 환불하고 싶습니다", "2026-05-10T09:00:00Z"),
           new DemoMessageResponse(
-              "message-1", "customer", "배송 상태를 알고 싶어요.", "2026-05-10T09:00:10Z"));
+              "msg-2", "assistant", "네, 환불 도와드리겠습니다. 주문번호를 알려주세요.", "2026-05-10T09:00:15Z"),
+          new DemoMessageResponse("msg-3", "user", "주문번호는 ORD-12345입니다", "2026-05-10T09:01:00Z"),
+          new DemoMessageResponse(
+              "msg-4",
+              "assistant",
+              "ORD-12345 주문에 대한 환불이 완료되었습니다. 14일 이내에 계좌로 입금됩니다.",
+              "2026-05-10T09:05:30Z"));
   private static final DemoExecutionResponse EXECUTION =
       new DemoExecutionResponse(
           "exec-1",
-          "completed",
-          "resolved",
-          "node-3",
-          "delivery_status",
-          Map.of("orderId", "ORD-2026-001"),
+          "COMPLETED",
+          "COMPLETED",
+          "wf-node-final",
+          "환불 요청",
+          Map.of("orderNumber", "ORD-12345", "refundAmount", 59000),
           List.of(),
-          List.of(new DemoPolicyHitResponse("policy-1", "배송 조회 정책", "pass", "주문번호로 배송 조회 가능")),
-          List.of(new DemoRiskHitResponse("risk-1", "개인정보 노출", "safe", "민감 정보 노출 없음")));
+          List.of(new DemoPolicyHitResponse("policy-1", "환불 가능 기간", "PASS", "구매일로부터 14일 이내")),
+          List.of(
+              new DemoRiskHitResponse("risk-1", "고액 환불", "LOW", "환불 금액 59,000원 — 고액 환불 기준 미만")));
   private static final List<DemoDecisionLogResponse> DECISION_LOGS =
       List.of(
           new DemoDecisionLogResponse(
               "log-1",
               1,
-              "message-1",
+              "msg-1",
               "INTENT_DETECTED",
-              "start",
-              "slot_filling",
+              "INITIAL",
+              "INTENT_DETECTED",
+              "ALLOW",
+              0.95,
+              "환불 요청 패턴 감지"),
+          new DemoDecisionLogResponse(
+              "log-2",
+              2,
+              "msg-3",
+              "SLOT_FILLED",
+              "INTENT_DETECTED",
+              "SLOT_COLLECTING",
+              "ALLOW",
+              0.88,
+              "주문번호 slot 수집 완료"),
+          new DemoDecisionLogResponse(
+              "log-3",
+              3,
+              "msg-3",
+              "POLICY_CHECKED",
+              "SLOT_COLLECTING",
+              "POLICY_CHECKING",
+              "ALLOW",
+              1.0,
+              "환불 가능 기간 정책 통과"),
+          new DemoDecisionLogResponse(
+              "log-4",
+              4,
+              "msg-3",
+              "RISK_CHECKED",
+              "POLICY_CHECKING",
+              "RISK_CHECKING",
+              "ALLOW",
+              0.75,
+              "고액 환불 위험 낮음"),
+          new DemoDecisionLogResponse(
+              "log-5",
+              5,
+              "msg-4",
+              "ANSWER_GENERATED",
+              "DECIDING",
+              "COMPLETED",
               "ALLOW",
               0.92,
-              "배송 상태 문의 표현이 포함됨"));
+              "환불 완료 안내 생성"));
   private static final DemoChatWorkflowResponse CHAT_WORKFLOW =
       new DemoChatWorkflowResponse(
           DOMAIN_PACK, WORKFLOW, CHAT_SESSION, MESSAGES, EXECUTION, DECISION_LOGS);

--- a/backend/src/main/java/com/init/chatdemo/application/DemoRuntimeFixture.java
+++ b/backend/src/main/java/com/init/chatdemo/application/DemoRuntimeFixture.java
@@ -20,6 +20,16 @@ import org.springframework.stereotype.Component;
 @Component
 public class DemoRuntimeFixture {
 
+  private static final String STATE_INITIAL = "INITIAL";
+  private static final String STATE_INTENT_DETECTED = "INTENT_DETECTED";
+  private static final String STATE_SLOT_COLLECTING = "SLOT_COLLECTING";
+  private static final String STATE_POLICY_CHECKING = "POLICY_CHECKING";
+  private static final String STATE_RISK_CHECKING = "RISK_CHECKING";
+  private static final String STATE_DECIDING = "DECIDING";
+  private static final String STATE_COMPLETED = "COMPLETED";
+  private static final String DECISION_ALLOW = "ALLOW";
+  private static final String MESSAGE_WITH_ORDER_NUMBER = "msg-3";
+
   private static final DemoDomainPackResponse DOMAIN_PACK =
       new DemoDomainPackResponse(
           "demo-pack-1",
@@ -37,22 +47,25 @@ public class DemoRuntimeFixture {
           "환불 처리 워크플로우",
           "고객 환불 요청을 처리하는 워크플로우",
           List.of(
-              "INITIAL",
-              "INTENT_DETECTED",
-              "SLOT_COLLECTING",
-              "POLICY_CHECKING",
-              "RISK_CHECKING",
-              "DECIDING",
-              "COMPLETED",
+              STATE_INITIAL,
+              STATE_INTENT_DETECTED,
+              STATE_SLOT_COLLECTING,
+              STATE_POLICY_CHECKING,
+              STATE_RISK_CHECKING,
+              STATE_DECIDING,
+              STATE_COMPLETED,
               "HANDOFF"),
           List.of(
-              new DemoTransitionResponse("INITIAL", "INTENT_DETECTED", "INTENT_DETECTED"),
-              new DemoTransitionResponse("INTENT_DETECTED", "SLOT_COLLECTING", "SLOT_FILLED"),
-              new DemoTransitionResponse("SLOT_COLLECTING", "POLICY_CHECKING", "POLICY_CHECKED"),
-              new DemoTransitionResponse("POLICY_CHECKING", "RISK_CHECKING", "RISK_CHECKED"),
-              new DemoTransitionResponse("RISK_CHECKING", "DECIDING", "STATE_TRANSITIONED"),
-              new DemoTransitionResponse("DECIDING", "COMPLETED", "ANSWER_GENERATED"),
-              new DemoTransitionResponse("DECIDING", "HANDOFF", "HANDOFF_TRIGGERED")));
+              new DemoTransitionResponse(STATE_INITIAL, STATE_INTENT_DETECTED, "INTENT_DETECTED"),
+              new DemoTransitionResponse(
+                  STATE_INTENT_DETECTED, STATE_SLOT_COLLECTING, "SLOT_FILLED"),
+              new DemoTransitionResponse(
+                  STATE_SLOT_COLLECTING, STATE_POLICY_CHECKING, "POLICY_CHECKED"),
+              new DemoTransitionResponse(
+                  STATE_POLICY_CHECKING, STATE_RISK_CHECKING, "RISK_CHECKED"),
+              new DemoTransitionResponse(STATE_RISK_CHECKING, STATE_DECIDING, "STATE_TRANSITIONED"),
+              new DemoTransitionResponse(STATE_DECIDING, STATE_COMPLETED, "ANSWER_GENERATED"),
+              new DemoTransitionResponse(STATE_DECIDING, "HANDOFF", "HANDOFF_TRIGGERED")));
   private static final DemoChatSessionResponse CHAT_SESSION =
       new DemoChatSessionResponse(
           "session-1", "completed", "2026-05-10T09:00:00Z", "2026-05-10T09:05:30Z");
@@ -61,7 +74,8 @@ public class DemoRuntimeFixture {
           new DemoMessageResponse("msg-1", "user", "제품 환불하고 싶습니다", "2026-05-10T09:00:00Z"),
           new DemoMessageResponse(
               "msg-2", "assistant", "네, 환불 도와드리겠습니다. 주문번호를 알려주세요.", "2026-05-10T09:00:15Z"),
-          new DemoMessageResponse("msg-3", "user", "주문번호는 ORD-12345입니다", "2026-05-10T09:01:00Z"),
+          new DemoMessageResponse(
+              MESSAGE_WITH_ORDER_NUMBER, "user", "주문번호는 ORD-12345입니다", "2026-05-10T09:01:00Z"),
           new DemoMessageResponse(
               "msg-4",
               "assistant",
@@ -70,8 +84,8 @@ public class DemoRuntimeFixture {
   private static final DemoExecutionResponse EXECUTION =
       new DemoExecutionResponse(
           "exec-1",
-          "COMPLETED",
-          "COMPLETED",
+          STATE_COMPLETED,
+          STATE_COMPLETED,
           "wf-node-final",
           "환불 요청",
           Map.of("orderNumber", "ORD-12345", "refundAmount", 59000),
@@ -86,39 +100,39 @@ public class DemoRuntimeFixture {
               1,
               "msg-1",
               "INTENT_DETECTED",
-              "INITIAL",
-              "INTENT_DETECTED",
-              "ALLOW",
+              STATE_INITIAL,
+              STATE_INTENT_DETECTED,
+              DECISION_ALLOW,
               0.95,
               "환불 요청 패턴 감지"),
           new DemoDecisionLogResponse(
               "log-2",
               2,
-              "msg-3",
+              MESSAGE_WITH_ORDER_NUMBER,
               "SLOT_FILLED",
-              "INTENT_DETECTED",
-              "SLOT_COLLECTING",
-              "ALLOW",
+              STATE_INTENT_DETECTED,
+              STATE_SLOT_COLLECTING,
+              DECISION_ALLOW,
               0.88,
               "주문번호 slot 수집 완료"),
           new DemoDecisionLogResponse(
               "log-3",
               3,
-              "msg-3",
+              MESSAGE_WITH_ORDER_NUMBER,
               "POLICY_CHECKED",
-              "SLOT_COLLECTING",
-              "POLICY_CHECKING",
-              "ALLOW",
+              STATE_SLOT_COLLECTING,
+              STATE_POLICY_CHECKING,
+              DECISION_ALLOW,
               1.0,
               "환불 가능 기간 정책 통과"),
           new DemoDecisionLogResponse(
               "log-4",
               4,
-              "msg-3",
+              MESSAGE_WITH_ORDER_NUMBER,
               "RISK_CHECKED",
-              "POLICY_CHECKING",
-              "RISK_CHECKING",
-              "ALLOW",
+              STATE_POLICY_CHECKING,
+              STATE_RISK_CHECKING,
+              DECISION_ALLOW,
               0.75,
               "고액 환불 위험 낮음"),
           new DemoDecisionLogResponse(
@@ -126,9 +140,9 @@ public class DemoRuntimeFixture {
               5,
               "msg-4",
               "ANSWER_GENERATED",
-              "DECIDING",
-              "COMPLETED",
-              "ALLOW",
+              STATE_DECIDING,
+              STATE_COMPLETED,
+              DECISION_ALLOW,
               0.92,
               "환불 완료 안내 생성"));
   private static final DemoChatWorkflowResponse CHAT_WORKFLOW =

--- a/backend/src/main/java/com/init/chatdemo/application/DemoRuntimeFixture.java
+++ b/backend/src/main/java/com/init/chatdemo/application/DemoRuntimeFixture.java
@@ -100,7 +100,7 @@ public class DemoRuntimeFixture {
               "log-1",
               1,
               "msg-1",
-              "INTENT_DETECTED",
+              STATE_INTENT_DETECTED,
               STATE_INITIAL,
               STATE_INTENT_DETECTED,
               DECISION_ALLOW,

--- a/backend/src/main/java/com/init/chatdemo/application/DemoRuntimeFixture.java
+++ b/backend/src/main/java/com/init/chatdemo/application/DemoRuntimeFixture.java
@@ -56,7 +56,8 @@ public class DemoRuntimeFixture {
               STATE_COMPLETED,
               "HANDOFF"),
           List.of(
-              new DemoTransitionResponse(STATE_INITIAL, STATE_INTENT_DETECTED, "INTENT_DETECTED"),
+              new DemoTransitionResponse(
+                  STATE_INITIAL, STATE_INTENT_DETECTED, STATE_INTENT_DETECTED),
               new DemoTransitionResponse(
                   STATE_INTENT_DETECTED, STATE_SLOT_COLLECTING, "SLOT_FILLED"),
               new DemoTransitionResponse(

--- a/backend/src/main/java/com/init/chatdemo/application/DemoRuntimeFixture.java
+++ b/backend/src/main/java/com/init/chatdemo/application/DemoRuntimeFixture.java
@@ -1,4 +1,4 @@
-package com.init.chatdemo.domain;
+package com.init.chatdemo.application;
 
 import com.init.chatdemo.presentation.dto.DemoChatSessionResponse;
 import com.init.chatdemo.presentation.dto.DemoChatWorkflowResponse;
@@ -35,7 +35,7 @@ public class DemoRuntimeFixture {
           "배송 문의 처리",
           "배송 문의를 확인하고 정책과 위험을 점검합니다.",
           List.of("start", "slot_filling", "resolved"),
-          List.of(new DemoTransitionResponse("start", "slot_filling", "intent_detected")));
+          List.of(new DemoTransitionResponse("start", "slot_filling", "INTENT_DETECTED")));
   private static final DemoChatSessionResponse CHAT_SESSION =
       new DemoChatSessionResponse(
           "session-1", "completed", "2026-05-10T09:00:00Z", "2026-05-10T09:05:30Z");

--- a/backend/src/main/java/com/init/chatdemo/application/DemoRuntimeMockService.java
+++ b/backend/src/main/java/com/init/chatdemo/application/DemoRuntimeMockService.java
@@ -1,6 +1,5 @@
 package com.init.chatdemo.application;
 
-import com.init.chatdemo.domain.DemoRuntimeFixture;
 import com.init.chatdemo.presentation.dto.DemoChatSessionEndpointResponse;
 import com.init.chatdemo.presentation.dto.DemoChatSessionResponse;
 import com.init.chatdemo.presentation.dto.DemoChatWorkflowResponse;
@@ -12,8 +11,10 @@ import com.init.shared.application.exception.BadRequestException;
 import com.init.shared.application.exception.NotFoundException;
 import java.util.List;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional(readOnly = true)
 public class DemoRuntimeMockService {
 
   private final DemoRuntimeFixture fixture;
@@ -50,7 +51,7 @@ public class DemoRuntimeMockService {
   }
 
   public DemoDecisionLogEndpointResponse getDecisionLogs(String executionId) {
-    if (executionId == null) {
+    if (executionId == null || executionId.isBlank()) {
       throw new BadRequestException("DEMO_EXECUTION_ID_REQUIRED", "executionId is required");
     }
     List<DemoDecisionLogResponse> decisionLogs = fixture.findDecisionLogs(executionId);

--- a/backend/src/main/java/com/init/chatdemo/application/DemoRuntimeMockService.java
+++ b/backend/src/main/java/com/init/chatdemo/application/DemoRuntimeMockService.java
@@ -1,0 +1,63 @@
+package com.init.chatdemo.application;
+
+import com.init.chatdemo.domain.DemoRuntimeFixture;
+import com.init.chatdemo.presentation.dto.DemoChatSessionEndpointResponse;
+import com.init.chatdemo.presentation.dto.DemoChatSessionResponse;
+import com.init.chatdemo.presentation.dto.DemoChatWorkflowResponse;
+import com.init.chatdemo.presentation.dto.DemoDecisionLogEndpointResponse;
+import com.init.chatdemo.presentation.dto.DemoDecisionLogResponse;
+import com.init.chatdemo.presentation.dto.DemoDomainPackEndpointResponse;
+import com.init.chatdemo.presentation.dto.DemoExecutionResponse;
+import com.init.shared.application.exception.BadRequestException;
+import com.init.shared.application.exception.NotFoundException;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+@Service
+public class DemoRuntimeMockService {
+
+  private final DemoRuntimeFixture fixture;
+
+  public DemoRuntimeMockService(DemoRuntimeFixture fixture) {
+    this.fixture = fixture;
+  }
+
+  public DemoChatWorkflowResponse getChatWorkflow() {
+    return fixture.provideChatWorkflow();
+  }
+
+  public DemoDomainPackEndpointResponse getDomainPack() {
+    DemoChatWorkflowResponse chatWorkflow = getChatWorkflow();
+    return new DemoDomainPackEndpointResponse(chatWorkflow.domainPack(), chatWorkflow.workflow());
+  }
+
+  public DemoChatSessionEndpointResponse getChatSession(String sessionId) {
+    DemoChatSessionResponse session = fixture.findSession(sessionId);
+    if (session == null) {
+      throw new NotFoundException(
+          "DEMO_CHAT_SESSION_NOT_FOUND", "Chat session not found: " + sessionId);
+    }
+    return new DemoChatSessionEndpointResponse(session, fixture.findSessionMessages(sessionId));
+  }
+
+  public DemoExecutionResponse getWorkflowExecution(String executionId) {
+    DemoExecutionResponse execution = fixture.findExecution(executionId);
+    if (execution == null) {
+      throw new NotFoundException(
+          "DEMO_EXECUTION_NOT_FOUND", "Execution not found: " + executionId);
+    }
+    return execution;
+  }
+
+  public DemoDecisionLogEndpointResponse getDecisionLogs(String executionId) {
+    if (executionId == null) {
+      throw new BadRequestException("DEMO_EXECUTION_ID_REQUIRED", "executionId is required");
+    }
+    List<DemoDecisionLogResponse> decisionLogs = fixture.findDecisionLogs(executionId);
+    if (decisionLogs.isEmpty()) {
+      throw new NotFoundException(
+          "DEMO_EXECUTION_NOT_FOUND", "Execution not found: " + executionId);
+    }
+    return new DemoDecisionLogEndpointResponse(decisionLogs);
+  }
+}

--- a/backend/src/main/java/com/init/chatdemo/domain/DemoRuntimeFixture.java
+++ b/backend/src/main/java/com/init/chatdemo/domain/DemoRuntimeFixture.java
@@ -1,0 +1,104 @@
+package com.init.chatdemo.domain;
+
+import com.init.chatdemo.presentation.dto.DemoChatSessionResponse;
+import com.init.chatdemo.presentation.dto.DemoChatWorkflowResponse;
+import com.init.chatdemo.presentation.dto.DemoDecisionLogResponse;
+import com.init.chatdemo.presentation.dto.DemoDomainPackResponse;
+import com.init.chatdemo.presentation.dto.DemoExecutionResponse;
+import com.init.chatdemo.presentation.dto.DemoIntentResponse;
+import com.init.chatdemo.presentation.dto.DemoMessageResponse;
+import com.init.chatdemo.presentation.dto.DemoPolicyHitResponse;
+import com.init.chatdemo.presentation.dto.DemoPolicyResponse;
+import com.init.chatdemo.presentation.dto.DemoRiskHitResponse;
+import com.init.chatdemo.presentation.dto.DemoRiskResponse;
+import com.init.chatdemo.presentation.dto.DemoTransitionResponse;
+import com.init.chatdemo.presentation.dto.DemoWorkflowResponse;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DemoRuntimeFixture {
+
+  private static final DemoDomainPackResponse DOMAIN_PACK =
+      new DemoDomainPackResponse(
+          "demo-pack-1",
+          "CS Support Domain Pack",
+          "1.0.0",
+          "PUBLISHED",
+          List.of(new DemoIntentResponse("intent-1", "delivery_status", "배송 상태 확인")),
+          List.of(new DemoPolicyResponse("policy-1", "배송 조회 정책", "주문번호로 배송 조회", "medium")),
+          List.of(new DemoRiskResponse("risk-1", "개인정보 노출", "민감 정보 노출 여부", "low")));
+  private static final DemoWorkflowResponse WORKFLOW =
+      new DemoWorkflowResponse(
+          "workflow-1",
+          "배송 문의 처리",
+          "배송 문의를 확인하고 정책과 위험을 점검합니다.",
+          List.of("start", "slot_filling", "resolved"),
+          List.of(new DemoTransitionResponse("start", "slot_filling", "intent_detected")));
+  private static final DemoChatSessionResponse CHAT_SESSION =
+      new DemoChatSessionResponse(
+          "session-1", "completed", "2026-05-10T09:00:00Z", "2026-05-10T09:05:30Z");
+  private static final List<DemoMessageResponse> MESSAGES =
+      List.of(
+          new DemoMessageResponse(
+              "message-1", "customer", "배송 상태를 알고 싶어요.", "2026-05-10T09:00:10Z"));
+  private static final DemoExecutionResponse EXECUTION =
+      new DemoExecutionResponse(
+          "exec-1",
+          "completed",
+          "resolved",
+          "node-3",
+          "delivery_status",
+          Map.of("orderId", "ORD-2026-001"),
+          List.of(),
+          List.of(new DemoPolicyHitResponse("policy-1", "배송 조회 정책", "pass", "주문번호로 배송 조회 가능")),
+          List.of(new DemoRiskHitResponse("risk-1", "개인정보 노출", "safe", "민감 정보 노출 없음")));
+  private static final List<DemoDecisionLogResponse> DECISION_LOGS =
+      List.of(
+          new DemoDecisionLogResponse(
+              "log-1",
+              1,
+              "message-1",
+              "INTENT_DETECTED",
+              "start",
+              "slot_filling",
+              "ALLOW",
+              0.92,
+              "배송 상태 문의 표현이 포함됨"));
+  private static final DemoChatWorkflowResponse CHAT_WORKFLOW =
+      new DemoChatWorkflowResponse(
+          DOMAIN_PACK, WORKFLOW, CHAT_SESSION, MESSAGES, EXECUTION, DECISION_LOGS);
+
+  public DemoChatWorkflowResponse provideChatWorkflow() {
+    return CHAT_WORKFLOW;
+  }
+
+  public DemoChatSessionResponse findSession(String sessionId) {
+    if (CHAT_SESSION.id().equals(sessionId)) {
+      return CHAT_SESSION;
+    }
+    return null;
+  }
+
+  public List<DemoMessageResponse> findSessionMessages(String sessionId) {
+    if (CHAT_SESSION.id().equals(sessionId)) {
+      return MESSAGES;
+    }
+    return List.of();
+  }
+
+  public DemoExecutionResponse findExecution(String executionId) {
+    if (EXECUTION.id().equals(executionId)) {
+      return EXECUTION;
+    }
+    return null;
+  }
+
+  public List<DemoDecisionLogResponse> findDecisionLogs(String executionId) {
+    if (EXECUTION.id().equals(executionId)) {
+      return DECISION_LOGS;
+    }
+    return List.of();
+  }
+}

--- a/backend/src/main/java/com/init/chatdemo/presentation/DemoRuntimeController.java
+++ b/backend/src/main/java/com/init/chatdemo/presentation/DemoRuntimeController.java
@@ -1,0 +1,53 @@
+package com.init.chatdemo.presentation;
+
+import com.init.chatdemo.application.DemoRuntimeMockService;
+import com.init.chatdemo.presentation.dto.DemoChatSessionEndpointResponse;
+import com.init.chatdemo.presentation.dto.DemoChatWorkflowResponse;
+import com.init.chatdemo.presentation.dto.DemoDecisionLogEndpointResponse;
+import com.init.chatdemo.presentation.dto.DemoDomainPackEndpointResponse;
+import com.init.chatdemo.presentation.dto.DemoExecutionResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/demo")
+public class DemoRuntimeController {
+
+  private final DemoRuntimeMockService service;
+
+  public DemoRuntimeController(DemoRuntimeMockService service) {
+    this.service = service;
+  }
+
+  @GetMapping("/chat-workflow")
+  public ResponseEntity<DemoChatWorkflowResponse> getChatWorkflow() {
+    return ResponseEntity.ok(service.getChatWorkflow());
+  }
+
+  @GetMapping("/domain-pack")
+  public ResponseEntity<DemoDomainPackEndpointResponse> getDomainPack() {
+    return ResponseEntity.ok(service.getDomainPack());
+  }
+
+  @GetMapping("/chat-sessions/{sessionId}")
+  public ResponseEntity<DemoChatSessionEndpointResponse> getChatSession(
+      @PathVariable String sessionId) {
+    return ResponseEntity.ok(service.getChatSession(sessionId));
+  }
+
+  @GetMapping("/workflow-executions/{executionId}")
+  public ResponseEntity<DemoExecutionResponse> getWorkflowExecution(
+      @PathVariable String executionId) {
+    return ResponseEntity.ok(service.getWorkflowExecution(executionId));
+  }
+
+  @GetMapping("/decision-logs")
+  public ResponseEntity<DemoDecisionLogEndpointResponse> getDecisionLogs(
+      @RequestParam(required = true) String executionId) {
+    return ResponseEntity.ok(service.getDecisionLogs(executionId));
+  }
+}

--- a/backend/src/main/java/com/init/chatdemo/presentation/dto/DemoChatSessionEndpointResponse.java
+++ b/backend/src/main/java/com/init/chatdemo/presentation/dto/DemoChatSessionEndpointResponse.java
@@ -1,0 +1,6 @@
+package com.init.chatdemo.presentation.dto;
+
+import java.util.List;
+
+public record DemoChatSessionEndpointResponse(
+    DemoChatSessionResponse chatSession, List<DemoMessageResponse> messages) {}

--- a/backend/src/main/java/com/init/chatdemo/presentation/dto/DemoChatSessionResponse.java
+++ b/backend/src/main/java/com/init/chatdemo/presentation/dto/DemoChatSessionResponse.java
@@ -1,0 +1,4 @@
+package com.init.chatdemo.presentation.dto;
+
+public record DemoChatSessionResponse(
+    String id, String status, String startedAt, String completedAt) {}

--- a/backend/src/main/java/com/init/chatdemo/presentation/dto/DemoChatWorkflowResponse.java
+++ b/backend/src/main/java/com/init/chatdemo/presentation/dto/DemoChatWorkflowResponse.java
@@ -1,0 +1,11 @@
+package com.init.chatdemo.presentation.dto;
+
+import java.util.List;
+
+public record DemoChatWorkflowResponse(
+    DemoDomainPackResponse domainPack,
+    DemoWorkflowResponse workflow,
+    DemoChatSessionResponse chatSession,
+    List<DemoMessageResponse> messages,
+    DemoExecutionResponse execution,
+    List<DemoDecisionLogResponse> decisionLogs) {}

--- a/backend/src/main/java/com/init/chatdemo/presentation/dto/DemoDecisionLogEndpointResponse.java
+++ b/backend/src/main/java/com/init/chatdemo/presentation/dto/DemoDecisionLogEndpointResponse.java
@@ -1,0 +1,5 @@
+package com.init.chatdemo.presentation.dto;
+
+import java.util.List;
+
+public record DemoDecisionLogEndpointResponse(List<DemoDecisionLogResponse> decisionLogs) {}

--- a/backend/src/main/java/com/init/chatdemo/presentation/dto/DemoDecisionLogResponse.java
+++ b/backend/src/main/java/com/init/chatdemo/presentation/dto/DemoDecisionLogResponse.java
@@ -1,0 +1,12 @@
+package com.init.chatdemo.presentation.dto;
+
+public record DemoDecisionLogResponse(
+    String id,
+    int step,
+    String messageId,
+    String eventType,
+    String stateFrom,
+    String stateTo,
+    String decision,
+    double confidence,
+    String reason) {}

--- a/backend/src/main/java/com/init/chatdemo/presentation/dto/DemoDomainPackEndpointResponse.java
+++ b/backend/src/main/java/com/init/chatdemo/presentation/dto/DemoDomainPackEndpointResponse.java
@@ -1,0 +1,4 @@
+package com.init.chatdemo.presentation.dto;
+
+public record DemoDomainPackEndpointResponse(
+    DemoDomainPackResponse domainPack, DemoWorkflowResponse workflow) {}

--- a/backend/src/main/java/com/init/chatdemo/presentation/dto/DemoDomainPackResponse.java
+++ b/backend/src/main/java/com/init/chatdemo/presentation/dto/DemoDomainPackResponse.java
@@ -1,0 +1,12 @@
+package com.init.chatdemo.presentation.dto;
+
+import java.util.List;
+
+public record DemoDomainPackResponse(
+    String id,
+    String name,
+    String version,
+    String status,
+    List<DemoIntentResponse> intents,
+    List<DemoPolicyResponse> policies,
+    List<DemoRiskResponse> risks) {}

--- a/backend/src/main/java/com/init/chatdemo/presentation/dto/DemoExecutionResponse.java
+++ b/backend/src/main/java/com/init/chatdemo/presentation/dto/DemoExecutionResponse.java
@@ -1,0 +1,15 @@
+package com.init.chatdemo.presentation.dto;
+
+import java.util.List;
+import java.util.Map;
+
+public record DemoExecutionResponse(
+    String id,
+    String status,
+    String currentState,
+    String currentNodeId,
+    String intent,
+    Map<String, Object> slotValues,
+    List<String> missingSlots,
+    List<DemoPolicyHitResponse> policyHits,
+    List<DemoRiskHitResponse> riskHits) {}

--- a/backend/src/main/java/com/init/chatdemo/presentation/dto/DemoIntentResponse.java
+++ b/backend/src/main/java/com/init/chatdemo/presentation/dto/DemoIntentResponse.java
@@ -1,0 +1,3 @@
+package com.init.chatdemo.presentation.dto;
+
+public record DemoIntentResponse(String id, String name, String description) {}

--- a/backend/src/main/java/com/init/chatdemo/presentation/dto/DemoMessageResponse.java
+++ b/backend/src/main/java/com/init/chatdemo/presentation/dto/DemoMessageResponse.java
@@ -1,0 +1,3 @@
+package com.init.chatdemo.presentation.dto;
+
+public record DemoMessageResponse(String id, String role, String content, String timestamp) {}

--- a/backend/src/main/java/com/init/chatdemo/presentation/dto/DemoPolicyHitResponse.java
+++ b/backend/src/main/java/com/init/chatdemo/presentation/dto/DemoPolicyHitResponse.java
@@ -1,0 +1,4 @@
+package com.init.chatdemo.presentation.dto;
+
+public record DemoPolicyHitResponse(
+    String policyId, String policyName, String result, String detail) {}

--- a/backend/src/main/java/com/init/chatdemo/presentation/dto/DemoPolicyResponse.java
+++ b/backend/src/main/java/com/init/chatdemo/presentation/dto/DemoPolicyResponse.java
@@ -1,0 +1,3 @@
+package com.init.chatdemo.presentation.dto;
+
+public record DemoPolicyResponse(String id, String name, String description, String severity) {}

--- a/backend/src/main/java/com/init/chatdemo/presentation/dto/DemoRiskHitResponse.java
+++ b/backend/src/main/java/com/init/chatdemo/presentation/dto/DemoRiskHitResponse.java
@@ -1,0 +1,3 @@
+package com.init.chatdemo.presentation.dto;
+
+public record DemoRiskHitResponse(String riskId, String riskName, String result, String detail) {}

--- a/backend/src/main/java/com/init/chatdemo/presentation/dto/DemoRiskResponse.java
+++ b/backend/src/main/java/com/init/chatdemo/presentation/dto/DemoRiskResponse.java
@@ -1,0 +1,3 @@
+package com.init.chatdemo.presentation.dto;
+
+public record DemoRiskResponse(String id, String name, String description, String level) {}

--- a/backend/src/main/java/com/init/chatdemo/presentation/dto/DemoTransitionResponse.java
+++ b/backend/src/main/java/com/init/chatdemo/presentation/dto/DemoTransitionResponse.java
@@ -1,0 +1,3 @@
+package com.init.chatdemo.presentation.dto;
+
+public record DemoTransitionResponse(String from, String to, String on) {}

--- a/backend/src/main/java/com/init/chatdemo/presentation/dto/DemoWorkflowResponse.java
+++ b/backend/src/main/java/com/init/chatdemo/presentation/dto/DemoWorkflowResponse.java
@@ -1,0 +1,10 @@
+package com.init.chatdemo.presentation.dto;
+
+import java.util.List;
+
+public record DemoWorkflowResponse(
+    String id,
+    String name,
+    String description,
+    List<String> states,
+    List<DemoTransitionResponse> transitions) {}

--- a/backend/src/test/java/com/init/chatdemo/application/DemoRuntimeMockServiceTest.java
+++ b/backend/src/test/java/com/init/chatdemo/application/DemoRuntimeMockServiceTest.java
@@ -3,6 +3,7 @@ package com.init.chatdemo.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.init.chatdemo.presentation.dto.DemoChatSessionEndpointResponse;
 import com.init.chatdemo.presentation.dto.DemoChatSessionResponse;
 import com.init.chatdemo.presentation.dto.DemoChatWorkflowResponse;
 import com.init.chatdemo.presentation.dto.DemoDecisionLogEndpointResponse;
@@ -26,7 +27,8 @@ class DemoRuntimeMockServiceTest {
 
   private static final String SERVICE_CLASS_NAME =
       "com.init.chatdemo.application.DemoRuntimeMockService";
-  private static final String FIXTURE_CLASS_NAME = "com.init.chatdemo.application.DemoRuntimeFixture";
+  private static final String FIXTURE_CLASS_NAME =
+      "com.init.chatdemo.application.DemoRuntimeFixture";
 
   private static final Set<String> ALLOWED_EVENT_TYPES =
       Set.of(
@@ -126,7 +128,7 @@ class DemoRuntimeMockServiceTest {
                     "getChatSession",
                     String.class,
                     "unknown-session-id",
-                    DemoChatSessionResponse.class))
+                    DemoChatSessionEndpointResponse.class))
         .isInstanceOf(NotFoundException.class);
   }
 

--- a/backend/src/test/java/com/init/chatdemo/application/DemoRuntimeMockServiceTest.java
+++ b/backend/src/test/java/com/init/chatdemo/application/DemoRuntimeMockServiceTest.java
@@ -24,7 +24,7 @@ class DemoRuntimeMockServiceTest {
 
   private static final String SERVICE_CLASS_NAME =
       "com.init.chatdemo.application.DemoRuntimeMockService";
-  private static final String FIXTURE_CLASS_NAME = "com.init.chatdemo.domain.DemoRuntimeFixture";
+  private static final String FIXTURE_CLASS_NAME = "com.init.chatdemo.application.DemoRuntimeFixture";
 
   private static final Set<String> ALLOWED_EVENT_TYPES =
       Set.of(
@@ -150,6 +150,22 @@ class DemoRuntimeMockServiceTest {
                     "getDecisionLogs",
                     String.class,
                     "unknown-execution-id",
+                    DemoDecisionLogEndpointResponse.class))
+        .isInstanceOf(RuntimeException.class);
+  }
+
+  @Test
+  @DisplayName("blank executionId로 decisionLogs 조회 시 오류가 발생한다")
+  void should_throw_when_lookingUpBlankDecisionLogsExecutionId() {
+    Object service = newService();
+
+    assertThatThrownBy(
+            () ->
+                invoke(
+                    service,
+                    "getDecisionLogs",
+                    String.class,
+                    " ",
                     DemoDecisionLogEndpointResponse.class))
         .isInstanceOf(RuntimeException.class);
   }

--- a/backend/src/test/java/com/init/chatdemo/application/DemoRuntimeMockServiceTest.java
+++ b/backend/src/test/java/com/init/chatdemo/application/DemoRuntimeMockServiceTest.java
@@ -1,0 +1,295 @@
+package com.init.chatdemo.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.init.chatdemo.presentation.dto.DemoChatSessionResponse;
+import com.init.chatdemo.presentation.dto.DemoChatWorkflowResponse;
+import com.init.chatdemo.presentation.dto.DemoDecisionLogEndpointResponse;
+import com.init.chatdemo.presentation.dto.DemoExecutionResponse;
+import com.init.chatdemo.presentation.dto.DemoMessageResponse;
+import com.init.chatdemo.presentation.dto.DemoPolicyHitResponse;
+import com.init.chatdemo.presentation.dto.DemoRiskHitResponse;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class DemoRuntimeMockServiceTest {
+
+  private static final String SERVICE_CLASS_NAME =
+      "com.init.chatdemo.application.DemoRuntimeMockService";
+  private static final String FIXTURE_CLASS_NAME = "com.init.chatdemo.domain.DemoRuntimeFixture";
+
+  private static final Set<String> ALLOWED_EVENT_TYPES =
+      Set.of(
+          "INTENT_DETECTED",
+          "ACTION_SELECTED",
+          "SLOT_FILLED",
+          "POLICY_CHECKED",
+          "RISK_CHECKED",
+          "STATE_TRANSITIONED",
+          "ANSWER_GENERATED",
+          "HANDOFF_TRIGGERED",
+          "SESSION_COMPLETED");
+
+  @Test
+  @DisplayName("통합 응답의 decisionLogs와 개별 decision log 조회 결과가 동일하다")
+  void should_match_when_comparingIntegratedAndIndividualDecisionLogs() {
+    Object service = newService();
+    DemoChatWorkflowResponse integratedResponse =
+        invoke(service, "getChatWorkflow", DemoChatWorkflowResponse.class);
+
+    DemoDecisionLogEndpointResponse individualDecisionLogsResponse =
+        invoke(
+            service,
+            "getDecisionLogs",
+            String.class,
+            integratedResponse.execution().id(),
+            DemoDecisionLogEndpointResponse.class);
+
+    assertThat(individualDecisionLogsResponse.decisionLogs())
+        .isEqualTo(integratedResponse.decisionLogs());
+  }
+
+  @Test
+  @DisplayName("모든 decisionLog의 messageId가 messages ID 중 하나와 연결된다")
+  void should_link_when_decisionLogMessageIdMatchesMessageId() {
+    DemoChatWorkflowResponse response =
+        invoke(newService(), "getChatWorkflow", DemoChatWorkflowResponse.class);
+    Set<String> messageIds =
+        response.messages().stream().map(DemoMessageResponse::id).collect(Collectors.toSet());
+
+    assertThat(response.decisionLogs())
+        .allSatisfy(decisionLog -> assertThat(messageIds).contains(decisionLog.messageId()));
+  }
+
+  @Test
+  @DisplayName("모든 decisionLog의 confidence가 0.0 ~ 1.0 범위이다")
+  void should_beInRange_when_checkingConfidenceBound() {
+    DemoChatWorkflowResponse response =
+        invoke(newService(), "getChatWorkflow", DemoChatWorkflowResponse.class);
+
+    assertThat(response.decisionLogs())
+        .allSatisfy(decisionLog -> assertThat(decisionLog.confidence()).isBetween(0.0, 1.0));
+  }
+
+  @Test
+  @DisplayName("모든 decisionLog의 eventType이 허용된 9개 타입 중 하나이다")
+  void should_beValid_when_checkingEventType() {
+    DemoChatWorkflowResponse response =
+        invoke(newService(), "getChatWorkflow", DemoChatWorkflowResponse.class);
+
+    assertThat(response.decisionLogs())
+        .allSatisfy(
+            decisionLog -> assertThat(ALLOWED_EVENT_TYPES).contains(decisionLog.eventType()));
+  }
+
+  @Test
+  @DisplayName("execution 응답에 slotValues, missingSlots, policyHits, riskHits가 포함된다")
+  void should_containAllFields_when_checkingExecutionResponse() {
+    Object service = newService();
+    DemoChatWorkflowResponse response =
+        invoke(service, "getChatWorkflow", DemoChatWorkflowResponse.class);
+    DemoExecutionResponse execution =
+        invoke(
+            service,
+            "getWorkflowExecution",
+            String.class,
+            response.execution().id(),
+            DemoExecutionResponse.class);
+
+    assertThat(execution.slotValues()).isNotNull().isInstanceOf(Map.class);
+    assertThat(execution.missingSlots()).isNotNull().isInstanceOf(List.class);
+    assertThat(execution.policyHits()).isNotNull().isNotEmpty();
+    assertThat(execution.riskHits()).isNotNull().isNotEmpty();
+    assertThat(execution.policyHits()).allSatisfy(this::assertPolicyHitFields);
+    assertThat(execution.riskHits()).allSatisfy(this::assertRiskHitFields);
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 sessionId 조회 시 오류가 발생한다")
+  void should_throw_when_lookingUpUnknownSession() {
+    Object service = newService();
+
+    assertThatThrownBy(
+            () ->
+                invoke(
+                    service,
+                    "getChatSession",
+                    String.class,
+                    "unknown-session-id",
+                    DemoChatSessionResponse.class))
+        .isInstanceOf(RuntimeException.class);
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 executionId 조회 시 오류가 발생한다")
+  void should_throw_when_lookingUpUnknownExecution() {
+    Object service = newService();
+
+    assertThatThrownBy(
+            () ->
+                invoke(
+                    service,
+                    "getWorkflowExecution",
+                    String.class,
+                    "unknown-execution-id",
+                    DemoExecutionResponse.class))
+        .isInstanceOf(RuntimeException.class);
+
+    assertThatThrownBy(
+            () ->
+                invoke(
+                    service,
+                    "getDecisionLogs",
+                    String.class,
+                    "unknown-execution-id",
+                    DemoDecisionLogEndpointResponse.class))
+        .isInstanceOf(RuntimeException.class);
+  }
+
+  @Test
+  @DisplayName("모든 decisionLog의 stateFrom과 stateTo가 null 또는 blank가 아니다")
+  void should_notBeBlank_when_checkingDecisionLogStates() {
+    DemoChatWorkflowResponse response =
+        invoke(newService(), "getChatWorkflow", DemoChatWorkflowResponse.class);
+
+    assertThat(response.decisionLogs())
+        .allSatisfy(
+            decisionLog -> {
+              assertThat(decisionLog.stateFrom()).isNotBlank();
+              assertThat(decisionLog.stateTo()).isNotBlank();
+            });
+  }
+
+  @Test
+  @DisplayName("동일 sessionId로 여러 번 조회해도 동일한 결과를 반환한다")
+  void should_beConsistent_when_lookingUpSameSessionMultipleTimes() {
+    Object fixture = newFixture();
+    DemoChatWorkflowResponse response =
+        invoke(fixture, "provideChatWorkflow", DemoChatWorkflowResponse.class);
+    String sessionId = response.chatSession().id();
+
+    DemoChatSessionResponse firstSession =
+        invoke(fixture, "findSession", String.class, sessionId, DemoChatSessionResponse.class);
+    DemoChatSessionResponse secondSession =
+        invoke(fixture, "findSession", String.class, sessionId, DemoChatSessionResponse.class);
+    List<DemoMessageResponse> firstMessages =
+        invokeList(
+            fixture, "findSessionMessages", String.class, sessionId, DemoMessageResponse.class);
+    List<DemoMessageResponse> secondMessages =
+        invokeList(
+            fixture, "findSessionMessages", String.class, sessionId, DemoMessageResponse.class);
+
+    assertThat(secondSession).isEqualTo(firstSession);
+    assertThat(secondMessages).isEqualTo(firstMessages);
+  }
+
+  private Object newService() {
+    Object fixture = newFixture();
+    Class<?> serviceClass = runtimeClass(SERVICE_CLASS_NAME);
+    Constructor<?> constructor = constructor(serviceClass, fixture.getClass());
+    return instantiate(constructor, fixture);
+  }
+
+  private Object newFixture() {
+    return instantiate(constructor(runtimeClass(FIXTURE_CLASS_NAME)));
+  }
+
+  private Class<?> runtimeClass(String className) {
+    try {
+      return Class.forName(className);
+    } catch (ClassNotFoundException exception) {
+      throw new IllegalStateException(
+          "Required demo runtime contract class is missing: " + className, exception);
+    }
+  }
+
+  private Constructor<?> constructor(Class<?> type, Class<?>... parameterTypes) {
+    try {
+      return type.getDeclaredConstructor(parameterTypes);
+    } catch (NoSuchMethodException exception) {
+      throw new IllegalStateException(
+          "Required constructor is missing: " + type.getName(), exception);
+    }
+  }
+
+  private Object instantiate(Constructor<?> constructor, Object... arguments) {
+    try {
+      return constructor.newInstance(arguments);
+    } catch (InstantiationException | IllegalAccessException exception) {
+      throw new IllegalStateException("Failed to create demo runtime contract instance", exception);
+    } catch (InvocationTargetException exception) {
+      throw rethrowRuntime(exception.getCause());
+    }
+  }
+
+  private <T> T invoke(Object target, String methodName, Class<T> returnType) {
+    return invoke(target, methodName, null, null, returnType);
+  }
+
+  private <T> T invoke(
+      Object target,
+      String methodName,
+      Class<?> parameterType,
+      Object argument,
+      Class<T> returnType) {
+    return returnType.cast(invokeRaw(target, methodName, parameterType, argument));
+  }
+
+  private <T> List<T> invokeList(
+      Object target,
+      String methodName,
+      Class<?> parameterType,
+      Object argument,
+      Class<T> elementType) {
+    Object result = invokeRaw(target, methodName, parameterType, argument);
+    assertThat(result).isInstanceOf(List.class);
+    return ((List<?>) result).stream().map(elementType::cast).toList();
+  }
+
+  private Object invokeRaw(
+      Object target, String methodName, Class<?> parameterType, Object argument) {
+    try {
+      Method method =
+          parameterType == null
+              ? target.getClass().getDeclaredMethod(methodName)
+              : target.getClass().getDeclaredMethod(methodName, parameterType);
+      return parameterType == null ? method.invoke(target) : method.invoke(target, argument);
+    } catch (NoSuchMethodException | IllegalAccessException exception) {
+      throw new IllegalStateException("Required method is missing: " + methodName, exception);
+    } catch (InvocationTargetException exception) {
+      throw rethrowRuntime(exception.getCause());
+    }
+  }
+
+  private RuntimeException rethrowRuntime(Throwable cause) {
+    if (cause instanceof RuntimeException runtimeException) {
+      return runtimeException;
+    }
+    if (cause instanceof Error error) {
+      throw error;
+    }
+    return new IllegalStateException("Demo runtime contract invocation failed", cause);
+  }
+
+  private void assertPolicyHitFields(DemoPolicyHitResponse policyHit) {
+    assertThat(policyHit.policyId()).isNotBlank();
+    assertThat(policyHit.policyName()).isNotBlank();
+    assertThat(policyHit.result()).isNotBlank();
+    assertThat(policyHit.detail()).isNotBlank();
+  }
+
+  private void assertRiskHitFields(DemoRiskHitResponse riskHit) {
+    assertThat(riskHit.riskId()).isNotBlank();
+    assertThat(riskHit.riskName()).isNotBlank();
+    assertThat(riskHit.result()).isNotBlank();
+    assertThat(riskHit.detail()).isNotBlank();
+  }
+}

--- a/backend/src/test/java/com/init/chatdemo/application/DemoRuntimeMockServiceTest.java
+++ b/backend/src/test/java/com/init/chatdemo/application/DemoRuntimeMockServiceTest.java
@@ -10,6 +10,8 @@ import com.init.chatdemo.presentation.dto.DemoExecutionResponse;
 import com.init.chatdemo.presentation.dto.DemoMessageResponse;
 import com.init.chatdemo.presentation.dto.DemoPolicyHitResponse;
 import com.init.chatdemo.presentation.dto.DemoRiskHitResponse;
+import com.init.shared.application.exception.BadRequestException;
+import com.init.shared.application.exception.NotFoundException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -125,7 +127,7 @@ class DemoRuntimeMockServiceTest {
                     String.class,
                     "unknown-session-id",
                     DemoChatSessionResponse.class))
-        .isInstanceOf(RuntimeException.class);
+        .isInstanceOf(NotFoundException.class);
   }
 
   @Test
@@ -141,7 +143,7 @@ class DemoRuntimeMockServiceTest {
                     String.class,
                     "unknown-execution-id",
                     DemoExecutionResponse.class))
-        .isInstanceOf(RuntimeException.class);
+        .isInstanceOf(NotFoundException.class);
 
     assertThatThrownBy(
             () ->
@@ -151,7 +153,7 @@ class DemoRuntimeMockServiceTest {
                     String.class,
                     "unknown-execution-id",
                     DemoDecisionLogEndpointResponse.class))
-        .isInstanceOf(RuntimeException.class);
+        .isInstanceOf(NotFoundException.class);
   }
 
   @Test
@@ -167,7 +169,7 @@ class DemoRuntimeMockServiceTest {
                     String.class,
                     " ",
                     DemoDecisionLogEndpointResponse.class))
-        .isInstanceOf(RuntimeException.class);
+        .isInstanceOf(BadRequestException.class);
   }
 
   @Test

--- a/backend/src/test/java/com/init/chatdemo/application/DemoRuntimeMockServiceTest.java
+++ b/backend/src/test/java/com/init/chatdemo/application/DemoRuntimeMockServiceTest.java
@@ -80,6 +80,7 @@ class DemoRuntimeMockServiceTest {
         invoke(newService(), "getChatWorkflow", DemoChatWorkflowResponse.class);
 
     assertThat(response.decisionLogs())
+        .isNotEmpty()
         .allSatisfy(decisionLog -> assertThat(decisionLog.confidence()).isBetween(0.0, 1.0));
   }
 
@@ -90,6 +91,7 @@ class DemoRuntimeMockServiceTest {
         invoke(newService(), "getChatWorkflow", DemoChatWorkflowResponse.class);
 
     assertThat(response.decisionLogs())
+        .isNotEmpty()
         .allSatisfy(
             decisionLog -> assertThat(ALLOWED_EVENT_TYPES).contains(decisionLog.eventType()));
   }
@@ -181,6 +183,7 @@ class DemoRuntimeMockServiceTest {
         invoke(newService(), "getChatWorkflow", DemoChatWorkflowResponse.class);
 
     assertThat(response.decisionLogs())
+        .isNotEmpty()
         .allSatisfy(
             decisionLog -> {
               assertThat(decisionLog.stateFrom()).isNotBlank();

--- a/backend/src/test/java/com/init/chatdemo/presentation/DemoRuntimeControllerTest.java
+++ b/backend/src/test/java/com/init/chatdemo/presentation/DemoRuntimeControllerTest.java
@@ -1,0 +1,309 @@
+package com.init.chatdemo.presentation;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.init.chatdemo.application.DemoRuntimeMockService;
+import com.init.chatdemo.presentation.dto.DemoChatSessionEndpointResponse;
+import com.init.chatdemo.presentation.dto.DemoChatSessionResponse;
+import com.init.chatdemo.presentation.dto.DemoChatWorkflowResponse;
+import com.init.chatdemo.presentation.dto.DemoDecisionLogEndpointResponse;
+import com.init.chatdemo.presentation.dto.DemoDecisionLogResponse;
+import com.init.chatdemo.presentation.dto.DemoDomainPackEndpointResponse;
+import com.init.chatdemo.presentation.dto.DemoDomainPackResponse;
+import com.init.chatdemo.presentation.dto.DemoExecutionResponse;
+import com.init.chatdemo.presentation.dto.DemoIntentResponse;
+import com.init.chatdemo.presentation.dto.DemoMessageResponse;
+import com.init.chatdemo.presentation.dto.DemoPolicyHitResponse;
+import com.init.chatdemo.presentation.dto.DemoPolicyResponse;
+import com.init.chatdemo.presentation.dto.DemoRiskHitResponse;
+import com.init.chatdemo.presentation.dto.DemoRiskResponse;
+import com.init.chatdemo.presentation.dto.DemoTransitionResponse;
+import com.init.chatdemo.presentation.dto.DemoWorkflowResponse;
+import com.init.fixtures.WithLongPrincipal;
+import com.init.shared.application.exception.NotFoundException;
+import com.init.shared.infrastructure.security.JwtAuthenticationFilter;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(
+    value = DemoRuntimeController.class,
+    excludeFilters =
+        @ComponentScan.Filter(
+            type = FilterType.ASSIGNABLE_TYPE,
+            classes = JwtAuthenticationFilter.class))
+@DisplayName("DemoRuntimeController")
+class DemoRuntimeControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private DemoRuntimeMockService service;
+
+  @Test
+  @DisplayName("GET /api/v1/demo/chat-workflow → 200, 6개 섹션 JSON 검증")
+  @WithLongPrincipal(10L)
+  void should_200_when_getChatWorkflow() throws Exception {
+    given(service.getChatWorkflow()).willReturn(chatWorkflowResponse());
+
+    mockMvc
+        .perform(get("/api/v1/demo/chat-workflow").accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.domainPack").exists())
+        .andExpect(jsonPath("$.workflow").exists())
+        .andExpect(jsonPath("$.chatSession").exists())
+        .andExpect(jsonPath("$.messages").isArray())
+        .andExpect(jsonPath("$.execution").exists())
+        .andExpect(jsonPath("$.decisionLogs").isArray());
+  }
+
+  @Test
+  @DisplayName("GET /api/v1/demo/domain-pack → 200, domainPack와 workflow JSON 검증")
+  @WithLongPrincipal(10L)
+  void should_200_when_getDomainPack() throws Exception {
+    given(service.getDomainPack()).willReturn(domainPackEndpointResponse());
+
+    mockMvc
+        .perform(get("/api/v1/demo/domain-pack").accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.domainPack.id").value("demo-pack-1"))
+        .andExpect(jsonPath("$.domainPack.name").value("CS Support Domain Pack"))
+        .andExpect(jsonPath("$.domainPack.version").value("1.0.0"))
+        .andExpect(jsonPath("$.domainPack.status").value("PUBLISHED"))
+        .andExpect(jsonPath("$.domainPack.intents").isArray())
+        .andExpect(jsonPath("$.domainPack.policies").isArray())
+        .andExpect(jsonPath("$.domainPack.risks").isArray())
+        .andExpect(jsonPath("$.workflow.id").value("workflow-1"))
+        .andExpect(jsonPath("$.workflow.name").value("배송 문의 처리"))
+        .andExpect(jsonPath("$.workflow.description").value("배송 문의를 확인하고 정책과 위험을 점검합니다."))
+        .andExpect(jsonPath("$.workflow.states").isArray())
+        .andExpect(jsonPath("$.workflow.transitions").isArray());
+  }
+
+  @Test
+  @DisplayName("GET /api/v1/demo/chat-sessions/{sessionId} → 200, chatSession과 messages JSON 검증")
+  @WithLongPrincipal(10L)
+  void should_200_when_getChatSession() throws Exception {
+    given(service.getChatSession("session-1")).willReturn(chatSessionEndpointResponse());
+
+    mockMvc
+        .perform(get("/api/v1/demo/chat-sessions/session-1").accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.chatSession.id").value("session-1"))
+        .andExpect(jsonPath("$.chatSession.status").value("completed"))
+        .andExpect(jsonPath("$.chatSession.startedAt").value("2026-05-10T09:00:00Z"))
+        .andExpect(jsonPath("$.chatSession.completedAt").value("2026-05-10T09:05:30Z"))
+        .andExpect(jsonPath("$.messages").isArray())
+        .andExpect(jsonPath("$.messages[0].id").value("message-1"))
+        .andExpect(jsonPath("$.messages[0].role").value("customer"))
+        .andExpect(jsonPath("$.messages[0].content").value("배송 상태를 알고 싶어요."))
+        .andExpect(jsonPath("$.messages[0].timestamp").value("2026-05-10T09:00:10Z"));
+  }
+
+  @Test
+  @DisplayName("GET /api/v1/demo/chat-sessions/unknown-id → 404")
+  @WithLongPrincipal(10L)
+  void should_404_when_getUnknownChatSession() throws Exception {
+    given(service.getChatSession("unknown-id"))
+        .willThrow(new NotFoundException("DEMO_CHAT_SESSION_NOT_FOUND", "Chat session not found"));
+
+    mockMvc
+        .perform(get("/api/v1/demo/chat-sessions/unknown-id").accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isNotFound())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.code").value("DEMO_CHAT_SESSION_NOT_FOUND"));
+  }
+
+  @Test
+  @DisplayName("GET /api/v1/demo/workflow-executions/{executionId} → 200, execution 상세 JSON 검증")
+  @WithLongPrincipal(10L)
+  void should_200_when_getWorkflowExecution() throws Exception {
+    given(service.getWorkflowExecution("exec-1")).willReturn(executionResponse());
+
+    mockMvc
+        .perform(get("/api/v1/demo/workflow-executions/exec-1").accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.id").value("exec-1"))
+        .andExpect(jsonPath("$.status").value("completed"))
+        .andExpect(jsonPath("$.currentState").value("resolved"))
+        .andExpect(jsonPath("$.currentNodeId").value("node-3"))
+        .andExpect(jsonPath("$.intent").value("delivery_status"))
+        .andExpect(jsonPath("$.slotValues").isMap())
+        .andExpect(jsonPath("$.slotValues.orderId").value("ORD-2026-001"))
+        .andExpect(jsonPath("$.missingSlots").isArray())
+        .andExpect(jsonPath("$.policyHits").isArray())
+        .andExpect(jsonPath("$.policyHits[0].policyId").value("policy-1"))
+        .andExpect(jsonPath("$.policyHits[0].policyName").value("배송 조회 정책"))
+        .andExpect(jsonPath("$.policyHits[0].result").value("pass"))
+        .andExpect(jsonPath("$.policyHits[0].detail").value("주문번호로 배송 조회 가능"))
+        .andExpect(jsonPath("$.riskHits").isArray())
+        .andExpect(jsonPath("$.riskHits[0].riskId").value("risk-1"))
+        .andExpect(jsonPath("$.riskHits[0].riskName").value("개인정보 노출"))
+        .andExpect(jsonPath("$.riskHits[0].result").value("safe"))
+        .andExpect(jsonPath("$.riskHits[0].detail").value("민감 정보 노출 없음"));
+  }
+
+  @Test
+  @DisplayName("GET /api/v1/demo/workflow-executions/unknown-id → 404")
+  @WithLongPrincipal(10L)
+  void should_404_when_getUnknownWorkflowExecution() throws Exception {
+    given(service.getWorkflowExecution("unknown-id"))
+        .willThrow(
+            new NotFoundException("DEMO_WORKFLOW_EXECUTION_NOT_FOUND", "Execution not found"));
+
+    mockMvc
+        .perform(
+            get("/api/v1/demo/workflow-executions/unknown-id").accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isNotFound())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.code").value("DEMO_WORKFLOW_EXECUTION_NOT_FOUND"));
+  }
+
+  @Test
+  @DisplayName("GET /api/v1/demo/decision-logs?executionId=exec-1 → 200, decisionLogs JSON 검증")
+  @WithLongPrincipal(10L)
+  void should_200_when_getDecisionLogs() throws Exception {
+    given(service.getDecisionLogs("exec-1")).willReturn(decisionLogEndpointResponse());
+
+    mockMvc
+        .perform(get("/api/v1/demo/decision-logs").queryParam("executionId", "exec-1"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.decisionLogs").isArray())
+        .andExpect(jsonPath("$.decisionLogs[0].id").value("log-1"))
+        .andExpect(jsonPath("$.decisionLogs[0].step").value(1))
+        .andExpect(jsonPath("$.decisionLogs[0].messageId").value("message-1"))
+        .andExpect(jsonPath("$.decisionLogs[0].eventType").value("intent_detected"))
+        .andExpect(jsonPath("$.decisionLogs[0].stateFrom").value("start"))
+        .andExpect(jsonPath("$.decisionLogs[0].stateTo").value("slot_filling"))
+        .andExpect(jsonPath("$.decisionLogs[0].decision").value("배송 조회 의도 감지"))
+        .andExpect(jsonPath("$.decisionLogs[0].confidence").value(0.92))
+        .andExpect(jsonPath("$.decisionLogs[0].reason").value("배송 상태 문의 표현이 포함됨"));
+  }
+
+  @Test
+  @DisplayName("GET /api/v1/demo/decision-logs executionId 누락 → 400")
+  @WithLongPrincipal(10L)
+  void should_400_when_missingExecutionId() throws Exception {
+    mockMvc
+        .perform(get("/api/v1/demo/decision-logs").accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("GET /api/v1/demo/decision-logs?executionId=unknown → 404")
+  @WithLongPrincipal(10L)
+  void should_404_when_getUnknownDecisionLogs() throws Exception {
+    given(service.getDecisionLogs("unknown"))
+        .willThrow(
+            new NotFoundException("DEMO_DECISION_LOGS_NOT_FOUND", "Decision logs not found"));
+
+    mockMvc
+        .perform(get("/api/v1/demo/decision-logs").queryParam("executionId", "unknown"))
+        .andExpect(status().isNotFound())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.code").value("DEMO_DECISION_LOGS_NOT_FOUND"));
+  }
+
+  @Test
+  @DisplayName("인증 없이 요청 시 401 반환")
+  void should_401_when_unauthenticated() throws Exception {
+    mockMvc
+        .perform(get("/api/v1/demo/chat-workflow").accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isUnauthorized());
+  }
+
+  private DemoChatWorkflowResponse chatWorkflowResponse() {
+    return new DemoChatWorkflowResponse(
+        domainPackResponse(),
+        workflowResponse(),
+        sessionResponse(),
+        messageResponses(),
+        executionResponse(),
+        decisionLogResponses());
+  }
+
+  private DemoDomainPackEndpointResponse domainPackEndpointResponse() {
+    return new DemoDomainPackEndpointResponse(domainPackResponse(), workflowResponse());
+  }
+
+  private DemoChatSessionEndpointResponse chatSessionEndpointResponse() {
+    return new DemoChatSessionEndpointResponse(sessionResponse(), messageResponses());
+  }
+
+  private DemoDecisionLogEndpointResponse decisionLogEndpointResponse() {
+    return new DemoDecisionLogEndpointResponse(decisionLogResponses());
+  }
+
+  private DemoDomainPackResponse domainPackResponse() {
+    return new DemoDomainPackResponse(
+        "demo-pack-1",
+        "CS Support Domain Pack",
+        "1.0.0",
+        "PUBLISHED",
+        List.of(new DemoIntentResponse("intent-1", "delivery_status", "배송 상태 확인")),
+        List.of(new DemoPolicyResponse("policy-1", "배송 조회 정책", "주문번호로 배송 조회", "medium")),
+        List.of(new DemoRiskResponse("risk-1", "개인정보 노출", "민감 정보 노출 여부", "low")));
+  }
+
+  private DemoWorkflowResponse workflowResponse() {
+    return new DemoWorkflowResponse(
+        "workflow-1",
+        "배송 문의 처리",
+        "배송 문의를 확인하고 정책과 위험을 점검합니다.",
+        List.of("start", "slot_filling", "resolved"),
+        List.of(new DemoTransitionResponse("start", "slot_filling", "intent_detected")));
+  }
+
+  private DemoChatSessionResponse sessionResponse() {
+    return new DemoChatSessionResponse(
+        "session-1", "completed", "2026-05-10T09:00:00Z", "2026-05-10T09:05:30Z");
+  }
+
+  private List<DemoMessageResponse> messageResponses() {
+    return List.of(
+        new DemoMessageResponse("message-1", "customer", "배송 상태를 알고 싶어요.", "2026-05-10T09:00:10Z"));
+  }
+
+  private DemoExecutionResponse executionResponse() {
+    return new DemoExecutionResponse(
+        "exec-1",
+        "completed",
+        "resolved",
+        "node-3",
+        "delivery_status",
+        Map.of("orderId", "ORD-2026-001"),
+        List.of(),
+        List.of(new DemoPolicyHitResponse("policy-1", "배송 조회 정책", "pass", "주문번호로 배송 조회 가능")),
+        List.of(new DemoRiskHitResponse("risk-1", "개인정보 노출", "safe", "민감 정보 노출 없음")));
+  }
+
+  private List<DemoDecisionLogResponse> decisionLogResponses() {
+    return List.of(
+        new DemoDecisionLogResponse(
+            "log-1",
+            1,
+            "message-1",
+            "intent_detected",
+            "start",
+            "slot_filling",
+            "배송 조회 의도 감지",
+            0.92,
+            "배송 상태 문의 표현이 포함됨"));
+  }
+}

--- a/backend/src/test/java/com/init/chatdemo/presentation/DemoRuntimeControllerTest.java
+++ b/backend/src/test/java/com/init/chatdemo/presentation/DemoRuntimeControllerTest.java
@@ -87,8 +87,8 @@ class DemoRuntimeControllerTest {
         .andExpect(jsonPath("$.domainPack.policies").isArray())
         .andExpect(jsonPath("$.domainPack.risks").isArray())
         .andExpect(jsonPath("$.workflow.id").value("workflow-1"))
-        .andExpect(jsonPath("$.workflow.name").value("배송 문의 처리"))
-        .andExpect(jsonPath("$.workflow.description").value("배송 문의를 확인하고 정책과 위험을 점검합니다."))
+        .andExpect(jsonPath("$.workflow.name").value("환불 처리 워크플로우"))
+        .andExpect(jsonPath("$.workflow.description").value("고객 환불 요청을 처리하는 워크플로우"))
         .andExpect(jsonPath("$.workflow.states").isArray())
         .andExpect(jsonPath("$.workflow.transitions").isArray());
   }
@@ -108,10 +108,12 @@ class DemoRuntimeControllerTest {
         .andExpect(jsonPath("$.chatSession.startedAt").value("2026-05-10T09:00:00Z"))
         .andExpect(jsonPath("$.chatSession.completedAt").value("2026-05-10T09:05:30Z"))
         .andExpect(jsonPath("$.messages").isArray())
-        .andExpect(jsonPath("$.messages[0].id").value("message-1"))
-        .andExpect(jsonPath("$.messages[0].role").value("customer"))
-        .andExpect(jsonPath("$.messages[0].content").value("배송 상태를 알고 싶어요."))
-        .andExpect(jsonPath("$.messages[0].timestamp").value("2026-05-10T09:00:10Z"));
+        .andExpect(jsonPath("$.messages[0].id").value("msg-1"))
+        .andExpect(jsonPath("$.messages[0].role").value("user"))
+        .andExpect(jsonPath("$.messages[0].content").value("제품 환불하고 싶습니다"))
+        .andExpect(jsonPath("$.messages[0].timestamp").value("2026-05-10T09:00:00Z"))
+        .andExpect(jsonPath("$.messages[3].id").value("msg-4"))
+        .andExpect(jsonPath("$.messages[3].role").value("assistant"));
   }
 
   @Test
@@ -139,23 +141,24 @@ class DemoRuntimeControllerTest {
         .andExpect(status().isOk())
         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.id").value("exec-1"))
-        .andExpect(jsonPath("$.status").value("completed"))
-        .andExpect(jsonPath("$.currentState").value("resolved"))
-        .andExpect(jsonPath("$.currentNodeId").value("node-3"))
-        .andExpect(jsonPath("$.intent").value("delivery_status"))
+        .andExpect(jsonPath("$.status").value("COMPLETED"))
+        .andExpect(jsonPath("$.currentState").value("COMPLETED"))
+        .andExpect(jsonPath("$.currentNodeId").value("wf-node-final"))
+        .andExpect(jsonPath("$.intent").value("환불 요청"))
         .andExpect(jsonPath("$.slotValues").isMap())
-        .andExpect(jsonPath("$.slotValues.orderId").value("ORD-2026-001"))
+        .andExpect(jsonPath("$.slotValues.orderNumber").value("ORD-12345"))
+        .andExpect(jsonPath("$.slotValues.refundAmount").value(59000))
         .andExpect(jsonPath("$.missingSlots").isArray())
         .andExpect(jsonPath("$.policyHits").isArray())
         .andExpect(jsonPath("$.policyHits[0].policyId").value("policy-1"))
-        .andExpect(jsonPath("$.policyHits[0].policyName").value("배송 조회 정책"))
-        .andExpect(jsonPath("$.policyHits[0].result").value("pass"))
-        .andExpect(jsonPath("$.policyHits[0].detail").value("주문번호로 배송 조회 가능"))
+        .andExpect(jsonPath("$.policyHits[0].policyName").value("환불 가능 기간"))
+        .andExpect(jsonPath("$.policyHits[0].result").value("PASS"))
+        .andExpect(jsonPath("$.policyHits[0].detail").value("구매일로부터 14일 이내"))
         .andExpect(jsonPath("$.riskHits").isArray())
         .andExpect(jsonPath("$.riskHits[0].riskId").value("risk-1"))
-        .andExpect(jsonPath("$.riskHits[0].riskName").value("개인정보 노출"))
-        .andExpect(jsonPath("$.riskHits[0].result").value("safe"))
-        .andExpect(jsonPath("$.riskHits[0].detail").value("민감 정보 노출 없음"));
+        .andExpect(jsonPath("$.riskHits[0].riskName").value("고액 환불"))
+        .andExpect(jsonPath("$.riskHits[0].result").value("LOW"))
+        .andExpect(jsonPath("$.riskHits[0].detail").value("환불 금액 59,000원 — 고액 환불 기준 미만"));
   }
 
   @Test
@@ -187,13 +190,14 @@ class DemoRuntimeControllerTest {
         .andExpect(jsonPath("$.decisionLogs").isArray())
         .andExpect(jsonPath("$.decisionLogs[0].id").value("log-1"))
         .andExpect(jsonPath("$.decisionLogs[0].step").value(1))
-        .andExpect(jsonPath("$.decisionLogs[0].messageId").value("message-1"))
+        .andExpect(jsonPath("$.decisionLogs[0].messageId").value("msg-1"))
         .andExpect(jsonPath("$.decisionLogs[0].eventType").value("INTENT_DETECTED"))
-        .andExpect(jsonPath("$.decisionLogs[0].stateFrom").value("start"))
-        .andExpect(jsonPath("$.decisionLogs[0].stateTo").value("slot_filling"))
-        .andExpect(jsonPath("$.decisionLogs[0].decision").value("배송 조회 의도 감지"))
-        .andExpect(jsonPath("$.decisionLogs[0].confidence").value(0.92))
-        .andExpect(jsonPath("$.decisionLogs[0].reason").value("배송 상태 문의 표현이 포함됨"));
+        .andExpect(jsonPath("$.decisionLogs[0].stateFrom").value("INITIAL"))
+        .andExpect(jsonPath("$.decisionLogs[0].stateTo").value("INTENT_DETECTED"))
+        .andExpect(jsonPath("$.decisionLogs[0].decision").value("ALLOW"))
+        .andExpect(jsonPath("$.decisionLogs[0].confidence").value(0.95))
+        .andExpect(jsonPath("$.decisionLogs[0].reason").value("환불 요청 패턴 감지"))
+        .andExpect(jsonPath("$.decisionLogs[4].eventType").value("ANSWER_GENERATED"));
   }
 
   @Test
@@ -256,18 +260,35 @@ class DemoRuntimeControllerTest {
         "CS Support Domain Pack",
         "1.0.0",
         "PUBLISHED",
-        List.of(new DemoIntentResponse("intent-1", "delivery_status", "배송 상태 확인")),
-        List.of(new DemoPolicyResponse("policy-1", "배송 조회 정책", "주문번호로 배송 조회", "medium")),
-        List.of(new DemoRiskResponse("risk-1", "개인정보 노출", "민감 정보 노출 여부", "low")));
+        List.of(
+            new DemoIntentResponse("intent-1", "환불 요청", "고객이 제품 환불을 요청하는 경우"),
+            new DemoIntentResponse("intent-2", "배송 조회", "고객이 배송 상태를 문의하는 경우")),
+        List.of(new DemoPolicyResponse("policy-1", "환불 가능 기간", "구매일로부터 14일 이내 환불 가능", "HARD")),
+        List.of(new DemoRiskResponse("risk-1", "고액 환불", "100만원 이상 환불 요청 시 리뷰 필요", "HIGH")));
   }
 
   private DemoWorkflowResponse workflowResponse() {
     return new DemoWorkflowResponse(
         "workflow-1",
-        "배송 문의 처리",
-        "배송 문의를 확인하고 정책과 위험을 점검합니다.",
-        List.of("start", "slot_filling", "resolved"),
-        List.of(new DemoTransitionResponse("start", "slot_filling", "INTENT_DETECTED")));
+        "환불 처리 워크플로우",
+        "고객 환불 요청을 처리하는 워크플로우",
+        List.of(
+            "INITIAL",
+            "INTENT_DETECTED",
+            "SLOT_COLLECTING",
+            "POLICY_CHECKING",
+            "RISK_CHECKING",
+            "DECIDING",
+            "COMPLETED",
+            "HANDOFF"),
+        List.of(
+            new DemoTransitionResponse("INITIAL", "INTENT_DETECTED", "INTENT_DETECTED"),
+            new DemoTransitionResponse("INTENT_DETECTED", "SLOT_COLLECTING", "SLOT_FILLED"),
+            new DemoTransitionResponse("SLOT_COLLECTING", "POLICY_CHECKING", "POLICY_CHECKED"),
+            new DemoTransitionResponse("POLICY_CHECKING", "RISK_CHECKING", "RISK_CHECKED"),
+            new DemoTransitionResponse("RISK_CHECKING", "DECIDING", "STATE_TRANSITIONED"),
+            new DemoTransitionResponse("DECIDING", "COMPLETED", "ANSWER_GENERATED"),
+            new DemoTransitionResponse("DECIDING", "HANDOFF", "HANDOFF_TRIGGERED")));
   }
 
   private DemoChatSessionResponse sessionResponse() {
@@ -277,20 +298,28 @@ class DemoRuntimeControllerTest {
 
   private List<DemoMessageResponse> messageResponses() {
     return List.of(
-        new DemoMessageResponse("message-1", "customer", "배송 상태를 알고 싶어요.", "2026-05-10T09:00:10Z"));
+        new DemoMessageResponse("msg-1", "user", "제품 환불하고 싶습니다", "2026-05-10T09:00:00Z"),
+        new DemoMessageResponse(
+            "msg-2", "assistant", "네, 환불 도와드리겠습니다. 주문번호를 알려주세요.", "2026-05-10T09:00:15Z"),
+        new DemoMessageResponse("msg-3", "user", "주문번호는 ORD-12345입니다", "2026-05-10T09:01:00Z"),
+        new DemoMessageResponse(
+            "msg-4",
+            "assistant",
+            "ORD-12345 주문에 대한 환불이 완료되었습니다. 14일 이내에 계좌로 입금됩니다.",
+            "2026-05-10T09:05:30Z"));
   }
 
   private DemoExecutionResponse executionResponse() {
     return new DemoExecutionResponse(
         "exec-1",
-        "completed",
-        "resolved",
-        "node-3",
-        "delivery_status",
-        Map.of("orderId", "ORD-2026-001"),
+        "COMPLETED",
+        "COMPLETED",
+        "wf-node-final",
+        "환불 요청",
+        Map.of("orderNumber", "ORD-12345", "refundAmount", 59000),
         List.of(),
-        List.of(new DemoPolicyHitResponse("policy-1", "배송 조회 정책", "pass", "주문번호로 배송 조회 가능")),
-        List.of(new DemoRiskHitResponse("risk-1", "개인정보 노출", "safe", "민감 정보 노출 없음")));
+        List.of(new DemoPolicyHitResponse("policy-1", "환불 가능 기간", "PASS", "구매일로부터 14일 이내")),
+        List.of(new DemoRiskHitResponse("risk-1", "고액 환불", "LOW", "환불 금액 59,000원 — 고액 환불 기준 미만")));
   }
 
   private List<DemoDecisionLogResponse> decisionLogResponses() {
@@ -298,12 +327,52 @@ class DemoRuntimeControllerTest {
         new DemoDecisionLogResponse(
             "log-1",
             1,
-            "message-1",
+            "msg-1",
             "INTENT_DETECTED",
-            "start",
-            "slot_filling",
-            "배송 조회 의도 감지",
+            "INITIAL",
+            "INTENT_DETECTED",
+            "ALLOW",
+            0.95,
+            "환불 요청 패턴 감지"),
+        new DemoDecisionLogResponse(
+            "log-2",
+            2,
+            "msg-3",
+            "SLOT_FILLED",
+            "INTENT_DETECTED",
+            "SLOT_COLLECTING",
+            "ALLOW",
+            0.88,
+            "주문번호 slot 수집 완료"),
+        new DemoDecisionLogResponse(
+            "log-3",
+            3,
+            "msg-3",
+            "POLICY_CHECKED",
+            "SLOT_COLLECTING",
+            "POLICY_CHECKING",
+            "ALLOW",
+            1.0,
+            "환불 가능 기간 정책 통과"),
+        new DemoDecisionLogResponse(
+            "log-4",
+            4,
+            "msg-3",
+            "RISK_CHECKED",
+            "POLICY_CHECKING",
+            "RISK_CHECKING",
+            "ALLOW",
+            0.75,
+            "고액 환불 위험 낮음"),
+        new DemoDecisionLogResponse(
+            "log-5",
+            5,
+            "msg-4",
+            "ANSWER_GENERATED",
+            "DECIDING",
+            "COMPLETED",
+            "ALLOW",
             0.92,
-            "배송 상태 문의 표현이 포함됨"));
+            "환불 완료 안내 생성"));
   }
 }

--- a/backend/src/test/java/com/init/chatdemo/presentation/DemoRuntimeControllerTest.java
+++ b/backend/src/test/java/com/init/chatdemo/presentation/DemoRuntimeControllerTest.java
@@ -188,7 +188,7 @@ class DemoRuntimeControllerTest {
         .andExpect(jsonPath("$.decisionLogs[0].id").value("log-1"))
         .andExpect(jsonPath("$.decisionLogs[0].step").value(1))
         .andExpect(jsonPath("$.decisionLogs[0].messageId").value("message-1"))
-        .andExpect(jsonPath("$.decisionLogs[0].eventType").value("intent_detected"))
+        .andExpect(jsonPath("$.decisionLogs[0].eventType").value("INTENT_DETECTED"))
         .andExpect(jsonPath("$.decisionLogs[0].stateFrom").value("start"))
         .andExpect(jsonPath("$.decisionLogs[0].stateTo").value("slot_filling"))
         .andExpect(jsonPath("$.decisionLogs[0].decision").value("배송 조회 의도 감지"))
@@ -267,7 +267,7 @@ class DemoRuntimeControllerTest {
         "배송 문의 처리",
         "배송 문의를 확인하고 정책과 위험을 점검합니다.",
         List.of("start", "slot_filling", "resolved"),
-        List.of(new DemoTransitionResponse("start", "slot_filling", "intent_detected")));
+        List.of(new DemoTransitionResponse("start", "slot_filling", "INTENT_DETECTED")));
   }
 
   private DemoChatSessionResponse sessionResponse() {
@@ -299,7 +299,7 @@ class DemoRuntimeControllerTest {
             "log-1",
             1,
             "message-1",
-            "intent_detected",
+            "INTENT_DETECTED",
             "start",
             "slot_filling",
             "배송 조회 의도 감지",

--- a/backend/src/test/java/com/init/chatdemo/presentation/dto/DemoDtoSerializationTest.java
+++ b/backend/src/test/java/com/init/chatdemo/presentation/dto/DemoDtoSerializationTest.java
@@ -1,0 +1,293 @@
+package com.init.chatdemo.presentation.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class DemoDtoSerializationTest {
+
+  private final ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
+
+  @Test
+  @DisplayName("DTO 직렬화/역직렬화 일치")
+  void should_matchContract_when_serializingDemoChatWorkflowResponse() throws Exception {
+    DemoChatWorkflowResponse response = chatWorkflowResponse();
+
+    String json = objectMapper.writeValueAsString(response);
+    JsonNode root = objectMapper.readTree(json);
+    DemoChatWorkflowResponse roundTripped =
+        objectMapper.readValue(json, DemoChatWorkflowResponse.class);
+
+    assertThat(root).hasSize(6);
+    assertThat(root.has("domainPack")).isTrue();
+    assertThat(root.has("workflow")).isTrue();
+    assertThat(root.has("chatSession")).isTrue();
+    assertThat(root.has("messages")).isTrue();
+    assertThat(root.has("execution")).isTrue();
+    assertThat(root.has("decisionLogs")).isTrue();
+    assertThat(json)
+        .contains(
+            "\"domainPack\"",
+            "\"workflow\"",
+            "\"chatSession\"",
+            "\"messages\"",
+            "\"execution\"",
+            "\"decisionLogs\"");
+    assertThat(roundTripped).isEqualTo(response);
+  }
+
+  @Test
+  @DisplayName("도메인 팩 엔드포인트 DTO 직렬화/역직렬화 일치")
+  void should_matchContract_when_serializingDomainPackEndpointResponse() throws Exception {
+    DemoDomainPackEndpointResponse response =
+        new DemoDomainPackEndpointResponse(domainPackResponse(), workflowResponse());
+
+    String json = objectMapper.writeValueAsString(response);
+    JsonNode root = objectMapper.readTree(json);
+    DemoDomainPackEndpointResponse roundTripped =
+        objectMapper.readValue(json, DemoDomainPackEndpointResponse.class);
+
+    assertThat(root).hasSize(2);
+    assertThat(root.has("domainPack")).isTrue();
+    assertThat(root.has("workflow")).isTrue();
+    assertThat(json).contains("\"domainPack\"", "\"workflow\"");
+    assertThat(roundTripped).isEqualTo(response);
+  }
+
+  @Test
+  @DisplayName("채팅 세션 엔드포인트 DTO 직렬화/역직렬화 일치")
+  void should_matchContract_when_serializingChatSessionEndpointResponse() throws Exception {
+    DemoChatSessionEndpointResponse response =
+        new DemoChatSessionEndpointResponse(chatSessionResponse(), messageResponses());
+
+    String json = objectMapper.writeValueAsString(response);
+    JsonNode root = objectMapper.readTree(json);
+    DemoChatSessionEndpointResponse roundTripped =
+        objectMapper.readValue(json, DemoChatSessionEndpointResponse.class);
+
+    assertThat(root).hasSize(2);
+    assertThat(root.has("chatSession")).isTrue();
+    assertThat(root.has("messages")).isTrue();
+    assertThat(json).contains("\"chatSession\"", "\"messages\"");
+    assertThat(roundTripped).isEqualTo(response);
+  }
+
+  @Test
+  @DisplayName("의사결정 로그 엔드포인트 DTO 직렬화/역직렬화 일치")
+  void should_matchContract_when_serializingDecisionLogEndpointResponse() throws Exception {
+    DemoDecisionLogEndpointResponse response =
+        new DemoDecisionLogEndpointResponse(decisionLogResponses());
+
+    String json = objectMapper.writeValueAsString(response);
+    JsonNode root = objectMapper.readTree(json);
+    DemoDecisionLogEndpointResponse roundTripped =
+        objectMapper.readValue(json, DemoDecisionLogEndpointResponse.class);
+
+    assertThat(root).hasSize(1);
+    assertThat(root.has("decisionLogs")).isTrue();
+    assertThat(json).contains("\"decisionLogs\"");
+    assertThat(roundTripped).isEqualTo(response);
+  }
+
+  @Test
+  @DisplayName("실행 DTO는 슬롯·정책·위험 구조를 유지한다")
+  void should_matchContract_when_serializingExecutionResponse() throws Exception {
+    DemoExecutionResponse response = executionResponse();
+
+    String json = objectMapper.writeValueAsString(response);
+    JsonNode root = objectMapper.readTree(json);
+    DemoExecutionResponse roundTripped = objectMapper.readValue(json, DemoExecutionResponse.class);
+
+    assertThat(root).hasSize(9);
+    assertThat(root.get("slotValues").get("orderNumber").asText()).isEqualTo("ORD-12345");
+    assertThat(root.get("slotValues").get("refundAmount").asInt()).isEqualTo(59000);
+    assertThat(root.get("missingSlots").isArray()).isTrue();
+    assertThat(root.get("policyHits")).hasSize(1);
+    assertThat(root.get("riskHits")).hasSize(1);
+    assertThat(json).contains("\"slotValues\"", "\"policyHits\"", "\"riskHits\"");
+    assertThat(roundTripped).isEqualTo(response);
+  }
+
+  @Test
+  @DisplayName("의사결정 로그 DTO는 숫자 타입과 모든 필드를 유지한다")
+  void should_matchContract_when_serializingDecisionLogResponse() throws Exception {
+    DemoDecisionLogResponse response = decisionLogResponses().getFirst();
+
+    String json = objectMapper.writeValueAsString(response);
+    JsonNode root = objectMapper.readTree(json);
+    DemoDecisionLogResponse roundTripped =
+        objectMapper.readValue(json, DemoDecisionLogResponse.class);
+
+    assertThat(root).hasSize(9);
+    assertThat(root.get("step").isInt()).isTrue();
+    assertThat(root.get("confidence").isDouble()).isTrue();
+    assertThat(json)
+        .contains(
+            "\"id\"",
+            "\"step\"",
+            "\"messageId\"",
+            "\"eventType\"",
+            "\"stateFrom\"",
+            "\"stateTo\"",
+            "\"decision\"",
+            "\"confidence\"",
+            "\"reason\"");
+    assertThat(roundTripped).isEqualTo(response);
+  }
+
+  @Test
+  @DisplayName("채팅 세션 DTO는 문자열 시간 필드를 유지한다")
+  void should_matchContract_when_serializingChatSessionResponse() throws Exception {
+    DemoChatSessionResponse response = chatSessionResponse();
+
+    String json = objectMapper.writeValueAsString(response);
+    JsonNode root = objectMapper.readTree(json);
+    DemoChatSessionResponse roundTripped =
+        objectMapper.readValue(json, DemoChatSessionResponse.class);
+
+    assertThat(root).hasSize(4);
+    assertThat(root.get("id").isTextual()).isTrue();
+    assertThat(root.get("status").isTextual()).isTrue();
+    assertThat(root.get("startedAt").isTextual()).isTrue();
+    assertThat(root.get("completedAt").isTextual()).isTrue();
+    assertThat(json).contains("\"id\"", "\"status\"", "\"startedAt\"", "\"completedAt\"");
+    assertThat(roundTripped).isEqualTo(response);
+  }
+
+  private DemoChatWorkflowResponse chatWorkflowResponse() {
+    return new DemoChatWorkflowResponse(
+        domainPackResponse(),
+        workflowResponse(),
+        chatSessionResponse(),
+        messageResponses(),
+        executionResponse(),
+        decisionLogResponses());
+  }
+
+  private DemoDomainPackResponse domainPackResponse() {
+    return new DemoDomainPackResponse(
+        "demo-pack-1",
+        "CS Support Domain Pack",
+        "1.0.0",
+        "PUBLISHED",
+        List.of(
+            new DemoIntentResponse("intent-1", "환불 요청", "고객이 제품 환불을 요청하는 경우"),
+            new DemoIntentResponse("intent-2", "배송 조회", "고객이 배송 상태를 문의하는 경우")),
+        List.of(new DemoPolicyResponse("policy-1", "환불 가능 기간", "구매일로부터 14일 이내 환불 가능", "HARD")),
+        List.of(new DemoRiskResponse("risk-1", "고액 환불", "100만원 이상 환불 요청 시 리뷰 필요", "HIGH")));
+  }
+
+  private DemoWorkflowResponse workflowResponse() {
+    return new DemoWorkflowResponse(
+        "workflow-1",
+        "환불 처리 워크플로우",
+        "고객 환불 요청을 처리하는 워크플로우",
+        List.of(
+            "INITIAL",
+            "INTENT_DETECTED",
+            "SLOT_COLLECTING",
+            "POLICY_CHECKING",
+            "RISK_CHECKING",
+            "DECIDING",
+            "COMPLETED",
+            "HANDOFF"),
+        List.of(
+            new DemoTransitionResponse("INITIAL", "INTENT_DETECTED", "INTENT_DETECTED"),
+            new DemoTransitionResponse("INTENT_DETECTED", "SLOT_COLLECTING", "SLOT_FILLED"),
+            new DemoTransitionResponse("SLOT_COLLECTING", "POLICY_CHECKING", "POLICY_CHECKED"),
+            new DemoTransitionResponse("POLICY_CHECKING", "RISK_CHECKING", "RISK_CHECKED"),
+            new DemoTransitionResponse("RISK_CHECKING", "DECIDING", "STATE_TRANSITIONED"),
+            new DemoTransitionResponse("DECIDING", "COMPLETED", "ANSWER_GENERATED"),
+            new DemoTransitionResponse("DECIDING", "HANDOFF", "HANDOFF_TRIGGERED")));
+  }
+
+  private DemoChatSessionResponse chatSessionResponse() {
+    return new DemoChatSessionResponse(
+        "session-1", "completed", "2026-05-10T09:00:00Z", "2026-05-10T09:05:30Z");
+  }
+
+  private List<DemoMessageResponse> messageResponses() {
+    return List.of(
+        new DemoMessageResponse("msg-1", "user", "제품 환불하고 싶습니다", "2026-05-10T09:00:00Z"),
+        new DemoMessageResponse(
+            "msg-2", "assistant", "네, 환불 도와드리겠습니다. 주문번호를 알려주세요.", "2026-05-10T09:00:15Z"),
+        new DemoMessageResponse("msg-3", "user", "주문번호는 ORD-12345입니다", "2026-05-10T09:01:00Z"),
+        new DemoMessageResponse(
+            "msg-4",
+            "assistant",
+            "ORD-12345 주문에 대한 환불이 완료되었습니다. 14일 이내에 계좌로 입금됩니다.",
+            "2026-05-10T09:05:30Z"));
+  }
+
+  private DemoExecutionResponse executionResponse() {
+    return new DemoExecutionResponse(
+        "exec-1",
+        "COMPLETED",
+        "COMPLETED",
+        "wf-node-final",
+        "환불 요청",
+        Map.of("orderNumber", "ORD-12345", "refundAmount", 59000),
+        List.of(),
+        List.of(new DemoPolicyHitResponse("policy-1", "환불 가능 기간", "PASS", "구매일로부터 14일 이내")),
+        List.of(new DemoRiskHitResponse("risk-1", "고액 환불", "LOW", "환불 금액 59,000원 — 고액 환불 기준 미만")));
+  }
+
+  private List<DemoDecisionLogResponse> decisionLogResponses() {
+    return List.of(
+        new DemoDecisionLogResponse(
+            "log-1",
+            1,
+            "msg-1",
+            "INTENT_DETECTED",
+            "INITIAL",
+            "INTENT_DETECTED",
+            "ALLOW",
+            0.95,
+            "환불 요청 패턴 감지"),
+        new DemoDecisionLogResponse(
+            "log-2",
+            2,
+            "msg-3",
+            "SLOT_FILLED",
+            "INTENT_DETECTED",
+            "SLOT_COLLECTING",
+            "ALLOW",
+            0.88,
+            "주문번호 slot 수집 완료"),
+        new DemoDecisionLogResponse(
+            "log-3",
+            3,
+            "msg-3",
+            "POLICY_CHECKED",
+            "SLOT_COLLECTING",
+            "POLICY_CHECKING",
+            "ALLOW",
+            1.0,
+            "환불 가능 기간 정책 통과"),
+        new DemoDecisionLogResponse(
+            "log-4",
+            4,
+            "msg-3",
+            "RISK_CHECKED",
+            "POLICY_CHECKING",
+            "RISK_CHECKING",
+            "ALLOW",
+            0.75,
+            "고액 환불 위험 낮음"),
+        new DemoDecisionLogResponse(
+            "log-5",
+            5,
+            "msg-4",
+            "ANSWER_GENERATED",
+            "DECIDING",
+            "COMPLETED",
+            "ALLOW",
+            0.92,
+            "환불 완료 안내 생성"));
+  }
+}


### PR DESCRIPTION
## Summary

Add 5 demo runtime mock API endpoints for frontend demo display, backed by in-memory
fixture data. No actual runtime engine, state machine, or database required.

- **Spec PR**: https://github.com/ajou-2026-1-capstone-5/ostone/pull/207
- **GitHub Issue**: 4.1.5 (SDD / Burndown Studio 작업)

## API Endpoints

| Method | Path | Description |
|--------|------|-------------|
| GET | `/api/v1/demo/chat-workflow` | Unified demo fixture (6 sections) |
| GET | `/api/v1/demo/domain-pack` | Domain pack + workflow data |
| GET | `/api/v1/demo/chat-sessions/{sessionId}` | Chat session with messages |
| GET | `/api/v1/demo/workflow-executions/{executionId}` | Execution detail with slots/policies/risks |
| GET | `/api/v1/demo/decision-logs?executionId={executionId}` | Decision logs for an execution |

## Changes

### Production code (`backend/src/main/java/com/init/chatdemo/`)

- **16 DTO records** for response serialization (under `presentation/dto/`)
- **DemoRuntimeFixture** (`@Component`): in-memory static fixture with domainPack, workflow, chatSession, messages, execution, decisionLogs
- **DemoRuntimeMockService** (`@Service`): wraps fixture with error handling (`NotFoundException` -> 404, `BadRequestException` -> 400)
- **DemoRuntimeController** (`@RestController`): 5 GET endpoints at `/api/v1/demo/`

### Test code (`backend/src/test/java/com/init/chatdemo/`)

- **DemoDtoSerializationTest**: 293-line JSON roundtrip contract for all DTOs
- **DemoRuntimeMockServiceTest**: 289-line service contract (positive + negative cases)
- **DemoRuntimeControllerTest**: 308-line HTTP contract (200 + 404 + 400 + 401)

## Verification

- `./gradlew test --tests "com.init.chatdemo.*"` -> BUILD SUCCESSFUL
- `./gradlew test` (전체) -> BUILD SUCCESSFUL
- `./gradlew build -x checkstyleMain -x checkstyleTest` -> BUILD SUCCESSFUL
- `spotlessCheck` -> passed (pre-commit hook)

## Scope Guardrails

- No existing files modified (22 new files only)
- No JPA entity, Repository, or Liquibase migration
- No security config, CORS config, or JWT filter changes
- No `workflow-runtime` or `domain-pack` controller changes
- No frontend TypeScript changes

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ajou-2026-1-capstone-5/ostone/pull/208" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 데모용 API 추가: 채팅 워크플로우, 도메인 팩, 채팅 세션, 워크플로우 실행 및 결정 로그 조회 가능

* **API 응답**
  * 엔드포인트용 응답 형식(여러 DTO) 추가로 상세한 JSON 페이로드 제공

* **테스트**
  * 서비스·컨트롤러 동작, 에러 처리, 및 DTO 직렬화 검증을 위한 단위/통합 테스트 추가

* **데모 데이터**
  * 인메모리 데모 데이터 제공자로 일관된 샘플 응답 구성

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ajou-2026-1-capstone-5/ostone/pull/208)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->