### PR TITLE
feat/511: [FE] Demo Workflow UX Redesign

### DIFF
--- a/frontend/DESIGN.md
+++ b/frontend/DESIGN.md
@@ -6,7 +6,7 @@ Figma's interface is the design tool that designed itself — a masterclass in t
 
 The page presents a fascinating duality: the interface chrome is strictly black-and-white (literally only `#000000` and `#ffffff` detected as colors), while the hero section and product showcases explode with vibrant multi-color gradients — electric greens, bright yellows, deep purples, hot pinks. This separation means the design system itself is colorless, treating the product's colorful output as the hero content. Figma's marketing page is essentially a white gallery wall displaying colorful art.
 
-What makes Figma distinctive beyond the variable font is its circle-and-pill geometry. Buttons use 50px radius (pill) or 50% (perfect circle for icon buttons), creating an organic, tool-palette-like feel. The dashed-outline focus indicator (`dashed 2px`) is a deliberate design choice that echoes selection handles in the Figma editor itself — the website's UI language references the product's UI language.
+What makes Figma distinctive beyond the variable font is its circle-and-pill geometry. Buttons use 50px radius (pill) or 50% (perfect circle for icon buttons), creating an organic, tool-palette-like feel. In this product UI, focus should stay visible without using dotted or dashed outlines: deepen the border color and add a soft monochrome ring instead.
 
 **Key Characteristics:**
 
@@ -14,7 +14,7 @@ What makes Figma distinctive beyond the variable font is its circle-and-pill geo
 - Strictly black-and-white interface chrome — color exists only in product content
 - figmaMono for uppercase technical labels with wide letter-spacing
 - Pill (50px) and circular (50%) button geometry
-- Dashed focus outlines echoing Figma's editor selection handles
+- Border/ring focus states instead of dotted or dashed outlines
 - Vibrant multi-color hero gradients (green, yellow, purple, pink)
 - OpenType `"kern"` feature enabled globally
 - Negative letter-spacing throughout — even body text at -0.14px to -0.26px
@@ -78,7 +78,7 @@ _Note: Figma's marketing site uses ONLY these two colors for its interface layer
 - Background: Pure Black (`#000000`)
 - Text: Pure White (`#ffffff`)
 - Radius: circle (50%) for icon buttons
-- Focus: dashed 2px outline
+- Focus: darker border plus soft monochrome ring
 - Maximum emphasis
 
 **White Pill**
@@ -87,7 +87,7 @@ _Note: Figma's marketing site uses ONLY these two colors for its interface layer
 - Text: Pure Black (`#000000`)
 - Padding: 8px 18px 10px (asymmetric vertical)
 - Radius: pill (50px)
-- Focus: dashed 2px outline
+- Focus: darker border plus soft monochrome ring
 - Standard CTA on dark/colored surfaces
 
 **Glass Dark**
@@ -95,7 +95,7 @@ _Note: Figma's marketing site uses ONLY these two colors for its interface layer
 - Background: `rgba(0, 0, 0, 0.08)` (subtle dark overlay)
 - Text: Pure Black
 - Radius: circle (50%)
-- Focus: dashed 2px outline
+- Focus: darker border plus soft monochrome ring
 - Secondary action on light surfaces
 
 **Glass Light**
@@ -103,7 +103,7 @@ _Note: Figma's marketing site uses ONLY these two colors for its interface layer
 - Background: `rgba(255, 255, 255, 0.16)` (frosted glass)
 - Text: Pure White
 - Radius: circle (50%)
-- Focus: dashed 2px outline
+- Focus: darker border plus soft monochrome ring
 - Secondary action on dark/colored surfaces
 
 ### Cards & Containers
@@ -137,11 +137,11 @@ _Note: Figma's marketing site uses ONLY these two colors for its interface layer
 - White text overlay with 86px display heading
 - Product screenshots floating within the gradient
 
-**Dashed Focus Indicators**
+**Focus Indicators**
 
-- All interactive elements use `dashed 2px` outline on focus
-- References the selection handles in the Figma editor
-- A meta-design choice connecting website and product
+- Interactive elements must keep a visible focus state
+- Use `outline: none` with darker `border-color` and a subtle `box-shadow` ring
+- Do not use dotted or dashed outlines for selected inputs, cards, nodes, or controls
 
 ## 5. Layout Principles
 
@@ -189,7 +189,7 @@ _Note: Figma's marketing site uses ONLY these two colors for its interface layer
 - Use figmaSans with precise variable weights (320–540) — the granular weight control IS the design
 - Keep the interface strictly black-and-white — color comes from product content only
 - Use pill (50px) and circular (50%) geometry for all interactive elements
-- Apply dashed 2px focus outlines — the signature accessibility pattern
+- Apply visible focus states with darker borders and soft monochrome rings
 - Enable `"kern"` feature on all text
 - Use figmaMono in uppercase with positive letter-spacing for labels
 - Apply negative letter-spacing throughout (-0.1px to -1.72px)
@@ -199,7 +199,7 @@ _Note: Figma's marketing site uses ONLY these two colors for its interface layer
 - Don't add interface colors — the monochrome palette is absolute
 - Don't use standard font weights (400, 500, 600, 700) — use the variable font's unique stops (320, 330, 340, 450, 480, 540)
 - Don't use sharp corners on buttons — pill and circular geometry only
-- Don't use solid focus outlines — dashed is the signature
+- Don't use dotted or dashed focus outlines
 - Don't increase body font weight above 450 — the light-weight aesthetic is core
 - Don't use positive letter-spacing on body text — it's always negative
 
@@ -242,6 +242,6 @@ _Note: Figma's marketing site uses ONLY these two colors for its interface layer
 
 1. Use variable font weight stops precisely: 320, 330, 340, 450, 480, 540, 700
 2. Interface is always black + white — never add colors to chrome
-3. Dashed focus outlines, not solid
+3. Focus uses darker borders and soft monochrome rings, not dotted or dashed outlines
 4. Letter-spacing is always negative on body, always positive on mono labels
 5. Pill (50px) for buttons/tabs, circle (50%) for icon buttons

--- a/frontend/src/app/index.css
+++ b/frontend/src/app/index.css
@@ -65,6 +65,7 @@
   --divider-subtle: rgba(0, 0, 0, 0.04);
   --app-header-height: 72px;
   --overlay-bg: rgba(0, 0, 0, 0.45);
