### PR TITLE
[011] fix(auth): prevent invalid token login redirect loop

### DIFF
--- a/frontend/src/pages/workspace/ui/WorkspaceRootRedirect.test.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceRootRedirect.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
 import { ApiRequestError } from '@/shared/api';
@@ -10,7 +10,11 @@ vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
   return {
     ...actual,
-    Navigate: ({ to }: { to: string }) => <div data-testid="navigate-to">{to}</div>,
+    Navigate: ({ to, replace }: { to: string; replace?: boolean }) => (
+      <div data-testid="navigate-to" data-replace={String(replace)}>
+        {to}
+      </div>
+    ),
     useNavigate: () => mockNavigate,
   };
 });
@@ -24,8 +28,17 @@ vi.mock('@/shared/ui/spinner', () => ({
 }));
 
 vi.mock('@/features/workspace', () => ({
-  CreateWorkspaceDialog: ({ open, onSuccess }: { open: boolean; onSuccess: (created: { id: number }) => void }) => (
+  CreateWorkspaceDialog: ({
+    open,
+    onOpenChange,
+    onSuccess,
+  }: {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    onSuccess: (created: { id: number }) => void;
+  }) => (
     open ? <div data-testid="create-dialog">
+      <button type="button" onClick={() => onOpenChange(false)}>닫기</button>
       <button type="button" onClick={() => onSuccess({ id: 999 })}>생성 완료</button>
     </div> : null
   ),
@@ -61,18 +74,23 @@ describe('WorkspaceRootRedirect', () => {
     });
     renderPage();
     expect(screen.getByTestId('navigate-to')).toHaveTextContent('/login');
+    expect(screen.getByTestId('navigate-to')).toHaveAttribute('data-replace', 'true');
   });
 
   it('403 에러 시 /login으로 리다이렉트하지 않는다', () => {
+    const refetch = vi.fn();
     useListWorkspaces.mockReturnValue({
       data: undefined,
       error: new ApiRequestError(403, 'FORBIDDEN', '권한이 없습니다.'),
       isLoading: false,
       isError: true,
+      refetch,
     });
     renderPage();
     expect(screen.queryByTestId('navigate-to')).not.toBeInTheDocument();
     expect(screen.getByRole('alert')).toHaveTextContent('워크스페이스 정보를 불러오지 못했습니다.');
+    fireEvent.click(screen.getByRole('button', { name: '다시 시도' }));
+    expect(refetch).toHaveBeenCalled();
   });
 
   it('network error 시 /login으로 리다이렉트하지 않는다', () => {
@@ -124,5 +142,12 @@ describe('WorkspaceRootRedirect', () => {
     const createBtn = screen.getByText('생성 완료');
     createBtn.click();
     expect(mockNavigate).toHaveBeenCalledWith('/workspaces/999/workflows', { replace: true });
+  });
+
+  it('CreateWorkspaceDialog 닫기 시 페이지를 새로고침하지 않고 현재 route를 유지한다', () => {
+    useListWorkspaces.mockReturnValue({ data: [], isLoading: false, isError: false });
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: '닫기' }));
+    expect(mockNavigate).toHaveBeenCalledWith('/workspaces', { replace: true });
   });
 });

--- a/frontend/src/pages/workspace/ui/WorkspaceRootRedirect.test.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceRootRedirect.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
+import { ApiRequestError } from '@/shared/api';
 
 const useListWorkspaces = vi.fn();
 const mockNavigate = vi.fn();
@@ -51,10 +52,39 @@ describe('WorkspaceRootRedirect', () => {
     expect(screen.getByTestId('spinner')).toBeInTheDocument();
   });
 
