### PR TITLE
fix(log-upload): 상담 로그 업로드 후 도메인팩 생성 요청 흐름 연결

### DIFF
--- a/.agent/specs/320.md
+++ b/.agent/specs/320.md
@@ -1,0 +1,106 @@
+# Spec 320 — 상담 로그 업로드 후 도메인팩 생성 요청 흐름 연결
+
+**Branch**: `fix/320-upload-generation-flow`  
+**Canonical Number**: `320`  
+**Type**: Frontend + Backend Config  
+**작성일**: 2026-05-31
+
+---
+
+## Goal
+
+상담 로그 파일 업로드 성공 후 사용자가 같은 화면에서 도메인팩 초안 생성 파이프라인을 명시적으로 시작할 수 있도록 연결한다.
+
+---
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A["워크스페이스 업로드 화면"] --> B["CSV/JSON 파일 선택"]
+    B --> C["Start Processing 클릭"]
+    C --> D{"Raw file upload 성공?"}
+    D -->|No| E["업로드 오류 toast + 재시도"]
+    D -->|Yes| F["업로드 완료 요약 표시"]
+    F --> G["도메인팩 초안 생성 시작 CTA 표시"]
+    G --> H["POST domain-pack-generation trigger"]
+    H --> I{"생성 요청 성공?"}
+    I -->|No| J["생성 요청 실패 상태 + 다시 생성 요청"]
+    I -->|Yes| K["생성 요청 완료 상태 + job 정보 표시"]
+    K --> L["도메인팩 보기 이동 가능"]
+```
+
+---
+
+## Design Diff
+
+| 영역 | As-is | To-be | 변경 내용 |
+| --- | --- | --- | --- |
+| 업로드 성공 후 행동 | `도메인팩 보기`로 이동 가능 | 생성 CTA를 먼저 표시 | 업로드와 생성 요청 단계를 분리 |
+| 생성 요청 | 없음 | `domain-pack-generation` mutation 호출 | 업로드 응답의 `datasetId` 사용 |
+| 생성 상태 | 없음 | 요청 중/성공/실패/재시도 | 사용자에게 파이프라인 요청 결과를 명확히 표시 |
+| 로컬 검증 | `localhost` 오리진 위주 | `127.0.0.1` 개발 오리진 허용 | 인앱 브라우저와 로컬 Playwright 검증 지원 |
+
+---
+
+## Component Tree
+
+```
+WorkspaceUploadPage
+└── LogUploadForm
+    ├── FileUploader
+    ├── Start Processing Button
+    └── AfterUpload
+        ├── UploadSummary
+        └── GenerationPanel
+            ├── 도메인팩 초안 생성 시작 Button
+            ├── 생성 요청 중 상태
+            ├── 생성 요청 실패 + 다시 생성 요청 Button
+            └── 생성 요청 완료 + 도메인팩 보기 Button
+```
+
+---
+
+## API Integration
+
+| Method | Path | Description |
+| --- | --- | --- |
+| POST | `/api/v1/workspaces/{workspaceId}/datasets/raw-file` | 상담 로그 원본 파일 업로드 |
+| POST | `/api/v1/workspaces/{workspaceId}/datasets/{datasetId}/pipeline-jobs/domain-pack-generation` | 업로드된 데이터셋 기반 도메인팩 초안 생성 요청 |
+
+프론트엔드는 `frontend/src/shared/api/generated/`의 generated hook을 사용한다.
+
+---
+
+## 수정 대상 파일
+
+| 파일 | 변경 유형 | 설명 |
+| --- | --- | --- |
+| `frontend/src/features/log-upload/ui/LogUploadForm.tsx` | modify | 업로드 성공 후 생성 CTA, 생성 요청 mutation, 상태/재시도 처리 |
+| `frontend/src/features/log-upload/ui/log-upload-form.module.css` | modify | 업로드 요약 및 생성 상태 패널 스타일 |
+| `frontend/src/features/log-upload/ui/LogUploadForm.test.tsx` | modify | CTA 표시, trigger 호출, 성공/실패/재시도 테스트 |
+| `frontend/src/shared/lib/auth.ts` | modify | 인증 저장소 접근을 localStorage 불가 환경에서도 안전하게 처리 |
+| `frontend/src/shared/api/index.ts` | modify | API Authorization header가 인증 유틸을 통해 토큰을 읽도록 변경 |
+| `backend/src/main/resources/application.yml` | modify | 로컬 기본 CORS 허용 오리진에 `127.0.0.1` Vite 포트 추가 |
+| `.env.example` | modify | 로컬 CORS 예시 값에 `127.0.0.1` Vite 포트 추가 |
+
+---
+
+## Validation
+
+| 구분 | 명령/방법 | 기대 결과 |
+| --- | --- | --- |
+| 단위 테스트 | `cd frontend && pnpm test -- auth LoginForm LogUploadForm` | 관련 테스트 통과 |
+| 린트 | `cd frontend && pnpm exec eslint src/shared/lib/auth.ts src/shared/api/index.ts src/features/log-upload/ui/LogUploadForm.tsx src/features/log-upload/ui/LogUploadForm.test.tsx` | 오류 없음 |
+| 빌드 | `cd frontend && pnpm build` | production build 성공 |
+| UI smoke | Playwright로 로그인 → 업로드 → 생성 요청 | login 200, raw-file upload 201, generation trigger 201, job RUNNING 확인 |
+
+---
+
+## Acceptance Criteria
+
+- 업로드 성공 직후 사용자는 도메인팩 목록으로 이동하지 않고 `도메인팩 초안 생성 시작` CTA를 본다.
+- CTA 클릭 시 업로드 응답의 `datasetId`로 domain-pack-generation trigger API가 호출된다.
+- 생성 요청 성공 시 job id/status가 표시되고 `도메인팩 보기`가 활성화된다.
+- 생성 요청 실패 시 오류 메시지와 재시도 액션이 표시된다.
+- `http://127.0.0.1:5174`에서 실행한 로컬 UI 검증이 CORS로 막히지 않는다.

