### PR TITLE
feat(frontend): add user chat UI with STOMP WebSocket

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@base-ui/react": "^1.3.0",
     "@hookform/resolvers": "^5.2.2",
+    "@stomp/stompjs": "^7.3.0",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/react-query": "^5.100.1",
     "@xyflow/react": "^12.10.2",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       '@hookform/resolvers':
         specifier: ^5.2.2
         version: 5.2.2(react-hook-form@7.72.1(react@19.2.4))
+      '@stomp/stompjs':
+        specifier: ^7.3.0
+        version: 7.3.0
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(@voidzero-dev/vite-plus-core@0.1.15(@types/node@24.12.0)(jiti@2.6.1)(typescript@5.9.3)(yaml@2.8.3))
@@ -1718,6 +1721,9 @@ packages:
 
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
+
+  '@stomp/stompjs@7.3.0':
+    resolution: {integrity: sha512-nKMLoFfJhrQAqkvvKd1vLq/cVBGCMwPRCD0LqW7UT1fecRx9C3GoKEIR2CYwVuErGeZu8w0kFkl2rlhPlqHVgQ==}
 
   '@tabby_ai/hijri-converter@1.0.5':
     resolution: {integrity: sha512-r5bClKrcIusDoo049dSL8CawnHR6mRdDwhlQuIgZRNty68q0x8k3Lf1BtPAMxRf/GgnHBnIO4ujd3+GQdLWzxQ==}
@@ -5253,6 +5259,8 @@ snapshots:
   '@standard-schema/spec@1.1.0': {}
 
   '@standard-schema/utils@0.3.0': {}
+
+  '@stomp/stompjs@7.3.0': {}
 
   '@tabby_ai/hijri-converter@1.0.5': {}
 

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -5,6 +5,7 @@ import { WorkspaceRootRedirect } from "../pages/workspace/ui/WorkspaceRootRedire
 import { PasswordResetInitPage } from "../pages/password-reset/ui/PasswordResetInitPage";
 import { PasswordResetCompletePage } from "../pages/password-reset/ui/PasswordResetCompletePage";
 import { ConsultationPage } from "../pages/consultation/ui/ConsultationPage";
+import { UserChatPage } from "../pages/user-chat";
 import { NotFoundPage } from "../pages/not-found/ui/NotFoundPage";
 import { IntentDraftReadPage } from "../pages/domain-pack/ui/IntentDraftReadPage";
 import { PolicyDraftReadPage } from "../pages/domain-pack/ui/PolicyDraftReadPage";
@@ -58,6 +59,7 @@ export function App() {
             path="consultation/:sessionId"
             element={<ConsultationPage />}
           />
+          <Route path="chat" element={<UserChatPage />} />
           <Route path="upload" element={<WorkspaceUploadPage />} />
           <Route path="domain-packs" element={<DomainPackListPage />} />
         </Route>

--- a/frontend/src/entities/chat/api/chatApi.test.ts
+++ b/frontend/src/entities/chat/api/chatApi.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createChatSession } from "./chatApi";
+
+const { customFetchMock } = vi.hoisted(() => ({
+  customFetchMock: vi.fn(),
+}));
+
+vi.mock("@/shared/api/mutator", () => ({
+  customFetch: customFetchMock,
+}));
+
+describe("chatApi", () => {
+  beforeEach(() => {
+    customFetchMock.mockReset();
+  });
+
+  it("workspaceId로 채팅 세션을 생성한다", async () => {
+    const session = {
+      id: 12,
+      workspaceId: 3,
+      status: "ACTIVE" as const,
+      createdAt: "2026-05-22T00:00:00Z",
+    };
+    customFetchMock.mockResolvedValue(session);
+
+    await expect(createChatSession(3)).resolves.toEqual(session);
+
+    expect(customFetchMock).toHaveBeenCalledWith("/api/v1/chat/sessions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ workspaceId: 3 }),
+    });
+  });
+});

--- a/frontend/src/entities/chat/api/chatApi.ts
+++ b/frontend/src/entities/chat/api/chatApi.ts
@@ -1,0 +1,10 @@
+import { customFetch } from "@/shared/api/mutator";
+import type { ChatSession } from "@/entities/chat/model/types";
+
+export function createChatSession(workspaceId: number): Promise<ChatSession> {
+  return customFetch<ChatSession>("/api/v1/chat/sessions", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ workspaceId }),
+  });
+}

--- a/frontend/src/entities/chat/index.ts
+++ b/frontend/src/entities/chat/index.ts
@@ -1,0 +1,2 @@
+export { createChatSession } from "@/entities/chat/api/chatApi";
+export type { ChatMessage, ChatSession, ConnectionStatus } from "@/entities/chat/model/types";

--- a/frontend/src/entities/chat/model/types.test.ts
+++ b/frontend/src/entities/chat/model/types.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import type { ChatMessage, ChatSession, ConnectionStatus } from "./types";
+
+describe("chat model types", () => {
+  it("ChatMessage shape을 고정한다", () => {
+    const message = {
+      id: "msg-1",
+      sessionId: 10,
+      content: "배송이 지연됐어요",
+      senderType: "USER",
+      senderId: 3,
+      senderName: "고객",
+      createdAt: "2026-05-22T00:00:00Z",
+    } satisfies ChatMessage;
+
+    expect(message.senderType).toBe("USER");
+  });
+
+  it("ChatSession과 ConnectionStatus union을 고정한다", () => {
+    const session = {
+      id: 10,
+      workspaceId: 1,
+      status: "ACTIVE",
+      createdAt: "2026-05-22T00:00:00Z",
+    } satisfies ChatSession;
+    const status: ConnectionStatus = "CONNECTED";
+
+    expect(session.status).toBe("ACTIVE");
+    expect(status).toBe("CONNECTED");
+  });
+});

--- a/frontend/src/entities/chat/model/types.ts
+++ b/frontend/src/entities/chat/model/types.ts
@@ -1,0 +1,18 @@
+export interface ChatMessage {
+  id: string;
+  sessionId: number;
+  content: string;
+  senderType: "USER" | "BOT" | "AGENT";
+  senderId?: number;
+  senderName?: string;
+  createdAt: string;
+}
+
+export interface ChatSession {
+  id: number;
+  workspaceId: number;
+  status: "ACTIVE" | "CLOSED";
+  createdAt: string;
+}
+
+export type ConnectionStatus = "CONNECTING" | "CONNECTED" | "DISCONNECTED" | "ERROR";

