### PR TITLE
feat(fe): 사용자 화면 미리보기 목적과 테스트 세션 흐름 명확화

### DIFF
--- a/.agent/specs/319.md
+++ b/.agent/specs/319.md
@@ -1,0 +1,109 @@
+# 사용자 화면 미리보기 라벨과 진입 화면 정리
+
+## Goal
+
+운영자가 사이드바와 고객 채팅 화면에서 고객용 미리보기 목적을 명확히 이해하고, 같은 이름의 기존 테스트 세션 재사용과 새 테스트 세션 시작을 구분할 수 있게 한다.
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A[운영자: 워크스페이스 사이드바] --> B[사용자 화면 미리보기 클릭]
+    B --> C[새 탭에서 고객 채팅 미리보기 진입]
+    C --> D[테스트 고객 이름 입력]
+    D --> E{저장된 세션 존재?}
+    E -->|Yes| F[기존 테스트 세션 이어서 열기]
+    E -->|No| G[새 테스트 세션 등록]
+    F --> H[대화 화면]
+    G --> H
+    H --> I{새 테스트 세션 시작 클릭?}
+    I -->|Yes| J[저장 세션 제거 후 새 세션 등록]
+    I -->|No| K[현재 세션 유지]
+    J --> H
+    K --> H
+```
+
+## Design Diff
+
+| 영역 | As-is | To-be | 변경 내용 |
+|------|-------|-------|----------|
+| 사이드바 | `Chat` 라벨 | `사용자 화면 미리보기` 라벨 | 운영자 상담 화면과 고객 화면 preview를 구분한다. |
+| 진입 화면 브랜딩 | `CSTONE · DEMO CHAT` | `CSTONE · 고객 채팅 미리보기` | 개발/시연 느낌보다 운영 중인 고객 화면 preview 맥락을 우선한다. |
+| 진입 안내 | 이름 입력 후 채팅 시작 | 운영 도메인 팩 기준 미리보기 시작 | 현재 운영 도메인 팩 기준의 고객 응답 확인 목적을 설명한다. |
+| 대화 화면 | 세션 재사용 여부가 명시되지 않음 | 세션 재사용 안내와 새 테스트 세션 시작 액션 | 같은 이름 재진입 시 기존 세션을 이어 쓰고, 사용자가 새 세션을 명시적으로 시작할 수 있다. |
+
+## Component Tree
+
+```text
+Sidebar
+└─ SidebarLink(chat)
+
+UserChatPage
+├─ ChatEntryScreen
+└─ ChatConversationScreen
+   ├─ ChatHeader
+   ├─ chat-meta-strip
+   ├─ chat-session-reuse-note
+   ├─ MessageList
+   └─ MessageInput
+```
+
+## API Integration
+
+기존 데모 채팅 세션 API를 유지한다. 새 테스트 세션 시작은 클라이언트에 저장된 세션 키를 제거한 뒤 기존 세션 등록 API를 다시 호출한다.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/api/v1/workspaces/{workspaceId}/demo/chat-sessions` | 테스트 고객 이름으로 데모 채팅 세션 생성 |
+| GET | `/api/v1/workspaces/{workspaceId}/demo/chat-sessions/{sessionId}/messages` | 데모 채팅 메시지 동기화 |
+| POST | `/api/v1/workspaces/{workspaceId}/demo/chat-sessions/{sessionId}/messages` | 데모 채팅 메시지 전송 |
+
+## 수정 대상 파일
+
+| 파일 | 변경 유형 | 설명 |
+|------|----------|------|
+| `frontend/src/shared/ui/ostone/chrome/Sidebar.tsx` | modify | 고객 화면 preview 목적이 드러나도록 chat 라벨 변경 |
+| `frontend/src/pages/user-chat/ui/ChatEntryScreen.tsx` | modify | 진입 화면 브랜딩과 안내 문구를 고객 채팅 미리보기 중심으로 변경 |
+| `frontend/src/pages/user-chat/ui/UserChatPage.tsx` | modify | 저장 세션 제거 후 새 데모 세션을 등록하는 재시작 흐름 추가 |
+| `frontend/src/pages/user-chat/ui/ChatConversationScreen.tsx` | modify | 운영 도메인 팩 기준 메타, 세션 재사용 안내, 새 테스트 세션 시작 버튼 추가 |
+| `frontend/src/shared/ui/ostone/chrome/Sidebar.test.tsx` | modify | 변경된 사이드바 라벨과 새 탭 링크 유지 검증 |
+| `frontend/src/widgets/ostone-shell/ui/OstoneShell.test.tsx` | modify | shell에서 변경된 사이드바 라벨 검증 |
+| `frontend/src/pages/user-chat/ui/ChatEntryScreen.test.tsx` | modify | 진입 화면 preview 문구 검증 |
+| `frontend/src/pages/user-chat/ui/ChatConversationScreen.test.tsx` | modify | 대화 화면 메타와 새 세션 액션 검증 |
+| `frontend/src/pages/user-chat/ui/UserChatPage.test.tsx` | modify | 기존 세션 재사용과 새 테스트 세션 생성 흐름 검증 |
+
+## State Management
+
+| 상태 | 위치 | 설명 |
+|------|------|------|
+| `draftName` | `UserChatPage` local state | 진입 화면 이름 입력값 |
+| `customerName` | `UserChatPage` local state | 현재 테스트 고객 이름 |
+| `chatState` | `UserChatPage` local state | 현재 workspace, customerName, session, error |
+| `localStorage` | browser storage | `workspaceId + customerName` 기준 데모 세션 캐시 |
+
+## Tests
+
+### Test Strategy
+
+| 구분 | 방법 | 도구 | 비고 |
+|------|------|------|------|
+| 컴포넌트/페이지 테스트 | 관련 테스트 파일 실행 | Vitest | 라벨, 문구, 세션 재사용/초기화 흐름 검증 |
+| 정적 검사 | 변경 파일 대상 ESLint | ESLint | 변경 범위 lint 확인 |
+| 빌드 | production build | Vite+ | 타입 및 번들 가능 여부 확인 |
+| 수동 확인 | 로컬 dev server + 브라우저 | Codex in-app browser | 진입 화면 렌더링 확인 |
+
+### Test Scenarios
+
+| # | 시나리오 | 조작 | 기대 결과 |
+|---|---------|------|----------|
+| 1 | 사이드바에서 고객 화면 preview 진입 확인 | `사용자 화면 미리보기` 클릭 | `/demo/workspaces/{id}/chat`가 새 탭으로 열린다. |
+| 2 | 진입 화면 문구 확인 | 고객 채팅 URL 진입 | `고객 채팅 미리보기`, `운영 중인 도메인 팩` 맥락이 표시된다. |
+| 3 | 기존 세션 재사용 | 같은 이름으로 재진입 | 저장된 세션 메시지를 유지하고 세션 재사용 안내를 표시한다. |
+| 4 | 새 테스트 세션 시작 | 대화 화면 버튼 클릭 | 저장 세션을 제거하고 새 백엔드 세션을 등록한다. |
+| 5 | 운영 도메인 팩 없음 | 세션 생성 API 404 또는 `DOMAIN_PACK_CURRENT_VERSION_NOT_FOUND` | 운영 중인 도메인 팩 버전이 없다는 안내를 표시한다. |
+
+## Verification
+
+- `pnpm test -- ChatEntryScreen ChatConversationScreen UserChatPage Sidebar OstoneShell --run`
+- 변경 파일 대상 `pnpm exec eslint ...`
+- `pnpm build`

