### PR TITLE
docs(spec): 5.3.2 STOMP WebSocket chat spec

### DIFF
--- a/.agent/specs/5.3.2.md
+++ b/.agent/specs/5.3.2.md
@@ -61,12 +61,12 @@ sequenceDiagram
 
 | Direction | Destination | Description |
 |-----------|-------------|-------------|
-| Client SEND | `/app/chat.startSession` | 새 `ChatSession`을 시작하고 session 전용 destination을 반환한다. |
+| Client SEND | `/app/chat.startSession` | 새 `ChatSession`을 시작하고 결과는 `/queue/chat.{sessionId}`로 반환한다. |
 | Client SEND | `/app/chat.sendMessage` | 기존 session에 사용자 메시지를 저장하고 구독자에게 이벤트를 발행한다. |
 | Client SEND | `/app/chat.session.leave` | 사용자가 session을 떠났음을 기록하고 cleanup을 수행한다. |
 | Client SUBSCRIBE | `/topic/chat.{sessionId}` | session 참여자가 실시간 메시지 이벤트를 받는다. |
-| Client SUBSCRIBE | `/queue/chat.{sessionId}` | session 생성 결과와 개인 오류처럼 session 단위 응답을 받는다. |
-| Agent SUBSCRIBE | `/topic/chat.queue` | 상담 에이전트가 새 OPEN session과 queue 변화를 받는다. |
+| Client SUBSCRIBE | `/queue/chat.{sessionId}` | session 생성 결과와 session scoped error를 받는다. |
+| Agent SUBSCRIBE | `/topic/chat.queue` | 상담 에이전트만 새 OPEN session과 queue 변화를 받는다. |
 
 ### CONNECT Headers
 
@@ -84,6 +84,8 @@ heart-beat: 10000,10000
 ```json
 { "domainPackVersionId": 101, "channel": "WEB" }
 ```
+
+`channel` 허용값은 `WEB`, `DEMO_WEB`이다. 생략 시 DB 기본값은 `DEMO_WEB`이며, 운영자 웹 콘솔은 `WEB`, 데모 화면은 `DEMO_WEB`을 사용한다.
 
 **SEND /app/chat.sendMessage**
 
