### PR TITLE
docs(spec): add 4.1.10 FE chat message selection workflow node highlight spec

### DIFF
--- a/.agent/specs/4.1.10.md
+++ b/.agent/specs/4.1.10.md
@@ -87,7 +87,7 @@ ChatWorkflowDemoPage (selectedMessageId: useState)
 |------|-------------|---------------|
 | 상태 표현 | `states: string[]` (단순 문자열 배열) | `nodes: GraphNode[]` (id, label, type, policyRef, position) |
 | 전이 표현 | `transitions: DemoWorkflowTransition[]` (from/to 문자열) | `edges: GraphEdge[]` (from/to GraphNode.id) |
-| 방향 정보 | 없음 | `direction: "LR" | "TB"` |
+| 방향 정보 | 없음 | `direction: "LR" \| "TB"` |
 | 노드 타입 | 없음 | `GraphNodeType` (START/ACTION/DECISION/END) |
 
 `DemoWorkflow.states`는 단순 문자열 배열인 반면, `WorkflowGraph.nodes`는 구조화된 `GraphNode` 객체 배열이다. 두 타입 간 직접 매핑이 불가능하다.
@@ -141,7 +141,7 @@ ChatWorkflowDemoPage (selectedMessageId: useState)
 - `GraphNode.id`는 인덱스 기반 `node_{i}` 패턴을 사용한다.
 - `GraphNode.type`은 기본값 `ACTION`을 사용하고, 시작/종료 상태는 상태 위치나 terminal 성격을 기준으로 자동 감지한다.
 - `WorkflowGraph.direction`은 기본값 `LR`을 사용한다.
-- `states` 배열이 비어 있거나 `null`이면 빈 `WorkflowGraph`를 반환한다.
+- `states` 배열이 비어 있으면 빈 `WorkflowGraph`를 반환한다.
 
 **fallback 전략**:
 