-  it('에러 시 /login으로 리다이렉트한다', () => {
-    useListWorkspaces.mockReturnValue({ data: undefined, isLoading: false, isError: true });
+  it('401 에러 시 /login으로 리다이렉트한다', () => {
+    useListWorkspaces.mockReturnValue({
+      data: undefined,
+      error: new ApiRequestError(401, 'UNAUTHORIZED', '인증이 필요합니다.'),
+      isLoading: false,
+      isError: true,
+    });
     renderPage();
     expect(screen.getByTestId('navigate-to')).toHaveTextContent('/login');
+  });
+
+  it('403 에러 시 /login으로 리다이렉트하지 않는다', () => {
+    useListWorkspaces.mockReturnValue({
+      data: undefined,
+      error: new ApiRequestError(403, 'FORBIDDEN', '권한이 없습니다.'),
+      isLoading: false,
+      isError: true,
+    });
+    renderPage();
+    expect(screen.queryByTestId('navigate-to')).not.toBeInTheDocument();
+    expect(screen.getByRole('alert')).toHaveTextContent('워크스페이스 정보를 불러오지 못했습니다.');
+  });
+
+  it('network error 시 /login으로 리다이렉트하지 않는다', () => {
+    useListWorkspaces.mockReturnValue({
+      data: undefined,
+      error: new Error('network error'),
+      isLoading: false,
+      isError: true,
+    });
+    renderPage();
+    expect(screen.queryByTestId('navigate-to')).not.toBeInTheDocument();
+    expect(screen.getByRole('alert')).toHaveTextContent('워크스페이스 정보를 불러오지 못했습니다.');
   });
 
   it('워크스페이스가 없으면 CreateWorkspaceDialog를 표시한다', () => {

--- a/frontend/src/pages/workspace/ui/WorkspaceRootRedirect.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceRootRedirect.tsx
@@ -5,6 +5,7 @@ import { useListWorkspaces } from "@/shared/api/generated/endpoints/workspace-co
 import { CreateWorkspaceDialog } from "@/features/workspace";
 import { Spinner } from "@/shared/ui/spinner";
 import { ApiRequestError } from "@/shared/api";
+import { ErrorState } from "@/shared/ui/ostone/atoms/ErrorState";
 
 export function WorkspaceRootRedirect() {
   const navigate = useNavigate();
@@ -13,6 +14,7 @@ export function WorkspaceRootRedirect() {
     error,
     isLoading,
     isError,
+    refetch,
   } = useListWorkspaces();
 
   if (isLoading) {
@@ -29,8 +31,13 @@ export function WorkspaceRootRedirect() {
 
   if (isError) {
     return (
-      <div role="alert" style={{ padding: "24px", color: "var(--danger)" }}>
-        워크스페이스 정보를 불러오지 못했습니다.
+      <div role="alert" style={{ padding: "24px" }}>
+        <ErrorState
+          message="워크스페이스 정보를 불러오지 못했습니다."
+          onRetry={() => {
+            void refetch();
+          }}
+        />
       </div>
     );
   }
@@ -47,7 +54,7 @@ export function WorkspaceRootRedirect() {
       <CreateWorkspaceDialog
         open={true}
         onOpenChange={() => {
-          window.location.reload();
+          navigate("/workspaces", { replace: true });
         }}
         onSuccess={async (created) => {
           navigate(`/workspaces/${created.id}/workflows`, { replace: true });

--- a/frontend/src/pages/workspace/ui/WorkspaceRootRedirect.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceRootRedirect.tsx
@@ -1,57 +1,58 @@
-import { useEffect, useState } from "react";
 import { Navigate, useNavigate } from "react-router-dom";
 
 import type { WorkspaceResponse } from "@/shared/api/generated/zod";
 import { useListWorkspaces } from "@/shared/api/generated/endpoints/workspace-controller/workspace-controller";
 import { CreateWorkspaceDialog } from "@/features/workspace";
 import { Spinner } from "@/shared/ui/spinner";
+import { ApiRequestError } from "@/shared/api";
 
 export function WorkspaceRootRedirect() {
-  const [target, setTarget] = useState<string | null>(null);
-  const [showCreate, setShowCreate] = useState(false);
   const navigate = useNavigate();
-  const { data: workspacesData, isLoading, isError } = useListWorkspaces();
+  const {
+    data: workspacesData,
+    error,
+    isLoading,
+    isError,
+  } = useListWorkspaces();
 
-  useEffect(() => {
-    if (isLoading || isError) {
-      return;
-    }
+  if (isLoading) {
+    return (
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "center", height: "100vh" }}>
+        <Spinner />
+      </div>
+    );
+  }
 
-    const workspaces = (workspacesData ?? []) as unknown as WorkspaceResponse[];
-    if (workspaces.length === 0) {
-      setShowCreate(true);
-      return;
-    }
+  if (error instanceof ApiRequestError && error.status === 401) {
+    return <Navigate to="/login" replace />;
+  }
+
+  if (isError) {
+    return (
+      <div role="alert" style={{ padding: "24px", color: "var(--danger)" }}>
+        워크스페이스 정보를 불러오지 못했습니다.
+      </div>
+    );
+  }
+
+  const workspaces = (workspacesData ?? []) as unknown as WorkspaceResponse[];
+  if (workspaces.length > 0) {
     const active =
       workspaces.find((w) => w.status === "ACTIVE") ?? workspaces[0];
-    setTarget(`/workspaces/${active.id}/workflows`);
-  }, [isLoading, isError, workspacesData]);
-
-  useEffect(() => {
-    if (isError) {
-      setTarget("/login");
-    }
-  }, [isError]);
-
-  if (target) {
-    return <Navigate to={target} replace />;
+    return <Navigate to={`/workspaces/${active.id}/workflows`} replace />;
   }
 
   return (
     <div style={{ display: "flex", alignItems: "center", justifyContent: "center", height: "100vh" }}>
-      {showCreate ? (
-        <CreateWorkspaceDialog
-          open={true}
-          onOpenChange={() => {
-            window.location.reload();
-          }}
-          onSuccess={async (created) => {
-            navigate(`/workspaces/${created.id}/workflows`, { replace: true });
-          }}
-        />
-      ) : (
-        <Spinner />
-      )}
+      <CreateWorkspaceDialog
+        open={true}
+        onOpenChange={() => {
+          window.location.reload();
+        }}
+        onSuccess={async (created) => {
+          navigate(`/workspaces/${created.id}/workflows`, { replace: true });
+        }}
+      />
     </div>
   );
 }

--- a/frontend/src/shared/api/index.test.ts
+++ b/frontend/src/shared/api/index.test.ts
@@ -278,5 +278,47 @@ describe("apiClient", () => {
         "요청 처리 중 오류가 발생했습니다.",
       );
     });
+
+    it("401 응답 시 auth session을 정리한다", async () => {
+      const removeItemSpy = vi.spyOn(localStorage, "removeItem");
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        json: async () => ({
+          code: "UNAUTHORIZED",
+          message: "인증이 필요합니다.",
+        }),
+      });
+
+      await expect(apiClient.get<{ id: number }>("/test")).rejects.toMatchObject({
+        status: 401,
+        code: "UNAUTHORIZED",
+      });
+
+      expect(removeItemSpy).toHaveBeenCalledWith("accessToken");
+      expect(removeItemSpy).toHaveBeenCalledWith("refreshToken");
+      expect(removeItemSpy).toHaveBeenCalledWith("user");
+      removeItemSpy.mockRestore();
+    });
+
+    it("401 외 non-ok 응답 시 auth session을 유지한다", async () => {
+      const removeItemSpy = vi.spyOn(localStorage, "removeItem");
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+        json: async () => ({
+          code: "FORBIDDEN",
+          message: "권한이 없습니다.",
+        }),
+      });
+
+      await expect(apiClient.get<{ id: number }>("/test")).rejects.toMatchObject({
+        status: 403,
+        code: "FORBIDDEN",
+      });
+
+      expect(removeItemSpy).not.toHaveBeenCalled();
+      removeItemSpy.mockRestore();
+    });
   });
 });