--- a/frontend/src/features/user-chat/index.ts
+++ b/frontend/src/features/user-chat/index.ts
@@ -1,0 +1,4 @@
+export { ChatRoom } from "./ui/ChatRoom";
+export { MessageList } from "./ui/MessageList";
+export { MessageInput } from "./ui/MessageInput";
+export { ConnectionStatus } from "./ui/ConnectionStatus";

--- a/frontend/src/features/user-chat/ui/ChatRoom.test.tsx
+++ b/frontend/src/features/user-chat/ui/ChatRoom.test.tsx
@@ -1,0 +1,64 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ChatRoom } from "./ChatRoom";
+
+const stompState = vi.hoisted(() => ({
+  connectionStatus: "CONNECTED" as "CONNECTING" | "CONNECTED" | "DISCONNECTED" | "ERROR",
+  lastMessage: null as unknown,
+  sendMessage: vi.fn(),
+  connect: vi.fn(),
+  disconnect: vi.fn(),
+}));
+
+vi.mock("@/shared/lib/websocket", () => ({
+  useStomp: () => stompState,
+}));
+
+describe("ChatRoom", () => {
+  beforeEach(() => {
+    stompState.connectionStatus = "CONNECTED";
+    stompState.lastMessage = null;
+    stompState.sendMessage.mockReset();
+  });
+
+  it("연결 상태와 빈 메시지 상태를 렌더링한다", () => {
+    render(<ChatRoom sessionId={7} />);
+
+    expect(screen.getByText("연결됨")).toBeInTheDocument();
+    expect(screen.getByText("아직 메시지가 없습니다. 첫 메시지를 보내보세요!")).toBeInTheDocument();
+  });
+
+  it("lastMessage가 바뀌면 메시지 목록에 추가한다", () => {
+    const { rerender } = render(<ChatRoom sessionId={7} />);
+
+    act(() => {
+      stompState.lastMessage = {
+        id: "m1",
+        sessionId: 7,
+        content: "안녕하세요",
+        senderType: "BOT",
+        createdAt: "2026-05-22T08:00:00Z",
+      };
+    });
+    rerender(<ChatRoom sessionId={7} />);
+
+    expect(screen.getByText("안녕하세요")).toBeInTheDocument();
+  });
+
+  it("입력 메시지를 sessionId와 함께 전송한다", () => {
+    render(<ChatRoom sessionId={7} />);
+
+    fireEvent.change(screen.getByLabelText("메시지 입력"), { target: { value: "문의합니다" } });
+    fireEvent.click(screen.getByRole("button", { name: "메시지 보내기" }));
+
+    expect(stompState.sendMessage).toHaveBeenCalledWith({ sessionId: 7, content: "문의합니다" });
+  });
+
+  it("연결되지 않으면 입력을 비활성화한다", () => {
+    stompState.connectionStatus = "DISCONNECTED";
+
+    render(<ChatRoom sessionId={7} />);
+
+    expect(screen.getByLabelText("메시지 입력")).toBeDisabled();
+  });
+});

--- a/frontend/src/features/user-chat/ui/ChatRoom.tsx
+++ b/frontend/src/features/user-chat/ui/ChatRoom.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useState } from "react";
+import type { ChatMessage } from "@/entities/chat";
+import { useStomp } from "@/shared/lib/websocket";
+import { ConnectionStatus } from "./ConnectionStatus";
+import { MessageInput } from "./MessageInput";
+import { MessageList } from "./MessageList";
+
+export interface ChatRoomProps {
+  sessionId: number;
+}
+
+function isChatMessage(message: unknown): message is ChatMessage {
+  if (!message || typeof message !== "object") return false;
+
+  const candidate = message as Partial<ChatMessage>;
+  return (
+    typeof candidate.id === "string" &&
+    typeof candidate.sessionId === "number" &&
+    typeof candidate.content === "string" &&
+    typeof candidate.createdAt === "string" &&
+    (candidate.senderType === "USER" ||
+      candidate.senderType === "BOT" ||
+      candidate.senderType === "AGENT")
+  );
+}
+
+export function ChatRoom({ sessionId }: ChatRoomProps) {
+  const { connectionStatus, sendMessage, lastMessage } = useStomp<ChatMessage>();
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+
+  useEffect(() => {
+    if (!isChatMessage(lastMessage)) return;
+
+    setMessages((current) => {
+      if (current.some((message) => message.id === lastMessage.id)) return current;
+      return [...current, lastMessage];
+    });
+  }, [lastMessage]);
+
+  return (
+    <section className="flex h-full min-h-[520px] flex-col rounded-lg border border-gray-200 bg-white">
+      <ConnectionStatus status={connectionStatus} />
+      <div className="flex-1 border-y border-gray-100">
+        <MessageList messages={messages} />
+      </div>
+      <MessageInput
+        disabled={connectionStatus !== "CONNECTED"}
+        onSend={(content) => sendMessage({ sessionId, content })}
+      />
+    </section>
+  );
+}

