### PR TITLE
feat(ml/draft-generation): add slot draft extraction from workflow_signal

### DIFF
--- a/ml/src/pipeline/stages/draft_generation/main.py
+++ b/ml/src/pipeline/stages/draft_generation/main.py
@@ -5,7 +5,7 @@ import logging
 import os
 import time
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
 from pipeline.common.artifacts import ensure_stage_directory, write_stage_manifest
 from pipeline.common.config import PipelineRuntimeConfig
@@ -29,6 +29,29 @@ _logger = logging.getLogger("pipeline.draft_generation")
 DEFAULT_CANDIDATE_ARTIFACT = "candidate.json"
 DEFAULT_CLUSTERS_ARTIFACT = "clusters.json"
 DEFAULT_PREPROCESSED_ARTIFACT = "preprocessed_data.json"
+
+
+class SlotTemplate(NamedTuple):
+    code_suffix: str
+    name: str
+    description: str
+    data_type: str
+    is_sensitive: bool
+
+
+SIGNAL_SLOT_MAPPING: dict[str, tuple[SlotTemplate, ...]] = {
+    "requires_payment_check": (
+        SlotTemplate("order_id", "주문 ID", "결제·환불 대상 주문 식별자", "STRING", False),
+        SlotTemplate("payment_method", "결제 수단", "결제 수단 (카드/계좌이체 등)", "STRING", False),
+    ),
+    "requires_user_identification": (
+        SlotTemplate("customer_name", "고객 이름", "본인 확인용 고객 이름", "STRING", True),
+        SlotTemplate("customer_phone", "고객 연락처", "본인 확인용 휴대폰 번호", "STRING", True),
+    ),
+    "has_escalation_cases": (
+        SlotTemplate("escalation_reason", "에스컬레이션 사유", "상담사 전환 사유", "STRING", False),
+    ),
+}
 
 
 def run(upstream_manifest_path: str | None = None) -> dict[str, object]:
@@ -68,6 +91,21 @@ def run(upstream_manifest_path: str | None = None) -> dict[str, object]:
         workflow_metrics["workflow_evidence_exemplar_total"],
         workflow_metrics["workflow_evidence_member_total"],
         workflow_metrics["workflow_with_empty_evidence_count"],
+    )
+
+    slots, intent_slot_bindings, slot_metrics = _build_slot_draft(clusters)
+    workflow_draft["slots"] = slots
+    workflow_draft["intentSlotBindings"] = intent_slot_bindings
+    metrics.update(slot_metrics)
+    logger.info(
+        "draft_generation.slot_summary slot_count=%d cluster_with_slot_count=%d "
+        "signal_slot_hit_payment_check=%d signal_slot_hit_user_identification=%d "
+        "signal_slot_hit_escalation=%d",
+        slot_metrics["slot_count"],
+        slot_metrics["cluster_with_slot_count"],
+        slot_metrics["signal_slot_hit_payment_check"],
+        slot_metrics["signal_slot_hit_user_identification"],
+        slot_metrics["signal_slot_hit_escalation"],
     )
 
     candidate = _build_candidate(intents, workflow_draft, stage_context)
@@ -343,6 +381,69 @@ def _build_workflow_draft(
         "workflow_with_empty_evidence_count": empty_evidence_count,
     }
     return draft, workflow_metrics
