### PR TITLE
[Spec] 4.1.7 채팅 타임라인 및 메시지별 워크플로우 매핑

### DIFF
--- a/.agent/specs/4.1.7.md
+++ b/.agent/specs/4.1.7.md
@@ -1,0 +1,563 @@
+# [FE-4.1.7] 채팅 타임라인 및 메시지별 워크플로우 매핑 표시
+
+> **Backlog**: 4.1.7 채팅 타임라인 및 메시지별 워크플로우 매핑 표시 구현
+> **FSD Layer**: `features/chat-workflow`, `pages/chat-demo`
+> **Template**: `_TEMPLATE_FE.md`
+> **Branch (구현 단계)**: `feature/4.1.7-chat-timeline-workflow-mapping`
+> **API Reference**: `.agent/specs/4.1.5.md` — 데모 Mock API 응답 구조
+
+---
+
+## Goal
+
+채팅 메시지 타임라인에서 특정 메시지를 선택하면, 해당 메시지와 연관된 워크플로우 상태 전이(decision log), 실행 컨텍스트(slot/policy/risk), 그리고 워크플로우 그래프를 우측 패널에 매핑하여 표시하는 2-column 레이아웃을 구현한다.
+
+기존 3-column 레이아웃(타임라인 | 그래프 | 실행 상세)을 타임라인(좌) + 통합 우측 패널(우)로 재구성하고, `scenario` prop을 제거하여 4.1.5 API 응답 구조와 정합시킨다.
+
+---
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A[페이지 진입] --> B[API 로딩<br/>GET /demo/chat-workflow]
+    B --> C{로딩 상태?}
+    C -->|Loading| D[Skeleton UI 표시]
+    C -->|Error| E[에러 메시지 + 재시도 버튼]
+    C -->|Success| F[2-column 레이아웃 표시]
+    
+    F --> G[좌: Chat Timeline<br/>메시지 목록 (role + content + timestamp)]
+    F --> H[우: 통합 패널<br/>워크플로우 개요]
+
+    H --> I{메시지 선택?}
+    I -->|No| J[워크플로우 전체 개요<br/>- 전체 state machine<br/>- 실행 context 요약<br/>- decision log 전체 목록]
+    I -->|Yes| K[선택 메시지 연동 뷰]
+    
+    K --> L[좌측: 선택 메시지 하이라이트]
+    K --> M[워크플로우 그래프<br/>커스텀 경량 노드-엣지<br/>현재 state 강조]
+    K --> N[실행 컨텍스트<br/>slots / policies / risks]
+    K --> O[연관 decision logs<br/>messageId 기준 필터링]
+    
+    L --> P[사용자: 다른 메시지 선택]
+    P --> K
+
+    subgraph "Edge Cases"
+        Q[메시지 0개] --> R[빈 타임라인 +<br/>'대화 내역이 없습니다.']
+        S[decision log 0개] --> T['기록된 결정이 없습니다.']
+        U[API 4xx/5xx] --> V[ErrorBoundary fallback]
+    end
+```
+
+> Gate 분기: `메시지 선택됨?` → Yes/No에 따라 우측 패널 내용이 전환됨
+
+---
+
+## Design Diff
+
+### As-is vs To-be
+
+| 영역 | As-is (현재) | To-be (변경 후) | 변경 내용 |
+|------|-------------|-----------------|----------|
+| 레이아웃 | 3-column (타임라인 0.38 \| 그래프 0.37 \| 실행 0.25) | 2-column (타임라인 좌 \| 통합 패널 우) | 기존 3개 패널을 타임라인+통합 우측 패널로 재구성 |
+| 타임라인 | 단순 메시지 목록 (role + content) | 타임라인 + timestamp + 선택 가능 + 선택 시 하이라이트 | 메시지 클릭 가능, timestamp 추가, 선택 상태 시각화 |
+| 그래프 | 단순 텍스트(current node만 표시) | 커스텀 경량 노드-엣지 그래프 | XYFlow 제거, 자체 구현 SVG 기반 state machine 시각화 |
+| 실행 패널 | status + context (key-value 목록) | 선택한 decision log 기반 slots/policies/risks 통합 표시 | 정적 context 대신 decision log 연동 |
+| Decision Log | Drawer 방식 (토글 열기) | 우측 패널 하단 인라인 섹션 | 별도 Drawer 제거, 우측 패널에 통합 |
+| Header | domainPack + scenario 표시 | domainPack만 표시 | `scenario` prop 제거 |
+| 타입 | 6개 interface (scenario 포함) | scenario 제거, API 응답 연동 타입 확장 | ChatMessage에 timestamp 추가, DecisionLogEntry에 messageId/eventType/stateFrom/stateTo/confidence 추가 |
+| Mock | 단순 fixture (3 messages, 2 entries) | 4.1.5 API 응답 기반 fixture로 교체 | scenario 제거, execution 상세(slots/policies/risks) 포함 |
+
+### 변경 요약 표
+
+| 파일 | As-is | To-be | 변경 |
+|------|-------|-------|------|
+| `chatWorkflow.types.ts` | 6 interfaces (ScenarioInfo 포함) | ScenarioInfo 제거, ChatMessage/DecisionLogEntry 확장, 신규 타입 추가 | 수정 |
+| `chatWorkflowDemo.mock.ts` | demoScenario 포함, 단순 fixture | scenario 제거, 4.1.5 응답 구조 fixture로 교체 | 수정 |
+| `ChatTimelinePanel.tsx` | 메시지 목록 단순 표시 | 클릭 가능 + timestamp + 선택 하이라이트 | 수정 |
+| `WorkflowGraphPanel.tsx` | 단순 텍스트 | 커스텀 경량 노드-엣지 그래프 (SVG) | 재구현 |
+| `ExecutionDetailPanel.tsx` | status + context | decision log 연동 slots/policies/risks | 재구현 |
+| `DecisionLogDrawer.tsx` | Drawer 토글 | 우측 패널에 인라인 통합 | 제거/통합 |
+| `ChatWorkflowHeader.tsx` | domainPack + scenario | domainPack only | 수정 |
+| `ChatWorkflowDemoPage.tsx` | 3-column layout | 2-column layout, props 변경 | 수정 |
+| `ChatWorkflowDemoPageWrapper.tsx` | scenario prop 포함 | scenario 제거, fixture 교체 | 수정 |
+
+---
+
+## Component Tree
+
+```
+ChatWorkflowDemoPage (2-column layout)
+├─ ChatWorkflowHeader
+│    └─ domainPack info (name + version + status badge)
+├─ ChatTimelinePanel (좌측, scrollable)
+│    ├─ TimelineMessage (role icon + content + timestamp)
+│    │    └─ [selected state: highlighted bg]
+│    └─ EmptyState (no messages)
+└─ WorkflowDetailPanel (우측, scrollable) [신규 통합]
+     ├─ [상단] WorkflowGraphView [신규]
+     │    └─ WorkflowNode (커스텀 SVG circle + label)
+     │    └─ WorkflowEdge (SVG path + arrow)
+     │    └─ NodeHighlight (selected state 강조)
+     ├─ [중단] ExecutionContextPanel [신규, 선택 메시지 연동]
+     │    ├─ SlotDisplay (key-value slots)
+     │    ├─ PolicyResultCard (policy name + result badge)
+     │    └─ RiskResultCard (risk name + level badge)
+     └─ [하단] DecisionLogSection [신규, 인라인]
+          ├─ DecisionLogEntryCard (step + eventType + decision badge)
+          └─ EmptyLogState
+```
+
+### 신규/변경 컴포넌트 목록
+
+| 컴포넌트 | 상태 | 설명 |
+|----------|------|------|
+| `ChatTimelinePanel` | **수정** | 클릭 핸들러 + selectedId prop 추가 |
+| `TimelineMessage` | **신규** | 개별 메시지 아이템 (role icon + content + timestamp + 선택 상태) |
+| `WorkflowGraphView` | **신규** | WorkflowGraphPanel 대체, 커스텀 SVG 그래프 |
+| `WorkflowNode` | **신규** | SVG circle 노드 (state 이름 + 현재 상태 강조) |
+| `WorkflowEdge` | **신규** | SVG path 엣지 (transition 화살표) |
+| `ExecutionContextPanel` | **신규** | ExecutionDetailPanel 대체, decision log 연동 |
+| `DecisionLogSection` | **신규** | DecisionLogDrawer 대체, 인라인 목록 |
+| `ChatWorkflowHeader` | **수정** | scenario prop 제거 |
+| `WorkflowDetailPanel` | **신규** | 우측 통합 패널 wrapper |
+
+---
+
+## API Integration
+
+### Endpoints (4.1.5 API 참조)
+
+4.1.5 API 스펙에 정의된 endpoints 중 chat-workflow 페이지에서 사용하는 API:
+- `_TEMPLATE_FE.md`의 API Integration 섹션 포맷 참조
+- `4.1.5.md` 데모 API의 chat-workflow 응답 구조를 기준으로 함
+
+| Method | Path | Description | 사용처 |
+|--------|------|-------------|--------|
+| GET | `/api/v1/demo/chat-workflow` | 통합 demo fixture (6개 섹션) | 초기 데이터 로딩 |
+| GET | `/api/v1/demo/chat-sessions/{sessionId}` | chatSession + messages | 세션 재조회 |
+| GET | `/api/v1/demo/workflow-executions/{executionId}` | execution 상세 (slots/policies/risks) | 실행 컨텍스트 상세 |
+| GET | `/api/v1/demo/decision-logs?executionId={id}` | decision logs | 메시지 필터링 대상 |
+
+> 자세한 응답 구조는 `.agent/specs/4.1.5.md` 참조. 본 스펙에서 중복 작성하지 않는다.
+
+### Query Key Pattern (TanStack Query)
+
+```typescript
+// features/chat-workflow/api/chatWorkflowKeys.ts
+export const chatWorkflowKeys = {
+  all: ['chat-workflow'] as const,
+  detail: () => [...chatWorkflowKeys.all, 'detail'] as const,
+  sessions: () => [...chatWorkflowKeys.all, 'session'] as const,
+  session: (id: string) => [...chatWorkflowKeys.sessions(), id] as const,
+  executions: () => [...chatWorkflowKeys.all, 'execution'] as const,
+  execution: (id: string) => [...chatWorkflowKeys.executions(), id] as const,
+  decisionLogs: (executionId: string) =>
+    [...chatWorkflowKeys.all, 'decision-logs', executionId] as const,
+};
+
+// features/chat-workflow/api/useChatWorkflow.ts
+export function useChatWorkflow() {
+  return useQuery({
+    queryKey: chatWorkflowKeys.detail(),
+    queryFn: () => fetchChatWorkflow(),
+  });
+}
+
+// features/chat-workflow/api/useDecisionLogs.ts
+export function useDecisionLogs(executionId: string) {
+  return useQuery({
+    queryKey: chatWorkflowKeys.decisionLogs(executionId),
+    queryFn: () => fetchDecisionLogs(executionId),
+    enabled: !!executionId,
+  });
+}
+```
+
+---
+
+## Data Flow
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                     ChatWorkflowDemoPage                         │
+│  ┌───────────── Local State ───────────────────────────────┐    │
+│  │  selectedMessageId: string | null                        │    │
+│  │  ← ChatTimelinePanel.onMessageSelect(id)                 │    │
+│  └──────────────────────────────────────────────────────────┘    │
+│                                                                   │
+│  ┌───────────── API Data (React Query) ────────────────────┐    │
+│  │  useChatWorkflow() → { messages, workflow, execution,    │    │
+│  │                         decisionLogs, domainPack }       │    │
+│  └──────────────────────────────────────────────────────────┘    │
+│                          │                                       │
+│            ┌─────────────┼──────────────────┐                    │
+│            ▼              ▼                   ▼                   │
+│  ┌─────────────────┐ ┌────────────────────┐ ┌────────────────┐  │
+│  │ ChatTimelinePanel│ │ WorkflowDetailPanel│ │ (error/loading)│  │
+│  │ messages[]       │ │ selectedMessageId  │ │                │  │
+│  │ selectedMessageId│ │ → decisionLog 필터  │ │                │  │
+│  │ onMessageSelect  │ │ → execution context │ │                │  │
+│  └─────────────────┘ └────────────────────┘ └────────────────┘  │
+└─────────────────────────────────────────────────────────────────┘
+
+[메시지 선택 시 데이터 흐름]
+1. ChatTimelinePanel에서 메시지 클릭 → onMessageSelect(messageId)
+2. ChatWorkflowDemoPage가 selectedMessageId 업데이트
+3. WorkflowDetailPanel이 selectedMessageId를 prop으로 수신
+4. decisionLogs에서 messageId === selectedMessageId 로 필터링
+5. 필터링된 logs의 stateFrom/stateTo로 workflow graph의 현재 위치 계산
+6. execution 데이터에서 해당 시점의 slots/policies/risks 추출
+7. 모든 정보를 우측 패널에 동시 렌더링
+8. 사용자가 다른 메시지 선택 시 2-7 반복
+9. 선택 해제(null) 시: decisionLog 전체 목록 + workflow 전체 개요 표시
+```
+
+---
+
+## Type Definitions
+
+4.1.5 API 응답 구조를 기반으로 한 신규 타입 정의. 현재 `chatWorkflow.types.ts`의 타입을 대체한다.
+
+```typescript
+// === 신규: API 응답 매핑 타입 ===
+
+// 4.1.5 GET /demo/chat-workflow 응답 구조 반영
+export interface DemoChatWorkflowResponse {
+  domainPack: DomainPackInfo;
+  workflow: WorkflowDefinition;       // state machine 구조
+  chatSession: ChatSession;
+  messages: ChatMessage[];
+  execution: WorkflowExecution;       // 실행 컨텍스트
+  decisionLogs: DecisionLogEntry[];   // 모든 decision log
+}
+
+// === 신규/변경 타입 ===
+
+// [변경] ChatMessage: timestamp 추가, role union type
+export interface ChatMessage {
+  id: string;
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+  timestamp: string;       // 신규: ISO 8601
+}
+
+// [신규] WorkflowDefinition: state machine 구조
+export interface WorkflowDefinition {
+  id: string;
+  name: string;
+  description: string;
+  states: string[];        // e.g., ["INITIAL", "INTENT_DETECTED", ...]
+  transitions: WorkflowTransition[];
+}
+
+export interface WorkflowTransition {
+  from: string;
+  to: string;
+  on: string;             // trigger event
+}
+
+// [변경] WorkflowExecution: 4.1.5 execution 구조 반영
+export interface WorkflowExecution {
+  id: string;
+  status: 'RUNNING' | 'COMPLETED' | 'FAILED' | 'HANDOFF';
+  currentState: string;
+  currentNodeId: string | null;
+  intent: string;
+  slotValues: Record<string, string | number>;
+  missingSlots: string[];
+  policyHits: PolicyHit[];
+  riskHits: RiskHit[];
+}
+
+export interface PolicyHit {
+  policyId: string;
+  policyName: string;
+  result: 'PASS' | 'FAIL' | 'SKIP';
+  detail: string;
+}
+
+export interface RiskHit {
+  riskId: string;
+  riskName: string;
+  result: 'LOW' | 'MEDIUM' | 'HIGH';
+  detail: string;
+}
+
+// [변경] DecisionLogEntry: messageId, eventType, confidence 등 확장
+export interface DecisionLogEntry {
+  id: string;
+  step: number;           // 신규: 실행 순서
+  messageId: string;       // 신규: 연관 메시지 ID (매핑 키)
+  eventType: string;       // 신규: e.g., INTENT_DETECTED, SLOT_FILLED
+  stateFrom: string;       // 신규: 이전 state
+  stateTo: string;         // 신규: 이후 state
+  decision: 'ALLOW' | 'BLOCK' | 'REVIEW';
+  confidence: number;      // 신규: 0.0 ~ 1.0
+  reason: string;
+}
+
+// [변경] ChatSession: 신규
+export interface ChatSession {
+  id: string;
+  status: 'active' | 'completed' | 'expired';
+  startedAt: string;
+  completedAt?: string;
+}
+
+// [변경] DomainPackInfo: domainPack 섹션 반영 (scenario 제거)
+export interface DomainPackInfo {
+  id?: string;
+  name: string;
+  version: string;
+  publishedAt?: string;
+  status?: string;
+  intents?: DomainIntent[];
+  policies?: DomainPolicy[];
+  risks?: DomainRisk[];
+}
+
+export interface DomainIntent {
+  id: string;
+  name: string;
+  description: string;
+}
+
+export interface DomainPolicy {
+  id: string;
+  name: string;
+  description: string;
+  severity: 'HARD' | 'SOFT';
+}
+
+export interface DomainRisk {
+  id: string;
+  name: string;
+  description: string;
+  level: 'LOW' | 'MEDIUM' | 'HIGH';
+}
+
+// [제거] ScenarioInfo — 더 이상 사용하지 않음
+
+// [변경] ChatWorkflowDemoPage props: scenario 제거
+export interface ChatWorkflowDemoPageProps {
+  domainPack: DomainPackInfo | null;
+  messages: ChatMessage[];
+  execution: WorkflowExecution | null;   // 변경: WorkflowState → WorkflowExecution
+  decisionLogs: DecisionLogEntry[];
+  workflowDefinition: WorkflowDefinition | null;  // 신규
+}
+
+// (참고: 기존 ChatWorkflowDemoState는 삭제, 컴포넌트별 개별 prop 전달로 대체)
+```
+
+---
+
+## UI States
+
+### 1. Loading State
+
+**트리거**: `useChatWorkflow()`가 isLoading 상태일 때
+
+- **전체 페이지**: Skeleton UI 표시
+  - Header 영역: 2줄 skeleton bar
+  - 좌측 타임라인 영역: 4-5개 메시지 skeleton (각각 다른 너비)
+  - 우측 패널 영역: 그래프 skeleton circle + line, context skeleton card 2개
+
+### 2. Empty State
+
+**트리거 A — 메시지 목록이 비어있을 때** (`messages.length === 0`)
+
+- 좌측 타임라인에 중앙 정렬 메시지:
+  - 아이콘: `MessageSquare` (또는 유사 아이콘)
+  - 제목: "대화 내역이 없습니다"
+  - 설명: "새로운 대화를 시작해보세요"
+
+**트리거 B — decision logs가 비어있을 때** (`decisionLogs.length === 0`)
+
+- 우측 패널 decision log 섹션에 표시:
+  - "기록된 결정이 없습니다"
+  - 설명: "워크플로우가 아직 실행되지 않았습니다"
+
+### 3. Default State (메시지 미선택)
+
+- **타임라인**: 모든 메시지 표시, 선택된 메시지 없음 (기본 배경)
+- **우측 패널 상단(그래프)**: 워크플로우 전체 state machine 그래프 표시
+  - 모든 노드 표시 (현재 상태는 강조)
+  - 텍스트: "메시지를 선택하면 해당 시점의 워크플로우 상태를 확인할 수 있습니다"
+- **우측 패널 중단(컨텍스트)**: 실행 컨텍스트 전체 요약
+  - intent, slotValues, policyHits, riskHits 전체 목록
+- **우측 패널 하단(log)**: decisionLog 전체 목록 (step 순)
+
+### 4. Selected State (메시지 선택됨)
+
+- **타임라인**: 선택된 메시지에 하이라이트 배경 (예: `bg-accent` 또는 파란색 테두리)
+- **우측 패널 상단(그래프)**: 선택 메시지의 decision log 기준 state 전이 강조
+  - `stateFrom` → `stateTo` 엣지 하이라이트
+  - 현재 state 노드 강조 표시
+  - 툴팁: "메시지 '{내용 일부}' → {eventType} → {stateTo}"
+- **우측 패널 중단(컨텍스트)**: 선택 시점의 slots/policies/risks 표시
+  - slots: messageId 시점까지 수집된 slot 값
+  - policies: messageId 시점까지 평가된 policy 결과
+  - risks: messageId 시점까지 평가된 risk 결과
+- **우측 패널 하단(log)**: messageId 기준 필터링된 decision logs
+  - "메시지 '{내용 일부}'와 관련된 결정 {N}건"
+  - 필터링된 log 목록 (step, eventType, decision badge, reason)
+
+### 5. Error State
+
+**트리거**: `useChatWorkflow()`가 error 상태일 때
+
+- **전체 페이지**: ErrorBoundary fallback
+  - 아이콘: `AlertTriangle`
+  - 제목: "데이터를 불러올 수 없습니다"
+  - 설명: error.message 표시
+  - 버튼: "다시 시도" (refetch 트리거)
+
+**부분 에러** (decision logs만 실패):
+- decision log 섹션만 에러 표시
+- 그래프 및 컨텍스트는 캐시된 데이터로 정상 표시
+- "결정 로그를 불러오지 못했습니다" + 재시도 버튼
+
+### UI States Diagram
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                 ChatWorkflowDemoPage                     │
+├─────────────────────────────────────────────────────────┤
+│  ┌──────────────────────┬──────────────────────────────┐ │
+│  │ ChatTimelinePanel    │ WorkflowDetailPanel          │ │
+│  │                      │                              │ │
+│  │ [Loading]            │ [Loading]                    │ │
+│  │  ┌──────────────┐    │  ┌──────────────────────┐   │ │
+│  │  │ ████████████  │    │  │     ○──→○            │   │ │
+│  │  │ ████████      │    │  │    /      \           │   │ │
+│  │  │ █████████     │    │  │   ○        ○          │   │ │
+│  │  └──────────────┘    │  └──────────────────────┘   │ │
+│  │                      │                              │ │
+│  │ [Empty]              │ [Error]                      │ │
+│  │  대화 내역이          │  ⚠ 데이터를 불러올 수 없습니다│ │
+│  │  없습니다            │  [다시 시도]                  │ │
+│  │                      │                              │ │
+│  │ [Default]            │ [Default - No Selection]     │ │
+│  │  👤: 내용...         │  전체 workflow graph         │ │
+│  │  🤖: 내용...    ←    │  실행 컨텍스트 요약            │ │
+│  │  👤: 내용...         │  decision log 전체           │ │
+│  │                      │                              │ │
+│  │ [Selected]           │ [Selected - msg-2]           │ │
+│  │  👤: 내용...         │  ▸ graph: INTENT_DETECTED 강조│ │
+│  │  🤖: 내용... 🎯←    │  ▸ slots: orderNumber 수집    │ │
+│  │  👤: 내용...         │  ▸ logs: msg-2 연관 2건     │ │
+│  └──────────────────────┴──────────────────────────────┘ │
+└─────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Testing Strategy
+
+### TDD 접근법 (RED → GREEN → REFACTOR)
+
+FSD 계층별로 구분하여 단위 테스트 → 통합 테스트 순서로 진행한다.
+
+### 1. Model/Type Tests
+
+**영역**: `chatWorkflow.types.ts`
+
+```typescript
+// RED: 타입 정의가 아직 없음 → GREEN: 타입 정의 후 컴파일 통과
+describe('ChatWorkflow Types', () => {
+  it('ChatMessage에 timestamp 필드가 포함된다', () => {
+    // type-level test (ts-expect-error 없이 사용 가능)
+  });
+  it('ScenarioInfo가 더 이상 사용되지 않는다', () => {
+    // ScenarioInfo 참조가 있는지 검증
+  });
+  it('DecisionLogEntry에 messageId, eventType, confidence가 포함된다', () => {
+    // type-level test
+  });
+});
+```
+
+### 2. Component Unit Tests (Vitest + Testing Library)
+
+**2a. ChatTimelinePanel**
+
+```typescript
+describe('ChatTimelinePanel', () => {
+  it('메시지 목록을 올바르게 렌더링한다');
+  it('빈 메시지 목록에서 empty state를 표시한다');
+  it('메시지 클릭 시 onMessageSelect(id)를 호출한다');
+  it('선택된 메시지에 하이라이트 클래스가 적용된다');
+  it('timestamp를 올바른 형식으로 표시한다');
+  it('role별로 다른 아이콘/라벨을 표시한다');
+  it('selectedMessageId가 null이면 하이라이트가 없다');
+});
+```
+
+**2b. WorkflowGraphView**
+
+```typescript
+describe('WorkflowGraphView', () => {
+  it('states 배열의 모든 노드를 SVG로 렌더링한다');
+  it('transitions 배열의 모든 엣지를 SVG path로 렌더링한다');
+  it('currentState에 해당하는 노드를 강조 표시한다');
+  it('highlightState가 있으면 해당 노드를 다른 색상으로 표시한다');
+  it('빈 states 배열에서 empty state를 표시한다');
+  it('노드 라벨이 올바르게 표시된다');
+});
+```
+
+**2c. ExecutionContextPanel**
+
+```typescript
+describe('ExecutionContextPanel', () => {
+  it('slotValues의 모든 key-value를 표시한다');
+  it('policyHits의 각 policy 결과를 badge로 표시한다');
+  it('riskHits의 각 risk 레벨을 색상으로 구분한다');
+  it('missingSlots가 있으면 알림을 표시한다');
+  it('데이터가 없으면 empty state를 표시한다');
+});
+```
+
+**2d. DecisionLogSection**
+
+```typescript
+describe('DecisionLogSection', () => {
+  it('모든 decision log를 step 순으로 표시한다');
+  it('messageId로 필터링된 로그만 표시한다');
+  it('decision 종류별로 다른 badge 색상을 사용한다 (ALLOW=green, BLOCK=red)');
+  it('confidence를 progress bar 또는 숫자로 표시한다');
+  it('빈 로그에서 empty state를 표시한다');
+  it('필터링 결과가 0건이면 "관련된 결정이 없습니다"를 표시한다');
+});
+```
+
+### 3. Integration Tests
+
+```typescript
+describe('ChatWorkflowDemoPage Integration', () => {
+  it('API 로딩 중에 skeleton UI를 표시한다');
+  it('API 성공 후 전체 레이아웃이 2-column으로 렌더링된다');
+  it('메시지 클릭 시 우측 패널이 업데이트된다');
+  it('다른 메시지 선택 시 이전 선택이 해제되고 새 선택이 적용된다');
+  it('선택 해제 시 전체 개요로 복원된다');
+  it('API 에러 시 ErrorBoundary fallback을 표시한다');
+  it('scenario prop이 더 이상 전달되지 않는다');
+});
+```
+
+### 4. 커스텀 Workflow Graph 테스트 전략
+
+커스텀 SVG 그래프는 XYFlow를 사용하지 않으므로 다음을 별도 검증:
+
+- SVG 엘리먼트 수가 states/transitions 개수와 일치하는지
+- edge path가 올바른 노드 좌표를 연결하는지
+- 하이라이트된 노드/엣지의 CSS class가 올바르게 적용되는지
+- 반응형: 컨테이너 크기에 따라 SVG viewBox가 조정되는지
+- 접근성: 각 노드에 aria-label이 있는지
+
+### 5. E2E 테스트 (Playwright) — 향후 확장
+
+- 메시지 선택 → 우측 패널 업데이트 플로우
+- 빈 상태/에러 상태 시각 확인
+- 반응형 레이아웃 (모바일에서 1-column 전환)

