### PR TITLE
feat(llm-tools): add decision log writer for LLM tool calls

### DIFF
--- a/backend/src/main/java/com/init/workflowruntime/application/LlmToolService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/LlmToolService.java
@@ -3,8 +3,10 @@ package com.init.workflowruntime.application;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
 import com.init.domainpack.domain.model.IntentDefinition;
 import com.init.domainpack.domain.model.IntentSlotBinding;
 import com.init.domainpack.domain.model.IntentWorkflowBinding;
@@ -36,8 +38,14 @@ import com.init.workflowruntime.application.dto.LlmToolSlotValueResponse;
 import com.init.workflowruntime.application.dto.LlmToolWorkflowResponse;
 import com.init.workflowruntime.domain.ChatSession;
 import com.init.workflowruntime.domain.ChatSessionRepository;
+import com.init.workflowruntime.domain.DecisionLog;
+import com.init.workflowruntime.domain.DecisionLogRepository;
+import com.init.workflowruntime.domain.DecisionLogType;
 import com.init.workflowruntime.domain.WorkflowExecution;
 import com.init.workflowruntime.domain.WorkflowExecutionRepository;
+import com.init.workflowruntime.domain.WorkflowExecutionStep;
+import com.init.workflowruntime.domain.WorkflowExecutionStepActionType;
+import com.init.workflowruntime.domain.WorkflowExecutionStepRepository;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -59,6 +67,8 @@ public class LlmToolService {
   private final IntentWorkflowBindingRepository intentWorkflowBindingRepository;
   private final WorkflowDefinitionRepository workflowDefinitionRepository;
   private final WorkflowPolicyRuntimeService workflowPolicyRuntimeService;
+  private final DecisionLogRepository decisionLogRepository;
+  private final WorkflowExecutionStepRepository workflowExecutionStepRepository;
   private final ObjectMapper objectMapper;
 
   public LlmToolService(
@@ -70,6 +80,8 @@ public class LlmToolService {
       IntentWorkflowBindingRepository intentWorkflowBindingRepository,
       WorkflowDefinitionRepository workflowDefinitionRepository,
       WorkflowPolicyRuntimeService workflowPolicyRuntimeService,
+      DecisionLogRepository decisionLogRepository,
+      WorkflowExecutionStepRepository workflowExecutionStepRepository,
       ObjectMapper objectMapper) {
     this.chatSessionRepository = chatSessionRepository;
     this.workflowExecutionRepository = workflowExecutionRepository;
@@ -79,9 +91,12 @@ public class LlmToolService {
     this.intentWorkflowBindingRepository = intentWorkflowBindingRepository;
     this.workflowDefinitionRepository = workflowDefinitionRepository;
     this.workflowPolicyRuntimeService = workflowPolicyRuntimeService;
+    this.decisionLogRepository = decisionLogRepository;
+    this.workflowExecutionStepRepository = workflowExecutionStepRepository;
     this.objectMapper = objectMapper;
   }
 
+  @Transactional
   public LlmToolWorkflowResponse getCurrentWorkflow(GetCurrentWorkflowCommand command) {
     Long sessionId = command.sessionId();
     ChatSession session = findSession(sessionId);
@@ -109,22 +124,42 @@ public class LlmToolService {
           "JSON_PARSE_FAILED", "Stored terminalStatesJson must be a JSON array");
     }
 
-    return new LlmToolWorkflowResponse(
-        session.getId(),
-        session.getWorkspaceId(),
-        session.getDomainPackVersionId(),
-        executionId,
-        executionStatus,
-        currentState,
-        definition != null ? definition.getId() : null,
-        definition != null ? definition.getWorkflowCode() : null,
-        definition != null ? definition.getName() : null,
-        definition != null ? definition.getDescription() : null,
-        graphJson,
-        definition != null ? definition.getInitialState() : null,
-        terminalStates);
+    LlmToolWorkflowResponse response =
+        new LlmToolWorkflowResponse(
+            session.getId(),
+            session.getWorkspaceId(),
+            session.getDomainPackVersionId(),
+            executionId,
+            executionStatus,
+            currentState,
+            definition != null ? definition.getId() : null,
+            definition != null ? definition.getWorkflowCode() : null,
+            definition != null ? definition.getName() : null,
+            definition != null ? definition.getDescription() : null,
+            graphJson,
+            definition != null ? definition.getInitialState() : null,
+            terminalStates);
+
+    if (execution != null) {
+      workflowExecutionRepository.findLatestByChatSessionIdForUpdate(sessionId);
+      int seq = nextStepSeqNo(execution.getId());
+      decisionLogRepository.save(
+          DecisionLog.record(
+              execution.getId(),
+              seq,
+              DecisionLogType.WORKFLOW_FETCHED,
+              execution.getIntentDefinitionId(),
+              execution.getCurrentState(),
+              null,
+              null,
+              "[]",
+              "{}"));
+    }
+
+    return response;
   }
 
+  @Transactional
   public LlmToolContextResponse getContext(GetLlmToolContextCommand command) {
     Long sessionId = command.sessionId();
     ChatSession session = findSession(sessionId);
@@ -142,18 +177,37 @@ public class LlmToolService {
                 session.getDomainPackVersionId(), execution, slotValues)
             : null;
 
-    return new LlmToolContextResponse(
-        session.getId(),
-        session.getWorkspaceId(),
-        session.getDomainPackVersionId(),
-        execution != null ? execution.getId() : null,
-        execution != null ? execution.getStatus() : null,
-        execution != null ? execution.getCurrentState() : null,
-        slotValues,
-        policySnapshot,
-        currentPolicy,
-        missingSlots,
-        slots);
+    LlmToolContextResponse response =
+        new LlmToolContextResponse(
+            session.getId(),
+            session.getWorkspaceId(),
+            session.getDomainPackVersionId(),
+            execution != null ? execution.getId() : null,
+            execution != null ? execution.getStatus() : null,
+            execution != null ? execution.getCurrentState() : null,
+            slotValues,
+            policySnapshot,
+            currentPolicy,
+            missingSlots,
+            slots);
+
+    if (execution != null) {
+      workflowExecutionRepository.findLatestByChatSessionIdForUpdate(sessionId);
+      int seq = nextStepSeqNo(execution.getId());
+      decisionLogRepository.save(
+          DecisionLog.record(
+              execution.getId(),
+              seq,
+              DecisionLogType.CONTEXT_FETCHED,
+              execution.getIntentDefinitionId(),
+              execution.getCurrentState(),
+              null,
+              null,
+              writeJson(toJsonArray(missingSlots)),
+              "{}"));
+    }
+
+    return response;
   }
 
   public LlmToolPolicyContextResponse getPolicyContext(GetLlmToolPolicyContextCommand command) {
@@ -177,15 +231,35 @@ public class LlmToolService {
         currentPolicy);
   }
 
+  @Transactional
   public List<LlmToolSlotResponse> listSlots(ListLlmToolSlotsCommand command) {
     Long sessionId = command.sessionId();
     ChatSession session = findSession(sessionId);
     WorkflowExecution execution = findExecution(sessionId);
     ObjectNode slotValues =
         readObjectNode(execution != null ? execution.getSlotValuesJson() : "{}");
-    return buildSlotResponses(session, execution, slotValues);
+    List<LlmToolSlotResponse> slots = buildSlotResponses(session, execution, slotValues);
+
+    if (execution != null) {
+      workflowExecutionRepository.findLatestByChatSessionIdForUpdate(sessionId);
+      int seq = nextStepSeqNo(execution.getId());
+      decisionLogRepository.save(
+          DecisionLog.record(
+              execution.getId(),
+              seq,
+              DecisionLogType.SLOTS_LISTED,
+              execution.getIntentDefinitionId(),
+              execution.getCurrentState(),
+              null,
+              null,
+              "[]",
+              writeJson(objectMapper.createObjectNode().put("returnedCount", slots.size()))));
+    }
+
+    return slots;
   }
 
+  @Transactional
   public LlmToolSlotResponse getSlot(GetLlmToolSlotCommand command) {
     Long sessionId = command.sessionId();
     String slotCode = command.slotCode();
@@ -195,18 +269,58 @@ public class LlmToolService {
         readObjectNode(execution != null ? execution.getSlotValuesJson() : "{}");
     SlotDefinition slot = findActiveSlot(session.getDomainPackVersionId(), slotCode);
     Map<Long, IntentSlotBinding> bindings = loadBindingsBySlotId(execution);
-    return toSlotResponse(slot, bindings.get(slot.getId()), slotValues);
+    LlmToolSlotResponse response = toSlotResponse(slot, bindings.get(slot.getId()), slotValues);
+
+    if (execution != null) {
+      workflowExecutionRepository.findLatestByChatSessionIdForUpdate(sessionId);
+      int seq = nextStepSeqNo(execution.getId());
+      decisionLogRepository.save(
+          DecisionLog.record(
+              execution.getId(),
+              seq,
+              DecisionLogType.SLOT_FETCHED,
+              execution.getIntentDefinitionId(),
+              execution.getCurrentState(),
+              null,
+              null,
+              "[]",
+              writeJson(objectMapper.createObjectNode().put("slotCode", slotCode))));
+    }
+
+    return response;
   }
 
+  @Transactional
   public List<LlmToolIntentResponse> listIntents(ListLlmToolIntentsCommand command) {
-    ChatSession session = findSession(command.sessionId());
-    return intentDefinitionRepository
-        .findByDomainPackVersionId(session.getDomainPackVersionId())
-        .stream()
-        .filter(intent -> !IntentDefinition.STATUS_REJECTED.equals(intent.getStatus()))
-        .sorted(Comparator.comparing(IntentDefinition::getIntentCode))
-        .map(this::toIntentResponse)
-        .toList();
+    Long sessionId = command.sessionId();
+    ChatSession session = findSession(sessionId);
+    List<LlmToolIntentResponse> result =
+        intentDefinitionRepository
+            .findByDomainPackVersionId(session.getDomainPackVersionId())
+            .stream()
+            .filter(intent -> !IntentDefinition.STATUS_REJECTED.equals(intent.getStatus()))
+            .sorted(Comparator.comparing(IntentDefinition::getIntentCode))
+            .map(this::toIntentResponse)
+            .toList();
+
+    WorkflowExecution execution = findExecution(sessionId);
+    if (execution != null) {
+      workflowExecutionRepository.findLatestByChatSessionIdForUpdate(sessionId);
+      int seq = nextStepSeqNo(execution.getId());
+      decisionLogRepository.save(
+          DecisionLog.record(
+              execution.getId(),
+              seq,
+              DecisionLogType.INTENTS_LISTED,
+              execution.getIntentDefinitionId(),
+              execution.getCurrentState(),
+              null,
+              null,
+              "[]",
+              writeJson(objectMapper.createObjectNode().put("returnedCount", result.size()))));
+    }
+
+    return result;
   }
 
   @Transactional
@@ -239,6 +353,26 @@ public class LlmToolService {
             .map(LlmToolSlotResponse::slotCode)
             .toList();
 
+    int seq = nextStepSeqNo(saved.getId());
+    workflowExecutionStepRepository.save(
+        WorkflowExecutionStep.record(
+            saved.getId(),
+            seq,
+            null,
+            saved.getCurrentState(),
+            WorkflowExecutionStepActionType.ASSIGN_INTENT));
+    decisionLogRepository.save(
+        DecisionLog.record(
+            saved.getId(),
+            seq,
+            DecisionLogType.INTENT_SELECTED,
+            intent.getId(),
+            saved.getCurrentState(),
+            null,
+            "ASSIGN_WORKFLOW",
+            writeJson(toJsonArray(missingRequiredSlots)),
+            writeJson(objectMapper.createObjectNode().put("intentCode", intent.getIntentCode()))));
+
     return new LlmToolIntentSelectionResponse(
         session.getId(),
         saved.getId(),
@@ -263,13 +397,37 @@ public class LlmToolService {
     }
 
     ChatSession session = findSession(sessionId);
-    findActiveSlot(session.getDomainPackVersionId(), slotCode);
+    SlotDefinition slotDef = findActiveSlot(session.getDomainPackVersionId(), slotCode);
 
     WorkflowExecution execution = findOrCreateExecutionForUpdate(session);
     ObjectNode slotValues = readObjectNode(execution.getSlotValuesJson());
     slotValues.set(slotCode, value.deepCopy());
     execution.replaceSlotValuesJson(writeJson(slotValues));
     WorkflowExecution saved = workflowExecutionRepository.save(execution);
+
+    int seq = nextStepSeqNo(saved.getId());
+    workflowExecutionStepRepository.save(
+        WorkflowExecutionStep.record(
+            saved.getId(),
+            seq,
+            saved.getCurrentState(),
+            saved.getCurrentState(),
+            WorkflowExecutionStepActionType.UPSERT_SLOT));
+
+    ObjectNode payload = objectMapper.createObjectNode();
+    payload.put("slotCode", slotCode);
+    payload.set("value", maskSensitiveSlotValue(slotDef, value));
+    decisionLogRepository.save(
+        DecisionLog.record(
+            saved.getId(),
+            seq,
+            DecisionLogType.SLOT_UPSERTED,
+            saved.getIntentDefinitionId(),
+            saved.getCurrentState(),
+            null,
+            null,
+            "[]",
+            writeJson(payload)));
 
     JsonNode savedValue = slotValues.get(slotCode);
     return new LlmToolSlotValueResponse(
@@ -297,6 +455,28 @@ public class LlmToolService {
     return workflowExecutionRepository
         .findLatestByChatSessionIdForUpdate(sessionId)
         .orElseGet(() -> workflowExecutionRepository.save(WorkflowExecution.create(sessionId)));
+  }
+
+  private int nextStepSeqNo(Long executionId) {
+    return decisionLogRepository
+        .findMaxStepSeqNoByExecutionId(executionId)
+        .map(max -> max + 1)
+        .orElse(1);
+  }
+
+  private JsonNode maskSensitiveSlotValue(SlotDefinition slotDef, JsonNode rawValue) {
+    if (Boolean.TRUE.equals(slotDef.getIsSensitive())) {
+      return TextNode.valueOf("***");
+    }
+    return rawValue;
+  }
+
+  private ArrayNode toJsonArray(List<String> codes) {
+    ArrayNode arr = objectMapper.createArrayNode();
+    for (String code : codes) {
+      arr.add(code);
+    }
+    return arr;
   }
 
   private List<LlmToolSlotResponse> buildSlotResponses(

--- a/backend/src/main/java/com/init/workflowruntime/application/LlmToolService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/LlmToolService.java
@@ -96,6 +96,7 @@ public class LlmToolService {
     this.objectMapper = objectMapper;
   }
 
+  @SuppressWarnings("java:S2201") // false positive: PESSIMISTIC_WRITE lock only, return ignored
   @Transactional
   public LlmToolWorkflowResponse getCurrentWorkflow(GetCurrentWorkflowCommand command) {
     Long sessionId = command.sessionId();
@@ -159,6 +160,7 @@ public class LlmToolService {
     return response;
   }
 
+  @SuppressWarnings("java:S2201") // false positive: PESSIMISTIC_WRITE lock only, return ignored
   @Transactional
   public LlmToolContextResponse getContext(GetLlmToolContextCommand command) {
     Long sessionId = command.sessionId();
@@ -231,6 +233,7 @@ public class LlmToolService {
         currentPolicy);
   }
 
+  @SuppressWarnings("java:S2201") // false positive: PESSIMISTIC_WRITE lock only, return ignored
   @Transactional
   public List<LlmToolSlotResponse> listSlots(ListLlmToolSlotsCommand command) {
     Long sessionId = command.sessionId();
@@ -259,6 +262,7 @@ public class LlmToolService {
     return slots;
   }
 
+  @SuppressWarnings("java:S2201") // false positive: PESSIMISTIC_WRITE lock only, return ignored
   @Transactional
   public LlmToolSlotResponse getSlot(GetLlmToolSlotCommand command) {
     Long sessionId = command.sessionId();
@@ -290,6 +294,7 @@ public class LlmToolService {
     return response;
   }
 
+  @SuppressWarnings("java:S2201") // false positive: PESSIMISTIC_WRITE lock only, return ignored
   @Transactional
   public List<LlmToolIntentResponse> listIntents(ListLlmToolIntentsCommand command) {
     Long sessionId = command.sessionId();

--- a/backend/src/main/java/com/init/workflowruntime/domain/DecisionLog.java
+++ b/backend/src/main/java/com/init/workflowruntime/domain/DecisionLog.java
@@ -1,0 +1,156 @@
+package com.init.workflowruntime.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import java.time.OffsetDateTime;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+@Entity
+@Table(name = "decision_log", schema = "runtime")
+public class DecisionLog {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "workflow_execution_id", nullable = false)
+  private Long workflowExecutionId;
+
+  @Column(name = "step_seq_no", nullable = false)
+  private int stepSeqNo;
+
+  @Column(name = "decision_type", nullable = false, length = 100)
+  private String decisionType;
+
+  @Column(name = "intent_definition_id")
+  private Long intentDefinitionId;
+
+  @Column(name = "state_name", length = 100)
+  private String stateName;
+
+  @Column(name = "confidence_score")
+  private Double confidenceScore;
+
+  @Column(name = "selected_action", length = 100)
+  private String selectedAction;
+
+  @Column(name = "missing_slots_json", nullable = false)
+  @JdbcTypeCode(SqlTypes.JSON)
+  private String missingSlotsJson;
+
+  @Column(name = "policy_hits_json", nullable = false)
+  @JdbcTypeCode(SqlTypes.JSON)
+  private String policyHitsJson;
+
+  @Column(name = "risk_hits_json", nullable = false)
+  @JdbcTypeCode(SqlTypes.JSON)
+  private String riskHitsJson;
+
+  @Column(name = "evidence_json", nullable = false)
+  @JdbcTypeCode(SqlTypes.JSON)
+  private String evidenceJson;
+
+  @Column(name = "payload_json", nullable = false)
+  @JdbcTypeCode(SqlTypes.JSON)
+  private String payloadJson;
+
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private OffsetDateTime createdAt;
+
+  protected DecisionLog() {}
+
+  public static DecisionLog record(
+      Long workflowExecutionId,
+      int stepSeqNo,
+      String decisionType,
+      Long intentDefinitionId,
+      String stateName,
+      Double confidenceScore,
+      String selectedAction,
+      String missingSlotsJson,
+      String payloadJson) {
+    DecisionLog log = new DecisionLog();
+    log.workflowExecutionId = workflowExecutionId;
+    log.stepSeqNo = stepSeqNo;
+    log.decisionType = decisionType;
+    log.intentDefinitionId = intentDefinitionId;
+    log.stateName = stateName;
+    log.confidenceScore = confidenceScore;
+    log.selectedAction = selectedAction;
+    log.missingSlotsJson = missingSlotsJson != null ? missingSlotsJson : "[]";
+    log.policyHitsJson = "[]";
+    log.riskHitsJson = "[]";
+    log.evidenceJson = "[]";
+    log.payloadJson = payloadJson != null ? payloadJson : "{}";
+    return log;
+  }
+
+  @PrePersist
+  void onCreate() {
+    if (createdAt == null) {
+      createdAt = OffsetDateTime.now();
+    }
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public Long getWorkflowExecutionId() {
+    return workflowExecutionId;
+  }
+
+  public int getStepSeqNo() {
+    return stepSeqNo;
+  }
+
+  public String getDecisionType() {
+    return decisionType;
+  }
+
+  public Long getIntentDefinitionId() {
+    return intentDefinitionId;
+  }
+
+  public String getStateName() {
+    return stateName;
+  }
+
+  public Double getConfidenceScore() {
+    return confidenceScore;
+  }
+
+  public String getSelectedAction() {
+    return selectedAction;
+  }
+
+  public String getMissingSlotsJson() {
+    return missingSlotsJson;
+  }
+
+  public String getPolicyHitsJson() {
+    return policyHitsJson;
+  }
+
+  public String getRiskHitsJson() {
+    return riskHitsJson;
+  }
+
+  public String getEvidenceJson() {
+    return evidenceJson;
+  }
+
+  public String getPayloadJson() {
+    return payloadJson;
+  }
+
+  public OffsetDateTime getCreatedAt() {
+    return createdAt;
+  }
+}

--- a/backend/src/main/java/com/init/workflowruntime/domain/DecisionLogRepository.java
+++ b/backend/src/main/java/com/init/workflowruntime/domain/DecisionLogRepository.java
@@ -1,0 +1,10 @@
+package com.init.workflowruntime.domain;
+
+import java.util.Optional;
+
+public interface DecisionLogRepository {
+
+  DecisionLog save(DecisionLog decisionLog);
+
+  Optional<Integer> findMaxStepSeqNoByExecutionId(Long executionId);
+}

--- a/backend/src/main/java/com/init/workflowruntime/domain/DecisionLogType.java
+++ b/backend/src/main/java/com/init/workflowruntime/domain/DecisionLogType.java
@@ -1,0 +1,14 @@
+package com.init.workflowruntime.domain;
+
+public final class DecisionLogType {
+
+  public static final String INTENT_SELECTED = "INTENT_SELECTED";
+  public static final String SLOT_UPSERTED = "SLOT_UPSERTED";
+  public static final String WORKFLOW_FETCHED = "WORKFLOW_FETCHED";
+  public static final String CONTEXT_FETCHED = "CONTEXT_FETCHED";
+  public static final String SLOTS_LISTED = "SLOTS_LISTED";
+  public static final String SLOT_FETCHED = "SLOT_FETCHED";
+  public static final String INTENTS_LISTED = "INTENTS_LISTED";
+
+  private DecisionLogType() {}
+}

--- a/backend/src/main/java/com/init/workflowruntime/domain/WorkflowExecutionStep.java
+++ b/backend/src/main/java/com/init/workflowruntime/domain/WorkflowExecutionStep.java
@@ -1,0 +1,104 @@
+package com.init.workflowruntime.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import java.time.OffsetDateTime;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+@Entity
+@Table(name = "workflow_execution_step", schema = "runtime")
+public class WorkflowExecutionStep {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "workflow_execution_id", nullable = false)
+  private Long workflowExecutionId;
+
+  @Column(name = "seq_no", nullable = false)
+  private int seqNo;
+
+  @Column(name = "state_from", length = 100)
+  private String stateFrom;
+
+  @Column(name = "state_to", length = 100)
+  private String stateTo;
+
+  @Column(name = "action_type", nullable = false, length = 100)
+  private String actionType;
+
+  @Column(name = "reason_text", columnDefinition = "text")
+  private String reasonText;
+
+  @Column(name = "evidence_json", nullable = false)
+  @JdbcTypeCode(SqlTypes.JSON)
+  private String evidenceJson;
+
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private OffsetDateTime createdAt;
+
+  protected WorkflowExecutionStep() {}
+
+  public static WorkflowExecutionStep record(
+      Long workflowExecutionId, int seqNo, String stateFrom, String stateTo, String actionType) {
+    WorkflowExecutionStep step = new WorkflowExecutionStep();
+    step.workflowExecutionId = workflowExecutionId;
+    step.seqNo = seqNo;
+    step.stateFrom = stateFrom;
+    step.stateTo = stateTo;
+    step.actionType = actionType;
+    step.reasonText = null;
+    step.evidenceJson = "[]";
+    return step;
+  }
+
+  @PrePersist
+  void onCreate() {
+    if (createdAt == null) {
+      createdAt = OffsetDateTime.now();
+    }
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public Long getWorkflowExecutionId() {
+    return workflowExecutionId;
+  }
+
+  public int getSeqNo() {
+    return seqNo;
+  }
+
+  public String getStateFrom() {
+    return stateFrom;
+  }
+
+  public String getStateTo() {
+    return stateTo;
+  }
+
+  public String getActionType() {
+    return actionType;
+  }
+
+  public String getReasonText() {
+    return reasonText;
+  }
+
+  public String getEvidenceJson() {
+    return evidenceJson;
+  }
+
+  public OffsetDateTime getCreatedAt() {
+    return createdAt;
+  }
+}

--- a/backend/src/main/java/com/init/workflowruntime/domain/WorkflowExecutionStepActionType.java
+++ b/backend/src/main/java/com/init/workflowruntime/domain/WorkflowExecutionStepActionType.java
@@ -1,0 +1,9 @@
+package com.init.workflowruntime.domain;
+
+public final class WorkflowExecutionStepActionType {
+
+  public static final String ASSIGN_INTENT = "ASSIGN_INTENT";
+  public static final String UPSERT_SLOT = "UPSERT_SLOT";
+
+  private WorkflowExecutionStepActionType() {}
+}

--- a/backend/src/main/java/com/init/workflowruntime/domain/WorkflowExecutionStepRepository.java
+++ b/backend/src/main/java/com/init/workflowruntime/domain/WorkflowExecutionStepRepository.java
@@ -1,0 +1,6 @@
+package com.init.workflowruntime.domain;
+
+public interface WorkflowExecutionStepRepository {
+
+  WorkflowExecutionStep save(WorkflowExecutionStep step);
+}

--- a/backend/src/main/java/com/init/workflowruntime/infrastructure/persistence/JpaDecisionLogRepository.java
+++ b/backend/src/main/java/com/init/workflowruntime/infrastructure/persistence/JpaDecisionLogRepository.java
@@ -1,0 +1,17 @@
+package com.init.workflowruntime.infrastructure.persistence;
+
+import com.init.workflowruntime.domain.DecisionLog;
+import com.init.workflowruntime.domain.DecisionLogRepository;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface JpaDecisionLogRepository
+    extends JpaRepository<DecisionLog, Long>, DecisionLogRepository {
+
+  @Query("select max(d.stepSeqNo) from DecisionLog d where d.workflowExecutionId = :execId")
+  Optional<Integer> findMaxStepSeqNoByExecutionId(@Param("execId") Long executionId);
+}

--- a/backend/src/main/java/com/init/workflowruntime/infrastructure/persistence/JpaWorkflowExecutionStepRepository.java
+++ b/backend/src/main/java/com/init/workflowruntime/infrastructure/persistence/JpaWorkflowExecutionStepRepository.java
@@ -1,0 +1,10 @@
+package com.init.workflowruntime.infrastructure.persistence;
+
+import com.init.workflowruntime.domain.WorkflowExecutionStep;
+import com.init.workflowruntime.domain.WorkflowExecutionStepRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface JpaWorkflowExecutionStepRepository
+    extends JpaRepository<WorkflowExecutionStep, Long>, WorkflowExecutionStepRepository {}

--- a/backend/src/main/resources/db/changelog/db.changelog-master.sql
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.sql
@@ -763,8 +763,3 @@ ALTER TABLE runtime.chat_session
 
 CREATE INDEX idx_chat_session_assigned_counselor_id
     ON runtime.chat_session (assigned_counselor_id);
-
---changeset init:20260523-add-idx-decision-log-execution-seq
---comment: Index decision_log lookups by (workflow_execution_id, step_seq_no) for MAX(step_seq_no) hot path
-CREATE INDEX idx_decision_log_execution_seq
-    ON runtime.decision_log (workflow_execution_id, step_seq_no);

--- a/backend/src/main/resources/db/changelog/db.changelog-master.sql
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.sql
@@ -763,3 +763,8 @@ ALTER TABLE runtime.chat_session
 
 CREATE INDEX idx_chat_session_assigned_counselor_id
     ON runtime.chat_session (assigned_counselor_id);
+
+--changeset init:20260523-add-idx-decision-log-execution-seq
+--comment: Index decision_log lookups by (workflow_execution_id, step_seq_no) for MAX(step_seq_no) hot path
+CREATE INDEX idx_decision_log_execution_seq
+    ON runtime.decision_log (workflow_execution_id, step_seq_no);

--- a/backend/src/test/java/com/init/workflowruntime/application/LlmToolServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/LlmToolServiceTest.java
@@ -672,7 +672,7 @@ class LlmToolServiceTest {
 
       service.upsertSlotValue(
           new UpsertLlmToolSlotValueCommand(
-              1L, "credit_card", objectMapper.readTree("\"4111-1111-1111-1111\"")));
+              1L, "credit_card", objectMapper.readTree("\"TEST_SENSITIVE_VALUE\"")));
 
       ArgumentCaptor<DecisionLog> dlogCaptor = ArgumentCaptor.forClass(DecisionLog.class);
       verify(decisionLogRepository).save(dlogCaptor.capture());

--- a/backend/src/test/java/com/init/workflowruntime/application/LlmToolServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/LlmToolServiceTest.java
@@ -616,6 +616,10 @@ class LlmToolServiceTest {
 
       assertThat(stepCaptor.getValue().getSeqNo()).isEqualTo(6);
       assertThat(dlogCaptor.getValue().getStepSeqNo()).isEqualTo(6);
+      assertThat(dlogCaptor.getValue().getPolicyHitsJson()).isEqualTo("[]");
+      assertThat(dlogCaptor.getValue().getRiskHitsJson()).isEqualTo("[]");
+      assertThat(dlogCaptor.getValue().getEvidenceJson()).isEqualTo("[]");
+      assertThat(dlogCaptor.getValue().getConfidenceScore()).isNull();
     }
 
     @Test
@@ -644,6 +648,10 @@ class LlmToolServiceTest {
 
       assertThat(stepCaptor.getValue().getSeqNo()).isEqualTo(3);
       assertThat(dlogCaptor.getValue().getStepSeqNo()).isEqualTo(3);
+      assertThat(dlogCaptor.getValue().getPolicyHitsJson()).isEqualTo("[]");
+      assertThat(dlogCaptor.getValue().getRiskHitsJson()).isEqualTo("[]");
+      assertThat(dlogCaptor.getValue().getEvidenceJson()).isEqualTo("[]");
+      assertThat(dlogCaptor.getValue().getConfidenceScore()).isNull();
     }
 
     @Test
@@ -785,6 +793,10 @@ class LlmToolServiceTest {
       assertThat(dlogCaptor.getValue().getDecisionType())
           .isEqualTo(DecisionLogType.WORKFLOW_FETCHED);
       assertThat(dlogCaptor.getValue().getStepSeqNo()).isEqualTo(1);
+      assertThat(dlogCaptor.getValue().getPolicyHitsJson()).isEqualTo("[]");
+      assertThat(dlogCaptor.getValue().getRiskHitsJson()).isEqualTo("[]");
+      assertThat(dlogCaptor.getValue().getEvidenceJson()).isEqualTo("[]");
+      assertThat(dlogCaptor.getValue().getConfidenceScore()).isNull();
     }
 
     @Test

--- a/backend/src/test/java/com/init/workflowruntime/application/LlmToolServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/LlmToolServiceTest.java
@@ -5,11 +5,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.init.domainpack.domain.model.IntentDefinition;
 import com.init.domainpack.domain.model.IntentSlotBinding;
 import com.init.domainpack.domain.model.IntentWorkflowBinding;
@@ -41,8 +43,14 @@ import com.init.workflowruntime.application.dto.LlmToolWorkflowResponse;
 import com.init.workflowruntime.domain.ChatSession;
 import com.init.workflowruntime.domain.ChatSessionRepository;
 import com.init.workflowruntime.domain.ChatSessionStatus;
+import com.init.workflowruntime.domain.DecisionLog;
+import com.init.workflowruntime.domain.DecisionLogRepository;
+import com.init.workflowruntime.domain.DecisionLogType;
 import com.init.workflowruntime.domain.WorkflowExecution;
 import com.init.workflowruntime.domain.WorkflowExecutionRepository;
+import com.init.workflowruntime.domain.WorkflowExecutionStep;
+import com.init.workflowruntime.domain.WorkflowExecutionStepActionType;
+import com.init.workflowruntime.domain.WorkflowExecutionStepRepository;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -50,7 +58,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -66,6 +77,8 @@ class LlmToolServiceTest {
   @Mock private IntentWorkflowBindingRepository intentWorkflowBindingRepository;
   @Mock private WorkflowDefinitionRepository workflowDefinitionRepository;
   @Mock private WorkflowPolicyRuntimeService workflowPolicyRuntimeService;
+  @Mock private DecisionLogRepository decisionLogRepository;
+  @Mock private WorkflowExecutionStepRepository workflowExecutionStepRepository;
 
   private ObjectMapper objectMapper;
   private LlmToolService service;
@@ -83,6 +96,8 @@ class LlmToolServiceTest {
             intentWorkflowBindingRepository,
             workflowDefinitionRepository,
             workflowPolicyRuntimeService,
+            decisionLogRepository,
+            workflowExecutionStepRepository,
             objectMapper);
   }
 
@@ -561,6 +576,459 @@ class LlmToolServiceTest {
             "{}");
     ReflectionTestUtils.setField(workflow, "id", id);
     return workflow;
+  }
+
+  @Nested
+  @DisplayName("Decision log writer")
+  class DecisionLogWriter {
+
+    @Test
+    @DisplayName("selectIntent 는 decision_log + step 두 row 를 같은 seq 로 작성")
+    void selectIntent_writesBothRowsWithSameSeq() {
+      ChatSession session = createSession(1L, 10L, 101L);
+      IntentDefinition intent = createIntent(70L, 101L, "request_refund", "환불 요청");
+      WorkflowDefinition workflow = createWorkflow(150L, 101L, "refund_flow", "start");
+      WorkflowExecution execution = createExecution(50L, 1L, null, "{}");
+
+      given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+      given(
+              intentDefinitionRepository.findByDomainPackVersionIdAndIntentCode(
+                  101L, "request_refund"))
+          .willReturn(Optional.of(intent));
+      given(intentWorkflowBindingRepository.findAllByIntentDefinitionIdIn(List.of(70L)))
+          .willReturn(List.of(createWorkflowBinding(70L, 150L, true)));
+      given(workflowDefinitionRepository.findByIdAndDomainPackVersionId(150L, 101L))
+          .willReturn(Optional.of(workflow));
+      given(workflowExecutionRepository.findLatestByChatSessionIdForUpdate(1L))
+          .willReturn(Optional.of(execution));
+      given(workflowExecutionRepository.save(execution)).willReturn(execution);
+      given(slotDefinitionRepository.findAllByDomainPackVersionIdOrderBySlotCodeAsc(101L))
+          .willReturn(List.of());
+      given(decisionLogRepository.findMaxStepSeqNoByExecutionId(50L)).willReturn(Optional.of(5));
+
+      service.selectIntent(new SelectLlmToolIntentCommand(1L, "request_refund"));
+
+      ArgumentCaptor<WorkflowExecutionStep> stepCaptor =
+          ArgumentCaptor.forClass(WorkflowExecutionStep.class);
+      ArgumentCaptor<DecisionLog> dlogCaptor = ArgumentCaptor.forClass(DecisionLog.class);
+      verify(workflowExecutionStepRepository).save(stepCaptor.capture());
+      verify(decisionLogRepository).save(dlogCaptor.capture());
+
+      assertThat(stepCaptor.getValue().getSeqNo()).isEqualTo(6);
+      assertThat(dlogCaptor.getValue().getStepSeqNo()).isEqualTo(6);
+    }
+
+    @Test
+    @DisplayName("upsertSlotValue 는 두 row 를 같은 seq 로 작성")
+    void upsertSlotValue_writesBothRowsWithSameSeq() throws Exception {
+      ChatSession session = createSession(1L, 10L, 101L);
+      SlotDefinition slot = createSlot(11L, 101L, "order_id");
+      WorkflowExecution execution = createExecution(50L, 1L, 70L, "{}");
+
+      given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+      given(slotDefinitionRepository.findByDomainPackVersionIdAndSlotCode(101L, "order_id"))
+          .willReturn(Optional.of(slot));
+      given(workflowExecutionRepository.findLatestByChatSessionIdForUpdate(1L))
+          .willReturn(Optional.of(execution));
+      given(workflowExecutionRepository.save(execution)).willReturn(execution);
+      given(decisionLogRepository.findMaxStepSeqNoByExecutionId(50L)).willReturn(Optional.of(2));
+
+      service.upsertSlotValue(
+          new UpsertLlmToolSlotValueCommand(1L, "order_id", objectMapper.readTree("\"A-100\"")));
+
+      ArgumentCaptor<WorkflowExecutionStep> stepCaptor =
+          ArgumentCaptor.forClass(WorkflowExecutionStep.class);
+      ArgumentCaptor<DecisionLog> dlogCaptor = ArgumentCaptor.forClass(DecisionLog.class);
+      verify(workflowExecutionStepRepository).save(stepCaptor.capture());
+      verify(decisionLogRepository).save(dlogCaptor.capture());
+
+      assertThat(stepCaptor.getValue().getSeqNo()).isEqualTo(3);
+      assertThat(dlogCaptor.getValue().getStepSeqNo()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("upsertSlotValue 의 sensitive slot 은 payload_json.value 가 '***' 로 마스킹")
+    void upsertSlotValue_masksSensitiveSlotValue() throws Exception {
+      ChatSession session = createSession(1L, 10L, 101L);
+      SlotDefinition sensitiveSlot = createSlot(11L, 101L, "credit_card");
+      ReflectionTestUtils.setField(sensitiveSlot, "isSensitive", true);
+      WorkflowExecution execution = createExecution(50L, 1L, 70L, "{}");
+
+      given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+      given(slotDefinitionRepository.findByDomainPackVersionIdAndSlotCode(101L, "credit_card"))
+          .willReturn(Optional.of(sensitiveSlot));
+      given(workflowExecutionRepository.findLatestByChatSessionIdForUpdate(1L))
+          .willReturn(Optional.of(execution));
+      given(workflowExecutionRepository.save(execution)).willReturn(execution);
+      given(decisionLogRepository.findMaxStepSeqNoByExecutionId(50L)).willReturn(Optional.empty());
+
+      service.upsertSlotValue(
+          new UpsertLlmToolSlotValueCommand(
+              1L, "credit_card", objectMapper.readTree("\"4111-1111-1111-1111\"")));
+
+      ArgumentCaptor<DecisionLog> dlogCaptor = ArgumentCaptor.forClass(DecisionLog.class);
+      verify(decisionLogRepository).save(dlogCaptor.capture());
+
+      ObjectNode payload =
+          (ObjectNode) objectMapper.readTree(dlogCaptor.getValue().getPayloadJson());
+      assertThat(payload.get("value").asText()).isEqualTo("***");
+    }
+
+    @Test
+    @DisplayName("upsertSlotValue 의 non-sensitive slot 은 원본 값 유지")
+    void upsertSlotValue_preservesNonSensitiveSlotValue() throws Exception {
+      ChatSession session = createSession(1L, 10L, 101L);
+      SlotDefinition slot = createSlot(11L, 101L, "order_id");
+      WorkflowExecution execution = createExecution(50L, 1L, 70L, "{}");
+
+      given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+      given(slotDefinitionRepository.findByDomainPackVersionIdAndSlotCode(101L, "order_id"))
+          .willReturn(Optional.of(slot));
+      given(workflowExecutionRepository.findLatestByChatSessionIdForUpdate(1L))
+          .willReturn(Optional.of(execution));
+      given(workflowExecutionRepository.save(execution)).willReturn(execution);
+      given(decisionLogRepository.findMaxStepSeqNoByExecutionId(50L)).willReturn(Optional.empty());
+
+      service.upsertSlotValue(
+          new UpsertLlmToolSlotValueCommand(1L, "order_id", objectMapper.readTree("\"A-200\"")));
+
+      ArgumentCaptor<DecisionLog> dlogCaptor = ArgumentCaptor.forClass(DecisionLog.class);
+      verify(decisionLogRepository).save(dlogCaptor.capture());
+
+      ObjectNode payload =
+          (ObjectNode) objectMapper.readTree(dlogCaptor.getValue().getPayloadJson());
+      assertThat(payload.get("value").asText()).isEqualTo("A-200");
+    }
+
+    @Test
+    @DisplayName("selectIntent 의 step.state_from=null, state_to=initialState")
+    void selectIntent_stepStateFromNullToInitial() {
+      ChatSession session = createSession(1L, 10L, 101L);
+      IntentDefinition intent = createIntent(70L, 101L, "request_refund", "환불 요청");
+      WorkflowDefinition workflow = createWorkflow(150L, 101L, "refund_flow", "start");
+      WorkflowExecution execution = createExecution(50L, 1L, null, "{}");
+
+      given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+      given(
+              intentDefinitionRepository.findByDomainPackVersionIdAndIntentCode(
+                  101L, "request_refund"))
+          .willReturn(Optional.of(intent));
+      given(intentWorkflowBindingRepository.findAllByIntentDefinitionIdIn(List.of(70L)))
+          .willReturn(List.of(createWorkflowBinding(70L, 150L, true)));
+      given(workflowDefinitionRepository.findByIdAndDomainPackVersionId(150L, 101L))
+          .willReturn(Optional.of(workflow));
+      given(workflowExecutionRepository.findLatestByChatSessionIdForUpdate(1L))
+          .willReturn(Optional.of(execution));
+      given(workflowExecutionRepository.save(execution)).willReturn(execution);
+      given(slotDefinitionRepository.findAllByDomainPackVersionIdOrderBySlotCodeAsc(101L))
+          .willReturn(List.of());
+      given(decisionLogRepository.findMaxStepSeqNoByExecutionId(50L)).willReturn(Optional.empty());
+
+      service.selectIntent(new SelectLlmToolIntentCommand(1L, "request_refund"));
+
+      ArgumentCaptor<WorkflowExecutionStep> stepCaptor =
+          ArgumentCaptor.forClass(WorkflowExecutionStep.class);
+      verify(workflowExecutionStepRepository).save(stepCaptor.capture());
+
+      assertThat(stepCaptor.getValue().getStateFrom()).isNull();
+      assertThat(stepCaptor.getValue().getStateTo()).isEqualTo("start");
+      assertThat(stepCaptor.getValue().getActionType())
+          .isEqualTo(WorkflowExecutionStepActionType.ASSIGN_INTENT);
+    }
+
+    @Test
+    @DisplayName("upsertSlotValue 의 step.state_from=state_to=currentState")
+    void upsertSlotValue_stepStateUnchanged() throws Exception {
+      ChatSession session = createSession(1L, 10L, 101L);
+      SlotDefinition slot = createSlot(11L, 101L, "order_id");
+      WorkflowExecution execution = createExecution(50L, 1L, 70L, "{}");
+      ReflectionTestUtils.setField(execution, "currentState", "collect_slots");
+
+      given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+      given(slotDefinitionRepository.findByDomainPackVersionIdAndSlotCode(101L, "order_id"))
+          .willReturn(Optional.of(slot));
+      given(workflowExecutionRepository.findLatestByChatSessionIdForUpdate(1L))
+          .willReturn(Optional.of(execution));
+      given(workflowExecutionRepository.save(execution)).willReturn(execution);
+      given(decisionLogRepository.findMaxStepSeqNoByExecutionId(50L)).willReturn(Optional.empty());
+
+      service.upsertSlotValue(
+          new UpsertLlmToolSlotValueCommand(1L, "order_id", objectMapper.readTree("\"A-100\"")));
+
+      ArgumentCaptor<WorkflowExecutionStep> stepCaptor =
+          ArgumentCaptor.forClass(WorkflowExecutionStep.class);
+      verify(workflowExecutionStepRepository).save(stepCaptor.capture());
+
+      assertThat(stepCaptor.getValue().getStateFrom()).isEqualTo("collect_slots");
+      assertThat(stepCaptor.getValue().getStateTo()).isEqualTo("collect_slots");
+      assertThat(stepCaptor.getValue().getActionType())
+          .isEqualTo(WorkflowExecutionStepActionType.UPSERT_SLOT);
+    }
+
+    @Test
+    @DisplayName("getCurrentWorkflow 는 execution 이 있으면 WORKFLOW_FETCHED 1행 작성, step 미작성")
+    void getCurrentWorkflow_writesDecisionLogOnly_whenExecutionExists() {
+      ChatSession session = createSession(1L, 10L, 101L);
+      WorkflowExecution execution = createExecution(50L, 1L, 70L, "{}");
+
+      given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+      given(workflowExecutionRepository.findTopByChatSessionIdOrderByStartedAtDescIdDesc(1L))
+          .willReturn(Optional.of(execution));
+      given(decisionLogRepository.findMaxStepSeqNoByExecutionId(50L)).willReturn(Optional.empty());
+
+      service.getCurrentWorkflow(new GetCurrentWorkflowCommand(1L));
+
+      ArgumentCaptor<DecisionLog> dlogCaptor = ArgumentCaptor.forClass(DecisionLog.class);
+      verify(decisionLogRepository).save(dlogCaptor.capture());
+      verify(workflowExecutionStepRepository, never()).save(any());
+
+      assertThat(dlogCaptor.getValue().getDecisionType())
+          .isEqualTo(DecisionLogType.WORKFLOW_FETCHED);
+      assertThat(dlogCaptor.getValue().getStepSeqNo()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("getCurrentWorkflow 는 execution 이 없으면 로그 스킵")
+    void getCurrentWorkflow_skipsLogging_whenNoExecution() {
+      ChatSession session = createSession(1L, 10L, 101L);
+
+      given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+      given(workflowExecutionRepository.findTopByChatSessionIdOrderByStartedAtDescIdDesc(1L))
+          .willReturn(Optional.empty());
+
+      service.getCurrentWorkflow(new GetCurrentWorkflowCommand(1L));
+
+      verify(decisionLogRepository, never()).save(any());
+      verify(workflowExecutionStepRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("getContext 는 missingSlots 를 missing_slots_json 에 기록")
+    void getContext_recordsMissingSlots() {
+      ChatSession session = createSession(1L, 10L, 101L);
+      WorkflowExecution execution = createExecution(50L, 1L, 70L, "{\"order_id\":\"A-100\"}");
+      SlotDefinition orderSlot = createSlot(11L, 101L, "order_id");
+      SlotDefinition customerSlot = createSlot(12L, 101L, "customer_name");
+      IntentSlotBinding orderBinding = createBinding(70L, 11L, true, 1, "주문번호");
+      IntentSlotBinding customerBinding = createBinding(70L, 12L, true, 2, "고객명");
+
+      given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+      given(workflowExecutionRepository.findTopByChatSessionIdOrderByStartedAtDescIdDesc(1L))
+          .willReturn(Optional.of(execution));
+      given(slotDefinitionRepository.findAllByDomainPackVersionIdOrderBySlotCodeAsc(101L))
+          .willReturn(List.of(customerSlot, orderSlot));
+      given(intentSlotBindingRepository.findAllByIntentDefinitionIdIn(List.of(70L)))
+          .willReturn(List.of(orderBinding, customerBinding));
+      given(decisionLogRepository.findMaxStepSeqNoByExecutionId(50L)).willReturn(Optional.empty());
+
+      service.getContext(new GetLlmToolContextCommand(1L));
+
+      ArgumentCaptor<DecisionLog> dlogCaptor = ArgumentCaptor.forClass(DecisionLog.class);
+      verify(decisionLogRepository).save(dlogCaptor.capture());
+
+      assertThat(dlogCaptor.getValue().getDecisionType())
+          .isEqualTo(DecisionLogType.CONTEXT_FETCHED);
+      assertThat(dlogCaptor.getValue().getMissingSlotsJson()).contains("customer_name");
+    }
+
+    @Test
+    @DisplayName("listSlots 는 payload_json.returnedCount 에 slot 갯수 기록")
+    void listSlots_recordsReturnedCount() {
+      ChatSession session = createSession(1L, 10L, 101L);
+      WorkflowExecution execution = createExecution(50L, 1L, 70L, "{}");
+      SlotDefinition slot1 = createSlot(11L, 101L, "order_id");
+      SlotDefinition slot2 = createSlot(12L, 101L, "customer_name");
+
+      given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+      given(workflowExecutionRepository.findTopByChatSessionIdOrderByStartedAtDescIdDesc(1L))
+          .willReturn(Optional.of(execution));
+      given(slotDefinitionRepository.findAllByDomainPackVersionIdOrderBySlotCodeAsc(101L))
+          .willReturn(List.of(slot1, slot2));
+      given(intentSlotBindingRepository.findAllByIntentDefinitionIdIn(List.of(70L)))
+          .willReturn(List.of());
+      given(decisionLogRepository.findMaxStepSeqNoByExecutionId(50L)).willReturn(Optional.empty());
+
+      service.listSlots(new ListLlmToolSlotsCommand(1L));
+
+      ArgumentCaptor<DecisionLog> dlogCaptor = ArgumentCaptor.forClass(DecisionLog.class);
+      verify(decisionLogRepository).save(dlogCaptor.capture());
+
+      assertThat(dlogCaptor.getValue().getDecisionType()).isEqualTo(DecisionLogType.SLOTS_LISTED);
+      assertThat(dlogCaptor.getValue().getPayloadJson()).contains("\"returnedCount\":2");
+    }
+
+    @Test
+    @DisplayName("getSlot 은 payload_json.slotCode 기록")
+    void getSlot_recordsSlotCode() {
+      ChatSession session = createSession(1L, 10L, 101L);
+      WorkflowExecution execution = createExecution(50L, 1L, 70L, "{}");
+      SlotDefinition slot = createSlot(11L, 101L, "order_id");
+
+      given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+      given(workflowExecutionRepository.findTopByChatSessionIdOrderByStartedAtDescIdDesc(1L))
+          .willReturn(Optional.of(execution));
+      given(slotDefinitionRepository.findByDomainPackVersionIdAndSlotCode(101L, "order_id"))
+          .willReturn(Optional.of(slot));
+      given(intentSlotBindingRepository.findAllByIntentDefinitionIdIn(List.of(70L)))
+          .willReturn(List.of());
+      given(decisionLogRepository.findMaxStepSeqNoByExecutionId(50L)).willReturn(Optional.empty());
+
+      service.getSlot(new GetLlmToolSlotCommand(1L, "order_id"));
+
+      ArgumentCaptor<DecisionLog> dlogCaptor = ArgumentCaptor.forClass(DecisionLog.class);
+      verify(decisionLogRepository).save(dlogCaptor.capture());
+
+      assertThat(dlogCaptor.getValue().getDecisionType()).isEqualTo(DecisionLogType.SLOT_FETCHED);
+      assertThat(dlogCaptor.getValue().getPayloadJson()).contains("\"slotCode\":\"order_id\"");
+    }
+
+    @Test
+    @DisplayName("listIntents 는 returnedCount 기록")
+    void listIntents_recordsReturnedCount() {
+      ChatSession session = createSession(1L, 10L, 101L);
+      WorkflowExecution execution = createExecution(50L, 1L, 70L, "{}");
+      IntentDefinition intent1 = createIntent(70L, 101L, "request_refund", "환불 요청");
+      IntentDefinition intent2 = createIntent(71L, 101L, "change_address", "배송지 변경");
+
+      given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+      given(intentDefinitionRepository.findByDomainPackVersionId(101L))
+          .willReturn(List.of(intent1, intent2));
+      given(workflowExecutionRepository.findTopByChatSessionIdOrderByStartedAtDescIdDesc(1L))
+          .willReturn(Optional.of(execution));
+      given(decisionLogRepository.findMaxStepSeqNoByExecutionId(50L)).willReturn(Optional.empty());
+
+      service.listIntents(new ListLlmToolIntentsCommand(1L));
+
+      ArgumentCaptor<DecisionLog> dlogCaptor = ArgumentCaptor.forClass(DecisionLog.class);
+      verify(decisionLogRepository).save(dlogCaptor.capture());
+
+      assertThat(dlogCaptor.getValue().getDecisionType()).isEqualTo(DecisionLogType.INTENTS_LISTED);
+      assertThat(dlogCaptor.getValue().getPayloadJson()).contains("\"returnedCount\":2");
+    }
+
+    @Test
+    @DisplayName("step_seq_no 는 decision_log MAX + 1")
+    void stepSeqNo_isMaxPlusOne() {
+      ChatSession session = createSession(1L, 10L, 101L);
+      WorkflowExecution execution = createExecution(50L, 1L, 70L, "{}");
+
+      given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+      given(workflowExecutionRepository.findTopByChatSessionIdOrderByStartedAtDescIdDesc(1L))
+          .willReturn(Optional.of(execution));
+      given(decisionLogRepository.findMaxStepSeqNoByExecutionId(50L)).willReturn(Optional.of(7));
+
+      service.getCurrentWorkflow(new GetCurrentWorkflowCommand(1L));
+
+      ArgumentCaptor<DecisionLog> dlogCaptor = ArgumentCaptor.forClass(DecisionLog.class);
+      verify(decisionLogRepository).save(dlogCaptor.capture());
+
+      assertThat(dlogCaptor.getValue().getStepSeqNo()).isEqualTo(8);
+    }
+
+    @Test
+    @DisplayName("같은 execution 에 read 가 연속되면 step_seq_no 가 매번 증가")
+    void readsBumpSeqEachCall() {
+      ChatSession session = createSession(1L, 10L, 101L);
+      WorkflowExecution execution = createExecution(50L, 1L, 70L, "{}");
+
+      given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+      given(workflowExecutionRepository.findTopByChatSessionIdOrderByStartedAtDescIdDesc(1L))
+          .willReturn(Optional.of(execution));
+      given(decisionLogRepository.findMaxStepSeqNoByExecutionId(50L))
+          .willReturn(Optional.of(3))
+          .willReturn(Optional.of(4));
+
+      service.getCurrentWorkflow(new GetCurrentWorkflowCommand(1L));
+      service.getCurrentWorkflow(new GetCurrentWorkflowCommand(1L));
+
+      ArgumentCaptor<DecisionLog> dlogCaptor = ArgumentCaptor.forClass(DecisionLog.class);
+      verify(decisionLogRepository, times(2)).save(dlogCaptor.capture());
+
+      List<DecisionLog> captured = dlogCaptor.getAllValues();
+      assertThat(captured.get(0).getStepSeqNo()).isEqualTo(4);
+      assertThat(captured.get(1).getStepSeqNo()).isEqualTo(5);
+    }
+
+    @Test
+    @DisplayName("write 후 read 가 와도 step.seq_no = dlog.step_seq_no (write row 기준)")
+    void writeAndReadShareSeqWithinSameTransaction() {
+      ChatSession session = createSession(1L, 10L, 101L);
+      SlotDefinition slot = createSlot(11L, 101L, "order_id");
+      WorkflowExecution execution = createExecution(50L, 1L, 70L, "{}");
+
+      given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+      given(slotDefinitionRepository.findByDomainPackVersionIdAndSlotCode(101L, "order_id"))
+          .willReturn(Optional.of(slot));
+      given(workflowExecutionRepository.findLatestByChatSessionIdForUpdate(1L))
+          .willReturn(Optional.of(execution));
+      given(workflowExecutionRepository.save(execution)).willReturn(execution);
+      given(decisionLogRepository.findMaxStepSeqNoByExecutionId(50L)).willReturn(Optional.of(3));
+
+      service.upsertSlotValue(
+          new UpsertLlmToolSlotValueCommand(
+              1L, "order_id", objectMapper.createObjectNode().put("v", "x")));
+
+      ArgumentCaptor<WorkflowExecutionStep> stepCaptor =
+          ArgumentCaptor.forClass(WorkflowExecutionStep.class);
+      ArgumentCaptor<DecisionLog> dlogCaptor = ArgumentCaptor.forClass(DecisionLog.class);
+      verify(workflowExecutionStepRepository).save(stepCaptor.capture());
+      verify(decisionLogRepository).save(dlogCaptor.capture());
+
+      assertThat(stepCaptor.getValue().getSeqNo()).isEqualTo(dlogCaptor.getValue().getStepSeqNo());
+    }
+
+    @Test
+    @DisplayName("WorkflowExecution.save 가 실패하면 dlog 도 저장되지 않는다 (verify never)")
+    void writePath_doesNotWriteLog_whenExecutionSaveThrows() {
+      ChatSession session = createSession(1L, 10L, 101L);
+      IntentDefinition intent = createIntent(70L, 101L, "request_refund", "환불 요청");
+      WorkflowDefinition workflow = createWorkflow(150L, 101L, "refund_flow", "start");
+      WorkflowExecution execution = createExecution(50L, 1L, null, "{}");
+
+      given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+      given(
+              intentDefinitionRepository.findByDomainPackVersionIdAndIntentCode(
+                  101L, "request_refund"))
+          .willReturn(Optional.of(intent));
+      given(intentWorkflowBindingRepository.findAllByIntentDefinitionIdIn(List.of(70L)))
+          .willReturn(List.of(createWorkflowBinding(70L, 150L, true)));
+      given(workflowDefinitionRepository.findByIdAndDomainPackVersionId(150L, 101L))
+          .willReturn(Optional.of(workflow));
+      given(workflowExecutionRepository.findLatestByChatSessionIdForUpdate(1L))
+          .willReturn(Optional.of(execution));
+      given(workflowExecutionRepository.save(execution))
+          .willThrow(new RuntimeException("DB failure"));
+
+      assertThatThrownBy(
+              () -> service.selectIntent(new SelectLlmToolIntentCommand(1L, "request_refund")))
+          .isInstanceOf(RuntimeException.class);
+
+      verify(decisionLogRepository, never()).save(any());
+      verify(workflowExecutionStepRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName(
+        "read tool 은 dlog 저장 직전에 findLatestByChatSessionIdForUpdate (PESSIMISTIC_WRITE) 를 호출")
+    void readPath_acquiresPessimisticLockBeforeDlogSave() {
+      ChatSession session = createSession(1L, 10L, 101L);
+      WorkflowExecution execution = createExecution(50L, 1L, 70L, "{}");
+
+      given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+      given(workflowExecutionRepository.findTopByChatSessionIdOrderByStartedAtDescIdDesc(1L))
+          .willReturn(Optional.of(execution));
+      given(decisionLogRepository.findMaxStepSeqNoByExecutionId(50L)).willReturn(Optional.empty());
+
+      service.getCurrentWorkflow(new GetCurrentWorkflowCommand(1L));
+
+      InOrder inOrder = Mockito.inOrder(workflowExecutionRepository, decisionLogRepository);
+      inOrder
+          .verify(workflowExecutionRepository)
+          .findTopByChatSessionIdOrderByStartedAtDescIdDesc(1L);
+      inOrder.verify(workflowExecutionRepository).findLatestByChatSessionIdForUpdate(1L);
+      inOrder.verify(decisionLogRepository).findMaxStepSeqNoByExecutionId(50L);
+      inOrder.verify(decisionLogRepository).save(any(DecisionLog.class));
+    }
   }
 
   @Nested


### PR DESCRIPTION
#### Summary

- `LlmToolService` 7개 tool call 경로에 `runtime.decision_log` 쓰기를 추가하여 외부 LLM 결정 이력을 audit-trail로 기록
- 쓰기 tool 2종(`selectIntent`, `upsertSlotValue`)은 `runtime.workflow_execution_step` row도 같은 트랜잭션에 기록
- read tool 5종은 method-level `@Transactional` override로 class-level `readOnly=true`를 무효화하고 `PESSIMISTIC_WRITE` lock으로 `step_seq_no` race 방지
- `runtime.decision_log (workflow_execution_id, step_seq_no)` 인덱스 Liquibase changeset 1건 신규 추가
- `DecisionLogType`, `WorkflowExecutionStepActionType` 포함 신규 도메인 파일 8개, `LlmToolServiceTest$DecisionLogWriter` 17개 신규 테스트

---

#### Context

스펙: `.agent/specs/525.md` — **[BE] 5.2.5 Decision Log Writer — LLM Tool Calls**

기존 `LlmToolController/Service`의 7개 tool call 경로가 `runtime.decision_log`에 audit row를 남기지 않던 문제를 해결한다. 스펙 범위는 쓰기 책임 inline 추가와 DB 인덱스 changeset 신설에 한정된다. `decision_log` 조회 API(U-003), `confidence_score` LLM source 연결(U-009), policy/risk evaluator 통합(U-010)은 본 PR 범위 밖(Deferred/Out-of-scope).

---

#### What Changed

| 파일 | 변경 요약 |
|---|---|
| `LlmToolService.java` | `DecisionLogRepository`·`WorkflowExecutionStepRepository` 생성자 주입. 7개 메서드 dlog 저장 추가. read 5종 `@Transactional` override. `nextStepSeqNo`, `maskSensitiveSlotValue`, `toJsonArray` private helper 신규. |
| `DecisionLog.java` | 신규 JPA 엔티티. 9인자 factory `record(...)`, public setter 없음, `@PrePersist` createdAt. |
| `DecisionLogType.java` | 7개 상수 (`INTENT_SELECTED`, `SLOT_UPSERTED`, `WORKFLOW_FETCHED`, `CONTEXT_FETCHED`, `SLOTS_LISTED`, `SLOT_FETCHED`, `INTENTS_LISTED`). `final` class, private constructor. |
| `DecisionLogRepository.java` + `JpaDecisionLogRepository.java` | domain interface + JPA 구현. `findMaxStepSeqNoByExecutionId` JPQL. |
| `WorkflowExecutionStep.java` | 신규 JPA 엔티티. 5인자 factory `record(...)`, public setter 없음. |
| `WorkflowExecutionStepActionType.java` | 2개 상수 (`ASSIGN_INTENT`, `UPSERT_SLOT`). |
| `WorkflowExecutionStepRepository.java` + `JpaWorkflowExecutionStepRepository.java` | domain interface + JPA 구현. |
| `db.changelog-master.sql` | `init:20260523-add-idx-decision-log-execution-seq` changeset 1건 append. CREATE TABLE DDL 미변경. |
| `LlmToolServiceTest.java` | `@Nested DecisionLogWriter` 17개 테스트 추가. 기존 setUp에 2개 mock 추가. |

---

#### Assumptions Adopted

| ID | 결정 유형 | 내용 |
|---|---|---|
| U-001 | Confirmed | DDL 재사용 — `runtime.decision_log`·`runtime.workflow_execution_step` 테이블 DDL 변경 없음. JPA 엔티티 신규 작성만. |
| U-004 (Q-006) | Decision | 7개 tool call 모두 dlog 1행 작성(Option B). execution 미존재 read tool은 스킵(Q-006 확정). |
| U-007 (Q-004) | Decision | Column 매핑 Option A(minimal) + sensitive slot masking 적용. `payload_json.value`만 마스킹, `WorkflowExecution.slotValuesJson`은 원본 유지. |
| U-008 | Engineering-bound | decision_log write는 tool call 본 처리와 동일 트랜잭션, read tool PESSIMISTIC_WRITE serialization 채택. readOnly 최적화 손실은 명시적으로 수용. |
| U-009, U-010 | Deferred | `confidence_score = null` 고정, `policy_hits_json`/`risk_hits_json`/`evidence_json` = `"[]"` 고정. evaluator 통합은 별도 spec. |
| U-012 | Confirmed | `idx_decision_log_execution_seq` Liquibase changeset 신설. `schema.md`에 이미 문서화된 인덱스를 changeset으로 소급 적용. |

---

#### Spec Deviations

N/A — 스펙 대비 구현 차이 없음. spec-consistency-report v2 CONSISTENT.

---

#### Blocked / Skipped Items

| 항목 | 사유 |
|---|---|
| `decision_log` 조회 API | U-003 Confirmed out-of-scope. 별도 spec 예정. |
| `confidence_score` LLM source | U-009 Deferred. LLM tool schema 변경 필요, 별도 spec. |
| `policy_hits_json`·`risk_hits_json` evaluator 연결 | U-010 Deferred. evaluator 미구현, `[]` 고정 유지. |
| `WorkflowExecutionStep` read 메서드 | YAGNI — 현재 조회 필요 없음. 추후 step 조회 spec에서 확장. |

---

#### Test Notes

**Unit Tests** — `LlmToolServiceTest$DecisionLogWriter` 17개 신규 테스트:
- write tool: `selectIntent`/`upsertSlotValue` 각각 step + dlog 동일 seq 작성 검증
- read tool: execution 존재/미존재 분기, step 미작성 검증(`verify never`)
- seq 채번: MAX+1, 연속 증가, write-read seq 공유 검증
- sensitive slot 마스킹 / non-sensitive 원본 보존
- `WorkflowExecution.save` 실패 시 dlog rollback (`verify never`)
- InOrder: `findLatestByChatSessionIdForUpdate` → `findMaxStepSeqNoByExecutionId` → `save(DecisionLog)` 순서 검증

**Regression** — `LlmToolServiceTest` 기존 16개, `LlmToolControllerTest` 11개 회귀 통과.

---
#### Reviewer Focus

1. **PESSIMISTIC_WRITE lock 순서** (`LlmToolService.java` read tool 5종): `findLatestByChatSessionIdForUpdate` 반환값을 의도적으로 버린다. `@SuppressWarnings("java:S2201")` 주석에 이유 명시. lock 획득 side-effect가 목적임을 확인 바람.
2. **`@Transactional` override 범위**: read tool 5종이 class-level `readOnly=true`를 method-level `@Transactional`로 무효화한다. JPA flush 최적화를 의도적으로 포기한 trade-off임.
3. **step_seq_no 채번**: `decision_log` MAX만 참조. `workflow_execution_step` MAX는 보지 않음. read tool gap(예: step.seq = {1,4,7}, dlog.seq = {1..7})이 설계 의도.
4. **W-003 assertion 추가** (`LlmToolServiceTest.java`): 3개 테스트에 `getPolicyHitsJson()/"[]"`, `getRiskHitsJson()/"[]"`, `getEvidenceJson()/"[]"`, `getConfidenceScore()/null` assertion 추가. factory 보증 검증.
5. **Liquibase changeset 위치**: `db.changelog-master.sql` 마지막 changeset 뒤에 append. CREATE TABLE DDL 미변경 확인.

---

#### Conflicts

없음.

---

#### Ready to Merge

**Final Audit verdict: PASS** (source: `.handoff/525/audit-report-525-2026-05-23-2233.md`)

- Critical violations: 0
- W-001 (java:S2201 false positive): Fixed — `@SuppressWarnings` 5개 메서드 추가
- W-002 (Sonar MCP Phase 1 partial): Skipped — MCP server schema 이슈, 코드 수정 대상 아님
- W-003 (test coverage gap): Fixed — 3개 테스트에 assertion 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 워크플로우 실행 중 주요 의사결정 이벤트를 기록하는 의사결정 로깅 기능 추가
  * 워크플로우 실행 단계(상태 전이, 액션 수행)를 추적하는 단계 기록 기능 추가
  * 민감한 슬롯 값 자동 마스킹을 통한 보안 강화
  * 인텐트 선택, 슬롯 업데이트 등 주요 작업 단계별 상세 기록

* **테스트**
  * 의사결정 로깅 및 실행 단계 저장 로직에 대한 종합 테스트 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ajou-2026-1-capstone-5/ostone/pull/277?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->