### PR TITLE
[chore] fix STOMP websocket session authentication

### DIFF
--- a/backend/src/main/java/com/init/workflowruntime/config/WebSocketSecurityConfig.java
+++ b/backend/src/main/java/com/init/workflowruntime/config/WebSocketSecurityConfig.java
@@ -1,13 +1,11 @@
 package com.init.workflowruntime.config;
 
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.annotation.web.socket.EnableWebSocketSecurity;
 
 /**
- * STOMP WebSocket 보안 설정입니다. {@code @EnableWebSocketSecurity}는 Spring Security의 WebSocket 메시지 인증/인가를
- * 활성화합니다. 구체적인 인증 로직은 {@link com.init.workflowruntime.interceptor.JwtChannelInterceptor}에서 CONNECT
- * 프레임 수준에서 처리합니다.
+ * STOMP WebSocket 보안 설정입니다. 인증/인가 로직은 {@link
+ * com.init.workflowruntime.interceptor.JwtChannelInterceptor}에서 CONNECT, SEND, SUBSCRIBE 프레임 수준으로
+ * 처리합니다.
  */
 @Configuration
-@EnableWebSocketSecurity
 public class WebSocketSecurityConfig {}

--- a/backend/src/main/java/com/init/workflowruntime/interceptor/JwtChannelInterceptor.java
+++ b/backend/src/main/java/com/init/workflowruntime/interceptor/JwtChannelInterceptor.java
@@ -34,6 +34,7 @@ public class JwtChannelInterceptor implements ChannelInterceptor {
   @Override
   public Message<?> preSend(Message<?> message, MessageChannel channel) {
     StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+    boolean headersChanged = false;
 
     if (StompCommand.CONNECT.equals(accessor.getCommand())) {
       String authHeader = accessor.getFirstNativeHeader("Authorization");
@@ -65,6 +66,7 @@ public class JwtChannelInterceptor implements ChannelInterceptor {
       return MessageBuilder.createMessage(message.getPayload(), accessor.getMessageHeaders());
     } else if (StompCommand.SUBSCRIBE.equals(accessor.getCommand())
         || StompCommand.SEND.equals(accessor.getCommand())) {
+      headersChanged = restorePrincipalFromSession(accessor);
       if (accessor.getUser() == null) {
         throw new MissingAuthHeaderException(
             "Authentication required for " + accessor.getCommand());
@@ -76,7 +78,26 @@ public class JwtChannelInterceptor implements ChannelInterceptor {
         }
       }
     }
+    if (headersChanged) {
+      return MessageBuilder.createMessage(message.getPayload(), accessor.getMessageHeaders());
+    }
     return message;
+  }
+
+  private boolean restorePrincipalFromSession(StompHeaderAccessor accessor) {
+    if (accessor.getUser() != null) {
+      return false;
+    }
+    Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
+    if (sessionAttributes == null) {
+      return false;
+    }
+    Object userId = sessionAttributes.get("userId");
+    if (userId == null) {
+      return false;
+    }
+    accessor.setUser(() -> String.valueOf(userId));
+    return true;
   }
 
   private void validateSubscribeDestination(String destination, StompHeaderAccessor accessor) {

--- a/backend/src/test/java/com/init/workflowruntime/interceptor/JwtChannelInterceptorTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/interceptor/JwtChannelInterceptorTest.java
@@ -187,6 +187,22 @@ class JwtChannelInterceptorTest {
   }
 
   @Test
+  @DisplayName("SUBSCRIBE restores Principal from session userId")
+  void should_restorePrincipalFromSession_when_subscribeWithoutUser() {
+    StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.SUBSCRIBE);
+    accessor.setSessionAttributes(new HashMap<>(Map.of("userId", 42L, "role", "OPERATOR")));
+    accessor.setDestination("/topic/chat.1");
+    Message<byte[]> message =
+        MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+
+    Message<?> result = interceptor.preSend(message, channel);
+
+    StompHeaderAccessor resultAccessor = StompHeaderAccessor.wrap(result);
+    assertThat(resultAccessor.getUser()).isNotNull();
+    assertThat(resultAccessor.getUser().getName()).isEqualTo("42");
+  }
+
+  @Test
   @DisplayName("SUBSCRIBE with USER auth, owned chat topic → passes through")
   void should_passThrough_when_userSubscribesOwnedChatTopic() {
     StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.SUBSCRIBE);
@@ -255,6 +271,21 @@ class JwtChannelInterceptorTest {
     Message<?> result = interceptor.preSend(message, channel);
 
     assertThat(result).isSameAs(message);
+  }
+
+  @Test
+  @DisplayName("SEND restores Principal from session userId")
+  void should_restorePrincipalFromSession_when_sendWithoutUser() {
+    StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.SEND);
+    accessor.setSessionAttributes(new HashMap<>(Map.of("userId", 42L)));
+    Message<byte[]> message =
+        MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+
+    Message<?> result = interceptor.preSend(message, channel);
+
+    StompHeaderAccessor resultAccessor = StompHeaderAccessor.wrap(result);
+    assertThat(resultAccessor.getUser()).isNotNull();
+    assertThat(resultAccessor.getUser().getName()).isEqualTo("42");
   }
 
   @Test

--- a/backend/src/test/java/com/init/workflowruntime/presentation/ChatWebSocketIntegrationTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/presentation/ChatWebSocketIntegrationTest.java
@@ -1,0 +1,110 @@
+package com.init.workflowruntime.presentation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.init.auth.application.JwtService;
+import java.lang.reflect.Type;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.messaging.converter.MappingJackson2MessageConverter;
+import org.springframework.messaging.simp.stomp.StompFrameHandler;
+import org.springframework.messaging.simp.stomp.StompHeaders;
+import org.springframework.messaging.simp.stomp.StompSession;
+import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.socket.WebSocketHttpHeaders;
+import org.springframework.web.socket.client.standard.StandardWebSocketClient;
+import org.springframework.web.socket.messaging.WebSocketStompClient;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@DisplayName("Chat WebSocket integration")
+class ChatWebSocketIntegrationTest {
+
+  @LocalServerPort private int port;
+
+  @Autowired private JwtService jwtService;
+
+  @Test
+  @DisplayName("valid access token으로 STOMP 연결이 수립된다")
+  void shouldConnectWithValidAccessToken() throws Exception {
+    WebSocketStompClient stompClient = new WebSocketStompClient(new StandardWebSocketClient());
+    stompClient.setMessageConverter(new MappingJackson2MessageConverter());
+
+    StompHeaders connectHeaders = new StompHeaders();
+    connectHeaders.add(
+        "Authorization",
+        "Bearer " + jwtService.generateAccessToken(1L, "operator@example.com", "OPERATOR"));
+
+    CompletableFuture<Throwable> transportError = new CompletableFuture<>();
+    StompSession session =
+        stompClient
+            .connectAsync(
+                "ws://localhost:" + port + "/ws/chat",
+                new WebSocketHttpHeaders(),
+                connectHeaders,
+                new StompSessionHandlerAdapter() {
+                  @Override
+                  public void handleTransportError(StompSession session, Throwable exception) {
+                    transportError.complete(exception);
+                  }
+                })
+            .get(5, TimeUnit.SECONDS);
+
+    try {
+      assertThat(session.isConnected()).isTrue();
+      assertThat(transportError).isNotCompleted();
+    } finally {
+      session.disconnect();
+      stompClient.stop();
+    }
+  }
+
+  @Test
+  @DisplayName("연결 후 사용자 queue 구독이 가능하다")
+  void shouldSubscribeUserErrorQueueAfterConnect() throws Exception {
+    WebSocketStompClient stompClient = new WebSocketStompClient(new StandardWebSocketClient());
+    stompClient.setMessageConverter(new MappingJackson2MessageConverter());
+
+    StompHeaders connectHeaders = new StompHeaders();
+    connectHeaders.add(
+        "Authorization",
+        "Bearer " + jwtService.generateAccessToken(1L, "operator@example.com", "OPERATOR"));
+
+    StompSession session =
+        stompClient
+            .connectAsync(
+                "ws://localhost:" + port + "/ws/chat",
+                new WebSocketHttpHeaders(),
+                connectHeaders,
+                new StompSessionHandlerAdapter() {})
+            .get(5, TimeUnit.SECONDS);
+
+    try {
+      session.subscribe(
+          "/user/queue/errors",
+          new StompFrameHandler() {
+            @Override
+            public Type getPayloadType(StompHeaders headers) {
+              return byte[].class;
+            }
+
+            @Override
+            public void handleFrame(StompHeaders headers, Object payload) {}
+          });
+
+      Thread.sleep(250);
+      assertThat(session.isConnected()).isTrue();
+    } finally {
+      if (session.isConnected()) {
+        session.disconnect();
+      }
+      stompClient.stop();
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- remove duplicate Spring Security WebSocket message interception so valid STOMP `CONNECT` frames are not closed by `AuthorizationChannelInterceptor`
- restore the authenticated Principal from STOMP session attributes on later `SUBSCRIBE` and `SEND` frames
- add a real WebSocket/STOMP integration test that connects with a valid JWT and subscribes to `/user/queue/errors`

## Root Cause
After the deployed URL and HTTP handshake fixes, the connection still failed during STOMP processing. Local integration testing reproduced `Failed to send message to ExecutorSubscribableChannel[clientInboundChannel]`; the underlying cause was Spring Security Messaging throwing `AccessDeniedException` before the custom JWT STOMP flow could complete. Once that duplicate layer was removed, later frames still needed the Principal restored from session attributes because `SUBSCRIBE`/`SEND` can arrive without `accessor.getUser()` populated.

## Validation
- `docker run --rm -v "$PWD":/workspace -v "$HOME/.gradle":/root/.gradle -w /workspace/backend gradle:9.2-jdk21 ./gradlew spotlessCheck test --tests com.init.workflowruntime.presentation.ChatWebSocketIntegrationTest --tests com.init.workflowruntime.interceptor.JwtChannelInterceptorTest --tests com.init.workflowruntime.presentation.LlmToolControllerSecurityTest --rerun-tasks`

## Notes
- Local host Java is 17, while the backend requires Java 21. The commit was made with `HUSKY=0` after running backend format/test checks in a JDK 21 Docker container.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * WebSocket 메시지 처리 시 세션 정보에서 사용자 정보를 자동으로 복원하도록 개선

* **테스트**
  * 세션 기반 사용자 정보 복원 동작 검증 테스트 추가
  * WebSocket 연결 및 구독 기능 통합 테스트 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ajou-2026-1-capstone-5/ostone/pull/292?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->