--- a/.agent/specs/4.1.7.md
+++ b/.agent/specs/4.1.7.md
@@ -94,7 +94,7 @@ ChatWorkflowDemoPage (2-column layout)
 │    │    └─ [selected state: highlighted bg]
 │    └─ EmptyState (no messages)
 └─ WorkflowDetailPanel (우측, scrollable) [신규 통합]
-     ├─ [상단] WorkflowGraphView [신규]
+     ├─ [상단] WorkflowGraphPanel (재구현: 기존 텍스트 → SVG 그래프)
      │    └─ WorkflowNode (커스텀 SVG circle + label)
      │    └─ WorkflowEdge (SVG path + arrow)
      │    └─ NodeHighlight (selected state 강조)
@@ -206,7 +206,7 @@ export function useDecisionLogs(executionId: string) {
 3. WorkflowDetailPanel이 selectedMessageId를 prop으로 수신
 4. decisionLogs에서 messageId === selectedMessageId 로 필터링
 5. 필터링된 logs의 stateFrom/stateTo로 workflow graph의 현재 위치 계산
-6. execution 데이터에서 해당 시점의 slots/policies/risks 추출
+6. DecisionLogEntry의 messageId 기준 필터링 결과를 execution의 slots/policies/risks와 함께 표시
 7. 모든 정보를 우측 패널에 동시 렌더링
 8. 사용자가 다른 메시지 선택 시 2-7 반복
 9. 선택 해제(null) 시: decisionLog 전체 목록 + workflow 전체 개요 표시
@@ -306,14 +306,14 @@ export interface ChatSession {
 
 // [변경] DomainPackInfo: domainPack 섹션 반영 (scenario 제거)
 export interface DomainPackInfo {
-  id?: string;
+  id: string;
   name: string;
   version: string;
   publishedAt?: string;
-  status?: string;
-  intents?: DomainIntent[];
-  policies?: DomainPolicy[];
-  risks?: DomainRisk[];
+  status: string;
+  intents: DomainIntent[];
+  policies: DomainPolicy[];
+  risks: DomainRisk[];
 }
 
 export interface DomainIntent {


### PR DESCRIPTION
## Summary

4.1.7 이슈에 대한 FE 스펙 문서를 작성합니다. 기존 3-column 데모 채팅 레이아웃을 타임라인(좌) + 메시지-워크플로우 매핑 통합 패널(우)의 2-column 레이아웃으로 재설계합니다.

## 주요 변경 사항

- 레이아웃: 3-column → 2-column (타임라인 + 통합 우측 패널)
- 타입: 기존 6개 interface 확장 (timestamp, messageId, eventType, confidence 등 추가, scenario 제거)
- 컴포넌트: 신규 6개 (WorkflowGraphView, TimelineMessage, ExecutionContextPanel, DecisionLogSection, WorkflowDetailPanel, WorkflowNode/Edge)
- API: 4.1.5 데모 Mock API 기반 Query Key Pattern 정의
- 테스트: TDD (RED→GREEN→REFACTOR) 접근법, 단위/통합 테스트 시나리오 명시

## 주요 결정 사항

- Workflow 그래프: 커스텀 경량 SVG (XYFlow 미사용)
- DecisionLogDrawer: 별도 Drawer → 인라인 섹션으로 통합
- scenario prop: 제거
- UI States: loading/empty/default/selected/error 5가지 상태 정의

## 참조

- FSD Template: `.agent/specs/_TEMPLATE_FE.md`
- API Reference: `.agent/specs/4.1.5.md`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ajou-2026-1-capstone-5/ostone/pull/216" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **문서화**
  * 채팅 타임라인 및 메시지별 워크플로우 매핑 표시 기능의 요구사항 및 설계 문서 추가
  * 메시지 선택 시 우측 통합 패널에서 연결된 워크플로우 정보 자동 필터링 및 표시 방식 명시
  * 데이터 흐름, UI 상태 및 테스트 전략에 대한 상세 가이드 포함

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ajou-2026-1-capstone-5/ostone/pull/216)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->