### PR TITLE
fix: Stabilize counselor chat role labels and session metadata

### DIFF
--- a/backend/src/main/java/com/init/workflowruntime/application/ChatSessionMetadataService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/ChatSessionMetadataService.java
@@ -1,0 +1,96 @@
+package com.init.workflowruntime.application;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.init.workflowruntime.domain.ChatMessage;
+import com.init.workflowruntime.domain.ChatSession;
+import java.time.OffsetDateTime;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ChatSessionMetadataService {
+
+  private static final int TITLE_MAX_LENGTH = 40;
+  private static final int PREVIEW_MAX_LENGTH = 80;
+
+  private final ObjectMapper objectMapper;
+
+  public ChatSessionMetadataService(ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  public void updateAfterMessage(ChatSession session, ChatMessage message) {
+    ObjectNode meta = parseMeta(session.getMetaJson());
+    ensureTitle(meta, session, message);
+    meta.put("messageCount", message.getSeqNo());
+    meta.put("lastMessagePreview", truncate(message.getContent(), PREVIEW_MAX_LENGTH));
+    meta.put("lastMessageRole", message.getSenderRole());
+    meta.put("lastMessageAt", resolveCreatedAt(message).toString());
+    session.updateMetaJson(meta.toString());
+  }
+
+  private ObjectNode parseMeta(String metaJson) {
+    if (metaJson == null || metaJson.isBlank()) {
+      return objectMapper.createObjectNode();
+    }
+    try {
+      JsonNode node = objectMapper.readTree(metaJson);
+      if (node != null && node.isObject()) {
+        return (ObjectNode) node;
+      }
+    } catch (Exception ignored) {
+      // Invalid legacy metadata should not block chat message persistence.
+    }
+    return objectMapper.createObjectNode();
+  }
+
+  private void ensureTitle(ObjectNode meta, ChatSession session, ChatMessage message) {
+    if (hasText(meta.path("title").asText(null))) {
+      return;
+    }
+
+    String title = firstText(meta, "handoffReason");
+    if (!hasText(title) && isCustomerRole(message.getSenderRole())) {
+      title = truncate(message.getContent(), TITLE_MAX_LENGTH);
+    }
+    if (!hasText(title)) {
+      String customerName = firstText(meta, "customerName");
+      if (hasText(customerName)) {
+        title = customerName + " 상담";
+      }
+    }
+    if (!hasText(title)) {
+      title = hasText(session.getChannel()) ? session.getChannel() + " 상담" : "채팅 상담";
+    }
+    meta.put("title", truncate(title, TITLE_MAX_LENGTH));
+  }
+
+  private static String firstText(ObjectNode meta, String fieldName) {
+    String value = meta.path(fieldName).asText(null);
+    return hasText(value) ? value.trim() : "";
+  }
+
+  private static boolean isCustomerRole(String senderRole) {
+    return "USER".equals(senderRole) || "CUSTOMER".equals(senderRole);
+  }
+
+  private static OffsetDateTime resolveCreatedAt(ChatMessage message) {
+    return message.getCreatedAt() != null ? message.getCreatedAt() : OffsetDateTime.now();
+  }
+
+  private static String truncate(String value, int maxLength) {
+    if (value == null || value.isBlank()) {
+      return "";
+    }
+    String normalized = value.trim().replaceAll("\\s+", " ");
+    if (normalized.length() <= maxLength) {
+      return normalized;
+    }
+    return normalized.substring(0, maxLength - 1).trim() + "…";
+  }
+
+  private static boolean hasText(String value) {
+    return value != null && !value.isBlank();
+  }
+}

--- a/backend/src/main/java/com/init/workflowruntime/application/ChatSessionMetadataService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/ChatSessionMetadataService.java
@@ -1,16 +1,20 @@
 package com.init.workflowruntime.application;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.init.workflowruntime.domain.ChatMessage;
 import com.init.workflowruntime.domain.ChatSession;
 import java.time.OffsetDateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 @Service
 public class ChatSessionMetadataService {
 
+  private static final Logger log = LoggerFactory.getLogger(ChatSessionMetadataService.class);
   private static final int TITLE_MAX_LENGTH = 40;
   private static final int PREVIEW_MAX_LENGTH = 80;
 
@@ -39,8 +43,8 @@ public class ChatSessionMetadataService {
       if (node != null && node.isObject()) {
         return (ObjectNode) node;
       }
-    } catch (Exception ignored) {
-      // Invalid legacy metadata should not block chat message persistence.
+    } catch (JsonProcessingException e) {
+      log.warn("Invalid legacy chat session metaJson; fallback to empty object", e);
     }
     return objectMapper.createObjectNode();
   }

--- a/backend/src/main/java/com/init/workflowruntime/application/ChatSessionMetadataService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/ChatSessionMetadataService.java
@@ -10,8 +10,10 @@ import java.time.OffsetDateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional(readOnly = true)
 public class ChatSessionMetadataService {
 
   private static final Logger log = LoggerFactory.getLogger(ChatSessionMetadataService.class);
@@ -24,6 +26,7 @@ public class ChatSessionMetadataService {
     this.objectMapper = objectMapper;
   }
 
+  @Transactional
   public void updateAfterMessage(ChatSession session, ChatMessage message) {
     ObjectNode meta = parseMeta(session.getMetaJson());
     ensureTitle(meta, session, message);

--- a/backend/src/main/java/com/init/workflowruntime/application/ChatWebSocketService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/ChatWebSocketService.java
@@ -25,16 +25,19 @@ public class ChatWebSocketService {
   private final ChatMessageRepository chatMessageRepository;
   private final SimpMessagingTemplate messagingTemplate;
   private final ApplicationEventPublisher eventPublisher;
+  private final ChatSessionMetadataService chatSessionMetadataService;
 
   public ChatWebSocketService(
       ChatSessionRepository chatSessionRepository,
       ChatMessageRepository chatMessageRepository,
       SimpMessagingTemplate messagingTemplate,
-      ApplicationEventPublisher eventPublisher) {
+      ApplicationEventPublisher eventPublisher,
+      ChatSessionMetadataService chatSessionMetadataService) {
     this.chatSessionRepository = chatSessionRepository;
     this.chatMessageRepository = chatMessageRepository;
     this.messagingTemplate = messagingTemplate;
     this.eventPublisher = eventPublisher;
+    this.chatSessionMetadataService = chatSessionMetadataService;
   }
 
   @Transactional
@@ -69,9 +72,10 @@ public class ChatWebSocketService {
     ChatMessage message =
         ChatMessage.create(
             command.sessionId(), nextSeqNo, command.senderRole(), "TEXT", command.content());
-    chatMessageRepository.save(message);
+    ChatMessage savedMessage = chatMessageRepository.save(message);
+    chatSessionMetadataService.updateAfterMessage(session, savedMessage);
 
-    ChatMessageResponse response = ChatMessageResponse.from(message);
+    ChatMessageResponse response = ChatMessageResponse.from(savedMessage);
     String destination = "/topic/chat." + command.sessionId();
 
     TransactionSynchronizationManager.registerSynchronization(

--- a/backend/src/main/java/com/init/workflowruntime/application/ConsultationService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/ConsultationService.java
@@ -31,16 +31,19 @@ public class ConsultationService {
   private final ChatMessageRepository chatMessageRepository;
   private final WorkspaceMemberRepository workspaceMemberRepository;
   private final ApplicationEventPublisher eventPublisher;
+  private final ChatSessionMetadataService chatSessionMetadataService;
 
   public ConsultationService(
       ChatSessionRepository chatSessionRepository,
       ChatMessageRepository chatMessageRepository,
       WorkspaceMemberRepository workspaceMemberRepository,
-      ApplicationEventPublisher eventPublisher) {
+      ApplicationEventPublisher eventPublisher,
+      ChatSessionMetadataService chatSessionMetadataService) {
     this.chatSessionRepository = chatSessionRepository;
     this.chatMessageRepository = chatMessageRepository;
     this.workspaceMemberRepository = workspaceMemberRepository;
     this.eventPublisher = eventPublisher;
+    this.chatSessionMetadataService = chatSessionMetadataService;
   }
 
   public List<ChatSessionResponse> getActiveQueue(Long workspaceId, Long userId) {
@@ -76,7 +79,7 @@ public class ConsultationService {
       @NonNull Long sessionId, @NonNull SendMessageRequest request) {
     ChatSession session =
         chatSessionRepository
-            .findById(sessionId)
+            .findByIdForUpdate(sessionId)
             .orElseThrow(
                 () ->
                     new NotFoundException("SESSION_NOT_FOUND", "Session not found: " + sessionId));
@@ -96,9 +99,10 @@ public class ConsultationService {
 
     ChatMessage newMessage =
         ChatMessage.create(session.getId(), nextSeqNo, role, messageType, request.getContent());
-    chatMessageRepository.save(newMessage);
+    ChatMessage savedMessage = chatMessageRepository.save(newMessage);
+    chatSessionMetadataService.updateAfterMessage(session, savedMessage);
 
-    return ChatMessageResponse.from(newMessage);
+    return ChatMessageResponse.from(savedMessage);
   }
 
   @Transactional

--- a/backend/src/main/java/com/init/workflowruntime/application/CounselorService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/CounselorService.java
@@ -33,16 +33,19 @@ public class CounselorService {
   private final ChatMessageRepository chatMessageRepository;
   private final SimpMessagingTemplate messagingTemplate;
   private final ApplicationEventPublisher eventPublisher;
+  private final ChatSessionMetadataService chatSessionMetadataService;
 
   public CounselorService(
       ChatSessionRepository chatSessionRepository,
       ChatMessageRepository chatMessageRepository,
       SimpMessagingTemplate messagingTemplate,
-      ApplicationEventPublisher eventPublisher) {
+      ApplicationEventPublisher eventPublisher,
+      ChatSessionMetadataService chatSessionMetadataService) {
     this.chatSessionRepository = chatSessionRepository;
     this.chatMessageRepository = chatMessageRepository;
     this.messagingTemplate = messagingTemplate;
     this.eventPublisher = eventPublisher;
+    this.chatSessionMetadataService = chatSessionMetadataService;
   }
 
   @Transactional
@@ -143,6 +146,7 @@ public class CounselorService {
     String senderRole = isNote ? "NOTE" : "COUNSELOR";
     ChatMessage message = ChatMessage.create(sessionId, nextSeqNo, senderRole, "TEXT", content);
     ChatMessage savedMessage = chatMessageRepository.save(message);
+    chatSessionMetadataService.updateAfterMessage(session, savedMessage);
 
     ChatMessageResponse response = ChatMessageResponse.from(savedMessage);
     String destination = "/topic/chat." + sessionId;

--- a/backend/src/main/java/com/init/workflowruntime/application/LlmResponseHandler.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/LlmResponseHandler.java
@@ -16,7 +16,8 @@ import org.springframework.context.event.EventListener;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
 
 @Component
 public class LlmResponseHandler {
@@ -28,32 +29,28 @@ public class LlmResponseHandler {
   private final ChatSessionRepository chatSessionRepository;
   private final SimpMessagingTemplate messagingTemplate;
   private final ChatSessionMetadataService chatSessionMetadataService;
+  private final TransactionTemplate transactionTemplate;
 
   public LlmResponseHandler(
       LlmAssistantService llmAssistantService,
       ChatMessageRepository chatMessageRepository,
       ChatSessionRepository chatSessionRepository,
       SimpMessagingTemplate messagingTemplate,
-      ChatSessionMetadataService chatSessionMetadataService) {
+      ChatSessionMetadataService chatSessionMetadataService,
+      PlatformTransactionManager transactionManager) {
     this.llmAssistantService = llmAssistantService;
     this.chatMessageRepository = chatMessageRepository;
     this.chatSessionRepository = chatSessionRepository;
     this.messagingTemplate = messagingTemplate;
     this.chatSessionMetadataService = chatSessionMetadataService;
+    this.transactionTemplate = new TransactionTemplate(transactionManager);
   }
 
   @Async
   @EventListener
-  @Transactional
   public void handleChatMessageReceived(ChatMessageReceivedEvent event) {
     try {
-      ChatSession session =
-          chatSessionRepository
-              .findByIdForUpdate(event.sessionId())
-              .orElseThrow(
-                  () ->
-                      new NotFoundException(
-                          "SESSION_NOT_FOUND", "Session not found: " + event.sessionId()));
+      ensureSessionExists(event.sessionId());
 
       List<ChatMessage> recentDesc =
           chatMessageRepository.findTop5ByChatSessionIdOrderBySeqNoDesc(event.sessionId());
@@ -66,16 +63,9 @@ public class LlmResponseHandler {
       String llmResponse =
           llmAssistantService.generateResponse(conversationContext, event.content());
 
-      Integer nextSeqNo =
-          chatMessageRepository
-              .findTopByChatSessionIdOrderBySeqNoDesc(event.sessionId())
-              .map(msg -> msg.getSeqNo() + 1)
-              .orElse(1);
-
       ChatMessage savedMessage =
-          chatMessageRepository.save(
-              ChatMessage.create(event.sessionId(), nextSeqNo, "ASSISTANT", "TEXT", llmResponse));
-      chatSessionMetadataService.updateAfterMessage(session, savedMessage);
+          transactionTemplate.execute(
+              status -> saveAssistantMessage(event.sessionId(), llmResponse));
 
       ChatMessageResponse response = ChatMessageResponse.from(savedMessage);
       String destination = "/topic/chat." + event.sessionId();
@@ -92,5 +82,33 @@ public class LlmResponseHandler {
           ChatMessageResponse.error("LLM_ERROR", "죄송합니다. 일시적인 오류가 발생했습니다.");
       messagingTemplate.convertAndSend("/topic/chat." + event.sessionId(), errorResponse);
     }
+  }
+
+  private void ensureSessionExists(Long sessionId) {
+    chatSessionRepository
+        .findById(sessionId)
+        .orElseThrow(
+            () -> new NotFoundException("SESSION_NOT_FOUND", "Session not found: " + sessionId));
+  }
+
+  private ChatMessage saveAssistantMessage(Long sessionId, String llmResponse) {
+    ChatSession session =
+        chatSessionRepository
+            .findByIdForUpdate(sessionId)
+            .orElseThrow(
+                () ->
+                    new NotFoundException("SESSION_NOT_FOUND", "Session not found: " + sessionId));
+
+    Integer nextSeqNo =
+        chatMessageRepository
+            .findTopByChatSessionIdOrderBySeqNoDesc(sessionId)
+            .map(msg -> msg.getSeqNo() + 1)
+            .orElse(1);
+
+    ChatMessage savedMessage =
+        chatMessageRepository.save(
+            ChatMessage.create(sessionId, nextSeqNo, "ASSISTANT", "TEXT", llmResponse));
+    chatSessionMetadataService.updateAfterMessage(session, savedMessage);
+    return savedMessage;
   }
 }

--- a/backend/src/main/java/com/init/workflowruntime/application/LlmResponseHandler.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/LlmResponseHandler.java
@@ -4,6 +4,7 @@ import com.init.shared.application.exception.NotFoundException;
 import com.init.workflowruntime.application.dto.ChatMessageResponse;
 import com.init.workflowruntime.domain.ChatMessage;
 import com.init.workflowruntime.domain.ChatMessageRepository;
+import com.init.workflowruntime.domain.ChatSession;
 import com.init.workflowruntime.domain.ChatSessionRepository;
 import com.init.workflowruntime.event.ChatMessageReceivedEvent;
 import java.util.Collections;
@@ -26,16 +27,19 @@ public class LlmResponseHandler {
   private final ChatMessageRepository chatMessageRepository;
   private final ChatSessionRepository chatSessionRepository;
   private final SimpMessagingTemplate messagingTemplate;
+  private final ChatSessionMetadataService chatSessionMetadataService;
 
   public LlmResponseHandler(
       LlmAssistantService llmAssistantService,
       ChatMessageRepository chatMessageRepository,
       ChatSessionRepository chatSessionRepository,
-      SimpMessagingTemplate messagingTemplate) {
+      SimpMessagingTemplate messagingTemplate,
+      ChatSessionMetadataService chatSessionMetadataService) {
     this.llmAssistantService = llmAssistantService;
     this.chatMessageRepository = chatMessageRepository;
     this.chatSessionRepository = chatSessionRepository;
     this.messagingTemplate = messagingTemplate;
+    this.chatSessionMetadataService = chatSessionMetadataService;
   }
 
   @Async
@@ -43,12 +47,13 @@ public class LlmResponseHandler {
   @Transactional
   public void handleChatMessageReceived(ChatMessageReceivedEvent event) {
     try {
-      chatSessionRepository
-          .findByIdForUpdate(event.sessionId())
-          .orElseThrow(
-              () ->
-                  new NotFoundException(
-                      "SESSION_NOT_FOUND", "Session not found: " + event.sessionId()));
+      ChatSession session =
+          chatSessionRepository
+              .findByIdForUpdate(event.sessionId())
+              .orElseThrow(
+                  () ->
+                      new NotFoundException(
+                          "SESSION_NOT_FOUND", "Session not found: " + event.sessionId()));
 
       List<ChatMessage> recentDesc =
           chatMessageRepository.findTop5ByChatSessionIdOrderBySeqNoDesc(event.sessionId());
@@ -70,6 +75,7 @@ public class LlmResponseHandler {
       ChatMessage savedMessage =
           chatMessageRepository.save(
               ChatMessage.create(event.sessionId(), nextSeqNo, "ASSISTANT", "TEXT", llmResponse));
+      chatSessionMetadataService.updateAfterMessage(session, savedMessage);
 
       ChatMessageResponse response = ChatMessageResponse.from(savedMessage);
       String destination = "/topic/chat." + event.sessionId();

--- a/backend/src/test/java/com/init/workflowruntime/application/ChatSessionMetadataServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/ChatSessionMetadataServiceTest.java
@@ -21,8 +21,7 @@ class ChatSessionMetadataServiceTest {
   @Test
   @DisplayName("updateAfterMessage: 기존 meta를 보존하고 최근 메시지 필드를 갱신한다")
   void should_preserveExistingMetaAndUpdateLastMessageFields() throws Exception {
-    ChatSession session =
-        createSession("{\"customerName\":\"김민지\",\"handoffReason\":\"환불 문의\"}");
+    ChatSession session = createSession("{\"customerName\":\"김민지\",\"handoffReason\":\"환불 문의\"}");
     ChatMessage message =
         createMessage(1L, 3, "COUNSELOR", "처리 도와드리겠습니다.", "2026-05-27T10:15:30+09:00");
 

--- a/backend/src/test/java/com/init/workflowruntime/application/ChatSessionMetadataServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/ChatSessionMetadataServiceTest.java
@@ -1,0 +1,83 @@
+package com.init.workflowruntime.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.init.workflowruntime.domain.ChatMessage;
+import com.init.workflowruntime.domain.ChatSession;
+import com.init.workflowruntime.domain.ChatSessionStatus;
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@DisplayName("ChatSessionMetadataService")
+class ChatSessionMetadataServiceTest {
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+  private final ChatSessionMetadataService service = new ChatSessionMetadataService(objectMapper);
+
+  @Test
+  @DisplayName("updateAfterMessage: 기존 meta를 보존하고 최근 메시지 필드를 갱신한다")
+  void should_preserveExistingMetaAndUpdateLastMessageFields() throws Exception {
+    ChatSession session =
+        createSession("{\"customerName\":\"김민지\",\"handoffReason\":\"환불 문의\"}");
+    ChatMessage message =
+        createMessage(1L, 3, "COUNSELOR", "처리 도와드리겠습니다.", "2026-05-27T10:15:30+09:00");
+
+    service.updateAfterMessage(session, message);
+
+    JsonNode meta = objectMapper.readTree(session.getMetaJson());
+    assertThat(meta.path("customerName").asText()).isEqualTo("김민지");
+    assertThat(meta.path("handoffReason").asText()).isEqualTo("환불 문의");
+    assertThat(meta.path("title").asText()).isEqualTo("환불 문의");
+    assertThat(meta.path("messageCount").asInt()).isEqualTo(3);
+    assertThat(meta.path("lastMessagePreview").asText()).isEqualTo("처리 도와드리겠습니다.");
+    assertThat(meta.path("lastMessageRole").asText()).isEqualTo("COUNSELOR");
+    assertThat(meta.path("lastMessageAt").asText()).isEqualTo("2026-05-27T10:15:30+09:00");
+  }
+
+  @Test
+  @DisplayName("updateAfterMessage: invalid metaJson을 복구하고 고객 메시지로 제목을 만든다")
+  void should_recoverInvalidMetaAndUseCustomerMessageTitle() throws Exception {
+    ChatSession session = createSession("{invalid-json}");
+    ChatMessage message =
+        createMessage(1L, 1, "USER", "환불 가능 여부를 확인하고 싶습니다.", "2026-05-27T10:00:00+09:00");
+
+    service.updateAfterMessage(session, message);
+
+    JsonNode meta = objectMapper.readTree(session.getMetaJson());
+    assertThat(meta.path("title").asText()).isEqualTo("환불 가능 여부를 확인하고 싶습니다.");
+    assertThat(meta.path("messageCount").asInt()).isEqualTo(1);
+    assertThat(meta.path("lastMessageRole").asText()).isEqualTo("USER");
+  }
+
+  @Test
+  @DisplayName("updateAfterMessage: 기존 title은 덮어쓰지 않는다")
+  void should_keepExistingTitle() throws Exception {
+    ChatSession session = createSession("{\"title\":\"VIP 환불 상담\",\"handoffReason\":\"다른 제목\"}");
+    ChatMessage message =
+        createMessage(1L, 2, "ASSISTANT", "안내 메시지입니다.", "2026-05-27T10:03:00+09:00");
+
+    service.updateAfterMessage(session, message);
+
+    JsonNode meta = objectMapper.readTree(session.getMetaJson());
+    assertThat(meta.path("title").asText()).isEqualTo("VIP 환불 상담");
+    assertThat(meta.path("lastMessageRole").asText()).isEqualTo("ASSISTANT");
+  }
+
+  private ChatSession createSession(String metaJson) {
+    ChatSession session = ChatSession.create(1L, 1L, ChatSessionStatus.OPEN, "WEB", metaJson, 1L);
+    ReflectionTestUtils.setField(session, "id", 1L);
+    return session;
+  }
+
+  private ChatMessage createMessage(
+      Long sessionId, int seqNo, String role, String content, String createdAt) {
+    ChatMessage message = ChatMessage.create(sessionId, seqNo, role, "TEXT", content);
+    ReflectionTestUtils.setField(message, "id", (long) seqNo);
+    ReflectionTestUtils.setField(message, "createdAt", OffsetDateTime.parse(createdAt));
+    return message;
+  }
+}

--- a/backend/src/test/java/com/init/workflowruntime/application/ChatSessionMetadataServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/ChatSessionMetadataServiceTest.java
@@ -66,8 +66,80 @@ class ChatSessionMetadataServiceTest {
     assertThat(meta.path("lastMessageRole").asText()).isEqualTo("ASSISTANT");
   }
 
+  @Test
+  @DisplayName("updateAfterMessage: 빈 meta와 빈 본문을 복구하고 채널 기반 제목을 사용한다")
+  void should_recoverBlankMetaAndUseChannelTitle() throws Exception {
+    ChatSession session = createSession(" ", "WEB");
+    ChatMessage message = createMessageWithoutCreatedAt(1L, 1, "AGENT", "   ");
+
+    service.updateAfterMessage(session, message);
+
+    JsonNode meta = objectMapper.readTree(session.getMetaJson());
+    assertThat(meta.path("title").asText()).isEqualTo("WEB 상담");
+    assertThat(meta.path("lastMessagePreview").asText()).isEmpty();
+    assertThat(meta.path("lastMessageAt").asText()).isNotBlank();
+  }
+
+  @Test
+  @DisplayName("updateAfterMessage: object가 아닌 metaJson도 메시지 저장을 막지 않는다")
+  void should_recoverNonObjectMetaJson() throws Exception {
+    ChatSession session = createSession("[]", "WEB");
+    ChatMessage message =
+        createMessage(1L, 1, "ASSISTANT", "안내 메시지입니다.", "2026-05-27T10:03:00+09:00");
+
+    service.updateAfterMessage(session, message);
+
+    JsonNode meta = objectMapper.readTree(session.getMetaJson());
+    assertThat(meta.path("title").asText()).isEqualTo("WEB 상담");
+    assertThat(meta.path("lastMessageRole").asText()).isEqualTo("ASSISTANT");
+  }
+
+  @Test
+  @DisplayName("updateAfterMessage: handoffReason이 없으면 고객명 기반 제목을 사용한다")
+  void should_useCustomerNameTitle_when_handoffReasonIsMissing() throws Exception {
+    ChatSession session = createSession("{\"customerName\":\"이영희\"}");
+    ChatMessage message =
+        createMessage(1L, 1, "ASSISTANT", "안내 메시지입니다.", "2026-05-27T10:03:00+09:00");
+
+    service.updateAfterMessage(session, message);
+
+    JsonNode meta = objectMapper.readTree(session.getMetaJson());
+    assertThat(meta.path("title").asText()).isEqualTo("이영희 상담");
+  }
+
+  @Test
+  @DisplayName("updateAfterMessage: 제목 후보가 없으면 기본 상담 제목을 사용한다")
+  void should_useDefaultTitle_when_noFallbackMetadataExists() throws Exception {
+    ChatSession session = createSession("{}", " ");
+    ChatMessage message =
+        createMessage(1L, 1, "ASSISTANT", "안내 메시지입니다.", "2026-05-27T10:03:00+09:00");
+
+    service.updateAfterMessage(session, message);
+
+    JsonNode meta = objectMapper.readTree(session.getMetaJson());
+    assertThat(meta.path("title").asText()).isEqualTo("채팅 상담");
+  }
+
+  @Test
+  @DisplayName("updateAfterMessage: 고객 메시지 제목과 최근 메시지 미리보기를 축약한다")
+  void should_truncateCustomerTitleAndLastMessagePreview() throws Exception {
+    ChatSession session = createSession("{}");
+    String content = "고객이 남긴 환불 문의 내용이 매우 길어서 상담 목록과 상세 미리보기에서 적절하게 줄여야 합니다. ".repeat(3);
+    ChatMessage message = createMessage(1L, 1, "CUSTOMER", content, "2026-05-27T10:03:00+09:00");
+
+    service.updateAfterMessage(session, message);
+
+    JsonNode meta = objectMapper.readTree(session.getMetaJson());
+    assertThat(meta.path("title").asText()).hasSizeLessThanOrEqualTo(40).endsWith("…");
+    assertThat(meta.path("lastMessagePreview").asText()).hasSizeLessThanOrEqualTo(80).endsWith("…");
+  }
+
   private ChatSession createSession(String metaJson) {
-    ChatSession session = ChatSession.create(1L, 1L, ChatSessionStatus.OPEN, "WEB", metaJson, 1L);
+    return createSession(metaJson, "WEB");
+  }
+
+  private ChatSession createSession(String metaJson, String channel) {
+    ChatSession session = ChatSession.create(1L, 1L, ChatSessionStatus.OPEN, channel, metaJson, 1L);
     ReflectionTestUtils.setField(session, "id", 1L);
     return session;
   }
@@ -77,6 +149,13 @@ class ChatSessionMetadataServiceTest {
     ChatMessage message = ChatMessage.create(sessionId, seqNo, role, "TEXT", content);
     ReflectionTestUtils.setField(message, "id", (long) seqNo);
     ReflectionTestUtils.setField(message, "createdAt", OffsetDateTime.parse(createdAt));
+    return message;
+  }
+
+  private ChatMessage createMessageWithoutCreatedAt(
+      Long sessionId, int seqNo, String role, String content) {
+    ChatMessage message = ChatMessage.create(sessionId, seqNo, role, "TEXT", content);
+    ReflectionTestUtils.setField(message, "id", (long) seqNo);
     return message;
   }
 }

--- a/backend/src/test/java/com/init/workflowruntime/application/ChatWebSocketServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/ChatWebSocketServiceTest.java
@@ -38,6 +38,7 @@ class ChatWebSocketServiceTest {
   @Mock private ChatMessageRepository chatMessageRepository;
   @Mock private SimpMessagingTemplate messagingTemplate;
   @Mock private ApplicationEventPublisher eventPublisher;
+  @Mock private ChatSessionMetadataService chatSessionMetadataService;
 
   private ChatWebSocketService service;
 
@@ -45,7 +46,11 @@ class ChatWebSocketServiceTest {
   void setUp() {
     service =
         new ChatWebSocketService(
-            chatSessionRepository, chatMessageRepository, messagingTemplate, eventPublisher);
+            chatSessionRepository,
+            chatMessageRepository,
+            messagingTemplate,
+            eventPublisher,
+            chatSessionMetadataService);
   }
 
   @Test
@@ -80,6 +85,7 @@ class ChatWebSocketServiceTest {
       assertThat(result.content()).isEqualTo("Hello");
       assertThat(result.senderRole()).isEqualTo("USER");
       verify(chatMessageRepository).save(any());
+      verify(chatSessionMetadataService).updateAfterMessage(session, savedMsg);
 
       // 즉시 전송되지 않음
       verify(messagingTemplate, never()).convertAndSend(anyString(), any(Object.class));
@@ -155,6 +161,7 @@ class ChatWebSocketServiceTest {
       assertThat(result).isNotNull();
       assertThat(result.content()).isEqualTo("Hello");
       verify(chatMessageRepository).save(any());
+      verify(chatSessionMetadataService).updateAfterMessage(session, savedMsg);
 
       verify(messagingTemplate, never()).convertAndSend(anyString(), any(Object.class));
 

--- a/backend/src/test/java/com/init/workflowruntime/application/ConsultationServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/ConsultationServiceTest.java
@@ -43,6 +43,7 @@ class ConsultationServiceTest {
   @Mock private ChatMessageRepository chatMessageRepository;
   @Mock private WorkspaceMemberRepository workspaceMemberRepository;
   @Mock private ApplicationEventPublisher eventPublisher;
+  @Mock private ChatSessionMetadataService chatSessionMetadataService;
 
   private ConsultationService service;
 
@@ -53,7 +54,8 @@ class ConsultationServiceTest {
             chatSessionRepository,
             chatMessageRepository,
             workspaceMemberRepository,
-            eventPublisher);
+            eventPublisher,
+            chatSessionMetadataService);
   }
 
   @Test
@@ -126,7 +128,7 @@ class ConsultationServiceTest {
   void should_생성된메시지반환_when_정상전송() {
     // given
     ChatSession session = createSession(1L);
-    given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+    given(chatSessionRepository.findByIdForUpdate(1L)).willReturn(Optional.of(session));
     given(chatMessageRepository.findTopByChatSessionIdOrderBySeqNoDesc(1L))
         .willReturn(Optional.empty());
 
@@ -144,6 +146,7 @@ class ConsultationServiceTest {
     assertThat(result.content()).isEqualTo("Hello");
     assertThat(result.senderRole()).isEqualTo("AGENT");
     verify(chatMessageRepository).save(any());
+    verify(chatSessionMetadataService).updateAfterMessage(session, savedMsg);
   }
 
   @Test

--- a/backend/src/test/java/com/init/workflowruntime/application/CounselorServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/CounselorServiceTest.java
@@ -260,6 +260,7 @@ class CounselorServiceTest {
           service.sendCounselorMessage(1L, "Hello from counselor", 42L, true);
 
       assertThat(result.senderRole()).isEqualTo("NOTE");
+      verify(chatSessionMetadataService).updateAfterMessage(session, savedMsg);
     } finally {
       TransactionSynchronizationManager.clearSynchronization();
     }

--- a/backend/src/test/java/com/init/workflowruntime/application/CounselorServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/CounselorServiceTest.java
@@ -48,6 +48,7 @@ class CounselorServiceTest {
   @Mock private ChatMessageRepository chatMessageRepository;
   @Mock private SimpMessagingTemplate messagingTemplate;
   @Mock private ApplicationEventPublisher eventPublisher;
+  @Mock private ChatSessionMetadataService chatSessionMetadataService;
 
   private CounselorService service;
 
@@ -55,7 +56,11 @@ class CounselorServiceTest {
   void setUp() {
     service =
         new CounselorService(
-            chatSessionRepository, chatMessageRepository, messagingTemplate, eventPublisher);
+            chatSessionRepository,
+            chatMessageRepository,
+            messagingTemplate,
+            eventPublisher,
+            chatSessionMetadataService);
   }
 
   // ── assignSession ─────────────────────────────────────────────────────────
@@ -225,6 +230,7 @@ class CounselorServiceTest {
       assertThat(result.content()).isEqualTo("Hello from counselor");
       assertThat(result.senderRole()).isEqualTo("COUNSELOR");
       verify(chatMessageRepository).save(any());
+      verify(chatSessionMetadataService).updateAfterMessage(session, savedMsg);
 
       verify(messagingTemplate, never()).convertAndSend(anyString(), any(Object.class));
 

--- a/backend/src/test/java/com/init/workflowruntime/application/LlmResponseHandlerTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/LlmResponseHandlerTest.java
@@ -63,8 +63,10 @@ class LlmResponseHandlerTest {
   void should_saveAndPush_when_llmRespondsSuccessfully() {
     ChatMessageReceivedEvent event = new ChatMessageReceivedEvent(1L, "안녕하세요", 1L);
     given(llmAssistantService.generateResponse("", "안녕하세요")).willReturn("안녕하세요! 무엇을 도와드릴까요?");
-    given(chatSessionRepository.findById(1L)).willReturn(Optional.of(mockSession()));
-    given(chatSessionRepository.findByIdForUpdate(1L)).willReturn(Optional.of(mockSession()));
+    ChatSession precheckSession = mockSession();
+    ChatSession lockSession = mockSession();
+    given(chatSessionRepository.findById(1L)).willReturn(Optional.of(precheckSession));
+    given(chatSessionRepository.findByIdForUpdate(1L)).willReturn(Optional.of(lockSession));
     given(chatMessageRepository.findTopByChatSessionIdOrderBySeqNoDesc(1L))
         .willReturn(Optional.empty());
     given(transactionManager.getTransaction(any(TransactionDefinition.class)))
@@ -81,7 +83,7 @@ class LlmResponseHandlerTest {
     lockOrder.verify(llmAssistantService).generateResponse("", "안녕하세요");
     lockOrder.verify(chatSessionRepository).findByIdForUpdate(1L);
     verify(chatMessageRepository).save(any(ChatMessage.class));
-    verify(chatSessionMetadataService).updateAfterMessage(any(ChatSession.class), eq(savedMsg));
+    verify(chatSessionMetadataService).updateAfterMessage(eq(lockSession), eq(savedMsg));
     verify(messagingTemplate).convertAndSend(eq("/topic/chat.1"), responseCaptor.capture());
 
     ChatMessageResponse pushed = responseCaptor.getValue();

--- a/backend/src/test/java/com/init/workflowruntime/application/LlmResponseHandlerTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/LlmResponseHandlerTest.java
@@ -34,6 +34,7 @@ class LlmResponseHandlerTest {
   @Mock private ChatMessageRepository chatMessageRepository;
   @Mock private SimpMessagingTemplate messagingTemplate;
   @Mock private ChatSessionRepository chatSessionRepository;
+  @Mock private ChatSessionMetadataService chatSessionMetadataService;
 
   @Captor private ArgumentCaptor<ChatMessageResponse> responseCaptor;
 
@@ -43,7 +44,11 @@ class LlmResponseHandlerTest {
   void setUp() {
     handler =
         new LlmResponseHandler(
-            llmAssistantService, chatMessageRepository, chatSessionRepository, messagingTemplate);
+            llmAssistantService,
+            chatMessageRepository,
+            chatSessionRepository,
+            messagingTemplate,
+            chatSessionMetadataService);
   }
 
   @Test
@@ -62,6 +67,7 @@ class LlmResponseHandlerTest {
     handler.handleChatMessageReceived(event);
 
     verify(chatMessageRepository).save(any(ChatMessage.class));
+    verify(chatSessionMetadataService).updateAfterMessage(any(ChatSession.class), eq(savedMsg));
     verify(messagingTemplate).convertAndSend(eq("/topic/chat.1"), responseCaptor.capture());
 
     ChatMessageResponse pushed = responseCaptor.getValue();

--- a/backend/src/test/java/com/init/workflowruntime/application/LlmResponseHandlerTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/LlmResponseHandlerTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -21,10 +22,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.support.SimpleTransactionStatus;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("LlmResponseHandler")
@@ -35,6 +40,7 @@ class LlmResponseHandlerTest {
   @Mock private SimpMessagingTemplate messagingTemplate;
   @Mock private ChatSessionRepository chatSessionRepository;
   @Mock private ChatSessionMetadataService chatSessionMetadataService;
+  @Mock private PlatformTransactionManager transactionManager;
 
   @Captor private ArgumentCaptor<ChatMessageResponse> responseCaptor;
 
@@ -48,7 +54,8 @@ class LlmResponseHandlerTest {
             chatMessageRepository,
             chatSessionRepository,
             messagingTemplate,
-            chatSessionMetadataService);
+            chatSessionMetadataService,
+            transactionManager);
   }
 
   @Test
@@ -56,9 +63,12 @@ class LlmResponseHandlerTest {
   void should_saveAndPush_when_llmRespondsSuccessfully() {
     ChatMessageReceivedEvent event = new ChatMessageReceivedEvent(1L, "안녕하세요", 1L);
     given(llmAssistantService.generateResponse("", "안녕하세요")).willReturn("안녕하세요! 무엇을 도와드릴까요?");
+    given(chatSessionRepository.findById(1L)).willReturn(Optional.of(mockSession()));
     given(chatSessionRepository.findByIdForUpdate(1L)).willReturn(Optional.of(mockSession()));
     given(chatMessageRepository.findTopByChatSessionIdOrderBySeqNoDesc(1L))
         .willReturn(Optional.empty());
+    given(transactionManager.getTransaction(any(TransactionDefinition.class)))
+        .willReturn(new SimpleTransactionStatus());
 
     ChatMessage savedMsg = ChatMessage.create(1L, 1, "ASSISTANT", "TEXT", "안녕하세요! 무엇을 도와드릴까요?");
     ReflectionTestUtils.setField(savedMsg, "id", 1L);
@@ -66,6 +76,10 @@ class LlmResponseHandlerTest {
 
     handler.handleChatMessageReceived(event);
 
+    InOrder lockOrder = inOrder(chatSessionRepository, llmAssistantService);
+    lockOrder.verify(chatSessionRepository).findById(1L);
+    lockOrder.verify(llmAssistantService).generateResponse("", "안녕하세요");
+    lockOrder.verify(chatSessionRepository).findByIdForUpdate(1L);
     verify(chatMessageRepository).save(any(ChatMessage.class));
     verify(chatSessionMetadataService).updateAfterMessage(any(ChatSession.class), eq(savedMsg));
     verify(messagingTemplate).convertAndSend(eq("/topic/chat.1"), responseCaptor.capture());
@@ -79,12 +93,13 @@ class LlmResponseHandlerTest {
   @DisplayName("handleChatMessageReceived: LLM 예외 → fallback 메시지 STOMP push")
   void should_pushFallback_when_llmThrowsException() {
     ChatMessageReceivedEvent event = new ChatMessageReceivedEvent(1L, "안녕하세요", 1L);
-    given(chatSessionRepository.findByIdForUpdate(1L)).willReturn(Optional.of(mockSession()));
+    given(chatSessionRepository.findById(1L)).willReturn(Optional.of(mockSession()));
     given(llmAssistantService.generateResponse(any(), eq("안녕하세요")))
         .willThrow(new RuntimeException("API timeout"));
 
     handler.handleChatMessageReceived(event);
 
+    verify(chatSessionRepository, never()).findByIdForUpdate(1L);
     verify(chatMessageRepository, never()).save(any(ChatMessage.class));
     verify(messagingTemplate).convertAndSend(eq("/topic/chat.1"), responseCaptor.capture());
 

--- a/frontend/src/features/consultation/lib/chatRoleLabels.ts
+++ b/frontend/src/features/consultation/lib/chatRoleLabels.ts
@@ -1,0 +1,43 @@
+export type ChatSenderRole =
+  | "USER"
+  | "CUSTOMER"
+  | "AGENT"
+  | "COUNSELOR"
+  | "ASSISTANT"
+  | "NOTE"
+  | "SYSTEM";
+
+type RoleTone = "customer" | "counselor" | "assistant" | "note" | "system";
+
+export interface ChatRolePresentation {
+  role: ChatSenderRole;
+  label: string;
+  avatar: string;
+  tone: RoleTone;
+}
+
+const ROLE_PRESENTATION: Record<ChatSenderRole, ChatRolePresentation> = {
+  USER: { role: "USER", label: "고객", avatar: "고", tone: "customer" },
+  CUSTOMER: { role: "CUSTOMER", label: "고객", avatar: "고", tone: "customer" },
+  AGENT: { role: "AGENT", label: "상담사", avatar: "C", tone: "counselor" },
+  COUNSELOR: { role: "COUNSELOR", label: "상담사", avatar: "C", tone: "counselor" },
+  ASSISTANT: { role: "ASSISTANT", label: "AI", avatar: "A", tone: "assistant" },
+  NOTE: { role: "NOTE", label: "내부 메모", avatar: "N", tone: "note" },
+  SYSTEM: { role: "SYSTEM", label: "시스템", avatar: "S", tone: "system" },
+};
+
+export function normalizeChatSenderRole(senderRole?: string | null): ChatSenderRole {
+  if (senderRole && senderRole in ROLE_PRESENTATION) {
+    return senderRole as ChatSenderRole;
+  }
+  return "SYSTEM";
+}
+
+export function getChatRolePresentation(senderRole?: string | null): ChatRolePresentation {
+  return ROLE_PRESENTATION[normalizeChatSenderRole(senderRole)];
+}
+
+export function isCounselorLikeRole(senderRole?: string | null): boolean {
+  const tone = getChatRolePresentation(senderRole).tone;
+  return tone === "counselor" || tone === "assistant";
+}

--- a/frontend/src/features/consultation/lib/chatRoleLabels.ts
+++ b/frontend/src/features/consultation/lib/chatRoleLabels.ts
@@ -27,7 +27,7 @@ const ROLE_PRESENTATION: Record<ChatSenderRole, ChatRolePresentation> = {
 };
 
 export function normalizeChatSenderRole(senderRole?: string | null): ChatSenderRole {
-  if (senderRole && senderRole in ROLE_PRESENTATION) {
+  if (senderRole && Object.prototype.hasOwnProperty.call(ROLE_PRESENTATION, senderRole)) {
     return senderRole as ChatSenderRole;
   }
   return "SYSTEM";

--- a/frontend/src/features/consultation/ui/ChatPanel.test.tsx
+++ b/frontend/src/features/consultation/ui/ChatPanel.test.tsx
@@ -147,6 +147,7 @@ describe("ChatPanel", () => {
       />,
     );
 
+    expect(screen.getByText("시스템")).toBeInTheDocument();
     expect(screen.getByText("상담이 시작되었습니다")).toBeInTheDocument();
     expect(screen.getByText("내부 메모")).toBeInTheDocument();
     expect(screen.getByText("내부 메모 내용")).toBeInTheDocument();

--- a/frontend/src/features/consultation/ui/ChatPanel.test.tsx
+++ b/frontend/src/features/consultation/ui/ChatPanel.test.tsx
@@ -148,7 +148,7 @@ describe("ChatPanel", () => {
     );
 
     expect(screen.getByText("상담이 시작되었습니다")).toBeInTheDocument();
-    expect(screen.getByText("📝 내부 메모")).toBeInTheDocument();
+    expect(screen.getByText("내부 메모")).toBeInTheDocument();
     expect(screen.getByText("내부 메모 내용")).toBeInTheDocument();
 
     fireEvent.click(screen.getByTitle("내부 메모 모드"));
@@ -359,5 +359,48 @@ describe("ChatPanel", () => {
     expect(screen.getByText("AI 메시지 내용")).toBeInTheDocument();
     expect(screen.getByText("AI ·")).toBeInTheDocument();
     expect(screen.getByText("A")).toBeInTheDocument();
+  });
+
+  it("USER, AGENT, NOTE, SYSTEM 역할 라벨을 일관되게 표시한다", () => {
+    render(
+      <ChatPanel
+        customerName="김민지"
+        channel="카카오톡"
+        messages={[
+          {
+            id: "user-1",
+            senderRole: "USER",
+            content: "고객 메시지",
+            timestamp: "10:01",
+          },
+          {
+            id: "agent-1",
+            senderRole: "AGENT",
+            content: "legacy 상담사 메시지",
+            timestamp: "10:02",
+          },
+          {
+            id: "note-1",
+            senderRole: "NOTE",
+            content: "메모",
+            timestamp: "10:03",
+          },
+          {
+            id: "system-1",
+            senderRole: "SYSTEM",
+            content: "시스템 안내",
+            timestamp: "10:04",
+          },
+        ]}
+        onSendMessage={vi.fn()}
+        selectedMessageId={null}
+        onSelectMessage={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("고객 ·")).toBeInTheDocument();
+    expect(screen.getByText("상담사 ·")).toBeInTheDocument();
+    expect(screen.getByText("내부 메모")).toBeInTheDocument();
+    expect(screen.getByText("시스템 안내")).toBeInTheDocument();
   });
 });

--- a/frontend/src/features/consultation/ui/ChatPanel.tsx
+++ b/frontend/src/features/consultation/ui/ChatPanel.tsx
@@ -113,9 +113,10 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
             );
           }
           if (msg.senderRole === "NOTE") {
+            const role = getChatRolePresentation(msg.senderRole);
             return (
               <div key={msg.id} className={styles.internalNote}>
-                <div className={styles.noteLabel}>내부 메모</div>
+                <div className={styles.noteLabel}>{role.label}</div>
                 {msg.content}
               </div>
             );

--- a/frontend/src/features/consultation/ui/ChatPanel.tsx
+++ b/frontend/src/features/consultation/ui/ChatPanel.tsx
@@ -1,10 +1,15 @@
 import React, { useState, useRef, useEffect } from "react";
 import { Send, StickyNote, MessageSquare } from "lucide-react";
+import {
+  getChatRolePresentation,
+  isCounselorLikeRole,
+  type ChatSenderRole,
+} from "../lib/chatRoleLabels";
 import styles from "./chat-panel.module.css";
 
 export interface ChatMessage {
   id: string;
-  senderRole: "CUSTOMER" | "AGENT" | "SYSTEM" | "NOTE" | "COUNSELOR" | "ASSISTANT";
+  senderRole: ChatSenderRole;
   content: string;
   timestamp: string;
 }
@@ -19,12 +24,6 @@ interface ChatPanelProps {
   sessionStatusLabel?: string;
   disabled?: boolean;
 }
-
-const roleLabel: Record<string, { avatar: string; label?: string }> = {
-  AGENT: { avatar: "A" },
-  COUNSELOR: { avatar: "C", label: "상담사" },
-  ASSISTANT: { avatar: "A", label: "AI" },
-};
 
 /**
  * 상담 대화 내용을 표시하고 메시지를 전송하는 패널 컴포넌트입니다.
@@ -105,24 +104,24 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
       <div className={styles.messageList} ref={listRef}>
         {messages.map((msg) => {
           if (msg.senderRole === "SYSTEM") {
+            const role = getChatRolePresentation(msg.senderRole);
             return (
               <div key={msg.id} className={styles.systemMessage}>
-                {msg.content}
+                <span className={styles.systemLabel}>{role.label}</span>
+                <span>{msg.content}</span>
               </div>
             );
           }
           if (msg.senderRole === "NOTE") {
             return (
               <div key={msg.id} className={styles.internalNote}>
-                <div className={styles.noteLabel}>📝 내부 메모</div>
+                <div className={styles.noteLabel}>내부 메모</div>
                 {msg.content}
               </div>
             );
           }
-          const isAgent =
-            msg.senderRole === "AGENT" ||
-            msg.senderRole === "COUNSELOR" ||
-            msg.senderRole === "ASSISTANT";
+          const role = getChatRolePresentation(msg.senderRole);
+          const isAgent = isCounselorLikeRole(msg.senderRole);
           const isSelected = selectedMessageId === msg.id;
           return (
             <div
@@ -152,7 +151,7 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
               <div
                 className={`${styles.msgAvatar} ${isAgent ? styles.msgAvatarAgent : styles.msgAvatarCustomer}`}
               >
-                {isAgent ? (roleLabel[msg.senderRole]?.avatar ?? "A") : customerInitial}
+                {isAgent ? role.avatar : customerInitial}
               </div>
               <div>
                 <div
@@ -161,9 +160,7 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
                   {msg.content}
                 </div>
                 <div className={`${styles.msgTime} ${isAgent ? styles.msgTimeAgent : ""}`}>
-                  {roleLabel[msg.senderRole]?.label && (
-                    <span>{roleLabel[msg.senderRole].label} · </span>
-                  )}
+                  <span>{role.label} · </span>
                   {msg.timestamp}
                 </div>
               </div>

--- a/frontend/src/features/consultation/ui/MessageDetailPanel.test.tsx
+++ b/frontend/src/features/consultation/ui/MessageDetailPanel.test.tsx
@@ -38,7 +38,8 @@ describe("MessageDetailPanel", () => {
       />,
     );
 
-    expect(screen.getByText("CUSTOMER")).toBeInTheDocument();
+    expect(screen.getByText("고객")).toBeInTheDocument();
+    expect(screen.queryByText("CUSTOMER")).not.toBeInTheDocument();
     expect(screen.getByText("테스트 메시지입니다")).toBeInTheDocument();
     expect(screen.getByText("14:30")).toBeInTheDocument();
   });

--- a/frontend/src/features/consultation/ui/MessageDetailPanel.tsx
+++ b/frontend/src/features/consultation/ui/MessageDetailPanel.tsx
@@ -1,5 +1,6 @@
 import { MessageSquare } from "lucide-react";
 import type { ReactNode } from "react";
+import { getChatRolePresentation } from "../lib/chatRoleLabels";
 import styles from "./MessageDetailPanel.module.css";
 
 /* ─── Types ─── */
@@ -113,6 +114,7 @@ export function MessageDetailPanel({
   onClose,
 }: MessageDetailPanelProps) {
   const { slots, policies, risks } = domainPackElements ?? MOCK_DATA;
+  const roleLabel = message ? getChatRolePresentation(message.senderRole).label : "";
 
   if (!message) {
     return (
@@ -129,7 +131,7 @@ export function MessageDetailPanel({
     <aside className={styles.wrapper}>
       <div className={styles.messageHeader}>
         <div className={styles.messageMeta}>
-          <span className={styles.senderRole}>{message.senderRole}</span>
+          <span className={styles.senderRole}>{roleLabel}</span>
           <span className={styles.timestamp}>{message.timestamp}</span>
         </div>
         <p className={styles.messagePreview}>{message.content}</p>

--- a/frontend/src/features/consultation/ui/QueuePanel.test.tsx
+++ b/frontend/src/features/consultation/ui/QueuePanel.test.tsx
@@ -68,6 +68,19 @@ describe("QueuePanel", () => {
     expect(screen.getByText("카드 오류")).toBeInTheDocument();
   });
 
+  it("title이 있으면 handoffReason보다 우선 표시한다", () => {
+    render(
+      <QueuePanel
+        customers={[makeCustomer("1", { title: "VIP 환불 상담", handoffReason: "카드 오류" })]}
+        activeCustomerId={null}
+        onSelectCustomer={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("VIP 환불 상담")).toBeInTheDocument();
+    expect(screen.queryByText("카드 오류")).not.toBeInTheDocument();
+  });
+
   it("고객 이름이 없으면 Unknown을 표시한다", () => {
     render(
       <QueuePanel

--- a/frontend/src/features/consultation/ui/QueuePanel.tsx
+++ b/frontend/src/features/consultation/ui/QueuePanel.tsx
@@ -5,6 +5,7 @@ import styles from "./queue-panel.module.css";
 export interface QueueCustomer {
   id: string;
   name?: string;
+  title?: string;
   channel: string;
   handoffReason: string;
   waitMinutes: number;
@@ -67,6 +68,7 @@ export const QueuePanel: React.FC<QueuePanelProps> = ({
 
     return customers.map((c) => {
       const displayName = c.name?.trim() || "Unknown";
+      const subject = c.title?.trim() || c.handoffReason;
       return (
         <div
           key={c.id}
@@ -88,7 +90,7 @@ export const QueuePanel: React.FC<QueuePanelProps> = ({
           </div>
           <div className={styles.queueItemInfo}>
             <div className={styles.customerName}>{displayName}</div>
-            <div className={styles.handoffPreview}>{c.handoffReason}</div>
+            <div className={styles.handoffPreview}>{subject}</div>
             {c.statusLabel && <div className={styles.sessionStatus}>{c.statusLabel}</div>}
           </div>
           <div

--- a/frontend/src/features/consultation/ui/chat-history/MessageHistory.tsx
+++ b/frontend/src/features/consultation/ui/chat-history/MessageHistory.tsx
@@ -1,6 +1,7 @@
 import { Dot, EmptyState, ErrorState, Eyebrow, Icon, LoadingSpinner, Mono, Pill } from "@/shared/ui/ostone/atoms";
 import type { ChatMessage } from "../../api/consultationApi";
 import { useChatMessages } from "../../api/chatHistoryApi";
+import { getChatRolePresentation, isCounselorLikeRole } from "../../lib/chatRoleLabels";
 import styles from "./MessageHistory.module.css";
 
 interface MessageHistoryProps {
@@ -12,27 +13,23 @@ function formatTimestamp(dateStr?: string): string {
   return new Date(dateStr).toLocaleString("ko-KR");
 }
 
-function getRoleLabel(senderRole?: string): string {
-  if (senderRole === "AGENT" || senderRole === "COUNSELOR") return "상담사";
-  if (senderRole === "CUSTOMER") return "고객";
-  return "시스템";
-}
-
 function getErrorMessage(error: unknown): string {
   if (error instanceof Error) return error.message;
   return "메시지를 불러오지 못했습니다";
 }
 
 function MessageBubble({ message }: { message: ChatMessage }) {
-  const roleLabel = getRoleLabel(message.senderRole);
-  const isCounselor = roleLabel === "상담사";
-  const isSystem = roleLabel === "시스템";
+  const role = getChatRolePresentation(message.senderRole);
+  const isCounselor = isCounselorLikeRole(message.senderRole);
+  const isSystem = role.tone === "system";
 
   if (isSystem) {
     return (
       <div className={styles.systemRow}>
         <Dot tone="mute" />
-        <Mono className={styles.systemText}>{message.content ?? "내용 없음"}</Mono>
+        <Mono className={styles.systemText}>
+          {role.label} · {message.content ?? "내용 없음"}
+        </Mono>
       </div>
     );
   }
@@ -41,7 +38,7 @@ function MessageBubble({ message }: { message: ChatMessage }) {
     <article className={`${styles.messageRow} ${isCounselor ? styles.counselorRow : styles.customerRow}`}>
       <div className={`${styles.bubble} ${isCounselor ? styles.counselorBubble : styles.customerBubble}`}>
         <div className={styles.metaLine}>
-          <span className={styles.roleLabel}>{roleLabel}</span>
+          <span className={styles.roleLabel}>{role.label}</span>
           <Pill tone={isCounselor ? "signal" : "mute"}>{message.messageType ?? "TEXT"}</Pill>
         </div>
         <p className={styles.content}>{message.content ?? "내용 없음"}</p>

--- a/frontend/src/features/consultation/ui/chat-history/SessionCard.tsx
+++ b/frontend/src/features/consultation/ui/chat-history/SessionCard.tsx
@@ -3,6 +3,7 @@ import type { ChatSession } from "../../api/consultationApi";
 import styles from "./SessionCard.module.css";
 
 type SessionMeta = {
+  title?: string;
   messageCount?: number;
   lastMessagePreview?: string;
   lastMessage?: string;
@@ -35,6 +36,10 @@ function getPreview(meta: SessionMeta): string {
   return meta.lastMessagePreview ?? meta.lastMessage ?? meta.preview ?? "최근 메시지가 없습니다";
 }
 
+function getTitle(meta: SessionMeta, channel: string): string {
+  return meta.title?.trim() || channel;
+}
+
 function getMessageCount(meta: SessionMeta): number {
   return meta.messageCount ?? 0;
 }
@@ -43,6 +48,8 @@ export function SessionCard({ session, isSelected, onSelectSession }: SessionCar
   const sessionId = String(session.id ?? "");
   const channel = session.channel ?? "채널 없음";
   const meta = parseMeta(session.metaJson);
+  const title = getTitle(meta, channel);
+  const eyebrow = title === channel ? "채널" : channel;
 
   const handleSelect = () => {
     if (sessionId) onSelectSession(sessionId);
@@ -58,8 +65,8 @@ export function SessionCard({ session, isSelected, onSelectSession }: SessionCar
       <div className={styles.header}>
         <Avatar initial={channel.charAt(0)} tone={isSelected ? "signal" : "mute"} size={32} />
         <div className={styles.titleGroup}>
-          <span className={styles.channelLabel}>채널</span>
-          <span className={styles.channel}>{channel}</span>
+          <span className={styles.channelLabel}>{eyebrow}</span>
+          <span className={styles.channel}>{title}</span>
           <Mono className={styles.date}>{formatSessionDate(session.startedAt)}</Mono>
         </div>
         <Pill tone={isSelected ? "signal" : "mute"}>메시지 {getMessageCount(meta)}개</Pill>

--- a/frontend/src/features/consultation/ui/chat-history/SessionList.test.tsx
+++ b/frontend/src/features/consultation/ui/chat-history/SessionList.test.tsx
@@ -101,11 +101,23 @@ describe("SessionList", () => {
       <SessionList workspaceId="workspace-1" selectedSessionId={null} onSelectSession={vi.fn()} />,
     );
 
-    expect(screen.getByText("채널")).toBeTruthy();
     expect(screen.getByText("카카오톡")).toBeTruthy();
     expect(screen.getByText(new Date("2026-05-22T09:00:00+09:00").toLocaleDateString("ko-KR"))).toBeTruthy();
     expect(screen.getByText("메시지 3개")).toBeTruthy();
     expect(screen.getByText("배송 상태를 확인해주세요")).toBeTruthy();
+  });
+
+  it("세션 카드 제목은 meta title을 우선 표시한다", () => {
+    mockedUseChatSessions.mockReturnValue(
+      makeQueryResult({ data: [makeSession(7, { title: "VIP 환불 상담" })] }),
+    );
+
+    render(
+      <SessionList workspaceId="workspace-1" selectedSessionId={null} onSelectSession={vi.fn()} />,
+    );
+
+    expect(screen.getByText("VIP 환불 상담")).toBeTruthy();
+    expect(screen.getByText("카카오톡")).toBeTruthy();
   });
 
   it("선택된 세션은 aria-pressed로 활성 상태를 드러낸다", () => {

--- a/frontend/src/features/consultation/ui/chat-panel.module.css
+++ b/frontend/src/features/consultation/ui/chat-panel.module.css
@@ -180,6 +180,9 @@
 
 /* System Message */
 .systemMessage {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
   text-align: center;
   font-size: 0.78rem;
   color: var(--text-secondary);
@@ -191,6 +194,11 @@
   text-transform: uppercase;
   letter-spacing: 0.5px;
   margin-bottom: 4px;
+}
+
+.systemLabel {
+  font-weight: 600;
+  color: var(--text-primary);
 }
 
 .internalNote {

--- a/frontend/src/pages/consultation/ui/ConsultationPage.test.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.test.tsx
@@ -843,6 +843,40 @@ describe("ConsultationPage", () => {
     });
   });
 
+  it("handles legacy AGENT echo and replaces the pending optimistic message", async () => {
+    const user = userEvent.setup();
+    render(<ConsultationPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("김민지")).toBeInTheDocument();
+    });
+
+    const customerItem = screen.getByText("김민지").closest("div");
+    if (customerItem) customerItem.click();
+
+    const input = await screen.findByPlaceholderText("메시지를 입력하세요...");
+    await user.type(input, "레거시 답변");
+    await user.keyboard("{Enter}");
+
+    await waitFor(() => {
+      expect(screen.getByText("레거시 답변")).toBeInTheDocument();
+    });
+
+    if (stompState.latestCallback) {
+      stompState.latestCallback({
+        id: 889,
+        senderRole: "AGENT",
+        content: "레거시 답변",
+        createdAt: new Date().toISOString(),
+      });
+    }
+
+    await waitFor(() => {
+      expect(screen.getByText("레거시 답변")).toBeInTheDocument();
+      expect(screen.getAllByText("레거시 답변")).toHaveLength(1);
+    });
+  });
+
   it("ignores counselor echo if there are no pending optimistic messages", async () => {
     render(<ConsultationPage />, { wrapper: Wrapper });
 

--- a/frontend/src/pages/consultation/ui/ConsultationPage.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.tsx
@@ -428,7 +428,12 @@ export const ConsultationPage: React.FC = () => {
     const topic = `/topic/chat.${activeCustomerId}`;
     const unsubscribe = subscribe(topic, (raw) => {
       const msg = raw as RealtimeChatMessage;
-      if (msg.senderRole === "COUNSELOR" || msg.senderRole === "NOTE") {
+      const normalizedRole = normalizeChatSenderRole(msg.senderRole);
+      if (
+        normalizedRole === "COUNSELOR" ||
+        normalizedRole === "AGENT" ||
+        normalizedRole === "NOTE"
+      ) {
         setMessagesCustomerId(activeCustomerId);
         setMessages((prev) => {
           const temps = [...pendingIdsRef.current];

--- a/frontend/src/pages/consultation/ui/ConsultationPage.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.tsx
@@ -9,6 +9,7 @@ import { QueuePanel } from "../../../features/consultation/ui/QueuePanel";
 import type { QueueCustomer } from "../../../features/consultation/ui/QueuePanel";
 import { ChatPanel } from "../../../features/consultation/ui/ChatPanel";
 import type { ChatMessage as UiChatMessage } from "../../../features/consultation/ui/ChatPanel";
+import { normalizeChatSenderRole } from "../../../features/consultation/lib/chatRoleLabels";
 import { consultationApi } from "../../../features/consultation/api/consultationApi";
 import type {
   ChatSession,
@@ -41,26 +42,17 @@ type MessageLike = {
   timestamp?: string | null;
 };
 
-const normalizeSenderRole = (senderRole?: string | null): UiChatMessage["senderRole"] => {
-  if (senderRole === "USER") return "CUSTOMER";
-  if (
-    senderRole === "CUSTOMER" ||
-    senderRole === "AGENT" ||
-    senderRole === "SYSTEM" ||
-    senderRole === "NOTE" ||
-    senderRole === "COUNSELOR" ||
-    senderRole === "ASSISTANT"
-  ) {
-    return senderRole;
-  }
-  return "SYSTEM";
+type SessionMeta = {
+  customerName?: string;
+  handoffReason?: string;
+  title?: string;
 };
 
 const toUiMessage = (message: MessageLike): UiChatMessage => {
   const createdAt = message.createdAt ?? message.timestamp ?? new Date().toISOString();
   return {
     id: String(message.id ?? `message-${createdAt}-${message.content ?? ""}`),
-    senderRole: normalizeSenderRole(message.senderRole),
+    senderRole: normalizeChatSenderRole(message.senderRole),
     content: message.content ?? "",
     timestamp: formatTime(createdAt),
   };
@@ -73,14 +65,15 @@ const calcWaitMinutes = (isoString: string) => {
   return Math.max(0, Math.floor(diffMs / 60000));
 };
 
-const parseSessionMeta = (metaJson?: string | null) => {
-  let meta = { customerName: "Unknown", handoffReason: "" };
+const parseSessionMeta = (metaJson?: string | null): SessionMeta => {
   try {
-    if (metaJson) meta = JSON.parse(metaJson);
+    if (!metaJson) return {};
+    const meta = JSON.parse(metaJson) as SessionMeta;
+    return meta && typeof meta === "object" ? meta : {};
   } catch (e) {
     console.error("Failed to parse metaJson", e);
+    return {};
   }
-  return meta;
 };
 
 const getSessionStatusLabel = (
@@ -113,6 +106,7 @@ const toQueueCustomer = (
   return {
     id: String(session.id ?? previous?.id ?? ""),
     name: meta.customerName?.trim() || previous?.name || "Unknown",
+    title: meta.title?.trim() || previous?.title || "",
     channel: session.channel ?? previous?.channel ?? "",
     handoffReason: meta.handoffReason ?? previous?.handoffReason ?? "",
     waitMinutes: startedAt ? calcWaitMinutes(startedAt) : (previous?.waitMinutes ?? 0),

--- a/frontend/src/pages/consultation/ui/chat-history/ChatHistoryPage.test.tsx
+++ b/frontend/src/pages/consultation/ui/chat-history/ChatHistoryPage.test.tsx
@@ -122,6 +122,25 @@ describe("ChatHistoryPage", () => {
     expect(screen.getByText("처리해드리겠습니다")).toBeTruthy();
   });
 
+  it("AI와 내부 메모 역할을 한국어 라벨로 표시한다", () => {
+    mockedUseChatMessages.mockReturnValue(
+      makeMessagesResult({
+        data: [
+          makeMessage({ id: 12, senderRole: "ASSISTANT", content: "AI 안내입니다" }),
+          makeMessage({ id: 13, senderRole: "NOTE", content: "내부 공유 메모" }),
+        ],
+      }),
+    );
+
+    renderPage();
+    fireEvent.click(screen.getByRole("button", { name: /카카오톡/ }));
+
+    expect(screen.getByText("AI")).toBeTruthy();
+    expect(screen.getByText("내부 메모")).toBeTruthy();
+    expect(screen.getByText("AI 안내입니다")).toBeTruthy();
+    expect(screen.getByText("내부 공유 메모")).toBeTruthy();
+  });
+
   it("선택한 세션에 메시지가 없으면 빈 상태를 표시한다", () => {
     mockedUseChatMessages.mockReturnValue(makeMessagesResult({ data: [] }));
 


### PR DESCRIPTION
## Summary
- Add shared backend session metadata updater for chat message persistence paths.
- Normalize counselor chat role labels across realtime chat, history, queue, and message detail UI.
- Surface session title metadata in queue/history while preserving legacy meta fields.

## Spec
- Spec PR: #301
- Spec file: .agent/specs/299.md

## Issue
Closes #299

## Tests
- `mise exec -- ./gradlew test --tests '*workflowruntime*'`
- `pnpm test src/features/consultation src/pages/consultation`
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 채팅 세션 메타 자동 갱신: 메시지 저장 직후 제목 우선 결정 및 마지막 메시지(미리보기/역할/시간/카운트) 반영
  * 발신자 역할 표기 통합: 역할별 라벨·아바타·톤 적용(고객·상담사·AI·내부 메모 등) 및 UI 전반 반영
  * 큐·세션 목록에서 meta.title 우선 표시 및 낙관적 메시지 매칭 대상 확대(COUNSELOR/AGENT/NOTE)

* **Bug Fixes**
  * 손상되거나 빈 세션 메타 복구/무시 처리로 안정성 향상
  * 시스템/내부 메모 라벨 표시 개선(CSS 포함)

* **Tests**
  * 메타 갱신 및 역할/라벨 관련 단위·통합 테스트 추가·갱신

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ajou-2026-1-capstone-5/ostone/pull/304?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->