### PR TITLE
Spec/011 : 로그인 Invalid Token 복구 흐름 스펙 보완

### DIFF
--- a/.agent/specs/011.md
+++ b/.agent/specs/011.md
@@ -416,8 +416,8 @@ return <ErrorState />;
 | 구분 | 방법 | 도구 | 비고 |
 |------|------|------|------|
 | 수동 테스트 | 브라우저 직접 확인 | Chrome DevTools | 로그인 -> workspace 흐름 확인 |
-| 단위 테스트 | auth/session 및 API client 동작 검증 | Vitest | 401 session clear, 403/500 session 유지 |
-| 라우팅 테스트 | LoginPage / WorkspaceRootRedirect 흐름 검증 | Testing Library | invalid token 루프 방지 |
+| 단위 테스트 | auth/session 및 API client 동작 검증 | Vitest | 401 session clear, 403/500/network error session 유지 |
+| 라우팅 테스트 | LoginPage / WorkspaceRootRedirect 흐름 검증 | Testing Library | invalid token 루프 방지, network error 로그인 리다이렉트 방지 |
 | 빌드 검증 | 정적 빌드 | `pnpm build` | 라우트 및 타입 검증 |
 
 ### Happy Path
@@ -460,7 +460,7 @@ return <ErrorState />;
 - [ ] 401 이후 `/login`에 도착했을 때 `/workspaces`로 다시 튕기지 않는다.
 - [ ] workspace 목록 조회 실패는 401/403/기타 오류로 분기하며, 403/기타 오류는 로그인 리다이렉트하지 않는다.
 - [ ] safe return helper 테스트는 허용 prefix, auth route, pathname 누락, 외부 URL fallback을 포함한다.
-- [ ] API client/session 테스트는 401 session clear와 403/500 session 유지 케이스를 포함한다.
+- [ ] API client/session 테스트는 401 session clear와 403/500/network error session 유지 케이스를 포함한다.
 - [ ] 실제 저장 로직이 없는 `아이디 저장` checkbox는 제거하거나 후속 remember-id spec으로 분리한다.
 - [ ] signup / password reset은 이번 범위 밖으로 분리된다.
 - [ ] `021.md`와 충돌하지 않는 로그인 진입 규칙을 유지한다.

--- a/.agent/specs/011.md
+++ b/.agent/specs/011.md
@@ -3,15 +3,17 @@
 > **Backlog**: 비인증 운영자가 로그인 화면에서 인증을 완료한 뒤, workspace 중심 콘솔 흐름으로 안정적으로 진입하고 싶다 → 로그인 이후 기본 운영 시작점을 `/workspaces`로 통일하고 안전한 보호 라우트 복귀 규칙을 명확히 하기 위해
 > **Layer**: Frontend (Operator Console)
 > **Template**: `.agent/specs/_TEMPLATE_FE.md`
-> **Branch**: `docs/workspace-flow-spec-alignment`
+> **Branch**: `spec/011`
 > **Depends on**: `.agent/specs/021.md`, `frontend/DESIGN.md`
-> **Verified existing paths**: `frontend/src/app/App.tsx`, `frontend/src/shared/ui/PrivateRoute.tsx`, `frontend/src/pages/login/ui/LoginPage.tsx`, `frontend/src/features/auth/ui/login-form/LoginForm.tsx`
+> **Verified existing paths**: `frontend/src/app/App.tsx`, `frontend/src/shared/ui/PrivateRoute.tsx`, `frontend/src/pages/login/ui/LoginPage.tsx`, `frontend/src/features/auth/ui/login-form/LoginForm.tsx`, `frontend/src/pages/workspace/ui/WorkspaceRootRedirect.tsx`, `frontend/src/shared/api/index.ts`
 
 ---
 
 ## Goal
 
 운영자 로그인 화면이 인증 전 진입점 역할을 맡고, 인증 성공 후에는 기본적으로 `/workspaces`로 이동하며, 보호 라우트에서 튕겨 온 경우에는 안전한 내부 private route로만 복귀하는 규칙을 명확히 정의한다.
+
+또한 backend가 보호 API에서 access token을 401로 거절한 경우, frontend가 stale/invalid auth session을 정리하고 `/login` ↔ `/workspaces` 무한 리다이렉트를 만들지 않는 복구 규칙을 추가로 정의한다.
 
 ---
 
