### PR TITLE
chore: Surface counselor messages in demo chat

### DIFF
--- a/backend/src/main/java/com/init/chatdemo/application/DemoChatSessionRegistrationService.java
+++ b/backend/src/main/java/com/init/chatdemo/application/DemoChatSessionRegistrationService.java
@@ -17,8 +17,11 @@ import com.init.workflowruntime.domain.ChatSessionStatus;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Service
 @Transactional(readOnly = true)
@@ -31,16 +34,19 @@ public class DemoChatSessionRegistrationService {
   private final ChatSessionRepository chatSessionRepository;
   private final ChatMessageRepository chatMessageRepository;
   private final LlmAssistantService llmAssistantService;
+  private final SimpMessagingTemplate messagingTemplate;
 
   public DemoChatSessionRegistrationService(
       DomainPackVersionRepository domainPackVersionRepository,
       ChatSessionRepository chatSessionRepository,
       ChatMessageRepository chatMessageRepository,
-      LlmAssistantService llmAssistantService) {
+      LlmAssistantService llmAssistantService,
+      SimpMessagingTemplate messagingTemplate) {
     this.domainPackVersionRepository = domainPackVersionRepository;
     this.chatSessionRepository = chatSessionRepository;
     this.chatMessageRepository = chatMessageRepository;
     this.llmAssistantService = llmAssistantService;
+    this.messagingTemplate = messagingTemplate;
   }
 
   @Transactional
@@ -101,8 +107,25 @@ public class DemoChatSessionRegistrationService {
         chatMessageRepository.save(
             ChatMessage.create(sessionId, nextSeqNo + 1, "ASSISTANT", "TEXT", assistantContent));
 
-    return List.of(
-        ChatMessageResponse.from(userMessage), ChatMessageResponse.from(assistantMessage));
+    List<ChatMessageResponse> responses =
+        List.of(ChatMessageResponse.from(userMessage), ChatMessageResponse.from(assistantMessage));
+    broadcastAfterCommit(sessionId, responses);
+    return responses;
+  }
+
+  public List<ChatMessageResponse> listMessages(Long workspaceId, Long sessionId) {
+    ChatSession session =
+        chatSessionRepository
+            .findById(sessionId)
+            .orElseThrow(
+                () ->
+                    new NotFoundException("SESSION_NOT_FOUND", "Session not found: " + sessionId));
+    if (!workspaceId.equals(session.getWorkspaceId())) {
+      throw new NotFoundException("SESSION_NOT_FOUND", "Session not found: " + sessionId);
+    }
+    return chatMessageRepository.findByChatSessionIdOrderBySeqNoAsc(sessionId).stream()
+        .map(ChatMessageResponse::from)
+        .toList();
   }
 
   private String normalizeCustomerName(String customerName) {
@@ -138,5 +161,23 @@ public class DemoChatSessionRegistrationService {
     return recentDesc.reversed().stream()
         .map(message -> message.getSenderRole() + ": " + message.getContent())
         .collect(Collectors.joining("\n"));
+  }
+
+  private void broadcastAfterCommit(Long sessionId, List<ChatMessageResponse> responses) {
+    Runnable broadcast =
+        () ->
+            responses.forEach(
+                response -> messagingTemplate.convertAndSend("/topic/chat." + sessionId, response));
+    if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+      broadcast.run();
+      return;
+    }
+    TransactionSynchronizationManager.registerSynchronization(
+        new TransactionSynchronization() {
+          @Override
+          public void afterCommit() {
+            broadcast.run();
+          }
+        });
   }
 }

--- a/backend/src/main/java/com/init/chatdemo/application/DemoChatSessionRegistrationService.java
+++ b/backend/src/main/java/com/init/chatdemo/application/DemoChatSessionRegistrationService.java
@@ -2,6 +2,8 @@ package com.init.chatdemo.application;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.init.chatdemo.application.dto.ListDemoChatMessagesCommand;
+import com.init.chatdemo.application.dto.ListDemoChatMessagesResult;
 import com.init.domainpack.domain.model.DomainPackVersion;
 import com.init.domainpack.domain.repository.DomainPackVersionRepository;
 import com.init.shared.application.exception.BadRequestException;
