### PR TITLE
feat: Add workspace consultation metrics for counselor topbar

### DIFF
--- a/backend/src/main/java/com/init/workflowruntime/application/ConsultationMetricsService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/ConsultationMetricsService.java
@@ -1,0 +1,110 @@
+package com.init.workflowruntime.application;
+
+import com.init.workflowruntime.application.dto.ConsultationMetricsResponse;
+import com.init.workflowruntime.domain.ConsultationMetricsRepository;
+import com.init.workflowruntime.domain.ConsultationMetricsSessionFact;
+import com.init.workspace.application.exception.WorkspaceAccessDeniedException;
+import com.init.workspace.domain.repository.WorkspaceMemberRepository;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Objects;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class ConsultationMetricsService {
+
+  private static final ZoneId METRIC_ZONE = ZoneId.of("Asia/Seoul");
+
+  private final ConsultationMetricsRepository consultationMetricsRepository;
+  private final WorkspaceMemberRepository workspaceMemberRepository;
+  private final Clock clock;
+
+  public ConsultationMetricsService(
+      ConsultationMetricsRepository consultationMetricsRepository,
+      WorkspaceMemberRepository workspaceMemberRepository,
+      Clock clock) {
+    this.consultationMetricsRepository = consultationMetricsRepository;
+    this.workspaceMemberRepository = workspaceMemberRepository;
+    this.clock = clock;
+  }
+
+  public ConsultationMetricsResponse getWorkspaceMetrics(Long workspaceId, Long userId) {
+    validateWorkspaceMembership(workspaceId, userId);
+
+    LocalDate today = LocalDate.now(clock.withZone(METRIC_ZONE));
+    OffsetDateTime periodStart = today.atStartOfDay(METRIC_ZONE).toOffsetDateTime();
+    OffsetDateTime periodEnd = today.plusDays(1).atStartOfDay(METRIC_ZONE).toOffsetDateTime();
+
+    List<ConsultationMetricsSessionFact> facts =
+        consultationMetricsRepository.findSessionFacts(workspaceId, periodStart, periodEnd);
+
+    long handledTodayCount =
+        facts.stream().filter(ConsultationMetricsSessionFact::handledToday).count();
+    long humanHandledTodayCount =
+        facts.stream()
+            .filter(ConsultationMetricsSessionFact::handledToday)
+            .filter(ConsultationMetricsSessionFact::hasHumanMessage)
+            .count();
+    long llmHandledTodayCount =
+        facts.stream()
+            .filter(ConsultationMetricsSessionFact::handledToday)
+            .filter(fact -> !fact.hasHumanMessage())
+            .filter(ConsultationMetricsSessionFact::hasLlmMessage)
+            .count();
+
+    return new ConsultationMetricsResponse(
+        workspaceId,
+        periodStart,
+        periodEnd,
+        averageSeconds(facts, ResponseKind.ANY),
+        averageSeconds(facts, ResponseKind.LLM),
+        averageSeconds(facts, ResponseKind.HUMAN),
+        handledTodayCount,
+        llmHandledTodayCount,
+        humanHandledTodayCount);
+  }
+
+  private void validateWorkspaceMembership(Long workspaceId, Long userId) {
+    workspaceMemberRepository
+        .findByWorkspaceIdAndUserId(workspaceId, userId)
+        .orElseThrow(() -> new WorkspaceAccessDeniedException("워크스페이스에 접근 권한이 없습니다."));
+  }
+
+  private Long averageSeconds(List<ConsultationMetricsSessionFact> facts, ResponseKind kind) {
+    double average =
+        facts.stream()
+            .map(fact -> responseSeconds(fact, kind))
+            .filter(Objects::nonNull)
+            .mapToLong(Long::longValue)
+            .average()
+            .orElse(Double.NaN);
+    return Double.isNaN(average) ? null : Math.round(average);
+  }
+
+  private Long responseSeconds(ConsultationMetricsSessionFact fact, ResponseKind kind) {
+    OffsetDateTime firstCustomerAt = fact.firstCustomerAt();
+    OffsetDateTime responseAt =
+        switch (kind) {
+          case ANY -> fact.firstResponseAt();
+          case LLM -> fact.firstLlmResponseAt();
+          case HUMAN -> fact.firstHumanResponseAt();
+        };
+
+    if (firstCustomerAt == null || responseAt == null || responseAt.isBefore(firstCustomerAt)) {
+      return null;
+    }
+    return Duration.between(firstCustomerAt, responseAt).getSeconds();
+  }
+
+  private enum ResponseKind {
+    ANY,
+    LLM,
+    HUMAN
+  }
+}

--- a/backend/src/main/java/com/init/workflowruntime/application/ConsultationMetricsService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/ConsultationMetricsService.java
@@ -1,5 +1,6 @@
 package com.init.workflowruntime.application;
 
+import com.init.workflowruntime.application.command.GetWorkspaceMetricsCommand;
 import com.init.workflowruntime.application.dto.ConsultationMetricsResponse;
 import com.init.workflowruntime.domain.ConsultationMetricsRepository;
 import com.init.workflowruntime.domain.ConsultationMetricsSessionFact;
@@ -34,7 +35,9 @@ public class ConsultationMetricsService {
     this.clock = clock;
   }
 
