### PR TITLE
fix(corpus): trigger raw upload ingestion after commit

### DIFF
--- a/.agent/specs/244.md
+++ b/.agent/specs/244.md
@@ -1,0 +1,43 @@
+# Spec 244: Raw File Upload Trigger Transaction Fix
+
+## Goal
+
+JSON 원본 상담 파일 업로드 후 ingestion 파이프라인을 트리거할 때, dataset row가 커밋되기 전에 pipeline job이 생성되어 FK 오류가 발생하지 않도록 한다.
+
+## Problem
+
+`RawFileUploadService.upload()`가 외부 `@Transactional` 경계를 열고 있는 상태에서 `RawDatasetUploadService`를 호출한다. 이 때문에 dataset/conversation 저장은 아직 커밋되지 않았는데, 같은 메서드 안에서 `triggerPort.trigger(...)`가 실행되어 pipeline job 생성 시점에 PostgreSQL FK 검증이 dataset row를 볼 수 없다.
+
+대표 오류:
+
+```text
+pipeline_job_dataset_id_fkey
+Key (dataset_id)=(...) is not present in table "dataset"
+```
+
+## Scope
+
+- `backend/src/main/java/com/init/corpus/application/RawFileUploadService.java`
+- raw file upload 성공 경로의 트랜잭션 경계와 trigger 호출 순서만 수정한다.
+- API contract, JSON 파일 형식, S3/MinIO 저장 방식은 변경하지 않는다.
+
+## Approach
+
+1. `RawFileUploadService`의 클래스/메서드 `@Transactional`을 제거한다.
+2. dataset/conversation 저장은 기존 `RawDatasetUploadService`의 트랜잭션 경계에 맡긴다.
+3. raw file metadata 저장까지 성공하면 `RawFileUploadResult`를 만든다.
+4. DB 저장 try/catch 블록이 끝난 뒤 `triggerPort.trigger(...)`를 호출한다.
+5. parsing 또는 DB 저장 실패 시 기존처럼 S3/MinIO object를 best-effort로 삭제한다.
+
+## Non-Goals
+
+- Airflow DAG 동작 변경
+- ML pipeline 변경
+- 파일 포맷 변경
+- 업로드 UI 변경
+
+## Validation
+
+- `RawFileUploadServiceTest` targeted test
+- `backend` compile
+- 로컬 JSON 업로드 smoke 확인

--- a/backend/src/main/java/com/init/corpus/application/RawFileUploadService.java
+++ b/backend/src/main/java/com/init/corpus/application/RawFileUploadService.java
@@ -24,10 +24,8 @@ import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional(readOnly = true)
 public class RawFileUploadService {
 
   private static final Logger log = LoggerFactory.getLogger(RawFileUploadService.class);
@@ -60,7 +58,6 @@ public class RawFileUploadService {
     this.objectMapper = objectMapper;
   }
 
-  @Transactional
   public RawFileUploadResult upload(RawFileUploadCommand command) {
     // 1. Fail-fast validation before S3 IO
     if (!workspaceExistenceRepository.existsById(command.workspaceId())) {
@@ -90,6 +87,7 @@ public class RawFileUploadService {
     // that must intercept any throwable — parse errors, DB errors, runtime errors — to delete
     // the already-uploaded S3 object before re-throwing. Restricting to specific types would
     // silently skip orphan cleanup for uncaught subtypes. (spec/114 U-05, error-handling.md 예외)
+    RawFileUploadResult result;
     try {
       List<RawConversationInput> conversations = parseConversations(command.fileBytes());
 
@@ -114,18 +112,17 @@ public class RawFileUploadService {
               checksum);
       rawFileRepository.save(rawFile);
 
-      triggerPort.trigger(command.workspaceId(), uploadResult.datasetId(), objectKey);
-
-      return new RawFileUploadResult(
-          uploadResult.datasetId(),
-          uploadResult.datasetKey(),
-          command.workspaceId(),
-          objectKey,
-          command.originalFilename(),
-          command.sizeBytes(),
-          uploadResult.status(),
-          uploadResult.piiRedactionStatus(),
-          uploadResult.conversationCount());
+      result =
+          new RawFileUploadResult(
+              uploadResult.datasetId(),
+              uploadResult.datasetKey(),
+              command.workspaceId(),
+              objectKey,
+              command.originalFilename(),
+              command.sizeBytes(),
+              uploadResult.status(),
+              uploadResult.piiRedactionStatus(),
+              uploadResult.conversationCount());
     } catch (Exception ex) {
       try {
         storagePort.delete(objectKey);
@@ -134,6 +131,9 @@ public class RawFileUploadService {
       }
       throw ex;
     }
+
+    triggerPort.trigger(command.workspaceId(), result.datasetId(), objectKey);
+    return result;
   }
 
   private String buildObjectKey(Long workspaceId, String datasetKey, String originalFilename) {


### PR DESCRIPTION
## Summary

- Fix raw JSON file upload triggering ingestion before the dataset row is committed.
- Remove the outer transaction from `RawFileUploadService` so the existing dataset upload transaction can commit before the pipeline trigger.
- Add spec `.agent/specs/244.md` for the fix branch CI/spec convention.

## Root Cause

`RawFileUploadService.upload()` wrapped the full upload flow in an outer `@Transactional`. The dataset insert performed by `RawDatasetUploadService` was still uncommitted when `triggerPort.trigger(...)` attempted to create the pipeline job. PostgreSQL FK validation could not see the dataset row yet, so local uploads failed with `pipeline_job_dataset_id_fkey`.

## Validation

- `git diff --check`
- `cd backend && ./gradlew compileJava --quiet`
- `cd backend && ./gradlew test --tests com.init.corpus.application.RawFileUploadServiceTest --quiet`

Closes #244


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 상담 파일 업로드 시 발생하던 데이터베이스 오류를 해결했습니다. 파일 업로드 후 처리 파이프라인이 정상적으로 실행됩니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ajou-2026-1-capstone-5/ostone/pull/245?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->