@@ -17,6 +19,8 @@ import com.init.workflowruntime.domain.ChatSessionStatus;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,6 +31,8 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 @Transactional(readOnly = true)
 public class DemoChatSessionRegistrationService {
 
+  private static final Logger log =
+      LoggerFactory.getLogger(DemoChatSessionRegistrationService.class);
   private static final String DEFAULT_CHANNEL = "WEB";
 
   private final ObjectMapper objectMapper = new ObjectMapper();
@@ -113,19 +119,22 @@ public class DemoChatSessionRegistrationService {
     return responses;
   }
 
-  public List<ChatMessageResponse> listMessages(Long workspaceId, Long sessionId) {
+  public ListDemoChatMessagesResult listMessages(ListDemoChatMessagesCommand command) {
     ChatSession session =
         chatSessionRepository
-            .findById(sessionId)
+            .findById(command.getSessionId())
             .orElseThrow(
                 () ->
-                    new NotFoundException("SESSION_NOT_FOUND", "Session not found: " + sessionId));
-    if (!workspaceId.equals(session.getWorkspaceId())) {
-      throw new NotFoundException("SESSION_NOT_FOUND", "Session not found: " + sessionId);
+                    new NotFoundException(
+                        "SESSION_NOT_FOUND", "Session not found: " + command.getSessionId()));
+    if (!command.getWorkspaceId().equals(session.getWorkspaceId())) {
+      throw new NotFoundException(
+          "SESSION_NOT_FOUND", "Session not found: " + command.getSessionId());
     }
-    return chatMessageRepository.findByChatSessionIdOrderBySeqNoAsc(sessionId).stream()
-        .map(ChatMessageResponse::from)
-        .toList();
+    return new ListDemoChatMessagesResult(
+        chatMessageRepository.findByChatSessionIdOrderBySeqNoAsc(command.getSessionId()).stream()
+            .map(ChatMessageResponse::from)
+            .toList());
   }
 
   private String normalizeCustomerName(String customerName) {
@@ -169,15 +178,23 @@ public class DemoChatSessionRegistrationService {
             responses.forEach(
                 response -> messagingTemplate.convertAndSend("/topic/chat." + sessionId, response));
     if (!TransactionSynchronizationManager.isSynchronizationActive()) {
-      broadcast.run();
+      runBroadcast(sessionId, broadcast);
       return;
     }
     TransactionSynchronizationManager.registerSynchronization(
         new TransactionSynchronization() {
           @Override
           public void afterCommit() {
-            broadcast.run();
+            runBroadcast(sessionId, broadcast);
           }
         });
+  }
+
+  private void runBroadcast(Long sessionId, Runnable broadcast) {
+    try {
+      broadcast.run();
+    } catch (RuntimeException e) {
+      log.warn("Demo chat broadcast failed. sessionId={}", sessionId, e);
+    }
   }
 }

--- a/backend/src/main/java/com/init/chatdemo/application/dto/ListDemoChatMessagesCommand.java
+++ b/backend/src/main/java/com/init/chatdemo/application/dto/ListDemoChatMessagesCommand.java
@@ -1,0 +1,20 @@
+package com.init.chatdemo.application.dto;
+
+public class ListDemoChatMessagesCommand {
+
+  private final Long workspaceId;
+  private final Long sessionId;
+
+  public ListDemoChatMessagesCommand(Long workspaceId, Long sessionId) {
+    this.workspaceId = workspaceId;
+    this.sessionId = sessionId;
+  }
+
+  public Long getWorkspaceId() {
+    return workspaceId;
+  }
+
+  public Long getSessionId() {
+    return sessionId;
+  }
+}

--- a/backend/src/main/java/com/init/chatdemo/application/dto/ListDemoChatMessagesResult.java
+++ b/backend/src/main/java/com/init/chatdemo/application/dto/ListDemoChatMessagesResult.java
@@ -1,0 +1,17 @@
+package com.init.chatdemo.application.dto;
+
+import com.init.workflowruntime.application.dto.ChatMessageResponse;
+import java.util.List;
+
+public class ListDemoChatMessagesResult {
+
+  private final List<ChatMessageResponse> messages;
+
+  public ListDemoChatMessagesResult(List<ChatMessageResponse> messages) {
+    this.messages = List.copyOf(messages);
+  }
+
+  public List<ChatMessageResponse> getMessages() {
+    return messages;
+  }
+}

--- a/backend/src/main/java/com/init/chatdemo/presentation/DemoRuntimeController.java
+++ b/backend/src/main/java/com/init/chatdemo/presentation/DemoRuntimeController.java
@@ -2,6 +2,8 @@ package com.init.chatdemo.presentation;
 
 import com.init.chatdemo.application.DemoChatSessionRegistrationService;
 import com.init.chatdemo.application.DemoRuntimeMockService;
+import com.init.chatdemo.application.dto.ListDemoChatMessagesCommand;
+import com.init.chatdemo.application.dto.ListDemoChatMessagesResult;
 import com.init.chatdemo.presentation.dto.CreateDemoChatSessionRequest;
 import com.init.chatdemo.presentation.dto.DemoChatSessionEndpointResponse;
 import com.init.chatdemo.presentation.dto.DemoChatWorkflowResponse;
@@ -72,7 +74,10 @@ public class DemoRuntimeController {
   @GetMapping("/chat-sessions/{sessionId}/messages")
   public ResponseEntity<List<ChatMessageResponse>> listChatMessages(
       @PathVariable Long workspaceId, @PathVariable Long sessionId) {
-    return ResponseEntity.ok(sessionRegistrationService.listMessages(workspaceId, sessionId));
+    ListDemoChatMessagesResult result =
+        sessionRegistrationService.listMessages(
+            new ListDemoChatMessagesCommand(workspaceId, sessionId));
+    return ResponseEntity.ok(result.getMessages());
   }
 
   @GetMapping("/workflow-executions/{executionId}")

--- a/backend/src/main/java/com/init/chatdemo/presentation/DemoRuntimeController.java
+++ b/backend/src/main/java/com/init/chatdemo/presentation/DemoRuntimeController.java
@@ -69,6 +69,12 @@ public class DemoRuntimeController {
         sessionRegistrationService.appendMessage(workspaceId, sessionId, request.content()));
   }
 
+  @GetMapping("/chat-sessions/{sessionId}/messages")
+  public ResponseEntity<List<ChatMessageResponse>> listChatMessages(
+      @PathVariable Long workspaceId, @PathVariable Long sessionId) {
+    return ResponseEntity.ok(sessionRegistrationService.listMessages(workspaceId, sessionId));
+  }
+
   @GetMapping("/workflow-executions/{executionId}")
   public ResponseEntity<DemoExecutionResponse> getWorkflowExecution(
       @PathVariable Long workspaceId, @PathVariable String executionId) {

--- a/backend/src/test/java/com/init/chatdemo/application/DemoChatSessionRegistrationServiceTest.java
+++ b/backend/src/test/java/com/init/chatdemo/application/DemoChatSessionRegistrationServiceTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -42,6 +43,7 @@ class DemoChatSessionRegistrationServiceTest {
   @Mock private ChatSessionRepository chatSessionRepository;
   @Mock private ChatMessageRepository chatMessageRepository;
   @Mock private LlmAssistantService llmAssistantService;
+  @Mock private SimpMessagingTemplate messagingTemplate;
 
   private DemoChatSessionRegistrationService service;
 
@@ -52,7 +54,8 @@ class DemoChatSessionRegistrationServiceTest {
             domainPackVersionRepository,
             chatSessionRepository,
             chatMessageRepository,
-            llmAssistantService);
+            llmAssistantService,
+            messagingTemplate);
   }
 
   @Test
@@ -123,6 +126,27 @@ class DemoChatSessionRegistrationServiceTest {
         .containsExactly(1, 2);
     assertThat(messageCaptor.getAllValues().get(1).getContent()).isEqualTo("LLM 응답입니다.");
     verify(llmAssistantService).generateResponse("USER: Hello", "Hello");
+    verify(messagingTemplate).convertAndSend("/topic/chat.77", responses.get(0));
+    verify(messagingTemplate).convertAndSend("/topic/chat.77", responses.get(1));
+  }
+
+  @Test
+  @DisplayName("데모 세션 메시지를 runtime.chat_message에서 시간순으로 조회한다")
+  void should_listRegisteredMessages_when_listMessages() {
+    ChatSession session =
+        ChatSession.create(WORKSPACE_ID, VERSION_ID, ChatSessionStatus.OPEN, "WEB", "{}");
+    ReflectionTestUtils.setField(session, "id", SESSION_ID);
+    ChatMessage greeting = ChatMessage.create(SESSION_ID, 1, "ASSISTANT", "TEXT", "안녕하세요");
+    ReflectionTestUtils.setField(greeting, "id", 1L);
+    given(chatSessionRepository.findById(SESSION_ID)).willReturn(Optional.of(session));
+    given(chatMessageRepository.findByChatSessionIdOrderBySeqNoAsc(SESSION_ID))
+        .willReturn(List.of(greeting));
+
+    List<ChatMessageResponse> responses = service.listMessages(WORKSPACE_ID, SESSION_ID);
+
+    assertThat(responses).hasSize(1);
+    assertThat(responses.get(0).senderRole()).isEqualTo("ASSISTANT");
+    assertThat(responses.get(0).content()).isEqualTo("안녕하세요");
   }
 
   @Test

--- a/backend/src/test/java/com/init/chatdemo/application/DemoChatSessionRegistrationServiceTest.java
+++ b/backend/src/test/java/com/init/chatdemo/application/DemoChatSessionRegistrationServiceTest.java
@@ -1,12 +1,18 @@
 package com.init.chatdemo.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import com.init.chatdemo.application.dto.ListDemoChatMessagesCommand;
+import com.init.chatdemo.application.dto.ListDemoChatMessagesResult;
 import com.init.domainpack.domain.model.DomainPackVersion;
 import com.init.domainpack.domain.repository.DomainPackVersionRepository;
 import com.init.shared.application.exception.BadRequestException;
@@ -30,6 +36,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("DemoChatSessionRegistrationService")
@@ -142,11 +150,27 @@ class DemoChatSessionRegistrationServiceTest {
     given(chatMessageRepository.findByChatSessionIdOrderBySeqNoAsc(SESSION_ID))
         .willReturn(List.of(greeting));
 
-    List<ChatMessageResponse> responses = service.listMessages(WORKSPACE_ID, SESSION_ID);
+    ListDemoChatMessagesResult result =
+        service.listMessages(new ListDemoChatMessagesCommand(WORKSPACE_ID, SESSION_ID));
 
+    List<ChatMessageResponse> responses = result.getMessages();
     assertThat(responses).hasSize(1);
     assertThat(responses.get(0).senderRole()).isEqualTo("ASSISTANT");
     assertThat(responses.get(0).content()).isEqualTo("안녕하세요");
+  }
+
+  @Test
+  @DisplayName("다른 워크스페이스의 데모 세션 메시지는 조회하지 않는다")
+  void should_throwNotFound_when_listMessagesWorkspaceMismatch() {
+    ChatSession session =
+        ChatSession.create(WORKSPACE_ID + 1, VERSION_ID, ChatSessionStatus.OPEN, "WEB", "{}");
+    ReflectionTestUtils.setField(session, "id", SESSION_ID);
+    given(chatSessionRepository.findById(SESSION_ID)).willReturn(Optional.of(session));
+
+    assertThatThrownBy(
+            () -> service.listMessages(new ListDemoChatMessagesCommand(WORKSPACE_ID, SESSION_ID)))
+        .isInstanceOf(NotFoundException.class)
+        .hasMessageContaining("Session not found: 77");
   }
 
   @Test
@@ -195,5 +219,43 @@ class DemoChatSessionRegistrationServiceTest {
         .isInstanceOf(BadRequestException.class);
     assertThatThrownBy(() -> service.appendMessage(WORKSPACE_ID, SESSION_ID, " "))
         .isInstanceOf(BadRequestException.class);
+  }
+
+  @Test
+  @DisplayName("트랜잭션 커밋 후 WebSocket 브로드캐스트 실패는 API 응답을 깨지 않는다")
+  void should_swallowBroadcastError_afterCommit() {
+    ChatSession session =
+        ChatSession.create(WORKSPACE_ID, VERSION_ID, ChatSessionStatus.OPEN, "WEB", "{}");
+    ReflectionTestUtils.setField(session, "id", SESSION_ID);
+    given(chatSessionRepository.findByIdForUpdate(SESSION_ID)).willReturn(Optional.of(session));
+    given(chatMessageRepository.findTopByChatSessionIdOrderBySeqNoDesc(SESSION_ID))
+        .willReturn(Optional.empty());
+    given(chatMessageRepository.findTop5ByChatSessionIdOrderBySeqNoDesc(SESSION_ID))
+        .willReturn(List.of());
+    given(llmAssistantService.generateResponse("", "Hello")).willReturn("LLM 응답입니다.");
+    given(chatMessageRepository.save(any(ChatMessage.class)))
+        .willAnswer(invocation -> invocation.getArgument(0));
+    doThrow(new RuntimeException("broker unavailable"))
+        .when(messagingTemplate)
+        .convertAndSend(eq("/topic/chat.77"), any(ChatMessageResponse.class));
+
+    TransactionSynchronizationManager.initSynchronization();
+    try {
+      List<ChatMessageResponse> responses =
+          service.appendMessage(WORKSPACE_ID, SESSION_ID, "Hello");
+
+      assertThat(responses).hasSize(2);
+      verify(messagingTemplate, never())
+          .convertAndSend(eq("/topic/chat.77"), any(ChatMessageResponse.class));
+      assertThatCode(
+              () ->
+                  TransactionSynchronizationManager.getSynchronizations().stream()
+                      .forEach(TransactionSynchronization::afterCommit))
+          .doesNotThrowAnyException();
+      verify(messagingTemplate)
+          .convertAndSend(eq("/topic/chat.77"), any(ChatMessageResponse.class));
+    } finally {
+      TransactionSynchronizationManager.clearSynchronization();
+    }
   }
 }

--- a/backend/src/test/java/com/init/chatdemo/presentation/DemoRuntimeControllerTest.java
+++ b/backend/src/test/java/com/init/chatdemo/presentation/DemoRuntimeControllerTest.java
@@ -1,5 +1,6 @@
 package com.init.chatdemo.presentation;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -11,6 +12,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.init.chatdemo.application.DemoChatSessionRegistrationService;
 import com.init.chatdemo.application.DemoRuntimeMockService;
+import com.init.chatdemo.application.dto.ListDemoChatMessagesCommand;
+import com.init.chatdemo.application.dto.ListDemoChatMessagesResult;
 import com.init.chatdemo.presentation.dto.DemoChatSessionEndpointResponse;
 import com.init.chatdemo.presentation.dto.DemoChatSessionResponse;
 import com.init.chatdemo.presentation.dto.DemoChatWorkflowResponse;
@@ -194,16 +197,17 @@ class DemoRuntimeControllerTest {
   @Test
   @DisplayName("GET /api/v1/demo/chat-sessions/{sessionId}/messages → 데모 메시지 목록 조회")
   void should_200_when_listRegisteredChatMessages() throws Exception {
-    given(sessionRegistrationService.listMessages(10L, 77L))
+    given(sessionRegistrationService.listMessages(any(ListDemoChatMessagesCommand.class)))
         .willReturn(
-            List.of(
-                new ChatMessageResponse(
-                    1L,
-                    1,
-                    "COUNSELOR",
-                    "TEXT",
-                    "상담사 답변입니다.",
-                    OffsetDateTime.parse("2026-05-22T00:00:00Z"))));
+            new ListDemoChatMessagesResult(
+                List.of(
+                    new ChatMessageResponse(
+                        1L,
+                        1,
+                        "COUNSELOR",
+                        "TEXT",
+                        "상담사 답변입니다.",
+                        OffsetDateTime.parse("2026-05-22T00:00:00Z")))));
 
     mockMvc
         .perform(get(DEMO_URL_PREFIX + "/chat-sessions/77/messages"))

--- a/backend/src/test/java/com/init/chatdemo/presentation/DemoRuntimeControllerTest.java
+++ b/backend/src/test/java/com/init/chatdemo/presentation/DemoRuntimeControllerTest.java
@@ -192,6 +192,27 @@ class DemoRuntimeControllerTest {
   }
 
   @Test
+  @DisplayName("GET /api/v1/demo/chat-sessions/{sessionId}/messages → 데모 메시지 목록 조회")
+  void should_200_when_listRegisteredChatMessages() throws Exception {
+    given(sessionRegistrationService.listMessages(10L, 77L))
+        .willReturn(
+            List.of(
+                new ChatMessageResponse(
+                    1L,
+                    1,
+                    "COUNSELOR",
+                    "TEXT",
+                    "상담사 답변입니다.",
+                    OffsetDateTime.parse("2026-05-22T00:00:00Z"))));
+
+    mockMvc
+        .perform(get(DEMO_URL_PREFIX + "/chat-sessions/77/messages"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].senderRole").value("COUNSELOR"))
+        .andExpect(jsonPath("$[0].content").value("상담사 답변입니다."));
+  }
+
+  @Test
   @DisplayName("POST /api/v1/demo/chat-sessions/{sessionId}/messages → content 공백이면 400")
   void should_400_when_appendRegisteredChatMessageWithBlankContent() throws Exception {
     mockMvc

--- a/frontend/src/entities/chat/api/chatApi.test.ts
+++ b/frontend/src/entities/chat/api/chatApi.test.ts
@@ -3,6 +3,7 @@ import {
   createChatSession,
   createDemoChatSession,
   listChatMessages,
+  listDemoChatMessages,
   registerDemoChatSession,
   sendDemoChatMessage,
 } from "./chatApi";
@@ -184,6 +185,34 @@ describe("chatApi", () => {
         method: "POST",
         body: JSON.stringify({ content: "Hello" }),
       },
+    );
+  });
+
+  it("백엔드 데모 채팅 메시지를 조회한다", async () => {
+    customFetchMock.mockResolvedValue([
+      {
+        id: 91,
+        seqNo: 4,
+        senderRole: "COUNSELOR",
+        messageType: "TEXT",
+        content: "상담사 답변입니다.",
+        createdAt: "2026-05-22T00:00:03Z",
+      },
+    ]);
+
+    await expect(listDemoChatMessages(2, "77")).resolves.toEqual([
+      {
+        id: "91",
+        sessionId: 77,
+        senderType: "AGENT",
+        content: "상담사 답변입니다.",
+        createdAt: "2026-05-22T00:00:03Z",
+      },
+    ]);
+
+    expect(customFetchMock).toHaveBeenCalledWith(
+      "/api/v1/workspaces/2/demo/chat-sessions/77/messages",
+      { method: "GET" },
     );
   });
 

--- a/frontend/src/entities/chat/api/chatApi.test.ts
+++ b/frontend/src/entities/chat/api/chatApi.test.ts
@@ -162,7 +162,7 @@ describe("chatApi", () => {
       },
     ]);
 
-    await expect(sendDemoChatMessage(2, "77", "Hello")).resolves.toEqual([
+    await expect(sendDemoChatMessage(2, " 77 ", "Hello")).resolves.toEqual([
       {
         id: "81",
         sessionId: 77,
@@ -218,6 +218,16 @@ describe("chatApi", () => {
 
   it("숫자가 아닌 데모 세션 id로 메시지를 보내지 않는다", async () => {
     await expect(sendDemoChatMessage(2, "workspace-2-demo-session", "Hello")).rejects.toThrow(
+      "Demo chat session id must be numeric.",
+    );
+    expect(customFetchMock).not.toHaveBeenCalled();
+  });
+
+  it("정수 문자열이 아닌 데모 세션 id로 메시지를 조회하지 않는다", async () => {
+    await expect(listDemoChatMessages(2, "1e2")).rejects.toThrow(
+      "Demo chat session id must be numeric.",
+    );
+    await expect(listDemoChatMessages(2, "77.5")).rejects.toThrow(
       "Demo chat session id must be numeric.",
     );
     expect(customFetchMock).not.toHaveBeenCalled();

--- a/frontend/src/entities/chat/api/chatApi.ts
+++ b/frontend/src/entities/chat/api/chatApi.ts
@@ -173,3 +173,18 @@ export async function sendDemoChatMessage(
   );
   return messages.map((message) => toChatMessage(message, numericSessionId));
 }
+
+export async function listDemoChatMessages(
+  workspaceId: number,
+  sessionId: string,
+): Promise<ChatMessage[]> {
+  const numericSessionId = Number(sessionId);
+  if (!Number.isFinite(numericSessionId)) {
+    throw new Error("Demo chat session id must be numeric.");
+  }
+  const messages = await customFetch<ChatMessageResponse[]>(
+    `/api/v1/workspaces/${workspaceId}/demo/chat-sessions/${sessionId}/messages`,
+    { method: "GET" },
+  );
+  return messages.map((message) => toChatMessage(message, numericSessionId));
+}

--- a/frontend/src/entities/chat/api/chatApi.ts
+++ b/frontend/src/entities/chat/api/chatApi.ts
@@ -1,14 +1,11 @@
 import { customFetch } from "@/shared/api/mutator";
 import type { ChatMessage, ChatSession } from "@/entities/chat/model/types";
-
-interface ChatMessageResponse {
-  id: number;
-  seqNo: number;
-  senderRole: string;
-  messageType: string;
-  content: string;
-  createdAt: string;
-}
+import {
+  parseDemoSessionId,
+  toChatMessage,
+  toSenderType,
+  type ChatMessageResponse,
+} from "../lib/chatMessageSync";
 
 interface DemoChatWorkflowResponse {
   chatSession?: {
@@ -49,40 +46,18 @@ function requireBackendSessionId(id: number | undefined): number {
   return id;
 }
 
-function toSenderType(senderRole: string): ChatMessage["senderType"] {
-  if (senderRole === "USER" || senderRole === "CUSTOMER") return "USER";
-  if (senderRole === "AGENT" || senderRole === "COUNSELOR") return "AGENT";
-  return "BOT";
-}
-
-function toChatMessage(message: ChatMessageResponse, sessionId: number): ChatMessage {
-  return {
-    id: String(message.id),
-    sessionId,
-    content: message.content,
-    senderType: toSenderType(message.senderRole),
-    createdAt: message.createdAt,
-  };
-}
-
-function toDemoSenderType(role?: string): ChatMessage["senderType"] {
-  if (role === "user" || role === "customer") return "USER";
-  if (role === "agent" || role === "counselor") return "AGENT";
-  return "BOT";
-}
-
 function toDemoChatMessage(
   message: DemoMessageResponse,
   index: number,
   customerName: string,
 ): ChatMessage {
-  const senderType = toDemoSenderType(message.role);
+  const senderType = toSenderType(message.role ?? "");
   return {
     id: message.id ?? `demo-message-${index}`,
     sessionId: 0,
     content: message.content ?? "",
     senderType,
-    senderName: senderType === "USER" ? customerName : undefined,
+    ...(senderType === "USER" ? { senderName: customerName } : {}),
     createdAt: message.timestamp ?? new Date().toISOString(),
   };
 }
@@ -160,12 +135,9 @@ export async function sendDemoChatMessage(
   sessionId: string,
   content: string,
 ): Promise<ChatMessage[]> {
-  const numericSessionId = Number(sessionId);
-  if (!Number.isFinite(numericSessionId)) {
-    throw new Error("Demo chat session id must be numeric.");
-  }
+  const numericSessionId = parseDemoSessionId(sessionId);
   const messages = await customFetch<ChatMessageResponse[]>(
-    `/api/v1/workspaces/${workspaceId}/demo/chat-sessions/${sessionId}/messages`,
+    `/api/v1/workspaces/${workspaceId}/demo/chat-sessions/${numericSessionId}/messages`,
     {
       method: "POST",
       body: JSON.stringify({ content }),
@@ -178,12 +150,9 @@ export async function listDemoChatMessages(
   workspaceId: number,
   sessionId: string,
 ): Promise<ChatMessage[]> {
-  const numericSessionId = Number(sessionId);
-  if (!Number.isFinite(numericSessionId)) {
-    throw new Error("Demo chat session id must be numeric.");
-  }
+  const numericSessionId = parseDemoSessionId(sessionId);
   const messages = await customFetch<ChatMessageResponse[]>(
-    `/api/v1/workspaces/${workspaceId}/demo/chat-sessions/${sessionId}/messages`,
+    `/api/v1/workspaces/${workspaceId}/demo/chat-sessions/${numericSessionId}/messages`,
     { method: "GET" },
   );
   return messages.map((message) => toChatMessage(message, numericSessionId));

--- a/frontend/src/entities/chat/index.ts
+++ b/frontend/src/entities/chat/index.ts
@@ -2,6 +2,7 @@ export {
   createChatSession,
   createDemoChatSession,
   listChatMessages,
+  listDemoChatMessages,
   registerDemoChatSession,
   sendDemoChatMessage,
 } from "@/entities/chat/api/chatApi";

--- a/frontend/src/entities/chat/lib/chatMessageSync.test.ts
+++ b/frontend/src/entities/chat/lib/chatMessageSync.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+import type { ChatMessage } from "../model/types";
+import {
+  isChatMessageResponse,
+  isRealtimeChatMessage,
+  mergeMessages,
+  mergePersistedMessages,
+  parseDemoSessionId,
+  toChatMessage,
+  toRealtimeChatMessage,
+  toSenderType,
+  tryParseDemoSessionId,
+  withCustomerNames,
+} from "./chatMessageSync";
+
+describe("chatMessageSync", () => {
+  it("데모 세션 id를 정수 문자열로만 파싱한다", () => {
+    expect(parseDemoSessionId(" 77 ")).toBe(77);
+    expect(tryParseDemoSessionId("88")).toBe(88);
+    expect(tryParseDemoSessionId("1e2")).toBeNull();
+    expect(() => parseDemoSessionId("77.5")).toThrow("Demo chat session id must be numeric.");
+    expect(() => parseDemoSessionId("workspace-2-demo-session")).toThrow(
+      "Demo chat session id must be numeric.",
+    );
+    expect(() => parseDemoSessionId(`${Number.MAX_SAFE_INTEGER + 1}`)).toThrow(
+      "Demo chat session id must be numeric.",
+    );
+  });
+
+  it("백엔드 메시지 응답 여부를 판별하고 UI 모델로 변환한다", () => {
+    const response = {
+      id: 91,
+      seqNo: 4,
+      senderRole: "COUNSELOR",
+      messageType: "TEXT",
+      content: "상담사 답변입니다.",
+      createdAt: "2026-05-22T00:00:03Z",
+    };
+
+    expect(isChatMessageResponse(response)).toBe(true);
+    expect(isChatMessageResponse({ ...response, seqNo: "4" })).toBe(false);
+    expect(toChatMessage(response, 77)).toEqual({
+      id: "91",
+      sessionId: 77,
+      senderType: "AGENT",
+      content: "상담사 답변입니다.",
+      createdAt: "2026-05-22T00:00:03Z",
+    });
+  });
+
+  it("실시간 메시지를 판별하고 고객 이름을 사용자 메시지에만 부여한다", () => {
+    expect(
+      isRealtimeChatMessage({
+        id: "local-1",
+        senderRole: "customer",
+        content: "안녕하세요",
+        createdAt: "2026-05-22T00:00:01Z",
+      }),
+    ).toBe(true);
+    expect(isRealtimeChatMessage({ id: "local-1", senderRole: "USER" })).toBe(false);
+    expect(toSenderType("ASSISTANT")).toBe("BOT");
+
+    expect(
+      toRealtimeChatMessage(
+        {
+          id: "local-1",
+          senderRole: "CUSTOMER",
+          content: "안녕하세요",
+          createdAt: "2026-05-22T00:00:01Z",
+        },
+        77,
+        "김민지",
+      ),
+    ).toEqual({
+      id: "local-1",
+      sessionId: 77,
+      senderType: "USER",
+      senderName: "김민지",
+      content: "안녕하세요",
+      createdAt: "2026-05-22T00:00:01Z",
+    });
+
+    expect(
+      toRealtimeChatMessage(
+        {
+          id: 92,
+          senderRole: "COUNSELOR",
+          content: "도와드릴게요.",
+          createdAt: "2026-05-22T00:00:02Z",
+        },
+        77,
+        "김민지",
+      ),
+    ).not.toHaveProperty("senderName");
+  });
+
+  it("메시지를 id 기준으로 병합하고 생성 시각 순으로 정렬한다", () => {
+    const currentMessages: ChatMessage[] = [
+      {
+        id: "2",
+        sessionId: 77,
+        senderType: "BOT",
+        content: "이전 답변",
+        createdAt: "2026-05-22T00:00:02Z",
+      },
+      {
+        id: "1",
+        sessionId: 77,
+        senderType: "USER",
+        content: "이전 질문",
+        createdAt: "2026-05-22T00:00:01Z",
+      },
+    ];
+    const nextMessages: ChatMessage[] = [
+      {
+        id: "2",
+        sessionId: 77,
+        senderType: "AGENT",
+        content: "상담사 답변",
+        createdAt: "2026-05-22T00:00:03Z",
+      },
+    ];
+
+    expect(mergeMessages(currentMessages, nextMessages)).toEqual([
+      currentMessages[1],
+      nextMessages[0],
+    ]);
+  });
+
+  it("저장 메시지는 optimistic 메시지만 유지한 뒤 백엔드 메시지와 병합한다", () => {
+    const currentMessages: ChatMessage[] = [
+      {
+        id: "local-user-1",
+        sessionId: 0,
+        senderType: "USER",
+        content: "전송 중",
+        createdAt: "2026-05-22T00:00:01Z",
+      },
+      {
+        id: "old-1",
+        sessionId: 77,
+        senderType: "BOT",
+        content: "오래된 응답",
+        createdAt: "2026-05-22T00:00:00Z",
+      },
+    ];
+    const persistedMessages = withCustomerNames(
+      [
+        {
+          id: "91",
+          sessionId: 77,
+          senderType: "USER",
+          content: "저장된 질문",
+          createdAt: "2026-05-22T00:00:02Z",
+        },
+      ],
+      "김민지",
+    );
+
+    expect(mergePersistedMessages(currentMessages, persistedMessages)).toEqual([
+      currentMessages[0],
+      {
+        ...persistedMessages[0],
+        senderName: "김민지",
+      },
+    ]);
+  });
+});

--- a/frontend/src/entities/chat/lib/chatMessageSync.ts
+++ b/frontend/src/entities/chat/lib/chatMessageSync.ts
@@ -1,0 +1,129 @@
+import type { ChatMessage } from "../model/types";
+
+const DEMO_SESSION_ID_PATTERN = /^\d+$/;
+
+export interface ChatMessageResponse {
+  id: number;
+  seqNo: number;
+  senderRole: string;
+  messageType: string;
+  content: string;
+  createdAt: string;
+}
+
+export interface RealtimeChatMessage {
+  id: number | string;
+  senderRole: string;
+  content: string;
+  createdAt: string;
+}
+
+export function parseDemoSessionId(sessionId: string): number {
+  const normalizedSessionId = sessionId.trim();
+  if (!DEMO_SESSION_ID_PATTERN.test(normalizedSessionId)) {
+    throw new Error("Demo chat session id must be numeric.");
+  }
+
+  const numericSessionId = Number(normalizedSessionId);
+  if (!Number.isSafeInteger(numericSessionId)) {
+    throw new Error("Demo chat session id must be numeric.");
+  }
+
+  return numericSessionId;
+}
+
+export function tryParseDemoSessionId(sessionId: string): number | null {
+  try {
+    return parseDemoSessionId(sessionId);
+  } catch {
+    return null;
+  }
+}
+
+export function isChatMessageResponse(message: unknown): message is ChatMessageResponse {
+  if (!message || typeof message !== "object") return false;
+
+  const candidate = message as Partial<ChatMessageResponse>;
+  return (
+    typeof candidate.id === "number" &&
+    typeof candidate.seqNo === "number" &&
+    typeof candidate.senderRole === "string" &&
+    typeof candidate.messageType === "string" &&
+    typeof candidate.content === "string" &&
+    typeof candidate.createdAt === "string"
+  );
+}
+
+export function isRealtimeChatMessage(message: unknown): message is RealtimeChatMessage {
+  if (!message || typeof message !== "object") return false;
+
+  const candidate = message as Partial<RealtimeChatMessage>;
+  return (
+    (typeof candidate.id === "number" || typeof candidate.id === "string") &&
+    typeof candidate.senderRole === "string" &&
+    typeof candidate.content === "string" &&
+    typeof candidate.createdAt === "string"
+  );
+}
+
+export function toSenderType(senderRole: string): ChatMessage["senderType"] {
+  const normalizedRole = senderRole.toUpperCase();
+  if (normalizedRole === "USER" || normalizedRole === "CUSTOMER") return "USER";
+  if (normalizedRole === "AGENT" || normalizedRole === "COUNSELOR") return "AGENT";
+  return "BOT";
+}
+
+export function toChatMessage(message: ChatMessageResponse, sessionId: number): ChatMessage {
+  return {
+    id: String(message.id),
+    sessionId,
+    content: message.content,
+    senderType: toSenderType(message.senderRole),
+    createdAt: message.createdAt,
+  };
+}
+
+export function toRealtimeChatMessage(
+  message: RealtimeChatMessage,
+  sessionId: number,
+  customerName?: string,
+): ChatMessage {
+  const senderType = toSenderType(message.senderRole);
+  return {
+    id: String(message.id),
+    sessionId,
+    content: message.content,
+    senderType,
+    ...(senderType === "USER" ? { senderName: customerName } : {}),
+    createdAt: message.createdAt,
+  };
+}
+
+export function compareMessageCreatedAt(a: ChatMessage, b: ChatMessage): number {
+  return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+}
+
+export function mergeMessages(
+  currentMessages: ChatMessage[],
+  nextMessages: ChatMessage[],
+): ChatMessage[] {
+  const byId = new Map<string, ChatMessage>();
+  [...currentMessages, ...nextMessages].forEach((message) => {
+    byId.set(message.id, message);
+  });
+  return Array.from(byId.values()).sort(compareMessageCreatedAt);
+}
+
+export function withCustomerNames(messages: ChatMessage[], customerName: string): ChatMessage[] {
+  return messages.map((message) =>
+    message.senderType === "USER" ? { ...message, senderName: customerName } : message,
+  );
+}
+
+export function mergePersistedMessages(
+  currentMessages: ChatMessage[],
+  persistedMessages: ChatMessage[],
+): ChatMessage[] {
+  const optimisticMessages = currentMessages.filter((message) => message.id.startsWith("local-"));
+  return mergeMessages(optimisticMessages, persistedMessages);
+}

--- a/frontend/src/features/user-chat/ui/ChatRoom.tsx
+++ b/frontend/src/features/user-chat/ui/ChatRoom.tsx
@@ -1,5 +1,10 @@
 import { useEffect, useState } from "react";
 import { listChatMessages, type ChatMessage } from "@/entities/chat";
+import {
+  isChatMessageResponse,
+  mergeMessages,
+  toChatMessage,
+} from "@/entities/chat/lib/chatMessageSync";
 import { useStomp } from "@/shared/lib/websocket";
 import { ConnectionStatus } from "./ConnectionStatus";
 import { MessageInput } from "./MessageInput";
@@ -22,57 +27,6 @@ function isChatMessage(message: unknown): message is ChatMessage {
       candidate.senderType === "BOT" ||
       candidate.senderType === "AGENT")
   );
-}
-
-interface ChatMessageResponse {
-  id: number;
-  seqNo: number;
-  senderRole: string;
-  messageType: string;
-  content: string;
-  createdAt: string;
-}
-
-function isChatMessageResponse(message: unknown): message is ChatMessageResponse {
-  if (!message || typeof message !== "object") return false;
-
-  const candidate = message as Partial<ChatMessageResponse>;
-  return (
-    typeof candidate.id === "number" &&
-    typeof candidate.seqNo === "number" &&
-    typeof candidate.senderRole === "string" &&
-    typeof candidate.messageType === "string" &&
-    typeof candidate.content === "string" &&
-    typeof candidate.createdAt === "string"
-  );
-}
-
-function toSenderType(senderRole: string): ChatMessage["senderType"] {
-  if (senderRole === "USER" || senderRole === "CUSTOMER") return "USER";
-  if (senderRole === "AGENT" || senderRole === "COUNSELOR") return "AGENT";
-  return "BOT";
-}
-
-function toChatMessage(message: ChatMessageResponse, sessionId: number): ChatMessage {
-  return {
-    id: String(message.id),
-    sessionId,
-    content: message.content,
-    senderType: toSenderType(message.senderRole),
-    createdAt: message.createdAt,
-  };
-}
-
-function compareMessageCreatedAt(a: ChatMessage, b: ChatMessage): number {
-  return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
-}
-
-function mergeMessages(currentMessages: ChatMessage[], nextMessages: ChatMessage[]): ChatMessage[] {
-  const byId = new Map<string, ChatMessage>();
-  [...currentMessages, ...nextMessages].forEach((message) => {
-    byId.set(message.id, message);
-  });
-  return Array.from(byId.values()).sort(compareMessageCreatedAt);
 }
 
 export function ChatRoom({ sessionId }: ChatRoomProps) {

--- a/frontend/src/pages/user-chat/ui/UserChatPage.test.tsx
+++ b/frontend/src/pages/user-chat/ui/UserChatPage.test.tsx
@@ -120,6 +120,25 @@ describe("UserChatPage", () => {
     expect(registerDemoChatSessionMock).not.toHaveBeenCalled();
   });
 
+  it("백엔드에 저장된 상담사 메시지를 동기화해 화면에 표시한다", async () => {
+    listDemoChatMessagesMock.mockResolvedValueOnce([
+      {
+        id: "91",
+        sessionId: 77,
+        content: "저장된 상담사 답변입니다.",
+        senderType: "AGENT",
+        createdAt: "2026-05-22T00:00:03Z",
+      },
+    ]);
+
+    render(<UserChatPage />);
+    fireEvent.change(screen.getByLabelText("이름"), { target: { value: "김민지" } });
+    fireEvent.click(screen.getByRole("button", { name: "채팅 시작" }));
+
+    expect(await screen.findByText("저장된 상담사 답변입니다.")).not.toBeNull();
+    expect(listDemoChatMessagesMock).toHaveBeenCalledWith(42, "77");
+  });
+
   it("메시지 전송 실패 시 optimistic 메시지를 되돌린다", async () => {
     sendDemoChatMessageMock.mockRejectedValueOnce(new Error("LLM failed"));
 

--- a/frontend/src/pages/user-chat/ui/UserChatPage.test.tsx
+++ b/frontend/src/pages/user-chat/ui/UserChatPage.test.tsx
@@ -1,17 +1,33 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ApiRequestError } from "@/shared/api";
 import { UserChatPage } from "./UserChatPage";
 
-const { registerDemoChatSessionMock, sendDemoChatMessageMock, routeState } = vi.hoisted(() => ({
+const {
+  listDemoChatMessagesMock,
+  registerDemoChatSessionMock,
+  sendDemoChatMessageMock,
+  routeState,
+  stompState,
+} = vi.hoisted(() => ({
+  listDemoChatMessagesMock: vi.fn(),
   registerDemoChatSessionMock: vi.fn(),
   sendDemoChatMessageMock: vi.fn(),
   routeState: { workspaceId: "42" as string | undefined },
+  stompState: {
+    connectionStatus: "DISCONNECTED",
+    subscribe: vi.fn(),
+  },
 }));
 
 vi.mock("@/entities/chat", () => ({
+  listDemoChatMessages: listDemoChatMessagesMock,
   registerDemoChatSession: registerDemoChatSessionMock,
   sendDemoChatMessage: sendDemoChatMessageMock,
+}));
+
+vi.mock("@/shared/lib/websocket", () => ({
+  useStomp: () => stompState,
 }));
 
 vi.mock("react-router-dom", async () => {
@@ -26,6 +42,11 @@ describe("UserChatPage", () => {
   beforeEach(() => {
     routeState.workspaceId = "42";
     window.localStorage.clear();
+    stompState.connectionStatus = "DISCONNECTED";
+    stompState.subscribe.mockReset();
+    stompState.subscribe.mockReturnValue(() => {});
+    listDemoChatMessagesMock.mockReset();
+    listDemoChatMessagesMock.mockRejectedValue(new Error("sync unavailable"));
     registerDemoChatSessionMock.mockReset();
     sendDemoChatMessageMock.mockReset();
     registerDemoChatSessionMock.mockResolvedValue({
@@ -114,6 +135,34 @@ describe("UserChatPage", () => {
       await screen.findByText("응답을 생성하지 못했습니다. 잠시 후 다시 시도해 주세요."),
     ).not.toBeNull();
     expect(screen.queryByText("Hello")).toBeNull();
+  });
+
+  it("상담사 WebSocket 메시지를 고객 화면에 반영한다", async () => {
+    let topicHandler: ((message: unknown) => void) | undefined;
+    stompState.connectionStatus = "CONNECTED";
+    stompState.subscribe.mockImplementation((_topic: string, cb: (message: unknown) => void) => {
+      topicHandler = cb;
+      return () => {};
+    });
+
+    render(<UserChatPage />);
+    fireEvent.change(screen.getByLabelText("이름"), { target: { value: "김민지" } });
+    fireEvent.click(screen.getByRole("button", { name: "채팅 시작" }));
+
+    await screen.findByTestId("chat-header-eyebrow");
+
+    expect(stompState.subscribe).toHaveBeenCalledWith("/topic/chat.77", expect.any(Function));
+
+    act(() => {
+      topicHandler?.({
+        id: 91,
+        senderRole: "COUNSELOR",
+        content: "상담사 답변입니다.",
+        createdAt: "2026-05-22T00:00:03Z",
+      });
+    });
+
+    expect(await screen.findByText("상담사 답변입니다.")).not.toBeNull();
   });
 
   it("이름이 비어 있으면 세션을 생성하지 않는다", async () => {

--- a/frontend/src/pages/user-chat/ui/UserChatPage.tsx
+++ b/frontend/src/pages/user-chat/ui/UserChatPage.tsx
@@ -1,8 +1,13 @@
-import { type FormEvent, useRef, useState } from "react";
+import { type FormEvent, useEffect, useRef, useState } from "react";
 import { useParams } from "react-router-dom";
-import { registerDemoChatSession, sendDemoChatMessage } from "@/entities/chat";
+import {
+  listDemoChatMessages,
+  registerDemoChatSession,
+  sendDemoChatMessage,
+} from "@/entities/chat";
 import type { ChatMessage, DemoChatSession } from "@/entities/chat";
 import { ApiRequestError } from "@/shared/api";
+import { useStomp } from "@/shared/lib/websocket";
 import { ChatConversationScreen } from "./ChatConversationScreen";
 import { ChatEntryScreen } from "./ChatEntryScreen";
 
@@ -65,6 +70,78 @@ function writeStoredSession(
   window.localStorage.setItem(createStorageKey(workspaceId, customerName), JSON.stringify(session));
 }
 
+interface RealtimeChatMessage {
+  id: number | string;
+  senderRole: string;
+  content: string;
+  createdAt: string;
+}
+
+function isRealtimeChatMessage(message: unknown): message is RealtimeChatMessage {
+  if (!message || typeof message !== "object") return false;
+
+  const candidate = message as Partial<RealtimeChatMessage>;
+  return (
+    (typeof candidate.id === "number" || typeof candidate.id === "string") &&
+    typeof candidate.senderRole === "string" &&
+    typeof candidate.content === "string" &&
+    typeof candidate.createdAt === "string"
+  );
+}
+
+function toSenderType(senderRole: string): ChatMessage["senderType"] {
+  if (senderRole === "USER" || senderRole === "CUSTOMER") return "USER";
+  if (senderRole === "AGENT" || senderRole === "COUNSELOR") return "AGENT";
+  return "BOT";
+}
+
+function toRealtimeChatMessage(
+  message: RealtimeChatMessage,
+  sessionId: number,
+  customerName: string,
+): ChatMessage {
+  const senderType = toSenderType(message.senderRole);
+  return {
+    id: String(message.id),
+    sessionId,
+    content: message.content,
+    senderType,
+    senderName: senderType === "USER" ? customerName : undefined,
+    createdAt: message.createdAt,
+  };
+}
+
+function compareMessageCreatedAt(a: ChatMessage, b: ChatMessage): number {
+  return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+}
+
+function mergeMessages(currentMessages: ChatMessage[], nextMessages: ChatMessage[]): ChatMessage[] {
+  const byId = new Map<string, ChatMessage>();
+  [...currentMessages, ...nextMessages].forEach((message) => {
+    byId.set(message.id, message);
+  });
+  return Array.from(byId.values()).sort(compareMessageCreatedAt);
+}
+
+function withCustomerNames(messages: ChatMessage[], customerName: string): ChatMessage[] {
+  return messages.map((message) =>
+    message.senderType === "USER" ? { ...message, senderName: customerName } : message,
+  );
+}
+
+function getNumericSessionId(sessionId: string): number | null {
+  const numericSessionId = Number(sessionId);
+  return Number.isFinite(numericSessionId) ? numericSessionId : null;
+}
+
+function mergePersistedMessages(
+  currentMessages: ChatMessage[],
+  persistedMessages: ChatMessage[],
+): ChatMessage[] {
+  const optimisticMessages = currentMessages.filter((message) => message.id.startsWith("local-"));
+  return mergeMessages(optimisticMessages, persistedMessages);
+}
+
 async function getOrCreateStoredSession(
   workspaceId: number,
   customerName: string,
@@ -80,6 +157,7 @@ async function getOrCreateStoredSession(
 export function UserChatPage() {
   const { workspaceId: raw } = useParams<{ workspaceId: string }>();
   const workspaceId = Number(raw);
+  const { connectionStatus, subscribe } = useStomp();
   const [draftName, setDraftName] = useState("");
   const [customerName, setCustomerName] = useState<string | null>(null);
   const [nameError, setNameError] = useState<string | null>(null);
@@ -97,6 +175,7 @@ export function UserChatPage() {
     chatState.workspaceId === workspaceId && chatState.customerName === customerName
       ? chatState
       : { session: null, error: null };
+  const activeSessionId = activeChatState.session?.id ?? null;
 
   const handleNameSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -203,6 +282,74 @@ export function UserChatPage() {
       setIsSending(false);
     }
   };
+
+  useEffect(() => {
+    if (!activeSessionId || !customerName) return;
+    const numericSessionId = getNumericSessionId(activeSessionId);
+    if (numericSessionId == null) return;
+
+    let cancelled = false;
+
+    const syncMessages = async () => {
+      try {
+        const persistedMessages = await listDemoChatMessages(workspaceId, activeSessionId);
+        if (cancelled) return;
+        const namedMessages = withCustomerNames(persistedMessages, customerName);
+        setChatState((current) => {
+          if (current.session?.id !== activeSessionId || current.customerName !== customerName) {
+            return current;
+          }
+          const nextSession = {
+            ...current.session,
+            messages: mergePersistedMessages(current.session.messages, namedMessages),
+          };
+          writeStoredSession(workspaceId, customerName, nextSession);
+          return {
+            ...current,
+            session: nextSession,
+          };
+        });
+      } catch {
+        // Demo chat remains usable through the send response even if background sync fails.
+      }
+    };
+
+    void syncMessages();
+    const intervalId = window.setInterval(() => {
+      void syncMessages();
+    }, 3000);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(intervalId);
+    };
+  }, [activeSessionId, customerName, workspaceId]);
+
+  useEffect(() => {
+    if (!activeSessionId || !customerName || connectionStatus !== "CONNECTED") return;
+    const numericSessionId = getNumericSessionId(activeSessionId);
+    if (numericSessionId == null) return;
+
+    return subscribe(`/topic/chat.${numericSessionId}`, (raw) => {
+      if (!isRealtimeChatMessage(raw)) return;
+
+      const nextMessage = toRealtimeChatMessage(raw, numericSessionId, customerName);
+      setChatState((current) => {
+        if (current.session?.id !== activeSessionId || current.customerName !== customerName) {
+          return current;
+        }
+        const nextSession = {
+          ...current.session,
+          messages: mergeMessages(current.session.messages, [nextMessage]),
+        };
+        writeStoredSession(workspaceId, customerName, nextSession);
+        return {
+          ...current,
+          session: nextSession,
+        };
+      });
+    });
+  }, [activeSessionId, connectionStatus, customerName, subscribe, workspaceId]);
 
   if (isInvalidWorkspace) {
     return (

--- a/frontend/src/pages/user-chat/ui/UserChatPage.tsx
+++ b/frontend/src/pages/user-chat/ui/UserChatPage.tsx
@@ -6,6 +6,14 @@ import {
   sendDemoChatMessage,
 } from "@/entities/chat";
 import type { ChatMessage, DemoChatSession } from "@/entities/chat";
+import {
+  isRealtimeChatMessage,
+  mergeMessages,
+  mergePersistedMessages,
+  toRealtimeChatMessage,
+  tryParseDemoSessionId,
+  withCustomerNames,
+} from "@/entities/chat/lib/chatMessageSync";
 import { ApiRequestError } from "@/shared/api";
 import { useStomp } from "@/shared/lib/websocket";
 import { ChatConversationScreen } from "./ChatConversationScreen";
@@ -43,7 +51,7 @@ function isDemoChatSession(value: unknown): value is DemoChatSession {
 }
 
 function isBackendRegisteredSession(session: DemoChatSession): boolean {
-  return Number.isFinite(Number(session.id));
+  return tryParseDemoSessionId(session.id) != null;
 }
 
 function readStoredSession(workspaceId: number, customerName: string): DemoChatSession | null {
@@ -68,78 +76,6 @@ function writeStoredSession(
   if (typeof window === "undefined") return;
 
   window.localStorage.setItem(createStorageKey(workspaceId, customerName), JSON.stringify(session));
-}
-
-interface RealtimeChatMessage {
-  id: number | string;
-  senderRole: string;
-  content: string;
-  createdAt: string;
-}
-
-function isRealtimeChatMessage(message: unknown): message is RealtimeChatMessage {
-  if (!message || typeof message !== "object") return false;
-
-  const candidate = message as Partial<RealtimeChatMessage>;
-  return (
-    (typeof candidate.id === "number" || typeof candidate.id === "string") &&
-    typeof candidate.senderRole === "string" &&
-    typeof candidate.content === "string" &&
-    typeof candidate.createdAt === "string"
-  );
-}
-
-function toSenderType(senderRole: string): ChatMessage["senderType"] {
-  if (senderRole === "USER" || senderRole === "CUSTOMER") return "USER";
-  if (senderRole === "AGENT" || senderRole === "COUNSELOR") return "AGENT";
-  return "BOT";
-}
-
-function toRealtimeChatMessage(
-  message: RealtimeChatMessage,
-  sessionId: number,
-  customerName: string,
-): ChatMessage {
-  const senderType = toSenderType(message.senderRole);
-  return {
-    id: String(message.id),
-    sessionId,
-    content: message.content,
-    senderType,
-    senderName: senderType === "USER" ? customerName : undefined,
-    createdAt: message.createdAt,
-  };
-}
-
-function compareMessageCreatedAt(a: ChatMessage, b: ChatMessage): number {
-  return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
-}
-
-function mergeMessages(currentMessages: ChatMessage[], nextMessages: ChatMessage[]): ChatMessage[] {
-  const byId = new Map<string, ChatMessage>();
-  [...currentMessages, ...nextMessages].forEach((message) => {
-    byId.set(message.id, message);
-  });
-  return Array.from(byId.values()).sort(compareMessageCreatedAt);
-}
-
-function withCustomerNames(messages: ChatMessage[], customerName: string): ChatMessage[] {
-  return messages.map((message) =>
-    message.senderType === "USER" ? { ...message, senderName: customerName } : message,
-  );
-}
-
-function getNumericSessionId(sessionId: string): number | null {
-  const numericSessionId = Number(sessionId);
-  return Number.isFinite(numericSessionId) ? numericSessionId : null;
-}
-
-function mergePersistedMessages(
-  currentMessages: ChatMessage[],
-  persistedMessages: ChatMessage[],
-): ChatMessage[] {
-  const optimisticMessages = currentMessages.filter((message) => message.id.startsWith("local-"));
-  return mergeMessages(optimisticMessages, persistedMessages);
 }
 
 async function getOrCreateStoredSession(
@@ -285,7 +221,7 @@ export function UserChatPage() {
 
   useEffect(() => {
     if (!activeSessionId || !customerName) return;
-    const numericSessionId = getNumericSessionId(activeSessionId);
+    const numericSessionId = tryParseDemoSessionId(activeSessionId);
     if (numericSessionId == null) return;
 
     let cancelled = false;
@@ -327,7 +263,7 @@ export function UserChatPage() {
 
   useEffect(() => {
     if (!activeSessionId || !customerName || connectionStatus !== "CONNECTED") return;
-    const numericSessionId = getNumericSessionId(activeSessionId);
+    const numericSessionId = tryParseDemoSessionId(activeSessionId);
     if (numericSessionId == null) return;
 
     return subscribe(`/topic/chat.${numericSessionId}`, (raw) => {


### PR DESCRIPTION
## Summary
- Expose registered demo chat messages through the public demo runtime API.
- Sync the customer demo chat screen with persisted runtime messages and subscribe to live chat topic updates when available.
- Broadcast demo customer/assistant messages after commit so both sides stay aligned.

## Why
Counselor messages were saved for the runtime session, but the customer demo chat screen only merged messages returned from its own send request and localStorage. That left counselor-originated messages with no path back into the customer UI.

## Validation
- `docker compose exec -T frontend pnpm test -- --run src/entities/chat/api/chatApi.test.ts src/pages/user-chat/ui/UserChatPage.test.tsx`
- `docker run --rm -v /Users/owen/.codex/worktrees/58f9/ostone/backend:/workspace -v /Users/owen/.gradle:/home/gradle/.gradle -w /workspace gradle:9.2-jdk21 ./gradlew test --tests com.init.chatdemo.application.DemoChatSessionRegistrationServiceTest --tests com.init.chatdemo.presentation.DemoRuntimeControllerTest`
- `docker compose exec -T frontend pnpm exec eslint src/pages/user-chat/ui/UserChatPage.tsx src/pages/user-chat/ui/UserChatPage.test.tsx src/entities/chat/api/chatApi.ts src/entities/chat/api/chatApi.test.ts src/entities/chat/index.ts`
- Manual browser flow: create demo customer session, select it in consultation, send counselor message, confirm it appears on the customer chat screen.

## Notes
- Full `pnpm run lint` still fails on pre-existing unrelated lint errors outside this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 데모 채팅 메시지 목록 조회 API 추가
  * 브로드캐스트를 트랜잭션 커밋 이후로 보장하도록 실시간 전송 개선

* **Refactor**
  * 메시지 동기화 로직과 변환 유틸을 공유 모듈로 분리하여 재사용성 향상
  * 클라이언트에서 REST 폴링과 실시간 구독을 병행한 동기화 도입

* **Tests**
  * 메시지 조회·동기화·브로드캐스트 관련 단위/통합 테스트 추가 및 확장

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ajou-2026-1-capstone-5/ostone/pull/309?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->