@@ -105,7 +107,22 @@ heart-beat: 10000,10000
 { "sessionId": 5001, "seqNo": 3, "senderRole": "USER", "content": "주문 취소하고 싶어요.", "messageType": "TEXT", "timestamp": "2026-05-20T10:00:00Z" }
 ```
 
-**MESSAGE /topic/chat.queue**는 `sessionId`, `status`, `domainPackVersionId`, `channel`, `startedAt`으로 queue 변화를 알린다. JWT 누락, 만료, refresh token 사용은 connection 단계에서 거부한다. 알 수 없는 session과 invalid payload는 가능한 경우 `/queue/chat.{sessionId}`로 오류 event를 보낸다.
+**MESSAGE /topic/chat.queue**는 agent queue 전용 알림이며 `sessionId`, `status`, `domainPackVersionId`, `channel`, `startedAt`으로 새 OPEN session과 queue 변화를 알린다.
+
+### Error Handling
+
+Error payload shape은 다음과 같다.
+
+```json
+{ "error": "UNKNOWN_SESSION", "message": "Chat session not found: 5001", "sessionId": 5001, "timestamp": "2026-05-20T10:00:00Z" }
+```
+
+| Error | Destination | Payload |
+|-------|-------------|---------|
+| Missing, expired, refresh JWT on `CONNECT` | STOMP connection rejection or `ERROR` frame | body 없이 연결 거부 |
+| `UNKNOWN_SESSION` from send/leave | `/queue/chat.{sessionId}` | `error`, `message`, `sessionId`, `timestamp` |
+| `VALIDATION_ERROR` with `sessionId` | `/queue/chat.{sessionId}` | `error`, `message`, `sessionId`, `field`, `timestamp` |
+| `VALIDATION_ERROR` before session creation | STOMP `ERROR` frame | `error`, `message`, `field`, `timestamp` |
 
 ---
 
@@ -151,20 +168,23 @@ classDiagram
 
 ### presentation/
 
+Boundary note: 아키텍처 문서상 `chat-demo`는 데모 화면과 WebSocket 이벤트 접점을 담당하지만, 현재 `ChatSession`/`ChatMessage` Java entity는 `com.init.workflowruntime.domain`에 있다. 이 스펙은 기존 entity 위치에 맞춰 `workflow-runtime` presentation layer를 확장하며, `chat-demo`는 frontend integration layer로 남긴다.
+
 | Class | Contract |
 |-------|----------|
 | `WebSocketConfig` | STOMP endpoint registration, `setAllowedOrigins()`, `WebSocketMessageBrokerConfigurer` 설정을 담당한다. endpoint는 `/ws`, application prefix는 `/app`, broker prefix는 `/topic`, `/queue`를 기본값으로 둔다. |
 | `ChatStompController` | `@MessageMapping("/chat.startSession")`, `@MessageMapping("/chat.sendMessage")`, `@MessageMapping("/chat.session.leave")` handler를 제공하고 service에 위임한다. |
 | `dto/ChatMessagePayload` | incoming message DTO. 필드: `sessionId`, `content`, `messageType`. |
 | `dto/ChatMessageEvent` | outgoing message event. 필드: `sessionId`, `seqNo`, `senderRole`, `content`, `messageType`, `timestamp`. |
-| `dto/StartSessionPayload` | session start request. 필드: `domainPackVersionId`, `channel`. |
+| `dto/StartSessionPayload` | session start request. 필드: `domainPackVersionId`, `channel`; `channel`은 `WEB` 또는 `DEMO_WEB`. |
+| `dto/LeaveSessionPayload` | session leave request. 필드: `sessionId`. |
 
 ### application/
 
 | Class | Contract |
 |-------|----------|
 | `ChatSessionService` | 기존 `ConsultationService` 흐름을 확장하거나 재사용한다. `startSession()`, `sendMessage()`, `leaveSession()`가 WebSocket message flow의 단일 진입점이다. |
-| `startSession()` | `Principal` userId를 시작 사용자로 사용하고 `ChatSession.create(workspaceId, domainPackVersionId, OPEN, channel, metaJson)`로 session을 만든다. `metaJson.stompSessionId`를 기록하고 `/topic/chat.queue`로 발행할 event를 반환한다. |
+| `startSession()` | `Principal` userId의 workspace membership에서 `workspaceId`를 결정한다. `ChatSession.create(workspaceId, domainPackVersionId, OPEN, channel, metaJson)`는 `startedBy`를 받지 않으므로 생성 후 별도 domain/service method로 `startedBy`를 설정한다. session 생성 결과는 `/queue/chat.{sessionId}`로 반환하고, 새 OPEN session 알림만 `/topic/chat.queue`로 발행한다. |
 | `sendMessage()` | session 접근 권한을 확인하고 다음 `seqNo`를 계산한 뒤 `ChatMessage.create(sessionId, seqNo, "USER", messageType, content)`로 저장한다. workflow 결과가 있으면 assistant/system event도 발행한다. |
 | `leaveSession()` | WebSocket 이탈 정보를 session metadata에 반영한다. 종료 조건이 충족되면 `ChatSession.closeSession()`을 사용한다. |
 
@@ -191,7 +211,7 @@ JWT access token은 STOMP `CONNECT` header로 전달한다. `JwtChannelIntercept
 신규 table이나 migration은 추가하지 않는다. `.agent/docs/schema.md`의 `7.7 runtime` DDL을 재사용한다.
 
 - `runtime.chat_session`: 기존 컬럼 `id`, `workspace_id`, `domain_pack_version_id`, `status`, `channel`, `started_by`, `meta_json`, `started_at`, `ended_at`을 사용한다. `meta_json`에는 `stompSessionId`, `lastConnectedUserId`, `lastConnectedAt`을 저장한다.
-- `runtime.chat_message`: 기존 컬럼 `id`, `chat_session_id`, `seq_no`, `sender_role`, `message_type`, `content`, `payload_json`, `created_at`을 사용한다. `(chat_session_id, seq_no)` unique 제약을 유지하고 `payload_json`에는 `workflowExecutionId`, `nodeId`, `edgeId`, `decisionType` 같은 workflow integration mapping을 저장한다.
+- `runtime.chat_message`: 기존 컬럼 `id`, `chat_session_id`, `seq_no`, `sender_role`, `message_type`, `content`, `payload_json`, `created_at`을 사용한다. `(chat_session_id, seq_no)` unique 제약을 유지한다. `payload_json`은 4.1.4의 AGENT/NOTE 실행 metadata(`workflowCode`, `workflowRefId`, `intentCode`, `currentNodeId`, `incomingEdgeId`, `policyRef`, `slotRefs`, `state`)와 호환되며, 5.3.2는 여기에 일반 mapping(`workflowExecutionId`, `nodeId`, `edgeId`, `decisionType`)을 추가로 허용한다.
 
 ---
 