@@ -36,6 +38,22 @@ flowchart TD
     G -->|network error| O[연결 실패 메시지]
 ```
 
+### Invalid Token Recovery Flow
+
+```mermaid
+flowchart TD
+    A[localStorage에 accessToken 존재] --> B[/login 또는 /workspaces 진입]
+    B --> C{isAuthenticated}
+    C -->|exp 유효| D[/workspaces 이동 또는 유지]
+    D --> E[GET /api/v1/workspaces]
+    E -->|401 Unauthorized| F[auth session 정리]
+    F --> G[/login replace 이동]
+    G --> H[LoginPage 렌더]
+    H --> I[로그인 폼 표시]
+    E -->|403 Forbidden| J[권한 없음 상태 표시]
+    E -->|500/network| K[일반 에러 상태 표시]
+```
+
 ---
 
 ## Design Diff
@@ -48,6 +66,8 @@ flowchart TD
 | 로그인 성공 후 이동 | `/upload` | `/workspaces` 또는 `state.from` | workspace 중심 흐름으로 수정 |
 | 보호 라우트 복귀 | `PrivateRoute`가 `state.from` 저장 | 로그인 spec에서 소비 규칙까지 명시 | 문서 간 역할 연결 |
 | 인증된 사용자의 `/login` 접근 | 별도 정책 불명확 | `/workspaces`로 replace 이동 | 중복 로그인 화면 노출 방지 |
+| backend 401 처리 | API 실패 후 stale token 유지 가능 | 401 수신 시 auth session 정리 | invalid token 루프 차단 |
+| workspace 진입 에러 | `useListWorkspaces` 에러를 `/login`으로 일괄 이동 | 401/403/기타 에러를 분기 | 인증 실패와 권한/서버 오류 구분 |
 
 ---
 
@@ -111,6 +131,20 @@ export interface LoginResponse {
 | 기타 API 오류 | 서버 메시지 또는 기본 실패 메시지 |
 | 네트워크 오류 | "서버에 연결할 수 없습니다. 잠시 후 다시 시도해주세요." |
 
+### Protected API Auth Failure
+
+로그인 이후 호출되는 보호 API의 401은 backend가 현재 access token을 인증 신뢰할 수 없다고 판단한 최종 신호로 본다.
+
+| 응답 | 의미 | Frontend 처리 |
+|------|------|---------------|
+| `401 UNAUTHORIZED` | token 누락/만료/서명 불일치/type 불일치/role claim 누락 등 인증 실패 | auth session 정리 후 로그인 화면으로 복귀 |
+| `403 FORBIDDEN` | 인증은 되었지만 workspace 또는 resource 권한 부족 | session 유지, 권한 없음 상태 표시 |
+| `5xx` 또는 network error | 서버/네트워크 장애 | session 유지, 일반 에러 상태 표시 |
+
+- frontend의 `isAuthenticated()`는 UX guard이며, backend 인증 결과를 대체하지 않는다.
+- backend가 보호 API에서 401을 반환하면 frontend는 저장된 `accessToken`, `refreshToken`, `user`를 폐기한다.
+- API client는 auth session 정리까지만 담당하고, router navigation은 page/route layer에서 처리한다.
+
 ---
 
 ## Data Flow
@@ -132,6 +166,16 @@ PrivateRoute
   -> if unauthenticated
      -> clearAuthSession()
      -> Navigate("/login", { state: { from: location }, replace: true })
+
+Protected API request
+  -> apiClient.request()
+     -> if response.status === 401
+        -> clearAuthSession()
+        -> throw ApiRequestError(401, "UNAUTHORIZED", message)
+     -> page-level query error handler
+        -> if 401: Navigate("/login", { replace: true })
+        -> if 403: render forbidden state
+        -> else: render generic error state
 ```
 
 `resolvePostLoginDestination`은 `state.from`을 그대로 신뢰하지 않고 "Safe Return Destination" 규칙을 먼저 적용한다.
@@ -147,6 +191,10 @@ PrivateRoute
 | 비인증 사용자가 `/login` 진입 | 로그인 화면 표시 |
 | 비인증 사용자가 private route 진입 | `PrivateRoute`가 `/login`으로 보내고 `state.from` 저장 |
 | 인증 사용자가 `/login` 재진입 | `/workspaces`로 replace 이동 |
