### PR TITLE
feat(domain-pack): [FE] Intent Revision 수정 화면

### DIFF
--- a/frontend/src/features/domain-pack-summary-read/model/usePackDetail.ts
+++ b/frontend/src/features/domain-pack-summary-read/model/usePackDetail.ts
@@ -1,8 +1,13 @@
 import { useGetDomainPack, useGetDomainPackVersion } from '@/shared/api/generated/endpoints/domain-pack-controller/domain-pack-controller';
+import {
+  type DomainPackDetailResult,
+  type DomainPackVersionDetailResult,
+} from "@/shared/api/generated/zod";
+import { unwrapApiResponse } from "@/shared/api";
 
 export function usePackDetail(wsId: number, packId: number) {
   return useGetDomainPack(wsId, packId, {
-    query: { select: (res) => res.data },
+    query: { select: (res) => unwrapApiResponse<DomainPackDetailResult>(res) },
   });
 }
 
@@ -12,6 +17,9 @@ export function useVersionDetail(
   versionId: number | null,
 ) {
   return useGetDomainPackVersion(wsId, packId, versionId ?? -1, {
-    query: { enabled: versionId !== null, select: (res) => res.data },
+    query: {
+      enabled: versionId !== null,
+      select: (res) => unwrapApiResponse<DomainPackVersionDetailResult>(res),
+    },
   });
 }

--- a/frontend/src/features/domain-pack-summary-read/model/usePreviewLists.ts
+++ b/frontend/src/features/domain-pack-summary-read/model/usePreviewLists.ts
@@ -8,12 +8,17 @@ import type { SlotSummary as SlotSummary2 } from '@/entities/slot';
 import type { PolicySummary as PolicySummary2 } from '@/entities/policy';
 import type { RiskSummary as RiskSummary2 } from '@/entities/risk';
 import type { WorkflowSummary as WorkflowSummary2 } from '@/entities/workflow';
+import { unwrapApiResponse } from "@/shared/api";
+
+function preview<T>(data: T[] | { data?: T[] }): T[] {
+  return (unwrapApiResponse<T[]>(data) ?? []).slice(0, 5);
+}
 
 export function useIntentPreview(wsId: number, packId: number, versionId: number | null) {
   return useListIntents(wsId, packId, versionId ?? -1, {
     query: {
       enabled: versionId !== null,
-      select: (data: { data: IntentSummary[] }) => data.data.slice(0, 5),
+      select: (data) => preview<IntentSummary>(data),
     },
   });
 }
@@ -22,7 +27,7 @@ export function useSlotPreview(wsId: number, packId: number, versionId: number |
   return useListSlots(wsId, packId, versionId ?? -1, {
     query: {
       enabled: versionId !== null,
-      select: (data: { data: SlotSummary2[] }) => data.data.slice(0, 5),
+      select: (data) => preview<SlotSummary2>(data),
     },
   });
 }
@@ -31,7 +36,7 @@ export function usePolicyPreview(wsId: number, packId: number, versionId: number
   return useListPolicies(wsId, packId, versionId ?? -1, {
     query: {
       enabled: versionId !== null,
-      select: (data: { data: PolicySummary2[] }) => data.data.slice(0, 5),
+      select: (data) => preview<PolicySummary2>(data),
     },
   });
 }
@@ -40,7 +45,7 @@ export function useRiskPreview(wsId: number, packId: number, versionId: number |
   return useListRisks(wsId, packId, versionId ?? -1, {
     query: {
       enabled: versionId !== null,
-      select: (data: { data: RiskSummary2[] }) => data.data.slice(0, 5),
+      select: (data) => preview<RiskSummary2>(data),
     },
   });
 }
@@ -49,7 +54,7 @@ export function useWorkflowPreview(wsId: number, packId: number, versionId: numb
   return useListWorkflows(wsId, packId, versionId ?? -1, {
     query: {
       enabled: versionId !== null,
-      select: (data: { data: WorkflowSummary2[] }) => data.data.slice(0, 5),
+      select: (data) => preview<WorkflowSummary2>(data),
     },
   });
 }