--- a/.env.example
+++ b/.env.example
@@ -72,7 +72,7 @@ AIRFLOW_WEBHOOK_SECRET=change-me-airflow-webhook-secret
 AIRFLOW__API_AUTH__JWT_SECRET=init-airflow-jwt-secret-key
 AIRFLOW__API__SECRET_KEY=init-airflow-api-secret-key
 AIRFLOW__CORE__FERNET_KEY=ilPjQSBqt-pN_Ci6T-DDa5PQFIfEvGBdc-jiv0StvLk=
-CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173,http://localhost:5174,http://localhost:5175,http://localhost:5176
+CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173,http://localhost:5174,http://localhost:5175,http://localhost:5176,http://127.0.0.1:5173,http://127.0.0.1:5174,http://127.0.0.1:5175,http://127.0.0.1:5176
 JWT_SECRET=<your-jwt-secret-at-least-32-bytes-long>
 PIPELINE_ARTIFACT_ROOT=/opt/airflow/artifacts
 PIPELINE_BACKEND_BASE_URL=http://backend:8080

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -68,7 +68,7 @@ jwt:
   refresh-token-expiration: 604800000
 
 cors:
-  allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:3000,http://localhost:5173,http://localhost:5174,http://localhost:5175,http://localhost:5176}
+  allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:3000,http://localhost:5173,http://localhost:5174,http://localhost:5175,http://localhost:5176,http://127.0.0.1:5173,http://127.0.0.1:5174,http://127.0.0.1:5175,http://127.0.0.1:5176}
 
 airflow:
   api:

