### PR TITLE
feat(llm-tools): [521] add get_current_workflow LLM tool

### DIFF
--- a/backend/src/main/java/com/init/workflowruntime/application/LlmToolService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/LlmToolService.java
@@ -18,6 +18,7 @@ import com.init.domainpack.domain.repository.WorkflowDefinitionRepository;
 import com.init.shared.application.exception.BadRequestException;
 import com.init.shared.application.exception.InternalException;
 import com.init.shared.application.exception.NotFoundException;
+import com.init.workflowruntime.application.command.GetCurrentWorkflowCommand;
 import com.init.workflowruntime.application.command.GetLlmToolContextCommand;
 import com.init.workflowruntime.application.command.GetLlmToolSlotCommand;
 import com.init.workflowruntime.application.command.ListLlmToolIntentsCommand;
@@ -29,6 +30,7 @@ import com.init.workflowruntime.application.dto.LlmToolIntentResponse;
 import com.init.workflowruntime.application.dto.LlmToolIntentSelectionResponse;
 import com.init.workflowruntime.application.dto.LlmToolSlotResponse;
 import com.init.workflowruntime.application.dto.LlmToolSlotValueResponse;
+import com.init.workflowruntime.application.dto.LlmToolWorkflowResponse;
 import com.init.workflowruntime.domain.ChatSession;
 import com.init.workflowruntime.domain.ChatSessionRepository;
 import com.init.workflowruntime.domain.WorkflowExecution;
