### PR TITLE
fix(infra): frontend dev 컨테이너를 root 로 실행해 5173 EACCES 회귀 해결

### DIFF
--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -7,9 +7,12 @@ RUN corepack enable
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN pnpm install --frozen-lockfile
 
-RUN chown -R node:node /app
-USER node
-
 EXPOSE 5173
 
+# 로컬 dev 컨테이너는 root 로 실행한다. bind mount(./frontend:/app) 와 익명
+# 볼륨(/app/node_modules) 양쪽 모두에 자유롭게 쓸 수 있어야 vite 가
+# .vite-temp 같은 런타임 파일을 생성할 수 있고, 이전 빌드의 익명 볼륨이
+# 다른 ownership 으로 남아 있어도 EACCES 로 죽지 않는다.
+# 외부 노출 없는 로컬 전용 이미지라 비-root 강제의 보안 이득은 없다.
+# production 이미지는 별도(frontend/Dockerfile, nginx) 라 영향 없음.
 CMD ["pnpm", "dev", "--host", "0.0.0.0", "--port", "5173"]


### PR DESCRIPTION
#246 에서 Dockerfile.dev 에 `chown -R node:node /app` + `USER node` 가 추가됐는데, docker-compose 의 익명 볼륨 `/app/node_modules` 가 이전 빌드 시점의 root 소유 상태로 굳어 있으면 image rebuild(--build)/컨테이너 recreate 만으로는 volume content 가 재초기화되지 않아 vite 가
`/app/node_modules/.vite-temp/*.mjs` 쓰기에서 EACCES 로 죽고 5173 이 응답하지 않는 회귀가 발생했다.

비-root 강제는 외부에 노출되는 production 이미지(frontend/Dockerfile, nginx) 에서 유효한 기준이고, 로컬 dev 전용 컨테이너에서는 보안 이득이
사실상 없는 반면 익명 볼륨 stale ownership 함정만 남긴다. dev
컨테이너를 root 로 되돌려 bind mount / 익명 볼륨 양쪽에 어떤 ownership 상태가 와도 vite 가 부팅하도록 한다.

- frontend/Dockerfile.dev: `RUN chown -R node:node /app` + `USER node` 제거. 의도 코멘트로 production 이미지가 별개 경로(nginx) 라는 점과 로컬 한정 결정임을 명시.

검증: stale 볼륨이 붙어 있는 상태에서 `docker compose rm -fsv frontend`
+ `docker compose up -d --build frontend` 후 5173 응답 HTTP 200, 컨테이너 logs 에서 VITE+ 0.1.16 정상 부팅 확인.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 로컬 개발 환경 컨테이너 구성이 업데이트되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ajou-2026-1-capstone-5/ostone/pull/247?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->