--- a/frontend/src/pages/user-chat/ui/ChatConversationScreen.test.tsx
+++ b/frontend/src/pages/user-chat/ui/ChatConversationScreen.test.tsx
@@ -34,9 +34,11 @@ function setup(overrides: Partial<Parameters<typeof ChatConversationScreen>[0]> 
   const props: Parameters<typeof ChatConversationScreen>[0] = {
     session: buildSession(),
     customerName: "김민지",
+    workspaceId: 42,
     isSending: false,
     messageError: null,
     onSend: vi.fn(),
+    onStartNewSession: vi.fn(),
     ...overrides,
   };
   render(<ChatConversationScreen {...props} />);
@@ -49,7 +51,9 @@ describe("ChatConversationScreen", () => {
 
     expect(screen.getByTestId("chat-header")).toBeInTheDocument();
     expect(screen.getByTestId("chat-meta-strip")).toHaveTextContent("연결됨");
-    expect(screen.getByTestId("chat-meta-strip")).toHaveTextContent("김민지");
+    expect(screen.getByTestId("chat-meta-strip")).toHaveTextContent("Workspace #42");
+    expect(screen.getByTestId("chat-meta-strip")).toHaveTextContent("운영 도메인 팩 기준");
+    expect(screen.getByTestId("chat-session-reuse-note")).toHaveTextContent("김민지 테스트 세션");
   });
 
   it("session.messages 의 본문이 화면에 렌더된다", () => {
@@ -81,6 +85,14 @@ describe("ChatConversationScreen", () => {
 
     expect(screen.getByLabelText("메시지 입력")).toBeDisabled();
     expect(screen.getByLabelText("메시지 보내기")).toBeDisabled();
+  });
+
+  it("새 테스트 세션 시작 클릭이 onStartNewSession 호출", () => {
+    const onStartNewSession = vi.fn();
+    setup({ onStartNewSession });
+
+    fireEvent.click(screen.getByRole("button", { name: "새 테스트 세션 시작" }));
+    expect(onStartNewSession).toHaveBeenCalled();
   });
 
   it("ChatHeader 가 session.id 와 status 를 노출한다", () => {

--- a/frontend/src/pages/user-chat/ui/ChatConversationScreen.tsx
+++ b/frontend/src/pages/user-chat/ui/ChatConversationScreen.tsx
@@ -5,17 +5,21 @@ import { ChatHeader } from "./ChatHeader";
 interface ChatConversationScreenProps {
   session: DemoChatSession;
   customerName: string;
+  workspaceId: number;
   isSending: boolean;
   messageError: string | null;
   onSend: (content: string) => void;
+  onStartNewSession: () => void;
 }
 
 export function ChatConversationScreen({
   session,
   customerName,
+  workspaceId,
   isSending,
   messageError,
   onSend,
+  onStartNewSession,
 }: ChatConversationScreenProps) {
   return (
     <div
@@ -36,6 +40,7 @@ export function ChatConversationScreen({
           display: "flex",
           justifyContent: "space-between",
           alignItems: "center",
+          gap: 12,
           padding: "8px 20px",
           background: "var(--paper-2)",
           borderBottom: "1px solid var(--line-2)",
@@ -46,21 +51,64 @@ export function ChatConversationScreen({
           color: "var(--ink-3)",
         }}
       >
-        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-          <span
-            aria-hidden="true"
-            style={{
-              width: 6,
-              height: 6,
-              borderRadius: 999,
-              background: "var(--signal)",
-            }}
-          />
-          연결됨
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 12,
+            minWidth: 0,
+            flexWrap: "wrap",
+          }}
+        >
+          <span style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
+            <span
+              aria-hidden="true"
+              style={{
+                width: 6,
+                height: 6,
+                borderRadius: 999,
+                background: "var(--signal)",
+              }}
+            />
+            연결됨
+          </span>
+          <span>Workspace #{workspaceId} · 운영 도메인 팩 기준</span>
         </div>
-        <div>
-          {customerName} · {session.messages.length} messages
-        </div>
+        <button
+          type="button"
+          data-testid="chat-new-session-button"
+          onClick={onStartNewSession}
+          style={{
+            minHeight: 30,
+            flexShrink: 0,
+            padding: "0 12px",
+            borderRadius: 999,
+            border: "1px solid var(--line)",
+            background: "var(--paper)",
+            color: "var(--ink)",
+            cursor: "pointer",
+            fontFamily: "var(--font-sans)",
+            fontSize: 12.5,
+            fontWeight: 540,
+            letterSpacing: "-0.12px",
+          }}
+        >
+          새 테스트 세션 시작
+        </button>
+      </div>
+      <div
+        data-testid="chat-session-reuse-note"
+        style={{
+          padding: "7px 20px",
+          borderBottom: "1px solid var(--line-2)",
+          background: "var(--paper)",
+          color: "var(--ink-3)",
+          fontSize: 12.5,
+          lineHeight: 1.45,
+        }}
+      >
+        같은 이름으로 다시 들어오면 {customerName} 테스트 세션을 이어서 엽니다. 새 테스트 세션
+        시작을 누르면 저장된 세션 대신 새 대화를 시작합니다.
       </div>
       <div
         style={{

--- a/frontend/src/pages/user-chat/ui/ChatEntryScreen.test.tsx
+++ b/frontend/src/pages/user-chat/ui/ChatEntryScreen.test.tsx
@@ -59,5 +59,14 @@ describe("ChatEntryScreen", () => {
     setup({ workspaceId: 42 });
 
     expect(screen.getByTestId("chat-entry-brand")).toHaveTextContent("Workspace #42");
+    expect(screen.getByTestId("chat-entry-brand")).toHaveTextContent("고객 채팅 미리보기");
+    expect(screen.getByTestId("chat-entry-brand")).toHaveTextContent("CURRENT PACK");
+    expect(screen.getByTestId("chat-entry-submit")).toHaveTextContent("미리보기 시작");
+    expect(screen.getByTestId("chat-entry-screen")).toHaveTextContent(
+      "운영 중인 도메인 팩이 고객에게 어떻게 응답하는지 확인할 이름을 적어 주세요",
+    );
+    expect(screen.getByTestId("chat-entry-brand")).toHaveTextContent(
+      "같은 이름으로 다시 들어오면 저장된 테스트 세션을 이어서 엽니다",
+    );
   });
 });

--- a/frontend/src/pages/user-chat/ui/ChatEntryScreen.tsx
+++ b/frontend/src/pages/user-chat/ui/ChatEntryScreen.tsx
@@ -66,7 +66,7 @@ export function ChatEntryScreen({
                 color: "var(--dark-ink-2)",
               }}
             >
-              CSTONE · DEMO CHAT
+              CSTONE · 고객 채팅 미리보기
             </div>
             <p
               style={{
@@ -80,10 +80,11 @@ export function ChatEntryScreen({
                 color: "var(--paper)",
               }}
             >
-              환불 / 배송 / 결제 등<br />
-              실제 상담 도메인 팩을 시연합니다.
+              운영 중인 도메인 팩으로
               <br />
-              먼저 이름을 알려 주세요.
+              고객 화면을 미리 확인합니다.
+              <br />
+              먼저 테스트 고객 이름을 알려 주세요.
             </p>
             <p
               style={{
@@ -93,8 +94,8 @@ export function ChatEntryScreen({
                 color: "var(--dark-ink-2)",
               }}
             >
-              입력하신 이름은 상담 세션 헤더와 메시지 표기에만 사용되며, 데모 종료 후 자동
-              폐기됩니다.
+              같은 이름으로 다시 들어오면 저장된 테스트 세션을 이어서 엽니다. 대화 화면에서
+              새 테스트 세션을 시작할 수 있습니다.
             </p>
             <div
               style={{
@@ -145,7 +146,7 @@ export function ChatEntryScreen({
               color: "var(--dark-ink-3)",
             }}
           >
-            SESSION · NEW · Workspace #{workspaceId}
+            PREVIEW · CURRENT PACK · Workspace #{workspaceId}
           </div>
         </aside>
 
@@ -168,7 +169,7 @@ export function ChatEntryScreen({
               color: "var(--ink-3)",
             }}
           >
-            Step 1 / 1
+            Customer preview
           </div>
           <h1
             style={{
@@ -179,7 +180,7 @@ export function ChatEntryScreen({
               color: "var(--ink)",
             }}
           >
-            대화를 시작합니다
+            고객 채팅 미리보기
           </h1>
           <p
             style={{
@@ -189,7 +190,8 @@ export function ChatEntryScreen({
               color: "var(--ink-2)",
             }}
           >
-            상담 화면에 표시될 이름을 적어 주세요. 한글 / 영문 모두 가능합니다.
+            운영 중인 도메인 팩이 고객에게 어떻게 응답하는지 확인할 이름을 적어 주세요.
+            한글 / 영문 모두 가능합니다.
           </p>
 
           <div>
@@ -262,7 +264,7 @@ export function ChatEntryScreen({
               fontFamily: "inherit",
             }}
           >
-            채팅 시작
+            미리보기 시작
           </button>
           <div
             style={{

--- a/frontend/src/pages/user-chat/ui/UserChatPage.test.tsx
+++ b/frontend/src/pages/user-chat/ui/UserChatPage.test.tsx
@@ -86,7 +86,7 @@ describe("UserChatPage", () => {
 
     expect(screen.getByRole("form", { name: "채팅 사용자 이름 입력" })).not.toBeNull();
     fireEvent.change(screen.getByLabelText("이름"), { target: { value: "김민지" } });
-    fireEvent.click(screen.getByRole("button", { name: "채팅 시작" }));
+    fireEvent.click(screen.getByRole("button", { name: "미리보기 시작" }));
 
     const eyebrow = await screen.findByTestId("chat-header-eyebrow");
     expect(eyebrow).toHaveTextContent("Session #77");
@@ -98,7 +98,7 @@ describe("UserChatPage", () => {
   it("같은 이름으로 다시 진입하면 저장된 세션 메시지를 유지한다", async () => {
     const firstRender = render(<UserChatPage />);
     fireEvent.change(screen.getByLabelText("이름"), { target: { value: "김민지" } });
-    fireEvent.click(screen.getByRole("button", { name: "채팅 시작" }));
+    fireEvent.click(screen.getByRole("button", { name: "미리보기 시작" }));
 
     const input = await screen.findByLabelText("메시지 입력");
     fireEvent.change(input, { target: { value: "Hello" } });
@@ -112,12 +112,102 @@ describe("UserChatPage", () => {
     render(<UserChatPage />);
 
     fireEvent.change(screen.getByLabelText("이름"), { target: { value: "김민지" } });
-    fireEvent.click(screen.getByRole("button", { name: "채팅 시작" }));
+    fireEvent.click(screen.getByRole("button", { name: "미리보기 시작" }));
 
     expect(await screen.findByText("Hello")).not.toBeNull();
     expect(screen.getByTestId("chat-header-eyebrow")).toHaveTextContent("Session #77");
     expect(screen.getByTestId("chat-header-name")).toHaveTextContent("김민지");
     expect(registerDemoChatSessionMock).not.toHaveBeenCalled();
+  });
+
+  it("새 테스트 세션 시작은 새 백엔드 세션으로 저장 세션을 교체한다", async () => {
+    registerDemoChatSessionMock
+      .mockResolvedValueOnce({
+        id: "77",
+        status: "OPEN",
+        startedAt: "2026-05-22T00:00:00Z",
+        messages: [
+          {
+            id: "backend-greeting-77",
+            sessionId: 77,
+            content: "첫 테스트 세션입니다.",
+            senderType: "BOT",
+            createdAt: "2026-05-22T00:00:00Z",
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        id: "88",
+        status: "OPEN",
+        startedAt: "2026-05-22T00:10:00Z",
+        messages: [
+          {
+            id: "backend-greeting-88",
+            sessionId: 88,
+            content: "새 테스트 세션입니다.",
+            senderType: "BOT",
+            createdAt: "2026-05-22T00:10:00Z",
+          },
+        ],
+      });
+
+    render(<UserChatPage />);
+    fireEvent.change(screen.getByLabelText("이름"), { target: { value: "김민지" } });
+    fireEvent.click(screen.getByRole("button", { name: "미리보기 시작" }));
+
+    expect(await screen.findByText("첫 테스트 세션입니다.")).not.toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "새 테스트 세션 시작" }));
+
+    expect(await screen.findByText("새 테스트 세션입니다.")).not.toBeNull();
+    expect(screen.getByTestId("chat-header-eyebrow")).toHaveTextContent("Session #88");
+    expect(registerDemoChatSessionMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("새 테스트 세션 생성 실패 시 운영 도메인팩 안내 에러를 표시한다", async () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    registerDemoChatSessionMock
+      .mockResolvedValueOnce({
+        id: "77",
+        status: "OPEN",
+        startedAt: "2026-05-22T00:00:00Z",
+        messages: [
+          {
+            id: "backend-greeting-77",
+            sessionId: 77,
+            content: "첫 테스트 세션입니다.",
+            senderType: "BOT",
+            createdAt: "2026-05-22T00:00:00Z",
+          },
+        ],
+      })
+      .mockRejectedValueOnce(
+        new ApiRequestError(
+          404,
+          "DOMAIN_PACK_CURRENT_VERSION_NOT_FOUND",
+          "현재 운영 중인 PUBLISHED version을 찾을 수 없습니다.",
+        ),
+      );
+
+    render(<UserChatPage />);
+    fireEvent.change(screen.getByLabelText("이름"), { target: { value: "김민지" } });
+    fireEvent.click(screen.getByRole("button", { name: "미리보기 시작" }));
+
+    expect(await screen.findByText("첫 테스트 세션입니다.")).not.toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "새 테스트 세션 시작" }));
+
+    expect(
+      await screen.findByText(
+        "이 워크스페이스에는 운영 중인 도메인 팩 버전이 없습니다. 관리자에게 문의해 주세요.",
+      ),
+    ).not.toBeNull();
+    const storedSession = window.localStorage.getItem(window.localStorage.key(0) ?? "");
+    expect(storedSession).toContain("첫 테스트 세션입니다.");
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Failed to restart demo chat session",
+      expect.any(ApiRequestError),
+    );
+
+    consoleErrorSpy.mockRestore();
   });
 
   it("백엔드에 저장된 상담사 메시지를 동기화해 화면에 표시한다", async () => {
@@ -133,7 +223,7 @@ describe("UserChatPage", () => {
 
     render(<UserChatPage />);
     fireEvent.change(screen.getByLabelText("이름"), { target: { value: "김민지" } });
-    fireEvent.click(screen.getByRole("button", { name: "채팅 시작" }));
+    fireEvent.click(screen.getByRole("button", { name: "미리보기 시작" }));
 
     expect(await screen.findByText("저장된 상담사 답변입니다.")).not.toBeNull();
     expect(listDemoChatMessagesMock).toHaveBeenCalledWith(42, "77");
@@ -144,7 +234,7 @@ describe("UserChatPage", () => {
 
     render(<UserChatPage />);
     fireEvent.change(screen.getByLabelText("이름"), { target: { value: "김민지" } });
-    fireEvent.click(screen.getByRole("button", { name: "채팅 시작" }));
+    fireEvent.click(screen.getByRole("button", { name: "미리보기 시작" }));
 
     const input = await screen.findByLabelText("메시지 입력");
     fireEvent.change(input, { target: { value: "Hello" } });
@@ -166,7 +256,7 @@ describe("UserChatPage", () => {
 
     render(<UserChatPage />);
     fireEvent.change(screen.getByLabelText("이름"), { target: { value: "김민지" } });
-    fireEvent.click(screen.getByRole("button", { name: "채팅 시작" }));
+    fireEvent.click(screen.getByRole("button", { name: "미리보기 시작" }));
 
     await screen.findByTestId("chat-header-eyebrow");
 
@@ -187,7 +277,7 @@ describe("UserChatPage", () => {
   it("이름이 비어 있으면 세션을 생성하지 않는다", async () => {
     render(<UserChatPage />);
 
-    fireEvent.click(screen.getByRole("button", { name: "채팅 시작" }));
+    fireEvent.click(screen.getByRole("button", { name: "미리보기 시작" }));
 
     expect(await screen.findByText("이름을 입력해 주세요.")).not.toBeNull();
     expect(window.localStorage.length).toBe(0);
@@ -224,7 +314,7 @@ describe("UserChatPage", () => {
 
       render(<UserChatPage />);
       fireEvent.change(screen.getByLabelText("이름"), { target: { value: "김민지" } });
-      fireEvent.click(screen.getByRole("button", { name: "채팅 시작" }));
+      fireEvent.click(screen.getByRole("button", { name: "미리보기 시작" }));
 
       expect(
         await screen.findByText(
@@ -243,7 +333,7 @@ describe("UserChatPage", () => {
 
       render(<UserChatPage />);
       fireEvent.change(screen.getByLabelText("이름"), { target: { value: "김민지" } });
-      fireEvent.click(screen.getByRole("button", { name: "채팅 시작" }));
+      fireEvent.click(screen.getByRole("button", { name: "미리보기 시작" }));
 
       expect(
         await screen.findByText("채팅 세션을 시작할 수 없습니다. 잠시 후 다시 시도해 주세요."),
@@ -255,7 +345,7 @@ describe("UserChatPage", () => {
 
       render(<UserChatPage />);
       fireEvent.change(screen.getByLabelText("이름"), { target: { value: "김민지" } });
-      fireEvent.click(screen.getByRole("button", { name: "채팅 시작" }));
+      fireEvent.click(screen.getByRole("button", { name: "미리보기 시작" }));
 
       const retryButton = await screen.findByRole("button", { name: "다시 시도" });
       fireEvent.click(retryButton);

--- a/frontend/src/pages/user-chat/ui/UserChatPage.tsx
+++ b/frontend/src/pages/user-chat/ui/UserChatPage.tsx
@@ -90,6 +90,15 @@ async function getOrCreateStoredSession(
   return nextSession;
 }
 
+async function createFreshStoredSession(
+  workspaceId: number,
+  customerName: string,
+): Promise<DemoChatSession> {
+  const nextSession = await registerDemoChatSession(workspaceId, customerName);
+  writeStoredSession(workspaceId, customerName, nextSession);
+  return nextSession;
+}
+
 export function UserChatPage() {
   const { workspaceId: raw } = useParams<{ workspaceId: string }>();
   const workspaceId = Number(raw);
@@ -136,6 +145,30 @@ export function UserChatPage() {
       setChatState({
         workspaceId,
         customerName: nextName,
+        session: null,
+        error: resolveSessionStartErrorMessage(error),
+      });
+    }
+  };
+
+  const handleStartNewSession = async () => {
+    if (!customerName) return;
+
+    const requestId = ++nameRequestIdRef.current;
+    setMessageError(null);
+    setNameError(null);
+    setChatState({ workspaceId, customerName, session: null, error: null });
+
+    try {
+      const nextSession = await createFreshStoredSession(workspaceId, customerName);
+      if (requestId !== nameRequestIdRef.current) return;
+      setChatState({ workspaceId, customerName, session: nextSession, error: null });
+    } catch (error) {
+      console.error("Failed to restart demo chat session", error);
+      if (requestId !== nameRequestIdRef.current) return;
+      setChatState({
+        workspaceId,
+        customerName,
         session: null,
         error: resolveSessionStartErrorMessage(error),
       });
@@ -340,10 +373,14 @@ export function UserChatPage() {
     <ChatConversationScreen
       session={activeChatState.session}
       customerName={customerName}
+      workspaceId={workspaceId}
       isSending={isSending}
       messageError={messageError}
       onSend={(content) => {
         void handleSendMessage(content);
+      }}
+      onStartNewSession={() => {
+        void handleStartNewSession();
       }}
     />
   );

--- a/frontend/src/shared/ui/ostone/chrome/Sidebar.test.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/Sidebar.test.tsx
@@ -24,11 +24,11 @@ describe("Sidebar", () => {
     expect(nav).toHaveAttribute("data-collapsed", "false");
     expect(nav).toHaveStyle({ width: "200px" });
     expect(screen.getByTitle("Consultation")).toBeInTheDocument();
-    expect(screen.getByTitle("Chat")).toBeInTheDocument();
+    expect(screen.getByTitle("사용자 화면 미리보기")).toBeInTheDocument();
     expect(screen.getByTitle("Uploads")).toBeInTheDocument();
     expect(screen.getByTitle("Domain Packs")).toBeInTheDocument();
     expect(screen.getByText("Consultation")).toBeInTheDocument();
-    expect(screen.getByText("Chat")).toBeInTheDocument();
+    expect(screen.getByText("사용자 화면 미리보기")).toBeInTheDocument();
     expect(screen.getByText("Uploads")).toBeInTheDocument();
     expect(screen.queryByTitle("Workflows")).not.toBeInTheDocument();
   });
@@ -78,16 +78,22 @@ describe("Sidebar", () => {
     renderSidebar({ basePath: "/workspaces/7" });
 
     expect(screen.getByTitle("Consultation")).toHaveAttribute("href", "/workspaces/7/consultation");
-    expect(screen.getByTitle("Chat")).toHaveAttribute("href", "/demo/workspaces/7/chat");
-    expect(screen.getByTitle("Chat")).toHaveAttribute("target", "_blank");
-    expect(screen.getByTitle("Chat")).toHaveAttribute("rel", "noopener noreferrer");
+    expect(screen.getByTitle("사용자 화면 미리보기")).toHaveAttribute(
+      "href",
+      "/demo/workspaces/7/chat",
+    );
+    expect(screen.getByTitle("사용자 화면 미리보기")).toHaveAttribute("target", "_blank");
+    expect(screen.getByTitle("사용자 화면 미리보기")).toHaveAttribute(
+      "rel",
+      "noopener noreferrer",
+    );
     expect(screen.getByTitle("Domain Packs")).toHaveAttribute("href", "/workspaces/7/domain-packs");
   });
 
-  it("workspaceId를 추출할 수 없으면 Chat 링크를 안전한 내부 경로로 보낸다", () => {
+  it("workspaceId를 추출할 수 없으면 사용자 화면 미리보기 링크를 안전한 내부 경로로 보낸다", () => {
     renderSidebar({ basePath: "/workspaces" });
 
-    expect(screen.getByTitle("Chat")).toHaveAttribute("href", "/workspaces");
+    expect(screen.getByTitle("사용자 화면 미리보기")).toHaveAttribute("href", "/workspaces");
   });
 
   it("switcher가 주어지면 렌더링된다", () => {

--- a/frontend/src/shared/ui/ostone/chrome/Sidebar.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/Sidebar.tsx
@@ -49,7 +49,7 @@ const TOP_NAV_ITEMS: TopNavItem[] = [
   {
     key: "chat",
     icon: "msg",
-    label: "Chat",
+    label: "사용자 화면 미리보기",
     getPath: getDemoChatPath,
     external: true,
   },

--- a/frontend/src/widgets/ostone-shell/ui/OstoneShell.test.tsx
+++ b/frontend/src/widgets/ostone-shell/ui/OstoneShell.test.tsx
@@ -22,7 +22,7 @@ describe("OstoneShell", () => {
     expect(screen.queryByTitle("Operator")).not.toBeInTheDocument();
     expect(screen.queryByTitle("Pipeline")).not.toBeInTheDocument();
     expect(screen.getByTitle("Consultation")).toBeInTheDocument();
-    expect(screen.getByTitle("Chat")).toBeInTheDocument();
+    expect(screen.getByTitle("사용자 화면 미리보기")).toBeInTheDocument();
     expect(screen.getByTitle("Uploads")).toBeInTheDocument();
     expect(screen.getByTitle("Domain Packs")).toBeInTheDocument();
     expect(screen.queryByTitle("Workflows")).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary

Closes #319

- 사이드바 `Chat` 라벨을 `사용자 화면 미리보기`로 변경하고 기존 새 탭 진입 동작을 유지했습니다.
- 고객 채팅 진입 화면의 `DEMO CHAT` 중심 문구를 `고객 채팅 미리보기`와 운영 도메인 팩 기준 안내로 정리했습니다.
- 같은 이름으로 재진입할 때 기존 테스트 세션을 이어 쓰는 맥락을 화면에 표시하고, 대화 화면에서 `새 테스트 세션 시작` 액션으로 새 백엔드 세션을 등록할 수 있게 했습니다.
- 새 테스트 세션 생성 실패 시 기존 저장 세션을 지우지 않도록 CodeRabbit 리뷰를 반영했습니다.
- PR 규칙 통과를 위해 `.agent/specs/319.md` FE 스펙을 추가했습니다.

## Impact

운영자는 사이드바 라벨만으로 고객용 preview 진입점임을 이해할 수 있고, 고객 채팅 미리보기 화면에서 현재 운영 도메인 팩 기준으로 테스트한다는 맥락을 확인할 수 있습니다. 같은 이름의 세션 재사용과 새 테스트 세션 시작도 명시적으로 구분됩니다.

## Validation

- `pnpm test -- ChatEntryScreen ChatConversationScreen UserChatPage Sidebar OstoneShell --run` 통과: 5 files / 47 tests
- 변경 파일 대상 `pnpm exec eslint ...` 통과
- `pnpm test -- --coverage --run` 통과: 197 files / 1350 tests, UserChatPage lines 96.12%
- `pnpm build` 통과
- 로컬 spec-check 조건 확인: `feature/319-user-chat-preview -> .agent/specs/319.md`
- 전체 `pnpm lint`는 기존 unrelated lint 오류 64개로 실패했습니다.