--- a/frontend/src/shared/api/index.test.ts
+++ b/frontend/src/shared/api/index.test.ts
@@ -39,6 +39,7 @@ describe("apiClient", () => {
   });
 
   afterEach(() => {
+    localStorage.clear();
     Storage.prototype.getItem = originalGetItem;
   });
 
@@ -171,6 +172,23 @@ describe("apiClient", () => {
       expect(result).toEqual(mockResponse);
     });
 
+    it("auth endpoint 요청에는 저장된 access token을 Authorization header로 붙이지 않는다", async () => {
+      const mockResponse = { success: true };
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResponse,
+      });
+
+      await apiClient.request<{ success: boolean }>("/auth/login", {
+        method: "POST",
+        body: { email: "admin@ostone.com", password: "wrong-password" } as unknown as BodyInit,
+      });
+
+      const callArgs = mockFetch.mock.calls[0];
+      const headers = callArgs[1].headers as Headers;
+      expect(headers.get("Authorization")).toBeNull();
+    });
+
     it("body가 object인 경우 JSON.stringify한다", async () => {
       const mockResponse = { id: 1 };
       mockFetch.mockResolvedValueOnce({
@@ -301,6 +319,34 @@ describe("apiClient", () => {
       expect(getStoredItem("accessToken")).toBeNull();
       expect(getStoredItem("refreshToken")).toBeNull();
       expect(getStoredItem("user")).toBeNull();
+    });
+
+    it("auth endpoint의 401 응답 시 기존 auth session을 유지한다", async () => {
+      localStorage.setItem("accessToken", "mock-token");
+      localStorage.setItem("refreshToken", "mock-refresh-token");
+      localStorage.setItem("user", JSON.stringify({ id: 1 }));
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        json: async () => ({
+          code: "UNAUTHORIZED",
+          message: "이메일 또는 비밀번호가 올바르지 않습니다.",
+        }),
+      });
+
+      await expect(
+        apiClient.request<{ id: number }>("/auth/login", {
+          method: "POST",
+          body: { email: "admin@ostone.com", password: "wrong-password" } as unknown as BodyInit,
+        }),
+      ).rejects.toMatchObject({
+        status: 401,
+        code: "UNAUTHORIZED",
+      });
+
+      expect(getStoredItem("accessToken")).toBe("mock-token");
+      expect(getStoredItem("refreshToken")).toBe("mock-refresh-token");
+      expect(getStoredItem("user")).toBe(JSON.stringify({ id: 1 }));
     });
 
     it("401 외 non-ok 응답 시 auth session을 유지한다", async () => {

--- a/frontend/src/shared/api/index.test.ts
+++ b/frontend/src/shared/api/index.test.ts
@@ -280,7 +280,9 @@ describe("apiClient", () => {
     });
 
     it("401 응답 시 auth session을 정리한다", async () => {
-      const removeItemSpy = vi.spyOn(localStorage, "removeItem");
+      localStorage.setItem("accessToken", "mock-token");
+      localStorage.setItem("refreshToken", "mock-refresh-token");
+      localStorage.setItem("user", JSON.stringify({ id: 1 }));
       mockFetch.mockResolvedValueOnce({
         ok: false,
         status: 401,
@@ -295,14 +297,15 @@ describe("apiClient", () => {
         code: "UNAUTHORIZED",
       });
 
-      expect(removeItemSpy).toHaveBeenCalledWith("accessToken");
-      expect(removeItemSpy).toHaveBeenCalledWith("refreshToken");
-      expect(removeItemSpy).toHaveBeenCalledWith("user");
-      removeItemSpy.mockRestore();
+      expect(localStorage.getItem("accessToken")).toBeNull();
+      expect(localStorage.getItem("refreshToken")).toBeNull();
+      expect(localStorage.getItem("user")).toBeNull();
     });
 
     it("401 외 non-ok 응답 시 auth session을 유지한다", async () => {
-      const removeItemSpy = vi.spyOn(localStorage, "removeItem");
+      localStorage.setItem("accessToken", "mock-token");
+      localStorage.setItem("refreshToken", "mock-refresh-token");
+      localStorage.setItem("user", JSON.stringify({ id: 1 }));
       mockFetch.mockResolvedValueOnce({
         ok: false,
         status: 403,
@@ -317,8 +320,9 @@ describe("apiClient", () => {
         code: "FORBIDDEN",
       });
 
-      expect(removeItemSpy).not.toHaveBeenCalled();
-      removeItemSpy.mockRestore();
+      expect(localStorage.getItem("accessToken")).toBe("mock-token");
+      expect(localStorage.getItem("refreshToken")).toBe("mock-refresh-token");
+      expect(localStorage.getItem("user")).toBe(JSON.stringify({ id: 1 }));
     });
   });
 });

--- a/frontend/src/shared/api/index.test.ts
+++ b/frontend/src/shared/api/index.test.ts
@@ -30,6 +30,7 @@ describe("resolveApiBase", () => {
 
 describe("apiClient", () => {
   let originalGetItem: typeof Storage.prototype.getItem;
+  const getStoredItem = (key: string) => originalGetItem.call(localStorage, key);
 
   beforeEach(() => {
     mockFetch.mockClear();
@@ -297,9 +298,9 @@ describe("apiClient", () => {
         code: "UNAUTHORIZED",
       });
 
-      expect(localStorage.getItem("accessToken")).toBeNull();
-      expect(localStorage.getItem("refreshToken")).toBeNull();
-      expect(localStorage.getItem("user")).toBeNull();
+      expect(getStoredItem("accessToken")).toBeNull();
+      expect(getStoredItem("refreshToken")).toBeNull();
+      expect(getStoredItem("user")).toBeNull();
     });
 
     it("401 외 non-ok 응답 시 auth session을 유지한다", async () => {
@@ -320,9 +321,9 @@ describe("apiClient", () => {
         code: "FORBIDDEN",
       });
 
-      expect(localStorage.getItem("accessToken")).toBe("mock-token");
-      expect(localStorage.getItem("refreshToken")).toBe("mock-refresh-token");
-      expect(localStorage.getItem("user")).toBe(JSON.stringify({ id: 1 }));
+      expect(getStoredItem("accessToken")).toBe("mock-token");
+      expect(getStoredItem("refreshToken")).toBe("mock-refresh-token");
+      expect(getStoredItem("user")).toBe(JSON.stringify({ id: 1 }));
     });
   });
 });

--- a/frontend/src/shared/api/index.ts
+++ b/frontend/src/shared/api/index.ts
@@ -11,6 +11,15 @@ interface ApiError {
   message: string;
 }
 
+interface RequestHeaders {
+  headers: Record<string, string>;
+  hasSessionAuthHeader: boolean;
+}
+
+interface ResponseHandlingOptions {
+  clearSessionOnUnauthorized: boolean;
+}
+
 class ApiClient {
   private baseUrl: string;
 
@@ -18,29 +27,43 @@ class ApiClient {
     this.baseUrl = baseUrl;
   }
 
-  private getHeaders(): Record<string, string> {
+  private shouldAttachAuthHeader(path: string): boolean {
+    const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+    const pathWithoutApiPrefix = normalizedPath.startsWith("/api/v1/")
+      ? normalizedPath.slice("/api/v1".length)
+      : normalizedPath;
+
+    return pathWithoutApiPrefix !== "/auth" && !pathWithoutApiPrefix.startsWith("/auth/");
+  }
+
+  private getHeaders(path: string): RequestHeaders {
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
     };
+    let hasSessionAuthHeader = false;
 
-    if (typeof window !== "undefined") {
+    if (typeof window !== "undefined" && this.shouldAttachAuthHeader(path)) {
       const token = localStorage.getItem("accessToken");
       if (token) {
         headers["Authorization"] = `Bearer ${token}`;
+        hasSessionAuthHeader = true;
       }
     }
 
-    return headers;
+    return { headers, hasSessionAuthHeader };
   }
 
-  private async handleResponse<T>(response: Response): Promise<T> {
+  private async handleResponse<T>(
+    response: Response,
+    options: ResponseHandlingOptions,
+  ): Promise<T> {
     if (!response.ok) {
       const errorData = (await response.json().catch(() => ({
         code: "UNKNOWN_ERROR",
         message: "요청 처리 중 오류가 발생했습니다.",
       }))) as ApiError;
 
-      if (response.status === 401) {
+      if (response.status === 401 && options.clearSessionOnUnauthorized) {
         clearAuthSession();
       }
 
@@ -59,13 +82,16 @@ class ApiClient {
   }
 
   async post<T>(path: string, body: unknown): Promise<T> {
+    const { headers, hasSessionAuthHeader } = this.getHeaders(path);
     const response = await fetch(`${this.baseUrl}${path}`, {
       method: "POST",
-      headers: this.getHeaders(),
+      headers,
       body: JSON.stringify(body),
     });
 
-    return this.handleResponse<T>(response);
+    return this.handleResponse<T>(response, {
+      clearSessionOnUnauthorized: hasSessionAuthHeader,
+    });
   }
 
   async request<T>(path: string, options: RequestInit): Promise<T> {
@@ -74,7 +100,8 @@ class ApiClient {
       body = JSON.stringify(body);
     }
 
-    const headers = new Headers(this.getHeaders());
+    const { headers: baseHeaders, hasSessionAuthHeader } = this.getHeaders(path);
+    const headers = new Headers(baseHeaders);
     if (body instanceof FormData || body instanceof Blob || body instanceof URLSearchParams) {
       headers.delete('Content-Type');
     }
@@ -90,36 +117,47 @@ class ApiClient {
       body,
       headers,
     });
-    return this.handleResponse<T>(response);
+    return this.handleResponse<T>(response, {
+      clearSessionOnUnauthorized: hasSessionAuthHeader,
+    });
   }
 
   async get<T>(path: string, options?: { signal?: AbortSignal }): Promise<T> {
+    const { headers, hasSessionAuthHeader } = this.getHeaders(path);
     const response = await fetch(`${this.baseUrl}${path}`, {
       method: "GET",
-      headers: this.getHeaders(),
+      headers,
       signal: options?.signal,
     });
 
-    return this.handleResponse<T>(response);
+    return this.handleResponse<T>(response, {
+      clearSessionOnUnauthorized: hasSessionAuthHeader,
+    });
   }
 
   async patch<T>(path: string, body: unknown): Promise<T> {
+    const { headers, hasSessionAuthHeader } = this.getHeaders(path);
     const response = await fetch(`${this.baseUrl}${path}`, {
       method: "PATCH",
-      headers: this.getHeaders(),
+      headers,
       body: JSON.stringify(body),
     });
 
-    return this.handleResponse<T>(response);
+    return this.handleResponse<T>(response, {
+      clearSessionOnUnauthorized: hasSessionAuthHeader,
+    });
   }
 
   async delete<T>(path: string): Promise<T> {
+    const { headers, hasSessionAuthHeader } = this.getHeaders(path);
     const response = await fetch(`${this.baseUrl}${path}`, {
       method: 'DELETE',
-      headers: this.getHeaders(),
+      headers,
     });
 
-    return this.handleResponse<T>(response);
+    return this.handleResponse<T>(response, {
+      clearSessionOnUnauthorized: hasSessionAuthHeader,
+    });
   }
 }
 

--- a/frontend/src/shared/api/index.ts
+++ b/frontend/src/shared/api/index.ts
@@ -1,3 +1,5 @@
+import { clearAuthSession } from "@/shared/lib/auth";
+
 export function resolveApiBase(apiBaseUrl: string | undefined): string {
   return apiBaseUrl || "/api/v1";
 }
@@ -37,6 +39,10 @@ class ApiClient {
         code: "UNKNOWN_ERROR",
         message: "요청 처리 중 오류가 발생했습니다.",
       }))) as ApiError;
+
+      if (response.status === 401) {
+        clearAuthSession();
+      }
 
       throw new ApiRequestError(
         response.status,


### PR DESCRIPTION
## Summary

- 보호 API에서 401 응답을 받으면 저장된 auth session을 정리하도록 API client 동작을 보완
- `/workspaces` 진입 시 workspace 목록 조회 실패를 401/403/기타 오류로 분기
- 401 인증 실패일 때만 `/login`으로 이동하고, 403 및 network/server error에서는 로그인 리다이렉트하지 않도록 수정
- invalid/stale token 상태에서 `/login` ↔ `/workspaces` 무한 리다이렉트가 발생하지 않도록 테스트를 추가

## Validation

- `pnpm exec eslint src/shared/api/index.ts src/pages/workspace/ui/WorkspaceRootRedirect.tsx src/shared/api/index.test.ts src/pages/workspace/ui/WorkspaceRootRedirect.test.tsx`
- `git diff --check -- frontend/src/shared/api/index.ts frontend/src/pages/workspace/ui/WorkspaceRootRedirect.tsx frontend/src/shared/api/index.test.ts frontend/src/pages/workspace/ui/WorkspaceRootRedirect.test.tsx`

## Notes

- `vp test`는 현재 로컬 테스트 환경의 `html-encoding-sniffer` / `@exodus/bytes` ESM-CJS 충돌로 worker 시작 전에 실패하여 실행하지 못함

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ajou-2026-1-capstone-5/ostone/pull/237" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 401 응답 시 로컬 인증 정보 자동 정리 및 로그인 페이지로 대체(replace) 이동
  * 401 외 오류(권한 오류/네트워크)에서는 리다이렉트 없이 실패 안내 표시

* **UI Changes**
  * 로딩 시 중앙 스피너 즉시 표시
  * 워크스페이스가 없을 때 생성 대화상자 기본 노출 및 생성/닫기 시 /workspaces로 대체 네비게이션

* **Tests**
  * 인증·권한·네트워크 오류별 세션/라우팅 동작, 대화상자 동작 및 로컬스토리지 처리 검증 테스트 추가/확장

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ajou-2026-1-capstone-5/ostone/pull/237?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->