@@ -72,6 +74,49 @@ public class LlmToolService {
     this.intentWorkflowBindingRepository = intentWorkflowBindingRepository;
     this.workflowDefinitionRepository = workflowDefinitionRepository;
     this.objectMapper = objectMapper;
+  }
+
+  public LlmToolWorkflowResponse getCurrentWorkflow(GetCurrentWorkflowCommand command) {
+    Long sessionId = command.sessionId();
+    ChatSession session = findSession(sessionId);
+    WorkflowExecution execution = findExecution(sessionId);
+
+    Long executionId = execution != null ? execution.getId() : null;
+    String executionStatus = execution != null ? execution.getStatus() : null;
+    String currentState = execution != null ? execution.getCurrentState() : null;
+    Long workflowDefinitionId = execution != null ? execution.getWorkflowDefinitionId() : null;
+
+    WorkflowDefinition definition = null;
+    if (workflowDefinitionId != null) {
+      definition =
+          workflowDefinitionRepository
+              .findByIdAndDomainPackVersionId(
+                  workflowDefinitionId, session.getDomainPackVersionId())
+              .orElse(null);
+    }
+
+    JsonNode graphJson = definition != null ? readJsonNode(definition.getGraphJson(), null) : null;
+    JsonNode terminalStates =
+        definition != null ? readJsonNode(definition.getTerminalStatesJson(), "[]") : null;
+    if (terminalStates != null && !terminalStates.isArray()) {
+      throw new InternalException(
+          "JSON_PARSE_FAILED", "Stored terminalStatesJson must be a JSON array");
+    }
+
+    return new LlmToolWorkflowResponse(
+        session.getId(),
+        session.getWorkspaceId(),
+        session.getDomainPackVersionId(),
+        executionId,
+        executionStatus,
+        currentState,
+        definition != null ? definition.getId() : null,
+        definition != null ? definition.getWorkflowCode() : null,
+        definition != null ? definition.getName() : null,
+        definition != null ? definition.getDescription() : null,
+        graphJson,
+        definition != null ? definition.getInitialState() : null,
+        terminalStates);
   }
 
   public LlmToolContextResponse getContext(GetLlmToolContextCommand command) {

--- a/backend/src/main/java/com/init/workflowruntime/application/command/GetCurrentWorkflowCommand.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/command/GetCurrentWorkflowCommand.java
@@ -1,0 +1,3 @@
+package com.init.workflowruntime.application.command;
+
+public record GetCurrentWorkflowCommand(Long sessionId) {}

--- a/backend/src/main/java/com/init/workflowruntime/application/dto/LlmToolWorkflowResponse.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/dto/LlmToolWorkflowResponse.java
@@ -1,0 +1,18 @@
+package com.init.workflowruntime.application.dto;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public record LlmToolWorkflowResponse(
+    Long sessionId,
+    Long workspaceId,
+    Long domainPackVersionId,
+    Long executionId,
+    String executionStatus,
+    String currentState,
+    Long workflowDefinitionId,
+    String workflowCode,
+    String workflowName,
+    String workflowDescription,
+    JsonNode graphJson,
+    String initialState,
+    JsonNode terminalStates) {}

--- a/backend/src/main/java/com/init/workflowruntime/presentation/LlmToolController.java
+++ b/backend/src/main/java/com/init/workflowruntime/presentation/LlmToolController.java
@@ -1,6 +1,7 @@
 package com.init.workflowruntime.presentation;
 
 import com.init.workflowruntime.application.LlmToolService;
+import com.init.workflowruntime.application.command.GetCurrentWorkflowCommand;
 import com.init.workflowruntime.application.command.GetLlmToolContextCommand;
 import com.init.workflowruntime.application.command.GetLlmToolSlotCommand;
 import com.init.workflowruntime.application.command.ListLlmToolIntentsCommand;
@@ -12,6 +13,7 @@ import com.init.workflowruntime.application.dto.LlmToolIntentResponse;
 import com.init.workflowruntime.application.dto.LlmToolIntentSelectionResponse;
 import com.init.workflowruntime.application.dto.LlmToolSlotResponse;
 import com.init.workflowruntime.application.dto.LlmToolSlotValueResponse;
+import com.init.workflowruntime.application.dto.LlmToolWorkflowResponse;
 import com.init.workflowruntime.application.dto.SelectIntentRequest;
 import com.init.workflowruntime.application.dto.UpsertSlotValueRequest;
 import jakarta.validation.Valid;
@@ -33,6 +35,12 @@ public class LlmToolController {
 
   public LlmToolController(LlmToolService llmToolService) {
     this.llmToolService = llmToolService;
+  }
+
+  @GetMapping("/workflow")
+  public ResponseEntity<LlmToolWorkflowResponse> getCurrentWorkflow(@PathVariable Long sessionId) {
+    return ResponseEntity.ok(
+        llmToolService.getCurrentWorkflow(new GetCurrentWorkflowCommand(sessionId)));
   }
 
   @GetMapping("/context")

--- a/backend/src/test/java/com/init/workflowruntime/application/LlmToolServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/LlmToolServiceTest.java
@@ -20,7 +20,9 @@ import com.init.domainpack.domain.repository.IntentWorkflowBindingRepository;
 import com.init.domainpack.domain.repository.SlotDefinitionRepository;
 import com.init.domainpack.domain.repository.WorkflowDefinitionRepository;
 import com.init.shared.application.exception.BadRequestException;
+import com.init.shared.application.exception.InternalException;
 import com.init.shared.application.exception.NotFoundException;
+import com.init.workflowruntime.application.command.GetCurrentWorkflowCommand;
 import com.init.workflowruntime.application.command.GetLlmToolContextCommand;
 import com.init.workflowruntime.application.command.GetLlmToolSlotCommand;
 import com.init.workflowruntime.application.command.ListLlmToolIntentsCommand;
@@ -31,6 +33,7 @@ import com.init.workflowruntime.application.dto.LlmToolContextResponse;
 import com.init.workflowruntime.application.dto.LlmToolIntentSelectionResponse;
 import com.init.workflowruntime.application.dto.LlmToolSlotResponse;
 import com.init.workflowruntime.application.dto.LlmToolSlotValueResponse;
+import com.init.workflowruntime.application.dto.LlmToolWorkflowResponse;
 import com.init.workflowruntime.domain.ChatSession;
 import com.init.workflowruntime.domain.ChatSessionRepository;
 import com.init.workflowruntime.domain.ChatSessionStatus;
@@ -40,6 +43,7 @@ import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -490,5 +494,202 @@ class LlmToolServiceTest {
             "{}");
     ReflectionTestUtils.setField(workflow, "id", id);
     return workflow;
+  }
+
+  @Nested
+  @DisplayName("getCurrentWorkflow")
+  class GetCurrentWorkflow {
+
+    @Test
+    @DisplayName("세션 + execution + workflow definition이 모두 있으면 graphJson 포함 응답")
+    void returnsFullWorkflowWhenAllPresent() {
+      // given
+      ChatSession session = createSession(1L, 10L, 101L);
+      WorkflowExecution execution = createExecution(50L, 1L, 70L, "{}");
+      ReflectionTestUtils.setField(execution, "workflowDefinitionId", 77L);
+      ReflectionTestUtils.setField(execution, "currentState", "collect_slots");
+      WorkflowDefinition definition = createWorkflow(77L, 101L, "refund_v1", "collect_slots");
+      ReflectionTestUtils.setField(definition, "name", "환불 처리 워크플로우");
+
+      given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+      given(workflowExecutionRepository.findTopByChatSessionIdOrderByStartedAtDescIdDesc(1L))
+          .willReturn(Optional.of(execution));
+      given(workflowDefinitionRepository.findByIdAndDomainPackVersionId(77L, 101L))
+          .willReturn(Optional.of(definition));
+
+      // when
+      LlmToolWorkflowResponse result =
+          service.getCurrentWorkflow(new GetCurrentWorkflowCommand(1L));
+
+      // then
+      assertThat(result.sessionId()).isEqualTo(1L);
+      assertThat(result.workspaceId()).isEqualTo(10L);
+      assertThat(result.domainPackVersionId()).isEqualTo(101L);
+      assertThat(result.executionId()).isEqualTo(50L);
+      assertThat(result.executionStatus()).isEqualTo("RUNNING");
+      assertThat(result.currentState()).isEqualTo("collect_slots");
+      assertThat(result.workflowDefinitionId()).isEqualTo(77L);
+      assertThat(result.workflowCode()).isEqualTo("refund_v1");
+      assertThat(result.graphJson()).isNotNull();
+      assertThat(result.graphJson().isNull()).isFalse();
+      assertThat(result.initialState()).isEqualTo("collect_slots");
+      assertThat(result.terminalStates()).isNotNull();
+      assertThat(result.terminalStates().isArray()).isTrue();
+    }
+
+    @Test
+    @DisplayName("execution 없으면 execution/workflow 필드 모두 null")
+    void returnsNullsWhenExecutionMissing() {
+      // given
+      ChatSession session = createSession(1L, 10L, 101L);
+
+      given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+      given(workflowExecutionRepository.findTopByChatSessionIdOrderByStartedAtDescIdDesc(1L))
+          .willReturn(Optional.empty());
+
+      // when
+      LlmToolWorkflowResponse result =
+          service.getCurrentWorkflow(new GetCurrentWorkflowCommand(1L));
+
+      // then
+      assertThat(result.sessionId()).isEqualTo(1L);
+      assertThat(result.workspaceId()).isEqualTo(10L);
+      assertThat(result.domainPackVersionId()).isEqualTo(101L);
+      assertThat(result.executionId()).isNull();
+      assertThat(result.executionStatus()).isNull();
+      assertThat(result.currentState()).isNull();
+      assertThat(result.workflowDefinitionId()).isNull();
+      assertThat(result.graphJson()).isNull();
+      assertThat(result.terminalStates()).isNull();
+    }
+
+    @Test
+    @DisplayName("workflowDefinitionId가 null이면 execution 필드만 채우고 workflow는 null")
+    void returnsExecutionOnlyWhenWorkflowNotBound() {
+      // given
+      ChatSession session = createSession(1L, 10L, 101L);
+      WorkflowExecution execution = createExecution(50L, 1L, null, "{}");
+
+      given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+      given(workflowExecutionRepository.findTopByChatSessionIdOrderByStartedAtDescIdDesc(1L))
+          .willReturn(Optional.of(execution));
+
+      // when
+      LlmToolWorkflowResponse result =
+          service.getCurrentWorkflow(new GetCurrentWorkflowCommand(1L));
+
+      // then
+      assertThat(result.executionId()).isEqualTo(50L);
+      assertThat(result.executionStatus()).isEqualTo("RUNNING");
+      assertThat(result.workflowDefinitionId()).isNull();
+      assertThat(result.graphJson()).isNull();
+      assertThat(result.terminalStates()).isNull();
+    }
+
+    @Test
+    @DisplayName("workflowDefinitionId와 session domainPackVersionId가 불일치하면 workflow null")
+    void returnsWorkflowNullOnCrossPackMismatch() {
+      // given
+      ChatSession session = createSession(1L, 10L, 101L);
+      WorkflowExecution execution = createExecution(50L, 1L, 70L, "{}");
+      ReflectionTestUtils.setField(execution, "workflowDefinitionId", 77L);
+
+      given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+      given(workflowExecutionRepository.findTopByChatSessionIdOrderByStartedAtDescIdDesc(1L))
+          .willReturn(Optional.of(execution));
+      given(workflowDefinitionRepository.findByIdAndDomainPackVersionId(77L, 101L))
+          .willReturn(Optional.empty());
+
+      // when
+      LlmToolWorkflowResponse result =
+          service.getCurrentWorkflow(new GetCurrentWorkflowCommand(1L));
+
+      // then
+      assertThat(result.executionId()).isEqualTo(50L);
+      assertThat(result.workflowDefinitionId()).isNull();
+      assertThat(result.graphJson()).isNull();
+      assertThat(result.terminalStates()).isNull();
+    }
+
+    @Test
+    @DisplayName("sessionId가 없으면 SESSION_NOT_FOUND")
+    void throwsWhenSessionMissing() {
+      // given
+      given(chatSessionRepository.findById(99L)).willReturn(Optional.empty());
+
+      // when & then
+      assertThatThrownBy(() -> service.getCurrentWorkflow(new GetCurrentWorkflowCommand(99L)))
+          .isInstanceOf(NotFoundException.class)
+          .hasMessageContaining("Session not found");
+    }
+
+    @Test
+    @DisplayName("graphJson이 malformed이면 JSON_PARSE_FAILED")
+    void throwsWhenGraphJsonMalformed() {
+      // given
+      ChatSession session = createSession(1L, 10L, 101L);
+      WorkflowExecution execution = createExecution(50L, 1L, 70L, "{}");
+      ReflectionTestUtils.setField(execution, "workflowDefinitionId", 77L);
+      WorkflowDefinition definition = createWorkflow(77L, 101L, "refund_v1", "start");
+      ReflectionTestUtils.setField(definition, "graphJson", "not-valid-json");
+
+      given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+      given(workflowExecutionRepository.findTopByChatSessionIdOrderByStartedAtDescIdDesc(1L))
+          .willReturn(Optional.of(execution));
+      given(workflowDefinitionRepository.findByIdAndDomainPackVersionId(77L, 101L))
+          .willReturn(Optional.of(definition));
+
+      // when & then
+      assertThatThrownBy(() -> service.getCurrentWorkflow(new GetCurrentWorkflowCommand(1L)))
+          .isInstanceOf(InternalException.class)
+          .satisfies(
+              ex -> assertThat(((InternalException) ex).getCode()).isEqualTo("JSON_PARSE_FAILED"));
+    }
+
+    @Test
+    @DisplayName("terminalStatesJson이 malformed이면 JSON_PARSE_FAILED")
+    void throwsWhenTerminalStatesJsonMalformed() {
+      // given
+      ChatSession session = createSession(1L, 10L, 101L);
+      WorkflowExecution execution = createExecution(50L, 1L, 70L, "{}");
+      ReflectionTestUtils.setField(execution, "workflowDefinitionId", 77L);
+      WorkflowDefinition definition = createWorkflow(77L, 101L, "refund_v1", "start");
+      ReflectionTestUtils.setField(definition, "terminalStatesJson", "not-valid-json");
+
+      given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+      given(workflowExecutionRepository.findTopByChatSessionIdOrderByStartedAtDescIdDesc(1L))
+          .willReturn(Optional.of(execution));
+      given(workflowDefinitionRepository.findByIdAndDomainPackVersionId(77L, 101L))
+          .willReturn(Optional.of(definition));
+
+      // when & then
+      assertThatThrownBy(() -> service.getCurrentWorkflow(new GetCurrentWorkflowCommand(1L)))
+          .isInstanceOf(InternalException.class)
+          .satisfies(
+              ex -> assertThat(((InternalException) ex).getCode()).isEqualTo("JSON_PARSE_FAILED"));
+    }
+
+    @Test
+    @DisplayName("terminalStatesJson이 array가 아니면 JSON_PARSE_FAILED")
+    void throwsWhenTerminalStatesJsonNotArray() {
+      // given
+      ChatSession session = createSession(1L, 10L, 101L);
+      WorkflowExecution execution = createExecution(50L, 1L, 70L, "{}");
+      ReflectionTestUtils.setField(execution, "workflowDefinitionId", 77L);
+      WorkflowDefinition definition = createWorkflow(77L, 101L, "refund_v1", "start");
+      ReflectionTestUtils.setField(definition, "terminalStatesJson", "{\"key\":\"value\"}");
+
+      given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+      given(workflowExecutionRepository.findTopByChatSessionIdOrderByStartedAtDescIdDesc(1L))
+          .willReturn(Optional.of(execution));
+      given(workflowDefinitionRepository.findByIdAndDomainPackVersionId(77L, 101L))
+          .willReturn(Optional.of(definition));
+
+      // when & then
+      assertThatThrownBy(() -> service.getCurrentWorkflow(new GetCurrentWorkflowCommand(1L)))
+          .isInstanceOf(InternalException.class)
+          .satisfies(
+              ex -> assertThat(((InternalException) ex).getCode()).isEqualTo("JSON_PARSE_FAILED"));
+    }
   }
 }

