### PR TITLE
docs: add consultation queue realtime spec

### DIFF
--- a/.agent/specs/298.md
+++ b/.agent/specs/298.md
@@ -1,0 +1,230 @@
+# 298. 상담사 대기열 실시간화
+
+## Goal
+
+상담사 채팅 화면의 대기열 갱신 방식을 5초 polling에서 `workspace-scoped REST snapshot + WebSocket delta event` 구조로 전환한다. 화면 진입과 WebSocket 재연결 시에는 REST snapshot으로 현재 상태를 맞추고, 이후 세션 생성/배정/해제/종료는 workspace별 STOMP topic으로 실시간 반영한다.
+
+이번 spec의 핵심은 “큐 목록 동기화”다. unread count, last message preview, 상담사별 read cursor는 범위 밖으로 둔다.
+
+GitHub Issue: https://github.com/ajou-2026-1-capstone-5/ostone/issues/298
+
+---
+
+## Current State
+
+- 기존 상담사 대기열 REST endpoint는 전역 큐다: `GET /api/v1/consultation/queue`.
+- `ConsultationPage`는 `consultationApi.getQueue()`를 mount 후 호출하고 5초마다 polling한다.
+- 채팅 메시지는 이미 세션별 STOMP topic `/topic/chat.{sessionId}`로 실시간 수신한다.
+- 상담사 배정 시 `SessionAssignedEvent`와 `/user/queue/counselor.notifications` 개인 알림은 존재하지만, 전체 workspace 대기열 broadcast로는 사용되지 않는다.
+- WebSocket 구독 권한은 현재 `/topic/chat.*`, `/user/queue/*`, `/queue/*` 중심으로 제한되어 있어 workspace queue topic을 새로 허용해야 한다.
+
+---
+
+## Backend Scope
+
+### REST API
+
+전역 REST 큐를 제거하고 workspace-scoped snapshot endpoint를 추가한다.
+
+```http
+GET /api/v1/workspaces/{workspaceId}/consultation/queue
+```
+
+응답은 기존 `ChatSessionResponse[]`를 그대로 사용한다.
+
+조회 조건:
+
+- `workspaceId = path variable`
+- `status in (OPEN, ACTIVE)`
+- `startedAt desc`
+
+권한:
+
+- `AuthenticationUtils.getUserId(authentication)`로 현재 사용자 ID를 얻는다.
+- `WorkspaceMemberRepository.findByWorkspaceIdAndUserId(workspaceId, userId)`가 없으면 `WorkspaceAccessDeniedException`을 던진다.
+
+Repository:
+
+- `ChatSessionRepository`에 `findByWorkspaceIdAndStatusInOrderByStartedAtDesc(Long workspaceId, Collection<ChatSessionStatus> statuses)`를 추가한다.
+
+### WebSocket Queue Event
+
+새 workspace queue topic:
+
+```text
+/topic/workspaces.{workspaceId}.consultation.queue
+```
+
+새 응답 DTO:
+
+```java
+class ConsultationQueueEventResponse {
+  ConsultationQueueEventType type; // SESSION_UPSERTED | SESSION_REMOVED
+  ChatSessionResponse session;
+  OffsetDateTime occurredAt;
+}
+```
+
+새 application event:
+
+```java
+record ConsultationQueueChangedEvent(
+    Long workspaceId,
+    Long sessionId,
+    ConsultationQueueEventType type
+) {}
+```
+
+event listener:
+
+- `@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)` 사용.
+- event의 `sessionId`로 세션을 다시 조회한다.
+- 조회 실패 시 warning log 후 skip한다.
+- 조회 성공 시 `ConsultationQueueEventResponse`를 만들어 workspace topic으로 `convertAndSend`한다.
+
+발행 지점:
+
+- `UserChatSessionService.createSession`: `SESSION_UPSERTED`
+- `CounselorService.assignSession`: `SESSION_UPSERTED`
+- `CounselorService.releaseSession`: `SESSION_UPSERTED`
+- `ConsultationService.updateSessionStatus`
+  - 변경 상태가 `OPEN` 또는 `ACTIVE`: `SESSION_UPSERTED`
+  - 변경 상태가 `RESOLVED` 또는 `COMPLETED`: `SESSION_REMOVED`
+
+기존 `/user/queue/counselor.notifications` 개인 알림은 유지한다.
+
+### WebSocket Auth
+
+`JwtChannelInterceptor`에 workspace queue topic 검증을 추가한다.
+
+구독 허용 조건:
+
+- 인증된 사용자
+- session role이 `OPERATOR`
+- workspace membership 존재
+
+거부 조건:
+
+- topic workspace id가 숫자가 아님 → `BadRequestException("INVALID_DESTINATION", ...)`
+- role이 `OPERATOR`가 아님 → `AccessDeniedException`
+- workspace membership 없음 → `AccessDeniedException`
+
+기존 `/topic/chat.{sessionId}` 구독 권한 검사는 유지한다.
+
+---
+
+## Frontend Scope
+
+### API Wrapper
+
+`consultationApi.getQueue` 시그니처를 workspace-scoped로 바꾼다.
+
+```ts
+getQueue(workspaceId: number): Promise<ChatSession[]>
+```
+
+구현은 OpenAPI generated 파일을 직접 수정하지 않고 `customFetch`를 사용한다.
+
+```text
+/api/v1/workspaces/${workspaceId}/consultation/queue
+```
+
+전역 generated `getQueue` import는 제거한다.
+
+### ConsultationPage Queue Flow
+
+`ConsultationPage`는 `useOutletContext<ShellContext>()`의 `workspace.id`를 사용한다.
+
+동작:
+
+- `workspace?.id`가 없으면 queue snapshot과 queue topic 구독을 시작하지 않는다.
+- mount 또는 `connectionStatus === "CONNECTED"` 전환 시 REST snapshot을 1회 호출한다.
+- 기존 `setInterval(loadQueue, 5000)` polling은 제거한다.
+- STOMP 연결 상태가 `CONNECTED`이고 workspace id가 있으면 `/topic/workspaces.{workspaceId}.consultation.queue`를 구독한다.
+
+queue event 처리:
+
+- `SESSION_UPSERTED`
+  - `session.id` 기준으로 기존 항목을 찾는다.
+  - 있으면 `toQueueCustomer(session, currentCounselorId, previous)`로 갱신한다.
+  - 없으면 새 항목으로 추가한다.
+  - 정렬은 `waitMinutes` 내림차순이 아니라 snapshot과 동일한 `startedAt desc` 의도를 유지하도록 최신 세션이 앞에 오게 한다. 단 기존 `QueueCustomer`에는 `startedAt`이 없으므로, 구현에서는 `ChatSession.startedAt` 기준 sort helper를 별도로 두거나 `QueueCustomer`에 내부용 `startedAt?: string`을 추가한다.
+- `SESSION_REMOVED`
+  - 해당 session을 queue에서 제거한다.
+  - 제거된 session이 active session이면 `activeCustomerId`, `selectedMessageId`, `messages`를 초기화한다.
+
+기존 세션별 메시지 구독 `/topic/chat.{activeCustomerId}`는 유지한다.
+
+### REST Mutations
+
+이번 범위에서는 다음 endpoint를 workspace-scoped로 재설계하지 않는다.
+
+- assign
+- release
+- status update
+- message send
+
+다만 assign/release/status mutation 성공 후 로컬 queue 갱신은 유지할 수 있다. WebSocket event가 나중에 도착해도 idempotent upsert/remove가 되도록 작성한다.
+
+---
+
+## Test Plan
+
+### Backend
+
+- `WorkspaceConsultationQueueController` 또는 대응 컨트롤러 테스트
+  - 멤버가 요청하면 `OPEN/ACTIVE` 세션 목록을 반환한다.
+  - 비멤버 요청은 거부한다.
+- `ConsultationService`
+  - workspace-scoped queue 조회가 `findByWorkspaceIdAndStatusInOrderByStartedAtDesc`를 사용한다.
+  - `updateSessionStatus(COMPLETED/RESOLVED)`가 `SESSION_REMOVED` event를 발행한다.
+  - `updateSessionStatus(OPEN/ACTIVE)`가 `SESSION_UPSERTED` event를 발행한다.
+- `CounselorService`
+  - assign/release 성공 시 `ConsultationQueueChangedEvent`를 발행한다.
+  - 기존 `SessionAssignedEvent` 발행은 유지된다.
+- `UserChatSessionService`
+  - 새 세션 생성 시 `SESSION_UPSERTED` event를 발행한다.
+  - 기존 세션 재사용 시 새 queue event를 발행하지 않는다.
+- `ConsultationQueueEventListener`
+  - 세션이 있으면 `/topic/workspaces.{workspaceId}.consultation.queue`로 DTO를 보낸다.
+  - 세션이 없으면 STOMP 전송 없이 skip한다.
+- `JwtChannelInterceptor`
+  - `OPERATOR` + workspace member는 queue topic 구독 성공.
+  - non-OPERATOR는 거부.
+  - workspace 비멤버는 거부.
+  - 잘못된 workspace id topic은 `BadRequestException`.
+- 기존 `/api/v1/consultation/queue` 컨트롤러 테스트는 삭제하거나 “존재하지 않음” 기대 테스트로 바꾼다.
+
+### Frontend
+
+- `consultationApi.getQueue(workspaceId)`
+  - 새 workspace-scoped URL을 `customFetch`로 호출한다.
+  - plain array와 `{ data }` wrapper 응답을 모두 unwrap한다.
+- `ConsultationPage`
+  - `workspace.id`가 있으면 `getQueue(workspace.id)`를 호출한다.
+  - `workspace.id`가 없으면 queue load/subscribe를 하지 않는다.
+  - 5초 polling interval을 만들지 않는다.
+  - `CONNECTED` 상태에서 workspace queue topic을 구독한다.
+  - `SESSION_UPSERTED` 이벤트가 queue 항목을 추가/갱신한다.
+  - `SESSION_REMOVED` 이벤트가 queue 항목을 제거하고 active session이면 선택과 메시지를 초기화한다.
+  - 기존 `/topic/chat.{sessionId}` 메시지 수신 테스트는 유지한다.
+  - 기존 메시지 전송, 배정, 해제, 메모 저장 회귀 테스트는 유지한다.
+
+---
+
+## Acceptance Criteria
+
+- 상담사 화면에서 5초 주기 REST polling이 사라진다.
+- 다른 사용자/상담사가 세션을 생성, 배정, 해제, 종료하면 같은 workspace 상담사 화면의 대기열이 WebSocket으로 갱신된다.
+- 브라우저 새로고침 또는 WebSocket 재연결 후에도 REST snapshot으로 현재 큐가 복구된다.
+- 전역 큐 `/api/v1/consultation/queue`는 더 이상 사용되지 않고 endpoint도 제거된다.
+- workspace membership 없는 사용자는 REST queue와 WebSocket queue topic 모두 접근할 수 없다.
+
+---
+
+## Assumptions
+
+- “REST 큐 제거”는 전역 REST 큐 제거를 의미한다. 초기/재연결 복구용 workspace-scoped REST snapshot은 유지한다.
+- OpenAPI generated 파일은 직접 수정하지 않는다.
+- 큐 실시간화 v1에서는 unread count, last message preview, counselor-specific read state를 구현하지 않는다.
+- 기존 assign/release/status/message REST endpoint의 path는 이번 spec에서 변경하지 않는다.


### PR DESCRIPTION
## Summary
- Adds the implementation spec for GitHub Issue #298.
- Defines the workspace-scoped REST snapshot plus WebSocket delta design for counselor queue realtime updates.
- Captures backend/frontend scope, test plan, acceptance criteria, and assumptions.

## Notes
- This PR intentionally contains only `.agent/specs/298.md`.
- Implementation changes are not included.

## Validation
- Not run; documentation/spec-only change.

Closes #298


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * 상담사 대기열 실시간화 요구사항 문서 추가
  * 대기열 조회가 주기적 폴링에서 실시간 업데이트 구조로 변경됨
  * 워크스페이스 기반 접근 제어 및 WebSocket 실시간 알림 시스템 명세 포함

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ajou-2026-1-capstone-5/ostone/pull/300?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->