### PR TITLE
fix(corpus): S3RawFileStorageAdapter에 sse 요청 헤더 추가

### DIFF
--- a/backend/src/main/java/com/init/corpus/infrastructure/storage/S3RawFileStorageAdapter.java
+++ b/backend/src/main/java/com/init/corpus/infrastructure/storage/S3RawFileStorageAdapter.java
@@ -21,14 +21,16 @@ public class S3RawFileStorageAdapter implements RawFileStoragePort {
 
   @Override
   public String put(String objectKey, byte[] content, String contentType) {
-    PutObjectRequest request =
+    PutObjectRequest.Builder builder =
         PutObjectRequest.builder()
             .bucket(properties.bucketName())
             .key(objectKey)
             .contentType(contentType)
-            .contentLength((long) content.length)
-            .serverSideEncryption(ServerSideEncryption.AES256)
-            .build();
+            .contentLength((long) content.length);
+    if (properties.serverSideEncryptionEnabled()) {
+      builder.serverSideEncryption(ServerSideEncryption.AES256);
+    }
+    PutObjectRequest request = builder.build();
 
     s3Client.putObject(request, RequestBody.fromBytes(content));
     return objectKey;

--- a/backend/src/main/java/com/init/corpus/infrastructure/storage/S3RawFileStorageAdapter.java
+++ b/backend/src/main/java/com/init/corpus/infrastructure/storage/S3RawFileStorageAdapter.java
@@ -6,6 +6,7 @@ import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.ServerSideEncryption;
 
 @Component
 public class S3RawFileStorageAdapter implements RawFileStoragePort {
@@ -26,6 +27,7 @@ public class S3RawFileStorageAdapter implements RawFileStoragePort {
             .key(objectKey)
             .contentType(contentType)
             .contentLength((long) content.length)
+            .serverSideEncryption(ServerSideEncryption.AES256)
             .build();
 
     s3Client.putObject(request, RequestBody.fromBytes(content));

--- a/backend/src/main/java/com/init/corpus/infrastructure/storage/StorageProperties.java
+++ b/backend/src/main/java/com/init/corpus/infrastructure/storage/StorageProperties.java
@@ -12,4 +12,5 @@ public record StorageProperties(
     String endpoint,
     String accessKey,
     String secretKey,
-    boolean pathStyleAccess) {}
+    boolean pathStyleAccess,
+    boolean serverSideEncryptionEnabled) {}

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -40,3 +40,4 @@ storage:
     access-key: ${MINIO_ROOT_USER:minioadmin}
     secret-key: ${MINIO_ROOT_PASSWORD:minioadmin}
     path-style-access: true
+    server-side-encryption-enabled: false

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -31,6 +31,7 @@ storage:
     access-key: ${STORAGE_S3_ACCESS_KEY:}
     secret-key: ${STORAGE_S3_SECRET_KEY:}
     path-style-access: ${STORAGE_S3_PATH_STYLE:false}
+    server-side-encryption-enabled: ${STORAGE_S3_SSE_ENABLED:false}
 
 management:
   endpoints:


### PR DESCRIPTION
버킷 정책에 따라, 명시적인 요청 헤더 추가함.
render 환경변수에 STORAGE_S3_SSE_ENABLED=true 추가 필요.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ajou-2026-1-capstone-5/ostone/pull/242" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경사항

* **보안 강화**
  * 클라우드 스토리지에 업로드되는 파일에 대해 AES256 기반 서버 측 암호화를 자동으로 적용하여 저장된 데이터의 보안 수준을 개선했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ajou-2026-1-capstone-5/ostone/pull/242?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->