### PR TITLE
feat(llm-tools): add 522 conversation state tools

### DIFF
--- a/.agent/specs/522.md
+++ b/.agent/specs/522.md
@@ -1,0 +1,69 @@
+# 522. External LLM Conversation State Tool API
+
+## Goal
+
+외부 LLM이 현재 상담 세션의 대화 상태를 조회하고, DB에 등록된 intent 목록 중 하나를 선택해 workflow execution을 시작할 수 있는 REST 기반 tool API를 제공한다.
+
+이 기능은 MCP 서버가 아니라, LLM function calling adapter가 backend HTTP API를 호출하는 구조다. `sessionId`는 tool schema에 노출하지 않고 adapter가 현재 상담 세션 값으로 주입한다.
+
+## Scope
+
+### Backend
+
+Base path:
+
+```text
+/api/v1/llm-tools/sessions/{sessionId}
+```
+
+추가/확장 endpoint:
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET` | `/context` | 현재 workflow execution 상태, 저장된 slot 값, missing slot 목록 조회 |
+| `GET` | `/intents` | 현재 세션의 domain pack version에 등록된 intent 목록 조회 |
+| `POST` | `/intent-selection` | LLM이 선택한 `intentCode`를 실행 상태에 저장하고 연결 workflow 및 required slot 누락 여부 반환 |
+| `GET` | `/slots` | 현재 세션의 active slot 정의와 저장 값 조회 |
+| `GET` | `/slots/{slotCode}` | 특정 slot 정의와 현재 값 조회 |
+| `PUT` | `/slots/{slotCode}` | 수집한 slot 값을 `workflow_execution.slot_values_json`에 저장 |
+
+Security:
+
+```text
+ROLE_OPERATOR required
+```
+
+### LLM Adapter
+
+외부 LLM에 등록할 tool name:
+
+| Tool | Backend call |
+| --- | --- |
+| `get_current_slot_context` | `GET /context` |
+| `list_current_intents` | `GET /intents` |
+| `select_current_intent` | `POST /intent-selection` |
+| `list_current_slots` | `GET /slots` |
+| `get_current_slot` | `GET /slots/{slotCode}` |
+| `upsert_current_slot_value` | `PUT /slots/{slotCode}` |
+
+`select_current_intent.intentCode`는 `list_current_intents` 응답에 포함된 값을 그대로 사용한다. LLM이 intent 이름이나 코드를 새로 생성하지 않는다.
+
+## Behavior
+
+1. Runtime이 상담 세션을 만들고 `sessionId`, `domainPackVersionId`를 보유한다.
+2. LLM은 `list_current_intents`로 DB intent 목록을 조회한다.
+3. LLM은 사용자 발화와 intent 목록을 비교해 가장 알맞은 `intentCode`를 선택한다.
+4. Adapter는 `select_current_intent` tool call을 backend의 `/intent-selection`으로 전달한다.
+5. Backend는 `intentDefinitionId`, `workflowDefinitionId`, `currentState`를 `runtime.workflow_execution`에 저장한다.
+6. Backend는 선택된 intent의 required slot 중 아직 값이 없는 항목을 반환한다.
+7. LLM은 필요한 slot을 사용자에게 질문하고, 확보한 값은 `upsert_current_slot_value`로 저장한다.
+
+## Validation
+
+검증 대상:
+
+- `listIntents`가 세션의 domain pack version 기준 intent 목록을 반환한다.
+- `selectIntent`가 선택된 intent와 연결 workflow를 execution에 저장한다.
+- intent 선택 응답이 required slot과 missing required slot을 반환한다.
+- adapter가 `list_current_intents`, `select_current_intent` tool call을 backend endpoint로 매핑한다.
+- 기존 slot context/list/get/upsert tool 동작을 유지한다.

--- a/backend/src/main/java/com/init/workflowruntime/application/LlmToolService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/LlmToolService.java
@@ -122,6 +122,7 @@ public class LlmToolService {
     return intentDefinitionRepository
         .findByDomainPackVersionId(session.getDomainPackVersionId())
         .stream()
+        .filter(intent -> !IntentDefinition.STATUS_REJECTED.equals(intent.getStatus()))
         .sorted(Comparator.comparing(IntentDefinition::getIntentCode))
         .map(this::toIntentResponse)
         .toList();

--- a/backend/src/main/java/com/init/workflowruntime/application/LlmToolService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/LlmToolService.java
@@ -5,18 +5,28 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.init.domainpack.domain.model.IntentDefinition;
 import com.init.domainpack.domain.model.IntentSlotBinding;
+import com.init.domainpack.domain.model.IntentWorkflowBinding;
 import com.init.domainpack.domain.model.SlotDefinition;
+import com.init.domainpack.domain.model.WorkflowDefinition;
+import com.init.domainpack.domain.repository.IntentDefinitionRepository;
 import com.init.domainpack.domain.repository.IntentSlotBindingRepository;
+import com.init.domainpack.domain.repository.IntentWorkflowBindingRepository;
 import com.init.domainpack.domain.repository.SlotDefinitionRepository;
+import com.init.domainpack.domain.repository.WorkflowDefinitionRepository;
 import com.init.shared.application.exception.BadRequestException;
 import com.init.shared.application.exception.InternalException;
 import com.init.shared.application.exception.NotFoundException;
 import com.init.workflowruntime.application.command.GetLlmToolContextCommand;
 import com.init.workflowruntime.application.command.GetLlmToolSlotCommand;
+import com.init.workflowruntime.application.command.ListLlmToolIntentsCommand;
 import com.init.workflowruntime.application.command.ListLlmToolSlotsCommand;
+import com.init.workflowruntime.application.command.SelectLlmToolIntentCommand;
 import com.init.workflowruntime.application.command.UpsertLlmToolSlotValueCommand;
 import com.init.workflowruntime.application.dto.LlmToolContextResponse;
+import com.init.workflowruntime.application.dto.LlmToolIntentResponse;
+import com.init.workflowruntime.application.dto.LlmToolIntentSelectionResponse;
 import com.init.workflowruntime.application.dto.LlmToolSlotResponse;
 import com.init.workflowruntime.application.dto.LlmToolSlotValueResponse;
 import com.init.workflowruntime.domain.ChatSession;
@@ -38,20 +48,29 @@ public class LlmToolService {
 
   private final ChatSessionRepository chatSessionRepository;
   private final WorkflowExecutionRepository workflowExecutionRepository;
+  private final IntentDefinitionRepository intentDefinitionRepository;
   private final SlotDefinitionRepository slotDefinitionRepository;
   private final IntentSlotBindingRepository intentSlotBindingRepository;
+  private final IntentWorkflowBindingRepository intentWorkflowBindingRepository;
+  private final WorkflowDefinitionRepository workflowDefinitionRepository;
   private final ObjectMapper objectMapper;
 
   public LlmToolService(
       ChatSessionRepository chatSessionRepository,
       WorkflowExecutionRepository workflowExecutionRepository,
+      IntentDefinitionRepository intentDefinitionRepository,
       SlotDefinitionRepository slotDefinitionRepository,
       IntentSlotBindingRepository intentSlotBindingRepository,
+      IntentWorkflowBindingRepository intentWorkflowBindingRepository,
+      WorkflowDefinitionRepository workflowDefinitionRepository,
       ObjectMapper objectMapper) {
     this.chatSessionRepository = chatSessionRepository;
     this.workflowExecutionRepository = workflowExecutionRepository;
+    this.intentDefinitionRepository = intentDefinitionRepository;
     this.slotDefinitionRepository = slotDefinitionRepository;
     this.intentSlotBindingRepository = intentSlotBindingRepository;
+    this.intentWorkflowBindingRepository = intentWorkflowBindingRepository;
+    this.workflowDefinitionRepository = workflowDefinitionRepository;
     this.objectMapper = objectMapper;
   }
 
@@ -96,6 +115,60 @@ public class LlmToolService {
     SlotDefinition slot = findActiveSlot(session.getDomainPackVersionId(), slotCode);
     Map<Long, IntentSlotBinding> bindings = loadBindingsBySlotId(execution);
     return toSlotResponse(slot, bindings.get(slot.getId()), slotValues);
+  }
+
+  public List<LlmToolIntentResponse> listIntents(ListLlmToolIntentsCommand command) {
+    ChatSession session = findSession(command.sessionId());
+    return intentDefinitionRepository
+        .findByDomainPackVersionId(session.getDomainPackVersionId())
+        .stream()
+        .sorted(Comparator.comparing(IntentDefinition::getIntentCode))
+        .map(this::toIntentResponse)
+        .toList();
+  }
+
+  @Transactional
+  public LlmToolIntentSelectionResponse selectIntent(SelectLlmToolIntentCommand command) {
+    String intentCode = command.intentCode();
+    if (intentCode == null || intentCode.isBlank()) {
+      throw new BadRequestException("INTENT_CODE_REQUIRED", "intentCode is required");
+    }
+
+    ChatSession session = findSession(command.sessionId());
+    IntentDefinition intent = findIntent(session.getDomainPackVersionId(), intentCode.trim());
+    if (IntentDefinition.STATUS_REJECTED.equals(intent.getStatus())) {
+      throw new BadRequestException(
+          "INTENT_NOT_SELECTABLE", "Rejected intent cannot be selected: " + intentCode);
+    }
+
+    WorkflowDefinition workflow = resolveWorkflow(session.getDomainPackVersionId(), intent);
+    WorkflowExecution execution = findOrCreateExecutionForUpdate(session);
+    execution.assignIntentWorkflow(intent.getId(), workflow.getId(), resolveInitialState(workflow));
+    WorkflowExecution saved = workflowExecutionRepository.save(execution);
+
+    ObjectNode slotValues = readObjectNode(saved.getSlotValuesJson());
+    List<LlmToolSlotResponse> requiredSlots =
+        buildSlotResponses(session, saved, slotValues).stream()
+            .filter(slot -> Boolean.TRUE.equals(slot.required()))
+            .toList();
+    List<String> missingRequiredSlots =
+        requiredSlots.stream()
+            .filter(slot -> !slot.hasValue())
+            .map(LlmToolSlotResponse::slotCode)
+            .toList();
+
+    return new LlmToolIntentSelectionResponse(
+        session.getId(),
+        saved.getId(),
+        intent.getId(),
+        intent.getIntentCode(),
+        intent.getName(),
+        workflow.getId(),
+        workflow.getWorkflowCode(),
+        saved.getCurrentState(),
+        !missingRequiredSlots.isEmpty(),
+        missingRequiredSlots,
+        requiredSlots);
   }
 
   @Transactional
@@ -192,6 +265,82 @@ public class LlmToolService {
     return slot;
   }
 
+  private IntentDefinition findIntent(Long domainPackVersionId, String intentCode) {
+    return intentDefinitionRepository
+        .findByDomainPackVersionIdAndIntentCode(domainPackVersionId, intentCode)
+        .orElseThrow(
+            () ->
+                new NotFoundException(
+                    "INTENT_DEFINITION_NOT_FOUND", "IntentDefinition not found: " + intentCode));
+  }
+
+  private WorkflowDefinition resolveWorkflow(Long domainPackVersionId, IntentDefinition intent) {
+    List<IntentWorkflowBinding> bindings =
+        intentWorkflowBindingRepository
+            .findAllByIntentDefinitionIdIn(List.of(intent.getId()))
+            .stream()
+            .sorted(
+                Comparator.comparing(
+                        IntentWorkflowBinding::getIsPrimary,
+                        Comparator.nullsLast(Comparator.reverseOrder()))
+                    .thenComparing(
+                        IntentWorkflowBinding::getId,
+                        Comparator.nullsLast(Comparator.naturalOrder())))
+            .toList();
+    if (bindings.isEmpty()) {
+      throw new NotFoundException(
+          "INTENT_WORKFLOW_BINDING_NOT_FOUND",
+          "Intent workflow binding not found: " + intent.getIntentCode());
+    }
+
+    for (IntentWorkflowBinding binding : bindings) {
+      var workflow =
+          workflowDefinitionRepository.findByIdAndDomainPackVersionId(
+              binding.getWorkflowDefinitionId(), domainPackVersionId);
+      if (workflow.isPresent()) {
+        return workflow.get();
+      }
+    }
+
+    throw new NotFoundException(
+        "WORKFLOW_DEFINITION_NOT_FOUND",
+        "WorkflowDefinition not found for intent: " + intent.getIntentCode());
+  }
+
+  private String resolveInitialState(WorkflowDefinition workflow) {
+    String initialState = trimToNull(workflow.getInitialState());
+    if (initialState != null) {
+      return initialState;
+    }
+
+    JsonNode graph = readJsonNode(workflow.getGraphJson(), null);
+    for (JsonNode node : graph.path("nodes")) {
+      if ("START".equals(node.path("type").asText(null))) {
+        String nodeId = trimToNull(node.path("id").asText(null));
+        if (nodeId != null) {
+          return nodeId;
+        }
+      }
+    }
+
+    throw new InternalException(
+        "WORKFLOW_INITIAL_STATE_MISSING",
+        "Workflow initial state cannot be resolved: " + workflow.getId());
+  }
+
+  private LlmToolIntentResponse toIntentResponse(IntentDefinition intent) {
+    return new LlmToolIntentResponse(
+        intent.getId(),
+        intent.getIntentCode(),
+        intent.getName(),
+        intent.getDescription(),
+        intent.getTaxonomyLevel(),
+        intent.getParentIntentId(),
+        intent.getStatus(),
+        readJsonNode(intent.getEntryConditionJson(), "{}"),
+        readJsonNode(intent.getMetaJson(), "{}"));
+  }
+
   private Map<Long, IntentSlotBinding> loadBindingsBySlotId(WorkflowExecution execution) {
     if (execution == null || execution.getIntentDefinitionId() == null) {
       return Map.of();
@@ -254,5 +403,13 @@ public class LlmToolService {
 
   private boolean hasValue(ObjectNode slotValues, String slotCode) {
     return slotValues.hasNonNull(slotCode);
+  }
+
+  private String trimToNull(String value) {
+    if (value == null) {
+      return null;
+    }
+    String trimmed = value.trim();
+    return trimmed.isEmpty() ? null : trimmed;
   }
 }

--- a/backend/src/main/java/com/init/workflowruntime/application/command/ListLlmToolIntentsCommand.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/command/ListLlmToolIntentsCommand.java
@@ -1,0 +1,3 @@
+package com.init.workflowruntime.application.command;
+
+public record ListLlmToolIntentsCommand(Long sessionId) {}

--- a/backend/src/main/java/com/init/workflowruntime/application/command/SelectLlmToolIntentCommand.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/command/SelectLlmToolIntentCommand.java
@@ -1,0 +1,3 @@
+package com.init.workflowruntime.application.command;
+
+public record SelectLlmToolIntentCommand(Long sessionId, String intentCode) {}

--- a/backend/src/main/java/com/init/workflowruntime/application/dto/LlmToolIntentResponse.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/dto/LlmToolIntentResponse.java
@@ -1,0 +1,14 @@
+package com.init.workflowruntime.application.dto;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public record LlmToolIntentResponse(
+    Long id,
+    String intentCode,
+    String name,
+    String description,
+    Integer taxonomyLevel,
+    Long parentIntentId,
+    String status,
+    JsonNode entryCondition,
+    JsonNode meta) {}

--- a/backend/src/main/java/com/init/workflowruntime/application/dto/LlmToolIntentSelectionResponse.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/dto/LlmToolIntentSelectionResponse.java
@@ -1,0 +1,16 @@
+package com.init.workflowruntime.application.dto;
+
+import java.util.List;
+
+public record LlmToolIntentSelectionResponse(
+    Long sessionId,
+    Long executionId,
+    Long intentDefinitionId,
+    String intentCode,
+    String intentName,
+    Long workflowDefinitionId,
+    String workflowCode,
+    String currentState,
+    boolean slotCollectionRequired,
+    List<String> missingRequiredSlots,
+    List<LlmToolSlotResponse> requiredSlots) {}

--- a/backend/src/main/java/com/init/workflowruntime/application/dto/SelectIntentRequest.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/dto/SelectIntentRequest.java
@@ -1,0 +1,5 @@
+package com.init.workflowruntime.application.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record SelectIntentRequest(@NotBlank String intentCode) {}

--- a/backend/src/main/java/com/init/workflowruntime/domain/InvalidSessionStateException.java
+++ b/backend/src/main/java/com/init/workflowruntime/domain/InvalidSessionStateException.java
@@ -1,8 +1,8 @@
 package com.init.workflowruntime.domain;
 
-import com.init.shared.application.exception.BusinessException;
+import com.init.shared.application.exception.BadRequestException;
 
-public class InvalidSessionStateException extends BusinessException {
+public class InvalidSessionStateException extends BadRequestException {
 
   public InvalidSessionStateException(String message) {
     super("INVALID_SESSION_STATE", message);

--- a/backend/src/main/java/com/init/workflowruntime/domain/WorkflowExecution.java
+++ b/backend/src/main/java/com/init/workflowruntime/domain/WorkflowExecution.java
@@ -123,4 +123,16 @@ public class WorkflowExecution {
   public void replaceSlotValuesJson(String slotValuesJson) {
     this.slotValuesJson = slotValuesJson != null ? slotValuesJson : "{}";
   }
+
+  public void assignIntentWorkflow(
+      Long intentDefinitionId, Long workflowDefinitionId, String currentState) {
+    Objects.requireNonNull(intentDefinitionId, "intentDefinitionId must not be null");
+    Objects.requireNonNull(workflowDefinitionId, "workflowDefinitionId must not be null");
+    Objects.requireNonNull(currentState, "currentState must not be null");
+
+    this.intentDefinitionId = intentDefinitionId;
+    this.workflowDefinitionId = workflowDefinitionId;
+    this.currentState = currentState;
+    this.status = STATUS_RUNNING;
+  }
 }

--- a/backend/src/main/java/com/init/workflowruntime/domain/WorkflowExecution.java
+++ b/backend/src/main/java/com/init/workflowruntime/domain/WorkflowExecution.java
@@ -133,7 +133,7 @@ public class WorkflowExecution {
     Objects.requireNonNull(currentState, "currentState must not be null");
 
     if (isTerminalStatus()) {
-      throw new IllegalStateException(
+      throw new InvalidSessionStateException(
           "Cannot assign intent workflow to terminal execution: " + this.status);
     }
 

--- a/backend/src/main/java/com/init/workflowruntime/domain/WorkflowExecution.java
+++ b/backend/src/main/java/com/init/workflowruntime/domain/WorkflowExecution.java
@@ -17,6 +17,8 @@ import org.hibernate.type.SqlTypes;
 public class WorkflowExecution {
 
   public static final String STATUS_RUNNING = "RUNNING";
+  public static final String STATUS_COMPLETED = "COMPLETED";
+  public static final String STATUS_FAILED = "FAILED";
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -130,9 +132,18 @@ public class WorkflowExecution {
     Objects.requireNonNull(workflowDefinitionId, "workflowDefinitionId must not be null");
     Objects.requireNonNull(currentState, "currentState must not be null");
 
+    if (isTerminalStatus()) {
+      throw new IllegalStateException(
+          "Cannot assign intent workflow to terminal execution: " + this.status);
+    }
+
     this.intentDefinitionId = intentDefinitionId;
     this.workflowDefinitionId = workflowDefinitionId;
     this.currentState = currentState;
     this.status = STATUS_RUNNING;
+  }
+
+  private boolean isTerminalStatus() {
+    return STATUS_COMPLETED.equals(this.status) || STATUS_FAILED.equals(this.status);
   }
 }

--- a/backend/src/main/java/com/init/workflowruntime/presentation/LlmToolController.java
+++ b/backend/src/main/java/com/init/workflowruntime/presentation/LlmToolController.java
@@ -3,17 +3,23 @@ package com.init.workflowruntime.presentation;
 import com.init.workflowruntime.application.LlmToolService;
 import com.init.workflowruntime.application.command.GetLlmToolContextCommand;
 import com.init.workflowruntime.application.command.GetLlmToolSlotCommand;
+import com.init.workflowruntime.application.command.ListLlmToolIntentsCommand;
 import com.init.workflowruntime.application.command.ListLlmToolSlotsCommand;
+import com.init.workflowruntime.application.command.SelectLlmToolIntentCommand;
 import com.init.workflowruntime.application.command.UpsertLlmToolSlotValueCommand;
 import com.init.workflowruntime.application.dto.LlmToolContextResponse;
+import com.init.workflowruntime.application.dto.LlmToolIntentResponse;
+import com.init.workflowruntime.application.dto.LlmToolIntentSelectionResponse;
 import com.init.workflowruntime.application.dto.LlmToolSlotResponse;
 import com.init.workflowruntime.application.dto.LlmToolSlotValueResponse;
+import com.init.workflowruntime.application.dto.SelectIntentRequest;
 import com.init.workflowruntime.application.dto.UpsertSlotValueRequest;
 import jakarta.validation.Valid;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -44,6 +50,19 @@ public class LlmToolController {
       @PathVariable Long sessionId, @PathVariable String slotCode) {
     return ResponseEntity.ok(
         llmToolService.getSlot(new GetLlmToolSlotCommand(sessionId, slotCode)));
+  }
+
+  @GetMapping("/intents")
+  public ResponseEntity<List<LlmToolIntentResponse>> listIntents(@PathVariable Long sessionId) {
+    return ResponseEntity.ok(llmToolService.listIntents(new ListLlmToolIntentsCommand(sessionId)));
+  }
+
+  @PostMapping("/intent-selection")
+  public ResponseEntity<LlmToolIntentSelectionResponse> selectIntent(
+      @PathVariable Long sessionId, @Valid @RequestBody SelectIntentRequest request) {
+    return ResponseEntity.ok(
+        llmToolService.selectIntent(
+            new SelectLlmToolIntentCommand(sessionId, request.intentCode())));
   }
 
   @PutMapping("/slots/{slotCode}")

--- a/backend/src/test/java/com/init/workflowruntime/application/LlmToolServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/LlmToolServiceTest.java
@@ -9,17 +9,26 @@ import static org.mockito.Mockito.verify;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.init.domainpack.domain.model.IntentDefinition;
 import com.init.domainpack.domain.model.IntentSlotBinding;
+import com.init.domainpack.domain.model.IntentWorkflowBinding;
 import com.init.domainpack.domain.model.SlotDefinition;
+import com.init.domainpack.domain.model.WorkflowDefinition;
+import com.init.domainpack.domain.repository.IntentDefinitionRepository;
 import com.init.domainpack.domain.repository.IntentSlotBindingRepository;
+import com.init.domainpack.domain.repository.IntentWorkflowBindingRepository;
 import com.init.domainpack.domain.repository.SlotDefinitionRepository;
+import com.init.domainpack.domain.repository.WorkflowDefinitionRepository;
 import com.init.shared.application.exception.BadRequestException;
 import com.init.shared.application.exception.NotFoundException;
 import com.init.workflowruntime.application.command.GetLlmToolContextCommand;
 import com.init.workflowruntime.application.command.GetLlmToolSlotCommand;
+import com.init.workflowruntime.application.command.ListLlmToolIntentsCommand;
 import com.init.workflowruntime.application.command.ListLlmToolSlotsCommand;
+import com.init.workflowruntime.application.command.SelectLlmToolIntentCommand;
 import com.init.workflowruntime.application.command.UpsertLlmToolSlotValueCommand;
 import com.init.workflowruntime.application.dto.LlmToolContextResponse;
+import com.init.workflowruntime.application.dto.LlmToolIntentSelectionResponse;
 import com.init.workflowruntime.application.dto.LlmToolSlotResponse;
 import com.init.workflowruntime.application.dto.LlmToolSlotValueResponse;
 import com.init.workflowruntime.domain.ChatSession;
@@ -43,8 +52,11 @@ class LlmToolServiceTest {
 
   @Mock private ChatSessionRepository chatSessionRepository;
   @Mock private WorkflowExecutionRepository workflowExecutionRepository;
+  @Mock private IntentDefinitionRepository intentDefinitionRepository;
   @Mock private SlotDefinitionRepository slotDefinitionRepository;
   @Mock private IntentSlotBindingRepository intentSlotBindingRepository;
+  @Mock private IntentWorkflowBindingRepository intentWorkflowBindingRepository;
+  @Mock private WorkflowDefinitionRepository workflowDefinitionRepository;
 
   private ObjectMapper objectMapper;
   private LlmToolService service;
@@ -56,8 +68,11 @@ class LlmToolServiceTest {
         new LlmToolService(
             chatSessionRepository,
             workflowExecutionRepository,
+            intentDefinitionRepository,
             slotDefinitionRepository,
             intentSlotBindingRepository,
+            intentWorkflowBindingRepository,
+            workflowDefinitionRepository,
             objectMapper);
   }
 
@@ -231,6 +246,72 @@ class LlmToolServiceTest {
         .hasMessageContaining("SlotDefinition not found");
   }
 
+  @Test
+  @DisplayName("listIntents: 세션 domain pack version의 intent 목록을 intentCode 순서로 반환한다")
+  void should_returnCurrentDomainPackIntents() {
+    // given
+    ChatSession session = createSession(1L, 10L, 101L);
+    IntentDefinition refundIntent = createIntent(70L, 101L, "request_refund", "환불 요청");
+    IntentDefinition addressIntent = createIntent(71L, 101L, "change_address", "배송지 변경");
+
+    given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+    given(intentDefinitionRepository.findByDomainPackVersionId(101L))
+        .willReturn(List.of(refundIntent, addressIntent));
+
+    // when
+    var result = service.listIntents(new ListLlmToolIntentsCommand(1L));
+
+    // then
+    assertThat(result).hasSize(2);
+    assertThat(result.get(0).intentCode()).isEqualTo("change_address");
+    assertThat(result.get(1).intentCode()).isEqualTo("request_refund");
+  }
+
+  @Test
+  @DisplayName(
+      "selectIntent: intentCode 선택 시 execution에 intent/workflow/currentState를 저장하고 필수 slot 누락을 반환한다")
+  void should_selectIntentAndReturnMissingRequiredSlots() {
+    // given
+    ChatSession session = createSession(1L, 10L, 101L);
+    IntentDefinition intent = createIntent(70L, 101L, "request_refund", "환불 요청");
+    WorkflowDefinition workflow = createWorkflow(150L, 101L, "refund_flow", "start");
+    IntentWorkflowBinding workflowBinding = createWorkflowBinding(70L, 150L, true);
+    WorkflowExecution execution = createExecution(50L, 1L, null, "{\"order_id\":\"A-100\"}");
+    SlotDefinition orderSlot = createSlot(11L, 101L, "order_id");
+    SlotDefinition refundSlot = createSlot(12L, 101L, "refund_reason");
+    IntentSlotBinding orderBinding = createBinding(70L, 11L, true, 1, "주문번호를 물어본다");
+    IntentSlotBinding refundBinding = createBinding(70L, 12L, true, 2, "환불 사유를 확인한다");
+
+    given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+    given(intentDefinitionRepository.findByDomainPackVersionIdAndIntentCode(101L, "request_refund"))
+        .willReturn(Optional.of(intent));
+    given(intentWorkflowBindingRepository.findAllByIntentDefinitionIdIn(List.of(70L)))
+        .willReturn(List.of(workflowBinding));
+    given(workflowDefinitionRepository.findByIdAndDomainPackVersionId(150L, 101L))
+        .willReturn(Optional.of(workflow));
+    given(workflowExecutionRepository.findLatestByChatSessionIdForUpdate(1L))
+        .willReturn(Optional.of(execution));
+    given(workflowExecutionRepository.save(execution)).willReturn(execution);
+    given(slotDefinitionRepository.findAllByDomainPackVersionIdOrderBySlotCodeAsc(101L))
+        .willReturn(List.of(refundSlot, orderSlot));
+    given(intentSlotBindingRepository.findAllByIntentDefinitionIdIn(List.of(70L)))
+        .willReturn(List.of(orderBinding, refundBinding));
+
+    // when
+    LlmToolIntentSelectionResponse result =
+        service.selectIntent(new SelectLlmToolIntentCommand(1L, "request_refund"));
+
+    // then
+    assertThat(result.executionId()).isEqualTo(50L);
+    assertThat(result.intentDefinitionId()).isEqualTo(70L);
+    assertThat(result.workflowDefinitionId()).isEqualTo(150L);
+    assertThat(result.currentState()).isEqualTo("start");
+    assertThat(result.slotCollectionRequired()).isTrue();
+    assertThat(result.missingRequiredSlots()).containsExactly("refund_reason");
+    assertThat(execution.getIntentDefinitionId()).isEqualTo(70L);
+    assertThat(execution.getWorkflowDefinitionId()).isEqualTo(150L);
+  }
+
   private ChatSession createSession(Long id, Long workspaceId, Long versionId) {
     ChatSession session =
         ChatSession.create(workspaceId, versionId, ChatSessionStatus.OPEN, "WEB", "{}");
@@ -271,5 +352,40 @@ class LlmToolServiceTest {
       String promptHint) {
     return IntentSlotBinding.create(
         intentDefinitionId, slotDefinitionId, required, collectionOrder, promptHint, "{}");
+  }
+
+  private IntentDefinition createIntent(Long id, Long versionId, String intentCode, String name) {
+    IntentDefinition intent =
+        IntentDefinition.create(
+            versionId, intentCode, name, "intent description", 1, "{}", "{}", "[]", "{}");
+    ReflectionTestUtils.setField(intent, "id", id);
+    return intent;
+  }
+
+  private IntentWorkflowBinding createWorkflowBinding(
+      Long intentDefinitionId, Long workflowDefinitionId, Boolean primary) {
+    IntentWorkflowBinding binding =
+        IntentWorkflowBinding.create(intentDefinitionId, workflowDefinitionId, primary, "{}");
+    ReflectionTestUtils.setField(binding, "id", 300L);
+    return binding;
+  }
+
+  private WorkflowDefinition createWorkflow(
+      Long id, Long versionId, String workflowCode, String initialState) {
+    WorkflowDefinition workflow =
+        WorkflowDefinition.create(
+            versionId,
+            workflowCode,
+            "workflow name",
+            "workflow description",
+            """
+            {"direction":"LR","nodes":[{"id":"start","type":"START"},{"id":"end","type":"TERMINAL"}],"edges":[{"id":"e1","from":"start","to":"end"}]}
+            """,
+            initialState,
+            "[\"end\"]",
+            "[]",
+            "{}");
+    ReflectionTestUtils.setField(workflow, "id", id);
+    return workflow;
   }
 }

--- a/backend/src/test/java/com/init/workflowruntime/application/LlmToolServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/LlmToolServiceTest.java
@@ -247,16 +247,18 @@ class LlmToolServiceTest {
   }
 
   @Test
-  @DisplayName("listIntents: 세션 domain pack version의 intent 목록을 intentCode 순서로 반환한다")
-  void should_returnCurrentDomainPackIntents() {
+  @DisplayName("listIntents: rejected intent를 제외하고 intentCode 순서로 반환한다")
+  void should_returnCurrentDomainPackIntentsExceptRejected() {
     // given
     ChatSession session = createSession(1L, 10L, 101L);
     IntentDefinition refundIntent = createIntent(70L, 101L, "request_refund", "환불 요청");
     IntentDefinition addressIntent = createIntent(71L, 101L, "change_address", "배송지 변경");
+    IntentDefinition rejectedIntent = createIntent(72L, 101L, "legacy_refund", "레거시 환불");
+    rejectedIntent.changeStatus(IntentDefinition.STATUS_REJECTED);
 
     given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
     given(intentDefinitionRepository.findByDomainPackVersionId(101L))
-        .willReturn(List.of(refundIntent, addressIntent));
+        .willReturn(List.of(refundIntent, rejectedIntent, addressIntent));
 
     // when
     var result = service.listIntents(new ListLlmToolIntentsCommand(1L));
@@ -310,6 +312,107 @@ class LlmToolServiceTest {
     assertThat(result.missingRequiredSlots()).containsExactly("refund_reason");
     assertThat(execution.getIntentDefinitionId()).isEqualTo(70L);
     assertThat(execution.getWorkflowDefinitionId()).isEqualTo(150L);
+  }
+
+  @Test
+  @DisplayName("selectIntent: workflow initialState가 없으면 START node id를 currentState로 사용한다")
+  void should_useStartNodeAsCurrentState_when_initialStateMissing() {
+    // given
+    ChatSession session = createSession(1L, 10L, 101L);
+    IntentDefinition intent = createIntent(70L, 101L, "request_refund", "환불 요청");
+    WorkflowDefinition workflow = createWorkflow(150L, 101L, "refund_flow", null);
+    WorkflowExecution execution = createExecution(50L, 1L, null, "{\"order_id\":\"A-100\"}");
+
+    given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+    given(intentDefinitionRepository.findByDomainPackVersionIdAndIntentCode(101L, "request_refund"))
+        .willReturn(Optional.of(intent));
+    given(intentWorkflowBindingRepository.findAllByIntentDefinitionIdIn(List.of(70L)))
+        .willReturn(List.of(createWorkflowBinding(70L, 150L, true)));
+    given(workflowDefinitionRepository.findByIdAndDomainPackVersionId(150L, 101L))
+        .willReturn(Optional.of(workflow));
+    given(workflowExecutionRepository.findLatestByChatSessionIdForUpdate(1L))
+        .willReturn(Optional.of(execution));
+    given(workflowExecutionRepository.save(execution)).willReturn(execution);
+    given(slotDefinitionRepository.findAllByDomainPackVersionIdOrderBySlotCodeAsc(101L))
+        .willReturn(List.of());
+
+    // when
+    LlmToolIntentSelectionResponse result =
+        service.selectIntent(new SelectLlmToolIntentCommand(1L, "request_refund"));
+
+    // then
+    assertThat(result.currentState()).isEqualTo("start");
+    assertThat(result.slotCollectionRequired()).isFalse();
+    assertThat(result.missingRequiredSlots()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("selectIntent: intentCode가 비어 있으면 400 예외")
+  void should_throwBadRequest_when_intentCodeBlank() {
+    assertThatThrownBy(() -> service.selectIntent(new SelectLlmToolIntentCommand(1L, " ")))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("intentCode is required");
+  }
+
+  @Test
+  @DisplayName("selectIntent: rejected intent는 선택할 수 없다")
+  void should_throwBadRequest_when_intentIsRejected() {
+    // given
+    ChatSession session = createSession(1L, 10L, 101L);
+    IntentDefinition intent = createIntent(70L, 101L, "request_refund", "환불 요청");
+    intent.changeStatus(IntentDefinition.STATUS_REJECTED);
+
+    given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+    given(intentDefinitionRepository.findByDomainPackVersionIdAndIntentCode(101L, "request_refund"))
+        .willReturn(Optional.of(intent));
+
+    // when & then
+    assertThatThrownBy(
+            () -> service.selectIntent(new SelectLlmToolIntentCommand(1L, "request_refund")))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("Rejected intent cannot be selected");
+  }
+
+  @Test
+  @DisplayName("selectIntent: intent workflow binding이 없으면 404 예외")
+  void should_throwNotFound_when_workflowBindingMissing() {
+    // given
+    ChatSession session = createSession(1L, 10L, 101L);
+    IntentDefinition intent = createIntent(70L, 101L, "request_refund", "환불 요청");
+
+    given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+    given(intentDefinitionRepository.findByDomainPackVersionIdAndIntentCode(101L, "request_refund"))
+        .willReturn(Optional.of(intent));
+    given(intentWorkflowBindingRepository.findAllByIntentDefinitionIdIn(List.of(70L)))
+        .willReturn(List.of());
+
+    // when & then
+    assertThatThrownBy(
+            () -> service.selectIntent(new SelectLlmToolIntentCommand(1L, "request_refund")))
+        .isInstanceOf(NotFoundException.class)
+        .hasMessageContaining("Intent workflow binding not found");
+  }
+
+  @Test
+  @DisplayName("selectIntent: binding workflow가 세션 version에 없으면 404 예외")
+  void should_throwNotFound_when_workflowMissing() {
+    // given
+    ChatSession session = createSession(1L, 10L, 101L);
+    IntentDefinition intent = createIntent(70L, 101L, "request_refund", "환불 요청");
+
+    given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+    given(intentDefinitionRepository.findByDomainPackVersionIdAndIntentCode(101L, "request_refund"))
+        .willReturn(Optional.of(intent));
+    given(intentWorkflowBindingRepository.findAllByIntentDefinitionIdIn(List.of(70L)))
+        .willReturn(List.of(createWorkflowBinding(70L, 150L, true)));
+    given(workflowDefinitionRepository.findByIdAndDomainPackVersionId(150L, 101L))
+        .willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(
+            () -> service.selectIntent(new SelectLlmToolIntentCommand(1L, "request_refund")))
+        .isInstanceOf(NotFoundException.class)
+        .hasMessageContaining("WorkflowDefinition not found");
   }
 
   private ChatSession createSession(Long id, Long workspaceId, Long versionId) {

--- a/backend/src/test/java/com/init/workflowruntime/domain/WorkflowExecutionTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/domain/WorkflowExecutionTest.java
@@ -1,7 +1,7 @@
 package com.init.workflowruntime.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 
 import java.time.OffsetDateTime;
@@ -79,7 +79,7 @@ class WorkflowExecutionTest {
     WorkflowExecution execution = WorkflowExecution.create(1L);
     ReflectionTestUtils.setField(execution, "status", WorkflowExecution.STATUS_COMPLETED);
 
-    assertThatIllegalStateException()
+    assertThatExceptionOfType(InvalidSessionStateException.class)
         .isThrownBy(() -> execution.assignIntentWorkflow(10L, 20L, "start"))
         .withMessageContaining("terminal execution");
 
@@ -95,7 +95,7 @@ class WorkflowExecutionTest {
     WorkflowExecution execution = WorkflowExecution.create(1L);
     ReflectionTestUtils.setField(execution, "status", WorkflowExecution.STATUS_FAILED);
 
-    assertThatIllegalStateException()
+    assertThatExceptionOfType(InvalidSessionStateException.class)
         .isThrownBy(() -> execution.assignIntentWorkflow(10L, 20L, "start"))
         .withMessageContaining("terminal execution");
 

--- a/backend/src/test/java/com/init/workflowruntime/domain/WorkflowExecutionTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/domain/WorkflowExecutionTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 
+import com.init.shared.application.exception.BadRequestException;
 import java.time.OffsetDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -79,7 +80,7 @@ class WorkflowExecutionTest {
     WorkflowExecution execution = WorkflowExecution.create(1L);
     ReflectionTestUtils.setField(execution, "status", WorkflowExecution.STATUS_COMPLETED);
 
-    assertThatExceptionOfType(InvalidSessionStateException.class)
+    assertThatExceptionOfType(BadRequestException.class)
         .isThrownBy(() -> execution.assignIntentWorkflow(10L, 20L, "start"))
         .withMessageContaining("terminal execution");
 
@@ -95,7 +96,7 @@ class WorkflowExecutionTest {
     WorkflowExecution execution = WorkflowExecution.create(1L);
     ReflectionTestUtils.setField(execution, "status", WorkflowExecution.STATUS_FAILED);
 
-    assertThatExceptionOfType(InvalidSessionStateException.class)
+    assertThatExceptionOfType(BadRequestException.class)
         .isThrownBy(() -> execution.assignIntentWorkflow(10L, 20L, "start"))
         .withMessageContaining("terminal execution");
 

--- a/backend/src/test/java/com/init/workflowruntime/domain/WorkflowExecutionTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/domain/WorkflowExecutionTest.java
@@ -1,6 +1,7 @@
 package com.init.workflowruntime.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 
 import java.time.OffsetDateTime;
@@ -57,5 +58,47 @@ class WorkflowExecutionTest {
 
     assertThat(execution.getId()).isEqualTo(10L);
     assertThat(execution.getSlotValuesJson()).isEqualTo("{}");
+  }
+
+  @Test
+  @DisplayName("assignIntentWorkflow: 실행 중이면 intent/workflow/currentState를 저장한다")
+  void should_assignIntentWorkflow_when_running() {
+    WorkflowExecution execution = WorkflowExecution.create(1L);
+
+    execution.assignIntentWorkflow(10L, 20L, "start");
+
+    assertThat(execution.getIntentDefinitionId()).isEqualTo(10L);
+    assertThat(execution.getWorkflowDefinitionId()).isEqualTo(20L);
+    assertThat(execution.getCurrentState()).isEqualTo("start");
+    assertThat(execution.getStatus()).isEqualTo(WorkflowExecution.STATUS_RUNNING);
+  }
+
+  @Test
+  @DisplayName("assignIntentWorkflow: 완료된 실행이면 재할당하지 않는다")
+  void should_throw_when_assigningCompletedExecution() {
+    WorkflowExecution execution = WorkflowExecution.create(1L);
+    ReflectionTestUtils.setField(execution, "status", WorkflowExecution.STATUS_COMPLETED);
+
+    assertThatIllegalStateException()
+        .isThrownBy(() -> execution.assignIntentWorkflow(10L, 20L, "start"))
+        .withMessageContaining("terminal execution");
+
+    assertThat(execution.getIntentDefinitionId()).isNull();
+    assertThat(execution.getWorkflowDefinitionId()).isNull();
+    assertThat(execution.getCurrentState()).isNull();
+    assertThat(execution.getStatus()).isEqualTo(WorkflowExecution.STATUS_COMPLETED);
+  }
+
+  @Test
+  @DisplayName("assignIntentWorkflow: 실패한 실행이면 재할당하지 않는다")
+  void should_throw_when_assigningFailedExecution() {
+    WorkflowExecution execution = WorkflowExecution.create(1L);
+    ReflectionTestUtils.setField(execution, "status", WorkflowExecution.STATUS_FAILED);
+
+    assertThatIllegalStateException()
+        .isThrownBy(() -> execution.assignIntentWorkflow(10L, 20L, "start"))
+        .withMessageContaining("terminal execution");
+
+    assertThat(execution.getStatus()).isEqualTo(WorkflowExecution.STATUS_FAILED);
   }
 }

--- a/backend/src/test/java/com/init/workflowruntime/presentation/LlmToolControllerTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/presentation/LlmToolControllerTest.java
@@ -3,6 +3,7 @@ package com.init.workflowruntime.presentation;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -12,9 +13,13 @@ import com.init.shared.infrastructure.security.JwtAuthenticationFilter;
 import com.init.workflowruntime.application.LlmToolService;
 import com.init.workflowruntime.application.command.GetLlmToolContextCommand;
 import com.init.workflowruntime.application.command.GetLlmToolSlotCommand;
+import com.init.workflowruntime.application.command.ListLlmToolIntentsCommand;
 import com.init.workflowruntime.application.command.ListLlmToolSlotsCommand;
+import com.init.workflowruntime.application.command.SelectLlmToolIntentCommand;
 import com.init.workflowruntime.application.command.UpsertLlmToolSlotValueCommand;
 import com.init.workflowruntime.application.dto.LlmToolContextResponse;
+import com.init.workflowruntime.application.dto.LlmToolIntentResponse;
+import com.init.workflowruntime.application.dto.LlmToolIntentSelectionResponse;
 import com.init.workflowruntime.application.dto.LlmToolSlotResponse;
 import com.init.workflowruntime.application.dto.LlmToolSlotValueResponse;
 import java.util.List;
@@ -101,6 +106,64 @@ class LlmToolControllerTest {
         .andExpect(jsonPath("$.slotCode").value("order_id"))
         .andExpect(jsonPath("$.hasValue").value(true))
         .andExpect(jsonPath("$.value").value("A-100"));
+  }
+
+  @Test
+  @DisplayName("GET /api/v1/llm-tools/sessions/{sessionId}/intents → 200 OK")
+  void should_returnIntents_when_validRequest() throws Exception {
+    // given
+    given(llmToolService.listIntents(new ListLlmToolIntentsCommand(1L)))
+        .willReturn(
+            List.of(
+                new LlmToolIntentResponse(
+                    70L,
+                    "request_refund",
+                    "환불 요청",
+                    "환불 요청 intent",
+                    1,
+                    null,
+                    "PUBLISHED",
+                    objectMapper.readTree("{}"),
+                    objectMapper.readTree("{}"))));
+
+    // when & then
+    mockMvc
+        .perform(get("/api/v1/llm-tools/sessions/1/intents"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].intentCode").value("request_refund"))
+        .andExpect(jsonPath("$[0].name").value("환불 요청"));
+  }
+
+  @Test
+  @DisplayName("POST /api/v1/llm-tools/sessions/{sessionId}/intent-selection → 200 OK")
+  void should_selectIntent_when_validRequest() throws Exception {
+    // given
+    given(llmToolService.selectIntent(any(SelectLlmToolIntentCommand.class)))
+        .willReturn(
+            new LlmToolIntentSelectionResponse(
+                1L,
+                50L,
+                70L,
+                "request_refund",
+                "환불 요청",
+                150L,
+                "refund_flow",
+                "start",
+                true,
+                List.of("order_id"),
+                List.of(slotResponse("order_id", false))));
+
+    // when & then
+    mockMvc
+        .perform(
+            post("/api/v1/llm-tools/sessions/1/intent-selection")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"intentCode\":\"request_refund\"}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.intentCode").value("request_refund"))
+        .andExpect(jsonPath("$.workflowCode").value("refund_flow"))
+        .andExpect(jsonPath("$.currentState").value("start"))
+        .andExpect(jsonPath("$.missingRequiredSlots[0]").value("order_id"));
   }
 
   @Test

--- a/integrations/llm-tools/README.md
+++ b/integrations/llm-tools/README.md
@@ -1,11 +1,13 @@
-# LLM Slot Tools
+# LLM Conversation State Tools
 
-이 모듈은 외부 LLM function calling layer가 backend의 slot tool REST API를 호출하도록 연결한다.
+이 모듈은 외부 LLM function calling layer가 backend의 현재 대화 상태 tool REST API를 호출하도록 연결한다.
 
 현재 backend endpoint:
 
 ```text
 GET /api/v1/llm-tools/sessions/{sessionId}/context
