### PR TITLE
docs(spec): define chat workflow admin layout

### DIFF
--- a/.agent/specs/4.1.6.md
+++ b/.agent/specs/4.1.6.md
@@ -147,17 +147,17 @@ pages/chat-demo/ui/ChatWorkflowDemoPage
 
 | 파일 | 변경 유형 | 설명 |
 |------|----------|------|
-| `src/pages/chat-demo/ui/ChatWorkflowDemoPage.tsx` | new | 페이지 엔트리, 레이아웃 조립 |
-| `src/widgets/chat-demo-header/ui/ChatWorkflowHeader.tsx` | new | 56px 헤더 |
-| `src/widgets/chat-demo-sidebar/ui/ChatDemoSidebar.tsx` | new | 220px 관리자 사이드바 |
-| `src/widgets/chat-timeline-panel/ui/ChatTimelinePanel.tsx` | new | 채팅 타임라인 패널 (38%) |
-| `src/widgets/workflow-graph-panel/ui/WorkflowGraphPanel.tsx` | new | 워크플로우 그래프 placeholder (37%) |
-| `src/widgets/execution-detail-panel/ui/ExecutionDetailPanel.tsx` | new | 실행 상세 placeholder (25%) |
-| `src/widgets/decision-log-drawer/ui/DecisionLogDrawer.tsx` | new | 의사결정 로그 Drawer |
-| `src/features/chat-demo/model/mock-data.ts` | new | Mock 메시지 데이터 |
-| `src/app/App.tsx` | modify | chat-demo 라우트 추가 |
-| `src/shared/ui/ostone/chrome/Sidebar.tsx` | modify | `SidebarActive` 타입에 `chat-demo` 추가, NAV_ITEMS에 항목 추가 |
-| `src/pages/workspace/ui/WorkspaceLayout.tsx` | modify | `getActiveFromPath`에 chat-demo 분기 추가 |
+| `frontend/src/pages/chat-demo/ui/ChatWorkflowDemoPage.tsx` | new | 페이지 엔트리, 레이아웃 조립 |
+| `frontend/src/widgets/chat-demo-header/ui/ChatWorkflowHeader.tsx` | new | 56px 헤더 |
+| `frontend/src/widgets/chat-demo-sidebar/ui/ChatDemoSidebar.tsx` | new | 220px 관리자 사이드바 |
+| `frontend/src/widgets/chat-timeline-panel/ui/ChatTimelinePanel.tsx` | new | 채팅 타임라인 패널 (38%) |
+| `frontend/src/widgets/workflow-graph-panel/ui/WorkflowGraphPanel.tsx` | new | 워크플로우 그래프 placeholder (37%) |
+| `frontend/src/widgets/execution-detail-panel/ui/ExecutionDetailPanel.tsx` | new | 실행 상세 placeholder (25%) |
+| `frontend/src/widgets/decision-log-drawer/ui/DecisionLogDrawer.tsx` | new | 의사결정 로그 Drawer |
+| `frontend/src/features/chat-demo/model/mock-data.ts` | new | Mock 메시지 데이터 |
+| `frontend/src/app/App.tsx` | modify | chat-demo 라우트 추가 |
+| `frontend/src/shared/ui/ostone/chrome/Sidebar.tsx` | modify | `SidebarActive` 타입에 `chat-demo` 추가, NAV_ITEMS에 항목 추가 |
+| `frontend/src/pages/workspace/ui/WorkspaceLayout.tsx` | modify | `getActiveFromPath`에 chat-demo 분기 추가 |
 
 ---
 

--- a/.agent/specs/4.1.6.md
+++ b/.agent/specs/4.1.6.md
@@ -19,7 +19,7 @@ flowchart TD
     B --> C{ChatWorkflowDemoPage 로드}
 
     C --> D[Header 56px]
-    C --> E[Sidebar 220px]
+    C --> E[Sidebar 56px]
     C --> F[MainContent 3열]
 
     D --> D1[DomainPackBadge: name, version]
@@ -47,7 +47,7 @@ flowchart TD
     subgraph layout_dimensions [레이아웃 치수]
         direction LR
         L1[Header: 56px]
-        L2[Sidebar: 220px]
+        L2[Sidebar: 56px]
         L3[ChatTimeline: 38%]
         L4[WorkflowGraph: 37%]
         L5[ExecutionDetail: 25%]
