### PR TITLE
feat(workflow-viewer): add workflow graph viewer with custom nodes and status styles

### DIFF
--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -20,6 +20,7 @@ import { DomainPackListPage } from '../pages/domain-pack/ui/DomainPackListPage';
 import { PrivateRoute } from '../shared/ui/PrivateRoute';
 import { Toaster } from '../shared/ui/sonner';
 import { ChatWorkflowDemoPageWrapper } from '../pages/chat-demo/ui/ChatWorkflowDemoPageWrapper';
+import { WorkflowGraphViewerPage } from '../pages/domain-pack/ui/WorkflowGraphViewerPage';
 
 export function App() {
   return (
@@ -51,6 +52,7 @@ export function App() {
         <Route path="/workspaces/:workspaceId/domain-packs/:packId/versions/:versionId/slots/:slotId?" element={<PrivateRoute><SlotDraftReadPage /></PrivateRoute>} />
         <Route path="/workspaces/:workspaceId/domain-packs/:packId/versions/:versionId/workflows" element={<PrivateRoute><WorkflowDraftReadPage /></PrivateRoute>} />
         <Route path="/workspaces/:workspaceId/domain-packs/:packId/versions/:versionId/workflows/:workflowId" element={<PrivateRoute><WorkflowDraftReadPage /></PrivateRoute>} />
+        <Route path="/workspaces/:workspaceId/domain-packs/:packId/versions/:versionId/workflows/:workflowId/graph" element={<PrivateRoute><WorkflowGraphViewerPage /></PrivateRoute>} />
         <Route path="/workspaces/:workspaceId/chat-demo" element={<PrivateRoute><ChatWorkflowDemoPageWrapper /></PrivateRoute>} />
         <Route path="*" element={<NotFoundPage />} />
       </Routes>

--- a/frontend/src/entities/workflow/api/index.ts
+++ b/frontend/src/entities/workflow/api/index.ts
@@ -1,0 +1,2 @@
+export { useGetWorkflowDefinition } from "./useGetWorkflowDefinition";
+export type { UseGetWorkflowDefinitionParams } from "./useGetWorkflowDefinition";

--- a/frontend/src/entities/workflow/api/useGetWorkflowDefinition.ts
+++ b/frontend/src/entities/workflow/api/useGetWorkflowDefinition.ts
@@ -1,0 +1,28 @@
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { getWorkflow } from "@/shared/api/generated/endpoints/workflow-definition-controller/workflow-definition-controller";
+import type { WorkflowDefinitionDetail } from "@/shared/api/generated/zod";
+
+export interface UseGetWorkflowDefinitionParams {
+  workspaceId: number;
+  packId: number;
+  versionId: number;
+  workflowId: number;
+  enabled: boolean;
+}
+
+export function useGetWorkflowDefinition({
+  workspaceId,
+  packId,
+  versionId,
+  workflowId,
+  enabled,
+}: UseGetWorkflowDefinitionParams): UseQueryResult<WorkflowDefinitionDetail> {
+  return useQuery<WorkflowDefinitionDetail>({
+    queryKey: ["workflows", "detail", workspaceId, packId, versionId, workflowId] as const,
+    queryFn: async () => {
+      const res = await getWorkflow(workspaceId, packId, versionId, workflowId);
+      return res.data;
+    },
+    enabled,
+  });
+}

--- a/frontend/src/entities/workflow/index.ts
+++ b/frontend/src/entities/workflow/index.ts
@@ -23,3 +23,4 @@ export {
   NODE_STATUS_STYLE_MAP,
   DEFAULT_NODE_STATUS,
 } from "./model/nodeStatus";
+export { useGetWorkflowDefinition } from "./api/useGetWorkflowDefinition";

--- a/frontend/src/entities/workflow/index.ts
+++ b/frontend/src/entities/workflow/index.ts
@@ -11,3 +11,15 @@ export type {
 export type { WorkflowTransitionDetail } from "@/shared/api/generated/zod";
 
 export { toFlow, convertFlowToWorkflowGraph } from "./lib/graphConverter";
+
+export type {
+  GraphNodeStatus,
+  GraphNodeStyleConfig,
+} from "./model/nodeStatus";
+
+export {
+  NODE_TYPES,
+  NODE_STATUSES,
+  NODE_STATUS_STYLE_MAP,
+  DEFAULT_NODE_STATUS,
+} from "./model/nodeStatus";

--- a/frontend/src/entities/workflow/model/nodeStatus.test.ts
+++ b/frontend/src/entities/workflow/model/nodeStatus.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_NODE_STATUS,
+  NODE_STATUSES,
+  NODE_STATUS_STYLE_MAP,
+  NODE_TYPES,
+} from "./nodeStatus";
+import type { GraphNodeStatus } from "./nodeStatus";
+
+describe("nodeStatus", () => {
+  it("NODE_TYPES는 6개 타입을 모두 포함한다", () => {
+    expect(NODE_TYPES).toEqual([
+      "START",
+      "ACTION",
+      "DECISION",
+      "ANSWER",
+      "HANDOFF",
+      "TERMINAL",
+    ]);
+  });
+
+  it("NODE_STATUSES는 4개 상태를 모두 포함한다", () => {
+    expect(NODE_STATUSES).toEqual([
+      "IDLE",
+      "ACTIVE",
+      "COMPLETED",
+      "FAILED",
+    ]);
+  });
+
+  it("DEFAULT_NODE_STATUS는 IDLE이다", () => {
+    expect(DEFAULT_NODE_STATUS).toBe("IDLE");
+  });
+
+  it("NODE_STATUS_STYLE_MAP은 모든 상태에 className과 label을 가진다", () => {
+    const keys = Object.keys(NODE_STATUS_STYLE_MAP) as GraphNodeStatus[];
+    expect(keys).toHaveLength(4);
+    expect(keys).toEqual(["IDLE", "ACTIVE", "COMPLETED", "FAILED"]);
+
+    expect(NODE_STATUS_STYLE_MAP.IDLE).toEqual({
+      className: "statusIdle",
+      label: "대기",
+    });
+    expect(NODE_STATUS_STYLE_MAP.ACTIVE).toEqual({
+      className: "statusActive",
+      label: "실행 중",
+    });
+    expect(NODE_STATUS_STYLE_MAP.COMPLETED).toEqual({
+      className: "statusCompleted",
+      label: "완료",
+    });
+    expect(NODE_STATUS_STYLE_MAP.FAILED).toEqual({
+      className: "statusFailed",
+      label: "실패",
+    });
+  });
+
+  it("GraphNodeStatus 타입은 IDLE | ACTIVE | COMPLETED | FAILED로 한정된다", () => {
+    const accept: GraphNodeStatus = "IDLE";
+    expect(accept).toBe("IDLE");
+  });
+});

--- a/frontend/src/entities/workflow/model/nodeStatus.ts
+++ b/frontend/src/entities/workflow/model/nodeStatus.ts
@@ -1,0 +1,39 @@
+import type { GraphNodeType } from "./types";
+
+export type { GraphNodeType } from "./types";
+
+export const NODE_TYPES: GraphNodeType[] = [
+  "START",
+  "ACTION",
+  "DECISION",
+  "ANSWER",
+  "HANDOFF",
+  "TERMINAL",
+];
+
+export type GraphNodeStatus =
+  | "IDLE"
+  | "ACTIVE"
+  | "COMPLETED"
+  | "FAILED";
+
+export const NODE_STATUSES: GraphNodeStatus[] = [
+  "IDLE",
+  "ACTIVE",
+  "COMPLETED",
+  "FAILED",
+];
+
+export interface GraphNodeStyleConfig {
+  className: string;
+  label: string;
+}
+
+export const NODE_STATUS_STYLE_MAP: Record<GraphNodeStatus, GraphNodeStyleConfig> = {
+  IDLE: { className: "statusIdle", label: "대기" },
+  ACTIVE: { className: "statusActive", label: "실행 중" },
+  COMPLETED: { className: "statusCompleted", label: "완료" },
+  FAILED: { className: "statusFailed", label: "실패" },
+};
+
+export const DEFAULT_NODE_STATUS: GraphNodeStatus = "IDLE";

--- a/frontend/src/features/workflow-viewer/ui/GraphViewer.module.css
+++ b/frontend/src/features/workflow-viewer/ui/GraphViewer.module.css
@@ -1,0 +1,45 @@
+.container {
+  width: 100%;
+  height: 100%;
+  min-height: 500px;
+  position: relative;
+  background: var(--bg-color);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+.container :global(.react-flow__edge-path) {
+  stroke: var(--text-primary);
+}
+
+.container :global(.react-flow__arrowhead) {
+  fill: var(--text-primary);
+}
+
+.container :global(.react-flow__edge-text) {
+  font-family: "Geist Mono", monospace;
+  font-size: 11px;
+  letter-spacing: 0.54px;
+  fill: var(--text-primary);
+}
+
+.container :global(.react-flow__edge-textbg) {
+  fill: var(--bg-color);
+}
+
+.container :global(.react-flow__background) {
+  background: var(--bg-secondary);
+}
+
+.container :global(.react-flow__controls) {
+  box-shadow: none;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-md);
+}
+
+.container :global(.react-flow__controls-button) {
+  background: var(--bg-color);
+  color: var(--text-primary);
+  border-bottom: 1px solid var(--glass-border);
+}

--- a/frontend/src/features/workflow-viewer/ui/GraphViewer.test.tsx
+++ b/frontend/src/features/workflow-viewer/ui/GraphViewer.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { WorkflowGraph } from "@/entities/workflow";
+import { GraphViewer } from "./GraphViewer";
+
+const mockToFlow = vi.hoisted(() =>
+  vi.fn(() => ({
+    nodes: [
+      {
+        id: "n1",
+        type: "start",
+        position: { x: 0, y: 0 },
+        data: { label: "Start" },
+      },
+    ],
+    edges: [{ id: "e1", source: "n1", target: "n2" }],
+  })),
+);
+
+vi.mock("@/entities/workflow/lib/graphConverter", () => ({
+  toFlow: mockToFlow,
+}));
+
+vi.mock("@xyflow/react", () => ({
+  ReactFlow: () => <div data-testid="reactflow" />,
+  Background: () => null,
+  Controls: () => null,
+  MarkerType: { ArrowClosed: "arrowclosed" },
+}));
+
+const mockGraph: WorkflowGraph = {
+  nodes: [{ id: "n1", type: "start", label: "Start", x: 0, y: 0 }],
+  edges: [{ id: "e1", from: "n1", to: "n2" }],
+};
+
+describe("GraphViewer", () => {
+  it("renders ReactFlow canvas", () => {
+    render(<GraphViewer graph={mockGraph} />);
+    const flow = screen.getByTestId("reactflow");
+    expect(flow).toBeInTheDocument();
+  });
+
+  it("passes graph data to toFlow converter", () => {
+    render(<GraphViewer graph={mockGraph} />);
+    expect(mockToFlow).toHaveBeenCalledWith(mockGraph);
+  });
+
+  it("renders with minimal props", () => {
+    const minimalGraph: WorkflowGraph = {
+      nodes: [],
+      edges: [],
+    };
+    render(<GraphViewer graph={minimalGraph} />);
+    const flow = screen.getByTestId("reactflow");
+    expect(flow).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/workflow-viewer/ui/GraphViewer.test.tsx
+++ b/frontend/src/features/workflow-viewer/ui/GraphViewer.test.tsx
@@ -29,8 +29,9 @@ vi.mock("@xyflow/react", () => ({
 }));
 
 const mockGraph: WorkflowGraph = {
-  nodes: [{ id: "n1", type: "start", label: "Start", x: 0, y: 0 }],
+  nodes: [{ id: "n1", type: "START", label: "Start", position: { x: 0, y: 0 } }],
   edges: [{ id: "e1", from: "n1", to: "n2" }],
+  direction: "LR",
 };
 
 describe("GraphViewer", () => {
@@ -49,6 +50,7 @@ describe("GraphViewer", () => {
     const minimalGraph: WorkflowGraph = {
       nodes: [],
       edges: [],
+      direction: "LR",
     };
     render(<GraphViewer graph={minimalGraph} />);
     const flow = screen.getByTestId("reactflow");

--- a/frontend/src/features/workflow-viewer/ui/GraphViewer.tsx
+++ b/frontend/src/features/workflow-viewer/ui/GraphViewer.tsx
@@ -1,0 +1,66 @@
+import { useMemo } from "react";
+import { ReactFlow, Background, Controls, type NodeTypes } from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+import type { WorkflowGraph } from "@/entities/workflow";
+import { toFlow } from "@/entities/workflow/lib/graphConverter";
+import { StartNode } from "./nodes/StartNode";
+import { ActionNode } from "./nodes/ActionNode";
+import { DecisionNode } from "./nodes/DecisionNode";
+import { AnswerNode } from "./nodes/AnswerNode";
+import { HandoffNode } from "./nodes/HandoffNode";
+import { TerminalNode } from "./nodes/TerminalNode";
+import { PlainEdge } from "./edges/PlainEdge";
+import styles from "./GraphViewer.module.css";
+
+const nodeTypes: NodeTypes = {
+  start: StartNode,
+  action: ActionNode,
+  decision: DecisionNode,
+  answer: AnswerNode,
+  handoff: HandoffNode,
+  terminal: TerminalNode,
+};
+
+const edgeTypes = {
+  plain: PlainEdge,
+};
+
+interface GraphViewerProps {
+  graph: WorkflowGraph;
+  onEdgeClick?: (edgeId: string) => void;
+  onPaneClick?: () => void;
+}
+
+export default function GraphViewer({
+  graph,
+  onEdgeClick,
+  onPaneClick,
+}: GraphViewerProps) {
+  const { nodes, edges: rawEdges } = useMemo(() => toFlow(graph), [graph]);
+  const edges = useMemo(
+    () => rawEdges.map((e) => ({ ...e, type: "plain" as const })),
+    [rawEdges],
+  );
+
+  return (
+    <div className={styles.container}>
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        nodeTypes={nodeTypes}
+        edgeTypes={edgeTypes}
+        fitView
+        panOnDrag={true}
+        zoomOnScroll={true}
+        nodesDraggable={false}
+        nodesConnectable={false}
+        elementsSelectable={false}
+        onEdgeClick={(_, edge) => onEdgeClick?.(edge.id)}
+        onPaneClick={onPaneClick}
+      >
+        <Background gap={20} size={1} />
+        <Controls showInteractive={false} />
+      </ReactFlow>
+    </div>
+  );
+}

--- a/frontend/src/features/workflow-viewer/ui/GraphViewer.tsx
+++ b/frontend/src/features/workflow-viewer/ui/GraphViewer.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { ReactFlow, Background, Controls, type NodeTypes } from "@xyflow/react";
+import { ReactFlow, Background, Controls, MarkerType, type NodeTypes } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import type { WorkflowGraph } from "@/entities/workflow";
 import { toFlow } from "@/entities/workflow/lib/graphConverter";
@@ -38,7 +38,7 @@ export default function GraphViewer({
 }: GraphViewerProps) {
   const { nodes, edges: rawEdges } = useMemo(() => toFlow(graph), [graph]);
   const edges = useMemo(
-    () => rawEdges.map((e) => ({ ...e, type: "plain" as const })),
+    () => rawEdges.map((e) => ({ ...e, type: "plain" as const, markerEnd: { type: MarkerType.ArrowClosed } })),
     [rawEdges],
   );
 

--- a/frontend/src/features/workflow-viewer/ui/GraphViewer.tsx
+++ b/frontend/src/features/workflow-viewer/ui/GraphViewer.tsx
@@ -31,7 +31,7 @@ interface GraphViewerProps {
   onPaneClick?: () => void;
 }
 
-export default function GraphViewer({
+export function GraphViewer({
   graph,
   onEdgeClick,
   onPaneClick,

--- a/frontend/src/features/workflow-viewer/ui/edges/PlainEdge.test.tsx
+++ b/frontend/src/features/workflow-viewer/ui/edges/PlainEdge.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { PlainEdge } from './PlainEdge';
+
+vi.mock('@xyflow/react', () => ({
+  BaseEdge: ({ path }: { path: string }) => <path data-testid="base-edge" d={path} />,
+  EdgeLabelRenderer: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  getBezierPath: () => ['M0,0 C50,0 50,100 100,100', 50, 50],
+  Position: { Left: 'left', Right: 'right', Top: 'top', Bottom: 'bottom' },
+}));
+
+const defaultProps = {
+  id: "test-edge",
+  source: "source-node",
+  target: "target-node",
+  sourceX: 0,
+  sourceY: 0,
+  targetX: 100,
+  targetY: 100,
+  sourcePosition: { name: 'right' } as any,
+  targetPosition: { name: 'left' } as any,
+  selected: false,
+  sourceHandleId: null,
+  targetHandleId: null,
+  markerEnd: undefined,
+  type: "plain" as const,
+  zIndex: 0,
+  label: undefined,
+};
+
+describe('PlainEdge', () => {
+  it('renders edge path (BaseEdge renders)', () => {
+    const { container } = render(<PlainEdge {...defaultProps} />);
+    const path = container.querySelector('path');
+    expect(path).toBeInTheDocument();
+  });
+
+  it('renders label text when provided', () => {
+    render(<PlainEdge {...defaultProps} label="에지 레이블" />);
+    expect(screen.getByText('에지 레이블')).toBeInTheDocument();
+  });
+
+  it('does NOT render label text when label is undefined', () => {
+    render(<PlainEdge {...defaultProps} />);
+    expect(screen.queryByText('에지 레이블')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/workflow-viewer/ui/edges/PlainEdge.tsx
+++ b/frontend/src/features/workflow-viewer/ui/edges/PlainEdge.tsx
@@ -35,7 +35,7 @@ export function PlainEdge({
             style={{
               position: "absolute",
               transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
-              fontSize: 11,
+              fontSize: "var(--font-size-xs)",
               pointerEvents: "none",
             }}
           >

--- a/frontend/src/features/workflow-viewer/ui/edges/PlainEdge.tsx
+++ b/frontend/src/features/workflow-viewer/ui/edges/PlainEdge.tsx
@@ -1,0 +1,48 @@
+import {
+  BaseEdge,
+  EdgeLabelRenderer,
+  getBezierPath,
+  type EdgeProps,
+} from "@xyflow/react";
+
+export function PlainEdge({
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  sourcePosition,
+  targetPosition,
+  markerEnd,
+  style,
+  label,
+}: EdgeProps) {
+  const [edgePath, labelX, labelY] = getBezierPath({
+    sourceX,
+    sourceY,
+    sourcePosition,
+    targetX,
+    targetY,
+    targetPosition,
+  });
+
+  return (
+    <>
+      <BaseEdge path={edgePath} markerEnd={markerEnd} style={style} />
+      {label && (
+        <EdgeLabelRenderer>
+          <div
+            className="nodrag nopan"
+            style={{
+              position: "absolute",
+              transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
+              fontSize: 11,
+              pointerEvents: "none",
+            }}
+          >
+            {label}
+          </div>
+        </EdgeLabelRenderer>
+      )}
+    </>
+  );
+}

--- a/frontend/src/features/workflow-viewer/ui/nodeStyles.test.ts
+++ b/frontend/src/features/workflow-viewer/ui/nodeStyles.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { STATUS_MAP } from "./nodeStyles";
+
+describe("nodeStyles", () => {
+  it("STATUS_MAP은 4개 상태를 모두 키로 가진다", () => {
+    expect(Object.keys(STATUS_MAP)).toEqual([
+      "IDLE",
+      "ACTIVE",
+      "COMPLETED",
+      "FAILED",
+    ]);
+  });
+
+  it("STATUS_MAP의 모든 값은 문자열이다", () => {
+    const values = Object.values(STATUS_MAP);
+    expect(values).toHaveLength(4);
+    values.forEach((value) => {
+      expect(typeof value).toBe("string");
+    });
+  });
+});

--- a/frontend/src/features/workflow-viewer/ui/nodeStyles.ts
+++ b/frontend/src/features/workflow-viewer/ui/nodeStyles.ts
@@ -1,0 +1,9 @@
+import theme from "@/shared/styles/workflow-node-theme.module.css";
+import type { GraphNodeStatus } from "@/entities/workflow";
+
+export const STATUS_MAP: Record<GraphNodeStatus, string> = {
+  IDLE: theme.statusIdle,
+  ACTIVE: theme.statusActive,
+  COMPLETED: theme.statusCompleted,
+  FAILED: theme.statusFailed,
+};

--- a/frontend/src/features/workflow-viewer/ui/nodes/ActionNode.test.tsx
+++ b/frontend/src/features/workflow-viewer/ui/nodes/ActionNode.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ActionNode } from './ActionNode';
+
+vi.mock('@xyflow/react', () => ({
+  Handle: () => <div data-testid="handle" />,
+  Position: { Left: 'left', Right: 'right', Top: 'top', Bottom: 'bottom' },
+}));
+
+const defaultProps = {
+  id: "test",
+  type: "action" as const,
+  selected: false,
+  dragging: false,
+  zIndex: 0,
+  selectable: true,
+  deletable: false,
+  draggable: true,
+  isConnectable: false,
+  positionAbsoluteX: 0,
+  positionAbsoluteY: 0,
+};
+
+describe('ActionNode', () => {
+  it('renders with label', () => {
+    render(<ActionNode {...defaultProps} data={{ label: "액션" }} />);
+    expect(screen.getByText('액션')).toBeInTheDocument();
+  });
+
+  it('renders with policyRef text when provided', () => {
+    render(<ActionNode {...defaultProps} data={{ label: "액션", policyRef: "POL-001" }} />);
+    expect(screen.getByText('POL-001')).toBeInTheDocument();
+  });
+
+  it('does NOT render policyRef div when not provided', () => {
+    render(<ActionNode {...defaultProps} data={{ label: "액션" }} />);
+    expect(screen.getByText('액션')).toBeInTheDocument();
+    expect(screen.queryByText('POL-001')).not.toBeInTheDocument();
+  });
+
+  it('renders with COMPLETED status', () => {
+    render(<ActionNode {...defaultProps} data={{ label: "액션", status: "COMPLETED" }} />);
+    const container = screen.getByText('액션').parentElement;
+    expect(container?.className).toContain('statusCompleted');
+  });
+
+  it('renders with IDLE status by default', () => {
+    render(<ActionNode {...defaultProps} data={{ label: "액션" }} />);
+    const container = screen.getByText('액션').parentElement;
+    expect(container?.className).toContain('statusIdle');
+  });
+});

--- a/frontend/src/features/workflow-viewer/ui/nodes/ActionNode.tsx
+++ b/frontend/src/features/workflow-viewer/ui/nodes/ActionNode.tsx
@@ -1,13 +1,7 @@
 import { Handle, Position, type NodeProps } from "@xyflow/react";
 import theme from "@/shared/styles/workflow-node-theme.module.css";
 import { DEFAULT_NODE_STATUS, type GraphNodeStatus } from "@/entities/workflow";
-
-const STATUS_MAP: Record<GraphNodeStatus, string> = {
-  IDLE: theme.statusIdle,
-  ACTIVE: theme.statusActive,
-  COMPLETED: theme.statusCompleted,
-  FAILED: theme.statusFailed,
-};
+import { STATUS_MAP } from "../nodeStyles";
 
 export function ActionNode({ data }: NodeProps) {
   const label = typeof data?.label === "string" ? data.label : "";

--- a/frontend/src/features/workflow-viewer/ui/nodes/ActionNode.tsx
+++ b/frontend/src/features/workflow-viewer/ui/nodes/ActionNode.tsx
@@ -1,0 +1,27 @@
+import { Handle, Position, type NodeProps } from "@xyflow/react";
+import theme from "../../../shared/styles/workflow-node-theme.module.css";
+import { DEFAULT_NODE_STATUS, type GraphNodeStatus } from "@/entities/workflow";
+
+const STATUS_MAP: Record<GraphNodeStatus, string> = {
+  IDLE: theme.statusIdle,
+  ACTIVE: theme.statusActive,
+  COMPLETED: theme.statusCompleted,
+  FAILED: theme.statusFailed,
+};
+
+export function ActionNode({ data }: NodeProps) {
+  const label = typeof data?.label === "string" ? data.label : "";
+  const status: GraphNodeStatus =
+    (data?.status as GraphNodeStatus | undefined) ?? DEFAULT_NODE_STATUS;
+  const policyRef =
+    typeof data?.policyRef === "string" ? data.policyRef : undefined;
+
+  return (
+    <div className={`${theme.action} ${STATUS_MAP[status]}`}>
+      <Handle type="target" position={Position.Left} />
+      <div>{label}</div>
+      {policyRef && <div>{policyRef}</div>}
+      <Handle type="source" position={Position.Right} />
+    </div>
+  );
+}

--- a/frontend/src/features/workflow-viewer/ui/nodes/ActionNode.tsx
+++ b/frontend/src/features/workflow-viewer/ui/nodes/ActionNode.tsx
@@ -1,5 +1,5 @@
 import { Handle, Position, type NodeProps } from "@xyflow/react";
-import theme from "../../../shared/styles/workflow-node-theme.module.css";
+import theme from "@/shared/styles/workflow-node-theme.module.css";
 import { DEFAULT_NODE_STATUS, type GraphNodeStatus } from "@/entities/workflow";
 
 const STATUS_MAP: Record<GraphNodeStatus, string> = {
@@ -17,7 +17,7 @@ export function ActionNode({ data }: NodeProps) {
     typeof data?.policyRef === "string" ? data.policyRef : undefined;
 
   return (
-    <div className={`${theme.action} ${STATUS_MAP[status]}`}>
+    <div className={`${theme.action} ${STATUS_MAP[status] ?? theme.statusIdle}`}>
       <Handle type="target" position={Position.Left} />
       <div>{label}</div>
       {policyRef && <div>{policyRef}</div>}

--- a/frontend/src/features/workflow-viewer/ui/nodes/AnswerNode.test.tsx
+++ b/frontend/src/features/workflow-viewer/ui/nodes/AnswerNode.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { AnswerNode } from './AnswerNode';
+
+vi.mock('@xyflow/react', () => ({
+  Handle: () => <div data-testid="handle" />,
+  Position: { Left: 'left', Right: 'right', Top: 'top', Bottom: 'bottom' },
+}));
+
+const defaultProps = {
+  id: "test",
+  type: "answer" as const,
+  selected: false,
+  dragging: false,
+  zIndex: 0,
+  selectable: true,
+  deletable: false,
+  draggable: true,
+  isConnectable: false,
+  positionAbsoluteX: 0,
+  positionAbsoluteY: 0,
+};
+
+describe('AnswerNode', () => {
+  it('renders with label', () => {
+    render(<AnswerNode {...defaultProps} data={{ label: "답변" }} />);
+    expect(screen.getByText('답변')).toBeInTheDocument();
+  });
+
+  it('renders with ACTIVE status', () => {
+    render(<AnswerNode {...defaultProps} data={{ label: "답변", status: "ACTIVE" }} />);
+    const container = screen.getByText('답변').parentElement;
+    expect(container?.className).toContain('statusActive');
+  });
+
+  it('renders with IDLE status by default', () => {
+    render(<AnswerNode {...defaultProps} data={{ label: "답변" }} />);
+    const container = screen.getByText('답변').parentElement;
+    expect(container?.className).toContain('statusIdle');
+  });
+});

--- a/frontend/src/features/workflow-viewer/ui/nodes/AnswerNode.tsx
+++ b/frontend/src/features/workflow-viewer/ui/nodes/AnswerNode.tsx
@@ -1,13 +1,7 @@
 import { Handle, Position, type NodeProps } from "@xyflow/react";
 import theme from "@/shared/styles/workflow-node-theme.module.css";
 import { DEFAULT_NODE_STATUS, type GraphNodeStatus } from "@/entities/workflow";
-
-const STATUS_MAP: Record<GraphNodeStatus, string> = {
-  IDLE: theme.statusIdle,
-  ACTIVE: theme.statusActive,
-  COMPLETED: theme.statusCompleted,
-  FAILED: theme.statusFailed,
-};
+import { STATUS_MAP } from "../nodeStyles";
 
 export function AnswerNode({ data }: NodeProps) {
   const label = typeof data?.label === "string" ? data.label : "";

--- a/frontend/src/features/workflow-viewer/ui/nodes/AnswerNode.tsx
+++ b/frontend/src/features/workflow-viewer/ui/nodes/AnswerNode.tsx
@@ -1,0 +1,25 @@
+import { Handle, Position, type NodeProps } from "@xyflow/react";
+import theme from "../../../shared/styles/workflow-node-theme.module.css";
+import { DEFAULT_NODE_STATUS, type GraphNodeStatus } from "@/entities/workflow";
+
+const STATUS_MAP: Record<GraphNodeStatus, string> = {
+  IDLE: theme.statusIdle,
+  ACTIVE: theme.statusActive,
+  COMPLETED: theme.statusCompleted,
+  FAILED: theme.statusFailed,
+};
+
+export function AnswerNode({ data }: NodeProps) {
+  const label = typeof data?.label === "string" ? data.label : "";
+  const status: GraphNodeStatus =
+    (data?.status as GraphNodeStatus | undefined) ?? DEFAULT_NODE_STATUS;
+  const statusClass = STATUS_MAP[status] ?? theme.statusIdle;
+
+  return (
+    <div className={`${theme.answer} ${statusClass}`}>
+      <Handle type="target" position={Position.Left} />
+      <span className={theme.label}>{label}</span>
+      <Handle type="source" position={Position.Right} />
+    </div>
+  );
+}

--- a/frontend/src/features/workflow-viewer/ui/nodes/AnswerNode.tsx
+++ b/frontend/src/features/workflow-viewer/ui/nodes/AnswerNode.tsx
@@ -1,5 +1,5 @@
 import { Handle, Position, type NodeProps } from "@xyflow/react";
-import theme from "../../../shared/styles/workflow-node-theme.module.css";
+import theme from "@/shared/styles/workflow-node-theme.module.css";
 import { DEFAULT_NODE_STATUS, type GraphNodeStatus } from "@/entities/workflow";
 
 const STATUS_MAP: Record<GraphNodeStatus, string> = {

--- a/frontend/src/features/workflow-viewer/ui/nodes/DecisionNode.test.tsx
+++ b/frontend/src/features/workflow-viewer/ui/nodes/DecisionNode.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { DecisionNode } from './DecisionNode';
+
+vi.mock('@xyflow/react', () => ({
+  Handle: () => <div data-testid="handle" />,
+  Position: { Left: 'left', Right: 'right', Top: 'top', Bottom: 'bottom' },
+}));
+
+const defaultProps = {
+  id: "test",
+  type: "decision" as const,
+  selected: false,
+  dragging: false,
+  zIndex: 0,
+  selectable: true,
+  deletable: false,
+  draggable: true,
+  isConnectable: false,
+  positionAbsoluteX: 0,
+  positionAbsoluteY: 0,
+};
+
+describe('DecisionNode', () => {
+  it('renders with label', () => {
+    render(<DecisionNode {...defaultProps} data={{ label: "분기점" }} />);
+    expect(screen.getByText('분기점')).toBeInTheDocument();
+  });
+
+  it('renders with FAILED status', () => {
+    render(<DecisionNode {...defaultProps} data={{ label: "분기점", status: "FAILED" }} />);
+    const container = screen.getByText('분기점').parentElement;
+    expect(container?.className).toContain('statusFailed');
+  });
+
+  it('renders with IDLE status by default', () => {
+    render(<DecisionNode {...defaultProps} data={{ label: "분기점" }} />);
+    const container = screen.getByText('분기점').parentElement;
+    expect(container?.className).toContain('statusIdle');
+  });
+});

--- a/frontend/src/features/workflow-viewer/ui/nodes/DecisionNode.tsx
+++ b/frontend/src/features/workflow-viewer/ui/nodes/DecisionNode.tsx
@@ -1,0 +1,25 @@
+import { Handle, Position, type NodeProps } from "@xyflow/react";
+import theme from "../../../shared/styles/workflow-node-theme.module.css";
+import { DEFAULT_NODE_STATUS, type GraphNodeStatus } from "@/entities/workflow";
+
+const STATUS_MAP: Record<GraphNodeStatus, string> = {
+  IDLE: theme.statusIdle,
+  ACTIVE: theme.statusActive,
+  COMPLETED: theme.statusCompleted,
+  FAILED: theme.statusFailed,
+};
+
+export function DecisionNode({ data }: NodeProps) {
+  const label = typeof data?.label === "string" ? data.label : "";
+  const status: GraphNodeStatus =
+    (data?.status as GraphNodeStatus | undefined) ?? DEFAULT_NODE_STATUS;
+  const statusClass = STATUS_MAP[status] ?? theme.statusIdle;
+
+  return (
+    <div className={`${theme.decision} ${statusClass}`}>
+      <Handle type="target" position={Position.Left} />
+      <span className={theme.decisionLabel}>{label}</span>
+      <Handle type="source" position={Position.Right} />
+    </div>
+  );
+}

--- a/frontend/src/features/workflow-viewer/ui/nodes/DecisionNode.tsx
+++ b/frontend/src/features/workflow-viewer/ui/nodes/DecisionNode.tsx
@@ -1,13 +1,7 @@
 import { Handle, Position, type NodeProps } from "@xyflow/react";
 import theme from "@/shared/styles/workflow-node-theme.module.css";
 import { DEFAULT_NODE_STATUS, type GraphNodeStatus } from "@/entities/workflow";
-
-const STATUS_MAP: Record<GraphNodeStatus, string> = {
-  IDLE: theme.statusIdle,
-  ACTIVE: theme.statusActive,
-  COMPLETED: theme.statusCompleted,
-  FAILED: theme.statusFailed,
-};
+import { STATUS_MAP } from "../nodeStyles";
 
 export function DecisionNode({ data }: NodeProps) {
   const label = typeof data?.label === "string" ? data.label : "";

--- a/frontend/src/features/workflow-viewer/ui/nodes/DecisionNode.tsx
+++ b/frontend/src/features/workflow-viewer/ui/nodes/DecisionNode.tsx
@@ -1,5 +1,5 @@
 import { Handle, Position, type NodeProps } from "@xyflow/react";
-import theme from "../../../shared/styles/workflow-node-theme.module.css";
+import theme from "@/shared/styles/workflow-node-theme.module.css";
 import { DEFAULT_NODE_STATUS, type GraphNodeStatus } from "@/entities/workflow";
 
 const STATUS_MAP: Record<GraphNodeStatus, string> = {

--- a/frontend/src/features/workflow-viewer/ui/nodes/HandoffNode.test.tsx
+++ b/frontend/src/features/workflow-viewer/ui/nodes/HandoffNode.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { HandoffNode } from './HandoffNode';
+
+vi.mock('@xyflow/react', () => ({
+  Handle: () => <div data-testid="handle" />,
+  Position: { Left: 'left', Right: 'right', Top: 'top', Bottom: 'bottom' },
+}));
+
+const defaultProps = {
+  id: "test",
+  type: "handoff" as const,
+  selected: false,
+  dragging: false,
+  zIndex: 0,
+  selectable: true,
+  deletable: false,
+  draggable: true,
+  isConnectable: false,
+  positionAbsoluteX: 0,
+  positionAbsoluteY: 0,
+};
+
+describe('HandoffNode', () => {
+  it('renders with label', () => {
+    render(<HandoffNode {...defaultProps} data={{ label: "전달" }} />);
+    expect(screen.getByText('전달')).toBeInTheDocument();
+  });
+
+  it('renders with IDLE status by default', () => {
+    render(<HandoffNode {...defaultProps} data={{ label: "전달" }} />);
+    const container = screen.getByText('전달').parentElement;
+    expect(container?.className).toContain('statusIdle');
+  });
+
+  it('renders with ACTIVE status when specified', () => {
+    render(<HandoffNode {...defaultProps} data={{ label: "전달", status: "ACTIVE" }} />);
+    const container = screen.getByText('전달').parentElement;
+    expect(container?.className).toContain('statusActive');
+  });
+});

--- a/frontend/src/features/workflow-viewer/ui/nodes/HandoffNode.tsx
+++ b/frontend/src/features/workflow-viewer/ui/nodes/HandoffNode.tsx
@@ -1,13 +1,7 @@
 import { Handle, Position, type NodeProps } from "@xyflow/react";
 import theme from "@/shared/styles/workflow-node-theme.module.css";
 import { DEFAULT_NODE_STATUS, type GraphNodeStatus } from "@/entities/workflow";
-
-const STATUS_MAP: Record<GraphNodeStatus, string> = {
-  IDLE: theme.statusIdle,
-  ACTIVE: theme.statusActive,
-  COMPLETED: theme.statusCompleted,
-  FAILED: theme.statusFailed,
-};
+import { STATUS_MAP } from "../nodeStyles";
 
 export function HandoffNode({ data }: NodeProps) {
   const label = typeof data?.label === "string" ? data.label : "";

--- a/frontend/src/features/workflow-viewer/ui/nodes/HandoffNode.tsx
+++ b/frontend/src/features/workflow-viewer/ui/nodes/HandoffNode.tsx
@@ -1,0 +1,25 @@
+import { Handle, Position, type NodeProps } from "@xyflow/react";
+import theme from "../../../shared/styles/workflow-node-theme.module.css";
+import { DEFAULT_NODE_STATUS, type GraphNodeStatus } from "@/entities/workflow";
+
+const STATUS_MAP: Record<GraphNodeStatus, string> = {
+  IDLE: theme.statusIdle,
+  ACTIVE: theme.statusActive,
+  COMPLETED: theme.statusCompleted,
+  FAILED: theme.statusFailed,
+};
+
+export function HandoffNode({ data }: NodeProps) {
+  const label = typeof data?.label === "string" ? data.label : "";
+  const status: GraphNodeStatus =
+    (data?.status as GraphNodeStatus | undefined) ?? DEFAULT_NODE_STATUS;
+  const statusClass = STATUS_MAP[status] ?? theme.statusIdle;
+
+  return (
+    <div className={`${theme.handoff} ${statusClass}`}>
+      <Handle type="target" position={Position.Left} />
+      <span>{label}</span>
+      <Handle type="source" position={Position.Right} />
+    </div>
+  );
+}

--- a/frontend/src/features/workflow-viewer/ui/nodes/HandoffNode.tsx
+++ b/frontend/src/features/workflow-viewer/ui/nodes/HandoffNode.tsx
@@ -12,7 +12,7 @@ export function HandoffNode({ data }: NodeProps) {
   return (
     <div className={`${theme.handoff} ${statusClass}`}>
       <Handle type="target" position={Position.Left} />
-      <span>{label}</span>
+      <span className={theme.label}>{label}</span>
       <Handle type="source" position={Position.Right} />
     </div>
   );

--- a/frontend/src/features/workflow-viewer/ui/nodes/HandoffNode.tsx
+++ b/frontend/src/features/workflow-viewer/ui/nodes/HandoffNode.tsx
@@ -1,5 +1,5 @@
 import { Handle, Position, type NodeProps } from "@xyflow/react";
-import theme from "../../../shared/styles/workflow-node-theme.module.css";
+import theme from "@/shared/styles/workflow-node-theme.module.css";
 import { DEFAULT_NODE_STATUS, type GraphNodeStatus } from "@/entities/workflow";
 
 const STATUS_MAP: Record<GraphNodeStatus, string> = {

--- a/frontend/src/features/workflow-viewer/ui/nodes/StartNode.test.tsx
+++ b/frontend/src/features/workflow-viewer/ui/nodes/StartNode.test.tsx
@@ -53,7 +53,8 @@ describe('StartNode', () => {
 
   it('shows empty label when data.label is undefined', () => {
     render(<StartNode {...defaultProps} data={{}} />);
-    const spans = screen.getAllByText('');
-    expect(spans.length).toBeGreaterThanOrEqual(1);
+    const label = screen.getByTestId('start-node-label');
+    expect(label).toBeInTheDocument();
+    expect(label.textContent).toBe('');
   });
 });

--- a/frontend/src/features/workflow-viewer/ui/nodes/StartNode.test.tsx
+++ b/frontend/src/features/workflow-viewer/ui/nodes/StartNode.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { StartNode } from './StartNode';
+
+vi.mock('@xyflow/react', () => ({
+  Handle: () => <div data-testid="handle" />,
+  Position: { Left: 'left', Right: 'right', Top: 'top', Bottom: 'bottom' },
+}));
+
+const defaultProps = {
+  id: "test",
+  type: "start" as const,
+  selected: false,
+  dragging: false,
+  zIndex: 0,
+  selectable: true,
+  deletable: false,
+  draggable: true,
+  isConnectable: false,
+  positionAbsoluteX: 0,
+  positionAbsoluteY: 0,
+};
+
+describe('StartNode', () => {
+  it('renders with label text', () => {
+    render(<StartNode {...defaultProps} data={{ label: "시작" }} />);
+    expect(screen.getByText('시작')).toBeInTheDocument();
+  });
+
+  it('renders with IDLE status by default', () => {
+    render(<StartNode {...defaultProps} data={{ label: "시작" }} />);
+    const container = screen.getByText('시작').parentElement;
+    expect(container?.className).toContain('statusIdle');
+  });
+
+  it('renders with ACTIVE status', () => {
+    render(<StartNode {...defaultProps} data={{ label: "시작", status: "ACTIVE" }} />);
+    const container = screen.getByText('시작').parentElement;
+    expect(container?.className).toContain('statusActive');
+  });
+
+  it('renders with COMPLETED status', () => {
+    render(<StartNode {...defaultProps} data={{ label: "시작", status: "COMPLETED" }} />);
+    const container = screen.getByText('시작').parentElement;
+    expect(container?.className).toContain('statusCompleted');
+  });
+
+  it('renders with FAILED status', () => {
+    render(<StartNode {...defaultProps} data={{ label: "시작", status: "FAILED" }} />);
+    const container = screen.getByText('시작').parentElement;
+    expect(container?.className).toContain('statusFailed');
+  });
+
+  it('shows empty label when data.label is undefined', () => {
+    render(<StartNode {...defaultProps} data={{}} />);
+    const spans = screen.getAllByText('');
+    expect(spans.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/frontend/src/features/workflow-viewer/ui/nodes/StartNode.tsx
+++ b/frontend/src/features/workflow-viewer/ui/nodes/StartNode.tsx
@@ -10,7 +10,7 @@ export function StartNode({ data }: NodeProps) {
 
   return (
     <div className={`${theme.start} ${STATUS_MAP[status] ?? theme.statusIdle}`}>
-      <span>{label}</span>
+      <span data-testid="start-node-label">{label}</span>
       <Handle type="source" position={Position.Right} />
     </div>
   );

--- a/frontend/src/features/workflow-viewer/ui/nodes/StartNode.tsx
+++ b/frontend/src/features/workflow-viewer/ui/nodes/StartNode.tsx
@@ -1,13 +1,7 @@
 import { Handle, Position, type NodeProps } from "@xyflow/react";
 import theme from "@/shared/styles/workflow-node-theme.module.css";
 import { DEFAULT_NODE_STATUS, type GraphNodeStatus } from "@/entities/workflow";
-
-const STATUS_MAP: Record<GraphNodeStatus, string> = {
-  IDLE: theme.statusIdle,
-  ACTIVE: theme.statusActive,
-  COMPLETED: theme.statusCompleted,
-  FAILED: theme.statusFailed,
-};
+import { STATUS_MAP } from "../nodeStyles";
 
 export function StartNode({ data }: NodeProps) {
   const label = typeof data?.label === "string" ? data.label : "";

--- a/frontend/src/features/workflow-viewer/ui/nodes/StartNode.tsx
+++ b/frontend/src/features/workflow-viewer/ui/nodes/StartNode.tsx
@@ -1,0 +1,23 @@
+import { Handle, Position, type NodeProps } from "@xyflow/react";
+import theme from "../../../shared/styles/workflow-node-theme.module.css";
+import { DEFAULT_NODE_STATUS, type GraphNodeStatus } from "@/entities/workflow";
+
+const STATUS_MAP: Record<GraphNodeStatus, string> = {
+  IDLE: theme.statusIdle,
+  ACTIVE: theme.statusActive,
+  COMPLETED: theme.statusCompleted,
+  FAILED: theme.statusFailed,
+};
+
+export function StartNode({ data }: NodeProps) {
+  const label = typeof data?.label === "string" ? data.label : "";
+  const status: GraphNodeStatus =
+    (data?.status as GraphNodeStatus | undefined) ?? DEFAULT_NODE_STATUS;
+
+  return (
+    <div className={`${theme.start} ${STATUS_MAP[status]}`}>
+      <span>{label}</span>
+      <Handle type="source" position={Position.Right} />
+    </div>
+  );
+}

--- a/frontend/src/features/workflow-viewer/ui/nodes/StartNode.tsx
+++ b/frontend/src/features/workflow-viewer/ui/nodes/StartNode.tsx
@@ -1,5 +1,5 @@
 import { Handle, Position, type NodeProps } from "@xyflow/react";
-import theme from "../../../shared/styles/workflow-node-theme.module.css";
+import theme from "@/shared/styles/workflow-node-theme.module.css";
 import { DEFAULT_NODE_STATUS, type GraphNodeStatus } from "@/entities/workflow";
 
 const STATUS_MAP: Record<GraphNodeStatus, string> = {
@@ -15,7 +15,7 @@ export function StartNode({ data }: NodeProps) {
     (data?.status as GraphNodeStatus | undefined) ?? DEFAULT_NODE_STATUS;
 
   return (
-    <div className={`${theme.start} ${STATUS_MAP[status]}`}>
+    <div className={`${theme.start} ${STATUS_MAP[status] ?? theme.statusIdle}`}>
       <span>{label}</span>
       <Handle type="source" position={Position.Right} />
     </div>

--- a/frontend/src/features/workflow-viewer/ui/nodes/TerminalNode.test.tsx
+++ b/frontend/src/features/workflow-viewer/ui/nodes/TerminalNode.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { TerminalNode } from './TerminalNode';
+
+vi.mock('@xyflow/react', () => ({
+  Handle: () => <div data-testid="handle" />,
+  Position: { Left: 'left', Right: 'right', Top: 'top', Bottom: 'bottom' },
+}));
+
+const defaultProps = {
+  id: "test",
+  type: "terminal" as const,
+  selected: false,
+  dragging: false,
+  zIndex: 0,
+  selectable: true,
+  deletable: false,
+  draggable: true,
+  isConnectable: false,
+  positionAbsoluteX: 0,
+  positionAbsoluteY: 0,
+};
+
+describe('TerminalNode', () => {
+  it('renders with label', () => {
+    render(<TerminalNode {...defaultProps} data={{ label: "종료" }} />);
+    expect(screen.getByText('종료')).toBeInTheDocument();
+  });
+
+  it('renders with COMPLETED status', () => {
+    render(<TerminalNode {...defaultProps} data={{ label: "종료", status: "COMPLETED" }} />);
+    const container = screen.getByText('종료').parentElement;
+    expect(container?.className).toContain('statusCompleted');
+  });
+
+  it('renders with IDLE status by default', () => {
+    render(<TerminalNode {...defaultProps} data={{ label: "종료" }} />);
+    const container = screen.getByText('종료').parentElement;
+    expect(container?.className).toContain('statusIdle');
+  });
+});

--- a/frontend/src/features/workflow-viewer/ui/nodes/TerminalNode.tsx
+++ b/frontend/src/features/workflow-viewer/ui/nodes/TerminalNode.tsx
@@ -1,13 +1,7 @@
 import { Handle, Position, type NodeProps } from "@xyflow/react";
 import theme from "@/shared/styles/workflow-node-theme.module.css";
 import { DEFAULT_NODE_STATUS, type GraphNodeStatus } from "@/entities/workflow";
-
-const STATUS_MAP: Record<GraphNodeStatus, string> = {
-  IDLE: theme.statusIdle,
-  ACTIVE: theme.statusActive,
-  COMPLETED: theme.statusCompleted,
-  FAILED: theme.statusFailed,
-};
+import { STATUS_MAP } from "../nodeStyles";
 
 export function TerminalNode({ data }: NodeProps) {
   const label = typeof data?.label === "string" ? data.label : "";

--- a/frontend/src/features/workflow-viewer/ui/nodes/TerminalNode.tsx
+++ b/frontend/src/features/workflow-viewer/ui/nodes/TerminalNode.tsx
@@ -1,0 +1,24 @@
+import { Handle, Position, type NodeProps } from "@xyflow/react";
+import theme from "../../../shared/styles/workflow-node-theme.module.css";
+import { DEFAULT_NODE_STATUS, type GraphNodeStatus } from "@/entities/workflow";
+
+const STATUS_MAP: Record<GraphNodeStatus, string> = {
+  IDLE: theme.statusIdle,
+  ACTIVE: theme.statusActive,
+  COMPLETED: theme.statusCompleted,
+  FAILED: theme.statusFailed,
+};
+
+export function TerminalNode({ data }: NodeProps) {
+  const label = typeof data?.label === "string" ? data.label : "";
+  const status: GraphNodeStatus =
+    (data?.status as GraphNodeStatus | undefined) ?? DEFAULT_NODE_STATUS;
+  const statusClass = STATUS_MAP[status] ?? theme.statusIdle;
+
+  return (
+    <div className={`${theme.terminal} ${statusClass}`}>
+      <Handle type="target" position={Position.Left} />
+      <span>{label}</span>
+    </div>
+  );
+}

--- a/frontend/src/features/workflow-viewer/ui/nodes/TerminalNode.tsx
+++ b/frontend/src/features/workflow-viewer/ui/nodes/TerminalNode.tsx
@@ -1,5 +1,5 @@
 import { Handle, Position, type NodeProps } from "@xyflow/react";
-import theme from "../../../shared/styles/workflow-node-theme.module.css";
+import theme from "@/shared/styles/workflow-node-theme.module.css";
 import { DEFAULT_NODE_STATUS, type GraphNodeStatus } from "@/entities/workflow";
 
 const STATUS_MAP: Record<GraphNodeStatus, string> = {

--- a/frontend/src/pages/domain-pack/ui/WorkflowGraphViewerPage.module.css
+++ b/frontend/src/pages/domain-pack/ui/WorkflowGraphViewerPage.module.css
@@ -1,0 +1,22 @@
+.loadingState {
+  padding: var(--s-8);
+  text-align: center;
+  color: var(--text-3);
+}
+
+.errorState {
+  padding: var(--s-8);
+  text-align: center;
+  color: var(--danger);
+}
+
+.emptyState {
+  padding: var(--s-8);
+  text-align: center;
+  color: var(--text-3);
+}
+
+.graphContainer {
+  flex: 1;
+  min-height: 0;
+}

--- a/frontend/src/pages/domain-pack/ui/WorkflowGraphViewerPage.test.tsx
+++ b/frontend/src/pages/domain-pack/ui/WorkflowGraphViewerPage.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import type { WorkflowDefinitionDetail } from "@/shared/api/generated/zod";
+import { WorkflowGraphViewerPage } from "./WorkflowGraphViewerPage";
+
+const mockUseGetWorkflowDefinition = vi.hoisted(() => vi.fn());
+
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...(actual as object),
+    useParams: () => ({
+      workspaceId: "1",
+      packId: "2",
+      versionId: "3",
+      workflowId: "4",
+    }),
+  };
+});
+
+vi.mock("@/entities/workflow", () => ({
+  useGetWorkflowDefinition: mockUseGetWorkflowDefinition,
+}));
+
+vi.mock("@/features/workflow-viewer/ui/GraphViewer", () => ({
+  GraphViewer: () => <div data-testid="graph-viewer">Graph</div>,
+}));
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  return <MemoryRouter>{children}</MemoryRouter>;
+}
+
+describe("WorkflowGraphViewerPage", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows loading state when isLoading is true", () => {
+    mockUseGetWorkflowDefinition.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    });
+
+    render(<WorkflowGraphViewerPage />, { wrapper: Wrapper });
+    expect(screen.getByTestId("loading-state")).toBeInTheDocument();
+  });
+
+  it("shows error state when error is present", () => {
+    mockUseGetWorkflowDefinition.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error("Failed to load"),
+    });
+
+    render(<WorkflowGraphViewerPage />, { wrapper: Wrapper });
+    expect(screen.getByTestId("error-state")).toBeInTheDocument();
+  });
+
+  it("shows GraphViewer when data is loaded", () => {
+    const mockData: WorkflowDefinitionDetail = {
+      graphJson: JSON.stringify({
+        nodes: [],
+        edges: [],
+      }),
+    };
+    mockUseGetWorkflowDefinition.mockReturnValue({
+      data: mockData,
+      isLoading: false,
+      error: null,
+    });
+
+    render(<WorkflowGraphViewerPage />, { wrapper: Wrapper });
+    expect(screen.getByTestId("graph-viewer")).toBeInTheDocument();
+  });
+
+  it("shows empty state when graphJson is null", () => {
+    const mockData: WorkflowDefinitionDetail = {
+      graphJson: undefined,
+    };
+    mockUseGetWorkflowDefinition.mockReturnValue({
+      data: mockData,
+      isLoading: false,
+      error: null,
+    });
+
+    render(<WorkflowGraphViewerPage />, { wrapper: Wrapper });
+    expect(screen.getByTestId("empty-state")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/domain-pack/ui/WorkflowGraphViewerPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/WorkflowGraphViewerPage.tsx
@@ -7,10 +7,10 @@ import type { WorkflowGraph } from "@/entities/workflow";
 import GraphViewer from "@/features/workflow-viewer/ui/GraphViewer";
 
 export function WorkflowGraphViewerPage() {
-  const { workspaceId, domainPackId, versionId, workflowId } = useParams();
+  const { workspaceId, packId, versionId, workflowId } = useParams();
 
   const wsId = parseRouteId(workspaceId);
-  const pkId = parseRouteId(domainPackId);
+  const pkId = parseRouteId(packId);
   const vsId = parseRouteId(versionId);
   const wfId = parseRouteId(workflowId);
 

--- a/frontend/src/pages/domain-pack/ui/WorkflowGraphViewerPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/WorkflowGraphViewerPage.tsx
@@ -1,10 +1,11 @@
 import { useMemo } from "react";
 import { useParams } from "react-router-dom";
+import { toast } from "sonner";
 import { OstoneShell } from "@/widgets/ostone-shell";
 import { parseRouteId } from "@/shared/lib/parseRouteId";
-import { useGetWorkflowDefinition } from "@/entities/workflow/api/useGetWorkflowDefinition";
+import { useGetWorkflowDefinition } from "@/entities/workflow";
 import type { WorkflowGraph } from "@/entities/workflow";
-import GraphViewer from "@/features/workflow-viewer/ui/GraphViewer";
+import { GraphViewer } from "@/features/workflow-viewer/ui/GraphViewer";
 import styles from "./WorkflowGraphViewerPage.module.css";
 
 export function WorkflowGraphViewerPage() {
@@ -32,63 +33,83 @@ export function WorkflowGraphViewerPage() {
       try {
         return JSON.parse(rawGraph) as WorkflowGraph;
       } catch {
+        console.error("워크플로우 그래프 JSON 파싱 실패:", rawGraph);
         return null;
       }
     }
     return rawGraph as WorkflowGraph;
   }, [rawGraph]);
 
-  const pageProps = {
-    active: "domain" as const,
-    crumbs: [
-      `WS \u00b7 ${wsId ?? "-"}`,
-      "Domain Packs",
-      `VER \u00b7 ${vsId ?? "-"}`,
-      "Workflow Graph",
-    ],
-  };
-
   if (isLoading) {
-    return OstoneShell({
-      ...pageProps,
-      children: (
+    return (
+      <OstoneShell
+        active="domain"
+        crumbs={[
+          `WS \u00b7 ${wsId ?? "-"}`,
+          "Domain Packs",
+          `VER \u00b7 ${vsId ?? "-"}`,
+          "Workflow Graph",
+        ]}
+      >
         <div data-testid="loading-state" className={styles.loadingState}>
           워크플로우 데이터를 불러오는 중...
         </div>
-      ),
-    });
+      </OstoneShell>
+    );
   }
 
   if (error) {
-    return OstoneShell({
-      ...pageProps,
-      children: (
+    toast.error("워크플로우 데이터를 불러오지 못했습니다.");
+    return (
+      <OstoneShell
+        active="domain"
+        crumbs={[
+          `WS \u00b7 ${wsId ?? "-"}`,
+          "Domain Packs",
+          `VER \u00b7 ${vsId ?? "-"}`,
+          "Workflow Graph",
+        ]}
+      >
         <div data-testid="error-state" className={styles.errorState}>
           에러: {error instanceof Error ? error.message : "데이터를 불러오는 중 오류가 발생했습니다."}
         </div>
-      ),
-    });
+      </OstoneShell>
+    );
   }
 
   if (!graph) {
-    return OstoneShell({
-      ...pageProps,
-      children: (
+    return (
+      <OstoneShell
+        active="domain"
+        crumbs={[
+          `WS \u00b7 ${wsId ?? "-"}`,
+          "Domain Packs",
+          `VER \u00b7 ${vsId ?? "-"}`,
+          "Workflow Graph",
+        ]}
+      >
         <div data-testid="empty-state" className={styles.emptyState}>
           표시할 워크플로우 그래프가 없습니다.
         </div>
-      ),
-    });
+      </OstoneShell>
+    );
   }
 
-  return OstoneShell({
-    ...pageProps,
-    children: (
+  return (
+    <OstoneShell
+      active="domain"
+      crumbs={[
+        `WS \u00b7 ${wsId ?? "-"}`,
+        "Domain Packs",
+        `VER \u00b7 ${vsId ?? "-"}`,
+        "Workflow Graph",
+      ]}
+    >
       <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
         <div className={styles.graphContainer}>
           <GraphViewer graph={graph} />
         </div>
       </div>
-    ),
-  });
+    </OstoneShell>
+  );
 }

--- a/frontend/src/pages/domain-pack/ui/WorkflowGraphViewerPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/WorkflowGraphViewerPage.tsx
@@ -5,6 +5,7 @@ import { parseRouteId } from "@/shared/lib/parseRouteId";
 import { useGetWorkflowDefinition } from "@/entities/workflow/api/useGetWorkflowDefinition";
 import type { WorkflowGraph } from "@/entities/workflow";
 import GraphViewer from "@/features/workflow-viewer/ui/GraphViewer";
+import styles from "./WorkflowGraphViewerPage.module.css";
 
 export function WorkflowGraphViewerPage() {
   const { workspaceId, packId, versionId, workflowId } = useParams();
@@ -51,14 +52,7 @@ export function WorkflowGraphViewerPage() {
     return OstoneShell({
       ...pageProps,
       children: (
-        <div
-          data-testid="loading-state"
-          style={{
-            padding: "var(--s-8)",
-            textAlign: "center",
-            color: "var(--text-3)",
-          }}
-        >
+        <div data-testid="loading-state" className={styles.loadingState}>
           워크플로우 데이터를 불러오는 중...
         </div>
       ),
@@ -69,14 +63,7 @@ export function WorkflowGraphViewerPage() {
     return OstoneShell({
       ...pageProps,
       children: (
-        <div
-          data-testid="error-state"
-          style={{
-            padding: "var(--s-8)",
-            textAlign: "center",
-            color: "var(--danger)",
-          }}
-        >
+        <div data-testid="error-state" className={styles.errorState}>
           에러: {error instanceof Error ? error.message : "데이터를 불러오는 중 오류가 발생했습니다."}
         </div>
       ),
@@ -87,14 +74,7 @@ export function WorkflowGraphViewerPage() {
     return OstoneShell({
       ...pageProps,
       children: (
-        <div
-          data-testid="empty-state"
-          style={{
-            padding: "var(--s-8)",
-            textAlign: "center",
-            color: "var(--text-3)",
-          }}
-        >
+        <div data-testid="empty-state" className={styles.emptyState}>
           표시할 워크플로우 그래프가 없습니다.
         </div>
       ),
@@ -105,7 +85,7 @@ export function WorkflowGraphViewerPage() {
     ...pageProps,
     children: (
       <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
-        <div style={{ flex: 1, minHeight: 0 }}>
+        <div className={styles.graphContainer}>
           <GraphViewer graph={graph} />
         </div>
       </div>

--- a/frontend/src/pages/domain-pack/ui/WorkflowGraphViewerPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/WorkflowGraphViewerPage.tsx
@@ -1,0 +1,114 @@
+import { useMemo } from "react";
+import { useParams } from "react-router-dom";
+import { OstoneShell } from "@/widgets/ostone-shell";
+import { parseRouteId } from "@/shared/lib/parseRouteId";
+import { useGetWorkflowDefinition } from "@/entities/workflow/api/useGetWorkflowDefinition";
+import type { WorkflowGraph } from "@/entities/workflow";
+import GraphViewer from "@/features/workflow-viewer/ui/GraphViewer";
+
+export function WorkflowGraphViewerPage() {
+  const { workspaceId, domainPackId, versionId, workflowId } = useParams();
+
+  const wsId = parseRouteId(workspaceId);
+  const pkId = parseRouteId(domainPackId);
+  const vsId = parseRouteId(versionId);
+  const wfId = parseRouteId(workflowId);
+
+  const enabled = wsId !== null && pkId !== null && vsId !== null && wfId !== null;
+
+  const { data, isLoading, error } = useGetWorkflowDefinition({
+    workspaceId: wsId ?? 0,
+    packId: pkId ?? 0,
+    versionId: vsId ?? 0,
+    workflowId: wfId ?? 0,
+    enabled,
+  });
+
+  const rawGraph = data?.graphJson;
+  const graph = useMemo<WorkflowGraph | null>(() => {
+    if (!rawGraph) return null;
+    if (typeof rawGraph === "string") {
+      try {
+        return JSON.parse(rawGraph) as WorkflowGraph;
+      } catch {
+        return null;
+      }
+    }
+    return rawGraph as WorkflowGraph;
+  }, [rawGraph]);
+
+  const pageProps = {
+    active: "domain" as const,
+    crumbs: [
+      `WS \u00b7 ${wsId ?? "-"}`,
+      "Domain Packs",
+      `VER \u00b7 ${vsId ?? "-"}`,
+      "Workflow Graph",
+    ],
+  };
+
+  if (isLoading) {
+    return OstoneShell({
+      ...pageProps,
+      children: (
+        <div
+          data-testid="loading-state"
+          style={{
+            padding: "var(--s-8)",
+            textAlign: "center",
+            color: "var(--text-3)",
+          }}
+        >
+          워크플로우 데이터를 불러오는 중...
+        </div>
+      ),
+    });
+  }
+
+  if (error) {
+    return OstoneShell({
+      ...pageProps,
+      children: (
+        <div
+          data-testid="error-state"
+          style={{
+            padding: "var(--s-8)",
+            textAlign: "center",
+            color: "var(--danger)",
+          }}
+        >
+          에러: {error instanceof Error ? error.message : "데이터를 불러오는 중 오류가 발생했습니다."}
+        </div>
+      ),
+    });
+  }
+
+  if (!graph) {
+    return OstoneShell({
+      ...pageProps,
+      children: (
+        <div
+          data-testid="empty-state"
+          style={{
+            padding: "var(--s-8)",
+            textAlign: "center",
+            color: "var(--text-3)",
+          }}
+        >
+          표시할 워크플로우 그래프가 없습니다.
+        </div>
+      ),
+    });
+  }
+
+  return OstoneShell({
+    ...pageProps,
+    children: (
+      <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
+        <div style={{ flex: 1, minHeight: 0 }}>
+          <GraphViewer graph={graph} />
+        </div>
+      </div>
+    ),
+  });
+}

--- a/frontend/src/pages/domain-pack/ui/WorkflowGraphViewerPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/WorkflowGraphViewerPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { useParams } from "react-router-dom";
 import { toast } from "sonner";
 import { OstoneShell } from "@/widgets/ostone-shell";
@@ -40,6 +40,12 @@ export function WorkflowGraphViewerPage() {
     return rawGraph as WorkflowGraph;
   }, [rawGraph]);
 
+  useEffect(() => {
+    if (error) {
+      toast.error("워크플로우 데이터를 불러오지 못했습니다.");
+    }
+  }, [error]);
+
   if (isLoading) {
     return (
       <OstoneShell
@@ -59,7 +65,6 @@ export function WorkflowGraphViewerPage() {
   }
 
   if (error) {
-    toast.error("워크플로우 데이터를 불러오지 못했습니다.");
     return (
       <OstoneShell
         active="domain"

--- a/frontend/src/shared/styles/workflow-node-theme.module.css
+++ b/frontend/src/shared/styles/workflow-node-theme.module.css
@@ -119,9 +119,6 @@
   color: var(--bg-color);
 }
 
-.statusIdle {
-}
-
 .statusActive {
   border-width: 2px;
 }

--- a/frontend/src/shared/styles/workflow-node-theme.module.css
+++ b/frontend/src/shared/styles/workflow-node-theme.module.css
@@ -1,0 +1,184 @@
+.base {
+  font-family: var(--font-sans);
+  font-weight: 400;
+  font-size: var(--font-size-sm);
+  letter-spacing: -0.14px;
+  color: var(--text-primary);
+  background: var(--bg-color);
+  border: 1px solid var(--text-primary);
+  padding: 8px 16px;
+  min-width: 120px;
+  max-width: 100%;
+  text-align: center;
+  white-space: nowrap;
+  transition: border-width var(--transition-fast), border-color var(--transition-fast),
+    background-color var(--transition-fast);
+}
+
+.start {
+  composes: base;
+  border-radius: var(--radius-xl);
+  background: var(--text-primary);
+  color: var(--bg-color);
+}
+
+.action {
+  composes: base;
+  border-radius: var(--radius-md);
+}
+
+.decision {
+  composes: base;
+  position: relative;
+  width: 96px;
+  height: 96px;
+  min-width: 0;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: transparent;
+  border-radius: 0;
+}
+
+.decision::before {
+  content: "";
+  position: absolute;
+  width: 68px;
+  height: 68px;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) rotate(45deg);
+  background: var(--bg-color);
+  border: 1px solid var(--text-primary);
+  border-radius: var(--radius-sm);
+}
+
+.decisionLabel {
+  display: block;
+  position: relative;
+  z-index: 1;
+  font-size: 12px;
+  max-width: 100%;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.answer {
+  composes: base;
+  position: relative;
+  border: none;
+  background: transparent;
+  padding-left: 20px;
+}
+
+.answer::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  clip-path: polygon(8px 0, 100% 0, 100% 100%, 0 100%);
+  border-radius: var(--radius-md);
+  background: var(--glass-dark);
+  border: 1px solid var(--text-primary);
+  z-index: -1;
+}
+
+.handoff {
+  composes: base;
+  position: relative;
+  border: none;
+  background: transparent;
+  padding-left: 18px;
+  padding-right: 18px;
+}
+
+.handoff::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  clip-path: polygon(8px 0, calc(100% - 8px) 0, 100% 100%, 0 100%);
+  border-radius: var(--radius-sm);
+  background: var(--bg-color);
+  border: 1px solid var(--text-primary);
+  z-index: -1;
+}
+
+.terminal {
+  composes: base;
+  border-radius: var(--radius-full);
+  width: 80px;
+  height: 80px;
+  min-width: 0;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--text-primary);
+  color: var(--bg-color);
+}
+
+.statusIdle {
+}
+
+.statusActive {
+  border-width: 2px;
+}
+
+.start.statusActive,
+.terminal.statusActive {
+  border-color: var(--bg-color);
+}
+
+.decision.statusActive::before,
+.answer.statusActive::before,
+.handoff.statusActive::before {
+  border-width: 2px;
+}
+
+.statusCompleted {
+  background-color: var(--signal-bg);
+  border-color: var(--signal);
+}
+
+.start.statusCompleted,
+.terminal.statusCompleted {
+  background-color: var(--text-primary);
+  border-color: var(--signal);
+  color: var(--bg-color);
+}
+
+.decision.statusCompleted::before,
+.answer.statusCompleted::before,
+.handoff.statusCompleted::before {
+  background-color: var(--signal-bg);
+  border-color: var(--signal);
+}
+
+.statusFailed {
+  background-color: var(--danger-bg);
+  border-color: var(--danger);
+}
+
+.start.statusFailed,
+.terminal.statusFailed {
+  background-color: var(--text-primary);
+  border-color: var(--danger);
+  color: var(--bg-color);
+}
+
+.decision.statusFailed::before,
+.answer.statusFailed::before,
+.handoff.statusFailed::before {
+  background-color: var(--danger-bg);
+  border-color: var(--danger);
+}
+
+.label {
+  display: block;
+  max-width: 100%;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}

--- a/frontend/src/shared/styles/workflow-node-theme.module.css
+++ b/frontend/src/shared/styles/workflow-node-theme.module.css
@@ -119,6 +119,9 @@
   color: var(--bg-color);
 }
 
+.statusIdle {
+}
+
 .statusActive {
   border-width: 2px;
 }

--- a/frontend/src/shared/styles/workflow-node-theme.module.css
+++ b/frontend/src/shared/styles/workflow-node-theme.module.css
@@ -120,6 +120,7 @@
 }
 
 .statusIdle {
+  /* Intentionally empty — default state */
 }
 
 .statusActive {


### PR DESCRIPTION
## Summary
- 워크플로우 그래프 뷰어를 위한 React Flow 기반 GraphViewer 컴포넌트 구현
- Start/Action/Decision/Answer/Handoff/Terminal 6종 커스텀 노드 지원
- IDLE/ACTIVE/COMPLETED/FAILED 노드 상태별 스타일링 시스템
- WorkflowGraphViewerPage 통합 페이지 및 API 연동

## Changes
### 신규 기능
- **GraphViewer 컴포넌트**: React Flow + 6종 nodeTypes + PlainEdge, 읽기 전용 뷰어
- **노드 상태 스타일 시스템**: nodeStatus.ts 타입 정의 + workflow-node-theme.module.css 테마
- **통합 페이지**: WorkflowGraphViewerPage (OstoneShell 기반, 로딩/에러/empty 상태 처리)
- **API Hook**: useGetWorkflowDefinition (React Query 기반)

### 파일 목록 (15 files, +687 lines)
- `entities/workflow/model/nodeStatus.ts` — 타입/스타일 정의
- `entities/workflow/api/useGetWorkflowDefinition.ts` — API fetch hook
- `features/workflow-viewer/ui/GraphViewer.tsx` — 메인 뷰어 컴포넌트
- `features/workflow-viewer/ui/nodes/*.tsx` — 6종 커스텀 노드
- `features/workflow-viewer/ui/edges/PlainEdge.tsx` — 엣지 컴포넌트
- `shared/styles/workflow-node-theme.module.css` — 노드 테마 CSS

### 검증
- tsc --noEmit: ✅ 0 errors
- build: ✅ 성공
- test: ✅ 126 files, 684 tests 통과

### Spec Reference
- `.agent/specs/4.1.8.md`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ajou-2026-1-capstone-5/ostone/pull/223" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 워크플로우 그래프 뷰어 추가 — 그래프 렌더링, 맞춤 엣지/레이블, 확대/축소 및 엣지 클릭 처리
  * 여러 노드 타입(시작/액션/결정/응답/핸드오프/종료) 및 노드 상태 매핑과 상태 정보 공개 API 추가
  * 워크플로우 정의 조회 훅과 해당 뷰어용 페이지 및 라우트 추가
* **스타일**
  * 그래프 레이아웃 및 노드 테마 CSS 모듈 추가
* **테스트**
  * 뷰어, 노드, 엣지, 상태맵 및 페이지 렌더링/유닛 테스트 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ajou-2026-1-capstone-5/ostone/pull/223)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->