--- a/.agent/specs/5.3.2.md
+++ b/.agent/specs/5.3.2.md
@@ -1,0 +1,214 @@
+# [BE-5.3.2] STOMP WebSocket 채팅 인프라
+
+> **Backlog**: 5.3.2 STOMP over WebSocket chat infrastructure
+> **Bounded Context**: `workflowruntime`
+> **Template**: `_TEMPLATE_BE.md`
+> **Branch**: `spec/5.3.2`
+> **작업 브랜치 (구현 단계)**: `feature/5.3.2-stomp-chat-infrastructure`
+
+---
+
+## Goal
+
+STOMP over WebSocket 기반 채팅 인프라 API와 아키텍처를 정의해 사용자와 상담 에이전트가 `workflow-runtime`의 `ChatSession`, `ChatMessage`, workflow 실행 흐름을 실시간 메시지로 주고받을 수 있게 한다.
+
+범위는 `workflowruntime` bounded context 안의 WebSocket presentation surface다. 기존 `ChatSession`, `ChatMessage`, `ChatSessionStatus`, repository를 재사용한다. STOMP `CONNECT` 단계에서 JWT access token을 검증해 WebSocket session의 `Principal`에 userId를 연결한다. 신규 DB migration은 만들지 않고 `runtime.chat_session.meta_json`, `runtime.chat_message.payload_json`을 사용한다.
+
+---
+
+## Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    actor client as Web Client
+    participant broker as STOMP Broker
+    participant interceptor as JwtChannelInterceptor
+    participant ctrl as ChatStompController
+    participant svc as ChatSessionService
+    participant repo as Chat Repositories
+    participant db as PostgreSQL
+    client ->> broker: CONNECT Authorization: Bearer {accessToken}
+    broker ->> interceptor: preSend(CONNECT)
+    interceptor ->> interceptor: JwtService.parseClaims(token)
+    interceptor ->> interceptor: isAccessToken(claims) && isTokenValid(claims)
+    interceptor -->> broker: Principal(userId)
+    broker -->> client: CONNECTED
+    client ->> broker: SUBSCRIBE /topic/chat.{sessionId}
+    client ->> broker: SEND /app/chat.startSession
+    broker ->> ctrl: startSession(StartSessionPayload, Principal)
+    ctrl ->> svc: startSession(payload, userId)
+    svc ->> repo: save(ChatSession OPEN, metaJson.stompSessionId)
+    repo ->> db: INSERT runtime.chat_session
+    broker -->> client: MESSAGE /queue/chat.{sessionId}
+    client ->> broker: SEND /app/chat.sendMessage
+    broker ->> ctrl: sendMessage(ChatMessagePayload, Principal)
+    ctrl ->> svc: sendMessage(payload, userId)
+    svc ->> repo: save(ChatMessage)
+    repo ->> db: INSERT runtime.chat_message
+    broker -->> client: MESSAGE /topic/chat.{sessionId}
+    client ->> broker: SEND /app/chat.session.leave
+    broker ->> ctrl: leaveSession(LeaveSessionPayload, Principal)
+    ctrl ->> svc: leaveSession(sessionId, userId)
+    client ->> broker: DISCONNECT
+    broker ->> interceptor: cleanup session metadata
+```
+
+---
+
+## STOMP API
+
+### Destinations
+
+| Direction | Destination | Description |
+|-----------|-------------|-------------|
+| Client SEND | `/app/chat.startSession` | 새 `ChatSession`을 시작하고 session 전용 destination을 반환한다. |
+| Client SEND | `/app/chat.sendMessage` | 기존 session에 사용자 메시지를 저장하고 구독자에게 이벤트를 발행한다. |
+| Client SEND | `/app/chat.session.leave` | 사용자가 session을 떠났음을 기록하고 cleanup을 수행한다. |
+| Client SUBSCRIBE | `/topic/chat.{sessionId}` | session 참여자가 실시간 메시지 이벤트를 받는다. |
+| Client SUBSCRIBE | `/queue/chat.{sessionId}` | session 생성 결과와 개인 오류처럼 session 단위 응답을 받는다. |
+| Agent SUBSCRIBE | `/topic/chat.queue` | 상담 에이전트가 새 OPEN session과 queue 변화를 받는다. |
+
+### CONNECT Headers
+
+```text
+CONNECT
+Authorization: Bearer {accessToken}
+accept-version: 1.2
+heart-beat: 10000,10000
+```
+
+### Request
+
+**SEND /app/chat.startSession**
+
+```json
+{ "domainPackVersionId": 101, "channel": "WEB" }
+```
+
+**SEND /app/chat.sendMessage**
+
+```json
+{ "sessionId": 5001, "content": "주문 취소하고 싶어요.", "messageType": "TEXT" }
+```
+
+**SEND /app/chat.session.leave**
+
+```json
+{ "sessionId": 5001 }
+```
+
+### Response
+
+**MESSAGE /topic/chat.{sessionId}**, **MESSAGE /queue/chat.{sessionId}**
+
+```json
+{ "sessionId": 5001, "seqNo": 3, "senderRole": "USER", "content": "주문 취소하고 싶어요.", "messageType": "TEXT", "timestamp": "2026-05-20T10:00:00Z" }
+```
+
+**MESSAGE /topic/chat.queue**는 `sessionId`, `status`, `domainPackVersionId`, `channel`, `startedAt`으로 queue 변화를 알린다. JWT 누락, 만료, refresh token 사용은 connection 단계에서 거부한다. 알 수 없는 session과 invalid payload는 가능한 경우 `/queue/chat.{sessionId}`로 오류 event를 보낸다.
+
+---
+
+## Class Design
+
+### DDD Layered Structure
+
+```mermaid
+classDiagram
+    class WebSocketConfig {
+        +registerStompEndpoints(StompEndpointRegistry): void
+        +configureMessageBroker(MessageBrokerRegistry): void
+        +configureClientInboundChannel(ChannelRegistration): void
+    }
+    class ChatStompController {
+        +startSession(StartSessionPayload, Principal): ChatMessageEvent
+        +sendMessage(ChatMessagePayload, Principal): void
+        +leaveSession(LeaveSessionPayload, Principal): void
+    }
+    class ChatSessionService {
+        +startSession(StartSessionCommand): ChatMessageEvent
+        +sendMessage(SendMessageCommand): ChatMessageEvent
+        +leaveSession(LeaveSessionCommand): void
+    }
+    class JwtChannelInterceptor {
+        +preSend(Message, MessageChannel): Message
+    }
+    class ChatSession {
+        +create(Long, Long, ChatSessionStatus, String, String): ChatSession
+        +activate(): void
+        +resolve(): void
+        +closeSession(): void
+    }
+    class ChatMessage {
+        +create(Long, Integer, String, String, String): ChatMessage
+    }
+    WebSocketConfig --> JwtChannelInterceptor
+    ChatStompController --> ChatSessionService
+    ChatSessionService --> ChatSession
+    ChatSessionService --> ChatMessage
+    JwtChannelInterceptor --> JwtService
+```
+
+### presentation/
+
+| Class | Contract |
+|-------|----------|
+| `WebSocketConfig` | STOMP endpoint registration, `setAllowedOrigins()`, `WebSocketMessageBrokerConfigurer` 설정을 담당한다. endpoint는 `/ws`, application prefix는 `/app`, broker prefix는 `/topic`, `/queue`를 기본값으로 둔다. |
+| `ChatStompController` | `@MessageMapping("/chat.startSession")`, `@MessageMapping("/chat.sendMessage")`, `@MessageMapping("/chat.session.leave")` handler를 제공하고 service에 위임한다. |
+| `dto/ChatMessagePayload` | incoming message DTO. 필드: `sessionId`, `content`, `messageType`. |
+| `dto/ChatMessageEvent` | outgoing message event. 필드: `sessionId`, `seqNo`, `senderRole`, `content`, `messageType`, `timestamp`. |
+| `dto/StartSessionPayload` | session start request. 필드: `domainPackVersionId`, `channel`. |
+
+### application/
+
+| Class | Contract |
+|-------|----------|
+| `ChatSessionService` | 기존 `ConsultationService` 흐름을 확장하거나 재사용한다. `startSession()`, `sendMessage()`, `leaveSession()`가 WebSocket message flow의 단일 진입점이다. |
+| `startSession()` | `Principal` userId를 시작 사용자로 사용하고 `ChatSession.create(workspaceId, domainPackVersionId, OPEN, channel, metaJson)`로 session을 만든다. `metaJson.stompSessionId`를 기록하고 `/topic/chat.queue`로 발행할 event를 반환한다. |
+| `sendMessage()` | session 접근 권한을 확인하고 다음 `seqNo`를 계산한 뒤 `ChatMessage.create(sessionId, seqNo, "USER", messageType, content)`로 저장한다. workflow 결과가 있으면 assistant/system event도 발행한다. |
+| `leaveSession()` | WebSocket 이탈 정보를 session metadata에 반영한다. 종료 조건이 충족되면 `ChatSession.closeSession()`을 사용한다. |
+
+### domain/
+
+`ChatSession`은 기존 entity를 재사용한다. 상태값은 `OPEN`, `ACTIVE`, `RESOLVED`, `COMPLETED`이며 상태 전이는 의미 있는 도메인 메서드로 수행한다. `ChatMessage`는 기존 entity를 재사용하고 `create()` validation과 `payloadJson="{}"` 기본값을 유지한다. `ChatSessionStatus`도 기존 enum을 그대로 사용한다.
+
+### infrastructure/
+
+`JwtChannelInterceptor`는 `ChannelInterceptor` 구현체다. `CONNECT` frame에서 JWT를 추출하고 `JwtService.parseClaims()`, `isAccessToken()`, `isTokenValid()`로 검증한다. 성공하면 claims subject userId로 `Principal`을 설정하고, 실패하면 `preSend()`에서 `null`을 반환한다. 기존 `ChatSessionRepository`, `ChatMessageRepository`를 재사용하고 WebSocket 전용 repository를 새로 만들지 않는다.
+
+---
+
+## WebSocket Authentication
+
+JWT access token은 STOMP `CONNECT` header로 전달한다. `JwtChannelInterceptor`는 `CONNECT` message만 인증 대상으로 처리하고, `Authorization: Bearer {accessToken}` 또는 native `accessToken` header에서 token을 추출한다.
+
+검증 순서: `JwtService.parseClaims(token)` 호출, `JwtService.isAccessToken(claims)` 확인, `JwtService.isTokenValid(claims)` 확인, `claims.getSubject()`를 `Long userId`로 변환, STOMP accessor에 `Principal` 설정. 어느 단계든 실패하면 `preSend()`에서 `null`을 반환해 연결을 거부한다. HTTP `JwtAuthenticationFilter`처럼 `role` claim은 authority 구성에 쓸 수 있지만, WebSocket 연결의 최소 식별 기준은 subject userId다.
+
+---
+
+## Database
+
+신규 table이나 migration은 추가하지 않는다. `.agent/docs/schema.md`의 `7.7 runtime` DDL을 재사용한다.
+
+- `runtime.chat_session`: 기존 컬럼 `id`, `workspace_id`, `domain_pack_version_id`, `status`, `channel`, `started_by`, `meta_json`, `started_at`, `ended_at`을 사용한다. `meta_json`에는 `stompSessionId`, `lastConnectedUserId`, `lastConnectedAt`을 저장한다.
+- `runtime.chat_message`: 기존 컬럼 `id`, `chat_session_id`, `seq_no`, `sender_role`, `message_type`, `content`, `payload_json`, `created_at`을 사용한다. `(chat_session_id, seq_no)` unique 제약을 유지하고 `payload_json`에는 `workflowExecutionId`, `nodeId`, `edgeId`, `decisionType` 같은 workflow integration mapping을 저장한다.
+
+---
+
+## Tests
+
+### Unit Tests
+
+**`JwtChannelInterceptorTest`**: valid access token은 `Principal` subject userId를 설정한다. missing token, expired token, refresh token은 `preSend(CONNECT)`에서 `null`을 반환한다. non CONNECT frame은 JWT validation 없이 통과한다.
+
+### Integration Tests
+
+**`ChatStompControllerTest`** uses `@SpringBootTest(webEnvironment = RANDOM_PORT)` and `WebSocketStompClient`.
+
+| Case | Flow | Expected |
+|------|------|----------|
+| valid JWT can exchange messages | Connect with valid JWT, subscribe to `/topic/chat.{sessionId}`, send `/app/chat.startSession`, send `/app/chat.sendMessage`. | Subscriber receives `ChatMessageEvent` with matching `sessionId`, `content`, `senderRole="USER"`. |
+| missing JWT rejects connection | Connect without JWT. | STOMP connection is rejected before subscription or send succeeds. |
+| leave session records cleanup | Connect with valid JWT, start session, send `/app/chat.session.leave`. | Session metadata or status reflects leave handling without deleting messages. |
+
+Persistence assertions: `runtime.chat_session` row has `status="OPEN"`, requested `domainPackVersionId`, requested `channel`, and `meta_json.stompSessionId`; `runtime.chat_message` row has increasing `seq_no`, `sender_role="USER"`, `message_type="TEXT"`, and request content.

--- a/.agent/specs/5.3.2.md
+++ b/.agent/specs/5.3.2.md
@@ -66,7 +66,7 @@ sequenceDiagram
 | Client SEND | `/app/chat.sendMessage` | 기존 session에 사용자 메시지를 저장하고 구독자에게 이벤트를 발행한다. |
 | Client SEND | `/app/chat.session.leave` | 사용자가 session을 떠났음을 기록하고 cleanup을 수행한다. |
 | Client SUBSCRIBE | `/topic/chat.{sessionId}` | session 참여자가 실시간 메시지 이벤트를 받는다. |
-| Client SUBSCRIBE | `/queue/chat.{sessionId}` | session 생성 결과와 session scoped error를 받는다. |
+| Client SUBSCRIBE | `/queue/chat.{sessionId}` | session 참여자가 session 스코프 응답을 받는다. (에러는 `/user/queue/chat.errors`로 수신) |
 | Client SUBSCRIBE | `/user/queue/chat.startSession` | startSession 결과와 생성 실패 응답을 받는다. |
 | Agent SUBSCRIBE | `/topic/chat.queue` | `ROLE_AGENT`만 새 OPEN session과 queue 변화를 받는다. 비상담원 구독은 STOMP `ERROR` frame으로 거부한다. |
 
@@ -122,8 +122,8 @@ Error payload shape은 다음과 같다.
 | Error | Destination | Payload |
 |-------|-------------|---------|
 | Missing, expired, refresh JWT on `CONNECT` | STOMP connection rejection or `ERROR` frame | body 없이 연결 거부 |
-| `UNKNOWN_SESSION` from send/leave | `/queue/chat.{sessionId}` | `error`, `message`, `sessionId`, `timestamp` |
-| `VALIDATION_ERROR` with `sessionId` | `/queue/chat.{sessionId}` | `error`, `message`, `sessionId`, `field`, `timestamp` |
+| `UNKNOWN_SESSION` from send/leave | `/user/queue/chat.errors` | `error`, `message`, `sessionId`, `timestamp` |
+| `VALIDATION_ERROR` with `sessionId` | `/user/queue/chat.errors` | `error`, `message`, `sessionId`, `field`, `timestamp` |
 | `VALIDATION_ERROR` before session creation | STOMP `ERROR` frame | `error`, `message`, `field`, `timestamp` |
 
 ---

--- a/.agent/specs/5.3.2.md
+++ b/.agent/specs/5.3.2.md
@@ -178,7 +178,7 @@ Boundary note: 아키텍처 문서상 `chat-demo`는 데모 화면과 WebSocket 
 | `ChatStompController` | `@MessageMapping("/chat.startSession")`, `@MessageMapping("/chat.sendMessage")`, `@MessageMapping("/chat.session.leave")` handler를 제공하고 service에 위임한다. |
 | `dto/ChatMessagePayload` | incoming message DTO. 필드: `sessionId`, `content`, `messageType`. |
 | `dto/ChatMessageEvent` | outgoing message event. 필드: `sessionId`, `seqNo`, `senderRole`, `content`, `messageType`, `timestamp`. |
-| `dto/StartSessionPayload` | session start request. 필드: `domainPackVersionId`, `channel`; `channel`은 `WEB` 또는 `DEMO_WEB`. |
+| `dto/StartSessionPayload` | session start request. 필드: `workspaceId`, `domainPackVersionId`, `channel`; `channel`은 `WEB` 또는 `DEMO_WEB`. |
 | `dto/LeaveSessionPayload` | session leave request. 필드: `sessionId`. |
 
 ### application/
@@ -186,8 +186,8 @@ Boundary note: 아키텍처 문서상 `chat-demo`는 데모 화면과 WebSocket 
 | Class | Contract |
 |-------|----------|
 | `ChatSessionService` | 기존 `ConsultationService` 흐름을 확장하거나 재사용한다. `startSession()`, `sendMessage()`, `leaveSession()`가 WebSocket message flow의 단일 진입점이다. |
-| `startSession()` | `Principal` userId의 workspace membership에서 `workspaceId`를 결정한다. 단일 transaction 안에서 `ChatSession.create(workspaceId, domainPackVersionId, OPEN, channel, metaJson, userId)`로 `startedBy(userId)`를 함께 전달해 원자적으로 생성한다. session 생성 결과는 `/user/queue/chat.startSession`으로 반환하고, 새 OPEN session 알림만 `/topic/chat.queue`로 발행한다. |
-| `sendMessage()` | session 접근 권한을 확인하고 다음 `seqNo`를 계산한 뒤 `ChatMessage.create(sessionId, seqNo, "USER", messageType, content)`로 저장한다. workflow 결과가 있으면 assistant/system event도 발행한다. |
+| `startSession()` | `StartSessionPayload.workspaceId`를 명시적으로 전달받고, 서버는 `Principal` userId의 해당 workspace membership을 검증한다. `workspaceId` 누락 또는 유효하지 않은 workspace는 validation error로 거부하고 session을 생성하지 않는다. 단일 transaction 안에서 `ChatSession.create(workspaceId, domainPackVersionId, OPEN, channel, metaJson, userId)`로 `startedBy(userId)`를 함께 전달해 원자적으로 생성한다. session 생성 결과는 `/user/queue/chat.startSession`으로 반환하고, 새 OPEN session 알림만 `/topic/chat.queue`로 발행한다. |
+| `sendMessage()` | `sessionId` 존재, session의 `workspaceId`에 `Principal` membership, `session.startedBy == Principal userId`, session status가 `OPEN`인지 확인한다. 조건 불충족 시 메시지를 저장하지 않고 `NOT_FOUND`, `FORBIDDEN`, `SESSION_CLOSED` 등 구분 가능한 error payload를 개인 큐(`/user/queue/chat.errors`)로 반환한다. seqNo는 단일 transaction에서 session row를 write lock으로 잠근 뒤 현재 최대 `seqNo` 기준으로 다음 번호를 배정한다. `ChatMessage.create(sessionId, seqNo, "USER", messageType, content)`로 저장한다. workflow 결과가 있으면 같은 lock 범위 안에서 연속 `seqNo`로 assistant/system event도 저장한다. |
 | `leaveSession()` | WebSocket 이탈 정보를 session metadata에 반영한다. 종료 조건이 충족되면 `ChatSession.closeSession()`을 사용한다. |
 
 ### domain/

--- a/.agent/specs/5.3.2.md
+++ b/.agent/specs/5.3.2.md
@@ -33,13 +33,14 @@ sequenceDiagram
     interceptor ->> interceptor: isAccessToken(claims) && isTokenValid(claims)
     interceptor -->> broker: Principal(userId)
     broker -->> client: CONNECTED
-    client ->> broker: SUBSCRIBE /topic/chat.{sessionId}
+    client ->> broker: SUBSCRIBE /user/queue/chat.startSession
     client ->> broker: SEND /app/chat.startSession
     broker ->> ctrl: startSession(StartSessionPayload, Principal)
     ctrl ->> svc: startSession(payload, userId)
     svc ->> repo: save(ChatSession OPEN, metaJson.stompSessionId)
     repo ->> db: INSERT runtime.chat_session
-    broker -->> client: MESSAGE /queue/chat.{sessionId}
+    broker -->> client: MESSAGE /user/queue/chat.startSession (sessionId)
+    client ->> broker: SUBSCRIBE /topic/chat.{sessionId}
     client ->> broker: SEND /app/chat.sendMessage
     broker ->> ctrl: sendMessage(ChatMessagePayload, Principal)
     ctrl ->> svc: sendMessage(payload, userId)
@@ -61,12 +62,13 @@ sequenceDiagram
 
 | Direction | Destination | Description |
 |-----------|-------------|-------------|
-| Client SEND | `/app/chat.startSession` | 새 `ChatSession`을 시작하고 결과는 `/queue/chat.{sessionId}`로 반환한다. |
+| Client SEND | `/app/chat.startSession` | 새 `ChatSession`을 시작한다. 결과는 session id가 정해지기 전에도 구독 가능한 `/user/queue/chat.startSession`으로 반환한다. |
 | Client SEND | `/app/chat.sendMessage` | 기존 session에 사용자 메시지를 저장하고 구독자에게 이벤트를 발행한다. |
 | Client SEND | `/app/chat.session.leave` | 사용자가 session을 떠났음을 기록하고 cleanup을 수행한다. |
 | Client SUBSCRIBE | `/topic/chat.{sessionId}` | session 참여자가 실시간 메시지 이벤트를 받는다. |
 | Client SUBSCRIBE | `/queue/chat.{sessionId}` | session 생성 결과와 session scoped error를 받는다. |
-| Agent SUBSCRIBE | `/topic/chat.queue` | 상담 에이전트만 새 OPEN session과 queue 변화를 받는다. |
+| Client SUBSCRIBE | `/user/queue/chat.startSession` | startSession 결과와 생성 실패 응답을 받는다. |
+| Agent SUBSCRIBE | `/topic/chat.queue` | `ROLE_AGENT`만 새 OPEN session과 queue 변화를 받는다. 비상담원 구독은 STOMP `ERROR` frame으로 거부한다. |
 
 ### CONNECT Headers
 
@@ -101,7 +103,7 @@ heart-beat: 10000,10000
 
 ### Response
 
-**MESSAGE /topic/chat.{sessionId}**, **MESSAGE /queue/chat.{sessionId}**
+**MESSAGE /user/queue/chat.startSession**, **MESSAGE /topic/chat.{sessionId}**, **MESSAGE /queue/chat.{sessionId}**
 
 ```json
 { "sessionId": 5001, "seqNo": 3, "senderRole": "USER", "content": "주문 취소하고 싶어요.", "messageType": "TEXT", "timestamp": "2026-05-20T10:00:00Z" }