--- a/frontend/src/features/user-chat/ui/ChatRoom.tsx
+++ b/frontend/src/features/user-chat/ui/ChatRoom.tsx
@@ -29,13 +29,18 @@ export function ChatRoom({ sessionId }: ChatRoomProps) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
 
   useEffect(() => {
+    setMessages([]);
+  }, [sessionId]);
+
+  useEffect(() => {
     if (!isChatMessage(lastMessage)) return;
+    if (lastMessage.sessionId !== sessionId) return;
 
     setMessages((current) => {
       if (current.some((message) => message.id === lastMessage.id)) return current;
       return [...current, lastMessage];
     });
-  }, [lastMessage]);
+  }, [lastMessage, sessionId]);
 
   return (
     <section className="flex h-full min-h-[520px] flex-col rounded-lg border border-gray-200 bg-white">

--- a/frontend/src/features/user-chat/ui/ConnectionStatus.test.tsx
+++ b/frontend/src/features/user-chat/ui/ConnectionStatus.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ConnectionStatus } from "./ConnectionStatus";
+
+describe("ConnectionStatus", () => {
+  it("CONNECTING 상태를 표시한다", () => {
+    render(<ConnectionStatus status="CONNECTING" />);
+
+    expect(screen.getByText("연결 중...")).toBeInTheDocument();
+  });
+
+  it("CONNECTED 상태를 표시한다", () => {
+    render(<ConnectionStatus status="CONNECTED" />);
+
+    expect(screen.getByText("연결됨")).toBeInTheDocument();
+  });
+
+  it("DISCONNECTED 상태와 재연결 안내를 표시한다", () => {
+    render(<ConnectionStatus status="DISCONNECTED" />);
+
+    expect(screen.getByText("연결 끊김")).toBeInTheDocument();
+    expect(screen.getByText("재연결 중...")).toBeInTheDocument();
+  });
+
+  it("ERROR 상태를 표시한다", () => {
+    render(<ConnectionStatus status="ERROR" />);
+
+    expect(screen.getByText("연결 오류")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/user-chat/ui/ConnectionStatus.tsx
+++ b/frontend/src/features/user-chat/ui/ConnectionStatus.tsx
@@ -1,0 +1,43 @@
+import { Circle, Loader2 } from "lucide-react";
+import type { ConnectionStatus as ChatConnectionStatus } from "@/entities/chat";
+
+export interface ConnectionStatusProps {
+  status: ChatConnectionStatus;
+}
+
+export function ConnectionStatus({ status }: ConnectionStatusProps) {
+  if (status === "CONNECTING") {
+    return (
+      <div className="flex items-center gap-2 px-4 py-2 text-sm text-gray-500">
+        <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+        연결 중...
+      </div>
+    );
+  }
+
+  if (status === "CONNECTED") {
+    return (
+      <div className="flex items-center gap-2 px-4 py-2 text-sm text-black">
+        <Circle className="size-3 fill-gray-900 text-gray-900" aria-hidden="true" />
+        연결됨
+      </div>
+    );
+  }
+
+  if (status === "DISCONNECTED") {
+    return (
+      <div className="flex items-center gap-2 px-4 py-2 text-sm text-gray-600">
+        <Circle className="size-3 fill-gray-500 text-gray-500" aria-hidden="true" />
+        <span>연결 끊김</span>
+        <span className="text-gray-500">재연결 중...</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-black">
+      <Circle className="size-3 fill-black text-black" aria-hidden="true" />
+      연결 오류
+    </div>
+  );
+}

--- a/frontend/src/features/user-chat/ui/MessageInput.test.tsx
+++ b/frontend/src/features/user-chat/ui/MessageInput.test.tsx
@@ -1,0 +1,44 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { MessageInput } from "./MessageInput";
+
+describe("MessageInput", () => {
+  it("입력 후 버튼 클릭으로 메시지를 전송하고 입력값을 비운다", () => {
+    const onSend = vi.fn();
+    render(<MessageInput onSend={onSend} />);
+
+    fireEvent.change(screen.getByLabelText("메시지 입력"), { target: { value: "환불 문의" } });
+    fireEvent.click(screen.getByRole("button", { name: "메시지 보내기" }));
+
+    expect(onSend).toHaveBeenCalledWith("환불 문의");
+    expect(screen.getByLabelText("메시지 입력")).toHaveValue("");
+  });
+
+  it("Enter 키로 메시지를 전송한다", () => {
+    const onSend = vi.fn();
+    render(<MessageInput onSend={onSend} />);
+
+    fireEvent.change(screen.getByLabelText("메시지 입력"), { target: { value: "배송 문의" } });
+    fireEvent.keyDown(screen.getByLabelText("메시지 입력"), { key: "Enter" });
+
+    expect(onSend).toHaveBeenCalledWith("배송 문의");
+  });
+
+  it("빈 메시지는 전송하지 않는다", () => {
+    const onSend = vi.fn();
+    render(<MessageInput onSend={onSend} />);
+
+    fireEvent.change(screen.getByLabelText("메시지 입력"), { target: { value: "   " } });
+    fireEvent.click(screen.getByRole("button", { name: "메시지 보내기" }));
+
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it("disabled 상태에서는 입력과 전송을 막는다", () => {
+    const onSend = vi.fn();
+    render(<MessageInput onSend={onSend} disabled />);
+
+    expect(screen.getByLabelText("메시지 입력")).toBeDisabled();
+    expect(screen.getByRole("button", { name: "메시지 보내기" })).toBeDisabled();
+  });
+});

--- a/frontend/src/features/user-chat/ui/MessageInput.tsx
+++ b/frontend/src/features/user-chat/ui/MessageInput.tsx
@@ -1,0 +1,46 @@
+import { useState } from "react";
+import { Send } from "lucide-react";
+
+export interface MessageInputProps {
+  onSend: (content: string) => void;
+  disabled?: boolean;
+}
+
+export function MessageInput({ onSend, disabled = false }: MessageInputProps) {
+  const [content, setContent] = useState("");
+
+  const submit = () => {
+    const trimmed = content.trim();
+    if (!trimmed || disabled) return;
+
+    onSend(trimmed);
+    setContent("");
+  };
+
+  return (
+    <div className="flex gap-2 border-t border-gray-200 bg-white p-4">
+      <input
+        aria-label="메시지 입력"
+        className="min-h-11 flex-1 rounded-full border border-gray-300 bg-white px-4 text-sm text-black outline-none transition focus:outline-2 focus:outline-dashed focus:outline-black disabled:pointer-events-none disabled:bg-gray-100 disabled:text-gray-500"
+        disabled={disabled}
+        placeholder="메시지를 입력하세요"
+        value={content}
+        onChange={(event) => setContent(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key !== "Enter" || event.shiftKey) return;
+          event.preventDefault();
+          submit();
+        }}
+      />
+      <button
+        type="button"
+        aria-label="메시지 보내기"
+        className="inline-flex size-11 items-center justify-center rounded-full bg-black text-white transition hover:bg-gray-900 focus:outline-2 focus:outline-dashed focus:outline-black focus:outline-offset-2 disabled:pointer-events-none disabled:bg-gray-300 disabled:text-white"
+        disabled={disabled}
+        onClick={submit}
+      >
+        <Send className="size-4" aria-hidden="true" />
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/features/user-chat/ui/MessageList.test.tsx
+++ b/frontend/src/features/user-chat/ui/MessageList.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { MessageList } from "./MessageList";
+import type { ChatMessage } from "@/entities/chat";
+
+const messages: ChatMessage[] = [
+  {
+    id: "m1",
+    sessionId: 1,
+    content: "배송이 지연됐어요",
+    senderType: "USER",
+    senderName: "고객",
+    createdAt: "2026-05-22T08:00:00Z",
+  },
+  {
+    id: "m2",
+    sessionId: 1,
+    content: "확인해 드리겠습니다",
+    senderType: "BOT",
+    senderName: "봇",
+    createdAt: "2026-05-22T08:01:00Z",
+  },
+];
+
+describe("MessageList", () => {
+  it("loading 상태를 표시한다", () => {
+    render(<MessageList messages={[]} loading />);
+
+    expect(screen.getByText("메시지를 불러오는 중입니다...")).toBeInTheDocument();
+  });
+
+  it("빈 메시지 상태를 표시한다", () => {
+    render(<MessageList messages={[]} />);
+
+    expect(screen.getByText("아직 메시지가 없습니다. 첫 메시지를 보내보세요!")).toBeInTheDocument();
+  });
+
+  it("에러 상태를 표시한다", () => {
+    render(<MessageList messages={[]} error="세션을 만들 수 없습니다." />);
+
+    expect(screen.getByText("세션을 만들 수 없습니다.")).toBeInTheDocument();
+  });
+
+  it("사용자와 응답 메시지를 서로 다른 정렬로 렌더링한다", () => {
+    render(<MessageList messages={messages} />);
+
+    expect(screen.getByText("배송이 지연됐어요")).toBeInTheDocument();
+    expect(screen.getByText("확인해 드리겠습니다")).toBeInTheDocument();
+    expect(screen.getByTestId("message-m1")).toHaveClass("justify-start");
+    expect(screen.getByTestId("message-m2")).toHaveClass("justify-end");
+  });
+
+  it("새 메시지가 렌더링되면 하단으로 스크롤한다", () => {
+    const scrollIntoView = vi.fn();
+    window.HTMLElement.prototype.scrollIntoView = scrollIntoView;
+
+    const { rerender } = render(<MessageList messages={[messages[0]!]} />);
+    rerender(<MessageList messages={messages} />);
+
+    expect(scrollIntoView).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/features/user-chat/ui/MessageList.test.tsx
+++ b/frontend/src/features/user-chat/ui/MessageList.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { MessageList } from "./MessageList";
-import type { ChatMessage } from "@/entities/chat";
+import type { ChatMessage } from "../../../entities/chat";
 
 const messages: ChatMessage[] = [
   {
@@ -26,31 +26,32 @@ describe("MessageList", () => {
   it("loading 상태를 표시한다", () => {
     render(<MessageList messages={[]} loading />);
 
-    expect(screen.getByText("메시지를 불러오는 중입니다...")).toBeInTheDocument();
+    expect(screen.getByText("메시지를 불러오는 중입니다...")).not.toBeNull();
   });
 
   it("빈 메시지 상태를 표시한다", () => {
     render(<MessageList messages={[]} />);
 
-    expect(screen.getByText("아직 메시지가 없습니다. 첫 메시지를 보내보세요!")).toBeInTheDocument();
+    expect(screen.getByText("아직 메시지가 없습니다. 첫 메시지를 보내보세요!")).not.toBeNull();
   });
 
   it("에러 상태를 표시한다", () => {
     render(<MessageList messages={[]} error="세션을 만들 수 없습니다." />);
 
-    expect(screen.getByText("세션을 만들 수 없습니다.")).toBeInTheDocument();
+    expect(screen.getByText("세션을 만들 수 없습니다.")).not.toBeNull();
   });
 
   it("사용자와 응답 메시지를 서로 다른 정렬로 렌더링한다", () => {
     render(<MessageList messages={messages} />);
 
-    expect(screen.getByText("배송이 지연됐어요")).toBeInTheDocument();
-    expect(screen.getByText("확인해 드리겠습니다")).toBeInTheDocument();
-    expect(screen.getByTestId("message-m1")).toHaveClass("justify-start");
-    expect(screen.getByTestId("message-m2")).toHaveClass("justify-end");
+    expect(screen.getByText("배송이 지연됐어요")).not.toBeNull();
+    expect(screen.getByText("확인해 드리겠습니다")).not.toBeNull();
+    expect(screen.getByTestId("message-m1").classList.contains("justify-start")).toBe(true);
+    expect(screen.getByTestId("message-m2").classList.contains("justify-end")).toBe(true);
   });
 
   it("새 메시지가 렌더링되면 하단으로 스크롤한다", () => {
+    const originalScrollIntoView = window.HTMLElement.prototype.scrollIntoView;
     const scrollIntoView = vi.fn();
     window.HTMLElement.prototype.scrollIntoView = scrollIntoView;
 
@@ -58,5 +59,6 @@ describe("MessageList", () => {
     rerender(<MessageList messages={messages} />);
 
     expect(scrollIntoView).toHaveBeenCalled();
+    window.HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
   });
 });

--- a/frontend/src/features/user-chat/ui/MessageList.tsx
+++ b/frontend/src/features/user-chat/ui/MessageList.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useRef } from "react";
+import { Loader2 } from "lucide-react";
+import type { ChatMessage } from "@/entities/chat";
+
+export interface MessageListProps {
+  messages: ChatMessage[];
+  loading?: boolean;
+  error?: string | null;
+}
+
+function formatMessageTime(value: string): string {
+  return new Intl.DateTimeFormat("ko-KR", {
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(new Date(value));
+}
+
+function resolveSenderName(message: ChatMessage): string {
+  if (message.senderName) return message.senderName;
+  if (message.senderType === "USER") return "사용자";
+  if (message.senderType === "AGENT") return "상담사";
+  return "봇";
+}
+
+export function MessageList({ messages, loading = false, error = null }: MessageListProps) {
+  const bottomRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView?.({ behavior: "smooth" });
+  }, [messages.length]);
+
+  if (error) {
+    return (
+      <div className="flex min-h-[400px] items-center justify-center overflow-y-auto bg-white p-6 text-sm text-black">
+        <div className="rounded-lg border border-black px-4 py-3">{error}</div>
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="flex min-h-[400px] items-center justify-center overflow-y-auto bg-white p-6 text-sm text-gray-500">
+        <Loader2 className="mr-2 size-4 animate-spin" aria-hidden="true" />
+        메시지를 불러오는 중입니다...
+      </div>
+    );
+  }
+
+  if (messages.length === 0) {
+    return (
+      <div className="flex min-h-[400px] items-center justify-center overflow-y-auto bg-white p-6 text-sm text-gray-500">
+        아직 메시지가 없습니다. 첫 메시지를 보내보세요!
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-[400px] overflow-y-auto bg-white p-4">
+      <div className="flex flex-col gap-4">
+        {messages.map((message) => {
+          const isUser = message.senderType === "USER";
+          return (
+            <div
+              key={message.id}
+              data-testid={`message-${message.id}`}
+              className={`flex ${isUser ? "justify-start" : "justify-end"}`}
+            >
+              <div className={`max-w-[72%] ${isUser ? "text-left" : "text-right"}`}>
+                <div className="mb-1 flex items-baseline gap-2 text-xs text-gray-500">
+                  <span>{resolveSenderName(message)}</span>
+                  <time dateTime={message.createdAt}>{formatMessageTime(message.createdAt)}</time>
+                </div>
+                <div
+                  className={`rounded-lg p-3 text-sm leading-6 ${
+                    isUser ? "bg-gray-100 text-black" : "bg-black text-white"
+                  }`}
+                >
+                  {message.content}
+                </div>
+              </div>
+            </div>
+          );
+        })}
+        <div ref={bottomRef} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/user-chat/index.ts
+++ b/frontend/src/pages/user-chat/index.ts
@@ -1,0 +1,1 @@
+export { UserChatPage } from "./ui/UserChatPage";

--- a/frontend/src/pages/user-chat/ui/UserChatPage.test.tsx
+++ b/frontend/src/pages/user-chat/ui/UserChatPage.test.tsx
@@ -4,7 +4,7 @@ import { UserChatPage } from "./UserChatPage";
 
 const { createChatSessionMock, routeState } = vi.hoisted(() => ({
   createChatSessionMock: vi.fn(),
-  routeState: { workspaceId: "42" },
+  routeState: { workspaceId: "42" as string | undefined },
 }));
 
 vi.mock("@/entities/chat", () => ({
@@ -13,6 +13,10 @@ vi.mock("@/entities/chat", () => ({
 
 vi.mock("@/features/user-chat", () => ({
   ChatRoom: ({ sessionId }: { sessionId: number }) => <div>ChatRoom session {sessionId}</div>,
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn() },
 }));
 
 vi.mock("react-router-dom", async () => {
@@ -40,7 +44,7 @@ describe("UserChatPage", () => {
 
     render(<UserChatPage />);
 
-    expect(screen.getByText("채팅방을 여는 중입니다...")).toBeInTheDocument();
+    expect(screen.getByText("채팅방을 여는 중입니다...")).not.toBeNull();
     await waitFor(() => expect(createChatSessionMock).toHaveBeenCalledWith(42));
   });
 
@@ -54,7 +58,7 @@ describe("UserChatPage", () => {
 
     render(<UserChatPage />);
 
-    expect(await screen.findByText("ChatRoom session 9")).toBeInTheDocument();
+    expect(await screen.findByText("ChatRoom session 9")).not.toBeNull();
   });
 
   it("세션 생성 실패 시 에러 메시지를 표시한다", async () => {
@@ -62,6 +66,16 @@ describe("UserChatPage", () => {
 
     render(<UserChatPage />);
 
-    expect(await screen.findByText("채팅 세션을 시작할 수 없습니다.")).toBeInTheDocument();
+    expect(await screen.findByText("채팅 세션을 시작할 수 없습니다.")).not.toBeNull();
+  });
+
+  it("유효하지 않은 workspaceId에서 에러 메시지를 표시한다", async () => {
+    routeState.workspaceId = undefined;
+    createChatSessionMock.mockReset();
+
+    render(<UserChatPage />);
+
+    expect(await screen.findByText("유효하지 않은 워크스페이스입니다.")).not.toBeNull();
+    expect(createChatSessionMock).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/user-chat/ui/UserChatPage.test.tsx
+++ b/frontend/src/pages/user-chat/ui/UserChatPage.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { UserChatPage } from "./UserChatPage";
+
+const { createChatSessionMock, routeState } = vi.hoisted(() => ({
+  createChatSessionMock: vi.fn(),
+  routeState: { workspaceId: "42" },
+}));
+
+vi.mock("@/entities/chat", () => ({
+  createChatSession: createChatSessionMock,
+}));
+
+vi.mock("@/features/user-chat", () => ({
+  ChatRoom: ({ sessionId }: { sessionId: number }) => <div>ChatRoom session {sessionId}</div>,
+}));
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  return {
+    ...actual,
+    useParams: () => routeState,
+    useOutletContext: () => ({ setTopbarRight: vi.fn(), setCrumbs: vi.fn() }),
+  };
+});
+
+describe("UserChatPage", () => {
+  beforeEach(() => {
+    routeState.workspaceId = "42";
+    createChatSessionMock.mockReset();
+  });
+
+  it("mount 시 URL의 workspaceId로 채팅 세션을 생성한다", async () => {
+    createChatSessionMock.mockResolvedValue({
+      id: 7,
+      workspaceId: 42,
+      status: "ACTIVE",
+      createdAt: "2026-05-22T00:00:00Z",
+    });
+
+    render(<UserChatPage />);
+
+    expect(screen.getByText("채팅방을 여는 중입니다...")).toBeInTheDocument();
+    await waitFor(() => expect(createChatSessionMock).toHaveBeenCalledWith(42));
+  });
+
+  it("생성된 session id를 ChatRoom에 전달한다", async () => {
+    createChatSessionMock.mockResolvedValue({
+      id: 9,
+      workspaceId: 42,
+      status: "ACTIVE",
+      createdAt: "2026-05-22T00:00:00Z",
+    });
+
+    render(<UserChatPage />);
+
+    expect(await screen.findByText("ChatRoom session 9")).toBeInTheDocument();
+  });
+
+  it("세션 생성 실패 시 에러 메시지를 표시한다", async () => {
+    createChatSessionMock.mockRejectedValue(new Error("failed"));
+
+    render(<UserChatPage />);
+
+    expect(await screen.findByText("채팅 세션을 시작할 수 없습니다.")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/user-chat/ui/UserChatPage.tsx
+++ b/frontend/src/pages/user-chat/ui/UserChatPage.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useState } from "react";
+import { useOutletContext, useParams } from "react-router-dom";
+import { createChatSession } from "@/entities/chat";
+import type { ChatSession } from "@/entities/chat";
+import { ChatRoom } from "@/features/user-chat";
+import type { ShellContext } from "@/shared/ui/ostone/chrome";
+
+export function UserChatPage() {
+  useOutletContext<ShellContext>();
+  const { workspaceId: raw } = useParams<{ workspaceId: string }>();
+  const workspaceId = Number(raw);
+  const [session, setSession] = useState<ChatSession | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!workspaceId) return;
+
+    let cancelled = false;
+
+    createChatSession(workspaceId)
+      .then((nextSession) => {
+        if (!cancelled) setSession(nextSession);
+      })
+      .catch(() => {
+        if (!cancelled) setError("채팅 세션을 시작할 수 없습니다.");
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [workspaceId]);
+
+  if (error) {
+    return <div className="flex h-full items-center justify-center p-8 text-sm">{error}</div>;
+  }
+
+  if (!session) {
+    return (
+      <div className="flex h-full items-center justify-center p-8 text-sm text-gray-500">
+        채팅방을 여는 중입니다...
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      <ChatRoom sessionId={session.id} />
+    </div>
+  );
+}

--- a/frontend/src/pages/user-chat/ui/UserChatPage.tsx
+++ b/frontend/src/pages/user-chat/ui/UserChatPage.tsx
@@ -14,6 +14,9 @@ export function UserChatPage() {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    setError(null);
+    setSession(null);
+
     if (!raw || Number.isNaN(workspaceId)) {
       setError("유효하지 않은 워크스페이스입니다.");
       return;

--- a/frontend/src/pages/user-chat/ui/UserChatPage.tsx
+++ b/frontend/src/pages/user-chat/ui/UserChatPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { useOutletContext, useParams } from "react-router-dom";
+import { toast } from "sonner";
 import { createChatSession } from "@/entities/chat";
 import type { ChatSession } from "@/entities/chat";
 import { ChatRoom } from "@/features/user-chat";
@@ -13,22 +14,29 @@ export function UserChatPage() {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!workspaceId) return;
+    if (!raw || Number.isNaN(workspaceId)) {
+      setError("유효하지 않은 워크스페이스입니다.");
+      return;
+    }
 
     let cancelled = false;
 
-    createChatSession(workspaceId)
-      .then((nextSession) => {
+    (async () => {
+      try {
+        const nextSession = await createChatSession(workspaceId);
         if (!cancelled) setSession(nextSession);
-      })
-      .catch(() => {
-        if (!cancelled) setError("채팅 세션을 시작할 수 없습니다.");
-      });
+      } catch {
+        if (!cancelled) {
+          setError("채팅 세션을 시작할 수 없습니다.");
+          toast.error("채팅 세션을 시작할 수 없습니다.");
+        }
+      }
+    })();
 
     return () => {
       cancelled = true;
     };
-  }, [workspaceId]);
+  }, [raw, workspaceId]);
 
   if (error) {
     return <div className="flex h-full items-center justify-center p-8 text-sm">{error}</div>;

--- a/frontend/src/shared/lib/websocket/index.ts
+++ b/frontend/src/shared/lib/websocket/index.ts
@@ -1,0 +1,3 @@
+export { createStompClient } from "./stompClient";
+export { useStomp } from "./useStomp";
+export type { ConnectionStatus, UseStompResult } from "./useStomp";

--- a/frontend/src/shared/lib/websocket/stompClient.test.ts
+++ b/frontend/src/shared/lib/websocket/stompClient.test.ts
@@ -21,7 +21,7 @@ describe("createStompClient", () => {
 
     expect(MockedClient).toHaveBeenCalledWith(
       expect.objectContaining({
-        brokerURL: "http://localhost:8080/ws/chat",
+        brokerURL: "ws://localhost:8080/ws/chat",
         connectHeaders: { Authorization: "Bearer access-token" },
         reconnectDelay: 5000,
         heartbeatIncoming: 10000,

--- a/frontend/src/shared/lib/websocket/stompClient.test.ts
+++ b/frontend/src/shared/lib/websocket/stompClient.test.ts
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Client } from "@stomp/stompjs";
+import { createStompClient } from "./stompClient";
+
+vi.mock("@stomp/stompjs", () => ({
+  Client: vi.fn(),
+}));
+
+const MockedClient = vi.mocked(Client);
+
+describe("createStompClient", () => {
+  beforeEach(() => {
+    MockedClient.mockClear();
+    localStorage.clear();
+  });
+
+  it("채팅 WebSocket broker URL과 인증 헤더로 STOMP Client를 생성한다", () => {
+    localStorage.setItem("accessToken", "access-token");
+
+    createStompClient();
+
+    expect(MockedClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        brokerURL: "http://localhost:8080/ws/chat",
+        connectHeaders: { Authorization: "Bearer access-token" },
+        reconnectDelay: 5000,
+        heartbeatIncoming: 10000,
+        heartbeatOutgoing: 10000,
+      }),
+    );
+  });
+});

--- a/frontend/src/shared/lib/websocket/stompClient.ts
+++ b/frontend/src/shared/lib/websocket/stompClient.ts
@@ -1,0 +1,20 @@
+import { Client } from "@stomp/stompjs";
+import { getAccessToken } from "@/shared/lib/auth";
+
+const DEFAULT_WS_URL = "http://localhost:8080";
+
+function getWebSocketBaseUrl(): string {
+  return import.meta.env.VITE_WS_URL ?? DEFAULT_WS_URL;
+}
+
+export function createStompClient(): Client {
+  const token = getAccessToken();
+
+  return new Client({
+    brokerURL: `${getWebSocketBaseUrl()}/ws/chat`,
+    connectHeaders: token ? { Authorization: `Bearer ${token}` } : {},
+    reconnectDelay: 5000,
+    heartbeatIncoming: 10000,
+    heartbeatOutgoing: 10000,
+  });
+}

--- a/frontend/src/shared/lib/websocket/stompClient.ts
+++ b/frontend/src/shared/lib/websocket/stompClient.ts
@@ -1,10 +1,18 @@
 import { Client } from "@stomp/stompjs";
 import { getAccessToken } from "@/shared/lib/auth";
 
-const DEFAULT_WS_URL = "http://localhost:8080";
+const DEFAULT_WS_URL = "ws://localhost:8080";
+
+function normalizeWsUrl(url: string): string {
+  return url
+    .replace(/^https:\/\//, "wss://")
+    .replace(/^http:\/\//, "ws://")
+    .replace(/\/$/, "");
+}
 
 function getWebSocketBaseUrl(): string {
-  return import.meta.env.VITE_WS_URL ?? DEFAULT_WS_URL;
+  const raw = import.meta.env.VITE_WS_URL ?? DEFAULT_WS_URL;
+  return normalizeWsUrl(raw);
 }
 
 export function createStompClient(): Client {

--- a/frontend/src/shared/lib/websocket/useStomp.test.tsx
+++ b/frontend/src/shared/lib/websocket/useStomp.test.tsx
@@ -1,0 +1,106 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Client, IMessage, StompSubscription } from "@stomp/stompjs";
+import { useStomp } from "./useStomp";
+
+const client = {
+  activate: vi.fn(),
+  deactivate: vi.fn(),
+  publish: vi.fn(),
+  subscribe: vi.fn(),
+  connected: false,
+  onConnect: undefined as Client["onConnect"],
+  onDisconnect: undefined as Client["onDisconnect"],
+  onStompError: undefined as Client["onStompError"],
+  onWebSocketError: undefined as Client["onWebSocketError"],
+};
+
+vi.mock("./stompClient", () => ({
+  createStompClient: () => client,
+}));
+
+const subscription: StompSubscription = { id: "messages", unsubscribe: vi.fn() };
+
+function makeMessage(body: string): IMessage {
+  return { body } as IMessage;
+}
+
+describe("useStomp", () => {
+  beforeEach(() => {
+    client.activate.mockClear();
+    client.deactivate.mockClear();
+    client.publish.mockClear();
+    client.subscribe.mockReset();
+    client.connected = false;
+    client.onConnect = undefined;
+    client.onDisconnect = undefined;
+    client.onStompError = undefined;
+    client.onWebSocketError = undefined;
+    vi.mocked(subscription.unsubscribe).mockClear();
+    client.subscribe.mockReturnValue(subscription);
+  });
+
+  it("mount 시 연결을 시작하고 unmount 시 연결을 종료한다", () => {
+    const { result, unmount } = renderHook(() => useStomp());
+
+    expect(result.current.connectionStatus).toBe("CONNECTING");
+    expect(client.activate).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      client.connected = true;
+      client.onConnect?.({} as Parameters<NonNullable<Client["onConnect"]>>[0]);
+    });
+
+    unmount();
+
+    expect(subscription.unsubscribe).toHaveBeenCalledTimes(1);
+    expect(client.deactivate).toHaveBeenCalledTimes(1);
+  });
+
+  it("연결되면 사용자 메시지 큐를 구독하고 수신 메시지를 저장한다", () => {
+    const { result } = renderHook(() => useStomp());
+
+    act(() => {
+      client.connected = true;
+      client.onConnect?.({} as Parameters<NonNullable<Client["onConnect"]>>[0]);
+    });
+
+    expect(result.current.connectionStatus).toBe("CONNECTED");
+    expect(client.subscribe).toHaveBeenCalledWith("/user/queue/messages", expect.any(Function));
+
+    const onMessage = client.subscribe.mock.calls[0]?.[1];
+    act(() => {
+      onMessage?.(makeMessage('{"id":"m1","content":"안녕하세요"}'));
+    });
+
+    expect(result.current.lastMessage).toEqual({ id: "m1", content: "안녕하세요" });
+  });
+
+  it("연결된 상태에서 채팅 메시지를 publish 한다", () => {
+    const { result } = renderHook(() => useStomp());
+
+    act(() => {
+      client.connected = true;
+      client.onConnect?.({} as Parameters<NonNullable<Client["onConnect"]>>[0]);
+    });
+
+    act(() => {
+      result.current.sendMessage({ sessionId: 1, content: "문의합니다" });
+    });
+
+    expect(client.publish).toHaveBeenCalledWith({
+      destination: "/app/chat.send",
+      body: JSON.stringify({ sessionId: 1, content: "문의합니다" }),
+    });
+  });
+
+  it("에러 콜백이 호출되면 ERROR 상태로 전환한다", () => {
+    const { result } = renderHook(() => useStomp());
+
+    act(() => {
+      client.onWebSocketError?.(new Event("error"));
+    });
+
+    expect(result.current.connectionStatus).toBe("ERROR");
+  });
+});

--- a/frontend/src/shared/lib/websocket/useStomp.ts
+++ b/frontend/src/shared/lib/websocket/useStomp.ts
@@ -1,0 +1,80 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { Client, IMessage, StompSubscription } from "@stomp/stompjs";
+import { createStompClient } from "./stompClient";
+
+export type ConnectionStatus = "CONNECTING" | "CONNECTED" | "DISCONNECTED" | "ERROR";
+
+const MESSAGE_QUEUE = "/user/queue/messages";
+const SEND_DESTINATION = "/app/chat.send";
+
+export interface UseStompResult<TLastMessage = unknown> {
+  connectionStatus: ConnectionStatus;
+  sendMessage: (message: unknown) => void;
+  lastMessage: TLastMessage | null;
+  connect: () => void;
+  disconnect: () => void;
+}
+
+function parseMessage<TLastMessage>(message: IMessage): TLastMessage {
+  return JSON.parse(message.body) as TLastMessage;
+}
+
+export function useStomp<TLastMessage = unknown>(): UseStompResult<TLastMessage> {
+  const clientRef = useRef<Client | null>(null);
+  const subscriptionRef = useRef<StompSubscription | null>(null);
+  const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>("DISCONNECTED");
+  const [lastMessage, setLastMessage] = useState<TLastMessage | null>(null);
+
+  const disconnect = useCallback(() => {
+    subscriptionRef.current?.unsubscribe();
+    subscriptionRef.current = null;
+    clientRef.current?.deactivate();
+    setConnectionStatus("DISCONNECTED");
+  }, []);
+
+  const connect = useCallback(() => {
+    if (clientRef.current?.connected) return;
+
+    const client = createStompClient();
+    clientRef.current = client;
+    setConnectionStatus("CONNECTING");
+
+    client.onConnect = () => {
+      setConnectionStatus("CONNECTED");
+      subscriptionRef.current = client.subscribe(MESSAGE_QUEUE, (message) => {
+        setLastMessage(parseMessage<TLastMessage>(message));
+      });
+    };
+
+    client.onDisconnect = () => {
+      setConnectionStatus("DISCONNECTED");
+    };
+
+    client.onStompError = () => {
+      setConnectionStatus("ERROR");
+    };
+
+    client.onWebSocketError = () => {
+      setConnectionStatus("ERROR");
+    };
+
+    client.activate();
+  }, []);
+
+  const sendMessage = useCallback((message: unknown) => {
+    const client = clientRef.current;
+    if (!client?.connected) return;
+
+    client.publish({
+      destination: SEND_DESTINATION,
+      body: JSON.stringify(message),
+    });
+  }, []);
+
+  useEffect(() => {
+    connect();
+    return disconnect;
+  }, [connect, disconnect]);
+
+  return { connectionStatus, sendMessage, lastMessage, connect, disconnect };
+}

--- a/frontend/src/shared/lib/websocket/useStomp.ts
+++ b/frontend/src/shared/lib/websocket/useStomp.ts
@@ -22,39 +22,60 @@ function parseMessage<TLastMessage>(message: IMessage): TLastMessage {
 export function useStomp<TLastMessage = unknown>(): UseStompResult<TLastMessage> {
   const clientRef = useRef<Client | null>(null);
   const subscriptionRef = useRef<StompSubscription | null>(null);
+  const connectionStatusRef = useRef<ConnectionStatus>("DISCONNECTED");
   const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>("DISCONNECTED");
   const [lastMessage, setLastMessage] = useState<TLastMessage | null>(null);
+
+  useEffect(() => {
+    connectionStatusRef.current = connectionStatus;
+  }, [connectionStatus]);
 
   const disconnect = useCallback(() => {
     subscriptionRef.current?.unsubscribe();
     subscriptionRef.current = null;
     clientRef.current?.deactivate();
+    connectionStatusRef.current = "DISCONNECTED";
     setConnectionStatus("DISCONNECTED");
   }, []);
 
   const connect = useCallback(() => {
+    if (
+      connectionStatusRef.current === "CONNECTING" ||
+      connectionStatusRef.current === "CONNECTED"
+    ) {
+      return;
+    }
     if (clientRef.current?.connected) return;
 
     const client = createStompClient();
     clientRef.current = client;
+    connectionStatusRef.current = "CONNECTING";
     setConnectionStatus("CONNECTING");
 
     client.onConnect = () => {
+      connectionStatusRef.current = "CONNECTED";
       setConnectionStatus("CONNECTED");
       subscriptionRef.current = client.subscribe(MESSAGE_QUEUE, (message) => {
-        setLastMessage(parseMessage<TLastMessage>(message));
+        try {
+          setLastMessage(parseMessage<TLastMessage>(message));
+        } catch {
+          // Skip malformed messages
+        }
       });
     };
 
     client.onDisconnect = () => {
+      connectionStatusRef.current = "DISCONNECTED";
       setConnectionStatus("DISCONNECTED");
     };
 
     client.onStompError = () => {
+      connectionStatusRef.current = "ERROR";
       setConnectionStatus("ERROR");
     };
 
     client.onWebSocketError = () => {
+      connectionStatusRef.current = "ERROR";
       setConnectionStatus("ERROR");
     };
 


### PR DESCRIPTION
## 개요

유저 전용 채팅 UI를 구현했습니다. STOMP WebSocket 클라이언트, 채팅 도메인 모델, UI 컴포넌트, 페이지 및 라우팅을 포함합니다.

## 변경 사항

### shared/lib/websocket
- stompClient.ts: @stomp/stompjs 기반 클라이언트 팩토리
- useStomp.ts: React Hook (4-state 연결 관리, 메시지 구독/발행)

### entities/chat
- types.ts: ChatMessage, ChatSession 타입 정의
- chatApi.ts: createChatSession REST API

### features/user-chat
- ChatRoom.tsx, MessageList.tsx, MessageInput.tsx, ConnectionStatus.tsx
- 로딩/빈/에러/연결 상태 UI

### pages/user-chat + app/App.tsx
- UserChatPage.tsx: workspaceId 기반 세션 생성
- /workspaces/:workspaceId/chat 라우트

## 검증
- pnpm test: 170 files / 1041 tests passed
- pnpm build: clean
- FSD 규칙 준수, DESIGN.md 적용, 기존 모듈 수정 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 워크스페이스 내 실시간 채팅 페이지 및 라우팅 추가
  * 채팅 UI 추가 — 채팅방, 메시지 목록, 입력창, 연결 상태 표시
  * 채팅 세션 생성/세션 기반 렌더링 및 메시지 송수신(WebSocket) 지원

* **Tests**
  * 채팅 API, 모델, UI 컴포넌트 및 WebSocket 훅/클라이언트 동작 검증용 단위/통합 테스트 추가

* **Chore**
  * STOMP WebSocket 클라이언트 라이브러리 의존성 추가 (실시간 연결 지원)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ajou-2026-1-capstone-5/ostone/pull/263?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->