### PR TITLE
feat(workflow-runtime): add policy-aware runtime tools

### DIFF
--- a/.agent/specs/524.md
+++ b/.agent/specs/524.md
@@ -3,7 +3,7 @@
 > **Backlog**: 5.2.4 워크플로우 런타임 다음 액션 계산 및 외부 LLM tool 연동
 > **Bounded Context**: `workflow-runtime`
 > **Template**: `_TEMPLATE_BE.md`
-> **Branch**: `feature/001-boundary-intent-pipeline`
+> **Branch**: `feature/524-workflow-runtime-tools`
 > **Frontend Scope**: 없음. 이번 스펙은 backend runtime engine과 외부 LLM tool adapter만 다룬다.
 
 ---
@@ -427,7 +427,7 @@ Base path:
 
 ### `POST /advance`
 
-`currentPolicy`는 이동 후 도착한 현재 node의 정책이고, `transitionPolicy`는 이번 edge 선택의 원인이 된 source node 정책이다. `transitionPolicy`는 `policy_hit` edge로 전이한 경우에만 채워진다.
+`policySnapshot`은 응답 시점의 `currentState` 기준 정책 snapshot만 담고, 전이를 유발한 source node 정책은 포함하지 않는다. `currentPolicy`는 이동 후 도착한 현재 node의 정책이고, `transitionPolicy`는 이번 edge 선택의 원인이 된 source node 정책이다. `transitionPolicy`는 `policy_hit` edge로 전이한 경우에만 채워진다.
 
 ```json
 {

--- a/.agent/specs/524.md
+++ b/.agent/specs/524.md
@@ -3,7 +3,7 @@
 > **Backlog**: 5.2.4 워크플로우 런타임 다음 액션 계산 및 외부 LLM tool 연동
 > **Bounded Context**: `workflow-runtime`
 > **Template**: `_TEMPLATE_BE.md`
-> **Branch**: `spec/524`
+> **Branch**: `feature/001-boundary-intent-pipeline`
 > **Frontend Scope**: 없음. 이번 스펙은 backend runtime engine과 외부 LLM tool adapter만 다룬다.
 
 ---
@@ -52,7 +52,7 @@
 
 ## Existing Implementation Paths
 
-아래 경로는 이 스펙을 구현할 때 사용할 대상 경로다.
+아래 경로는 현재 저장소에서 확인된 구현 대상이다.
 
 | Path | Layer | 역할 |
 | --- | --- | --- |
@@ -265,6 +265,7 @@ workflow node의 `policyRef`는 `PolicyDefinition.policyCode`를 가리킨다.
 - `conditionJson`이 있으면 `WorkflowConditionEvaluator`로 slot/policy/risk snapshot을 기준으로 평가한다.
 - match되면 `policySnapshot.hits`에 해당 `policyCode`가 들어간다.
 - LLM은 `currentPolicy.action`, `currentPolicy.evidence`, `currentPolicy.meta`를 답변 지침으로 사용한다.
+- `policy_hit` edge로 전이된 경우, 도착 node의 정책과 별개로 이번 전이를 유발한 source node 정책을 `transitionPolicy`에 담는다.
 
 ---
 
@@ -426,6 +427,8 @@ Base path:
 
 ### `POST /advance`
 
+`currentPolicy`는 이동 후 도착한 현재 node의 정책이고, `transitionPolicy`는 이번 edge 선택의 원인이 된 source node 정책이다. `transitionPolicy`는 `policy_hit` edge로 전이한 경우에만 채워진다.
+
 ```json
 {
   "sessionId": 1,
@@ -445,6 +448,7 @@ Base path:
   "policySnapshot": {
     "hits": []
   },
+  "transitionPolicy": null,
   "currentPolicy": {
     "policyCode": "reservation_cancel_deadline",
     "matched": false,
@@ -472,6 +476,7 @@ Base path:
   "policySnapshot": {
     "hits": []
   },
+  "transitionPolicy": null,
   "currentPolicy": null,
   "reason": "required slot values are missing"
 }
@@ -776,14 +781,25 @@ LLM tool call:
   "currentNodeType": "HANDOFF",
   "edgeId": "e_confirm_handoff",
   "targetState": "handoff",
-  "policySnapshot": {
-    "hits": [
-      {
-        "policyCode": "reservation_cancel_deadline",
-        "nodeId": "confirm_cancel"
-      }
-    ]
+  "condition": {
+    "type": "policy_hit",
+    "policyCode": "reservation_cancel_deadline"
   },
+  "policySnapshot": {
+    "hits": []
+  },
+  "transitionPolicy": {
+    "policyCode": "reservation_cancel_deadline",
+    "nodeId": "confirm_cancel",
+    "matched": true,
+    "action": {
+      "answerGuide": "즉시 취소 확정을 약속하지 말고 상담사 확인이 필요하다고 안내한다.",
+      "allowedActions": ["handoff"],
+      "prohibitedActions": ["promise_full_refund"]
+    },
+    "reason": "policy condition matched"
+  },
+  "currentPolicy": null,
   "reason": "transitioned from confirm_cancel to handoff"
 }
 ```
@@ -838,10 +854,10 @@ sequenceDiagram
     runtime ->> policy: evaluate current node policyRef
     policy ->> db: SELECT PolicyDefinition
     db -->> policy: policy condition/action/evidence
-    policy -->> runtime: policySnapshot/currentPolicy
+    policy -->> runtime: source node policySnapshot
     runtime ->> runtime: edge condition 평가
     runtime -->> tool: HANDOFF or ADVANCE
-    tool -->> llm: actionType, currentPolicy
+    tool -->> llm: actionType, transitionPolicy, currentPolicy
     llm -->> customer: policy 기반 안내 답변
 ```
 

--- a/backend/src/main/java/com/init/domainpack/domain/repository/PolicyDefinitionRepository.java
+++ b/backend/src/main/java/com/init/domainpack/domain/repository/PolicyDefinitionRepository.java
@@ -17,6 +17,9 @@ public interface PolicyDefinitionRepository {
 
   Optional<PolicyDefinition> findByIdAndDomainPackVersionId(Long id, Long domainPackVersionId);
 
+  Optional<PolicyDefinition> findByDomainPackVersionIdAndPolicyCode(
+      Long domainPackVersionId, String policyCode);
+
   List<PolicyDefinition> findAllByDomainPackVersionIdOrderByPolicyCodeAsc(Long domainPackVersionId);
 
   PolicyDefinition save(PolicyDefinition policy);

--- a/backend/src/main/java/com/init/domainpack/infrastructure/persistence/JpaPolicyDefinitionRepository.java
+++ b/backend/src/main/java/com/init/domainpack/infrastructure/persistence/JpaPolicyDefinitionRepository.java
@@ -25,6 +25,9 @@ public interface JpaPolicyDefinitionRepository
 
   Optional<PolicyDefinition> findByIdAndDomainPackVersionId(Long id, Long domainPackVersionId);
 
+  Optional<PolicyDefinition> findByDomainPackVersionIdAndPolicyCode(
+      Long domainPackVersionId, String policyCode);
+
   @Query(
       "SELECT p.policyCode FROM PolicyDefinition p"
           + " WHERE p.domainPackVersionId = :versionId AND p.policyCode IN :policyCodes")

--- a/backend/src/main/java/com/init/shared/infrastructure/security/SecurityConfig.java
+++ b/backend/src/main/java/com/init/shared/infrastructure/security/SecurityConfig.java
@@ -62,6 +62,8 @@ public class SecurityConfig {
                     .permitAll()
                     .requestMatchers("/api/v1/consultation/**")
                     .hasRole("OPERATOR")
+                    .requestMatchers("/api/v1/workflow-runtime/**")
+                    .hasRole("OPERATOR")
                     .requestMatchers("/api/v1/llm-tools/**")
                     .hasRole("OPERATOR")
                     .anyRequest()

--- a/backend/src/main/java/com/init/workflowruntime/application/LlmToolService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/LlmToolService.java
@@ -20,6 +20,7 @@ import com.init.shared.application.exception.InternalException;
 import com.init.shared.application.exception.NotFoundException;
 import com.init.workflowruntime.application.command.GetCurrentWorkflowCommand;
 import com.init.workflowruntime.application.command.GetLlmToolContextCommand;
+import com.init.workflowruntime.application.command.GetLlmToolPolicyContextCommand;
 import com.init.workflowruntime.application.command.GetLlmToolSlotCommand;
 import com.init.workflowruntime.application.command.ListLlmToolIntentsCommand;
 import com.init.workflowruntime.application.command.ListLlmToolSlotsCommand;
@@ -155,7 +156,8 @@ public class LlmToolService {
         slots);
   }
 
-  public LlmToolPolicyContextResponse getPolicyContext(Long sessionId) {
+  public LlmToolPolicyContextResponse getPolicyContext(GetLlmToolPolicyContextCommand command) {
+    Long sessionId = command.sessionId();
     ChatSession session = findSession(sessionId);
     WorkflowExecution execution = findExecution(sessionId);
     if (execution == null) {

--- a/backend/src/main/java/com/init/workflowruntime/application/LlmToolService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/LlmToolService.java
@@ -28,6 +28,8 @@ import com.init.workflowruntime.application.command.UpsertLlmToolSlotValueComman
 import com.init.workflowruntime.application.dto.LlmToolContextResponse;
 import com.init.workflowruntime.application.dto.LlmToolIntentResponse;
 import com.init.workflowruntime.application.dto.LlmToolIntentSelectionResponse;
+import com.init.workflowruntime.application.dto.LlmToolPolicyContextResponse;
+import com.init.workflowruntime.application.dto.LlmToolPolicyResponse;
 import com.init.workflowruntime.application.dto.LlmToolSlotResponse;
 import com.init.workflowruntime.application.dto.LlmToolSlotValueResponse;
 import com.init.workflowruntime.application.dto.LlmToolWorkflowResponse;
@@ -55,6 +57,7 @@ public class LlmToolService {
   private final IntentSlotBindingRepository intentSlotBindingRepository;
   private final IntentWorkflowBindingRepository intentWorkflowBindingRepository;
   private final WorkflowDefinitionRepository workflowDefinitionRepository;
+  private final WorkflowPolicyRuntimeService workflowPolicyRuntimeService;
   private final ObjectMapper objectMapper;
 
   public LlmToolService(
@@ -65,6 +68,7 @@ public class LlmToolService {
       IntentSlotBindingRepository intentSlotBindingRepository,
       IntentWorkflowBindingRepository intentWorkflowBindingRepository,
       WorkflowDefinitionRepository workflowDefinitionRepository,
+      WorkflowPolicyRuntimeService workflowPolicyRuntimeService,
       ObjectMapper objectMapper) {
     this.chatSessionRepository = chatSessionRepository;
     this.workflowExecutionRepository = workflowExecutionRepository;
@@ -73,6 +77,7 @@ public class LlmToolService {
     this.intentSlotBindingRepository = intentSlotBindingRepository;
     this.intentWorkflowBindingRepository = intentWorkflowBindingRepository;
     this.workflowDefinitionRepository = workflowDefinitionRepository;
+    this.workflowPolicyRuntimeService = workflowPolicyRuntimeService;
     this.objectMapper = objectMapper;
   }
 
@@ -128,6 +133,13 @@ public class LlmToolService {
     List<LlmToolSlotResponse> slots = buildSlotResponses(session, execution, slotValues);
     List<String> missingSlots =
         slots.stream().filter(slot -> !slot.hasValue()).map(LlmToolSlotResponse::slotCode).toList();
+    JsonNode policySnapshot =
+        readJsonNode(execution != null ? execution.getPolicySnapshotJson() : "{}", "{}");
+    LlmToolPolicyResponse currentPolicy =
+        execution != null
+            ? workflowPolicyRuntimeService.evaluateCurrentPolicy(
+                session.getDomainPackVersionId(), execution, slotValues)
+            : null;
 
     return new LlmToolContextResponse(
         session.getId(),
@@ -137,8 +149,30 @@ public class LlmToolService {
         execution != null ? execution.getStatus() : null,
         execution != null ? execution.getCurrentState() : null,
         slotValues,
+        policySnapshot,
+        currentPolicy,
         missingSlots,
         slots);
+  }
+
+  public LlmToolPolicyContextResponse getPolicyContext(Long sessionId) {
+    ChatSession session = findSession(sessionId);
+    WorkflowExecution execution = findExecution(sessionId);
+    if (execution == null) {
+      return new LlmToolPolicyContextResponse(
+          session.getId(), null, null, readJsonNode("{}", "{}"), null);
+    }
+    ObjectNode slotValues = readObjectNode(execution.getSlotValuesJson());
+    LlmToolPolicyResponse currentPolicy =
+        workflowPolicyRuntimeService.evaluateCurrentPolicy(
+            session.getDomainPackVersionId(), execution, slotValues);
+    JsonNode policySnapshot = readJsonNode(execution.getPolicySnapshotJson(), "{}");
+    return new LlmToolPolicyContextResponse(
+        session.getId(),
+        execution.getId(),
+        execution.getCurrentState(),
+        policySnapshot,
+        currentPolicy);
   }
 
   public List<LlmToolSlotResponse> listSlots(ListLlmToolSlotsCommand command) {

--- a/backend/src/main/java/com/init/workflowruntime/application/PolicyEvaluationCommand.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/PolicyEvaluationCommand.java
@@ -1,0 +1,11 @@
+package com.init.workflowruntime.application;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.init.workflowruntime.application.WorkflowRuntimeGraph.RuntimeNode;
+import com.init.workflowruntime.domain.WorkflowExecution;
+
+record PolicyEvaluationCommand(
+    Long domainPackVersionId,
+    RuntimeNode node,
+    ObjectNode slotValues,
+    WorkflowExecution execution) {}

--- a/backend/src/main/java/com/init/workflowruntime/application/WorkflowConditionEvaluator.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/WorkflowConditionEvaluator.java
@@ -1,0 +1,227 @@
+package com.init.workflowruntime.application;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.init.shared.application.exception.BadRequestException;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+final class WorkflowConditionEvaluator {
+
+  private WorkflowConditionEvaluator() {}
+
+  static ConditionEvaluation evaluate(JsonNode condition, ConditionContext context) {
+    if (isMissingCondition(condition)) {
+      return new ConditionEvaluation(false, false);
+    }
+    if (!condition.isObject()) {
+      throw invalidCondition("condition must be an object");
+    }
+
+    String type = requiredText(condition, "type");
+    return switch (type) {
+      case "always" -> new ConditionEvaluation(true, false);
+      case "default" -> new ConditionEvaluation(false, true);
+      case "slot_present" ->
+          new ConditionEvaluation(
+              hasSlotValue(context.slotValues(), requiredText(condition, "slotCode")), false);
+      case "slot_missing" ->
+          new ConditionEvaluation(
+              !hasSlotValue(context.slotValues(), requiredText(condition, "slotCode")), false);
+      case "slot_equals" ->
+          new ConditionEvaluation(slotEquals(context.slotValues(), condition), false);
+      case "all" -> new ConditionEvaluation(evaluateAll(condition, context), false);
+      case "any" -> new ConditionEvaluation(evaluateAny(condition, context), false);
+      case "policy_hit" ->
+          new ConditionEvaluation(
+              containsCode(context.policySnapshot(), requiredText(condition, "policyCode")), false);
+      case "risk_level_gte" ->
+          new ConditionEvaluation(
+              maxRiskLevel(context.riskSnapshot())
+                  >= riskLevelValue(requiredText(condition, "riskLevel")),
+              false);
+      default -> throw invalidCondition("unsupported condition type: " + type);
+    };
+  }
+
+  static boolean isDefaultCondition(JsonNode condition) {
+    return condition != null
+        && condition.isObject()
+        && "default".equals(condition.path("type").asText(null));
+  }
+
+  static List<String> blockedSlotCodes(
+      List<WorkflowRuntimeGraph.RuntimeEdge> edges, ObjectNode slotValues) {
+    Set<String> slotCodes = new LinkedHashSet<>();
+    for (WorkflowRuntimeGraph.RuntimeEdge edge : edges) {
+      collectBlockedSlotCodes(edge.condition(), slotValues, slotCodes);
+    }
+    return List.copyOf(slotCodes);
+  }
+
+  static List<String> blockedSlotCodes(JsonNode condition, ObjectNode slotValues) {
+    Set<String> slotCodes = new LinkedHashSet<>();
+    collectBlockedSlotCodes(condition, slotValues, slotCodes);
+    return List.copyOf(slotCodes);
+  }
+
+  private static boolean evaluateAll(JsonNode condition, ConditionContext context) {
+    List<JsonNode> conditions = requiredConditionArray(condition);
+    for (JsonNode child : conditions) {
+      ConditionEvaluation result = evaluate(child, context);
+      if (result.defaultCondition() || !result.matched()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static boolean evaluateAny(JsonNode condition, ConditionContext context) {
+    List<JsonNode> conditions = requiredConditionArray(condition);
+    for (JsonNode child : conditions) {
+      ConditionEvaluation result = evaluate(child, context);
+      if (!result.defaultCondition() && result.matched()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean slotEquals(ObjectNode slotValues, JsonNode condition) {
+    String slotCode = requiredText(condition, "slotCode");
+    if (!hasSlotValue(slotValues, slotCode) || !condition.has("value")) {
+      return false;
+    }
+    return slotValues.get(slotCode).equals(condition.get("value"));
+  }
+
+  private static void collectBlockedSlotCodes(
+      JsonNode condition, ObjectNode slotValues, Set<String> slotCodes) {
+    if (isMissingCondition(condition) || !condition.isObject()) {
+      return;
+    }
+    String type = condition.path("type").asText(null);
+    if ("slot_present".equals(type) || "slot_equals".equals(type)) {
+      String slotCode = condition.path("slotCode").asText(null);
+      if (slotCode != null && !slotCode.isBlank() && !hasSlotValue(slotValues, slotCode)) {
+        slotCodes.add(slotCode);
+      }
+      return;
+    }
+    if ("all".equals(type) || "any".equals(type)) {
+      for (JsonNode child : condition.path("conditions")) {
+        collectBlockedSlotCodes(child, slotValues, slotCodes);
+      }
+    }
+  }
+
+  private static boolean hasSlotValue(ObjectNode slotValues, String slotCode) {
+    if (!slotValues.hasNonNull(slotCode)) {
+      return false;
+    }
+    JsonNode value = slotValues.get(slotCode);
+    if (value.isTextual()) {
+      return !value.asText().isBlank();
+    }
+    if (value.isArray() || value.isObject()) {
+      return !value.isEmpty();
+    }
+    return true;
+  }
+
+  private static boolean containsCode(JsonNode node, String code) {
+    if (node == null || node.isNull() || node.isMissingNode()) {
+      return false;
+    }
+    if (node.isTextual()) {
+      return code.equals(node.asText());
+    }
+    if (node.isArray()) {
+      for (JsonNode child : node) {
+        if (containsCode(child, code)) {
+          return true;
+        }
+      }
+      return false;
+    }
+    if (!node.isObject()) {
+      return false;
+    }
+    if (code.equals(node.path("policyCode").asText(null))
+        || code.equals(node.path("code").asText(null))) {
+      return true;
+    }
+    return containsCode(node.path("hits"), code) || containsCode(node.path("policyHits"), code);
+  }
+
+  private static int maxRiskLevel(JsonNode node) {
+    if (node == null || node.isNull() || node.isMissingNode()) {
+      return 0;
+    }
+    if (node.isTextual()) {
+      return riskLevelValue(node.asText());
+    }
+    if (node.isArray()) {
+      int max = 0;
+      for (JsonNode child : node) {
+        max = Math.max(max, maxRiskLevel(child));
+      }
+      return max;
+    }
+    if (!node.isObject()) {
+      return 0;
+    }
+    int current =
+        Math.max(
+            riskLevelValue(node.path("riskLevel").asText(null)),
+            riskLevelValue(node.path("level").asText(null)));
+    return Math.max(
+        current, Math.max(maxRiskLevel(node.path("hits")), maxRiskLevel(node.path("riskHits"))));
+  }
+
+  private static int riskLevelValue(String riskLevel) {
+    if (riskLevel == null || riskLevel.isBlank()) {
+      return 0;
+    }
+    return switch (riskLevel.trim().toUpperCase(Locale.ROOT)) {
+      case "LOW" -> 1;
+      case "MEDIUM" -> 2;
+      case "HIGH" -> 3;
+      case "CRITICAL" -> 4;
+      default -> throw invalidCondition("unsupported risk level: " + riskLevel);
+    };
+  }
+
+  private static List<JsonNode> requiredConditionArray(JsonNode condition) {
+    JsonNode children = condition.path("conditions");
+    if (!children.isArray() || children.isEmpty()) {
+      throw invalidCondition("conditions must be a non-empty array");
+    }
+    List<JsonNode> result = new ArrayList<>();
+    children.forEach(result::add);
+    return result;
+  }
+
+  private static String requiredText(JsonNode condition, String fieldName) {
+    String value = condition.path(fieldName).asText(null);
+    if (value == null || value.isBlank()) {
+      throw invalidCondition(fieldName + " is required");
+    }
+    return value.trim();
+  }
+
+  private static boolean isMissingCondition(JsonNode condition) {
+    return condition == null || condition.isNull() || condition.isMissingNode();
+  }
+
+  private static BadRequestException invalidCondition(String message) {
+    return new BadRequestException("WORKFLOW_CONDITION_INVALID", message);
+  }
+
+  record ConditionContext(ObjectNode slotValues, JsonNode policySnapshot, JsonNode riskSnapshot) {}
+
+  record ConditionEvaluation(boolean matched, boolean defaultCondition) {}
+}

--- a/backend/src/main/java/com/init/workflowruntime/application/WorkflowPolicyRuntimeService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/WorkflowPolicyRuntimeService.java
@@ -18,8 +18,10 @@ import com.init.workflowruntime.application.dto.LlmToolPolicyResponse;
 import com.init.workflowruntime.domain.WorkflowExecution;
 import java.util.List;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional(readOnly = true)
 public class WorkflowPolicyRuntimeService {
 
   private final PolicyDefinitionRepository policyDefinitionRepository;
@@ -41,14 +43,15 @@ public class WorkflowPolicyRuntimeService {
     if (currentNode == null) {
       return null;
     }
-    return evaluateNodePolicy(domainPackVersionId, currentNode, slotValues, execution);
+    return evaluateNodePolicy(
+        new PolicyEvaluationCommand(domainPackVersionId, currentNode, slotValues, execution));
   }
 
-  LlmToolPolicyResponse evaluateNodePolicy(
-      Long domainPackVersionId,
-      RuntimeNode node,
-      ObjectNode slotValues,
-      WorkflowExecution execution) {
+  LlmToolPolicyResponse evaluateNodePolicy(PolicyEvaluationCommand command) {
+    Long domainPackVersionId = command.domainPackVersionId();
+    RuntimeNode node = command.node();
+    ObjectNode slotValues = command.slotValues();
+    WorkflowExecution execution = command.execution();
     String policyRef = trimToNull(node.policyRef());
     if (policyRef == null) {
       return null;

--- a/backend/src/main/java/com/init/workflowruntime/application/WorkflowPolicyRuntimeService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/WorkflowPolicyRuntimeService.java
@@ -1,0 +1,184 @@
+package com.init.workflowruntime.application;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.init.domainpack.domain.model.PolicyDefinition;
+import com.init.domainpack.domain.model.WorkflowDefinition;
+import com.init.domainpack.domain.repository.PolicyDefinitionRepository;
+import com.init.domainpack.domain.repository.WorkflowDefinitionRepository;
+import com.init.shared.application.exception.BadRequestException;
+import com.init.shared.application.exception.InternalException;
+import com.init.workflowruntime.application.WorkflowConditionEvaluator.ConditionContext;
+import com.init.workflowruntime.application.WorkflowConditionEvaluator.ConditionEvaluation;
+import com.init.workflowruntime.application.WorkflowRuntimeGraph.RuntimeNode;
+import com.init.workflowruntime.application.dto.LlmToolPolicyResponse;
+import com.init.workflowruntime.domain.WorkflowExecution;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+@Service
+public class WorkflowPolicyRuntimeService {
+
+  private final PolicyDefinitionRepository policyDefinitionRepository;
+  private final WorkflowDefinitionRepository workflowDefinitionRepository;
+  private final ObjectMapper objectMapper;
+
+  public WorkflowPolicyRuntimeService(
+      PolicyDefinitionRepository policyDefinitionRepository,
+      WorkflowDefinitionRepository workflowDefinitionRepository,
+      ObjectMapper objectMapper) {
+    this.policyDefinitionRepository = policyDefinitionRepository;
+    this.workflowDefinitionRepository = workflowDefinitionRepository;
+    this.objectMapper = objectMapper;
+  }
+
+  public LlmToolPolicyResponse evaluateCurrentPolicy(
+      Long domainPackVersionId, WorkflowExecution execution, ObjectNode slotValues) {
+    RuntimeNode currentNode = resolveCurrentNode(domainPackVersionId, execution);
+    if (currentNode == null) {
+      return null;
+    }
+    return evaluateNodePolicy(domainPackVersionId, currentNode, slotValues, execution);
+  }
+
+  LlmToolPolicyResponse evaluateNodePolicy(
+      Long domainPackVersionId,
+      RuntimeNode node,
+      ObjectNode slotValues,
+      WorkflowExecution execution) {
+    String policyRef = trimToNull(node.policyRef());
+    if (policyRef == null) {
+      return null;
+    }
+
+    PolicyDefinition policy =
+        policyDefinitionRepository
+            .findByDomainPackVersionIdAndPolicyCode(domainPackVersionId, policyRef)
+            .orElseThrow(
+                () ->
+                    new BadRequestException(
+                        "POLICY_DEFINITION_NOT_FOUND", "PolicyDefinition not found: " + policyRef));
+    JsonNode condition = readJsonNode(policy.getConditionJson(), "{}");
+    JsonNode action = readJsonNode(policy.getActionJson(), "{}");
+    JsonNode evidence = readJsonNode(policy.getEvidenceJson(), "[]");
+    JsonNode meta = readJsonNode(policy.getMetaJson(), "{}");
+    PolicyEvaluation evaluation = evaluatePolicyCondition(condition, slotValues, execution);
+
+    return new LlmToolPolicyResponse(
+        policy.getId(),
+        policy.getPolicyCode(),
+        policy.getName(),
+        policy.getDescription(),
+        policy.getSeverity(),
+        condition,
+        action,
+        evidence,
+        meta,
+        policy.getStatus(),
+        node.id(),
+        evaluation.matched(),
+        evaluation.missingSlotCodes(),
+        evaluation.reason());
+  }
+
+  public JsonNode buildPolicySnapshot(LlmToolPolicyResponse currentPolicy) {
+    ObjectNode snapshot = objectMapper.createObjectNode();
+    if (currentPolicy == null) {
+      snapshot.set("hits", objectMapper.createArrayNode());
+      return snapshot;
+    }
+
+    ObjectNode policyNode = objectMapper.createObjectNode();
+    policyNode.put("policyCode", currentPolicy.policyCode());
+    policyNode.put("name", currentPolicy.name());
+    policyNode.put("severity", currentPolicy.severity());
+    policyNode.put("nodeId", currentPolicy.nodeId());
+    policyNode.put("matched", currentPolicy.matched());
+    policyNode.set("missingSlotCodes", objectMapper.valueToTree(currentPolicy.missingSlotCodes()));
+    policyNode.set("condition", currentPolicy.condition());
+    policyNode.set("action", currentPolicy.action());
+    policyNode.set("evidence", currentPolicy.evidence());
+
+    snapshot.set("currentPolicy", policyNode);
+    ArrayNode hits = objectMapper.createArrayNode();
+    if (currentPolicy.matched()) {
+      ObjectNode hit = objectMapper.createObjectNode();
+      hit.put("policyCode", currentPolicy.policyCode());
+      hit.put("nodeId", currentPolicy.nodeId());
+      hits.add(hit);
+    }
+    snapshot.set("hits", hits);
+    return snapshot;
+  }
+
+  private RuntimeNode resolveCurrentNode(Long domainPackVersionId, WorkflowExecution execution) {
+    if (execution == null
+        || execution.getWorkflowDefinitionId() == null
+        || trimToNull(execution.getCurrentState()) == null) {
+      return null;
+    }
+    WorkflowDefinition workflow =
+        workflowDefinitionRepository
+            .findByIdAndDomainPackVersionId(
+                execution.getWorkflowDefinitionId(), domainPackVersionId)
+            .orElse(null);
+    if (workflow == null) {
+      return null;
+    }
+    WorkflowRuntimeGraph graph =
+        WorkflowRuntimeGraph.parse(objectMapper, workflow.getGraphJson(), workflow.getId());
+    return graph.findNode(execution.getCurrentState());
+  }
+
+  private PolicyEvaluation evaluatePolicyCondition(
+      JsonNode condition, ObjectNode slotValues, WorkflowExecution execution) {
+    if (!hasExecutableCondition(condition)) {
+      return new PolicyEvaluation(true, List.of(), "policy has no condition");
+    }
+    JsonNode policySnapshot = readJsonNode(execution.getPolicySnapshotJson(), "{}");
+    JsonNode riskSnapshot = readJsonNode(execution.getRiskSnapshotJson(), "{}");
+    ConditionEvaluation result =
+        WorkflowConditionEvaluator.evaluate(
+            condition, new ConditionContext(slotValues, policySnapshot, riskSnapshot));
+    List<String> missingSlotCodes =
+        result.matched()
+            ? List.of()
+            : WorkflowConditionEvaluator.blockedSlotCodes(condition, slotValues);
+    return new PolicyEvaluation(
+        result.matched(),
+        missingSlotCodes,
+        result.matched() ? "policy condition matched" : "policy condition not matched");
+  }
+
+  private boolean hasExecutableCondition(JsonNode condition) {
+    return condition != null
+        && condition.isObject()
+        && condition.hasNonNull("type")
+        && !condition.path("type").asText().isBlank();
+  }
+
+  private JsonNode readJsonNode(String json, String defaultJson) {
+    String source = trimToNull(json);
+    if (source == null) {
+      source = defaultJson;
+    }
+    try {
+      return objectMapper.readTree(source);
+    } catch (JsonProcessingException e) {
+      throw new InternalException("JSON_PARSE_FAILED", "Stored JSON value cannot be parsed", e);
+    }
+  }
+
+  private String trimToNull(String value) {
+    if (value == null) {
+      return null;
+    }
+    String trimmed = value.trim();
+    return trimmed.isEmpty() ? null : trimmed;
+  }
+
+  private record PolicyEvaluation(boolean matched, List<String> missingSlotCodes, String reason) {}
+}

--- a/backend/src/main/java/com/init/workflowruntime/application/WorkflowRuntimeGraph.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/WorkflowRuntimeGraph.java
@@ -1,0 +1,97 @@
+package com.init.workflowruntime.application;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.NullNode;
+import com.init.shared.application.exception.InternalException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+final class WorkflowRuntimeGraph {
+
+  private final Map<String, RuntimeNode> nodesById;
+  private final Map<String, List<RuntimeEdge>> outgoingEdgesByNodeId;
+
+  private WorkflowRuntimeGraph(
+      Map<String, RuntimeNode> nodesById, Map<String, List<RuntimeEdge>> outgoingEdgesByNodeId) {
+    this.nodesById = nodesById;
+    this.outgoingEdgesByNodeId = outgoingEdgesByNodeId;
+  }
+
+  static WorkflowRuntimeGraph parse(ObjectMapper objectMapper, String graphJson, Long workflowId) {
+    try {
+      JsonNode root = objectMapper.readTree(graphJson);
+      Map<String, RuntimeNode> nodesById = parseNodes(root, workflowId);
+      Map<String, List<RuntimeEdge>> outgoingEdgesByNodeId = parseEdges(root, workflowId);
+      return new WorkflowRuntimeGraph(nodesById, outgoingEdgesByNodeId);
+    } catch (JsonProcessingException e) {
+      throw new InternalException(
+          "WORKFLOW_GRAPH_PARSE_FAILED", "Workflow graphJson cannot be parsed: " + workflowId, e);
+    }
+  }
+
+  RuntimeNode requireNode(String nodeId) {
+    RuntimeNode node = nodesById.get(trimToNull(nodeId));
+    if (node == null) {
+      throw new InternalException(
+          "WORKFLOW_STATE_NOT_FOUND", "Workflow state not found: " + nodeId);
+    }
+    return node;
+  }
+
+  RuntimeNode findNode(String nodeId) {
+    return nodesById.get(trimToNull(nodeId));
+  }
+
+  List<RuntimeEdge> outgoingEdges(String nodeId) {
+    return outgoingEdgesByNodeId.getOrDefault(nodeId, List.of());
+  }
+
+  private static Map<String, RuntimeNode> parseNodes(JsonNode root, Long workflowId) {
+    Map<String, RuntimeNode> nodesById = new LinkedHashMap<>();
+    for (JsonNode node : root.path("nodes")) {
+      String id = trimToNull(node.path("id").asText(null));
+      String type = trimToNull(node.path("type").asText(null));
+      if (id == null || type == null) {
+        throw new InternalException(
+            "WORKFLOW_GRAPH_INVALID", "Workflow graph node is invalid: " + workflowId);
+      }
+      String policyRef = trimToNull(node.path("policyRef").asText(null));
+      nodesById.put(id, new RuntimeNode(id, type, policyRef));
+    }
+    return nodesById;
+  }
+
+  private static Map<String, List<RuntimeEdge>> parseEdges(JsonNode root, Long workflowId) {
+    Map<String, List<RuntimeEdge>> outgoingEdgesByNodeId = new LinkedHashMap<>();
+    for (JsonNode edge : root.path("edges")) {
+      String id = trimToNull(edge.path("id").asText(null));
+      String from = trimToNull(edge.path("from").asText(null));
+      String to = trimToNull(edge.path("to").asText(null));
+      if (id == null || from == null || to == null) {
+        throw new InternalException(
+            "WORKFLOW_GRAPH_INVALID", "Workflow graph edge is invalid: " + workflowId);
+      }
+      JsonNode condition = edge.has("condition") ? edge.path("condition") : NullNode.getInstance();
+      outgoingEdgesByNodeId
+          .computeIfAbsent(from, ignored -> new ArrayList<>())
+          .add(new RuntimeEdge(id, from, to, condition));
+    }
+    return outgoingEdgesByNodeId;
+  }
+
+  private static String trimToNull(String value) {
+    if (value == null) {
+      return null;
+    }
+    String trimmed = value.trim();
+    return trimmed.isEmpty() ? null : trimmed;
+  }
+
+  record RuntimeNode(String id, String type, String policyRef) {}
+
+  record RuntimeEdge(String id, String from, String to, JsonNode condition) {}
+}

--- a/backend/src/main/java/com/init/workflowruntime/application/WorkflowRuntimeGraph.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/WorkflowRuntimeGraph.java
@@ -27,7 +27,7 @@ final class WorkflowRuntimeGraph {
       Map<String, RuntimeNode> nodesById = parseNodes(root, workflowId);
       Map<String, List<RuntimeEdge>> outgoingEdgesByNodeId = parseEdges(root, workflowId);
       return new WorkflowRuntimeGraph(nodesById, outgoingEdgesByNodeId);
-    } catch (JsonProcessingException e) {
+    } catch (JsonProcessingException | IllegalArgumentException e) {
       throw new InternalException(
           "WORKFLOW_GRAPH_PARSE_FAILED", "Workflow graphJson cannot be parsed: " + workflowId, e);
     }

--- a/backend/src/main/java/com/init/workflowruntime/application/WorkflowRuntimeService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/WorkflowRuntimeService.java
@@ -255,7 +255,8 @@ public class WorkflowRuntimeService {
       RuntimeNode currentNode,
       ObjectNode slotValues) {
     return workflowPolicyRuntimeService.evaluateNodePolicy(
-        session.getDomainPackVersionId(), currentNode, slotValues, execution);
+        new PolicyEvaluationCommand(
+            session.getDomainPackVersionId(), currentNode, slotValues, execution));
   }
 
   private LlmToolPolicyResponse transitionPolicyFor(
@@ -268,11 +269,22 @@ public class WorkflowRuntimeService {
   }
 
   private String policyHitCode(JsonNode condition) {
-    if (condition == null || !"policy_hit".equals(condition.path("type").asText())) {
+    if (condition == null || !condition.isObject()) {
       return null;
     }
-    String policyCode = condition.path("policyCode").asText(null);
-    return trimToNull(policyCode);
+    String type = condition.path("type").asText(null);
+    if ("policy_hit".equals(type)) {
+      return trimToNull(condition.path("policyCode").asText(null));
+    }
+    if ("all".equals(type) || "any".equals(type)) {
+      for (JsonNode child : condition.path("conditions")) {
+        String policyCode = policyHitCode(child);
+        if (policyCode != null) {
+          return policyCode;
+        }
+      }
+    }
+    return null;
   }
 
   private WorkflowAdvanceResponse response(AdvanceContext context, ResponseDraft draft) {

--- a/backend/src/main/java/com/init/workflowruntime/application/WorkflowRuntimeService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/WorkflowRuntimeService.java
@@ -31,6 +31,14 @@ public class WorkflowRuntimeService {
   private static final String NODE_TYPE_ANSWER = "ANSWER";
   private static final String NODE_TYPE_HANDOFF = "HANDOFF";
   private static final String NODE_TYPE_TERMINAL = "TERMINAL";
+  private static final String ACTION_ADVANCE = "ADVANCE";
+  private static final String ACTION_ASK_SLOT = "ASK_SLOT";
+  private static final String ACTION_ANSWER = "ANSWER";
+  private static final String ACTION_COMPLETED = "COMPLETED";
+  private static final String ACTION_HANDOFF = "HANDOFF";
+  private static final String ACTION_WAIT = "WAIT";
+  private static final String ACTION_WAIT_CONDITION = "WAIT_CONDITION";
+  private static final JsonNode NO_CONDITION = NullNode.getInstance();
 
   private final ChatSessionRepository chatSessionRepository;
   private final WorkflowExecutionRepository workflowExecutionRepository;
@@ -53,92 +61,28 @@ public class WorkflowRuntimeService {
 
   @Transactional
   public WorkflowAdvanceResponse advance(Long sessionId) {
-    ChatSession session = findSession(sessionId);
-    WorkflowExecution execution = findExecution(sessionId);
-    WorkflowDefinition workflow = findWorkflow(session, execution);
-    WorkflowRuntimeGraph graph =
-        WorkflowRuntimeGraph.parse(objectMapper, workflow.getGraphJson(), workflow.getId());
+    AdvanceContext context = loadAdvanceContext(sessionId);
 
-    String previousState = requireCurrentState(execution);
-    RuntimeNode currentNode = graph.requireNode(previousState);
-    ObjectNode slotValues = readObjectNode(execution.getSlotValuesJson());
-    LlmToolPolicyResponse sourcePolicy =
-        evaluateNodePolicy(session, execution, currentNode, slotValues);
-    JsonNode policySnapshot = workflowPolicyRuntimeService.buildPolicySnapshot(sourcePolicy);
-    JsonNode riskSnapshot = readJsonNode(execution.getRiskSnapshotJson(), "{}");
-
-    if (NODE_TYPE_TERMINAL.equals(currentNode.type())) {
-      execution.complete();
-      WorkflowExecution saved = workflowExecutionRepository.save(execution);
-      return response(
-          session,
-          saved,
-          previousState,
-          currentNode,
-          "COMPLETED",
-          null,
-          previousState,
-          List.of(),
-          NullNode.getInstance(),
-          readObjectNode(saved.getSlotValuesJson()),
-          null,
-          false,
-          "terminal state reached");
+    if (NODE_TYPE_TERMINAL.equals(context.currentNode().type())) {
+      context.execution().complete();
+      return completedResponse(context);
     }
-    if (NODE_TYPE_HANDOFF.equals(currentNode.type())) {
-      return response(
-          session,
-          execution,
-          previousState,
-          currentNode,
-          "HANDOFF",
-          null,
-          previousState,
-          List.of(),
-          NullNode.getInstance(),
-          slotValues,
-          null,
-          false,
-          "current state requires counselor handoff");
+    if (NODE_TYPE_HANDOFF.equals(context.currentNode().type())) {
+      return handoffResponse(context);
     }
-    if (NODE_TYPE_ANSWER.equals(currentNode.type())) {
-      return response(
-          session,
-          execution,
-          previousState,
-          currentNode,
-          "ANSWER",
-          null,
-          previousState,
-          List.of(),
-          NullNode.getInstance(),
-          slotValues,
-          null,
-          false,
-          "current state is answer node");
+    if (NODE_TYPE_ANSWER.equals(context.currentNode().type())) {
+      return answerResponse(context);
     }
 
-    List<RuntimeEdge> outgoingEdges = graph.outgoingEdges(previousState);
+    List<RuntimeEdge> outgoingEdges = context.graph().outgoingEdges(context.previousState());
     if (outgoingEdges.isEmpty()) {
-      return response(
-          session,
-          execution,
-          previousState,
-          currentNode,
-          "WAIT",
-          null,
-          previousState,
-          List.of(),
-          NullNode.getInstance(),
-          slotValues,
-          null,
-          false,
-          "current state has no outgoing edge");
+      return waitResponse(context);
     }
 
     RuntimeEdge defaultEdge = null;
     ConditionContext conditionContext =
-        new ConditionContext(slotValues, policySnapshot, riskSnapshot);
+        new ConditionContext(
+            context.slotValues(), context.policySnapshot(), context.riskSnapshot());
     for (RuntimeEdge edge : outgoingEdges) {
       if (WorkflowConditionEvaluator.isDefaultCondition(edge.condition())) {
         if (defaultEdge == null) {
@@ -149,87 +93,120 @@ public class WorkflowRuntimeService {
       ConditionEvaluation result =
           WorkflowConditionEvaluator.evaluate(edge.condition(), conditionContext);
       if (result.matched()) {
-        return advanceToEdge(
-            session, execution, graph, previousState, currentNode, edge, sourcePolicy);
+        return advanceToEdge(context, edge);
       }
     }
 
     if (defaultEdge != null) {
-      return advanceToEdge(
-          session, execution, graph, previousState, currentNode, defaultEdge, sourcePolicy);
+      return advanceToEdge(context, defaultEdge);
     }
 
     List<String> missingSlotCodes =
-        WorkflowConditionEvaluator.blockedSlotCodes(outgoingEdges, slotValues);
+        WorkflowConditionEvaluator.blockedSlotCodes(outgoingEdges, context.slotValues());
     if (!missingSlotCodes.isEmpty()) {
-      return response(
-          session,
-          execution,
-          previousState,
-          currentNode,
-          "ASK_SLOT",
-          null,
-          previousState,
-          missingSlotCodes,
-          NullNode.getInstance(),
-          slotValues,
-          null,
-          false,
-          "required slot values are missing");
+      return askSlotResponse(context, missingSlotCodes);
     }
 
-    return response(
-        session,
-        execution,
-        previousState,
-        currentNode,
-        "WAIT_CONDITION",
-        null,
-        previousState,
-        List.of(),
-        NullNode.getInstance(),
-        slotValues,
-        null,
-        false,
-        "no edge condition matched");
+    return waitConditionResponse(context);
   }
 
-  private WorkflowAdvanceResponse advanceToEdge(
-      ChatSession session,
-      WorkflowExecution execution,
-      WorkflowRuntimeGraph graph,
-      String previousState,
-      RuntimeNode previousNode,
-      RuntimeEdge edge,
-      LlmToolPolicyResponse sourcePolicy) {
-    RuntimeNode targetNode = graph.requireNode(edge.to());
-    execution.moveToState(targetNode.id());
-    if (NODE_TYPE_TERMINAL.equals(targetNode.type())) {
-      execution.complete();
-    }
-    LlmToolPolicyResponse transitionPolicy = transitionPolicyFor(edge, sourcePolicy);
-    return response(
+  private AdvanceContext loadAdvanceContext(Long sessionId) {
+    ChatSession session = findSession(sessionId);
+    WorkflowExecution execution = findExecution(sessionId);
+    WorkflowDefinition workflow = findWorkflow(session, execution);
+    WorkflowRuntimeGraph graph =
+        WorkflowRuntimeGraph.parse(objectMapper, workflow.getGraphJson(), workflow.getId());
+
+    String previousState = requireCurrentState(execution);
+    RuntimeNode currentNode = graph.requireNode(previousState);
+    ObjectNode slotValues = readObjectNode(execution.getSlotValuesJson());
+    LlmToolPolicyResponse currentPolicy =
+        evaluateNodePolicy(session, execution, currentNode, slotValues);
+    JsonNode policySnapshot = workflowPolicyRuntimeService.buildPolicySnapshot(currentPolicy);
+    JsonNode riskSnapshot = readJsonNode(execution.getRiskSnapshotJson(), "{}");
+    return AdvanceContext.of(
         session,
         execution,
+        graph,
         previousState,
-        targetNode,
-        actionTypeFor(targetNode),
-        edge.id(),
-        targetNode.id(),
-        List.of(),
-        edge.condition(),
-        readObjectNode(execution.getSlotValuesJson()),
-        transitionPolicy,
-        true,
-        "transitioned from " + previousNode.id() + " to " + targetNode.id());
+        currentNode,
+        slotValues,
+        currentPolicy,
+        policySnapshot,
+        riskSnapshot);
+  }
+
+  private WorkflowAdvanceResponse completedResponse(AdvanceContext context) {
+    return currentNodeResponse(
+        context, ACTION_COMPLETED, List.of(), true, "terminal state reached");
+  }
+
+  private WorkflowAdvanceResponse handoffResponse(AdvanceContext context) {
+    return currentNodeResponse(
+        context, ACTION_HANDOFF, List.of(), false, "current state requires counselor handoff");
+  }
+
+  private WorkflowAdvanceResponse answerResponse(AdvanceContext context) {
+    return currentNodeResponse(
+        context, ACTION_ANSWER, List.of(), false, "current state is answer node");
+  }
+
+  private WorkflowAdvanceResponse waitResponse(AdvanceContext context) {
+    return currentNodeResponse(
+        context, ACTION_WAIT, List.of(), false, "current state has no outgoing edge");
+  }
+
+  private WorkflowAdvanceResponse askSlotResponse(
+      AdvanceContext context, List<String> missingSlotCodes) {
+    return currentNodeResponse(
+        context, ACTION_ASK_SLOT, missingSlotCodes, false, "required slot values are missing");
+  }
+
+  private WorkflowAdvanceResponse waitConditionResponse(AdvanceContext context) {
+    return currentNodeResponse(
+        context, ACTION_WAIT_CONDITION, List.of(), false, "no edge condition matched");
+  }
+
+  private WorkflowAdvanceResponse currentNodeResponse(
+      AdvanceContext context,
+      String actionType,
+      List<String> missingSlotCodes,
+      boolean persistExecution,
+      String reason) {
+    return response(
+        context,
+        ResponseDraft.currentNode(context, actionType, missingSlotCodes, persistExecution, reason));
+  }
+
+  private WorkflowAdvanceResponse advanceToEdge(AdvanceContext context, RuntimeEdge edge) {
+    RuntimeNode targetNode = context.graph().requireNode(edge.to());
+    context.execution().moveToState(targetNode.id());
+    if (NODE_TYPE_TERMINAL.equals(targetNode.type())) {
+      context.execution().complete();
+    }
+    ObjectNode slotValues = readObjectNode(context.execution().getSlotValuesJson());
+    LlmToolPolicyResponse targetPolicy =
+        evaluateNodePolicy(context.session(), context.execution(), targetNode, slotValues);
+    JsonNode targetPolicySnapshot = workflowPolicyRuntimeService.buildPolicySnapshot(targetPolicy);
+    LlmToolPolicyResponse transitionPolicy = transitionPolicyFor(edge, context.currentPolicy());
+    return response(
+        context,
+        ResponseDraft.transition(
+            targetNode,
+            actionTypeFor(targetNode),
+            edge,
+            targetPolicySnapshot,
+            transitionPolicy,
+            targetPolicy,
+            "transitioned from " + context.currentNode().id() + " to " + targetNode.id()));
   }
 
   private String actionTypeFor(RuntimeNode targetNode) {
     return switch (targetNode.type()) {
-      case NODE_TYPE_ANSWER -> "ANSWER";
-      case NODE_TYPE_HANDOFF -> "HANDOFF";
-      case NODE_TYPE_TERMINAL -> "COMPLETED";
-      default -> "ADVANCE";
+      case NODE_TYPE_ANSWER -> ACTION_ANSWER;
+      case NODE_TYPE_HANDOFF -> ACTION_HANDOFF;
+      case NODE_TYPE_TERMINAL -> ACTION_COMPLETED;
+      default -> ACTION_ADVANCE;
     };
   }
 
@@ -298,49 +275,123 @@ public class WorkflowRuntimeService {
     return trimToNull(policyCode);
   }
 
-  private WorkflowAdvanceResponse response(
-      ChatSession session,
-      WorkflowExecution execution,
-      String previousState,
-      RuntimeNode currentNode,
-      String actionType,
-      String edgeId,
-      String targetState,
-      List<String> missingSlotCodes,
-      JsonNode condition,
-      ObjectNode slotValues,
-      LlmToolPolicyResponse transitionPolicy,
-      boolean persistExecution,
-      String reason) {
-    LlmToolPolicyResponse currentPolicy =
-        workflowPolicyRuntimeService.evaluateNodePolicy(
-            session.getDomainPackVersionId(), currentNode, slotValues, execution);
-    JsonNode policySnapshot = workflowPolicyRuntimeService.buildPolicySnapshot(currentPolicy);
-    String policySnapshotJson = writeJson(policySnapshot);
+  private WorkflowAdvanceResponse response(AdvanceContext context, ResponseDraft draft) {
+    WorkflowExecution execution = context.execution();
+    String policySnapshotJson = writeJson(draft.policySnapshot());
     boolean policySnapshotChanged = !policySnapshotJson.equals(execution.getPolicySnapshotJson());
     if (policySnapshotChanged) {
       execution.replacePolicySnapshotJson(policySnapshotJson);
     }
     WorkflowExecution responseExecution =
-        persistExecution || policySnapshotChanged
+        draft.persistExecution() || policySnapshotChanged
             ? workflowExecutionRepository.save(execution)
             : execution;
     return new WorkflowAdvanceResponse(
-        session.getId(),
+        context.session().getId(),
         responseExecution.getId(),
         responseExecution.getStatus(),
-        previousState,
+        context.previousState(),
         responseExecution.getCurrentState(),
-        currentNode.type(),
-        actionType,
-        edgeId,
-        targetState,
-        missingSlotCodes,
-        condition,
-        policySnapshot,
-        transitionPolicy,
-        currentPolicy,
-        reason);
+        draft.node().type(),
+        draft.actionType(),
+        draft.edgeId(),
+        draft.targetState(),
+        draft.missingSlotCodes(),
+        draft.condition(),
+        draft.policySnapshot(),
+        draft.transitionPolicy(),
+        draft.currentPolicy(),
+        draft.reason());
+  }
+
+  private record AdvanceContext(
+      ChatSession session,
+      WorkflowExecution execution,
+      WorkflowRuntimeGraph graph,
+      String previousState,
+      RuntimeNode currentNode,
+      ObjectNode slotValues,
+      LlmToolPolicyResponse currentPolicy,
+      JsonNode policySnapshot,
+      JsonNode riskSnapshot) {
+
+    private static AdvanceContext of(
+        ChatSession session,
+        WorkflowExecution execution,
+        WorkflowRuntimeGraph graph,
+        String previousState,
+        RuntimeNode currentNode,
+        ObjectNode slotValues,
+        LlmToolPolicyResponse currentPolicy,
+        JsonNode policySnapshot,
+        JsonNode riskSnapshot) {
+      return new AdvanceContext(
+          session,
+          execution,
+          graph,
+          previousState,
+          currentNode,
+          slotValues,
+          currentPolicy,
+          policySnapshot,
+          riskSnapshot);
+    }
+  }
+
+  private record ResponseDraft(
+      RuntimeNode node,
+      String actionType,
+      String edgeId,
+      String targetState,
+      List<String> missingSlotCodes,
+      JsonNode condition,
+      JsonNode policySnapshot,
+      LlmToolPolicyResponse transitionPolicy,
+      LlmToolPolicyResponse currentPolicy,
+      boolean persistExecution,
+      String reason) {
+
+    private static ResponseDraft currentNode(
+        AdvanceContext context,
+        String actionType,
+        List<String> missingSlotCodes,
+        boolean persistExecution,
+        String reason) {
+      return new ResponseDraft(
+          context.currentNode(),
+          actionType,
+          null,
+          context.previousState(),
+          missingSlotCodes,
+          NO_CONDITION,
+          context.policySnapshot(),
+          null,
+          context.currentPolicy(),
+          persistExecution,
+          reason);
+    }
+
+    private static ResponseDraft transition(
+        RuntimeNode targetNode,
+        String actionType,
+        RuntimeEdge edge,
+        JsonNode policySnapshot,
+        LlmToolPolicyResponse transitionPolicy,
+        LlmToolPolicyResponse currentPolicy,
+        String reason) {
+      return new ResponseDraft(
+          targetNode,
+          actionType,
+          edge.id(),
+          targetNode.id(),
+          List.of(),
+          edge.condition(),
+          policySnapshot,
+          transitionPolicy,
+          currentPolicy,
+          true,
+          reason);
+    }
   }
 
   private ObjectNode readObjectNode(String json) {

--- a/backend/src/main/java/com/init/workflowruntime/application/WorkflowRuntimeService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/WorkflowRuntimeService.java
@@ -188,7 +188,7 @@ public class WorkflowRuntimeService {
     LlmToolPolicyResponse targetPolicy =
         evaluateNodePolicy(context.session(), context.execution(), targetNode, slotValues);
     JsonNode targetPolicySnapshot = workflowPolicyRuntimeService.buildPolicySnapshot(targetPolicy);
-    LlmToolPolicyResponse transitionPolicy = transitionPolicyFor(edge, context.currentPolicy());
+    LlmToolPolicyResponse transitionPolicy = transitionPolicyFor(context, edge);
     return response(
         context,
         ResponseDraft.transition(
@@ -259,28 +259,44 @@ public class WorkflowRuntimeService {
             session.getDomainPackVersionId(), currentNode, slotValues, execution));
   }
 
-  private LlmToolPolicyResponse transitionPolicyFor(
-      RuntimeEdge edge, LlmToolPolicyResponse sourcePolicy) {
-    String policyCode = policyHitCode(edge.condition());
+  private LlmToolPolicyResponse transitionPolicyFor(AdvanceContext context, RuntimeEdge edge) {
+    LlmToolPolicyResponse sourcePolicy = context.currentPolicy();
+    ConditionContext conditionContext =
+        new ConditionContext(
+            context.slotValues(), context.policySnapshot(), context.riskSnapshot());
+    String policyCode = matchedPolicyHitCode(edge.condition(), conditionContext);
     if (policyCode == null || sourcePolicy == null || !sourcePolicy.matched()) {
       return null;
     }
     return policyCode.equals(sourcePolicy.policyCode()) ? sourcePolicy : null;
   }
 
-  private String policyHitCode(JsonNode condition) {
+  private String matchedPolicyHitCode(JsonNode condition, ConditionContext context) {
     if (condition == null || !condition.isObject()) {
       return null;
     }
     String type = condition.path("type").asText(null);
     if ("policy_hit".equals(type)) {
-      return trimToNull(condition.path("policyCode").asText(null));
+      ConditionEvaluation result = WorkflowConditionEvaluator.evaluate(condition, context);
+      return result.matched() ? trimToNull(condition.path("policyCode").asText(null)) : null;
     }
-    if ("all".equals(type) || "any".equals(type)) {
+    if ("all".equals(type)) {
       for (JsonNode child : condition.path("conditions")) {
-        String policyCode = policyHitCode(child);
+        ConditionEvaluation result = WorkflowConditionEvaluator.evaluate(child, context);
+        if (result.defaultCondition() || !result.matched()) {
+          return null;
+        }
+        String policyCode = matchedPolicyHitCode(child, context);
         if (policyCode != null) {
           return policyCode;
+        }
+      }
+    }
+    if ("any".equals(type)) {
+      for (JsonNode child : condition.path("conditions")) {
+        ConditionEvaluation result = WorkflowConditionEvaluator.evaluate(child, context);
+        if (!result.defaultCondition() && result.matched()) {
+          return matchedPolicyHitCode(child, context);
         }
       }
     }

--- a/backend/src/main/java/com/init/workflowruntime/application/WorkflowRuntimeService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/WorkflowRuntimeService.java
@@ -1,0 +1,381 @@
+package com.init.workflowruntime.application;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.NullNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.init.domainpack.domain.model.WorkflowDefinition;
+import com.init.domainpack.domain.repository.WorkflowDefinitionRepository;
+import com.init.shared.application.exception.BadRequestException;
+import com.init.shared.application.exception.InternalException;
+import com.init.shared.application.exception.NotFoundException;
+import com.init.workflowruntime.application.WorkflowConditionEvaluator.ConditionContext;
+import com.init.workflowruntime.application.WorkflowConditionEvaluator.ConditionEvaluation;
+import com.init.workflowruntime.application.WorkflowRuntimeGraph.RuntimeEdge;
+import com.init.workflowruntime.application.WorkflowRuntimeGraph.RuntimeNode;
+import com.init.workflowruntime.application.dto.LlmToolPolicyResponse;
+import com.init.workflowruntime.application.dto.WorkflowAdvanceResponse;
+import com.init.workflowruntime.domain.ChatSession;
+import com.init.workflowruntime.domain.ChatSessionRepository;
+import com.init.workflowruntime.domain.WorkflowExecution;
+import com.init.workflowruntime.domain.WorkflowExecutionRepository;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class WorkflowRuntimeService {
+
+  private static final String NODE_TYPE_ANSWER = "ANSWER";
+  private static final String NODE_TYPE_HANDOFF = "HANDOFF";
+  private static final String NODE_TYPE_TERMINAL = "TERMINAL";
+
+  private final ChatSessionRepository chatSessionRepository;
+  private final WorkflowExecutionRepository workflowExecutionRepository;
+  private final WorkflowDefinitionRepository workflowDefinitionRepository;
+  private final WorkflowPolicyRuntimeService workflowPolicyRuntimeService;
+  private final ObjectMapper objectMapper;
+
+  public WorkflowRuntimeService(
+      ChatSessionRepository chatSessionRepository,
+      WorkflowExecutionRepository workflowExecutionRepository,
+      WorkflowDefinitionRepository workflowDefinitionRepository,
+      WorkflowPolicyRuntimeService workflowPolicyRuntimeService,
+      ObjectMapper objectMapper) {
+    this.chatSessionRepository = chatSessionRepository;
+    this.workflowExecutionRepository = workflowExecutionRepository;
+    this.workflowDefinitionRepository = workflowDefinitionRepository;
+    this.workflowPolicyRuntimeService = workflowPolicyRuntimeService;
+    this.objectMapper = objectMapper;
+  }
+
+  @Transactional
+  public WorkflowAdvanceResponse advance(Long sessionId) {
+    ChatSession session = findSession(sessionId);
+    WorkflowExecution execution = findExecution(sessionId);
+    WorkflowDefinition workflow = findWorkflow(session, execution);
+    WorkflowRuntimeGraph graph =
+        WorkflowRuntimeGraph.parse(objectMapper, workflow.getGraphJson(), workflow.getId());
+
+    String previousState = requireCurrentState(execution);
+    RuntimeNode currentNode = graph.requireNode(previousState);
+    ObjectNode slotValues = readObjectNode(execution.getSlotValuesJson());
+    LlmToolPolicyResponse sourcePolicy =
+        evaluateNodePolicy(session, execution, currentNode, slotValues);
+    JsonNode policySnapshot = workflowPolicyRuntimeService.buildPolicySnapshot(sourcePolicy);
+    JsonNode riskSnapshot = readJsonNode(execution.getRiskSnapshotJson(), "{}");
+
+    if (NODE_TYPE_TERMINAL.equals(currentNode.type())) {
+      execution.complete();
+      WorkflowExecution saved = workflowExecutionRepository.save(execution);
+      return response(
+          session,
+          saved,
+          previousState,
+          currentNode,
+          "COMPLETED",
+          null,
+          previousState,
+          List.of(),
+          NullNode.getInstance(),
+          readObjectNode(saved.getSlotValuesJson()),
+          null,
+          false,
+          "terminal state reached");
+    }
+    if (NODE_TYPE_HANDOFF.equals(currentNode.type())) {
+      return response(
+          session,
+          execution,
+          previousState,
+          currentNode,
+          "HANDOFF",
+          null,
+          previousState,
+          List.of(),
+          NullNode.getInstance(),
+          slotValues,
+          null,
+          false,
+          "current state requires counselor handoff");
+    }
+    if (NODE_TYPE_ANSWER.equals(currentNode.type())) {
+      return response(
+          session,
+          execution,
+          previousState,
+          currentNode,
+          "ANSWER",
+          null,
+          previousState,
+          List.of(),
+          NullNode.getInstance(),
+          slotValues,
+          null,
+          false,
+          "current state is answer node");
+    }
+
+    List<RuntimeEdge> outgoingEdges = graph.outgoingEdges(previousState);
+    if (outgoingEdges.isEmpty()) {
+      return response(
+          session,
+          execution,
+          previousState,
+          currentNode,
+          "WAIT",
+          null,
+          previousState,
+          List.of(),
+          NullNode.getInstance(),
+          slotValues,
+          null,
+          false,
+          "current state has no outgoing edge");
+    }
+
+    RuntimeEdge defaultEdge = null;
+    ConditionContext conditionContext =
+        new ConditionContext(slotValues, policySnapshot, riskSnapshot);
+    for (RuntimeEdge edge : outgoingEdges) {
+      if (WorkflowConditionEvaluator.isDefaultCondition(edge.condition())) {
+        if (defaultEdge == null) {
+          defaultEdge = edge;
+        }
+        continue;
+      }
+      ConditionEvaluation result =
+          WorkflowConditionEvaluator.evaluate(edge.condition(), conditionContext);
+      if (result.matched()) {
+        return advanceToEdge(
+            session, execution, graph, previousState, currentNode, edge, sourcePolicy);
+      }
+    }
+
+    if (defaultEdge != null) {
+      return advanceToEdge(
+          session, execution, graph, previousState, currentNode, defaultEdge, sourcePolicy);
+    }
+
+    List<String> missingSlotCodes =
+        WorkflowConditionEvaluator.blockedSlotCodes(outgoingEdges, slotValues);
+    if (!missingSlotCodes.isEmpty()) {
+      return response(
+          session,
+          execution,
+          previousState,
+          currentNode,
+          "ASK_SLOT",
+          null,
+          previousState,
+          missingSlotCodes,
+          NullNode.getInstance(),
+          slotValues,
+          null,
+          false,
+          "required slot values are missing");
+    }
+
+    return response(
+        session,
+        execution,
+        previousState,
+        currentNode,
+        "WAIT_CONDITION",
+        null,
+        previousState,
+        List.of(),
+        NullNode.getInstance(),
+        slotValues,
+        null,
+        false,
+        "no edge condition matched");
+  }
+
+  private WorkflowAdvanceResponse advanceToEdge(
+      ChatSession session,
+      WorkflowExecution execution,
+      WorkflowRuntimeGraph graph,
+      String previousState,
+      RuntimeNode previousNode,
+      RuntimeEdge edge,
+      LlmToolPolicyResponse sourcePolicy) {
+    RuntimeNode targetNode = graph.requireNode(edge.to());
+    execution.moveToState(targetNode.id());
+    if (NODE_TYPE_TERMINAL.equals(targetNode.type())) {
+      execution.complete();
+    }
+    LlmToolPolicyResponse transitionPolicy = transitionPolicyFor(edge, sourcePolicy);
+    return response(
+        session,
+        execution,
+        previousState,
+        targetNode,
+        actionTypeFor(targetNode),
+        edge.id(),
+        targetNode.id(),
+        List.of(),
+        edge.condition(),
+        readObjectNode(execution.getSlotValuesJson()),
+        transitionPolicy,
+        true,
+        "transitioned from " + previousNode.id() + " to " + targetNode.id());
+  }
+
+  private String actionTypeFor(RuntimeNode targetNode) {
+    return switch (targetNode.type()) {
+      case NODE_TYPE_ANSWER -> "ANSWER";
+      case NODE_TYPE_HANDOFF -> "HANDOFF";
+      case NODE_TYPE_TERMINAL -> "COMPLETED";
+      default -> "ADVANCE";
+    };
+  }
+
+  private ChatSession findSession(Long sessionId) {
+    return chatSessionRepository
+        .findById(sessionId)
+        .orElseThrow(
+            () -> new NotFoundException("SESSION_NOT_FOUND", "Session not found: " + sessionId));
+  }
+
+  private WorkflowExecution findExecution(Long sessionId) {
+    return workflowExecutionRepository
+        .findTopByChatSessionIdOrderByStartedAtDescIdDesc(sessionId)
+        .orElseThrow(
+            () ->
+                new BadRequestException(
+                    "WORKFLOW_EXECUTION_NOT_FOUND",
+                    "Workflow execution not found for session: " + sessionId));
+  }
+
+  private WorkflowDefinition findWorkflow(ChatSession session, WorkflowExecution execution) {
+    if (execution.getWorkflowDefinitionId() == null) {
+      throw new BadRequestException("WORKFLOW_NOT_SELECTED", "Workflow is not selected");
+    }
+    return workflowDefinitionRepository
+        .findByIdAndDomainPackVersionId(
+            execution.getWorkflowDefinitionId(), session.getDomainPackVersionId())
+        .orElseThrow(
+            () ->
+                new NotFoundException(
+                    "WORKFLOW_DEFINITION_NOT_FOUND",
+                    "WorkflowDefinition not found: " + execution.getWorkflowDefinitionId()));
+  }
+
+  private String requireCurrentState(WorkflowExecution execution) {
+    String currentState = trimToNull(execution.getCurrentState());
+    if (currentState == null) {
+      throw new BadRequestException("WORKFLOW_STATE_MISSING", "Workflow currentState is missing");
+    }
+    return currentState;
+  }
+
+  private LlmToolPolicyResponse evaluateNodePolicy(
+      ChatSession session,
+      WorkflowExecution execution,
+      RuntimeNode currentNode,
+      ObjectNode slotValues) {
+    return workflowPolicyRuntimeService.evaluateNodePolicy(
+        session.getDomainPackVersionId(), currentNode, slotValues, execution);
+  }
+
+  private LlmToolPolicyResponse transitionPolicyFor(
+      RuntimeEdge edge, LlmToolPolicyResponse sourcePolicy) {
+    String policyCode = policyHitCode(edge.condition());
+    if (policyCode == null || sourcePolicy == null || !sourcePolicy.matched()) {
+      return null;
+    }
+    return policyCode.equals(sourcePolicy.policyCode()) ? sourcePolicy : null;
+  }
+
+  private String policyHitCode(JsonNode condition) {
+    if (condition == null || !"policy_hit".equals(condition.path("type").asText())) {
+      return null;
+    }
+    String policyCode = condition.path("policyCode").asText(null);
+    return trimToNull(policyCode);
+  }
+
+  private WorkflowAdvanceResponse response(
+      ChatSession session,
+      WorkflowExecution execution,
+      String previousState,
+      RuntimeNode currentNode,
+      String actionType,
+      String edgeId,
+      String targetState,
+      List<String> missingSlotCodes,
+      JsonNode condition,
+      ObjectNode slotValues,
+      LlmToolPolicyResponse transitionPolicy,
+      boolean persistExecution,
+      String reason) {
+    LlmToolPolicyResponse currentPolicy =
+        workflowPolicyRuntimeService.evaluateNodePolicy(
+            session.getDomainPackVersionId(), currentNode, slotValues, execution);
+    JsonNode policySnapshot = workflowPolicyRuntimeService.buildPolicySnapshot(currentPolicy);
+    String policySnapshotJson = writeJson(policySnapshot);
+    boolean policySnapshotChanged = !policySnapshotJson.equals(execution.getPolicySnapshotJson());
+    if (policySnapshotChanged) {
+      execution.replacePolicySnapshotJson(policySnapshotJson);
+    }
+    WorkflowExecution responseExecution =
+        persistExecution || policySnapshotChanged
+            ? workflowExecutionRepository.save(execution)
+            : execution;
+    return new WorkflowAdvanceResponse(
+        session.getId(),
+        responseExecution.getId(),
+        responseExecution.getStatus(),
+        previousState,
+        responseExecution.getCurrentState(),
+        currentNode.type(),
+        actionType,
+        edgeId,
+        targetState,
+        missingSlotCodes,
+        condition,
+        policySnapshot,
+        transitionPolicy,
+        currentPolicy,
+        reason);
+  }
+
+  private ObjectNode readObjectNode(String json) {
+    JsonNode node = readJsonNode(json, "{}");
+    if (node.isObject()) {
+      return (ObjectNode) node;
+    }
+    throw new InternalException("JSON_OBJECT_EXPECTED", "Stored JSON value must be an object");
+  }
+
+  private JsonNode readJsonNode(String json, String defaultJson) {
+    String source = trimToNull(json);
+    if (source == null) {
+      source = defaultJson;
+    }
+    try {
+      return objectMapper.readTree(source);
+    } catch (JsonProcessingException e) {
+      throw new InternalException("JSON_PARSE_FAILED", "Stored JSON value cannot be parsed", e);
+    }
+  }
+
+  private String writeJson(JsonNode node) {
+    try {
+      return objectMapper.writeValueAsString(node);
+    } catch (JsonProcessingException e) {
+      throw new InternalException("JSON_WRITE_FAILED", "Policy snapshot cannot be serialized", e);
+    }
+  }
+
+  private String trimToNull(String value) {
+    if (value == null) {
+      return null;
+    }
+    String trimmed = value.trim();
+    return trimmed.isEmpty() ? null : trimmed;
+  }
+}

--- a/backend/src/main/java/com/init/workflowruntime/application/command/GetLlmToolPolicyContextCommand.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/command/GetLlmToolPolicyContextCommand.java
@@ -1,0 +1,3 @@
+package com.init.workflowruntime.application.command;
+
+public record GetLlmToolPolicyContextCommand(Long sessionId) {}

--- a/backend/src/main/java/com/init/workflowruntime/application/dto/LlmToolPolicyContextResponse.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/dto/LlmToolPolicyContextResponse.java
@@ -1,0 +1,10 @@
+package com.init.workflowruntime.application.dto;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public record LlmToolPolicyContextResponse(
+    Long sessionId,
+    Long executionId,
+    String currentState,
+    JsonNode policySnapshot,
+    LlmToolPolicyResponse currentPolicy) {}

--- a/backend/src/main/java/com/init/workflowruntime/application/dto/LlmToolPolicyResponse.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/dto/LlmToolPolicyResponse.java
@@ -1,0 +1,20 @@
+package com.init.workflowruntime.application.dto;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.List;
+
+public record LlmToolPolicyResponse(
+    Long id,
+    String policyCode,
+    String name,
+    String description,
+    String severity,
+    JsonNode condition,
+    JsonNode action,
+    JsonNode evidence,
+    JsonNode meta,
+    String status,
+    String nodeId,
+    boolean matched,
+    List<String> missingSlotCodes,
+    String reason) {}

--- a/backend/src/main/java/com/init/workflowruntime/application/dto/WorkflowAdvanceResponse.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/dto/WorkflowAdvanceResponse.java
@@ -3,15 +3,19 @@ package com.init.workflowruntime.application.dto;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.util.List;
 
-public record LlmToolContextResponse(
+public record WorkflowAdvanceResponse(
     Long sessionId,
-    Long workspaceId,
-    Long domainPackVersionId,
     Long executionId,
     String executionStatus,
+    String previousState,
     String currentState,
-    JsonNode slotValues,
+    String currentNodeType,
+    String actionType,
+    String edgeId,
+    String targetState,
+    List<String> missingSlotCodes,
+    JsonNode condition,
     JsonNode policySnapshot,
+    LlmToolPolicyResponse transitionPolicy,
     LlmToolPolicyResponse currentPolicy,
-    List<String> missingSlots,
-    List<LlmToolSlotResponse> slots) {}
+    String reason) {}

--- a/backend/src/main/java/com/init/workflowruntime/domain/WorkflowExecution.java
+++ b/backend/src/main/java/com/init/workflowruntime/domain/WorkflowExecution.java
@@ -153,6 +153,9 @@ public class WorkflowExecution {
 
   public void moveToState(String nextState) {
     Objects.requireNonNull(nextState, "nextState must not be null");
+    if (nextState.isBlank()) {
+      throw new InvalidSessionStateException("nextState must not be blank");
+    }
     if (isTerminalStatus()) {
       throw new InvalidSessionStateException(
           "Cannot move terminal execution to next state: " + this.status);

--- a/backend/src/main/java/com/init/workflowruntime/domain/WorkflowExecution.java
+++ b/backend/src/main/java/com/init/workflowruntime/domain/WorkflowExecution.java
@@ -126,6 +126,14 @@ public class WorkflowExecution {
     this.slotValuesJson = slotValuesJson != null ? slotValuesJson : "{}";
   }
 
+  public void replacePolicySnapshotJson(String policySnapshotJson) {
+    this.policySnapshotJson = policySnapshotJson != null ? policySnapshotJson : "{}";
+  }
+
+  public void replaceRiskSnapshotJson(String riskSnapshotJson) {
+    this.riskSnapshotJson = riskSnapshotJson != null ? riskSnapshotJson : "{}";
+  }
+
   public void assignIntentWorkflow(
       Long intentDefinitionId, Long workflowDefinitionId, String currentState) {
     Objects.requireNonNull(intentDefinitionId, "intentDefinitionId must not be null");
@@ -141,6 +149,26 @@ public class WorkflowExecution {
     this.workflowDefinitionId = workflowDefinitionId;
     this.currentState = currentState;
     this.status = STATUS_RUNNING;
+  }
+
+  public void moveToState(String nextState) {
+    Objects.requireNonNull(nextState, "nextState must not be null");
+    if (isTerminalStatus()) {
+      throw new InvalidSessionStateException(
+          "Cannot move terminal execution to next state: " + this.status);
+    }
+    this.currentState = nextState;
+  }
+
+  public void complete() {
+    if (STATUS_COMPLETED.equals(this.status)) {
+      return;
+    }
+    if (STATUS_FAILED.equals(this.status)) {
+      throw new InvalidSessionStateException("Cannot complete failed execution");
+    }
+    this.status = STATUS_COMPLETED;
+    this.finishedAt = OffsetDateTime.now();
   }
 
   private boolean isTerminalStatus() {

--- a/backend/src/main/java/com/init/workflowruntime/presentation/LlmToolController.java
+++ b/backend/src/main/java/com/init/workflowruntime/presentation/LlmToolController.java
@@ -3,6 +3,7 @@ package com.init.workflowruntime.presentation;
 import com.init.workflowruntime.application.LlmToolService;
 import com.init.workflowruntime.application.command.GetCurrentWorkflowCommand;
 import com.init.workflowruntime.application.command.GetLlmToolContextCommand;
+import com.init.workflowruntime.application.command.GetLlmToolPolicyContextCommand;
 import com.init.workflowruntime.application.command.GetLlmToolSlotCommand;
 import com.init.workflowruntime.application.command.ListLlmToolIntentsCommand;
 import com.init.workflowruntime.application.command.ListLlmToolSlotsCommand;
@@ -52,7 +53,8 @@ public class LlmToolController {
   @GetMapping("/policy-context")
   public ResponseEntity<LlmToolPolicyContextResponse> getPolicyContext(
       @PathVariable Long sessionId) {
-    return ResponseEntity.ok(llmToolService.getPolicyContext(sessionId));
+    return ResponseEntity.ok(
+        llmToolService.getPolicyContext(new GetLlmToolPolicyContextCommand(sessionId)));
   }
 
   @GetMapping("/slots")

--- a/backend/src/main/java/com/init/workflowruntime/presentation/LlmToolController.java
+++ b/backend/src/main/java/com/init/workflowruntime/presentation/LlmToolController.java
@@ -11,6 +11,7 @@ import com.init.workflowruntime.application.command.UpsertLlmToolSlotValueComman
 import com.init.workflowruntime.application.dto.LlmToolContextResponse;
 import com.init.workflowruntime.application.dto.LlmToolIntentResponse;
 import com.init.workflowruntime.application.dto.LlmToolIntentSelectionResponse;
+import com.init.workflowruntime.application.dto.LlmToolPolicyContextResponse;
 import com.init.workflowruntime.application.dto.LlmToolSlotResponse;
 import com.init.workflowruntime.application.dto.LlmToolSlotValueResponse;
 import com.init.workflowruntime.application.dto.LlmToolWorkflowResponse;
@@ -46,6 +47,12 @@ public class LlmToolController {
   @GetMapping("/context")
   public ResponseEntity<LlmToolContextResponse> getContext(@PathVariable Long sessionId) {
     return ResponseEntity.ok(llmToolService.getContext(new GetLlmToolContextCommand(sessionId)));
+  }
+
+  @GetMapping("/policy-context")
+  public ResponseEntity<LlmToolPolicyContextResponse> getPolicyContext(
+      @PathVariable Long sessionId) {
+    return ResponseEntity.ok(llmToolService.getPolicyContext(sessionId));
   }
 
   @GetMapping("/slots")

--- a/backend/src/main/java/com/init/workflowruntime/presentation/WorkflowRuntimeController.java
+++ b/backend/src/main/java/com/init/workflowruntime/presentation/WorkflowRuntimeController.java
@@ -1,0 +1,25 @@
+package com.init.workflowruntime.presentation;
+
+import com.init.workflowruntime.application.WorkflowRuntimeService;
+import com.init.workflowruntime.application.dto.WorkflowAdvanceResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/workflow-runtime/sessions/{sessionId}")
+public class WorkflowRuntimeController {
+
+  private final WorkflowRuntimeService workflowRuntimeService;
+
+  public WorkflowRuntimeController(WorkflowRuntimeService workflowRuntimeService) {
+    this.workflowRuntimeService = workflowRuntimeService;
+  }
+
+  @PostMapping("/advance")
+  public ResponseEntity<WorkflowAdvanceResponse> advance(@PathVariable Long sessionId) {
+    return ResponseEntity.ok(workflowRuntimeService.advance(sessionId));
+  }
+}

--- a/backend/src/test/java/com/init/workflowruntime/application/LlmToolServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/LlmToolServiceTest.java
@@ -3,6 +3,7 @@ package com.init.workflowruntime.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -31,6 +32,8 @@ import com.init.workflowruntime.application.command.SelectLlmToolIntentCommand;
 import com.init.workflowruntime.application.command.UpsertLlmToolSlotValueCommand;
 import com.init.workflowruntime.application.dto.LlmToolContextResponse;
 import com.init.workflowruntime.application.dto.LlmToolIntentSelectionResponse;
+import com.init.workflowruntime.application.dto.LlmToolPolicyContextResponse;
+import com.init.workflowruntime.application.dto.LlmToolPolicyResponse;
 import com.init.workflowruntime.application.dto.LlmToolSlotResponse;
 import com.init.workflowruntime.application.dto.LlmToolSlotValueResponse;
 import com.init.workflowruntime.application.dto.LlmToolWorkflowResponse;
@@ -139,6 +142,65 @@ class LlmToolServiceTest {
     assertThat(result.get(0).required()).isFalse();
     assertThat(result.get(0).hasValue()).isFalse();
     assertThat(result.get(0).value().isNull()).isTrue();
+  }
+
+  @Test
+  @DisplayName("getPolicyContext: 실행이 없으면 세션과 빈 policy snapshot만 반환한다")
+  void returnsEmptyPolicyContextWhenExecutionMissing() {
+    ChatSession session = createSession(1L, 10L, 101L);
+
+    given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+    given(workflowExecutionRepository.findTopByChatSessionIdOrderByStartedAtDescIdDesc(1L))
+        .willReturn(Optional.empty());
+
+    LlmToolPolicyContextResponse result = service.getPolicyContext(1L);
+
+    assertThat(result.sessionId()).isEqualTo(1L);
+    assertThat(result.executionId()).isNull();
+    assertThat(result.currentState()).isNull();
+    assertThat(result.policySnapshot().isObject()).isTrue();
+    assertThat(result.policySnapshot()).isEmpty();
+    assertThat(result.currentPolicy()).isNull();
+  }
+
+  @Test
+  @DisplayName("getPolicyContext: 실행이 있으면 current policy와 policy snapshot을 반환한다")
+  void returnsPolicyContextWhenExecutionExists() throws Exception {
+    ChatSession session = createSession(1L, 10L, 101L);
+    WorkflowExecution execution = createExecution(50L, 1L, 70L, "{\"order_id\":\"A-100\"}");
+    ReflectionTestUtils.setField(execution, "currentState", "policy_check");
+    execution.replacePolicySnapshotJson("{\"hits\":[{\"policyCode\":\"refund_policy\"}]}");
+    LlmToolPolicyResponse policyResponse =
+        new LlmToolPolicyResponse(
+            300L,
+            "refund_policy",
+            "환불 정책",
+            "환불 가능 조건",
+            "HIGH",
+            objectMapper.createObjectNode(),
+            objectMapper.createObjectNode(),
+            objectMapper.createArrayNode(),
+            objectMapper.createObjectNode(),
+            "ACTIVE",
+            "policy_check",
+            true,
+            List.of(),
+            "policy condition matched");
+
+    given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+    given(workflowExecutionRepository.findTopByChatSessionIdOrderByStartedAtDescIdDesc(1L))
+        .willReturn(Optional.of(execution));
+    given(workflowPolicyRuntimeService.evaluateCurrentPolicy(eq(101L), eq(execution), any()))
+        .willReturn(policyResponse);
+
+    LlmToolPolicyContextResponse result = service.getPolicyContext(1L);
+
+    assertThat(result.sessionId()).isEqualTo(1L);
+    assertThat(result.executionId()).isEqualTo(50L);
+    assertThat(result.currentState()).isEqualTo("policy_check");
+    assertThat(result.policySnapshot().path("hits").get(0).path("policyCode").asText())
+        .isEqualTo("refund_policy");
+    assertThat(result.currentPolicy()).isEqualTo(policyResponse);
   }
 
   @Test

--- a/backend/src/test/java/com/init/workflowruntime/application/LlmToolServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/LlmToolServiceTest.java
@@ -147,7 +147,7 @@ class LlmToolServiceTest {
 
   @Test
   @DisplayName("getPolicyContext: 실행이 없으면 세션과 빈 policy snapshot만 반환한다")
-  void returnsEmptyPolicyContextWhenExecutionMissing() {
+  void should_returnEmptyPolicyContext_when_executionMissing() {
     ChatSession session = createSession(1L, 10L, 101L);
 
     given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
@@ -167,7 +167,7 @@ class LlmToolServiceTest {
 
   @Test
   @DisplayName("getPolicyContext: 실행이 있으면 current policy와 policy snapshot을 반환한다")
-  void returnsPolicyContextWhenExecutionExists() throws Exception {
+  void should_returnPolicyContext_when_executionExists() throws Exception {
     ChatSession session = createSession(1L, 10L, 101L);
     WorkflowExecution execution = createExecution(50L, 1L, 70L, "{\"order_id\":\"A-100\"}");
     ReflectionTestUtils.setField(execution, "currentState", "policy_check");

--- a/backend/src/test/java/com/init/workflowruntime/application/LlmToolServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/LlmToolServiceTest.java
@@ -61,6 +61,7 @@ class LlmToolServiceTest {
   @Mock private IntentSlotBindingRepository intentSlotBindingRepository;
   @Mock private IntentWorkflowBindingRepository intentWorkflowBindingRepository;
   @Mock private WorkflowDefinitionRepository workflowDefinitionRepository;
+  @Mock private WorkflowPolicyRuntimeService workflowPolicyRuntimeService;
 
   private ObjectMapper objectMapper;
   private LlmToolService service;
@@ -77,6 +78,7 @@ class LlmToolServiceTest {
             intentSlotBindingRepository,
             intentWorkflowBindingRepository,
             workflowDefinitionRepository,
+            workflowPolicyRuntimeService,
             objectMapper);
   }
 

--- a/backend/src/test/java/com/init/workflowruntime/application/LlmToolServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/LlmToolServiceTest.java
@@ -25,6 +25,7 @@ import com.init.shared.application.exception.InternalException;
 import com.init.shared.application.exception.NotFoundException;
 import com.init.workflowruntime.application.command.GetCurrentWorkflowCommand;
 import com.init.workflowruntime.application.command.GetLlmToolContextCommand;
+import com.init.workflowruntime.application.command.GetLlmToolPolicyContextCommand;
 import com.init.workflowruntime.application.command.GetLlmToolSlotCommand;
 import com.init.workflowruntime.application.command.ListLlmToolIntentsCommand;
 import com.init.workflowruntime.application.command.ListLlmToolSlotsCommand;
@@ -153,7 +154,8 @@ class LlmToolServiceTest {
     given(workflowExecutionRepository.findTopByChatSessionIdOrderByStartedAtDescIdDesc(1L))
         .willReturn(Optional.empty());
 
-    LlmToolPolicyContextResponse result = service.getPolicyContext(1L);
+    LlmToolPolicyContextResponse result =
+        service.getPolicyContext(new GetLlmToolPolicyContextCommand(1L));
 
     assertThat(result.sessionId()).isEqualTo(1L);
     assertThat(result.executionId()).isNull();
@@ -193,7 +195,8 @@ class LlmToolServiceTest {
     given(workflowPolicyRuntimeService.evaluateCurrentPolicy(eq(101L), eq(execution), any()))
         .willReturn(policyResponse);
 
-    LlmToolPolicyContextResponse result = service.getPolicyContext(1L);
+    LlmToolPolicyContextResponse result =
+        service.getPolicyContext(new GetLlmToolPolicyContextCommand(1L));
 
     assertThat(result.sessionId()).isEqualTo(1L);
     assertThat(result.executionId()).isEqualTo(50L);

--- a/backend/src/test/java/com/init/workflowruntime/application/WorkflowConditionEvaluatorTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/WorkflowConditionEvaluatorTest.java
@@ -245,9 +245,9 @@ class WorkflowConditionEvaluatorTest {
             new RuntimeEdge("e2", "a", "c", read("{\"type\":\"default\"}")));
 
     assertThat(WorkflowConditionEvaluator.blockedSlotCodes(condition, slotValues))
-        .containsExactly("reservation_no", "order_no");
+        .containsExactlyInAnyOrder("reservation_no", "order_no");
     assertThat(WorkflowConditionEvaluator.blockedSlotCodes(edges, slotValues))
-        .containsExactly("reservation_no", "order_no");
+        .containsExactlyInAnyOrder("reservation_no", "order_no");
   }
 
   @Test

--- a/backend/src/test/java/com/init/workflowruntime/application/WorkflowConditionEvaluatorTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/WorkflowConditionEvaluatorTest.java
@@ -1,0 +1,304 @@
+package com.init.workflowruntime.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.init.shared.application.exception.BadRequestException;
+import com.init.workflowruntime.application.WorkflowConditionEvaluator.ConditionContext;
+import com.init.workflowruntime.application.WorkflowConditionEvaluator.ConditionEvaluation;
+import com.init.workflowruntime.application.WorkflowRuntimeGraph.RuntimeEdge;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("WorkflowConditionEvaluator")
+class WorkflowConditionEvaluatorTest {
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Test
+  @DisplayName("evaluate: missing condition은 match되지 않는다")
+  void shouldNotMatchWhenConditionMissing() {
+    ConditionEvaluation result = evaluate(null, "{}", "{}", "{}");
+
+    assertThat(result.matched()).isFalse();
+    assertThat(result.defaultCondition()).isFalse();
+  }
+
+  @Test
+  @DisplayName("evaluate: always/default 조건을 구분한다")
+  void shouldEvaluateAlwaysAndDefaultConditions() {
+    ConditionEvaluation always = evaluate("{\"type\":\"always\"}", "{}", "{}", "{}");
+    ConditionEvaluation defaultCondition = evaluate("{\"type\":\"default\"}", "{}", "{}", "{}");
+
+    assertThat(always.matched()).isTrue();
+    assertThat(always.defaultCondition()).isFalse();
+    assertThat(defaultCondition.matched()).isFalse();
+    assertThat(defaultCondition.defaultCondition()).isTrue();
+    assertThat(WorkflowConditionEvaluator.isDefaultCondition(read("{\"type\":\"default\"}")))
+        .isTrue();
+  }
+
+  @Test
+  @DisplayName("evaluate: slot 조건은 공백/빈 배열/빈 객체를 missing으로 판단한다")
+  void shouldEvaluateSlotPresenceByMeaningfulValue() {
+    String slotValues =
+        """
+        {
+          "reservation_no": "R-1234",
+          "blank": " ",
+          "emptyItems": [],
+          "emptyObject": {},
+          "confirmed": true
+        }
+        """;
+
+    assertThat(
+            evaluate("{\"type\":\"slot_present\",\"slotCode\":\"reservation_no\"}", slotValues)
+                .matched())
+        .isTrue();
+    assertThat(evaluate("{\"type\":\"slot_present\",\"slotCode\":\"blank\"}", slotValues).matched())
+        .isFalse();
+    assertThat(
+            evaluate("{\"type\":\"slot_missing\",\"slotCode\":\"emptyItems\"}", slotValues)
+                .matched())
+        .isTrue();
+    assertThat(
+            evaluate("{\"type\":\"slot_missing\",\"slotCode\":\"emptyObject\"}", slotValues)
+                .matched())
+        .isTrue();
+    assertThat(
+            evaluate("{\"type\":\"slot_present\",\"slotCode\":\"confirmed\"}", slotValues)
+                .matched())
+        .isTrue();
+  }
+
+  @Test
+  @DisplayName("evaluate: slot_equals는 JSON 값 동등성을 비교한다")
+  void shouldEvaluateSlotEqualsByJsonValue() {
+    String slotValues = "{\"count\":3,\"decision\":\"approve\"}";
+
+    assertThat(
+            evaluate("{\"type\":\"slot_equals\",\"slotCode\":\"count\",\"value\":3}", slotValues)
+                .matched())
+        .isTrue();
+    assertThat(
+            evaluate(
+                    "{\"type\":\"slot_equals\",\"slotCode\":\"count\",\"value\":\"3\"}", slotValues)
+                .matched())
+        .isFalse();
+    assertThat(
+            evaluate("{\"type\":\"slot_equals\",\"slotCode\":\"missing\",\"value\":3}", slotValues)
+                .matched())
+        .isFalse();
+    assertThat(
+            evaluate("{\"type\":\"slot_equals\",\"slotCode\":\"decision\"}", slotValues).matched())
+        .isFalse();
+  }
+
+  @Test
+  @DisplayName("evaluate: all/any는 중첩 조건을 평가하고 default 조건은 match로 취급하지 않는다")
+  void shouldEvaluateNestedConditions() {
+    String slotValues = "{\"reservation_no\":\"R-1234\",\"vip\":true}";
+
+    assertThat(
+            evaluate(
+                    """
+                    {
+                      "type": "all",
+                      "conditions": [
+                        {"type": "slot_present", "slotCode": "reservation_no"},
+                        {"type": "slot_equals", "slotCode": "vip", "value": true}
+                      ]
+                    }
+                    """,
+                    slotValues)
+                .matched())
+        .isTrue();
+    assertThat(
+            evaluate(
+                    """
+                    {
+                      "type": "all",
+                      "conditions": [
+                        {"type": "slot_present", "slotCode": "reservation_no"},
+                        {"type": "default"}
+                      ]
+                    }
+                    """,
+                    slotValues)
+                .matched())
+        .isFalse();
+    assertThat(
+            evaluate(
+                    """
+                    {
+                      "type": "any",
+                      "conditions": [
+                        {"type": "default"},
+                        {"type": "slot_present", "slotCode": "missing"},
+                        {"type": "slot_equals", "slotCode": "vip", "value": true}
+                      ]
+                    }
+                    """,
+                    slotValues)
+                .matched())
+        .isTrue();
+  }
+
+  @Test
+  @DisplayName("evaluate: policy_hit은 snapshot 내부의 policyCode/code를 재귀 탐색한다")
+  void shouldEvaluatePolicyHitFromSnapshot() {
+    String policySnapshot =
+        """
+        {
+          "hits": [{"policyCode": "refund_policy"}],
+          "policyHits": [{"code": "deadline_policy"}]
+        }
+        """;
+
+    assertThat(
+            evaluate(
+                    "{\"type\":\"policy_hit\",\"policyCode\":\"refund_policy\"}",
+                    "{}",
+                    policySnapshot,
+                    "{}")
+                .matched())
+        .isTrue();
+    assertThat(
+            evaluate(
+                    "{\"type\":\"policy_hit\",\"policyCode\":\"deadline_policy\"}",
+                    "{}",
+                    policySnapshot,
+                    "{}")
+                .matched())
+        .isTrue();
+    assertThat(
+            evaluate(
+                    "{\"type\":\"policy_hit\",\"policyCode\":\"missing_policy\"}",
+                    "{}",
+                    policySnapshot,
+                    "{}")
+                .matched())
+        .isFalse();
+  }
+
+  @Test
+  @DisplayName("evaluate: risk_level_gte는 snapshot 내 최대 risk level을 비교한다")
+  void shouldEvaluateRiskLevelGteFromSnapshot() {
+    String riskSnapshot =
+        """
+        {
+          "riskHits": [
+            {"riskLevel": "LOW"},
+            {"level": "HIGH"}
+          ]
+        }
+        """;
+
+    assertThat(
+            evaluate(
+                    "{\"type\":\"risk_level_gte\",\"riskLevel\":\"MEDIUM\"}",
+                    "{}",
+                    "{}",
+                    riskSnapshot)
+                .matched())
+        .isTrue();
+    assertThat(
+            evaluate(
+                    "{\"type\":\"risk_level_gte\",\"riskLevel\":\"CRITICAL\"}",
+                    "{}",
+                    "{}",
+                    riskSnapshot)
+                .matched())
+        .isFalse();
+    assertThat(
+            evaluate(
+                    "{\"type\":\"risk_level_gte\",\"riskLevel\":\"LOW\"}", "{}", "{}", "\"MEDIUM\"")
+                .matched())
+        .isTrue();
+  }
+
+  @Test
+  @DisplayName("blockedSlotCodes: edge와 단일 condition에서 부족한 slotCode를 중복 없이 반환한다")
+  void shouldCollectBlockedSlotCodes() {
+    ObjectNode slotValues = object("{\"reservation_no\":\"\"}");
+    JsonNode condition =
+        read(
+            """
+            {
+              "type": "any",
+              "conditions": [
+                {"type": "slot_present", "slotCode": "reservation_no"},
+                {"type": "slot_equals", "slotCode": "order_no", "value": "O-1"},
+                {"type": "slot_present", "slotCode": "order_no"}
+              ]
+            }
+            """);
+    List<RuntimeEdge> edges =
+        List.of(
+            new RuntimeEdge("e1", "a", "b", condition),
+            new RuntimeEdge("e2", "a", "c", read("{\"type\":\"default\"}")));
+
+    assertThat(WorkflowConditionEvaluator.blockedSlotCodes(condition, slotValues))
+        .containsExactly("reservation_no", "order_no");
+    assertThat(WorkflowConditionEvaluator.blockedSlotCodes(edges, slotValues))
+        .containsExactly("reservation_no", "order_no");
+  }
+
+  @Test
+  @DisplayName("evaluate: 잘못된 condition은 BadRequestException을 던진다")
+  void shouldThrowBadRequestWhenConditionInvalid() {
+    assertThatThrownBy(() -> evaluate("[]", "{}", "{}", "{}"))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("condition must be an object");
+    assertThatThrownBy(() -> evaluate("{\"type\":\"unknown\"}", "{}", "{}", "{}"))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("unsupported condition type");
+    assertThatThrownBy(() -> evaluate("{\"type\":\"slot_present\"}", "{}", "{}", "{}"))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("slotCode is required");
+    assertThatThrownBy(() -> evaluate("{\"type\":\"all\",\"conditions\":[]}", "{}", "{}", "{}"))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("conditions must be a non-empty array");
+    assertThatThrownBy(
+            () ->
+                evaluate(
+                    "{\"type\":\"risk_level_gte\",\"riskLevel\":\"URGENT\"}", "{}", "{}", "{}"))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("unsupported risk level");
+  }
+
+  private ConditionEvaluation evaluate(String conditionJson, String slotValuesJson) {
+    return evaluate(conditionJson, slotValuesJson, "{}", "{}");
+  }
+
+  private ConditionEvaluation evaluate(
+      String conditionJson,
+      String slotValuesJson,
+      String policySnapshotJson,
+      String riskSnapshotJson) {
+    return WorkflowConditionEvaluator.evaluate(
+        conditionJson == null ? null : read(conditionJson),
+        new ConditionContext(
+            object(slotValuesJson), read(policySnapshotJson), read(riskSnapshotJson)));
+  }
+
+  private ObjectNode object(String json) {
+    JsonNode node = read(json);
+    assertThat(node.isObject()).isTrue();
+    return (ObjectNode) node;
+  }
+
+  private JsonNode read(String json) {
+    try {
+      return objectMapper.readTree(json);
+    } catch (JsonProcessingException e) {
+      throw new IllegalArgumentException(e);
+    }
+  }
+}

--- a/backend/src/test/java/com/init/workflowruntime/application/WorkflowPolicyRuntimeServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/WorkflowPolicyRuntimeServiceTest.java
@@ -1,0 +1,156 @@
+package com.init.workflowruntime.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.init.domainpack.domain.model.PolicyDefinition;
+import com.init.domainpack.domain.model.WorkflowDefinition;
+import com.init.domainpack.domain.repository.PolicyDefinitionRepository;
+import com.init.domainpack.domain.repository.WorkflowDefinitionRepository;
+import com.init.workflowruntime.application.dto.LlmToolPolicyResponse;
+import com.init.workflowruntime.domain.WorkflowExecution;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("WorkflowPolicyRuntimeService")
+class WorkflowPolicyRuntimeServiceTest {
+
+  @Mock private PolicyDefinitionRepository policyDefinitionRepository;
+  @Mock private WorkflowDefinitionRepository workflowDefinitionRepository;
+
+  private WorkflowPolicyRuntimeService service;
+
+  @BeforeEach
+  void setUp() {
+    service =
+        new WorkflowPolicyRuntimeService(
+            policyDefinitionRepository, workflowDefinitionRepository, new ObjectMapper());
+  }
+
+  @Test
+  @DisplayName("evaluateCurrentPolicy: 현재 node의 policyRef 정책을 slot 값으로 평가한다")
+  void should_evaluateCurrentPolicyWithSlotValues() {
+    WorkflowExecution execution =
+        createExecution(50L, 1L, 150L, "confirm_cancel", "{\"reservation_no\":\"R-1234\"}");
+    WorkflowDefinition workflow = createWorkflow(150L, 101L, graphJson());
+    PolicyDefinition policy = createPolicy(10L, 101L);
+
+    given(workflowDefinitionRepository.findByIdAndDomainPackVersionId(150L, 101L))
+        .willReturn(Optional.of(workflow));
+    given(policyDefinitionRepository.findByDomainPackVersionIdAndPolicyCode(101L, "cancel_policy"))
+        .willReturn(Optional.of(policy));
+
+    LlmToolPolicyResponse result =
+        service.evaluateCurrentPolicy(
+            101L, execution, new ObjectMapper().createObjectNode().put("reservation_no", "R-1234"));
+    JsonNode snapshot = service.buildPolicySnapshot(result);
+
+    assertThat(result.policyCode()).isEqualTo("cancel_policy");
+    assertThat(result.nodeId()).isEqualTo("confirm_cancel");
+    assertThat(result.matched()).isTrue();
+    assertThat(result.missingSlotCodes()).isEmpty();
+    assertThat(result.action().path("answerGuide").asText()).isEqualTo("예약 취소 가능 여부를 안내한다.");
+    assertThat(snapshot.path("hits").get(0).path("policyCode").asText()).isEqualTo("cancel_policy");
+  }
+
+  @Test
+  @DisplayName("evaluateCurrentPolicy: 정책 조건에 필요한 slot이 없으면 missingSlotCodes를 반환한다")
+  void should_returnMissingSlots_when_policyConditionBlocked() {
+    WorkflowExecution execution = createExecution(50L, 1L, 150L, "confirm_cancel", "{}");
+    WorkflowDefinition workflow = createWorkflow(150L, 101L, graphJson());
+    PolicyDefinition policy = createPolicy(10L, 101L);
+
+    given(workflowDefinitionRepository.findByIdAndDomainPackVersionId(150L, 101L))
+        .willReturn(Optional.of(workflow));
+    given(policyDefinitionRepository.findByDomainPackVersionIdAndPolicyCode(101L, "cancel_policy"))
+        .willReturn(Optional.of(policy));
+
+    LlmToolPolicyResponse result =
+        service.evaluateCurrentPolicy(101L, execution, new ObjectMapper().createObjectNode());
+
+    assertThat(result.matched()).isFalse();
+    assertThat(result.missingSlotCodes()).containsExactly("reservation_no");
+  }
+
+  private WorkflowExecution createExecution(
+      Long id, Long sessionId, Long workflowId, String currentState, String slotValuesJson) {
+    WorkflowExecution execution = WorkflowExecution.create(sessionId);
+    ReflectionTestUtils.setField(execution, "id", id);
+    execution.assignIntentWorkflow(70L, workflowId, currentState);
+    execution.replaceSlotValuesJson(slotValuesJson);
+    return execution;
+  }
+
+  private WorkflowDefinition createWorkflow(Long id, Long versionId, String graphJson) {
+    WorkflowDefinition workflow =
+        WorkflowDefinition.create(
+            versionId,
+            "reservation_cancel",
+            "예약 취소",
+            "예약 취소 workflow",
+            graphJson,
+            "start",
+            "[\"done\"]",
+            "[]",
+            "{}");
+    ReflectionTestUtils.setField(workflow, "id", id);
+    return workflow;
+  }
+
+  private PolicyDefinition createPolicy(Long id, Long versionId) {
+    PolicyDefinition policy =
+        PolicyDefinition.create(
+            versionId,
+            "cancel_policy",
+            "예약 취소 정책",
+            "예약번호 기준 취소 가능 여부를 판단한다.",
+            "HIGH",
+            "{\"type\":\"slot_present\",\"slotCode\":\"reservation_no\"}",
+            "{\"answerGuide\":\"예약 취소 가능 여부를 안내한다.\"}",
+            "[]",
+            "{}");
+    ReflectionTestUtils.setField(policy, "id", id);
+    return policy;
+  }
+
+  private String graphJson() {
+    return """
+        {
+          "direction": "LR",
+          "nodes": [
+            {"id": "start", "type": "START", "label": "시작"},
+            {
+              "id": "confirm_cancel",
+              "type": "ACTION",
+              "label": "취소 가능 여부 확인",
+              "policyRef": "cancel_policy"
+            },
+            {"id": "done", "type": "TERMINAL", "label": "종료"}
+          ],
+          "edges": [
+            {
+              "id": "e_start_confirm",
+              "from": "start",
+              "to": "confirm_cancel",
+              "condition": {"type": "always"}
+            },
+            {
+              "id": "e_confirm_done",
+              "from": "confirm_cancel",
+              "to": "done",
+              "condition": {"type": "always"}
+            }
+          ]
+        }
+        """;
+  }
+}

--- a/backend/src/test/java/com/init/workflowruntime/application/WorkflowRuntimeGraphTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/WorkflowRuntimeGraphTest.java
@@ -1,0 +1,24 @@
+package com.init.workflowruntime.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.init.shared.application.exception.InternalException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("WorkflowRuntimeGraph")
+class WorkflowRuntimeGraphTest {
+
+  @Test
+  @DisplayName("parse: graphJson이 null이면 InternalException으로 래핑한다")
+  void wrapsNullGraphJsonWithInternalException() {
+    assertThatExceptionOfType(InternalException.class)
+        .isThrownBy(() -> WorkflowRuntimeGraph.parse(new ObjectMapper(), null, 150L))
+        .satisfies(
+            ex ->
+                assertThat(((InternalException) ex).getCode())
+                    .isEqualTo("WORKFLOW_GRAPH_PARSE_FAILED"));
+  }
+}

--- a/backend/src/test/java/com/init/workflowruntime/application/WorkflowRuntimeServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/WorkflowRuntimeServiceTest.java
@@ -1,0 +1,310 @@
+package com.init.workflowruntime.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.init.domainpack.domain.model.WorkflowDefinition;
+import com.init.domainpack.domain.repository.WorkflowDefinitionRepository;
+import com.init.workflowruntime.application.dto.LlmToolPolicyResponse;
+import com.init.workflowruntime.application.dto.WorkflowAdvanceResponse;
+import com.init.workflowruntime.domain.ChatSession;
+import com.init.workflowruntime.domain.ChatSessionRepository;
+import com.init.workflowruntime.domain.ChatSessionStatus;
+import com.init.workflowruntime.domain.WorkflowExecution;
+import com.init.workflowruntime.domain.WorkflowExecutionRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("WorkflowRuntimeService")
+class WorkflowRuntimeServiceTest {
+
+  @Mock private ChatSessionRepository chatSessionRepository;
+  @Mock private WorkflowExecutionRepository workflowExecutionRepository;
+  @Mock private WorkflowDefinitionRepository workflowDefinitionRepository;
+  @Mock private WorkflowPolicyRuntimeService workflowPolicyRuntimeService;
+
+  private WorkflowRuntimeService service;
+  private ObjectMapper objectMapper;
+
+  @BeforeEach
+  void setUp() {
+    objectMapper = new ObjectMapper();
+    service =
+        new WorkflowRuntimeService(
+            chatSessionRepository,
+            workflowExecutionRepository,
+            workflowDefinitionRepository,
+            workflowPolicyRuntimeService,
+            objectMapper);
+    given(workflowPolicyRuntimeService.buildPolicySnapshot(null))
+        .willReturn(objectMapper.createObjectNode());
+  }
+
+  @Test
+  @DisplayName("advance: slot_present 조건이 충족되지 않으면 현재 state에 머물며 ASK_SLOT을 반환한다")
+  void should_askSlotAndKeepCurrentState_when_slotValueMissing() {
+    ChatSession session = createSession(1L, 10L, 101L);
+    WorkflowExecution execution = createExecution(50L, 1L, 150L, "collect_reservation_no", "{}");
+    WorkflowDefinition workflow = createWorkflow(150L, 101L, reservationCancelGraphJson());
+
+    given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+    given(workflowExecutionRepository.findTopByChatSessionIdOrderByStartedAtDescIdDesc(1L))
+        .willReturn(Optional.of(execution));
+    given(workflowDefinitionRepository.findByIdAndDomainPackVersionId(150L, 101L))
+        .willReturn(Optional.of(workflow));
+
+    WorkflowAdvanceResponse result = service.advance(1L);
+
+    assertThat(result.actionType()).isEqualTo("ASK_SLOT");
+    assertThat(result.currentState()).isEqualTo("collect_reservation_no");
+    assertThat(result.missingSlotCodes()).containsExactly("reservation_no");
+    assertThat(execution.getCurrentState()).isEqualTo("collect_reservation_no");
+    verify(workflowExecutionRepository, never()).save(execution);
+  }
+
+  @Test
+  @DisplayName("advance: slot_present 조건이 충족되면 해당 edge target으로 currentState를 전이한다")
+  void should_advanceToTargetState_when_slotConditionMatches() {
+    ChatSession session = createSession(1L, 10L, 101L);
+    WorkflowExecution execution =
+        createExecution(50L, 1L, 150L, "collect_reservation_no", "{\"reservation_no\":\"R-1234\"}");
+    WorkflowDefinition workflow = createWorkflow(150L, 101L, reservationCancelGraphJson());
+
+    given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+    given(workflowExecutionRepository.findTopByChatSessionIdOrderByStartedAtDescIdDesc(1L))
+        .willReturn(Optional.of(execution));
+    given(workflowDefinitionRepository.findByIdAndDomainPackVersionId(150L, 101L))
+        .willReturn(Optional.of(workflow));
+    given(workflowExecutionRepository.save(execution)).willReturn(execution);
+
+    WorkflowAdvanceResponse result = service.advance(1L);
+
+    assertThat(result.actionType()).isEqualTo("ADVANCE");
+    assertThat(result.previousState()).isEqualTo("collect_reservation_no");
+    assertThat(result.currentState()).isEqualTo("confirm_cancel");
+    assertThat(result.edgeId()).isEqualTo("e_collect_confirm");
+    assertThat(result.condition().path("type").asText()).isEqualTo("slot_present");
+    assertThat(result.transitionPolicy()).isNull();
+    assertThat(execution.getCurrentState()).isEqualTo("confirm_cancel");
+    verify(workflowExecutionRepository).save(execution);
+  }
+
+  @Test
+  @DisplayName("advance: 매칭 조건이 없으면 default edge를 사용해 handoff state로 전이한다")
+  void should_useDefaultEdgeForHandoff_when_noConditionMatches() {
+    ChatSession session = createSession(1L, 10L, 101L);
+    WorkflowExecution execution =
+        createExecution(50L, 1L, 150L, "cancel_decision", "{\"auto_cancel_available\":false}");
+    WorkflowDefinition workflow = createWorkflow(150L, 101L, reservationCancelGraphJson());
+
+    given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+    given(workflowExecutionRepository.findTopByChatSessionIdOrderByStartedAtDescIdDesc(1L))
+        .willReturn(Optional.of(execution));
+    given(workflowDefinitionRepository.findByIdAndDomainPackVersionId(150L, 101L))
+        .willReturn(Optional.of(workflow));
+    given(workflowExecutionRepository.save(execution)).willReturn(execution);
+
+    WorkflowAdvanceResponse result = service.advance(1L);
+
+    assertThat(result.actionType()).isEqualTo("HANDOFF");
+    assertThat(result.currentState()).isEqualTo("handoff");
+    assertThat(result.currentNodeType()).isEqualTo("HANDOFF");
+    assertThat(result.edgeId()).isEqualTo("e_decision_handoff");
+    assertThat(execution.getCurrentState()).isEqualTo("handoff");
+  }
+
+  @Test
+  @DisplayName("advance: 현재 노드 policy 평가 결과가 맞으면 policy_hit edge로 즉시 전이한다")
+  void should_advanceByPolicyHitEdge_when_currentNodePolicyMatches() throws Exception {
+    ChatSession session = createSession(1L, 10L, 101L);
+    WorkflowExecution execution = createExecution(50L, 1L, 150L, "policy_check", "{}");
+    WorkflowDefinition workflow = createWorkflow(150L, 101L, policyHitGraphJson());
+    LlmToolPolicyResponse policyResponse =
+        new LlmToolPolicyResponse(
+            300L,
+            "refund_policy",
+            "환불 정책",
+            "환불 가능 조건",
+            "HIGH",
+            objectMapper.createObjectNode(),
+            objectMapper.createObjectNode(),
+            objectMapper.createArrayNode(),
+            objectMapper.createObjectNode(),
+            "ACTIVE",
+            "policy_check",
+            true,
+            List.of(),
+            "policy condition matched");
+    JsonNode policySnapshot =
+        objectMapper.readTree("{\"hits\":[{\"policyCode\":\"refund_policy\"}]}");
+
+    given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+    given(workflowExecutionRepository.findTopByChatSessionIdOrderByStartedAtDescIdDesc(1L))
+        .willReturn(Optional.of(execution));
+    given(workflowDefinitionRepository.findByIdAndDomainPackVersionId(150L, 101L))
+        .willReturn(Optional.of(workflow));
+    given(
+            workflowPolicyRuntimeService.evaluateNodePolicy(
+                eq(101L),
+                eq(new WorkflowRuntimeGraph.RuntimeNode("policy_check", "ACTION", "refund_policy")),
+                any(),
+                eq(execution)))
+        .willReturn(policyResponse);
+    given(workflowPolicyRuntimeService.buildPolicySnapshot(policyResponse))
+        .willReturn(policySnapshot);
+    given(workflowExecutionRepository.save(execution)).willReturn(execution);
+
+    WorkflowAdvanceResponse result = service.advance(1L);
+
+    assertThat(result.actionType()).isEqualTo("HANDOFF");
+    assertThat(result.edgeId()).isEqualTo("e_policy_handoff");
+    assertThat(result.currentState()).isEqualTo("handoff");
+    assertThat(result.condition().path("type").asText()).isEqualTo("policy_hit");
+    assertThat(result.transitionPolicy()).isEqualTo(policyResponse);
+    assertThat(result.currentPolicy()).isNull();
+    assertThat(execution.getCurrentState()).isEqualTo("handoff");
+  }
+
+  private ChatSession createSession(Long id, Long workspaceId, Long versionId) {
+    ChatSession session =
+        ChatSession.create(workspaceId, versionId, ChatSessionStatus.OPEN, "WEB", "{}");
+    ReflectionTestUtils.setField(session, "id", id);
+    return session;
+  }
+
+  private WorkflowExecution createExecution(
+      Long id, Long sessionId, Long workflowId, String currentState, String slotValuesJson) {
+    WorkflowExecution execution = WorkflowExecution.create(sessionId);
+    ReflectionTestUtils.setField(execution, "id", id);
+    execution.assignIntentWorkflow(70L, workflowId, currentState);
+    execution.replaceSlotValuesJson(slotValuesJson);
+    return execution;
+  }
+
+  private WorkflowDefinition createWorkflow(Long id, Long versionId, String graphJson) {
+    WorkflowDefinition workflow =
+        WorkflowDefinition.create(
+            versionId,
+            "reservation_cancel",
+            "예약 취소",
+            "예약 취소 workflow",
+            graphJson,
+            "start",
+            "[\"done\"]",
+            "[]",
+            "{}");
+    ReflectionTestUtils.setField(workflow, "id", id);
+    return workflow;
+  }
+
+  private String reservationCancelGraphJson() {
+    return """
+        {
+          "direction": "LR",
+          "nodes": [
+            {"id": "start", "type": "START", "label": "시작"},
+            {
+              "id": "collect_reservation_no",
+              "type": "ACTION",
+              "label": "예약번호 확인",
+              "policyRef": "cancel_policy"
+            },
+            {
+              "id": "confirm_cancel",
+              "type": "ACTION",
+              "label": "취소 가능 여부 확인",
+              "policyRef": "cancel_policy"
+            },
+            {"id": "cancel_decision", "type": "DECISION", "label": "취소 처리 분기"},
+            {"id": "handoff", "type": "HANDOFF", "label": "상담사 이관"},
+            {"id": "done", "type": "TERMINAL", "label": "종료"}
+          ],
+          "edges": [
+            {
+              "id": "e_start_collect",
+              "from": "start",
+              "to": "collect_reservation_no",
+              "condition": {"type": "always"}
+            },
+            {
+              "id": "e_collect_confirm",
+              "from": "collect_reservation_no",
+              "to": "confirm_cancel",
+              "label": "예약번호 있음",
+              "condition": {"type": "slot_present", "slotCode": "reservation_no"}
+            },
+            {
+              "id": "e_confirm_decision",
+              "from": "confirm_cancel",
+              "to": "cancel_decision",
+              "condition": {"type": "always"}
+            },
+            {
+              "id": "e_decision_done",
+              "from": "cancel_decision",
+              "to": "done",
+              "label": "자동 처리 가능",
+              "condition": {
+                "type": "slot_equals",
+                "slotCode": "auto_cancel_available",
+                "value": true
+              }
+            },
+            {
+              "id": "e_decision_handoff",
+              "from": "cancel_decision",
+              "to": "handoff",
+              "label": "이관 필요",
+              "condition": {"type": "default"}
+            }
+          ]
+        }
+        """;
+  }
+
+  private String policyHitGraphJson() {
+    return """
+        {
+          "direction": "LR",
+          "nodes": [
+            {
+              "id": "policy_check",
+              "type": "ACTION",
+              "label": "정책 확인",
+              "policyRef": "refund_policy"
+            },
+            {"id": "handoff", "type": "HANDOFF", "label": "상담사 이관"},
+            {"id": "answer", "type": "ANSWER", "label": "일반 답변"}
+          ],
+          "edges": [
+            {
+              "id": "e_policy_handoff",
+              "from": "policy_check",
+              "to": "handoff",
+              "condition": {"type": "policy_hit", "policyCode": "refund_policy"}
+            },
+            {
+              "id": "e_policy_answer",
+              "from": "policy_check",
+              "to": "answer",
+              "condition": {"type": "default"}
+            }
+          ]
+        }
+        """;
+  }
+}

--- a/backend/src/test/java/com/init/workflowruntime/application/WorkflowRuntimeServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/WorkflowRuntimeServiceTest.java
@@ -177,6 +177,54 @@ class WorkflowRuntimeServiceTest {
     assertThat(execution.getCurrentState()).isEqualTo("handoff");
   }
 
+  @Test
+  @DisplayName("advance: any 조건에서 먼저 매칭된 조건이 policy_hit이 아니면 transitionPolicy를 비운다")
+  void should_notSetTransitionPolicy_when_anyMatchedByNonPolicyConditionFirst() throws Exception {
+    ChatSession session = createSession(1L, 10L, 101L);
+    WorkflowExecution execution =
+        createExecution(50L, 1L, 150L, "policy_check", "{\"reservation_no\":\"R-1234\"}");
+    WorkflowDefinition workflow = createWorkflow(150L, 101L, policyHitAfterSlotAnyGraphJson());
+    LlmToolPolicyResponse policyResponse =
+        new LlmToolPolicyResponse(
+            300L,
+            "refund_policy",
+            "환불 정책",
+            "환불 가능 조건",
+            "HIGH",
+            objectMapper.createObjectNode(),
+            objectMapper.createObjectNode(),
+            objectMapper.createArrayNode(),
+            objectMapper.createObjectNode(),
+            "ACTIVE",
+            "policy_check",
+            true,
+            List.of(),
+            "policy condition matched");
+    JsonNode policySnapshot =
+        objectMapper.readTree("{\"hits\":[{\"policyCode\":\"refund_policy\"}]}");
+
+    given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+    given(workflowExecutionRepository.findTopByChatSessionIdOrderByStartedAtDescIdDesc(1L))
+        .willReturn(Optional.of(execution));
+    given(workflowDefinitionRepository.findByIdAndDomainPackVersionId(150L, 101L))
+        .willReturn(Optional.of(workflow));
+    given(
+            workflowPolicyRuntimeService.evaluateNodePolicy(
+                argThat(command -> command != null && "policy_check".equals(command.node().id()))))
+        .willReturn(policyResponse);
+    given(workflowPolicyRuntimeService.buildPolicySnapshot(policyResponse))
+        .willReturn(policySnapshot);
+    given(workflowExecutionRepository.save(execution)).willReturn(execution);
+
+    WorkflowAdvanceResponse result = service.advance(1L);
+
+    assertThat(result.actionType()).isEqualTo("HANDOFF");
+    assertThat(result.edgeId()).isEqualTo("e_policy_handoff");
+    assertThat(result.condition().path("type").asText()).isEqualTo("any");
+    assertThat(result.transitionPolicy()).isNull();
+    assertThat(execution.getCurrentState()).isEqualTo("handoff");
+  }
+
   private ChatSession createSession(Long id, Long workspaceId, Long versionId) {
     ChatSession session =
         ChatSession.create(workspaceId, versionId, ChatSessionStatus.OPEN, "WEB", "{}");
@@ -296,6 +344,44 @@ class WorkflowRuntimeServiceTest {
               "condition": {
                 "type": "all",
                 "conditions": [
+                  {"type": "policy_hit", "policyCode": "refund_policy"}
+                ]
+              }
+            },
+            {
+              "id": "e_policy_answer",
+              "from": "policy_check",
+              "to": "answer",
+              "condition": {"type": "default"}
+            }
+          ]
+        }
+        """;
+  }
+
+  private String policyHitAfterSlotAnyGraphJson() {
+    return """
+        {
+          "direction": "LR",
+          "nodes": [
+            {
+              "id": "policy_check",
+              "type": "ACTION",
+              "label": "정책 확인",
+              "policyRef": "refund_policy"
+            },
+            {"id": "handoff", "type": "HANDOFF", "label": "상담사 이관"},
+            {"id": "answer", "type": "ANSWER", "label": "일반 답변"}
+          ],
+          "edges": [
+            {
+              "id": "e_policy_handoff",
+              "from": "policy_check",
+              "to": "handoff",
+              "condition": {
+                "type": "any",
+                "conditions": [
+                  {"type": "slot_present", "slotCode": "reservation_no"},
                   {"type": "policy_hit", "policyCode": "refund_policy"}
                 ]
               }

--- a/backend/src/test/java/com/init/workflowruntime/application/WorkflowRuntimeServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/WorkflowRuntimeServiceTest.java
@@ -1,8 +1,7 @@
 package com.init.workflowruntime.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -159,10 +158,7 @@ class WorkflowRuntimeServiceTest {
         .willReturn(Optional.of(workflow));
     given(
             workflowPolicyRuntimeService.evaluateNodePolicy(
-                eq(101L),
-                eq(new WorkflowRuntimeGraph.RuntimeNode("policy_check", "ACTION", "refund_policy")),
-                any(),
-                eq(execution)))
+                argThat(command -> command != null && "policy_check".equals(command.node().id()))))
         .willReturn(policyResponse);
     given(workflowPolicyRuntimeService.buildPolicySnapshot(policyResponse))
         .willReturn(policySnapshot);
@@ -173,7 +169,9 @@ class WorkflowRuntimeServiceTest {
     assertThat(result.actionType()).isEqualTo("HANDOFF");
     assertThat(result.edgeId()).isEqualTo("e_policy_handoff");
     assertThat(result.currentState()).isEqualTo("handoff");
-    assertThat(result.condition().path("type").asText()).isEqualTo("policy_hit");
+    assertThat(result.condition().path("type").asText()).isEqualTo("all");
+    assertThat(result.condition().path("conditions").get(0).path("type").asText())
+        .isEqualTo("policy_hit");
     assertThat(result.transitionPolicy()).isEqualTo(policyResponse);
     assertThat(result.currentPolicy()).isNull();
     assertThat(execution.getCurrentState()).isEqualTo("handoff");
@@ -295,7 +293,12 @@ class WorkflowRuntimeServiceTest {
               "id": "e_policy_handoff",
               "from": "policy_check",
               "to": "handoff",
-              "condition": {"type": "policy_hit", "policyCode": "refund_policy"}
+              "condition": {
+                "type": "all",
+                "conditions": [
+                  {"type": "policy_hit", "policyCode": "refund_policy"}
+                ]
+              }
             },
             {
               "id": "e_policy_answer",

--- a/backend/src/test/java/com/init/workflowruntime/domain/WorkflowExecutionTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/domain/WorkflowExecutionTest.java
@@ -120,6 +120,19 @@ class WorkflowExecutionTest {
   }
 
   @Test
+  @DisplayName("moveToState: 공백 state는 허용하지 않는다")
+  void throwsWhenMovingToBlankState() {
+    WorkflowExecution execution = WorkflowExecution.create(1L);
+    execution.assignIntentWorkflow(10L, 20L, "start");
+
+    assertThatExceptionOfType(BadRequestException.class)
+        .isThrownBy(() -> execution.moveToState(" "))
+        .withMessageContaining("nextState must not be blank");
+
+    assertThat(execution.getCurrentState()).isEqualTo("start");
+  }
+
+  @Test
   @DisplayName("complete: 실행 중이면 완료 상태와 종료 시각을 저장한다")
   void completesExecutionWhenRunning() {
     WorkflowExecution execution = WorkflowExecution.create(1L);

--- a/backend/src/test/java/com/init/workflowruntime/domain/WorkflowExecutionTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/domain/WorkflowExecutionTest.java
@@ -62,6 +62,26 @@ class WorkflowExecutionTest {
   }
 
   @Test
+  @DisplayName("replacePolicySnapshotJson: null은 빈 JSON object로 저장한다")
+  void replacesPolicySnapshotWithEmptyJsonWhenValueIsNull() {
+    WorkflowExecution execution = WorkflowExecution.create(1L);
+
+    execution.replacePolicySnapshotJson(null);
+
+    assertThat(execution.getPolicySnapshotJson()).isEqualTo("{}");
+  }
+
+  @Test
+  @DisplayName("replaceRiskSnapshotJson: null은 빈 JSON object로 저장한다")
+  void replacesRiskSnapshotWithEmptyJsonWhenValueIsNull() {
+    WorkflowExecution execution = WorkflowExecution.create(1L);
+
+    execution.replaceRiskSnapshotJson(null);
+
+    assertThat(execution.getRiskSnapshotJson()).isEqualTo("{}");
+  }
+
+  @Test
   @DisplayName("assignIntentWorkflow: 실행 중이면 intent/workflow/currentState를 저장한다")
   void should_assignIntentWorkflow_when_running() {
     WorkflowExecution execution = WorkflowExecution.create(1L);
@@ -72,6 +92,69 @@ class WorkflowExecutionTest {
     assertThat(execution.getWorkflowDefinitionId()).isEqualTo(20L);
     assertThat(execution.getCurrentState()).isEqualTo("start");
     assertThat(execution.getStatus()).isEqualTo(WorkflowExecution.STATUS_RUNNING);
+  }
+
+  @Test
+  @DisplayName("moveToState: 실행 중이면 currentState를 변경한다")
+  void movesToStateWhenRunning() {
+    WorkflowExecution execution = WorkflowExecution.create(1L);
+    execution.assignIntentWorkflow(10L, 20L, "start");
+
+    execution.moveToState("confirm");
+
+    assertThat(execution.getCurrentState()).isEqualTo("confirm");
+  }
+
+  @Test
+  @DisplayName("moveToState: 완료된 실행이면 currentState를 변경하지 않는다")
+  void throwsWhenMovingCompletedExecution() {
+    WorkflowExecution execution = WorkflowExecution.create(1L);
+    execution.assignIntentWorkflow(10L, 20L, "start");
+    execution.complete();
+
+    assertThatExceptionOfType(BadRequestException.class)
+        .isThrownBy(() -> execution.moveToState("confirm"))
+        .withMessageContaining("terminal execution");
+
+    assertThat(execution.getCurrentState()).isEqualTo("start");
+  }
+
+  @Test
+  @DisplayName("complete: 실행 중이면 완료 상태와 종료 시각을 저장한다")
+  void completesExecutionWhenRunning() {
+    WorkflowExecution execution = WorkflowExecution.create(1L);
+
+    execution.complete();
+
+    assertThat(execution.getStatus()).isEqualTo(WorkflowExecution.STATUS_COMPLETED);
+    assertThat(execution.getFinishedAt()).isNotNull();
+  }
+
+  @Test
+  @DisplayName("complete: 이미 완료된 실행이면 상태를 유지한다")
+  void keepsCompletedExecutionWhenAlreadyCompleted() {
+    WorkflowExecution execution = WorkflowExecution.create(1L);
+    execution.complete();
+    OffsetDateTime firstFinishedAt = execution.getFinishedAt();
+
+    execution.complete();
+
+    assertThat(execution.getStatus()).isEqualTo(WorkflowExecution.STATUS_COMPLETED);
+    assertThat(execution.getFinishedAt()).isEqualTo(firstFinishedAt);
+  }
+
+  @Test
+  @DisplayName("complete: 실패한 실행이면 완료로 변경하지 않는다")
+  void throwsWhenCompletingFailedExecution() {
+    WorkflowExecution execution = WorkflowExecution.create(1L);
+    ReflectionTestUtils.setField(execution, "status", WorkflowExecution.STATUS_FAILED);
+
+    assertThatExceptionOfType(BadRequestException.class)
+        .isThrownBy(execution::complete)
+        .withMessageContaining("Cannot complete failed execution");
+
+    assertThat(execution.getStatus()).isEqualTo(WorkflowExecution.STATUS_FAILED);
+    assertThat(execution.getFinishedAt()).isNull();
   }
 
   @Test

--- a/backend/src/test/java/com/init/workflowruntime/domain/WorkflowExecutionTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/domain/WorkflowExecutionTest.java
@@ -63,7 +63,7 @@ class WorkflowExecutionTest {
 
   @Test
   @DisplayName("replacePolicySnapshotJson: null은 빈 JSON object로 저장한다")
-  void replacesPolicySnapshotWithEmptyJsonWhenValueIsNull() {
+  void should_replacePolicySnapshotWithEmptyJson_when_valueIsNull() {
     WorkflowExecution execution = WorkflowExecution.create(1L);
 
     execution.replacePolicySnapshotJson(null);
@@ -73,7 +73,7 @@ class WorkflowExecutionTest {
 
   @Test
   @DisplayName("replaceRiskSnapshotJson: null은 빈 JSON object로 저장한다")
-  void replacesRiskSnapshotWithEmptyJsonWhenValueIsNull() {
+  void should_replaceRiskSnapshotWithEmptyJson_when_valueIsNull() {
     WorkflowExecution execution = WorkflowExecution.create(1L);
 
     execution.replaceRiskSnapshotJson(null);
@@ -96,7 +96,7 @@ class WorkflowExecutionTest {
 
   @Test
   @DisplayName("moveToState: 실행 중이면 currentState를 변경한다")
-  void movesToStateWhenRunning() {
+  void should_moveToState_when_running() {
     WorkflowExecution execution = WorkflowExecution.create(1L);
     execution.assignIntentWorkflow(10L, 20L, "start");
 
@@ -107,7 +107,7 @@ class WorkflowExecutionTest {
 
   @Test
   @DisplayName("moveToState: 완료된 실행이면 currentState를 변경하지 않는다")
-  void throwsWhenMovingCompletedExecution() {
+  void should_throw_when_movingCompletedExecution() {
     WorkflowExecution execution = WorkflowExecution.create(1L);
     execution.assignIntentWorkflow(10L, 20L, "start");
     execution.complete();
@@ -121,7 +121,7 @@ class WorkflowExecutionTest {
 
   @Test
   @DisplayName("moveToState: 공백 state는 허용하지 않는다")
-  void throwsWhenMovingToBlankState() {
+  void should_throw_when_movingToBlankState() {
     WorkflowExecution execution = WorkflowExecution.create(1L);
     execution.assignIntentWorkflow(10L, 20L, "start");
 
@@ -134,7 +134,7 @@ class WorkflowExecutionTest {
 
   @Test
   @DisplayName("complete: 실행 중이면 완료 상태와 종료 시각을 저장한다")
-  void completesExecutionWhenRunning() {
+  void should_completeExecution_when_running() {
     WorkflowExecution execution = WorkflowExecution.create(1L);
 
     execution.complete();
@@ -145,7 +145,7 @@ class WorkflowExecutionTest {
 
   @Test
   @DisplayName("complete: 이미 완료된 실행이면 상태를 유지한다")
-  void keepsCompletedExecutionWhenAlreadyCompleted() {
+  void should_keepCompletedExecution_when_alreadyCompleted() {
     WorkflowExecution execution = WorkflowExecution.create(1L);
     execution.complete();
     OffsetDateTime firstFinishedAt = execution.getFinishedAt();
@@ -158,7 +158,7 @@ class WorkflowExecutionTest {
 
   @Test
   @DisplayName("complete: 실패한 실행이면 완료로 변경하지 않는다")
-  void throwsWhenCompletingFailedExecution() {
+  void should_throw_when_completingFailedExecution() {
     WorkflowExecution execution = WorkflowExecution.create(1L);
     ReflectionTestUtils.setField(execution, "status", WorkflowExecution.STATUS_FAILED);
 

--- a/backend/src/test/java/com/init/workflowruntime/presentation/LlmToolControllerSecurityTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/presentation/LlmToolControllerSecurityTest.java
@@ -87,6 +87,8 @@ class LlmToolControllerSecurityTest {
                 null,
                 null,
                 objectMapper.readTree("{}"),
+                objectMapper.readTree("{\"hits\":[]}"),
+                null,
                 List.of(),
                 List.of()));
 

--- a/backend/src/test/java/com/init/workflowruntime/presentation/LlmToolControllerTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/presentation/LlmToolControllerTest.java
@@ -22,6 +22,7 @@ import com.init.workflowruntime.application.command.UpsertLlmToolSlotValueComman
 import com.init.workflowruntime.application.dto.LlmToolContextResponse;
 import com.init.workflowruntime.application.dto.LlmToolIntentResponse;
 import com.init.workflowruntime.application.dto.LlmToolIntentSelectionResponse;
+import com.init.workflowruntime.application.dto.LlmToolPolicyContextResponse;
 import com.init.workflowruntime.application.dto.LlmToolSlotResponse;
 import com.init.workflowruntime.application.dto.LlmToolSlotValueResponse;
 import com.init.workflowruntime.application.dto.LlmToolWorkflowResponse;
@@ -131,6 +132,8 @@ class LlmToolControllerTest {
                 "RUNNING",
                 "collect_slots",
                 objectMapper.readTree("{\"order_id\":\"A-100\"}"),
+                objectMapper.readTree("{\"hits\":[]}"),
+                null,
                 List.of("customer_name"),
                 List.of(slotResponse("order_id", true))));
 
@@ -142,6 +145,27 @@ class LlmToolControllerTest {
         .andExpect(jsonPath("$.slotValues.order_id").value("A-100"))
         .andExpect(jsonPath("$.missingSlots[0]").value("customer_name"))
         .andExpect(jsonPath("$.slots[0].slotCode").value("order_id"));
+  }
+
+  @Test
+  @DisplayName("GET /api/v1/llm-tools/sessions/{sessionId}/policy-context → 200 OK")
+  void should_returnPolicyContext_when_validRequest() throws Exception {
+    given(llmToolService.getPolicyContext(1L))
+        .willReturn(
+            new LlmToolPolicyContextResponse(
+                1L,
+                50L,
+                "confirm_cancel",
+                objectMapper.readTree(
+                    "{\"hits\":[{\"policyCode\":\"cancel_policy\",\"nodeId\":\"confirm_cancel\"}]}"),
+                null));
+
+    mockMvc
+        .perform(get("/api/v1/llm-tools/sessions/1/policy-context"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.sessionId").value(1))
+        .andExpect(jsonPath("$.currentState").value("confirm_cancel"))
+        .andExpect(jsonPath("$.policySnapshot.hits[0].policyCode").value("cancel_policy"));
   }
 
   @Test

--- a/backend/src/test/java/com/init/workflowruntime/presentation/LlmToolControllerTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/presentation/LlmToolControllerTest.java
@@ -14,6 +14,7 @@ import com.init.shared.infrastructure.security.JwtAuthenticationFilter;
 import com.init.workflowruntime.application.LlmToolService;
 import com.init.workflowruntime.application.command.GetCurrentWorkflowCommand;
 import com.init.workflowruntime.application.command.GetLlmToolContextCommand;
+import com.init.workflowruntime.application.command.GetLlmToolPolicyContextCommand;
 import com.init.workflowruntime.application.command.GetLlmToolSlotCommand;
 import com.init.workflowruntime.application.command.ListLlmToolIntentsCommand;
 import com.init.workflowruntime.application.command.ListLlmToolSlotsCommand;
@@ -150,7 +151,7 @@ class LlmToolControllerTest {
   @Test
   @DisplayName("GET /api/v1/llm-tools/sessions/{sessionId}/policy-context → 200 OK")
   void should_returnPolicyContext_when_validRequest() throws Exception {
-    given(llmToolService.getPolicyContext(1L))
+    given(llmToolService.getPolicyContext(new GetLlmToolPolicyContextCommand(1L)))
         .willReturn(
             new LlmToolPolicyContextResponse(
                 1L,

--- a/backend/src/test/java/com/init/workflowruntime/presentation/WorkflowRuntimeControllerTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/presentation/WorkflowRuntimeControllerTest.java
@@ -1,0 +1,117 @@
+package com.init.workflowruntime.presentation;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.init.shared.infrastructure.security.JwtAuthenticationFilter;
+import com.init.workflowruntime.application.WorkflowRuntimeService;
+import com.init.workflowruntime.application.dto.LlmToolPolicyResponse;
+import com.init.workflowruntime.application.dto.WorkflowAdvanceResponse;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(
+    value = WorkflowRuntimeController.class,
+    excludeFilters =
+        @ComponentScan.Filter(
+            type = FilterType.ASSIGNABLE_TYPE,
+            classes = JwtAuthenticationFilter.class))
+@AutoConfigureMockMvc(addFilters = false)
+@DisplayName("WorkflowRuntimeController")
+class WorkflowRuntimeControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @Autowired private ObjectMapper objectMapper;
+
+  @MockitoBean private WorkflowRuntimeService workflowRuntimeService;
+
+  @Test
+  @DisplayName("POST /api/v1/workflow-runtime/sessions/{sessionId}/advance → 200 OK")
+  void should_advanceWorkflow_when_validRequest() throws Exception {
+    given(workflowRuntimeService.advance(1L))
+        .willReturn(
+            new WorkflowAdvanceResponse(
+                1L,
+                50L,
+                "RUNNING",
+                "collect_reservation_no",
+                "collect_reservation_no",
+                "ACTION",
+                "ASK_SLOT",
+                null,
+                "collect_reservation_no",
+                List.of("reservation_no"),
+                objectMapper.readTree("null"),
+                objectMapper.readTree("{}"),
+                null,
+                null,
+                "required slot values are missing"));
+
+    mockMvc
+        .perform(post("/api/v1/workflow-runtime/sessions/1/advance"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.sessionId").value(1))
+        .andExpect(jsonPath("$.actionType").value("ASK_SLOT"))
+        .andExpect(jsonPath("$.missingSlotCodes[0]").value("reservation_no"));
+  }
+
+  @Test
+  @DisplayName("POST /advance → policy_hit 전이 근거를 transitionPolicy로 반환한다")
+  void should_returnTransitionPolicy_when_policyHitEdgeMatched() throws Exception {
+    LlmToolPolicyResponse transitionPolicy =
+        new LlmToolPolicyResponse(
+            300L,
+            "cancel_deadline_policy",
+            "취소 마감 정책",
+            "체크인 24시간 이내 취소는 상담사 확인이 필요하다.",
+            "HIGH",
+            objectMapper.createObjectNode(),
+            objectMapper.createObjectNode(),
+            objectMapper.createArrayNode(),
+            objectMapper.createObjectNode(),
+            "ACTIVE",
+            "confirm_cancel_policy",
+            true,
+            List.of(),
+            "policy condition matched");
+
+    given(workflowRuntimeService.advance(1L))
+        .willReturn(
+            new WorkflowAdvanceResponse(
+                1L,
+                50L,
+                "RUNNING",
+                "confirm_cancel_policy",
+                "handoff",
+                "HANDOFF",
+                "HANDOFF",
+                "e_policy_handoff",
+                "handoff",
+                List.of(),
+                objectMapper.readTree(
+                    "{\"type\":\"policy_hit\",\"policyCode\":\"cancel_deadline_policy\"}"),
+                objectMapper.readTree("{}"),
+                transitionPolicy,
+                null,
+                "transitioned from confirm_cancel_policy to handoff"));
+
+    mockMvc
+        .perform(post("/api/v1/workflow-runtime/sessions/1/advance"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.actionType").value("HANDOFF"))
+        .andExpect(jsonPath("$.condition.type").value("policy_hit"))
+        .andExpect(jsonPath("$.transitionPolicy.policyCode").value("cancel_deadline_policy"));
+  }
+}

--- a/integrations/llm-tools/README.md
+++ b/integrations/llm-tools/README.md
@@ -7,11 +7,13 @@
 ```text
 GET /api/v1/llm-tools/sessions/{sessionId}/workflow
 GET /api/v1/llm-tools/sessions/{sessionId}/context
+GET /api/v1/llm-tools/sessions/{sessionId}/policy-context
 GET /api/v1/llm-tools/sessions/{sessionId}/intents
 POST /api/v1/llm-tools/sessions/{sessionId}/intent-selection
 GET /api/v1/llm-tools/sessions/{sessionId}/slots
 GET /api/v1/llm-tools/sessions/{sessionId}/slots/{slotCode}
 PUT /api/v1/llm-tools/sessions/{sessionId}/slots/{slotCode}
+POST /api/v1/workflow-runtime/sessions/{sessionId}/advance
 ```
 
 ## Usage
@@ -41,6 +43,8 @@ const toolResult = await handleToolCall(toolCall);
 | --- | --- |
 | `get_current_workflow` | 현재 세션에 묶인 워크플로우 그래프와 현재 실행 상태(state, status) 조회 |
 | `get_current_slot_context` | 현재 세션의 전체 slot context, missing slot 목록, 저장된 값을 조회 |
+| `get_current_policy_context` | 현재 node 기준 policy snapshot과 정책 판단 결과 조회 |
+| `advance_current_workflow` | 현재 state, slot, policy 기준으로 다음 workflow action/state 계산 |
 | `list_current_intents` | 현재 세션 domain pack version에 등록된 intent 목록 조회 |
 | `select_current_intent` | 목록에서 선택한 `intentCode`로 workflow execution을 시작하고 필수 slot 누락 여부 조회 |
 | `list_current_slots` | 현재 세션의 active slot 목록 조회 |

--- a/integrations/llm-tools/llm-tool-adapter.mjs
+++ b/integrations/llm-tools/llm-tool-adapter.mjs
@@ -25,8 +25,18 @@ export function createLlmSlotToolHandler({
       case LLM_WORKFLOW_TOOL_NAMES.getCurrentWorkflow:
         return wrapToolResult(toolCall, name, await requestJson("/workflow"));
 
+      case LLM_WORKFLOW_TOOL_NAMES.advanceWorkflow:
+        return wrapToolResult(
+          toolCall,
+          name,
+          await requestRuntimeJson("/advance", { method: "POST" }),
+        );
+
       case LLM_SLOT_TOOL_NAMES.getContext:
         return wrapToolResult(toolCall, name, await requestJson("/context"));
+
+      case LLM_SLOT_TOOL_NAMES.getPolicyContext:
+        return wrapToolResult(toolCall, name, await requestJson("/policy-context"));
 
       case LLM_SLOT_TOOL_NAMES.listIntents:
         return wrapToolResult(toolCall, name, await requestJson("/intents"));
@@ -77,6 +87,15 @@ export function createLlmSlotToolHandler({
 
   async function requestJson(path, { method = "GET", body } = {}) {
     const url = buildToolUrl(backendBaseUrl, sessionId, path);
+    return requestBackendJson(url, { method, body });
+  }
+
+  async function requestRuntimeJson(path, { method = "GET", body } = {}) {
+    const url = buildRuntimeUrl(backendBaseUrl, sessionId, path);
+    return requestBackendJson(url, { method, body });
+  }
+
+  async function requestBackendJson(url, { method = "GET", body } = {}) {
     const headers = {
       Accept: "application/json",
     };
@@ -124,6 +143,14 @@ export function buildToolUrl(backendBaseUrl, sessionId, path) {
   const normalizedPath = path ? (path.startsWith("/") ? path : `/${path}`) : "";
   const relativePath =
     `api/v1/llm-tools/sessions/${encodeURIComponent(sessionId)}${normalizedPath}`;
+  return new URL(relativePath, baseUrl).toString();
+}
+
+export function buildRuntimeUrl(backendBaseUrl, sessionId, path) {
+  const baseUrl = backendBaseUrl.endsWith("/") ? backendBaseUrl : `${backendBaseUrl}/`;
+  const normalizedPath = path ? (path.startsWith("/") ? path : `/${path}`) : "";
+  const relativePath =
+    `api/v1/workflow-runtime/sessions/${encodeURIComponent(sessionId)}${normalizedPath}`;
   return new URL(relativePath, baseUrl).toString();
 }
 

--- a/integrations/llm-tools/llm-tool-adapter.test.mjs
+++ b/integrations/llm-tools/llm-tool-adapter.test.mjs
@@ -4,6 +4,7 @@ import { describe, it } from "node:test";
 import {
   LLM_SLOT_TOOL_NAMES,
   LLM_WORKFLOW_TOOL_NAMES,
+  buildRuntimeUrl,
   buildToolUrl,
   createLlmSlotToolHandler,
   llmSlotTools,
@@ -99,6 +100,13 @@ describe("llm slot tools", () => {
     );
   });
 
+  it("builds backend workflow-runtime URLs", () => {
+    assert.equal(
+      buildRuntimeUrl("http://localhost:8080", 7, "/advance"),
+      "http://localhost:8080/api/v1/workflow-runtime/sessions/7/advance",
+    );
+  });
+
   it("maps get_current_slot tool calls to the backend slot endpoint", async () => {
     const requests = [];
     const handler = createLlmSlotToolHandler({
@@ -182,6 +190,60 @@ describe("llm slot tools", () => {
     assert.equal(requests[0].url, "http://localhost:8080/api/v1/llm-tools/sessions/7/intents");
     assert.equal(requests[0].init.method, "GET");
     assert.deepEqual(result.result, [{ intentCode: "request_refund" }]);
+  });
+
+  it("maps get_current_policy_context tool calls to the backend policy context endpoint", async () => {
+    const requests = [];
+    const handler = createLlmSlotToolHandler({
+      backendBaseUrl: "http://localhost:8080",
+      sessionId: 7,
+      fetchImpl: async (url, init) => {
+        requests.push({ url, init });
+        return {
+          ok: true,
+          status: 200,
+          text: async () => "{\"currentState\":\"confirm_cancel\",\"currentPolicy\":null}",
+        };
+      },
+    });
+
+    await handler({
+      name: LLM_SLOT_TOOL_NAMES.getPolicyContext,
+      arguments: {},
+    });
+
+    assert.equal(
+      requests[0].url,
+      "http://localhost:8080/api/v1/llm-tools/sessions/7/policy-context",
+    );
+    assert.equal(requests[0].init.method, "GET");
+  });
+
+  it("maps advance_current_workflow tool calls to the backend runtime endpoint", async () => {
+    const requests = [];
+    const handler = createLlmSlotToolHandler({
+      backendBaseUrl: "http://localhost:8080",
+      sessionId: 7,
+      fetchImpl: async (url, init) => {
+        requests.push({ url, init });
+        return {
+          ok: true,
+          status: 200,
+          text: async () => "{\"actionType\":\"ASK_SLOT\"}",
+        };
+      },
+    });
+
+    await handler({
+      name: LLM_WORKFLOW_TOOL_NAMES.advanceWorkflow,
+      arguments: {},
+    });
+
+    assert.equal(
+      requests[0].url,
+      "http://localhost:8080/api/v1/workflow-runtime/sessions/7/advance",
+    );
+    assert.equal(requests[0].init.method, "POST");
   });
 
   it("maps select_current_intent tool calls to POST with intentCode body", async () => {

--- a/integrations/llm-tools/tool-schema.mjs
+++ b/integrations/llm-tools/tool-schema.mjs
@@ -1,5 +1,6 @@
 export const LLM_WORKFLOW_TOOL_NAMES = Object.freeze({
   getCurrentWorkflow: "get_current_workflow",
+  advanceWorkflow: "advance_current_workflow",
 });
 
 export const LLM_SLOT_TOOL_NAMES = Object.freeze({
@@ -9,6 +10,7 @@ export const LLM_SLOT_TOOL_NAMES = Object.freeze({
   upsertSlotValue: "upsert_current_slot_value",
   listIntents: "list_current_intents",
   selectIntent: "select_current_intent",
+  getPolicyContext: "get_current_policy_context",
 });
 
 const emptyParameters = Object.freeze({
@@ -96,6 +98,24 @@ export const llmSlotTools = Object.freeze([
       name: LLM_WORKFLOW_TOOL_NAMES.getCurrentWorkflow,
       description:
         "현재 상담 세션에 묶인 결정론적 워크플로우 그래프와 현재 실행 상태(state, status)를 조회한다.",
+      parameters: emptyParameters,
+    }),
+  }),
+  Object.freeze({
+    type: "function",
+    function: Object.freeze({
+      name: LLM_SLOT_TOOL_NAMES.getPolicyContext,
+      description:
+        "현재 workflow node에 연결된 정책 평가 결과와 policy snapshot을 조회한다.",
+      parameters: emptyParameters,
+    }),
+  }),
+  Object.freeze({
+    type: "function",
+    function: Object.freeze({
+      name: LLM_WORKFLOW_TOOL_NAMES.advanceWorkflow,
+      description:
+        "현재 workflow execution의 state, slot, policy snapshot을 기준으로 다음 action과 state를 계산한다.",
       parameters: emptyParameters,
     }),
   }),


### PR DESCRIPTION
## 개요

524 스펙에 맞춰 외부 LLM이 현재 상담 세션의 intent, slot, policy, workflow runtime 상태를 tool 호출로 조회하고, workflow engine이 현재 state와 slot/policy snapshot을 기준으로 다음 action을 결정하도록 구현했습니다.

특히 `policy_hit` edge로 전이될 때 도착 node의 `currentPolicy`와 별도로, 이번 전이를 유발한 source node 정책을 `transitionPolicy`로 반환하도록 분리했습니다. 이를 통해 LLM은 `handoff` 같은 도착 node에 정책이 직접 붙어 있지 않아도, 왜 이관이 발생했는지 응답 근거로 사용할 수 있습니다.

## 변경사항

### 신규파일

- `backend/src/main/java/com/init/workflowruntime/application/WorkflowConditionEvaluator.java`
- `backend/src/main/java/com/init/workflowruntime/application/WorkflowPolicyRuntimeService.java`
- `backend/src/main/java/com/init/workflowruntime/application/WorkflowRuntimeGraph.java`
- `backend/src/main/java/com/init/workflowruntime/application/WorkflowRuntimeService.java`
- `backend/src/main/java/com/init/workflowruntime/application/dto/LlmToolPolicyContextResponse.java`
- `backend/src/main/java/com/init/workflowruntime/application/dto/LlmToolPolicyResponse.java`
- `backend/src/main/java/com/init/workflowruntime/application/dto/WorkflowAdvanceResponse.java`
- `backend/src/main/java/com/init/workflowruntime/presentation/WorkflowRuntimeController.java`
- `backend/src/test/java/com/init/workflowruntime/application/WorkflowPolicyRuntimeServiceTest.java`
- `backend/src/test/java/com/init/workflowruntime/application/WorkflowRuntimeServiceTest.java`
- `backend/src/test/java/com/init/workflowruntime/presentation/WorkflowRuntimeControllerTest.java`

### 수정된파일

- `.agent/specs/524.md`: `transitionPolicy`를 포함한 runtime/tool 사용 흐름 보강
- `PolicyDefinitionRepository`, `JpaPolicyDefinitionRepository`: policy code 기반 조회 추가
- `SecurityConfig`: `/api/v1/workflow-runtime/**` OPERATOR 권한 보호 추가
- `LlmToolService`, `LlmToolController`: policy context 조회 tool API 추가
- `LlmToolContextResponse`: slot context 응답에 policy snapshot/current policy 포함
- `WorkflowExecution`: runtime state 이동, 완료 처리, snapshot 교체 메서드 추가
- `integrations/llm-tools/*`: `get_current_policy_context`, `advance_current_workflow` tool schema/adapter/테스트 추가
- 관련 backend controller/service/security 테스트 갱신

## 아키텍처

- 외부 LLM은 `integrations/llm-tools/tool-schema.mjs`에 정의된 tool만 호출합니다.
- adapter는 LLM tool call을 backend REST API로 변환하고, `sessionId`는 tool schema에 노출하지 않고 adapter layer에서 주입합니다.
- `LlmToolController`는 intent/slot/policy context 조회를 담당하고, `WorkflowRuntimeController`는 workflow 전이를 담당합니다.
- `WorkflowRuntimeService`는 현재 execution의 `currentState`, `slotValuesJson`, `policySnapshotJson`, `riskSnapshotJson`을 기준으로 현재 node의 outgoing edge를 평가합니다.
- `WorkflowPolicyRuntimeService`는 node의 `policyRef`를 `PolicyDefinition.policyCode`와 연결하고, policy condition을 slot/policy/risk snapshot으로 평가합니다.
- edge 조건은 `WorkflowConditionEvaluator`에서 `always`, `default`, `slot_present`, `slot_missing`, `slot_equals`, `all`, `any`, `policy_hit`, `risk_level_gte` 형태로 결정론적으로 처리합니다.
- 응답 모델은 `currentPolicy`와 `transitionPolicy`를 분리합니다. `currentPolicy`는 이동 후 현재 node 정책이고, `transitionPolicy`는 이번 edge 선택을 유발한 source node 정책입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - POST /api/v1/workflow-runtime/sessions/{id}/advance로 워크플로우 자동 전이 추가
  - GET /api/v1/llm-tools/sessions/{id}/policy-context로 현재 노드 정책 컨텍스트 조회 추가
  - 응답에 transitionPolicy와 currentPolicy 및 정책 스냅샷 포함

- **Documentation**
  - LLM 툴 연동 문서에 policy-context·advance 엔드포인트 및 툴명 추가

- **Tests**
  - 전이·정책 평가·조건 평가 등 단위·통합 테스트 다수 추가/갱신

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ajou-2026-1-capstone-5/ostone/pull/272?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->