@@ -66,7 +66,7 @@ flowchart TD
 | 영역 | As-is | To-be | 변경 내용 |
 |------|-------|-------|----------|
 | 사이드바 네비게이션 | 5개 항목 (Workflows, Domain Packs, Pipeline, Consultation, Uploads) | 6개 항목 (+ Chat Workflow Demo) | SidebarActive 타입에 `chat-demo` 추가, NAV_ITEMS 배열 확장 |
-| 사이드바 너비 | 56px (icon-only) | 220px (text label 포함) | 기존 Sidebar와 별도로 220px짜리 Admin Sidebar 컴포넌트를 chat-demo 전용으로 신규 작성 |
+| 사이드바 너비 | 56px (icon-only) | 56px (icon-only, + Chat Demo 항목) | 기존 Sidebar.tsx에 SidebarActive 타입(`chat-demo`) 및 NAV_ITEMS 항목 추가 |
 | 헤더 | 없음 | 56px 고정 헤더 | DomainPackBadge + ScenarioName + ResetButton + NextStepButton |
 | 메인 콘텐츠 영역 | 단일 패널 (라우트마다 상이) | 3열 분할 (38/37/25) | ChatTimelinePanel / WorkflowGraphPanel / ExecutionDetailPanel |
 | Decision Log | 없음 | 하단 Drawer (collapsed/open, 260px) | 접이식 패널, 빈 상태 placeholder 포함 |
@@ -78,21 +78,18 @@ flowchart TD
 +-----------------------------------------------------------+
 | ChatWorkflowHeader (height: 56px)                         |
 | [DomainPackBadge] [ScenarioName]    [Reset] [NextStep]    |