+  --focus-ring: 0 0 0 3px rgba(0, 0, 0, 0.12);
 
   /* ---- Workflow node category palette (oklch) ---------------------------
      Used by frontend/src/shared/styles/workflow-node-theme.module.css
@@ -120,8 +121,8 @@
 }
 
 *:focus-visible {
-  outline: dashed 2px;
-  outline-offset: 2px;
+  outline: none;
+  box-shadow: var(--focus-ring);
 }
 
 body {

--- a/frontend/src/features/consultation/ui/MessageDetailPanel.module.css
+++ b/frontend/src/features/consultation/ui/MessageDetailPanel.module.css
@@ -196,8 +196,8 @@
 }
 
 .closeButton:focus-visible {
-  outline: 2px dashed var(--ink);
-  outline-offset: 2px;
+  outline: none;
+  box-shadow: var(--focus-ring);
 }
 
 .closeButton:active {

--- a/frontend/src/features/consultation/ui/chat-history/SessionCard.module.css
+++ b/frontend/src/features/consultation/ui/chat-history/SessionCard.module.css
@@ -23,8 +23,8 @@
 }
 
 .card:focus-visible {
-  outline: 2px dashed var(--ink);
-  outline-offset: 2px;
+  outline: none;
+  box-shadow: var(--focus-ring);
 }
 
 .selected {

--- a/frontend/src/features/consultation/ui/chat-panel.module.css
+++ b/frontend/src/features/consultation/ui/chat-panel.module.css
@@ -99,8 +99,8 @@
 }
 
 .messageGroup:focus-visible {
-  outline: 2px dashed var(--ink);
-  outline-offset: 2px;
+  outline: none;
+  box-shadow: var(--focus-ring);
 }
 
 .messageSelected {

--- a/frontend/src/features/consultation/ui/queue-panel.module.css
+++ b/frontend/src/features/consultation/ui/queue-panel.module.css
@@ -51,8 +51,8 @@
 }
 
 .queueItem:focus-visible {
-  outline: 2px dashed var(--primary-color);
-  outline-offset: 2px;
+  outline: none;
+  box-shadow: var(--focus-ring);
   background: rgba(0, 0, 0, 0.05);
 }
 

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.module.css
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.module.css
@@ -301,8 +301,8 @@
 .approvalButton:focus-visible,
 .approvalDialogCancel:focus-visible,
 .approvalDialogConfirm:focus-visible {
-  outline: 2px dashed #000000;
-  outline-offset: 3px;
+  outline: none;
+  box-shadow: var(--focus-ring);
 }
 
 .approvalActions {

--- a/frontend/src/features/intent-revision-draft/ui/intent-revision-draft.module.css
+++ b/frontend/src/features/intent-revision-draft/ui/intent-revision-draft.module.css
@@ -129,8 +129,8 @@
 
 .field input:focus,
 .field textarea:focus {
-  outline: 2px dashed var(--text-primary);
-  outline-offset: 2px;
+  outline: none;
+  box-shadow: var(--focus-ring);
 }
 
 .field input[aria-invalid="true"],

--- a/frontend/src/features/policy-draft-read/ui/PolicyDetailPanel.module.css
+++ b/frontend/src/features/policy-draft-read/ui/PolicyDetailPanel.module.css
@@ -91,8 +91,8 @@
 }
 
 .editButton:focus-visible {
-  outline: 2px dashed var(--text-primary);
-  outline-offset: 2px;
+  outline: none;
+  box-shadow: var(--focus-ring);
 }
 
 .body {

--- a/frontend/src/features/policy-draft-read/ui/PolicyListPanel.module.css
+++ b/frontend/src/features/policy-draft-read/ui/PolicyListPanel.module.css
@@ -70,8 +70,8 @@
 }
 
 .item:focus-visible {
-  outline: 2px dashed var(--text-primary);
-  outline-offset: 2px;
+  outline: none;
+  box-shadow: var(--focus-ring);
 }
 
 .itemActive {

--- a/frontend/src/features/risk-draft-read/ui/RiskDetailPanel.module.css
+++ b/frontend/src/features/risk-draft-read/ui/RiskDetailPanel.module.css
@@ -82,8 +82,8 @@
 }
 
 .editButton:focus-visible {
-  outline: 2px dashed var(--text-primary);
-  outline-offset: 2px;
+  outline: none;
+  box-shadow: var(--focus-ring);
 }
 
 .body {
@@ -226,8 +226,8 @@
 }
 
 .retryButton:focus-visible {
-  outline: 2px dashed var(--text-primary);
-  outline-offset: 2px;
+  outline: none;
+  box-shadow: var(--focus-ring);
 }
 
 @media (max-width: 767px) {

--- a/frontend/src/features/risk-draft-read/ui/RiskListPanel.module.css
+++ b/frontend/src/features/risk-draft-read/ui/RiskListPanel.module.css
@@ -70,8 +70,8 @@
 }
 
 .item:focus-visible {
-  outline: 2px dashed var(--text-primary);
-  outline-offset: 2px;
+  outline: none;
+  box-shadow: var(--focus-ring);
 }
 
 .itemActive {
@@ -189,8 +189,8 @@
 }
 
 .retryButton:focus-visible {
-  outline: 2px dashed var(--text-primary);
-  outline-offset: 2px;
+  outline: none;
+  box-shadow: var(--focus-ring);
 }
 
 @media (max-width: 1599px) {

--- a/frontend/src/features/slot-draft-read/ui/SlotListPanel.module.css
+++ b/frontend/src/features/slot-draft-read/ui/SlotListPanel.module.css
@@ -67,8 +67,8 @@
 }
 
 .item:focus-visible {
-  outline: 2px dashed var(--text-primary);
-  outline-offset: 2px;
+  outline: none;
+  box-shadow: var(--focus-ring);
 }
 
 .itemActive {

--- a/frontend/src/features/update-risk/ui/risk-edit-panel.module.css
+++ b/frontend/src/features/update-risk/ui/risk-edit-panel.module.css
@@ -75,8 +75,8 @@
 }
 
 .closeButton:focus-visible {
-  outline: 2px dashed var(--text-primary);
-  outline-offset: 2px;
+  outline: none;
+  box-shadow: var(--focus-ring);
 }
 
 .body {

--- a/frontend/src/features/update-workflow/ui/addNodeToolbar.module.css
+++ b/frontend/src/features/update-workflow/ui/addNodeToolbar.module.css
@@ -56,5 +56,5 @@
 .addNodeBtn:focus-visible {
   outline: none;
   border-color: var(--text-primary);
-  box-shadow: 0 0 0 3px oklch(0.62 0.22 285 / 0.16);
+  box-shadow: var(--focus-ring);
 }

--- a/frontend/src/features/update-workflow/ui/addNodeToolbar.module.css
+++ b/frontend/src/features/update-workflow/ui/addNodeToolbar.module.css
@@ -54,6 +54,7 @@
 }
 
 .addNodeBtn:focus-visible {
-  outline: dashed 2px var(--node-status-active);
-  outline-offset: 2px;
+  outline: none;
+  border-color: var(--text-primary);
+  box-shadow: 0 0 0 3px oklch(0.62 0.22 285 / 0.16);
 }

--- a/frontend/src/features/update-workflow/ui/nodes/editableNodes.module.css
+++ b/frontend/src/features/update-workflow/ui/nodes/editableNodes.module.css
@@ -328,5 +328,5 @@
 
 .deleteBtn:focus-visible {
   outline: none;
-  box-shadow: 0 0 0 3px oklch(0.62 0.2 25 / 0.2);
+  box-shadow: var(--focus-ring);
 }

--- a/frontend/src/features/update-workflow/ui/nodes/editableNodes.module.css
+++ b/frontend/src/features/update-workflow/ui/nodes/editableNodes.module.css
@@ -61,7 +61,7 @@
   min-width: 0;
   background: transparent;
   border: none;
-  border-bottom: 1px dashed rgba(255, 255, 255, 0.55);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.38);
   color: #fff;
   font-family: inherit;
   font-size: inherit;
@@ -79,6 +79,7 @@
 .labelInput:focus {
   border-bottom-color: #fff;
   outline: none;
+  box-shadow: 0 1px 0 #fff;
 }
 
 .body {
@@ -252,7 +253,7 @@
   width: 90px;
   background: transparent;
   border: none;
-  border-bottom: 1px dashed var(--node-zinc-500);
+  border-bottom: 1px solid var(--node-zinc-500);
   color: var(--node-zinc-700);
   font-family: inherit;
   font-size: 12px;
@@ -269,6 +270,7 @@
 
 .terminalInput:focus {
   border-bottom-color: var(--node-status-active);
+  box-shadow: 0 1px 0 var(--node-status-active);
 }
 
 /* ---- Handles ---------------------------------------------------------- */
@@ -325,6 +327,6 @@
 }
 
 .deleteBtn:focus-visible {
-  outline: dashed 2px var(--danger);
-  outline-offset: 2px;
+  outline: none;
+  box-shadow: 0 0 0 3px oklch(0.62 0.2 25 / 0.2);
 }