--- a/frontend/src/features/intent-draft-read/model/useIntentDetail.ts
+++ b/frontend/src/features/intent-draft-read/model/useIntentDetail.ts
@@ -36,9 +36,12 @@ export function useIntentDetail(
       .detail(wsId, packId, versionId, intentId)
       .then((data) => {
         if (!cancelled) {
+          const detail = "data" in Object(data)
+            ? (data as { data?: IntentDetail }).data
+            : data;
           setState({
             requestKey,
-            value: { status: "ready", data: data as any },
+            value: { status: "ready", data: detail as IntentDetail },
           });
         }
       })

--- a/frontend/src/features/intent-draft-read/model/useIntentDetail.ts
+++ b/frontend/src/features/intent-draft-read/model/useIntentDetail.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { intentApi } from "../api/intentApi";
 import { mapApiError } from "./mapApiError";
 import type { IntentDetail } from "../../../entities/intent";
+import { unwrapApiResponse } from "@/shared/api/unwrapApiResponse";
 
 export type IntentDetailState =
   | { status: "idle" }
@@ -36,12 +37,9 @@ export function useIntentDetail(
       .detail(wsId, packId, versionId, intentId)
       .then((data) => {
         if (!cancelled) {
-          const detail = "data" in Object(data)
-            ? (data as { data?: IntentDetail }).data
-            : data;
           setState({
             requestKey,
-            value: { status: "ready", data: detail as IntentDetail },
+            value: { status: "ready", data: unwrapApiResponse<IntentDetail>(data) },
           });
         }
       })

--- a/frontend/src/features/intent-draft-read/model/useIntentList.ts
+++ b/frontend/src/features/intent-draft-read/model/useIntentList.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { intentApi } from "../api/intentApi";
 import { mapApiError } from "./mapApiError";
 import type { IntentSummary } from "../../../entities/intent";
+import { unwrapApiResponse } from "@/shared/api/unwrapApiResponse";
 
 export type IntentListState =
   | { status: "loading" }
@@ -30,9 +31,7 @@ export function useIntentList(
       .list(wsId, packId, versionId)
       .then((data) => {
         if (!cancelled) {
-          const list = Array.isArray(data)
-            ? data
-            : (data as { data?: IntentSummary[] }).data ?? [];
+          const list = unwrapApiResponse<IntentSummary[]>(data) ?? [];
           setState({
             requestKey,
             value: { status: "ready", data: list },

--- a/frontend/src/features/intent-draft-read/model/useIntentList.ts
+++ b/frontend/src/features/intent-draft-read/model/useIntentList.ts
@@ -8,8 +8,13 @@ export type IntentListState =
   | { status: "error"; code: string; message: string; httpStatus?: number }
   | { status: "ready"; data: IntentSummary[] };
 
-export function useIntentList(wsId: number, packId: number, versionId: number): IntentListState {
-  const requestKey = `${wsId}:${packId}:${versionId}`;
+export function useIntentList(
+  wsId: number,
+  packId: number,
+  versionId: number,
+  refreshKey?: number,
+): IntentListState {
+  const requestKey = `${wsId}:${packId}:${versionId}:${refreshKey ?? 0}`;
   const [state, setState] = useState<{
     requestKey: string;
     value: IntentListState;
@@ -25,9 +30,12 @@ export function useIntentList(wsId: number, packId: number, versionId: number): 
       .list(wsId, packId, versionId)
       .then((data) => {
         if (!cancelled) {
+          const list = Array.isArray(data)
+            ? data
+            : (data as { data?: IntentSummary[] }).data ?? [];
           setState({
             requestKey,
-            value: { status: "ready", data: data as any },
+            value: { status: "ready", data: list },
           });
         }
       })

--- a/frontend/src/features/intent-draft-read/ui/IntentDetailPanel.module.css
+++ b/frontend/src/features/intent-draft-read/ui/IntentDetailPanel.module.css
@@ -81,7 +81,7 @@
   border: 1px solid var(--glass-border);
   border-radius: var(--radius-lg);
   background: var(--bg-color);
-  overflow: hidden;
+  overflow: visible;
 }
 
 .cardHeader {
@@ -120,11 +120,91 @@
   color: var(--bg-color);
 }
 
+.resourceSection {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 2px;
+}
+
+.resourceSectionHeader {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.resourceSectionTitle {
+  margin: 0;
+  font-family: "Pretendard Variable", sans-serif;
+  font-size: 18px;
+  font-weight: 540;
+  line-height: 1.2;
+  letter-spacing: -0.14px;
+  color: var(--text-primary);
+}
+
+.resourceSectionMeta {
+  font-family: "Geist Mono", monospace;
+  font-size: 10px;
+  letter-spacing: 0.54px;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.resourceGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(280px, 1fr));
+  gap: 14px;
+}
+
+.resourceCard {
+  min-width: 0;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-lg);
+  background: var(--bg-color);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.resourceHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 13px 14px 11px;
+  border-bottom: 1px solid var(--divider-subtle);
+}
+
+.resourceLabel {
+  font-family: "Geist Mono", monospace;
+  font-size: 10px;
+  letter-spacing: 0.54px;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.resourceMeta {
+  flex-shrink: 0;
+  font-family: "Geist Mono", monospace;
+  font-size: 10px;
+  letter-spacing: 0.54px;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.resourceBody {
+  min-width: 0;
+  padding: 12px;
+}
+
 .jsonBlock {
+  margin: 0;
   background: var(--bg-secondary);
   border: 1px solid var(--glass-border);
   border-radius: var(--radius-lg);
-  padding: 18px;
+  padding: 14px;
   font-family: "Geist Mono", monospace;
   font-size: 12px;
   line-height: 1.55;
@@ -132,6 +212,8 @@
   overflow: auto;
   white-space: pre-wrap;
   overflow-wrap: anywhere;
+  max-height: none;
+  min-height: 96px;
 }
 
 .placeholder {
@@ -184,6 +266,10 @@
   }
 
   .grid {
+    grid-template-columns: 1fr;
+  }
+
+  .resourceGrid {
     grid-template-columns: 1fr;
   }
 

--- a/frontend/src/features/intent-draft-read/ui/IntentDetailPanel.module.css
+++ b/frontend/src/features/intent-draft-read/ui/IntentDetailPanel.module.css
@@ -15,6 +15,19 @@
   gap: 10px;
 }
 
+.headerTop {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.headerText {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
 .code {
   font-family: "Geist Mono", monospace;
   font-size: 12px;

--- a/frontend/src/features/intent-draft-read/ui/IntentDetailPanel.tsx
+++ b/frontend/src/features/intent-draft-read/ui/IntentDetailPanel.tsx
@@ -10,10 +10,23 @@ interface IntentDetailPanelProps {
   versionId: number;
   intentId: number | null;
   refreshKey?: number;
+  headerActions?: (detail: IntentDetail) => ReactNode;
+  afterHeader?: (detail: IntentDetail) => ReactNode;
+  beforeJsonCards?: (detail: IntentDetail) => ReactNode;
   children?: (detail: IntentDetail) => ReactNode;
 }
 
-export function IntentDetailPanel({ wsId, packId, versionId, intentId, refreshKey, children }: IntentDetailPanelProps) {
+export function IntentDetailPanel({
+  wsId,
+  packId,
+  versionId,
+  intentId,
+  refreshKey,
+  headerActions,
+  afterHeader,
+  beforeJsonCards,
+  children,
+}: IntentDetailPanelProps) {
   const state = useIntentDetail(wsId, packId, versionId, intentId, refreshKey);
   const errorCode = state.status === "error" ? state.code : undefined;
   const errorHttpStatus = state.status === "error" ? state.httpStatus : undefined;
@@ -64,7 +77,8 @@ export function IntentDetailPanel({ wsId, packId, versionId, intentId, refreshKe
 
   return (
     <section className={styles.panel} aria-label="intent 상세">
-      <DetailHeader detail={state.data} />
+      <DetailHeader detail={state.data} actions={headerActions?.(state.data)} />
+      {afterHeader?.(state.data)}
       <div className={styles.body}>
         <div className={styles.grid}>
           <InfoCard
@@ -84,6 +98,7 @@ export function IntentDetailPanel({ wsId, packId, versionId, intentId, refreshKe
             value={<span className={styles.value}>{formatDate(state.data.createdAt ?? "")}</span>}
           />
         </div>
+        {beforeJsonCards?.(state.data)}
         <JsonCard label="Source Cluster Ref" value={state.data.sourceClusterRef ?? ""} />
         <JsonCard label="Entry Condition" value={state.data.entryConditionJson ?? ""} />
         <JsonCard label="Evidence" value={state.data.evidenceJson ?? ""} />
@@ -94,13 +109,18 @@ export function IntentDetailPanel({ wsId, packId, versionId, intentId, refreshKe
   );
 }
 
-function DetailHeader({ detail }: { detail: IntentDetail }) {
+function DetailHeader({ detail, actions }: { detail: IntentDetail; actions?: ReactNode }) {
   return (
     <header className={styles.header}>
-      <span className={styles.code}>{detail.intentCode}</span>
-      <span className={styles.name}>{detail.name ?? ""}</span>
-      {detail.description && <span className={styles.description}>{detail.description}</span>}
-      <span className={styles.updatedAt}>UPDATED · {formatDate(detail.updatedAt ?? "")}</span>
+      <div className={styles.headerTop}>
+        <span className={styles.code}>{detail.intentCode}</span>
+        {actions}
+      </div>
+      <div className={styles.headerText}>
+        <span className={styles.name}>{detail.name ?? ""}</span>
+        {detail.description && <span className={styles.description}>{detail.description}</span>}
+        <span className={styles.updatedAt}>UPDATED · {formatDate(detail.updatedAt ?? "")}</span>
+      </div>
     </header>
   );
 }

--- a/frontend/src/features/intent-draft-read/ui/IntentDetailPanel.tsx
+++ b/frontend/src/features/intent-draft-read/ui/IntentDetailPanel.tsx
@@ -99,10 +99,20 @@ export function IntentDetailPanel({
           />
         </div>
         {beforeJsonCards?.(state.data)}
-        <JsonCard label="Source Cluster Ref" value={state.data.sourceClusterRef ?? ""} />
-        <JsonCard label="Entry Condition" value={state.data.entryConditionJson ?? ""} />
-        <JsonCard label="Evidence" value={state.data.evidenceJson ?? ""} />
-        <JsonCard label="Meta" value={state.data.metaJson ?? ""} />
+        <section className={styles.resourceSection} aria-labelledby="intent-resource-section-title">
+          <div className={styles.resourceSectionHeader}>
+            <h2 id="intent-resource-section-title" className={styles.resourceSectionTitle}>
+              내부 리소스
+            </h2>
+            <span className={styles.resourceSectionMeta}>JSON FIELDS</span>
+          </div>
+          <div className={styles.resourceGrid}>
+            <JsonCard label="Source Cluster Ref" value={state.data.sourceClusterRef ?? ""} />
+            <JsonCard label="Entry Condition" value={state.data.entryConditionJson ?? ""} />
+            <JsonCard label="Evidence" value={state.data.evidenceJson ?? ""} />
+            <JsonCard label="Meta" value={state.data.metaJson ?? ""} />
+          </div>
+        </section>
       </div>
       {children?.(state.data)}
     </section>
@@ -135,12 +145,18 @@ function InfoCard({ label, value }: { label: string; value: ReactNode }) {
 }
 
 function JsonCard({ label, value }: { label: string; value: string }) {
+  const formatted = formatJsonForDisplay(value);
+  const meta = describeJson(value);
+
   return (
-    <section className={styles.card}>
-      <header className={styles.cardHeader}>{label}</header>
-      <div className={styles.cardBody}>
+    <section className={styles.resourceCard}>
+      <header className={styles.resourceHeader}>
+        <span className={styles.resourceLabel}>{label}</span>
+        <span className={styles.resourceMeta}>{meta}</span>
+      </header>
+      <div className={styles.resourceBody}>
         <pre className={styles.jsonBlock}>
-          <code>{formatJsonForDisplay(value)}</code>
+          <code>{formatted}</code>
         </pre>
       </div>
     </section>
@@ -153,6 +169,20 @@ function formatJsonForDisplay(raw: string): string {
     return JSON.stringify(JSON.parse(raw), null, 2);
   } catch {
     return raw;
+  }
+}
+
+function describeJson(raw: string): string {
+  if (!raw) return "EMPTY";
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (Array.isArray(parsed)) return `${parsed.length} ITEMS`;
+    if (parsed !== null && typeof parsed === "object") {
+      return `${Object.keys(parsed).length} KEYS`;
+    }
+    return typeof parsed === "string" ? "STRING" : "VALUE";
+  } catch {
+    return "RAW";
   }
 }
 

--- a/frontend/src/features/intent-draft-read/ui/IntentTreePanel.module.css
+++ b/frontend/src/features/intent-draft-read/ui/IntentTreePanel.module.css
@@ -139,6 +139,25 @@
   background: transparent;
 }
 
+.marker {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-family: "Geist Mono", monospace;
+  font-size: 10px;
+  letter-spacing: 0.54px;
+  text-transform: uppercase;
+  padding: 4px 10px 5px;
+  border-radius: var(--radius-xl);
+  border: 1px dashed currentcolor;
+  color: inherit;
+  background: rgba(0, 0, 0, 0.06);
+}
+
+.itemActive .marker {
+  background: rgba(255, 255, 255, 0.16);
+}
+
 .skeletonGroup {
   display: flex;
   flex-direction: column;

--- a/frontend/src/features/intent-draft-read/ui/IntentTreePanel.module.css
+++ b/frontend/src/features/intent-draft-read/ui/IntentTreePanel.module.css
@@ -67,6 +67,16 @@
   border-color: var(--hover-border);
 }
 
+.itemLevelOne {
+  background: var(--bg-secondary);
+  border-color: rgba(0, 0, 0, 0.18);
+}
+
+.itemLevelOne:hover {
+  background: var(--hover-bg);
+  border-color: var(--text-primary);
+}
+
 .itemActive {
   background: var(--text-primary);
   color: var(--bg-color);
@@ -82,20 +92,6 @@
   display: flex;
   flex-direction: column;
   gap: 8px;
-}
-
-.depthGuide {
-  position: absolute;
-  left: 0;
-  top: 6px;
-  bottom: 6px;
-  width: 2px;
-  background-image: repeating-linear-gradient(
-    to bottom,
-    currentcolor 0 4px,
-    transparent 4px 8px
-  );
-  opacity: 0.22;
 }
 
 .code {

--- a/frontend/src/features/intent-draft-read/ui/IntentTreePanel.test.tsx
+++ b/frontend/src/features/intent-draft-read/ui/IntentTreePanel.test.tsx
@@ -1,0 +1,82 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { toast } from "sonner";
+import { useIntentList } from "../model/useIntentList";
+import { IntentTreePanel } from "./IntentTreePanel";
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn() },
+}));
+
+vi.mock("../model/useIntentList", () => ({
+  useIntentList: vi.fn(),
+}));
+
+const mockedUseIntentList = vi.mocked(useIntentList);
+const mockedToastError = vi.mocked(toast.error);
+
+describe("IntentTreePanel", () => {
+  beforeEach(() => {
+    mockedUseIntentList.mockReset();
+    mockedToastError.mockReset();
+  });
+
+  it("intent tree와 revision marker를 렌더링하고 선택을 전달한다", () => {
+    const onSelect = vi.fn();
+    mockedUseIntentList.mockReturnValue({
+      status: "ready",
+      data: [
+        {
+          id: 1,
+          intentCode: "root",
+          name: "상위 intent",
+          taxonomyLevel: 1,
+          parentIntentId: undefined,
+          status: "PUBLISHED",
+        },
+        {
+          id: 2,
+          intentCode: "refund",
+          name: "환불 문의",
+          taxonomyLevel: 2,
+          parentIntentId: 1,
+          status: "PUBLISHED",
+        },
+      ],
+    } as ReturnType<typeof useIntentList>);
+
+    render(
+      <IntentTreePanel
+        wsId={1}
+        packId={2}
+        versionId={3}
+        selectedId={2}
+        onSelect={onSelect}
+        markers={{ 2: "수정 중" }}
+      />,
+    );
+
+    expect(screen.getByText("2 · TREE")).toBeInTheDocument();
+    expect(screen.getByText("수정 중")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /refund/ })).toHaveAttribute(
+      "aria-current",
+      "true",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /refund/ }));
+    expect(onSelect).toHaveBeenCalledWith(2);
+  });
+
+  it("목록 조회 실패 시 toast와 error empty state를 보여준다", () => {
+    mockedUseIntentList.mockReturnValue({
+      status: "error",
+      code: "ERR",
+      message: "목록 실패",
+    });
+
+    render(<IntentTreePanel wsId={1} packId={2} versionId={3} selectedId={null} onSelect={vi.fn()} />);
+
+    expect(screen.getByText("목록을 불러오지 못했습니다.")).toBeInTheDocument();
+    expect(mockedToastError).toHaveBeenCalledWith("목록 실패");
+  });
+});

--- a/frontend/src/features/intent-draft-read/ui/IntentTreePanel.tsx
+++ b/frontend/src/features/intent-draft-read/ui/IntentTreePanel.tsx
@@ -11,6 +11,8 @@ interface IntentTreePanelProps {
   versionId: number;
   selectedId: number | null;
   onSelect: (id: number) => void;
+  refreshKey?: number;
+  markers?: Record<number, "수정 중" | "수정됨">;
 }
 
 export function IntentTreePanel({
@@ -19,8 +21,10 @@ export function IntentTreePanel({
   versionId,
   selectedId,
   onSelect,
+  refreshKey,
+  markers = {},
 }: IntentTreePanelProps) {
-  const state = useIntentList(wsId, packId, versionId);
+  const state = useIntentList(wsId, packId, versionId, refreshKey);
   const errorMessage = state.status === "error" ? state.message : undefined;
   const tree = useMemo(
     () => (state.status === "ready" ? buildIntentTree(state.data) : []),
@@ -72,6 +76,7 @@ export function IntentTreePanel({
                 depth={0}
                 selectedId={selectedId}
                 onSelect={onSelect}
+                markers={markers}
               />
             ))}
           </div>
@@ -86,14 +91,17 @@ function IntentTreeRow({
   depth,
   selectedId,
   onSelect,
+  markers,
 }: {
   node: IntentTreeNode;
   depth: number;
   selectedId: number | null;
   onSelect: (id: number) => void;
+  markers: Record<number, "수정 중" | "수정됨">;
 }) {
   const isActive = node.id === selectedId;
   const paddingLeft = 20 + depth * 18;
+  const marker = node.id == null ? undefined : markers[node.id];
 
   return (
     <>
@@ -109,6 +117,7 @@ function IntentTreeRow({
           <span className={styles.code}>{node.intentCode}</span>
           <span className={styles.name}>{node.name}</span>
           <span className={styles.meta}>
+            {marker && <span className={styles.marker}>{marker}</span>}
             <span className={styles.badge}>LV · {node.taxonomyLevel}</span>
             <span className={styles.badge}>{node.status}</span>
           </span>
@@ -122,6 +131,7 @@ function IntentTreeRow({
           depth={depth + 1}
           selectedId={selectedId}
           onSelect={onSelect}
+          markers={markers}
         />
       ))}
     </>

--- a/frontend/src/features/intent-draft-read/ui/IntentTreePanel.tsx
+++ b/frontend/src/features/intent-draft-read/ui/IntentTreePanel.tsx
@@ -102,18 +102,25 @@ function IntentTreeRow({
   const isActive = node.id === selectedId;
   const paddingLeft = 20 + depth * 18;
   const marker = node.id == null ? undefined : markers[node.id];
+  const isLevelOne = node.taxonomyLevel === 1;
+  const itemClassName = [
+    styles.item,
+    isLevelOne ? styles.itemLevelOne : "",
+    isActive ? styles.itemActive : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
 
   return (
     <>
       <button
         type="button"
-        className={`${styles.item} ${isActive ? styles.itemActive : ""}`}
+        className={itemClassName}
         style={{ paddingLeft }}
         onClick={() => node.id != null && onSelect(node.id!)}
         aria-current={isActive ? "true" : undefined}
       >
         <div className={styles.itemInner}>
-          {depth > 0 && <span className={styles.depthGuide} aria-hidden="true" />}
           <span className={styles.code}>{node.intentCode}</span>
           <span className={styles.name}>{node.name}</span>
           <span className={styles.meta}>

--- a/frontend/src/features/intent-draft-read/ui/IntentTreePanel.tsx
+++ b/frontend/src/features/intent-draft-read/ui/IntentTreePanel.tsx
@@ -101,7 +101,9 @@ function IntentTreeRow({
 }) {
   const isActive = node.id === selectedId;
   const paddingLeft = 20 + depth * 18;
-  const marker = node.id == null ? undefined : markers[node.id];
+  const intentId = node.id;
+  const hasIntentId = intentId !== null && intentId !== undefined;
+  const marker = hasIntentId ? markers[intentId] : undefined;
   const isLevelOne = node.taxonomyLevel === 1;
   const itemClassName = [
     styles.item,
@@ -117,7 +119,9 @@ function IntentTreeRow({
         type="button"
         className={itemClassName}
         style={{ paddingLeft }}
-        onClick={() => node.id != null && onSelect(node.id!)}
+        onClick={() => {
+          if (hasIntentId) onSelect(intentId);
+        }}
         aria-current={isActive ? "true" : undefined}
       >
         <div className={styles.itemInner}>

--- a/frontend/src/features/intent-revision-draft/api/intentRevisionDraftApi.test.ts
+++ b/frontend/src/features/intent-revision-draft/api/intentRevisionDraftApi.test.ts
@@ -17,6 +17,7 @@ const mockedPost = vi.mocked(apiClient.post);
 const mockedPatch = vi.mocked(apiClient.patch);
 const mockedDelete = vi.mocked(apiClient.delete);
 const mockedGet = vi.mocked(apiClient.get);
+const mockedWarn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
 
 describe("intentRevisionDraftApi", () => {
   beforeEach(() => {
@@ -24,9 +25,23 @@ describe("intentRevisionDraftApi", () => {
     mockedPatch.mockReset();
     mockedDelete.mockReset();
     mockedGet.mockReset();
+    mockedWarn.mockClear();
   });
 
-  it("revision draft 생성 응답의 draftVersion.versionId를 정규화한다", async () => {
+  it("revision draft 생성 응답의 canonical draftVersionId를 정규화한다", async () => {
+    mockedPost.mockResolvedValue({ draftVersionId: 15 });
+
+    await expect(intentRevisionDraftApi.createRevisionDraft(1, 2, 12)).resolves.toEqual({
+      draftVersionId: 15,
+    });
+    expect(mockedWarn).not.toHaveBeenCalled();
+    expect(mockedPost).toHaveBeenCalledWith(
+      "/workspaces/1/domain-packs/2/versions/12/revision-drafts",
+      undefined,
+    );
+  });
+
+  it("revision draft 생성 응답의 legacy draftVersion.versionId를 warning과 함께 정규화한다", async () => {
     mockedPost.mockResolvedValue({
       draftVersion: { versionId: 15, versionNo: 5, lifecycleStatus: "DRAFT" },
     });
@@ -37,6 +52,9 @@ describe("intentRevisionDraftApi", () => {
     expect(mockedPost).toHaveBeenCalledWith(
       "/workspaces/1/domain-packs/2/versions/12/revision-drafts",
       undefined,
+    );
+    expect(mockedWarn).toHaveBeenCalledWith(
+      "[intentRevisionDraftApi] using legacy revision draft id response field",
     );
   });
 

--- a/frontend/src/features/intent-revision-draft/api/intentRevisionDraftApi.test.ts
+++ b/frontend/src/features/intent-revision-draft/api/intentRevisionDraftApi.test.ts
@@ -1,0 +1,86 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { apiClient } from "@/shared/api";
+import { intentRevisionDraftApi } from "./intentRevisionDraftApi";
+
+vi.mock("@/shared/api", () => ({
+  apiClient: {
+    post: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    get: vi.fn(),
+  },
+}));
+
+const mockedPost = vi.mocked(apiClient.post);
+const mockedPatch = vi.mocked(apiClient.patch);
+const mockedDelete = vi.mocked(apiClient.delete);
+const mockedGet = vi.mocked(apiClient.get);
+
+describe("intentRevisionDraftApi", () => {
+  beforeEach(() => {
+    mockedPost.mockReset();
+    mockedPatch.mockReset();
+    mockedDelete.mockReset();
+    mockedGet.mockReset();
+  });
+
+  it("revision draft 생성 응답의 draftVersion.versionId를 정규화한다", async () => {
+    mockedPost.mockResolvedValue({
+      draftVersion: { versionId: 15, versionNo: 5, lifecycleStatus: "DRAFT" },
+    });
+
+    await expect(intentRevisionDraftApi.createRevisionDraft(1, 2, 12)).resolves.toEqual({
+      draftVersionId: 15,
+    });
+    expect(mockedPost).toHaveBeenCalledWith(
+      "/workspaces/1/domain-packs/2/versions/12/revision-drafts",
+      undefined,
+    );
+  });
+
+  it("activate 응답의 id를 activatedVersionId로 정규화한다", async () => {
+    mockedPost.mockResolvedValue({
+      id: 16,
+      domainPackId: 2,
+      lifecycleStatus: "PUBLISHED",
+    });
+
+    await expect(intentRevisionDraftApi.activateVersion(1, 2, 15)).resolves.toEqual({
+      activatedVersionId: 16,
+    });
+  });
+
+  it("data wrapper가 있는 list/detail 응답을 unwrap한다", async () => {
+    mockedGet.mockResolvedValueOnce({ data: [{ id: 1, intentCode: "refund" }] });
+    mockedGet.mockResolvedValueOnce({ data: { id: 1, intentCode: "refund", name: "환불" } });
+
+    await expect(intentRevisionDraftApi.listIntents(1, 2, 3)).resolves.toEqual([
+      { id: 1, intentCode: "refund" },
+    ]);
+    await expect(intentRevisionDraftApi.getIntent(1, 2, 3, 1)).resolves.toMatchObject({
+      id: 1,
+      intentCode: "refund",
+    });
+  });
+
+  it("draft intent PATCH와 discard 경로를 고정한다", async () => {
+    mockedPatch.mockResolvedValue({ id: 7, intentCode: "refund" });
+    mockedDelete.mockResolvedValue(undefined);
+
+    await intentRevisionDraftApi.updateDraftIntent(1, 2, 3, 7, {
+      name: "환불 문의",
+      description: "",
+    });
+    await intentRevisionDraftApi.discardDraft(1, 2, 3);
+
+    expect(mockedPatch).toHaveBeenCalledWith(
+      "/workspaces/1/domain-packs/2/versions/3/intents/7",
+      { name: "환불 문의", description: "" },
+    );
+    expect(mockedDelete).toHaveBeenCalledWith(
+      "/workspaces/1/domain-packs/2/versions/3/draft",
+    );
+  });
+});

--- a/frontend/src/features/intent-revision-draft/api/intentRevisionDraftApi.test.ts
+++ b/frontend/src/features/intent-revision-draft/api/intentRevisionDraftApi.test.ts
@@ -50,6 +50,10 @@ describe("intentRevisionDraftApi", () => {
     await expect(intentRevisionDraftApi.activateVersion(1, 2, 15)).resolves.toEqual({
       activatedVersionId: 16,
     });
+    expect(mockedPost).toHaveBeenCalledWith(
+      "/workspaces/1/domain-packs/2/versions/15/activate",
+      undefined,
+    );
   });
 
   it("data wrapper가 있는 list/detail 응답을 unwrap한다", async () => {

--- a/frontend/src/features/intent-revision-draft/api/intentRevisionDraftApi.ts
+++ b/frontend/src/features/intent-revision-draft/api/intentRevisionDraftApi.ts
@@ -18,6 +18,12 @@ interface RevisionDraftResponse {
   data?: RevisionDraftResponse;
 }
 
+interface ActivateVersionResponse {
+  id?: number;
+  versionId?: number;
+  data?: ActivateVersionResponse;
+}
+
 function unwrapData<T>(response: T | { data?: T }): T {
   if (
     response &&
@@ -41,6 +47,17 @@ function normalizeDraftVersionId(response: RevisionDraftResponse): number {
 
   if (typeof id !== "number") {
     throw new Error("Intent 수정 초안 version id를 확인할 수 없습니다.");
+  }
+
+  return id;
+}
+
+function normalizeActivatedVersionId(response: ActivateVersionResponse): number {
+  const unwrapped = unwrapData(response);
+  const id = unwrapped.versionId ?? unwrapped.id;
+
+  if (typeof id !== "number") {
+    throw new Error("활성화된 version id를 확인할 수 없습니다.");
   }
 
   return id;
@@ -77,12 +94,12 @@ export const intentRevisionDraftApi = {
     workspaceId: number,
     packId: number,
     versionId: number,
-  ): Promise<DomainPackVersionDetail> {
-    const response = await apiClient.post<DomainPackVersionDetail | { data: DomainPackVersionDetail }>(
+  ): Promise<{ activatedVersionId: number }> {
+    const response = await apiClient.post<ActivateVersionResponse>(
       `/workspaces/${workspaceId}/domain-packs/${packId}/versions/${versionId}/activate`,
       {},
     );
-    return unwrapData(response);
+    return { activatedVersionId: normalizeActivatedVersionId(response) };
   },
 
   async discardDraft(

--- a/frontend/src/features/intent-revision-draft/api/intentRevisionDraftApi.ts
+++ b/frontend/src/features/intent-revision-draft/api/intentRevisionDraftApi.ts
@@ -1,4 +1,5 @@
 import { apiClient } from "@/shared/api";
+import { unwrapApiResponse } from "@/shared/api/unwrapApiResponse";
 import type { DomainPackVersionDetail } from "@/entities/domain-pack";
 import type { IntentDetail, IntentSummary } from "@/entities/intent";
 
@@ -24,20 +25,8 @@ interface ActivateVersionResponse {
   data?: ActivateVersionResponse;
 }
 
-function unwrapData<T>(response: T | { data?: T }): T {
-  if (
-    response &&
-    typeof response === "object" &&
-    "data" in response &&
-    (response as { data?: T }).data !== undefined
-  ) {
-    return (response as { data: T }).data;
-  }
-  return response as T;
-}
-
 function normalizeDraftVersionId(response: RevisionDraftResponse): number {
-  const unwrapped = unwrapData(response);
+  const unwrapped = unwrapApiResponse(response);
   const id =
     unwrapped.draftVersionId ??
     unwrapped.versionId ??
@@ -53,7 +42,7 @@ function normalizeDraftVersionId(response: RevisionDraftResponse): number {
 }
 
 function normalizeActivatedVersionId(response: ActivateVersionResponse): number {
-  const unwrapped = unwrapData(response);
+  const unwrapped = unwrapApiResponse(response);
   const id = unwrapped.versionId ?? unwrapped.id;
 
   if (typeof id !== "number") {
@@ -87,7 +76,7 @@ export const intentRevisionDraftApi = {
       `/workspaces/${workspaceId}/domain-packs/${packId}/versions/${draftVersionId}/intents/${intentId}`,
       body,
     );
-    return unwrapData(response);
+    return unwrapApiResponse(response);
   },
 
   async activateVersion(
@@ -97,7 +86,7 @@ export const intentRevisionDraftApi = {
   ): Promise<{ activatedVersionId: number }> {
     const response = await apiClient.post<ActivateVersionResponse>(
       `/workspaces/${workspaceId}/domain-packs/${packId}/versions/${versionId}/activate`,
-      {},
+      undefined,
     );
     return { activatedVersionId: normalizeActivatedVersionId(response) };
   },
@@ -122,7 +111,7 @@ export const intentRevisionDraftApi = {
       `/workspaces/${workspaceId}/domain-packs/${packId}/versions/${versionId}/intents`,
       options,
     );
-    return unwrapData(response);
+    return unwrapApiResponse(response);
   },
 
   async getIntent(
@@ -134,7 +123,7 @@ export const intentRevisionDraftApi = {
     const response = await apiClient.get<IntentDetail | { data: IntentDetail }>(
       `/workspaces/${workspaceId}/domain-packs/${packId}/versions/${versionId}/intents/${intentId}`,
     );
-    return unwrapData(response);
+    return unwrapApiResponse(response);
   },
 
   async getVersionDetail(
@@ -145,6 +134,6 @@ export const intentRevisionDraftApi = {
     const response = await apiClient.get<DomainPackVersionDetail | { data: DomainPackVersionDetail }>(
       `/workspaces/${workspaceId}/domain-packs/${packId}/versions/${versionId}`,
     );
-    return unwrapData(response);
+    return unwrapApiResponse(response);
   },
 };

--- a/frontend/src/features/intent-revision-draft/api/intentRevisionDraftApi.ts
+++ b/frontend/src/features/intent-revision-draft/api/intentRevisionDraftApi.ts
@@ -27,12 +27,15 @@ interface ActivateVersionResponse {
 
 function normalizeDraftVersionId(response: RevisionDraftResponse): number {
   const unwrapped = unwrapApiResponse(response);
-  const id =
-    unwrapped.draftVersionId ??
-    unwrapped.versionId ??
-    unwrapped.id ??
-    unwrapped.draftVersion?.versionId ??
-    unwrapped.draftVersion?.id;
+  const canonicalId = unwrapped.draftVersionId;
+  const legacyId =
+    unwrapped.versionId ?? unwrapped.id ?? unwrapped.draftVersion?.versionId ?? unwrapped.draftVersion?.id;
+  const id = canonicalId ?? legacyId;
+
+  if (canonicalId === undefined && legacyId !== undefined) {
+    // TODO: remove fallback handling once RevisionDraftResponse always returns draftVersionId.
+    console.warn("[intentRevisionDraftApi] using legacy revision draft id response field");
+  }
 
   if (typeof id !== "number") {
     throw new Error("Intent 수정 초안 version id를 확인할 수 없습니다.");

--- a/frontend/src/features/intent-revision-draft/api/intentRevisionDraftApi.ts
+++ b/frontend/src/features/intent-revision-draft/api/intentRevisionDraftApi.ts
@@ -1,0 +1,133 @@
+import { apiClient } from "@/shared/api";
+import type { DomainPackVersionDetail } from "@/entities/domain-pack";
+import type { IntentDetail, IntentSummary } from "@/entities/intent";
+
+export interface UpdateDraftIntentBody {
+  name: string;
+  description: string;
+}
+
+interface RevisionDraftResponse {
+  versionId?: number;
+  id?: number;
+  draftVersionId?: number;
+  draftVersion?: {
+    versionId?: number;
+    id?: number;
+  };
+  data?: RevisionDraftResponse;
+}
+
+function unwrapData<T>(response: T | { data?: T }): T {
+  if (
+    response &&
+    typeof response === "object" &&
+    "data" in response &&
+    (response as { data?: T }).data !== undefined
+  ) {
+    return (response as { data: T }).data;
+  }
+  return response as T;
+}
+
+function normalizeDraftVersionId(response: RevisionDraftResponse): number {
+  const unwrapped = unwrapData(response);
+  const id =
+    unwrapped.draftVersionId ??
+    unwrapped.versionId ??
+    unwrapped.id ??
+    unwrapped.draftVersion?.versionId ??
+    unwrapped.draftVersion?.id;
+
+  if (typeof id !== "number") {
+    throw new Error("Intent 수정 초안 version id를 확인할 수 없습니다.");
+  }
+
+  return id;
+}
+
+export const intentRevisionDraftApi = {
+  async createRevisionDraft(
+    workspaceId: number,
+    packId: number,
+    versionId: number,
+  ): Promise<{ draftVersionId: number }> {
+    const response = await apiClient.post<RevisionDraftResponse>(
+      `/workspaces/${workspaceId}/domain-packs/${packId}/versions/${versionId}/revision-drafts`,
+      undefined,
+    );
+    return { draftVersionId: normalizeDraftVersionId(response) };
+  },
+
+  async updateDraftIntent(
+    workspaceId: number,
+    packId: number,
+    draftVersionId: number,
+    intentId: number,
+    body: UpdateDraftIntentBody,
+  ): Promise<IntentDetail> {
+    const response = await apiClient.patch<IntentDetail | { data: IntentDetail }>(
+      `/workspaces/${workspaceId}/domain-packs/${packId}/versions/${draftVersionId}/intents/${intentId}`,
+      body,
+    );
+    return unwrapData(response);
+  },
+
+  async activateVersion(
+    workspaceId: number,
+    packId: number,
+    versionId: number,
+  ): Promise<DomainPackVersionDetail> {
+    const response = await apiClient.post<DomainPackVersionDetail | { data: DomainPackVersionDetail }>(
+      `/workspaces/${workspaceId}/domain-packs/${packId}/versions/${versionId}/activate`,
+      {},
+    );
+    return unwrapData(response);
+  },
+
+  async discardDraft(
+    workspaceId: number,
+    packId: number,
+    draftVersionId: number,
+  ): Promise<void> {
+    await apiClient.delete<void>(
+      `/workspaces/${workspaceId}/domain-packs/${packId}/versions/${draftVersionId}/draft`,
+    );
+  },
+
+  async listIntents(
+    workspaceId: number,
+    packId: number,
+    versionId: number,
+    options?: { signal?: AbortSignal },
+  ): Promise<IntentSummary[]> {
+    const response = await apiClient.get<IntentSummary[] | { data: IntentSummary[] }>(
+      `/workspaces/${workspaceId}/domain-packs/${packId}/versions/${versionId}/intents`,
+      options,
+    );
+    return unwrapData(response);
+  },
+
+  async getIntent(
+    workspaceId: number,
+    packId: number,
+    versionId: number,
+    intentId: number,
+  ): Promise<IntentDetail> {
+    const response = await apiClient.get<IntentDetail | { data: IntentDetail }>(
+      `/workspaces/${workspaceId}/domain-packs/${packId}/versions/${versionId}/intents/${intentId}`,
+    );
+    return unwrapData(response);
+  },
+
+  async getVersionDetail(
+    workspaceId: number,
+    packId: number,
+    versionId: number,
+  ): Promise<DomainPackVersionDetail> {
+    const response = await apiClient.get<DomainPackVersionDetail | { data: DomainPackVersionDetail }>(
+      `/workspaces/${workspaceId}/domain-packs/${packId}/versions/${versionId}`,
+    );
+    return unwrapData(response);
+  },
+};

--- a/frontend/src/features/intent-revision-draft/index.ts
+++ b/frontend/src/features/intent-revision-draft/index.ts
@@ -5,6 +5,11 @@ export {
   parseIntentRevisionDraftSource,
   type IntentRevisionDraftSource,
 } from "./model/draftSource";
+export {
+  classifyExistingDraftSource,
+  resolveSingleExistingDraft,
+  type ExistingDraftSourceType,
+} from "./model/existingDraftTarget";
 export { useIntentRevisionMarkers } from "./model/useIntentRevisionMarkers";
 export {
   buildIntentRevisionSummary,

--- a/frontend/src/features/intent-revision-draft/index.ts
+++ b/frontend/src/features/intent-revision-draft/index.ts
@@ -1,0 +1,20 @@
+export { intentRevisionDraftApi } from "./api/intentRevisionDraftApi";
+export type { UpdateDraftIntentBody } from "./api/intentRevisionDraftApi";
+export {
+  isIntentRevisionDraft,
+  parseIntentRevisionDraftSource,
+  type IntentRevisionDraftSource,
+} from "./model/draftSource";
+export { useIntentRevisionMarkers } from "./model/useIntentRevisionMarkers";
+export {
+  buildIntentRevisionSummary,
+  useIntentRevisionSummary,
+  type IntentRevisionSummary,
+  type IntentRevisionSummaryState,
+} from "./model/useIntentRevisionSummary";
+export { useSaveIntentRevisionDraft } from "./model/useSaveIntentRevisionDraft";
+export { useUpdateDraftIntent } from "./model/useUpdateDraftIntent";
+export { IntentRevisionDiffPanel } from "./ui/IntentRevisionDiffPanel";
+export { IntentRevisionDraftActions } from "./ui/IntentRevisionDraftActions";
+export { IntentRevisionEditForm } from "./ui/IntentRevisionEditForm";
+export { IntentRevisionRecoveryBanner } from "./ui/IntentRevisionRecoveryBanner";

--- a/frontend/src/features/intent-revision-draft/model/draftSource.test.ts
+++ b/frontend/src/features/intent-revision-draft/model/draftSource.test.ts
@@ -1,0 +1,43 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { parseIntentRevisionDraftSource } from "./draftSource";
+
+describe("parseIntentRevisionDraftSource", () => {
+  it("INTENT_REVISION draftSource를 파싱한다", () => {
+    expect(
+      parseIntentRevisionDraftSource(
+        JSON.stringify({
+          draftSource: {
+            type: "INTENT_REVISION",
+            baseVersionId: 12,
+            baseVersionNo: 4,
+            reason: "intent 보정",
+          },
+        }),
+      ),
+    ).toEqual({
+      type: "INTENT_REVISION",
+      baseVersionId: 12,
+      baseVersionNo: 4,
+      reason: "intent 보정",
+    });
+  });
+
+  it("파싱 실패나 baseVersionId 누락은 null로 처리한다", () => {
+    expect(parseIntentRevisionDraftSource("{bad json}")).toBeNull();
+    expect(
+      parseIntentRevisionDraftSource(
+        JSON.stringify({ draftSource: { type: "INTENT_REVISION" } }),
+      ),
+    ).toBeNull();
+  });
+
+  it("다른 draftSource type은 INTENT_REVISION으로 간주하지 않는다", () => {
+    expect(
+      parseIntentRevisionDraftSource(
+        JSON.stringify({ draftSource: { type: "RESTORE", baseVersionId: 12 } }),
+      ),
+    ).toBeNull();
+  });
+});

--- a/frontend/src/features/intent-revision-draft/model/draftSource.ts
+++ b/frontend/src/features/intent-revision-draft/model/draftSource.ts
@@ -1,0 +1,46 @@
+import type { DomainPackVersionDetail } from "@/entities/domain-pack";
+
+export interface IntentRevisionDraftSource {
+  type: "INTENT_REVISION";
+  baseVersionId: number;
+  baseVersionNo?: number;
+  reason?: string;
+}
+
+export function parseIntentRevisionDraftSource(
+  summaryJson?: string | null,
+): IntentRevisionDraftSource | null {
+  if (!summaryJson) return null;
+
+  try {
+    const parsed: unknown = JSON.parse(summaryJson);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+
+    const draftSource = (parsed as { draftSource?: unknown }).draftSource;
+    if (!draftSource || typeof draftSource !== "object" || Array.isArray(draftSource)) {
+      return null;
+    }
+
+    const source = draftSource as Record<string, unknown>;
+    if (source.type !== "INTENT_REVISION" || typeof source.baseVersionId !== "number") {
+      return null;
+    }
+
+    return {
+      type: "INTENT_REVISION",
+      baseVersionId: source.baseVersionId,
+      baseVersionNo:
+        typeof source.baseVersionNo === "number" ? source.baseVersionNo : undefined,
+      reason: typeof source.reason === "string" ? source.reason : undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function isIntentRevisionDraft(version?: DomainPackVersionDetail | null): boolean {
+  return (
+    version?.lifecycleStatus === "DRAFT" &&
+    parseIntentRevisionDraftSource(version.summaryJson)?.type === "INTENT_REVISION"
+  );
+}

--- a/frontend/src/features/intent-revision-draft/model/existingDraftTarget.test.ts
+++ b/frontend/src/features/intent-revision-draft/model/existingDraftTarget.test.ts
@@ -1,0 +1,61 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import type { DomainPackVersionSummary } from "@/entities/domain-pack";
+import {
+  classifyExistingDraftSource,
+  resolveSingleExistingDraft,
+} from "./existingDraftTarget";
+
+function version(overrides: Partial<DomainPackVersionSummary>): DomainPackVersionSummary {
+  return {
+    versionId: 1,
+    versionNo: 1,
+    lifecycleStatus: "PUBLISHED",
+    createdAt: "",
+    updatedAt: "",
+    ...overrides,
+  };
+}
+
+describe("resolveSingleExistingDraft", () => {
+  it("DRAFT가 정확히 하나면 이동 대상 versionId를 반환한다", () => {
+    expect(
+      resolveSingleExistingDraft([
+        version({ versionId: 10, lifecycleStatus: "PUBLISHED" }),
+        version({ versionId: 11, lifecycleStatus: "DRAFT" }),
+      ]),
+    ).toEqual({ status: "ready", versionId: 11 });
+  });
+
+  it("DRAFT가 없거나 복수면 invalid를 반환한다", () => {
+    expect(resolveSingleExistingDraft([version({ lifecycleStatus: "PUBLISHED" })])).toEqual({
+      status: "invalid",
+    });
+    expect(
+      resolveSingleExistingDraft([
+        version({ versionId: 11, lifecycleStatus: "DRAFT" }),
+        version({ versionId: 12, lifecycleStatus: "DRAFT" }),
+      ]),
+    ).toEqual({ status: "invalid" });
+  });
+});
+
+describe("classifyExistingDraftSource", () => {
+  it("INTENT_REVISION draftSource를 분류한다", () => {
+    expect(
+      classifyExistingDraftSource(
+        JSON.stringify({ draftSource: { type: "INTENT_REVISION", baseVersionId: 10 } }),
+      ),
+    ).toBe("INTENT_REVISION");
+  });
+
+  it("파싱 불가 또는 일반 DRAFT는 GENERAL_DRAFT로 분류한다", () => {
+    expect(classifyExistingDraftSource("{bad json}")).toBe("GENERAL_DRAFT");
+    expect(
+      classifyExistingDraftSource(
+        JSON.stringify({ draftSource: { type: "RESTORE", baseVersionId: 10 } }),
+      ),
+    ).toBe("GENERAL_DRAFT");
+  });
+});

--- a/frontend/src/features/intent-revision-draft/model/existingDraftTarget.ts
+++ b/frontend/src/features/intent-revision-draft/model/existingDraftTarget.ts
@@ -1,0 +1,26 @@
+import type { DomainPackVersionSummary } from "@/entities/domain-pack";
+import { parseIntentRevisionDraftSource } from "./draftSource";
+
+export type ExistingDraftSourceType = "INTENT_REVISION" | "GENERAL_DRAFT";
+
+export type ExistingDraftResolution =
+  | { status: "ready"; versionId: number }
+  | { status: "invalid" };
+
+export function resolveSingleExistingDraft(
+  versions: DomainPackVersionSummary[] | undefined,
+): ExistingDraftResolution {
+  const drafts = (versions ?? []).filter(
+    (version) => version.lifecycleStatus === "DRAFT" && version.versionId != null,
+  );
+
+  if (drafts.length !== 1 || drafts[0].versionId == null) {
+    return { status: "invalid" };
+  }
+
+  return { status: "ready", versionId: drafts[0].versionId };
+}
+
+export function classifyExistingDraftSource(summaryJson?: string | null): ExistingDraftSourceType {
+  return parseIntentRevisionDraftSource(summaryJson) ? "INTENT_REVISION" : "GENERAL_DRAFT";
+}

--- a/frontend/src/features/intent-revision-draft/model/useIntentRevisionMarkers.test.ts
+++ b/frontend/src/features/intent-revision-draft/model/useIntentRevisionMarkers.test.ts
@@ -1,0 +1,63 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useIntentRevisionMarkers } from "./useIntentRevisionMarkers";
+import type { IntentRevisionSummaryState } from "./useIntentRevisionSummary";
+
+const readySummary: IntentRevisionSummaryState = {
+  status: "ready",
+  data: {
+    changedIntents: [
+      {
+        intentId: 10,
+        intentCode: "refund",
+        name: "환불 문의",
+        fields: ["name"],
+        before: { name: "환불", description: "" },
+        after: { name: "환불 문의", description: "" },
+      },
+    ],
+    changedFieldCounts: { name: 1, description: 0 },
+    changedByDraftIntentId: {},
+  },
+};
+
+describe("useIntentRevisionMarkers", () => {
+  it("저장된 변경과 현재 편집 중인 intent marker를 함께 반환한다", () => {
+    const { result } = renderHook(() =>
+      useIntentRevisionMarkers({
+        editingIntentId: 20,
+        isDirty: true,
+        summaryState: readySummary,
+      }),
+    );
+
+    expect(result.current).toEqual({
+      10: "수정됨",
+      20: "수정 중",
+    });
+  });
+
+  it("편집 중인 intent가 이미 변경 목록에 있으면 수정 중 marker를 우선한다", () => {
+    const { result } = renderHook(() =>
+      useIntentRevisionMarkers({
+        editingIntentId: 10,
+        isDirty: true,
+        summaryState: readySummary,
+      }),
+    );
+
+    expect(result.current).toEqual({ 10: "수정 중" });
+  });
+
+  it("summary가 ready가 아니고 dirty도 아니면 빈 marker를 반환한다", () => {
+    const { result } = renderHook(() =>
+      useIntentRevisionMarkers({
+        editingIntentId: 10,
+        isDirty: false,
+        summaryState: { status: "loading" },
+      }),
+    );
+
+    expect(result.current).toEqual({});
+  });
+});

--- a/frontend/src/features/intent-revision-draft/model/useIntentRevisionMarkers.ts
+++ b/frontend/src/features/intent-revision-draft/model/useIntentRevisionMarkers.ts
@@ -1,0 +1,28 @@
+import { useMemo } from "react";
+import type { IntentRevisionSummaryState } from "./useIntentRevisionSummary";
+
+export function useIntentRevisionMarkers({
+  editingIntentId,
+  isDirty,
+  summaryState,
+}: {
+  editingIntentId: number | null;
+  isDirty: boolean;
+  summaryState: IntentRevisionSummaryState;
+}): Record<number, "수정 중" | "수정됨"> {
+  return useMemo(() => {
+    const markers: Record<number, "수정 중" | "수정됨"> = {};
+
+    if (summaryState.status === "ready") {
+      for (const change of summaryState.data.changedIntents) {
+        markers[change.intentId] = "수정됨";
+      }
+    }
+
+    if (editingIntentId !== null && isDirty) {
+      markers[editingIntentId] = "수정 중";
+    }
+
+    return markers;
+  }, [editingIntentId, isDirty, summaryState]);
+}

--- a/frontend/src/features/intent-revision-draft/model/useIntentRevisionSummary.hook.test.ts
+++ b/frontend/src/features/intent-revision-draft/model/useIntentRevisionSummary.hook.test.ts
@@ -1,0 +1,88 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { intentRevisionDraftApi } from "../api/intentRevisionDraftApi";
+import { useIntentRevisionSummary } from "./useIntentRevisionSummary";
+
+vi.mock("../api/intentRevisionDraftApi", () => ({
+  intentRevisionDraftApi: {
+    listIntents: vi.fn(),
+  },
+}));
+
+const mockedListIntents = vi.mocked(intentRevisionDraftApi.listIntents);
+
+describe("useIntentRevisionSummary hook", () => {
+  beforeEach(() => {
+    mockedListIntents.mockReset();
+  });
+
+  it("비활성 상태에서는 idle을 반환하고 API를 호출하지 않는다", () => {
+    const { result } = renderHook(() =>
+      useIntentRevisionSummary({
+        workspaceId: 1,
+        packId: 2,
+        draftVersionId: 4,
+        baseVersionId: null,
+        enabled: false,
+      }),
+    );
+
+    expect(result.current).toEqual({ status: "idle" });
+    expect(mockedListIntents).not.toHaveBeenCalled();
+  });
+
+  it("base와 draft intent를 조회해 변경 요약을 만든다", async () => {
+    mockedListIntents
+      .mockResolvedValueOnce([
+        { id: 10, intentCode: "refund", name: "환불", description: "" },
+      ] as never)
+      .mockResolvedValueOnce([
+        { id: 20, intentCode: "refund", name: "환불 문의", description: "새 설명" },
+      ] as never);
+
+    const { result } = renderHook(() =>
+      useIntentRevisionSummary({
+        workspaceId: 1,
+        packId: 2,
+        draftVersionId: 4,
+        baseVersionId: 3,
+        enabled: true,
+      }),
+    );
+
+    expect(result.current.status).toBe("loading");
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+    if (result.current.status !== "ready") throw new Error("summary not ready");
+    expect(result.current.data.changedIntents[0]).toMatchObject({
+      intentId: 20,
+      intentCode: "refund",
+      fields: ["name", "description"],
+    });
+    expect(mockedListIntents).toHaveBeenCalledWith(1, 2, 3, {
+      signal: expect.any(AbortSignal),
+    });
+    expect(mockedListIntents).toHaveBeenCalledWith(1, 2, 4, {
+      signal: expect.any(AbortSignal),
+    });
+  });
+
+  it("조회 실패 시 error 상태를 반환한다", async () => {
+    mockedListIntents.mockRejectedValue(new Error("summary failed"));
+
+    const { result } = renderHook(() =>
+      useIntentRevisionSummary({
+        workspaceId: 1,
+        packId: 2,
+        draftVersionId: 4,
+        baseVersionId: 3,
+        enabled: true,
+      }),
+    );
+
+    await waitFor(() => expect(result.current.status).toBe("error"));
+    expect(result.current).toEqual({
+      status: "error",
+      message: "summary failed",
+    });
+  });
+});

--- a/frontend/src/features/intent-revision-draft/model/useIntentRevisionSummary.test.ts
+++ b/frontend/src/features/intent-revision-draft/model/useIntentRevisionSummary.test.ts
@@ -1,0 +1,66 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import type { IntentSummary } from "@/entities/intent";
+import { buildIntentRevisionSummary } from "./useIntentRevisionSummary";
+
+function intent(overrides: Partial<IntentSummary>): IntentSummary {
+  return {
+    id: 1,
+    intentCode: "refund",
+    name: "환불 문의",
+    description: "환불 조건 확인",
+    taxonomyLevel: 1,
+    parentIntentId: undefined,
+    status: "PUBLISHED",
+    sourceClusterRef: "{}",
+    createdAt: "",
+    updatedAt: "",
+    ...overrides,
+  } as IntentSummary;
+}
+
+describe("buildIntentRevisionSummary", () => {
+  it("intentCode 기준으로 name과 description 변경을 계산한다", () => {
+    const summary = buildIntentRevisionSummary(
+      [intent({ id: 10, intentCode: "refund", name: "환불", description: "기존 설명" })],
+      [
+        intent({
+          id: 20,
+          intentCode: "refund",
+          name: "환불 문의",
+          description: "새 설명",
+        }),
+      ],
+    );
+
+    expect(summary.changedIntents).toHaveLength(1);
+    expect(summary.changedIntents[0]).toMatchObject({
+      intentId: 20,
+      intentCode: "refund",
+      fields: ["name", "description"],
+      before: { name: "환불", description: "기존 설명" },
+      after: { name: "환불 문의", description: "새 설명" },
+    });
+    expect(summary.changedFieldCounts).toEqual({ name: 1, description: 1 });
+    expect(summary.changedByDraftIntentId[20]?.intentCode).toBe("refund");
+  });
+
+  it("description null과 빈 문자열은 같은 값으로 취급한다", () => {
+    const summary = buildIntentRevisionSummary(
+      [intent({ id: 10, description: null as unknown as string })],
+      [intent({ id: 20, description: "" })],
+    );
+
+    expect(summary.changedIntents).toHaveLength(0);
+  });
+
+  it("base에 없는 draft intent는 diff 대상에서 제외한다", () => {
+    const summary = buildIntentRevisionSummary(
+      [intent({ id: 10, intentCode: "refund" })],
+      [intent({ id: 20, intentCode: "delivery", name: "배송 문의" })],
+    );
+
+    expect(summary.changedIntents).toHaveLength(0);
+  });
+});

--- a/frontend/src/features/intent-revision-draft/model/useIntentRevisionSummary.ts
+++ b/frontend/src/features/intent-revision-draft/model/useIntentRevisionSummary.ts
@@ -131,6 +131,7 @@ export function useIntentRevisionSummary({
       }),
     ])
       .then(([baseIntents, draftIntents]) => {
+        if (controller.signal.aborted) return;
         setState({
           requestKey,
           value: {

--- a/frontend/src/features/intent-revision-draft/model/useIntentRevisionSummary.ts
+++ b/frontend/src/features/intent-revision-draft/model/useIntentRevisionSummary.ts
@@ -155,7 +155,7 @@ export function useIntentRevisionSummary({
       });
 
     return () => controller.abort();
-  }, [baseVersionId, draftVersionId, enabled, packId, requestKey, refreshKey, workspaceId]);
+  }, [baseVersionId, draftVersionId, enabled, packId, requestKey, workspaceId]);
 
   return useMemo(() => {
     if (requestKey === null) return { status: "idle" };

--- a/frontend/src/features/intent-revision-draft/model/useIntentRevisionSummary.ts
+++ b/frontend/src/features/intent-revision-draft/model/useIntentRevisionSummary.ts
@@ -1,0 +1,163 @@
+import { useEffect, useMemo, useState } from "react";
+import type { IntentSummary } from "@/entities/intent";
+import { intentRevisionDraftApi } from "../api/intentRevisionDraftApi";
+
+export type RevisionChangedField = "name" | "description";
+
+export interface IntentRevisionChange {
+  intentId: number;
+  intentCode: string;
+  name: string;
+  fields: RevisionChangedField[];
+  before: {
+    name: string;
+    description: string;
+  };
+  after: {
+    name: string;
+    description: string;
+  };
+}
+
+export interface IntentRevisionSummary {
+  changedIntents: IntentRevisionChange[];
+  changedFieldCounts: Record<RevisionChangedField, number>;
+  changedByDraftIntentId: Record<number, IntentRevisionChange>;
+}
+
+export type IntentRevisionSummaryState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "ready"; data: IntentRevisionSummary }
+  | { status: "error"; message: string };
+
+function normalizeText(value: string | null | undefined): string {
+  return value ?? "";
+}
+
+export function buildIntentRevisionSummary(
+  baseIntents: IntentSummary[],
+  draftIntents: IntentSummary[],
+): IntentRevisionSummary {
+  const baseByCode = new Map(
+    baseIntents
+      .filter((intent) => intent.intentCode)
+      .map((intent) => [intent.intentCode as string, intent]),
+  );
+
+  const changedIntents = draftIntents.flatMap<IntentRevisionChange>((draft) => {
+    if (draft.id == null || !draft.intentCode) return [];
+
+    const base = baseByCode.get(draft.intentCode);
+    if (!base) return [];
+
+    const fields: RevisionChangedField[] = [];
+    const before = {
+      name: normalizeText(base.name),
+      description: normalizeText(base.description),
+    };
+    const after = {
+      name: normalizeText(draft.name),
+      description: normalizeText(draft.description),
+    };
+
+    if (before.name !== after.name) fields.push("name");
+    if (before.description !== after.description) fields.push("description");
+    if (fields.length === 0) return [];
+
+    return [
+      {
+        intentId: draft.id,
+        intentCode: draft.intentCode,
+        name: after.name,
+        fields,
+        before,
+        after,
+      },
+    ];
+  });
+
+  return {
+    changedIntents,
+    changedFieldCounts: {
+      name: changedIntents.filter((change) => change.fields.includes("name")).length,
+      description: changedIntents.filter((change) =>
+        change.fields.includes("description"),
+      ).length,
+    },
+    changedByDraftIntentId: Object.fromEntries(
+      changedIntents.map((change) => [change.intentId, change]),
+    ),
+  };
+}
+
+export function useIntentRevisionSummary({
+  workspaceId,
+  packId,
+  draftVersionId,
+  baseVersionId,
+  refreshKey,
+  enabled,
+}: {
+  workspaceId: number;
+  packId: number;
+  draftVersionId: number;
+  baseVersionId: number | null;
+  refreshKey?: number;
+  enabled: boolean;
+}): IntentRevisionSummaryState {
+  const requestKey =
+    enabled && baseVersionId !== null
+      ? `${workspaceId}:${packId}:${baseVersionId}:${draftVersionId}:${refreshKey ?? 0}`
+      : null;
+  const [state, setState] = useState<{
+    requestKey: string | null;
+    value: IntentRevisionSummaryState;
+  }>({ requestKey: null, value: { status: "idle" } });
+
+  useEffect(() => {
+    if (!enabled || baseVersionId === null) {
+      return;
+    }
+
+    const controller = new AbortController();
+
+    Promise.all([
+      intentRevisionDraftApi.listIntents(workspaceId, packId, baseVersionId, {
+        signal: controller.signal,
+      }),
+      intentRevisionDraftApi.listIntents(workspaceId, packId, draftVersionId, {
+        signal: controller.signal,
+      }),
+    ])
+      .then(([baseIntents, draftIntents]) => {
+        setState({
+          requestKey,
+          value: {
+            status: "ready",
+            data: buildIntentRevisionSummary(baseIntents, draftIntents),
+          },
+        });
+      })
+      .catch((error: unknown) => {
+        if (controller.signal.aborted) return;
+        setState({
+          requestKey,
+          value: {
+            status: "error",
+            message:
+              error instanceof Error
+                ? error.message
+                : "Intent 수정 요약을 불러오지 못했습니다.",
+          },
+        });
+      });
+
+    return () => controller.abort();
+  }, [baseVersionId, draftVersionId, enabled, packId, requestKey, refreshKey, workspaceId]);
+
+  return useMemo(() => {
+    if (requestKey === null) return { status: "idle" };
+    return state.requestKey === requestKey ? state.value : { status: "loading" };
+  }, [requestKey, state]);
+}

--- a/frontend/src/features/intent-revision-draft/model/useSaveIntentRevisionDraft.hook.test.ts
+++ b/frontend/src/features/intent-revision-draft/model/useSaveIntentRevisionDraft.hook.test.ts
@@ -1,0 +1,48 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { intentRevisionDraftApi } from "../api/intentRevisionDraftApi";
+import { useSaveIntentRevisionDraft } from "./useSaveIntentRevisionDraft";
+
+vi.mock("../api/intentRevisionDraftApi", () => ({
+  intentRevisionDraftApi: {
+    createRevisionDraft: vi.fn(),
+    listIntents: vi.fn(),
+    updateDraftIntent: vi.fn(),
+  },
+}));
+
+const mockedApi = vi.mocked(intentRevisionDraftApi);
+
+describe("useSaveIntentRevisionDraft", () => {
+  beforeEach(() => {
+    mockedApi.createRevisionDraft.mockReset();
+    mockedApi.listIntents.mockReset();
+    mockedApi.updateDraftIntent.mockReset();
+  });
+
+  it("revision draft 저장 flow를 실행하고 pending 상태를 복구한다", async () => {
+    mockedApi.createRevisionDraft.mockResolvedValue({ draftVersionId: 4 });
+    mockedApi.listIntents.mockResolvedValue([{ id: 40, intentCode: "refund" }] as never);
+    mockedApi.updateDraftIntent.mockResolvedValue({ id: 40 } as never);
+    const { result } = renderHook(() => useSaveIntentRevisionDraft());
+
+    let promise: Promise<unknown>;
+    act(() => {
+      promise = result.current.saveIntentRevisionDraft({
+        workspaceId: 1,
+        packId: 2,
+        baseVersionId: 3,
+        intentCode: "refund",
+        values: { name: "환불 문의", description: "설명" },
+      });
+    });
+
+    expect(result.current.isPending).toBe(true);
+    await expect(promise!).resolves.toEqual({
+      draftVersionId: 4,
+      clonedIntentId: 40,
+      patchSucceeded: true,
+    });
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+  });
+});

--- a/frontend/src/features/intent-revision-draft/model/useSaveIntentRevisionDraft.test.ts
+++ b/frontend/src/features/intent-revision-draft/model/useSaveIntentRevisionDraft.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { saveIntentRevisionDraftFlow } from "./useSaveIntentRevisionDraft";
+
+const api = {
+  createRevisionDraft: vi.fn(),
+  listIntents: vi.fn(),
+  updateDraftIntent: vi.fn(),
+};
+
+const params = {
+  workspaceId: 1,
+  packId: 2,
+  baseVersionId: 10,
+  intentCode: "refund",
+  values: { name: "환불 문의", description: "환불 조건 확인" },
+};
+
+describe("saveIntentRevisionDraftFlow", () => {
+  beforeEach(() => {
+    api.createRevisionDraft.mockReset();
+    api.listIntents.mockReset();
+    api.updateDraftIntent.mockReset();
+  });
+
+  it("revision draft 생성 후 같은 intentCode의 cloned intent를 PATCH한다", async () => {
+    api.createRevisionDraft.mockResolvedValue({ draftVersionId: 11 });
+    api.listIntents.mockResolvedValue([{ id: 20, intentCode: "refund" }]);
+    api.updateDraftIntent.mockResolvedValue({ id: 20 });
+
+    await expect(saveIntentRevisionDraftFlow(api, params)).resolves.toEqual({
+      draftVersionId: 11,
+      clonedIntentId: 20,
+      patchSucceeded: true,
+    });
+
+    expect(api.createRevisionDraft).toHaveBeenCalledWith(1, 2, 10);
+    expect(api.listIntents).toHaveBeenCalledWith(1, 2, 11);
+    expect(api.updateDraftIntent).toHaveBeenCalledWith(1, 2, 11, 20, params.values);
+  });
+
+  it("cloned intent를 찾지 못하면 PATCH하지 않고 draft 위치를 반환한다", async () => {
+    api.createRevisionDraft.mockResolvedValue({ draftVersionId: 11 });
+    api.listIntents.mockResolvedValue([{ id: 21, intentCode: "delivery" }]);
+
+    await expect(saveIntentRevisionDraftFlow(api, params)).resolves.toEqual({
+      draftVersionId: 11,
+      clonedIntentId: null,
+      patchSucceeded: false,
+    });
+
+    expect(api.updateDraftIntent).not.toHaveBeenCalled();
+  });
+
+  it("PATCH 실패 시 생성된 draft와 cloned intent id를 보존한다", async () => {
+    api.createRevisionDraft.mockResolvedValue({ draftVersionId: 11 });
+    api.listIntents.mockResolvedValue([{ id: 20, intentCode: "refund" }]);
+    api.updateDraftIntent.mockRejectedValue(new Error("patch failed"));
+
+    await expect(saveIntentRevisionDraftFlow(api, params)).resolves.toEqual({
+      draftVersionId: 11,
+      clonedIntentId: 20,
+      patchSucceeded: false,
+    });
+  });
+});

--- a/frontend/src/features/intent-revision-draft/model/useSaveIntentRevisionDraft.ts
+++ b/frontend/src/features/intent-revision-draft/model/useSaveIntentRevisionDraft.ts
@@ -1,5 +1,6 @@
 import { useCallback, useState } from "react";
 import { intentRevisionDraftApi, type UpdateDraftIntentBody } from "../api/intentRevisionDraftApi";
+import type { IntentSummary } from "@/entities/intent";
 
 export interface SaveIntentRevisionDraftResult {
   draftVersionId: number;
@@ -7,62 +8,77 @@ export interface SaveIntentRevisionDraftResult {
   patchSucceeded: boolean;
 }
 
+interface SaveIntentRevisionDraftApiPort {
+  createRevisionDraft: (
+    workspaceId: number,
+    packId: number,
+    versionId: number,
+  ) => Promise<{ draftVersionId: number }>;
+  listIntents: (
+    workspaceId: number,
+    packId: number,
+    versionId: number,
+  ) => Promise<IntentSummary[]>;
+  updateDraftIntent: (
+    workspaceId: number,
+    packId: number,
+    draftVersionId: number,
+    intentId: number,
+    values: UpdateDraftIntentBody,
+  ) => Promise<unknown>;
+}
+
+interface SaveIntentRevisionDraftParams {
+  workspaceId: number;
+  packId: number;
+  baseVersionId: number;
+  intentCode: string;
+  values: UpdateDraftIntentBody;
+}
+
+export async function saveIntentRevisionDraftFlow(
+  api: SaveIntentRevisionDraftApiPort,
+  {
+    workspaceId,
+    packId,
+    baseVersionId,
+    intentCode,
+    values,
+  }: SaveIntentRevisionDraftParams,
+): Promise<SaveIntentRevisionDraftResult> {
+  const { draftVersionId } = await api.createRevisionDraft(workspaceId, packId, baseVersionId);
+
+  const draftIntents = await api.listIntents(workspaceId, packId, draftVersionId);
+  const clonedIntent = draftIntents.find((intent) => intent.intentCode === intentCode);
+
+  if (clonedIntent?.id == null) {
+    return { draftVersionId, clonedIntentId: null, patchSucceeded: false };
+  }
+
+  try {
+    await api.updateDraftIntent(workspaceId, packId, draftVersionId, clonedIntent.id, values);
+    return {
+      draftVersionId,
+      clonedIntentId: clonedIntent.id,
+      patchSucceeded: true,
+    };
+  } catch {
+    return {
+      draftVersionId,
+      clonedIntentId: clonedIntent.id,
+      patchSucceeded: false,
+    };
+  }
+}
+
 export function useSaveIntentRevisionDraft() {
   const [isPending, setPending] = useState(false);
 
   const saveIntentRevisionDraft = useCallback(
-    async ({
-      workspaceId,
-      packId,
-      baseVersionId,
-      intentCode,
-      values,
-    }: {
-      workspaceId: number;
-      packId: number;
-      baseVersionId: number;
-      intentCode: string;
-      values: UpdateDraftIntentBody;
-    }): Promise<SaveIntentRevisionDraftResult> => {
+    async (params: SaveIntentRevisionDraftParams): Promise<SaveIntentRevisionDraftResult> => {
       setPending(true);
       try {
-        const { draftVersionId } = await intentRevisionDraftApi.createRevisionDraft(
-          workspaceId,
-          packId,
-          baseVersionId,
-        );
-
-        const draftIntents = await intentRevisionDraftApi.listIntents(
-          workspaceId,
-          packId,
-          draftVersionId,
-        );
-        const clonedIntent = draftIntents.find((intent) => intent.intentCode === intentCode);
-
-        if (clonedIntent?.id == null) {
-          return { draftVersionId, clonedIntentId: null, patchSucceeded: false };
-        }
-
-        try {
-          await intentRevisionDraftApi.updateDraftIntent(
-            workspaceId,
-            packId,
-            draftVersionId,
-            clonedIntent.id,
-            values,
-          );
-          return {
-            draftVersionId,
-            clonedIntentId: clonedIntent.id,
-            patchSucceeded: true,
-          };
-        } catch {
-          return {
-            draftVersionId,
-            clonedIntentId: clonedIntent.id,
-            patchSucceeded: false,
-          };
-        }
+        return await saveIntentRevisionDraftFlow(intentRevisionDraftApi, params);
       } finally {
         setPending(false);
       }

--- a/frontend/src/features/intent-revision-draft/model/useSaveIntentRevisionDraft.ts
+++ b/frontend/src/features/intent-revision-draft/model/useSaveIntentRevisionDraft.ts
@@ -1,0 +1,74 @@
+import { useCallback, useState } from "react";
+import { intentRevisionDraftApi, type UpdateDraftIntentBody } from "../api/intentRevisionDraftApi";
+
+export interface SaveIntentRevisionDraftResult {
+  draftVersionId: number;
+  clonedIntentId: number | null;
+  patchSucceeded: boolean;
+}
+
+export function useSaveIntentRevisionDraft() {
+  const [isPending, setPending] = useState(false);
+
+  const saveIntentRevisionDraft = useCallback(
+    async ({
+      workspaceId,
+      packId,
+      baseVersionId,
+      intentCode,
+      values,
+    }: {
+      workspaceId: number;
+      packId: number;
+      baseVersionId: number;
+      intentCode: string;
+      values: UpdateDraftIntentBody;
+    }): Promise<SaveIntentRevisionDraftResult> => {
+      setPending(true);
+      try {
+        const { draftVersionId } = await intentRevisionDraftApi.createRevisionDraft(
+          workspaceId,
+          packId,
+          baseVersionId,
+        );
+
+        const draftIntents = await intentRevisionDraftApi.listIntents(
+          workspaceId,
+          packId,
+          draftVersionId,
+        );
+        const clonedIntent = draftIntents.find((intent) => intent.intentCode === intentCode);
+
+        if (clonedIntent?.id == null) {
+          return { draftVersionId, clonedIntentId: null, patchSucceeded: false };
+        }
+
+        try {
+          await intentRevisionDraftApi.updateDraftIntent(
+            workspaceId,
+            packId,
+            draftVersionId,
+            clonedIntent.id,
+            values,
+          );
+          return {
+            draftVersionId,
+            clonedIntentId: clonedIntent.id,
+            patchSucceeded: true,
+          };
+        } catch {
+          return {
+            draftVersionId,
+            clonedIntentId: clonedIntent.id,
+            patchSucceeded: false,
+          };
+        }
+      } finally {
+        setPending(false);
+      }
+    },
+    [],
+  );
+
+  return { saveIntentRevisionDraft, isPending };
+}

--- a/frontend/src/features/intent-revision-draft/model/useUpdateDraftIntent.test.ts
+++ b/frontend/src/features/intent-revision-draft/model/useUpdateDraftIntent.test.ts
@@ -1,0 +1,61 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { intentRevisionDraftApi } from "../api/intentRevisionDraftApi";
+import { useUpdateDraftIntent } from "./useUpdateDraftIntent";
+
+vi.mock("../api/intentRevisionDraftApi", () => ({
+  intentRevisionDraftApi: {
+    updateDraftIntent: vi.fn(),
+  },
+}));
+
+const mockedUpdateDraftIntent = vi.mocked(intentRevisionDraftApi.updateDraftIntent);
+
+describe("useUpdateDraftIntent", () => {
+  beforeEach(() => {
+    mockedUpdateDraftIntent.mockReset();
+  });
+
+  it("draft intent PATCH를 호출하고 pending 상태를 복구한다", async () => {
+    mockedUpdateDraftIntent.mockResolvedValue({ id: 10, intentCode: "refund" } as never);
+    const { result } = renderHook(() => useUpdateDraftIntent());
+
+    let promise: Promise<unknown>;
+    act(() => {
+      promise = result.current.updateDraftIntent({
+        workspaceId: 1,
+        packId: 2,
+        draftVersionId: 3,
+        intentId: 10,
+        values: { name: "환불 문의", description: "설명" },
+      });
+    });
+
+    expect(result.current.isPending).toBe(true);
+    await expect(promise!).resolves.toMatchObject({ id: 10 });
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+    expect(mockedUpdateDraftIntent).toHaveBeenCalledWith(1, 2, 3, 10, {
+      name: "환불 문의",
+      description: "설명",
+    });
+  });
+
+  it("PATCH 실패를 caller에게 전달하면서 pending 상태를 복구한다", async () => {
+    mockedUpdateDraftIntent.mockRejectedValue(new Error("patch failed"));
+    const { result } = renderHook(() => useUpdateDraftIntent());
+
+    let promise: Promise<unknown>;
+    act(() => {
+      promise = result.current.updateDraftIntent({
+        workspaceId: 1,
+        packId: 2,
+        draftVersionId: 3,
+        intentId: 10,
+        values: { name: "환불 문의", description: "설명" },
+      });
+    });
+
+    await expect(promise!).rejects.toThrow("patch failed");
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+  });
+});

--- a/frontend/src/features/intent-revision-draft/model/useUpdateDraftIntent.ts
+++ b/frontend/src/features/intent-revision-draft/model/useUpdateDraftIntent.ts
@@ -1,0 +1,38 @@
+import { useCallback, useState } from "react";
+import { intentRevisionDraftApi, type UpdateDraftIntentBody } from "../api/intentRevisionDraftApi";
+
+export function useUpdateDraftIntent() {
+  const [isPending, setPending] = useState(false);
+
+  const updateDraftIntent = useCallback(
+    async ({
+      workspaceId,
+      packId,
+      draftVersionId,
+      intentId,
+      values,
+    }: {
+      workspaceId: number;
+      packId: number;
+      draftVersionId: number;
+      intentId: number;
+      values: UpdateDraftIntentBody;
+    }) => {
+      setPending(true);
+      try {
+        return await intentRevisionDraftApi.updateDraftIntent(
+          workspaceId,
+          packId,
+          draftVersionId,
+          intentId,
+          values,
+        );
+      } finally {
+        setPending(false);
+      }
+    },
+    [],
+  );
+
+  return { updateDraftIntent, isPending };
+}

--- a/frontend/src/features/intent-revision-draft/ui/IntentRevisionDiffPanel.test.tsx
+++ b/frontend/src/features/intent-revision-draft/ui/IntentRevisionDiffPanel.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { IntentRevisionChange } from "../model/useIntentRevisionSummary";
+import { IntentRevisionDiffPanel } from "./IntentRevisionDiffPanel";
+
+const change: IntentRevisionChange = {
+  intentId: 10,
+  intentCode: "refund",
+  name: "환불 문의",
+  fields: ["name", "description"],
+  before: { name: "환불", description: "" },
+  after: { name: "환불 문의", description: "새 설명" },
+};
+
+describe("IntentRevisionDiffPanel", () => {
+  it("변경된 필드의 before/after 값을 보여준다", () => {
+    render(<IntentRevisionDiffPanel change={change} />);
+
+    expect(screen.getByLabelText("Intent 수정 diff")).toBeInTheDocument();
+    expect(screen.getByText("2 fields")).toBeInTheDocument();
+    expect(screen.getByText("환불")).toBeInTheDocument();
+    expect(screen.getByText("환불 문의")).toBeInTheDocument();
+    expect(screen.getByText("비어 있음")).toBeInTheDocument();
+    expect(screen.getByText("새 설명")).toBeInTheDocument();
+  });
+
+  it("변경 정보가 없으면 렌더링하지 않는다", () => {
+    const { container } = render(<IntentRevisionDiffPanel />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/frontend/src/features/intent-revision-draft/ui/IntentRevisionDiffPanel.tsx
+++ b/frontend/src/features/intent-revision-draft/ui/IntentRevisionDiffPanel.tsx
@@ -1,0 +1,57 @@
+import type { IntentRevisionChange } from "../model/useIntentRevisionSummary";
+import styles from "./intent-revision-draft.module.css";
+
+interface IntentRevisionDiffPanelProps {
+  change?: IntentRevisionChange;
+}
+
+export function IntentRevisionDiffPanel({ change }: IntentRevisionDiffPanelProps) {
+  if (!change) return null;
+
+  return (
+    <section className={styles.diffPanel} aria-label="Intent 수정 diff">
+      <header className={styles.sectionHeader}>
+        <span>Intent 수정 diff</span>
+        <span>{change.fields.length} fields</span>
+      </header>
+      <div className={styles.diffGrid}>
+        {change.fields.includes("name") && (
+          <DiffRow label="Name" before={change.before.name} after={change.after.name} />
+        )}
+        {change.fields.includes("description") && (
+          <DiffRow
+            label="Description"
+            before={change.before.description}
+            after={change.after.description}
+          />
+        )}
+      </div>
+    </section>
+  );
+}
+
+function DiffRow({
+  label,
+  before,
+  after,
+}: {
+  label: string;
+  before: string;
+  after: string;
+}) {
+  return (
+    <div className={styles.diffRow}>
+      <span className={styles.diffLabel}>{label}</span>
+      <div className={styles.diffValues}>
+        <div>
+          <span className={styles.diffCaption}>Before</span>
+          <p>{before || "비어 있음"}</p>
+        </div>
+        <div>
+          <span className={styles.diffCaption}>After</span>
+          <p>{after || "비어 있음"}</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/intent-revision-draft/ui/IntentRevisionDraftActions.test.tsx
+++ b/frontend/src/features/intent-revision-draft/ui/IntentRevisionDraftActions.test.tsx
@@ -1,0 +1,96 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { IntentRevisionSummary } from "../model/useIntentRevisionSummary";
+import { IntentRevisionDraftActions } from "./IntentRevisionDraftActions";
+
+const summary: IntentRevisionSummary = {
+  changedIntents: [
+    {
+      intentId: 10,
+      intentCode: "refund",
+      name: "환불 문의",
+      fields: ["name", "description"],
+      before: { name: "환불", description: "기존 설명" },
+      after: { name: "환불 문의", description: "새 설명" },
+    },
+  ],
+  changedFieldCounts: { name: 1, description: 1 },
+  changedByDraftIntentId: {},
+};
+
+function renderActions(
+  props: Partial<React.ComponentProps<typeof IntentRevisionDraftActions>> = {},
+) {
+  const defaults = {
+    summary,
+    isSummaryLoading: false,
+    summaryError: null,
+    isPending: false,
+    onRetrySummary: vi.fn(),
+    onApply: vi.fn(),
+    onDiscard: vi.fn(),
+  };
+
+  render(<IntentRevisionDraftActions {...defaults} {...props} />);
+  return defaults;
+}
+
+describe("IntentRevisionDraftActions", () => {
+  it("변경 요약을 보여주고 확인 후 적용 callback을 호출한다", () => {
+    const { onApply } = renderActions();
+
+    expect(screen.getByText("변경된 intent 1개")).toBeInTheDocument();
+    fireEvent.click(screen.getAllByRole("button", { name: "적용" })[0]);
+    expect(screen.getByText("Intent 수정 초안을 적용할까요?")).toBeInTheDocument();
+
+    const confirmButtons = screen.getAllByRole("button", { name: "적용" });
+    fireEvent.click(confirmButtons[confirmButtons.length - 1]);
+
+    expect(onApply).toHaveBeenCalledTimes(1);
+  });
+
+  it("취소 확인 dialog에서 discard callback을 호출한다", () => {
+    const { onDiscard } = renderActions();
+
+    fireEvent.click(screen.getAllByRole("button", { name: "취소" })[0]);
+    expect(screen.getByText("Intent 수정 초안을 취소할까요?")).toBeInTheDocument();
+
+    const confirmButtons = screen.getAllByRole("button", { name: "취소" });
+    fireEvent.click(confirmButtons[confirmButtons.length - 1]);
+
+    expect(onDiscard).toHaveBeenCalledTimes(1);
+  });
+
+  it("요약 로딩 중에는 적용을 막고 loading 문구를 보여준다", () => {
+    renderActions({ summary: undefined, isSummaryLoading: true });
+
+    expect(screen.getByText("변경 요약을 불러오는 중입니다.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "적용" })).toBeDisabled();
+  });
+
+  it("요약 조회 실패 시 retry를 제공하고 적용을 막는다", () => {
+    const { onRetrySummary } = renderActions({
+      summary: undefined,
+      summaryError: "변경 요약을 불러오지 못했습니다.",
+    });
+
+    expect(screen.getByText("변경 요약을 불러오지 못했습니다.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "적용" })).toBeDisabled();
+
+    fireEvent.click(screen.getByRole("button", { name: "다시 시도" }));
+    expect(onRetrySummary).toHaveBeenCalledTimes(1);
+  });
+
+  it("변경된 intent가 없으면 적용을 막는다", () => {
+    renderActions({
+      summary: {
+        changedIntents: [],
+        changedFieldCounts: { name: 0, description: 0 },
+        changedByDraftIntentId: {},
+      },
+    });
+
+    expect(screen.getByText("변경된 intent가 없습니다.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "적용" })).toBeDisabled();
+  });
+});

--- a/frontend/src/features/intent-revision-draft/ui/IntentRevisionDraftActions.test.tsx
+++ b/frontend/src/features/intent-revision-draft/ui/IntentRevisionDraftActions.test.tsx
@@ -81,6 +81,15 @@ describe("IntentRevisionDraftActions", () => {
     expect(onRetrySummary).toHaveBeenCalledTimes(1);
   });
 
+  it("요약 조회 실패 Error 메시지가 비어 있으면 fallback 문구를 보여준다", () => {
+    renderActions({
+      summary: undefined,
+      summaryError: new Error(""),
+    });
+
+    expect(screen.getByText("변경 요약을 불러오지 못했습니다.")).toBeInTheDocument();
+  });
+
   it("변경된 intent가 없으면 적용을 막는다", () => {
     renderActions({
       summary: {

--- a/frontend/src/features/intent-revision-draft/ui/IntentRevisionDraftActions.tsx
+++ b/frontend/src/features/intent-revision-draft/ui/IntentRevisionDraftActions.tsx
@@ -32,10 +32,8 @@ export function IntentRevisionDraftActions({
   const [dialog, setDialog] = useState<"apply" | "discard" | null>(null);
   const changedCount = summary?.changedIntents.length ?? 0;
   const canApply = changedCount > 0 && !isSummaryLoading && !summaryError && !isPending;
-  const errorMessage =
-    summaryError instanceof Error
-      ? summaryError.message
-      : summaryError || "변경 요약을 불러오지 못했습니다.";
+  const rawErrorMessage = summaryError instanceof Error ? summaryError.message : summaryError;
+  const errorMessage = rawErrorMessage || "변경 요약을 불러오지 못했습니다.";
 
   return (
     <div className={styles.actions}>

--- a/frontend/src/features/intent-revision-draft/ui/IntentRevisionDraftActions.tsx
+++ b/frontend/src/features/intent-revision-draft/ui/IntentRevisionDraftActions.tsx
@@ -1,0 +1,141 @@
+import { useState } from "react";
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogTitle,
+} from "@/shared/ui/alert-dialog";
+import { Button } from "@/shared/ui/button";
+import type { IntentRevisionSummary } from "../model/useIntentRevisionSummary";
+import styles from "./intent-revision-draft.module.css";
+
+interface IntentRevisionDraftActionsProps {
+  summary?: IntentRevisionSummary;
+  isSummaryLoading: boolean;
+  isPending: boolean;
+  onApply: () => void;
+  onDiscard: () => void;
+}
+
+export function IntentRevisionDraftActions({
+  summary,
+  isSummaryLoading,
+  isPending,
+  onApply,
+  onDiscard,
+}: IntentRevisionDraftActionsProps) {
+  const [dialog, setDialog] = useState<"apply" | "discard" | null>(null);
+  const changedCount = summary?.changedIntents.length ?? 0;
+  const canApply = changedCount > 0 && !isSummaryLoading && !isPending;
+
+  return (
+    <div className={styles.actions}>
+      <div className={styles.summaryText}>
+        {isSummaryLoading
+          ? "변경 요약을 불러오는 중입니다."
+          : changedCount > 0
+            ? `변경된 intent ${changedCount}개`
+            : "변경된 intent가 없습니다."}
+      </div>
+      <div className={styles.actionButtons}>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => setDialog("discard")}
+          disabled={isPending}
+        >
+          취소
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          onClick={() => setDialog("apply")}
+          disabled={!canApply}
+        >
+          적용
+        </Button>
+      </div>
+
+      <AlertDialog open={dialog === "apply"} onOpenChange={() => setDialog(null)}>
+        <AlertDialogContent size="sm" className={styles.dialogContent}>
+          <AlertDialogTitle className={styles.dialogTitle}>
+            Intent 수정 초안을 적용할까요?
+          </AlertDialogTitle>
+          <AlertDialogDescription className={styles.dialogDescription}>
+            저장된 intent 수정 내용이 새 운영 버전으로 반영됩니다.
+          </AlertDialogDescription>
+          {summary && <ChangeSummaryPreview summary={summary} />}
+          <AlertDialogFooter className={styles.dialogButtons}>
+            <Button type="button" variant="outline" onClick={() => setDialog(null)}>
+              취소
+            </Button>
+            <Button
+              type="button"
+              onClick={() => {
+                setDialog(null);
+                onApply();
+              }}
+              disabled={!canApply}
+            >
+              적용
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog open={dialog === "discard"} onOpenChange={() => setDialog(null)}>
+        <AlertDialogContent size="sm" className={styles.dialogContent}>
+          <AlertDialogTitle className={styles.dialogTitle}>
+            Intent 수정 초안을 취소할까요?
+          </AlertDialogTitle>
+          <AlertDialogDescription className={styles.dialogDescription}>
+            이 초안에 저장된 intent 수정 내용이 폐기되고 현재 운영 버전으로 돌아갑니다.
+          </AlertDialogDescription>
+          <AlertDialogFooter className={styles.dialogButtons}>
+            <Button type="button" variant="outline" onClick={() => setDialog(null)}>
+              계속 보기
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              onClick={() => {
+                setDialog(null);
+                onDiscard();
+              }}
+              disabled={isPending}
+            >
+              취소
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}
+
+function ChangeSummaryPreview({ summary }: { summary: IntentRevisionSummary }) {
+  const firstFive = summary.changedIntents.slice(0, 5);
+  const rest = summary.changedIntents.length - firstFive.length;
+
+  return (
+    <div className={styles.changePreview}>
+      <div className={styles.changeCounts}>
+        <span>변경된 intent {summary.changedIntents.length}개</span>
+        <span>이름 변경 {summary.changedFieldCounts.name}개</span>
+        <span>설명 변경 {summary.changedFieldCounts.description}개</span>
+      </div>
+      <ul className={styles.changeList}>
+        {firstFive.map((change) => (
+          <li key={change.intentId}>
+            <span>{change.intentCode}</span>
+            <strong>{change.name || "이름 없음"}</strong>
+            <em>{change.fields.map((field) => (field === "name" ? "이름" : "설명")).join(", ")}</em>
+          </li>
+        ))}
+        {rest > 0 && <li>외 {rest}개</li>}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/features/intent-revision-draft/ui/IntentRevisionDraftActions.tsx
+++ b/frontend/src/features/intent-revision-draft/ui/IntentRevisionDraftActions.tsx
@@ -13,7 +13,9 @@ import styles from "./intent-revision-draft.module.css";
 interface IntentRevisionDraftActionsProps {
   summary?: IntentRevisionSummary;
   isSummaryLoading: boolean;
+  summaryError?: Error | string | null;
   isPending: boolean;
+  onRetrySummary: () => void;
   onApply: () => void;
   onDiscard: () => void;
 }
@@ -21,24 +23,43 @@ interface IntentRevisionDraftActionsProps {
 export function IntentRevisionDraftActions({
   summary,
   isSummaryLoading,
+  summaryError,
   isPending,
+  onRetrySummary,
   onApply,
   onDiscard,
 }: IntentRevisionDraftActionsProps) {
   const [dialog, setDialog] = useState<"apply" | "discard" | null>(null);
   const changedCount = summary?.changedIntents.length ?? 0;
-  const canApply = changedCount > 0 && !isSummaryLoading && !isPending;
+  const canApply = changedCount > 0 && !isSummaryLoading && !summaryError && !isPending;
+  const errorMessage =
+    summaryError instanceof Error
+      ? summaryError.message
+      : summaryError || "변경 요약을 불러오지 못했습니다.";
 
   return (
     <div className={styles.actions}>
       <div className={styles.summaryText}>
         {isSummaryLoading
           ? "변경 요약을 불러오는 중입니다."
-          : changedCount > 0
-            ? `변경된 intent ${changedCount}개`
-            : "변경된 intent가 없습니다."}
+          : summaryError
+            ? errorMessage
+            : changedCount > 0
+              ? `변경된 intent ${changedCount}개`
+              : "변경된 intent가 없습니다."}
       </div>
       <div className={styles.actionButtons}>
+        {summaryError && (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={onRetrySummary}
+            disabled={isPending || isSummaryLoading}
+          >
+            다시 시도
+          </Button>
+        )}
         <Button
           type="button"
           variant="outline"

--- a/frontend/src/features/intent-revision-draft/ui/IntentRevisionEditForm.test.tsx
+++ b/frontend/src/features/intent-revision-draft/ui/IntentRevisionEditForm.test.tsx
@@ -40,8 +40,8 @@ function renderForm(
     onDirtyChange: vi.fn(),
   };
 
-  render(<IntentRevisionEditForm {...defaults} {...props} />);
-  return defaults;
+  const view = render(<IntentRevisionEditForm {...defaults} {...props} />);
+  return { ...defaults, ...view };
 }
 
 describe("IntentRevisionEditForm", () => {
@@ -161,6 +161,35 @@ describe("IntentRevisionEditForm", () => {
     fireEvent.click(screen.getByRole("button", { name: "취소" }));
 
     expect(screen.getByRole("button", { name: "수정" })).toBeInTheDocument();
+  });
+
+  it("detail이 바뀌는 순간 stale dirty 상태를 다시 보고하지 않는다", async () => {
+    const onDirtyChange = vi.fn();
+    const { rerender } = renderForm({ onDirtyChange });
+
+    fireEvent.click(screen.getByRole("button", { name: "수정" }));
+    fireEvent.change(screen.getByLabelText("이름"), {
+      target: { value: "임시 수정" },
+    });
+
+    await waitFor(() => expect(onDirtyChange).toHaveBeenCalledWith(true, 10));
+    onDirtyChange.mockClear();
+
+    rerender(
+      <IntentRevisionEditForm
+        wsId={1}
+        packId={2}
+        versionId={3}
+        detail={{ ...detail, id: 11, intentCode: "delivery", name: "배송 문의" } as IntentDetail}
+        canEdit
+        isSaving={false}
+        onSave={vi.fn().mockResolvedValue(true)}
+        onDirtyChange={onDirtyChange}
+      />,
+    );
+
+    await waitFor(() => expect(onDirtyChange).toHaveBeenCalledWith(false, null));
+    expect(onDirtyChange).not.toHaveBeenCalledWith(true, 11);
   });
 
   it("최신 내용 불러오기를 누르면 conflict 데이터를 form baseline으로 반영한다", async () => {

--- a/frontend/src/features/intent-revision-draft/ui/IntentRevisionEditForm.test.tsx
+++ b/frontend/src/features/intent-revision-draft/ui/IntentRevisionEditForm.test.tsx
@@ -133,6 +133,24 @@ describe("IntentRevisionEditForm", () => {
     expect(screen.getByLabelText("이름")).toHaveValue("닫히면 안 되는 수정");
   });
 
+  it("저장 요청이 reject되면 toast를 띄우고 사용자의 입력을 유지한다", async () => {
+    const onSave = vi.fn().mockRejectedValue(new Error("patch failed"));
+    renderForm({ onSave });
+
+    fireEvent.click(screen.getByRole("button", { name: "수정" }));
+    fireEvent.change(screen.getByLabelText("이름"), {
+      target: { value: "유지되어야 하는 수정" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "저장" }));
+
+    await waitFor(() =>
+      expect(mockedToastError).toHaveBeenCalledWith(
+        "Intent 수정 내용 저장에 실패했습니다. patch failed",
+      ),
+    );
+    expect(screen.getByLabelText("이름")).toHaveValue("유지되어야 하는 수정");
+  });
+
   it("취소하면 입력을 baseline으로 되돌리고 편집 상태를 닫는다", () => {
     renderForm();
 

--- a/frontend/src/features/intent-revision-draft/ui/IntentRevisionEditForm.test.tsx
+++ b/frontend/src/features/intent-revision-draft/ui/IntentRevisionEditForm.test.tsx
@@ -1,0 +1,187 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { toast } from "sonner";
+import type { IntentDetail } from "@/entities/intent";
+import { intentRevisionDraftApi } from "../api/intentRevisionDraftApi";
+import { IntentRevisionEditForm } from "./IntentRevisionEditForm";
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn() },
+}));
+
+vi.mock("../api/intentRevisionDraftApi", () => ({
+  intentRevisionDraftApi: {
+    getIntent: vi.fn(),
+  },
+}));
+
+const mockedGetIntent = vi.mocked(intentRevisionDraftApi.getIntent);
+const mockedToastError = vi.mocked(toast.error);
+
+const detail = {
+  id: 10,
+  intentCode: "refund",
+  name: "환불 문의",
+  description: "환불 조건을 확인합니다.",
+  updatedAt: "2026-05-01T00:00:00Z",
+} as IntentDetail;
+
+function renderForm(
+  props: Partial<React.ComponentProps<typeof IntentRevisionEditForm>> = {},
+) {
+  const defaults = {
+    wsId: 1,
+    packId: 2,
+    versionId: 3,
+    detail,
+    canEdit: true,
+    isSaving: false,
+    onSave: vi.fn().mockResolvedValue(true),
+    onDirtyChange: vi.fn(),
+  };
+
+  render(<IntentRevisionEditForm {...defaults} {...props} />);
+  return defaults;
+}
+
+describe("IntentRevisionEditForm", () => {
+  beforeEach(() => {
+    mockedGetIntent.mockReset();
+    mockedToastError.mockReset();
+    mockedGetIntent.mockResolvedValue(detail);
+  });
+
+  it("한국어 label과 접근성 연결을 가진 수정 form을 렌더링한다", () => {
+    renderForm();
+
+    fireEvent.click(screen.getByRole("button", { name: "수정" }));
+
+    expect(screen.getByLabelText("이름")).toHaveValue("환불 문의");
+    expect(screen.getByLabelText("설명")).toHaveValue("환불 조건을 확인합니다.");
+  });
+
+  it("최신 intent와 충돌이 없으면 저장 후 편집 상태를 닫는다", async () => {
+    const onSave = vi.fn().mockResolvedValue(true);
+    renderForm({ onSave });
+
+    fireEvent.click(screen.getByRole("button", { name: "수정" }));
+    fireEvent.change(screen.getByLabelText("이름"), {
+      target: { value: "환불 문의 수정" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "저장" }));
+
+    await waitFor(() =>
+      expect(onSave).toHaveBeenCalledWith({
+        name: "환불 문의 수정",
+        description: "환불 조건을 확인합니다.",
+      }),
+    );
+    await waitFor(() => expect(screen.getByRole("button", { name: "수정" })).toBeInTheDocument());
+  });
+
+  it("최신 intent가 변경되었으면 저장하지 않고 conflict dialog를 보여준다", async () => {
+    const onSave = vi.fn();
+    mockedGetIntent.mockResolvedValue({
+      ...detail,
+      name: "다른 사용자 수정",
+      updatedAt: "2026-05-02T00:00:00Z",
+    } as IntentDetail);
+    renderForm({ onSave });
+
+    fireEvent.click(screen.getByRole("button", { name: "수정" }));
+    fireEvent.change(screen.getByLabelText("이름"), {
+      target: { value: "환불 문의 수정" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "저장" }));
+
+    await waitFor(() =>
+      expect(screen.getByText("다른 사용자가 먼저 수정했습니다.")).toBeInTheDocument(),
+    );
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it("최신 intent 조회 실패 시 toast를 띄우고 저장하지 않는다", async () => {
+    const onSave = vi.fn();
+    mockedGetIntent.mockRejectedValue(new Error("network down"));
+    renderForm({ onSave });
+
+    fireEvent.click(screen.getByRole("button", { name: "수정" }));
+    fireEvent.change(screen.getByLabelText("이름"), {
+      target: { value: "환불 문의 수정" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "저장" }));
+
+    await waitFor(() =>
+      expect(mockedToastError).toHaveBeenCalledWith(
+        "최신 Intent 정보를 확인하지 못했습니다. network down",
+      ),
+    );
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it("저장 실패를 받으면 사용자의 입력을 유지한다", async () => {
+    const onSave = vi.fn().mockResolvedValue(false);
+    renderForm({ onSave });
+
+    fireEvent.click(screen.getByRole("button", { name: "수정" }));
+    fireEvent.change(screen.getByLabelText("이름"), {
+      target: { value: "닫히면 안 되는 수정" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "저장" }));
+
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+    expect(screen.getByLabelText("이름")).toHaveValue("닫히면 안 되는 수정");
+  });
+
+  it("취소하면 입력을 baseline으로 되돌리고 편집 상태를 닫는다", () => {
+    renderForm();
+
+    fireEvent.click(screen.getByRole("button", { name: "수정" }));
+    fireEvent.change(screen.getByLabelText("이름"), {
+      target: { value: "취소될 수정" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "취소" }));
+
+    expect(screen.getByRole("button", { name: "수정" })).toBeInTheDocument();
+  });
+
+  it("최신 내용 불러오기를 누르면 conflict 데이터를 form baseline으로 반영한다", async () => {
+    mockedGetIntent.mockResolvedValue({
+      ...detail,
+      name: "최신 이름",
+      description: "최신 설명",
+      updatedAt: "2026-05-02T00:00:00Z",
+    } as IntentDetail);
+    renderForm();
+
+    fireEvent.click(screen.getByRole("button", { name: "수정" }));
+    fireEvent.change(screen.getByLabelText("이름"), {
+      target: { value: "사용자 수정" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "저장" }));
+
+    await waitFor(() =>
+      expect(screen.getByText("다른 사용자가 먼저 수정했습니다.")).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "최신 내용 불러오기" }));
+
+    expect(screen.getByLabelText("이름")).toHaveValue("최신 이름");
+    expect(screen.getByLabelText("설명")).toHaveValue("최신 설명");
+  });
+
+  it("필수/길이 검증 오류를 aria-invalid와 함께 보여준다", () => {
+    renderForm();
+
+    fireEvent.click(screen.getByRole("button", { name: "수정" }));
+    fireEvent.change(screen.getByLabelText("이름"), { target: { value: "" } });
+    fireEvent.change(screen.getByLabelText("설명"), {
+      target: { value: "a".repeat(1001) },
+    });
+
+    expect(screen.getByText("이름을 입력해 주세요.")).toBeInTheDocument();
+    expect(screen.getByText("설명은 1000자 이하로 입력해 주세요.")).toBeInTheDocument();
+    expect(screen.getByLabelText("이름")).toHaveAttribute("aria-invalid", "true");
+    expect(screen.getByLabelText("설명")).toHaveAttribute("aria-invalid", "true");
+    expect(screen.getByRole("button", { name: "저장" })).toBeDisabled();
+  });
+});

--- a/frontend/src/features/intent-revision-draft/ui/IntentRevisionEditForm.tsx
+++ b/frontend/src/features/intent-revision-draft/ui/IntentRevisionEditForm.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useMemo, useState } from "react";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import {
   AlertDialog,
@@ -63,6 +63,7 @@ export function IntentRevisionEditForm({
   const [baseline, setBaseline] = useState<Baseline>(() => normalizeDetail(detail));
   const [values, setValues] = useState<FormValues>(() => normalizeDetail(detail));
   const [latestConflict, setLatestConflict] = useState<IntentDetail | null>(null);
+  const skipNextDirtyReportRef = useRef(false);
   const nameId = useId();
   const descriptionId = useId();
   const nameErrorId = `${nameId}-error`;
@@ -70,6 +71,7 @@ export function IntentRevisionEditForm({
 
   useEffect(() => {
     const next = normalizeDetail(detail);
+    skipNextDirtyReportRef.current = true;
     // The form mirrors a freshly loaded server baseline whenever the selected
     // intent/detail refresh changes.
     // eslint-disable-next-line react-hooks/set-state-in-effect
@@ -98,6 +100,10 @@ export function IntentRevisionEditForm({
   const hasError = Boolean(errors.name || errors.description);
 
   useEffect(() => {
+    if (skipNextDirtyReportRef.current) {
+      skipNextDirtyReportRef.current = false;
+      return;
+    }
     onDirtyChange(isEditing && isDirty, isEditing && detail.id != null ? detail.id : null);
   }, [detail.id, isDirty, isEditing, onDirtyChange]);
 

--- a/frontend/src/features/intent-revision-draft/ui/IntentRevisionEditForm.tsx
+++ b/frontend/src/features/intent-revision-draft/ui/IntentRevisionEditForm.tsx
@@ -126,10 +126,21 @@ export function IntentRevisionEditForm({
       return;
     }
 
-    const saved = await onSave({
-      name: values.name.trim(),
-      description: values.description,
-    });
+    let saved = false;
+    try {
+      saved = await onSave({
+        name: values.name.trim(),
+        description: values.description,
+      });
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? `Intent 수정 내용 저장에 실패했습니다. ${error.message}`
+          : "Intent 수정 내용 저장에 실패했습니다.",
+      );
+      return;
+    }
+
     if (saved) {
       setEditing(false);
     }

--- a/frontend/src/features/intent-revision-draft/ui/IntentRevisionEditForm.tsx
+++ b/frontend/src/features/intent-revision-draft/ui/IntentRevisionEditForm.tsx
@@ -18,7 +18,7 @@ interface IntentRevisionEditFormProps {
   detail: IntentDetail;
   canEdit: boolean;
   isSaving: boolean;
-  onSave: (values: UpdateDraftIntentBody) => Promise<void>;
+  onSave: (values: UpdateDraftIntentBody) => Promise<boolean>;
   onDirtyChange: (dirty: boolean, intentId: number | null) => void;
 }
 
@@ -110,11 +110,13 @@ export function IntentRevisionEditForm({
       return;
     }
 
-    await onSave({
+    const saved = await onSave({
       name: values.name.trim(),
       description: values.description,
     });
-    setEditing(false);
+    if (saved) {
+      setEditing(false);
+    }
   };
 
   const loadLatest = () => {

--- a/frontend/src/features/intent-revision-draft/ui/IntentRevisionEditForm.tsx
+++ b/frontend/src/features/intent-revision-draft/ui/IntentRevisionEditForm.tsx
@@ -1,0 +1,198 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogTitle,
+} from "@/shared/ui/alert-dialog";
+import { Button } from "@/shared/ui/button";
+import type { IntentDetail } from "@/entities/intent";
+import { intentRevisionDraftApi, type UpdateDraftIntentBody } from "../api/intentRevisionDraftApi";
+import styles from "./intent-revision-draft.module.css";
+
+interface IntentRevisionEditFormProps {
+  wsId: number;
+  packId: number;
+  versionId: number;
+  detail: IntentDetail;
+  canEdit: boolean;
+  isSaving: boolean;
+  onSave: (values: UpdateDraftIntentBody) => Promise<void>;
+  onDirtyChange: (dirty: boolean, intentId: number | null) => void;
+}
+
+interface FormValues {
+  name: string;
+  description: string;
+}
+
+interface Baseline extends FormValues {
+  updatedAt: string;
+}
+
+function normalizeDetail(detail: IntentDetail): Baseline {
+  return {
+    name: detail.name ?? "",
+    description: detail.description ?? "",
+    updatedAt: detail.updatedAt ?? "",
+  };
+}
+
+function hasBaselineChanged(baseline: Baseline, latest: IntentDetail): boolean {
+  const latestBaseline = normalizeDetail(latest);
+  return (
+    baseline.name !== latestBaseline.name ||
+    baseline.description !== latestBaseline.description ||
+    baseline.updatedAt !== latestBaseline.updatedAt
+  );
+}
+
+export function IntentRevisionEditForm({
+  wsId,
+  packId,
+  versionId,
+  detail,
+  canEdit,
+  isSaving,
+  onSave,
+  onDirtyChange,
+}: IntentRevisionEditFormProps) {
+  const [isEditing, setEditing] = useState(false);
+  const [baseline, setBaseline] = useState<Baseline>(() => normalizeDetail(detail));
+  const [values, setValues] = useState<FormValues>(() => normalizeDetail(detail));
+  const [latestConflict, setLatestConflict] = useState<IntentDetail | null>(null);
+
+  useEffect(() => {
+    const next = normalizeDetail(detail);
+    // The form mirrors a freshly loaded server baseline whenever the selected
+    // intent/detail refresh changes.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setBaseline(next);
+    setValues(next);
+    setEditing(false);
+    onDirtyChange(false, null);
+  }, [detail, onDirtyChange]);
+
+  const errors = useMemo(() => {
+    const next: Partial<Record<keyof FormValues, string>> = {};
+    if (values.name.trim().length === 0) {
+      next.name = "이름을 입력해 주세요.";
+    } else if (values.name.trim().length > 60) {
+      next.name = "이름은 60자 이하로 입력해 주세요.";
+    }
+
+    if (values.description.length > 1000) {
+      next.description = "설명은 1000자 이하로 입력해 주세요.";
+    }
+
+    return next;
+  }, [values.description, values.name]);
+
+  const isDirty = baseline.name !== values.name || baseline.description !== values.description;
+  const hasError = Boolean(errors.name || errors.description);
+
+  useEffect(() => {
+    onDirtyChange(isEditing && isDirty, isEditing && detail.id != null ? detail.id : null);
+  }, [detail.id, isDirty, isEditing, onDirtyChange]);
+
+  if (!canEdit || detail.id == null) return null;
+
+  const handleCancel = () => {
+    setValues({ name: baseline.name, description: baseline.description });
+    setEditing(false);
+  };
+
+  const handleSave = async () => {
+    const latest = await intentRevisionDraftApi.getIntent(wsId, packId, versionId, detail.id!);
+    if (hasBaselineChanged(baseline, latest)) {
+      setLatestConflict(latest);
+      return;
+    }
+
+    await onSave({
+      name: values.name.trim(),
+      description: values.description,
+    });
+    setEditing(false);
+  };
+
+  const loadLatest = () => {
+    if (!latestConflict) return;
+    const next = normalizeDetail(latestConflict);
+    setBaseline(next);
+    setValues(next);
+    setLatestConflict(null);
+  };
+
+  if (!isEditing) {
+    return (
+      <div className={styles.formShell}>
+        <Button type="button" size="sm" onClick={() => setEditing(true)}>
+          수정
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <form
+      className={styles.formShell}
+      onSubmit={(event) => {
+        event.preventDefault();
+        if (!hasError && isDirty && !isSaving) void handleSave();
+      }}
+    >
+      <label className={styles.field}>
+        <span>Name</span>
+        <input
+          value={values.name}
+          onChange={(event) => setValues((prev) => ({ ...prev, name: event.target.value }))}
+          aria-invalid={Boolean(errors.name)}
+        />
+        {errors.name && <span className={styles.errorText}>{errors.name}</span>}
+      </label>
+      <label className={styles.field}>
+        <span>Description</span>
+        <textarea
+          value={values.description}
+          onChange={(event) =>
+            setValues((prev) => ({ ...prev, description: event.target.value }))
+          }
+          aria-invalid={Boolean(errors.description)}
+          rows={5}
+        />
+        {errors.description && (
+          <span className={styles.errorText}>{errors.description}</span>
+        )}
+      </label>
+      <div className={styles.buttonRow}>
+        <Button type="button" variant="outline" onClick={handleCancel} disabled={isSaving}>
+          취소
+        </Button>
+        <Button type="submit" disabled={hasError || !isDirty || isSaving}>
+          {isSaving ? "저장 중..." : "저장"}
+        </Button>
+      </div>
+
+      <AlertDialog open={latestConflict !== null} onOpenChange={() => setLatestConflict(null)}>
+        <AlertDialogContent size="sm" className={styles.dialogContent}>
+          <AlertDialogTitle className={styles.dialogTitle}>
+            다른 사용자가 먼저 수정했습니다.
+          </AlertDialogTitle>
+          <AlertDialogDescription className={styles.dialogDescription}>
+            최신 내용을 불러온 뒤 다시 수정해 주세요.
+          </AlertDialogDescription>
+          <AlertDialogFooter className={styles.dialogButtons}>
+            <Button type="button" variant="outline" onClick={() => setLatestConflict(null)}>
+              취소
+            </Button>
+            <Button type="button" onClick={loadLatest}>
+              최신 내용 불러오기
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </form>
+  );
+}

--- a/frontend/src/features/intent-revision-draft/ui/IntentRevisionEditForm.tsx
+++ b/frontend/src/features/intent-revision-draft/ui/IntentRevisionEditForm.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useId, useMemo, useState } from "react";
+import { toast } from "sonner";
 import {
   AlertDialog,
   AlertDialogContent,
@@ -62,6 +63,10 @@ export function IntentRevisionEditForm({
   const [baseline, setBaseline] = useState<Baseline>(() => normalizeDetail(detail));
   const [values, setValues] = useState<FormValues>(() => normalizeDetail(detail));
   const [latestConflict, setLatestConflict] = useState<IntentDetail | null>(null);
+  const nameId = useId();
+  const descriptionId = useId();
+  const nameErrorId = `${nameId}-error`;
+  const descriptionErrorId = `${descriptionId}-error`;
 
   useEffect(() => {
     const next = normalizeDetail(detail);
@@ -104,7 +109,18 @@ export function IntentRevisionEditForm({
   };
 
   const handleSave = async () => {
-    const latest = await intentRevisionDraftApi.getIntent(wsId, packId, versionId, detail.id!);
+    let latest: IntentDetail;
+    try {
+      latest = await intentRevisionDraftApi.getIntent(wsId, packId, versionId, detail.id!);
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? `최신 Intent 정보를 확인하지 못했습니다. ${error.message}`
+          : "최신 Intent 정보를 확인하지 못했습니다.",
+      );
+      return;
+    }
+
     if (hasBaselineChanged(baseline, latest)) {
       setLatestConflict(latest);
       return;
@@ -145,27 +161,37 @@ export function IntentRevisionEditForm({
         if (!hasError && isDirty && !isSaving) void handleSave();
       }}
     >
-      <label className={styles.field}>
-        <span>Name</span>
+      <label className={styles.field} htmlFor={nameId}>
+        <span>이름</span>
         <input
+          id={nameId}
           value={values.name}
           onChange={(event) => setValues((prev) => ({ ...prev, name: event.target.value }))}
           aria-invalid={Boolean(errors.name)}
+          aria-describedby={errors.name ? nameErrorId : undefined}
         />
-        {errors.name && <span className={styles.errorText}>{errors.name}</span>}
+        {errors.name && (
+          <span id={nameErrorId} className={styles.errorText}>
+            {errors.name}
+          </span>
+        )}
       </label>
-      <label className={styles.field}>
-        <span>Description</span>
+      <label className={styles.field} htmlFor={descriptionId}>
+        <span>설명</span>
         <textarea
+          id={descriptionId}
           value={values.description}
           onChange={(event) =>
             setValues((prev) => ({ ...prev, description: event.target.value }))
           }
           aria-invalid={Boolean(errors.description)}
+          aria-describedby={errors.description ? descriptionErrorId : undefined}
           rows={5}
         />
         {errors.description && (
-          <span className={styles.errorText}>{errors.description}</span>
+          <span id={descriptionErrorId} className={styles.errorText}>
+            {errors.description}
+          </span>
         )}
       </label>
       <div className={styles.buttonRow}>

--- a/frontend/src/features/intent-revision-draft/ui/IntentRevisionEditForm.tsx
+++ b/frontend/src/features/intent-revision-draft/ui/IntentRevisionEditForm.tsx
@@ -161,8 +161,8 @@ export function IntentRevisionEditForm({
         if (!hasError && isDirty && !isSaving) void handleSave();
       }}
     >
-      <label className={styles.field} htmlFor={nameId}>
-        <span>이름</span>
+      <div className={styles.field}>
+        <label htmlFor={nameId}>이름</label>
         <input
           id={nameId}
           value={values.name}
@@ -175,9 +175,9 @@ export function IntentRevisionEditForm({
             {errors.name}
           </span>
         )}
-      </label>
-      <label className={styles.field} htmlFor={descriptionId}>
-        <span>설명</span>
+      </div>
+      <div className={styles.field}>
+        <label htmlFor={descriptionId}>설명</label>
         <textarea
           id={descriptionId}
           value={values.description}
@@ -193,7 +193,7 @@ export function IntentRevisionEditForm({
             {errors.description}
           </span>
         )}
-      </label>
+      </div>
       <div className={styles.buttonRow}>
         <Button type="button" variant="outline" onClick={handleCancel} disabled={isSaving}>
           취소

--- a/frontend/src/features/intent-revision-draft/ui/IntentRevisionRecoveryBanner.test.tsx
+++ b/frontend/src/features/intent-revision-draft/ui/IntentRevisionRecoveryBanner.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { IntentRevisionRecoveryBanner } from "./IntentRevisionRecoveryBanner";
+
+describe("IntentRevisionRecoveryBanner", () => {
+  it("첫 수정 저장 실패 후 복구 안내를 status로 노출한다", () => {
+    render(<IntentRevisionRecoveryBanner />);
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Intent 수정 초안은 생성됐지만 첫 수정 내용은 저장되지 않았습니다.",
+    );
+  });
+});

--- a/frontend/src/features/intent-revision-draft/ui/IntentRevisionRecoveryBanner.tsx
+++ b/frontend/src/features/intent-revision-draft/ui/IntentRevisionRecoveryBanner.tsx
@@ -1,0 +1,9 @@
+import styles from "./intent-revision-draft.module.css";
+
+export function IntentRevisionRecoveryBanner() {
+  return (
+    <div className={styles.recoveryBanner} role="status">
+      Intent 수정 초안은 생성됐지만 첫 수정 내용은 저장되지 않았습니다. 다시 수정 후 저장해 주세요.
+    </div>
+  );
+}

--- a/frontend/src/features/intent-revision-draft/ui/intent-revision-draft.module.css
+++ b/frontend/src/features/intent-revision-draft/ui/intent-revision-draft.module.css
@@ -1,0 +1,240 @@
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.summaryText {
+  font-family: "Geist Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.54px;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.actionButtons,
+.buttonRow,
+.dialogButtons {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.formShell {
+  margin: 0 28px 28px;
+  padding: 18px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-lg);
+  background: var(--bg-color);
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-family: "Geist Mono", monospace;
+  font-size: 10px;
+  letter-spacing: 0.54px;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.field input,
+.field textarea {
+  width: 100%;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-lg);
+  background: var(--bg-color);
+  color: var(--text-primary);
+  font-family: "Pretendard Variable", sans-serif;
+  font-size: 15px;
+  font-weight: 330;
+  line-height: 1.45;
+  letter-spacing: -0.14px;
+  padding: 10px 12px;
+  outline: none;
+}
+
+.field input:focus,
+.field textarea:focus {
+  outline: 2px dashed var(--text-primary);
+  outline-offset: 2px;
+}
+
+.field input[aria-invalid="true"],
+.field textarea[aria-invalid="true"] {
+  border-color: var(--text-primary);
+}
+
+.errorText {
+  color: var(--text-primary);
+  font-family: "Pretendard Variable", sans-serif;
+  font-size: 12px;
+  letter-spacing: -0.14px;
+  text-transform: none;
+}
+
+.recoveryBanner {
+  margin: 16px 28px 0;
+  padding: 12px 14px;
+  border: 1px dashed var(--text-primary);
+  border-radius: var(--radius-lg);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  font-size: 13px;
+  line-height: 1.5;
+  letter-spacing: -0.14px;
+}
+
+.diffPanel {
+  border: 1px dashed var(--glass-border);
+  border-radius: var(--radius-lg);
+  background: var(--bg-secondary);
+  overflow: hidden;
+}
+
+.sectionHeader {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 14px 0;
+  font-family: "Geist Mono", monospace;
+  font-size: 10px;
+  letter-spacing: 0.54px;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.diffGrid {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 14px;
+}
+
+.diffRow {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.diffLabel,
+.diffCaption {
+  font-family: "Geist Mono", monospace;
+  font-size: 10px;
+  letter-spacing: 0.54px;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.diffValues {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.diffValues div {
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-lg);
+  background: var(--bg-color);
+  padding: 10px;
+}
+
+.diffValues p {
+  margin: 6px 0 0;
+  color: var(--text-primary);
+  font-size: 14px;
+  line-height: 1.45;
+  letter-spacing: -0.14px;
+  overflow-wrap: anywhere;
+}
+
+.dialogContent {
+  border-radius: 8px;
+  padding: 24px !important;
+  gap: 16px;
+}
+
+.dialogTitle {
+  font-size: 1.25rem;
+  font-weight: 540;
+  letter-spacing: -0.26px;
+  line-height: 1.2;
+}
+
+.dialogDescription {
+  color: var(--text-secondary);
+  font-size: 0.92rem;
+  line-height: 1.6;
+  letter-spacing: -0.14px;
+}
+
+.changePreview {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.changeCounts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.changeCounts span,
+.changeList em {
+  display: inline-flex;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-xl);
+  padding: 4px 10px 5px;
+  font-family: "Geist Mono", monospace;
+  font-size: 10px;
+  letter-spacing: 0.54px;
+  text-transform: uppercase;
+  color: var(--text-primary);
+  font-style: normal;
+}
+
+.changeList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.changeList li {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  letter-spacing: -0.14px;
+  color: var(--text-secondary);
+}
+
+.changeList strong {
+  color: var(--text-primary);
+  font-weight: 540;
+}
+
+@media (max-width: 767px) {
+  .actions {
+    justify-content: flex-start;
+  }
+
+  .formShell {
+    margin-left: 16px;
+    margin-right: 16px;
+  }
+
+  .diffValues {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/pages/domain-pack/model/useIntentDraftReadController.ts
+++ b/frontend/src/pages/domain-pack/model/useIntentDraftReadController.ts
@@ -159,7 +159,6 @@ export function useIntentDraftReadController({
     vId,
     summaryState,
     packQuery,
-    versionQuery,
     navigateToIntentCode,
     setVersionActionPending,
   });
@@ -448,7 +447,6 @@ function useApplyRevisionDraftHandler({
   vId,
   summaryState,
   packQuery,
-  versionQuery,
   navigateToIntentCode,
   setVersionActionPending,
 }: {
@@ -457,7 +455,6 @@ function useApplyRevisionDraftHandler({
   vId: number;
   summaryState: ReturnType<typeof useIntentRevisionSummary>;
   packQuery: UseQueryResult<DomainPackDetail>;
-  versionQuery: UseQueryResult<DomainPackVersionDetail>;
   navigateToIntentCode: (versionId: number, intentCode?: string | null) => Promise<void>;
   setVersionActionPending: (isPending: boolean) => void;
 }) {
@@ -470,7 +467,6 @@ function useApplyRevisionDraftHandler({
       try {
         const activated = await intentRevisionDraftApi.activateVersion(wsId, pId, vId);
         await packQuery.refetch();
-        await versionQuery.refetch();
         toast.success("Intent 수정 초안이 적용되었습니다.");
         await navigateToIntentCode(activated.activatedVersionId, intentCode);
       } catch {
@@ -486,7 +482,6 @@ function useApplyRevisionDraftHandler({
       setVersionActionPending,
       summaryState,
       vId,
-      versionQuery,
       wsId,
     ],
   );

--- a/frontend/src/pages/domain-pack/model/useIntentDraftReadController.ts
+++ b/frontend/src/pages/domain-pack/model/useIntentDraftReadController.ts
@@ -1,0 +1,547 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { UseQueryResult } from "@tanstack/react-query";
+import { useNavigate } from "react-router-dom";
+import { toast } from "sonner";
+import type { DomainPackDetail, DomainPackVersionDetail } from "@/entities/domain-pack";
+import type { IntentDetail } from "@/entities/intent";
+import { usePackDetail, useVersionDetail } from "@/features/domain-pack-summary-read";
+import {
+  classifyExistingDraftSource,
+  intentRevisionDraftApi,
+  parseIntentRevisionDraftSource,
+  resolveSingleExistingDraft,
+  useIntentRevisionMarkers,
+  useIntentRevisionSummary,
+  useSaveIntentRevisionDraft,
+  useUpdateDraftIntent,
+  type UpdateDraftIntentBody,
+} from "@/features/intent-revision-draft";
+import { ApiRequestError } from "@/shared/api";
+
+interface DirtyState {
+  isDirty: boolean;
+  intentId: number | null;
+}
+
+export interface ExistingDraftTarget {
+  versionId: number;
+  intentCode: string;
+  sourceType: "INTENT_REVISION" | "GENERAL_DRAFT";
+}
+
+interface IntentDraftReadControllerParams {
+  wsId: number;
+  pId: number;
+  vId: number;
+  iId: number | null;
+}
+
+export function useIntentDraftReadController({
+  wsId,
+  pId,
+  vId,
+  iId,
+}: IntentDraftReadControllerParams) {
+  const navigate = useNavigate();
+  const packQuery = usePackDetail(wsId, pId) as UseQueryResult<DomainPackDetail>;
+  const versionQuery = useVersionDetail(wsId, pId, vId) as UseQueryResult<DomainPackVersionDetail>;
+  const { saveIntentRevisionDraft, isPending: isCreatingRevision } = useSaveIntentRevisionDraft();
+  const { updateDraftIntent, isPending: isUpdatingDraft } = useUpdateDraftIntent();
+  const [detailRefreshKey, setDetailRefreshKey] = useState(0);
+  const [listRefreshKey, setListRefreshKey] = useState(0);
+  const [summaryRefreshKey, setSummaryRefreshKey] = useState(0);
+  const [versionActionPending, setVersionActionPending] = useState(false);
+  const [dirtyState, setDirtyState] = useState<DirtyState>({ isDirty: false, intentId: null });
+  const [pendingNavigation, setPendingNavigation] = useState<(() => void) | null>(null);
+  const [existingDraftTarget, setExistingDraftTarget] = useState<ExistingDraftTarget | null>(null);
+  const [recoveryVersionId, setRecoveryVersionId] = useState<number | null>(null);
+  const [selectedIntentCode, setSelectedIntentCode] = useState<string | null>(null);
+
+  const currentPublishedVersion = useCurrentPublishedVersion(packQuery.data?.versions);
+  const versionDetail = versionQuery.data;
+  const revisionSource = parseIntentRevisionDraftSource(versionDetail?.summaryJson);
+  const isRevisionDraft =
+    versionDetail?.lifecycleStatus === "DRAFT" && revisionSource?.type === "INTENT_REVISION";
+  const isCurrentPublished =
+    versionDetail?.lifecycleStatus === "PUBLISHED" &&
+    currentPublishedVersion?.versionId === versionDetail.versionId;
+  const isGeneralDraft = versionDetail?.lifecycleStatus === "DRAFT" && !isRevisionDraft;
+  const canEditIntent = isCurrentPublished || isRevisionDraft;
+
+  const summaryState = useIntentRevisionSummary({
+    workspaceId: wsId,
+    packId: pId,
+    draftVersionId: vId,
+    baseVersionId: revisionSource?.baseVersionId ?? null,
+    refreshKey: summaryRefreshKey,
+    enabled: isRevisionDraft,
+  });
+  const markers = useIntentRevisionMarkers({
+    editingIntentId: dirtyState.intentId,
+    isDirty: dirtyState.isDirty,
+    summaryState,
+  });
+
+  const resetDirty = useCallback(() => {
+    setDirtyState({ isDirty: false, intentId: null });
+  }, []);
+  const handleDirtyChange = useCallback((isDirty: boolean, intentId: number | null) => {
+    setDirtyState({ isDirty, intentId });
+  }, []);
+
+  useBeforeUnloadGuard(dirtyState.isDirty);
+
+  const navigateToIntentRoute = useCallback(
+    (versionId: number, intentId: number | null) => {
+      const suffix = intentId === null ? "" : `/${intentId}`;
+      navigate(`/workspaces/${wsId}/domain-packs/${pId}/versions/${versionId}/intents${suffix}`);
+    },
+    [navigate, pId, wsId],
+  );
+  const navigateToIntentCode = useCallback(
+    async (versionId: number, intentCode?: string | null) => {
+      if (!intentCode) {
+        navigateToIntentRoute(versionId, null);
+        return;
+      }
+
+      try {
+        const intents = await intentRevisionDraftApi.listIntents(wsId, pId, versionId);
+        const target = intents.find((intent) => intent.intentCode === intentCode);
+        navigateToIntentRoute(versionId, target?.id ?? null);
+      } catch {
+        navigateToIntentRoute(versionId, null);
+      }
+    },
+    [navigateToIntentRoute, pId, wsId],
+  );
+
+  const guardNavigation = useCallback(
+    (next: () => void) => {
+      if (!dirtyState.isDirty) {
+        next();
+        return;
+      }
+      setPendingNavigation(() => next);
+    },
+    [dirtyState.isDirty],
+  );
+  const refreshIntentViews = useCallback(() => {
+    setDetailRefreshKey((key) => key + 1);
+    setListRefreshKey((key) => key + 1);
+    setSummaryRefreshKey((key) => key + 1);
+  }, []);
+
+  const resolveExistingDraftTarget = useResolveExistingDraftTarget({
+    wsId,
+    pId,
+    packQuery,
+    setExistingDraftTarget,
+  });
+  const handleSaveRevision = useSaveRevisionHandler({
+    wsId,
+    pId,
+    vId,
+    isCurrentPublished,
+    isRevisionDraft,
+    packQuery,
+    saveIntentRevisionDraft,
+    updateDraftIntent,
+    resetDirty,
+    refreshIntentViews,
+    navigateToIntentRoute,
+    resolveExistingDraftTarget,
+    setRecoveryVersionId,
+  });
+  const handleApplyRevisionDraft = useApplyRevisionDraftHandler({
+    wsId,
+    pId,
+    vId,
+    summaryState,
+    packQuery,
+    versionQuery,
+    navigateToIntentCode,
+    setVersionActionPending,
+  });
+  const handleDiscardRevisionDraft = useDiscardRevisionDraftHandler({
+    wsId,
+    pId,
+    vId,
+    currentPublishedVersionId: currentPublishedVersion?.versionId ?? null,
+    baseVersionId: revisionSource?.baseVersionId ?? null,
+    packQuery,
+    navigate,
+    navigateToIntentCode,
+    setVersionActionPending,
+  });
+
+  return {
+    canEditIntent,
+    detailRefreshKey,
+    existingDraftTarget,
+    handleDirtyChange,
+    isCurrentPublished,
+    isGeneralDraft,
+    isMutationPending: isCreatingRevision || isUpdatingDraft || versionActionPending,
+    isRevisionDraft,
+    listRefreshKey,
+    markers,
+    pendingNavigation,
+    recoveryVersionId,
+    selectedChange:
+      iId !== null && summaryState.status === "ready"
+        ? summaryState.data.changedByDraftIntentId[iId]
+        : undefined,
+    selectedIntentCode,
+    setExistingDraftTarget,
+    setPendingNavigation,
+    setSelectedIntentCode,
+    summaryState,
+    versionDetail,
+    confirmExistingDraftNavigation: () => {
+      const target = existingDraftTarget;
+      setExistingDraftTarget(null);
+      resetDirty();
+      if (target) void navigateToIntentCode(target.versionId, target.intentCode);
+    },
+    confirmPendingNavigation: () => {
+      const next = pendingNavigation;
+      setPendingNavigation(null);
+      resetDirty();
+      next?.();
+    },
+    handleApplyRevisionDraftAction: () => {
+      guardNavigation(() => void handleApplyRevisionDraft(selectedIntentCode));
+    },
+    handleBack: () => {
+      guardNavigation(() => navigateToIntentRoute(vId, null));
+    },
+    handleDiscardRevisionDraftAction: () => {
+      guardNavigation(() => void handleDiscardRevisionDraft(selectedIntentCode));
+    },
+    handleSaveRevision,
+    handleSelect: (id: number) => {
+      guardNavigation(() => navigateToIntentRoute(vId, id));
+    },
+    retrySummary: () => setSummaryRefreshKey((key) => key + 1),
+  };
+}
+
+function useCurrentPublishedVersion(versions: DomainPackDetail["versions"] | undefined) {
+  return useMemo(() => {
+    return (versions ?? [])
+      .filter((version) => version.lifecycleStatus === "PUBLISHED" && version.versionId != null)
+      .reduce<NonNullable<DomainPackDetail["versions"]>[number] | null>((current, version) => {
+        if (!current) return version;
+        return (version.versionNo ?? 0) > (current.versionNo ?? 0) ? version : current;
+      }, null);
+  }, [versions]);
+}
+
+function useBeforeUnloadGuard(isDirty: boolean) {
+  useEffect(() => {
+    if (!isDirty) return;
+
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      event.returnValue = "";
+    };
+
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => window.removeEventListener("beforeunload", handleBeforeUnload);
+  }, [isDirty]);
+}
+
+function useResolveExistingDraftTarget({
+  wsId,
+  pId,
+  packQuery,
+  setExistingDraftTarget,
+}: {
+  wsId: number;
+  pId: number;
+  packQuery: UseQueryResult<DomainPackDetail>;
+  setExistingDraftTarget: (target: ExistingDraftTarget | null) => void;
+}) {
+  return useCallback(
+    async (intentCode: string): Promise<boolean> => {
+      try {
+        const refetched = await packQuery.refetch();
+        const resolution = resolveSingleExistingDraft(refetched.data?.versions);
+
+        if (resolution.status === "invalid") {
+          toast.error("초안 상태를 확인할 수 없습니다. 목록을 새로고침해 주세요.");
+          return false;
+        }
+
+        const draftDetail = await intentRevisionDraftApi.getVersionDetail(
+          wsId,
+          pId,
+          resolution.versionId,
+        );
+        setExistingDraftTarget({
+          versionId: resolution.versionId,
+          intentCode,
+          sourceType: classifyExistingDraftSource(draftDetail.summaryJson),
+        });
+        return true;
+      } catch {
+        toast.error("진행 중인 초안을 확인하지 못했습니다. 잠시 후 다시 시도해 주세요.");
+        return false;
+      }
+    },
+    [pId, packQuery, setExistingDraftTarget, wsId],
+  );
+}
+
+function useSaveRevisionHandler({
+  wsId,
+  pId,
+  vId,
+  isCurrentPublished,
+  isRevisionDraft,
+  packQuery,
+  saveIntentRevisionDraft,
+  updateDraftIntent,
+  resetDirty,
+  refreshIntentViews,
+  navigateToIntentRoute,
+  resolveExistingDraftTarget,
+  setRecoveryVersionId,
+}: {
+  wsId: number;
+  pId: number;
+  vId: number;
+  isCurrentPublished: boolean;
+  isRevisionDraft: boolean;
+  packQuery: UseQueryResult<DomainPackDetail>;
+  saveIntentRevisionDraft: ReturnType<typeof useSaveIntentRevisionDraft>["saveIntentRevisionDraft"];
+  updateDraftIntent: ReturnType<typeof useUpdateDraftIntent>["updateDraftIntent"];
+  resetDirty: () => void;
+  refreshIntentViews: () => void;
+  navigateToIntentRoute: (versionId: number, intentId: number | null) => void;
+  resolveExistingDraftTarget: (intentCode: string) => Promise<boolean>;
+  setRecoveryVersionId: (versionId: number | null) => void;
+}) {
+  return useCallback(
+    async (detail: IntentDetail, values: UpdateDraftIntentBody): Promise<boolean> => {
+      if (detail.id == null || !detail.intentCode) return false;
+
+      if (isCurrentPublished) {
+        return savePublishedIntentRevision({
+          wsId,
+          pId,
+          vId,
+          detail,
+          values,
+          packQuery,
+          saveIntentRevisionDraft,
+          resetDirty,
+          navigateToIntentRoute,
+          resolveExistingDraftTarget,
+          setRecoveryVersionId,
+        });
+      }
+
+      if (!isRevisionDraft) return false;
+
+      try {
+        await updateDraftIntent({
+          workspaceId: wsId,
+          packId: pId,
+          draftVersionId: vId,
+          intentId: detail.id,
+          values,
+        });
+        resetDirty();
+        refreshIntentViews();
+        return true;
+      } catch {
+        toast.error("Intent 수정 내용 저장에 실패했습니다.");
+        return false;
+      }
+    },
+    [
+      isCurrentPublished,
+      isRevisionDraft,
+      navigateToIntentRoute,
+      pId,
+      packQuery,
+      refreshIntentViews,
+      resetDirty,
+      resolveExistingDraftTarget,
+      saveIntentRevisionDraft,
+      setRecoveryVersionId,
+      updateDraftIntent,
+      vId,
+      wsId,
+    ],
+  );
+}
+
+async function savePublishedIntentRevision({
+  wsId,
+  pId,
+  vId,
+  detail,
+  values,
+  packQuery,
+  saveIntentRevisionDraft,
+  resetDirty,
+  navigateToIntentRoute,
+  resolveExistingDraftTarget,
+  setRecoveryVersionId,
+}: {
+  wsId: number;
+  pId: number;
+  vId: number;
+  detail: IntentDetail;
+  values: UpdateDraftIntentBody;
+  packQuery: UseQueryResult<DomainPackDetail>;
+  saveIntentRevisionDraft: ReturnType<typeof useSaveIntentRevisionDraft>["saveIntentRevisionDraft"];
+  resetDirty: () => void;
+  navigateToIntentRoute: (versionId: number, intentId: number | null) => void;
+  resolveExistingDraftTarget: (intentCode: string) => Promise<boolean>;
+  setRecoveryVersionId: (versionId: number | null) => void;
+}): Promise<boolean> {
+  try {
+    const result = await saveIntentRevisionDraft({
+      workspaceId: wsId,
+      packId: pId,
+      baseVersionId: vId,
+      intentCode: detail.intentCode!,
+      values,
+    });
+
+    resetDirty();
+    await packQuery.refetch();
+    if (!result.patchSucceeded) {
+      toast.error(
+        result.clonedIntentId === null
+          ? "Intent 수정 초안에서 같은 intent를 찾지 못했습니다."
+          : "Intent 수정 초안은 생성됐지만 수정 내용 저장에 실패했습니다.",
+      );
+      setRecoveryVersionId(result.draftVersionId);
+    }
+    navigateToIntentRoute(result.draftVersionId, result.clonedIntentId);
+    return true;
+  } catch (error) {
+    if (error instanceof ApiRequestError && error.code === "DOMAIN_PACK_DRAFT_ALREADY_EXISTS") {
+      await resolveExistingDraftTarget(detail.intentCode!);
+      return false;
+    }
+
+    if (error instanceof ApiRequestError && error.code === "DOMAIN_PACK_VERSION_NOT_CURRENT") {
+      await packQuery.refetch();
+      toast.error("현재 운영 버전이 변경되었습니다. 최신 버전에서 다시 수정해 주세요.");
+      return false;
+    }
+
+    toast.error("Intent 수정 내용 저장에 실패했습니다.");
+    return false;
+  }
+}
+
+function useApplyRevisionDraftHandler({
+  wsId,
+  pId,
+  vId,
+  summaryState,
+  packQuery,
+  versionQuery,
+  navigateToIntentCode,
+  setVersionActionPending,
+}: {
+  wsId: number;
+  pId: number;
+  vId: number;
+  summaryState: ReturnType<typeof useIntentRevisionSummary>;
+  packQuery: UseQueryResult<DomainPackDetail>;
+  versionQuery: UseQueryResult<DomainPackVersionDetail>;
+  navigateToIntentCode: (versionId: number, intentCode?: string | null) => Promise<void>;
+  setVersionActionPending: (isPending: boolean) => void;
+}) {
+  return useCallback(
+    async (intentCode?: string | null) => {
+      const summary = summaryState.status === "ready" ? summaryState.data : null;
+      if (!summary || summary.changedIntents.length === 0) return;
+
+      setVersionActionPending(true);
+      try {
+        const activated = await intentRevisionDraftApi.activateVersion(wsId, pId, vId);
+        await packQuery.refetch();
+        await versionQuery.refetch();
+        toast.success("Intent 수정 초안이 적용되었습니다.");
+        await navigateToIntentCode(activated.activatedVersionId, intentCode);
+      } catch {
+        toast.error("Intent 수정 초안 적용에 실패했습니다.");
+      } finally {
+        setVersionActionPending(false);
+      }
+    },
+    [
+      navigateToIntentCode,
+      pId,
+      packQuery,
+      setVersionActionPending,
+      summaryState,
+      vId,
+      versionQuery,
+      wsId,
+    ],
+  );
+}
+
+function useDiscardRevisionDraftHandler({
+  wsId,
+  pId,
+  vId,
+  currentPublishedVersionId,
+  baseVersionId,
+  packQuery,
+  navigate,
+  navigateToIntentCode,
+  setVersionActionPending,
+}: {
+  wsId: number;
+  pId: number;
+  vId: number;
+  currentPublishedVersionId: number | null;
+  baseVersionId: number | null;
+  packQuery: UseQueryResult<DomainPackDetail>;
+  navigate: ReturnType<typeof useNavigate>;
+  navigateToIntentCode: (versionId: number, intentCode?: string | null) => Promise<void>;
+  setVersionActionPending: (isPending: boolean) => void;
+}) {
+  return useCallback(
+    async (intentCode?: string | null) => {
+      setVersionActionPending(true);
+      try {
+        await intentRevisionDraftApi.discardDraft(wsId, pId, vId);
+        const targetVersionId = currentPublishedVersionId ?? baseVersionId;
+        await packQuery.refetch();
+        toast.success("Intent 수정 초안이 취소되었습니다.");
+        if (targetVersionId !== null) {
+          await navigateToIntentCode(targetVersionId, intentCode);
+        } else {
+          navigate(`/workspaces/${wsId}/domain-packs/${pId}`);
+        }
+      } catch {
+        toast.error("Intent 수정 초안 취소에 실패했습니다.");
+      } finally {
+        setVersionActionPending(false);
+      }
+    },
+    [
+      baseVersionId,
+      currentPublishedVersionId,
+      navigate,
+      navigateToIntentCode,
+      pId,
+      packQuery,
+      setVersionActionPending,
+      vId,
+      wsId,
+    ],
+  );
+}

--- a/frontend/src/pages/domain-pack/ui/DomainPackListPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/DomainPackListPage.tsx
@@ -3,6 +3,7 @@ import { LoadingSpinner } from "@/shared/ui/ostone/atoms/LoadingSpinner";
 import { ErrorState } from "@/shared/ui/ostone/atoms/ErrorState";
 import { EmptyState } from "@/shared/ui/ostone/atoms/EmptyState";
 import { parseRouteId } from "@/shared/lib/parseRouteId";
+import { unwrapApiResponse } from "@/shared/api";
 import { useListDomainPacks } from "@/shared/api/generated/endpoints/domain-pack-controller/domain-pack-controller";
 import type { DomainPackSummaryResult } from "@/shared/api/generated/zod";
 
@@ -46,7 +47,7 @@ export function DomainPackListPage() {
     );
   }
 
-  const packs = query.data?.data ?? [];
+  const packs = unwrapApiResponse<DomainPackSummaryResult[]>(query.data) ?? [];
 
   if (packs.length === 0) {
     return (

--- a/frontend/src/pages/domain-pack/ui/IntentDraftReadPage.test.tsx
+++ b/frontend/src/pages/domain-pack/ui/IntentDraftReadPage.test.tsx
@@ -1,0 +1,425 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiRequestError } from "@/shared/api";
+import { IntentDraftReadPage } from "./IntentDraftReadPage";
+
+const mocks = vi.hoisted(() => ({
+  navigate: vi.fn(),
+  packRefetch: vi.fn(),
+  versionRefetch: vi.fn(),
+  saveIntentRevisionDraft: vi.fn(),
+  updateDraftIntent: vi.fn(),
+  activateVersion: vi.fn(),
+  discardDraft: vi.fn(),
+  listIntents: vi.fn(),
+  getVersionDetail: vi.fn(),
+  summaryState: {
+    status: "ready",
+    data: {
+      changedIntents: [
+        {
+          intentId: 10,
+          intentCode: "refund",
+          name: "환불 문의",
+          fields: ["name"],
+          before: { name: "환불", description: "" },
+          after: { name: "환불 문의", description: "" },
+        },
+      ],
+      changedFieldCounts: { name: 1, description: 0 },
+      changedByDraftIntentId: {},
+    },
+  },
+  packData: {
+    packId: 7,
+    versions: [
+      { versionId: 2, versionNo: 1, lifecycleStatus: "PUBLISHED" },
+      { versionId: 3, versionNo: 2, lifecycleStatus: "PUBLISHED" },
+    ],
+  },
+  versionData: {
+    versionId: 3,
+    lifecycleStatus: "PUBLISHED",
+    summaryJson: "{}",
+  },
+}));
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => mocks.navigate,
+  };
+});
+
+vi.mock("@/widgets/ostone-shell", () => ({
+  OstoneShell: ({ children }: { children: React.ReactNode }) => <main>{children}</main>,
+}));
+
+vi.mock("@/features/domain-pack-summary-read", () => ({
+  usePackDetail: () => ({ data: mocks.packData, refetch: mocks.packRefetch }),
+  useVersionDetail: () => ({ data: mocks.versionData, refetch: mocks.versionRefetch }),
+}));
+
+vi.mock("@/features/intent-draft-read/ui", () => ({
+  IntentTreePanel: ({ onSelect }: { onSelect: (id: number) => void }) => (
+    <button type="button" onClick={() => onSelect(10)}>
+      select intent
+    </button>
+  ),
+  IntentDetailPanel: ({
+    intentId,
+    afterHeader,
+    beforeJsonCards,
+    children,
+  }: {
+    intentId: number | null;
+    afterHeader?: (detail: { id: number; intentCode: string }) => React.ReactNode;
+    beforeJsonCards?: () => React.ReactNode;
+    children?: (detail: { id: number; intentCode: string; name: string; description: string }) => React.ReactNode;
+  }) => {
+    if (intentId === null) return <div>empty intent detail</div>;
+    const detail = {
+      id: intentId,
+      intentCode: "refund",
+      name: "환불 문의",
+      description: "기존 설명",
+    };
+    return (
+      <section>
+        <div>intent detail {intentId}</div>
+        {afterHeader?.(detail)}
+        {beforeJsonCards?.()}
+        {children?.(detail)}
+      </section>
+    );
+  },
+}));
+
+vi.mock("@/features/approve-intent", () => ({
+  IntentDetailWithApproval: () => <div>approval detail</div>,
+}));
+
+vi.mock("@/features/intent-revision-draft", () => ({
+  IntentRevisionDiffPanel: () => <div>revision diff</div>,
+  IntentRevisionRecoveryBanner: () => <div>recovery banner</div>,
+  IntentRevisionDraftActions: ({
+    onApply,
+    onDiscard,
+    onRetrySummary,
+  }: {
+    onApply: () => void;
+    onDiscard: () => void;
+    onRetrySummary: () => void;
+  }) => (
+    <div>
+      <button type="button" onClick={onApply}>
+        apply revision
+      </button>
+      <button type="button" onClick={onDiscard}>
+        discard revision
+      </button>
+      <button type="button" onClick={onRetrySummary}>
+        retry summary
+      </button>
+    </div>
+  ),
+  IntentRevisionEditForm: ({
+    onSave,
+    onDirtyChange,
+  }: {
+    onSave: (values: { name: string; description: string }) => Promise<boolean>;
+    onDirtyChange: (dirty: boolean, intentId: number | null) => void;
+  }) => (
+    <div>
+      <button type="button" onClick={() => onDirtyChange(true, 10)}>
+        mark dirty
+      </button>
+      <button
+        type="button"
+        onClick={() => void onSave({ name: "환불 문의 수정", description: "수정 설명" })}
+      >
+        save revision
+      </button>
+    </div>
+  ),
+  classifyExistingDraftSource: () => "INTENT_REVISION",
+  intentRevisionDraftApi: {
+    activateVersion: mocks.activateVersion,
+    discardDraft: mocks.discardDraft,
+    listIntents: mocks.listIntents,
+    getVersionDetail: mocks.getVersionDetail,
+  },
+  parseIntentRevisionDraftSource: (summaryJson?: string) =>
+    summaryJson?.includes("INTENT_REVISION")
+      ? { type: "INTENT_REVISION", baseVersionId: 2 }
+      : null,
+  resolveSingleExistingDraft: (versions?: Array<{ versionId?: number; lifecycleStatus?: string }>) => {
+    const drafts = versions?.filter((version) => version.lifecycleStatus === "DRAFT") ?? [];
+    return drafts.length === 1 && drafts[0]?.versionId != null
+      ? { status: "resolved", versionId: drafts[0].versionId }
+      : { status: "invalid" };
+  },
+  useIntentRevisionMarkers: () => ({}),
+  useIntentRevisionSummary: () => mocks.summaryState,
+  useSaveIntentRevisionDraft: () => ({
+    saveIntentRevisionDraft: mocks.saveIntentRevisionDraft,
+    isPending: false,
+  }),
+  useUpdateDraftIntent: () => ({
+    updateDraftIntent: mocks.updateDraftIntent,
+    isPending: false,
+  }),
+}));
+
+function renderPage(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route
+          path="/workspaces/:workspaceId/domain-packs/:packId/versions/:versionId/intents/:intentId?"
+          element={<IntentDraftReadPage />}
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("IntentDraftReadPage", () => {
+  beforeEach(() => {
+    mocks.navigate.mockReset();
+    mocks.packRefetch.mockReset();
+    mocks.versionRefetch.mockReset();
+    mocks.saveIntentRevisionDraft.mockReset();
+    mocks.updateDraftIntent.mockReset();
+    mocks.activateVersion.mockReset();
+    mocks.discardDraft.mockReset();
+    mocks.listIntents.mockReset();
+    mocks.getVersionDetail.mockReset();
+    mocks.packData = {
+      packId: 7,
+      versions: [
+        { versionId: 2, versionNo: 1, lifecycleStatus: "PUBLISHED" },
+        { versionId: 3, versionNo: 2, lifecycleStatus: "PUBLISHED" },
+      ],
+    };
+    mocks.versionData = {
+      versionId: 3,
+      lifecycleStatus: "PUBLISHED",
+      summaryJson: "{}",
+    };
+    mocks.summaryState = {
+      status: "ready",
+      data: {
+        changedIntents: [
+          {
+            intentId: 10,
+            intentCode: "refund",
+            name: "환불 문의",
+            fields: ["name"],
+            before: { name: "환불", description: "" },
+            after: { name: "환불 문의", description: "" },
+          },
+        ],
+        changedFieldCounts: { name: 1, description: 0 },
+        changedByDraftIntentId: {},
+      },
+    };
+    mocks.packRefetch.mockResolvedValue({ data: mocks.packData });
+    mocks.versionRefetch.mockResolvedValue({ data: mocks.versionData });
+    mocks.listIntents.mockResolvedValue([{ id: 50, intentCode: "refund" }]);
+  });
+
+  it("잘못된 URL 파라미터면 alert를 표시한다", () => {
+    renderPage("/workspaces/abc/domain-packs/7/versions/3/intents");
+
+    expect(screen.getByRole("alert")).toHaveTextContent("잘못된 URL 파라미터입니다.");
+  });
+
+  it("intent 선택 시 상세 URL로 이동한다", () => {
+    renderPage("/workspaces/1/domain-packs/7/versions/3/intents");
+
+    fireEvent.click(screen.getByRole("button", { name: "select intent" }));
+
+    expect(mocks.navigate).toHaveBeenCalledWith(
+      "/workspaces/1/domain-packs/7/versions/3/intents/10",
+    );
+  });
+
+  it("현재 운영 버전에서 첫 저장 시 revision draft를 생성하고 cloned intent로 이동한다", async () => {
+    mocks.saveIntentRevisionDraft.mockResolvedValue({
+      draftVersionId: 4,
+      clonedIntentId: 40,
+      patchSucceeded: true,
+    });
+    renderPage("/workspaces/1/domain-packs/7/versions/3/intents/10");
+
+    fireEvent.click(screen.getByRole("button", { name: "save revision" }));
+
+    await waitFor(() =>
+      expect(mocks.saveIntentRevisionDraft).toHaveBeenCalledWith({
+        workspaceId: 1,
+        packId: 7,
+        baseVersionId: 3,
+        intentCode: "refund",
+        values: { name: "환불 문의 수정", description: "수정 설명" },
+      }),
+    );
+    expect(mocks.navigate).toHaveBeenCalledWith(
+      "/workspaces/1/domain-packs/7/versions/4/intents/40",
+    );
+  });
+
+  it("이미 진행 중인 초안이 있으면 기존 초안 이동 dialog를 보여준다", async () => {
+    mocks.packData = {
+      packId: 7,
+      versions: [
+        { versionId: 3, versionNo: 2, lifecycleStatus: "PUBLISHED" },
+        { versionId: 5, versionNo: 3, lifecycleStatus: "DRAFT" },
+      ],
+    };
+    mocks.packRefetch.mockResolvedValue({ data: mocks.packData });
+    mocks.getVersionDetail.mockResolvedValue({
+      versionId: 5,
+      lifecycleStatus: "DRAFT",
+      summaryJson: '{"draftSource":"INTENT_REVISION"}',
+    });
+    mocks.saveIntentRevisionDraft.mockRejectedValue(
+      new ApiRequestError(409, "DOMAIN_PACK_DRAFT_ALREADY_EXISTS", "draft exists"),
+    );
+    renderPage("/workspaces/1/domain-packs/7/versions/3/intents/10");
+
+    fireEvent.click(screen.getByRole("button", { name: "save revision" }));
+
+    await waitFor(() => expect(screen.getByText("진행 중인 초안이 있습니다.")).toBeInTheDocument());
+  });
+
+  it("기존 초안 dialog에서 이동을 확정하면 해당 초안의 같은 intent로 이동한다", async () => {
+    mocks.packData = {
+      packId: 7,
+      versions: [
+        { versionId: 3, versionNo: 2, lifecycleStatus: "PUBLISHED" },
+        { versionId: 5, versionNo: 3, lifecycleStatus: "DRAFT" },
+      ],
+    };
+    mocks.packRefetch.mockResolvedValue({ data: mocks.packData });
+    mocks.getVersionDetail.mockResolvedValue({
+      versionId: 5,
+      lifecycleStatus: "DRAFT",
+      summaryJson: '{"draftSource":"INTENT_REVISION"}',
+    });
+    mocks.saveIntentRevisionDraft.mockRejectedValue(
+      new ApiRequestError(409, "DOMAIN_PACK_DRAFT_ALREADY_EXISTS", "draft exists"),
+    );
+    renderPage("/workspaces/1/domain-packs/7/versions/3/intents/10");
+
+    fireEvent.click(screen.getByRole("button", { name: "save revision" }));
+    await waitFor(() => expect(screen.getByText("진행 중인 초안이 있습니다.")).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: "이동" }));
+
+    await waitFor(() =>
+      expect(mocks.navigate).toHaveBeenCalledWith(
+        "/workspaces/1/domain-packs/7/versions/5/intents/50",
+      ),
+    );
+  });
+
+  it("revision draft 적용 후 선택 intent code를 새 버전 intent id로 복원한다", async () => {
+    mocks.versionData = {
+      versionId: 6,
+      lifecycleStatus: "DRAFT",
+      summaryJson: '{"draftSource":"INTENT_REVISION"}',
+    };
+    mocks.activateVersion.mockResolvedValue({ activatedVersionId: 9 });
+    renderPage("/workspaces/1/domain-packs/7/versions/6/intents/10");
+
+    fireEvent.click(screen.getByRole("button", { name: "apply revision" }));
+
+    await waitFor(() => expect(mocks.activateVersion).toHaveBeenCalledWith(1, 7, 6));
+    await waitFor(() =>
+      expect(mocks.navigate).toHaveBeenCalledWith(
+        "/workspaces/1/domain-packs/7/versions/9/intents/50",
+      ),
+    );
+  });
+
+  it("적용 후 intent code 조회가 실패하면 새 버전 root로 이동한다", async () => {
+    mocks.versionData = {
+      versionId: 6,
+      lifecycleStatus: "DRAFT",
+      summaryJson: '{"draftSource":"INTENT_REVISION"}',
+    };
+    mocks.activateVersion.mockResolvedValue({ activatedVersionId: 9 });
+    mocks.listIntents.mockRejectedValue(new Error("list failed"));
+    renderPage("/workspaces/1/domain-packs/7/versions/6/intents/10");
+
+    fireEvent.click(screen.getByRole("button", { name: "apply revision" }));
+
+    await waitFor(() =>
+      expect(mocks.navigate).toHaveBeenCalledWith(
+        "/workspaces/1/domain-packs/7/versions/9/intents",
+      ),
+    );
+  });
+
+  it("revision draft 상태에서는 기존 draft intent를 PATCH하고 현재 화면을 새로고침한다", async () => {
+    mocks.versionData = {
+      versionId: 6,
+      lifecycleStatus: "DRAFT",
+      summaryJson: '{"draftSource":"INTENT_REVISION"}',
+    };
+    mocks.updateDraftIntent.mockResolvedValue({ id: 10 });
+    renderPage("/workspaces/1/domain-packs/7/versions/6/intents/10");
+
+    fireEvent.click(screen.getByRole("button", { name: "save revision" }));
+
+    await waitFor(() =>
+      expect(mocks.updateDraftIntent).toHaveBeenCalledWith({
+        workspaceId: 1,
+        packId: 7,
+        draftVersionId: 6,
+        intentId: 10,
+        values: { name: "환불 문의 수정", description: "수정 설명" },
+      }),
+    );
+    expect(screen.getByText("revision diff")).toBeInTheDocument();
+  });
+
+  it("dirty 상태에서 적용을 누르면 guard 확인 전까지 적용하지 않는다", async () => {
+    mocks.versionData = {
+      versionId: 6,
+      lifecycleStatus: "DRAFT",
+      summaryJson: '{"draftSource":"INTENT_REVISION"}',
+    };
+    mocks.activateVersion.mockResolvedValue({ activatedVersionId: 9 });
+    renderPage("/workspaces/1/domain-packs/7/versions/6/intents/10");
+
+    fireEvent.click(screen.getByRole("button", { name: "mark dirty" }));
+    fireEvent.click(screen.getByRole("button", { name: "apply revision" }));
+
+    expect(screen.getByText("저장하지 않고 이동할까요?")).toBeInTheDocument();
+    expect(mocks.activateVersion).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "이동" }));
+    await waitFor(() => expect(mocks.activateVersion).toHaveBeenCalledWith(1, 7, 6));
+  });
+
+  it("revision draft 취소 후 운영 버전으로 돌아간다", async () => {
+    mocks.versionData = {
+      versionId: 6,
+      lifecycleStatus: "DRAFT",
+      summaryJson: '{"draftSource":"INTENT_REVISION"}',
+    };
+    renderPage("/workspaces/1/domain-packs/7/versions/6/intents/10");
+
+    fireEvent.click(screen.getByRole("button", { name: "discard revision" }));
+
+    await waitFor(() => expect(mocks.discardDraft).toHaveBeenCalledWith(1, 7, 6));
+    await waitFor(() =>
+      expect(mocks.navigate).toHaveBeenCalledWith(
+        "/workspaces/1/domain-packs/7/versions/3/intents/50",
+      ),
+    );
+  });
+});

--- a/frontend/src/pages/domain-pack/ui/IntentDraftReadPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/IntentDraftReadPage.tsx
@@ -1,14 +1,51 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { UseQueryResult } from "@tanstack/react-query";
 import { useNavigate, useParams } from "react-router-dom";
+import { toast } from "sonner";
+import type { DomainPackDetail, DomainPackVersionDetail } from "@/entities/domain-pack";
+import type { IntentDetail } from "@/entities/intent";
 import { IntentDetailPanel, IntentTreePanel } from "@/features/intent-draft-read/ui";
 import { IntentDetailWithApproval } from "@/features/approve-intent";
+import { usePackDetail, useVersionDetail } from "@/features/domain-pack-summary-read";
+import {
+  IntentRevisionDiffPanel,
+  IntentRevisionDraftActions,
+  IntentRevisionEditForm,
+  IntentRevisionRecoveryBanner,
+  intentRevisionDraftApi,
+  parseIntentRevisionDraftSource,
+  useIntentRevisionMarkers,
+  useIntentRevisionSummary,
+  useSaveIntentRevisionDraft,
+  useUpdateDraftIntent,
+  type UpdateDraftIntentBody,
+} from "@/features/intent-revision-draft";
+import { ApiRequestError } from "@/shared/api";
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogTitle,
+} from "@/shared/ui/alert-dialog";
+import { Button } from "@/shared/ui/button";
 import { parseRouteId } from "@/shared/lib/parseRouteId";
 import { OstoneShell } from "@/widgets/ostone-shell";
 import { Mono } from "@/shared/ui/ostone/atoms";
 import styles from "./intent-draft-read-page.module.css";
 
+interface DirtyState {
+  isDirty: boolean;
+  intentId: number | null;
+}
+
+interface ExistingDraftTarget {
+  versionId: number;
+  intentCode: string;
+}
+
 export function IntentDraftReadPage() {
   const { workspaceId, packId, versionId, intentId } = useParams();
-  const navigate = useNavigate();
 
   const wsId = parseRouteId(workspaceId);
   const pId = parseRouteId(packId);
@@ -25,15 +62,266 @@ export function IntentDraftReadPage() {
     );
   }
 
+  return <IntentDraftReadContent wsId={wsId} pId={pId} vId={vId} iId={iId} />;
+}
+
+function IntentDraftReadContent({
+  wsId,
+  pId,
+  vId,
+  iId,
+}: {
+  wsId: number;
+  pId: number;
+  vId: number;
+  iId: number | null;
+}) {
+  const navigate = useNavigate();
+  const packQuery = usePackDetail(wsId, pId) as UseQueryResult<DomainPackDetail>;
+  const versionQuery = useVersionDetail(wsId, pId, vId) as UseQueryResult<DomainPackVersionDetail>;
+  const { saveIntentRevisionDraft, isPending: isCreatingRevision } = useSaveIntentRevisionDraft();
+  const { updateDraftIntent, isPending: isUpdatingDraft } = useUpdateDraftIntent();
+  const [detailRefreshKey, setDetailRefreshKey] = useState(0);
+  const [listRefreshKey, setListRefreshKey] = useState(0);
+  const [summaryRefreshKey, setSummaryRefreshKey] = useState(0);
+  const [versionActionPending, setVersionActionPending] = useState(false);
+  const [dirtyState, setDirtyState] = useState<DirtyState>({ isDirty: false, intentId: null });
+  const [pendingNavigation, setPendingNavigation] = useState<(() => void) | null>(null);
+  const [existingDraftTarget, setExistingDraftTarget] = useState<ExistingDraftTarget | null>(null);
+  const [recoveryVersionId, setRecoveryVersionId] = useState<number | null>(null);
+
+  const currentPublishedVersion = useMemo(() => {
+    const versions = packQuery.data?.versions ?? [];
+    return versions
+      .filter((version) => version.lifecycleStatus === "PUBLISHED" && version.versionId != null)
+      .reduce<NonNullable<DomainPackDetail["versions"]>[number] | null>((current, version) => {
+        if (!current) return version;
+        return (version.versionNo ?? 0) > (current.versionNo ?? 0) ? version : current;
+      }, null);
+  }, [packQuery.data?.versions]);
+
+  const versionDetail = versionQuery.data;
+  const revisionSource = parseIntentRevisionDraftSource(versionDetail?.summaryJson);
+  const isRevisionDraft =
+    versionDetail?.lifecycleStatus === "DRAFT" && revisionSource?.type === "INTENT_REVISION";
+  const isCurrentPublished =
+    versionDetail?.lifecycleStatus === "PUBLISHED" &&
+    currentPublishedVersion?.versionId === versionDetail.versionId;
+  const isGeneralDraft = versionDetail?.lifecycleStatus === "DRAFT" && !isRevisionDraft;
+  const canEditIntent = isCurrentPublished || isRevisionDraft;
+  const hasSelection = iId !== null;
+
+  const summaryState = useIntentRevisionSummary({
+    workspaceId: wsId,
+    packId: pId,
+    draftVersionId: vId,
+    baseVersionId: revisionSource?.baseVersionId ?? null,
+    refreshKey: summaryRefreshKey,
+    enabled: isRevisionDraft,
+  });
+
+  const markers = useIntentRevisionMarkers({
+    editingIntentId: dirtyState.intentId,
+    isDirty: dirtyState.isDirty,
+    summaryState,
+  });
+
+  const resetDirty = useCallback(() => {
+    setDirtyState({ isDirty: false, intentId: null });
+  }, []);
+
+  const handleDirtyChange = useCallback((isDirty: boolean, intentId: number | null) => {
+    setDirtyState({ isDirty, intentId });
+  }, []);
+
+  useEffect(() => {
+    if (!dirtyState.isDirty) return;
+
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      event.returnValue = "";
+    };
+
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => window.removeEventListener("beforeunload", handleBeforeUnload);
+  }, [dirtyState.isDirty]);
+
+  const navigateToIntentRoute = useCallback(
+    (versionId: number, intentId: number | null) => {
+      const suffix = intentId === null ? "" : `/${intentId}`;
+      navigate(`/workspaces/${wsId}/domain-packs/${pId}/versions/${versionId}/intents${suffix}`);
+    },
+    [navigate, pId, wsId],
+  );
+
+  const navigateToIntentCode = useCallback(
+    async (versionId: number, intentCode?: string | null) => {
+      if (!intentCode) {
+        navigateToIntentRoute(versionId, null);
+        return;
+      }
+
+      const intents = await intentRevisionDraftApi.listIntents(wsId, pId, versionId);
+      const target = intents.find((intent) => intent.intentCode === intentCode);
+      navigateToIntentRoute(versionId, target?.id ?? null);
+    },
+    [navigateToIntentRoute, pId, wsId],
+  );
+
+  const guardNavigation = useCallback(
+    (next: () => void) => {
+      if (!dirtyState.isDirty) {
+        next();
+        return;
+      }
+      setPendingNavigation(() => next);
+    },
+    [dirtyState.isDirty],
+  );
+
   const handleSelect = (id: number) => {
-    navigate(`/workspaces/${wsId}/domain-packs/${pId}/versions/${vId}/intents/${id}`);
+    guardNavigation(() => navigateToIntentRoute(vId, id));
   };
 
   const handleBack = () => {
-    navigate(`/workspaces/${wsId}/domain-packs/${pId}/versions/${vId}/intents`);
+    guardNavigation(() => navigateToIntentRoute(vId, null));
   };
 
-  const hasSelection = iId !== null;
+  const refreshIntentViews = () => {
+    setDetailRefreshKey((key) => key + 1);
+    setListRefreshKey((key) => key + 1);
+    setSummaryRefreshKey((key) => key + 1);
+  };
+
+  const resolveExistingDraftTarget = async (intentCode: string) => {
+    const refetched = await packQuery.refetch();
+    const drafts = (refetched.data?.versions ?? []).filter(
+      (version) => version.lifecycleStatus === "DRAFT" && version.versionId != null,
+    );
+
+    if (drafts.length !== 1 || drafts[0].versionId == null) {
+      toast.error("초안 상태를 확인할 수 없습니다. 목록을 새로고침해 주세요.");
+      return;
+    }
+
+    await intentRevisionDraftApi.getVersionDetail(wsId, pId, drafts[0].versionId);
+    setExistingDraftTarget({ versionId: drafts[0].versionId, intentCode });
+  };
+
+  const handleSaveRevision = async (detail: IntentDetail, values: UpdateDraftIntentBody) => {
+    if (detail.id == null || !detail.intentCode) return;
+
+    if (isCurrentPublished) {
+      try {
+        const result = await saveIntentRevisionDraft({
+          workspaceId: wsId,
+          packId: pId,
+          baseVersionId: vId,
+          intentCode: detail.intentCode,
+          values,
+        });
+
+        resetDirty();
+        await packQuery.refetch();
+        if (!result.patchSucceeded) {
+          toast.error(
+            result.clonedIntentId === null
+              ? "Intent 수정 초안에서 같은 intent를 찾지 못했습니다."
+              : "Intent 수정 초안은 생성됐지만 수정 내용 저장에 실패했습니다.",
+          );
+          setRecoveryVersionId(result.draftVersionId);
+        }
+        navigateToIntentRoute(result.draftVersionId, result.clonedIntentId);
+      } catch (error) {
+        if (
+          error instanceof ApiRequestError &&
+          error.code === "DOMAIN_PACK_DRAFT_ALREADY_EXISTS"
+        ) {
+          await resolveExistingDraftTarget(detail.intentCode);
+          return;
+        }
+
+        if (
+          error instanceof ApiRequestError &&
+          error.code === "DOMAIN_PACK_VERSION_NOT_CURRENT"
+        ) {
+          await packQuery.refetch();
+          toast.error("현재 운영 버전이 변경되었습니다. 최신 버전에서 다시 수정해 주세요.");
+          return;
+        }
+
+        toast.error("Intent 수정 내용 저장에 실패했습니다.");
+      }
+      return;
+    }
+
+    if (isRevisionDraft) {
+      try {
+        await updateDraftIntent({
+          workspaceId: wsId,
+          packId: pId,
+          draftVersionId: vId,
+          intentId: detail.id,
+          values,
+        });
+        resetDirty();
+        refreshIntentViews();
+      } catch {
+        toast.error("Intent 수정 내용 저장에 실패했습니다.");
+      }
+    }
+  };
+
+  const handleApplyRevisionDraft = async (detail: IntentDetail) => {
+    const summary = summaryState.status === "ready" ? summaryState.data : null;
+    if (!summary || summary.changedIntents.length === 0) return;
+
+    setVersionActionPending(true);
+    try {
+      const activated = await intentRevisionDraftApi.activateVersion(wsId, pId, vId);
+      await packQuery.refetch();
+      await versionQuery.refetch();
+      toast.success("Intent 수정 초안이 적용되었습니다.");
+      await navigateToIntentCode(activated.versionId ?? vId, detail.intentCode);
+    } catch {
+      toast.error("Intent 수정 초안 적용에 실패했습니다.");
+    } finally {
+      setVersionActionPending(false);
+    }
+  };
+
+  const handleDiscardRevisionDraft = async (detail: IntentDetail) => {
+    setVersionActionPending(true);
+    try {
+      await intentRevisionDraftApi.discardDraft(wsId, pId, vId);
+      const targetVersionId =
+        currentPublishedVersion?.versionId ?? revisionSource?.baseVersionId ?? null;
+      await packQuery.refetch();
+      toast.success("Intent 수정 초안이 취소되었습니다.");
+      if (targetVersionId !== null) {
+        await navigateToIntentCode(targetVersionId, detail.intentCode);
+      } else {
+        navigate(`/workspaces/${wsId}/domain-packs/${pId}`);
+      }
+    } catch {
+      toast.error("Intent 수정 초안 취소에 실패했습니다.");
+    } finally {
+      setVersionActionPending(false);
+    }
+  };
+
+  const versionLabel = getVersionLabel({
+    lifecycleStatus: versionDetail?.lifecycleStatus,
+    isCurrentPublished,
+    isRevisionDraft,
+  });
+
+  const selectedChange =
+    iId !== null && summaryState.status === "ready"
+      ? summaryState.data.changedByDraftIntentId[iId]
+      : undefined;
+
+  const isMutationPending = isCreatingRevision || isUpdatingDraft || versionActionPending;
 
   return (
     <OstoneShell active="domain" crumbs={[`PACK · ${pId}`, `Version · ${vId}`]}>
@@ -47,8 +335,8 @@ export function IntentDraftReadPage() {
             <Mono>VER · {vId}</Mono>
           </nav>
           <div className={styles.versionMeta}>
-            <span className={styles.versionTitle}>Intent 초안 조회</span>
-            <span className={styles.versionBadge}>READ ONLY</span>
+            <span className={styles.versionTitle}>Intent 조회</span>
+            <span className={styles.versionBadge}>{versionLabel}</span>
           </div>
         </header>
         {hasSelection && (
@@ -64,17 +352,129 @@ export function IntentDraftReadPage() {
               versionId={vId}
               selectedId={iId}
               onSelect={handleSelect}
+              refreshKey={listRefreshKey}
+              markers={markers}
             />
           </div>
           <div className={styles.detailSlot}>
             {iId !== null ? (
-              <IntentDetailWithApproval key={iId} wsId={wsId} pId={pId} vId={vId} iId={iId} />
+              isGeneralDraft ? (
+                <IntentDetailWithApproval key={iId} wsId={wsId} pId={pId} vId={vId} iId={iId} />
+              ) : (
+                <IntentDetailPanel
+                  key={iId}
+                  wsId={wsId}
+                  packId={pId}
+                  versionId={vId}
+                  intentId={iId}
+                  refreshKey={detailRefreshKey}
+                  headerActions={(detail) =>
+                    isRevisionDraft ? (
+                      <IntentRevisionDraftActions
+                        summary={summaryState.status === "ready" ? summaryState.data : undefined}
+                        isSummaryLoading={summaryState.status === "loading"}
+                        isPending={isMutationPending}
+                        onApply={() => void handleApplyRevisionDraft(detail)}
+                        onDiscard={() => void handleDiscardRevisionDraft(detail)}
+                      />
+                    ) : undefined
+                  }
+                  afterHeader={() =>
+                    recoveryVersionId === vId ? <IntentRevisionRecoveryBanner /> : null
+                  }
+                  beforeJsonCards={() =>
+                    isRevisionDraft ? <IntentRevisionDiffPanel change={selectedChange} /> : null
+                  }
+                >
+                  {(detail) => (
+                    <IntentRevisionEditForm
+                      wsId={wsId}
+                      packId={pId}
+                      versionId={vId}
+                      detail={detail}
+                      canEdit={canEditIntent}
+                      isSaving={isMutationPending}
+                      onSave={(values) => handleSaveRevision(detail, values)}
+                      onDirtyChange={handleDirtyChange}
+                    />
+                  )}
+                </IntentDetailPanel>
+              )
             ) : (
               <IntentDetailPanel wsId={wsId} packId={pId} versionId={vId} intentId={null} />
             )}
           </div>
         </div>
       </div>
+
+      <AlertDialog open={pendingNavigation !== null} onOpenChange={() => setPendingNavigation(null)}>
+        <AlertDialogContent size="sm">
+          <AlertDialogTitle>저장하지 않고 이동할까요?</AlertDialogTitle>
+          <AlertDialogDescription>
+            저장하지 않고 이동 시 수정 내역은 사라집니다.
+          </AlertDialogDescription>
+          <AlertDialogFooter>
+            <Button type="button" variant="outline" onClick={() => setPendingNavigation(null)}>
+              취소
+            </Button>
+            <Button
+              type="button"
+              onClick={() => {
+                const next = pendingNavigation;
+                setPendingNavigation(null);
+                resetDirty();
+                next?.();
+              }}
+            >
+              이동
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog
+        open={existingDraftTarget !== null}
+        onOpenChange={() => setExistingDraftTarget(null)}
+      >
+        <AlertDialogContent size="sm">
+          <AlertDialogTitle>진행 중인 초안이 있습니다.</AlertDialogTitle>
+          <AlertDialogDescription>
+            저장하지 않고 이동 시 수정 내역은 사라집니다. 기존 초안으로 이동할까요?
+          </AlertDialogDescription>
+          <AlertDialogFooter>
+            <Button type="button" variant="outline" onClick={() => setExistingDraftTarget(null)}>
+              취소
+            </Button>
+            <Button
+              type="button"
+              onClick={() => {
+                const target = existingDraftTarget;
+                setExistingDraftTarget(null);
+                resetDirty();
+                if (target) void navigateToIntentCode(target.versionId, target.intentCode);
+              }}
+            >
+              이동
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </OstoneShell>
   );
+}
+
+function getVersionLabel({
+  lifecycleStatus,
+  isCurrentPublished,
+  isRevisionDraft,
+}: {
+  lifecycleStatus?: string;
+  isCurrentPublished: boolean;
+  isRevisionDraft: boolean;
+}): string {
+  if (isRevisionDraft) return "Intent 수정 검토";
+  if (isCurrentPublished) return "운영 중";
+  if (lifecycleStatus === "PUBLISHED") return "이전 버전";
+  if (lifecycleStatus === "DRAFT") return "DRAFT";
+  return "확인 중";
 }

--- a/frontend/src/pages/domain-pack/ui/IntentDraftReadPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/IntentDraftReadPage.tsx
@@ -1,28 +1,17 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
-import type { UseQueryResult } from "@tanstack/react-query";
-import { useNavigate, useParams } from "react-router-dom";
-import { toast } from "sonner";
-import type { DomainPackDetail, DomainPackVersionDetail } from "@/entities/domain-pack";
-import type { IntentDetail } from "@/entities/intent";
+import { useEffect } from "react";
+import { useParams } from "react-router-dom";
 import { IntentDetailPanel, IntentTreePanel } from "@/features/intent-draft-read/ui";
 import { IntentDetailWithApproval } from "@/features/approve-intent";
-import { usePackDetail, useVersionDetail } from "@/features/domain-pack-summary-read";
 import {
   IntentRevisionDiffPanel,
   IntentRevisionDraftActions,
   IntentRevisionEditForm,
   IntentRevisionRecoveryBanner,
-  classifyExistingDraftSource,
-  intentRevisionDraftApi,
-  parseIntentRevisionDraftSource,
-  resolveSingleExistingDraft,
-  useIntentRevisionMarkers,
-  useIntentRevisionSummary,
-  useSaveIntentRevisionDraft,
-  useUpdateDraftIntent,
-  type UpdateDraftIntentBody,
 } from "@/features/intent-revision-draft";
-import { ApiRequestError } from "@/shared/api";
+import {
+  type ExistingDraftTarget,
+  useIntentDraftReadController,
+} from "@/pages/domain-pack/model/useIntentDraftReadController";
 import {
   AlertDialog,
   AlertDialogContent,
@@ -35,17 +24,6 @@ import { parseRouteId } from "@/shared/lib/parseRouteId";
 import { OstoneShell } from "@/widgets/ostone-shell";
 import { Mono } from "@/shared/ui/ostone/atoms";
 import styles from "./intent-draft-read-page.module.css";
-
-interface DirtyState {
-  isDirty: boolean;
-  intentId: number | null;
-}
-
-interface ExistingDraftTarget {
-  versionId: number;
-  intentCode: string;
-  sourceType: "INTENT_REVISION" | "GENERAL_DRAFT";
-}
 
 export function IntentDraftReadPage() {
   const { workspaceId, packId, versionId, intentId } = useParams();
@@ -79,438 +57,249 @@ function IntentDraftReadContent({
   vId: number;
   iId: number | null;
 }) {
-  const navigate = useNavigate();
-  const packQuery = usePackDetail(wsId, pId) as UseQueryResult<DomainPackDetail>;
-  const versionQuery = useVersionDetail(wsId, pId, vId) as UseQueryResult<DomainPackVersionDetail>;
-  const { saveIntentRevisionDraft, isPending: isCreatingRevision } = useSaveIntentRevisionDraft();
-  const { updateDraftIntent, isPending: isUpdatingDraft } = useUpdateDraftIntent();
-  const [detailRefreshKey, setDetailRefreshKey] = useState(0);
-  const [listRefreshKey, setListRefreshKey] = useState(0);
-  const [summaryRefreshKey, setSummaryRefreshKey] = useState(0);
-  const [versionActionPending, setVersionActionPending] = useState(false);
-  const [dirtyState, setDirtyState] = useState<DirtyState>({ isDirty: false, intentId: null });
-  const [pendingNavigation, setPendingNavigation] = useState<(() => void) | null>(null);
-  const [existingDraftTarget, setExistingDraftTarget] = useState<ExistingDraftTarget | null>(null);
-  const [recoveryVersionId, setRecoveryVersionId] = useState<number | null>(null);
-  const [selectedIntentCode, setSelectedIntentCode] = useState<string | null>(null);
-
-  const currentPublishedVersion = useMemo(() => {
-    const versions = packQuery.data?.versions ?? [];
-    return versions
-      .filter((version) => version.lifecycleStatus === "PUBLISHED" && version.versionId != null)
-      .reduce<NonNullable<DomainPackDetail["versions"]>[number] | null>((current, version) => {
-        if (!current) return version;
-        return (version.versionNo ?? 0) > (current.versionNo ?? 0) ? version : current;
-      }, null);
-  }, [packQuery.data?.versions]);
-
-  const versionDetail = versionQuery.data;
-  const revisionSource = parseIntentRevisionDraftSource(versionDetail?.summaryJson);
-  const isRevisionDraft =
-    versionDetail?.lifecycleStatus === "DRAFT" && revisionSource?.type === "INTENT_REVISION";
-  const isCurrentPublished =
-    versionDetail?.lifecycleStatus === "PUBLISHED" &&
-    currentPublishedVersion?.versionId === versionDetail.versionId;
-  const isGeneralDraft = versionDetail?.lifecycleStatus === "DRAFT" && !isRevisionDraft;
-  const canEditIntent = isCurrentPublished || isRevisionDraft;
+  const controller = useIntentDraftReadController({ wsId, pId, vId, iId });
   const hasSelection = iId !== null;
 
-  const summaryState = useIntentRevisionSummary({
-    workspaceId: wsId,
-    packId: pId,
-    draftVersionId: vId,
-    baseVersionId: revisionSource?.baseVersionId ?? null,
-    refreshKey: summaryRefreshKey,
-    enabled: isRevisionDraft,
-  });
-
-  const markers = useIntentRevisionMarkers({
-    editingIntentId: dirtyState.intentId,
-    isDirty: dirtyState.isDirty,
-    summaryState,
-  });
-
-  const resetDirty = useCallback(() => {
-    setDirtyState({ isDirty: false, intentId: null });
-  }, []);
-
-  const handleDirtyChange = useCallback((isDirty: boolean, intentId: number | null) => {
-    setDirtyState({ isDirty, intentId });
-  }, []);
-
-  useEffect(() => {
-    if (!dirtyState.isDirty) return;
-
-    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
-      event.preventDefault();
-      event.returnValue = "";
-    };
-
-    window.addEventListener("beforeunload", handleBeforeUnload);
-    return () => window.removeEventListener("beforeunload", handleBeforeUnload);
-  }, [dirtyState.isDirty]);
-
-  const navigateToIntentRoute = useCallback(
-    (versionId: number, intentId: number | null) => {
-      const suffix = intentId === null ? "" : `/${intentId}`;
-      navigate(`/workspaces/${wsId}/domain-packs/${pId}/versions/${versionId}/intents${suffix}`);
-    },
-    [navigate, pId, wsId],
-  );
-
-  const navigateToIntentCode = useCallback(
-    async (versionId: number, intentCode?: string | null) => {
-      if (!intentCode) {
-        navigateToIntentRoute(versionId, null);
-        return;
-      }
-
-      try {
-        const intents = await intentRevisionDraftApi.listIntents(wsId, pId, versionId);
-        const target = intents.find((intent) => intent.intentCode === intentCode);
-        navigateToIntentRoute(versionId, target?.id ?? null);
-      } catch {
-        navigateToIntentRoute(versionId, null);
-      }
-    },
-    [navigateToIntentRoute, pId, wsId],
-  );
-
-  const guardNavigation = useCallback(
-    (next: () => void) => {
-      if (!dirtyState.isDirty) {
-        next();
-        return;
-      }
-      setPendingNavigation(() => next);
-    },
-    [dirtyState.isDirty],
-  );
-
-  const handleSelect = (id: number) => {
-    guardNavigation(() => navigateToIntentRoute(vId, id));
-  };
-
-  const handleBack = () => {
-    guardNavigation(() => navigateToIntentRoute(vId, null));
-  };
-
-  const refreshIntentViews = () => {
-    setDetailRefreshKey((key) => key + 1);
-    setListRefreshKey((key) => key + 1);
-    setSummaryRefreshKey((key) => key + 1);
-  };
-
-  const resolveExistingDraftTarget = async (intentCode: string): Promise<boolean> => {
-    try {
-      const refetched = await packQuery.refetch();
-      const resolution = resolveSingleExistingDraft(refetched.data?.versions);
-
-      if (resolution.status === "invalid") {
-        toast.error("초안 상태를 확인할 수 없습니다. 목록을 새로고침해 주세요.");
-        return false;
-      }
-
-      const draftDetail = await intentRevisionDraftApi.getVersionDetail(
-        wsId,
-        pId,
-        resolution.versionId,
-      );
-      setExistingDraftTarget({
-        versionId: resolution.versionId,
-        intentCode,
-        sourceType: classifyExistingDraftSource(draftDetail.summaryJson),
-      });
-      return true;
-    } catch {
-      toast.error("진행 중인 초안을 확인하지 못했습니다. 잠시 후 다시 시도해 주세요.");
-      return false;
-    }
-  };
-
-  const handleSaveRevision = async (
-    detail: IntentDetail,
-    values: UpdateDraftIntentBody,
-  ): Promise<boolean> => {
-    if (detail.id == null || !detail.intentCode) return false;
-
-    if (isCurrentPublished) {
-      try {
-        const result = await saveIntentRevisionDraft({
-          workspaceId: wsId,
-          packId: pId,
-          baseVersionId: vId,
-          intentCode: detail.intentCode,
-          values,
-        });
-
-        resetDirty();
-        await packQuery.refetch();
-        if (!result.patchSucceeded) {
-          toast.error(
-            result.clonedIntentId === null
-              ? "Intent 수정 초안에서 같은 intent를 찾지 못했습니다."
-              : "Intent 수정 초안은 생성됐지만 수정 내용 저장에 실패했습니다.",
-          );
-          setRecoveryVersionId(result.draftVersionId);
-        }
-        navigateToIntentRoute(result.draftVersionId, result.clonedIntentId);
-        return true;
-      } catch (error) {
-        if (
-          error instanceof ApiRequestError &&
-          error.code === "DOMAIN_PACK_DRAFT_ALREADY_EXISTS"
-        ) {
-          await resolveExistingDraftTarget(detail.intentCode);
-          return false;
-        }
-
-        if (
-          error instanceof ApiRequestError &&
-          error.code === "DOMAIN_PACK_VERSION_NOT_CURRENT"
-        ) {
-          await packQuery.refetch();
-          toast.error("현재 운영 버전이 변경되었습니다. 최신 버전에서 다시 수정해 주세요.");
-          return false;
-        }
-
-        toast.error("Intent 수정 내용 저장에 실패했습니다.");
-        return false;
-      }
-    }
-
-    if (isRevisionDraft) {
-      try {
-        await updateDraftIntent({
-          workspaceId: wsId,
-          packId: pId,
-          draftVersionId: vId,
-          intentId: detail.id,
-          values,
-        });
-        resetDirty();
-        refreshIntentViews();
-        return true;
-      } catch {
-        toast.error("Intent 수정 내용 저장에 실패했습니다.");
-        return false;
-      }
-    }
-
-    return false;
-  };
-
-  const handleApplyRevisionDraft = async (intentCode?: string | null) => {
-    const summary = summaryState.status === "ready" ? summaryState.data : null;
-    if (!summary || summary.changedIntents.length === 0) return;
-
-    setVersionActionPending(true);
-    try {
-      const activated = await intentRevisionDraftApi.activateVersion(wsId, pId, vId);
-      await packQuery.refetch();
-      await versionQuery.refetch();
-      toast.success("Intent 수정 초안이 적용되었습니다.");
-      await navigateToIntentCode(activated.activatedVersionId, intentCode);
-    } catch {
-      toast.error("Intent 수정 초안 적용에 실패했습니다.");
-    } finally {
-      setVersionActionPending(false);
-    }
-  };
-
-  const handleDiscardRevisionDraft = async (intentCode?: string | null) => {
-    setVersionActionPending(true);
-    try {
-      await intentRevisionDraftApi.discardDraft(wsId, pId, vId);
-      const targetVersionId =
-        currentPublishedVersion?.versionId ?? revisionSource?.baseVersionId ?? null;
-      await packQuery.refetch();
-      toast.success("Intent 수정 초안이 취소되었습니다.");
-      if (targetVersionId !== null) {
-        await navigateToIntentCode(targetVersionId, intentCode);
-      } else {
-        navigate(`/workspaces/${wsId}/domain-packs/${pId}`);
-      }
-    } catch {
-      toast.error("Intent 수정 초안 취소에 실패했습니다.");
-    } finally {
-      setVersionActionPending(false);
-    }
-  };
-
-  const handleApplyRevisionDraftAction = () => {
-    guardNavigation(() => {
-      void handleApplyRevisionDraft(selectedIntentCode);
-    });
-  };
-
-  const handleDiscardRevisionDraftAction = () => {
-    guardNavigation(() => {
-      void handleDiscardRevisionDraft(selectedIntentCode);
-    });
-  };
-
   const versionLabel = getVersionLabel({
-    lifecycleStatus: versionDetail?.lifecycleStatus,
-    isCurrentPublished,
-    isRevisionDraft,
+    lifecycleStatus: controller.versionDetail?.lifecycleStatus,
+    isCurrentPublished: controller.isCurrentPublished,
+    isRevisionDraft: controller.isRevisionDraft,
   });
-
-  const selectedChange =
-    iId !== null && summaryState.status === "ready"
-      ? summaryState.data.changedByDraftIntentId[iId]
-      : undefined;
-
-  const isMutationPending = isCreatingRevision || isUpdatingDraft || versionActionPending;
 
   return (
     <OstoneShell active="domain" crumbs={[`PACK · ${pId}`, `Version · ${vId}`]}>
       <div className={styles.pageWrapper}>
-        <header className={styles.pageHeader}>
-          <nav className={styles.breadcrumb} aria-label="경로">
-            <Mono>WS · {wsId}</Mono>
-            <span className={styles.breadcrumbSeparator}>/</span>
-            <Mono>PACK · {pId}</Mono>
-            <span className={styles.breadcrumbSeparator}>/</span>
-            <Mono>VER · {vId}</Mono>
-          </nav>
-          <div className={styles.versionMeta}>
-            <span className={styles.versionTitle}>Intent 조회</span>
-            <span className={styles.versionBadge}>{versionLabel}</span>
-            {isRevisionDraft && (
-              <IntentRevisionDraftActions
-                summary={summaryState.status === "ready" ? summaryState.data : undefined}
-                isSummaryLoading={summaryState.status === "loading"}
-                summaryError={
-                  summaryState.status === "error" ? summaryState.message : null
-                }
-                isPending={isMutationPending}
-                onRetrySummary={() => setSummaryRefreshKey((key) => key + 1)}
-                onApply={handleApplyRevisionDraftAction}
-                onDiscard={handleDiscardRevisionDraftAction}
-              />
-            )}
-          </div>
-        </header>
+        <IntentDraftHeader
+          controller={controller}
+          versionLabel={versionLabel}
+          wsId={wsId}
+          pId={pId}
+          vId={vId}
+        />
         {hasSelection && (
-          <button type="button" className={styles.backButton} onClick={handleBack}>
+          <button type="button" className={styles.backButton} onClick={controller.handleBack}>
             ← 목록
           </button>
         )}
-        <div className={`${styles.twoPane} ${hasSelection ? styles.hasSelection : ""}`}>
-          <div className={styles.listSlot}>
-            <IntentTreePanel
-              wsId={wsId}
-              packId={pId}
-              versionId={vId}
-              selectedId={iId}
-              onSelect={handleSelect}
-              refreshKey={listRefreshKey}
-              markers={markers}
-            />
-          </div>
-          <div className={styles.detailSlot}>
-            {iId !== null ? (
-              isGeneralDraft ? (
-                <IntentDetailWithApproval key={iId} wsId={wsId} pId={pId} vId={vId} iId={iId} />
-              ) : (
-                <IntentDetailPanel
-                  key={iId}
-                  wsId={wsId}
-                  packId={pId}
-                  versionId={vId}
-                  intentId={iId}
-                  refreshKey={detailRefreshKey}
-                  afterHeader={(detail) => (
-                    <>
-                      <SelectedIntentCodeSync
-                        intentCode={detail.intentCode ?? null}
-                        onChange={setSelectedIntentCode}
-                      />
-                      {recoveryVersionId === vId ? <IntentRevisionRecoveryBanner /> : null}
-                    </>
-                  )}
-                  beforeJsonCards={() =>
-                    isRevisionDraft ? <IntentRevisionDiffPanel change={selectedChange} /> : null
-                  }
-                >
-                  {(detail) => (
-                    <IntentRevisionEditForm
-                      wsId={wsId}
-                      packId={pId}
-                      versionId={vId}
-                      detail={detail}
-                      canEdit={canEditIntent}
-                      isSaving={isMutationPending}
-                      onSave={(values) => handleSaveRevision(detail, values)}
-                      onDirtyChange={handleDirtyChange}
-                    />
-                  )}
-                </IntentDetailPanel>
-              )
-            ) : (
-              <IntentDetailPanel wsId={wsId} packId={pId} versionId={vId} intentId={null} />
-            )}
-          </div>
-        </div>
+        <IntentDraftTwoPane
+          controller={controller}
+          hasSelection={hasSelection}
+          wsId={wsId}
+          pId={pId}
+          vId={vId}
+          iId={iId}
+        />
       </div>
 
-      <AlertDialog open={pendingNavigation !== null} onOpenChange={() => setPendingNavigation(null)}>
-        <AlertDialogContent size="sm">
-          <AlertDialogTitle>저장하지 않고 이동할까요?</AlertDialogTitle>
-          <AlertDialogDescription>
-            저장하지 않고 이동 시 수정 내역은 사라집니다.
-          </AlertDialogDescription>
-          <AlertDialogFooter>
-            <Button type="button" variant="outline" onClick={() => setPendingNavigation(null)}>
-              취소
-            </Button>
-            <Button
-              type="button"
-              onClick={() => {
-                const next = pendingNavigation;
-                setPendingNavigation(null);
-                resetDirty();
-                next?.();
-              }}
-            >
-              이동
-            </Button>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-
-      <AlertDialog
-        open={existingDraftTarget !== null}
-        onOpenChange={() => setExistingDraftTarget(null)}
-      >
-        <AlertDialogContent size="sm">
-          <AlertDialogTitle>진행 중인 초안이 있습니다.</AlertDialogTitle>
-          <AlertDialogDescription>
-            저장하지 않고 이동 시 수정 내역은 사라집니다.{" "}
-            {existingDraftTarget?.sourceType === "INTENT_REVISION"
-              ? "기존 Intent 수정 초안으로 이동할까요?"
-              : "기존 초안으로 이동할까요?"}
-          </AlertDialogDescription>
-          <AlertDialogFooter>
-            <Button type="button" variant="outline" onClick={() => setExistingDraftTarget(null)}>
-              취소
-            </Button>
-            <Button
-              type="button"
-              onClick={() => {
-                const target = existingDraftTarget;
-                setExistingDraftTarget(null);
-                resetDirty();
-                if (target) void navigateToIntentCode(target.versionId, target.intentCode);
-              }}
-            >
-              이동
-            </Button>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      <PendingNavigationDialog controller={controller} />
+      <ExistingDraftDialog controller={controller} />
     </OstoneShell>
+  );
+}
+
+type IntentDraftController = ReturnType<typeof useIntentDraftReadController>;
+
+function IntentDraftHeader({
+  controller,
+  versionLabel,
+  wsId,
+  pId,
+  vId,
+}: {
+  controller: IntentDraftController;
+  versionLabel: string;
+  wsId: number;
+  pId: number;
+  vId: number;
+}) {
+  const summaryState = controller.summaryState;
+
+  return (
+    <header className={styles.pageHeader}>
+      <nav className={styles.breadcrumb} aria-label="경로">
+        <Mono>WS · {wsId}</Mono>
+        <span className={styles.breadcrumbSeparator}>/</span>
+        <Mono>PACK · {pId}</Mono>
+        <span className={styles.breadcrumbSeparator}>/</span>
+        <Mono>VER · {vId}</Mono>
+      </nav>
+      <div className={styles.versionMeta}>
+        <span className={styles.versionTitle}>Intent 조회</span>
+        <span className={styles.versionBadge}>{versionLabel}</span>
+        {controller.isRevisionDraft && (
+          <IntentRevisionDraftActions
+            summary={summaryState.status === "ready" ? summaryState.data : undefined}
+            isSummaryLoading={summaryState.status === "loading"}
+            summaryError={summaryState.status === "error" ? summaryState.message : null}
+            isPending={controller.isMutationPending}
+            onRetrySummary={controller.retrySummary}
+            onApply={controller.handleApplyRevisionDraftAction}
+            onDiscard={controller.handleDiscardRevisionDraftAction}
+          />
+        )}
+      </div>
+    </header>
+  );
+}
+
+function IntentDraftTwoPane({
+  controller,
+  hasSelection,
+  wsId,
+  pId,
+  vId,
+  iId,
+}: {
+  controller: IntentDraftController;
+  hasSelection: boolean;
+  wsId: number;
+  pId: number;
+  vId: number;
+  iId: number | null;
+}) {
+  return (
+    <div className={`${styles.twoPane} ${hasSelection ? styles.hasSelection : ""}`}>
+      <div className={styles.listSlot}>
+        <IntentTreePanel
+          wsId={wsId}
+          packId={pId}
+          versionId={vId}
+          selectedId={iId}
+          onSelect={controller.handleSelect}
+          refreshKey={controller.listRefreshKey}
+          markers={controller.markers}
+        />
+      </div>
+      <IntentDetailSlot controller={controller} wsId={wsId} pId={pId} vId={vId} iId={iId} />
+    </div>
+  );
+}
+
+function IntentDetailSlot({
+  controller,
+  wsId,
+  pId,
+  vId,
+  iId,
+}: {
+  controller: IntentDraftController;
+  wsId: number;
+  pId: number;
+  vId: number;
+  iId: number | null;
+}) {
+  if (iId === null) {
+    return (
+      <div className={styles.detailSlot}>
+        <IntentDetailPanel wsId={wsId} packId={pId} versionId={vId} intentId={null} />
+      </div>
+    );
+  }
+
+  if (controller.isGeneralDraft) {
+    return (
+      <div className={styles.detailSlot}>
+        <IntentDetailWithApproval key={iId} wsId={wsId} pId={pId} vId={vId} iId={iId} />
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.detailSlot}>
+      <IntentDetailPanel
+        key={iId}
+        wsId={wsId}
+        packId={pId}
+        versionId={vId}
+        intentId={iId}
+        refreshKey={controller.detailRefreshKey}
+        afterHeader={(detail) => (
+          <>
+            <SelectedIntentCodeSync
+              intentCode={detail.intentCode ?? null}
+              onChange={controller.setSelectedIntentCode}
+            />
+            {controller.recoveryVersionId === vId ? <IntentRevisionRecoveryBanner /> : null}
+          </>
+        )}
+        beforeJsonCards={() =>
+          controller.isRevisionDraft ? (
+            <IntentRevisionDiffPanel change={controller.selectedChange} />
+          ) : null
+        }
+      >
+        {(detail) => (
+          <IntentRevisionEditForm
+            wsId={wsId}
+            packId={pId}
+            versionId={vId}
+            detail={detail}
+            canEdit={controller.canEditIntent}
+            isSaving={controller.isMutationPending}
+            onSave={(values) => controller.handleSaveRevision(detail, values)}
+            onDirtyChange={controller.handleDirtyChange}
+          />
+        )}
+      </IntentDetailPanel>
+    </div>
+  );
+}
+
+function PendingNavigationDialog({ controller }: { controller: IntentDraftController }) {
+  return (
+    <AlertDialog
+      open={controller.pendingNavigation !== null}
+      onOpenChange={() => controller.setPendingNavigation(null)}
+    >
+      <AlertDialogContent size="sm">
+        <AlertDialogTitle>저장하지 않고 이동할까요?</AlertDialogTitle>
+        <AlertDialogDescription>
+          저장하지 않고 이동 시 수정 내역은 사라집니다.
+        </AlertDialogDescription>
+        <AlertDialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => controller.setPendingNavigation(null)}
+          >
+            취소
+          </Button>
+          <Button type="button" onClick={controller.confirmPendingNavigation}>
+            이동
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+
+function ExistingDraftDialog({ controller }: { controller: IntentDraftController }) {
+  const target = controller.existingDraftTarget;
+
+  return (
+    <AlertDialog
+      open={target !== null}
+      onOpenChange={() => controller.setExistingDraftTarget(null)}
+    >
+      <AlertDialogContent size="sm">
+        <AlertDialogTitle>진행 중인 초안이 있습니다.</AlertDialogTitle>
+        <AlertDialogDescription>
+          저장하지 않고 이동 시 수정 내역은 사라집니다. {getExistingDraftDescription(target)}
+        </AlertDialogDescription>
+        <AlertDialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => controller.setExistingDraftTarget(null)}
+          >
+            취소
+          </Button>
+          <Button type="button" onClick={controller.confirmExistingDraftNavigation}>
+            이동
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   );
 }
 
@@ -543,4 +332,10 @@ function getVersionLabel({
   if (lifecycleStatus === "PUBLISHED") return "이전 버전";
   if (lifecycleStatus === "DRAFT") return "DRAFT";
   return "확인 중";
+}
+
+function getExistingDraftDescription(target: ExistingDraftTarget | null): string {
+  return target?.sourceType === "INTENT_REVISION"
+    ? "기존 Intent 수정 초안으로 이동할까요?"
+    : "기존 초안으로 이동할까요?";
 }

--- a/frontend/src/pages/domain-pack/ui/IntentDraftReadPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/IntentDraftReadPage.tsx
@@ -89,6 +89,7 @@ function IntentDraftReadContent({
   const [pendingNavigation, setPendingNavigation] = useState<(() => void) | null>(null);
   const [existingDraftTarget, setExistingDraftTarget] = useState<ExistingDraftTarget | null>(null);
   const [recoveryVersionId, setRecoveryVersionId] = useState<number | null>(null);
+  const [selectedIntentCode, setSelectedIntentCode] = useState<string | null>(null);
 
   const currentPublishedVersion = useMemo(() => {
     const versions = packQuery.data?.versions ?? [];
@@ -208,8 +209,11 @@ function IntentDraftReadContent({
     setExistingDraftTarget({ versionId: drafts[0].versionId, intentCode });
   };
 
-  const handleSaveRevision = async (detail: IntentDetail, values: UpdateDraftIntentBody) => {
-    if (detail.id == null || !detail.intentCode) return;
+  const handleSaveRevision = async (
+    detail: IntentDetail,
+    values: UpdateDraftIntentBody,
+  ): Promise<boolean> => {
+    if (detail.id == null || !detail.intentCode) return false;
 
     if (isCurrentPublished) {
       try {
@@ -232,13 +236,14 @@ function IntentDraftReadContent({
           setRecoveryVersionId(result.draftVersionId);
         }
         navigateToIntentRoute(result.draftVersionId, result.clonedIntentId);
+        return true;
       } catch (error) {
         if (
           error instanceof ApiRequestError &&
           error.code === "DOMAIN_PACK_DRAFT_ALREADY_EXISTS"
         ) {
           await resolveExistingDraftTarget(detail.intentCode);
-          return;
+          return false;
         }
 
         if (
@@ -247,12 +252,12 @@ function IntentDraftReadContent({
         ) {
           await packQuery.refetch();
           toast.error("현재 운영 버전이 변경되었습니다. 최신 버전에서 다시 수정해 주세요.");
-          return;
+          return false;
         }
 
         toast.error("Intent 수정 내용 저장에 실패했습니다.");
+        return false;
       }
-      return;
     }
 
     if (isRevisionDraft) {
@@ -266,13 +271,17 @@ function IntentDraftReadContent({
         });
         resetDirty();
         refreshIntentViews();
+        return true;
       } catch {
         toast.error("Intent 수정 내용 저장에 실패했습니다.");
+        return false;
       }
     }
+
+    return false;
   };
 
-  const handleApplyRevisionDraft = async (detail: IntentDetail) => {
+  const handleApplyRevisionDraft = async (intentCode?: string | null) => {
     const summary = summaryState.status === "ready" ? summaryState.data : null;
     if (!summary || summary.changedIntents.length === 0) return;
 
@@ -282,7 +291,7 @@ function IntentDraftReadContent({
       await packQuery.refetch();
       await versionQuery.refetch();
       toast.success("Intent 수정 초안이 적용되었습니다.");
-      await navigateToIntentCode(activated.versionId ?? vId, detail.intentCode);
+      await navigateToIntentCode(activated.activatedVersionId, intentCode);
     } catch {
       toast.error("Intent 수정 초안 적용에 실패했습니다.");
     } finally {
@@ -290,7 +299,7 @@ function IntentDraftReadContent({
     }
   };
 
-  const handleDiscardRevisionDraft = async (detail: IntentDetail) => {
+  const handleDiscardRevisionDraft = async (intentCode?: string | null) => {
     setVersionActionPending(true);
     try {
       await intentRevisionDraftApi.discardDraft(wsId, pId, vId);
@@ -299,7 +308,7 @@ function IntentDraftReadContent({
       await packQuery.refetch();
       toast.success("Intent 수정 초안이 취소되었습니다.");
       if (targetVersionId !== null) {
-        await navigateToIntentCode(targetVersionId, detail.intentCode);
+        await navigateToIntentCode(targetVersionId, intentCode);
       } else {
         navigate(`/workspaces/${wsId}/domain-packs/${pId}`);
       }
@@ -337,6 +346,15 @@ function IntentDraftReadContent({
           <div className={styles.versionMeta}>
             <span className={styles.versionTitle}>Intent 조회</span>
             <span className={styles.versionBadge}>{versionLabel}</span>
+            {isRevisionDraft && (
+              <IntentRevisionDraftActions
+                summary={summaryState.status === "ready" ? summaryState.data : undefined}
+                isSummaryLoading={summaryState.status === "loading"}
+                isPending={isMutationPending}
+                onApply={() => void handleApplyRevisionDraft(selectedIntentCode)}
+                onDiscard={() => void handleDiscardRevisionDraft(selectedIntentCode)}
+              />
+            )}
           </div>
         </header>
         {hasSelection && (
@@ -368,20 +386,15 @@ function IntentDraftReadContent({
                   versionId={vId}
                   intentId={iId}
                   refreshKey={detailRefreshKey}
-                  headerActions={(detail) =>
-                    isRevisionDraft ? (
-                      <IntentRevisionDraftActions
-                        summary={summaryState.status === "ready" ? summaryState.data : undefined}
-                        isSummaryLoading={summaryState.status === "loading"}
-                        isPending={isMutationPending}
-                        onApply={() => void handleApplyRevisionDraft(detail)}
-                        onDiscard={() => void handleDiscardRevisionDraft(detail)}
+                  afterHeader={(detail) => (
+                    <>
+                      <SelectedIntentCodeSync
+                        intentCode={detail.intentCode ?? null}
+                        onChange={setSelectedIntentCode}
                       />
-                    ) : undefined
-                  }
-                  afterHeader={() =>
-                    recoveryVersionId === vId ? <IntentRevisionRecoveryBanner /> : null
-                  }
+                      {recoveryVersionId === vId ? <IntentRevisionRecoveryBanner /> : null}
+                    </>
+                  )}
                   beforeJsonCards={() =>
                     isRevisionDraft ? <IntentRevisionDiffPanel change={selectedChange} /> : null
                   }
@@ -461,6 +474,21 @@ function IntentDraftReadContent({
       </AlertDialog>
     </OstoneShell>
   );
+}
+
+function SelectedIntentCodeSync({
+  intentCode,
+  onChange,
+}: {
+  intentCode: string | null;
+  onChange: (intentCode: string | null) => void;
+}) {
+  useEffect(() => {
+    onChange(intentCode);
+    return () => onChange(null);
+  }, [intentCode, onChange]);
+
+  return null;
 }
 
 function getVersionLabel({

--- a/frontend/src/pages/domain-pack/ui/IntentDraftReadPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/IntentDraftReadPage.tsx
@@ -12,8 +12,10 @@ import {
   IntentRevisionDraftActions,
   IntentRevisionEditForm,
   IntentRevisionRecoveryBanner,
+  classifyExistingDraftSource,
   intentRevisionDraftApi,
   parseIntentRevisionDraftSource,
+  resolveSingleExistingDraft,
   useIntentRevisionMarkers,
   useIntentRevisionSummary,
   useSaveIntentRevisionDraft,
@@ -42,6 +44,7 @@ interface DirtyState {
 interface ExistingDraftTarget {
   versionId: number;
   intentCode: string;
+  sourceType: "INTENT_REVISION" | "GENERAL_DRAFT";
 }
 
 export function IntentDraftReadPage() {
@@ -196,17 +199,19 @@ function IntentDraftReadContent({
 
   const resolveExistingDraftTarget = async (intentCode: string) => {
     const refetched = await packQuery.refetch();
-    const drafts = (refetched.data?.versions ?? []).filter(
-      (version) => version.lifecycleStatus === "DRAFT" && version.versionId != null,
-    );
+    const resolution = resolveSingleExistingDraft(refetched.data?.versions);
 
-    if (drafts.length !== 1 || drafts[0].versionId == null) {
+    if (resolution.status === "invalid") {
       toast.error("초안 상태를 확인할 수 없습니다. 목록을 새로고침해 주세요.");
       return;
     }
 
-    await intentRevisionDraftApi.getVersionDetail(wsId, pId, drafts[0].versionId);
-    setExistingDraftTarget({ versionId: drafts[0].versionId, intentCode });
+    const draftDetail = await intentRevisionDraftApi.getVersionDetail(wsId, pId, resolution.versionId);
+    setExistingDraftTarget({
+      versionId: resolution.versionId,
+      intentCode,
+      sourceType: classifyExistingDraftSource(draftDetail.summaryJson),
+    });
   };
 
   const handleSaveRevision = async (
@@ -452,7 +457,10 @@ function IntentDraftReadContent({
         <AlertDialogContent size="sm">
           <AlertDialogTitle>진행 중인 초안이 있습니다.</AlertDialogTitle>
           <AlertDialogDescription>
-            저장하지 않고 이동 시 수정 내역은 사라집니다. 기존 초안으로 이동할까요?
+            저장하지 않고 이동 시 수정 내역은 사라집니다.{" "}
+            {existingDraftTarget?.sourceType === "INTENT_REVISION"
+              ? "기존 Intent 수정 초안으로 이동할까요?"
+              : "기존 초안으로 이동할까요?"}
           </AlertDialogDescription>
           <AlertDialogFooter>
             <Button type="button" variant="outline" onClick={() => setExistingDraftTarget(null)}>

--- a/frontend/src/pages/domain-pack/ui/IntentDraftReadPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/IntentDraftReadPage.tsx
@@ -165,9 +165,13 @@ function IntentDraftReadContent({
         return;
       }
 
-      const intents = await intentRevisionDraftApi.listIntents(wsId, pId, versionId);
-      const target = intents.find((intent) => intent.intentCode === intentCode);
-      navigateToIntentRoute(versionId, target?.id ?? null);
+      try {
+        const intents = await intentRevisionDraftApi.listIntents(wsId, pId, versionId);
+        const target = intents.find((intent) => intent.intentCode === intentCode);
+        navigateToIntentRoute(versionId, target?.id ?? null);
+      } catch {
+        navigateToIntentRoute(versionId, null);
+      }
     },
     [navigateToIntentRoute, pId, wsId],
   );
@@ -197,21 +201,31 @@ function IntentDraftReadContent({
     setSummaryRefreshKey((key) => key + 1);
   };
 
-  const resolveExistingDraftTarget = async (intentCode: string) => {
-    const refetched = await packQuery.refetch();
-    const resolution = resolveSingleExistingDraft(refetched.data?.versions);
+  const resolveExistingDraftTarget = async (intentCode: string): Promise<boolean> => {
+    try {
+      const refetched = await packQuery.refetch();
+      const resolution = resolveSingleExistingDraft(refetched.data?.versions);
 
-    if (resolution.status === "invalid") {
-      toast.error("초안 상태를 확인할 수 없습니다. 목록을 새로고침해 주세요.");
-      return;
+      if (resolution.status === "invalid") {
+        toast.error("초안 상태를 확인할 수 없습니다. 목록을 새로고침해 주세요.");
+        return false;
+      }
+
+      const draftDetail = await intentRevisionDraftApi.getVersionDetail(
+        wsId,
+        pId,
+        resolution.versionId,
+      );
+      setExistingDraftTarget({
+        versionId: resolution.versionId,
+        intentCode,
+        sourceType: classifyExistingDraftSource(draftDetail.summaryJson),
+      });
+      return true;
+    } catch {
+      toast.error("진행 중인 초안을 확인하지 못했습니다. 잠시 후 다시 시도해 주세요.");
+      return false;
     }
-
-    const draftDetail = await intentRevisionDraftApi.getVersionDetail(wsId, pId, resolution.versionId);
-    setExistingDraftTarget({
-      versionId: resolution.versionId,
-      intentCode,
-      sourceType: classifyExistingDraftSource(draftDetail.summaryJson),
-    });
   };
 
   const handleSaveRevision = async (
@@ -324,6 +338,18 @@ function IntentDraftReadContent({
     }
   };
 
+  const handleApplyRevisionDraftAction = () => {
+    guardNavigation(() => {
+      void handleApplyRevisionDraft(selectedIntentCode);
+    });
+  };
+
+  const handleDiscardRevisionDraftAction = () => {
+    guardNavigation(() => {
+      void handleDiscardRevisionDraft(selectedIntentCode);
+    });
+  };
+
   const versionLabel = getVersionLabel({
     lifecycleStatus: versionDetail?.lifecycleStatus,
     isCurrentPublished,
@@ -355,9 +381,13 @@ function IntentDraftReadContent({
               <IntentRevisionDraftActions
                 summary={summaryState.status === "ready" ? summaryState.data : undefined}
                 isSummaryLoading={summaryState.status === "loading"}
+                summaryError={
+                  summaryState.status === "error" ? summaryState.message : null
+                }
                 isPending={isMutationPending}
-                onApply={() => void handleApplyRevisionDraft(selectedIntentCode)}
-                onDiscard={() => void handleDiscardRevisionDraft(selectedIntentCode)}
+                onRetrySummary={() => setSummaryRefreshKey((key) => key + 1)}
+                onApply={handleApplyRevisionDraftAction}
+                onDiscard={handleDiscardRevisionDraftAction}
               />
             )}
           </div>

--- a/frontend/src/shared/api/index.ts
+++ b/frontend/src/shared/api/index.ts
@@ -130,3 +130,4 @@ export class ApiRequestError extends Error {
 }
 
 export const apiClient = new ApiClient(API_BASE);
+export { unwrapApiResponse } from "./unwrapApiResponse";

--- a/frontend/src/shared/api/unwrapApiResponse.test.ts
+++ b/frontend/src/shared/api/unwrapApiResponse.test.ts
@@ -1,0 +1,19 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { unwrapApiResponse } from "./unwrapApiResponse";
+
+describe("unwrapApiResponse", () => {
+  it("data envelope가 있으면 내부 data를 반환한다", () => {
+    expect(unwrapApiResponse({ data: { id: 1, name: "환불" } })).toEqual({
+      id: 1,
+      name: "환불",
+    });
+  });
+
+  it("data가 없으면 원본 응답을 반환한다", () => {
+    const response = { id: 1, name: "환불" };
+
+    expect(unwrapApiResponse(response)).toBe(response);
+  });
+});

--- a/frontend/src/shared/api/unwrapApiResponse.ts
+++ b/frontend/src/shared/api/unwrapApiResponse.ts
@@ -1,0 +1,12 @@
+export function unwrapApiResponse<T>(response: T | { data?: T }): T {
+  if (
+    response &&
+    typeof response === "object" &&
+    "data" in response &&
+    (response as { data?: T }).data !== undefined
+  ) {
+    return (response as { data: T }).data;
+  }
+
+  return response as T;
+}

--- a/frontend/src/shared/api/unwrapApiResponse.ts
+++ b/frontend/src/shared/api/unwrapApiResponse.ts
@@ -1,4 +1,7 @@
-export function unwrapApiResponse<T>(response: T | { data?: T }): T {
+export function unwrapApiResponse(response: undefined): undefined;
+export function unwrapApiResponse<T>(response: T | { data?: T }): T;
+export function unwrapApiResponse<T>(response: T | { data?: T } | undefined): T | undefined;
+export function unwrapApiResponse<T>(response: T | { data?: T } | undefined): T | undefined {
   if (
     response &&
     typeof response === "object" &&

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -10,34 +10,42 @@ type GlobalWithJsdom = { jsdom?: { window?: { localStorage?: Storage } } };
 const jsdomWindow = (globalThis as unknown as GlobalWithJsdom).jsdom?.window;
 const jsdomLocalStorage = jsdomWindow?.localStorage;
 
-if (
-  !jsdomLocalStorage ||
-  typeof jsdomLocalStorage.clear !== "function" ||
-  typeof jsdomLocalStorage.setItem !== "function" ||
-  typeof jsdomLocalStorage.getItem !== "function"
-) {
-  throw new Error(
-    "jsdom localStorage is unavailable or missing expected methods (clear/setItem/getItem). " +
-      "Ensure globalThis.jsdom.window.localStorage is populated by the test environment.",
-  );
+function createMemoryStorage(): Storage {
+  const values = new Map<string, string>();
+  return {
+    get length() {
+      return values.size;
+    },
+    clear: () => values.clear(),
+    getItem: (key: string) => values.get(key) ?? null,
+    key: (index: number) => Array.from(values.keys())[index] ?? null,
+    removeItem: (key: string) => {
+      values.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      values.set(key, value);
+    },
+  };
 }
 
 Object.defineProperty(globalThis, "localStorage", {
-  value: jsdomLocalStorage,
+  value: jsdomLocalStorage ?? createMemoryStorage(),
   writable: true,
   configurable: true,
 });
 
-Object.defineProperty(window, "matchMedia", {
-  writable: true,
-  value: vi.fn().mockImplementation((query: string) => ({
-    matches: false,
-    media: query,
-    onchange: null,
-    addListener: vi.fn(),
-    removeListener: vi.fn(),
-    addEventListener: vi.fn(),
-    removeEventListener: vi.fn(),
-    dispatchEvent: vi.fn(),
-  })),
-});
+if (typeof window !== "undefined") {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}


### PR DESCRIPTION
## Summary

- 현재 운영 중인 PUBLISHED Domain Pack version의 intent name/description 수정 UX를 추가
- 첫 저장 시 revision draft 생성 후 cloned intent를 PATCH하고, Intent 수정 검토 화면으로 이동하도록 구성
- Intent 수정 검토 화면에서 변경 요약, before/after diff, 적용/취소 action을 제공
- 일반 DRAFT 승인/반려 UX와 INTENT_REVISION DRAFT UX를 분리
- 미저장 이동 guard, beforeunload guard, 동시 편집 best-effort 방어를 추가

## Scope

- Frontend only
- Backend 신규 API, DB schema 변경, OpenAPI generated 갱신 없음
- 수정 가능 필드는 `name`, `description`으로 제한

## Tests

- `cd frontend && pnpm test -- src/features/intent-revision-draft/api/intentRevisionDraftApi.test.ts src/features/intent-revision-draft/model/existingDraftTarget.test.ts src/features/intent-revision-draft/model/useSaveIntentRevisionDraft.test.ts src/features/intent-revision-draft/model/useIntentRevisionSummary.test.ts src/features/intent-revision-draft/model/draftSource.test.ts`
- `cd frontend && pnpm build`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ajou-2026-1-capstone-5/ostone/pull/210" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 의도 개정판 초안 생성·편집·적용 워크플로우 추가
  * 의도 변경 비교(diff) UI 및 요약 표시 추가
  * 초안 수정 상태 마커 및 복구 배너 추가
  * 초안 저장/업데이트용 편의 API 및 작업 흐름 제공

* **개선 사항**
  * 의도 상세 패널의 렌더링 커스터마이즈 지점 확대
  * 의도 목록 새로고침 트리거 지원 및 마커 연동
  * 백엔드 응답 정규화로 데이터 안정성 향상
  * 도중 네비게이션 경고·충돌 처리·기존 초안 처리 개선

* **테스트**
  * 신규 기능 및 훅/유틸에 대한 단위·통합 테스트 대거 추가

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ajou-2026-1-capstone-5/ostone/pull/210)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->