### PR TITLE
chore: fix chat WebSocket implementation bugs

### DIFF
--- a/backend/src/main/java/com/init/workflowruntime/application/ChatWebSocketService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/ChatWebSocketService.java
@@ -47,6 +47,12 @@ public class ChatWebSocketService {
                     new NotFoundException(
                         "SESSION_NOT_FOUND", "Session not found: " + command.sessionId()));
 
+    if (session.getStartedBy() != null && !session.getStartedBy().equals(command.userId())) {
+      throw new BadRequestException(
+          "SESSION_ACCESS_DENIED",
+          "User " + command.userId() + " does not own session " + command.sessionId());
+    }
+
     ChatSessionStatus status = session.getStatus();
     if (status != ChatSessionStatus.OPEN && status != ChatSessionStatus.ACTIVE) {
       throw new BadRequestException(
@@ -72,9 +78,12 @@ public class ChatWebSocketService {
         new TransactionSynchronization() {
           @Override
           public void afterCommit() {
-            messagingTemplate.convertAndSend(destination, response);
-            eventPublisher.publishEvent(
-                new ChatMessageReceivedEvent(command.sessionId(), command.content(), null));
+            try {
+              messagingTemplate.convertAndSend(destination, response);
+            } finally {
+              eventPublisher.publishEvent(
+                  new ChatMessageReceivedEvent(command.sessionId(), command.content(), null));
+            }
           }
         });
 

--- a/backend/src/main/java/com/init/workflowruntime/application/ConsultationService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/ConsultationService.java
@@ -10,6 +10,7 @@ import com.init.workflowruntime.domain.ChatMessageRepository;
 import com.init.workflowruntime.domain.ChatSession;
 import com.init.workflowruntime.domain.ChatSessionRepository;
 import com.init.workflowruntime.domain.ChatSessionStatus;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.lang.NonNull;
@@ -31,17 +32,12 @@ public class ConsultationService {
   }
 
   public List<ChatSessionResponse> getActiveQueue() {
-    List<ChatSession> open =
-        chatSessionRepository.findByStatusOrderByStartedAtDesc(ChatSessionStatus.OPEN);
-    List<ChatSession> active =
-        chatSessionRepository.findByStatusOrderByStartedAtDesc(ChatSessionStatus.ACTIVE);
-    List<ChatSession> sessions = new java.util.ArrayList<>(open);
-    sessions.addAll(active);
-    sessions.sort(
-        java.util.Comparator.comparing(
-            ChatSession::getStartedAt,
-            java.util.Comparator.nullsLast(java.util.Comparator.reverseOrder())));
-    return sessions.stream().map(ChatSessionResponse::from).collect(Collectors.toList());
+    return chatSessionRepository
+        .findByStatusInOrderByStartedAtDesc(
+            Arrays.asList(ChatSessionStatus.OPEN, ChatSessionStatus.ACTIVE))
+        .stream()
+        .map(ChatSessionResponse::from)
+        .collect(Collectors.toList());
   }
 
   public List<ChatMessageResponse> getMessages(@NonNull Long sessionId) {

--- a/backend/src/main/java/com/init/workflowruntime/application/ConsultationService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/ConsultationService.java
@@ -31,8 +31,16 @@ public class ConsultationService {
   }
 
   public List<ChatSessionResponse> getActiveQueue() {
-    List<ChatSession> sessions =
+    List<ChatSession> open =
         chatSessionRepository.findByStatusOrderByStartedAtDesc(ChatSessionStatus.OPEN);
+    List<ChatSession> active =
+        chatSessionRepository.findByStatusOrderByStartedAtDesc(ChatSessionStatus.ACTIVE);
+    List<ChatSession> sessions = new java.util.ArrayList<>(open);
+    sessions.addAll(active);
+    sessions.sort(
+        java.util.Comparator.comparing(
+            ChatSession::getStartedAt,
+            java.util.Comparator.nullsLast(java.util.Comparator.reverseOrder())));
     return sessions.stream().map(ChatSessionResponse::from).collect(Collectors.toList());
   }
 

--- a/backend/src/main/java/com/init/workflowruntime/application/CounselorService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/CounselorService.java
@@ -103,7 +103,7 @@ public class CounselorService {
 
   @Transactional
   public ChatMessageResponse sendCounselorMessage(
-      Long sessionId, String content, Long counselorId) {
+      Long sessionId, String content, Long counselorId, boolean isNote) {
     validateCounselorId(counselorId);
 
     ChatSession session =
@@ -132,7 +132,8 @@ public class CounselorService {
             .map(msg -> msg.getSeqNo() + 1)
             .orElse(1);
 
-    ChatMessage message = ChatMessage.create(sessionId, nextSeqNo, "COUNSELOR", "TEXT", content);
+    String senderRole = isNote ? "NOTE" : "COUNSELOR";
+    ChatMessage message = ChatMessage.create(sessionId, nextSeqNo, senderRole, "TEXT", content);
     ChatMessage savedMessage = chatMessageRepository.save(message);
 
     ChatMessageResponse response = ChatMessageResponse.from(savedMessage);

--- a/backend/src/main/java/com/init/workflowruntime/application/LlmResponseHandler.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/LlmResponseHandler.java
@@ -6,6 +6,8 @@ import com.init.workflowruntime.domain.ChatMessage;
 import com.init.workflowruntime.domain.ChatMessageRepository;
 import com.init.workflowruntime.domain.ChatSessionRepository;
 import com.init.workflowruntime.event.ChatMessageReceivedEvent;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.event.EventListener;
@@ -40,14 +42,24 @@ public class LlmResponseHandler {
   @Transactional
   public void handleChatMessageReceived(ChatMessageReceivedEvent event) {
     try {
-      String llmResponse = llmAssistantService.generateResponse("", event.content());
-
       chatSessionRepository
           .findByIdForUpdate(event.sessionId())
           .orElseThrow(
               () ->
                   new NotFoundException(
                       "SESSION_NOT_FOUND", "Session not found: " + event.sessionId()));
+
+      List<ChatMessage> allMessages =
+          chatMessageRepository.findByChatSessionIdOrderBySeqNoAsc(event.sessionId());
+      int from = Math.max(0, allMessages.size() - 5);
+      List<ChatMessage> recentMessages = allMessages.subList(from, allMessages.size());
+      String conversationContext =
+          recentMessages.stream()
+              .map(m -> m.getSenderRole() + ": " + m.getContent())
+              .collect(Collectors.joining("\n"));
+
+      String llmResponse =
+          llmAssistantService.generateResponse(conversationContext, event.content());
 
       Integer nextSeqNo =
           chatMessageRepository

--- a/backend/src/main/java/com/init/workflowruntime/application/LlmResponseHandler.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/LlmResponseHandler.java
@@ -6,6 +6,7 @@ import com.init.workflowruntime.domain.ChatMessage;
 import com.init.workflowruntime.domain.ChatMessageRepository;
 import com.init.workflowruntime.domain.ChatSessionRepository;
 import com.init.workflowruntime.event.ChatMessageReceivedEvent;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -49,12 +50,11 @@ public class LlmResponseHandler {
                   new NotFoundException(
                       "SESSION_NOT_FOUND", "Session not found: " + event.sessionId()));
 
-      List<ChatMessage> allMessages =
-          chatMessageRepository.findByChatSessionIdOrderBySeqNoAsc(event.sessionId());
-      int from = Math.max(0, allMessages.size() - 5);
-      List<ChatMessage> recentMessages = allMessages.subList(from, allMessages.size());
+      List<ChatMessage> recentDesc =
+          chatMessageRepository.findTop5ByChatSessionIdOrderBySeqNoDesc(event.sessionId());
+      Collections.reverse(recentDesc);
       String conversationContext =
-          recentMessages.stream()
+          recentDesc.stream()
               .map(m -> m.getSenderRole() + ": " + m.getContent())
               .collect(Collectors.joining("\n"));
 

--- a/backend/src/main/java/com/init/workflowruntime/application/SessionAssignedEventListener.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/SessionAssignedEventListener.java
@@ -4,6 +4,8 @@ import com.init.workflowruntime.application.dto.ChatSessionResponse;
 import com.init.workflowruntime.domain.ChatSession;
 import com.init.workflowruntime.domain.ChatSessionRepository;
 import com.init.workflowruntime.domain.event.SessionAssignedEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
@@ -11,6 +13,8 @@ import org.springframework.transaction.event.TransactionalEventListener;
 
 @Component
 public class SessionAssignedEventListener {
+
+  private static final Logger log = LoggerFactory.getLogger(SessionAssignedEventListener.class);
 
   private final ChatSessionRepository chatSessionRepository;
   private final SimpMessagingTemplate messagingTemplate;
@@ -24,7 +28,10 @@ public class SessionAssignedEventListener {
   @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
   public void handleSessionAssigned(SessionAssignedEvent event) {
     ChatSession session = chatSessionRepository.findById(event.sessionId()).orElse(null);
-    if (session == null) return;
+    if (session == null) {
+      log.warn("SessionAssignedEvent: session {} not found, skipping notification", event.sessionId());
+      return;
+    }
 
     ChatSessionResponse response = ChatSessionResponse.from(session);
     String counselorQueue = "/queue/counselor.notifications";

--- a/backend/src/main/java/com/init/workflowruntime/application/SessionAssignedEventListener.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/SessionAssignedEventListener.java
@@ -29,7 +29,8 @@ public class SessionAssignedEventListener {
   public void handleSessionAssigned(SessionAssignedEvent event) {
     ChatSession session = chatSessionRepository.findById(event.sessionId()).orElse(null);
     if (session == null) {
-      log.warn("SessionAssignedEvent: session {} not found, skipping notification", event.sessionId());
+      log.warn(
+          "SessionAssignedEvent: session {} not found, skipping notification", event.sessionId());
       return;
     }
 

--- a/backend/src/main/java/com/init/workflowruntime/application/SessionAssignedEventListener.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/SessionAssignedEventListener.java
@@ -4,15 +4,12 @@ import com.init.workflowruntime.application.dto.ChatSessionResponse;
 import com.init.workflowruntime.domain.ChatSession;
 import com.init.workflowruntime.domain.ChatSessionRepository;
 import com.init.workflowruntime.domain.event.SessionAssignedEvent;
-import org.springframework.context.event.EventListener;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.support.TransactionSynchronization;
-import org.springframework.transaction.support.TransactionSynchronizationManager;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 @Component
-@Transactional(readOnly = true)
 public class SessionAssignedEventListener {
 
   private final ChatSessionRepository chatSessionRepository;
@@ -24,21 +21,14 @@ public class SessionAssignedEventListener {
     this.messagingTemplate = messagingTemplate;
   }
 
-  @EventListener
-  @Transactional
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
   public void handleSessionAssigned(SessionAssignedEvent event) {
     ChatSession session = chatSessionRepository.findById(event.sessionId()).orElse(null);
     if (session == null) return;
 
     ChatSessionResponse response = ChatSessionResponse.from(session);
     String counselorQueue = "/queue/counselor.notifications";
-    TransactionSynchronizationManager.registerSynchronization(
-        new TransactionSynchronization() {
-          @Override
-          public void afterCommit() {
-            messagingTemplate.convertAndSendToUser(
-                String.valueOf(event.counselorId()), counselorQueue, response);
-          }
-        });
+    messagingTemplate.convertAndSendToUser(
+        String.valueOf(event.counselorId()), counselorQueue, response);
   }
 }

--- a/backend/src/main/java/com/init/workflowruntime/application/dto/ChatSessionResponse.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/dto/ChatSessionResponse.java
@@ -12,6 +12,8 @@ public class ChatSessionResponse {
   private String channel;
   private String metaJson;
   private OffsetDateTime startedAt;
+  private Long assignedCounselorId;
+  private OffsetDateTime endedAt;
 
   /**
    * ChatSession 엔티티를 ChatSessionResponse DTO로 변환합니다.
@@ -26,6 +28,8 @@ public class ChatSessionResponse {
     resp.channel = session.getChannel();
     resp.metaJson = session.getMetaJson();
     resp.startedAt = session.getStartedAt();
+    resp.assignedCounselorId = session.getAssignedCounselorId();
+    resp.endedAt = session.getEndedAt();
     return resp;
   }
 
@@ -68,5 +72,21 @@ public class ChatSessionResponse {
 
   public void setStartedAt(OffsetDateTime startedAt) {
     this.startedAt = startedAt;
+  }
+
+  public Long getAssignedCounselorId() {
+    return assignedCounselorId;
+  }
+
+  public void setAssignedCounselorId(Long assignedCounselorId) {
+    this.assignedCounselorId = assignedCounselorId;
+  }
+
+  public OffsetDateTime getEndedAt() {
+    return endedAt;
+  }
+
+  public void setEndedAt(OffsetDateTime endedAt) {
+    this.endedAt = endedAt;
   }
 }

--- a/backend/src/main/java/com/init/workflowruntime/application/dto/CounselorMessageRequest.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/dto/CounselorMessageRequest.java
@@ -9,6 +9,8 @@ public class CounselorMessageRequest {
 
   @NotBlank private String content;
 
+  private boolean isNote;
+
   public Long getSessionId() {
     return sessionId;
   }
@@ -23,5 +25,13 @@ public class CounselorMessageRequest {
 
   public void setContent(String content) {
     this.content = content;
+  }
+
+  public boolean isNote() {
+    return isNote;
+  }
+
+  public void setNote(boolean isNote) {
+    this.isNote = isNote;
   }
 }

--- a/backend/src/main/java/com/init/workflowruntime/application/dto/CounselorMessageRequest.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/dto/CounselorMessageRequest.java
@@ -1,5 +1,6 @@
 package com.init.workflowruntime.application.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
@@ -9,6 +10,7 @@ public class CounselorMessageRequest {
 
   @NotBlank private String content;
 
+  @JsonProperty("isNote")
   private boolean isNote;
 
   public Long getSessionId() {

--- a/backend/src/main/java/com/init/workflowruntime/domain/ChatMessageRepository.java
+++ b/backend/src/main/java/com/init/workflowruntime/domain/ChatMessageRepository.java
@@ -12,5 +12,7 @@ public interface ChatMessageRepository {
 
   List<ChatMessage> findByChatSessionIdOrderBySeqNoAsc(Long chatSessionId);
 
+  List<ChatMessage> findTop5ByChatSessionIdOrderBySeqNoDesc(Long chatSessionId);
+
   Optional<ChatMessage> findTopByChatSessionIdOrderBySeqNoDesc(Long chatSessionId);
 }

--- a/backend/src/main/java/com/init/workflowruntime/domain/ChatSession.java
+++ b/backend/src/main/java/com/init/workflowruntime/domain/ChatSession.java
@@ -137,6 +137,7 @@ public class ChatSession {
           "reopen() requires status RESOLVED but was " + this.status);
     }
     this.status = ChatSessionStatus.OPEN;
+    this.assignedCounselorId = null;
     this.endedAt = null;
   }
 
@@ -174,6 +175,7 @@ public class ChatSession {
       throw new InvalidSessionStateException("closeSession() requires status not COMPLETED");
     }
     this.status = ChatSessionStatus.COMPLETED;
+    this.assignedCounselorId = null;
     if (this.startedAt == null) {
       this.startedAt = OffsetDateTime.now();
     }

--- a/backend/src/main/java/com/init/workflowruntime/domain/ChatSessionRepository.java
+++ b/backend/src/main/java/com/init/workflowruntime/domain/ChatSessionRepository.java
@@ -1,5 +1,6 @@
 package com.init.workflowruntime.domain;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
@@ -15,6 +16,8 @@ public interface ChatSessionRepository {
   ChatSession save(ChatSession session);
 
   List<ChatSession> findByStatusOrderByStartedAtDesc(ChatSessionStatus status);
+
+  List<ChatSession> findByStatusInOrderByStartedAtDesc(Collection<ChatSessionStatus> statuses);
 
   List<ChatSession> findByAssignedCounselorId(Long counselorId);
 

--- a/backend/src/main/java/com/init/workflowruntime/interceptor/JwtChannelInterceptor.java
+++ b/backend/src/main/java/com/init/workflowruntime/interceptor/JwtChannelInterceptor.java
@@ -1,6 +1,7 @@
 package com.init.workflowruntime.interceptor;
 
 import com.init.auth.application.JwtService;
+import com.init.shared.application.exception.BadRequestException;
 import com.init.shared.application.exception.InvalidTokenException;
 import io.jsonwebtoken.Claims;
 import java.util.HashMap;
@@ -54,7 +55,29 @@ public class JwtChannelInterceptor implements ChannelInterceptor {
       }
       sessionAttrs.put("role", claims.get("role", String.class));
       return MessageBuilder.createMessage(message.getPayload(), accessor.getMessageHeaders());
+    } else if (StompCommand.SUBSCRIBE.equals(accessor.getCommand())
+        || StompCommand.SEND.equals(accessor.getCommand())) {
+      if (accessor.getUser() == null) {
+        throw new MissingAuthHeaderException(
+            "Authentication required for " + accessor.getCommand());
+      }
+      if (StompCommand.SUBSCRIBE.equals(accessor.getCommand())) {
+        String destination = accessor.getDestination();
+        if (destination != null) {
+          validateSubscribeDestination(destination);
+        }
+      }
     }
     return message;
+  }
+
+  private void validateSubscribeDestination(String destination) {
+    if (destination.startsWith("/topic/chat.")
+        || destination.startsWith("/user/queue/")
+        || destination.startsWith("/queue/")) {
+      return;
+    }
+    throw new BadRequestException(
+        "INVALID_DESTINATION", "Unauthorized subscription destination: " + destination);
   }
 }

--- a/backend/src/main/java/com/init/workflowruntime/presentation/ChatWebSocketController.java
+++ b/backend/src/main/java/com/init/workflowruntime/presentation/ChatWebSocketController.java
@@ -36,7 +36,12 @@ public class ChatWebSocketController {
     if (principal == null || principal.getName() == null) {
       throw new BadRequestException("INVALID_PRINCIPAL", "Authentication required");
     }
-    Long userId = Long.parseLong(principal.getName());
+    Long userId;
+    try {
+      userId = Long.parseLong(principal.getName());
+    } catch (NumberFormatException e) {
+      throw new BadRequestException("INVALID_PRINCIPAL", "Invalid principal: " + principal.getName());
+    }
     SendChatMessageCommand command =
         new SendChatMessageCommand(request.getSessionId(), request.getContent(), userId, "USER");
     return chatWebSocketService.saveAndBroadcast(command);

--- a/backend/src/main/java/com/init/workflowruntime/presentation/ChatWebSocketController.java
+++ b/backend/src/main/java/com/init/workflowruntime/presentation/ChatWebSocketController.java
@@ -40,7 +40,8 @@ public class ChatWebSocketController {
     try {
       userId = Long.parseLong(principal.getName());
     } catch (NumberFormatException e) {
-      throw new BadRequestException("INVALID_PRINCIPAL", "Invalid principal: " + principal.getName());
+      throw new BadRequestException(
+          "INVALID_PRINCIPAL", "Invalid principal: " + principal.getName());
     }
     SendChatMessageCommand command =
         new SendChatMessageCommand(request.getSessionId(), request.getContent(), userId, "USER");

--- a/backend/src/main/java/com/init/workflowruntime/presentation/ChatWebSocketController.java
+++ b/backend/src/main/java/com/init/workflowruntime/presentation/ChatWebSocketController.java
@@ -1,5 +1,6 @@
 package com.init.workflowruntime.presentation;
 
+import com.init.shared.application.exception.BadRequestException;
 import com.init.shared.application.exception.BusinessException;
 import com.init.workflowruntime.application.ChatWebSocketService;
 import com.init.workflowruntime.application.dto.ChatMessageRequest;
@@ -32,6 +33,9 @@ public class ChatWebSocketController {
       @Valid ChatMessageRequest request,
       @Header("simpSessionId") String sessionId,
       Principal principal) {
+    if (principal == null || principal.getName() == null) {
+      throw new BadRequestException("INVALID_PRINCIPAL", "Authentication required");
+    }
     Long userId = Long.parseLong(principal.getName());
     SendChatMessageCommand command =
         new SendChatMessageCommand(request.getSessionId(), request.getContent(), userId, "USER");

--- a/backend/src/main/java/com/init/workflowruntime/presentation/CounselorWebSocketController.java
+++ b/backend/src/main/java/com/init/workflowruntime/presentation/CounselorWebSocketController.java
@@ -39,7 +39,7 @@ public class CounselorWebSocketController {
       throw new BadRequestException("INVALID_PRINCIPAL", "Counselor id must be numeric");
     }
     return counselorService.sendCounselorMessage(
-        request.getSessionId(), request.getContent(), counselorId);
+        request.getSessionId(), request.getContent(), counselorId, request.isNote());
   }
 
   @MessageExceptionHandler

--- a/backend/src/test/java/com/init/workflowruntime/application/ChatWebSocketServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/ChatWebSocketServiceTest.java
@@ -2,12 +2,14 @@ package com.init.workflowruntime.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
+import com.init.shared.application.exception.BadRequestException;
 import com.init.shared.application.exception.NotFoundException;
 import com.init.workflowruntime.application.dto.ChatMessageResponse;
 import com.init.workflowruntime.application.dto.SendChatMessageCommand;
@@ -99,10 +101,11 @@ class ChatWebSocketServiceTest {
     ReflectionTestUtils.setField(session, "startedBy", 99L);
     given(chatSessionRepository.findByIdForUpdate(1L)).willReturn(Optional.of(session));
 
-    assertThatThrownBy(
-            () -> service.saveAndBroadcast(new SendChatMessageCommand(1L, "Hello", 1L, "USER")))
-        .isInstanceOf(com.init.shared.application.exception.BadRequestException.class)
-        .hasMessageContaining("does not own session");
+    BadRequestException ex =
+        catchThrowableOfType(
+            () -> service.saveAndBroadcast(new SendChatMessageCommand(1L, "Hello", 1L, "USER")),
+            BadRequestException.class);
+    assertThat(ex.getCode()).isEqualTo("SESSION_ACCESS_DENIED");
   }
 
   @Test
@@ -111,10 +114,11 @@ class ChatWebSocketServiceTest {
     ChatSession session = createSession(1L, ChatSessionStatus.COMPLETED);
     given(chatSessionRepository.findByIdForUpdate(1L)).willReturn(Optional.of(session));
 
-    assertThatThrownBy(
-            () -> service.saveAndBroadcast(new SendChatMessageCommand(1L, "Hello", 1L, "USER")))
-        .isInstanceOf(com.init.shared.application.exception.BadRequestException.class)
-        .hasMessageContaining("is not open or active");
+    BadRequestException ex =
+        catchThrowableOfType(
+            () -> service.saveAndBroadcast(new SendChatMessageCommand(1L, "Hello", 1L, "USER")),
+            BadRequestException.class);
+    assertThat(ex.getCode()).isEqualTo("SESSION_NOT_OPEN_OR_ACTIVE");
   }
 
   @Test

--- a/backend/src/test/java/com/init/workflowruntime/application/ChatWebSocketServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/ChatWebSocketServiceTest.java
@@ -102,7 +102,7 @@ class ChatWebSocketServiceTest {
     assertThatThrownBy(
             () -> service.saveAndBroadcast(new SendChatMessageCommand(1L, "Hello", 1L, "USER")))
         .isInstanceOf(com.init.shared.application.exception.BadRequestException.class)
-        .hasMessageContaining("SESSION_ACCESS_DENIED");
+        .hasMessageContaining("does not own session");
   }
 
   @Test
@@ -114,7 +114,7 @@ class ChatWebSocketServiceTest {
     assertThatThrownBy(
             () -> service.saveAndBroadcast(new SendChatMessageCommand(1L, "Hello", 1L, "USER")))
         .isInstanceOf(com.init.shared.application.exception.BadRequestException.class)
-        .hasMessageContaining("SESSION_NOT_OPEN_OR_ACTIVE");
+        .hasMessageContaining("is not open or active");
   }
 
   @Test

--- a/backend/src/test/java/com/init/workflowruntime/application/ChatWebSocketServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/ChatWebSocketServiceTest.java
@@ -93,6 +93,31 @@ class ChatWebSocketServiceTest {
   }
 
   @Test
+  @DisplayName("saveAndBroadcast: 세션 소유자가 다른 사용자 → SESSION_ACCESS_DENIED")
+  void should_throwBadRequest_when_userDoesNotOwnSession() {
+    ChatSession session = createSession(1L, ChatSessionStatus.OPEN);
+    ReflectionTestUtils.setField(session, "startedBy", 99L);
+    given(chatSessionRepository.findByIdForUpdate(1L)).willReturn(Optional.of(session));
+
+    assertThatThrownBy(
+            () -> service.saveAndBroadcast(new SendChatMessageCommand(1L, "Hello", 1L, "USER")))
+        .isInstanceOf(com.init.shared.application.exception.BadRequestException.class)
+        .hasMessageContaining("SESSION_ACCESS_DENIED");
+  }
+
+  @Test
+  @DisplayName("saveAndBroadcast: 세션 상태가 COMPLETED → SESSION_NOT_OPEN_OR_ACTIVE")
+  void should_throwBadRequest_when_sessionCompleted() {
+    ChatSession session = createSession(1L, ChatSessionStatus.COMPLETED);
+    given(chatSessionRepository.findByIdForUpdate(1L)).willReturn(Optional.of(session));
+
+    assertThatThrownBy(
+            () -> service.saveAndBroadcast(new SendChatMessageCommand(1L, "Hello", 1L, "USER")))
+        .isInstanceOf(com.init.shared.application.exception.BadRequestException.class)
+        .hasMessageContaining("SESSION_NOT_OPEN_OR_ACTIVE");
+  }
+
+  @Test
   @DisplayName("saveAndBroadcast: 세션 상태가 OPEN → 정상 저장 및 afterCommit broadcast")
   void should_saveAndBroadcast_when_sessionOpen() {
     ChatSession session = createSession(1L, ChatSessionStatus.OPEN);

--- a/backend/src/test/java/com/init/workflowruntime/application/ConsultationServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/ConsultationServiceTest.java
@@ -41,6 +41,29 @@ class ConsultationServiceTest {
   }
 
   @Test
+  @DisplayName("getActiveQueue: OPEN+ACTIVE 세션 목록을 반환한다")
+  void should_returnActiveQueue_when_called() {
+    ChatSession s1 = createSession(1L);
+    ChatSession s2 = createSession(2L);
+    given(chatSessionRepository.findByStatusInOrderByStartedAtDesc(any()))
+        .willReturn(List.of(s1, s2));
+
+    List<ChatSessionResponse> result = service.getActiveQueue();
+
+    assertThat(result).hasSize(2);
+    assertThat(result.get(0).getId()).isEqualTo(1L);
+    assertThat(result.get(1).getId()).isEqualTo(2L);
+  }
+
+  @Test
+  @DisplayName("getActiveQueue: 대기 세션 없음 → 빈 목록 반환")
+  void should_returnEmptyList_when_noActiveQueue() {
+    given(chatSessionRepository.findByStatusInOrderByStartedAtDesc(any())).willReturn(List.of());
+
+    assertThat(service.getActiveQueue()).isEmpty();
+  }
+
+  @Test
   @DisplayName("getMessages: 세션 없음 → NotFoundException 발생")
   void should_NotFoundException발생_when_세션없음() {
     // given

--- a/backend/src/test/java/com/init/workflowruntime/application/ConsultationServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/ConsultationServiceTest.java
@@ -43,8 +43,8 @@ class ConsultationServiceTest {
   @Test
   @DisplayName("getActiveQueue: OPEN+ACTIVE 세션 목록을 반환한다")
   void should_returnActiveQueue_when_called() {
-    ChatSession s1 = createSession(1L);
-    ChatSession s2 = createSession(2L);
+    ChatSession s1 = createSession(1L, ChatSessionStatus.OPEN);
+    ChatSession s2 = createSession(2L, ChatSessionStatus.ACTIVE);
     given(chatSessionRepository.findByStatusInOrderByStartedAtDesc(any()))
         .willReturn(List.of(s1, s2));
 
@@ -145,7 +145,11 @@ class ConsultationServiceTest {
   // ── helpers ────────────────────────────────────────────────────────────────
 
   private ChatSession createSession(Long id) {
-    ChatSession session = ChatSession.create(1L, 1L, ChatSessionStatus.OPEN, "WEB", "{}");
+    return createSession(id, ChatSessionStatus.OPEN);
+  }
+
+  private ChatSession createSession(Long id, ChatSessionStatus status) {
+    ChatSession session = ChatSession.create(1L, 1L, status, "WEB", "{}");
     ReflectionTestUtils.setField(session, "id", id);
     return session;
   }

--- a/backend/src/test/java/com/init/workflowruntime/application/CounselorServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/CounselorServiceTest.java
@@ -235,6 +235,29 @@ class CounselorServiceTest {
   }
 
   @Test
+  @DisplayName("sendCounselorMessage: isNote=true → senderRole NOTE")
+  void should_saveNoteRole_when_isNoteTrue() {
+    ChatSession session = createSession(1L, ChatSessionStatus.ACTIVE);
+    ReflectionTestUtils.setField(session, "assignedCounselorId", 42L);
+    given(chatSessionRepository.findByIdForUpdate(1L)).willReturn(Optional.of(session));
+    given(chatMessageRepository.findTopByChatSessionIdOrderBySeqNoDesc(1L))
+        .willReturn(Optional.empty());
+
+    ChatMessage savedMsg = createMessage(1L, 1, "NOTE", "Hello from counselor");
+    given(chatMessageRepository.save(any())).willReturn(savedMsg);
+
+    TransactionSynchronizationManager.initSynchronization();
+    try {
+      ChatMessageResponse result =
+          service.sendCounselorMessage(1L, "Hello from counselor", 42L, true);
+
+      assertThat(result.senderRole()).isEqualTo("NOTE");
+    } finally {
+      TransactionSynchronizationManager.clearSynchronization();
+    }
+  }
+
+  @Test
   @DisplayName("sendCounselorMessage: 배정되지 않은 상담사 → BadRequestException")
   void should_throwBadRequest_when_counselorNotAssignedToSend() {
     ChatSession session = createSession(1L, ChatSessionStatus.ACTIVE);

--- a/backend/src/test/java/com/init/workflowruntime/application/CounselorServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/CounselorServiceTest.java
@@ -216,7 +216,8 @@ class CounselorServiceTest {
 
     TransactionSynchronizationManager.initSynchronization();
     try {
-      ChatMessageResponse result = service.sendCounselorMessage(1L, "Hello from counselor", 42L);
+      ChatMessageResponse result =
+          service.sendCounselorMessage(1L, "Hello from counselor", 42L, false);
 
       assertThat(result).isNotNull();
       assertThat(result.content()).isEqualTo("Hello from counselor");
@@ -240,7 +241,7 @@ class CounselorServiceTest {
     ReflectionTestUtils.setField(session, "assignedCounselorId", 10L);
     given(chatSessionRepository.findByIdForUpdate(1L)).willReturn(Optional.of(session));
 
-    assertThatThrownBy(() -> service.sendCounselorMessage(1L, "Hello", 42L))
+    assertThatThrownBy(() -> service.sendCounselorMessage(1L, "Hello", 42L, false))
         .isInstanceOf(BadRequestException.class)
         .hasMessageContaining("not assigned to counselor");
   }
@@ -252,7 +253,7 @@ class CounselorServiceTest {
     ReflectionTestUtils.setField(session, "assignedCounselorId", 42L);
     given(chatSessionRepository.findByIdForUpdate(1L)).willReturn(Optional.of(session));
 
-    assertThatThrownBy(() -> service.sendCounselorMessage(1L, "Hello", 42L))
+    assertThatThrownBy(() -> service.sendCounselorMessage(1L, "Hello", 42L, false))
         .isInstanceOf(BadRequestException.class)
         .hasMessageContaining("not ACTIVE");
   }

--- a/backend/src/test/java/com/init/workflowruntime/application/LlmResponseHandlerTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/LlmResponseHandlerTest.java
@@ -73,7 +73,8 @@ class LlmResponseHandlerTest {
   @DisplayName("handleChatMessageReceived: LLM 예외 → fallback 메시지 STOMP push")
   void should_pushFallback_when_llmThrowsException() {
     ChatMessageReceivedEvent event = new ChatMessageReceivedEvent(1L, "안녕하세요", 1L);
-    given(llmAssistantService.generateResponse("", "안녕하세요"))
+    given(chatSessionRepository.findByIdForUpdate(1L)).willReturn(Optional.of(mockSession()));
+    given(llmAssistantService.generateResponse(any(), eq("안녕하세요")))
         .willThrow(new RuntimeException("API timeout"));
 
     handler.handleChatMessageReceived(event);

--- a/backend/src/test/java/com/init/workflowruntime/application/SessionAssignedEventListenerTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/SessionAssignedEventListenerTest.java
@@ -1,0 +1,59 @@
+package com.init.workflowruntime.application;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.init.workflowruntime.domain.ChatSession;
+import com.init.workflowruntime.domain.ChatSessionRepository;
+import com.init.workflowruntime.domain.ChatSessionStatus;
+import com.init.workflowruntime.domain.event.SessionAssignedEvent;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SessionAssignedEventListener")
+class SessionAssignedEventListenerTest {
+
+  @Mock private ChatSessionRepository chatSessionRepository;
+  @Mock private SimpMessagingTemplate messagingTemplate;
+
+  private SessionAssignedEventListener listener;
+
+  @BeforeEach
+  void setUp() {
+    listener = new SessionAssignedEventListener(chatSessionRepository, messagingTemplate);
+  }
+
+  @Test
+  @DisplayName("세션이 존재하면 상담사 큐에 STOMP 메시지를 전송한다")
+  void should_sendNotification_when_sessionExists() {
+    ChatSession session = ChatSession.create(1L, 1L, ChatSessionStatus.ACTIVE, "WEB", "{}");
+    ReflectionTestUtils.setField(session, "id", 1L);
+    given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+
+    listener.handleSessionAssigned(new SessionAssignedEvent(1L, 42L));
+
+    verify(messagingTemplate)
+        .convertAndSendToUser(eq("42"), eq("/queue/counselor.notifications"), any());
+  }
+
+  @Test
+  @DisplayName("세션이 없으면 STOMP 전송 없이 경고만 기록한다")
+  void should_skipNotification_when_sessionNotFound() {
+    given(chatSessionRepository.findById(99L)).willReturn(Optional.empty());
+
+    listener.handleSessionAssigned(new SessionAssignedEvent(99L, 42L));
+
+    verify(messagingTemplate, never()).convertAndSendToUser(any(), any(), any());
+  }
+}

--- a/backend/src/test/java/com/init/workflowruntime/domain/ChatSessionTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/domain/ChatSessionTest.java
@@ -1,0 +1,55 @@
+package com.init.workflowruntime.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@DisplayName("ChatSession")
+class ChatSessionTest {
+
+  @Test
+  @DisplayName("reopen: RESOLVED → OPEN, assignedCounselorId와 endedAt이 초기화된다")
+  void should_clearCounselorAndEndedAt_when_reopen() {
+    ChatSession session = ChatSession.create(1L, 1L, ChatSessionStatus.RESOLVED, "WEB", "{}");
+    ReflectionTestUtils.setField(session, "assignedCounselorId", 42L);
+    ReflectionTestUtils.setField(session, "endedAt", java.time.OffsetDateTime.now());
+
+    session.reopen();
+
+    assertThat(session.getStatus()).isEqualTo(ChatSessionStatus.OPEN);
+    assertThat(session.getAssignedCounselorId()).isNull();
+    assertThat(session.getEndedAt()).isNull();
+  }
+
+  @Test
+  @DisplayName("reopen: RESOLVED가 아닌 상태 → InvalidSessionStateException")
+  void should_throw_when_reopenFromNonResolved() {
+    ChatSession session = ChatSession.create(1L, 1L, ChatSessionStatus.OPEN, "WEB", "{}");
+
+    assertThatThrownBy(session::reopen).isInstanceOf(InvalidSessionStateException.class);
+  }
+
+  @Test
+  @DisplayName("closeSession: assignedCounselorId가 초기화되고 endedAt이 설정된다")
+  void should_clearCounselorAndSetEndedAt_when_closeSession() {
+    ChatSession session = ChatSession.create(1L, 1L, ChatSessionStatus.ACTIVE, "WEB", "{}");
+    ReflectionTestUtils.setField(session, "assignedCounselorId", 42L);
+
+    session.closeSession();
+
+    assertThat(session.getStatus()).isEqualTo(ChatSessionStatus.COMPLETED);
+    assertThat(session.getAssignedCounselorId()).isNull();
+    assertThat(session.getEndedAt()).isNotNull();
+  }
+
+  @Test
+  @DisplayName("closeSession: 이미 COMPLETED → InvalidSessionStateException")
+  void should_throw_when_closeSessionAlreadyCompleted() {
+    ChatSession session = ChatSession.create(1L, 1L, ChatSessionStatus.COMPLETED, "WEB", "{}");
+
+    assertThatThrownBy(session::closeSession).isInstanceOf(InvalidSessionStateException.class);
+  }
+}

--- a/backend/src/test/java/com/init/workflowruntime/interceptor/JwtChannelInterceptorTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/interceptor/JwtChannelInterceptorTest.java
@@ -160,4 +160,55 @@ class JwtChannelInterceptorTest {
     assertThatThrownBy(() -> interceptor.preSend(message, channel))
         .isInstanceOf(MissingAuthHeaderException.class);
   }
+
+  @Test
+  @DisplayName("SUBSCRIBE with auth, valid destination → passes through")
+  void should_passThrough_when_subscribeWithAuthAndValidDestination() {
+    StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.SUBSCRIBE);
+    accessor.setUser(() -> "42");
+    accessor.setDestination("/topic/chat.1");
+    Message<byte[]> message =
+        MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+
+    Message<?> result = interceptor.preSend(message, channel);
+
+    assertThat(result).isSameAs(message);
+  }
+
+  @Test
+  @DisplayName("SUBSCRIBE with auth, invalid destination → BadRequestException")
+  void should_throwBadRequest_when_subscribeToUnauthorizedDestination() {
+    StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.SUBSCRIBE);
+    accessor.setUser(() -> "42");
+    accessor.setDestination("/topic/unauthorized");
+    Message<byte[]> message =
+        MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+
+    assertThatThrownBy(() -> interceptor.preSend(message, channel))
+        .isInstanceOf(com.init.shared.application.exception.BadRequestException.class);
+  }
+
+  @Test
+  @DisplayName("SEND with authentication → passes through")
+  void should_passThrough_when_sendWithAuth() {
+    StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.SEND);
+    accessor.setUser(() -> "42");
+    Message<byte[]> message =
+        MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+
+    Message<?> result = interceptor.preSend(message, channel);
+
+    assertThat(result).isSameAs(message);
+  }
+
+  @Test
+  @DisplayName("SEND without authentication → MissingAuthHeaderException")
+  void should_throwMissingAuthHeader_when_sendWithoutAuth() {
+    StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.SEND);
+    Message<byte[]> message =
+        MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+
+    assertThatThrownBy(() -> interceptor.preSend(message, channel))
+        .isInstanceOf(MissingAuthHeaderException.class);
+  }
 }

--- a/backend/src/test/java/com/init/workflowruntime/interceptor/JwtChannelInterceptorTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/interceptor/JwtChannelInterceptorTest.java
@@ -139,14 +139,25 @@ class JwtChannelInterceptorTest {
   }
 
   @Test
-  @DisplayName("Non-CONNECT command → passes through without validation")
+  @DisplayName("DISCONNECT command → passes through without validation")
   void should_passThrough_when_notConnectCommand() {
-    StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.SUBSCRIBE);
+    StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.DISCONNECT);
     Message<byte[]> message =
         MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
 
     Message<?> result = interceptor.preSend(message, channel);
 
     assertThat(result).isSameAs(message);
+  }
+
+  @Test
+  @DisplayName("SUBSCRIBE without authentication → MissingAuthHeaderException")
+  void should_throwMissingAuthHeader_when_subscribeWithoutAuth() {
+    StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.SUBSCRIBE);
+    Message<byte[]> message =
+        MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+
+    assertThatThrownBy(() -> interceptor.preSend(message, channel))
+        .isInstanceOf(MissingAuthHeaderException.class);
   }
 }

--- a/backend/src/test/java/com/init/workflowruntime/presentation/ChatWebSocketControllerTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/presentation/ChatWebSocketControllerTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
+import com.init.shared.application.exception.BadRequestException;
 import com.init.shared.application.exception.NotFoundException;
 import com.init.workflowruntime.application.ChatWebSocketService;
 import com.init.workflowruntime.application.dto.ChatMessageRequest;
@@ -70,6 +71,43 @@ class ChatWebSocketControllerTest {
         .isInstanceOf(NotFoundException.class)
         .satisfies(
             e -> assertThat(((NotFoundException) e).getCode()).isEqualTo("SESSION_NOT_FOUND"));
+  }
+
+  @Test
+  @DisplayName("sendMessage: principal null → BadRequestException")
+  void should_throwBadRequest_when_principalNull() {
+    ChatMessageRequest request = new ChatMessageRequest();
+    request.setSessionId(1L);
+    request.setContent("Hello");
+
+    assertThatThrownBy(() -> controller.sendMessage(request, "simp-1", null))
+        .isInstanceOf(BadRequestException.class);
+  }
+
+  @Test
+  @DisplayName("sendMessage: principal.getName() null → BadRequestException")
+  void should_throwBadRequest_when_principalNameNull() {
+    ChatMessageRequest request = new ChatMessageRequest();
+    request.setSessionId(1L);
+    request.setContent("Hello");
+
+    Principal principal = () -> null;
+
+    assertThatThrownBy(() -> controller.sendMessage(request, "simp-1", principal))
+        .isInstanceOf(BadRequestException.class);
+  }
+
+  @Test
+  @DisplayName("sendMessage: principal이 숫자가 아닌 경우 → BadRequestException")
+  void should_throwBadRequest_when_principalNotNumeric() {
+    ChatMessageRequest request = new ChatMessageRequest();
+    request.setSessionId(1L);
+    request.setContent("Hello");
+
+    Principal principal = () -> "not-a-number";
+
+    assertThatThrownBy(() -> controller.sendMessage(request, "simp-1", principal))
+        .isInstanceOf(BadRequestException.class);
   }
 
   @Test

--- a/backend/src/test/java/com/init/workflowruntime/presentation/CounselorWebSocketControllerTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/presentation/CounselorWebSocketControllerTest.java
@@ -45,7 +45,8 @@ class CounselorWebSocketControllerTest {
         new ChatMessageResponse(
             10L, 1, "COUNSELOR", "TEXT", "Counselor message", OffsetDateTime.now());
 
-    given(counselorService.sendCounselorMessage(1L, "Counselor message", 42L)).willReturn(expected);
+    given(counselorService.sendCounselorMessage(1L, "Counselor message", 42L, false))
+        .willReturn(expected);
 
     ChatMessageResponse result = controller.sendCounselorMessage(request, principal);
 
@@ -62,7 +63,7 @@ class CounselorWebSocketControllerTest {
 
     Principal principal = () -> "42";
 
-    given(counselorService.sendCounselorMessage(999L, "Hello", 42L))
+    given(counselorService.sendCounselorMessage(999L, "Hello", 42L, false))
         .willThrow(new NotFoundException("SESSION_NOT_FOUND", "Session not found: 999"));
 
     assertThatThrownBy(() -> controller.sendCounselorMessage(request, principal))
@@ -80,7 +81,7 @@ class CounselorWebSocketControllerTest {
 
     Principal principal = () -> "99";
 
-    given(counselorService.sendCounselorMessage(1L, "Hello", 99L))
+    given(counselorService.sendCounselorMessage(1L, "Hello", 99L, false))
         .willThrow(
             new BadRequestException(
                 "SESSION_NOT_ASSIGNED", "Session 1 is not assigned to counselor: 99"));

--- a/frontend/src/features/user-chat/ui/ChatRoom.test.tsx
+++ b/frontend/src/features/user-chat/ui/ChatRoom.test.tsx
@@ -1,14 +1,23 @@
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
 import { ChatRoom } from "./ChatRoom";
 
-const stompState = vi.hoisted(() => ({
-  connectionStatus: "CONNECTED" as "CONNECTING" | "CONNECTED" | "DISCONNECTED" | "ERROR",
-  lastMessage: null as unknown,
-  sendMessage: vi.fn(),
-  connect: vi.fn(),
-  disconnect: vi.fn(),
-}));
+const stompState = vi.hoisted(() => {
+  const callbacks = new Map<string, (msg: unknown) => void>();
+  const subscribe = vi.fn((topic: string, cb: (msg: unknown) => void) => {
+    callbacks.set(topic, cb);
+    return () => {};
+  });
+  return {
+    connectionStatus: "CONNECTED" as "CONNECTING" | "CONNECTED" | "DISCONNECTED" | "ERROR",
+    sendMessage: vi.fn(),
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    subscribe,
+    dispatch: (topic: string, msg: unknown) => callbacks.get(topic)?.(msg),
+  };
+});
 
 vi.mock("@/shared/lib/websocket", () => ({
   useStomp: () => stompState,
@@ -17,8 +26,8 @@ vi.mock("@/shared/lib/websocket", () => ({
 describe("ChatRoom", () => {
   beforeEach(() => {
     stompState.connectionStatus = "CONNECTED";
-    stompState.lastMessage = null;
     stompState.sendMessage.mockReset();
+    stompState.subscribe.mockClear();
   });
 
   it("연결 상태와 빈 메시지 상태를 렌더링한다", () => {
@@ -28,19 +37,22 @@ describe("ChatRoom", () => {
     expect(screen.getByText("아직 메시지가 없습니다. 첫 메시지를 보내보세요!")).toBeInTheDocument();
   });
 
-  it("lastMessage가 바뀌면 메시지 목록에 추가한다", () => {
-    const { rerender } = render(<ChatRoom sessionId={7} />);
+  it("STOMP 메시지 수신 시 메시지 목록에 추가한다", async () => {
+    render(<ChatRoom sessionId={7} />);
+
+    await waitFor(() => {
+      expect(stompState.subscribe).toHaveBeenCalledWith("/topic/chat.7", expect.any(Function));
+    });
 
     act(() => {
-      stompState.lastMessage = {
+      stompState.dispatch("/topic/chat.7", {
         id: "m1",
         sessionId: 7,
         content: "안녕하세요",
         senderType: "BOT",
         createdAt: "2026-05-22T08:00:00Z",
-      };
+      });
     });
-    rerender(<ChatRoom sessionId={7} />);
 
     expect(screen.getByText("안녕하세요")).toBeInTheDocument();
   });

--- a/frontend/src/features/user-chat/ui/ChatRoom.tsx
+++ b/frontend/src/features/user-chat/ui/ChatRoom.tsx
@@ -25,7 +25,7 @@ function isChatMessage(message: unknown): message is ChatMessage {
 }
 
 export function ChatRoom({ sessionId }: ChatRoomProps) {
-  const { connectionStatus, sendMessage, lastMessage } = useStomp<ChatMessage>();
+  const { connectionStatus, sendMessage, subscribe } = useStomp();
   const [messages, setMessages] = useState<ChatMessage[]>([]);
 
   useEffect(() => {
@@ -33,14 +33,17 @@ export function ChatRoom({ sessionId }: ChatRoomProps) {
   }, [sessionId]);
 
   useEffect(() => {
-    if (!isChatMessage(lastMessage)) return;
-    if (lastMessage.sessionId !== sessionId) return;
-
-    setMessages((current) => {
-      if (current.some((message) => message.id === lastMessage.id)) return current;
-      return [...current, lastMessage];
+    if (connectionStatus !== "CONNECTED") return;
+    const unsubscribe = subscribe(`/topic/chat.${sessionId}`, (raw) => {
+      if (!isChatMessage(raw)) return;
+      if (raw.sessionId !== sessionId) return;
+      setMessages((current) => {
+        if (current.some((message) => message.id === raw.id)) return current;
+        return [...current, raw];
+      });
     });
-  }, [lastMessage, sessionId]);
+    return unsubscribe;
+  }, [connectionStatus, sessionId, subscribe]);
 
   return (
     <section className="flex h-full min-h-[520px] flex-col rounded-lg border border-gray-200 bg-white">

--- a/frontend/src/features/user-chat/ui/MessageList.tsx
+++ b/frontend/src/features/user-chat/ui/MessageList.tsx
@@ -27,7 +27,7 @@ export function MessageList({ messages, loading = false, error = null }: Message
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView?.({ behavior: "smooth" });
-  }, [messages.length]);
+  }, [messages]);
 
   if (error) {
     return (

--- a/frontend/src/pages/consultation/ui/ConsultationPage.test.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.test.tsx
@@ -533,14 +533,14 @@ describe("ConsultationPage", () => {
       stompState.latestCallback({
         id: 888,
         senderRole: "COUNSELOR",
-        content: "정식 답변 내용",
+        content: "임시 답변",
         createdAt: new Date().toISOString(),
       });
     }
 
     await waitFor(() => {
-      expect(screen.getByText("정식 답변 내용")).toBeInTheDocument();
-      expect(screen.queryByText("임시 답변")).not.toBeInTheDocument();
+      expect(screen.getByText("임시 답변")).toBeInTheDocument();
+      expect(screen.getAllByText("임시 답변")).toHaveLength(1);
     });
   });
 

--- a/frontend/src/pages/consultation/ui/ConsultationPage.test.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.test.tsx
@@ -195,7 +195,7 @@ describe("ConsultationPage", () => {
     if (customerItem) customerItem.click();
 
     await waitFor(() => {
-      expect(mockSubscribe).toHaveBeenCalledWith("/topic/chat.counselor.1", expect.any(Function));
+      expect(mockSubscribe).toHaveBeenCalledWith("/topic/chat.1", expect.any(Function));
     });
   });
 

--- a/frontend/src/pages/consultation/ui/ConsultationPage.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.tsx
@@ -169,7 +169,8 @@ export const ConsultationPage: React.FC = () => {
               const pending = prev.find((m) => m.id === id);
               return pending?.content === (msg.content ?? "");
             });
-            const tempId = matchIdx >= 0 ? temps[matchIdx] : temps[0];
+            if (matchIdx < 0) return prev;
+            const tempId = temps[matchIdx];
             pendingIdsRef.current.delete(tempId);
             return prev.map((m) =>
               m.id === tempId

--- a/frontend/src/pages/consultation/ui/ConsultationPage.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.tsx
@@ -63,8 +63,9 @@ export const ConsultationPage: React.FC = () => {
   const [memos, setMemos] = useState<Record<string, string>>({});
   const [statuses, setStatuses] = useState<Record<string, string>>({});
   const [selectedMessageId, setSelectedMessageId] = useState<string | null>(null);
-  const { connectionStatus, subscribe, sendTo } = useStomp<RealtimeChatMessage>();
+  const { connectionStatus, subscribe, sendTo } = useStomp();
   const pendingIdsRef = useRef<Set<string>>(new Set());
+  const tempCounterRef = useRef(0);
 
   const activeCustomer = queue.find((c) => c.id === activeCustomerId) || null;
   const selectedMessage = messages.find((m) => m.id === selectedMessageId) || null;
@@ -157,16 +158,27 @@ export const ConsultationPage: React.FC = () => {
   useEffect(() => {
     if (connectionStatus !== "CONNECTED" || !activeCustomerId) return;
 
-    const topic = `/topic/chat.counselor.${activeCustomerId}`;
-    const unsubscribe = subscribe(topic, (msg) => {
+    const topic = `/topic/chat.${activeCustomerId}`;
+    const unsubscribe = subscribe(topic, (raw) => {
+      const msg = raw as RealtimeChatMessage;
       if (msg.senderRole === "COUNSELOR") {
         setMessages((prev) => {
           const temps = [...pendingIdsRef.current];
           if (temps.length > 0) {
-            pendingIdsRef.current.delete(temps[0]);
+            const matchIdx = temps.findIndex((id) => {
+              const pending = prev.find((m) => m.id === id);
+              return pending?.content === (msg.content ?? "");
+            });
+            const tempId = matchIdx >= 0 ? temps[matchIdx] : temps[0];
+            pendingIdsRef.current.delete(tempId);
             return prev.map((m) =>
-              m.id === temps[0]
-                ? { id: String(msg.id), senderRole: "COUNSELOR" as const, content: msg.content ?? "", timestamp: formatTime(msg.createdAt ?? msg.timestamp ?? "") }
+              m.id === tempId
+                ? {
+                    id: String(msg.id),
+                    senderRole: "COUNSELOR" as const,
+                    content: msg.content ?? "",
+                    timestamp: formatTime(msg.createdAt ?? msg.timestamp ?? ""),
+                  }
                 : m,
             );
           }
@@ -174,15 +186,19 @@ export const ConsultationPage: React.FC = () => {
         });
         return;
       }
-      setMessages((prev) => [
-        ...prev,
-        {
-          id: String(msg.id),
-          senderRole: msg.senderRole as UiChatMessage["senderRole"],
-          content: msg.content ?? "",
-          timestamp: formatTime(msg.createdAt ?? msg.timestamp ?? ""),
-        },
-      ]);
+      const msgId = String(msg.id);
+      setMessages((prev) => {
+        if (prev.some((m) => m.id === msgId)) return prev;
+        return [
+          ...prev,
+          {
+            id: msgId,
+            senderRole: msg.senderRole as UiChatMessage["senderRole"],
+            content: msg.content ?? "",
+            timestamp: formatTime(msg.createdAt ?? msg.timestamp ?? ""),
+          },
+        ];
+      });
     });
 
     return () => {
@@ -214,7 +230,7 @@ export const ConsultationPage: React.FC = () => {
       };
 
       const optimisticMsg: UiChatMessage = {
-        id: `temp-${Date.now()}`,
+        id: `temp-${Date.now()}-${++tempCounterRef.current}`,
         senderRole: "COUNSELOR",
         content,
         timestamp: formatTime(new Date().toISOString()),

--- a/frontend/src/shared/lib/websocket/stompClient.test.ts
+++ b/frontend/src/shared/lib/websocket/stompClient.test.ts
@@ -18,20 +18,23 @@ describe("createStompClient", () => {
     vi.unstubAllEnvs();
   });
 
-  it("채팅 WebSocket broker URL과 인증 헤더로 STOMP Client를 생성한다", () => {
+  it("채팅 WebSocket broker URL과 기본 설정으로 STOMP Client를 생성하고, beforeConnect로 동적 토큰을 설정한다", () => {
     localStorage.setItem("accessToken", "access-token");
 
-    createStompClient();
+    const client = createStompClient();
 
     expect(MockedClient).toHaveBeenCalledWith(
       expect.objectContaining({
         brokerURL: "ws://localhost:8080/ws/chat",
-        connectHeaders: { Authorization: "Bearer access-token" },
         reconnectDelay: 5000,
         heartbeatIncoming: 10000,
         heartbeatOutgoing: 10000,
       }),
     );
+
+    expect(typeof client.beforeConnect).toBe("function");
+    (client.beforeConnect as () => void)();
+    expect(client.connectHeaders).toEqual({ Authorization: "Bearer access-token" });
   });
 
   it("VITE_WS_URL 환경 변수가 https 프로토콜일 때 wss로 자동 변환하고 trailing slash를 제거한다", () => {

--- a/frontend/src/shared/lib/websocket/stompClient.ts
+++ b/frontend/src/shared/lib/websocket/stompClient.ts
@@ -16,13 +16,15 @@ function getWebSocketBaseUrl(): string {
 }
 
 export function createStompClient(): Client {
-  const token = getAccessToken();
-
-  return new Client({
+  const client = new Client({
     brokerURL: `${getWebSocketBaseUrl()}/ws/chat`,
-    connectHeaders: token ? { Authorization: `Bearer ${token}` } : {},
     reconnectDelay: 5000,
     heartbeatIncoming: 10000,
     heartbeatOutgoing: 10000,
   });
+  client.beforeConnect = () => {
+    const token = getAccessToken();
+    client.connectHeaders = token ? { Authorization: `Bearer ${token}` } : {};
+  };
+  return client;
 }

--- a/frontend/src/shared/lib/websocket/useStomp.test.tsx
+++ b/frontend/src/shared/lib/websocket/useStomp.test.tsx
@@ -31,7 +31,7 @@ vi.mock("./stompClient", () => ({
   createStompClient: () => client as unknown as Client,
 }));
 
-const subscription: StompSubscription = { id: "messages", unsubscribe: vi.fn() };
+const subscription: StompSubscription = { id: "errors", unsubscribe: vi.fn() };
 const dummyFrame = { headers: {}, body: "", command: "CONNECTED" } as unknown as IFrame;
 
 function makeMessage(body: string): IMessage {
@@ -78,23 +78,15 @@ describe("useStomp", () => {
     expect(client.deactivate).toHaveBeenCalledTimes(1);
   });
 
-  it("연결되면 사용자 메시지 큐를 구독하고 수신 메시지를 저장한다", async () => {
-    const { result } = await renderUseStompHelper();
+  it("onConnect 시 서버 에러 큐를 구독한다", async () => {
+    await renderUseStompHelper();
 
     act(() => {
       client.connected = true;
       client.onConnect?.(dummyFrame);
     });
 
-    expect(result.current.connectionStatus).toBe("CONNECTED");
-    expect(client.subscribe).toHaveBeenCalledWith("/user/queue/messages", expect.any(Function));
-
-    const onMessage = client.subscribe.mock.calls[0]?.[1];
-    act(() => {
-      onMessage?.(makeMessage('{"id":"m1","content":"안녕하세요"}'));
-    });
-
-    expect(result.current.lastMessage).toEqual({ id: "m1", content: "안녕하세요" });
+    expect(client.subscribe).toHaveBeenCalledWith("/user/queue/errors", expect.any(Function));
   });
 
   it("연결된 상태에서 채팅 메시지를 publish 한다", async () => {
@@ -110,7 +102,7 @@ describe("useStomp", () => {
     });
 
     expect(client.publish).toHaveBeenCalledWith({
-      destination: "/app/chat.send",
+      destination: "/app/chat.sendMessage",
       body: JSON.stringify({ sessionId: 1, content: "문의합니다" }),
     });
   });
@@ -224,27 +216,25 @@ describe("useStomp", () => {
     expect(client.publish).not.toHaveBeenCalled();
   });
 
-  it("onConnect 내부의 기본 큐(/user/queue/messages) 구독에서 잘못된 JSON 수신 시 무시한다", async () => {
-    const { result } = await renderUseStompHelper();
+  it("onConnect 내부의 에러 큐(/user/queue/errors) 구독에서 잘못된 JSON 수신 시 무시한다", async () => {
+    await renderUseStompHelper();
 
     act(() => {
       client.connected = true;
       client.onConnect?.(dummyFrame);
     });
 
-    const defaultQueueOnMessage = client.subscribe.mock.calls.find(
-      (call) => call[0] === "/user/queue/messages"
+    const errorQueueOnMessage = client.subscribe.mock.calls.find(
+      (call) => call[0] === "/user/queue/errors"
     )?.[1];
 
-    expect(defaultQueueOnMessage).toBeDefined();
+    expect(errorQueueOnMessage).toBeDefined();
 
     expect(() => {
       act(() => {
-        defaultQueueOnMessage?.(makeMessage("invalid-json"));
+        errorQueueOnMessage?.(makeMessage("invalid-json"));
       });
     }).not.toThrow();
-
-    expect(result.current.lastMessage).toBeNull();
   });
 
   it("onDisconnect가 호출되면 DISCONNECTED 상태로 전환한다", async () => {

--- a/frontend/src/shared/lib/websocket/useStomp.ts
+++ b/frontend/src/shared/lib/websocket/useStomp.ts
@@ -1,44 +1,39 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { Client, IMessage, StompSubscription } from "@stomp/stompjs";
+import type { Client, StompSubscription } from "@stomp/stompjs";
 import { createStompClient } from "./stompClient";
 
 export type ConnectionStatus = "CONNECTING" | "CONNECTED" | "DISCONNECTED" | "ERROR";
 
-const MESSAGE_QUEUE = "/user/queue/messages";
-const SEND_DESTINATION = "/app/chat.send";
+const SEND_DESTINATION = "/app/chat.sendMessage";
+const ERROR_QUEUE = "/user/queue/errors";
 
-export interface UseStompResult<TLastMessage = unknown> {
+export interface UseStompResult {
   connectionStatus: ConnectionStatus;
   sendMessage: (message: unknown) => void;
-  lastMessage: TLastMessage | null;
   connect: () => void;
   disconnect: () => void;
-  subscribe: (topic: string, cb: (msg: TLastMessage) => void) => () => void;
+  subscribe: (topic: string, cb: (msg: unknown) => void) => () => void;
   sendTo: (destination: string, body: unknown) => void;
 }
 
-function parseMessage<TLastMessage>(message: IMessage): TLastMessage {
-  return JSON.parse(message.body) as TLastMessage;
-}
-
-export function useStomp<TLastMessage = unknown>(): UseStompResult<TLastMessage> {
+export function useStomp(): UseStompResult {
   const clientRef = useRef<Client | null>(null);
-  const subscriptionRef = useRef<StompSubscription | null>(null);
+  const errorSubscriptionRef = useRef<StompSubscription | null>(null);
   const customSubscriptionsRef = useRef<Map<string, StompSubscription>>(new Map());
   const connectionStatusRef = useRef<ConnectionStatus>("DISCONNECTED");
   const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>("DISCONNECTED");
-  const [lastMessage, setLastMessage] = useState<TLastMessage | null>(null);
 
   useEffect(() => {
     connectionStatusRef.current = connectionStatus;
   }, [connectionStatus]);
 
   const disconnect = useCallback(() => {
-    subscriptionRef.current?.unsubscribe();
-    subscriptionRef.current = null;
+    errorSubscriptionRef.current?.unsubscribe();
+    errorSubscriptionRef.current = null;
     customSubscriptionsRef.current.forEach((sub) => sub.unsubscribe());
     customSubscriptionsRef.current.clear();
     clientRef.current?.deactivate();
+    clientRef.current = null;
     connectionStatusRef.current = "DISCONNECTED";
     setConnectionStatus("DISCONNECTED");
   }, []);
@@ -58,13 +53,15 @@ export function useStomp<TLastMessage = unknown>(): UseStompResult<TLastMessage>
     setConnectionStatus("CONNECTING");
 
     client.onConnect = () => {
+      if (clientRef.current !== client) return;
       connectionStatusRef.current = "CONNECTED";
       setConnectionStatus("CONNECTED");
-      subscriptionRef.current = client.subscribe(MESSAGE_QUEUE, (message) => {
+      errorSubscriptionRef.current = client.subscribe(ERROR_QUEUE, (message) => {
         try {
-          setLastMessage(parseMessage<TLastMessage>(message));
+          const error = JSON.parse(message.body) as unknown;
+          console.error("WebSocket server error:", error);
         } catch {
-          // Skip malformed messages
+          // ignore malformed error frames
         }
       });
     };
@@ -98,7 +95,7 @@ export function useStomp<TLastMessage = unknown>(): UseStompResult<TLastMessage>
   }, []);
 
   const subscribe = useCallback(
-    (topic: string, cb: (msg: TLastMessage) => void): (() => void) => {
+    (topic: string, cb: (msg: unknown) => void): (() => void) => {
       const client = clientRef.current;
       if (!client?.connected) {
         return () => {};
@@ -106,7 +103,7 @@ export function useStomp<TLastMessage = unknown>(): UseStompResult<TLastMessage>
 
       const subscription = client.subscribe(topic, (message) => {
         try {
-          cb(parseMessage<TLastMessage>(message));
+          cb(JSON.parse(message.body) as unknown);
         } catch {
           // Skip malformed messages
         }
@@ -151,5 +148,5 @@ export function useStomp<TLastMessage = unknown>(): UseStompResult<TLastMessage>
     };
   }, [connect, disconnect]);
 
-  return { connectionStatus, sendMessage, lastMessage, connect, disconnect, subscribe, sendTo };
+  return { connectionStatus, sendMessage, connect, disconnect, subscribe, sendTo };
 }

--- a/frontend/src/shared/lib/websocket/useStomp.ts
+++ b/frontend/src/shared/lib/websocket/useStomp.ts
@@ -67,16 +67,19 @@ export function useStomp(): UseStompResult {
     };
 
     client.onDisconnect = () => {
+      if (clientRef.current !== client) return;
       connectionStatusRef.current = "DISCONNECTED";
       setConnectionStatus("DISCONNECTED");
     };
 
     client.onStompError = () => {
+      if (clientRef.current !== client) return;
       connectionStatusRef.current = "ERROR";
       setConnectionStatus("ERROR");
     };
 
     client.onWebSocketError = () => {
+      if (clientRef.current !== client) return;
       connectionStatusRef.current = "ERROR";
       setConnectionStatus("ERROR");
     };


### PR DESCRIPTION
## Summary

- **STOMP destination 불일치**: `/app/chat.send` → `/app/chat.sendMessage`, `/topic/chat.counselor.*` → `/topic/chat.*` (실시간 채팅이 전혀 동작하지 않던 핵심 버그)
- **useStomp 재설계**: `lastMessage` 단일 상태 제거 → `subscribe(topic, cb)` API 추가, zombie WebSocket 방지 guard, 에러 큐(`/user/queue/errors`) 내부 구독
- **stompClient**: 토큰을 생성 시점이 아닌 `beforeConnect` 콜백에서 읽어 재연결 시 갱신
- **ChatRoom**: `subscribe()` 기반 메시지 수신, 중복 메시지 id guard
- **ConsultationPage**: content 기반 낙관적 업데이트 매칭, 중복 수신 방지, temp ID 고유화(`Date.now() + counter`)
- **MessageList**: scroll `useEffect` deps `[messages.length]` → `[messages]`
- **ChatWebSocketService**: IDOR 방지 세션 소유자 검증, `afterCommit` try-finally로 이벤트 발행 보장
- **ChatSession**: `reopen()` / `closeSession()` 시 `assignedCounselorId`·`endedAt` 초기화
- **SessionAssignedEventListener**: `@EventListener` → `@TransactionalEventListener(AFTER_COMMIT)`
- **LlmResponseHandler**: 최근 5개 메시지 대화 컨텍스트를 LLM에 전달
- **JwtChannelInterceptor**: SUBSCRIBE/SEND 명령 인증 검증 및 destination whitelist 적용
- **CounselorService**: `isNote` 플래그로 `NOTE` / `COUNSELOR` role 분기
- **ConsultationService**: 대기열 OPEN+ACTIVE 세션 `startedAt DESC` 정렬

## Test plan

- [ ] 프론트엔드 테스트 1107개 전체 통과 확인 (`pnpm test --run`)
- [ ] 백엔드 컴파일 오류 없음 확인 (`./gradlew compileJava compileTestJava`)
- [ ] 사용자 채팅 — WebSocket 연결 후 메시지 송수신 동작 확인
- [ ] 상담사 채팅 — 실시간 메시지 수신 및 낙관적 업데이트 확인
- [ ] 재연결 시 토큰 갱신 확인 (토큰 만료 후 재연결 시나리오)
- [ ] IDOR 방지 — 다른 세션 ID로 메시지 전송 시 거부 확인
- [ ] LLM 응답에 대화 컨텍스트가 포함되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 상담사 메시지에 "노트" 옵션 추가
  * 세션 응답에 상담사 배정 ID와 종료 시간 노출

* **버그 수정**
  * 세션 시작자 권한 검증 강화(무단 전송 차단)
  * 웹소켓 인증·구독 검증 강화(허용되지 않은 목적지/인증 누락 차단)
  * 메시지 전송 실패 시 이벤트 발행 보장
  * WebSocket 요청자(Principal) 유효성 검사 추가

* **개선 사항**
  * 실시간 구독/중복 필터링·임시 ID 매칭 개선 및 구독 토픽 정리
  * STOMP 연결 시 토큰을 연결 직전에 동적 설정
  * LLM 응답에 최근 대화 문맥 반영
  * 상담 대기열에 ACTIVE 상태 포함
  * 메시지 리스트 스크롤 동작 개선

* **테스트**
  * 관련 유닛/통합 테스트 보강 및 신규 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ajou-2026-1-capstone-5/ostone/pull/285?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->