@@ -356,7 +356,7 @@ interface GraphRendererProps {
 
 ## 구현 계획 (Implementation Plan)
 
-각 Step은 독립적으로 구현 및 테스트 가능하며, 이전 Step의 결과에 의존하지 않는다. Step 3 실패 시 Step 1+2만으로도 `GraphRenderer` 기본 동작 확인이 가능하다.
+Step 1, 2는 독립적으로 구현 및 테스트 가능하다. Step 3는 Step 1+2의 결과에 의존하며, Step 3 실패 시 Step 1+2만으로도 `GraphRenderer` 기본 동작 확인이 가능하다.
 
 ### Step 1: `demoWorkflowToWorkflowGraph.ts` adapter 생성
 
@@ -503,7 +503,7 @@ ChatWorkflowDemoPage
 |-------------|------|----------|
 | 정상 변환 | 3 states + 2 transitions의 DemoWorkflow | 3 nodes + 2 edges의 WorkflowGraph |
 | 빈 states | `{ states: [], transitions: [] }` | `{ nodes: [], edges: [], direction: 'LR' }` |
-| null input | `null` | 빈 WorkflowGraph 반환 |
+| 빈 transitions | `{ states: ["idle"], transitions: [] }` | 1 node + 0 edges, direction: "LR" |
 | 단일 state | `{ states: ["idle"], transitions: [] }` | 1 node + 0 edges |
 | transition에 from/to가 states에 없음 | from="unknown" | 해당 transition 제외, console.warn 확인 |
 
@@ -574,6 +574,4 @@ ChatWorkflowDemoPage
 
 ## Open Questions
 
-1. `DemoWorkflow`의 `states` 문자열과 `GraphNode.id` 간 매핑 규칙은 무엇인가? (인덱스 기반? 이름 기반?)
-2. `GraphRenderer`가 `workflow-draft-read` 도메인에 속하므로, `chat-workflow`에서 import 시 순환 의존성이 발생하지 않는가?
-3. `DecisionLogDrawer`의 기존 강조 패턴을 `GraphRenderer`의 노드 강조 스타일에 반영해야 하는가?
+1. `DecisionLogDrawer`의 기존 강조 패턴을 `GraphRenderer`의 노드 강조 스타일에 반영해야 하는가?

--- a/.agent/specs/4.1.10.md
+++ b/.agent/specs/4.1.10.md
@@ -1,0 +1,579 @@
+# Frontend Spec: 메시지-그래프 양방향 강조 (Issue 4.1.10)
+
+> 채팅 데모 화면에서 메시지 선택 시 연결된 워크플로우 노드를 강조하고, 반대로 노드 클릭 시 연결된 메시지를 강조하는 양방향 동기화 기능을 구현한다.
+
+---
+
+## Goal
+
+`ChatWorkflowDemoPage`에서 메시지 선택과 워크플로우 그래프 노드 강조를 양방향으로 동기화한다. 기존 SVG 기반 `StateMachineGraph`를 ReactFlow 기반 `GraphRenderer`로 교체하여 일관된 렌더링 경험을 제공한다.
+
+---
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    subgraph 메시지→노드[메시지 → 노드]
+        A[사용자: 채팅 메시지 클릭] --> B{selectedMessageId 갱신}
+        B --> C[ChatTimelinePanel 강조]
+        B --> D[SidePanel/GraphRenderer 전달]
+        D --> E[messageIdToNodeIds 매핑]
+        E --> F[연결된 워크플로우 노드 강조]
+    end
+
+    subgraph 노드→메시지[노드 → 메시지]
+        H[사용자: 워크플로우 노드 클릭] --> I{onNodeSelect(nodeId)}
+        I --> J[nodeIdToMessageId 역매핑]
+        J --> K{messageId 존재?}
+        K -->|Yes| L[setSelectedMessageId]
+        K -->|No| M[선택 상태 유지]
+        L --> N[ChatTimelinePanel 강조]
+    end
+
+    F --> 종료[종료]
+    N --> 종료
+    M --> 종료
+```
+
+두 가지 사용자 시나리오(메시지 → 노드, 노드 → 메시지)는 서로 독립적으로 동작하며, `selectedMessageId`를 단일 진실 공급원(Single Source of Truth)으로 공유한다.
+
+---
+
+## 현재 상태 분석 (Architecture Reality Check)
+
+### 사용자 요구사항
+
+1. **메시지 → 노드**: 타임라인에서 메시지 클릭 시, 해당 메시지와 연결된 워크플로우 노드가 그래프에서 강조 표시된다.
+2. **노드 → 메시지**: 그래프에서 노드 클릭 시, 해당 노드와 연결된 메시지가 타임라인에서 강조 표시된다.
+3. **양방향 동기화**: 두 방향의 선택 상태가 `selectedMessageId` 단일 소스로 통합된다.
+
+### 관련 파일 목록 및 역할
+
+| 파일 | 계층 (FSD) | 역할 |
+|------|-----------|------|
+| `frontend/src/pages/chat-demo/ui/ChatWorkflowDemoPage.tsx` | pages | `selectedMessageId`의 Single Source of Truth (useState). `ChatTimelinePanel`과 `SidePanel`에 prop 전달 |
+| `frontend/src/features/chat-workflow/ui/ChatTimelinePanel.tsx` | features | 메시지 목록 표시, 선택 강조 (파란색 border-left), `onMessageSelect` 콜백 발생 |
+| `frontend/src/features/chat-workflow/ui/SidePanel.tsx` | features | 현재 `StateMachineGraph` 렌더링. `selectedMessageId`를 자식에 전달 중 |
+| `frontend/src/features/chat-workflow/ui/StateMachineGraph.tsx` | features | SVG 기반 그래프 렌더러. `stateFrom`/`stateTo` 문자열로 decision log 매칭 (레거시) |
+| `frontend/src/features/workflow-draft-read/ui/GraphRenderer.tsx` | features | ReactFlow 기반 그래프 렌더러. 목표 통합 대상 |
+| `frontend/src/features/workflow-draft-read/ui/graphMapper.ts` | features | `toFlow` re-export. `selectedMessageId` 주입 로직 없음 |
+| `frontend/src/entities/workflow/model/types.ts` | entities | `WorkflowGraph`, `GraphNode`, `GraphEdge` 타입 정의 |
+| `frontend/src/entities/workflow/lib/graphConverter.ts` | entities | `toFlow` / `convertFlowToWorkflowGraph` 양방향 변환. messageId ↔ nodeId 매핑 없음 |
+| `frontend/src/features/chat-workflow/model/chatWorkflow.types.ts` | features | `DemoWorkflow`, `DemoDecisionLogEntry`, `DemoChatMessage` 타입 정의 |
+| `frontend/src/features/chat-workflow/ui/DecisionLogDrawer.tsx` | features | decision log 항목 강조 패턴 (참고용) |
+
+### 데이터 흐름 (As-is)
+
+```
+ChatWorkflowDemoPage (selectedMessageId: useState)
+├── ChatTimelinePanel
+│   ├── selectedMessageId (prop)
+│   └── onMessageSelect(id) → 부모로 콜백
+└── SidePanel
+    ├── selectedMessageId (prop)
+    └── StateMachineGraph (SVG)
+        ├── selectedMessageId (prop)
+        └── decisionLogs에서 stateFrom/stateTo 매칭 → SVG 노드 강조
+```
+
+**문제**: `GraphRenderer`로 `selectedMessageId`가 전달되지 않음. `StateMachineGraph`는 SVG 기반 레거시.
+
+### 3가지 Gap
+
+#### Gap 1 (데이터): `DemoWorkflow` vs `WorkflowGraph` 타입 불일치
+
+| 측면 | DemoWorkflow | WorkflowGraph |
+|------|-------------|---------------|
+| 상태 표현 | `states: string[]` (단순 문자열 배열) | `nodes: GraphNode[]` (id, label, type, policyRef, position) |
+| 전이 표현 | `transitions: DemoWorkflowTransition[]` (from/to 문자열) | `edges: GraphEdge[]` (from/to GraphNode.id) |
+| 방향 정보 | 없음 | `direction: "LR" | "TB"` |
+| 노드 타입 | 없음 | `GraphNodeType` (START/ACTION/DECISION/END) |
+
+`DemoWorkflow.states`는 단순 문자열 배열인 반면, `WorkflowGraph.nodes`는 구조화된 `GraphNode` 객체 배열이다. 두 타입 간 직접 매핑이 불가능하다.
+
+#### Gap 2 (매핑): `DemoDecisionLogEntry.stateFrom/stateTo` → `GraphNode.id` 매핑 부재
+
+- `DemoDecisionLogEntry.stateFrom = "pending"` (상태 이름 문자열)
+- `GraphNode.id = "node_action_1"` (노드 고유 ID)
+- 현재 코드베이스에 상태 이름을 GraphNode.id로 변환하는 로직이 존재하지 않는다.
+- 해결 방향: `DemoWorkflow`의 상태 이름과 인덱스를 기반으로 `WorkflowGraph`의 `GraphNode.id`를 매핑하는 어댑터가 필요하다. 매칭 실패 시 fallback 처리 필수.
+
+#### Gap 3 (통합 지점): `SidePanel`의 그래프 렌더러 교체
+
+- 현재: `SidePanel` → `StateMachineGraph` (SVG, `chat-workflow` 도메인 내)
+- 목표: `SidePanel` → `GraphRenderer` (ReactFlow, `workflow-draft-read` 도메인)
+- 문제: `workflow-draft-read`는 채팅 데모와 독립적인 도메인. mutual dependency 방지 필요.
+- 결정: `SidePanel`에서 기존 `StateMachineGraph`를 `GraphRenderer`로 교체한다. 병행 렌더링 금지.
+
+---
+
+## Design Diff
+
+### As-is vs To-be
+
+| 영역 | As-is | To-be | 변경 내용 |
+|------|-------|-------|----------|
+| 그래프 렌더러 | `StateMachineGraph` (SVG) | `GraphRenderer` (ReactFlow) | 렌더러 교체 |
+| 메시지 선택 → 노드 강조 | `stateFrom`/`stateTo` 문자열 매칭 | `messageId → GraphNode.id[]` 어댑터 매칭 | 매핑 로직 변경 |
+| 노드 클릭 → 메시지 선택 | 미구현 | `GraphNode.id → messageId` 역매핑 + `onMessageSelect` 콜백 | 신규 기능 |
+| selectedMessageId 전달 | `SidePanel` → `StateMachineGraph` | `ChatWorkflowDemoPage` → `GraphRenderer` | prop 경로 변경 |
+| 타입 변환 | 없음 | `DemoWorkflow` → `WorkflowGraph` 어댑터 | 신규 변환 로직 |
+
+---
+
+## 아키텍처 설계 결정
+
+### Gap 1: 데이터 타입 불일치 해결
+
+**결정**: `frontend/src/features/chat-workflow/model/demoWorkflowToWorkflowGraph.ts`에 `DemoWorkflow`를 `WorkflowGraph`로 변환하는 adapter를 둔다.
+
+**책임**:
+
+- `DemoWorkflow.states`와 `DemoWorkflow.transitions`를 `WorkflowGraph.nodes`와 `WorkflowGraph.edges`로 변환한다.
+- `createMessageIdToNodeIdMap`은 별도 함수로 분리하여 메시지 선택과 그래프 노드 강조 사이의 매핑만 담당한다.
+- 변환 실패나 매칭 실패는 그래프 렌더링 실패로 전파하지 않고 안전한 빈 결과로 축소한다.
+
+**변환 규칙**:
+
+- `DemoWorkflow.states[i]`는 `WorkflowGraph.nodes[i]`로 변환한다.
+- 상태 문자열은 `GraphNode.label`이 된다.
+- `GraphNode.id`는 인덱스 기반 `node_{i}` 패턴을 사용한다.
+- `GraphNode.type`은 기본값 `ACTION`을 사용하고, 시작/종료 상태는 상태 위치나 terminal 성격을 기준으로 자동 감지한다.
+- `WorkflowGraph.direction`은 기본값 `LR`을 사용한다.
+- `states` 배열이 비어 있거나 `null`이면 빈 `WorkflowGraph`를 반환한다.
+
+**fallback 전략**:
+
+- 입력 상태가 없으면 `{ nodes: [], edges: [], direction: 'LR' }` 형태의 빈 그래프를 반환한다.
+- `stateFrom` 또는 `stateTo`가 `DemoWorkflow.states`에서 발견되지 않으면 해당 매핑은 제외하고 `console.warn`으로 누락 상태를 남긴다.
+- fallback은 사용자에게 잘못된 강조를 보여주지 않기 위해 빈 배열을 반환하는 방식으로 제한한다.
+
+**Why**: `DemoWorkflow`는 채팅 데모 실행 모델이고 `WorkflowGraph`는 ReactFlow 렌더링 모델이다. 두 모델을 렌더러 내부에서 섞으면 `GraphRenderer`가 채팅 데모 전용 decision log를 알아야 하므로 재사용성이 깨진다. adapter를 `chat-workflow` model 계층에 두면 변환 책임이 데모 도메인 안에 머물고, `GraphRenderer` 변경은 optional props 추가로 제한된다.
+
+### Gap 2: 매핑 부재 해결
+
+**결정**: `DemoWorkflow.states` 배열의 인덱스를 `WorkflowGraph.nodes` 배열의 인덱스와 동일하게 유지하고, 상태 이름을 중간 키로 사용한다.
+
+**`messageId → GraphNode.id[]` 매핑 규칙**:
+
+1. `decisionLogs`에서 `messageId`가 일치하는 entry만 필터링한다.
+2. 각 entry의 `stateFrom`, `stateTo`를 추출한다.
+3. 각 상태 이름을 `DemoWorkflow.states.indexOf(stateName)`로 찾는다.
+4. 찾은 인덱스로 `WorkflowGraph.nodes[index].id`를 조회한다.
+5. 하나라도 찾지 못하면 해당 상태만 제외하고, 전체 결과가 없으면 빈 배열을 반환한다.
+6. 매칭 실패는 `console.warn`으로 남긴다.
+
+**`GraphNode.id → messageId` 역매핑 규칙**:
+
+1. 클릭된 `nodeId`에 해당하는 `GraphNode`를 찾고 `label`을 상태 이름으로 사용한다.
+2. `decisionLogs`에서 `stateFrom` 또는 `stateTo`가 해당 label과 일치하는 entry를 찾는다.
+3. 일치하는 entry의 `messageId`를 반환한다.
+4. 1:N 관계에서는 첫 번째 매칭의 `messageId`를 반환한다.
+5. 매칭이 없으면 `null`을 반환하고 메시지 선택 상태를 변경하지 않는다.
+
+**1:N 동작**:
+
+- 하나의 메시지가 여러 decision log entry와 연결되면 연결된 모든 노드를 강조한다.
+- 중복 노드 ID는 제거하되, 강조 결과는 다중 노드 배열로 유지한다.
+- 노드에서 메시지로 돌아가는 역방향은 사용자가 클릭한 단일 노드 기준이므로 첫 번째 매칭만 선택한다.
+
+**Why**: 현재 decision log는 상태 이름(`stateFrom`, `stateTo`)만 알고 있고, ReactFlow 노드는 `GraphNode.id`로 동작한다. 인덱스 기반 생성 규칙을 고정하면 별도의 영속 ID 없이도 데모 데이터와 그래프 데이터의 순서를 안정적으로 연결할 수 있다. 매칭 실패 시 빈 결과를 반환하면 잘못된 노드 강조보다 안전하며 기존 타임라인 선택 동작도 유지된다.
+
+### Gap 3: 통합 지점 해결
+
+**결정**: `SidePanel`의 그래프 렌더링 지점에서 `StateMachineGraph` 참조를 제거하고 `GraphRenderer`로 바로 교체한다. 단, `StateMachineGraph` 파일 자체는 다른 사용처 가능성을 고려해 삭제하지 않는다.
+
+**통합 방식**:
+
+- `ChatWorkflowDemoPage`에서 `DemoWorkflow`를 `WorkflowGraph`로 변환한다.
+- 변환된 `WorkflowGraph`와 `selectedMessageId`를 `SidePanel`에 전달한다.
+- `SidePanel`은 전달받은 `WorkflowGraph`와 `selectedMessageId`를 `GraphRenderer`에 그대로 전달한다.
+- `SidePanel` 안에서 `{isUsingStateMachine ? <StateMachineGraph /> : <GraphRenderer />}` 형태의 병행 렌더링 분기를 만들지 않는다.
+
+**FSD 의존성 결정**:
+
+- `pages` 계층인 `ChatWorkflowDemoPage`는 여러 feature를 조합할 수 있으므로 adapter 변환과 콜백 연결의 조립 지점이 된다.
+- `features/chat-workflow`가 `features/workflow-draft-read`를 직접 import하는 구조는 feature 간 직접 의존을 만들 수 있으므로 피한다.
+- 따라서 `SidePanel`은 가능한 한 `WorkflowGraph`, `selectedMessageId`, 콜백을 props로 받아 렌더링 계약만 수행한다.
+
+**하이라이트 parity**:
+
+- 기존 `StateMachineGraph`가 사용하던 decision log 기반 매칭 의미를 유지한다.
+- 메시지 선택 시 `stateFrom`/`stateTo`에 연결된 노드가 강조되어야 한다.
+- 비강조 노드는 dimming하지 않고 기존 스타일을 유지한다.
+
+**Why**: 두 그래프를 동시에 유지하거나 조건부로 병행 렌더링하면 동일 상태를 두 렌더러가 서로 다르게 해석할 위험이 있다. 바로 교체하면 사용자가 보는 그래프는 하나로 유지되고, 기존 하이라이트 의미만 ReactFlow 노드 강조로 이식할 수 있다.
+
+---
+
+## Oracle CONDITIONAL 판정
+
+### 조건 1: Adapter 생성 및 Fallback
+
+`DemoWorkflow` → `WorkflowGraph` + `messageId → GraphNode.id[]` 매핑 어댑터를 생성한다. 상태 이름 매칭이 실패할 경우 fallback 처리하여 기존 그래프 렌더링이 깨지지 않도록 한다.
+
+### 조건 2: GraphRenderer 변경은 Additive
+
+`GraphRenderer`에 `selectedMessageId` prop을 추가한다. 기존 props(`graph`, `onEdgeClick`, `onPaneClick`)의 동작을 변경하지 않는다. optional props만 추가하는 additive 변경이다.
+
+### 조건 3: SidePanel 그래프 영역 교체
+
+`SidePanel` 내 기존 `StateMachineGraph` 렌더링 영역을 `GraphRenderer`로 교체한다. 두 그래프를 동시에 렌더링하지 않는다.
+
+---
+
+## 데이터 흐름 및 매핑 방식 보강
+
+### `selectedMessageId` 흐름 경로
+
+```
+ChatTimelinePanel.onMessageSelect(id)
+  → ChatWorkflowDemoPage.setSelectedMessageId(id)
+  → SidePanel.selectedMessageId
+  → GraphRenderer.selectedMessageId
+  → messageIdToNodeIds(messageId, decisionLogs, workflowNodes)
+  → 연결된 노드 강조
+```
+
+`selectedMessageId`의 Single Source of Truth는 `ChatWorkflowDemoPage`에 둔다. `SidePanel`과 `GraphRenderer`는 이 값을 복사하거나 별도 상태로 재해석하지 않고 props로만 전달받는다.
+
+### 메시지 → 노드 시나리오
+
+1. 사용자가 `ChatTimelinePanel`에서 메시지를 클릭한다.
+2. 기존 `onMessageSelect(id)`가 호출된다.
+3. `ChatWorkflowDemoPage`가 `selectedMessageId`를 갱신한다.
+4. `SidePanel`이 갱신된 `selectedMessageId`를 받는다.
+5. `GraphRenderer`가 `messageIdToNodeIds` 결과에 포함된 모든 노드 ID를 강조한다.
+
+### 노드 → 메시지 시나리오
+
+1. 사용자가 `GraphRenderer`에서 노드를 클릭한다.
+2. `GraphRenderer.onNodeSelect(nodeId)`가 호출된다.
+3. `SidePanel.onNodeSelect(nodeId)`가 상위로 전달된다.
+4. `ChatWorkflowDemoPage.onNodeSelect(nodeId)`가 `nodeIdToMessageId(nodeId, decisionLogs)`를 호출한다.
+5. `messageId`가 있으면 `ChatWorkflowDemoPage.setSelectedMessageId(messageId)`를 호출한다.
+6. `ChatTimelinePanel`은 기존 메시지 강조 스타일로 해당 메시지를 강조한다.
+
+### 매핑 함수 계약
+
+```typescript
+function messageIdToNodeIds(
+  messageId: string,
+  decisionLogs: readonly DemoDecisionLogEntry[],
+  workflowNodes: readonly GraphNode[],
+): string[];
+
+function nodeIdToMessageId(
+  nodeId: string,
+  decisionLogs: readonly DemoDecisionLogEntry[],
+): string | null;
+```
+
+**전제**:
+
+- `workflowNodes`는 `DemoWorkflow.states`와 동일한 순서로 adapter가 생성한 노드 목록이다.
+- `GraphNode.label`은 `DemoWorkflow.states`의 상태 문자열과 동일하다.
+- 역매핑 함수가 `workflowNodes`를 받지 않는 경우, 호출 지점에서 `nodeId`를 label로 해석할 수 있는 보조 map을 이미 확보해야 한다. 구현 단계에서는 동일 파일 안의 adapter 결과에서 `nodeId → label` 조회를 먼저 수행한 뒤 위 계약을 만족하도록 연결한다.
+
+**Why**: 함수 시그니처를 작게 유지하면 테스트가 쉬워지고, 메시지 선택과 노드 선택의 책임을 분리할 수 있다. 반환값을 배열과 `null`로 고정하면 실패 처리가 호출자에게 명확하게 드러난다.
+
+---
+
+## 컴포넌트 인터페이스 및 API 계약
+
+### `GraphRenderer` props 변경
+
+`GraphRenderer`는 기존 사용처를 깨지 않도록 optional props만 추가한다.
+
+```typescript
+interface GraphRendererProps {
+  graph: WorkflowGraph;
+  selectedMessageId?: string | null;
+  onNodeSelect?: (nodeId: string) => void;
+  onEdgeClick?: (edgeId: string) => void;
+  onPaneClick?: () => void;
+}
+```
+
+**계약**:
+
+- `selectedMessageId`가 없거나 `null`이면 기존 렌더링과 동일하게 동작한다.
+- `onNodeSelect`가 없으면 노드 클릭 시 선택 콜백을 호출하지 않는다.
+- 기존 `onEdgeClick`, `onPaneClick`, `graph` 계약은 변경하지 않는다.
+
+### 노드 강조 스타일 계약
+
+**적용 대상**: `ActionNode`, `DecisionNode`, `AnswerNode`, `HandoffNode` 등 모든 커스텀 노드.
+
+**강조 상태**:
+
+- 배경색: `var(--highlight-bg)`를 우선 사용하고, 토큰이 없으면 `#dbeafe` 또는 `#eff6ff`를 사용한다.
+- 테두리: `2px solid var(--highlight-border)`를 우선 사용하고, 토큰이 없으면 `2px solid #3b82f6`를 사용한다.
+- 강조는 `messageIdToNodeIds` 결과에 포함된 노드에만 적용한다.
+
+**비강조 상태**:
+
+- 기존 노드 스타일을 유지한다.
+- dimming, opacity 감소, blur 처리는 적용하지 않는다.
+
+**Why**: 사용자가 요청한 강조 방식은 배경색과 테두리 색상 변경이다. dimming을 적용하지 않으면 기존 `StateMachineGraph`에서 선택되지 않은 노드가 계속 읽히던 parity를 유지할 수 있고, 다중 노드 강조 시에도 전체 그래프 맥락이 사라지지 않는다.
+
+### 양방향 콜백 흐름
+
+```
+메시지 클릭: ChatTimelinePanel.onMessageSelect(id)
+  → ChatWorkflowDemoPage.setState(id)
+  → SidePanel.props.selectedMessageId = id
+  → GraphRenderer.props.selectedMessageId = id
+  → 노드 강조
+
+노드 클릭: GraphRenderer.onNodeSelect(nodeId)
+  → SidePanel.onNodeSelect(nodeId)
+  → ChatWorkflowDemoPage.onNodeSelect(nodeId)
+  → nodeId → messageId 역매핑
+  → ChatWorkflowDemoPage.setSelectedMessageId(messageId)
+  → ChatTimelinePanel 강조
+```
+
+### `SidePanel` 전달 경로
+
+`SidePanel`은 `GraphRenderer`에 필요한 렌더링 입력을 props로 받는다.
+
+```tsx
+<GraphRenderer
+  graph={workflowGraph}
+  selectedMessageId={selectedMessageId}
+  onNodeSelect={handleNodeSelect}
+/>
+```
+
+`workflowGraph`는 `ChatWorkflowDemoPage`에서 `demoWorkflowToWorkflowGraph` adapter를 통해 생성한 값이다. `SidePanel`은 `DemoWorkflow`를 직접 변환하지 않고, 전달받은 `WorkflowGraph`를 렌더링한다.
+
+**Why**: 변환과 렌더링을 분리하면 `SidePanel`은 UI 조립 책임에 머물고, `ChatWorkflowDemoPage`는 page 계층에서 feature 간 연결을 담당한다. 이 구조는 FSD 의존성 방향을 지키면서 `GraphRenderer`를 채팅 데모 전용 컴포넌트로 오염시키지 않는다.
+
+---
+
+## 구현 계획 (Implementation Plan)
+
+각 Step은 독립적으로 구현 및 테스트 가능하며, 이전 Step의 결과에 의존하지 않는다. Step 3 실패 시 Step 1+2만으로도 `GraphRenderer` 기본 동작 확인이 가능하다.
+
+### Step 1: `demoWorkflowToWorkflowGraph.ts` adapter 생성
+
+**위치**: `frontend/src/features/chat-workflow/model/demoWorkflowToWorkflowGraph.ts`
+
+**구현 항목**:
+
+- `demoWorkflowToWorkflowGraph(workflow: DemoWorkflow): WorkflowGraph` — `DemoWorkflow`를 `WorkflowGraph`로 변환
+- `createMessageIdToNodeIdMap(messageId: string, decisionLogs: DemoDecisionLogEntry[], workflowNodes: GraphNode[]): string[]` — 메시지 ID → 연결된 노드 ID 배열
+- `createNodeIdToMessageIdMap(nodeId: string, decisionLogs: DemoDecisionLogEntry[]): string | null` — 노드 ID → 메시지 ID 역매핑
+
+**테스트**: 단위 테스트 포함 (경로: `frontend/src/features/chat-workflow/model/__tests__/demoWorkflowToWorkflowGraph.test.ts`)
+
+**의존성**: 없음 (순수 함수, 외부 상태 미사용)
+
+### Step 2: `GraphRenderer` props 확장
+
+**위치**: `frontend/src/features/workflow-draft-read/ui/GraphRenderer.tsx`
+
+**구현 항목**:
+
+- `selectedMessageId?: string | null` props 추가
+- `onNodeSelect?: (nodeId: string) => void` props 추가
+- `selectedMessageId` 전달 시 연결된 커스텀 노드에 강조 스타일 적용
+
+**변경 방식**: additive only — 기존 props(`graph`, `onEdgeClick`, `onPaneClick`)의 동작과 계약을 변경하지 않음
+
+**테스트**: 단위 테스트 포함 (경로: `frontend/src/features/workflow-draft-read/ui/__tests__/GraphRenderer.test.tsx`)
+
+**의존성**: Step 1 완료 불필요 (props 타입만 정의하면 독립적 테스트 가능)
+
+### Step 3: `SidePanel` 교체 및 `ChatWorkflowDemoPage` 연결
+
+**위치**: `frontend/src/features/chat-workflow/ui/SidePanel.tsx`, `frontend/src/pages/chat-demo/ui/ChatWorkflowDemoPage.tsx`
+
+**구현 항목**:
+
+- `SidePanel`에서 `StateMachineGraph` 참조 제거 → `GraphRenderer`로 교체
+- `ChatWorkflowDemoPage`에서 adapter 변환 및 콜백 연결
+- `workflowGraph` 상태 추가 및 `DemoWorkflow` → `WorkflowGraph` 변환
+- `onNodeSelect` 핸들러에서 `nodeId → messageId` 역매핑 및 `setSelectedMessageId` 호출
+
+**테스트**: 통합 테스트 포함 (페이지 수동 QA 시나리오)
+
+**의존성**: Step 1 + Step 2 완료 필요
+
+### Step 우선순위 및 Fallback
+
+| Step | 우선순위 | 독립 테스트 | 실패 시 영향 |
+|------|---------|------------|-------------|
+| Step 1 | P0 | 가능 | 양방향 강조 전체 불가 |
+| Step 2 | P0 | 가능 | `selectedMessageId` prop 미전달 시 기존 동작 유지 |
+| Step 3 | P1 | 불가 (Step 1+2 필요) | `GraphRenderer` props 확장까지만 검증 가능 |
+
+---
+
+## Component Tree (To-be)
+
+```
+ChatWorkflowDemoPage
+├── ChatTimelinePanel
+│   ├── selectedMessageId (prop)
+│   └── onMessageSelect(id) → 부모로 콜백
+└── SidePanel
+    ├── selectedMessageId (prop)
+    ├── workflow: WorkflowGraph (adapter 변환 결과)
+    └── GraphRenderer (ReactFlow)
+        ├── graph: WorkflowGraph
+        ├── selectedMessageId (prop)
+        ├── onNodeSelect(nodeId) → 부모로 콜백
+        │   └── nodeId → messageId 역매핑
+        │       └── setSelectedMessageId(messageId)
+        ├── onEdgeClick (기존 유지)
+        └── onPaneClick (기존 유지)
+```
+
+```
+                        ┌──────────────────────────────┐
+                        │    ChatWorkflowDemoPage       │
+                        │  selectedMessageId (useState) │
+                        └──────┬───────────────┬───────┘
+                               │               │
+                    ┌──────────▼───────┐ ┌────▼──────────────┐
+                    │ ChatTimelinePanel│ │    SidePanel      │
+                    │  selectedMsgId   │ │  selectedMsgId    │
+                    │  onMsgSelect(id) │ │  workflow(WfGraph)│
+                    └──────────────────┘ │  onNodeSelect(id) │
+                                         └────┬──────────────┘
+                                              │
+                                    ┌─────────▼──────────┐
+                                    │   GraphRenderer    │
+                                    │  selectedMsgId     │
+                                    │  onNodeSelect      │
+                                    │  그래프 + 강조     │
+                                    └────────────────────┘
+```
+
+---
+
+## States & Loading
+
+### 상태 관리
+
+| 상태 | 타입 | 위치 | 설명 |
+|------|------|------|------|
+| `selectedMessageId` | `string \| null` | `ChatWorkflowDemoPage` | Single Source of Truth |
+| `workflow` | `WorkflowGraph` | `ChatWorkflowDemoPage` (adapter 변환) | `DemoWorkflow` → `WorkflowGraph` 변환 결과 |
+| `messageIdToNodeIds` | `Map<string, string[]>` | adapter | 메시지 ID → 노드 ID 배열 매핑 |
+| `nodeIdToMessageId` | `Map<string, string>` | adapter | 노드 ID → 메시지 ID 역매핑 |
+
+### Loading 상태
+
+- 기존 `ChatWorkflowDemoPage`의 로딩 상태 유지
+- 어댑터 변환은 동기 연산 (별도 로딩 상태 불필요)
+
+---
+
+## Error Handling
+
+| 시나리오 | 처리 방식 |
+|----------|----------|
+| `DemoWorkflow` → `WorkflowGraph` 변환 실패 | 빈 `WorkflowGraph` 반환, 그래프 영역에 "데이터 없음" 표시 |
+| `stateFrom`/`stateTo` 매칭 실패 | 해당 노드 강조 스킵, 콘솔 warn 로그 |
+| `nodeId → messageId` 역매핑 실패 | `onMessageSelect` 호출하지 않음 |
+| `GraphRenderer` 렌더링 에러 | React ErrorBoundary로 포착, fallback UI 표시 |
+
+---
+
+## 테스트 전략 (Test Strategy)
+
+### TDD 원칙
+
+- 모든 adapter 함수는 **TDD 우선**으로 작성한다. 테스트를 먼저 정의하고 구현한다.
+- 모든 테스트는 **독립적으로 실행 가능**해야 하며, 외부 상태(msw, localStorage, IndexedDB)에 의존하지 않는다.
+- 렌더링 테스트는 React Testing Library를 사용하고, msw/playwright는 사용하지 않는다.
+
+### 단위 테스트
+
+#### 1. Adapter 변환 테스트 (TDD 우선)
+
+**경로**: `frontend/src/features/chat-workflow/model/__tests__/demoWorkflowToWorkflowGraph.test.ts`
+
+| 테스트 케이스 | 입력 | 기대 결과 |
+|-------------|------|----------|
+| 정상 변환 | 3 states + 2 transitions의 DemoWorkflow | 3 nodes + 2 edges의 WorkflowGraph |
+| 빈 states | `{ states: [], transitions: [] }` | `{ nodes: [], edges: [], direction: 'LR' }` |
+| null input | `null` | 빈 WorkflowGraph 반환 |
+| 단일 state | `{ states: ["idle"], transitions: [] }` | 1 node + 0 edges |
+| transition에 from/to가 states에 없음 | from="unknown" | 해당 transition 제외, console.warn 확인 |
+
+#### 2. 매핑 테스트 (TDD 우선)
+
+**경로**: `frontend/src/features/chat-workflow/model/__tests__/demoWorkflowToWorkflowGraph.test.ts`
+
+| 테스트 케이스 | 입력 | 기대 결과 |
+|-------------|------|----------|
+| messageId → nodeIds 정상 | 1개의 messageId + 2개 decisionLog entry | 2개 nodeId 반환 (`string[]`) |
+| messageId 매칭 실패 | 일치하는 entry 없음 | 빈 배열 반환 + console.warn |
+| nodeId → messageId 정상 | nodeId + 1개 decisionLog entry | messageId 반환 |
+| nodeId → messageId 실패 | 매칭되는 entry 없음 | `null` 반환 |
+| 중복 노드 ID | 동일 노드 참조 2회 | 중복 제거된 배열 |
+
+#### 3. GraphRenderer prop 테스트
+
+**경로**: `frontend/src/features/workflow-draft-read/ui/__tests__/GraphRenderer.test.tsx`
+
+| 테스트 케이스 | 검증 내용 |
+|-------------|----------|
+| selectedMessageId 전달 | 해당 노드에 강조 CSS 클래스/스타일 적용 확인 |
+| onNodeSelect 콜백 | 노드 클릭 시 올바른 nodeId로 콜백 호출 확인 |
+| regression (기존 props만) | `selectedMessageId`/`onNodeSelect` 없이 기존 동작 유지 확인 |
+| 다중 노드 강조 | 여러 노드 ID 전달 시 모두 강조 적용 확인 |
+| 강조 해제 | `selectedMessageId` 변경/제거 시 이전 강조 해제 확인 |
+
+### 통합 테스트
+
+#### 수동 QA 시나리오
+
+| 시나리오 | 예상 결과 | 확인 방법 |
+|---------|----------|----------|
+| 메시지 클릭 → 그래프 노드 강조 | 연결된 모든 노드 강조 표시 | 시각적 확인 |
+| 노드 클릭 → 타임라인 메시지 강조 | 해당 메시지가 타임라인에서 강조 | 시각적 확인 |
+| 연속 클릭 시 이전 강조 해제 | 새 선택 시 이전 강조가 사라짐 | 시각적 확인 |
+| 연결 없는 메시지 클릭 | 그래프 변화 없음 | 시각적 확인 |
+| 연결 없는 노드 클릭 | 타임라인 변화 없음 | 시각적 확인 |
+
+---
+
+## 리스크 및 완화 (Risks & Mitigation)
+
+| 리스크 | 영향 | 확률 | 완화 방안 |
+|--------|------|------|----------|
+| DemoWorkflow.states와 WorkflowGraph.nodes 순서 불일치 | 잘못된 노드 강조 | Low | 인덱스 기반 매핑 + label fallback으로 이중 검증 |
+| GraphRenderer가 chat-workflow 의존성 | 순환 참조 | Low | FSD pages 계층에서 조립, features 간 직접 import 금지 |
+| 다중 노드 강조 시 가독성 저하 | UX 저하 | Medium | 강조 색상 통일, 비강조 노드 dimming 금지로 맥락 유지 |
+| StateMachineGraph 제거 후 회귀 | 기능 손실 | Low | 파일 삭제 금지, SidePanel 참조만 제거하여 복구 용이 |
+| adapter 변환 실패 시 전체 그래프 미표시 | 기능 손실 | Low | 빈 WorkflowGraph fallback으로 그래프 영역 유지 |
+| selectedMessageId와 onNodeSelect 콜백 무한 루프 | 성능 저하 | Low | setSelectedMessageId 호출 전 현재 값 비교 (변경 시에만 갱신) |
+
+---
+
+## 완료 정의 (Definition of Done)
+
+- [ ] `demoWorkflowToWorkflowGraph` adapter 단위 테스트 통과
+- [ ] `GraphRenderer` props 확장 단위 테스트 통과
+- [ ] `SidePanel` → `GraphRenderer` 교체 통합 테스트 통과
+- [ ] 메시지 클릭 → 노드 강조 시각적 확인 (연결된 모든 노드)
+- [ ] 노드 클릭 → 메시지 강조 시각적 확인 (타임라인 메시지)
+- [ ] 연속 클릭 시 이전 강조 해제 확인
+- [ ] 기존 `StateMachineGraph` 참조만 제거, 파일은 유지
+- [ ] 기존 `GraphRenderer` props 계약 변경 없음 확인 (regression)
+- [ ] 문서/주석에 내부 실행 정보 없음 확인
+
+---
+
+## Open Questions
+
+1. `DemoWorkflow`의 `states` 문자열과 `GraphNode.id` 간 매핑 규칙은 무엇인가? (인덱스 기반? 이름 기반?)
+2. `GraphRenderer`가 `workflow-draft-read` 도메인에 속하므로, `chat-workflow`에서 import 시 순환 의존성이 발생하지 않는가?
+3. `DecisionLogDrawer`의 기존 강조 패턴을 `GraphRenderer`의 노드 강조 스타일에 반영해야 하는가?


### PR DESCRIPTION
## Summary
- 4.1.10 [FE] 채팅 메시지 선택 시 워크플로우 노드 강조 및 상태 동기화 스펙 정의
- 3가지 아키텍처 Gap 식별 및 설계 결정 문서화
- Oracle 조건 검증 통과
- 579 lines, 10개 템플릿 섹션 완비
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ajou-2026-1-capstone-5/ostone/pull/229" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **문서**
  * 채팅 데모에서 메시지 선택 ↔ 워크플로우 그래프 노드 강조의 양방향 동기화 설계 명세 추가
  * 아키텍처·데이터 흐름(단일 원천), 그래프 렌더러 확장 계약, 메시지↔노드 매핑 규칙 및 페일백 처리 문서화
  * 구현 단계, 테스트 전략, 오류 시나리오, 리스크·완화 및 미해결 질문 포함

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ajou-2026-1-capstone-5/ostone/pull/229)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->