### PR TITLE
chore(frontend): apply defensive coding in workflow-consultation bar

### DIFF
--- a/frontend/src/features/consultation/api/llmToolWorkflowApi.test.ts
+++ b/frontend/src/features/consultation/api/llmToolWorkflowApi.test.ts
@@ -79,10 +79,20 @@ describe("llmToolWorkflowApi", () => {
       expect(result).toBeNull();
     });
 
-    it("rethrows non-404/400 errors", async () => {
+    it("returns null on 5xx ApiRequestError (bar degrades silently)", async () => {
       mockedFetch.mockRejectedValueOnce(new ApiRequestError(500, "INTERNAL", "boom"));
 
-      await expect(getCurrentWorkflow(7)).rejects.toThrow("boom");
+      const result = await getCurrentWorkflow(7);
+
+      expect(result).toBeNull();
+    });
+
+    it("returns null on network/non-ApiRequestError failures", async () => {
+      mockedFetch.mockRejectedValueOnce(new TypeError("Failed to fetch"));
+
+      const result = await getCurrentWorkflow(7);
+
+      expect(result).toBeNull();
     });
   });
 

--- a/frontend/src/features/consultation/api/llmToolWorkflowApi.ts
+++ b/frontend/src/features/consultation/api/llmToolWorkflowApi.ts
@@ -1,5 +1,4 @@
 import { customFetch } from "@/shared/api/mutator";
-import { ApiRequestError } from "@/shared/api";
 
 export interface LlmToolWorkflowPayload {
   sessionId: number | null;
@@ -27,6 +26,8 @@ export function isMatchedWorkflow(
 }
 
 export async function getCurrentWorkflow(sessionId: number): Promise<MatchedWorkflow | null> {
+  // 매칭 워크플로우 바는 보조 정보 패널이다. 서버 오류(5xx)·네트워크 실패·미매칭(404/400)
+  // 어느 경우든 "표시할 워크플로우 없음"으로 degrade하여 null을 반환하고, 패널만 조용히 숨긴다.
   try {
     const payload = await customFetch<LlmToolWorkflowPayload>(
       `/api/v1/consultation/sessions/${sessionId}/matched-workflow`,
@@ -34,9 +35,7 @@ export async function getCurrentWorkflow(sessionId: number): Promise<MatchedWork
     );
     return isMatchedWorkflow(payload) ? payload : null;
   } catch (error) {
-    if (error instanceof ApiRequestError && (error.status === 404 || error.status === 400)) {
-      return null;
-    }
-    throw error;
+    console.warn("matched-workflow 조회 실패 — 바를 숨깁니다.", error);
+    return null;
   }
 }

--- a/frontend/src/pages/consultation/ui/ConsultationPage.test.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.test.tsx
@@ -369,7 +369,7 @@ describe("ConsultationPage", () => {
       expect(screen.queryByTestId("matched-workflow-bar")).not.toBeInTheDocument();
     });
 
-    it("hides the bar when the workflow lookup throws", async () => {
+    it("hides the bar without showing an error toast when the workflow lookup fails", async () => {
       vi.mocked(getCurrentWorkflow).mockRejectedValueOnce(new Error("boom"));
 
       render(<ConsultationPage />, { wrapper: Wrapper });
@@ -388,6 +388,8 @@ describe("ConsultationPage", () => {
         expect(screen.queryByTestId("matched-workflow-bar-skeleton")).not.toBeInTheDocument();
       });
       expect(screen.queryByTestId("matched-workflow-bar")).not.toBeInTheDocument();
+      // 매칭 바는 보조 패널이므로 조회 실패가 운영자에게 토스트로 노출되지 않아야 한다.
+      expect(toast.error).not.toHaveBeenCalledWith("워크플로우 정보를 불러오지 못했습니다.");
     });
 
     it("refetches the workflow after an assistant message arrives via STOMP", async () => {

--- a/frontend/src/pages/consultation/ui/ConsultationPage.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.tsx
@@ -256,21 +256,16 @@ export const ConsultationPage: React.FC = () => {
     pendingIdsRef.current.clear();
   }, []);
 
-  const loadMatchedWorkflow = useCallback(
-    async (sessionId: number, options: { silent?: boolean } = {}) => {
-      try {
-        const workflow = await getCurrentWorkflow(sessionId);
-        return workflow;
-      } catch (error) {
-        console.error("Failed to load matched workflow:", error);
-        if (!options.silent) {
-          toast.error("워크플로우 정보를 불러오지 못했습니다.");
-        }
-        return null;
-      }
-    },
-    [],
-  );
+  const loadMatchedWorkflow = useCallback(async (sessionId: number) => {
+    // 매칭 워크플로우 바는 보조 패널이므로 실패 시 토스트 없이 바만 숨긴다.
+    // getCurrentWorkflow는 오류를 흡수해 null을 반환하지만, 방어적으로 catch도 유지한다.
+    try {
+      return await getCurrentWorkflow(sessionId);
+    } catch (error) {
+      console.error("Failed to load matched workflow:", error);
+      return null;
+    }
+  }, []);
 
   useEffect(() => {
     activeCustomerIdRef.current = activeCustomerId;
@@ -511,7 +506,7 @@ export const ConsultationPage: React.FC = () => {
         }
         workflowRefetchTimerRef.current = setTimeout(() => {
           workflowRefetchTimerRef.current = null;
-          void loadMatchedWorkflow(sessionIdForFetch, { silent: true }).then((workflow) => {
+          void loadMatchedWorkflow(sessionIdForFetch).then((workflow) => {
             if (activeCustomerIdRef.current === String(sessionIdForFetch)) {
               setMatchedWorkflow(workflow);
             }


### PR DESCRIPTION
코드: FE 매칭 바 견고화 (커밋 대상, 4파일)
llmToolWorkflowApi.ts: getCurrentWorkflow 가 5xx·네트워크·기타 모든 오류에서 null 반환(보조 패널이므로 best-effort degrade), 404/400 분기 흡수.
ConsultationPage.tsx: loadMatchedWorkflow 의 에러 토스트 제거 + 사용되지 않게 된 silent 옵션 정리.
테스트: llmToolWorkflowApi.test.ts(5xx·네트워크 → null), ConsultationPage.test.tsx(실패 시 토스트 미호출).
검증 결과
vitest 전체 197파일 / 1339 테스트 통과, lint clean, tsc+build 통과.
sonarSentinel local-quality-gate(frontend): coverage gate passed, reliability/security A, build OK. (duplication은 로컬 측정 불가 — Sonar Cloud 전용; 변경은 코드 순감소라 위험 낮음)
Playwright(local): 세션 15 선택 → "환불 요청 처리" 매칭 바 렌더, 워크플로우 미배정 세션 → 바 없음 + 토스트 없음, console error 0, 네트워크 matched-workflow 200.
참고

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 워크플로우 정보 조회 실패 시 사용자에게 표시되는 에러 메시지 제거
  * 모든 조회 오류를 일관되게 처리하도록 개선

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ajou-2026-1-capstone-5/ostone/pull/315?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->