### PR TITLE
[5.3.6] FE 채팅 기록 API 연동

### DIFF
--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -56,6 +56,7 @@ export function App() {
           <Route path="workflows" element={<WorkspaceWorkflowsPage />} />
           <Route path="pipeline" element={<Navigate to="upload" replace />} />
           <Route path="consultation/history" element={<ChatHistoryPage />} />
+          <Route path="consultation/history/:sessionId" element={<ChatHistoryPage />} />
           <Route path="consultation" element={<ConsultationPage />} />
           <Route
             path="consultation/:sessionId"

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -4,6 +4,7 @@ import { SignupPage } from "../pages/signup/ui/SignupPage";
 import { WorkspaceRootRedirect } from "../pages/workspace/ui/WorkspaceRootRedirect";
 import { PasswordResetInitPage } from "../pages/password-reset/ui/PasswordResetInitPage";
 import { PasswordResetCompletePage } from "../pages/password-reset/ui/PasswordResetCompletePage";
+import { ChatHistoryPage } from "../pages/consultation/ui/chat-history/ChatHistoryPage";
 import { ConsultationPage } from "../pages/consultation/ui/ConsultationPage";
 import { UserChatPage } from "../pages/user-chat";
 import { NotFoundPage } from "../pages/not-found/ui/NotFoundPage";
@@ -54,6 +55,7 @@ export function App() {
           <Route index element={<Navigate to="workflows" replace />} />
           <Route path="workflows" element={<WorkspaceWorkflowsPage />} />
           <Route path="pipeline" element={<Navigate to="upload" replace />} />
+          <Route path="consultation/history" element={<ChatHistoryPage />} />
           <Route path="consultation" element={<ConsultationPage />} />
           <Route
             path="consultation/:sessionId"

--- a/frontend/src/features/consultation/api/chatHistoryApi.test.ts
+++ b/frontend/src/features/consultation/api/chatHistoryApi.test.ts
@@ -10,26 +10,27 @@ vi.mock("./consultationApi", () => ({
   },
 }));
 
+import { ChatSessionResponse, ChatMessageResponse } from "../../../shared/api/generated/zod";
 import { useChatSessions, useChatMessages } from "./chatHistoryApi";
 import { consultationApi } from "./consultationApi";
 
 const mockedGetSessions = vi.mocked(consultationApi.getSessions);
 const mockedGetMessages = vi.mocked(consultationApi.getMessages);
 
-const stubSession = {
+const stubSession: ChatSessionResponse = {
   id: 1,
-  title: "테스트 상담 세션",
-  customerName: "홍길동",
-  status: "ACTIVE",
-  createdAt: "2025-01-01T00:00:00Z",
-  updatedAt: "2025-01-01T00:00:00Z",
+  status: "COMPLETED",
+  channel: "KAKAO",
+  metaJson: null,
+  startedAt: "2025-01-01T00:00:00Z",
 };
 
-const stubMessage = {
+const stubMessage: ChatMessageResponse = {
   id: 1,
-  sessionId: 1,
+  seqNo: 1,
+  senderRole: "CUSTOMER",
+  messageType: "TEXT",
   content: "안녕하세요",
-  role: "USER" as const,
   createdAt: "2025-01-01T00:00:00Z",
 };
 
@@ -48,7 +49,7 @@ describe("useChatSessions", () => {
   });
 
   it("세션 목록을 조회한다", async () => {
-    mockedGetSessions.mockResolvedValue([stubSession as any]);
+    mockedGetSessions.mockResolvedValue([stubSession]);
 
     const { result } = renderHook(
       () =>
@@ -63,7 +64,7 @@ describe("useChatSessions", () => {
   });
 
   it("상태 필터로 세션 목록을 조회한다", async () => {
-    mockedGetSessions.mockResolvedValue([stubSession as any]);
+    mockedGetSessions.mockResolvedValue([stubSession]);
 
     const { result } = renderHook(
       () =>
@@ -87,7 +88,7 @@ describe("useChatMessages", () => {
   });
 
   it("sessionId가 있으면 메시지 목록을 조회한다", async () => {
-    mockedGetMessages.mockResolvedValue([stubMessage as any]);
+    mockedGetMessages.mockResolvedValue([stubMessage]);
 
     const { result } = renderHook(() => useChatMessages("1"), { wrapper: makeWrapper() });
 
@@ -103,7 +104,7 @@ describe("useChatMessages", () => {
   });
 
   it("페이지를 지정해서 메시지 목록을 조회한다", async () => {
-    mockedGetMessages.mockResolvedValue([stubMessage as any]);
+    mockedGetMessages.mockResolvedValue([stubMessage]);
 
     const { result } = renderHook(() => useChatMessages("1", 2, 30), { wrapper: makeWrapper() });
 

--- a/frontend/src/features/consultation/api/chatHistoryApi.test.ts
+++ b/frontend/src/features/consultation/api/chatHistoryApi.test.ts
@@ -1,0 +1,113 @@
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./consultationApi", () => ({
+  consultationApi: {
+    getSessions: vi.fn(),
+    getMessages: vi.fn(),
+  },
+}));
+
+import { useChatSessions, useChatMessages } from "./chatHistoryApi";
+import { consultationApi } from "./consultationApi";
+
+const mockedGetSessions = vi.mocked(consultationApi.getSessions);
+const mockedGetMessages = vi.mocked(consultationApi.getMessages);
+
+const stubSession = {
+  id: 1,
+  title: "테스트 상담 세션",
+  customerName: "홍길동",
+  status: "ACTIVE",
+  createdAt: "2025-01-01T00:00:00Z",
+  updatedAt: "2025-01-01T00:00:00Z",
+};
+
+const stubMessage = {
+  id: 1,
+  sessionId: 1,
+  content: "안녕하세요",
+  role: "USER" as const,
+  createdAt: "2025-01-01T00:00:00Z",
+};
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+describe("useChatSessions", () => {
+  beforeEach(() => {
+    mockedGetSessions.mockReset();
+  });
+
+  it("세션 목록을 조회한다", async () => {
+    mockedGetSessions.mockResolvedValue([stubSession as any]);
+
+    const { result } = renderHook(
+      () =>
+        useChatSessions({
+          workspaceId: "ws-1",
+        }),
+      { wrapper: makeWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.data).toEqual([stubSession]));
+    expect(mockedGetSessions).toHaveBeenCalledWith({ status: undefined, page: 0, size: 20 });
+  });
+
+  it("상태 필터로 세션 목록을 조회한다", async () => {
+    mockedGetSessions.mockResolvedValue([stubSession as any]);
+
+    const { result } = renderHook(
+      () =>
+        useChatSessions({
+          workspaceId: "ws-1",
+          status: "COMPLETED",
+          page: 1,
+          size: 10,
+        }),
+      { wrapper: makeWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.data).toEqual([stubSession]));
+    expect(mockedGetSessions).toHaveBeenCalledWith({ status: "COMPLETED", page: 1, size: 10 });
+  });
+});
+
+describe("useChatMessages", () => {
+  beforeEach(() => {
+    mockedGetMessages.mockReset();
+  });
+
+  it("sessionId가 있으면 메시지 목록을 조회한다", async () => {
+    mockedGetMessages.mockResolvedValue([stubMessage as any]);
+
+    const { result } = renderHook(() => useChatMessages("1"), { wrapper: makeWrapper() });
+
+    await waitFor(() => expect(result.current.data).toEqual([stubMessage]));
+    expect(mockedGetMessages).toHaveBeenCalledWith(1, { page: 0, size: 50 });
+  });
+
+  it("sessionId가 없으면 쿼리를 활성화하지 않는다", async () => {
+    const { result } = renderHook(() => useChatMessages(""), { wrapper: makeWrapper() });
+
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(mockedGetMessages).not.toHaveBeenCalled();
+  });
+
+  it("페이지를 지정해서 메시지 목록을 조회한다", async () => {
+    mockedGetMessages.mockResolvedValue([stubMessage as any]);
+
+    const { result } = renderHook(() => useChatMessages("1", 2, 30), { wrapper: makeWrapper() });
+
+    await waitFor(() => expect(result.current.data).toEqual([stubMessage]));
+    expect(mockedGetMessages).toHaveBeenCalledWith(1, { page: 2, size: 30 });
+  });
+});

--- a/frontend/src/features/consultation/api/chatHistoryApi.ts
+++ b/frontend/src/features/consultation/api/chatHistoryApi.ts
@@ -11,14 +11,14 @@ export interface UseChatSessionsParams {
 
 export function useChatSessions({ workspaceId, status, page = 0, size = 20 }: UseChatSessionsParams) {
   return useQuery({
-    queryKey: chatHistoryKeys.sessionList(workspaceId, status, page),
+    queryKey: chatHistoryKeys.sessionList(workspaceId, status, page, size),
     queryFn: () => consultationApi.getSessions({ status, page, size }),
   });
 }
 
 export function useChatMessages(sessionId: string, page: number = 0, size: number = 50) {
   return useQuery({
-    queryKey: chatHistoryKeys.messages(sessionId, page),
+    queryKey: chatHistoryKeys.messages(sessionId, page, size),
     queryFn: () => consultationApi.getMessages(Number(sessionId), { page, size }),
     enabled: !!sessionId,
   });

--- a/frontend/src/features/consultation/api/chatHistoryApi.ts
+++ b/frontend/src/features/consultation/api/chatHistoryApi.ts
@@ -17,9 +17,12 @@ export function useChatSessions({ workspaceId, status, page = 0, size = 20 }: Us
 }
 
 export function useChatMessages(sessionId: string, page: number = 0, size: number = 50) {
+  const parsedSessionId = Number(sessionId);
+  const hasValidSessionId = Number.isSafeInteger(parsedSessionId) && parsedSessionId > 0;
+
   return useQuery({
     queryKey: chatHistoryKeys.messages(sessionId, page, size),
-    queryFn: () => consultationApi.getMessages(Number(sessionId), { page, size }),
-    enabled: !!sessionId,
+    queryFn: () => consultationApi.getMessages(parsedSessionId, { page, size }),
+    enabled: hasValidSessionId,
   });
 }

--- a/frontend/src/features/consultation/api/chatHistoryApi.ts
+++ b/frontend/src/features/consultation/api/chatHistoryApi.ts
@@ -1,0 +1,25 @@
+import { useQuery } from "@tanstack/react-query";
+import { consultationApi } from "./consultationApi";
+import { chatHistoryKeys } from "./chatHistoryKeys";
+
+export interface UseChatSessionsParams {
+  workspaceId: string;
+  status?: string;
+  page?: number;
+  size?: number;
+}
+
+export function useChatSessions({ workspaceId, status, page = 0, size = 20 }: UseChatSessionsParams) {
+  return useQuery({
+    queryKey: chatHistoryKeys.sessionList(workspaceId, status, page),
+    queryFn: () => consultationApi.getSessions({ status, page, size }),
+  });
+}
+
+export function useChatMessages(sessionId: string, page: number = 0, size: number = 50) {
+  return useQuery({
+    queryKey: chatHistoryKeys.messages(sessionId, page),
+    queryFn: () => consultationApi.getMessages(Number(sessionId), { page, size }),
+    enabled: !!sessionId,
+  });
+}

--- a/frontend/src/features/consultation/api/chatHistoryKeys.ts
+++ b/frontend/src/features/consultation/api/chatHistoryKeys.ts
@@ -1,0 +1,7 @@
+export const chatHistoryKeys = {
+  all: ["chat-history"] as const,
+  sessionList: (workspaceId: string, status?: string, page?: number) =>
+    ["chat-history", "session-list", workspaceId, status ?? "all", page ?? 0] as const,
+  messages: (sessionId: string, page?: number) =>
+    ["chat-history", "messages", sessionId, page ?? 0] as const,
+};

--- a/frontend/src/features/consultation/api/chatHistoryKeys.ts
+++ b/frontend/src/features/consultation/api/chatHistoryKeys.ts
@@ -1,7 +1,7 @@
 export const chatHistoryKeys = {
   all: ["chat-history"] as const,
-  sessionList: (workspaceId: string, status?: string, page?: number) =>
-    ["chat-history", "session-list", workspaceId, status ?? "all", page ?? 0] as const,
-  messages: (sessionId: string, page?: number) =>
-    ["chat-history", "messages", sessionId, page ?? 0] as const,
+  sessionList: (workspaceId: string, status?: string, page?: number, size?: number) =>
+    ["chat-history", "session-list", workspaceId, status ?? "all", page ?? 0, size ?? 20] as const,
+  messages: (sessionId: string, page?: number, size?: number) =>
+    ["chat-history", "messages", sessionId, page ?? 0, size ?? 50] as const,
 };

--- a/frontend/src/features/consultation/api/consultationApi.test.ts
+++ b/frontend/src/features/consultation/api/consultationApi.test.ts
@@ -5,19 +5,29 @@ import {
   getMessages,
   sendMessage,
   updateStatus,
+  getGetMessagesUrl,
 } from "@/shared/api/generated/endpoints/consultation-controller/consultation-controller";
+import { customFetch } from "@/shared/api/mutator";
+import type { ChatMessageResponse, ChatSessionResponse } from "@/shared/api/generated/zod";
 
 vi.mock("@/shared/api/generated/endpoints/consultation-controller/consultation-controller", () => ({
   getQueue: vi.fn(),
   getMessages: vi.fn(),
   sendMessage: vi.fn(),
   updateStatus: vi.fn(),
+  getGetMessagesUrl: vi.fn((sessionId: number) => `/api/v1/consultation/sessions/${sessionId}/messages`),
+}));
+
+vi.mock("@/shared/api/mutator", () => ({
+  customFetch: vi.fn(),
 }));
 
 const mockedGetQueue = vi.mocked(getQueue);
 const mockedGetMessages = vi.mocked(getMessages);
 const mockedSendMessage = vi.mocked(sendMessage);
 const mockedUpdateStatus = vi.mocked(updateStatus);
+const mockedGetGetMessagesUrl = vi.mocked(getGetMessagesUrl);
+const mockedCustomFetch = vi.mocked(customFetch);
 
 describe("consultationApi", () => {
   beforeEach(() => {
@@ -25,6 +35,7 @@ describe("consultationApi", () => {
     mockedGetMessages.mockClear();
     mockedSendMessage.mockClear();
     mockedUpdateStatus.mockClear();
+    mockedCustomFetch.mockClear();
   });
 
   it("getQueue가 queue 데이터를 반환한다", async () => {
@@ -121,5 +132,81 @@ describe("consultationApi", () => {
 
     expect(mockedUpdateStatus).toHaveBeenCalledWith(1, { status: "COMPLETED" });
     expect(result).toEqual(stubSession);
+  });
+
+  it("getSessions가 모든 세션을 반환한다", async () => {
+    const stubSessions = [
+      {
+        id: 1,
+        status: "OPEN",
+        channel: "카카오톡",
+        metaJson: "{}",
+        startedAt: new Date().toISOString(),
+      },
+    ];
+    mockedCustomFetch.mockResolvedValue({ data: stubSessions, status: 200, headers: new Headers() });
+
+    const result = await consultationApi.getSessions();
+
+    expect(mockedCustomFetch).toHaveBeenCalledWith("/api/v1/consultation/sessions", { method: "GET" });
+    expect(result).toEqual(stubSessions);
+  });
+
+  it("getSessions가 status 필터를 전달한다", async () => {
+    const stubSessions: ChatSessionResponse[] = [];
+    mockedCustomFetch.mockResolvedValue({ data: stubSessions, status: 200, headers: new Headers() });
+
+    await consultationApi.getSessions({ status: "OPEN" });
+
+    expect(mockedCustomFetch).toHaveBeenCalledWith(
+      "/api/v1/consultation/sessions?status=OPEN",
+      { method: "GET" },
+    );
+  });
+
+  it("getSessions가 page/size를 전달한다", async () => {
+    const stubSessions: ChatSessionResponse[] = [];
+    mockedCustomFetch.mockResolvedValue({ data: stubSessions, status: 200, headers: new Headers() });
+
+    await consultationApi.getSessions({ page: 1, size: 20 });
+
+    expect(mockedCustomFetch).toHaveBeenCalledWith(
+      "/api/v1/consultation/sessions?page=1&size=20",
+      { method: "GET" },
+    );
+  });
+
+  it("getMessages가 params 없이 호출되면 generated 함수를 사용한다", async () => {
+    const stubMessages: ChatMessageResponse[] = [];
+    mockedGetMessages.mockResolvedValue({ data: stubMessages, status: 200, headers: new Headers() });
+
+    const result = await consultationApi.getMessages(1);
+
+    expect(mockedGetMessages).toHaveBeenCalledWith(1);
+    expect(mockedCustomFetch).not.toHaveBeenCalled();
+    expect(result).toEqual(stubMessages);
+  });
+
+  it("getMessages가 page/size 파라미터와 함께 호출되면 customFetch를 사용한다", async () => {
+    const stubMessages: ChatMessageResponse[] = [
+      {
+        id: 1,
+        seqNo: 1,
+        senderRole: "AGENT",
+        messageType: "TEXT",
+        content: "안녕하세요",
+        createdAt: new Date().toISOString(),
+      },
+    ];
+    mockedCustomFetch.mockResolvedValue({ data: stubMessages, status: 200, headers: new Headers() });
+
+    const result = await consultationApi.getMessages(1, { page: 0, size: 10 });
+
+    expect(mockedGetGetMessagesUrl).toHaveBeenCalledWith(1);
+    expect(mockedCustomFetch).toHaveBeenCalledWith(
+      "/api/v1/consultation/sessions/1/messages?page=0&size=10",
+      { method: "GET" },
+    );
+    expect(result).toEqual(stubMessages);
   });
 });

--- a/frontend/src/features/consultation/api/consultationApi.ts
+++ b/frontend/src/features/consultation/api/consultationApi.ts
@@ -3,7 +3,9 @@ import {
   getQueue,
   sendMessage,
   updateStatus,
+  getGetMessagesUrl,
 } from "@/shared/api/generated/endpoints/consultation-controller/consultation-controller";
+import { customFetch } from "@/shared/api/mutator";
 import type { ChatMessageResponse, ChatSessionResponse } from "@/shared/api/generated/zod";
 
 export type ChatSession = ChatSessionResponse;
@@ -14,8 +16,33 @@ export const consultationApi = {
     return (await getQueue()).data;
   },
 
-  getMessages: async (sessionId: number): Promise<ChatMessage[]> => {
-    return (await getMessages(sessionId)).data;
+  getSessions: async (params?: {
+    status?: string;
+    page?: number;
+    size?: number;
+  }): Promise<ChatSession[]> => {
+    const searchParams = new URLSearchParams();
+    if (params?.status) searchParams.set("status", params.status);
+    if (params?.page !== undefined) searchParams.set("page", String(params.page));
+    if (params?.size !== undefined) searchParams.set("size", String(params.size));
+    const query = searchParams.toString();
+    const url = `/api/v1/consultation/sessions${query ? `?${query}` : ""}`;
+    return (await customFetch<{ data: ChatSession[]; status: number; headers: Headers }>(url, { method: "GET" })).data;
+  },
+
+  getMessages: async (
+    sessionId: number,
+    params?: { page?: number; size?: number },
+  ): Promise<ChatMessage[]> => {
+    if (!params) {
+      return (await getMessages(sessionId)).data;
+    }
+    const searchParams = new URLSearchParams();
+    if (params.page !== undefined) searchParams.set("page", String(params.page));
+    if (params.size !== undefined) searchParams.set("size", String(params.size));
+    const query = searchParams.toString();
+    const url = `${getGetMessagesUrl(sessionId)}${query ? `?${query}` : ""}`;
+    return (await customFetch<{ data: ChatMessage[]; status: number; headers: Headers }>(url, { method: "GET" })).data;
   },
 
   sendMessage: async (

--- a/frontend/src/features/consultation/ui/chat-history/MessageHistory.module.css
+++ b/frontend/src/features/consultation/ui/chat-history/MessageHistory.module.css
@@ -1,0 +1,168 @@
+.wrapper {
+  height: 100%;
+  min-width: 0;
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  overflow: hidden;
+  background: var(--paper);
+  color: var(--ink);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--s-4);
+  padding: var(--s-4) var(--s-5);
+  border-bottom: 1px solid var(--line);
+  background: var(--paper);
+}
+
+.titleGroup {
+  display: flex;
+  flex-direction: column;
+  gap: var(--s-1);
+}
+
+.title {
+  color: var(--ink);
+  font-family: var(--sans);
+  font-size: 18px;
+  font-weight: 540;
+  letter-spacing: -0.03em;
+}
+
+.count {
+  color: var(--ink-3);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.messageList {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--s-4);
+  overflow-y: auto;
+  padding: var(--s-5);
+  background:
+    radial-gradient(circle at 8% 6%, var(--paper-2) 0, transparent 28%),
+    linear-gradient(180deg, var(--paper) 0%, var(--bg) 100%);
+}
+
+.messageRow {
+  display: flex;
+  width: 100%;
+}
+
+.customerRow {
+  justify-content: flex-start;
+}
+
+.counselorRow {
+  justify-content: flex-end;
+}
+
+.bubble {
+  max-width: min(640px, 72%);
+  display: flex;
+  flex-direction: column;
+  gap: var(--s-3);
+  padding: var(--s-4);
+  border: 1px solid var(--line);
+  color: var(--ink);
+}
+
+.customerBubble {
+  border-radius: var(--r-3) var(--r-3) var(--r-3) var(--r-1);
+  background: var(--paper);
+}
+
+.counselorBubble {
+  border-color: var(--ink);
+  border-radius: var(--r-3) var(--r-3) var(--r-1) var(--r-3);
+  background: var(--paper-2);
+}
+
+.metaLine {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--s-3);
+}
+
+.roleLabel {
+  color: var(--ink);
+  font-family: var(--sans);
+  font-size: 13px;
+  font-weight: 540;
+  letter-spacing: -0.02em;
+}
+
+.content {
+  margin: 0;
+  color: var(--ink);
+  font-family: var(--sans);
+  font-size: 14px;
+  font-weight: 330;
+  letter-spacing: -0.01em;
+  line-height: 1.55;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.timestamp {
+  align-self: flex-end;
+  color: var(--ink-3);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+
+.systemRow {
+  align-self: center;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--s-2);
+  max-width: min(520px, 90%);
+  padding: var(--s-2) var(--s-4);
+  border: 1px solid var(--line);
+  border-radius: var(--r-pill);
+  background: var(--paper);
+}
+
+.systemText {
+  color: var(--ink-3);
+  font-size: 11px;
+}
+
+.stateArea,
+.placeholder {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--s-6);
+  background: var(--paper);
+}
+
+.placeholder {
+  gap: var(--s-3);
+  color: var(--ink-3);
+  font-family: var(--sans);
+  font-size: 14px;
+  letter-spacing: -0.01em;
+}
+
+@media (max-width: 760px) {
+  .messageList {
+    padding: var(--s-4);
+  }
+
+  .bubble {
+    max-width: 88%;
+  }
+}

--- a/frontend/src/features/consultation/ui/chat-history/MessageHistory.tsx
+++ b/frontend/src/features/consultation/ui/chat-history/MessageHistory.tsx
@@ -1,0 +1,119 @@
+import { Dot, EmptyState, ErrorState, Eyebrow, Icon, LoadingSpinner, Mono, Pill } from "@/shared/ui/ostone/atoms";
+import type { ChatMessage } from "../../api/consultationApi";
+import { useChatMessages } from "../../api/chatHistoryApi";
+import styles from "./MessageHistory.module.css";
+
+interface MessageHistoryProps {
+  sessionId?: string | null;
+}
+
+function formatTimestamp(dateStr?: string): string {
+  if (!dateStr) return "시간 없음";
+  return new Date(dateStr).toLocaleString("ko-KR");
+}
+
+function getRoleLabel(senderRole?: string): string {
+  if (senderRole === "AGENT" || senderRole === "COUNSELOR") return "상담사";
+  if (senderRole === "CUSTOMER") return "고객";
+  return "시스템";
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return "메시지를 불러오지 못했습니다";
+}
+
+function MessageBubble({ message }: { message: ChatMessage }) {
+  const roleLabel = getRoleLabel(message.senderRole);
+  const isCounselor = roleLabel === "상담사";
+  const isSystem = roleLabel === "시스템";
+
+  if (isSystem) {
+    return (
+      <div className={styles.systemRow}>
+        <Dot tone="mute" />
+        <Mono className={styles.systemText}>{message.content ?? "내용 없음"}</Mono>
+      </div>
+    );
+  }
+
+  return (
+    <article className={`${styles.messageRow} ${isCounselor ? styles.counselorRow : styles.customerRow}`}>
+      <div className={`${styles.bubble} ${isCounselor ? styles.counselorBubble : styles.customerBubble}`}>
+        <div className={styles.metaLine}>
+          <span className={styles.roleLabel}>{roleLabel}</span>
+          <Pill tone={isCounselor ? "signal" : "mute"}>{message.messageType ?? "TEXT"}</Pill>
+        </div>
+        <p className={styles.content}>{message.content ?? "내용 없음"}</p>
+        <Mono className={styles.timestamp}>{formatTimestamp(message.createdAt)}</Mono>
+      </div>
+    </article>
+  );
+}
+
+export function MessageHistory({ sessionId }: MessageHistoryProps) {
+  const activeSessionId = sessionId ?? "";
+  const { data: messages = [], isLoading, isError, error, refetch } = useChatMessages(activeSessionId);
+
+  if (!activeSessionId) {
+    return (
+      <section className={styles.wrapper} aria-label="채팅 메시지 내역">
+        <div className={styles.placeholder}>
+          <Icon name="msg" size={18} />
+          <span>좌측 목록에서 세션을 선택해주세요</span>
+        </div>
+      </section>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <section className={styles.wrapper} aria-label="채팅 메시지 내역">
+        <Header countText="불러오는 중" />
+        <div className={styles.stateArea}>
+          <LoadingSpinner />
+        </div>
+      </section>
+    );
+  }
+
+  if (isError) {
+    return (
+      <section className={styles.wrapper} aria-label="채팅 메시지 내역">
+        <Header countText="오류" />
+        <div className={styles.stateArea}>
+          <ErrorState message={getErrorMessage(error)} onRetry={() => refetch()} />
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className={styles.wrapper} aria-label="채팅 메시지 내역">
+      <Header countText={`${messages.length}개 메시지`} />
+      {messages.length === 0 ? (
+        <div className={styles.stateArea}>
+          <EmptyState message="아직 메시지가 없습니다" />
+        </div>
+      ) : (
+        <div className={styles.messageList}>
+          {messages.map((message) => (
+            <MessageBubble key={String(message.id ?? message.seqNo)} message={message} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function Header({ countText }: { countText: string }) {
+  return (
+    <div className={styles.header}>
+      <div className={styles.titleGroup}>
+        <Eyebrow>Message history</Eyebrow>
+        <span className={styles.title}>상담 메시지</span>
+      </div>
+      <Mono className={styles.count}>{countText}</Mono>
+    </div>
+  );
+}

--- a/frontend/src/features/consultation/ui/chat-history/SessionCard.module.css
+++ b/frontend/src/features/consultation/ui/chat-history/SessionCard.module.css
@@ -1,0 +1,85 @@
+.card {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: var(--s-3);
+  padding: var(--s-4);
+  border: 1px solid var(--line-2);
+  border-radius: var(--r-3);
+  background: var(--paper);
+  color: var(--ink);
+  cursor: pointer;
+  text-align: left;
+  transition:
+    background 0.15s,
+    border-color 0.15s,
+    transform 0.15s;
+}
+
+.card:hover {
+  border-color: var(--line);
+  background: var(--paper-2);
+  transform: translateY(-1px);
+}
+
+.card:focus-visible {
+  outline: 2px dashed var(--ink);
+  outline-offset: 2px;
+}
+
+.selected {
+  border-color: var(--ink);
+  background: var(--paper-2);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: var(--s-3);
+  min-width: 0;
+}
+
+.titleGroup {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--s-1);
+}
+
+.channelLabel {
+  color: var(--ink-3);
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+}
+
+.channel {
+  overflow: hidden;
+  color: var(--ink);
+  font-family: var(--sans);
+  font-size: 14px;
+  font-weight: 450;
+  letter-spacing: -0.02em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.date {
+  color: var(--ink-3);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+
+.preview {
+  margin: 0;
+  color: var(--ink-3);
+  display: -webkit-box;
+  font-family: var(--sans);
+  font-size: 13px;
+  letter-spacing: -0.01em;
+  line-height: 1.45;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}

--- a/frontend/src/features/consultation/ui/chat-history/SessionCard.tsx
+++ b/frontend/src/features/consultation/ui/chat-history/SessionCard.tsx
@@ -48,18 +48,11 @@ export function SessionCard({ session, isSelected, onSelectSession }: SessionCar
     if (sessionId) onSelectSession(sessionId);
   };
 
-  const handleKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
-    if (event.key !== "Enter" && event.key !== " ") return;
-    event.preventDefault();
-    handleSelect();
-  };
-
   return (
     <button
       type="button"
       className={`${styles.card} ${isSelected ? styles.selected : ""}`}
       onClick={handleSelect}
-      onKeyDown={handleKeyDown}
       aria-pressed={isSelected}
     >
       <div className={styles.header}>

--- a/frontend/src/features/consultation/ui/chat-history/SessionCard.tsx
+++ b/frontend/src/features/consultation/ui/chat-history/SessionCard.tsx
@@ -1,0 +1,77 @@
+import { Avatar, Mono, Pill } from "@/shared/ui/ostone/atoms";
+import type { ChatSession } from "../../api/consultationApi";
+import styles from "./SessionCard.module.css";
+
+type SessionMeta = {
+  messageCount?: number;
+  lastMessagePreview?: string;
+  lastMessage?: string;
+  preview?: string;
+};
+
+interface SessionCardProps {
+  session: ChatSession;
+  isSelected: boolean;
+  onSelectSession: (sessionId: string) => void;
+}
+
+function parseMeta(metaJson?: string): SessionMeta {
+  if (!metaJson) return {};
+
+  try {
+    const meta = JSON.parse(metaJson) as SessionMeta;
+    return meta && typeof meta === "object" ? meta : {};
+  } catch {
+    return {};
+  }
+}
+
+function formatSessionDate(dateStr?: string): string {
+  if (!dateStr) return "날짜 없음";
+  return new Date(dateStr).toLocaleDateString("ko-KR");
+}
+
+function getPreview(meta: SessionMeta): string {
+  return meta.lastMessagePreview ?? meta.lastMessage ?? meta.preview ?? "최근 메시지가 없습니다";
+}
+
+function getMessageCount(meta: SessionMeta): number {
+  return meta.messageCount ?? 0;
+}
+
+export function SessionCard({ session, isSelected, onSelectSession }: SessionCardProps) {
+  const sessionId = String(session.id ?? "");
+  const channel = session.channel ?? "채널 없음";
+  const meta = parseMeta(session.metaJson);
+
+  const handleSelect = () => {
+    if (sessionId) onSelectSession(sessionId);
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (event.key !== "Enter" && event.key !== " ") return;
+    event.preventDefault();
+    handleSelect();
+  };
+
+  return (
+    <button
+      type="button"
+      className={`${styles.card} ${isSelected ? styles.selected : ""}`}
+      onClick={handleSelect}
+      onKeyDown={handleKeyDown}
+      aria-pressed={isSelected}
+    >
+      <div className={styles.header}>
+        <Avatar initial={channel.charAt(0)} tone={isSelected ? "signal" : "mute"} size={32} />
+        <div className={styles.titleGroup}>
+          <span className={styles.channelLabel}>채널</span>
+          <span className={styles.channel}>{channel}</span>
+          <Mono className={styles.date}>{formatSessionDate(session.startedAt)}</Mono>
+        </div>
+        <Pill tone={isSelected ? "signal" : "mute"}>메시지 {getMessageCount(meta)}개</Pill>
+      </div>
+      <p className={styles.preview}>{getPreview(meta)}</p>
+    </button>
+  );
+}

--- a/frontend/src/features/consultation/ui/chat-history/SessionList.module.css
+++ b/frontend/src/features/consultation/ui/chat-history/SessionList.module.css
@@ -1,0 +1,48 @@
+.wrapper {
+  width: 320px;
+  min-width: 320px;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border-right: 1px solid var(--line-2);
+  background: var(--paper-2);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--s-3);
+  padding: var(--s-4);
+  border-bottom: 1px solid var(--line-2);
+  background: var(--paper);
+}
+
+.count {
+  color: var(--ink-3);
+  font-family: var(--mono);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+}
+
+.list {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--s-2);
+  overflow-y: auto;
+  padding: var(--s-3);
+}
+
+.stateArea {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--s-6);
+}

--- a/frontend/src/features/consultation/ui/chat-history/SessionList.test.tsx
+++ b/frontend/src/features/consultation/ui/chat-history/SessionList.test.tsx
@@ -1,0 +1,131 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useChatSessions } from "../../api/chatHistoryApi";
+import type { ChatSession } from "../../api/consultationApi";
+import { SessionList } from "./SessionList";
+
+vi.mock("../../api/chatHistoryApi", () => ({
+  useChatSessions: vi.fn(),
+}));
+
+const mockedUseChatSessions = vi.mocked(useChatSessions);
+
+type MockChatSessionsResult = Pick<
+  ReturnType<typeof useChatSessions>,
+  "data" | "isLoading" | "isError" | "error" | "refetch"
+>;
+
+const makeQueryResult = (overrides?: Partial<MockChatSessionsResult>) => ({
+  data: [],
+  isLoading: false,
+  isError: false,
+  error: null,
+  refetch: vi.fn(),
+  ...overrides,
+}) as ReturnType<typeof useChatSessions>;
+
+const makeSession = (id: number, meta?: Record<string, unknown>): ChatSession => ({
+  id,
+  status: "COMPLETED",
+  channel: "카카오톡",
+  metaJson: JSON.stringify({
+    messageCount: 3,
+    lastMessagePreview: "배송 상태를 확인해주세요",
+    ...meta,
+  }),
+  startedAt: "2026-05-22T09:00:00+09:00",
+});
+
+describe("SessionList", () => {
+  beforeEach(() => {
+    mockedUseChatSessions.mockReset();
+  });
+
+  it("완료된 세션 목록을 기본 필터로 요청한다", () => {
+    mockedUseChatSessions.mockReturnValue(makeQueryResult());
+
+    render(
+      <SessionList workspaceId="workspace-1" selectedSessionId={null} onSelectSession={vi.fn()} />,
+    );
+
+    expect(mockedUseChatSessions).toHaveBeenCalledWith({
+      workspaceId: "workspace-1",
+      status: "completed",
+    });
+  });
+
+  it("로딩 상태를 표시한다", () => {
+    mockedUseChatSessions.mockReturnValue(makeQueryResult({ isLoading: true }));
+
+    render(
+      <SessionList workspaceId="workspace-1" selectedSessionId={null} onSelectSession={vi.fn()} />,
+    );
+
+    expect(screen.getByText("불러오는 중")).toBeTruthy();
+  });
+
+  it("세션이 없으면 빈 상태 메시지를 표시한다", () => {
+    mockedUseChatSessions.mockReturnValue(makeQueryResult({ data: [] }));
+
+    render(
+      <SessionList workspaceId="workspace-1" selectedSessionId={null} onSelectSession={vi.fn()} />,
+    );
+
+    expect(screen.getByText("아직 채팅 기록이 없습니다")).toBeTruthy();
+  });
+
+  it("오류 상태에서 메시지와 다시 시도 버튼을 표시한다", () => {
+    const refetch = vi.fn();
+    mockedUseChatSessions.mockReturnValue(
+      makeQueryResult({
+        isError: true,
+        error: new Error("목록을 불러오지 못했습니다"),
+        refetch,
+      }),
+    );
+
+    render(
+      <SessionList workspaceId="workspace-1" selectedSessionId={null} onSelectSession={vi.fn()} />,
+    );
+
+    expect(screen.getByText("목록을 불러오지 못했습니다")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "다시 시도" }));
+    expect(refetch).toHaveBeenCalled();
+  });
+
+  it("세션 카드에 채널, 날짜, 메시지 수, 마지막 메시지를 표시한다", () => {
+    mockedUseChatSessions.mockReturnValue(makeQueryResult({ data: [makeSession(7)] }));
+
+    render(
+      <SessionList workspaceId="workspace-1" selectedSessionId={null} onSelectSession={vi.fn()} />,
+    );
+
+    expect(screen.getByText("채널")).toBeTruthy();
+    expect(screen.getByText("카카오톡")).toBeTruthy();
+    expect(screen.getByText(new Date("2026-05-22T09:00:00+09:00").toLocaleDateString("ko-KR"))).toBeTruthy();
+    expect(screen.getByText("메시지 3개")).toBeTruthy();
+    expect(screen.getByText("배송 상태를 확인해주세요")).toBeTruthy();
+  });
+
+  it("선택된 세션은 aria-pressed로 활성 상태를 드러낸다", () => {
+    mockedUseChatSessions.mockReturnValue(makeQueryResult({ data: [makeSession(7)] }));
+
+    render(
+      <SessionList workspaceId="workspace-1" selectedSessionId="7" onSelectSession={vi.fn()} />,
+    );
+
+    expect(screen.getByRole("button", { pressed: true })).toBeTruthy();
+  });
+
+  it("카드를 클릭하면 onSelectSession이 호출된다", () => {
+    const onSelect = vi.fn();
+    mockedUseChatSessions.mockReturnValue(makeQueryResult({ data: [makeSession(7)] }));
+
+    render(<SessionList workspaceId="workspace-1" selectedSessionId={null} onSelectSession={onSelect} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /카카오톡/ }));
+
+    expect(onSelect).toHaveBeenCalledWith("7");
+  });
+});

--- a/frontend/src/features/consultation/ui/chat-history/SessionList.tsx
+++ b/frontend/src/features/consultation/ui/chat-history/SessionList.tsx
@@ -19,6 +19,9 @@ export function SessionList({ workspaceId, selectedSessionId, onSelectSession }:
     workspaceId,
     status: "completed",
   });
+  const validSessions = sessions.filter(
+    (session): session is typeof session & { id: number } => session.id != null,
+  );
 
   if (isLoading) {
     return (
@@ -52,28 +55,26 @@ export function SessionList({ workspaceId, selectedSessionId, onSelectSession }:
     <aside className={styles.wrapper} aria-label="채팅 기록 목록">
       <div className={styles.header}>
         <Eyebrow>Chat history</Eyebrow>
-        <span className={styles.count}>{sessions.length}개 세션</span>
+        <span className={styles.count}>{validSessions.length}개 세션</span>
       </div>
 
-      {sessions.length === 0 ? (
+      {validSessions.length === 0 ? (
         <div className={styles.stateArea}>
           <EmptyState message="아직 채팅 기록이 없습니다" />
         </div>
       ) : (
         <div className={styles.list}>
-          {sessions
-            .filter((session): session is typeof session & { id: number } => session.id != null)
-            .map((session) => {
-              const sessionId = String(session.id);
-              return (
-                <SessionCard
-                  key={sessionId}
-                  session={session}
-                  isSelected={selectedSessionId === sessionId}
-                  onSelectSession={onSelectSession}
-                />
-              );
-            })}
+          {validSessions.map((session) => {
+            const sessionId = String(session.id);
+            return (
+              <SessionCard
+                key={sessionId}
+                session={session}
+                isSelected={selectedSessionId === sessionId}
+                onSelectSession={onSelectSession}
+              />
+            );
+          })}
         </div>
       )}
     </aside>

--- a/frontend/src/features/consultation/ui/chat-history/SessionList.tsx
+++ b/frontend/src/features/consultation/ui/chat-history/SessionList.tsx
@@ -61,17 +61,19 @@ export function SessionList({ workspaceId, selectedSessionId, onSelectSession }:
         </div>
       ) : (
         <div className={styles.list}>
-          {sessions.map((session) => {
-            const sessionId = String(session.id ?? "");
-            return (
-              <SessionCard
-                key={sessionId}
-                session={session}
-                isSelected={selectedSessionId === sessionId}
-                onSelectSession={onSelectSession}
-              />
-            );
-          })}
+          {sessions
+            .filter((session): session is typeof session & { id: number } => session.id != null)
+            .map((session) => {
+              const sessionId = String(session.id);
+              return (
+                <SessionCard
+                  key={sessionId}
+                  session={session}
+                  isSelected={selectedSessionId === sessionId}
+                  onSelectSession={onSelectSession}
+                />
+              );
+            })}
         </div>
       )}
     </aside>

--- a/frontend/src/features/consultation/ui/chat-history/SessionList.tsx
+++ b/frontend/src/features/consultation/ui/chat-history/SessionList.tsx
@@ -1,0 +1,79 @@
+import { EmptyState, ErrorState, Eyebrow, LoadingSpinner } from "@/shared/ui/ostone/atoms";
+import { useChatSessions } from "../../api/chatHistoryApi";
+import { SessionCard } from "./SessionCard";
+import styles from "./SessionList.module.css";
+
+interface SessionListProps {
+  workspaceId: string;
+  selectedSessionId?: string | null;
+  onSelectSession: (sessionId: string) => void;
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return "채팅 기록을 불러오지 못했습니다";
+}
+
+export function SessionList({ workspaceId, selectedSessionId, onSelectSession }: SessionListProps) {
+  const { data: sessions = [], isLoading, isError, error, refetch } = useChatSessions({
+    workspaceId,
+    status: "completed",
+  });
+
+  if (isLoading) {
+    return (
+      <aside className={styles.wrapper} aria-label="채팅 기록 목록">
+        <div className={styles.header}>
+          <Eyebrow>Chat history</Eyebrow>
+          <span className={styles.count}>불러오는 중</span>
+        </div>
+        <div className={styles.stateArea}>
+          <LoadingSpinner />
+        </div>
+      </aside>
+    );
+  }
+
+  if (isError) {
+    return (
+      <aside className={styles.wrapper} aria-label="채팅 기록 목록">
+        <div className={styles.header}>
+          <Eyebrow>Chat history</Eyebrow>
+          <span className={styles.count}>오류</span>
+        </div>
+        <div className={styles.stateArea}>
+          <ErrorState message={getErrorMessage(error)} onRetry={() => refetch()} />
+        </div>
+      </aside>
+    );
+  }
+
+  return (
+    <aside className={styles.wrapper} aria-label="채팅 기록 목록">
+      <div className={styles.header}>
+        <Eyebrow>Chat history</Eyebrow>
+        <span className={styles.count}>{sessions.length}개 세션</span>
+      </div>
+
+      {sessions.length === 0 ? (
+        <div className={styles.stateArea}>
+          <EmptyState message="아직 채팅 기록이 없습니다" />
+        </div>
+      ) : (
+        <div className={styles.list}>
+          {sessions.map((session) => {
+            const sessionId = String(session.id ?? "");
+            return (
+              <SessionCard
+                key={sessionId}
+                session={session}
+                isSelected={selectedSessionId === sessionId}
+                onSelectSession={onSelectSession}
+              />
+            );
+          })}
+        </div>
+      )}
+    </aside>
+  );
+}

--- a/frontend/src/pages/consultation/ui/chat-history/ChatHistoryPage.module.css
+++ b/frontend/src/pages/consultation/ui/chat-history/ChatHistoryPage.module.css
@@ -1,0 +1,23 @@
+.page {
+  height: 100%;
+  min-height: 0;
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+  background: var(--bg);
+  color: var(--ink);
+}
+
+.contentPane {
+  min-width: 0;
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+  background: var(--paper);
+}
+
+@media (max-width: 760px) {
+  .page {
+    flex-direction: column;
+  }
+}

--- a/frontend/src/pages/consultation/ui/chat-history/ChatHistoryPage.test.tsx
+++ b/frontend/src/pages/consultation/ui/chat-history/ChatHistoryPage.test.tsx
@@ -68,6 +68,7 @@ function renderPage(path = "/workspaces/workspace-1/consultation/history") {
     <MemoryRouter initialEntries={[path]}>
       <Routes>
         <Route path="/workspaces/:workspaceId/consultation/history" element={<ChatHistoryPage />} />
+        <Route path="/workspaces/:workspaceId/consultation/history/:sessionId" element={<ChatHistoryPage />} />
       </Routes>
     </MemoryRouter>,
   );
@@ -151,5 +152,12 @@ describe("ChatHistoryPage", () => {
 
     expect(screen.getByText("메시지 오류")).toBeTruthy();
     expect(refetch).toHaveBeenCalled();
+  });
+
+  it("URL의 sessionId로 초기 세션을 선택한다", () => {
+    mockedUseChatMessages.mockReturnValue(makeMessagesResult({ data: [makeMessage()] }));
+    renderPage("/workspaces/workspace-1/consultation/history/7");
+
+    expect(mockedUseChatMessages).toHaveBeenLastCalledWith("7");
   });
 });

--- a/frontend/src/pages/consultation/ui/chat-history/ChatHistoryPage.test.tsx
+++ b/frontend/src/pages/consultation/ui/chat-history/ChatHistoryPage.test.tsx
@@ -1,0 +1,155 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useChatMessages, useChatSessions } from "../../../../features/consultation/api/chatHistoryApi";
+import type { ChatMessage, ChatSession } from "../../../../features/consultation/api/consultationApi";
+import { ChatHistoryPage } from "./ChatHistoryPage";
+
+vi.mock("../../../../features/consultation/api/chatHistoryApi", () => ({
+  useChatSessions: vi.fn(),
+  useChatMessages: vi.fn(),
+}));
+
+const mockedUseChatSessions = vi.mocked(useChatSessions);
+const mockedUseChatMessages = vi.mocked(useChatMessages);
+
+type MockChatSessionsResult = Pick<
+  ReturnType<typeof useChatSessions>,
+  "data" | "isLoading" | "isError" | "error" | "refetch"
+>;
+
+type MockChatMessagesResult = Pick<
+  ReturnType<typeof useChatMessages>,
+  "data" | "isLoading" | "isError" | "error" | "refetch"
+>;
+
+const makeSessionsResult = (overrides?: Partial<MockChatSessionsResult>) => ({
+  data: [makeSession(7)],
+  isLoading: false,
+  isError: false,
+  error: null,
+  refetch: vi.fn(),
+  ...overrides,
+}) as ReturnType<typeof useChatSessions>;
+
+const makeMessagesResult = (overrides?: Partial<MockChatMessagesResult>) => ({
+  data: [],
+  isLoading: false,
+  isError: false,
+  error: null,
+  refetch: vi.fn(),
+  ...overrides,
+}) as ReturnType<typeof useChatMessages>;
+
+function makeSession(id: number): ChatSession {
+  return {
+    id,
+    status: "COMPLETED",
+    channel: "카카오톡",
+    metaJson: JSON.stringify({ messageCount: 2, lastMessagePreview: "상담 종료 내역입니다" }),
+    startedAt: "2026-05-22T09:00:00+09:00",
+  };
+}
+
+function makeMessage(overrides?: Partial<ChatMessage>): ChatMessage {
+  return {
+    id: 11,
+    seqNo: 1,
+    senderRole: "CUSTOMER",
+    messageType: "TEXT",
+    content: "환불 문의 드립니다",
+    createdAt: "2026-05-22T09:10:00+09:00",
+    ...overrides,
+  };
+}
+
+function renderPage(path = "/workspaces/workspace-1/consultation/history") {
+  render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/workspaces/:workspaceId/consultation/history" element={<ChatHistoryPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("ChatHistoryPage", () => {
+  beforeEach(() => {
+    mockedUseChatSessions.mockReset();
+    mockedUseChatMessages.mockReset();
+    mockedUseChatSessions.mockReturnValue(makeSessionsResult());
+    mockedUseChatMessages.mockReturnValue(makeMessagesResult());
+  });
+
+  it("URL의 workspaceId로 완료 세션 목록을 요청한다", () => {
+    renderPage();
+
+    expect(mockedUseChatSessions).toHaveBeenCalledWith({
+      workspaceId: "workspace-1",
+      status: "completed",
+    });
+  });
+
+  it("세션을 선택하지 않으면 안내 문구를 표시한다", () => {
+    renderPage();
+
+    expect(screen.getByText("좌측 목록에서 세션을 선택해주세요")).toBeTruthy();
+  });
+
+  it("세션을 선택하면 해당 세션의 메시지 내역을 표시한다", () => {
+    mockedUseChatMessages.mockReturnValue(makeMessagesResult({ data: [makeMessage()] }));
+
+    renderPage();
+    fireEvent.click(screen.getByRole("button", { name: /카카오톡/ }));
+
+    expect(mockedUseChatMessages).toHaveBeenLastCalledWith("7");
+    expect(screen.getByText("고객")).toBeTruthy();
+    expect(screen.getByText("환불 문의 드립니다")).toBeTruthy();
+    expect(screen.getByText("TEXT")).toBeTruthy();
+    expect(screen.getByText(new Date("2026-05-22T09:10:00+09:00").toLocaleString("ko-KR"))).toBeTruthy();
+  });
+
+  it("상담사 메시지는 상담사 역할로 표시한다", () => {
+    mockedUseChatMessages.mockReturnValue(
+      makeMessagesResult({ data: [makeMessage({ senderRole: "AGENT", content: "처리해드리겠습니다" })] }),
+    );
+
+    renderPage();
+    fireEvent.click(screen.getByRole("button", { name: /카카오톡/ }));
+
+    expect(screen.getByText("상담사")).toBeTruthy();
+    expect(screen.getByText("처리해드리겠습니다")).toBeTruthy();
+  });
+
+  it("선택한 세션에 메시지가 없으면 빈 상태를 표시한다", () => {
+    mockedUseChatMessages.mockReturnValue(makeMessagesResult({ data: [] }));
+
+    renderPage();
+    fireEvent.click(screen.getByRole("button", { name: /카카오톡/ }));
+
+    expect(screen.getByText("아직 메시지가 없습니다")).toBeTruthy();
+  });
+
+  it("메시지 로딩 상태를 표시한다", () => {
+    mockedUseChatMessages.mockReturnValue(makeMessagesResult({ isLoading: true }));
+
+    renderPage();
+    fireEvent.click(screen.getByRole("button", { name: /카카오톡/ }));
+
+    expect(screen.getByText("불러오는 중")).toBeTruthy();
+  });
+
+  it("메시지 오류 상태에서 다시 시도할 수 있다", () => {
+    const refetch = vi.fn();
+    mockedUseChatMessages.mockReturnValue(
+      makeMessagesResult({ isError: true, error: new Error("메시지 오류"), refetch }),
+    );
+
+    renderPage();
+    fireEvent.click(screen.getByRole("button", { name: /카카오톡/ }));
+    fireEvent.click(screen.getByRole("button", { name: "다시 시도" }));
+
+    expect(screen.getByText("메시지 오류")).toBeTruthy();
+    expect(refetch).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/pages/consultation/ui/chat-history/ChatHistoryPage.tsx
+++ b/frontend/src/pages/consultation/ui/chat-history/ChatHistoryPage.tsx
@@ -9,9 +9,9 @@ interface ChatHistoryPageProps {
 }
 
 export function ChatHistoryPage({ workspaceId: workspaceIdProp }: ChatHistoryPageProps) {
-  const { workspaceId: workspaceIdParam } = useParams<{ workspaceId: string }>();
+  const { workspaceId: workspaceIdParam, sessionId: sessionIdParam } = useParams<{ workspaceId: string; sessionId: string }>();
   const workspaceId = workspaceIdProp ?? workspaceIdParam ?? "";
-  const [selectedSessionId, setSelectedSessionId] = useState<string | null>(null);
+  const [selectedSessionId, setSelectedSessionId] = useState<string | null>(sessionIdParam ?? null);
 
   return (
     <main className={styles.page}>

--- a/frontend/src/pages/consultation/ui/chat-history/ChatHistoryPage.tsx
+++ b/frontend/src/pages/consultation/ui/chat-history/ChatHistoryPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { MessageHistory } from "../../../../features/consultation/ui/chat-history/MessageHistory";
 import { SessionList } from "../../../../features/consultation/ui/chat-history/SessionList";
@@ -12,6 +12,10 @@ export function ChatHistoryPage({ workspaceId: workspaceIdProp }: ChatHistoryPag
   const { workspaceId: workspaceIdParam, sessionId: sessionIdParam } = useParams<{ workspaceId: string; sessionId: string }>();
   const workspaceId = workspaceIdProp ?? workspaceIdParam ?? "";
   const [selectedSessionId, setSelectedSessionId] = useState<string | null>(sessionIdParam ?? null);
+
+  useEffect(() => {
+    setSelectedSessionId(sessionIdParam ?? null);
+  }, [sessionIdParam]);
 
   return (
     <main className={styles.page}>

--- a/frontend/src/pages/consultation/ui/chat-history/ChatHistoryPage.tsx
+++ b/frontend/src/pages/consultation/ui/chat-history/ChatHistoryPage.tsx
@@ -1,0 +1,28 @@
+import { useState } from "react";
+import { useParams } from "react-router-dom";
+import { MessageHistory } from "../../../../features/consultation/ui/chat-history/MessageHistory";
+import { SessionList } from "../../../../features/consultation/ui/chat-history/SessionList";
+import styles from "./ChatHistoryPage.module.css";
+
+interface ChatHistoryPageProps {
+  workspaceId?: string;
+}
+
+export function ChatHistoryPage({ workspaceId: workspaceIdProp }: ChatHistoryPageProps) {
+  const { workspaceId: workspaceIdParam } = useParams<{ workspaceId: string }>();
+  const workspaceId = workspaceIdProp ?? workspaceIdParam ?? "";
+  const [selectedSessionId, setSelectedSessionId] = useState<string | null>(null);
+
+  return (
+    <main className={styles.page}>
+      <SessionList
+        workspaceId={workspaceId}
+        selectedSessionId={selectedSessionId}
+        onSelectSession={setSelectedSessionId}
+      />
+      <div className={styles.contentPane}>
+        <MessageHistory sessionId={selectedSessionId} />
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## 개요
상담사 채팅 기록 조회 API를 TanStack Query로 연동하고, 채팅 기록 페이지를 구현했습니다.

## 변경 내용

### API Layer
- `consultationApi.ts`: `getSessions()` 신규 추가, `getMessages()` 페이지네이션 확장
- `chatHistoryKeys.ts`: Query key factory (all, sessionList, messages)
- `chatHistoryApi.ts`: `useChatSessions`, `useChatMessages` hooks

### UI Components
- `SessionCard.tsx`: 채널, 날짜, 메시지 수, 미리보기 표시
- `SessionList.tsx`: 세션 목록 (로딩/빈/오류 상태 처리)
- `MessageHistory.tsx`: 상담사(우)/고객(좌) bubble 배치

### Page + Routing
- `ChatHistoryPage.tsx`: 2-pane 레이아웃, URL `:sessionId` 활용
- `App.tsx`: `/workspaces/:workspaceId/consultation/history` 라우트

## 검증
- Test: 1037/1037 통과
- Build: tsc + vite build 성공
- 모든 UI 상태 (로딩, 빈 상태, 오류, 정상) 테스트 완료

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 상담 채팅 이력 페이지 추가 — 완료된 세션 목록에서 세션을 선택해 과거 메시지를 확인할 수 있습니다.
  * 세션 선택을 URL로 초기화/유지(세션 링크로 바로 열기) 지원.

* **UI / 스타일**
  * 세션 리스트/카드와 메시지 히스토리의 신규 레이아웃, 말풍선 및 반응형 스타일 적용.
  * 로딩·빈 상태·에러 상태 및 메시지 카운트 표기 개선.

* **테스트**
  * 세션/메시지 조회 훅과 페이지·컴포넌트 동작에 대한 단위 테스트 추가.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ajou-2026-1-capstone-5/ostone/pull/275?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->