### PR TITLE
feat(consultation): add message detail panel with slot/policy/risk tags

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -45,6 +45,7 @@
     "@playwright/test": "^1.59.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^24.12.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -109,6 +109,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/node':
         specifier: ^24.12.0
         version: 24.12.0
@@ -1844,6 +1847,12 @@ packages:
         optional: true
       '@types/react-dom':
         optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
 
   '@ts-morph/common@0.29.0':
     resolution: {integrity: sha512-35oUmphHbJvQ/+UTwFNme/t2p3FoKiGJ5auTjjpNTop2dyREspirjMy82PLSC1pnDJ8ah1GU98hwpVt64YXQsg==}
@@ -5351,6 +5360,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
 
   '@ts-morph/common@0.29.0':
     dependencies:

--- a/frontend/src/features/consultation/ui/ChatPanel.tsx
+++ b/frontend/src/features/consultation/ui/ChatPanel.tsx
@@ -122,6 +122,19 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
                   onSelectMessage(msg.id);
                 }
               }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  if (isSelected) {
+                    onSelectMessage(null);
+                  } else {
+                    onSelectMessage(msg.id);
+                  }
+                }
+              }}
+              tabIndex={0}
+              role="button"
+              aria-pressed={isSelected}
             >
               <div
                 className={`${styles.msgAvatar} ${isAgent ? styles.msgAvatarAgent : styles.msgAvatarCustomer}`}

--- a/frontend/src/features/consultation/ui/ChatPanel.tsx
+++ b/frontend/src/features/consultation/ui/ChatPanel.tsx
@@ -14,6 +14,8 @@ interface ChatPanelProps {
   channel: string | null;
   messages: ChatMessage[];
   onSendMessage: (content: string, isNote: boolean) => void;
+  selectedMessageId: string | null;
+  onSelectMessage: (messageId: string | null) => void;
 }
 
 /**
@@ -28,6 +30,8 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
   channel,
   messages,
   onSendMessage,
+  selectedMessageId,
+  onSelectMessage,
 }) => {
   const [input, setInput] = useState('');
   const [isNoteMode, setIsNoteMode] = useState(false);
@@ -106,10 +110,18 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
             );
           }
           const isAgent = msg.senderRole === 'AGENT';
+          const isSelected = selectedMessageId === msg.id;
           return (
             <div
               key={msg.id}
-              className={`${styles.messageGroup} ${isAgent ? styles.messageGroupAgent : styles.messageGroupCustomer}`}
+              className={`${styles.messageGroup} ${isAgent ? styles.messageGroupAgent : styles.messageGroupCustomer} ${isSelected ? styles.messageSelected : ''}`}
+              onClick={() => {
+                if (isSelected) {
+                  onSelectMessage(null);
+                } else {
+                  onSelectMessage(msg.id);
+                }
+              }}
             >
               <div
                 className={`${styles.msgAvatar} ${isAgent ? styles.msgAvatarAgent : styles.msgAvatarCustomer}`}

--- a/frontend/src/features/consultation/ui/MessageDetailPanel.module.css
+++ b/frontend/src/features/consultation/ui/MessageDetailPanel.module.css
@@ -1,0 +1,201 @@
+.wrapper {
+  width: 320px;
+  flex-shrink: 0;
+  background: var(--paper-2);
+  border-left: 1px solid var(--line-2);
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow-y: auto;
+}
+
+/* ─── Empty State ─── */
+.emptyState {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 32px;
+}
+
+.emptyStateIcon {
+  color: var(--ink-4);
+}
+
+.emptyStateText {
+  font-size: 12px;
+  color: var(--ink-3);
+  text-align: center;
+  line-height: 1.5;
+  font-family: var(--mono);
+}
+
+/* ─── Message Header ─── */
+.messageHeader {
+  padding: 16px;
+  border-bottom: 1px solid var(--line-2);
+}
+
+.messageMeta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.senderRole {
+  font-family: var(--mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--signal-ink);
+  background: var(--signal-bg);
+  padding: 2px 8px;
+  border-radius: var(--r-2);
+  font-weight: 500;
+}
+
+.timestamp {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--ink-3);
+  font-variant-numeric: tabular-nums;
+}
+
+.messagePreview {
+  font-size: 12px;
+  color: var(--ink);
+  line-height: 1.5;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+/* ─── Sections ─── */
+.section {
+  padding: 16px;
+  border-bottom: 1px solid var(--line-2);
+}
+
+.section:last-of-type {
+  border-bottom: none;
+}
+
+.sectionTitle {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 500;
+  color: var(--ink-3);
+  margin-bottom: 12px;
+}
+
+/* ─── Tag List ─── */
+.tagList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+/* ─── Tag Pill ─── */
+.tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  border-radius: var(--r-pill);
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  line-height: 1.4;
+  transition: background 0.15s, color 0.15s;
+}
+
+.tag:hover {
+  filter: brightness(0.95);
+}
+
+.tagExtracted {
+  background: var(--signal-bg);
+  color: var(--signal-ink);
+}
+
+.tagNotExtracted {
+  background: var(--paper-3);
+  color: var(--ink-3);
+}
+
+.tagValue {
+  font-weight: 400;
+  opacity: 0.85;
+}
+
+.tagValue::before {
+  content: ': ';
+}
+
+/* ─── Risk Level Indicators ─── */
+.tagRiskHigh {
+  background: var(--danger-bg);
+  color: var(--danger);
+}
+
+.tagRiskMedium {
+  background: var(--warn-bg);
+  color: var(--warn);
+}
+
+.tagRiskLow {
+  background: var(--info-bg);
+  color: var(--info);
+}
+
+.tagRiskHigh.tagNotExtracted,
+.tagRiskMedium.tagNotExtracted,
+.tagRiskLow.tagNotExtracted {
+  background: var(--paper-3);
+  color: var(--ink-3);
+}
+
+/* ─── Close Button ─── */
+.closeArea {
+  margin-top: auto;
+  padding: 12px 16px;
+  border-top: 1px solid var(--line-2);
+}
+
+.closeButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  width: 100%;
+  padding: 8px 0;
+  border: 1px solid var(--line);
+  border-radius: var(--r-3);
+  background: var(--paper);
+  color: var(--ink-2);
+  font-family: var(--mono);
+  font-size: 11px;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+
+.closeButton:hover {
+  background: var(--paper-3);
+  color: var(--ink);
+}
+
+.closeButton:focus-visible {
+  outline: 2px dashed var(--ink);
+  outline-offset: 2px;
+}
+
+.closeButton:active {
+  background: var(--line-2);
+}

