### PR TITLE
chore(domain-pack): improve summary json presentation

### DIFF
--- a/frontend/src/features/domain-pack-summary-read/ui/ComponentCountGrid.generated-api.test.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/ComponentCountGrid.generated-api.test.tsx
@@ -7,7 +7,6 @@ const mocks = vi.hoisted(() => ({
   toastError: vi.fn(),
   useListIntents: vi.fn(),
   useListPolicies: vi.fn(),
-  useListRisks: vi.fn(),
   useListSlots: vi.fn(),
   useListWorkflows: vi.fn(),
 }));
@@ -38,13 +37,6 @@ vi.mock(
   "@/shared/api/generated/endpoints/policy-definition-controller/policy-definition-controller",
   () => ({
     useListPolicies: mocks.useListPolicies,
-  }),
-);
-
-vi.mock(
-  "@/shared/api/generated/endpoints/risk-definition-controller/risk-definition-controller",
-  () => ({
-    useListRisks: mocks.useListRisks,
   }),
 );
 
@@ -86,7 +78,6 @@ function renderGrid() {
       intentCount={6}
       slotCount={1}
       policyCount={1}
-      riskCount={1}
       workflowCount={1}
       renderSlotEditSheet={(slotId, isOpen) =>
         isOpen ? <div role="dialog">slot edit {slotId}</div> : null
@@ -115,9 +106,6 @@ describe("ComponentCountGrid generated API integration", () => {
     mocks.useListPolicies.mockImplementation((...args: unknown[]) =>
       makeGeneratedPreview({ data: [{ id: 21, name: "환불 정책" }] }, getOptions(args, 3)),
     );
-    mocks.useListRisks.mockImplementation((...args: unknown[]) =>
-      makeGeneratedPreview({ data: [{ id: 31, name: "사기 위험" }] }, getOptions(args, 3)),
-    );
     mocks.useListWorkflows.mockImplementation((...args: unknown[]) =>
       makeGeneratedPreview({ data: [{ id: 41, name: "환불 처리" }] }, getOptions(args, 4)),
     );
@@ -131,7 +119,6 @@ describe("ComponentCountGrid generated API integration", () => {
     expect(screen.queryByText("intent-6")).not.toBeInTheDocument();
     expect(screen.getByText("배송 주소")).toBeInTheDocument();
     expect(screen.getByText("환불 정책")).toBeInTheDocument();
-    expect(screen.getByText("사기 위험")).toBeInTheDocument();
     expect(screen.getByText("환불 처리")).toBeInTheDocument();
   });
 

--- a/frontend/src/features/domain-pack-summary-read/ui/ComponentCountGrid.test.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/ComponentCountGrid.test.tsx
@@ -14,7 +14,6 @@ vi.mock("../model/usePreviewLists", () => ({
   useIntentPreview: vi.fn(),
   useSlotPreview: vi.fn(),
   usePolicyPreview: vi.fn(),
-  useRiskPreview: vi.fn(),
   useWorkflowPreview: vi.fn(),
 }));
 
@@ -34,7 +33,6 @@ const defaultProps = {
   intentCount: 2,
   slotCount: 3,
   policyCount: 1,
-  riskCount: 0,
   workflowCount: 4,
 };
 
@@ -49,7 +47,6 @@ describe("ComponentCountGrid", () => {
     vi.mocked(previewLists.useIntentPreview).mockReturnValue(makeHook());
     vi.mocked(previewLists.useSlotPreview).mockReturnValue(makeHook());
     vi.mocked(previewLists.usePolicyPreview).mockReturnValue(makeHook());
-    vi.mocked(previewLists.useRiskPreview).mockReturnValue(makeHook());
     vi.mocked(previewLists.useWorkflowPreview).mockReturnValue(makeHook());
   });
 
@@ -61,16 +58,13 @@ describe("ComponentCountGrid", () => {
     expect(screen.getByText("4")).toBeInTheDocument();
   });
 
-  it("Intent, Policy, Risk 카드 클릭 시 상세 목록으로 이동한다", () => {
+  it("Intent, Policy 카드 클릭 시 상세 목록으로 이동한다", () => {
     render(<ComponentCountGrid {...defaultProps} renderSlotEditSheet={renderSlotEditSheet} />);
     fireEvent.click(screen.getByRole("button", { name: /Intent/ }));
     expect(mockNavigate).toHaveBeenCalledWith("/workspaces/1/domain-packs/2/intents?versionId=3");
 
     fireEvent.click(screen.getByRole("button", { name: /Policy/ }));
     expect(mockNavigate).toHaveBeenCalledWith("/workspaces/1/domain-packs/2/policies?versionId=3");
-
-    fireEvent.click(screen.getByRole("button", { name: /Risk/ }));
-    expect(mockNavigate).toHaveBeenCalledWith("/workspaces/1/domain-packs/2/risks?versionId=3");
   });
 
   it("Slot 카드 클릭 시 SlotEditSheet를 연다", () => {

--- a/frontend/src/features/domain-pack-summary-read/ui/ComponentCountGrid.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/ComponentCountGrid.tsx
@@ -7,7 +7,6 @@ import {
   useIntentPreview,
   useSlotPreview,
   usePolicyPreview,
-  useRiskPreview,
   useWorkflowPreview,
 } from "../model/usePreviewLists";
 import styles from "./ComponentCountGrid.module.css";
@@ -19,7 +18,6 @@ interface ComponentCountGridProps {
   intentCount: number;
   slotCount: number;
   policyCount: number;
-  riskCount: number;
   workflowCount: number;
   renderSlotEditSheet?: (slotId: number, isOpen: boolean, onClose: () => void) => ReactNode;
 }
@@ -31,7 +29,6 @@ export function ComponentCountGrid({
   intentCount,
   slotCount,
   policyCount,
-  riskCount,
   workflowCount,
   renderSlotEditSheet,
 }: ComponentCountGridProps) {
@@ -41,7 +38,6 @@ export function ComponentCountGrid({
   const intentPreview = useIntentPreview(wsId, packId, versionId);
   const slotPreview = useSlotPreview(wsId, packId, versionId);
   const policyPreview = usePolicyPreview(wsId, packId, versionId);
-  const riskPreview = useRiskPreview(wsId, packId, versionId);
   const workflowPreview = useWorkflowPreview(wsId, packId, versionId);
 
   useEffect(() => {
@@ -55,10 +51,6 @@ export function ComponentCountGrid({
   useEffect(() => {
     if (policyPreview.isError) toast.error("Policy 미리보기 로드 실패");
   }, [policyPreview.isError]);
-
-  useEffect(() => {
-    if (riskPreview.isError) toast.error("Risk 미리보기 로드 실패");
-  }, [riskPreview.isError]);
 
   useEffect(() => {
     if (workflowPreview.isError) toast.error("Workflow 미리보기 로드 실패");
@@ -93,14 +85,6 @@ export function ComponentCountGrid({
           onNavigate={() => navigate(domainPackSectionPath(wsId, packId, versionId, "policies"))}
           previewNames={policyPreview.data?.map((p) => p.name) as string[]}
           isLoadingPreview={policyPreview.isLoading}
-        />
-        <CountCard
-          label="Risk"
-          count={riskCount}
-          disabled={false}
-          onNavigate={() => navigate(domainPackSectionPath(wsId, packId, versionId, "risks"))}
-          previewNames={riskPreview.data?.map((r) => r.name) as string[]}
-          isLoadingPreview={riskPreview.isLoading}
         />
         <CountCard
           label="Workflow"

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.test.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.test.tsx
@@ -134,7 +134,6 @@ describe("SummaryDetailPanel", () => {
 
     expect(screen.getByText("v1")).toBeInTheDocument();
     expect(screen.getByText("DRAFT")).toBeInTheDocument();
-    expect(screen.getByText("Summary JSON")).toBeInTheDocument();
     expect(screen.getByTestId("summary-json-card")).toHaveTextContent('{"key":"val"}');
     expect(screen.getByTestId("component-count-grid")).toBeInTheDocument();
     expect(screen.queryByText("승인 준비 상태")).not.toBeInTheDocument();

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.tsx
@@ -303,10 +303,7 @@ export function SummaryDetailPanel({
         </AlertDialogContent>
       </AlertDialog>
 
-      <div>
-        <div className={styles.sectionTitle}>Summary JSON</div>
-        <SummaryJsonCard summaryJson={v.summaryJson ?? ""} />
-      </div>
+      <SummaryJsonCard summaryJson={v.summaryJson ?? ""} />
 
       <div>
         <div className={styles.sectionTitle}>구성요소</div>
@@ -318,7 +315,6 @@ export function SummaryDetailPanel({
             intentCount={v.intentCount ?? 0}
             slotCount={v.slotCount ?? 0}
             policyCount={v.policyCount ?? 0}
-            riskCount={v.riskCount ?? 0}
             workflowCount={v.workflowCount ?? 0}
             renderSlotEditSheet={renderSlotEditSheet}
           />

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryJsonCard.module.css
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryJsonCard.module.css
@@ -1,7 +1,7 @@
 .card {
   border: 1px solid var(--glass-border);
   border-radius: var(--radius-lg);
-  overflow: hidden;
+  overflow: visible;
 }
 
 .cardHeader {
@@ -14,11 +14,10 @@
 }
 
 .cardTitle {
-  font-size: var(--font-size-label);
+  font-size: var(--font-size-sm);
   font-weight: var(--font-weight-heading);
-  color: var(--text-secondary);
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
+  color: var(--text-primary);
+  letter-spacing: 0;
 }
 
 .toggleGroup {
@@ -53,11 +52,155 @@
   padding: 14px;
 }
 
-.keyValueGrid {
+.summaryLayout {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.topicBlock {
+  min-width: 0;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--divider-subtle);
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.topicValue {
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-heading);
+  color: var(--text-primary);
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.highlightGrid {
   display: grid;
-  grid-template-columns: auto 1fr;
-  gap: 6px 12px;
+  grid-template-columns: repeat(auto-fit, minmax(132px, 1fr));
+  gap: 8px;
+}
+
+.highlightItem {
+  min-width: 0;
+  padding: 10px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-md);
+  background: var(--bg-secondary);
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.highlightValue {
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-heading);
+  color: var(--text-primary);
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.summarySection {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.summarySectionTitle {
+  margin: 0;
   font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-heading);
+  color: var(--text-primary);
+}
+
+.metricGrid {
+  display: grid;
+  gap: 6px;
+}
+
+.metricItem {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--divider-subtle);
+}
+
+.metricItem:last-child {
+  border-bottom: none;
+}
+
+.metricLabel {
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+}
+
+.metricValue {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-heading);
+  color: var(--text-primary);
+}
+
+.issueList {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin: 0;
+  padding-left: 18px;
+  color: var(--text-primary);
+  font-size: var(--font-size-sm);
+  line-height: 1.55;
+}
+
+.jsonList {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  max-height: 360px;
+  overflow-y: auto;
+  scrollbar-gutter: stable;
+  padding-right: 10px;
+  padding-bottom: 6px;
+}
+
+.jsonRow {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: minmax(96px, auto) minmax(0, 1fr);
+  gap: 12px;
+  padding: 9px 0;
+  border-bottom: 1px solid var(--divider-subtle);
+}
+
+.jsonRow:last-child {
+  border-bottom: none;
+}
+
+.jsonKey {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-label);
+  color: var(--text-secondary);
+  overflow-wrap: anywhere;
+}
+
+.jsonValue,
+.jsonCode {
+  color: var(--text-primary);
+  font-size: var(--font-size-sm);
+  line-height: 1.5;
+  overflow-wrap: anywhere;
+}
+
+.jsonCode {
+  display: block;
+  padding: 0;
+  border: none;
+  background: transparent;
+  font-family: var(--font-mono);
+  font-size: var(--font-size-label);
+  white-space: pre-wrap;
 }
 
 .key {
@@ -65,11 +208,6 @@
   font-size: var(--font-size-label);
   color: var(--text-secondary);
   white-space: nowrap;
-}
-
-.value {
-  color: var(--text-primary);
-  overflow-wrap: anywhere;
 }
 
 .rawPre {

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryJsonCard.test.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryJsonCard.test.tsx
@@ -3,12 +3,63 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import { SummaryJsonCard } from "./SummaryJsonCard";
 
 describe("SummaryJsonCard", () => {
-  it("유효한 JSON 객체는 key-value 형태로 렌더링한다", () => {
-    render(<SummaryJsonCard summaryJson='{"intent":"greeting","count":3}' />);
+  it("알려진 요약 필드는 사용자가 읽기 좋은 섹션으로 렌더링한다", () => {
+    render(
+      <SummaryJsonCard summaryJson='{"topic":"환불 자동화 팩","generation":{"source":"pipeline","clusterCount":12},"quality":{"mappingRate":0.82,"outlierRate":0.07,"workflowSeparability":0.76},"review":{"needsReviewCount":3,"topIssues":["워크플로우 미매핑"]}}' />,
+    );
+
+    expect(screen.getByText("도메인팩 정보")).toBeInTheDocument();
+    expect(screen.getByText("topic")).toBeInTheDocument();
+    expect(screen.getByText("환불 자동화 팩")).toBeInTheDocument();
+    expect(screen.getByText("생성 출처")).toBeInTheDocument();
+    expect(screen.getByText("pipeline")).toBeInTheDocument();
+    expect(screen.getByText("클러스터")).toBeInTheDocument();
+    expect(screen.getByText("12")).toBeInTheDocument();
+    expect(screen.getByText("검토 필요")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+    expect(screen.getByText("품질 지표")).toBeInTheDocument();
+    expect(screen.getByText("매핑률")).toBeInTheDocument();
+    expect(screen.getByText("82%")).toBeInTheDocument();
+    expect(screen.getByText("이탈률")).toBeInTheDocument();
+    expect(screen.getByText("7%")).toBeInTheDocument();
+    expect(screen.getByText("워크플로우 분리도")).toBeInTheDocument();
+    expect(screen.getByText("76%")).toBeInTheDocument();
+    expect(screen.getByText("검토 포인트")).toBeInTheDocument();
+    expect(screen.getByText("워크플로우 미매핑")).toBeInTheDocument();
+  });
+
+  it("카드 제목으로 도메인팩 정보를 렌더링한다", () => {
+    render(<SummaryJsonCard summaryJson='{"generation":{"source":"pipeline"}}' />);
+    expect(screen.getByText("도메인팩 정보")).toBeInTheDocument();
+  });
+
+  it("알려지지 않은 JSON 객체는 요약 화면에 노출하지 않고 전체 JSON에서 확인한다", () => {
+    const json = '{"intent":"greeting","count":3}';
+    render(<SummaryJsonCard summaryJson={json} />);
+    expect(screen.getByText("내용 없음")).toBeInTheDocument();
+    expect(screen.queryByText("기타 메타데이터")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "전체 JSON" }));
     expect(screen.getByText("intent")).toBeInTheDocument();
     expect(screen.getByText("greeting")).toBeInTheDocument();
     expect(screen.getByText("count")).toBeInTheDocument();
     expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
+  it("전체 JSON 화면에서는 객체 값을 보기 좋은 코드 블록으로 렌더링한다", () => {
+    render(<SummaryJsonCard summaryJson='{"nested":{"a":1}}' />);
+    fireEvent.click(screen.getByRole("button", { name: "전체 JSON" }));
+    expect(screen.getByText("nested")).toBeInTheDocument();
+    expect(screen.getByText(/"a": 1/)).toBeInTheDocument();
+  });
+
+  it("draftSource는 내부 타입 대신 변경 기준 버전만 렌더링한다", () => {
+    render(
+      <SummaryJsonCard summaryJson='{"draftSource":{"type":"INTENT_REVISION","baseVersionNo":2,"reason":"환불 인텐트 세분화"}}' />,
+    );
+
+    expect(screen.getByText("변경 기준")).toBeInTheDocument();
+    expect(screen.getByText("v2")).toBeInTheDocument();
+    expect(screen.queryByText(/INTENT_REVISION/)).not.toBeInTheDocument();
   });
 
   it("빈 JSON 객체는 '내용 없음'을 표시한다", () => {
@@ -22,28 +73,19 @@ describe("SummaryJsonCard", () => {
     expect(screen.getByText("{bad}")).toBeInTheDocument();
   });
 
-  it("Raw JSON 버튼 클릭 시 원문 JSON을 표시한다", () => {
+  it("전체 JSON 버튼 클릭 시 전체 JSON 필드를 카드로 표시한다", () => {
     const json = '{"key":"val"}';
     render(<SummaryJsonCard summaryJson={json} />);
-    fireEvent.click(screen.getByRole("button", { name: "Raw JSON" }));
-    expect(screen.getByText(json)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "전체 JSON" }));
+    expect(screen.getByText("key")).toBeInTheDocument();
+    expect(screen.getByText("val")).toBeInTheDocument();
   });
 
   it("카드 버튼으로 다시 카드 모드로 전환한다", () => {
-    render(<SummaryJsonCard summaryJson='{"k":"v"}' />);
-    fireEvent.click(screen.getByRole("button", { name: "Raw JSON" }));
-    fireEvent.click(screen.getByRole("button", { name: "카드" }));
-    expect(screen.getByText("k")).toBeInTheDocument();
-    expect(screen.getByText("v")).toBeInTheDocument();
-  });
-
-  it("객체 값은 JSON 문자열로 렌더링한다", () => {
-    render(<SummaryJsonCard summaryJson='{"nested":{"a":1}}' />);
-    expect(screen.getByText('{"a":1}')).toBeInTheDocument();
-  });
-
-  it("null 값은 'null' 문자열로 렌더링한다", () => {
-    render(<SummaryJsonCard summaryJson='{"key":null}' />);
-    expect(screen.getByText("null")).toBeInTheDocument();
+    render(<SummaryJsonCard summaryJson='{"generation":{"source":"pipeline"}}' />);
+    fireEvent.click(screen.getByRole("button", { name: "전체 JSON" }));
+    fireEvent.click(screen.getByRole("button", { name: "요약" }));
+    expect(screen.getByText("생성 출처")).toBeInTheDocument();
+    expect(screen.getByText("pipeline")).toBeInTheDocument();
   });
 });

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryJsonCard.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryJsonCard.tsx
@@ -1,11 +1,111 @@
-import { useState, useMemo, Fragment } from "react";
+import { useState, useMemo } from "react";
 import { parseSummaryJson } from "../model/parseSummaryJson";
 import styles from "./SummaryJsonCard.module.css";
+
+type SummaryData = Record<string, unknown>;
+
+interface SummaryItem {
+  label: string;
+  value: string;
+}
 
 function renderValue(v: unknown): string {
   if (v === null || v === undefined) return String(v);
   if (typeof v === "object") return JSON.stringify(v);
   return String(v);
+}
+
+function isRecord(value: unknown): value is SummaryData {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function readPath(data: SummaryData, path: string[]): unknown {
+  return path.reduce<unknown>((acc, key) => (isRecord(acc) ? acc[key] : undefined), data);
+}
+
+function firstValue(data: SummaryData, paths: string[][]): unknown {
+  for (const path of paths) {
+    const value = readPath(data, path);
+    if (value !== undefined && value !== null && value !== "") return value;
+  }
+  return undefined;
+}
+
+function formatNumber(value: unknown): string | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value.toLocaleString("ko-KR");
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed.toLocaleString("ko-KR");
+  }
+  return null;
+}
+
+function formatRate(value: unknown): string | null {
+  const numeric =
+    typeof value === "number" ? value : typeof value === "string" ? Number(value) : Number.NaN;
+  if (!Number.isFinite(numeric)) return null;
+  const ratio = numeric <= 1 ? numeric * 100 : numeric;
+  return `${Math.round(ratio)}%`;
+}
+
+function formatDraftSource(value: unknown): string | null {
+  if (!isRecord(value)) return null;
+  const baseVersion = value.baseVersionNo ?? value.baseVersionId;
+  return baseVersion ? `v${String(baseVersion)}` : null;
+}
+
+function readStringList(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((item) => {
+      if (typeof item === "string") return item;
+      if (isRecord(item) && typeof item.message === "string") return item.message;
+      if (isRecord(item) && typeof item.title === "string") return item.title;
+      return null;
+    })
+    .filter((item): item is string => Boolean(item));
+}
+
+function buildSummary(data: SummaryData) {
+  const topic = typeof data.topic === "string" ? data.topic.trim() : "";
+  const source = firstValue(data, [["generation", "source"], ["source"], ["sourceType"]]);
+  const clusterCount = firstValue(data, [["generation", "clusterCount"], ["clusterCount"]]);
+  const draftSource = firstValue(data, [["draftSource"]]);
+  const needsReviewCount = firstValue(data, [["review", "needsReviewCount"], ["needsReviewCount"]]);
+
+  const highlights: SummaryItem[] = [];
+  if (source) highlights.push({ label: "생성 출처", value: renderValue(source) });
+  const clusterLabel = formatNumber(clusterCount);
+  if (clusterLabel) highlights.push({ label: "클러스터", value: clusterLabel });
+  const draftSourceLabel = formatDraftSource(draftSource);
+  if (draftSourceLabel) highlights.push({ label: "변경 기준", value: draftSourceLabel });
+  const reviewCountLabel = formatNumber(needsReviewCount);
+  if (reviewCountLabel) highlights.push({ label: "검토 필요", value: reviewCountLabel });
+
+  const metrics: SummaryItem[] = [
+    {
+      label: "매핑률",
+      value: formatRate(firstValue(data, [["quality", "mappingRate"], ["mappingRate"]])) ?? "",
+    },
+    {
+      label: "이탈률",
+      value: formatRate(firstValue(data, [["quality", "outlierRate"], ["outlierRate"]])) ?? "",
+    },
+    {
+      label: "워크플로우 분리도",
+      value:
+        formatRate(
+          firstValue(data, [["quality", "workflowSeparability"], ["workflowSeparability"]]),
+        ) ?? "",
+    },
+  ].filter((item) => item.value);
+
+  const issues = [
+    ...readStringList(firstValue(data, [["review", "topIssues"], ["topIssues"]])),
+    ...readStringList(firstValue(data, [["review", "issues"], ["issues"]])),
+  ];
+
+  return { topic, highlights, metrics, issues };
 }
 
 interface SummaryJsonCardProps {
@@ -20,7 +120,7 @@ export function SummaryJsonCard({ summaryJson }: SummaryJsonCardProps) {
   return (
     <div className={styles.card}>
       <div className={styles.cardHeader}>
-        <span className={styles.cardTitle}>Summary JSON</span>
+        <span className={styles.cardTitle}>도메인팩 정보</span>
         <div className={styles.toggleGroup} role="group" aria-label="보기 방식">
           <button
             type="button"
@@ -28,7 +128,7 @@ export function SummaryJsonCard({ summaryJson }: SummaryJsonCardProps) {
             onClick={() => setMode("card")}
             aria-pressed={mode === "card"}
           >
-            카드
+            요약
           </button>
           <button
             type="button"
@@ -36,7 +136,7 @@ export function SummaryJsonCard({ summaryJson }: SummaryJsonCardProps) {
             onClick={() => setMode("raw")}
             aria-pressed={mode === "raw"}
           >
-            Raw JSON
+            전체 JSON
           </button>
         </div>
       </div>
@@ -45,22 +145,11 @@ export function SummaryJsonCard({ summaryJson }: SummaryJsonCardProps) {
           <>
             {!parsed.ok && (
               <p className={styles.fallbackWarning} role="alert">
-                JSON 파싱 실패 — 원문 표시
+                JSON 파싱 실패 - 원문 표시
               </p>
             )}
             {parsed.ok ? (
-              Object.keys(parsed.data).length === 0 ? (
-                <span className={styles.empty}>내용 없음</span>
-              ) : (
-                <div className={styles.keyValueGrid}>
-                  {Object.entries(parsed.data).map(([k, v]) => (
-                    <Fragment key={k}>
-                      <span className={styles.key}>{k}</span>
-                      <span className={styles.value}>{renderValue(v)}</span>
-                    </Fragment>
-                  ))}
-                </div>
-              )
+              <ReadableSummary data={parsed.data} />
             ) : (
               <pre className={styles.rawPre}>
                 <code>{parsed.raw}</code>
@@ -68,11 +157,105 @@ export function SummaryJsonCard({ summaryJson }: SummaryJsonCardProps) {
             )}
           </>
         ) : (
-          <pre className={styles.rawPre}>
-            <code>{summaryJson}</code>
-          </pre>
+          <StructuredJsonView parsed={parsed} raw={summaryJson} />
         )}
       </div>
     </div>
   );
+}
+
+function ReadableSummary({ data }: { data: SummaryData }) {
+  const summary = buildSummary(data);
+  const hasContent =
+    summary.topic ||
+    summary.highlights.length > 0 ||
+    summary.metrics.length > 0 ||
+    summary.issues.length > 0;
+
+  if (!hasContent) return <span className={styles.empty}>내용 없음</span>;
+
+  return (
+    <div className={styles.summaryLayout}>
+      {summary.topic && (
+        <div className={styles.topicBlock}>
+          <span className={styles.key}>topic</span>
+          <strong className={styles.topicValue}>{summary.topic}</strong>
+        </div>
+      )}
+
+      {summary.highlights.length > 0 && (
+        <div className={styles.highlightGrid}>
+          {summary.highlights.map((item) => (
+            <div key={item.label} className={styles.highlightItem}>
+              <span className={styles.key}>{item.label}</span>
+              <strong className={styles.highlightValue}>{item.value}</strong>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {summary.metrics.length > 0 && (
+        <section className={styles.summarySection}>
+          <h4 className={styles.summarySectionTitle}>품질 지표</h4>
+          <div className={styles.metricGrid}>
+            {summary.metrics.map((item) => (
+              <div key={item.label} className={styles.metricItem}>
+                <span className={styles.metricLabel}>{item.label}</span>
+                <span className={styles.metricValue}>{item.value}</span>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {summary.issues.length > 0 && (
+        <section className={styles.summarySection}>
+          <h4 className={styles.summarySectionTitle}>검토 포인트</h4>
+          <ul className={styles.issueList}>
+            {summary.issues.map((issue, index) => (
+              <li key={`${issue}-${index}`}>{issue}</li>
+            ))}
+          </ul>
+        </section>
+      )}
+    </div>
+  );
+}
+
+function StructuredJsonView({
+  parsed,
+  raw,
+}: {
+  parsed: ReturnType<typeof parseSummaryJson>;
+  raw: string;
+}) {
+  if (!parsed.ok) {
+    return (
+      <pre className={styles.rawPre}>
+        <code>{raw}</code>
+      </pre>
+    );
+  }
+
+  const entries = Object.entries(parsed.data);
+  if (entries.length === 0) return <span className={styles.empty}>내용 없음</span>;
+
+  return (
+    <div className={styles.jsonList}>
+      {entries.map(([key, value]) => (
+        <div key={key} className={styles.jsonRow}>
+          <span className={styles.jsonKey}>{key}</span>
+          <JsonValue value={value} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function JsonValue({ value }: { value: unknown }) {
+  if (isRecord(value) || Array.isArray(value)) {
+    return <code className={styles.jsonCode}>{JSON.stringify(value, null, 2)}</code>;
+  }
+
+  return <span className={styles.jsonValue}>{renderValue(value)}</span>;
 }


### PR DESCRIPTION
## Summary

- Domain Pack 요약 화면에서 summaryJson을 운영자가 읽기 쉬운 UI로 재구성
- `topic`, 생성 출처, 클러스터, 변경 기준, 품질 지표, 검토 포인트를 요약 화면에 표시
- 전체 JSON 탭을 원문 문자열 대신 key-value 형태로 정리해 표시
- 구성요소 카드에서 Risk 항목 제거

## Test

- pnpm test 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * 도메인팩 요약 카드의 정보 표시 구조를 개선했습니다 (주제, 품질 지표, 검토 포인트 등 섹션화).
  * 요약 JSON 카드의 렌더링 방식을 단순 key-value 그리드에서 구조화된 섹션 형태로 변경했습니다.
  * Risk 카드 관련 기능을 제거했습니다.

* **Style**
  * 요약 카드의 레이아웃 및 타이포그래피 스타일을 업데이트했습니다.

* **Tests**
  * 변경된 기능에 맞게 테스트를 업데이트했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ajou-2026-1-capstone-5/ostone/pull/316?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->