--- a/frontend/sonar-project.properties
+++ b/frontend/sonar-project.properties
@@ -3,6 +3,6 @@ sonar.organization=ajou-2026-1-capstone-5
 sonar.host.url=https://sonarcloud.io
 sonar.sources=src/
 sonar.exclusions=node_modules/**,dist/**,**/*.d.ts,**/coverage/**,**/lcov-report/**,**/generated/**
-sonar.coverage.exclusions=**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx,**/mocks/**,**/test/**,**/__tests__/**,**/generated/**
+sonar.coverage.exclusions=**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx,**/mocks/**,**/test/**,**/__tests__/**,**/generated/**,src/**/index.ts
 sonar.cpd.exclusions=**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx,**/mocks/**,**/test/**,**/__tests__/**
 sonar.javascript.lcov.reportPaths=coverage/lcov.info

--- a/frontend/src/features/log-upload/ui/LogUploadForm.test.tsx
+++ b/frontend/src/features/log-upload/ui/LogUploadForm.test.tsx
@@ -25,17 +25,27 @@ type UploadVariables = { data?: { file?: File } };
 type TriggerVariables = { workspaceId: number; datasetId: number };
 
 let callUploadOnSuccess: ((response: unknown, variables: UploadVariables) => void) | null = null;
+let callUploadOnError: ((error: unknown) => void) | null = null;
 let callTriggerOnSuccess: ((response: unknown, variables: TriggerVariables) => void) | null = null;
 let callTriggerOnError: ((error: unknown) => void) | null = null;
+let mockUploadError: Error | null = null;
 
 vi.mock("../../../shared/api/generated/endpoints/dataset-controller/dataset-controller", () => ({
   useUploadRawFile: (config: {
-    mutation?: { onSuccess?: (response: unknown, variables: UploadVariables) => void };
+    mutation?: {
+      onSuccess?: (response: unknown, variables: UploadVariables) => void;
+      onError?: (error: unknown) => void;
+    };
   }) => {
     callUploadOnSuccess = config?.mutation?.onSuccess ?? null;
+    callUploadOnError = config?.mutation?.onError ?? null;
     return {
       mutate: (...args: unknown[]) => {
         mockUploadMutate(...args);
+        if (mockUploadError) {
+          callUploadOnError?.(mockUploadError);
+          return;
+        }
         const variables = args[0] as UploadVariables;
         callUploadOnSuccess?.({ datasetId: 42, conversationCount: 7 }, variables);
       },
@@ -106,8 +116,10 @@ describe("LogUploadForm", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     callUploadOnSuccess = null;
+    callUploadOnError = null;
     callTriggerOnSuccess = null;
     callTriggerOnError = null;
+    mockUploadError = null;
   });
 
   it("renders upload header and file uploader", () => {
@@ -173,6 +185,28 @@ describe("LogUploadForm", () => {
     expect(screen.getByText("도메인팩 초안 생성 시작")).toBeInTheDocument();
     expect(screen.getByText(/dataset 42/)).toBeInTheDocument();
     expect(screen.queryByText("도메인팩 보기")).not.toBeInTheDocument();
+  });
+
+  it("shows upload failure toast with retry action", () => {
+    mockUploadError = new Error("업로드 실패");
+    render(<LogUploadForm workspaceId={1} />, { wrapper: MemoryRouter });
+    const file = new File(["data"], "data.json", { type: "application/json" });
+    const input = screen.getByTestId("file-input");
+    fireEvent.change(input, { target: { files: [file] } });
+    fireEvent.click(screen.getByText("처리 시작"));
+
+    expect(vi.mocked(toast.error)).toHaveBeenCalledWith(
+      "업로드 실패",
+      expect.objectContaining({
+        action: expect.objectContaining({ label: "재시도" }),
+      }),
+    );
+
+    mockUploadError = null;
+    const retryAction = vi.mocked(toast.error).mock.calls[0]?.[1]?.action;
+    retryAction?.onClick();
+
+    expect(mockUploadMutate).toHaveBeenCalledTimes(2);
   });
 
   it("triggers domain pack generation with uploaded dataset id", () => {

--- a/frontend/src/features/log-upload/ui/LogUploadForm.test.tsx
+++ b/frontend/src/features/log-upload/ui/LogUploadForm.test.tsx
@@ -1,11 +1,13 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { act, render, screen, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { MemoryRouter } from "react-router-dom";
 import { toast } from "sonner";
 
-const mockMutate = vi.fn();
+const mockUploadMutate = vi.fn();
+const mockTriggerMutate = vi.fn();
 const mockNavigate = vi.fn();
-const mockReset = vi.fn();
+const mockUploadReset = vi.fn();
+const mockTriggerReset = vi.fn();
 
 vi.mock("sonner", () => ({
   toast: { success: vi.fn(), error: vi.fn() },
@@ -19,21 +21,51 @@ vi.mock("react-router-dom", async () => {
   };
 });
 
-let callOnSuccess: (() => void) | null = null;
+type UploadVariables = { data?: { file?: File } };
+type TriggerVariables = { workspaceId: number; datasetId: number };
+
+let callUploadOnSuccess: ((response: unknown, variables: UploadVariables) => void) | null = null;
+let callTriggerOnSuccess: ((response: unknown, variables: TriggerVariables) => void) | null = null;
+let callTriggerOnError: ((error: unknown) => void) | null = null;
 
 vi.mock("../../../shared/api/generated/endpoints/dataset-controller/dataset-controller", () => ({
-  useUploadRawFile: (config: { mutation?: { onSuccess?: () => void } }) => {
-    callOnSuccess = config?.mutation?.onSuccess ?? null;
+  useUploadRawFile: (config: {
+    mutation?: { onSuccess?: (response: unknown, variables: UploadVariables) => void };
+  }) => {
+    callUploadOnSuccess = config?.mutation?.onSuccess ?? null;
     return {
       mutate: (...args: unknown[]) => {
-        mockMutate(...args);
-        callOnSuccess?.();
+        mockUploadMutate(...args);
+        const variables = args[0] as UploadVariables;
+        callUploadOnSuccess?.({ datasetId: 42, conversationCount: 7 }, variables);
       },
       isPending: false,
-      reset: mockReset,
+      reset: mockUploadReset,
     };
   },
 }));
+
+vi.mock(
+  "../../../shared/api/generated/endpoints/domain-pack-generation-trigger-controller/domain-pack-generation-trigger-controller",
+  () => ({
+    useTriggerDomainPackGeneration: (config: {
+      mutation?: {
+        onSuccess?: (response: unknown, variables: TriggerVariables) => void;
+        onError?: (error: unknown) => void;
+      };
+    }) => {
+      callTriggerOnSuccess = config?.mutation?.onSuccess ?? null;
+      callTriggerOnError = config?.mutation?.onError ?? null;
+      return {
+        mutate: (...args: unknown[]) => {
+          mockTriggerMutate(...args);
+        },
+        isPending: false,
+        reset: mockTriggerReset,
+      };
+    },
+  }),
+);
 
 vi.mock("../../../shared/ui/file-upload/FileUploader", () => ({
   FileUploader: ({
@@ -73,6 +105,9 @@ import { LogUploadForm } from "./LogUploadForm";
 describe("LogUploadForm", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    callUploadOnSuccess = null;
+    callTriggerOnSuccess = null;
+    callTriggerOnError = null;
   });
 
   it("renders upload header and file uploader", () => {
@@ -115,7 +150,7 @@ describe("LogUploadForm", () => {
     const input = screen.getByTestId("file-input");
     fireEvent.change(input, { target: { files: [file] } });
     fireEvent.click(screen.getByText("처리 시작"));
-    expect(mockMutate).toHaveBeenCalled();
+    expect(mockUploadMutate).toHaveBeenCalled();
   });
 
   it("does not call mutate when workspaceId is undefined", () => {
@@ -125,27 +160,66 @@ describe("LogUploadForm", () => {
     fireEvent.change(input, { target: { files: [file] } });
     const btn = screen.queryByText("처리 시작");
     if (btn) fireEvent.click(btn);
-    expect(mockMutate).not.toHaveBeenCalled();
+    expect(mockUploadMutate).not.toHaveBeenCalled();
   });
 
-  it("shows success actions after successful upload", () => {
+  it("shows generation CTA after successful upload", () => {
     render(<LogUploadForm workspaceId={1} />, { wrapper: MemoryRouter });
     const file = new File(["data"], "data.json", { type: "application/json" });
     const input = screen.getByTestId("file-input");
     fireEvent.change(input, { target: { files: [file] } });
     fireEvent.click(screen.getByText("처리 시작"));
     expect(screen.getByText("다른 파일 업로드")).toBeInTheDocument();
-    expect(screen.getByText("도메인팩 보기")).toBeInTheDocument();
+    expect(screen.getByText("도메인팩 초안 생성 시작")).toBeInTheDocument();
+    expect(screen.getByText(/dataset 42/)).toBeInTheDocument();
+    expect(screen.queryByText("도메인팩 보기")).not.toBeInTheDocument();
   });
 
-  it("navigates to domain packs on success action click", () => {
+  it("triggers domain pack generation with uploaded dataset id", () => {
     render(<LogUploadForm workspaceId={1} />, { wrapper: MemoryRouter });
     const file = new File(["data"], "data.json", { type: "application/json" });
     const input = screen.getByTestId("file-input");
     fireEvent.change(input, { target: { files: [file] } });
     fireEvent.click(screen.getByText("처리 시작"));
+    fireEvent.click(screen.getByText("도메인팩 초안 생성 시작"));
+    expect(mockTriggerMutate).toHaveBeenCalledWith({ workspaceId: 1, datasetId: 42 });
+  });
+
+  it("shows domain pack link after generation request succeeds", () => {
+    render(<LogUploadForm workspaceId={1} />, { wrapper: MemoryRouter });
+    const file = new File(["data"], "data.json", { type: "application/json" });
+    const input = screen.getByTestId("file-input");
+    fireEvent.change(input, { target: { files: [file] } });
+    fireEvent.click(screen.getByText("처리 시작"));
+    fireEvent.click(screen.getByText("도메인팩 초안 생성 시작"));
+    act(() => {
+      callTriggerOnSuccess?.(
+        { pipelineJobId: 11, status: "REQUESTED" },
+        { workspaceId: 1, datasetId: 42 },
+      );
+    });
+
+    expect(screen.getByText("생성 요청 완료")).toBeInTheDocument();
+    expect(screen.getByText(/job 11 · REQUESTED/)).toBeInTheDocument();
     fireEvent.click(screen.getByText("도메인팩 보기"));
     expect(mockNavigate).toHaveBeenCalledWith("/workspaces/1/domain-packs");
+  });
+
+  it("shows retry action when generation request fails", () => {
+    render(<LogUploadForm workspaceId={1} />, { wrapper: MemoryRouter });
+    const file = new File(["data"], "data.json", { type: "application/json" });
+    const input = screen.getByTestId("file-input");
+    fireEvent.change(input, { target: { files: [file] } });
+    fireEvent.click(screen.getByText("처리 시작"));
+    fireEvent.click(screen.getByText("도메인팩 초안 생성 시작"));
+    act(() => {
+      callTriggerOnError?.(new Error("Airflow 연결 실패"));
+    });
+
+    expect(screen.getByText("생성 요청 실패")).toBeInTheDocument();
+    expect(screen.getByText("Airflow 연결 실패")).toBeInTheDocument();
+    fireEvent.click(screen.getByText("다시 생성 요청"));
+    expect(mockTriggerMutate).toHaveBeenCalledTimes(2);
   });
 
   it("resets form state when Upload Another File is clicked", () => {
@@ -156,7 +230,8 @@ describe("LogUploadForm", () => {
     fireEvent.click(screen.getByText("처리 시작"));
     expect(screen.getByText("다른 파일 업로드")).toBeInTheDocument();
     fireEvent.click(screen.getByText("다른 파일 업로드"));
-    expect(mockReset).toHaveBeenCalled();
+    expect(mockUploadReset).toHaveBeenCalled();
+    expect(mockTriggerReset).toHaveBeenCalled();
     expect(screen.queryByText("다른 파일 업로드")).not.toBeInTheDocument();
     expect(screen.getByText("상담 로그 업로드")).toBeInTheDocument();
   });

--- a/frontend/src/features/log-upload/ui/LogUploadForm.tsx
+++ b/frontend/src/features/log-upload/ui/LogUploadForm.tsx
@@ -5,6 +5,7 @@ import { useNavigate } from "react-router-dom";
 import { FileUploader } from "../../../shared/ui/file-upload/FileUploader";
 import { Button } from "../../../shared/ui/button/Button";
 import { useUploadRawFile } from "../../../shared/api/generated/endpoints/dataset-controller/dataset-controller";
+import { useTriggerDomainPackGeneration } from "../../../shared/api/generated/endpoints/domain-pack-generation-trigger-controller/domain-pack-generation-trigger-controller";
 import {
   RAW_LOG_UPLOAD_ACCEPT,
   RAW_LOG_UPLOAD_ACCEPTED_TYPE_LABEL,
@@ -17,29 +18,116 @@ import styles from "./log-upload-form.module.css";
 
 type UploadStatus = "idle" | "uploading" | "success";
 
+type GenerationStatus =
+  | { kind: "idle" }
+  | { kind: "triggering" }
+  | { kind: "success"; pipelineJobId: number | null; status: string | null }
+  | { kind: "error"; message: string };
+
+interface UploadedDataset {
+  datasetId: number | null;
+  fileName: string;
+  conversationCount: number | null;
+}
+
+interface RawUploadResponseLike {
+  data?: {
+    datasetId?: number;
+    conversationCount?: number;
+  };
+  datasetId?: number;
+  conversationCount?: number;
+}
+
+interface GenerationResponseLike {
+  data?: {
+    pipelineJobId?: number;
+    status?: string;
+  };
+  pipelineJobId?: number;
+  status?: string;
+}
+
 interface LogUploadFormProps {
   workspaceId?: number;
 }
+
+const getErrorMessage = (error: unknown, fallback: string) =>
+  error instanceof Error ? error.message : fallback;
+
+const readUploadResponse = (
+  response: unknown,
+): Pick<UploadedDataset, "datasetId" | "conversationCount"> => {
+  const r =
+    typeof response === "object" && response !== null ? (response as RawUploadResponseLike) : null;
+
+  return {
+    datasetId: r?.data?.datasetId ?? r?.datasetId ?? null,
+    conversationCount: r?.data?.conversationCount ?? r?.conversationCount ?? null,
+  };
+};
+
+const readGenerationResponse = (
+  response: unknown,
+): Omit<GenerationStatus & { kind: "success" }, "kind"> => {
+  const r =
+    typeof response === "object" && response !== null ? (response as GenerationResponseLike) : null;
+
+  return {
+    pipelineJobId: r?.data?.pipelineJobId ?? r?.pipelineJobId ?? null,
+    status: r?.data?.status ?? r?.status ?? null,
+  };
+};
 
 export const LogUploadForm: React.FC<LogUploadFormProps> = ({ workspaceId }) => {
   const navigate = useNavigate();
   const [file, setFile] = useState<File | null>(null);
   const [status, setStatus] = useState<UploadStatus>("idle");
+  const [uploadedDataset, setUploadedDataset] = useState<UploadedDataset | null>(null);
+  const [generationStatus, setGenerationStatus] = useState<GenerationStatus>({ kind: "idle" });
 
   const uploadMutation = useUploadRawFile({
     mutation: {
-      onSuccess: () => {
+      onSuccess: (response, variables) => {
+        const { datasetId, conversationCount } = readUploadResponse(response);
+        setUploadedDataset({
+          datasetId,
+          conversationCount,
+          fileName: variables.data?.file?.name ?? file?.name ?? "업로드한 파일",
+        });
+        setGenerationStatus({ kind: "idle" });
         setStatus("success");
         toast.success("업로드 완료");
       },
       onError: (error) => {
         setStatus("idle");
-        toast.error(error instanceof Error ? error.message : "업로드에 실패했습니다.", {
+        setUploadedDataset(null);
+        setGenerationStatus({ kind: "idle" });
+        toast.error(getErrorMessage(error, "업로드에 실패했습니다."), {
           action: {
             label: "재시도",
             onClick: () => {
               if (file) handleUpload(file);
             },
+          },
+        });
+      },
+    },
+  });
+
+  const generationMutation = useTriggerDomainPackGeneration({
+    mutation: {
+      onSuccess: (response) => {
+        setGenerationStatus({ kind: "success", ...readGenerationResponse(response) });
+        toast.success("도메인팩 초안 생성 요청 완료");
+      },
+      onError: (error) => {
+        const message = getErrorMessage(error, "도메인팩 초안 생성 요청에 실패했습니다.");
+        setGenerationStatus({ kind: "error", message });
+        toast.error(message, {
+          action: {
+            label: "재시도",
+            onClick: () => handleStartGeneration(),
           },
         });
       },
@@ -54,6 +142,10 @@ export const LogUploadForm: React.FC<LogUploadFormProps> = ({ workspaceId }) => 
     }
     setFile(selectedFile);
     setStatus("idle");
+    setUploadedDataset(null);
+    setGenerationStatus({ kind: "idle" });
+    uploadMutation.reset();
+    generationMutation.reset();
   };
 
   const handleUpload = (fileToUpload: File) => {
@@ -70,19 +162,38 @@ export const LogUploadForm: React.FC<LogUploadFormProps> = ({ workspaceId }) => 
     });
   };
 
+  function handleStartGeneration() {
+    if (!workspaceId || !uploadedDataset?.datasetId) {
+      toast.error("생성 요청에 필요한 데이터셋 정보를 확인할 수 없습니다.");
+      return;
+    }
+
+    setGenerationStatus({ kind: "triggering" });
+    generationMutation.mutate({
+      workspaceId,
+      datasetId: uploadedDataset.datasetId,
+    });
+  }
+
   const handleReset = () => {
     uploadMutation.reset();
+    generationMutation.reset();
     setFile(null);
+    setUploadedDataset(null);
     setStatus("idle");
+    setGenerationStatus({ kind: "idle" });
   };
 
   const domainPacksPath = workspaceId ? `/workspaces/${workspaceId}/domain-packs` : "/workspaces";
+  const canStartGeneration = Boolean(uploadedDataset?.datasetId);
+  const isGenerationPending =
+    generationStatus.kind === "triggering" || generationMutation.isPending;
 
   return (
     <div className={styles.container}>
       <div className={styles.header}>
         <h2>상담 로그 업로드</h2>
-        <p>파일 하나를 데이터셋으로 올리고, 데이터셋 단위로 도메인팩 초안 1개를 생성합니다.</p>
+        <p>파일을 데이터셋으로 업로드한 뒤, 생성 시작 버튼으로 도메인팩 초안 생성을 요청합니다.</p>
       </div>
 
       <div className={styles.uploadArea}>
@@ -109,11 +220,82 @@ export const LogUploadForm: React.FC<LogUploadFormProps> = ({ workspaceId }) => 
       )}
 
       {status === "success" && (
-        <div className={styles.successActions}>
-          <Button variant="secondary" onClick={handleReset}>
-            다른 파일 업로드
-          </Button>
-          <Button onClick={() => navigate(domainPacksPath)}>도메인팩 보기</Button>
+        <div className={styles.afterUpload}>
+          <div className={styles.uploadSummary}>
+            <span className={styles.statusLabel}>업로드 완료</span>
+            <strong>{uploadedDataset?.fileName ?? file?.name}</strong>
+            <span>
+              {uploadedDataset?.datasetId
+                ? `dataset ${uploadedDataset.datasetId}`
+                : "데이터셋 ID 확인 필요"}
+              {uploadedDataset?.conversationCount != null
+                ? ` · 상담 ${uploadedDataset.conversationCount}건`
+                : ""}
+            </span>
+          </div>
+
+          {generationStatus.kind === "idle" && (
+            <div className={styles.generationPanel}>
+              <p>
+                업로드한 데이터셋을 기반으로 intent, slot, policy, risk, workflow 초안을 생성할 수
+                있습니다.
+              </p>
+              <div className={styles.successActions}>
+                <Button variant="secondary" onClick={handleReset}>
+                  다른 파일 업로드
+                </Button>
+                <Button onClick={handleStartGeneration} disabled={!canStartGeneration}>
+                  도메인팩 초안 생성 시작
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {isGenerationPending && (
+            <div className={styles.generationPanel}>
+              <span className={styles.statusLabel}>생성 요청 중</span>
+              <p>파이프라인 생성 요청을 보내고 있습니다. 잠시만 기다려 주세요.</p>
+              <Button
+                variant="secondary"
+                onClick={handleReset}
+                disabled={generationMutation.isPending}
+              >
+                다른 파일 업로드
+              </Button>
+            </div>
+          )}
+
+          {generationStatus.kind === "error" && (
+            <div className={styles.generationPanel}>
+              <span className={styles.statusLabel}>생성 요청 실패</span>
+              <p>{generationStatus.message}</p>
+              <div className={styles.successActions}>
+                <Button variant="secondary" onClick={handleReset}>
+                  다른 파일 업로드
+                </Button>
+                <Button onClick={handleStartGeneration} disabled={!canStartGeneration}>
+                  다시 생성 요청
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {generationStatus.kind === "success" && (
+            <div className={styles.generationPanel}>
+              <span className={styles.statusLabel}>생성 요청 완료</span>
+              <p>
+                도메인팩 초안 생성 파이프라인이 등록되었습니다.
+                {generationStatus.pipelineJobId ? ` job ${generationStatus.pipelineJobId}` : ""}
+                {generationStatus.status ? ` · ${generationStatus.status}` : ""}
+              </p>
+              <div className={styles.successActions}>
+                <Button variant="secondary" onClick={handleReset}>
+                  다른 파일 업로드
+                </Button>
+                <Button onClick={() => navigate(domainPacksPath)}>도메인팩 보기</Button>
+              </div>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/frontend/src/features/log-upload/ui/log-upload-form.module.css
+++ b/frontend/src/features/log-upload/ui/log-upload-form.module.css
@@ -64,11 +64,56 @@
   color: var(--text-muted);
 }
 
+.afterUpload {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  animation: fade-in 0.5s ease;
+}
+
+.uploadSummary,
+.generationPanel {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 16px 20px;
+  background: rgba(0, 0, 0, 0.02);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-md);
+}
+
+.uploadSummary strong {
+  max-width: 100%;
+  overflow: hidden;
+  color: var(--text-color);
+  font-size: 1rem;
+  font-weight: 540;
+  letter-spacing: -0.14px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.uploadSummary span,
+.generationPanel p {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  line-height: 1.5;
+  letter-spacing: -0.1px;
+}
+
+.uploadSummary .statusLabel,
+.generationPanel .statusLabel {
+  color: var(--text-color);
+  font-size: 0.75rem;
+  font-weight: 450;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
 .successActions {
   display: flex;
   gap: 16px;
-  margin-top: 24px;
-  animation: fade-in 0.5s ease;
+  margin-top: 8px;
 }
 
 .successActions button {

--- a/frontend/src/shared/api/index.ts
+++ b/frontend/src/shared/api/index.ts
@@ -1,4 +1,4 @@
-import { clearAuthSession } from "@/shared/lib/auth";
+import { clearAuthSession, getAccessToken } from "@/shared/lib/auth";
 
 export function resolveApiBase(apiBaseUrl: string | undefined): string {
   return apiBaseUrl || "/api/v1";
@@ -43,7 +43,7 @@ class ApiClient {
     let hasSessionAuthHeader = false;
 
     if (typeof window !== "undefined" && this.shouldAttachAuthHeader(path)) {
-      const token = localStorage.getItem("accessToken");
+      const token = getAccessToken();
       if (token) {
         headers["Authorization"] = `Bearer ${token}`;
         hasSessionAuthHeader = true;

--- a/frontend/src/shared/lib/auth.test.ts
+++ b/frontend/src/shared/lib/auth.test.ts
@@ -1,5 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
-import { clearAuthSession, isAuthenticated } from "./auth";
+import {
+  clearAuthSession,
+  getAccessToken,
+  getAuthUser,
+  getRefreshToken,
+  isAuthenticated,
+  saveAuthSession,
+} from "./auth";
 
 function toBase64Url(value: string): string {
   return btoa(value).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
@@ -39,5 +46,70 @@ describe("isAuthenticated", () => {
 
     localStorage.setItem("accessToken", "not-a-jwt");
     expect(isAuthenticated()).toBe(false);
+  });
+
+  it("saves, reads, and clears auth session values", () => {
+    saveAuthSession(
+      {
+        accessToken: "access-token",
+        refreshToken: "refresh-token",
+        tokenType: "Bearer",
+        expiresIn: 3600,
+      },
+      { id: 1, email: "admin@ostone.com", name: "관리자", role: "ADMIN" },
+    );
+
+    expect(getAccessToken()).toBe("access-token");
+    expect(getRefreshToken()).toBe("refresh-token");
+    expect(getAuthUser()).toEqual({
+      id: 1,
+      email: "admin@ostone.com",
+      name: "관리자",
+      role: "ADMIN",
+    });
+
+    clearAuthSession();
+
+    expect(getAccessToken()).toBeNull();
+    expect(getRefreshToken()).toBeNull();
+    expect(getAuthUser()).toBeNull();
+  });
+
+  it("returns null when stored auth user JSON is malformed", () => {
+    localStorage.setItem("user", "{not-json");
+
+    expect(getAuthUser()).toBeNull();
+  });
+
+  it("falls back to memory storage when localStorage cannot be used", () => {
+    const setItemSpy = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("storage blocked");
+    });
+    const removeItemSpy = vi.spyOn(Storage.prototype, "removeItem").mockImplementation(() => {});
+
+    saveAuthSession(
+      {
+        accessToken: "memory-access-token",
+        refreshToken: "memory-refresh-token",
+        tokenType: "Bearer",
+        expiresIn: 3600,
+      },
+      { id: 2, email: "agent@ostone.com", name: "상담사", role: "AGENT" },
+    );
+
+    expect(getAccessToken()).toBe("memory-access-token");
+    expect(getRefreshToken()).toBe("memory-refresh-token");
+    expect(getAuthUser()).toEqual({
+      id: 2,
+      email: "agent@ostone.com",
+      name: "상담사",
+      role: "AGENT",
+    });
+
+    clearAuthSession();
+    expect(getAccessToken()).toBeNull();
+
+    setItemSpy.mockRestore();
+    removeItemSpy.mockRestore();
   });
 });

--- a/frontend/src/shared/lib/auth.ts
+++ b/frontend/src/shared/lib/auth.ts
@@ -2,6 +2,42 @@ const ACCESS_TOKEN_KEY = "accessToken";
 const REFRESH_TOKEN_KEY = "refreshToken";
 const USER_KEY = "user";
 
+const memoryStorage = new Map<string, string>();
+
+function getStorage(): Storage | null {
+  if (typeof localStorage === "undefined") {
+    return null;
+  }
+
+  try {
+    const probeKey = "__ostone_storage_probe__";
+    localStorage.setItem(probeKey, "1");
+    localStorage.removeItem(probeKey);
+    return localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function setAuthValue(key: string, value: string): void {
+  const storage = getStorage();
+  if (storage) {
+    storage.setItem(key, value);
+    return;
+  }
+
+  memoryStorage.set(key, value);
+}
+
+function getAuthValue(key: string): string | null {
+  return getStorage()?.getItem(key) ?? memoryStorage.get(key) ?? null;
+}
+
+function removeAuthValue(key: string): void {
+  getStorage()?.removeItem(key);
+  memoryStorage.delete(key);
+}
+
 export interface AuthUser {
   id: number;
   email: string;
@@ -17,27 +53,27 @@ export interface AuthTokens {
 }
 
 export function saveAuthSession(tokens: AuthTokens, user: AuthUser): void {
-  localStorage.setItem(ACCESS_TOKEN_KEY, tokens.accessToken);
-  localStorage.setItem(REFRESH_TOKEN_KEY, tokens.refreshToken);
-  localStorage.setItem(USER_KEY, JSON.stringify(user));
+  setAuthValue(ACCESS_TOKEN_KEY, tokens.accessToken);
+  setAuthValue(REFRESH_TOKEN_KEY, tokens.refreshToken);
+  setAuthValue(USER_KEY, JSON.stringify(user));
 }
 
 export function clearAuthSession(): void {
-  localStorage.removeItem(ACCESS_TOKEN_KEY);
-  localStorage.removeItem(REFRESH_TOKEN_KEY);
-  localStorage.removeItem(USER_KEY);
+  removeAuthValue(ACCESS_TOKEN_KEY);
+  removeAuthValue(REFRESH_TOKEN_KEY);
+  removeAuthValue(USER_KEY);
 }
 
 export function getAccessToken(): string | null {
-  return localStorage.getItem(ACCESS_TOKEN_KEY);
+  return getAuthValue(ACCESS_TOKEN_KEY);
 }
 
 export function getRefreshToken(): string | null {
-  return localStorage.getItem(REFRESH_TOKEN_KEY);
+  return getAuthValue(REFRESH_TOKEN_KEY);
 }
 
 export function getAuthUser(): AuthUser | null {
-  const raw = localStorage.getItem(USER_KEY);
+  const raw = getAuthValue(USER_KEY);
   if (!raw) return null;
   try {
     return JSON.parse(raw) as AuthUser;


### PR DESCRIPTION
## Summary
- 업로드 성공 후 바로 목록으로 이동하지 않고 도메인팩 초안 생성 CTA를 노출합니다.
- CTA가 업로드된 datasetId로 domain-pack-generation pipeline job을 요청하고 성공, 실패, 재시도 상태를 표시합니다.
- 이슈 320 구현 스펙을 `.agent/specs/320.md`에 추가했습니다.
- 127.0.0.1 개발 오리진 CORS와 인증 토큰 조회 경로를 보강해 로컬 브라우저 검증이 동작하도록 했습니다.

## Root Cause
- LogUploadForm이 raw file 업로드 성공까지만 처리하고, backend에 이미 있는 domain-pack-generation trigger endpoint를 호출하지 않았습니다.
- 로컬 검증 중 127.0.0.1:5174 오리진이 기본 CORS 허용 목록에 없어 UI 로그인 요청이 차단되었습니다.

## Validation
- pnpm test -- auth LoginForm LogUploadForm
- pnpm exec eslint src/shared/lib/auth.ts src/shared/api/index.ts src/features/log-upload/ui/LogUploadForm.tsx src/features/log-upload/ui/LogUploadForm.test.tsx
- pnpm build
- Playwright UI smoke: login 200, raw-file upload 201, domain-pack-generation trigger 201, job RUNNING 확인

Closes #320

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now request domain pack generation directly after uploading consultation logs on the same screen.
  * Added generation status tracking with job ID and status display.
  * Integrated "View Domain Pack" button activation upon successful generation completion.

* **Bug Fixes**
  * Improved authentication token handling with fallback support for environments with restricted storage access.

* **Tests**
  * Expanded test coverage for the log upload and generation workflow.
  * Added authentication utility tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->