+GET /api/v1/llm-tools/sessions/{sessionId}/intents
+POST /api/v1/llm-tools/sessions/{sessionId}/intent-selection
 GET /api/v1/llm-tools/sessions/{sessionId}/slots
 GET /api/v1/llm-tools/sessions/{sessionId}/slots/{slotCode}
 PUT /api/v1/llm-tools/sessions/{sessionId}/slots/{slotCode}
@@ -37,6 +39,8 @@ const toolResult = await handleToolCall(toolCall);
 | Tool | Purpose |
 | --- | --- |
 | `get_current_slot_context` | 현재 세션의 전체 slot context, missing slot 목록, 저장된 값을 조회 |
+| `list_current_intents` | 현재 세션 domain pack version에 등록된 intent 목록 조회 |
+| `select_current_intent` | 목록에서 선택한 `intentCode`로 workflow execution을 시작하고 필수 slot 누락 여부 조회 |
 | `list_current_slots` | 현재 세션의 active slot 목록 조회 |
 | `get_current_slot` | 특정 `slotCode`의 정의와 현재 값 조회 |
 | `upsert_current_slot_value` | 특정 `slotCode`에 수집한 값을 저장 |

--- a/integrations/llm-tools/llm-tool-adapter.mjs
+++ b/integrations/llm-tools/llm-tool-adapter.mjs
@@ -25,6 +25,21 @@ export function createLlmSlotToolHandler({
       case LLM_SLOT_TOOL_NAMES.getContext:
         return wrapToolResult(toolCall, name, await requestJson("/context"));
 
+      case LLM_SLOT_TOOL_NAMES.listIntents:
+        return wrapToolResult(toolCall, name, await requestJson("/intents"));
+
+      case LLM_SLOT_TOOL_NAMES.selectIntent: {
+        const intentCode = requireString(args, "intentCode");
+        return wrapToolResult(
+          toolCall,
+          name,
+          await requestJson("/intent-selection", {
+            method: "POST",
+            body: { intentCode },
+          }),
+        );
+      }
+
       case LLM_SLOT_TOOL_NAMES.listSlots:
         return wrapToolResult(toolCall, name, await requestJson("/slots"));
 

--- a/integrations/llm-tools/llm-tool-adapter.test.mjs
+++ b/integrations/llm-tools/llm-tool-adapter.test.mjs
@@ -105,6 +105,60 @@ describe("llm slot tools", () => {
     assert.equal(requests[0].init.body, "{\"value\":\"A-200\"}");
   });
 
+  it("maps list_current_intents tool calls to the backend intents endpoint", async () => {
+    const requests = [];
+    const handler = createLlmSlotToolHandler({
+      backendBaseUrl: "http://localhost:8080",
+      sessionId: 7,
+      fetchImpl: async (url, init) => {
+        requests.push({ url, init });
+        return {
+          ok: true,
+          status: 200,
+          text: async () => "[{\"intentCode\":\"request_refund\"}]",
+        };
+      },
+    });
+
+    const result = await handler({
+      name: LLM_SLOT_TOOL_NAMES.listIntents,
+      arguments: {},
+    });
+
+    assert.equal(requests[0].url, "http://localhost:8080/api/v1/llm-tools/sessions/7/intents");
+    assert.equal(requests[0].init.method, "GET");
+    assert.deepEqual(result.result, [{ intentCode: "request_refund" }]);
+  });
+
+  it("maps select_current_intent tool calls to POST with intentCode body", async () => {
+    const requests = [];
+    const handler = createLlmSlotToolHandler({
+      backendBaseUrl: "http://localhost:8080",
+      sessionId: 7,
+      fetchImpl: async (url, init) => {
+        requests.push({ url, init });
+        return {
+          ok: true,
+          status: 200,
+          text: async () => "{\"intentCode\":\"request_refund\",\"currentState\":\"start\"}",
+        };
+      },
+    });
+
+    await handler({
+      name: LLM_SLOT_TOOL_NAMES.selectIntent,
+      arguments: { intentCode: "request_refund" },
+    });
+
+    assert.equal(
+      requests[0].url,
+      "http://localhost:8080/api/v1/llm-tools/sessions/7/intent-selection",
+    );
+    assert.equal(requests[0].init.method, "POST");
+    assert.equal(requests[0].init.headers["Content-Type"], "application/json");
+    assert.equal(requests[0].init.body, "{\"intentCode\":\"request_refund\"}");
+  });
+
   it("preserves status and non-JSON payloads from failed backend responses", async () => {
     const handler = createLlmSlotToolHandler({
       backendBaseUrl: "http://localhost:8080",

--- a/integrations/llm-tools/tool-schema.mjs
+++ b/integrations/llm-tools/tool-schema.mjs
@@ -3,6 +3,8 @@ export const LLM_SLOT_TOOL_NAMES = Object.freeze({
   listSlots: "list_current_slots",
   getSlot: "get_current_slot",
   upsertSlotValue: "upsert_current_slot_value",
+  listIntents: "list_current_intents",
+  selectIntent: "select_current_intent",
 });
 
 const emptyParameters = Object.freeze({
@@ -71,6 +73,36 @@ export const llmSlotTools = Object.freeze([
           }),
         }),
         required: Object.freeze(["slotCode", "value"]),
+        additionalProperties: false,
+      }),
+    }),
+  }),
+  Object.freeze({
+    type: "function",
+    function: Object.freeze({
+      name: LLM_SLOT_TOOL_NAMES.listIntents,
+      description:
+        "현재 상담 세션의 domain pack version에 등록된 전체 intent 목록을 조회한다. 이 목록의 intentCode 중 하나를 선택해야 한다.",
+      parameters: emptyParameters,
+    }),
+  }),
+  Object.freeze({
+    type: "function",
+    function: Object.freeze({
+      name: LLM_SLOT_TOOL_NAMES.selectIntent,
+      description:
+        "list_current_intents로 조회한 intentCode 중 현재 고객 발화에 가장 알맞은 intent를 선택하고 workflow execution을 시작한다.",
+      parameters: Object.freeze({
+        type: "object",
+        properties: Object.freeze({
+          intentCode: Object.freeze({
+            type: "string",
+            minLength: 1,
+            description:
+              "list_current_intents 응답에 포함된 intentCode. 임의로 생성하지 않고 목록에서 그대로 선택한다.",
+          }),
+        }),
+        required: Object.freeze(["intentCode"]),
         additionalProperties: false,
       }),
     }),


### PR DESCRIPTION
## Summary

- Add `.agent/specs/522.md` for the external LLM conversation state tool API.
- Extend the existing `llm-tools` runtime endpoints with DB-backed intent listing and exact `intentCode` selection.
- Persist selected intent, workflow, and current state into `runtime.workflow_execution`, then return required slot collection status.
- Update the JS tool schema/adapter and tests for `list_current_intents` and `select_current_intent`.

## Branch Rule Check

- Branch: `feature/522-llm-conversation-state-tool`
- Spec: `.agent/specs/522.md`
- Matches project rule: `feature/{issue-number}-{description}` with `.agent/specs/{issue-number}.md`

## Validation

- `cd backend && ./gradlew spotlessApply`
- `cd backend && ./gradlew test --tests 'com.init.workflowruntime.application.LlmToolServiceTest' --tests 'com.init.workflowruntime.presentation.LlmToolControllerTest'`
- `cd backend && ./gradlew spotlessCheck`
- `node --test integrations/llm-tools/llm-tool-adapter.test.mjs`
- `git diff --cached --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * LLM이 세션 기반으로 의도 목록 조회 및 특정 의도 선택으로 워크플로우 실행을 시작할 수 있음
  * 의도 선택 응답에 실행 정보(현재 상태, 워크플로 식별자)와 필수 슬롯 누락 정보 포함
  * 의도 선택 시 입력 검증(빈 intentCode 차단) 및 이미 종료된 실행에 대한 선택 차단(400 에러)

* **Documentation**
  * LLM 통합 문서에 세션 컨텍스트·intents·intent-selection 엔드포인트 및 도구 이름(조회/선택) 추가

* **Tests**
  * 의도 조회·선택 흐름과 예외·경계 케이스(유효성, 거절 상태, 초기 상태 처리 등)를 검증하는 테스트 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ajou-2026-1-capstone-5/ostone/pull/267?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->