--- a/frontend/src/features/user-chat/ui/MessageInput.tsx
+++ b/frontend/src/features/user-chat/ui/MessageInput.tsx
@@ -21,7 +21,7 @@ export function MessageInput({ onSend, disabled = false }: MessageInputProps) {
     <div className="flex gap-2 border-t border-gray-200 bg-white p-4">
       <input
         aria-label="메시지 입력"
-        className="min-h-11 flex-1 rounded-full border border-gray-300 bg-white px-4 text-sm text-black outline-none transition focus:outline-2 focus:outline-dashed focus:outline-black disabled:pointer-events-none disabled:bg-gray-100 disabled:text-gray-500"
+        className="min-h-11 flex-1 rounded-full border border-gray-300 bg-white px-4 text-sm text-black outline-none transition focus:border-black focus:ring-3 focus:ring-black/10 disabled:pointer-events-none disabled:bg-gray-100 disabled:text-gray-500"
         disabled={disabled}
         placeholder="메시지를 입력하세요"
         value={content}
@@ -35,7 +35,7 @@ export function MessageInput({ onSend, disabled = false }: MessageInputProps) {
       <button
         type="button"
         aria-label="메시지 보내기"
-        className="inline-flex size-11 items-center justify-center rounded-full bg-black text-white transition hover:bg-gray-900 focus:outline-2 focus:outline-dashed focus:outline-black focus:outline-offset-2 disabled:pointer-events-none disabled:bg-gray-300 disabled:text-white"
+        className="inline-flex size-11 items-center justify-center rounded-full bg-black text-white outline-none transition hover:bg-gray-900 focus:ring-3 focus:ring-black/15 disabled:pointer-events-none disabled:bg-gray-300 disabled:text-white"
         disabled={disabled}
         onClick={submit}
       >

--- a/frontend/src/features/workflow-draft-read/ui/TransitionListPanel.module.css
+++ b/frontend/src/features/workflow-draft-read/ui/TransitionListPanel.module.css
@@ -31,8 +31,8 @@
 }
 
 .retryButton:focus-visible {
-  outline: dashed 2px var(--text-primary);
-  outline-offset: 2px;
+  outline: none;
+  box-shadow: var(--focus-ring);
 }
 
 .list {

--- a/frontend/src/features/workflow-draft-read/ui/TransitionPopover.module.css
+++ b/frontend/src/features/workflow-draft-read/ui/TransitionPopover.module.css
@@ -46,8 +46,8 @@
 }
 
 .closeButton:focus-visible {
-  outline: dashed 2px var(--text-primary);
-  outline-offset: 2px;
+  outline: none;
+  box-shadow: var(--focus-ring);
 }
 
 .field {

--- a/frontend/src/features/workflow-draft-read/ui/WorkflowDetailPanel.module.css
+++ b/frontend/src/features/workflow-draft-read/ui/WorkflowDetailPanel.module.css
@@ -41,8 +41,8 @@
 }
 
 .editButton:focus-visible {
-  outline: dashed 2px var(--text-primary);
-  outline-offset: 2px;
+  outline: none;
+  box-shadow: var(--focus-ring);
 }
 
 .code {

--- a/frontend/src/features/workflow-list/ui/WorkflowCard.test.tsx
+++ b/frontend/src/features/workflow-list/ui/WorkflowCard.test.tsx
@@ -69,6 +69,20 @@ describe("WorkflowCard", () => {
     expect(screen.getByTestId("workflow-list-card-42-detail")).toBeInTheDocument();
   });
 
+  it("keyboard focus가 카드 안에 남아 있으면 mouseLeave로 preview를 닫지 않는다", () => {
+    setup();
+    const card = screen.getByTestId("workflow-list-card-42");
+    const button = screen.getByTestId("workflow-list-card-42-open");
+
+    fireEvent.focus(button);
+    expect(screen.getByTestId("workflow-list-card-42-graph")).toBeInTheDocument();
+
+    button.focus();
+    fireEvent.mouseLeave(card);
+
+    expect(screen.getByTestId("workflow-list-card-42-graph")).toBeInTheDocument();
+  });
+
   it("카드 버튼 클릭 시 onOpen이 호출된다", () => {
     const onOpen = vi.fn();
     setup({ onOpen });

--- a/frontend/src/features/workflow-list/ui/WorkflowCard.test.tsx
+++ b/frontend/src/features/workflow-list/ui/WorkflowCard.test.tsx
@@ -22,8 +22,6 @@ const ENTRY: WorkspaceWorkflowEntry = {
 function setup(overrides: Partial<React.ComponentProps<typeof WorkflowCard>> = {}) {
   const defaults: React.ComponentProps<typeof WorkflowCard> = {
     entry: ENTRY,
-    expanded: false,
-    onToggle: vi.fn(),
     onOpen: vi.fn(),
   };
   return render(
@@ -34,11 +32,10 @@ function setup(overrides: Partial<React.ComponentProps<typeof WorkflowCard>> = {
 }
 
 describe("WorkflowCard", () => {
-  it("기본(접힘) 상태에서는 graph mini, description, 열기 버튼이 보이지 않는다", () => {
+  it("기본 상태에서는 graph mini와 description이 보이지 않는다", () => {
     setup();
     expect(screen.queryByTestId("workflow-list-card-42-graph")).not.toBeInTheDocument();
     expect(screen.queryByTestId("workflow-list-card-42-detail")).not.toBeInTheDocument();
-    expect(screen.queryByTestId("workflow-list-card-42-open")).not.toBeInTheDocument();
   });
 
   it("기본 상태에서 헤더의 pack 이름과 워크플로우 코드를 표시한다", () => {
@@ -48,41 +45,49 @@ describe("WorkflowCard", () => {
     expect(screen.getByText("환불 워크플로우")).toBeInTheDocument();
   });
 
-  it("카드 클릭 시 onToggle 호출", () => {
-    const onToggle = vi.fn();
-    setup({ onToggle });
-    fireEvent.click(screen.getByTestId("workflow-list-card-42-toggle"));
-    expect(onToggle).toHaveBeenCalledTimes(1);
+  it("카드 클릭 시 onOpen 호출", () => {
+    const onOpen = vi.fn();
+    setup({ onOpen });
+    fireEvent.click(screen.getByTestId("workflow-list-card-42-open"));
+    expect(onOpen).toHaveBeenCalledTimes(1);
   });
 
-  it("expanded=true 일 때 graph mini, description, 열기 버튼이 노출된다", () => {
-    setup({ expanded: true });
+  it("hover 중 graph mini와 description이 노출되고 hover가 끝나면 닫힌다", () => {
+    setup();
+    fireEvent.mouseEnter(screen.getByTestId("workflow-list-card-42"));
     expect(screen.getByTestId("workflow-list-card-42-graph")).toBeInTheDocument();
     expect(screen.getByTestId("workflow-list-card-42-detail")).toBeInTheDocument();
     expect(screen.getByText("환불 요청 처리")).toBeInTheDocument();
-    expect(screen.getByTestId("workflow-list-card-42-open")).toBeInTheDocument();
+    fireEvent.mouseLeave(screen.getByTestId("workflow-list-card-42"));
+    expect(screen.queryByTestId("workflow-list-card-42-graph")).not.toBeInTheDocument();
   });
 
-  it("열기 버튼 클릭 시 onOpen 호출 (onToggle 은 호출되지 않음)", () => {
-    const onToggle = vi.fn();
+  it("focus 중 graph mini와 description이 노출된다", () => {
+    setup();
+    fireEvent.focus(screen.getByTestId("workflow-list-card-42-open"));
+    expect(screen.getByTestId("workflow-list-card-42-graph")).toBeInTheDocument();
+    expect(screen.getByTestId("workflow-list-card-42-detail")).toBeInTheDocument();
+  });
+
+  it("카드 버튼 클릭 시 onOpen이 호출된다", () => {
     const onOpen = vi.fn();
-    setup({ expanded: true, onToggle, onOpen });
+    setup({ onOpen });
     fireEvent.click(screen.getByTestId("workflow-list-card-42-open"));
     expect(onOpen).toHaveBeenCalledTimes(1);
-    expect(onToggle).not.toHaveBeenCalled();
   });
 
   it("testIdPrefix 를 적용하면 모든 testId 가 그 prefix 를 사용한다", () => {
-    setup({ testIdPrefix: "pack-workflows", expanded: true });
+    setup({ testIdPrefix: "pack-workflows" });
+    fireEvent.mouseEnter(screen.getByTestId("pack-workflows-card-42"));
     expect(screen.getByTestId("pack-workflows-card-42")).toBeInTheDocument();
     expect(screen.getByTestId("pack-workflows-card-42-open")).toBeInTheDocument();
   });
 
   it("description 이 없으면 detail 영역에서 설명 단락을 건너뛴다", () => {
     setup({
-      expanded: true,
       entry: { ...ENTRY, description: null },
     });
+    fireEvent.mouseEnter(screen.getByTestId("workflow-list-card-42"));
     expect(screen.queryByText("환불 요청 처리")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/features/workflow-list/ui/WorkflowCard.tsx
+++ b/frontend/src/features/workflow-list/ui/WorkflowCard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type FocusEvent } from "react";
+import { useEffect, useRef, useState, type FocusEvent, type MouseEvent } from "react";
 
 import type { WorkspaceWorkflowEntry } from "@/entities/workflow";
 import { Mono, Pill } from "@/shared/ui/ostone/atoms";
@@ -46,6 +46,12 @@ export function WorkflowCard({
     }
   };
 
+  const closePreviewOnMouseLeave = (event: MouseEvent<HTMLElement>) => {
+    if (!event.currentTarget.contains(document.activeElement)) {
+      setPreviewOpen(false);
+    }
+  };
+
   return (
     <article
       ref={cardRef}
@@ -54,7 +60,7 @@ export function WorkflowCard({
       data-preview-open={previewOpen ? "true" : "false"}
       style={{ gridRow: `span ${rowSpan}` }}
       onMouseEnter={() => setPreviewOpen(true)}
-      onMouseLeave={() => setPreviewOpen(false)}
+      onMouseLeave={closePreviewOnMouseLeave}
       onFocusCapture={() => setPreviewOpen(true)}
       onBlurCapture={closePreviewOnBlur}
     >

--- a/frontend/src/features/workflow-list/ui/WorkflowCard.tsx
+++ b/frontend/src/features/workflow-list/ui/WorkflowCard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type FocusEvent } from "react";
 
 import type { WorkspaceWorkflowEntry } from "@/entities/workflow";
 import { Mono, Pill } from "@/shared/ui/ostone/atoms";
@@ -11,22 +11,19 @@ const ROW_GAP_PX = 8;
 
 interface WorkflowCardProps {
   entry: WorkspaceWorkflowEntry;
-  expanded: boolean;
-  onToggle: () => void;
   onOpen: () => void;
   testIdPrefix?: string;
 }
 
 export function WorkflowCard({
   entry,
-  expanded,
-  onToggle,
   onOpen,
   testIdPrefix = "workflow-list",
 }: WorkflowCardProps) {
   const cardTestId = `${testIdPrefix}-card-${entry.workflowId}`;
   const cardRef = useRef<HTMLElement>(null);
   const [rowSpan, setRowSpan] = useState(20);
+  const [previewOpen, setPreviewOpen] = useState(false);
 
   useEffect(() => {
     const el = cardRef.current;
@@ -40,29 +37,35 @@ export function WorkflowCard({
     const observer = new ResizeObserver(recompute);
     observer.observe(el);
     return () => observer.disconnect();
-  }, [expanded]);
+  }, [previewOpen]);
+
+  const closePreviewOnBlur = (event: FocusEvent<HTMLElement>) => {
+    const nextTarget = event.relatedTarget;
+    if (!nextTarget || !event.currentTarget.contains(nextTarget)) {
+      setPreviewOpen(false);
+    }
+  };
 
   return (
     <article
       ref={cardRef}
       className={styles.card}
       data-testid={cardTestId}
-      data-expanded={expanded ? "true" : "false"}
+      data-preview-open={previewOpen ? "true" : "false"}
       style={{ gridRow: `span ${rowSpan}` }}
+      onMouseEnter={() => setPreviewOpen(true)}
+      onMouseLeave={() => setPreviewOpen(false)}
+      onFocusCapture={() => setPreviewOpen(true)}
+      onBlurCapture={closePreviewOnBlur}
     >
       <button
         type="button"
         className={styles.cardBody}
-        onClick={onToggle}
-        data-testid={`${cardTestId}-toggle`}
+        onClick={onOpen}
+        data-testid={`${cardTestId}-open`}
       >
-        {expanded && (
-          <div
-            className={styles.graphSlot}
-            data-testid={`${cardTestId}-graph`}
-            onClick={(e) => e.stopPropagation()}
-            onKeyDown={(e) => e.stopPropagation()}
-          >
+        {previewOpen && (
+          <div className={styles.graphSlot} data-testid={`${cardTestId}-graph`}>
             <WorkflowGraphMini
               workspaceId={null /* derived from packId via context — see WorkflowListView */}
               packId={entry.packId}
@@ -81,7 +84,7 @@ export function WorkflowCard({
           <h2 className={styles.title}>{entry.name}</h2>
         </div>
 
-        {expanded && (
+        {previewOpen && (
           <div className={styles.detail} data-testid={`${cardTestId}-detail`}>
             {entry.description && <p className={styles.description}>{entry.description}</p>}
             <Mono className={styles.meta}>
@@ -92,23 +95,9 @@ export function WorkflowCard({
       </button>
 
       <div className={styles.footer}>
-        {expanded ? (
-          <button
-            type="button"
-            className={styles.openBtn}
-            onClick={(e) => {
-              e.stopPropagation();
-              onOpen();
-            }}
-            data-testid={`${cardTestId}-open`}
-          >
-            열기
-          </button>
-        ) : (
-          <Mono className={styles.meta}>
-            pack #{entry.packId} · version #{entry.versionId}
-          </Mono>
-        )}
+        <Mono className={styles.meta}>
+          pack #{entry.packId} · version #{entry.versionId}
+        </Mono>
       </div>
     </article>
   );

--- a/frontend/src/features/workflow-list/ui/WorkflowListView.test.tsx
+++ b/frontend/src/features/workflow-list/ui/WorkflowListView.test.tsx
@@ -88,20 +88,20 @@ describe("WorkflowListView", () => {
     expect(cards[0].dataset.testid).toBe("wl-card-20");
   });
 
-  it("카드 클릭 시 펼침 상태가 토글된다", () => {
+  it("카드 hover 시 preview가 열리고 hover가 끝나면 닫힌다", () => {
     setup([makeEntry(1)]);
     const card = screen.getByTestId("wl-card-1");
-    expect(card.dataset.expanded).toBe("false");
-    fireEvent.click(screen.getByTestId("wl-card-1-toggle"));
-    expect(screen.getByTestId("wl-card-1").dataset.expanded).toBe("true");
-    fireEvent.click(screen.getByTestId("wl-card-1-toggle"));
-    expect(screen.getByTestId("wl-card-1").dataset.expanded).toBe("false");
+    expect(card.dataset.previewOpen).toBe("false");
+    fireEvent.mouseEnter(card);
+    expect(screen.getByTestId("wl-card-1").dataset.previewOpen).toBe("true");
+    expect(screen.getByTestId("wl-card-1-graph")).toBeInTheDocument();
+    fireEvent.mouseLeave(card);
+    expect(screen.getByTestId("wl-card-1").dataset.previewOpen).toBe("false");
   });
 
-  it("열기 버튼 클릭 시 onOpen 콜백이 entry 와 함께 호출된다", () => {
+  it("카드 클릭 시 onOpen 콜백이 entry 와 함께 호출된다", () => {
     const onOpen = vi.fn();
     setup([makeEntry(7, "Lucky")], onOpen);
-    fireEvent.click(screen.getByTestId("wl-card-7-toggle"));
     fireEvent.click(screen.getByTestId("wl-card-7-open"));
     expect(onOpen).toHaveBeenCalledWith(expect.objectContaining({ workflowId: 7, name: "Lucky" }));
   });

--- a/frontend/src/features/workflow-list/ui/WorkflowListView.tsx
+++ b/frontend/src/features/workflow-list/ui/WorkflowListView.tsx
@@ -44,7 +44,6 @@ export function WorkflowListView({
 }: WorkflowListViewProps) {
   const [settings, setSettings] = useState<PageWorkflowSettings>(() => readPageWorkflowSettings());
   const [settingsOpen, setSettingsOpen] = useState(false);
-  const [expanded, setExpanded] = useState<Set<number>>(() => new Set());
   const [page, setPage] = useState(1);
   const [filterWorkflowId, setFilterWorkflowId] = useState<number | null>(null);
   const settingsButtonRef = useRef<HTMLButtonElement>(null);
@@ -72,15 +71,6 @@ export function WorkflowListView({
   const safePage = Math.min(page, totalPages);
   const pageStart = (safePage - 1) * settings.pageSize;
   const pageEntries = filteredAndSorted.slice(pageStart, pageStart + settings.pageSize);
-
-  const handleToggleCard = (workflowId: number) => {
-    setExpanded((prev) => {
-      const next = new Set(prev);
-      if (next.has(workflowId)) next.delete(workflowId);
-      else next.add(workflowId);
-      return next;
-    });
-  };
 
   const settingsEntries: WorkflowSettingEntry[] = [
     {
@@ -185,8 +175,6 @@ export function WorkflowListView({
           <WorkflowCard
             key={`${entry.packId}-${entry.workflowId}`}
             entry={entry}
-            expanded={expanded.has(entry.workflowId)}
-            onToggle={() => handleToggleCard(entry.workflowId)}
             onOpen={() => onOpen(entry)}
             testIdPrefix={testIdPrefix}
           />

--- a/frontend/src/features/workflow-list/ui/workflow-card.module.css
+++ b/frontend/src/features/workflow-list/ui/workflow-card.module.css
@@ -12,16 +12,19 @@
     transform 120ms ease;
 }
 
-.card:hover {
+.card:hover,
+.card:focus-within {
   box-shadow: var(--shadow-card-hover, var(--shadow-card));
   transform: translateY(-1px);
 }
 
-.card[data-expanded="true"] {
+.card[data-preview-open="true"],
+.card:focus-within {
   border-color: var(--ink);
 }
 
 .cardBody {
+  width: 100%;
   display: flex;
   flex-direction: column;
   gap: var(--s-2);
@@ -32,6 +35,12 @@
   cursor: pointer;
   font: inherit;
   color: inherit;
+  border-radius: var(--r-lg) var(--r-lg) 0 0;
+  outline: none;
+}
+
+.cardBody:focus-visible {
+  box-shadow: inset 0 0 0 2px var(--ink);
 }
 
 .graphSlot {
@@ -95,20 +104,9 @@
 .footer {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-start;
   padding: 8px var(--s-3);
   border-top: 1px solid var(--line-2);
   background: var(--paper-2);
   border-radius: 0 0 var(--r-lg) var(--r-lg);
-}
-
-.openBtn {
-  padding: 4px 12px;
-  border-radius: var(--r-2);
-  border: 1px solid var(--ink);
-  background: var(--ink);
-  color: var(--paper);
-  font-family: var(--mono);
-  font-size: 11px;
-  cursor: pointer;
 }

--- a/frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.test.tsx
+++ b/frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.test.tsx
@@ -142,7 +142,7 @@ describe("WorkflowDraftReadPage", () => {
     expect(screen.getByTestId("inline-editor")).toHaveTextContent("editing refund.standard");
   });
 
-  it("편집 모드에서 보기 버튼 클릭 시 viewer로 복귀한다", () => {
+  it("편집 모드에서는 상단 보기 버튼을 렌더하지 않는다", () => {
     mockUseGetWorkflowDefinition.mockReturnValue({
       isLoading: false,
       isError: false,
@@ -160,9 +160,7 @@ describe("WorkflowDraftReadPage", () => {
     renderPage("/workspaces/1/domain-packs/2/workflows/10?versionId=3");
     fireEvent.click(screen.getByTestId("edit-toggle"));
     expect(screen.getByTestId("inline-editor")).toBeInTheDocument();
-    fireEvent.click(screen.getByTestId("view-toggle"));
-    expect(screen.queryByTestId("inline-editor")).not.toBeInTheDocument();
-    expect(screen.getByTestId("graph-viewer")).toBeInTheDocument();
+    expect(screen.queryByTestId("view-toggle")).not.toBeInTheDocument();
   });
 
   it("InlineWorkflowEditor의 onClose가 호출되면 보기 모드로 복귀한다", () => {

--- a/frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.tsx
@@ -12,6 +12,7 @@ import { EmptyState } from "@/shared/ui/ostone/atoms/EmptyState";
 import { useGetWorkflowDefinition } from "@/entities/workflow";
 import type { WorkflowGraph } from "@/entities/workflow";
 import { GraphViewer } from "@/features/workflow-viewer/ui/GraphViewer";
+import styles from "./workflow-draft-read-page.module.css";
 
 function isWorkflowGraph(v: unknown): v is WorkflowGraph {
   return (
@@ -112,71 +113,39 @@ export function WorkflowDraftReadPage() {
 
   return (
     <OstoneShell active="workflows" crumbs={crumbs}>
-      <div
-        style={{
-          display: "flex",
-          flexDirection: "column",
-          height: "100%",
-          overflow: "hidden",
-        }}
-      >
-        <div
-          style={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "space-between",
-            padding: "14px 20px",
-            borderBottom: "1px solid var(--line-2)",
-            gap: "12px",
-          }}
-        >
-          <div style={{ display: "flex", alignItems: "center", gap: "10px", minWidth: 0 }}>
+      <div className={styles.detailPage}>
+        <div className={styles.detailHeader}>
+          <div className={styles.titleGroup}>
             <Button
               type="button"
               variant="outline"
               size="sm"
               onClick={handleBackToList}
               data-testid="list-back"
-              /*
-               * shadcn Button defaults to font-medium (500); Pretendard renders
-               * that with a noticeably heavy stem. 450 sits between the original
-               * thin look and the shadcn default — heavier than regular body
-               * copy but lighter than the page title.
-               */
-              style={{ fontWeight: 450 }}
+              className={styles.headerButton}
             >
               <Icon name="chevron" size={14} />
               목록
             </Button>
-            <h2
-              data-testid="workflow-detail-title"
-              style={{
-                fontFamily: "var(--sans)",
-                fontSize: "16px",
-                fontWeight: 600,
-                margin: 0,
-                color: "var(--ink)",
-                overflow: "hidden",
-                textOverflow: "ellipsis",
-                whiteSpace: "nowrap",
-              }}
-            >
-              {workflow?.name || (query.isLoading ? "워크플로우 로드 중..." : "워크플로우")}
-            </h2>
+            <div className={styles.titleStack}>
+              <h2 data-testid="workflow-detail-title" className={styles.detailTitle}>
+                {workflow?.name || (query.isLoading ? "워크플로우 로드 중..." : "워크플로우")}
+              </h2>
+              {workflow?.description && (
+                <p className={styles.detailDescription}>{workflow.description}</p>
+              )}
+            </div>
             {workflow?.workflowCode && (
-              <Mono style={{ fontSize: "12px", color: "var(--ink-3)", fontWeight: 500 }}>
-                {workflow.workflowCode}
-              </Mono>
+              <Mono className={styles.workflowCode}>{workflow.workflowCode}</Mono>
             )}
             {workflow && <Pill tone="signal">DRAFT</Pill>}
+            {workflow && isEditing && <Pill tone="ink">EDITING</Pill>}
             {workflow && (
-              <Mono style={{ fontSize: "12px", color: "var(--ink-3)", fontWeight: 500 }}>
-                {nodeCount} nodes
-              </Mono>
+              <Mono className={styles.nodeCount}>{nodeCount} nodes</Mono>
             )}
           </div>
 
-          <div style={{ display: "flex", alignItems: "center", gap: "8px", flexShrink: 0 }}>
+          <div className={styles.headerActions}>
             {workflow && !isEditing && (
               <Button
                 type="button"
@@ -184,68 +153,31 @@ export function WorkflowDraftReadPage() {
                 size="sm"
                 data-testid="edit-toggle"
                 onClick={() => setIsEditing(true)}
-                style={{ fontWeight: 450 }}
+                className={styles.headerButton}
               >
                 <Icon name="edit" size={14} />
                 편집
               </Button>
             )}
-            {workflow && isEditing && (
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                data-testid="view-toggle"
-                onClick={() => setIsEditing(false)}
-                style={{ fontWeight: 450 }}
-              >
-                <Icon name="eye" size={14} />
-                보기
-              </Button>
-            )}
           </div>
         </div>
 
-        <div
-          style={{
-            flex: 1,
-            position: "relative",
-            margin: "12px 20px 20px",
-            borderRadius: "var(--r-2)",
-            border: "1px solid var(--line-2)",
-            background: "var(--paper)",
-            overflow: "hidden",
-            minHeight: "400px",
-          }}
-        >
+        <div className={styles.canvasFrame} data-editing={isEditing ? "true" : "false"}>
           {!enabled && (
-            <div
-              data-testid="workflow-select-empty"
-              style={{ padding: "32px", textAlign: "center", color: "var(--ink-3)" }}
-            >
+            <div data-testid="workflow-select-empty" className={styles.centerState}>
               좌측 사이드바에서 워크플로우를 선택하세요.
             </div>
           )}
 
           {enabled && query.isLoading && (
-            <div
-              data-testid="workflow-loading"
-              style={{
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-                height: "100%",
-                flexDirection: "column",
-                gap: "12px",
-              }}
-            >
+            <div data-testid="workflow-loading" className={styles.loadingState}>
               <LoadingSpinner />
-              <Mono style={{ fontSize: "11px", color: "var(--ink-3)" }}>워크플로우 로드 중...</Mono>
+              <Mono className={styles.loadingText}>워크플로우 로드 중...</Mono>
             </div>
           )}
 
           {enabled && query.isError && (
-            <div data-testid="workflow-error" style={{ padding: "32px" }}>
+            <div data-testid="workflow-error" className={styles.errorState}>
               <ErrorState
                 message="워크플로우를 불러오지 못했습니다."
                 onRetry={() => query.refetch()}

--- a/frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.tsx
@@ -116,17 +116,6 @@ export function WorkflowDraftReadPage() {
       <div className={styles.detailPage}>
         <div className={styles.detailHeader}>
           <div className={styles.titleGroup}>
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={handleBackToList}
-              data-testid="list-back"
-              className={styles.headerButton}
-            >
-              <Icon name="chevron" size={14} />
-              목록
-            </Button>
             <div className={styles.titleStack}>
               <h2 data-testid="workflow-detail-title" className={styles.detailTitle}>
                 {workflow?.name || (query.isLoading ? "워크플로우 로드 중..." : "워크플로우")}
@@ -146,14 +135,24 @@ export function WorkflowDraftReadPage() {
           </div>
 
           <div className={styles.headerActions}>
+            <Button
+              type="button"
+              variant="outline"
+              size="default"
+              onClick={handleBackToList}
+              data-testid="list-back"
+              className={`${styles.headerButton} ${styles.backAction}`}
+            >
+              <Icon name="chevron" size={14} />
+              목록
+            </Button>
             {workflow && !isEditing && (
               <Button
                 type="button"
-                variant="outline"
-                size="sm"
+                size="default"
                 data-testid="edit-toggle"
                 onClick={() => setIsEditing(true)}
-                className={styles.headerButton}
+                className={`${styles.headerButton} ${styles.editAction}`}
               >
                 <Icon name="edit" size={14} />
                 편집

--- a/frontend/src/pages/domain-pack/ui/domain-pack-list-page.module.css
+++ b/frontend/src/pages/domain-pack/ui/domain-pack-list-page.module.css
@@ -135,12 +135,14 @@
 .statusBadgeOperating {
   background: var(--ink);
   color: var(--paper);
+  font-weight: 540;
 }
 
 .statusBadgeIdle {
-  border: 1px solid var(--line);
+  border: 1px solid var(--ink-4);
   background: var(--paper-2);
-  color: var(--ink-3);
+  color: var(--ink-2);
+  font-weight: 540;
 }
 
 .versionText,

--- a/frontend/src/pages/domain-pack/ui/intent-draft-read-page.module.css
+++ b/frontend/src/pages/domain-pack/ui/intent-draft-read-page.module.css
@@ -4,16 +4,16 @@
   width: 100%;
   height: calc(100vh - var(--app-header-height));
   overflow: hidden;
-  background: var(--bg-color);
+  background: var(--paper);
 }
 
 .pageHeader {
-  padding: 20px 28px 18px;
-  border-bottom: 1px solid var(--glass-border);
+  padding: 16px 24px;
+  border-bottom: 1px solid var(--line-2);
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  background: var(--bg-color);
+  gap: 10px;
+  background: var(--paper);
 }
 
 .breadcrumb {
@@ -26,11 +26,11 @@
   line-height: 1;
   letter-spacing: 0.54px;
   text-transform: uppercase;
-  color: var(--text-muted);
+  color: var(--ink-3);
 }
 
 .breadcrumbSeparator {
-  color: var(--text-muted);
+  color: var(--ink-4);
 }
 
 .versionMeta {
@@ -43,10 +43,10 @@
 .versionTitle {
   font-family: "Pretendard Variable", sans-serif;
   font-weight: 540;
-  font-size: 24px;
+  font-size: 20px;
   line-height: 1.1;
-  letter-spacing: -0.26px;
-  color: var(--text-primary);
+  letter-spacing: -0.14px;
+  color: var(--ink);
 }
 
 .versionBadge {
@@ -57,11 +57,12 @@
   font-size: 11px;
   letter-spacing: 0.54px;
   text-transform: uppercase;
-  padding: 6px 12px 7px;
-  border-radius: var(--radius-xl);
-  background: var(--glass-dark);
-  border: 1px solid transparent;
-  color: var(--text-primary);
+  padding: 4px 10px 5px;
+  border-radius: var(--r-pill);
+  background: var(--paper-2);
+  border: 1px solid var(--line);
+  color: var(--ink-2);
+  font-weight: 540;
 }
 
 .twoPane {
@@ -69,6 +70,7 @@
   flex: 1;
   overflow: hidden;
   min-height: 0;
+  background: var(--paper);
 }
 
 .invalidParams {
@@ -84,10 +86,12 @@
   flex: 1;
   min-width: 0;
   min-height: 0;
+  background: var(--paper);
 }
 
 .listSlot {
   flex: 0 0 auto;
+  border-right: 1px solid var(--line-2);
 }
 
 @media (max-width: 767px) {
@@ -102,6 +106,11 @@
 
   .twoPane {
     flex-direction: column;
+  }
+
+  .listSlot {
+    border-right: none;
+    border-bottom: 1px solid var(--line-2);
   }
 
   .twoPane.hasSelection .listSlot {
@@ -123,9 +132,9 @@
     margin: 12px 16px 0;
     padding: 8px 16px 9px;
     border-radius: var(--radius-xl);
-    border: 1px solid var(--text-primary);
-    background: var(--bg-color);
-    color: var(--text-primary);
+    border: 1px solid var(--ink);
+    background: var(--paper);
+    color: var(--ink);
     font-family: "Geist Mono", monospace;
     font-size: 11px;
     letter-spacing: 0.54px;

--- a/frontend/src/pages/domain-pack/ui/risk-draft-read-page.module.css
+++ b/frontend/src/pages/domain-pack/ui/risk-draft-read-page.module.css
@@ -142,8 +142,8 @@
   }
 
   .backButton:focus-visible {
-    outline: 2px dashed var(--text-primary);
-    outline-offset: 2px;
+    outline: none;
+    box-shadow: var(--focus-ring);
   }
 }
 

--- a/frontend/src/pages/domain-pack/ui/workflow-draft-read-page.module.css
+++ b/frontend/src/pages/domain-pack/ui/workflow-draft-read-page.module.css
@@ -1,3 +1,113 @@
+.detailPage {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+  background: var(--paper);
+}
+
+.detailHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--s-3);
+  padding: 14px 20px;
+  border-bottom: 1px solid var(--line-2);
+  background: var(--paper);
+}
+
+.titleGroup {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+.titleStack {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.detailTitle {
+  margin: 0;
+  color: var(--ink);
+  font-family: var(--sans);
+  font-size: 16px;
+  font-weight: 540;
+  letter-spacing: -0.14px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.detailDescription {
+  margin: 0;
+  color: var(--ink-3);
+  font-size: 12px;
+  font-weight: 340;
+  line-height: 1.45;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workflowCode,
+.nodeCount,
+.loadingText {
+  font-size: 11px;
+  color: var(--ink-3);
+  font-weight: 500;
+}
+
+.headerActions {
+  display: flex;
+  align-items: center;
+  gap: var(--s-2);
+  flex-shrink: 0;
+}
+
+.headerButton {
+  font-weight: 450;
+}
+
+.canvasFrame {
+  flex: 1;
+  position: relative;
+  margin: 12px 20px 20px;
+  border-radius: var(--r-2);
+  border: 1px solid var(--line-2);
+  background: var(--paper);
+  overflow: hidden;
+  min-height: 400px;
+  box-shadow: inset 0 0 0 1px rgb(0 0 0 / 0.015);
+}
+
+.canvasFrame[data-editing="true"] {
+  border-color: var(--line);
+  background: var(--paper-2);
+}
+
+.centerState {
+  padding: 32px;
+  text-align: center;
+  color: var(--ink-3);
+}
+
+.loadingState {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.errorState {
+  padding: 32px;
+}
+
 .pageWrapper {
   display: flex;
   flex-direction: column;

--- a/frontend/src/pages/domain-pack/ui/workflow-draft-read-page.module.css
+++ b/frontend/src/pages/domain-pack/ui/workflow-draft-read-page.module.css
@@ -10,8 +10,8 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: var(--s-3);
-  padding: 14px 20px;
+  gap: var(--s-4);
+  padding: 16px 22px;
   border-bottom: 1px solid var(--line-2);
   background: var(--paper);
 }
@@ -19,7 +19,7 @@
 .titleGroup {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 12px;
   min-width: 0;
 }
 
@@ -64,12 +64,49 @@
 .headerActions {
   display: flex;
   align-items: center;
-  gap: var(--s-2);
+  gap: 10px;
   flex-shrink: 0;
 }
 
 .headerButton {
+  min-width: 104px;
+  height: 40px;
+  padding: 0 18px;
+  border-radius: var(--r-pill);
   font-weight: 450;
+  letter-spacing: -0.1px;
+}
+
+.headerButton svg {
+  width: 15px;
+  height: 15px;
+}
+
+.backAction {
+  border-color: var(--line);
+  background: var(--paper);
+  color: var(--ink-2);
+}
+
+.backAction:hover {
+  border-color: var(--ink);
+  background: var(--paper-2);
+  color: var(--ink);
+}
+
+.editAction {
+  min-width: 112px;
+  background: var(--ink);
+  color: var(--paper);
+  border: 1px solid var(--ink);
+  box-shadow: 0 10px 22px rgb(0 0 0 / 0.1);
+}
+
+.editAction:hover {
+  background: var(--ink-2);
+  border-color: var(--ink-2);
+  color: var(--paper);
+  transform: translateY(-1px);
 }
 
 .canvasFrame {

--- a/frontend/src/pages/upload/ui/UploadPage.tsx
+++ b/frontend/src/pages/upload/ui/UploadPage.tsx
@@ -15,7 +15,7 @@ export const UploadPage: React.FC = () => {
   const workspaceId = workspaceIdParam ? Number(workspaceIdParam) : undefined;
 
   useEffect(() => {
-    setCrumbs(["CARD-CS", "Pipeline · Datasets"]);
+    setCrumbs(["상담 로그 수집"]);
     return () => setCrumbs([]);
   }, [setCrumbs]);
 

--- a/frontend/src/shared/ui/input/input.module.css
+++ b/frontend/src/shared/ui/input/input.module.css
@@ -43,8 +43,7 @@
 }
 
 .input:focus-visible {
-  outline: dashed 2px;
-  outline-offset: 2px;
+  outline: none;
   border-color: #000000;
   box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.1);
   background: #ffffff;
@@ -67,9 +66,9 @@
 }
 
 .errorInput:focus-visible {
+  border-color: var(--error-color);
   box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.1);
-  outline: dashed 2px;
-  outline-offset: 2px;
+  outline: none;
 }
 
 .errorText {

--- a/frontend/src/shared/ui/ostone/chrome/Sidebar.test.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/Sidebar.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { Sidebar } from "./Sidebar";
@@ -8,8 +8,6 @@ type SidebarProps = Parameters<typeof Sidebar>[0];
 function renderSidebar(props: Partial<SidebarProps> = {}) {
   const defaults: SidebarProps = {
     active: "consult",
-    collapsed: true,
-    onToggleCollapsed: vi.fn(),
   };
   return render(
     <MemoryRouter>
@@ -19,24 +17,26 @@ function renderSidebar(props: Partial<SidebarProps> = {}) {
 }
 
 describe("Sidebar", () => {
-  it("collapsed 모드에서는 width 72px과 글로벌 아이콘 항목을 표시한다", () => {
-    renderSidebar({ collapsed: true });
-
-    const nav = screen.getByLabelText("주요 내비게이션");
-    expect(nav).toHaveAttribute("data-collapsed", "true");
-    expect(nav).toHaveStyle({ width: "72px" });
-    expect(screen.getByTitle("Consultation")).toBeInTheDocument();
-    expect(screen.getByTitle("Uploads")).toBeInTheDocument();
-    expect(screen.getByTitle("Domain Packs")).toBeInTheDocument();
-    expect(screen.queryByTitle("Workflows")).not.toBeInTheDocument();
-  });
-
-  it("expanded 모드에서는 Domain Packs가 목록 화면 링크만 담당한다", () => {
-    renderSidebar({ collapsed: false });
+  it("항상 200px 고정 폭과 글로벌 항목 label을 표시한다", () => {
+    renderSidebar();
 
     const nav = screen.getByLabelText("주요 내비게이션");
     expect(nav).toHaveAttribute("data-collapsed", "false");
-    expect(nav).toHaveStyle({ width: "256px" });
+    expect(nav).toHaveStyle({ width: "200px" });
+    expect(screen.getByTitle("Consultation")).toBeInTheDocument();
+    expect(screen.getByTitle("Uploads")).toBeInTheDocument();
+    expect(screen.getByTitle("Domain Packs")).toBeInTheDocument();
+    expect(screen.getByText("Consultation")).toBeInTheDocument();
+    expect(screen.getByText("Uploads")).toBeInTheDocument();
+    expect(screen.queryByTitle("Workflows")).not.toBeInTheDocument();
+  });
+
+  it("Domain Packs가 목록 화면 링크만 담당한다", () => {
+    renderSidebar();
+
+    const nav = screen.getByLabelText("주요 내비게이션");
+    expect(nav).toHaveAttribute("data-collapsed", "false");
+    expect(nav).toHaveStyle({ width: "200px" });
     expect(screen.getByTestId("sidebar-domain-link")).toHaveAttribute(
       "href",
       "/workspaces/domain-packs",
@@ -45,7 +45,7 @@ describe("Sidebar", () => {
   });
 
   it("도메인팩 하위 화면 active에서도 Domain Packs 링크만 active이고 트리는 표시하지 않는다", () => {
-    renderSidebar({ collapsed: false, active: "intent" });
+    renderSidebar({ active: "intent" });
 
     const link = screen.getByTestId("sidebar-domain-link");
     expect(link).toHaveAttribute("data-active", "true");
@@ -55,43 +55,25 @@ describe("Sidebar", () => {
   });
 
   it("Domain Packs 링크는 active=consult이면 비활성이다", () => {
-    renderSidebar({ collapsed: false, active: "consult" });
+    renderSidebar({ active: "consult" });
 
     expect(screen.getByTestId("sidebar-domain-link")).toHaveAttribute("data-active", "false");
   });
 
-  it("collapsed 시 nav 배경 클릭으로 onToggleCollapsed가 호출된다", () => {
-    const onToggleCollapsed = vi.fn();
-    renderSidebar({ collapsed: true, onToggleCollapsed });
-
-    fireEvent.click(screen.getByLabelText("주요 내비게이션"));
-
-    expect(onToggleCollapsed).toHaveBeenCalledTimes(1);
-  });
-
-  it("collapsed 시에는 별도 접기 버튼이 렌더되지 않는다", () => {
-    renderSidebar({ collapsed: true });
+  it("접기 버튼을 렌더하지 않는다", () => {
+    renderSidebar();
 
     expect(screen.queryByLabelText("사이드바 접기")).not.toBeInTheDocument();
   });
 
-  it("expanded 시 접기 버튼 클릭으로 onToggleCollapsed가 호출된다", () => {
-    const onToggleCollapsed = vi.fn();
-    renderSidebar({ collapsed: false, onToggleCollapsed });
-
-    fireEvent.click(screen.getByLabelText("사이드바 접기"));
-
-    expect(onToggleCollapsed).toHaveBeenCalledTimes(1);
-  });
-
   it("active=consult일 때 Consultation 항목이 강조된다", () => {
-    renderSidebar({ active: "consult", collapsed: true });
+    renderSidebar({ active: "consult" });
 
     expect(screen.getByTitle("Consultation")).toHaveAttribute("data-active", "true");
   });
 
   it("basePath prop을 지정하면 링크에 반영된다", () => {
-    renderSidebar({ collapsed: true, basePath: "/workspaces/7" });
+    renderSidebar({ basePath: "/workspaces/7" });
 
     expect(screen.getByTitle("Consultation")).toHaveAttribute(
       "href",
@@ -110,7 +92,7 @@ describe("Sidebar", () => {
   });
 
   it("inactive 항목에 mouseEnter/Leave 시 배경이 토글된다", () => {
-    renderSidebar({ active: "consult", collapsed: true });
+    renderSidebar({ active: "consult" });
     const link = screen.getByTitle("Uploads") as HTMLElement;
 
     fireEvent.mouseEnter(link);

--- a/frontend/src/shared/ui/ostone/chrome/Sidebar.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/Sidebar.tsx
@@ -163,7 +163,7 @@ export function Sidebar({
         style={{
           marginTop: "auto",
           display: "flex",
-          justifyContent: "stretch",
+          alignItems: "stretch",
           paddingLeft: "var(--s-3)",
           paddingRight: "var(--s-3)",
           paddingTop: "var(--s-3)",

--- a/frontend/src/shared/ui/ostone/chrome/Sidebar.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/Sidebar.tsx
@@ -19,8 +19,6 @@ interface SidebarProps {
   dark?: boolean;
   basePath?: string;
   switcher?: ReactNode;
-  collapsed: boolean;
-  onToggleCollapsed: () => void;
 }
 
 interface TopNavItem {
@@ -47,6 +45,7 @@ const TOP_NAV_ITEMS: TopNavItem[] = [
 
 const DOMAIN_PACKS_LABEL = "Domain Packs";
 const DOMAIN_PACKS_ICON: IconName = "folder";
+const SIDEBAR_WIDTH = "200px";
 
 function deriveSidebarColors(dark: boolean) {
   return {
@@ -74,42 +73,30 @@ export function Sidebar({
   dark = false,
   basePath = "/workspaces",
   switcher,
-  collapsed,
-  onToggleCollapsed,
 }: SidebarProps) {
   const { containerBg, borderColor, defaultColor, hoverBg, activeColor } =
     deriveSidebarColors(dark);
 
-  const handleNavCapture: React.MouseEventHandler<HTMLElement> = (e) => {
-    if (collapsed) {
-      e.stopPropagation();
-      e.preventDefault();
-      onToggleCollapsed();
-    }
-  };
-
   return (
     <nav
-      onClickCapture={handleNavCapture}
       style={{
-        width: collapsed ? "72px" : "256px",
+        width: SIDEBAR_WIDTH,
         background: containerBg,
         borderRight: `1px solid ${borderColor}`,
         display: "flex",
         flexDirection: "column",
-        alignItems: collapsed ? "center" : "stretch",
+        alignItems: "stretch",
         padding: "var(--s-3) 0",
         gap: "var(--s-2)",
         height: "100%",
         flexShrink: 0,
         overflowY: "auto",
         overflowX: "hidden",
-        cursor: collapsed ? "pointer" : "default",
-        transition:
-          "width 400ms cubic-bezier(0.32, 0.72, 0.16, 1), background 200ms ease",
+        cursor: "default",
+        transition: "background 200ms ease",
       }}
       aria-label="주요 내비게이션"
-      data-collapsed={collapsed ? "true" : "false"}
+      data-collapsed="false"
     >
       <div
         style={{
@@ -118,54 +105,22 @@ export function Sidebar({
           alignItems: "center",
           gap: "var(--s-2)",
           marginBottom: "var(--s-2)",
-          padding: collapsed ? "0" : "0 var(--s-3)",
-          justifyContent: collapsed ? "center" : "flex-start",
-          width: collapsed ? "auto" : "100%",
+          padding: "0 var(--s-3)",
+          justifyContent: "flex-start",
+          width: "100%",
         }}
       >
         {switcher !== undefined && (
           <div
             style={{
-              flex: collapsed ? "0 0 auto" : "1 1 0",
+              flex: "1 1 0",
               minWidth: 0,
               display: "flex",
-              justifyContent: collapsed ? "center" : "flex-start",
+              justifyContent: "flex-start",
             }}
           >
             {switcher}
           </div>
-        )}
-        {!collapsed && (
-          <button
-            type="button"
-            onClick={onToggleCollapsed}
-            aria-label="사이드바 접기"
-            title="사이드바 접기"
-            style={{
-              flexShrink: 0,
-              width: "40px",
-              height: "40px",
-              borderRadius: "var(--r-2)",
-              border: "1px solid var(--line)",
-              background: "var(--paper)",
-              color: "var(--ink)",
-              display: "inline-flex",
-              alignItems: "center",
-              justifyContent: "center",
-              cursor: "pointer",
-              transition: "background 160ms ease, border-color 160ms ease",
-            }}
-          >
-            <span
-              style={{
-                display: "inline-flex",
-                transform: "rotate(180deg)",
-                transition: "transform 240ms cubic-bezier(0.4, 0, 0.2, 1)",
-              }}
-            >
-              <Icon name="chevron" size={14} />
-            </span>
-          </button>
         )}
       </div>
 
@@ -184,7 +139,6 @@ export function Sidebar({
             to={item.getPath(basePath)}
             icon={item.icon}
             label={item.label}
-            collapsed={collapsed}
             isActive={active === item.key}
             activeColor={activeColor}
             defaultColor={defaultColor}
@@ -196,7 +150,6 @@ export function Sidebar({
           to={`${basePath}/domain-packs`}
           icon={DOMAIN_PACKS_ICON}
           label={DOMAIN_PACKS_LABEL}
-          collapsed={collapsed}
           isActive={isDomainSectionActive(active)}
           activeColor={activeColor}
           defaultColor={defaultColor}
@@ -210,9 +163,9 @@ export function Sidebar({
         style={{
           marginTop: "auto",
           display: "flex",
-          justifyContent: collapsed ? "center" : "stretch",
-          paddingLeft: collapsed ? 0 : "var(--s-3)",
-          paddingRight: collapsed ? 0 : "var(--s-3)",
+          justifyContent: "stretch",
+          paddingLeft: "var(--s-3)",
+          paddingRight: "var(--s-3)",
           paddingTop: "var(--s-3)",
           position: "sticky",
           bottom: 0,
@@ -220,7 +173,7 @@ export function Sidebar({
           zIndex: 50,
         }}
       >
-        <AccountMenu collapsed={collapsed} />
+        <AccountMenu collapsed={false} />
       </div>
     </nav>
   );
@@ -230,7 +183,6 @@ interface SidebarLinkProps {
   to: string;
   icon: IconName;
   label: string;
-  collapsed: boolean;
   isActive: boolean;
   activeColor: string;
   defaultColor: string;
@@ -242,27 +194,12 @@ function SidebarLink({
   to,
   icon,
   label,
-  collapsed,
   isActive,
   activeColor,
   defaultColor,
   hoverBg,
   testId,
 }: SidebarLinkProps) {
-  const collapsedStyle: CSSProperties = {
-    width: "40px",
-    height: "40px",
-    borderRadius: "var(--r-2)",
-    display: "flex",
-    alignItems: "center",
-    justifyContent: "center",
-    color: isActive ? activeColor : defaultColor,
-    background: isActive ? hoverBg : "transparent",
-    textDecoration: "none",
-    transition: "background 160ms ease, color 160ms ease",
-    margin: "0 auto",
-  };
-
   const expandedStyle: CSSProperties = {
     height: "40px",
     padding: "0 var(--s-3)",
@@ -287,7 +224,7 @@ function SidebarLink({
       title={label}
       data-active={isActive ? "true" : "false"}
       data-testid={testId}
-      style={collapsed ? collapsedStyle : expandedStyle}
+      style={expandedStyle}
       onMouseEnter={(e) => {
         if (!isActive) {
           e.currentTarget.style.background = hoverBg;
@@ -302,7 +239,7 @@ function SidebarLink({
       }}
     >
       <Icon name={icon} size={16} />
-      {!collapsed && <span>{label}</span>}
+      <span>{label}</span>
     </NavLink>
   );
 }

--- a/frontend/src/widgets/ostone-shell/ui/OstoneShell.test.tsx
+++ b/frontend/src/widgets/ostone-shell/ui/OstoneShell.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { OstoneShell } from "./OstoneShell";
 
@@ -36,7 +36,7 @@ describe("OstoneShell", () => {
     );
     expect(screen.getByText("OSTONE")).toBeInTheDocument();
     expect(screen.getByText("CARD-CS")).toBeInTheDocument();
-    expect(screen.getByText("Domain Packs")).toBeInTheDocument();
+    expect(screen.getAllByText("Domain Packs")).toHaveLength(2);
   });
 
   it("renders children in main area", () => {
@@ -49,7 +49,7 @@ describe("OstoneShell", () => {
     expect(screen.getByTestId("shell-child")).toBeInTheDocument();
   });
 
-  it("starts collapsed by default", () => {
+  it("starts with fixed expanded sidebar", () => {
     render(
       <OstoneShell active="workflows" crumbs={[]}>
         <div>content</div>
@@ -58,11 +58,13 @@ describe("OstoneShell", () => {
     );
     expect(screen.getByLabelText("주요 내비게이션")).toHaveAttribute(
       "data-collapsed",
-      "true",
+      "false",
     );
+    expect(screen.getByLabelText("주요 내비게이션")).toHaveStyle({ width: "200px" });
   });
 
-  it("collapsed 시 nav 배경 클릭으로 펼쳐지고 localStorage에 저장되며, expanded 후엔 접기 버튼이 동작한다", () => {
+  it("sidebar collapsed localStorage 값이 있어도 fixed expanded 상태를 유지한다", () => {
+    window.localStorage.setItem("ostone:sidebar:collapsed", "true");
     render(
       <OstoneShell active="workflows" crumbs={[]}>
         <div>content</div>
@@ -70,23 +72,12 @@ describe("OstoneShell", () => {
       { wrapper: Wrapper },
     );
     const nav = screen.getByLabelText("주요 내비게이션");
-    expect(nav).toHaveAttribute("data-collapsed", "true");
-    fireEvent.click(nav);
-    expect(screen.getByLabelText("주요 내비게이션")).toHaveAttribute(
-      "data-collapsed",
-      "false",
-    );
-    expect(window.localStorage.getItem("ostone:sidebar:collapsed")).toBe(
-      "false",
-    );
-    fireEvent.click(screen.getByLabelText("사이드바 접기"));
-    expect(screen.getByLabelText("주요 내비게이션")).toHaveAttribute(
-      "data-collapsed",
-      "true",
-    );
+    expect(nav).toHaveAttribute("data-collapsed", "false");
+    expect(screen.queryByLabelText("사이드바 접기")).not.toBeInTheDocument();
+    expect(window.localStorage.getItem("ostone:sidebar:collapsed")).toBe("true");
   });
 
-  it("localStorage에 false가 저장돼 있으면 expanded로 시작한다", () => {
+  it("localStorage에 false가 저장돼 있어도 sidebar 값을 다시 쓰지 않는다", () => {
     window.localStorage.setItem("ostone:sidebar:collapsed", "false");
     render(
       <OstoneShell active="workflows" crumbs={[]}>
@@ -98,6 +89,7 @@ describe("OstoneShell", () => {
       "data-collapsed",
       "false",
     );
+    expect(window.localStorage.getItem("ostone:sidebar:collapsed")).toBe("false");
   });
 
   it("renders dark variant", () => {

--- a/frontend/src/widgets/ostone-shell/ui/OstoneShell.test.tsx
+++ b/frontend/src/widgets/ostone-shell/ui/OstoneShell.test.tsx
@@ -39,6 +39,31 @@ describe("OstoneShell", () => {
     expect(screen.getAllByText("Domain Packs")).toHaveLength(2);
   });
 
+  it("상위 화면의 workspace breadcrumb를 업무 라벨로 표시한다", () => {
+    render(
+      <OstoneShell active="upload" crumbs={["CARD-CS"]}>
+        <div>content</div>
+      </OstoneShell>,
+      { wrapper: Wrapper },
+    );
+
+    expect(screen.queryByText("CARD-CS")).not.toBeInTheDocument();
+    expect(screen.getByText("상담 로그 수집")).toBeInTheDocument();
+  });
+
+  it("상세 화면의 여러 breadcrumb는 그대로 유지한다", () => {
+    render(
+      <OstoneShell active="workflows" crumbs={["WS · 1", "Domain Packs", "Workflows"]}>
+        <div>content</div>
+      </OstoneShell>,
+      { wrapper: Wrapper },
+    );
+
+    expect(screen.getByText("WS · 1")).toBeInTheDocument();
+    expect(screen.getAllByText("Domain Packs")).toHaveLength(2);
+    expect(screen.getByText("Workflows")).toBeInTheDocument();
+  });
+
   it("renders children in main area", () => {
     render(
       <OstoneShell active="workflows" crumbs={[]}>

--- a/frontend/src/widgets/ostone-shell/ui/OstoneShell.tsx
+++ b/frontend/src/widgets/ostone-shell/ui/OstoneShell.tsx
@@ -20,6 +20,30 @@ interface SidebarBaseProps {
   switcher: ReactNode;
 }
 
+const TOP_LEVEL_CRUMB_BY_ACTIVE: Partial<Record<SidebarActive, string>> = {
+  workflows: "워크플로우 설계",
+  upload: "상담 로그 수집",
+  consult: "상담 응대",
+  domain: "도메인팩 관리",
+};
+
+function resolveDisplayCrumbs(active: SidebarActive, crumbs: string[]): string[] {
+  if (crumbs[0] === "CARD-CS" && crumbs[1] === "실시간 상담") {
+    return ["상담 응대"];
+  }
+
+  if (crumbs[0] === "CARD-CS" && crumbs[1] === "Pipeline · Datasets") {
+    return ["상담 로그 수집"];
+  }
+
+  const topLevelCrumb = TOP_LEVEL_CRUMB_BY_ACTIVE[active];
+  if (crumbs.length === 1 && topLevelCrumb) {
+    return [topLevelCrumb];
+  }
+
+  return crumbs;
+}
+
 export function OstoneShell({
   active,
   crumbs,
@@ -34,6 +58,7 @@ export function OstoneShell({
   const numericWorkspaceId = workspaceId ? Number(workspaceId) : null;
   const safeWorkspaceId =
     numericWorkspaceId !== null && Number.isFinite(numericWorkspaceId) ? numericWorkspaceId : null;
+  const displayCrumbs = resolveDisplayCrumbs(active, crumbs);
 
   const fallbackSwitcher = sidebarSwitcher ?? (
     <WorkspaceMarker workspaceId={safeWorkspaceId} collapsed={false} />
@@ -66,7 +91,7 @@ export function OstoneShell({
         }}
       >
         <div style={{ flexShrink: 0 }}>
-          <Topbar crumbs={crumbs} right={topbarRight} dark={dark} />
+          <Topbar crumbs={displayCrumbs} right={topbarRight} dark={dark} />
         </div>
         <main style={{ flex: 1, overflow: "auto" }}>{children}</main>
       </div>

--- a/frontend/src/widgets/ostone-shell/ui/OstoneShell.tsx
+++ b/frontend/src/widgets/ostone-shell/ui/OstoneShell.tsx
@@ -1,29 +1,7 @@
-import { useCallback, useEffect, useState, type ReactNode } from "react";
+import { type ReactNode } from "react";
 import { useParams } from "react-router-dom";
 import { Sidebar, Topbar, type SidebarActive } from "@/shared/ui/ostone/chrome";
 import { WorkspaceMarker } from "@/shared/ui/ostone/chrome/WorkspaceMarker";
-
-const COLLAPSED_STORAGE_KEY = "ostone:sidebar:collapsed";
-
-function readPersistedCollapsed(): boolean {
-  if (typeof window === "undefined") return true;
-  try {
-    const raw = window.localStorage.getItem(COLLAPSED_STORAGE_KEY);
-    if (raw === null) return true;
-    return raw !== "false";
-  } catch {
-    return true;
-  }
-}
-
-function persistCollapsed(value: boolean): void {
-  if (typeof window === "undefined") return;
-  try {
-    window.localStorage.setItem(COLLAPSED_STORAGE_KEY, value ? "true" : "false");
-  } catch {
-    /* noop */
-  }
-}
 
 interface OstoneShellProps {
   active: SidebarActive;
@@ -40,8 +18,6 @@ interface SidebarBaseProps {
   dark: boolean;
   basePath: string;
   switcher: ReactNode;
-  collapsed: boolean;
-  onToggleCollapsed: () => void;
 }
 
 export function OstoneShell({
@@ -59,18 +35,8 @@ export function OstoneShell({
   const safeWorkspaceId =
     numericWorkspaceId !== null && Number.isFinite(numericWorkspaceId) ? numericWorkspaceId : null;
 
-  const [collapsed, setCollapsed] = useState<boolean>(() => readPersistedCollapsed());
-
-  useEffect(() => {
-    persistCollapsed(collapsed);
-  }, [collapsed]);
-
-  const handleToggle = useCallback(() => {
-    setCollapsed((v) => !v);
-  }, []);
-
   const fallbackSwitcher = sidebarSwitcher ?? (
-    <WorkspaceMarker workspaceId={safeWorkspaceId} collapsed={collapsed} />
+    <WorkspaceMarker workspaceId={safeWorkspaceId} collapsed={false} />
   );
 
   const sidebarBaseProps: SidebarBaseProps = {
@@ -78,8 +44,6 @@ export function OstoneShell({
     dark,
     basePath: resolvedBasePath,
     switcher: fallbackSwitcher,
-    collapsed,
-    onToggleCollapsed: handleToggle,
   };
 
   return (


### PR DESCRIPTION
## Summary

- Workflow 목록에서 hover/focus 시 preview 영역이 열리도록 개선
- Workflow 상세 화면의 목록/편집 액션 배치와 버튼 위계 정리
- Domain Pack 상태 배지, Intent 화면 톤, focus ring 스타일 등 데모 UI polish 적용
- Sidebar를 200px 고정 폭으로 정리하고 collapse 버튼 제거
- Topbar에 workspace명 대신 화면별 업무 라벨 표시

## Verification

- `docker compose exec frontend pnpm test WorkflowCard WorkflowListView WorkflowDraftReadPage Sidebar OstoneShell`
- `docker compose exec frontend pnpm test WorkflowDraftReadPage OstoneShell`
- `pnpm exec tsc -b`
- pre-commit lint/format passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 사이드바가 항상 펼쳐진 고정 너비로 변경되어 레이아웃이 일관되게 표시됩니다.
  * 워크플로우 카드의 미리보기 동작이 개선되어 호버/포커스 시 상세 프리뷰 및 열기 동작이 명확해졌습니다.

* **스타일**
  * 포커스 인디케이터를 점선 아웃라인에서 더 어두운 테두리와 부드러운 모노크롬 링(box-shadow)으로 일괄 전환했습니다.
  * 여러 컴포넌트의 레이아웃·타이포·버튼·입력 스타일을 정비하여 시각적 일관성 향상.

* **테스트**
  * 카드·사이드바·쉘 관련 상호작용 테스트가 미리보기/열기 중심으로 갱신되었습니다.

* **문서**
  * 포커스 인디케이터 디자인 가이드 문서가 업데이트되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ajou-2026-1-capstone-5/ostone/pull/282?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->