### PR TITLE
fix(frontend): remove pipeline menu

### DIFF
--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -1,7 +1,6 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { LoginPage } from '../pages/login/ui/LoginPage';
 import { SignupPage } from '../pages/signup/ui/SignupPage';
-import { UploadPage } from '../pages/upload/ui/UploadPage';
 import { WorkspaceRootRedirect } from '../pages/workspace/ui/WorkspaceRootRedirect';
 import { PasswordResetInitPage } from '../pages/password-reset/ui/PasswordResetInitPage';
 import { PasswordResetCompletePage } from '../pages/password-reset/ui/PasswordResetCompletePage';
@@ -37,7 +36,7 @@ export function App() {
         <Route path="/workspaces/:workspaceId" element={<PrivateRoute><WorkspaceLayout /></PrivateRoute>}>
           <Route index element={<Navigate to="workflows" replace />} />
           <Route path="workflows" element={<WorkspaceWorkflowsPage />} />
-          <Route path="pipeline" element={<UploadPage />} />
+          <Route path="pipeline" element={<Navigate to="upload" replace />} />
           <Route path="consultation" element={<ConsultationPage />} />
           <Route path="consultation/:sessionId" element={<ConsultationPage />} />
           <Route path="upload" element={<WorkspaceUploadPage />} />

--- a/frontend/src/pages/workspace/ui/WorkspaceLayout.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceLayout.tsx
@@ -14,7 +14,6 @@ import { parseRouteId } from "@/shared/lib/parseRouteId";
 
 const getActiveFromPath = (pathname: string): SidebarActive => {
   if (pathname.includes("/domain-packs")) return "domain";
-  if (pathname.includes("/pipeline")) return "pipeline";
   if (pathname.includes("/consultation")) return "consult";
   if (pathname.includes("/upload")) return "upload";
   if (pathname.includes("/workflows")) return "workflows";

--- a/frontend/src/shared/ui/ostone/chrome/Sidebar.test.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/Sidebar.test.tsx
@@ -47,7 +47,7 @@ describe('Sidebar', () => {
     expect(nav).toHaveAttribute('data-collapsed', 'true');
     expect(nav).toHaveStyle({ width: '72px' });
     expect(screen.getByTitle('Operator')).toBeInTheDocument();
-    expect(screen.getByTitle('Pipeline')).toBeInTheDocument();
+    expect(screen.queryByTitle('Pipeline')).not.toBeInTheDocument();
     expect(screen.getByTitle('Consultation')).toBeInTheDocument();
     expect(screen.getByTitle('Uploads')).toBeInTheDocument();
     expect(screen.getByTitle('Domain Packs')).toBeInTheDocument();
@@ -235,7 +235,7 @@ describe('Sidebar', () => {
 
   it('inactive 항목에 mouseEnter/Leave 시 배경이 토글된다', () => {
     renderSidebar({ active: 'operator', collapsed: true });
-    const link = screen.getByTitle('Pipeline') as HTMLElement;
+    const link = screen.getByTitle('Consultation') as HTMLElement;
     fireEvent.mouseEnter(link);
     expect(link.style.background).toBe('var(--paper-3)');
     fireEvent.mouseLeave(link);

--- a/frontend/src/shared/ui/ostone/chrome/Sidebar.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/Sidebar.tsx
@@ -28,7 +28,6 @@ const SORT_DIR_KO_LABELS: Record<(typeof SORT_DIR_OPTIONS)[number]['value'], str
 export type SidebarActive =
   | 'operator'
   | 'workflows'
-  | 'pipeline'
   | 'consult'
   | 'upload'
   | 'domain'
@@ -76,7 +75,6 @@ interface TopNavItem {
 
 const TOP_NAV_ITEMS: TopNavItem[] = [
   { key: 'operator', icon: 'msg', label: 'Operator', getPath: (base) => `${base}/chat-demo` },
-  { key: 'pipeline', icon: 'flow', label: 'Pipeline', getPath: (base) => `${base}/pipeline` },
   { key: 'consult', icon: 'book', label: 'Consultation', getPath: (base) => `${base}/consultation` },
   { key: 'upload', icon: 'upload', label: 'Uploads', getPath: (base) => `${base}/upload` },
 ];
@@ -871,4 +869,3 @@ function PackNode({
     </div>
   );
 }
-

--- a/frontend/src/widgets/ostone-shell/ui/OstoneShell.test.tsx
+++ b/frontend/src/widgets/ostone-shell/ui/OstoneShell.test.tsx
@@ -24,7 +24,7 @@ describe('OstoneShell', () => {
       { wrapper: Wrapper },
     );
     expect(screen.getByTitle('Operator')).toBeInTheDocument();
-    expect(screen.getByTitle('Pipeline')).toBeInTheDocument();
+    expect(screen.queryByTitle('Pipeline')).not.toBeInTheDocument();
     expect(screen.getByTitle('Consultation')).toBeInTheDocument();
     expect(screen.getByTitle('Uploads')).toBeInTheDocument();
     expect(screen.getByTitle('Domain Packs')).toBeInTheDocument();


### PR DESCRIPTION
## Summary

- 사이드바 top nav에서 Pipeline 메뉴를 제거
- `/workspaces/:workspaceId/pipeline` 직접 접근은 `/upload`로 redirect하도록 유지
- Pipeline active key와 관련 테스트 기대값을 정리

## Test

- [x] `pnpm build`
- [x] `git diff --check`
- [x] `pnpm test -- src/shared/ui/ostone/chrome/Sidebar.test.tsx src/widgets/ostone-shell/ui/OstoneShell.test.tsx src/app/App.test.tsx`
- [ ] `pnpm lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * 사이드바 네비게이션에서 파이프라인 메뉴 항목이 제거되었습니다.
  * 파이프라인 경로 접근 시 업로드 기능으로 자동 리다이렉트됩니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ajou-2026-1-capstone-5/ostone/pull/250?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->