### PR TITLE
feat(llm-tools): add external slot tool adapter

### DIFF
--- a/.agent/specs/523.md
+++ b/.agent/specs/523.md
@@ -1,0 +1,311 @@
+# 523. External LLM Slot Tool API
+
+## Goal
+
+외부 LLM이 고객 상담 중 현재 세션의 워크플로우 실행 컨텍스트와 slot 정의/값을 조회하고, 필요한 slot 값을 저장할 수 있는 REST 기반 tool API를 제공한다.
+
+이 기능은 MCP 서버 구현이 아니라, 외부 LLM adapter 또는 function calling layer가 HTTP tool로 호출할 수 있는 backend API이다.
+
+## Current Implementation Status
+
+현재 구현은 backend `workflow-runtime` bounded context와 루트 `integrations/llm-tools` adapter에 추가된 상태다. 구현 파일은 아직 Git 기준 untracked 파일을 포함한다.
+
+### 생성/변경된 코드
+
+| Path | Layer | 역할 |
+| --- | --- | --- |
+| `backend/src/main/java/com/init/workflowruntime/presentation/LlmToolController.java` | presentation | `/api/v1/llm-tools/sessions/{sessionId}` 하위 REST endpoint 제공 |
+| `backend/src/main/java/com/init/workflowruntime/application/LlmToolService.java` | application | 세션, workflow execution, slot definition, intent-slot binding을 조합해 tool 응답 생성 |
+| `backend/src/main/java/com/init/workflowruntime/application/dto/LlmToolContextResponse.java` | application DTO | 세션 전체 tool context 응답 |
+| `backend/src/main/java/com/init/workflowruntime/application/dto/LlmToolSlotResponse.java` | application DTO | slot 단건/목록 응답 |
+| `backend/src/main/java/com/init/workflowruntime/application/dto/LlmToolSlotValueResponse.java` | application DTO | slot 값 저장 결과 응답 |
+| `backend/src/main/java/com/init/workflowruntime/application/dto/UpsertSlotValueRequest.java` | application DTO | slot 값 저장 요청 body |
+| `backend/src/main/java/com/init/workflowruntime/domain/WorkflowExecution.java` | domain | `runtime.workflow_execution` 매핑, `slot_values_json` 저장 |
+| `backend/src/main/java/com/init/workflowruntime/domain/WorkflowExecutionRepository.java` | domain repository | 최신 workflow execution 조회 및 저장 port |
+| `backend/src/main/java/com/init/workflowruntime/infrastructure/persistence/JpaWorkflowExecutionRepository.java` | infrastructure | Spring Data JPA repository adapter |
+| `backend/src/main/java/com/init/domainpack/domain/repository/SlotDefinitionRepository.java` | domain repository | `domainPackVersionId + slotCode` 조회 메서드 추가 |
+| `backend/src/main/java/com/init/domainpack/infrastructure/persistence/JpaSlotDefinitionRepository.java` | infrastructure | `domainPackVersionId + slotCode` JPA derived query 추가 |
+| `backend/src/main/java/com/init/shared/infrastructure/security/SecurityConfig.java` | infrastructure/security | `/api/v1/llm-tools/**`를 `OPERATOR` 권한으로 보호 |
+| `backend/src/test/java/com/init/workflowruntime/application/LlmToolServiceTest.java` | test | context 조회, slot 값 저장, 없는 slot 404 검증 |
+| `backend/src/test/java/com/init/workflowruntime/presentation/LlmToolControllerTest.java` | test | REST endpoint 응답과 validation 검증 |
+| `integrations/llm-tools/tool-schema.mjs` | integration | 외부 LLM에 등록할 function tool schema 정의 |
+| `integrations/llm-tools/llm-tool-adapter.mjs` | integration | LLM tool call을 backend REST API 호출로 변환 |
+| `integrations/llm-tools/README.md` | integration docs | adapter 사용 예시와 tool 이름 정리 |
+| `integrations/llm-tools/llm-tool-adapter.test.mjs` | integration test | schema/adapter 동작 검증 |
+
+## LLM Tool Schema And Adapter
+
+외부 LLM에는 `integrations/llm-tools/tool-schema.mjs`의 `llmSlotTools`를 tools로 등록한다.
+
+Tool schema는 `sessionId`를 노출하지 않는다. 현재 상담 세션 ID는 adapter 생성 시 서버 코드가 주입한다. 이렇게 해야 LLM이 임의 session ID를 조작하는 것을 막을 수 있다.
+
+Tool names:
+
+| Tool | Parameters | Backend call |
+| --- | --- | --- |
+| `get_current_slot_context` | none | `GET /api/v1/llm-tools/sessions/{sessionId}/context` |
+| `list_current_slots` | none | `GET /api/v1/llm-tools/sessions/{sessionId}/slots` |
+| `get_current_slot` | `slotCode` | `GET /api/v1/llm-tools/sessions/{sessionId}/slots/{slotCode}` |
+| `upsert_current_slot_value` | `slotCode`, `value` | `PUT /api/v1/llm-tools/sessions/{sessionId}/slots/{slotCode}` |
+
+사용 예시:
+
+```js
+import {
+  createLlmSlotToolHandler,
+  llmSlotTools,
+} from "./integrations/llm-tools/llm-tool-adapter.mjs";
+
+const handleToolCall = createLlmSlotToolHandler({
+  backendBaseUrl: "http://localhost:8080",
+  bearerToken: process.env.OPERATOR_JWT,
+  sessionId: currentSessionId,
+});
+
+// LLM 요청에 llmSlotTools를 tools로 전달한다.
+// LLM이 tool_call을 반환하면 handler에 넘겨 backend REST API를 호출한다.
+const toolResult = await handleToolCall(toolCall);
+```
+
+## REST API
+
+Base path:
+
+```text
+/api/v1/llm-tools/sessions/{sessionId}
+```
+
+Security:
+
+```text
+ROLE_OPERATOR required
+```
+
+### GET `/context`
+
+현재 상담 세션 기준으로 외부 LLM이 필요한 전체 tool context를 반환한다.
+
+Response fields:
+
+| Field | Description |
+| --- | --- |
+| `sessionId` | 상담 세션 ID |
+| `workspaceId` | 세션이 속한 workspace ID |
+| `domainPackVersionId` | 세션이 사용하는 domain pack version ID |
+| `executionId` | 최신 workflow execution ID. 없으면 `null` |
+| `executionStatus` | 최신 workflow execution 상태. 없으면 `null` |
+| `currentState` | 최신 workflow execution 현재 상태. 없으면 `null` |
+| `slotValues` | 현재까지 저장된 slot 값 JSON object |
+| `missingSlots` | active slot 중 값이 없는 slotCode 목록 |
+| `slots` | active slot 정의, binding 정보, 현재 값 목록 |
+
+Example:
+
+```json
+{
+  "sessionId": 1,
+  "workspaceId": 10,
+  "domainPackVersionId": 101,
+  "executionId": 50,
+  "executionStatus": "RUNNING",
+  "currentState": "collect_slots",
+  "slotValues": {
+    "order_id": "A-100"
+  },
+  "missingSlots": ["customer_name"],
+  "slots": [
+    {
+      "id": 11,
+      "slotCode": "order_id",
+      "name": "주문번호",
+      "description": "주문 식별자",
+      "dataType": "STRING",
+      "isSensitive": false,
+      "validationRule": { "type": "string" },
+      "defaultValue": null,
+      "meta": {},
+      "status": "ACTIVE",
+      "required": true,
+      "collectionOrder": 1,
+      "promptHint": "주문번호를 물어본다",
+      "hasValue": true,
+      "value": "A-100"
+    }
+  ]
+}
+```
+
+### GET `/slots`
+
+현재 상담 세션의 domain pack version에 속한 active slot 목록을 반환한다.
+
+동작:
+
+- `ChatSession.domainPackVersionId` 기준으로 slot definition 목록을 조회한다.
+- `SlotDefinition.STATUS_ACTIVE`인 slot만 노출한다.
+- 최신 workflow execution의 `intentDefinitionId`가 있으면 intent-slot binding을 붙여 `required`, `collectionOrder`, `promptHint`를 채운다.
+- 최신 workflow execution이 없으면 stored slot value는 빈 object로 본다.
+
+### GET `/slots/{slotCode}`
+
+특정 slotCode의 정의와 현재 값을 반환한다.
+
+동작:
+
+- 세션의 `domainPackVersionId`에 해당 `slotCode`가 있는지 확인한다.
+- slot status가 `ACTIVE`가 아니면 404와 동일하게 처리한다.
+- 현재 저장 값이 있으면 `hasValue=true`, 없으면 `hasValue=false`와 `value=null`에 준하는 JSON null을 반환한다.
+
+### PUT `/slots/{slotCode}`
+
+외부 LLM이 고객에게서 확보한 slot 값을 저장한다.
+
+Request:
+
+```json
+{
+  "value": "A-200"
+}
+```
+
+Response:
+
+```json
+{
+  "sessionId": 1,
+  "executionId": 50,
+  "slotCode": "order_id",
+  "hasValue": true,
+  "value": "A-200"
+}
+```
+
+동작:
+
+- `value`가 없으면 validation error를 반환한다.
+- 세션의 domain pack version에 active slotCode가 있는지 검증한다.
+- 최신 workflow execution이 있으면 해당 row의 `slot_values_json`을 갱신한다.
+- workflow execution이 없으면 `WorkflowExecution.create(sessionId)`로 `RUNNING` execution을 생성한 뒤 저장한다.
+- 기존 `slot_values_json` object에 `{slotCode: value}`를 upsert한다.
+
+## Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    actor llm as External LLM Adapter
+    participant ctrl as LlmToolController
+    participant svc as LlmToolService
+    participant sessionRepo as ChatSessionRepository
+    participant execRepo as WorkflowExecutionRepository
+    participant slotRepo as SlotDefinitionRepository
+    participant bindingRepo as IntentSlotBindingRepository
+    participant db as PostgreSQL
+
+    llm ->> ctrl: GET /api/v1/llm-tools/sessions/{sessionId}/context
+    ctrl ->> svc: getContext(sessionId)
+    svc ->> sessionRepo: findById(sessionId)
+    sessionRepo ->> db: SELECT runtime.chat_session
+    db -->> sessionRepo: ChatSession
+    svc ->> execRepo: findTopByChatSessionIdOrderByStartedAtDesc(sessionId)
+    execRepo ->> db: SELECT runtime.workflow_execution
+    db -->> execRepo: latest execution or empty
+    svc ->> slotRepo: findAllByDomainPackVersionIdOrderBySlotCodeAsc(versionId)
+    slotRepo ->> db: SELECT pack.slot_definition
+    db -->> slotRepo: slots
+    svc ->> bindingRepo: findAllByIntentDefinitionIdIn(intentDefinitionId)
+    bindingRepo ->> db: SELECT pack.intent_slot_binding
+    db -->> bindingRepo: bindings
+    svc -->> ctrl: LlmToolContextResponse
+    ctrl -->> llm: 200 OK
+```
+
+## Application Logic
+
+### `LlmToolService.getContext`
+
+세션, 최신 workflow execution, active slot 목록, 저장된 slot 값을 한 번에 반환한다. 외부 LLM이 다음 질문을 결정하거나 이미 확보한 정보를 확인할 때 사용하는 기본 endpoint이다.
+
+### `LlmToolService.listSlots`
+
+slot 정의 목록만 필요한 경우 사용한다. 전체 context보다 응답 범위가 작지만, 각 slot의 현재 저장 값과 binding 정보도 포함한다.
+
+### `LlmToolService.getSlot`
+
+외부 LLM이 특정 정보가 필요한 시점에 `slotCode`로 단건 조회한다. 예를 들어 `order_id`가 필요한 tool call을 실행하기 전에 현재 값이 있는지 확인할 수 있다.
+
+### `LlmToolService.upsertSlotValue`
+
+외부 LLM이 고객에게서 slot 값을 얻었을 때 저장한다. 저장 대상은 `runtime.workflow_execution.slot_values_json`이며, 실행이 없으면 새 execution을 생성한다.
+
+## Data Model
+
+### `WorkflowExecution`
+
+`runtime.workflow_execution` table에 대응한다.
+
+주요 필드:
+
+| Field | DB column | Purpose |
+| --- | --- | --- |
+| `chatSessionId` | `chat_session_id` | 상담 세션 연결 |
+| `workflowDefinitionId` | `workflow_definition_id` | 실행 workflow 연결 |
+| `intentDefinitionId` | `intent_definition_id` | 현재 intent 연결 |
+| `status` | `status` | 실행 상태 |
+| `currentState` | `current_state` | 현재 workflow state |
+| `slotValuesJson` | `slot_values_json` | 외부 LLM/tool이 수집한 slot 값 |
+| `policySnapshotJson` | `policy_snapshot_json` | 정책 스냅샷 |
+| `riskSnapshotJson` | `risk_snapshot_json` | 리스크 스냅샷 |
+
+현재 구현은 `slotValuesJson`만 직접 갱신한다.
+
+## Error Handling
+
+| Case | Current behavior |
+| --- | --- |
+| sessionId가 없음 | `SESSION_NOT_FOUND` `NotFoundException` |
+| slotCode가 세션 version에 없음 | `SLOT_DEFINITION_NOT_FOUND` `NotFoundException` |
+| slotCode가 있지만 status가 active가 아님 | `SLOT_DEFINITION_NOT_FOUND` `NotFoundException` |
+| PUT body에 `value` 없음 | validation error |
+| 저장된 JSON이 object가 아님 | `JSON_OBJECT_EXPECTED` `InternalException` |
+| 저장된 JSON parse 실패 | `JSON_PARSE_FAILED` `InternalException` |
+| slot value serialization 실패 | `JSON_WRITE_FAILED` `InternalException` |
+
+## Verification
+
+현재 확인된 검증:
+
+```bash
+cd backend
+./gradlew compileJava test --tests 'com.init.workflowruntime.application.LlmToolServiceTest' --tests 'com.init.workflowruntime.presentation.LlmToolControllerTest'
+
+cd ..
+node --test integrations/llm-tools/llm-tool-adapter.test.mjs
+```
+
+검증 결과:
+
+```text
+BUILD SUCCESSFUL
+tests 5
+pass 5
+```
+
+테스트 커버리지:
+
+- `getContext`가 세션 기준 slot 정의와 저장 값을 함께 반환하는지 검증
+- `upsertSlotValue`가 execution이 없을 때 생성 후 slot 값을 저장하는지 검증
+- 존재하지 않는 slotCode가 404 계열 예외로 처리되는지 검증
+- controller가 context, slot 단건, slot 값 저장 응답을 반환하는지 검증
+- PUT body에 `value`가 없으면 400 validation error가 나는지 검증
+- tool schema가 `sessionId`를 노출하지 않는지 검증
+- OpenAI-style function tool call parsing을 검증
+- `get_current_slot`, `upsert_current_slot_value`가 backend endpoint로 매핑되는지 검증
+
+## Remaining Decisions
+
+1. 외부 연동 표준을 현재 REST tool adapter로 확정할지, 별도 MCP server를 추가할지 결정해야 한다.
+2. 외부 LLM이 사용할 인증 방식은 현재 `ROLE_OPERATOR` JWT 전제다. 서버 간 호출용 token 또는 scoped API key가 필요한지 결정해야 한다.
+3. `slot_values_json` 저장 값에 대한 dataType별 validation은 현재 `SlotDefinition.validationRuleJson`을 응답으로 제공할 뿐, backend가 직접 강제하지 않는다.
+4. sensitive slot 응답 정책은 현재 `isSensitive`를 노출하지만 value masking은 하지 않는다.
+5. 최신 workflow execution 선택 기준은 `startedAt DESC` 하나다. 세션당 execution 수명 정책과 동시성 정책을 정해야 한다.
+6. OpenAPI/Orval generated client 반영 여부는 별도 작업으로 확인해야 한다.

--- a/backend/src/main/java/com/init/domainpack/domain/repository/SlotDefinitionRepository.java
+++ b/backend/src/main/java/com/init/domainpack/domain/repository/SlotDefinitionRepository.java
@@ -19,4 +19,7 @@ public interface SlotDefinitionRepository {
   List<SlotDefinition> findAllByDomainPackVersionIdOrderBySlotCodeAsc(Long domainPackVersionId);
 
   Optional<SlotDefinition> findByIdAndDomainPackVersionId(Long id, Long domainPackVersionId);
+
+  Optional<SlotDefinition> findByDomainPackVersionIdAndSlotCode(
+      Long domainPackVersionId, String slotCode);
 }

--- a/backend/src/main/java/com/init/domainpack/infrastructure/persistence/JpaSlotDefinitionRepository.java
+++ b/backend/src/main/java/com/init/domainpack/infrastructure/persistence/JpaSlotDefinitionRepository.java
@@ -21,4 +21,7 @@ public interface JpaSlotDefinitionRepository
   List<SlotDefinition> findAllByDomainPackVersionIdOrderBySlotCodeAsc(Long domainPackVersionId);
 
   Optional<SlotDefinition> findByIdAndDomainPackVersionId(Long id, Long domainPackVersionId);
+
+  Optional<SlotDefinition> findByDomainPackVersionIdAndSlotCode(
+      Long domainPackVersionId, String slotCode);
 }

--- a/backend/src/main/java/com/init/shared/infrastructure/security/SecurityConfig.java
+++ b/backend/src/main/java/com/init/shared/infrastructure/security/SecurityConfig.java
@@ -62,6 +62,8 @@ public class SecurityConfig {
                     .permitAll()
                     .requestMatchers("/api/v1/consultation/**")
                     .hasRole("OPERATOR")
+                    .requestMatchers("/api/v1/llm-tools/**")
+                    .hasRole("OPERATOR")
                     .anyRequest()
                     .authenticated())
         .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/backend/src/main/java/com/init/workflowruntime/application/LlmToolService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/LlmToolService.java
@@ -130,7 +130,7 @@ public class LlmToolService {
 
   private WorkflowExecution findExecution(Long sessionId) {
     return workflowExecutionRepository
-        .findTopByChatSessionIdOrderByStartedAtDesc(sessionId)
+        .findTopByChatSessionIdOrderByStartedAtDescIdDesc(sessionId)
         .orElse(null);
   }
 

--- a/backend/src/main/java/com/init/workflowruntime/application/LlmToolService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/LlmToolService.java
@@ -12,6 +12,10 @@ import com.init.domainpack.domain.repository.SlotDefinitionRepository;
 import com.init.shared.application.exception.BadRequestException;
 import com.init.shared.application.exception.InternalException;
 import com.init.shared.application.exception.NotFoundException;
+import com.init.workflowruntime.application.command.GetLlmToolContextCommand;
+import com.init.workflowruntime.application.command.GetLlmToolSlotCommand;
+import com.init.workflowruntime.application.command.ListLlmToolSlotsCommand;
+import com.init.workflowruntime.application.command.UpsertLlmToolSlotValueCommand;
 import com.init.workflowruntime.application.dto.LlmToolContextResponse;
 import com.init.workflowruntime.application.dto.LlmToolSlotResponse;
 import com.init.workflowruntime.application.dto.LlmToolSlotValueResponse;
@@ -51,7 +55,8 @@ public class LlmToolService {
     this.objectMapper = objectMapper;
   }
 
-  public LlmToolContextResponse getContext(Long sessionId) {
+  public LlmToolContextResponse getContext(GetLlmToolContextCommand command) {
+    Long sessionId = command.sessionId();
     ChatSession session = findSession(sessionId);
     WorkflowExecution execution = findExecution(sessionId);
     ObjectNode slotValues =
@@ -72,7 +77,8 @@ public class LlmToolService {
         slots);
   }
 
-  public List<LlmToolSlotResponse> listSlots(Long sessionId) {
+  public List<LlmToolSlotResponse> listSlots(ListLlmToolSlotsCommand command) {
+    Long sessionId = command.sessionId();
     ChatSession session = findSession(sessionId);
     WorkflowExecution execution = findExecution(sessionId);
     ObjectNode slotValues =
@@ -80,7 +86,9 @@ public class LlmToolService {
     return buildSlotResponses(session, execution, slotValues);
   }
 
-  public LlmToolSlotResponse getSlot(Long sessionId, String slotCode) {
+  public LlmToolSlotResponse getSlot(GetLlmToolSlotCommand command) {
+    Long sessionId = command.sessionId();
+    String slotCode = command.slotCode();
     ChatSession session = findSession(sessionId);
     WorkflowExecution execution = findExecution(sessionId);
     ObjectNode slotValues =
@@ -91,7 +99,10 @@ public class LlmToolService {
   }
 
   @Transactional
-  public LlmToolSlotValueResponse upsertSlotValue(Long sessionId, String slotCode, JsonNode value) {
+  public LlmToolSlotValueResponse upsertSlotValue(UpsertLlmToolSlotValueCommand command) {
+    Long sessionId = command.sessionId();
+    String slotCode = command.slotCode();
+    JsonNode value = command.value();
     if (value == null) {
       throw new BadRequestException("SLOT_VALUE_REQUIRED", "slot value is required");
     }
@@ -99,7 +110,7 @@ public class LlmToolService {
     ChatSession session = findSession(sessionId);
     findActiveSlot(session.getDomainPackVersionId(), slotCode);
 
-    WorkflowExecution execution = findOrCreateExecution(session);
+    WorkflowExecution execution = findOrCreateExecutionForUpdate(session);
     ObjectNode slotValues = readObjectNode(execution.getSlotValuesJson());
     slotValues.set(slotCode, value.deepCopy());
     execution.replaceSlotValuesJson(writeJson(slotValues));
@@ -123,13 +134,13 @@ public class LlmToolService {
         .orElse(null);
   }
 
-  private WorkflowExecution findOrCreateExecution(ChatSession session) {
+  private WorkflowExecution findOrCreateExecutionForUpdate(ChatSession session) {
     Long sessionId = session.getId();
     if (sessionId == null) {
       throw new InternalException("SESSION_ID_MISSING", "Session ID cannot be null");
     }
     return workflowExecutionRepository
-        .findTopByChatSessionIdOrderByStartedAtDesc(sessionId)
+        .findLatestByChatSessionIdForUpdate(sessionId)
         .orElseGet(() -> workflowExecutionRepository.save(WorkflowExecution.create(sessionId)));
   }
 

--- a/backend/src/main/java/com/init/workflowruntime/application/LlmToolService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/LlmToolService.java
@@ -1,0 +1,247 @@
+package com.init.workflowruntime.application;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.NullNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.init.domainpack.domain.model.IntentSlotBinding;
+import com.init.domainpack.domain.model.SlotDefinition;
+import com.init.domainpack.domain.repository.IntentSlotBindingRepository;
+import com.init.domainpack.domain.repository.SlotDefinitionRepository;
+import com.init.shared.application.exception.BadRequestException;
+import com.init.shared.application.exception.InternalException;
+import com.init.shared.application.exception.NotFoundException;
+import com.init.workflowruntime.application.dto.LlmToolContextResponse;
+import com.init.workflowruntime.application.dto.LlmToolSlotResponse;
+import com.init.workflowruntime.application.dto.LlmToolSlotValueResponse;
+import com.init.workflowruntime.domain.ChatSession;
+import com.init.workflowruntime.domain.ChatSessionRepository;
+import com.init.workflowruntime.domain.WorkflowExecution;
+import com.init.workflowruntime.domain.WorkflowExecutionRepository;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class LlmToolService {
+
+  private final ChatSessionRepository chatSessionRepository;
+  private final WorkflowExecutionRepository workflowExecutionRepository;
+  private final SlotDefinitionRepository slotDefinitionRepository;
+  private final IntentSlotBindingRepository intentSlotBindingRepository;
+  private final ObjectMapper objectMapper;
+
+  public LlmToolService(
+      ChatSessionRepository chatSessionRepository,
+      WorkflowExecutionRepository workflowExecutionRepository,
+      SlotDefinitionRepository slotDefinitionRepository,
+      IntentSlotBindingRepository intentSlotBindingRepository,
+      ObjectMapper objectMapper) {
+    this.chatSessionRepository = chatSessionRepository;
+    this.workflowExecutionRepository = workflowExecutionRepository;
+    this.slotDefinitionRepository = slotDefinitionRepository;
+    this.intentSlotBindingRepository = intentSlotBindingRepository;
+    this.objectMapper = objectMapper;
+  }
+
+  public LlmToolContextResponse getContext(Long sessionId) {
+    ChatSession session = findSession(sessionId);
+    WorkflowExecution execution = findExecution(sessionId);
+    ObjectNode slotValues =
+        readObjectNode(execution != null ? execution.getSlotValuesJson() : "{}");
+    List<LlmToolSlotResponse> slots = buildSlotResponses(session, execution, slotValues);
+    List<String> missingSlots =
+        slots.stream().filter(slot -> !slot.hasValue()).map(LlmToolSlotResponse::slotCode).toList();
+
+    return new LlmToolContextResponse(
+        session.getId(),
+        session.getWorkspaceId(),
+        session.getDomainPackVersionId(),
+        execution != null ? execution.getId() : null,
+        execution != null ? execution.getStatus() : null,
+        execution != null ? execution.getCurrentState() : null,
+        slotValues,
+        missingSlots,
+        slots);
+  }
+
+  public List<LlmToolSlotResponse> listSlots(Long sessionId) {
+    ChatSession session = findSession(sessionId);
+    WorkflowExecution execution = findExecution(sessionId);
+    ObjectNode slotValues =
+        readObjectNode(execution != null ? execution.getSlotValuesJson() : "{}");
+    return buildSlotResponses(session, execution, slotValues);
+  }
+
+  public LlmToolSlotResponse getSlot(Long sessionId, String slotCode) {
+    ChatSession session = findSession(sessionId);
+    WorkflowExecution execution = findExecution(sessionId);
+    ObjectNode slotValues =
+        readObjectNode(execution != null ? execution.getSlotValuesJson() : "{}");
+    SlotDefinition slot = findActiveSlot(session.getDomainPackVersionId(), slotCode);
+    Map<Long, IntentSlotBinding> bindings = loadBindingsBySlotId(execution);
+    return toSlotResponse(slot, bindings.get(slot.getId()), slotValues);
+  }
+
+  @Transactional
+  public LlmToolSlotValueResponse upsertSlotValue(Long sessionId, String slotCode, JsonNode value) {
+    if (value == null) {
+      throw new BadRequestException("SLOT_VALUE_REQUIRED", "slot value is required");
+    }
+
+    ChatSession session = findSession(sessionId);
+    findActiveSlot(session.getDomainPackVersionId(), slotCode);
+
+    WorkflowExecution execution = findOrCreateExecution(session);
+    ObjectNode slotValues = readObjectNode(execution.getSlotValuesJson());
+    slotValues.set(slotCode, value.deepCopy());
+    execution.replaceSlotValuesJson(writeJson(slotValues));
+    WorkflowExecution saved = workflowExecutionRepository.save(execution);
+
+    JsonNode savedValue = slotValues.get(slotCode);
+    return new LlmToolSlotValueResponse(
+        session.getId(), saved.getId(), slotCode, hasValue(slotValues, slotCode), savedValue);
+  }
+
+  private ChatSession findSession(Long sessionId) {
+    return chatSessionRepository
+        .findById(sessionId)
+        .orElseThrow(
+            () -> new NotFoundException("SESSION_NOT_FOUND", "Session not found: " + sessionId));
+  }
+
+  private WorkflowExecution findExecution(Long sessionId) {
+    return workflowExecutionRepository
+        .findTopByChatSessionIdOrderByStartedAtDesc(sessionId)
+        .orElse(null);
+  }
+
+  private WorkflowExecution findOrCreateExecution(ChatSession session) {
+    Long sessionId = session.getId();
+    if (sessionId == null) {
+      throw new InternalException("SESSION_ID_MISSING", "Session ID cannot be null");
+    }
+    return workflowExecutionRepository
+        .findTopByChatSessionIdOrderByStartedAtDesc(sessionId)
+        .orElseGet(() -> workflowExecutionRepository.save(WorkflowExecution.create(sessionId)));
+  }
+
+  private List<LlmToolSlotResponse> buildSlotResponses(
+      ChatSession session, WorkflowExecution execution, ObjectNode slotValues) {
+    Map<Long, IntentSlotBinding> bindings = loadBindingsBySlotId(execution);
+    return slotDefinitionRepository
+        .findAllByDomainPackVersionIdOrderBySlotCodeAsc(session.getDomainPackVersionId())
+        .stream()
+        .filter(slot -> SlotDefinition.STATUS_ACTIVE.equals(slot.getStatus()))
+        .sorted(Comparator.comparing(SlotDefinition::getSlotCode))
+        .map(slot -> toSlotResponse(slot, bindings.get(slot.getId()), slotValues))
+        .toList();
+  }
+
+  private LlmToolSlotResponse toSlotResponse(
+      SlotDefinition slot, IntentSlotBinding binding, ObjectNode slotValues) {
+    String slotCode = slot.getSlotCode();
+    return new LlmToolSlotResponse(
+        slot.getId(),
+        slotCode,
+        slot.getName(),
+        slot.getDescription(),
+        slot.getDataType(),
+        slot.getIsSensitive(),
+        readJsonNode(slot.getValidationRuleJson(), "{}"),
+        readJsonNode(slot.getDefaultValueJson(), null),
+        readJsonNode(slot.getMetaJson(), "{}"),
+        slot.getStatus(),
+        binding != null ? binding.getIsRequired() : false,
+        binding != null ? binding.getCollectionOrder() : null,
+        binding != null ? binding.getPromptHint() : null,
+        hasValue(slotValues, slotCode),
+        slotValues.has(slotCode) ? slotValues.get(slotCode) : NullNode.getInstance());
+  }
+
+  private SlotDefinition findActiveSlot(Long domainPackVersionId, String slotCode) {
+    SlotDefinition slot =
+        slotDefinitionRepository
+            .findByDomainPackVersionIdAndSlotCode(domainPackVersionId, slotCode)
+            .orElseThrow(
+                () ->
+                    new NotFoundException(
+                        "SLOT_DEFINITION_NOT_FOUND", "SlotDefinition not found: " + slotCode));
+    if (!SlotDefinition.STATUS_ACTIVE.equals(slot.getStatus())) {
+      throw new NotFoundException(
+          "SLOT_DEFINITION_NOT_FOUND", "SlotDefinition not found: " + slotCode);
+    }
+    return slot;
+  }
+
+  private Map<Long, IntentSlotBinding> loadBindingsBySlotId(WorkflowExecution execution) {
+    if (execution == null || execution.getIntentDefinitionId() == null) {
+      return Map.of();
+    }
+
+    return intentSlotBindingRepository
+        .findAllByIntentDefinitionIdIn(List.of(execution.getIntentDefinitionId()))
+        .stream()
+        .collect(
+            Collectors.toMap(
+                IntentSlotBinding::getSlotDefinitionId,
+                Function.identity(),
+                this::preferLowerCollectionOrder,
+                LinkedHashMap::new));
+  }
+
+  private IntentSlotBinding preferLowerCollectionOrder(
+      IntentSlotBinding left, IntentSlotBinding right) {
+    Integer leftOrder = left.getCollectionOrder();
+    Integer rightOrder = right.getCollectionOrder();
+    if (leftOrder == null) {
+      return rightOrder == null ? left : right;
+    }
+    if (rightOrder == null) {
+      return left;
+    }
+    return leftOrder <= rightOrder ? left : right;
+  }
+
+  private ObjectNode readObjectNode(String json) {
+    JsonNode node = readJsonNode(json, "{}");
+    if (node.isObject()) {
+      return (ObjectNode) node;
+    }
+    throw new InternalException("JSON_OBJECT_EXPECTED", "Stored JSON value must be an object");
+  }
+
+  private JsonNode readJsonNode(String json, String defaultJson) {
+    String source = json;
+    if (source == null || source.isBlank()) {
+      source = defaultJson;
+    }
+    if (source == null) {
+      return NullNode.getInstance();
+    }
+    try {
+      return objectMapper.readTree(source);
+    } catch (JsonProcessingException e) {
+      throw new InternalException("JSON_PARSE_FAILED", "Stored JSON value cannot be parsed", e);
+    }
+  }
+
+  private String writeJson(JsonNode node) {
+    try {
+      return objectMapper.writeValueAsString(node);
+    } catch (JsonProcessingException e) {
+      throw new InternalException("JSON_WRITE_FAILED", "Slot values cannot be serialized", e);
+    }
+  }
+
+  private boolean hasValue(ObjectNode slotValues, String slotCode) {
+    return slotValues.hasNonNull(slotCode);
+  }
+}

--- a/backend/src/main/java/com/init/workflowruntime/application/command/GetLlmToolContextCommand.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/command/GetLlmToolContextCommand.java
@@ -1,0 +1,3 @@
+package com.init.workflowruntime.application.command;
+
+public record GetLlmToolContextCommand(Long sessionId) {}

--- a/backend/src/main/java/com/init/workflowruntime/application/command/GetLlmToolSlotCommand.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/command/GetLlmToolSlotCommand.java
@@ -1,0 +1,3 @@
+package com.init.workflowruntime.application.command;
+
+public record GetLlmToolSlotCommand(Long sessionId, String slotCode) {}

--- a/backend/src/main/java/com/init/workflowruntime/application/command/ListLlmToolSlotsCommand.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/command/ListLlmToolSlotsCommand.java
@@ -1,0 +1,3 @@
+package com.init.workflowruntime.application.command;
+
+public record ListLlmToolSlotsCommand(Long sessionId) {}

--- a/backend/src/main/java/com/init/workflowruntime/application/command/UpsertLlmToolSlotValueCommand.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/command/UpsertLlmToolSlotValueCommand.java
@@ -1,0 +1,5 @@
+package com.init.workflowruntime.application.command;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public record UpsertLlmToolSlotValueCommand(Long sessionId, String slotCode, JsonNode value) {}

--- a/backend/src/main/java/com/init/workflowruntime/application/dto/LlmToolContextResponse.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/dto/LlmToolContextResponse.java
@@ -1,0 +1,15 @@
+package com.init.workflowruntime.application.dto;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.List;
+
+public record LlmToolContextResponse(
+    Long sessionId,
+    Long workspaceId,
+    Long domainPackVersionId,
+    Long executionId,
+    String executionStatus,
+    String currentState,
+    JsonNode slotValues,
+    List<String> missingSlots,
+    List<LlmToolSlotResponse> slots) {}

--- a/backend/src/main/java/com/init/workflowruntime/application/dto/LlmToolSlotResponse.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/dto/LlmToolSlotResponse.java
@@ -1,0 +1,20 @@
+package com.init.workflowruntime.application.dto;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public record LlmToolSlotResponse(
+    Long id,
+    String slotCode,
+    String name,
+    String description,
+    String dataType,
+    Boolean isSensitive,
+    JsonNode validationRule,
+    JsonNode defaultValue,
+    JsonNode meta,
+    String status,
+    Boolean required,
+    Integer collectionOrder,
+    String promptHint,
+    boolean hasValue,
+    JsonNode value) {}

--- a/backend/src/main/java/com/init/workflowruntime/application/dto/LlmToolSlotValueResponse.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/dto/LlmToolSlotValueResponse.java
@@ -1,0 +1,6 @@
+package com.init.workflowruntime.application.dto;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public record LlmToolSlotValueResponse(
+    Long sessionId, Long executionId, String slotCode, boolean hasValue, JsonNode value) {}

--- a/backend/src/main/java/com/init/workflowruntime/application/dto/UpsertSlotValueRequest.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/dto/UpsertSlotValueRequest.java
@@ -1,0 +1,6 @@
+package com.init.workflowruntime.application.dto;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import jakarta.validation.constraints.NotNull;
+
+public record UpsertSlotValueRequest(@NotNull JsonNode value) {}

--- a/backend/src/main/java/com/init/workflowruntime/domain/WorkflowExecution.java
+++ b/backend/src/main/java/com/init/workflowruntime/domain/WorkflowExecution.java
@@ -1,0 +1,126 @@
+package com.init.workflowruntime.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import java.time.OffsetDateTime;
+import java.util.Objects;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+@Entity
+@Table(name = "workflow_execution", schema = "runtime")
+public class WorkflowExecution {
+
+  public static final String STATUS_RUNNING = "RUNNING";
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "chat_session_id", nullable = false)
+  private Long chatSessionId;
+
+  @Column(name = "workflow_definition_id")
+  private Long workflowDefinitionId;
+
+  @Column(name = "intent_definition_id")
+  private Long intentDefinitionId;
+
+  @Column(nullable = false)
+  private String status;
+
+  @Column(name = "current_state")
+  private String currentState;
+
+  @JdbcTypeCode(SqlTypes.JSON)
+  @Column(name = "slot_values_json", columnDefinition = "jsonb", nullable = false)
+  private String slotValuesJson;
+
+  @JdbcTypeCode(SqlTypes.JSON)
+  @Column(name = "policy_snapshot_json", columnDefinition = "jsonb", nullable = false)
+  private String policySnapshotJson;
+
+  @JdbcTypeCode(SqlTypes.JSON)
+  @Column(name = "risk_snapshot_json", columnDefinition = "jsonb", nullable = false)
+  private String riskSnapshotJson;
+
+  @Column(name = "started_at", nullable = false, updatable = false)
+  private OffsetDateTime startedAt;
+
+  @Column(name = "finished_at")
+  private OffsetDateTime finishedAt;
+
+  protected WorkflowExecution() {}
+
+  public static WorkflowExecution create(Long chatSessionId) {
+    Objects.requireNonNull(chatSessionId, "chatSessionId must not be null");
+
+    WorkflowExecution execution = new WorkflowExecution();
+    execution.chatSessionId = chatSessionId;
+    execution.status = STATUS_RUNNING;
+    execution.slotValuesJson = "{}";
+    execution.policySnapshotJson = "{}";
+    execution.riskSnapshotJson = "{}";
+    return execution;
+  }
+
+  @PrePersist
+  protected void onPersist() {
+    if (this.startedAt == null) {
+      this.startedAt = OffsetDateTime.now();
+    }
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public Long getChatSessionId() {
+    return chatSessionId;
+  }
+
+  public Long getWorkflowDefinitionId() {
+    return workflowDefinitionId;
+  }
+
+  public Long getIntentDefinitionId() {
+    return intentDefinitionId;
+  }
+
+  public String getStatus() {
+    return status;
+  }
+
+  public String getCurrentState() {
+    return currentState;
+  }
+
+  public String getSlotValuesJson() {
+    return slotValuesJson;
+  }
+
+  public String getPolicySnapshotJson() {
+    return policySnapshotJson;
+  }
+
+  public String getRiskSnapshotJson() {
+    return riskSnapshotJson;
+  }
+
+  public OffsetDateTime getStartedAt() {
+    return startedAt;
+  }
+
+  public OffsetDateTime getFinishedAt() {
+    return finishedAt;
+  }
+
+  public void replaceSlotValuesJson(String slotValuesJson) {
+    this.slotValuesJson = slotValuesJson != null ? slotValuesJson : "{}";
+  }
+}

--- a/backend/src/main/java/com/init/workflowruntime/domain/WorkflowExecutionRepository.java
+++ b/backend/src/main/java/com/init/workflowruntime/domain/WorkflowExecutionRepository.java
@@ -4,7 +4,7 @@ import java.util.Optional;
 
 public interface WorkflowExecutionRepository {
 
-  Optional<WorkflowExecution> findTopByChatSessionIdOrderByStartedAtDesc(Long chatSessionId);
+  Optional<WorkflowExecution> findTopByChatSessionIdOrderByStartedAtDescIdDesc(Long chatSessionId);
 
   Optional<WorkflowExecution> findLatestByChatSessionIdForUpdate(Long chatSessionId);
 

--- a/backend/src/main/java/com/init/workflowruntime/domain/WorkflowExecutionRepository.java
+++ b/backend/src/main/java/com/init/workflowruntime/domain/WorkflowExecutionRepository.java
@@ -1,0 +1,10 @@
+package com.init.workflowruntime.domain;
+
+import java.util.Optional;
+
+public interface WorkflowExecutionRepository {
+
+  Optional<WorkflowExecution> findTopByChatSessionIdOrderByStartedAtDesc(Long chatSessionId);
+
+  WorkflowExecution save(WorkflowExecution execution);
+}

--- a/backend/src/main/java/com/init/workflowruntime/domain/WorkflowExecutionRepository.java
+++ b/backend/src/main/java/com/init/workflowruntime/domain/WorkflowExecutionRepository.java
@@ -6,5 +6,7 @@ public interface WorkflowExecutionRepository {
 
   Optional<WorkflowExecution> findTopByChatSessionIdOrderByStartedAtDesc(Long chatSessionId);
 
+  Optional<WorkflowExecution> findLatestByChatSessionIdForUpdate(Long chatSessionId);
+
   WorkflowExecution save(WorkflowExecution execution);
 }

--- a/backend/src/main/java/com/init/workflowruntime/infrastructure/persistence/JpaWorkflowExecutionRepository.java
+++ b/backend/src/main/java/com/init/workflowruntime/infrastructure/persistence/JpaWorkflowExecutionRepository.java
@@ -2,9 +2,35 @@ package com.init.workflowruntime.infrastructure.persistence;
 
 import com.init.workflowruntime.domain.WorkflowExecution;
 import com.init.workflowruntime.domain.WorkflowExecutionRepository;
+import jakarta.persistence.LockModeType;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface JpaWorkflowExecutionRepository
-    extends JpaRepository<WorkflowExecution, Long>, WorkflowExecutionRepository {}
+    extends JpaRepository<WorkflowExecution, Long>, WorkflowExecutionRepository {
+
+  @Override
+  default Optional<WorkflowExecution> findLatestByChatSessionIdForUpdate(Long chatSessionId) {
+    return findAllByChatSessionIdForUpdate(chatSessionId, PageRequest.of(0, 1)).stream()
+        .findFirst();
+  }
+
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query(
+      """
+      select execution
+      from WorkflowExecution execution
+      where execution.chatSessionId = :chatSessionId
+      order by execution.startedAt desc
+      """)
+  List<WorkflowExecution> findAllByChatSessionIdForUpdate(
+      @Param("chatSessionId") Long chatSessionId, Pageable pageable);
+}

--- a/backend/src/main/java/com/init/workflowruntime/infrastructure/persistence/JpaWorkflowExecutionRepository.java
+++ b/backend/src/main/java/com/init/workflowruntime/infrastructure/persistence/JpaWorkflowExecutionRepository.java
@@ -1,0 +1,10 @@
+package com.init.workflowruntime.infrastructure.persistence;
+
+import com.init.workflowruntime.domain.WorkflowExecution;
+import com.init.workflowruntime.domain.WorkflowExecutionRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface JpaWorkflowExecutionRepository
+    extends JpaRepository<WorkflowExecution, Long>, WorkflowExecutionRepository {}

--- a/backend/src/main/java/com/init/workflowruntime/infrastructure/persistence/JpaWorkflowExecutionRepository.java
+++ b/backend/src/main/java/com/init/workflowruntime/infrastructure/persistence/JpaWorkflowExecutionRepository.java
@@ -29,7 +29,7 @@ public interface JpaWorkflowExecutionRepository
       select execution
       from WorkflowExecution execution
       where execution.chatSessionId = :chatSessionId
-      order by execution.startedAt desc
+      order by execution.startedAt desc, execution.id desc
       """)
   List<WorkflowExecution> findAllByChatSessionIdForUpdate(
       @Param("chatSessionId") Long chatSessionId, Pageable pageable);

--- a/backend/src/main/java/com/init/workflowruntime/presentation/LlmToolController.java
+++ b/backend/src/main/java/com/init/workflowruntime/presentation/LlmToolController.java
@@ -1,0 +1,51 @@
+package com.init.workflowruntime.presentation;
+
+import com.init.workflowruntime.application.LlmToolService;
+import com.init.workflowruntime.application.dto.LlmToolContextResponse;
+import com.init.workflowruntime.application.dto.LlmToolSlotResponse;
+import com.init.workflowruntime.application.dto.LlmToolSlotValueResponse;
+import com.init.workflowruntime.application.dto.UpsertSlotValueRequest;
+import jakarta.validation.Valid;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/llm-tools/sessions/{sessionId}")
+public class LlmToolController {
+
+  private final LlmToolService llmToolService;
+
+  public LlmToolController(LlmToolService llmToolService) {
+    this.llmToolService = llmToolService;
+  }
+
+  @GetMapping("/context")
+  public ResponseEntity<LlmToolContextResponse> getContext(@PathVariable Long sessionId) {
+    return ResponseEntity.ok(llmToolService.getContext(sessionId));
+  }
+
+  @GetMapping("/slots")
+  public ResponseEntity<List<LlmToolSlotResponse>> listSlots(@PathVariable Long sessionId) {
+    return ResponseEntity.ok(llmToolService.listSlots(sessionId));
+  }
+
+  @GetMapping("/slots/{slotCode}")
+  public ResponseEntity<LlmToolSlotResponse> getSlot(
+      @PathVariable Long sessionId, @PathVariable String slotCode) {
+    return ResponseEntity.ok(llmToolService.getSlot(sessionId, slotCode));
+  }
+
+  @PutMapping("/slots/{slotCode}")
+  public ResponseEntity<LlmToolSlotValueResponse> upsertSlotValue(
+      @PathVariable Long sessionId,
+      @PathVariable String slotCode,
+      @Valid @RequestBody UpsertSlotValueRequest request) {
+    return ResponseEntity.ok(llmToolService.upsertSlotValue(sessionId, slotCode, request.value()));
+  }
+}

--- a/backend/src/main/java/com/init/workflowruntime/presentation/LlmToolController.java
+++ b/backend/src/main/java/com/init/workflowruntime/presentation/LlmToolController.java
@@ -1,6 +1,10 @@
 package com.init.workflowruntime.presentation;
 
 import com.init.workflowruntime.application.LlmToolService;
+import com.init.workflowruntime.application.command.GetLlmToolContextCommand;
+import com.init.workflowruntime.application.command.GetLlmToolSlotCommand;
+import com.init.workflowruntime.application.command.ListLlmToolSlotsCommand;
+import com.init.workflowruntime.application.command.UpsertLlmToolSlotValueCommand;
 import com.init.workflowruntime.application.dto.LlmToolContextResponse;
 import com.init.workflowruntime.application.dto.LlmToolSlotResponse;
 import com.init.workflowruntime.application.dto.LlmToolSlotValueResponse;
@@ -27,18 +31,19 @@ public class LlmToolController {
 
   @GetMapping("/context")
   public ResponseEntity<LlmToolContextResponse> getContext(@PathVariable Long sessionId) {
-    return ResponseEntity.ok(llmToolService.getContext(sessionId));
+    return ResponseEntity.ok(llmToolService.getContext(new GetLlmToolContextCommand(sessionId)));
   }
 
   @GetMapping("/slots")
   public ResponseEntity<List<LlmToolSlotResponse>> listSlots(@PathVariable Long sessionId) {
-    return ResponseEntity.ok(llmToolService.listSlots(sessionId));
+    return ResponseEntity.ok(llmToolService.listSlots(new ListLlmToolSlotsCommand(sessionId)));
   }
 
   @GetMapping("/slots/{slotCode}")
   public ResponseEntity<LlmToolSlotResponse> getSlot(
       @PathVariable Long sessionId, @PathVariable String slotCode) {
-    return ResponseEntity.ok(llmToolService.getSlot(sessionId, slotCode));
+    return ResponseEntity.ok(
+        llmToolService.getSlot(new GetLlmToolSlotCommand(sessionId, slotCode)));
   }
 
   @PutMapping("/slots/{slotCode}")
@@ -46,6 +51,8 @@ public class LlmToolController {
       @PathVariable Long sessionId,
       @PathVariable String slotCode,
       @Valid @RequestBody UpsertSlotValueRequest request) {
-    return ResponseEntity.ok(llmToolService.upsertSlotValue(sessionId, slotCode, request.value()));
+    return ResponseEntity.ok(
+        llmToolService.upsertSlotValue(
+            new UpsertLlmToolSlotValueCommand(sessionId, slotCode, request.value())));
   }
 }

--- a/backend/src/test/java/com/init/workflowruntime/application/LlmToolServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/LlmToolServiceTest.java
@@ -1,0 +1,268 @@
+package com.init.workflowruntime.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.init.domainpack.domain.model.IntentSlotBinding;
+import com.init.domainpack.domain.model.SlotDefinition;
+import com.init.domainpack.domain.repository.IntentSlotBindingRepository;
+import com.init.domainpack.domain.repository.SlotDefinitionRepository;
+import com.init.shared.application.exception.BadRequestException;
+import com.init.shared.application.exception.NotFoundException;
+import com.init.workflowruntime.application.dto.LlmToolContextResponse;
+import com.init.workflowruntime.application.dto.LlmToolSlotResponse;
+import com.init.workflowruntime.application.dto.LlmToolSlotValueResponse;
+import com.init.workflowruntime.domain.ChatSession;
+import com.init.workflowruntime.domain.ChatSessionRepository;
+import com.init.workflowruntime.domain.ChatSessionStatus;
+import com.init.workflowruntime.domain.WorkflowExecution;
+import com.init.workflowruntime.domain.WorkflowExecutionRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("LlmToolService")
+class LlmToolServiceTest {
+
+  @Mock private ChatSessionRepository chatSessionRepository;
+  @Mock private WorkflowExecutionRepository workflowExecutionRepository;
+  @Mock private SlotDefinitionRepository slotDefinitionRepository;
+  @Mock private IntentSlotBindingRepository intentSlotBindingRepository;
+
+  private ObjectMapper objectMapper;
+  private LlmToolService service;
+
+  @BeforeEach
+  void setUp() {
+    objectMapper = new ObjectMapper();
+    service =
+        new LlmToolService(
+            chatSessionRepository,
+            workflowExecutionRepository,
+            slotDefinitionRepository,
+            intentSlotBindingRepository,
+            objectMapper);
+  }
+
+  @Test
+  @DisplayName("getContext: 세션 기준 slot 정의와 저장 값을 함께 반환한다")
+  void should_returnContextWithSlotsAndValues() {
+    // given
+    ChatSession session = createSession(1L, 10L, 101L);
+    WorkflowExecution execution = createExecution(50L, 1L, 70L, "{\"order_id\":\"A-100\"}");
+    SlotDefinition orderSlot = createSlot(11L, 101L, "order_id");
+    SlotDefinition customerSlot = createSlot(12L, 101L, "customer_name");
+    IntentSlotBinding orderBinding = createBinding(70L, 11L, true, 1, "주문번호를 물어본다");
+    IntentSlotBinding customerBinding = createBinding(70L, 12L, true, 2, "고객명을 물어본다");
+
+    given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+    given(workflowExecutionRepository.findTopByChatSessionIdOrderByStartedAtDesc(1L))
+        .willReturn(Optional.of(execution));
+    given(slotDefinitionRepository.findAllByDomainPackVersionIdOrderBySlotCodeAsc(101L))
+        .willReturn(List.of(customerSlot, orderSlot));
+    given(intentSlotBindingRepository.findAllByIntentDefinitionIdIn(List.of(70L)))
+        .willReturn(List.of(orderBinding, customerBinding));
+
+    // when
+    LlmToolContextResponse result = service.getContext(1L);
+
+    // then
+    assertThat(result.sessionId()).isEqualTo(1L);
+    assertThat(result.executionId()).isEqualTo(50L);
+    assertThat(result.slotValues().get("order_id").asText()).isEqualTo("A-100");
+    assertThat(result.missingSlots()).containsExactly("customer_name");
+    assertThat(result.slots()).hasSize(2);
+    assertThat(result.slots().get(0).slotCode()).isEqualTo("customer_name");
+    assertThat(result.slots().get(0).required()).isTrue();
+    assertThat(result.slots().get(1).hasValue()).isTrue();
+  }
+
+  @Test
+  @DisplayName("listSlots: 실행이 없으면 active slot 정의만 값 없이 반환한다")
+  void should_returnActiveSlotsWithoutValues_when_executionMissing() {
+    // given
+    ChatSession session = createSession(1L, 10L, 101L);
+    SlotDefinition activeSlot = createSlot(11L, 101L, "order_id");
+    SlotDefinition inactiveSlot = createSlot(12L, 101L, "legacy_code");
+    inactiveSlot.changeStatus(SlotDefinition.STATUS_INACTIVE);
+
+    given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+    given(workflowExecutionRepository.findTopByChatSessionIdOrderByStartedAtDesc(1L))
+        .willReturn(Optional.empty());
+    given(slotDefinitionRepository.findAllByDomainPackVersionIdOrderBySlotCodeAsc(101L))
+        .willReturn(List.of(activeSlot, inactiveSlot));
+
+    // when
+    List<LlmToolSlotResponse> result = service.listSlots(1L);
+
+    // then
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).slotCode()).isEqualTo("order_id");
+    assertThat(result.get(0).required()).isFalse();
+    assertThat(result.get(0).hasValue()).isFalse();
+    assertThat(result.get(0).value().isNull()).isTrue();
+  }
+
+  @Test
+  @DisplayName("getSlot: inactive slotCode면 404 예외")
+  void should_throwNotFound_when_slotIsInactive() {
+    // given
+    ChatSession session = createSession(1L, 10L, 101L);
+    SlotDefinition inactiveSlot = createSlot(11L, 101L, "order_id");
+    inactiveSlot.changeStatus(SlotDefinition.STATUS_INACTIVE);
+
+    given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+    given(workflowExecutionRepository.findTopByChatSessionIdOrderByStartedAtDesc(1L))
+        .willReturn(Optional.empty());
+    given(slotDefinitionRepository.findByDomainPackVersionIdAndSlotCode(101L, "order_id"))
+        .willReturn(Optional.of(inactiveSlot));
+
+    // when & then
+    assertThatThrownBy(() -> service.getSlot(1L, "order_id"))
+        .isInstanceOf(NotFoundException.class)
+        .hasMessageContaining("SlotDefinition not found");
+  }
+
+  @Test
+  @DisplayName("upsertSlotValue: 기존 실행이 있으면 slot 값을 덮어쓴다")
+  void should_updateExistingExecution_when_executionExists() throws Exception {
+    // given
+    ChatSession session = createSession(1L, 10L, 101L);
+    SlotDefinition slot = createSlot(11L, 101L, "order_id");
+    WorkflowExecution execution = createExecution(50L, 1L, 70L, "{\"order_id\":\"A-100\"}");
+
+    given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+    given(slotDefinitionRepository.findByDomainPackVersionIdAndSlotCode(101L, "order_id"))
+        .willReturn(Optional.of(slot));
+    given(workflowExecutionRepository.findTopByChatSessionIdOrderByStartedAtDesc(1L))
+        .willReturn(Optional.of(execution));
+    given(workflowExecutionRepository.save(execution)).willReturn(execution);
+
+    JsonNode value = objectMapper.readTree("\"A-200\"");
+
+    // when
+    LlmToolSlotValueResponse result = service.upsertSlotValue(1L, "order_id", value);
+
+    // then
+    assertThat(result.executionId()).isEqualTo(50L);
+    assertThat(result.value().asText()).isEqualTo("A-200");
+    assertThat(objectMapper.readTree(execution.getSlotValuesJson()).get("order_id").asText())
+        .isEqualTo("A-200");
+    verify(workflowExecutionRepository).save(execution);
+  }
+
+  @Test
+  @DisplayName("upsertSlotValue: value가 null이면 400 예외")
+  void should_throwBadRequest_when_valueIsNull() {
+    assertThatThrownBy(() -> service.upsertSlotValue(1L, "order_id", null))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("slot value is required");
+  }
+
+  @Test
+  @DisplayName("upsertSlotValue: 실행이 없으면 생성한 뒤 slot 값을 저장한다")
+  void should_createExecutionAndUpsertSlotValue_when_executionMissing() throws Exception {
+    // given
+    ChatSession session = createSession(1L, 10L, 101L);
+    SlotDefinition slot = createSlot(11L, 101L, "order_id");
+
+    given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+    given(slotDefinitionRepository.findByDomainPackVersionIdAndSlotCode(101L, "order_id"))
+        .willReturn(Optional.of(slot));
+    given(workflowExecutionRepository.findTopByChatSessionIdOrderByStartedAtDesc(1L))
+        .willReturn(Optional.empty());
+    given(workflowExecutionRepository.save(any(WorkflowExecution.class)))
+        .willAnswer(
+            invocation -> {
+              WorkflowExecution execution = invocation.getArgument(0);
+              if (execution.getId() == null) {
+                ReflectionTestUtils.setField(execution, "id", 90L);
+              }
+              return execution;
+            });
+
+    JsonNode value = objectMapper.readTree("\"A-100\"");
+
+    // when
+    LlmToolSlotValueResponse result = service.upsertSlotValue(1L, "order_id", value);
+
+    // then
+    assertThat(result.executionId()).isEqualTo(90L);
+    assertThat(result.slotCode()).isEqualTo("order_id");
+    assertThat(result.hasValue()).isTrue();
+    assertThat(result.value().asText()).isEqualTo("A-100");
+    verify(workflowExecutionRepository, times(2)).save(any(WorkflowExecution.class));
+  }
+
+  @Test
+  @DisplayName("getSlot: 세션 domain pack version에 없는 slotCode면 404 예외")
+  void should_throwNotFound_when_slotCodeMissing() {
+    // given
+    ChatSession session = createSession(1L, 10L, 101L);
+    given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+    given(workflowExecutionRepository.findTopByChatSessionIdOrderByStartedAtDesc(1L))
+        .willReturn(Optional.empty());
+    given(slotDefinitionRepository.findByDomainPackVersionIdAndSlotCode(101L, "unknown"))
+        .willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> service.getSlot(1L, "unknown"))
+        .isInstanceOf(NotFoundException.class)
+        .hasMessageContaining("SlotDefinition not found");
+  }
+
+  private ChatSession createSession(Long id, Long workspaceId, Long versionId) {
+    ChatSession session =
+        ChatSession.create(workspaceId, versionId, ChatSessionStatus.OPEN, "WEB", "{}");
+    ReflectionTestUtils.setField(session, "id", id);
+    return session;
+  }
+
+  private WorkflowExecution createExecution(
+      Long id, Long sessionId, Long intentDefinitionId, String slotValuesJson) {
+    WorkflowExecution execution = WorkflowExecution.create(sessionId);
+    ReflectionTestUtils.setField(execution, "id", id);
+    ReflectionTestUtils.setField(execution, "intentDefinitionId", intentDefinitionId);
+    execution.replaceSlotValuesJson(slotValuesJson);
+    return execution;
+  }
+
+  private SlotDefinition createSlot(Long id, Long versionId, String slotCode) {
+    SlotDefinition slot =
+        SlotDefinition.create(
+            versionId,
+            slotCode,
+            slotCode,
+            "slot description",
+            "STRING",
+            false,
+            "{\"type\":\"string\"}",
+            null,
+            "{}");
+    ReflectionTestUtils.setField(slot, "id", id);
+    return slot;
+  }
+
+  private IntentSlotBinding createBinding(
+      Long intentDefinitionId,
+      Long slotDefinitionId,
+      Boolean required,
+      Integer collectionOrder,
+      String promptHint) {
+    return IntentSlotBinding.create(
+        intentDefinitionId, slotDefinitionId, required, collectionOrder, promptHint, "{}");
+  }
+}

--- a/backend/src/test/java/com/init/workflowruntime/application/LlmToolServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/LlmToolServiceTest.java
@@ -15,6 +15,10 @@ import com.init.domainpack.domain.repository.IntentSlotBindingRepository;
 import com.init.domainpack.domain.repository.SlotDefinitionRepository;
 import com.init.shared.application.exception.BadRequestException;
 import com.init.shared.application.exception.NotFoundException;
+import com.init.workflowruntime.application.command.GetLlmToolContextCommand;
+import com.init.workflowruntime.application.command.GetLlmToolSlotCommand;
+import com.init.workflowruntime.application.command.ListLlmToolSlotsCommand;
+import com.init.workflowruntime.application.command.UpsertLlmToolSlotValueCommand;
 import com.init.workflowruntime.application.dto.LlmToolContextResponse;
 import com.init.workflowruntime.application.dto.LlmToolSlotResponse;
 import com.init.workflowruntime.application.dto.LlmToolSlotValueResponse;
@@ -77,7 +81,7 @@ class LlmToolServiceTest {
         .willReturn(List.of(orderBinding, customerBinding));
 
     // when
-    LlmToolContextResponse result = service.getContext(1L);
+    LlmToolContextResponse result = service.getContext(new GetLlmToolContextCommand(1L));
 
     // then
     assertThat(result.sessionId()).isEqualTo(1L);
@@ -106,7 +110,7 @@ class LlmToolServiceTest {
         .willReturn(List.of(activeSlot, inactiveSlot));
 
     // when
-    List<LlmToolSlotResponse> result = service.listSlots(1L);
+    List<LlmToolSlotResponse> result = service.listSlots(new ListLlmToolSlotsCommand(1L));
 
     // then
     assertThat(result).hasSize(1);
@@ -131,7 +135,7 @@ class LlmToolServiceTest {
         .willReturn(Optional.of(inactiveSlot));
 
     // when & then
-    assertThatThrownBy(() -> service.getSlot(1L, "order_id"))
+    assertThatThrownBy(() -> service.getSlot(new GetLlmToolSlotCommand(1L, "order_id")))
         .isInstanceOf(NotFoundException.class)
         .hasMessageContaining("SlotDefinition not found");
   }
@@ -147,14 +151,15 @@ class LlmToolServiceTest {
     given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
     given(slotDefinitionRepository.findByDomainPackVersionIdAndSlotCode(101L, "order_id"))
         .willReturn(Optional.of(slot));
-    given(workflowExecutionRepository.findTopByChatSessionIdOrderByStartedAtDesc(1L))
+    given(workflowExecutionRepository.findLatestByChatSessionIdForUpdate(1L))
         .willReturn(Optional.of(execution));
     given(workflowExecutionRepository.save(execution)).willReturn(execution);
 
     JsonNode value = objectMapper.readTree("\"A-200\"");
 
     // when
-    LlmToolSlotValueResponse result = service.upsertSlotValue(1L, "order_id", value);
+    LlmToolSlotValueResponse result =
+        service.upsertSlotValue(new UpsertLlmToolSlotValueCommand(1L, "order_id", value));
 
     // then
     assertThat(result.executionId()).isEqualTo(50L);
@@ -167,7 +172,8 @@ class LlmToolServiceTest {
   @Test
   @DisplayName("upsertSlotValue: value가 null이면 400 예외")
   void should_throwBadRequest_when_valueIsNull() {
-    assertThatThrownBy(() -> service.upsertSlotValue(1L, "order_id", null))
+    assertThatThrownBy(
+            () -> service.upsertSlotValue(new UpsertLlmToolSlotValueCommand(1L, "order_id", null)))
         .isInstanceOf(BadRequestException.class)
         .hasMessageContaining("slot value is required");
   }
@@ -182,7 +188,7 @@ class LlmToolServiceTest {
     given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
     given(slotDefinitionRepository.findByDomainPackVersionIdAndSlotCode(101L, "order_id"))
         .willReturn(Optional.of(slot));
-    given(workflowExecutionRepository.findTopByChatSessionIdOrderByStartedAtDesc(1L))
+    given(workflowExecutionRepository.findLatestByChatSessionIdForUpdate(1L))
         .willReturn(Optional.empty());
     given(workflowExecutionRepository.save(any(WorkflowExecution.class)))
         .willAnswer(
@@ -197,7 +203,8 @@ class LlmToolServiceTest {
     JsonNode value = objectMapper.readTree("\"A-100\"");
 
     // when
-    LlmToolSlotValueResponse result = service.upsertSlotValue(1L, "order_id", value);
+    LlmToolSlotValueResponse result =
+        service.upsertSlotValue(new UpsertLlmToolSlotValueCommand(1L, "order_id", value));
 
     // then
     assertThat(result.executionId()).isEqualTo(90L);
@@ -219,7 +226,7 @@ class LlmToolServiceTest {
         .willReturn(Optional.empty());
 
     // when & then
-    assertThatThrownBy(() -> service.getSlot(1L, "unknown"))
+    assertThatThrownBy(() -> service.getSlot(new GetLlmToolSlotCommand(1L, "unknown")))
         .isInstanceOf(NotFoundException.class)
         .hasMessageContaining("SlotDefinition not found");
   }

--- a/backend/src/test/java/com/init/workflowruntime/application/LlmToolServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/LlmToolServiceTest.java
@@ -73,7 +73,7 @@ class LlmToolServiceTest {
     IntentSlotBinding customerBinding = createBinding(70L, 12L, true, 2, "고객명을 물어본다");
 
     given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
-    given(workflowExecutionRepository.findTopByChatSessionIdOrderByStartedAtDesc(1L))
+    given(workflowExecutionRepository.findTopByChatSessionIdOrderByStartedAtDescIdDesc(1L))
         .willReturn(Optional.of(execution));
     given(slotDefinitionRepository.findAllByDomainPackVersionIdOrderBySlotCodeAsc(101L))
         .willReturn(List.of(customerSlot, orderSlot));
@@ -104,7 +104,7 @@ class LlmToolServiceTest {
     inactiveSlot.changeStatus(SlotDefinition.STATUS_INACTIVE);
 
     given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
-    given(workflowExecutionRepository.findTopByChatSessionIdOrderByStartedAtDesc(1L))
+    given(workflowExecutionRepository.findTopByChatSessionIdOrderByStartedAtDescIdDesc(1L))
         .willReturn(Optional.empty());
     given(slotDefinitionRepository.findAllByDomainPackVersionIdOrderBySlotCodeAsc(101L))
         .willReturn(List.of(activeSlot, inactiveSlot));
@@ -129,7 +129,7 @@ class LlmToolServiceTest {
     inactiveSlot.changeStatus(SlotDefinition.STATUS_INACTIVE);
 
     given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
-    given(workflowExecutionRepository.findTopByChatSessionIdOrderByStartedAtDesc(1L))
+    given(workflowExecutionRepository.findTopByChatSessionIdOrderByStartedAtDescIdDesc(1L))
         .willReturn(Optional.empty());
     given(slotDefinitionRepository.findByDomainPackVersionIdAndSlotCode(101L, "order_id"))
         .willReturn(Optional.of(inactiveSlot));
@@ -220,7 +220,7 @@ class LlmToolServiceTest {
     // given
     ChatSession session = createSession(1L, 10L, 101L);
     given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
-    given(workflowExecutionRepository.findTopByChatSessionIdOrderByStartedAtDesc(1L))
+    given(workflowExecutionRepository.findTopByChatSessionIdOrderByStartedAtDescIdDesc(1L))
         .willReturn(Optional.empty());
     given(slotDefinitionRepository.findByDomainPackVersionIdAndSlotCode(101L, "unknown"))
         .willReturn(Optional.empty());

--- a/backend/src/test/java/com/init/workflowruntime/domain/WorkflowExecutionTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/domain/WorkflowExecutionTest.java
@@ -1,0 +1,61 @@
+package com.init.workflowruntime.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@DisplayName("WorkflowExecution")
+class WorkflowExecutionTest {
+
+  @Test
+  @DisplayName("create: 실행 기본값을 초기화한다")
+  void should_initializeDefaults_when_create() {
+    WorkflowExecution execution = WorkflowExecution.create(1L);
+
+    assertThat(execution.getChatSessionId()).isEqualTo(1L);
+    assertThat(execution.getWorkflowDefinitionId()).isNull();
+    assertThat(execution.getIntentDefinitionId()).isNull();
+    assertThat(execution.getStatus()).isEqualTo(WorkflowExecution.STATUS_RUNNING);
+    assertThat(execution.getCurrentState()).isNull();
+    assertThat(execution.getSlotValuesJson()).isEqualTo("{}");
+    assertThat(execution.getPolicySnapshotJson()).isEqualTo("{}");
+    assertThat(execution.getRiskSnapshotJson()).isEqualTo("{}");
+    assertThat(execution.getFinishedAt()).isNull();
+  }
+
+  @Test
+  @DisplayName("create: chatSessionId가 null이면 예외")
+  void should_throw_when_chatSessionIdIsNull() {
+    assertThatNullPointerException().isThrownBy(() -> WorkflowExecution.create(null));
+  }
+
+  @Test
+  @DisplayName("onPersist: startedAt이 없을 때만 시작 시각을 채운다")
+  void should_setStartedAtOnlyWhenMissing_when_onPersist() {
+    WorkflowExecution execution = WorkflowExecution.create(1L);
+
+    execution.onPersist();
+    OffsetDateTime firstStartedAt = execution.getStartedAt();
+
+    execution.onPersist();
+
+    assertThat(firstStartedAt).isNotNull();
+    assertThat(execution.getStartedAt()).isEqualTo(firstStartedAt);
+  }
+
+  @Test
+  @DisplayName("replaceSlotValuesJson: null은 빈 JSON object로 저장한다")
+  void should_replaceSlotValuesWithEmptyJson_when_valueIsNull() {
+    WorkflowExecution execution = WorkflowExecution.create(1L);
+    ReflectionTestUtils.setField(execution, "id", 10L);
+
+    execution.replaceSlotValuesJson(null);
+
+    assertThat(execution.getId()).isEqualTo(10L);
+    assertThat(execution.getSlotValuesJson()).isEqualTo("{}");
+  }
+}

--- a/backend/src/test/java/com/init/workflowruntime/presentation/LlmToolControllerSecurityTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/presentation/LlmToolControllerSecurityTest.java
@@ -1,0 +1,74 @@
+package com.init.workflowruntime.presentation;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.init.auth.application.JwtService;
+import com.init.shared.infrastructure.security.ApiAuthenticationEntryPoint;
+import com.init.shared.infrastructure.security.JwtAuthenticationFilter;
+import com.init.shared.infrastructure.security.SecurityConfig;
+import com.init.workflowruntime.application.LlmToolService;
+import com.init.workflowruntime.application.command.GetLlmToolContextCommand;
+import com.init.workflowruntime.application.dto.LlmToolContextResponse;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(LlmToolController.class)
+@Import({SecurityConfig.class, JwtAuthenticationFilter.class, ApiAuthenticationEntryPoint.class})
+@TestPropertySource(properties = "cors.allowed-origins=http://localhost:5173")
+@DisplayName("LlmToolController security")
+class LlmToolControllerSecurityTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @Autowired private ObjectMapper objectMapper;
+
+  @MockitoBean private LlmToolService llmToolService;
+
+  @MockitoBean private JwtService jwtService;
+
+  @Test
+  @DisplayName("인증되지 않은 요청이면 401")
+  void should_return401_when_unauthenticated() throws Exception {
+    mockMvc
+        .perform(get("/api/v1/llm-tools/sessions/1/context"))
+        .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @WithMockUser(roles = "USER")
+  @DisplayName("ROLE_OPERATOR가 없으면 403")
+  void should_return403_when_userIsNotOperator() throws Exception {
+    mockMvc.perform(get("/api/v1/llm-tools/sessions/1/context")).andExpect(status().isForbidden());
+  }
+
+  @Test
+  @WithMockUser(roles = "OPERATOR")
+  @DisplayName("ROLE_OPERATOR면 200")
+  void should_return200_when_userIsOperator() throws Exception {
+    given(llmToolService.getContext(new GetLlmToolContextCommand(1L)))
+        .willReturn(
+            new LlmToolContextResponse(
+                1L,
+                10L,
+                101L,
+                null,
+                null,
+                null,
+                objectMapper.readTree("{}"),
+                List.of(),
+                List.of()));
+
+    mockMvc.perform(get("/api/v1/llm-tools/sessions/1/context")).andExpect(status().isOk());
+  }
+}

--- a/backend/src/test/java/com/init/workflowruntime/presentation/LlmToolControllerTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/presentation/LlmToolControllerTest.java
@@ -1,7 +1,6 @@
 package com.init.workflowruntime.presentation;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -11,6 +10,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.init.shared.infrastructure.security.JwtAuthenticationFilter;
 import com.init.workflowruntime.application.LlmToolService;
+import com.init.workflowruntime.application.command.GetLlmToolContextCommand;
+import com.init.workflowruntime.application.command.GetLlmToolSlotCommand;
+import com.init.workflowruntime.application.command.ListLlmToolSlotsCommand;
+import com.init.workflowruntime.application.command.UpsertLlmToolSlotValueCommand;
 import com.init.workflowruntime.application.dto.LlmToolContextResponse;
 import com.init.workflowruntime.application.dto.LlmToolSlotResponse;
 import com.init.workflowruntime.application.dto.LlmToolSlotValueResponse;
@@ -46,7 +49,7 @@ class LlmToolControllerTest {
   @DisplayName("GET /api/v1/llm-tools/sessions/{sessionId}/context → 200 OK")
   void should_returnContext_when_validRequest() throws Exception {
     // given
-    given(llmToolService.getContext(1L))
+    given(llmToolService.getContext(new GetLlmToolContextCommand(1L)))
         .willReturn(
             new LlmToolContextResponse(
                 1L,
@@ -73,7 +76,8 @@ class LlmToolControllerTest {
   @DisplayName("GET /api/v1/llm-tools/sessions/{sessionId}/slots → 200 OK")
   void should_returnSlots_when_validRequest() throws Exception {
     // given
-    given(llmToolService.listSlots(1L)).willReturn(List.of(slotResponse("order_id", true)));
+    given(llmToolService.listSlots(new ListLlmToolSlotsCommand(1L)))
+        .willReturn(List.of(slotResponse("order_id", true)));
 
     // when & then
     mockMvc
@@ -87,7 +91,8 @@ class LlmToolControllerTest {
   @DisplayName("GET /api/v1/llm-tools/sessions/{sessionId}/slots/{slotCode} → 200 OK")
   void should_returnSlot_when_validRequest() throws Exception {
     // given
-    given(llmToolService.getSlot(1L, "order_id")).willReturn(slotResponse("order_id", true));
+    given(llmToolService.getSlot(new GetLlmToolSlotCommand(1L, "order_id")))
+        .willReturn(slotResponse("order_id", true));
 
     // when & then
     mockMvc
@@ -102,7 +107,7 @@ class LlmToolControllerTest {
   @DisplayName("PUT /api/v1/llm-tools/sessions/{sessionId}/slots/{slotCode} → 200 OK")
   void should_upsertSlotValue_when_validRequest() throws Exception {
     // given
-    given(llmToolService.upsertSlotValue(eq(1L), eq("order_id"), any()))
+    given(llmToolService.upsertSlotValue(any(UpsertLlmToolSlotValueCommand.class)))
         .willReturn(
             new LlmToolSlotValueResponse(
                 1L, 50L, "order_id", true, objectMapper.readTree("\"A-200\"")));

--- a/backend/src/test/java/com/init/workflowruntime/presentation/LlmToolControllerTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/presentation/LlmToolControllerTest.java
@@ -1,0 +1,152 @@
+package com.init.workflowruntime.presentation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.init.shared.infrastructure.security.JwtAuthenticationFilter;
+import com.init.workflowruntime.application.LlmToolService;
+import com.init.workflowruntime.application.dto.LlmToolContextResponse;
+import com.init.workflowruntime.application.dto.LlmToolSlotResponse;
+import com.init.workflowruntime.application.dto.LlmToolSlotValueResponse;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(
+    value = LlmToolController.class,
+    excludeFilters =
+        @ComponentScan.Filter(
+            type = FilterType.ASSIGNABLE_TYPE,
+            classes = JwtAuthenticationFilter.class))
+@AutoConfigureMockMvc(addFilters = false)
+@DisplayName("LlmToolController")
+class LlmToolControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @Autowired private ObjectMapper objectMapper;
+
+  @MockitoBean private LlmToolService llmToolService;
+
+  @Test
+  @DisplayName("GET /api/v1/llm-tools/sessions/{sessionId}/context → 200 OK")
+  void should_returnContext_when_validRequest() throws Exception {
+    // given
+    given(llmToolService.getContext(1L))
+        .willReturn(
+            new LlmToolContextResponse(
+                1L,
+                10L,
+                101L,
+                50L,
+                "RUNNING",
+                "collect_slots",
+                objectMapper.readTree("{\"order_id\":\"A-100\"}"),
+                List.of("customer_name"),
+                List.of(slotResponse("order_id", true))));
+
+    // when & then
+    mockMvc
+        .perform(get("/api/v1/llm-tools/sessions/1/context"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.sessionId").value(1))
+        .andExpect(jsonPath("$.slotValues.order_id").value("A-100"))
+        .andExpect(jsonPath("$.missingSlots[0]").value("customer_name"))
+        .andExpect(jsonPath("$.slots[0].slotCode").value("order_id"));
+  }
+
+  @Test
+  @DisplayName("GET /api/v1/llm-tools/sessions/{sessionId}/slots → 200 OK")
+  void should_returnSlots_when_validRequest() throws Exception {
+    // given
+    given(llmToolService.listSlots(1L)).willReturn(List.of(slotResponse("order_id", true)));
+
+    // when & then
+    mockMvc
+        .perform(get("/api/v1/llm-tools/sessions/1/slots"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].slotCode").value("order_id"))
+        .andExpect(jsonPath("$[0].hasValue").value(true));
+  }
+
+  @Test
+  @DisplayName("GET /api/v1/llm-tools/sessions/{sessionId}/slots/{slotCode} → 200 OK")
+  void should_returnSlot_when_validRequest() throws Exception {
+    // given
+    given(llmToolService.getSlot(1L, "order_id")).willReturn(slotResponse("order_id", true));
+
+    // when & then
+    mockMvc
+        .perform(get("/api/v1/llm-tools/sessions/1/slots/order_id"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.slotCode").value("order_id"))
+        .andExpect(jsonPath("$.hasValue").value(true))
+        .andExpect(jsonPath("$.value").value("A-100"));
+  }
+
+  @Test
+  @DisplayName("PUT /api/v1/llm-tools/sessions/{sessionId}/slots/{slotCode} → 200 OK")
+  void should_upsertSlotValue_when_validRequest() throws Exception {
+    // given
+    given(llmToolService.upsertSlotValue(eq(1L), eq("order_id"), any()))
+        .willReturn(
+            new LlmToolSlotValueResponse(
+                1L, 50L, "order_id", true, objectMapper.readTree("\"A-200\"")));
+
+    // when & then
+    mockMvc
+        .perform(
+            put("/api/v1/llm-tools/sessions/1/slots/order_id")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"value\":\"A-200\"}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.executionId").value(50))
+        .andExpect(jsonPath("$.slotCode").value("order_id"))
+        .andExpect(jsonPath("$.value").value("A-200"));
+  }
+
+  @Test
+  @DisplayName("PUT /api/v1/llm-tools/sessions/{sessionId}/slots/{slotCode} value 누락 → 400")
+  void should_return400_when_valueMissing() throws Exception {
+    mockMvc
+        .perform(
+            put("/api/v1/llm-tools/sessions/1/slots/order_id")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+  }
+
+  private LlmToolSlotResponse slotResponse(String slotCode, boolean hasValue) throws Exception {
+    return new LlmToolSlotResponse(
+        11L,
+        slotCode,
+        "주문번호",
+        "주문 식별자",
+        "STRING",
+        false,
+        objectMapper.readTree("{\"type\":\"string\"}"),
+        null,
+        objectMapper.readTree("{}"),
+        "ACTIVE",
+        true,
+        1,
+        "주문번호를 물어본다",
+        hasValue,
+        hasValue ? objectMapper.readTree("\"A-100\"") : null);
+  }
+}

--- a/integrations/llm-tools/README.md
+++ b/integrations/llm-tools/README.md
@@ -1,0 +1,42 @@
+# LLM Slot Tools
+
+이 모듈은 외부 LLM function calling layer가 backend의 slot tool REST API를 호출하도록 연결한다.
+
+현재 backend endpoint:
+
+```text
+GET /api/v1/llm-tools/sessions/{sessionId}/context
+GET /api/v1/llm-tools/sessions/{sessionId}/slots
+GET /api/v1/llm-tools/sessions/{sessionId}/slots/{slotCode}
+PUT /api/v1/llm-tools/sessions/{sessionId}/slots/{slotCode}
+```
+
+## Usage
+
+```js
+import {
+  createLlmSlotToolHandler,
+  llmSlotTools,
+} from "./integrations/llm-tools/llm-tool-adapter.mjs";
+
+const handleToolCall = createLlmSlotToolHandler({
+  backendBaseUrl: "http://localhost:8080",
+  bearerToken: process.env.OPERATOR_JWT,
+  sessionId: currentSessionId,
+});
+
+// LLM 요청에 llmSlotTools를 tools로 전달한다.
+// LLM이 tool_call을 반환하면 handler에 넘겨 backend REST API를 호출한다.
+const toolResult = await handleToolCall(toolCall);
+```
+
+`sessionId`는 tool schema에 노출하지 않는다. 현재 상담 세션은 adapter가 주입한다.
+
+## Tool Names
+
+| Tool | Purpose |
+| --- | --- |
+| `get_current_slot_context` | 현재 세션의 전체 slot context, missing slot 목록, 저장된 값을 조회 |
+| `list_current_slots` | 현재 세션의 active slot 목록 조회 |
+| `get_current_slot` | 특정 `slotCode`의 정의와 현재 값 조회 |
+| `upsert_current_slot_value` | 특정 `slotCode`에 수집한 값을 저장 |

--- a/integrations/llm-tools/README.md
+++ b/integrations/llm-tools/README.md
@@ -17,7 +17,7 @@ PUT /api/v1/llm-tools/sessions/{sessionId}/slots/{slotCode}
 import {
   createLlmSlotToolHandler,
   llmSlotTools,
-} from "./integrations/llm-tools/llm-tool-adapter.mjs";
+} from "./llm-tool-adapter.mjs";
 
 const handleToolCall = createLlmSlotToolHandler({
   backendBaseUrl: "http://localhost:8080",

--- a/integrations/llm-tools/llm-tool-adapter.mjs
+++ b/integrations/llm-tools/llm-tool-adapter.mjs
@@ -76,16 +76,15 @@ export function createLlmSlotToolHandler({
       body: body !== undefined ? JSON.stringify(body) : undefined,
     });
     const responseText = await response.text();
-    const payload = responseText ? JSON.parse(responseText) : null;
 
     if (!response.ok) {
       const error = new Error(`LLM slot tool request failed: ${response.status}`);
       error.status = response.status;
-      error.payload = payload;
+      error.payload = parseResponsePayload(responseText);
       throw error;
     }
 
-    return payload;
+    return responseText ? JSON.parse(responseText) : null;
   }
 }
 
@@ -104,7 +103,9 @@ export function parseToolCall(toolCall) {
 
 export function buildToolUrl(backendBaseUrl, sessionId, path) {
   const baseUrl = backendBaseUrl.endsWith("/") ? backendBaseUrl : `${backendBaseUrl}/`;
-  const relativePath = `api/v1/llm-tools/sessions/${encodeURIComponent(sessionId)}${path}`;
+  const normalizedPath = path ? (path.startsWith("/") ? path : `/${path}`) : "";
+  const relativePath =
+    `api/v1/llm-tools/sessions/${encodeURIComponent(sessionId)}${normalizedPath}`;
   return new URL(relativePath, baseUrl).toString();
 }
 
@@ -125,6 +126,17 @@ function requireString(args, key) {
     throw new Error(`${key} must be a non-empty string`);
   }
   return value;
+}
+
+function parseResponsePayload(responseText) {
+  if (!responseText) {
+    return null;
+  }
+  try {
+    return JSON.parse(responseText);
+  } catch {
+    return responseText;
+  }
 }
 
 function wrapToolResult(toolCall, name, result) {

--- a/integrations/llm-tools/llm-tool-adapter.mjs
+++ b/integrations/llm-tools/llm-tool-adapter.mjs
@@ -1,0 +1,136 @@
+import { LLM_SLOT_TOOL_NAMES, llmSlotTools } from "./tool-schema.mjs";
+
+export { LLM_SLOT_TOOL_NAMES, llmSlotTools };
+
+export function createLlmSlotToolHandler({
+  backendBaseUrl,
+  bearerToken,
+  sessionId,
+  fetchImpl = globalThis.fetch,
+} = {}) {
+  if (!backendBaseUrl) {
+    throw new Error("backendBaseUrl is required");
+  }
+  if (!sessionId) {
+    throw new Error("sessionId is required");
+  }
+  if (typeof fetchImpl !== "function") {
+    throw new Error("fetchImpl must be a function");
+  }
+
+  return async function handleLlmSlotToolCall(toolCall) {
+    const { name, arguments: args } = parseToolCall(toolCall);
+
+    switch (name) {
+      case LLM_SLOT_TOOL_NAMES.getContext:
+        return wrapToolResult(toolCall, name, await requestJson("/context"));
+
+      case LLM_SLOT_TOOL_NAMES.listSlots:
+        return wrapToolResult(toolCall, name, await requestJson("/slots"));
+
+      case LLM_SLOT_TOOL_NAMES.getSlot: {
+        const slotCode = requireString(args, "slotCode");
+        return wrapToolResult(
+          toolCall,
+          name,
+          await requestJson(`/slots/${encodeURIComponent(slotCode)}`),
+        );
+      }
+
+      case LLM_SLOT_TOOL_NAMES.upsertSlotValue: {
+        const slotCode = requireString(args, "slotCode");
+        if (!Object.prototype.hasOwnProperty.call(args, "value")) {
+          throw new Error("value is required");
+        }
+        return wrapToolResult(
+          toolCall,
+          name,
+          await requestJson(`/slots/${encodeURIComponent(slotCode)}`, {
+            method: "PUT",
+            body: { value: args.value },
+          }),
+        );
+      }
+
+      default:
+        throw new Error(`Unsupported tool call: ${name}`);
+    }
+  };
+
+  async function requestJson(path, { method = "GET", body } = {}) {
+    const url = buildToolUrl(backendBaseUrl, sessionId, path);
+    const headers = {
+      Accept: "application/json",
+    };
+    const token = typeof bearerToken === "function" ? await bearerToken() : bearerToken;
+    if (token) {
+      headers.Authorization = `Bearer ${token}`;
+    }
+    if (body !== undefined) {
+      headers["Content-Type"] = "application/json";
+    }
+
+    const response = await fetchImpl(url, {
+      method,
+      headers,
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    });
+    const responseText = await response.text();
+    const payload = responseText ? JSON.parse(responseText) : null;
+
+    if (!response.ok) {
+      const error = new Error(`LLM slot tool request failed: ${response.status}`);
+      error.status = response.status;
+      error.payload = payload;
+      throw error;
+    }
+
+    return payload;
+  }
+}
+
+export function parseToolCall(toolCall) {
+  const name = toolCall?.function?.name ?? toolCall?.name;
+  if (!name) {
+    throw new Error("tool call name is required");
+  }
+
+  const rawArguments = toolCall?.function?.arguments ?? toolCall?.arguments ?? {};
+  return {
+    name,
+    arguments: parseArguments(rawArguments),
+  };
+}
+
+export function buildToolUrl(backendBaseUrl, sessionId, path) {
+  const baseUrl = backendBaseUrl.endsWith("/") ? backendBaseUrl : `${backendBaseUrl}/`;
+  const relativePath = `api/v1/llm-tools/sessions/${encodeURIComponent(sessionId)}${path}`;
+  return new URL(relativePath, baseUrl).toString();
+}
+
+function parseArguments(rawArguments) {
+  if (typeof rawArguments === "string") {
+    const trimmed = rawArguments.trim();
+    return trimmed ? JSON.parse(trimmed) : {};
+  }
+  if (rawArguments && typeof rawArguments === "object") {
+    return rawArguments;
+  }
+  return {};
+}
+
+function requireString(args, key) {
+  const value = args[key];
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`${key} must be a non-empty string`);
+  }
+  return value;
+}
+
+function wrapToolResult(toolCall, name, result) {
+  return {
+    toolCallId: toolCall?.id ?? toolCall?.call_id ?? null,
+    name,
+    result,
+  };
+}

--- a/integrations/llm-tools/llm-tool-adapter.test.mjs
+++ b/integrations/llm-tools/llm-tool-adapter.test.mjs
@@ -39,6 +39,10 @@ describe("llm slot tools", () => {
       buildToolUrl("http://localhost:8080", 7, "/slots/order_id"),
       "http://localhost:8080/api/v1/llm-tools/sessions/7/slots/order_id",
     );
+    assert.equal(
+      buildToolUrl("http://localhost:8080/", 7, "slots/order_id"),
+      "http://localhost:8080/api/v1/llm-tools/sessions/7/slots/order_id",
+    );
   });
 
   it("maps get_current_slot tool calls to the backend slot endpoint", async () => {
@@ -99,5 +103,30 @@ describe("llm slot tools", () => {
     assert.equal(requests[0].init.method, "PUT");
     assert.equal(requests[0].init.headers["Content-Type"], "application/json");
     assert.equal(requests[0].init.body, "{\"value\":\"A-200\"}");
+  });
+
+  it("preserves status and non-JSON payloads from failed backend responses", async () => {
+    const handler = createLlmSlotToolHandler({
+      backendBaseUrl: "http://localhost:8080",
+      sessionId: 7,
+      fetchImpl: async () => ({
+        ok: false,
+        status: 502,
+        text: async () => "bad gateway",
+      }),
+    });
+
+    await assert.rejects(
+      () =>
+        handler({
+          name: LLM_SLOT_TOOL_NAMES.listSlots,
+          arguments: {},
+        }),
+      error => {
+        assert.equal(error.status, 502);
+        assert.equal(error.payload, "bad gateway");
+        return true;
+      },
+    );
   });
 });

--- a/integrations/llm-tools/llm-tool-adapter.test.mjs
+++ b/integrations/llm-tools/llm-tool-adapter.test.mjs
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  LLM_SLOT_TOOL_NAMES,
+  buildToolUrl,
+  createLlmSlotToolHandler,
+  llmSlotTools,
+  parseToolCall,
+} from "./llm-tool-adapter.mjs";
+
+describe("llm slot tools", () => {
+  it("does not expose sessionId in tool schemas", () => {
+    for (const tool of llmSlotTools) {
+      assert.equal(
+        Object.prototype.hasOwnProperty.call(tool.function.parameters.properties, "sessionId"),
+        false,
+      );
+    }
+  });
+
+  it("parses OpenAI-style function tool calls", () => {
+    const parsed = parseToolCall({
+      id: "call_1",
+      function: {
+        name: LLM_SLOT_TOOL_NAMES.getSlot,
+        arguments: "{\"slotCode\":\"order_id\"}",
+      },
+    });
+
+    assert.deepEqual(parsed, {
+      name: LLM_SLOT_TOOL_NAMES.getSlot,
+      arguments: { slotCode: "order_id" },
+    });
+  });
+
+  it("builds backend llm-tools URLs", () => {
+    assert.equal(
+      buildToolUrl("http://localhost:8080", 7, "/slots/order_id"),
+      "http://localhost:8080/api/v1/llm-tools/sessions/7/slots/order_id",
+    );
+  });
+
+  it("maps get_current_slot tool calls to the backend slot endpoint", async () => {
+    const requests = [];
+    const handler = createLlmSlotToolHandler({
+      backendBaseUrl: "http://localhost:8080",
+      bearerToken: "token",
+      sessionId: 7,
+      fetchImpl: async (url, init) => {
+        requests.push({ url, init });
+        return {
+          ok: true,
+          status: 200,
+          text: async () => "{\"slotCode\":\"order_id\",\"value\":\"A-100\"}",
+        };
+      },
+    });
+
+    const result = await handler({
+      id: "call_1",
+      function: {
+        name: LLM_SLOT_TOOL_NAMES.getSlot,
+        arguments: "{\"slotCode\":\"order_id\"}",
+      },
+    });
+
+    assert.equal(requests[0].url, "http://localhost:8080/api/v1/llm-tools/sessions/7/slots/order_id");
+    assert.equal(requests[0].init.method, "GET");
+    assert.equal(requests[0].init.headers.Authorization, "Bearer token");
+    assert.deepEqual(result, {
+      toolCallId: "call_1",
+      name: LLM_SLOT_TOOL_NAMES.getSlot,
+      result: { slotCode: "order_id", value: "A-100" },
+    });
+  });
+
+  it("maps upsert_current_slot_value tool calls to PUT with value body", async () => {
+    const requests = [];
+    const handler = createLlmSlotToolHandler({
+      backendBaseUrl: "http://localhost:8080",
+      sessionId: 7,
+      fetchImpl: async (url, init) => {
+        requests.push({ url, init });
+        return {
+          ok: true,
+          status: 200,
+          text: async () => "{\"slotCode\":\"order_id\",\"value\":\"A-200\"}",
+        };
+      },
+    });
+
+    await handler({
+      name: LLM_SLOT_TOOL_NAMES.upsertSlotValue,
+      arguments: { slotCode: "order_id", value: "A-200" },
+    });
+
+    assert.equal(requests[0].url, "http://localhost:8080/api/v1/llm-tools/sessions/7/slots/order_id");
+    assert.equal(requests[0].init.method, "PUT");
+    assert.equal(requests[0].init.headers["Content-Type"], "application/json");
+    assert.equal(requests[0].init.body, "{\"value\":\"A-200\"}");
+  });
+});

--- a/integrations/llm-tools/tool-schema.mjs
+++ b/integrations/llm-tools/tool-schema.mjs
@@ -1,0 +1,78 @@
+export const LLM_SLOT_TOOL_NAMES = Object.freeze({
+  getContext: "get_current_slot_context",
+  listSlots: "list_current_slots",
+  getSlot: "get_current_slot",
+  upsertSlotValue: "upsert_current_slot_value",
+});
+
+const emptyParameters = Object.freeze({
+  type: "object",
+  properties: Object.freeze({}),
+  required: Object.freeze([]),
+  additionalProperties: false,
+});
+
+export const llmSlotTools = Object.freeze([
+  Object.freeze({
+    type: "function",
+    function: Object.freeze({
+      name: LLM_SLOT_TOOL_NAMES.getContext,
+      description:
+        "현재 상담 세션의 workflow execution context, 저장된 slot 값, 아직 비어 있는 slot 목록을 조회한다.",
+      parameters: emptyParameters,
+    }),
+  }),
+  Object.freeze({
+    type: "function",
+    function: Object.freeze({
+      name: LLM_SLOT_TOOL_NAMES.listSlots,
+      description:
+        "현재 상담 세션의 domain pack version에 속한 active slot 정의와 현재 저장 값을 조회한다.",
+      parameters: emptyParameters,
+    }),
+  }),
+  Object.freeze({
+    type: "function",
+    function: Object.freeze({
+      name: LLM_SLOT_TOOL_NAMES.getSlot,
+      description:
+        "현재 상담 세션에서 특정 slotCode의 정의, 수집 힌트, required 여부, 현재 저장 값을 조회한다.",
+      parameters: Object.freeze({
+        type: "object",
+        properties: Object.freeze({
+          slotCode: Object.freeze({
+            type: "string",
+            minLength: 1,
+            description: "조회할 slot code. 예: order_id, customer_name",
+          }),
+        }),
+        required: Object.freeze(["slotCode"]),
+        additionalProperties: false,
+      }),
+    }),
+  }),
+  Object.freeze({
+    type: "function",
+    function: Object.freeze({
+      name: LLM_SLOT_TOOL_NAMES.upsertSlotValue,
+      description:
+        "고객에게서 확보한 slot 값을 현재 상담 세션의 workflow execution에 저장한다.",
+      parameters: Object.freeze({
+        type: "object",
+        properties: Object.freeze({
+          slotCode: Object.freeze({
+            type: "string",
+            minLength: 1,
+            description: "저장할 slot code. 예: order_id, customer_name",
+          }),
+          value: Object.freeze({
+            description:
+              "저장할 slot 값. string, number, boolean, object, array 모두 가능하다.",
+          }),
+        }),
+        required: Object.freeze(["slotCode", "value"]),
+        additionalProperties: false,
+      }),
+    }),
+  }),
+]);


### PR DESCRIPTION
## Summary
- add backend LLM slot tool REST endpoints for context, slot lookup, and slot value upsert
- add external LLM function-tool schema and adapter that maps tool calls to the backend API
- document issue 523 in .agent/specs/523.md

## Validation
- cd backend && ./gradlew compileJava test --tests 'com.init.workflowruntime.application.LlmToolServiceTest' --tests 'com.init.workflowruntime.presentation.LlmToolControllerTest'
- cd backend && ./gradlew test
- cd backend && ./gradlew spotlessCheck
- node --test integrations/llm-tools/llm-tool-adapter.test.mjs

## Notes
- This is a REST tool adapter, not an MCP server.
- sessionId is injected by the adapter rather than exposed to the LLM tool schema.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 외부 LLM이 세션 단위로 REST로 현재 워크플로우 컨텍스트 조회, 슬롯 목록/개별 슬롯 조회 및 슬롯 값 업서트 가능. 최신 실행이 없을 시 자동으로 워크플로우 실행 생성/저장.

* **Security**
  * 해당 API는 운영자 권한(ROLE_OPERATOR)으로 제한됨.

* **Domain Model**
  * 워크플로우 실행과 슬롯값 관리용 실행 엔티티/응답 스키마 추가.

* **Documentation**
  * External LLM Slot Tool API 명세 및 어댑터 연동 가이드 추가(세션 ID는 툴 스키마에 노출되지 않음).

* **Tests**
  * 서비스·컨트롤러·어댑터 단위·통합 테스트 추가.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ajou-2026-1-capstone-5/ostone/pull/264?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->