### PR TITLE
docs: Add spec for counselor chat session metadata fix

### DIFF
--- a/.agent/specs/299.md
+++ b/.agent/specs/299.md
@@ -1,0 +1,102 @@
+# [fix/299] Counselor chat role labels and session metadata
+
+> GitHub Issue: #299  
+> Spec branch: `spec/299`  
+> Implementation branch: `fix/299-counselor-chat-session-metadata`
+
+## 목적
+
+상담사 실시간 채팅과 상담 이력에서 메시지 역할 라벨을 일관되게 표시하고, 메시지 저장 시 세션 제목과 최근 메시지 요약 메타를 `runtime.chat_session.meta_json`에 안정적으로 갱신한다.
+
+## 범위
+
+- Backend: 채팅 메시지 저장 경로에서 세션 메타 갱신
+- Frontend: 상담사 채팅/이력/상세 패널의 역할 라벨 및 세션 제목 표시 정리
+- DB migration 없음
+- 수동 세션 제목 편집 API 없음
+
+## 역할 라벨 정책
+
+| senderRole | 표시 라벨 |
+| --- | --- |
+| `USER`, `CUSTOMER` | 고객 |
+| `COUNSELOR`, `AGENT` | 상담사 |
+| `ASSISTANT` | AI |
+| `NOTE` | 내부 메모 |
+| 그 외 또는 누락 | 시스템 |
+
+프론트엔드는 실시간 상담 화면, 상담 이력 화면, 메시지 상세 패널에서 같은 매핑을 사용한다. 기존 legacy role인 `AGENT`는 상담사로 유지한다.
+
+## 세션 메타 정책
+
+`chat_session.meta_json`은 기존 필드를 보존하면서 아래 필드를 추가/갱신한다.
+
+```json
+{
+  "customerName": "김민지",
+  "handoffReason": "환불 문의",
+  "title": "환불 문의",
+  "messageCount": 12,
+  "lastMessagePreview": "처리 도와드리겠습니다.",
+  "lastMessageRole": "COUNSELOR",
+  "lastMessageAt": "2026-05-27T10:15:30+09:00"
+}
+```
+
+- `title`은 기존 값이 있으면 유지한다.
+- `title`이 없으면 `handoffReason`을 우선 사용한다.
+- `handoffReason`이 없고 고객 첫 메시지가 있으면 해당 내용을 40자 내외로 축약한다.
+- 그래도 없으면 `customerName + " 상담"` 또는 `channel + " 상담"`을 사용한다.
+- `messageCount`는 저장된 메시지의 최신 `seqNo`를 기준으로 갱신한다.
+- `lastMessagePreview`는 마지막 메시지 본문을 80자 내외로 축약한다.
+- invalid `meta_json`은 `{}`로 복구하고 메시지 저장은 성공시킨다.
+
+## Backend 구현 방향
+
+공통 메타 갱신 로직을 `workflowruntime` application 계층에 둔다. 메시지를 저장한 뒤 같은 transaction 안에서 세션 엔티티의 `metaJson`을 갱신한다.
+
+적용 대상 저장 경로:
+
+- `ChatWebSocketService.saveAndBroadcast`: 사용자 WebSocket 메시지
+- `CounselorService.sendCounselorMessage`: 상담사 WebSocket 메시지
+- `ConsultationService.sendMessage`: 기존 상담사 REST 메시지
+- `LlmResponseHandler.handleChatMessageReceived`: LLM `ASSISTANT` 응답
+
+응답 DTO shape는 변경하지 않고 기존 `ChatSessionResponse.metaJson` 문자열을 통해 확장된 값을 전달한다.
+
+## Frontend 구현 방향
+
+- 상담 메시지 role 표시 유틸을 `features/consultation` 내부에 둔다.
+- `ChatPanel`은 상담사/AI/고객 메시지의 라벨과 avatar를 유틸 기반으로 표시한다.
+- `MessageHistory`와 `MessageDetailPanel`은 raw senderRole 대신 표시 라벨을 사용한다.
+- `SessionCard`는 `meta.title`을 우선 제목으로 표시하고, 없으면 기존 channel/preview fallback을 유지한다.
+- 대기열/상담 헤더는 `meta.title`이 있으면 문의 제목으로 사용하고 기존 `handoffReason`은 fallback으로 유지한다.
+
+## 테스트
+
+Backend:
+
+- 기존 `customerName`, `handoffReason`이 meta 갱신 후에도 보존된다.
+- invalid `metaJson`이 있는 세션에도 메시지 저장이 성공하고 새 meta 필드가 생성된다.
+- `USER`, `COUNSELOR`, `ASSISTANT`, `NOTE` 메시지 저장 경로에서 `messageCount`, `lastMessagePreview`, `lastMessageRole`, `lastMessageAt`이 갱신된다.
+- `title`은 기존 값이 있으면 덮어쓰지 않고, 없으면 fallback 규칙으로 생성된다.
+
+Frontend:
+
+- `USER/CUSTOMER/COUNSELOR/AGENT/ASSISTANT/NOTE/SYSTEM` 역할이 한국어 라벨로 렌더링된다.
+- 상담 이력 세션 카드는 `meta.title`을 우선 표시하고, 없으면 기존 preview fallback을 표시한다.
+- 메시지 상세 패널에서 raw role 대신 표시 라벨을 보여준다.
+
+## 수동 검증
+
+- `/workspaces/2/consultation`에서 고객/상담사/AI/내부 메모/시스템 라벨 확인
+- 메시지 전송 후 대기열 또는 상담 이력의 제목/최근 메시지 요약 갱신 확인
+- invalid `metaJson`이 있는 세션도 메시지 송수신이 실패하지 않는지 확인
+
+## 검증 명령
+
+```bash
+cd backend && ./gradlew test --tests '*workflowruntime*'
+cd frontend && pnpm test src/features/consultation src/pages/consultation
+cd frontend && pnpm build
+```


### PR DESCRIPTION
## Summary
- Add SDD spec for counselor chat role labels and session metadata fix.
- Link implementation branch plan for fix/299-counselor-chat-session-metadata.

## Issue
Refs #299

## Tests
- Not run (spec only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 상담 채팅 인터페이스에서 메시지 송신자 역할 표시 및 세션 메타데이터 관리에 관한 사양 문서 추가. 송신자 역할을 일관된 한국어 라벨로 표시하고, 세션 제목과 메시지 요약 정보 관리 규칙을 정의함.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ajou-2026-1-capstone-5/ostone/pull/301?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->