-+----------+------------------------------------------------+
-|          | +-------------------+-------------------+----+  |
-| Sidebar  | | ChatTimeline     | WorkflowGraph     | Det|  |
-| (220px)  | | (38%)            | (37%)             | (25|  |
-|          | | scroll-y         | placeholder       | pl |  |
-| Dashboard| | mock messages    |                   |   |  |
-| Packs    | |                  |                   |    |  |
-| Review   | |                  |                   |     |  |
-| > Chat   | +------------------+-------------------+-----+  |
-|   Demo   |                                                  |
-|   (active|                                                  |
-+----------+--------------------------------------------------+
-| DecisionLogDrawer (collapsed: hidden, open: 260px)          |
-| [No decision log entries] (empty state)                     |
-+-------------------------------------------------------------+
++------+---------------------------------------------------+
+|      | +-------------------+-------------------+-------+  |
+| Side | | ChatTimeline      | WorkflowGraph    |   Det |  |
+| bar  | | (38%)             | (37%)             |  ail  |  |
+| 56px | | scroll-y          | placeholder      |  (25%)|  |
+|      | | mock messages     |                   |       |  |
+|      | |                   |                   |       |  |
+|      | +-------------------+-------------------+-------+  |
+|      |                                                    |
+|      | [DecisionLogDrawer: collapsed hidden / open 260px]|
+|      | [No decision log entries] (empty state)           |
++------+----------------------------------------------------+
 ```
 
 ---
@@ -101,31 +98,26 @@ flowchart TD
 
 ```
 pages/chat-demo/ui/ChatWorkflowDemoPage
-├─ ChatWorkflowHeader (height: 56px)
-│    ├─ DomainPackBadge
-│    │    ├─ pack name text
-│    │    └─ version badge
-│    ├─ ScenarioName (placeholder text)
-│    ├─ ResetButton
-│    └─ NextStepButton
-├─ ChatDemoSidebar (width: 220px)
-│    └─ NavItems
-│         ├─ Dashboard → /workspaces/:id/workflows
-│         ├─ Domain Packs → /workspaces/:id/domain-packs
-│         ├─ Review → /workspaces/:id/review
-│         └─ Chat Workflow Demo → /workspaces/:id/chat-demo (active)
+├─ OstoneShell
+│    ├─ ChatWorkflowHeader (height: 56px) — inline in page
+│    │    ├─ DomainPackBadge
+│    │    │    ├─ pack name text
+│    │    │    └─ version badge
+│    │    ├─ ScenarioName (placeholder text)
+│    │    ├─ ResetButton
+│    │    └─ NextStepButton
+│    └─ Sidebar (56px, reused existing)
+│         └─ NavItems (SidebarActive: chat-demo)
 ├─ MainContent (flex-1, 3열 horizontal)
 │    ├─ ChatTimelinePanel (width: 38%)
 │    │    └─ scroll-y container with mock messages
 │    ├─ WorkflowGraphPanel (width: 37%)
-│    │    └─ placeholder div with label
+│    │    └─ placeholder text
 │    └─ ExecutionDetailPanel (width: 25%)
-│         └─ placeholder div with label
-└─ DecisionLogDrawer (collapsed/open toggle)
-     ├─ handle/trigger bar
-     └─ content area (height: 260px when open)
-          ├─ (with entries) → log entry rows
-          └─ (empty) → "No decision log entries" placeholder
+│         └─ placeholder text
+└─ DecisionLogDrawer (conditional)
+     ├─ collapsed: bottom trigger bar only
+     └─ open: entry list or empty state
 ```
 
 ### FSD 매핑
@@ -133,8 +125,6 @@ pages/chat-demo/ui/ChatWorkflowDemoPage
 | FSD 계층 | 경로 | 파일 |
 |----------|------|------|
 | **pages** | `pages/chat-demo/` | `ui/ChatWorkflowDemoPage.tsx` |
-| **widgets** | `widgets/chat-demo-header/` | `ui/ChatWorkflowHeader.tsx` |
-| **widgets** | `widgets/chat-demo-sidebar/` | `ui/ChatDemoSidebar.tsx` |
 | **widgets** | `widgets/chat-timeline-panel/` | `ui/ChatTimelinePanel.tsx` |
 | **widgets** | `widgets/workflow-graph-panel/` | `ui/WorkflowGraphPanel.tsx` |
 | **widgets** | `widgets/execution-detail-panel/` | `ui/ExecutionDetailPanel.tsx` |
@@ -147,17 +137,16 @@ pages/chat-demo/ui/ChatWorkflowDemoPage
 
 | 파일 | 변경 유형 | 설명 |
 |------|----------|------|
-| `frontend/src/pages/chat-demo/ui/ChatWorkflowDemoPage.tsx` | new | 페이지 엔트리, 레이아웃 조립 |
-| `frontend/src/widgets/chat-demo-header/ui/ChatWorkflowHeader.tsx` | new | 56px 헤더 |
-| `frontend/src/widgets/chat-demo-sidebar/ui/ChatDemoSidebar.tsx` | new | 220px 관리자 사이드바 |
-| `frontend/src/widgets/chat-timeline-panel/ui/ChatTimelinePanel.tsx` | new | 채팅 타임라인 패널 (38%) |
-| `frontend/src/widgets/workflow-graph-panel/ui/WorkflowGraphPanel.tsx` | new | 워크플로우 그래프 placeholder (37%) |
-| `frontend/src/widgets/execution-detail-panel/ui/ExecutionDetailPanel.tsx` | new | 실행 상세 placeholder (25%) |
-| `frontend/src/widgets/decision-log-drawer/ui/DecisionLogDrawer.tsx` | new | 의사결정 로그 Drawer |
-| `frontend/src/features/chat-demo/model/mock-data.ts` | new | Mock 메시지 데이터 |
-| `frontend/src/app/App.tsx` | modify | chat-demo 라우트 추가 |
-| `frontend/src/shared/ui/ostone/chrome/Sidebar.tsx` | modify | `SidebarActive` 타입에 `chat-demo` 추가, NAV_ITEMS에 항목 추가 |
-| `frontend/src/pages/workspace/ui/WorkspaceLayout.tsx` | modify | `getActiveFromPath`에 chat-demo 분기 추가 |
+| `frontend/src/features/chat-workflow/pages/ChatWorkflowDemoPage.tsx` | new | 페이지 엔트리, OstoneShell 재사용. Header 인라인 포함. WorkspaceLayout과 별도 라우트로 동작 |
+| `frontend/src/features/chat-workflow/ui/ChatTimelinePanel.tsx` | new | 채팅 타임라인 패널 (38%) |
+| `frontend/src/features/chat-workflow/ui/WorkflowGraphPanel.tsx` | new | 워크플로우 그래프 placeholder (37%) |
+| `frontend/src/features/chat-workflow/ui/ExecutionDetailPanel.tsx` | new | 실행 상세 placeholder (25%) |
+| `frontend/src/features/chat-workflow/ui/DecisionLogDrawer.tsx` | new | 의사결정 로그 Drawer |
+| `frontend/src/features/chat-workflow/model/chatWorkflow.types.ts` | new | 타입 정의 |
+| `frontend/src/features/chat-workflow/model/chatWorkflowDemo.mock.ts` | new | Mock 데이터 |
+| `frontend/src/app/App.tsx` | modify | `/workspaces/:workspaceId/chat-demo` 라우트 등록 (WorkspaceLayout과 별도 Route) |
+| `frontend/src/shared/ui/ostone/chrome/Sidebar.tsx` | modify | SidebarActive 타입에 `chat-demo` 추가, NAV_ITEMS에 Chat Demo 항목 추가 |
+| `frontend/src/pages/workspace/ui/WorkspaceLayout.tsx` | modify | `getActiveFromPath`에 chat-demo 분기 추가 (Sidebar active 상태 일관성 유지) |
 
 ---
 

--- a/.agent/specs/4.1.6.md
+++ b/.agent/specs/4.1.6.md
@@ -1,0 +1,404 @@
+# Chat Workflow Admin Layout
+
+> Vite+ FSD 기반으로 채팅과 워크플로우 매핑을 중심으로 한 Admin 화면 기본 골격을 구현한다.
+> 데모 시연을 위한 Mock 기반 Skeleton이며, 실제 API 연동은 이후 단계에서 진행한다.
+
+---
+
+## Goal
+
+`/workspaces/:workspaceId/chat-demo` 경로에 채팅 타임라인, 워크플로우 그래프, 실행 상세, 의사결정 로그를 한 화면에서 확인할 수 있는 3열 레이아웃 Admin 페이지를 구현한다. 실제 데이터 연동 없이 Mock 데이터와 props drilling만으로 동작하며, 레이아웃 골격과 패널 배치가 핵심이다.
+
+---
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A[워크스페이스 사이드바<br/>Chat Workflow Demo 클릭] --> B[/workspaces/:id/chat-demo]
+    B --> C{ChatWorkflowDemoPage 로드}
+
+    C --> D[Header 56px]
+    C --> E[Sidebar 220px]
+    C --> F[MainContent 3열]
+
+    D --> D1[DomainPackBadge: name, version]
+    D --> D2[ScenarioName: placeholder]
+    D --> D3[ResetButton]
+    D --> D4[NextStepButton]
+
+    E --> E1[NavItems<br/>Dashboard / Domain Packs / Review<br/>Chat Workflow Demo active]
+
+    F --> G[ChatTimelinePanel 38%]
+    F --> H[WorkflowGraphPanel 37%]
+    F --> I[ExecutionDetailPanel 25%]
+
+    G --> G1[대화 메시지 목록<br/>세로 스크롤, mock messages]
+    H --> H1[워크플로우 그래프<br/>placeholder]
+    I --> I1[실행 상세 정보<br/>placeholder]
+
+    C --> J{DecisionLogDrawer}
+    J -->|collapsed| J1[Drawer 닫힘<br/>하단 바만 표시]
+    J -->|open| J2[260px 높이<br/>Decision Log entries<br/>또는 empty state]
+
+    D3 --> K[Reset 확인 dialog → 초기 상태]
+    D4 --> L[NextStep 호출 → timeline 갱신]
+
+    subgraph layout_dimensions [레이아웃 치수]
+        direction LR
+        L1[Header: 56px]
+        L2[Sidebar: 220px]
+        L3[ChatTimeline: 38%]
+        L4[WorkflowGraph: 37%]
+        L5[ExecutionDetail: 25%]
+        L6[DecisionLog: 260px]
+    end
+```
+
+> **Gate 분기**: DecisionLogDrawer는 collapsed/open 두 상태를 가지며, 이에 따라 메인 콘텐츠 영역 높이가 조정된다 (open 시 하단 260px 차감).
+
+---
+
+## Design Diff
+
+### As-is vs To-be
+
+| 영역 | As-is | To-be | 변경 내용 |
+|------|-------|-------|----------|
+| 사이드바 네비게이션 | 5개 항목 (Workflows, Domain Packs, Pipeline, Consultation, Uploads) | 6개 항목 (+ Chat Workflow Demo) | SidebarActive 타입에 `chat-demo` 추가, NAV_ITEMS 배열 확장 |
+| 사이드바 너비 | 56px (icon-only) | 220px (text label 포함) | 기존 Sidebar와 별도로 220px짜리 Admin Sidebar 컴포넌트를 chat-demo 전용으로 신규 작성 |
+| 헤더 | 없음 | 56px 고정 헤더 | DomainPackBadge + ScenarioName + ResetButton + NextStepButton |
+| 메인 콘텐츠 영역 | 단일 패널 (라우트마다 상이) | 3열 분할 (38/37/25) | ChatTimelinePanel / WorkflowGraphPanel / ExecutionDetailPanel |
+| Decision Log | 없음 | 하단 Drawer (collapsed/open, 260px) | 접이식 패널, 빈 상태 placeholder 포함 |
+| 채팅 페이지 | 초기화만 된 상태 (.gitkeep) | 전체 레이아웃 골격 구현 | Mock 데이터 기반 UI skeleton |
+
+### 레이아웃 치수
+
+```
++-----------------------------------------------------------+
+| ChatWorkflowHeader (height: 56px)                         |
+| [DomainPackBadge] [ScenarioName]    [Reset] [NextStep]    |
++----------+------------------------------------------------+
+|          | +-------------------+-------------------+----+  |
+| Sidebar  | | ChatTimeline     | WorkflowGraph     | Det|  |
+| (220px)  | | (38%)            | (37%)             | (25|  |
+|          | | scroll-y         | placeholder       | pl |  |
+| Dashboard| | mock messages    |                   |   |  |
+| Packs    | |                  |                   |    |  |
+| Review   | |                  |                   |     |  |
+| > Chat   | +------------------+-------------------+-----+  |
+|   Demo   |                                                  |
+|   (active|                                                  |
++----------+--------------------------------------------------+
+| DecisionLogDrawer (collapsed: hidden, open: 260px)          |
+| [No decision log entries] (empty state)                     |
++-------------------------------------------------------------+
+```
+
+---
+
+## Component Tree
+
+```
+pages/chat-demo/ui/ChatWorkflowDemoPage
+├─ ChatWorkflowHeader (height: 56px)
+│    ├─ DomainPackBadge
+│    │    ├─ pack name text
+│    │    └─ version badge
+│    ├─ ScenarioName (placeholder text)
+│    ├─ ResetButton
+│    └─ NextStepButton
+├─ ChatDemoSidebar (width: 220px)
+│    └─ NavItems
+│         ├─ Dashboard → /workspaces/:id/workflows
+│         ├─ Domain Packs → /workspaces/:id/domain-packs
+│         ├─ Review → /workspaces/:id/review
+│         └─ Chat Workflow Demo → /workspaces/:id/chat-demo (active)
+├─ MainContent (flex-1, 3열 horizontal)
+│    ├─ ChatTimelinePanel (width: 38%)
+│    │    └─ scroll-y container with mock messages
+│    ├─ WorkflowGraphPanel (width: 37%)
+│    │    └─ placeholder div with label
+│    └─ ExecutionDetailPanel (width: 25%)
+│         └─ placeholder div with label
+└─ DecisionLogDrawer (collapsed/open toggle)
+     ├─ handle/trigger bar
+     └─ content area (height: 260px when open)
+          ├─ (with entries) → log entry rows
+          └─ (empty) → "No decision log entries" placeholder
+```
+
+### FSD 매핑
+
+| FSD 계층 | 경로 | 파일 |
+|----------|------|------|
+| **pages** | `pages/chat-demo/` | `ui/ChatWorkflowDemoPage.tsx` |
+| **widgets** | `widgets/chat-demo-header/` | `ui/ChatWorkflowHeader.tsx` |
+| **widgets** | `widgets/chat-demo-sidebar/` | `ui/ChatDemoSidebar.tsx` |
+| **widgets** | `widgets/chat-timeline-panel/` | `ui/ChatTimelinePanel.tsx` |
+| **widgets** | `widgets/workflow-graph-panel/` | `ui/WorkflowGraphPanel.tsx` |
+| **widgets** | `widgets/execution-detail-panel/` | `ui/ExecutionDetailPanel.tsx` |
+| **widgets** | `widgets/decision-log-drawer/` | `ui/DecisionLogDrawer.tsx` |
+| **features** | `features/chat-demo/` | `model/mock-data.ts` (mock messages) |
+
+---
+
+## 수정 대상 파일
+
+| 파일 | 변경 유형 | 설명 |
+|------|----------|------|
+| `src/pages/chat-demo/ui/ChatWorkflowDemoPage.tsx` | new | 페이지 엔트리, 레이아웃 조립 |
+| `src/widgets/chat-demo-header/ui/ChatWorkflowHeader.tsx` | new | 56px 헤더 |
+| `src/widgets/chat-demo-sidebar/ui/ChatDemoSidebar.tsx` | new | 220px 관리자 사이드바 |
+| `src/widgets/chat-timeline-panel/ui/ChatTimelinePanel.tsx` | new | 채팅 타임라인 패널 (38%) |
+| `src/widgets/workflow-graph-panel/ui/WorkflowGraphPanel.tsx` | new | 워크플로우 그래프 placeholder (37%) |
+| `src/widgets/execution-detail-panel/ui/ExecutionDetailPanel.tsx` | new | 실행 상세 placeholder (25%) |
+| `src/widgets/decision-log-drawer/ui/DecisionLogDrawer.tsx` | new | 의사결정 로그 Drawer |
+| `src/features/chat-demo/model/mock-data.ts` | new | Mock 메시지 데이터 |
+| `src/app/App.tsx` | modify | chat-demo 라우트 추가 |
+| `src/shared/ui/ostone/chrome/Sidebar.tsx` | modify | `SidebarActive` 타입에 `chat-demo` 추가, NAV_ITEMS에 항목 추가 |
+| `src/pages/workspace/ui/WorkspaceLayout.tsx` | modify | `getActiveFromPath`에 chat-demo 분기 추가 |
+
+---
+
+## State Management
+
+### Local State (props drilling only)
+
+```typescript
+// features/chat-demo/model/mock-data.ts
+export interface ChatMessage {
+  id: string;
+  role: 'user' | 'assistant';
+  content: string;
+  timestamp: string;
+}
+
+export interface DecisionLogEntry {
+  id: string;
+  step: string;
+  decision: string;
+  reason: string;
+  timestamp: string;
+}
+
+export const MOCK_MESSAGES: ChatMessage[] = [
+  { id: '1', role: 'user', content: '안녕하세요, 상담 문의드립니다.', timestamp: '2026-05-12 10:00:00' },
+  { id: '2', role: 'assistant', content: '안녕하세요. 무엇을 도와드릴까요?', timestamp: '2026-05-12 10:00:05' },
+];
+
+export const MOCK_DECISION_LOG: DecisionLogEntry[] = [];
+```
+
+```typescript
+// ChatWorkflowDemoPage (local state)
+const [messages] = useState<ChatMessage[]>(MOCK_MESSAGES);
+const [decisionLog] = useState<DecisionLogEntry[]>(MOCK_DECISION_LOG);
+const [decisionLogOpen, setDecisionLogOpen] = useState(false);
+
+// Props drilling only — no React Query, no Zustand, no fetch
+<ChatTimelinePanel messages={messages} />
+<DecisionLogDrawer
+  entries={decisionLog}
+  open={decisionLogOpen}
+  onToggle={() => setDecisionLogOpen((v) => !v)}
+/>
+```
+
+### Client State (none 추가 예정)
+
+실제 API 연동 및 상태 관리(React Query, Zustand)는 이번 스펙에서 명시적으로 범위 밖으로 한다. 모든 상태는 `ChatWorkflowDemoPage`의 `useState`로 관리하며 props drilling으로 하위 컴포넌트에 전달한다.
+
+---
+
+## API Integration
+
+### Endpoints
+
+**해당 없음.** 이번 구현은 Mock 기반 skeleton이며, 실제 API 호출은 일절 포함하지 않는다.
+
+| 항목 | 상태 | 설명 |
+|------|------|------|
+| 실제 API 연동 | ❌ Scope-out | feature/4.1.7+에서 진행 |
+| React Query | ❌ 사용 안 함 | 이후 도입 예정 |
+| fetch / axios | ❌ 사용 안 함 | 이후 도입 예정 |
+
+---
+
+## Data Flow
+
+```
+ChatWorkflowDemoPage (local useState)
+│
+├─ props: messages ──────► ChatTimelinePanel
+│                            └─ map → MessageBubble (role, content, timestamp)
+│
+├─ props: (placeholder) ─► WorkflowGraphPanel
+│                            └─ <div>Workflow Graph Placeholder</div>
+│
+├─ props: (placeholder) ─► ExecutionDetailPanel
+│                            └─ <div>Execution Detail Placeholder</div>
+│
+├─ props: entries, open ─► DecisionLogDrawer
+│    onToggle                ├─ collapsed: 하단 trigger bar만 표시
+│                            └─ open: entry list 또는 empty state
+│
+└─ (no fetch, no query keys, no cache)
+```
+
+---
+
+## Error / Empty / Loading Boundary
+
+### Loading
+- 패널 자체가 placeholder이므로 별도 loading spinner는 표시하지 않는다.
+- `ChatWorkflowDemoPage`는 동기적으로 렌더링되며, 데이터 로딩 상태가 존재하지 않는다.
+
+### Empty
+| 컴포넌트 | Empty 조건 | 표시 |
+|----------|-----------|------|
+| ChatTimelinePanel | messages.length === 0 | 빈 메시지 목록 (스크롤 영역 비움) |
+| WorkflowGraphPanel | 항상 placeholder | "Workflow Graph" 라벨 표시 |
+| ExecutionDetailPanel | 항상 placeholder | "Execution Detail" 라벨 표시 |
+| DecisionLogDrawer | entries.length === 0 && open | `"No decision log entries"` 텍스트 표시 |
+
+### Error
+- React render error: 기존 `ErrorBoundary` (`shared/ui/`)에 위임한다.
+- 별도의 error state handling은 이번 스펙에서 구현하지 않는다.
+
+---
+
+## Tests
+
+### Test Strategy
+
+| 구분 | 방법 | 도구 | 비고 |
+|------|------|------|------|
+| 컴포넌트 테스트 | Vitest + jsdom + React Testing Library | `pnpm test` | TDD (RED → GREEN → REFACTOR) |
+| 통합 테스트 | Vitest + jsdom | `pnpm test` | Route smoke test, Page layout test |
+
+### Test Environment & 사전 조건
+
+| 항목 | 값 |
+|------|---|
+| 환경 | `pnpm test` (CI) |
+| API Mock | 해당 없음 (모든 데이터 로컬 Mock) |
+| 사전 조건 | React Router로 `/workspaces/1/chat-demo` 접근 가능 |
+
+### Test Scenarios
+
+#### Happy Path
+
+| # | 시나리오 | 사전 조건 | 조작 | 기대 결과 |
+|---|---------|---------|------|----------|
+| 1 | Route 진입 | 워크스페이스 ID=1 존재 | `/workspaces/1/chat-demo` 접근 | `ChatWorkflowDemoPage` 렌더링, 200 OK |
+| 2 | 페이지 구조 확인 | 페이지 로드 | — | Header(56px) + Sidebar(220px) + 3열 패널 존재 |
+| 3 | 사이드바 active 확인 | 페이지 로드 | — | "Chat Workflow Demo" 항목 active 스타일 적용 |
+| 4 | ChatTimelinePanel 표시 | mock messages 2개 | — | 2개의 메시지 bubble 렌더링 |
+| 5 | DecisionLogDrawer collapsed | 초기 상태 | — | Drawer 내용 안 보임 (collapsed) |
+| 6 | DecisionLogDrawer open | collapsed 상태 | toggle 버튼 클릭 | Drawer 열림, 260px 영역 표시 |
+| 7 | DecisionLogDrawer empty | entries.length === 0 | Drawer open | "No decision log entries" 텍스트 표시 |
+
+#### Error & Edge Cases
+
+| # | 시나리오 | 조작 | 기대 결과 |
+|---|---------|------|----------|
+| 1 | DecisionLogDrawer toggle | 두 번 클릭 | collapsed → open → collapsed |
+| 2 | ChatTimelinePanel 빈 상태 | messages.length === 0 | 패널은 렌더링되지만 목록 비어 있음 |
+| 3 | ResetButton 클릭 | ResetButton 클릭 | 확인 dialog 표시 (UI만, 실제 reset은 scope-out) |
+
+#### 반응형 & 접근성
+
+| # | 확인 항목 | 기대 결과 |
+|---|---------|----------|
+| 1 | 데스크톱 (1280px+) | 3열 레이아웃 정상 표시 (38/37/25) |
+| 2 | 작은 화면 (<1024px) | sidebar 220px + 3열 overflow-x 처리 (이번 스펙에서는 scroll만, 적응형은 scope-out) |
+| 3 | 키보드 탭 이동 | 모든 버튼/링크 접근 가능 |
+| 4 | aria-label | 사이드바 네비게이션 항목에 aria-label 필요 |
+
+---
+
+## Implementation Example
+
+```typescript
+// pages/chat-demo/ui/ChatWorkflowDemoPage.tsx
+import { useState } from 'react';
+import { ChatWorkflowHeader } from '@/widgets/chat-demo-header';
+import { ChatDemoSidebar } from '@/widgets/chat-demo-sidebar';
+import { ChatTimelinePanel } from '@/widgets/chat-timeline-panel';
+import { WorkflowGraphPanel } from '@/widgets/workflow-graph-panel';
+import { ExecutionDetailPanel } from '@/widgets/execution-detail-panel';
+import { DecisionLogDrawer } from '@/widgets/decision-log-drawer';
+import { MOCK_MESSAGES, MOCK_DECISION_LOG, type ChatMessage, type DecisionLogEntry } from '@/features/chat-demo/model/mock-data';
+
+export function ChatWorkflowDemoPage() {
+  const [messages] = useState<ChatMessage[]>(MOCK_MESSAGES);
+  const [decisionLog] = useState<DecisionLogEntry[]>(MOCK_DECISION_LOG);
+  const [decisionLogOpen, setDecisionLogOpen] = useState(false);
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      <ChatWorkflowHeader
+        packName="CS Domain Pack"
+        packVersion="v1.0.0"
+        scenarioName="기본 상담 시나리오"
+      />
+      <div style={{ display: 'flex', flex: 1, overflow: 'hidden' }}>
+        <ChatDemoSidebar active="chat-demo" />
+        <main style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+          <div style={{ display: 'flex', flex: 1 }}>
+            <ChatTimelinePanel messages={messages} />
+            <WorkflowGraphPanel />
+            <ExecutionDetailPanel />
+          </div>
+          <DecisionLogDrawer
+            entries={decisionLog}
+            open={decisionLogOpen}
+            onToggle={() => setDecisionLogOpen((v) => !v)}
+          />
+        </main>
+      </div>
+    </div>
+  );
+}
+```
+
+---
+
+## Performance Considerations
+
+- 이번 스펙은 Mock 데이터 기반 skeleton이므로 성능 최적화는 적용하지 않는다.
+- 이후 실제 데이터 연동 시 가상 스크롤(virtual scroll) 적용을 고려 (ChatTimelinePanel이 대량 메시지를 처리할 경우).
+- 모든 이미지/아이콘 없음: UI는 텍스트와 CSS 기반.
+
+---
+
+## Scope-out
+
+다음 항목은 이번 스펙에서 명시적으로 제외한다:
+
+| 항목 | 사유 | 이후 처리 |
+|------|------|----------|
+| 실제 API 연동 | skeleton 단계, data layer 미구현 | feature/4.1.7+ |
+| 워크플로우 그래프 엔진 | 복잡한 시각화는 별도 스펙 필요 | feature/4.2.x |
+| 채팅 입력(input) | ChatTimelinePanel은 읽기 전용, 메시지 발송 기능 없음 | feature/4.1.8+ |
+| 새 상태 관리 라이브러리 | props drilling으로 충분 | 이후 도입 검토 |
+| Vaul / react-resizable-panels | 레이아웃 조절 기능은 이후 | feature/4.2.x |
+| Sidebar 전면 리팩토링 | 기존 56px Sidebar는 유지, chat-demo만 220px 신규 작성 | - |
+| Persistent E2E 테스트 | Playwright 구성 및 인프라 필요 | 이후 |
+| 반응형/모바일 대응 | 이번 스펙은 데스크톱 전용 | feature/4.2.x |
+
+---
+
+## Branch Strategy
+
+```
+main
+  └── spec/4.1.6 (← 현재, spec 문서)
+        └── feature/4.1.6-chat-workflow-admin-layout (구현)
+              └── main (PR merge)
+```
+
+1. `spec/4.1.6` → spec PR (문서 리뷰)
+2. spec 승인 후 `feature/4.1.6-chat-workflow-admin-layout` 브랜치 생성
+3. 구현 PR → main merge


### PR DESCRIPTION
## Summary

4.1.6 채팅-워크플로우 중심 Admin 화면 기본 레이아웃 구현을 위한 FE 스펙 문서입니다.

## Details

- **Issue**: Closes #211
- **파일**: `.agent/specs/4.1.6.md`
- **변경**: spec 문서만 추가 (frontend source code 변경 없음)

## Definition of Done

- [x] FE spec 템플릿 기준 필수 항목 포함
- [x] 브랜치: `spec/4.1.6` (main에서 분기)
- [x] frontend source code 변경 없음
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ajou-2026-1-capstone-5/ostone/pull/212" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **문서**
  * Chat Workflow Demo 관리 화면의 Vite+FSD 기반 레이아웃 및 동작 명세 문서 추가
  * 3열(38/37/25) 패널, 56px 고정 헤더, 220px 사이드바, DecisionLog 드로어 동작과 치수/플로우 다이어그램 정의
  * 컴포넌트 트리·FSD 매핑, 로컬 상태(스텁) 사용 및 API 연동 Scope-out 명시
  * 테스트 시나리오(라우트/상태/드로어/빈 상태/접근성) 및 구현 스니펫 포함

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ajou-2026-1-capstone-5/ostone/pull/212)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ajou-2026-1-capstone-5/ostone/pull/212)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->