### PR TITLE
feat(fe/be): consultation·user-chat 재구성 + 진입 흐름·워크플로 surface 안정화

### DIFF
--- a/backend/src/main/java/com/init/domainpack/infrastructure/DemoRefundRequestSeedRunner.java
+++ b/backend/src/main/java/com/init/domainpack/infrastructure/DemoRefundRequestSeedRunner.java
@@ -218,14 +218,14 @@ public class DemoRefundRequestSeedRunner implements ApplicationRunner {
         {
           "direction": "top-to-bottom",
           "nodes": [
-            {"id": "start", "type": "START", "label": "시작"},
-            {"id": "n1", "type": "ACTION", "label": "환불 금액 확인", "policyRef": "refund_amount_check"},
-            {"id": "n2", "type": "DECISION", "label": "환불 가능?"},
-            {"id": "n3", "type": "ACTION", "label": "반품 기한 확인", "policyRef": "return_deadline_check"},
-            {"id": "n4", "type": "DECISION", "label": "기한 내?"},
-            {"id": "n5", "type": "ACTION", "label": "고액 환불 알림", "policyRef": "high_value_alert"},
-            {"id": "end_requested", "type": "TERMINAL", "label": "환불 접수 완료", "state": "refund_requested"},
-            {"id": "end_rejected", "type": "TERMINAL", "label": "환불 불가", "state": "rejected"}
+            {"id": "start", "type": "START", "label": "시작", "description": "환불 요청 워크플로우의 진입점."},
+            {"id": "n1", "type": "ACTION", "label": "환불 금액 확인", "description": "주문 데이터를 조회해 환불 가능 금액과 결제 채널을 검증합니다.", "policyRef": "refund_amount_check", "iconHint": "Wallet"},
+            {"id": "n2", "type": "DECISION", "label": "환불 가능?", "description": "환불 정책 기준을 충족하는지 판단합니다."},
+            {"id": "n3", "type": "ACTION", "label": "반품 기한 확인", "description": "구매일 기준 14일 이내인지 검증합니다.", "policyRef": "return_deadline_check", "iconHint": "CalendarClock"},
+            {"id": "n4", "type": "DECISION", "label": "기한 내?", "description": "반품 가능 기한 안에 들어오는지 분기합니다."},
+            {"id": "n5", "type": "ACTION", "label": "고액 환불 알림", "description": "고액 환불 임계치 초과 시 매니저에게 자동 알림을 전송합니다.", "policyRef": "high_value_alert", "iconHint": "BellRing"},
+            {"id": "end_requested", "type": "TERMINAL", "label": "환불 접수 완료", "description": "환불 요청이 성공적으로 접수되었습니다.", "state": "refund_requested"},
+            {"id": "end_rejected", "type": "TERMINAL", "label": "환불 불가", "description": "환불 조건 불충족으로 요청이 거절되었습니다.", "state": "rejected"}
           ],
           "edges": [
             {"id": "e1", "from": "start", "to": "n1"},

--- a/backend/src/test/java/com/init/domainpack/infrastructure/DemoRefundSeedRunnerGuardTest.java
+++ b/backend/src/test/java/com/init/domainpack/infrastructure/DemoRefundSeedRunnerGuardTest.java
@@ -1,5 +1,6 @@
 package com.init.domainpack.infrastructure;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
@@ -7,6 +8,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.init.domainpack.domain.model.IntentDefinition;
 import com.init.domainpack.domain.model.WorkflowDefinition;
 import com.init.domainpack.domain.repository.IntentDefinitionRepository;
@@ -24,6 +27,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.DefaultApplicationArguments;
@@ -117,6 +121,61 @@ class DemoRefundSeedRunnerGuardTest {
     verify(intentSlotBindingRepository).saveAll(any());
     verify(chatSessionRepository).save(any(ChatSession.class));
     verify(chatMessageRepository, times(5)).save(any(ChatMessage.class));
+  }
+
+  @Test
+  @DisplayName("seed된 graph_json은 모든 노드에 description 필드를 포함한다")
+  void shouldSeedGraphJsonWithEnrichedDescriptions() throws Exception {
+    given(workflowDefinitionRepository.findAllByDomainPackVersionIdOrderByWorkflowCodeAsc(101L))
+        .willReturn(List.of());
+    given(intentDefinitionRepository.save(any(IntentDefinition.class)))
+        .willAnswer(
+            invocation -> {
+              IntentDefinition intent = invocation.getArgument(0);
+              ReflectionTestUtils.setField(intent, "id", 111L);
+              return intent;
+            });
+    ArgumentCaptor<WorkflowDefinition> workflowCaptor =
+        ArgumentCaptor.forClass(WorkflowDefinition.class);
+    given(workflowDefinitionRepository.save(workflowCaptor.capture()))
+        .willAnswer(
+            invocation -> {
+              WorkflowDefinition workflow = invocation.getArgument(0);
+              ReflectionTestUtils.setField(workflow, "id", 153L);
+              return workflow;
+            });
+    given(chatSessionRepository.save(any(ChatSession.class)))
+        .willAnswer(
+            invocation -> {
+              ChatSession session = invocation.getArgument(0);
+              ReflectionTestUtils.setField(session, "id", 1L);
+              return session;
+            });
+    given(chatMessageRepository.save(any(ChatMessage.class)))
+        .willAnswer(
+            invocation -> {
+              ChatMessage message = invocation.getArgument(0);
+              ReflectionTestUtils.setField(message, "id", 10L);
+              return message;
+            });
+    when(entityManager.createNativeQuery(any(String.class))).thenReturn(query);
+    when(query.setParameter(any(String.class), any())).thenReturn(query);
+
+    runner.run(new DefaultApplicationArguments());
+
+    WorkflowDefinition savedWorkflow = workflowCaptor.getValue();
+    JsonNode root = new ObjectMapper().readTree(savedWorkflow.getGraphJson());
+    JsonNode nodes = root.path("nodes");
+    assertThat(nodes.isArray()).isTrue();
+    assertThat(nodes).isNotEmpty();
+    for (JsonNode node : nodes) {
+      assertThat(node.hasNonNull("description"))
+          .as("node %s must include description", node.path("id").asText())
+          .isTrue();
+      assertThat(node.path("description").asText())
+          .as("description must be non-blank for node %s", node.path("id").asText())
+          .isNotBlank();
+    }
   }
 
   private WorkflowDefinitionSummaryRow existingWorkflow(String workflowCode) {

--- a/frontend/src/app/App.test.tsx
+++ b/frontend/src/app/App.test.tsx
@@ -1,12 +1,5 @@
 import { render, screen, waitFor } from "@testing-library/react";
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-} from "vite-plus/test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import { App } from "./App";
 import { AppProviders } from "./providers";
 

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -34,10 +34,7 @@ export function App() {
         <Route path="/login" element={<LoginPage />} />
         <Route path="/signup" element={<SignupPage />} />
         <Route path="/password-reset" element={<PasswordResetInitPage />} />
-        <Route
-          path="/password-reset/complete"
-          element={<PasswordResetCompletePage />}
-        />
+        <Route path="/password-reset/complete" element={<PasswordResetCompletePage />} />
         <Route
           path="/workspaces"
           element={
@@ -60,17 +57,11 @@ export function App() {
           <Route path="consultation/history" element={<ChatHistoryPage />} />
           <Route path="consultation/history/:sessionId" element={<ChatHistoryPage />} />
           <Route path="consultation" element={<ConsultationPage />} />
-          <Route
-            path="consultation/:sessionId"
-            element={<ConsultationPage />}
-          />
+          <Route path="consultation/:sessionId" element={<ConsultationPage />} />
           <Route path="upload" element={<WorkspaceUploadPage />} />
           <Route path="domain-packs" element={<DomainPackListPage />} />
         </Route>
-        <Route
-          path="/demo/workspaces/:workspaceId/chat"
-          element={<UserChatPage />}
-        />
+        <Route path="/demo/workspaces/:workspaceId/chat" element={<UserChatPage />} />
         <Route
           path="/upload"
           element={

--- a/frontend/src/entities/chat/api/chatApi.test.ts
+++ b/frontend/src/entities/chat/api/chatApi.test.ts
@@ -59,10 +59,9 @@ describe("chatApi", () => {
       },
     ]);
 
-    expect(customFetchMock).toHaveBeenCalledWith(
-      "/api/v1/consultation/sessions/7/messages",
-      { method: "GET" },
-    );
+    expect(customFetchMock).toHaveBeenCalledWith("/api/v1/consultation/sessions/7/messages", {
+      method: "GET",
+    });
   });
 
   it("데모 채팅 워크플로우를 채팅 UI 모델로 변환한다", async () => {
@@ -98,10 +97,9 @@ describe("chatApi", () => {
       ],
     });
 
-    expect(customFetchMock).toHaveBeenCalledWith(
-      "/api/v1/workspaces/2/demo/chat-workflow",
-      { method: "GET" },
-    );
+    expect(customFetchMock).toHaveBeenCalledWith("/api/v1/workspaces/2/demo/chat-workflow", {
+      method: "GET",
+    });
   });
 
   it("백엔드에 데모 채팅 세션을 등록한다", async () => {
@@ -126,13 +124,10 @@ describe("chatApi", () => {
       ],
     });
 
-    expect(customFetchMock).toHaveBeenCalledWith(
-      "/api/v1/workspaces/2/demo/chat-sessions",
-      {
-        method: "POST",
-        body: JSON.stringify({ customerName: "김민지" }),
-      },
-    );
+    expect(customFetchMock).toHaveBeenCalledWith("/api/v1/workspaces/2/demo/chat-sessions", {
+      method: "POST",
+      body: JSON.stringify({ customerName: "김민지" }),
+    });
   });
 
   it("백엔드 데모 채팅 세션 응답에 숫자 id가 없으면 실패한다", async () => {

--- a/frontend/src/entities/chat/api/chatApi.ts
+++ b/frontend/src/entities/chat/api/chatApi.ts
@@ -87,10 +87,7 @@ function toDemoChatMessage(
   };
 }
 
-export function createChatSession(
-  workspaceId: number,
-  customerName: string,
-): Promise<ChatSession> {
+export function createChatSession(workspaceId: number, customerName: string): Promise<ChatSession> {
   const params = new URLSearchParams({ customerName });
   return customFetch<ChatSession>(
     `/api/v1/workspaces/${workspaceId}/chat/sessions/current?${params.toString()}`,

--- a/frontend/src/entities/intent/index.ts
+++ b/frontend/src/entities/intent/index.ts
@@ -1,6 +1,1 @@
-export type {
-  IntentDetail,
-  IntentListState,
-  IntentSummary,
-  IntentTreeNode,
-} from "./model/types";
+export type { IntentDetail, IntentListState, IntentSummary, IntentTreeNode } from "./model/types";

--- a/frontend/src/entities/workflow/api/useListWorkflowsByIntent.ts
+++ b/frontend/src/entities/workflow/api/useListWorkflowsByIntent.ts
@@ -2,10 +2,7 @@ import { useQuery, type UseQueryResult } from "@tanstack/react-query";
 
 import { getDomainPack } from "@/shared/api/generated/endpoints/domain-pack-controller/domain-pack-controller";
 import { listWorkflows } from "@/shared/api/generated/endpoints/workflow-definition-controller/workflow-definition-controller";
-import type {
-  DomainPackDetailResult,
-  WorkflowDefinitionSummary,
-} from "@/shared/api/generated/zod";
+import type { DomainPackDetailResult, WorkflowDefinitionSummary } from "@/shared/api/generated/zod";
 import { unwrapApiResponse } from "@/shared/api/unwrapApiResponse";
 
 import type { WorkspaceWorkflowEntry } from "./useListAllWorkspaceWorkflows";

--- a/frontend/src/entities/workflow/lib/useConnectedSides.test.ts
+++ b/frontend/src/entities/workflow/lib/useConnectedSides.test.ts
@@ -60,19 +60,13 @@ describe("useConnectedSides", () => {
   });
 
   it("같은 side의 중복 엣지가 있어도 한 번만 반환한다", () => {
-    testEdges = [
-      edge("e1", "n1", "right", "n2", "left"),
-      edge("e2", "n1", "right", "n3", "top"),
-    ];
+    testEdges = [edge("e1", "n1", "right", "n2", "left"), edge("e2", "n1", "right", "n3", "top")];
     const result = useConnectedSides("n1");
     expect(result.sources.filter((s) => s === "right")).toHaveLength(1);
   });
 
   it("여러 방향의 source와 target 엣지를 모두 수집한다", () => {
-    testEdges = [
-      edge("e1", "n1", "right", "n2", "left"),
-      edge("e2", "n3", "bottom", "n1", "top"),
-    ];
+    testEdges = [edge("e1", "n1", "right", "n2", "left"), edge("e2", "n3", "bottom", "n1", "top")];
     const result = useConnectedSides("n1");
     expect(result.sources).toContain("right");
     expect(result.targets).toContain("top");

--- a/frontend/src/entities/workflow/ui/WorkflowGraphMini.tsx
+++ b/frontend/src/entities/workflow/ui/WorkflowGraphMini.tsx
@@ -4,13 +4,7 @@ import { useParams } from "react-router-dom";
 import { useGetWorkflowDefinition } from "../api/useGetWorkflowDefinition";
 
 import { layoutDag, type LayoutNode } from "./lib/dagLayout";
-import {
-  buildEdgePath,
-  edgeLabelPoint,
-  nodeAnchor,
-  NODE_HEIGHT,
-  NODE_WIDTH,
-} from "./lib/edgePath";
+import { buildEdgePath, edgeLabelPoint, nodeAnchor, NODE_HEIGHT, NODE_WIDTH } from "./lib/edgePath";
 import { safeParseGraph, type GraphNodeType, type ParsedEdge } from "./lib/parseGraph";
 
 interface WorkflowGraphMiniProps {
@@ -26,13 +20,7 @@ function truncate(label: string, max = 10): string {
   return label.length > max ? `${label.slice(0, max - 1)}…` : label;
 }
 
-function NodeShape({
-  node,
-  showLabel,
-}: {
-  node: LayoutNode;
-  showLabel: boolean;
-}) {
+function NodeShape({ node, showLabel }: { node: LayoutNode; showLabel: boolean }) {
   const stroke = "var(--ink)";
   const paper = "var(--paper)";
   const ink = "var(--ink)";

--- a/frontend/src/entities/workflow/ui/lib/edgePath.ts
+++ b/frontend/src/entities/workflow/ui/lib/edgePath.ts
@@ -8,11 +8,7 @@ export interface EdgePoint {
 export const NODE_WIDTH = 56;
 export const NODE_HEIGHT = 26;
 
-export function nodeAnchor(
-  type: GraphNodeType,
-  center: EdgePoint,
-  toward: EdgePoint,
-): EdgePoint {
+export function nodeAnchor(type: GraphNodeType, center: EdgePoint, toward: EdgePoint): EdgePoint {
   const dx = toward.x - center.x;
   const dy = toward.y - center.y;
   const len = Math.hypot(dx, dy);

--- a/frontend/src/features/approve-intent/ui/IntentDetailWithApproval.tsx
+++ b/frontend/src/features/approve-intent/ui/IntentDetailWithApproval.tsx
@@ -14,11 +14,7 @@ function normalizeIntentStatus(
   override: IntentApprovalStatus | null,
 ): "DRAFT" | IntentApprovalStatus {
   const effective = override ?? raw;
-  if (
-    effective === "DRAFT" ||
-    effective === "PUBLISHED" ||
-    effective === "REJECTED"
-  ) {
+  if (effective === "DRAFT" || effective === "PUBLISHED" || effective === "REJECTED") {
     return effective as IntentApprovalStatus;
   }
   return "DRAFT";
@@ -47,11 +43,8 @@ export function IntentDetailWithApproval({
   nonDraftHeaderActions?: (detail: IntentDetail) => ReactNode;
   children?: (detail: IntentDetail) => ReactNode;
 }) {
-  const [approvalState, setApprovalState] = useState(() =>
-    createApprovalState(iId),
-  );
-  const currentState =
-    approvalState.intentId === iId ? approvalState : createApprovalState(iId);
+  const [approvalState, setApprovalState] = useState(() => createApprovalState(iId));
+  const currentState = approvalState.intentId === iId ? approvalState : createApprovalState(iId);
 
   const mutation = useApproveIntent({
     wsId,
@@ -91,8 +84,7 @@ export function IntentDetailWithApproval({
       return { ...base, dialogAction: action };
     });
   };
-  const combinedRefreshKey =
-    (refreshKey ?? 0) * 1000 + currentState.detailRefreshKey;
+  const combinedRefreshKey = (refreshKey ?? 0) * 1000 + currentState.detailRefreshKey;
 
   return (
     <IntentDetailPanel

--- a/frontend/src/features/consultation/api/chatHistoryApi.ts
+++ b/frontend/src/features/consultation/api/chatHistoryApi.ts
@@ -9,7 +9,12 @@ export interface UseChatSessionsParams {
   size?: number;
 }
 
-export function useChatSessions({ workspaceId, status, page = 0, size = 20 }: UseChatSessionsParams) {
+export function useChatSessions({
+  workspaceId,
+  status,
+  page = 0,
+  size = 20,
+}: UseChatSessionsParams) {
   return useQuery({
     queryKey: chatHistoryKeys.sessionList(workspaceId, status, page, size),
     queryFn: () => consultationApi.getSessions({ status, page, size }),

--- a/frontend/src/features/consultation/api/consultationApi.test.ts
+++ b/frontend/src/features/consultation/api/consultationApi.test.ts
@@ -13,7 +13,9 @@ vi.mock("@/shared/api/generated/endpoints/consultation-controller/consultation-c
   getMessages: vi.fn(),
   sendMessage: vi.fn(),
   updateStatus: vi.fn(),
-  getGetMessagesUrl: vi.fn((sessionId: number) => `/api/v1/consultation/sessions/${sessionId}/messages`),
+  getGetMessagesUrl: vi.fn(
+    (sessionId: number) => `/api/v1/consultation/sessions/${sessionId}/messages`,
+  ),
 }));
 
 vi.mock("@/shared/api/mutator", () => ({
@@ -44,14 +46,17 @@ describe("consultationApi", () => {
         startedAt: new Date().toISOString(),
       },
     ];
-    mockedCustomFetch.mockResolvedValue({ data: stubSessions, status: 200, headers: new Headers() });
+    mockedCustomFetch.mockResolvedValue({
+      data: stubSessions,
+      status: 200,
+      headers: new Headers(),
+    });
 
     const result = await consultationApi.getQueue(2);
 
-    expect(mockedCustomFetch).toHaveBeenCalledWith(
-      "/api/v1/workspaces/2/consultation/queue",
-      { method: "GET" },
-    );
+    expect(mockedCustomFetch).toHaveBeenCalledWith("/api/v1/workspaces/2/consultation/queue", {
+      method: "GET",
+    });
     expect(result).toEqual(stubSessions);
     expect(result).toHaveLength(1);
   });
@@ -176,11 +181,17 @@ describe("consultationApi", () => {
         startedAt: new Date().toISOString(),
       },
     ];
-    mockedCustomFetch.mockResolvedValue({ data: stubSessions, status: 200, headers: new Headers() });
+    mockedCustomFetch.mockResolvedValue({
+      data: stubSessions,
+      status: 200,
+      headers: new Headers(),
+    });
 
     const result = await consultationApi.getSessions();
 
-    expect(mockedCustomFetch).toHaveBeenCalledWith("/api/v1/consultation/sessions", { method: "GET" });
+    expect(mockedCustomFetch).toHaveBeenCalledWith("/api/v1/consultation/sessions", {
+      method: "GET",
+    });
     expect(result).toEqual(stubSessions);
   });
 
@@ -203,31 +214,41 @@ describe("consultationApi", () => {
 
   it("getSessions가 status 필터를 전달한다", async () => {
     const stubSessions: ChatSessionResponse[] = [];
-    mockedCustomFetch.mockResolvedValue({ data: stubSessions, status: 200, headers: new Headers() });
+    mockedCustomFetch.mockResolvedValue({
+      data: stubSessions,
+      status: 200,
+      headers: new Headers(),
+    });
 
     await consultationApi.getSessions({ status: "OPEN" });
 
-    expect(mockedCustomFetch).toHaveBeenCalledWith(
-      "/api/v1/consultation/sessions?status=OPEN",
-      { method: "GET" },
-    );
+    expect(mockedCustomFetch).toHaveBeenCalledWith("/api/v1/consultation/sessions?status=OPEN", {
+      method: "GET",
+    });
   });
 
   it("getSessions가 page/size를 전달한다", async () => {
     const stubSessions: ChatSessionResponse[] = [];
-    mockedCustomFetch.mockResolvedValue({ data: stubSessions, status: 200, headers: new Headers() });
+    mockedCustomFetch.mockResolvedValue({
+      data: stubSessions,
+      status: 200,
+      headers: new Headers(),
+    });
 
     await consultationApi.getSessions({ page: 1, size: 20 });
 
-    expect(mockedCustomFetch).toHaveBeenCalledWith(
-      "/api/v1/consultation/sessions?page=1&size=20",
-      { method: "GET" },
-    );
+    expect(mockedCustomFetch).toHaveBeenCalledWith("/api/v1/consultation/sessions?page=1&size=20", {
+      method: "GET",
+    });
   });
 
   it("getMessages가 params 없이 호출되면 generated 함수를 사용한다", async () => {
     const stubMessages: ChatMessageResponse[] = [];
-    mockedGetMessages.mockResolvedValue({ data: stubMessages, status: 200, headers: new Headers() });
+    mockedGetMessages.mockResolvedValue({
+      data: stubMessages,
+      status: 200,
+      headers: new Headers(),
+    });
 
     const result = await consultationApi.getMessages(1);
 
@@ -247,7 +268,11 @@ describe("consultationApi", () => {
         createdAt: new Date().toISOString(),
       },
     ];
-    mockedCustomFetch.mockResolvedValue({ data: stubMessages, status: 200, headers: new Headers() });
+    mockedCustomFetch.mockResolvedValue({
+      data: stubMessages,
+      status: 200,
+      headers: new Headers(),
+    });
 
     const result = await consultationApi.getMessages(1, { page: 0, size: 10 });
 
@@ -365,10 +390,9 @@ describe("consultationApi", () => {
 
     const result = await consultationApi.getMetrics(2);
 
-    expect(mockedCustomFetch).toHaveBeenCalledWith(
-      "/api/v1/workspaces/2/consultation/metrics",
-      { method: "GET" },
-    );
+    expect(mockedCustomFetch).toHaveBeenCalledWith("/api/v1/workspaces/2/consultation/metrics", {
+      method: "GET",
+    });
     expect(result).toEqual(stubMetrics);
   });
 });

--- a/frontend/src/features/consultation/ui/ChatPanel.test.tsx
+++ b/frontend/src/features/consultation/ui/ChatPanel.test.tsx
@@ -20,7 +20,6 @@ describe("ChatPanel", () => {
     expect(screen.queryByPlaceholderText("메시지를 입력하세요...")).not.toBeInTheDocument();
   });
 
-
   it("일반 메시지를 전송하면 입력값이 비워진다", () => {
     const onSendMessage = vi.fn();
 

--- a/frontend/src/features/consultation/ui/QueuePanel.test.tsx
+++ b/frontend/src/features/consultation/ui/QueuePanel.test.tsx
@@ -2,7 +2,10 @@ import { describe, expect, it, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { QueuePanel } from "./QueuePanel";
 
-const makeCustomer = (id: string, extra?: Partial<Parameters<typeof QueuePanel>[0]["customers"][0]>) => ({
+const makeCustomer = (
+  id: string,
+  extra?: Partial<Parameters<typeof QueuePanel>[0]["customers"][0]>,
+) => ({
   id,
   name: `고객${id}`,
   channel: "CHAT",
@@ -96,7 +99,11 @@ describe("QueuePanel", () => {
   it("클릭하면 onSelectCustomer가 호출된다", () => {
     const onSelect = vi.fn();
     render(
-      <QueuePanel customers={[makeCustomer("42")]} activeCustomerId={null} onSelectCustomer={onSelect} />,
+      <QueuePanel
+        customers={[makeCustomer("42")]}
+        activeCustomerId={null}
+        onSelectCustomer={onSelect}
+      />,
     );
     fireEvent.click(screen.getByRole("button"));
     expect(onSelect).toHaveBeenCalledWith("42");
@@ -105,7 +112,11 @@ describe("QueuePanel", () => {
   it("Enter 키로 onSelectCustomer가 호출된다", () => {
     const onSelect = vi.fn();
     render(
-      <QueuePanel customers={[makeCustomer("5")]} activeCustomerId={null} onSelectCustomer={onSelect} />,
+      <QueuePanel
+        customers={[makeCustomer("5")]}
+        activeCustomerId={null}
+        onSelectCustomer={onSelect}
+      />,
     );
     fireEvent.keyDown(screen.getByRole("button"), { key: "Enter" });
     expect(onSelect).toHaveBeenCalledWith("5");
@@ -114,7 +125,11 @@ describe("QueuePanel", () => {
   it("스페이스 키로 onSelectCustomer가 호출된다", () => {
     const onSelect = vi.fn();
     render(
-      <QueuePanel customers={[makeCustomer("7")]} activeCustomerId={null} onSelectCustomer={onSelect} />,
+      <QueuePanel
+        customers={[makeCustomer("7")]}
+        activeCustomerId={null}
+        onSelectCustomer={onSelect}
+      />,
     );
     fireEvent.keyDown(screen.getByRole("button"), { key: " " });
     expect(onSelect).toHaveBeenCalledWith("7");
@@ -123,7 +138,11 @@ describe("QueuePanel", () => {
   it("다른 키는 onSelectCustomer를 호출하지 않는다", () => {
     const onSelect = vi.fn();
     render(
-      <QueuePanel customers={[makeCustomer("8")]} activeCustomerId={null} onSelectCustomer={onSelect} />,
+      <QueuePanel
+        customers={[makeCustomer("8")]}
+        activeCustomerId={null}
+        onSelectCustomer={onSelect}
+      />,
     );
     fireEvent.keyDown(screen.getByRole("button"), { key: "Tab" });
     expect(onSelect).not.toHaveBeenCalled();

--- a/frontend/src/features/consultation/ui/chat-history/MessageHistory.tsx
+++ b/frontend/src/features/consultation/ui/chat-history/MessageHistory.tsx
@@ -1,4 +1,13 @@
-import { Dot, EmptyState, ErrorState, Eyebrow, Icon, LoadingSpinner, Mono, Pill } from "@/shared/ui/ostone/atoms";
+import {
+  Dot,
+  EmptyState,
+  ErrorState,
+  Eyebrow,
+  Icon,
+  LoadingSpinner,
+  Mono,
+  Pill,
+} from "@/shared/ui/ostone/atoms";
 import type { ChatMessage } from "../../api/consultationApi";
 import { useChatMessages } from "../../api/chatHistoryApi";
 import { getChatRolePresentation, isCounselorLikeRole } from "../../lib/chatRoleLabels";
@@ -35,8 +44,12 @@ function MessageBubble({ message }: { message: ChatMessage }) {
   }
 
   return (
-    <article className={`${styles.messageRow} ${isCounselor ? styles.counselorRow : styles.customerRow}`}>
-      <div className={`${styles.bubble} ${isCounselor ? styles.counselorBubble : styles.customerBubble}`}>
+    <article
+      className={`${styles.messageRow} ${isCounselor ? styles.counselorRow : styles.customerRow}`}
+    >
+      <div
+        className={`${styles.bubble} ${isCounselor ? styles.counselorBubble : styles.customerBubble}`}
+      >
         <div className={styles.metaLine}>
           <span className={styles.roleLabel}>{role.label}</span>
           <Pill tone={isCounselor ? "signal" : "mute"}>{message.messageType ?? "TEXT"}</Pill>
@@ -50,7 +63,13 @@ function MessageBubble({ message }: { message: ChatMessage }) {
 
 export function MessageHistory({ sessionId }: MessageHistoryProps) {
   const activeSessionId = sessionId ?? "";
-  const { data: messages = [], isLoading, isError, error, refetch } = useChatMessages(activeSessionId);
+  const {
+    data: messages = [],
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useChatMessages(activeSessionId);
 
   if (!activeSessionId) {
     return (

--- a/frontend/src/features/consultation/ui/chat-history/SessionList.test.tsx
+++ b/frontend/src/features/consultation/ui/chat-history/SessionList.test.tsx
@@ -15,14 +15,15 @@ type MockChatSessionsResult = Pick<
   "data" | "isLoading" | "isError" | "error" | "refetch"
 >;
 
-const makeQueryResult = (overrides?: Partial<MockChatSessionsResult>) => ({
-  data: [],
-  isLoading: false,
-  isError: false,
-  error: null,
-  refetch: vi.fn(),
-  ...overrides,
-}) as ReturnType<typeof useChatSessions>;
+const makeQueryResult = (overrides?: Partial<MockChatSessionsResult>) =>
+  ({
+    data: [],
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+    ...overrides,
+  }) as ReturnType<typeof useChatSessions>;
 
 const makeSession = (id: number, meta?: Record<string, unknown>): ChatSession => ({
   id,
@@ -102,7 +103,9 @@ describe("SessionList", () => {
     );
 
     expect(screen.getByText("카카오톡")).toBeTruthy();
-    expect(screen.getByText(new Date("2026-05-22T09:00:00+09:00").toLocaleDateString("ko-KR"))).toBeTruthy();
+    expect(
+      screen.getByText(new Date("2026-05-22T09:00:00+09:00").toLocaleDateString("ko-KR")),
+    ).toBeTruthy();
     expect(screen.getByText("메시지 3개")).toBeTruthy();
     expect(screen.getByText("배송 상태를 확인해주세요")).toBeTruthy();
   });
@@ -134,7 +137,9 @@ describe("SessionList", () => {
     const onSelect = vi.fn();
     mockedUseChatSessions.mockReturnValue(makeQueryResult({ data: [makeSession(7)] }));
 
-    render(<SessionList workspaceId="workspace-1" selectedSessionId={null} onSelectSession={onSelect} />);
+    render(
+      <SessionList workspaceId="workspace-1" selectedSessionId={null} onSelectSession={onSelect} />,
+    );
 
     fireEvent.click(screen.getByRole("button", { name: /카카오톡/ }));
 

--- a/frontend/src/features/consultation/ui/chat-history/SessionList.tsx
+++ b/frontend/src/features/consultation/ui/chat-history/SessionList.tsx
@@ -15,7 +15,13 @@ function getErrorMessage(error: unknown): string {
 }
 
 export function SessionList({ workspaceId, selectedSessionId, onSelectSession }: SessionListProps) {
-  const { data: sessions = [], isLoading, isError, error, refetch } = useChatSessions({
+  const {
+    data: sessions = [],
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useChatSessions({
     workspaceId,
     status: "completed",
   });

--- a/frontend/src/features/domain-pack-summary-read/model/usePackDetail.ts
+++ b/frontend/src/features/domain-pack-summary-read/model/usePackDetail.ts
@@ -8,11 +8,7 @@ import {
 } from "@/shared/api/generated/zod";
 import { unwrapApiResponse } from "@/shared/api";
 
-export function usePackDetail(
-  wsId: number,
-  packId: number,
-  options?: { enabled?: boolean },
-) {
+export function usePackDetail(wsId: number, packId: number, options?: { enabled?: boolean }) {
   return useGetDomainPack(wsId, packId, {
     query: {
       enabled: options?.enabled,

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.test.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.test.tsx
@@ -1,10 +1,6 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  QueryClient,
-  QueryClientProvider,
-  type UseQueryResult,
-} from "@tanstack/react-query";
+import { QueryClient, QueryClientProvider, type UseQueryResult } from "@tanstack/react-query";
 import type { DomainPackVersionDetail } from "@/entities/domain-pack";
 import { ApiRequestError } from "@/shared/api";
 import { SummaryDetailPanel } from "./SummaryDetailPanel";
@@ -20,13 +16,7 @@ vi.mock("./ComponentCountGrid", () => ({
 }));
 
 vi.mock("@/shared/ui/ostone/atoms/ErrorState", () => ({
-  ErrorState: ({
-    message,
-    onRetry,
-  }: {
-    message: string;
-    onRetry?: () => void;
-  }) => (
+  ErrorState: ({ message, onRetry }: { message: string; onRetry?: () => void }) => (
     <div role="alert">
       <span>{message}</span>
       {onRetry && (
@@ -74,9 +64,7 @@ const publishedDetail: DomainPackVersionDetail = {
 
 function renderSummaryDetailPanel(ui: React.ReactElement) {
   const queryClient = new QueryClient();
-  return render(
-    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
-  );
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
 }
 
 describe("SummaryDetailPanel", () => {
@@ -85,20 +73,14 @@ describe("SummaryDetailPanel", () => {
   });
 
   it('data 없고 로딩/에러 없으면 "버전을 선택하세요." 안내를 표시한다', () => {
-    renderSummaryDetailPanel(
-      <SummaryDetailPanel query={makeQuery({})} wsId={1} packId={2} />,
-    );
+    renderSummaryDetailPanel(<SummaryDetailPanel query={makeQuery({})} wsId={1} packId={2} />);
 
     expect(screen.getByText("버전을 선택하세요.")).toBeInTheDocument();
   });
 
   it('loading 상태에서 "로딩 중" aria-label을 렌더링한다', () => {
     renderSummaryDetailPanel(
-      <SummaryDetailPanel
-        query={makeQuery({ isLoading: true })}
-        wsId={1}
-        packId={2}
-      />,
+      <SummaryDetailPanel query={makeQuery({ isLoading: true })} wsId={1} packId={2} />,
     );
 
     expect(screen.getByLabelText("로딩 중")).toBeInTheDocument();
@@ -113,9 +95,7 @@ describe("SummaryDetailPanel", () => {
       />,
     );
 
-    expect(screen.getByRole("alert")).toHaveTextContent(
-      "버전 정보를 불러오지 못했습니다.",
-    );
+    expect(screen.getByRole("alert")).toHaveTextContent("버전 정보를 불러오지 못했습니다.");
   });
 
   it('404 에러 시 "버전을 찾을 수 없습니다." 메시지를 표시하고 다시 시도 버튼은 없다', () => {
@@ -128,12 +108,8 @@ describe("SummaryDetailPanel", () => {
       />,
     );
 
-    expect(screen.getByRole("alert")).toHaveTextContent(
-      "버전을 찾을 수 없습니다.",
-    );
-    expect(
-      screen.queryByRole("button", { name: "다시 시도" }),
-    ).not.toBeInTheDocument();
+    expect(screen.getByRole("alert")).toHaveTextContent("버전을 찾을 수 없습니다.");
+    expect(screen.queryByRole("button", { name: "다시 시도" })).not.toBeInTheDocument();
   });
 
   it("일반 에러 시 다시 시도 버튼을 표시하고 클릭 시 refetch를 호출한다", () => {
@@ -153,19 +129,13 @@ describe("SummaryDetailPanel", () => {
 
   it("정상 데이터 시 Summary JSON과 구성요소를 렌더링하고 승인 준비 상태는 렌더링하지 않는다", () => {
     renderSummaryDetailPanel(
-      <SummaryDetailPanel
-        query={makeQuery({ data: stubDetail })}
-        wsId={1}
-        packId={2}
-      />,
+      <SummaryDetailPanel query={makeQuery({ data: stubDetail })} wsId={1} packId={2} />,
     );
 
     expect(screen.getByText("v1")).toBeInTheDocument();
     expect(screen.getByText("DRAFT")).toBeInTheDocument();
     expect(screen.getByText("Summary JSON")).toBeInTheDocument();
-    expect(screen.getByTestId("summary-json-card")).toHaveTextContent(
-      '{"key":"val"}',
-    );
+    expect(screen.getByTestId("summary-json-card")).toHaveTextContent('{"key":"val"}');
     expect(screen.getByTestId("component-count-grid")).toBeInTheDocument();
     expect(screen.queryByText("승인 준비 상태")).not.toBeInTheDocument();
   });
@@ -249,9 +219,7 @@ describe("SummaryDetailPanel", () => {
 
     expect(screen.getByRole("button", { name: "적용" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "삭제" })).toBeInTheDocument();
-    expect(
-      screen.queryByRole("button", { name: "배포" }),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "배포" })).not.toBeInTheDocument();
   });
 
   it("DRAFT 버전에서는 제공된 action callback의 버튼만 표시한다", () => {
@@ -265,9 +233,7 @@ describe("SummaryDetailPanel", () => {
     );
 
     expect(screen.getByRole("button", { name: "적용" })).toBeInTheDocument();
-    expect(
-      screen.queryByRole("button", { name: "삭제" }),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "삭제" })).not.toBeInTheDocument();
   });
 
   it("DRAFT 버전에서 삭제 callback만 있으면 삭제 버튼만 표시한다", () => {
@@ -281,9 +247,7 @@ describe("SummaryDetailPanel", () => {
     );
 
     expect(screen.getByRole("button", { name: "삭제" })).toBeInTheDocument();
-    expect(
-      screen.queryByRole("button", { name: "적용" }),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "적용" })).not.toBeInTheDocument();
   });
 
   it("Draft 처리 중에는 적용/삭제 버튼을 비활성화하고 진행 중 label을 보여준다", () => {
@@ -335,9 +299,7 @@ describe("SummaryDetailPanel", () => {
     fireEvent.click(screen.getByRole("button", { name: "삭제" }));
     expect(screen.getByText("Draft 버전을 삭제할까요?")).toBeInTheDocument();
     expect(
-      screen.getByText(
-        "삭제하면 이 Draft 버전과 저장된 수정 내용이 모두 삭제됩니다.",
-      ),
+      screen.getByText("삭제하면 이 Draft 버전과 저장된 수정 내용이 모두 삭제됩니다."),
     ).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "삭제하기" }));
 

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.tsx
@@ -27,11 +27,7 @@ interface SummaryDetailPanelProps {
   onDeploy?: (versionId: number) => void;
   onApplyDraft?: (versionId: number) => void;
   onDiscardDraft?: (versionId: number) => void;
-  renderSlotEditSheet?: (
-    slotId: number,
-    isOpen: boolean,
-    onClose: () => void,
-  ) => React.ReactNode;
+  renderSlotEditSheet?: (slotId: number, isOpen: boolean, onClose: () => void) => React.ReactNode;
 }
 
 export function SummaryDetailPanel({
@@ -58,23 +54,11 @@ export function SummaryDetailPanel({
   const isDiscarding = versionId != null && versionId === discardingVersionId;
   const isDraftVersion = v?.lifecycleStatus === "DRAFT";
   const canDeploy =
-    onDeploy != null &&
-    versionId != null &&
-    !isCurrentVersion &&
-    !isDeploying &&
-    !isDraftVersion;
+    onDeploy != null && versionId != null && !isCurrentVersion && !isDeploying && !isDraftVersion;
   const canApplyDraft =
-    onApplyDraft != null &&
-    versionId != null &&
-    isDraftVersion &&
-    !isApplying &&
-    !isDiscarding;
+    onApplyDraft != null && versionId != null && isDraftVersion && !isApplying && !isDiscarding;
   const canDiscardDraft =
-    onDiscardDraft != null &&
-    versionId != null &&
-    isDraftVersion &&
-    !isApplying &&
-    !isDiscarding;
+    onDiscardDraft != null && versionId != null && isDraftVersion && !isApplying && !isDiscarding;
 
   const handleConfirmDeploy = () => {
     if (!canDeploy) return;
@@ -104,37 +88,20 @@ export function SummaryDetailPanel({
     return (
       <div className={styles.panel}>
         <div className={styles.skeleton} aria-label="로딩 중">
-          <div
-            className={styles.skeletonBlock}
-            style={{ height: 80 }}
-            aria-hidden
-          />
-          <div
-            className={styles.skeletonBlock}
-            style={{ height: 160 }}
-            aria-hidden
-          />
-          <div
-            className={styles.skeletonBlock}
-            style={{ height: 200 }}
-            aria-hidden
-          />
+          <div className={styles.skeletonBlock} style={{ height: 80 }} aria-hidden />
+          <div className={styles.skeletonBlock} style={{ height: 160 }} aria-hidden />
+          <div className={styles.skeletonBlock} style={{ height: 200 }} aria-hidden />
         </div>
       </div>
     );
   }
 
   if (query.isError) {
-    const is404 =
-      query.error instanceof ApiRequestError && query.error.status === 404;
+    const is404 = query.error instanceof ApiRequestError && query.error.status === 404;
     return (
       <div className={styles.panel}>
         <ErrorState
-          message={
-            is404
-              ? "버전을 찾을 수 없습니다."
-              : "버전 정보를 불러오지 못했습니다."
-          }
+          message={is404 ? "버전을 찾을 수 없습니다." : "버전 정보를 불러오지 못했습니다."}
           onRetry={!is404 ? () => query.refetch() : undefined}
         />
       </div>
@@ -158,22 +125,16 @@ export function SummaryDetailPanel({
                 {v.lifecycleStatus}
               </span>
               {isCurrentVersion && (
-                <span className={`${styles.badge} ${styles.badgeOperating}`}>
-                  배포중
-                </span>
+                <span className={`${styles.badge} ${styles.badgeOperating}`}>배포중</span>
               )}
             </div>
           </div>
           <div className={styles.metaGrid}>
             <span className={styles.metaKey}>생성</span>
-            <span className={styles.metaValue}>
-              {formatDate(v.createdAt ?? "")}
-            </span>
+            <span className={styles.metaValue}>{formatDate(v.createdAt ?? "")}</span>
           </div>
         </div>
-        {isDraftVersion &&
-        versionId != null &&
-        (onApplyDraft || onDiscardDraft) ? (
+        {isDraftVersion && versionId != null && (onApplyDraft || onDiscardDraft) ? (
           <div className={styles.deployActions}>
             {onDiscardDraft && (
               <button
@@ -210,11 +171,7 @@ export function SummaryDetailPanel({
                 if (canDeploy) setDeployDialogOpen(true);
               }}
             >
-              {isCurrentVersion
-                ? "배포중"
-                : isDeploying
-                  ? "배포 중..."
-                  : "배포"}
+              {isCurrentVersion ? "배포중" : isDeploying ? "배포 중..." : "배포"}
             </button>
           </div>
         ) : null}
@@ -231,8 +188,7 @@ export function SummaryDetailPanel({
             이 버전을 배포할까요?
           </AlertDialogTitle>
           <AlertDialogDescription className={styles.approvalDialogDescription}>
-            배포하면 현재 운영 중인 Domain Pack 버전이 선택한 버전으로
-            전환됩니다.
+            배포하면 현재 운영 중인 Domain Pack 버전이 선택한 버전으로 전환됩니다.
           </AlertDialogDescription>
           <AlertDialogFooter className={styles.approvalDialogFooter}>
             <Button

--- a/frontend/src/features/intent-draft-read/ui/IntentDetailPanel.test.tsx
+++ b/frontend/src/features/intent-draft-read/ui/IntentDetailPanel.test.tsx
@@ -1,15 +1,8 @@
 import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { toast } from "sonner";
-import type {
-  IntentDetail,
-  IntentListState,
-  IntentSummary,
-} from "@/entities/intent";
-import {
-  useIntentDetail,
-  type IntentDetailState,
-} from "../model/useIntentDetail";
+import type { IntentDetail, IntentListState, IntentSummary } from "@/entities/intent";
+import { useIntentDetail, type IntentDetailState } from "../model/useIntentDetail";
 import { IntentDetailPanel } from "./IntentDetailPanel";
 
 vi.mock("../model/useIntentDetail", () => ({
@@ -48,9 +41,7 @@ function readyList(data: IntentSummary[]): IntentListState {
   return { status: "ready", data };
 }
 
-function renderPanel(
-  props: Partial<React.ComponentProps<typeof IntentDetailPanel>> = {},
-) {
+function renderPanel(props: Partial<React.ComponentProps<typeof IntentDetailPanel>> = {}) {
   const defaults = {
     wsId: 1,
     packId: 2,
@@ -113,9 +104,7 @@ describe("IntentDetailPanel", () => {
   });
 
   it("parent intent id 대신 parent intent 제목을 표시한다", () => {
-    mockedUseIntentDetail.mockReturnValue(
-      readyDetail({ ...stubDetail, parentIntentId: 20 }),
-    );
+    mockedUseIntentDetail.mockReturnValue(readyDetail({ ...stubDetail, parentIntentId: 20 }));
     renderPanel({
       intentListState: readyList([
         {
@@ -133,9 +122,7 @@ describe("IntentDetailPanel", () => {
   });
 
   it("parent intent 이름이 없으면 intent code를 fallback으로 표시한다", () => {
-    mockedUseIntentDetail.mockReturnValue(
-      readyDetail({ ...stubDetail, parentIntentId: 20 }),
-    );
+    mockedUseIntentDetail.mockReturnValue(readyDetail({ ...stubDetail, parentIntentId: 20 }));
 
     renderPanel({
       intentListState: readyList([
@@ -152,9 +139,7 @@ describe("IntentDetailPanel", () => {
   });
 
   it("parent intent 목록이 loading/error이면 상태별 fallback을 표시한다", () => {
-    mockedUseIntentDetail.mockReturnValue(
-      readyDetail({ ...stubDetail, parentIntentId: 20 }),
-    );
+    mockedUseIntentDetail.mockReturnValue(readyDetail({ ...stubDetail, parentIntentId: 20 }));
     const { rerender } = render(
       <IntentDetailPanel
         wsId={1}
@@ -186,9 +171,7 @@ describe("IntentDetailPanel", () => {
 
   it("ready 상태에서 children render-prop을 호출하고 detail.data를 전달한다", () => {
     mockedUseIntentDetail.mockReturnValue(readyDetail(stubDetail));
-    const childrenFn = vi.fn((detail) => (
-      <div data-testid="children">{detail.name}</div>
-    ));
+    const childrenFn = vi.fn((detail) => <div data-testid="children">{detail.name}</div>);
 
     renderPanel({ children: childrenFn });
 

--- a/frontend/src/features/intent-draft-read/ui/IntentDetailPanel.tsx
+++ b/frontend/src/features/intent-draft-read/ui/IntentDetailPanel.tsx
@@ -31,15 +31,11 @@ export function IntentDetailPanel({
 }: IntentDetailPanelProps) {
   const state = useIntentDetail(wsId, packId, versionId, intentId, refreshKey);
   const errorCode = state.status === "error" ? state.code : undefined;
-  const errorHttpStatus =
-    state.status === "error" ? state.httpStatus : undefined;
+  const errorHttpStatus = state.status === "error" ? state.httpStatus : undefined;
   const errorMessage = state.status === "error" ? state.message : undefined;
   const parentIntentLabel =
     state.status === "ready"
-      ? resolveParentIntentLabel(
-          state.data.parentIntentId ?? null,
-          intentListState,
-        )
+      ? resolveParentIntentLabel(state.data.parentIntentId ?? null, intentListState)
       : "—";
 
   useEffect(() => {
@@ -52,16 +48,7 @@ export function IntentDetailPanel({
     toast.error(message, {
       id: `intent-detail-error-${wsId}-${packId}-${versionId}-${intentId ?? "none"}-${errorCode ?? errorHttpStatus ?? "unknown"}`,
     });
-  }, [
-    state.status,
-    wsId,
-    packId,
-    versionId,
-    intentId,
-    errorCode,
-    errorHttpStatus,
-    errorMessage,
-  ]);
+  }, [state.status, wsId, packId, versionId, intentId, errorCode, errorHttpStatus, errorMessage]);
 
   if (state.status === "idle") {
     return (
@@ -106,11 +93,7 @@ export function IntentDetailPanel({
           />
           <InfoCard
             label="Taxonomy Level"
-            value={
-              <span className={styles.value}>
-                LV {state.data.taxonomyLevel}
-              </span>
-            }
+            value={<span className={styles.value}>LV {state.data.taxonomyLevel}</span>}
           />
           <InfoCard
             label="Parent Intent"
@@ -118,36 +101,20 @@ export function IntentDetailPanel({
           />
           <InfoCard
             label="Created At"
-            value={
-              <span className={styles.value}>
-                {formatDate(state.data.createdAt ?? "")}
-              </span>
-            }
+            value={<span className={styles.value}>{formatDate(state.data.createdAt ?? "")}</span>}
           />
         </div>
         {beforeJsonCards?.(state.data)}
-        <section
-          className={styles.resourceSection}
-          aria-labelledby="intent-resource-section-title"
-        >
+        <section className={styles.resourceSection} aria-labelledby="intent-resource-section-title">
           <div className={styles.resourceSectionHeader}>
-            <h2
-              id="intent-resource-section-title"
-              className={styles.resourceSectionTitle}
-            >
+            <h2 id="intent-resource-section-title" className={styles.resourceSectionTitle}>
               내부 리소스
             </h2>
             <span className={styles.resourceSectionMeta}>JSON FIELDS</span>
           </div>
           <div className={styles.resourceGrid}>
-            <JsonCard
-              label="Source Cluster Ref"
-              value={state.data.sourceClusterRef ?? ""}
-            />
-            <JsonCard
-              label="Entry Condition"
-              value={state.data.entryConditionJson ?? ""}
-            />
+            <JsonCard label="Source Cluster Ref" value={state.data.sourceClusterRef ?? ""} />
+            <JsonCard label="Entry Condition" value={state.data.entryConditionJson ?? ""} />
             <JsonCard label="Evidence" value={state.data.evidenceJson ?? ""} />
             <JsonCard label="Meta" value={state.data.metaJson ?? ""} />
           </div>
@@ -170,13 +137,7 @@ function resolveParentIntentLabel(
   return parent?.name || parent?.intentCode || "확인 불가";
 }
 
-function DetailHeader({
-  detail,
-  actions,
-}: {
-  detail: IntentDetail;
-  actions?: ReactNode;
-}) {
+function DetailHeader({ detail, actions }: { detail: IntentDetail; actions?: ReactNode }) {
   return (
     <header className={styles.header}>
       <div className={styles.headerTop}>
@@ -185,12 +146,8 @@ function DetailHeader({
       </div>
       <div className={styles.headerText}>
         <span className={styles.name}>{detail.name ?? ""}</span>
-        {detail.description && (
-          <span className={styles.description}>{detail.description}</span>
-        )}
-        <span className={styles.updatedAt}>
-          UPDATED · {formatDate(detail.updatedAt ?? "")}
-        </span>
+        {detail.description && <span className={styles.description}>{detail.description}</span>}
+        <span className={styles.updatedAt}>UPDATED · {formatDate(detail.updatedAt ?? "")}</span>
       </div>
     </header>
   );

--- a/frontend/src/features/intent-draft-read/ui/IntentTreePanel.test.tsx
+++ b/frontend/src/features/intent-draft-read/ui/IntentTreePanel.test.tsx
@@ -65,9 +65,7 @@ describe("IntentTreePanel", () => {
     const selectedRow = screen.getByRole("button", { name: /refund/ });
     expect(selectedRow).toHaveAttribute("aria-current", "true");
     const selectedText = selectedRow.textContent ?? "";
-    expect(selectedText.indexOf("LV · 2")).toBeLessThan(
-      selectedText.indexOf("수정 중"),
-    );
+    expect(selectedText.indexOf("LV · 2")).toBeLessThan(selectedText.indexOf("수정 중"));
 
     fireEvent.click(selectedRow);
     expect(onSelect).toHaveBeenCalledWith(2);
@@ -84,9 +82,7 @@ describe("IntentTreePanel", () => {
     renderPanel({ status: "ready", data: [] });
 
     expect(screen.getByText("0 · TREE")).toBeInTheDocument();
-    expect(
-      screen.getByText("해당 버전에 등록된 intent 초안이 없습니다."),
-    ).toBeInTheDocument();
+    expect(screen.getByText("해당 버전에 등록된 intent 초안이 없습니다.")).toBeInTheDocument();
   });
 
   it("목록 조회 실패 시 toast와 error empty state를 보여준다", () => {
@@ -107,8 +103,6 @@ describe("IntentTreePanel", () => {
       message: undefined,
     } as unknown as IntentListState);
 
-    expect(mockedToastError).toHaveBeenCalledWith(
-      "목록을 불러오지 못했습니다.",
-    );
+    expect(mockedToastError).toHaveBeenCalledWith("목록을 불러오지 못했습니다.");
   });
 });

--- a/frontend/src/features/intent-draft-read/ui/IntentTreePanel.tsx
+++ b/frontend/src/features/intent-draft-read/ui/IntentTreePanel.tsx
@@ -35,9 +35,7 @@ export function IntentTreePanel({
       <header className={styles.header}>
         <span className={styles.headerTitle}>Intents</span>
         <span className={styles.headerMeta}>
-          {state.status === "ready"
-            ? `${state.data.length} · TREE`
-            : "— · TREE"}
+          {state.status === "ready" ? `${state.data.length} · TREE` : "— · TREE"}
         </span>
       </header>
 

--- a/frontend/src/features/intent-draft-read/ui/MatchedWorkflowSection.test.tsx
+++ b/frontend/src/features/intent-draft-read/ui/MatchedWorkflowSection.test.tsx
@@ -5,17 +5,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const navigateSpy = vi.fn();
 
 vi.mock("react-router-dom", async () => {
-  const actual =
-    await vi.importActual<typeof import("react-router-dom")>(
-      "react-router-dom",
-    );
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
   return { ...actual, useNavigate: () => navigateSpy };
 });
 
 vi.mock("@/entities/workflow", async () => {
-  const actual = await vi.importActual<typeof import("@/entities/workflow")>(
-    "@/entities/workflow",
-  );
+  const actual = await vi.importActual<typeof import("@/entities/workflow")>("@/entities/workflow");
   return {
     ...actual,
     useListWorkflowsByIntent: vi.fn(),
@@ -32,12 +27,7 @@ const mockedHook = vi.mocked(useListWorkflowsByIntent);
 function renderSection(intentId: number | null = 100) {
   return render(
     <MemoryRouter>
-      <MatchedWorkflowSection
-        wsId={1}
-        packId={9}
-        versionId={4}
-        intentId={intentId}
-      />
+      <MatchedWorkflowSection wsId={1} packId={9} versionId={4} intentId={intentId} />
     </MemoryRouter>,
   );
 }
@@ -57,27 +47,21 @@ describe("MatchedWorkflowSection", () => {
   it("loading 상태", () => {
     mockedHook.mockReturnValue({ loading: true, error: null, entries: [] });
     renderSection();
-    expect(
-      screen.getByTestId("matched-workflow-section-loading"),
-    ).toBeInTheDocument();
+    expect(screen.getByTestId("matched-workflow-section-loading")).toBeInTheDocument();
   });
 
   it("error 상태", async () => {
     mockedHook.mockReturnValue({ loading: false, error: "boom", entries: [] });
     renderSection();
     await waitFor(() =>
-      expect(
-        screen.getByTestId("matched-workflow-section-error"),
-      ).toBeInTheDocument(),
+      expect(screen.getByTestId("matched-workflow-section-error")).toBeInTheDocument(),
     );
   });
 
   it("empty 상태 메시지", () => {
     mockedHook.mockReturnValue({ loading: false, error: null, entries: [] });
     renderSection();
-    expect(
-      screen.getByTestId("matched-workflow-section-empty"),
-    ).toBeInTheDocument();
+    expect(screen.getByTestId("matched-workflow-section-empty")).toBeInTheDocument();
   });
 
   it("entry 렌더 + WorkflowRow open 시 navigate", () => {
@@ -100,9 +84,7 @@ describe("MatchedWorkflowSection", () => {
 
     renderSection();
     expect(screen.getByTestId("matched-workflow-row-7")).toBeInTheDocument();
-    expect(
-      screen.getByTestId("matched-workflow-section-list"),
-    ).toBeInTheDocument();
+    expect(screen.getByTestId("matched-workflow-section-list")).toBeInTheDocument();
 
     fireEvent.click(screen.getByTestId("matched-workflow-row-7-open"));
     expect(navigateSpy).toHaveBeenCalledWith(

--- a/frontend/src/features/intent-draft-read/ui/MatchedWorkflowSection.tsx
+++ b/frontend/src/features/intent-draft-read/ui/MatchedWorkflowSection.tsx
@@ -35,13 +35,7 @@ export function MatchedWorkflowSection({
 
   const openWorkflow = (entry: WorkspaceWorkflowEntry) => {
     navigate(
-      domainPackSectionPath(
-        wsId,
-        entry.packId,
-        entry.versionId,
-        "workflows",
-        entry.workflowId,
-      ),
+      domainPackSectionPath(wsId, entry.packId, entry.versionId, "workflows", entry.workflowId),
       {
         state: { workflowReturnTo: `${location.pathname}${location.search}` },
       },
@@ -60,43 +54,29 @@ export function MatchedWorkflowSection({
         <h2 id="matched-workflow-section-title" className={styles.title}>
           매칭된 워크플로우
         </h2>
-        <Mono className={styles.count}>
-          {loading ? "loading…" : `${entries.length} ITEMS`}
-        </Mono>
+        <Mono className={styles.count}>{loading ? "loading…" : `${entries.length} ITEMS`}</Mono>
       </header>
 
       {loading && (
-        <div
-          className={styles.placeholder}
-          data-testid="matched-workflow-section-loading"
-        >
+        <div className={styles.placeholder} data-testid="matched-workflow-section-loading">
           <Mono>워크플로우 조회 중…</Mono>
         </div>
       )}
 
       {!loading && error && (
-        <div
-          className={styles.placeholder}
-          data-testid="matched-workflow-section-error"
-        >
+        <div className={styles.placeholder} data-testid="matched-workflow-section-error">
           <Mono>{error}</Mono>
         </div>
       )}
 
       {!loading && !error && entries.length === 0 && (
-        <div
-          className={styles.placeholder}
-          data-testid="matched-workflow-section-empty"
-        >
+        <div className={styles.placeholder} data-testid="matched-workflow-section-empty">
           <Mono>이 인텐트에 매칭된 워크플로우가 없습니다.</Mono>
         </div>
       )}
 
       {!loading && !error && entries.length > 0 && (
-        <div
-          className={styles.list}
-          data-testid="matched-workflow-section-list"
-        >
+        <div className={styles.list} data-testid="matched-workflow-section-list">
           {entries.map((entry) => (
             <WorkflowRow
               key={entry.workflowId}

--- a/frontend/src/features/intent-revision-draft/ui/IntentRevisionDraftActions.test.tsx
+++ b/frontend/src/features/intent-revision-draft/ui/IntentRevisionDraftActions.test.tsx
@@ -39,19 +39,11 @@ describe("IntentRevisionDraftActions", () => {
 
     expect(screen.getByText("변경된 intent 1개")).toBeInTheDocument();
     expect(
-      screen.getByText(
-        "수정 내용의 적용 및 삭제는 Domain Pack 화면에서 진행할 수 있습니다.",
-      ),
+      screen.getByText("수정 내용의 적용 및 삭제는 Domain Pack 화면에서 진행할 수 있습니다."),
     ).toBeInTheDocument();
-    expect(
-      screen.queryByRole("button", { name: "적용" }),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole("button", { name: "취소" }),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole("button", { name: "삭제" }),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "적용" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "취소" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "삭제" })).not.toBeInTheDocument();
   });
 
   it("변경 요약 조회 실패 시 retry만 제공한다", () => {
@@ -60,12 +52,8 @@ describe("IntentRevisionDraftActions", () => {
       summaryError: "변경 요약을 불러오지 못했습니다.",
     });
 
-    expect(
-      screen.getByText("변경 요약을 불러오지 못했습니다."),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: "다시 시도" }),
-    ).toBeInTheDocument();
+    expect(screen.getByText("변경 요약을 불러오지 못했습니다.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "다시 시도" })).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "다시 시도" }));
     expect(onRetrySummary).toHaveBeenCalledTimes(1);
@@ -77,28 +65,18 @@ describe("IntentRevisionDraftActions", () => {
       summaryError: "",
     });
 
-    expect(
-      screen.getByRole("button", { name: "다시 시도" }),
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByText("변경된 intent가 없습니다."),
-    ).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "다시 시도" })).toBeInTheDocument();
+    expect(screen.queryByText("변경된 intent가 없습니다.")).not.toBeInTheDocument();
   });
 
   it("요약 로딩 중에는 로딩 문구와 안내 문구만 보여준다", () => {
     renderActions({ summary: undefined, isSummaryLoading: true });
 
+    expect(screen.getByText("변경 요약을 불러오는 중입니다.")).toBeInTheDocument();
     expect(
-      screen.getByText("변경 요약을 불러오는 중입니다."),
+      screen.getByText("수정 내용의 적용 및 삭제는 Domain Pack 화면에서 진행할 수 있습니다."),
     ).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        "수정 내용의 적용 및 삭제는 Domain Pack 화면에서 진행할 수 있습니다.",
-      ),
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByRole("button", { name: "적용" }),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "적용" })).not.toBeInTheDocument();
   });
 
   it("변경된 intent가 없으면 empty 문구를 보여준다", () => {

--- a/frontend/src/features/intent-revision-draft/ui/IntentRevisionDraftActions.tsx
+++ b/frontend/src/features/intent-revision-draft/ui/IntentRevisionDraftActions.tsx
@@ -20,8 +20,7 @@ export function IntentRevisionDraftActions({
 }: IntentRevisionDraftActionsProps) {
   const changedCount = summary?.changedIntents.length ?? 0;
   const hasSummaryError = summaryError != null;
-  const rawErrorMessage =
-    summaryError instanceof Error ? summaryError.message : summaryError;
+  const rawErrorMessage = summaryError instanceof Error ? summaryError.message : summaryError;
   const errorMessage = rawErrorMessage ?? "변경 요약을 불러오지 못했습니다.";
 
   return (

--- a/frontend/src/features/update-workflow/api/useUpdateWorkflow.test.ts
+++ b/frontend/src/features/update-workflow/api/useUpdateWorkflow.test.ts
@@ -96,9 +96,7 @@ describe("useUpdateWorkflow", () => {
     });
 
     await waitFor(() =>
-      expect(toast.error).toHaveBeenCalledWith(
-        "DRAFT 상태의 버전에서만 수정할 수 있습니다.",
-      ),
+      expect(toast.error).toHaveBeenCalledWith("DRAFT 상태의 버전에서만 수정할 수 있습니다."),
     );
   });
 
@@ -115,19 +113,13 @@ describe("useUpdateWorkflow", () => {
     });
 
     await waitFor(() =>
-      expect(toast.error).toHaveBeenCalledWith(
-        "START 노드가 정확히 1개여야 합니다.",
-      ),
+      expect(toast.error).toHaveBeenCalledWith("START 노드가 정확히 1개여야 합니다."),
     );
   });
 
   it("알 수 없는 API 에러 코드는 서버 메시지를 표시한다", async () => {
     mockedUpdateWorkflow.mockRejectedValue(
-      new ApiRequestError(
-        400,
-        "VALIDATION_ERROR",
-        "transitionId가 유효하지 않습니다.",
-      ),
+      new ApiRequestError(400, "VALIDATION_ERROR", "transitionId가 유효하지 않습니다."),
     );
     const { result } = renderHook(() => useUpdateWorkflow(), {
       wrapper: makeWrapper(),
@@ -138,9 +130,7 @@ describe("useUpdateWorkflow", () => {
     });
 
     await waitFor(() =>
-      expect(toast.error).toHaveBeenCalledWith(
-        "transitionId가 유효하지 않습니다.",
-      ),
+      expect(toast.error).toHaveBeenCalledWith("transitionId가 유효하지 않습니다."),
     );
   });
 
@@ -155,9 +145,7 @@ describe("useUpdateWorkflow", () => {
     });
 
     await waitFor(() =>
-      expect(toast.error).toHaveBeenCalledWith(
-        "워크플로우 수정에 실패했습니다.",
-      ),
+      expect(toast.error).toHaveBeenCalledWith("워크플로우 수정에 실패했습니다."),
     );
   });
 });

--- a/frontend/src/features/update-workflow/api/useUpdateWorkflow.ts
+++ b/frontend/src/features/update-workflow/api/useUpdateWorkflow.ts
@@ -23,8 +23,7 @@ const ERROR_MESSAGES: Record<string, string> = {
   WORKFLOW_UNREACHABLE_NODE: "모든 노드가 START에서 도달 가능해야 합니다.",
   WORKFLOW_CYCLE_DETECTED: "그래프에 순환 경로가 있습니다.",
   WORKFLOW_UNLABELED_BRANCH: "DECISION 노드의 모든 분기에 label이 필요합니다.",
-  WORKFLOW_ACTION_NODE_POLICY_REF_MISSING:
-    "ACTION 노드의 policyRef 값이 필요합니다.",
+  WORKFLOW_ACTION_NODE_POLICY_REF_MISSING: "ACTION 노드의 policyRef 값이 필요합니다.",
   WORKFLOW_ACTION_NODE_POLICY_REF_INVALID_CHARS:
     "ACTION 노드의 policyRef 형식이 유효하지 않습니다.",
   WORKFLOW_ACTION_NODE_POLICY_REF_NOT_FOUND:
@@ -36,32 +35,13 @@ const ERROR_MESSAGES: Record<string, string> = {
 export function useUpdateWorkflow() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async ({
-      wsId,
-      packId,
-      versionId,
-      workflowId,
-      body,
-    }: UpdateWorkflowParams) => {
-      const res = await updateWorkflow(
-        wsId,
-        packId,
-        versionId,
-        workflowId,
-        body,
-      );
+    mutationFn: async ({ wsId, packId, versionId, workflowId, body }: UpdateWorkflowParams) => {
+      const res = await updateWorkflow(wsId, packId, versionId, workflowId, body);
       return res.data;
     },
     onSuccess: (_, { wsId, packId, versionId, workflowId }) => {
       queryClient.invalidateQueries({
-        queryKey: [
-          "workflows",
-          "detail",
-          wsId,
-          packId,
-          versionId,
-          workflowId,
-        ] as const,
+        queryKey: ["workflows", "detail", wsId, packId, versionId, workflowId] as const,
       });
       queryClient.invalidateQueries({
         queryKey: ["workflows", "list", wsId, packId, versionId] as const,
@@ -71,9 +51,7 @@ export function useUpdateWorkflow() {
     onError: (error: unknown) => {
       const code = error instanceof ApiRequestError ? error.code : "";
       const message = error instanceof ApiRequestError ? error.message : "";
-      toast.error(
-        (ERROR_MESSAGES[code] ?? message) || "워크플로우 수정에 실패했습니다.",
-      );
+      toast.error((ERROR_MESSAGES[code] ?? message) || "워크플로우 수정에 실패했습니다.");
     },
   });
 }

--- a/frontend/src/features/update-workflow/ui/WorkflowEditForm.test.tsx
+++ b/frontend/src/features/update-workflow/ui/WorkflowEditForm.test.tsx
@@ -96,9 +96,7 @@ describe("WorkflowEditForm", () => {
 
   it("renders workflow name and description in form fields", () => {
     renderForm();
-    expect(
-      screen.getByDisplayValue("환불 처리 워크플로우"),
-    ).toBeInTheDocument();
+    expect(screen.getByDisplayValue("환불 처리 워크플로우")).toBeInTheDocument();
     expect(screen.getByDisplayValue("표준 환불 처리 절차")).toBeInTheDocument();
   });
 
@@ -121,14 +119,8 @@ describe("WorkflowEditForm", () => {
       },
     });
 
-    expect(screen.getByTestId("graph-editor")).toHaveAttribute(
-      "data-node-count",
-      "0",
-    );
-    expect(screen.getByTestId("graph-editor")).toHaveAttribute(
-      "data-edge-count",
-      "0",
-    );
+    expect(screen.getByTestId("graph-editor")).toHaveAttribute("data-node-count", "0");
+    expect(screen.getByTestId("graph-editor")).toHaveAttribute("data-edge-count", "0");
   });
 
   it("calls onClose when cancel button is clicked", () => {
@@ -188,9 +180,7 @@ describe("WorkflowEditForm", () => {
     fireEvent.change(nameInput, { target: { value: "" } });
     fireEvent.click(screen.getByRole("button", { name: "저장" }));
     await waitFor(() => {
-      expect(
-        screen.getByText("워크플로우 이름은 필수입니다."),
-      ).toBeInTheDocument();
+      expect(screen.getByText("워크플로우 이름은 필수입니다.")).toBeInTheDocument();
     });
     expect(mutateWorkflow).not.toHaveBeenCalled();
   });

--- a/frontend/src/features/update-workflow/ui/WorkflowEditForm.tsx
+++ b/frontend/src/features/update-workflow/ui/WorkflowEditForm.tsx
@@ -3,10 +3,7 @@ import { useForm, Controller } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import type { Node, Edge } from "@xyflow/react";
 import { Button } from "@/shared/ui/button";
-import {
-  workflowEditSchema,
-  type WorkflowEditFormValues,
-} from "../model/schema";
+import { workflowEditSchema, type WorkflowEditFormValues } from "../model/schema";
 import { useUpdateWorkflow } from "../api/useUpdateWorkflow";
 import { InteractiveGraphEditor } from "./InteractiveGraphEditor";
 import { toWorkflowGraph } from "../lib/graphToWorkflow";

--- a/frontend/src/features/update-workflow/ui/WorkflowEditSheet.test.tsx
+++ b/frontend/src/features/update-workflow/ui/WorkflowEditSheet.test.tsx
@@ -39,13 +39,9 @@ vi.mock("@/shared/ui/spinner", () => ({
 }));
 
 vi.mock("@/shared/ui/button", () => ({
-  Button: ({
-    children,
-    onClick,
-  }: {
-    children: React.ReactNode;
-    onClick?: () => void;
-  }) => <button onClick={onClick}>{children}</button>,
+  Button: ({ children, onClick }: { children: React.ReactNode; onClick?: () => void }) => (
+    <button onClick={onClick}>{children}</button>
+  ),
 }));
 
 import { useGetWorkflow } from "../api/useGetWorkflow";

--- a/frontend/src/features/update-workflow/ui/edges/EditableEdge.test.tsx
+++ b/frontend/src/features/update-workflow/ui/edges/EditableEdge.test.tsx
@@ -76,7 +76,9 @@ describe("EditableEdge", () => {
     fireEvent.change(input, { target: { value: "변경후" } });
     fireEvent.blur(input);
     expect(setEdgesMock).toHaveBeenCalledTimes(1);
-    const updater = setEdgesMock.mock.calls[0][0] as (eds: { id: string; label: string }[]) => { id: string; label: string }[];
+    const updater = setEdgesMock.mock.calls[0][0] as (
+      eds: { id: string; label: string }[],
+    ) => { id: string; label: string }[];
     const result = updater([
       { id: "e1", label: "변경전" },
       { id: "e2", label: "다른것" },

--- a/frontend/src/features/update-workflow/ui/nodes/NodeDeleteToolbar.test.tsx
+++ b/frontend/src/features/update-workflow/ui/nodes/NodeDeleteToolbar.test.tsx
@@ -3,13 +3,8 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import { NodeDeleteToolbar } from "./NodeDeleteToolbar";
 
 vi.mock("@xyflow/react", () => ({
-  NodeToolbar: ({
-    isVisible,
-    children,
-  }: {
-    isVisible?: boolean;
-    children: React.ReactNode;
-  }) => (isVisible ? <div data-testid="toolbar">{children}</div> : null),
+  NodeToolbar: ({ isVisible, children }: { isVisible?: boolean; children: React.ReactNode }) =>
+    isVisible ? <div data-testid="toolbar">{children}</div> : null,
   Position: { Top: "top" },
 }));
 

--- a/frontend/src/features/user-chat/ui/ChatRoom.test.tsx
+++ b/frontend/src/features/user-chat/ui/ChatRoom.test.tsx
@@ -43,7 +43,9 @@ describe("ChatRoom", () => {
     render(<ChatRoom sessionId={7} />);
 
     expect(screen.getByText("연결됨")).toBeInTheDocument();
-    expect(await screen.findByText("아직 메시지가 없습니다. 첫 메시지를 보내보세요!")).toBeInTheDocument();
+    expect(
+      await screen.findByText("아직 메시지가 없습니다. 첫 메시지를 보내보세요!"),
+    ).toBeInTheDocument();
   });
 
   it("STOMP 메시지 수신 시 메시지 목록에 추가한다", async () => {

--- a/frontend/src/features/user-chat/ui/MessageInput.tsx
+++ b/frontend/src/features/user-chat/ui/MessageInput.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Send } from "lucide-react";
+import { Paperclip, Send } from "lucide-react";
 
 export interface MessageInputProps {
   onSend: (content: string) => void;
@@ -17,16 +17,61 @@ export function MessageInput({ onSend, disabled = false }: MessageInputProps) {
     setContent("");
   };
 
+  const isSendDisabled = disabled || content.trim().length === 0;
+
   return (
-    <div className="flex gap-3 border-t border-gray-200 bg-white" style={{ padding: "14px 16px" }}>
+    <form
+      data-testid="message-input"
+      onSubmit={(event) => {
+        event.preventDefault();
+        submit();
+      }}
+      style={{
+        background: "var(--paper)",
+        borderTop: "1px solid var(--line-2)",
+        padding: "12px 20px 14px",
+        display: "flex",
+        alignItems: "center",
+        gap: 12,
+      }}
+    >
+      <button
+        type="button"
+        aria-label="파일 첨부"
+        title="파일 첨부 (예정)"
+        disabled
+        data-testid="message-attach"
+        style={{
+          width: 38,
+          height: 38,
+          borderRadius: 999,
+          background: "var(--paper-2)",
+          color: "var(--ink-3)",
+          display: "inline-flex",
+          alignItems: "center",
+          justifyContent: "center",
+          border: "1px solid var(--line-2)",
+          cursor: "not-allowed",
+        }}
+      >
+        <Paperclip size={16} aria-hidden="true" />
+      </button>
       <input
         aria-label="메시지 입력"
-        className="flex-1 rounded-full border border-gray-300 bg-white text-sm text-black outline-none transition focus:border-black focus:ring-3 focus:ring-black/10 disabled:pointer-events-none disabled:bg-gray-100 disabled:text-gray-500"
         disabled={disabled}
         placeholder="메시지를 입력하세요"
         style={{
-          minHeight: 48,
+          flex: 1,
+          height: 42,
           padding: "0 18px",
+          borderRadius: 28,
+          border: "1px solid var(--line)",
+          background: disabled ? "var(--paper-2)" : "var(--paper)",
+          color: disabled ? "var(--ink-3)" : "var(--ink)",
+          fontSize: 13.5,
+          fontWeight: 460,
+          fontFamily: "inherit",
+          letterSpacing: "-0.12px",
         }}
         value={content}
         onChange={(event) => setContent(event.target.value)}
@@ -40,16 +85,24 @@ export function MessageInput({ onSend, disabled = false }: MessageInputProps) {
       <button
         type="button"
         aria-label="메시지 보내기"
-        className="inline-flex items-center justify-center rounded-full bg-black text-white outline-none transition hover:bg-gray-900 focus:ring-3 focus:ring-black/15 disabled:pointer-events-none disabled:bg-gray-300 disabled:text-white"
-        disabled={disabled}
+        disabled={isSendDisabled}
         style={{
-          height: 48,
-          width: 48,
+          width: 42,
+          height: 42,
+          borderRadius: 999,
+          background: isSendDisabled ? "var(--paper-3)" : "var(--ink)",
+          color: isSendDisabled ? "var(--ink-4)" : "var(--paper)",
+          display: "inline-flex",
+          alignItems: "center",
+          justifyContent: "center",
+          border: "none",
+          cursor: isSendDisabled ? "not-allowed" : "pointer",
+          transition: "background 160ms ease, color 160ms ease",
         }}
         onClick={submit}
       >
-        <Send className="size-4" aria-hidden="true" />
+        <Send size={16} aria-hidden="true" />
       </button>
-    </div>
+    </form>
   );
 }

--- a/frontend/src/features/user-chat/ui/MessageInput.tsx
+++ b/frontend/src/features/user-chat/ui/MessageInput.tsx
@@ -18,10 +18,7 @@ export function MessageInput({ onSend, disabled = false }: MessageInputProps) {
   };
 
   return (
-    <div
-      className="flex gap-3 border-t border-gray-200 bg-white"
-      style={{ padding: "14px 16px" }}
-    >
+    <div className="flex gap-3 border-t border-gray-200 bg-white" style={{ padding: "14px 16px" }}>
       <input
         aria-label="메시지 입력"
         className="flex-1 rounded-full border border-gray-300 bg-white text-sm text-black outline-none transition focus:border-black focus:ring-3 focus:ring-black/10 disabled:pointer-events-none disabled:bg-gray-100 disabled:text-gray-500"

--- a/frontend/src/features/user-chat/ui/MessageList.test.tsx
+++ b/frontend/src/features/user-chat/ui/MessageList.test.tsx
@@ -46,8 +46,8 @@ describe("MessageList", () => {
 
     expect(screen.getByText("배송이 지연됐어요")).not.toBeNull();
     expect(screen.getByText("확인해 드리겠습니다")).not.toBeNull();
-    expect(screen.getByTestId("message-m1").classList.contains("justify-end")).toBe(true);
-    expect(screen.getByTestId("message-m2").classList.contains("justify-start")).toBe(true);
+    expect(screen.getByTestId("message-m1")).toHaveAttribute("data-sender", "user");
+    expect(screen.getByTestId("message-m2")).toHaveAttribute("data-sender", "bot");
   });
 
   it("새 메시지가 렌더링되면 하단으로 스크롤한다", () => {

--- a/frontend/src/features/user-chat/ui/MessageList.tsx
+++ b/frontend/src/features/user-chat/ui/MessageList.tsx
@@ -22,6 +22,17 @@ function resolveSenderName(message: ChatMessage): string {
   return "봇";
 }
 
+const STATE_CONTAINER_BASE = {
+  height: "100%",
+  minHeight: 0,
+  overflowY: "auto" as const,
+  background: "var(--paper-2)",
+  padding: "32px 24px",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+};
+
 export function MessageList({ messages, loading = false, error = null }: MessageListProps) {
   const bottomRef = useRef<HTMLDivElement | null>(null);
 
@@ -31,61 +42,123 @@ export function MessageList({ messages, loading = false, error = null }: Message
 
   if (error) {
     return (
-      <div className="flex h-full min-h-0 items-center justify-center overflow-y-auto bg-white p-8 text-sm text-black">
-        <div className="rounded-lg border border-black px-5 py-4">{error}</div>
+      <div style={STATE_CONTAINER_BASE} data-testid="message-list-error">
+        <div
+          style={{
+            padding: "12px 18px",
+            borderRadius: 8,
+            border: "1px solid var(--danger)",
+            background: "var(--danger-bg)",
+            color: "var(--danger)",
+            fontSize: 13,
+            fontWeight: 500,
+          }}
+        >
+          {error}
+        </div>
       </div>
     );
   }
 
   if (loading) {
     return (
-      <div className="flex h-full min-h-0 items-center justify-center overflow-y-auto bg-white p-8 text-sm text-gray-500">
-        <Loader2 className="mr-2 size-4 animate-spin" aria-hidden="true" />
-        메시지를 불러오는 중입니다...
+      <div
+        style={{ ...STATE_CONTAINER_BASE, color: "var(--ink-3)" }}
+        data-testid="message-list-loading"
+      >
+        <Loader2 className="animate-spin" aria-hidden="true" size={14} style={{ marginRight: 8 }} />
+        <span style={{ fontSize: 13 }}>메시지를 불러오는 중입니다...</span>
       </div>
     );
   }
 
   if (messages.length === 0) {
     return (
-      <div className="flex h-full min-h-0 items-center justify-center overflow-y-auto bg-white p-8 text-sm text-gray-500">
-        아직 메시지가 없습니다. 첫 메시지를 보내보세요!
+      <div
+        style={{ ...STATE_CONTAINER_BASE, color: "var(--ink-3)" }}
+        data-testid="message-list-empty"
+      >
+        <span style={{ fontSize: 13 }}>아직 메시지가 없습니다. 첫 메시지를 보내보세요!</span>
       </div>
     );
   }
 
   return (
-    <div className="h-full min-h-0 overflow-y-auto bg-white px-6 py-5">
-      <div className="flex flex-col gap-5">
+    <div
+      style={{
+        height: "100%",
+        minHeight: 0,
+        overflowY: "auto",
+        background: "var(--paper-2)",
+        padding: "18px 20px",
+      }}
+      data-testid="message-list"
+    >
+      <div style={{ display: "flex", flexDirection: "column", gap: 18 }}>
         {messages.map((message) => {
           const isUser = message.senderType === "USER";
+          const sender = isUser ? "user" : "bot";
           return (
             <div
               key={message.id}
               data-testid={`message-${message.id}`}
-              className={`flex ${isUser ? "justify-end" : "justify-start"}`}
+              data-sender={sender}
+              style={{
+                maxWidth: "72%",
+                display: "flex",
+                flexDirection: "column",
+                gap: 4,
+                alignSelf: isUser ? "flex-end" : "flex-start",
+                alignItems: isUser ? "flex-end" : "flex-start",
+              }}
             >
-              <div className={`max-w-[72%] ${isUser ? "text-right" : "text-left"}`}>
-                <div
-                  className={`flex items-baseline gap-2 text-xs text-gray-500 ${
-                    isUser ? "justify-end" : "justify-start"
-                  }`}
-                  style={{ marginBottom: 6 }}
-                >
-                  <span>{resolveSenderName(message)}</span>
-                  <time dateTime={message.createdAt}>{formatMessageTime(message.createdAt)}</time>
-                </div>
-                <div
-                  className={`text-sm leading-6 ${
-                    isUser ? "bg-gray-100 text-black" : "bg-black text-white"
-                  }`}
-                  style={{
-                    borderRadius: 8,
-                    padding: "10px 14px",
-                  }}
-                >
-                  {message.content}
-                </div>
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 6,
+                  fontFamily: "var(--mono)",
+                  fontSize: 10,
+                  textTransform: "uppercase",
+                  letterSpacing: "0.06em",
+                  color: "var(--ink-3)",
+                }}
+              >
+                {isUser ? (
+                  <>
+                    <time dateTime={message.createdAt}>{formatMessageTime(message.createdAt)}</time>
+                    <span>{resolveSenderName(message)}</span>
+                  </>
+                ) : (
+                  <>
+                    <span>{resolveSenderName(message)}</span>
+                    <time dateTime={message.createdAt}>{formatMessageTime(message.createdAt)}</time>
+                  </>
+                )}
+              </div>
+              <div
+                style={{
+                  padding: "10px 14px",
+                  borderRadius: 12,
+                  fontSize: 13.5,
+                  lineHeight: 1.55,
+                  letterSpacing: "-0.12px",
+                  boxShadow: "0 1px 2px rgba(15, 23, 42, 0.04), 0 6px 14px rgba(15, 23, 42, 0.06)",
+                  ...(isUser
+                    ? {
+                        background: "var(--paper)",
+                        color: "var(--ink)",
+                        border: "1px solid var(--line)",
+                        borderBottomRightRadius: 4,
+                      }
+                    : {
+                        background: "var(--ink)",
+                        color: "var(--paper)",
+                        borderBottomLeftRadius: 4,
+                      }),
+                }}
+              >
+                {message.content}
               </div>
             </div>
           );

--- a/frontend/src/pages/consultation/ui/ConsultationPage.test.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.test.tsx
@@ -684,6 +684,47 @@ describe("ConsultationPage", () => {
     });
   });
 
+  it("loads queue only once on initial mount and does not spam toast errors", async () => {
+    render(<ConsultationPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(consultationApi.getQueue).toHaveBeenCalledTimes(1);
+      expect(screen.getByText("김민지")).toBeInTheDocument();
+    });
+
+    const errorToasts = vi
+      .mocked(toast.error)
+      .mock.calls.filter(([message]) => message === "대기열을 불러오지 못했습니다.");
+    expect(errorToasts).toHaveLength(0);
+  });
+
+  it("deduplicates queue error toast across multiple failed loads", async () => {
+    vi.mocked(consultationApi.getQueue)
+      .mockRejectedValueOnce(new Error("Network Error"))
+      .mockRejectedValueOnce(new Error("Network Error"));
+    const user = userEvent.setup();
+
+    render(<ConsultationPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("대기열을 불러오지 못했습니다.");
+    });
+
+    let queueErrorToasts = vi
+      .mocked(toast.error)
+      .mock.calls.filter(([message]) => message === "대기열을 불러오지 못했습니다.");
+    expect(queueErrorToasts).toHaveLength(1);
+
+    await user.click(screen.getByText("다시 시도"));
+
+    await waitFor(() => {
+      queueErrorToasts = vi
+        .mocked(toast.error)
+        .mock.calls.filter(([message]) => message === "대기열을 불러오지 못했습니다.");
+      expect(queueErrorToasts).toHaveLength(2);
+    });
+  });
+
   it("shows error toast when loading messages fails", async () => {
     render(<ConsultationPage />, { wrapper: Wrapper });
 

--- a/frontend/src/pages/consultation/ui/ConsultationPage.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.tsx
@@ -210,6 +210,7 @@ export const ConsultationPage: React.FC = () => {
   const tempCounterRef = useRef(0);
   const activeCustomerIdRef = useRef<string | null>(null);
   const metricsErrorToastShownRef = useRef(false);
+  const queueErrorToastShownRef = useRef(false);
   const currentCounselorId = getAuthUser()?.id ?? null;
 
   const activeCustomer = queue.find((c) => c.id === activeCustomerId) || null;
@@ -227,7 +228,11 @@ export const ConsultationPage: React.FC = () => {
     activeCustomer && messagesCustomerId === activeCustomer.id ? messages : [];
   const selectedMessage = visibleMessages.find((m) => m.id === selectedMessageId) || null;
   const activeStatusLabel = activeCustomer
-    ? getSessionStatusLabel(activeCustomer.status, activeCustomer.assignedCounselorId, currentCounselorId)
+    ? getSessionStatusLabel(
+        activeCustomer.status,
+        activeCustomer.assignedCounselorId,
+        currentCounselorId,
+      )
     : undefined;
   const isAssignedToCurrentCounselor =
     !!activeCustomer?.assignedCounselorId &&
@@ -307,32 +312,47 @@ export const ConsultationPage: React.FC = () => {
     };
   }, [workspaceId]);
 
-  const loadQueue = useCallback(async () => {
-    if (!workspaceId) {
-      setQueue([]);
-      setIsQueueLoading(false);
+  const loadQueue = useCallback(
+    async (isManualRetry = false) => {
+      if (!workspaceId) {
+        setQueue([]);
+        setIsQueueLoading(false);
+        setQueueLoadError(null);
+        clearActiveConversation();
+        return;
+      }
+
+      if (isManualRetry) {
+        queueErrorToastShownRef.current = false;
+      }
+
+      setIsQueueLoading(true);
       setQueueLoadError(null);
-      clearActiveConversation();
-      return;
-    }
 
-    setIsQueueLoading(true);
-    setQueueLoadError(null);
+      try {
+        const sessions = await consultationApi.getQueue(workspaceId);
+        const formattedQueue = (Array.isArray(sessions) ? sessions : []).map((s) =>
+          toQueueCustomer(s, currentCounselorId),
+        );
+        setQueue(sortQueueCustomers(formattedQueue));
+        queueErrorToastShownRef.current = false;
+      } catch (error) {
+        console.error("Failed to load queue:", error);
+        setQueueLoadError("대기열을 불러오지 못했습니다.");
+        if (!queueErrorToastShownRef.current) {
+          queueErrorToastShownRef.current = true;
+          toast.error("대기열을 불러오지 못했습니다.");
+        }
+      } finally {
+        setIsQueueLoading(false);
+      }
+    },
+    [clearActiveConversation, currentCounselorId, workspaceId],
+  );
 
-    try {
-      const sessions = await consultationApi.getQueue(workspaceId);
-      const formattedQueue = (Array.isArray(sessions) ? sessions : []).map((s) =>
-        toQueueCustomer(s, currentCounselorId),
-      );
-      setQueue(sortQueueCustomers(formattedQueue));
-    } catch (error) {
-      console.error("Failed to load queue:", error);
-      setQueueLoadError("대기열을 불러오지 못했습니다.");
-      toast.error("대기열을 불러오지 못했습니다.");
-    } finally {
-      setIsQueueLoading(false);
-    }
-  }, [clearActiveConversation, currentCounselorId, workspaceId]);
+  const handleQueueRetry = useCallback(() => {
+    void loadQueue(true);
+  }, [loadQueue]);
 
   const handleQueueEvent = useCallback(
     (raw: unknown) => {
@@ -367,14 +387,13 @@ export const ConsultationPage: React.FC = () => {
   );
 
   useEffect(() => {
-    if (connectionStatus === "CONNECTED") return;
+    queueErrorToastShownRef.current = false;
     void loadQueue();
-  }, [connectionStatus, loadQueue]);
+  }, [loadQueue]);
 
   useEffect(() => {
     if (connectionStatus !== "CONNECTED" || !workspaceId) return;
 
-    void loadQueue();
     const unsubscribe = subscribe(
       `/topic/workspaces.${workspaceId}.consultation.queue`,
       handleQueueEvent,
@@ -383,7 +402,7 @@ export const ConsultationPage: React.FC = () => {
     return () => {
       unsubscribe();
     };
-  }, [connectionStatus, handleQueueEvent, loadQueue, subscribe, workspaceId]);
+  }, [connectionStatus, handleQueueEvent, subscribe, workspaceId]);
 
   useEffect(() => {
     if (!activeCustomerId) {
@@ -576,13 +595,7 @@ export const ConsultationPage: React.FC = () => {
       setMemos((prev) => ({ ...prev, [requestCustomerId]: "" }));
       toast.success("상담 메모 저장 요청을 전송했습니다.");
     }
-  }, [
-    activeCustomerId,
-    connectionStatus,
-    handleSendMessage,
-    isAssignedToCurrentCounselor,
-    memos,
-  ]);
+  }, [activeCustomerId, connectionStatus, handleSendMessage, isAssignedToCurrentCounselor, memos]);
 
   return (
     <div className={styles.consultationRoot}>
@@ -593,7 +606,7 @@ export const ConsultationPage: React.FC = () => {
           onSelectCustomer={handleSelectCustomer}
           isLoading={isQueueLoading}
           loadError={queueLoadError}
-          onRetry={loadQueue}
+          onRetry={handleQueueRetry}
         />
       </div>
 
@@ -647,7 +660,10 @@ export const ConsultationPage: React.FC = () => {
       <div className={styles.detailPane}>
         {selectedMessage ? (
           // TODO: domainPackElements를 실제 API 응답 데이터로 교체 (별도 API 연동 티켓)
-          <MessageDetailPanel message={selectedMessage} onClose={() => setSelectedMessageId(null)} />
+          <MessageDetailPanel
+            message={selectedMessage}
+            onClose={() => setSelectedMessageId(null)}
+          />
         ) : (
           <CustomerPanel
             customer={

--- a/frontend/src/pages/consultation/ui/chat-history/ChatHistoryPage.test.tsx
+++ b/frontend/src/pages/consultation/ui/chat-history/ChatHistoryPage.test.tsx
@@ -1,8 +1,14 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { useChatMessages, useChatSessions } from "../../../../features/consultation/api/chatHistoryApi";
-import type { ChatMessage, ChatSession } from "../../../../features/consultation/api/consultationApi";
+import {
+  useChatMessages,
+  useChatSessions,
+} from "../../../../features/consultation/api/chatHistoryApi";
+import type {
+  ChatMessage,
+  ChatSession,
+} from "../../../../features/consultation/api/consultationApi";
 import { ChatHistoryPage } from "./ChatHistoryPage";
 
 vi.mock("../../../../features/consultation/api/chatHistoryApi", () => ({
@@ -23,23 +29,25 @@ type MockChatMessagesResult = Pick<
   "data" | "isLoading" | "isError" | "error" | "refetch"
 >;
 
-const makeSessionsResult = (overrides?: Partial<MockChatSessionsResult>) => ({
-  data: [makeSession(7)],
-  isLoading: false,
-  isError: false,
-  error: null,
-  refetch: vi.fn(),
-  ...overrides,
-}) as ReturnType<typeof useChatSessions>;
+const makeSessionsResult = (overrides?: Partial<MockChatSessionsResult>) =>
+  ({
+    data: [makeSession(7)],
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+    ...overrides,
+  }) as ReturnType<typeof useChatSessions>;
 
-const makeMessagesResult = (overrides?: Partial<MockChatMessagesResult>) => ({
-  data: [],
-  isLoading: false,
-  isError: false,
-  error: null,
-  refetch: vi.fn(),
-  ...overrides,
-}) as ReturnType<typeof useChatMessages>;
+const makeMessagesResult = (overrides?: Partial<MockChatMessagesResult>) =>
+  ({
+    data: [],
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+    ...overrides,
+  }) as ReturnType<typeof useChatMessages>;
 
 function makeSession(id: number): ChatSession {
   return {
@@ -68,7 +76,10 @@ function renderPage(path = "/workspaces/workspace-1/consultation/history") {
     <MemoryRouter initialEntries={[path]}>
       <Routes>
         <Route path="/workspaces/:workspaceId/consultation/history" element={<ChatHistoryPage />} />
-        <Route path="/workspaces/:workspaceId/consultation/history/:sessionId" element={<ChatHistoryPage />} />
+        <Route
+          path="/workspaces/:workspaceId/consultation/history/:sessionId"
+          element={<ChatHistoryPage />}
+        />
       </Routes>
     </MemoryRouter>,
   );
@@ -107,12 +118,16 @@ describe("ChatHistoryPage", () => {
     expect(screen.getByText("고객")).toBeTruthy();
     expect(screen.getByText("환불 문의 드립니다")).toBeTruthy();
     expect(screen.getByText("TEXT")).toBeTruthy();
-    expect(screen.getByText(new Date("2026-05-22T09:10:00+09:00").toLocaleString("ko-KR"))).toBeTruthy();
+    expect(
+      screen.getByText(new Date("2026-05-22T09:10:00+09:00").toLocaleString("ko-KR")),
+    ).toBeTruthy();
   });
 
   it("상담사 메시지는 상담사 역할로 표시한다", () => {
     mockedUseChatMessages.mockReturnValue(
-      makeMessagesResult({ data: [makeMessage({ senderRole: "AGENT", content: "처리해드리겠습니다" })] }),
+      makeMessagesResult({
+        data: [makeMessage({ senderRole: "AGENT", content: "처리해드리겠습니다" })],
+      }),
     );
 
     renderPage();

--- a/frontend/src/pages/consultation/ui/chat-history/ChatHistoryPage.tsx
+++ b/frontend/src/pages/consultation/ui/chat-history/ChatHistoryPage.tsx
@@ -9,7 +9,10 @@ interface ChatHistoryPageProps {
 }
 
 export function ChatHistoryPage({ workspaceId: workspaceIdProp }: ChatHistoryPageProps) {
-  const { workspaceId: workspaceIdParam, sessionId: sessionIdParam } = useParams<{ workspaceId: string; sessionId: string }>();
+  const { workspaceId: workspaceIdParam, sessionId: sessionIdParam } = useParams<{
+    workspaceId: string;
+    sessionId: string;
+  }>();
   const workspaceId = workspaceIdProp ?? workspaceIdParam ?? "";
   const [selectedSessionId, setSelectedSessionId] = useState<string | null>(sessionIdParam ?? null);
 

--- a/frontend/src/pages/consultation/ui/consultation-page.module.css
+++ b/frontend/src/pages/consultation/ui/consultation-page.module.css
@@ -129,5 +129,4 @@
     width: 220px;
     flex-basis: 220px;
   }
-
 }

--- a/frontend/src/pages/consultation/ui/sections/CustomerPanel.tsx
+++ b/frontend/src/pages/consultation/ui/sections/CustomerPanel.tsx
@@ -1,5 +1,7 @@
-import type { ReactNode } from "react";
-import { Eyebrow, Mono, Pill } from "@/shared/ui/ostone/atoms";
+import { Pill } from "@/shared/ui/ostone/atoms";
+import { InfoCard } from "./InfoCard";
+import { InfoRow } from "./InfoRow";
+import { ProgressStepper, type ProgressStepperStep } from "./ProgressStepper";
 
 interface CustomerInfo {
   name: string;
@@ -17,32 +19,12 @@ interface CustomerPanelProps {
   isMemoSaving?: boolean;
 }
 
-function Section({ title, children }: { title: string; children: ReactNode }) {
-  return (
-    <div style={{ padding: "16px", borderBottom: "1px solid var(--line-2)" }}>
-      <div style={{ marginBottom: 12 }}>
-        <Eyebrow>{title}</Eyebrow>
-      </div>
-      {children}
-    </div>
-  );
-}
-
-function Row({ label, value }: { label: string; value: string }) {
-  return (
-    <div
-      style={{
-        display: "flex",
-        justifyContent: "space-between",
-        alignItems: "center",
-        padding: "4px 0",
-      }}
-    >
-      <Mono style={{ fontSize: 11, color: "var(--ink-3)" }}>{label}</Mono>
-      <span style={{ fontSize: 12, color: "var(--ink)" }}>{value}</span>
-    </div>
-  );
-}
+const STEPS: ProgressStepperStep[] = [
+  { label: "접수", value: "05-03", state: "done" },
+  { label: "확인 완료", value: "05-04", state: "done" },
+  { label: "처리", value: "진행중", state: "active" },
+  { label: "완료", value: "예정", state: "todo" },
+];
 
 export function CustomerPanel({
   customer,
@@ -56,6 +38,7 @@ export function CustomerPanel({
   if (!customer) {
     return (
       <div
+        data-testid="customer-panel-empty"
         style={{
           width: 320,
           flexShrink: 0,
@@ -64,109 +47,82 @@ export function CustomerPanel({
           display: "flex",
           alignItems: "center",
           justifyContent: "center",
+          padding: 16,
         }}
       >
-        <Mono style={{ fontSize: 12, color: "var(--ink-3)" }}>
+        <span
+          style={{
+            fontFamily: "var(--mono)",
+            fontSize: 11,
+            color: "var(--ink-3)",
+            textTransform: "uppercase",
+            letterSpacing: "0.08em",
+          }}
+        >
           고객을 선택하면 정보가 표시됩니다
-        </Mono>
+        </span>
       </div>
     );
   }
 
   return (
     <div
+      data-testid="customer-panel"
       style={{
         width: 320,
         flexShrink: 0,
         background: "var(--paper-2)",
         overflow: "auto",
+        padding: 14,
+        display: "flex",
+        flexDirection: "column",
+        gap: 10,
       }}
     >
-      <Section title="고객 정보">
-        <Row label="이름" value={customer.name} />
-        <Row label="채널" value={customer.channel} />
-        <Row label="회원 등급" value={customer.membershipTier || "일반"} />
-        <Row label="연락처" value={customer.contact || "010-****-1234"} />
-        <Row label="이메일" value={customer.email || "mi***@example.com"} />
-      </Section>
+      <InfoCard title="고객 정보" meta={customer.channel || undefined}>
+        <InfoRow label="이름" value={customer.name} />
+        <InfoRow label="채널" value={customer.channel} />
+        <InfoRow
+          label="회원 등급"
+          value={customer.membershipTier || "일반"}
+          tone={customer.membershipTier ? "signal" : "default"}
+        />
+        <InfoRow label="연락처" value={customer.contact || "010-****-1234"} />
+        <InfoRow label="이메일" value={customer.email || "mi***@example.com"} />
+      </InfoCard>
 
-      <Section title="문의 관련 주문">
-        <Row label="주문 ID" value="#ORD-2024-08921" />
-        <Row label="주문일" value="2024-05-03" />
-        <Row label="결제금액" value="89,000원" />
-        <div
-          style={{
-            display: "flex",
-            justifyContent: "space-between",
-            alignItems: "center",
-            padding: "4px 0",
-          }}
-        >
-          <Mono style={{ fontSize: 11, color: "var(--ink-3)" }}>주문 상태</Mono>
-          <Pill tone="signal">배송 완료</Pill>
-        </div>
-      </Section>
+      <InfoCard title="문의 관련 주문" meta="#ORD-2024-08921">
+        <InfoRow label="주문일" value="2024-05-03" />
+        <InfoRow label="결제금액" value="89,000원" />
+        <InfoRow label="상태" tone="signal" value={<Pill tone="signal">배송 완료</Pill>} />
+      </InfoCard>
 
-      <Section title="처리 단계">
-        <div style={{ display: "flex", alignItems: "center", gap: 4, padding: "8px 0" }}>
-          {[
-            { label: "접수", done: true },
-            { label: "확인 중", done: true },
-            { label: "처리 중", done: true, active: true },
-            { label: "완료", done: false },
-          ].map((step, i, arr) => (
-            <div key={step.label} style={{ display: "flex", alignItems: "center", gap: 4 }}>
-              <span
-                style={{
-                  fontSize: 10,
-                  fontWeight: step.active ? 700 : 400,
-                  color: step.done ? "var(--signal)" : "var(--ink-4)",
-                  fontFamily: "var(--mono)",
-                }}
-              >
-                {step.label}
-              </span>
-              {i < arr.length - 1 && (
-                <span style={{ color: step.done ? "var(--signal)" : "var(--ink-4)", fontSize: 10 }}>
-                  →
-                </span>
-              )}
-            </div>
-          ))}
-        </div>
-      </Section>
+      <InfoCard title="처리 단계" meta="3 of 4">
+        <ProgressStepper steps={STEPS} />
+      </InfoCard>
 
-      <Section title="확인된 정보">
-        {[
-          { field: "카드번호", value: "5432 **** **** 8912" },
-          { field: "환불 요청액", value: "45,000원" },
-          { field: "환불 사유", value: "부분 환불 요청" },
-          { field: "처리 기한", value: "2024-05-10" },
-        ].map((item) => (
-          <div key={item.field} style={{ padding: "4px 0" }}>
-            <Mono
-              style={{ fontSize: 10, color: "var(--ink-3)", display: "block", marginBottom: 2 }}
-            >
-              {item.field}
-            </Mono>
-            <span style={{ fontSize: 12, color: "var(--ink)" }}>{item.value}</span>
-          </div>
-        ))}
-      </Section>
+      <InfoCard title="확인된 정보" meta="자동 발췌">
+        <InfoRow label="카드번호" value="5432 **** **** 8912" />
+        <InfoRow label="환불 요청액" value="45,000원" tone="warn" />
+        <InfoRow label="환불 사유" value="부분 환불 요청" />
+        <InfoRow label="처리 기한" value="2024-05-10" tone="danger" />
+      </InfoCard>
 
-      <Section title="상담 메모">
+      <InfoCard title="상담 메모" meta="private">
         <textarea
+          data-testid="customer-memo-textarea"
           value={memo}
           onChange={(e) => onMemoChange(e.target.value)}
           placeholder="상담 메모를 입력하세요..."
+          aria-label="상담 메모 입력"
           style={{
             width: "100%",
-            minHeight: 80,
-            padding: 8,
-            fontSize: 12,
+            minHeight: 84,
+            padding: 10,
+            fontSize: 12.5,
             lineHeight: 1.5,
             border: "1px solid var(--line)",
-            borderRadius: "var(--r-2)",
+            borderRadius: "var(--r-3)",
             background: "var(--paper)",
             color: "var(--ink)",
             resize: "vertical",
@@ -175,24 +131,27 @@ export function CustomerPanel({
         />
         <button
           type="button"
+          data-testid="customer-memo-save"
           onClick={onMemoSave}
           disabled={isMemoSaveDisabled}
           style={{
             width: "100%",
-            marginTop: 8,
-            padding: "8px 10px",
-            border: "1px solid var(--line)",
-            borderRadius: "var(--r-2)",
+            marginTop: 10,
+            height: 36,
+            padding: "0 14px",
+            border: isMemoSaveDisabled ? "1px solid var(--line)" : "1px solid var(--ink)",
+            borderRadius: "var(--r-3)",
             background: isMemoSaveDisabled ? "var(--paper-2)" : "var(--ink)",
             color: isMemoSaveDisabled ? "var(--ink-4)" : "var(--paper)",
             cursor: isMemoSaveDisabled ? "not-allowed" : "pointer",
-            fontSize: 12,
-            fontWeight: 700,
+            fontSize: 12.5,
+            fontWeight: 600,
+            letterSpacing: "-0.1px",
           }}
         >
           {isMemoSaving ? "저장 중..." : "메모 저장"}
         </button>
-      </Section>
+      </InfoCard>
     </div>
   );
 }

--- a/frontend/src/pages/consultation/ui/sections/InfoCard.test.tsx
+++ b/frontend/src/pages/consultation/ui/sections/InfoCard.test.tsx
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { InfoCard } from "./InfoCard";
+
+describe("InfoCard", () => {
+  it("renders title as level-3 heading + content slot", () => {
+    render(
+      <InfoCard title="고객 정보">
+        <span data-testid="child">payload</span>
+      </InfoCard>,
+    );
+
+    const heading = screen.getByRole("heading", { level: 3, name: "고객 정보" });
+    expect(heading).toBeInTheDocument();
+    expect(screen.getByTestId("info-card-content")).toHaveTextContent("payload");
+  });
+
+  it("renders meta string when provided", () => {
+    render(
+      <InfoCard title="문의 관련 주문" meta="#ORD-2024-08921">
+        <div />
+      </InfoCard>,
+    );
+
+    expect(screen.getByTestId("info-card-meta")).toHaveTextContent("#ORD-2024-08921");
+  });
+
+  it("omits meta slot when not provided", () => {
+    render(
+      <InfoCard title="확인된 정보">
+        <div />
+      </InfoCard>,
+    );
+
+    expect(screen.queryByTestId("info-card-meta")).not.toBeInTheDocument();
+  });
+
+  it("uses explicit testId when provided", () => {
+    render(
+      <InfoCard title="처리 단계" testId="custom-card">
+        <div />
+      </InfoCard>,
+    );
+
+    expect(screen.getByTestId("custom-card")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/consultation/ui/sections/InfoCard.tsx
+++ b/frontend/src/pages/consultation/ui/sections/InfoCard.tsx
@@ -1,0 +1,75 @@
+import type { CSSProperties, ReactNode } from "react";
+
+interface InfoCardProps {
+  title: string;
+  meta?: string;
+  children: ReactNode;
+  testId?: string;
+  style?: CSSProperties;
+}
+
+export function InfoCard({ title, meta, children, testId, style }: InfoCardProps) {
+  return (
+    <section
+      data-testid={testId ?? `info-card-${slugify(title)}`}
+      style={{
+        background: "var(--paper)",
+        border: "1px solid var(--line-2)",
+        borderRadius: "var(--r-3)",
+        padding: "14px 14px 12px",
+        boxShadow: "0 1px 2px rgba(15, 23, 42, 0.04), 0 6px 14px rgba(15, 23, 42, 0.06)",
+        ...style,
+      }}
+    >
+      <header
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 8,
+          paddingBottom: 10,
+          marginBottom: 10,
+          borderBottom: "1px solid var(--line-2)",
+        }}
+      >
+        <h3
+          data-testid="info-card-title"
+          style={{
+            margin: 0,
+            fontFamily: "var(--mono)",
+            fontSize: 10.5,
+            fontWeight: 600,
+            textTransform: "uppercase",
+            letterSpacing: "0.08em",
+            color: "var(--ink-2)",
+          }}
+        >
+          {title}
+        </h3>
+        {meta !== undefined && (
+          <span
+            data-testid="info-card-meta"
+            style={{
+              fontFamily: "var(--mono)",
+              fontSize: 10,
+              color: "var(--ink-3)",
+              textTransform: "uppercase",
+              letterSpacing: "0.04em",
+            }}
+          >
+            {meta}
+          </span>
+        )}
+      </header>
+      <div data-testid="info-card-content">{children}</div>
+    </section>
+  );
+}
+
+function slugify(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, "-")
+    .replace(/[^a-z0-9가-힣-]/g, "");
+}

--- a/frontend/src/pages/consultation/ui/sections/InfoRow.test.tsx
+++ b/frontend/src/pages/consultation/ui/sections/InfoRow.test.tsx
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { InfoRow } from "./InfoRow";
+
+describe("InfoRow", () => {
+  it("renders label + value text", () => {
+    render(<InfoRow label="이름" value="김민지" testId="row-name" />);
+
+    const row = screen.getByTestId("row-name");
+    expect(row).toHaveTextContent("이름");
+    expect(row).toHaveTextContent("김민지");
+  });
+
+  it("defaults to data-tone='default' when tone is omitted", () => {
+    render(<InfoRow label="채널" value="카카오톡" testId="row-channel" />);
+    expect(screen.getByTestId("row-channel")).toHaveAttribute("data-tone", "default");
+  });
+
+  it.each(["signal", "warn", "danger"] as const)(
+    "propagates tone='%s' to data-tone attribute",
+    (tone) => {
+      render(<InfoRow label="상태" value="OK" tone={tone} testId={`row-${tone}`} />);
+      expect(screen.getByTestId(`row-${tone}`)).toHaveAttribute("data-tone", tone);
+    },
+  );
+
+  it("supports ReactNode as value (e.g., Pill)", () => {
+    render(
+      <InfoRow
+        label="상태"
+        value={<span data-testid="custom-pill">배송 완료</span>}
+        testId="row-status"
+      />,
+    );
+
+    expect(screen.getByTestId("custom-pill")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/consultation/ui/sections/InfoRow.tsx
+++ b/frontend/src/pages/consultation/ui/sections/InfoRow.tsx
@@ -1,0 +1,56 @@
+import type { ReactNode } from "react";
+
+export type InfoRowTone = "default" | "signal" | "warn" | "danger";
+
+const TONE_BORDER: Record<InfoRowTone, string> = {
+  default: "var(--line-2)",
+  signal: "var(--signal)",
+  warn: "var(--warn)",
+  danger: "var(--danger)",
+};
+
+interface InfoRowProps {
+  label: string;
+  value: ReactNode;
+  tone?: InfoRowTone;
+  testId?: string;
+}
+
+export function InfoRow({ label, value, tone = "default", testId }: InfoRowProps) {
+  return (
+    <div
+      data-testid={testId}
+      data-tone={tone}
+      style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        gap: 12,
+        padding: "6px 0 6px 10px",
+        borderLeft: `2px solid ${TONE_BORDER[tone]}`,
+      }}
+    >
+      <span
+        style={{
+          fontFamily: "var(--mono)",
+          fontSize: 10.5,
+          textTransform: "uppercase",
+          letterSpacing: "0.06em",
+          color: "var(--ink-3)",
+        }}
+      >
+        {label}
+      </span>
+      <span
+        style={{
+          fontSize: 12.5,
+          fontWeight: 500,
+          color: "var(--ink)",
+          textAlign: "right",
+        }}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}

--- a/frontend/src/pages/consultation/ui/sections/Message.tsx
+++ b/frontend/src/pages/consultation/ui/sections/Message.tsx
@@ -58,9 +58,7 @@ export function Message({ variant, name, time, text }: MessageProps) {
             justifyContent: isRight ? "flex-end" : "flex-start",
           }}
         >
-          <span style={{ fontSize: 12, fontWeight: 600, color: "var(--ink)" }}>
-            {displayName}
-          </span>
+          <span style={{ fontSize: 12, fontWeight: 600, color: "var(--ink)" }}>{displayName}</span>
           <Mono style={{ fontSize: 10, color: "var(--ink-3)" }}>{time}</Mono>
         </div>
         <div

--- a/frontend/src/pages/consultation/ui/sections/ProgressStepper.test.tsx
+++ b/frontend/src/pages/consultation/ui/sections/ProgressStepper.test.tsx
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ProgressStepper, type ProgressStepperStep } from "./ProgressStepper";
+
+const STEPS: ProgressStepperStep[] = [
+  { label: "접수", value: "05-03", state: "done" },
+  { label: "확인 중", value: "05-04", state: "done" },
+  { label: "처리 중", value: "진행중", state: "active" },
+  { label: "완료", value: "예정", state: "todo" },
+];
+
+describe("ProgressStepper", () => {
+  it("renders one listitem per step", () => {
+    render(<ProgressStepper steps={STEPS} />);
+
+    expect(screen.getAllByRole("listitem")).toHaveLength(STEPS.length);
+  });
+
+  it("marks the active step with aria-current='step'", () => {
+    render(<ProgressStepper steps={STEPS} />);
+
+    const active = screen.getAllByRole("listitem").find((node) => node.dataset.state === "active");
+    expect(active).toBeDefined();
+    expect(active).toHaveAttribute("aria-current", "step");
+  });
+
+  it("exposes data-state matching each step state", () => {
+    render(<ProgressStepper steps={STEPS} />);
+
+    const items = screen.getAllByRole("listitem");
+    expect(items[0]).toHaveAttribute("data-state", "done");
+    expect(items[1]).toHaveAttribute("data-state", "done");
+    expect(items[2]).toHaveAttribute("data-state", "active");
+    expect(items[3]).toHaveAttribute("data-state", "todo");
+  });
+
+  it("renders optional step value when provided", () => {
+    render(<ProgressStepper steps={STEPS} />);
+
+    expect(screen.getByText("05-03")).toBeInTheDocument();
+    expect(screen.getByText("진행중")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/consultation/ui/sections/ProgressStepper.tsx
+++ b/frontend/src/pages/consultation/ui/sections/ProgressStepper.tsx
@@ -1,0 +1,94 @@
+export type ProgressStepperState = "done" | "active" | "todo";
+
+export interface ProgressStepperStep {
+  label: string;
+  value?: string;
+  state: ProgressStepperState;
+}
+
+interface ProgressStepperProps {
+  steps: ProgressStepperStep[];
+}
+
+const STEP_BG: Record<ProgressStepperState, string> = {
+  done: "var(--signal-bg)",
+  active: "var(--ink)",
+  todo: "var(--paper-2)",
+};
+
+const STEP_BORDER: Record<ProgressStepperState, string> = {
+  done: "var(--signal)",
+  active: "var(--ink)",
+  todo: "var(--line-2)",
+};
+
+const STEP_LABEL_COLOR: Record<ProgressStepperState, string> = {
+  done: "var(--signal-ink)",
+  active: "var(--paper)",
+  todo: "var(--ink-3)",
+};
+
+const STEP_VALUE_COLOR: Record<ProgressStepperState, string> = {
+  done: "var(--ink)",
+  active: "var(--paper)",
+  todo: "var(--ink-2)",
+};
+
+export function ProgressStepper({ steps }: ProgressStepperProps) {
+  return (
+    <ol
+      data-testid="progress-stepper"
+      style={{
+        display: "grid",
+        gridTemplateColumns: `repeat(${Math.max(steps.length, 1)}, minmax(0, 1fr))`,
+        gap: 6,
+        listStyle: "none",
+        margin: 0,
+        padding: 0,
+      }}
+    >
+      {steps.map((step) => {
+        const isActive = step.state === "active";
+        return (
+          <li
+            key={step.label}
+            data-state={step.state}
+            aria-current={isActive ? "step" : undefined}
+            style={{
+              padding: "10px 10px",
+              borderRadius: "var(--r-3)",
+              background: STEP_BG[step.state],
+              border: `1px solid ${STEP_BORDER[step.state]}`,
+              transition: "background 160ms ease, color 160ms ease",
+            }}
+          >
+            <div
+              style={{
+                fontFamily: "var(--mono)",
+                fontSize: 10,
+                textTransform: "uppercase",
+                letterSpacing: "0.05em",
+                color: STEP_LABEL_COLOR[step.state],
+                fontWeight: isActive ? 700 : 500,
+              }}
+            >
+              {step.label}
+            </div>
+            {step.value !== undefined && (
+              <div
+                style={{
+                  marginTop: 4,
+                  fontSize: 12.5,
+                  fontWeight: 500,
+                  color: STEP_VALUE_COLOR[step.state],
+                }}
+              >
+                {step.value}
+              </div>
+            )}
+          </li>
+        );
+      })}
+    </ol>
+  );
+}

--- a/frontend/src/pages/consultation/ui/sections/ProgressStepper.tsx
+++ b/frontend/src/pages/consultation/ui/sections/ProgressStepper.tsx
@@ -47,11 +47,11 @@ export function ProgressStepper({ steps }: ProgressStepperProps) {
         padding: 0,
       }}
     >
-      {steps.map((step) => {
+      {steps.map((step, index) => {
         const isActive = step.state === "active";
         return (
           <li
-            key={step.label}
+            key={`${step.label}-${index}`}
             data-state={step.state}
             aria-current={isActive ? "step" : undefined}
             style={{

--- a/frontend/src/pages/domain-pack/model/useIntentDraftReadController.ts
+++ b/frontend/src/pages/domain-pack/model/useIntentDraftReadController.ts
@@ -2,15 +2,9 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import type { UseQueryResult } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
 import { toast } from "sonner";
-import type {
-  DomainPackDetail,
-  DomainPackVersionDetail,
-} from "@/entities/domain-pack";
+import type { DomainPackDetail, DomainPackVersionDetail } from "@/entities/domain-pack";
 import type { IntentDetail } from "@/entities/intent";
-import {
-  usePackDetail,
-  useVersionDetail,
-} from "@/features/domain-pack-summary-read";
+import { usePackDetail, useVersionDetail } from "@/features/domain-pack-summary-read";
 import {
   domainPackSectionPath,
   shouldReplaceDomainPackChildRoute,
@@ -57,19 +51,10 @@ export function useIntentDraftReadController({
   iId,
 }: IntentDraftReadControllerParams) {
   const navigate = useNavigate();
-  const packQuery = usePackDetail(
-    wsId,
-    pId,
-  ) as UseQueryResult<DomainPackDetail>;
-  const versionQuery = useVersionDetail(
-    wsId,
-    pId,
-    vId,
-  ) as UseQueryResult<DomainPackVersionDetail>;
-  const { saveIntentRevisionDraft, isPending: isCreatingRevision } =
-    useSaveIntentRevisionDraft();
-  const { updateDraftIntent, isPending: isUpdatingDraft } =
-    useUpdateDraftIntent();
+  const packQuery = usePackDetail(wsId, pId) as UseQueryResult<DomainPackDetail>;
+  const versionQuery = useVersionDetail(wsId, pId, vId) as UseQueryResult<DomainPackVersionDetail>;
+  const { saveIntentRevisionDraft, isPending: isCreatingRevision } = useSaveIntentRevisionDraft();
+  const { updateDraftIntent, isPending: isUpdatingDraft } = useUpdateDraftIntent();
   const [detailRefreshKey, setDetailRefreshKey] = useState(0);
   const [listRefreshKey, setListRefreshKey] = useState(0);
   const [summaryRefreshKey, setSummaryRefreshKey] = useState(0);
@@ -78,33 +63,20 @@ export function useIntentDraftReadController({
     isDirty: false,
     intentId: null,
   });
-  const [pendingNavigation, setPendingNavigation] = useState<
-    (() => void) | null
-  >(null);
-  const [existingDraftTarget, setExistingDraftTarget] =
-    useState<ExistingDraftTarget | null>(null);
-  const [recoveryVersionId, setRecoveryVersionId] = useState<number | null>(
-    null,
-  );
-  const [selectedIntentCode, setSelectedIntentCode] = useState<string | null>(
-    null,
-  );
+  const [pendingNavigation, setPendingNavigation] = useState<(() => void) | null>(null);
+  const [existingDraftTarget, setExistingDraftTarget] = useState<ExistingDraftTarget | null>(null);
+  const [recoveryVersionId, setRecoveryVersionId] = useState<number | null>(null);
+  const [selectedIntentCode, setSelectedIntentCode] = useState<string | null>(null);
 
-  const currentPublishedVersion = useCurrentPublishedVersion(
-    packQuery.data?.versions,
-  );
+  const currentPublishedVersion = useCurrentPublishedVersion(packQuery.data?.versions);
   const versionDetail = versionQuery.data;
-  const revisionSource = parseIntentRevisionDraftSource(
-    versionDetail?.summaryJson,
-  );
+  const revisionSource = parseIntentRevisionDraftSource(versionDetail?.summaryJson);
   const isRevisionDraft =
-    versionDetail?.lifecycleStatus === "DRAFT" &&
-    revisionSource?.type === "INTENT_REVISION";
+    versionDetail?.lifecycleStatus === "DRAFT" && revisionSource?.type === "INTENT_REVISION";
   const isCurrentPublished =
     versionDetail?.lifecycleStatus === "PUBLISHED" &&
     currentPublishedVersion?.versionId === versionDetail.versionId;
-  const isGeneralDraft =
-    versionDetail?.lifecycleStatus === "DRAFT" && !isRevisionDraft;
+  const isGeneralDraft = versionDetail?.lifecycleStatus === "DRAFT" && !isRevisionDraft;
   const canEditIntent = isCurrentPublished || isRevisionDraft;
 
   const summaryState = useIntentRevisionSummary({
@@ -124,28 +96,15 @@ export function useIntentDraftReadController({
   const resetDirty = useCallback(() => {
     setDirtyState({ isDirty: false, intentId: null });
   }, []);
-  const handleDirtyChange = useCallback(
-    (isDirty: boolean, intentId: number | null) => {
-      setDirtyState({ isDirty, intentId });
-    },
-    [],
-  );
+  const handleDirtyChange = useCallback((isDirty: boolean, intentId: number | null) => {
+    setDirtyState({ isDirty, intentId });
+  }, []);
 
   useBeforeUnloadGuard(dirtyState.isDirty);
 
   const navigateToIntentRoute = useCallback(
-    (
-      versionId: number,
-      intentId: number | null,
-      options?: IntentRouteNavigationOptions,
-    ) => {
-      const path = domainPackSectionPath(
-        wsId,
-        pId,
-        versionId,
-        "intents",
-        intentId ?? undefined,
-      );
+    (versionId: number, intentId: number | null, options?: IntentRouteNavigationOptions) => {
+      const path = domainPackSectionPath(wsId, pId, versionId, "intents", intentId ?? undefined);
       if (options?.replace ?? shouldReplaceDomainPackChildRoute(iId)) {
         navigate(path, { replace: true });
         return;
@@ -166,14 +125,8 @@ export function useIntentDraftReadController({
       }
 
       try {
-        const intents = await intentRevisionDraftApi.listIntents(
-          wsId,
-          pId,
-          versionId,
-        );
-        const target = intents.find(
-          (intent) => intent.intentCode === intentCode,
-        );
+        const intents = await intentRevisionDraftApi.listIntents(wsId, pId, versionId);
+        const target = intents.find((intent) => intent.intentCode === intentCode);
         navigateToIntentRoute(versionId, target?.id ?? null, options);
       } catch {
         navigateToIntentRoute(versionId, null, options);
@@ -249,8 +202,7 @@ export function useIntentDraftReadController({
     handleDirtyChange,
     isCurrentPublished,
     isGeneralDraft,
-    isMutationPending:
-      isCreatingRevision || isUpdatingDraft || versionActionPending,
+    isMutationPending: isCreatingRevision || isUpdatingDraft || versionActionPending,
     isRevisionDraft,
     listRefreshKey,
     markers,
@@ -270,8 +222,7 @@ export function useIntentDraftReadController({
       const target = existingDraftTarget;
       setExistingDraftTarget(null);
       resetDirty();
-      if (target)
-        void navigateToIntentCode(target.versionId, target.intentCode);
+      if (target) void navigateToIntentCode(target.versionId, target.intentCode);
     },
     confirmPendingNavigation: () => {
       const next = pendingNavigation;
@@ -286,9 +237,7 @@ export function useIntentDraftReadController({
       guardNavigation(() => navigateToIntentRoute(vId, null));
     },
     handleDiscardRevisionDraftAction: () => {
-      guardNavigation(
-        () => void handleDiscardRevisionDraft(selectedIntentCode),
-      );
+      guardNavigation(() => void handleDiscardRevisionDraft(selectedIntentCode));
     },
     handleSaveRevision,
     handleSelect: (id: number) => {
@@ -298,24 +247,14 @@ export function useIntentDraftReadController({
   };
 }
 
-function useCurrentPublishedVersion(
-  versions: DomainPackDetail["versions"] | undefined,
-) {
+function useCurrentPublishedVersion(versions: DomainPackDetail["versions"] | undefined) {
   return useMemo(() => {
     return (versions ?? [])
-      .filter(
-        (version) =>
-          version.lifecycleStatus === "PUBLISHED" && version.versionId != null,
-      )
-      .reduce<NonNullable<DomainPackDetail["versions"]>[number] | null>(
-        (current, version) => {
-          if (!current) return version;
-          return (version.versionNo ?? 0) > (current.versionNo ?? 0)
-            ? version
-            : current;
-        },
-        null,
-      );
+      .filter((version) => version.lifecycleStatus === "PUBLISHED" && version.versionId != null)
+      .reduce<NonNullable<DomainPackDetail["versions"]>[number] | null>((current, version) => {
+        if (!current) return version;
+        return (version.versionNo ?? 0) > (current.versionNo ?? 0) ? version : current;
+      }, null);
   }, [versions]);
 }
 
@@ -351,9 +290,7 @@ function useResolveExistingDraftTarget({
         const resolution = resolveSingleExistingDraft(refetched.data?.versions);
 
         if (resolution.status === "invalid") {
-          toast.error(
-            "초안 상태를 확인할 수 없습니다. 목록을 새로고침해 주세요.",
-          );
+          toast.error("초안 상태를 확인할 수 없습니다. 목록을 새로고침해 주세요.");
           return false;
         }
 
@@ -369,9 +306,7 @@ function useResolveExistingDraftTarget({
         });
         return true;
       } catch {
-        toast.error(
-          "진행 중인 초안을 확인하지 못했습니다. 잠시 후 다시 시도해 주세요.",
-        );
+        toast.error("진행 중인 초안을 확인하지 못했습니다. 잠시 후 다시 시도해 주세요.");
         return false;
       }
     },
@@ -400,12 +335,8 @@ function useSaveRevisionHandler({
   isCurrentPublished: boolean;
   isRevisionDraft: boolean;
   packQuery: UseQueryResult<DomainPackDetail>;
-  saveIntentRevisionDraft: ReturnType<
-    typeof useSaveIntentRevisionDraft
-  >["saveIntentRevisionDraft"];
-  updateDraftIntent: ReturnType<
-    typeof useUpdateDraftIntent
-  >["updateDraftIntent"];
+  saveIntentRevisionDraft: ReturnType<typeof useSaveIntentRevisionDraft>["saveIntentRevisionDraft"];
+  updateDraftIntent: ReturnType<typeof useUpdateDraftIntent>["updateDraftIntent"];
   resetDirty: () => void;
   refreshIntentViews: () => void;
   navigateToIntentRoute: (versionId: number, intentId: number | null) => void;
@@ -413,10 +344,7 @@ function useSaveRevisionHandler({
   setRecoveryVersionId: (versionId: number | null) => void;
 }) {
   return useCallback(
-    async (
-      detail: IntentDetail,
-      values: UpdateDraftIntentBody,
-    ): Promise<boolean> => {
+    async (detail: IntentDetail, values: UpdateDraftIntentBody): Promise<boolean> => {
       if (detail.id == null || !detail.intentCode) return false;
 
       if (isCurrentPublished) {
@@ -450,12 +378,7 @@ function useSaveRevisionHandler({
         toast.success("Intent 수정 내용이 저장되었습니다.");
         return true;
       } catch (error) {
-        toast.error(
-          resolveApiErrorMessage(
-            error,
-            "Intent 수정 내용 저장에 실패했습니다.",
-          ),
-        );
+        toast.error(resolveApiErrorMessage(error, "Intent 수정 내용 저장에 실패했습니다."));
         return false;
       }
     },
@@ -496,9 +419,7 @@ async function savePublishedIntentRevision({
   detail: IntentDetail;
   values: UpdateDraftIntentBody;
   packQuery: UseQueryResult<DomainPackDetail>;
-  saveIntentRevisionDraft: ReturnType<
-    typeof useSaveIntentRevisionDraft
-  >["saveIntentRevisionDraft"];
+  saveIntentRevisionDraft: ReturnType<typeof useSaveIntentRevisionDraft>["saveIntentRevisionDraft"];
   resetDirty: () => void;
   navigateToIntentRoute: (versionId: number, intentId: number | null) => void;
   resolveExistingDraftTarget: (intentCode: string) => Promise<boolean>;
@@ -529,28 +450,18 @@ async function savePublishedIntentRevision({
     }
     return true;
   } catch (error) {
-    if (
-      error instanceof ApiRequestError &&
-      error.code === "DOMAIN_PACK_DRAFT_ALREADY_EXISTS"
-    ) {
+    if (error instanceof ApiRequestError && error.code === "DOMAIN_PACK_DRAFT_ALREADY_EXISTS") {
       await resolveExistingDraftTarget(detail.intentCode!);
       return false;
     }
 
-    if (
-      error instanceof ApiRequestError &&
-      error.code === "DOMAIN_PACK_VERSION_NOT_CURRENT"
-    ) {
+    if (error instanceof ApiRequestError && error.code === "DOMAIN_PACK_VERSION_NOT_CURRENT") {
       await packQuery.refetch();
-      toast.error(
-        "현재 운영 버전이 변경되었습니다. 최신 버전에서 다시 수정해 주세요.",
-      );
+      toast.error("현재 운영 버전이 변경되었습니다. 최신 버전에서 다시 수정해 주세요.");
       return false;
     }
 
-    toast.error(
-      resolveApiErrorMessage(error, "Intent 수정 내용 저장에 실패했습니다."),
-    );
+    toast.error(resolveApiErrorMessage(error, "Intent 수정 내용 저장에 실패했습니다."));
     return false;
   }
 }
@@ -582,17 +493,12 @@ function useApplyRevisionDraftHandler({
 }) {
   return useCallback(
     async (intentCode?: string | null) => {
-      const summary =
-        summaryState.status === "ready" ? summaryState.data : null;
+      const summary = summaryState.status === "ready" ? summaryState.data : null;
       if (!summary || summary.changedIntents.length === 0) return;
 
       setVersionActionPending(true);
       try {
-        const activated = await intentRevisionDraftApi.activateVersion(
-          wsId,
-          pId,
-          vId,
-        );
+        const activated = await intentRevisionDraftApi.activateVersion(wsId, pId, vId);
         await Promise.all([packQuery.refetch(), versionQuery.refetch()]);
         refreshIntentViews();
         toast.success("Intent 수정 초안이 적용되었습니다.");
@@ -600,12 +506,7 @@ function useApplyRevisionDraftHandler({
           replace: true,
         });
       } catch (error) {
-        toast.error(
-          resolveApiErrorMessage(
-            error,
-            "Intent 수정 초안 적용에 실패했습니다.",
-          ),
-        );
+        toast.error(resolveApiErrorMessage(error, "Intent 수정 초안 적용에 실패했습니다."));
       } finally {
         setVersionActionPending(false);
       }
@@ -667,12 +568,7 @@ function useDiscardRevisionDraftHandler({
           });
         }
       } catch (error) {
-        toast.error(
-          resolveApiErrorMessage(
-            error,
-            "Intent 수정 초안 취소에 실패했습니다.",
-          ),
-        );
+        toast.error(resolveApiErrorMessage(error, "Intent 수정 초안 취소에 실패했습니다."));
       } finally {
         setVersionActionPending(false);
       }

--- a/frontend/src/pages/domain-pack/ui/DomainPackListPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/DomainPackListPage.tsx
@@ -67,7 +67,9 @@ function PackSection({ id, title, count, emptyMessage, packs, workspaceId }: Pac
             const cardContent = (
               <>
                 <div className={styles.cardTopRow}>
-                  <span className={operating ? styles.statusBadgeOperating : styles.statusBadgeIdle}>
+                  <span
+                    className={operating ? styles.statusBadgeOperating : styles.statusBadgeIdle}
+                  >
                     {operating ? "운영중" : "비운영"}
                   </span>
                   <span className={styles.versionText}>{buildVersionLabel(pack)}</span>
@@ -146,7 +148,10 @@ export function DomainPackListPage() {
   if (query.isError) {
     return (
       <div className={styles.errorPanel} data-testid="domain-packs-error">
-        <ErrorState message="도메인 팩 목록을 불러오지 못했습니다." onRetry={() => query.refetch()} />
+        <ErrorState
+          message="도메인 팩 목록을 불러오지 못했습니다."
+          onRetry={() => query.refetch()}
+        />
       </div>
     );
   }

--- a/frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.test.tsx
+++ b/frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.test.tsx
@@ -6,10 +6,7 @@ import { ApiRequestError } from "@/shared/api";
 import { useDeploy } from "@/shared/api/generated/endpoints/deploy-domain-pack-version-controller/deploy-domain-pack-version-controller";
 import { useActivate } from "@/shared/api/generated/endpoints/activate-domain-pack-version-controller/activate-domain-pack-version-controller";
 import { useDiscard } from "@/shared/api/generated/endpoints/discard-draft-version-controller/discard-draft-version-controller";
-import {
-  usePackDetail,
-  useVersionDetail,
-} from "@/features/domain-pack-summary-read";
+import { usePackDetail, useVersionDetail } from "@/features/domain-pack-summary-read";
 import { DomainPackSummaryPage } from "./DomainPackSummaryPage";
 
 vi.mock("sonner", () => ({
@@ -17,9 +14,7 @@ vi.mock("sonner", () => ({
 }));
 
 vi.mock("@/widgets/ostone-shell", () => ({
-  OstoneShell: ({ children }: { children: React.ReactNode }) => (
-    <div>{children}</div>
-  ),
+  OstoneShell: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
 }));
 
 vi.mock("@/shared/ui/ostone/atoms/LoadingSpinner", () => ({
@@ -27,13 +22,7 @@ vi.mock("@/shared/ui/ostone/atoms/LoadingSpinner", () => ({
 }));
 
 vi.mock("@/shared/ui/ostone/atoms/ErrorState", () => ({
-  ErrorState: ({
-    message,
-    onRetry,
-  }: {
-    message: string;
-    onRetry?: () => void;
-  }) => (
+  ErrorState: ({ message, onRetry }: { message: string; onRetry?: () => void }) => (
     <div data-testid="error-state" role="alert">
       <span>{message}</span>
       {onRetry && (
@@ -48,11 +37,7 @@ vi.mock("@/shared/ui/ostone/atoms/ErrorState", () => ({
 vi.mock("@/features/domain-pack-summary-read", () => ({
   usePackDetail: vi.fn(),
   useVersionDetail: vi.fn(),
-  VersionListPanel: ({
-    onSelect,
-  }: {
-    onSelect: (versionId: number) => void;
-  }) => (
+  VersionListPanel: ({ onSelect }: { onSelect: (versionId: number) => void }) => (
     <div data-testid="version-list-panel">
       <button type="button" onClick={() => onSelect(4)}>
         select version
@@ -119,9 +104,7 @@ function makePackQuery(overrides: Record<string, unknown> = {}): any {
 
 function LocationProbe() {
   const location = useLocation();
-  return (
-    <div data-testid="location">{`${location.pathname}${location.search}`}</div>
-  );
+  return <div data-testid="location">{`${location.pathname}${location.search}`}</div>;
 }
 
 function renderPage(path = "/workspaces/1/domain-packs/2") {
@@ -176,22 +159,16 @@ describe("DomainPackSummaryPage", () => {
       makePackQuery({ isError: true, error: new Error("fail"), refetch }),
     );
     renderPage();
-    expect(screen.getByRole("alert")).toHaveTextContent(
-      "Pack 정보를 불러오지 못했습니다.",
-    );
+    expect(screen.getByRole("alert")).toHaveTextContent("Pack 정보를 불러오지 못했습니다.");
     fireEvent.click(screen.getByRole("button", { name: "다시 시도" }));
     expect(refetch).toHaveBeenCalled();
   });
 
   it('packDetail 404 에러 시 "Pack을 찾을 수 없습니다." 메시지를 표시한다', () => {
     const error404 = new ApiRequestError(404, "NOT_FOUND", "not found");
-    vi.mocked(usePackDetail).mockReturnValue(
-      makePackQuery({ isError: true, error: error404 }),
-    );
+    vi.mocked(usePackDetail).mockReturnValue(makePackQuery({ isError: true, error: error404 }));
     renderPage();
-    expect(screen.getByRole("alert")).toHaveTextContent(
-      "Pack을 찾을 수 없습니다.",
-    );
+    expect(screen.getByRole("alert")).toHaveTextContent("Pack을 찾을 수 없습니다.");
   });
 
   it("정상 상태에서 VersionListPanel과 SummaryDetailPanel을 렌더링한다", () => {
@@ -220,9 +197,7 @@ describe("DomainPackSummaryPage", () => {
     renderPage("/workspaces/1/domain-packs/2");
 
     await waitFor(() =>
-      expect(screen.getByTestId("location")).toHaveTextContent(
-        "/workspaces/1/domain-packs/2",
-      ),
+      expect(screen.getByTestId("location")).toHaveTextContent("/workspaces/1/domain-packs/2"),
     );
     expect(useVersionDetail).toHaveBeenCalledWith(1, 2, null);
   });
@@ -319,9 +294,7 @@ describe("DomainPackSummaryPage", () => {
 
   it("Draft 적용 성공 후 기존 draft 상세 refetch 실패로 실패 toast를 띄우지 않는다", async () => {
     const packRefetch = vi.fn().mockRejectedValue(new Error("refetch failed"));
-    const versionRefetch = vi
-      .fn()
-      .mockRejectedValue(new Error("old draft missing"));
+    const versionRefetch = vi.fn().mockRejectedValue(new Error("old draft missing"));
     const mutate = vi.fn((variables) => {
       void activateOnSuccess?.({ id: 6 }, variables, undefined);
     });
@@ -369,9 +342,7 @@ describe("DomainPackSummaryPage", () => {
     expect(packRefetch).toHaveBeenCalled();
     expect(versionRefetch).toHaveBeenCalled();
     expect(toast.success).toHaveBeenCalledWith("Draft 버전이 적용되었습니다.");
-    expect(toast.error).not.toHaveBeenCalledWith(
-      "Draft 버전을 적용하지 못했습니다.",
-    );
+    expect(toast.error).not.toHaveBeenCalledWith("Draft 버전을 적용하지 못했습니다.");
   });
 
   it("Draft 삭제 버튼 클릭 시 discard mutation을 호출한다", () => {
@@ -409,9 +380,7 @@ describe("DomainPackSummaryPage", () => {
           packId: 2,
           name: "CS Pack",
           code: "CS",
-          versions: [
-            { versionId: 4, versionNo: 2, lifecycleStatus: "PUBLISHED" },
-          ],
+          versions: [{ versionId: 4, versionNo: 2, lifecycleStatus: "PUBLISHED" }],
         },
       }),
     );
@@ -448,15 +417,11 @@ describe("DomainPackSummaryPage", () => {
       }),
     );
     renderPage();
-    expect(
-      screen.queryByRole("button", { name: "새 DRAFT 묶기" }),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "새 DRAFT 묶기" })).not.toBeInTheDocument();
   });
 
   it("packDetail 로딩 중 LoadingSpinner를 표시한다", () => {
-    vi.mocked(usePackDetail).mockReturnValue(
-      makePackQuery({ isLoading: true }),
-    );
+    vi.mocked(usePackDetail).mockReturnValue(makePackQuery({ isLoading: true }));
     renderPage();
     expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
     expect(screen.queryByTestId("version-list-panel")).not.toBeInTheDocument();
@@ -468,32 +433,22 @@ describe("DomainPackSummaryPage", () => {
     );
     renderPage();
     await waitFor(() =>
-      expect(toast.error).toHaveBeenCalledWith(
-        "Pack 정보를 불러오지 못했습니다.",
-      ),
+      expect(toast.error).toHaveBeenCalledWith("Pack 정보를 불러오지 못했습니다."),
     );
     expect(toast.error).toHaveBeenCalledTimes(1);
   });
 
   it('packDetail 404 에러 시 toast.error를 "Pack을 찾을 수 없습니다."로 호출한다', async () => {
     const error404 = new ApiRequestError(404, "NOT_FOUND", "not found");
-    vi.mocked(usePackDetail).mockReturnValue(
-      makePackQuery({ isError: true, error: error404 }),
-    );
+    vi.mocked(usePackDetail).mockReturnValue(makePackQuery({ isError: true, error: error404 }));
     renderPage();
-    await waitFor(() =>
-      expect(toast.error).toHaveBeenCalledWith("Pack을 찾을 수 없습니다."),
-    );
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith("Pack을 찾을 수 없습니다."));
   });
 
   it('packDetail 404 에러 시 "다시 시도" 버튼을 표시하지 않는다', () => {
     const error404 = new ApiRequestError(404, "NOT_FOUND", "not found");
-    vi.mocked(usePackDetail).mockReturnValue(
-      makePackQuery({ isError: true, error: error404 }),
-    );
+    vi.mocked(usePackDetail).mockReturnValue(makePackQuery({ isError: true, error: error404 }));
     renderPage();
-    expect(
-      screen.queryByRole("button", { name: "다시 시도" }),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "다시 시도" })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.tsx
@@ -11,20 +11,14 @@ import { LoadingSpinner } from "@/shared/ui/ostone/atoms/LoadingSpinner";
 import { ErrorState } from "@/shared/ui/ostone/atoms/ErrorState";
 import type { Crumb } from "@/shared/ui/ostone/chrome";
 import { parseRouteId } from "@/shared/lib/parseRouteId";
-import {
-  domainPackPath,
-  withVersionSearch,
-} from "@/shared/lib/domainPackRoutes";
+import { domainPackPath, withVersionSearch } from "@/shared/lib/domainPackRoutes";
 import {
   usePackDetail,
   useVersionDetail,
   VersionListPanel,
   SummaryDetailPanel,
 } from "@/features/domain-pack-summary-read";
-import type {
-  DomainPackDetail,
-  DomainPackVersionDetail,
-} from "@/entities/domain-pack";
+import type { DomainPackDetail, DomainPackVersionDetail } from "@/entities/domain-pack";
 import styles from "./domain-pack-summary-page.module.css";
 
 export function DomainPackSummaryPage() {
@@ -36,11 +30,7 @@ export function DomainPackSummaryPage() {
   const rawVersionId = search.get("versionId");
   const vId = rawVersionId === null ? null : parseRouteId(rawVersionId);
 
-  if (
-    wsId === null ||
-    pId === null ||
-    (rawVersionId !== null && vId === null)
-  ) {
+  if (wsId === null || pId === null || (rawVersionId !== null && vId === null)) {
     return (
       <OstoneShell active="domain" crumbs={[]}>
         <div className={styles.invalidParams} role="alert">
@@ -73,19 +63,12 @@ function DomainPackSummaryPageContent({
   selectedVersionId,
   setSearch,
 }: ContentProps) {
-  const packQuery = usePackDetail(
-    wsId,
-    packId,
-  ) as UseQueryResult<DomainPackDetail>;
+  const packQuery = usePackDetail(wsId, packId) as UseQueryResult<DomainPackDetail>;
 
   useEffect(() => {
     if (!packQuery.isError) return;
-    const is404 =
-      packQuery.error instanceof ApiRequestError &&
-      packQuery.error.status === 404;
-    toast.error(
-      is404 ? "Pack을 찾을 수 없습니다." : "Pack 정보를 불러오지 못했습니다.",
-    );
+    const is404 = packQuery.error instanceof ApiRequestError && packQuery.error.status === 404;
+    toast.error(is404 ? "Pack을 찾을 수 없습니다." : "Pack 정보를 불러오지 못했습니다.");
   }, [packQuery.isError, packQuery.error]);
 
   const versionQuery = useVersionDetail(
@@ -96,8 +79,7 @@ function DomainPackSummaryPageContent({
   const pack = packQuery.data;
   const currentVersionId = pack?.currentVersionId ?? null;
   const selectedVersionNo =
-    pack?.versions?.find((v) => v.versionId === selectedVersionId)?.versionNo ??
-    null;
+    pack?.versions?.find((v) => v.versionId === selectedVersionId)?.versionNo ?? null;
 
   const deployMutation = useDeploy({
     mutation: {
@@ -113,10 +95,7 @@ function DomainPackSummaryPageContent({
   const activateMutation = useActivate({
     mutation: {
       onSuccess: async (result, variables) => {
-        const activatedVersionId = resolveActivatedVersionId(
-          result,
-          variables.versionId,
-        );
+        const activatedVersionId = resolveActivatedVersionId(result, variables.versionId);
         setSearch(
           (prev) => {
             const next = new URLSearchParams(prev);
@@ -129,12 +108,7 @@ function DomainPackSummaryPageContent({
         toast.success("Draft 버전이 적용되었습니다.");
       },
       onError: (error) => {
-        toast.error(
-          resolveVersionActionErrorMessage(
-            error,
-            "Draft 버전을 적용하지 못했습니다.",
-          ),
-        );
+        toast.error(resolveVersionActionErrorMessage(error, "Draft 버전을 적용하지 못했습니다."));
       },
     },
   });
@@ -142,8 +116,7 @@ function DomainPackSummaryPageContent({
     mutation: {
       onSuccess: async () => {
         const refetched = await packQuery.refetch();
-        const targetVersionId =
-          refetched.data?.currentVersionId ?? currentVersionId;
+        const targetVersionId = refetched.data?.currentVersionId ?? currentVersionId;
         setSearch(
           (prev) => {
             const next = new URLSearchParams(prev);
@@ -159,12 +132,7 @@ function DomainPackSummaryPageContent({
         toast.success("Draft 버전이 삭제되었습니다.");
       },
       onError: (error) => {
-        toast.error(
-          resolveVersionActionErrorMessage(
-            error,
-            "Draft 버전을 삭제하지 못했습니다.",
-          ),
-        );
+        toast.error(resolveVersionActionErrorMessage(error, "Draft 버전을 삭제하지 못했습니다."));
       },
     },
   });
@@ -207,10 +175,7 @@ function DomainPackSummaryPageContent({
     if (selectedVersionId !== null && selectedVersionNo !== null) {
       items.push({
         label: `#${selectedVersionNo}`,
-        href: withVersionSearch(
-          domainPackPath(wsId, packId),
-          selectedVersionId,
-        ),
+        href: withVersionSearch(domainPackPath(wsId, packId), selectedVersionId),
       });
     }
     return items;
@@ -225,17 +190,11 @@ function DomainPackSummaryPageContent({
   }
 
   if (packQuery.isError) {
-    const is404 =
-      packQuery.error instanceof ApiRequestError &&
-      packQuery.error.status === 404;
+    const is404 = packQuery.error instanceof ApiRequestError && packQuery.error.status === 404;
     return (
       <OstoneShell active="domain" crumbs={buildSummaryCrumbs()}>
         <ErrorState
-          message={
-            is404
-              ? "Pack을 찾을 수 없습니다."
-              : "Pack 정보를 불러오지 못했습니다."
-          }
+          message={is404 ? "Pack을 찾을 수 없습니다." : "Pack 정보를 불러오지 못했습니다."}
           onRetry={!is404 ? () => packQuery.refetch() : undefined}
         />
       </OstoneShell>
@@ -269,19 +228,13 @@ function DomainPackSummaryPageContent({
             packId={packId}
             currentVersionId={currentVersionId}
             deployingVersionId={
-              deployMutation.isPending
-                ? deployMutation.variables?.versionId
-                : null
+              deployMutation.isPending ? deployMutation.variables?.versionId : null
             }
             applyingVersionId={
-              activateMutation.isPending
-                ? activateMutation.variables?.versionId
-                : null
+              activateMutation.isPending ? activateMutation.variables?.versionId : null
             }
             discardingVersionId={
-              discardMutation.isPending
-                ? discardMutation.variables?.draftVersionId
-                : null
+              discardMutation.isPending ? discardMutation.variables?.draftVersionId : null
             }
             onDeploy={handleDeployVersion}
             onApplyDraft={handleApplyDraft}
@@ -300,10 +253,7 @@ function resolveDeployErrorMessage(error: unknown): string {
   return "도메인팩 버전을 배포하지 못했습니다.";
 }
 
-function resolveVersionActionErrorMessage(
-  error: unknown,
-  fallback: string,
-): string {
+function resolveVersionActionErrorMessage(error: unknown, fallback: string): string {
   if (error instanceof ApiRequestError && error.message) {
     return error.message;
   }

--- a/frontend/src/pages/domain-pack/ui/IntentDraftReadPage.test.tsx
+++ b/frontend/src/pages/domain-pack/ui/IntentDraftReadPage.test.tsx
@@ -53,10 +53,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("react-router-dom", async () => {
-  const actual =
-    await vi.importActual<typeof import("react-router-dom")>(
-      "react-router-dom",
-    );
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
   return {
     ...actual,
     useNavigate: () => mocks.navigate,
@@ -124,14 +121,8 @@ vi.mock("@/features/intent-draft-read/ui", () => ({
     intentListState,
   }: {
     intentId: number | null;
-    headerActions?: (detail: {
-      id: number;
-      intentCode: string;
-    }) => React.ReactNode;
-    afterHeader?: (detail: {
-      id: number;
-      intentCode: string;
-    }) => React.ReactNode;
+    headerActions?: (detail: { id: number; intentCode: string }) => React.ReactNode;
+    afterHeader?: (detail: { id: number; intentCode: string }) => React.ReactNode;
     beforeJsonCards?: () => React.ReactNode;
     children?: (detail: {
       id: number;
@@ -219,15 +210,9 @@ vi.mock("@/features/approve-intent", () => ({
 vi.mock("@/features/intent-revision-draft", () => ({
   IntentRevisionDiffPanel: () => <div>revision diff</div>,
   IntentRevisionRecoveryBanner: () => <div>recovery banner</div>,
-  IntentRevisionDraftActions: ({
-    onRetrySummary,
-  }: {
-    onRetrySummary: () => void;
-  }) => (
+  IntentRevisionDraftActions: ({ onRetrySummary }: { onRetrySummary: () => void }) => (
     <div>
-      <span>
-        수정 내용의 적용 및 삭제는 Domain Pack 화면에서 진행할 수 있습니다.
-      </span>
+      <span>수정 내용의 적용 및 삭제는 Domain Pack 화면에서 진행할 수 있습니다.</span>
       <button type="button" onClick={onRetrySummary}>
         retry summary
       </button>
@@ -250,9 +235,7 @@ vi.mock("@/features/intent-revision-draft", () => ({
         </button>
         <button
           type="button"
-          onClick={() =>
-            void onSave({ name: "환불 문의 수정", description: "수정 설명" })
-          }
+          onClick={() => void onSave({ name: "환불 문의 수정", description: "수정 설명" })}
         >
           save revision
         </button>
@@ -272,14 +255,11 @@ vi.mock("@/features/intent-revision-draft", () => ({
     getVersionDetail: mocks.getVersionDetail,
   },
   parseIntentRevisionDraftSource: (summaryJson?: string) =>
-    summaryJson?.includes("INTENT_REVISION")
-      ? { type: "INTENT_REVISION", baseVersionId: 2 }
-      : null,
+    summaryJson?.includes("INTENT_REVISION") ? { type: "INTENT_REVISION", baseVersionId: 2 } : null,
   resolveSingleExistingDraft: (
     versions?: Array<{ versionId?: number; lifecycleStatus?: string }>,
   ) => {
-    const drafts =
-      versions?.filter((version) => version.lifecycleStatus === "DRAFT") ?? [];
+    const drafts = versions?.filter((version) => version.lifecycleStatus === "DRAFT") ?? [];
     return drafts.length === 1 && drafts[0]?.versionId != null
       ? { status: "resolved", versionId: drafts[0].versionId }
       : { status: "invalid" };
@@ -370,9 +350,7 @@ describe("IntentDraftReadPage", () => {
   it("잘못된 URL 파라미터면 alert를 표시한다", () => {
     renderPage("/workspaces/abc/domain-packs/7/intents?versionId=3");
 
-    expect(screen.getByRole("alert")).toHaveTextContent(
-      "잘못된 URL 파라미터입니다.",
-    );
+    expect(screen.getByRole("alert")).toHaveTextContent("잘못된 URL 파라미터입니다.");
   });
 
   it("intent 선택 시 상세 URL로 이동한다", () => {
@@ -447,18 +425,12 @@ describe("IntentDraftReadPage", () => {
       "/workspaces/1/domain-packs/7/intents?versionId=4",
       { replace: true },
     );
-    expect(mocks.toastSuccess).not.toHaveBeenCalledWith(
-      "Intent 수정 초안이 생성되었습니다.",
-    );
+    expect(mocks.toastSuccess).not.toHaveBeenCalledWith("Intent 수정 초안이 생성되었습니다.");
   });
 
   it("운영 버전이 바뀐 상태에서 저장하면 pack을 새로고침하고 안내한다", async () => {
     mocks.saveIntentRevisionDraft.mockRejectedValue(
-      new ApiRequestError(
-        409,
-        "DOMAIN_PACK_VERSION_NOT_CURRENT",
-        "version changed",
-      ),
+      new ApiRequestError(409, "DOMAIN_PACK_VERSION_NOT_CURRENT", "version changed"),
     );
     renderPage("/workspaces/1/domain-packs/7/intents/10?versionId=3");
 
@@ -489,26 +461,16 @@ describe("IntentDraftReadPage", () => {
       summaryJson: '{"draftSource":"INTENT_REVISION"}',
     });
     mocks.saveIntentRevisionDraft.mockRejectedValue(
-      new ApiRequestError(
-        409,
-        "DOMAIN_PACK_DRAFT_ALREADY_EXISTS",
-        "draft exists",
-      ),
+      new ApiRequestError(409, "DOMAIN_PACK_DRAFT_ALREADY_EXISTS", "draft exists"),
     );
     renderPage("/workspaces/1/domain-packs/7/intents/10?versionId=3");
 
     fireEvent.click(screen.getByRole("button", { name: "수정" }));
     fireEvent.click(screen.getByRole("button", { name: "save revision" }));
 
-    await waitFor(() =>
-      expect(
-        screen.getByText("진행 중인 초안이 있습니다."),
-      ).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText("진행 중인 초안이 있습니다.")).toBeInTheDocument());
     expect(
-      screen.getByText(
-        /이미 진행 중인 Draft가 있어 새 수정 초안을 만들 수 없습니다./,
-      ),
+      screen.getByText(/이미 진행 중인 Draft가 있어 새 수정 초안을 만들 수 없습니다./),
     ).toBeInTheDocument();
   });
 
@@ -523,11 +485,7 @@ describe("IntentDraftReadPage", () => {
     };
     mocks.packRefetch.mockResolvedValue({ data: mocks.packData });
     mocks.saveIntentRevisionDraft.mockRejectedValue(
-      new ApiRequestError(
-        409,
-        "DOMAIN_PACK_DRAFT_ALREADY_EXISTS",
-        "draft exists",
-      ),
+      new ApiRequestError(409, "DOMAIN_PACK_DRAFT_ALREADY_EXISTS", "draft exists"),
     );
     renderPage("/workspaces/1/domain-packs/7/intents/10?versionId=3");
 
@@ -539,9 +497,7 @@ describe("IntentDraftReadPage", () => {
         "초안 상태를 확인할 수 없습니다. 목록을 새로고침해 주세요.",
       ),
     );
-    expect(
-      screen.queryByText("진행 중인 초안이 있습니다."),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText("진행 중인 초안이 있습니다.")).not.toBeInTheDocument();
   });
 
   it("기존 초안 dialog에서 이동을 확정하면 해당 초안의 같은 intent로 이동한다", async () => {
@@ -559,21 +515,13 @@ describe("IntentDraftReadPage", () => {
       summaryJson: '{"draftSource":"INTENT_REVISION"}',
     });
     mocks.saveIntentRevisionDraft.mockRejectedValue(
-      new ApiRequestError(
-        409,
-        "DOMAIN_PACK_DRAFT_ALREADY_EXISTS",
-        "draft exists",
-      ),
+      new ApiRequestError(409, "DOMAIN_PACK_DRAFT_ALREADY_EXISTS", "draft exists"),
     );
     renderPage("/workspaces/1/domain-packs/7/intents/10?versionId=3");
 
     fireEvent.click(screen.getByRole("button", { name: "수정" }));
     fireEvent.click(screen.getByRole("button", { name: "save revision" }));
-    await waitFor(() =>
-      expect(
-        screen.getByText("진행 중인 초안이 있습니다."),
-      ).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText("진행 중인 초안이 있습니다.")).toBeInTheDocument());
     fireEvent.click(screen.getByRole("button", { name: "이동" }));
 
     await waitFor(() =>
@@ -622,9 +570,7 @@ describe("IntentDraftReadPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "수정" }));
     fireEvent.click(screen.getByRole("button", { name: "save revision" }));
 
-    await waitFor(() =>
-      expect(mocks.toastError).toHaveBeenCalledWith("이름이 너무 깁니다."),
-    );
+    await waitFor(() => expect(mocks.toastError).toHaveBeenCalledWith("이름이 너무 깁니다."));
     expect(mocks.versionRefetch).not.toHaveBeenCalled();
     expect(mocks.navigate).not.toHaveBeenCalled();
   });
@@ -641,9 +587,7 @@ describe("IntentDraftReadPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "mark dirty" }));
     fireEvent.click(screen.getByRole("button", { name: "select intent" }));
 
-    expect(
-      await screen.findByText("저장하지 않고 이동할까요?"),
-    ).toBeInTheDocument();
+    expect(await screen.findByText("저장하지 않고 이동할까요?")).toBeInTheDocument();
     expect(mocks.navigate).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByRole("button", { name: "이동" }));
@@ -686,16 +630,10 @@ describe("IntentDraftReadPage", () => {
     renderPage("/workspaces/1/domain-packs/7/intents/10?versionId=6");
 
     expect(
-      screen.getByText(
-        "수정 내용의 적용 및 삭제는 Domain Pack 화면에서 진행할 수 있습니다.",
-      ),
+      screen.getByText("수정 내용의 적용 및 삭제는 Domain Pack 화면에서 진행할 수 있습니다."),
     ).toBeInTheDocument();
-    expect(
-      screen.queryByRole("button", { name: "apply revision" }),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole("button", { name: "discard revision" }),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "apply revision" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "discard revision" })).not.toBeInTheDocument();
     expect(mocks.activateVersion).not.toHaveBeenCalled();
     expect(mocks.discardDraft).not.toHaveBeenCalled();
   });

--- a/frontend/src/pages/domain-pack/ui/IntentDraftReadPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/IntentDraftReadPage.tsx
@@ -44,12 +44,7 @@ export function IntentDraftReadPage() {
   const vId = parseRouteId(search.get("versionId") ?? undefined);
   const iId = intentId ? parseRouteId(intentId) : null;
 
-  if (
-    wsId === null ||
-    pId === null ||
-    vId === null ||
-    (intentId !== undefined && iId === null)
-  ) {
+  if (wsId === null || pId === null || vId === null || (intentId !== undefined && iId === null)) {
     return (
       <OstoneShell active="domain" crumbs={[]}>
         <div className={styles.invalidParams} role="alert">
@@ -74,16 +69,10 @@ function IntentDraftReadContent({
   iId: number | null;
 }) {
   const controller = useIntentDraftReadController({ wsId, pId, vId, iId });
-  const intentListState = useIntentList(
-    wsId,
-    pId,
-    vId,
-    controller.listRefreshKey,
-  );
+  const intentListState = useIntentList(wsId, pId, vId, controller.listRefreshKey);
   const packDetail = usePackDetail(wsId, pId).data;
   const packName = packDetail?.name ?? `PACK · ${pId}`;
-  const versionNo =
-    packDetail?.versions?.find((v) => v.versionId === vId)?.versionNo ?? vId;
+  const versionNo = packDetail?.versions?.find((v) => v.versionId === vId)?.versionNo ?? vId;
 
   const versionLabel = getVersionLabel({
     lifecycleStatus: controller.versionDetail?.lifecycleStatus,
@@ -118,13 +107,9 @@ function IntentDraftReadContent({
       <Pill tone={versionLabelTone(versionLabel)}>{versionLabel}</Pill>
       {controller.isRevisionDraft && (
         <IntentRevisionDraftActions
-          summary={
-            summaryState.status === "ready" ? summaryState.data : undefined
-          }
+          summary={summaryState.status === "ready" ? summaryState.data : undefined}
           isSummaryLoading={summaryState.status === "loading"}
-          summaryError={
-            summaryState.status === "error" ? summaryState.message : null
-          }
+          summaryError={summaryState.status === "error" ? summaryState.message : null}
           isPending={controller.isMutationPending}
           onRetrySummary={controller.retrySummary}
         />
@@ -172,9 +157,7 @@ function IntentDraftTwoPane({
   intentListState: IntentListState;
 }) {
   return (
-    <div
-      className={`${styles.twoPane} ${hasSelection ? styles.hasSelection : ""}`}
-    >
+    <div className={`${styles.twoPane} ${hasSelection ? styles.hasSelection : ""}`}>
       <div className={styles.listSlot}>
         <IntentTreePanel
           intentListState={intentListState}
@@ -214,24 +197,16 @@ function IntentDetailSlot({
     intentId: number;
     versionId: number;
   } | null>(null);
-  const isEditingIntent =
-    editingTarget?.intentId === iId && editingTarget.versionId === vId;
+  const isEditingIntent = editingTarget?.intentId === iId && editingTarget.versionId === vId;
   const setEditingIntent = useCallback(
     (next: boolean) => {
-      setEditingTarget(
-        next && iId !== null ? { intentId: iId, versionId: vId } : null,
-      );
+      setEditingTarget(next && iId !== null ? { intentId: iId, versionId: vId } : null);
     },
     [iId, vId],
   );
 
   const renderMatchedWorkflows = (detail: IntentDetail) => (
-    <MatchedWorkflowSection
-      wsId={wsId}
-      packId={pId}
-      versionId={vId}
-      intentId={detail.id ?? null}
-    />
+    <MatchedWorkflowSection wsId={wsId} packId={pId} versionId={vId} intentId={detail.id ?? null} />
   );
 
   if (iId === null) {
@@ -292,9 +267,7 @@ function IntentDetailSlot({
           intentCode={detail.intentCode ?? null}
           onChange={controller.setSelectedIntentCode}
         />
-        {controller.recoveryVersionId === vId ? (
-          <IntentRevisionRecoveryBanner />
-        ) : null}
+        {controller.recoveryVersionId === vId ? <IntentRevisionRecoveryBanner /> : null}
       </>
     ),
     beforeJsonCards: () =>
@@ -344,18 +317,12 @@ function IntentDetailSlot({
 
   return (
     <div className={styles.detailSlot}>
-      <IntentDetailPanel {...detailSharedProps}>
-        {renderRevisionEditor}
-      </IntentDetailPanel>
+      <IntentDetailPanel {...detailSharedProps}>{renderRevisionEditor}</IntentDetailPanel>
     </div>
   );
 }
 
-function PendingNavigationDialog({
-  controller,
-}: {
-  controller: IntentDraftController;
-}) {
+function PendingNavigationDialog({ controller }: { controller: IntentDraftController }) {
   return (
     <AlertDialog
       open={controller.pendingNavigation !== null}
@@ -383,11 +350,7 @@ function PendingNavigationDialog({
   );
 }
 
-function ExistingDraftDialog({
-  controller,
-}: {
-  controller: IntentDraftController;
-}) {
+function ExistingDraftDialog({ controller }: { controller: IntentDraftController }) {
   const target = controller.existingDraftTarget;
 
   return (
@@ -409,10 +372,7 @@ function ExistingDraftDialog({
           >
             취소
           </Button>
-          <Button
-            type="button"
-            onClick={controller.confirmExistingDraftNavigation}
-          >
+          <Button type="button" onClick={controller.confirmExistingDraftNavigation}>
             이동
           </Button>
         </AlertDialogFooter>
@@ -459,9 +419,7 @@ function getVersionLabel({
   return "확인 중";
 }
 
-function getExistingDraftDescription(
-  target: ExistingDraftTarget | null,
-): string {
+function getExistingDraftDescription(target: ExistingDraftTarget | null): string {
   return target?.sourceType === "INTENT_REVISION"
     ? "기존 Intent 수정 Draft로 이동하거나 Domain Pack 화면에서 Draft를 적용 또는 폐기해 주세요."
     : "기존 Draft로 이동하거나 Domain Pack 화면에서 Draft를 적용 또는 폐기해 주세요.";

--- a/frontend/src/pages/domain-pack/ui/PackWorkflowListPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/PackWorkflowListPage.tsx
@@ -29,8 +29,7 @@ export function PackWorkflowListPage() {
     enabled: wsId !== null && pId !== null && vId !== null,
   }).data;
   const packName = packDetail?.name ?? `PACK · ${pId ?? "?"}`;
-  const versionNo =
-    packDetail?.versions?.find((v) => v.versionId === vId)?.versionNo ?? vId ?? 0;
+  const versionNo = packDetail?.versions?.find((v) => v.versionId === vId)?.versionNo ?? vId ?? 0;
 
   const query = useListWorkflows(wsId ?? 0, pId ?? 0, vId ?? 0, undefined, {
     query: { enabled },
@@ -67,7 +66,9 @@ export function PackWorkflowListPage() {
   });
 
   const handleOpen = (entry: WorkspaceWorkflowEntry) => {
-    navigate(domainPackSectionPath(wsId, entry.packId, entry.versionId, "workflows", entry.workflowId));
+    navigate(
+      domainPackSectionPath(wsId, entry.packId, entry.versionId, "workflows", entry.workflowId),
+    );
   };
 
   return (

--- a/frontend/src/pages/domain-pack/ui/PolicyDraftReadPage.test.tsx
+++ b/frontend/src/pages/domain-pack/ui/PolicyDraftReadPage.test.tsx
@@ -78,10 +78,9 @@ describe("PolicyDraftReadPage", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "select policy" }));
 
-    expect(navigate).toHaveBeenCalledWith(
-      "/workspaces/1/domain-packs/7/policies/4?versionId=101",
-      { replace: true },
-    );
+    expect(navigate).toHaveBeenCalledWith("/workspaces/1/domain-packs/7/policies/4?versionId=101", {
+      replace: true,
+    });
   });
 
   it("잘못된 URL 파라미터면 alert를 표시한다", () => {

--- a/frontend/src/pages/domain-pack/ui/PolicyDraftReadPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/PolicyDraftReadPage.tsx
@@ -36,8 +36,7 @@ export function PolicyDraftReadPage() {
     enabled: wsId !== null && pId !== null && vId !== null && !hasInvalidPolicyId,
   }).data;
   const packName = packDetail?.name ?? `PACK · ${pId ?? "?"}`;
-  const versionNo =
-    packDetail?.versions?.find((v) => v.versionId === vId)?.versionNo ?? vId ?? 0;
+  const versionNo = packDetail?.versions?.find((v) => v.versionId === vId)?.versionNo ?? vId ?? 0;
 
   if (wsId === null || pId === null || vId === null || hasInvalidPolicyId) {
     return (

--- a/frontend/src/pages/domain-pack/ui/RiskDraftReadPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/RiskDraftReadPage.tsx
@@ -36,8 +36,7 @@ export function RiskDraftReadPage() {
     enabled: wsId !== null && pId !== null && vId !== null && !hasInvalidRiskId,
   }).data;
   const packName = packDetail?.name ?? `PACK · ${pId ?? "?"}`;
-  const versionNo =
-    packDetail?.versions?.find((v) => v.versionId === vId)?.versionNo ?? vId ?? 0;
+  const versionNo = packDetail?.versions?.find((v) => v.versionId === vId)?.versionNo ?? vId ?? 0;
 
   if (wsId === null || pId === null || vId === null || hasInvalidRiskId) {
     return (

--- a/frontend/src/pages/domain-pack/ui/SlotDraftReadPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/SlotDraftReadPage.tsx
@@ -23,11 +23,11 @@ export function SlotDraftReadPage() {
   const sId = slotId ? parseRouteId(slotId) : null;
 
   const packDetail = usePackDetail(wsId ?? 0, pId ?? 0, {
-    enabled: wsId !== null && pId !== null && vId !== null && (slotId === undefined || sId !== null),
+    enabled:
+      wsId !== null && pId !== null && vId !== null && (slotId === undefined || sId !== null),
   }).data;
   const packName = packDetail?.name ?? `PACK · ${pId ?? "?"}`;
-  const versionNo =
-    packDetail?.versions?.find((v) => v.versionId === vId)?.versionNo ?? vId ?? 0;
+  const versionNo = packDetail?.versions?.find((v) => v.versionId === vId)?.versionNo ?? vId ?? 0;
 
   if (wsId === null || pId === null || vId === null || (slotId !== undefined && sId === null)) {
     return (

--- a/frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.test.tsx
+++ b/frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.test.tsx
@@ -11,8 +11,7 @@ const mockListWorkflows = vi.fn();
 const mockToastSuccess = vi.fn();
 const mockToastError = vi.fn();
 vi.mock("@/entities/workflow", () => ({
-  useGetWorkflowDefinition: (...args: unknown[]) =>
-    mockUseGetWorkflowDefinition(...args),
+  useGetWorkflowDefinition: (...args: unknown[]) => mockUseGetWorkflowDefinition(...args),
 }));
 
 vi.mock("@/features/domain-pack-summary-read", () => ({
@@ -23,11 +22,7 @@ vi.mock("@/features/update-workflow", () => ({
   InlineWorkflowEditor: vi.fn(({ workflow, onClose, onDirtyChange }) => (
     <div data-testid="inline-editor">
       editing {workflow.workflowCode}
-      <button
-        type="button"
-        data-testid="editor-dirty"
-        onClick={() => onDirtyChange(true)}
-      >
+      <button type="button" data-testid="editor-dirty" onClick={() => onDirtyChange(true)}>
         dirty
       </button>
       <button type="button" data-testid="editor-close" onClick={onClose}>
@@ -44,13 +39,7 @@ vi.mock("@/features/workflow-viewer/ui/GraphViewer", () => ({
 }));
 
 vi.mock("@/widgets/ostone-shell", () => ({
-  OstoneShell: ({
-    children,
-    crumbs,
-  }: {
-    children: React.ReactNode;
-    crumbs: string[];
-  }) => (
+  OstoneShell: ({ children, crumbs }: { children: React.ReactNode; crumbs: string[] }) => (
     <div>
       <div data-testid="crumbs">{crumbs.join(" / ")}</div>
       {children}
@@ -59,8 +48,7 @@ vi.mock("@/widgets/ostone-shell", () => ({
 }));
 vi.mock("@/features/intent-revision-draft", () => ({
   intentRevisionDraftApi: {
-    createRevisionDraft: (...args: unknown[]) =>
-      mockCreateRevisionDraft(...args),
+    createRevisionDraft: (...args: unknown[]) => mockCreateRevisionDraft(...args),
   },
 }));
 vi.mock(
@@ -76,14 +64,11 @@ vi.mock("sonner", () => ({
   },
 }));
 
-const ROUTE =
-  "/workspaces/:workspaceId/domain-packs/:packId/workflows/:workflowId?";
+const ROUTE = "/workspaces/:workspaceId/domain-packs/:packId/workflows/:workflowId?";
 
 function LocationProbe() {
   const location = useLocation();
-  return (
-    <div data-testid="location">{`${location.pathname}${location.search}`}</div>
-  );
+  return <div data-testid="location">{`${location.pathname}${location.search}`}</div>;
 }
 
 function renderPage(path: string, state?: unknown) {
@@ -137,9 +122,7 @@ describe("WorkflowDraftReadPage", () => {
   it("유효하지 않은 URL 파라미터는 에러 메시지를 보여준다", () => {
     mockUseGetWorkflowDefinition.mockReturnValue({ isLoading: false });
     renderPage("/workspaces/abc/domain-packs/2/workflows?versionId=3");
-    expect(screen.getByRole("alert")).toHaveTextContent(
-      "잘못된 URL 파라미터입니다.",
-    );
+    expect(screen.getByRole("alert")).toHaveTextContent("잘못된 URL 파라미터입니다.");
   });
 
   it("workflowId가 없으면 좌측 사이드바에서 선택하라는 안내를 표시한다", () => {
@@ -183,14 +166,10 @@ describe("WorkflowDraftReadPage", () => {
       },
     });
     renderPage("/workspaces/1/domain-packs/2/workflows/10?versionId=3");
-    expect(screen.getByTestId("workflow-detail-title")).toHaveTextContent(
-      "환불 처리",
-    );
+    expect(screen.getByTestId("workflow-detail-title")).toHaveTextContent("환불 처리");
     expect(screen.queryByText("refund.standard")).not.toBeInTheDocument();
     expect(screen.getByText("2 nodes")).toBeInTheDocument();
-    expect(screen.getByTestId("graph-viewer")).toHaveTextContent(
-      "graph nodes: 2",
-    );
+    expect(screen.getByTestId("graph-viewer")).toHaveTextContent("graph nodes: 2");
   });
 
   it("graphJson이 없으면 빈 그래프 안내를 표시한다", () => {
@@ -232,9 +211,7 @@ describe("WorkflowDraftReadPage", () => {
     renderPage("/workspaces/1/domain-packs/2/workflows/10?versionId=3");
     expect(screen.queryByTestId("inline-editor")).not.toBeInTheDocument();
     fireEvent.click(screen.getByTestId("edit-toggle"));
-    expect(screen.getByTestId("inline-editor")).toHaveTextContent(
-      "editing refund.standard",
-    );
+    expect(screen.getByTestId("inline-editor")).toHaveTextContent("editing refund.standard");
     expect(mockCreateRevisionDraft).not.toHaveBeenCalled();
   });
 
@@ -242,9 +219,7 @@ describe("WorkflowDraftReadPage", () => {
     mockUsePackDetail.mockReturnValue({
       data: {
         name: "CS Pack",
-        versions: [
-          { versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" },
-        ],
+        versions: [{ versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" }],
       },
       refetch: vi.fn().mockResolvedValue({
         data: {
@@ -285,9 +260,7 @@ describe("WorkflowDraftReadPage", () => {
     mockUsePackDetail.mockReturnValue({
       data: {
         name: "CS Pack",
-        versions: [
-          { versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" },
-        ],
+        versions: [{ versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" }],
       },
       refetch: vi.fn(),
     });
@@ -318,9 +291,7 @@ describe("WorkflowDraftReadPage", () => {
     mockUsePackDetail.mockReturnValue({
       data: {
         name: "CS Pack",
-        versions: [
-          { versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" },
-        ],
+        versions: [{ versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" }],
       },
       refetch: vi.fn().mockResolvedValue({
         data: {
@@ -363,9 +334,7 @@ describe("WorkflowDraftReadPage", () => {
     mockUsePackDetail.mockReturnValue({
       data: {
         name: "CS Pack",
-        versions: [
-          { versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" },
-        ],
+        versions: [{ versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" }],
       },
       refetch: vi.fn().mockResolvedValue({
         data: {
@@ -396,9 +365,7 @@ describe("WorkflowDraftReadPage", () => {
     renderPage("/workspaces/1/domain-packs/2/workflows/10?versionId=3");
     fireEvent.click(screen.getByTestId("edit-toggle"));
 
-    expect(
-      await screen.findByText("진행 중인 Draft가 있습니다"),
-    ).toBeInTheDocument();
+    expect(await screen.findByText("진행 중인 Draft가 있습니다")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "기존 Draft로 이동" }));
     await waitFor(() =>
       expect(screen.getByTestId("location")).toHaveTextContent(
@@ -411,15 +378,11 @@ describe("WorkflowDraftReadPage", () => {
     mockUsePackDetail.mockReturnValue({
       data: {
         name: "CS Pack",
-        versions: [
-          { versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" },
-        ],
+        versions: [{ versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" }],
       },
       refetch: vi.fn().mockResolvedValue({
         data: {
-          versions: [
-            { versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" },
-          ],
+          versions: [{ versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" }],
         },
       }),
     });
@@ -445,18 +408,14 @@ describe("WorkflowDraftReadPage", () => {
         "진행 중인 Draft를 확인할 수 없습니다. Domain Pack 화면에서 상태를 확인해 주세요.",
       ),
     );
-    expect(
-      screen.queryByText("진행 중인 Draft가 있습니다"),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText("진행 중인 Draft가 있습니다")).not.toBeInTheDocument();
   });
 
   it("기존 DRAFT 충돌 후 같은 workflow를 찾지 못하면 이동 dialog를 열지 않는다", async () => {
     mockUsePackDetail.mockReturnValue({
       data: {
         name: "CS Pack",
-        versions: [
-          { versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" },
-        ],
+        versions: [{ versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" }],
       },
       refetch: vi.fn().mockResolvedValue({
         data: {
@@ -492,22 +451,16 @@ describe("WorkflowDraftReadPage", () => {
         "기존 Draft에서 같은 워크플로우를 찾지 못했습니다.",
       ),
     );
-    expect(
-      screen.queryByText("진행 중인 Draft가 있습니다"),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText("진행 중인 Draft가 있습니다")).not.toBeInTheDocument();
   });
 
   it("기존 DRAFT 충돌 후 pack refetch가 실패하면 에러를 안내하고 dialog를 열지 않는다", async () => {
-    const consoleError = vi
-      .spyOn(console, "error")
-      .mockImplementation(() => undefined);
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
     try {
       mockUsePackDetail.mockReturnValue({
         data: {
           name: "CS Pack",
-          versions: [
-            { versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" },
-          ],
+          versions: [{ versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" }],
         },
         refetch: vi.fn().mockRejectedValue(new Error("refetch failed")),
       });
@@ -528,32 +481,24 @@ describe("WorkflowDraftReadPage", () => {
       renderPage("/workspaces/1/domain-packs/2/workflows/10?versionId=3");
       fireEvent.click(screen.getByTestId("edit-toggle"));
 
-      await waitFor(() =>
-        expect(mockToastError).toHaveBeenCalledWith("refetch failed"),
-      );
+      await waitFor(() => expect(mockToastError).toHaveBeenCalledWith("refetch failed"));
       expect(consoleError).toHaveBeenCalledWith(
         "Failed to resolve existing workflow draft",
         expect.any(Error),
       );
-      expect(
-        screen.queryByText("진행 중인 Draft가 있습니다"),
-      ).not.toBeInTheDocument();
+      expect(screen.queryByText("진행 중인 Draft가 있습니다")).not.toBeInTheDocument();
     } finally {
       consoleError.mockRestore();
     }
   });
 
   it("기존 DRAFT 충돌 후 workflow 목록 조회가 실패하면 에러를 안내한다", async () => {
-    const consoleError = vi
-      .spyOn(console, "error")
-      .mockImplementation(() => undefined);
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
     try {
       mockUsePackDetail.mockReturnValue({
         data: {
           name: "CS Pack",
-          versions: [
-            { versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" },
-          ],
+          versions: [{ versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" }],
         },
         refetch: vi.fn().mockResolvedValue({
           data: {
@@ -582,9 +527,7 @@ describe("WorkflowDraftReadPage", () => {
       renderPage("/workspaces/1/domain-packs/2/workflows/10?versionId=3");
       fireEvent.click(screen.getByTestId("edit-toggle"));
 
-      await waitFor(() =>
-        expect(mockToastError).toHaveBeenCalledWith("workflow list failed"),
-      );
+      await waitFor(() => expect(mockToastError).toHaveBeenCalledWith("workflow list failed"));
       expect(consoleError).toHaveBeenCalled();
     } finally {
       consoleError.mockRestore();
@@ -607,9 +550,7 @@ describe("WorkflowDraftReadPage", () => {
     fireEvent.click(screen.getByTestId("editor-dirty"));
     fireEvent.click(screen.getByTestId("editor-close"));
 
-    expect(
-      await screen.findByText("변경 내역을 버릴까요?"),
-    ).toBeInTheDocument();
+    expect(await screen.findByText("변경 내역을 버릴까요?")).toBeInTheDocument();
     expect(screen.getByTestId("inline-editor")).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "계속 편집" }));
@@ -637,9 +578,7 @@ describe("WorkflowDraftReadPage", () => {
     fireEvent.click(screen.getByTestId("editor-dirty"));
     fireEvent.click(screen.getByRole("button", { name: "목록" }));
 
-    expect(
-      await screen.findByText("변경 내역을 버릴까요?"),
-    ).toBeInTheDocument();
+    expect(await screen.findByText("변경 내역을 버릴까요?")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "변경 내역 버리기" }));
 
     await waitFor(() =>
@@ -677,18 +616,12 @@ describe("WorkflowDraftReadPage", () => {
     mockUsePackDetail.mockReturnValue({
       data: {
         name: "CS Pack",
-        versions: [
-          { versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" },
-        ],
+        versions: [{ versionId: 3, versionNo: 1, lifecycleStatus: "PUBLISHED" }],
       },
       refetch: vi.fn(),
     });
     mockCreateRevisionDraft.mockRejectedValue(
-      new ApiRequestError(
-        400,
-        "DOMAIN_PACK_VERSION_NOT_CURRENT",
-        "현재 운영 버전이 아닙니다.",
-      ),
+      new ApiRequestError(400, "DOMAIN_PACK_VERSION_NOT_CURRENT", "현재 운영 버전이 아닙니다."),
     );
     mockUseGetWorkflowDefinition.mockReturnValue({
       isLoading: false,
@@ -704,9 +637,7 @@ describe("WorkflowDraftReadPage", () => {
     renderPage("/workspaces/1/domain-packs/2/workflows/10?versionId=3");
     fireEvent.click(screen.getByTestId("edit-toggle"));
 
-    await waitFor(() =>
-      expect(mockToastError).toHaveBeenCalledWith("현재 운영 버전이 아닙니다."),
-    );
+    await waitFor(() => expect(mockToastError).toHaveBeenCalledWith("현재 운영 버전이 아닙니다."));
   });
 
   it("편집 모드에서는 상단 보기 버튼을 렌더하지 않는다", () => {
@@ -765,9 +696,7 @@ describe("WorkflowDraftReadPage", () => {
     renderPage("/workspaces/1/domain-packs/2/workflows/10?versionId=3");
     // legacy panels gone
     expect(screen.queryByText(/검토 중 · v0\.4/)).not.toBeInTheDocument();
-    expect(
-      screen.queryByText("Card payment refund flow"),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Card payment refund flow")).not.toBeInTheDocument();
     expect(screen.queryByText("Selected node")).not.toBeInTheDocument();
     expect(screen.queryByText(/Edit graph/)).not.toBeInTheDocument();
     // tab list gone

--- a/frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.tsx
@@ -1,18 +1,10 @@
 import { type ReactNode, useEffect, useMemo, useState } from "react";
-import {
-  useLocation,
-  useNavigate,
-  useParams,
-  useSearchParams,
-} from "react-router-dom";
+import { useLocation, useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { toast } from "sonner";
 import { usePackDetail } from "@/features/domain-pack-summary-read";
 import { InlineWorkflowEditor } from "@/features/update-workflow";
 import { intentRevisionDraftApi } from "@/features/intent-revision-draft";
-import {
-  buildDomainPackCrumbs,
-  domainPackSectionPath,
-} from "@/shared/lib/domainPackRoutes";
+import { buildDomainPackCrumbs, domainPackSectionPath } from "@/shared/lib/domainPackRoutes";
 import { parseRouteId } from "@/shared/lib/parseRouteId";
 import { OstoneShell } from "@/widgets/ostone-shell";
 import { Pill, Mono, Icon } from "@/shared/ui/ostone/atoms";
@@ -78,17 +70,14 @@ export function WorkflowDraftReadPage() {
   const vId = parseRouteId(search.get("versionId") ?? undefined);
   const wfId = workflowId ? parseRouteId(workflowId) : null;
 
-  const enabled =
-    wsId !== null && pId !== null && vId !== null && wfId !== null;
+  const enabled = wsId !== null && pId !== null && vId !== null && wfId !== null;
 
   const packQuery = usePackDetail(wsId ?? 0, pId ?? 0, {
     enabled: wsId !== null && pId !== null && vId !== null && wfId !== null,
   });
   const packDetail = packQuery.data;
   const packName = packDetail?.name ?? `PACK · ${pId ?? "?"}`;
-  const selectedVersion = packDetail?.versions?.find(
-    (v) => v.versionId === vId,
-  );
+  const selectedVersion = packDetail?.versions?.find((v) => v.versionId === vId);
   const versionNo = selectedVersion?.versionNo ?? vId ?? 0;
   const lifecycleStatus = selectedVersion?.lifecycleStatus ?? null;
   const workflowReturnTo = readWorkflowReturnTo(location.state);
@@ -148,32 +137,17 @@ export function WorkflowDraftReadPage() {
     setPendingClose(() => next);
   };
 
-  const navigateToWorkflow = (
-    versionId: number,
-    targetWorkflowId: number | null,
-  ) => {
+  const navigateToWorkflow = (versionId: number, targetWorkflowId: number | null) => {
     navigate(
-      domainPackSectionPath(
-        wsId,
-        pId,
-        versionId,
-        "workflows",
-        targetWorkflowId ?? undefined,
-      ),
+      domainPackSectionPath(wsId, pId, versionId, "workflows", targetWorkflowId ?? undefined),
       { replace: true },
     );
   };
 
-  const findWorkflowIdByCode = async (
-    versionId: number,
-    workflowCode: string,
-  ) => {
+  const findWorkflowIdByCode = async (versionId: number, workflowCode: string) => {
     const response = await listWorkflows(wsId, pId, versionId);
-    const workflows = (unwrapApiResponse(response) ??
-      []) as WorkflowDefinitionSummary[];
-    const target = workflows.find(
-      (entry) => entry.workflowCode === workflowCode,
-    );
+    const workflows = (unwrapApiResponse(response) ?? []) as WorkflowDefinitionSummary[];
+    const target = workflows.find((entry) => entry.workflowCode === workflowCode);
     return typeof target?.id === "number" ? target.id : null;
   };
 
@@ -181,8 +155,7 @@ export function WorkflowDraftReadPage() {
     try {
       const refetched = await packQuery.refetch();
       const drafts = (refetched.data?.versions ?? []).filter(
-        (version) =>
-          version.lifecycleStatus === "DRAFT" && version.versionId != null,
+        (version) => version.lifecycleStatus === "DRAFT" && version.versionId != null,
       );
 
       if (drafts.length !== 1 || drafts[0].versionId == null) {
@@ -193,10 +166,7 @@ export function WorkflowDraftReadPage() {
       }
 
       const draftVersionId = drafts[0].versionId;
-      const draftWorkflowId = await findWorkflowIdByCode(
-        draftVersionId,
-        workflowCode,
-      );
+      const draftWorkflowId = await findWorkflowIdByCode(draftVersionId, workflowCode);
 
       if (draftWorkflowId == null) {
         toast.error("기존 Draft에서 같은 워크플로우를 찾지 못했습니다.");
@@ -221,12 +191,9 @@ export function WorkflowDraftReadPage() {
   const handleBackToList = () => {
     guardEditorClose(() => {
       closeEditor();
-      navigate(
-        workflowReturnTo ?? domainPackSectionPath(wsId, pId, vId, "workflows"),
-        {
-          replace: true,
-        },
-      );
+      navigate(workflowReturnTo ?? domainPackSectionPath(wsId, pId, vId, "workflows"), {
+        replace: true,
+      });
     });
   };
 
@@ -238,21 +205,15 @@ export function WorkflowDraftReadPage() {
     }
 
     if (!workflow.workflowCode) {
-      toast.error(
-        "워크플로우 코드를 확인할 수 없어 수정 초안을 만들 수 없습니다.",
-      );
+      toast.error("워크플로우 코드를 확인할 수 없어 수정 초안을 만들 수 없습니다.");
       return;
     }
 
     setCreatingDraft(true);
     try {
-      const { draftVersionId } =
-        await intentRevisionDraftApi.createRevisionDraft(wsId, pId, vId);
+      const { draftVersionId } = await intentRevisionDraftApi.createRevisionDraft(wsId, pId, vId);
       await packQuery.refetch();
-      const draftWorkflowId = await findWorkflowIdByCode(
-        draftVersionId,
-        workflow.workflowCode,
-      );
+      const draftWorkflowId = await findWorkflowIdByCode(draftVersionId, workflow.workflowCode);
       if (draftWorkflowId === null) {
         toast.error("수정 초안에서 같은 워크플로우를 찾지 못했습니다.");
         navigateToWorkflow(draftVersionId, null);
@@ -263,18 +224,12 @@ export function WorkflowDraftReadPage() {
       setEditDirty(false);
       toast.success("워크플로우 수정 초안이 생성되었습니다.");
     } catch (error) {
-      if (
-        error instanceof ApiRequestError &&
-        error.code === "DOMAIN_PACK_DRAFT_ALREADY_EXISTS"
-      ) {
+      if (error instanceof ApiRequestError && error.code === "DOMAIN_PACK_DRAFT_ALREADY_EXISTS") {
         await resolveExistingDraft(workflow.workflowCode);
         return;
       }
       toast.error(
-        resolveWorkflowActionErrorMessage(
-          error,
-          "워크플로우 수정 초안 생성에 실패했습니다.",
-        ),
+        resolveWorkflowActionErrorMessage(error, "워크플로우 수정 초안 생성에 실패했습니다."),
       );
     } finally {
       setCreatingDraft(false);
@@ -303,8 +258,7 @@ export function WorkflowDraftReadPage() {
     packName,
     versionNo,
     section: { label: "WORKFLOWS", path: "workflows" },
-    selectedLabel:
-      workflow?.workflowCode ?? (wfId !== null ? `#${wfId}` : null),
+    selectedLabel: workflow?.workflowCode ?? (wfId !== null ? `#${wfId}` : null),
   });
 
   let graphContent: ReactNode;
@@ -322,10 +276,7 @@ export function WorkflowDraftReadPage() {
     );
   } else if (graph) {
     graphContent = (
-      <div
-        data-testid="workflow-graph-viewer"
-        style={{ width: "100%", height: "100%" }}
-      >
+      <div data-testid="workflow-graph-viewer" style={{ width: "100%", height: "100%" }}>
         <GraphViewer graph={graph} />
       </div>
     );
@@ -343,26 +294,16 @@ export function WorkflowDraftReadPage() {
         <div className={styles.detailHeader}>
           <div className={styles.titleGroup}>
             <div className={styles.titleStack}>
-              <h2
-                data-testid="workflow-detail-title"
-                className={styles.detailTitle}
-              >
-                {workflow?.name ||
-                  (query.isLoading ? "워크플로우 로드 중..." : "워크플로우")}
+              <h2 data-testid="workflow-detail-title" className={styles.detailTitle}>
+                {workflow?.name || (query.isLoading ? "워크플로우 로드 중..." : "워크플로우")}
               </h2>
               {workflow?.description && (
-                <p className={styles.detailDescription}>
-                  {workflow.description}
-                </p>
+                <p className={styles.detailDescription}>{workflow.description}</p>
               )}
             </div>
-            {workflow && lifecycleStatus && (
-              <Pill tone="signal">{lifecycleStatus}</Pill>
-            )}
+            {workflow && lifecycleStatus && <Pill tone="signal">{lifecycleStatus}</Pill>}
             {workflow && isEditing && <Pill tone="ink">EDITING</Pill>}
-            {workflow && (
-              <Mono className={styles.nodeCount}>{nodeCount} nodes</Mono>
-            )}
+            {workflow && <Mono className={styles.nodeCount}>{nodeCount} nodes</Mono>}
           </div>
 
           <div className={styles.headerActions}>
@@ -393,15 +334,9 @@ export function WorkflowDraftReadPage() {
           </div>
         </div>
 
-        <div
-          className={styles.canvasFrame}
-          data-editing={isEditing ? "true" : "false"}
-        >
+        <div className={styles.canvasFrame} data-editing={isEditing ? "true" : "false"}>
           {!enabled && (
-            <div
-              data-testid="workflow-select-empty"
-              className={styles.centerState}
-            >
+            <div data-testid="workflow-select-empty" className={styles.centerState}>
               좌측 사이드바에서 워크플로우를 선택하세요.
             </div>
           )}
@@ -422,11 +357,7 @@ export function WorkflowDraftReadPage() {
             </div>
           )}
 
-          {enabled &&
-            !query.isLoading &&
-            !query.isError &&
-            workflow &&
-            graphContent}
+          {enabled && !query.isLoading && !query.isError && workflow && graphContent}
         </div>
       </div>
       <AlertDialog
@@ -441,11 +372,7 @@ export function WorkflowDraftReadPage() {
             저장하지 않고 이동하면 현재 편집 중인 변경 내역이 버려집니다.
           </AlertDialogDescription>
           <AlertDialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => setPendingClose(null)}
-            >
+            <Button type="button" variant="outline" onClick={() => setPendingClose(null)}>
               계속 편집
             </Button>
             <Button type="button" onClick={confirmPendingClose}>
@@ -463,15 +390,11 @@ export function WorkflowDraftReadPage() {
         <AlertDialogContent size="sm">
           <AlertDialogTitle>진행 중인 Draft가 있습니다</AlertDialogTitle>
           <AlertDialogDescription>
-            새 Draft를 만들 수 없습니다. 기존 Draft에서 계속 편집하거나, Domain
-            Pack 화면에서 Draft를 적용 또는 폐기한 뒤 다시 시도하세요.
+            새 Draft를 만들 수 없습니다. 기존 Draft에서 계속 편집하거나, Domain Pack 화면에서
+            Draft를 적용 또는 폐기한 뒤 다시 시도하세요.
           </AlertDialogDescription>
           <AlertDialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => setExistingDraftTarget(null)}
-            >
+            <Button type="button" variant="outline" onClick={() => setExistingDraftTarget(null)}>
               취소
             </Button>
             <Button type="button" onClick={confirmExistingDraftNavigation}>
@@ -490,10 +413,7 @@ function readWorkflowReturnTo(state: unknown): string | null {
   return typeof value === "string" && value.startsWith("/") ? value : null;
 }
 
-function resolveWorkflowActionErrorMessage(
-  error: unknown,
-  fallback: string,
-): string {
+function resolveWorkflowActionErrorMessage(error: unknown, fallback: string): string {
   if (error instanceof ApiRequestError && error.message) {
     return error.message;
   }

--- a/frontend/src/pages/domain-pack/ui/WorkflowGraphViewerPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/WorkflowGraphViewerPage.tsx
@@ -34,8 +34,7 @@ export function WorkflowGraphViewerPage() {
     enabled: wsId !== null && pkId !== null,
   }).data;
   const packName = packDetail?.name ?? `PACK · ${pkId ?? "?"}`;
-  const versionNo =
-    packDetail?.versions?.find((v) => v.versionId === vsId)?.versionNo ?? vsId ?? 0;
+  const versionNo = packDetail?.versions?.find((v) => v.versionId === vsId)?.versionNo ?? vsId ?? 0;
 
   const rawGraph = data?.graphJson;
   const graph = useMemo<WorkflowGraph | null>(() => {
@@ -66,8 +65,7 @@ export function WorkflowGraphViewerPage() {
           packName,
           versionNo,
           section: { label: "WORKFLOWS", path: "workflows" },
-          selectedLabel:
-            data?.workflowCode ?? (wfId !== null ? `#${wfId} GRAPH` : "GRAPH"),
+          selectedLabel: data?.workflowCode ?? (wfId !== null ? `#${wfId} GRAPH` : "GRAPH"),
         })
       : ["Domain Packs", "Workflow Graph"];
 

--- a/frontend/src/pages/upload/ui/UploadPage.tsx
+++ b/frontend/src/pages/upload/ui/UploadPage.tsx
@@ -58,9 +58,9 @@ export const UploadPage: React.FC = () => {
             marginTop: 8,
           }}
         >
-          업로드한 데이터셋 1개당 도메인 팩 초안 1개를 생성하고, 여러 상담에서 추출한 intent,
-          slot, policy, risk, workflow를 그 안에 모읍니다. 파이프라인은 6단계로 구성되며 각
-          단계의 진행 상황을 실시간으로 모니터링할 수 있습니다.
+          업로드한 데이터셋 1개당 도메인 팩 초안 1개를 생성하고, 여러 상담에서 추출한 intent, slot,
+          policy, risk, workflow를 그 안에 모읍니다. 파이프라인은 6단계로 구성되며 각 단계의 진행
+          상황을 실시간으로 모니터링할 수 있습니다.
         </p>
       </div>
 

--- a/frontend/src/pages/user-chat/ui/ChatConversationScreen.test.tsx
+++ b/frontend/src/pages/user-chat/ui/ChatConversationScreen.test.tsx
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ChatMessage, DemoChatSession } from "@/entities/chat";
+import { ChatConversationScreen } from "./ChatConversationScreen";
+
+function buildSession(overrides: Partial<DemoChatSession> = {}): DemoChatSession {
+  const baseMessages: ChatMessage[] = [
+    {
+      id: "1",
+      sessionId: 77,
+      content: "안녕하세요, 김민지님.",
+      senderType: "BOT",
+      createdAt: "2026-05-22T00:00:00Z",
+    },
+    {
+      id: "2",
+      sessionId: 77,
+      content: "결제 오류 환불 진행 상태 알려주세요.",
+      senderType: "USER",
+      senderName: "김민지",
+      createdAt: "2026-05-22T00:00:10Z",
+    },
+  ];
+  return {
+    id: "77",
+    status: "OPEN",
+    startedAt: "2026-05-22T00:00:00Z",
+    messages: baseMessages,
+    ...overrides,
+  };
+}
+
+function setup(overrides: Partial<Parameters<typeof ChatConversationScreen>[0]> = {}) {
+  const props: Parameters<typeof ChatConversationScreen>[0] = {
+    session: buildSession(),
+    customerName: "김민지",
+    isSending: false,
+    messageError: null,
+    onSend: vi.fn(),
+    ...overrides,
+  };
+  render(<ChatConversationScreen {...props} />);
+  return props;
+}
+
+describe("ChatConversationScreen", () => {
+  it("renders ChatHeader 와 meta strip, message list 를 포함한다", () => {
+    setup();
+
+    expect(screen.getByTestId("chat-header")).toBeInTheDocument();
+    expect(screen.getByTestId("chat-meta-strip")).toHaveTextContent("연결됨");
+    expect(screen.getByTestId("chat-meta-strip")).toHaveTextContent("김민지");
+  });
+
+  it("session.messages 의 본문이 화면에 렌더된다", () => {
+    setup();
+
+    expect(screen.getByText("안녕하세요, 김민지님.")).toBeInTheDocument();
+    expect(screen.getByText("결제 오류 환불 진행 상태 알려주세요.")).toBeInTheDocument();
+  });
+
+  it("messageError 가 주어지면 role=alert 으로 에러 배너를 렌더", () => {
+    setup({ messageError: "응답을 생성하지 못했습니다." });
+
+    const alert = screen.getByTestId("chat-message-error");
+    expect(alert).toHaveAttribute("role", "alert");
+    expect(alert).toHaveTextContent("응답을 생성하지 못했습니다.");
+  });
+
+  it("MessageInput 의 send 클릭이 onSend 호출", () => {
+    const onSend = vi.fn();
+    setup({ onSend });
+
+    fireEvent.change(screen.getByLabelText("메시지 입력"), { target: { value: "Hello" } });
+    fireEvent.click(screen.getByLabelText("메시지 보내기"));
+    expect(onSend).toHaveBeenCalledWith("Hello");
+  });
+
+  it("isSending=true 면 MessageInput 이 disabled", () => {
+    setup({ isSending: true });
+
+    expect(screen.getByLabelText("메시지 입력")).toBeDisabled();
+    expect(screen.getByLabelText("메시지 보내기")).toBeDisabled();
+  });
+
+  it("ChatHeader 가 session.id 와 status 를 노출한다", () => {
+    setup({ session: buildSession({ id: "9", status: "CLOSED" }) });
+
+    expect(screen.getByTestId("chat-header-eyebrow")).toHaveTextContent("Session #9");
+    expect(screen.getByTestId("chat-header-status")).toHaveTextContent("CLOSED");
+  });
+});

--- a/frontend/src/pages/user-chat/ui/ChatConversationScreen.tsx
+++ b/frontend/src/pages/user-chat/ui/ChatConversationScreen.tsx
@@ -1,0 +1,98 @@
+import type { DemoChatSession } from "@/entities/chat";
+import { MessageInput, MessageList } from "@/features/user-chat";
+import { ChatHeader } from "./ChatHeader";
+
+interface ChatConversationScreenProps {
+  session: DemoChatSession;
+  customerName: string;
+  isSending: boolean;
+  messageError: string | null;
+  onSend: (content: string) => void;
+}
+
+export function ChatConversationScreen({
+  session,
+  customerName,
+  isSending,
+  messageError,
+  onSend,
+}: ChatConversationScreenProps) {
+  return (
+    <div
+      data-testid="chat-conversation-screen"
+      style={{
+        display: "flex",
+        height: "100vh",
+        minHeight: 0,
+        flexDirection: "column",
+        overflow: "hidden",
+        background: "var(--paper-2)",
+      }}
+    >
+      <ChatHeader customerName={customerName} sessionId={session.id} status={session.status} />
+      <div
+        data-testid="chat-meta-strip"
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          padding: "8px 20px",
+          background: "var(--paper-2)",
+          borderBottom: "1px solid var(--line-2)",
+          fontFamily: "var(--mono)",
+          fontSize: 10.5,
+          textTransform: "uppercase",
+          letterSpacing: "0.08em",
+          color: "var(--ink-3)",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <span
+            aria-hidden="true"
+            style={{
+              width: 6,
+              height: 6,
+              borderRadius: 999,
+              background: "var(--signal)",
+            }}
+          />
+          연결됨
+        </div>
+        <div>
+          {customerName} · {session.messages.length} messages
+        </div>
+      </div>
+      <div
+        style={{
+          flex: 1,
+          minHeight: 0,
+          background: "var(--paper-2)",
+        }}
+      >
+        <MessageList messages={session.messages} />
+      </div>
+      {messageError && (
+        <div
+          role="alert"
+          data-testid="chat-message-error"
+          style={{
+            borderTop: "1px solid var(--danger)",
+            background: "var(--danger-bg)",
+            padding: "10px 20px",
+            fontSize: 12.5,
+            color: "var(--danger)",
+            fontWeight: 500,
+          }}
+        >
+          {messageError}
+        </div>
+      )}
+      <MessageInput
+        onSend={(content) => {
+          onSend(content);
+        }}
+        disabled={isSending}
+      />
+    </div>
+  );
+}

--- a/frontend/src/pages/user-chat/ui/ChatEntryScreen.test.tsx
+++ b/frontend/src/pages/user-chat/ui/ChatEntryScreen.test.tsx
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { ChatEntryScreen } from "./ChatEntryScreen";
+
+function setup(overrides: Partial<Parameters<typeof ChatEntryScreen>[0]> = {}) {
+  const props: Parameters<typeof ChatEntryScreen>[0] = {
+    draftName: "",
+    nameError: null,
+    workspaceId: 2,
+    onDraftChange: vi.fn(),
+    onSubmit: vi.fn((event) => event.preventDefault()),
+    ...overrides,
+  };
+  render(<ChatEntryScreen {...props} />);
+  return props;
+}
+
+describe("ChatEntryScreen", () => {
+  it("렌더 시 split brand + form 구조를 노출한다", () => {
+    setup();
+
+    expect(screen.getByTestId("chat-entry-screen")).toBeInTheDocument();
+    expect(screen.getByTestId("chat-entry-brand")).toBeInTheDocument();
+    const form = screen.getByTestId("chat-entry-form");
+    expect(form).toHaveAttribute("aria-label", "채팅 사용자 이름 입력");
+  });
+
+  it("submit 버튼은 항상 enabled 이며 빈 이름 검증은 페이지 레벨에서 처리된다", () => {
+    setup();
+
+    expect(screen.getByTestId("chat-entry-submit")).toBeEnabled();
+  });
+
+  it("input 변경 시 onDraftChange 호출", () => {
+    const onDraftChange = vi.fn();
+    setup({ onDraftChange });
+
+    fireEvent.change(screen.getByTestId("chat-name-input"), { target: { value: "김" } });
+    expect(onDraftChange).toHaveBeenCalledWith("김");
+  });
+
+  it("submit 시 onSubmit 호출", () => {
+    const onSubmit = vi.fn((event: { preventDefault: () => void }) => event.preventDefault());
+    setup({ draftName: "김민지", onSubmit });
+
+    fireEvent.click(screen.getByTestId("chat-entry-submit"));
+    expect(onSubmit).toHaveBeenCalled();
+  });
+
+  it("nameError 가 있으면 role=alert 으로 메시지 렌더", () => {
+    setup({ nameError: "이름을 입력해 주세요." });
+
+    const error = screen.getByTestId("chat-name-error");
+    expect(error).toHaveAttribute("role", "alert");
+    expect(error).toHaveTextContent("이름을 입력해 주세요.");
+  });
+
+  it("workspaceId 가 brand 영역에 mono eyebrow 로 표기된다", () => {
+    setup({ workspaceId: 42 });
+
+    expect(screen.getByTestId("chat-entry-brand")).toHaveTextContent("Workspace #42");
+  });
+});

--- a/frontend/src/pages/user-chat/ui/ChatEntryScreen.tsx
+++ b/frontend/src/pages/user-chat/ui/ChatEntryScreen.tsx
@@ -214,6 +214,8 @@ export function ChatEntryScreen({
               onChange={(event) => onDraftChange(event.target.value)}
               placeholder="예: 김민지"
               autoComplete="name"
+              aria-invalid={Boolean(nameError)}
+              aria-describedby={nameError ? "chat-name-error" : undefined}
               style={{
                 width: "100%",
                 height: 48,
@@ -229,6 +231,7 @@ export function ChatEntryScreen({
             />
             {nameError && (
               <p
+                id="chat-name-error"
                 role="alert"
                 data-testid="chat-name-error"
                 style={{
@@ -253,7 +256,7 @@ export function ChatEntryScreen({
               background: "var(--ink)",
               color: "var(--paper)",
               fontSize: 14,
-              fontWeight: 600,
+              fontWeight: 540,
               letterSpacing: "-0.1px",
               cursor: "pointer",
               fontFamily: "inherit",

--- a/frontend/src/pages/user-chat/ui/ChatEntryScreen.tsx
+++ b/frontend/src/pages/user-chat/ui/ChatEntryScreen.tsx
@@ -1,0 +1,279 @@
+import type { FormEvent } from "react";
+
+interface ChatEntryScreenProps {
+  draftName: string;
+  nameError: string | null;
+  workspaceId: number;
+  onDraftChange: (value: string) => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+}
+
+export function ChatEntryScreen({
+  draftName,
+  nameError,
+  workspaceId,
+  onDraftChange,
+  onSubmit,
+}: ChatEntryScreenProps) {
+  return (
+    <div
+      data-testid="chat-entry-screen"
+      style={{
+        minHeight: "100vh",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        padding: "32px 20px",
+        background: "var(--paper-2)",
+        color: "var(--ink)",
+      }}
+    >
+      <form
+        onSubmit={onSubmit}
+        aria-label="채팅 사용자 이름 입력"
+        data-testid="chat-entry-form"
+        style={{
+          width: "100%",
+          maxWidth: 880,
+          display: "grid",
+          gridTemplateColumns: "minmax(280px, 360px) 1fr",
+          borderRadius: 12,
+          overflow: "hidden",
+          border: "1px solid var(--line)",
+          background: "var(--paper)",
+          boxShadow: "0 1px 2px rgba(15, 23, 42, 0.04), 0 18px 36px rgba(15, 23, 42, 0.06)",
+        }}
+      >
+        <aside
+          data-testid="chat-entry-brand"
+          style={{
+            background: "var(--ink)",
+            color: "var(--paper)",
+            padding: "32px 28px",
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "space-between",
+            gap: 24,
+          }}
+        >
+          <div>
+            <div
+              style={{
+                fontFamily: "var(--mono)",
+                fontSize: 10.5,
+                textTransform: "uppercase",
+                letterSpacing: "0.14em",
+                color: "var(--dark-ink-2)",
+              }}
+            >
+              CSTONE · DEMO CHAT
+            </div>
+            <p
+              style={{
+                fontFamily: "var(--serif)",
+                fontSize: 26,
+                fontWeight: 400,
+                fontStyle: "italic",
+                lineHeight: 1.25,
+                letterSpacing: "-0.5px",
+                marginTop: 10,
+                color: "var(--paper)",
+              }}
+            >
+              환불 / 배송 / 결제 등<br />
+              실제 상담 도메인 팩을 시연합니다.
+              <br />
+              먼저 이름을 알려 주세요.
+            </p>
+            <p
+              style={{
+                marginTop: 18,
+                fontSize: 12.5,
+                lineHeight: 1.6,
+                color: "var(--dark-ink-2)",
+              }}
+            >
+              입력하신 이름은 상담 세션 헤더와 메시지 표기에만 사용되며, 데모 종료 후 자동
+              폐기됩니다.
+            </p>
+            <div
+              style={{
+                marginTop: 22,
+                display: "flex",
+                flexWrap: "wrap",
+                gap: 6,
+              }}
+            >
+              {["환불 요청", "배송 문의", "결제 오류"].map((chip) => (
+                <span
+                  key={chip}
+                  style={{
+                    display: "inline-flex",
+                    alignItems: "center",
+                    gap: 5,
+                    padding: "4px 10px",
+                    borderRadius: 999,
+                    fontFamily: "var(--mono)",
+                    fontSize: 10.5,
+                    textTransform: "uppercase",
+                    letterSpacing: "0.06em",
+                    background: "rgba(255, 255, 255, 0.08)",
+                    border: "1px solid rgba(255, 255, 255, 0.16)",
+                    color: "var(--paper)",
+                  }}
+                >
+                  <span
+                    aria-hidden="true"
+                    style={{
+                      width: 6,
+                      height: 6,
+                      borderRadius: 999,
+                      background: "var(--signal)",
+                    }}
+                  />
+                  {chip}
+                </span>
+              ))}
+            </div>
+          </div>
+          <div
+            style={{
+              fontFamily: "var(--mono)",
+              fontSize: 10.5,
+              textTransform: "uppercase",
+              letterSpacing: "0.08em",
+              color: "var(--dark-ink-3)",
+            }}
+          >
+            SESSION · NEW · Workspace #{workspaceId}
+          </div>
+        </aside>
+
+        <div
+          style={{
+            padding: "36px 32px",
+            background: "var(--paper)",
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "center",
+            gap: 18,
+          }}
+        >
+          <div
+            style={{
+              fontFamily: "var(--mono)",
+              fontSize: 10.5,
+              textTransform: "uppercase",
+              letterSpacing: "0.1em",
+              color: "var(--ink-3)",
+            }}
+          >
+            Step 1 / 1
+          </div>
+          <h1
+            style={{
+              margin: 0,
+              fontSize: 26,
+              fontWeight: 540,
+              letterSpacing: "-0.5px",
+              color: "var(--ink)",
+            }}
+          >
+            대화를 시작합니다
+          </h1>
+          <p
+            style={{
+              margin: 0,
+              fontSize: 13.5,
+              lineHeight: 1.6,
+              color: "var(--ink-2)",
+            }}
+          >
+            상담 화면에 표시될 이름을 적어 주세요. 한글 / 영문 모두 가능합니다.
+          </p>
+
+          <div>
+            <label
+              htmlFor="chat-customer-name"
+              style={{
+                display: "block",
+                fontFamily: "var(--mono)",
+                fontSize: 10.5,
+                textTransform: "uppercase",
+                letterSpacing: "0.08em",
+                color: "var(--ink-3)",
+                marginBottom: 6,
+              }}
+            >
+              이름
+            </label>
+            <input
+              id="chat-customer-name"
+              data-testid="chat-name-input"
+              value={draftName}
+              onChange={(event) => onDraftChange(event.target.value)}
+              placeholder="예: 김민지"
+              autoComplete="name"
+              style={{
+                width: "100%",
+                height: 48,
+                padding: "0 16px",
+                borderRadius: 8,
+                border: "1px solid var(--line)",
+                background: "var(--paper)",
+                color: "var(--ink)",
+                fontSize: 14,
+                fontWeight: 500,
+                fontFamily: "inherit",
+              }}
+            />
+            {nameError && (
+              <p
+                role="alert"
+                data-testid="chat-name-error"
+                style={{
+                  marginTop: 6,
+                  fontSize: 12,
+                  color: "var(--danger)",
+                }}
+              >
+                {nameError}
+              </p>
+            )}
+          </div>
+
+          <button
+            type="submit"
+            data-testid="chat-entry-submit"
+            style={{
+              height: 48,
+              padding: "0 18px",
+              borderRadius: 999,
+              border: "none",
+              background: "var(--ink)",
+              color: "var(--paper)",
+              fontSize: 14,
+              fontWeight: 600,
+              letterSpacing: "-0.1px",
+              cursor: "pointer",
+              fontFamily: "inherit",
+            }}
+          >
+            채팅 시작
+          </button>
+          <div
+            style={{
+              fontFamily: "var(--mono)",
+              fontSize: 10.5,
+              textTransform: "uppercase",
+              letterSpacing: "0.08em",
+              color: "var(--ink-3)",
+            }}
+          >
+            ENTER 키로도 시작 가능
+          </div>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/pages/user-chat/ui/ChatHeader.test.tsx
+++ b/frontend/src/pages/user-chat/ui/ChatHeader.test.tsx
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ChatHeader } from "./ChatHeader";
+import { deriveAvatarInitial } from "./deriveAvatarInitial";
+
+describe("deriveAvatarInitial", () => {
+  it("returns first hangul character for Korean names", () => {
+    expect(deriveAvatarInitial("김민지")).toBe("김");
+    expect(deriveAvatarInitial("이준혁")).toBe("이");
+  });
+
+  it("returns up to 2 uppercase letters for ASCII names", () => {
+    expect(deriveAvatarInitial("john")).toBe("JO");
+    expect(deriveAvatarInitial("a")).toBe("A");
+  });
+
+  it("returns '?' for empty/whitespace name", () => {
+    expect(deriveAvatarInitial("")).toBe("?");
+    expect(deriveAvatarInitial("   ")).toBe("?");
+  });
+});
+
+describe("ChatHeader", () => {
+  it("renders avatar initial, name, session eyebrow", () => {
+    render(<ChatHeader customerName="김민지" sessionId="77" status="OPEN" />);
+
+    expect(screen.getByTestId("chat-header-avatar")).toHaveTextContent("김");
+    expect(screen.getByTestId("chat-header-name")).toHaveTextContent("김민지");
+    expect(screen.getByTestId("chat-header-eyebrow")).toHaveTextContent("Session #77");
+  });
+
+  it("status pill renders text and tone for OPEN", () => {
+    render(<ChatHeader customerName="김민지" sessionId="77" status="OPEN" />);
+
+    const pill = screen.getByTestId("chat-header-status");
+    expect(pill).toHaveTextContent("OPEN");
+    expect(pill.style.background).toBe("var(--signal-bg)");
+  });
+
+  it("status pill changes appearance for non-OPEN states", () => {
+    render(<ChatHeader customerName="김민지" sessionId="77" status="CLOSED" />);
+
+    const pill = screen.getByTestId("chat-header-status");
+    expect(pill).toHaveTextContent("CLOSED");
+    expect(pill.style.background).toBe("var(--paper-3)");
+  });
+});

--- a/frontend/src/pages/user-chat/ui/ChatHeader.tsx
+++ b/frontend/src/pages/user-chat/ui/ChatHeader.tsx
@@ -1,0 +1,105 @@
+import { deriveAvatarInitial } from "./deriveAvatarInitial";
+
+interface ChatHeaderProps {
+  customerName: string;
+  sessionId: string;
+  status: string;
+}
+
+export function ChatHeader({ customerName, sessionId, status }: ChatHeaderProps) {
+  const initial = deriveAvatarInitial(customerName);
+  const isOpen = status === "OPEN";
+  return (
+    <header
+      data-testid="chat-header"
+      style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        gap: 12,
+        padding: "16px 20px",
+        background: "var(--paper)",
+        borderBottom: "1px solid var(--line-2)",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+        <div
+          aria-hidden="true"
+          data-testid="chat-header-avatar"
+          style={{
+            width: 40,
+            height: 40,
+            borderRadius: 999,
+            background: "var(--ink)",
+            color: "var(--paper)",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            fontSize: 14,
+            fontWeight: 600,
+          }}
+        >
+          {initial}
+        </div>
+        <div style={{ display: "flex", flexDirection: "column" }}>
+          <span
+            data-testid="chat-header-eyebrow"
+            style={{
+              fontFamily: "var(--mono)",
+              fontSize: 10.5,
+              fontWeight: 500,
+              color: "var(--ink-3)",
+              textTransform: "uppercase",
+              letterSpacing: "0.1em",
+            }}
+          >
+            Session #{sessionId}
+          </span>
+          <h1
+            data-testid="chat-header-name"
+            style={{
+              margin: 0,
+              fontSize: 17,
+              fontWeight: 540,
+              letterSpacing: "-0.2px",
+              color: "var(--ink)",
+              marginTop: 2,
+            }}
+          >
+            {customerName}
+          </h1>
+        </div>
+      </div>
+      <span
+        data-testid="chat-header-status"
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: 6,
+          padding: "4px 12px",
+          borderRadius: 999,
+          fontFamily: "var(--mono)",
+          fontSize: 10.5,
+          fontWeight: 600,
+          letterSpacing: "0.08em",
+          textTransform: "uppercase",
+          background: isOpen ? "var(--signal-bg)" : "var(--paper-3)",
+          color: isOpen ? "var(--signal-ink)" : "var(--ink-3)",
+          border: `1px solid ${isOpen ? "var(--signal)" : "var(--line)"}`,
+        }}
+      >
+        <span
+          aria-hidden="true"
+          style={{
+            width: 7,
+            height: 7,
+            borderRadius: 999,
+            background: isOpen ? "var(--signal)" : "var(--ink-3)",
+            boxShadow: isOpen ? "0 0 0 3px rgba(34, 197, 94, 0.18)" : undefined,
+          }}
+        />
+        {status}
+      </span>
+    </header>
+  );
+}

--- a/frontend/src/pages/user-chat/ui/ChatHeader.tsx
+++ b/frontend/src/pages/user-chat/ui/ChatHeader.tsx
@@ -36,7 +36,7 @@ export function ChatHeader({ customerName, sessionId, status }: ChatHeaderProps)
             alignItems: "center",
             justifyContent: "center",
             fontSize: 14,
-            fontWeight: 600,
+            fontWeight: 540,
           }}
         >
           {initial}
@@ -47,7 +47,7 @@ export function ChatHeader({ customerName, sessionId, status }: ChatHeaderProps)
             style={{
               fontFamily: "var(--mono)",
               fontSize: 10.5,
-              fontWeight: 500,
+              fontWeight: 480,
               color: "var(--ink-3)",
               textTransform: "uppercase",
               letterSpacing: "0.1em",
@@ -80,7 +80,7 @@ export function ChatHeader({ customerName, sessionId, status }: ChatHeaderProps)
           borderRadius: 999,
           fontFamily: "var(--mono)",
           fontSize: 10.5,
-          fontWeight: 600,
+          fontWeight: 540,
           letterSpacing: "0.08em",
           textTransform: "uppercase",
           background: isOpen ? "var(--signal-bg)" : "var(--paper-3)",

--- a/frontend/src/pages/user-chat/ui/UserChatPage.test.tsx
+++ b/frontend/src/pages/user-chat/ui/UserChatPage.test.tsx
@@ -67,7 +67,9 @@ describe("UserChatPage", () => {
     fireEvent.change(screen.getByLabelText("이름"), { target: { value: "김민지" } });
     fireEvent.click(screen.getByRole("button", { name: "채팅 시작" }));
 
-    expect(await screen.findByText("김민지 · Session #77")).not.toBeNull();
+    const eyebrow = await screen.findByTestId("chat-header-eyebrow");
+    expect(eyebrow).toHaveTextContent("Session #77");
+    expect(screen.getByTestId("chat-header-name")).toHaveTextContent("김민지");
     expect(screen.getByText("안녕하세요, 김민지님. 무엇을 도와드릴까요?")).not.toBeNull();
     expect(registerDemoChatSessionMock).toHaveBeenCalledWith(42, "김민지");
   });
@@ -92,7 +94,8 @@ describe("UserChatPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "채팅 시작" }));
 
     expect(await screen.findByText("Hello")).not.toBeNull();
-    expect(screen.getByText("김민지 · Session #77")).not.toBeNull();
+    expect(screen.getByTestId("chat-header-eyebrow")).toHaveTextContent("Session #77");
+    expect(screen.getByTestId("chat-header-name")).toHaveTextContent("김민지");
     expect(registerDemoChatSessionMock).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/pages/user-chat/ui/UserChatPage.test.tsx
+++ b/frontend/src/pages/user-chat/ui/UserChatPage.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiRequestError } from "@/shared/api";
 import { UserChatPage } from "./UserChatPage";
 
 const { registerDemoChatSessionMock, sendDemoChatMessageMock, routeState } = vi.hoisted(() => ({
@@ -106,7 +107,9 @@ describe("UserChatPage", () => {
     fireEvent.change(input, { target: { value: "Hello" } });
     fireEvent.click(screen.getByRole("button", { name: "메시지 보내기" }));
 
-    expect(await screen.findByText("응답을 생성하지 못했습니다. 잠시 후 다시 시도해 주세요.")).not.toBeNull();
+    expect(
+      await screen.findByText("응답을 생성하지 못했습니다. 잠시 후 다시 시도해 주세요."),
+    ).not.toBeNull();
     expect(screen.queryByText("Hello")).toBeNull();
   });
 
@@ -126,5 +129,67 @@ describe("UserChatPage", () => {
 
     expect(await screen.findByText("유효하지 않은 워크스페이스입니다.")).not.toBeNull();
     expect(window.localStorage.length).toBe(0);
+  });
+
+  describe("session start error handling", () => {
+    let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      consoleErrorSpy.mockRestore();
+    });
+
+    it("DOMAIN_PACK_CURRENT_VERSION_NOT_FOUND 에러를 구체적인 안내로 표시하고 콘솔에 로깅한다", async () => {
+      registerDemoChatSessionMock.mockRejectedValueOnce(
+        new ApiRequestError(
+          404,
+          "DOMAIN_PACK_CURRENT_VERSION_NOT_FOUND",
+          "현재 운영 중인 PUBLISHED version을 찾을 수 없습니다.",
+        ),
+      );
+
+      render(<UserChatPage />);
+      fireEvent.change(screen.getByLabelText("이름"), { target: { value: "김민지" } });
+      fireEvent.click(screen.getByRole("button", { name: "채팅 시작" }));
+
+      expect(
+        await screen.findByText(
+          "이 워크스페이스에는 운영 중인 도메인 팩 버전이 없습니다. 관리자에게 문의해 주세요.",
+        ),
+      ).not.toBeNull();
+      expect(screen.getByRole("alert")).not.toBeNull();
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "Failed to start demo chat session",
+        expect.any(ApiRequestError),
+      );
+    });
+
+    it("그 외 에러는 기본 메시지로 안내한다", async () => {
+      registerDemoChatSessionMock.mockRejectedValueOnce(new Error("Network down"));
+
+      render(<UserChatPage />);
+      fireEvent.change(screen.getByLabelText("이름"), { target: { value: "김민지" } });
+      fireEvent.click(screen.getByRole("button", { name: "채팅 시작" }));
+
+      expect(
+        await screen.findByText("채팅 세션을 시작할 수 없습니다. 잠시 후 다시 시도해 주세요."),
+      ).not.toBeNull();
+    });
+
+    it("에러 화면의 다시 시도 버튼은 이름 입력 폼으로 복귀한다", async () => {
+      registerDemoChatSessionMock.mockRejectedValueOnce(new Error("transient"));
+
+      render(<UserChatPage />);
+      fireEvent.change(screen.getByLabelText("이름"), { target: { value: "김민지" } });
+      fireEvent.click(screen.getByRole("button", { name: "채팅 시작" }));
+
+      const retryButton = await screen.findByRole("button", { name: "다시 시도" });
+      fireEvent.click(retryButton);
+
+      expect(screen.getByRole("form", { name: "채팅 사용자 이름 입력" })).not.toBeNull();
+    });
   });
 });

--- a/frontend/src/pages/user-chat/ui/UserChatPage.tsx
+++ b/frontend/src/pages/user-chat/ui/UserChatPage.tsx
@@ -3,6 +3,19 @@ import { useParams } from "react-router-dom";
 import { registerDemoChatSession, sendDemoChatMessage } from "@/entities/chat";
 import type { ChatMessage, DemoChatSession } from "@/entities/chat";
 import { ConnectionStatus, MessageInput, MessageList } from "@/features/user-chat";
+import { ApiRequestError } from "@/shared/api";
+
+function resolveSessionStartErrorMessage(error: unknown): string {
+  if (error instanceof ApiRequestError) {
+    if (error.code === "DOMAIN_PACK_CURRENT_VERSION_NOT_FOUND" || error.status === 404) {
+      return "이 워크스페이스에는 운영 중인 도메인 팩 버전이 없습니다. 관리자에게 문의해 주세요.";
+    }
+    if (error.status === 401 || error.status === 403) {
+      return "채팅을 시작할 권한이 없습니다. 다시 로그인 후 시도해 주세요.";
+    }
+  }
+  return "채팅 세션을 시작할 수 없습니다. 잠시 후 다시 시도해 주세요.";
+}
 
 const DEMO_SESSION_STORAGE_PREFIX = "ostone:demo-chat-session";
 
@@ -48,10 +61,7 @@ function writeStoredSession(
 ): void {
   if (typeof window === "undefined") return;
 
-  window.localStorage.setItem(
-    createStorageKey(workspaceId, customerName),
-    JSON.stringify(session),
-  );
+  window.localStorage.setItem(createStorageKey(workspaceId, customerName), JSON.stringify(session));
 }
 
 async function getOrCreateStoredSession(
@@ -104,15 +114,24 @@ export function UserChatPage() {
       const nextSession = await getOrCreateStoredSession(workspaceId, nextName);
       if (requestId !== nameRequestIdRef.current) return;
       setChatState({ workspaceId, customerName: nextName, session: nextSession, error: null });
-    } catch {
+    } catch (error) {
+      console.error("Failed to start demo chat session", error);
       if (requestId !== nameRequestIdRef.current) return;
       setChatState({
         workspaceId,
         customerName: nextName,
         session: null,
-        error: "채팅 세션을 시작할 수 없습니다.",
+        error: resolveSessionStartErrorMessage(error),
       });
     }
+  };
+
+  const handleResetToNameForm = () => {
+    nameRequestIdRef.current += 1;
+    setCustomerName(null);
+    setDraftName("");
+    setNameError(null);
+    setChatState({ workspaceId: null, customerName: null, session: null, error: null });
   };
 
   const handleSendMessage = async (content: string) => {
@@ -226,8 +245,21 @@ export function UserChatPage() {
 
   if (activeChatState.error) {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-white p-8 text-sm text-black">
-        {activeChatState.error}
+      <div
+        className="flex min-h-screen items-center justify-center bg-white p-8 text-black"
+        role="alert"
+      >
+        <div className="w-full max-w-[420px]">
+          <h1 className="text-[20px] font-medium text-black">채팅을 시작할 수 없습니다</h1>
+          <p className="mt-3 text-sm leading-relaxed text-gray-700">{activeChatState.error}</p>
+          <button
+            type="button"
+            onClick={handleResetToNameForm}
+            className="mt-6 h-12 w-full rounded-full bg-black px-5 text-sm text-white"
+          >
+            다시 시도
+          </button>
+        </div>
       </div>
     );
   }

--- a/frontend/src/pages/user-chat/ui/UserChatPage.tsx
+++ b/frontend/src/pages/user-chat/ui/UserChatPage.tsx
@@ -2,8 +2,9 @@ import { type FormEvent, useRef, useState } from "react";
 import { useParams } from "react-router-dom";
 import { registerDemoChatSession, sendDemoChatMessage } from "@/entities/chat";
 import type { ChatMessage, DemoChatSession } from "@/entities/chat";
-import { ConnectionStatus, MessageInput, MessageList } from "@/features/user-chat";
 import { ApiRequestError } from "@/shared/api";
+import { ChatConversationScreen } from "./ChatConversationScreen";
+import { ChatEntryScreen } from "./ChatEntryScreen";
 
 function resolveSessionStartErrorMessage(error: unknown): string {
   if (error instanceof ApiRequestError) {
@@ -213,33 +214,13 @@ export function UserChatPage() {
 
   if (!customerName) {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-white p-8 text-black">
-        <form
-          onSubmit={handleNameSubmit}
-          className="w-full max-w-[360px]"
-          aria-label="채팅 사용자 이름 입력"
-        >
-          <h1 className="text-[22px] font-medium text-black">사용자 채팅</h1>
-          <label className="mt-6 block text-sm text-black" htmlFor="chat-customer-name">
-            이름
-          </label>
-          <input
-            id="chat-customer-name"
-            value={draftName}
-            onChange={(event) => setDraftName(event.target.value)}
-            className="mt-2 h-12 w-full rounded-full border border-gray-300 bg-white px-5 text-sm text-black outline-none focus:border-black focus:ring-2 focus:ring-black/10"
-            placeholder="이름을 입력하세요"
-            autoComplete="name"
-          />
-          {nameError && <p className="mt-2 text-xs text-red-600">{nameError}</p>}
-          <button
-            type="submit"
-            className="mt-5 h-12 w-full rounded-full bg-black px-5 text-sm text-white"
-          >
-            채팅 시작
-          </button>
-        </form>
-      </div>
+      <ChatEntryScreen
+        draftName={draftName}
+        nameError={nameError}
+        workspaceId={workspaceId}
+        onDraftChange={setDraftName}
+        onSubmit={handleNameSubmit}
+      />
     );
   }
 
@@ -273,43 +254,14 @@ export function UserChatPage() {
   }
 
   return (
-    <div
-      className="flex h-screen min-h-0 flex-col overflow-hidden bg-white"
-      style={{ padding: "20px 24px 24px" }}
-    >
-      <header
-        className="flex shrink-0 items-center justify-between border-b border-gray-200"
-        style={{ padding: "0 0 16px" }}
-      >
-        <div>
-          <h1 className="text-[18px] font-medium text-black">사용자 채팅</h1>
-          <p className="mt-1 text-xs text-gray-500">
-            {customerName} · Session #{activeChatState.session.id}
-          </p>
-        </div>
-        <span className="rounded-full border border-gray-200 px-3 py-1 text-xs text-gray-600">
-          {activeChatState.session.status}
-        </span>
-      </header>
-      <div className="min-h-0 flex-1" style={{ paddingTop: 16 }}>
-        <section className="flex h-full min-h-0 flex-col overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
-          <ConnectionStatus status="CONNECTED" />
-          <div className="min-h-0 flex-1 border-y border-gray-100">
-            <MessageList messages={activeChatState.session.messages} />
-          </div>
-          {messageError && (
-            <div className="border-t border-red-100 bg-red-50 px-4 py-3 text-xs text-red-700">
-              {messageError}
-            </div>
-          )}
-          <MessageInput
-            onSend={(content) => {
-              void handleSendMessage(content);
-            }}
-            disabled={isSending}
-          />
-        </section>
-      </div>
-    </div>
+    <ChatConversationScreen
+      session={activeChatState.session}
+      customerName={customerName}
+      isSending={isSending}
+      messageError={messageError}
+      onSend={(content) => {
+        void handleSendMessage(content);
+      }}
+    />
   );
 }

--- a/frontend/src/pages/user-chat/ui/deriveAvatarInitial.ts
+++ b/frontend/src/pages/user-chat/ui/deriveAvatarInitial.ts
@@ -1,0 +1,7 @@
+export function deriveAvatarInitial(name: string): string {
+  const trimmed = name.trim();
+  if (!trimmed) return "?";
+  const firstChar = trimmed[0];
+  if (/[가-힣]/.test(firstChar)) return firstChar;
+  return trimmed.slice(0, 2).toUpperCase();
+}

--- a/frontend/src/pages/workspace/ui/WorkspaceLayout.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceLayout.tsx
@@ -2,10 +2,7 @@ import { useMemo, useState, type ReactNode } from "react";
 import { Navigate, Outlet, useLocation, useParams } from "react-router-dom";
 import type { ShellContext, SidebarActive } from "@/shared/ui/ostone/chrome";
 
-import {
-  mapWorkspaceActionError,
-  type WorkspaceResponse,
-} from "@/entities/workspace";
+import { mapWorkspaceActionError, type WorkspaceResponse } from "@/entities/workspace";
 import { useGetWorkspace } from "@/shared/api/generated/endpoints/workspace-controller/workspace-controller";
 import { ErrorState } from "@/shared/ui/ostone/atoms/ErrorState";
 import { LoadingSpinner } from "@/shared/ui/ostone/atoms/LoadingSpinner";
@@ -25,9 +22,7 @@ export function WorkspaceLayout() {
   const { workspaceId } = useParams();
   const location = useLocation();
   const parsedWorkspaceId = parseRouteId(workspaceId);
-  const basePath = parsedWorkspaceId
-    ? `/workspaces/${parsedWorkspaceId}`
-    : "/workspaces";
+  const basePath = parsedWorkspaceId ? `/workspaces/${parsedWorkspaceId}` : "/workspaces";
   const [topbarRight, setTopbarRight] = useState<ReactNode>(null);
   const [crumbs, setCrumbs] = useState<string[]>([]);
   const active = getActiveFromPath(location.pathname);
@@ -40,19 +35,11 @@ export function WorkspaceLayout() {
   } = useGetWorkspace(parsedWorkspaceId ?? 0, {
     query: { enabled: parsedWorkspaceId !== null },
   });
-  const workspace = fetchedWorkspace
-    ? (fetchedWorkspace as unknown as WorkspaceResponse)
-    : null;
-  const error =
-    parsedWorkspaceId !== null && fetchError
-      ? mapWorkspaceActionError(fetchError)
-      : "";
+  const workspace = fetchedWorkspace ? (fetchedWorkspace as unknown as WorkspaceResponse) : null;
+  const error = parsedWorkspaceId !== null && fetchError ? mapWorkspaceActionError(fetchError) : "";
   const isLoading = parsedWorkspaceId !== null && isFetchingWorkspace;
 
-  const defaultCrumbs = useMemo(
-    () => (workspace?.name ? [workspace.name] : []),
-    [workspace],
-  );
+  const defaultCrumbs = useMemo(() => (workspace?.name ? [workspace.name] : []), [workspace]);
 
   if (parsedWorkspaceId === null) {
     return <Navigate to="/workspaces" replace />;

--- a/frontend/src/shared/api/mocks/index.test.ts
+++ b/frontend/src/shared/api/mocks/index.test.ts
@@ -53,7 +53,9 @@ describe("isMockEnabled", () => {
 describe("resolveMock", () => {
   it("mock 비활성이면 null", () => {
     setLocation("");
-    expect(resolveMock("/workspaces/1/domain-packs/1/versions/1/intents", { method: "GET" })).toBeNull();
+    expect(
+      resolveMock("/workspaces/1/domain-packs/1/versions/1/intents", { method: "GET" }),
+    ).toBeNull();
   });
 
   it("mock 활성이고 GET 매칭이면 데이터 반환", () => {

--- a/frontend/src/shared/api/mocks/workflowFixtures.ts
+++ b/frontend/src/shared/api/mocks/workflowFixtures.ts
@@ -295,7 +295,7 @@ function workflowSummary(wf: MockWorkflow) {
     name: wf.name,
     description: wf.description,
     initialState: "start",
-    terminalStatesJson: "[\"end\"]",
+    terminalStatesJson: '["end"]',
     createdAt: NOW,
     updatedAt: NOW,
   };
@@ -309,7 +309,7 @@ function workflowDetail(wf: MockWorkflow) {
     description: wf.description,
     graphJson: wf.graphJson,
     initialState: "start",
-    terminalStatesJson: "[\"end\"]",
+    terminalStatesJson: '["end"]',
     evidenceJson: "[]",
     metaJson: "{}",
     createdAt: NOW,

--- a/frontend/src/shared/lib/domainPackRoutes.ts
+++ b/frontend/src/shared/lib/domainPackRoutes.ts
@@ -65,7 +65,10 @@ export function domainPackSectionPath(
   childId?: number,
 ): string {
   const childPath = childId === undefined ? "" : `/${childId}`;
-  return withVersionSearch(`${domainPackPath(workspaceId, packId)}/${section}${childPath}`, versionId);
+  return withVersionSearch(
+    `${domainPackPath(workspaceId, packId)}/${section}${childPath}`,
+    versionId,
+  );
 }
 
 export function shouldReplaceDomainPackChildRoute(currentChildId: number | null): boolean {
@@ -84,5 +87,8 @@ export function domainPackSectionPathFromBase(
   childId?: number,
 ): string {
   const childPath = childId === undefined ? "" : `/${childId}`;
-  return withVersionSearch(`${domainPackPathFromBase(basePath, packId)}/${section}${childPath}`, versionId);
+  return withVersionSearch(
+    `${domainPackPathFromBase(basePath, packId)}/${section}${childPath}`,
+    versionId,
+  );
 }

--- a/frontend/src/shared/lib/websocket/useStomp.test.tsx
+++ b/frontend/src/shared/lib/websocket/useStomp.test.tsx
@@ -1,6 +1,13 @@
 import { act, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { IMessage, StompSubscription, IFrame, frameCallbackType, wsErrorCallbackType, Client } from "@stomp/stompjs";
+import type {
+  IMessage,
+  StompSubscription,
+  IFrame,
+  frameCallbackType,
+  wsErrorCallbackType,
+  Client,
+} from "@stomp/stompjs";
 import { useStomp } from "./useStomp";
 
 interface MockClient {
@@ -142,7 +149,7 @@ describe("useStomp", () => {
     expect(topicCallback).toHaveBeenCalledWith({ content: "hello" });
 
     act(() => {
-      onMessage?.(makeMessage('invalid-json'));
+      onMessage?.(makeMessage("invalid-json"));
     });
     expect(topicCallback).toHaveBeenCalledTimes(1);
 
@@ -225,7 +232,7 @@ describe("useStomp", () => {
     });
 
     const errorQueueOnMessage = client.subscribe.mock.calls.find(
-      (call) => call[0] === "/user/queue/errors"
+      (call) => call[0] === "/user/queue/errors",
     )?.[1];
 
     expect(errorQueueOnMessage).toBeDefined();

--- a/frontend/src/shared/lib/websocket/useStomp.ts
+++ b/frontend/src/shared/lib/websocket/useStomp.ts
@@ -97,34 +97,31 @@ export function useStomp(): UseStompResult {
     });
   }, []);
 
-  const subscribe = useCallback(
-    (topic: string, cb: (msg: unknown) => void): (() => void) => {
-      const client = clientRef.current;
-      if (!client?.connected) {
-        return () => {};
+  const subscribe = useCallback((topic: string, cb: (msg: unknown) => void): (() => void) => {
+    const client = clientRef.current;
+    if (!client?.connected) {
+      return () => {};
+    }
+
+    const subscription = client.subscribe(topic, (message) => {
+      try {
+        cb(JSON.parse(message.body) as unknown);
+      } catch {
+        // Skip malformed messages
       }
+    });
+    const prev = customSubscriptionsRef.current.get(topic);
+    prev?.unsubscribe();
+    customSubscriptionsRef.current.set(topic, subscription);
 
-      const subscription = client.subscribe(topic, (message) => {
-        try {
-          cb(JSON.parse(message.body) as unknown);
-        } catch {
-          // Skip malformed messages
-        }
-      });
-      const prev = customSubscriptionsRef.current.get(topic);
-      prev?.unsubscribe();
-      customSubscriptionsRef.current.set(topic, subscription);
-
-      return () => {
-        subscription.unsubscribe();
-        const current = customSubscriptionsRef.current.get(topic);
-        if (current === subscription) {
-          customSubscriptionsRef.current.delete(topic);
-        }
-      };
-    },
-    [],
-  );
+    return () => {
+      subscription.unsubscribe();
+      const current = customSubscriptionsRef.current.get(topic);
+      if (current === subscription) {
+        customSubscriptionsRef.current.delete(topic);
+      }
+    };
+  }, []);
 
   const sendTo = useCallback((destination: string, body: unknown) => {
     const client = clientRef.current;

--- a/frontend/src/shared/ui/ostone/chrome/AccountMenu.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/AccountMenu.tsx
@@ -109,7 +109,7 @@ export function AccountMenu({ collapsed }: AccountMenuProps) {
         cursor: "pointer",
         textAlign: "left",
         color: "var(--ink)",
-        fontFamily: "var(--sans)",
+        fontFamily: "var(--font-sans)",
         fontSize: "13px",
         transition: "background 160ms ease",
       }}
@@ -169,7 +169,7 @@ export function AccountMenu({ collapsed }: AccountMenuProps) {
               <div style={{ display: "flex", flexDirection: "column" }}>
                 <span
                   style={{
-                    fontFamily: "var(--sans)",
+                    fontFamily: "var(--font-sans)",
                     fontSize: "12px",
                     fontWeight: 500,
                     color: "var(--ink)",
@@ -200,7 +200,7 @@ export function AccountMenu({ collapsed }: AccountMenuProps) {
                 border: "none",
                 borderRadius: "var(--r-1)",
                 cursor: "pointer",
-                fontFamily: "var(--sans)",
+                fontFamily: "var(--font-sans)",
                 fontSize: "12px",
                 color: "var(--ink)",
                 textAlign: "left",
@@ -233,7 +233,7 @@ export function AccountMenu({ collapsed }: AccountMenuProps) {
                 border: "none",
                 borderRadius: "var(--r-1)",
                 cursor: "pointer",
-                fontFamily: "var(--sans)",
+                fontFamily: "var(--font-sans)",
                 fontSize: "12px",
                 color: "var(--ink)",
                 textAlign: "left",

--- a/frontend/src/shared/ui/ostone/chrome/Sidebar.test.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/Sidebar.test.tsx
@@ -106,14 +106,14 @@ describe("Sidebar", () => {
     expect(link.style.background).toBe("transparent");
   });
 
-  it("redesign: active 링크는 fontWeight 600, idle은 460 으로 그려진다", () => {
+  it("redesign: active 링크는 fontWeight 540, idle은 450 으로 그려진다", () => {
     renderSidebar({ active: "consult" });
 
     const activeLink = screen.getByTitle("Consultation") as HTMLElement;
     const idleLink = screen.getByTitle("Uploads") as HTMLElement;
 
-    expect(activeLink.style.fontWeight).toBe("600");
-    expect(idleLink.style.fontWeight).toBe("460");
+    expect(activeLink.style.fontWeight).toBe("540");
+    expect(idleLink.style.fontWeight).toBe("450");
   });
 
   it("redesign: 모든 링크는 13.5px / letter-spacing -0.18px / Pretendard 변수 폰트를 사용한다", () => {

--- a/frontend/src/shared/ui/ostone/chrome/Sidebar.test.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/Sidebar.test.tsx
@@ -77,20 +77,11 @@ describe("Sidebar", () => {
   it("basePath prop을 지정하면 링크에 반영된다", () => {
     renderSidebar({ basePath: "/workspaces/7" });
 
-    expect(screen.getByTitle("Consultation")).toHaveAttribute(
-      "href",
-      "/workspaces/7/consultation",
-    );
-    expect(screen.getByTitle("Chat")).toHaveAttribute(
-      "href",
-      "/demo/workspaces/7/chat",
-    );
+    expect(screen.getByTitle("Consultation")).toHaveAttribute("href", "/workspaces/7/consultation");
+    expect(screen.getByTitle("Chat")).toHaveAttribute("href", "/demo/workspaces/7/chat");
     expect(screen.getByTitle("Chat")).toHaveAttribute("target", "_blank");
     expect(screen.getByTitle("Chat")).toHaveAttribute("rel", "noopener noreferrer");
-    expect(screen.getByTitle("Domain Packs")).toHaveAttribute(
-      "href",
-      "/workspaces/7/domain-packs",
-    );
+    expect(screen.getByTitle("Domain Packs")).toHaveAttribute("href", "/workspaces/7/domain-packs");
   });
 
   it("workspaceId를 추출할 수 없으면 Chat 링크를 안전한 내부 경로로 보낸다", () => {

--- a/frontend/src/shared/ui/ostone/chrome/Sidebar.test.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/Sidebar.test.tsx
@@ -105,4 +105,31 @@ describe("Sidebar", () => {
     fireEvent.mouseLeave(link);
     expect(link.style.background).toBe("transparent");
   });
+
+  it("redesign: active 링크는 fontWeight 600, idle은 460 으로 그려진다", () => {
+    renderSidebar({ active: "consult" });
+
+    const activeLink = screen.getByTitle("Consultation") as HTMLElement;
+    const idleLink = screen.getByTitle("Uploads") as HTMLElement;
+
+    expect(activeLink.style.fontWeight).toBe("600");
+    expect(idleLink.style.fontWeight).toBe("460");
+  });
+
+  it("redesign: 모든 링크는 13.5px / letter-spacing -0.18px / Pretendard 변수 폰트를 사용한다", () => {
+    renderSidebar({ active: "consult" });
+
+    const link = screen.getByTitle("Consultation") as HTMLElement;
+    expect(link.style.fontSize).toBe("13.5px");
+    expect(link.style.letterSpacing).toBe("-0.18px");
+    expect(link.style.fontFamily).toBe("var(--font-sans)");
+  });
+
+  it("redesign: TOP_NAV 항목마다 sidebar-link-{key} data-testid를 노출한다", () => {
+    renderSidebar({ active: "consult" });
+
+    expect(screen.getByTestId("sidebar-link-consult")).toBeInTheDocument();
+    expect(screen.getByTestId("sidebar-link-chat")).toBeInTheDocument();
+    expect(screen.getByTestId("sidebar-link-upload")).toBeInTheDocument();
+  });
 });

--- a/frontend/src/shared/ui/ostone/chrome/Sidebar.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/Sidebar.tsx
@@ -239,7 +239,7 @@ function buildLinkStyle({
     transition: "background 160ms ease, color 160ms ease",
     fontFamily: "var(--font-sans)",
     fontSize: "13.5px",
-    fontWeight: isActive ? 600 : 460,
+    fontWeight: isActive ? 540 : 450,
     letterSpacing: "-0.18px",
   };
 }

--- a/frontend/src/shared/ui/ostone/chrome/Sidebar.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/Sidebar.tsx
@@ -71,6 +71,7 @@ function deriveSidebarColors(dark: boolean) {
     borderColor: dark ? "var(--dark-line)" : "var(--line)",
     defaultColor: dark ? "var(--dark-ink-3)" : "var(--ink-3)",
     hoverBg: dark ? "var(--dark-bg-2)" : "var(--paper-3)",
+    activeBg: dark ? "var(--dark-bg-2)" : "var(--paper-3)",
     activeColor: dark ? "var(--dark-ink)" : "var(--ink)",
   };
 }
@@ -92,7 +93,7 @@ export function Sidebar({
   basePath = "/workspaces",
   switcher,
 }: SidebarProps) {
-  const { containerBg, borderColor, defaultColor, hoverBg, activeColor } =
+  const { containerBg, borderColor, defaultColor, hoverBg, activeBg, activeColor } =
     deriveSidebarColors(dark);
 
   return (
@@ -161,6 +162,8 @@ export function Sidebar({
             activeColor={activeColor}
             defaultColor={defaultColor}
             hoverBg={hoverBg}
+            activeBg={activeBg}
+            testId={`sidebar-link-${item.key}`}
             target={item.external ? "_blank" : undefined}
           />
         ))}
@@ -173,6 +176,7 @@ export function Sidebar({
           activeColor={activeColor}
           defaultColor={defaultColor}
           hoverBg={hoverBg}
+          activeBg={activeBg}
           testId="sidebar-domain-link"
         />
       </div>
@@ -206,8 +210,38 @@ interface SidebarLinkProps {
   activeColor: string;
   defaultColor: string;
   hoverBg: string;
+  activeBg: string;
   testId?: string;
   target?: "_blank";
+}
+
+function buildLinkStyle({
+  isActive,
+  activeColor,
+  defaultColor,
+  activeBg,
+}: {
+  isActive: boolean;
+  activeColor: string;
+  defaultColor: string;
+  activeBg: string;
+}): CSSProperties {
+  return {
+    height: "40px",
+    padding: "0 var(--s-3)",
+    display: "flex",
+    alignItems: "center",
+    gap: "var(--s-2)",
+    color: isActive ? activeColor : defaultColor,
+    background: isActive ? activeBg : "transparent",
+    borderLeft: `3px solid ${isActive ? "var(--signal)" : "transparent"}`,
+    textDecoration: "none",
+    transition: "background 160ms ease, color 160ms ease",
+    fontFamily: "var(--font-sans)",
+    fontSize: "13.5px",
+    fontWeight: isActive ? 600 : 460,
+    letterSpacing: "-0.18px",
+  };
 }
 
 function SidebarLink({
@@ -218,25 +252,16 @@ function SidebarLink({
   activeColor,
   defaultColor,
   hoverBg,
+  activeBg,
   testId,
   target,
 }: SidebarLinkProps) {
-  const expandedStyle: CSSProperties = {
-    height: "40px",
-    padding: "0 var(--s-3)",
-    display: "flex",
-    alignItems: "center",
-    gap: "var(--s-2)",
-    color: isActive ? activeColor : defaultColor,
-    background: isActive ? hoverBg : "transparent",
-    borderLeft: `3px solid ${isActive ? "var(--signal)" : "transparent"}`,
-    textDecoration: "none",
-    transition: "background 160ms ease, color 160ms ease",
-    fontFamily: "var(--sans)",
-    fontSize: "14px",
-    fontWeight: isActive ? 500 : 400,
-    letterSpacing: "-0.1px",
-  };
+  const expandedStyle: CSSProperties = buildLinkStyle({
+    isActive,
+    activeColor,
+    defaultColor,
+    activeBg,
+  });
 
   const handleMouseEnter = (e: MouseEvent<HTMLAnchorElement>) => {
     if (!isActive) {

--- a/frontend/src/shared/ui/ostone/chrome/Topbar.test.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/Topbar.test.tsx
@@ -75,9 +75,7 @@ describe("Topbar", () => {
 
     const linkB = screen.getByText("INTENTS") as HTMLAnchorElement;
     expect(linkB.tagName).toBe("A");
-    expect(linkB.getAttribute("href")).toBe(
-      "/workspaces/1/domain-packs/9/intents?versionId=1",
-    );
+    expect(linkB.getAttribute("href")).toBe("/workspaces/1/domain-packs/9/intents?versionId=1");
 
     const last = screen.getByText("current");
     expect(last.tagName).not.toBe("A");

--- a/frontend/src/shared/ui/ostone/chrome/Topbar.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/Topbar.tsx
@@ -53,7 +53,7 @@ export function Topbar({ crumbs, right, left, dark = false }: TopbarProps) {
             display: "inline-flex",
             alignItems: "center",
             height: "20px",
-            fontFamily: "var(--sans)",
+            fontFamily: "var(--font-sans)",
             fontSize: "14px",
             fontWeight: 540,
             lineHeight: 1,

--- a/frontend/src/shared/ui/ostone/chrome/Topbar.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/Topbar.tsx
@@ -108,8 +108,7 @@ export function Topbar({ crumbs, right, left, dark = false }: TopbarProps) {
                       (e.currentTarget as HTMLAnchorElement).style.color = ink;
                     }}
                     onMouseLeave={(e) => {
-                      (e.currentTarget as HTMLAnchorElement).style.color =
-                        color;
+                      (e.currentTarget as HTMLAnchorElement).style.color = color;
                     }}
                   >
                     {crumb.label}

--- a/frontend/src/shared/ui/ostone/chrome/WorkflowSettingsPanel.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/WorkflowSettingsPanel.tsx
@@ -42,7 +42,7 @@ const rowStyle: CSSProperties = {
   display: "flex",
   alignItems: "center",
   gap: "var(--s-2)",
-  fontFamily: "var(--sans)",
+  fontFamily: "var(--font-sans)",
   fontSize: "13px",
   fontWeight: 500,
   color: "var(--ink)",
@@ -70,7 +70,7 @@ function chipStyle(active: boolean): CSSProperties {
     color: active ? "var(--paper)" : "var(--ink)",
     fontSize: "12px",
     fontWeight: 500,
-    fontFamily: "var(--sans)",
+    fontFamily: "var(--font-sans)",
     cursor: "pointer",
     lineHeight: 1.2,
   };

--- a/frontend/src/shared/ui/ostone/molecules/WorkflowRow/WorkflowRow.test.tsx
+++ b/frontend/src/shared/ui/ostone/molecules/WorkflowRow/WorkflowRow.test.tsx
@@ -65,11 +65,7 @@ describe("WorkflowRow", () => {
 
   it("description 없으면 description 단락 생략", () => {
     render(
-      <WorkflowRow
-        entry={{ ...ENTRY, description: null }}
-        onOpen={vi.fn()}
-        testIdPrefix="row"
-      />,
+      <WorkflowRow entry={{ ...ENTRY, description: null }} onOpen={vi.fn()} testIdPrefix="row" />,
     );
     fireEvent.mouseEnter(screen.getByTestId("row-7"));
     expect(screen.queryByText("설명")).not.toBeInTheDocument();

--- a/frontend/src/shared/ui/ostone/molecules/WorkflowRow/WorkflowRow.tsx
+++ b/frontend/src/shared/ui/ostone/molecules/WorkflowRow/WorkflowRow.tsx
@@ -1,9 +1,4 @@
-import {
-  useState,
-  type FocusEvent,
-  type MouseEvent,
-  type ReactNode,
-} from "react";
+import { useState, type FocusEvent, type MouseEvent, type ReactNode } from "react";
 
 import { Mono, Pill } from "@/shared/ui/ostone/atoms";
 
@@ -86,18 +81,10 @@ export function WorkflowRow({
         >
           <div className={styles.expandedInner}>
             {previewOpen && (
-              <div
-                className={styles.expanded}
-                data-testid={`${rowTestId}-detail`}
-              >
-                {entry.description && (
-                  <p className={styles.description}>{entry.description}</p>
-                )}
+              <div className={styles.expanded} data-testid={`${rowTestId}-detail`}>
+                {entry.description && <p className={styles.description}>{entry.description}</p>}
                 {graphSlot && (
-                  <div
-                    className={styles.graphSlot}
-                    data-testid={`${rowTestId}-graph`}
-                  >
+                  <div className={styles.graphSlot} data-testid={`${rowTestId}-graph`}>
                     {graphSlot}
                   </div>
                 )}

--- a/frontend/src/widgets/ostone-shell/ui/OstoneShell.test.tsx
+++ b/frontend/src/widgets/ostone-shell/ui/OstoneShell.test.tsx
@@ -54,10 +54,7 @@ describe("OstoneShell", () => {
 
   it("상세 화면의 여러 breadcrumb는 그대로 유지한다", () => {
     render(
-      <OstoneShell
-        active="workflows"
-        crumbs={["WS · 1", "Domain Packs", "Workflows"]}
-      >
+      <OstoneShell active="workflows" crumbs={["WS · 1", "Domain Packs", "Workflows"]}>
         <div>content</div>
       </OstoneShell>,
       { wrapper: Wrapper },
@@ -85,10 +82,7 @@ describe("OstoneShell", () => {
       </OstoneShell>,
       { wrapper: Wrapper },
     );
-    expect(screen.getByLabelText("주요 내비게이션")).toHaveAttribute(
-      "data-collapsed",
-      "false",
-    );
+    expect(screen.getByLabelText("주요 내비게이션")).toHaveAttribute("data-collapsed", "false");
     expect(screen.getByLabelText("주요 내비게이션")).toHaveStyle({
       width: "200px",
     });
@@ -105,9 +99,7 @@ describe("OstoneShell", () => {
     const nav = screen.getByLabelText("주요 내비게이션");
     expect(nav).toHaveAttribute("data-collapsed", "false");
     expect(screen.queryByLabelText("사이드바 접기")).not.toBeInTheDocument();
-    expect(window.localStorage.getItem("ostone:sidebar:collapsed")).toBe(
-      "true",
-    );
+    expect(window.localStorage.getItem("ostone:sidebar:collapsed")).toBe("true");
   });
 
   it("localStorage에 false가 저장돼 있어도 sidebar 값을 다시 쓰지 않는다", () => {
@@ -118,13 +110,8 @@ describe("OstoneShell", () => {
       </OstoneShell>,
       { wrapper: Wrapper },
     );
-    expect(screen.getByLabelText("주요 내비게이션")).toHaveAttribute(
-      "data-collapsed",
-      "false",
-    );
-    expect(window.localStorage.getItem("ostone:sidebar:collapsed")).toBe(
-      "false",
-    );
+    expect(screen.getByLabelText("주요 내비게이션")).toHaveAttribute("data-collapsed", "false");
+    expect(window.localStorage.getItem("ostone:sidebar:collapsed")).toBe("false");
   });
 
   it("renders dark variant", () => {


### PR DESCRIPTION
## Summary

상담 응대(`/workspaces/{id}/consultation`)와 데모 사용자 채팅(`/demo/workspaces/{id}/chat`) UX를 두 단계에 걸쳐 정리한다.

**1단계 — 진입 흐름 안정화 (`e0250dd`):** 토스트 폭주 / 채팅 시작 silent fail / 워크플로 노드 description 미표시 3건의 사용자 가시 버그를 해결.

**2단계 — UI 전면 재구성 (working tree):** Sidebar / Consultation 우측 패널 / Chat 진입 / Chat 대화 4개 면을 `frontend/DESIGN.md`의 Pretendard variable weight 가이드에 맞춰 재구성. 인터랙티브 HTML 프로토타입을 함께 추가.

---

## 1단계: 진입 흐름 안정화 (`e0250dd`)

### Problem 1 — Consultation 진입 시 토스트 폭주
`/workspaces/{id}/consultation` 진입 직후 "대기열을 불러오지 못했습니다." 토스트가 3회, "상담 지표를 불러오지 못했습니다." 1회 깜빡이며 떠다가 0명 대기 상태로 안정화되는 현상.

**Root cause**: `ConsultationPage`에서 `loadQueue`를 호출하는 useEffect가 두 개로 갈라져 있어 STOMP 연결 phase 전환(`DISCONNECTED → CONNECTING → CONNECTED`) 동안 2~3회 발사됐다.

**Fix** ([ConsultationPage.tsx](frontend/src/pages/consultation/ui/ConsultationPage.tsx)):
- `queueErrorToastShownRef`로 토스트 1회만 발사하도록 dedup (metrics에 이미 있던 동일 패턴 재사용).
- `loadQueue(isManualRetry = false)` 파라미터 추가 — 명시적 `onRetry` 클릭 시에만 ref 리셋.
- 두 effect를 **단일 effect**로 통합: 마운트/workspaceId 변경 시 1회 호출 + 별도 effect는 STOMP subscribe만 담당.

### Problem 2 — Demo Chat 시작 silent fail
이름 입력 후 "채팅 시작" 클릭 시 백엔드는 실제로 호출되지만 catch가 모든 에러를 `"채팅 세션을 시작할 수 없습니다."` 한 문구로 일반화. 사용자는 원인을 알 수 없고 빠져나갈 동선도 없음.

**Fix** ([UserChatPage.tsx](frontend/src/pages/user-chat/ui/UserChatPage.tsx)):
- `resolveSessionStartErrorMessage(error)` 분기 — `ApiRequestError.code === "DOMAIN_PACK_CURRENT_VERSION_NOT_FOUND"` / status 401·403 / 기타.
- `console.error("Failed to start demo chat session", error)` 로깅 추가.
- error UI를 `role="alert"` 카드로 확장: 큰 메시지 + "다시 시도" 버튼(`handleResetToNameForm`으로 이름 폼 복귀).

### Problem 3 — Workflow 상세 description 미표시
`/workspaces/.../workflows/{id}` 노드 카드에 description/iconHint/badges enrichment가 비어 보임. FE renderer는 정상이고, 백엔드 graphJson에 필드가 저장돼 있지 않은 것이 원인.

**Fix**:
- [DemoRefundRequestSeedRunner.java](backend/src/main/java/com/init/domainpack/infrastructure/DemoRefundRequestSeedRunner.java) `buildRefundRequestGraphJson()`의 9개 노드 각각에 `description` + `iconHint` 직접 저장.
- [DemoRefundSeedRunnerGuardTest.java](backend/src/test/java/com/init/domainpack/infrastructure/DemoRefundSeedRunnerGuardTest.java) — `ArgumentCaptor<WorkflowDefinition>`로 enriched description assertion.
- 기존 DB row(시드 skip 대상)에 대해서는 `jsonb_set` + `jsonb_agg`로 6개 워크플로 / 58개 노드 일괄 patch 실행 (`refund_request_flow`, `delivery_inquiry_flow`, `card_usage_dispute_flow`).

### 1단계 검증
- RTL: 추가 케이스 모두 PASS — Consultation toast dedup, retry, 단일 호출 / Demo Chat 에러 분기 + console.error + 다시 시도.
- 백엔드: `DemoRefundSeedRunnerGuardTest` 신규 케이스 PASS.
- Playwright runtime 캡처 (이전 세션): `problem1-consultation-after-fix-v2.png`, `problem2-chat-error-screen.png`, `problem3-workflow-descriptions.png`.

---

## 2단계: UI 전면 재구성

13" 노트북 환경에서 (1) 사이드바 폰트가 얇고 (2) 우측 정보 패널의 시각 대비가 부족하며 (3) 채팅 진입/대화 화면이 단조롭다는 보고에 따라 4개 면을 재구성.

### Sidebar (`Consultation` · `Chat` · `Uploads` · `Domain Packs`)
[Sidebar.tsx](frontend/src/shared/ui/ostone/chrome/Sidebar.tsx)
- `expandedStyle` inline 객체를 `buildLinkStyle({ isActive, ... })` helper로 추출.
- Pretendard Variable의 weight stop 직접 사용: idle 460 / active 600, fontSize 13.5px, letter-spacing -0.18px, fontFamily `var(--font-sans)`.
- active 항목은 `--paper-3` 배경 + 좌측 3px `--signal` 라인.
- `data-testid="sidebar-link-{key}"` 추가.

### Consultation 우측 정보 패널 (`CustomerPanel`)
[CustomerPanel.tsx](frontend/src/pages/consultation/ui/sections/CustomerPanel.tsx) — 5개 섹션을 카드 단위로 분리.
- **신규** [InfoCard.tsx](frontend/src/pages/consultation/ui/sections/InfoCard.tsx) — mono uppercase 헤더 + meta + 1px underline + `--paper` 카드 + subtle shadow.
- **신규** [InfoRow.tsx](frontend/src/pages/consultation/ui/sections/InfoRow.tsx) — 좌측 2px accent border (tone='default'|'signal'|'warn'|'danger'), label mono 10.5px `--ink-3`, value 12.5px.
- **신규** [ProgressStepper.tsx](frontend/src/pages/consultation/ui/sections/ProgressStepper.tsx) — segmented bar로 처리 단계 표시. **색깔만으로 상태 구분** (dot 제거): done=`signal-bg`/`signal`, active=`ink` 반전, todo=`paper-2`/`line-2`.
- STEPS 라벨 변경: `확인 중` → `확인 완료`(done), `처리 중` → `처리`(active).
- 데이터 자체(주문 ID, 카드번호 등 mock 값)는 본 PR 범위 밖 — 시각만 재구성.

### Chat 진입 (`/demo/workspaces/{id}/chat`)
- **신규** [ChatEntryScreen.tsx](frontend/src/pages/user-chat/ui/ChatEntryScreen.tsx) — full-screen split 카드 (좌 360px `--ink` brand 패널 + 우 form 패널, 880px max-w 2-column).
- 좌측: `CSTONE · DEMO CHAT` 모노 라벨 + serif italic 환영 카피 + 도메인 팩 hint chips(`환불 요청`/`배송 문의`/`결제 오류`) + `SESSION · NEW · Workspace #{id}` footer.
- 우측: mono eyebrow `Step 1 / 1` + h1 26px weight 540 + label/input + pill submit + ENTER 키 hint.

### Chat 대화
- **신규** [ChatHeader.tsx](frontend/src/pages/user-chat/ui/ChatHeader.tsx) — 40px avatar circle(이니셜) + mono eyebrow `Session #{id}` + h1 17px name + 우측 status pill(`OPEN` 시 signal-bg + 펄스 dot).
- **신규** [deriveAvatarInitial.ts](frontend/src/pages/user-chat/ui/deriveAvatarInitial.ts) — 한글 1자 / ASCII 2자 / 빈값 `?`.
- **신규** [ChatConversationScreen.tsx](frontend/src/pages/user-chat/ui/ChatConversationScreen.tsx) — Header + meta strip(`연결됨` dot + `{name} · N messages`) + MessageList + 에러 alert + MessageInput 합성.
- [MessageList.tsx](frontend/src/features/user-chat/ui/MessageList.tsx) 재작성 — paper-2 배경, bubble border-radius 12 + asymmetric tail(4px), subtle shadow, mono uppercase meta(`봇` `오후 06:44`), bot=`ink`/`paper`, user=`paper`/`ink`+1px border, `data-sender` 속성.
- [MessageInput.tsx](frontend/src/features/user-chat/ui/MessageInput.tsx) 재작성 — 파일 첨부 pill button(disabled, hint `파일 첨부 (예정)`) + 28px radius input + 42px circular send 버튼 (빈 입력 시 disabled).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 채팅 입장 화면 및 대화 화면 추가(채팅 헤더/아바타 포함)
  * 상담용 InfoCard, InfoRow, ProgressStepper 컴포넌트 추가
  * 환불 요청 워크플로우 노드에 설명(description) 필드 추가

* **버그 수정**
  * 대기열 로딩 실패 토스트 중복 방지
  * 데모 채팅 세션 시작 시 오류 메시지 개선 및 상세 처리

* **UI 개선**
  * 메시지 입력 폼·첨부·전송 버튼 상태 시각화 개선
  * 메시지 목록 렌더링 및 스타일 정리
  * 사이드바 활성 상태 스타일 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->