### PR TITLE
fix(pipeline): generate one domain pack per dataset

### DIFF
--- a/backend/src/main/java/com/init/pipelinejob/domain/model/PipelineJob.java
+++ b/backend/src/main/java/com/init/pipelinejob/domain/model/PipelineJob.java
@@ -138,7 +138,7 @@ public class PipelineJob {
   }
 
   public boolean canAcceptDomainPackDraftCallback() {
-    return STATUS_QUEUED.equals(status) || STATUS_RUNNING.equals(status);
+    return domainPackId == null && (STATUS_QUEUED.equals(status) || STATUS_RUNNING.equals(status));
   }
 
   public boolean canAcceptIntentDraftCallback() {

--- a/backend/src/test/java/com/init/pipelinejob/application/ReceiveDomainPackDraftCallbackUseCaseTest.java
+++ b/backend/src/test/java/com/init/pipelinejob/application/ReceiveDomainPackDraftCallbackUseCaseTest.java
@@ -264,8 +264,27 @@ class ReceiveDomainPackDraftCallbackUseCaseTest {
     given(pipelineJobRepository.findById(11L))
         .willReturn(Optional.of(pipelineJob(11L, 3L, PipelineJob.STATUS_WAITING_INTENT_CALLBACK)));
 
-    assertThatThrownBy(() -> useCase.execute(validCommand()))
+    ReceiveDomainPackDraftCallbackCommand command = validCommand();
+
+    assertThatThrownBy(() -> useCase.execute(command))
         .isInstanceOf(PipelineJobCallbackNotAllowedException.class);
+  }
+
+  @Test
+  @DisplayName("이미 DomainPack이 연결된 RUNNING job에 domain-pack callback이 다시 오면 409 예외를 던진다")
+  void execute_runningJobWithDomainPack_throwsConflict() {
+    PipelineJob job = pipelineJob(11L, 3L, PipelineJob.STATUS_RUNNING);
+    ReflectionTestUtils.setField(job, "domainPackId", 7L);
+    given(webhookReceiptRepository.findByExternalEventId("evt-draft-1"))
+        .willReturn(Optional.empty());
+    given(pipelineJobRepository.findById(11L)).willReturn(Optional.of(job));
+
+    ReceiveDomainPackDraftCallbackCommand command = validCommand();
+
+    assertThatThrownBy(() -> useCase.execute(command))
+        .isInstanceOf(PipelineJobCallbackNotAllowedException.class);
+
+    verify(createDomainPackDraftPort, never()).execute(any());
   }
 
   private ReceiveDomainPackDraftCallbackCommand validCommand() {

--- a/backend/src/test/java/com/init/pipelinejob/domain/model/PipelineJobTest.java
+++ b/backend/src/test/java/com/init/pipelinejob/domain/model/PipelineJobTest.java
@@ -50,6 +50,22 @@ class PipelineJobTest {
   }
 
   @Test
+  @DisplayName("이미 DomainPack이 연결된 job은 RUNNING이어도 domain-pack draft callback을 다시 받을 수 없다")
+  void canAcceptDomainPackDraftCallback_runningWithDomainPack_returnsFalse() {
+    PipelineJob job = PipelineJob.createDomainPackGeneration(1L, 7L, 55L, "{}", NOW);
+    job.assignAirflowRun("domain_pack_generation", "pipeline_job_123", "{}");
+    job.markAirflowTriggered(NOW);
+    assertThat(job.canAcceptDomainPackDraftCallback()).isTrue();
+
+    job.markAwaitingIntentCallback(3L, "{}");
+    job.markRunning("{}");
+
+    assertThat(job.getStatus()).isEqualTo(PipelineJob.STATUS_RUNNING);
+    assertThat(job.getDomainPackId()).isEqualTo(3L);
+    assertThat(job.canAcceptDomainPackDraftCallback()).isFalse();
+  }
+
+  @Test
   @DisplayName("종료된 job은 RUNNING 상태로 되돌릴 수 없다")
   void markRunning_finalizedJob_throws() {
     PipelineJob job = PipelineJob.createDomainPackGeneration(1L, 7L, 55L, "{}", NOW);

--- a/frontend/src/features/log-upload/ui/LogUploadForm.test.tsx
+++ b/frontend/src/features/log-upload/ui/LogUploadForm.test.tsx
@@ -59,7 +59,7 @@ describe("LogUploadForm", () => {
 
   it("renders upload header and file uploader", () => {
     render(<LogUploadForm workspaceId={1} />, { wrapper: MemoryRouter });
-    expect(screen.getByText("Upload Consult Logs")).toBeInTheDocument();
+    expect(screen.getByText("상담 로그 업로드")).toBeInTheDocument();
     expect(screen.getByTestId("file-uploader")).toBeInTheDocument();
   });
 
@@ -131,6 +131,6 @@ describe("LogUploadForm", () => {
     fireEvent.click(screen.getByText("Upload Another File"));
     expect(mockReset).toHaveBeenCalled();
     expect(screen.queryByText("Upload Another File")).not.toBeInTheDocument();
-    expect(screen.getByText("Upload Consult Logs")).toBeInTheDocument();
+    expect(screen.getByText("상담 로그 업로드")).toBeInTheDocument();
   });
 });

--- a/frontend/src/features/log-upload/ui/LogUploadForm.tsx
+++ b/frontend/src/features/log-upload/ui/LogUploadForm.tsx
@@ -74,8 +74,8 @@ export const LogUploadForm: React.FC<LogUploadFormProps> = ({ workspaceId }) => 
   return (
     <div className={styles.container}>
       <div className={styles.header}>
-        <h2>Upload Consult Logs</h2>
-        <p>Drop your customer service log file to automatically generate a workflow.</p>
+        <h2>상담 로그 업로드</h2>
+        <p>파일 하나를 데이터셋으로 올리고, 데이터셋 단위로 도메인팩 초안 1개를 생성합니다.</p>
       </div>
 
       <div className={styles.uploadArea}>

--- a/frontend/src/pages/upload/ui/UploadPage.tsx
+++ b/frontend/src/pages/upload/ui/UploadPage.tsx
@@ -58,9 +58,9 @@ export const UploadPage: React.FC = () => {
             marginTop: 8,
           }}
         >
-          대량의 상담 로그를 자동으로 분석하여 intent, slot, policy, risk, workflow를 포함한 도메인
-          팩 초안을 생성합니다. 파이프라인은 6단계로 구성되며 각 단계의 진행 상황을 실시간으로
-          모니터링할 수 있습니다.
+          업로드한 데이터셋 1개당 도메인 팩 초안 1개를 생성하고, 여러 상담에서 추출한 intent,
+          slot, policy, risk, workflow를 그 안에 모읍니다. 파이프라인은 6단계로 구성되며 각
+          단계의 진행 상황을 실시간으로 모니터링할 수 있습니다.
         </p>
       </div>
 

--- a/frontend/src/pages/upload/ui/sections/Dropzone.test.tsx
+++ b/frontend/src/pages/upload/ui/sections/Dropzone.test.tsx
@@ -116,11 +116,12 @@ describe("Dropzone", () => {
     render(<Dropzone workspaceId={1} />);
     act(() => {
       lastConfig?.mutation?.onSuccess?.(
-        { datasetId: 42 },
+        { datasetId: 42, conversationCount: 10 },
         { data: { file: new File(["x"], "a.json") } },
       );
     });
     expect(screen.getByText(/업로드 완료 — a\.json \(dataset 42\)/)).toBeInTheDocument();
+    expect(screen.getByText("상담 10건은 도메인팩 초안 1개 안에 반영됩니다.")).toBeInTheDocument();
     expect(vi.mocked(toast.success)).toHaveBeenCalledWith("업로드 완료");
   });
 
@@ -128,11 +129,12 @@ describe("Dropzone", () => {
     render(<Dropzone workspaceId={1} />);
     act(() => {
       lastConfig?.mutation?.onSuccess?.(
-        { data: { datasetId: 99 } },
+        { data: { datasetId: 99, conversationCount: 3 } },
         { data: { file: new File(["x"], "b.json") } },
       );
     });
     expect(screen.getByText(/업로드 완료 — b\.json \(dataset 99\)/)).toBeInTheDocument();
+    expect(screen.getByText("상담 3건은 도메인팩 초안 1개 안에 반영됩니다.")).toBeInTheDocument();
   });
 
   it("onSuccess: datasetId 가 없으면 -1 로 폴백한다", () => {

--- a/frontend/src/pages/upload/ui/sections/Dropzone.tsx
+++ b/frontend/src/pages/upload/ui/sections/Dropzone.tsx
@@ -10,7 +10,7 @@ interface DropzoneProps {
 type UploadStatus =
   | { kind: "idle" }
   | { kind: "uploading"; fileName: string }
-  | { kind: "success"; fileName: string; datasetId: number }
+  | { kind: "success"; fileName: string; datasetId: number; conversationCount: number | null }
   | { kind: "error"; message: string };
 
 export const Dropzone: React.FC<DropzoneProps> = ({ workspaceId }) => {
@@ -27,13 +27,19 @@ export const Dropzone: React.FC<DropzoneProps> = ({ workspaceId }) => {
         // 단 null/primitive 응답에서 `in` 연산자 TypeError 만 차단.
         const r =
           typeof response === "object" && response !== null
-            ? (response as { data?: { datasetId?: number }; datasetId?: number })
+            ? (response as {
+                data?: { datasetId?: number; conversationCount?: number };
+                datasetId?: number;
+                conversationCount?: number;
+              })
             : null;
         const datasetId = r?.data?.datasetId ?? r?.datasetId;
+        const conversationCount = r?.data?.conversationCount ?? r?.conversationCount ?? null;
         setStatus({
           kind: "success",
           fileName: variables.data?.file?.name ?? "",
           datasetId: datasetId ?? -1,
+          conversationCount,
         });
         toast.success("업로드 완료");
       },
@@ -170,7 +176,9 @@ export const Dropzone: React.FC<DropzoneProps> = ({ workspaceId }) => {
           {status.kind === "idle" && "파일을 클릭하여 선택하세요"}
         </span>
         <Mono style={{ color: "var(--ink-3)" }}>
-          .json (consulting conversation array) &middot; max 50MB
+          {status.kind === "success"
+            ? `상담 ${status.conversationCount ?? "-"}건은 도메인팩 초안 1개 안에 반영됩니다.`
+            : ".json (consulting conversation array) · max 50MB"}
         </Mono>
       </div>
 

--- a/ml/src/pipeline/stages/draft_generation/main.py
+++ b/ml/src/pipeline/stages/draft_generation/main.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
-import hashlib
 import json
 import logging
 import os
-import re
 import time
-from collections.abc import Iterable
 from pathlib import Path
 from typing import Any, NamedTuple
 
@@ -32,8 +29,6 @@ _logger = logging.getLogger("pipeline.draft_generation")
 DEFAULT_CANDIDATE_ARTIFACT = "candidate.json"
 DEFAULT_CLUSTERS_ARTIFACT = "clusters.json"
 DEFAULT_PREPROCESSED_ARTIFACT = "preprocessed_data.json"
-DEFAULT_SEGMENT_ARTIFACT = "intent_segments_v3.jsonl"
-INTENT_MISC = "기타 문의"
 
 
 class SlotTemplate(NamedTuple):
@@ -74,17 +69,9 @@ def run(upstream_manifest_path: str | None = None) -> dict[str, object]:
     preprocessed_index = _read_preprocessed_index(runtime_config, stage_context)
     logger.info("draft_generation.preprocessed_loaded conversation_count=%d", len(preprocessed_index))
 
-    segment_rows = _read_segment_rows(runtime_config, stage_context)
-    consultation_cluster_groups = _build_consultation_cluster_groups(clusters, segment_rows)
-    if consultation_cluster_groups:
-        logger.info(
-            "draft_generation.consultation_split consultation_count=%d",
-            len(consultation_cluster_groups),
-        )
-
     cases_per_intent = _resolve_cases_per_intent()
     candidate, metrics = _build_candidate_artifact(
-        consultation_cluster_groups or {"": clusters},
+        clusters,
         preprocessed_index,
         cases_per_intent,
         stage_context,
@@ -177,140 +164,6 @@ def _read_preprocessed_index(
     return {conv["id"]: conv for conv in conversations if isinstance(conv, dict) and "id" in conv}
 
 
-def _read_segment_rows(
-    runtime_config: PipelineRuntimeConfig,
-    stage_context: StageContext,
-) -> list[dict[str, Any]]:
-    segment_path = _upstream_stage_dir("intent_discovery", runtime_config, stage_context) / DEFAULT_SEGMENT_ARTIFACT
-    if not segment_path.exists():
-        return []
-
-    rows: list[dict[str, Any]] = []
-    try:
-        for line_number, line in enumerate(segment_path.read_text(encoding="utf-8").splitlines(), start=1):
-            line = line.strip()
-            if not line:
-                continue
-            payload = json.loads(line)
-            if not isinstance(payload, dict):
-                raise PipelineStageError(f"{DEFAULT_SEGMENT_ARTIFACT} line {line_number} must be a JSON object.")
-            rows.append(payload)
-    except OSError as exc:
-        raise PipelineStageError(f"Failed to read {DEFAULT_SEGMENT_ARTIFACT}: {segment_path}") from exc
-    except json.JSONDecodeError as exc:
-        raise PipelineStageError(f"Invalid JSONL in {DEFAULT_SEGMENT_ARTIFACT}: {segment_path}") from exc
-    return rows
-
-
-def _build_consultation_cluster_groups(
-    clusters: list[Any],
-    segment_rows: list[dict[str, Any]],
-) -> dict[str, list[dict[str, Any]]]:
-    if not segment_rows:
-        return {}
-
-    global_by_canonical, global_by_cluster_id = _build_global_cluster_index(clusters)
-    grouped = _group_segment_rows_by_consultation(segment_rows)
-    consultation_clusters: dict[str, list[dict[str, Any]]] = {}
-    for consultation_id, canonical_groups in grouped.items():
-        consultation_clusters[consultation_id] = [
-            _build_local_consultation_cluster(
-                local_cluster_id,
-                consultation_id,
-                canonical,
-                rows,
-                global_by_canonical,
-                global_by_cluster_id,
-            )
-            for local_cluster_id, (canonical, rows) in enumerate(canonical_groups.items())
-        ]
-    return consultation_clusters
-
-
-def _build_global_cluster_index(
-    clusters: list[Any],
-) -> tuple[dict[str, dict[str, Any]], dict[int, dict[str, Any]]]:
-    global_by_canonical: dict[str, dict[str, Any]] = {}
-    global_by_cluster_id: dict[int, dict[str, Any]] = {}
-    for cluster in clusters:
-        if not isinstance(cluster, dict):
-            continue
-        canonical = _string_value(cluster.get("canonical_intent")) or _string_value(cluster.get("suggested_name"))
-        if canonical:
-            global_by_canonical[canonical] = cluster
-        cluster_id = _int_value(cluster.get("cluster_id"))
-        if cluster_id is not None:
-            global_by_cluster_id[cluster_id] = cluster
-    return global_by_canonical, global_by_cluster_id
-
-
-def _group_segment_rows_by_consultation(
-    segment_rows: list[dict[str, Any]],
-) -> dict[str, dict[str, list[dict[str, Any]]]]:
-    grouped: dict[str, dict[str, list[dict[str, Any]]]] = {}
-    for row in segment_rows:
-        consultation_id = _string_value(row.get("consultation_id"))
-        canonical = _string_value(row.get("canonical_intent"))
-        if consultation_id and canonical:
-            grouped.setdefault(consultation_id, {}).setdefault(canonical, []).append(row)
-    return grouped
-
-
-def _build_local_consultation_cluster(
-    local_cluster_id: int,
-    consultation_id: str,
-    canonical: str,
-    rows: list[dict[str, Any]],
-    global_by_canonical: dict[str, dict[str, Any]],
-    global_by_cluster_id: dict[int, dict[str, Any]],
-) -> dict[str, Any]:
-    base = _base_cluster(canonical, rows[0], global_by_canonical, global_by_cluster_id)
-    workflow_signal = base.get("workflow_signal")
-    return {
-        "cluster_id": local_cluster_id,
-        "canonical_intent": canonical,
-        "suggested_name": canonical,
-        "description": _string_value(base.get("description")) or _description_from_canonical(canonical),
-        "suggested_description": _string_value(base.get("suggested_description"))
-        or _description_from_canonical(canonical),
-        "cluster_size": len(rows),
-        "source": base.get("source") or "consultation_split_v1",
-        "segment_ids": _non_empty_values(_string_value(row.get("segment_id")) for row in rows),
-        "sample_intent_phrases": _unique_non_empty(
-            (_string_value(row.get("intent_phrase_refined")) or canonical for row in rows),
-        )[:8],
-        "sample_segment_texts": _non_empty_values(_string_value(row.get("segment_customer_text")) for row in rows)[:5],
-        "member_conv_ids": [consultation_id],
-        "exemplar_conv_ids": [consultation_id],
-        "workflow_signal": workflow_signal
-        if isinstance(workflow_signal, dict)
-        else _workflow_signal_from_canonical(canonical),
-        "fallback_name": bool(base.get("fallback_name", canonical == INTENT_MISC)),
-    }
-
-
-def _base_cluster(
-    canonical: str,
-    first_row: dict[str, Any],
-    global_by_canonical: dict[str, dict[str, Any]],
-    global_by_cluster_id: dict[int, dict[str, Any]],
-) -> dict[str, Any]:
-    cluster_id = _int_value(first_row.get("cluster_id"))
-    if canonical in global_by_canonical:
-        return global_by_canonical[canonical]
-    if cluster_id is not None and cluster_id in global_by_cluster_id:
-        return global_by_cluster_id[cluster_id]
-    return {}
-
-
-def _non_empty_values(values: Iterable[str | None]) -> list[str]:
-    return [value for value in values if value]
-
-
-def _unique_non_empty(values: Iterable[str | None]) -> list[str]:
-    return list(dict.fromkeys(value for value in values if value).keys())
-
-
 def _upstream_stage_dir(
     stage_name: str,
     runtime_config: PipelineRuntimeConfig,
@@ -328,90 +181,30 @@ def _upstream_stage_dir(
 
 
 def _build_candidate_artifact(
-    cluster_groups: dict[str, list[dict[str, Any]]],
+    clusters: list[Any],
     preprocessed_index: dict[str, dict[str, Any]],
     cases_per_intent: int,
     stage_context: StageContext,
 ) -> tuple[dict[str, Any], dict[str, Any]]:
-    candidates: list[dict[str, Any]] = []
-    intent_metrics = _empty_intent_metrics()
-    workflow_metrics = _empty_workflow_metrics()
-    slot_metrics = _empty_slot_metrics()
-
-    for consultation_id, clusters in cluster_groups.items():
-        scoped_consultation_id = consultation_id or None
-        intents, current_intent_metrics = _build_intents(clusters, preprocessed_index, cases_per_intent)
-        workflow_draft, current_workflow_metrics = _build_workflow_draft(clusters)
-        slots, intent_slot_bindings, current_slot_metrics = _build_slot_draft(clusters)
-        workflow_draft["slots"] = slots
-        workflow_draft["intentSlotBindings"] = intent_slot_bindings
-        candidates.append(_build_candidate(intents, workflow_draft, stage_context, scoped_consultation_id))
-        _merge_numeric_metrics(intent_metrics, current_intent_metrics)
-        _merge_numeric_metrics(workflow_metrics, current_workflow_metrics)
-        _merge_numeric_metrics(slot_metrics, current_slot_metrics)
+    intents, intent_metrics = _build_intents(clusters, preprocessed_index, cases_per_intent)
+    workflow_draft, workflow_metrics = _build_workflow_draft(clusters)
+    slots, intent_slot_bindings, slot_metrics = _build_slot_draft(clusters)
+    workflow_draft["slots"] = slots
+    workflow_draft["intentSlotBindings"] = intent_slot_bindings
 
     if intent_metrics["intent_count"] > 0:
         intent_metrics["representative_case_avg_per_intent"] = (
             intent_metrics["representative_case_total"] / intent_metrics["intent_count"]
         )
 
-    candidate: dict[str, Any]
-    if len(candidates) == 1:
-        candidate = candidates[0]
-    else:
-        candidate = {
-            "schemaVersion": "1.0",
-            "candidateMode": "consultation_split_v1",
-            "candidates": candidates,
-        }
+    candidate = _build_candidate(intents, workflow_draft, stage_context)
 
     return candidate, {
-        "candidate_count": len(candidates),
+        "candidate_count": 1,
         "intent_metrics": intent_metrics,
         "workflow_metrics": workflow_metrics,
         "slot_metrics": slot_metrics,
     }
-
-
-def _empty_intent_metrics() -> dict[str, Any]:
-    return {
-        "intent_count": 0,
-        "representative_case_total": 0,
-        "representative_case_avg_per_intent": 0.0,
-        "intents_with_zero_cases": 0,
-    }
-
-
-def _empty_workflow_metrics() -> dict[str, Any]:
-    return {
-        "workflow_count": 0,
-        "workflow_with_identify_count": 0,
-        "workflow_with_payment_check_count": 0,
-        "workflow_with_escalation_count": 0,
-        "workflow_evidence_keyword_total": 0,
-        "workflow_evidence_exemplar_total": 0,
-        "workflow_evidence_member_total": 0,
-        "workflow_with_empty_evidence_count": 0,
-    }
-
-
-def _empty_slot_metrics() -> dict[str, Any]:
-    return {
-        "slot_count": 0,
-        "cluster_with_slot_count": 0,
-        "signal_slot_hit_payment_check": 0,
-        "signal_slot_hit_user_identification": 0,
-        "signal_slot_hit_escalation": 0,
-    }
-
-
-def _merge_numeric_metrics(target: dict[str, Any], source: dict[str, Any]) -> None:
-    for key, value in source.items():
-        if isinstance(value, bool) or not isinstance(value, (int, float)):
-            continue
-        if key.endswith("_avg_per_intent"):
-            continue
-        target[key] = target.get(key, 0) + value
 
 
 def _flatten_metrics(metrics: dict[str, Any]) -> dict[str, Any]:
@@ -521,29 +314,14 @@ def _hydrate_case(conv: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _derive_pack_identity(stage_context: StageContext, consultation_id: str | None = None) -> tuple[str, str]:
+def _derive_pack_identity(stage_context: StageContext) -> tuple[str, str]:
     if stage_context.workspace_id is None or stage_context.dataset_id is None:
         raise PipelineStageError("packKey requires both workspace_id and dataset_id in StageContext.")
     base_key = f"pack_ws{stage_context.workspace_id}_ds{stage_context.dataset_id}"
     base_name = f"Pack ws{stage_context.workspace_id}/ds{stage_context.dataset_id}"
-    if consultation_id:
-        digest = hashlib.sha256(consultation_id.encode("utf-8")).hexdigest()[:8]
-        suffix = f"_{digest}"
-        prefix = f"{base_key}_conv_"
-        if len(prefix) + len(suffix) >= 100:
-            prefix = f"{base_key[: 100 - len('_conv_') - len(suffix) - 1]}_conv_"
-        slug = _slugify(consultation_id, max_length=100 - len(prefix) - len(suffix))
-        pack_key = f"{prefix}{slug}{suffix}"
-        pack_name = f"{base_name}/{consultation_id}"[:255]
-        return pack_key, pack_name
     pack_key = base_key
     pack_name = base_name
     return pack_key, pack_name
-
-
-def _slugify(value: str, max_length: int) -> str:
-    slug = re.sub(r"[^a-zA-Z0-9_-]+", "-", value).strip("-_").lower()
-    return (slug or "conversation")[:max_length]
 
 
 def _aggregate_evidence_metrics(
@@ -752,59 +530,19 @@ def _build_candidate(
     intents: list[dict[str, Any]],
     workflow_draft: dict[str, Any],
     stage_context: StageContext,
-    consultation_id: str | None = None,
 ) -> dict[str, Any]:
-    pack_key, pack_name = _derive_pack_identity(stage_context, consultation_id)
+    pack_key, pack_name = _derive_pack_identity(stage_context)
     domain_pack_draft: dict[str, Any] = {
         "packKey": pack_key,
         "packName": pack_name,
     }
-    if consultation_id:
-        domain_pack_draft["summaryJson"] = _compact_json(
-            {
-                "generationScope": "consultation",
-                "consultationId": consultation_id,
-                "workspaceId": stage_context.workspace_id,
-                "datasetId": stage_context.dataset_id,
-                "pipelineVersion": "consultation_split_v1",
-            }
-        )
     return {
         "schemaVersion": "1.0",
-        "consultationId": consultation_id,
         "domainPackDraft": domain_pack_draft,
         "intentDraft": {
             "intents": intents,
         },
         "workflowDraft": workflow_draft,
-    }
-
-
-def _string_value(value: object) -> str | None:
-    if isinstance(value, str) and value.strip():
-        return value.strip()
-    return None
-
-
-def _int_value(value: object) -> int | None:
-    if isinstance(value, bool):
-        return None
-    if isinstance(value, int):
-        return value
-    if isinstance(value, str) and value.isdecimal():
-        return int(value)
-    return None
-
-
-def _description_from_canonical(canonical: str) -> str:
-    return f"고객이 {canonical.replace(' 문의', '')}와 관련해 확인, 요청 또는 상담을 원하는 의도"
-
-
-def _workflow_signal_from_canonical(canonical: str) -> dict[str, bool]:
-    return {
-        "requires_payment_check": bool(re.search(r"결제|입금|환불|가격|견적|요금|비용", canonical)),
-        "requires_user_identification": bool(re.search(r"예약|변경|취소|환불|신청", canonical)),
-        "has_escalation_cases": bool(re.search(r"문제|보상|불만|컴플레인", canonical)),
     }
 
 

--- a/ml/src/pipeline/stages/publish_candidate/main.py
+++ b/ml/src/pipeline/stages/publish_candidate/main.py
@@ -410,19 +410,17 @@ def _run_callbacks(
     stage_context: StageContext,
     runtime_config: PipelineRuntimeConfig,
 ) -> None:
-    candidates = _candidate_items(candidate)
-    result["candidateCount"] = len(candidates)
-    for index, current_candidate in enumerate(candidates):
-        scope = _candidate_scope(current_candidate, index) if len(candidates) > 1 else None
-        _run_candidate_callbacks(
-            current_candidate,
-            result,
-            result_path,
-            stage_context,
-            runtime_config,
-            scope,
-            final_callback=index == len(candidates) - 1,
-        )
+    _candidate_items(candidate)
+    result["candidateCount"] = 1
+    _run_candidate_callbacks(
+        candidate,
+        result,
+        result_path,
+        stage_context,
+        runtime_config,
+        None,
+        final_callback=True,
+    )
 
 
 def _run_candidate_callbacks(
@@ -648,22 +646,9 @@ def _candidate_items(candidate: dict[str, Any]) -> list[dict[str, Any]]:
     candidates = candidate.get("candidates")
     if candidates is None:
         return [candidate]
-    if not isinstance(candidates, list) or not candidates:
-        raise PipelineStageError("candidates must be a non-empty JSON array when present.")
-    if not all(isinstance(item, dict) for item in candidates):
-        raise PipelineStageError("candidates must contain JSON objects.")
-    return cast(list[dict[str, Any]], candidates)
-
-
-def _candidate_scope(candidate: dict[str, Any], index: int) -> str:
-    domain_pack_draft = _required_object(candidate, "domainPackDraft")
-    pack_key = domain_pack_draft.get("packKey")
-    if isinstance(pack_key, str) and pack_key.strip():
-        return pack_key.strip()
-    consultation_id = candidate.get("consultationId")
-    if isinstance(consultation_id, str) and consultation_id.strip():
-        return f"consultation_{consultation_id.strip()}"
-    return f"candidate_{index}"
+    raise PipelineStageError(
+        "Candidate artifact must describe exactly one domain pack; candidates arrays are not supported."
+    )
 
 
 def _required_object(payload: dict[str, Any], key: str) -> dict[str, Any]:

--- a/ml/tests/stages/test_draft_generation_main.py
+++ b/ml/tests/stages/test_draft_generation_main.py
@@ -11,7 +11,6 @@ from pipeline.common.context import StageContext
 from pipeline.common.exceptions import PipelineStageError
 from pipeline.stages.draft_generation.main import (
     _build_candidate,
-    _build_consultation_cluster_groups,
     _build_intents,
     _build_slot_draft,
     _build_workflow_draft,
@@ -274,65 +273,6 @@ def test_build_intents_avg_per_intent() -> None:
     assert metrics["intents_with_zero_cases"] == 1
 
 
-def test_build_consultation_cluster_groups_splits_by_consultation_and_canonical() -> None:
-    clusters: list[Any] = [
-        "invalid",
-        {
-            "cluster_id": 10,
-            "canonical_intent": "항공권 변경 문의",
-            "description": "항공권 변경",
-            "suggested_description": "항공권 변경 설명",
-            "source": "global",
-            "workflow_signal": {"requires_user_identification": True},
-        },
-        {
-            "cluster_id": 20,
-            "description": "fallback cluster",
-            "fallback_name": True,
-            "workflow_signal": {"requires_payment_check": True},
-        },
-    ]
-    segment_rows: list[dict[str, Any]] = [
-        {
-            "consultation_id": "consultation-a",
-            "canonical_intent": "항공권 변경 문의",
-            "cluster_id": 10,
-            "segment_id": "seg-a-1",
-            "segment_customer_text": "항공권 날짜를 변경하고 싶어요",
-            "intent_phrase_refined": "항공권 변경 문의",
-        },
-        {
-            "consultation_id": "consultation-a",
-            "canonical_intent": "항공권 변경 문의",
-            "cluster_id": 10,
-            "segment_id": "seg-a-2",
-            "segment_customer_text": "인원을 추가할 수 있나요?",
-            "intent_phrase_refined": "항공권 변경 문의",
-        },
-        {
-            "consultation_id": "consultation-b",
-            "canonical_intent": "기타 문의",
-            "cluster_id": 20,
-            "segment_id": "seg-b-1",
-            "segment_customer_text": "안녕하세요",
-            "intent_phrase_refined": "",
-        },
-        {"consultation_id": "", "canonical_intent": "무시"},
-    ]
-
-    grouped = _build_consultation_cluster_groups(clusters, segment_rows)
-
-    assert set(grouped) == {"consultation-a", "consultation-b"}
-    assert grouped["consultation-a"][0]["cluster_id"] == 0
-    assert grouped["consultation-a"][0]["source"] == "global"
-    assert grouped["consultation-a"][0]["segment_ids"] == ["seg-a-1", "seg-a-2"]
-    assert grouped["consultation-a"][0]["sample_intent_phrases"] == ["항공권 변경 문의"]
-    assert grouped["consultation-a"][0]["workflow_signal"] == {"requires_user_identification": True}
-    assert grouped["consultation-b"][0]["description"] == "fallback cluster"
-    assert grouped["consultation-b"][0]["fallback_name"] is True
-    assert grouped["consultation-b"][0]["member_conv_ids"] == ["consultation-b"]
-
-
 def _write_upstream_manifest(tmp_path: Path) -> Path:
     manifest_path = tmp_path / "upstream_manifest.json"
     manifest_payload = {
@@ -382,6 +322,71 @@ def test_run_success(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     assert candidate["workflowDraft"]["workflows"][0]["workflowCode"] == "WORKFLOW_0"
 
 
+def test_run_keeps_single_dataset_candidate_when_segment_rows_exist(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    artifact_root = tmp_path / "artifacts"
+    clusters_dir = artifact_root / "dag" / "run1" / "intent_discovery"
+    preprocessed_dir = artifact_root / "dag" / "run1" / "preprocessing"
+    _write_clusters(
+        clusters_dir,
+        [
+            {
+                "cluster_id": 0,
+                "canonical_intent": "항공권 변경 문의",
+                "suggested_name": "항공권 변경 문의",
+                "suggested_description": "항공권 변경 관련",
+                "exemplar_conv_ids": ["consultation-a", "consultation-b"],
+                "workflow_signal": {"requires_user_identification": True},
+            }
+        ],
+    )
+    (clusters_dir / "intent_segments_v3.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "consultation_id": "consultation-a",
+                        "canonical_intent": "항공권 변경 문의",
+                        "cluster_id": 0,
+                    },
+                    ensure_ascii=False,
+                ),
+                json.dumps(
+                    {
+                        "consultation_id": "consultation-b",
+                        "canonical_intent": "항공권 변경 문의",
+                        "cluster_id": 0,
+                    },
+                    ensure_ascii=False,
+                ),
+            ]
+        ),
+        encoding="utf-8",
+    )
+    _write_preprocessed(
+        preprocessed_dir,
+        [
+            _preprocessed_conv("consultation-a", "항공권 변경 요청", "항공권 변경"),
+            _preprocessed_conv("consultation-b", "탑승자 변경 문의", "탑승자 변경"),
+        ],
+    )
+    manifest_path = _write_upstream_manifest(tmp_path)
+
+    monkeypatch.setenv("PIPELINE_ARTIFACT_ROOT", str(artifact_root))
+    monkeypatch.setenv("PIPELINE_BACKEND_BASE_URL", "http://backend:8080")
+
+    result = run(upstream_manifest_path=str(manifest_path))
+
+    candidate = json.loads(Path(str(result["candidateArtifactPath"])).read_text(encoding="utf-8"))
+    assert "candidateMode" not in candidate
+    assert "candidates" not in candidate
+    assert "consultationId" not in candidate
+    assert candidate["domainPackDraft"]["packKey"] == "pack_wsws1_dsds1"
+    assert len(candidate["intentDraft"]["intents"]) == 1
+    assert len(candidate["intentDraft"]["intents"][0]["representativeCases"]) == 2
+
+
 def test_build_candidate_structure() -> None:
     intents = [{"intentCode": "INTENT_0", "name": "환불", "representativeCases": []}]
     clusters = [{"cluster_id": 0, "suggested_name": "환불", "workflow_signal": {}}]
@@ -421,33 +426,6 @@ def test_derive_pack_identity_formats_correctly() -> None:
     pack_key, pack_name = _derive_pack_identity(context)
     assert pack_key == "pack_wsws42_dsds7"
     assert pack_name == "Pack wsws42/dsds7"
-
-
-def test_derive_pack_identity_adds_hash_suffix_for_consultation_scope() -> None:
-    context = _stage_context(workspace_id="ws42", dataset_id="ds7")
-    pack_key, pack_name = _derive_pack_identity(context, "consultation-001")
-    suffix = pack_key.rsplit("_", 1)[-1]
-
-    assert pack_key.startswith("pack_wsws42_dsds7_conv_consultation-001_")
-    assert len(pack_key) <= 100
-    assert len(suffix) == 8
-    int(suffix, 16)
-    assert pack_name == "Pack wsws42/dsds7/consultation-001"
-
-
-def test_derive_pack_identity_keeps_long_similar_consultation_ids_distinct() -> None:
-    context = _stage_context(workspace_id="ws42", dataset_id="ds7")
-    long_id_a = f"consultation-{'a' * 120}"
-    long_id_b = f"consultation-{'a' * 119}b"
-
-    pack_key_a, _ = _derive_pack_identity(context, long_id_a)
-    pack_key_b, _ = _derive_pack_identity(context, long_id_b)
-
-    assert len(pack_key_a) <= 100
-    assert len(pack_key_b) <= 100
-    assert pack_key_a != pack_key_b
-    assert len(pack_key_a.rsplit("_", 1)[-1]) == 8
-    assert len(pack_key_b.rsplit("_", 1)[-1]) == 8
 
 
 def test_derive_pack_identity_raises_on_none_workspace() -> None:

--- a/ml/tests/stages/test_publish_candidate_main.py
+++ b/ml/tests/stages/test_publish_candidate_main.py
@@ -177,6 +177,20 @@ def test_validate_candidate_requires_workflow_component() -> None:
         publish.validate_candidate(candidate)
 
 
+@pytest.mark.parametrize("candidate_count", [1, 2])
+def test_validate_candidate_rejects_legacy_domain_pack_candidates_array(
+    candidate_count: int,
+) -> None:
+    candidate = {
+        "schemaVersion": "1.0",
+        "candidateMode": "consultation_split_v1",
+        "candidates": [_candidate() for _ in range(candidate_count)],
+    }
+
+    with pytest.raises(PipelineStageError, match="exactly one domain pack"):
+        publish.validate_candidate(candidate)
+
+
 def test_validate_candidate_rejects_missing_spring_required_fields() -> None:
     cases = [
         ("intent name", ("intentDraft", "intents", 0, "name")),


### PR DESCRIPTION
## Summary
- Change ML draft generation to produce one dataset-scoped domain pack draft per uploaded dataset.
- Reject legacy multi-candidate publish artifacts so one pipeline job cannot fan out to multiple domain packs.
- Block repeated backend draft callbacks after a pipeline job already has a domain pack attached.
- Align upload UI copy and tests with the new dataset 1 -> domain pack draft 1 definition.

## Root Cause
The ML draft-generation stage still supported consultation-split candidate fan-out from segmented intent artifacts. When one uploaded dataset contained multiple consultations, that path could emit multiple candidate drafts and publish multiple callbacks.

## Validation
- cd ml && uv run pytest tests/stages/test_draft_generation_main.py tests/stages/test_publish_candidate_main.py tests/dags/test_pipeline_smoke.py
- cd ml && uv run ruff check src/pipeline/stages/draft_generation/main.py src/pipeline/stages/publish_candidate/main.py tests/stages/test_draft_generation_main.py tests/stages/test_publish_candidate_main.py
- cd backend && ./gradlew test --tests 'com.init.pipelinejob.domain.model.PipelineJobTest' --tests 'com.init.pipelinejob.application.ReceiveDomainPackDraftCallbackUseCaseTest'
- cd frontend && pnpm install
- cd frontend && pnpm test -- src/pages/upload/ui/sections/Dropzone.test.tsx src/features/log-upload/ui/LogUploadForm.test.tsx
- cd frontend && pnpm exec eslint src/pages/upload/ui/sections/Dropzone.tsx src/pages/upload/ui/sections/Dropzone.test.tsx src/features/log-upload/ui/LogUploadForm.tsx src/features/log-upload/ui/LogUploadForm.test.tsx src/pages/upload/ui/UploadPage.tsx
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 업로드 성공 시 반영된 상담 건수(conversation count)를 표시합니다.

* **개선 사항**
  * 도메인팩 생성 흐름을 단순화해 데이터셋당 1개의 도메인팩 초안만 생성되도록 변경했습니다.

* **버그 수정**
  * 도메인팩이 이미 연결된 작업에 대한 콜백 요청을 거부하도록 검증을 강화했습니다.
  * 다중 도메인팩 후보 배열 입력을 명확히 거부하도록 검증을 추가했습니다.

* **테스트**
  * 관련 단위·통합 테스트를 추가 및 갱신했습니다.

* **UI**
  * 업로드 페이지 및 폼의 문구를 한국어로 변경했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ajou-2026-1-capstone-5/ostone/pull/268?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->