+| stale/invalid token 보유 사용자가 `/workspaces` 진입 | 보호 API 401 수신 후 session 정리, `/login` 이동 |
+| stale/invalid token 보유 사용자가 `/login` 진입 | 최초 `isAuthenticated()`가 true일 수 있으나, `/workspaces` 보호 API 401 후 session 정리되어 `/login`에 머무름 |
+| workspace 목록 조회가 403 실패 | session 유지, 권한 없음/접근 불가 상태 표시 |
+| workspace 목록 조회가 5xx/network 실패 | session 유지, 일반 에러 상태 표시 |
 
 ### Post-login Destination
 
@@ -203,6 +251,8 @@ export function LoginPage() {
 
 - 인증 판별은 access token 유효성 기준으로 한다.
 - 인증된 사용자가 로그인 화면을 다시 보는 상태를 허용하지 않는다.
+- 단, 이 판별은 token payload의 만료 시간 기반 UX guard이므로 backend의 401 응답보다 우선하지 않는다.
+- backend 401 이후 auth session이 정리되면 `/login`은 반드시 로그인 폼을 렌더링해야 한다.
 
 ### LoginForm
 
@@ -269,6 +319,41 @@ return <>{children}</>;
 - 유효하지 않은 세션은 즉시 정리해 stale user 정보만으로 private route를 통과하지 못하게 한다.
 - current `location`은 로그인 후 복귀를 위해 `state.from`에 저장한다.
 
+### API Client 401 Handling
+
+공통 API client는 보호 API에서 401 응답을 받으면 auth session을 정리한다.
+
+```ts
+if (response.status === 401) {
+  clearAuthSession();
+}
+```
+
+- 위치 후보는 `frontend/src/shared/api/index.ts`의 response handling 지점이다.
+- 공통 client는 `clearAuthSession()`만 수행하고 `navigate()`는 호출하지 않는다.
+- 라우팅은 `WorkspaceRootRedirect` 같은 page/route layer에서 `ApiRequestError.status`를 보고 처리한다.
+- 403, 5xx, network error에서는 session을 정리하지 않는다.
+
+### WorkspaceRootRedirect
+
+`WorkspaceRootRedirect`는 workspace 목록 조회 실패를 인증 실패로 일괄 해석하지 않는다.
+
+```tsx
+if (isApiRequestError(error) && error.status === 401) {
+  return <Navigate to="/login" replace />;
+}
+
+if (isApiRequestError(error) && error.status === 403) {
+  return <ForbiddenState />;
+}
+
+return <ErrorState />;
+```
+
+- 401만 로그인 복귀 조건으로 사용한다.
+- 403은 인증된 사용자의 권한 문제이므로 로그인 화면으로 보내지 않는다.
+- 500 또는 네트워크 오류는 로그인 리다이렉트가 아니라 일반 오류 복구 UI를 보여준다.
+
 ---
 
 ## 후속 구현 대상 파일
@@ -282,6 +367,8 @@ return <>{children}</>;
 | `frontend/src/shared/ui/PrivateRoute.tsx` | modify | token 유효성 기반 인증 판별 및 `state.from` 저장 규칙 정리 |
 | `frontend/src/features/auth/ui/login-form/LoginForm.tsx` | modify | 로그인 성공 후 safe 목적지 결정 규칙 반영 |
 | `frontend/src/pages/login/ui/LoginPage.tsx` | modify | 인증된 사용자의 `/login` 재진입 시 `/workspaces` 이동 |
+| `frontend/src/shared/api/index.ts` | modify | 보호 API 401 수신 시 auth session 정리 |
+| `frontend/src/pages/workspace/ui/WorkspaceRootRedirect.tsx` | modify | workspace 목록 조회 실패를 401/403/기타로 분기 |
 
 ---
 
@@ -305,6 +392,8 @@ return <>{children}</>;
 - 로그인 성공 시 access token / refresh token / 사용자 정보를 저장한다.
 - 이후 private route는 access token 유효성을 기준으로 인증 상태를 판별한다.
 - access token이 없거나 만료/파싱 실패 상태이면 저장된 auth session을 정리한다.
+- 보호 API에서 401을 수신하면 token payload의 `exp`와 무관하게 저장된 auth session을 정리한다.
+- 403/5xx/network error에서는 auth session을 정리하지 않는다.
 
 ---
 
@@ -327,6 +416,8 @@ return <>{children}</>;
 | 구분 | 방법 | 도구 | 비고 |
 |------|------|------|------|
 | 수동 테스트 | 브라우저 직접 확인 | Chrome DevTools | 로그인 -> workspace 흐름 확인 |
+| 단위 테스트 | auth/session 및 API client 동작 검증 | Vitest | 401 session clear, 403/500 session 유지 |
+| 라우팅 테스트 | LoginPage / WorkspaceRootRedirect 흐름 검증 | Testing Library | invalid token 루프 방지 |
 | 빌드 검증 | 정적 빌드 | `pnpm build` | 라우트 및 타입 검증 |
 
 ### Happy Path
@@ -352,6 +443,9 @@ return <>{children}</>;
 | 8 | pathname 누락 | `state.from`이 없거나 `pathname` 없음 | `/workspaces`로 fallback |
 | 9 | 외부 URL | `https://example.com`이 후보 값으로 전달 | `/workspaces`로 fallback |
 | 10 | 만료된 token | 만료된 access token 저장 상태로 private route 진입 | session 정리 후 `/login` 이동 |
+| 11 | backend 401 invalid token | exp는 유효하지만 backend가 `/api/v1/workspaces`를 401로 응답 | session 정리 후 `/login` 이동, `/workspaces` 재진입 없음 |
+| 12 | workspace 403 | `/api/v1/workspaces`가 403 응답 | session 유지, 권한 없음 상태 표시 |
+| 13 | workspace 500/network | `/api/v1/workspaces`가 5xx 또는 network error | session 유지, 일반 에러 상태 표시 |
 
 ---
 
@@ -362,7 +456,11 @@ return <>{children}</>;
 - [ ] `PrivateRoute`의 `state.from`은 `ALLOWED_RETURN_PREFIXES` 기반 safe return destination으로 검증한 뒤 소비한다.
 - [ ] 인증된 사용자가 `/login`에 진입하면 `/workspaces`로 이동한다.
 - [ ] private route는 access token 유효성 기준으로 인증 여부를 판별한다.
+- [ ] 보호 API에서 401을 수신하면 저장된 auth session을 정리한다.
+- [ ] 401 이후 `/login`에 도착했을 때 `/workspaces`로 다시 튕기지 않는다.
+- [ ] workspace 목록 조회 실패는 401/403/기타 오류로 분기하며, 403/기타 오류는 로그인 리다이렉트하지 않는다.
 - [ ] safe return helper 테스트는 허용 prefix, auth route, pathname 누락, 외부 URL fallback을 포함한다.
+- [ ] API client/session 테스트는 401 session clear와 403/500 session 유지 케이스를 포함한다.
 - [ ] 실제 저장 로직이 없는 `아이디 저장` checkbox는 제거하거나 후속 remember-id spec으로 분리한다.
 - [ ] signup / password reset은 이번 범위 밖으로 분리된다.
 - [ ] `021.md`와 충돌하지 않는 로그인 진입 규칙을 유지한다.


### PR DESCRIPTION
## Summary

- 로그인/워크스페이스 랜딩 스펙(`011.md`)에 invalid/stale access token 복구 흐름을 추가
- 보호 API에서 backend가 401을 반환할 때 frontend auth session을 정리하는 규칙을 명시
- `/login` ↔ `/workspaces` 무한 리다이렉트 방지를 위한 `WorkspaceRootRedirect` 에러 분기 기준을 정리

## Details

- `401 UNAUTHORIZED`
  - access token 인증 실패로 간주
  - `accessToken`, `refreshToken`, `user` 세션 정리
  - page/route layer에서 `/login`으로 이동
- `403 FORBIDDEN`
  - 인증은 되었지만 권한이 없는 상태로 간주
  - 세션 유지
  - 권한 없음 상태 표시
- `5xx` 또는 network error
  - 서버/네트워크 오류로 간주
  - 세션 유지
  - 일반 에러 상태 표시

## Updated Spec

- `.agent/specs/011.md`

## Notes

- 코드 구현은 포함하지 않고 스펙만 보완
- 후속 구현 대상 파일로 `frontend/src/shared/api/index.ts`와 `frontend/src/pages/workspace/ui/WorkspaceRootRedirect.tsx`를 추가

## Test

- 문서 변경만 포함하여 별도 테스트는 실행하지 않음

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ajou-2026-1-capstone-5/ostone/pull/234" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * 운영자 콘솔의 로그인 및 워크스페이스 랜딩 흐름 규칙 명시
  * 세션 만료/무효 상황에서의 복구 절차 및 에러 처리 규칙 문서화
  * 인증 오류 시 세션 정리 및 안전한 리다이렉션 프로세스 정의

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ajou-2026-1-capstone-5/ostone/pull/234?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->