### PR TITLE
[chore] fix deployed websocket URL

### DIFF
--- a/.agent/docs/deployment.md
+++ b/.agent/docs/deployment.md
@@ -115,9 +115,10 @@ Blueprint 대신 대시보드에서 수동 생성:
 
 #### Frontend 환경변수 (Render Dashboard → Frontend → Environment)
 
-| 변수                | 값                                           | 설명                 |
-| ------------------- | -------------------------------------------- | -------------------- |
-| `VITE_API_BASE_URL` | `https://ostone-backend.onrender.com/api/v1` | Backend API 전체 URL |
+| 변수                | 값                                           | 설명                                      |
+| ------------------- | -------------------------------------------- | ----------------------------------------- |
+| `VITE_API_BASE_URL` | `https://ostone-backend.onrender.com/api/v1` | Backend API 전체 URL                      |
+| `VITE_WS_URL`       | `wss://ostone-backend.onrender.com`          | STOMP WebSocket origin (`/ws/chat` 제외) |
 
 ## 5. GitHub-Render 연결 확인
 

--- a/.env.example
+++ b/.env.example
@@ -79,3 +79,4 @@ SPRING_DATASOURCE_URL=jdbc:postgresql://<neon-host>:5432/<dbname>?sslmode=requir
 SPRING_DATASOURCE_USERNAME=<neon-username>
 SPRING_PROFILES_ACTIVE=dev
 VITE_API_BASE_URL=https://<render-backend-url>/api/v1
+VITE_WS_URL=wss://<render-backend-url>

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,7 +3,9 @@ FROM node:22-alpine AS builder
 WORKDIR /app
 
 ARG VITE_API_BASE_URL=/api/v1
+ARG VITE_WS_URL=
 ENV VITE_API_BASE_URL=${VITE_API_BASE_URL}
+ENV VITE_WS_URL=${VITE_WS_URL}
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN corepack enable && pnpm install --frozen-lockfile

--- a/frontend/src/shared/lib/websocket/stompClient.test.ts
+++ b/frontend/src/shared/lib/websocket/stompClient.test.ts
@@ -60,4 +60,16 @@ describe("createStompClient", () => {
       }),
     );
   });
+
+  it("VITE_WS_URL이 없으면 VITE_API_BASE_URL에서 WebSocket base URL을 유추한다", () => {
+    vi.stubEnv("VITE_API_BASE_URL", "https://backend.example.com/api/v1");
+
+    createStompClient();
+
+    expect(MockedClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        brokerURL: "wss://backend.example.com/ws/chat",
+      }),
+    );
+  });
 });

--- a/frontend/src/shared/lib/websocket/stompClient.ts
+++ b/frontend/src/shared/lib/websocket/stompClient.ts
@@ -2,6 +2,7 @@ import { Client } from "@stomp/stompjs";
 import { getAccessToken } from "@/shared/lib/auth";
 
 const DEFAULT_WS_URL = "ws://localhost:8080";
+const API_BASE_SUFFIX = "/api/v1";
 
 function normalizeWsUrl(url: string): string {
   return url
@@ -11,8 +12,19 @@ function normalizeWsUrl(url: string): string {
 }
 
 function getWebSocketBaseUrl(): string {
-  const raw = import.meta.env.VITE_WS_URL ?? DEFAULT_WS_URL;
+  const raw = import.meta.env.VITE_WS_URL ?? resolveWsUrlFromApiBase() ?? DEFAULT_WS_URL;
   return normalizeWsUrl(raw);
+}
+
+function resolveWsUrlFromApiBase(): string | undefined {
+  const apiBaseUrl = import.meta.env.VITE_API_BASE_URL;
+  if (!apiBaseUrl || apiBaseUrl.startsWith("/")) {
+    return undefined;
+  }
+
+  return apiBaseUrl.endsWith(API_BASE_SUFFIX)
+    ? apiBaseUrl.slice(0, -API_BASE_SUFFIX.length)
+    : apiBaseUrl;
 }
 
 export function createStompClient(): Client {


### PR DESCRIPTION
## Summary
- derive the STOMP WebSocket origin from `VITE_API_BASE_URL` when `VITE_WS_URL` is not set
- expose `VITE_WS_URL` in the frontend Docker build and document the Render setting
- add a regression test for production API URL fallback

## Root Cause
The production frontend bundle only received `VITE_API_BASE_URL`. The WebSocket client had a localhost fallback, so deployed browsers tried to connect to `ws://localhost:8080/ws/chat` instead of the Render backend.

## Validation
- `pnpm test src/shared/lib/websocket/stompClient.test.ts`
- pre-commit: `cd frontend && pnpm run lint`
- pre-commit: `cd frontend && pnpm run format`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * 배포 문서와 환경 변수 예제에 WebSocket URL 설정 항목을 추가했습니다.

* **Chores**
  * Docker 빌드 설정에 WebSocket URL 환경 변수 지원을 추가했습니다.

* **Tests**
  * WebSocket 연결 설정의 폴백 동작에 대한 테스트를 추가했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ajou-2026-1-capstone-5/ostone/pull/290?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->