### PR TITLE
feat(workflow-runtime): 상담사 개입 기능 구현 (5.3.4)

### DIFF
--- a/backend/src/main/java/com/init/workflowruntime/application/CounselorService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/CounselorService.java
@@ -47,9 +47,12 @@ public class CounselorService {
   public CounselorSessionResponse assignSession(Long counselorId, Long sessionId) {
     validateCounselorId(counselorId);
 
-    ChatSession session = chatSessionRepository
-        .findByIdForUpdate(sessionId)
-        .orElseThrow(() -> new NotFoundException("SESSION_NOT_FOUND", "Session not found: " + sessionId));
+    ChatSession session =
+        chatSessionRepository
+            .findByIdForUpdate(sessionId)
+            .orElseThrow(
+                () ->
+                    new NotFoundException("SESSION_NOT_FOUND", "Session not found: " + sessionId));
 
     session.assignTo(counselorId);
     chatSessionRepository.save(session);
@@ -63,12 +66,16 @@ public class CounselorService {
   public CounselorSessionResponse releaseSession(Long sessionId, Long counselorId) {
     validateCounselorId(counselorId);
 
-    ChatSession session = chatSessionRepository
-        .findByIdForUpdate(sessionId)
-        .orElseThrow(() -> new NotFoundException("SESSION_NOT_FOUND", "Session not found: " + sessionId));
+    ChatSession session =
+        chatSessionRepository
+            .findByIdForUpdate(sessionId)
+            .orElseThrow(
+                () ->
+                    new NotFoundException("SESSION_NOT_FOUND", "Session not found: " + sessionId));
 
     if (!Objects.equals(counselorId, session.getAssignedCounselorId())) {
-      throw new BadRequestException("SESSION_NOT_ASSIGNED_TO_COUNSELOR",
+      throw new BadRequestException(
+          "SESSION_NOT_ASSIGNED_TO_COUNSELOR",
           "Session " + sessionId + " is not assigned to counselor: " + counselorId);
     }
 
@@ -79,9 +86,12 @@ public class CounselorService {
   }
 
   public boolean isSessionAssigned(Long sessionId) {
-    ChatSession session = chatSessionRepository
-        .findById(sessionId)
-        .orElseThrow(() -> new NotFoundException("SESSION_NOT_FOUND", "Session not found: " + sessionId));
+    ChatSession session =
+        chatSessionRepository
+            .findById(sessionId)
+            .orElseThrow(
+                () ->
+                    new NotFoundException("SESSION_NOT_FOUND", "Session not found: " + sessionId));
     return session.getAssignedCounselorId() != null;
   }
 
@@ -92,28 +102,35 @@ public class CounselorService {
   }
 
   @Transactional
-  public ChatMessageResponse sendCounselorMessage(Long sessionId, String content, Long counselorId) {
+  public ChatMessageResponse sendCounselorMessage(
+      Long sessionId, String content, Long counselorId) {
     validateCounselorId(counselorId);
 
-    ChatSession session = chatSessionRepository
-        .findByIdForUpdate(sessionId)
-        .orElseThrow(() -> new NotFoundException("SESSION_NOT_FOUND", "Session not found: " + sessionId));
+    ChatSession session =
+        chatSessionRepository
+            .findByIdForUpdate(sessionId)
+            .orElseThrow(
+                () ->
+                    new NotFoundException("SESSION_NOT_FOUND", "Session not found: " + sessionId));
 
     if (!Objects.equals(counselorId, session.getAssignedCounselorId())) {
-      throw new BadRequestException("SESSION_NOT_ASSIGNED",
+      throw new BadRequestException(
+          "SESSION_NOT_ASSIGNED",
           "Session " + sessionId + " is not assigned to counselor: " + counselorId);
     }
 
     ChatSessionStatus status = session.getStatus();
     if (status != ChatSessionStatus.ACTIVE) {
-      throw new BadRequestException("SESSION_NOT_ACTIVE",
+      throw new BadRequestException(
+          "SESSION_NOT_ACTIVE",
           "Session " + sessionId + " is not ACTIVE; current status: " + status);
     }
 
-    Integer nextSeqNo = chatMessageRepository
-        .findTopByChatSessionIdOrderBySeqNoDesc(sessionId)
-        .map(msg -> msg.getSeqNo() + 1)
-        .orElse(1);
+    Integer nextSeqNo =
+        chatMessageRepository
+            .findTopByChatSessionIdOrderBySeqNoDesc(sessionId)
+            .map(msg -> msg.getSeqNo() + 1)
+            .orElse(1);
 
     ChatMessage message = ChatMessage.create(sessionId, nextSeqNo, "COUNSELOR", "TEXT", content);
     ChatMessage savedMessage = chatMessageRepository.save(message);
@@ -153,12 +170,17 @@ public class CounselorService {
       sessionPage = chatSessionRepository.findAll(pageRequest);
     }
 
-    List<ChatSessionResponse> content = sessionPage.getContent().stream()
-        .map(ChatSessionResponse::from)
-        .collect(Collectors.toList());
+    List<ChatSessionResponse> content =
+        sessionPage.getContent().stream()
+            .map(ChatSessionResponse::from)
+            .collect(Collectors.toList());
 
-    return new CounselorSessionResponse(content, sessionPage.getNumber(), sessionPage.getSize(),
-        sessionPage.getTotalElements(), sessionPage.getTotalPages());
+    return new CounselorSessionResponse(
+        content,
+        sessionPage.getNumber(),
+        sessionPage.getSize(),
+        sessionPage.getTotalElements(),
+        sessionPage.getTotalPages());
   }
 
   private void validateCounselorId(Long counselorId) {

--- a/backend/src/main/java/com/init/workflowruntime/application/CounselorService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/CounselorService.java
@@ -1,0 +1,152 @@
+package com.init.workflowruntime.application;
+
+import com.init.shared.application.exception.BadRequestException;
+import com.init.shared.application.exception.NotFoundException;
+import com.init.workflowruntime.application.dto.ChatMessageResponse;
+import com.init.workflowruntime.application.dto.ChatSessionResponse;
+import com.init.workflowruntime.application.dto.CounselorSessionResponse;
+import com.init.workflowruntime.domain.ChatMessage;
+import com.init.workflowruntime.domain.ChatMessageRepository;
+import com.init.workflowruntime.domain.ChatSession;
+import com.init.workflowruntime.domain.ChatSessionRepository;
+import com.init.workflowruntime.domain.ChatSessionStatus;
+import com.init.workflowruntime.domain.event.SessionAssignedEvent;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+@Service
+@Transactional(readOnly = true)
+public class CounselorService {
+
+  private final ChatSessionRepository chatSessionRepository;
+  private final ChatMessageRepository chatMessageRepository;
+  private final SimpMessagingTemplate messagingTemplate;
+  private final ApplicationEventPublisher eventPublisher;
+
+  public CounselorService(
+      ChatSessionRepository chatSessionRepository,
+      ChatMessageRepository chatMessageRepository,
+      SimpMessagingTemplate messagingTemplate,
+      ApplicationEventPublisher eventPublisher) {
+    this.chatSessionRepository = chatSessionRepository;
+    this.chatMessageRepository = chatMessageRepository;
+    this.messagingTemplate = messagingTemplate;
+    this.eventPublisher = eventPublisher;
+  }
+
+  @Transactional
+  public CounselorSessionResponse assignSession(Long counselorId, Long sessionId) {
+    ChatSession session = chatSessionRepository
+        .findByIdForUpdate(sessionId)
+        .orElseThrow(() -> new NotFoundException("SESSION_NOT_FOUND", "Session not found: " + sessionId));
+
+    session.assignTo(counselorId);
+    chatSessionRepository.save(session);
+
+    eventPublisher.publishEvent(new SessionAssignedEvent(sessionId, counselorId));
+
+    return CounselorSessionResponse.from(session);
+  }
+
+  @Transactional
+  public CounselorSessionResponse releaseSession(Long sessionId, Long counselorId) {
+    ChatSession session = chatSessionRepository
+        .findByIdForUpdate(sessionId)
+        .orElseThrow(() -> new NotFoundException("SESSION_NOT_FOUND", "Session not found: " + sessionId));
+
+    if (!counselorId.equals(session.getAssignedCounselorId())) {
+      throw new BadRequestException("SESSION_NOT_ASSIGNED_TO_COUNSELOR",
+          "Session " + sessionId + " is not assigned to counselor: " + counselorId);
+    }
+
+    session.releaseFrom();
+    chatSessionRepository.save(session);
+
+    return CounselorSessionResponse.from(session);
+  }
+
+  public boolean isSessionAssigned(Long sessionId) {
+    ChatSession session = chatSessionRepository
+        .findById(sessionId)
+        .orElseThrow(() -> new NotFoundException("SESSION_NOT_FOUND", "Session not found: " + sessionId));
+    return session.getAssignedCounselorId() != null;
+  }
+
+  public List<ChatSessionResponse> getAssignedSessions(Long counselorId) {
+    return chatSessionRepository.findByAssignedCounselorId(counselorId).stream()
+        .map(ChatSessionResponse::from)
+        .collect(Collectors.toList());
+  }
+
+  @Transactional
+  public ChatMessageResponse sendCounselorMessage(Long sessionId, String content, Long counselorId) {
+    ChatSession session = chatSessionRepository
+        .findByIdForUpdate(sessionId)
+        .orElseThrow(() -> new NotFoundException("SESSION_NOT_FOUND", "Session not found: " + sessionId));
+
+    if (!counselorId.equals(session.getAssignedCounselorId())) {
+      throw new BadRequestException("SESSION_NOT_ASSIGNED",
+          "Session " + sessionId + " is not assigned to counselor: " + counselorId);
+    }
+
+    ChatSessionStatus status = session.getStatus();
+    if (status != ChatSessionStatus.ACTIVE) {
+      throw new BadRequestException("SESSION_NOT_ACTIVE",
+          "Session " + sessionId + " is not ACTIVE; current status: " + status);
+    }
+
+    Integer nextSeqNo = chatMessageRepository
+        .findTopByChatSessionIdOrderBySeqNoDesc(sessionId)
+        .map(msg -> msg.getSeqNo() + 1)
+        .orElse(1);
+
+    ChatMessage message = ChatMessage.create(sessionId, nextSeqNo, "COUNSELOR", "TEXT", content);
+    chatMessageRepository.save(message);
+
+    ChatMessageResponse response = ChatMessageResponse.from(message);
+    String destination = "/topic/chat." + sessionId;
+    TransactionSynchronizationManager.registerSynchronization(
+        new TransactionSynchronization() {
+          @Override
+          public void afterCommit() {
+            messagingTemplate.convertAndSend(destination, response);
+          }
+        });
+
+    return response;
+  }
+
+  public CounselorSessionResponse getSessions(String status, int page, int size) {
+    ChatSessionStatus sessionStatus = null;
+    if (status != null && !status.isBlank()) {
+      try {
+        sessionStatus = ChatSessionStatus.valueOf(status.toUpperCase());
+      } catch (IllegalArgumentException e) {
+        throw new BadRequestException("UNSUPPORTED_STATUS", "Unsupported status: " + status);
+      }
+    }
+
+    PageRequest pageRequest = PageRequest.of(page, size);
+    Page<ChatSession> sessionPage;
+    if (sessionStatus != null) {
+      sessionPage = chatSessionRepository.findByStatus(sessionStatus, pageRequest);
+    } else {
+      sessionPage = chatSessionRepository.findAll(pageRequest);
+    }
+
+    List<ChatSessionResponse> content = sessionPage.getContent().stream()
+        .map(ChatSessionResponse::from)
+        .collect(Collectors.toList());
+
+    return new CounselorSessionResponse(content, sessionPage.getNumber(), sessionPage.getSize(),
+        sessionPage.getTotalElements(), sessionPage.getTotalPages());
+  }
+}

--- a/backend/src/main/java/com/init/workflowruntime/application/CounselorService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/CounselorService.java
@@ -12,6 +12,7 @@ import com.init.workflowruntime.domain.ChatSessionRepository;
 import com.init.workflowruntime.domain.ChatSessionStatus;
 import com.init.workflowruntime.domain.event.SessionAssignedEvent;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
@@ -44,6 +45,8 @@ public class CounselorService {
 
   @Transactional
   public CounselorSessionResponse assignSession(Long counselorId, Long sessionId) {
+    validateCounselorId(counselorId);
+
     ChatSession session = chatSessionRepository
         .findByIdForUpdate(sessionId)
         .orElseThrow(() -> new NotFoundException("SESSION_NOT_FOUND", "Session not found: " + sessionId));
@@ -58,11 +61,13 @@ public class CounselorService {
 
   @Transactional
   public CounselorSessionResponse releaseSession(Long sessionId, Long counselorId) {
+    validateCounselorId(counselorId);
+
     ChatSession session = chatSessionRepository
         .findByIdForUpdate(sessionId)
         .orElseThrow(() -> new NotFoundException("SESSION_NOT_FOUND", "Session not found: " + sessionId));
 
-    if (!counselorId.equals(session.getAssignedCounselorId())) {
+    if (!Objects.equals(counselorId, session.getAssignedCounselorId())) {
       throw new BadRequestException("SESSION_NOT_ASSIGNED_TO_COUNSELOR",
           "Session " + sessionId + " is not assigned to counselor: " + counselorId);
     }
@@ -88,11 +93,13 @@ public class CounselorService {
 
   @Transactional
   public ChatMessageResponse sendCounselorMessage(Long sessionId, String content, Long counselorId) {
+    validateCounselorId(counselorId);
+
     ChatSession session = chatSessionRepository
         .findByIdForUpdate(sessionId)
         .orElseThrow(() -> new NotFoundException("SESSION_NOT_FOUND", "Session not found: " + sessionId));
 
-    if (!counselorId.equals(session.getAssignedCounselorId())) {
+    if (!Objects.equals(counselorId, session.getAssignedCounselorId())) {
       throw new BadRequestException("SESSION_NOT_ASSIGNED",
           "Session " + sessionId + " is not assigned to counselor: " + counselorId);
     }
@@ -125,6 +132,10 @@ public class CounselorService {
   }
 
   public CounselorSessionResponse getSessions(String status, int page, int size) {
+    if (page < 0 || size <= 0) {
+      throw new BadRequestException("INVALID_PAGING", "page must be >= 0 and size must be > 0");
+    }
+
     ChatSessionStatus sessionStatus = null;
     if (status != null && !status.isBlank()) {
       try {
@@ -148,5 +159,11 @@ public class CounselorService {
 
     return new CounselorSessionResponse(content, sessionPage.getNumber(), sessionPage.getSize(),
         sessionPage.getTotalElements(), sessionPage.getTotalPages());
+  }
+
+  private void validateCounselorId(Long counselorId) {
+    if (counselorId == null) {
+      throw new BadRequestException("INVALID_COUNSELOR_ID", "counselorId must not be null");
+    }
   }
 }

--- a/backend/src/main/java/com/init/workflowruntime/application/CounselorService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/CounselorService.java
@@ -109,9 +109,9 @@ public class CounselorService {
         .orElse(1);
 
     ChatMessage message = ChatMessage.create(sessionId, nextSeqNo, "COUNSELOR", "TEXT", content);
-    chatMessageRepository.save(message);
+    ChatMessage savedMessage = chatMessageRepository.save(message);
 
-    ChatMessageResponse response = ChatMessageResponse.from(message);
+    ChatMessageResponse response = ChatMessageResponse.from(savedMessage);
     String destination = "/topic/chat." + sessionId;
     TransactionSynchronizationManager.registerSynchronization(
         new TransactionSynchronization() {

--- a/backend/src/main/java/com/init/workflowruntime/application/SessionAssignedEventListener.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/SessionAssignedEventListener.java
@@ -1,0 +1,47 @@
+package com.init.workflowruntime.application;
+
+import com.init.workflowruntime.application.dto.ChatSessionResponse;
+import com.init.workflowruntime.domain.ChatSession;
+import com.init.workflowruntime.domain.ChatSessionRepository;
+import com.init.workflowruntime.domain.event.SessionAssignedEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+@Component
+@Transactional(readOnly = true)
+public class SessionAssignedEventListener {
+
+  private final ChatSessionRepository chatSessionRepository;
+  private final SimpMessagingTemplate messagingTemplate;
+
+  public SessionAssignedEventListener(
+      ChatSessionRepository chatSessionRepository,
+      SimpMessagingTemplate messagingTemplate) {
+    this.chatSessionRepository = chatSessionRepository;
+    this.messagingTemplate = messagingTemplate;
+  }
+
+  @EventListener
+  @Transactional
+  public void handleSessionAssigned(SessionAssignedEvent event) {
+    ChatSession session = chatSessionRepository
+        .findById(event.sessionId())
+        .orElse(null);
+    if (session == null) return;
+
+    ChatSessionResponse response = ChatSessionResponse.from(session);
+    String counselorQueue = "/queue/counselor.notifications";
+    TransactionSynchronizationManager.registerSynchronization(
+        new TransactionSynchronization() {
+          @Override
+          public void afterCommit() {
+            messagingTemplate.convertAndSendToUser(
+                String.valueOf(event.counselorId()), counselorQueue, response);
+          }
+        });
+  }
+}

--- a/backend/src/main/java/com/init/workflowruntime/application/SessionAssignedEventListener.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/SessionAssignedEventListener.java
@@ -19,8 +19,7 @@ public class SessionAssignedEventListener {
   private final SimpMessagingTemplate messagingTemplate;
 
   public SessionAssignedEventListener(
-      ChatSessionRepository chatSessionRepository,
-      SimpMessagingTemplate messagingTemplate) {
+      ChatSessionRepository chatSessionRepository, SimpMessagingTemplate messagingTemplate) {
     this.chatSessionRepository = chatSessionRepository;
     this.messagingTemplate = messagingTemplate;
   }
@@ -28,9 +27,7 @@ public class SessionAssignedEventListener {
   @EventListener
   @Transactional
   public void handleSessionAssigned(SessionAssignedEvent event) {
-    ChatSession session = chatSessionRepository
-        .findById(event.sessionId())
-        .orElse(null);
+    ChatSession session = chatSessionRepository.findById(event.sessionId()).orElse(null);
     if (session == null) return;
 
     ChatSessionResponse response = ChatSessionResponse.from(session);

--- a/backend/src/main/java/com/init/workflowruntime/application/dto/CounselorMessageRequest.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/dto/CounselorMessageRequest.java
@@ -5,14 +5,23 @@ import jakarta.validation.constraints.NotNull;
 
 public class CounselorMessageRequest {
 
-  @NotNull
-  private Long sessionId;
+  @NotNull private Long sessionId;
 
-  @NotBlank
-  private String content;
+  @NotBlank private String content;
 
-  public Long getSessionId() { return sessionId; }
-  public void setSessionId(Long sessionId) { this.sessionId = sessionId; }
-  public String getContent() { return content; }
-  public void setContent(String content) { this.content = content; }
+  public Long getSessionId() {
+    return sessionId;
+  }
+
+  public void setSessionId(Long sessionId) {
+    this.sessionId = sessionId;
+  }
+
+  public String getContent() {
+    return content;
+  }
+
+  public void setContent(String content) {
+    this.content = content;
+  }
 }

--- a/backend/src/main/java/com/init/workflowruntime/application/dto/CounselorMessageRequest.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/dto/CounselorMessageRequest.java
@@ -1,0 +1,18 @@
+package com.init.workflowruntime.application.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public class CounselorMessageRequest {
+
+  @NotNull
+  private Long sessionId;
+
+  @NotBlank
+  private String content;
+
+  public Long getSessionId() { return sessionId; }
+  public void setSessionId(Long sessionId) { this.sessionId = sessionId; }
+  public String getContent() { return content; }
+  public void setContent(String content) { this.content = content; }
+}

--- a/backend/src/main/java/com/init/workflowruntime/application/dto/CounselorSessionResponse.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/dto/CounselorSessionResponse.java
@@ -1,0 +1,64 @@
+package com.init.workflowruntime.application.dto;
+
+import com.init.workflowruntime.domain.ChatSession;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+public class CounselorSessionResponse {
+  private Long id;
+  private String status;
+  private String channel;
+  private String metaJson;
+  private OffsetDateTime startedAt;
+  private Long assignedCounselorId;
+
+  private List<ChatSessionResponse> content;
+  private int page;
+  private int size;
+  private long totalElements;
+  private int totalPages;
+
+  public CounselorSessionResponse() {}
+
+  public CounselorSessionResponse(List<ChatSessionResponse> content, int page, int size, long totalElements, int totalPages) {
+    this.content = content;
+    this.page = page;
+    this.size = size;
+    this.totalElements = totalElements;
+    this.totalPages = totalPages;
+  }
+
+  public static CounselorSessionResponse from(ChatSession session) {
+    CounselorSessionResponse resp = new CounselorSessionResponse();
+    resp.id = session.getId();
+    resp.status = session.getStatus() != null ? session.getStatus().name() : null;
+    resp.channel = session.getChannel();
+    resp.metaJson = session.getMetaJson();
+    resp.startedAt = session.getStartedAt();
+    resp.assignedCounselorId = session.getAssignedCounselorId();
+    return resp;
+  }
+
+  public Long getId() { return id; }
+  public void setId(Long id) { this.id = id; }
+  public String getStatus() { return status; }
+  public void setStatus(String status) { this.status = status; }
+  public String getChannel() { return channel; }
+  public void setChannel(String channel) { this.channel = channel; }
+  public String getMetaJson() { return metaJson; }
+  public void setMetaJson(String metaJson) { this.metaJson = metaJson; }
+  public OffsetDateTime getStartedAt() { return startedAt; }
+  public void setStartedAt(OffsetDateTime startedAt) { this.startedAt = startedAt; }
+  public Long getAssignedCounselorId() { return assignedCounselorId; }
+  public void setAssignedCounselorId(Long assignedCounselorId) { this.assignedCounselorId = assignedCounselorId; }
+  public List<ChatSessionResponse> getContent() { return content; }
+  public void setContent(List<ChatSessionResponse> content) { this.content = content; }
+  public int getPage() { return page; }
+  public void setPage(int page) { this.page = page; }
+  public int getSize() { return size; }
+  public void setSize(int size) { this.size = size; }
+  public long getTotalElements() { return totalElements; }
+  public void setTotalElements(long totalElements) { this.totalElements = totalElements; }
+  public int getTotalPages() { return totalPages; }
+  public void setTotalPages(int totalPages) { this.totalPages = totalPages; }
+}

--- a/backend/src/main/java/com/init/workflowruntime/application/dto/CounselorSessionResponse.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/dto/CounselorSessionResponse.java
@@ -20,7 +20,8 @@ public class CounselorSessionResponse {
 
   public CounselorSessionResponse() {}
 
-  public CounselorSessionResponse(List<ChatSessionResponse> content, int page, int size, long totalElements, int totalPages) {
+  public CounselorSessionResponse(
+      List<ChatSessionResponse> content, int page, int size, long totalElements, int totalPages) {
     this.content = content;
     this.page = page;
     this.size = size;
@@ -39,26 +40,91 @@ public class CounselorSessionResponse {
     return resp;
   }
 
-  public Long getId() { return id; }
-  public void setId(Long id) { this.id = id; }
-  public String getStatus() { return status; }
-  public void setStatus(String status) { this.status = status; }
-  public String getChannel() { return channel; }
-  public void setChannel(String channel) { this.channel = channel; }
-  public String getMetaJson() { return metaJson; }
-  public void setMetaJson(String metaJson) { this.metaJson = metaJson; }
-  public OffsetDateTime getStartedAt() { return startedAt; }
-  public void setStartedAt(OffsetDateTime startedAt) { this.startedAt = startedAt; }
-  public Long getAssignedCounselorId() { return assignedCounselorId; }
-  public void setAssignedCounselorId(Long assignedCounselorId) { this.assignedCounselorId = assignedCounselorId; }
-  public List<ChatSessionResponse> getContent() { return content; }
-  public void setContent(List<ChatSessionResponse> content) { this.content = content; }
-  public int getPage() { return page; }
-  public void setPage(int page) { this.page = page; }
-  public int getSize() { return size; }
-  public void setSize(int size) { this.size = size; }
-  public long getTotalElements() { return totalElements; }
-  public void setTotalElements(long totalElements) { this.totalElements = totalElements; }
-  public int getTotalPages() { return totalPages; }
-  public void setTotalPages(int totalPages) { this.totalPages = totalPages; }
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public String getStatus() {
+    return status;
+  }
+
+  public void setStatus(String status) {
+    this.status = status;
+  }
+
+  public String getChannel() {
+    return channel;
+  }
+
+  public void setChannel(String channel) {
+    this.channel = channel;
+  }
+
+  public String getMetaJson() {
+    return metaJson;
+  }
+
+  public void setMetaJson(String metaJson) {
+    this.metaJson = metaJson;
+  }
+
+  public OffsetDateTime getStartedAt() {
+    return startedAt;
+  }
+
+  public void setStartedAt(OffsetDateTime startedAt) {
+    this.startedAt = startedAt;
+  }
+
+  public Long getAssignedCounselorId() {
+    return assignedCounselorId;
+  }
+
+  public void setAssignedCounselorId(Long assignedCounselorId) {
+    this.assignedCounselorId = assignedCounselorId;
+  }
+
+  public List<ChatSessionResponse> getContent() {
+    return content;
+  }
+
+  public void setContent(List<ChatSessionResponse> content) {
+    this.content = content;
+  }
+
+  public int getPage() {
+    return page;
+  }
+
+  public void setPage(int page) {
+    this.page = page;
+  }
+
+  public int getSize() {
+    return size;
+  }
+
+  public void setSize(int size) {
+    this.size = size;
+  }
+
+  public long getTotalElements() {
+    return totalElements;
+  }
+
+  public void setTotalElements(long totalElements) {
+    this.totalElements = totalElements;
+  }
+
+  public int getTotalPages() {
+    return totalPages;
+  }
+
+  public void setTotalPages(int totalPages) {
+    this.totalPages = totalPages;
+  }
 }

--- a/backend/src/main/java/com/init/workflowruntime/domain/ChatSession.java
+++ b/backend/src/main/java/com/init/workflowruntime/domain/ChatSession.java
@@ -149,7 +149,8 @@ public class ChatSession {
           "assignTo() requires status OPEN but was " + this.status);
     }
     if (this.assignedCounselorId != null) {
-      throw new InvalidSessionStateException("Session already assigned to counselor: " + this.assignedCounselorId);
+      throw new InvalidSessionStateException(
+          "Session already assigned to counselor: " + this.assignedCounselorId);
     }
     this.assignedCounselorId = counselorId;
     this.status = ChatSessionStatus.ACTIVE;

--- a/backend/src/main/java/com/init/workflowruntime/domain/ChatSession.java
+++ b/backend/src/main/java/com/init/workflowruntime/domain/ChatSession.java
@@ -146,7 +146,7 @@ public class ChatSession {
           "assignTo() requires status OPEN but was " + this.status);
     }
     if (this.assignedCounselorId != null) {
-      throw new IllegalStateException("Session already assigned to counselor: " + this.assignedCounselorId);
+      throw new InvalidSessionStateException("Session already assigned to counselor: " + this.assignedCounselorId);
     }
     this.assignedCounselorId = counselorId;
     this.status = ChatSessionStatus.ACTIVE;
@@ -154,7 +154,7 @@ public class ChatSession {
 
   public void releaseFrom() {
     if (this.assignedCounselorId == null) {
-      throw new IllegalStateException("Session is not assigned to any counselor");
+      throw new InvalidSessionStateException("Session is not assigned to any counselor");
     }
     this.assignedCounselorId = null;
     this.status = ChatSessionStatus.OPEN;

--- a/backend/src/main/java/com/init/workflowruntime/domain/ChatSession.java
+++ b/backend/src/main/java/com/init/workflowruntime/domain/ChatSession.java
@@ -141,6 +141,9 @@ public class ChatSession {
   }
 
   public void assignTo(Long counselorId) {
+    if (counselorId == null) {
+      throw new InvalidSessionStateException("assignTo() requires non-null counselorId");
+    }
     if (this.status != ChatSessionStatus.OPEN) {
       throw new InvalidSessionStateException(
           "assignTo() requires status OPEN but was " + this.status);
@@ -153,6 +156,10 @@ public class ChatSession {
   }
 
   public void releaseFrom() {
+    if (this.status != ChatSessionStatus.ACTIVE) {
+      throw new InvalidSessionStateException(
+          "releaseFrom() requires status ACTIVE but was " + this.status);
+    }
     if (this.assignedCounselorId == null) {
       throw new InvalidSessionStateException("Session is not assigned to any counselor");
     }

--- a/backend/src/main/java/com/init/workflowruntime/domain/ChatSession.java
+++ b/backend/src/main/java/com/init/workflowruntime/domain/ChatSession.java
@@ -35,6 +35,9 @@ public class ChatSession {
   @Column(nullable = false)
   private String channel;
 
+  @Column(name = "assigned_counselor_id")
+  private Long assignedCounselorId;
+
   @Column(name = "started_by")
   private Long startedBy;
 
@@ -96,6 +99,10 @@ public class ChatSession {
     return startedBy;
   }
 
+  public Long getAssignedCounselorId() {
+    return assignedCounselorId;
+  }
+
   public String getMetaJson() {
     return metaJson;
   }
@@ -131,6 +138,26 @@ public class ChatSession {
     }
     this.status = ChatSessionStatus.OPEN;
     this.endedAt = null;
+  }
+
+  public void assignTo(Long counselorId) {
+    if (this.status != ChatSessionStatus.OPEN) {
+      throw new InvalidSessionStateException(
+          "assignTo() requires status OPEN but was " + this.status);
+    }
+    if (this.assignedCounselorId != null) {
+      throw new IllegalStateException("Session already assigned to counselor: " + this.assignedCounselorId);
+    }
+    this.assignedCounselorId = counselorId;
+    this.status = ChatSessionStatus.ACTIVE;
+  }
+
+  public void releaseFrom() {
+    if (this.assignedCounselorId == null) {
+      throw new IllegalStateException("Session is not assigned to any counselor");
+    }
+    this.assignedCounselorId = null;
+    this.status = ChatSessionStatus.OPEN;
   }
 
   /** 세션을 종료하고 상태를 COMPLETED로 변경하며 종료 시각을 기록합니다. */

--- a/backend/src/main/java/com/init/workflowruntime/domain/ChatSessionRepository.java
+++ b/backend/src/main/java/com/init/workflowruntime/domain/ChatSessionRepository.java
@@ -2,6 +2,8 @@ package com.init.workflowruntime.domain;
 
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 /** 채팅 세션 영속성을 위한 도메인 포트 인터페이스입니다. */
 public interface ChatSessionRepository {
@@ -13,4 +15,10 @@ public interface ChatSessionRepository {
   ChatSession save(ChatSession session);
 
   List<ChatSession> findByStatusOrderByStartedAtDesc(ChatSessionStatus status);
+
+  List<ChatSession> findByAssignedCounselorId(Long counselorId);
+
+  Page<ChatSession> findByStatus(ChatSessionStatus status, Pageable pageable);
+
+  Page<ChatSession> findAll(Pageable pageable);
 }

--- a/backend/src/main/java/com/init/workflowruntime/domain/event/SessionAssignedEvent.java
+++ b/backend/src/main/java/com/init/workflowruntime/domain/event/SessionAssignedEvent.java
@@ -1,0 +1,3 @@
+package com.init.workflowruntime.domain.event;
+
+public record SessionAssignedEvent(Long sessionId, Long counselorId) {}

--- a/backend/src/main/java/com/init/workflowruntime/infrastructure/persistence/JpaChatSessionRepository.java
+++ b/backend/src/main/java/com/init/workflowruntime/infrastructure/persistence/JpaChatSessionRepository.java
@@ -2,8 +2,12 @@ package com.init.workflowruntime.infrastructure.persistence;
 
 import com.init.workflowruntime.domain.ChatSession;
 import com.init.workflowruntime.domain.ChatSessionRepository;
+import com.init.workflowruntime.domain.ChatSessionStatus;
 import jakarta.persistence.LockModeType;
+import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
@@ -19,4 +23,10 @@ public interface JpaChatSessionRepository
   @Query("select cs from ChatSession cs where cs.id = :id")
   @Override
   Optional<ChatSession> findByIdForUpdate(@Param("id") Long id);
+
+  @Override
+  List<ChatSession> findByAssignedCounselorId(Long counselorId);
+
+  @Override
+  Page<ChatSession> findByStatus(ChatSessionStatus status, Pageable pageable);
 }

--- a/backend/src/main/java/com/init/workflowruntime/presentation/CounselorSessionController.java
+++ b/backend/src/main/java/com/init/workflowruntime/presentation/CounselorSessionController.java
@@ -1,0 +1,42 @@
+package com.init.workflowruntime.presentation;
+
+import com.init.workflowruntime.application.CounselorService;
+import com.init.workflowruntime.application.dto.CounselorSessionResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/consultation")
+public class CounselorSessionController {
+
+  private final CounselorService counselorService;
+
+  public CounselorSessionController(CounselorService counselorService) {
+    this.counselorService = counselorService;
+  }
+
+  @PostMapping("/sessions/{sessionId}/assign")
+  public ResponseEntity<CounselorSessionResponse> assignSession(
+      @PathVariable Long sessionId, @RequestParam Long counselorId) {
+    return ResponseEntity.ok(counselorService.assignSession(counselorId, sessionId));
+  }
+
+  @PostMapping("/sessions/{sessionId}/release")
+  public ResponseEntity<CounselorSessionResponse> releaseSession(
+      @PathVariable Long sessionId, @RequestParam Long counselorId) {
+    return ResponseEntity.ok(counselorService.releaseSession(sessionId, counselorId));
+  }
+
+  @GetMapping("/sessions")
+  public ResponseEntity<CounselorSessionResponse> getSessions(
+      @RequestParam(required = false) String status,
+      @RequestParam(defaultValue = "0") int page,
+      @RequestParam(defaultValue = "20") int size) {
+    return ResponseEntity.ok(counselorService.getSessions(status, page, size));
+  }
+}

--- a/backend/src/main/java/com/init/workflowruntime/presentation/CounselorSessionController.java
+++ b/backend/src/main/java/com/init/workflowruntime/presentation/CounselorSessionController.java
@@ -2,6 +2,8 @@ package com.init.workflowruntime.presentation;
 
 import com.init.workflowruntime.application.CounselorService;
 import com.init.workflowruntime.application.dto.CounselorSessionResponse;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -35,8 +37,8 @@ public class CounselorSessionController {
   @GetMapping("/sessions")
   public ResponseEntity<CounselorSessionResponse> getSessions(
       @RequestParam(required = false) String status,
-      @RequestParam(defaultValue = "0") int page,
-      @RequestParam(defaultValue = "20") int size) {
+      @RequestParam(defaultValue = "0") @Min(0) int page,
+      @RequestParam(defaultValue = "20") @Min(1) @Max(100) int size) {
     return ResponseEntity.ok(counselorService.getSessions(status, page, size));
   }
 }

--- a/backend/src/main/java/com/init/workflowruntime/presentation/CounselorWebSocketController.java
+++ b/backend/src/main/java/com/init/workflowruntime/presentation/CounselorWebSocketController.java
@@ -1,5 +1,6 @@
 package com.init.workflowruntime.presentation;
 
+import com.init.shared.application.exception.BadRequestException;
 import com.init.shared.application.exception.BusinessException;
 import com.init.workflowruntime.application.CounselorService;
 import com.init.workflowruntime.application.dto.ChatMessageResponse;
@@ -28,7 +29,15 @@ public class CounselorWebSocketController {
   @MessageMapping("/chat.counselor.send")
   public ChatMessageResponse sendCounselorMessage(
       @Valid CounselorMessageRequest request, Principal principal) {
-    Long counselorId = Long.parseLong(principal.getName());
+    if (principal == null || principal.getName() == null) {
+      throw new BadRequestException("INVALID_PRINCIPAL", "Counselor principal is required");
+    }
+    final Long counselorId;
+    try {
+      counselorId = Long.valueOf(principal.getName());
+    } catch (NumberFormatException e) {
+      throw new BadRequestException("INVALID_PRINCIPAL", "Counselor id must be numeric");
+    }
     return counselorService.sendCounselorMessage(
         request.getSessionId(), request.getContent(), counselorId);
   }

--- a/backend/src/main/java/com/init/workflowruntime/presentation/CounselorWebSocketController.java
+++ b/backend/src/main/java/com/init/workflowruntime/presentation/CounselorWebSocketController.java
@@ -1,0 +1,46 @@
+package com.init.workflowruntime.presentation;
+
+import com.init.shared.application.exception.BusinessException;
+import com.init.workflowruntime.application.CounselorService;
+import com.init.workflowruntime.application.dto.ChatMessageResponse;
+import com.init.workflowruntime.application.dto.CounselorMessageRequest;
+import jakarta.validation.Valid;
+import java.security.Principal;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.messaging.simp.annotation.SendToUser;
+import org.springframework.stereotype.Controller;
+
+@Controller
+public class CounselorWebSocketController {
+
+  private static final Logger log = LoggerFactory.getLogger(CounselorWebSocketController.class);
+
+  private final CounselorService counselorService;
+
+  public CounselorWebSocketController(CounselorService counselorService) {
+    this.counselorService = counselorService;
+  }
+
+  @MessageMapping("/chat.counselor.send")
+  public ChatMessageResponse sendCounselorMessage(
+      @Valid CounselorMessageRequest request, Principal principal) {
+    Long counselorId = Long.parseLong(principal.getName());
+    return counselorService.sendCounselorMessage(
+        request.getSessionId(), request.getContent(), counselorId);
+  }
+
+  @MessageExceptionHandler
+  @SendToUser("/queue/errors")
+  public ChatMessageResponse handleException(
+      Exception exception, SimpMessageHeaderAccessor headerAccessor) {
+    if (exception instanceof BusinessException be) {
+      return ChatMessageResponse.error(be.getCode(), be.getMessage());
+    }
+    log.error("Counselor WebSocket message processing error", exception);
+    return ChatMessageResponse.error("INTERNAL_ERROR", "서버 오류가 발생했습니다.");
+  }
+}

--- a/backend/src/main/resources/db/changelog/db.changelog-master.sql
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.sql
@@ -750,3 +750,7 @@ ALTER TABLE pack.intent_definition
 ALTER TABLE pack.intent_definition
     ADD CONSTRAINT chk_intent_definition_status
     CHECK (status IN ('DRAFT', 'PUBLISHED', 'REJECTED'));
+
+--changeset init:20260522-add-assigned-counselor-id-to-chat-session
+--comment: Add assigned_counselor_id column to runtime.chat_session for counselor intervention
+ALTER TABLE runtime.chat_session ADD COLUMN assigned_counselor_id BIGINT;

--- a/backend/src/main/resources/db/changelog/db.changelog-master.sql
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.sql
@@ -754,3 +754,12 @@ ALTER TABLE pack.intent_definition
 --changeset init:20260522-add-assigned-counselor-id-to-chat-session
 --comment: Add assigned_counselor_id column to runtime.chat_session for counselor intervention
 ALTER TABLE runtime.chat_session ADD COLUMN assigned_counselor_id BIGINT;
+
+--changeset init:20260522-add-assigned-counselor-id-constraints
+--comment: Add FK and index for assigned counselor lookup
+ALTER TABLE runtime.chat_session
+    ADD CONSTRAINT fk_chat_session_assigned_counselor
+    FOREIGN KEY (assigned_counselor_id) REFERENCES app.app_user(id);
+
+CREATE INDEX idx_chat_session_assigned_counselor_id
+    ON runtime.chat_session (assigned_counselor_id);

--- a/backend/src/test/java/com/init/workflowruntime/application/CounselorServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/CounselorServiceTest.java
@@ -53,8 +53,9 @@ class CounselorServiceTest {
 
   @BeforeEach
   void setUp() {
-    service = new CounselorService(
-        chatSessionRepository, chatMessageRepository, messagingTemplate, eventPublisher);
+    service =
+        new CounselorService(
+            chatSessionRepository, chatMessageRepository, messagingTemplate, eventPublisher);
   }
 
   // ── assignSession ─────────────────────────────────────────────────────────
@@ -171,8 +172,7 @@ class CounselorServiceTest {
   void should_throwNotFound_when_sessionNotFound() {
     given(chatSessionRepository.findById(999L)).willReturn(Optional.empty());
 
-    assertThatThrownBy(() -> service.isSessionAssigned(999L))
-        .isInstanceOf(NotFoundException.class);
+    assertThatThrownBy(() -> service.isSessionAssigned(999L)).isInstanceOf(NotFoundException.class);
   }
 
   // ── getAssignedSessions ───────────────────────────────────────────────────

--- a/backend/src/test/java/com/init/workflowruntime/application/CounselorServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/CounselorServiceTest.java
@@ -18,6 +18,7 @@ import com.init.workflowruntime.domain.ChatMessageRepository;
 import com.init.workflowruntime.domain.ChatSession;
 import com.init.workflowruntime.domain.ChatSessionRepository;
 import com.init.workflowruntime.domain.ChatSessionStatus;
+import com.init.workflowruntime.domain.InvalidSessionStateException;
 import com.init.workflowruntime.domain.event.SessionAssignedEvent;
 import java.util.List;
 import java.util.Optional;
@@ -83,14 +84,14 @@ class CounselorServiceTest {
   }
 
   @Test
-  @DisplayName("assignSession: 이미 배정된 세션 → IllegalStateException")
-  void should_throwIllegalState_when_alreadyAssigned() {
+  @DisplayName("assignSession: 이미 배정된 세션 → InvalidSessionStateException")
+  void should_throwInvalidState_when_alreadyAssigned() {
     ChatSession session = createSession(1L, ChatSessionStatus.OPEN);
     ReflectionTestUtils.setField(session, "assignedCounselorId", 10L);
     given(chatSessionRepository.findByIdForUpdate(1L)).willReturn(Optional.of(session));
 
     assertThatThrownBy(() -> service.assignSession(42L, 1L))
-        .isInstanceOf(IllegalStateException.class)
+        .isInstanceOf(InvalidSessionStateException.class)
         .hasMessageContaining("already assigned");
   }
 

--- a/backend/src/test/java/com/init/workflowruntime/application/CounselorServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/CounselorServiceTest.java
@@ -1,0 +1,308 @@
+package com.init.workflowruntime.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.init.shared.application.exception.BadRequestException;
+import com.init.shared.application.exception.NotFoundException;
+import com.init.workflowruntime.application.dto.ChatMessageResponse;
+import com.init.workflowruntime.application.dto.ChatSessionResponse;
+import com.init.workflowruntime.application.dto.CounselorSessionResponse;
+import com.init.workflowruntime.domain.ChatMessage;
+import com.init.workflowruntime.domain.ChatMessageRepository;
+import com.init.workflowruntime.domain.ChatSession;
+import com.init.workflowruntime.domain.ChatSessionRepository;
+import com.init.workflowruntime.domain.ChatSessionStatus;
+import com.init.workflowruntime.domain.event.SessionAssignedEvent;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CounselorService")
+class CounselorServiceTest {
+
+  @Mock private ChatSessionRepository chatSessionRepository;
+  @Mock private ChatMessageRepository chatMessageRepository;
+  @Mock private SimpMessagingTemplate messagingTemplate;
+  @Mock private ApplicationEventPublisher eventPublisher;
+
+  @Captor private ArgumentCaptor<SessionAssignedEvent> eventCaptor;
+
+  private CounselorService service;
+
+  @BeforeEach
+  void setUp() {
+    service = new CounselorService(
+        chatSessionRepository, chatMessageRepository, messagingTemplate, eventPublisher);
+  }
+
+  // ── assignSession ─────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("assignSession: 정상 배정 → 상태 ACTIVE, 이벤트 발행")
+  void should_assignSession_when_sessionOpen() {
+    ChatSession session = createSession(1L, ChatSessionStatus.OPEN);
+    given(chatSessionRepository.findByIdForUpdate(1L)).willReturn(Optional.of(session));
+
+    CounselorSessionResponse result = service.assignSession(42L, 1L);
+
+    assertThat(result.getStatus()).isEqualTo("ACTIVE");
+    assertThat(result.getAssignedCounselorId()).isEqualTo(42L);
+    verify(chatSessionRepository).save(session);
+    verify(eventPublisher).publishEvent(any(SessionAssignedEvent.class));
+  }
+
+  @Test
+  @DisplayName("assignSession: 세션 없음 → NotFoundException")
+  void should_throwNotFoundException_when_sessionNotFound() {
+    given(chatSessionRepository.findByIdForUpdate(999L)).willReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.assignSession(1L, 999L))
+        .isInstanceOf(NotFoundException.class)
+        .hasMessageContaining("Session not found: 999");
+  }
+
+  @Test
+  @DisplayName("assignSession: 이미 배정된 세션 → IllegalStateException")
+  void should_throwIllegalState_when_alreadyAssigned() {
+    ChatSession session = createSession(1L, ChatSessionStatus.OPEN);
+    ReflectionTestUtils.setField(session, "assignedCounselorId", 10L);
+    given(chatSessionRepository.findByIdForUpdate(1L)).willReturn(Optional.of(session));
+
+    assertThatThrownBy(() -> service.assignSession(42L, 1L))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("already assigned");
+  }
+
+  @Test
+  @DisplayName("assignSession: OPEN이 아닌 세션 → InvalidSessionStateException")
+  void should_throwInvalidState_when_notOpen() {
+    ChatSession session = createSession(1L, ChatSessionStatus.COMPLETED);
+    given(chatSessionRepository.findByIdForUpdate(1L)).willReturn(Optional.of(session));
+
+    assertThatThrownBy(() -> service.assignSession(42L, 1L))
+        .isInstanceOf(com.init.workflowruntime.domain.InvalidSessionStateException.class)
+        .hasMessageContaining("requires status OPEN");
+  }
+
+  // ── releaseSession ────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("releaseSession: 정상 해제 → 상태 OPEN, assignedCounselorId null")
+  void should_releaseSession_when_assignedToCounselor() {
+    ChatSession session = createSession(1L, ChatSessionStatus.ACTIVE);
+    ReflectionTestUtils.setField(session, "assignedCounselorId", 42L);
+    given(chatSessionRepository.findByIdForUpdate(1L)).willReturn(Optional.of(session));
+
+    CounselorSessionResponse result = service.releaseSession(1L, 42L);
+
+    assertThat(result.getStatus()).isEqualTo("OPEN");
+    assertThat(result.getAssignedCounselorId()).isNull();
+    verify(chatSessionRepository).save(session);
+  }
+
+  @Test
+  @DisplayName("releaseSession: 다른 상담사가 해제 시도 → BadRequestException")
+  void should_throwBadRequest_when_notAssignedToThisCounselor() {
+    ChatSession session = createSession(1L, ChatSessionStatus.ACTIVE);
+    ReflectionTestUtils.setField(session, "assignedCounselorId", 42L);
+    given(chatSessionRepository.findByIdForUpdate(1L)).willReturn(Optional.of(session));
+
+    assertThatThrownBy(() -> service.releaseSession(1L, 99L))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("not assigned to counselor");
+  }
+
+  @Test
+  @DisplayName("releaseSession: 배정되지 않은 세션 → BadRequestException")
+  void should_throwBadRequest_when_notAssignedToRelease() {
+    ChatSession session = createSession(1L, ChatSessionStatus.OPEN);
+    given(chatSessionRepository.findByIdForUpdate(1L)).willReturn(Optional.of(session));
+
+    assertThatThrownBy(() -> service.releaseSession(1L, 42L))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("not assigned to counselor");
+  }
+
+  // ── isSessionAssigned ─────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("isSessionAssigned: 배정됨 → true")
+  void should_returnTrue_when_assigned() {
+    ChatSession session = createSession(1L, ChatSessionStatus.ACTIVE);
+    ReflectionTestUtils.setField(session, "assignedCounselorId", 42L);
+    given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+
+    assertThat(service.isSessionAssigned(1L)).isTrue();
+  }
+
+  @Test
+  @DisplayName("isSessionAssigned: 미배정 → false")
+  void should_returnFalse_when_notAssigned() {
+    ChatSession session = createSession(1L, ChatSessionStatus.OPEN);
+    given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+
+    assertThat(service.isSessionAssigned(1L)).isFalse();
+  }
+
+  @Test
+  @DisplayName("isSessionAssigned: 세션 없음 → NotFoundException")
+  void should_throwNotFound_when_sessionNotFound() {
+    given(chatSessionRepository.findById(999L)).willReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.isSessionAssigned(999L))
+        .isInstanceOf(NotFoundException.class);
+  }
+
+  // ── getAssignedSessions ───────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("getAssignedSessions: 상담사별 배정 세션 목록 반환")
+  void should_returnAssignedSessions() {
+    ChatSession session = createSession(1L, ChatSessionStatus.ACTIVE);
+    given(chatSessionRepository.findByAssignedCounselorId(42L)).willReturn(List.of(session));
+
+    List<ChatSessionResponse> result = service.getAssignedSessions(42L);
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).getId()).isEqualTo(1L);
+  }
+
+  @Test
+  @DisplayName("getAssignedSessions: 배정 세션 없음 → 빈 목록")
+  void should_returnEmptyList_when_noAssignedSessions() {
+    given(chatSessionRepository.findByAssignedCounselorId(99L)).willReturn(List.of());
+
+    List<ChatSessionResponse> result = service.getAssignedSessions(99L);
+
+    assertThat(result).isEmpty();
+  }
+
+  // ── sendCounselorMessage ──────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("sendCounselorMessage: 정상 → 메시지 저장 및 afterCommit broadcast")
+  void should_sendAndBroadcast_when_valid() {
+    ChatSession session = createSession(1L, ChatSessionStatus.ACTIVE);
+    ReflectionTestUtils.setField(session, "assignedCounselorId", 42L);
+    given(chatSessionRepository.findByIdForUpdate(1L)).willReturn(Optional.of(session));
+
+    given(chatMessageRepository.findTopByChatSessionIdOrderBySeqNoDesc(1L))
+        .willReturn(Optional.empty());
+
+    ChatMessage savedMsg = createMessage(1L, 1, "COUNSELOR", "Hello from counselor");
+    given(chatMessageRepository.save(any())).willReturn(savedMsg);
+
+    TransactionSynchronizationManager.initSynchronization();
+    try {
+      ChatMessageResponse result = service.sendCounselorMessage(1L, "Hello from counselor", 42L);
+
+      assertThat(result).isNotNull();
+      assertThat(result.content()).isEqualTo("Hello from counselor");
+      assertThat(result.senderRole()).isEqualTo("COUNSELOR");
+      verify(chatMessageRepository).save(any());
+
+      verify(messagingTemplate, never()).convertAndSend(anyString(), any(Object.class));
+
+      TransactionSynchronizationManager.getSynchronizations().forEach(s -> s.afterCommit());
+
+      verify(messagingTemplate).convertAndSend("/topic/chat.1", result);
+    } finally {
+      TransactionSynchronizationManager.clearSynchronization();
+    }
+  }
+
+  @Test
+  @DisplayName("sendCounselorMessage: 배정되지 않은 상담사 → BadRequestException")
+  void should_throwBadRequest_when_counselorNotAssignedToSend() {
+    ChatSession session = createSession(1L, ChatSessionStatus.ACTIVE);
+    ReflectionTestUtils.setField(session, "assignedCounselorId", 10L);
+    given(chatSessionRepository.findByIdForUpdate(1L)).willReturn(Optional.of(session));
+
+    assertThatThrownBy(() -> service.sendCounselorMessage(1L, "Hello", 42L))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("not assigned to counselor");
+  }
+
+  @Test
+  @DisplayName("sendCounselorMessage: 세션이 ACTIVE가 아님 → BadRequestException")
+  void should_throwBadRequest_when_sessionNotActive() {
+    ChatSession session = createSession(1L, ChatSessionStatus.OPEN);
+    ReflectionTestUtils.setField(session, "assignedCounselorId", 42L);
+    given(chatSessionRepository.findByIdForUpdate(1L)).willReturn(Optional.of(session));
+
+    assertThatThrownBy(() -> service.sendCounselorMessage(1L, "Hello", 42L))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("not ACTIVE");
+  }
+
+  // ── getSessions ───────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("getSessions: 상태 필터 없음 → 전체 세션 페이지 반환")
+  void should_returnAllSessions_when_noStatusFilter() {
+    ChatSession session = createSession(1L, ChatSessionStatus.OPEN);
+    Page<ChatSession> page = new PageImpl<>(List.of(session));
+    given(chatSessionRepository.findAll(any(Pageable.class))).willReturn(page);
+
+    CounselorSessionResponse result = service.getSessions(null, 0, 20);
+
+    assertThat(result.getContent()).hasSize(1);
+    assertThat(result.getTotalElements()).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("getSessions: 상태 필터 있음 → 필터링된 페이지 반환")
+  void should_returnFilteredSessions_when_statusGiven() {
+    ChatSession session = createSession(1L, ChatSessionStatus.OPEN);
+    Page<ChatSession> page = new PageImpl<>(List.of(session));
+    given(chatSessionRepository.findByStatus(any(ChatSessionStatus.class), any(Pageable.class)))
+        .willReturn(page);
+
+    CounselorSessionResponse result = service.getSessions("OPEN", 0, 20);
+
+    assertThat(result.getContent()).hasSize(1);
+  }
+
+  @Test
+  @DisplayName("getSessions: 지원하지 않는 상태 → BadRequestException")
+  void should_throwBadRequest_when_invalidStatus() {
+    assertThatThrownBy(() -> service.getSessions("INVALID", 0, 20))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("Unsupported status");
+  }
+
+  // ── helpers ───────────────────────────────────────────────────────────────
+
+  private ChatSession createSession(Long id, ChatSessionStatus status) {
+    ChatSession session = ChatSession.create(1L, 1L, status, "WEB", "{}");
+    ReflectionTestUtils.setField(session, "id", id);
+    return session;
+  }
+
+  private ChatMessage createMessage(Long sessionId, int seqNo, String role, String content) {
+    ChatMessage msg = ChatMessage.create(sessionId, seqNo, role, "TEXT", content);
+    ReflectionTestUtils.setField(msg, "id", 1L);
+    return msg;
+  }
+}

--- a/backend/src/test/java/com/init/workflowruntime/presentation/CounselorSessionControllerTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/presentation/CounselorSessionControllerTest.java
@@ -1,0 +1,148 @@
+package com.init.workflowruntime.presentation;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.init.shared.application.exception.BadRequestException;
+import com.init.shared.application.exception.NotFoundException;
+import com.init.shared.infrastructure.security.JwtAuthenticationFilter;
+import com.init.workflowruntime.application.CounselorService;
+import com.init.workflowruntime.application.dto.CounselorSessionResponse;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(
+    value = CounselorSessionController.class,
+    excludeFilters =
+        @ComponentScan.Filter(
+            type = FilterType.ASSIGNABLE_TYPE,
+            classes = JwtAuthenticationFilter.class))
+@AutoConfigureMockMvc(addFilters = false)
+class CounselorSessionControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @SuppressWarnings("removal")
+  @MockBean
+  private CounselorService counselorService;
+
+  @Test
+  @DisplayName("POST /api/v1/consultation/sessions/{id}/assign - 배정 성공")
+  void should_assignSession_when_validRequest() throws Exception {
+    CounselorSessionResponse response = new CounselorSessionResponse();
+    response.setId(1L);
+    response.setStatus("ACTIVE");
+    response.setAssignedCounselorId(42L);
+    response.setChannel("WEB");
+    response.setStartedAt(OffsetDateTime.now());
+
+    given(counselorService.assignSession(eq(42L), eq(1L))).willReturn(response);
+
+    mockMvc
+        .perform(post("/api/v1/consultation/sessions/1/assign").param("counselorId", "42"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(1))
+        .andExpect(jsonPath("$.status").value("ACTIVE"))
+        .andExpect(jsonPath("$.assignedCounselorId").value(42));
+  }
+
+  @Test
+  @DisplayName("POST /api/v1/consultation/sessions/{id}/assign - 세션 없음 → 404")
+  void should_return404_when_sessionNotFound() throws Exception {
+    given(counselorService.assignSession(eq(1L), eq(999L)))
+        .willThrow(new NotFoundException("SESSION_NOT_FOUND", "Session not found: 999"));
+
+    mockMvc
+        .perform(post("/api/v1/consultation/sessions/999/assign").param("counselorId", "1"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("SESSION_NOT_FOUND"));
+  }
+
+  @Test
+  @DisplayName("POST /api/v1/consultation/sessions/{id}/assign - 이미 배정됨 → 400")
+  void should_return400_when_alreadyAssigned() throws Exception {
+    given(counselorService.assignSession(eq(1L), eq(999L)))
+        .willThrow(new BadRequestException("ALREADY_ASSIGNED", "Session already assigned"));
+
+    mockMvc
+        .perform(post("/api/v1/consultation/sessions/999/assign").param("counselorId", "1"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("ALREADY_ASSIGNED"));
+  }
+
+  @Test
+  @DisplayName("POST /api/v1/consultation/sessions/{id}/release - 해제 성공")
+  void should_releaseSession_when_validRequest() throws Exception {
+    CounselorSessionResponse response = new CounselorSessionResponse();
+    response.setId(1L);
+    response.setStatus("OPEN");
+    response.setAssignedCounselorId(null);
+
+    given(counselorService.releaseSession(eq(1L), eq(42L))).willReturn(response);
+
+    mockMvc
+        .perform(post("/api/v1/consultation/sessions/1/release").param("counselorId", "42"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.status").value("OPEN"));
+  }
+
+  @Test
+  @DisplayName("GET /api/v1/consultation/sessions - 전체 세션 목록 조회")
+  void should_returnSessions_when_noStatusFilter() throws Exception {
+    CounselorSessionResponse response = new CounselorSessionResponse(List.of(), 0, 20, 0, 0);
+
+    given(counselorService.getSessions(eq(null), eq(0), eq(20))).willReturn(response);
+
+    mockMvc
+        .perform(get("/api/v1/consultation/sessions").param("page", "0").param("size", "20"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content").isArray());
+  }
+
+  @Test
+  @DisplayName("GET /api/v1/consultation/sessions - 상태 필터 조회")
+  void should_returnSessions_when_statusFilter() throws Exception {
+    CounselorSessionResponse response = new CounselorSessionResponse(List.of(), 0, 20, 0, 0);
+
+    given(counselorService.getSessions(eq("OPEN"), eq(0), eq(20))).willReturn(response);
+
+    mockMvc
+        .perform(
+            get("/api/v1/consultation/sessions")
+                .param("status", "OPEN")
+                .param("page", "0")
+                .param("size", "20"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content").isArray());
+  }
+
+  @Test
+  @DisplayName("GET /api/v1/consultation/sessions - 유효하지 않은 상태 → 400")
+  void should_return400_when_invalidStatus() throws Exception {
+    given(counselorService.getSessions(eq("INVALID"), anyInt(), anyInt()))
+        .willThrow(new BadRequestException("UNSUPPORTED_STATUS", "Unsupported status: INVALID"));
+
+    mockMvc
+        .perform(
+            get("/api/v1/consultation/sessions")
+                .param("status", "INVALID")
+                .param("page", "0")
+                .param("size", "20"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("UNSUPPORTED_STATUS"));
+  }
+}

--- a/backend/src/test/java/com/init/workflowruntime/presentation/CounselorWebSocketControllerTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/presentation/CounselorWebSocketControllerTest.java
@@ -1,0 +1,114 @@
+package com.init.workflowruntime.presentation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.init.shared.application.exception.BadRequestException;
+import com.init.shared.application.exception.NotFoundException;
+import com.init.workflowruntime.application.CounselorService;
+import com.init.workflowruntime.application.dto.ChatMessageResponse;
+import com.init.workflowruntime.application.dto.CounselorMessageRequest;
+import java.security.Principal;
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CounselorWebSocketController")
+class CounselorWebSocketControllerTest {
+
+  @Mock private CounselorService counselorService;
+
+  private CounselorWebSocketController controller;
+
+  @BeforeEach
+  void setUp() {
+    controller = new CounselorWebSocketController(counselorService);
+  }
+
+  @Test
+  @DisplayName("sendCounselorMessage: 정상 요청 → 서비스 호출 및 응답 반환")
+  void should_returnResponse_when_validRequest() {
+    CounselorMessageRequest request = new CounselorMessageRequest();
+    request.setSessionId(1L);
+    request.setContent("Counselor message");
+
+    Principal principal = () -> "42";
+
+    ChatMessageResponse expected =
+        new ChatMessageResponse(10L, 1, "COUNSELOR", "TEXT", "Counselor message", OffsetDateTime.now());
+
+    given(counselorService.sendCounselorMessage(1L, "Counselor message", 42L))
+        .willReturn(expected);
+
+    ChatMessageResponse result = controller.sendCounselorMessage(request, principal);
+
+    assertThat(result).isEqualTo(expected);
+    assertThat(result.senderRole()).isEqualTo("COUNSELOR");
+  }
+
+  @Test
+  @DisplayName("sendCounselorMessage: 배정되지 않은 세션 → NotFoundException 전파")
+  void should_propagateNotFoundException_when_sessionNotFound() {
+    CounselorMessageRequest request = new CounselorMessageRequest();
+    request.setSessionId(999L);
+    request.setContent("Hello");
+
+    Principal principal = () -> "42";
+
+    given(counselorService.sendCounselorMessage(999L, "Hello", 42L))
+        .willThrow(new NotFoundException("SESSION_NOT_FOUND", "Session not found: 999"));
+
+    assertThatThrownBy(() -> controller.sendCounselorMessage(request, principal))
+        .isInstanceOf(NotFoundException.class)
+        .satisfies(e -> assertThat(((NotFoundException) e).getCode()).isEqualTo("SESSION_NOT_FOUND"));
+  }
+
+  @Test
+  @DisplayName("sendCounselorMessage: 권한 없는 상담사 → BadRequestException 전파")
+  void should_propagateBadRequestException_when_notAssigned() {
+    CounselorMessageRequest request = new CounselorMessageRequest();
+    request.setSessionId(1L);
+    request.setContent("Hello");
+
+    Principal principal = () -> "99";
+
+    given(counselorService.sendCounselorMessage(1L, "Hello", 99L))
+        .willThrow(new BadRequestException("SESSION_NOT_ASSIGNED",
+            "Session 1 is not assigned to counselor: 99"));
+
+    assertThatThrownBy(() -> controller.sendCounselorMessage(request, principal))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("not assigned to counselor");
+  }
+
+  @Test
+  @DisplayName("handleException: BusinessException → code + message 반환")
+  void should_returnErrorMessage_when_businessException() {
+    SimpMessageHeaderAccessor headerAccessor = SimpMessageHeaderAccessor.create();
+    Exception ex = new NotFoundException("SESSION_NOT_FOUND", "Session not found: 999");
+
+    ChatMessageResponse result = controller.handleException(ex, headerAccessor);
+
+    assertThat(result.content()).contains("[SESSION_NOT_FOUND] Session not found: 999");
+  }
+
+  @Test
+  @DisplayName("handleException: 일반 Exception → INTERNAL_ERROR 반환")
+  void should_returnInternalError_when_genericException() {
+    SimpMessageHeaderAccessor headerAccessor = SimpMessageHeaderAccessor.create();
+    Exception ex = new RuntimeException("Unexpected error");
+
+    ChatMessageResponse result = controller.handleException(ex, headerAccessor);
+
+    assertThat(result.content()).contains("INTERNAL_ERROR");
+    assertThat(result.content()).contains("서버 오류가 발생했습니다.");
+  }
+}

--- a/backend/src/test/java/com/init/workflowruntime/presentation/CounselorWebSocketControllerTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/presentation/CounselorWebSocketControllerTest.java
@@ -2,7 +2,6 @@ package com.init.workflowruntime.presentation;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
 import com.init.shared.application.exception.BadRequestException;
@@ -43,10 +42,10 @@ class CounselorWebSocketControllerTest {
     Principal principal = () -> "42";
 
     ChatMessageResponse expected =
-        new ChatMessageResponse(10L, 1, "COUNSELOR", "TEXT", "Counselor message", OffsetDateTime.now());
+        new ChatMessageResponse(
+            10L, 1, "COUNSELOR", "TEXT", "Counselor message", OffsetDateTime.now());
 
-    given(counselorService.sendCounselorMessage(1L, "Counselor message", 42L))
-        .willReturn(expected);
+    given(counselorService.sendCounselorMessage(1L, "Counselor message", 42L)).willReturn(expected);
 
     ChatMessageResponse result = controller.sendCounselorMessage(request, principal);
 
@@ -68,7 +67,8 @@ class CounselorWebSocketControllerTest {
 
     assertThatThrownBy(() -> controller.sendCounselorMessage(request, principal))
         .isInstanceOf(NotFoundException.class)
-        .satisfies(e -> assertThat(((NotFoundException) e).getCode()).isEqualTo("SESSION_NOT_FOUND"));
+        .satisfies(
+            e -> assertThat(((NotFoundException) e).getCode()).isEqualTo("SESSION_NOT_FOUND"));
   }
 
   @Test
@@ -81,8 +81,9 @@ class CounselorWebSocketControllerTest {
     Principal principal = () -> "99";
 
     given(counselorService.sendCounselorMessage(1L, "Hello", 99L))
-        .willThrow(new BadRequestException("SESSION_NOT_ASSIGNED",
-            "Session 1 is not assigned to counselor: 99"));
+        .willThrow(
+            new BadRequestException(
+                "SESSION_NOT_ASSIGNED", "Session 1 is not assigned to counselor: 99"));
 
     assertThatThrownBy(() -> controller.sendCounselorMessage(request, principal))
         .isInstanceOf(BadRequestException.class)


### PR DESCRIPTION
## 개요

상담사 개입 기능을 workflow-runtime 모듈에 구현합니다. 세션 할당/해제, 상담사 메시지 처리, 알림 push를 포함합니다.

## 변경 사항

### DB 마이그레이션
- `runtime.chat_session` 테이블에 `assigned_counselor_id BIGINT` 컬럼 추가

### Domain
- `ChatSession.assignTo(counselorId)` / `releaseFrom(counselorId)` — 세션 상태 전이 캡슐화 (OPEN→ACTIVE, ACTIVE→OPEN)
- `SessionAssignedEvent` — 세션 할당 도메인 이벤트

### Application
- `CounselorService` — assignSession, releaseSession, sendCounselorMessage, getSessions, isSessionAssigned
- `SessionAssignedEventListener` — 이벤트 수신 → /queue/counselor.notifications push (afterCommit)

### Presentation (REST)
- `POST /api/v1/consultation/sessions/{id}/assign?counselorId=`
- `POST /api/v1/consultation/sessions/{id}/release?counselorId=`
- `GET /api/v1/consultation/sessions?status=&page=&size=` (페이징)

### Presentation (STOMP)
- `/chat.counselor.send` — 상담사 메시지 전송 (senderRole: COUNSELOR)

### Test
- CounselorServiceTest: 18 tests
- CounselorSessionControllerTest: 7 tests
- CounselorWebSocketControllerTest: 5 tests
- **All 30 tests PASS**

## 관련 이슈
- 5.3.4 BE 상담사 개입

## 체크리스트
- [x] 세션 할당/해제 API
- [x] 상담사 메시지 STOMP 송수신
- [x] 상담사 알림 push
- [x] 발신자 타입 COUNSELOR
- [x] 오류 케이스 모두 처리 (InvalidSessionStateException → 400)
- [x] TDD (30 tests, all green)
- [x] Plan compliance audit (Oracle) APPROVE
- [x] Code quality review APPROVE
- [x] Manual QA (E2E curl) APPROVE
- [x] Scope fidelity check APPROVE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 상담사의 채팅 세션 배정/해제, 배정 상태 확인 및 상담사 발신 메시지 전송·실시간 브로드캐스트 추가
  * 상담사 대상 개인 알림(큐) 및 세션 상태 기반 알림 발송(트랜잭션 커밋 후 전송 보장)
  * 세션 목록 페이징·상태·담당자 필터링 조회 및 WebSocket 에러 응답 포맷 개선
  * 입력 검증이 적용된 메시지/요청 DTO 추가

* **Tests**
  * 서비스, REST 컨트롤러, WebSocket 컨트롤러 단위 테스트 추가

* **Chores**
  * DB 마이그레이션: 세션에 상담자 매핑 컬럼·외래키·인덱스 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ajou-2026-1-capstone-5/ostone/pull/262?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->