### PR TITLE
Spec/011: 로그인 스펙 라우팅 정합성 보완

### DIFF
--- a/.agent/specs/011.md
+++ b/.agent/specs/011.md
@@ -206,7 +206,7 @@ Protected API request
 
 - `state.from.pathname`이 존재하고, 외부 URL이 아니며, 명시적 allowlist prefix 중 하나로 시작할 때만 복귀 대상으로 사용한다.
 - 이번 스펙에서 허용하는 return path prefix는 `["/workspaces"]`뿐이다.
-- `/login`, `/signup`, `/reset-password`, `/reset-password/complete` 같은 auth route는 allowlist에 포함하지 않으므로 항상 `/workspaces`로 fallback한다.
+- `/login`, `/signup`, `/password-reset`, `/password-reset/complete` 같은 auth route는 allowlist에 포함하지 않으므로 항상 `/workspaces`로 fallback한다.
 - pathname이 없거나 allowlist에 포함되지 않은 값은 모두 `/workspaces`로 fallback한다.
 - 이 규칙은 open redirect와 auth route 왕복 루프를 피하기 위한 최소 방어선이다.
 
@@ -222,9 +222,9 @@ Protected API request
 <Route path="/" element={<Navigate to="/workspaces" replace />} />
 <Route path="/login" element={<LoginPage />} />
 <Route path="/signup" element={<SignupPage />} />
-<Route path="/reset-password" element={<PasswordResetInitPage />} />
-<Route path="/reset-password/complete" element={<PasswordResetCompletePage />} />
-<Route path="/workspaces" element={<PrivateRoute><WorkspaceListPage /></PrivateRoute>} />
+<Route path="/password-reset" element={<PasswordResetInitPage />} />
+<Route path="/password-reset/complete" element={<PasswordResetCompletePage />} />
+<Route path="/workspaces" element={<PrivateRoute><WorkspaceRootRedirect /></PrivateRoute>} />
 ```
 
 - `/`는 더 이상 `/login`으로 보내지 않고 `/workspaces`로 보낸다.
@@ -272,7 +272,7 @@ navigate(destination, { replace: true });
 - 로그인 성공 후 기본 목적지는 `/workspaces`다.
 - `state.from`이 safe return destination이면 해당 경로로 이동한다.
 - `state.from`이 auth route이거나 유효하지 않으면 `/workspaces`로 fallback한다.
-- 현재 UI에 존재하는 `아이디 저장` checkbox는 실제 저장 로직이 없으므로, 구현 시 제거하거나 별도 remember-id spec으로 분리한다. 본 스펙에서는 remember-id 기능을 정의하지 않는다.
+- 본 스펙에서는 remember-id 기능을 정의하지 않으므로, `아이디 저장` checkbox를 새로 추가하지 않는다.
 
 ### Safe Destination Helper
 
@@ -461,7 +461,7 @@ return <ErrorState />;
 - [ ] workspace 목록 조회 실패는 401/403/기타 오류로 분기하며, 403/기타 오류는 로그인 리다이렉트하지 않는다.
 - [ ] safe return helper 테스트는 허용 prefix, auth route, pathname 누락, 외부 URL fallback을 포함한다.
 - [ ] API client/session 테스트는 401 session clear와 403/500/network error session 유지 케이스를 포함한다.
-- [ ] 실제 저장 로직이 없는 `아이디 저장` checkbox는 제거하거나 후속 remember-id spec으로 분리한다.
+- [ ] remember-id 기능은 이번 범위에서 추가하지 않으며, `아이디 저장` checkbox를 새로 만들지 않는다.
 - [ ] signup / password reset은 이번 범위 밖으로 분리된다.
 - [ ] `021.md`와 충돌하지 않는 로그인 진입 규칙을 유지한다.
 

--- a/.agent/specs/011.md
+++ b/.agent/specs/011.md
@@ -439,7 +439,7 @@ return <ErrorState />;
 | 4 | 비밀번호 재설정 필요 | 해당 응답 수신 | 재설정 필요 메시지 표시 |
 | 5 | 네트워크 오류 | 서버 미응답 | 연결 실패 메시지 표시 |
 | 6 | 허용된 return path | `/workspaces/1/upload`이 `state.from.pathname`으로 전달 | `/workspaces/1/upload` 복귀 |
-| 7 | auth route from 값 | `/login` 또는 `/signup`이 `state.from.pathname`으로 전달 | `/workspaces`로 fallback |
+| 7 | auth route from 값 | `/login`, `/signup`, `/password-reset`, `/password-reset/complete`이 `state.from.pathname`으로 전달 | `/workspaces`로 fallback |
 | 8 | pathname 누락 | `state.from`이 없거나 `pathname` 없음 | `/workspaces`로 fallback |
 | 9 | 외부 URL | `https://example.com`이 후보 값으로 전달 | `/workspaces`로 fallback |
 | 10 | 만료된 token | 만료된 access token 저장 상태로 private route 진입 | session 정리 후 `/login` 이동 |


### PR DESCRIPTION
## 개요

FE-011 스펙에서 현재 프론트엔드 코드와 맞지 않는 라우트/컴포넌트 표기를 정정

## 변경 내용

- password reset 라우트 표기를 현재 코드 기준으로 수정
  - `/reset-password` → `/password-reset`
  - `/reset-password/complete` → `/password-reset/complete`
- `/workspaces` 라우트 예시의 컴포넌트명을 현재 코드 기준으로 수정
  - `WorkspaceListPage` → `WorkspaceRootRedirect`
- 현재 UI에 존재하지 않는 `아이디 저장` checkbox 설명을 수정
  - 제거/분리 대상처럼 표현하지 않고, 이번 스펙에서 새로 추가하지 않는 항목으로 정리

## 검증

- 변경 파일: `.agent/specs/011.md`
- 코드 변경 없음
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ajou-2026-1-capstone-5/ostone/pull/236" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * 인증 관련 라우팅 동작 규칙을 명확히 했습니다.
  * 로그인 후 이동 경로에 대한 안내를 업데이트했습니다.
  * 향후 개발 범위를 명시했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ajou-2026-1-capstone-5/ostone/pull/236?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->