@@ -151,7 +153,7 @@ classDiagram
         +preSend(Message, MessageChannel): Message
     }
     class ChatSession {
-        +create(Long, Long, ChatSessionStatus, String, String): ChatSession
+        +create(Long, Long, ChatSessionStatus, String, String, Long): ChatSession
         +activate(): void
         +resolve(): void
         +closeSession(): void
@@ -184,7 +186,7 @@ Boundary note: 아키텍처 문서상 `chat-demo`는 데모 화면과 WebSocket 
 | Class | Contract |
 |-------|----------|
 | `ChatSessionService` | 기존 `ConsultationService` 흐름을 확장하거나 재사용한다. `startSession()`, `sendMessage()`, `leaveSession()`가 WebSocket message flow의 단일 진입점이다. |
-| `startSession()` | `Principal` userId의 workspace membership에서 `workspaceId`를 결정한다. `ChatSession.create(workspaceId, domainPackVersionId, OPEN, channel, metaJson)`는 `startedBy`를 받지 않으므로 생성 후 별도 domain/service method로 `startedBy`를 설정한다. session 생성 결과는 `/queue/chat.{sessionId}`로 반환하고, 새 OPEN session 알림만 `/topic/chat.queue`로 발행한다. |
+| `startSession()` | `Principal` userId의 workspace membership에서 `workspaceId`를 결정한다. 단일 transaction 안에서 `ChatSession.create(workspaceId, domainPackVersionId, OPEN, channel, metaJson, userId)`로 `startedBy(userId)`를 함께 전달해 원자적으로 생성한다. session 생성 결과는 `/user/queue/chat.startSession`으로 반환하고, 새 OPEN session 알림만 `/topic/chat.queue`로 발행한다. |
 | `sendMessage()` | session 접근 권한을 확인하고 다음 `seqNo`를 계산한 뒤 `ChatMessage.create(sessionId, seqNo, "USER", messageType, content)`로 저장한다. workflow 결과가 있으면 assistant/system event도 발행한다. |
 | `leaveSession()` | WebSocket 이탈 정보를 session metadata에 반영한다. 종료 조건이 충족되면 `ChatSession.closeSession()`을 사용한다. |
 
@@ -203,6 +205,8 @@ Boundary note: 아키텍처 문서상 `chat-demo`는 데모 화면과 WebSocket 
 JWT access token은 STOMP `CONNECT` header로 전달한다. `JwtChannelInterceptor`는 `CONNECT` message만 인증 대상으로 처리하고, `Authorization: Bearer {accessToken}` 또는 native `accessToken` header에서 token을 추출한다.
 
 검증 순서: `JwtService.parseClaims(token)` 호출, `JwtService.isAccessToken(claims)` 확인, `JwtService.isTokenValid(claims)` 확인, `claims.getSubject()`를 `Long userId`로 변환, STOMP accessor에 `Principal` 설정. 어느 단계든 실패하면 `preSend()`에서 `null`을 반환해 연결을 거부한다. HTTP `JwtAuthenticationFilter`처럼 `role` claim은 authority 구성에 쓸 수 있지만, WebSocket 연결의 최소 식별 기준은 subject userId다.
+
+`JwtChannelInterceptor`는 `/topic/chat.queue` SUBSCRIBE에 대해 role 기반 인가도 수행한다. `ROLE_AGENT` authority를 가진 사용자만 구독할 수 있으며, 권한 없는 SUBSCRIBE는 `{"error":"FORBIDDEN"}` payload를 담은 STOMP `ERROR` frame과 connection-level denial detail로 거부한다.
 
 ---
 
@@ -227,7 +231,7 @@ JWT access token은 STOMP `CONNECT` header로 전달한다. `JwtChannelIntercept
 
 | Case | Flow | Expected |
 |------|------|----------|
-| valid JWT can exchange messages | Connect with valid JWT, subscribe to `/topic/chat.{sessionId}`, send `/app/chat.startSession`, send `/app/chat.sendMessage`. | Subscriber receives `ChatMessageEvent` with matching `sessionId`, `content`, `senderRole="USER"`. |
+| valid JWT can exchange messages | Connect with valid JWT, subscribe to `/user/queue/chat.startSession`, send `/app/chat.startSession`, then subscribe to `/topic/chat.{sessionId}` and send `/app/chat.sendMessage`. | Subscriber receives `ChatMessageEvent` with matching `sessionId`, `content`, `senderRole="USER"`. |
 | missing JWT rejects connection | Connect without JWT. | STOMP connection is rejected before subscription or send succeeds. |
 | leave session records cleanup | Connect with valid JWT, start session, send `/app/chat.session.leave`. | Session metadata or status reflects leave handling without deleting messages. |
 


### PR DESCRIPTION
# [BE-5.3.2] STOMP WebSocket 채팅 인프라 스펙

## 요약

STOMP over WebSocket 기반 채팅 인프라 API와 아키텍처 스펙 문서 작성.

## 변경사항

- `.agent/specs/5.3.2.md` (234 lines)
  - Goal: STOMP over WebSocket 채팅 인프라 정의
  - Sequence Diagram: CONNECT → SUBSCRIBE → SEND → MESSAGE → DISCONNECT 전체 흐름
  - STOMP API: 6개 destination 정의
  - Error Handling: UNKNOWN_SESSION, VALIDATION_ERROR 등 명시적 에러 payload 정의
  - Class Design: DDD 4계층 (WebSocketConfig, ChatStompController, ChatSessionService, JwtChannelInterceptor)
  - WebSocket Authentication: JWT CONNECT header → ChannelInterceptor 검증
  - Database: runtime.chat_session, runtime.chat_message (기존 DDL 재사용)
  - Tests: unit test + integration test 시나리오

## 검토사항

- 기존 ChatSession/ChatMessage/ChatSessionStatus 엔티티 재사용
- 기존 JwtService.parseClaims(), isAccessToken(), isTokenValid() 재사용
- 신규 DB migration 없음
- Bounded context: workflow-runtime presentation layer 확장
- payload_json: 4.1.4 실행 metadata와 호환

## Final Wave 검증

| Reviewer | Verdict |
|----------|---------|
| F1 Plan Compliance (oracle) | APPROVE |
| F2 Spec Completeness | APPROVE (1회 fix 후) |
| F3 Scope Fidelity (deep) | APPROVE |
| F4 Cross-Plan Consistency | APPROVE (1회 fix 후) |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 실시간 채팅 추가: STOMP-over-WebSocket을 통한 채팅 세션 및 메시지의 실시간 송수신 지원
  * 연결 시 JWT 인증으로 사용자 식별 및 세션 관리 적용

* **문서화**
  * 채팅 API, STOMP 목적지(연결/전송/구독) 및 메시지/응답/오류 페이로드 형식 명세
  * DDD 관점의 아키텍처 책임·계약과 데이터 호환 규칙(추가 DB 마이그레이션 불필요) 문서화
  * 운영·테스트 시나리오 및 영속성 기대값 포함

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ajou-2026-1-capstone-5/ostone/pull/256?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->