### PR TITLE
docs: Add consultation metrics spec

### DIFF
--- a/.agent/specs/296.md
+++ b/.agent/specs/296.md
@@ -1,0 +1,109 @@
+# [feature/296] Consultation metrics for counselor topbar
+
+> GitHub Issue: #296  
+> Spec branch: `spec/296`  
+> Implementation branch: `feature/296-consultation-metrics`
+
+## 목적
+
+상담사 화면 상단의 정적 지표 `평균 첫응답`, `오늘 처리`를 실제 런타임 데이터 기반 통계로 전환한다. LLM 자동응답과 인간 상담사 응답이 함께 존재하므로 API는 전체/LLM/인간 지표를 모두 반환하고, 화면은 기존 위치에 전체 지표를 우선 표시한다.
+
+## 범위
+
+- Backend: 워크스페이스 기준 상담 통계 API 추가
+- Frontend: 상담사 화면 상단 지표 API 연동
+- DB migration 없음
+- `session_outcome` 테이블은 현재 코드에서 사용되지 않으므로 v1 집계에 사용하지 않음
+
+## API 계약
+
+### `GET /api/v1/workspaces/{workspaceId}/consultation/metrics`
+
+인증 사용자의 워크스페이스 멤버십을 검증한다.
+
+- 사용자 ID: `AuthenticationUtils.getUserId(authentication)`
+- 권한 검증: `WorkspaceMemberRepository.findByWorkspaceIdAndUserId(workspaceId, userId)`
+- 권한 없음: `WorkspaceAccessDeniedException`
+
+응답:
+
+```json
+{
+  "workspaceId": 2,
+  "periodStart": "2026-05-27T00:00:00+09:00",
+  "periodEnd": "2026-05-28T00:00:00+09:00",
+  "averageFirstResponseSeconds": 134,
+  "averageLlmFirstResponseSeconds": 3,
+  "averageHumanFirstResponseSeconds": 420,
+  "handledTodayCount": 14,
+  "llmHandledTodayCount": 9,
+  "humanHandledTodayCount": 5
+}
+```
+
+평균을 계산할 수 없는 경우 각 average 필드는 `null`이다. count 필드는 항상 0 이상의 정수다.
+
+## 집계 정의
+
+기준일은 `Asia/Seoul` 기준 오늘 `[00:00, 다음날 00:00)`이다.
+
+- 첫응답 평균 대상: `runtime.chat_session.started_at`이 오늘인 현재 워크스페이스 세션
+- 첫 고객 메시지: 같은 세션의 가장 이른 `runtime.chat_message.sender_role in ('USER', 'CUSTOMER')`
+- 전체 첫응답: 첫 고객 메시지 이후 가장 이른 `ASSISTANT`, `COUNSELOR`, `AGENT` 메시지까지의 초 단위 차이
+- LLM 첫응답: 첫 고객 메시지 이후 가장 이른 `ASSISTANT` 메시지까지의 초 단위 차이
+- 인간 첫응답: 첫 고객 메시지 이후 가장 이른 `COUNSELOR`, legacy `AGENT` 메시지까지의 초 단위 차이
+- 오늘 처리 건수: `ended_at`이 오늘이고 `status = 'COMPLETED'`인 현재 워크스페이스 세션 수
+- 인간 처리 건수: 오늘 처리 세션 중 `COUNSELOR` 또는 `AGENT` 메시지가 하나 이상 있는 세션 수
+- LLM 처리 건수: 오늘 처리 세션 중 인간 메시지가 없고 `ASSISTANT` 메시지가 하나 이상 있는 세션 수
+
+고객 메시지가 없거나 응답 메시지가 없는 세션은 평균 계산에서 제외한다.
+
+## 구현 방향
+
+- `workflow-runtime/application`에 `ConsultationMetricsService` 추가
+- `workflow-runtime/application/dto`에 `ConsultationMetricsResponse` 추가
+- `workflow-runtime/domain`에 `ConsultationMetricsRepository` port 추가
+- `workflow-runtime/infrastructure/persistence`에 native SQL 또는 `EntityManager` 기반 구현 추가
+- 여러 메시지 self-join과 조건부 평균이 필요하므로 JPA derived query로 구현하지 않는다
+- `workflow-runtime/presentation`에 workspace path 기반 controller 추가
+
+Frontend:
+
+- `features/consultation/api/consultationApi.ts`에 `getMetrics(workspaceId)` 추가
+- `ConsultationPage`에서 `workspace.id`가 있을 때 metrics API 호출
+- `StatusRight`를 props 기반 컴포넌트로 변경
+- `averageFirstResponseSeconds`는 `N분 M초` 형식으로 표시
+- average가 `null`, 로딩, 실패면 `--` 표시
+- 처리 건수는 `handledTodayCount`를 `{n}건`으로 표시
+- API 실패는 화면을 깨지 않고 fallback 처리하며 `toast.error("상담 지표를 불러오지 못했습니다.")`를 한 번 표시
+
+## 테스트
+
+Backend service:
+
+- LLM만 응답한 세션은 전체/LLM 평균에 포함되고 인간 평균에서는 제외
+- 인간 상담사 응답 세션은 전체/인간 평균에 포함
+- LLM 후 인간 응답이 모두 있는 세션은 전체/LLM/인간 평균에 각각 독립 반영
+- 고객 메시지가 없거나 응답이 없는 세션은 평균 계산에서 제외
+- 오늘 처리 건수는 `ended_at`이 오늘인 `COMPLETED` 세션만 포함
+- 인간 메시지가 있으면 인간 처리, 없고 `ASSISTANT`가 있으면 LLM 처리로 분류
+
+Backend controller:
+
+- 워크스페이스 멤버가 metrics 응답을 받음
+- 멤버가 아닌 사용자는 접근 거부
+- 데이터가 없는 워크스페이스는 average `null`, count `0`
+
+Frontend:
+
+- API 성공 시 `평균 첫응답`과 `오늘 처리`가 응답값으로 표시
+- 초 단위 평균이 `N분 M초` 형식으로 표시
+- average `null` 또는 API 실패 시 `--` fallback 표시
+
+## 검증 명령
+
+```bash
+cd backend && ./gradlew test --tests '*Consultation*' --tests '*Counselor*'
+docker compose exec -T frontend pnpm test src/pages/consultation/ui/ConsultationPage.test.tsx src/features/consultation/api/consultationApi.test.ts
+docker compose exec -T frontend pnpm build
+```


### PR DESCRIPTION
## Summary
- Adds spec for workspace-scoped consultation metrics API and counselor topbar integration
- Documents LLM/human first-response and handled-count split definitions
- Links implementation to #296

Closes nothing; implementation follows in `feature/296-consultation-metrics`.

## Validation
- Spec-only change; no runtime checks needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 상담사 화면 상단에 실시간 통계 지표 추가: 첫 응답 평균 시간(전체/LLM/인간) 및 오늘 처리 건수(전체/LLM/인간) 표시
  * API 기반 실시간 데이터 연동으로 최신 상담 현황 파악 가능

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ajou-2026-1-capstone-5/ostone/pull/297?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->