--- a/frontend/src/features/consultation/ui/MessageDetailPanel.test.tsx
+++ b/frontend/src/features/consultation/ui/MessageDetailPanel.test.tsx
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MessageDetailPanel } from './MessageDetailPanel';
+
+describe('MessageDetailPanel', () => {
+  /* ─── Test 1: empty state ─── */
+  it('shows empty state when message is null', () => {
+    render(
+      <MessageDetailPanel
+        message={null}
+        domainPackElements={{ slots: [], policies: [], risks: [] }}
+        onClose={() => {}}
+      />,
+    );
+
+    expect(screen.getByText('메시지를 선택하세요')).toBeInTheDocument();
+
+    const aside = document.querySelector('aside');
+    expect(aside).toBeInTheDocument();
+
+    expect(screen.queryByText('Slot')).not.toBeInTheDocument();
+    expect(screen.queryByText('Policy')).not.toBeInTheDocument();
+    expect(screen.queryByText('Risk')).not.toBeInTheDocument();
+  });
+
+  /* ─── Test 2: message header ─── */
+  it('renders message header with sender role, content, and timestamp', () => {
+    render(
+      <MessageDetailPanel
+        message={{
+          id: '1',
+          senderRole: 'CUSTOMER',
+          content: '테스트 메시지입니다',
+          timestamp: '14:30',
+        }}
+        domainPackElements={{ slots: [], policies: [], risks: [] }}
+        onClose={() => {}}
+      />,
+    );
+
+    expect(screen.getByText('CUSTOMER')).toBeInTheDocument();
+    expect(screen.getByText('테스트 메시지입니다')).toBeInTheDocument();
+    expect(screen.getByText('14:30')).toBeInTheDocument();
+  });
+
+  /* ─── Test 3: Slot tags ─── */
+  it('renders Slot tags from MOCK_DATA', () => {
+    render(
+      <MessageDetailPanel
+        message={{
+          id: '1',
+          senderRole: 'CUSTOMER',
+          content: 'test',
+          timestamp: '12:00',
+        }}
+        domainPackElements={{ slots: [], policies: [], risks: [] }}
+        onClose={() => {}}
+      />,
+    );
+
+    expect(screen.getByText('가격 문의')).toBeInTheDocument();
+    expect(screen.getByText('89,000원')).toBeInTheDocument();
+    expect(screen.getByText('배송지 주소')).toBeInTheDocument();
+  });
+
+  /* ─── Test 4: Policy tags ─── */
+  it('renders Policy tags from MOCK_DATA', () => {
+    render(
+      <MessageDetailPanel
+        message={{
+          id: '1',
+          senderRole: 'CUSTOMER',
+          content: 'test',
+          timestamp: '12:00',
+        }}
+        domainPackElements={{ slots: [], policies: [], risks: [] }}
+        onClose={() => {}}
+      />,
+    );
+
+    expect(screen.getByText('반품 정책')).toBeInTheDocument();
+    expect(screen.getByText('환불 정책')).toBeInTheDocument();
+    expect(screen.getByText('교환 정책')).toBeInTheDocument();
+  });
+
+  /* ─── Test 5: Risk tags ─── */
+  it('renders Risk tags from MOCK_DATA', () => {
+    render(
+      <MessageDetailPanel
+        message={{
+          id: '1',
+          senderRole: 'CUSTOMER',
+          content: 'test',
+          timestamp: '12:00',
+        }}
+        domainPackElements={{ slots: [], policies: [], risks: [] }}
+        onClose={() => {}}
+      />,
+    );
+
+    expect(screen.getByText('고객 불만 고조')).toBeInTheDocument();
+    expect(screen.getByText('환불 요청')).toBeInTheDocument();
+    expect(screen.getByText('법적 대응')).toBeInTheDocument();
+  });
+
+  /* ─── Test 6: Close button ─── */
+  it('calls onClose when close button is clicked', () => {
+    const onClose = vi.fn();
+
+    render(
+      <MessageDetailPanel
+        message={{
+          id: '1',
+          senderRole: 'CUSTOMER',
+          content: 'test',
+          timestamp: '12:00',
+        }}
+        domainPackElements={{ slots: [], policies: [], risks: [] }}
+        onClose={onClose}
+      />,
+    );
+
+    fireEvent.click(screen.getByText('닫기'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/features/consultation/ui/MessageDetailPanel.test.tsx
+++ b/frontend/src/features/consultation/ui/MessageDetailPanel.test.tsx
@@ -53,7 +53,6 @@ describe('MessageDetailPanel', () => {
           content: 'test',
           timestamp: '12:00',
         }}
-        domainPackElements={{ slots: [], policies: [], risks: [] }}
         onClose={() => {}}
       />,
     );
@@ -73,7 +72,6 @@ describe('MessageDetailPanel', () => {
           content: 'test',
           timestamp: '12:00',
         }}
-        domainPackElements={{ slots: [], policies: [], risks: [] }}
         onClose={() => {}}
       />,
     );
@@ -93,7 +91,6 @@ describe('MessageDetailPanel', () => {
           content: 'test',
           timestamp: '12:00',
         }}
-        domainPackElements={{ slots: [], policies: [], risks: [] }}
         onClose={() => {}}
       />,
     );

--- a/frontend/src/features/consultation/ui/MessageDetailPanel.tsx
+++ b/frontend/src/features/consultation/ui/MessageDetailPanel.tsx
@@ -148,7 +148,7 @@ export function MessageDetailPanel({ message, domainPackElements, onClose }: Mes
       </Section>
 
       <div className={styles.closeArea}>
-        <button className={styles.closeButton} onClick={onClose}>
+        <button type="button" className={styles.closeButton} onClick={onClose}>
           닫기
         </button>
       </div>

--- a/frontend/src/features/consultation/ui/MessageDetailPanel.tsx
+++ b/frontend/src/features/consultation/ui/MessageDetailPanel.tsx
@@ -28,7 +28,7 @@ export interface MessageDetailPanelProps {
     content: string;
     timestamp: string;
   } | null;
-  domainPackElements: {
+  domainPackElements?: {
     slots: SlotTag[];
     policies: PolicyTag[];
     risks: RiskTag[];
@@ -105,8 +105,8 @@ function RiskTagItem({ risk }: { risk: RiskTag }) {
 }
 
 /* ─── Component ─── */
-export function MessageDetailPanel({ message, onClose }: MessageDetailPanelProps) {
-  const { slots, policies, risks } = MOCK_DATA;
+export function MessageDetailPanel({ message, domainPackElements, onClose }: MessageDetailPanelProps) {
+  const { slots, policies, risks } = domainPackElements ?? MOCK_DATA;
 
   if (!message) {
     return (

--- a/frontend/src/features/consultation/ui/MessageDetailPanel.tsx
+++ b/frontend/src/features/consultation/ui/MessageDetailPanel.tsx
@@ -1,0 +1,157 @@
+import { MessageSquare } from 'lucide-react';
+import type { ReactNode } from 'react';
+import styles from './MessageDetailPanel.module.css';
+
+/* ─── Types ─── */
+export interface SlotTag {
+  name: string;
+  extracted: boolean;
+  value?: string;
+}
+
+export interface PolicyTag {
+  name: string;
+  extracted: boolean;
+  matched: boolean;
+}
+
+export interface RiskTag {
+  name: string;
+  extracted: boolean;
+  level: 'low' | 'medium' | 'high';
+}
+
+export interface MessageDetailPanelProps {
+  message: {
+    id: string;
+    senderRole: string;
+    content: string;
+    timestamp: string;
+  } | null;
+  domainPackElements: {
+    slots: SlotTag[];
+    policies: PolicyTag[];
+    risks: RiskTag[];
+  };
+  onClose: () => void;
+}
+
+/* ─── Mock Data ─── */
+const MOCK_DATA: {
+  slots: SlotTag[];
+  policies: PolicyTag[];
+  risks: RiskTag[];
+} = {
+  slots: [
+    { name: '가격 문의', extracted: true, value: '89,000원' },
+    { name: '주문 번호', extracted: true, value: '#ORD-2024-08921' },
+    { name: '배송지 주소', extracted: false },
+  ],
+  policies: [
+    { name: '반품 정책', extracted: true, matched: true },
+    { name: '환불 정책', extracted: true, matched: false },
+    { name: '교환 정책', extracted: false, matched: false },
+  ],
+  risks: [
+    { name: '고객 불만 고조', extracted: true, level: 'high' as const },
+    { name: '환불 요청', extracted: true, level: 'medium' as const },
+    { name: '법적 대응', extracted: false, level: 'low' as const },
+  ],
+} as const;
+
+/* ─── Helpers ─── */
+function riskTagClass(risk: RiskTag): string {
+  if (!risk.extracted) return `${styles.tag} ${styles.tagNotExtracted}`;
+  const levelClass =
+    risk.level === 'high'
+      ? styles.tagRiskHigh
+      : risk.level === 'medium'
+        ? styles.tagRiskMedium
+        : styles.tagRiskLow;
+  return `${styles.tag} ${levelClass}`;
+}
+
+/* ─── Sub-components ─── */
+function Section({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <div className={styles.section}>
+      <div className={styles.sectionTitle}>{title}</div>
+      <div className={styles.tagList}>{children}</div>
+    </div>
+  );
+}
+
+function SlotTagItem({ slot }: { slot: SlotTag }) {
+  const cls = slot.extracted ? `${styles.tag} ${styles.tagExtracted}` : `${styles.tag} ${styles.tagNotExtracted}`;
+  return (
+    <span className={cls}>
+      {slot.name}
+      {slot.value && <span className={styles.tagValue}>{slot.value}</span>}
+    </span>
+  );
+}
+
+function PolicyTagItem({ policy }: { policy: PolicyTag }) {
+  const cls =
+    policy.extracted && policy.matched
+      ? `${styles.tag} ${styles.tagExtracted}`
+      : `${styles.tag} ${styles.tagNotExtracted}`;
+  return <span className={cls}>{policy.name}</span>;
+}
+
+function RiskTagItem({ risk }: { risk: RiskTag }) {
+  const cls = riskTagClass(risk);
+  return <span className={cls}>{risk.name}</span>;
+}
+
+/* ─── Component ─── */
+export function MessageDetailPanel({ message, onClose }: MessageDetailPanelProps) {
+  const { slots, policies, risks } = MOCK_DATA;
+
+  if (!message) {
+    return (
+      <aside className={styles.wrapper}>
+        <div className={styles.emptyState}>
+          <MessageSquare size={36} className={styles.emptyStateIcon} />
+          <p className={styles.emptyStateText}>메시지를 선택하세요</p>
+        </div>
+      </aside>
+    );
+  }
+
+  return (
+    <aside className={styles.wrapper}>
+      <div className={styles.messageHeader}>
+        <div className={styles.messageMeta}>
+          <span className={styles.senderRole}>{message.senderRole}</span>
+          <span className={styles.timestamp}>{message.timestamp}</span>
+        </div>
+        <p className={styles.messagePreview}>{message.content}</p>
+      </div>
+
+      <Section title="Slot">
+        {slots.map((slot) => (
+          <SlotTagItem key={slot.name} slot={slot} />
+        ))}
+      </Section>
+
+      <Section title="Policy">
+        {policies.map((policy) => (
+          <PolicyTagItem key={policy.name} policy={policy} />
+        ))}
+      </Section>
+
+      <Section title="Risk">
+        {risks.map((risk) => (
+          <RiskTagItem key={risk.name} risk={risk} />
+        ))}
+      </Section>
+
+      <div className={styles.closeArea}>
+        <button className={styles.closeButton} onClick={onClose}>
+          닫기
+        </button>
+      </div>
+    </aside>
+  );
+}

--- a/frontend/src/features/consultation/ui/chat-panel.module.css
+++ b/frontend/src/features/consultation/ui/chat-panel.module.css
@@ -93,6 +93,11 @@
   position: relative;
 }
 
+.messageGroup:focus-visible {
+  outline: 2px dashed var(--ink);
+  outline-offset: 2px;
+}
+
 .messageSelected {
   background: var(--signal-bg);
 }
@@ -173,7 +178,6 @@
 .systemMessage {
   text-align: center;
   font-size: 0.78rem;
-  letter-spacing: normal;
   color: var(--text-secondary);
   padding: 8px 16px;
   background: rgba(0, 0, 0, 0.02);

--- a/frontend/src/features/consultation/ui/chat-panel.module.css
+++ b/frontend/src/features/consultation/ui/chat-panel.module.css
@@ -87,6 +87,25 @@
   display: flex;
   gap: 10px;
   max-width: 75%;
+  cursor: pointer;
+  border-radius: var(--r-3);
+  transition: background 0.15s;
+  position: relative;
+}
+
+.messageSelected {
+  background: var(--signal-bg);
+}
+
+.messageSelected::before {
+  content: '';
+  position: absolute;
+  left: -10px;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  background: var(--signal-ink);
+  border-radius: 2px;
 }
 
 .messageGroupCustomer {

--- a/frontend/src/pages/consultation/ui/ConsultationPage.test.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.test.tsx
@@ -31,7 +31,18 @@ vi.mock('../../../features/consultation/api/consultationApi', () => ({
         },
       ]),
     ),
-    getMessages: vi.fn(() => Promise.resolve([])),
+    getMessages: vi.fn(() =>
+      Promise.resolve([
+        {
+          id: 100,
+          seqNo: 1,
+          senderRole: 'CUSTOMER',
+          messageType: 'TEXT',
+          content: '환불 문의 드립니다.',
+          createdAt: new Date().toISOString(),
+        },
+      ]),
+    ),
     sendMessage: vi.fn(() =>
       Promise.resolve({
         id: 99,
@@ -139,5 +150,61 @@ describe('ConsultationPage', () => {
     unmount();
     expect(shellContext.setTopbarRight).toHaveBeenCalledWith(undefined);
     expect(shellContext.setCrumbs).toHaveBeenCalledWith([]);
+  });
+
+  it('shows MessageDetailPanel when a message is clicked and hides it on close', async () => {
+    render(<ConsultationPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText('김민지')).toBeInTheDocument();
+    });
+
+    const customerItem = screen.getByText('김민지').closest('div');
+    if (customerItem) customerItem.click();
+
+    await waitFor(() => {
+      expect(screen.getByText('환불 문의 드립니다.')).toBeInTheDocument();
+    });
+
+    const messageEl = screen.getByText('환불 문의 드립니다.');
+    fireEvent.click(messageEl);
+
+    await waitFor(() => {
+      expect(screen.getByText('가격 문의')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('닫기'));
+
+    await waitFor(() => {
+      expect(screen.getByText('고객 정보')).toBeInTheDocument();
+    });
+  });
+
+  it('deselects message when the same message is clicked again', async () => {
+    render(<ConsultationPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText('김민지')).toBeInTheDocument();
+    });
+
+    const customerItem = screen.getByText('김민지').closest('div');
+    if (customerItem) customerItem.click();
+
+    await waitFor(() => {
+      expect(screen.getByText('환불 문의 드립니다.')).toBeInTheDocument();
+    });
+
+    const messageEl = screen.getByText('환불 문의 드립니다.');
+    fireEvent.click(messageEl);
+
+    await waitFor(() => {
+      expect(screen.getByText('가격 문의')).toBeInTheDocument();
+    });
+
+    fireEvent.click(messageEl);
+
+    await waitFor(() => {
+      expect(screen.getByText('고객 정보')).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/pages/consultation/ui/ConsultationPage.test.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { ConsultationPage } from './ConsultationPage';
 import { consultationApi } from '../../../features/consultation/api/consultationApi';
@@ -209,6 +210,7 @@ describe('ConsultationPage', () => {
   });
 
   it('opens detail panel with Enter key and closes on re-Enter', async () => {
+    const user = userEvent.setup();
     render(<ConsultationPage />, { wrapper: Wrapper });
 
     await waitFor(() => {
@@ -222,14 +224,16 @@ describe('ConsultationPage', () => {
       expect(screen.getByText('환불 문의 드립니다.')).toBeInTheDocument();
     });
 
-    const messageEl = screen.getByText('환불 문의 드립니다.');
-    fireEvent.keyDown(messageEl, { key: 'Enter' });
+    const messageButton = screen.getByRole('button', { name: /환불 문의 드립니다/ });
+    messageButton.focus();
+    await user.keyboard('{Enter}');
 
     await waitFor(() => {
       expect(screen.getByText('가격 문의')).toBeInTheDocument();
     });
 
-    fireEvent.keyDown(messageEl, { key: 'Enter' });
+    messageButton.focus();
+    await user.keyboard('{Enter}');
 
     await waitFor(() => {
       expect(screen.getByText('고객 정보')).toBeInTheDocument();
@@ -237,6 +241,7 @@ describe('ConsultationPage', () => {
   });
 
   it('opens detail panel with Space key', async () => {
+    const user = userEvent.setup();
     render(<ConsultationPage />, { wrapper: Wrapper });
 
     await waitFor(() => {
@@ -250,8 +255,9 @@ describe('ConsultationPage', () => {
       expect(screen.getByText('환불 문의 드립니다.')).toBeInTheDocument();
     });
 
-    const messageEl = screen.getByText('환불 문의 드립니다.');
-    fireEvent.keyDown(messageEl, { key: ' ' });
+    const messageButton = screen.getByRole('button', { name: /환불 문의 드립니다/ });
+    messageButton.focus();
+    await user.keyboard(' ');
 
     await waitFor(() => {
       expect(screen.getByText('가격 문의')).toBeInTheDocument();

--- a/frontend/src/pages/consultation/ui/ConsultationPage.test.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.test.tsx
@@ -207,4 +207,54 @@ describe('ConsultationPage', () => {
       expect(screen.getByText('고객 정보')).toBeInTheDocument();
     });
   });
+
+  it('opens detail panel with Enter key and closes on re-Enter', async () => {
+    render(<ConsultationPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText('김민지')).toBeInTheDocument();
+    });
+
+    const customerItem = screen.getByText('김민지').closest('div');
+    if (customerItem) customerItem.click();
+
+    await waitFor(() => {
+      expect(screen.getByText('환불 문의 드립니다.')).toBeInTheDocument();
+    });
+
+    const messageEl = screen.getByText('환불 문의 드립니다.');
+    fireEvent.keyDown(messageEl, { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(screen.getByText('가격 문의')).toBeInTheDocument();
+    });
+
+    fireEvent.keyDown(messageEl, { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(screen.getByText('고객 정보')).toBeInTheDocument();
+    });
+  });
+
+  it('opens detail panel with Space key', async () => {
+    render(<ConsultationPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText('김민지')).toBeInTheDocument();
+    });
+
+    const customerItem = screen.getByText('김민지').closest('div');
+    if (customerItem) customerItem.click();
+
+    await waitFor(() => {
+      expect(screen.getByText('환불 문의 드립니다.')).toBeInTheDocument();
+    });
+
+    const messageEl = screen.getByText('환불 문의 드립니다.');
+    fireEvent.keyDown(messageEl, { key: ' ' });
+
+    await waitFor(() => {
+      expect(screen.getByText('가격 문의')).toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/src/pages/consultation/ui/ConsultationPage.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.tsx
@@ -293,7 +293,7 @@ export const ConsultationPage: React.FC = () => {
           )}
         </div>
 
-        {selectedMessageId ? (
+        {selectedMessage ? (
           // TODO: domainPackElements를 실제 API 응답 데이터로 교체 (별도 API 연동 티켓)
           <MessageDetailPanel
             message={selectedMessage}

--- a/frontend/src/pages/consultation/ui/ConsultationPage.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.tsx
@@ -156,6 +156,7 @@ export const ConsultationPage: React.FC = () => {
     const targetId = activeCustomerId;
     try {
       const newMsg = await consultationApi.sendMessage(Number(targetId), content, isNote);
+      // UX: 메시지 전송 후 선택 해제되어 고객 정보 패널 복원 (의도된 동작)
       setSelectedMessageId(null);
       setActiveCustomerId(current => {
         if (current === targetId) {

--- a/frontend/src/pages/consultation/ui/ConsultationPage.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.tsx
@@ -80,6 +80,13 @@ export const ConsultationPage: React.FC = () => {
     };
   }, [setTopbarRight, setCrumbs]);
 
+  // Sync selectedMessageId with messages list (e.g., after polling refresh)
+  useEffect(() => {
+    if (selectedMessageId && !messages.some((m) => m.id === selectedMessageId)) {
+      setSelectedMessageId(null);
+    }
+  }, [messages, selectedMessageId]);
+
   const loadQueue = useCallback(async () => {
     try {
       const sessions = await consultationApi.getQueue();

--- a/frontend/src/pages/consultation/ui/ConsultationPage.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.tsx
@@ -11,6 +11,7 @@ import { CustomerInfoPanel } from '../../../features/consultation/ui/CustomerInf
 import { StatusBar } from '../../../features/consultation/ui/StatusBar';
 import { consultationApi } from '../../../features/consultation/api/consultationApi';
 import { CustomerPanel } from './sections/CustomerPanel';
+import { MessageDetailPanel } from '../../../features/consultation/ui/MessageDetailPanel';
 
 void CustomerInfoPanel;
 void StatusBar;
@@ -62,11 +63,13 @@ export const ConsultationPage: React.FC = () => {
   const [memos, setMemos] = useState<Record<string, string>>({});
   const [statuses, setStatuses] = useState<Record<string, string>>({});
   const [categories, setCategories] = useState<Record<string, string>>({});
+  const [selectedMessageId, setSelectedMessageId] = useState<string | null>(null);
 
   void categories;
   void setCategories;
 
   const activeCustomer = queue.find((c) => c.id === activeCustomerId) || null;
+  const selectedMessage = messages.find((m) => m.id === selectedMessageId) || null;
 
   useEffect(() => {
     setTopbarRight(<StatusRight />);
@@ -142,6 +145,7 @@ export const ConsultationPage: React.FC = () => {
 
   const handleSelectCustomer = (id: string) => {
     setActiveCustomerId(id);
+    setSelectedMessageId(null);
     if (!statuses[id]) {
       setStatuses((prev) => ({ ...prev, [id]: 'IN_PROGRESS' }));
     }
@@ -152,6 +156,7 @@ export const ConsultationPage: React.FC = () => {
     const targetId = activeCustomerId;
     try {
       const newMsg = await consultationApi.sendMessage(Number(targetId), content, isNote);
+      setSelectedMessageId(null);
       setActiveCustomerId(current => {
         if (current === targetId) {
           setMessages(prev => [...prev, {
@@ -176,6 +181,7 @@ export const ConsultationPage: React.FC = () => {
       toast.success('상담이 종료되었습니다.');
       loadQueue();
       setActiveCustomerId(null);
+      setSelectedMessageId(null);
     } catch(err) {
       toast.error('세션 종료 실패');
     }
@@ -247,6 +253,8 @@ export const ConsultationPage: React.FC = () => {
               channel={activeCustomer?.channel || null}
               messages={messages}
               onSendMessage={handleSendMessage}
+              selectedMessageId={selectedMessageId}
+              onSelectMessage={setSelectedMessageId}
             />
           </div>
 
@@ -284,18 +292,26 @@ export const ConsultationPage: React.FC = () => {
           )}
         </div>
 
-        <CustomerPanel
-          customer={activeCustomer ? {
-            name: activeCustomer.name,
-            channel: activeCustomer.channel,
-          } : null}
-          memo={activeCustomerId ? (memos[activeCustomerId] || '') : ''}
-          onMemoChange={(val) => {
-            if (activeCustomerId) {
-              setMemos((prev) => ({ ...prev, [activeCustomerId]: val }));
-            }
-          }}
-        />
+        {selectedMessageId ? (
+          <MessageDetailPanel
+            message={selectedMessage}
+            domainPackElements={{ slots: [], policies: [], risks: [] }}
+            onClose={() => setSelectedMessageId(null)}
+          />
+        ) : (
+          <CustomerPanel
+            customer={activeCustomer ? {
+              name: activeCustomer.name,
+              channel: activeCustomer.channel,
+            } : null}
+            memo={activeCustomerId ? (memos[activeCustomerId] || '') : ''}
+            onMemoChange={(val) => {
+              if (activeCustomerId) {
+                setMemos((prev) => ({ ...prev, [activeCustomerId]: val }));
+              }
+            }}
+          />
+        )}
     </div>
   );
 };

--- a/frontend/src/pages/consultation/ui/ConsultationPage.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.tsx
@@ -293,9 +293,9 @@ export const ConsultationPage: React.FC = () => {
         </div>
 
         {selectedMessageId ? (
+          // TODO: domainPackElements를 실제 API 응답 데이터로 교체 (별도 API 연동 티켓)
           <MessageDetailPanel
             message={selectedMessage}
-            domainPackElements={{ slots: [], policies: [], risks: [] }}
             onClose={() => setSelectedMessageId(null)}
           />
         ) : (


### PR DESCRIPTION
## Summary
- MessageDetailPanel 컴포넌트 신규 구현 (Slot/Policy/Risk 태그 섹션별 표시)
- ChatPanel 메시지 클릭 핸들러 및 선택 상태 (selectedMessageId) 추가
- ConsultationPage에 selectedMessageId 상태 연결, 선택 시 우측 패널 토글
- DESIGN.md 스타일 가이드 준수 (CSS 변수, focus-visible dashed outline, pill radius)
- Mock 데이터로 동작 검증 (API 연동은 별도 티켓)
- 신규 8개 + 기존 724개 = 732개 테스트 모두 통과

## Changes
- **New**: `MessageDetailPanel.tsx` + `MessageDetailPanel.module.css` — Slot/Policy/Risk 섹션별 태그, empty state, 닫기 버튼
- **Modified**: `ChatPanel.tsx` — onSelectMessage prop, 선택 토글 (재클릭 시 해제), messageSelected CSS 클래스
- **Modified**: `chat-panel.module.css` — messageSelected 스타일 (signal-bg 배경, 3px signal-ink left border via ::before)
- **Modified**: `ConsultationPage.tsx` — selectedMessageId 상태, 패널 조건부 렌더링 (CustomerPanel ↔ MessageDetailPanel)
- **New**: `MessageDetailPanel.test.tsx` — 6개 테스트 (empty state, header, Slot, Policy, Risk, Close)
- **Modified**: `ConsultationPage.test.tsx` — 2개 신규 테스트 (메시지 선택/해제)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ajou-2026-1-capstone-5/ostone/pull/225" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 채팅에서 메시지 클릭·Enter/Space로 개별 메시지 선택·해제(토글) 가능
  * 선택된 메시지에 대한 상세 정보 패널 추가(발신자·타임스탬프·미리보기·Slot/Policy/Risk 태그, 닫기 버튼, 빈 상태)

* **스타일**
  * 선택 상태에 배경 하이라이트와 왼쪽 강조 바 추가
  * 메시지 그룹에 포커스·호버·커서 개선으로 접근성 향상

* **테스트**
  * 상세 패널과 선택/닫기/키보드 상호작용을 검증하는 테스트 추가

* **잡무**
  * 테스트 유틸리티 의존성 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ajou-2026-1-capstone-5/ostone/pull/225)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->