+
+
+def _build_slot_draft(
+    clusters: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], dict[str, int]]:
+    """cluster.workflow_signal 기반으로 slots + intentSlotBindings 도출.
+
+    Returns:
+        (slots, intentSlotBindings, metrics)
+    """
+    slots: list[dict[str, Any]] = []
+    bindings: list[dict[str, Any]] = []
+    cluster_with_slot_count = 0
+    signal_hit_counts: dict[str, int] = {key: 0 for key in SIGNAL_SLOT_MAPPING}
+
+    for cluster in clusters:
+        if not isinstance(cluster, dict):
+            continue
+        cluster_id = cluster.get("cluster_id")
+        signal = cluster.get("workflow_signal") or {}
+        intent_code = f"INTENT_{cluster_id}"
+        cluster_slot_counter = 0
+
+        for signal_key, templates in SIGNAL_SLOT_MAPPING.items():
+            if not signal.get(signal_key):
+                continue
+            signal_hit_counts[signal_key] += 1
+            for template in templates:
+                cluster_slot_counter += 1
+                slot_code = f"SLOT_{cluster_id}_{cluster_slot_counter}"
+                slots.append(
+                    {
+                        "slotCode": slot_code,
+                        "name": template.name,
+                        "description": template.description,
+                        "dataType": template.data_type,
+                        "isSensitive": template.is_sensitive,
+                        "validationRuleJson": "{}",
+                        "defaultValueJson": None,
+                        "metaJson": "{}",
+                    }
+                )
+                bindings.append(
+                    {
+                        "intentCode": intent_code,
+                        "slotCode": slot_code,
+                        "isRequired": True,
+                        "collectionOrder": cluster_slot_counter,
+                        "promptHint": "",
+                        "conditionJson": "{}",
+                    }
+                )
+        if cluster_slot_counter > 0:
+            cluster_with_slot_count += 1
+
+    metrics: dict[str, int] = {
+        "slot_count": len(slots),
+        "cluster_with_slot_count": cluster_with_slot_count,
+        "signal_slot_hit_payment_check": signal_hit_counts["requires_payment_check"],
+        "signal_slot_hit_user_identification": signal_hit_counts["requires_user_identification"],
+        "signal_slot_hit_escalation": signal_hit_counts["has_escalation_cases"],
+    }
+    return slots, bindings, metrics
 
 
 def _build_candidate(

--- a/ml/tests/stages/test_draft_generation_main.py
+++ b/ml/tests/stages/test_draft_generation_main.py
@@ -12,6 +12,7 @@ from pipeline.common.exceptions import PipelineStageError
 from pipeline.stages.draft_generation.main import (
     _build_candidate,
     _build_intents,
+    _build_slot_draft,
     _build_workflow_draft,
     _derive_pack_identity,
     _hydrate_case,
@@ -21,6 +22,7 @@ from pipeline.stages.draft_generation.main import (
     _write_candidate,
     run,
 )
+from pipeline.stages.publish_candidate.main import validate_candidate
 
 
 def _runtime_config(tmp_path: Path) -> PipelineRuntimeConfig:
@@ -586,3 +588,215 @@ def test_build_workflow_draft_metrics_sum_matches_evidence() -> None:
     assert metrics["workflow_evidence_exemplar_total"] == 1
     assert metrics["workflow_evidence_member_total"] == 2
     assert metrics["workflow_with_empty_evidence_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# _build_slot_draft
+# ---------------------------------------------------------------------------
+
+
+def test_build_slot_draft_all_signals_false_returns_empty() -> None:
+    clusters = [
+        {
+            "cluster_id": 1,
+            "workflow_signal": {
+                "requires_payment_check": False,
+                "requires_user_identification": False,
+                "has_escalation_cases": False,
+            },
+        }
+    ]
+
+    slots, bindings, metrics = _build_slot_draft(clusters)
+
+    assert slots == []
+    assert bindings == []
+    assert metrics["slot_count"] == 0
+    assert metrics["cluster_with_slot_count"] == 0
+
+
+def test_build_slot_draft_payment_check_true_yields_two_slots() -> None:
+    clusters = [
+        {
+            "cluster_id": 1,
+            "workflow_signal": {
+                "requires_payment_check": True,
+                "requires_user_identification": False,
+                "has_escalation_cases": False,
+            },
+        }
+    ]
+
+    slots, bindings, _ = _build_slot_draft(clusters)
+
+    assert len(slots) == 2
+    assert len(bindings) == 2
+    slot_codes = [s["slotCode"] for s in slots]
+    assert "SLOT_1_1" in slot_codes
+    assert "SLOT_1_2" in slot_codes
+    names = {s["name"] for s in slots}
+    assert "주문 ID" in names
+    assert "결제 수단" in names
+
+
+def test_build_slot_draft_user_identification_is_sensitive() -> None:
+    clusters = [
+        {
+            "cluster_id": 2,
+            "workflow_signal": {
+                "requires_payment_check": False,
+                "requires_user_identification": True,
+                "has_escalation_cases": False,
+            },
+        }
+    ]
+
+    slots, bindings, _ = _build_slot_draft(clusters)
+
+    assert len(slots) == 2
+    assert all(s["isSensitive"] is True for s in slots)
+    names = {s["name"] for s in slots}
+    assert "고객 이름" in names
+    assert "고객 연락처" in names
+
+
+def test_build_slot_draft_all_signals_true_yields_five_slots() -> None:
+    clusters = [
+        {
+            "cluster_id": 3,
+            "workflow_signal": {
+                "requires_payment_check": True,
+                "requires_user_identification": True,
+                "has_escalation_cases": True,
+            },
+        }
+    ]
+
+    slots, bindings, _ = _build_slot_draft(clusters)
+
+    assert len(slots) == 5
+    assert len(bindings) == 5
+    collection_orders = sorted(b["collectionOrder"] for b in bindings)
+    assert collection_orders == [1, 2, 3, 4, 5]
+
+
+def test_build_slot_draft_multiple_clusters_slot_codes_reset() -> None:
+    clusters = [
+        {"cluster_id": 1, "workflow_signal": {"requires_payment_check": True}},
+        {"cluster_id": 2, "workflow_signal": {"requires_payment_check": True}},
+    ]
+
+    slots, _, _ = _build_slot_draft(clusters)
+
+    slot_codes = [s["slotCode"] for s in slots]
+    assert "SLOT_1_1" in slot_codes
+    assert "SLOT_1_2" in slot_codes
+    assert "SLOT_2_1" in slot_codes
+    assert "SLOT_2_2" in slot_codes
+
+
+def test_build_slot_draft_intent_code_matches_cluster_id() -> None:
+    clusters = [
+        {"cluster_id": 7, "workflow_signal": {"requires_payment_check": True}},
+    ]
+
+    _, bindings, _ = _build_slot_draft(clusters)
+
+    assert all(b["intentCode"] == "INTENT_7" for b in bindings)
+
+
+def test_build_slot_draft_metrics_accuracy() -> None:
+    clusters = [
+        {
+            "cluster_id": 0,
+            "workflow_signal": {
+                "requires_payment_check": True,
+                "requires_user_identification": True,
+                "has_escalation_cases": False,
+            },
+        },
+        {
+            "cluster_id": 1,
+            "workflow_signal": {
+                "requires_payment_check": False,
+                "requires_user_identification": False,
+                "has_escalation_cases": True,
+            },
+        },
+        {
+            "cluster_id": 2,
+            "workflow_signal": {},
+        },
+    ]
+
+    _, _, metrics = _build_slot_draft(clusters)
+
+    assert metrics["slot_count"] == 5  # 2+2 + 1
+    assert metrics["cluster_with_slot_count"] == 2
+    assert metrics["signal_slot_hit_payment_check"] == 1
+    assert metrics["signal_slot_hit_user_identification"] == 1
+    assert metrics["signal_slot_hit_escalation"] == 1
+
+
+def test_run_success_with_signals_slots_populated(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    artifact_root = tmp_path / "artifacts"
+    clusters_dir = artifact_root / "dag" / "run1" / "intent_discovery"
+    preprocessed_dir = artifact_root / "dag" / "run1" / "preprocessing"
+    _write_clusters(
+        clusters_dir,
+        [
+            {
+                "cluster_id": 0,
+                "suggested_name": "결제 문의",
+                "suggested_description": "결제 관련",
+                "exemplar_conv_ids": [],
+                "workflow_signal": {
+                    "requires_payment_check": True,
+                    "requires_user_identification": False,
+                    "has_escalation_cases": False,
+                },
+            }
+        ],
+    )
+    _write_preprocessed(preprocessed_dir, [])
+    manifest_path = _write_upstream_manifest(tmp_path)
+
+    monkeypatch.setenv("PIPELINE_ARTIFACT_ROOT", str(artifact_root))
+    monkeypatch.setenv("PIPELINE_BACKEND_BASE_URL", "http://backend:8080")
+
+    run(upstream_manifest_path=str(manifest_path))
+
+    candidate_path = artifact_root / "dag" / "run1" / "draft_generation" / "candidate.json"
+    candidate = json.loads(candidate_path.read_text(encoding="utf-8"))
+    slots = candidate["workflowDraft"]["slots"]
+    bindings = candidate["workflowDraft"]["intentSlotBindings"]
+    assert len(slots) == 2
+    assert len(bindings) == 2
+    assert slots[0]["slotCode"] == "SLOT_0_1"
+    assert bindings[0]["intentCode"] == "INTENT_0"
+
+
+def test_publish_candidate_validate_accepts_slot_draft() -> None:
+    clusters = [
+        {
+            "cluster_id": 1,
+            "suggested_name": "결제 문의",
+            "suggested_description": "결제 관련",
+            "exemplar_conv_ids": [],
+            "workflow_signal": {
+                "requires_payment_check": True,
+                "requires_user_identification": False,
+                "has_escalation_cases": False,
+            },
+        }
+    ]
+    context = _stage_context(workspace_id="ws1", dataset_id="ds1")
+
+    intents, _ = _build_intents(clusters, {}, cases_per_intent=0)
+    workflow_draft, _ = _build_workflow_draft(clusters)
+    slots, intent_slot_bindings, _ = _build_slot_draft(clusters)
+    workflow_draft["slots"] = slots
+    workflow_draft["intentSlotBindings"] = intent_slot_bindings
+    candidate = _build_candidate(intents, workflow_draft, context)
+
+    validate_candidate(candidate)  # must not raise


### PR DESCRIPTION
#### Summary

- `draft_generation` stage에 `_build_slot_draft()` 함수 추가 — `workflowDraft.slots` / `intentSlotBindings` 채움
- `SlotTemplate(NamedTuple)` + `SIGNAL_SLOT_MAPPING` 상수(3 signal, 5 template) 기반 정적 추출
- slotCode 패턴 `SLOT_{cluster_id}_{counter}`, isRequired=True, `status` 필드 없음
- 관련 5개 metric 추가 및 `draft_generation.slot_summary` 로그
- 신규 테스트 9개 추가, coverage 97.37%

#### Context

Spec `.agent/specs/432.md` — **[ML] 4.3.2 Slot 초안 자동 추출** 구현.
`draft_generation` stage의 `workflowDraft.slots` / `intentSlotBindings`가 빈 list로 하드코딩되어 있던 부분을 채운다. 도출된 slot은 `publish_candidate`의 workflow-drafts callback을 통해 BE로 전달되며, 운영자가 FE UI에서 검토·수정·삭제한다.

#### What Changed

- **`ml/src/pipeline/stages/draft_generation/main.py`**: `SlotTemplate(NamedTuple)` 및 `SIGNAL_SLOT_MAPPING` 상수 추가, `_build_slot_draft()` 구현, `run()`에서 반환값으로 slots/bindings 채움 및 `metrics.update(slot_metrics)` 삽입.
- **`ml/tests/stages/test_draft_generation_main.py`**: 9개 신규 테스트 추가 (unit 8개 + downstream contract test 1개).
- DAG task 추가 없음. `candidate.json` 최상위 구조 변경 없음. `pyproject.toml` 변경 없음.

#### Assumptions Adopted

- **U-001** (Decision): scope을 slot 초안 자동 추출로 한정. slot status 전환 패턴 추출 Out of Scope.
- **U-002** (Decision): `cluster.workflow_signal` 정적 mapping 사용. NER/keyword/regex 기반 동적 탐지 기각.
- **U-003** (Decision): `draft_generation/main.py` 내부 구현. 새 stage/file/DAG task 생성 없음. cluster당 자연 상한 5개(2+2+1).
- **U-004** (engineering-bound): 6개 candidate.json slot contract invariant(slotCode unique, ≤100자, name/dataType 비어있지 않음, intentCode/slotCode 참조 일관성)를 패턴으로 자연 보장. `status` 필드 미포함. `publish_candidate.validate_candidate` 변경 없음.
- **U-005** (Deferred): 선행 spec 4.3.1 부재로 해당 artifact 미참조. 본 spec 입력은 `clusters.json` + `preprocessed_data.json`만 사용.

#### Spec Deviations

N/A — 스펙 대비 구현 차이 없음.

**SC-M2 처리**: spec-consistency-report CSC-001에서 `run()` 삽입 위치 pseudocode의 `metrics.update(workflow_metrics)` 중복 삽입 위험이 지적됨. 구현 전 `main.py:59` 직접 확인 후 기존 call은 유지하고 `metrics.update(slot_metrics)`(main.py:99)만 신규 삽입하여 해소.

#### Blocked / Skipped Items

- **U-005** (Deferred): 선행 spec 4.3.1 미완료. 현재 spec 입력(`clusters.json`, `preprocessed_data.json`)만으로 충분하여 skip.

#### Test Notes

- 신규 테스트 9개 전항목 작성 완료.
- line coverage 97.37% (local-measure, `ajou-2026-1-capstone-5_ostone_ml`).
- `test_publish_candidate_validate_accepts_slot_draft:779` — downstream contract test, `validate_candidate()` raise 없음 확인.
- 기존 `test_build_workflow_draft_single_cluster:390`의 `assert draft["slots"] == []` 회귀 확인 — `_build_workflow_draft`는 항상 slots: [] 초기화, slot 채움은 `run()` 레벨에서 수행되므로 설계 의도와 일치.

#### Reviewer Focus

1. **`SIGNAL_SLOT_MAPPING` 상수** (`main.py:42-54`) — 3 signal × templates 매핑이 도메인 요구사항에 부합하는지. 새 signal key 추가 시 mapping 수동 갱신 필요.
2. **`cluster_id` 타입 가정** (`_build_slot_draft` 내 f-string 직접 사용) — `_build_intents` / `_build_workflow_draft`와 동일 가정이나, cluster_id가 int가 아닌 경우 slotCode 패턴이 예상과 달라질 수 있음.
3. **`metrics.update` 분리** — `main.py:82` 기존 `metrics.update(workflow_metrics)`와 `main.py:99` 신규 `metrics.update(slot_metrics)` 분리가 올바른지 확인.
4. **empty `workflow_signal` 처리** — `cluster.get("workflow_signal") or {}` 패턴으로 key 부재·빈 dict 처리. key-absent 케이스에 대한 명시적 독립 테스트 없음 (I-002 참조).

#### Conflicts (if any)

N/A

#### Ready to Merge / Needs Input

Final Audit verdict: **PASS** (source of truth: `.handoff/432/audit-report-432-2026-05-13-1826.md`).

`isFinalAudit: false` — 머지 전 SonarQube Cloud CI Quality Gate (PR 생성 후 자동 분석) 결과 확인 필요.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ajou-2026-1-capstone-5/ostone/pull/220" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 워크플로우 드래프트 생성 시 워크플로우 신호를 기반으로 슬롯 및 슬롯-인텐트 바인딩이 자동으로 생성됩니다.
  * 신호 유형(결제 확인, 사용자 식별, 에스컬레이션 등)에 따라 슬롯 템플릿이 매핑되고 적용됩니다.

* **테스트**
  * 다양한 신호 조합에 대한 슬롯 드래프트 생성 테스트가 추가되었습니다.
  * 엔드-투-엔드 워크플로우 검증 테스트가 추가되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ajou-2026-1-capstone-5/ostone/pull/220)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->