### PR TITLE
[3.2.10] feat(domain-pack): add workflow transition patch api

### DIFF
--- a/backend/src/main/java/com/init/domainpack/application/UpdateWorkflowTransitionCommand.java
+++ b/backend/src/main/java/com/init/domainpack/application/UpdateWorkflowTransitionCommand.java
@@ -1,0 +1,19 @@
+package com.init.domainpack.application;
+
+public record UpdateWorkflowTransitionCommand(
+    Long workspaceId,
+    Long packId,
+    Long versionId,
+    Long workflowId,
+    String transitionId,
+    Long requesterId,
+    ConditionPatch condition,
+    ActionPatch action,
+    OutcomePatch outcome) {
+
+  public record ConditionPatch(String label) {}
+
+  public record ActionPatch(String policyRef) {}
+
+  public record OutcomePatch(String state, String label) {}
+}

--- a/backend/src/main/java/com/init/domainpack/application/UpdateWorkflowTransitionUseCase.java
+++ b/backend/src/main/java/com/init/domainpack/application/UpdateWorkflowTransitionUseCase.java
@@ -154,7 +154,7 @@ public class UpdateWorkflowTransitionUseCase {
       WorkflowGraphDocument document,
       ObjectNode edge,
       ObjectNode fromNode) {
-    if (!NODE_TYPE_DECISION.equals(fromNode.path("type").asText(null))) {
+    if (!NODE_TYPE_DECISION.equals(nodeType(fromNode))) {
       throw new WorkflowTransitionConditionNotEditableException(command.transitionId());
     }
     document.putText(
@@ -163,7 +163,7 @@ public class UpdateWorkflowTransitionUseCase {
 
   private void applyActionPatch(
       UpdateWorkflowTransitionCommand command, WorkflowGraphDocument document, ObjectNode toNode) {
-    if (!NODE_TYPE_ACTION.equals(toNode.path("type").asText(null))) {
+    if (!NODE_TYPE_ACTION.equals(nodeType(toNode))) {
       throw new WorkflowTransitionActionNotEditableException(command.transitionId());
     }
     validateTargetNotShared(command, document, toNode);
@@ -177,7 +177,7 @@ public class UpdateWorkflowTransitionUseCase {
 
   private void applyOutcomePatch(
       UpdateWorkflowTransitionCommand command, WorkflowGraphDocument document, ObjectNode toNode) {
-    if (!NODE_TYPE_TERMINAL.equals(toNode.path("type").asText(null))) {
+    if (!NODE_TYPE_TERMINAL.equals(nodeType(toNode))) {
       throw new WorkflowTransitionOutcomeNotEditableException(command.transitionId());
     }
     validateTargetNotShared(command, document, toNode);
@@ -188,6 +188,18 @@ public class UpdateWorkflowTransitionUseCase {
       document.putText(
           toNode, "label", normalizeRequired(command.outcome().label(), "outcome.label", 255));
     }
+  }
+
+  private String nodeType(ObjectNode node) {
+    return trimToNull(node.path("type").asText(null));
+  }
+
+  private String trimToNull(String value) {
+    if (value == null) {
+      return null;
+    }
+    String trimmed = value.trim();
+    return trimmed.isBlank() ? null : trimmed;
   }
 
   private void applyOutcomeStatePatch(

--- a/backend/src/main/java/com/init/domainpack/application/UpdateWorkflowTransitionUseCase.java
+++ b/backend/src/main/java/com/init/domainpack/application/UpdateWorkflowTransitionUseCase.java
@@ -1,0 +1,189 @@
+package com.init.domainpack.application;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.init.domainpack.application.exception.DomainPackDraftRequestInvalidException;
+import com.init.domainpack.application.exception.DomainPackVersionNotFoundException;
+import com.init.domainpack.application.exception.WorkflowActionNodePolicyRefInvalidCharsException;
+import com.init.domainpack.application.exception.WorkflowDefinitionNotFoundException;
+import com.init.domainpack.application.exception.WorkflowTransitionActionNotEditableException;
+import com.init.domainpack.application.exception.WorkflowTransitionConditionNotEditableException;
+import com.init.domainpack.application.exception.WorkflowTransitionNotFoundException;
+import com.init.domainpack.application.exception.WorkflowTransitionOutcomeEmptyException;
+import com.init.domainpack.application.exception.WorkflowTransitionOutcomeNotEditableException;
+import com.init.domainpack.application.exception.WorkflowTransitionOutcomeStateInvalidCharsException;
+import com.init.domainpack.application.exception.WorkflowTransitionPatchEmptyException;
+import com.init.domainpack.domain.model.DomainPackVersion;
+import com.init.domainpack.domain.model.WorkflowDefinition;
+import com.init.domainpack.domain.repository.DomainPackVersionRepository;
+import com.init.domainpack.domain.repository.WorkflowDefinitionRepository;
+import com.init.shared.application.exception.BadRequestException;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class UpdateWorkflowTransitionUseCase {
+
+  private static final Pattern TRANSITION_ID_PATTERN = Pattern.compile("[A-Za-z0-9_-]+");
+  private static final Pattern MACHINE_CODE_PATTERN = Pattern.compile("[A-Za-z0-9_-]+");
+
+  private final DomainPackValidator validator;
+  private final DomainPackVersionRepository versionRepository;
+  private final WorkflowDefinitionRepository workflowRepository;
+
+  public UpdateWorkflowTransitionUseCase(
+      DomainPackValidator validator,
+      DomainPackVersionRepository versionRepository,
+      WorkflowDefinitionRepository workflowRepository) {
+    this.validator = validator;
+    this.versionRepository = versionRepository;
+    this.workflowRepository = workflowRepository;
+  }
+
+  @Transactional
+  public WorkflowTransitionDetail execute(UpdateWorkflowTransitionCommand command) {
+    validateCommand(command);
+    validator.validateWorkspaceAccess(command.workspaceId(), command.requesterId());
+    validator.validateDomainPack(command.packId(), command.workspaceId());
+
+    DomainPackVersion version =
+        versionRepository
+            .findById(command.versionId())
+            .orElseThrow(() -> new DomainPackVersionNotFoundException(command.versionId()));
+    if (!version.getDomainPackId().equals(command.packId())) {
+      throw new DomainPackVersionNotFoundException(command.versionId());
+    }
+    if (!DomainPackVersion.STATUS_DRAFT.equals(version.getLifecycleStatus())) {
+      throw new BadRequestException("WORKFLOW_NOT_EDITABLE", "DRAFT 상태의 버전에서만 수정할 수 있습니다.");
+    }
+
+    WorkflowDefinition workflow =
+        workflowRepository
+            .findByIdAndDomainPackVersionId(command.workflowId(), command.versionId())
+            .orElseThrow(() -> new WorkflowDefinitionNotFoundException(command.workflowId()));
+
+    WorkflowGraphValidator.parseAndValidate(workflow.getGraphJson(), workflow.getWorkflowCode());
+    WorkflowGraphDocument document =
+        WorkflowGraphDocument.parse(workflow.getGraphJson(), workflow.getId());
+    ObjectNode edge =
+        document
+            .findEdge(command.transitionId())
+            .orElseThrow(() -> new WorkflowTransitionNotFoundException(command.transitionId()));
+    ObjectNode fromNode = document.requireFromNode(edge);
+    ObjectNode toNode = document.requireToNode(edge);
+
+    applyPatch(command, document, edge, fromNode, toNode);
+
+    String updatedGraphJson = document.toJson();
+    WorkflowGraphValidator.ParsedGraph parsed =
+        WorkflowGraphValidator.parseAndValidate(updatedGraphJson, workflow.getWorkflowCode());
+
+    Set<String> policyRefs =
+        parsed.nodes().stream()
+            .filter(node -> "ACTION".equals(node.type()))
+            .map(WorkflowGraphValidator.GraphNode::policyRef)
+            .collect(Collectors.toCollection(LinkedHashSet::new));
+    validator.validatePolicyCodes(command.versionId(), policyRefs);
+
+    String initialState = WorkflowGraphValidator.extractInitialState(parsed);
+    String terminalStatesJson;
+    try {
+      terminalStatesJson = WorkflowGraphValidator.extractTerminalStatesJson(parsed);
+    } catch (IllegalStateException e) {
+      throw new DomainPackDraftRequestInvalidException("Failed to serialize terminal states", e);
+    }
+
+    try {
+      workflow.updateGraph(
+          workflow.getName(),
+          workflow.getDescription(),
+          updatedGraphJson,
+          initialState,
+          terminalStatesJson);
+    } catch (IllegalArgumentException e) {
+      throw new BadRequestException("VALIDATION_ERROR", e.getMessage());
+    }
+
+    workflowRepository.save(workflow);
+    return document
+        .findTransitionDetail(command.transitionId(), workflow.getDomainPackVersionId())
+        .orElseThrow(() -> new WorkflowTransitionNotFoundException(command.transitionId()));
+  }
+
+  private void validateCommand(UpdateWorkflowTransitionCommand command) {
+    if (!TRANSITION_ID_PATTERN.matcher(command.transitionId()).matches()) {
+      throw new BadRequestException("VALIDATION_ERROR", "transitionId가 유효하지 않습니다.");
+    }
+    if (command.condition() == null && command.action() == null && command.outcome() == null) {
+      throw new WorkflowTransitionPatchEmptyException();
+    }
+    if (command.outcome() != null
+        && command.outcome().state() == null
+        && command.outcome().label() == null) {
+      throw new WorkflowTransitionOutcomeEmptyException();
+    }
+  }
+
+  private void applyPatch(
+      UpdateWorkflowTransitionCommand command,
+      WorkflowGraphDocument document,
+      ObjectNode edge,
+      ObjectNode fromNode,
+      ObjectNode toNode) {
+    if (command.condition() != null) {
+      if (!"DECISION".equals(fromNode.path("type").asText(null))) {
+        throw new WorkflowTransitionConditionNotEditableException(command.transitionId());
+      }
+      document.putText(
+          edge, "label", normalizeRequired(command.condition().label(), "condition.label", 255));
+    }
+
+    if (command.action() != null) {
+      if (!"ACTION".equals(toNode.path("type").asText(null))) {
+        throw new WorkflowTransitionActionNotEditableException(command.transitionId());
+      }
+      String policyRef = normalizeRequired(command.action().policyRef(), "action.policyRef", 100);
+      if (!MACHINE_CODE_PATTERN.matcher(policyRef).matches()) {
+        throw new WorkflowActionNodePolicyRefInvalidCharsException(
+            command.workflowId(), toNode.path("id").asText());
+      }
+      document.putText(toNode, "policyRef", policyRef);
+    }
+
+    if (command.outcome() != null) {
+      if (!"TERMINAL".equals(toNode.path("type").asText(null))) {
+        throw new WorkflowTransitionOutcomeNotEditableException(command.transitionId());
+      }
+      if (command.outcome().state() != null) {
+        String state = normalizeRequired(command.outcome().state(), "outcome.state", 100);
+        if (!MACHINE_CODE_PATTERN.matcher(state).matches()) {
+          throw new WorkflowTransitionOutcomeStateInvalidCharsException(state);
+        }
+        document.putText(toNode, "state", state);
+      }
+      if (command.outcome().label() != null) {
+        document.putText(
+            toNode, "label", normalizeRequired(command.outcome().label(), "outcome.label", 255));
+      }
+    }
+  }
+
+  private String normalizeRequired(String value, String fieldName, int maxLength) {
+    if (value == null) {
+      throw new BadRequestException("VALIDATION_ERROR", fieldName + "은 필수 항목입니다.");
+    }
+    String trimmed = value.trim();
+    if (trimmed.isBlank()) {
+      throw new BadRequestException("VALIDATION_ERROR", fieldName + "은 빈 값일 수 없습니다.");
+    }
+    if (trimmed.length() > maxLength) {
+      throw new BadRequestException(
+          "VALIDATION_ERROR", fieldName + "은 " + maxLength + "자 이하여야 합니다.");
+    }
+    return trimmed;
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/application/UpdateWorkflowTransitionUseCase.java
+++ b/backend/src/main/java/com/init/domainpack/application/UpdateWorkflowTransitionUseCase.java
@@ -30,6 +30,9 @@ public class UpdateWorkflowTransitionUseCase {
 
   private static final Pattern TRANSITION_ID_PATTERN = Pattern.compile("[A-Za-z0-9_-]+");
   private static final Pattern MACHINE_CODE_PATTERN = Pattern.compile("[A-Za-z0-9_-]+");
+  private static final String NODE_TYPE_ACTION = "ACTION";
+  private static final String NODE_TYPE_DECISION = "DECISION";
+  private static final String NODE_TYPE_TERMINAL = "TERMINAL";
 
   private final DomainPackValidator validator;
   private final DomainPackVersionRepository versionRepository;
@@ -84,7 +87,7 @@ public class UpdateWorkflowTransitionUseCase {
 
     Set<String> policyRefs =
         parsed.nodes().stream()
-            .filter(node -> "ACTION".equals(node.type()))
+            .filter(node -> NODE_TYPE_ACTION.equals(node.type()))
             .map(WorkflowGraphValidator.GraphNode::policyRef)
             .collect(Collectors.toCollection(LinkedHashSet::new));
     validator.validatePolicyCodes(command.versionId(), policyRefs);
@@ -135,41 +138,62 @@ public class UpdateWorkflowTransitionUseCase {
       ObjectNode fromNode,
       ObjectNode toNode) {
     if (command.condition() != null) {
-      if (!"DECISION".equals(fromNode.path("type").asText(null))) {
-        throw new WorkflowTransitionConditionNotEditableException(command.transitionId());
-      }
-      document.putText(
-          edge, "label", normalizeRequired(command.condition().label(), "condition.label", 255));
+      applyConditionPatch(command, document, edge, fromNode);
     }
-
     if (command.action() != null) {
-      if (!"ACTION".equals(toNode.path("type").asText(null))) {
-        throw new WorkflowTransitionActionNotEditableException(command.transitionId());
-      }
-      String policyRef = normalizeRequired(command.action().policyRef(), "action.policyRef", 100);
-      if (!MACHINE_CODE_PATTERN.matcher(policyRef).matches()) {
-        throw new WorkflowActionNodePolicyRefInvalidCharsException(
-            command.workflowId(), toNode.path("id").asText());
-      }
-      document.putText(toNode, "policyRef", policyRef);
+      applyActionPatch(command, document, toNode);
     }
-
     if (command.outcome() != null) {
-      if (!"TERMINAL".equals(toNode.path("type").asText(null))) {
-        throw new WorkflowTransitionOutcomeNotEditableException(command.transitionId());
-      }
-      if (command.outcome().state() != null) {
-        String state = normalizeRequired(command.outcome().state(), "outcome.state", 100);
-        if (!MACHINE_CODE_PATTERN.matcher(state).matches()) {
-          throw new WorkflowTransitionOutcomeStateInvalidCharsException(state);
-        }
-        document.putText(toNode, "state", state);
-      }
-      if (command.outcome().label() != null) {
-        document.putText(
-            toNode, "label", normalizeRequired(command.outcome().label(), "outcome.label", 255));
-      }
+      applyOutcomePatch(command, document, toNode);
     }
+  }
+
+  private void applyConditionPatch(
+      UpdateWorkflowTransitionCommand command,
+      WorkflowGraphDocument document,
+      ObjectNode edge,
+      ObjectNode fromNode) {
+    if (!NODE_TYPE_DECISION.equals(fromNode.path("type").asText(null))) {
+      throw new WorkflowTransitionConditionNotEditableException(command.transitionId());
+    }
+    document.putText(
+        edge, "label", normalizeRequired(command.condition().label(), "condition.label", 255));
+  }
+
+  private void applyActionPatch(
+      UpdateWorkflowTransitionCommand command, WorkflowGraphDocument document, ObjectNode toNode) {
+    if (!NODE_TYPE_ACTION.equals(toNode.path("type").asText(null))) {
+      throw new WorkflowTransitionActionNotEditableException(command.transitionId());
+    }
+    String policyRef = normalizeRequired(command.action().policyRef(), "action.policyRef", 100);
+    if (!MACHINE_CODE_PATTERN.matcher(policyRef).matches()) {
+      throw new WorkflowActionNodePolicyRefInvalidCharsException(
+          command.workflowId(), toNode.path("id").asText());
+    }
+    document.putText(toNode, "policyRef", policyRef);
+  }
+
+  private void applyOutcomePatch(
+      UpdateWorkflowTransitionCommand command, WorkflowGraphDocument document, ObjectNode toNode) {
+    if (!NODE_TYPE_TERMINAL.equals(toNode.path("type").asText(null))) {
+      throw new WorkflowTransitionOutcomeNotEditableException(command.transitionId());
+    }
+    if (command.outcome().state() != null) {
+      applyOutcomeStatePatch(command, document, toNode);
+    }
+    if (command.outcome().label() != null) {
+      document.putText(
+          toNode, "label", normalizeRequired(command.outcome().label(), "outcome.label", 255));
+    }
+  }
+
+  private void applyOutcomeStatePatch(
+      UpdateWorkflowTransitionCommand command, WorkflowGraphDocument document, ObjectNode toNode) {
+    String state = normalizeRequired(command.outcome().state(), "outcome.state", 100);
+    if (!MACHINE_CODE_PATTERN.matcher(state).matches()) {
+      throw new WorkflowTransitionOutcomeStateInvalidCharsException(state);
+    }
+    document.putText(toNode, "state", state);
   }
 
   private String normalizeRequired(String value, String fieldName, int maxLength) {

--- a/backend/src/main/java/com/init/domainpack/application/UpdateWorkflowTransitionUseCase.java
+++ b/backend/src/main/java/com/init/domainpack/application/UpdateWorkflowTransitionUseCase.java
@@ -105,7 +105,7 @@ public class UpdateWorkflowTransitionUseCase {
           initialState,
           terminalStatesJson);
     } catch (IllegalArgumentException e) {
-      throw new BadRequestException("VALIDATION_ERROR", e.getMessage());
+      throw new BadRequestException("VALIDATION_ERROR", e.getMessage(), e);
     }
 
     workflowRepository.save(workflow);

--- a/backend/src/main/java/com/init/domainpack/application/UpdateWorkflowTransitionUseCase.java
+++ b/backend/src/main/java/com/init/domainpack/application/UpdateWorkflowTransitionUseCase.java
@@ -33,6 +33,7 @@ public class UpdateWorkflowTransitionUseCase {
   private static final String NODE_TYPE_ACTION = "ACTION";
   private static final String NODE_TYPE_DECISION = "DECISION";
   private static final String NODE_TYPE_TERMINAL = "TERMINAL";
+  private static final String SHARED_TARGET_NOT_EDITABLE = "WORKFLOW_TRANSITION_TARGET_SHARED";
 
   private final DomainPackValidator validator;
   private final DomainPackVersionRepository versionRepository;
@@ -165,6 +166,7 @@ public class UpdateWorkflowTransitionUseCase {
     if (!NODE_TYPE_ACTION.equals(toNode.path("type").asText(null))) {
       throw new WorkflowTransitionActionNotEditableException(command.transitionId());
     }
+    validateTargetNotShared(command, document, toNode);
     String policyRef = normalizeRequired(command.action().policyRef(), "action.policyRef", 100);
     if (!MACHINE_CODE_PATTERN.matcher(policyRef).matches()) {
       throw new WorkflowActionNodePolicyRefInvalidCharsException(
@@ -178,6 +180,7 @@ public class UpdateWorkflowTransitionUseCase {
     if (!NODE_TYPE_TERMINAL.equals(toNode.path("type").asText(null))) {
       throw new WorkflowTransitionOutcomeNotEditableException(command.transitionId());
     }
+    validateTargetNotShared(command, document, toNode);
     if (command.outcome().state() != null) {
       applyOutcomeStatePatch(command, document, toNode);
     }
@@ -194,6 +197,15 @@ public class UpdateWorkflowTransitionUseCase {
       throw new WorkflowTransitionOutcomeStateInvalidCharsException(state);
     }
     document.putText(toNode, "state", state);
+  }
+
+  private void validateTargetNotShared(
+      UpdateWorkflowTransitionCommand command, WorkflowGraphDocument document, ObjectNode toNode) {
+    if (!document.hasSingleInboundEdge(toNode)) {
+      throw new BadRequestException(
+          SHARED_TARGET_NOT_EDITABLE,
+          "공유 목적지 node를 가진 transition에서는 action/outcome을 수정할 수 없습니다: " + command.transitionId());
+    }
   }
 
   private String normalizeRequired(String value, String fieldName, int maxLength) {

--- a/backend/src/main/java/com/init/domainpack/application/UpdateWorkflowTransitionUseCase.java
+++ b/backend/src/main/java/com/init/domainpack/application/UpdateWorkflowTransitionUseCase.java
@@ -52,7 +52,7 @@ public class UpdateWorkflowTransitionUseCase {
 
     DomainPackVersion version =
         versionRepository
-            .findById(command.versionId())
+            .findByIdForUpdate(command.versionId())
             .orElseThrow(() -> new DomainPackVersionNotFoundException(command.versionId()));
     if (!version.getDomainPackId().equals(command.packId())) {
       throw new DomainPackVersionNotFoundException(command.versionId());
@@ -63,7 +63,7 @@ public class UpdateWorkflowTransitionUseCase {
 
     WorkflowDefinition workflow =
         workflowRepository
-            .findByIdAndDomainPackVersionId(command.workflowId(), command.versionId())
+            .findByIdAndDomainPackVersionIdForUpdate(command.workflowId(), command.versionId())
             .orElseThrow(() -> new WorkflowDefinitionNotFoundException(command.workflowId()));
 
     WorkflowGraphValidator.parseAndValidate(workflow.getGraphJson(), workflow.getWorkflowCode());

--- a/backend/src/main/java/com/init/domainpack/application/UpdateWorkflowUseCase.java
+++ b/backend/src/main/java/com/init/domainpack/application/UpdateWorkflowUseCase.java
@@ -39,7 +39,7 @@ public class UpdateWorkflowUseCase {
 
     DomainPackVersion version =
         versionRepository
-            .findById(command.versionId())
+            .findByIdForUpdate(command.versionId())
             .orElseThrow(
                 () -> new NotFoundException("NOT_FOUND", "버전을 찾을 수 없습니다: " + command.versionId()));
     if (!version.getDomainPackId().equals(command.packId())) {
@@ -59,7 +59,7 @@ public class UpdateWorkflowUseCase {
 
     WorkflowDefinition workflow =
         workflowRepository
-            .findByIdAndDomainPackVersionId(command.workflowId(), command.versionId())
+            .findByIdAndDomainPackVersionIdForUpdate(command.workflowId(), command.versionId())
             .orElseThrow(
                 () ->
                     new NotFoundException(

--- a/backend/src/main/java/com/init/domainpack/application/UpdateWorkflowUseCase.java
+++ b/backend/src/main/java/com/init/domainpack/application/UpdateWorkflowUseCase.java
@@ -75,9 +75,7 @@ public class UpdateWorkflowUseCase {
             .filter(n -> "ACTION".equals(n.type()))
             .map(WorkflowGraphValidator.GraphNode::policyRef)
             .collect(Collectors.toCollection(LinkedHashSet::new));
-    if (!policyRefs.isEmpty()) {
-      validator.validatePolicyCodes(command.versionId(), policyRefs);
-    }
+    validator.validatePolicyCodes(command.versionId(), policyRefs);
 
     String initialState = WorkflowGraphValidator.extractInitialState(parsed);
     String terminalStatesJson;

--- a/backend/src/main/java/com/init/domainpack/application/WorkflowGraphDocument.java
+++ b/backend/src/main/java/com/init/domainpack/application/WorkflowGraphDocument.java
@@ -9,11 +9,9 @@ import com.init.domainpack.application.exception.WorkflowActionNodePolicyRefMiss
 import com.init.domainpack.application.exception.WorkflowGraphJsonInvalidException;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -91,20 +89,6 @@ final class WorkflowGraphDocument {
 
   ObjectNode requireToNode(ObjectNode edge) {
     return requireNode(text(edge, "to"));
-  }
-
-  Set<String> collectActionPolicyRefs() {
-    Set<String> policyRefs = new LinkedHashSet<>();
-    for (ObjectNode node : nodeMap.values()) {
-      if (!NODE_TYPE_ACTION.equals(text(node, "type"))) {
-        continue;
-      }
-      String policyRef = text(node, POLICY_REF_FIELD);
-      if (policyRef != null && !policyRef.isBlank()) {
-        policyRefs.add(policyRef);
-      }
-    }
-    return policyRefs;
   }
 
   String toJson() {

--- a/backend/src/main/java/com/init/domainpack/application/WorkflowGraphDocument.java
+++ b/backend/src/main/java/com/init/domainpack/application/WorkflowGraphDocument.java
@@ -1,0 +1,205 @@
+package com.init.domainpack.application;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.init.domainpack.application.exception.WorkflowActionNodePolicyRefInvalidCharsException;
+import com.init.domainpack.application.exception.WorkflowActionNodePolicyRefMissingException;
+import com.init.domainpack.application.exception.WorkflowGraphJsonInvalidException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+final class WorkflowGraphDocument {
+
+  private static final Logger log = LoggerFactory.getLogger(WorkflowGraphDocument.class);
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final Pattern POLICY_REF_PATTERN = Pattern.compile("[A-Za-z0-9_-]+");
+
+  private final Long workflowId;
+  private final ObjectNode root;
+  private final Map<String, ObjectNode> nodeMap;
+
+  private WorkflowGraphDocument(Long workflowId, ObjectNode root, Map<String, ObjectNode> nodeMap) {
+    this.workflowId = workflowId;
+    this.root = root;
+    this.nodeMap = nodeMap;
+  }
+
+  static WorkflowGraphDocument parse(String graphJson, Long workflowId) {
+    if (graphJson == null) {
+      throw new WorkflowGraphJsonInvalidException(
+          workflowId, new IllegalArgumentException("graphJson is null"));
+    }
+    try {
+      JsonNode parsed = MAPPER.readTree(graphJson);
+      if (!(parsed instanceof ObjectNode objectNode)) {
+        throw new IllegalArgumentException("graphJson root must be an object");
+      }
+      return new WorkflowGraphDocument(
+          workflowId, objectNode, buildNodeMap(objectNode, workflowId));
+    } catch (JsonProcessingException | IllegalArgumentException e) {
+      throw new WorkflowGraphJsonInvalidException(workflowId, e);
+    }
+  }
+
+  List<WorkflowTransitionDetail> listTransitionDetails(Long versionId) {
+    List<WorkflowTransitionDetail> result = new ArrayList<>();
+    for (JsonNode edge : root.path("edges")) {
+      String edgeId = text(edge, "id");
+      if (edgeId == null || edgeId.isBlank()) {
+        log.warn(
+            "skipping edge with missing id: workflowId={}, versionId={}", workflowId, versionId);
+        continue;
+      }
+      result.add(buildDetail(edge, edgeId.trim(), versionId));
+    }
+    return result;
+  }
+
+  Optional<WorkflowTransitionDetail> findTransitionDetail(String transitionId, Long versionId) {
+    return findEdge(transitionId).map(edge -> buildDetail(edge, transitionId, versionId));
+  }
+
+  Optional<ObjectNode> findEdge(String transitionId) {
+    for (JsonNode edge : root.path("edges")) {
+      String edgeId = text(edge, "id");
+      if (transitionId.equals(edgeId == null ? null : edgeId.trim())) {
+        if (edge instanceof ObjectNode objectNode) {
+          return Optional.of(objectNode);
+        }
+        throw new WorkflowGraphJsonInvalidException(
+            workflowId, new IllegalArgumentException("edge must be an object"));
+      }
+    }
+    return Optional.empty();
+  }
+
+  ObjectNode requireFromNode(ObjectNode edge) {
+    return requireNode(text(edge, "from"));
+  }
+
+  ObjectNode requireToNode(ObjectNode edge) {
+    return requireNode(text(edge, "to"));
+  }
+
+  Set<String> collectActionPolicyRefs() {
+    Set<String> policyRefs = new LinkedHashSet<>();
+    for (ObjectNode node : nodeMap.values()) {
+      if (!"ACTION".equals(text(node, "type"))) {
+        continue;
+      }
+      String policyRef = text(node, "policyRef");
+      if (policyRef != null && !policyRef.isBlank()) {
+        policyRefs.add(policyRef);
+      }
+    }
+    return policyRefs;
+  }
+
+  String toJson() {
+    try {
+      return MAPPER.writeValueAsString(root);
+    } catch (JsonProcessingException e) {
+      throw new WorkflowGraphJsonInvalidException(workflowId, e);
+    }
+  }
+
+  void putText(ObjectNode node, String fieldName, String value) {
+    node.put(fieldName, value);
+  }
+
+  private WorkflowTransitionDetail buildDetail(JsonNode edge, String edgeId, Long versionId) {
+    String fromNodeId = trimToNull(text(edge, "from"));
+    String toNodeId = trimToNull(text(edge, "to"));
+    ObjectNode fromNode = fromNodeId == null ? null : nodeMap.get(fromNodeId);
+    ObjectNode toNode = toNodeId == null ? null : nodeMap.get(toNodeId);
+    String fromType = fromNode == null ? null : trimToNull(text(fromNode, "type"));
+    String toType = toNode == null ? null : trimToNull(text(toNode, "type"));
+
+    boolean conditionEditable = "DECISION".equals(fromType);
+    boolean actionEditable = "ACTION".equals(toType);
+    boolean outcomeEditable = "TERMINAL".equals(toType);
+
+    String label = conditionEditable ? text(edge, "label") : null;
+    String policyRef = actionEditable && toNode != null ? text(toNode, "policyRef") : null;
+    String outcomeState = outcomeEditable && toNode != null ? text(toNode, "state") : null;
+    String outcomeLabel = outcomeEditable && toNode != null ? text(toNode, "label") : null;
+
+    return new WorkflowTransitionDetail(
+        edgeId,
+        workflowId,
+        versionId,
+        fromNodeId,
+        toNodeId,
+        fromType,
+        toType,
+        label,
+        policyRef,
+        new WorkflowTransitionDetail.TransitionConditionDetail(conditionEditable, label),
+        new WorkflowTransitionDetail.TransitionActionDetail(actionEditable, policyRef),
+        new WorkflowTransitionDetail.TransitionOutcomeDetail(
+            outcomeEditable, outcomeState, outcomeLabel));
+  }
+
+  private static Map<String, ObjectNode> buildNodeMap(ObjectNode root, Long workflowId) {
+    Map<String, ObjectNode> nodes = new HashMap<>();
+    for (JsonNode node : root.path("nodes")) {
+      if (!(node instanceof ObjectNode objectNode)) {
+        throw new WorkflowGraphJsonInvalidException(
+            workflowId, new IllegalArgumentException("node must be an object"));
+      }
+      String nodeId = trimToNull(text(objectNode, "id"));
+      String nodeType = trimToNull(text(objectNode, "type"));
+      if (nodeId == null) {
+        continue;
+      }
+      nodes.put(nodeId, objectNode);
+      if ("ACTION".equals(nodeType)) {
+        validateActionPolicyRef(workflowId, nodeId, text(objectNode, "policyRef"));
+      }
+    }
+    return nodes;
+  }
+
+  private ObjectNode requireNode(String nodeId) {
+    ObjectNode node = nodeMap.get(trimToNull(nodeId));
+    if (node == null) {
+      throw new WorkflowGraphJsonInvalidException(
+          workflowId, new IllegalArgumentException("node not found: " + nodeId));
+    }
+    return node;
+  }
+
+  private static void validateActionPolicyRef(Long workflowId, String nodeId, String policyRef) {
+    if (policyRef == null || policyRef.isBlank()) {
+      throw new WorkflowActionNodePolicyRefMissingException(workflowId, nodeId);
+    }
+    if (!POLICY_REF_PATTERN.matcher(policyRef).matches()) {
+      throw new WorkflowActionNodePolicyRefInvalidCharsException(workflowId, nodeId);
+    }
+  }
+
+  private static String text(JsonNode node, String fieldName) {
+    if (node == null || !node.hasNonNull(fieldName)) {
+      return null;
+    }
+    return node.path(fieldName).asText(null);
+  }
+
+  private static String trimToNull(String value) {
+    if (value == null) {
+      return null;
+    }
+    String trimmed = value.trim();
+    return trimmed.isEmpty() ? null : trimmed;
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/application/WorkflowGraphDocument.java
+++ b/backend/src/main/java/com/init/domainpack/application/WorkflowGraphDocument.java
@@ -119,6 +119,20 @@ final class WorkflowGraphDocument {
     node.put(fieldName, value);
   }
 
+  boolean hasSingleInboundEdge(ObjectNode node) {
+    String nodeId = trimToNull(text(node, "id"));
+    if (nodeId == null) {
+      return false;
+    }
+    int inboundCount = 0;
+    for (JsonNode edge : root.path("edges")) {
+      if (nodeId.equals(trimToNull(text(edge, "to")))) {
+        inboundCount++;
+      }
+    }
+    return inboundCount == 1;
+  }
+
   private WorkflowTransitionDetail buildDetail(JsonNode edge, String edgeId, Long versionId) {
     String fromNodeId = trimToNull(text(edge, "from"));
     String toNodeId = trimToNull(text(edge, "to"));

--- a/backend/src/main/java/com/init/domainpack/application/WorkflowGraphDocument.java
+++ b/backend/src/main/java/com/init/domainpack/application/WorkflowGraphDocument.java
@@ -23,6 +23,8 @@ final class WorkflowGraphDocument {
   private static final Logger log = LoggerFactory.getLogger(WorkflowGraphDocument.class);
   private static final ObjectMapper MAPPER = new ObjectMapper();
   private static final Pattern POLICY_REF_PATTERN = Pattern.compile("[A-Za-z0-9_-]+");
+  private static final String NODE_TYPE_ACTION = "ACTION";
+  private static final String POLICY_REF_FIELD = "policyRef";
 
   private final Long workflowId;
   private final ObjectNode root;
@@ -94,10 +96,10 @@ final class WorkflowGraphDocument {
   Set<String> collectActionPolicyRefs() {
     Set<String> policyRefs = new LinkedHashSet<>();
     for (ObjectNode node : nodeMap.values()) {
-      if (!"ACTION".equals(text(node, "type"))) {
+      if (!NODE_TYPE_ACTION.equals(text(node, "type"))) {
         continue;
       }
-      String policyRef = text(node, "policyRef");
+      String policyRef = text(node, POLICY_REF_FIELD);
       if (policyRef != null && !policyRef.isBlank()) {
         policyRefs.add(policyRef);
       }
@@ -126,11 +128,11 @@ final class WorkflowGraphDocument {
     String toType = toNode == null ? null : trimToNull(text(toNode, "type"));
 
     boolean conditionEditable = "DECISION".equals(fromType);
-    boolean actionEditable = "ACTION".equals(toType);
+    boolean actionEditable = NODE_TYPE_ACTION.equals(toType);
     boolean outcomeEditable = "TERMINAL".equals(toType);
 
     String label = conditionEditable ? text(edge, "label") : null;
-    String policyRef = actionEditable && toNode != null ? text(toNode, "policyRef") : null;
+    String policyRef = actionEditable && toNode != null ? text(toNode, POLICY_REF_FIELD) : null;
     String outcomeState = outcomeEditable && toNode != null ? text(toNode, "state") : null;
     String outcomeLabel = outcomeEditable && toNode != null ? text(toNode, "label") : null;
 
@@ -163,8 +165,8 @@ final class WorkflowGraphDocument {
         continue;
       }
       nodes.put(nodeId, objectNode);
-      if ("ACTION".equals(nodeType)) {
-        validateActionPolicyRef(workflowId, nodeId, text(objectNode, "policyRef"));
+      if (NODE_TYPE_ACTION.equals(nodeType)) {
+        validateActionPolicyRef(workflowId, nodeId, text(objectNode, POLICY_REF_FIELD));
       }
     }
     return nodes;

--- a/backend/src/main/java/com/init/domainpack/application/WorkflowTransitionDetail.java
+++ b/backend/src/main/java/com/init/domainpack/application/WorkflowTransitionDetail.java
@@ -1,19 +1,7 @@
 package com.init.domainpack.application;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.init.domainpack.application.exception.WorkflowActionNodePolicyRefInvalidCharsException;
-import com.init.domainpack.application.exception.WorkflowActionNodePolicyRefMissingException;
-import com.init.domainpack.application.exception.WorkflowGraphJsonInvalidException;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.regex.Pattern;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public record WorkflowTransitionDetail(
     String id,
@@ -21,96 +9,51 @@ public record WorkflowTransitionDetail(
     Long domainPackVersionId,
     String from,
     String to,
+    String fromType,
+    String toType,
     String label,
-    String toPolicyRef) {
+    String toPolicyRef,
+    TransitionConditionDetail condition,
+    TransitionActionDetail action,
+    TransitionOutcomeDetail outcome) {
 
-  private static final Logger log = LoggerFactory.getLogger(WorkflowTransitionDetail.class);
-  private static final ObjectMapper MAPPER = new ObjectMapper();
-  private static final Pattern POLICY_REF_PATTERN = Pattern.compile("[A-Za-z0-9_-]+");
+  public WorkflowTransitionDetail(
+      String id,
+      Long workflowDefinitionId,
+      Long domainPackVersionId,
+      String from,
+      String to,
+      String label,
+      String toPolicyRef) {
+    this(
+        id,
+        workflowDefinitionId,
+        domainPackVersionId,
+        from,
+        to,
+        null,
+        null,
+        label,
+        toPolicyRef,
+        new TransitionConditionDetail(label != null, label),
+        new TransitionActionDetail(toPolicyRef != null, toPolicyRef),
+        new TransitionOutcomeDetail(false, null, null));
+  }
 
   static List<WorkflowTransitionDetail> listFromGraphJson(
       String graphJson, Long workflowId, Long versionId) {
-    if (graphJson == null) {
-      throw new WorkflowGraphJsonInvalidException(
-          workflowId, new IllegalArgumentException("graphJson is null"));
-    }
-    try {
-      JsonNode root = MAPPER.readTree(graphJson);
-      NodeMaps nodeMaps = buildNodeMaps(root, workflowId);
-      List<WorkflowTransitionDetail> result = new ArrayList<>();
-      for (JsonNode e : root.path("edges")) {
-        String edgeId = e.hasNonNull("id") ? e.path("id").asText(null).trim() : null;
-        if (edgeId == null || edgeId.isBlank()) {
-          log.warn(
-              "skipping edge with missing id: workflowId={}, versionId={}", workflowId, versionId);
-          continue;
-        }
-        result.add(buildDetail(e, edgeId, workflowId, versionId, nodeMaps));
-      }
-      return result;
-    } catch (IOException | IllegalArgumentException e) {
-      throw new WorkflowGraphJsonInvalidException(workflowId, e);
-    }
+    return WorkflowGraphDocument.parse(graphJson, workflowId).listTransitionDetails(versionId);
   }
 
   static Optional<WorkflowTransitionDetail> fromGraphJson(
       String graphJson, String transitionId, Long workflowId, Long versionId) {
-    if (graphJson == null) {
-      throw new WorkflowGraphJsonInvalidException(
-          workflowId, new IllegalArgumentException("graphJson is null"));
-    }
-    try {
-      JsonNode root = MAPPER.readTree(graphJson);
-      NodeMaps nodeMaps = buildNodeMaps(root, workflowId);
-      for (JsonNode e : root.path("edges")) {
-        String edgeId = e.hasNonNull("id") ? e.path("id").asText(null).trim() : null;
-        if (transitionId.equals(edgeId)) {
-          return Optional.of(buildDetail(e, edgeId, workflowId, versionId, nodeMaps));
-        }
-      }
-      return Optional.empty();
-    } catch (IOException | IllegalArgumentException e) {
-      throw new WorkflowGraphJsonInvalidException(workflowId, e);
-    }
+    return WorkflowGraphDocument.parse(graphJson, workflowId)
+        .findTransitionDetail(transitionId, versionId);
   }
 
-  private static NodeMaps buildNodeMaps(JsonNode root, Long workflowId) {
-    Map<String, String> nodeTypeMap = new HashMap<>();
-    Map<String, String> actionPolicyRefMap = new HashMap<>();
-    for (JsonNode n : root.path("nodes")) {
-      String nodeId = n.path("id").asText().trim();
-      String nodeType = n.path("type").asText().trim();
-      nodeTypeMap.put(nodeId, nodeType);
-      if ("ACTION".equals(nodeType)) {
-        String policyRef = n.hasNonNull("policyRef") ? n.path("policyRef").asText(null) : null;
-        if (policyRef == null || policyRef.isBlank()) {
-          throw new WorkflowActionNodePolicyRefMissingException(workflowId, nodeId);
-        }
-        if (!POLICY_REF_PATTERN.matcher(policyRef).matches()) {
-          throw new WorkflowActionNodePolicyRefInvalidCharsException(workflowId, nodeId);
-        }
-        actionPolicyRefMap.put(nodeId, policyRef);
-      }
-    }
-    return new NodeMaps(nodeTypeMap, actionPolicyRefMap);
-  }
+  public record TransitionConditionDetail(boolean editable, String label) {}
 
-  private static WorkflowTransitionDetail buildDetail(
-      JsonNode e, String edgeId, Long workflowId, Long versionId, NodeMaps nodeMaps) {
-    String fromNodeId = e.path("from").asText().trim();
-    String toNodeId = e.path("to").asText().trim();
-    String label =
-        "DECISION".equals(nodeMaps.nodeTypeMap().get(fromNodeId))
-            ? (e.hasNonNull("label") ? e.path("label").asText(null) : null)
-            : null;
-    String toPolicyRef =
-        "ACTION".equals(nodeMaps.nodeTypeMap().get(toNodeId))
-            ? nodeMaps.actionPolicyRefMap().get(toNodeId)
-            : null;
-    return new WorkflowTransitionDetail(
-        edgeId, workflowId, versionId, fromNodeId, toNodeId, label, toPolicyRef);
-  }
+  public record TransitionActionDetail(boolean editable, String policyRef) {}
 
-  private record NodeMaps(
-      Map<String, String> nodeTypeMap, Map<String, String> actionPolicyRefMap) {}
+  public record TransitionOutcomeDetail(boolean editable, String state, String label) {}
 }

--- a/backend/src/main/java/com/init/domainpack/application/exception/WorkflowTransitionActionNotEditableException.java
+++ b/backend/src/main/java/com/init/domainpack/application/exception/WorkflowTransitionActionNotEditableException.java
@@ -1,0 +1,11 @@
+package com.init.domainpack.application.exception;
+
+import com.init.shared.application.exception.BadRequestException;
+
+public class WorkflowTransitionActionNotEditableException extends BadRequestException {
+  public WorkflowTransitionActionNotEditableException(String transitionId) {
+    super(
+        "WORKFLOW_TRANSITION_ACTION_NOT_EDITABLE",
+        "ACTION 목적지 transition에서만 action을 수정할 수 있습니다: " + transitionId);
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/application/exception/WorkflowTransitionActionNotEditableException.java
+++ b/backend/src/main/java/com/init/domainpack/application/exception/WorkflowTransitionActionNotEditableException.java
@@ -2,6 +2,7 @@ package com.init.domainpack.application.exception;
 
 import com.init.shared.application.exception.BadRequestException;
 
+@SuppressWarnings("java:S110")
 public class WorkflowTransitionActionNotEditableException extends BadRequestException {
   public WorkflowTransitionActionNotEditableException(String transitionId) {
     super(

--- a/backend/src/main/java/com/init/domainpack/application/exception/WorkflowTransitionConditionNotEditableException.java
+++ b/backend/src/main/java/com/init/domainpack/application/exception/WorkflowTransitionConditionNotEditableException.java
@@ -1,0 +1,11 @@
+package com.init.domainpack.application.exception;
+
+import com.init.shared.application.exception.BadRequestException;
+
+public class WorkflowTransitionConditionNotEditableException extends BadRequestException {
+  public WorkflowTransitionConditionNotEditableException(String transitionId) {
+    super(
+        "WORKFLOW_TRANSITION_CONDITION_NOT_EDITABLE",
+        "DECISION 발신 transition에서만 condition을 수정할 수 있습니다: " + transitionId);
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/application/exception/WorkflowTransitionConditionNotEditableException.java
+++ b/backend/src/main/java/com/init/domainpack/application/exception/WorkflowTransitionConditionNotEditableException.java
@@ -2,6 +2,7 @@ package com.init.domainpack.application.exception;
 
 import com.init.shared.application.exception.BadRequestException;
 
+@SuppressWarnings("java:S110")
 public class WorkflowTransitionConditionNotEditableException extends BadRequestException {
   public WorkflowTransitionConditionNotEditableException(String transitionId) {
     super(

--- a/backend/src/main/java/com/init/domainpack/application/exception/WorkflowTransitionNotFoundException.java
+++ b/backend/src/main/java/com/init/domainpack/application/exception/WorkflowTransitionNotFoundException.java
@@ -2,6 +2,7 @@ package com.init.domainpack.application.exception;
 
 import com.init.shared.application.exception.NotFoundException;
 
+@SuppressWarnings("java:S110")
 public class WorkflowTransitionNotFoundException extends NotFoundException {
   public WorkflowTransitionNotFoundException(String transitionId) {
     super("WORKFLOW_TRANSITION_NOT_FOUND", "워크플로우 전환을 찾을 수 없습니다: " + transitionId);

--- a/backend/src/main/java/com/init/domainpack/application/exception/WorkflowTransitionOutcomeEmptyException.java
+++ b/backend/src/main/java/com/init/domainpack/application/exception/WorkflowTransitionOutcomeEmptyException.java
@@ -2,6 +2,7 @@ package com.init.domainpack.application.exception;
 
 import com.init.shared.application.exception.BadRequestException;
 
+@SuppressWarnings("java:S110")
 public class WorkflowTransitionOutcomeEmptyException extends BadRequestException {
   public WorkflowTransitionOutcomeEmptyException() {
     super("WORKFLOW_TRANSITION_OUTCOME_EMPTY", "outcome에는 state 또는 label 중 하나가 필요합니다.");

--- a/backend/src/main/java/com/init/domainpack/application/exception/WorkflowTransitionOutcomeEmptyException.java
+++ b/backend/src/main/java/com/init/domainpack/application/exception/WorkflowTransitionOutcomeEmptyException.java
@@ -1,0 +1,9 @@
+package com.init.domainpack.application.exception;
+
+import com.init.shared.application.exception.BadRequestException;
+
+public class WorkflowTransitionOutcomeEmptyException extends BadRequestException {
+  public WorkflowTransitionOutcomeEmptyException() {
+    super("WORKFLOW_TRANSITION_OUTCOME_EMPTY", "outcome에는 state 또는 label 중 하나가 필요합니다.");
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/application/exception/WorkflowTransitionOutcomeNotEditableException.java
+++ b/backend/src/main/java/com/init/domainpack/application/exception/WorkflowTransitionOutcomeNotEditableException.java
@@ -2,6 +2,7 @@ package com.init.domainpack.application.exception;
 
 import com.init.shared.application.exception.BadRequestException;
 
+@SuppressWarnings("java:S110")
 public class WorkflowTransitionOutcomeNotEditableException extends BadRequestException {
   public WorkflowTransitionOutcomeNotEditableException(String transitionId) {
     super(

--- a/backend/src/main/java/com/init/domainpack/application/exception/WorkflowTransitionOutcomeNotEditableException.java
+++ b/backend/src/main/java/com/init/domainpack/application/exception/WorkflowTransitionOutcomeNotEditableException.java
@@ -1,0 +1,11 @@
+package com.init.domainpack.application.exception;
+
+import com.init.shared.application.exception.BadRequestException;
+
+public class WorkflowTransitionOutcomeNotEditableException extends BadRequestException {
+  public WorkflowTransitionOutcomeNotEditableException(String transitionId) {
+    super(
+        "WORKFLOW_TRANSITION_OUTCOME_NOT_EDITABLE",
+        "TERMINAL 목적지 transition에서만 outcome을 수정할 수 있습니다: " + transitionId);
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/application/exception/WorkflowTransitionOutcomeStateInvalidCharsException.java
+++ b/backend/src/main/java/com/init/domainpack/application/exception/WorkflowTransitionOutcomeStateInvalidCharsException.java
@@ -1,0 +1,11 @@
+package com.init.domainpack.application.exception;
+
+import com.init.shared.application.exception.BadRequestException;
+
+public class WorkflowTransitionOutcomeStateInvalidCharsException extends BadRequestException {
+  public WorkflowTransitionOutcomeStateInvalidCharsException(String state) {
+    super(
+        "WORKFLOW_TRANSITION_OUTCOME_STATE_INVALID_CHARS",
+        "outcome.state는 영문, 숫자, _, -만 사용할 수 있습니다: " + state);
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/application/exception/WorkflowTransitionOutcomeStateInvalidCharsException.java
+++ b/backend/src/main/java/com/init/domainpack/application/exception/WorkflowTransitionOutcomeStateInvalidCharsException.java
@@ -2,6 +2,7 @@ package com.init.domainpack.application.exception;
 
 import com.init.shared.application.exception.BadRequestException;
 
+@SuppressWarnings("java:S110")
 public class WorkflowTransitionOutcomeStateInvalidCharsException extends BadRequestException {
   public WorkflowTransitionOutcomeStateInvalidCharsException(String state) {
     super(

--- a/backend/src/main/java/com/init/domainpack/application/exception/WorkflowTransitionPatchEmptyException.java
+++ b/backend/src/main/java/com/init/domainpack/application/exception/WorkflowTransitionPatchEmptyException.java
@@ -1,0 +1,9 @@
+package com.init.domainpack.application.exception;
+
+import com.init.shared.application.exception.BadRequestException;
+
+public class WorkflowTransitionPatchEmptyException extends BadRequestException {
+  public WorkflowTransitionPatchEmptyException() {
+    super("WORKFLOW_TRANSITION_PATCH_EMPTY", "수정할 transition 필드가 없습니다.");
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/application/exception/WorkflowTransitionPatchEmptyException.java
+++ b/backend/src/main/java/com/init/domainpack/application/exception/WorkflowTransitionPatchEmptyException.java
@@ -2,6 +2,7 @@ package com.init.domainpack.application.exception;
 
 import com.init.shared.application.exception.BadRequestException;
 
+@SuppressWarnings("java:S110")
 public class WorkflowTransitionPatchEmptyException extends BadRequestException {
   public WorkflowTransitionPatchEmptyException() {
     super("WORKFLOW_TRANSITION_PATCH_EMPTY", "수정할 transition 필드가 없습니다.");

--- a/backend/src/main/java/com/init/domainpack/domain/repository/WorkflowDefinitionRepository.java
+++ b/backend/src/main/java/com/init/domainpack/domain/repository/WorkflowDefinitionRepository.java
@@ -19,6 +19,9 @@ public interface WorkflowDefinitionRepository {
 
   Optional<WorkflowDefinition> findByIdAndDomainPackVersionId(Long id, Long domainPackVersionId);
 
+  Optional<WorkflowDefinition> findByIdAndDomainPackVersionIdForUpdate(
+      Long id, Long domainPackVersionId);
+
   boolean existsByDomainPackVersionIdAndPolicyRef(Long versionId, String policyCode);
 
   long countByDomainPackVersionId(Long domainPackVersionId);

--- a/backend/src/main/java/com/init/domainpack/infrastructure/persistence/JpaWorkflowDefinitionRepository.java
+++ b/backend/src/main/java/com/init/domainpack/infrastructure/persistence/JpaWorkflowDefinitionRepository.java
@@ -3,9 +3,11 @@ package com.init.domainpack.infrastructure.persistence;
 import com.init.domainpack.domain.model.WorkflowDefinition;
 import com.init.domainpack.domain.repository.WorkflowDefinitionRepository;
 import com.init.domainpack.domain.repository.WorkflowDefinitionSummaryRow;
+import jakarta.persistence.LockModeType;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -23,6 +25,14 @@ public interface JpaWorkflowDefinitionRepository
 
   @Override
   Optional<WorkflowDefinition> findByIdAndDomainPackVersionId(Long id, Long domainPackVersionId);
+
+  @Override
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query(
+      "SELECT w FROM WorkflowDefinition w"
+          + " WHERE w.id = :id AND w.domainPackVersionId = :domainPackVersionId")
+  Optional<WorkflowDefinition> findByIdAndDomainPackVersionIdForUpdate(
+      @Param("id") Long id, @Param("domainPackVersionId") Long domainPackVersionId);
 
   @Override
   @Query(

--- a/backend/src/main/java/com/init/domainpack/presentation/WorkflowDefinitionController.java
+++ b/backend/src/main/java/com/init/domainpack/presentation/WorkflowDefinitionController.java
@@ -1,5 +1,6 @@
 package com.init.domainpack.presentation;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.init.domainpack.application.GetWorkflowDefinitionListQuery;
 import com.init.domainpack.application.GetWorkflowDefinitionListUseCase;
 import com.init.domainpack.application.GetWorkflowDefinitionQuery;
@@ -9,11 +10,15 @@ import com.init.domainpack.application.GetWorkflowTransitionListUseCase;
 import com.init.domainpack.application.GetWorkflowTransitionQuery;
 import com.init.domainpack.application.GetWorkflowTransitionUseCase;
 import com.init.domainpack.application.UpdateWorkflowCommand;
+import com.init.domainpack.application.UpdateWorkflowTransitionCommand;
+import com.init.domainpack.application.UpdateWorkflowTransitionUseCase;
 import com.init.domainpack.application.UpdateWorkflowUseCase;
 import com.init.domainpack.application.WorkflowDefinitionDetail;
 import com.init.domainpack.application.WorkflowDefinitionSummary;
 import com.init.domainpack.application.WorkflowTransitionDetail;
 import com.init.domainpack.presentation.dto.UpdateWorkflowRequest;
+import com.init.domainpack.presentation.dto.UpdateWorkflowTransitionRequest;
+import com.init.shared.application.exception.BadRequestException;
 import com.init.shared.presentation.AuthenticationUtils;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -36,18 +41,21 @@ public class WorkflowDefinitionController {
   private final UpdateWorkflowUseCase updateUseCase;
   private final GetWorkflowTransitionUseCase transitionUseCase;
   private final GetWorkflowTransitionListUseCase transitionListUseCase;
+  private final UpdateWorkflowTransitionUseCase updateTransitionUseCase;
 
   public WorkflowDefinitionController(
       GetWorkflowDefinitionListUseCase listUseCase,
       GetWorkflowDefinitionUseCase detailUseCase,
       UpdateWorkflowUseCase updateUseCase,
       GetWorkflowTransitionUseCase transitionUseCase,
-      GetWorkflowTransitionListUseCase transitionListUseCase) {
+      GetWorkflowTransitionListUseCase transitionListUseCase,
+      UpdateWorkflowTransitionUseCase updateTransitionUseCase) {
     this.listUseCase = listUseCase;
     this.detailUseCase = detailUseCase;
     this.updateUseCase = updateUseCase;
     this.transitionUseCase = transitionUseCase;
     this.transitionListUseCase = transitionListUseCase;
+    this.updateTransitionUseCase = updateTransitionUseCase;
   }
 
   @GetMapping
@@ -128,5 +136,136 @@ public class WorkflowDefinitionController {
                 request.description(),
                 graphJsonStr));
     return ResponseEntity.ok(result);
+  }
+
+  @PatchMapping("/{workflowId}/transitions/{transitionId}")
+  public ResponseEntity<WorkflowTransitionDetail> updateTransition(
+      @PathVariable Long workspaceId,
+      @PathVariable Long packId,
+      @PathVariable Long versionId,
+      @PathVariable Long workflowId,
+      @PathVariable String transitionId,
+      @RequestBody JsonNode requestBody,
+      Authentication authentication) {
+    Long userId = AuthenticationUtils.getUserId(authentication);
+    UpdateWorkflowTransitionRequest request = parseTransitionPatchRequest(requestBody);
+    UpdateWorkflowTransitionCommand command =
+        new UpdateWorkflowTransitionCommand(
+            workspaceId,
+            packId,
+            versionId,
+            workflowId,
+            transitionId,
+            userId,
+            toConditionCommand(request.condition()),
+            toActionCommand(request.action()),
+            toOutcomeCommand(request.outcome()));
+    WorkflowTransitionDetail result = updateTransitionUseCase.execute(command);
+    return ResponseEntity.ok(result);
+  }
+
+  private UpdateWorkflowTransitionCommand.ConditionPatch toConditionCommand(
+      UpdateWorkflowTransitionRequest.ConditionPatch condition) {
+    if (condition == null) {
+      return null;
+    }
+    return new UpdateWorkflowTransitionCommand.ConditionPatch(condition.label());
+  }
+
+  private UpdateWorkflowTransitionCommand.ActionPatch toActionCommand(
+      UpdateWorkflowTransitionRequest.ActionPatch action) {
+    if (action == null) {
+      return null;
+    }
+    return new UpdateWorkflowTransitionCommand.ActionPatch(action.policyRef());
+  }
+
+  private UpdateWorkflowTransitionCommand.OutcomePatch toOutcomeCommand(
+      UpdateWorkflowTransitionRequest.OutcomePatch outcome) {
+    if (outcome == null) {
+      return null;
+    }
+    return new UpdateWorkflowTransitionCommand.OutcomePatch(outcome.state(), outcome.label());
+  }
+
+  private UpdateWorkflowTransitionRequest parseTransitionPatchRequest(JsonNode body) {
+    if (body == null || !body.isObject()) {
+      throw validationError("요청 본문은 JSON object여야 합니다.");
+    }
+    return new UpdateWorkflowTransitionRequest(
+        parseConditionPatch(body), parseActionPatch(body), parseOutcomePatch(body));
+  }
+
+  private UpdateWorkflowTransitionRequest.ConditionPatch parseConditionPatch(JsonNode body) {
+    if (!body.has("condition")) {
+      return null;
+    }
+    JsonNode section = requireObjectSection(body, "condition");
+    return new UpdateWorkflowTransitionRequest.ConditionPatch(
+        requireTextField(section, "condition.label", "label", 255));
+  }
+
+  private UpdateWorkflowTransitionRequest.ActionPatch parseActionPatch(JsonNode body) {
+    if (!body.has("action")) {
+      return null;
+    }
+    JsonNode section = requireObjectSection(body, "action");
+    return new UpdateWorkflowTransitionRequest.ActionPatch(
+        requireTextField(section, "action.policyRef", "policyRef", 100));
+  }
+
+  private UpdateWorkflowTransitionRequest.OutcomePatch parseOutcomePatch(JsonNode body) {
+    if (!body.has("outcome")) {
+      return null;
+    }
+    JsonNode section = requireObjectSection(body, "outcome");
+    return new UpdateWorkflowTransitionRequest.OutcomePatch(
+        optionalTextField(section, "outcome.state", "state", 100),
+        optionalTextField(section, "outcome.label", "label", 255));
+  }
+
+  private JsonNode requireObjectSection(JsonNode body, String sectionName) {
+    JsonNode section = body.get(sectionName);
+    if (section == null || section.isNull() || !section.isObject()) {
+      throw validationError(sectionName + "은 JSON object여야 합니다.");
+    }
+    return section;
+  }
+
+  private String requireTextField(
+      JsonNode section, String displayName, String fieldName, int maxLength) {
+    if (!section.has(fieldName) || section.get(fieldName).isNull()) {
+      throw validationError(displayName + "은 필수 항목입니다.");
+    }
+    return validateTextField(section.get(fieldName), displayName, maxLength);
+  }
+
+  private String optionalTextField(
+      JsonNode section, String displayName, String fieldName, int maxLength) {
+    if (!section.has(fieldName)) {
+      return null;
+    }
+    if (section.get(fieldName).isNull()) {
+      throw validationError(displayName + "은 null일 수 없습니다.");
+    }
+    return validateTextField(section.get(fieldName), displayName, maxLength);
+  }
+
+  private String validateTextField(JsonNode value, String displayName, int maxLength) {
+    if (!value.isTextual()) {
+      throw validationError(displayName + "은 문자열이어야 합니다.");
+    }
+    String trimmed = value.asText().trim();
+    if (trimmed.isBlank()) {
+      throw validationError(displayName + "은 빈 값일 수 없습니다.");
+    }
+    if (trimmed.length() > maxLength) {
+      throw validationError(displayName + "은 " + maxLength + "자 이하여야 합니다.");
+    }
+    return trimmed;
+  }
+
+  private BadRequestException validationError(String message) {
+    return new BadRequestException("VALIDATION_ERROR", message);
   }
 }

--- a/backend/src/main/java/com/init/domainpack/presentation/dto/UpdateWorkflowTransitionRequest.java
+++ b/backend/src/main/java/com/init/domainpack/presentation/dto/UpdateWorkflowTransitionRequest.java
@@ -1,29 +1,11 @@
 package com.init.domainpack.presentation.dto;
 
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
-
 public record UpdateWorkflowTransitionRequest(
-    @Valid ConditionPatch condition, @Valid ActionPatch action, @Valid OutcomePatch outcome) {
+    ConditionPatch condition, ActionPatch action, OutcomePatch outcome) {
 
-  public record ConditionPatch(
-      @NotBlank(message = "condition.label은 필수 항목입니다.")
-          @Size(max = 255, message = "condition.label은 255자 이하여야 합니다.")
-          String label) {}
+  public record ConditionPatch(String label) {}
 
-  public record ActionPatch(
-      @NotBlank(message = "action.policyRef는 필수 항목입니다.")
-          @Size(max = 100, message = "action.policyRef는 100자 이하여야 합니다.")
-          @Pattern(
-              regexp = "[A-Za-z0-9_-]+",
-              message = "action.policyRef는 영문, 숫자, _, -만 사용할 수 있습니다.")
-          String policyRef) {}
+  public record ActionPatch(String policyRef) {}
 
-  public record OutcomePatch(
-      @Size(max = 100, message = "outcome.state는 100자 이하여야 합니다.")
-          @Pattern(regexp = "[A-Za-z0-9_-]+", message = "outcome.state는 영문, 숫자, _, -만 사용할 수 있습니다.")
-          String state,
-      @Size(max = 255, message = "outcome.label은 255자 이하여야 합니다.") String label) {}
+  public record OutcomePatch(String state, String label) {}
 }

--- a/backend/src/main/java/com/init/domainpack/presentation/dto/UpdateWorkflowTransitionRequest.java
+++ b/backend/src/main/java/com/init/domainpack/presentation/dto/UpdateWorkflowTransitionRequest.java
@@ -1,0 +1,29 @@
+package com.init.domainpack.presentation.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record UpdateWorkflowTransitionRequest(
+    @Valid ConditionPatch condition, @Valid ActionPatch action, @Valid OutcomePatch outcome) {
+
+  public record ConditionPatch(
+      @NotBlank(message = "condition.label은 필수 항목입니다.")
+          @Size(max = 255, message = "condition.label은 255자 이하여야 합니다.")
+          String label) {}
+
+  public record ActionPatch(
+      @NotBlank(message = "action.policyRef는 필수 항목입니다.")
+          @Size(max = 100, message = "action.policyRef는 100자 이하여야 합니다.")
+          @Pattern(
+              regexp = "[A-Za-z0-9_-]+",
+              message = "action.policyRef는 영문, 숫자, _, -만 사용할 수 있습니다.")
+          String policyRef) {}
+
+  public record OutcomePatch(
+      @Size(max = 100, message = "outcome.state는 100자 이하여야 합니다.")
+          @Pattern(regexp = "[A-Za-z0-9_-]+", message = "outcome.state는 영문, 숫자, _, -만 사용할 수 있습니다.")
+          String state,
+      @Size(max = 255, message = "outcome.label은 255자 이하여야 합니다.") String label) {}
+}

--- a/backend/src/main/java/com/init/shared/presentation/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/init/shared/presentation/GlobalExceptionHandler.java
@@ -17,6 +17,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.validation.FieldError;
@@ -138,6 +139,13 @@ public class GlobalExceptionHandler {
             .toList();
     return ResponseEntity.status(HttpStatus.BAD_REQUEST)
         .body(new ValidationErrorResponse("VALIDATION_ERROR", errors));
+  }
+
+  @ExceptionHandler(HttpMessageNotReadableException.class)
+  public ResponseEntity<ErrorResponse> handleHttpMessageNotReadable(
+      HttpMessageNotReadableException ex) {
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+        .body(new ErrorResponse("VALIDATION_ERROR", "요청 본문이 유효한 JSON 형식이 아닙니다."));
   }
 
   @ExceptionHandler(Exception.class)

--- a/backend/src/test/java/com/init/domainpack/application/GetWorkflowTransitionListUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/GetWorkflowTransitionListUseCaseTest.java
@@ -113,16 +113,24 @@ class GetWorkflowTransitionListUseCaseTest {
     assertThat(first.domainPackVersionId()).isEqualTo(VERSION_ID);
     assertThat(first.from()).isEqualTo("check");
     assertThat(first.to()).isEqualTo("answer");
+    assertThat(first.fromType()).isEqualTo("DECISION");
+    assertThat(first.toType()).isEqualTo("ACTION");
     assertThat(first.label()).isEqualTo("eligible");
     assertThat(first.toPolicyRef()).isEqualTo("refund_policy");
+    assertThat(first.condition().editable()).isTrue();
+    assertThat(first.action().editable()).isTrue();
+    assertThat(first.outcome().editable()).isFalse();
 
     WorkflowTransitionDetail second = result.get(1);
     assertThat(second.label()).isEqualTo("not_eligible");
     assertThat(second.toPolicyRef()).isEqualTo("handoff_policy");
 
     WorkflowTransitionDetail third = result.get(2);
+    assertThat(third.fromType()).isEqualTo("ACTION");
+    assertThat(third.toType()).isEqualTo("TERMINAL");
     assertThat(third.label()).isNull();
     assertThat(third.toPolicyRef()).isNull();
+    assertThat(third.outcome().editable()).isTrue();
   }
 
   @Test

--- a/backend/src/test/java/com/init/domainpack/application/GetWorkflowTransitionUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/GetWorkflowTransitionUseCaseTest.java
@@ -94,8 +94,15 @@ class GetWorkflowTransitionUseCaseTest {
     assertThat(result.domainPackVersionId()).isEqualTo(VERSION_ID);
     assertThat(result.from()).isEqualTo("check");
     assertThat(result.to()).isEqualTo("answer");
+    assertThat(result.fromType()).isEqualTo("DECISION");
+    assertThat(result.toType()).isEqualTo("ACTION");
     assertThat(result.label()).isEqualTo("eligible");
     assertThat(result.toPolicyRef()).isEqualTo("refund_policy");
+    assertThat(result.condition().editable()).isTrue();
+    assertThat(result.condition().label()).isEqualTo("eligible");
+    assertThat(result.action().editable()).isTrue();
+    assertThat(result.action().policyRef()).isEqualTo("refund_policy");
+    assertThat(result.outcome().editable()).isFalse();
   }
 
   @Test
@@ -111,6 +118,10 @@ class GetWorkflowTransitionUseCaseTest {
 
     // then
     assertThat(result.label()).isNull();
+    assertThat(result.fromType()).isEqualTo("START");
+    assertThat(result.toType()).isEqualTo("TERMINAL");
+    assertThat(result.condition().editable()).isFalse();
+    assertThat(result.outcome().editable()).isTrue();
   }
 
   @Test

--- a/backend/src/test/java/com/init/domainpack/application/UpdateWorkflowTransitionUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/UpdateWorkflowTransitionUseCaseTest.java
@@ -60,6 +60,30 @@ class UpdateWorkflowTransitionUseCaseTest {
           + "{\"id\":\"e_check_reject\",\"from\":\"check\",\"to\":\"end_reject\",\"label\":\"불가능\"},"
           + "{\"id\":\"e_action_end\",\"from\":\"action\",\"to\":\"end_ok\"}]}";
 
+  private static final String SHARED_ACTION_TARGET_GRAPH =
+      "{\"direction\":\"LR\","
+          + "\"nodes\":["
+          + "{\"id\":\"start\",\"type\":\"START\"},"
+          + "{\"id\":\"check\",\"type\":\"DECISION\"},"
+          + "{\"id\":\"action\",\"type\":\"ACTION\",\"policyRef\":\"policy_old\"},"
+          + "{\"id\":\"end\",\"type\":\"TERMINAL\",\"state\":\"done\",\"label\":\"완료\"}],"
+          + "\"edges\":["
+          + "{\"id\":\"e_start_check\",\"from\":\"start\",\"to\":\"check\"},"
+          + "{\"id\":\"e_start_action\",\"from\":\"start\",\"to\":\"action\"},"
+          + "{\"id\":\"e_check_action\",\"from\":\"check\",\"to\":\"action\",\"label\":\"가능\"},"
+          + "{\"id\":\"e_action_end\",\"from\":\"action\",\"to\":\"end\"}]}";
+
+  private static final String SHARED_TERMINAL_TARGET_GRAPH =
+      "{\"direction\":\"LR\","
+          + "\"nodes\":["
+          + "{\"id\":\"start\",\"type\":\"START\"},"
+          + "{\"id\":\"check\",\"type\":\"DECISION\"},"
+          + "{\"id\":\"end\",\"type\":\"TERMINAL\",\"state\":\"done\",\"label\":\"완료\"}],"
+          + "\"edges\":["
+          + "{\"id\":\"e_start_check\",\"from\":\"start\",\"to\":\"check\"},"
+          + "{\"id\":\"e_start_end\",\"from\":\"start\",\"to\":\"end\"},"
+          + "{\"id\":\"e_check_end\",\"from\":\"check\",\"to\":\"end\",\"label\":\"가능\"}]}";
+
   private final ObjectMapper objectMapper = new ObjectMapper();
 
   @Mock private DomainPackValidator validator;
@@ -286,6 +310,44 @@ class UpdateWorkflowTransitionUseCaseTest {
   }
 
   @Test
+  @DisplayName("공유 ACTION 목적지 transition에는 action을 수정할 수 없다")
+  void should_WORKFLOW_TRANSITION_TARGET_SHARED_when_actionTargetHasMultipleInboundEdges() {
+    stubDraftWorkflow(SHARED_ACTION_TARGET_GRAPH);
+    UpdateWorkflowTransitionCommand command =
+        command(
+            "e_check_action",
+            null,
+            new UpdateWorkflowTransitionCommand.ActionPatch("policy_new"),
+            null);
+
+    assertThatThrownBy(() -> useCase.execute(command))
+        .isInstanceOf(BadRequestException.class)
+        .extracting("code")
+        .isEqualTo("WORKFLOW_TRANSITION_TARGET_SHARED");
+
+    verify(workflowRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("공유 TERMINAL 목적지 transition에는 outcome을 수정할 수 없다")
+  void should_WORKFLOW_TRANSITION_TARGET_SHARED_when_outcomeTargetHasMultipleInboundEdges() {
+    stubDraftWorkflow(SHARED_TERMINAL_TARGET_GRAPH);
+    UpdateWorkflowTransitionCommand command =
+        command(
+            "e_check_end",
+            null,
+            null,
+            new UpdateWorkflowTransitionCommand.OutcomePatch("pending", null));
+
+    assertThatThrownBy(() -> useCase.execute(command))
+        .isInstanceOf(BadRequestException.class)
+        .extracting("code")
+        .isEqualTo("WORKFLOW_TRANSITION_TARGET_SHARED");
+
+    verify(workflowRepository, never()).save(any());
+  }
+
+  @Test
   @DisplayName("outcome.state 패턴 위반 시 WORKFLOW_TRANSITION_OUTCOME_STATE_INVALID_CHARS")
   void should_WORKFLOW_TRANSITION_OUTCOME_STATE_INVALID_CHARS_when_outcomeStateInvalidChars() {
     stubDraftWorkflow();
@@ -424,13 +486,17 @@ class UpdateWorkflowTransitionUseCaseTest {
   }
 
   private WorkflowDefinition stubDraftWorkflow() {
+    return stubDraftWorkflow(GRAPH);
+  }
+
+  private WorkflowDefinition stubDraftWorkflow(String graph) {
     given(versionRepository.findByIdForUpdate(VERSION_ID))
         .willReturn(
             Optional.of(
                 DomainPackVersion.ofForTest(VERSION_ID, PACK_ID, DomainPackVersion.STATUS_DRAFT)));
     WorkflowDefinition workflow =
         WorkflowDefinition.create(
-            VERSION_ID, "wf_refund", "환불 플로우", null, GRAPH, "start", "[\"end_ok\"]", null, null);
+            VERSION_ID, "wf_refund", "환불 플로우", null, graph, "start", "[\"end_ok\"]", null, null);
     ReflectionTestUtils.setField(workflow, "id", WORKFLOW_ID);
     given(workflowRepository.findByIdAndDomainPackVersionIdForUpdate(WORKFLOW_ID, VERSION_ID))
         .willReturn(Optional.of(workflow));

--- a/backend/src/test/java/com/init/domainpack/application/UpdateWorkflowTransitionUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/UpdateWorkflowTransitionUseCaseTest.java
@@ -1,0 +1,351 @@
+package com.init.domainpack.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.init.domainpack.application.exception.WorkflowActionNodePolicyRefNotFoundException;
+import com.init.domainpack.application.exception.WorkflowDefinitionNotFoundException;
+import com.init.domainpack.application.exception.WorkflowTransitionActionNotEditableException;
+import com.init.domainpack.application.exception.WorkflowTransitionConditionNotEditableException;
+import com.init.domainpack.application.exception.WorkflowTransitionNotFoundException;
+import com.init.domainpack.application.exception.WorkflowTransitionOutcomeEmptyException;
+import com.init.domainpack.application.exception.WorkflowTransitionOutcomeNotEditableException;
+import com.init.domainpack.application.exception.WorkflowTransitionPatchEmptyException;
+import com.init.domainpack.domain.model.DomainPackVersion;
+import com.init.domainpack.domain.model.WorkflowDefinition;
+import com.init.domainpack.domain.repository.DomainPackVersionRepository;
+import com.init.domainpack.domain.repository.WorkflowDefinitionRepository;
+import com.init.shared.application.exception.BadRequestException;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UpdateWorkflowTransitionUseCase")
+class UpdateWorkflowTransitionUseCaseTest {
+
+  private static final Long WORKSPACE_ID = 1L;
+  private static final Long PACK_ID = 7L;
+  private static final Long VERSION_ID = 101L;
+  private static final Long WORKFLOW_ID = 3001L;
+  private static final Long USER_ID = 10L;
+
+  private static final String GRAPH =
+      "{\"direction\":\"LR\","
+          + "\"nodes\":["
+          + "{\"id\":\"start\",\"type\":\"START\"},"
+          + "{\"id\":\"check\",\"type\":\"DECISION\"},"
+          + "{\"id\":\"action\",\"type\":\"ACTION\",\"policyRef\":\"policy_old\"},"
+          + "{\"id\":\"end_ok\",\"type\":\"TERMINAL\",\"state\":\"approved\",\"label\":\"승인\"},"
+          + "{\"id\":\"end_reject\",\"type\":\"TERMINAL\",\"state\":\"rejected\",\"label\":\"거절\"}],"
+          + "\"edges\":["
+          + "{\"id\":\"e_start_check\",\"from\":\"start\",\"to\":\"check\"},"
+          + "{\"id\":\"e_check_action\",\"from\":\"check\",\"to\":\"action\",\"label\":\"가능\"},"
+          + "{\"id\":\"e_check_reject\",\"from\":\"check\",\"to\":\"end_reject\",\"label\":\"불가능\"},"
+          + "{\"id\":\"e_action_end\",\"from\":\"action\",\"to\":\"end_ok\"}]}";
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Mock private DomainPackValidator validator;
+  @Mock private DomainPackVersionRepository versionRepository;
+  @Mock private WorkflowDefinitionRepository workflowRepository;
+
+  private UpdateWorkflowTransitionUseCase useCase;
+
+  @BeforeEach
+  void setUp() {
+    useCase = new UpdateWorkflowTransitionUseCase(validator, versionRepository, workflowRepository);
+  }
+
+  @Test
+  @DisplayName("DECISION -> ACTION transition에서 condition과 action을 수정한다")
+  void should_updateConditionAndAction_when_decisionToActionTransition() throws Exception {
+    // given
+    WorkflowDefinition workflow = stubDraftWorkflow();
+    given(workflowRepository.save(any())).willReturn(workflow);
+
+    UpdateWorkflowTransitionCommand command =
+        command(
+            "e_check_action",
+            new UpdateWorkflowTransitionCommand.ConditionPatch("  가능함  "),
+            new UpdateWorkflowTransitionCommand.ActionPatch("policy_new"),
+            null);
+
+    // when
+    WorkflowTransitionDetail result = useCase.execute(command);
+
+    // then
+    assertThat(result.label()).isEqualTo("가능함");
+    assertThat(result.toPolicyRef()).isEqualTo("policy_new");
+    assertThat(result.condition().editable()).isTrue();
+    assertThat(result.action().editable()).isTrue();
+
+    JsonNode graph = objectMapper.readTree(workflow.getGraphJson());
+    assertThat(findEdge(graph, "e_check_action").path("label").asText()).isEqualTo("가능함");
+    assertThat(findNode(graph, "action").path("policyRef").asText()).isEqualTo("policy_new");
+    verify(validator).validatePolicyCodes(eq(VERSION_ID), eq(Set.of("policy_new")));
+    verify(workflowRepository).save(workflow);
+  }
+
+  @Test
+  @DisplayName("DECISION -> TERMINAL transition에서 outcome.state와 outcome.label을 수정한다")
+  void should_updateOutcome_when_decisionToTerminalTransition() throws Exception {
+    // given
+    WorkflowDefinition workflow = stubDraftWorkflow();
+    given(workflowRepository.save(any())).willReturn(workflow);
+
+    UpdateWorkflowTransitionCommand command =
+        command(
+            "e_check_reject",
+            new UpdateWorkflowTransitionCommand.ConditionPatch("보류"),
+            null,
+            new UpdateWorkflowTransitionCommand.OutcomePatch("pending", "보류 처리"));
+
+    // when
+    WorkflowTransitionDetail result = useCase.execute(command);
+
+    // then
+    assertThat(result.condition().label()).isEqualTo("보류");
+    assertThat(result.outcome().editable()).isTrue();
+    assertThat(result.outcome().state()).isEqualTo("pending");
+    assertThat(result.outcome().label()).isEqualTo("보류 처리");
+
+    JsonNode graph = objectMapper.readTree(workflow.getGraphJson());
+    assertThat(findNode(graph, "end_reject").path("state").asText()).isEqualTo("pending");
+    assertThat(findNode(graph, "end_reject").path("label").asText()).isEqualTo("보류 처리");
+  }
+
+  @Test
+  @DisplayName("outcome.state만 보내면 label은 유지한다")
+  void should_keepOutcomeLabel_when_onlyStateProvided() throws Exception {
+    // given
+    WorkflowDefinition workflow = stubDraftWorkflow();
+    given(workflowRepository.save(any())).willReturn(workflow);
+
+    // when
+    useCase.execute(
+        command(
+            "e_check_reject",
+            null,
+            null,
+            new UpdateWorkflowTransitionCommand.OutcomePatch("failed", null)));
+
+    // then
+    JsonNode terminal = findNode(objectMapper.readTree(workflow.getGraphJson()), "end_reject");
+    assertThat(terminal.path("state").asText()).isEqualTo("failed");
+    assertThat(terminal.path("label").asText()).isEqualTo("거절");
+  }
+
+  @Test
+  @DisplayName("빈 PATCH 요청이면 WORKFLOW_TRANSITION_PATCH_EMPTY")
+  void should_WORKFLOW_TRANSITION_PATCH_EMPTY_when_emptyPatch() {
+    assertThatThrownBy(() -> useCase.execute(command("e_check_action", null, null, null)))
+        .isInstanceOf(WorkflowTransitionPatchEmptyException.class);
+
+    verify(workflowRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("non-DECISION edge에 condition 요청 시 WORKFLOW_TRANSITION_CONDITION_NOT_EDITABLE")
+  void should_WORKFLOW_TRANSITION_CONDITION_NOT_EDITABLE_when_nonDecisionEdge() {
+    stubDraftWorkflow();
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    command(
+                        "e_action_end",
+                        new UpdateWorkflowTransitionCommand.ConditionPatch("완료"),
+                        null,
+                        null)))
+        .isInstanceOf(WorkflowTransitionConditionNotEditableException.class);
+  }
+
+  @Test
+  @DisplayName("non-ACTION 목적지에 action 요청 시 WORKFLOW_TRANSITION_ACTION_NOT_EDITABLE")
+  void should_WORKFLOW_TRANSITION_ACTION_NOT_EDITABLE_when_toNodeIsNotAction() {
+    stubDraftWorkflow();
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    command(
+                        "e_check_reject",
+                        null,
+                        new UpdateWorkflowTransitionCommand.ActionPatch("policy_new"),
+                        null)))
+        .isInstanceOf(WorkflowTransitionActionNotEditableException.class);
+  }
+
+  @Test
+  @DisplayName("non-TERMINAL 목적지에 outcome 요청 시 WORKFLOW_TRANSITION_OUTCOME_NOT_EDITABLE")
+  void should_WORKFLOW_TRANSITION_OUTCOME_NOT_EDITABLE_when_toNodeIsNotTerminal() {
+    stubDraftWorkflow();
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    command(
+                        "e_check_action",
+                        null,
+                        null,
+                        new UpdateWorkflowTransitionCommand.OutcomePatch("done", null))))
+        .isInstanceOf(WorkflowTransitionOutcomeNotEditableException.class);
+  }
+
+  @Test
+  @DisplayName("outcome 내부가 비어 있으면 WORKFLOW_TRANSITION_OUTCOME_EMPTY")
+  void should_WORKFLOW_TRANSITION_OUTCOME_EMPTY_when_outcomeEmpty() {
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    command(
+                        "e_check_reject",
+                        null,
+                        null,
+                        new UpdateWorkflowTransitionCommand.OutcomePatch(null, null))))
+        .isInstanceOf(WorkflowTransitionOutcomeEmptyException.class);
+  }
+
+  @Test
+  @DisplayName("action section이 없어도 전체 ACTION node policyRef 존재 검증을 수행한다")
+  void should_validateAllPolicyRefs_when_actionSectionMissing() {
+    // given
+    stubDraftWorkflow();
+    doThrow(new WorkflowActionNodePolicyRefNotFoundException("policy_old"))
+        .when(validator)
+        .validatePolicyCodes(eq(VERSION_ID), eq(Set.of("policy_old")));
+
+    // when & then
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    command(
+                        "e_check_reject",
+                        new UpdateWorkflowTransitionCommand.ConditionPatch("보류"),
+                        null,
+                        null)))
+        .isInstanceOf(WorkflowActionNodePolicyRefNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("PUBLISHED version이면 WORKFLOW_NOT_EDITABLE")
+  void should_WORKFLOW_NOT_EDITABLE_when_publishedVersion() {
+    given(versionRepository.findById(VERSION_ID))
+        .willReturn(
+            Optional.of(
+                DomainPackVersion.ofForTest(
+                    VERSION_ID, PACK_ID, DomainPackVersion.STATUS_PUBLISHED)));
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    command(
+                        "e_check_action",
+                        new UpdateWorkflowTransitionCommand.ConditionPatch("가능함"),
+                        null,
+                        null)))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("DRAFT");
+  }
+
+  @Test
+  @DisplayName("transitionId 미존재이면 WORKFLOW_TRANSITION_NOT_FOUND")
+  void should_WORKFLOW_TRANSITION_NOT_FOUND_when_transitionMissing() {
+    stubDraftWorkflow();
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    command(
+                        "missing_edge",
+                        new UpdateWorkflowTransitionCommand.ConditionPatch("가능함"),
+                        null,
+                        null)))
+        .isInstanceOf(WorkflowTransitionNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("workflowId 미존재이면 WORKFLOW_DEFINITION_NOT_FOUND")
+  void should_WORKFLOW_DEFINITION_NOT_FOUND_when_workflowMissing() {
+    given(versionRepository.findById(VERSION_ID))
+        .willReturn(
+            Optional.of(
+                DomainPackVersion.ofForTest(VERSION_ID, PACK_ID, DomainPackVersion.STATUS_DRAFT)));
+    given(workflowRepository.findByIdAndDomainPackVersionId(WORKFLOW_ID, VERSION_ID))
+        .willReturn(Optional.empty());
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    command(
+                        "e_check_action",
+                        new UpdateWorkflowTransitionCommand.ConditionPatch("가능함"),
+                        null,
+                        null)))
+        .isInstanceOf(WorkflowDefinitionNotFoundException.class);
+  }
+
+  private UpdateWorkflowTransitionCommand command(
+      String transitionId,
+      UpdateWorkflowTransitionCommand.ConditionPatch condition,
+      UpdateWorkflowTransitionCommand.ActionPatch action,
+      UpdateWorkflowTransitionCommand.OutcomePatch outcome) {
+    return new UpdateWorkflowTransitionCommand(
+        WORKSPACE_ID,
+        PACK_ID,
+        VERSION_ID,
+        WORKFLOW_ID,
+        transitionId,
+        USER_ID,
+        condition,
+        action,
+        outcome);
+  }
+
+  private WorkflowDefinition stubDraftWorkflow() {
+    given(versionRepository.findById(VERSION_ID))
+        .willReturn(
+            Optional.of(
+                DomainPackVersion.ofForTest(VERSION_ID, PACK_ID, DomainPackVersion.STATUS_DRAFT)));
+    WorkflowDefinition workflow =
+        WorkflowDefinition.create(
+            VERSION_ID, "wf_refund", "환불 플로우", null, GRAPH, "start", "[\"end_ok\"]", null, null);
+    ReflectionTestUtils.setField(workflow, "id", WORKFLOW_ID);
+    given(workflowRepository.findByIdAndDomainPackVersionId(WORKFLOW_ID, VERSION_ID))
+        .willReturn(Optional.of(workflow));
+    return workflow;
+  }
+
+  private JsonNode findNode(JsonNode graph, String nodeId) {
+    for (JsonNode node : graph.path("nodes")) {
+      if (nodeId.equals(node.path("id").asText())) {
+        return node;
+      }
+    }
+    throw new AssertionError("node not found: " + nodeId);
+  }
+
+  private JsonNode findEdge(JsonNode graph, String edgeId) {
+    for (JsonNode edge : graph.path("edges")) {
+      if (edgeId.equals(edge.path("id").asText())) {
+        return edge;
+      }
+    }
+    throw new AssertionError("edge not found: " + edgeId);
+  }
+}

--- a/backend/src/test/java/com/init/domainpack/application/UpdateWorkflowTransitionUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/UpdateWorkflowTransitionUseCaseTest.java
@@ -262,8 +262,8 @@ class UpdateWorkflowTransitionUseCaseTest {
         .isInstanceOf(BadRequestException.class)
         .hasMessageContaining("transitionId");
 
-    verify(versionRepository, never()).findById(any());
-    verify(workflowRepository, never()).findByIdAndDomainPackVersionId(any(), any());
+    verify(versionRepository, never()).findByIdForUpdate(any());
+    verify(workflowRepository, never()).findByIdAndDomainPackVersionIdForUpdate(any(), any());
     verify(workflowRepository, never()).save(any());
   }
 
@@ -329,7 +329,7 @@ class UpdateWorkflowTransitionUseCaseTest {
   @Test
   @DisplayName("PUBLISHED version이면 WORKFLOW_NOT_EDITABLE")
   void should_WORKFLOW_NOT_EDITABLE_when_publishedVersion() {
-    given(versionRepository.findById(VERSION_ID))
+    given(versionRepository.findByIdForUpdate(VERSION_ID))
         .willReturn(
             Optional.of(
                 DomainPackVersion.ofForTest(
@@ -366,11 +366,11 @@ class UpdateWorkflowTransitionUseCaseTest {
   @Test
   @DisplayName("workflowId 미존재이면 WORKFLOW_DEFINITION_NOT_FOUND")
   void should_WORKFLOW_DEFINITION_NOT_FOUND_when_workflowMissing() {
-    given(versionRepository.findById(VERSION_ID))
+    given(versionRepository.findByIdForUpdate(VERSION_ID))
         .willReturn(
             Optional.of(
                 DomainPackVersion.ofForTest(VERSION_ID, PACK_ID, DomainPackVersion.STATUS_DRAFT)));
-    given(workflowRepository.findByIdAndDomainPackVersionId(WORKFLOW_ID, VERSION_ID))
+    given(workflowRepository.findByIdAndDomainPackVersionIdForUpdate(WORKFLOW_ID, VERSION_ID))
         .willReturn(Optional.empty());
 
     assertThatThrownBy(
@@ -382,6 +382,28 @@ class UpdateWorkflowTransitionUseCaseTest {
                         null,
                         null)))
         .isInstanceOf(WorkflowDefinitionNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("수정 대상 version과 workflow는 for update 조회를 사용한다")
+  void should_useForUpdateLookups_when_updateTransition() {
+    // given
+    WorkflowDefinition workflow = stubDraftWorkflow();
+    given(workflowRepository.save(any())).willReturn(workflow);
+
+    // when
+    useCase.execute(
+        command(
+            "e_check_action",
+            new UpdateWorkflowTransitionCommand.ConditionPatch("가능함"),
+            null,
+            null));
+
+    // then
+    verify(versionRepository).findByIdForUpdate(VERSION_ID);
+    verify(versionRepository, never()).findById(VERSION_ID);
+    verify(workflowRepository).findByIdAndDomainPackVersionIdForUpdate(WORKFLOW_ID, VERSION_ID);
+    verify(workflowRepository, never()).findByIdAndDomainPackVersionId(WORKFLOW_ID, VERSION_ID);
   }
 
   private UpdateWorkflowTransitionCommand command(
@@ -402,7 +424,7 @@ class UpdateWorkflowTransitionUseCaseTest {
   }
 
   private WorkflowDefinition stubDraftWorkflow() {
-    given(versionRepository.findById(VERSION_ID))
+    given(versionRepository.findByIdForUpdate(VERSION_ID))
         .willReturn(
             Optional.of(
                 DomainPackVersion.ofForTest(VERSION_ID, PACK_ID, DomainPackVersion.STATUS_DRAFT)));
@@ -410,7 +432,7 @@ class UpdateWorkflowTransitionUseCaseTest {
         WorkflowDefinition.create(
             VERSION_ID, "wf_refund", "환불 플로우", null, GRAPH, "start", "[\"end_ok\"]", null, null);
     ReflectionTestUtils.setField(workflow, "id", WORKFLOW_ID);
-    given(workflowRepository.findByIdAndDomainPackVersionId(WORKFLOW_ID, VERSION_ID))
+    given(workflowRepository.findByIdAndDomainPackVersionIdForUpdate(WORKFLOW_ID, VERSION_ID))
         .willReturn(Optional.of(workflow));
     return workflow;
   }

--- a/backend/src/test/java/com/init/domainpack/application/UpdateWorkflowTransitionUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/UpdateWorkflowTransitionUseCaseTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.verify;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.init.domainpack.application.exception.WorkflowActionNodePolicyRefInvalidCharsException;
 import com.init.domainpack.application.exception.WorkflowActionNodePolicyRefNotFoundException;
 import com.init.domainpack.application.exception.WorkflowDefinitionNotFoundException;
 import com.init.domainpack.application.exception.WorkflowTransitionActionNotEditableException;
@@ -18,6 +19,7 @@ import com.init.domainpack.application.exception.WorkflowTransitionConditionNotE
 import com.init.domainpack.application.exception.WorkflowTransitionNotFoundException;
 import com.init.domainpack.application.exception.WorkflowTransitionOutcomeEmptyException;
 import com.init.domainpack.application.exception.WorkflowTransitionOutcomeNotEditableException;
+import com.init.domainpack.application.exception.WorkflowTransitionOutcomeStateInvalidCharsException;
 import com.init.domainpack.application.exception.WorkflowTransitionPatchEmptyException;
 import com.init.domainpack.domain.model.DomainPackVersion;
 import com.init.domainpack.domain.model.WorkflowDefinition;
@@ -151,6 +153,31 @@ class UpdateWorkflowTransitionUseCaseTest {
   }
 
   @Test
+  @DisplayName("outcome.label만 보내면 state는 유지한다")
+  void should_keepOutcomeState_when_onlyLabelProvided() throws Exception {
+    // given
+    WorkflowDefinition workflow = stubDraftWorkflow();
+    given(workflowRepository.save(any())).willReturn(workflow);
+
+    // when
+    WorkflowTransitionDetail result =
+        useCase.execute(
+            command(
+                "e_check_reject",
+                null,
+                null,
+                new UpdateWorkflowTransitionCommand.OutcomePatch(null, "검토 필요")));
+
+    // then
+    assertThat(result.outcome().state()).isEqualTo("rejected");
+    assertThat(result.outcome().label()).isEqualTo("검토 필요");
+
+    JsonNode terminal = findNode(objectMapper.readTree(workflow.getGraphJson()), "end_reject");
+    assertThat(terminal.path("state").asText()).isEqualTo("rejected");
+    assertThat(terminal.path("label").asText()).isEqualTo("검토 필요");
+  }
+
+  @Test
   @DisplayName("빈 PATCH 요청이면 WORKFLOW_TRANSITION_PATCH_EMPTY")
   void should_WORKFLOW_TRANSITION_PATCH_EMPTY_when_emptyPatch() {
     assertThatThrownBy(() -> useCase.execute(command("e_check_action", null, null, null)))
@@ -222,6 +249,61 @@ class UpdateWorkflowTransitionUseCaseTest {
   }
 
   @Test
+  @DisplayName("transitionId 패턴 위반 시 DB 조회 전에 VALIDATION_ERROR")
+  void should_VALIDATION_ERROR_beforeRepositoryLookup_when_transitionIdInvalid() {
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    command(
+                        "edge.with.dot",
+                        new UpdateWorkflowTransitionCommand.ConditionPatch("가능"),
+                        null,
+                        null)))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("transitionId");
+
+    verify(versionRepository, never()).findById(any());
+    verify(workflowRepository, never()).findByIdAndDomainPackVersionId(any(), any());
+    verify(workflowRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("action.policyRef 패턴 위반 시 WORKFLOW_ACTION_NODE_POLICY_REF_INVALID_CHARS")
+  void should_WORKFLOW_ACTION_NODE_POLICY_REF_INVALID_CHARS_when_policyRefInvalidChars() {
+    stubDraftWorkflow();
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    command(
+                        "e_check_action",
+                        null,
+                        new UpdateWorkflowTransitionCommand.ActionPatch("policy ref"),
+                        null)))
+        .isInstanceOf(WorkflowActionNodePolicyRefInvalidCharsException.class);
+
+    verify(workflowRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("outcome.state 패턴 위반 시 WORKFLOW_TRANSITION_OUTCOME_STATE_INVALID_CHARS")
+  void should_WORKFLOW_TRANSITION_OUTCOME_STATE_INVALID_CHARS_when_outcomeStateInvalidChars() {
+    stubDraftWorkflow();
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    command(
+                        "e_check_reject",
+                        null,
+                        null,
+                        new UpdateWorkflowTransitionCommand.OutcomePatch("검토 필요", null))))
+        .isInstanceOf(WorkflowTransitionOutcomeStateInvalidCharsException.class);
+
+    verify(workflowRepository, never()).save(any());
+  }
+
+  @Test
   @DisplayName("action section이 없어도 전체 ACTION node policyRef 존재 검증을 수행한다")
   void should_validateAllPolicyRefs_when_actionSectionMissing() {
     // given
@@ -240,6 +322,8 @@ class UpdateWorkflowTransitionUseCaseTest {
                         null,
                         null)))
         .isInstanceOf(WorkflowActionNodePolicyRefNotFoundException.class);
+
+    verify(workflowRepository, never()).save(any());
   }
 
   @Test

--- a/backend/src/test/java/com/init/domainpack/application/UpdateWorkflowTransitionUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/UpdateWorkflowTransitionUseCaseTest.java
@@ -84,6 +84,20 @@ class UpdateWorkflowTransitionUseCaseTest {
           + "{\"id\":\"e_start_end\",\"from\":\"start\",\"to\":\"end\"},"
           + "{\"id\":\"e_check_end\",\"from\":\"check\",\"to\":\"end\",\"label\":\"가능\"}]}";
 
+  private static final String GRAPH_WITH_PADDED_NODE_TYPES =
+      "{\"direction\":\"LR\","
+          + "\"nodes\":["
+          + "{\"id\":\"start\",\"type\":\" START \"},"
+          + "{\"id\":\"check\",\"type\":\" DECISION \"},"
+          + "{\"id\":\"action\",\"type\":\" ACTION \",\"policyRef\":\"policy_old\"},"
+          + "{\"id\":\"end_ok\",\"type\":\" TERMINAL \",\"state\":\"approved\",\"label\":\"승인\"},"
+          + "{\"id\":\"end_reject\",\"type\":\" TERMINAL \",\"state\":\"rejected\",\"label\":\"거절\"}],"
+          + "\"edges\":["
+          + "{\"id\":\"e_start_check\",\"from\":\"start\",\"to\":\"check\"},"
+          + "{\"id\":\"e_check_action\",\"from\":\"check\",\"to\":\"action\",\"label\":\"가능\"},"
+          + "{\"id\":\"e_check_reject\",\"from\":\"check\",\"to\":\"end_reject\",\"label\":\"불가능\"},"
+          + "{\"id\":\"e_action_end\",\"from\":\"action\",\"to\":\"end_ok\"}]}";
+
   private final ObjectMapper objectMapper = new ObjectMapper();
 
   @Mock private DomainPackValidator validator;
@@ -146,6 +160,59 @@ class UpdateWorkflowTransitionUseCaseTest {
 
     // then
     assertThat(result.condition().label()).isEqualTo("보류");
+    assertThat(result.outcome().editable()).isTrue();
+    assertThat(result.outcome().state()).isEqualTo("pending");
+    assertThat(result.outcome().label()).isEqualTo("보류 처리");
+
+    JsonNode graph = objectMapper.readTree(workflow.getGraphJson());
+    assertThat(findNode(graph, "end_reject").path("state").asText()).isEqualTo("pending");
+    assertThat(findNode(graph, "end_reject").path("label").asText()).isEqualTo("보류 처리");
+  }
+
+  @Test
+  @DisplayName("node type에 공백이 있어도 condition과 action을 수정한다")
+  void should_updateConditionAndAction_when_nodeTypesHavePadding() throws Exception {
+    // given
+    WorkflowDefinition workflow = stubDraftWorkflow(GRAPH_WITH_PADDED_NODE_TYPES);
+    given(workflowRepository.save(any())).willReturn(workflow);
+
+    // when
+    WorkflowTransitionDetail result =
+        useCase.execute(
+            command(
+                "e_check_action",
+                new UpdateWorkflowTransitionCommand.ConditionPatch("가능함"),
+                new UpdateWorkflowTransitionCommand.ActionPatch("policy_new"),
+                null));
+
+    // then
+    assertThat(result.condition().editable()).isTrue();
+    assertThat(result.action().editable()).isTrue();
+    assertThat(result.label()).isEqualTo("가능함");
+    assertThat(result.toPolicyRef()).isEqualTo("policy_new");
+
+    JsonNode graph = objectMapper.readTree(workflow.getGraphJson());
+    assertThat(findEdge(graph, "e_check_action").path("label").asText()).isEqualTo("가능함");
+    assertThat(findNode(graph, "action").path("policyRef").asText()).isEqualTo("policy_new");
+  }
+
+  @Test
+  @DisplayName("node type에 공백이 있어도 outcome을 수정한다")
+  void should_updateOutcome_when_nodeTypesHavePadding() throws Exception {
+    // given
+    WorkflowDefinition workflow = stubDraftWorkflow(GRAPH_WITH_PADDED_NODE_TYPES);
+    given(workflowRepository.save(any())).willReturn(workflow);
+
+    // when
+    WorkflowTransitionDetail result =
+        useCase.execute(
+            command(
+                "e_check_reject",
+                null,
+                null,
+                new UpdateWorkflowTransitionCommand.OutcomePatch("pending", "보류 처리")));
+
+    // then
     assertThat(result.outcome().editable()).isTrue();
     assertThat(result.outcome().state()).isEqualTo("pending");
     assertThat(result.outcome().label()).isEqualTo("보류 처리");

--- a/backend/src/test/java/com/init/domainpack/application/UpdateWorkflowUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/UpdateWorkflowUseCaseTest.java
@@ -434,8 +434,8 @@ class UpdateWorkflowUseCaseTest {
   }
 
   @Test
-  @DisplayName("ACTION 노드가 없으면 validatePolicyCodes를 호출하지 않는다")
-  void should_validatePolicyCodes미호출_when_ACTION노드없음() {
+  @DisplayName("ACTION 노드가 없어도 빈 policyRef set으로 검증을 위임한다")
+  void should_delegatePolicyCodeValidationWithEmptySet_when_ACTION노드없음() {
     // given
     DomainPackVersion version = draftVersion(10L, 7L);
     given(versionRepository.findByIdForUpdate(10L)).willReturn(Optional.of(version));
@@ -450,7 +450,7 @@ class UpdateWorkflowUseCaseTest {
     useCase.execute(command);
 
     // then
-    verify(validator, never()).validatePolicyCodes(anyLong(), anySet());
+    verify(validator).validatePolicyCodes(eq(10L), eq(Set.<String>of()));
   }
 
   // ── factories ──────────────────────────────────────────────────────────────

--- a/backend/src/test/java/com/init/domainpack/application/UpdateWorkflowUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/UpdateWorkflowUseCaseTest.java
@@ -71,10 +71,10 @@ class UpdateWorkflowUseCaseTest {
   void should_수정완료_when_유효한요청() {
     // given
     DomainPackVersion version = draftVersion(10L, 7L);
-    given(versionRepository.findById(10L)).willReturn(Optional.of(version));
+    given(versionRepository.findByIdForUpdate(10L)).willReturn(Optional.of(version));
 
     WorkflowDefinition workflow = workflow(99L, 10L);
-    given(workflowRepository.findByIdAndDomainPackVersionId(99L, 10L))
+    given(workflowRepository.findByIdAndDomainPackVersionIdForUpdate(99L, 10L))
         .willReturn(Optional.of(workflow));
     given(workflowRepository.save(any())).willReturn(workflow);
 
@@ -88,13 +88,17 @@ class UpdateWorkflowUseCaseTest {
     assertThat(result.name()).isEqualTo("수정된 이름");
     assertThat(result.description()).isEqualTo("새 설명");
     assertThat(result.initialState()).isEqualTo("start");
+    verify(versionRepository).findByIdForUpdate(10L);
+    verify(versionRepository, never()).findById(10L);
+    verify(workflowRepository).findByIdAndDomainPackVersionIdForUpdate(99L, 10L);
+    verify(workflowRepository, never()).findByIdAndDomainPackVersionId(99L, 10L);
     verify(workflowRepository).save(workflow);
   }
 
   @Test
   @DisplayName("버전 미존재 시 NotFoundException")
   void should_버전없음예외_when_버전미존재() {
-    given(versionRepository.findById(10L)).willReturn(Optional.empty());
+    given(versionRepository.findByIdForUpdate(10L)).willReturn(Optional.empty());
 
     assertThatThrownBy(
             () ->
@@ -109,7 +113,7 @@ class UpdateWorkflowUseCaseTest {
   @DisplayName("packId 불일치 시 NotFoundException")
   void should_버전없음예외_when_packId불일치() {
     DomainPackVersion version = draftVersion(10L, 999L); // packId=999, not 7
-    given(versionRepository.findById(10L)).willReturn(Optional.of(version));
+    given(versionRepository.findByIdForUpdate(10L)).willReturn(Optional.of(version));
 
     assertThatThrownBy(
             () ->
@@ -124,7 +128,7 @@ class UpdateWorkflowUseCaseTest {
   @DisplayName("DRAFT가 아닌 버전 수정 시 BadRequestException(WORKFLOW_NOT_EDITABLE)")
   void should_WORKFLOW_NOT_EDITABLE_when_버전이PUBLISHED() {
     DomainPackVersion version = publishedVersion(10L, 7L);
-    given(versionRepository.findById(10L)).willReturn(Optional.of(version));
+    given(versionRepository.findByIdForUpdate(10L)).willReturn(Optional.of(version));
 
     assertThatThrownBy(
             () ->
@@ -140,7 +144,7 @@ class UpdateWorkflowUseCaseTest {
   @DisplayName("graphJson 크기 초과 시 BadRequestException(GRAPH_JSON_TOO_LARGE)")
   void should_GRAPH_JSON_TOO_LARGE_when_크기초과() {
     DomainPackVersion version = draftVersion(10L, 7L);
-    given(versionRepository.findById(10L)).willReturn(Optional.of(version));
+    given(versionRepository.findByIdForUpdate(10L)).willReturn(Optional.of(version));
 
     String oversizedGraph = "x".repeat(100_001);
     assertThatThrownBy(
@@ -157,8 +161,9 @@ class UpdateWorkflowUseCaseTest {
   @DisplayName("존재하지 않는 workflowId 요청 시 NotFoundException")
   void should_404_when_workflowNotFound() {
     DomainPackVersion version = draftVersion(10L, 7L);
-    given(versionRepository.findById(10L)).willReturn(Optional.of(version));
-    given(workflowRepository.findByIdAndDomainPackVersionId(99L, 10L)).willReturn(Optional.empty());
+    given(versionRepository.findByIdForUpdate(10L)).willReturn(Optional.of(version));
+    given(workflowRepository.findByIdAndDomainPackVersionIdForUpdate(99L, 10L))
+        .willReturn(Optional.empty());
 
     assertThatThrownBy(
             () ->
@@ -174,9 +179,9 @@ class UpdateWorkflowUseCaseTest {
   void should_V1예외_when_START노드이상() {
     // given
     DomainPackVersion version = draftVersion(10L, 7L);
-    given(versionRepository.findById(10L)).willReturn(Optional.of(version));
+    given(versionRepository.findByIdForUpdate(10L)).willReturn(Optional.of(version));
     WorkflowDefinition workflow = workflow(99L, 10L);
-    given(workflowRepository.findByIdAndDomainPackVersionId(99L, 10L))
+    given(workflowRepository.findByIdAndDomainPackVersionIdForUpdate(99L, 10L))
         .willReturn(Optional.of(workflow));
     String noStartGraph =
         "{\"direction\":\"LR\","
@@ -197,9 +202,9 @@ class UpdateWorkflowUseCaseTest {
   void should_V2예외_when_TERMINAL노드없음() {
     // given
     DomainPackVersion version = draftVersion(10L, 7L);
-    given(versionRepository.findById(10L)).willReturn(Optional.of(version));
+    given(versionRepository.findByIdForUpdate(10L)).willReturn(Optional.of(version));
     WorkflowDefinition workflow = workflow(99L, 10L);
-    given(workflowRepository.findByIdAndDomainPackVersionId(99L, 10L))
+    given(workflowRepository.findByIdAndDomainPackVersionIdForUpdate(99L, 10L))
         .willReturn(Optional.of(workflow));
     String noTerminalGraph =
         "{\"direction\":\"LR\","
@@ -222,9 +227,9 @@ class UpdateWorkflowUseCaseTest {
   void should_V3예외_when_dangling엣지() {
     // given
     DomainPackVersion version = draftVersion(10L, 7L);
-    given(versionRepository.findById(10L)).willReturn(Optional.of(version));
+    given(versionRepository.findByIdForUpdate(10L)).willReturn(Optional.of(version));
     WorkflowDefinition workflow = workflow(99L, 10L);
-    given(workflowRepository.findByIdAndDomainPackVersionId(99L, 10L))
+    given(workflowRepository.findByIdAndDomainPackVersionIdForUpdate(99L, 10L))
         .willReturn(Optional.of(workflow));
     String danglingGraph =
         "{\"direction\":\"LR\","
@@ -247,9 +252,9 @@ class UpdateWorkflowUseCaseTest {
   void should_V4예외_when_미도달노드() {
     // given
     DomainPackVersion version = draftVersion(10L, 7L);
-    given(versionRepository.findById(10L)).willReturn(Optional.of(version));
+    given(versionRepository.findByIdForUpdate(10L)).willReturn(Optional.of(version));
     WorkflowDefinition workflow = workflow(99L, 10L);
-    given(workflowRepository.findByIdAndDomainPackVersionId(99L, 10L))
+    given(workflowRepository.findByIdAndDomainPackVersionIdForUpdate(99L, 10L))
         .willReturn(Optional.of(workflow));
     String unreachableGraph =
         "{\"direction\":\"LR\","
@@ -273,9 +278,9 @@ class UpdateWorkflowUseCaseTest {
   void should_V5예외_when_사이클() {
     // given
     DomainPackVersion version = draftVersion(10L, 7L);
-    given(versionRepository.findById(10L)).willReturn(Optional.of(version));
+    given(versionRepository.findByIdForUpdate(10L)).willReturn(Optional.of(version));
     WorkflowDefinition workflow = workflow(99L, 10L);
-    given(workflowRepository.findByIdAndDomainPackVersionId(99L, 10L))
+    given(workflowRepository.findByIdAndDomainPackVersionIdForUpdate(99L, 10L))
         .willReturn(Optional.of(workflow));
     // n1 → start creates a back-edge (cycle)
     String cycleGraph =
@@ -303,9 +308,9 @@ class UpdateWorkflowUseCaseTest {
   void should_V6예외_when_DECISION레이블없음() {
     // given
     DomainPackVersion version = draftVersion(10L, 7L);
-    given(versionRepository.findById(10L)).willReturn(Optional.of(version));
+    given(versionRepository.findByIdForUpdate(10L)).willReturn(Optional.of(version));
     WorkflowDefinition workflow = workflow(99L, 10L);
-    given(workflowRepository.findByIdAndDomainPackVersionId(99L, 10L))
+    given(workflowRepository.findByIdAndDomainPackVersionIdForUpdate(99L, 10L))
         .willReturn(Optional.of(workflow));
     // d1 DECISION node has one unlabeled outgoing edge
     String unlabeledDecisionGraph =
@@ -334,9 +339,9 @@ class UpdateWorkflowUseCaseTest {
   @DisplayName("V7a 위반(edge id 누락) 시 WorkflowEdgeIdMissingException")
   void should_V7a예외_when_edge아이디누락() {
     DomainPackVersion version = draftVersion(10L, 7L);
-    given(versionRepository.findById(10L)).willReturn(Optional.of(version));
+    given(versionRepository.findByIdForUpdate(10L)).willReturn(Optional.of(version));
     WorkflowDefinition workflow = workflow(99L, 10L);
-    given(workflowRepository.findByIdAndDomainPackVersionId(99L, 10L))
+    given(workflowRepository.findByIdAndDomainPackVersionIdForUpdate(99L, 10L))
         .willReturn(Optional.of(workflow));
     String noEdgeIdGraph =
         "{\"direction\":\"LR\","
@@ -355,9 +360,9 @@ class UpdateWorkflowUseCaseTest {
   @DisplayName("V7b 위반(edge id 중복) 시 WorkflowEdgeIdDuplicateException")
   void should_V7b예외_when_edge아이디중복() {
     DomainPackVersion version = draftVersion(10L, 7L);
-    given(versionRepository.findById(10L)).willReturn(Optional.of(version));
+    given(versionRepository.findByIdForUpdate(10L)).willReturn(Optional.of(version));
     WorkflowDefinition workflow = workflow(99L, 10L);
-    given(workflowRepository.findByIdAndDomainPackVersionId(99L, 10L))
+    given(workflowRepository.findByIdAndDomainPackVersionIdForUpdate(99L, 10L))
         .willReturn(Optional.of(workflow));
     String duplicateEdgeIdGraph =
         "{\"direction\":\"LR\","
@@ -383,9 +388,9 @@ class UpdateWorkflowUseCaseTest {
   void should_성공_when_ACTION노드policyRef유효() {
     // given
     DomainPackVersion version = draftVersion(10L, 7L);
-    given(versionRepository.findById(10L)).willReturn(Optional.of(version));
+    given(versionRepository.findByIdForUpdate(10L)).willReturn(Optional.of(version));
     WorkflowDefinition workflow = workflow(99L, 10L);
-    given(workflowRepository.findByIdAndDomainPackVersionId(99L, 10L))
+    given(workflowRepository.findByIdAndDomainPackVersionIdForUpdate(99L, 10L))
         .willReturn(Optional.of(workflow));
     given(workflowRepository.save(any())).willReturn(workflow);
     UpdateWorkflowCommand command =
@@ -405,9 +410,9 @@ class UpdateWorkflowUseCaseTest {
   void should_예외_when_ACTION노드policyRef미존재() {
     // given
     DomainPackVersion version = draftVersion(10L, 7L);
-    given(versionRepository.findById(10L)).willReturn(Optional.of(version));
+    given(versionRepository.findByIdForUpdate(10L)).willReturn(Optional.of(version));
     WorkflowDefinition workflow = workflow(99L, 10L);
-    given(workflowRepository.findByIdAndDomainPackVersionId(99L, 10L))
+    given(workflowRepository.findByIdAndDomainPackVersionIdForUpdate(99L, 10L))
         .willReturn(Optional.of(workflow));
     doThrow(new WorkflowActionNodePolicyRefNotFoundException("policy-1"))
         .when(validator)
@@ -433,9 +438,9 @@ class UpdateWorkflowUseCaseTest {
   void should_validatePolicyCodes미호출_when_ACTION노드없음() {
     // given
     DomainPackVersion version = draftVersion(10L, 7L);
-    given(versionRepository.findById(10L)).willReturn(Optional.of(version));
+    given(versionRepository.findByIdForUpdate(10L)).willReturn(Optional.of(version));
     WorkflowDefinition workflow = workflow(99L, 10L);
-    given(workflowRepository.findByIdAndDomainPackVersionId(99L, 10L))
+    given(workflowRepository.findByIdAndDomainPackVersionIdForUpdate(99L, 10L))
         .willReturn(Optional.of(workflow));
     given(workflowRepository.save(any())).willReturn(workflow);
     UpdateWorkflowCommand command =

--- a/backend/src/test/java/com/init/domainpack/infrastructure/JpaWorkflowDefinitionRepositoryTest.java
+++ b/backend/src/test/java/com/init/domainpack/infrastructure/JpaWorkflowDefinitionRepositoryTest.java
@@ -5,6 +5,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.init.domainpack.domain.model.WorkflowDefinition;
 import com.init.domainpack.domain.repository.WorkflowDefinitionSummaryRow;
 import com.init.domainpack.infrastructure.persistence.JpaWorkflowDefinitionRepository;
+import jakarta.persistence.LockModeType;
+import java.lang.reflect.Method;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -99,6 +101,17 @@ class JpaWorkflowDefinitionRepositoryTest {
         repository.findAllByDomainPackVersionIdOrderByWorkflowCodeAsc(VERSION_ID);
 
     assertThat(results).isEmpty();
+  }
+
+  @Test
+  @DisplayName("findByIdAndDomainPackVersionIdForUpdate: PESSIMISTIC_WRITE lock 사용")
+  void should_usePessimisticWriteLock_when_forUpdate조회() throws NoSuchMethodException {
+    Method method =
+        JpaWorkflowDefinitionRepository.class.getMethod(
+            "findByIdAndDomainPackVersionIdForUpdate", Long.class, Long.class);
+
+    assertThat(method.getAnnotation(org.springframework.data.jpa.repository.Lock.class).value())
+        .isEqualTo(LockModeType.PESSIMISTIC_WRITE);
   }
 
   private WorkflowDefinition workflow(Long versionId, String code, String name) {

--- a/backend/src/test/java/com/init/domainpack/presentation/WorkflowDefinitionControllerTest.java
+++ b/backend/src/test/java/com/init/domainpack/presentation/WorkflowDefinitionControllerTest.java
@@ -10,6 +10,7 @@ import com.init.domainpack.application.GetWorkflowDefinitionListUseCase;
 import com.init.domainpack.application.GetWorkflowDefinitionUseCase;
 import com.init.domainpack.application.GetWorkflowTransitionListUseCase;
 import com.init.domainpack.application.GetWorkflowTransitionUseCase;
+import com.init.domainpack.application.UpdateWorkflowTransitionUseCase;
 import com.init.domainpack.application.UpdateWorkflowUseCase;
 import com.init.domainpack.application.WorkflowDefinitionDetail;
 import com.init.domainpack.application.WorkflowDefinitionSummary;
@@ -52,6 +53,7 @@ class WorkflowDefinitionControllerTest {
   @MockitoBean private UpdateWorkflowUseCase updateUseCase;
   @MockitoBean private GetWorkflowTransitionUseCase transitionUseCase;
   @MockitoBean private GetWorkflowTransitionListUseCase transitionListUseCase;
+  @MockitoBean private UpdateWorkflowTransitionUseCase updateTransitionUseCase;
 
   @Test
   @DisplayName("GET .../workflows → 200 OK, 목록 반환")

--- a/backend/src/test/java/com/init/domainpack/presentation/WorkflowDefinitionUpdateControllerTest.java
+++ b/backend/src/test/java/com/init/domainpack/presentation/WorkflowDefinitionUpdateControllerTest.java
@@ -17,6 +17,7 @@ import com.init.domainpack.application.GetWorkflowDefinitionUseCase;
 import com.init.domainpack.application.GetWorkflowTransitionListUseCase;
 import com.init.domainpack.application.GetWorkflowTransitionUseCase;
 import com.init.domainpack.application.UpdateWorkflowCommand;
+import com.init.domainpack.application.UpdateWorkflowTransitionUseCase;
 import com.init.domainpack.application.UpdateWorkflowUseCase;
 import com.init.domainpack.application.WorkflowDefinitionDetail;
 import com.init.domainpack.application.exception.DomainPackUnauthorizedWorkspaceAccessException;
@@ -62,6 +63,7 @@ class WorkflowDefinitionUpdateControllerTest {
   @MockitoBean private UpdateWorkflowUseCase updateUseCase;
   @MockitoBean private GetWorkflowTransitionUseCase transitionUseCase;
   @MockitoBean private GetWorkflowTransitionListUseCase transitionListUseCase;
+  @MockitoBean private UpdateWorkflowTransitionUseCase updateTransitionUseCase;
 
   @Test
   @DisplayName("유효한 요청 시 200 OK + WorkflowDefinitionDetail 반환")

--- a/backend/src/test/java/com/init/domainpack/presentation/WorkflowTransitionUpdateControllerTest.java
+++ b/backend/src/test/java/com/init/domainpack/presentation/WorkflowTransitionUpdateControllerTest.java
@@ -1,0 +1,207 @@
+package com.init.domainpack.presentation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.init.domainpack.application.GetWorkflowDefinitionListUseCase;
+import com.init.domainpack.application.GetWorkflowDefinitionUseCase;
+import com.init.domainpack.application.GetWorkflowTransitionListUseCase;
+import com.init.domainpack.application.GetWorkflowTransitionUseCase;
+import com.init.domainpack.application.UpdateWorkflowTransitionCommand;
+import com.init.domainpack.application.UpdateWorkflowTransitionUseCase;
+import com.init.domainpack.application.UpdateWorkflowUseCase;
+import com.init.domainpack.application.WorkflowTransitionDetail;
+import com.init.domainpack.application.exception.WorkflowTransitionNotFoundException;
+import com.init.fixtures.WithLongPrincipal;
+import com.init.shared.application.exception.BadRequestException;
+import com.init.shared.infrastructure.security.JwtAuthenticationFilter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(
+    value = WorkflowDefinitionController.class,
+    excludeFilters =
+        @ComponentScan.Filter(
+            type = FilterType.ASSIGNABLE_TYPE,
+            classes = JwtAuthenticationFilter.class))
+@DisplayName("WorkflowDefinitionController PATCH /{workflowId}/transitions/{transitionId}")
+class WorkflowTransitionUpdateControllerTest {
+
+  private static final String BASE_URL =
+      "/api/v1/workspaces/1/domain-packs/7/versions/10/workflows/99/transitions/e_check_action";
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private GetWorkflowDefinitionListUseCase listUseCase;
+  @MockitoBean private GetWorkflowDefinitionUseCase detailUseCase;
+  @MockitoBean private UpdateWorkflowUseCase updateUseCase;
+  @MockitoBean private GetWorkflowTransitionUseCase transitionUseCase;
+  @MockitoBean private GetWorkflowTransitionListUseCase transitionListUseCase;
+  @MockitoBean private UpdateWorkflowTransitionUseCase updateTransitionUseCase;
+
+  @Test
+  @DisplayName("정상 요청 시 200 OK + 확장된 WorkflowTransitionDetail 반환")
+  @WithLongPrincipal(5L)
+  void should_200OK_when_validPatchRequest() throws Exception {
+    ArgumentCaptor<UpdateWorkflowTransitionCommand> captor =
+        ArgumentCaptor.forClass(UpdateWorkflowTransitionCommand.class);
+    given(updateTransitionUseCase.execute(any())).willReturn(sampleTransition());
+
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    "{\"condition\":{\"label\":\" 가능 \"},"
+                        + "\"action\":{\"policyRef\":\"policy_new\"}}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value("e_check_action"))
+        .andExpect(jsonPath("$.fromType").value("DECISION"))
+        .andExpect(jsonPath("$.toType").value("ACTION"))
+        .andExpect(jsonPath("$.condition.editable").value(true))
+        .andExpect(jsonPath("$.condition.label").value("가능"))
+        .andExpect(jsonPath("$.action.editable").value(true))
+        .andExpect(jsonPath("$.action.policyRef").value("policy_new"))
+        .andExpect(jsonPath("$.outcome.editable").value(false));
+
+    verify(updateTransitionUseCase).execute(captor.capture());
+    UpdateWorkflowTransitionCommand command = captor.getValue();
+    assertThat(command.workspaceId()).isEqualTo(1L);
+    assertThat(command.packId()).isEqualTo(7L);
+    assertThat(command.versionId()).isEqualTo(10L);
+    assertThat(command.workflowId()).isEqualTo(99L);
+    assertThat(command.transitionId()).isEqualTo("e_check_action");
+    assertThat(command.requesterId()).isEqualTo(5L);
+    assertThat(command.condition().label()).isEqualTo("가능");
+    assertThat(command.action().policyRef()).isEqualTo("policy_new");
+    assertThat(command.outcome()).isNull();
+  }
+
+  @Test
+  @DisplayName("명시적 null section이면 400 VALIDATION_ERROR")
+  @WithLongPrincipal(5L)
+  void should_400_when_explicitNullSection() throws Exception {
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"action\":null}"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+
+    verifyNoInteractions(updateTransitionUseCase);
+  }
+
+  @Test
+  @DisplayName("명시적 null field이면 400 VALIDATION_ERROR")
+  @WithLongPrincipal(5L)
+  void should_400_when_explicitNullField() throws Exception {
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"outcome\":{\"state\":null,\"label\":\"완료\"}}"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+
+    verifyNoInteractions(updateTransitionUseCase);
+  }
+
+  @Test
+  @DisplayName("malformed JSON이면 400 VALIDATION_ERROR")
+  @WithLongPrincipal(5L)
+  void should_400_when_malformedJson() throws Exception {
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"condition\":"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+
+    verifyNoInteractions(updateTransitionUseCase);
+  }
+
+  @Test
+  @DisplayName("UseCase가 WORKFLOW_TRANSITION_NOT_FOUND를 던지면 404")
+  @WithLongPrincipal(5L)
+  void should_404_when_transitionNotFound() throws Exception {
+    given(updateTransitionUseCase.execute(any()))
+        .willThrow(new WorkflowTransitionNotFoundException("e_check_action"));
+
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"condition\":{\"label\":\"가능\"}}"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("WORKFLOW_TRANSITION_NOT_FOUND"));
+  }
+
+  @Test
+  @DisplayName("UseCase가 WORKFLOW_NOT_EDITABLE을 던지면 400")
+  @WithLongPrincipal(5L)
+  void should_400_when_workflowNotEditable() throws Exception {
+    given(updateTransitionUseCase.execute(any()))
+        .willThrow(new BadRequestException("WORKFLOW_NOT_EDITABLE", "DRAFT 상태의 버전에서만 수정할 수 있습니다."));
+
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"condition\":{\"label\":\"가능\"}}"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("WORKFLOW_NOT_EDITABLE"));
+  }
+
+  @Test
+  @DisplayName("인증 없는 요청이면 401")
+  void should_401_when_unauthenticated() throws Exception {
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"condition\":{\"label\":\"가능\"}}"))
+        .andExpect(status().isUnauthorized());
+
+    verifyNoInteractions(updateTransitionUseCase);
+  }
+
+  private WorkflowTransitionDetail sampleTransition() {
+    return new WorkflowTransitionDetail(
+        "e_check_action",
+        99L,
+        10L,
+        "check",
+        "action",
+        "DECISION",
+        "ACTION",
+        "가능",
+        "policy_new",
+        new WorkflowTransitionDetail.TransitionConditionDetail(true, "가능"),
+        new WorkflowTransitionDetail.TransitionActionDetail(true, "policy_new"),
+        new WorkflowTransitionDetail.TransitionOutcomeDetail(false, null, null));
+  }
+}

--- a/backend/src/test/java/com/init/domainpack/presentation/WorkflowTransitionUpdateControllerTest.java
+++ b/backend/src/test/java/com/init/domainpack/presentation/WorkflowTransitionUpdateControllerTest.java
@@ -126,6 +126,59 @@ class WorkflowTransitionUpdateControllerTest {
   }
 
   @Test
+  @DisplayName("빈 본문이면 400 VALIDATION_ERROR")
+  @WithLongPrincipal(5L)
+  void should_400_when_emptyBody() throws Exception {
+    mockMvc
+        .perform(patch(BASE_URL).with(csrf()).contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+
+    verifyNoInteractions(updateTransitionUseCase);
+  }
+
+  @Test
+  @DisplayName("blank 문자열 field이면 400 VALIDATION_ERROR")
+  @WithLongPrincipal(5L)
+  void should_400_when_blankField() throws Exception {
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"condition\":{\"label\":\"   \"}}"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+
+    verifyNoInteractions(updateTransitionUseCase);
+  }
+
+  @Test
+  @DisplayName("outcome 빈 객체는 command에 빈 outcome으로 전달한다")
+  @WithLongPrincipal(5L)
+  void should_passEmptyOutcomeToUseCase_when_outcomeObjectEmpty() throws Exception {
+    ArgumentCaptor<UpdateWorkflowTransitionCommand> captor =
+        ArgumentCaptor.forClass(UpdateWorkflowTransitionCommand.class);
+    given(updateTransitionUseCase.execute(any()))
+        .willThrow(
+            new BadRequestException("WORKFLOW_TRANSITION_OUTCOME_EMPTY", "outcome이 비어 있습니다."));
+
+    mockMvc
+        .perform(
+            patch(BASE_URL)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"outcome\":{}}"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("WORKFLOW_TRANSITION_OUTCOME_EMPTY"));
+
+    verify(updateTransitionUseCase).execute(captor.capture());
+    assertThat(captor.getValue().outcome()).isNotNull();
+    assertThat(captor.getValue().outcome().state()).isNull();
+    assertThat(captor.getValue().outcome().label()).isNull();
+  }
+
+  @Test
   @DisplayName("malformed JSON이면 400 VALIDATION_ERROR")
   @WithLongPrincipal(5L)
   void should_400_when_malformedJson() throws Exception {


### PR DESCRIPTION
## 요약

- DRAFT 상태의 Domain Pack Version에서 workflow transition 의미 필드를 부분 수정하는 PATCH API를 추가
- transition 조회 응답에 from/to node type과 condition/action/outcome editable 정보를 확장
- 수정 후 기존 workflow graph validation과 ACTION policyRef 검증을 다시 수행하도록 함
- version/workflow row lock을 적용해 publish race와 동시 PATCH lost update를 방지
- request validation, 부분 outcome 수정, policyRef/state 검증, lock 사용 여부 테스트를 보강

## 범위

수정 가능:
- DECISION 발신 transition의 condition label
- ACTION 목적지 node의 action policyRef
- TERMINAL 목적지 node의 outcome state/label

## 검증

- `cd backend && ./gradlew test`
- `cd backend && ./gradlew spotlessJavaCheck`
- pre-commit `cd backend && ./gradlew spotlessCheck`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ajou-2026-1-capstone-5/ostone/pull/215" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 초안 도메인 패키지 버전 내 워크플로우 전환의 조건·작업·결과를 수정하는 PATCH 엔드포인트 추가
  * 전환 상세 응답이 편집 가능 여부와 중첩된 조건/작업/결과 필드를 포함하도록 확장
  * 동시성 제어를 위한 데이터 잠금(업데이트용 잠금) 도입

* **Bug Fixes / Validation**
  * JSON/필드 유효성 검사 강화 및 관련 오류 코드 매핑 개선

* **Tests**
  * 엔드투엔드 수준의 유닛·웹 계층 테스트 대폭 보강

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ajou-2026-1-capstone-5/ostone/pull/215)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->