### PR TITLE
chore(domain-pack): improve intent resource summary UI

### DIFF
--- a/frontend/src/features/intent-draft-read/ui/IntentDetailPanel.module.css
+++ b/frontend/src/features/intent-draft-read/ui/IntentDetailPanel.module.css
@@ -152,6 +152,237 @@
   color: var(--text-muted);
 }
 
+.resourceToggleGroup {
+  display: inline-flex;
+  flex-shrink: 0;
+  gap: 2px;
+  padding: 2px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-xl);
+  background: var(--bg-secondary);
+}
+
+.resourceToggleButton {
+  border: 0;
+  border-radius: var(--radius-xl);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-family: "Geist Mono", monospace;
+  font-size: 10px;
+  letter-spacing: 0.54px;
+  line-height: 1;
+  padding: 7px 13px 8px;
+  text-transform: uppercase;
+  transition:
+    background var(--transition-fast),
+    color var(--transition-fast),
+    box-shadow var(--transition-fast);
+}
+
+.resourceToggleButton:hover {
+  color: var(--text-primary);
+}
+
+.resourceToggleButton:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.12);
+}
+
+.resourceToggleButtonActive {
+  background: var(--bg-color);
+  box-shadow: var(--shadow-card);
+  color: var(--text-primary);
+}
+
+.resourceSummary {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.summaryBlock {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  min-width: 0;
+}
+
+.summaryBlockHeader {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.summaryBlockIcon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-full);
+  background: var(--bg-color);
+  color: var(--text-primary);
+}
+
+.summaryBlockTitle {
+  margin: 0;
+  font-family: "Pretendard Variable", sans-serif;
+  font-size: 17px;
+  font-weight: 540;
+  letter-spacing: -0.14px;
+  line-height: 1.2;
+  color: var(--text-primary);
+}
+
+.scopePanel {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-lg);
+  background: var(--bg-color);
+}
+
+.scopeList {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(132px, 1fr));
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.scopeItem {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  min-width: 0;
+  padding: 10px;
+  border-radius: var(--radius-md);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+}
+
+.scopeIcon {
+  display: inline-flex;
+  flex-shrink: 0;
+  margin-top: 2px;
+  color: var(--text-primary);
+}
+
+.scopeItemText {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+
+.scopeLabel {
+  font-family: "Geist Mono", monospace;
+  font-size: 10px;
+  letter-spacing: 0.54px;
+  line-height: 1.1;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.scopeValue {
+  min-width: 0;
+  font-size: 15px;
+  font-weight: 450;
+  line-height: 1.35;
+  letter-spacing: -0.14px;
+  overflow-wrap: anywhere;
+}
+
+.keywordGroup {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding-top: 2px;
+}
+
+.keywordChip {
+  display: inline-flex;
+  align-items: center;
+  max-width: 100%;
+  padding: 5px 10px 6px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-xl);
+  background: var(--bg-color);
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 330;
+  line-height: 1.2;
+  letter-spacing: -0.14px;
+  overflow-wrap: anywhere;
+}
+
+.keywordChip::before {
+  content: "#";
+  margin-right: 2px;
+  color: var(--text-muted);
+}
+
+.evidenceList {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.evidenceItem {
+  display: grid;
+  grid-template-columns: max-content minmax(0, 1fr);
+  gap: 6px;
+  align-items: start;
+  padding: 10px 12px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-lg);
+  background: var(--bg-secondary);
+}
+
+.evidenceTurn {
+  font-family: "Pretendard Variable", sans-serif;
+  font-size: 15px;
+  font-weight: 330;
+  letter-spacing: -0.14px;
+  line-height: 1.5;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+.evidenceTurn::after {
+  content: ":";
+}
+
+.evidenceText {
+  min-width: 0;
+  font-size: 15px;
+  font-weight: 330;
+  line-height: 1.5;
+  letter-spacing: -0.14px;
+  color: var(--text-primary);
+  overflow-wrap: anywhere;
+}
+
+.summaryEmpty {
+  display: inline-flex;
+  align-self: flex-start;
+  padding: 12px 14px;
+  border: 1px dashed var(--hover-border);
+  border-radius: var(--radius-lg);
+  color: var(--text-secondary);
+  font-size: 14px;
+  line-height: 1.45;
+  letter-spacing: -0.14px;
+}
+
 .resourceGrid {
   display: grid;
   grid-template-columns: repeat(2, minmax(280px, 1fr));
@@ -271,6 +502,20 @@
 
   .resourceGrid {
     grid-template-columns: 1fr;
+  }
+
+  .resourceSectionHeader {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .scopeList {
+    grid-template-columns: 1fr;
+  }
+
+  .evidenceItem {
+    grid-template-columns: 1fr;
+    gap: 4px;
   }
 
   .panel {

--- a/frontend/src/features/intent-draft-read/ui/IntentDetailPanel.test.tsx
+++ b/frontend/src/features/intent-draft-read/ui/IntentDetailPanel.test.tsx
@@ -290,6 +290,22 @@ describe("IntentDetailPanel", () => {
     expect(screen.getByText("운송장 번호를 확인해 주세요")).toBeInTheDocument();
   });
 
+  it("지원하지 않는 prefix가 있는 문장은 speaker로 분리하지 않는다", () => {
+    mockedUseIntentDetail.mockReturnValue(
+      readyDetail({
+        ...stubDetail,
+        evidenceJson: JSON.stringify({
+          sampleSegmentTexts: ["order_id: 12345 확인 요청"],
+        }),
+      }),
+    );
+
+    renderPanel();
+
+    expect(screen.getByText("참고 1")).toBeInTheDocument();
+    expect(screen.getByText("order_id: 12345 확인 요청")).toBeInTheDocument();
+  });
+
   it("JSON 탭에서 JSON 타입별 메타 정보를 표시한다", () => {
     mockedUseIntentDetail.mockReturnValue(
       readyDetail({

--- a/frontend/src/features/intent-draft-read/ui/IntentDetailPanel.test.tsx
+++ b/frontend/src/features/intent-draft-read/ui/IntentDetailPanel.test.tsx
@@ -217,7 +217,7 @@ describe("IntentDetailPanel", () => {
     expect(screen.getByText("대표 문장")).toBeInTheDocument();
     expect(screen.getByText("참고 1")).toBeInTheDocument();
     expect(screen.getByText("최근 이용내역을 확인하고 싶어요")).toBeInTheDocument();
-    expect(screen.getByText("상담자")).toBeInTheDocument();
+    expect(screen.getAllByText("상담자")).toHaveLength(2);
     expect(screen.getByText("해외 결제 내역이 보여요")).toBeInTheDocument();
     expect(screen.getByText("환불 가능한가요")).toBeInTheDocument();
     expect(screen.getByText("상담사")).toBeInTheDocument();

--- a/frontend/src/features/intent-draft-read/ui/IntentDetailPanel.test.tsx
+++ b/frontend/src/features/intent-draft-read/ui/IntentDetailPanel.test.tsx
@@ -194,7 +194,12 @@ describe("IntentDetailPanel", () => {
           source: "boundary_segment_v1",
         }),
         evidenceJson: JSON.stringify({
-          sampleSegmentTexts: ["최근 이용내역을 확인하고 싶어요", "customer: 해외 결제 내역이 보여요"],
+          sampleSegmentTexts: [
+            "최근 이용내역을 확인하고 싶어요",
+            "customer: 해외 결제 내역이 보여요",
+            "고객: 환불 가능한가요",
+            "상담사: 주문번호를 알려주세요",
+          ],
           sampleIntentPhrases: ["이용내역 문의"],
         }),
       }),
@@ -214,6 +219,9 @@ describe("IntentDetailPanel", () => {
     expect(screen.getByText("최근 이용내역을 확인하고 싶어요")).toBeInTheDocument();
     expect(screen.getByText("상담자")).toBeInTheDocument();
     expect(screen.getByText("해외 결제 내역이 보여요")).toBeInTheDocument();
+    expect(screen.getByText("환불 가능한가요")).toBeInTheDocument();
+    expect(screen.getByText("상담사")).toBeInTheDocument();
+    expect(screen.getByText("주문번호를 알려주세요")).toBeInTheDocument();
   });
 
   it("JSON 탭에서는 기존 JSON 필드를 그대로 확인할 수 있다", () => {

--- a/frontend/src/features/intent-draft-read/ui/IntentDetailPanel.test.tsx
+++ b/frontend/src/features/intent-draft-read/ui/IntentDetailPanel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { toast } from "sonner";
 import type { IntentDetail, IntentListState, IntentSummary } from "@/entities/intent";
@@ -179,5 +179,81 @@ describe("IntentDetailPanel", () => {
     expect(childrenFn).toHaveBeenCalledWith(stubDetail);
     expect(screen.getByTestId("children")).toHaveTextContent("배송 조회 문의");
     expect(screen.getByText("INTENT_001")).toBeInTheDocument();
+  });
+
+  it("내부 리소스 요약 화면에서 cluster 관련 키워드와 evidence 대표 문장을 표시한다", () => {
+    mockedUseIntentDetail.mockReturnValue(
+      readyDetail({
+        ...stubDetail,
+        sourceClusterRef: JSON.stringify({
+          clusterId: 12,
+          clusterSize: 36,
+          canonicalIntent: "카드 이용내역 확인",
+          keywords: ["카드", "이용내역"],
+          segmentIds: ["seg-1", "seg-2"],
+          source: "boundary_segment_v1",
+        }),
+        evidenceJson: JSON.stringify({
+          sampleSegmentTexts: ["최근 이용내역을 확인하고 싶어요", "customer: 해외 결제 내역이 보여요"],
+          sampleIntentPhrases: ["이용내역 문의"],
+        }),
+      }),
+    );
+
+    renderPanel();
+
+    expect(screen.getByText("관련 키워드")).toBeInTheDocument();
+    expect(screen.getByText("#12")).toBeInTheDocument();
+    expect(screen.getByText("36건")).toBeInTheDocument();
+    expect(screen.getByText("카드 이용내역 확인")).toBeInTheDocument();
+    expect(screen.getByText("카드")).toBeInTheDocument();
+    expect(screen.getByText("이용내역")).toBeInTheDocument();
+    expect(screen.getByText("2개")).toBeInTheDocument();
+    expect(screen.getByText("대표 문장")).toBeInTheDocument();
+    expect(screen.getByText("참고 1")).toBeInTheDocument();
+    expect(screen.getByText("최근 이용내역을 확인하고 싶어요")).toBeInTheDocument();
+    expect(screen.getByText("상담자")).toBeInTheDocument();
+    expect(screen.getByText("해외 결제 내역이 보여요")).toBeInTheDocument();
+  });
+
+  it("JSON 탭에서는 기존 JSON 필드를 그대로 확인할 수 있다", () => {
+    mockedUseIntentDetail.mockReturnValue(
+      readyDetail({
+        ...stubDetail,
+        sourceClusterRef: JSON.stringify({ clusterId: 7 }),
+        evidenceJson: JSON.stringify({ sampleSegmentTexts: ["환불 가능 여부 문의"] }),
+      }),
+    );
+
+    renderPanel();
+
+    expect(screen.queryByText("Source Cluster Ref")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "JSON" }));
+
+    expect(screen.getByText("Source Cluster Ref")).toBeInTheDocument();
+    expect(screen.getByText("Entry Condition")).toBeInTheDocument();
+    expect(screen.getByText("Evidence")).toBeInTheDocument();
+    expect(screen.getByText("Meta")).toBeInTheDocument();
+    expect(screen.getByText((content) => content.includes("sampleSegmentTexts"))).toBeInTheDocument();
+  });
+
+  it("cluster/evidence JSON을 해석할 수 없으면 요약 화면에서 빈 상태를 표시한다", () => {
+    mockedUseIntentDetail.mockReturnValue(
+      readyDetail({
+        ...stubDetail,
+        sourceClusterRef: "not-json",
+        evidenceJson: "not-json",
+      }),
+    );
+
+    renderPanel();
+
+    expect(screen.getByText("관련 키워드 정보가 없습니다.")).toBeInTheDocument();
+    expect(screen.getByText("대표 문장이 없습니다.")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "JSON" }));
+
+    expect(screen.getAllByText("not-json")).toHaveLength(2);
   });
 });

--- a/frontend/src/features/intent-draft-read/ui/IntentDetailPanel.test.tsx
+++ b/frontend/src/features/intent-draft-read/ui/IntentDetailPanel.test.tsx
@@ -246,6 +246,71 @@ describe("IntentDetailPanel", () => {
     expect(screen.getByText((content) => content.includes("sampleSegmentTexts"))).toBeInTheDocument();
   });
 
+  it("sampleIntentPhrases fallback과 배열형 evidence를 대표 문장으로 표시한다", () => {
+    mockedUseIntentDetail.mockReturnValue(
+      readyDetail({
+        ...stubDetail,
+        evidenceJson: JSON.stringify({
+          sampleIntentPhrases: ["사용자: 배송 위치를 확인하고 싶어요"],
+        }),
+      }),
+    );
+
+    const { rerender } = render(
+      <IntentDetailPanel
+        wsId={1}
+        packId={2}
+        versionId={3}
+        intentId={10}
+        intentListState={emptyIntentListState}
+      />,
+    );
+
+    expect(screen.getByText("상담자")).toBeInTheDocument();
+    expect(screen.getByText("배송 위치를 확인하고 싶어요")).toBeInTheDocument();
+
+    mockedUseIntentDetail.mockReturnValue(
+      readyDetail({
+        ...stubDetail,
+        evidenceJson: JSON.stringify([{ role: "agent", text: "운송장 번호를 확인해 주세요" }]),
+      }),
+    );
+
+    rerender(
+      <IntentDetailPanel
+        wsId={1}
+        packId={2}
+        versionId={3}
+        intentId={10}
+        intentListState={emptyIntentListState}
+      />,
+    );
+
+    expect(screen.getByText("상담사")).toBeInTheDocument();
+    expect(screen.getByText("운송장 번호를 확인해 주세요")).toBeInTheDocument();
+  });
+
+  it("JSON 탭에서 JSON 타입별 메타 정보를 표시한다", () => {
+    mockedUseIntentDetail.mockReturnValue(
+      readyDetail({
+        ...stubDetail,
+        sourceClusterRef: JSON.stringify(10),
+        entryConditionJson: JSON.stringify("ready"),
+        evidenceJson: "",
+        metaJson: JSON.stringify(["a", "b"]),
+      }),
+    );
+
+    renderPanel();
+
+    fireEvent.click(screen.getByRole("button", { name: "JSON" }));
+
+    expect(screen.getByText("VALUE")).toBeInTheDocument();
+    expect(screen.getByText("STRING")).toBeInTheDocument();
+    expect(screen.getByText("EMPTY")).toBeInTheDocument();
+    expect(screen.getByText("2 ITEMS")).toBeInTheDocument();
+  });
+
   it("cluster/evidence JSON을 해석할 수 없으면 요약 화면에서 빈 상태를 표시한다", () => {
     mockedUseIntentDetail.mockReturnValue(
       readyDetail({

--- a/frontend/src/features/intent-draft-read/ui/IntentDetailPanel.tsx
+++ b/frontend/src/features/intent-draft-read/ui/IntentDetailPanel.tsx
@@ -414,7 +414,7 @@ function evidenceItemToLine(item: unknown, index: number): EvidenceLine | null {
 }
 
 function splitTurnPrefix(value: string): EvidenceLine | null {
-  const match = value.match(/^([A-Za-z][A-Za-z0-9_-]{1,24})\s*:\s*(.+)$/);
+  const match = value.match(/^(\p{L}[\p{L}\p{N}_-]{1,24})\s*:\s*(.+)$/u);
   if (!match) return null;
   return { turn: normalizeTurnLabel(match[1]) ?? match[1], text: match[2].trim() };
 }

--- a/frontend/src/features/intent-draft-read/ui/IntentDetailPanel.tsx
+++ b/frontend/src/features/intent-draft-read/ui/IntentDetailPanel.tsx
@@ -1,4 +1,12 @@
-import { useEffect, type ReactNode } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
+import {
+  BracesIcon,
+  FileTextIcon,
+  GitBranchIcon,
+  HashIcon,
+  LayersIcon,
+  MessageSquareIcon,
+} from "lucide-react";
 import { toast } from "sonner";
 import { useIntentDetail } from "../model/useIntentDetail";
 import type { IntentDetail, IntentListState } from "../../../entities/intent";
@@ -106,18 +114,7 @@ export function IntentDetailPanel({
         </div>
         {beforeJsonCards?.(state.data)}
         <section className={styles.resourceSection} aria-labelledby="intent-resource-section-title">
-          <div className={styles.resourceSectionHeader}>
-            <h2 id="intent-resource-section-title" className={styles.resourceSectionTitle}>
-              내부 리소스
-            </h2>
-            <span className={styles.resourceSectionMeta}>JSON FIELDS</span>
-          </div>
-          <div className={styles.resourceGrid}>
-            <JsonCard label="Source Cluster Ref" value={state.data.sourceClusterRef ?? ""} />
-            <JsonCard label="Entry Condition" value={state.data.entryConditionJson ?? ""} />
-            <JsonCard label="Evidence" value={state.data.evidenceJson ?? ""} />
-            <JsonCard label="Meta" value={state.data.metaJson ?? ""} />
-          </div>
+          <IntentResourceSection detail={state.data} />
         </section>
       </div>
       {children?.(state.data)}
@@ -162,6 +159,129 @@ function InfoCard({ label, value }: { label: string; value: ReactNode }) {
   );
 }
 
+function IntentResourceSection({ detail }: { detail: IntentDetail }) {
+  const [mode, setMode] = useState<"summary" | "json">("summary");
+
+  return (
+    <>
+      <div className={styles.resourceSectionHeader}>
+        <h2 id="intent-resource-section-title" className={styles.resourceSectionTitle}>
+          내부 리소스
+        </h2>
+        <div className={styles.resourceToggleGroup} role="group" aria-label="내부 리소스 보기">
+          <button
+            type="button"
+            aria-pressed={mode === "summary"}
+            className={`${styles.resourceToggleButton} ${mode === "summary" ? styles.resourceToggleButtonActive : ""}`}
+            onClick={() => setMode("summary")}
+          >
+            요약
+          </button>
+          <button
+            type="button"
+            aria-pressed={mode === "json"}
+            className={`${styles.resourceToggleButton} ${mode === "json" ? styles.resourceToggleButtonActive : ""}`}
+            onClick={() => setMode("json")}
+          >
+            JSON
+          </button>
+        </div>
+      </div>
+
+      {mode === "summary" ? (
+        <div className={styles.resourceSummary}>
+          <ClusterScope sourceClusterRef={detail.sourceClusterRef ?? ""} />
+          <EvidenceReference evidenceJson={detail.evidenceJson ?? ""} />
+        </div>
+      ) : (
+        <div className={styles.resourceGrid}>
+          <JsonCard label="Source Cluster Ref" value={detail.sourceClusterRef ?? ""} />
+          <JsonCard label="Entry Condition" value={detail.entryConditionJson ?? ""} />
+          <JsonCard label="Evidence" value={detail.evidenceJson ?? ""} />
+          <JsonCard label="Meta" value={detail.metaJson ?? ""} />
+        </div>
+      )}
+    </>
+  );
+}
+
+function ClusterScope({ sourceClusterRef }: { sourceClusterRef: string }) {
+  const scope = useMemo(() => buildClusterScope(sourceClusterRef), [sourceClusterRef]);
+  const hasContent = scope.items.length > 0 || scope.keywords.length > 0;
+
+  return (
+    <section className={styles.summaryBlock} aria-labelledby="intent-cluster-scope-title">
+      <div className={styles.summaryBlockHeader}>
+        <span className={styles.summaryBlockIcon} aria-hidden="true">
+          <LayersIcon size={16} />
+        </span>
+        <h3 id="intent-cluster-scope-title" className={styles.summaryBlockTitle}>
+          관련 키워드
+        </h3>
+      </div>
+      {hasContent ? (
+        <div className={styles.scopePanel}>
+          {scope.items.length > 0 && (
+            <ul className={styles.scopeList}>
+              {scope.items.map((item, index) => (
+                <li key={`${item.label}-${item.value}-${index}`} className={styles.scopeItem}>
+                  <span className={styles.scopeIcon} aria-hidden="true">
+                    {item.icon}
+                  </span>
+                  <span className={styles.scopeItemText}>
+                    <span className={styles.scopeLabel}>{item.label}</span>
+                    <span className={styles.scopeValue}>{item.value}</span>
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+          {scope.keywords.length > 0 && (
+            <div className={styles.keywordGroup} aria-label="keywords">
+              {scope.keywords.map((keyword, index) => (
+                <span key={`${keyword}-${index}`} className={styles.keywordChip}>
+                  {keyword}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+      ) : (
+        <span className={styles.summaryEmpty}>관련 키워드 정보가 없습니다.</span>
+      )}
+    </section>
+  );
+}
+
+function EvidenceReference({ evidenceJson }: { evidenceJson: string }) {
+  const lines = useMemo(() => buildEvidenceLines(evidenceJson), [evidenceJson]);
+
+  return (
+    <section className={styles.summaryBlock} aria-labelledby="intent-evidence-title">
+      <div className={styles.summaryBlockHeader}>
+        <span className={styles.summaryBlockIcon} aria-hidden="true">
+          <MessageSquareIcon size={16} />
+        </span>
+        <h3 id="intent-evidence-title" className={styles.summaryBlockTitle}>
+          대표 문장
+        </h3>
+      </div>
+      {lines.length > 0 ? (
+        <ul className={styles.evidenceList}>
+          {lines.map((line, index) => (
+            <li key={`${line.turn}-${line.text}-${index}`} className={styles.evidenceItem}>
+              <span className={styles.evidenceTurn}>{line.turn}</span>
+              <span className={styles.evidenceText}>{line.text}</span>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <span className={styles.summaryEmpty}>대표 문장이 없습니다.</span>
+      )}
+    </section>
+  );
+}
+
 function JsonCard({ label, value }: { label: string; value: string }) {
   const formatted = formatJsonForDisplay(value);
   const meta = describeJson(value);
@@ -179,6 +299,169 @@ function JsonCard({ label, value }: { label: string; value: string }) {
       </div>
     </section>
   );
+}
+
+type JsonRecord = Record<string, unknown>;
+
+interface ClusterScopeItem {
+  label: string;
+  value: string;
+  icon: ReactNode;
+}
+
+interface ClusterScopeView {
+  items: ClusterScopeItem[];
+  keywords: string[];
+}
+
+interface EvidenceLine {
+  turn: string;
+  text: string;
+}
+
+function buildClusterScope(raw: string): ClusterScopeView {
+  const parsed = parseJson(raw);
+  if (!isRecord(parsed)) return { items: [], keywords: [] };
+
+  const items: ClusterScopeItem[] = [];
+  const clusterId = readPrimitive(parsed.clusterId);
+  const clusterSize = readPrimitive(parsed.clusterSize);
+  const canonicalIntent = readString(parsed.canonicalIntent);
+  const keywords = readStringArray(parsed.keywords).slice(0, 8);
+  const segmentIds = Array.isArray(parsed.segmentIds) ? parsed.segmentIds : [];
+  const source = readString(parsed.source);
+
+  if (clusterId) {
+    items.push({
+      label: "Cluster",
+      value: `#${clusterId}`,
+      icon: <HashIcon size={16} />,
+    });
+  }
+  if (clusterSize) {
+    items.push({
+      label: "Cases",
+      value: `${clusterSize}건`,
+      icon: <FileTextIcon size={16} />,
+    });
+  }
+  if (canonicalIntent) {
+    items.push({
+      label: "Intent",
+      value: canonicalIntent,
+      icon: <LayersIcon size={16} />,
+    });
+  }
+  if (segmentIds.length > 0) {
+    items.push({
+      label: "Segments",
+      value: `${segmentIds.length}개`,
+      icon: <GitBranchIcon size={16} />,
+    });
+  }
+  if (source) {
+    items.push({
+      label: "Source",
+      value: source,
+      icon: <BracesIcon size={16} />,
+    });
+  }
+
+  return { items, keywords };
+}
+
+function buildEvidenceLines(raw: string): EvidenceLine[] {
+  const parsed = parseJson(raw);
+  const sourceItems = resolveEvidenceSourceItems(parsed);
+
+  return sourceItems
+    .map((item, index) => evidenceItemToLine(item, index))
+    .filter((line): line is EvidenceLine => line !== null)
+    .slice(0, 5);
+}
+
+function resolveEvidenceSourceItems(parsed: unknown): unknown[] {
+  if (isRecord(parsed)) {
+    const segmentTexts = Array.isArray(parsed.sampleSegmentTexts) ? parsed.sampleSegmentTexts : [];
+    if (segmentTexts.length > 0) return segmentTexts;
+
+    const intentPhrases = Array.isArray(parsed.sampleIntentPhrases) ? parsed.sampleIntentPhrases : [];
+    if (intentPhrases.length > 0) return intentPhrases;
+  }
+
+  return Array.isArray(parsed) ? parsed : [];
+}
+
+function evidenceItemToLine(item: unknown, index: number): EvidenceLine | null {
+  if (typeof item === "string") {
+    const text = item.trim();
+    if (!text) return null;
+    const prefixed = splitTurnPrefix(text);
+    if (prefixed) return prefixed;
+    return { turn: `참고 ${index + 1}`, text };
+  }
+
+  if (!isRecord(item)) return null;
+  const text =
+    readString(item.text) ??
+    readString(item.message) ??
+    readString(item.canonicalText) ??
+    readString(item.customerProblemText);
+  if (!text) return null;
+
+  const turn = readString(item.turn) ?? readString(item.role) ?? readString(item.speaker);
+  return { turn: normalizeTurnLabel(turn) ?? `참고 ${index + 1}`, text };
+}
+
+function splitTurnPrefix(value: string): EvidenceLine | null {
+  const match = value.match(/^([A-Za-z][A-Za-z0-9_-]{1,24})\s*:\s*(.+)$/);
+  if (!match) return null;
+  return { turn: normalizeTurnLabel(match[1]) ?? match[1], text: match[2].trim() };
+}
+
+function normalizeTurnLabel(value: string | null): string | null {
+  if (!value) return null;
+  const normalized = value.trim().toLowerCase();
+  if (["customer", "client", "user", "고객", "사용자"].includes(normalized)) return "상담자";
+  if (["agent", "assistant", "counselor", "consultant", "상담사"].includes(normalized)) {
+    return "상담사";
+  }
+  return value.trim();
+}
+
+function parseJson(raw: string): unknown {
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function isRecord(value: unknown): value is JsonRecord {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function readPrimitive(value: unknown): string | null {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed ? trimmed : null;
+  }
+  if (typeof value === "number" && Number.isFinite(value)) return value.toLocaleString("ko-KR");
+  return null;
+}
+
+function readString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function readStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((item) => readString(item))
+    .filter((item): item is string => item !== null);
 }
 
 function formatJsonForDisplay(raw: string): string {

--- a/frontend/src/features/intent-draft-read/ui/IntentDetailPanel.tsx
+++ b/frontend/src/features/intent-draft-read/ui/IntentDetailPanel.tsx
@@ -319,6 +319,15 @@ interface EvidenceLine {
   text: string;
 }
 
+const CUSTOMER_TURN_LABELS = new Set(["customer", "client", "user", "고객", "사용자"]);
+const AGENT_TURN_LABELS = new Set([
+  "agent",
+  "assistant",
+  "counselor",
+  "consultant",
+  "상담사",
+]);
+
 function buildClusterScope(raw: string): ClusterScopeView {
   const parsed = parseJson(raw);
   if (!isRecord(parsed)) return { items: [], keywords: [] };
@@ -414,18 +423,26 @@ function evidenceItemToLine(item: unknown, index: number): EvidenceLine | null {
 }
 
 function splitTurnPrefix(value: string): EvidenceLine | null {
-  const match = value.match(/^(\p{L}[\p{L}\p{N}_-]{1,24})\s*:\s*(.+)$/u);
-  if (!match) return null;
-  return { turn: normalizeTurnLabel(match[1]) ?? match[1], text: match[2].trim() };
+  const separatorIndex = value.indexOf(":");
+  if (separatorIndex <= 0) return null;
+
+  const prefix = value.slice(0, separatorIndex).trim();
+  const text = value.slice(separatorIndex + 1).trim();
+  if (!text || !isSupportedTurnPrefix(prefix)) return null;
+
+  return { turn: normalizeTurnLabel(prefix) ?? prefix, text };
+}
+
+function isSupportedTurnPrefix(value: string): boolean {
+  const normalized = value.trim().toLowerCase();
+  return CUSTOMER_TURN_LABELS.has(normalized) || AGENT_TURN_LABELS.has(normalized);
 }
 
 function normalizeTurnLabel(value: string | null): string | null {
   if (!value) return null;
   const normalized = value.trim().toLowerCase();
-  if (["customer", "client", "user", "고객", "사용자"].includes(normalized)) return "상담자";
-  if (["agent", "assistant", "counselor", "consultant", "상담사"].includes(normalized)) {
-    return "상담사";
-  }
+  if (CUSTOMER_TURN_LABELS.has(normalized)) return "상담자";
+  if (AGENT_TURN_LABELS.has(normalized)) return "상담사";
   return value.trim();
 }
 

--- a/ml/src/pipeline/stages/draft_generation/main.py
+++ b/ml/src/pipeline/stages/draft_generation/main.py
@@ -257,6 +257,7 @@ def _build_intents(
                         "clusterSize": cluster.get("cluster_size"),
                         "source": cluster.get("source"),
                         "canonicalIntent": cluster.get("canonical_intent") or cluster.get("suggested_name"),
+                        "keywords": _string_list(cluster.get("keywords"), limit=8),
                         "segmentIds": _string_list(cluster.get("segment_ids"), limit=100),
                     }
                 ),

--- a/ml/tests/stages/test_draft_generation_main.py
+++ b/ml/tests/stages/test_draft_generation_main.py
@@ -69,6 +69,7 @@ def test_build_intents_full_hydration() -> None:
             "suggested_name": "환불 문의",
             "suggested_description": "환불 관련 클러스터",
             "exemplar_conv_ids": ["c1", "c2", "c3"],
+            "keywords": ["환불", "취소"],
         }
     ]
     index = {
@@ -90,6 +91,7 @@ def test_build_intents_full_hydration() -> None:
     assert intents[0]["representativeCases"][0]["canonicalText"] == "환불 요청합니다"
     assert intents[0]["representativeCases"][0]["customerProblemText"] == "환불"
     assert intents[0]["representativeCases"][0]["endedStatus"] == "resolved"
+    assert json.loads(intents[0]["sourceClusterRef"])["keywords"] == ["환불", "취소"]
 
 
 def test_build_intents_partial_hydration() -> None:


### PR DESCRIPTION
## Summary

- Intent 상세의 내부 리소스 영역을 요약/JSON 보기로 분리
- 요약 보기에서 관련 키워드와 대표 문장을 읽기 쉬운 형태로 표시
- draft generation 단계에서 cluster keywords를 sourceClusterRef에 포함하도록 보강
- 기존 JSON 필드 확인 화면은 JSON 보기로 유지

## Test

- pnpm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 리소스 섹션에 요약/JSON 토글 뷰 추가, 요약 모드에서 키워드·범위·대표 증거 노출 개선
  * 생성된 인텐트 메타에 키워드 포함으로 관련 정보 노출 강화

* **Style**
  * 리소스 섹션 UI 전반 스타일링 추가 및 모바일 반응형 레이아웃 개선

* **Tests**
  * 탭 전환·요약/JSON 표시 및 메타/증거 노출 동작을 검증하는 테스트 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ajou-2026-1-capstone-5/ostone/pull/317?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->