### PR TITLE
chore: Connect demo chat to LLM-backed sessions

### DIFF
--- a/.agent/specs/5.3.3.md
+++ b/.agent/specs/5.3.3.md
@@ -237,7 +237,7 @@ spring:
       api-key: ${OPENAI_API_KEY}
       chat:
         options:
-          model: ${OPENAI_CHAT_MODEL:gpt-4o-mini}
+          model: ${OPENAI_CHAT_MODEL:gpt-5.4-mini}
           temperature: ${OPENAI_CHAT_TEMPERATURE:0.2}
           max-tokens: ${OPENAI_CHAT_MAX_TOKENS:800}
 

--- a/backend/src/main/java/com/init/chatdemo/application/DemoChatSessionRegistrationService.java
+++ b/backend/src/main/java/com/init/chatdemo/application/DemoChatSessionRegistrationService.java
@@ -14,8 +14,6 @@ import com.init.workflowruntime.domain.ChatMessageRepository;
 import com.init.workflowruntime.domain.ChatSession;
 import com.init.workflowruntime.domain.ChatSessionRepository;
 import com.init.workflowruntime.domain.ChatSessionStatus;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -136,9 +134,8 @@ public class DemoChatSessionRegistrationService {
 
   private String createConversationContext(Long sessionId) {
     List<ChatMessage> recentDesc =
-        new ArrayList<>(chatMessageRepository.findTop5ByChatSessionIdOrderBySeqNoDesc(sessionId));
-    Collections.reverse(recentDesc);
-    return recentDesc.stream()
+        chatMessageRepository.findTop5ByChatSessionIdOrderBySeqNoDesc(sessionId);
+    return recentDesc.reversed().stream()
         .map(message -> message.getSenderRole() + ": " + message.getContent())
         .collect(Collectors.joining("\n"));
   }

--- a/backend/src/main/java/com/init/chatdemo/application/DemoChatSessionRegistrationService.java
+++ b/backend/src/main/java/com/init/chatdemo/application/DemoChatSessionRegistrationService.java
@@ -79,7 +79,7 @@ public class DemoChatSessionRegistrationService {
     String normalizedContent = normalizeMessageContent(content);
     ChatSession session =
         chatSessionRepository
-            .findById(sessionId)
+            .findByIdForUpdate(sessionId)
             .orElseThrow(
                 () ->
                     new NotFoundException("SESSION_NOT_FOUND", "Session not found: " + sessionId));

--- a/backend/src/main/java/com/init/chatdemo/application/DemoChatSessionRegistrationService.java
+++ b/backend/src/main/java/com/init/chatdemo/application/DemoChatSessionRegistrationService.java
@@ -1,0 +1,145 @@
+package com.init.chatdemo.application;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.init.domainpack.domain.model.DomainPackVersion;
+import com.init.domainpack.domain.repository.DomainPackVersionRepository;
+import com.init.shared.application.exception.BadRequestException;
+import com.init.shared.application.exception.NotFoundException;
+import com.init.workflowruntime.application.LlmAssistantService;
+import com.init.workflowruntime.application.dto.ChatMessageResponse;
+import com.init.workflowruntime.application.dto.ChatSessionResponse;
+import com.init.workflowruntime.domain.ChatMessage;
+import com.init.workflowruntime.domain.ChatMessageRepository;
+import com.init.workflowruntime.domain.ChatSession;
+import com.init.workflowruntime.domain.ChatSessionRepository;
+import com.init.workflowruntime.domain.ChatSessionStatus;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class DemoChatSessionRegistrationService {
+
+  private static final String DEFAULT_CHANNEL = "WEB";
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+  private final DomainPackVersionRepository domainPackVersionRepository;
+  private final ChatSessionRepository chatSessionRepository;
+  private final ChatMessageRepository chatMessageRepository;
+  private final LlmAssistantService llmAssistantService;
+
+  public DemoChatSessionRegistrationService(
+      DomainPackVersionRepository domainPackVersionRepository,
+      ChatSessionRepository chatSessionRepository,
+      ChatMessageRepository chatMessageRepository,
+      LlmAssistantService llmAssistantService) {
+    this.domainPackVersionRepository = domainPackVersionRepository;
+    this.chatSessionRepository = chatSessionRepository;
+    this.chatMessageRepository = chatMessageRepository;
+    this.llmAssistantService = llmAssistantService;
+  }
+
+  @Transactional
+  public ChatSessionResponse createSession(Long workspaceId, String customerName) {
+    String normalizedName = normalizeCustomerName(customerName);
+    DomainPackVersion version =
+        domainPackVersionRepository
+            .findCurrentPublishedByWorkspaceId(workspaceId)
+            .orElseThrow(
+                () ->
+                    new NotFoundException(
+                        "DOMAIN_PACK_CURRENT_VERSION_NOT_FOUND",
+                        "현재 운영 중인 PUBLISHED version을 찾을 수 없습니다. workspaceId=" + workspaceId));
+
+    ChatSession session =
+        chatSessionRepository.save(
+            ChatSession.create(
+                workspaceId,
+                version.getId(),
+                ChatSessionStatus.OPEN,
+                DEFAULT_CHANNEL,
+                createMetaJson(normalizedName),
+                null));
+
+    chatMessageRepository.save(
+        ChatMessage.create(
+            session.getId(), 1, "ASSISTANT", "TEXT", createGreeting(normalizedName)));
+
+    return ChatSessionResponse.from(session);
+  }
+
+  @Transactional
+  public List<ChatMessageResponse> appendMessage(Long workspaceId, Long sessionId, String content) {
+    String normalizedContent = normalizeMessageContent(content);
+    ChatSession session =
+        chatSessionRepository
+            .findById(sessionId)
+            .orElseThrow(
+                () ->
+                    new NotFoundException("SESSION_NOT_FOUND", "Session not found: " + sessionId));
+    if (!workspaceId.equals(session.getWorkspaceId())) {
+      throw new NotFoundException("SESSION_NOT_FOUND", "Session not found: " + sessionId);
+    }
+
+    int nextSeqNo =
+        chatMessageRepository
+            .findTopByChatSessionIdOrderBySeqNoDesc(sessionId)
+            .map(message -> message.getSeqNo() + 1)
+            .orElse(1);
+    ChatMessage userMessage =
+        chatMessageRepository.save(
+            ChatMessage.create(sessionId, nextSeqNo, "USER", "TEXT", normalizedContent));
+
+    String assistantContent =
+        llmAssistantService.generateResponse(
+            createConversationContext(sessionId), normalizedContent);
+    ChatMessage assistantMessage =
+        chatMessageRepository.save(
+            ChatMessage.create(sessionId, nextSeqNo + 1, "ASSISTANT", "TEXT", assistantContent));
+
+    return List.of(
+        ChatMessageResponse.from(userMessage), ChatMessageResponse.from(assistantMessage));
+  }
+
+  private String normalizeCustomerName(String customerName) {
+    if (customerName == null || customerName.isBlank()) {
+      throw new BadRequestException("VALIDATION_ERROR", "customerName must not be blank");
+    }
+    return customerName.trim();
+  }
+
+  private String normalizeMessageContent(String content) {
+    if (content == null || content.isBlank()) {
+      throw new BadRequestException("VALIDATION_ERROR", "content must not be blank");
+    }
+    return content.trim();
+  }
+
+  private String createMetaJson(String customerName) {
+    try {
+      return objectMapper.writeValueAsString(
+          Map.of("customerName", customerName, "handoffReason", "데모 채팅", "demo", true));
+    } catch (JsonProcessingException e) {
+      throw new BadRequestException("VALIDATION_ERROR", "customerName is invalid", e);
+    }
+  }
+
+  private String createGreeting(String customerName) {
+    return "안녕하세요, " + customerName + "님. 무엇을 도와드릴까요?";
+  }
+
+  private String createConversationContext(Long sessionId) {
+    List<ChatMessage> recentDesc =
+        new ArrayList<>(chatMessageRepository.findTop5ByChatSessionIdOrderBySeqNoDesc(sessionId));
+    Collections.reverse(recentDesc);
+    return recentDesc.stream()
+        .map(message -> message.getSenderRole() + ": " + message.getContent())
+        .collect(Collectors.joining("\n"));
+  }
+}

--- a/backend/src/main/java/com/init/chatdemo/presentation/DemoRuntimeController.java
+++ b/backend/src/main/java/com/init/chatdemo/presentation/DemoRuntimeController.java
@@ -11,6 +11,7 @@ import com.init.chatdemo.presentation.dto.DemoExecutionResponse;
 import com.init.chatdemo.presentation.dto.SendDemoChatMessageRequest;
 import com.init.workflowruntime.application.dto.ChatMessageResponse;
 import com.init.workflowruntime.application.dto.ChatSessionResponse;
+import jakarta.validation.Valid;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -54,7 +55,7 @@ public class DemoRuntimeController {
 
   @PostMapping("/chat-sessions")
   public ResponseEntity<ChatSessionResponse> createChatSession(
-      @PathVariable Long workspaceId, @RequestBody CreateDemoChatSessionRequest request) {
+      @PathVariable Long workspaceId, @Valid @RequestBody CreateDemoChatSessionRequest request) {
     return ResponseEntity.ok(
         sessionRegistrationService.createSession(workspaceId, request.customerName()));
   }
@@ -63,7 +64,7 @@ public class DemoRuntimeController {
   public ResponseEntity<List<ChatMessageResponse>> appendChatMessage(
       @PathVariable Long workspaceId,
       @PathVariable Long sessionId,
-      @RequestBody SendDemoChatMessageRequest request) {
+      @Valid @RequestBody SendDemoChatMessageRequest request) {
     return ResponseEntity.ok(
         sessionRegistrationService.appendMessage(workspaceId, sessionId, request.content()));
   }

--- a/backend/src/main/java/com/init/chatdemo/presentation/DemoRuntimeController.java
+++ b/backend/src/main/java/com/init/chatdemo/presentation/DemoRuntimeController.java
@@ -1,14 +1,22 @@
 package com.init.chatdemo.presentation;
 
+import com.init.chatdemo.application.DemoChatSessionRegistrationService;
 import com.init.chatdemo.application.DemoRuntimeMockService;
+import com.init.chatdemo.presentation.dto.CreateDemoChatSessionRequest;
 import com.init.chatdemo.presentation.dto.DemoChatSessionEndpointResponse;
 import com.init.chatdemo.presentation.dto.DemoChatWorkflowResponse;
 import com.init.chatdemo.presentation.dto.DemoDecisionLogEndpointResponse;
 import com.init.chatdemo.presentation.dto.DemoDomainPackEndpointResponse;
 import com.init.chatdemo.presentation.dto.DemoExecutionResponse;
+import com.init.chatdemo.presentation.dto.SendDemoChatMessageRequest;
+import com.init.workflowruntime.application.dto.ChatMessageResponse;
+import com.init.workflowruntime.application.dto.ChatSessionResponse;
+import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -18,9 +26,13 @@ import org.springframework.web.bind.annotation.RestController;
 public class DemoRuntimeController {
 
   private final DemoRuntimeMockService service;
+  private final DemoChatSessionRegistrationService sessionRegistrationService;
 
-  public DemoRuntimeController(DemoRuntimeMockService service) {
+  public DemoRuntimeController(
+      DemoRuntimeMockService service,
+      DemoChatSessionRegistrationService sessionRegistrationService) {
     this.service = service;
+    this.sessionRegistrationService = sessionRegistrationService;
   }
 
   @GetMapping("/chat-workflow")
@@ -38,6 +50,22 @@ public class DemoRuntimeController {
   public ResponseEntity<DemoChatSessionEndpointResponse> getChatSession(
       @PathVariable Long workspaceId, @PathVariable String sessionId) {
     return ResponseEntity.ok(service.getChatSession(workspaceId, sessionId));
+  }
+
+  @PostMapping("/chat-sessions")
+  public ResponseEntity<ChatSessionResponse> createChatSession(
+      @PathVariable Long workspaceId, @RequestBody CreateDemoChatSessionRequest request) {
+    return ResponseEntity.ok(
+        sessionRegistrationService.createSession(workspaceId, request.customerName()));
+  }
+
+  @PostMapping("/chat-sessions/{sessionId}/messages")
+  public ResponseEntity<List<ChatMessageResponse>> appendChatMessage(
+      @PathVariable Long workspaceId,
+      @PathVariable Long sessionId,
+      @RequestBody SendDemoChatMessageRequest request) {
+    return ResponseEntity.ok(
+        sessionRegistrationService.appendMessage(workspaceId, sessionId, request.content()));
   }
 
   @GetMapping("/workflow-executions/{executionId}")

--- a/backend/src/main/java/com/init/chatdemo/presentation/dto/CreateDemoChatSessionRequest.java
+++ b/backend/src/main/java/com/init/chatdemo/presentation/dto/CreateDemoChatSessionRequest.java
@@ -1,3 +1,5 @@
 package com.init.chatdemo.presentation.dto;
 
-public record CreateDemoChatSessionRequest(String customerName) {}
+import jakarta.validation.constraints.NotBlank;
+
+public record CreateDemoChatSessionRequest(@NotBlank String customerName) {}

--- a/backend/src/main/java/com/init/chatdemo/presentation/dto/CreateDemoChatSessionRequest.java
+++ b/backend/src/main/java/com/init/chatdemo/presentation/dto/CreateDemoChatSessionRequest.java
@@ -1,0 +1,3 @@
+package com.init.chatdemo.presentation.dto;
+
+public record CreateDemoChatSessionRequest(String customerName) {}

--- a/backend/src/main/java/com/init/chatdemo/presentation/dto/SendDemoChatMessageRequest.java
+++ b/backend/src/main/java/com/init/chatdemo/presentation/dto/SendDemoChatMessageRequest.java
@@ -1,0 +1,3 @@
+package com.init.chatdemo.presentation.dto;
+
+public record SendDemoChatMessageRequest(String content) {}

--- a/backend/src/main/java/com/init/chatdemo/presentation/dto/SendDemoChatMessageRequest.java
+++ b/backend/src/main/java/com/init/chatdemo/presentation/dto/SendDemoChatMessageRequest.java
@@ -1,3 +1,5 @@
 package com.init.chatdemo.presentation.dto;
 
-public record SendDemoChatMessageRequest(String content) {}
+import jakarta.validation.constraints.NotBlank;
+
+public record SendDemoChatMessageRequest(@NotBlank String content) {}

--- a/backend/src/main/java/com/init/shared/infrastructure/security/SecurityConfig.java
+++ b/backend/src/main/java/com/init/shared/infrastructure/security/SecurityConfig.java
@@ -51,6 +51,8 @@ public class SecurityConfig {
                     .permitAll()
                     .requestMatchers("/ws/**")
                     .permitAll()
+                    .requestMatchers("/api/v1/workspaces/*/demo/**")
+                    .permitAll()
                     .requestMatchers(
                         HttpMethod.POST, "/api/v1/pipeline-jobs/*/callbacks/domain-pack-drafts")
                     .permitAll()

--- a/backend/src/main/java/com/init/workflowruntime/application/UserChatSessionService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/UserChatSessionService.java
@@ -1,7 +1,9 @@
 package com.init.workflowruntime.application;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.init.domainpack.domain.model.DomainPackVersion;
 import com.init.domainpack.domain.repository.DomainPackVersionRepository;
 import com.init.shared.application.exception.BadRequestException;
@@ -89,7 +91,7 @@ public class UserChatSessionService {
   }
 
   private ChatSession updateCustomerName(ChatSession session, String customerName) {
-    String nextMetaJson = createMetaJson(customerName);
+    String nextMetaJson = mergeCustomerName(session.getMetaJson(), customerName);
     if (!nextMetaJson.equals(session.getMetaJson())) {
       session.updateMetaJson(nextMetaJson);
     }
@@ -98,10 +100,26 @@ public class UserChatSessionService {
 
   private String createMetaJson(String customerName) {
     try {
-      return objectMapper.writeValueAsString(
-          Map.of("customerName", customerName, "handoffReason", ""));
+      return objectMapper.writeValueAsString(Map.of("customerName", customerName));
     } catch (JsonProcessingException e) {
       throw new BadRequestException("VALIDATION_ERROR", "customerName is invalid", e);
+    }
+  }
+
+  private String mergeCustomerName(String currentMetaJson, String customerName) {
+    try {
+      JsonNode current =
+          currentMetaJson == null || currentMetaJson.isBlank()
+              ? objectMapper.createObjectNode()
+              : objectMapper.readTree(currentMetaJson);
+      ObjectNode next =
+          current != null && current.isObject()
+              ? ((ObjectNode) current).deepCopy()
+              : objectMapper.createObjectNode();
+      next.put("customerName", customerName);
+      return objectMapper.writeValueAsString(next);
+    } catch (JsonProcessingException e) {
+      throw new BadRequestException("VALIDATION_ERROR", "metaJson is invalid", e);
     }
   }
 }

--- a/backend/src/main/java/com/init/workflowruntime/application/UserChatSessionService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/UserChatSessionService.java
@@ -1,7 +1,10 @@
 package com.init.workflowruntime.application;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.init.domainpack.domain.model.DomainPackVersion;
 import com.init.domainpack.domain.repository.DomainPackVersionRepository;
+import com.init.shared.application.exception.BadRequestException;
 import com.init.shared.application.exception.NotFoundException;
 import com.init.workflowruntime.application.command.GetOrCreateCurrentSessionCommand;
 import com.init.workflowruntime.application.dto.ChatSessionResponse;
@@ -11,6 +14,7 @@ import com.init.workflowruntime.domain.ChatSessionStatus;
 import com.init.workspace.application.exception.WorkspaceAccessDeniedException;
 import com.init.workspace.domain.repository.WorkspaceMemberRepository;
 import java.util.List;
+import java.util.Map;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,6 +26,7 @@ public class UserChatSessionService {
   private static final List<ChatSessionStatus> REUSABLE_STATUSES =
       List.of(ChatSessionStatus.OPEN, ChatSessionStatus.ACTIVE);
 
+  private final ObjectMapper objectMapper = new ObjectMapper();
   private final ChatSessionRepository chatSessionRepository;
   private final DomainPackVersionRepository domainPackVersionRepository;
   private final WorkspaceMemberRepository workspaceMemberRepository;
@@ -46,9 +51,14 @@ public class UserChatSessionService {
     return chatSessionRepository
         .findFirstByWorkspaceIdAndStartedByAndStatusInOrderByStartedAtDescIdDesc(
             command.workspaceId(), command.userId(), REUSABLE_STATUSES)
-        .map(ChatSessionResponse::from)
+        .map(
+            session ->
+                ChatSessionResponse.from(updateCustomerName(session, command.customerName())))
         .orElseGet(
-            () -> ChatSessionResponse.from(createSession(command.workspaceId(), command.userId())));
+            () ->
+                ChatSessionResponse.from(
+                    createSession(
+                        command.workspaceId(), command.userId(), command.customerName())));
   }
 
   private void validateWorkspaceMembership(Long workspaceId, Long userId) {
@@ -57,7 +67,7 @@ public class UserChatSessionService {
         .orElseThrow(() -> new WorkspaceAccessDeniedException("워크스페이스에 접근 권한이 없습니다."));
   }
 
-  private ChatSession createSession(Long workspaceId, Long userId) {
+  private ChatSession createSession(Long workspaceId, Long userId, String customerName) {
     DomainPackVersion version =
         domainPackVersionRepository
             .findCurrentPublishedByWorkspaceId(workspaceId)
@@ -69,7 +79,29 @@ public class UserChatSessionService {
 
     ChatSession session =
         ChatSession.create(
-            workspaceId, version.getId(), ChatSessionStatus.OPEN, DEFAULT_CHANNEL, "{}", userId);
+            workspaceId,
+            version.getId(),
+            ChatSessionStatus.OPEN,
+            DEFAULT_CHANNEL,
+            createMetaJson(customerName),
+            userId);
     return chatSessionRepository.save(session);
+  }
+
+  private ChatSession updateCustomerName(ChatSession session, String customerName) {
+    String nextMetaJson = createMetaJson(customerName);
+    if (!nextMetaJson.equals(session.getMetaJson())) {
+      session.updateMetaJson(nextMetaJson);
+    }
+    return session;
+  }
+
+  private String createMetaJson(String customerName) {
+    try {
+      return objectMapper.writeValueAsString(
+          Map.of("customerName", customerName, "handoffReason", ""));
+    } catch (JsonProcessingException e) {
+      throw new BadRequestException("VALIDATION_ERROR", "customerName is invalid", e);
+    }
   }
 }

--- a/backend/src/main/java/com/init/workflowruntime/application/command/GetOrCreateCurrentSessionCommand.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/command/GetOrCreateCurrentSessionCommand.java
@@ -1,3 +1,12 @@
 package com.init.workflowruntime.application.command;
 
-public record GetOrCreateCurrentSessionCommand(Long workspaceId, Long userId) {}
+import com.init.shared.application.exception.BadRequestException;
+
+public record GetOrCreateCurrentSessionCommand(Long workspaceId, Long userId, String customerName) {
+  public GetOrCreateCurrentSessionCommand {
+    if (customerName == null || customerName.isBlank()) {
+      throw new BadRequestException("VALIDATION_ERROR", "customerName must not be blank");
+    }
+    customerName = customerName.trim();
+  }
+}

--- a/backend/src/main/java/com/init/workflowruntime/domain/ChatSession.java
+++ b/backend/src/main/java/com/init/workflowruntime/domain/ChatSession.java
@@ -118,6 +118,13 @@ public class ChatSession {
     return metaJson;
   }
 
+  public void updateMetaJson(String metaJson) {
+    if (metaJson == null || metaJson.isBlank()) {
+      throw new InvalidSessionStateException("metaJson must not be blank");
+    }
+    this.metaJson = metaJson;
+  }
+
   public OffsetDateTime getStartedAt() {
     return startedAt;
   }

--- a/backend/src/main/java/com/init/workflowruntime/presentation/UserChatSessionController.java
+++ b/backend/src/main/java/com/init/workflowruntime/presentation/UserChatSessionController.java
@@ -9,6 +9,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -23,10 +24,12 @@ public class UserChatSessionController {
 
   @GetMapping("/current")
   public ResponseEntity<ChatSessionResponse> getCurrentSession(
-      @PathVariable Long workspaceId, Authentication authentication) {
+      @PathVariable Long workspaceId,
+      @RequestParam String customerName,
+      Authentication authentication) {
     Long userId = AuthenticationUtils.getUserId(authentication);
     return ResponseEntity.ok(
         userChatSessionService.getOrCreateCurrentSession(
-            new GetOrCreateCurrentSessionCommand(workspaceId, userId)));
+            new GetOrCreateCurrentSessionCommand(workspaceId, userId, customerName)));
   }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
       api-key: ${OPENAI_API_KEY:}
       chat:
         options:
-          model: gpt-5.4-mini
+          model: ${OPENAI_CHAT_MODEL:gpt-5.4-mini}
           temperature: 0.7
   datasource:
     url: jdbc:postgresql://localhost:5432/init

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
       api-key: ${OPENAI_API_KEY:}
       chat:
         options:
-          model: gpt-4o-mini
+          model: gpt-5.4-mini
           temperature: 0.7
   datasource:
     url: jdbc:postgresql://localhost:5432/init

--- a/backend/src/test/java/com/init/chatdemo/application/DemoChatSessionRegistrationServiceTest.java
+++ b/backend/src/test/java/com/init/chatdemo/application/DemoChatSessionRegistrationServiceTest.java
@@ -97,7 +97,7 @@ class DemoChatSessionRegistrationServiceTest {
     ChatSession session =
         ChatSession.create(WORKSPACE_ID, VERSION_ID, ChatSessionStatus.OPEN, "WEB", "{}");
     ReflectionTestUtils.setField(session, "id", SESSION_ID);
-    given(chatSessionRepository.findById(SESSION_ID)).willReturn(Optional.of(session));
+    given(chatSessionRepository.findByIdForUpdate(SESSION_ID)).willReturn(Optional.of(session));
     given(chatMessageRepository.findTopByChatSessionIdOrderBySeqNoDesc(SESSION_ID))
         .willReturn(Optional.empty());
     given(chatMessageRepository.findTop5ByChatSessionIdOrderBySeqNoDesc(SESSION_ID))

--- a/backend/src/test/java/com/init/chatdemo/application/DemoChatSessionRegistrationServiceTest.java
+++ b/backend/src/test/java/com/init/chatdemo/application/DemoChatSessionRegistrationServiceTest.java
@@ -1,0 +1,124 @@
+package com.init.chatdemo.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.init.domainpack.domain.model.DomainPackVersion;
+import com.init.domainpack.domain.repository.DomainPackVersionRepository;
+import com.init.workflowruntime.application.LlmAssistantService;
+import com.init.workflowruntime.application.dto.ChatMessageResponse;
+import com.init.workflowruntime.application.dto.ChatSessionResponse;
+import com.init.workflowruntime.domain.ChatMessage;
+import com.init.workflowruntime.domain.ChatMessageRepository;
+import com.init.workflowruntime.domain.ChatSession;
+import com.init.workflowruntime.domain.ChatSessionRepository;
+import com.init.workflowruntime.domain.ChatSessionStatus;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("DemoChatSessionRegistrationService")
+class DemoChatSessionRegistrationServiceTest {
+
+  private static final Long WORKSPACE_ID = 2L;
+  private static final Long VERSION_ID = 101L;
+  private static final Long SESSION_ID = 77L;
+
+  @Mock private DomainPackVersionRepository domainPackVersionRepository;
+  @Mock private ChatSessionRepository chatSessionRepository;
+  @Mock private ChatMessageRepository chatMessageRepository;
+  @Mock private LlmAssistantService llmAssistantService;
+
+  private DemoChatSessionRegistrationService service;
+
+  @BeforeEach
+  void setUp() {
+    service =
+        new DemoChatSessionRegistrationService(
+            domainPackVersionRepository,
+            chatSessionRepository,
+            chatMessageRepository,
+            llmAssistantService);
+  }
+
+  @Test
+  @DisplayName("데모 채팅 세션을 runtime.chat_session에 OPEN으로 등록한다")
+  void should_createOpenRuntimeSession_when_createSession() {
+    given(domainPackVersionRepository.findCurrentPublishedByWorkspaceId(WORKSPACE_ID))
+        .willReturn(
+            Optional.of(
+                DomainPackVersion.ofForTest(VERSION_ID, 1L, DomainPackVersion.STATUS_PUBLISHED)));
+    given(chatSessionRepository.save(any(ChatSession.class)))
+        .willAnswer(
+            invocation -> {
+              ChatSession session = invocation.getArgument(0);
+              ReflectionTestUtils.setField(session, "id", SESSION_ID);
+              return session;
+            });
+    given(chatMessageRepository.save(any(ChatMessage.class)))
+        .willAnswer(invocation -> invocation.getArgument(0));
+
+    ChatSessionResponse response = service.createSession(WORKSPACE_ID, " 김민지 ");
+
+    assertThat(response.getId()).isEqualTo(SESSION_ID);
+    assertThat(response.getStatus()).isEqualTo("OPEN");
+
+    ArgumentCaptor<ChatSession> sessionCaptor = ArgumentCaptor.forClass(ChatSession.class);
+    verify(chatSessionRepository).save(sessionCaptor.capture());
+    ChatSession savedSession = sessionCaptor.getValue();
+    assertThat(savedSession.getWorkspaceId()).isEqualTo(WORKSPACE_ID);
+    assertThat(savedSession.getDomainPackVersionId()).isEqualTo(VERSION_ID);
+    assertThat(savedSession.getStartedBy()).isNull();
+    assertThat(savedSession.getMetaJson()).contains("\"customerName\":\"김민지\"");
+    assertThat(savedSession.getMetaJson()).contains("\"demo\":true");
+
+    ArgumentCaptor<ChatMessage> messageCaptor = ArgumentCaptor.forClass(ChatMessage.class);
+    verify(chatMessageRepository).save(messageCaptor.capture());
+    ChatMessage greeting = messageCaptor.getValue();
+    assertThat(greeting.getChatSessionId()).isEqualTo(SESSION_ID);
+    assertThat(greeting.getSenderRole()).isEqualTo("ASSISTANT");
+    assertThat(greeting.getContent()).contains("김민지");
+  }
+
+  @Test
+  @DisplayName("데모 사용자 메시지와 assistant 응답을 runtime.chat_message에 등록한다")
+  void should_appendUserAndAssistantMessages_when_appendMessage() {
+    ChatSession session =
+        ChatSession.create(WORKSPACE_ID, VERSION_ID, ChatSessionStatus.OPEN, "WEB", "{}");
+    ReflectionTestUtils.setField(session, "id", SESSION_ID);
+    given(chatSessionRepository.findById(SESSION_ID)).willReturn(Optional.of(session));
+    given(chatMessageRepository.findTopByChatSessionIdOrderBySeqNoDesc(SESSION_ID))
+        .willReturn(Optional.empty());
+    given(chatMessageRepository.findTop5ByChatSessionIdOrderBySeqNoDesc(SESSION_ID))
+        .willReturn(List.of(ChatMessage.create(SESSION_ID, 1, "USER", "TEXT", "Hello")));
+    given(llmAssistantService.generateResponse("USER: Hello", "Hello")).willReturn("LLM 응답입니다.");
+    given(chatMessageRepository.save(any(ChatMessage.class)))
+        .willAnswer(invocation -> invocation.getArgument(0));
+
+    List<ChatMessageResponse> responses =
+        service.appendMessage(WORKSPACE_ID, SESSION_ID, " Hello ");
+
+    assertThat(responses).hasSize(2);
+    ArgumentCaptor<ChatMessage> messageCaptor = ArgumentCaptor.forClass(ChatMessage.class);
+    verify(chatMessageRepository, times(2)).save(messageCaptor.capture());
+    assertThat(messageCaptor.getAllValues())
+        .extracting(ChatMessage::getSenderRole)
+        .containsExactly("USER", "ASSISTANT");
+    assertThat(messageCaptor.getAllValues())
+        .extracting(ChatMessage::getSeqNo)
+        .containsExactly(1, 2);
+    assertThat(messageCaptor.getAllValues().get(1).getContent()).isEqualTo("LLM 응답입니다.");
+    verify(llmAssistantService).generateResponse("USER: Hello", "Hello");
+  }
+}

--- a/backend/src/test/java/com/init/chatdemo/application/DemoChatSessionRegistrationServiceTest.java
+++ b/backend/src/test/java/com/init/chatdemo/application/DemoChatSessionRegistrationServiceTest.java
@@ -1,6 +1,7 @@
 package com.init.chatdemo.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
@@ -8,6 +9,8 @@ import static org.mockito.Mockito.verify;
 
 import com.init.domainpack.domain.model.DomainPackVersion;
 import com.init.domainpack.domain.repository.DomainPackVersionRepository;
+import com.init.shared.application.exception.BadRequestException;
+import com.init.shared.application.exception.NotFoundException;
 import com.init.workflowruntime.application.LlmAssistantService;
 import com.init.workflowruntime.application.dto.ChatMessageResponse;
 import com.init.workflowruntime.application.dto.ChatSessionResponse;
@@ -120,5 +123,53 @@ class DemoChatSessionRegistrationServiceTest {
         .containsExactly(1, 2);
     assertThat(messageCaptor.getAllValues().get(1).getContent()).isEqualTo("LLM 응답입니다.");
     verify(llmAssistantService).generateResponse("USER: Hello", "Hello");
+  }
+
+  @Test
+  @DisplayName("데모 메시지 컨텍스트는 최근 메시지를 시간순으로 정렬해 LLM에 전달한다")
+  void should_sendConversationContextInAscendingOrder_when_appendMessage() {
+    ChatSession session =
+        ChatSession.create(WORKSPACE_ID, VERSION_ID, ChatSessionStatus.OPEN, "WEB", "{}");
+    ReflectionTestUtils.setField(session, "id", SESSION_ID);
+    given(chatSessionRepository.findByIdForUpdate(SESSION_ID)).willReturn(Optional.of(session));
+    given(chatMessageRepository.findTopByChatSessionIdOrderBySeqNoDesc(SESSION_ID))
+        .willReturn(Optional.of(ChatMessage.create(SESSION_ID, 3, "ASSISTANT", "TEXT", "최근 답변")));
+    given(chatMessageRepository.findTop5ByChatSessionIdOrderBySeqNoDesc(SESSION_ID))
+        .willReturn(
+            List.of(
+                ChatMessage.create(SESSION_ID, 3, "ASSISTANT", "TEXT", "최근 답변"),
+                ChatMessage.create(SESSION_ID, 2, "USER", "TEXT", "이전 질문")));
+    given(llmAssistantService.generateResponse("USER: 이전 질문\nASSISTANT: 최근 답변", "다음 질문"))
+        .willReturn("다음 답변");
+    given(chatMessageRepository.save(any(ChatMessage.class)))
+        .willAnswer(invocation -> invocation.getArgument(0));
+
+    List<ChatMessageResponse> responses =
+        service.appendMessage(WORKSPACE_ID, SESSION_ID, " 다음 질문 ");
+
+    assertThat(responses).hasSize(2);
+    assertThat(responses.get(0).seqNo()).isEqualTo(4);
+    assertThat(responses.get(1).seqNo()).isEqualTo(5);
+    verify(llmAssistantService).generateResponse("USER: 이전 질문\nASSISTANT: 최근 답변", "다음 질문");
+  }
+
+  @Test
+  @DisplayName("데모 세션 생성 시 운영 중인 domain pack version이 없으면 404를 반환한다")
+  void should_throwNotFound_when_currentPublishedVersionMissing() {
+    given(domainPackVersionRepository.findCurrentPublishedByWorkspaceId(WORKSPACE_ID))
+        .willReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.createSession(WORKSPACE_ID, "김민지"))
+        .isInstanceOf(NotFoundException.class)
+        .hasMessageContaining("workspaceId=2");
+  }
+
+  @Test
+  @DisplayName("데모 사용자 이름과 메시지가 비어 있으면 검증 오류를 반환한다")
+  void should_throwBadRequest_when_blankInputs() {
+    assertThatThrownBy(() -> service.createSession(WORKSPACE_ID, " "))
+        .isInstanceOf(BadRequestException.class);
+    assertThatThrownBy(() -> service.appendMessage(WORKSPACE_ID, SESSION_ID, " "))
+        .isInstanceOf(BadRequestException.class);
   }
 }

--- a/backend/src/test/java/com/init/chatdemo/presentation/DemoRuntimeControllerTest.java
+++ b/backend/src/test/java/com/init/chatdemo/presentation/DemoRuntimeControllerTest.java
@@ -2,10 +2,12 @@ package com.init.chatdemo.presentation;
 
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.init.chatdemo.application.DemoChatSessionRegistrationService;
 import com.init.chatdemo.application.DemoRuntimeMockService;
 import com.init.chatdemo.presentation.dto.DemoChatSessionEndpointResponse;
 import com.init.chatdemo.presentation.dto.DemoChatSessionResponse;
@@ -26,11 +28,15 @@ import com.init.chatdemo.presentation.dto.DemoWorkflowResponse;
 import com.init.fixtures.WithLongPrincipal;
 import com.init.shared.application.exception.NotFoundException;
 import com.init.shared.infrastructure.security.JwtAuthenticationFilter;
+import com.init.workflowruntime.application.dto.ChatMessageResponse;
+import com.init.workflowruntime.application.dto.ChatSessionResponse;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
@@ -44,6 +50,7 @@ import org.springframework.test.web.servlet.MockMvc;
         @ComponentScan.Filter(
             type = FilterType.ASSIGNABLE_TYPE,
             classes = JwtAuthenticationFilter.class))
+@AutoConfigureMockMvc(addFilters = false)
 @DisplayName("DemoRuntimeController")
 class DemoRuntimeControllerTest {
 
@@ -52,6 +59,7 @@ class DemoRuntimeControllerTest {
   @Autowired private MockMvc mockMvc;
 
   @MockitoBean private DemoRuntimeMockService service;
+  @MockitoBean private DemoChatSessionRegistrationService sessionRegistrationService;
 
   @Test
   @DisplayName("GET /api/v1/demo/chat-workflow → 200, 6개 섹션 JSON 검증")
@@ -118,6 +126,54 @@ class DemoRuntimeControllerTest {
         .andExpect(jsonPath("$.messages[0].timestamp").value("2026-05-10T09:00:00Z"))
         .andExpect(jsonPath("$.messages[3].id").value("msg-4"))
         .andExpect(jsonPath("$.messages[3].role").value("assistant"));
+  }
+
+  @Test
+  @DisplayName("POST /api/v1/demo/chat-sessions → 백엔드 데모 세션 등록")
+  void should_200_when_createRegisteredChatSession() throws Exception {
+    ChatSessionResponse response = new ChatSessionResponse();
+    response.setId(77L);
+    response.setStatus("OPEN");
+    response.setChannel("WEB");
+    response.setMetaJson("{\"customerName\":\"김민지\"}");
+    response.setStartedAt(OffsetDateTime.parse("2026-05-22T00:00:00+09:00"));
+    given(sessionRegistrationService.createSession(10L, "김민지")).willReturn(response);
+
+    mockMvc
+        .perform(
+            post(DEMO_URL_PREFIX + "/chat-sessions")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"customerName\":\"김민지\"}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(77))
+        .andExpect(jsonPath("$.status").value("OPEN"))
+        .andExpect(jsonPath("$.metaJson").value("{\"customerName\":\"김민지\"}"));
+  }
+
+  @Test
+  @DisplayName("POST /api/v1/demo/chat-sessions/{sessionId}/messages → 데모 메시지 등록")
+  void should_200_when_appendRegisteredChatMessage() throws Exception {
+    given(sessionRegistrationService.appendMessage(10L, 77L, "Hello"))
+        .willReturn(
+            List.of(
+                new ChatMessageResponse(
+                    1L, 1, "USER", "TEXT", "Hello", OffsetDateTime.parse("2026-05-22T00:00:00Z")),
+                new ChatMessageResponse(
+                    2L,
+                    2,
+                    "ASSISTANT",
+                    "TEXT",
+                    "안내드릴게요.",
+                    OffsetDateTime.parse("2026-05-22T00:00:01Z"))));
+
+    mockMvc
+        .perform(
+            post(DEMO_URL_PREFIX + "/chat-sessions/77/messages")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"content\":\"Hello\"}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].senderRole").value("USER"))
+        .andExpect(jsonPath("$[1].senderRole").value("ASSISTANT"));
   }
 
   @Test
@@ -232,11 +288,13 @@ class DemoRuntimeControllerTest {
   }
 
   @Test
-  @DisplayName("인증 없이 요청 시 401 반환")
-  void should_401_when_unauthenticated() throws Exception {
+  @DisplayName("인증 없이 demo workflow 요청 시 200 반환")
+  void should_200_when_unauthenticated() throws Exception {
+    given(service.getChatWorkflow(10L)).willReturn(chatWorkflowResponse());
+
     mockMvc
         .perform(get(DEMO_URL_PREFIX + "/chat-workflow").accept(MediaType.APPLICATION_JSON))
-        .andExpect(status().isUnauthorized());
+        .andExpect(status().isOk());
   }
 
   private DemoChatWorkflowResponse chatWorkflowResponse() {

--- a/backend/src/test/java/com/init/chatdemo/presentation/DemoRuntimeControllerTest.java
+++ b/backend/src/test/java/com/init/chatdemo/presentation/DemoRuntimeControllerTest.java
@@ -1,6 +1,8 @@
 package com.init.chatdemo.presentation;
 
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -151,6 +153,19 @@ class DemoRuntimeControllerTest {
   }
 
   @Test
+  @DisplayName("POST /api/v1/demo/chat-sessions → customerName 공백이면 400")
+  void should_400_when_createRegisteredChatSessionWithBlankName() throws Exception {
+    mockMvc
+        .perform(
+            post(DEMO_URL_PREFIX + "/chat-sessions")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"customerName\":\" \"}"))
+        .andExpect(status().isBadRequest());
+
+    verify(sessionRegistrationService, never()).createSession(10L, " ");
+  }
+
+  @Test
   @DisplayName("POST /api/v1/demo/chat-sessions/{sessionId}/messages → 데모 메시지 등록")
   void should_200_when_appendRegisteredChatMessage() throws Exception {
     given(sessionRegistrationService.appendMessage(10L, 77L, "Hello"))
@@ -174,6 +189,19 @@ class DemoRuntimeControllerTest {
         .andExpect(status().isOk())
         .andExpect(jsonPath("$[0].senderRole").value("USER"))
         .andExpect(jsonPath("$[1].senderRole").value("ASSISTANT"));
+  }
+
+  @Test
+  @DisplayName("POST /api/v1/demo/chat-sessions/{sessionId}/messages → content 공백이면 400")
+  void should_400_when_appendRegisteredChatMessageWithBlankContent() throws Exception {
+    mockMvc
+        .perform(
+            post(DEMO_URL_PREFIX + "/chat-sessions/77/messages")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"content\":\" \"}"))
+        .andExpect(status().isBadRequest());
+
+    verify(sessionRegistrationService, never()).appendMessage(10L, 77L, " ");
   }
 
   @Test
@@ -288,8 +316,8 @@ class DemoRuntimeControllerTest {
   }
 
   @Test
-  @DisplayName("인증 없이 demo workflow 요청 시 200 반환")
-  void should_200_when_unauthenticated() throws Exception {
+  @DisplayName("컨트롤러 단위 테스트에서 demo workflow 요청 시 200 반환")
+  void should_return200_when_getChatWorkflow_withoutSecurityFilters() throws Exception {
     given(service.getChatWorkflow(10L)).willReturn(chatWorkflowResponse());
 
     mockMvc

--- a/backend/src/test/java/com/init/workflowruntime/application/UserChatSessionServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/UserChatSessionServiceTest.java
@@ -78,6 +78,31 @@ class UserChatSessionServiceTest {
   }
 
   @Test
+  @DisplayName("current session: 기존 세션의 다른 metaJson 필드를 보존하며 customerName만 갱신한다")
+  void should_preserveExistingMetaJsonFields_when_updateCustomerName() {
+    ChatSession session =
+        createSession(
+            5L,
+            ChatSessionStatus.OPEN,
+            "{\"handoffReason\":\"환불 문의\",\"demo\":true,\"customerName\":\"이전 이름\"}");
+    given(workspaceMemberRepository.findByWorkspaceIdAndUserId(WORKSPACE_ID, USER_ID))
+        .willReturn(
+            Optional.of(WorkspaceMember.create(WORKSPACE_ID, USER_ID, WorkspaceMemberRole.OWNER)));
+    given(
+            chatSessionRepository
+                .findFirstByWorkspaceIdAndStartedByAndStatusInOrderByStartedAtDescIdDesc(
+                    any(), any(), any()))
+        .willReturn(Optional.of(session));
+
+    ChatSessionResponse result = service.getOrCreateCurrentSession(command());
+
+    assertThat(result.getMetaJson()).contains("\"customerName\":\"김민지\"");
+    assertThat(result.getMetaJson()).contains("\"handoffReason\":\"환불 문의\"");
+    assertThat(result.getMetaJson()).contains("\"demo\":true");
+    verify(chatSessionRepository, never()).save(any());
+  }
+
+  @Test
   @DisplayName("current session: 기존 세션이 없으면 현재 PUBLISHED 버전으로 OPEN 세션을 생성한다")
   void should_createOpenSession_when_reusableSessionDoesNotExist() {
     given(workspaceMemberRepository.findByWorkspaceIdAndUserId(WORKSPACE_ID, USER_ID))
@@ -153,8 +178,12 @@ class UserChatSessionServiceTest {
   }
 
   private ChatSession createSession(Long id, ChatSessionStatus status) {
+    return createSession(id, status, "{}");
+  }
+
+  private ChatSession createSession(Long id, ChatSessionStatus status, String metaJson) {
     ChatSession session =
-        ChatSession.create(WORKSPACE_ID, VERSION_ID, status, "WEB", "{}", USER_ID);
+        ChatSession.create(WORKSPACE_ID, VERSION_ID, status, "WEB", metaJson, USER_ID);
     ReflectionTestUtils.setField(session, "id", id);
     return session;
   }

--- a/backend/src/test/java/com/init/workflowruntime/application/UserChatSessionServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/UserChatSessionServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.verify;
 
 import com.init.domainpack.domain.model.DomainPackVersion;
 import com.init.domainpack.domain.repository.DomainPackVersionRepository;
+import com.init.shared.application.exception.BadRequestException;
 import com.init.shared.application.exception.NotFoundException;
 import com.init.workflowruntime.application.command.GetOrCreateCurrentSessionCommand;
 import com.init.workflowruntime.application.dto.ChatSessionResponse;
@@ -103,6 +104,42 @@ class UserChatSessionServiceTest {
   }
 
   @Test
+  @DisplayName("current session: metaJson이 비어 있어도 customerName을 채운다")
+  void should_fillCustomerName_when_existingMetaJsonIsBlank() {
+    ChatSession session = createSession(5L, ChatSessionStatus.OPEN, " ");
+    given(workspaceMemberRepository.findByWorkspaceIdAndUserId(WORKSPACE_ID, USER_ID))
+        .willReturn(
+            Optional.of(WorkspaceMember.create(WORKSPACE_ID, USER_ID, WorkspaceMemberRole.OWNER)));
+    given(
+            chatSessionRepository
+                .findFirstByWorkspaceIdAndStartedByAndStatusInOrderByStartedAtDescIdDesc(
+                    any(), any(), any()))
+        .willReturn(Optional.of(session));
+
+    ChatSessionResponse result = service.getOrCreateCurrentSession(command());
+
+    assertThat(result.getMetaJson()).contains("\"customerName\":\"김민지\"");
+    verify(chatSessionRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("current session: 기존 metaJson이 잘못된 JSON이면 검증 오류를 반환한다")
+  void should_throwBadRequest_when_existingMetaJsonIsInvalid() {
+    ChatSession session = createSession(5L, ChatSessionStatus.OPEN, "{invalid");
+    given(workspaceMemberRepository.findByWorkspaceIdAndUserId(WORKSPACE_ID, USER_ID))
+        .willReturn(
+            Optional.of(WorkspaceMember.create(WORKSPACE_ID, USER_ID, WorkspaceMemberRole.OWNER)));
+    given(
+            chatSessionRepository
+                .findFirstByWorkspaceIdAndStartedByAndStatusInOrderByStartedAtDescIdDesc(
+                    any(), any(), any()))
+        .willReturn(Optional.of(session));
+
+    assertThatThrownBy(() -> service.getOrCreateCurrentSession(command()))
+        .isInstanceOf(BadRequestException.class);
+  }
+
+  @Test
   @DisplayName("current session: 기존 세션이 없으면 현재 PUBLISHED 버전으로 OPEN 세션을 생성한다")
   void should_createOpenSession_when_reusableSessionDoesNotExist() {
     given(workspaceMemberRepository.findByWorkspaceIdAndUserId(WORKSPACE_ID, USER_ID))
@@ -152,6 +189,17 @@ class UserChatSessionServiceTest {
 
     verify(concurrencyGuard, never()).lockCurrentSession(any(), any());
     verify(chatSessionRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("current session command: customerName은 trim되고 공백은 거부한다")
+  void should_trimAndValidateCustomerName_when_createCommand() {
+    GetOrCreateCurrentSessionCommand command =
+        new GetOrCreateCurrentSessionCommand(WORKSPACE_ID, USER_ID, " 김민지 ");
+
+    assertThat(command.customerName()).isEqualTo("김민지");
+    assertThatThrownBy(() -> new GetOrCreateCurrentSessionCommand(WORKSPACE_ID, USER_ID, " "))
+        .isInstanceOf(BadRequestException.class);
   }
 
   @Test

--- a/backend/src/test/java/com/init/workflowruntime/application/UserChatSessionServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/UserChatSessionServiceTest.java
@@ -36,6 +36,7 @@ class UserChatSessionServiceTest {
   private static final Long WORKSPACE_ID = 10L;
   private static final Long USER_ID = 7L;
   private static final Long VERSION_ID = 101L;
+  private static final String CUSTOMER_NAME = "김민지";
 
   @Mock private ChatSessionRepository chatSessionRepository;
   @Mock private DomainPackVersionRepository domainPackVersionRepository;
@@ -71,6 +72,7 @@ class UserChatSessionServiceTest {
 
     assertThat(result.getId()).isEqualTo(5L);
     assertThat(result.getStatus()).isEqualTo("OPEN");
+    assertThat(result.getMetaJson()).contains("\"customerName\":\"김민지\"");
     verify(concurrencyGuard).lockCurrentSession(WORKSPACE_ID, USER_ID);
     verify(chatSessionRepository, never()).save(any());
   }
@@ -111,6 +113,7 @@ class UserChatSessionServiceTest {
     assertThat(saved.getDomainPackVersionId()).isEqualTo(VERSION_ID);
     assertThat(saved.getStartedBy()).isEqualTo(USER_ID);
     assertThat(saved.getChannel()).isEqualTo("WEB");
+    assertThat(saved.getMetaJson()).contains("\"customerName\":\"김민지\"");
   }
 
   @Test
@@ -157,6 +160,6 @@ class UserChatSessionServiceTest {
   }
 
   private GetOrCreateCurrentSessionCommand command() {
-    return new GetOrCreateCurrentSessionCommand(WORKSPACE_ID, USER_ID);
+    return new GetOrCreateCurrentSessionCommand(WORKSPACE_ID, USER_ID, CUSTOMER_NAME);
   }
 }

--- a/backend/src/test/java/com/init/workflowruntime/domain/ChatSessionTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/domain/ChatSessionTest.java
@@ -52,4 +52,12 @@ class ChatSessionTest {
 
     assertThatThrownBy(session::closeSession).isInstanceOf(InvalidSessionStateException.class);
   }
+
+  @Test
+  @DisplayName("create: metaJson이 null이면 빈 JSON 객체로 초기화한다")
+  void should_defaultMetaJson_when_createWithNullMetaJson() {
+    ChatSession session = ChatSession.create(1L, 1L, ChatSessionStatus.OPEN, "WEB", null);
+
+    assertThat(session.getMetaJson()).isEqualTo("{}");
+  }
 }

--- a/backend/src/test/java/com/init/workflowruntime/presentation/UserChatSessionControllerTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/presentation/UserChatSessionControllerTest.java
@@ -46,7 +46,7 @@ class UserChatSessionControllerTest {
 
     given(
             userChatSessionService.getOrCreateCurrentSession(
-                new GetOrCreateCurrentSessionCommand(10L, 7L)))
+                new GetOrCreateCurrentSessionCommand(10L, 7L, "김민지")))
         .willReturn(response);
 
     UsernamePasswordAuthenticationToken authentication =
@@ -54,7 +54,10 @@ class UserChatSessionControllerTest {
             7L, null, java.util.List.of(new SimpleGrantedAuthority("ROLE_USER")));
 
     mockMvc
-        .perform(get("/api/v1/workspaces/10/chat/sessions/current").principal(authentication))
+        .perform(
+            get("/api/v1/workspaces/10/chat/sessions/current")
+                .param("customerName", "김민지")
+                .principal(authentication))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.id").value(33))
         .andExpect(jsonPath("$.status").value("OPEN"))

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -24,7 +24,7 @@ spring:
       api-key: test-api-key
       chat:
         options:
-          model: gpt-5.4-mini
+          model: ${OPENAI_CHAT_MODEL:gpt-5.4-mini}
           temperature: 0.7
 
 jwt:

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -24,7 +24,7 @@ spring:
       api-key: test-api-key
       chat:
         options:
-          model: gpt-4o-mini
+          model: gpt-5.4-mini
           temperature: 0.7
 
 jwt:

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -64,10 +64,13 @@ export function App() {
             path="consultation/:sessionId"
             element={<ConsultationPage />}
           />
-          <Route path="chat" element={<UserChatPage />} />
           <Route path="upload" element={<WorkspaceUploadPage />} />
           <Route path="domain-packs" element={<DomainPackListPage />} />
         </Route>
+        <Route
+          path="/demo/workspaces/:workspaceId/chat"
+          element={<UserChatPage />}
+        />
         <Route
           path="/upload"
           element={

--- a/frontend/src/entities/chat/api/chatApi.test.ts
+++ b/frontend/src/entities/chat/api/chatApi.test.ts
@@ -135,6 +135,17 @@ describe("chatApi", () => {
     );
   });
 
+  it("백엔드 데모 채팅 세션 응답에 숫자 id가 없으면 실패한다", async () => {
+    customFetchMock.mockResolvedValue({
+      status: "OPEN",
+      startedAt: "2026-05-22T00:00:00Z",
+    });
+
+    await expect(registerDemoChatSession(2, "김민지")).rejects.toThrow(
+      "Demo chat session response is missing a numeric id.",
+    );
+  });
+
   it("데모 채팅 메시지를 백엔드에 등록한다", async () => {
     customFetchMock.mockResolvedValue([
       {
@@ -179,5 +190,12 @@ describe("chatApi", () => {
         body: JSON.stringify({ content: "Hello" }),
       },
     );
+  });
+
+  it("숫자가 아닌 데모 세션 id로 메시지를 보내지 않는다", async () => {
+    await expect(sendDemoChatMessage(2, "workspace-2-demo-session", "Hello")).rejects.toThrow(
+      "Demo chat session id must be numeric.",
+    );
+    expect(customFetchMock).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/entities/chat/api/chatApi.test.ts
+++ b/frontend/src/entities/chat/api/chatApi.test.ts
@@ -1,5 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createChatSession } from "./chatApi";
+import {
+  createChatSession,
+  createDemoChatSession,
+  listChatMessages,
+  registerDemoChatSession,
+  sendDemoChatMessage,
+} from "./chatApi";
 
 const { customFetchMock } = vi.hoisted(() => ({
   customFetchMock: vi.fn(),
@@ -23,11 +29,155 @@ describe("chatApi", () => {
     };
     customFetchMock.mockResolvedValue(session);
 
-    await expect(createChatSession(3)).resolves.toEqual(session);
+    await expect(createChatSession(3, "김민지")).resolves.toEqual(session);
 
     expect(customFetchMock).toHaveBeenCalledWith(
-      "/api/v1/workspaces/3/chat/sessions/current",
+      "/api/v1/workspaces/3/chat/sessions/current?customerName=%EA%B9%80%EB%AF%BC%EC%A7%80",
       { method: "GET" },
+    );
+  });
+
+  it("세션 메시지를 채팅 UI 모델로 변환한다", async () => {
+    customFetchMock.mockResolvedValue([
+      {
+        id: 21,
+        seqNo: 1,
+        senderRole: "ASSISTANT",
+        messageType: "TEXT",
+        content: "안녕하세요",
+        createdAt: "2026-05-22T00:00:00Z",
+      },
+    ]);
+
+    await expect(listChatMessages(7)).resolves.toEqual([
+      {
+        id: "21",
+        sessionId: 7,
+        senderType: "BOT",
+        content: "안녕하세요",
+        createdAt: "2026-05-22T00:00:00Z",
+      },
+    ]);
+
+    expect(customFetchMock).toHaveBeenCalledWith(
+      "/api/v1/consultation/sessions/7/messages",
+      { method: "GET" },
+    );
+  });
+
+  it("데모 채팅 워크플로우를 채팅 UI 모델로 변환한다", async () => {
+    customFetchMock.mockResolvedValue({
+      chatSession: {
+        id: "session-2",
+        status: "completed",
+        startedAt: "2026-05-10T10:00:00Z",
+      },
+      messages: [
+        {
+          id: "card-msg-1",
+          role: "user",
+          content: "안녕하세요",
+          timestamp: "2026-05-10T10:00:00Z",
+        },
+      ],
+    });
+
+    await expect(createDemoChatSession(2, "김민지")).resolves.toEqual({
+      id: "session-2",
+      status: "completed",
+      startedAt: "2026-05-10T10:00:00Z",
+      messages: [
+        {
+          id: "card-msg-1",
+          sessionId: 0,
+          senderType: "USER",
+          senderName: "김민지",
+          content: "안녕하세요",
+          createdAt: "2026-05-10T10:00:00Z",
+        },
+      ],
+    });
+
+    expect(customFetchMock).toHaveBeenCalledWith(
+      "/api/v1/workspaces/2/demo/chat-workflow",
+      { method: "GET" },
+    );
+  });
+
+  it("백엔드에 데모 채팅 세션을 등록한다", async () => {
+    customFetchMock.mockResolvedValue({
+      id: 77,
+      status: "OPEN",
+      startedAt: "2026-05-22T00:00:00Z",
+    });
+
+    await expect(registerDemoChatSession(2, "김민지")).resolves.toEqual({
+      id: "77",
+      status: "OPEN",
+      startedAt: "2026-05-22T00:00:00Z",
+      messages: [
+        {
+          id: "backend-greeting-77",
+          sessionId: 77,
+          senderType: "BOT",
+          content: "안녕하세요, 김민지님. 무엇을 도와드릴까요?",
+          createdAt: "2026-05-22T00:00:00Z",
+        },
+      ],
+    });
+
+    expect(customFetchMock).toHaveBeenCalledWith(
+      "/api/v1/workspaces/2/demo/chat-sessions",
+      {
+        method: "POST",
+        body: JSON.stringify({ customerName: "김민지" }),
+      },
+    );
+  });
+
+  it("데모 채팅 메시지를 백엔드에 등록한다", async () => {
+    customFetchMock.mockResolvedValue([
+      {
+        id: 81,
+        seqNo: 2,
+        senderRole: "USER",
+        messageType: "TEXT",
+        content: "Hello",
+        createdAt: "2026-05-22T00:00:01Z",
+      },
+      {
+        id: 82,
+        seqNo: 3,
+        senderRole: "ASSISTANT",
+        messageType: "TEXT",
+        content: "LLM 응답입니다.",
+        createdAt: "2026-05-22T00:00:02Z",
+      },
+    ]);
+
+    await expect(sendDemoChatMessage(2, "77", "Hello")).resolves.toEqual([
+      {
+        id: "81",
+        sessionId: 77,
+        senderType: "USER",
+        content: "Hello",
+        createdAt: "2026-05-22T00:00:01Z",
+      },
+      {
+        id: "82",
+        sessionId: 77,
+        senderType: "BOT",
+        content: "LLM 응답입니다.",
+        createdAt: "2026-05-22T00:00:02Z",
+      },
+    ]);
+
+    expect(customFetchMock).toHaveBeenCalledWith(
+      "/api/v1/workspaces/2/demo/chat-sessions/77/messages",
+      {
+        method: "POST",
+        body: JSON.stringify({ content: "Hello" }),
+      },
     );
   });
 });

--- a/frontend/src/entities/chat/api/chatApi.ts
+++ b/frontend/src/entities/chat/api/chatApi.ts
@@ -1,8 +1,166 @@
 import { customFetch } from "@/shared/api/mutator";
-import type { ChatSession } from "@/entities/chat/model/types";
+import type { ChatMessage, ChatSession } from "@/entities/chat/model/types";
 
-export function createChatSession(workspaceId: number): Promise<ChatSession> {
-  return customFetch<ChatSession>(`/api/v1/workspaces/${workspaceId}/chat/sessions/current`, {
-    method: "GET",
-  });
+interface ChatMessageResponse {
+  id: number;
+  seqNo: number;
+  senderRole: string;
+  messageType: string;
+  content: string;
+  createdAt: string;
+}
+
+interface DemoChatWorkflowResponse {
+  chatSession?: {
+    id?: string;
+    status?: string;
+    startedAt?: string;
+    completedAt?: string;
+  };
+  messages?: DemoMessageResponse[];
+}
+
+interface DemoMessageResponse {
+  id?: string;
+  role?: string;
+  content?: string;
+  timestamp?: string;
+}
+
+export interface DemoChatSession {
+  id: string;
+  status: string;
+  startedAt: string;
+  messages: ChatMessage[];
+}
+
+interface DemoRegisteredChatSessionResponse {
+  id?: number;
+  status?: string;
+  channel?: string;
+  metaJson?: string;
+  startedAt?: string;
+}
+
+function toSenderType(senderRole: string): ChatMessage["senderType"] {
+  if (senderRole === "USER" || senderRole === "CUSTOMER") return "USER";
+  if (senderRole === "AGENT" || senderRole === "COUNSELOR") return "AGENT";
+  return "BOT";
+}
+
+function toChatMessage(message: ChatMessageResponse, sessionId: number): ChatMessage {
+  return {
+    id: String(message.id),
+    sessionId,
+    content: message.content,
+    senderType: toSenderType(message.senderRole),
+    createdAt: message.createdAt,
+  };
+}
+
+function toDemoSenderType(role?: string): ChatMessage["senderType"] {
+  if (role === "user" || role === "customer") return "USER";
+  if (role === "agent" || role === "counselor") return "AGENT";
+  return "BOT";
+}
+
+function toDemoChatMessage(
+  message: DemoMessageResponse,
+  index: number,
+  customerName: string,
+): ChatMessage {
+  const senderType = toDemoSenderType(message.role);
+  return {
+    id: message.id ?? `demo-message-${index}`,
+    sessionId: 0,
+    content: message.content ?? "",
+    senderType,
+    senderName: senderType === "USER" ? customerName : undefined,
+    createdAt: message.timestamp ?? new Date().toISOString(),
+  };
+}
+
+export function createChatSession(
+  workspaceId: number,
+  customerName: string,
+): Promise<ChatSession> {
+  const params = new URLSearchParams({ customerName });
+  return customFetch<ChatSession>(
+    `/api/v1/workspaces/${workspaceId}/chat/sessions/current?${params.toString()}`,
+    {
+      method: "GET",
+    },
+  );
+}
+
+export async function listChatMessages(sessionId: number): Promise<ChatMessage[]> {
+  const messages = await customFetch<ChatMessageResponse[]>(
+    `/api/v1/consultation/sessions/${sessionId}/messages`,
+    { method: "GET" },
+  );
+  return messages.map((message) => toChatMessage(message, sessionId));
+}
+
+export async function createDemoChatSession(
+  workspaceId: number,
+  customerName: string,
+): Promise<DemoChatSession> {
+  const response = await customFetch<DemoChatWorkflowResponse>(
+    `/api/v1/workspaces/${workspaceId}/demo/chat-workflow`,
+    { method: "GET" },
+  );
+  const chatSession = response.chatSession;
+
+  return {
+    id: chatSession?.id ?? `workspace-${workspaceId}-demo-session`,
+    status: chatSession?.status ?? "open",
+    startedAt: chatSession?.startedAt ?? new Date().toISOString(),
+    messages: (response.messages ?? []).map((message, index) =>
+      toDemoChatMessage(message, index, customerName),
+    ),
+  };
+}
+
+export async function registerDemoChatSession(
+  workspaceId: number,
+  customerName: string,
+): Promise<DemoChatSession> {
+  const response = await customFetch<DemoRegisteredChatSessionResponse>(
+    `/api/v1/workspaces/${workspaceId}/demo/chat-sessions`,
+    {
+      method: "POST",
+      body: JSON.stringify({ customerName }),
+    },
+  );
+  const startedAt = response.startedAt ?? new Date().toISOString();
+
+  return {
+    id: String(response.id ?? `workspace-${workspaceId}-demo-session`),
+    status: response.status ?? "OPEN",
+    startedAt,
+    messages: [
+      {
+        id: `backend-greeting-${response.id ?? Date.now()}`,
+        sessionId: Number(response.id ?? 0),
+        content: `안녕하세요, ${customerName}님. 무엇을 도와드릴까요?`,
+        senderType: "BOT",
+        createdAt: startedAt,
+      },
+    ],
+  };
+}
+
+export async function sendDemoChatMessage(
+  workspaceId: number,
+  sessionId: string,
+  content: string,
+): Promise<ChatMessage[]> {
+  const messages = await customFetch<ChatMessageResponse[]>(
+    `/api/v1/workspaces/${workspaceId}/demo/chat-sessions/${sessionId}/messages`,
+    {
+      method: "POST",
+      body: JSON.stringify({ content }),
+    },
+  );
+  return messages.map((message) => toChatMessage(message, Number(sessionId)));
 }

--- a/frontend/src/entities/chat/api/chatApi.ts
+++ b/frontend/src/entities/chat/api/chatApi.ts
@@ -42,6 +42,13 @@ interface DemoRegisteredChatSessionResponse {
   startedAt?: string;
 }
 
+function requireBackendSessionId(id: number | undefined): number {
+  if (typeof id !== "number" || !Number.isFinite(id)) {
+    throw new Error("Demo chat session response is missing a numeric id.");
+  }
+  return id;
+}
+
 function toSenderType(senderRole: string): ChatMessage["senderType"] {
   if (senderRole === "USER" || senderRole === "CUSTOMER") return "USER";
   if (senderRole === "AGENT" || senderRole === "COUNSELOR") return "AGENT";
@@ -132,16 +139,17 @@ export async function registerDemoChatSession(
       body: JSON.stringify({ customerName }),
     },
   );
+  const sessionId = requireBackendSessionId(response.id);
   const startedAt = response.startedAt ?? new Date().toISOString();
 
   return {
-    id: String(response.id ?? `workspace-${workspaceId}-demo-session`),
+    id: String(sessionId),
     status: response.status ?? "OPEN",
     startedAt,
     messages: [
       {
-        id: `backend-greeting-${response.id ?? Date.now()}`,
-        sessionId: Number(response.id ?? 0),
+        id: `backend-greeting-${sessionId}`,
+        sessionId,
         content: `안녕하세요, ${customerName}님. 무엇을 도와드릴까요?`,
         senderType: "BOT",
         createdAt: startedAt,
@@ -155,6 +163,10 @@ export async function sendDemoChatMessage(
   sessionId: string,
   content: string,
 ): Promise<ChatMessage[]> {
+  const numericSessionId = Number(sessionId);
+  if (!Number.isFinite(numericSessionId)) {
+    throw new Error("Demo chat session id must be numeric.");
+  }
   const messages = await customFetch<ChatMessageResponse[]>(
     `/api/v1/workspaces/${workspaceId}/demo/chat-sessions/${sessionId}/messages`,
     {
@@ -162,5 +174,5 @@ export async function sendDemoChatMessage(
       body: JSON.stringify({ content }),
     },
   );
-  return messages.map((message) => toChatMessage(message, Number(sessionId)));
+  return messages.map((message) => toChatMessage(message, numericSessionId));
 }

--- a/frontend/src/entities/chat/index.ts
+++ b/frontend/src/entities/chat/index.ts
@@ -1,2 +1,9 @@
-export { createChatSession } from "@/entities/chat/api/chatApi";
+export {
+  createChatSession,
+  createDemoChatSession,
+  listChatMessages,
+  registerDemoChatSession,
+  sendDemoChatMessage,
+} from "@/entities/chat/api/chatApi";
+export type { DemoChatSession } from "@/entities/chat/api/chatApi";
 export type { ChatMessage, ChatSession, ConnectionStatus } from "@/entities/chat/model/types";

--- a/frontend/src/features/auth/model/resolvePostLoginDestination.test.ts
+++ b/frontend/src/features/auth/model/resolvePostLoginDestination.test.ts
@@ -15,6 +15,14 @@ describe("resolvePostLoginDestination", () => {
     ).toBe("/workspaces/1/upload?tab=logs");
   });
 
+  it("allows demo workspace chat paths", () => {
+    expect(
+      resolvePostLoginDestination({
+        from: { pathname: "/demo/workspaces/1/chat", search: "?preview=true" },
+      }),
+    ).toBe("/demo/workspaces/1/chat?preview=true");
+  });
+
   it("falls back for auth routes", () => {
     expect(resolvePostLoginDestination({ from: { pathname: "/login" } })).toBe("/workspaces");
     expect(resolvePostLoginDestination({ from: { pathname: "/signup" } })).toBe("/workspaces");

--- a/frontend/src/features/auth/model/resolvePostLoginDestination.ts
+++ b/frontend/src/features/auth/model/resolvePostLoginDestination.ts
@@ -1,5 +1,5 @@
 const DEFAULT_POST_LOGIN_PATH = "/workspaces";
-const ALLOWED_RETURN_PREFIXES = ["/workspaces"];
+const ALLOWED_RETURN_PREFIXES = ["/workspaces", "/demo/workspaces"];
 
 interface ReturnLocation {
   pathname?: unknown;

--- a/frontend/src/features/consultation/api/consultationApi.ts
+++ b/frontend/src/features/consultation/api/consultationApi.ts
@@ -11,9 +11,16 @@ import type { ChatMessageResponse, ChatSessionResponse } from "@/shared/api/gene
 export type ChatSession = ChatSessionResponse;
 export type ChatMessage = ChatMessageResponse;
 
+function unwrapData<T>(response: T | { data: T }): T {
+  if (response && typeof response === "object" && "data" in response) {
+    return (response as { data: T }).data;
+  }
+  return response as T;
+}
+
 export const consultationApi = {
   getQueue: async (): Promise<ChatSession[]> => {
-    return (await getQueue()).data;
+    return unwrapData(await getQueue());
   },
 
   getSessions: async (params?: {
@@ -27,7 +34,12 @@ export const consultationApi = {
     if (params?.size !== undefined) searchParams.set("size", String(params.size));
     const query = searchParams.toString();
     const url = `/api/v1/consultation/sessions${query ? `?${query}` : ""}`;
-    return (await customFetch<{ data: ChatSession[]; status: number; headers: Headers }>(url, { method: "GET" })).data;
+    return unwrapData(
+      await customFetch<ChatSession[] | { data: ChatSession[]; status: number; headers: Headers }>(
+        url,
+        { method: "GET" },
+      ),
+    );
   },
 
   getMessages: async (
@@ -35,14 +47,19 @@ export const consultationApi = {
     params?: { page?: number; size?: number },
   ): Promise<ChatMessage[]> => {
     if (!params) {
-      return (await getMessages(sessionId)).data;
+      return unwrapData(await getMessages(sessionId));
     }
     const searchParams = new URLSearchParams();
     if (params.page !== undefined) searchParams.set("page", String(params.page));
     if (params.size !== undefined) searchParams.set("size", String(params.size));
     const query = searchParams.toString();
     const url = `${getGetMessagesUrl(sessionId)}${query ? `?${query}` : ""}`;
-    return (await customFetch<{ data: ChatMessage[]; status: number; headers: Headers }>(url, { method: "GET" })).data;
+    return unwrapData(
+      await customFetch<ChatMessage[] | { data: ChatMessage[]; status: number; headers: Headers }>(
+        url,
+        { method: "GET" },
+      ),
+    );
   },
 
   sendMessage: async (
@@ -50,10 +67,10 @@ export const consultationApi = {
     content: string,
     isNote: boolean = false,
   ): Promise<ChatMessage> => {
-    return (await sendMessage(sessionId, { content, isNote })).data;
+    return unwrapData(await sendMessage(sessionId, { content, isNote }));
   },
 
   updateStatus: async (sessionId: number, status: string): Promise<ChatSession> => {
-    return (await updateStatus(sessionId, { status })).data;
+    return unwrapData(await updateStatus(sessionId, { status }));
   },
 };

--- a/frontend/src/features/consultation/ui/QueuePanel.test.tsx
+++ b/frontend/src/features/consultation/ui/QueuePanel.test.tsx
@@ -36,6 +36,18 @@ describe("QueuePanel", () => {
     expect(screen.getByText("카드 오류")).toBeInTheDocument();
   });
 
+  it("고객 이름이 없으면 Unknown을 표시한다", () => {
+    render(
+      <QueuePanel
+        customers={[makeCustomer("1", { name: undefined })]}
+        activeCustomerId={null}
+        onSelectCustomer={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Unknown")).toBeInTheDocument();
+  });
+
   it("클릭하면 onSelectCustomer가 호출된다", () => {
     const onSelect = vi.fn();
     render(

--- a/frontend/src/features/consultation/ui/QueuePanel.tsx
+++ b/frontend/src/features/consultation/ui/QueuePanel.tsx
@@ -4,7 +4,7 @@ import styles from "./queue-panel.module.css";
 
 export interface QueueCustomer {
   id: string;
-  name: string;
+  name?: string;
   channel: string;
   handoffReason: string;
   waitMinutes: number;
@@ -53,7 +53,7 @@ export const QueuePanel: React.FC<QueuePanelProps> = ({
               <div
                 className={`${styles.customerAvatar} ${activeCustomerId === c.id ? styles.customerAvatarActive : ""}`}
               >
-                {c.name.charAt(0)}
+                {c.name?.charAt(0)}
               </div>
               <div className={styles.queueItemInfo}>
                 <div className={styles.customerName}>{c.name}</div>

--- a/frontend/src/features/consultation/ui/QueuePanel.tsx
+++ b/frontend/src/features/consultation/ui/QueuePanel.tsx
@@ -36,37 +36,45 @@ export const QueuePanel: React.FC<QueuePanelProps> = ({
             <p className={styles.emptyText}>대기중인 고객이 없습니다</p>
           </div>
         ) : (
-          customers.map((c) => (
-            <div
-              key={c.id}
-              role="button"
-              tabIndex={0}
-              className={`${styles.queueItem} ${activeCustomerId === c.id ? styles.queueItemActive : ""}`}
-              onClick={() => onSelectCustomer(c.id)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" || e.key === " ") {
-                  e.preventDefault();
-                  onSelectCustomer(c.id);
-                }
-              }}
-            >
+          customers.map((c) => {
+            const displayName = c.name?.trim() || "Unknown";
+            return (
               <div
-                className={`${styles.customerAvatar} ${activeCustomerId === c.id ? styles.customerAvatarActive : ""}`}
+                key={c.id}
+                role="button"
+                tabIndex={0}
+                className={`${styles.queueItem} ${activeCustomerId === c.id ? styles.queueItemActive : ""}`}
+                onClick={() => onSelectCustomer(c.id)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    onSelectCustomer(c.id);
+                  }
+                }}
               >
-                {c.name?.charAt(0)}
+                <div
+                  className={`${styles.customerAvatar} ${activeCustomerId === c.id ? styles.customerAvatarActive : ""}`}
+                >
+                  {displayName.charAt(0)}
+                </div>
+                <div className={styles.queueItemInfo}>
+                  <div className={styles.customerName}>{displayName}</div>
+                  <div className={styles.handoffPreview}>{c.handoffReason}</div>
+                </div>
+                <div
+                  style={{
+                    display: "flex",
+                    flexDirection: "column",
+                    alignItems: "flex-end",
+                    gap: 4,
+                  }}
+                >
+                  <span className={styles.waitTime}>{c.waitMinutes}분 전</span>
+                  {c.hasUnread && <span className={styles.unreadDot}></span>}
+                </div>
               </div>
-              <div className={styles.queueItemInfo}>
-                <div className={styles.customerName}>{c.name}</div>
-                <div className={styles.handoffPreview}>{c.handoffReason}</div>
-              </div>
-              <div
-                style={{ display: "flex", flexDirection: "column", alignItems: "flex-end", gap: 4 }}
-              >
-                <span className={styles.waitTime}>{c.waitMinutes}분 전</span>
-                {c.hasUnread && <span className={styles.unreadDot}></span>}
-              </div>
-            </div>
-          ))
+            );
+          })
         )}
       </div>
     </aside>

--- a/frontend/src/features/user-chat/ui/ChatRoom.test.tsx
+++ b/frontend/src/features/user-chat/ui/ChatRoom.test.tsx
@@ -100,4 +100,46 @@ describe("ChatRoom", () => {
     expect(await screen.findByText("이전 메시지")).toBeInTheDocument();
     expect(listChatMessagesMock).toHaveBeenCalledWith(7);
   });
+
+  it("초기 메시지 로딩 중 도착한 STOMP 메시지를 유지한다", async () => {
+    let resolveInitialMessages: (messages: unknown[]) => void = () => {};
+    listChatMessagesMock.mockReturnValue(
+      new Promise((resolve) => {
+        resolveInitialMessages = resolve;
+      }),
+    );
+
+    render(<ChatRoom sessionId={7} />);
+
+    await waitFor(() => {
+      expect(stompState.subscribe).toHaveBeenCalledWith("/topic/chat.7", expect.any(Function));
+    });
+
+    act(() => {
+      stompState.dispatch("/topic/chat.7", {
+        id: 2,
+        seqNo: 2,
+        senderRole: "ASSISTANT",
+        messageType: "TEXT",
+        content: "실시간 메시지",
+        createdAt: "2026-05-22T08:00:02Z",
+      });
+    });
+    expect(screen.getByText("실시간 메시지")).toBeInTheDocument();
+
+    await act(async () => {
+      resolveInitialMessages([
+        {
+          id: "m1",
+          sessionId: 7,
+          senderType: "USER",
+          content: "이전 메시지",
+          createdAt: "2026-05-22T08:00:01Z",
+        },
+      ]);
+    });
+
+    expect(await screen.findByText("이전 메시지")).toBeInTheDocument();
+    expect(screen.getByText("실시간 메시지")).toBeInTheDocument();
+  });
 });

--- a/frontend/src/features/user-chat/ui/ChatRoom.test.tsx
+++ b/frontend/src/features/user-chat/ui/ChatRoom.test.tsx
@@ -3,21 +3,28 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 import { ChatRoom } from "./ChatRoom";
 
-const stompState = vi.hoisted(() => {
+const { stompState, listChatMessagesMock } = vi.hoisted(() => {
   const callbacks = new Map<string, (msg: unknown) => void>();
   const subscribe = vi.fn((topic: string, cb: (msg: unknown) => void) => {
     callbacks.set(topic, cb);
     return () => {};
   });
   return {
-    connectionStatus: "CONNECTED" as "CONNECTING" | "CONNECTED" | "DISCONNECTED" | "ERROR",
-    sendMessage: vi.fn(),
-    connect: vi.fn(),
-    disconnect: vi.fn(),
-    subscribe,
-    dispatch: (topic: string, msg: unknown) => callbacks.get(topic)?.(msg),
+    listChatMessagesMock: vi.fn(),
+    stompState: {
+      connectionStatus: "CONNECTED" as "CONNECTING" | "CONNECTED" | "DISCONNECTED" | "ERROR",
+      sendMessage: vi.fn(),
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+      subscribe,
+      dispatch: (topic: string, msg: unknown) => callbacks.get(topic)?.(msg),
+    },
   };
 });
+
+vi.mock("@/entities/chat", () => ({
+  listChatMessages: listChatMessagesMock,
+}));
 
 vi.mock("@/shared/lib/websocket", () => ({
   useStomp: () => stompState,
@@ -28,13 +35,15 @@ describe("ChatRoom", () => {
     stompState.connectionStatus = "CONNECTED";
     stompState.sendMessage.mockReset();
     stompState.subscribe.mockClear();
+    listChatMessagesMock.mockReset();
+    listChatMessagesMock.mockResolvedValue([]);
   });
 
-  it("연결 상태와 빈 메시지 상태를 렌더링한다", () => {
+  it("연결 상태와 빈 메시지 상태를 렌더링한다", async () => {
     render(<ChatRoom sessionId={7} />);
 
     expect(screen.getByText("연결됨")).toBeInTheDocument();
-    expect(screen.getByText("아직 메시지가 없습니다. 첫 메시지를 보내보세요!")).toBeInTheDocument();
+    expect(await screen.findByText("아직 메시지가 없습니다. 첫 메시지를 보내보세요!")).toBeInTheDocument();
   });
 
   it("STOMP 메시지 수신 시 메시지 목록에 추가한다", async () => {
@@ -73,5 +82,22 @@ describe("ChatRoom", () => {
     render(<ChatRoom sessionId={7} />);
 
     expect(screen.getByLabelText("메시지 입력")).toBeDisabled();
+  });
+
+  it("초기 메시지를 불러와 렌더링한다", async () => {
+    listChatMessagesMock.mockResolvedValue([
+      {
+        id: "m1",
+        sessionId: 7,
+        senderType: "BOT",
+        content: "이전 메시지",
+        createdAt: "2026-05-22T08:00:00Z",
+      },
+    ]);
+
+    render(<ChatRoom sessionId={7} />);
+
+    expect(await screen.findByText("이전 메시지")).toBeInTheDocument();
+    expect(listChatMessagesMock).toHaveBeenCalledWith(7);
   });
 });

--- a/frontend/src/features/user-chat/ui/ChatRoom.tsx
+++ b/frontend/src/features/user-chat/ui/ChatRoom.tsx
@@ -63,6 +63,18 @@ function toChatMessage(message: ChatMessageResponse, sessionId: number): ChatMes
   };
 }
 
+function compareMessageCreatedAt(a: ChatMessage, b: ChatMessage): number {
+  return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+}
+
+function mergeMessages(currentMessages: ChatMessage[], nextMessages: ChatMessage[]): ChatMessage[] {
+  const byId = new Map<string, ChatMessage>();
+  [...currentMessages, ...nextMessages].forEach((message) => {
+    byId.set(message.id, message);
+  });
+  return Array.from(byId.values()).sort(compareMessageCreatedAt);
+}
+
 export function ChatRoom({ sessionId }: ChatRoomProps) {
   const { connectionStatus, sendMessage, subscribe } = useStomp();
   const [messageState, setMessageState] = useState<{
@@ -84,11 +96,14 @@ export function ChatRoom({ sessionId }: ChatRoomProps) {
       try {
         const initialMessages = await listChatMessages(sessionId);
         if (!cancelled) {
-          setMessageState({
-            sessionId,
-            messages: initialMessages,
-            loading: false,
-            error: null,
+          setMessageState((current) => {
+            const currentMessages = current.sessionId === sessionId ? current.messages : [];
+            return {
+              sessionId,
+              messages: mergeMessages(currentMessages, initialMessages),
+              loading: false,
+              error: null,
+            };
           });
         }
       } catch {
@@ -129,7 +144,7 @@ export function ChatRoom({ sessionId }: ChatRoomProps) {
         }
         return {
           sessionId,
-          messages: [...currentMessages, nextMessage],
+          messages: mergeMessages(currentMessages, [nextMessage]),
           loading: false,
           error: current.sessionId === sessionId ? current.error : null,
         };

--- a/frontend/src/features/user-chat/ui/ChatRoom.tsx
+++ b/frontend/src/features/user-chat/ui/ChatRoom.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import type { ChatMessage } from "@/entities/chat";
+import { listChatMessages, type ChatMessage } from "@/entities/chat";
 import { useStomp } from "@/shared/lib/websocket";
 import { ConnectionStatus } from "./ConnectionStatus";
 import { MessageInput } from "./MessageInput";
@@ -68,8 +68,45 @@ export function ChatRoom({ sessionId }: ChatRoomProps) {
   const [messageState, setMessageState] = useState<{
     sessionId: number;
     messages: ChatMessage[];
-  }>({ sessionId, messages: [] });
-  const messages = messageState.sessionId === sessionId ? messageState.messages : [];
+    loading: boolean;
+    error: string | null;
+  }>({ sessionId, messages: [], loading: true, error: null });
+  const currentMessageState =
+    messageState.sessionId === sessionId
+      ? messageState
+      : { messages: [], loading: true, error: null };
+  const messages = currentMessageState.messages;
+
+  useEffect(() => {
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const initialMessages = await listChatMessages(sessionId);
+        if (!cancelled) {
+          setMessageState({
+            sessionId,
+            messages: initialMessages,
+            loading: false,
+            error: null,
+          });
+        }
+      } catch {
+        if (!cancelled) {
+          setMessageState({
+            sessionId,
+            messages: [],
+            loading: false,
+            error: "메시지를 불러오지 못했습니다.",
+          });
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId]);
 
   useEffect(() => {
     if (connectionStatus !== "CONNECTED") return;
@@ -83,19 +120,33 @@ export function ChatRoom({ sessionId }: ChatRoomProps) {
       setMessageState((current) => {
         const currentMessages = current.sessionId === sessionId ? current.messages : [];
         if (currentMessages.some((message) => message.id === nextMessage.id)) {
-          return { sessionId, messages: currentMessages };
+          return {
+            sessionId,
+            messages: currentMessages,
+            loading: false,
+            error: current.sessionId === sessionId ? current.error : null,
+          };
         }
-        return { sessionId, messages: [...currentMessages, nextMessage] };
+        return {
+          sessionId,
+          messages: [...currentMessages, nextMessage],
+          loading: false,
+          error: current.sessionId === sessionId ? current.error : null,
+        };
       });
     });
     return unsubscribe;
   }, [connectionStatus, sessionId, subscribe]);
 
   return (
-    <section className="flex h-full min-h-[520px] flex-col rounded-lg border border-gray-200 bg-white">
+    <section className="flex h-full min-h-0 flex-col overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
       <ConnectionStatus status={connectionStatus} />
-      <div className="flex-1 border-y border-gray-100">
-        <MessageList messages={messages} />
+      <div className="min-h-0 flex-1 border-y border-gray-100">
+        <MessageList
+          messages={messages}
+          loading={currentMessageState.loading}
+          error={currentMessageState.error}
+        />
       </div>
       <MessageInput
         disabled={connectionStatus !== "CONNECTED"}

--- a/frontend/src/features/user-chat/ui/ConnectionStatus.tsx
+++ b/frontend/src/features/user-chat/ui/ConnectionStatus.tsx
@@ -8,7 +8,7 @@ export interface ConnectionStatusProps {
 export function ConnectionStatus({ status }: ConnectionStatusProps) {
   if (status === "CONNECTING") {
     return (
-      <div className="flex items-center gap-2 px-4 py-2 text-sm text-gray-500">
+      <div className="flex items-center gap-2 px-5 py-3 text-sm text-gray-500">
         <Loader2 className="size-4 animate-spin" aria-hidden="true" />
         연결 중...
       </div>
@@ -17,7 +17,7 @@ export function ConnectionStatus({ status }: ConnectionStatusProps) {
 
   if (status === "CONNECTED") {
     return (
-      <div className="flex items-center gap-2 px-4 py-2 text-sm text-black">
+      <div className="flex items-center gap-2 px-5 py-3 text-sm text-black">
         <Circle className="size-3 fill-gray-900 text-gray-900" aria-hidden="true" />
         연결됨
       </div>
@@ -26,7 +26,7 @@ export function ConnectionStatus({ status }: ConnectionStatusProps) {
 
   if (status === "DISCONNECTED") {
     return (
-      <div className="flex items-center gap-2 px-4 py-2 text-sm text-gray-600">
+      <div className="flex items-center gap-2 px-5 py-3 text-sm text-gray-600">
         <Circle className="size-3 fill-gray-500 text-gray-500" aria-hidden="true" />
         <span>연결 끊김</span>
         <span className="text-gray-500">재연결 중...</span>
@@ -35,7 +35,7 @@ export function ConnectionStatus({ status }: ConnectionStatusProps) {
   }
 
   return (
-    <div className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-black">
+    <div className="flex items-center gap-2 px-5 py-3 text-sm font-medium text-black">
       <Circle className="size-3 fill-black text-black" aria-hidden="true" />
       연결 오류
     </div>

--- a/frontend/src/features/user-chat/ui/MessageInput.tsx
+++ b/frontend/src/features/user-chat/ui/MessageInput.tsx
@@ -18,12 +18,19 @@ export function MessageInput({ onSend, disabled = false }: MessageInputProps) {
   };
 
   return (
-    <div className="flex gap-2 border-t border-gray-200 bg-white p-4">
+    <div
+      className="flex gap-3 border-t border-gray-200 bg-white"
+      style={{ padding: "14px 16px" }}
+    >
       <input
         aria-label="메시지 입력"
-        className="min-h-11 flex-1 rounded-full border border-gray-300 bg-white px-4 text-sm text-black outline-none transition focus:border-black focus:ring-3 focus:ring-black/10 disabled:pointer-events-none disabled:bg-gray-100 disabled:text-gray-500"
+        className="flex-1 rounded-full border border-gray-300 bg-white text-sm text-black outline-none transition focus:border-black focus:ring-3 focus:ring-black/10 disabled:pointer-events-none disabled:bg-gray-100 disabled:text-gray-500"
         disabled={disabled}
         placeholder="메시지를 입력하세요"
+        style={{
+          minHeight: 48,
+          padding: "0 18px",
+        }}
         value={content}
         onChange={(event) => setContent(event.target.value)}
         onKeyDown={(event) => {
@@ -36,8 +43,12 @@ export function MessageInput({ onSend, disabled = false }: MessageInputProps) {
       <button
         type="button"
         aria-label="메시지 보내기"
-        className="inline-flex size-11 items-center justify-center rounded-full bg-black text-white outline-none transition hover:bg-gray-900 focus:ring-3 focus:ring-black/15 disabled:pointer-events-none disabled:bg-gray-300 disabled:text-white"
+        className="inline-flex items-center justify-center rounded-full bg-black text-white outline-none transition hover:bg-gray-900 focus:ring-3 focus:ring-black/15 disabled:pointer-events-none disabled:bg-gray-300 disabled:text-white"
         disabled={disabled}
+        style={{
+          height: 48,
+          width: 48,
+        }}
         onClick={submit}
       >
         <Send className="size-4" aria-hidden="true" />

--- a/frontend/src/features/user-chat/ui/MessageList.test.tsx
+++ b/frontend/src/features/user-chat/ui/MessageList.test.tsx
@@ -46,8 +46,8 @@ describe("MessageList", () => {
 
     expect(screen.getByText("배송이 지연됐어요")).not.toBeNull();
     expect(screen.getByText("확인해 드리겠습니다")).not.toBeNull();
-    expect(screen.getByTestId("message-m1").classList.contains("justify-start")).toBe(true);
-    expect(screen.getByTestId("message-m2").classList.contains("justify-end")).toBe(true);
+    expect(screen.getByTestId("message-m1").classList.contains("justify-end")).toBe(true);
+    expect(screen.getByTestId("message-m2").classList.contains("justify-start")).toBe(true);
   });
 
   it("새 메시지가 렌더링되면 하단으로 스크롤한다", () => {

--- a/frontend/src/features/user-chat/ui/MessageList.tsx
+++ b/frontend/src/features/user-chat/ui/MessageList.tsx
@@ -31,15 +31,15 @@ export function MessageList({ messages, loading = false, error = null }: Message
 
   if (error) {
     return (
-      <div className="flex min-h-[400px] items-center justify-center overflow-y-auto bg-white p-6 text-sm text-black">
-        <div className="rounded-lg border border-black px-4 py-3">{error}</div>
+      <div className="flex h-full min-h-0 items-center justify-center overflow-y-auto bg-white p-8 text-sm text-black">
+        <div className="rounded-lg border border-black px-5 py-4">{error}</div>
       </div>
     );
   }
 
   if (loading) {
     return (
-      <div className="flex min-h-[400px] items-center justify-center overflow-y-auto bg-white p-6 text-sm text-gray-500">
+      <div className="flex h-full min-h-0 items-center justify-center overflow-y-auto bg-white p-8 text-sm text-gray-500">
         <Loader2 className="mr-2 size-4 animate-spin" aria-hidden="true" />
         메시지를 불러오는 중입니다...
       </div>
@@ -48,32 +48,41 @@ export function MessageList({ messages, loading = false, error = null }: Message
 
   if (messages.length === 0) {
     return (
-      <div className="flex min-h-[400px] items-center justify-center overflow-y-auto bg-white p-6 text-sm text-gray-500">
+      <div className="flex h-full min-h-0 items-center justify-center overflow-y-auto bg-white p-8 text-sm text-gray-500">
         아직 메시지가 없습니다. 첫 메시지를 보내보세요!
       </div>
     );
   }
 
   return (
-    <div className="min-h-[400px] overflow-y-auto bg-white p-4">
-      <div className="flex flex-col gap-4">
+    <div className="h-full min-h-0 overflow-y-auto bg-white px-6 py-5">
+      <div className="flex flex-col gap-5">
         {messages.map((message) => {
           const isUser = message.senderType === "USER";
           return (
             <div
               key={message.id}
               data-testid={`message-${message.id}`}
-              className={`flex ${isUser ? "justify-start" : "justify-end"}`}
+              className={`flex ${isUser ? "justify-end" : "justify-start"}`}
             >
-              <div className={`max-w-[72%] ${isUser ? "text-left" : "text-right"}`}>
-                <div className="mb-1 flex items-baseline gap-2 text-xs text-gray-500">
+              <div className={`max-w-[72%] ${isUser ? "text-right" : "text-left"}`}>
+                <div
+                  className={`flex items-baseline gap-2 text-xs text-gray-500 ${
+                    isUser ? "justify-end" : "justify-start"
+                  }`}
+                  style={{ marginBottom: 6 }}
+                >
                   <span>{resolveSenderName(message)}</span>
                   <time dateTime={message.createdAt}>{formatMessageTime(message.createdAt)}</time>
                 </div>
                 <div
-                  className={`rounded-lg p-3 text-sm leading-6 ${
+                  className={`text-sm leading-6 ${
                     isUser ? "bg-gray-100 text-black" : "bg-black text-white"
                   }`}
+                  style={{
+                    borderRadius: 8,
+                    padding: "10px 14px",
+                  }}
                 >
                   {message.content}
                 </div>

--- a/frontend/src/pages/consultation/ui/ConsultationPage.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.tsx
@@ -60,6 +60,7 @@ export const ConsultationPage: React.FC = () => {
   const [queue, setQueue] = useState<QueueCustomer[]>([]);
   const [activeCustomerId, setActiveCustomerId] = useState<string | null>(null);
   const [messages, setMessages] = useState<UiChatMessage[]>([]);
+  const [messagesCustomerId, setMessagesCustomerId] = useState<string | null>(null);
   const [memos, setMemos] = useState<Record<string, string>>({});
   const [statuses, setStatuses] = useState<Record<string, string>>({});
   const [selectedMessageId, setSelectedMessageId] = useState<string | null>(null);
@@ -69,7 +70,8 @@ export const ConsultationPage: React.FC = () => {
 
   const activeCustomer = queue.find((c) => c.id === activeCustomerId) || null;
   const activeCustomerName = activeCustomer?.name?.trim() || "Unknown";
-  const visibleMessages = activeCustomerId ? messages : [];
+  const visibleMessages =
+    activeCustomer && messagesCustomerId === activeCustomer.id ? messages : [];
   const selectedMessage = visibleMessages.find((m) => m.id === selectedMessageId) || null;
 
   useEffect(() => {
@@ -142,6 +144,7 @@ export const ConsultationPage: React.FC = () => {
             timestamp: formatTime(m.createdAt ?? ""),
           })),
         );
+        setMessagesCustomerId(activeCustomerId);
       } catch (error) {
         if (!cancelled) {
           console.error("Failed to load messages:", error);
@@ -164,6 +167,7 @@ export const ConsultationPage: React.FC = () => {
     const unsubscribe = subscribe(topic, (raw) => {
       const msg = raw as RealtimeChatMessage;
       if (msg.senderRole === "COUNSELOR") {
+        setMessagesCustomerId(activeCustomerId);
         setMessages((prev) => {
           const temps = [...pendingIdsRef.current];
           if (temps.length > 0) {
@@ -190,6 +194,7 @@ export const ConsultationPage: React.FC = () => {
         return;
       }
       const msgId = String(msg.id);
+      setMessagesCustomerId(activeCustomerId);
       setMessages((prev) => {
         if (prev.some((m) => m.id === msgId)) return prev;
         return [
@@ -212,6 +217,8 @@ export const ConsultationPage: React.FC = () => {
   const handleSelectCustomer = (id: string) => {
     setActiveCustomerId(id);
     setSelectedMessageId(null);
+    setMessages([]);
+    setMessagesCustomerId(null);
     if (!statuses[id]) {
       setStatuses((prev) => ({ ...prev, [id]: "IN_PROGRESS" }));
     }
@@ -239,6 +246,7 @@ export const ConsultationPage: React.FC = () => {
         timestamp: formatTime(new Date().toISOString()),
       };
       setMessages((prev) => [...prev, optimisticMsg]);
+      setMessagesCustomerId(targetId);
       pendingIdsRef.current.add(optimisticMsg.id);
       setSelectedMessageId(null);
 
@@ -256,6 +264,8 @@ export const ConsultationPage: React.FC = () => {
       loadQueue();
       setActiveCustomerId(null);
       setSelectedMessageId(null);
+      setMessages([]);
+      setMessagesCustomerId(null);
     } catch {
       toast.error("세션 종료 실패");
     }

--- a/frontend/src/pages/consultation/ui/ConsultationPage.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.tsx
@@ -68,7 +68,9 @@ export const ConsultationPage: React.FC = () => {
   const tempCounterRef = useRef(0);
 
   const activeCustomer = queue.find((c) => c.id === activeCustomerId) || null;
-  const selectedMessage = messages.find((m) => m.id === selectedMessageId) || null;
+  const activeCustomerName = activeCustomer?.name?.trim() || "Unknown";
+  const visibleMessages = activeCustomerId ? messages : [];
+  const selectedMessage = visibleMessages.find((m) => m.id === selectedMessageId) || null;
 
   useEffect(() => {
     setTopbarRight(<StatusRight />);
@@ -78,13 +80,6 @@ export const ConsultationPage: React.FC = () => {
       setCrumbs([]);
     };
   }, [setTopbarRight, setCrumbs]);
-
-  // Sync selectedMessageId with messages list (e.g., after polling refresh)
-  useEffect(() => {
-    if (selectedMessageId && !messages.some((m) => m.id === selectedMessageId)) {
-      setSelectedMessageId(null);
-    }
-  }, [messages, selectedMessageId]);
 
   const loadQueue = useCallback(async () => {
     try {
@@ -113,14 +108,21 @@ export const ConsultationPage: React.FC = () => {
   }, []);
 
   useEffect(() => {
-    loadQueue();
-    const interval = setInterval(loadQueue, 5000);
-    return () => clearInterval(interval);
+    const initialLoad = window.setTimeout(() => {
+      void loadQueue();
+    }, 0);
+    const interval = window.setInterval(() => {
+      void loadQueue();
+    }, 5000);
+    return () => {
+      window.clearTimeout(initialLoad);
+      window.clearInterval(interval);
+    };
   }, [loadQueue]);
 
   useEffect(() => {
     if (!activeCustomerId) {
-      setMessages([]);
+      pendingIdsRef.current.clear();
       return;
     }
 
@@ -254,7 +256,7 @@ export const ConsultationPage: React.FC = () => {
       loadQueue();
       setActiveCustomerId(null);
       setSelectedMessageId(null);
-    } catch (err) {
+    } catch {
       toast.error("세션 종료 실패");
     }
   };
@@ -276,10 +278,10 @@ export const ConsultationPage: React.FC = () => {
           >
             <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
               <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
-                <Avatar initial={activeCustomer.name.charAt(0)} tone="warn" size={36} />
+                <Avatar initial={activeCustomerName.charAt(0)} tone="warn" size={36} />
                 <div>
                   <div style={{ fontSize: 14, fontWeight: 700, color: "var(--ink)" }}>
-                    {activeCustomer.name} 고객
+                    {activeCustomerName} 고객
                   </div>
                   <Mono style={{ fontSize: 10, color: "var(--ink-3)" }}>
                     {activeCustomer.channel ?? ""} · {activeCustomer.waitMinutes}분 대기 중
@@ -335,9 +337,9 @@ export const ConsultationPage: React.FC = () => {
 
         <div style={{ flex: 1, overflow: "auto" }}>
           <ChatPanel
-            customerName={activeCustomer?.name || null}
+            customerName={activeCustomer ? activeCustomerName : null}
             channel={activeCustomer?.channel || null}
-            messages={messages}
+            messages={visibleMessages}
             onSendMessage={handleSendMessage}
             selectedMessageId={selectedMessageId}
             onSelectMessage={setSelectedMessageId}
@@ -386,7 +388,7 @@ export const ConsultationPage: React.FC = () => {
           customer={
             activeCustomer
               ? {
-                  name: activeCustomer.name,
+                  name: activeCustomerName,
                   channel: activeCustomer.channel,
                 }
               : null

--- a/frontend/src/pages/consultation/ui/sections/Message.tsx
+++ b/frontend/src/pages/consultation/ui/sections/Message.tsx
@@ -12,6 +12,7 @@ export interface MessageProps {
 
 export function Message({ variant, name, time, text }: MessageProps) {
   const isRight = variant === "bot" || variant === "agent";
+  const displayName = name?.trim() || "Unknown";
 
   let avatarInitial: string;
   let avatarTone: AvatarTone;
@@ -19,7 +20,7 @@ export function Message({ variant, name, time, text }: MessageProps) {
   let bodyBorder: string | undefined;
 
   if (variant === "customer") {
-    avatarInitial = name.charAt(0);
+    avatarInitial = displayName.charAt(0);
     avatarTone = "warn";
     bodyBg = "var(--paper-2)";
     bodyBorder = undefined;
@@ -57,7 +58,9 @@ export function Message({ variant, name, time, text }: MessageProps) {
             justifyContent: isRight ? "flex-end" : "flex-start",
           }}
         >
-          <span style={{ fontSize: 12, fontWeight: 600, color: "var(--ink)" }}>{name}</span>
+          <span style={{ fontSize: 12, fontWeight: 600, color: "var(--ink)" }}>
+            {displayName}
+          </span>
           <Mono style={{ fontSize: 10, color: "var(--ink-3)" }}>{time}</Mono>
         </div>
         <div

--- a/frontend/src/pages/consultation/ui/sections/Queue.tsx
+++ b/frontend/src/pages/consultation/ui/sections/Queue.tsx
@@ -23,6 +23,7 @@ export function Queue({
     <div>
       {items.map((item) => {
         const isActive = item.id === activeId;
+        const displayName = item.name?.trim() || "Unknown";
         return (
           <div
             key={item.id}
@@ -44,9 +45,9 @@ export function Queue({
             }}
           >
             <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 6 }}>
-              <Avatar initial={item.name.charAt(0)} size={28} />
+              <Avatar initial={displayName.charAt(0)} size={28} />
               <span style={{ fontSize: 13, fontWeight: 700, color: "var(--ink)" }}>
-                {item.name}
+                {displayName}
               </span>
               <Mono style={{ fontSize: 10, color: "var(--ink-3)" }}>{item.channel}</Mono>
               <Mono style={{ fontSize: 10, color: "var(--ink-3)", marginLeft: "auto" }}>

--- a/frontend/src/pages/user-chat/ui/UserChatPage.test.tsx
+++ b/frontend/src/pages/user-chat/ui/UserChatPage.test.tsx
@@ -1,18 +1,16 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { UserChatPage } from "./UserChatPage";
 
-const { createChatSessionMock, routeState } = vi.hoisted(() => ({
-  createChatSessionMock: vi.fn(),
+const { registerDemoChatSessionMock, sendDemoChatMessageMock, routeState } = vi.hoisted(() => ({
+  registerDemoChatSessionMock: vi.fn(),
+  sendDemoChatMessageMock: vi.fn(),
   routeState: { workspaceId: "42" as string | undefined },
 }));
 
 vi.mock("@/entities/chat", () => ({
-  createChatSession: createChatSessionMock,
-}));
-
-vi.mock("@/features/user-chat", () => ({
-  ChatRoom: ({ sessionId }: { sessionId: number }) => <div>ChatRoom session {sessionId}</div>,
+  registerDemoChatSession: registerDemoChatSessionMock,
+  sendDemoChatMessage: sendDemoChatMessageMock,
 }));
 
 vi.mock("react-router-dom", async () => {
@@ -20,58 +18,98 @@ vi.mock("react-router-dom", async () => {
   return {
     ...actual,
     useParams: () => routeState,
-    useOutletContext: () => ({ setTopbarRight: vi.fn(), setCrumbs: vi.fn() }),
   };
 });
 
 describe("UserChatPage", () => {
   beforeEach(() => {
     routeState.workspaceId = "42";
-    createChatSessionMock.mockReset();
-  });
-
-  it("mount 시 URL의 workspaceId로 채팅 세션을 생성한다", async () => {
-    createChatSessionMock.mockResolvedValue({
-      id: 7,
+    window.localStorage.clear();
+    registerDemoChatSessionMock.mockReset();
+    sendDemoChatMessageMock.mockReset();
+    registerDemoChatSessionMock.mockResolvedValue({
+      id: "77",
       status: "OPEN",
-      channel: "WEB",
       startedAt: "2026-05-22T00:00:00Z",
+      messages: [
+        {
+          id: "backend-greeting-77",
+          sessionId: 77,
+          content: "안녕하세요, 김민지님. 무엇을 도와드릴까요?",
+          senderType: "BOT",
+          createdAt: "2026-05-22T00:00:00Z",
+        },
+      ],
     });
-
-    render(<UserChatPage />);
-
-    expect(screen.getByText("채팅방을 여는 중입니다...")).not.toBeNull();
-    await waitFor(() => expect(createChatSessionMock).toHaveBeenCalledWith(42));
+    sendDemoChatMessageMock.mockResolvedValue([
+      {
+        id: "81",
+        sessionId: 77,
+        content: "Hello",
+        senderType: "USER",
+        createdAt: "2026-05-22T00:00:01Z",
+      },
+      {
+        id: "82",
+        sessionId: 77,
+        content: "LLM 응답입니다.",
+        senderType: "BOT",
+        createdAt: "2026-05-22T00:00:02Z",
+      },
+    ]);
   });
 
-  it("생성된 session id를 ChatRoom에 전달한다", async () => {
-    createChatSessionMock.mockResolvedValue({
-      id: 9,
-      status: "OPEN",
-      channel: "WEB",
-      startedAt: "2026-05-22T00:00:00Z",
-    });
-
+  it("이름 입력 후 URL의 workspaceId와 이름으로 데모 세션을 생성한다", async () => {
     render(<UserChatPage />);
 
-    expect(await screen.findByText("ChatRoom session 9")).not.toBeNull();
+    expect(screen.getByRole("form", { name: "채팅 사용자 이름 입력" })).not.toBeNull();
+    fireEvent.change(screen.getByLabelText("이름"), { target: { value: "김민지" } });
+    fireEvent.click(screen.getByRole("button", { name: "채팅 시작" }));
+
+    expect(await screen.findByText("김민지 · Session #77")).not.toBeNull();
+    expect(screen.getByText("안녕하세요, 김민지님. 무엇을 도와드릴까요?")).not.toBeNull();
+    expect(registerDemoChatSessionMock).toHaveBeenCalledWith(42, "김민지");
   });
 
-  it("세션 생성 실패 시 에러 메시지를 표시한다", async () => {
-    createChatSessionMock.mockRejectedValue(new Error("failed"));
+  it("같은 이름으로 다시 진입하면 저장된 세션 메시지를 유지한다", async () => {
+    const firstRender = render(<UserChatPage />);
+    fireEvent.change(screen.getByLabelText("이름"), { target: { value: "김민지" } });
+    fireEvent.click(screen.getByRole("button", { name: "채팅 시작" }));
 
+    const input = await screen.findByLabelText("메시지 입력");
+    fireEvent.change(input, { target: { value: "Hello" } });
+    fireEvent.click(screen.getByRole("button", { name: "메시지 보내기" }));
+    expect(await screen.findByText("Hello")).not.toBeNull();
+    expect(await screen.findByText("LLM 응답입니다.")).not.toBeNull();
+    expect(sendDemoChatMessageMock).toHaveBeenCalledWith(42, "77", "Hello");
+
+    firstRender.unmount();
+    registerDemoChatSessionMock.mockClear();
     render(<UserChatPage />);
 
-    expect(await screen.findByText("채팅 세션을 시작할 수 없습니다.")).not.toBeNull();
+    fireEvent.change(screen.getByLabelText("이름"), { target: { value: "김민지" } });
+    fireEvent.click(screen.getByRole("button", { name: "채팅 시작" }));
+
+    expect(await screen.findByText("Hello")).not.toBeNull();
+    expect(screen.getByText("김민지 · Session #77")).not.toBeNull();
+    expect(registerDemoChatSessionMock).not.toHaveBeenCalled();
+  });
+
+  it("이름이 비어 있으면 세션을 생성하지 않는다", async () => {
+    render(<UserChatPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: "채팅 시작" }));
+
+    expect(await screen.findByText("이름을 입력해 주세요.")).not.toBeNull();
+    expect(window.localStorage.length).toBe(0);
   });
 
   it("유효하지 않은 workspaceId에서 에러 메시지를 표시한다", async () => {
     routeState.workspaceId = undefined;
-    createChatSessionMock.mockReset();
 
     render(<UserChatPage />);
 
     expect(await screen.findByText("유효하지 않은 워크스페이스입니다.")).not.toBeNull();
-    expect(createChatSessionMock).not.toHaveBeenCalled();
+    expect(window.localStorage.length).toBe(0);
   });
 });

--- a/frontend/src/pages/user-chat/ui/UserChatPage.test.tsx
+++ b/frontend/src/pages/user-chat/ui/UserChatPage.test.tsx
@@ -95,6 +95,21 @@ describe("UserChatPage", () => {
     expect(registerDemoChatSessionMock).not.toHaveBeenCalled();
   });
 
+  it("메시지 전송 실패 시 optimistic 메시지를 되돌린다", async () => {
+    sendDemoChatMessageMock.mockRejectedValueOnce(new Error("LLM failed"));
+
+    render(<UserChatPage />);
+    fireEvent.change(screen.getByLabelText("이름"), { target: { value: "김민지" } });
+    fireEvent.click(screen.getByRole("button", { name: "채팅 시작" }));
+
+    const input = await screen.findByLabelText("메시지 입력");
+    fireEvent.change(input, { target: { value: "Hello" } });
+    fireEvent.click(screen.getByRole("button", { name: "메시지 보내기" }));
+
+    expect(await screen.findByText("응답을 생성하지 못했습니다. 잠시 후 다시 시도해 주세요.")).not.toBeNull();
+    expect(screen.queryByText("Hello")).toBeNull();
+  });
+
   it("이름이 비어 있으면 세션을 생성하지 않는다", async () => {
     render(<UserChatPage />);
 

--- a/frontend/src/pages/user-chat/ui/UserChatPage.tsx
+++ b/frontend/src/pages/user-chat/ui/UserChatPage.tsx
@@ -1,61 +1,216 @@
-import { useEffect, useState } from "react";
-import { useOutletContext, useParams } from "react-router-dom";
-import { createChatSession } from "@/entities/chat";
-import type { ChatSession } from "@/entities/chat";
-import { ChatRoom } from "@/features/user-chat";
-import type { ShellContext } from "@/shared/ui/ostone/chrome";
+import { type FormEvent, useState } from "react";
+import { useParams } from "react-router-dom";
+import { registerDemoChatSession, sendDemoChatMessage } from "@/entities/chat";
+import type { ChatMessage, DemoChatSession } from "@/entities/chat";
+import { ConnectionStatus, MessageInput, MessageList } from "@/features/user-chat";
+
+const DEMO_SESSION_STORAGE_PREFIX = "ostone:demo-chat-session";
+
+function createStorageKey(workspaceId: number, customerName: string): string {
+  const normalizedName = customerName.trim().toLowerCase();
+  return `${DEMO_SESSION_STORAGE_PREFIX}:${workspaceId}:${encodeURIComponent(normalizedName)}`;
+}
+
+function isDemoChatSession(value: unknown): value is DemoChatSession {
+  if (!value || typeof value !== "object") return false;
+
+  const candidate = value as Partial<DemoChatSession>;
+  return (
+    typeof candidate.id === "string" &&
+    typeof candidate.status === "string" &&
+    typeof candidate.startedAt === "string" &&
+    Array.isArray(candidate.messages)
+  );
+}
+
+function isBackendRegisteredSession(session: DemoChatSession): boolean {
+  return Number.isFinite(Number(session.id));
+}
+
+function readStoredSession(workspaceId: number, customerName: string): DemoChatSession | null {
+  if (typeof window === "undefined") return null;
+
+  const raw = window.localStorage.getItem(createStorageKey(workspaceId, customerName));
+  if (!raw) return null;
+
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return isDemoChatSession(parsed) && isBackendRegisteredSession(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeStoredSession(
+  workspaceId: number,
+  customerName: string,
+  session: DemoChatSession,
+): void {
+  if (typeof window === "undefined") return;
+
+  window.localStorage.setItem(
+    createStorageKey(workspaceId, customerName),
+    JSON.stringify(session),
+  );
+}
+
+async function getOrCreateStoredSession(
+  workspaceId: number,
+  customerName: string,
+): Promise<DemoChatSession> {
+  const storedSession = readStoredSession(workspaceId, customerName);
+  if (storedSession) return storedSession;
+
+  const nextSession = await registerDemoChatSession(workspaceId, customerName);
+  writeStoredSession(workspaceId, customerName, nextSession);
+  return nextSession;
+}
 
 export function UserChatPage() {
-  useOutletContext<ShellContext>();
   const { workspaceId: raw } = useParams<{ workspaceId: string }>();
   const workspaceId = Number(raw);
+  const [draftName, setDraftName] = useState("");
+  const [customerName, setCustomerName] = useState<string | null>(null);
+  const [nameError, setNameError] = useState<string | null>(null);
+  const [isSending, setIsSending] = useState(false);
+  const [messageError, setMessageError] = useState<string | null>(null);
   const [chatState, setChatState] = useState<{
     workspaceId: number | null;
-    session: ChatSession | null;
+    customerName: string | null;
+    session: DemoChatSession | null;
     error: string | null;
-  }>({ workspaceId: null, session: null, error: null });
+  }>({ workspaceId: null, customerName: null, session: null, error: null });
   const isInvalidWorkspace = !raw || Number.isNaN(workspaceId);
   const activeChatState =
-    chatState.workspaceId === workspaceId ? chatState : { session: null, error: null };
+    chatState.workspaceId === workspaceId && chatState.customerName === customerName
+      ? chatState
+      : { session: null, error: null };
 
-  useEffect(() => {
-    if (isInvalidWorkspace) return;
+  const handleNameSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
 
-    let cancelled = false;
+    const nextName = draftName.trim();
+    if (!nextName) {
+      setNameError("이름을 입력해 주세요.");
+      return;
+    }
 
-    (async () => {
-      try {
-        const nextSession = await createChatSession(workspaceId);
-        if (!cancelled) {
-          setChatState({ workspaceId, session: nextSession, error: null });
-        }
-      } catch {
-        if (!cancelled) {
-          setChatState({
-            workspaceId,
-            session: null,
-            error: "채팅 세션을 시작할 수 없습니다.",
-          });
-        }
-      }
-    })();
+    setNameError(null);
+    setCustomerName(nextName);
+    setChatState({ workspaceId, customerName: nextName, session: null, error: null });
+    try {
+      const nextSession = await getOrCreateStoredSession(workspaceId, nextName);
+      setChatState({ workspaceId, customerName: nextName, session: nextSession, error: null });
+    } catch {
+      setChatState({
+        workspaceId,
+        customerName: nextName,
+        session: null,
+        error: "채팅 세션을 시작할 수 없습니다.",
+      });
+    }
+  };
 
-    return () => {
-      cancelled = true;
+  const handleSendMessage = async (content: string) => {
+    const activeSession = activeChatState.session;
+    if (!activeSession || !customerName || isSending) return;
+
+    const now = new Date().toISOString();
+    const userMessage: ChatMessage = {
+      id: `local-user-${Date.now()}`,
+      sessionId: 0,
+      content,
+      senderType: "USER",
+      senderName: customerName,
+      createdAt: now,
     };
-  }, [isInvalidWorkspace, workspaceId]);
+
+    setMessageError(null);
+    setIsSending(true);
+    setChatState((current) => {
+      if (current.session?.id !== activeSession.id) return current;
+      const nextSession = {
+        ...activeSession,
+        messages: [...activeSession.messages, userMessage],
+      };
+      writeStoredSession(workspaceId, customerName, nextSession);
+      return {
+        ...current,
+        session: nextSession,
+      };
+    });
+
+    try {
+      const savedMessages = await sendDemoChatMessage(workspaceId, activeSession.id, content);
+      const namedMessages = savedMessages.map((message) =>
+        message.senderType === "USER" ? { ...message, senderName: customerName } : message,
+      );
+
+      setChatState((current) => {
+        if (current.session?.id !== activeSession.id) return current;
+        const nextSession = {
+          ...current.session,
+          messages: [
+            ...current.session.messages.filter((message) => message.id !== userMessage.id),
+            ...namedMessages,
+          ],
+        };
+        writeStoredSession(workspaceId, customerName, nextSession);
+        return {
+          ...current,
+          session: nextSession,
+        };
+      });
+    } catch {
+      setMessageError("응답을 생성하지 못했습니다. 잠시 후 다시 시도해 주세요.");
+    } finally {
+      setIsSending(false);
+    }
+  };
 
   if (isInvalidWorkspace) {
     return (
-      <div className="flex h-full items-center justify-center p-8 text-sm">
+      <div className="flex min-h-screen items-center justify-center bg-white p-8 text-sm text-black">
         유효하지 않은 워크스페이스입니다.
+      </div>
+    );
+  }
+
+  if (!customerName) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-white p-8 text-black">
+        <form
+          onSubmit={handleNameSubmit}
+          className="w-full max-w-[360px]"
+          aria-label="채팅 사용자 이름 입력"
+        >
+          <h1 className="text-[22px] font-medium text-black">사용자 채팅</h1>
+          <label className="mt-6 block text-sm text-black" htmlFor="chat-customer-name">
+            이름
+          </label>
+          <input
+            id="chat-customer-name"
+            value={draftName}
+            onChange={(event) => setDraftName(event.target.value)}
+            className="mt-2 h-12 w-full rounded-full border border-gray-300 bg-white px-5 text-sm text-black outline-none focus:border-black focus:ring-2 focus:ring-black/10"
+            placeholder="이름을 입력하세요"
+            autoComplete="name"
+          />
+          {nameError && <p className="mt-2 text-xs text-red-600">{nameError}</p>}
+          <button
+            type="submit"
+            className="mt-5 h-12 w-full rounded-full bg-black px-5 text-sm text-white"
+          >
+            채팅 시작
+          </button>
+        </form>
       </div>
     );
   }
 
   if (activeChatState.error) {
     return (
-      <div className="flex h-full items-center justify-center p-8 text-sm">
+      <div className="flex min-h-screen items-center justify-center bg-white p-8 text-sm text-black">
         {activeChatState.error}
       </div>
     );
@@ -63,15 +218,50 @@ export function UserChatPage() {
 
   if (!activeChatState.session) {
     return (
-      <div className="flex h-full items-center justify-center p-8 text-sm text-gray-500">
+      <div className="flex min-h-screen items-center justify-center bg-white p-8 text-sm text-gray-500">
         채팅방을 여는 중입니다...
       </div>
     );
   }
 
   return (
-    <div className="flex h-full flex-col">
-      <ChatRoom sessionId={activeChatState.session.id} />
+    <div
+      className="flex h-screen min-h-0 flex-col overflow-hidden bg-white"
+      style={{ padding: "20px 24px 24px" }}
+    >
+      <header
+        className="flex shrink-0 items-center justify-between border-b border-gray-200"
+        style={{ padding: "0 0 16px" }}
+      >
+        <div>
+          <h1 className="text-[18px] font-medium text-black">사용자 채팅</h1>
+          <p className="mt-1 text-xs text-gray-500">
+            {customerName} · Session #{activeChatState.session.id}
+          </p>
+        </div>
+        <span className="rounded-full border border-gray-200 px-3 py-1 text-xs text-gray-600">
+          {activeChatState.session.status}
+        </span>
+      </header>
+      <div className="min-h-0 flex-1" style={{ paddingTop: 16 }}>
+        <section className="flex h-full min-h-0 flex-col overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+          <ConnectionStatus status="CONNECTED" />
+          <div className="min-h-0 flex-1 border-y border-gray-100">
+            <MessageList messages={activeChatState.session.messages} />
+          </div>
+          {messageError && (
+            <div className="border-t border-red-100 bg-red-50 px-4 py-3 text-xs text-red-700">
+              {messageError}
+            </div>
+          )}
+          <MessageInput
+            onSend={(content) => {
+              void handleSendMessage(content);
+            }}
+            disabled={isSending}
+          />
+        </section>
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/user-chat/ui/UserChatPage.tsx
+++ b/frontend/src/pages/user-chat/ui/UserChatPage.tsx
@@ -1,4 +1,4 @@
-import { type FormEvent, useState } from "react";
+import { type FormEvent, useRef, useState } from "react";
 import { useParams } from "react-router-dom";
 import { registerDemoChatSession, sendDemoChatMessage } from "@/entities/chat";
 import type { ChatMessage, DemoChatSession } from "@/entities/chat";
@@ -74,6 +74,7 @@ export function UserChatPage() {
   const [nameError, setNameError] = useState<string | null>(null);
   const [isSending, setIsSending] = useState(false);
   const [messageError, setMessageError] = useState<string | null>(null);
+  const nameRequestIdRef = useRef(0);
   const [chatState, setChatState] = useState<{
     workspaceId: number | null;
     customerName: string | null;
@@ -95,13 +96,16 @@ export function UserChatPage() {
       return;
     }
 
+    const requestId = ++nameRequestIdRef.current;
     setNameError(null);
     setCustomerName(nextName);
     setChatState({ workspaceId, customerName: nextName, session: null, error: null });
     try {
       const nextSession = await getOrCreateStoredSession(workspaceId, nextName);
+      if (requestId !== nameRequestIdRef.current) return;
       setChatState({ workspaceId, customerName: nextName, session: nextSession, error: null });
     } catch {
+      if (requestId !== nameRequestIdRef.current) return;
       setChatState({
         workspaceId,
         customerName: nextName,
@@ -162,6 +166,18 @@ export function UserChatPage() {
         };
       });
     } catch {
+      setChatState((current) => {
+        if (current.session?.id !== activeSession.id) return current;
+        const nextSession = {
+          ...current.session,
+          messages: current.session.messages.filter((message) => message.id !== userMessage.id),
+        };
+        writeStoredSession(workspaceId, customerName, nextSession);
+        return {
+          ...current,
+          session: nextSession,
+        };
+      });
       setMessageError("응답을 생성하지 못했습니다. 잠시 후 다시 시도해 주세요.");
     } finally {
       setIsSending(false);

--- a/frontend/src/pages/workspace/ui/WorkspaceLayout.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceLayout.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { useMemo, useState, type ReactNode } from "react";
 import { Navigate, Outlet, useLocation, useParams } from "react-router-dom";
 import type { ShellContext, SidebarActive } from "@/shared/ui/ostone/chrome";
 
@@ -28,9 +28,6 @@ export function WorkspaceLayout() {
   const basePath = parsedWorkspaceId
     ? `/workspaces/${parsedWorkspaceId}`
     : "/workspaces";
-  const [workspace, setWorkspace] = useState<WorkspaceResponse | null>(null);
-  const [isLoading, setIsLoading] = useState(parsedWorkspaceId !== null);
-  const [error, setError] = useState("");
   const [topbarRight, setTopbarRight] = useState<ReactNode>(null);
   const [crumbs, setCrumbs] = useState<string[]>([]);
   const active = getActiveFromPath(location.pathname);
@@ -43,22 +40,14 @@ export function WorkspaceLayout() {
   } = useGetWorkspace(parsedWorkspaceId ?? 0, {
     query: { enabled: parsedWorkspaceId !== null },
   });
-
-  useEffect(() => {
-    if (fetchedWorkspace) {
-      setWorkspace(fetchedWorkspace as unknown as WorkspaceResponse);
-      setError("");
-    } else if (parsedWorkspaceId !== null && fetchError) {
-      setError(mapWorkspaceActionError(fetchError));
-      setWorkspace(null);
-    }
-  }, [fetchedWorkspace, fetchError, parsedWorkspaceId]);
-
-  useEffect(() => {
-    if (!isFetchingWorkspace && parsedWorkspaceId !== null) {
-      setIsLoading(false);
-    }
-  }, [isFetchingWorkspace, parsedWorkspaceId]);
+  const workspace = fetchedWorkspace
+    ? (fetchedWorkspace as unknown as WorkspaceResponse)
+    : null;
+  const error =
+    parsedWorkspaceId !== null && fetchError
+      ? mapWorkspaceActionError(fetchError)
+      : "";
+  const isLoading = parsedWorkspaceId !== null && isFetchingWorkspace;
 
   const defaultCrumbs = useMemo(
     () => (workspace?.name ? [workspace.name] : []),

--- a/frontend/src/shared/ui/ostone/chrome/Sidebar.test.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/Sidebar.test.tsx
@@ -24,9 +24,11 @@ describe("Sidebar", () => {
     expect(nav).toHaveAttribute("data-collapsed", "false");
     expect(nav).toHaveStyle({ width: "200px" });
     expect(screen.getByTitle("Consultation")).toBeInTheDocument();
+    expect(screen.getByTitle("Chat")).toBeInTheDocument();
     expect(screen.getByTitle("Uploads")).toBeInTheDocument();
     expect(screen.getByTitle("Domain Packs")).toBeInTheDocument();
     expect(screen.getByText("Consultation")).toBeInTheDocument();
+    expect(screen.getByText("Chat")).toBeInTheDocument();
     expect(screen.getByText("Uploads")).toBeInTheDocument();
     expect(screen.queryByTitle("Workflows")).not.toBeInTheDocument();
   });
@@ -79,6 +81,12 @@ describe("Sidebar", () => {
       "href",
       "/workspaces/7/consultation",
     );
+    expect(screen.getByTitle("Chat")).toHaveAttribute(
+      "href",
+      "/demo/workspaces/7/chat",
+    );
+    expect(screen.getByTitle("Chat")).toHaveAttribute("target", "_blank");
+    expect(screen.getByTitle("Chat")).toHaveAttribute("rel", "noopener noreferrer");
     expect(screen.getByTitle("Domain Packs")).toHaveAttribute(
       "href",
       "/workspaces/7/domain-packs",

--- a/frontend/src/shared/ui/ostone/chrome/Sidebar.test.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/Sidebar.test.tsx
@@ -93,6 +93,12 @@ describe("Sidebar", () => {
     );
   });
 
+  it("workspaceId를 추출할 수 없으면 Chat 링크를 안전한 내부 경로로 보낸다", () => {
+    renderSidebar({ basePath: "/workspaces" });
+
+    expect(screen.getByTitle("Chat")).toHaveAttribute("href", "/workspaces");
+  });
+
   it("switcher가 주어지면 렌더링된다", () => {
     renderSidebar({ switcher: <div data-testid="switcher">Switch</div> });
 

--- a/frontend/src/shared/ui/ostone/chrome/Sidebar.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/Sidebar.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties, ReactNode } from "react";
+import type { CSSProperties, MouseEvent, ReactNode } from "react";
 import { NavLink } from "react-router-dom";
 import { Icon } from "../atoms/Icon";
 import type { IconName } from "../atoms/Icon";
@@ -7,6 +7,7 @@ import { AccountMenu } from "./AccountMenu";
 export type SidebarActive =
   | "workflows"
   | "consult"
+  | "chat"
   | "upload"
   | "domain"
   | "intent"
@@ -26,6 +27,15 @@ interface TopNavItem {
   icon: IconName;
   label: string;
   getPath: (base: string) => string;
+  external?: boolean;
+}
+
+function getDemoChatPath(base: string): string {
+  if (base.startsWith("/workspaces/")) {
+    return base.replace("/workspaces/", "/demo/workspaces/") + "/chat";
+  }
+
+  return "/demo/workspaces/chat";
 }
 
 const TOP_NAV_ITEMS: TopNavItem[] = [
@@ -34,6 +44,13 @@ const TOP_NAV_ITEMS: TopNavItem[] = [
     icon: "book",
     label: "Consultation",
     getPath: (base) => `${base}/consultation`,
+  },
+  {
+    key: "chat",
+    icon: "msg",
+    label: "Chat",
+    getPath: getDemoChatPath,
+    external: true,
   },
   {
     key: "upload",
@@ -143,6 +160,7 @@ export function Sidebar({
             activeColor={activeColor}
             defaultColor={defaultColor}
             hoverBg={hoverBg}
+            target={item.external ? "_blank" : undefined}
           />
         ))}
 
@@ -188,6 +206,7 @@ interface SidebarLinkProps {
   defaultColor: string;
   hoverBg: string;
   testId?: string;
+  target?: "_blank";
 }
 
 function SidebarLink({
@@ -199,6 +218,7 @@ function SidebarLink({
   defaultColor,
   hoverBg,
   testId,
+  target,
 }: SidebarLinkProps) {
   const expandedStyle: CSSProperties = {
     height: "40px",
@@ -217,6 +237,45 @@ function SidebarLink({
     letterSpacing: "-0.1px",
   };
 
+  const handleMouseEnter = (e: MouseEvent<HTMLAnchorElement>) => {
+    if (!isActive) {
+      e.currentTarget.style.background = hoverBg;
+      e.currentTarget.style.color = activeColor;
+    }
+  };
+
+  const handleMouseLeave = (e: MouseEvent<HTMLAnchorElement>) => {
+    if (!isActive) {
+      e.currentTarget.style.background = "transparent";
+      e.currentTarget.style.color = defaultColor;
+    }
+  };
+
+  const content = (
+    <>
+      <Icon name={icon} size={16} />
+      <span>{label}</span>
+    </>
+  );
+
+  if (target === "_blank") {
+    return (
+      <a
+        href={to}
+        title={label}
+        target="_blank"
+        rel="noopener noreferrer"
+        data-active={isActive ? "true" : "false"}
+        data-testid={testId}
+        style={expandedStyle}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+      >
+        {content}
+      </a>
+    );
+  }
+
   return (
     <NavLink
       to={to}
@@ -225,21 +284,10 @@ function SidebarLink({
       data-active={isActive ? "true" : "false"}
       data-testid={testId}
       style={expandedStyle}
-      onMouseEnter={(e) => {
-        if (!isActive) {
-          e.currentTarget.style.background = hoverBg;
-          e.currentTarget.style.color = activeColor;
-        }
-      }}
-      onMouseLeave={(e) => {
-        if (!isActive) {
-          e.currentTarget.style.background = "transparent";
-          e.currentTarget.style.color = defaultColor;
-        }
-      }}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
     >
-      <Icon name={icon} size={16} />
-      <span>{label}</span>
+      {content}
     </NavLink>
   );
 }

--- a/frontend/src/shared/ui/ostone/chrome/Sidebar.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/Sidebar.tsx
@@ -31,11 +31,12 @@ interface TopNavItem {
 }
 
 function getDemoChatPath(base: string): string {
-  if (base.startsWith("/workspaces/")) {
-    return base.replace("/workspaces/", "/demo/workspaces/") + "/chat";
+  const match = /^\/workspaces\/([^/]+)(?:\/.*)?$/.exec(base);
+  if (!match) {
+    return "/workspaces";
   }
 
-  return "/demo/workspaces/chat";
+  return `/demo/workspaces/${match[1]}/chat`;
 }
 
 const TOP_NAV_ITEMS: TopNavItem[] = [

--- a/frontend/src/widgets/ostone-shell/ui/OstoneShell.test.tsx
+++ b/frontend/src/widgets/ostone-shell/ui/OstoneShell.test.tsx
@@ -22,6 +22,7 @@ describe("OstoneShell", () => {
     expect(screen.queryByTitle("Operator")).not.toBeInTheDocument();
     expect(screen.queryByTitle("Pipeline")).not.toBeInTheDocument();
     expect(screen.getByTitle("Consultation")).toBeInTheDocument();
+    expect(screen.getByTitle("Chat")).toBeInTheDocument();
     expect(screen.getByTitle("Uploads")).toBeInTheDocument();
     expect(screen.getByTitle("Domain Packs")).toBeInTheDocument();
     expect(screen.queryByTitle("Workflows")).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary

- Move the user chat demo to the public `/demo/workspaces/:workspaceId/chat` route and open it from the workspace sidebar in a new tab.
- Add name-based demo session startup, local session reuse, and backend registration in `runtime.chat_session` / `runtime.chat_message`.
- Replace the fixed frontend bot response with backend-generated LLM responses using the existing Spring AI `LlmAssistantService`.
- Tighten chat/consultation UI behavior around message padding, missing names, session metadata, and demo-route login redirects.

## Why

The demo chat was behaving like an admin-shell screen and generated responses on the frontend with a fixed placeholder. That meant sessions were not reliably registered as runtime chat records and the chatbot experience did not reflect the configured LLM path.

## Validation

- `pnpm test src/entities/chat/api/chatApi.test.ts src/pages/user-chat/ui/UserChatPage.test.tsx`
- `docker run --rm -v /Users/owen/Projects/school/ostone/backend:/workspace -v /Users/owen/.gradle:/root/.gradle -w /workspace eclipse-temurin:21-jdk ./gradlew test --tests com.init.chatdemo.application.DemoChatSessionRegistrationServiceTest --tests com.init.chatdemo.presentation.DemoRuntimeControllerTest --no-daemon`
- `pnpm exec eslint src/entities/chat/api/chatApi.ts src/entities/chat/api/chatApi.test.ts src/pages/user-chat/ui/UserChatPage.tsx src/pages/user-chat/ui/UserChatPage.test.tsx`
- `docker run --rm -v /Users/owen/Projects/school/ostone/backend:/workspace -v /Users/owen/.gradle:/root/.gradle -w /workspace eclipse-temurin:21-jdk ./gradlew spotlessCheck --no-daemon`
- `pnpm build`
- `docker compose build backend && docker compose up -d backend`
- Browser verified `http://localhost:5173/demo/workspaces/2/chat` with session `#9`; the assistant response was LLM-generated and persisted to `runtime.chat_message`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 데모 채팅: 이름 입력 기반 세션 생성·복원, 초기 봇 인사 자동 생성 및 메시지 전송 흐름 추가
  * 데모 전용 엔드포인트 연동(세션 등록·초기 메시지 불러오기·메시지 전송)

* **개선 사항**
  * AI 모델 기본값 gpt-4o-mini → gpt-5.4-mini로 업데이트
  * 초기 메시지 비동기 로드, 로컬 낙관적 업데이트 및 로딩/오류 표시 개선
  * 사이드바에 데모 채팅 링크 추가(새 탭 지원)

* **버그 수정 / 테스트**
  * 고객명·메시지 공백 검증 강화 및 관련 단위/통합 테스트 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ajou-2026-1-capstone-5/ostone/pull/294?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->