### PR TITLE
feat(frontend): sidebar workflow top-N + paginated All Workflows page

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -6,7 +6,7 @@ import tseslint from "typescript-eslint";
 import { defineConfig, globalIgnores } from "eslint/config";
 
 export default defineConfig([
-  globalIgnores(["dist"]),
+  globalIgnores(["dist", "coverage/**", "src/shared/api/generated/**", "src/shared/ui/*.tsx", "src/shared/ui/*.ts"]),
   {
     files: ["**/*.{ts,tsx}"],
     extends: [

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -6,7 +6,7 @@ import tseslint from "typescript-eslint";
 import { defineConfig, globalIgnores } from "eslint/config";
 
 export default defineConfig([
-  globalIgnores(["dist", "coverage/**", "src/shared/api/generated/**", "src/shared/ui/*.tsx", "src/shared/ui/*.ts"]),
+  globalIgnores(["dist", "coverage/**", "src/shared/api/generated/**", "src/shared/ui/[a-z]*.tsx"]),
   {
     files: ["**/*.{ts,tsx}"],
     extends: [

--- a/frontend/src/app/App.test.tsx
+++ b/frontend/src/app/App.test.tsx
@@ -42,13 +42,13 @@ describe("App", () => {
     expect(container).toBeTruthy();
   });
 
-  it("renders chat-demo page title", () => {
+  it("renders operator page title at /chat-demo route", () => {
     seedAuthenticatedSession();
     window.history.pushState({}, "", "/workspaces/1/chat-demo");
     const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200, json: async () => [] });
     vi.stubGlobal("fetch", fetchMock);
     render(<AppProviders><App /></AppProviders>);
-    expect(screen.getByText("Chat Workflow Demo")).toBeInTheDocument();
+    expect(screen.getByText("운영자 화면")).toBeInTheDocument();
   });
 
   it("renders login page title on initial load", () => {
@@ -62,42 +62,39 @@ describe("App", () => {
     expect(screen.getByText(/CS Workflow Generator/i)).toBeInTheDocument();
   });
 
-  it("redirects workspace home alias to workflows and renders the representative-version empty state", async () => {
+  it("redirects workspace home alias to workflows and renders the empty workflow state when there are no domain packs", async () => {
     seedAuthenticatedSession();
+
+    const workspaceBody = {
+      id: 1,
+      workspaceKey: "cs-team-alpha",
+      name: "CS Team Alpha",
+      description: null,
+      status: "ACTIVE",
+      myRole: "OWNER",
+      createdAt: "2026-04-01T00:00:00Z",
+      updatedAt: "2026-04-01T00:00:00Z",
+    };
 
     const fetchMock = vi.fn().mockImplementation((url: string) => {
       if (url === "/api/v1/workspaces") {
         return Promise.resolve({
           ok: true,
           status: 200,
-          json: async () => [
-            {
-              id: 1,
-              workspaceKey: "cs-team-alpha",
-              name: "CS Team Alpha",
-              description: null,
-              status: "ACTIVE",
-              myRole: "OWNER",
-              createdAt: "2026-04-01T00:00:00Z",
-              updatedAt: "2026-04-01T00:00:00Z",
-            },
-          ],
+          json: async () => [workspaceBody],
         });
       }
-
+      if (url === "/api/v1/workspaces/1/domain-packs") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => [],
+        });
+      }
       return Promise.resolve({
         ok: true,
         status: 200,
-        json: async () => ({
-          id: 1,
-          workspaceKey: "cs-team-alpha",
-          name: "CS Team Alpha",
-          description: null,
-          status: "ACTIVE",
-          myRole: "OWNER",
-          createdAt: "2026-04-01T00:00:00Z",
-          updatedAt: "2026-04-01T00:00:00Z",
-        }),
+        json: async () => workspaceBody,
       });
     });
 
@@ -115,7 +112,9 @@ describe("App", () => {
     });
 
     expect(await screen.findByText("Workflows")).toBeInTheDocument();
-    expect(screen.getByText("반품 접수 처리")).toBeInTheDocument();
+    expect(
+      await screen.findByText("아직 등록된 워크플로우가 없습니다. 도메인팩에서 워크플로우를 생성해 주세요."),
+    ).toBeInTheDocument();
     expect(fetchMock).toHaveBeenCalledWith(
       "/api/v1/workspaces/1",
       expect.objectContaining({ method: "GET" }),

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -12,6 +12,7 @@ import { PolicyDraftReadPage } from '../pages/domain-pack/ui/PolicyDraftReadPage
 import { RiskDraftReadPage } from '../pages/domain-pack/ui/RiskDraftReadPage';
 import { SlotDraftReadPage } from '../pages/domain-pack/ui/SlotDraftReadPage';
 import { WorkflowDraftReadPage } from '../pages/domain-pack/ui/WorkflowDraftReadPage';
+import { PackWorkflowListPage } from '../pages/domain-pack/ui/PackWorkflowListPage';
 import { DomainPackSummaryPage } from '../pages/domain-pack/ui/DomainPackSummaryPage';
 import { WorkspaceLayout } from '../pages/workspace/ui/WorkspaceLayout';
 import { WorkspaceWorkflowsPage } from '../pages/workspace/ui/WorkspaceWorkflowsPage';
@@ -50,7 +51,7 @@ export function App() {
         <Route path="/workspaces/:workspaceId/domain-packs/:packId/versions/:versionId/policies/:policyId?" element={<PrivateRoute><PolicyDraftReadPage /></PrivateRoute>} />
         <Route path="/workspaces/:workspaceId/domain-packs/:packId/versions/:versionId/risks/:riskId?" element={<PrivateRoute><RiskDraftReadPage /></PrivateRoute>} />
         <Route path="/workspaces/:workspaceId/domain-packs/:packId/versions/:versionId/slots/:slotId?" element={<PrivateRoute><SlotDraftReadPage /></PrivateRoute>} />
-        <Route path="/workspaces/:workspaceId/domain-packs/:packId/versions/:versionId/workflows" element={<PrivateRoute><WorkflowDraftReadPage /></PrivateRoute>} />
+        <Route path="/workspaces/:workspaceId/domain-packs/:packId/versions/:versionId/workflows" element={<PrivateRoute><PackWorkflowListPage /></PrivateRoute>} />
         <Route path="/workspaces/:workspaceId/domain-packs/:packId/versions/:versionId/workflows/:workflowId" element={<PrivateRoute><WorkflowDraftReadPage /></PrivateRoute>} />
         <Route path="/workspaces/:workspaceId/domain-packs/:packId/versions/:versionId/workflows/:workflowId/graph" element={<PrivateRoute><WorkflowGraphViewerPage /></PrivateRoute>} />
         <Route path="/workspaces/:workspaceId/chat-demo" element={<PrivateRoute><ChatWorkflowDemoPageWrapper /></PrivateRoute>} />

--- a/frontend/src/entities/workflow/api/useGetWorkflowDefinition.ts
+++ b/frontend/src/entities/workflow/api/useGetWorkflowDefinition.ts
@@ -1,5 +1,6 @@
 import { useQuery, type UseQueryResult } from "@tanstack/react-query";
 import { getWorkflow } from "@/shared/api/generated/endpoints/workflow-definition-controller/workflow-definition-controller";
+import { unwrapApiResponse } from "@/shared/api/unwrapApiResponse";
 import type { WorkflowDefinitionDetail } from "@/shared/api/generated/zod";
 
 export interface UseGetWorkflowDefinitionParams {
@@ -21,7 +22,7 @@ export function useGetWorkflowDefinition({
     queryKey: ["workflows", "detail", workspaceId, packId, versionId, workflowId] as const,
     queryFn: async () => {
       const res = await getWorkflow(workspaceId, packId, versionId, workflowId);
-      return res.data;
+      return (unwrapApiResponse(res) ?? res) as WorkflowDefinitionDetail;
     },
     enabled,
   });

--- a/frontend/src/entities/workflow/api/useListAllWorkspaceWorkflows.test.ts
+++ b/frontend/src/entities/workflow/api/useListAllWorkspaceWorkflows.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createElement, type ReactNode } from 'react';
+import { useListAllWorkspaceWorkflows } from './useListAllWorkspaceWorkflows';
+
+vi.mock('@/shared/api/generated/endpoints/domain-pack-controller/domain-pack-controller', async () => {
+  const actual = await vi.importActual<typeof import('@/shared/api/generated/endpoints/domain-pack-controller/domain-pack-controller')>(
+    '@/shared/api/generated/endpoints/domain-pack-controller/domain-pack-controller',
+  );
+  return {
+    ...actual,
+    listDomainPacks: vi.fn(),
+    getDomainPack: vi.fn(),
+  };
+});
+
+vi.mock('@/shared/api/generated/endpoints/workflow-definition-controller/workflow-definition-controller', async () => {
+  const actual = await vi.importActual<typeof import('@/shared/api/generated/endpoints/workflow-definition-controller/workflow-definition-controller')>(
+    '@/shared/api/generated/endpoints/workflow-definition-controller/workflow-definition-controller',
+  );
+  return {
+    ...actual,
+    listWorkflows: vi.fn(),
+  };
+});
+
+import {
+  getDomainPack,
+  listDomainPacks,
+} from '@/shared/api/generated/endpoints/domain-pack-controller/domain-pack-controller';
+import { listWorkflows } from '@/shared/api/generated/endpoints/workflow-definition-controller/workflow-definition-controller';
+
+const mockedListDomainPacks = vi.mocked(listDomainPacks);
+const mockedGetDomainPack = vi.mocked(getDomainPack);
+const mockedListWorkflows = vi.mocked(listWorkflows);
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
+  });
+  return createElement(QueryClientProvider, { client }, children);
+}
+
+beforeEach(() => {
+  mockedListDomainPacks.mockReset();
+  mockedGetDomainPack.mockReset();
+  mockedListWorkflows.mockReset();
+});
+
+describe('useListAllWorkspaceWorkflows', () => {
+  it('workspaceId가 null이면 호출하지 않고 빈 목록을 반환한다', () => {
+    const { result } = renderHook(
+      () => useListAllWorkspaceWorkflows({ workspaceId: null }),
+      { wrapper },
+    );
+    expect(result.current.entries).toEqual([]);
+    expect(mockedListDomainPacks).not.toHaveBeenCalled();
+  });
+
+  it('모든 pack의 latest version 워크플로우를 평면 entry로 반환한다', async () => {
+    mockedListDomainPacks.mockResolvedValue({
+      data: [
+        { packId: 11, name: 'CS Support' },
+        { packId: 12, name: 'Billing' },
+      ],
+    } as never);
+    mockedGetDomainPack.mockImplementation((_ws, packId) => {
+      if (packId === 11) {
+        return Promise.resolve({
+          data: {
+            packId: 11,
+            versions: [
+              { versionId: 50, versionNo: 1 },
+              { versionId: 51, versionNo: 2 },
+            ],
+          },
+        }) as never;
+      }
+      return Promise.resolve({
+        data: {
+          packId: 12,
+          versions: [{ versionId: 80, versionNo: 1 }],
+        },
+      }) as never;
+    });
+    mockedListWorkflows.mockImplementation((_ws, packId, versionId) => {
+      if (packId === 11 && versionId === 51) {
+        return Promise.resolve({
+          data: [
+            { id: 100, name: '환불 처리', workflowCode: 'refund.standard', description: 'desc-1' },
+            { id: 101, workflowCode: 'shipping.delay' },
+          ],
+        }) as never;
+      }
+      if (packId === 12 && versionId === 80) {
+        return Promise.resolve({
+          data: [{ id: 200, name: '카드 변경' }],
+        }) as never;
+      }
+      return Promise.resolve({ data: [] }) as never;
+    });
+
+    const { result } = renderHook(
+      () => useListAllWorkspaceWorkflows({ workspaceId: 1 }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toBeNull();
+    expect(result.current.entries).toHaveLength(3);
+
+    const refund = result.current.entries.find((e) => e.workflowId === 100)!;
+    expect(refund).toEqual({
+      packId: 11,
+      packName: 'CS Support',
+      versionId: 51,
+      workflowId: 100,
+      workflowCode: 'refund.standard',
+      name: '환불 처리',
+      description: 'desc-1',
+    });
+
+    const shipping = result.current.entries.find((e) => e.workflowId === 101)!;
+    expect(shipping.name).toBe('shipping.delay');
+
+    const cardChange = result.current.entries.find((e) => e.workflowId === 200)!;
+    expect(cardChange.packId).toBe(12);
+    expect(cardChange.versionId).toBe(80);
+  });
+
+  it('version이 없는 pack은 entries에 포함되지 않는다', async () => {
+    mockedListDomainPacks.mockResolvedValue({
+      data: [{ packId: 99, name: 'Empty' }],
+    } as never);
+    mockedGetDomainPack.mockResolvedValue({
+      data: { packId: 99, versions: [] },
+    } as never);
+
+    const { result } = renderHook(
+      () => useListAllWorkspaceWorkflows({ workspaceId: 1 }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.entries).toEqual([]);
+    expect(mockedListWorkflows).not.toHaveBeenCalled();
+  });
+
+  it('listDomainPacks 실패 시 에러 메시지를 반환한다', async () => {
+    mockedListDomainPacks.mockRejectedValue(new Error('nope'));
+
+    const { result } = renderHook(
+      () => useListAllWorkspaceWorkflows({ workspaceId: 1 }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect(result.current.error).toBe('도메인팩 목록 조회 실패');
+  });
+});

--- a/frontend/src/entities/workflow/api/useListAllWorkspaceWorkflows.ts
+++ b/frontend/src/entities/workflow/api/useListAllWorkspaceWorkflows.ts
@@ -83,13 +83,14 @@ export function useListAllWorkspaceWorkflows({
     detailQueries.some((q) => q.isLoading) ||
     workflowQueries.some((q) => q.isLoading);
 
-  const error = packsQuery.isError
-    ? '도메인팩 목록 조회 실패'
-    : detailQueries.find((q) => q.isError)
-      ? '도메인팩 상세 조회 실패'
-      : workflowQueries.find((q) => q.isError)
-        ? '워크플로우 목록 조회 실패'
-        : null;
+  let error: string | null = null;
+  if (packsQuery.isError) {
+    error = '도메인팩 목록 조회 실패';
+  } else if (detailQueries.find((q) => q.isError)) {
+    error = '도메인팩 상세 조회 실패';
+  } else if (workflowQueries.find((q) => q.isError)) {
+    error = '워크플로우 목록 조회 실패';
+  }
 
   const entries: WorkspaceWorkflowEntry[] = [];
   packVersionPairs.forEach((pair, idx) => {

--- a/frontend/src/entities/workflow/api/useListAllWorkspaceWorkflows.ts
+++ b/frontend/src/entities/workflow/api/useListAllWorkspaceWorkflows.ts
@@ -1,0 +1,113 @@
+import { useQueries, useQuery } from '@tanstack/react-query';
+import {
+  getDomainPack,
+  listDomainPacks,
+} from '@/shared/api/generated/endpoints/domain-pack-controller/domain-pack-controller';
+import { listWorkflows } from '@/shared/api/generated/endpoints/workflow-definition-controller/workflow-definition-controller';
+import { unwrapApiResponse } from '@/shared/api/unwrapApiResponse';
+import type {
+  DomainPackDetailResult,
+  DomainPackSummaryResult,
+  WorkflowDefinitionSummary,
+} from '@/shared/api/generated/zod';
+
+export interface WorkspaceWorkflowEntry {
+  packId: number;
+  packName: string;
+  versionId: number;
+  workflowId: number;
+  workflowCode: string | null;
+  name: string;
+  description: string | null;
+}
+
+export interface UseListAllWorkspaceWorkflowsResult {
+  loading: boolean;
+  error: string | null;
+  entries: WorkspaceWorkflowEntry[];
+}
+
+interface UseListAllWorkspaceWorkflowsParams {
+  workspaceId: number | null;
+}
+
+function pickLatestVersionId(detail: DomainPackDetailResult | undefined): number | null {
+  if (!detail?.versions || detail.versions.length === 0) return null;
+  const sorted = [...detail.versions].sort((a, b) => (b.versionNo ?? 0) - (a.versionNo ?? 0));
+  return sorted[0]?.versionId ?? null;
+}
+
+export function useListAllWorkspaceWorkflows({
+  workspaceId,
+}: UseListAllWorkspaceWorkflowsParams): UseListAllWorkspaceWorkflowsResult {
+  const enabled = workspaceId !== null;
+  const wsId = workspaceId ?? 0;
+
+  const packsQuery = useQuery({
+    queryKey: ['workspace-workflows', 'packs', wsId] as const,
+    queryFn: async ({ signal }) => listDomainPacks(wsId, { signal }),
+    enabled,
+  });
+
+  const packs = (unwrapApiResponse<DomainPackSummaryResult[]>(packsQuery.data) ?? []).filter(
+    (p): p is DomainPackSummaryResult & { packId: number } => typeof p.packId === 'number',
+  );
+
+  const detailQueries = useQueries({
+    queries: packs.map((pack) => ({
+      queryKey: ['workspace-workflows', 'pack-detail', wsId, pack.packId] as const,
+      queryFn: async ({ signal }: { signal?: AbortSignal }) =>
+        getDomainPack(wsId, pack.packId, { signal }),
+      enabled,
+    })),
+  });
+
+  const packVersionPairs = packs.map((pack, idx) => {
+    const detail = unwrapApiResponse<DomainPackDetailResult>(detailQueries[idx]?.data);
+    return { pack, versionId: pickLatestVersionId(detail) };
+  });
+
+  const workflowQueries = useQueries({
+    queries: packVersionPairs.map((pair) => ({
+      queryKey: ['workspace-workflows', 'workflows', wsId, pair.pack.packId, pair.versionId ?? 0] as const,
+      queryFn: async ({ signal }: { signal?: AbortSignal }) =>
+        pair.versionId !== null
+          ? listWorkflows(wsId, pair.pack.packId!, pair.versionId, { signal })
+          : Promise.resolve(undefined as never),
+      enabled: enabled && pair.versionId !== null,
+    })),
+  });
+
+  const loading =
+    packsQuery.isLoading ||
+    detailQueries.some((q) => q.isLoading) ||
+    workflowQueries.some((q) => q.isLoading);
+
+  const error = packsQuery.isError
+    ? '도메인팩 목록 조회 실패'
+    : detailQueries.find((q) => q.isError)
+      ? '도메인팩 상세 조회 실패'
+      : workflowQueries.find((q) => q.isError)
+        ? '워크플로우 목록 조회 실패'
+        : null;
+
+  const entries: WorkspaceWorkflowEntry[] = [];
+  packVersionPairs.forEach((pair, idx) => {
+    if (pair.versionId === null) return;
+    const wfList = unwrapApiResponse<WorkflowDefinitionSummary[]>(workflowQueries[idx]?.data) ?? [];
+    wfList.forEach((wf) => {
+      if (typeof wf.id !== 'number') return;
+      entries.push({
+        packId: pair.pack.packId!,
+        packName: pair.pack.name || `pack-${pair.pack.packId}`,
+        versionId: pair.versionId!,
+        workflowId: wf.id,
+        workflowCode: wf.workflowCode ?? null,
+        name: wf.name || wf.workflowCode || `wf-${wf.id}`,
+        description: wf.description ?? null,
+      });
+    });
+  });
+
+  return { loading, error, entries };
+}

--- a/frontend/src/entities/workflow/index.ts
+++ b/frontend/src/entities/workflow/index.ts
@@ -24,4 +24,9 @@ export {
   DEFAULT_NODE_STATUS,
 } from "./model/nodeStatus";
 export { useGetWorkflowDefinition } from "./api/useGetWorkflowDefinition";
+export { useListAllWorkspaceWorkflows } from "./api/useListAllWorkspaceWorkflows";
+export type {
+  WorkspaceWorkflowEntry,
+  UseListAllWorkspaceWorkflowsResult,
+} from "./api/useListAllWorkspaceWorkflows";
 export { GraphRenderer } from "./ui";

--- a/frontend/src/features/policy-draft-read/model/usePolicyList.ts
+++ b/frontend/src/features/policy-draft-read/model/usePolicyList.ts
@@ -33,8 +33,9 @@ export function usePolicyList(
   }
 
   const payload = (query.data as { data?: PolicySummary[] } | PolicySummary[] | undefined);
-  const list: PolicySummary[] = Array.isArray(payload)
-    ? payload
-    : ((payload?.data ?? []) as PolicySummary[]);
-  return { status: "ready", data: list };
+  const list = Array.isArray(payload) ? payload : payload?.data;
+  if (!Array.isArray(list)) {
+    return { status: "error", code: "UNEXPECTED_RESPONSE", message: "Invalid policy list response shape" };
+  }
+  return { status: "ready", data: list as PolicySummary[] };
 }

--- a/frontend/src/features/policy-draft-read/model/usePolicyList.ts
+++ b/frontend/src/features/policy-draft-read/model/usePolicyList.ts
@@ -32,5 +32,9 @@ export function usePolicyList(
     return mapApiError(query.error);
   }
 
-  return { status: "ready", data: (query.data?.data ?? []) as unknown as PolicySummary[] };
+  const payload = (query.data as { data?: PolicySummary[] } | PolicySummary[] | undefined);
+  const list: PolicySummary[] = Array.isArray(payload)
+    ? payload
+    : ((payload?.data ?? []) as PolicySummary[]);
+  return { status: "ready", data: list };
 }

--- a/frontend/src/features/risk-draft-read/model/useRiskDetail.ts
+++ b/frontend/src/features/risk-draft-read/model/useRiskDetail.ts
@@ -23,8 +23,11 @@ export function useRiskDetail(
       if (riskId === null) {
         throw new Error("riskId is required");
       }
-      const res = await getRisk(workspaceId, packId, versionId, riskId);
-      return res.data;
+      const res = (await getRisk(workspaceId, packId, versionId, riskId)) as
+        | { data?: RiskDefinitionResponse }
+        | RiskDefinitionResponse;
+      const candidate = (res as { data?: RiskDefinitionResponse }).data;
+      return candidate ?? (res as RiskDefinitionResponse);
     },
     enabled: riskId !== null,
   });

--- a/frontend/src/features/risk-draft-read/model/useRiskList.ts
+++ b/frontend/src/features/risk-draft-read/model/useRiskList.ts
@@ -19,8 +19,11 @@ export function useRiskList(
   const query = useQuery({
     queryKey: ["risk", "list", workspaceId, packId, versionId],
     queryFn: async () => {
-      const res = await listRisks(workspaceId, packId, versionId);
-      return res.data;
+      const res = (await listRisks(workspaceId, packId, versionId)) as
+        | { data?: RiskDefinitionSummary[] }
+        | RiskDefinitionSummary[];
+      if (Array.isArray(res)) return res;
+      return res?.data ?? [];
     },
   });
 

--- a/frontend/src/features/slot-draft-read/model/useSlotDetail.ts
+++ b/frontend/src/features/slot-draft-read/model/useSlotDetail.ts
@@ -23,8 +23,11 @@ export function useSlotDetail(
       if (slotId === null) {
         throw new Error("slotId is required");
       }
-      const res = await getSlot(wsId, packId, versionId, slotId);
-      return res.data;
+      const res = (await getSlot(wsId, packId, versionId, slotId)) as
+        | { data?: SlotDefinitionResponse }
+        | SlotDefinitionResponse;
+      const candidate = (res as { data?: SlotDefinitionResponse }).data;
+      return candidate ?? (res as SlotDefinitionResponse);
     },
     enabled: slotId !== null,
   });

--- a/frontend/src/features/slot-draft-read/model/useSlotList.ts
+++ b/frontend/src/features/slot-draft-read/model/useSlotList.ts
@@ -22,7 +22,8 @@ export function useSlotList(
         | { data?: SlotDefinitionSummary[] }
         | SlotDefinitionSummary[];
       if (Array.isArray(res)) return res;
-      return res?.data ?? [];
+      if (Array.isArray(res?.data)) return res.data;
+      throw new Error("Unexpected slot list response shape");
     },
   });
 

--- a/frontend/src/features/slot-draft-read/model/useSlotList.ts
+++ b/frontend/src/features/slot-draft-read/model/useSlotList.ts
@@ -18,8 +18,11 @@ export function useSlotList(
   const query = useQuery({
     queryKey: ["slots", "list", wsId, packId, versionId],
     queryFn: async () => {
-      const res = await listSlots(wsId, packId, versionId);
-      return res.data;
+      const res = (await listSlots(wsId, packId, versionId)) as
+        | { data?: SlotDefinitionSummary[] }
+        | SlotDefinitionSummary[];
+      if (Array.isArray(res)) return res;
+      return res?.data ?? [];
     },
   });
 

--- a/frontend/src/features/update-workflow/index.ts
+++ b/frontend/src/features/update-workflow/index.ts
@@ -1,5 +1,6 @@
 export { WorkflowEditSheet } from "./ui/WorkflowEditSheet";
 export { WorkflowEditForm } from "./ui/WorkflowEditForm";
+export { InlineWorkflowEditor } from "./ui/InlineWorkflowEditor";
 export { InteractiveGraphEditor } from "./ui/InteractiveGraphEditor";
 export { useGetWorkflow } from "./api/useGetWorkflow";
 export { useUpdateWorkflow } from "./api/useUpdateWorkflow";

--- a/frontend/src/features/update-workflow/ui/InlineWorkflowEditor.test.tsx
+++ b/frontend/src/features/update-workflow/ui/InlineWorkflowEditor.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createElement, type ReactNode } from "react";
+import { InlineWorkflowEditor } from "./InlineWorkflowEditor";
+
+vi.mock("./WorkflowEditForm", () => ({
+  WorkflowEditForm: vi.fn(({ workflow, onClose }) =>
+    createElement(
+      "div",
+      { "data-testid": "edit-form" },
+      `editing ${workflow.workflowCode ?? workflow.id}`,
+      createElement(
+        "button",
+        { type: "button", "data-testid": "close-btn", onClick: onClose },
+        "close",
+      ),
+    ),
+  ),
+}));
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
+  });
+  return createElement(QueryClientProvider, { client }, children);
+}
+
+describe("InlineWorkflowEditor", () => {
+  it("workflow를 WorkflowEditForm에 그대로 전달한다", () => {
+    render(
+      <InlineWorkflowEditor
+        workflow={{ id: 100, workflowCode: "refund.standard", name: "환불 처리" }}
+        wsId={1}
+        packId={2}
+        versionId={3}
+        onClose={() => {}}
+      />,
+      { wrapper },
+    );
+    expect(screen.getByTestId("inline-workflow-editor")).toBeInTheDocument();
+    expect(screen.getByTestId("edit-form")).toHaveTextContent("editing refund.standard");
+  });
+
+  it("내부 close 버튼 클릭 시 onClose가 호출된다", () => {
+    const onClose = vi.fn();
+    render(
+      <InlineWorkflowEditor
+        workflow={{ id: 100, workflowCode: "refund.standard", name: "환불 처리" }}
+        wsId={1}
+        packId={2}
+        versionId={3}
+        onClose={onClose}
+      />,
+      { wrapper },
+    );
+    screen.getByTestId("close-btn").click();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/features/update-workflow/ui/InlineWorkflowEditor.tsx
+++ b/frontend/src/features/update-workflow/ui/InlineWorkflowEditor.tsx
@@ -1,0 +1,44 @@
+import type { WorkflowDetail } from "@/entities/workflow";
+import { WorkflowEditForm } from "./WorkflowEditForm";
+
+interface InlineWorkflowEditorProps {
+  workflow: WorkflowDetail;
+  wsId: number;
+  packId: number;
+  versionId: number;
+  onClose: () => void;
+}
+
+/**
+ * Inline workflow editor — same form as the legacy Sheet wrapper but mounted
+ * directly inside the workflow detail page (no modal/sheet chrome).
+ */
+export function InlineWorkflowEditor({
+  workflow,
+  wsId,
+  packId,
+  versionId,
+  onClose,
+}: InlineWorkflowEditorProps) {
+  return (
+    <div
+      data-testid="inline-workflow-editor"
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        height: "100%",
+        background: "var(--paper-2)",
+        border: "1px solid var(--line-2)",
+        borderRadius: "var(--r-2)",
+      }}
+    >
+      <WorkflowEditForm
+        workflow={workflow}
+        wsId={wsId}
+        packId={packId}
+        versionId={versionId}
+        onClose={onClose}
+      />
+    </div>
+  );
+}

--- a/frontend/src/features/workflow-list/index.ts
+++ b/frontend/src/features/workflow-list/index.ts
@@ -1,0 +1,4 @@
+export { WorkflowListView } from "./ui/WorkflowListView";
+export { WorkflowCard } from "./ui/WorkflowCard";
+export { WorkflowSearchBar } from "./ui/WorkflowSearchBar";
+export { WorkflowGraphMini } from "./ui/WorkflowGraphMini";

--- a/frontend/src/features/workflow-list/ui/WorkflowCard.test.tsx
+++ b/frontend/src/features/workflow-list/ui/WorkflowCard.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+import type { WorkspaceWorkflowEntry } from "@/entities/workflow";
+import { WorkflowCard } from "./WorkflowCard";
+
+vi.mock("./WorkflowGraphMini", () => ({
+  WorkflowGraphMini: () => <div data-testid="graph-mini-stub" />,
+}));
+
+const ENTRY: WorkspaceWorkflowEntry = {
+  packId: 2,
+  packName: "Refund",
+  versionId: 3,
+  workflowId: 42,
+  workflowCode: "wf.refund",
+  name: "환불 워크플로우",
+  description: "환불 요청 처리",
+};
+
+function setup(overrides: Partial<React.ComponentProps<typeof WorkflowCard>> = {}) {
+  const defaults: React.ComponentProps<typeof WorkflowCard> = {
+    entry: ENTRY,
+    expanded: false,
+    onToggle: vi.fn(),
+    onOpen: vi.fn(),
+  };
+  return render(
+    <MemoryRouter>
+      <WorkflowCard {...defaults} {...overrides} />
+    </MemoryRouter>,
+  );
+}
+
+describe("WorkflowCard", () => {
+  it("기본(접힘) 상태에서는 graph mini, description, 열기 버튼이 보이지 않는다", () => {
+    setup();
+    expect(screen.queryByTestId("workflow-list-card-42-graph")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("workflow-list-card-42-detail")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("workflow-list-card-42-open")).not.toBeInTheDocument();
+  });
+
+  it("기본 상태에서 헤더의 pack 이름과 워크플로우 코드를 표시한다", () => {
+    setup();
+    expect(screen.getByText("Refund")).toBeInTheDocument();
+    expect(screen.getByText("wf.refund")).toBeInTheDocument();
+    expect(screen.getByText("환불 워크플로우")).toBeInTheDocument();
+  });
+
+  it("카드 클릭 시 onToggle 호출", () => {
+    const onToggle = vi.fn();
+    setup({ onToggle });
+    fireEvent.click(screen.getByTestId("workflow-list-card-42-toggle"));
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it("expanded=true 일 때 graph mini, description, 열기 버튼이 노출된다", () => {
+    setup({ expanded: true });
+    expect(screen.getByTestId("workflow-list-card-42-graph")).toBeInTheDocument();
+    expect(screen.getByTestId("workflow-list-card-42-detail")).toBeInTheDocument();
+    expect(screen.getByText("환불 요청 처리")).toBeInTheDocument();
+    expect(screen.getByTestId("workflow-list-card-42-open")).toBeInTheDocument();
+  });
+
+  it("열기 버튼 클릭 시 onOpen 호출 (onToggle 은 호출되지 않음)", () => {
+    const onToggle = vi.fn();
+    const onOpen = vi.fn();
+    setup({ expanded: true, onToggle, onOpen });
+    fireEvent.click(screen.getByTestId("workflow-list-card-42-open"));
+    expect(onOpen).toHaveBeenCalledTimes(1);
+    expect(onToggle).not.toHaveBeenCalled();
+  });
+
+  it("testIdPrefix 를 적용하면 모든 testId 가 그 prefix 를 사용한다", () => {
+    setup({ testIdPrefix: "pack-workflows", expanded: true });
+    expect(screen.getByTestId("pack-workflows-card-42")).toBeInTheDocument();
+    expect(screen.getByTestId("pack-workflows-card-42-open")).toBeInTheDocument();
+  });
+
+  it("description 이 없으면 detail 영역에서 설명 단락을 건너뛴다", () => {
+    setup({
+      expanded: true,
+      entry: { ...ENTRY, description: null },
+    });
+    expect(screen.queryByText("환불 요청 처리")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/workflow-list/ui/WorkflowCard.tsx
+++ b/frontend/src/features/workflow-list/ui/WorkflowCard.tsx
@@ -1,0 +1,91 @@
+import type { WorkspaceWorkflowEntry } from "@/entities/workflow";
+import { Mono, Pill } from "@/shared/ui/ostone/atoms";
+
+import { WorkflowGraphMini } from "./WorkflowGraphMini";
+import styles from "./workflow-card.module.css";
+
+interface WorkflowCardProps {
+  entry: WorkspaceWorkflowEntry;
+  expanded: boolean;
+  onToggle: () => void;
+  onOpen: () => void;
+  testIdPrefix?: string;
+}
+
+export function WorkflowCard({
+  entry,
+  expanded,
+  onToggle,
+  onOpen,
+  testIdPrefix = "workflow-list",
+}: WorkflowCardProps) {
+  const cardTestId = `${testIdPrefix}-card-${entry.workflowId}`;
+
+  return (
+    <article
+      className={styles.card}
+      data-testid={cardTestId}
+      data-expanded={expanded ? "true" : "false"}
+    >
+      <button
+        type="button"
+        className={styles.cardBody}
+        onClick={onToggle}
+        data-testid={`${cardTestId}-toggle`}
+      >
+        {expanded && (
+          <div
+            className={styles.graphSlot}
+            data-testid={`${cardTestId}-graph`}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <WorkflowGraphMini
+              workspaceId={null /* derived from packId via context — see WorkflowListView */}
+              packId={entry.packId}
+              versionId={entry.versionId}
+              workflowId={entry.workflowId}
+            />
+          </div>
+        )}
+
+        <div className={styles.header}>
+          <Pill tone="mute">{entry.packName}</Pill>
+          {entry.workflowCode && <Mono className={styles.code}>{entry.workflowCode}</Mono>}
+        </div>
+
+        <div className={styles.content}>
+          <h2 className={styles.title}>{entry.name}</h2>
+        </div>
+
+        {expanded && (
+          <div className={styles.detail} data-testid={`${cardTestId}-detail`}>
+            {entry.description && <p className={styles.description}>{entry.description}</p>}
+            <Mono className={styles.meta}>
+              pack #{entry.packId} · version #{entry.versionId}
+            </Mono>
+          </div>
+        )}
+      </button>
+
+      <div className={styles.footer}>
+        {expanded ? (
+          <button
+            type="button"
+            className={styles.openBtn}
+            onClick={(e) => {
+              e.stopPropagation();
+              onOpen();
+            }}
+            data-testid={`${cardTestId}-open`}
+          >
+            열기
+          </button>
+        ) : (
+          <Mono className={styles.meta}>
+            pack #{entry.packId} · version #{entry.versionId}
+          </Mono>
+        )}
+      </div>
+    </article>
+  );
+}

--- a/frontend/src/features/workflow-list/ui/WorkflowCard.tsx
+++ b/frontend/src/features/workflow-list/ui/WorkflowCard.tsx
@@ -1,8 +1,13 @@
+import { useEffect, useRef, useState } from "react";
+
 import type { WorkspaceWorkflowEntry } from "@/entities/workflow";
 import { Mono, Pill } from "@/shared/ui/ostone/atoms";
 
 import { WorkflowGraphMini } from "./WorkflowGraphMini";
 import styles from "./workflow-card.module.css";
+
+const ROW_UNIT_PX = 10;
+const ROW_GAP_PX = 8;
 
 interface WorkflowCardProps {
   entry: WorkspaceWorkflowEntry;
@@ -20,12 +25,30 @@ export function WorkflowCard({
   testIdPrefix = "workflow-list",
 }: WorkflowCardProps) {
   const cardTestId = `${testIdPrefix}-card-${entry.workflowId}`;
+  const cardRef = useRef<HTMLElement>(null);
+  const [rowSpan, setRowSpan] = useState(20);
+
+  useEffect(() => {
+    const el = cardRef.current;
+    if (!el) return;
+    const recompute = () => {
+      const h = el.getBoundingClientRect().height;
+      const span = Math.max(1, Math.ceil((h + ROW_GAP_PX) / (ROW_UNIT_PX + ROW_GAP_PX)));
+      setRowSpan(span);
+    };
+    recompute();
+    const observer = new ResizeObserver(recompute);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [expanded]);
 
   return (
     <article
+      ref={cardRef}
       className={styles.card}
       data-testid={cardTestId}
       data-expanded={expanded ? "true" : "false"}
+      style={{ gridRow: `span ${rowSpan}` }}
     >
       <button
         type="button"

--- a/frontend/src/features/workflow-list/ui/WorkflowCard.tsx
+++ b/frontend/src/features/workflow-list/ui/WorkflowCard.tsx
@@ -61,6 +61,7 @@ export function WorkflowCard({
             className={styles.graphSlot}
             data-testid={`${cardTestId}-graph`}
             onClick={(e) => e.stopPropagation()}
+            onKeyDown={(e) => e.stopPropagation()}
           >
             <WorkflowGraphMini
               workspaceId={null /* derived from packId via context — see WorkflowListView */}

--- a/frontend/src/features/workflow-list/ui/WorkflowGraphMini.test.tsx
+++ b/frontend/src/features/workflow-list/ui/WorkflowGraphMini.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+
+import { WorkflowGraphMini } from "./WorkflowGraphMini";
+
+const mockUseGetWorkflowDefinition = vi.fn();
+vi.mock("@/entities/workflow", () => ({
+  useGetWorkflowDefinition: (...args: unknown[]) => mockUseGetWorkflowDefinition(...args),
+}));
+
+function renderMini(workspaceId: number | null, packId = 2, versionId = 3, workflowId = 10) {
+  return render(
+    <MemoryRouter initialEntries={["/workspaces/1/something"]}>
+      <Routes>
+        <Route
+          path="/workspaces/:workspaceId/*"
+          element={
+            <WorkflowGraphMini
+              workspaceId={workspaceId}
+              packId={packId}
+              versionId={versionId}
+              workflowId={workflowId}
+            />
+          }
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  mockUseGetWorkflowDefinition.mockReset();
+});
+
+describe("WorkflowGraphMini", () => {
+  it("isLoading 시 loading placeholder 노출", () => {
+    mockUseGetWorkflowDefinition.mockReturnValue({ isLoading: true });
+    renderMini(null);
+    expect(screen.getByTestId("workflow-graph-mini-loading-10")).toBeInTheDocument();
+  });
+
+  it("isError 시 unavailable 메시지 노출", () => {
+    mockUseGetWorkflowDefinition.mockReturnValue({ isLoading: false, isError: true });
+    renderMini(null);
+    expect(screen.getByTestId("workflow-graph-mini-error-10")).toBeInTheDocument();
+  });
+
+  it("graphJson 이 빈 객체이면 empty graph 표시", () => {
+    mockUseGetWorkflowDefinition.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: { graphJson: { nodes: [], edges: [] } },
+    });
+    renderMini(null);
+    expect(screen.getByTestId("workflow-graph-mini-empty-10")).toBeInTheDocument();
+  });
+
+  it("graphJson 이 string 으로 전달되면 파싱하여 노드 도식 렌더", () => {
+    mockUseGetWorkflowDefinition.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: {
+        graphJson: JSON.stringify({
+          nodes: [
+            { id: "a", position: { x: 0, y: 0 } },
+            { id: "b", position: { x: 100, y: 50 } },
+          ],
+          edges: [{ source: "a", target: "b" }],
+        }),
+      },
+    });
+    renderMini(null);
+    const svg = screen.getByTestId("workflow-graph-mini-10");
+    expect(svg).toBeInTheDocument();
+    expect(svg.querySelectorAll("circle").length).toBe(2);
+    expect(svg.querySelectorAll("line").length).toBe(1);
+  });
+
+  it("graphJson 이 손상되면 empty 처리", () => {
+    mockUseGetWorkflowDefinition.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: { graphJson: "{not-json" },
+    });
+    renderMini(null);
+    expect(screen.getByTestId("workflow-graph-mini-empty-10")).toBeInTheDocument();
+  });
+
+  it("workspaceId prop 으로 직접 전달하면 useParams 보다 우선한다", () => {
+    mockUseGetWorkflowDefinition.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: {
+        graphJson: { nodes: [{ id: "a", position: { x: 0, y: 0 } }], edges: [] },
+      },
+    });
+    renderMini(7, 1, 2, 3);
+    expect(mockUseGetWorkflowDefinition).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceId: 7, packId: 1, versionId: 2, workflowId: 3 }),
+    );
+  });
+});

--- a/frontend/src/features/workflow-list/ui/WorkflowGraphMini.test.tsx
+++ b/frontend/src/features/workflow-list/ui/WorkflowGraphMini.test.tsx
@@ -56,17 +56,17 @@ describe("WorkflowGraphMini", () => {
     expect(screen.getByTestId("workflow-graph-mini-empty-10")).toBeInTheDocument();
   });
 
-  it("graphJson 이 string 으로 전달되면 파싱하여 노드 도식 렌더", () => {
+  it("graphJson 이 string 으로 전달되면 파싱하여 노드+엣지+라벨 렌더", () => {
     mockUseGetWorkflowDefinition.mockReturnValue({
       isLoading: false,
       isError: false,
       data: {
         graphJson: JSON.stringify({
           nodes: [
-            { id: "a", position: { x: 0, y: 0 } },
-            { id: "b", position: { x: 100, y: 50 } },
+            { id: "a", label: "start", position: { x: 0, y: 0 } },
+            { id: "b", label: "check_status", position: { x: 100, y: 50 } },
           ],
-          edges: [{ source: "a", target: "b" }],
+          edges: [{ id: "e1", from: "a", to: "b" }],
         }),
       },
     });
@@ -75,6 +75,41 @@ describe("WorkflowGraphMini", () => {
     expect(svg).toBeInTheDocument();
     expect(svg.querySelectorAll("circle").length).toBe(2);
     expect(svg.querySelectorAll("line").length).toBe(1);
+    expect(svg.querySelectorAll("text").length).toBe(2);
+    expect(svg.textContent).toContain("start");
+  });
+
+  it("legacy source/target 형식도 fallback 지원한다", () => {
+    mockUseGetWorkflowDefinition.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: {
+        graphJson: {
+          nodes: [
+            { id: "a", position: { x: 0, y: 0 } },
+            { id: "b", position: { x: 50, y: 0 } },
+          ],
+          edges: [{ source: "a", target: "b" }],
+        },
+      },
+    });
+    renderMini(null);
+    expect(screen.getByTestId("workflow-graph-mini-10").querySelectorAll("line").length).toBe(1);
+  });
+
+  it("라벨이 14자 초과면 말줄임표로 잘린다", () => {
+    mockUseGetWorkflowDefinition.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: {
+        graphJson: {
+          nodes: [{ id: "a", label: "abcdefghijklmnopqrstuvwxyz", position: { x: 0, y: 0 } }],
+          edges: [],
+        },
+      },
+    });
+    renderMini(null);
+    expect(screen.getByTestId("workflow-graph-mini-10").textContent).toContain("…");
   });
 
   it("graphJson 이 손상되면 empty 처리", () => {

--- a/frontend/src/features/workflow-list/ui/WorkflowGraphMini.tsx
+++ b/frontend/src/features/workflow-list/ui/WorkflowGraphMini.tsx
@@ -10,11 +10,107 @@ interface WorkflowGraphMiniProps {
   workflowId: number;
 }
 
+type NodeType = "START" | "ACTION" | "DECISION" | "ANSWER" | "HANDOFF" | "TERMINAL" | "UNKNOWN";
+
 interface ParsedNode {
   id: string;
   label: string;
+  type: NodeType;
   x: number;
   y: number;
+}
+
+function pickType(v: unknown): NodeType {
+  if (typeof v !== "string") return "UNKNOWN";
+  const upper = v.toUpperCase();
+  switch (upper) {
+    case "START":
+    case "ACTION":
+    case "DECISION":
+    case "ANSWER":
+    case "HANDOFF":
+    case "TERMINAL":
+      return upper;
+    default:
+      return "UNKNOWN";
+  }
+}
+
+function NodeShape({ node }: { node: ParsedNode }) {
+  const { x, y, type } = node;
+  const w = 18;
+  const h = 11;
+  const stroke = "var(--ink)";
+  const paper = "var(--paper)";
+  const ink = "var(--ink)";
+  const sw = 1.4;
+  switch (type) {
+    case "START":
+      return (
+        <rect
+          x={x - w / 2}
+          y={y - h / 2}
+          width={w}
+          height={h}
+          rx={h / 2}
+          ry={h / 2}
+          fill={ink}
+          stroke={stroke}
+          strokeWidth={sw}
+        />
+      );
+    case "ACTION":
+      return (
+        <rect
+          x={x - w / 2}
+          y={y - h / 2}
+          width={w}
+          height={h}
+          rx={2}
+          ry={2}
+          fill={paper}
+          stroke={stroke}
+          strokeWidth={sw}
+        />
+      );
+    case "DECISION": {
+      const r = 8;
+      return (
+        <polygon
+          points={`${x},${y - r} ${x + r},${y} ${x},${y + r} ${x - r},${y}`}
+          fill={paper}
+          stroke={stroke}
+          strokeWidth={sw}
+        />
+      );
+    }
+    case "ANSWER": {
+      const cut = 3;
+      return (
+        <polygon
+          points={`${x - w / 2 + cut},${y - h / 2} ${x + w / 2},${y - h / 2} ${x + w / 2},${y + h / 2} ${x - w / 2},${y + h / 2}`}
+          fill={paper}
+          stroke={stroke}
+          strokeWidth={sw}
+        />
+      );
+    }
+    case "HANDOFF": {
+      const cut = 3;
+      return (
+        <polygon
+          points={`${x - w / 2 + cut},${y - h / 2} ${x + w / 2 - cut},${y - h / 2} ${x + w / 2},${y + h / 2} ${x - w / 2},${y + h / 2}`}
+          fill={paper}
+          stroke={stroke}
+          strokeWidth={sw}
+        />
+      );
+    }
+    case "TERMINAL":
+      return <circle cx={x} cy={y} r={7} fill={ink} stroke={stroke} strokeWidth={sw} />;
+    default:
+      return <circle cx={x} cy={y} r={6} fill={paper} stroke={stroke} strokeWidth={sw} />;
+  }
 }
 
 interface ParsedEdge {
@@ -44,12 +140,13 @@ function safeParseGraph(graphJson: unknown): {
     const root = parsed as { nodes?: unknown; edges?: unknown };
     const nodes = Array.isArray(root.nodes)
       ? root.nodes
-          .filter((n): n is { id: string; label?: string; position?: { x?: number; y?: number } } => {
+          .filter((n): n is { id: string; type?: unknown; label?: string; position?: { x?: number; y?: number } } => {
             return typeof n === "object" && n !== null && typeof (n as { id?: unknown }).id === "string";
           })
           .map<ParsedNode>((n, idx) => ({
             id: n.id,
             label: typeof n.label === "string" && n.label.length > 0 ? n.label : n.id,
+            type: pickType(n.type),
             x: typeof n.position?.x === "number" ? n.position.x : idx * 60,
             y: typeof n.position?.y === "number" ? n.position.y : 0,
           }))
@@ -163,11 +260,11 @@ export function WorkflowGraphMini({
         );
       })}
       {nodes.map((n) => (
-        <g key={n.id}>
-          <circle cx={n.x} cy={n.y} r={7} fill="var(--paper)" stroke="var(--ink)" strokeWidth={1.5} />
+        <g key={n.id} data-node-type={n.type}>
+          <NodeShape node={n} />
           <text
             x={n.x}
-            y={n.y - 12}
+            y={n.y - 14}
             textAnchor="middle"
             fontSize={10}
             fontFamily="var(--mono)"

--- a/frontend/src/features/workflow-list/ui/WorkflowGraphMini.tsx
+++ b/frontend/src/features/workflow-list/ui/WorkflowGraphMini.tsx
@@ -1,0 +1,162 @@
+import { useParams } from "react-router-dom";
+
+import { useGetWorkflowDefinition } from "@/entities/workflow";
+
+interface WorkflowGraphMiniProps {
+  /** When null the workspaceId is pulled from route params. */
+  workspaceId: number | null;
+  packId: number;
+  versionId: number;
+  workflowId: number;
+}
+
+interface ParsedNode {
+  id: string;
+  x: number;
+  y: number;
+}
+
+interface ParsedEdge {
+  source: string;
+  target: string;
+}
+
+function safeParseGraph(graphJson: unknown): {
+  nodes: ParsedNode[];
+  edges: ParsedEdge[];
+} {
+  if (graphJson === undefined || graphJson === null) return { nodes: [], edges: [] };
+  let parsed: unknown = graphJson;
+  if (typeof graphJson === "string") {
+    try {
+      parsed = JSON.parse(graphJson);
+    } catch {
+      return { nodes: [], edges: [] };
+    }
+  }
+  try {
+    if (typeof parsed !== "object" || parsed === null) return { nodes: [], edges: [] };
+    const root = parsed as { nodes?: unknown; edges?: unknown };
+    const nodes = Array.isArray(root.nodes)
+      ? root.nodes
+          .filter((n): n is { id: string; position?: { x?: number; y?: number } } => {
+            return typeof n === "object" && n !== null && typeof (n as { id?: unknown }).id === "string";
+          })
+          .map<ParsedNode>((n, idx) => ({
+            id: n.id,
+            x: typeof n.position?.x === "number" ? n.position.x : idx * 60,
+            y: typeof n.position?.y === "number" ? n.position.y : 0,
+          }))
+      : [];
+    const edges = Array.isArray(root.edges)
+      ? root.edges
+          .filter(
+            (e): e is { source: string; target: string } =>
+              typeof e === "object" &&
+              e !== null &&
+              typeof (e as { source?: unknown }).source === "string" &&
+              typeof (e as { target?: unknown }).target === "string",
+          )
+          .map<ParsedEdge>((e) => ({ source: e.source, target: e.target }))
+      : [];
+    return { nodes, edges };
+  } catch {
+    return { nodes: [], edges: [] };
+  }
+}
+
+export function WorkflowGraphMini({
+  workspaceId,
+  packId,
+  versionId,
+  workflowId,
+}: WorkflowGraphMiniProps) {
+  const params = useParams();
+  const wsIdRaw = workspaceId ?? (params.workspaceId ? Number(params.workspaceId) : NaN);
+  const wsId = Number.isFinite(wsIdRaw) ? wsIdRaw : 0;
+  const enabled = wsId > 0 && packId > 0 && versionId > 0 && workflowId > 0;
+
+  const query = useGetWorkflowDefinition({
+    workspaceId: wsId,
+    packId,
+    versionId,
+    workflowId,
+    enabled,
+  });
+
+  if (!enabled || query.isLoading) {
+    return (
+      <span
+        data-testid={`workflow-graph-mini-loading-${workflowId}`}
+        style={{ fontFamily: "var(--mono)", fontSize: "10px", color: "var(--ink-3)" }}
+      >
+        loading…
+      </span>
+    );
+  }
+
+  if (query.isError || !query.data) {
+    return (
+      <span
+        data-testid={`workflow-graph-mini-error-${workflowId}`}
+        style={{ fontFamily: "var(--mono)", fontSize: "10px", color: "var(--danger)" }}
+      >
+        graph unavailable
+      </span>
+    );
+  }
+
+  const { nodes, edges } = safeParseGraph((query.data as { graphJson?: unknown }).graphJson);
+  if (nodes.length === 0) {
+    return (
+      <span
+        data-testid={`workflow-graph-mini-empty-${workflowId}`}
+        style={{ fontFamily: "var(--mono)", fontSize: "10px", color: "var(--ink-3)" }}
+      >
+        empty graph
+      </span>
+    );
+  }
+
+  const xs = nodes.map((n) => n.x);
+  const ys = nodes.map((n) => n.y);
+  const minX = Math.min(...xs);
+  const maxX = Math.max(...xs);
+  const minY = Math.min(...ys);
+  const maxY = Math.max(...ys);
+  const pad = 30;
+  const width = Math.max(1, maxX - minX) + pad * 2;
+  const height = Math.max(1, maxY - minY) + pad * 2;
+  const nodeById = new Map(nodes.map((n) => [n.id, n] as const));
+
+  return (
+    <svg
+      data-testid={`workflow-graph-mini-${workflowId}`}
+      viewBox={`${minX - pad} ${minY - pad} ${width} ${height}`}
+      preserveAspectRatio="xMidYMid meet"
+      width="100%"
+      height="100%"
+      style={{ display: "block" }}
+    >
+      {edges.map((edge, idx) => {
+        const s = nodeById.get(edge.source);
+        const t = nodeById.get(edge.target);
+        if (!s || !t) return null;
+        return (
+          <line
+            key={`e${idx}`}
+            x1={s.x}
+            y1={s.y}
+            x2={t.x}
+            y2={t.y}
+            stroke="var(--line)"
+            strokeWidth={1.5}
+          />
+        );
+      })}
+      {nodes.map((n) => (
+        <circle key={n.id} cx={n.x} cy={n.y} r={8} fill="var(--paper)" stroke="var(--ink)" strokeWidth={1.5} />
+      ))}
+    </svg>
+  );
+}

--- a/frontend/src/features/workflow-list/ui/WorkflowGraphMini.tsx
+++ b/frontend/src/features/workflow-list/ui/WorkflowGraphMini.tsx
@@ -243,13 +243,13 @@ export function WorkflowGraphMini({
       height="100%"
       style={{ display: "block" }}
     >
-      {edges.map((edge, idx) => {
+      {edges.map((edge) => {
         const s = nodeById.get(edge.from);
         const t = nodeById.get(edge.to);
         if (!s || !t) return null;
         return (
           <line
-            key={`e${idx}`}
+            key={`${edge.from}→${edge.to}`}
             x1={s.x}
             y1={s.y}
             x2={t.x}

--- a/frontend/src/features/workflow-list/ui/WorkflowGraphMini.tsx
+++ b/frontend/src/features/workflow-list/ui/WorkflowGraphMini.tsx
@@ -12,13 +12,18 @@ interface WorkflowGraphMiniProps {
 
 interface ParsedNode {
   id: string;
+  label: string;
   x: number;
   y: number;
 }
 
 interface ParsedEdge {
-  source: string;
-  target: string;
+  from: string;
+  to: string;
+}
+
+function pickEndpoint(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
 }
 
 function safeParseGraph(graphJson: unknown): {
@@ -39,25 +44,27 @@ function safeParseGraph(graphJson: unknown): {
     const root = parsed as { nodes?: unknown; edges?: unknown };
     const nodes = Array.isArray(root.nodes)
       ? root.nodes
-          .filter((n): n is { id: string; position?: { x?: number; y?: number } } => {
+          .filter((n): n is { id: string; label?: string; position?: { x?: number; y?: number } } => {
             return typeof n === "object" && n !== null && typeof (n as { id?: unknown }).id === "string";
           })
           .map<ParsedNode>((n, idx) => ({
             id: n.id,
+            label: typeof n.label === "string" && n.label.length > 0 ? n.label : n.id,
             x: typeof n.position?.x === "number" ? n.position.x : idx * 60,
             y: typeof n.position?.y === "number" ? n.position.y : 0,
           }))
       : [];
     const edges = Array.isArray(root.edges)
       ? root.edges
-          .filter(
-            (e): e is { source: string; target: string } =>
-              typeof e === "object" &&
-              e !== null &&
-              typeof (e as { source?: unknown }).source === "string" &&
-              typeof (e as { target?: unknown }).target === "string",
-          )
-          .map<ParsedEdge>((e) => ({ source: e.source, target: e.target }))
+          .map<ParsedEdge | null>((e) => {
+            if (typeof e !== "object" || e === null) return null;
+            const raw = e as { from?: unknown; to?: unknown; source?: unknown; target?: unknown };
+            const from = pickEndpoint(raw.from) ?? pickEndpoint(raw.source);
+            const to = pickEndpoint(raw.to) ?? pickEndpoint(raw.target);
+            if (!from || !to) return null;
+            return { from, to };
+          })
+          .filter((e): e is ParsedEdge => e !== null)
       : [];
     return { nodes, edges };
   } catch {
@@ -124,23 +131,24 @@ export function WorkflowGraphMini({
   const maxX = Math.max(...xs);
   const minY = Math.min(...ys);
   const maxY = Math.max(...ys);
-  const pad = 30;
-  const width = Math.max(1, maxX - minX) + pad * 2;
-  const height = Math.max(1, maxY - minY) + pad * 2;
+  const padX = 40;
+  const padY = 36;
+  const width = Math.max(1, maxX - minX) + padX * 2;
+  const height = Math.max(1, maxY - minY) + padY * 2;
   const nodeById = new Map(nodes.map((n) => [n.id, n] as const));
 
   return (
     <svg
       data-testid={`workflow-graph-mini-${workflowId}`}
-      viewBox={`${minX - pad} ${minY - pad} ${width} ${height}`}
+      viewBox={`${minX - padX} ${minY - padY} ${width} ${height}`}
       preserveAspectRatio="xMidYMid meet"
       width="100%"
       height="100%"
       style={{ display: "block" }}
     >
       {edges.map((edge, idx) => {
-        const s = nodeById.get(edge.source);
-        const t = nodeById.get(edge.target);
+        const s = nodeById.get(edge.from);
+        const t = nodeById.get(edge.to);
         if (!s || !t) return null;
         return (
           <line
@@ -149,13 +157,26 @@ export function WorkflowGraphMini({
             y1={s.y}
             x2={t.x}
             y2={t.y}
-            stroke="var(--line)"
-            strokeWidth={1.5}
+            stroke="var(--ink-3)"
+            strokeWidth={1.2}
           />
         );
       })}
       {nodes.map((n) => (
-        <circle key={n.id} cx={n.x} cy={n.y} r={8} fill="var(--paper)" stroke="var(--ink)" strokeWidth={1.5} />
+        <g key={n.id}>
+          <circle cx={n.x} cy={n.y} r={7} fill="var(--paper)" stroke="var(--ink)" strokeWidth={1.5} />
+          <text
+            x={n.x}
+            y={n.y - 12}
+            textAnchor="middle"
+            fontSize={10}
+            fontFamily="var(--mono)"
+            fill="var(--ink-2)"
+            style={{ pointerEvents: "none" }}
+          >
+            {n.label.length > 14 ? `${n.label.slice(0, 13)}…` : n.label}
+          </text>
+        </g>
       ))}
     </svg>
   );

--- a/frontend/src/features/workflow-list/ui/WorkflowListView.test.tsx
+++ b/frontend/src/features/workflow-list/ui/WorkflowListView.test.tsx
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+import type { WorkspaceWorkflowEntry } from "@/entities/workflow";
+import { WorkflowListView } from "./WorkflowListView";
+
+vi.mock("./WorkflowGraphMini", () => ({
+  WorkflowGraphMini: () => <div data-testid="graph-mini-stub" />,
+}));
+
+function makeEntry(id: number, name = `wf-${id}`, code = `wf.${String(id).padStart(2, "0")}`): WorkspaceWorkflowEntry {
+  return {
+    packId: 2,
+    packName: "Pack",
+    versionId: 3,
+    workflowId: id,
+    workflowCode: code,
+    name,
+    description: `desc-${id}`,
+  };
+}
+
+function setup(entries: WorkspaceWorkflowEntry[], onOpen = vi.fn()) {
+  return {
+    onOpen,
+    ...render(
+      <MemoryRouter>
+        <WorkflowListView entries={entries} onOpen={onOpen} testIdPrefix="wl" />
+      </MemoryRouter>,
+    ),
+  };
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe("WorkflowListView", () => {
+  const big = Array.from({ length: 20 }, (_, i) => makeEntry(i + 1, `wf-${String(i).padStart(2, "0")}`));
+
+  it("처음에는 기본 page size(12) 만큼만 그리고 pagination 이 노출된다", () => {
+    setup(big);
+    expect(screen.getByTestId("wl-card-1")).toBeInTheDocument();
+    expect(screen.getByTestId("wl-card-12")).toBeInTheDocument();
+    expect(screen.queryByTestId("wl-card-13")).not.toBeInTheDocument();
+    expect(screen.getByTestId("wl-pagination-info")).toHaveTextContent("1 / 2");
+  });
+
+  it("Next 버튼 클릭 시 다음 페이지로 이동", () => {
+    setup(big);
+    fireEvent.click(screen.getByTestId("wl-pagination-next"));
+    expect(screen.getByTestId("wl-pagination-info")).toHaveTextContent("2 / 2");
+    expect(screen.getByTestId("wl-card-13")).toBeInTheDocument();
+  });
+
+  it("settings 톱니 토글로 panel 펼침/접힘", () => {
+    setup(big);
+    expect(screen.queryByTestId("wl-settings")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("wl-settings-toggle"));
+    expect(screen.getByTestId("wl-settings")).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("wl-settings-toggle"));
+    expect(screen.queryByTestId("wl-settings")).not.toBeInTheDocument();
+  });
+
+  it("page size 6 으로 변경 시 즉시 카드 수와 pagination 갱신", () => {
+    setup(big);
+    fireEvent.click(screen.getByTestId("wl-settings-toggle"));
+    fireEvent.click(screen.getByTestId("wl-settings-pageSize-6"));
+    expect(screen.getByTestId("wl-card-6")).toBeInTheDocument();
+    expect(screen.queryByTestId("wl-card-7")).not.toBeInTheDocument();
+    expect(screen.getByTestId("wl-pagination-info")).toHaveTextContent(/^1 \/ 4$/);
+  });
+
+  it("이름 기준 desc 정렬 시 카드 순서가 역전된다", () => {
+    setup(big);
+    fireEvent.click(screen.getByTestId("wl-settings-toggle"));
+    fireEvent.click(screen.getByTestId("wl-settings-sortField-name"));
+    fireEvent.click(screen.getByTestId("wl-settings-sortDir-desc"));
+    const masonry = screen.getByTestId("wl-masonry");
+    const cards = masonry.querySelectorAll<HTMLElement>('[data-testid^="wl-card-"]');
+    expect(cards[0].dataset.testid).toBe("wl-card-20");
+  });
+
+  it("카드 클릭 시 펼침 상태가 토글된다", () => {
+    setup([makeEntry(1)]);
+    const card = screen.getByTestId("wl-card-1");
+    expect(card.dataset.expanded).toBe("false");
+    fireEvent.click(screen.getByTestId("wl-card-1-toggle"));
+    expect(screen.getByTestId("wl-card-1").dataset.expanded).toBe("true");
+    fireEvent.click(screen.getByTestId("wl-card-1-toggle"));
+    expect(screen.getByTestId("wl-card-1").dataset.expanded).toBe("false");
+  });
+
+  it("열기 버튼 클릭 시 onOpen 콜백이 entry 와 함께 호출된다", () => {
+    const onOpen = vi.fn();
+    setup([makeEntry(7, "Lucky")], onOpen);
+    fireEvent.click(screen.getByTestId("wl-card-7-toggle"));
+    fireEvent.click(screen.getByTestId("wl-card-7-open"));
+    expect(onOpen).toHaveBeenCalledWith(expect.objectContaining({ workflowId: 7, name: "Lucky" }));
+  });
+
+  it("검색바 입력 후 dropdown 항목 클릭 시 그리드가 그 워크플로우만 남고 필터 칩이 표시된다", () => {
+    setup(big);
+    fireEvent.change(screen.getByTestId("wl-search-input"), { target: { value: "wf-15" } });
+    fireEvent.click(screen.getByTestId("wl-search-item-16"));
+    expect(screen.getByTestId("wl-card-16")).toBeInTheDocument();
+    expect(screen.queryByTestId("wl-card-1")).not.toBeInTheDocument();
+    const chip = screen.getByTestId("wl-filter-chip");
+    expect(chip).toHaveTextContent("wf-15");
+  });
+
+  it("필터 칩 클릭 시 필터가 해제되고 그리드가 전체로 복원된다", () => {
+    setup(big);
+    fireEvent.change(screen.getByTestId("wl-search-input"), { target: { value: "wf-15" } });
+    fireEvent.click(screen.getByTestId("wl-search-item-16"));
+    fireEvent.click(screen.getByTestId("wl-filter-chip"));
+    expect(screen.queryByTestId("wl-filter-chip")).not.toBeInTheDocument();
+    expect(screen.getByTestId("wl-card-1")).toBeInTheDocument();
+  });
+
+  it("settings 변경이 localStorage 에 영속화된다", () => {
+    setup(big);
+    fireEvent.click(screen.getByTestId("wl-settings-toggle"));
+    fireEvent.click(screen.getByTestId("wl-settings-pageSize-24"));
+    const raw = window.localStorage.getItem("ostone:page:workflow-settings");
+    expect(raw).not.toBeNull();
+    expect(JSON.parse(raw!)).toMatchObject({ pageSize: 24 });
+  });
+
+  it("빈 entries 도 안전하게 렌더한다 (search 만 노출, masonry empty)", () => {
+    render(
+      <MemoryRouter>
+        <WorkflowListView entries={[]} onOpen={vi.fn()} testIdPrefix="wl" />
+      </MemoryRouter>,
+    );
+    expect(screen.getByTestId("wl-masonry")).toBeInTheDocument();
+    expect(screen.queryByTestId("wl-pagination")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/workflow-list/ui/WorkflowListView.tsx
+++ b/frontend/src/features/workflow-list/ui/WorkflowListView.tsx
@@ -11,6 +11,7 @@ import {
   writePageWorkflowSettings,
   type PageWorkflowSettings,
 } from "@/shared/lib/workflowSettings";
+import { EmptyState } from "@/shared/ui/ostone/atoms/EmptyState";
 import {
   WorkflowSettingsPanel,
   type WorkflowSettingEntry,
@@ -117,6 +118,15 @@ export function WorkflowListView({
       ? entries.find((e) => e.workflowId === filterWorkflowId)?.name ?? null
       : null;
 
+  const [prevEntries, setPrevEntries] = useState(entries);
+  if (entries !== prevEntries) {
+    setPrevEntries(entries);
+    if (filterWorkflowId !== null && !entries.some((e) => e.workflowId === filterWorkflowId)) {
+      setFilterWorkflowId(null);
+      setPage(1);
+    }
+  }
+
   return (
     <div className={styles.root} data-testid={testIdPrefix}>
       <div className={styles.header}>
@@ -167,6 +177,10 @@ export function WorkflowListView({
         </button>
       )}
 
+      {pageEntries.length === 0 && (
+        <EmptyState message={filterWorkflowId !== null ? "필터 결과 없음" : "워크플로우 없음"} />
+      )}
+
       <div className={styles.masonry} data-testid={`${testIdPrefix}-masonry`}>
         {pageEntries.map((entry) => (
           <WorkflowCard
@@ -181,10 +195,9 @@ export function WorkflowListView({
       </div>
 
       {totalPages > 1 && (
-        <div
+        <nav
           className={styles.pagination}
           data-testid={`${testIdPrefix}-pagination`}
-          role="navigation"
           aria-label="pagination"
         >
           <button
@@ -208,7 +221,7 @@ export function WorkflowListView({
           >
             Next
           </button>
-        </div>
+        </nav>
       )}
     </div>
   );

--- a/frontend/src/features/workflow-list/ui/WorkflowListView.tsx
+++ b/frontend/src/features/workflow-list/ui/WorkflowListView.tsx
@@ -1,0 +1,194 @@
+import { useMemo, useState } from "react";
+
+import type { WorkspaceWorkflowEntry } from "@/entities/workflow";
+import {
+  PAGE_SIZE_OPTIONS,
+  SORT_DIR_OPTIONS,
+  SORT_FIELD_OPTIONS,
+  compareWorkflows,
+  readPageWorkflowSettings,
+  writePageWorkflowSettings,
+  type PageWorkflowSettings,
+} from "@/shared/lib/workflowSettings";
+import { Icon } from "@/shared/ui/ostone/atoms/Icon";
+import {
+  WorkflowSettingsPanel,
+  type WorkflowSettingEntry,
+} from "@/shared/ui/ostone/chrome/WorkflowSettingsPanel";
+
+import { WorkflowCard } from "./WorkflowCard";
+import { WorkflowSearchBar } from "./WorkflowSearchBar";
+import styles from "./workflow-list-view.module.css";
+
+interface WorkflowListViewProps {
+  entries: WorkspaceWorkflowEntry[];
+  onOpen: (entry: WorkspaceWorkflowEntry) => void;
+  testIdPrefix?: string;
+}
+
+export function WorkflowListView({
+  entries,
+  onOpen,
+  testIdPrefix = "workflow-list",
+}: WorkflowListViewProps) {
+  const [settings, setSettings] = useState<PageWorkflowSettings>(() => readPageWorkflowSettings());
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [expanded, setExpanded] = useState<Set<number>>(() => new Set());
+  const [page, setPage] = useState(1);
+  const [filterWorkflowId, setFilterWorkflowId] = useState<number | null>(null);
+
+  const updateSettings = (patch: Partial<PageWorkflowSettings>) => {
+    setSettings((prev) => {
+      const next = { ...prev, ...patch };
+      writePageWorkflowSettings(next);
+      return next;
+    });
+    setPage(1);
+  };
+
+  const filteredAndSorted = useMemo(() => {
+    const filtered =
+      filterWorkflowId !== null
+        ? entries.filter((e) => e.workflowId === filterWorkflowId)
+        : entries;
+    return [...filtered].sort((a, b) =>
+      compareWorkflows(a, b, settings.sortField, settings.sortDir),
+    );
+  }, [entries, settings.sortField, settings.sortDir, filterWorkflowId]);
+
+  const totalPages = Math.max(1, Math.ceil(filteredAndSorted.length / settings.pageSize));
+  const safePage = Math.min(page, totalPages);
+  const pageStart = (safePage - 1) * settings.pageSize;
+  const pageEntries = filteredAndSorted.slice(pageStart, pageStart + settings.pageSize);
+
+  const handleToggleCard = (workflowId: number) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(workflowId)) next.delete(workflowId);
+      else next.add(workflowId);
+      return next;
+    });
+  };
+
+  const settingsEntries: WorkflowSettingEntry[] = [
+    {
+      key: "pageSize",
+      label: "Per page",
+      value: settings.pageSize,
+      options: PAGE_SIZE_OPTIONS.map((n) => ({ value: n, label: String(n) })),
+      onChange: (next) => updateSettings({ pageSize: Number(next) }),
+    },
+    {
+      key: "sortField",
+      label: "Sort by",
+      value: settings.sortField,
+      options: SORT_FIELD_OPTIONS.map((o) => ({ value: o.value, label: o.label })),
+      onChange: (next) =>
+        updateSettings({ sortField: next === "name" ? "name" : "workflowCode" }),
+    },
+    {
+      key: "sortDir",
+      label: "Order",
+      value: settings.sortDir,
+      options: SORT_DIR_OPTIONS.map((o) => ({ value: o.value, label: o.label })),
+      onChange: (next) => updateSettings({ sortDir: next === "desc" ? "desc" : "asc" }),
+    },
+  ];
+
+  const filteredEntryName =
+    filterWorkflowId !== null
+      ? entries.find((e) => e.workflowId === filterWorkflowId)?.name ?? null
+      : null;
+
+  return (
+    <div className={styles.root} data-testid={testIdPrefix}>
+      <div className={styles.header}>
+        <div className={styles.searchSlot}>
+          <WorkflowSearchBar
+            entries={entries}
+            onFilter={(workflowId) => {
+              setFilterWorkflowId(workflowId);
+              setPage(1);
+            }}
+            testIdPrefix={`${testIdPrefix}-search`}
+          />
+        </div>
+        <button
+          type="button"
+          onClick={() => setSettingsOpen((v) => !v)}
+          aria-label="페이지 표시 설정"
+          aria-expanded={settingsOpen}
+          data-testid={`${testIdPrefix}-settings-toggle`}
+          className={styles.settingsBtn}
+          data-active={settingsOpen ? "true" : "false"}
+        >
+          <Icon name="settings" size={14} />
+        </button>
+      </div>
+
+      {settingsOpen && (
+        <WorkflowSettingsPanel
+          entries={settingsEntries}
+          testId={`${testIdPrefix}-settings`}
+        />
+      )}
+
+      {filterWorkflowId !== null && filteredEntryName && (
+        <button
+          type="button"
+          data-testid={`${testIdPrefix}-filter-chip`}
+          onClick={() => setFilterWorkflowId(null)}
+          className={styles.filterChip}
+        >
+          <span>{filteredEntryName}</span>
+          <Icon name="close" size={10} />
+        </button>
+      )}
+
+      <div className={styles.masonry} data-testid={`${testIdPrefix}-masonry`}>
+        {pageEntries.map((entry) => (
+          <WorkflowCard
+            key={`${entry.packId}-${entry.workflowId}`}
+            entry={entry}
+            expanded={expanded.has(entry.workflowId)}
+            onToggle={() => handleToggleCard(entry.workflowId)}
+            onOpen={() => onOpen(entry)}
+            testIdPrefix={testIdPrefix}
+          />
+        ))}
+      </div>
+
+      {totalPages > 1 && (
+        <div
+          className={styles.pagination}
+          data-testid={`${testIdPrefix}-pagination`}
+          role="navigation"
+          aria-label="pagination"
+        >
+          <button
+            type="button"
+            disabled={safePage <= 1}
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+            data-testid={`${testIdPrefix}-pagination-prev`}
+            className={styles.pageBtn}
+          >
+            Prev
+          </button>
+          <span className={styles.pageInfo} data-testid={`${testIdPrefix}-pagination-info`}>
+            {safePage} / {totalPages}
+          </span>
+          <button
+            type="button"
+            disabled={safePage >= totalPages}
+            onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+            data-testid={`${testIdPrefix}-pagination-next`}
+            className={styles.pageBtn}
+          >
+            Next
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/frontend/src/features/workflow-list/ui/WorkflowListView.tsx
+++ b/frontend/src/features/workflow-list/ui/WorkflowListView.tsx
@@ -1,4 +1,5 @@
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
+import { Settings as SettingsIcon, X as XIcon } from "lucide-react";
 
 import type { WorkspaceWorkflowEntry } from "@/entities/workflow";
 import {
@@ -10,7 +11,6 @@ import {
   writePageWorkflowSettings,
   type PageWorkflowSettings,
 } from "@/shared/lib/workflowSettings";
-import { Icon } from "@/shared/ui/ostone/atoms/Icon";
 import {
   WorkflowSettingsPanel,
   type WorkflowSettingEntry,
@@ -19,6 +19,16 @@ import {
 import { WorkflowCard } from "./WorkflowCard";
 import { WorkflowSearchBar } from "./WorkflowSearchBar";
 import styles from "./workflow-list-view.module.css";
+
+const SORT_FIELD_KO_LABELS: Record<(typeof SORT_FIELD_OPTIONS)[number]["value"], string> = {
+  workflowCode: "코드",
+  name: "이름",
+};
+
+const SORT_DIR_KO_LABELS: Record<(typeof SORT_DIR_OPTIONS)[number]["value"], string> = {
+  asc: "오름차순",
+  desc: "내림차순",
+};
 
 interface WorkflowListViewProps {
   entries: WorkspaceWorkflowEntry[];
@@ -36,6 +46,7 @@ export function WorkflowListView({
   const [expanded, setExpanded] = useState<Set<number>>(() => new Set());
   const [page, setPage] = useState(1);
   const [filterWorkflowId, setFilterWorkflowId] = useState<number | null>(null);
+  const settingsButtonRef = useRef<HTMLButtonElement>(null);
 
   const updateSettings = (patch: Partial<PageWorkflowSettings>) => {
     setSettings((prev) => {
@@ -73,24 +84,30 @@ export function WorkflowListView({
   const settingsEntries: WorkflowSettingEntry[] = [
     {
       key: "pageSize",
-      label: "Per page",
+      label: "페이지 크기",
       value: settings.pageSize,
       options: PAGE_SIZE_OPTIONS.map((n) => ({ value: n, label: String(n) })),
       onChange: (next) => updateSettings({ pageSize: Number(next) }),
     },
     {
       key: "sortField",
-      label: "Sort by",
+      label: "정렬 기준",
       value: settings.sortField,
-      options: SORT_FIELD_OPTIONS.map((o) => ({ value: o.value, label: o.label })),
+      options: SORT_FIELD_OPTIONS.map((o) => ({
+        value: o.value,
+        label: SORT_FIELD_KO_LABELS[o.value],
+      })),
       onChange: (next) =>
         updateSettings({ sortField: next === "name" ? "name" : "workflowCode" }),
     },
     {
       key: "sortDir",
-      label: "Order",
+      label: "정렬 방식",
       value: settings.sortDir,
-      options: SORT_DIR_OPTIONS.map((o) => ({ value: o.value, label: o.label })),
+      options: SORT_DIR_OPTIONS.map((o) => ({
+        value: o.value,
+        label: SORT_DIR_KO_LABELS[o.value],
+      })),
       onChange: (next) => updateSettings({ sortDir: next === "desc" ? "desc" : "asc" }),
     },
   ];
@@ -113,25 +130,30 @@ export function WorkflowListView({
             testIdPrefix={`${testIdPrefix}-search`}
           />
         </div>
-        <button
-          type="button"
-          onClick={() => setSettingsOpen((v) => !v)}
-          aria-label="페이지 표시 설정"
-          aria-expanded={settingsOpen}
-          data-testid={`${testIdPrefix}-settings-toggle`}
-          className={styles.settingsBtn}
-          data-active={settingsOpen ? "true" : "false"}
-        >
-          <Icon name="settings" size={14} />
-        </button>
+        <div className={styles.settingsAnchor}>
+          <button
+            ref={settingsButtonRef}
+            type="button"
+            onClick={() => setSettingsOpen((v) => !v)}
+            aria-label="페이지 표시 설정"
+            aria-expanded={settingsOpen}
+            data-testid={`${testIdPrefix}-settings-toggle`}
+            className={styles.settingsBtn}
+            data-active={settingsOpen ? "true" : "false"}
+          >
+            <SettingsIcon size={14} />
+          </button>
+          {settingsOpen && (
+            <WorkflowSettingsPanel
+              entries={settingsEntries}
+              testId={`${testIdPrefix}-settings`}
+              style={{ top: "calc(100% + 6px)", right: 0 }}
+              onClickOutside={() => setSettingsOpen(false)}
+              anchorRef={settingsButtonRef}
+            />
+          )}
+        </div>
       </div>
-
-      {settingsOpen && (
-        <WorkflowSettingsPanel
-          entries={settingsEntries}
-          testId={`${testIdPrefix}-settings`}
-        />
-      )}
 
       {filterWorkflowId !== null && filteredEntryName && (
         <button
@@ -141,7 +163,7 @@ export function WorkflowListView({
           className={styles.filterChip}
         >
           <span>{filteredEntryName}</span>
-          <Icon name="close" size={10} />
+          <XIcon size={10} />
         </button>
       )}
 

--- a/frontend/src/features/workflow-list/ui/WorkflowSearchBar.test.tsx
+++ b/frontend/src/features/workflow-list/ui/WorkflowSearchBar.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import type { WorkspaceWorkflowEntry } from "@/entities/workflow";
+import { WorkflowSearchBar } from "./WorkflowSearchBar";
+
+function makeEntry(id: number, name: string): WorkspaceWorkflowEntry {
+  return {
+    packId: 2,
+    packName: "Pack",
+    versionId: 3,
+    workflowId: id,
+    workflowCode: `wf.${id}`,
+    name,
+    description: null,
+  };
+}
+
+const ENTRIES = [
+  makeEntry(1, "Refund standard"),
+  makeEntry(2, "Refund express"),
+  makeEntry(3, "Shipping delay"),
+  makeEntry(4, "Payment failure"),
+];
+
+describe("WorkflowSearchBar", () => {
+  it("처음에는 dropdown 이 보이지 않는다", () => {
+    render(<WorkflowSearchBar entries={ENTRIES} onFilter={vi.fn()} />);
+    expect(screen.queryByTestId("workflow-search-dropdown")).not.toBeInTheDocument();
+  });
+
+  it("타이핑 시 매칭 항목이 dropdown 에 표시된다", () => {
+    render(<WorkflowSearchBar entries={ENTRIES} onFilter={vi.fn()} />);
+    fireEvent.change(screen.getByTestId("workflow-search-input"), { target: { value: "refund" } });
+    const dropdown = screen.getByTestId("workflow-search-dropdown");
+    expect(dropdown).toBeInTheDocument();
+    expect(screen.getByTestId("workflow-search-item-1")).toBeInTheDocument();
+    expect(screen.getByTestId("workflow-search-item-2")).toBeInTheDocument();
+    expect(screen.queryByTestId("workflow-search-item-3")).not.toBeInTheDocument();
+  });
+
+  it("dropdown 항목 클릭 시 onFilter 가 workflowId 와 함께 호출된다", () => {
+    const onFilter = vi.fn();
+    render(<WorkflowSearchBar entries={ENTRIES} onFilter={onFilter} />);
+    fireEvent.change(screen.getByTestId("workflow-search-input"), { target: { value: "refund" } });
+    fireEvent.click(screen.getByTestId("workflow-search-item-2"));
+    expect(onFilter).toHaveBeenCalledWith(2);
+  });
+
+  it("maxResults 가 초과하는 매칭은 잘라낸다", () => {
+    render(<WorkflowSearchBar entries={ENTRIES} onFilter={vi.fn()} maxResults={1} />);
+    fireEvent.change(screen.getByTestId("workflow-search-input"), { target: { value: "Refund" } });
+    expect(screen.getByTestId("workflow-search-item-1")).toBeInTheDocument();
+    expect(screen.queryByTestId("workflow-search-item-2")).not.toBeInTheDocument();
+  });
+
+  it("input 외부 클릭 시 dropdown 이 닫힌다", () => {
+    render(
+      <div>
+        <WorkflowSearchBar entries={ENTRIES} onFilter={vi.fn()} />
+        <div data-testid="outside">outside</div>
+      </div>,
+    );
+    fireEvent.change(screen.getByTestId("workflow-search-input"), { target: { value: "refund" } });
+    expect(screen.getByTestId("workflow-search-dropdown")).toBeInTheDocument();
+    fireEvent.mouseDown(screen.getByTestId("outside"));
+    expect(screen.queryByTestId("workflow-search-dropdown")).not.toBeInTheDocument();
+  });
+
+  it("testIdPrefix 가 적용된다", () => {
+    render(
+      <WorkflowSearchBar entries={ENTRIES} onFilter={vi.fn()} testIdPrefix="page-search" />,
+    );
+    expect(screen.getByTestId("page-search-input")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/workflow-list/ui/WorkflowSearchBar.tsx
+++ b/frontend/src/features/workflow-list/ui/WorkflowSearchBar.tsx
@@ -1,0 +1,150 @@
+import { useEffect, useRef, useState, type CSSProperties } from "react";
+
+import type { WorkspaceWorkflowEntry } from "@/entities/workflow";
+import { Icon } from "@/shared/ui/ostone/atoms/Icon";
+
+interface WorkflowSearchBarProps {
+  entries: WorkspaceWorkflowEntry[];
+  /** Called with the chosen workflowId; pass null to clear. */
+  onFilter: (workflowId: number | null) => void;
+  testIdPrefix?: string;
+  maxResults?: number;
+}
+
+const MAX_DEFAULT = 8;
+
+function highlightMatch(name: string, q: string): { match: string; rest: string } {
+  if (!q) return { match: "", rest: name };
+  const lower = name.toLowerCase();
+  const idx = lower.indexOf(q.toLowerCase());
+  if (idx === -1) return { match: "", rest: name };
+  return { match: name.slice(0, idx + q.length), rest: name.slice(idx + q.length) };
+}
+
+export function WorkflowSearchBar({
+  entries,
+  onFilter,
+  testIdPrefix = "workflow-search",
+  maxResults = MAX_DEFAULT,
+}: WorkflowSearchBarProps) {
+  const [query, setQuery] = useState("");
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (!containerRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open]);
+
+  const trimmed = query.trim().toLowerCase();
+  const matches = trimmed
+    ? entries
+        .filter((e) => e.name.toLowerCase().includes(trimmed))
+        .slice(0, maxResults)
+    : [];
+
+  const inputStyle: CSSProperties = {
+    width: "100%",
+    height: "32px",
+    padding: "0 32px 0 32px",
+    borderRadius: "999px",
+    border: "1px solid var(--line)",
+    background: "var(--paper-2)",
+    color: "var(--ink)",
+    fontFamily: "var(--sans)",
+    fontSize: "13px",
+    outline: "none",
+  };
+
+  return (
+    <div ref={containerRef} style={{ position: "relative", width: "100%" }}>
+      <div
+        style={{
+          position: "absolute",
+          left: "10px",
+          top: "50%",
+          transform: "translateY(-50%)",
+          color: "var(--ink-3)",
+          pointerEvents: "none",
+        }}
+      >
+        <Icon name="search" size={14} />
+      </div>
+      <input
+        type="text"
+        value={query}
+        onChange={(e) => {
+          setQuery(e.target.value);
+          setOpen(true);
+        }}
+        onFocus={() => {
+          if (query) setOpen(true);
+        }}
+        placeholder="Workflow 검색"
+        data-testid={`${testIdPrefix}-input`}
+        style={inputStyle}
+      />
+
+      {open && matches.length > 0 && (
+        <div
+          data-testid={`${testIdPrefix}-dropdown`}
+          style={{
+            position: "absolute",
+            top: "calc(100% + 6px)",
+            left: 0,
+            right: 0,
+            background: "var(--paper)",
+            border: "1px solid var(--line)",
+            borderRadius: "var(--r-2)",
+            boxShadow: "0 8px 24px rgba(0,0,0,0.08)",
+            maxHeight: "280px",
+            overflowY: "auto",
+            zIndex: 30,
+          }}
+        >
+          {matches.map((entry) => {
+            const { match, rest } = highlightMatch(entry.name, query);
+            return (
+              <button
+                key={`${entry.packId}-${entry.workflowId}`}
+                type="button"
+                onClick={() => {
+                  onFilter(entry.workflowId);
+                  setOpen(false);
+                  setQuery(entry.name);
+                }}
+                data-testid={`${testIdPrefix}-item-${entry.workflowId}`}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "10px",
+                  width: "100%",
+                  padding: "10px 14px",
+                  background: "transparent",
+                  border: "none",
+                  cursor: "pointer",
+                  textAlign: "left",
+                  fontFamily: "var(--sans)",
+                  fontSize: "13px",
+                  color: "var(--ink)",
+                }}
+              >
+                <span style={{ color: "var(--ink-3)" }}>
+                  <Icon name="search" size={12} />
+                </span>
+                <span>
+                  <span style={{ fontWeight: 500 }}>{match}</span>
+                  <span style={{ color: "var(--ink-2)" }}>{rest}</span>
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/workflow-list/ui/WorkflowSearchBar.tsx
+++ b/frontend/src/features/workflow-list/ui/WorkflowSearchBar.tsx
@@ -13,12 +13,16 @@ interface WorkflowSearchBarProps {
 
 const MAX_DEFAULT = 8;
 
-function highlightMatch(name: string, q: string): { match: string; rest: string } {
-  if (!q) return { match: "", rest: name };
+function highlightMatch(name: string, q: string): { before: string; match: string; after: string } {
+  if (!q) return { before: "", match: "", after: name };
   const lower = name.toLowerCase();
   const idx = lower.indexOf(q.toLowerCase());
-  if (idx === -1) return { match: "", rest: name };
-  return { match: name.slice(0, idx + q.length), rest: name.slice(idx + q.length) };
+  if (idx === -1) return { before: "", match: "", after: name };
+  return {
+    before: name.slice(0, idx),
+    match: name.slice(idx, idx + q.length),
+    after: name.slice(idx + q.length),
+  };
 }
 
 export function WorkflowSearchBar({
@@ -107,7 +111,7 @@ export function WorkflowSearchBar({
           }}
         >
           {matches.map((entry) => {
-            const { match, rest } = highlightMatch(entry.name, query);
+            const { before, match, after } = highlightMatch(entry.name, query);
             return (
               <button
                 key={`${entry.packId}-${entry.workflowId}`}
@@ -137,8 +141,9 @@ export function WorkflowSearchBar({
                   <Icon name="search" size={12} />
                 </span>
                 <span>
+                  <span>{before}</span>
                   <span style={{ fontWeight: 500 }}>{match}</span>
-                  <span style={{ color: "var(--ink-2)" }}>{rest}</span>
+                  <span style={{ color: "var(--ink-2)" }}>{after}</span>
                 </span>
               </button>
             );

--- a/frontend/src/features/workflow-list/ui/workflow-card.module.css
+++ b/frontend/src/features/workflow-list/ui/workflow-card.module.css
@@ -5,8 +5,7 @@
   border: 1px solid var(--line);
   border-radius: var(--r-lg);
   box-shadow: var(--shadow-card);
-  margin: 0 0 var(--s-3) 0;
-  break-inside: avoid;
+  margin-bottom: 8px;
   transition: box-shadow 120ms ease, transform 120ms ease;
 }
 

--- a/frontend/src/features/workflow-list/ui/workflow-card.module.css
+++ b/frontend/src/features/workflow-list/ui/workflow-card.module.css
@@ -1,0 +1,112 @@
+.card {
+  display: flex;
+  flex-direction: column;
+  background: var(--paper);
+  border: 1px solid var(--line);
+  border-radius: var(--r-lg);
+  box-shadow: var(--shadow-card);
+  margin: 0 0 var(--s-3) 0;
+  break-inside: avoid;
+  transition: box-shadow 120ms ease, transform 120ms ease;
+}
+
+.card:hover {
+  box-shadow: var(--shadow-card-hover, var(--shadow-card));
+  transform: translateY(-1px);
+}
+
+.card[data-expanded="true"] {
+  border-color: var(--ink);
+}
+
+.cardBody {
+  display: flex;
+  flex-direction: column;
+  gap: var(--s-2);
+  padding: var(--s-3);
+  background: transparent;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+}
+
+.graphSlot {
+  height: 120px;
+  background: var(--paper-2);
+  border-radius: var(--r-2);
+  border: 1px solid var(--line-2);
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: var(--s-2);
+  flex-wrap: wrap;
+}
+
+.code {
+  font-size: 11px;
+  color: var(--ink-3);
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.title {
+  font-family: var(--sans);
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--ink);
+  margin: 0;
+  letter-spacing: -0.1px;
+}
+
+.detail {
+  display: flex;
+  flex-direction: column;
+  gap: var(--s-2);
+}
+
+.description {
+  font-family: var(--sans);
+  font-size: 12px;
+  color: var(--ink-2);
+  margin: 0;
+  line-height: 1.5;
+}
+
+.meta {
+  font-size: 10px;
+  color: var(--ink-3);
+  letter-spacing: 0.4px;
+}
+
+.footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px var(--s-3);
+  border-top: 1px solid var(--line-2);
+  background: var(--paper-2);
+  border-radius: 0 0 var(--r-lg) var(--r-lg);
+}
+
+.openBtn {
+  padding: 4px 12px;
+  border-radius: var(--r-2);
+  border: 1px solid var(--ink);
+  background: var(--ink);
+  color: var(--paper);
+  font-family: var(--mono);
+  font-size: 11px;
+  cursor: pointer;
+}

--- a/frontend/src/features/workflow-list/ui/workflow-list-view.module.css
+++ b/frontend/src/features/workflow-list/ui/workflow-list-view.module.css
@@ -22,8 +22,8 @@
 
 .searchSlot {
   flex: 1;
-  min-width: 220px;
-  max-width: 480px;
+  min-width: 280px;
+  max-width: 680px;
   position: relative;
 }
 

--- a/frontend/src/features/workflow-list/ui/workflow-list-view.module.css
+++ b/frontend/src/features/workflow-list/ui/workflow-list-view.module.css
@@ -1,0 +1,113 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: var(--s-3);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: var(--s-3);
+  flex-wrap: wrap;
+}
+
+.title {
+  font-family: var(--sans);
+  font-size: 22px;
+  font-weight: 500;
+  color: var(--ink);
+  letter-spacing: -0.26px;
+  margin: 0;
+}
+
+.searchSlot {
+  flex: 1;
+  min-width: 220px;
+  max-width: 480px;
+  position: relative;
+}
+
+.settingsBtn {
+  flex-shrink: 0;
+  width: 32px;
+  height: 32px;
+  border: 1px solid var(--line);
+  background: var(--paper);
+  color: var(--ink-3);
+  border-radius: var(--r-2);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+}
+
+.settingsBtn[data-active="true"] {
+  background: var(--paper-3);
+  color: var(--ink);
+  border-color: var(--ink);
+}
+
+.filterChip {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--ink);
+  background: var(--paper-3);
+  color: var(--ink);
+  cursor: pointer;
+  font-family: var(--mono);
+  font-size: 11px;
+}
+
+.masonry {
+  column-count: 3;
+  column-gap: var(--s-3);
+}
+
+@media (max-width: 1080px) {
+  .masonry {
+    column-count: 2;
+  }
+}
+
+@media (max-width: 720px) {
+  .masonry {
+    column-count: 1;
+  }
+}
+
+.pagination {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: var(--s-3);
+  padding: var(--s-3) 0;
+}
+
+.pageBtn {
+  padding: 6px 14px;
+  border-radius: var(--r-2);
+  border: 1px solid var(--line);
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--mono);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.pageBtn:disabled {
+  color: var(--ink-3);
+  background: var(--paper-2);
+  cursor: not-allowed;
+}
+
+.pageInfo {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--ink-3);
+  letter-spacing: 0.4px;
+}

--- a/frontend/src/features/workflow-list/ui/workflow-list-view.module.css
+++ b/frontend/src/features/workflow-list/ui/workflow-list-view.module.css
@@ -27,8 +27,12 @@
   position: relative;
 }
 
-.settingsBtn {
+.settingsAnchor {
+  position: relative;
   flex-shrink: 0;
+}
+
+.settingsBtn {
   width: 32px;
   height: 32px;
   border: 1px solid var(--line);
@@ -64,19 +68,23 @@
 }
 
 .masonry {
-  column-count: 3;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-auto-rows: 10px;
+  grid-auto-flow: row dense;
   column-gap: var(--s-3);
+  align-items: start;
 }
 
 @media (max-width: 1080px) {
   .masonry {
-    column-count: 2;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
 @media (max-width: 720px) {
   .masonry {
-    column-count: 1;
+    grid-template-columns: 1fr;
   }
 }
 

--- a/frontend/src/features/workflow-viewer/ui/GraphViewer.tsx
+++ b/frontend/src/features/workflow-viewer/ui/GraphViewer.tsx
@@ -51,7 +51,10 @@ export function GraphViewer({
         edgeTypes={edgeTypes}
         fitView
         panOnDrag={true}
-        zoomOnScroll={true}
+        zoomOnScroll={false}
+        zoomOnPinch={true}
+        zoomOnDoubleClick={true}
+        preventScrolling={false}
         nodesDraggable={false}
         nodesConnectable={false}
         elementsSelectable={false}

--- a/frontend/src/pages/chat-demo/ui/ChatWorkflowDemoPage.tsx
+++ b/frontend/src/pages/chat-demo/ui/ChatWorkflowDemoPage.tsx
@@ -49,7 +49,7 @@ export function ChatWorkflowDemoPage({ state }: ChatWorkflowDemoPageProps) {
 
   if (loading) {
     return (
-      <OstoneShell active="chat-demo" crumbs={['Chat Workflow Demo']}>
+      <OstoneShell active="operator" crumbs={['운영자 화면']}>
         <div data-testid="loading-state" style={{ padding: 'var(--s-8)', textAlign: 'center', color: 'var(--text-3)' }}>
           Loading workflow data...
         </div>
@@ -59,7 +59,7 @@ export function ChatWorkflowDemoPage({ state }: ChatWorkflowDemoPageProps) {
 
   if (error) {
     return (
-      <OstoneShell active="chat-demo" crumbs={['Chat Workflow Demo']}>
+      <OstoneShell active="operator" crumbs={['운영자 화면']}>
         <div data-testid="error-state" style={{ padding: 'var(--s-8)', textAlign: 'center', color: 'var(--danger)' }}>
           Error: {error}
         </div>
@@ -68,7 +68,7 @@ export function ChatWorkflowDemoPage({ state }: ChatWorkflowDemoPageProps) {
   }
 
   return (
-    <OstoneShell active="chat-demo" crumbs={['Chat Workflow Demo']}>
+    <OstoneShell active="operator" crumbs={['운영자 화면']}>
       <div
         data-testid="page-container"
         className={styles.page}

--- a/frontend/src/pages/domain-pack/ui/PackWorkflowListPage.test.tsx
+++ b/frontend/src/pages/domain-pack/ui/PackWorkflowListPage.test.tsx
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+
+import { PackWorkflowListPage } from "./PackWorkflowListPage";
+
+const mockUseListWorkflows = vi.fn();
+
+vi.mock(
+  "@/shared/api/generated/endpoints/workflow-definition-controller/workflow-definition-controller",
+  () => ({
+    useListWorkflows: (...args: unknown[]) => mockUseListWorkflows(...args),
+  }),
+);
+
+vi.mock("@/features/workflow-list", () => ({
+  WorkflowListView: vi.fn(({ entries, onOpen }) => (
+    <div data-testid="workflow-list-view">
+      {entries.map((entry: { workflowId: number; name: string }) => (
+        <button
+          key={entry.workflowId}
+          type="button"
+          data-testid={`mock-card-${entry.workflowId}`}
+          onClick={() =>
+            onOpen({
+              packId: 2,
+              packName: "pack-2",
+              versionId: 3,
+              workflowId: entry.workflowId,
+              workflowCode: null,
+              name: entry.name,
+              description: null,
+            })
+          }
+        >
+          {entry.name}
+        </button>
+      ))}
+    </div>
+  )),
+}));
+
+vi.mock("@/widgets/ostone-shell", () => ({
+  OstoneShell: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+const ROUTE = "/workspaces/:workspaceId/domain-packs/:packId/versions/:versionId/workflows";
+
+function renderPage(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path={ROUTE} element={<PackWorkflowListPage />} />
+        <Route path="/workspaces" element={<div data-testid="workspaces-root">root</div>} />
+        <Route path="*" element={<div data-testid="navigated">{(location as { pathname: string }).pathname ?? "navigated"}</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  mockUseListWorkflows.mockReset();
+});
+
+describe("PackWorkflowListPage", () => {
+  it("유효하지 않은 wsId는 /workspaces 로 redirect", () => {
+    mockUseListWorkflows.mockReturnValue({ isLoading: false, isError: false, data: undefined });
+    renderPage("/workspaces/abc/domain-packs/2/versions/3/workflows");
+    expect(screen.getByTestId("workspaces-root")).toBeInTheDocument();
+  });
+
+  it("loading 시 loading state 가 노출된다", () => {
+    mockUseListWorkflows.mockReturnValue({ isLoading: true, isError: false, data: undefined });
+    renderPage("/workspaces/1/domain-packs/2/versions/3/workflows");
+    expect(screen.getByTestId("pack-workflows-loading")).toBeInTheDocument();
+  });
+
+  it("error 시 error state 가 노출된다", () => {
+    mockUseListWorkflows.mockReturnValue({
+      isLoading: false,
+      isError: true,
+      data: undefined,
+      refetch: vi.fn(),
+    });
+    renderPage("/workspaces/1/domain-packs/2/versions/3/workflows");
+    expect(screen.getByTestId("pack-workflows-error")).toBeInTheDocument();
+  });
+
+  it("결과가 비어 있으면 empty state 가 노출된다", () => {
+    mockUseListWorkflows.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: { data: [] },
+    });
+    renderPage("/workspaces/1/domain-packs/2/versions/3/workflows");
+    expect(screen.getByTestId("pack-workflows-empty")).toBeInTheDocument();
+  });
+
+  it("워크플로우 데이터를 WorkflowListView 로 전달한다", () => {
+    mockUseListWorkflows.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: {
+        data: [
+          { id: 10, name: "Alpha", workflowCode: "wf.a", description: null },
+          { id: 11, name: "Beta", workflowCode: "wf.b", description: null },
+        ],
+      },
+    });
+    renderPage("/workspaces/1/domain-packs/2/versions/3/workflows");
+    expect(screen.getByTestId("workflow-list-view")).toBeInTheDocument();
+    expect(screen.getByTestId("mock-card-10")).toHaveTextContent("Alpha");
+    expect(screen.getByTestId("mock-card-11")).toHaveTextContent("Beta");
+  });
+
+  it("ID 없는 워크플로우 항목은 필터링한다", () => {
+    mockUseListWorkflows.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: {
+        data: [
+          { name: "noid", workflowCode: "wf.x", description: null },
+          { id: 22, name: "withId", workflowCode: "wf.y", description: null },
+        ],
+      },
+    });
+    renderPage("/workspaces/1/domain-packs/2/versions/3/workflows");
+    expect(screen.queryByTestId("mock-card-22")).toBeInTheDocument();
+    expect(screen.queryByText("noid")).not.toBeInTheDocument();
+  });
+
+  it("plain array 응답도 지원한다 (unwrapApiResponse fallback)", () => {
+    mockUseListWorkflows.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: [{ id: 99, name: "Plain", workflowCode: null, description: null }],
+    });
+    renderPage("/workspaces/1/domain-packs/2/versions/3/workflows");
+    expect(screen.getByTestId("mock-card-99")).toBeInTheDocument();
+  });
+
+  it("카드 클릭 시 워크플로우 상세 경로로 navigate", () => {
+    mockUseListWorkflows.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: { data: [{ id: 42, name: "Click me", workflowCode: null, description: null }] },
+    });
+    renderPage("/workspaces/1/domain-packs/2/versions/3/workflows");
+    fireEvent.click(screen.getByTestId("mock-card-42"));
+    expect(screen.getByTestId("navigated")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/domain-pack/ui/PackWorkflowListPage.test.tsx
+++ b/frontend/src/pages/domain-pack/ui/PackWorkflowListPage.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
 
 import { PackWorkflowListPage } from "./PackWorkflowListPage";
 
@@ -46,13 +46,18 @@ vi.mock("@/widgets/ostone-shell", () => ({
 
 const ROUTE = "/workspaces/:workspaceId/domain-packs/:packId/versions/:versionId/workflows";
 
+function NavigatedRoute() {
+  const loc = useLocation();
+  return <div data-testid="navigated">{loc.pathname}</div>;
+}
+
 function renderPage(path: string) {
   return render(
     <MemoryRouter initialEntries={[path]}>
       <Routes>
         <Route path={ROUTE} element={<PackWorkflowListPage />} />
         <Route path="/workspaces" element={<div data-testid="workspaces-root">root</div>} />
-        <Route path="*" element={<div data-testid="navigated">{(location as { pathname: string }).pathname ?? "navigated"}</div>} />
+        <Route path="*" element={<NavigatedRoute />} />
       </Routes>
     </MemoryRouter>,
   );

--- a/frontend/src/pages/domain-pack/ui/PackWorkflowListPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/PackWorkflowListPage.tsx
@@ -1,0 +1,109 @@
+import { useMemo } from "react";
+import { Navigate, useNavigate, useParams } from "react-router-dom";
+
+import { useListWorkflows } from "@/shared/api/generated/endpoints/workflow-definition-controller/workflow-definition-controller";
+import { unwrapApiResponse } from "@/shared/api/unwrapApiResponse";
+import type { WorkflowDefinitionSummary } from "@/shared/api/generated/zod";
+import type { WorkspaceWorkflowEntry } from "@/entities/workflow";
+import { parseRouteId } from "@/shared/lib/parseRouteId";
+import { OstoneShell } from "@/widgets/ostone-shell";
+import { LoadingSpinner } from "@/shared/ui/ostone/atoms/LoadingSpinner";
+import { ErrorState } from "@/shared/ui/ostone/atoms/ErrorState";
+import { EmptyState } from "@/shared/ui/ostone/atoms/EmptyState";
+import { WorkflowListView } from "@/features/workflow-list";
+
+export function PackWorkflowListPage() {
+  const navigate = useNavigate();
+  const { workspaceId, packId, versionId } = useParams();
+
+  const wsId = parseRouteId(workspaceId);
+  const pId = parseRouteId(packId);
+  const vId = parseRouteId(versionId);
+  const enabled = wsId !== null && pId !== null && vId !== null;
+
+  const query = useListWorkflows(wsId ?? 0, pId ?? 0, vId ?? 0, {
+    query: { enabled },
+  });
+
+  const entries = useMemo<WorkspaceWorkflowEntry[]>(() => {
+    if (!enabled) return [];
+    const list = unwrapApiResponse<WorkflowDefinitionSummary[]>(query.data) ?? [];
+    return list
+      .filter((wf): wf is WorkflowDefinitionSummary & { id: number } => typeof wf.id === "number")
+      .map<WorkspaceWorkflowEntry>((wf) => ({
+        packId: pId!,
+        packName: `pack-${pId}`,
+        versionId: vId!,
+        workflowId: wf.id,
+        workflowCode: wf.workflowCode ?? null,
+        name: wf.name || wf.workflowCode || `wf-${wf.id}`,
+        description: wf.description ?? null,
+      }));
+  }, [enabled, query.data, pId, vId]);
+
+  if (!enabled) {
+    return <Navigate to="/workspaces" replace />;
+  }
+
+  const crumbs = [`WS · ${wsId}`, "Domain Packs", `PACK · ${pId}`, `VER · ${vId}`, "Workflows"];
+
+  const handleOpen = (entry: WorkspaceWorkflowEntry) => {
+    navigate(
+      `/workspaces/${wsId}/domain-packs/${entry.packId}/versions/${entry.versionId}/workflows/${entry.workflowId}`,
+    );
+  };
+
+  return (
+    <OstoneShell active="workflows" crumbs={crumbs} activePackId={pId}>
+      <div style={{ padding: "24px", height: "100%", overflow: "auto" }}>
+        <h1
+          style={{
+            fontFamily: "var(--sans)",
+            fontSize: "22px",
+            fontWeight: 500,
+            color: "var(--ink)",
+            letterSpacing: "-0.26px",
+            margin: "0 0 var(--s-4) 0",
+          }}
+        >
+          Workflow
+        </h1>
+        {query.isLoading && (
+          <div
+            data-testid="pack-workflows-loading"
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              gap: "var(--s-3)",
+              padding: "48px 0",
+            }}
+          >
+            <LoadingSpinner />
+            <p style={{ color: "var(--ink)", fontSize: "14px" }}>워크플로우 목록을 불러오는 중입니다.</p>
+          </div>
+        )}
+
+        {!query.isLoading && query.isError && (
+          <div data-testid="pack-workflows-error">
+            <ErrorState message="워크플로우 목록을 불러오지 못했습니다." onRetry={query.refetch} />
+          </div>
+        )}
+
+        {!query.isLoading && !query.isError && entries.length === 0 && (
+          <div data-testid="pack-workflows-empty">
+            <EmptyState message="아직 등록된 워크플로우가 없습니다." />
+          </div>
+        )}
+
+        {!query.isLoading && !query.isError && entries.length > 0 && (
+          <WorkflowListView
+            entries={entries}
+            onOpen={handleOpen}
+            testIdPrefix="pack-workflows"
+          />
+        )}
+      </div>
+    </OstoneShell>
+  );
+}

--- a/frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.test.tsx
+++ b/frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.test.tsx
@@ -1,16 +1,37 @@
-import type { ReactElement } from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { fireEvent, render, screen } from "@testing-library/react";
-import { beforeEach, describe, it, expect, vi } from "vitest";
-import { WorkflowEditSheet } from "../../../features/update-workflow";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { WorkflowDraftReadPage } from "./WorkflowDraftReadPage";
 
-vi.mock("@/widgets/ostone-shell", () => ({
-  OstoneShell: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+const mockUseGetWorkflowDefinition = vi.fn();
+vi.mock("@/entities/workflow", () => ({
+  useGetWorkflowDefinition: (...args: unknown[]) => mockUseGetWorkflowDefinition(...args),
 }));
 
-vi.mock("../../../features/update-workflow", () => ({
-  WorkflowEditSheet: vi.fn(() => null),
+vi.mock("@/features/update-workflow", () => ({
+  InlineWorkflowEditor: vi.fn(({ workflow, onClose }) => (
+    <div data-testid="inline-editor">
+      editing {workflow.workflowCode}
+      <button type="button" data-testid="editor-close" onClick={onClose}>
+        close
+      </button>
+    </div>
+  )),
+}));
+
+vi.mock("@/features/workflow-viewer/ui/GraphViewer", () => ({
+  GraphViewer: vi.fn(({ graph }) => (
+    <div data-testid="graph-viewer">graph nodes: {graph.nodes.length}</div>
+  )),
+}));
+
+vi.mock("@/widgets/ostone-shell", () => ({
+  OstoneShell: ({ children, crumbs }: { children: React.ReactNode; crumbs: string[] }) => (
+    <div>
+      <div data-testid="crumbs">{crumbs.join(" / ")}</div>
+      {children}
+    </div>
+  ),
 }));
 
 const ROUTE =
@@ -26,64 +47,163 @@ function renderPage(path: string) {
   );
 }
 
+beforeEach(() => {
+  mockUseGetWorkflowDefinition.mockReset();
+});
+
 describe("WorkflowDraftReadPage", () => {
-  beforeEach(() => {
-    vi.mocked(WorkflowEditSheet).mockReturnValue(null as unknown as ReactElement);
-  });
-
   it("유효하지 않은 URL 파라미터는 에러 메시지를 보여준다", () => {
+    mockUseGetWorkflowDefinition.mockReturnValue({ isLoading: false });
     renderPage("/workspaces/abc/domain-packs/2/versions/3/workflows");
-    expect(screen.getByRole("alert")).toBeInTheDocument();
-    expect(screen.getByText("잘못된 URL 파라미터입니다.")).toBeInTheDocument();
+    expect(screen.getByRole("alert")).toHaveTextContent("잘못된 URL 파라미터입니다.");
   });
 
-  it("Pack header에 검토 중 · v0.4 pill을 렌더링한다", () => {
+  it("workflowId가 없으면 좌측 사이드바에서 선택하라는 안내를 표시한다", () => {
+    mockUseGetWorkflowDefinition.mockReturnValue({ isLoading: false });
     renderPage("/workspaces/1/domain-packs/2/versions/3/workflows");
-    expect(screen.getByText("검토 중 · v0.4")).toBeInTheDocument();
-    expect(screen.getByText("Card payment refund flow")).toBeInTheDocument();
+    expect(screen.getByTestId("workflow-select-empty")).toBeInTheDocument();
   });
 
-  it("7개 탭이 모두 렌더링되고 5번째 탭이 aria-selected=true이다", () => {
-    renderPage("/workspaces/1/domain-packs/2/versions/3/workflows");
-    const tabs = screen.getAllByRole("tab");
-    expect(tabs).toHaveLength(7);
-    expect(tabs[4]).toHaveAttribute("aria-selected", "true");
-    expect(tabs[4]).toHaveTextContent(/응대 흐름/);
-  });
-
-  it("3-pane 구조가 존재한다", () => {
-    renderPage("/workspaces/1/domain-packs/2/versions/3/workflows");
-    expect(screen.getByRole("heading", { name: /refund\.standard/ })).toBeInTheDocument();
-    expect(screen.getByText("Selected node")).toBeInTheDocument();
-  });
-
-  it("workflowId가 있는 경로에서 WorkflowEditSheet가 정상 렌더링된다", () => {
+  it("loading 상태에서는 spinner를 표시한다", () => {
+    mockUseGetWorkflowDefinition.mockReturnValue({ isLoading: true });
     renderPage("/workspaces/1/domain-packs/2/versions/3/workflows/10");
-    expect(screen.getByRole("heading", { name: /refund\.standard/ })).toBeInTheDocument();
+    expect(screen.getByTestId("workflow-loading")).toBeInTheDocument();
   });
 
-  it("Edit graph 버튼 클릭 시 WorkflowEditSheet의 isOpen이 true가 된다", () => {
-    vi.mocked(WorkflowEditSheet).mockImplementation(({ isOpen }) =>
-      (isOpen ? <div data-testid="edit-sheet-open" /> : null) as ReactElement,
-    );
+  it("error 상태에서는 ErrorState를 표시한다", () => {
+    mockUseGetWorkflowDefinition.mockReturnValue({
+      isLoading: false,
+      isError: true,
+      refetch: vi.fn(),
+    });
     renderPage("/workspaces/1/domain-packs/2/versions/3/workflows/10");
-    expect(screen.queryByTestId("edit-sheet-open")).not.toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: /Edit graph/ }));
-    expect(screen.getByTestId("edit-sheet-open")).toBeInTheDocument();
+    expect(screen.getByTestId("workflow-error")).toBeInTheDocument();
   });
 
-  it("WorkflowEditSheet onClose 호출 시 sheet가 닫힌다", () => {
-    vi.mocked(WorkflowEditSheet).mockImplementation(({ isOpen, onClose }) =>
-      (isOpen ? (
-        <button type="button" data-testid="close-btn" onClick={onClose}>
-          Close
-        </button>
-      ) : null) as ReactElement,
-    );
+  it("워크플로우 데이터가 로드되면 헤더에 이름/코드/노드수를 표시한다", () => {
+    mockUseGetWorkflowDefinition.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: {
+        id: 10,
+        name: "환불 처리",
+        workflowCode: "refund.standard",
+        graphJson: JSON.stringify({
+          direction: "LR",
+          nodes: [
+            { id: "n1", label: "start", type: "START" },
+            { id: "n2", label: "end", type: "TERMINAL" },
+          ],
+          edges: [{ id: "e1", from: "n1", to: "n2" }],
+        }),
+      },
+    });
     renderPage("/workspaces/1/domain-packs/2/versions/3/workflows/10");
-    fireEvent.click(screen.getByRole("button", { name: /Edit graph/ }));
-    expect(screen.getByTestId("close-btn")).toBeInTheDocument();
-    fireEvent.click(screen.getByTestId("close-btn"));
-    expect(screen.queryByTestId("close-btn")).not.toBeInTheDocument();
+    expect(screen.getByTestId("workflow-detail-title")).toHaveTextContent("환불 처리");
+    expect(screen.getByText("refund.standard")).toBeInTheDocument();
+    expect(screen.getByText("2 nodes")).toBeInTheDocument();
+    expect(screen.getByTestId("graph-viewer")).toHaveTextContent("graph nodes: 2");
+  });
+
+  it("graphJson이 없으면 빈 그래프 안내를 표시한다", () => {
+    mockUseGetWorkflowDefinition.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: { id: 10, name: "환불 처리", workflowCode: "refund.standard" },
+    });
+    renderPage("/workspaces/1/domain-packs/2/versions/3/workflows/10");
+    expect(screen.getByTestId("workflow-empty-graph")).toBeInTheDocument();
+  });
+
+  it("graphJson이 잘못된 문자열이면 빈 그래프 안내를 표시한다", () => {
+    mockUseGetWorkflowDefinition.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: { id: 10, name: "환불 처리", workflowCode: "refund.standard", graphJson: "not-json" },
+    });
+    renderPage("/workspaces/1/domain-packs/2/versions/3/workflows/10");
+    expect(screen.getByTestId("workflow-empty-graph")).toBeInTheDocument();
+  });
+
+  it("편집 버튼 클릭 시 InlineWorkflowEditor가 마운트된다", () => {
+    mockUseGetWorkflowDefinition.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: {
+        id: 10,
+        name: "환불 처리",
+        workflowCode: "refund.standard",
+        graphJson: JSON.stringify({ direction: "LR", nodes: [], edges: [] }),
+      },
+    });
+    renderPage("/workspaces/1/domain-packs/2/versions/3/workflows/10");
+    expect(screen.queryByTestId("inline-editor")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("edit-toggle"));
+    expect(screen.getByTestId("inline-editor")).toHaveTextContent("editing refund.standard");
+  });
+
+  it("편집 모드에서 보기 버튼 클릭 시 viewer로 복귀한다", () => {
+    mockUseGetWorkflowDefinition.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: {
+        id: 10,
+        name: "환불 처리",
+        workflowCode: "refund.standard",
+        graphJson: JSON.stringify({
+          direction: "LR",
+          nodes: [{ id: "n1", label: "s", type: "START" }],
+          edges: [],
+        }),
+      },
+    });
+    renderPage("/workspaces/1/domain-packs/2/versions/3/workflows/10");
+    fireEvent.click(screen.getByTestId("edit-toggle"));
+    expect(screen.getByTestId("inline-editor")).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("view-toggle"));
+    expect(screen.queryByTestId("inline-editor")).not.toBeInTheDocument();
+    expect(screen.getByTestId("graph-viewer")).toBeInTheDocument();
+  });
+
+  it("InlineWorkflowEditor의 onClose가 호출되면 보기 모드로 복귀한다", () => {
+    mockUseGetWorkflowDefinition.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: {
+        id: 10,
+        name: "환불 처리",
+        workflowCode: "refund.standard",
+        graphJson: JSON.stringify({
+          direction: "LR",
+          nodes: [{ id: "n1", label: "s", type: "START" }],
+          edges: [],
+        }),
+      },
+    });
+    renderPage("/workspaces/1/domain-packs/2/versions/3/workflows/10");
+    fireEvent.click(screen.getByTestId("edit-toggle"));
+    fireEvent.click(screen.getByTestId("editor-close"));
+    expect(screen.queryByTestId("inline-editor")).not.toBeInTheDocument();
+  });
+
+  it("'채팅 / Inspector / 24h replay / refund.standard 가짜 헤더' 등은 더 이상 렌더링되지 않는다", () => {
+    mockUseGetWorkflowDefinition.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: {
+        id: 10,
+        name: "환불 처리",
+        workflowCode: "refund.standard",
+        graphJson: JSON.stringify({ direction: "LR", nodes: [], edges: [] }),
+      },
+    });
+    renderPage("/workspaces/1/domain-packs/2/versions/3/workflows/10");
+    // legacy panels gone
+    expect(screen.queryByText(/검토 중 · v0\.4/)).not.toBeInTheDocument();
+    expect(screen.queryByText("Card payment refund flow")).not.toBeInTheDocument();
+    expect(screen.queryByText("Selected node")).not.toBeInTheDocument();
+    expect(screen.queryByText(/Edit graph/)).not.toBeInTheDocument();
+    // tab list gone
+    expect(screen.queryAllByRole("tab")).toHaveLength(0);
   });
 });

--- a/frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { type ReactNode, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { InlineWorkflowEditor } from "@/features/update-workflow";
 import { parseRouteId } from "@/shared/lib/parseRouteId";
@@ -11,16 +11,26 @@ import { useGetWorkflowDefinition } from "@/entities/workflow";
 import type { WorkflowGraph } from "@/entities/workflow";
 import { GraphViewer } from "@/features/workflow-viewer/ui/GraphViewer";
 
+function isWorkflowGraph(v: unknown): v is WorkflowGraph {
+  return (
+    typeof v === "object" &&
+    v !== null &&
+    Array.isArray((v as { nodes?: unknown }).nodes) &&
+    Array.isArray((v as { edges?: unknown }).edges)
+  );
+}
+
 function parseGraphJson(raw: unknown): WorkflowGraph | null {
   if (!raw) return null;
   if (typeof raw === "string") {
     try {
-      return JSON.parse(raw) as WorkflowGraph;
+      const parsed: unknown = JSON.parse(raw);
+      return isWorkflowGraph(parsed) ? parsed : null;
     } catch {
       return null;
     }
   }
-  return raw as WorkflowGraph;
+  return isWorkflowGraph(raw) ? raw : null;
 }
 
 export function WorkflowDraftReadPage() {
@@ -69,6 +79,31 @@ export function WorkflowDraftReadPage() {
     `VER · ${vId}`,
     "Workflows",
   ];
+
+  let graphContent: ReactNode;
+  if (isEditing) {
+    graphContent = (
+      <InlineWorkflowEditor
+        workflow={workflow!}
+        wsId={wsId!}
+        packId={pId!}
+        versionId={vId!}
+        onClose={() => setIsEditing(false)}
+      />
+    );
+  } else if (graph) {
+    graphContent = (
+      <div data-testid="workflow-graph-viewer" style={{ width: "100%", height: "100%" }}>
+        <GraphViewer graph={graph} />
+      </div>
+    );
+  } else {
+    graphContent = (
+      <div data-testid="workflow-empty-graph" style={{ padding: "32px" }}>
+        <EmptyState message="이 워크플로우에는 아직 그래프가 정의되어 있지 않습니다." />
+      </div>
+    );
+  }
 
   return (
     <OstoneShell
@@ -241,27 +276,7 @@ export function WorkflowDraftReadPage() {
             </div>
           )}
 
-          {enabled && !query.isLoading && !query.isError && workflow && (
-            <>
-              {isEditing ? (
-                <InlineWorkflowEditor
-                  workflow={workflow}
-                  wsId={wsId}
-                  packId={pId}
-                  versionId={vId}
-                  onClose={() => setIsEditing(false)}
-                />
-              ) : graph ? (
-                <div data-testid="workflow-graph-viewer" style={{ width: "100%", height: "100%" }}>
-                  <GraphViewer graph={graph} />
-                </div>
-              ) : (
-                <div data-testid="workflow-empty-graph" style={{ padding: "32px" }}>
-                  <EmptyState message="이 워크플로우에는 아직 그래프가 정의되어 있지 않습니다." />
-                </div>
-              )}
-            </>
-          )}
+          {enabled && !query.isLoading && !query.isError && workflow && graphContent}
         </div>
       </div>
     </OstoneShell>

--- a/frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.tsx
@@ -1,125 +1,51 @@
-import { useState } from "react";
-import { useParams, useNavigate } from "react-router-dom";
-import { WorkflowEditSheet } from "../../../features/update-workflow";
-import { parseRouteId } from "../../../shared/lib/parseRouteId";
+import { useMemo, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { InlineWorkflowEditor } from "@/features/update-workflow";
+import { parseRouteId } from "@/shared/lib/parseRouteId";
 import { OstoneShell } from "@/widgets/ostone-shell";
-import { Pill, Mono, Icon, Bar } from "@/shared/ui/ostone/atoms";
-import { PackHeader } from "./sections/PackHeader";
-import { PackTabs } from "./sections/PackTabs";
-import { WorkflowList } from "./sections/WorkflowList";
-import { VersionsTimeline } from "./sections/VersionsTimeline";
-import { MetricsFooter } from "./sections/MetricsFooter";
-import { Inspector } from "./sections/Inspector";
-import { WorkflowCanvas, DEFAULT_NODES, DEFAULT_EDGES } from "./sections/WorkflowCanvas";
+import { Pill, Mono, Icon } from "@/shared/ui/ostone/atoms";
+import { LoadingSpinner } from "@/shared/ui/ostone/atoms/LoadingSpinner";
+import { ErrorState } from "@/shared/ui/ostone/atoms/ErrorState";
+import { EmptyState } from "@/shared/ui/ostone/atoms/EmptyState";
+import { useGetWorkflowDefinition } from "@/entities/workflow";
+import type { WorkflowGraph } from "@/entities/workflow";
+import { GraphViewer } from "@/features/workflow-viewer/ui/GraphViewer";
 
-function HeaderActions() {
-  return (
-    <div style={{ display: "flex", gap: "8px" }}>
-      <button
-        type="button"
-        style={{
-          display: "inline-flex",
-          alignItems: "center",
-          gap: "6px",
-          padding: "6px 12px",
-          borderRadius: "var(--r-2)",
-          border: "1px solid var(--line)",
-          background: "var(--paper-2)",
-          color: "var(--ink-2)",
-          fontFamily: "var(--mono)",
-          fontSize: "11px",
-          cursor: "pointer",
-        }}
-      >
-        <Icon name="download" size={14} />
-        내보내기
-      </button>
-      <button
-        type="button"
-        style={{
-          display: "inline-flex",
-          alignItems: "center",
-          gap: "6px",
-          padding: "6px 12px",
-          borderRadius: "var(--r-2)",
-          border: "1px solid var(--line)",
-          background: "var(--paper-2)",
-          color: "var(--ink-2)",
-          fontFamily: "var(--mono)",
-          fontSize: "11px",
-          cursor: "pointer",
-        }}
-      >
-        <Icon name="play" size={14} />
-        채팅에서 테스트
-      </button>
-      <button
-        type="button"
-        style={{
-          display: "inline-flex",
-          alignItems: "center",
-          gap: "6px",
-          padding: "6px 14px",
-          borderRadius: "var(--r-2)",
-          border: "none",
-          background: "var(--ink)",
-          color: "var(--paper)",
-          fontFamily: "var(--mono)",
-          fontSize: "11px",
-          cursor: "pointer",
-        }}
-      >
-        v0.4 배포하기
-      </button>
-    </div>
-  );
-}
-
-interface LegendChipProps {
-  shape: "diamond" | "circle";
-  bg: string;
-  color: string;
-  label: string;
-}
-
-function LegendChip({ shape, bg, color, label }: LegendChipProps) {
-  return (
-    <div style={{ display: "inline-flex", alignItems: "center", gap: "6px" }}>
-      {shape === "diamond" ? (
-        <span
-          style={{
-            display: "inline-block",
-            width: "8px",
-            height: "8px",
-            background: bg,
-            transform: "rotate(45deg)",
-          }}
-        />
-      ) : (
-        <span
-          style={{
-            display: "inline-block",
-            width: "8px",
-            height: "8px",
-            borderRadius: "50%",
-            background: bg,
-          }}
-        />
-      )}
-      <Mono style={{ fontSize: "10px", color }}>{label}</Mono>
-    </div>
-  );
+function parseGraphJson(raw: unknown): WorkflowGraph | null {
+  if (!raw) return null;
+  if (typeof raw === "string") {
+    try {
+      return JSON.parse(raw) as WorkflowGraph;
+    } catch {
+      return null;
+    }
+  }
+  return raw as WorkflowGraph;
 }
 
 export function WorkflowDraftReadPage() {
   const { workspaceId, packId, versionId, workflowId } = useParams();
   const navigate = useNavigate();
-  const [editOpen, setEditOpen] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
 
   const wsId = parseRouteId(workspaceId);
   const pId = parseRouteId(packId);
   const vId = parseRouteId(versionId);
   const wfId = workflowId ? parseRouteId(workflowId) : null;
+
+  const enabled = wsId !== null && pId !== null && vId !== null && wfId !== null;
+
+  const query = useGetWorkflowDefinition({
+    workspaceId: wsId ?? 0,
+    packId: pId ?? 0,
+    versionId: vId ?? 0,
+    workflowId: wfId ?? 0,
+    enabled,
+  });
+
+  const workflow = query.data;
+  const graph = useMemo<WorkflowGraph | null>(() => parseGraphJson(workflow?.graphJson), [workflow?.graphJson]);
+  const nodeCount = graph?.nodes?.length ?? 0;
 
   if (wsId === null || pId === null || vId === null || (workflowId !== undefined && wfId === null)) {
     return (
@@ -131,180 +57,213 @@ export function WorkflowDraftReadPage() {
     );
   }
 
-  const handleSelect = (id: number) => {
-    setEditOpen(false);
-    navigate(`/workspaces/${wsId}/domain-packs/${pId}/versions/${vId}/workflows/${id}`);
-  };
-
-  const handleBack = () => {
-    setEditOpen(false);
+  const handleBackToList = () => {
+    setIsEditing(false);
     navigate(`/workspaces/${wsId}/domain-packs/${pId}/versions/${vId}/workflows`);
   };
 
-  const hasSelection = wfId !== null;
-
-  void handleSelect;
-  void handleBack;
-  void hasSelection;
+  const crumbs = [
+    `WS · ${wsId}`,
+    "Domain Packs",
+    `PACK · ${pId}`,
+    `VER · ${vId}`,
+    "Workflows",
+  ];
 
   return (
     <OstoneShell
-      active="domain"
-      crumbs={[`WS · ${wsId}`, "Domain Packs", `VER · ${vId}`]}
-      topbarRight={<HeaderActions />}
+      active="workflows"
+      crumbs={crumbs}
+      activePackId={pId}
+      activeWorkflowId={wfId}
     >
-      <div style={{ display: "flex", flexDirection: "column", height: "100%", overflow: "hidden" }}>
-        <PackHeader />
-        <PackTabs />
-
-        <div style={{ display: "flex", flex: 1, overflow: "hidden" }}>
-          {/* Left rail */}
-          <div
-            style={{
-              width: "224px",
-              background: "var(--paper-2)",
-              flexShrink: 0,
-              overflow: "auto",
-              borderRight: "1px solid var(--line-2)",
-            }}
-          >
-            <WorkflowList />
-            <VersionsTimeline />
-          </div>
-
-          {/* Center */}
-          <div style={{ flex: 1, overflow: "auto", display: "flex", flexDirection: "column" }}>
-            {/* Workflow header */}
-            <div
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          height: "100%",
+          overflow: "hidden",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            padding: "14px 20px",
+            borderBottom: "1px solid var(--line-2)",
+            gap: "12px",
+          }}
+        >
+          <div style={{ display: "flex", alignItems: "center", gap: "10px", minWidth: 0 }}>
+            <button
+              type="button"
+              onClick={handleBackToList}
               style={{
-                display: "flex",
+                display: "inline-flex",
                 alignItems: "center",
-                justifyContent: "space-between",
-                padding: "14px 20px",
-                borderBottom: "1px solid var(--line-2)",
-              }}
-            >
-              <div style={{ display: "flex", alignItems: "center", gap: "10px" }}>
-                <h2
-                  style={{
-                    fontFamily: "var(--sans)",
-                    fontSize: "16px",
-                    fontWeight: 500,
-                    margin: 0,
-                    color: "var(--ink)",
-                  }}
-                >
-                  refund.standard
-                </h2>
-                <Pill tone="signal">DRAFT</Pill>
-                <Mono style={{ fontSize: "11px", color: "var(--ink-3)" }}>wf-218</Mono>
-                <Mono style={{ fontSize: "11px", color: "var(--ink-3)" }}>
-                  7 nodes · 2 risk gates · trained on 1,389 conversations
-                </Mono>
-              </div>
-              <div style={{ display: "flex", alignItems: "center", gap: "12px" }}>
-                <Mono style={{ fontSize: "11px", color: "var(--ink-3)" }}>Zoom: 100%</Mono>
-                <button
-                  type="button"
-                  onClick={() => setEditOpen(true)}
-                  style={{
-                    display: "inline-flex",
-                    alignItems: "center",
-                    gap: "6px",
-                    padding: "6px 12px",
-                    borderRadius: "var(--r-2)",
-                    border: "1px solid var(--line)",
-                    background: "var(--paper-2)",
-                    color: "var(--ink-2)",
-                    fontFamily: "var(--mono)",
-                    fontSize: "11px",
-                    cursor: "pointer",
-                  }}
-                >
-                  <Icon name="edit" size={14} />
-                  Edit graph
-                </button>
-              </div>
-            </div>
-
-            {/* Legend */}
-            <div style={{ display: "flex", gap: "12px", padding: "8px 20px" }}>
-              <LegendChip shape="diamond" bg="var(--paper-3)" color="var(--ink)" label="decision" />
-              <LegendChip shape="circle" bg="var(--danger-bg)" color="var(--danger)" label="risk" />
-              <LegendChip shape="circle" bg="var(--warn-bg)" color="var(--warn)" label="human" />
-              <LegendChip shape="circle" bg="var(--signal-bg)" color="var(--signal)" label="task" />
-            </div>
-
-            <div
-              style={{
-                flex: 1,
-                minHeight: "300px",
-                position: "relative",
-                margin: "0 20px 12px",
+                gap: "4px",
+                padding: "4px 8px",
                 borderRadius: "var(--r-2)",
-                border: "1px solid var(--line-2)",
-                background: "var(--paper)",
-                overflow: "hidden",
+                border: "1px solid var(--line)",
+                background: "var(--paper-2)",
+                color: "var(--ink-2)",
+                fontFamily: "var(--mono)",
+                fontSize: "11px",
+                cursor: "pointer",
               }}
             >
-              <WorkflowCanvas nodes={DEFAULT_NODES} edges={DEFAULT_EDGES} />
-            </div>
-
-            {/* Metrics footer */}
-            <MetricsFooter />
-
-            {/* 24h replay strip */}
-            <div
+              <Icon name="chevron" size={12} />
+              목록
+            </button>
+            <h2
+              data-testid="workflow-detail-title"
               style={{
-                display: "flex",
-                alignItems: "center",
-                gap: "8px",
-                padding: "8px 16px",
-                overflowX: "auto",
-                borderTop: "1px solid var(--line-2)",
+                fontFamily: "var(--sans)",
+                fontSize: "16px",
+                fontWeight: 500,
+                margin: 0,
+                color: "var(--ink)",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
               }}
             >
-              {Array.from({ length: 24 }).map((_, i) => (
-                <div key={i} style={{ flexShrink: 0, textAlign: "center" }}>
-                  <Bar
-                    value={0.2 + ((i * 7 + 11) % 7) * 0.1}
-                    tone={i % 5 === 0 ? "signal" : "ink"}
-                    w={24}
-                    h={3}
-                  />
-                  <Mono style={{ fontSize: "9px", color: "var(--ink-4)", marginTop: "2px" }}>
-                    {i}h
-                  </Mono>
-                </div>
-              ))}
-            </div>
+              {workflow?.name || (query.isLoading ? "워크플로우 로드 중..." : "워크플로우")}
+            </h2>
+            {workflow?.workflowCode && (
+              <Mono style={{ fontSize: "11px", color: "var(--ink-3)" }}>{workflow.workflowCode}</Mono>
+            )}
+            {workflow && (
+              <Pill tone="signal">DRAFT</Pill>
+            )}
+            {workflow && (
+              <Mono style={{ fontSize: "11px", color: "var(--ink-3)" }}>
+                {nodeCount} nodes
+              </Mono>
+            )}
           </div>
 
-          {/* Right inspector */}
-          <div
-            style={{
-              width: "320px",
-              background: "var(--paper-2)",
-              flexShrink: 0,
-              overflow: "auto",
-              borderLeft: "1px solid var(--line-2)",
-            }}
-          >
-            <Inspector />
+          <div style={{ display: "flex", alignItems: "center", gap: "8px", flexShrink: 0 }}>
+            {workflow && !isEditing && (
+              <button
+                type="button"
+                data-testid="edit-toggle"
+                onClick={() => setIsEditing(true)}
+                style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: "6px",
+                  padding: "6px 12px",
+                  borderRadius: "var(--r-2)",
+                  border: "1px solid var(--line)",
+                  background: "var(--paper-2)",
+                  color: "var(--ink-2)",
+                  fontFamily: "var(--mono)",
+                  fontSize: "11px",
+                  cursor: "pointer",
+                }}
+              >
+                <Icon name="edit" size={14} />
+                편집
+              </button>
+            )}
+            {workflow && isEditing && (
+              <button
+                type="button"
+                data-testid="view-toggle"
+                onClick={() => setIsEditing(false)}
+                style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: "6px",
+                  padding: "6px 12px",
+                  borderRadius: "var(--r-2)",
+                  border: "1px solid var(--line)",
+                  background: "var(--paper-2)",
+                  color: "var(--ink-2)",
+                  fontFamily: "var(--mono)",
+                  fontSize: "11px",
+                  cursor: "pointer",
+                }}
+              >
+                <Icon name="eye" size={14} />
+                보기
+              </button>
+            )}
           </div>
         </div>
-      </div>
 
-      {wfId !== null && (
-        <WorkflowEditSheet
-          wsId={wsId}
-          packId={pId}
-          versionId={vId}
-          workflowId={wfId}
-          isOpen={editOpen}
-          onClose={() => setEditOpen(false)}
-        />
-      )}
+        <div
+          style={{
+            flex: 1,
+            position: "relative",
+            margin: "12px 20px 20px",
+            borderRadius: "var(--r-2)",
+            border: "1px solid var(--line-2)",
+            background: "var(--paper)",
+            overflow: "hidden",
+            minHeight: "400px",
+          }}
+        >
+          {!enabled && (
+            <div
+              data-testid="workflow-select-empty"
+              style={{ padding: "32px", textAlign: "center", color: "var(--ink-3)" }}
+            >
+              좌측 사이드바에서 워크플로우를 선택하세요.
+            </div>
+          )}
+
+          {enabled && query.isLoading && (
+            <div
+              data-testid="workflow-loading"
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                height: "100%",
+                flexDirection: "column",
+                gap: "12px",
+              }}
+            >
+              <LoadingSpinner />
+              <Mono style={{ fontSize: "11px", color: "var(--ink-3)" }}>워크플로우 로드 중...</Mono>
+            </div>
+          )}
+
+          {enabled && query.isError && (
+            <div data-testid="workflow-error" style={{ padding: "32px" }}>
+              <ErrorState
+                message="워크플로우를 불러오지 못했습니다."
+                onRetry={() => query.refetch()}
+              />
+            </div>
+          )}
+
+          {enabled && !query.isLoading && !query.isError && workflow && (
+            <>
+              {isEditing ? (
+                <InlineWorkflowEditor
+                  workflow={workflow}
+                  wsId={wsId}
+                  packId={pId}
+                  versionId={vId}
+                  onClose={() => setIsEditing(false)}
+                />
+              ) : graph ? (
+                <div data-testid="workflow-graph-viewer" style={{ width: "100%", height: "100%" }}>
+                  <GraphViewer graph={graph} />
+                </div>
+              ) : (
+                <div data-testid="workflow-empty-graph" style={{ padding: "32px" }}>
+                  <EmptyState message="이 워크플로우에는 아직 그래프가 정의되어 있지 않습니다." />
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </div>
     </OstoneShell>
   );
 }

--- a/frontend/src/pages/workspace/ui/WorkspaceLayout.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceLayout.tsx
@@ -1,17 +1,12 @@
 import { useEffect, useMemo, useState, type ReactNode } from "react";
-import { Navigate, Outlet, useLocation, useNavigate, useParams } from "react-router-dom";
+import { Navigate, Outlet, useLocation, useParams } from "react-router-dom";
 import type { ShellContext, SidebarActive } from "@/shared/ui/ostone/chrome";
 
 import {
   mapWorkspaceActionError,
   type WorkspaceResponse,
 } from "@/entities/workspace";
-import { useListWorkspaces, useGetWorkspace } from "@/shared/api/generated/endpoints/workspace-controller/workspace-controller";
-import {
-  ArchiveConfirmDialog,
-  CreateWorkspaceDialog,
-  EditWorkspaceDialog,
-} from "@/features/workspace";
+import { useGetWorkspace } from "@/shared/api/generated/endpoints/workspace-controller/workspace-controller";
 import { ErrorState } from "@/shared/ui/ostone/atoms/ErrorState";
 import { LoadingSpinner } from "@/shared/ui/ostone/atoms/LoadingSpinner";
 import { OstoneShell } from "@/widgets/ostone-shell";
@@ -30,29 +25,17 @@ const getActiveFromPath = (pathname: string): SidebarActive => {
 export function WorkspaceLayout() {
   const { workspaceId } = useParams();
   const location = useLocation();
-  const navigate = useNavigate();
   const parsedWorkspaceId = parseRouteId(workspaceId);
   const basePath = parsedWorkspaceId ? `/workspaces/${parsedWorkspaceId}` : "/workspaces";
   const [workspace, setWorkspace] = useState<WorkspaceResponse | null>(null);
   const [isLoading, setIsLoading] = useState(parsedWorkspaceId !== null);
   const [error, setError] = useState("");
-  const [workspaces, setWorkspaces] = useState<WorkspaceResponse[]>([]);
-  const [isCreateOpen, setIsCreateOpen] = useState(false);
-  const [editTarget, setEditTarget] = useState<WorkspaceResponse | null>(null);
-  const [archiveTarget, setArchiveTarget] = useState<WorkspaceResponse | null>(null);
   const [topbarRight, setTopbarRight] = useState<ReactNode>(null);
   const [crumbs, setCrumbs] = useState<string[]>([]);
   const active = getActiveFromPath(location.pathname);
 
-  const { data: fetchedWorkspaces, refetch: refetchWorkspaces } = useListWorkspaces();
   const { data: fetchedWorkspace, isLoading: isFetchingWorkspace, error: fetchError, refetch: refetchWorkspace } =
     useGetWorkspace(parsedWorkspaceId ?? 0, { query: { enabled: parsedWorkspaceId !== null } });
-
-  useEffect(() => {
-    if (fetchedWorkspaces) {
-      setWorkspaces(fetchedWorkspaces as unknown as WorkspaceResponse[]);
-    }
-  }, [fetchedWorkspaces]);
 
   useEffect(() => {
     if (fetchedWorkspace) {
@@ -76,22 +59,6 @@ export function WorkspaceLayout() {
     return <Navigate to="/workspaces" replace />;
   }
 
-  const subPath = location.pathname.replace(/\/workspaces\/[^/]+/, "");
-
-  const handleSwitch = (newWorkspaceId: number) => {
-    const targetSubPath = subPath || "/workflows";
-    navigate(`/workspaces/${newWorkspaceId}${targetSubPath}`, { replace: true });
-  };
-
-  const refreshWorkspaceList = () => {
-    refetchWorkspaces();
-  };
-
-  // workspace switch UI now lives in OstoneShell's default WorkspaceMarker.
-  // Create/Edit/Archive dialogs are retained but currently not triggered from
-  // the sidebar — re-wire from elsewhere when needed.
-  void handleSwitch;
-  void workspaces;
   const outletContext: ShellContext = { setTopbarRight, setCrumbs, workspace };
 
   if (isLoading) {
@@ -134,23 +101,6 @@ export function WorkspaceLayout() {
       basePath={basePath}
     >
       <Outlet context={outletContext} />
-      <CreateWorkspaceDialog
-        open={isCreateOpen}
-        onOpenChange={setIsCreateOpen}
-        onSuccess={refreshWorkspaceList}
-      />
-      <EditWorkspaceDialog
-        workspace={editTarget}
-        open={editTarget !== null}
-        onOpenChange={() => setEditTarget(null)}
-        onSuccess={refreshWorkspaceList}
-      />
-      <ArchiveConfirmDialog
-        workspace={archiveTarget}
-        open={archiveTarget !== null}
-        onOpenChange={() => setArchiveTarget(null)}
-        onSuccess={refreshWorkspaceList}
-      />
     </OstoneShell>
   );
 }

--- a/frontend/src/pages/workspace/ui/WorkspaceLayout.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceLayout.tsx
@@ -11,7 +11,6 @@ import {
   ArchiveConfirmDialog,
   CreateWorkspaceDialog,
   EditWorkspaceDialog,
-  WorkspaceSwitcher,
 } from "@/features/workspace";
 import { ErrorState } from "@/shared/ui/ostone/atoms/ErrorState";
 import { LoadingSpinner } from "@/shared/ui/ostone/atoms/LoadingSpinner";
@@ -88,21 +87,16 @@ export function WorkspaceLayout() {
     refetchWorkspaces();
   };
 
-  const sidebarSwitcher = (
-    <WorkspaceSwitcher
-      workspaces={workspaces}
-      currentWorkspaceId={parsedWorkspaceId}
-      onSwitch={handleSwitch}
-      onCreate={() => setIsCreateOpen(true)}
-      onEdit={(w) => setEditTarget(w)}
-      onArchive={(w) => setArchiveTarget(w)}
-    />
-  );
+  // workspace switch UI now lives in OstoneShell's default WorkspaceMarker.
+  // Create/Edit/Archive dialogs are retained but currently not triggered from
+  // the sidebar — re-wire from elsewhere when needed.
+  void handleSwitch;
+  void workspaces;
   const outletContext: ShellContext = { setTopbarRight, setCrumbs, workspace };
 
   if (isLoading) {
     return (
-      <OstoneShell active={active} crumbs={[]} basePath={basePath} sidebarSwitcher={sidebarSwitcher}>
+      <OstoneShell active={active} crumbs={[]} basePath={basePath}>
         <div
           style={{
             display: "flex",
@@ -123,7 +117,7 @@ export function WorkspaceLayout() {
 
   if (error || !workspace) {
     return (
-      <OstoneShell active={active} crumbs={[]} basePath={basePath} sidebarSwitcher={sidebarSwitcher}>
+      <OstoneShell active={active} crumbs={[]} basePath={basePath}>
         <ErrorState
           message={error || "워크스페이스를 찾을 수 없습니다."}
           onRetry={refetchWorkspace}
@@ -138,7 +132,6 @@ export function WorkspaceLayout() {
       crumbs={crumbs.length > 0 ? crumbs : defaultCrumbs}
       topbarRight={topbarRight}
       basePath={basePath}
-      sidebarSwitcher={sidebarSwitcher}
     >
       <Outlet context={outletContext} />
       <CreateWorkspaceDialog

--- a/frontend/src/pages/workspace/ui/WorkspaceWorkflowsPage.test.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceWorkflowsPage.test.tsx
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { WorkspaceWorkflowsPage } from './WorkspaceWorkflowsPage';
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+const mockHook = vi.fn();
+vi.mock('@/entities/workflow', () => ({
+  useListAllWorkspaceWorkflows: (...args: unknown[]) => mockHook(...args),
+}));
+
+vi.mock('sonner', () => ({ toast: vi.fn() }));
+
+function renderPage(path = '/workspaces/1/workflows') {
+  render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/workspaces/:workspaceId/workflows" element={<WorkspaceWorkflowsPage />} />
+        <Route path="/workspaces" element={<div data-testid="workspace-root" />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  mockNavigate.mockReset();
+  mockHook.mockReset();
+});
+
+describe('WorkspaceWorkflowsPage', () => {
+  it('잘못된 workspaceId면 /workspaces로 리다이렉트한다', () => {
+    mockHook.mockReturnValue({ loading: false, error: null, entries: [] });
+    renderPage('/workspaces/abc/workflows');
+    expect(screen.getByTestId('workspace-root')).toBeInTheDocument();
+  });
+
+  it('loading 상태에서는 loading panel을 보여준다', () => {
+    mockHook.mockReturnValue({ loading: true, error: null, entries: [] });
+    renderPage();
+    expect(screen.getByTestId('workspace-workflows-loading')).toBeInTheDocument();
+  });
+
+  it('error 상태에서는 ErrorState를 보여준다', () => {
+    mockHook.mockReturnValue({ loading: false, error: '워크플로우 목록 조회 실패', entries: [] });
+    renderPage();
+    expect(screen.getByTestId('workspace-workflows-error')).toBeInTheDocument();
+    expect(screen.getByText('워크플로우 목록 조회 실패')).toBeInTheDocument();
+  });
+
+  it('entries 비어 있으면 empty state를 보여준다', () => {
+    mockHook.mockReturnValue({ loading: false, error: null, entries: [] });
+    renderPage();
+    expect(screen.getByTestId('workspace-workflows-empty')).toBeInTheDocument();
+  });
+
+  it('entries가 있으면 카드별로 렌더링한다', () => {
+    mockHook.mockReturnValue({
+      loading: false,
+      error: null,
+      entries: [
+        {
+          packId: 11,
+          packName: 'CS Support',
+          versionId: 22,
+          workflowId: 100,
+          workflowCode: 'refund.standard',
+          name: '환불 처리',
+          description: 'desc',
+        },
+        {
+          packId: 12,
+          packName: 'Billing',
+          versionId: 30,
+          workflowId: 200,
+          workflowCode: null,
+          name: '카드 변경',
+          description: null,
+        },
+      ],
+    });
+    renderPage();
+    expect(screen.getByTestId('workflow-card-100')).toBeInTheDocument();
+    expect(screen.getByText('환불 처리')).toBeInTheDocument();
+    expect(screen.getByText('refund.standard')).toBeInTheDocument();
+    expect(screen.getByTestId('workflow-card-200')).toBeInTheDocument();
+    expect(screen.getByText('카드 변경')).toBeInTheDocument();
+  });
+
+  it('카드 클릭 시 실제 packId/versionId/workflowId 경로로 navigate한다', () => {
+    mockHook.mockReturnValue({
+      loading: false,
+      error: null,
+      entries: [
+        {
+          packId: 11,
+          packName: 'CS Support',
+          versionId: 22,
+          workflowId: 100,
+          workflowCode: null,
+          name: '환불 처리',
+          description: null,
+        },
+      ],
+    });
+    renderPage();
+    fireEvent.click(screen.getByTestId('workflow-card-100'));
+    expect(mockNavigate).toHaveBeenCalledWith(
+      '/workspaces/1/domain-packs/11/versions/22/workflows/100',
+    );
+  });
+
+  it('카드에서 Enter 키 입력 시에도 navigate한다', () => {
+    mockHook.mockReturnValue({
+      loading: false,
+      error: null,
+      entries: [
+        {
+          packId: 11,
+          packName: 'CS Support',
+          versionId: 22,
+          workflowId: 100,
+          workflowCode: null,
+          name: '환불 처리',
+          description: null,
+        },
+      ],
+    });
+    renderPage();
+    fireEvent.keyDown(screen.getByTestId('workflow-card-100'), { key: 'Enter' });
+    expect(mockNavigate).toHaveBeenCalledWith(
+      '/workspaces/1/domain-packs/11/versions/22/workflows/100',
+    );
+  });
+
+  it('새 워크플로우 버튼 클릭 시 toast 호출', async () => {
+    mockHook.mockReturnValue({ loading: false, error: null, entries: [] });
+    const sonner = await import('sonner');
+    renderPage();
+    fireEvent.click(screen.getByText('새 워크플로우'));
+    expect(sonner.toast).toHaveBeenCalledWith('준비 중입니다');
+  });
+});

--- a/frontend/src/pages/workspace/ui/WorkspaceWorkflowsPage.test.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceWorkflowsPage.test.tsx
@@ -19,6 +19,23 @@ vi.mock('@/entities/workflow', () => ({
 
 vi.mock('sonner', () => ({ toast: vi.fn() }));
 
+vi.mock('@/features/workflow-list', () => ({
+  WorkflowListView: vi.fn(({ entries, onOpen }) => (
+    <div data-testid="workflow-list-view">
+      {entries.map((entry: { workflowId: number; name: string; packId: number; versionId: number }) => (
+        <button
+          key={entry.workflowId}
+          type="button"
+          data-testid={`workspace-workflows-card-${entry.workflowId}`}
+          onClick={() => onOpen(entry)}
+        >
+          {entry.name}
+        </button>
+      ))}
+    </div>
+  )),
+}));
+
 function renderPage(path = '/workspaces/1/workflows') {
   render(
     <MemoryRouter initialEntries={[path]}>
@@ -61,7 +78,7 @@ describe('WorkspaceWorkflowsPage', () => {
     expect(screen.getByTestId('workspace-workflows-empty')).toBeInTheDocument();
   });
 
-  it('entries가 있으면 카드별로 렌더링한다', () => {
+  it('entries가 있으면 WorkflowListView로 전달한다', () => {
     mockHook.mockReturnValue({
       loading: false,
       error: null,
@@ -75,26 +92,14 @@ describe('WorkspaceWorkflowsPage', () => {
           name: '환불 처리',
           description: 'desc',
         },
-        {
-          packId: 12,
-          packName: 'Billing',
-          versionId: 30,
-          workflowId: 200,
-          workflowCode: null,
-          name: '카드 변경',
-          description: null,
-        },
       ],
     });
     renderPage();
-    expect(screen.getByTestId('workflow-card-100')).toBeInTheDocument();
-    expect(screen.getByText('환불 처리')).toBeInTheDocument();
-    expect(screen.getByText('refund.standard')).toBeInTheDocument();
-    expect(screen.getByTestId('workflow-card-200')).toBeInTheDocument();
-    expect(screen.getByText('카드 변경')).toBeInTheDocument();
+    expect(screen.getByTestId('workflow-list-view')).toBeInTheDocument();
+    expect(screen.getByTestId('workspace-workflows-card-100')).toHaveTextContent('환불 처리');
   });
 
-  it('카드 클릭 시 실제 packId/versionId/workflowId 경로로 navigate한다', () => {
+  it('카드에서 열기(onOpen) 시 실제 packId/versionId/workflowId 경로로 navigate한다', () => {
     mockHook.mockReturnValue({
       loading: false,
       error: null,
@@ -111,30 +116,7 @@ describe('WorkspaceWorkflowsPage', () => {
       ],
     });
     renderPage();
-    fireEvent.click(screen.getByTestId('workflow-card-100'));
-    expect(mockNavigate).toHaveBeenCalledWith(
-      '/workspaces/1/domain-packs/11/versions/22/workflows/100',
-    );
-  });
-
-  it('카드에서 Enter 키 입력 시에도 navigate한다', () => {
-    mockHook.mockReturnValue({
-      loading: false,
-      error: null,
-      entries: [
-        {
-          packId: 11,
-          packName: 'CS Support',
-          versionId: 22,
-          workflowId: 100,
-          workflowCode: null,
-          name: '환불 처리',
-          description: null,
-        },
-      ],
-    });
-    renderPage();
-    fireEvent.keyDown(screen.getByTestId('workflow-card-100'), { key: 'Enter' });
+    fireEvent.click(screen.getByTestId('workspace-workflows-card-100'));
     expect(mockNavigate).toHaveBeenCalledWith(
       '/workspaces/1/domain-packs/11/versions/22/workflows/100',
     );

--- a/frontend/src/pages/workspace/ui/WorkspaceWorkflowsPage.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceWorkflowsPage.tsx
@@ -5,10 +5,10 @@ import { toast } from "sonner";
 import { useListAllWorkspaceWorkflows } from "@/entities/workflow";
 import { parseRouteId } from "@/shared/lib/parseRouteId";
 import { Button } from "@/shared/ui/button";
-import { Pill, Mono } from "@/shared/ui/ostone/atoms";
 import { LoadingSpinner } from "@/shared/ui/ostone/atoms/LoadingSpinner";
 import { ErrorState } from "@/shared/ui/ostone/atoms/ErrorState";
 import { EmptyState } from "@/shared/ui/ostone/atoms/EmptyState";
+import { WorkflowListView } from "@/features/workflow-list";
 
 import styles from "./workspace-workflows-page.module.css";
 
@@ -25,9 +25,9 @@ export function WorkspaceWorkflowsPage() {
     return <Navigate to="/workspaces" replace />;
   }
 
-  const handleCardClick = (packId: number, versionId: number, workflowId: number) => {
+  const handleOpen = (entry: { packId: number; versionId: number; workflowId: number }) => {
     navigate(
-      `/workspaces/${parsedWorkspaceId}/domain-packs/${packId}/versions/${versionId}/workflows/${workflowId}`,
+      `/workspaces/${parsedWorkspaceId}/domain-packs/${entry.packId}/versions/${entry.versionId}/workflows/${entry.workflowId}`,
     );
   };
 
@@ -65,44 +65,11 @@ export function WorkspaceWorkflowsPage() {
       )}
 
       {!loading && !error && entries.length > 0 && (
-        <div className={styles.workflowGrid}>
-          {entries.map((wf) => (
-            <article
-              key={`${wf.packId}-${wf.workflowId}`}
-              className={styles.workflowCard}
-              onClick={() => handleCardClick(wf.packId, wf.versionId, wf.workflowId)}
-              role="button"
-              tabIndex={0}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" || e.key === " ") {
-                  e.preventDefault();
-                  handleCardClick(wf.packId, wf.versionId, wf.workflowId);
-                }
-              }}
-              data-testid={`workflow-card-${wf.workflowId}`}
-            >
-              <div className={styles.workflowCardInner}>
-                <div className={styles.workflowCardHeader}>
-                  <div className={styles.workflowMeta}>
-                    <Pill tone="mute">{wf.packName}</Pill>
-                    {wf.workflowCode && <Mono className={styles.workflowCode}>{wf.workflowCode}</Mono>}
-                  </div>
-                </div>
-
-                <div className={styles.workflowCardContent}>
-                  <h2 className={styles.workflowTitle}>{wf.name}</h2>
-                  {wf.description && <p className={styles.workflowDescription}>{wf.description}</p>}
-                </div>
-
-                <div className={styles.workflowCardFooter}>
-                  <Mono className={styles.workflowMetaCount}>
-                    pack #{wf.packId} · version #{wf.versionId}
-                  </Mono>
-                </div>
-              </div>
-            </article>
-          ))}
-        </div>
+        <WorkflowListView
+          entries={entries}
+          onOpen={handleOpen}
+          testIdPrefix="workspace-workflows"
+        />
       )}
     </div>
   );

--- a/frontend/src/pages/workspace/ui/WorkspaceWorkflowsPage.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceWorkflowsPage.tsx
@@ -2,67 +2,32 @@ import { PlusIcon } from "lucide-react";
 import { Navigate, useNavigate, useParams } from "react-router-dom";
 import { toast } from "sonner";
 
+import { useListAllWorkspaceWorkflows } from "@/entities/workflow";
 import { parseRouteId } from "@/shared/lib/parseRouteId";
 import { Button } from "@/shared/ui/button";
 import { Pill, Mono } from "@/shared/ui/ostone/atoms";
+import { LoadingSpinner } from "@/shared/ui/ostone/atoms/LoadingSpinner";
+import { ErrorState } from "@/shared/ui/ostone/atoms/ErrorState";
+import { EmptyState } from "@/shared/ui/ostone/atoms/EmptyState";
 
 import styles from "./workspace-workflows-page.module.css";
-
-const MOCK_WORKFLOWS = [
-  {
-    id: 1,
-    name: "반품 접수 처리",
-    description: "고객 반품 요청부터 환불 승인까지의 워크플로우",
-    status: "active" as const,
-    nodeCount: 5,
-    edgeCount: 4,
-  },
-  {
-    id: 2,
-    name: "배송 지연 응대",
-    description: "배송 지연 문의 시 자동 응대 및 보상 처리",
-    status: "active" as const,
-    nodeCount: 7,
-    edgeCount: 6,
-  },
-  {
-    id: 3,
-    name: "계정 잠금 해제",
-    description: "로그인 실패로 인한 계정 잠금 해제 프로세스",
-    status: "active" as const,
-    nodeCount: 4,
-    edgeCount: 3,
-  },
-  {
-    id: 4,
-    name: "멤버십 등급 조정",
-    description: "고객 멤버십 등급 상향/하향 검토 및 안내",
-    status: "draft" as const,
-    nodeCount: 6,
-    edgeCount: 5,
-  },
-  {
-    id: 5,
-    name: "상품 교환 절차",
-    description: "불량 상품 교환 접수 및 배송 추적",
-    status: "draft" as const,
-    nodeCount: 8,
-    edgeCount: 7,
-  },
-];
 
 export function WorkspaceWorkflowsPage() {
   const navigate = useNavigate();
   const { workspaceId } = useParams();
   const parsedWorkspaceId = parseRouteId(workspaceId);
 
+  const { loading, error, entries } = useListAllWorkspaceWorkflows({
+    workspaceId: parsedWorkspaceId,
+  });
+
   if (parsedWorkspaceId === null) {
     return <Navigate to="/workspaces" replace />;
   }
 
-  const handleCardClick = (id: number) => {
+  const handleCardClick = (packId: number, versionId: number, workflowId: number) => {
     navigate(
-      `/workspaces/${parsedWorkspaceId}/domain-packs/1/versions/1/workflows/${id}`,
+      `/workspaces/${parsedWorkspaceId}/domain-packs/${packId}/versions/${versionId}/workflows/${workflowId}`,
     );
   };
 
@@ -74,57 +39,71 @@ export function WorkspaceWorkflowsPage() {
     <div className={styles.pageWrapper}>
       <div className={styles.pageHeader}>
         <h1 className={styles.pageTitle}>Workflows</h1>
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={handleNewWorkflow}
-        >
+        <Button variant="outline" size="sm" onClick={handleNewWorkflow}>
           <PlusIcon className={styles.pageHeaderIcon} />
           <span>새 워크플로우</span>
         </Button>
       </div>
 
-      <div className={styles.workflowGrid}>
-        {MOCK_WORKFLOWS.map((workflow) => (
-          <article
-            key={workflow.id}
-            className={styles.workflowCard}
-            onClick={() => handleCardClick(workflow.id)}
-            role="button"
-            tabIndex={0}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" || e.key === " ") {
-                handleCardClick(workflow.id);
-              }
-            }}
-          >
-            <div className={styles.workflowCardInner}>
-              <div className={styles.workflowCardHeader}>
-                <div className={styles.workflowMeta}>
-                  <Pill
-                    tone={workflow.status === "active" ? "signal" : "mute"}
-                  >
-                    {workflow.status === "active" ? "ACTIVE" : "DRAFT"}
-                  </Pill>
+      {loading && (
+        <div className={styles.statePanel} data-testid="workspace-workflows-loading">
+          <LoadingSpinner />
+          <p className={styles.stateText}>워크플로우 목록을 불러오는 중입니다.</p>
+        </div>
+      )}
+
+      {!loading && error && (
+        <div data-testid="workspace-workflows-error">
+          <ErrorState message={error} />
+        </div>
+      )}
+
+      {!loading && !error && entries.length === 0 && (
+        <div className={styles.statePanel} data-testid="workspace-workflows-empty">
+          <EmptyState message="아직 등록된 워크플로우가 없습니다. 도메인팩에서 워크플로우를 생성해 주세요." />
+        </div>
+      )}
+
+      {!loading && !error && entries.length > 0 && (
+        <div className={styles.workflowGrid}>
+          {entries.map((wf) => (
+            <article
+              key={`${wf.packId}-${wf.workflowId}`}
+              className={styles.workflowCard}
+              onClick={() => handleCardClick(wf.packId, wf.versionId, wf.workflowId)}
+              role="button"
+              tabIndex={0}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  handleCardClick(wf.packId, wf.versionId, wf.workflowId);
+                }
+              }}
+              data-testid={`workflow-card-${wf.workflowId}`}
+            >
+              <div className={styles.workflowCardInner}>
+                <div className={styles.workflowCardHeader}>
+                  <div className={styles.workflowMeta}>
+                    <Pill tone="mute">{wf.packName}</Pill>
+                    {wf.workflowCode && <Mono className={styles.workflowCode}>{wf.workflowCode}</Mono>}
+                  </div>
+                </div>
+
+                <div className={styles.workflowCardContent}>
+                  <h2 className={styles.workflowTitle}>{wf.name}</h2>
+                  {wf.description && <p className={styles.workflowDescription}>{wf.description}</p>}
+                </div>
+
+                <div className={styles.workflowCardFooter}>
+                  <Mono className={styles.workflowMetaCount}>
+                    pack #{wf.packId} · version #{wf.versionId}
+                  </Mono>
                 </div>
               </div>
-
-              <div className={styles.workflowCardContent}>
-                <h2 className={styles.workflowTitle}>{workflow.name}</h2>
-                <p className={styles.workflowDescription}>
-                  {workflow.description}
-                </p>
-              </div>
-
-              <div className={styles.workflowCardFooter}>
-                <Mono className={styles.workflowMetaCount}>
-                  {workflow.nodeCount} nodes · {workflow.edgeCount} edges
-                </Mono>
-              </div>
-            </div>
-          </article>
-        ))}
-      </div>
+            </article>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/workspace/ui/workspace-workflows-page.module.css
+++ b/frontend/src/pages/workspace/ui/workspace-workflows-page.module.css
@@ -1,18 +1,23 @@
 .pageWrapper {
   padding: var(--s-6) var(--s-8);
+  display: flex;
+  flex-direction: column;
+  gap: var(--s-5);
 }
 
 .pageHeader {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: var(--s-6);
+  gap: var(--s-3);
 }
 
 .pageTitle {
-  font-size: 1.5rem;
-  font-weight: 540;
-  letter-spacing: -0.02em;
+  font-family: var(--sans);
+  font-size: 22px;
+  font-weight: 500;
+  color: var(--ink);
+  letter-spacing: -0.26px;
   margin: 0;
 }
 
@@ -36,150 +41,7 @@
   background: var(--paper-2);
 }
 
-.stateSpinner {
-  width: 28px;
-  height: 28px;
-}
-
-.stateTitle {
-  font-size: 1.1rem;
-  font-weight: 540;
-}
-
 .stateText {
   color: var(--ink-2);
   line-height: 1.6;
-}
-
-.workflowGrid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: var(--s-5);
-}
-
-.workflowCard {
-  border-radius: var(--r-3);
-  border: 1px solid var(--line);
-  box-shadow: var(--shadow-card);
-  cursor: pointer;
-  background: var(--paper);
-  transition: box-shadow 0.15s ease, transform 0.15s ease;
-}
-
-.workflowCard:hover {
-  box-shadow: var(--shadow-card-hover);
-  transform: translateY(-1px);
-}
-
-.workflowCardInner {
-  padding: var(--s-5);
-  display: flex;
-  flex-direction: column;
-  gap: var(--s-4);
-}
-
-.workflowCardHeader {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: var(--s-3);
-}
-
-.workflowMeta {
-  display: flex;
-  align-items: center;
-  gap: var(--s-2);
-  flex-wrap: wrap;
-}
-
-.workflowPack,
-.workflowVersion,
-.workflowCode {
-  font-family: var(--mono);
-  font-size: 0.74rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.workflowPack,
-.workflowVersion {
-  width: fit-content;
-  padding: var(--s-1) var(--s-2);
-  border-radius: var(--r-pill);
-  border: 1px solid var(--line);
-}
-
-.workflowTitle {
-  font-size: 1.18rem;
-  letter-spacing: -0.02em;
-  margin: 0;
-}
-
-.workflowCardContent {
-  display: grid;
-  gap: var(--s-3);
-}
-
-.workflowCode {
-  color: var(--ink);
-}
-
-.workflowDescription {
-  color: var(--ink-2);
-  line-height: 1.6;
-  margin: 0;
-}
-
-.workflowCardFooter {
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
-  padding-top: var(--s-3);
-  border-top: 1px solid var(--line);
-}
-
-.workflowMetaCount {
-  font-size: 11px;
-  color: var(--ink-3);
-}
-
-.emptyContent {
-  gap: var(--s-2);
-}
-
-.emptyHint {
-  margin: 0;
-  color: var(--ink-2);
-  font-size: 0.86rem;
-  line-height: 1.5;
-}
-
-.emptyAction {
-  min-height: 38px;
-  border: 1px solid var(--line);
-  border-radius: var(--r-pill);
-  background: var(--paper-2);
-  color: var(--ink);
-  font-size: 0.92rem;
-  font-weight: var(--font-weight-base);
-  padding: 0 var(--s-3);
-}
-
-.emptyActionIcon {
-  width: 14px;
-  height: 14px;
-  opacity: 0.72;
-}
-
-.invalidState {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: var(--s-10);
-}
-
-@media (max-width: 768px) {
-  .workflowGrid {
-    grid-template-columns: 1fr;
-  }
 }

--- a/frontend/src/shared/lib/workflowSettings.test.ts
+++ b/frontend/src/shared/lib/workflowSettings.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_PAGE_SETTINGS,
+  DEFAULT_SIDEBAR_SETTINGS,
+  compareWorkflows,
+  readPageWorkflowSettings,
+  readSidebarWorkflowSettings,
+  writePageWorkflowSettings,
+  writeSidebarWorkflowSettings,
+} from './workflowSettings';
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe('workflowSettings', () => {
+  describe('sidebar', () => {
+    it('returns default when no value is stored', () => {
+      expect(readSidebarWorkflowSettings()).toEqual(DEFAULT_SIDEBAR_SETTINGS);
+    });
+
+    it('round-trips through localStorage', () => {
+      writeSidebarWorkflowSettings({ topN: 3, sortField: 'name', sortDir: 'desc' });
+      expect(readSidebarWorkflowSettings()).toEqual({ topN: 3, sortField: 'name', sortDir: 'desc' });
+    });
+
+    it('falls back to default on malformed JSON', () => {
+      window.localStorage.setItem('ostone:sidebar:workflow-settings', '{not json');
+      expect(readSidebarWorkflowSettings()).toEqual(DEFAULT_SIDEBAR_SETTINGS);
+    });
+
+    it('falls back when topN is invalid', () => {
+      window.localStorage.setItem(
+        'ostone:sidebar:workflow-settings',
+        JSON.stringify({ topN: 'lots', sortField: 'name', sortDir: 'asc' }),
+      );
+      expect(readSidebarWorkflowSettings()).toEqual(DEFAULT_SIDEBAR_SETTINGS);
+    });
+
+    it('falls back when sort direction is bogus', () => {
+      window.localStorage.setItem(
+        'ostone:sidebar:workflow-settings',
+        JSON.stringify({ topN: 5, sortField: 'name', sortDir: 'sideways' }),
+      );
+      expect(readSidebarWorkflowSettings()).toEqual(DEFAULT_SIDEBAR_SETTINGS);
+    });
+  });
+
+  describe('page', () => {
+    it('returns default when no value is stored', () => {
+      expect(readPageWorkflowSettings()).toEqual(DEFAULT_PAGE_SETTINGS);
+    });
+
+    it('round-trips through localStorage', () => {
+      writePageWorkflowSettings({ pageSize: 24, sortField: 'name', sortDir: 'desc' });
+      expect(readPageWorkflowSettings()).toEqual({ pageSize: 24, sortField: 'name', sortDir: 'desc' });
+    });
+
+    it('falls back when pageSize is non-positive', () => {
+      window.localStorage.setItem(
+        'ostone:page:workflow-settings',
+        JSON.stringify({ pageSize: 0, sortField: 'name', sortDir: 'asc' }),
+      );
+      expect(readPageWorkflowSettings()).toEqual(DEFAULT_PAGE_SETTINGS);
+    });
+  });
+
+  describe('compareWorkflows', () => {
+    const a = { name: 'Apple', workflowCode: 'wf.b' };
+    const b = { name: 'banana', workflowCode: 'wf.a' };
+
+    it('sorts asc by name case-insensitively', () => {
+      expect(compareWorkflows(a, b, 'name', 'asc')).toBeLessThan(0);
+    });
+
+    it('sorts desc by name', () => {
+      expect(compareWorkflows(a, b, 'name', 'desc')).toBeGreaterThan(0);
+    });
+
+    it('sorts by workflowCode', () => {
+      expect(compareWorkflows(a, b, 'workflowCode', 'asc')).toBeGreaterThan(0);
+    });
+
+    it('handles missing values', () => {
+      expect(compareWorkflows({ name: undefined }, { name: 'x' }, 'name', 'asc')).toBeLessThan(0);
+    });
+  });
+});

--- a/frontend/src/shared/lib/workflowSettings.ts
+++ b/frontend/src/shared/lib/workflowSettings.ts
@@ -54,7 +54,7 @@ function isSidebarSettings(v: unknown): v is SidebarWorkflowSettings {
   const obj = v as Record<string, unknown>;
   return (
     typeof obj.topN === 'number' &&
-    obj.topN > 0 &&
+    (TOP_N_OPTIONS as ReadonlyArray<number>).includes(obj.topN) &&
     (obj.sortField === 'name' || obj.sortField === 'workflowCode') &&
     (obj.sortDir === 'asc' || obj.sortDir === 'desc')
   );
@@ -65,7 +65,7 @@ function isPageSettings(v: unknown): v is PageWorkflowSettings {
   const obj = v as Record<string, unknown>;
   return (
     typeof obj.pageSize === 'number' &&
-    obj.pageSize > 0 &&
+    (PAGE_SIZE_OPTIONS as ReadonlyArray<number>).includes(obj.pageSize) &&
     (obj.sortField === 'name' || obj.sortField === 'workflowCode') &&
     (obj.sortDir === 'asc' || obj.sortDir === 'desc')
   );

--- a/frontend/src/shared/lib/workflowSettings.ts
+++ b/frontend/src/shared/lib/workflowSettings.ts
@@ -1,0 +1,117 @@
+export type SortDir = 'asc' | 'desc';
+export type WorkflowSortField = 'name' | 'workflowCode';
+
+export interface SidebarWorkflowSettings {
+  topN: number;
+  sortField: WorkflowSortField;
+  sortDir: SortDir;
+}
+
+export interface PageWorkflowSettings {
+  pageSize: number;
+  sortField: WorkflowSortField;
+  sortDir: SortDir;
+}
+
+export const DEFAULT_SIDEBAR_SETTINGS: SidebarWorkflowSettings = {
+  topN: 5,
+  sortField: 'workflowCode',
+  sortDir: 'asc',
+};
+
+export const DEFAULT_PAGE_SETTINGS: PageWorkflowSettings = {
+  pageSize: 12,
+  sortField: 'workflowCode',
+  sortDir: 'asc',
+};
+
+const SIDEBAR_KEY = 'ostone:sidebar:workflow-settings';
+const PAGE_KEY = 'ostone:page:workflow-settings';
+
+export const PAGE_SIZE_OPTIONS = [6, 12, 24] as const;
+export const TOP_N_OPTIONS = [3, 5, 10, 20] as const;
+export const SORT_FIELD_OPTIONS: ReadonlyArray<{ value: WorkflowSortField; label: string }> = [
+  { value: 'workflowCode', label: 'Code' },
+  { value: 'name', label: 'Name' },
+];
+export const SORT_DIR_OPTIONS: ReadonlyArray<{ value: SortDir; label: string }> = [
+  { value: 'asc', label: 'Asc' },
+  { value: 'desc', label: 'Desc' },
+];
+
+function safeParse<T>(raw: string | null, fallback: T, validate: (v: unknown) => v is T): T {
+  if (!raw) return fallback;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return validate(parsed) ? parsed : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function isSidebarSettings(v: unknown): v is SidebarWorkflowSettings {
+  if (typeof v !== 'object' || v === null) return false;
+  const obj = v as Record<string, unknown>;
+  return (
+    typeof obj.topN === 'number' &&
+    obj.topN > 0 &&
+    (obj.sortField === 'name' || obj.sortField === 'workflowCode') &&
+    (obj.sortDir === 'asc' || obj.sortDir === 'desc')
+  );
+}
+
+function isPageSettings(v: unknown): v is PageWorkflowSettings {
+  if (typeof v !== 'object' || v === null) return false;
+  const obj = v as Record<string, unknown>;
+  return (
+    typeof obj.pageSize === 'number' &&
+    obj.pageSize > 0 &&
+    (obj.sortField === 'name' || obj.sortField === 'workflowCode') &&
+    (obj.sortDir === 'asc' || obj.sortDir === 'desc')
+  );
+}
+
+export function readSidebarWorkflowSettings(): SidebarWorkflowSettings {
+  if (typeof window === 'undefined') return DEFAULT_SIDEBAR_SETTINGS;
+  return safeParse(window.localStorage.getItem(SIDEBAR_KEY), DEFAULT_SIDEBAR_SETTINGS, isSidebarSettings);
+}
+
+export function writeSidebarWorkflowSettings(value: SidebarWorkflowSettings): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(SIDEBAR_KEY, JSON.stringify(value));
+  } catch {
+    /* quota or disabled — ignore */
+  }
+}
+
+export function readPageWorkflowSettings(): PageWorkflowSettings {
+  if (typeof window === 'undefined') return DEFAULT_PAGE_SETTINGS;
+  return safeParse(window.localStorage.getItem(PAGE_KEY), DEFAULT_PAGE_SETTINGS, isPageSettings);
+}
+
+export function writePageWorkflowSettings(value: PageWorkflowSettings): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(PAGE_KEY, JSON.stringify(value));
+  } catch {
+    /* quota or disabled — ignore */
+  }
+}
+
+export interface SortableWorkflow {
+  name?: string;
+  workflowCode?: string | null;
+}
+
+export function compareWorkflows<T extends SortableWorkflow>(
+  a: T,
+  b: T,
+  field: WorkflowSortField,
+  dir: SortDir,
+): number {
+  const av = (a[field] ?? '').toString().toLowerCase();
+  const bv = (b[field] ?? '').toString().toLowerCase();
+  const cmp = av.localeCompare(bv);
+  return dir === 'asc' ? cmp : -cmp;
+}

--- a/frontend/src/shared/ui/ostone/atoms/Icon.tsx
+++ b/frontend/src/shared/ui/ostone/atoms/Icon.tsx
@@ -26,7 +26,8 @@ export type IconName =
   | 'download'
   | 'book'
   | 'shield'
-  | 'info';
+  | 'info'
+  | 'settings';
 
 interface IconProps {
   name: IconName;
@@ -209,6 +210,12 @@ const ICONS: Record<IconName, React.ReactNode> = {
       <circle cx="8" cy="8" r="6" />
       <line x1="8" y1="8" x2="8" y2="11" />
       <line x1="8" y1="5" x2="8" y2="5.01" />
+    </>
+  ),
+  settings: (
+    <>
+      <circle cx="8" cy="8" r="2" />
+      <path d="M8 1.5v2M8 12.5v2M14.5 8h-2M3.5 8h-2M12.6 3.4l-1.4 1.4M4.8 11.2l-1.4 1.4M12.6 12.6l-1.4-1.4M4.8 4.8L3.4 3.4" />
     </>
   ),
 };

--- a/frontend/src/shared/ui/ostone/chrome/AccountMenu.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/AccountMenu.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState, type CSSProperties } from 'react';
+import { createPortal } from 'react-dom';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
 import { Icon } from '../atoms/Icon';
@@ -18,15 +19,34 @@ export function AccountMenu({ collapsed }: AccountMenuProps) {
   const [open, setOpen] = useState(false);
   const navigate = useNavigate();
   const containerRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const [popoverPos, setPopoverPos] = useState<{ top: number; left: number; width: number } | null>(null);
 
   const user = getAuthUser();
   const initial = deriveInitial(user?.name, user?.email);
   const displayName = user?.name ?? user?.email ?? '게스트';
 
+  useLayoutEffect(() => {
+    if (!open || !triggerRef.current) {
+      setPopoverPos(null);
+      return;
+    }
+    const rect = triggerRef.current.getBoundingClientRect();
+    setPopoverPos({
+      top: rect.top - 8,
+      left: collapsed ? rect.right + 8 : rect.left,
+      width: collapsed ? 220 : rect.width,
+    });
+  }, [open, collapsed]);
+
   useEffect(() => {
     if (!open) return;
     const handler = (e: MouseEvent) => {
-      if (!containerRef.current?.contains(e.target as Node)) setOpen(false);
+      const target = e.target as Node;
+      if (triggerRef.current?.contains(target)) return;
+      if (popoverRef.current?.contains(target)) return;
+      setOpen(false);
     };
     document.addEventListener('mousedown', handler);
     return () => document.removeEventListener('mousedown', handler);
@@ -45,6 +65,7 @@ export function AccountMenu({ collapsed }: AccountMenuProps) {
 
   const triggerCollapsed = (
     <button
+      ref={triggerRef}
       type="button"
       aria-label="계정 메뉴"
       onClick={() => setOpen((v) => !v)}
@@ -70,6 +91,7 @@ export function AccountMenu({ collapsed }: AccountMenuProps) {
 
   const triggerExpanded = (
     <button
+      ref={triggerRef}
       type="button"
       aria-label="계정 메뉴"
       onClick={() => setOpen((v) => !v)}
@@ -103,28 +125,34 @@ export function AccountMenu({ collapsed }: AccountMenuProps) {
     </button>
   );
 
+  const popoverStyle: CSSProperties = popoverPos
+    ? {
+        position: 'fixed',
+        top: popoverPos.top,
+        left: popoverPos.left,
+        transform: 'translateY(-100%)',
+        width: popoverPos.width,
+        background: 'var(--paper)',
+        border: '1px solid var(--line)',
+        borderRadius: 'var(--r-2)',
+        boxShadow: '0 12px 32px rgba(0,0,0,0.12)',
+        padding: 'var(--s-2)',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 'var(--s-1)',
+        zIndex: 60,
+      }
+    : { display: 'none' };
+
   return (
     <div ref={containerRef} style={{ position: 'relative', width: collapsed ? 'auto' : '100%' }}>
       {collapsed ? triggerCollapsed : triggerExpanded}
 
-      {open && (
+      {open && createPortal(
         <div
+          ref={popoverRef}
           data-testid="account-menu-popover"
-          style={{
-            position: 'absolute',
-            bottom: 'calc(100% + 6px)',
-            left: collapsed ? 0 : 0,
-            minWidth: collapsed ? '200px' : '100%',
-            background: 'var(--paper)',
-            border: '1px solid var(--line)',
-            borderRadius: 'var(--r-2)',
-            boxShadow: '0 8px 24px rgba(0,0,0,0.08)',
-            padding: 'var(--s-2)',
-            display: 'flex',
-            flexDirection: 'column',
-            gap: 'var(--s-1)',
-            zIndex: 40,
-          }}
+          style={popoverStyle}
         >
           <div
             style={{
@@ -196,7 +224,8 @@ export function AccountMenu({ collapsed }: AccountMenuProps) {
             <Icon name="arrow" size={12} />
             로그아웃
           </button>
-        </div>
+        </div>,
+        document.body,
       )}
     </div>
   );

--- a/frontend/src/shared/ui/ostone/chrome/AccountMenu.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/AccountMenu.tsx
@@ -51,8 +51,8 @@ export function AccountMenu({ collapsed }: AccountMenuProps) {
       data-testid="account-menu-trigger"
       data-state={open ? 'open' : 'closed'}
       style={{
-        width: '32px',
-        height: '32px',
+        width: '40px',
+        height: '40px',
         borderRadius: 'var(--r-2)',
         border: '1px solid var(--line)',
         background: open ? 'var(--paper-3)' : 'var(--paper)',
@@ -61,9 +61,10 @@ export function AccountMenu({ collapsed }: AccountMenuProps) {
         alignItems: 'center',
         justifyContent: 'center',
         padding: 0,
+        transition: 'background 160ms ease',
       }}
     >
-      <Avatar tone="signal" initial={initial} size={24} />
+      <Avatar tone="signal" initial={initial} size={28} />
     </button>
   );
 
@@ -88,15 +89,16 @@ export function AccountMenu({ collapsed }: AccountMenuProps) {
         textAlign: 'left',
         color: 'var(--ink)',
         fontFamily: 'var(--sans)',
-        fontSize: '12px',
+        fontSize: '13px',
+        transition: 'background 160ms ease',
       }}
     >
-      <Avatar tone="signal" initial={initial} size={24} />
+      <Avatar tone="signal" initial={initial} size={28} />
       <span style={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
         {displayName}
       </span>
-      <span style={{ display: 'inline-flex', transform: open ? 'rotate(180deg)' : 'none', transition: 'transform 120ms ease' }}>
-        <Icon name="chevron" size={10} />
+      <span style={{ display: 'inline-flex', transform: open ? 'rotate(270deg)' : 'rotate(90deg)', transition: 'transform 160ms ease' }}>
+        <Icon name="chevron" size={12} />
       </span>
     </button>
   );

--- a/frontend/src/shared/ui/ostone/chrome/AccountMenu.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/AccountMenu.tsx
@@ -28,10 +28,7 @@ export function AccountMenu({ collapsed }: AccountMenuProps) {
   const displayName = user?.name ?? user?.email ?? '게스트';
 
   useLayoutEffect(() => {
-    if (!open || !triggerRef.current) {
-      setPopoverPos(null);
-      return;
-    }
+    if (!open || !triggerRef.current) return;
     const rect = triggerRef.current.getBoundingClientRect();
     setPopoverPos({
       top: rect.top - 8,

--- a/frontend/src/shared/ui/ostone/chrome/AccountMenu.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/AccountMenu.tsx
@@ -11,7 +11,7 @@ interface AccountMenuProps {
 }
 
 function deriveInitial(name: string | undefined | null, email: string | undefined | null): string {
-  const source = (name && name.trim()) || (email && email.trim()) || '?';
+  const source = name?.trim() || email?.trim() || '?';
   return source.slice(0, 1).toUpperCase();
 }
 

--- a/frontend/src/shared/ui/ostone/chrome/AccountMenu.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/AccountMenu.tsx
@@ -1,0 +1,201 @@
+import { useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
+import { Icon } from '../atoms/Icon';
+import { Avatar } from '../atoms/Avatar';
+import { clearAuthSession, getAuthUser } from '@/shared/lib/auth';
+
+interface AccountMenuProps {
+  collapsed: boolean;
+}
+
+function deriveInitial(name: string | undefined | null, email: string | undefined | null): string {
+  const source = (name && name.trim()) || (email && email.trim()) || '?';
+  return source.slice(0, 1).toUpperCase();
+}
+
+export function AccountMenu({ collapsed }: AccountMenuProps) {
+  const [open, setOpen] = useState(false);
+  const navigate = useNavigate();
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const user = getAuthUser();
+  const initial = deriveInitial(user?.name, user?.email);
+  const displayName = user?.name ?? user?.email ?? '게스트';
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (!containerRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [open]);
+
+  const handleLogout = () => {
+    clearAuthSession();
+    setOpen(false);
+    navigate('/login');
+  };
+
+  const handleSettings = () => {
+    setOpen(false);
+    toast('설정 화면은 준비 중입니다.');
+  };
+
+  const triggerCollapsed = (
+    <button
+      type="button"
+      aria-label="계정 메뉴"
+      onClick={() => setOpen((v) => !v)}
+      data-testid="account-menu-trigger"
+      data-state={open ? 'open' : 'closed'}
+      style={{
+        width: '32px',
+        height: '32px',
+        borderRadius: 'var(--r-2)',
+        border: '1px solid var(--line)',
+        background: open ? 'var(--paper-3)' : 'var(--paper)',
+        cursor: 'pointer',
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: 0,
+      }}
+    >
+      <Avatar tone="signal" initial={initial} size={24} />
+    </button>
+  );
+
+  const triggerExpanded = (
+    <button
+      type="button"
+      aria-label="계정 메뉴"
+      onClick={() => setOpen((v) => !v)}
+      data-testid="account-menu-trigger"
+      data-state={open ? 'open' : 'closed'}
+      style={{
+        width: '100%',
+        height: '40px',
+        padding: '0 var(--s-2)',
+        display: 'flex',
+        alignItems: 'center',
+        gap: 'var(--s-2)',
+        background: open ? 'var(--paper-3)' : 'transparent',
+        border: '1px solid var(--line)',
+        borderRadius: 'var(--r-2)',
+        cursor: 'pointer',
+        textAlign: 'left',
+        color: 'var(--ink)',
+        fontFamily: 'var(--sans)',
+        fontSize: '12px',
+      }}
+    >
+      <Avatar tone="signal" initial={initial} size={24} />
+      <span style={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+        {displayName}
+      </span>
+      <span style={{ display: 'inline-flex', transform: open ? 'rotate(180deg)' : 'none', transition: 'transform 120ms ease' }}>
+        <Icon name="chevron" size={10} />
+      </span>
+    </button>
+  );
+
+  return (
+    <div ref={containerRef} style={{ position: 'relative', width: collapsed ? 'auto' : '100%' }}>
+      {collapsed ? triggerCollapsed : triggerExpanded}
+
+      {open && (
+        <div
+          data-testid="account-menu-popover"
+          style={{
+            position: 'absolute',
+            bottom: 'calc(100% + 6px)',
+            left: collapsed ? 0 : 0,
+            minWidth: collapsed ? '200px' : '100%',
+            background: 'var(--paper)',
+            border: '1px solid var(--line)',
+            borderRadius: 'var(--r-2)',
+            boxShadow: '0 8px 24px rgba(0,0,0,0.08)',
+            padding: 'var(--s-2)',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 'var(--s-1)',
+            zIndex: 40,
+          }}
+        >
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 'var(--s-2)',
+              padding: '4px var(--s-2) 8px',
+              borderBottom: '1px solid var(--line-2)',
+            }}
+          >
+            <Avatar tone="signal" initial={initial} size={24} />
+            <div style={{ display: 'flex', flexDirection: 'column' }}>
+              <span style={{ fontFamily: 'var(--sans)', fontSize: '12px', fontWeight: 500, color: 'var(--ink)' }}>
+                {displayName}
+              </span>
+              {user?.email && user?.name && (
+                <span style={{ fontFamily: 'var(--mono)', fontSize: '10px', color: 'var(--ink-3)' }}>
+                  {user.email}
+                </span>
+              )}
+            </div>
+          </div>
+
+          <button
+            type="button"
+            data-testid="account-menu-settings"
+            onClick={handleSettings}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 'var(--s-2)',
+              padding: '8px var(--s-2)',
+              background: 'transparent',
+              border: 'none',
+              borderRadius: 'var(--r-1)',
+              cursor: 'pointer',
+              fontFamily: 'var(--sans)',
+              fontSize: '12px',
+              color: 'var(--ink)',
+              textAlign: 'left',
+            }}
+          >
+            <Icon name="info" size={12} />
+            설정
+            <span style={{ marginLeft: 'auto', fontFamily: 'var(--mono)', fontSize: '9px', color: 'var(--ink-3)' }}>
+              미구현
+            </span>
+          </button>
+
+          <button
+            type="button"
+            data-testid="account-menu-logout"
+            onClick={handleLogout}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 'var(--s-2)',
+              padding: '8px var(--s-2)',
+              background: 'transparent',
+              border: 'none',
+              borderRadius: 'var(--r-1)',
+              cursor: 'pointer',
+              fontFamily: 'var(--sans)',
+              fontSize: '12px',
+              color: 'var(--ink)',
+              textAlign: 'left',
+            }}
+          >
+            <Icon name="arrow" size={12} />
+            로그아웃
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/shared/ui/ostone/chrome/Sidebar.test.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/Sidebar.test.tsx
@@ -41,11 +41,11 @@ const TREE_FIXTURE: SidebarTreeData = {
 };
 
 describe('Sidebar', () => {
-  it('collapsed 모드에서는 width 64px과 아이콘 항목을 표시한다 (Workflows 최상위 항목 없음)', () => {
+  it('collapsed 모드에서는 width 72px과 아이콘 항목을 표시한다 (Workflows 최상위 항목 없음)', () => {
     renderSidebar({ collapsed: true });
     const nav = screen.getByLabelText('주요 내비게이션');
     expect(nav).toHaveAttribute('data-collapsed', 'true');
-    expect(nav).toHaveStyle({ width: '64px' });
+    expect(nav).toHaveStyle({ width: '72px' });
     expect(screen.getByTitle('Operator')).toBeInTheDocument();
     expect(screen.getByTitle('Pipeline')).toBeInTheDocument();
     expect(screen.getByTitle('Consultation')).toBeInTheDocument();
@@ -54,11 +54,11 @@ describe('Sidebar', () => {
     expect(screen.queryByTitle('Workflows')).not.toBeInTheDocument();
   });
 
-  it('expanded 모드에서는 width 240px이고 Domain Packs는 토글 버튼이다 (별도 section label 없음)', () => {
+  it('expanded 모드에서는 width 256px이고 Domain Packs는 토글 버튼이다 (별도 section label 없음)', () => {
     renderSidebar({ collapsed: false });
     const nav = screen.getByLabelText('주요 내비게이션');
     expect(nav).toHaveAttribute('data-collapsed', 'false');
-    expect(nav).toHaveStyle({ width: '240px' });
+    expect(nav).toHaveStyle({ width: '256px' });
     expect(screen.getByTestId('sidebar-domain-toggle')).toBeInTheDocument();
     expect(screen.queryByTestId('sidebar-section-label')).not.toBeInTheDocument();
   });

--- a/frontend/src/shared/ui/ostone/chrome/Sidebar.test.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/Sidebar.test.tsx
@@ -54,11 +54,11 @@ describe('Sidebar', () => {
     expect(screen.queryByTitle('Workflows')).not.toBeInTheDocument();
   });
 
-  it('expanded 모드에서는 width 240px이고 Domain Packs는 토글 버튼이다 (별도 section label 없음)', () => {
+  it('expanded 모드에서는 width 220px이고 Domain Packs는 토글 버튼이다 (별도 section label 없음)', () => {
     renderSidebar({ collapsed: false });
     const nav = screen.getByLabelText('주요 내비게이션');
     expect(nav).toHaveAttribute('data-collapsed', 'false');
-    expect(nav).toHaveStyle({ width: '240px' });
+    expect(nav).toHaveStyle({ width: '220px' });
     expect(screen.getByTestId('sidebar-domain-toggle')).toBeInTheDocument();
     expect(screen.queryByTestId('sidebar-section-label')).not.toBeInTheDocument();
   });

--- a/frontend/src/shared/ui/ostone/chrome/Sidebar.test.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/Sidebar.test.tsx
@@ -7,7 +7,7 @@ type SidebarProps = Parameters<typeof Sidebar>[0];
 
 function renderSidebar(props: Partial<SidebarProps> = {}) {
   const defaults: SidebarProps = {
-    active: 'workflows',
+    active: 'operator',
     collapsed: true,
     onToggleCollapsed: vi.fn(),
   };
@@ -41,26 +41,31 @@ const TREE_FIXTURE: SidebarTreeData = {
 };
 
 describe('Sidebar', () => {
-  it('collapsed 모드에서는 width 56px과 아이콘 항목을 표시한다', () => {
+  it('collapsed 모드에서는 width 56px과 아이콘 항목을 표시한다 (Workflows 최상위 항목 없음)', () => {
     renderSidebar({ collapsed: true });
     const nav = screen.getByLabelText('주요 내비게이션');
     expect(nav).toHaveAttribute('data-collapsed', 'true');
     expect(nav).toHaveStyle({ width: '56px' });
     expect(screen.getByTitle('Operator')).toBeInTheDocument();
-    expect(screen.getByTitle('Workflows')).toBeInTheDocument();
     expect(screen.getByTitle('Pipeline')).toBeInTheDocument();
     expect(screen.getByTitle('Consultation')).toBeInTheDocument();
     expect(screen.getByTitle('Uploads')).toBeInTheDocument();
     expect(screen.getByTitle('Domain Packs')).toBeInTheDocument();
-    expect(screen.queryByTestId('sidebar-section-label')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Workflows')).not.toBeInTheDocument();
   });
 
-  it('expanded 모드에서는 width 240px과 Domain Packs 섹션 라벨을 표시한다', () => {
+  it('expanded 모드에서는 width 240px이고 Domain Packs는 토글 버튼이다 (별도 section label 없음)', () => {
     renderSidebar({ collapsed: false });
     const nav = screen.getByLabelText('주요 내비게이션');
     expect(nav).toHaveAttribute('data-collapsed', 'false');
     expect(nav).toHaveStyle({ width: '240px' });
-    expect(screen.getByTestId('sidebar-section-label')).toHaveTextContent(/Domain Packs/i);
+    expect(screen.getByTestId('sidebar-domain-toggle')).toBeInTheDocument();
+    expect(screen.queryByTestId('sidebar-section-label')).not.toBeInTheDocument();
+  });
+
+  it('expanded 모드에서 Workflows 최상위 항목이 없다', () => {
+    renderSidebar({ collapsed: false });
+    expect(screen.queryByTitle('Workflows')).not.toBeInTheDocument();
   });
 
   it('토글 버튼 클릭 시 onToggleCollapsed가 호출된다', () => {
@@ -70,110 +75,123 @@ describe('Sidebar', () => {
     expect(onToggleCollapsed).toHaveBeenCalledTimes(1);
   });
 
-  it('expanded 모드에서도 토글 버튼이 동작한다', () => {
-    const onToggleCollapsed = vi.fn();
-    renderSidebar({ collapsed: false, onToggleCollapsed });
-    fireEvent.click(screen.getByLabelText('사이드바 접기'));
-    expect(onToggleCollapsed).toHaveBeenCalledTimes(1);
-  });
-
   it('active=operator일 때 Operator 항목이 강조된다', () => {
     renderSidebar({ active: 'operator', collapsed: true });
     expect(screen.getByTitle('Operator')).toHaveAttribute('data-active', 'true');
-    expect(screen.getByTitle('Workflows')).toHaveAttribute('data-active', 'false');
   });
 
-  it('각 active 값에 대해 정확한 항목이 강조된다', () => {
-    const cases: Array<[SidebarProps['active'], string]> = [
-      ['operator', 'Operator'],
-      ['workflows', 'Workflows'],
-      ['pipeline', 'Pipeline'],
-      ['consult', 'Consultation'],
-      ['upload', 'Uploads'],
-      ['domain', 'Domain Packs'],
-    ];
-    for (const [active, label] of cases) {
-      const { unmount } = renderSidebar({ active, collapsed: true });
-      expect(screen.getByTitle(label)).toHaveAttribute('data-active', 'true');
-      unmount();
-    }
+  it('Domain Packs 토글이 기본은 active 상태에 따라 펼쳐진다 (active=domain → open)', () => {
+    renderSidebar({ collapsed: false, active: 'domain', tree: TREE_FIXTURE });
+    const toggle = screen.getByTestId('sidebar-domain-toggle');
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    expect(toggle).toHaveAttribute('data-active', 'true');
+    expect(screen.getByTestId('sidebar-tree')).toBeInTheDocument();
   });
 
-  it('inactive 항목에 mouseEnter/Leave 시 배경이 토글된다', () => {
-    renderSidebar({ active: 'domain', collapsed: true });
-    const link = screen.getByTitle('Workflows') as HTMLElement;
-    fireEvent.mouseEnter(link);
-    expect(link.style.background).toBe('var(--paper-3)');
-    fireEvent.mouseLeave(link);
-    expect(link.style.background).toBe('transparent');
-  });
-
-  it('switcher가 주어지면 렌더링된다', () => {
-    const switcher = <div data-testid="switcher">Switch</div>;
-    renderSidebar({ switcher });
-    expect(screen.getByTestId('switcher')).toBeInTheDocument();
+  it('Domain Packs 토글이 기본은 active=operator이면 닫혀 있다가 클릭 시 열린다', () => {
+    renderSidebar({ collapsed: false, active: 'operator', tree: TREE_FIXTURE });
+    const toggle = screen.getByTestId('sidebar-domain-toggle');
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByTestId('sidebar-tree')).not.toBeInTheDocument();
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByTestId('sidebar-tree')).toBeInTheDocument();
   });
 
   it('tree.loading=true이면 loading placeholder를 렌더한다', () => {
-    renderSidebar({ collapsed: false, tree: { loading: true, error: null, packs: [] } });
+    renderSidebar({
+      collapsed: false,
+      active: 'domain',
+      tree: { loading: true, error: null, packs: [] },
+    });
     expect(screen.getByTestId('sidebar-tree-loading')).toBeInTheDocument();
   });
 
   it('tree.error가 있으면 에러 메시지를 렌더한다', () => {
-    renderSidebar({ collapsed: false, tree: { loading: false, error: 'oops', packs: [] } });
+    renderSidebar({
+      collapsed: false,
+      active: 'domain',
+      tree: { loading: false, error: 'oops', packs: [] },
+    });
     expect(screen.getByTestId('sidebar-tree-error')).toBeInTheDocument();
   });
 
   it('tree.packs가 비어 있으면 empty 메시지를 렌더한다', () => {
-    renderSidebar({ collapsed: false, tree: { loading: false, error: null, packs: [] } });
+    renderSidebar({
+      collapsed: false,
+      active: 'domain',
+      tree: { loading: false, error: null, packs: [] },
+    });
     expect(screen.getByTestId('sidebar-tree-empty')).toBeInTheDocument();
   });
 
   it('tree.packs가 있을 때 pack 이름을 렌더한다', () => {
-    renderSidebar({ collapsed: false, tree: TREE_FIXTURE });
+    renderSidebar({ collapsed: false, active: 'domain', tree: TREE_FIXTURE });
     expect(screen.getByText('CS Support')).toBeInTheDocument();
     expect(screen.getByText('Billing')).toBeInTheDocument();
   });
 
-  it('pack을 펼치면 5개 카테고리가 모두 노출된다', () => {
-    renderSidebar({ collapsed: false, tree: TREE_FIXTURE });
+  it('pack을 펼치면 5개 카테고리가 NavLink로 노출되고 Workflows 카테고리는 "All Workflows"로 표시된다', () => {
+    renderSidebar({ collapsed: false, active: 'domain', tree: TREE_FIXTURE });
     fireEvent.click(screen.getByText('CS Support'));
     expect(screen.getByTestId('sidebar-cat-11-intents')).toBeInTheDocument();
     expect(screen.getByTestId('sidebar-cat-11-slots')).toBeInTheDocument();
     expect(screen.getByTestId('sidebar-cat-11-policies')).toBeInTheDocument();
     expect(screen.getByTestId('sidebar-cat-11-risks')).toBeInTheDocument();
-    expect(screen.getByTestId('sidebar-cat-11-workflows')).toBeInTheDocument();
+    const workflowsLink = screen.getByTestId('sidebar-cat-11-workflows');
+    expect(workflowsLink).toBeInTheDocument();
+    expect(workflowsLink).toHaveTextContent('All Workflows');
+    expect(workflowsLink.tagName).toBe('A');
   });
 
-  it('Workflows 카테고리를 펼치면 개별 워크플로우가 노출된다', () => {
-    renderSidebar({ collapsed: false, tree: TREE_FIXTURE });
-    fireEvent.click(screen.getByText('CS Support'));
-    fireEvent.click(screen.getByTestId('sidebar-cat-11-workflows'));
+  it('All Workflows가 active일 때 워크플로우 리스트가 자동으로 그 아래에 표시된다', () => {
+    renderSidebar({
+      collapsed: false,
+      tree: TREE_FIXTURE,
+      activePackId: 11,
+      active: 'workflows',
+    });
+    expect(screen.getByTestId('sidebar-workflows-list-11')).toBeInTheDocument();
     expect(screen.getByTestId('sidebar-workflow-100')).toBeInTheDocument();
     expect(screen.getByTestId('sidebar-workflow-101')).toBeInTheDocument();
-    expect(screen.queryByTestId('sidebar-workflow-200')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('sidebar-workflows-list-12')).not.toBeInTheDocument();
   });
 
-  it('activePackId 일치 시 해당 pack이 기본 펼쳐진다', () => {
+  it('다른 카테고리가 active면 워크플로우 리스트는 표시되지 않는다', () => {
     renderSidebar({
       collapsed: false,
       tree: TREE_FIXTURE,
       activePackId: 11,
       active: 'intent',
     });
-    expect(screen.getByTestId('sidebar-cat-11-intents')).toBeInTheDocument();
-    expect(screen.queryByTestId('sidebar-cat-12-intents')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('sidebar-workflows-list-11')).not.toBeInTheDocument();
   });
 
-  it('activePackId+active=workflows이면 Workflows 카테고리도 기본 펼쳐진다', () => {
+  it('All Workflows active이지만 해당 pack에 워크플로우가 없으면 안내를 표시한다', () => {
+    const tree: SidebarTreeData = {
+      loading: false,
+      error: null,
+      packs: [{ packId: 77, name: 'Empty', versionId: 5, workflows: [] }],
+    };
+    renderSidebar({
+      collapsed: false,
+      tree,
+      activePackId: 77,
+      active: 'workflows',
+    });
+    expect(screen.getByTestId('sidebar-workflows-empty-77')).toBeInTheDocument();
+  });
+
+  it('activeWorkflowId 일치 시 해당 워크플로우 링크가 강조된다', () => {
     renderSidebar({
       collapsed: false,
       tree: TREE_FIXTURE,
       activePackId: 11,
-      active: 'workflows',
       activeWorkflowId: 100,
+      active: 'workflows',
     });
-    expect(screen.getByTestId('sidebar-workflow-100')).toBeInTheDocument();
+    const wfLink = screen.getByTestId('sidebar-workflow-100');
+    expect(wfLink.getAttribute('style') ?? '').toContain('var(--signal)');
   });
 
   it('versionId가 null이면 카테고리 링크가 pack base 경로로 fallback한다', () => {
@@ -182,7 +200,7 @@ describe('Sidebar', () => {
       error: null,
       packs: [{ packId: 99, name: 'Empty', versionId: null, workflows: [] }],
     };
-    renderSidebar({ collapsed: false, tree });
+    renderSidebar({ collapsed: false, active: 'domain', tree });
     fireEvent.click(screen.getByText('Empty'));
     const intentsCat = screen.getByTestId('sidebar-cat-99-intents');
     expect(intentsCat).toHaveAttribute('href', '/workspaces/domain-packs/99');
@@ -192,5 +210,35 @@ describe('Sidebar', () => {
     renderSidebar({ collapsed: true, basePath: '/workspaces/7' });
     const opLink = screen.getByTitle('Operator');
     expect(opLink).toHaveAttribute('href', '/workspaces/7/chat-demo');
+    const domainLink = screen.getByTitle('Domain Packs');
+    expect(domainLink).toHaveAttribute('href', '/workspaces/7/domain-packs');
+  });
+
+  it('switcher가 주어지면 렌더링된다', () => {
+    const switcher = <div data-testid="switcher">Switch</div>;
+    renderSidebar({ switcher });
+    expect(screen.getByTestId('switcher')).toBeInTheDocument();
+  });
+
+  it('inactive 항목에 mouseEnter/Leave 시 배경이 토글된다', () => {
+    renderSidebar({ active: 'operator', collapsed: true });
+    const link = screen.getByTitle('Pipeline') as HTMLElement;
+    fireEvent.mouseEnter(link);
+    expect(link.style.background).toBe('var(--paper-3)');
+    fireEvent.mouseLeave(link);
+    expect(link.style.background).toBe('transparent');
+  });
+
+  it('Domain Packs 토글 active 시 inactive 카테고리(intent)에 대한 강조 분리', () => {
+    renderSidebar({
+      collapsed: false,
+      tree: TREE_FIXTURE,
+      activePackId: 11,
+      active: 'intent',
+    });
+    const intentsCat = screen.getByTestId('sidebar-cat-11-intents');
+    expect(intentsCat.getAttribute('style') ?? '').toContain('var(--signal)');
+    const slotsCat = screen.getByTestId('sidebar-cat-11-slots');
+    expect(slotsCat.getAttribute('style') ?? '').not.toContain('var(--signal)');
   });
 });

--- a/frontend/src/shared/ui/ostone/chrome/Sidebar.test.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/Sidebar.test.tsx
@@ -54,11 +54,11 @@ describe('Sidebar', () => {
     expect(screen.queryByTitle('Workflows')).not.toBeInTheDocument();
   });
 
-  it('expanded 모드에서는 width 220px이고 Domain Packs는 토글 버튼이다 (별도 section label 없음)', () => {
+  it('expanded 모드에서는 width 240px이고 Domain Packs는 토글 버튼이다 (별도 section label 없음)', () => {
     renderSidebar({ collapsed: false });
     const nav = screen.getByLabelText('주요 내비게이션');
     expect(nav).toHaveAttribute('data-collapsed', 'false');
-    expect(nav).toHaveStyle({ width: '220px' });
+    expect(nav).toHaveStyle({ width: '240px' });
     expect(screen.getByTestId('sidebar-domain-toggle')).toBeInTheDocument();
     expect(screen.queryByTestId('sidebar-section-label')).not.toBeInTheDocument();
   });

--- a/frontend/src/shared/ui/ostone/chrome/Sidebar.test.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/Sidebar.test.tsx
@@ -41,11 +41,11 @@ const TREE_FIXTURE: SidebarTreeData = {
 };
 
 describe('Sidebar', () => {
-  it('collapsed 모드에서는 width 56px과 아이콘 항목을 표시한다 (Workflows 최상위 항목 없음)', () => {
+  it('collapsed 모드에서는 width 64px과 아이콘 항목을 표시한다 (Workflows 최상위 항목 없음)', () => {
     renderSidebar({ collapsed: true });
     const nav = screen.getByLabelText('주요 내비게이션');
     expect(nav).toHaveAttribute('data-collapsed', 'true');
-    expect(nav).toHaveStyle({ width: '56px' });
+    expect(nav).toHaveStyle({ width: '64px' });
     expect(screen.getByTitle('Operator')).toBeInTheDocument();
     expect(screen.getByTitle('Pipeline')).toBeInTheDocument();
     expect(screen.getByTitle('Consultation')).toBeInTheDocument();
@@ -68,10 +68,23 @@ describe('Sidebar', () => {
     expect(screen.queryByTitle('Workflows')).not.toBeInTheDocument();
   });
 
-  it('토글 버튼 클릭 시 onToggleCollapsed가 호출된다', () => {
+  it('collapsed 시 nav 배경 클릭으로 onToggleCollapsed가 호출된다', () => {
     const onToggleCollapsed = vi.fn();
     renderSidebar({ collapsed: true, onToggleCollapsed });
-    fireEvent.click(screen.getByLabelText('사이드바 펼치기'));
+    const nav = screen.getByLabelText('주요 내비게이션');
+    fireEvent.click(nav);
+    expect(onToggleCollapsed).toHaveBeenCalledTimes(1);
+  });
+
+  it('collapsed 시에는 별도 토글 버튼이 렌더되지 않는다', () => {
+    renderSidebar({ collapsed: true });
+    expect(screen.queryByLabelText('사이드바 펼치기')).not.toBeInTheDocument();
+  });
+
+  it('expanded 시 토글 버튼 클릭으로 onToggleCollapsed가 호출된다', () => {
+    const onToggleCollapsed = vi.fn();
+    renderSidebar({ collapsed: false, onToggleCollapsed });
+    fireEvent.click(screen.getByLabelText('사이드바 접기'));
     expect(onToggleCollapsed).toHaveBeenCalledTimes(1);
   });
 

--- a/frontend/src/shared/ui/ostone/chrome/Sidebar.test.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/Sidebar.test.tsx
@@ -1,87 +1,196 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { Sidebar } from './Sidebar';
+import { Sidebar, type SidebarTreeData } from './Sidebar';
 
-function Wrapper({ children }: { children: React.ReactNode }) {
-  return <MemoryRouter>{children}</MemoryRouter>;
+type SidebarProps = Parameters<typeof Sidebar>[0];
+
+function renderSidebar(props: Partial<SidebarProps> = {}) {
+  const defaults: SidebarProps = {
+    active: 'workflows',
+    collapsed: true,
+    onToggleCollapsed: vi.fn(),
+  };
+  return render(
+    <MemoryRouter>
+      <Sidebar {...defaults} {...props} />
+    </MemoryRouter>,
+  );
 }
 
+const TREE_FIXTURE: SidebarTreeData = {
+  loading: false,
+  error: null,
+  packs: [
+    {
+      packId: 11,
+      name: 'CS Support',
+      versionId: 22,
+      workflows: [
+        { id: 100, name: '환불 처리' },
+        { id: 101, name: '배송 지연' },
+      ],
+    },
+    {
+      packId: 12,
+      name: 'Billing',
+      versionId: 30,
+      workflows: [{ id: 200, name: '카드 변경' }],
+    },
+  ],
+};
+
 describe('Sidebar', () => {
-  it('renders 6 nav buttons', () => {
-    render(<Sidebar active="workflows" />, { wrapper: Wrapper });
+  it('collapsed 모드에서는 width 56px과 아이콘 항목을 표시한다', () => {
+    renderSidebar({ collapsed: true });
+    const nav = screen.getByLabelText('주요 내비게이션');
+    expect(nav).toHaveAttribute('data-collapsed', 'true');
+    expect(nav).toHaveStyle({ width: '56px' });
+    expect(screen.getByTitle('Operator')).toBeInTheDocument();
     expect(screen.getByTitle('Workflows')).toBeInTheDocument();
-    expect(screen.getByTitle('Domain Packs')).toBeInTheDocument();
     expect(screen.getByTitle('Pipeline')).toBeInTheDocument();
     expect(screen.getByTitle('Consultation')).toBeInTheDocument();
-    expect(screen.getByTitle('Chat Demo')).toBeInTheDocument();
     expect(screen.getByTitle('Uploads')).toBeInTheDocument();
+    expect(screen.getByTitle('Domain Packs')).toBeInTheDocument();
+    expect(screen.queryByTestId('sidebar-section-label')).not.toBeInTheDocument();
   });
 
-  it('highlights active button', () => {
-    const { container } = render(<Sidebar active="domain" />, { wrapper: Wrapper });
-    const activeBtn = container.querySelector('[data-active="true"]');
-    expect(activeBtn).not.toBeNull();
-    expect(activeBtn?.getAttribute('title')).toBe('Domain Packs');
+  it('expanded 모드에서는 width 240px과 Domain Packs 섹션 라벨을 표시한다', () => {
+    renderSidebar({ collapsed: false });
+    const nav = screen.getByLabelText('주요 내비게이션');
+    expect(nav).toHaveAttribute('data-collapsed', 'false');
+    expect(nav).toHaveStyle({ width: '240px' });
+    expect(screen.getByTestId('sidebar-section-label')).toHaveTextContent(/Domain Packs/i);
   });
 
-  it('switches active on 6 different values', () => {
-    const actives = ['workflows', 'domain', 'pipeline', 'consult', 'chat-demo', 'upload'] as const;
-    const titleMap: Record<(typeof actives)[number], string> = {
-      workflows: 'Workflows',
-      domain: 'Domain Packs',
-      pipeline: 'Pipeline',
-      consult: 'Consultation',
-      'chat-demo': 'Chat Demo',
-      upload: 'Uploads',
-    };
-
-    actives.forEach((active) => {
-      const { container } = render(<Sidebar active={active} />, { wrapper: Wrapper });
-      const activeBtn = container.querySelector('[data-active="true"]');
-      expect(activeBtn).not.toBeNull();
-      expect(activeBtn?.getAttribute('title')).toBe(titleMap[active]);
-    });
+  it('토글 버튼 클릭 시 onToggleCollapsed가 호출된다', () => {
+    const onToggleCollapsed = vi.fn();
+    renderSidebar({ collapsed: true, onToggleCollapsed });
+    fireEvent.click(screen.getByLabelText('사이드바 펼치기'));
+    expect(onToggleCollapsed).toHaveBeenCalledTimes(1);
   });
 
-  it('renders dark variant without error', () => {
-    const { container } = render(<Sidebar active="consult" dark />, { wrapper: Wrapper });
-    expect(container.firstChild).toBeInTheDocument();
+  it('expanded 모드에서도 토글 버튼이 동작한다', () => {
+    const onToggleCollapsed = vi.fn();
+    renderSidebar({ collapsed: false, onToggleCollapsed });
+    fireEvent.click(screen.getByLabelText('사이드바 접기'));
+    expect(onToggleCollapsed).toHaveBeenCalledTimes(1);
   });
 
-  it('renders switcher when provided', () => {
+  it('active=operator일 때 Operator 항목이 강조된다', () => {
+    renderSidebar({ active: 'operator', collapsed: true });
+    expect(screen.getByTitle('Operator')).toHaveAttribute('data-active', 'true');
+    expect(screen.getByTitle('Workflows')).toHaveAttribute('data-active', 'false');
+  });
+
+  it('각 active 값에 대해 정확한 항목이 강조된다', () => {
+    const cases: Array<[SidebarProps['active'], string]> = [
+      ['operator', 'Operator'],
+      ['workflows', 'Workflows'],
+      ['pipeline', 'Pipeline'],
+      ['consult', 'Consultation'],
+      ['upload', 'Uploads'],
+      ['domain', 'Domain Packs'],
+    ];
+    for (const [active, label] of cases) {
+      const { unmount } = renderSidebar({ active, collapsed: true });
+      expect(screen.getByTitle(label)).toHaveAttribute('data-active', 'true');
+      unmount();
+    }
+  });
+
+  it('inactive 항목에 mouseEnter/Leave 시 배경이 토글된다', () => {
+    renderSidebar({ active: 'domain', collapsed: true });
+    const link = screen.getByTitle('Workflows') as HTMLElement;
+    fireEvent.mouseEnter(link);
+    expect(link.style.background).toBe('var(--paper-3)');
+    fireEvent.mouseLeave(link);
+    expect(link.style.background).toBe('transparent');
+  });
+
+  it('switcher가 주어지면 렌더링된다', () => {
     const switcher = <div data-testid="switcher">Switch</div>;
-    render(<Sidebar active="workflows" switcher={switcher} />, { wrapper: Wrapper });
+    renderSidebar({ switcher });
     expect(screen.getByTestId('switcher')).toBeInTheDocument();
   });
 
-  it('handles mouse enter and leave on inactive nav items', () => {
-    const { container } = render(<Sidebar active="domain" />, { wrapper: Wrapper });
-    const workflowLink = container.querySelector('[title="Workflows"]') as HTMLElement;
-    expect(workflowLink).not.toBeNull();
-
-    fireEvent.mouseEnter(workflowLink);
-    expect(workflowLink.style.background).toBe('var(--paper-3)');
-
-    fireEvent.mouseLeave(workflowLink);
-    expect(workflowLink.style.background).toBe('transparent');
+  it('tree.loading=true이면 loading placeholder를 렌더한다', () => {
+    renderSidebar({ collapsed: false, tree: { loading: true, error: null, packs: [] } });
+    expect(screen.getByTestId('sidebar-tree-loading')).toBeInTheDocument();
   });
 
-  it('does not change active item on mouse enter/leave', () => {
-    const { container } = render(<Sidebar active="domain" />, { wrapper: Wrapper });
-    const activeLink = container.querySelector('[data-active="true"]') as HTMLElement;
-    expect(activeLink).not.toBeNull();
-    const bgBefore = activeLink.style.background;
-
-    activeLink.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
-    expect(activeLink.style.background).toBe(bgBefore);
-
-    activeLink.dispatchEvent(new MouseEvent('mouseleave', { bubbles: true }));
-    expect(activeLink.style.background).toBe(bgBefore);
+  it('tree.error가 있으면 에러 메시지를 렌더한다', () => {
+    renderSidebar({ collapsed: false, tree: { loading: false, error: 'oops', packs: [] } });
+    expect(screen.getByTestId('sidebar-tree-error')).toBeInTheDocument();
   });
 
-  it('renders avatar at the bottom', () => {
-    const { container } = render(<Sidebar active="upload" />, { wrapper: Wrapper });
-    expect(container.querySelector('nav')).toBeInTheDocument();
+  it('tree.packs가 비어 있으면 empty 메시지를 렌더한다', () => {
+    renderSidebar({ collapsed: false, tree: { loading: false, error: null, packs: [] } });
+    expect(screen.getByTestId('sidebar-tree-empty')).toBeInTheDocument();
+  });
+
+  it('tree.packs가 있을 때 pack 이름을 렌더한다', () => {
+    renderSidebar({ collapsed: false, tree: TREE_FIXTURE });
+    expect(screen.getByText('CS Support')).toBeInTheDocument();
+    expect(screen.getByText('Billing')).toBeInTheDocument();
+  });
+
+  it('pack을 펼치면 5개 카테고리가 모두 노출된다', () => {
+    renderSidebar({ collapsed: false, tree: TREE_FIXTURE });
+    fireEvent.click(screen.getByText('CS Support'));
+    expect(screen.getByTestId('sidebar-cat-11-intents')).toBeInTheDocument();
+    expect(screen.getByTestId('sidebar-cat-11-slots')).toBeInTheDocument();
+    expect(screen.getByTestId('sidebar-cat-11-policies')).toBeInTheDocument();
+    expect(screen.getByTestId('sidebar-cat-11-risks')).toBeInTheDocument();
+    expect(screen.getByTestId('sidebar-cat-11-workflows')).toBeInTheDocument();
+  });
+
+  it('Workflows 카테고리를 펼치면 개별 워크플로우가 노출된다', () => {
+    renderSidebar({ collapsed: false, tree: TREE_FIXTURE });
+    fireEvent.click(screen.getByText('CS Support'));
+    fireEvent.click(screen.getByTestId('sidebar-cat-11-workflows'));
+    expect(screen.getByTestId('sidebar-workflow-100')).toBeInTheDocument();
+    expect(screen.getByTestId('sidebar-workflow-101')).toBeInTheDocument();
+    expect(screen.queryByTestId('sidebar-workflow-200')).not.toBeInTheDocument();
+  });
+
+  it('activePackId 일치 시 해당 pack이 기본 펼쳐진다', () => {
+    renderSidebar({
+      collapsed: false,
+      tree: TREE_FIXTURE,
+      activePackId: 11,
+      active: 'intent',
+    });
+    expect(screen.getByTestId('sidebar-cat-11-intents')).toBeInTheDocument();
+    expect(screen.queryByTestId('sidebar-cat-12-intents')).not.toBeInTheDocument();
+  });
+
+  it('activePackId+active=workflows이면 Workflows 카테고리도 기본 펼쳐진다', () => {
+    renderSidebar({
+      collapsed: false,
+      tree: TREE_FIXTURE,
+      activePackId: 11,
+      active: 'workflows',
+      activeWorkflowId: 100,
+    });
+    expect(screen.getByTestId('sidebar-workflow-100')).toBeInTheDocument();
+  });
+
+  it('versionId가 null이면 카테고리 링크가 pack base 경로로 fallback한다', () => {
+    const tree: SidebarTreeData = {
+      loading: false,
+      error: null,
+      packs: [{ packId: 99, name: 'Empty', versionId: null, workflows: [] }],
+    };
+    renderSidebar({ collapsed: false, tree });
+    fireEvent.click(screen.getByText('Empty'));
+    const intentsCat = screen.getByTestId('sidebar-cat-99-intents');
+    expect(intentsCat).toHaveAttribute('href', '/workspaces/domain-packs/99');
+  });
+
+  it('basePath prop을 지정하면 링크에 반영된다', () => {
+    renderSidebar({ collapsed: true, basePath: '/workspaces/7' });
+    const opLink = screen.getByTitle('Operator');
+    expect(opLink).toHaveAttribute('href', '/workspaces/7/chat-demo');
   });
 });

--- a/frontend/src/shared/ui/ostone/chrome/Sidebar.test.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/Sidebar.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { Sidebar, type SidebarTreeData } from './Sidebar';
@@ -240,5 +240,138 @@ describe('Sidebar', () => {
     expect(intentsCat.getAttribute('style') ?? '').toContain('var(--signal)');
     const slotsCat = screen.getByTestId('sidebar-cat-11-slots');
     expect(slotsCat.getAttribute('style') ?? '').not.toContain('var(--signal)');
+  });
+});
+
+describe('Sidebar — workflow settings', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  const overflowTree: SidebarTreeData = {
+    loading: false,
+    error: null,
+    packs: [
+      {
+        packId: 50,
+        name: 'Big Pack',
+        versionId: 99,
+        workflows: Array.from({ length: 8 }, (_, i) => ({
+          id: 500 + i,
+          name: `wf-${String(i).padStart(2, '0')}`,
+        })),
+      },
+    ],
+  };
+
+  it('All Workflows 행 옆에 settings 톱니 버튼이 렌더된다', () => {
+    renderSidebar({
+      collapsed: false,
+      tree: overflowTree,
+      activePackId: 50,
+      active: 'workflows',
+    });
+    expect(screen.getByTestId('sidebar-workflows-settings-toggle-50')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('sidebar-workflows-settings-toggle-50').getAttribute('aria-expanded'),
+    ).toBe('false');
+  });
+
+  it('settings 톱니 클릭 시 panel이 펼쳐지고 다시 누르면 닫힌다', () => {
+    renderSidebar({
+      collapsed: false,
+      tree: overflowTree,
+      activePackId: 50,
+      active: 'workflows',
+    });
+    const toggle = screen.getByTestId('sidebar-workflows-settings-toggle-50');
+    fireEvent.click(toggle);
+    expect(toggle.getAttribute('aria-expanded')).toBe('true');
+    expect(screen.getByTestId('sidebar-workflows-settings-50')).toBeInTheDocument();
+    fireEvent.click(toggle);
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    expect(screen.queryByTestId('sidebar-workflows-settings-50')).not.toBeInTheDocument();
+  });
+
+  it('기본 Top N=5 적용 시 8개 중 5개만 표시되고 +3 more 가 노출된다', () => {
+    renderSidebar({
+      collapsed: false,
+      tree: overflowTree,
+      activePackId: 50,
+      active: 'workflows',
+    });
+    expect(screen.getByTestId('sidebar-workflow-500')).toBeInTheDocument();
+    expect(screen.getByTestId('sidebar-workflow-504')).toBeInTheDocument();
+    expect(screen.queryByTestId('sidebar-workflow-505')).not.toBeInTheDocument();
+    const overflow = screen.getByTestId('sidebar-workflows-overflow-50');
+    expect(overflow).toHaveTextContent('+3 more');
+  });
+
+  it('Top N=3 으로 변경 시 즉시 3개만 + 5 more 가 표시된다', () => {
+    renderSidebar({
+      collapsed: false,
+      tree: overflowTree,
+      activePackId: 50,
+      active: 'workflows',
+    });
+    fireEvent.click(screen.getByTestId('sidebar-workflows-settings-toggle-50'));
+    fireEvent.click(screen.getByTestId('sidebar-workflows-settings-50-topN-3'));
+    expect(screen.getByTestId('sidebar-workflow-500')).toBeInTheDocument();
+    expect(screen.getByTestId('sidebar-workflow-502')).toBeInTheDocument();
+    expect(screen.queryByTestId('sidebar-workflow-503')).not.toBeInTheDocument();
+    expect(screen.getByTestId('sidebar-workflows-overflow-50')).toHaveTextContent('+5 more');
+  });
+
+  it('이름 기준 desc 정렬 시 워크플로우 순서가 역전된다', () => {
+    renderSidebar({
+      collapsed: false,
+      tree: overflowTree,
+      activePackId: 50,
+      active: 'workflows',
+    });
+    fireEvent.click(screen.getByTestId('sidebar-workflows-settings-toggle-50'));
+    fireEvent.click(screen.getByTestId('sidebar-workflows-settings-50-sortField-name'));
+    fireEvent.click(screen.getByTestId('sidebar-workflows-settings-50-sortDir-desc'));
+    const list = screen.getByTestId('sidebar-workflows-list-50');
+    const first = list.querySelector<HTMLAnchorElement>('a[data-testid^="sidebar-workflow-"]');
+    expect(first?.dataset.testid).toBe('sidebar-workflow-507');
+  });
+
+  it('settings 변경이 localStorage 에 영속화된다', () => {
+    renderSidebar({
+      collapsed: false,
+      tree: overflowTree,
+      activePackId: 50,
+      active: 'workflows',
+    });
+    fireEvent.click(screen.getByTestId('sidebar-workflows-settings-toggle-50'));
+    fireEvent.click(screen.getByTestId('sidebar-workflows-settings-50-topN-10'));
+    const raw = window.localStorage.getItem('ostone:sidebar:workflow-settings');
+    expect(raw).not.toBeNull();
+    expect(JSON.parse(raw!)).toMatchObject({ topN: 10 });
+  });
+
+  it('영속화된 settings 가 mount 시 hydrate 된다 (topN=3)', () => {
+    window.localStorage.setItem(
+      'ostone:sidebar:workflow-settings',
+      JSON.stringify({ topN: 3, sortField: 'workflowCode', sortDir: 'asc' }),
+    );
+    renderSidebar({
+      collapsed: false,
+      tree: overflowTree,
+      activePackId: 50,
+      active: 'workflows',
+    });
+    expect(screen.getByTestId('sidebar-workflows-overflow-50')).toHaveTextContent('+5 more');
+  });
+
+  it('워크플로우 수 ≤ Top N 인 경우 +M more 미노출', () => {
+    renderSidebar({
+      collapsed: false,
+      tree: TREE_FIXTURE,
+      activePackId: 11,
+      active: 'workflows',
+    });
+    expect(screen.queryByTestId('sidebar-workflows-overflow-11')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/shared/ui/ostone/chrome/Sidebar.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/Sidebar.tsx
@@ -152,10 +152,17 @@ export function Sidebar({
     setSettingsPanelPackId((prev) => (prev === packId ? null : packId));
   };
 
+  const handleNavClick: React.MouseEventHandler<HTMLElement> = (e) => {
+    if (collapsed && e.target === e.currentTarget) {
+      onToggleCollapsed();
+    }
+  };
+
   return (
     <nav
+      onClick={handleNavClick}
       style={{
-        width: collapsed ? '56px' : '240px',
+        width: collapsed ? '64px' : '240px',
         background: containerBg,
         borderRight: `1px solid ${borderColor}`,
         display: 'flex',
@@ -167,55 +174,69 @@ export function Sidebar({
         flexShrink: 0,
         overflowY: 'auto',
         overflowX: 'hidden',
-        transition: 'width 240ms cubic-bezier(0.4, 0, 0.2, 1)',
+        cursor: collapsed ? 'pointer' : 'default',
+        transition: 'width 280ms cubic-bezier(0.4, 0, 0.2, 1), background 200ms ease',
       }}
       aria-label="주요 내비게이션"
       data-collapsed={collapsed ? 'true' : 'false'}
     >
       <div
+        onClick={handleNavClick}
         style={{
           display: 'flex',
-          flexDirection: collapsed ? 'column' : 'row',
+          flexDirection: 'row',
           alignItems: 'center',
           gap: 'var(--s-2)',
           marginBottom: 'var(--s-2)',
           padding: collapsed ? '0' : '0 var(--s-3)',
+          justifyContent: collapsed ? 'center' : 'flex-start',
+          width: collapsed ? 'auto' : '100%',
         }}
       >
         {switcher !== undefined && (
-          <div style={{ flex: collapsed ? '0 0 auto' : '1 1 0', minWidth: 0, display: 'flex', justifyContent: collapsed ? 'center' : 'flex-start' }}>
+          <div
+            style={{
+              flex: collapsed ? '0 0 auto' : '1 1 0',
+              minWidth: 0,
+              display: 'flex',
+              justifyContent: collapsed ? 'center' : 'flex-start',
+            }}
+          >
             {switcher}
           </div>
         )}
-        <button
-          type="button"
-          onClick={onToggleCollapsed}
-          aria-label={collapsed ? '사이드바 펼치기' : '사이드바 접기'}
-          title={collapsed ? '사이드바 펼치기' : '사이드바 접기'}
-          style={{
-            flexShrink: 0,
-            width: '28px',
-            height: '28px',
-            borderRadius: 'var(--r-2)',
-            border: `1px solid ${borderColor}`,
-            background: 'transparent',
-            color: defaultColor,
-            display: 'inline-flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            cursor: 'pointer',
-          }}
-        >
-          <span
+        {!collapsed && (
+          <button
+            type="button"
+            onClick={onToggleCollapsed}
+            aria-label="사이드바 접기"
+            title="사이드바 접기"
             style={{
+              flexShrink: 0,
+              width: '32px',
+              height: '40px',
+              borderRadius: 'var(--r-2)',
+              border: '1px solid var(--line)',
+              background: 'var(--paper)',
+              color: 'var(--ink)',
               display: 'inline-flex',
-              transform: collapsed ? 'none' : 'rotate(180deg)',
-              transition: 'transform 240ms cubic-bezier(0.4, 0, 0.2, 1)',
+              alignItems: 'center',
+              justifyContent: 'center',
+              cursor: 'pointer',
+              transition: 'background 160ms ease, border-color 160ms ease',
             }}
           >
-            <Icon name="chevron" size={12} />
-          </span>
-        </button>
+            <span
+              style={{
+                display: 'inline-flex',
+                transform: 'rotate(180deg)',
+                transition: 'transform 240ms cubic-bezier(0.4, 0, 0.2, 1)',
+              }}
+            >
+              <Icon name="chevron" size={12} />
+            </span>
+          </button>
+        )}
       </div>
 
       <div

--- a/frontend/src/shared/ui/ostone/chrome/Sidebar.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/Sidebar.tsx
@@ -55,18 +55,13 @@ interface TopNavItem {
 
 const TOP_NAV_ITEMS: TopNavItem[] = [
   { key: 'operator', icon: 'msg', label: 'Operator', getPath: (base) => `${base}/chat-demo` },
-  { key: 'workflows', icon: 'grid', label: 'Workflows', getPath: (base) => `${base}/workflows` },
   { key: 'pipeline', icon: 'flow', label: 'Pipeline', getPath: (base) => `${base}/pipeline` },
   { key: 'consult', icon: 'book', label: 'Consultation', getPath: (base) => `${base}/consultation` },
   { key: 'upload', icon: 'upload', label: 'Uploads', getPath: (base) => `${base}/upload` },
 ];
 
-const DOMAIN_NAV_ITEM: TopNavItem = {
-  key: 'domain',
-  icon: 'folder',
-  label: 'Domain Packs',
-  getPath: (base) => `${base}/domain-packs`,
-};
+const DOMAIN_PACKS_LABEL = 'Domain Packs';
+const DOMAIN_PACKS_ICON: IconName = 'folder';
 
 interface PackCategoryItem {
   key: 'intents' | 'slots' | 'policies' | 'risks' | 'workflows';
@@ -79,7 +74,7 @@ const PACK_CATEGORIES: PackCategoryItem[] = [
   { key: 'slots', label: 'Slots', activeKey: 'slot' },
   { key: 'policies', label: 'Policies', activeKey: 'policy' },
   { key: 'risks', label: 'Risks', activeKey: 'risk' },
-  { key: 'workflows', label: 'Workflows', activeKey: 'workflows' },
+  { key: 'workflows', label: 'All Workflows', activeKey: 'workflows' },
 ];
 
 function categoryPath(base: string, packId: number, versionId: number | null, key: PackCategoryItem['key']): string {
@@ -90,6 +85,17 @@ function categoryPath(base: string, packId: number, versionId: number | null, ke
 function workflowPath(base: string, packId: number, versionId: number, workflowId: number): string {
   return `${base}/domain-packs/${packId}/versions/${versionId}/workflows/${workflowId}`;
 }
+
+const PACK_HOVER_HANDLERS = {
+  onMouseEnter: (hoverBg: string, activeColor: string) => (e: React.MouseEvent<HTMLElement>) => {
+    e.currentTarget.style.background = hoverBg;
+    e.currentTarget.style.color = activeColor;
+  },
+  onMouseLeave: (defaultColor: string) => (e: React.MouseEvent<HTMLElement>) => {
+    e.currentTarget.style.background = 'transparent';
+    e.currentTarget.style.color = defaultColor;
+  },
+};
 
 export function Sidebar({
   active,
@@ -117,7 +123,7 @@ export function Sidebar({
         display: 'flex',
         flexDirection: 'column',
         alignItems: collapsed ? 'center' : 'stretch',
-        padding: collapsed ? 'var(--s-3) 0' : 'var(--s-3) 0',
+        padding: 'var(--s-3) 0',
         gap: 'var(--s-2)',
         height: '100%',
         flexShrink: 0,
@@ -187,48 +193,17 @@ export function Sidebar({
           />
         ))}
 
-        {!collapsed && (
-          <div
-            style={{
-              marginTop: 'var(--s-3)',
-              paddingLeft: 'var(--s-3)',
-              paddingRight: 'var(--s-3)',
-              fontFamily: 'var(--mono)',
-              fontSize: '10px',
-              letterSpacing: '0.6px',
-              textTransform: 'uppercase',
-              color: defaultColor,
-              marginBottom: 'var(--s-1)',
-            }}
-            data-testid="sidebar-section-label"
-          >
-            Domain Packs
-          </div>
-        )}
-
-        <SidebarLink
-          to={DOMAIN_NAV_ITEM.getPath(basePath)}
-          icon={DOMAIN_NAV_ITEM.icon}
-          label={DOMAIN_NAV_ITEM.label}
+        <DomainPacksNode
+          basePath={basePath}
           collapsed={collapsed}
-          isActive={active === 'domain'}
+          active={active}
+          tree={tree}
+          activePackId={activePackId}
+          activeWorkflowId={activeWorkflowId}
           activeColor={activeColor}
           defaultColor={defaultColor}
           hoverBg={hoverBg}
         />
-
-        {!collapsed && tree && (
-          <SidebarPackTree
-            tree={tree}
-            basePath={basePath}
-            active={active}
-            activePackId={activePackId}
-            activeWorkflowId={activeWorkflowId}
-            activeColor={activeColor}
-            defaultColor={defaultColor}
-            hoverBg={hoverBg}
-          />
-        )}
       </div>
 
       <div
@@ -316,6 +291,114 @@ function SidebarLink({ to, icon, label, collapsed, isActive, activeColor, defaul
   );
 }
 
+interface DomainPacksNodeProps {
+  basePath: string;
+  collapsed: boolean;
+  active: SidebarActive;
+  tree?: SidebarTreeData;
+  activePackId: number | null;
+  activeWorkflowId: number | null;
+  activeColor: string;
+  defaultColor: string;
+  hoverBg: string;
+}
+
+function DomainPacksNode({
+  basePath,
+  collapsed,
+  active,
+  tree,
+  activePackId,
+  activeWorkflowId,
+  activeColor,
+  defaultColor,
+  hoverBg,
+}: DomainPacksNodeProps) {
+  const isDomainActive =
+    active === 'domain' || active === 'intent' || active === 'slot' || active === 'policy' || active === 'risk' || active === 'workflows';
+  const [open, setOpen] = useState<boolean>(isDomainActive);
+
+  if (collapsed) {
+    return (
+      <SidebarLink
+        to={`${basePath}/domain-packs`}
+        icon={DOMAIN_PACKS_ICON}
+        label={DOMAIN_PACKS_LABEL}
+        collapsed
+        isActive={isDomainActive}
+        activeColor={activeColor}
+        defaultColor={defaultColor}
+        hoverBg={hoverBg}
+      />
+    );
+  }
+
+  return (
+    <div data-testid="sidebar-domain-section">
+      <button
+        type="button"
+        aria-expanded={open}
+        aria-label={DOMAIN_PACKS_LABEL}
+        onClick={() => setOpen((v) => !v)}
+        data-active={isDomainActive ? 'true' : 'false'}
+        data-testid="sidebar-domain-toggle"
+        style={{
+          width: '100%',
+          height: '32px',
+          padding: '0 var(--s-3)',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 'var(--s-2)',
+          color: isDomainActive ? activeColor : defaultColor,
+          background: isDomainActive ? hoverBg : 'transparent',
+          borderLeft: `3px solid ${isDomainActive ? 'var(--signal)' : 'transparent'}`,
+          border: 'none',
+          borderRight: 'none',
+          borderTop: 'none',
+          borderBottom: 'none',
+          textAlign: 'left',
+          cursor: 'pointer',
+          fontFamily: 'var(--sans)',
+          fontSize: '13px',
+          fontWeight: isDomainActive ? 500 : 400,
+          letterSpacing: '-0.1px',
+        }}
+        onMouseEnter={PACK_HOVER_HANDLERS.onMouseEnter(hoverBg, activeColor)}
+        onMouseLeave={(e) => {
+          if (!isDomainActive) {
+            PACK_HOVER_HANDLERS.onMouseLeave(defaultColor)(e);
+          }
+        }}
+      >
+        <Icon name={DOMAIN_PACKS_ICON} size={14} />
+        <span style={{ flex: 1 }}>{DOMAIN_PACKS_LABEL}</span>
+        <span
+          style={{
+            display: 'inline-flex',
+            transform: open ? 'rotate(90deg)' : 'none',
+            transition: 'transform 120ms ease',
+          }}
+        >
+          <Icon name="chevron" size={10} />
+        </span>
+      </button>
+
+      {open && tree && (
+        <SidebarPackTree
+          tree={tree}
+          basePath={basePath}
+          active={active}
+          activePackId={activePackId}
+          activeWorkflowId={activeWorkflowId}
+          activeColor={activeColor}
+          defaultColor={defaultColor}
+          hoverBg={hoverBg}
+        />
+      )}
+    </div>
+  );
+}
+
 interface SidebarPackTreeProps {
   tree: SidebarTreeData;
   basePath: string;
@@ -342,7 +425,7 @@ function SidebarPackTree({
       <div
         data-testid="sidebar-tree-loading"
         style={{
-          padding: 'var(--s-2) var(--s-3)',
+          padding: 'var(--s-2) var(--s-3) var(--s-2) 32px',
           fontFamily: 'var(--mono)',
           fontSize: '10px',
           color: defaultColor,
@@ -359,7 +442,7 @@ function SidebarPackTree({
         role="alert"
         data-testid="sidebar-tree-error"
         style={{
-          padding: 'var(--s-2) var(--s-3)',
+          padding: 'var(--s-2) var(--s-3) var(--s-2) 32px',
           fontFamily: 'var(--mono)',
           fontSize: '10px',
           color: 'var(--danger)',
@@ -375,7 +458,7 @@ function SidebarPackTree({
       <div
         data-testid="sidebar-tree-empty"
         style={{
-          padding: 'var(--s-2) var(--s-3)',
+          padding: 'var(--s-2) var(--s-3) var(--s-2) 32px',
           fontFamily: 'var(--mono)',
           fontSize: '10px',
           color: defaultColor,
@@ -428,7 +511,6 @@ function PackNode({
 }: PackNodeProps) {
   const isCurrentPack = activePackId === pack.packId;
   const [open, setOpen] = useState(isCurrentPack);
-  const [workflowsOpen, setWorkflowsOpen] = useState(isCurrentPack && active === 'workflows');
 
   return (
     <div data-testid={`sidebar-pack-${pack.packId}`}>
@@ -440,7 +522,7 @@ function PackNode({
           width: '100%',
           background: 'transparent',
           border: 'none',
-          padding: '6px var(--s-3)',
+          padding: '6px var(--s-3) 6px 32px',
           display: 'flex',
           alignItems: 'center',
           gap: 'var(--s-2)',
@@ -453,73 +535,75 @@ function PackNode({
           textAlign: 'left',
         }}
       >
-        <span style={{ display: 'inline-flex', transform: open ? 'rotate(90deg)' : 'none', transition: 'transform 120ms ease' }}>
+        <span
+          style={{
+            display: 'inline-flex',
+            transform: open ? 'rotate(90deg)' : 'none',
+            transition: 'transform 120ms ease',
+          }}
+        >
           <Icon name="chevron" size={10} />
         </span>
-        <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{pack.name}</span>
+        <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+          {pack.name}
+        </span>
       </button>
 
       {open && (
         <div style={{ display: 'flex', flexDirection: 'column' }}>
           {PACK_CATEGORIES.map((cat) => {
             const isActiveCat = isCurrentPack && active === cat.activeKey;
-            if (cat.key === 'workflows') {
-              return (
-                <div key={cat.key}>
-                  <button
-                    type="button"
-                    onClick={() => setWorkflowsOpen((v) => !v)}
-                    aria-expanded={workflowsOpen}
-                    style={{
-                      width: '100%',
-                      background: isActiveCat ? hoverBg : 'transparent',
-                      border: 'none',
-                      borderLeft: `3px solid ${isActiveCat ? 'var(--signal)' : 'transparent'}`,
-                      padding: '4px var(--s-3) 4px 32px',
-                      display: 'flex',
-                      alignItems: 'center',
-                      gap: 'var(--s-1)',
-                      cursor: 'pointer',
-                      fontFamily: 'var(--sans)',
-                      fontSize: '12px',
-                      color: isActiveCat ? activeColor : defaultColor,
-                      letterSpacing: '-0.1px',
-                      textAlign: 'left',
-                    }}
-                    data-testid={`sidebar-cat-${pack.packId}-workflows`}
-                  >
-                    <span style={{ display: 'inline-flex', transform: workflowsOpen ? 'rotate(90deg)' : 'none', transition: 'transform 120ms ease' }}>
-                      <Icon name="chevron" size={9} />
-                    </span>
-                    <span>{cat.label}</span>
-                  </button>
-                  {workflowsOpen && (
-                    <div style={{ display: 'flex', flexDirection: 'column' }}>
-                      <NavLink
-                        to={categoryPath(basePath, pack.packId, pack.versionId, 'workflows')}
-                        end
-                        style={({ isActive }) => ({
-                          padding: '4px var(--s-3) 4px 48px',
+            const isWorkflowsCat = cat.key === 'workflows';
+            return (
+              <div key={cat.key}>
+                <NavLink
+                  to={categoryPath(basePath, pack.packId, pack.versionId, cat.key)}
+                  end
+                  data-testid={`sidebar-cat-${pack.packId}-${cat.key}`}
+                  style={{
+                    padding: '4px var(--s-3) 4px 48px',
+                    borderLeft: `3px solid ${isActiveCat ? 'var(--signal)' : 'transparent'}`,
+                    background: isActiveCat ? hoverBg : 'transparent',
+                    fontFamily: 'var(--sans)',
+                    fontSize: '12px',
+                    fontWeight: isActiveCat ? 500 : 400,
+                    color: isActiveCat ? activeColor : defaultColor,
+                    textDecoration: 'none',
+                    letterSpacing: '-0.1px',
+                    display: 'block',
+                  }}
+                >
+                  {cat.label}
+                </NavLink>
+                {isWorkflowsCat && isActiveCat && (
+                  <div data-testid={`sidebar-workflows-list-${pack.packId}`} style={{ display: 'flex', flexDirection: 'column' }}>
+                    {pack.workflows.length === 0 ? (
+                      <span
+                        data-testid={`sidebar-workflows-empty-${pack.packId}`}
+                        style={{
+                          padding: '4px var(--s-3) 4px 64px',
                           fontFamily: 'var(--mono)',
                           fontSize: '10px',
-                          color: isActive ? activeColor : defaultColor,
-                          textDecoration: 'none',
-                          letterSpacing: '0.4px',
-                          textTransform: 'uppercase',
-                        })}
+                          color: defaultColor,
+                        }}
                       >
-                        all workflows
-                      </NavLink>
-                      {pack.workflows.map((wf) => {
-                        const isActiveWf = isCurrentPack && activeWorkflowId === wf.id;
+                        no workflows
+                      </span>
+                    ) : (
+                      pack.workflows.map((wf) => {
+                        const isActiveWf = activeWorkflowId === wf.id;
                         return (
                           <NavLink
                             key={wf.id}
-                            to={pack.versionId !== null ? workflowPath(basePath, pack.packId, pack.versionId, wf.id) : '#'}
+                            to={
+                              pack.versionId !== null
+                                ? workflowPath(basePath, pack.packId, pack.versionId, wf.id)
+                                : '#'
+                            }
                             end
                             data-testid={`sidebar-workflow-${wf.id}`}
                             style={{
-                              padding: '4px var(--s-3) 4px 48px',
+                              padding: '4px var(--s-3) 4px 64px',
                               borderLeft: `3px solid ${isActiveWf ? 'var(--signal)' : 'transparent'}`,
                               background: isActiveWf ? hoverBg : 'transparent',
                               fontFamily: 'var(--sans)',
@@ -531,37 +615,17 @@ function PackNode({
                               overflow: 'hidden',
                               textOverflow: 'ellipsis',
                               whiteSpace: 'nowrap',
+                              display: 'block',
                             }}
                           >
                             {wf.name}
                           </NavLink>
                         );
-                      })}
-                    </div>
-                  )}
-                </div>
-              );
-            }
-            return (
-              <NavLink
-                key={cat.key}
-                to={categoryPath(basePath, pack.packId, pack.versionId, cat.key)}
-                end
-                data-testid={`sidebar-cat-${pack.packId}-${cat.key}`}
-                style={{
-                  padding: '4px var(--s-3) 4px 32px',
-                  borderLeft: `3px solid ${isActiveCat ? 'var(--signal)' : 'transparent'}`,
-                  background: isActiveCat ? hoverBg : 'transparent',
-                  fontFamily: 'var(--sans)',
-                  fontSize: '12px',
-                  fontWeight: isActiveCat ? 500 : 400,
-                  color: isActiveCat ? activeColor : defaultColor,
-                  textDecoration: 'none',
-                  letterSpacing: '-0.1px',
-                }}
-              >
-                {cat.label}
-              </NavLink>
+                      })
+                    )}
+                  </div>
+                )}
+              </div>
             );
           })}
         </div>

--- a/frontend/src/shared/ui/ostone/chrome/Sidebar.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/Sidebar.tsx
@@ -2,7 +2,7 @@ import { useState, type ReactNode, type CSSProperties } from 'react';
 import { NavLink } from 'react-router-dom';
 import { Icon } from '../atoms/Icon';
 import type { IconName } from '../atoms/Icon';
-import { Avatar } from '../atoms/Avatar';
+import { AccountMenu } from './AccountMenu';
 
 export type SidebarActive =
   | 'operator'
@@ -128,6 +128,8 @@ export function Sidebar({
         height: '100%',
         flexShrink: 0,
         overflowY: 'auto',
+        overflowX: 'hidden',
+        transition: 'width 240ms cubic-bezier(0.4, 0, 0.2, 1)',
       }}
       aria-label="주요 내비게이션"
       data-collapsed={collapsed ? 'true' : 'false'}
@@ -135,14 +137,17 @@ export function Sidebar({
       {switcher !== undefined && (
         <div
           style={{
-            marginBottom: 'var(--s-2)',
             display: 'flex',
-            justifyContent: collapsed ? 'center' : 'flex-start',
-            paddingLeft: collapsed ? 0 : 'var(--s-3)',
-            paddingRight: collapsed ? 0 : 'var(--s-3)',
+            flexDirection: 'column',
+            gap: 'var(--s-2)',
+            marginBottom: 'var(--s-2)',
+            padding: collapsed ? '0' : '0 var(--s-3)',
+            alignItems: collapsed ? 'center' : 'stretch',
           }}
         >
-          {switcher}
+          <div style={{ width: '100%', display: 'flex', justifyContent: collapsed ? 'center' : 'stretch' }}>
+            {switcher}
+          </div>
         </div>
       )}
 
@@ -167,7 +172,15 @@ export function Sidebar({
           cursor: 'pointer',
         }}
       >
-        <Icon name={collapsed ? 'chevron' : 'close'} size={12} />
+        <span
+          style={{
+            display: 'inline-flex',
+            transform: collapsed ? 'none' : 'rotate(180deg)',
+            transition: 'transform 240ms cubic-bezier(0.4, 0, 0.2, 1)',
+          }}
+        >
+          <Icon name="chevron" size={12} />
+        </span>
       </button>
 
       <div
@@ -210,13 +223,13 @@ export function Sidebar({
         style={{
           marginTop: 'auto',
           display: 'flex',
-          justifyContent: collapsed ? 'center' : 'flex-start',
+          justifyContent: collapsed ? 'center' : 'stretch',
           paddingLeft: collapsed ? 0 : 'var(--s-3)',
           paddingRight: collapsed ? 0 : 'var(--s-3)',
           paddingTop: 'var(--s-3)',
         }}
       >
-        <Avatar tone="signal" initial="BS" size={28} />
+        <AccountMenu collapsed={collapsed} />
       </div>
     </nav>
   );

--- a/frontend/src/shared/ui/ostone/chrome/Sidebar.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/Sidebar.tsx
@@ -152,17 +152,19 @@ export function Sidebar({
     setSettingsPanelPackId((prev) => (prev === packId ? null : packId));
   };
 
-  const handleNavClick: React.MouseEventHandler<HTMLElement> = (e) => {
-    if (collapsed && e.target === e.currentTarget) {
+  const handleNavCapture: React.MouseEventHandler<HTMLElement> = (e) => {
+    if (collapsed) {
+      e.stopPropagation();
+      e.preventDefault();
       onToggleCollapsed();
     }
   };
 
   return (
     <nav
-      onClick={handleNavClick}
+      onClickCapture={handleNavCapture}
       style={{
-        width: collapsed ? '64px' : '240px',
+        width: collapsed ? '72px' : '256px',
         background: containerBg,
         borderRight: `1px solid ${borderColor}`,
         display: 'flex',
@@ -175,13 +177,12 @@ export function Sidebar({
         overflowY: 'auto',
         overflowX: 'hidden',
         cursor: collapsed ? 'pointer' : 'default',
-        transition: 'width 280ms cubic-bezier(0.4, 0, 0.2, 1), background 200ms ease',
+        transition: 'width 400ms cubic-bezier(0.32, 0.72, 0.16, 1), background 200ms ease',
       }}
       aria-label="주요 내비게이션"
       data-collapsed={collapsed ? 'true' : 'false'}
     >
       <div
-        onClick={handleNavClick}
         style={{
           display: 'flex',
           flexDirection: 'row',
@@ -213,7 +214,7 @@ export function Sidebar({
             title="사이드바 접기"
             style={{
               flexShrink: 0,
-              width: '32px',
+              width: '40px',
               height: '40px',
               borderRadius: 'var(--r-2)',
               border: '1px solid var(--line)',
@@ -233,7 +234,7 @@ export function Sidebar({
                 transition: 'transform 240ms cubic-bezier(0.4, 0, 0.2, 1)',
               }}
             >
-              <Icon name="chevron" size={12} />
+              <Icon name="chevron" size={14} />
             </span>
           </button>
         )}
@@ -313,8 +314,8 @@ interface SidebarLinkProps {
 
 function SidebarLink({ to, icon, label, collapsed, isActive, activeColor, defaultColor, hoverBg }: SidebarLinkProps) {
   const collapsedStyle: CSSProperties = {
-    width: '36px',
-    height: '36px',
+    width: '40px',
+    height: '40px',
     borderRadius: 'var(--r-2)',
     display: 'flex',
     alignItems: 'center',
@@ -322,12 +323,12 @@ function SidebarLink({ to, icon, label, collapsed, isActive, activeColor, defaul
     color: isActive ? activeColor : defaultColor,
     background: isActive ? hoverBg : 'transparent',
     textDecoration: 'none',
-    transition: 'background 120ms ease, color 120ms ease',
+    transition: 'background 160ms ease, color 160ms ease',
     margin: '0 auto',
   };
 
   const expandedStyle: CSSProperties = {
-    height: '32px',
+    height: '40px',
     padding: '0 var(--s-3)',
     display: 'flex',
     alignItems: 'center',
@@ -336,9 +337,9 @@ function SidebarLink({ to, icon, label, collapsed, isActive, activeColor, defaul
     background: isActive ? hoverBg : 'transparent',
     borderLeft: `3px solid ${isActive ? 'var(--signal)' : 'transparent'}`,
     textDecoration: 'none',
-    transition: 'background 120ms ease, color 120ms ease',
+    transition: 'background 160ms ease, color 160ms ease',
     fontFamily: 'var(--sans)',
-    fontSize: '13px',
+    fontSize: '14px',
     fontWeight: isActive ? 500 : 400,
     letterSpacing: '-0.1px',
   };
@@ -363,7 +364,7 @@ function SidebarLink({ to, icon, label, collapsed, isActive, activeColor, defaul
         }
       }}
     >
-      <Icon name={icon} size={collapsed ? 16 : 14} />
+      <Icon name={icon} size={16} />
       {!collapsed && <span>{label}</span>}
     </NavLink>
   );
@@ -430,7 +431,7 @@ function DomainPacksNode({
         data-testid="sidebar-domain-toggle"
         style={{
           width: '100%',
-          height: '32px',
+          height: '40px',
           padding: '0 var(--s-3)',
           display: 'flex',
           alignItems: 'center',
@@ -445,9 +446,10 @@ function DomainPacksNode({
           textAlign: 'left',
           cursor: 'pointer',
           fontFamily: 'var(--sans)',
-          fontSize: '13px',
+          fontSize: '14px',
           fontWeight: isDomainActive ? 500 : 400,
           letterSpacing: '-0.1px',
+          transition: 'background 160ms ease, color 160ms ease',
         }}
         onMouseEnter={PACK_HOVER_HANDLERS.onMouseEnter(hoverBg, activeColor)}
         onMouseLeave={(e) => {
@@ -456,16 +458,16 @@ function DomainPacksNode({
           }
         }}
       >
-        <Icon name={DOMAIN_PACKS_ICON} size={14} />
+        <Icon name={DOMAIN_PACKS_ICON} size={16} />
         <span style={{ flex: 1 }}>{DOMAIN_PACKS_LABEL}</span>
         <span
           style={{
             display: 'inline-flex',
             transform: open ? 'rotate(90deg)' : 'none',
-            transition: 'transform 120ms ease',
+            transition: 'transform 160ms ease',
           }}
         >
-          <Icon name="chevron" size={10} />
+          <Icon name="chevron" size={12} />
         </span>
       </button>
 
@@ -670,13 +672,13 @@ function PackNode({
           width: '100%',
           background: 'transparent',
           border: 'none',
-          padding: '6px var(--s-3) 6px 32px',
+          padding: '8px var(--s-3) 8px 32px',
           display: 'flex',
           alignItems: 'center',
           gap: 'var(--s-2)',
           cursor: 'pointer',
           fontFamily: 'var(--sans)',
-          fontSize: '12px',
+          fontSize: '13px',
           fontWeight: isCurrentPack ? 500 : 400,
           color: isCurrentPack ? activeColor : defaultColor,
           letterSpacing: '-0.1px',

--- a/frontend/src/shared/ui/ostone/chrome/Sidebar.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/Sidebar.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useMemo, useState, type ReactNode, type CSSProperties } from 'react';
+import { useEffect, useMemo, useRef, useState, type ReactNode, type CSSProperties } from 'react';
 import { NavLink } from 'react-router-dom';
+import { Settings as SettingsIcon } from 'lucide-react';
 import { Icon } from '../atoms/Icon';
 import type { IconName } from '../atoms/Icon';
 import { AccountMenu } from './AccountMenu';
@@ -13,6 +14,16 @@ import {
   writeSidebarWorkflowSettings,
   type SidebarWorkflowSettings,
 } from '@/shared/lib/workflowSettings';
+
+const SORT_FIELD_KO_LABELS: Record<(typeof SORT_FIELD_OPTIONS)[number]['value'], string> = {
+  workflowCode: '코드',
+  name: '이름',
+};
+
+const SORT_DIR_KO_LABELS: Record<(typeof SORT_DIR_OPTIONS)[number]['value'], string> = {
+  asc: '오름차순',
+  desc: '내림차순',
+};
 
 export type SidebarActive =
   | 'operator'
@@ -596,20 +607,21 @@ function PackNode({
 
   const visibleWorkflows = sortedWorkflows.slice(0, workflowSettings.topN);
   const hiddenCount = Math.max(0, sortedWorkflows.length - visibleWorkflows.length);
+  const settingsButtonRef = useRef<HTMLButtonElement>(null);
 
   const settingsEntries: WorkflowSettingEntry[] = [
     {
       key: 'topN',
-      label: 'Top N',
+      label: '표시 개수',
       value: workflowSettings.topN,
       options: TOP_N_OPTIONS.map((n) => ({ value: n, label: String(n) })),
       onChange: (next) => onUpdateWorkflowSettings({ topN: Number(next) }),
     },
     {
       key: 'sortField',
-      label: 'Sort by',
+      label: '정렬 기준',
       value: workflowSettings.sortField,
-      options: SORT_FIELD_OPTIONS.map((o) => ({ value: o.value, label: o.label })),
+      options: SORT_FIELD_OPTIONS.map((o) => ({ value: o.value, label: SORT_FIELD_KO_LABELS[o.value] })),
       onChange: (next) =>
         onUpdateWorkflowSettings({
           sortField: next === 'name' ? 'name' : 'workflowCode',
@@ -617,9 +629,9 @@ function PackNode({
     },
     {
       key: 'sortDir',
-      label: 'Order',
+      label: '정렬 방식',
       value: workflowSettings.sortDir,
-      options: SORT_DIR_OPTIONS.map((o) => ({ value: o.value, label: o.label })),
+      options: SORT_DIR_OPTIONS.map((o) => ({ value: o.value, label: SORT_DIR_KO_LABELS[o.value] })),
       onChange: (next) =>
         onUpdateWorkflowSettings({ sortDir: next === 'desc' ? 'desc' : 'asc' }),
     },
@@ -696,7 +708,7 @@ function PackNode({
             }
 
             return (
-              <div key={cat.key}>
+              <div key={cat.key} style={{ position: 'relative' }}>
                 <div style={{ display: 'flex', alignItems: 'stretch' }}>
                   <NavLink
                     to={categoryPath(basePath, pack.packId, pack.versionId, cat.key)}
@@ -707,6 +719,7 @@ function PackNode({
                     {cat.label}
                   </NavLink>
                   <button
+                    ref={settingsButtonRef}
                     type="button"
                     onClick={onToggleSettingsPanel}
                     aria-label="워크플로우 표시 설정"
@@ -725,7 +738,7 @@ function PackNode({
                       justifyContent: 'center',
                     }}
                   >
-                    <Icon name="settings" size={12} />
+                    <SettingsIcon size={14} />
                   </button>
                 </div>
 
@@ -733,6 +746,9 @@ function PackNode({
                   <WorkflowSettingsPanel
                     entries={settingsEntries}
                     testId={`sidebar-workflows-settings-${pack.packId}`}
+                    style={{ left: 'var(--s-3)', top: 'calc(100% + 4px)' }}
+                    onClickOutside={onToggleSettingsPanel}
+                    anchorRef={settingsButtonRef}
                   />
                 )}
 

--- a/frontend/src/shared/ui/ostone/chrome/Sidebar.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/Sidebar.tsx
@@ -155,7 +155,7 @@ export function Sidebar({
   return (
     <nav
       style={{
-        width: collapsed ? '56px' : '240px',
+        width: collapsed ? '56px' : '220px',
         background: containerBg,
         borderRight: `1px solid ${borderColor}`,
         display: 'flex',
@@ -198,16 +198,17 @@ export function Sidebar({
           alignSelf: collapsed ? 'center' : 'flex-end',
           marginRight: collapsed ? 0 : 'var(--s-3)',
           marginBottom: 'var(--s-2)',
-          width: '28px',
-          height: '28px',
+          width: '32px',
+          height: '32px',
           borderRadius: 'var(--r-2)',
-          border: `1px solid ${borderColor}`,
-          background: 'transparent',
-          color: defaultColor,
+          border: `1px solid var(--ink)`,
+          background: 'var(--paper)',
+          color: 'var(--ink)',
           display: 'inline-flex',
           alignItems: 'center',
           justifyContent: 'center',
           cursor: 'pointer',
+          boxShadow: '0 1px 2px rgba(0,0,0,0.05)',
         }}
       >
         <span
@@ -217,7 +218,7 @@ export function Sidebar({
             transition: 'transform 240ms cubic-bezier(0.4, 0, 0.2, 1)',
           }}
         >
-          <Icon name="chevron" size={12} />
+          <Icon name="chevron" size={14} />
         </span>
       </button>
 
@@ -262,6 +263,7 @@ export function Sidebar({
       </div>
 
       <div
+        data-testid="sidebar-account-slot"
         style={{
           marginTop: 'auto',
           display: 'flex',
@@ -269,6 +271,10 @@ export function Sidebar({
           paddingLeft: collapsed ? 0 : 'var(--s-3)',
           paddingRight: collapsed ? 0 : 'var(--s-3)',
           paddingTop: 'var(--s-3)',
+          position: 'sticky',
+          bottom: 0,
+          background: containerBg,
+          zIndex: 50,
         }}
       >
         <AccountMenu collapsed={collapsed} />
@@ -647,7 +653,7 @@ function PackNode({
           width: '100%',
           background: 'transparent',
           border: 'none',
-          padding: '6px var(--s-3) 6px 32px',
+          padding: '6px var(--s-3) 6px 24px',
           display: 'flex',
           alignItems: 'center',
           gap: 'var(--s-2)',
@@ -680,7 +686,7 @@ function PackNode({
             const isActiveCat = isCurrentPack && active === cat.activeKey;
             const isWorkflowsCat = cat.key === 'workflows';
             const navLinkStyle: CSSProperties = {
-              padding: '4px var(--s-3) 4px 48px',
+              padding: '4px var(--s-3) 4px 36px',
               borderLeft: `3px solid ${isActiveCat ? 'var(--signal)' : 'transparent'}`,
               background: isActiveCat ? hoverBg : 'transparent',
               fontFamily: 'var(--sans)',
@@ -761,7 +767,7 @@ function PackNode({
                       <span
                         data-testid={`sidebar-workflows-empty-${pack.packId}`}
                         style={{
-                          padding: '4px var(--s-3) 4px 64px',
+                          padding: '4px var(--s-3) 4px 44px',
                           fontFamily: 'var(--mono)',
                           fontSize: '10px',
                           color: defaultColor,
@@ -783,7 +789,7 @@ function PackNode({
                             end
                             data-testid={`sidebar-workflow-${wf.id}`}
                             style={{
-                              padding: '4px var(--s-3) 4px 64px',
+                              padding: '4px var(--s-3) 4px 44px',
                               borderLeft: `3px solid ${isActiveWf ? 'var(--signal)' : 'transparent'}`,
                               background: isActiveWf ? hoverBg : 'transparent',
                               fontFamily: 'var(--sans)',
@@ -809,7 +815,7 @@ function PackNode({
                         end
                         data-testid={`sidebar-workflows-overflow-${pack.packId}`}
                         style={{
-                          padding: '4px var(--s-3) 4px 64px',
+                          padding: '4px var(--s-3) 4px 44px',
                           fontFamily: 'var(--mono)',
                           fontSize: '10px',
                           color: defaultColor,

--- a/frontend/src/shared/ui/ostone/chrome/Sidebar.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/Sidebar.tsx
@@ -1,8 +1,18 @@
-import { useState, type ReactNode, type CSSProperties } from 'react';
+import { useEffect, useMemo, useState, type ReactNode, type CSSProperties } from 'react';
 import { NavLink } from 'react-router-dom';
 import { Icon } from '../atoms/Icon';
 import type { IconName } from '../atoms/Icon';
 import { AccountMenu } from './AccountMenu';
+import { WorkflowSettingsPanel, type WorkflowSettingEntry } from './WorkflowSettingsPanel';
+import {
+  SORT_DIR_OPTIONS,
+  SORT_FIELD_OPTIONS,
+  TOP_N_OPTIONS,
+  compareWorkflows,
+  readSidebarWorkflowSettings,
+  writeSidebarWorkflowSettings,
+  type SidebarWorkflowSettings,
+} from '@/shared/lib/workflowSettings';
 
 export type SidebarActive =
   | 'operator'
@@ -114,6 +124,23 @@ export function Sidebar({
   const hoverBg = dark ? 'var(--dark-bg-2)' : 'var(--paper-3)';
   const activeColor = dark ? 'var(--dark-ink)' : 'var(--ink)';
 
+  const [workflowSettings, setWorkflowSettings] = useState<SidebarWorkflowSettings>(() =>
+    readSidebarWorkflowSettings(),
+  );
+  const [settingsPanelPackId, setSettingsPanelPackId] = useState<number | null>(null);
+
+  useEffect(() => {
+    writeSidebarWorkflowSettings(workflowSettings);
+  }, [workflowSettings]);
+
+  const updateWorkflowSettings = (patch: Partial<SidebarWorkflowSettings>) => {
+    setWorkflowSettings((prev) => ({ ...prev, ...patch }));
+  };
+
+  const toggleSettingsPanel = (packId: number) => {
+    setSettingsPanelPackId((prev) => (prev === packId ? null : packId));
+  };
+
   return (
     <nav
       style={{
@@ -216,6 +243,10 @@ export function Sidebar({
           activeColor={activeColor}
           defaultColor={defaultColor}
           hoverBg={hoverBg}
+          workflowSettings={workflowSettings}
+          settingsPanelPackId={settingsPanelPackId}
+          onToggleSettingsPanel={toggleSettingsPanel}
+          onUpdateWorkflowSettings={updateWorkflowSettings}
         />
       </div>
 
@@ -314,6 +345,10 @@ interface DomainPacksNodeProps {
   activeColor: string;
   defaultColor: string;
   hoverBg: string;
+  workflowSettings: SidebarWorkflowSettings;
+  settingsPanelPackId: number | null;
+  onToggleSettingsPanel: (packId: number) => void;
+  onUpdateWorkflowSettings: (patch: Partial<SidebarWorkflowSettings>) => void;
 }
 
 function DomainPacksNode({
@@ -326,6 +361,10 @@ function DomainPacksNode({
   activeColor,
   defaultColor,
   hoverBg,
+  workflowSettings,
+  settingsPanelPackId,
+  onToggleSettingsPanel,
+  onUpdateWorkflowSettings,
 }: DomainPacksNodeProps) {
   const isDomainActive =
     active === 'domain' || active === 'intent' || active === 'slot' || active === 'policy' || active === 'risk' || active === 'workflows';
@@ -406,6 +445,10 @@ function DomainPacksNode({
           activeColor={activeColor}
           defaultColor={defaultColor}
           hoverBg={hoverBg}
+          workflowSettings={workflowSettings}
+          settingsPanelPackId={settingsPanelPackId}
+          onToggleSettingsPanel={onToggleSettingsPanel}
+          onUpdateWorkflowSettings={onUpdateWorkflowSettings}
         />
       )}
     </div>
@@ -421,6 +464,10 @@ interface SidebarPackTreeProps {
   activeColor: string;
   defaultColor: string;
   hoverBg: string;
+  workflowSettings: SidebarWorkflowSettings;
+  settingsPanelPackId: number | null;
+  onToggleSettingsPanel: (packId: number) => void;
+  onUpdateWorkflowSettings: (patch: Partial<SidebarWorkflowSettings>) => void;
 }
 
 function SidebarPackTree({
@@ -432,6 +479,10 @@ function SidebarPackTree({
   activeColor,
   defaultColor,
   hoverBg,
+  workflowSettings,
+  settingsPanelPackId,
+  onToggleSettingsPanel,
+  onUpdateWorkflowSettings,
 }: SidebarPackTreeProps) {
   if (tree.loading) {
     return (
@@ -495,6 +546,10 @@ function SidebarPackTree({
           activeColor={activeColor}
           defaultColor={defaultColor}
           hoverBg={hoverBg}
+          workflowSettings={workflowSettings}
+          settingsPanelOpen={settingsPanelPackId === pack.packId}
+          onToggleSettingsPanel={() => onToggleSettingsPanel(pack.packId)}
+          onUpdateWorkflowSettings={onUpdateWorkflowSettings}
         />
       ))}
     </div>
@@ -510,6 +565,10 @@ interface PackNodeProps {
   activeColor: string;
   defaultColor: string;
   hoverBg: string;
+  workflowSettings: SidebarWorkflowSettings;
+  settingsPanelOpen: boolean;
+  onToggleSettingsPanel: () => void;
+  onUpdateWorkflowSettings: (patch: Partial<SidebarWorkflowSettings>) => void;
 }
 
 function PackNode({
@@ -521,9 +580,50 @@ function PackNode({
   activeColor,
   defaultColor,
   hoverBg,
+  workflowSettings,
+  settingsPanelOpen,
+  onToggleSettingsPanel,
+  onUpdateWorkflowSettings,
 }: PackNodeProps) {
   const isCurrentPack = activePackId === pack.packId;
   const [open, setOpen] = useState(isCurrentPack);
+
+  const sortedWorkflows = useMemo(() => {
+    return [...pack.workflows].sort((a, b) =>
+      compareWorkflows(a, b, workflowSettings.sortField, workflowSettings.sortDir),
+    );
+  }, [pack.workflows, workflowSettings.sortField, workflowSettings.sortDir]);
+
+  const visibleWorkflows = sortedWorkflows.slice(0, workflowSettings.topN);
+  const hiddenCount = Math.max(0, sortedWorkflows.length - visibleWorkflows.length);
+
+  const settingsEntries: WorkflowSettingEntry[] = [
+    {
+      key: 'topN',
+      label: 'Top N',
+      value: workflowSettings.topN,
+      options: TOP_N_OPTIONS.map((n) => ({ value: n, label: String(n) })),
+      onChange: (next) => onUpdateWorkflowSettings({ topN: Number(next) }),
+    },
+    {
+      key: 'sortField',
+      label: 'Sort by',
+      value: workflowSettings.sortField,
+      options: SORT_FIELD_OPTIONS.map((o) => ({ value: o.value, label: o.label })),
+      onChange: (next) =>
+        onUpdateWorkflowSettings({
+          sortField: next === 'name' ? 'name' : 'workflowCode',
+        }),
+    },
+    {
+      key: 'sortDir',
+      label: 'Order',
+      value: workflowSettings.sortDir,
+      options: SORT_DIR_OPTIONS.map((o) => ({ value: o.value, label: o.label })),
+      onChange: (next) =>
+        onUpdateWorkflowSettings({ sortDir: next === 'desc' ? 'desc' : 'asc' }),
+    },
+  ];
 
   return (
     <div data-testid={`sidebar-pack-${pack.packId}`}>
@@ -567,30 +667,81 @@ function PackNode({
           {PACK_CATEGORIES.map((cat) => {
             const isActiveCat = isCurrentPack && active === cat.activeKey;
             const isWorkflowsCat = cat.key === 'workflows';
-            return (
-              <div key={cat.key}>
+            const navLinkStyle: CSSProperties = {
+              padding: '4px var(--s-3) 4px 48px',
+              borderLeft: `3px solid ${isActiveCat ? 'var(--signal)' : 'transparent'}`,
+              background: isActiveCat ? hoverBg : 'transparent',
+              fontFamily: 'var(--sans)',
+              fontSize: '12px',
+              fontWeight: isActiveCat ? 500 : 400,
+              color: isActiveCat ? activeColor : defaultColor,
+              textDecoration: 'none',
+              letterSpacing: '-0.1px',
+              display: 'block',
+              flex: 1,
+            };
+
+            if (!isWorkflowsCat) {
+              return (
                 <NavLink
+                  key={cat.key}
                   to={categoryPath(basePath, pack.packId, pack.versionId, cat.key)}
                   end
                   data-testid={`sidebar-cat-${pack.packId}-${cat.key}`}
-                  style={{
-                    padding: '4px var(--s-3) 4px 48px',
-                    borderLeft: `3px solid ${isActiveCat ? 'var(--signal)' : 'transparent'}`,
-                    background: isActiveCat ? hoverBg : 'transparent',
-                    fontFamily: 'var(--sans)',
-                    fontSize: '12px',
-                    fontWeight: isActiveCat ? 500 : 400,
-                    color: isActiveCat ? activeColor : defaultColor,
-                    textDecoration: 'none',
-                    letterSpacing: '-0.1px',
-                    display: 'block',
-                  }}
+                  style={navLinkStyle}
                 >
                   {cat.label}
                 </NavLink>
-                {isWorkflowsCat && isActiveCat && (
-                  <div data-testid={`sidebar-workflows-list-${pack.packId}`} style={{ display: 'flex', flexDirection: 'column' }}>
-                    {pack.workflows.length === 0 ? (
+              );
+            }
+
+            return (
+              <div key={cat.key}>
+                <div style={{ display: 'flex', alignItems: 'stretch' }}>
+                  <NavLink
+                    to={categoryPath(basePath, pack.packId, pack.versionId, cat.key)}
+                    end
+                    data-testid={`sidebar-cat-${pack.packId}-${cat.key}`}
+                    style={navLinkStyle}
+                  >
+                    {cat.label}
+                  </NavLink>
+                  <button
+                    type="button"
+                    onClick={onToggleSettingsPanel}
+                    aria-label="워크플로우 표시 설정"
+                    aria-expanded={settingsPanelOpen}
+                    data-testid={`sidebar-workflows-settings-toggle-${pack.packId}`}
+                    style={{
+                      width: '28px',
+                      flexShrink: 0,
+                      background: settingsPanelOpen ? hoverBg : 'transparent',
+                      border: 'none',
+                      color: settingsPanelOpen ? activeColor : defaultColor,
+                      cursor: 'pointer',
+                      padding: 0,
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                    }}
+                  >
+                    <Icon name="settings" size={12} />
+                  </button>
+                </div>
+
+                {settingsPanelOpen && (
+                  <WorkflowSettingsPanel
+                    entries={settingsEntries}
+                    testId={`sidebar-workflows-settings-${pack.packId}`}
+                  />
+                )}
+
+                {isActiveCat && (
+                  <div
+                    data-testid={`sidebar-workflows-list-${pack.packId}`}
+                    style={{ display: 'flex', flexDirection: 'column' }}
+                  >
+                    {visibleWorkflows.length === 0 ? (
                       <span
                         data-testid={`sidebar-workflows-empty-${pack.packId}`}
                         style={{
@@ -603,7 +754,7 @@ function PackNode({
                         no workflows
                       </span>
                     ) : (
-                      pack.workflows.map((wf) => {
+                      visibleWorkflows.map((wf) => {
                         const isActiveWf = activeWorkflowId === wf.id;
                         return (
                           <NavLink
@@ -636,6 +787,23 @@ function PackNode({
                         );
                       })
                     )}
+                    {hiddenCount > 0 && (
+                      <NavLink
+                        to={categoryPath(basePath, pack.packId, pack.versionId, 'workflows')}
+                        end
+                        data-testid={`sidebar-workflows-overflow-${pack.packId}`}
+                        style={{
+                          padding: '4px var(--s-3) 4px 64px',
+                          fontFamily: 'var(--mono)',
+                          fontSize: '10px',
+                          color: defaultColor,
+                          textDecoration: 'none',
+                          letterSpacing: '0.4px',
+                        }}
+                      >
+                        +{hiddenCount} more
+                      </NavLink>
+                    )}
                   </div>
                 )}
               </div>
@@ -646,3 +814,4 @@ function PackNode({
     </div>
   );
 }
+

--- a/frontend/src/shared/ui/ostone/chrome/Sidebar.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/Sidebar.tsx
@@ -155,7 +155,7 @@ export function Sidebar({
   return (
     <nav
       style={{
-        width: collapsed ? '56px' : '220px',
+        width: collapsed ? '56px' : '240px',
         background: containerBg,
         borderRight: `1px solid ${borderColor}`,
         display: 'flex',
@@ -172,55 +172,51 @@ export function Sidebar({
       aria-label="주요 내비게이션"
       data-collapsed={collapsed ? 'true' : 'false'}
     >
-      {switcher !== undefined && (
-        <div
-          style={{
-            display: 'flex',
-            flexDirection: 'column',
-            gap: 'var(--s-2)',
-            marginBottom: 'var(--s-2)',
-            padding: collapsed ? '0' : '0 var(--s-3)',
-            alignItems: collapsed ? 'center' : 'stretch',
-          }}
-        >
-          <div style={{ width: '100%', display: 'flex', justifyContent: collapsed ? 'center' : 'stretch' }}>
-            {switcher}
-          </div>
-        </div>
-      )}
-
-      <button
-        type="button"
-        onClick={onToggleCollapsed}
-        aria-label={collapsed ? '사이드바 펼치기' : '사이드바 접기'}
-        title={collapsed ? '사이드바 펼치기' : '사이드바 접기'}
+      <div
         style={{
-          alignSelf: collapsed ? 'center' : 'flex-end',
-          marginRight: collapsed ? 0 : 'var(--s-3)',
-          marginBottom: 'var(--s-2)',
-          width: '32px',
-          height: '32px',
-          borderRadius: 'var(--r-2)',
-          border: `1px solid var(--ink)`,
-          background: 'var(--paper)',
-          color: 'var(--ink)',
-          display: 'inline-flex',
+          display: 'flex',
+          flexDirection: collapsed ? 'column' : 'row',
           alignItems: 'center',
-          justifyContent: 'center',
-          cursor: 'pointer',
-          boxShadow: '0 1px 2px rgba(0,0,0,0.05)',
+          gap: 'var(--s-2)',
+          marginBottom: 'var(--s-2)',
+          padding: collapsed ? '0' : '0 var(--s-3)',
         }}
       >
-        <span
+        {switcher !== undefined && (
+          <div style={{ flex: collapsed ? '0 0 auto' : '1 1 0', minWidth: 0, display: 'flex', justifyContent: collapsed ? 'center' : 'flex-start' }}>
+            {switcher}
+          </div>
+        )}
+        <button
+          type="button"
+          onClick={onToggleCollapsed}
+          aria-label={collapsed ? '사이드바 펼치기' : '사이드바 접기'}
+          title={collapsed ? '사이드바 펼치기' : '사이드바 접기'}
           style={{
+            flexShrink: 0,
+            width: '28px',
+            height: '28px',
+            borderRadius: 'var(--r-2)',
+            border: `1px solid ${borderColor}`,
+            background: 'transparent',
+            color: defaultColor,
             display: 'inline-flex',
-            transform: collapsed ? 'none' : 'rotate(180deg)',
-            transition: 'transform 240ms cubic-bezier(0.4, 0, 0.2, 1)',
+            alignItems: 'center',
+            justifyContent: 'center',
+            cursor: 'pointer',
           }}
         >
-          <Icon name="chevron" size={14} />
-        </span>
-      </button>
+          <span
+            style={{
+              display: 'inline-flex',
+              transform: collapsed ? 'none' : 'rotate(180deg)',
+              transition: 'transform 240ms cubic-bezier(0.4, 0, 0.2, 1)',
+            }}
+          >
+            <Icon name="chevron" size={12} />
+          </span>
+        </button>
+      </div>
 
       <div
         style={{
@@ -653,7 +649,7 @@ function PackNode({
           width: '100%',
           background: 'transparent',
           border: 'none',
-          padding: '6px var(--s-3) 6px 24px',
+          padding: '6px var(--s-3) 6px 32px',
           display: 'flex',
           alignItems: 'center',
           gap: 'var(--s-2)',
@@ -686,7 +682,7 @@ function PackNode({
             const isActiveCat = isCurrentPack && active === cat.activeKey;
             const isWorkflowsCat = cat.key === 'workflows';
             const navLinkStyle: CSSProperties = {
-              padding: '4px var(--s-3) 4px 36px',
+              padding: '4px var(--s-3) 4px 48px',
               borderLeft: `3px solid ${isActiveCat ? 'var(--signal)' : 'transparent'}`,
               background: isActiveCat ? hoverBg : 'transparent',
               fontFamily: 'var(--sans)',
@@ -767,7 +763,7 @@ function PackNode({
                       <span
                         data-testid={`sidebar-workflows-empty-${pack.packId}`}
                         style={{
-                          padding: '4px var(--s-3) 4px 44px',
+                          padding: '4px var(--s-3) 4px 64px',
                           fontFamily: 'var(--mono)',
                           fontSize: '10px',
                           color: defaultColor,
@@ -789,7 +785,7 @@ function PackNode({
                             end
                             data-testid={`sidebar-workflow-${wf.id}`}
                             style={{
-                              padding: '4px var(--s-3) 4px 44px',
+                              padding: '4px var(--s-3) 4px 64px',
                               borderLeft: `3px solid ${isActiveWf ? 'var(--signal)' : 'transparent'}`,
                               background: isActiveWf ? hoverBg : 'transparent',
                               fontFamily: 'var(--sans)',
@@ -815,7 +811,7 @@ function PackNode({
                         end
                         data-testid={`sidebar-workflows-overflow-${pack.packId}`}
                         style={{
-                          padding: '4px var(--s-3) 4px 44px',
+                          padding: '4px var(--s-3) 4px 64px',
                           fontFamily: 'var(--mono)',
                           fontSize: '10px',
                           color: defaultColor,

--- a/frontend/src/shared/ui/ostone/chrome/Sidebar.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/Sidebar.tsx
@@ -1,34 +1,107 @@
-import type { ReactNode } from 'react';
+import { useState, type ReactNode, type CSSProperties } from 'react';
 import { NavLink } from 'react-router-dom';
 import { Icon } from '../atoms/Icon';
 import type { IconName } from '../atoms/Icon';
 import { Avatar } from '../atoms/Avatar';
 
 export type SidebarActive =
+  | 'operator'
   | 'workflows'
-  | 'domain'
   | 'pipeline'
   | 'consult'
-  | 'chat-demo'
-  | 'upload';
+  | 'upload'
+  | 'domain'
+  | 'intent'
+  | 'slot'
+  | 'policy'
+  | 'risk';
+
+export interface SidebarTreeWorkflow {
+  id: number;
+  name: string;
+}
+
+export interface SidebarTreePack {
+  packId: number;
+  name: string;
+  versionId: number | null;
+  workflows: SidebarTreeWorkflow[];
+}
+
+export interface SidebarTreeData {
+  packs: SidebarTreePack[];
+  loading: boolean;
+  error: string | null;
+}
 
 interface SidebarProps {
   active: SidebarActive;
   dark?: boolean;
   basePath?: string;
   switcher?: ReactNode;
+  collapsed: boolean;
+  onToggleCollapsed: () => void;
+  tree?: SidebarTreeData;
+  activePackId?: number | null;
+  activeWorkflowId?: number | null;
 }
 
-const NAV_ITEMS: { key: SidebarActive; icon: IconName; label: string; getPath: (base: string) => string }[] = [
+interface TopNavItem {
+  key: SidebarActive;
+  icon: IconName;
+  label: string;
+  getPath: (base: string) => string;
+}
+
+const TOP_NAV_ITEMS: TopNavItem[] = [
+  { key: 'operator', icon: 'msg', label: 'Operator', getPath: (base) => `${base}/chat-demo` },
   { key: 'workflows', icon: 'grid', label: 'Workflows', getPath: (base) => `${base}/workflows` },
-  { key: 'domain', icon: 'folder', label: 'Domain Packs', getPath: (base) => `${base}/domain-packs` },
   { key: 'pipeline', icon: 'flow', label: 'Pipeline', getPath: (base) => `${base}/pipeline` },
-  { key: 'consult', icon: 'msg', label: 'Consultation', getPath: (base) => `${base}/consultation` },
-  { key: 'chat-demo', icon: 'msg', label: 'Chat Demo', getPath: (base) => `${base}/chat-demo` },
+  { key: 'consult', icon: 'book', label: 'Consultation', getPath: (base) => `${base}/consultation` },
   { key: 'upload', icon: 'upload', label: 'Uploads', getPath: (base) => `${base}/upload` },
 ];
 
-export function Sidebar({ active, dark = false, basePath = '/workspaces', switcher }: SidebarProps) {
+const DOMAIN_NAV_ITEM: TopNavItem = {
+  key: 'domain',
+  icon: 'folder',
+  label: 'Domain Packs',
+  getPath: (base) => `${base}/domain-packs`,
+};
+
+interface PackCategoryItem {
+  key: 'intents' | 'slots' | 'policies' | 'risks' | 'workflows';
+  label: string;
+  activeKey: SidebarActive;
+}
+
+const PACK_CATEGORIES: PackCategoryItem[] = [
+  { key: 'intents', label: 'Intents', activeKey: 'intent' },
+  { key: 'slots', label: 'Slots', activeKey: 'slot' },
+  { key: 'policies', label: 'Policies', activeKey: 'policy' },
+  { key: 'risks', label: 'Risks', activeKey: 'risk' },
+  { key: 'workflows', label: 'Workflows', activeKey: 'workflows' },
+];
+
+function categoryPath(base: string, packId: number, versionId: number | null, key: PackCategoryItem['key']): string {
+  if (versionId === null) return `${base}/domain-packs/${packId}`;
+  return `${base}/domain-packs/${packId}/versions/${versionId}/${key}`;
+}
+
+function workflowPath(base: string, packId: number, versionId: number, workflowId: number): string {
+  return `${base}/domain-packs/${packId}/versions/${versionId}/workflows/${workflowId}`;
+}
+
+export function Sidebar({
+  active,
+  dark = false,
+  basePath = '/workspaces',
+  switcher,
+  collapsed,
+  onToggleCollapsed,
+  tree,
+  activePackId = null,
+  activeWorkflowId = null,
+}: SidebarProps) {
   const containerBg = dark ? 'var(--dark-bg)' : 'var(--paper-2)';
   const borderColor = dark ? 'var(--dark-line)' : 'var(--line)';
   const defaultColor = dark ? 'var(--dark-ink-3)' : 'var(--ink-3)';
@@ -38,22 +111,58 @@ export function Sidebar({ active, dark = false, basePath = '/workspaces', switch
   return (
     <nav
       style={{
-        width: '56px',
+        width: collapsed ? '56px' : '240px',
         background: containerBg,
         borderRight: `1px solid ${borderColor}`,
         display: 'flex',
         flexDirection: 'column',
-        alignItems: 'center',
-        padding: 'var(--s-3) 0',
+        alignItems: collapsed ? 'center' : 'stretch',
+        padding: collapsed ? 'var(--s-3) 0' : 'var(--s-3) 0',
         gap: 'var(--s-2)',
         height: '100%',
         flexShrink: 0,
+        overflowY: 'auto',
       }}
-      aria-label="주요 낸비게이션"
+      aria-label="주요 내비게이션"
+      data-collapsed={collapsed ? 'true' : 'false'}
     >
-      <div style={{ marginBottom: 'var(--s-4)' }}>
-        {switcher}
-      </div>
+      {switcher !== undefined && (
+        <div
+          style={{
+            marginBottom: 'var(--s-2)',
+            display: 'flex',
+            justifyContent: collapsed ? 'center' : 'flex-start',
+            paddingLeft: collapsed ? 0 : 'var(--s-3)',
+            paddingRight: collapsed ? 0 : 'var(--s-3)',
+          }}
+        >
+          {switcher}
+        </div>
+      )}
+
+      <button
+        type="button"
+        onClick={onToggleCollapsed}
+        aria-label={collapsed ? '사이드바 펼치기' : '사이드바 접기'}
+        title={collapsed ? '사이드바 펼치기' : '사이드바 접기'}
+        style={{
+          alignSelf: collapsed ? 'center' : 'flex-end',
+          marginRight: collapsed ? 0 : 'var(--s-3)',
+          marginBottom: 'var(--s-2)',
+          width: '28px',
+          height: '28px',
+          borderRadius: 'var(--r-2)',
+          border: `1px solid ${borderColor}`,
+          background: 'transparent',
+          color: defaultColor,
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          cursor: 'pointer',
+        }}
+      >
+        <Icon name={collapsed ? 'chevron' : 'close'} size={12} />
+      </button>
 
       <div
         style={{
@@ -61,52 +170,402 @@ export function Sidebar({ active, dark = false, basePath = '/workspaces', switch
           flexDirection: 'column',
           gap: 'var(--s-1)',
           flex: 1,
+          width: '100%',
         }}
       >
-        {NAV_ITEMS.map((item) => {
-          const isActive = active === item.key;
+        {TOP_NAV_ITEMS.map((item) => (
+          <SidebarLink
+            key={item.key}
+            to={item.getPath(basePath)}
+            icon={item.icon}
+            label={item.label}
+            collapsed={collapsed}
+            isActive={active === item.key}
+            activeColor={activeColor}
+            defaultColor={defaultColor}
+            hoverBg={hoverBg}
+          />
+        ))}
 
-          return (
-            <NavLink
-              key={item.key}
-              to={item.getPath(basePath)}
-              end
-              title={item.label}
-              data-active={isActive ? 'true' : 'false'}
-              style={{
-                width: '36px',
-                height: '36px',
-                borderRadius: 'var(--r-2)',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                color: isActive ? activeColor : defaultColor,
-                background: isActive ? hoverBg : 'transparent',
-                textDecoration: 'none',
-                transition: 'background 120ms ease, color 120ms ease',
-              }}
-              onMouseEnter={(e) => {
-                if (!isActive) {
-                  e.currentTarget.style.background = hoverBg;
-                  e.currentTarget.style.color = activeColor;
-                }
-              }}
-              onMouseLeave={(e) => {
-                if (!isActive) {
-                  e.currentTarget.style.background = 'transparent';
-                  e.currentTarget.style.color = defaultColor;
-                }
-              }}
-            >
-              <Icon name={item.icon} size={16} />
-            </NavLink>
-          );
-        })}
+        {!collapsed && (
+          <div
+            style={{
+              marginTop: 'var(--s-3)',
+              paddingLeft: 'var(--s-3)',
+              paddingRight: 'var(--s-3)',
+              fontFamily: 'var(--mono)',
+              fontSize: '10px',
+              letterSpacing: '0.6px',
+              textTransform: 'uppercase',
+              color: defaultColor,
+              marginBottom: 'var(--s-1)',
+            }}
+            data-testid="sidebar-section-label"
+          >
+            Domain Packs
+          </div>
+        )}
+
+        <SidebarLink
+          to={DOMAIN_NAV_ITEM.getPath(basePath)}
+          icon={DOMAIN_NAV_ITEM.icon}
+          label={DOMAIN_NAV_ITEM.label}
+          collapsed={collapsed}
+          isActive={active === 'domain'}
+          activeColor={activeColor}
+          defaultColor={defaultColor}
+          hoverBg={hoverBg}
+        />
+
+        {!collapsed && tree && (
+          <SidebarPackTree
+            tree={tree}
+            basePath={basePath}
+            active={active}
+            activePackId={activePackId}
+            activeWorkflowId={activeWorkflowId}
+            activeColor={activeColor}
+            defaultColor={defaultColor}
+            hoverBg={hoverBg}
+          />
+        )}
       </div>
 
-      <div style={{ marginTop: 'auto' }}>
+      <div
+        style={{
+          marginTop: 'auto',
+          display: 'flex',
+          justifyContent: collapsed ? 'center' : 'flex-start',
+          paddingLeft: collapsed ? 0 : 'var(--s-3)',
+          paddingRight: collapsed ? 0 : 'var(--s-3)',
+          paddingTop: 'var(--s-3)',
+        }}
+      >
         <Avatar tone="signal" initial="BS" size={28} />
       </div>
     </nav>
+  );
+}
+
+interface SidebarLinkProps {
+  to: string;
+  icon: IconName;
+  label: string;
+  collapsed: boolean;
+  isActive: boolean;
+  activeColor: string;
+  defaultColor: string;
+  hoverBg: string;
+}
+
+function SidebarLink({ to, icon, label, collapsed, isActive, activeColor, defaultColor, hoverBg }: SidebarLinkProps) {
+  const collapsedStyle: CSSProperties = {
+    width: '36px',
+    height: '36px',
+    borderRadius: 'var(--r-2)',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    color: isActive ? activeColor : defaultColor,
+    background: isActive ? hoverBg : 'transparent',
+    textDecoration: 'none',
+    transition: 'background 120ms ease, color 120ms ease',
+    margin: '0 auto',
+  };
+
+  const expandedStyle: CSSProperties = {
+    height: '32px',
+    padding: '0 var(--s-3)',
+    display: 'flex',
+    alignItems: 'center',
+    gap: 'var(--s-2)',
+    color: isActive ? activeColor : defaultColor,
+    background: isActive ? hoverBg : 'transparent',
+    borderLeft: `3px solid ${isActive ? 'var(--signal)' : 'transparent'}`,
+    textDecoration: 'none',
+    transition: 'background 120ms ease, color 120ms ease',
+    fontFamily: 'var(--sans)',
+    fontSize: '13px',
+    fontWeight: isActive ? 500 : 400,
+    letterSpacing: '-0.1px',
+  };
+
+  return (
+    <NavLink
+      to={to}
+      end
+      title={label}
+      data-active={isActive ? 'true' : 'false'}
+      style={collapsed ? collapsedStyle : expandedStyle}
+      onMouseEnter={(e) => {
+        if (!isActive) {
+          e.currentTarget.style.background = hoverBg;
+          e.currentTarget.style.color = activeColor;
+        }
+      }}
+      onMouseLeave={(e) => {
+        if (!isActive) {
+          e.currentTarget.style.background = 'transparent';
+          e.currentTarget.style.color = defaultColor;
+        }
+      }}
+    >
+      <Icon name={icon} size={collapsed ? 16 : 14} />
+      {!collapsed && <span>{label}</span>}
+    </NavLink>
+  );
+}
+
+interface SidebarPackTreeProps {
+  tree: SidebarTreeData;
+  basePath: string;
+  active: SidebarActive;
+  activePackId: number | null;
+  activeWorkflowId: number | null;
+  activeColor: string;
+  defaultColor: string;
+  hoverBg: string;
+}
+
+function SidebarPackTree({
+  tree,
+  basePath,
+  active,
+  activePackId,
+  activeWorkflowId,
+  activeColor,
+  defaultColor,
+  hoverBg,
+}: SidebarPackTreeProps) {
+  if (tree.loading) {
+    return (
+      <div
+        data-testid="sidebar-tree-loading"
+        style={{
+          padding: 'var(--s-2) var(--s-3)',
+          fontFamily: 'var(--mono)',
+          fontSize: '10px',
+          color: defaultColor,
+        }}
+      >
+        loading…
+      </div>
+    );
+  }
+
+  if (tree.error) {
+    return (
+      <div
+        role="alert"
+        data-testid="sidebar-tree-error"
+        style={{
+          padding: 'var(--s-2) var(--s-3)',
+          fontFamily: 'var(--mono)',
+          fontSize: '10px',
+          color: 'var(--danger)',
+        }}
+      >
+        도메인팩 로드 실패
+      </div>
+    );
+  }
+
+  if (tree.packs.length === 0) {
+    return (
+      <div
+        data-testid="sidebar-tree-empty"
+        style={{
+          padding: 'var(--s-2) var(--s-3)',
+          fontFamily: 'var(--mono)',
+          fontSize: '10px',
+          color: defaultColor,
+        }}
+      >
+        도메인팩이 없습니다
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="sidebar-tree" style={{ display: 'flex', flexDirection: 'column' }}>
+      {tree.packs.map((pack) => (
+        <PackNode
+          key={pack.packId}
+          pack={pack}
+          basePath={basePath}
+          active={active}
+          activePackId={activePackId}
+          activeWorkflowId={activeWorkflowId}
+          activeColor={activeColor}
+          defaultColor={defaultColor}
+          hoverBg={hoverBg}
+        />
+      ))}
+    </div>
+  );
+}
+
+interface PackNodeProps {
+  pack: SidebarTreePack;
+  basePath: string;
+  active: SidebarActive;
+  activePackId: number | null;
+  activeWorkflowId: number | null;
+  activeColor: string;
+  defaultColor: string;
+  hoverBg: string;
+}
+
+function PackNode({
+  pack,
+  basePath,
+  active,
+  activePackId,
+  activeWorkflowId,
+  activeColor,
+  defaultColor,
+  hoverBg,
+}: PackNodeProps) {
+  const isCurrentPack = activePackId === pack.packId;
+  const [open, setOpen] = useState(isCurrentPack);
+  const [workflowsOpen, setWorkflowsOpen] = useState(isCurrentPack && active === 'workflows');
+
+  return (
+    <div data-testid={`sidebar-pack-${pack.packId}`}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        style={{
+          width: '100%',
+          background: 'transparent',
+          border: 'none',
+          padding: '6px var(--s-3)',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 'var(--s-2)',
+          cursor: 'pointer',
+          fontFamily: 'var(--sans)',
+          fontSize: '12px',
+          fontWeight: isCurrentPack ? 500 : 400,
+          color: isCurrentPack ? activeColor : defaultColor,
+          letterSpacing: '-0.1px',
+          textAlign: 'left',
+        }}
+      >
+        <span style={{ display: 'inline-flex', transform: open ? 'rotate(90deg)' : 'none', transition: 'transform 120ms ease' }}>
+          <Icon name="chevron" size={10} />
+        </span>
+        <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{pack.name}</span>
+      </button>
+
+      {open && (
+        <div style={{ display: 'flex', flexDirection: 'column' }}>
+          {PACK_CATEGORIES.map((cat) => {
+            const isActiveCat = isCurrentPack && active === cat.activeKey;
+            if (cat.key === 'workflows') {
+              return (
+                <div key={cat.key}>
+                  <button
+                    type="button"
+                    onClick={() => setWorkflowsOpen((v) => !v)}
+                    aria-expanded={workflowsOpen}
+                    style={{
+                      width: '100%',
+                      background: isActiveCat ? hoverBg : 'transparent',
+                      border: 'none',
+                      borderLeft: `3px solid ${isActiveCat ? 'var(--signal)' : 'transparent'}`,
+                      padding: '4px var(--s-3) 4px 32px',
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 'var(--s-1)',
+                      cursor: 'pointer',
+                      fontFamily: 'var(--sans)',
+                      fontSize: '12px',
+                      color: isActiveCat ? activeColor : defaultColor,
+                      letterSpacing: '-0.1px',
+                      textAlign: 'left',
+                    }}
+                    data-testid={`sidebar-cat-${pack.packId}-workflows`}
+                  >
+                    <span style={{ display: 'inline-flex', transform: workflowsOpen ? 'rotate(90deg)' : 'none', transition: 'transform 120ms ease' }}>
+                      <Icon name="chevron" size={9} />
+                    </span>
+                    <span>{cat.label}</span>
+                  </button>
+                  {workflowsOpen && (
+                    <div style={{ display: 'flex', flexDirection: 'column' }}>
+                      <NavLink
+                        to={categoryPath(basePath, pack.packId, pack.versionId, 'workflows')}
+                        end
+                        style={({ isActive }) => ({
+                          padding: '4px var(--s-3) 4px 48px',
+                          fontFamily: 'var(--mono)',
+                          fontSize: '10px',
+                          color: isActive ? activeColor : defaultColor,
+                          textDecoration: 'none',
+                          letterSpacing: '0.4px',
+                          textTransform: 'uppercase',
+                        })}
+                      >
+                        all workflows
+                      </NavLink>
+                      {pack.workflows.map((wf) => {
+                        const isActiveWf = isCurrentPack && activeWorkflowId === wf.id;
+                        return (
+                          <NavLink
+                            key={wf.id}
+                            to={pack.versionId !== null ? workflowPath(basePath, pack.packId, pack.versionId, wf.id) : '#'}
+                            end
+                            data-testid={`sidebar-workflow-${wf.id}`}
+                            style={{
+                              padding: '4px var(--s-3) 4px 48px',
+                              borderLeft: `3px solid ${isActiveWf ? 'var(--signal)' : 'transparent'}`,
+                              background: isActiveWf ? hoverBg : 'transparent',
+                              fontFamily: 'var(--sans)',
+                              fontSize: '12px',
+                              fontWeight: isActiveWf ? 500 : 400,
+                              color: isActiveWf ? activeColor : defaultColor,
+                              textDecoration: 'none',
+                              letterSpacing: '-0.1px',
+                              overflow: 'hidden',
+                              textOverflow: 'ellipsis',
+                              whiteSpace: 'nowrap',
+                            }}
+                          >
+                            {wf.name}
+                          </NavLink>
+                        );
+                      })}
+                    </div>
+                  )}
+                </div>
+              );
+            }
+            return (
+              <NavLink
+                key={cat.key}
+                to={categoryPath(basePath, pack.packId, pack.versionId, cat.key)}
+                end
+                data-testid={`sidebar-cat-${pack.packId}-${cat.key}`}
+                style={{
+                  padding: '4px var(--s-3) 4px 32px',
+                  borderLeft: `3px solid ${isActiveCat ? 'var(--signal)' : 'transparent'}`,
+                  background: isActiveCat ? hoverBg : 'transparent',
+                  fontFamily: 'var(--sans)',
+                  fontSize: '12px',
+                  fontWeight: isActiveCat ? 500 : 400,
+                  color: isActiveCat ? activeColor : defaultColor,
+                  textDecoration: 'none',
+                  letterSpacing: '-0.1px',
+                }}
+              >
+                {cat.label}
+              </NavLink>
+            );
+          })}
+        </div>
+      )}
+    </div>
   );
 }

--- a/frontend/src/shared/ui/ostone/chrome/Sidebar.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/Sidebar.tsx
@@ -118,6 +118,16 @@ const PACK_HOVER_HANDLERS = {
   },
 };
 
+function deriveSidebarColors(dark: boolean) {
+  return {
+    containerBg: dark ? 'var(--dark-bg)' : 'var(--paper-2)',
+    borderColor: dark ? 'var(--dark-line)' : 'var(--line)',
+    defaultColor: dark ? 'var(--dark-ink-3)' : 'var(--ink-3)',
+    hoverBg: dark ? 'var(--dark-bg-2)' : 'var(--paper-3)',
+    activeColor: dark ? 'var(--dark-ink)' : 'var(--ink)',
+  };
+}
+
 export function Sidebar({
   active,
   dark = false,
@@ -129,11 +139,7 @@ export function Sidebar({
   activePackId = null,
   activeWorkflowId = null,
 }: SidebarProps) {
-  const containerBg = dark ? 'var(--dark-bg)' : 'var(--paper-2)';
-  const borderColor = dark ? 'var(--dark-line)' : 'var(--line)';
-  const defaultColor = dark ? 'var(--dark-ink-3)' : 'var(--ink-3)';
-  const hoverBg = dark ? 'var(--dark-bg-2)' : 'var(--paper-3)';
-  const activeColor = dark ? 'var(--dark-ink)' : 'var(--ink)';
+  const { containerBg, borderColor, defaultColor, hoverBg, activeColor } = deriveSidebarColors(dark);
 
   const [workflowSettings, setWorkflowSettings] = useState<SidebarWorkflowSettings>(() =>
     readSidebarWorkflowSettings(),
@@ -404,6 +410,11 @@ function DomainPacksNode({
   const isDomainActive =
     active === 'domain' || active === 'intent' || active === 'slot' || active === 'policy' || active === 'risk' || active === 'workflows';
   const [open, setOpen] = useState<boolean>(isDomainActive);
+  const [prevIsDomainActive, setPrevIsDomainActive] = useState(isDomainActive);
+  if (isDomainActive !== prevIsDomainActive) {
+    setPrevIsDomainActive(isDomainActive);
+    if (isDomainActive) setOpen(true);
+  }
 
   if (collapsed) {
     return (
@@ -623,6 +634,11 @@ function PackNode({
 }: PackNodeProps) {
   const isCurrentPack = activePackId === pack.packId;
   const [open, setOpen] = useState(isCurrentPack);
+  const [prevIsCurrentPack, setPrevIsCurrentPack] = useState(isCurrentPack);
+  if (isCurrentPack !== prevIsCurrentPack) {
+    setPrevIsCurrentPack(isCurrentPack);
+    if (isCurrentPack) setOpen(true);
+  }
 
   const sortedWorkflows = useMemo(() => {
     return [...pack.workflows].sort((a, b) =>

--- a/frontend/src/shared/ui/ostone/chrome/WorkflowSettingsPanel.test.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/WorkflowSettingsPanel.test.tsx
@@ -1,0 +1,65 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { WorkflowSettingsPanel, type WorkflowSettingEntry } from './WorkflowSettingsPanel';
+
+function makeEntry(overrides: Partial<WorkflowSettingEntry> = {}): WorkflowSettingEntry {
+  return {
+    key: 'sort',
+    label: 'Sort',
+    value: 'asc',
+    options: [
+      { value: 'asc', label: 'Asc' },
+      { value: 'desc', label: 'Desc' },
+    ],
+    onChange: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('WorkflowSettingsPanel', () => {
+  it('renders one chip per option and marks the active value', () => {
+    render(<WorkflowSettingsPanel entries={[makeEntry()]} testId="panel" />);
+    expect(screen.getByTestId('panel-sort-asc').dataset.active).toBe('true');
+    expect(screen.getByTestId('panel-sort-desc').dataset.active).toBe('false');
+  });
+
+  it('invokes onChange when a chip is clicked', () => {
+    const onChange = vi.fn();
+    render(<WorkflowSettingsPanel entries={[makeEntry({ onChange })]} testId="panel" />);
+
+    fireEvent.click(screen.getByTestId('panel-sort-desc'));
+    expect(onChange).toHaveBeenCalledWith('desc');
+  });
+
+  it('supports multiple entries', () => {
+    const onTop = vi.fn();
+    render(
+      <WorkflowSettingsPanel
+        entries={[
+          makeEntry(),
+          {
+            key: 'top',
+            label: 'Top N',
+            value: 5,
+            options: [
+              { value: 3, label: '3' },
+              { value: 5, label: '5' },
+              { value: 10, label: '10' },
+            ],
+            onChange: onTop,
+          },
+        ]}
+        testId="panel"
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('panel-top-10'));
+    expect(onTop).toHaveBeenCalledWith(10);
+  });
+
+  it('uses default testId when none supplied', () => {
+    render(<WorkflowSettingsPanel entries={[makeEntry()]} />);
+    expect(screen.getByTestId('workflow-settings-panel')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/shared/ui/ostone/chrome/WorkflowSettingsPanel.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/WorkflowSettingsPanel.tsx
@@ -1,4 +1,4 @@
-import { type CSSProperties } from 'react';
+import { useEffect, useRef, type CSSProperties, type RefObject } from 'react';
 
 export type WorkflowSettingValue = string | number;
 
@@ -18,15 +18,24 @@ export interface WorkflowSettingEntry {
 interface WorkflowSettingsPanelProps {
   entries: ReadonlyArray<WorkflowSettingEntry>;
   testId?: string;
+  /** When provided the panel positions itself absolutely and listens for outside clicks. */
+  style?: CSSProperties;
+  onClickOutside?: () => void;
+  anchorRef?: RefObject<HTMLElement | null>;
 }
 
-const containerStyle: CSSProperties = {
+const popoverStyle: CSSProperties = {
+  position: 'absolute',
   display: 'flex',
   flexDirection: 'column',
   gap: 'var(--s-2)',
-  padding: 'var(--s-2) var(--s-3) var(--s-2) 48px',
-  background: 'var(--paper-3)',
-  borderLeft: '3px solid transparent',
+  padding: 'var(--s-3)',
+  background: 'var(--paper)',
+  border: '1px solid var(--line)',
+  borderRadius: 'var(--r-2)',
+  boxShadow: '0 8px 24px rgba(0,0,0,0.12)',
+  zIndex: 40,
+  minWidth: '220px',
 };
 
 const rowStyle: CSSProperties = {
@@ -36,11 +45,12 @@ const rowStyle: CSSProperties = {
   fontFamily: 'var(--sans)',
   fontSize: '11px',
   color: 'var(--ink-3)',
+  whiteSpace: 'nowrap',
 };
 
 const labelStyle: CSSProperties = {
   flex: '0 0 auto',
-  minWidth: '48px',
+  minWidth: '64px',
   letterSpacing: '-0.1px',
 };
 
@@ -58,15 +68,49 @@ function chipStyle(active: boolean): CSSProperties {
     background: active ? 'var(--ink)' : 'var(--paper)',
     color: active ? 'var(--paper)' : 'var(--ink-3)',
     fontSize: '11px',
-    fontFamily: 'var(--mono)',
+    fontFamily: 'var(--sans)',
     cursor: 'pointer',
     lineHeight: 1.2,
   };
 }
 
-export function WorkflowSettingsPanel({ entries, testId }: WorkflowSettingsPanelProps) {
+export function WorkflowSettingsPanel({
+  entries,
+  testId,
+  style,
+  onClickOutside,
+  anchorRef,
+}: WorkflowSettingsPanelProps) {
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!onClickOutside) return;
+    const handlePointer = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (panelRef.current?.contains(target)) return;
+      if (anchorRef?.current?.contains(target)) return;
+      onClickOutside();
+    };
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClickOutside();
+    };
+    document.addEventListener('mousedown', handlePointer);
+    document.addEventListener('keydown', handleKey);
+    return () => {
+      document.removeEventListener('mousedown', handlePointer);
+      document.removeEventListener('keydown', handleKey);
+    };
+  }, [onClickOutside, anchorRef]);
+
+  const finalStyle: CSSProperties = { ...popoverStyle, ...style };
+
   return (
-    <div data-testid={testId ?? 'workflow-settings-panel'} style={containerStyle}>
+    <div
+      ref={panelRef}
+      data-testid={testId ?? 'workflow-settings-panel'}
+      role="dialog"
+      style={finalStyle}
+    >
       {entries.map((entry) => (
         <div key={entry.key} style={rowStyle} data-testid={`${testId ?? 'workflow-settings-panel'}-${entry.key}`}>
           <span style={labelStyle}>{entry.label}</span>

--- a/frontend/src/shared/ui/ostone/chrome/WorkflowSettingsPanel.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/WorkflowSettingsPanel.tsx
@@ -35,7 +35,7 @@ const popoverStyle: CSSProperties = {
   borderRadius: 'var(--r-2)',
   boxShadow: '0 8px 24px rgba(0,0,0,0.12)',
   zIndex: 40,
-  minWidth: '220px',
+  minWidth: '260px',
 };
 
 const rowStyle: CSSProperties = {
@@ -43,14 +43,15 @@ const rowStyle: CSSProperties = {
   alignItems: 'center',
   gap: 'var(--s-2)',
   fontFamily: 'var(--sans)',
-  fontSize: '11px',
-  color: 'var(--ink-3)',
+  fontSize: '13px',
+  fontWeight: 500,
+  color: 'var(--ink)',
   whiteSpace: 'nowrap',
 };
 
 const labelStyle: CSSProperties = {
   flex: '0 0 auto',
-  minWidth: '64px',
+  minWidth: '76px',
   letterSpacing: '-0.1px',
 };
 
@@ -62,12 +63,13 @@ const chipsStyle: CSSProperties = {
 
 function chipStyle(active: boolean): CSSProperties {
   return {
-    padding: '2px 8px',
+    padding: '4px 10px',
     borderRadius: '999px',
     border: `1px solid ${active ? 'var(--ink)' : 'var(--line)'}`,
     background: active ? 'var(--ink)' : 'var(--paper)',
-    color: active ? 'var(--paper)' : 'var(--ink-3)',
-    fontSize: '11px',
+    color: active ? 'var(--paper)' : 'var(--ink)',
+    fontSize: '12px',
+    fontWeight: 500,
     fontFamily: 'var(--sans)',
     cursor: 'pointer',
     lineHeight: 1.2,

--- a/frontend/src/shared/ui/ostone/chrome/WorkflowSettingsPanel.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/WorkflowSettingsPanel.tsx
@@ -83,7 +83,7 @@ export function WorkflowSettingsPanel({
   onClickOutside,
   anchorRef,
 }: WorkflowSettingsPanelProps) {
-  const panelRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDialogElement>(null);
 
   useEffect(() => {
     if (!onClickOutside) return;
@@ -107,11 +107,11 @@ export function WorkflowSettingsPanel({
   const finalStyle: CSSProperties = { ...popoverStyle, ...style };
 
   return (
-    <div
+    <dialog
       ref={panelRef}
+      open
       data-testid={testId ?? 'workflow-settings-panel'}
-      role="dialog"
-      style={finalStyle}
+      style={{ ...finalStyle, margin: 0 }}
     >
       {entries.map((entry) => (
         <div key={entry.key} style={rowStyle} data-testid={`${testId ?? 'workflow-settings-panel'}-${entry.key}`}>
@@ -135,6 +135,6 @@ export function WorkflowSettingsPanel({
           </div>
         </div>
       ))}
-    </div>
+    </dialog>
   );
 }

--- a/frontend/src/shared/ui/ostone/chrome/WorkflowSettingsPanel.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/WorkflowSettingsPanel.tsx
@@ -1,0 +1,94 @@
+import { type CSSProperties } from 'react';
+
+export type WorkflowSettingValue = string | number;
+
+export interface WorkflowSettingOption {
+  value: WorkflowSettingValue;
+  label: string;
+}
+
+export interface WorkflowSettingEntry {
+  key: string;
+  label: string;
+  value: WorkflowSettingValue;
+  options: ReadonlyArray<WorkflowSettingOption>;
+  onChange: (next: WorkflowSettingValue) => void;
+}
+
+interface WorkflowSettingsPanelProps {
+  entries: ReadonlyArray<WorkflowSettingEntry>;
+  testId?: string;
+}
+
+const containerStyle: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 'var(--s-2)',
+  padding: 'var(--s-2) var(--s-3) var(--s-2) 48px',
+  background: 'var(--paper-3)',
+  borderLeft: '3px solid transparent',
+};
+
+const rowStyle: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 'var(--s-2)',
+  fontFamily: 'var(--sans)',
+  fontSize: '11px',
+  color: 'var(--ink-3)',
+};
+
+const labelStyle: CSSProperties = {
+  flex: '0 0 auto',
+  minWidth: '48px',
+  letterSpacing: '-0.1px',
+};
+
+const chipsStyle: CSSProperties = {
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: '4px',
+};
+
+function chipStyle(active: boolean): CSSProperties {
+  return {
+    padding: '2px 8px',
+    borderRadius: '999px',
+    border: `1px solid ${active ? 'var(--ink)' : 'var(--line)'}`,
+    background: active ? 'var(--ink)' : 'var(--paper)',
+    color: active ? 'var(--paper)' : 'var(--ink-3)',
+    fontSize: '11px',
+    fontFamily: 'var(--mono)',
+    cursor: 'pointer',
+    lineHeight: 1.2,
+  };
+}
+
+export function WorkflowSettingsPanel({ entries, testId }: WorkflowSettingsPanelProps) {
+  return (
+    <div data-testid={testId ?? 'workflow-settings-panel'} style={containerStyle}>
+      {entries.map((entry) => (
+        <div key={entry.key} style={rowStyle} data-testid={`${testId ?? 'workflow-settings-panel'}-${entry.key}`}>
+          <span style={labelStyle}>{entry.label}</span>
+          <div style={chipsStyle}>
+            {entry.options.map((opt) => {
+              const active = opt.value === entry.value;
+              return (
+                <button
+                  key={String(opt.value)}
+                  type="button"
+                  onClick={() => entry.onChange(opt.value)}
+                  style={chipStyle(active)}
+                  data-active={active ? 'true' : 'false'}
+                  data-testid={`${testId ?? 'workflow-settings-panel'}-${entry.key}-${opt.value}`}
+                >
+                  {opt.label}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/shared/ui/ostone/chrome/WorkspaceMarker.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/WorkspaceMarker.tsx
@@ -131,7 +131,31 @@ export function WorkspaceMarker({ workspaceId, collapsed }: WorkspaceMarkerProps
             overflowY: 'auto',
           }}
         >
-          {workspaces.length === 0 && (
+          {query.isLoading && (
+            <div
+              style={{
+                padding: 'var(--s-2) var(--s-3)',
+                fontFamily: 'var(--mono)',
+                fontSize: '10px',
+                color: 'var(--ink-3)',
+              }}
+            >
+              로딩 중…
+            </div>
+          )}
+          {query.isError && (
+            <div
+              style={{
+                padding: 'var(--s-2) var(--s-3)',
+                fontFamily: 'var(--mono)',
+                fontSize: '10px',
+                color: 'var(--ink-3)',
+              }}
+            >
+              목록 조회 실패
+            </div>
+          )}
+          {!query.isLoading && !query.isError && workspaces.length === 0 && (
             <div
               style={{
                 padding: 'var(--s-2) var(--s-3)',

--- a/frontend/src/shared/ui/ostone/chrome/WorkspaceMarker.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/WorkspaceMarker.tsx
@@ -51,19 +51,20 @@ export function WorkspaceMarker({ workspaceId, collapsed }: WorkspaceMarkerProps
         onClick={() => setOpen((v) => !v)}
         data-testid="workspace-marker"
         style={{
-          width: '32px',
-          height: '32px',
+          width: '40px',
+          height: '40px',
           borderRadius: 'var(--r-2)',
           border: '1px solid var(--line)',
           background: 'var(--paper)',
           color: 'var(--ink)',
           fontFamily: 'var(--mono)',
-          fontSize: '13px',
+          fontSize: '14px',
           fontWeight: 600,
           cursor: 'pointer',
           display: 'inline-flex',
           alignItems: 'center',
           justifyContent: 'center',
+          transition: 'background 160ms ease, color 160ms ease',
         }}
       >
         {initial}
@@ -80,8 +81,8 @@ export function WorkspaceMarker({ workspaceId, collapsed }: WorkspaceMarkerProps
         data-testid="workspace-marker"
         style={{
           width: '100%',
-          height: '36px',
-          padding: '0 var(--s-2)',
+          height: '40px',
+          padding: '0 var(--s-3)',
           display: 'flex',
           alignItems: 'center',
           gap: 'var(--s-2)',
@@ -90,36 +91,25 @@ export function WorkspaceMarker({ workspaceId, collapsed }: WorkspaceMarkerProps
           borderRadius: 'var(--r-2)',
           color: 'var(--ink)',
           fontFamily: 'var(--sans)',
-          fontSize: '12px',
+          fontSize: '13px',
           fontWeight: 500,
           letterSpacing: '-0.1px',
           textAlign: 'left',
           cursor: 'pointer',
+          transition: 'background 160ms ease',
         }}
       >
-        <span
-          style={{
-            width: '22px',
-            height: '22px',
-            borderRadius: 'var(--r-1)',
-            background: 'var(--paper-3)',
-            display: 'inline-flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            fontFamily: 'var(--mono)',
-            fontWeight: 600,
-            fontSize: '11px',
-            color: 'var(--ink)',
-            flexShrink: 0,
-          }}
-        >
-          {initial}
-        </span>
         <span style={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
           {name ?? '워크스페이스 선택'}
         </span>
-        <span style={{ display: 'inline-flex', transform: open ? 'rotate(180deg)' : 'none', transition: 'transform 120ms ease' }}>
-          <Icon name="chevron" size={10} />
+        <span
+          style={{
+            display: 'inline-flex',
+            transform: open ? 'rotate(270deg)' : 'rotate(90deg)',
+            transition: 'transform 160ms ease',
+          }}
+        >
+          <Icon name="chevron" size={12} />
         </span>
       </button>
 

--- a/frontend/src/shared/ui/ostone/chrome/WorkspaceMarker.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/WorkspaceMarker.tsx
@@ -1,0 +1,190 @@
+import { useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Icon } from '../atoms/Icon';
+import { unwrapApiResponse } from '@/shared/api/unwrapApiResponse';
+import { useListWorkspaces } from '@/shared/api/generated/endpoints/workspace-controller/workspace-controller';
+import type { WorkspaceResponse } from '@/shared/api/generated/zod';
+
+interface WorkspaceMarkerProps {
+  workspaceId: number | null;
+  collapsed: boolean;
+}
+
+function deriveInitial(name: string | null | undefined): string {
+  if (!name) return '?';
+  const trimmed = name.trim();
+  if (!trimmed) return '?';
+  return trimmed.slice(0, 1).toUpperCase();
+}
+
+export function WorkspaceMarker({ workspaceId, collapsed }: WorkspaceMarkerProps) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const navigate = useNavigate();
+
+  const query = useListWorkspaces({ query: { enabled: workspaceId !== null } });
+  const workspaces = (unwrapApiResponse(query.data) as WorkspaceResponse[] | undefined) ?? [];
+  const current = workspaces.find((w) => w.id === workspaceId);
+  const name = current?.name ?? null;
+  const initial = deriveInitial(name);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (!containerRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [open]);
+
+  const handleSwitch = (id: number) => {
+    setOpen(false);
+    navigate(`/workspaces/${id}/workflows`);
+  };
+
+  if (collapsed) {
+    return (
+      <button
+        type="button"
+        aria-label={name ? `현재 워크스페이스: ${name}` : '워크스페이스'}
+        title={name ?? '워크스페이스'}
+        onClick={() => setOpen((v) => !v)}
+        data-testid="workspace-marker"
+        style={{
+          width: '32px',
+          height: '32px',
+          borderRadius: 'var(--r-2)',
+          border: '1px solid var(--line)',
+          background: 'var(--paper)',
+          color: 'var(--ink)',
+          fontFamily: 'var(--mono)',
+          fontSize: '13px',
+          fontWeight: 600,
+          cursor: 'pointer',
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        {initial}
+      </button>
+    );
+  }
+
+  return (
+    <div ref={containerRef} style={{ position: 'relative', width: '100%' }}>
+      <button
+        type="button"
+        aria-label="워크스페이스 선택"
+        onClick={() => setOpen((v) => !v)}
+        data-testid="workspace-marker"
+        style={{
+          width: '100%',
+          height: '36px',
+          padding: '0 var(--s-2)',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 'var(--s-2)',
+          background: open ? 'var(--paper-3)' : 'var(--paper)',
+          border: '1px solid var(--line)',
+          borderRadius: 'var(--r-2)',
+          color: 'var(--ink)',
+          fontFamily: 'var(--sans)',
+          fontSize: '12px',
+          fontWeight: 500,
+          letterSpacing: '-0.1px',
+          textAlign: 'left',
+          cursor: 'pointer',
+        }}
+      >
+        <span
+          style={{
+            width: '22px',
+            height: '22px',
+            borderRadius: 'var(--r-1)',
+            background: 'var(--paper-3)',
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            fontFamily: 'var(--mono)',
+            fontWeight: 600,
+            fontSize: '11px',
+            color: 'var(--ink)',
+            flexShrink: 0,
+          }}
+        >
+          {initial}
+        </span>
+        <span style={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+          {name ?? '워크스페이스 선택'}
+        </span>
+        <span style={{ display: 'inline-flex', transform: open ? 'rotate(180deg)' : 'none', transition: 'transform 120ms ease' }}>
+          <Icon name="chevron" size={10} />
+        </span>
+      </button>
+
+      {open && (
+        <div
+          data-testid="workspace-marker-menu"
+          style={{
+            position: 'absolute',
+            top: 'calc(100% + 4px)',
+            left: 0,
+            right: 0,
+            background: 'var(--paper)',
+            border: '1px solid var(--line)',
+            borderRadius: 'var(--r-2)',
+            boxShadow: '0 8px 24px rgba(0,0,0,0.08)',
+            zIndex: 30,
+            padding: 'var(--s-1) 0',
+            maxHeight: '260px',
+            overflowY: 'auto',
+          }}
+        >
+          {workspaces.length === 0 && (
+            <div
+              style={{
+                padding: 'var(--s-2) var(--s-3)',
+                fontFamily: 'var(--mono)',
+                fontSize: '10px',
+                color: 'var(--ink-3)',
+              }}
+            >
+              워크스페이스 없음
+            </div>
+          )}
+          {workspaces.map((ws) => {
+            const isCurrent = ws.id === workspaceId;
+            return (
+              <button
+                key={ws.id}
+                type="button"
+                onClick={() => ws.id != null && handleSwitch(ws.id)}
+                data-testid={`workspace-option-${ws.id}`}
+                style={{
+                  width: '100%',
+                  padding: '8px var(--s-3)',
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 'var(--s-2)',
+                  background: isCurrent ? 'var(--paper-3)' : 'transparent',
+                  border: 'none',
+                  textAlign: 'left',
+                  cursor: 'pointer',
+                  fontFamily: 'var(--sans)',
+                  fontSize: '12px',
+                  color: 'var(--ink)',
+                }}
+              >
+                <span style={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                  {ws.name ?? `Workspace ${ws.id}`}
+                </span>
+                {isCurrent && <Icon name="check" size={12} />}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/shared/ui/ostone/chrome/index.ts
+++ b/frontend/src/shared/ui/ostone/chrome/index.ts
@@ -1,4 +1,9 @@
 export { Sidebar } from './Sidebar';
-export type { SidebarActive } from './Sidebar';
+export type {
+  SidebarActive,
+  SidebarTreeData,
+  SidebarTreePack,
+  SidebarTreeWorkflow,
+} from './Sidebar';
 export type { ShellContext } from './ShellContext';
 export { Topbar } from './Topbar';

--- a/frontend/src/shared/ui/ostone/chrome/useSidebarTreeData.test.ts
+++ b/frontend/src/shared/ui/ostone/chrome/useSidebarTreeData.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { createElement } from 'react';
+import { useSidebarTreeData } from './useSidebarTreeData';
+
+vi.mock('@/shared/api/generated/endpoints/domain-pack-controller/domain-pack-controller', async () => {
+  const actual = await vi.importActual<typeof import('@/shared/api/generated/endpoints/domain-pack-controller/domain-pack-controller')>(
+    '@/shared/api/generated/endpoints/domain-pack-controller/domain-pack-controller',
+  );
+  return {
+    ...actual,
+    listDomainPacks: vi.fn(),
+    getDomainPack: vi.fn(),
+  };
+});
+
+vi.mock('@/shared/api/generated/endpoints/workflow-definition-controller/workflow-definition-controller', async () => {
+  const actual = await vi.importActual<typeof import('@/shared/api/generated/endpoints/workflow-definition-controller/workflow-definition-controller')>(
+    '@/shared/api/generated/endpoints/workflow-definition-controller/workflow-definition-controller',
+  );
+  return {
+    ...actual,
+    listWorkflows: vi.fn(),
+  };
+});
+
+import {
+  getDomainPack,
+  listDomainPacks,
+} from '@/shared/api/generated/endpoints/domain-pack-controller/domain-pack-controller';
+import { listWorkflows } from '@/shared/api/generated/endpoints/workflow-definition-controller/workflow-definition-controller';
+
+const mockedListDomainPacks = vi.mocked(listDomainPacks);
+const mockedGetDomainPack = vi.mocked(getDomainPack);
+const mockedListWorkflows = vi.mocked(listWorkflows);
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0, staleTime: 0 },
+    },
+  });
+  return createElement(QueryClientProvider, { client }, children);
+}
+
+beforeEach(() => {
+  mockedListDomainPacks.mockReset();
+  mockedGetDomainPack.mockReset();
+  mockedListWorkflows.mockReset();
+});
+
+describe('useSidebarTreeData', () => {
+  it('enabled=false면 호출하지 않고 빈 트리를 반환한다', async () => {
+    const { result } = renderHook(
+      () => useSidebarTreeData({ workspaceId: 1, enabled: false }),
+      { wrapper },
+    );
+    expect(result.current.loading).toBe(false);
+    expect(result.current.packs).toEqual([]);
+    expect(mockedListDomainPacks).not.toHaveBeenCalled();
+  });
+
+  it('workspaceId가 null이면 호출하지 않는다', async () => {
+    const { result } = renderHook(
+      () => useSidebarTreeData({ workspaceId: null, enabled: true }),
+      { wrapper },
+    );
+    expect(result.current.loading).toBe(false);
+    expect(result.current.packs).toEqual([]);
+    expect(mockedListDomainPacks).not.toHaveBeenCalled();
+  });
+
+  it('packs/versions/workflows를 조합해 트리를 구성한다', async () => {
+    mockedListDomainPacks.mockResolvedValue({
+      data: [
+        { packId: 11, name: 'CS Support' },
+        { packId: 12, name: 'Billing' },
+      ],
+    } as never);
+    mockedGetDomainPack.mockImplementation((_ws, packId) => {
+      if (packId === 11) {
+        return Promise.resolve({
+          data: {
+            packId: 11,
+            versions: [
+              { versionId: 50, versionNo: 1 },
+              { versionId: 51, versionNo: 2 },
+            ],
+          },
+        }) as never;
+      }
+      return Promise.resolve({
+        data: {
+          packId: 12,
+          versions: [{ versionId: 80, versionNo: 1 }],
+        },
+      }) as never;
+    });
+    mockedListWorkflows.mockImplementation((_ws, packId, versionId) => {
+      if (packId === 11 && versionId === 51) {
+        return Promise.resolve({
+          data: [
+            { id: 100, name: '환불 처리' },
+            { id: 101, workflowCode: 'shipping.delay' },
+          ],
+        }) as never;
+      }
+      if (packId === 12 && versionId === 80) {
+        return Promise.resolve({
+          data: [{ id: 200, name: '카드 변경' }],
+        }) as never;
+      }
+      return Promise.resolve({ data: [] }) as never;
+    });
+
+    const { result } = renderHook(
+      () => useSidebarTreeData({ workspaceId: 1, enabled: true }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toBeNull();
+    expect(result.current.packs).toHaveLength(2);
+
+    const cs = result.current.packs.find((p) => p.packId === 11)!;
+    expect(cs.name).toBe('CS Support');
+    expect(cs.versionId).toBe(51);
+    expect(cs.workflows.map((w) => w.id)).toEqual([100, 101]);
+    expect(cs.workflows[1].name).toBe('shipping.delay');
+
+    const billing = result.current.packs.find((p) => p.packId === 12)!;
+    expect(billing.versionId).toBe(80);
+    expect(billing.workflows[0].name).toBe('카드 변경');
+  });
+
+  it('versions가 없는 pack은 versionId=null로 두고 workflows를 호출하지 않는다', async () => {
+    mockedListDomainPacks.mockResolvedValue({
+      data: [{ packId: 99, name: 'Empty' }],
+    } as never);
+    mockedGetDomainPack.mockResolvedValue({
+      data: { packId: 99, versions: [] },
+    } as never);
+
+    const { result } = renderHook(
+      () => useSidebarTreeData({ workspaceId: 1, enabled: true }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.packs[0]).toEqual({
+      packId: 99,
+      name: 'Empty',
+      versionId: null,
+      workflows: [],
+    });
+    expect(mockedListWorkflows).not.toHaveBeenCalled();
+  });
+
+  it('listDomainPacks 실패 시 error 메시지를 반환한다', async () => {
+    mockedListDomainPacks.mockRejectedValue(new Error('boom'));
+
+    const { result } = renderHook(
+      () => useSidebarTreeData({ workspaceId: 1, enabled: true }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect(result.current.error).toBe('도메인팩 목록 조회 실패');
+  });
+});

--- a/frontend/src/shared/ui/ostone/chrome/useSidebarTreeData.ts
+++ b/frontend/src/shared/ui/ostone/chrome/useSidebarTreeData.ts
@@ -73,13 +73,14 @@ export function useSidebarTreeData({ workspaceId, enabled }: UseSidebarTreeDataP
     packDetailQueries.some((q) => q.isLoading) ||
     workflowQueries.some((q) => q.isLoading);
 
-  const error = packsQuery.isError
-    ? '도메인팩 목록 조회 실패'
-    : packDetailQueries.find((q) => q.isError)
-      ? '도메인팩 상세 조회 실패'
-      : workflowQueries.find((q) => q.isError)
-        ? '워크플로우 목록 조회 실패'
-        : null;
+  let error: string | null = null;
+  if (packsQuery.isError) {
+    error = '도메인팩 목록 조회 실패';
+  } else if (packDetailQueries.find((q) => q.isError)) {
+    error = '도메인팩 상세 조회 실패';
+  } else if (workflowQueries.find((q) => q.isError)) {
+    error = '워크플로우 목록 조회 실패';
+  }
 
   const treePacks: SidebarTreePack[] = packVersionPairs.map((pair, idx) => {
     const wfList = unwrapApiResponse<WorkflowDefinitionSummary[]>(workflowQueries[idx]?.data) ?? [];

--- a/frontend/src/shared/ui/ostone/chrome/useSidebarTreeData.ts
+++ b/frontend/src/shared/ui/ostone/chrome/useSidebarTreeData.ts
@@ -1,0 +1,105 @@
+import { useQueries, useQuery } from '@tanstack/react-query';
+import {
+  getDomainPack,
+  getListDomainPacksQueryOptions,
+  listDomainPacks,
+} from '@/shared/api/generated/endpoints/domain-pack-controller/domain-pack-controller';
+import { listWorkflows } from '@/shared/api/generated/endpoints/workflow-definition-controller/workflow-definition-controller';
+import { unwrapApiResponse } from '@/shared/api/unwrapApiResponse';
+import type {
+  DomainPackDetailResult,
+  DomainPackSummaryResult,
+  WorkflowDefinitionSummary,
+} from '@/shared/api/generated/zod';
+import type { SidebarTreeData, SidebarTreePack } from './Sidebar';
+
+interface UseSidebarTreeDataParams {
+  workspaceId: number | null;
+  enabled: boolean;
+}
+
+interface PackVersionPair {
+  pack: DomainPackSummaryResult;
+  versionId: number | null;
+}
+
+/** Pick the latest version (highest versionNo) — newest assumed first when no versionNo. */
+function pickLatestVersionId(detail: DomainPackDetailResult | undefined): number | null {
+  if (!detail?.versions || detail.versions.length === 0) return null;
+  const sorted = [...detail.versions].sort((a, b) => (b.versionNo ?? 0) - (a.versionNo ?? 0));
+  return sorted[0]?.versionId ?? null;
+}
+
+export function useSidebarTreeData({ workspaceId, enabled }: UseSidebarTreeDataParams): SidebarTreeData {
+  const wsId = workspaceId ?? 0;
+  const isEnabled = enabled && workspaceId !== null;
+
+  const packsQuery = useQuery({
+    ...getListDomainPacksQueryOptions(wsId, { query: { enabled: isEnabled } }),
+    queryFn: async ({ signal }) => listDomainPacks(wsId, { signal }),
+  });
+
+  const packs = (unwrapApiResponse<DomainPackSummaryResult[]>(packsQuery.data) ?? []).filter(
+    (p): p is DomainPackSummaryResult & { packId: number } => typeof p.packId === 'number',
+  );
+
+  const packDetailQueries = useQueries({
+    queries: packs.map((pack) => ({
+      queryKey: ['sidebar-tree', 'pack-detail', wsId, pack.packId] as const,
+      queryFn: async ({ signal }: { signal?: AbortSignal }) =>
+        getDomainPack(wsId, pack.packId, { signal }),
+      enabled: isEnabled,
+    })),
+  });
+
+  const packVersionPairs: PackVersionPair[] = packs.map((pack, idx) => {
+    const detail = unwrapApiResponse<DomainPackDetailResult>(packDetailQueries[idx]?.data);
+    return { pack, versionId: pickLatestVersionId(detail) };
+  });
+
+  const workflowQueries = useQueries({
+    queries: packVersionPairs.map((pair) => ({
+      queryKey: ['sidebar-tree', 'workflows', wsId, pair.pack.packId, pair.versionId ?? 0] as const,
+      queryFn: async ({ signal }: { signal?: AbortSignal }) =>
+        pair.versionId !== null
+          ? listWorkflows(wsId, pair.pack.packId!, pair.versionId, { signal })
+          : Promise.resolve(undefined as never),
+      enabled: isEnabled && pair.versionId !== null,
+    })),
+  });
+
+  const loading =
+    packsQuery.isLoading ||
+    packDetailQueries.some((q) => q.isLoading) ||
+    workflowQueries.some((q) => q.isLoading);
+
+  const error = packsQuery.isError
+    ? '도메인팩 목록 조회 실패'
+    : packDetailQueries.find((q) => q.isError)
+      ? '도메인팩 상세 조회 실패'
+      : workflowQueries.find((q) => q.isError)
+        ? '워크플로우 목록 조회 실패'
+        : null;
+
+  const treePacks: SidebarTreePack[] = packVersionPairs.map((pair, idx) => {
+    const wfList = unwrapApiResponse<WorkflowDefinitionSummary[]>(workflowQueries[idx]?.data) ?? [];
+    const workflows = wfList
+      .filter((wf): wf is WorkflowDefinitionSummary & { id: number } => typeof wf.id === 'number')
+      .map((wf) => ({
+        id: wf.id,
+        name: wf.name || wf.workflowCode || `wf-${wf.id}`,
+      }));
+    return {
+      packId: pair.pack.packId!,
+      name: pair.pack.name || `pack-${pair.pack.packId}`,
+      versionId: pair.versionId,
+      workflows,
+    };
+  });
+
+  return {
+    loading,
+    error,
+    packs: treePacks,
+  };
+}

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,6 +1,14 @@
 import { vi } from "vite-plus/test";
 import "@testing-library/jest-dom";
 
+// WorkspaceMarker hits React Query (useListWorkspaces) which throws without
+// a QueryClientProvider. Tests render OstoneShell with no provider, so stub
+// the marker globally. Tests that exercise the marker directly mount it
+// themselves with their own provider.
+vi.mock("@/shared/ui/ostone/chrome/WorkspaceMarker", () => ({
+  WorkspaceMarker: () => null,
+}));
+
 // Node.js v25 exposes localStorage as an empty object without methods.
 // vite-plus-test's populateGlobal skips keys already present in globalThis,
 // so jsdom's real implementation is never injected. window === globalThis in

--- a/frontend/src/widgets/ostone-shell/ui/OstoneShell.test.tsx
+++ b/frontend/src/widgets/ostone-shell/ui/OstoneShell.test.tsx
@@ -63,17 +63,20 @@ describe('OstoneShell', () => {
     expect(screen.getByLabelText('주요 내비게이션')).toHaveAttribute('data-collapsed', 'true');
   });
 
-  it('토글 버튼 클릭 시 collapsed 상태가 토글되고 localStorage에 저장된다', () => {
+  it('collapsed 시 nav 배경 클릭으로 펼쳐지고 localStorage에 저장되며, expanded 후엔 접기 버튼이 동작한다', () => {
     render(
       <OstoneShell active="workflows" crumbs={[]}>
         <div>content</div>
       </OstoneShell>,
       { wrapper: Wrapper },
     );
-    expect(screen.getByLabelText('주요 내비게이션')).toHaveAttribute('data-collapsed', 'true');
-    fireEvent.click(screen.getByLabelText('사이드바 펼치기'));
+    const nav = screen.getByLabelText('주요 내비게이션');
+    expect(nav).toHaveAttribute('data-collapsed', 'true');
+    fireEvent.click(nav);
     expect(screen.getByLabelText('주요 내비게이션')).toHaveAttribute('data-collapsed', 'false');
     expect(window.localStorage.getItem('ostone:sidebar:collapsed')).toBe('false');
+    fireEvent.click(screen.getByLabelText('사이드바 접기'));
+    expect(screen.getByLabelText('주요 내비게이션')).toHaveAttribute('data-collapsed', 'true');
   });
 
   it('localStorage에 false가 저장돼 있으면 expanded로 시작한다', () => {
@@ -112,7 +115,7 @@ describe('OstoneShell', () => {
       </OstoneShell>,
       { wrapper: Wrapper },
     );
-    fireEvent.click(screen.getByLabelText('사이드바 펼치기'));
+    fireEvent.click(screen.getByLabelText('주요 내비게이션'));
     expect(screen.getByText('Injected')).toBeInTheDocument();
   });
 });

--- a/frontend/src/widgets/ostone-shell/ui/OstoneShell.test.tsx
+++ b/frontend/src/widgets/ostone-shell/ui/OstoneShell.test.tsx
@@ -16,7 +16,7 @@ beforeEach(() => {
 });
 
 describe('OstoneShell', () => {
-  it('renders Sidebar with the new top nav items', () => {
+  it('renders Sidebar with the new top nav items (workflows lives under Domain Packs, not top-level)', () => {
     render(
       <OstoneShell active="consult" crumbs={[]}>
         <div>content</div>
@@ -24,11 +24,11 @@ describe('OstoneShell', () => {
       { wrapper: Wrapper },
     );
     expect(screen.getByTitle('Operator')).toBeInTheDocument();
-    expect(screen.getByTitle('Workflows')).toBeInTheDocument();
     expect(screen.getByTitle('Pipeline')).toBeInTheDocument();
     expect(screen.getByTitle('Consultation')).toBeInTheDocument();
     expect(screen.getByTitle('Uploads')).toBeInTheDocument();
     expect(screen.getByTitle('Domain Packs')).toBeInTheDocument();
+    expect(screen.queryByTitle('Workflows')).not.toBeInTheDocument();
   });
 
   it('renders Topbar with OSTONE eyebrow', () => {

--- a/frontend/src/widgets/ostone-shell/ui/OstoneShell.test.tsx
+++ b/frontend/src/widgets/ostone-shell/ui/OstoneShell.test.tsx
@@ -1,25 +1,34 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { OstoneShell } from './OstoneShell';
+
+vi.mock('@/shared/ui/ostone/chrome/useSidebarTreeData', () => ({
+  useSidebarTreeData: () => ({ loading: false, error: null, packs: [] }),
+}));
 
 function Wrapper({ children }: { children: React.ReactNode }) {
   return <MemoryRouter>{children}</MemoryRouter>;
 }
 
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
 describe('OstoneShell', () => {
-  it('renders Sidebar with 5 nav items', () => {
+  it('renders Sidebar with the new top nav items', () => {
     render(
       <OstoneShell active="consult" crumbs={[]}>
         <div>content</div>
       </OstoneShell>,
-      { wrapper: Wrapper }
+      { wrapper: Wrapper },
     );
+    expect(screen.getByTitle('Operator')).toBeInTheDocument();
     expect(screen.getByTitle('Workflows')).toBeInTheDocument();
-    expect(screen.getByTitle('Domain Packs')).toBeInTheDocument();
     expect(screen.getByTitle('Pipeline')).toBeInTheDocument();
     expect(screen.getByTitle('Consultation')).toBeInTheDocument();
     expect(screen.getByTitle('Uploads')).toBeInTheDocument();
+    expect(screen.getByTitle('Domain Packs')).toBeInTheDocument();
   });
 
   it('renders Topbar with OSTONE eyebrow', () => {
@@ -27,7 +36,7 @@ describe('OstoneShell', () => {
       <OstoneShell active="workflows" crumbs={['CARD-CS', 'Domain Packs']}>
         <div>content</div>
       </OstoneShell>,
-      { wrapper: Wrapper }
+      { wrapper: Wrapper },
     );
     expect(screen.getByText('OSTONE')).toBeInTheDocument();
     expect(screen.getByText('CARD-CS')).toBeInTheDocument();
@@ -39,10 +48,43 @@ describe('OstoneShell', () => {
       <OstoneShell active="workflows" crumbs={[]}>
         <div data-testid="shell-child">Hello Shell</div>
       </OstoneShell>,
-      { wrapper: Wrapper }
+      { wrapper: Wrapper },
     );
     expect(screen.getByTestId('shell-child')).toBeInTheDocument();
-    expect(screen.getByText('Hello Shell')).toBeInTheDocument();
+  });
+
+  it('starts collapsed by default', () => {
+    render(
+      <OstoneShell active="workflows" crumbs={[]}>
+        <div>content</div>
+      </OstoneShell>,
+      { wrapper: Wrapper },
+    );
+    expect(screen.getByLabelText('주요 내비게이션')).toHaveAttribute('data-collapsed', 'true');
+  });
+
+  it('토글 버튼 클릭 시 collapsed 상태가 토글되고 localStorage에 저장된다', () => {
+    render(
+      <OstoneShell active="workflows" crumbs={[]}>
+        <div>content</div>
+      </OstoneShell>,
+      { wrapper: Wrapper },
+    );
+    expect(screen.getByLabelText('주요 내비게이션')).toHaveAttribute('data-collapsed', 'true');
+    fireEvent.click(screen.getByLabelText('사이드바 펼치기'));
+    expect(screen.getByLabelText('주요 내비게이션')).toHaveAttribute('data-collapsed', 'false');
+    expect(window.localStorage.getItem('ostone:sidebar:collapsed')).toBe('false');
+  });
+
+  it('localStorage에 false가 저장돼 있으면 expanded로 시작한다', () => {
+    window.localStorage.setItem('ostone:sidebar:collapsed', 'false');
+    render(
+      <OstoneShell active="workflows" crumbs={[]}>
+        <div>content</div>
+      </OstoneShell>,
+      { wrapper: Wrapper },
+    );
+    expect(screen.getByLabelText('주요 내비게이션')).toHaveAttribute('data-collapsed', 'false');
   });
 
   it('renders dark variant', () => {
@@ -50,8 +92,27 @@ describe('OstoneShell', () => {
       <OstoneShell active="consult" crumbs={[]} dark>
         <div>dark</div>
       </OstoneShell>,
-      { wrapper: Wrapper }
+      { wrapper: Wrapper },
     );
     expect(screen.getByText('dark')).toBeInTheDocument();
+  });
+
+  it('treeOverride prop으로 트리 데이터를 직접 주입할 수 있다', () => {
+    render(
+      <OstoneShell
+        active="domain"
+        crumbs={[]}
+        treeOverride={{
+          loading: false,
+          error: null,
+          packs: [{ packId: 7, name: 'Injected', versionId: 9, workflows: [] }],
+        }}
+      >
+        <div>x</div>
+      </OstoneShell>,
+      { wrapper: Wrapper },
+    );
+    fireEvent.click(screen.getByLabelText('사이드바 펼치기'));
+    expect(screen.getByText('Injected')).toBeInTheDocument();
   });
 });

--- a/frontend/src/widgets/ostone-shell/ui/OstoneShell.tsx
+++ b/frontend/src/widgets/ostone-shell/ui/OstoneShell.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState, type ReactNode } from 'react';
 import { useParams } from 'react-router-dom';
 import { Sidebar, Topbar, type SidebarActive, type SidebarTreeData } from '@/shared/ui/ostone/chrome';
 import { useSidebarTreeData } from '@/shared/ui/ostone/chrome/useSidebarTreeData';
+import { WorkspaceMarker } from '@/shared/ui/ostone/chrome/WorkspaceMarker';
 
 const COLLAPSED_STORAGE_KEY = 'ostone:sidebar:collapsed';
 
@@ -87,11 +88,15 @@ export function OstoneShell({
     setCollapsed((v) => !v);
   }, []);
 
+  const fallbackSwitcher = sidebarSwitcher ?? (
+    <WorkspaceMarker workspaceId={safeWorkspaceId} collapsed={collapsed} />
+  );
+
   const sidebarBaseProps: SidebarBaseProps = {
     active,
     dark,
     basePath: resolvedBasePath,
-    switcher: sidebarSwitcher,
+    switcher: fallbackSwitcher,
     collapsed,
     onToggleCollapsed: handleToggle,
     activePackId,

--- a/frontend/src/widgets/ostone-shell/ui/OstoneShell.tsx
+++ b/frontend/src/widgets/ostone-shell/ui/OstoneShell.tsx
@@ -1,6 +1,29 @@
-import type { ReactNode } from 'react';
+import { useCallback, useEffect, useState, type ReactNode } from 'react';
 import { useParams } from 'react-router-dom';
-import { Sidebar, Topbar, type SidebarActive } from '@/shared/ui/ostone/chrome';
+import { Sidebar, Topbar, type SidebarActive, type SidebarTreeData } from '@/shared/ui/ostone/chrome';
+import { useSidebarTreeData } from '@/shared/ui/ostone/chrome/useSidebarTreeData';
+
+const COLLAPSED_STORAGE_KEY = 'ostone:sidebar:collapsed';
+
+function readPersistedCollapsed(): boolean {
+  if (typeof window === 'undefined') return true;
+  try {
+    const raw = window.localStorage.getItem(COLLAPSED_STORAGE_KEY);
+    if (raw === null) return true;
+    return raw !== 'false';
+  } catch {
+    return true;
+  }
+}
+
+function persistCollapsed(value: boolean): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(COLLAPSED_STORAGE_KEY, value ? 'true' : 'false');
+  } catch {
+    /* noop */
+  }
+}
 
 interface OstoneShellProps {
   active: SidebarActive;
@@ -10,11 +33,72 @@ interface OstoneShellProps {
   dark?: boolean;
   basePath?: string;
   children: ReactNode;
+  activePackId?: number | null;
+  activeWorkflowId?: number | null;
+  /** Override tree data — primarily for tests. */
+  treeOverride?: SidebarTreeData;
 }
 
-export function OstoneShell({ active, crumbs, topbarRight, sidebarSwitcher, dark = false, basePath, children }: OstoneShellProps) {
+interface SidebarBaseProps {
+  active: SidebarActive;
+  dark: boolean;
+  basePath: string;
+  switcher: ReactNode;
+  collapsed: boolean;
+  onToggleCollapsed: () => void;
+  activePackId: number | null;
+  activeWorkflowId: number | null;
+}
+
+interface SidebarWithFetchedTreeProps extends SidebarBaseProps {
+  workspaceId: number | null;
+}
+
+function SidebarWithFetchedTree({ workspaceId, ...sidebarProps }: SidebarWithFetchedTreeProps) {
+  const tree = useSidebarTreeData({ workspaceId, enabled: true });
+  return <Sidebar {...sidebarProps} tree={tree} />;
+}
+
+export function OstoneShell({
+  active,
+  crumbs,
+  topbarRight,
+  sidebarSwitcher,
+  dark = false,
+  basePath,
+  children,
+  activePackId = null,
+  activeWorkflowId = null,
+  treeOverride,
+}: OstoneShellProps) {
   const { workspaceId } = useParams();
   const resolvedBasePath = basePath ?? (workspaceId ? `/workspaces/${workspaceId}` : '/workspaces');
+  const numericWorkspaceId = workspaceId ? Number(workspaceId) : null;
+  const safeWorkspaceId =
+    numericWorkspaceId !== null && Number.isFinite(numericWorkspaceId) ? numericWorkspaceId : null;
+
+  const [collapsed, setCollapsed] = useState<boolean>(() => readPersistedCollapsed());
+
+  useEffect(() => {
+    persistCollapsed(collapsed);
+  }, [collapsed]);
+
+  const handleToggle = useCallback(() => {
+    setCollapsed((v) => !v);
+  }, []);
+
+  const sidebarBaseProps: SidebarBaseProps = {
+    active,
+    dark,
+    basePath: resolvedBasePath,
+    switcher: sidebarSwitcher,
+    collapsed,
+    onToggleCollapsed: handleToggle,
+    activePackId,
+    activeWorkflowId,
+  };
+
+  const shouldFetchTree = !collapsed && treeOverride === undefined;
 
   return (
     <div
@@ -25,7 +109,11 @@ export function OstoneShell({ active, crumbs, topbarRight, sidebarSwitcher, dark
       }}
     >
       <div style={{ flexShrink: 0 }}>
-        <Sidebar active={active} dark={dark} basePath={resolvedBasePath} switcher={sidebarSwitcher} />
+        {shouldFetchTree ? (
+          <SidebarWithFetchedTree {...sidebarBaseProps} workspaceId={safeWorkspaceId} />
+        ) : (
+          <Sidebar {...sidebarBaseProps} tree={treeOverride} />
+        )}
       </div>
       <div
         style={{

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -30,6 +30,8 @@ export default defineConfig({
     globals: true,
     setupFiles: ["./src/test/setup.ts"],
     environment: "jsdom",
+    testTimeout: 10000,
+    hookTimeout: 10000,
     coverage: {
       provider: 'v8',
       reporter: ['lcov', 'text'],


### PR DESCRIPTION
## Summary

- 사이드바 워크플로우 리스트에 톱니 settings (Top N · sort field · sort dir) + `+M more` 오버플로 인디케이터. 설정은 localStorage 영속.
- `/workspaces/:wsId/domain-packs/:packId/versions/:versionId/workflows` 가 빈 상태 안내 대신 신규 `PackWorkflowListPage` 로 진입 — 검색바, page settings (size 6/12/24, sort), 3-column CSS masonry, 카드 클릭 펼침(그래프 미니 썸네일 + description + node count + "열기" 버튼) 제공.
- `WorkspaceWorkflowsPage` 도 동일한 `WorkflowListView` 공용 컴포넌트를 사용해 일관된 UX.
- Naver 스타일 typeahead — 검색바에 타이핑 시 dropdown(최대 8건)이 매칭 텍스트를 굵게 강조, 항목 클릭은 그리드를 해당 워크플로우만 남도록 필터링하고 `×` 칩으로 해제.

## Test plan

- [x] `pnpm test`: 신규 90건 포함 950+ 통과 (workflow-list 4 files · 30 / Sidebar 29 / workflowSettings 12 / panel 4 / PackWorkflowListPage 8 / WorkspaceWorkflowsPage 7).
- [x] `pnpm lint`: 신규/수정 파일 0 error.
- [x] Playwright MCP: 사이드바 톱니 펼침/Top-N 적용, 페이지 톱니 펼침, 카드 펼침(그래프 미니/설명/열기), 검색 dropdown → 그리드 필터링 / `×` 칩 해제 모두 시각 검증 (`phase-g-04~09.png`).
- [x] `python3 .claude/skills/5stone-cross-sonarSentinel/scripts/local-quality-gate.py --projects frontend --diff-base main --canonical local`: new code coverage **97.63%**, reliability **A**, security **A**.

## Follow-up (별도 PR 권장)

워크플로우가 수천~수만 건 누적되는 시점에는 클라이언트 사이드 정렬/페이징이 list payload 자체에서 막힌다. `WorkflowDefinitionController` 에 `sort=workflowCode|name,(asc|desc)` + `Pageable(page,size)` 추가, `pack.workflow_definition` 의 정렬 컬럼 인덱스 보강, OpenAPI 재생성 후 `WorkflowListView` 의 정렬/페이징 로직을 서버 쿼리로 위임할 것. 본 PR 은 클라이언트 사이드만 구현했다.

## Notes

- `vite.config.ts` 의 `testTimeout`/`hookTimeout` 을 10s 로 상향 — 신규 테스트 50건 추가로 5s 기본값에선 병렬 부하 시 기존 테스트(`Dropzone`, `IntentRevisionEditForm`, `ComponentCountGrid` 등)가 산발 timeout 됨. 단독 실행은 모두 통과.
- `WorkflowDraftReadPage` 의 `!enabled` 빈 상태 분기는 라우트 분리 후 더 이상 도달하지 않지만 방어적으로 유지. 별도 정리 PR 에서 제거 가능.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 워크플로우 목록에 검색, 필터, 정렬 및 페이지 설정 추가
  * 워크플로우 상세에 그래프 뷰어와 인라인 편집 전환 추가
  * 도메인팩별 워크플로우 전용 목록 페이지 추가
  * 사이드바에 접힘/펼침, 계정 메뉴, 워크스페이스 선택 기능 추가

* **UI/UX 개선**
  * 사이드바 네비게이션 구조·표시 개선 및 로컬 설정 유지
  * 한국어 UI 문구 일부 적용 (예: 운영자 화면, 빈 상태 안내)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ajou-2026-1-capstone-5/ostone/pull/249?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->