-  public ConsultationMetricsResponse getWorkspaceMetrics(Long workspaceId, Long userId) {
+  public ConsultationMetricsResponse getWorkspaceMetrics(GetWorkspaceMetricsCommand command) {
+    Long workspaceId = command.workspaceId();
+    Long userId = command.userId();
     validateWorkspaceMembership(workspaceId, userId);
 
     LocalDate today = LocalDate.now(clock.withZone(METRIC_ZONE));

--- a/backend/src/main/java/com/init/workflowruntime/application/command/GetWorkspaceMetricsCommand.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/command/GetWorkspaceMetricsCommand.java
@@ -1,0 +1,10 @@
+package com.init.workflowruntime.application.command;
+
+import java.util.Objects;
+
+public record GetWorkspaceMetricsCommand(Long workspaceId, Long userId) {
+  public GetWorkspaceMetricsCommand {
+    Objects.requireNonNull(workspaceId, "workspaceId must not be null");
+    Objects.requireNonNull(userId, "userId must not be null");
+  }
+}

--- a/backend/src/main/java/com/init/workflowruntime/application/dto/ConsultationMetricsResponse.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/dto/ConsultationMetricsResponse.java
@@ -1,0 +1,14 @@
+package com.init.workflowruntime.application.dto;
+
+import java.time.OffsetDateTime;
+
+public record ConsultationMetricsResponse(
+    Long workspaceId,
+    OffsetDateTime periodStart,
+    OffsetDateTime periodEnd,
+    Long averageFirstResponseSeconds,
+    Long averageLlmFirstResponseSeconds,
+    Long averageHumanFirstResponseSeconds,
+    long handledTodayCount,
+    long llmHandledTodayCount,
+    long humanHandledTodayCount) {}

--- a/backend/src/main/java/com/init/workflowruntime/domain/ConsultationMetricsRepository.java
+++ b/backend/src/main/java/com/init/workflowruntime/domain/ConsultationMetricsRepository.java
@@ -1,0 +1,10 @@
+package com.init.workflowruntime.domain;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+public interface ConsultationMetricsRepository {
+
+  List<ConsultationMetricsSessionFact> findSessionFacts(
+      Long workspaceId, OffsetDateTime periodStart, OffsetDateTime periodEnd);
+}

--- a/backend/src/main/java/com/init/workflowruntime/domain/ConsultationMetricsSessionFact.java
+++ b/backend/src/main/java/com/init/workflowruntime/domain/ConsultationMetricsSessionFact.java
@@ -1,0 +1,13 @@
+package com.init.workflowruntime.domain;
+
+import java.time.OffsetDateTime;
+
+public record ConsultationMetricsSessionFact(
+    Long sessionId,
+    OffsetDateTime firstCustomerAt,
+    OffsetDateTime firstResponseAt,
+    OffsetDateTime firstLlmResponseAt,
+    OffsetDateTime firstHumanResponseAt,
+    boolean handledToday,
+    boolean hasLlmMessage,
+    boolean hasHumanMessage) {}

--- a/backend/src/main/java/com/init/workflowruntime/infrastructure/persistence/JpaConsultationMetricsRepository.java
+++ b/backend/src/main/java/com/init/workflowruntime/infrastructure/persistence/JpaConsultationMetricsRepository.java
@@ -1,0 +1,147 @@
+package com.init.workflowruntime.infrastructure.persistence;
+
+import com.init.workflowruntime.domain.ConsultationMetricsRepository;
+import com.init.workflowruntime.domain.ConsultationMetricsSessionFact;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.Query;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class JpaConsultationMetricsRepository implements ConsultationMetricsRepository {
+
+  @PersistenceContext private EntityManager entityManager;
+
+  @Override
+  public List<ConsultationMetricsSessionFact> findSessionFacts(
+      Long workspaceId, OffsetDateTime periodStart, OffsetDateTime periodEnd) {
+    Query query =
+        entityManager.createNativeQuery(
+            """
+            with scoped_sessions as (
+              select cs.id, cs.status, cs.started_at, cs.ended_at
+              from runtime.chat_session cs
+              where cs.workspace_id = :workspaceId
+                and (
+                  (cs.started_at >= :periodStart and cs.started_at < :periodEnd)
+                  or (cs.ended_at >= :periodStart and cs.ended_at < :periodEnd and cs.status = 'COMPLETED')
+                )
+            ),
+            first_customer as (
+              select ss.id as session_id, min(cm.created_at) as first_customer_at
+              from scoped_sessions ss
+              join runtime.chat_message cm on cm.chat_session_id = ss.id
+              where ss.started_at >= :periodStart
+                and ss.started_at < :periodEnd
+                and cm.sender_role in ('USER', 'CUSTOMER')
+              group by ss.id
+            )
+            select
+              ss.id as session_id,
+              fc.first_customer_at,
+              (
+                select min(response.created_at)
+                from runtime.chat_message response
+                where response.chat_session_id = ss.id
+                  and fc.first_customer_at is not null
+                  and response.created_at > fc.first_customer_at
+                  and response.sender_role in ('ASSISTANT', 'COUNSELOR', 'AGENT')
+              ) as first_response_at,
+              (
+                select min(response.created_at)
+                from runtime.chat_message response
+                where response.chat_session_id = ss.id
+                  and fc.first_customer_at is not null
+                  and response.created_at > fc.first_customer_at
+                  and response.sender_role = 'ASSISTANT'
+              ) as first_llm_response_at,
+              (
+                select min(response.created_at)
+                from runtime.chat_message response
+                where response.chat_session_id = ss.id
+                  and fc.first_customer_at is not null
+                  and response.created_at > fc.first_customer_at
+                  and response.sender_role in ('COUNSELOR', 'AGENT')
+              ) as first_human_response_at,
+              (
+                ss.status = 'COMPLETED'
+                and ss.ended_at >= :periodStart
+                and ss.ended_at < :periodEnd
+              ) as handled_today,
+              exists (
+                select 1
+                from runtime.chat_message llm_message
+                where llm_message.chat_session_id = ss.id
+                  and llm_message.sender_role = 'ASSISTANT'
+              ) as has_llm_message,
+              exists (
+                select 1
+                from runtime.chat_message human_message
+                where human_message.chat_session_id = ss.id
+                  and human_message.sender_role in ('COUNSELOR', 'AGENT')
+              ) as has_human_message
+            from scoped_sessions ss
+            left join first_customer fc on fc.session_id = ss.id
+            """);
+
+    query.setParameter("workspaceId", workspaceId);
+    query.setParameter("periodStart", periodStart);
+    query.setParameter("periodEnd", periodEnd);
+
+    @SuppressWarnings("unchecked")
+    List<Object[]> rows = query.getResultList();
+    return rows.stream().map(this::toSessionFact).toList();
+  }
+
+  private ConsultationMetricsSessionFact toSessionFact(Object[] row) {
+    return new ConsultationMetricsSessionFact(
+        toLong(row[0]),
+        toOffsetDateTime(row[1]),
+        toOffsetDateTime(row[2]),
+        toOffsetDateTime(row[3]),
+        toOffsetDateTime(row[4]),
+        toBoolean(row[5]),
+        toBoolean(row[6]),
+        toBoolean(row[7]));
+  }
+
+  private Long toLong(Object value) {
+    return value instanceof Number number ? number.longValue() : null;
+  }
+
+  private boolean toBoolean(Object value) {
+    if (value instanceof Boolean bool) {
+      return bool;
+    }
+    if (value instanceof Number number) {
+      return number.intValue() != 0;
+    }
+    return Boolean.parseBoolean(String.valueOf(value));
+  }
+
+  private OffsetDateTime toOffsetDateTime(Object value) {
+    if (value == null) {
+      return null;
+    }
+    if (value instanceof OffsetDateTime offsetDateTime) {
+      return offsetDateTime;
+    }
+    if (value instanceof Instant instant) {
+      return OffsetDateTime.ofInstant(instant, ZoneOffset.UTC);
+    }
+    if (value instanceof Timestamp timestamp) {
+      return OffsetDateTime.ofInstant(timestamp.toInstant(), ZoneOffset.UTC);
+    }
+    if (value instanceof LocalDateTime localDateTime) {
+      return localDateTime.atOffset(ZoneOffset.UTC);
+    }
+    throw new IllegalArgumentException(
+        "Unsupported timestamp value: " + value.getClass().getName());
+  }
+}

--- a/backend/src/main/java/com/init/workflowruntime/infrastructure/persistence/JpaConsultationMetricsRepository.java
+++ b/backend/src/main/java/com/init/workflowruntime/infrastructure/persistence/JpaConsultationMetricsRepository.java
@@ -3,7 +3,6 @@ package com.init.workflowruntime.infrastructure.persistence;
 import com.init.workflowruntime.domain.ConsultationMetricsRepository;
 import com.init.workflowruntime.domain.ConsultationMetricsSessionFact;
 import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.Query;
 import java.sql.Timestamp;
 import java.time.Instant;
@@ -16,7 +15,11 @@ import org.springframework.stereotype.Repository;
 @Repository
 public class JpaConsultationMetricsRepository implements ConsultationMetricsRepository {
 
-  @PersistenceContext private EntityManager entityManager;
+  private final EntityManager entityManager;
+
+  public JpaConsultationMetricsRepository(EntityManager entityManager) {
+    this.entityManager = entityManager;
+  }
 
   @Override
   public List<ConsultationMetricsSessionFact> findSessionFacts(

--- a/backend/src/main/java/com/init/workflowruntime/presentation/ConsultationMetricsController.java
+++ b/backend/src/main/java/com/init/workflowruntime/presentation/ConsultationMetricsController.java
@@ -1,0 +1,29 @@
+package com.init.workflowruntime.presentation;
+
+import com.init.shared.presentation.AuthenticationUtils;
+import com.init.workflowruntime.application.ConsultationMetricsService;
+import com.init.workflowruntime.application.dto.ConsultationMetricsResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/workspaces/{workspaceId}/consultation")
+public class ConsultationMetricsController {
+
+  private final ConsultationMetricsService consultationMetricsService;
+
+  public ConsultationMetricsController(ConsultationMetricsService consultationMetricsService) {
+    this.consultationMetricsService = consultationMetricsService;
+  }
+
+  @GetMapping("/metrics")
+  public ResponseEntity<ConsultationMetricsResponse> getMetrics(
+      @PathVariable Long workspaceId, Authentication authentication) {
+    Long userId = AuthenticationUtils.getUserId(authentication);
+    return ResponseEntity.ok(consultationMetricsService.getWorkspaceMetrics(workspaceId, userId));
+  }
+}

--- a/backend/src/main/java/com/init/workflowruntime/presentation/ConsultationMetricsController.java
+++ b/backend/src/main/java/com/init/workflowruntime/presentation/ConsultationMetricsController.java
@@ -2,6 +2,7 @@ package com.init.workflowruntime.presentation;
 
 import com.init.shared.presentation.AuthenticationUtils;
 import com.init.workflowruntime.application.ConsultationMetricsService;
+import com.init.workflowruntime.application.command.GetWorkspaceMetricsCommand;
 import com.init.workflowruntime.application.dto.ConsultationMetricsResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -24,6 +25,8 @@ public class ConsultationMetricsController {
   public ResponseEntity<ConsultationMetricsResponse> getMetrics(
       @PathVariable Long workspaceId, Authentication authentication) {
     Long userId = AuthenticationUtils.getUserId(authentication);
-    return ResponseEntity.ok(consultationMetricsService.getWorkspaceMetrics(workspaceId, userId));
+    return ResponseEntity.ok(
+        consultationMetricsService.getWorkspaceMetrics(
+            new GetWorkspaceMetricsCommand(workspaceId, userId)));
   }
 }

--- a/backend/src/test/java/com/init/workflowruntime/application/ConsultationMetricsServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/ConsultationMetricsServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
+import com.init.workflowruntime.application.command.GetWorkspaceMetricsCommand;
 import com.init.workflowruntime.application.dto.ConsultationMetricsResponse;
 import com.init.workflowruntime.domain.ConsultationMetricsRepository;
 import com.init.workflowruntime.domain.ConsultationMetricsSessionFact;
@@ -75,7 +76,8 @@ class ConsultationMetricsServiceTest {
                     true,
                     true)));
 
-    ConsultationMetricsResponse response = service.getWorkspaceMetrics(WORKSPACE_ID, USER_ID);
+    ConsultationMetricsResponse response =
+        service.getWorkspaceMetrics(new GetWorkspaceMetricsCommand(WORKSPACE_ID, USER_ID));
 
     assertThat(response.workspaceId()).isEqualTo(WORKSPACE_ID);
     assertThat(response.periodStart()).isEqualTo(periodStart());
@@ -99,7 +101,8 @@ class ConsultationMetricsServiceTest {
                 fact(1L, null, null, null, null, false, true, false),
                 fact(2L, base, null, null, null, false, false, false)));
 
-    ConsultationMetricsResponse response = service.getWorkspaceMetrics(WORKSPACE_ID, USER_ID);
+    ConsultationMetricsResponse response =
+        service.getWorkspaceMetrics(new GetWorkspaceMetricsCommand(WORKSPACE_ID, USER_ID));
 
     assertThat(response.averageFirstResponseSeconds()).isNull();
     assertThat(response.averageLlmFirstResponseSeconds()).isNull();
@@ -115,7 +118,9 @@ class ConsultationMetricsServiceTest {
     given(workspaceMemberRepository.findByWorkspaceIdAndUserId(WORKSPACE_ID, USER_ID))
         .willReturn(Optional.empty());
 
-    assertThatThrownBy(() -> service.getWorkspaceMetrics(WORKSPACE_ID, USER_ID))
+    assertThatThrownBy(
+            () ->
+                service.getWorkspaceMetrics(new GetWorkspaceMetricsCommand(WORKSPACE_ID, USER_ID)))
         .isInstanceOf(WorkspaceAccessDeniedException.class);
     verify(consultationMetricsRepository, never())
         .findSessionFacts(WORKSPACE_ID, periodStart(), periodEnd());

--- a/backend/src/test/java/com/init/workflowruntime/application/ConsultationMetricsServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/ConsultationMetricsServiceTest.java
@@ -1,0 +1,157 @@
+package com.init.workflowruntime.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.init.workflowruntime.application.dto.ConsultationMetricsResponse;
+import com.init.workflowruntime.domain.ConsultationMetricsRepository;
+import com.init.workflowruntime.domain.ConsultationMetricsSessionFact;
+import com.init.workspace.application.exception.WorkspaceAccessDeniedException;
+import com.init.workspace.domain.model.WorkspaceMember;
+import com.init.workspace.domain.model.WorkspaceMemberRole;
+import com.init.workspace.domain.repository.WorkspaceMemberRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ConsultationMetricsService")
+class ConsultationMetricsServiceTest {
+
+  private static final Long WORKSPACE_ID = 2L;
+  private static final Long USER_ID = 7L;
+  private static final ZoneId SEOUL = ZoneId.of("Asia/Seoul");
+
+  @Mock private ConsultationMetricsRepository consultationMetricsRepository;
+  @Mock private WorkspaceMemberRepository workspaceMemberRepository;
+
+  private ConsultationMetricsService service;
+
+  @BeforeEach
+  void setUp() {
+    Clock clock = Clock.fixed(Instant.parse("2026-05-27T03:00:00Z"), SEOUL);
+    service =
+        new ConsultationMetricsService(
+            consultationMetricsRepository, workspaceMemberRepository, clock);
+  }
+
+  @Test
+  @DisplayName("LLM/인간/혼합 세션을 독립 지표로 집계한다")
+  void should_aggregateSplitMetrics_when_sessionsHaveLlmAndHumanResponses() {
+    OffsetDateTime base = OffsetDateTime.parse("2026-05-27T09:00:00+09:00");
+    givenMember();
+    given(consultationMetricsRepository.findSessionFacts(WORKSPACE_ID, periodStart(), periodEnd()))
+        .willReturn(
+            List.of(
+                fact(1L, base, base.plusSeconds(3), base.plusSeconds(3), null, true, true, false),
+                fact(
+                    2L,
+                    base,
+                    base.plusSeconds(420),
+                    null,
+                    base.plusSeconds(420),
+                    true,
+                    false,
+                    true),
+                fact(
+                    3L,
+                    base,
+                    base.plusSeconds(2),
+                    base.plusSeconds(2),
+                    base.plusSeconds(300),
+                    true,
+                    true,
+                    true)));
+
+    ConsultationMetricsResponse response = service.getWorkspaceMetrics(WORKSPACE_ID, USER_ID);
+
+    assertThat(response.workspaceId()).isEqualTo(WORKSPACE_ID);
+    assertThat(response.periodStart()).isEqualTo(periodStart());
+    assertThat(response.periodEnd()).isEqualTo(periodEnd());
+    assertThat(response.averageFirstResponseSeconds()).isEqualTo(142L);
+    assertThat(response.averageLlmFirstResponseSeconds()).isEqualTo(3L);
+    assertThat(response.averageHumanFirstResponseSeconds()).isEqualTo(360L);
+    assertThat(response.handledTodayCount()).isEqualTo(3);
+    assertThat(response.llmHandledTodayCount()).isEqualTo(1);
+    assertThat(response.humanHandledTodayCount()).isEqualTo(2);
+  }
+
+  @Test
+  @DisplayName("고객 메시지나 응답이 없는 세션은 평균에서 제외한다")
+  void should_returnNullAverages_when_noMeasurableResponsesExist() {
+    OffsetDateTime base = OffsetDateTime.parse("2026-05-27T09:00:00+09:00");
+    givenMember();
+    given(consultationMetricsRepository.findSessionFacts(WORKSPACE_ID, periodStart(), periodEnd()))
+        .willReturn(
+            List.of(
+                fact(1L, null, null, null, null, false, true, false),
+                fact(2L, base, null, null, null, false, false, false)));
+
+    ConsultationMetricsResponse response = service.getWorkspaceMetrics(WORKSPACE_ID, USER_ID);
+
+    assertThat(response.averageFirstResponseSeconds()).isNull();
+    assertThat(response.averageLlmFirstResponseSeconds()).isNull();
+    assertThat(response.averageHumanFirstResponseSeconds()).isNull();
+    assertThat(response.handledTodayCount()).isZero();
+    assertThat(response.llmHandledTodayCount()).isZero();
+    assertThat(response.humanHandledTodayCount()).isZero();
+  }
+
+  @Test
+  @DisplayName("워크스페이스 멤버가 아니면 접근을 거부한다")
+  void should_throwAccessDenied_when_userIsNotWorkspaceMember() {
+    given(workspaceMemberRepository.findByWorkspaceIdAndUserId(WORKSPACE_ID, USER_ID))
+        .willReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.getWorkspaceMetrics(WORKSPACE_ID, USER_ID))
+        .isInstanceOf(WorkspaceAccessDeniedException.class);
+    verify(consultationMetricsRepository, never())
+        .findSessionFacts(WORKSPACE_ID, periodStart(), periodEnd());
+  }
+
+  private void givenMember() {
+    given(workspaceMemberRepository.findByWorkspaceIdAndUserId(WORKSPACE_ID, USER_ID))
+        .willReturn(
+            Optional.of(WorkspaceMember.create(WORKSPACE_ID, USER_ID, WorkspaceMemberRole.OWNER)));
+  }
+
+  private OffsetDateTime periodStart() {
+    return OffsetDateTime.parse("2026-05-27T00:00:00+09:00");
+  }
+
+  private OffsetDateTime periodEnd() {
+    return OffsetDateTime.parse("2026-05-28T00:00:00+09:00");
+  }
+
+  private ConsultationMetricsSessionFact fact(
+      Long sessionId,
+      OffsetDateTime firstCustomerAt,
+      OffsetDateTime firstResponseAt,
+      OffsetDateTime firstLlmResponseAt,
+      OffsetDateTime firstHumanResponseAt,
+      boolean handledToday,
+      boolean hasLlmMessage,
+      boolean hasHumanMessage) {
+    return new ConsultationMetricsSessionFact(
+        sessionId,
+        firstCustomerAt,
+        firstResponseAt,
+        firstLlmResponseAt,
+        firstHumanResponseAt,
+        handledToday,
+        hasLlmMessage,
+        hasHumanMessage);
+  }
+}

--- a/backend/src/test/java/com/init/workflowruntime/infrastructure/persistence/JpaConsultationMetricsRepositoryTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/infrastructure/persistence/JpaConsultationMetricsRepositoryTest.java
@@ -1,0 +1,200 @@
+package com.init.workflowruntime.infrastructure.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.init.workflowruntime.domain.ChatSessionStatus;
+import com.init.workflowruntime.domain.ConsultationMetricsSessionFact;
+import jakarta.persistence.EntityManager;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(JpaConsultationMetricsRepository.class)
+@DisplayName("JpaConsultationMetricsRepository")
+class JpaConsultationMetricsRepositoryTest {
+
+  private static final OffsetDateTime PERIOD_START =
+      OffsetDateTime.parse("2026-05-27T00:00:00+09:00");
+  private static final OffsetDateTime PERIOD_END =
+      OffsetDateTime.parse("2026-05-28T00:00:00+09:00");
+
+  @Autowired private JpaConsultationMetricsRepository repository;
+
+  @Autowired private EntityManager entityManager;
+
+  @Test
+  @DisplayName("findSessionFacts: 오늘 시작 세션의 첫응답과 오늘 종료 세션의 처리 분류를 집계한다")
+  void should_findSessionFacts_when_sessionsStartedOrCompletedToday() {
+    Long workspaceId = persistWorkspaceAndVersion();
+
+    Long llmOnlySessionId =
+        persistSession(
+            workspaceId,
+            ChatSessionStatus.COMPLETED,
+            at("2026-05-27T09:00:00+09:00"),
+            at("2026-05-27T09:05:00+09:00"));
+    persistMessage(llmOnlySessionId, 1, "USER", at("2026-05-27T09:00:00+09:00"));
+    persistMessage(llmOnlySessionId, 2, "ASSISTANT", at("2026-05-27T09:00:03+09:00"));
+
+    Long mixedSessionId =
+        persistSession(
+            workspaceId,
+            ChatSessionStatus.COMPLETED,
+            at("2026-05-27T11:00:00+09:00"),
+            at("2026-05-27T11:10:00+09:00"));
+    persistMessage(mixedSessionId, 1, "CUSTOMER", at("2026-05-27T11:00:00+09:00"));
+    persistMessage(mixedSessionId, 2, "ASSISTANT", at("2026-05-27T11:00:02+09:00"));
+    persistMessage(mixedSessionId, 3, "AGENT", at("2026-05-27T11:05:00+09:00"));
+
+    Long oldHumanCompletedSessionId =
+        persistSession(
+            workspaceId,
+            ChatSessionStatus.COMPLETED,
+            at("2026-05-26T15:00:00+09:00"),
+            at("2026-05-27T12:00:00+09:00"));
+    persistMessage(oldHumanCompletedSessionId, 1, "USER", at("2026-05-26T15:00:00+09:00"));
+    persistMessage(oldHumanCompletedSessionId, 2, "COUNSELOR", at("2026-05-26T15:02:00+09:00"));
+
+    persistSession(workspaceId, ChatSessionStatus.OPEN, at("2026-05-26T16:00:00+09:00"), null);
+
+    List<ConsultationMetricsSessionFact> facts =
+        repository.findSessionFacts(workspaceId, PERIOD_START, PERIOD_END);
+    Map<Long, ConsultationMetricsSessionFact> bySessionId =
+        facts.stream()
+            .collect(
+                Collectors.toMap(ConsultationMetricsSessionFact::sessionId, Function.identity()));
+
+    assertThat(bySessionId)
+        .containsOnlyKeys(llmOnlySessionId, mixedSessionId, oldHumanCompletedSessionId);
+    assertThat(
+            Duration.between(
+                    bySessionId.get(llmOnlySessionId).firstCustomerAt(),
+                    bySessionId.get(llmOnlySessionId).firstResponseAt())
+                .getSeconds())
+        .isEqualTo(3);
+    assertThat(
+            Duration.between(
+                    bySessionId.get(llmOnlySessionId).firstCustomerAt(),
+                    bySessionId.get(llmOnlySessionId).firstLlmResponseAt())
+                .getSeconds())
+        .isEqualTo(3);
+    assertThat(bySessionId.get(llmOnlySessionId).firstHumanResponseAt()).isNull();
+    assertThat(bySessionId.get(llmOnlySessionId).handledToday()).isTrue();
+    assertThat(bySessionId.get(llmOnlySessionId).hasLlmMessage()).isTrue();
+    assertThat(bySessionId.get(llmOnlySessionId).hasHumanMessage()).isFalse();
+
+    assertThat(
+            Duration.between(
+                    bySessionId.get(mixedSessionId).firstCustomerAt(),
+                    bySessionId.get(mixedSessionId).firstResponseAt())
+                .getSeconds())
+        .isEqualTo(2);
+    assertThat(
+            Duration.between(
+                    bySessionId.get(mixedSessionId).firstCustomerAt(),
+                    bySessionId.get(mixedSessionId).firstHumanResponseAt())
+                .getSeconds())
+        .isEqualTo(300);
+    assertThat(bySessionId.get(mixedSessionId).hasLlmMessage()).isTrue();
+    assertThat(bySessionId.get(mixedSessionId).hasHumanMessage()).isTrue();
+
+    assertThat(bySessionId.get(oldHumanCompletedSessionId).firstCustomerAt()).isNull();
+    assertThat(bySessionId.get(oldHumanCompletedSessionId).handledToday()).isTrue();
+    assertThat(bySessionId.get(oldHumanCompletedSessionId).hasHumanMessage()).isTrue();
+  }
+
+  private Long persistWorkspaceAndVersion() {
+    update(
+        """
+        insert into app.workspace (id, workspace_key, name, status, created_at, updated_at)
+        values (2, 'consultation-metrics', 'Consultation Metrics', 'ACTIVE', :now, :now)
+        """,
+        Map.of("now", PERIOD_START));
+    update(
+        """
+        insert into pack.domain_pack
+          (id, workspace_id, pack_key, name, status, created_at, updated_at)
+        values (10, 2, 'consultation-metrics-pack', 'Metrics Pack', 'ACTIVE', :now, :now)
+        """,
+        Map.of("now", PERIOD_START));
+    update(
+        """
+        insert into pack.domain_pack_version
+          (id, domain_pack_id, version_no, lifecycle_status, summary_json, created_at, updated_at, version)
+        values (20, 10, 1, 'DRAFT', '{}', :now, :now, 0)
+        """,
+        Map.of("now", PERIOD_START));
+    return 2L;
+  }
+
+  private Long persistSession(
+      Long workspaceId,
+      ChatSessionStatus status,
+      OffsetDateTime startedAt,
+      OffsetDateTime endedAt) {
+    Long sessionId =
+        ((Number)
+                entityManager
+                    .createNativeQuery("select coalesce(max(id), 0) + 1 from runtime.chat_session")
+                    .getSingleResult())
+            .longValue();
+    var query =
+        entityManager.createNativeQuery(
+            """
+            insert into runtime.chat_session
+              (id, workspace_id, domain_pack_version_id, status, channel, meta_json, started_at, ended_at)
+            values (:id, :workspaceId, 20, :status, 'WEB', '{}', :startedAt, :endedAt)
+            """);
+    query.setParameter("id", sessionId);
+    query.setParameter("workspaceId", workspaceId);
+    query.setParameter("status", status.name());
+    query.setParameter("startedAt", startedAt);
+    query.setParameter("endedAt", endedAt);
+    query.executeUpdate();
+    return sessionId;
+  }
+
+  private void persistMessage(
+      Long sessionId, int seqNo, String senderRole, OffsetDateTime createdAt) {
+    Long messageId =
+        ((Number)
+                entityManager
+                    .createNativeQuery("select coalesce(max(id), 0) + 1 from runtime.chat_message")
+                    .getSingleResult())
+            .longValue();
+    var query =
+        entityManager.createNativeQuery(
+            """
+            insert into runtime.chat_message
+              (id, chat_session_id, seq_no, sender_role, message_type, content, payload_json, created_at)
+            values (:id, :sessionId, :seqNo, :senderRole, 'TEXT', :senderRole, '{}', :createdAt)
+            """);
+    query.setParameter("id", messageId);
+    query.setParameter("sessionId", sessionId);
+    query.setParameter("seqNo", seqNo);
+    query.setParameter("senderRole", senderRole);
+    query.setParameter("createdAt", createdAt);
+    query.executeUpdate();
+  }
+
+  private void update(String sql, Map<String, Object> params) {
+    var query = entityManager.createNativeQuery(sql);
+    params.forEach(query::setParameter);
+    query.executeUpdate();
+  }
+
+  private OffsetDateTime at(String value) {
+    return OffsetDateTime.parse(value);
+  }
+}

--- a/backend/src/test/java/com/init/workflowruntime/presentation/ConsultationMetricsControllerTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/presentation/ConsultationMetricsControllerTest.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.init.shared.infrastructure.security.JwtAuthenticationFilter;
 import com.init.workflowruntime.application.ConsultationMetricsService;
+import com.init.workflowruntime.application.command.GetWorkspaceMetricsCommand;
 import com.init.workflowruntime.application.dto.ConsultationMetricsResponse;
 import com.init.workspace.application.exception.WorkspaceAccessDeniedException;
 import java.time.OffsetDateTime;
@@ -41,7 +42,7 @@ class ConsultationMetricsControllerTest {
   @Test
   @DisplayName("GET /api/v1/workspaces/{workspaceId}/consultation/metrics - 멤버 조회 성공")
   void should_returnMetrics_when_workspaceMemberRequests() throws Exception {
-    given(consultationMetricsService.getWorkspaceMetrics(2L, 7L))
+    given(consultationMetricsService.getWorkspaceMetrics(new GetWorkspaceMetricsCommand(2L, 7L)))
         .willReturn(
             new ConsultationMetricsResponse(
                 2L,
@@ -69,7 +70,7 @@ class ConsultationMetricsControllerTest {
   @Test
   @DisplayName("GET /api/v1/workspaces/{workspaceId}/consultation/metrics - 멤버 아님")
   void should_returnForbidden_when_userIsNotWorkspaceMember() throws Exception {
-    given(consultationMetricsService.getWorkspaceMetrics(2L, 7L))
+    given(consultationMetricsService.getWorkspaceMetrics(new GetWorkspaceMetricsCommand(2L, 7L)))
         .willThrow(new WorkspaceAccessDeniedException("워크스페이스에 접근 권한이 없습니다."));
 
     mockMvc
@@ -81,7 +82,7 @@ class ConsultationMetricsControllerTest {
   @Test
   @DisplayName("GET /api/v1/workspaces/{workspaceId}/consultation/metrics - 데이터 없음")
   void should_returnEmptyMetrics_when_workspaceHasNoData() throws Exception {
-    given(consultationMetricsService.getWorkspaceMetrics(2L, 7L))
+    given(consultationMetricsService.getWorkspaceMetrics(new GetWorkspaceMetricsCommand(2L, 7L)))
         .willReturn(
             new ConsultationMetricsResponse(
                 2L,

--- a/backend/src/test/java/com/init/workflowruntime/presentation/ConsultationMetricsControllerTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/presentation/ConsultationMetricsControllerTest.java
@@ -1,0 +1,110 @@
+package com.init.workflowruntime.presentation;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.init.shared.infrastructure.security.JwtAuthenticationFilter;
+import com.init.workflowruntime.application.ConsultationMetricsService;
+import com.init.workflowruntime.application.dto.ConsultationMetricsResponse;
+import com.init.workspace.application.exception.WorkspaceAccessDeniedException;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(
+    value = ConsultationMetricsController.class,
+    excludeFilters =
+        @ComponentScan.Filter(
+            type = FilterType.ASSIGNABLE_TYPE,
+            classes = JwtAuthenticationFilter.class))
+@AutoConfigureMockMvc(addFilters = false)
+class ConsultationMetricsControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @SuppressWarnings("removal")
+  @MockBean
+  private ConsultationMetricsService consultationMetricsService;
+
+  @Test
+  @DisplayName("GET /api/v1/workspaces/{workspaceId}/consultation/metrics - 멤버 조회 성공")
+  void should_returnMetrics_when_workspaceMemberRequests() throws Exception {
+    given(consultationMetricsService.getWorkspaceMetrics(2L, 7L))
+        .willReturn(
+            new ConsultationMetricsResponse(
+                2L,
+                OffsetDateTime.parse("2026-05-27T00:00:00+09:00"),
+                OffsetDateTime.parse("2026-05-28T00:00:00+09:00"),
+                134L,
+                3L,
+                420L,
+                14,
+                9,
+                5));
+
+    mockMvc
+        .perform(get("/api/v1/workspaces/2/consultation/metrics").principal(auth()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.workspaceId").value(2))
+        .andExpect(jsonPath("$.averageFirstResponseSeconds").value(134))
+        .andExpect(jsonPath("$.averageLlmFirstResponseSeconds").value(3))
+        .andExpect(jsonPath("$.averageHumanFirstResponseSeconds").value(420))
+        .andExpect(jsonPath("$.handledTodayCount").value(14))
+        .andExpect(jsonPath("$.llmHandledTodayCount").value(9))
+        .andExpect(jsonPath("$.humanHandledTodayCount").value(5));
+  }
+
+  @Test
+  @DisplayName("GET /api/v1/workspaces/{workspaceId}/consultation/metrics - 멤버 아님")
+  void should_returnForbidden_when_userIsNotWorkspaceMember() throws Exception {
+    given(consultationMetricsService.getWorkspaceMetrics(2L, 7L))
+        .willThrow(new WorkspaceAccessDeniedException("워크스페이스에 접근 권한이 없습니다."));
+
+    mockMvc
+        .perform(get("/api/v1/workspaces/2/consultation/metrics").principal(auth()))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.code").value("WORKSPACE_ACCESS_DENIED"));
+  }
+
+  @Test
+  @DisplayName("GET /api/v1/workspaces/{workspaceId}/consultation/metrics - 데이터 없음")
+  void should_returnEmptyMetrics_when_workspaceHasNoData() throws Exception {
+    given(consultationMetricsService.getWorkspaceMetrics(2L, 7L))
+        .willReturn(
+            new ConsultationMetricsResponse(
+                2L,
+                OffsetDateTime.parse("2026-05-27T00:00:00+09:00"),
+                OffsetDateTime.parse("2026-05-28T00:00:00+09:00"),
+                null,
+                null,
+                null,
+                0,
+                0,
+                0));
+
+    mockMvc
+        .perform(get("/api/v1/workspaces/2/consultation/metrics").principal(auth()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.averageFirstResponseSeconds").isEmpty())
+        .andExpect(jsonPath("$.averageLlmFirstResponseSeconds").isEmpty())
+        .andExpect(jsonPath("$.averageHumanFirstResponseSeconds").isEmpty())
+        .andExpect(jsonPath("$.handledTodayCount").value(0));
+  }
+
+  private UsernamePasswordAuthenticationToken auth() {
+    return new UsernamePasswordAuthenticationToken(
+        7L, null, List.of(new SimpleGrantedAuthority("ROLE_OPERATOR")));
+  }
+}

--- a/frontend/src/features/consultation/api/consultationApi.test.ts
+++ b/frontend/src/features/consultation/api/consultationApi.test.ts
@@ -298,4 +298,31 @@ describe("consultationApi", () => {
     );
     expect(result).toEqual(stubSession);
   });
+
+  it("getMetrics가 워크스페이스 상담 지표를 반환한다", async () => {
+    const stubMetrics = {
+      workspaceId: 2,
+      periodStart: "2026-05-27T00:00:00+09:00",
+      periodEnd: "2026-05-28T00:00:00+09:00",
+      averageFirstResponseSeconds: 134,
+      averageLlmFirstResponseSeconds: 3,
+      averageHumanFirstResponseSeconds: 420,
+      handledTodayCount: 14,
+      llmHandledTodayCount: 9,
+      humanHandledTodayCount: 5,
+    };
+    mockedCustomFetch.mockResolvedValue({
+      data: stubMetrics,
+      status: 200,
+      headers: new Headers(),
+    });
+
+    const result = await consultationApi.getMetrics(2);
+
+    expect(mockedCustomFetch).toHaveBeenCalledWith(
+      "/api/v1/workspaces/2/consultation/metrics",
+      { method: "GET" },
+    );
+    expect(result).toEqual(stubMetrics);
+  });
 });

--- a/frontend/src/features/consultation/api/consultationApi.ts
+++ b/frontend/src/features/consultation/api/consultationApi.ts
@@ -19,6 +19,18 @@ export interface ConsultationQueueEvent {
   occurredAt?: string;
 }
 
+export interface ConsultationMetrics {
+  workspaceId: number;
+  periodStart: string;
+  periodEnd: string;
+  averageFirstResponseSeconds: number | null;
+  averageLlmFirstResponseSeconds: number | null;
+  averageHumanFirstResponseSeconds: number | null;
+  handledTodayCount: number;
+  llmHandledTodayCount: number;
+  humanHandledTodayCount: number;
+}
+
 type SessionListResponse =
   | ChatSession[]
   | { data?: ChatSession[] | { content?: ChatSession[] }; content?: ChatSession[] };
@@ -95,5 +107,13 @@ export const consultationApi = {
       { method: "POST" },
     );
     return unwrapApiResponse<ChatSession>(response);
+  },
+
+  getMetrics: async (workspaceId: number): Promise<ConsultationMetrics> => {
+    const response = await customFetch<ConsultationMetrics | { data?: ConsultationMetrics }>(
+      `/api/v1/workspaces/${workspaceId}/consultation/metrics`,
+      { method: "GET" },
+    );
+    return unwrapApiResponse<ConsultationMetrics>(response);
   },
 };

--- a/frontend/src/pages/consultation/ui/ConsultationPage.test.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.test.tsx
@@ -171,6 +171,7 @@ describe("ConsultationPage", () => {
       throw new Error("Topbar node was not set");
     }
     return node as React.ReactElement<{
+      metricsViewState?: "loading" | "error" | "empty" | "ready";
       averageFirstResponseSeconds?: number | null;
       handledTodayCount?: number | null;
     }>;
@@ -195,6 +196,20 @@ describe("ConsultationPage", () => {
     expect(topbar.getByText("2분 14초")).toBeInTheDocument();
     expect(topbar.getByText("14건")).toBeInTheDocument();
     topbar.unmount();
+  });
+
+  it("renders metric loading state while the request is pending", async () => {
+    vi.mocked(consultationApi.getMetrics).mockImplementationOnce(() => new Promise(() => {}));
+
+    const { unmount } = render(<ConsultationPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(getLatestTopbarNode().props.metricsViewState).toBe("loading");
+    });
+    const topbar = renderLatestTopbar();
+    expect(topbar.getAllByText("로딩중")).toHaveLength(2);
+    topbar.unmount();
+    unmount();
   });
 
   it("renders metric fallbacks when average value is null", async () => {
@@ -225,7 +240,7 @@ describe("ConsultationPage", () => {
     topbar.unmount();
   });
 
-  it("keeps metric fallbacks and shows a toast once when metrics fail", async () => {
+  it("renders metric error state and shows a toast once when metrics fail", async () => {
     vi.mocked(consultationApi.getMetrics).mockRejectedValueOnce(new Error("Metrics failed"));
 
     render(<ConsultationPage />, { wrapper: Wrapper });
@@ -233,9 +248,13 @@ describe("ConsultationPage", () => {
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith("상담 지표를 불러오지 못했습니다.");
     });
+    expect(toast.error).toHaveBeenCalledTimes(1);
 
+    await waitFor(() => {
+      expect(getLatestTopbarNode().props.metricsViewState).toBe("error");
+    });
     const topbar = renderLatestTopbar();
-    expect(topbar.getAllByText("--")).toHaveLength(2);
+    expect(topbar.getAllByText("오류")).toHaveLength(2);
     topbar.unmount();
   });
 
@@ -270,6 +289,14 @@ describe("ConsultationPage", () => {
       expect.stringContaining("consultation.queue"),
       expect.any(Function),
     );
+    expect(consultationApi.getMetrics).not.toHaveBeenCalled();
+
+    await waitFor(() => {
+      expect(getLatestTopbarNode().props.metricsViewState).toBe("empty");
+    });
+    const topbar = renderLatestTopbar();
+    expect(topbar.getAllByText("--")).toHaveLength(2);
+    topbar.unmount();
   });
 
   it("updates queue items from workspace queue upsert events", async () => {

--- a/frontend/src/pages/consultation/ui/ConsultationPage.test.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.test.tsx
@@ -103,6 +103,19 @@ vi.mock("../../../features/consultation/api/consultationApi", () => ({
         assignedCounselorId: null,
       }),
     ),
+    getMetrics: vi.fn(() =>
+      Promise.resolve({
+        workspaceId: 2,
+        periodStart: "2026-05-27T00:00:00+09:00",
+        periodEnd: "2026-05-28T00:00:00+09:00",
+        averageFirstResponseSeconds: 134,
+        averageLlmFirstResponseSeconds: 3,
+        averageHumanFirstResponseSeconds: 420,
+        handledTodayCount: 14,
+        llmHandledTodayCount: 9,
+        humanHandledTodayCount: 5,
+      }),
+    ),
     sendMessage: vi.fn((_sessionId: number, content: string, isNote = false) =>
       Promise.resolve({
         id: 200,
@@ -148,6 +161,82 @@ describe("ConsultationPage", () => {
     shellContext.workspace = { id: 2, name: "QA Alpha" };
     window.alert = vi.fn();
     window.localStorage.clear();
+  });
+
+  const getLatestTopbarNode = () => {
+    const node = [...shellContext.setTopbarRight.mock.calls]
+      .reverse()
+      .find(([value]) => value !== undefined)?.[0];
+    if (!node) {
+      throw new Error("Topbar node was not set");
+    }
+    return node as React.ReactElement<{
+      averageFirstResponseSeconds?: number | null;
+      handledTodayCount?: number | null;
+    }>;
+  };
+
+  const renderLatestTopbar = () => {
+    const node = getLatestTopbarNode();
+    return render(<>{node}</>);
+  };
+
+  it("loads consultation metrics and renders the topbar values", async () => {
+    render(<ConsultationPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(consultationApi.getMetrics).toHaveBeenCalledWith(2);
+    });
+
+    await waitFor(() => {
+      expect(getLatestTopbarNode().props.averageFirstResponseSeconds).toBe(134);
+    });
+    const topbar = renderLatestTopbar();
+    expect(topbar.getByText("2분 14초")).toBeInTheDocument();
+    expect(topbar.getByText("14건")).toBeInTheDocument();
+    topbar.unmount();
+  });
+
+  it("renders metric fallbacks when average value is null", async () => {
+    vi.mocked(consultationApi.getMetrics).mockResolvedValueOnce({
+      workspaceId: 2,
+      periodStart: "2026-05-27T00:00:00+09:00",
+      periodEnd: "2026-05-28T00:00:00+09:00",
+      averageFirstResponseSeconds: null,
+      averageLlmFirstResponseSeconds: null,
+      averageHumanFirstResponseSeconds: null,
+      handledTodayCount: 0,
+      llmHandledTodayCount: 0,
+      humanHandledTodayCount: 0,
+    });
+
+    render(<ConsultationPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(consultationApi.getMetrics).toHaveBeenCalledWith(2);
+    });
+
+    await waitFor(() => {
+      expect(getLatestTopbarNode().props.handledTodayCount).toBe(0);
+    });
+    const topbar = renderLatestTopbar();
+    expect(topbar.getByText("--")).toBeInTheDocument();
+    expect(topbar.getByText("0건")).toBeInTheDocument();
+    topbar.unmount();
+  });
+
+  it("keeps metric fallbacks and shows a toast once when metrics fail", async () => {
+    vi.mocked(consultationApi.getMetrics).mockRejectedValueOnce(new Error("Metrics failed"));
+
+    render(<ConsultationPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("상담 지표를 불러오지 못했습니다.");
+    });
+
+    const topbar = renderLatestTopbar();
+    expect(topbar.getAllByText("--")).toHaveLength(2);
+    topbar.unmount();
   });
 
   it("renders 3-pane structure with QueuePanel, ChatPanel, and CustomerPanel", async () => {

--- a/frontend/src/pages/consultation/ui/ConsultationPage.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.tsx
@@ -12,6 +12,7 @@ import type { ChatMessage as UiChatMessage } from "../../../features/consultatio
 import { consultationApi } from "../../../features/consultation/api/consultationApi";
 import type {
   ChatSession,
+  ConsultationMetrics,
   ConsultationQueueEvent,
 } from "../../../features/consultation/api/consultationApi";
 import { CustomerPanel } from "./sections/CustomerPanel";
@@ -127,7 +128,23 @@ const sortQueueCustomers = (customers: QueueCustomer[]) =>
     return bTime - aTime;
   });
 
-const StatusRight = () => (
+const formatAverageFirstResponse = (seconds?: number | null) => {
+  if (seconds == null) return "--";
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  return minutes > 0 ? `${minutes}분 ${remainingSeconds}초` : `${remainingSeconds}초`;
+};
+
+const formatHandledTodayCount = (count?: number | null) => {
+  return count == null ? "--" : `${count}건`;
+};
+
+type StatusRightProps = {
+  averageFirstResponseSeconds?: number | null;
+  handledTodayCount?: number | null;
+};
+
+const StatusRight = ({ averageFirstResponseSeconds, handledTodayCount }: StatusRightProps) => (
   <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
     <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
       <Dot tone="signal" />
@@ -136,13 +153,16 @@ const StatusRight = () => (
     <div style={{ width: 1, height: 16, background: "var(--line)" }} />
     <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
       <Mono style={{ fontSize: 11, color: "var(--ink-3)" }}>평균 첫응답</Mono>
-      <span style={{ fontSize: 14, fontWeight: 700 }}>2분</span>
-      <Mono style={{ fontSize: 11, color: "var(--ink-3)" }}>14초</Mono>
+      <span style={{ fontSize: 14, fontWeight: 700 }}>
+        {formatAverageFirstResponse(averageFirstResponseSeconds)}
+      </span>
     </div>
     <div style={{ width: 1, height: 16, background: "var(--line)" }} />
     <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
       <Mono style={{ fontSize: 11, color: "var(--ink-3)" }}>오늘 처리</Mono>
-      <span style={{ fontSize: 14, fontWeight: 700 }}>14건</span>
+      <span style={{ fontSize: 14, fontWeight: 700 }}>
+        {formatHandledTodayCount(handledTodayCount)}
+      </span>
     </div>
   </div>
 );
@@ -154,6 +174,7 @@ export const ConsultationPage: React.FC = () => {
   const [activeCustomerId, setActiveCustomerId] = useState<string | null>(null);
   const [messages, setMessages] = useState<UiChatMessage[]>([]);
   const [messagesCustomerId, setMessagesCustomerId] = useState<string | null>(null);
+  const [metrics, setMetrics] = useState<ConsultationMetrics | null>(null);
   const [memos, setMemos] = useState<Record<string, string>>({});
   const [selectedMessageId, setSelectedMessageId] = useState<string | null>(null);
   const [isSending, setIsSending] = useState(false);
@@ -163,11 +184,13 @@ export const ConsultationPage: React.FC = () => {
   const pendingIdsRef = useRef<Set<string>>(new Set());
   const tempCounterRef = useRef(0);
   const activeCustomerIdRef = useRef<string | null>(null);
+  const metricsErrorToastShownRef = useRef(false);
   const currentCounselorId = getAuthUser()?.id ?? null;
 
   const activeCustomer = queue.find((c) => c.id === activeCustomerId) || null;
   const activeCustomerName = activeCustomer?.name?.trim() || "Unknown";
   const activeCustomerInitial = activeCustomerName.charAt(0) || "?";
+  const activeMetrics = metrics?.workspaceId === workspaceId ? metrics : null;
   const visibleMessages =
     activeCustomer && messagesCustomerId === activeCustomer.id ? messages : [];
   const selectedMessage = visibleMessages.find((m) => m.id === selectedMessageId) || null;
@@ -191,13 +214,52 @@ export const ConsultationPage: React.FC = () => {
   }, [activeCustomerId]);
 
   useEffect(() => {
-    setTopbarRight(<StatusRight />);
-    setCrumbs(["CARD-CS", "실시간 상담"]);
+    setTopbarRight(
+      <StatusRight
+        averageFirstResponseSeconds={activeMetrics?.averageFirstResponseSeconds ?? null}
+        handledTodayCount={activeMetrics?.handledTodayCount ?? null}
+      />,
+    );
     return () => {
       setTopbarRight(undefined);
+    };
+  }, [setTopbarRight, activeMetrics]);
+
+  useEffect(() => {
+    setCrumbs(["CARD-CS", "실시간 상담"]);
+    return () => {
       setCrumbs([]);
     };
-  }, [setTopbarRight, setCrumbs]);
+  }, [setCrumbs]);
+
+  useEffect(() => {
+    if (!workspaceId) {
+      return;
+    }
+
+    let cancelled = false;
+    metricsErrorToastShownRef.current = false;
+
+    consultationApi
+      .getMetrics(workspaceId)
+      .then((data) => {
+        if (cancelled) return;
+        setMetrics(data);
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        console.error("Failed to load consultation metrics:", error);
+        setMetrics(null);
+        if (!metricsErrorToastShownRef.current) {
+          metricsErrorToastShownRef.current = true;
+          toast.error("상담 지표를 불러오지 못했습니다.");
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [workspaceId]);
 
   const loadQueue = useCallback(async () => {
     if (!workspaceId) {

--- a/frontend/src/pages/consultation/ui/ConsultationPage.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.tsx
@@ -139,33 +139,60 @@ const formatHandledTodayCount = (count?: number | null) => {
   return count == null ? "--" : `${count}건`;
 };
 
+type MetricsViewState = "loading" | "error" | "empty" | "ready";
+
 type StatusRightProps = {
+  metricsViewState: MetricsViewState;
   averageFirstResponseSeconds?: number | null;
   handledTodayCount?: number | null;
 };
 
-const StatusRight = ({ averageFirstResponseSeconds, handledTodayCount }: StatusRightProps) => (
-  <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
-    <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
-      <Dot tone="signal" />
-      <span style={{ fontSize: 12 }}>응대 가능</span>
+const formatMetricValue = (
+  metricsViewState: MetricsViewState,
+  value: number | null | undefined,
+  formatter: (value?: number | null) => string,
+) => {
+  if (metricsViewState === "loading") return "로딩중";
+  if (metricsViewState === "error") return "오류";
+  if (metricsViewState === "empty") return "--";
+  return formatter(value);
+};
+
+const StatusRight = ({
+  metricsViewState,
+  averageFirstResponseSeconds,
+  handledTodayCount,
+}: StatusRightProps) => {
+  const averageLabel = formatMetricValue(
+    metricsViewState,
+    averageFirstResponseSeconds,
+    formatAverageFirstResponse,
+  );
+  const handledLabel = formatMetricValue(
+    metricsViewState,
+    handledTodayCount,
+    formatHandledTodayCount,
+  );
+
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+        <Dot tone="signal" />
+        <span style={{ fontSize: 12 }}>응대 가능</span>
+      </div>
+      <div style={{ width: 1, height: 16, background: "var(--line)" }} />
+      <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+        <Mono style={{ fontSize: 11, color: "var(--ink-3)" }}>평균 첫응답</Mono>
+        <span style={{ fontSize: 14, fontWeight: 700 }}>{averageLabel}</span>
+      </div>
+      <div style={{ width: 1, height: 16, background: "var(--line)" }} />
+      <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+        <Mono style={{ fontSize: 11, color: "var(--ink-3)" }}>오늘 처리</Mono>
+        <span style={{ fontSize: 14, fontWeight: 700 }}>{handledLabel}</span>
+      </div>
     </div>
-    <div style={{ width: 1, height: 16, background: "var(--line)" }} />
-    <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
-      <Mono style={{ fontSize: 11, color: "var(--ink-3)" }}>평균 첫응답</Mono>
-      <span style={{ fontSize: 14, fontWeight: 700 }}>
-        {formatAverageFirstResponse(averageFirstResponseSeconds)}
-      </span>
-    </div>
-    <div style={{ width: 1, height: 16, background: "var(--line)" }} />
-    <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
-      <Mono style={{ fontSize: 11, color: "var(--ink-3)" }}>오늘 처리</Mono>
-      <span style={{ fontSize: 14, fontWeight: 700 }}>
-        {formatHandledTodayCount(handledTodayCount)}
-      </span>
-    </div>
-  </div>
-);
+  );
+};
 
 export const ConsultationPage: React.FC = () => {
   const { setTopbarRight, setCrumbs, workspace } = useOutletContext<ShellContext>();
@@ -175,6 +202,8 @@ export const ConsultationPage: React.FC = () => {
   const [messages, setMessages] = useState<UiChatMessage[]>([]);
   const [messagesCustomerId, setMessagesCustomerId] = useState<string | null>(null);
   const [metrics, setMetrics] = useState<ConsultationMetrics | null>(null);
+  const [isMetricsLoading, setIsMetricsLoading] = useState(false);
+  const [metricsError, setMetricsError] = useState<string | null>(null);
   const [memos, setMemos] = useState<Record<string, string>>({});
   const [selectedMessageId, setSelectedMessageId] = useState<string | null>(null);
   const [isSending, setIsSending] = useState(false);
@@ -191,6 +220,13 @@ export const ConsultationPage: React.FC = () => {
   const activeCustomerName = activeCustomer?.name?.trim() || "Unknown";
   const activeCustomerInitial = activeCustomerName.charAt(0) || "?";
   const activeMetrics = metrics?.workspaceId === workspaceId ? metrics : null;
+  const metricsViewState: MetricsViewState = isMetricsLoading
+    ? "loading"
+    : metricsError
+      ? "error"
+      : activeMetrics
+        ? "ready"
+        : "empty";
   const visibleMessages =
     activeCustomer && messagesCustomerId === activeCustomer.id ? messages : [];
   const selectedMessage = visibleMessages.find((m) => m.id === selectedMessageId) || null;
@@ -216,6 +252,7 @@ export const ConsultationPage: React.FC = () => {
   useEffect(() => {
     setTopbarRight(
       <StatusRight
+        metricsViewState={metricsViewState}
         averageFirstResponseSeconds={activeMetrics?.averageFirstResponseSeconds ?? null}
         handledTodayCount={activeMetrics?.handledTodayCount ?? null}
       />,
@@ -223,7 +260,7 @@ export const ConsultationPage: React.FC = () => {
     return () => {
       setTopbarRight(undefined);
     };
-  }, [setTopbarRight, activeMetrics]);
+  }, [setTopbarRight, activeMetrics, metricsViewState]);
 
   useEffect(() => {
     setCrumbs(["CARD-CS", "실시간 상담"]);
@@ -234,27 +271,40 @@ export const ConsultationPage: React.FC = () => {
 
   useEffect(() => {
     if (!workspaceId) {
+      setMetrics(null);
+      setMetricsError(null);
+      setIsMetricsLoading(false);
       return;
     }
 
     let cancelled = false;
     metricsErrorToastShownRef.current = false;
+    setIsMetricsLoading(true);
+    setMetricsError(null);
 
-    consultationApi
-      .getMetrics(workspaceId)
-      .then((data) => {
+    const loadMetrics = async () => {
+      try {
+        const data = await consultationApi.getMetrics(workspaceId);
         if (cancelled) return;
         setMetrics(data);
-      })
-      .catch((error) => {
+        setMetricsError(null);
+      } catch (error) {
         if (cancelled) return;
         console.error("Failed to load consultation metrics:", error);
         setMetrics(null);
+        setMetricsError("상담 지표를 불러오지 못했습니다.");
         if (!metricsErrorToastShownRef.current) {
           metricsErrorToastShownRef.current = true;
           toast.error("상담 지표를 불러오지 못했습니다.");
         }
-      });
+      } finally {
+        if (!cancelled) {
+          setIsMetricsLoading(false);
+        }
+      }
+    };
+
+    void loadMetrics();
 
     return () => {
       cancelled = true;


### PR DESCRIPTION
## Summary
- Add workspace consultation metrics API for the counselor topbar.
- Aggregate total, LLM, and human first-response and handled-today metrics for the Asia/Seoul day window.
- Connect ConsultationPage topbar to the metrics API with fallback display and error toast.

## Issue
Closes #296

## Validation
- mise exec -- ./gradlew test --tests '*Consultation*' --tests '*Counselor*'
- mise exec -- ./gradlew spotlessCheck
- pnpm test src/pages/consultation/ui/ConsultationPage.test.tsx src/features/consultation/api/consultationApi.test.ts
- pnpm exec eslint src/pages/consultation/ui/ConsultationPage.tsx src/pages/consultation/ui/ConsultationPage.test.tsx src/features/consultation/api/consultationApi.ts src/features/consultation/api/consultationApi.test.ts
- pnpm build

Note: full frontend pnpm lint still fails on pre-existing unrelated lint issues outside this change set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 워크스페이스 상담 메트릭 조회 API 및 서비스 추가
  * 평균 첫 응답 시간(전체/LLM/휴먼)과 오늘 처리 건수(총/LLM/휴먼) 노출
  * 상담 페이지 상단에 실시간 메트릭 상태(로딩/오류/빈값/값 표시) 및 포맷된 표시 추가

* **Tests**
  * 서비스·컨트롤러·저장소의 단위/통합 테스트 추가 및 UI 테스트 확장

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ajou-2026-1-capstone-5/ostone/pull/303?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->