--- a/backend/src/test/java/com/init/workflowruntime/presentation/LlmToolControllerSecurityTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/presentation/LlmToolControllerSecurityTest.java
@@ -53,6 +53,15 @@ class LlmToolControllerSecurityTest {
   }
 
   @Test
+  @WithMockUser(roles = "USER")
+  @DisplayName("/workflow 경로에서 ROLE_OPERATOR가 없으면 403")
+  void should_return403_when_userIsNotOperator_forWorkflow() throws Exception {
+    mockMvc
+        .perform(get("/api/v1/llm-tools/sessions/1/workflow"))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
   @WithMockUser(roles = "OPERATOR")
   @DisplayName("ROLE_OPERATOR면 200")
   void should_return200_when_userIsOperator() throws Exception {

--- a/backend/src/test/java/com/init/workflowruntime/presentation/LlmToolControllerSecurityTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/presentation/LlmToolControllerSecurityTest.java
@@ -10,8 +10,10 @@ import com.init.shared.infrastructure.security.ApiAuthenticationEntryPoint;
 import com.init.shared.infrastructure.security.JwtAuthenticationFilter;
 import com.init.shared.infrastructure.security.SecurityConfig;
 import com.init.workflowruntime.application.LlmToolService;
+import com.init.workflowruntime.application.command.GetCurrentWorkflowCommand;
 import com.init.workflowruntime.application.command.GetLlmToolContextCommand;
 import com.init.workflowruntime.application.dto.LlmToolContextResponse;
+import com.init.workflowruntime.application.dto.LlmToolWorkflowResponse;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -56,9 +58,19 @@ class LlmToolControllerSecurityTest {
   @WithMockUser(roles = "USER")
   @DisplayName("/workflow 경로에서 ROLE_OPERATOR가 없으면 403")
   void should_return403_when_userIsNotOperator_forWorkflow() throws Exception {
-    mockMvc
-        .perform(get("/api/v1/llm-tools/sessions/1/workflow"))
-        .andExpect(status().isForbidden());
+    mockMvc.perform(get("/api/v1/llm-tools/sessions/1/workflow")).andExpect(status().isForbidden());
+  }
+
+  @Test
+  @WithMockUser(roles = "OPERATOR")
+  @DisplayName("/workflow 경로에서 ROLE_OPERATOR면 200")
+  void should_return200_when_userIsOperator_forWorkflow() throws Exception {
+    given(llmToolService.getCurrentWorkflow(new GetCurrentWorkflowCommand(1L)))
+        .willReturn(
+            new LlmToolWorkflowResponse(
+                1L, 10L, 101L, null, null, null, null, null, null, null, null, null, null));
+
+    mockMvc.perform(get("/api/v1/llm-tools/sessions/1/workflow")).andExpect(status().isOk());
   }
 
   @Test

--- a/backend/src/test/java/com/init/workflowruntime/presentation/LlmToolControllerTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/presentation/LlmToolControllerTest.java
@@ -9,8 +9,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.init.shared.application.exception.NotFoundException;
 import com.init.shared.infrastructure.security.JwtAuthenticationFilter;
 import com.init.workflowruntime.application.LlmToolService;
+import com.init.workflowruntime.application.command.GetCurrentWorkflowCommand;
 import com.init.workflowruntime.application.command.GetLlmToolContextCommand;
 import com.init.workflowruntime.application.command.GetLlmToolSlotCommand;
 import com.init.workflowruntime.application.command.ListLlmToolIntentsCommand;
@@ -22,6 +24,7 @@ import com.init.workflowruntime.application.dto.LlmToolIntentResponse;
 import com.init.workflowruntime.application.dto.LlmToolIntentSelectionResponse;
 import com.init.workflowruntime.application.dto.LlmToolSlotResponse;
 import com.init.workflowruntime.application.dto.LlmToolSlotValueResponse;
+import com.init.workflowruntime.application.dto.LlmToolWorkflowResponse;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -49,6 +52,70 @@ class LlmToolControllerTest {
   @Autowired private ObjectMapper objectMapper;
 
   @MockitoBean private LlmToolService llmToolService;
+
+  @Test
+  @DisplayName("GET /api/v1/llm-tools/sessions/{sessionId}/workflow → 200 OK")
+  void getCurrentWorkflow_returnsOk() throws Exception {
+    // given
+    given(llmToolService.getCurrentWorkflow(new GetCurrentWorkflowCommand(1L)))
+        .willReturn(
+            new LlmToolWorkflowResponse(
+                1L,
+                10L,
+                101L,
+                50L,
+                "RUNNING",
+                "collect_slots",
+                77L,
+                "refund_v1",
+                "환불 처리 워크플로우",
+                "환불 요청 처리",
+                objectMapper.readTree("{\"nodes\":[]}"),
+                "collect_slots",
+                objectMapper.readTree("[\"refund_granted\"]")));
+
+    // when & then
+    mockMvc
+        .perform(get("/api/v1/llm-tools/sessions/1/workflow"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.sessionId").value(1))
+        .andExpect(jsonPath("$.executionId").value(50))
+        .andExpect(jsonPath("$.workflowCode").value("refund_v1"))
+        .andExpect(jsonPath("$.currentState").value("collect_slots"))
+        .andExpect(jsonPath("$.graphJson.nodes").isArray());
+  }
+
+  @Test
+  @DisplayName("GET /workflow session 없으면 404")
+  void getCurrentWorkflow_returnsNotFound_whenSessionMissing() throws Exception {
+    // given
+    given(llmToolService.getCurrentWorkflow(new GetCurrentWorkflowCommand(99L)))
+        .willThrow(new NotFoundException("SESSION_NOT_FOUND", "Session not found: 99"));
+
+    // when & then
+    mockMvc
+        .perform(get("/api/v1/llm-tools/sessions/99/workflow"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("SESSION_NOT_FOUND"));
+  }
+
+  @Test
+  @DisplayName("GET /workflow execution 없으면 200 + null 필드")
+  void getCurrentWorkflow_returnsOk_withNulls_whenNoExecution() throws Exception {
+    // given
+    given(llmToolService.getCurrentWorkflow(new GetCurrentWorkflowCommand(1L)))
+        .willReturn(
+            new LlmToolWorkflowResponse(
+                1L, 10L, 101L, null, null, null, null, null, null, null, null, null, null));
+
+    // when & then
+    mockMvc
+        .perform(get("/api/v1/llm-tools/sessions/1/workflow"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.sessionId").value(1))
+        .andExpect(jsonPath("$.executionId").doesNotExist())
+        .andExpect(jsonPath("$.workflowCode").doesNotExist());
+  }
 
   @Test
   @DisplayName("GET /api/v1/llm-tools/sessions/{sessionId}/context → 200 OK")

--- a/integrations/llm-tools/README.md
+++ b/integrations/llm-tools/README.md
@@ -5,6 +5,7 @@
 현재 backend endpoint:
 
 ```text
+GET /api/v1/llm-tools/sessions/{sessionId}/workflow
 GET /api/v1/llm-tools/sessions/{sessionId}/context
 GET /api/v1/llm-tools/sessions/{sessionId}/intents
 POST /api/v1/llm-tools/sessions/{sessionId}/intent-selection
@@ -38,6 +39,7 @@ const toolResult = await handleToolCall(toolCall);
 
 | Tool | Purpose |
 | --- | --- |
+| `get_current_workflow` | 현재 세션에 묶인 워크플로우 그래프와 현재 실행 상태(state, status) 조회 |
 | `get_current_slot_context` | 현재 세션의 전체 slot context, missing slot 목록, 저장된 값을 조회 |
 | `list_current_intents` | 현재 세션 domain pack version에 등록된 intent 목록 조회 |
 | `select_current_intent` | 목록에서 선택한 `intentCode`로 workflow execution을 시작하고 필수 slot 누락 여부 조회 |

--- a/integrations/llm-tools/llm-tool-adapter.mjs
+++ b/integrations/llm-tools/llm-tool-adapter.mjs
@@ -1,6 +1,6 @@
-import { LLM_SLOT_TOOL_NAMES, llmSlotTools } from "./tool-schema.mjs";
+import { LLM_SLOT_TOOL_NAMES, LLM_WORKFLOW_TOOL_NAMES, llmSlotTools } from "./tool-schema.mjs";
 
-export { LLM_SLOT_TOOL_NAMES, llmSlotTools };
+export { LLM_SLOT_TOOL_NAMES, LLM_WORKFLOW_TOOL_NAMES, llmSlotTools };
 
 export function createLlmSlotToolHandler({
   backendBaseUrl,
@@ -22,6 +22,9 @@ export function createLlmSlotToolHandler({
     const { name, arguments: args } = parseToolCall(toolCall);
 
     switch (name) {
+      case LLM_WORKFLOW_TOOL_NAMES.getCurrentWorkflow:
+        return wrapToolResult(toolCall, name, await requestJson("/workflow"));
+
       case LLM_SLOT_TOOL_NAMES.getContext:
         return wrapToolResult(toolCall, name, await requestJson("/context"));
 

--- a/integrations/llm-tools/llm-tool-adapter.test.mjs
+++ b/integrations/llm-tools/llm-tool-adapter.test.mjs
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 
 import {
   LLM_SLOT_TOOL_NAMES,
+  LLM_WORKFLOW_TOOL_NAMES,
   buildToolUrl,
   createLlmSlotToolHandler,
   llmSlotTools,
@@ -17,6 +18,59 @@ describe("llm slot tools", () => {
         false,
       );
     }
+  });
+
+  it("get_current_workflow tool schema does not expose sessionId", () => {
+    const workflowTool = llmSlotTools.find(
+      (t) => t.function.name === LLM_WORKFLOW_TOOL_NAMES.getCurrentWorkflow,
+    );
+    assert.ok(workflowTool, "get_current_workflow tool must exist in llmSlotTools");
+    assert.equal(
+      Object.prototype.hasOwnProperty.call(
+        workflowTool.function.parameters.properties,
+        "sessionId",
+      ),
+      false,
+    );
+  });
+
+  it("maps get_current_workflow tool calls to GET /workflow", async () => {
+    const requests = [];
+    const handler = createLlmSlotToolHandler({
+      backendBaseUrl: "http://localhost:8080",
+      bearerToken: "token",
+      sessionId: 7,
+      fetchImpl: async (url, init) => {
+        requests.push({ url, init });
+        return {
+          ok: true,
+          status: 200,
+          text: async () =>
+            JSON.stringify({
+              sessionId: 7,
+              workflowCode: "refund_v1",
+              graphJson: { nodes: [] },
+            }),
+        };
+      },
+    });
+
+    const result = await handler({
+      id: "call_wf1",
+      function: {
+        name: LLM_WORKFLOW_TOOL_NAMES.getCurrentWorkflow,
+        arguments: "{}",
+      },
+    });
+
+    assert.equal(
+      requests[0].url,
+      "http://localhost:8080/api/v1/llm-tools/sessions/7/workflow",
+    );
+    assert.equal(requests[0].init.method, "GET");
+    assert.equal(requests[0].init.headers.Authorization, "Bearer token");
+    assert.equal(result.toolCallId, "call_wf1");
+    assert.equal(result.name, LLM_WORKFLOW_TOOL_NAMES.getCurrentWorkflow);
   });
 
   it("parses OpenAI-style function tool calls", () => {

--- a/integrations/llm-tools/tool-schema.mjs
+++ b/integrations/llm-tools/tool-schema.mjs
@@ -1,3 +1,7 @@
+export const LLM_WORKFLOW_TOOL_NAMES = Object.freeze({
+  getCurrentWorkflow: "get_current_workflow",
+});
+
 export const LLM_SLOT_TOOL_NAMES = Object.freeze({
   getContext: "get_current_slot_context",
   listSlots: "list_current_slots",
@@ -83,6 +87,15 @@ export const llmSlotTools = Object.freeze([
       name: LLM_SLOT_TOOL_NAMES.listIntents,
       description:
         "현재 상담 세션의 domain pack version에 등록된 전체 intent 목록을 조회한다. 이 목록의 intentCode 중 하나를 선택해야 한다.",
+      parameters: emptyParameters,
+    }),
+  }),
+  Object.freeze({
+    type: "function",
+    function: Object.freeze({
+      name: LLM_WORKFLOW_TOOL_NAMES.getCurrentWorkflow,
+      description:
+        "현재 상담 세션에 묶인 결정론적 워크플로우 그래프와 현재 실행 상태(state, status)를 조회한다.",
       parameters: emptyParameters,
     }),
   }),


### PR DESCRIPTION
#### Summary

- `GET /api/v1/llm-tools/sessions/{sessionId}/workflow` 신규 엔드포인트 추가 — 최신 `WorkflowExecution` 상태 + 연결된 `WorkflowDefinition` 그래프를 단일 응답으로 반환
- `LlmToolService`에 `getCurrentWorkflow(GetCurrentWorkflowCommand)` 추가, execution 없음 / workflowDefinitionId null / cross-pack mismatch 3가지 부재 케이스 모두 200 + 부분 null로 처리
- `tool-schema.mjs`에 `LLM_WORKFLOW_TOOL_NAMES` 신규 상수 추가 (기존 `LLM_SLOT_TOOL_NAMES` 보존), `llm-tool-adapter.mjs`에 `get_current_workflow → GET /workflow` 라우팅 추가
- 서비스 테스트 8개 + 컨트롤러 테스트 3개 + 보안 테스트 1개 + mjs 통합 테스트 2개 추가
- V-001 (security test coverage gap) codeRemediator 처리 완료 (commit: `53d07fd`)

---

#### Context

- Spec: `.agent/specs/521.md` — **[521] Get Current Workflow LLM Tool** (5.2.x tool 시리즈 첫 번째)
- 기존 4개 slot tool (base path `/api/v1/llm-tools/sessions/{sessionId}`)에 5번째 workflow tool 추가
- Spring Boot `workflow-runtime` BC + `domain-pack` BC(`WorkflowDefinitionRepository`) 참조
- LLM이 graph + currentState를 기준으로 다음 액션을 결정하기 위한 결정론적 워크플로우 엔진 입구

---

#### What Changed

**Backend (Java)**

- `LlmToolService`: `WorkflowDefinitionRepository` final 필드 추가, `getCurrentWorkflow` 메서드 추가. `terminalStates` 파싱 시 `isArray()` inline check + `InternalException("JSON_PARSE_FAILED")` guard 포함.
- `LlmToolController`: `@GetMapping("/workflow")` 추가, Command 생성 후 서비스 위임.
- `GetCurrentWorkflowCommand` (신규): `sessionId`, `domainPackVersionId` 포함.
- `LlmToolWorkflowResponse` (신규): `graphJson: JsonNode`, `terminalStates: JsonNode`, `executionStatus`, `currentState`, `workflowDefinitionId` 필드 — record 타입.

**Integration (mjs)**

- `tool-schema.mjs`: `LLM_WORKFLOW_TOOL_NAMES = { getCurrentWorkflow: "get_current_workflow" }` 신규 추가, `llmSlotTools` 배열에 `get_current_workflow` 스키마 추가 (`emptyParameters` — sessionId 미노출).
- `llm-tool-adapter.mjs`: switch 분기 최우선에 `getCurrentWorkflow` case 추가, `LLM_WORKFLOW_TOOL_NAMES` re-export.
- `README.md`: endpoint 목록 및 Tool Names 표 갱신.

---

#### Assumptions Adopted

없음. 모든 uncertainty 항목(U-001~U-008)이 Confirmed / Deferred / Engineering-bound 상태로 사전 결정되어 있어 임의 assumption 없이 구현 완료.

- **U-001~U-004, U-006, U-007, U-008**: Confirmed (스펙 결정 그대로 구현, deviation 없음)
- **U-005** (DTO 공통화): Deferred — 후속 5.2.x spec에서 결정 예정 (본 PR 범위 외)
- **U-006** (cross-pack invariant): Engineering-bound — `findByIdAndDomainPackVersionId` `Optional.empty()` 시 workflow 필드 null 반환

---

#### Spec Deviations

N/A. 구현된 모든 항목이 스펙과 일치. (audit-report V-001은 deviation이 아닌 test coverage 누락으로 분류, 수정 완료.)

---

#### Blocked / Skipped Items

- **U-005 (DTO 공통화)**: `LlmToolWorkflowResponse`만 정의. 5.2.x 시리즈 공통 DTO 추출은 후속 spec에서 결정 예정.

---

#### Test Notes

| 위치 | 테스트 | 결과 |
|---|---|---|
| `LlmToolServiceTest` (Nested: `GetCurrentWorkflow`) | 8개 케이스 (full response, execution 없음, workflowDefinitionId null, cross-pack mismatch, session 404, graphJson malformed ×2, terminalStates not array) | BUILD SUCCESSFUL |
| `LlmToolControllerTest` | 3개 케이스 (200 OK, session 404, execution 없음 200 + nulls) | BUILD SUCCESSFUL |
| `LlmToolControllerSecurityTest` | `should_return403_when_userIsNotOperator_forWorkflow` 1건 추가 (V-001 fix, commit `53d07fd`) | BUILD SUCCESSFUL |
| `llm-tool-adapter.test.mjs` | `get_current_workflow` sessionId 미노출 검증, GET /workflow 라우팅 검증 | PASS (manual verification) |

테스트 fixture 전략: mock-only (`@ExtendWith(MockitoExtension.class)` + `@Mock` + `ReflectionTestUtils.setField`). DB seed 없음 (U-008 결정).

---

#### Codegen Status

BE controller 변경 포함 (`LlmToolController.java` — 신규 endpoint 추가)이므로 본 섹션 포함.

- `frontend/src/shared/api/generated/` 변경 파일: **0** (이번 PR에서 미재생성)
- regenerate command (`./gradlew generateOpenApiDocs` + `pnpm api:gen`) 실행: **✗**
- manual layer (`mutator.ts` / `index.ts`) 변경: **✗**
- `.codegen-meta.json` hash sync: **UNVERIFIED** (regeneration 미수행)

> **Note**: `/api/v1/llm-tools/**` 는 `llm-tool-adapter.mjs` 통합 레이어가 직접 호출하며 Orval-generated React client를 경유하지 않는다. 이번 PR에서 FE generated/ 재생성을 수행하지 않았고, codeAuditor는 이를 violation으로 분류하지 않았다(audit 시점 headSha `e4babb9`). 리뷰어가 codegen 재생성 필요 여부를 확인 권장.

---

#### Reviewer Focus

1. **`LlmToolService.getCurrentWorkflow` null 처리 3-way**: execution 없음 vs `workflowDefinitionId` null vs cross-pack mismatch — 모두 200 + 부분 null. 의도한 동작인지 재확인.
2. **`terminalStates` `isArray()` check**: `graph_json` NOT NULL이지만 `terminal_states_json` blank 케이스 처리. `InternalException("JSON_PARSE_FAILED")` 발화 경로가 명확한지 확인.
3. **`LLM_WORKFLOW_TOOL_NAMES` additive 방식**: 기존 `LLM_SLOT_TOOL_NAMES` 보존 + 별도 상수 추가 (U-007 결정). consumer가 두 상수를 별도로 import해야 하는 API surface 변화.
4. **Codegen 재생성 미수행**: 신규 endpoint가 Orval-generated client에 포함되지 않은 상태. 외부 LLM 통합 레이어(mjs)에서만 소비한다는 전제가 맞는지 확인.

---

#### Conflicts

없음.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 세션 기반 현재 워크플로우 조회 추가: 워크플로우 그래프, 실행 상태(상태·상태코드) 및 정의 정보를 반환합니다.
  * LLM 도구 통합: LLM에서 현재 워크플로우 조회 도구(get_current_workflow)를 통해 해당 정보를 호출할 수 있습니다.

* **Tests**
  * 서비스·컨트롤러용 단·통합 테스트 추가 및 보안(권한) 검증 강화.

* **Documentation**
  * LLM-Tools 통합 문서에 워크플로우 조회 엔드포인트 및 도구 설명 추가.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ajou-2026-1-capstone-5/ostone/pull/270?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->