### PR TITLE
chore(frontend): 상담사 친화 용어로 화면 문구 정리

### DIFF
--- a/frontend/e2e/auth-login.spec.ts
+++ b/frontend/e2e/auth-login.spec.ts
@@ -95,7 +95,7 @@ test.describe("Login screen", () => {
         await page.getByRole("button", { name: "시스템 로그인" }).click();
 
         await expect(page).toHaveURL(/\/workspaces\/1\/workflows/);
-        await expect(page.getByText("Workflows")).toBeVisible();
+        await expect(page.getByText("응대 흐름")).toBeVisible();
         await expect
           .poll(() => page.evaluate(() => window.localStorage.getItem("accessToken")))
           .toBeTruthy();

--- a/frontend/e2e/domain-pack-read.spec.ts
+++ b/frontend/e2e/domain-pack-read.spec.ts
@@ -82,7 +82,7 @@ test.describe("Domain pack generated read screens", () => {
         );
         await expect(page.getByText("환불 workflow")).toBeVisible();
         await expect(
-          page.getByText("이 워크플로우에는 아직 그래프가 정의되어 있지 않습니다."),
+          page.getByText("이 응대 흐름에는 아직 흐름도가 정의되어 있지 않습니다."),
         ).toBeVisible();
         expect(seen).toContain("GET /workspaces/1/domain-packs/1/versions/1/workflows");
         expect(seen).toContain("GET /workspaces/1/domain-packs/1/versions/1/workflows/401");

--- a/frontend/e2e/workspace-create.spec.ts
+++ b/frontend/e2e/workspace-create.spec.ts
@@ -82,7 +82,7 @@ test.describe("Workspace creation", () => {
 
         await expect(page).toHaveURL(/\/workspaces\/777\/workflows/);
         await expect(page.getByText("워크스페이스를 생성했습니다.")).toBeVisible();
-        await expect(page.getByText("Workflows")).toBeVisible();
+        await expect(page.getByText("응대 흐름")).toBeVisible();
         expect(seen).toContain("POST /workspaces");
       });
     });

--- a/frontend/src/app/App.test.tsx
+++ b/frontend/src/app/App.test.tsx
@@ -105,10 +105,10 @@ describe("App", () => {
       expect(window.location.pathname).toBe("/workspaces/1/workflows");
     });
 
-    expect(await screen.findByText("Workflows")).toBeInTheDocument();
+    expect(await screen.findByText("응대 흐름")).toBeInTheDocument();
     expect(
       await screen.findByText(
-        "아직 등록된 워크플로우가 없습니다. 도메인팩에서 워크플로우를 생성해 주세요.",
+        "아직 등록된 응대 흐름이 없습니다. 도메인팩에서 응대 흐름을 생성해 주세요.",
       ),
     ).toBeInTheDocument();
     expect(fetchMock).toHaveBeenCalledWith(

--- a/frontend/src/entities/workflow/api/useListAllWorkspaceWorkflows.ts
+++ b/frontend/src/entities/workflow/api/useListAllWorkspaceWorkflows.ts
@@ -90,7 +90,7 @@ export function useListAllWorkspaceWorkflows({
   } else if (detailQueries.find((q) => q.isError)) {
     error = "도메인팩 상세 조회 실패";
   } else if (workflowQueries.find((q) => q.isError)) {
-    error = "워크플로우 목록 조회 실패";
+    error = "응대 흐름 목록 조회 실패";
   }
 
   const entries: WorkspaceWorkflowEntry[] = [];

--- a/frontend/src/entities/workflow/api/useListWorkflowsByIntent.test.ts
+++ b/frontend/src/entities/workflow/api/useListWorkflowsByIntent.test.ts
@@ -141,7 +141,7 @@ describe("useListWorkflowsByIntent", () => {
     );
 
     await waitFor(() => expect(result.current.error).not.toBeNull());
-    expect(result.current.error).toBe("워크플로우 목록 조회 실패");
+    expect(result.current.error).toBe("응대 흐름 목록 조회 실패");
   });
 
   it("workflows 응답이 비어있을 때 빈 entries", async () => {

--- a/frontend/src/entities/workflow/api/useListWorkflowsByIntent.ts
+++ b/frontend/src/entities/workflow/api/useListWorkflowsByIntent.ts
@@ -87,7 +87,7 @@ export function useListWorkflowsByIntent({
 
   const loading = enabled && (packQuery.isLoading || workflowsQuery.isLoading);
   const error = workflowsQuery.isError
-    ? "워크플로우 목록 조회 실패"
+    ? "응대 흐름 목록 조회 실패"
     : packQuery.isError
       ? "도메인팩 정보 조회 실패"
       : null;

--- a/frontend/src/entities/workflow/ui/GraphRenderer.test.tsx
+++ b/frontend/src/entities/workflow/ui/GraphRenderer.test.tsx
@@ -51,7 +51,7 @@ describe("GraphRenderer", () => {
   it("노드/엣지 없는 그래프도 오류 없이 렌더링한다", () => {
     const emptyGraph = { direction: "TB" as const, nodes: [], edges: [] };
     render(<GraphRenderer graph={emptyGraph} />);
-    expect(screen.getByText("No workflow data")).toBeInTheDocument();
+    expect(screen.getByText("응대 흐름 데이터 없음")).toBeInTheDocument();
   });
 
   it("interaction props가 spec대로 설정된다", () => {

--- a/frontend/src/entities/workflow/ui/GraphRenderer.tsx
+++ b/frontend/src/entities/workflow/ui/GraphRenderer.tsx
@@ -70,15 +70,15 @@ export default function GraphRenderer({
   return (
     <div className={styles.container}>
       {isLoading ? (
-        <div className={styles.loading}>Loading workflow...</div>
+        <div className={styles.loading}>응대 흐름을 불러오는 중...</div>
       ) : error ? (
         <div className={styles.error}>
           Error: {typeof error === "string" ? error : error.message}
         </div>
       ) : !nodes || nodes.length === 0 ? (
-        <div className={styles.empty}>{emptyMessage ?? "No workflow data"}</div>
+        <div className={styles.empty}>{emptyMessage ?? "응대 흐름 데이터 없음"}</div>
       ) : (
-        <ErrorBoundary fallback={<div className={styles.error}>Something went wrong</div>}>
+        <ErrorBoundary fallback={<div className={styles.error}>흐름도를 표시할 수 없습니다</div>}>
           <ReactFlow
             nodes={nodes}
             edges={edges}

--- a/frontend/src/entities/workflow/ui/WorkflowGraphMini.tsx
+++ b/frontend/src/entities/workflow/ui/WorkflowGraphMini.tsx
@@ -36,7 +36,7 @@ export function WorkflowGraphMini({
         data-testid={`workflow-graph-mini-loading-${workflowId}`}
         style={{ fontFamily: "var(--mono)", fontSize: "10px", color: "var(--ink-3)" }}
       >
-        loading…
+        확인 중…
       </span>
     );
   }
@@ -47,7 +47,7 @@ export function WorkflowGraphMini({
         data-testid={`workflow-graph-mini-error-${workflowId}`}
         style={{ fontFamily: "var(--mono)", fontSize: "10px", color: "var(--danger)" }}
       >
-        graph unavailable
+        흐름도 없음
       </span>
     );
   }
@@ -59,7 +59,7 @@ export function WorkflowGraphMini({
         data-testid={`workflow-graph-mini-error-${workflowId}`}
         style={{ fontFamily: "var(--mono)", fontSize: "10px", color: "var(--danger)" }}
       >
-        graph unavailable
+        흐름도 없음
       </span>
     );
   }

--- a/frontend/src/features/approve-intent/api/useApproveIntent.ts
+++ b/frontend/src/features/approve-intent/api/useApproveIntent.ts
@@ -12,7 +12,7 @@ export interface UseApproveIntentProps {
 }
 
 const INTENT_ERROR_MESSAGES = {
-  INTENT_NOT_EDITABLE: "편집할 수 없는 상태의 intent입니다.",
+  INTENT_NOT_EDITABLE: "편집할 수 없는 상태의 상담 유형입니다.",
 } as const;
 
 export function useApproveIntent({
@@ -30,7 +30,7 @@ export function useApproveIntent({
       {
         onSuccess: () => {
           onStatusChanged?.(status);
-          toast.success("intent 상태가 변경되었습니다.");
+          toast.success("상담 유형 상태가 변경되었습니다.");
         },
         onError: (error) => {
           if (error instanceof ApiRequestError) {
@@ -39,7 +39,7 @@ export function useApproveIntent({
               return;
             }
           }
-          toast.error("intent 상태 변경에 실패했습니다.");
+          toast.error("상담 유형 상태 변경에 실패했습니다.");
         },
       },
     );

--- a/frontend/src/features/approve-intent/ui/ApproveIntentDialog.test.tsx
+++ b/frontend/src/features/approve-intent/ui/ApproveIntentDialog.test.tsx
@@ -74,7 +74,7 @@ describe("ApproveIntentDialog", () => {
     expect(onOpenChange).not.toHaveBeenCalled();
   });
 
-  it("intentName이 다이얼로그 제목과 설명에 표시된다", () => {
+  it("상담 유형 이름이 다이얼로그 제목과 설명에 표시된다", () => {
     render(
       <ApproveIntentDialog
         intentName="order_cancel"
@@ -86,7 +86,7 @@ describe("ApproveIntentDialog", () => {
       />,
     );
 
-    expect(screen.getByText(/intent publish하기/)).toBeInTheDocument();
+    expect(screen.getByText(/상담 유형 승인/)).toBeInTheDocument();
     expect(screen.getByText(/order_cancel/)).toBeInTheDocument();
   });
 });

--- a/frontend/src/features/approve-intent/ui/ApproveIntentDialog.tsx
+++ b/frontend/src/features/approve-intent/ui/ApproveIntentDialog.tsx
@@ -28,8 +28,10 @@ export function ApproveIntentDialog({
   onConfirm,
   isLoading,
 }: ApproveIntentDialogProps) {
-  const confirmLabel = action === "publish" ? "승인" : "반려";
-  const confirmVariant = action === "publish" ? "default" : "destructive";
+  const isPublish = action === "publish";
+  const actionLabel = isPublish ? "승인" : "반려";
+  const confirmLabel = actionLabel;
+  const confirmVariant = isPublish ? "default" : "destructive";
 
   return (
     <AlertDialog
@@ -39,9 +41,9 @@ export function ApproveIntentDialog({
       }}
     >
       <AlertDialogContent size="sm" className={styles.dialogContent}>
-        <AlertDialogTitle className={styles.title}>intent {action}하기</AlertDialogTitle>
+        <AlertDialogTitle className={styles.title}>상담 유형 {actionLabel}</AlertDialogTitle>
         <AlertDialogDescription className={styles.description}>
-          <strong>{intentName}</strong> intent를 {action} 처리합니다.
+          <strong>{intentName}</strong> 상담 유형을 {actionLabel} 처리합니다.
         </AlertDialogDescription>
         <AlertDialogFooter className={styles.buttonRow}>
           <Button

--- a/frontend/src/features/consultation/ui/MessageDetailPanel.test.tsx
+++ b/frontend/src/features/consultation/ui/MessageDetailPanel.test.tsx
@@ -77,9 +77,9 @@ describe("MessageDetailPanel", () => {
       />,
     );
 
-    expect(screen.getByText("반품 정책")).toBeInTheDocument();
-    expect(screen.getByText("환불 정책")).toBeInTheDocument();
-    expect(screen.getByText("교환 정책")).toBeInTheDocument();
+    expect(screen.getByText("반품 응대 기준")).toBeInTheDocument();
+    expect(screen.getByText("환불 응대 기준")).toBeInTheDocument();
+    expect(screen.getByText("교환 응대 기준")).toBeInTheDocument();
   });
 
   /* ─── Test 5: Risk tags ─── */

--- a/frontend/src/features/consultation/ui/MessageDetailPanel.tsx
+++ b/frontend/src/features/consultation/ui/MessageDetailPanel.tsx
@@ -49,9 +49,9 @@ const MOCK_DATA: {
     { name: "배송지 주소", extracted: false },
   ],
   policies: [
-    { name: "반품 정책", extracted: true, matched: true },
-    { name: "환불 정책", extracted: true, matched: false },
-    { name: "교환 정책", extracted: false, matched: false },
+    { name: "반품 응대 기준", extracted: true, matched: true },
+    { name: "환불 응대 기준", extracted: true, matched: false },
+    { name: "교환 응대 기준", extracted: false, matched: false },
   ],
   risks: [
     { name: "고객 불만 고조", extracted: true, level: "high" as const },
@@ -137,19 +137,19 @@ export function MessageDetailPanel({
         <p className={styles.messagePreview}>{message.content}</p>
       </div>
 
-      <Section title="Slot">
+      <Section title="확인 항목">
         {slots.map((slot) => (
           <SlotTagItem key={slot.name} slot={slot} />
         ))}
       </Section>
 
-      <Section title="Policy">
+      <Section title="응대 기준">
         {policies.map((policy) => (
           <PolicyTagItem key={policy.name} policy={policy} />
         ))}
       </Section>
 
-      <Section title="Risk">
+      <Section title="주의 사항">
         {risks.map((risk) => (
           <RiskTagItem key={risk.name} risk={risk} />
         ))}

--- a/frontend/src/features/consultation/ui/chat-history/SessionList.tsx
+++ b/frontend/src/features/consultation/ui/chat-history/SessionList.tsx
@@ -33,7 +33,7 @@ export function SessionList({ workspaceId, selectedSessionId, onSelectSession }:
     return (
       <aside className={styles.wrapper} aria-label="채팅 기록 목록">
         <div className={styles.header}>
-          <Eyebrow>Chat history</Eyebrow>
+          <Eyebrow>상담 이력</Eyebrow>
           <span className={styles.count}>불러오는 중</span>
         </div>
         <div className={styles.stateArea}>
@@ -47,7 +47,7 @@ export function SessionList({ workspaceId, selectedSessionId, onSelectSession }:
     return (
       <aside className={styles.wrapper} aria-label="채팅 기록 목록">
         <div className={styles.header}>
-          <Eyebrow>Chat history</Eyebrow>
+          <Eyebrow>상담 이력</Eyebrow>
           <span className={styles.count}>오류</span>
         </div>
         <div className={styles.stateArea}>
@@ -60,7 +60,7 @@ export function SessionList({ workspaceId, selectedSessionId, onSelectSession }:
   return (
     <aside className={styles.wrapper} aria-label="채팅 기록 목록">
       <div className={styles.header}>
-        <Eyebrow>Chat history</Eyebrow>
+        <Eyebrow>상담 이력</Eyebrow>
         <span className={styles.count}>{validSessions.length}개 세션</span>
       </div>
 

--- a/frontend/src/features/domain-pack-draft-create/api/createDraftApi.ts
+++ b/frontend/src/features/domain-pack-draft-create/api/createDraftApi.ts
@@ -16,7 +16,7 @@ export const createDraftApi = {
     const response = await createDraft(wsId, packId, payload);
     return requireApiData<CreateDomainPackDraftResponse>(
       response,
-      "DRAFT 생성 응답을 확인할 수 없습니다.",
+      "검토본 생성 응답을 확인할 수 없습니다.",
     );
   },
 };

--- a/frontend/src/features/domain-pack-draft-create/model/useCreateDraft.test.tsx
+++ b/frontend/src/features/domain-pack-draft-create/model/useCreateDraft.test.tsx
@@ -52,9 +52,7 @@ describe("useCreateDraft", () => {
     vi.mocked(createDraftApi.create).mockResolvedValue(stubResponse as any);
     const { result } = renderHook(() => useCreateDraft(), { wrapper });
     result.current.mutate(mutateParams);
-    await waitFor(() =>
-      expect(toast.success).toHaveBeenCalledWith("새 DRAFT 버전이 생성되었습니다."),
-    );
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith("새 검토본이 생성되었습니다."));
   });
 
   it('403 에러 시 "접근 권한 없음" toast.error를 호출한다', async () => {
@@ -76,19 +74,19 @@ describe("useCreateDraft", () => {
     expect(toast.error).not.toHaveBeenCalled();
   });
 
-  it('400 에러 시 "DRAFT 생성에 실패했습니다." toast.error를 호출한다', async () => {
+  it('400 에러 시 "검토본 생성에 실패했습니다." toast.error를 호출한다', async () => {
     vi.mocked(createDraftApi.create).mockRejectedValue(
       new ApiRequestError(400, "BAD_REQUEST", "잘못된 요청"),
     );
     const { result } = renderHook(() => useCreateDraft(), { wrapper });
     result.current.mutate(mutateParams);
-    await waitFor(() => expect(toast.error).toHaveBeenCalledWith("DRAFT 생성에 실패했습니다."));
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith("검토본 생성에 실패했습니다."));
   });
 
-  it('비 ApiRequestError 에러 시 "DRAFT 생성에 실패했습니다." toast.error를 호출한다', async () => {
+  it('비 ApiRequestError 에러 시 "검토본 생성에 실패했습니다." toast.error를 호출한다', async () => {
     vi.mocked(createDraftApi.create).mockRejectedValue(new Error("network error"));
     const { result } = renderHook(() => useCreateDraft(), { wrapper });
     result.current.mutate(mutateParams);
-    await waitFor(() => expect(toast.error).toHaveBeenCalledWith("DRAFT 생성에 실패했습니다."));
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith("검토본 생성에 실패했습니다."));
   });
 });

--- a/frontend/src/features/domain-pack-draft-create/model/useCreateDraft.test.tsx
+++ b/frontend/src/features/domain-pack-draft-create/model/useCreateDraft.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { toast } from "sonner";
 import { ApiRequestError } from "@/shared/api";
 import { createDraftApi } from "../api/createDraftApi";
+import type { CreateDomainPackDraftResponse } from "../api/createDraftApi";
 import { useCreateDraft } from "./useCreateDraft";
 
 vi.mock("../api/createDraftApi", () => ({
@@ -25,19 +26,19 @@ function wrapper({ children }: { children: React.ReactNode }) {
   return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
 }
 
-const stubResponse = {
+const stubResponse: CreateDomainPackDraftResponse = {
   versionId: 10,
   domainPackId: 2,
   versionNo: 2,
-  lifecycleStatus: "DRAFT" as const,
-  sourcePipelineJobId: undefined as any,
+  lifecycleStatus: "DRAFT",
+  sourcePipelineJobId: undefined,
   intentCount: 0,
   slotCount: 0,
   policyCount: 0,
   riskCount: 0,
   workflowCount: 0,
   createdAt: "",
-} as any;
+};
 
 const mutateParams = { wsId: 1, packId: 2, payload: {} };
 
@@ -49,7 +50,7 @@ describe("useCreateDraft", () => {
   });
 
   it("201 성공 시 toast.success를 호출한다", async () => {
-    vi.mocked(createDraftApi.create).mockResolvedValue(stubResponse as any);
+    vi.mocked(createDraftApi.create).mockResolvedValue(stubResponse);
     const { result } = renderHook(() => useCreateDraft(), { wrapper });
     result.current.mutate(mutateParams);
     await waitFor(() => expect(toast.success).toHaveBeenCalledWith("새 검토본이 생성되었습니다."));
@@ -64,14 +65,14 @@ describe("useCreateDraft", () => {
     await waitFor(() => expect(toast.error).toHaveBeenCalledWith("접근 권한 없음"));
   });
 
-  it("409 에러 시 toast를 호출하지 않는다", async () => {
+  it('409 에러 시 "검토본 생성에 실패했습니다." toast.error를 호출한다', async () => {
     vi.mocked(createDraftApi.create).mockRejectedValue(
       new ApiRequestError(409, "CONFLICT", "conflict"),
     );
     const { result } = renderHook(() => useCreateDraft(), { wrapper });
     result.current.mutate(mutateParams);
     await waitFor(() => expect(result.current.isError).toBe(true));
-    expect(toast.error).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledWith("검토본 생성에 실패했습니다.");
   });
 
   it('400 에러 시 "검토본 생성에 실패했습니다." toast.error를 호출한다', async () => {

--- a/frontend/src/features/domain-pack-draft-create/model/useCreateDraft.ts
+++ b/frontend/src/features/domain-pack-draft-create/model/useCreateDraft.ts
@@ -17,7 +17,7 @@ export function useCreateDraft() {
       createDraftApi.create(wsId, packId, payload as Parameters<typeof createDraftApi.create>[2]),
     onSuccess: (_data, { wsId, packId }) => {
       queryClient.invalidateQueries({ queryKey: domainPackQueryKeys.detail(wsId, packId) });
-      toast.success("새 DRAFT 버전이 생성되었습니다.");
+      toast.success("새 검토본이 생성되었습니다.");
     },
     onError: (error: unknown) => {
       if (error instanceof ApiRequestError) {
@@ -26,10 +26,10 @@ export function useCreateDraft() {
         } else if (error.status === 409) {
           // 409는 caller(모달)의 per-call onError에서 처리. toast 없음.
         } else {
-          toast.error("DRAFT 생성에 실패했습니다.");
+          toast.error("검토본 생성에 실패했습니다.");
         }
       } else {
-        toast.error("DRAFT 생성에 실패했습니다.");
+        toast.error("검토본 생성에 실패했습니다.");
       }
     },
   });

--- a/frontend/src/features/domain-pack-draft-create/model/useCreateDraft.ts
+++ b/frontend/src/features/domain-pack-draft-create/model/useCreateDraft.ts
@@ -24,7 +24,7 @@ export function useCreateDraft() {
         if (error.status === 403) {
           toast.error("접근 권한 없음");
         } else if (error.status === 409) {
-          // 409는 caller(모달)의 per-call onError에서 처리. toast 없음.
+          toast.error("검토본 생성에 실패했습니다.");
         } else {
           toast.error("검토본 생성에 실패했습니다.");
         }

--- a/frontend/src/features/domain-pack-draft-create/ui/CreateDraftModal.test.tsx
+++ b/frontend/src/features/domain-pack-draft-create/ui/CreateDraftModal.test.tsx
@@ -50,7 +50,7 @@ describe("CreateDraftModal", () => {
 
   it("모달 제목과 textarea를 렌더링한다", () => {
     renderModal();
-    expect(screen.getByText("새 DRAFT 묶기")).toBeInTheDocument();
+    expect(screen.getByText("새 검토본 묶기")).toBeInTheDocument();
     expect(screen.getByRole("textbox")).toBeInTheDocument();
   });
 
@@ -75,7 +75,7 @@ describe("CreateDraftModal", () => {
     expect(screen.getByRole("alert")).toHaveTextContent("유효하지 않은 JSON입니다");
   });
 
-  it('409 에러 응답 시 인라인 에러 "동일 Pack 묶기 충돌"을 표시한다', async () => {
+  it("409 에러 응답 시 도메인팩 초안 충돌 안내를 표시한다", async () => {
     const mutate = vi.fn((_params: unknown, callbacks: { onError: (e: unknown) => void }) => {
       callbacks.onError(new ApiRequestError(409, "CONFLICT", "conflict"));
     });
@@ -83,7 +83,11 @@ describe("CreateDraftModal", () => {
     renderModal();
     fireEvent.change(screen.getByRole("textbox"), { target: { value: "{}" } });
     fireEvent.click(screen.getByRole("button", { name: "묶기" }));
-    await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent("동일 Pack 묶기 충돌"));
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "동일한 도메인팩 초안이 이미 있습니다. 잠시 후 다시 시도하세요.",
+      ),
+    );
   });
 
   it('400 에러 응답 시 인라인 에러 "요청 검증 실패"를 표시한다', async () => {

--- a/frontend/src/features/domain-pack-draft-create/ui/CreateDraftModal.tsx
+++ b/frontend/src/features/domain-pack-draft-create/ui/CreateDraftModal.tsx
@@ -61,7 +61,7 @@ export function CreateDraftModal({ wsId, packId, onClose, onSuccess }: CreateDra
         onError: (error: unknown) => {
           if (error instanceof ApiRequestError) {
             if (error.status === 409) {
-              setInlineError("동일 Pack 묶기 충돌. 잠시 후 재시도하세요.");
+              setInlineError("동일한 도메인팩 초안이 이미 있습니다. 잠시 후 다시 시도하세요.");
             } else if (error.status === 400) {
               setInlineError(error.message || "요청 검증 실패. 입력을 확인해 주세요.");
             } else {
@@ -99,7 +99,7 @@ export function CreateDraftModal({ wsId, packId, onClose, onSuccess }: CreateDra
       >
         <div className={styles.header}>
           <span id="create-draft-title" className={styles.title}>
-            새 DRAFT 묶기
+            새 검토본 묶기
           </span>
           <button type="button" className={styles.closeBtn} onClick={onClose} aria-label="닫기">
             ✕
@@ -124,7 +124,7 @@ export function CreateDraftModal({ wsId, packId, onClose, onSuccess }: CreateDra
             onClick={() => setActiveTab("pipeline")}
             title="파이프라인 import 기능 준비 중"
           >
-            파이프라인 import
+            파이프라인 가져오기
           </button>
         </div>
 

--- a/frontend/src/features/domain-pack-summary-read/model/buildDomainPackApprovalReadiness.test.ts
+++ b/frontend/src/features/domain-pack-summary-read/model/buildDomainPackApprovalReadiness.test.ts
@@ -31,7 +31,7 @@ describe("buildDomainPackApprovalReadiness", () => {
     expect(result.blockers).toEqual([
       {
         type: "VERSION",
-        message: "DRAFT 상태의 버전만 승인할 수 있습니다.",
+        message: "검토 중인 버전만 승인할 수 있습니다.",
       },
     ]);
   });

--- a/frontend/src/features/domain-pack-summary-read/model/buildDomainPackApprovalReadiness.ts
+++ b/frontend/src/features/domain-pack-summary-read/model/buildDomainPackApprovalReadiness.ts
@@ -53,7 +53,7 @@ export function buildDomainPackApprovalReadiness({
       blockers: [
         {
           type: "VERSION",
-          message: "DRAFT 상태의 버전만 승인할 수 있습니다.",
+          message: "검토 중인 버전만 승인할 수 있습니다.",
         },
       ],
     };

--- a/frontend/src/features/domain-pack-summary-read/model/resolveDomainPackApprovalErrorMessage.test.ts
+++ b/frontend/src/features/domain-pack-summary-read/model/resolveDomainPackApprovalErrorMessage.test.ts
@@ -11,11 +11,11 @@ describe("resolveDomainPackApprovalErrorMessage", () => {
       "DOMAIN_PACK_CONFLICT",
       "다른 요청으로 버전 상태가 변경되었습니다. 새로고침 후 다시 시도해 주세요.",
     ],
-    ["FORBIDDEN", "Domain Pack을 승인할 권한이 없습니다."],
-    ["DOMAIN_PACK_VERSION_NOT_FOUND", "Domain Pack 버전을 찾을 수 없습니다."],
-    ["DOMAIN_PACK_NOT_FOUND", "Domain Pack을 찾을 수 없습니다."],
+    ["FORBIDDEN", "도메인팩을 승인할 권한이 없습니다."],
+    ["DOMAIN_PACK_VERSION_NOT_FOUND", "도메인팩 버전을 찾을 수 없습니다."],
+    ["DOMAIN_PACK_NOT_FOUND", "도메인팩을 찾을 수 없습니다."],
     ["WORKSPACE_NOT_FOUND", "워크스페이스를 찾을 수 없습니다."],
-    ["NOT_FOUND", "Domain Pack 또는 버전을 찾을 수 없습니다."],
+    ["NOT_FOUND", "도메인팩 또는 버전을 찾을 수 없습니다."],
     ["UNAUTHORIZED", "로그인이 필요합니다."],
   ])("error code %s에 맞는 메시지를 반환한다", (code, message) => {
     expect(resolveDomainPackApprovalErrorMessage(new ApiRequestError(400, code, "fail"))).toBe(
@@ -26,12 +26,12 @@ describe("resolveDomainPackApprovalErrorMessage", () => {
   it("error code가 없어도 HTTP 404면 not found fallback을 반환한다", () => {
     expect(
       resolveDomainPackApprovalErrorMessage(new ApiRequestError(404, "UNKNOWN_ERROR", "fail")),
-    ).toBe("Domain Pack 또는 버전을 찾을 수 없습니다.");
+    ).toBe("도메인팩 또는 버전을 찾을 수 없습니다.");
   });
 
   it("알 수 없는 에러면 기본 실패 메시지를 반환한다", () => {
     expect(resolveDomainPackApprovalErrorMessage(new Error("fail"))).toBe(
-      "Domain Pack 승인에 실패했습니다.",
+      "도메인팩 승인에 실패했습니다.",
     );
   });
 });

--- a/frontend/src/features/domain-pack-summary-read/model/resolveDomainPackApprovalErrorMessage.ts
+++ b/frontend/src/features/domain-pack-summary-read/model/resolveDomainPackApprovalErrorMessage.ts
@@ -4,11 +4,11 @@ const ERROR_MESSAGE_BY_CODE: Record<string, string> = {
   DOMAIN_PACK_VERSION_NOT_LATEST: "최신 버전만 승인할 수 있습니다.",
   DOMAIN_PACK_INVALID_STATE: "현재 상태에서는 승인할 수 없습니다.",
   DOMAIN_PACK_CONFLICT: "다른 요청으로 버전 상태가 변경되었습니다. 새로고침 후 다시 시도해 주세요.",
-  FORBIDDEN: "Domain Pack을 승인할 권한이 없습니다.",
-  DOMAIN_PACK_VERSION_NOT_FOUND: "Domain Pack 버전을 찾을 수 없습니다.",
-  DOMAIN_PACK_NOT_FOUND: "Domain Pack을 찾을 수 없습니다.",
+  FORBIDDEN: "도메인팩을 승인할 권한이 없습니다.",
+  DOMAIN_PACK_VERSION_NOT_FOUND: "도메인팩 버전을 찾을 수 없습니다.",
+  DOMAIN_PACK_NOT_FOUND: "도메인팩을 찾을 수 없습니다.",
   WORKSPACE_NOT_FOUND: "워크스페이스를 찾을 수 없습니다.",
-  NOT_FOUND: "Domain Pack 또는 버전을 찾을 수 없습니다.",
+  NOT_FOUND: "도메인팩 또는 버전을 찾을 수 없습니다.",
   UNAUTHORIZED: "로그인이 필요합니다.",
 };
 
@@ -18,9 +18,9 @@ export function resolveDomainPackApprovalErrorMessage(error: unknown): string {
     if (message) return message;
 
     if (error.status === 404) {
-      return "Domain Pack 또는 버전을 찾을 수 없습니다.";
+      return "도메인팩 또는 버전을 찾을 수 없습니다.";
     }
   }
 
-  return "Domain Pack 승인에 실패했습니다.";
+  return "도메인팩 승인에 실패했습니다.";
 }

--- a/frontend/src/features/domain-pack-summary-read/ui/ComponentCountGrid.generated-api.test.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/ComponentCountGrid.generated-api.test.tsx
@@ -132,10 +132,10 @@ describe("ComponentCountGrid generated API integration", () => {
     );
   });
 
-  it("generated slot preview가 있으면 Slot 카드에서 편집 sheet를 연다", () => {
+  it("generated slot preview가 있으면 확인 항목 카드에서 편집 sheet를 연다", () => {
     renderGrid();
 
-    fireEvent.click(screen.getByRole("button", { name: /Slot/ }));
+    fireEvent.click(screen.getByRole("button", { name: /확인 항목/ }));
 
     expect(screen.getByRole("dialog")).toHaveTextContent("slot edit 11");
   });

--- a/frontend/src/features/domain-pack-summary-read/ui/ComponentCountGrid.test.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/ComponentCountGrid.test.tsx
@@ -37,7 +37,7 @@ const defaultProps = {
 };
 
 function renderSlotEditSheet(_slotId: number, isOpen: boolean) {
-  return isOpen ? <div role="dialog">슬롯 수정</div> : null;
+  return isOpen ? <div role="dialog">확인 항목 수정</div> : null;
 }
 
 describe("ComponentCountGrid", () => {
@@ -52,18 +52,18 @@ describe("ComponentCountGrid", () => {
 
   it("카드 레이블과 카운트를 렌더링한다", () => {
     render(<ComponentCountGrid {...defaultProps} renderSlotEditSheet={renderSlotEditSheet} />);
-    expect(screen.getByText("Intent")).toBeInTheDocument();
+    expect(screen.getByText("상담 유형")).toBeInTheDocument();
     expect(screen.getByText("2")).toBeInTheDocument();
-    expect(screen.getByText("Workflow")).toBeInTheDocument();
+    expect(screen.getByText("응대 흐름")).toBeInTheDocument();
     expect(screen.getByText("4")).toBeInTheDocument();
   });
 
   it("Intent, Policy 카드 클릭 시 상세 목록으로 이동한다", () => {
     render(<ComponentCountGrid {...defaultProps} renderSlotEditSheet={renderSlotEditSheet} />);
-    fireEvent.click(screen.getByRole("button", { name: /Intent/ }));
+    fireEvent.click(screen.getByRole("button", { name: /상담 유형/ }));
     expect(mockNavigate).toHaveBeenCalledWith("/workspaces/1/domain-packs/2/intents?versionId=3");
 
-    fireEvent.click(screen.getByRole("button", { name: /Policy/ }));
+    fireEvent.click(screen.getByRole("button", { name: /응대 기준/ }));
     expect(mockNavigate).toHaveBeenCalledWith("/workspaces/1/domain-packs/2/policies?versionId=3");
   });
 
@@ -72,8 +72,8 @@ describe("ComponentCountGrid", () => {
       makeHook({ data: [{ id: 9, name: "slot-1" }] }),
     );
     render(<ComponentCountGrid {...defaultProps} renderSlotEditSheet={renderSlotEditSheet} />);
-    fireEvent.click(screen.getByRole("button", { name: /Slot/ }));
-    expect(screen.getByRole("dialog")).toHaveTextContent("슬롯 수정");
+    fireEvent.click(screen.getByRole("button", { name: /확인 항목/ }));
+    expect(screen.getByRole("dialog")).toHaveTextContent("확인 항목 수정");
   });
 
   it("로딩 중일 때 스켈레톤을 렌더링한다", () => {
@@ -85,19 +85,25 @@ describe("ComponentCountGrid", () => {
   it("intent isError 시 toast.error를 호출한다", async () => {
     vi.mocked(previewLists.useIntentPreview).mockReturnValue(makeHook({ isError: true }));
     render(<ComponentCountGrid {...defaultProps} />);
-    await waitFor(() => expect(toast.error).toHaveBeenCalledWith("Intent 미리보기 로드 실패"));
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith("상담 유형 미리보기를 불러오지 못했습니다."),
+    );
   });
 
   it("slot isError 시 toast.error를 호출한다", async () => {
     vi.mocked(previewLists.useSlotPreview).mockReturnValue(makeHook({ isError: true }));
     render(<ComponentCountGrid {...defaultProps} />);
-    await waitFor(() => expect(toast.error).toHaveBeenCalledWith("Slot 미리보기 로드 실패"));
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith("확인 항목 미리보기를 불러오지 못했습니다."),
+    );
   });
 
   it("workflow isError 시 toast.error를 호출한다", async () => {
     vi.mocked(previewLists.useWorkflowPreview).mockReturnValue(makeHook({ isError: true }));
     render(<ComponentCountGrid {...defaultProps} />);
-    await waitFor(() => expect(toast.error).toHaveBeenCalledWith("Workflow 미리보기 로드 실패"));
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith("응대 흐름 미리보기를 불러오지 못했습니다."),
+    );
   });
 
   it("workflow previewItems가 있으면 이름 목록을 렌더링한다", () => {

--- a/frontend/src/features/domain-pack-summary-read/ui/ComponentCountGrid.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/ComponentCountGrid.tsx
@@ -41,19 +41,19 @@ export function ComponentCountGrid({
   const workflowPreview = useWorkflowPreview(wsId, packId, versionId);
 
   useEffect(() => {
-    if (intentPreview.isError) toast.error("Intent 미리보기 로드 실패");
+    if (intentPreview.isError) toast.error("상담 유형 미리보기를 불러오지 못했습니다.");
   }, [intentPreview.isError]);
 
   useEffect(() => {
-    if (slotPreview.isError) toast.error("Slot 미리보기 로드 실패");
+    if (slotPreview.isError) toast.error("확인 항목 미리보기를 불러오지 못했습니다.");
   }, [slotPreview.isError]);
 
   useEffect(() => {
-    if (policyPreview.isError) toast.error("Policy 미리보기 로드 실패");
+    if (policyPreview.isError) toast.error("응대 기준 미리보기를 불러오지 못했습니다.");
   }, [policyPreview.isError]);
 
   useEffect(() => {
-    if (workflowPreview.isError) toast.error("Workflow 미리보기 로드 실패");
+    if (workflowPreview.isError) toast.error("응대 흐름 미리보기를 불러오지 못했습니다.");
   }, [workflowPreview.isError]);
 
   const firstSlotId = slotPreview.data?.[0]?.id;
@@ -62,7 +62,7 @@ export function ComponentCountGrid({
     <>
       <div className={styles.grid}>
         <CountCard
-          label="Intent"
+          label="상담 유형"
           count={intentCount}
           disabled={false}
           onNavigate={() => navigate(domainPackSectionPath(wsId, packId, versionId, "intents"))}
@@ -70,16 +70,16 @@ export function ComponentCountGrid({
           isLoadingPreview={intentPreview.isLoading}
         />
         <CountCard
-          label="Slot"
+          label="확인 항목"
           count={slotCount}
           disabled={firstSlotId === undefined}
-          tooltip="수정할 Slot이 없습니다"
+          tooltip="수정할 확인 항목이 없습니다"
           onNavigate={() => setSlotEditOpen(true)}
           previewNames={slotPreview.data?.map((s) => s.name) as string[]}
           isLoadingPreview={slotPreview.isLoading}
         />
         <CountCard
-          label="Policy"
+          label="응대 기준"
           count={policyCount}
           disabled={false}
           onNavigate={() => navigate(domainPackSectionPath(wsId, packId, versionId, "policies"))}
@@ -87,7 +87,7 @@ export function ComponentCountGrid({
           isLoadingPreview={policyPreview.isLoading}
         />
         <CountCard
-          label="Workflow"
+          label="응대 흐름"
           count={workflowCount}
           disabled={false}
           onNavigate={() => navigate(domainPackSectionPath(wsId, packId, versionId, "workflows"))}

--- a/frontend/src/features/domain-pack-summary-read/ui/DomainPackApprovalDialog.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/DomainPackApprovalDialog.tsx
@@ -31,7 +31,7 @@ export function DomainPackApprovalDialog({
     >
       <AlertDialogContent size="sm" className={styles.approvalDialogContent}>
         <AlertDialogTitle className={styles.approvalDialogTitle}>
-          Domain Pack 버전을 승인할까요?
+          도메인팩 버전을 승인할까요?
         </AlertDialogTitle>
         <AlertDialogDescription className={styles.approvalDialogDescription}>
           승인하면 이 버전은 운영에 사용되며, 이후 구성요소를 수정할 수 없습니다.

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.test.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.test.tsx
@@ -133,7 +133,7 @@ describe("SummaryDetailPanel", () => {
     );
 
     expect(screen.getByText("v1")).toBeInTheDocument();
-    expect(screen.getByText("DRAFT")).toBeInTheDocument();
+    expect(screen.getByText("검토 중")).toBeInTheDocument();
     expect(screen.getByTestId("summary-json-card")).toHaveTextContent('{"key":"val"}');
     expect(screen.getByTestId("component-count-grid")).toBeInTheDocument();
     expect(screen.queryByText("승인 준비 상태")).not.toBeInTheDocument();
@@ -296,9 +296,9 @@ describe("SummaryDetailPanel", () => {
     );
 
     fireEvent.click(screen.getByRole("button", { name: "삭제" }));
-    expect(screen.getByText("Draft 버전을 삭제할까요?")).toBeInTheDocument();
+    expect(screen.getByText("검토 중인 버전을 삭제할까요?")).toBeInTheDocument();
     expect(
-      screen.getByText("삭제하면 이 Draft 버전과 저장된 수정 내용이 모두 삭제됩니다."),
+      screen.getByText("삭제하면 이 검토 중인 버전과 저장된 수정 내용이 모두 삭제됩니다."),
     ).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "삭제하기" }));
 

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.test.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.test.tsx
@@ -139,6 +139,25 @@ describe("SummaryDetailPanel", () => {
     expect(screen.queryByText("승인 준비 상태")).not.toBeInTheDocument();
   });
 
+  it("상태가 없는 버전도 상담사 용어로 표시한다", () => {
+    renderSummaryDetailPanel(
+      <SummaryDetailPanel
+        query={makeQuery({
+          data: {
+            ...stubDetail,
+            lifecycleStatus: null,
+            createdAt: "날짜 확인 전",
+          },
+        })}
+        wsId={1}
+        packId={2}
+      />,
+    );
+
+    expect(screen.getByText("상태 없음")).toBeInTheDocument();
+    expect(screen.getByText("날짜 확인 전")).toBeInTheDocument();
+  });
+
   it("상세 메타 카드의 배포 버튼 클릭 시 확인 다이얼로그를 먼저 표시한다", () => {
     const onDeploy = vi.fn();
 

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.tsx
@@ -122,7 +122,7 @@ export function SummaryDetailPanel({
                   v.lifecycleStatus === "PUBLISHED" ? styles.badgePublished : ""
                 }`}
               >
-                {v.lifecycleStatus}
+                {formatLifecycleStatus(v.lifecycleStatus)}
               </span>
               {isCurrentVersion && (
                 <span className={`${styles.badge} ${styles.badgeOperating}`}>배포중</span>
@@ -188,7 +188,7 @@ export function SummaryDetailPanel({
             이 버전을 배포할까요?
           </AlertDialogTitle>
           <AlertDialogDescription className={styles.approvalDialogDescription}>
-            배포하면 현재 운영 중인 Domain Pack 버전이 선택한 버전으로 전환됩니다.
+            배포하면 현재 운영 중인 도메인팩 버전이 선택한 버전으로 전환됩니다.
           </AlertDialogDescription>
           <AlertDialogFooter className={styles.approvalDialogFooter}>
             <Button
@@ -227,10 +227,10 @@ export function SummaryDetailPanel({
       >
         <AlertDialogContent size="sm" className={styles.approvalDialogContent}>
           <AlertDialogTitle className={styles.approvalDialogTitle}>
-            Draft 버전을 적용할까요?
+            검토 중인 버전을 적용할까요?
           </AlertDialogTitle>
           <AlertDialogDescription className={styles.approvalDialogDescription}>
-            적용하면 이 Draft가 운영 가능한 Published 버전으로 전환됩니다.
+            적용하면 이 버전이 상담 응대에 사용할 수 있는 운영 버전으로 전환됩니다.
           </AlertDialogDescription>
           <AlertDialogFooter className={styles.approvalDialogFooter}>
             <Button
@@ -269,10 +269,10 @@ export function SummaryDetailPanel({
       >
         <AlertDialogContent size="sm" className={styles.approvalDialogContent}>
           <AlertDialogTitle className={styles.approvalDialogTitle}>
-            Draft 버전을 삭제할까요?
+            검토 중인 버전을 삭제할까요?
           </AlertDialogTitle>
           <AlertDialogDescription className={styles.approvalDialogDescription}>
-            삭제하면 이 Draft 버전과 저장된 수정 내용이 모두 삭제됩니다.
+            삭제하면 이 검토 중인 버전과 저장된 수정 내용이 모두 삭제됩니다.
           </AlertDialogDescription>
           <AlertDialogFooter className={styles.approvalDialogFooter}>
             <Button
@@ -328,4 +328,10 @@ function formatDate(iso: string): string {
   const d = new Date(iso);
   if (Number.isNaN(d.getTime())) return iso;
   return d.toLocaleString("ko-KR");
+}
+
+function formatLifecycleStatus(status?: string | null): string {
+  if (status === "PUBLISHED") return "운영 가능";
+  if (status === "DRAFT") return "검토 중";
+  return status ?? "상태 없음";
 }

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryJsonCard.test.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryJsonCard.test.tsx
@@ -22,7 +22,7 @@ describe("SummaryJsonCard", () => {
     expect(screen.getByText("82%")).toBeInTheDocument();
     expect(screen.getByText("이탈률")).toBeInTheDocument();
     expect(screen.getByText("7%")).toBeInTheDocument();
-    expect(screen.getByText("워크플로우 분리도")).toBeInTheDocument();
+    expect(screen.getByText("응대 흐름 분리도")).toBeInTheDocument();
     expect(screen.getByText("76%")).toBeInTheDocument();
     expect(screen.getByText("검토 포인트")).toBeInTheDocument();
     expect(screen.getByText("워크플로우 미매핑")).toBeInTheDocument();

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryJsonCard.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryJsonCard.tsx
@@ -92,7 +92,7 @@ function buildSummary(data: SummaryData) {
       value: formatRate(firstValue(data, [["quality", "outlierRate"], ["outlierRate"]])) ?? "",
     },
     {
-      label: "워크플로우 분리도",
+      label: "응대 흐름 분리도",
       value:
         formatRate(
           firstValue(data, [["quality", "workflowSeparability"], ["workflowSeparability"]]),

--- a/frontend/src/features/domain-pack-summary-read/ui/VersionListPanel.test.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/VersionListPanel.test.tsx
@@ -160,10 +160,12 @@ describe("VersionListPanel", () => {
             ...stubPack,
             versions: [
               { ...stubVersion, lifecycleStatus: "PUBLISHED", createdAt: "날짜 확인 전" },
+              { ...stubVersion2, versionNo: null, lifecycleStatus: null, createdAt: "날짜 확인 전" },
               {
                 ...stubVersion2,
-                versionNo: null,
-                lifecycleStatus: null,
+                versionId: 3,
+                versionNo: 3,
+                lifecycleStatus: "ARCHIVED" as never,
                 createdAt: "날짜 확인 전",
               },
             ],
@@ -178,6 +180,8 @@ describe("VersionListPanel", () => {
     expect(screen.getByRole("button", { name: /v1/ })).toHaveTextContent("운영 가능");
     expect(screen.getByRole("button", { name: /v1/ })).toHaveTextContent("배포중");
     expect(screen.getByRole("button", { name: /v-/ })).toHaveTextContent("상태 없음");
-    expect(screen.getAllByText("날짜 확인 전")).toHaveLength(2);
+    expect(screen.getByRole("button", { name: /v3/ })).toHaveTextContent("상태 없음");
+    expect(screen.getByRole("button", { name: /v3/ })).not.toHaveTextContent("ARCHIVED");
+    expect(screen.getAllByText("날짜 확인 전")).toHaveLength(3);
   });
 });

--- a/frontend/src/features/domain-pack-summary-read/ui/VersionListPanel.test.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/VersionListPanel.test.tsx
@@ -151,4 +151,33 @@ describe("VersionListPanel", () => {
 
     expect(screen.getByRole("button", { name: /v1/ })).toHaveTextContent("배포중");
   });
+
+  it("운영 가능 버전과 상태가 없는 버전을 상담사 용어로 표시한다", () => {
+    render(
+      <VersionListPanel
+        query={makeQuery({
+          data: {
+            ...stubPack,
+            versions: [
+              { ...stubVersion, lifecycleStatus: "PUBLISHED", createdAt: "날짜 확인 전" },
+              {
+                ...stubVersion2,
+                versionNo: null,
+                lifecycleStatus: null,
+                createdAt: "날짜 확인 전",
+              },
+            ],
+          },
+        })}
+        selectedId={2}
+        currentVersionId={1}
+        onSelect={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /v1/ })).toHaveTextContent("운영 가능");
+    expect(screen.getByRole("button", { name: /v1/ })).toHaveTextContent("배포중");
+    expect(screen.getByRole("button", { name: /v-/ })).toHaveTextContent("상태 없음");
+    expect(screen.getAllByText("날짜 확인 전")).toHaveLength(2);
+  });
 });

--- a/frontend/src/features/domain-pack-summary-read/ui/VersionListPanel.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/VersionListPanel.tsx
@@ -130,5 +130,5 @@ function VersionListItem({
 function formatLifecycleStatus(status?: string | null): string {
   if (status === "PUBLISHED") return "운영 가능";
   if (status === "DRAFT") return "검토 중";
-  return status ?? "상태 없음";
+  return "상태 없음";
 }

--- a/frontend/src/features/domain-pack-summary-read/ui/VersionListPanel.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/VersionListPanel.tsx
@@ -115,7 +115,7 @@ function VersionListItem({
           <span
             className={`${styles.badge} ${isPublished ? styles.badgePublished : styles.badgeDraft}`}
           >
-            {version.lifecycleStatus}
+            {formatLifecycleStatus(version.lifecycleStatus)}
           </span>
           {isCurrentVersion && (
             <span className={`${styles.badge} ${styles.badgeOperating}`}>배포중</span>
@@ -125,4 +125,10 @@ function VersionListItem({
       </button>
     </li>
   );
+}
+
+function formatLifecycleStatus(status?: string | null): string {
+  if (status === "PUBLISHED") return "운영 가능";
+  if (status === "DRAFT") return "검토 중";
+  return status ?? "상태 없음";
 }

--- a/frontend/src/features/intent-draft-read/ui/IntentDetailPanel.test.tsx
+++ b/frontend/src/features/intent-draft-read/ui/IntentDetailPanel.test.tsx
@@ -116,7 +116,7 @@ describe("IntentDetailPanel", () => {
       ]),
     });
 
-    expect(screen.getByText("Parent Intent")).toBeInTheDocument();
+    expect(screen.getByText("상위 상담 유형")).toBeInTheDocument();
     expect(screen.getByText("주문 상태 문의")).toBeInTheDocument();
     expect(screen.queryByText("20")).not.toBeInTheDocument();
   });

--- a/frontend/src/features/intent-draft-read/ui/IntentDetailPanel.tsx
+++ b/frontend/src/features/intent-draft-read/ui/IntentDetailPanel.tsx
@@ -50,7 +50,7 @@ export function IntentDetailPanel({
     if (state.status !== "error") return;
     const message =
       errorHttpStatus === 404
-        ? "intent를 찾을 수 없습니다."
+        ? "상담 유형을 찾을 수 없습니다."
         : errorMessage || "상세 정보를 불러오지 못했습니다.";
 
     toast.error(message, {
@@ -60,9 +60,9 @@ export function IntentDetailPanel({
 
   if (state.status === "idle") {
     return (
-      <section className={styles.panel} aria-label="intent 상세">
+      <section className={styles.panel} aria-label="상담 유형 상세">
         <div className={styles.placeholder}>
-          <span>좌측 목록에서 intent를 선택해 주세요.</span>
+          <span>좌측 목록에서 상담 유형을 선택해 주세요.</span>
         </div>
       </section>
     );
@@ -70,7 +70,7 @@ export function IntentDetailPanel({
 
   if (state.status === "loading") {
     return (
-      <section className={styles.panel} aria-label="intent 상세">
+      <section className={styles.panel} aria-label="상담 유형 상세">
         <div className={styles.body}>
           <div className={styles.skeleton} />
         </div>
@@ -80,7 +80,7 @@ export function IntentDetailPanel({
 
   if (state.status === "error") {
     return (
-      <section className={styles.panel} aria-label="intent 상세">
+      <section className={styles.panel} aria-label="상담 유형 상세">
         <div className={styles.placeholder}>
           <span>상세 정보를 불러오지 못했습니다.</span>
           <span className={styles.errorCode}>{errorCode}</span>
@@ -90,25 +90,25 @@ export function IntentDetailPanel({
   }
 
   return (
-    <section className={styles.panel} aria-label="intent 상세">
+    <section className={styles.panel} aria-label="상담 유형 상세">
       <DetailHeader detail={state.data} actions={headerActions?.(state.data)} />
       {afterHeader?.(state.data)}
       <div className={styles.body}>
         <div className={styles.grid}>
           <InfoCard
-            label="Status"
+            label="상태"
             value={<span className={styles.badge}>{state.data.status}</span>}
           />
           <InfoCard
-            label="Taxonomy Level"
+            label="분류 단계"
             value={<span className={styles.value}>LV {state.data.taxonomyLevel}</span>}
           />
           <InfoCard
-            label="Parent Intent"
+            label="상위 상담 유형"
             value={<span className={styles.value}>{parentIntentLabel}</span>}
           />
           <InfoCard
-            label="Created At"
+            label="생성일"
             value={<span className={styles.value}>{formatDate(state.data.createdAt ?? "")}</span>}
           />
         </div>
@@ -144,7 +144,7 @@ function DetailHeader({ detail, actions }: { detail: IntentDetail; actions?: Rea
       <div className={styles.headerText}>
         <span className={styles.name}>{detail.name ?? ""}</span>
         {detail.description && <span className={styles.description}>{detail.description}</span>}
-        <span className={styles.updatedAt}>UPDATED · {formatDate(detail.updatedAt ?? "")}</span>
+        <span className={styles.updatedAt}>수정일 · {formatDate(detail.updatedAt ?? "")}</span>
       </div>
     </header>
   );
@@ -342,28 +342,28 @@ function buildClusterScope(raw: string): ClusterScopeView {
 
   if (clusterId) {
     items.push({
-      label: "Cluster",
+      label: "묶음",
       value: `#${clusterId}`,
       icon: <HashIcon size={16} />,
     });
   }
   if (clusterSize) {
     items.push({
-      label: "Cases",
+      label: "상담 건수",
       value: `${clusterSize}건`,
       icon: <FileTextIcon size={16} />,
     });
   }
   if (canonicalIntent) {
     items.push({
-      label: "Intent",
+      label: "상담 유형",
       value: canonicalIntent,
       icon: <LayersIcon size={16} />,
     });
   }
   if (segmentIds.length > 0) {
     items.push({
-      label: "Segments",
+      label: "상담 조각",
       value: `${segmentIds.length}개`,
       icon: <GitBranchIcon size={16} />,
     });

--- a/frontend/src/features/intent-draft-read/ui/IntentTreePanel.test.tsx
+++ b/frontend/src/features/intent-draft-read/ui/IntentTreePanel.test.tsx
@@ -60,7 +60,7 @@ describe("IntentTreePanel", () => {
       },
     );
 
-    expect(screen.getByText("2 · TREE")).toBeInTheDocument();
+    expect(screen.getByText("2개")).toBeInTheDocument();
     expect(screen.getByText("수정 중")).toBeInTheDocument();
     const selectedRow = screen.getByRole("button", { name: /refund/ });
     expect(selectedRow).toHaveAttribute("aria-current", "true");
@@ -74,15 +74,15 @@ describe("IntentTreePanel", () => {
   it("loading 상태에서는 skeleton과 pending meta를 표시한다", () => {
     renderPanel({ status: "loading" });
 
-    expect(screen.getByText("— · TREE")).toBeInTheDocument();
+    expect(screen.getByText("—개")).toBeInTheDocument();
     expect(screen.queryByRole("button")).not.toBeInTheDocument();
   });
 
   it("ready 상태에서 intent가 없으면 empty state를 표시한다", () => {
     renderPanel({ status: "ready", data: [] });
 
-    expect(screen.getByText("0 · TREE")).toBeInTheDocument();
-    expect(screen.getByText("해당 버전에 등록된 intent 초안이 없습니다.")).toBeInTheDocument();
+    expect(screen.getByText("0개")).toBeInTheDocument();
+    expect(screen.getByText("해당 버전에 등록된 상담 유형 초안이 없습니다.")).toBeInTheDocument();
   });
 
   it("목록 조회 실패 시 toast와 error empty state를 보여준다", () => {

--- a/frontend/src/features/intent-draft-read/ui/IntentTreePanel.tsx
+++ b/frontend/src/features/intent-draft-read/ui/IntentTreePanel.tsx
@@ -31,11 +31,11 @@ export function IntentTreePanel({
   }, [state.status, errorMessage]);
 
   return (
-    <aside className={styles.panel} aria-label="intent 목록">
+    <aside className={styles.panel} aria-label="상담 유형 목록">
       <header className={styles.header}>
-        <span className={styles.headerTitle}>Intents</span>
+        <span className={styles.headerTitle}>상담 유형</span>
         <span className={styles.headerMeta}>
-          {state.status === "ready" ? `${state.data.length} · TREE` : "— · TREE"}
+          {state.status === "ready" ? `${state.data.length}개` : "—개"}
         </span>
       </header>
 
@@ -56,7 +56,7 @@ export function IntentTreePanel({
 
         {state.status === "ready" && state.data.length === 0 && (
           <div className={styles.emptyState}>
-            <span>해당 버전에 등록된 intent 초안이 없습니다.</span>
+            <span>해당 버전에 등록된 상담 유형 초안이 없습니다.</span>
           </div>
         )}
 

--- a/frontend/src/features/intent-draft-read/ui/MatchedWorkflowSection.test.tsx
+++ b/frontend/src/features/intent-draft-read/ui/MatchedWorkflowSection.test.tsx
@@ -75,7 +75,7 @@ describe("MatchedWorkflowSection", () => {
           versionId: 4,
           workflowId: 7,
           workflowCode: "wf.x",
-          name: "워크플로우",
+          name: "응대 흐름",
           description: "d",
           intentDefinitionId: 100,
         },
@@ -93,13 +93,13 @@ describe("MatchedWorkflowSection", () => {
     );
   });
 
-  it("count 가 loading 인 동안 loading 텍스트 노출", () => {
+  it("count 가 loading 인 동안 확인 중 텍스트 노출", () => {
     mockedHook.mockReturnValue({ loading: true, error: null, entries: [] });
     renderSection();
-    expect(screen.getByText(/loading/)).toBeInTheDocument();
+    expect(screen.getByText(/확인 중/)).toBeInTheDocument();
   });
 
-  it("count 가 ITEMS 형식으로 노출", () => {
+  it("count 가 개수 형식으로 노출", () => {
     mockedHook.mockReturnValue({
       loading: false,
       error: null,
@@ -117,6 +117,6 @@ describe("MatchedWorkflowSection", () => {
       ],
     });
     renderSection();
-    expect(screen.getByText("1 ITEMS")).toBeInTheDocument();
+    expect(screen.getByText("1개")).toBeInTheDocument();
   });
 });

--- a/frontend/src/features/intent-draft-read/ui/MatchedWorkflowSection.tsx
+++ b/frontend/src/features/intent-draft-read/ui/MatchedWorkflowSection.tsx
@@ -52,14 +52,14 @@ export function MatchedWorkflowSection({
     >
       <header className={styles.header}>
         <h2 id="matched-workflow-section-title" className={styles.title}>
-          매칭된 워크플로우
+          연결된 응대 흐름
         </h2>
-        <Mono className={styles.count}>{loading ? "loading…" : `${entries.length} ITEMS`}</Mono>
+        <Mono className={styles.count}>{loading ? "확인 중…" : `${entries.length}개`}</Mono>
       </header>
 
       {loading && (
         <div className={styles.placeholder} data-testid="matched-workflow-section-loading">
-          <Mono>워크플로우 조회 중…</Mono>
+          <Mono>응대 흐름을 불러오는 중…</Mono>
         </div>
       )}
 
@@ -71,7 +71,7 @@ export function MatchedWorkflowSection({
 
       {!loading && !error && entries.length === 0 && (
         <div className={styles.placeholder} data-testid="matched-workflow-section-empty">
-          <Mono>이 인텐트에 매칭된 워크플로우가 없습니다.</Mono>
+          <Mono>이 상담 유형에 연결된 응대 흐름이 없습니다.</Mono>
         </div>
       )}
 

--- a/frontend/src/features/intent-revision-draft/api/intentRevisionDraftApi.ts
+++ b/frontend/src/features/intent-revision-draft/api/intentRevisionDraftApi.ts
@@ -50,7 +50,7 @@ function normalizeDraftVersionId(response: RevisionDraftResponse): number {
   }
 
   if (typeof id !== "number") {
-    throw new Error("Intent 수정 초안 version id를 확인할 수 없습니다.");
+    throw new Error("상담 유형 수정 초안 버전 ID를 확인할 수 없습니다.");
   }
 
   return id;
@@ -85,7 +85,7 @@ export const intentRevisionDraftApi = {
     body: UpdateDraftIntentBody,
   ): Promise<IntentDetail> {
     const response = await update(workspaceId, packId, draftVersionId, intentId, body);
-    return requireApiData<IntentDetail>(response, "Intent 수정 응답을 확인할 수 없습니다.");
+    return requireApiData<IntentDetail>(response, "상담 유형 수정 응답을 확인할 수 없습니다.");
   },
 
   async activateVersion(
@@ -119,7 +119,7 @@ export const intentRevisionDraftApi = {
     intentId: number,
   ): Promise<IntentDetail> {
     const response = await getIntent(workspaceId, packId, versionId, intentId);
-    return requireApiData<IntentDetail>(response, "Intent 상세 응답을 확인할 수 없습니다.");
+    return requireApiData<IntentDetail>(response, "상담 유형 상세 응답을 확인할 수 없습니다.");
   },
 
   async getVersionDetail(

--- a/frontend/src/features/intent-revision-draft/model/useIntentRevisionSummary.ts
+++ b/frontend/src/features/intent-revision-draft/model/useIntentRevisionSummary.ts
@@ -145,7 +145,9 @@ export function useIntentRevisionSummary({
           value: {
             status: "error",
             message:
-              error instanceof Error ? error.message : "Intent 수정 요약을 불러오지 못했습니다.",
+              error instanceof Error
+                ? error.message
+                : "상담 유형 수정 요약을 불러오지 못했습니다.",
           },
         });
       });

--- a/frontend/src/features/intent-revision-draft/ui/IntentRevisionDiffPanel.test.tsx
+++ b/frontend/src/features/intent-revision-draft/ui/IntentRevisionDiffPanel.test.tsx
@@ -16,8 +16,8 @@ describe("IntentRevisionDiffPanel", () => {
   it("변경된 필드의 before/after 값을 보여준다", () => {
     render(<IntentRevisionDiffPanel change={change} />);
 
-    expect(screen.getByLabelText("Intent 수정 diff")).toBeInTheDocument();
-    expect(screen.getByText("2 fields")).toBeInTheDocument();
+    expect(screen.getByLabelText("상담 유형 수정 내용")).toBeInTheDocument();
+    expect(screen.getByText("2개 항목")).toBeInTheDocument();
     expect(screen.getByText("환불")).toBeInTheDocument();
     expect(screen.getByText("환불 문의")).toBeInTheDocument();
     expect(screen.getByText("비어 있음")).toBeInTheDocument();

--- a/frontend/src/features/intent-revision-draft/ui/IntentRevisionDiffPanel.tsx
+++ b/frontend/src/features/intent-revision-draft/ui/IntentRevisionDiffPanel.tsx
@@ -9,18 +9,18 @@ export function IntentRevisionDiffPanel({ change }: IntentRevisionDiffPanelProps
   if (!change) return null;
 
   return (
-    <section className={styles.diffPanel} aria-label="Intent 수정 diff">
+    <section className={styles.diffPanel} aria-label="상담 유형 수정 내용">
       <header className={styles.sectionHeader}>
-        <span>Intent 수정 diff</span>
-        <span>{change.fields.length} fields</span>
+        <span>상담 유형 수정 내용</span>
+        <span>{change.fields.length}개 항목</span>
       </header>
       <div className={styles.diffGrid}>
         {change.fields.includes("name") && (
-          <DiffRow label="Name" before={change.before.name} after={change.after.name} />
+          <DiffRow label="이름" before={change.before.name} after={change.after.name} />
         )}
         {change.fields.includes("description") && (
           <DiffRow
-            label="Description"
+            label="설명"
             before={change.before.description}
             after={change.after.description}
           />
@@ -36,11 +36,11 @@ function DiffRow({ label, before, after }: { label: string; before: string; afte
       <span className={styles.diffLabel}>{label}</span>
       <div className={styles.diffValues}>
         <div>
-          <span className={styles.diffCaption}>Before</span>
+          <span className={styles.diffCaption}>변경 전</span>
           <p>{before || "비어 있음"}</p>
         </div>
         <div>
-          <span className={styles.diffCaption}>After</span>
+          <span className={styles.diffCaption}>변경 후</span>
           <p>{after || "비어 있음"}</p>
         </div>
       </div>

--- a/frontend/src/features/intent-revision-draft/ui/IntentRevisionDraftActions.test.tsx
+++ b/frontend/src/features/intent-revision-draft/ui/IntentRevisionDraftActions.test.tsx
@@ -37,9 +37,9 @@ describe("IntentRevisionDraftActions", () => {
   it("변경 요약과 Domain Pack 화면 안내 문구를 보여준다", () => {
     renderActions();
 
-    expect(screen.getByText("변경된 intent 1개")).toBeInTheDocument();
+    expect(screen.getByText("변경된 상담 유형 1개")).toBeInTheDocument();
     expect(
-      screen.getByText("수정 내용의 적용 및 삭제는 Domain Pack 화면에서 진행할 수 있습니다."),
+      screen.getByText("수정 내용의 적용 및 삭제는 도메인팩 화면에서 진행할 수 있습니다."),
     ).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "적용" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "취소" })).not.toBeInTheDocument();
@@ -66,7 +66,7 @@ describe("IntentRevisionDraftActions", () => {
     });
 
     expect(screen.getByRole("button", { name: "다시 시도" })).toBeInTheDocument();
-    expect(screen.queryByText("변경된 intent가 없습니다.")).not.toBeInTheDocument();
+    expect(screen.queryByText("변경된 상담 유형이 없습니다.")).not.toBeInTheDocument();
   });
 
   it("요약 로딩 중에는 로딩 문구와 안내 문구만 보여준다", () => {
@@ -74,7 +74,7 @@ describe("IntentRevisionDraftActions", () => {
 
     expect(screen.getByText("변경 요약을 불러오는 중입니다.")).toBeInTheDocument();
     expect(
-      screen.getByText("수정 내용의 적용 및 삭제는 Domain Pack 화면에서 진행할 수 있습니다."),
+      screen.getByText("수정 내용의 적용 및 삭제는 도메인팩 화면에서 진행할 수 있습니다."),
     ).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "적용" })).not.toBeInTheDocument();
   });
@@ -88,6 +88,6 @@ describe("IntentRevisionDraftActions", () => {
       },
     });
 
-    expect(screen.getByText("변경된 intent가 없습니다.")).toBeInTheDocument();
+    expect(screen.getByText("변경된 상담 유형이 없습니다.")).toBeInTheDocument();
   });
 });

--- a/frontend/src/features/intent-revision-draft/ui/IntentRevisionDraftActions.tsx
+++ b/frontend/src/features/intent-revision-draft/ui/IntentRevisionDraftActions.tsx
@@ -31,11 +31,11 @@ export function IntentRevisionDraftActions({
           : hasSummaryError
             ? errorMessage
             : changedCount > 0
-              ? `변경된 intent ${changedCount}개`
-              : "변경된 intent가 없습니다."}
+              ? `변경된 상담 유형 ${changedCount}개`
+              : "변경된 상담 유형이 없습니다."}
       </div>
       <div className={styles.summaryText}>
-        수정 내용의 적용 및 삭제는 Domain Pack 화면에서 진행할 수 있습니다.
+        수정 내용의 적용 및 삭제는 도메인팩 화면에서 진행할 수 있습니다.
       </div>
       <div className={styles.actionButtons}>
         {hasSummaryError && (

--- a/frontend/src/features/intent-revision-draft/ui/IntentRevisionEditForm.test.tsx
+++ b/frontend/src/features/intent-revision-draft/ui/IntentRevisionEditForm.test.tsx
@@ -144,7 +144,7 @@ describe("IntentRevisionEditForm", () => {
 
     await waitFor(() =>
       expect(mockedToastError).toHaveBeenCalledWith(
-        "Intent 수정 내용 저장에 실패했습니다. patch failed",
+        "상담 유형 수정 내용 저장에 실패했습니다. patch failed",
       ),
     );
     expect(screen.getByLabelText("이름")).toHaveValue("유지되어야 하는 수정");

--- a/frontend/src/features/intent-revision-draft/ui/IntentRevisionEditForm.tsx
+++ b/frontend/src/features/intent-revision-draft/ui/IntentRevisionEditForm.tsx
@@ -165,8 +165,8 @@ export function IntentRevisionEditForm({
     } catch (error) {
       toast.error(
         error instanceof Error
-          ? `Intent 수정 내용 저장에 실패했습니다. ${error.message}`
-          : "Intent 수정 내용 저장에 실패했습니다.",
+          ? `상담 유형 수정 내용 저장에 실패했습니다. ${error.message}`
+          : "상담 유형 수정 내용 저장에 실패했습니다.",
       );
       return;
     }

--- a/frontend/src/features/intent-revision-draft/ui/IntentRevisionRecoveryBanner.test.tsx
+++ b/frontend/src/features/intent-revision-draft/ui/IntentRevisionRecoveryBanner.test.tsx
@@ -7,7 +7,7 @@ describe("IntentRevisionRecoveryBanner", () => {
     render(<IntentRevisionRecoveryBanner />);
 
     expect(screen.getByRole("status")).toHaveTextContent(
-      "Intent 수정 초안은 생성됐지만 첫 수정 내용은 저장되지 않았습니다.",
+      "상담 유형 수정 초안은 생성됐지만 첫 수정 내용은 저장되지 않았습니다.",
     );
   });
 });

--- a/frontend/src/features/intent-revision-draft/ui/IntentRevisionRecoveryBanner.tsx
+++ b/frontend/src/features/intent-revision-draft/ui/IntentRevisionRecoveryBanner.tsx
@@ -3,7 +3,7 @@ import styles from "./intent-revision-draft.module.css";
 export function IntentRevisionRecoveryBanner() {
   return (
     <div className={styles.recoveryBanner} role="status">
-      Intent 수정 초안은 생성됐지만 첫 수정 내용은 저장되지 않았습니다. 다시 수정 후 저장해 주세요.
+      상담 유형 수정 초안은 생성됐지만 첫 수정 내용은 저장되지 않았습니다. 다시 수정 후 저장해 주세요.
     </div>
   );
 }

--- a/frontend/src/features/log-upload/ui/LogUploadForm.test.tsx
+++ b/frontend/src/features/log-upload/ui/LogUploadForm.test.tsx
@@ -88,7 +88,7 @@ describe("LogUploadForm", () => {
     const file = new File(["test"], "test.json", { type: "application/json" });
     const input = screen.getByTestId("file-input");
     fireEvent.change(input, { target: { files: [file] } });
-    expect(screen.getByText("Start Processing")).toBeInTheDocument();
+    expect(screen.getByText("처리 시작")).toBeInTheDocument();
     expect(screen.getByText("test.json")).toBeInTheDocument();
   });
 
@@ -114,7 +114,7 @@ describe("LogUploadForm", () => {
     const file = new File(["data"], "data.json", { type: "application/json" });
     const input = screen.getByTestId("file-input");
     fireEvent.change(input, { target: { files: [file] } });
-    fireEvent.click(screen.getByText("Start Processing"));
+    fireEvent.click(screen.getByText("처리 시작"));
     expect(mockMutate).toHaveBeenCalled();
   });
 
@@ -123,7 +123,7 @@ describe("LogUploadForm", () => {
     const file = new File(["data"], "data.json", { type: "application/json" });
     const input = screen.getByTestId("file-input");
     fireEvent.change(input, { target: { files: [file] } });
-    const btn = screen.queryByText("Start Processing");
+    const btn = screen.queryByText("처리 시작");
     if (btn) fireEvent.click(btn);
     expect(mockMutate).not.toHaveBeenCalled();
   });
@@ -133,8 +133,8 @@ describe("LogUploadForm", () => {
     const file = new File(["data"], "data.json", { type: "application/json" });
     const input = screen.getByTestId("file-input");
     fireEvent.change(input, { target: { files: [file] } });
-    fireEvent.click(screen.getByText("Start Processing"));
-    expect(screen.getByText("Upload Another File")).toBeInTheDocument();
+    fireEvent.click(screen.getByText("처리 시작"));
+    expect(screen.getByText("다른 파일 업로드")).toBeInTheDocument();
     expect(screen.getByText("도메인팩 보기")).toBeInTheDocument();
   });
 
@@ -143,7 +143,7 @@ describe("LogUploadForm", () => {
     const file = new File(["data"], "data.json", { type: "application/json" });
     const input = screen.getByTestId("file-input");
     fireEvent.change(input, { target: { files: [file] } });
-    fireEvent.click(screen.getByText("Start Processing"));
+    fireEvent.click(screen.getByText("처리 시작"));
     fireEvent.click(screen.getByText("도메인팩 보기"));
     expect(mockNavigate).toHaveBeenCalledWith("/workspaces/1/domain-packs");
   });
@@ -153,11 +153,11 @@ describe("LogUploadForm", () => {
     const file = new File(["data"], "data.json", { type: "application/json" });
     const input = screen.getByTestId("file-input");
     fireEvent.change(input, { target: { files: [file] } });
-    fireEvent.click(screen.getByText("Start Processing"));
-    expect(screen.getByText("Upload Another File")).toBeInTheDocument();
-    fireEvent.click(screen.getByText("Upload Another File"));
+    fireEvent.click(screen.getByText("처리 시작"));
+    expect(screen.getByText("다른 파일 업로드")).toBeInTheDocument();
+    fireEvent.click(screen.getByText("다른 파일 업로드"));
     expect(mockReset).toHaveBeenCalled();
-    expect(screen.queryByText("Upload Another File")).not.toBeInTheDocument();
+    expect(screen.queryByText("다른 파일 업로드")).not.toBeInTheDocument();
     expect(screen.getByText("상담 로그 업로드")).toBeInTheDocument();
   });
 });

--- a/frontend/src/features/log-upload/ui/LogUploadForm.tsx
+++ b/frontend/src/features/log-upload/ui/LogUploadForm.tsx
@@ -104,14 +104,14 @@ export const LogUploadForm: React.FC<LogUploadFormProps> = ({ workspaceId }) => 
             <span className={styles.fileName}>{file.name}</span>
             <span className={styles.fileSize}>{(file.size / 1024 / 1024).toFixed(2)} MB</span>
           </div>
-          <Button onClick={() => handleUpload(file)}>Start Processing</Button>
+          <Button onClick={() => handleUpload(file)}>처리 시작</Button>
         </div>
       )}
 
       {status === "success" && (
         <div className={styles.successActions}>
           <Button variant="secondary" onClick={handleReset}>
-            Upload Another File
+            다른 파일 업로드
           </Button>
           <Button onClick={() => navigate(domainPacksPath)}>도메인팩 보기</Button>
         </div>

--- a/frontend/src/features/policy-draft-read/ui/PolicyDetailPanel.test.tsx
+++ b/frontend/src/features/policy-draft-read/ui/PolicyDetailPanel.test.tsx
@@ -50,7 +50,7 @@ describe("PolicyDetailPanel", () => {
 
     renderPanel();
 
-    expect(screen.getByText("정책을 선택하세요.")).toBeInTheDocument();
+    expect(screen.getByText("응대 기준을 선택하세요.")).toBeInTheDocument();
   });
 
   it("ready 상태에서는 정책 상세와 수정 액션을 보여준다", () => {
@@ -61,7 +61,7 @@ describe("PolicyDetailPanel", () => {
     expect(screen.getByText("환불 정책")).toBeInTheDocument();
     expect(screen.getByText(/REFUND_REVIEW/)).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: /POL_REFUND 정책 수정/ }));
+    fireEvent.click(screen.getByRole("button", { name: /POL_REFUND 응대 기준 수정/ }));
 
     expect(onEdit).toHaveBeenCalledWith(4);
   });
@@ -79,7 +79,7 @@ describe("PolicyDetailPanel", () => {
     expect(screen.getByText("상세 정보를 불러오지 못했습니다.")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "다시 시도" })).toBeInTheDocument();
     expect(toast.error).toHaveBeenCalledWith(
-      "정책을 찾을 수 없습니다.",
+      "응대 기준을 찾을 수 없습니다.",
       expect.objectContaining({ id: expect.stringContaining("policy-detail-error") }),
     );
   });

--- a/frontend/src/features/policy-draft-read/ui/PolicyDetailPanel.test.tsx
+++ b/frontend/src/features/policy-draft-read/ui/PolicyDetailPanel.test.tsx
@@ -66,6 +66,30 @@ describe("PolicyDetailPanel", () => {
     expect(onEdit).toHaveBeenCalledWith(4);
   });
 
+  it("빈 JSON과 비활성 응대 기준도 상담사 용어로 표시한다", () => {
+    mockedUsePolicyDetail.mockReturnValue({
+      status: "ready",
+      data: {
+        ...stubPolicy,
+        description: null,
+        severity: null,
+        conditionJson: null,
+        actionJson: null,
+        evidenceJson: null,
+        metaJson: null,
+        status: "INACTIVE",
+        updatedAt: "확인 전",
+      },
+    });
+
+    renderPanel();
+
+    expect(screen.getByText("중요도")).toBeInTheDocument();
+    expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(5);
+    expect(screen.getByText("사용 안 함")).toBeInTheDocument();
+    expect(screen.getByText("수정일 · 확인 전")).toBeInTheDocument();
+  });
+
   it("error 상태에서는 toast와 재시도 버튼을 보여준다", () => {
     mockedUsePolicyDetail.mockReturnValue({
       status: "error",

--- a/frontend/src/features/policy-draft-read/ui/PolicyDetailPanel.tsx
+++ b/frontend/src/features/policy-draft-read/ui/PolicyDetailPanel.tsx
@@ -35,8 +35,8 @@ export function PolicyDetailPanel({
     if (state.status !== "error") return;
     const message =
       errorHttpStatus === 404
-        ? "정책을 찾을 수 없습니다."
-        : errorMessage || "정책 상세 정보를 불러오지 못했습니다.";
+        ? "응대 기준을 찾을 수 없습니다."
+        : errorMessage || "응대 기준 상세 정보를 불러오지 못했습니다.";
 
     toast.error(message, {
       id: `policy-detail-error-${workspaceId}-${packId}-${versionId}-${policyId ?? "none"}-${errorCode ?? errorHttpStatus ?? "unknown"}`,
@@ -54,9 +54,9 @@ export function PolicyDetailPanel({
 
   if (state.status === "idle") {
     return (
-      <section className={styles.panel} aria-label="정책 상세">
+      <section className={styles.panel} aria-label="응대 기준 상세">
         <div className={styles.placeholder}>
-          <span>정책을 선택하세요.</span>
+          <span>응대 기준을 선택하세요.</span>
         </div>
       </section>
     );
@@ -64,7 +64,7 @@ export function PolicyDetailPanel({
 
   if (state.status === "loading") {
     return (
-      <section className={styles.panel} aria-label="정책 상세">
+      <section className={styles.panel} aria-label="응대 기준 상세">
         <div className={styles.body}>
           <div className={styles.skeleton} />
         </div>
@@ -74,10 +74,10 @@ export function PolicyDetailPanel({
 
   if (state.status === "error") {
     return (
-      <section className={styles.panel} aria-label="정책 상세">
+      <section className={styles.panel} aria-label="응대 기준 상세">
         <div className={styles.placeholder}>
           <span>상세 정보를 불러오지 못했습니다.</span>
-          <span>{errorHttpStatus === 404 ? "정책을 찾을 수 없습니다." : errorMessage}</span>
+          <span>{errorHttpStatus === 404 ? "응대 기준을 찾을 수 없습니다." : errorMessage}</span>
           <span className={styles.errorCode}>{errorCode}</span>
           <button
             type="button"
@@ -92,47 +92,47 @@ export function PolicyDetailPanel({
   }
 
   const jsonFields: PolicyJsonField[] = [
-    { label: "Condition", value: state.data.conditionJson ?? "" },
-    { label: "Action", value: state.data.actionJson ?? "" },
-    { label: "Evidence", value: state.data.evidenceJson ?? "" },
-    { label: "Meta", value: state.data.metaJson ?? "" },
+    { label: "적용 조건", value: state.data.conditionJson ?? "" },
+    { label: "응대 방법", value: state.data.actionJson ?? "" },
+    { label: "근거 로그", value: state.data.evidenceJson ?? "" },
+    { label: "추가 정보", value: state.data.metaJson ?? "" },
   ];
 
   return (
-    <section className={styles.panel} aria-label="정책 상세">
+    <section className={styles.panel} aria-label="응대 기준 상세">
       <DetailHeader detail={state.data} onEdit={() => onEdit(state.data.id!)} />
       <div className={styles.body}>
         <div className={styles.grid}>
           <InfoCard
-            label="Policy Code"
+            label="기준 코드"
             value={<span className={styles.value}>{state.data.policyCode}</span>}
           />
           <InfoCard
-            label="Severity"
-            value={<span className={styles.value}>{state.data.severity ?? "—"}</span>}
+            label="중요도"
+            value={<span className={styles.value}>{formatSeverity(state.data.severity)}</span>}
           />
           <InfoCard
-            label="Status"
+            label="상태"
             value={
               <span
                 className={`${styles.badge} ${
                   state.data.status === "ACTIVE" ? styles.badgeActive : styles.badgeInactive
                 }`}
               >
-                {state.data.status === "ACTIVE" ? "● ACTIVE" : "○ INACTIVE"}
+                {formatStatus(state.data.status)}
               </span>
             }
           />
           <InfoCard
-            label="Version Id"
+            label="버전 ID"
             value={<span className={styles.value}>{state.data.domainPackVersionId}</span>}
           />
           <InfoCard
-            label="Created At"
+            label="생성일"
             value={<span className={styles.value}>{formatDate(state.data.createdAt ?? "")}</span>}
           />
           <InfoCard
-            label="Updated At"
+            label="수정일"
             value={<span className={styles.value}>{formatDate(state.data.updatedAt ?? "")}</span>}
           />
         </div>
@@ -157,19 +157,34 @@ function DetailHeader({
         <span className={styles.code}>{detail.policyCode}</span>
         <span className={styles.name}>{detail.name ?? ""}</span>
         {detail.description && <span className={styles.description}>{detail.description}</span>}
-        <span className={styles.updatedAt}>UPDATED · {formatDate(detail.updatedAt ?? "")}</span>
+        <span className={styles.updatedAt}>수정일 · {formatDate(detail.updatedAt ?? "")}</span>
       </div>
       <button
         type="button"
         className={styles.editButton}
         onClick={onEdit}
-        aria-label={`${detail.policyCode} 정책 수정`}
+        aria-label={`${detail.policyCode} 응대 기준 수정`}
       >
         <PencilIcon aria-hidden="true" />
         <span>수정</span>
       </button>
     </header>
   );
+}
+
+function formatStatus(status: PolicyDefinition["status"]): string {
+  return status === "ACTIVE" ? "사용중" : "사용 안 함";
+}
+
+function formatSeverity(severity: PolicyDefinition["severity"]): string {
+  if (!severity) return "—";
+  const labels: Record<string, string> = {
+    LOW: "낮음",
+    MEDIUM: "보통",
+    HIGH: "높음",
+    CRITICAL: "긴급",
+  };
+  return labels[severity] ?? severity;
 }
 
 function InfoCard({ label, value }: Readonly<{ label: string; value: ReactNode }>) {

--- a/frontend/src/features/policy-draft-read/ui/PolicyListPanel.test.tsx
+++ b/frontend/src/features/policy-draft-read/ui/PolicyListPanel.test.tsx
@@ -44,8 +44,8 @@ describe("PolicyListPanel", () => {
 
     renderPanel();
 
-    expect(screen.getByLabelText("정책 목록")).toBeInTheDocument();
-    expect(screen.getByText("— · LIST")).toBeInTheDocument();
+    expect(screen.getByLabelText("응대 기준 목록")).toBeInTheDocument();
+    expect(screen.getByText("—개")).toBeInTheDocument();
   });
 
   it("ready 상태에서는 목록을 렌더링하고 선택 이벤트를 전달한다", () => {
@@ -54,7 +54,7 @@ describe("PolicyListPanel", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /POL_REFUND/ }));
 
-    expect(screen.getByText("1 · LIST")).toBeInTheDocument();
+    expect(screen.getByText("1개")).toBeInTheDocument();
     expect(screen.getByText("환불 정책")).toBeInTheDocument();
     expect(onSelect).toHaveBeenCalledWith(4);
   });
@@ -68,7 +68,7 @@ describe("PolicyListPanel", () => {
 
     renderPanel();
 
-    expect(screen.getByText("정책 목록을 불러오지 못했습니다.")).toBeInTheDocument();
+    expect(screen.getByText("응대 기준 목록을 불러오지 못했습니다.")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "다시 시도" })).toBeInTheDocument();
   });
 });

--- a/frontend/src/features/policy-draft-read/ui/PolicyListPanel.tsx
+++ b/frontend/src/features/policy-draft-read/ui/PolicyListPanel.tsx
@@ -25,16 +25,16 @@ export function PolicyListPanel({
 
   useEffect(() => {
     if (state.status === "error") {
-      toast.error(errorMessage ?? "정책 목록을 불러오지 못했습니다.");
+      toast.error(errorMessage ?? "응대 기준 목록을 불러오지 못했습니다.");
     }
   }, [state.status, errorMessage]);
 
   return (
-    <aside className={styles.panel} aria-label="정책 목록">
+    <aside className={styles.panel} aria-label="응대 기준 목록">
       <header className={styles.header}>
-        <span className={styles.headerTitle}>Policies</span>
+        <span className={styles.headerTitle}>응대 기준</span>
         <span className={styles.headerMeta}>
-          {state.status === "ready" ? `${state.data.length} · LIST` : "— · LIST"}
+          {state.status === "ready" ? `${state.data.length}개` : "—개"}
         </span>
       </header>
 
@@ -74,7 +74,7 @@ function PolicyListContent({
   if (state.status === "error") {
     return (
       <div className={styles.emptyState}>
-        <span>정책 목록을 불러오지 못했습니다.</span>
+        <span>응대 기준 목록을 불러오지 못했습니다.</span>
         <button type="button" className={styles.retryButton} onClick={onRetry}>
           다시 시도
         </button>
@@ -85,7 +85,7 @@ function PolicyListContent({
   if (state.data.length === 0) {
     return (
       <div className={styles.emptyState}>
-        <span>등록된 정책 초안이 없습니다.</span>
+        <span>등록된 응대 기준 초안이 없습니다.</span>
       </div>
     );
   }
@@ -129,7 +129,7 @@ function PolicyListRow({
               policy.status === "ACTIVE" ? styles.badgeActive : styles.badgeInactive
             }`}
           >
-            {policy.status === "ACTIVE" ? "● ACTIVE" : "○ INACTIVE"}
+            {formatStatus(policy.status)}
           </span>
           <span
             className={`${styles.badge} ${
@@ -138,10 +138,25 @@ function PolicyListRow({
                 : ""
             }`}
           >
-            {policy.severity ?? "NO SEVERITY"}
+            {formatSeverity(policy.severity)}
           </span>
         </span>
       </div>
     </button>
   );
+}
+
+function formatStatus(status: PolicySummary["status"]): string {
+  return status === "ACTIVE" ? "사용중" : "사용 안 함";
+}
+
+function formatSeverity(severity: PolicySummary["severity"]): string {
+  if (!severity) return "중요도 없음";
+  const labels: Record<string, string> = {
+    LOW: "낮음",
+    MEDIUM: "보통",
+    HIGH: "높음",
+    CRITICAL: "긴급",
+  };
+  return labels[severity] ?? severity;
 }

--- a/frontend/src/features/risk-draft-read/model/mapApiError.ts
+++ b/frontend/src/features/risk-draft-read/model/mapApiError.ts
@@ -1,9 +1,9 @@
 import { ApiRequestError } from "@/shared/api";
 
 export const RISK_READ_ERROR_MESSAGES = {
-  NOT_FOUND: "위험요소를 찾을 수 없습니다.",
-  LOAD_LIST_FAILED: "위험요소 목록을 불러오지 못했습니다.",
-  LOAD_DETAIL_FAILED: "위험요소 상세 정보를 불러오지 못했습니다.",
+  NOT_FOUND: "주의 사항을 찾을 수 없습니다.",
+  LOAD_LIST_FAILED: "주의 사항 목록을 불러오지 못했습니다.",
+  LOAD_DETAIL_FAILED: "주의 사항 상세 정보를 불러오지 못했습니다.",
   UNKNOWN: "알 수 없는 오류가 발생했습니다.",
 } as const;
 

--- a/frontend/src/features/risk-draft-read/ui/RiskDetailPanel.test.tsx
+++ b/frontend/src/features/risk-draft-read/ui/RiskDetailPanel.test.tsx
@@ -63,6 +63,30 @@ describe("RiskDetailPanel", () => {
     expect(screen.getByText("응대 방법")).toBeInTheDocument();
   });
 
+  it("빈 JSON과 비활성 주의 사항도 상담사 용어로 표시한다", () => {
+    mockedUseRiskDetail.mockReturnValue({
+      status: "ready",
+      data: {
+        ...stubRisk,
+        description: null,
+        riskLevel: null,
+        triggerConditionJson: null,
+        handlingActionJson: null,
+        evidenceJson: null,
+        metaJson: null,
+        status: "INACTIVE",
+        updatedAt: "확인 전",
+      },
+    });
+
+    renderPanel();
+
+    expect(screen.getByText("주의 수준")).toBeInTheDocument();
+    expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(5);
+    expect(screen.getByText("사용 안 함")).toBeInTheDocument();
+    expect(screen.getByText("수정일 · 확인 전")).toBeInTheDocument();
+  });
+
   it("수정 버튼을 누르면 onEdit에 riskId를 전달한다", () => {
     mockedUseRiskDetail.mockReturnValue({ status: "ready", data: stubRisk });
     const { onEdit } = renderPanel();

--- a/frontend/src/features/risk-draft-read/ui/RiskDetailPanel.test.tsx
+++ b/frontend/src/features/risk-draft-read/ui/RiskDetailPanel.test.tsx
@@ -48,10 +48,10 @@ describe("RiskDetailPanel", () => {
 
     renderPanel();
 
-    expect(screen.getByText("위험요소를 선택하세요.")).toBeInTheDocument();
+    expect(screen.getByText("주의 사항을 선택하세요.")).toBeInTheDocument();
   });
 
-  it("ready 상태에서는 위험요소 상세와 JSON 필드를 보여준다", () => {
+  it("ready 상태에서는 주의 사항 상세와 JSON 필드를 보여준다", () => {
     mockedUseRiskDetail.mockReturnValue({ status: "ready", data: stubRisk });
 
     renderPanel();
@@ -59,15 +59,15 @@ describe("RiskDetailPanel", () => {
     expect(screen.getAllByText("RISK_FRAUD")).toHaveLength(2);
     expect(screen.getByText("사기 위험")).toBeInTheDocument();
     expect(screen.getByText(/MANUAL_REVIEW/)).toBeInTheDocument();
-    expect(screen.getByText("Trigger Condition")).toBeInTheDocument();
-    expect(screen.getByText("Handling Action")).toBeInTheDocument();
+    expect(screen.getByText("감지 조건")).toBeInTheDocument();
+    expect(screen.getByText("응대 방법")).toBeInTheDocument();
   });
 
   it("수정 버튼을 누르면 onEdit에 riskId를 전달한다", () => {
     mockedUseRiskDetail.mockReturnValue({ status: "ready", data: stubRisk });
     const { onEdit } = renderPanel();
 
-    fireEvent.click(screen.getByRole("button", { name: "RISK_FRAUD 위험요소 수정" }));
+    fireEvent.click(screen.getByRole("button", { name: "RISK_FRAUD 주의 사항 수정" }));
 
     expect(onEdit).toHaveBeenCalledWith(4);
   });
@@ -85,7 +85,7 @@ describe("RiskDetailPanel", () => {
     expect(screen.getByText("상세 정보를 불러오지 못했습니다.")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "다시 시도" })).toBeInTheDocument();
     expect(toast.error).toHaveBeenCalledWith(
-      "위험요소를 찾을 수 없습니다.",
+      "주의 사항을 찾을 수 없습니다.",
       expect.objectContaining({ id: expect.stringContaining("risk-detail-error") }),
     );
   });

--- a/frontend/src/features/risk-draft-read/ui/RiskDetailPanel.tsx
+++ b/frontend/src/features/risk-draft-read/ui/RiskDetailPanel.tsx
@@ -7,16 +7,23 @@ import type { RiskDefinition } from "@/entities/risk";
 import styles from "./RiskDetailPanel.module.css";
 
 const RISK_JSON_FIELDS = [
-  ["Trigger Condition", "triggerConditionJson"],
-  ["Handling Action", "handlingActionJson"],
-  ["Evidence", "evidenceJson"],
-  ["Meta", "metaJson"],
+  ["감지 조건", "triggerConditionJson"],
+  ["응대 방법", "handlingActionJson"],
+  ["근거 로그", "evidenceJson"],
+  ["추가 정보", "metaJson"],
 ] as const;
 
 const STATUS_LABELS = {
-  ACTIVE: "● ACTIVE",
-  INACTIVE: "○ INACTIVE",
+  ACTIVE: "사용중",
+  INACTIVE: "사용 안 함",
 } as const;
+
+const RISK_LEVEL_LABELS: Record<string, string> = {
+  LOW: "낮음",
+  MEDIUM: "보통",
+  HIGH: "높음",
+  CRITICAL: "긴급",
+};
 
 const DATE_FORMATTER = new Intl.DateTimeFormat("ko-KR", {
   year: "numeric",
@@ -77,9 +84,9 @@ export function RiskDetailPanel({
 
   if (state.status === "idle") {
     return (
-      <section className={styles.panel} aria-label="위험요소 상세">
+      <section className={styles.panel} aria-label="주의 사항 상세">
         <div className={styles.placeholder}>
-          <span>위험요소를 선택하세요.</span>
+          <span>주의 사항을 선택하세요.</span>
         </div>
       </section>
     );
@@ -87,7 +94,7 @@ export function RiskDetailPanel({
 
   if (state.status === "loading") {
     return (
-      <section className={styles.panel} aria-label="위험요소 상세">
+      <section className={styles.panel} aria-label="주의 사항 상세">
         <div className={styles.body}>
           <div className={styles.skeleton} />
         </div>
@@ -97,7 +104,7 @@ export function RiskDetailPanel({
 
   if (state.status === "error") {
     return (
-      <section className={styles.panel} aria-label="위험요소 상세">
+      <section className={styles.panel} aria-label="주의 사항 상세">
         <div className={styles.placeholder}>
           <span>상세 정보를 불러오지 못했습니다.</span>
           <span>{errorHttpStatus === 404 ? RISK_READ_ERROR_MESSAGES.NOT_FOUND : errorMessage}</span>
@@ -116,16 +123,16 @@ export function RiskDetailPanel({
 
   const detail = state.data;
   const infoFields: RiskInfoField[] = [
-    { label: "Risk Code", value: <span>{detail.riskCode}</span> },
-    { label: "Risk Level", value: <span>{detail.riskLevel}</span> },
-    { label: "Status", value: <StatusBadge status={detail.status} /> },
-    { label: "Version Id", value: <span>{detail.domainPackVersionId}</span> },
-    { label: "Created At", value: formatDate(detail.createdAt ?? "") },
-    { label: "Updated At", value: formatDate(detail.updatedAt ?? "") },
+    { label: "주의 코드", value: <span>{detail.riskCode}</span> },
+    { label: "주의 수준", value: <span>{formatRiskLevel(detail.riskLevel)}</span> },
+    { label: "상태", value: <StatusBadge status={detail.status} /> },
+    { label: "버전 ID", value: <span>{detail.domainPackVersionId}</span> },
+    { label: "생성일", value: formatDate(detail.createdAt ?? "") },
+    { label: "수정일", value: formatDate(detail.updatedAt ?? "") },
   ];
 
   return (
-    <section className={styles.panel} aria-label="위험요소 상세">
+    <section className={styles.panel} aria-label="주의 사항 상세">
       <DetailHeader detail={detail} onEdit={() => onEdit(detail.id!)} />
       <div className={styles.body}>
         <InfoGrid fields={infoFields} />
@@ -147,19 +154,23 @@ function DetailHeader({
         <span className={styles.code}>{detail.riskCode}</span>
         <span className={styles.name}>{detail.name}</span>
         {detail.description && <span className={styles.description}>{detail.description}</span>}
-        <span className={styles.updatedAt}>UPDATED · {formatDate(detail.updatedAt ?? "")}</span>
+        <span className={styles.updatedAt}>수정일 · {formatDate(detail.updatedAt ?? "")}</span>
       </div>
       <button
         type="button"
         className={styles.editButton}
         onClick={onEdit}
-        aria-label={`${detail.riskCode} 위험요소 수정`}
+        aria-label={`${detail.riskCode} 주의 사항 수정`}
       >
         <PencilIcon aria-hidden="true" />
         <span>수정</span>
       </button>
     </header>
   );
+}
+
+function formatRiskLevel(level: RiskDefinition["riskLevel"]): string {
+  return level ? (RISK_LEVEL_LABELS[level] ?? level) : "—";
 }
 
 function InfoGrid({ fields }: Readonly<{ fields: readonly RiskInfoField[] }>) {

--- a/frontend/src/features/risk-draft-read/ui/RiskListPanel.test.tsx
+++ b/frontend/src/features/risk-draft-read/ui/RiskListPanel.test.tsx
@@ -44,8 +44,8 @@ describe("RiskListPanel", () => {
 
     renderPanel();
 
-    expect(screen.getByLabelText("위험요소 목록")).toBeInTheDocument();
-    expect(screen.getByText("— · LIST")).toBeInTheDocument();
+    expect(screen.getByLabelText("주의 사항 목록")).toBeInTheDocument();
+    expect(screen.getByText("—개")).toBeInTheDocument();
   });
 
   it("ready 상태에서는 목록을 렌더링하고 선택 이벤트를 전달한다", () => {
@@ -55,7 +55,7 @@ describe("RiskListPanel", () => {
     const riskButton = screen.getByRole("button", { name: /RISK_FRAUD/ });
     fireEvent.click(riskButton);
 
-    expect(screen.getByText("1 · LIST")).toBeInTheDocument();
+    expect(screen.getByText("1개")).toBeInTheDocument();
     expect(riskButton).toHaveAttribute("aria-current", "true");
     expect(screen.getByText("사기 위험")).toBeInTheDocument();
     expect(onSelect).toHaveBeenCalledWith(4);
@@ -66,8 +66,8 @@ describe("RiskListPanel", () => {
 
     renderPanel();
 
-    expect(screen.getByText("0 · LIST")).toBeInTheDocument();
-    expect(screen.getByText("등록된 위험요소 초안이 없습니다.")).toBeInTheDocument();
+    expect(screen.getByText("0개")).toBeInTheDocument();
+    expect(screen.getByText("등록된 주의 사항 초안이 없습니다.")).toBeInTheDocument();
   });
 
   it("error 상태에서는 재시도 버튼을 제공한다", () => {
@@ -79,7 +79,7 @@ describe("RiskListPanel", () => {
 
     renderPanel();
 
-    expect(screen.getByText("위험요소 목록을 불러오지 못했습니다.")).toBeInTheDocument();
+    expect(screen.getByText("주의 사항 목록을 불러오지 못했습니다.")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "다시 시도" })).toBeInTheDocument();
   });
 });

--- a/frontend/src/features/risk-draft-read/ui/RiskListPanel.tsx
+++ b/frontend/src/features/risk-draft-read/ui/RiskListPanel.tsx
@@ -33,15 +33,15 @@ export function RiskListPanel({
   }, [state.status, errorMessage]);
 
   return (
-    <aside className={styles.panel} aria-label="위험요소 목록">
+    <aside className={styles.panel} aria-label="주의 사항 목록">
       <header className={styles.header}>
-        <span className={styles.headerTitle}>Risks</span>
+        <span className={styles.headerTitle}>주의 사항</span>
         <span className={styles.headerMeta}>
           {state.status === "ready"
-            ? `${state.data.length} · LIST`
+            ? `${state.data.length}개`
             : state.status === "empty"
-              ? "0 · LIST"
-              : "— · LIST"}
+              ? "0개"
+              : "—개"}
         </span>
       </header>
 
@@ -76,7 +76,7 @@ function RiskListContent({
     const message =
       state.status === "error"
         ? RISK_READ_ERROR_MESSAGES.LOAD_LIST_FAILED
-        : "등록된 위험요소 초안이 없습니다.";
+        : "등록된 주의 사항 초안이 없습니다.";
 
     return (
       <RiskListMessage
@@ -157,7 +157,7 @@ function RiskListRow({
               risk.status === "ACTIVE" ? styles.badgeActive : styles.badgeInactive
             }`}
           >
-            {risk.status === "ACTIVE" ? "● ACTIVE" : "○ INACTIVE"}
+            {formatStatus(risk.status)}
           </span>
           <span
             className={`${styles.badge} ${
@@ -166,10 +166,25 @@ function RiskListRow({
                 : ""
             }`}
           >
-            {risk.riskLevel}
+            {formatRiskLevel(risk.riskLevel)}
           </span>
         </span>
       </div>
     </button>
   );
+}
+
+function formatStatus(status: RiskSummary["status"]): string {
+  return status === "ACTIVE" ? "사용중" : "사용 안 함";
+}
+
+function formatRiskLevel(level: RiskSummary["riskLevel"]): string {
+  if (!level) return "위험도 없음";
+  const labels: Record<string, string> = {
+    LOW: "낮음",
+    MEDIUM: "보통",
+    HIGH: "높음",
+    CRITICAL: "긴급",
+  };
+  return labels[level] ?? level;
 }

--- a/frontend/src/features/slot-draft-read/ui/SlotDetailPanel.test.tsx
+++ b/frontend/src/features/slot-draft-read/ui/SlotDetailPanel.test.tsx
@@ -47,7 +47,7 @@ describe("SlotDetailPanel", () => {
 
     renderPanel();
 
-    expect(screen.getByText("슬롯을 선택하세요.")).toBeInTheDocument();
+    expect(screen.getByText("확인 항목을 선택하세요.")).toBeInTheDocument();
   });
 
   it("loading 상태에서는 스켈레톤을 보여준다", () => {
@@ -55,7 +55,7 @@ describe("SlotDetailPanel", () => {
 
     renderPanel();
 
-    expect(screen.getByLabelText("슬롯 상세")).toBeInTheDocument();
+    expect(screen.getByLabelText("확인 항목 상세")).toBeInTheDocument();
     expect(document.querySelector('[class*="skeleton"]')).toBeTruthy();
   });
 
@@ -67,14 +67,14 @@ describe("SlotDetailPanel", () => {
     expect(screen.getAllByText("SLOT_001").length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("배송 주소")).toBeInTheDocument();
     expect(screen.getAllByText("STRING").length).toBeGreaterThanOrEqual(1);
-    expect(screen.getByText("NO")).toBeInTheDocument();
+    expect(screen.getByText("아니오")).toBeInTheDocument();
   });
 
   it("error 상태에서는 toast와 재시도 버튼을 보여준다", () => {
     mockedUseSlotDetail.mockReturnValue({
       status: "error",
       code: "SLOT_NOT_FOUND",
-      message: "슬롯을 찾을 수 없습니다.",
+      message: "확인 항목을 찾을 수 없습니다.",
       httpStatus: 404,
     });
 
@@ -84,7 +84,7 @@ describe("SlotDetailPanel", () => {
     expect(screen.getByText("SLOT_NOT_FOUND")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "다시 시도" })).toBeInTheDocument();
     expect(toast.error).toHaveBeenCalledWith(
-      "슬롯을 찾을 수 없습니다.",
+      "확인 항목을 찾을 수 없습니다.",
       expect.objectContaining({ id: expect.stringContaining("slot-detail-error") }),
     );
   });

--- a/frontend/src/features/slot-draft-read/ui/SlotDetailPanel.test.tsx
+++ b/frontend/src/features/slot-draft-read/ui/SlotDetailPanel.test.tsx
@@ -70,6 +70,30 @@ describe("SlotDetailPanel", () => {
     expect(screen.getByText("아니오")).toBeInTheDocument();
   });
 
+  it("민감 확인 항목과 빈 JSON을 상담사 용어로 표시한다", () => {
+    mockedUseSlotDetail.mockReturnValue({
+      status: "ready",
+      data: {
+        ...stubDetail,
+        description: "주문자 본인 확인",
+        isSensitive: true,
+        validationRuleJson: undefined,
+        defaultValueJson: "",
+        metaJson: undefined,
+        status: "INACTIVE",
+        updatedAt: "확인 전",
+      },
+    });
+
+    renderPanel();
+
+    expect(screen.getByText("주문자 본인 확인")).toBeInTheDocument();
+    expect(screen.getByText("사용 안 함")).toBeInTheDocument();
+    expect(screen.getByText("예")).toBeInTheDocument();
+    expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(3);
+    expect(screen.getByText("수정일 · 확인 전")).toBeInTheDocument();
+  });
+
   it("error 상태에서는 toast와 재시도 버튼을 보여준다", () => {
     mockedUseSlotDetail.mockReturnValue({
       status: "error",

--- a/frontend/src/features/slot-draft-read/ui/SlotDetailPanel.tsx
+++ b/frontend/src/features/slot-draft-read/ui/SlotDetailPanel.tsx
@@ -22,7 +22,7 @@ export function SlotDetailPanel({ wsId, packId, versionId, slotId }: SlotDetailP
     if (state.status !== "error") return;
     const message =
       errorHttpStatus === 404
-        ? "슬롯을 찾을 수 없습니다."
+        ? "확인 항목을 찾을 수 없습니다."
         : errorMessage || "상세 정보를 불러오지 못했습니다.";
 
     toast.error(message, {
@@ -32,9 +32,9 @@ export function SlotDetailPanel({ wsId, packId, versionId, slotId }: SlotDetailP
 
   if (state.status === "idle") {
     return (
-      <section className={styles.panel} aria-label="슬롯 상세">
+      <section className={styles.panel} aria-label="확인 항목 상세">
         <div className={styles.placeholder}>
-          <span>슬롯을 선택하세요.</span>
+          <span>확인 항목을 선택하세요.</span>
         </div>
       </section>
     );
@@ -42,7 +42,7 @@ export function SlotDetailPanel({ wsId, packId, versionId, slotId }: SlotDetailP
 
   if (state.status === "loading") {
     return (
-      <section className={styles.panel} aria-label="슬롯 상세">
+      <section className={styles.panel} aria-label="확인 항목 상세">
         <div className={styles.body}>
           <div className={styles.skeleton} />
         </div>
@@ -52,7 +52,7 @@ export function SlotDetailPanel({ wsId, packId, versionId, slotId }: SlotDetailP
 
   if (state.status === "error") {
     return (
-      <section className={styles.panel} aria-label="슬롯 상세">
+      <section className={styles.panel} aria-label="확인 항목 상세">
         <div className={styles.placeholder}>
           <span>상세 정보를 불러오지 못했습니다.</span>
           <span className={styles.errorCode}>{errorCode}</span>
@@ -69,38 +69,38 @@ export function SlotDetailPanel({ wsId, packId, versionId, slotId }: SlotDetailP
   }
 
   return (
-    <section className={styles.panel} aria-label="슬롯 상세">
+    <section className={styles.panel} aria-label="확인 항목 상세">
       <DetailHeader detail={state.data} />
       <div className={styles.body}>
         <div className={styles.grid}>
           <InfoCard
-            label="Slot Code"
+            label="항목 코드"
             value={<span className={styles.value}>{state.data.slotCode}</span>}
           />
           <InfoCard
-            label="Data Type"
+            label="값 형식"
             value={<span className={styles.value}>{state.data.dataType}</span>}
           />
           <InfoCard
-            label="Status"
-            value={<span className={styles.badge}>{state.data.status}</span>}
+            label="상태"
+            value={<span className={styles.badge}>{formatStatus(state.data.status)}</span>}
           />
           <InfoCard
-            label="Is Sensitive"
-            value={<span className={styles.value}>{state.data.isSensitive ? "YES" : "NO"}</span>}
+            label="민감 정보"
+            value={<span className={styles.value}>{state.data.isSensitive ? "예" : "아니오"}</span>}
           />
           <InfoCard
-            label="Created At"
+            label="생성일"
             value={<span className={styles.value}>{formatDate(state.data.createdAt ?? "")}</span>}
           />
           <InfoCard
-            label="Updated At"
+            label="수정일"
             value={<span className={styles.value}>{formatDate(state.data.updatedAt ?? "")}</span>}
           />
         </div>
-        <JsonCard label="Validation Rule" value={state.data.validationRuleJson ?? ""} />
-        <JsonCard label="Default Value" value={(state.data.defaultValueJson ?? "") || null} />
-        <JsonCard label="Meta" value={state.data.metaJson ?? ""} />
+        <JsonCard label="검증 규칙" value={state.data.validationRuleJson ?? ""} />
+        <JsonCard label="기본값" value={(state.data.defaultValueJson ?? "") || null} />
+        <JsonCard label="추가 정보" value={state.data.metaJson ?? ""} />
       </div>
     </section>
   );
@@ -112,9 +112,13 @@ function DetailHeader({ detail }: { detail: SlotDefinition }) {
       <span className={styles.code}>{detail.slotCode}</span>
       <span className={styles.name}>{detail.name}</span>
       {detail.description && <span className={styles.description}>{detail.description}</span>}
-      <span className={styles.updatedAt}>UPDATED · {formatDate(detail.updatedAt ?? "")}</span>
+      <span className={styles.updatedAt}>수정일 · {formatDate(detail.updatedAt ?? "")}</span>
     </header>
   );
+}
+
+function formatStatus(status: SlotDefinition["status"]): string {
+  return status === "ACTIVE" ? "사용중" : "사용 안 함";
 }
 
 function InfoCard({ label, value }: { label: string; value: ReactNode }) {

--- a/frontend/src/features/slot-draft-read/ui/SlotListPanel.tsx
+++ b/frontend/src/features/slot-draft-read/ui/SlotListPanel.tsx
@@ -25,16 +25,16 @@ export function SlotListPanel({
 
   useEffect(() => {
     if (state.status === "error") {
-      toast.error(errorMessage ?? "목록을 불러오지 못했습니다.");
+      toast.error(errorMessage ?? "확인 항목 목록을 불러오지 못했습니다.");
     }
   }, [state.status, errorMessage]);
 
   return (
-    <aside className={styles.panel} aria-label="슬롯 목록">
+    <aside className={styles.panel} aria-label="확인 항목 목록">
       <header className={styles.header}>
-        <span className={styles.headerTitle}>Slots</span>
+        <span className={styles.headerTitle}>확인 항목</span>
         <span className={styles.headerMeta}>
-          {state.status === "ready" ? `${state.data.length} · LIST` : "— · LIST"}
+          {state.status === "ready" ? `${state.data.length}개` : "—개"}
         </span>
       </header>
 
@@ -49,7 +49,7 @@ export function SlotListPanel({
 
         {state.status === "error" && (
           <div className={styles.emptyState}>
-            <span>목록을 불러오지 못했습니다.</span>
+            <span>확인 항목 목록을 불러오지 못했습니다.</span>
             <button
               type="button"
               className={styles.retryButton}
@@ -62,7 +62,7 @@ export function SlotListPanel({
 
         {state.status === "ready" && state.data.length === 0 && (
           <div className={styles.emptyState}>
-            <span>등록된 슬롯 초안이 없습니다.</span>
+            <span>등록된 확인 항목 초안이 없습니다.</span>
           </div>
         )}
 

--- a/frontend/src/features/update-policy/api/__tests__/useUpdatePolicy.test.ts
+++ b/frontend/src/features/update-policy/api/__tests__/useUpdatePolicy.test.ts
@@ -97,7 +97,7 @@ describe("useUpdatePolicy", () => {
       result.current.mutate({ ...params, body: { name: "새 정책" } });
     });
 
-    await waitFor(() => expect(toast.success).toHaveBeenCalledWith("정책이 수정되었습니다."));
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith("응대 기준이 수정되었습니다."));
   });
 
   it("POLICY_NOT_EDITABLE 에러 시 전용 안내 메시지를 표시한다", async () => {

--- a/frontend/src/features/update-policy/api/messages.ts
+++ b/frontend/src/features/update-policy/api/messages.ts
@@ -1,10 +1,10 @@
 export const POLICY_ERROR_MESSAGES = {
-  POLICY_NOT_EDITABLE: "DRAFT 상태의 버전에서만 정책을 수정할 수 있습니다.",
+  POLICY_NOT_EDITABLE: "검토 중인 버전에서만 응대 기준을 수정할 수 있습니다.",
   POLICY_CODE_REFERENCED_BY_WORKFLOW:
-    "이 정책을 참조하는 워크플로우가 있어 비활성화할 수 없습니다.",
-  VALIDATION_ERROR: "정책 데이터 검증에 실패했습니다. 입력값을 확인해주세요.",
-  NOT_FOUND: "정책을 찾을 수 없습니다.",
-  UPDATE_FAILED: "정책 수정에 실패했습니다.",
-  STATUS_FAILED: "정책 상태 변경에 실패했습니다.",
-  LOAD_FAILED: "정책 정보를 불러오지 못했습니다.",
+    "이 응대 기준을 참조하는 응대 흐름이 있어 비활성화할 수 없습니다.",
+  VALIDATION_ERROR: "응대 기준 데이터 검증에 실패했습니다. 입력값을 확인해주세요.",
+  NOT_FOUND: "응대 기준을 찾을 수 없습니다.",
+  UPDATE_FAILED: "응대 기준 수정에 실패했습니다.",
+  STATUS_FAILED: "응대 기준 상태 변경에 실패했습니다.",
+  LOAD_FAILED: "응대 기준 정보를 불러오지 못했습니다.",
 } as const;

--- a/frontend/src/features/update-policy/api/useUpdatePolicy.ts
+++ b/frontend/src/features/update-policy/api/useUpdatePolicy.ts
@@ -43,7 +43,7 @@ export function useUpdatePolicy() {
               : item,
           ),
       );
-      toast.success("정책이 수정되었습니다.");
+      toast.success("응대 기준이 수정되었습니다.");
     },
     onError: (error: unknown) => {
       if (error instanceof ApiRequestError) {

--- a/frontend/src/features/update-policy/api/useUpdatePolicyStatus.ts
+++ b/frontend/src/features/update-policy/api/useUpdatePolicyStatus.ts
@@ -34,7 +34,7 @@ export function useUpdatePolicyStatus() {
       const res = await updatePolicyStatus(workspaceId, packId, versionId, policyId, { status });
       return requireApiData<PolicyDefinitionResponse>(
         res,
-        "정책 상태 변경 응답을 확인할 수 없습니다.",
+        "응대 기준 상태 변경 응답을 확인할 수 없습니다.",
       );
     },
     onMutate: async ({ workspaceId, packId, versionId, policyId, status }) => {

--- a/frontend/src/features/update-policy/model/schema.test.ts
+++ b/frontend/src/features/update-policy/model/schema.test.ts
@@ -30,7 +30,7 @@ describe("policyEditSchema", () => {
 
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error.issues[0]?.message).toBe("조건 JSON은 객체여야 합니다.");
+      expect(result.error.issues[0]?.message).toBe("적용 조건 JSON은 객체여야 합니다.");
     }
   });
 
@@ -54,7 +54,7 @@ describe("policyEditSchema", () => {
 
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error.issues[0]?.message).toBe("액션 JSON은 객체여야 합니다.");
+      expect(result.error.issues[0]?.message).toBe("응대 방법 JSON은 객체여야 합니다.");
     }
   });
 
@@ -66,7 +66,7 @@ describe("policyEditSchema", () => {
 
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error.issues[0]?.message).toBe("메타 JSON은 객체여야 합니다.");
+      expect(result.error.issues[0]?.message).toBe("추가 정보 JSON은 객체여야 합니다.");
     }
   });
 
@@ -78,7 +78,7 @@ describe("policyEditSchema", () => {
 
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error.issues[0]?.message).toBe("조건 JSON은 객체여야 합니다.");
+      expect(result.error.issues[0]?.message).toBe("적용 조건 JSON은 객체여야 합니다.");
     }
   });
 });

--- a/frontend/src/features/update-policy/model/schema.ts
+++ b/frontend/src/features/update-policy/model/schema.ts
@@ -26,13 +26,13 @@ export function jsonArrayString(message: string) {
 }
 
 export const policyEditSchema = z.object({
-  name: z.string().trim().min(1, "정책 이름은 필수입니다."),
+  name: z.string().trim().min(1, "응대 기준 이름은 필수입니다."),
   description: z.string().nullable().optional(),
   severity: z.string().nullable().optional(),
-  conditionJson: jsonObjectString("조건 JSON은 객체여야 합니다."),
-  actionJson: jsonObjectString("액션 JSON은 객체여야 합니다."),
+  conditionJson: jsonObjectString("적용 조건 JSON은 객체여야 합니다."),
+  actionJson: jsonObjectString("응대 방법 JSON은 객체여야 합니다."),
   evidenceJson: jsonArrayString("근거 JSON은 배열이어야 합니다."),
-  metaJson: jsonObjectString("메타 JSON은 객체여야 합니다."),
+  metaJson: jsonObjectString("추가 정보 JSON은 객체여야 합니다."),
 });
 
 export type PolicyEditFormValues = z.infer<typeof policyEditSchema>;

--- a/frontend/src/features/update-policy/ui/PolicyEditForm.tsx
+++ b/frontend/src/features/update-policy/ui/PolicyEditForm.tsx
@@ -113,7 +113,7 @@ export function PolicyEditForm({
                 onValueChange={(value) => field.onChange(value === "NONE" ? null : value)}
               >
                 <FormControl>
-                  <SelectTrigger className="w-full" aria-label="정책 심각도">
+                  <SelectTrigger className="w-full" aria-label="응대 기준 중요도">
                     <SelectValue placeholder="선택 안 함" />
                   </SelectTrigger>
                 </FormControl>
@@ -138,7 +138,7 @@ export function PolicyEditForm({
           )}
         />
 
-        <ReadonlyPolicyValue label="정책 코드" value={policy.policyCode ?? ""} />
+        <ReadonlyPolicyValue label="기준 코드" value={policy.policyCode ?? ""} />
         <ReadonlyPolicyValue label="버전 ID" value={policy.domainPackVersionId ?? 0} />
 
         <PolicyJsonFields />

--- a/frontend/src/features/update-policy/ui/PolicyEditPanel.tsx
+++ b/frontend/src/features/update-policy/ui/PolicyEditPanel.tsx
@@ -37,14 +37,14 @@ export function PolicyEditPanel({
   });
 
   return (
-    <section className={styles.panel} aria-label="정책 수정">
+    <section className={styles.panel} aria-label="응대 기준 수정">
       <header className={styles.header}>
         <div className={styles.headerText}>
-          <span className={styles.eyebrow}>EDIT POLICY</span>
+          <span className={styles.eyebrow}>응대 기준 수정</span>
           <h2 className={styles.title}>
-            {policy ? `${policy.policyCode} · ${policy.name}` : "정책 수정"}
+            {policy ? `${policy.policyCode} · ${policy.name}` : "응대 기준 수정"}
           </h2>
-          <p className={styles.description}>정책 필드와 상태를 수정합니다.</p>
+          <p className={styles.description}>응대 기준 필드와 상태를 수정합니다.</p>
         </div>
         <button
           type="button"

--- a/frontend/src/features/update-policy/ui/PolicyEditSheet.tsx
+++ b/frontend/src/features/update-policy/ui/PolicyEditSheet.tsx
@@ -44,8 +44,10 @@ export function PolicyEditSheet({
     >
       <SheetContent side="right" className="w-full overflow-y-auto sm:max-w-xl">
         <SheetHeader className="px-4 pt-4">
-          <SheetTitle>{policy ? `${policy.policyCode} · ${policy.name}` : "정책 수정"}</SheetTitle>
-          <SheetDescription>정책 필드와 상태를 수정합니다.</SheetDescription>
+          <SheetTitle>
+            {policy ? `${policy.policyCode} · ${policy.name}` : "응대 기준 수정"}
+          </SheetTitle>
+          <SheetDescription>응대 기준 필드와 상태를 수정합니다.</SheetDescription>
         </SheetHeader>
 
         {isLoading && (

--- a/frontend/src/features/update-policy/ui/PolicyStatusToggle.test.tsx
+++ b/frontend/src/features/update-policy/ui/PolicyStatusToggle.test.tsx
@@ -30,7 +30,7 @@ describe("PolicyStatusToggle", () => {
       />,
     );
 
-    expect(screen.getByRole("switch", { name: "정책 상태" })).toBeChecked();
+    expect(screen.getByRole("switch", { name: "응대 기준 상태" })).toBeChecked();
   });
 
   it("상태 변경 시 update mutation을 호출한다", () => {
@@ -44,7 +44,7 @@ describe("PolicyStatusToggle", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("switch", { name: "정책 상태" }));
+    fireEvent.click(screen.getByRole("switch", { name: "응대 기준 상태" }));
 
     expect(mutate).toHaveBeenCalledWith({
       workspaceId: 1,

--- a/frontend/src/features/update-policy/ui/PolicyStatusToggle.tsx
+++ b/frontend/src/features/update-policy/ui/PolicyStatusToggle.tsx
@@ -33,7 +33,7 @@ export function PolicyStatusToggle({
 
   return (
     <Switch
-      aria-label="정책 상태"
+      aria-label="응대 기준 상태"
       checked={currentStatus === "ACTIVE"}
       onCheckedChange={handleCheckedChange}
       disabled={disabled || isPending}

--- a/frontend/src/features/update-risk/api/messages.ts
+++ b/frontend/src/features/update-risk/api/messages.ts
@@ -1,8 +1,8 @@
 export const RISK_ERROR_MESSAGES = {
-  RISK_NOT_EDITABLE: "DRAFT 상태의 버전에서만 위험요소를 수정할 수 있습니다.",
-  VALIDATION_ERROR: "위험요소 데이터 검증에 실패했습니다. 입력값을 확인해주세요.",
-  NOT_FOUND: "위험요소를 찾을 수 없습니다.",
-  UPDATE_FAILED: "위험요소 수정에 실패했습니다.",
-  STATUS_FAILED: "위험요소 상태 변경에 실패했습니다.",
-  LOAD_FAILED: "위험요소 정보를 불러오지 못했습니다.",
+  RISK_NOT_EDITABLE: "검토 중인 버전에서만 주의 사항을 수정할 수 있습니다.",
+  VALIDATION_ERROR: "주의 사항 데이터 검증에 실패했습니다. 입력값을 확인해주세요.",
+  NOT_FOUND: "주의 사항을 찾을 수 없습니다.",
+  UPDATE_FAILED: "주의 사항 수정에 실패했습니다.",
+  STATUS_FAILED: "주의 사항 상태 변경에 실패했습니다.",
+  LOAD_FAILED: "주의 사항 정보를 불러오지 못했습니다.",
 } as const;

--- a/frontend/src/features/update-risk/api/useUpdateRisk.test.ts
+++ b/frontend/src/features/update-risk/api/useUpdateRisk.test.ts
@@ -71,7 +71,7 @@ describe("useUpdateRisk", () => {
       });
     });
 
-    await waitFor(() => expect(toast.success).toHaveBeenCalledWith("위험요소가 수정되었습니다."));
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith("주의 사항이 수정되었습니다."));
   });
 
   it("수정 응답 data가 없으면 성공 처리하지 않고 실패 메시지를 표시한다", async () => {

--- a/frontend/src/features/update-risk/api/useUpdateRisk.ts
+++ b/frontend/src/features/update-risk/api/useUpdateRisk.ts
@@ -25,7 +25,7 @@ export function useUpdateRisk() {
       const res = await updateRisk(workspaceId, packId, versionId, riskId, body);
       return requireApiData<RiskDefinitionResponse>(
         res,
-        "위험요소 수정 응답을 확인할 수 없습니다.",
+        "주의 사항 수정 응답을 확인할 수 없습니다.",
       );
     },
     onSuccess: (updatedRisk, { workspaceId, packId, versionId, riskId }) => {
@@ -49,7 +49,7 @@ export function useUpdateRisk() {
               : item,
           ),
       );
-      toast.success("위험요소가 수정되었습니다.");
+      toast.success("주의 사항이 수정되었습니다.");
     },
     onError: (error: unknown) => {
       if (error instanceof ApiRequestError) {

--- a/frontend/src/features/update-risk/model/schema.test.ts
+++ b/frontend/src/features/update-risk/model/schema.test.ts
@@ -35,7 +35,7 @@ describe("riskEditSchema", () => {
 
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error.issues[0]?.message).toBe("트리거 조건 JSON은 객체여야 합니다.");
+      expect(result.error.issues[0]?.message).toBe("감지 조건 JSON은 객체여야 합니다.");
     }
   });
 
@@ -47,7 +47,7 @@ describe("riskEditSchema", () => {
 
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error.issues[0]?.message).toBe("처리 액션 JSON은 객체여야 합니다.");
+      expect(result.error.issues[0]?.message).toBe("응대 방법 JSON은 객체여야 합니다.");
     }
   });
 
@@ -71,7 +71,7 @@ describe("riskEditSchema", () => {
 
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error.issues[0]?.message).toBe("메타 JSON은 객체여야 합니다.");
+      expect(result.error.issues[0]?.message).toBe("추가 정보 JSON은 객체여야 합니다.");
     }
   });
 });

--- a/frontend/src/features/update-risk/model/schema.ts
+++ b/frontend/src/features/update-risk/model/schema.ts
@@ -5,13 +5,13 @@ import { jsonArrayString, jsonObjectString } from "@/shared/lib/jsonSchema";
 export const riskLevelSchema = z.enum(["LOW", "MEDIUM", "HIGH", "CRITICAL"]);
 
 export const riskEditSchema = z.object({
-  name: z.string().trim().min(1, "위험요소 이름은 필수입니다."),
+  name: z.string().trim().min(1, "주의 사항 이름은 필수입니다."),
   description: z.string().nullable().optional(),
   riskLevel: riskLevelSchema,
-  triggerConditionJson: jsonObjectString("트리거 조건 JSON은 객체여야 합니다."),
-  handlingActionJson: jsonObjectString("처리 액션 JSON은 객체여야 합니다."),
+  triggerConditionJson: jsonObjectString("감지 조건 JSON은 객체여야 합니다."),
+  handlingActionJson: jsonObjectString("응대 방법 JSON은 객체여야 합니다."),
   evidenceJson: jsonArrayString("근거 JSON은 배열이어야 합니다."),
-  metaJson: jsonObjectString("메타 JSON은 객체여야 합니다."),
+  metaJson: jsonObjectString("추가 정보 JSON은 객체여야 합니다."),
 });
 
 export type RiskEditFormValues = z.infer<typeof riskEditSchema>;

--- a/frontend/src/features/update-risk/ui/RiskEditForm.tsx
+++ b/frontend/src/features/update-risk/ui/RiskEditForm.tsx
@@ -105,7 +105,7 @@ export function RiskEditForm({
               <FormLabel>위험도 *</FormLabel>
               <Select value={field.value} onValueChange={field.onChange}>
                 <FormControl>
-                  <SelectTrigger className="w-full" aria-label="위험요소 위험도">
+                  <SelectTrigger className="w-full" aria-label="주의 사항 수준">
                     <SelectValue placeholder="위험도 선택" />
                   </SelectTrigger>
                 </FormControl>
@@ -126,7 +126,7 @@ export function RiskEditForm({
           )}
         />
 
-        <ReadonlyRiskValue label="위험요소 코드" value={risk.riskCode ?? ""} />
+        <ReadonlyRiskValue label="주의 코드" value={risk.riskCode ?? ""} />
         <ReadonlyRiskValue label="버전 ID" value={risk.domainPackVersionId ?? 0} />
 
         <RiskJsonFields />

--- a/frontend/src/features/update-risk/ui/RiskEditPanel.tsx
+++ b/frontend/src/features/update-risk/ui/RiskEditPanel.tsx
@@ -41,14 +41,14 @@ export function RiskEditPanel({
   const showEmptyState = !isLoading && !isError && !hasRisk;
 
   return (
-    <section className={styles.panel} aria-label="위험요소 수정">
+    <section className={styles.panel} aria-label="주의 사항 수정">
       <header className={styles.header}>
         <div className={styles.headerText}>
-          <span className={styles.eyebrow}>EDIT RISK</span>
+          <span className={styles.eyebrow}>주의 사항 수정</span>
           <h2 className={styles.title}>
-            {risk ? `${risk.riskCode} · ${risk.name}` : "위험요소 수정"}
+            {risk ? `${risk.riskCode} · ${risk.name}` : "주의 사항 수정"}
           </h2>
-          <p className={styles.description}>위험요소 필드와 상태를 수정합니다.</p>
+          <p className={styles.description}>주의 사항 필드와 상태를 수정합니다.</p>
         </div>
         <button
           type="button"
@@ -90,7 +90,7 @@ export function RiskEditPanel({
 
       {showEmptyState && (
         <div className={styles.statePanel}>
-          <span>위험요소 정보를 찾을 수 없습니다.</span>
+          <span>주의 사항 정보를 찾을 수 없습니다.</span>
         </div>
       )}
     </section>

--- a/frontend/src/features/update-risk/ui/RiskStatusToggle.test.tsx
+++ b/frontend/src/features/update-risk/ui/RiskStatusToggle.test.tsx
@@ -30,7 +30,7 @@ describe("RiskStatusToggle", () => {
       />,
     );
 
-    expect(screen.getByRole("switch", { name: "위험요소 상태" })).toBeChecked();
+    expect(screen.getByRole("switch", { name: "주의 사항 상태" })).toBeChecked();
   });
 
   it("상태 변경 시 update mutation을 호출한다", () => {
@@ -44,7 +44,7 @@ describe("RiskStatusToggle", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("switch", { name: "위험요소 상태" }));
+    fireEvent.click(screen.getByRole("switch", { name: "주의 사항 상태" }));
 
     expect(mutate).toHaveBeenCalledWith({
       workspaceId: 1,

--- a/frontend/src/features/update-risk/ui/RiskStatusToggle.tsx
+++ b/frontend/src/features/update-risk/ui/RiskStatusToggle.tsx
@@ -33,7 +33,7 @@ export function RiskStatusToggle({
 
   return (
     <Switch
-      aria-label="위험요소 상태"
+      aria-label="주의 사항 상태"
       checked={currentStatus === "ACTIVE"}
       onCheckedChange={handleCheckedChange}
       disabled={disabled || isPending}

--- a/frontend/src/features/update-slot/api/__tests__/useUpdateSlot.test.ts
+++ b/frontend/src/features/update-slot/api/__tests__/useUpdateSlot.test.ts
@@ -90,7 +90,7 @@ describe("useUpdateSlot", () => {
       result.current.mutate({ ...params, body: { name: "새 이름" } });
     });
 
-    await waitFor(() => expect(toast.success).toHaveBeenCalledWith("슬롯이 수정되었습니다."));
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith("확인 항목이 수정되었습니다."));
   });
 
   it("SLOT_NOT_EDITABLE 에러 시 전용 안내 메시지를 toast.error로 표시한다", async () => {

--- a/frontend/src/features/update-slot/api/messages.ts
+++ b/frontend/src/features/update-slot/api/messages.ts
@@ -1,6 +1,6 @@
 export const SLOT_ERROR_MESSAGES = {
-  SLOT_NOT_EDITABLE: "DRAFT 상태의 버전에서만 수정할 수 있습니다.",
-  NOT_FOUND: "슬롯을 찾을 수 없습니다.",
-  UPDATE_FAILED: "슬롯 수정에 실패했습니다.",
+  SLOT_NOT_EDITABLE: "검토 중인 버전에서만 확인 항목을 수정할 수 있습니다.",
+  NOT_FOUND: "확인 항목을 찾을 수 없습니다.",
+  UPDATE_FAILED: "확인 항목 수정에 실패했습니다.",
   STATUS_FAILED: "상태 변경에 실패했습니다.",
 } as const;

--- a/frontend/src/features/update-slot/api/useUpdateSlot.ts
+++ b/frontend/src/features/update-slot/api/useUpdateSlot.ts
@@ -27,7 +27,7 @@ export function useUpdateSlot() {
       queryClient.invalidateQueries({
         queryKey: slotQueryKeys.list(workspaceId, packId, versionId),
       });
-      toast.success("슬롯이 수정되었습니다.");
+      toast.success("확인 항목이 수정되었습니다.");
     },
     onError: (error: unknown) => {
       if (error instanceof ApiRequestError && error.code === "SLOT_NOT_EDITABLE") {

--- a/frontend/src/features/update-slot/model/schema.ts
+++ b/frontend/src/features/update-slot/model/schema.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 export const slotEditSchema = z.object({
-  name: z.string().trim().min(1, "슬롯 이름은 필수입니다."),
+  name: z.string().trim().min(1, "확인 항목 이름은 필수입니다."),
   description: z.string().nullable().optional(),
   isSensitive: z.boolean().optional(),
   validationRuleJson: z.string().nullable().optional(),

--- a/frontend/src/features/update-slot/ui/SlotEditForm.tsx
+++ b/frontend/src/features/update-slot/ui/SlotEditForm.tsx
@@ -84,7 +84,7 @@ export function SlotEditForm({ slot, workspaceId, packId, versionId, onClose }: 
         </div>
 
         <div className="grid gap-2">
-          <span className="text-sm font-medium leading-none">슬롯 코드</span>
+          <span className="text-sm font-medium leading-none">항목 코드</span>
           <Input value={slot.slotCode} readOnly disabled />
         </div>
 

--- a/frontend/src/features/update-slot/ui/SlotEditSheet.tsx
+++ b/frontend/src/features/update-slot/ui/SlotEditSheet.tsx
@@ -43,8 +43,8 @@ export function SlotEditSheet({
     >
       <SheetContent side="right" className="w-full sm:max-w-md overflow-y-auto">
         <SheetHeader className="px-4 pt-4">
-          <SheetTitle>{slot ? `${slot.slotCode} · ${slot.name}` : "슬롯 수정"}</SheetTitle>
-          <SheetDescription>슬롯 필드와 상태를 수정합니다.</SheetDescription>
+          <SheetTitle>{slot ? `${slot.slotCode} · ${slot.name}` : "확인 항목 수정"}</SheetTitle>
+          <SheetDescription>확인 항목 필드와 상태를 수정합니다.</SheetDescription>
         </SheetHeader>
 
         {isLoading && (
@@ -55,7 +55,7 @@ export function SlotEditSheet({
 
         {isError && (
           <div className="flex flex-col items-center justify-center gap-4 py-12 px-4 text-sm text-muted-foreground">
-            <span>슬롯 정보를 불러오지 못했습니다.</span>
+            <span>확인 항목 정보를 불러오지 못했습니다.</span>
             <Button variant="outline" size="sm" onClick={() => refetch()}>
               다시 시도
             </Button>

--- a/frontend/src/features/update-slot/ui/SlotStatusToggle.tsx
+++ b/frontend/src/features/update-slot/ui/SlotStatusToggle.tsx
@@ -32,7 +32,7 @@ export function SlotStatusToggle({
 
   return (
     <Switch
-      aria-label="슬롯 상태"
+      aria-label="확인 항목 상태"
       checked={currentStatus === "ACTIVE"}
       onCheckedChange={handleCheckedChange}
       disabled={disabled || isPending}

--- a/frontend/src/features/update-workflow/api/useUpdateWorkflow.test.ts
+++ b/frontend/src/features/update-workflow/api/useUpdateWorkflow.test.ts
@@ -80,7 +80,7 @@ describe("useUpdateWorkflow", () => {
       await result.current.mutateAsync(mutateParams);
     });
 
-    expect(toast.success).toHaveBeenCalledWith("워크플로우가 수정되었습니다.");
+    expect(toast.success).toHaveBeenCalledWith("응대 흐름이 수정되었습니다.");
   });
 
   it("알려진 에러 코드 WORKFLOW_NOT_EDITABLE에 대해 매핑된 메시지를 표시한다", async () => {
@@ -96,7 +96,9 @@ describe("useUpdateWorkflow", () => {
     });
 
     await waitFor(() =>
-      expect(toast.error).toHaveBeenCalledWith("DRAFT 상태의 버전에서만 수정할 수 있습니다."),
+      expect(toast.error).toHaveBeenCalledWith(
+        "검토 중인 버전에서만 응대 흐름을 수정할 수 있습니다.",
+      ),
     );
   });
 
@@ -145,7 +147,7 @@ describe("useUpdateWorkflow", () => {
     });
 
     await waitFor(() =>
-      expect(toast.error).toHaveBeenCalledWith("워크플로우 수정에 실패했습니다."),
+      expect(toast.error).toHaveBeenCalledWith("응대 흐름 수정에 실패했습니다."),
     );
   });
 });

--- a/frontend/src/features/update-workflow/api/useUpdateWorkflow.ts
+++ b/frontend/src/features/update-workflow/api/useUpdateWorkflow.ts
@@ -13,7 +13,7 @@ interface UpdateWorkflowParams {
 }
 
 const ERROR_MESSAGES: Record<string, string> = {
-  WORKFLOW_NOT_EDITABLE: "DRAFT 상태의 버전에서만 수정할 수 있습니다.",
+  WORKFLOW_NOT_EDITABLE: "검토 중인 버전에서만 응대 흐름을 수정할 수 있습니다.",
   GRAPH_JSON_REQUIRED: "그래프 데이터가 필요합니다.",
   GRAPH_JSON_TOO_LARGE: "그래프 데이터가 너무 큽니다.",
   WORKFLOW_GRAPH_JSON_INVALID: "그래프 데이터 형식이 유효하지 않습니다.",
@@ -23,11 +23,11 @@ const ERROR_MESSAGES: Record<string, string> = {
   WORKFLOW_UNREACHABLE_NODE: "모든 노드가 START에서 도달 가능해야 합니다.",
   WORKFLOW_CYCLE_DETECTED: "그래프에 순환 경로가 있습니다.",
   WORKFLOW_UNLABELED_BRANCH: "DECISION 노드의 모든 분기에 label이 필요합니다.",
-  WORKFLOW_ACTION_NODE_POLICY_REF_MISSING: "ACTION 노드의 policyRef 값이 필요합니다.",
+  WORKFLOW_ACTION_NODE_POLICY_REF_MISSING: "ACTION 노드의 응대 기준 참조값이 필요합니다.",
   WORKFLOW_ACTION_NODE_POLICY_REF_INVALID_CHARS:
-    "ACTION 노드의 policyRef 형식이 유효하지 않습니다.",
+    "ACTION 노드의 응대 기준 참조 형식이 유효하지 않습니다.",
   WORKFLOW_ACTION_NODE_POLICY_REF_NOT_FOUND:
-    "ACTION 노드의 policyRef가 이 버전에 존재하지 않습니다.",
+    "ACTION 노드가 참조하는 응대 기준이 이 버전에 존재하지 않습니다.",
   WORKFLOW_EDGE_ID_MISSING: "그래프 구조가 유효하지 않습니다.",
   WORKFLOW_EDGE_ID_DUPLICATE: "그래프 구조가 유효하지 않습니다.",
 };
@@ -46,12 +46,12 @@ export function useUpdateWorkflow() {
       queryClient.invalidateQueries({
         queryKey: workflowQueryKeys.list(wsId, packId, versionId),
       });
-      toast.success("워크플로우가 수정되었습니다.");
+      toast.success("응대 흐름이 수정되었습니다.");
     },
     onError: (error: unknown) => {
       const code = error instanceof ApiRequestError ? error.code : "";
       const message = error instanceof ApiRequestError ? error.message : "";
-      toast.error((ERROR_MESSAGES[code] ?? message) || "워크플로우 수정에 실패했습니다.");
+      toast.error((ERROR_MESSAGES[code] ?? message) || "응대 흐름 수정에 실패했습니다.");
     },
   });
 }

--- a/frontend/src/features/update-workflow/model/schema.ts
+++ b/frontend/src/features/update-workflow/model/schema.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 export const workflowEditSchema = z.object({
-  name: z.string().trim().min(1, "워크플로우 이름은 필수입니다."),
+  name: z.string().trim().min(1, "응대 흐름 이름은 필수입니다."),
   description: z.string().nullable().optional(),
 });
 

--- a/frontend/src/features/update-workflow/ui/WorkflowEditForm.test.tsx
+++ b/frontend/src/features/update-workflow/ui/WorkflowEditForm.test.tsx
@@ -32,7 +32,7 @@ const mockedUseUpdateWorkflow = vi.mocked(useUpdateWorkflow);
 const stubWorkflow = {
   id: 10,
   workflowCode: "WF-REFUND-01",
-  name: "환불 처리 워크플로우",
+  name: "환불 처리 응대 흐름",
   description: "표준 환불 처리 절차",
   graphJson: JSON.stringify({ direction: "LR", nodes: [], edges: [] }),
   createdAt: "2025-01-01T00:00:00+09:00",
@@ -96,7 +96,7 @@ describe("WorkflowEditForm", () => {
 
   it("renders workflow name and description in form fields", () => {
     renderForm();
-    expect(screen.getByDisplayValue("환불 처리 워크플로우")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("환불 처리 응대 흐름")).toBeInTheDocument();
     expect(screen.getByDisplayValue("표준 환불 처리 절차")).toBeInTheDocument();
   });
 
@@ -131,8 +131,8 @@ describe("WorkflowEditForm", () => {
 
   it("calls mutate on form submit with updated values", async () => {
     renderForm();
-    const nameInput = screen.getByDisplayValue("환불 처리 워크플로우");
-    fireEvent.change(nameInput, { target: { value: "수정된 워크플로우" } });
+    const nameInput = screen.getByDisplayValue("환불 처리 응대 흐름");
+    fireEvent.change(nameInput, { target: { value: "수정된 응대 흐름" } });
     fireEvent.click(screen.getByRole("button", { name: "저장" }));
     await waitFor(() => expect(mutateWorkflow).toHaveBeenCalled());
     expect(mutateWorkflow).toHaveBeenCalledWith(
@@ -141,7 +141,7 @@ describe("WorkflowEditForm", () => {
         packId: 2,
         versionId: 3,
         workflowId: 10,
-        body: expect.objectContaining({ name: "수정된 워크플로우" }),
+        body: expect.objectContaining({ name: "수정된 응대 흐름" }),
       }),
       expect.objectContaining({ onSuccess: expect.any(Function) }),
     );
@@ -154,8 +154,8 @@ describe("WorkflowEditForm", () => {
       options?.onSuccess?.();
     });
     renderForm({ onSaved, onDirtyChange });
-    const nameInput = screen.getByDisplayValue("환불 처리 워크플로우");
-    fireEvent.change(nameInput, { target: { value: "수정된 워크플로우" } });
+    const nameInput = screen.getByDisplayValue("환불 처리 응대 흐름");
+    fireEvent.change(nameInput, { target: { value: "수정된 응대 흐름" } });
 
     await waitFor(() => expect(onDirtyChange).toHaveBeenCalledWith(true));
     fireEvent.click(screen.getByRole("button", { name: "저장" }));
@@ -176,11 +176,11 @@ describe("WorkflowEditForm", () => {
 
   it("shows validation error when name is cleared", async () => {
     renderForm();
-    const nameInput = screen.getByDisplayValue("환불 처리 워크플로우");
+    const nameInput = screen.getByDisplayValue("환불 처리 응대 흐름");
     fireEvent.change(nameInput, { target: { value: "" } });
     fireEvent.click(screen.getByRole("button", { name: "저장" }));
     await waitFor(() => {
-      expect(screen.getByText("워크플로우 이름은 필수입니다.")).toBeInTheDocument();
+      expect(screen.getByText("응대 흐름 이름은 필수입니다.")).toBeInTheDocument();
     });
     expect(mutateWorkflow).not.toHaveBeenCalled();
   });

--- a/frontend/src/features/update-workflow/ui/WorkflowEditForm.tsx
+++ b/frontend/src/features/update-workflow/ui/WorkflowEditForm.tsx
@@ -167,7 +167,7 @@ export function WorkflowEditForm({
                 id="wf-name"
                 {...field}
                 className={styles.fieldInput}
-                placeholder="워크플로우 이름"
+                placeholder="응대 흐름 이름"
                 aria-invalid={errors.name ? "true" : "false"}
                 data-testid="workflow-edit-name"
               />
@@ -182,7 +182,7 @@ export function WorkflowEditForm({
 
         <div className={styles.field}>
           <label className={styles.fieldLabel} htmlFor="wf-code">
-            워크플로우 코드
+            응대 코드
           </label>
           <input
             id="wf-code"
@@ -210,7 +210,7 @@ export function WorkflowEditForm({
                 name={field.name}
                 ref={field.ref}
                 className={styles.fieldInput}
-                placeholder="이 워크플로우의 목적을 한 줄로 설명"
+                placeholder="이 응대 흐름의 목적을 한 줄로 설명"
                 data-testid="workflow-edit-description"
               />
             )}

--- a/frontend/src/features/update-workflow/ui/WorkflowEditSheet.test.tsx
+++ b/frontend/src/features/update-workflow/ui/WorkflowEditSheet.test.tsx
@@ -110,7 +110,7 @@ describe("WorkflowEditSheet", () => {
       refetch: vi.fn(),
     } as unknown as ReturnType<typeof useGetWorkflow>);
     render(<WorkflowEditSheet {...makeProps()} />);
-    expect(screen.getByText("워크플로우 정보를 불러오지 못했습니다.")).toBeInTheDocument();
+    expect(screen.getByText("응대 흐름 정보를 불러오지 못했습니다.")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "다시 시도" })).toBeInTheDocument();
   });
 
@@ -157,7 +157,7 @@ describe("WorkflowEditSheet", () => {
       refetch: vi.fn(),
     } as unknown as ReturnType<typeof useGetWorkflow>);
     render(<WorkflowEditSheet {...makeProps()} />);
-    expect(screen.getByText("워크플로우 수정")).toBeInTheDocument();
+    expect(screen.getByText("응대 흐름 수정")).toBeInTheDocument();
   });
 
   it("Sheet onOpenChange(!open) 시 onClose가 호출된다", () => {

--- a/frontend/src/features/update-workflow/ui/WorkflowEditSheet.tsx
+++ b/frontend/src/features/update-workflow/ui/WorkflowEditSheet.tsx
@@ -38,9 +38,9 @@ export function WorkflowEditSheet({
       <SheetContent side="right" className="w-full sm:max-w-4xl overflow-y-auto flex flex-col">
         <SheetHeader className="px-4 pt-4">
           <SheetTitle>
-            {workflow ? `${workflow.workflowCode} · ${workflow.name}` : "워크플로우 수정"}
+            {workflow ? `${workflow.workflowCode} · ${workflow.name}` : "응대 흐름 수정"}
           </SheetTitle>
-          <SheetDescription>워크플로우 이름, 설명, 그래프를 수정합니다.</SheetDescription>
+          <SheetDescription>응대 흐름 이름, 설명, 흐름도를 수정합니다.</SheetDescription>
         </SheetHeader>
 
         {isLoading && (
@@ -51,7 +51,7 @@ export function WorkflowEditSheet({
 
         {isError && (
           <div className="flex flex-col items-center justify-center gap-4 py-12 px-4 text-sm text-muted-foreground">
-            <span>워크플로우 정보를 불러오지 못했습니다.</span>
+            <span>응대 흐름 정보를 불러오지 못했습니다.</span>
             <Button variant="outline" size="sm" onClick={() => refetch()}>
               다시 시도
             </Button>

--- a/frontend/src/features/update-workflow/ui/nodes/EditableActionNode.tsx
+++ b/frontend/src/features/update-workflow/ui/nodes/EditableActionNode.tsx
@@ -53,8 +53,8 @@ export function EditableActionNode({ id, data, selected }: NodeProps) {
             onFocus={policyRef.onFocus}
             onBlur={policyRef.onBlur}
             size={chipInputSize(policyRef.value)}
-            placeholder="policyRef"
-            aria-label="정책 참조 코드"
+            placeholder="응대 기준 코드"
+            aria-label="응대 기준 참조 코드"
           />
         }
         containerTestId="editable-action-node"

--- a/frontend/src/features/update-workflow/ui/nodes/EditableNodes.test.tsx
+++ b/frontend/src/features/update-workflow/ui/nodes/EditableNodes.test.tsx
@@ -83,7 +83,7 @@ describe("EditableActionNode", () => {
       />,
     );
     expect(screen.getByLabelText("노드 이름")).toHaveValue("처리");
-    expect(screen.getByLabelText("정책 참조 코드")).toHaveValue("PR-001");
+    expect(screen.getByLabelText("응대 기준 참조 코드")).toHaveValue("PR-001");
   });
 
   it("renders container testid", () => {
@@ -96,7 +96,7 @@ describe("EditableActionNode", () => {
     render(
       <EditableActionNode {...baseProps} type="action" data={{ label: "x", policyRef: "" }} />,
     );
-    const input = screen.getByLabelText("정책 참조 코드");
+    const input = screen.getByLabelText("응대 기준 참조 코드");
     fireEvent.focus(input);
     fireEvent.change(input, { target: { value: "PR-NEW" } });
     fireEvent.blur(input);

--- a/frontend/src/features/workflow-draft-read/ui/TransitionPopover.test.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/TransitionPopover.test.tsx
@@ -27,20 +27,20 @@ const stubPolicy: PolicySummary = {
 } as any;
 
 describe("TransitionPopover", () => {
-  it("transition 기본 정보를 표시한다", () => {
+  it("전환 조건 기본 정보를 표시한다", () => {
     render(<TransitionPopover transition={stubTransition} policy={null} onClose={vi.fn()} />);
-    expect(screen.getByRole("dialog", { name: "transition 상세" })).toBeInTheDocument();
+    expect(screen.getByRole("dialog", { name: "전환 조건 상세" })).toBeInTheDocument();
     expect(screen.getByText("STATE_A → STATE_B")).toBeInTheDocument();
     expect(screen.getByText("조건A")).toBeInTheDocument();
   });
 
-  it("policy가 있으면 policy 섹션을 표시한다", () => {
+  it("응대 기준이 있으면 응대 기준 섹션을 표시한다", () => {
     render(<TransitionPopover transition={stubTransition} policy={stubPolicy} onClose={vi.fn()} />);
     expect(screen.getByText("정책 이름")).toBeInTheDocument();
     expect(screen.getByText("정책 설명")).toBeInTheDocument();
   });
 
-  it("policy=null이면 policy 섹션을 표시하지 않는다", () => {
+  it("응대 기준이 없으면 응대 기준 섹션을 표시하지 않는다", () => {
     render(<TransitionPopover transition={stubTransition} policy={null} onClose={vi.fn()} />);
     expect(screen.queryByText("정책 이름")).not.toBeInTheDocument();
   });
@@ -69,6 +69,6 @@ describe("TransitionPopover", () => {
   it("label=null이면 label 섹션을 표시하지 않는다", () => {
     const noLabel = { ...stubTransition, label: null } as any;
     render(<TransitionPopover transition={noLabel} policy={null} onClose={vi.fn()} />);
-    expect(screen.queryByText("Label")).not.toBeInTheDocument();
+    expect(screen.queryByText("조건 이름")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/features/workflow-draft-read/ui/TransitionPopover.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/TransitionPopover.tsx
@@ -31,7 +31,7 @@ export function TransitionPopover({ transition, policy, onClose }: TransitionPop
   }, [onClose]);
 
   return (
-    <div ref={ref} className={styles.popover} role="dialog" aria-label="transition 상세">
+    <div ref={ref} className={styles.popover} role="dialog" aria-label="전환 조건 상세">
       <div className={styles.header}>
         <span className={styles.id}>{transition.id}</span>
         <button type="button" className={styles.closeButton} onClick={onClose} aria-label="닫기">
@@ -40,7 +40,7 @@ export function TransitionPopover({ transition, policy, onClose }: TransitionPop
       </div>
 
       <div className={styles.field}>
-        <span className={styles.label}>Route</span>
+        <span className={styles.label}>이동 경로</span>
         <span className={styles.value}>
           {transition.from} → {transition.to}
         </span>
@@ -48,14 +48,14 @@ export function TransitionPopover({ transition, policy, onClose }: TransitionPop
 
       {transition.label != null && (
         <div className={styles.field}>
-          <span className={styles.label}>Label</span>
+          <span className={styles.label}>조건 이름</span>
           <span className={styles.badge}>{transition.label}</span>
         </div>
       )}
 
       {policy != null && (
         <div className={styles.policySection}>
-          <span className={styles.label}>Policy</span>
+          <span className={styles.label}>응대 기준</span>
           <span className={styles.policyName}>{policy.name}</span>
           {policy.description && <span className={styles.policyDesc}>{policy.description}</span>}
         </div>

--- a/frontend/src/features/workflow-draft-read/ui/WorkflowDetailPanel.test.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/WorkflowDetailPanel.test.tsx
@@ -47,7 +47,7 @@ const mockedUseListPolicies = vi.mocked(useListPolicies);
 const stubDetail = {
   id: 10,
   workflowCode: "W001",
-  name: "테스트 워크플로우",
+  name: "테스트 응대 흐름",
   description: "설명입니다",
   graphJson: { direction: "LR" as const, nodes: [], edges: [] },
   initialState: "START",
@@ -91,7 +91,7 @@ describe("WorkflowDetailPanel", () => {
     vi.mocked(toast.error).mockReset();
     mockedUseTransitionList.mockReturnValue(stubTransitionResult);
     mockedUseListPolicies.mockReturnValue({
-      data: [{ id: 1, policyCode: "POLICY_001", name: "정책" }],
+      data: [{ id: 1, policyCode: "POLICY_001", name: "응대 기준" }],
       isLoading: false,
       isError: false,
       error: null,
@@ -107,7 +107,7 @@ describe("WorkflowDetailPanel", () => {
       refetch: vi.fn(),
     } as unknown as ReturnType<typeof useWorkflowDetail>);
     renderPanel({ workflowId: null });
-    expect(screen.getByText("좌측 목록에서 workflow를 선택해 주세요.")).toBeInTheDocument();
+    expect(screen.getByText("좌측 목록에서 응대 흐름을 선택해 주세요.")).toBeInTheDocument();
   });
 
   it("loading 상태에서는 skeleton 영역을 렌더링한다", () => {
@@ -119,7 +119,7 @@ describe("WorkflowDetailPanel", () => {
       refetch: vi.fn(),
     } as unknown as ReturnType<typeof useWorkflowDetail>);
     renderPanel();
-    expect(screen.getByRole("region", { name: "workflow 상세" })).toBeInTheDocument();
+    expect(screen.getByRole("region", { name: "응대 흐름 상세" })).toBeInTheDocument();
   });
 
   it("error 상태에서는 에러 메시지와 재시도 버튼을 보여준다", async () => {
@@ -144,7 +144,7 @@ describe("WorkflowDetailPanel", () => {
     await waitFor(() => expect(toast.error).toHaveBeenCalledWith("서버 오류"));
   });
 
-  it("404 error 시 워크플로우 미존재 메시지로 toast를 호출한다", async () => {
+  it("404 error 시 응대 흐름 미존재 메시지로 toast를 호출한다", async () => {
     const err = new ApiRequestError(404, "NOT_FOUND", "없음");
     mockedUseWorkflowDetail.mockReturnValue({
       data: undefined,
@@ -154,7 +154,7 @@ describe("WorkflowDetailPanel", () => {
       refetch: vi.fn(),
     } as unknown as ReturnType<typeof useWorkflowDetail>);
     renderPanel();
-    await waitFor(() => expect(toast.error).toHaveBeenCalledWith("workflow를 찾을 수 없습니다."));
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith("응대 흐름을 찾을 수 없습니다."));
   });
 
   it("성공 상태에서는 헤더 정보와 탭 목록을 보여준다", () => {
@@ -167,13 +167,13 @@ describe("WorkflowDetailPanel", () => {
     } as unknown as ReturnType<typeof useWorkflowDetail>);
     renderPanel();
     expect(screen.getByText("W001")).toBeInTheDocument();
-    expect(screen.getByText("테스트 워크플로우")).toBeInTheDocument();
-    expect(screen.getByRole("tab", { name: "Graph" })).toBeInTheDocument();
+    expect(screen.getByText("테스트 응대 흐름")).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "흐름도" })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "JSON" })).toBeInTheDocument();
-    expect(screen.getByRole("tab", { name: "Meta" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "상세 정보" })).toBeInTheDocument();
   });
 
-  it("정책 목록 조회 중이면 graph 탭에 loading 상태를 보여준다", () => {
+  it("응대 기준 목록 조회 중이면 흐름도 탭에 loading 상태를 보여준다", () => {
     mockedUseWorkflowDetail.mockReturnValue({
       data: stubDetail,
       isLoading: false,
@@ -190,10 +190,12 @@ describe("WorkflowDetailPanel", () => {
 
     renderPanel();
 
-    expect(screen.getByRole("status")).toHaveTextContent("정책 목록을 불러오는 중입니다.");
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "응대 기준 목록을 불러오는 중입니다.",
+    );
   });
 
-  it("정책 목록 조회 실패 시 toast와 error 상태를 보여준다", async () => {
+  it("응대 기준 목록 조회 실패 시 toast와 error 상태를 보여준다", async () => {
     mockedUseWorkflowDetail.mockReturnValue({
       data: stubDetail,
       isLoading: false,
@@ -205,16 +207,16 @@ describe("WorkflowDetailPanel", () => {
       data: undefined,
       isLoading: false,
       isError: true,
-      error: new ApiRequestError(500, "SERVER_ERROR", "정책 오류"),
+      error: new ApiRequestError(500, "SERVER_ERROR", "응대 기준 오류"),
     } as unknown as ReturnType<typeof useListPolicies>);
 
     renderPanel();
 
-    expect(screen.getByRole("alert")).toHaveTextContent("정책 목록을 불러오지 못했습니다.");
-    await waitFor(() => expect(toast.error).toHaveBeenCalledWith("정책 오류"));
+    expect(screen.getByRole("alert")).toHaveTextContent("응대 기준 목록을 불러오지 못했습니다.");
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith("응대 기준 오류"));
   });
 
-  it("정책 목록이 비어 있으면 empty 상태를 보여준다", () => {
+  it("응대 기준 목록이 비어 있으면 empty 상태를 보여준다", () => {
     mockedUseWorkflowDetail.mockReturnValue({
       data: stubDetail,
       isLoading: false,
@@ -231,7 +233,7 @@ describe("WorkflowDetailPanel", () => {
 
     renderPanel();
 
-    expect(screen.getByText("참조할 정책이 없습니다.")).toBeInTheDocument();
+    expect(screen.getByText("참조할 응대 기준이 없습니다.")).toBeInTheDocument();
   });
 
   it("JSON 탭 클릭 시 tabpanel이 활성화된다", () => {
@@ -248,7 +250,7 @@ describe("WorkflowDetailPanel", () => {
     expect(jsonTab).toHaveAttribute("aria-selected", "true");
   });
 
-  it("Meta 탭 클릭 시 initialState와 terminalStates를 표시한다", () => {
+  it("상세 정보 탭 클릭 시 initialState와 terminalStates를 표시한다", () => {
     mockedUseWorkflowDetail.mockReturnValue({
       data: stubDetail,
       isLoading: false,
@@ -257,9 +259,9 @@ describe("WorkflowDetailPanel", () => {
       refetch: vi.fn(),
     } as unknown as ReturnType<typeof useWorkflowDetail>);
     renderPanel();
-    fireEvent.click(screen.getByRole("tab", { name: "Meta" }));
-    expect(screen.getByText("Initial State")).toBeInTheDocument();
-    expect(screen.getByText("Terminal States")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("tab", { name: "상세 정보" }));
+    expect(screen.getByText("시작 상태")).toBeInTheDocument();
+    expect(screen.getByText("종료 상태")).toBeInTheDocument();
     expect(screen.getByText("START")).toBeInTheDocument();
     expect(screen.getByText("DONE")).toBeInTheDocument();
   });
@@ -274,11 +276,11 @@ describe("WorkflowDetailPanel", () => {
       refetch: vi.fn(),
     } as unknown as ReturnType<typeof useWorkflowDetail>);
     renderPanel({ onEdit });
-    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+    fireEvent.click(screen.getByRole("button", { name: "수정" }));
     expect(onEdit).toHaveBeenCalledTimes(1);
   });
 
-  it("WORKFLOW_GRAPH_JSON_INVALID 에러 시 graph 손상 메시지로 toast를 호출한다", async () => {
+  it("WORKFLOW_GRAPH_JSON_INVALID 에러 시 흐름도 손상 메시지로 toast를 호출한다", async () => {
     const err = new ApiRequestError(422, "WORKFLOW_GRAPH_JSON_INVALID", "invalid graph");
     mockedUseWorkflowDetail.mockReturnValue({
       data: undefined,
@@ -290,7 +292,7 @@ describe("WorkflowDetailPanel", () => {
     renderPanel();
     await waitFor(() =>
       expect(toast.error).toHaveBeenCalledWith(
-        "graph 데이터가 손상되어 시각화를 표시할 수 없습니다.",
+        "흐름도 데이터가 손상되어 표시할 수 없습니다.",
       ),
     );
   });
@@ -304,11 +306,11 @@ describe("WorkflowDetailPanel", () => {
       refetch: vi.fn(),
     } as unknown as ReturnType<typeof useWorkflowDetail>);
     renderPanel();
-    fireEvent.keyDown(screen.getByRole("tab", { name: "Graph" }), { key: "ArrowRight" });
+    fireEvent.keyDown(screen.getByRole("tab", { name: "흐름도" }), { key: "ArrowRight" });
     expect(screen.getByRole("tab", { name: "JSON" })).toHaveAttribute("aria-selected", "true");
   });
 
-  it("ArrowLeft 키로 이전 탭(Graph)으로 이동한다", () => {
+  it("ArrowLeft 키로 이전 탭(흐름도)으로 이동한다", () => {
     mockedUseWorkflowDetail.mockReturnValue({
       data: stubDetail,
       isLoading: false,
@@ -319,40 +321,46 @@ describe("WorkflowDetailPanel", () => {
     renderPanel();
     fireEvent.click(screen.getByRole("tab", { name: "JSON" }));
     fireEvent.keyDown(screen.getByRole("tab", { name: "JSON" }), { key: "ArrowLeft" });
-    expect(screen.getByRole("tab", { name: "Graph" })).toHaveAttribute("aria-selected", "true");
-  });
-
-  it("Home 키로 첫 번째 탭(Graph)으로 이동한다", () => {
-    mockedUseWorkflowDetail.mockReturnValue({
-      data: stubDetail,
-      isLoading: false,
-      isError: false,
-      error: null,
-      refetch: vi.fn(),
-    } as unknown as ReturnType<typeof useWorkflowDetail>);
-    renderPanel();
-    fireEvent.click(screen.getByRole("tab", { name: "Meta" }));
-    fireEvent.keyDown(screen.getByRole("tab", { name: "Meta" }), { key: "Home" });
-    expect(screen.getByRole("tab", { name: "Graph" })).toHaveAttribute("aria-selected", "true");
-  });
-
-  it("End 키로 마지막 탭(Transitions)으로 이동한다", () => {
-    mockedUseWorkflowDetail.mockReturnValue({
-      data: stubDetail,
-      isLoading: false,
-      isError: false,
-      error: null,
-      refetch: vi.fn(),
-    } as unknown as ReturnType<typeof useWorkflowDetail>);
-    renderPanel();
-    fireEvent.keyDown(screen.getByRole("tab", { name: "Graph" }), { key: "End" });
-    expect(screen.getByRole("tab", { name: "Transitions" })).toHaveAttribute(
+    expect(screen.getByRole("tab", { name: "흐름도" })).toHaveAttribute(
       "aria-selected",
       "true",
     );
   });
 
-  it("Meta 탭 — evidenceJson이 malformed JSON이면 raw 문자열을 표시한다", () => {
+  it("Home 키로 첫 번째 탭(흐름도)으로 이동한다", () => {
+    mockedUseWorkflowDetail.mockReturnValue({
+      data: stubDetail,
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useWorkflowDetail>);
+    renderPanel();
+    fireEvent.click(screen.getByRole("tab", { name: "상세 정보" }));
+    fireEvent.keyDown(screen.getByRole("tab", { name: "상세 정보" }), { key: "Home" });
+    expect(screen.getByRole("tab", { name: "흐름도" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  });
+
+  it("End 키로 마지막 탭(전환 조건)으로 이동한다", () => {
+    mockedUseWorkflowDetail.mockReturnValue({
+      data: stubDetail,
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useWorkflowDetail>);
+    renderPanel();
+    fireEvent.keyDown(screen.getByRole("tab", { name: "흐름도" }), { key: "End" });
+    expect(screen.getByRole("tab", { name: "전환 조건" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  });
+
+  it("상세 정보 탭 — evidenceJson이 malformed JSON이면 raw 문자열을 표시한다", () => {
     const badDetail = { ...stubDetail, evidenceJson: "not-valid-json" };
     mockedUseWorkflowDetail.mockReturnValue({
       data: badDetail,
@@ -362,7 +370,7 @@ describe("WorkflowDetailPanel", () => {
       refetch: vi.fn(),
     } as unknown as ReturnType<typeof useWorkflowDetail>);
     renderPanel();
-    fireEvent.click(screen.getByRole("tab", { name: "Meta" }));
+    fireEvent.click(screen.getByRole("tab", { name: "상세 정보" }));
     expect(screen.getByText("not-valid-json")).toBeInTheDocument();
   });
 });

--- a/frontend/src/features/workflow-draft-read/ui/WorkflowDetailPanel.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/WorkflowDetailPanel.tsx
@@ -18,10 +18,10 @@ type Tab = "graph" | "json" | "meta" | "transitions";
 
 const TABS = ["graph", "json", "meta", "transitions"] as const;
 const TAB_LABELS: Record<Tab, string> = {
-  graph: "Graph",
+  graph: "흐름도",
   json: "JSON",
-  meta: "Meta",
-  transitions: "Transitions",
+  meta: "상세 정보",
+  transitions: "전환 조건",
 };
 
 interface WorkflowDetailPanelProps {
@@ -79,7 +79,7 @@ export function WorkflowDetailPanel({
   const policyErrorMessage =
     policyErr instanceof ApiRequestError
       ? policyErr.message
-      : "정책 목록을 불러오지 못했습니다.";
+      : "응대 기준 목록을 불러오지 못했습니다.";
 
   useEffect(() => {
     if (!policyError) return;
@@ -120,9 +120,9 @@ export function WorkflowDetailPanel({
     if (!isError) return;
     const msg =
       apiErrorStatus === 404
-        ? "workflow를 찾을 수 없습니다."
+        ? "응대 흐름을 찾을 수 없습니다."
         : apiErrorCode === "WORKFLOW_GRAPH_JSON_INVALID"
-          ? "graph 데이터가 손상되어 시각화를 표시할 수 없습니다."
+          ? "흐름도 데이터가 손상되어 표시할 수 없습니다."
           : apiErrorMessage || "상세 정보를 불러오지 못했습니다.";
     toast.error(msg);
   }, [isError, apiErrorCode, apiErrorStatus, apiErrorMessage]);
@@ -143,9 +143,9 @@ export function WorkflowDetailPanel({
 
   if (workflowId === null) {
     return (
-      <section className={styles.panel} aria-label="workflow 상세">
+      <section className={styles.panel} aria-label="응대 흐름 상세">
         <div className={styles.placeholder}>
-          <span>좌측 목록에서 workflow를 선택해 주세요.</span>
+          <span>좌측 목록에서 응대 흐름을 선택해 주세요.</span>
         </div>
       </section>
     );
@@ -153,7 +153,7 @@ export function WorkflowDetailPanel({
 
   if (isLoading) {
     return (
-      <section className={styles.panel} aria-label="workflow 상세">
+      <section className={styles.panel} aria-label="응대 흐름 상세">
         <div className={styles.body}>
           <div className={styles.skeleton} />
         </div>
@@ -163,7 +163,7 @@ export function WorkflowDetailPanel({
 
   if (isError) {
     return (
-      <section className={styles.panel} aria-label="workflow 상세">
+      <section className={styles.panel} aria-label="응대 흐름 상세">
         <div className={styles.placeholder}>
           <span>상세 정보를 불러오지 못했습니다.</span>
           <button type="button" className={styles.retryButton} onClick={() => void refetch()}>
@@ -177,9 +177,9 @@ export function WorkflowDetailPanel({
   if (!detail) return null;
 
   return (
-    <section className={styles.panel} aria-label="workflow 상세">
+    <section className={styles.panel} aria-label="응대 흐름 상세">
       <DetailHeader detail={detail} onEdit={onEdit} />
-      <nav className={styles.tabs} role="tablist" aria-label="workflow 상세 뷰">
+      <nav className={styles.tabs} role="tablist" aria-label="응대 흐름 상세 뷰">
         {TABS.map((t, i) => (
           <button
             key={t}
@@ -221,16 +221,16 @@ export function WorkflowDetailPanel({
           </ErrorBoundary>
           {policyLoading && (
             <div className={styles.policyStatus} role="status">
-              정책 목록을 불러오는 중입니다.
+              응대 기준 목록을 불러오는 중입니다.
             </div>
           )}
           {policyError && (
             <div className={styles.policyStatus} role="alert">
-              정책 목록을 불러오지 못했습니다.
+              응대 기준 목록을 불러오지 못했습니다.
             </div>
           )}
           {!policyLoading && !policyError && (policyList ?? []).length === 0 && (
-            <div className={styles.policyStatus}>참조할 정책이 없습니다.</div>
+            <div className={styles.policyStatus}>참조할 응대 기준이 없습니다.</div>
           )}
           {selectedEdgeId !== null && selectedTransition !== null && (
             <TransitionPopover
@@ -299,7 +299,7 @@ function GraphContent({
   if (graphJson == null) {
     return (
       <div className={styles.placeholder}>
-        <span>그래프 데이터 없음</span>
+        <span>흐름도 데이터 없음</span>
       </div>
     );
   }
@@ -321,12 +321,12 @@ function DetailHeader({ detail, onEdit }: { detail: WorkflowDetail; onEdit?: () 
           <span className={styles.name}>{detail.name}</span>
           {detail.description && <span className={styles.description}>{detail.description}</span>}
           <span className={styles.updatedAt}>
-            UPDATED · {detail.updatedAt ? new Date(detail.updatedAt).toLocaleString() : "—"}
+            수정일 · {detail.updatedAt ? new Date(detail.updatedAt).toLocaleString() : "—"}
           </span>
         </div>
         {onEdit && (
           <button type="button" className={styles.editButton} onClick={onEdit}>
-            Edit
+            수정
           </button>
         )}
       </div>
@@ -347,7 +347,7 @@ function MetaTab({ detail }: { detail: WorkflowDetail }) {
   return (
     <div className={styles.metaSection}>
       <div className={styles.metaItem}>
-        <span className={styles.metaLabel}>Initial State</span>
+        <span className={styles.metaLabel}>시작 상태</span>
         {detail.initialState ? (
           <span className={styles.badge}>{detail.initialState}</span>
         ) : (
@@ -355,7 +355,7 @@ function MetaTab({ detail }: { detail: WorkflowDetail }) {
         )}
       </div>
       <div className={styles.metaItem}>
-        <span className={styles.metaLabel}>Terminal States</span>
+        <span className={styles.metaLabel}>종료 상태</span>
         {terminals.ok ? (
           terminals.value.length === 0 ? (
             <span>—</span>
@@ -373,13 +373,13 @@ function MetaTab({ detail }: { detail: WorkflowDetail }) {
         )}
       </div>
       <div className={styles.metaItem}>
-        <span className={styles.metaLabel}>Evidence (raw)</span>
+        <span className={styles.metaLabel}>근거 로그</span>
         <pre className={styles.rawCode}>
           <code>{formatJsonForDisplay(detail.evidenceJson ?? "")}</code>
         </pre>
       </div>
       <div className={styles.metaItem}>
-        <span className={styles.metaLabel}>Meta (raw)</span>
+        <span className={styles.metaLabel}>추가 정보</span>
         <pre className={styles.rawCode}>
           <code>{formatJsonForDisplay(detail.metaJson ?? "")}</code>
         </pre>

--- a/frontend/src/features/workflow-draft-read/ui/WorkflowListPanel.test.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/WorkflowListPanel.test.tsx
@@ -16,7 +16,7 @@ const mockedUseWorkflowList = vi.mocked(useWorkflowList);
 const stubWorkflow = {
   id: 1,
   workflowCode: "W001",
-  name: "테스트 워크플로우",
+  name: "테스트 응대 흐름",
   description: null,
   initialState: "START",
   terminalStatesJson: '["DONE", "CANCEL"]',
@@ -49,11 +49,11 @@ describe("WorkflowListPanel", () => {
       refetch: vi.fn(),
     } as unknown as ReturnType<typeof useWorkflowList>);
     renderPanel();
-    expect(screen.getByLabelText("workflow 목록")).toBeInTheDocument();
-    expect(screen.getByText("— · CODE")).toBeInTheDocument();
+    expect(screen.getByLabelText("응대 흐름 목록")).toBeInTheDocument();
+    expect(screen.getByText("—개")).toBeInTheDocument();
   });
 
-  it("success 상태에서는 workflow 목록과 항목 수를 렌더링한다", () => {
+  it("success 상태에서는 응대 흐름 목록과 항목 수를 렌더링한다", () => {
     mockedUseWorkflowList.mockReturnValue({
       isLoading: false,
       isError: false,
@@ -63,9 +63,9 @@ describe("WorkflowListPanel", () => {
       refetch: vi.fn(),
     } as unknown as ReturnType<typeof useWorkflowList>);
     renderPanel();
-    expect(screen.getByText("1 · CODE")).toBeInTheDocument();
+    expect(screen.getByText("1개")).toBeInTheDocument();
     expect(screen.getByText("W001")).toBeInTheDocument();
-    expect(screen.getByText("테스트 워크플로우")).toBeInTheDocument();
+    expect(screen.getByText("테스트 응대 흐름")).toBeInTheDocument();
   });
 
   it("success 상태에서 항목 클릭 시 onSelect를 호출한다", () => {
@@ -93,7 +93,7 @@ describe("WorkflowListPanel", () => {
       refetch: vi.fn(),
     } as unknown as ReturnType<typeof useWorkflowList>);
     renderPanel();
-    expect(screen.getByText("해당 버전에 등록된 workflow 초안이 없습니다.")).toBeInTheDocument();
+    expect(screen.getByText("해당 버전에 등록된 응대 흐름 초안이 없습니다.")).toBeInTheDocument();
   });
 
   it("error 상태에서는 에러 메시지와 재시도 버튼을 보여준다", () => {

--- a/frontend/src/features/workflow-draft-read/ui/WorkflowListPanel.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/WorkflowListPanel.tsx
@@ -40,11 +40,11 @@ export function WorkflowListPanel({
   }, [isError, errorMessage]);
 
   return (
-    <aside className={styles.panel} aria-label="workflow 목록">
+    <aside className={styles.panel} aria-label="응대 흐름 목록">
       <header className={styles.header}>
-        <span className={styles.headerTitle}>Workflows</span>
+        <span className={styles.headerTitle}>응대 흐름</span>
         <span className={styles.headerMeta}>
-          {isSuccess ? `${data.length} · CODE` : "— · CODE"}
+          {isSuccess ? `${data.length}개` : "—개"}
         </span>
       </header>
 
@@ -68,7 +68,7 @@ export function WorkflowListPanel({
 
         {isSuccess && data.length === 0 && (
           <div className={styles.emptyState}>
-            <span>해당 버전에 등록된 workflow 초안이 없습니다.</span>
+            <span>해당 버전에 등록된 응대 흐름 초안이 없습니다.</span>
           </div>
         )}
 

--- a/frontend/src/features/workflow-list/ui/WorkflowListView.tsx
+++ b/frontend/src/features/workflow-list/ui/WorkflowListView.tsx
@@ -22,7 +22,7 @@ import { WorkflowSearchBar } from "./WorkflowSearchBar";
 import styles from "./workflow-list-view.module.css";
 
 const SORT_FIELD_KO_LABELS: Record<(typeof SORT_FIELD_OPTIONS)[number]["value"], string> = {
-  workflowCode: "코드",
+  workflowCode: "응대 코드",
   name: "이름",
 };
 
@@ -167,7 +167,7 @@ export function WorkflowListView({
       )}
 
       {pageEntries.length === 0 && (
-        <EmptyState message={filterWorkflowId !== null ? "필터 결과 없음" : "워크플로우 없음"} />
+        <EmptyState message={filterWorkflowId !== null ? "필터 결과 없음" : "응대 흐름 없음"} />
       )}
 
       <div className={styles.list} data-testid={`${testIdPrefix}-list`}>
@@ -193,7 +193,7 @@ export function WorkflowListView({
         <nav
           className={styles.pagination}
           data-testid={`${testIdPrefix}-pagination`}
-          aria-label="pagination"
+          aria-label="페이지 이동"
         >
           <button
             type="button"
@@ -202,7 +202,7 @@ export function WorkflowListView({
             data-testid={`${testIdPrefix}-pagination-prev`}
             className={styles.pageBtn}
           >
-            Prev
+            이전
           </button>
           <span className={styles.pageInfo} data-testid={`${testIdPrefix}-pagination-info`}>
             {safePage} / {totalPages}
@@ -214,7 +214,7 @@ export function WorkflowListView({
             data-testid={`${testIdPrefix}-pagination-next`}
             className={styles.pageBtn}
           >
-            Next
+            다음
           </button>
         </nav>
       )}

--- a/frontend/src/features/workflow-list/ui/WorkflowSearchBar.tsx
+++ b/frontend/src/features/workflow-list/ui/WorkflowSearchBar.tsx
@@ -86,7 +86,7 @@ export function WorkflowSearchBar({
         onFocus={() => {
           if (query) setOpen(true);
         }}
-        placeholder="Workflow 검색"
+        placeholder="응대 흐름 검색"
         data-testid={`${testIdPrefix}-input`}
         style={inputStyle}
       />

--- a/frontend/src/features/workspace/ui/CreateWorkspaceDialog.tsx
+++ b/frontend/src/features/workspace/ui/CreateWorkspaceDialog.tsx
@@ -106,7 +106,7 @@ export function CreateWorkspaceDialog({
         <DialogHeader>
           <DialogTitle>워크스페이스 생성</DialogTitle>
           <DialogDescription>
-            팀이 함께 사용할 워크스페이스를 만들고 워크플로우 생성 작업을 시작합니다.
+            팀이 함께 사용할 워크스페이스를 만들고 응대 흐름 생성 작업을 시작합니다.
           </DialogDescription>
         </DialogHeader>
         <form className={styles.form} onSubmit={handleSubmit}>

--- a/frontend/src/pages/consultation/ui/sections/MatchedWorkflowBar.test.tsx
+++ b/frontend/src/pages/consultation/ui/sections/MatchedWorkflowBar.test.tsx
@@ -56,7 +56,7 @@ describe("MatchedWorkflowBar", () => {
     expect(screen.getByTestId("matched-workflow-bar-title")).toHaveTextContent("환불 워크플로우");
     expect(screen.queryByTestId("matched-workflow-bar-preview")).not.toBeInTheDocument();
     expect(screen.queryByTestId("matched-workflow-bar-meta")).not.toBeInTheDocument();
-    expect(screen.queryByText("RUNNING")).not.toBeInTheDocument();
+    expect(screen.queryByText("진행 중")).not.toBeInTheDocument();
   });
 
   it("expands preview on hover (mouseEnter)", () => {
@@ -67,9 +67,9 @@ describe("MatchedWorkflowBar", () => {
 
     expect(bar).toHaveAttribute("data-state", "open");
     expect(screen.getByTestId("matched-workflow-bar-preview")).toBeInTheDocument();
-    expect(screen.getByText("RUNNING")).toBeInTheDocument();
+    expect(screen.getByText("진행 중")).toBeInTheDocument();
     expect(screen.getByTestId("matched-workflow-bar-meta")).toHaveTextContent(
-      "wf REFUND_FLOW · v12 · COLLECT_INFO",
+      "응대 코드 REFUND_FLOW · v12 · COLLECT_INFO",
     );
     expect(screen.getByTestId("matched-workflow-bar-description")).toHaveTextContent(
       "환불 처리 흐름",
@@ -131,14 +131,16 @@ describe("MatchedWorkflowBar", () => {
   it("falls back to literal label when both workflowName and workflowCode are null", () => {
     renderBar({ ...baseWorkflow, workflowName: null, workflowCode: null });
 
-    expect(screen.getByTestId("matched-workflow-bar-title")).toHaveTextContent("워크플로우");
+    expect(screen.getByTestId("matched-workflow-bar-title")).toHaveTextContent("응대 흐름");
   });
 
   it("shows graph unavailable placeholder when graphJson is missing (after hover)", () => {
     renderBar({ ...baseWorkflow, graphJson: undefined });
     fireEvent.mouseEnter(screen.getByTestId("matched-workflow-bar"));
 
-    expect(screen.getByTestId("matched-workflow-bar-graph")).toHaveTextContent("graph unavailable");
+    expect(screen.getByTestId("matched-workflow-bar-graph")).toHaveTextContent(
+      "흐름 미리보기 없음",
+    );
     expect(screen.queryByTestId("workflow-graph-mini-88")).not.toBeInTheDocument();
   });
 
@@ -153,7 +155,7 @@ describe("MatchedWorkflowBar", () => {
     renderBar({ ...baseWorkflow, executionStatus: null });
     fireEvent.mouseEnter(screen.getByTestId("matched-workflow-bar"));
 
-    expect(screen.getByText("UNKNOWN")).toBeInTheDocument();
+    expect(screen.getByText("상태 미확인")).toBeInTheDocument();
   });
 
   it("omits meta in preview when no meta parts are available", () => {

--- a/frontend/src/pages/consultation/ui/sections/MatchedWorkflowBar.tsx
+++ b/frontend/src/pages/consultation/ui/sections/MatchedWorkflowBar.tsx
@@ -26,7 +26,7 @@ function resolveStatusTone(status: string | null): PillTone {
 
 function buildMeta(workflow: MatchedWorkflow): string {
   const parts: string[] = [];
-  if (workflow.workflowCode) parts.push(`wf ${workflow.workflowCode}`);
+  if (workflow.workflowCode) parts.push(`응대 코드 ${workflow.workflowCode}`);
   if (workflow.domainPackVersionId != null) parts.push(`v${workflow.domainPackVersionId}`);
   if (workflow.currentState) parts.push(workflow.currentState);
   return parts.join(" · ");
@@ -35,9 +35,9 @@ function buildMeta(workflow: MatchedWorkflow): string {
 export function MatchedWorkflowBar({ workflow }: MatchedWorkflowBarProps) {
   const navigate = useNavigate();
   const [previewOpen, setPreviewOpen] = useState(false);
-  const title = workflow.workflowName ?? workflow.workflowCode ?? "워크플로우";
+  const title = workflow.workflowName ?? workflow.workflowCode ?? "응대 흐름";
   const meta = buildMeta(workflow);
-  const statusLabel = workflow.executionStatus ?? "UNKNOWN";
+  const statusLabel = formatExecutionStatus(workflow.executionStatus);
   const tone = resolveStatusTone(workflow.executionStatus);
 
   const canNavigate =
@@ -76,7 +76,7 @@ export function MatchedWorkflowBar({ workflow }: MatchedWorkflowBarProps) {
       className={styles.bar}
       data-testid="matched-workflow-bar"
       data-state={previewOpen ? "open" : "closed"}
-      aria-label="매칭된 워크플로우"
+      aria-label="매칭된 응대 흐름"
       onMouseEnter={() => setPreviewOpen(true)}
       onMouseLeave={handleMouseLeave}
       onFocusCapture={() => setPreviewOpen(true)}
@@ -89,7 +89,7 @@ export function MatchedWorkflowBar({ workflow }: MatchedWorkflowBarProps) {
         disabled={!canNavigate}
         data-testid="matched-workflow-bar-open"
       >
-        <span className={styles.label}>workflow</span>
+        <span className={styles.label}>응대 흐름</span>
         <span className={styles.title} data-testid="matched-workflow-bar-title">
           {title}
         </span>
@@ -119,7 +119,7 @@ export function MatchedWorkflowBar({ workflow }: MatchedWorkflowBarProps) {
                     graphJson={workflow.graphJson}
                   />
                 ) : (
-                  <span className={styles.graphMissing}>graph unavailable</span>
+                  <span className={styles.graphMissing}>흐름 미리보기 없음</span>
                 )}
               </div>
             </div>
@@ -136,9 +136,19 @@ export function MatchedWorkflowBarSkeleton() {
       className={styles.skeleton}
       data-testid="matched-workflow-bar-skeleton"
       aria-busy="true"
-      aria-label="매칭된 워크플로우 로딩 중"
+      aria-label="매칭된 응대 흐름 로딩 중"
     >
       <span className={styles.skeletonBar} />
     </div>
   );
+}
+
+function formatExecutionStatus(status: string | null): string {
+  const labels: Record<string, string> = {
+    RUNNING: "진행 중",
+    COMPLETED: "완료",
+    FAILED: "실패",
+    CANCELED: "취소됨",
+  };
+  return status ? (labels[status.toUpperCase()] ?? status) : "상태 미확인";
 }

--- a/frontend/src/pages/domain-pack/model/useIntentDraftReadController.ts
+++ b/frontend/src/pages/domain-pack/model/useIntentDraftReadController.ts
@@ -375,10 +375,10 @@ function useSaveRevisionHandler({
         });
         resetDirty();
         refreshIntentViews();
-        toast.success("Intent 수정 내용이 저장되었습니다.");
+        toast.success("상담 유형 수정 내용이 저장되었습니다.");
         return true;
       } catch (error) {
-        toast.error(resolveApiErrorMessage(error, "Intent 수정 내용 저장에 실패했습니다."));
+        toast.error(resolveApiErrorMessage(error, "상담 유형 수정 내용 저장에 실패했습니다."));
         return false;
       }
     },
@@ -439,14 +439,14 @@ async function savePublishedIntentRevision({
     if (!result.patchSucceeded) {
       toast.error(
         result.clonedIntentId === null
-          ? "Intent 수정 초안에서 같은 intent를 찾지 못했습니다."
-          : "Intent 수정 초안은 생성됐지만 수정 내용 저장에 실패했습니다.",
+          ? "상담 유형 수정 초안에서 같은 상담 유형을 찾지 못했습니다."
+          : "상담 유형 수정 초안은 생성됐지만 수정 내용 저장에 실패했습니다.",
       );
       setRecoveryVersionId(result.draftVersionId);
     }
     navigateToIntentRoute(result.draftVersionId, result.clonedIntentId);
     if (result.patchSucceeded) {
-      toast.success("Intent 수정 초안이 생성되었습니다.");
+      toast.success("상담 유형 수정 초안이 생성되었습니다.");
     }
     return true;
   } catch (error) {
@@ -461,7 +461,7 @@ async function savePublishedIntentRevision({
       return false;
     }
 
-    toast.error(resolveApiErrorMessage(error, "Intent 수정 내용 저장에 실패했습니다."));
+    toast.error(resolveApiErrorMessage(error, "상담 유형 수정 내용 저장에 실패했습니다."));
     return false;
   }
 }
@@ -501,12 +501,12 @@ function useApplyRevisionDraftHandler({
         const activated = await intentRevisionDraftApi.activateVersion(wsId, pId, vId);
         await Promise.all([packQuery.refetch(), versionQuery.refetch()]);
         refreshIntentViews();
-        toast.success("Intent 수정 초안이 적용되었습니다.");
+        toast.success("상담 유형 수정 초안이 적용되었습니다.");
         await navigateToIntentCode(activated.activatedVersionId, intentCode, {
           replace: true,
         });
       } catch (error) {
-        toast.error(resolveApiErrorMessage(error, "Intent 수정 초안 적용에 실패했습니다."));
+        toast.error(resolveApiErrorMessage(error, "상담 유형 수정 초안 적용에 실패했습니다."));
       } finally {
         setVersionActionPending(false);
       }
@@ -557,7 +557,7 @@ function useDiscardRevisionDraftHandler({
         await intentRevisionDraftApi.discardDraft(wsId, pId, vId);
         const targetVersionId = currentPublishedVersionId ?? baseVersionId;
         await packQuery.refetch();
-        toast.success("Intent 수정 초안이 취소되었습니다.");
+        toast.success("상담 유형 수정 초안이 취소되었습니다.");
         if (targetVersionId !== null) {
           await navigateToIntentCode(targetVersionId, intentCode, {
             replace: true,
@@ -568,7 +568,7 @@ function useDiscardRevisionDraftHandler({
           });
         }
       } catch (error) {
-        toast.error(resolveApiErrorMessage(error, "Intent 수정 초안 취소에 실패했습니다."));
+        toast.error(resolveApiErrorMessage(error, "상담 유형 수정 초안 취소에 실패했습니다."));
       } finally {
         setVersionActionPending(false);
       }

--- a/frontend/src/pages/domain-pack/ui/DomainPackListPage.test.tsx
+++ b/frontend/src/pages/domain-pack/ui/DomainPackListPage.test.tsx
@@ -87,7 +87,7 @@ describe("DomainPackListPage", () => {
     expect(screen.queryByText("상담 로그 업로드")).not.toBeInTheDocument();
   });
 
-  it("데이터가 있을 때 Domain Packs 제목과 목록을 렌더링한다", () => {
+  it("데이터가 있을 때 도메인팩 관리 제목과 목록을 렌더링한다", () => {
     useListDomainPacks.mockReturnValue({
       isLoading: false,
       isError: false,
@@ -107,7 +107,7 @@ describe("DomainPackListPage", () => {
       refetch: vi.fn(),
     });
     renderPage();
-    expect(screen.getByText("Domain Packs")).toBeInTheDocument();
+    expect(screen.getByText("도메인팩 관리")).toBeInTheDocument();
     expect(screen.getByText("CS Pack")).toBeInTheDocument();
     expect(screen.getByText("Customer service pack")).toBeInTheDocument();
     expect(screen.getByText("Pack 2")).toBeInTheDocument();

--- a/frontend/src/pages/domain-pack/ui/DomainPackListPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/DomainPackListPage.tsx
@@ -175,7 +175,7 @@ export function DomainPackListPage() {
     <div className={styles.pageWrapper}>
       <div className={styles.pageHeader}>
         <div>
-          <h1 className={styles.pageTitle}>Domain Packs</h1>
+          <h1 className={styles.pageTitle}>도메인팩 관리</h1>
           <div className={styles.summaryRow} aria-label="도메인팩 상태 요약">
             <span className={styles.summaryPill}>전체 {packs.length}</span>
             <span className={styles.summaryPill}>운영중 {operatingPacks.length}</span>

--- a/frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.test.tsx
+++ b/frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.test.tsx
@@ -341,8 +341,10 @@ describe("DomainPackSummaryPage", () => {
     );
     expect(packRefetch).toHaveBeenCalled();
     expect(versionRefetch).toHaveBeenCalled();
-    expect(toast.success).toHaveBeenCalledWith("Draft 버전이 적용되었습니다.");
-    expect(toast.error).not.toHaveBeenCalledWith("Draft 버전을 적용하지 못했습니다.");
+    expect(toast.success).toHaveBeenCalledWith(
+      "검토 중인 버전이 운영 버전으로 적용되었습니다.",
+    );
+    expect(toast.error).not.toHaveBeenCalledWith("검토 중인 버전을 적용하지 못했습니다.");
   });
 
   it("Draft 삭제 버튼 클릭 시 discard mutation을 호출한다", () => {
@@ -410,14 +412,14 @@ describe("DomainPackSummaryPage", () => {
     expect(screen.getByTestId("current-version-id")).toHaveTextContent("none");
   });
 
-  it('"새 DRAFT 묶기" 버튼을 표시하지 않는다', () => {
+  it('"새 검토본 묶기" 버튼을 표시하지 않는다', () => {
     vi.mocked(usePackDetail).mockReturnValue(
       makePackQuery({
         data: { packId: 2, name: "CS Pack", code: "CS", versions: [] },
       }),
     );
     renderPage();
-    expect(screen.queryByRole("button", { name: "새 DRAFT 묶기" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "새 검토본 묶기" })).not.toBeInTheDocument();
   });
 
   it("packDetail 로딩 중 LoadingSpinner를 표시한다", () => {

--- a/frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.test.tsx
+++ b/frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.test.tsx
@@ -347,6 +347,34 @@ describe("DomainPackSummaryPage", () => {
     expect(toast.error).not.toHaveBeenCalledWith("검토 중인 버전을 적용하지 못했습니다.");
   });
 
+  it("Draft 적용 실패 시 상담사 용어의 실패 toast를 띄운다", () => {
+    let activateOnError: ((error: unknown) => unknown) | undefined;
+    const mutate = vi.fn(() => activateOnError?.(new Error("activate failed")));
+    vi.mocked(useActivate).mockImplementation((options) => {
+      activateOnError = options?.mutation?.onError;
+      return {
+        mutate,
+        isPending: false,
+        variables: undefined,
+      } as unknown as ReturnType<typeof useActivate>;
+    });
+    vi.mocked(usePackDetail).mockReturnValue(
+      makePackQuery({
+        data: {
+          packId: 2,
+          name: "CS Pack",
+          code: "CS",
+          versions: [{ versionId: 5, versionNo: 3, lifecycleStatus: "DRAFT" }],
+        },
+      }),
+    );
+
+    renderPage("/workspaces/1/domain-packs/2?versionId=5");
+    fireEvent.click(screen.getByRole("button", { name: "apply draft" }));
+
+    expect(toast.error).toHaveBeenCalledWith("검토 중인 버전을 적용하지 못했습니다.");
+  });
+
   it("Draft 삭제 버튼 클릭 시 discard mutation을 호출한다", () => {
     const mutate = vi.fn();
     vi.mocked(useDiscard).mockReturnValue({
@@ -373,6 +401,40 @@ describe("DomainPackSummaryPage", () => {
       packId: 2,
       draftVersionId: 5,
     });
+  });
+
+  it("Draft 삭제 성공 후 운영 버전이 없으면 versionId를 제거한다", async () => {
+    const packRefetch = vi.fn().mockResolvedValue({ data: { currentVersionId: null } });
+    let discardOnSuccess: (() => unknown) | undefined;
+    const mutate = vi.fn(() => discardOnSuccess?.());
+    vi.mocked(useDiscard).mockImplementation((options) => {
+      discardOnSuccess = options?.mutation?.onSuccess;
+      return {
+        mutate,
+        isPending: false,
+        variables: undefined,
+      } as unknown as ReturnType<typeof useDiscard>;
+    });
+    vi.mocked(usePackDetail).mockReturnValue(
+      makePackQuery({
+        data: {
+          packId: 2,
+          name: "CS Pack",
+          code: "CS",
+          currentVersionId: null,
+          versions: [{ versionId: 5, versionNo: 3, lifecycleStatus: "DRAFT" }],
+        },
+        refetch: packRefetch,
+      }),
+    );
+
+    renderPage("/workspaces/1/domain-packs/2?versionId=5");
+    fireEvent.click(screen.getByRole("button", { name: "delete draft" }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("location")).toHaveTextContent("/workspaces/1/domain-packs/2"),
+    );
+    expect(toast.success).toHaveBeenCalledWith("검토 중인 버전이 삭제되었습니다.");
   });
 
   it("currentVersionId가 없으면 PUBLISHED 버전이 하나뿐이어도 운영 버전을 추론하지 않는다", () => {

--- a/frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.tsx
@@ -105,10 +105,10 @@ function DomainPackSummaryPageContent({
           { replace: true },
         );
         await Promise.allSettled([packQuery.refetch(), versionQuery.refetch()]);
-        toast.success("Draft 버전이 적용되었습니다.");
+        toast.success("검토 중인 버전이 운영 버전으로 적용되었습니다.");
       },
       onError: (error) => {
-        toast.error(resolveVersionActionErrorMessage(error, "Draft 버전을 적용하지 못했습니다."));
+        toast.error(resolveVersionActionErrorMessage(error, "검토 중인 버전을 적용하지 못했습니다."));
       },
     },
   });
@@ -129,10 +129,10 @@ function DomainPackSummaryPageContent({
           },
           { replace: true },
         );
-        toast.success("Draft 버전이 삭제되었습니다.");
+        toast.success("검토 중인 버전이 삭제되었습니다.");
       },
       onError: (error) => {
-        toast.error(resolveVersionActionErrorMessage(error, "Draft 버전을 삭제하지 못했습니다."));
+        toast.error(resolveVersionActionErrorMessage(error, "검토 중인 버전을 삭제하지 못했습니다."));
       },
     },
   });

--- a/frontend/src/pages/domain-pack/ui/IntentDraftReadPage.test.tsx
+++ b/frontend/src/pages/domain-pack/ui/IntentDraftReadPage.test.tsx
@@ -212,7 +212,7 @@ vi.mock("@/features/intent-revision-draft", () => ({
   IntentRevisionRecoveryBanner: () => <div>recovery banner</div>,
   IntentRevisionDraftActions: ({ onRetrySummary }: { onRetrySummary: () => void }) => (
     <div>
-      <span>수정 내용의 적용 및 삭제는 Domain Pack 화면에서 진행할 수 있습니다.</span>
+      <span>수정 내용의 적용 및 삭제는 도메인팩 화면에서 진행할 수 있습니다.</span>
       <button type="button" onClick={onRetrySummary}>
         retry summary
       </button>
@@ -418,14 +418,14 @@ describe("IntentDraftReadPage", () => {
 
     await waitFor(() =>
       expect(mocks.toastError).toHaveBeenCalledWith(
-        "Intent 수정 초안에서 같은 intent를 찾지 못했습니다.",
+        "상담 유형 수정 초안에서 같은 상담 유형을 찾지 못했습니다.",
       ),
     );
     expect(mocks.navigate).toHaveBeenCalledWith(
       "/workspaces/1/domain-packs/7/intents?versionId=4",
       { replace: true },
     );
-    expect(mocks.toastSuccess).not.toHaveBeenCalledWith("Intent 수정 초안이 생성되었습니다.");
+    expect(mocks.toastSuccess).not.toHaveBeenCalledWith("상담 유형 수정 초안이 생성되었습니다.");
   });
 
   it("운영 버전이 바뀐 상태에서 저장하면 pack을 새로고침하고 안내한다", async () => {
@@ -630,7 +630,7 @@ describe("IntentDraftReadPage", () => {
     renderPage("/workspaces/1/domain-packs/7/intents/10?versionId=6");
 
     expect(
-      screen.getByText("수정 내용의 적용 및 삭제는 Domain Pack 화면에서 진행할 수 있습니다."),
+      screen.getByText("수정 내용의 적용 및 삭제는 도메인팩 화면에서 진행할 수 있습니다."),
     ).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "apply revision" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "discard revision" })).not.toBeInTheDocument();

--- a/frontend/src/pages/domain-pack/ui/IntentDraftReadPage.test.tsx
+++ b/frontend/src/pages/domain-pack/ui/IntentDraftReadPage.test.tsx
@@ -425,7 +425,7 @@ describe("IntentDraftReadPage", () => {
       "/workspaces/1/domain-packs/7/intents?versionId=4",
       { replace: true },
     );
-    expect(mocks.toastSuccess).not.toHaveBeenCalledWith("상담 유형 수정 초안이 생성되었습니다.");
+    expect(mocks.toastSuccess).not.toHaveBeenCalled();
   });
 
   it("운영 버전이 바뀐 상태에서 저장하면 pack을 새로고침하고 안내한다", async () => {

--- a/frontend/src/pages/domain-pack/ui/IntentDraftReadPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/IntentDraftReadPage.tsx
@@ -90,7 +90,7 @@ function IntentDraftReadContent({
         vId,
         packName,
         versionNo,
-        section: { label: "INTENTS", path: "intents" },
+        section: { label: "상담 유형", path: "intents" },
         selectedLabel: controller.selectedIntentCode,
       }),
     [wsId, pId, vId, packName, versionNo, controller.selectedIntentCode],
@@ -398,7 +398,7 @@ function SelectedIntentCodeSync({
 
 function versionLabelTone(label: string): PillTone {
   if (label === "운영 중") return "signal";
-  if (label === "DRAFT" || label === "Intent 수정 검토") return "warn";
+  if (label === "검토 중" || label === "상담 유형 수정 검토") return "warn";
   if (label === "이전 버전") return "mute";
   return "mute";
 }
@@ -412,15 +412,15 @@ function getVersionLabel({
   isCurrentPublished: boolean;
   isRevisionDraft: boolean;
 }): string {
-  if (isRevisionDraft) return "Intent 수정 검토";
+  if (isRevisionDraft) return "상담 유형 수정 검토";
   if (isCurrentPublished) return "운영 중";
   if (lifecycleStatus === "PUBLISHED") return "이전 버전";
-  if (lifecycleStatus === "DRAFT") return "DRAFT";
+  if (lifecycleStatus === "DRAFT") return "검토 중";
   return "확인 중";
 }
 
 function getExistingDraftDescription(target: ExistingDraftTarget | null): string {
   return target?.sourceType === "INTENT_REVISION"
-    ? "기존 Intent 수정 Draft로 이동하거나 Domain Pack 화면에서 Draft를 적용 또는 폐기해 주세요."
-    : "기존 Draft로 이동하거나 Domain Pack 화면에서 Draft를 적용 또는 폐기해 주세요.";
+    ? "기존 상담 유형 수정 검토본으로 이동하거나 도메인팩 화면에서 검토본을 적용 또는 폐기해 주세요."
+    : "기존 검토본으로 이동하거나 도메인팩 화면에서 검토본을 적용 또는 폐기해 주세요.";
 }

--- a/frontend/src/pages/domain-pack/ui/PackWorkflowListPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/PackWorkflowListPage.tsx
@@ -62,7 +62,7 @@ export function PackWorkflowListPage() {
     vId,
     packName,
     versionNo,
-    section: { label: "WORKFLOWS", path: "workflows" },
+    section: { label: "응대 흐름", path: "workflows" },
   });
 
   const handleOpen = (entry: WorkspaceWorkflowEntry) => {
@@ -87,20 +87,20 @@ export function PackWorkflowListPage() {
           >
             <LoadingSpinner />
             <p style={{ color: "var(--ink)", fontSize: "14px" }}>
-              워크플로우 목록을 불러오는 중입니다.
+              응대 흐름 목록을 불러오는 중입니다.
             </p>
           </div>
         )}
 
         {!query.isLoading && query.isError && (
           <div data-testid="pack-workflows-error">
-            <ErrorState message="워크플로우 목록을 불러오지 못했습니다." onRetry={query.refetch} />
+            <ErrorState message="응대 흐름 목록을 불러오지 못했습니다." onRetry={query.refetch} />
           </div>
         )}
 
         {!query.isLoading && !query.isError && entries.length === 0 && (
           <div data-testid="pack-workflows-empty">
-            <EmptyState message="아직 등록된 워크플로우가 없습니다." />
+            <EmptyState message="아직 등록된 응대 흐름이 없습니다." />
           </div>
         )}
 

--- a/frontend/src/pages/domain-pack/ui/PolicyDraftReadPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/PolicyDraftReadPage.tsx
@@ -40,7 +40,7 @@ export function PolicyDraftReadPage() {
 
   if (wsId === null || pId === null || vId === null || hasInvalidPolicyId) {
     return (
-      <OstoneShell active="domain" crumbs={["Domain Packs"]}>
+      <OstoneShell active="domain" crumbs={["도메인팩 관리"]}>
         <div className={styles.invalidParams} role="alert">
           잘못된 URL 파라미터입니다.
         </div>
@@ -70,11 +70,11 @@ export function PolicyDraftReadPage() {
     vId,
     packName,
     versionNo,
-    section: { label: "POLICIES", path: "policies" },
+    section: { label: "응대 기준", path: "policies" },
     selectedLabel: selectedPolicyId !== null ? `#${selectedPolicyId}` : null,
   });
 
-  const topbarRight = <Pill tone="mute">READ / EDIT</Pill>;
+  const topbarRight = <Pill tone="mute">조회/수정</Pill>;
 
   return (
     <OstoneShell active="policy" crumbs={crumbs} topbarRight={topbarRight}>

--- a/frontend/src/pages/domain-pack/ui/RiskDraftReadPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/RiskDraftReadPage.tsx
@@ -40,7 +40,7 @@ export function RiskDraftReadPage() {
 
   if (wsId === null || pId === null || vId === null || hasInvalidRiskId) {
     return (
-      <OstoneShell active="domain" crumbs={["Domain Packs"]}>
+      <OstoneShell active="domain" crumbs={["도메인팩 관리"]}>
         <div className={styles.invalidParams} role="alert">
           잘못된 URL 파라미터입니다.
         </div>
@@ -60,11 +60,11 @@ export function RiskDraftReadPage() {
     vId,
     packName,
     versionNo,
-    section: { label: "RISKS", path: "risks" },
+    section: { label: "주의 사항", path: "risks" },
     selectedLabel: selectedRiskId !== null ? `#${selectedRiskId}` : null,
   });
 
-  const topbarRight = <Pill tone="mute">READ / EDIT</Pill>;
+  const topbarRight = <Pill tone="mute">조회/수정</Pill>;
 
   return (
     <OstoneShell active="risk" crumbs={crumbs} topbarRight={topbarRight}>

--- a/frontend/src/pages/domain-pack/ui/SlotDraftReadPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/SlotDraftReadPage.tsx
@@ -31,7 +31,7 @@ export function SlotDraftReadPage() {
 
   if (wsId === null || pId === null || vId === null || (slotId !== undefined && sId === null)) {
     return (
-      <OstoneShell active="domain" crumbs={["Domain Packs"]}>
+      <OstoneShell active="domain" crumbs={["도메인팩 관리"]}>
         <div className={styles.invalidParams} role="alert">
           잘못된 URL 파라미터입니다.
         </div>
@@ -56,11 +56,11 @@ export function SlotDraftReadPage() {
     vId,
     packName,
     versionNo,
-    section: { label: "SLOTS", path: "slots" },
+    section: { label: "확인 항목", path: "slots" },
     selectedLabel: sId !== null ? `#${sId}` : null,
   });
 
-  const topbarRight = <Pill tone="mute">READ ONLY</Pill>;
+  const topbarRight = <Pill tone="mute">읽기 전용</Pill>;
 
   return (
     <OstoneShell active="slot" crumbs={crumbs} topbarRight={topbarRight}>

--- a/frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.test.tsx
+++ b/frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.test.tsx
@@ -168,7 +168,7 @@ describe("WorkflowDraftReadPage", () => {
     renderPage("/workspaces/1/domain-packs/2/workflows/10?versionId=3");
     expect(screen.getByTestId("workflow-detail-title")).toHaveTextContent("환불 처리");
     expect(screen.queryByText("refund.standard")).not.toBeInTheDocument();
-    expect(screen.getByText("2 nodes")).toBeInTheDocument();
+    expect(screen.getByText("노드 2개")).toBeInTheDocument();
     expect(screen.getByTestId("graph-viewer")).toHaveTextContent("graph nodes: 2");
   });
 
@@ -280,7 +280,7 @@ describe("WorkflowDraftReadPage", () => {
 
     await waitFor(() =>
       expect(mockToastError).toHaveBeenCalledWith(
-        "워크플로우 코드를 확인할 수 없어 수정 초안을 만들 수 없습니다.",
+        "응대 코드를 확인할 수 없어 수정 검토본을 만들 수 없습니다.",
       ),
     );
     expect(mockCreateRevisionDraft).not.toHaveBeenCalled();
@@ -322,7 +322,7 @@ describe("WorkflowDraftReadPage", () => {
 
     await waitFor(() =>
       expect(mockToastError).toHaveBeenCalledWith(
-        "수정 초안에서 같은 워크플로우를 찾지 못했습니다.",
+        "수정 검토본에서 같은 응대 흐름을 찾지 못했습니다.",
       ),
     );
     expect(screen.getByTestId("location")).toHaveTextContent(
@@ -330,7 +330,7 @@ describe("WorkflowDraftReadPage", () => {
     );
   });
 
-  it("기존 DRAFT가 있으면 기존 Draft 이동 dialog를 표시한다", async () => {
+  it("기존 검토본이 있으면 기존 검토본 이동 dialog를 표시한다", async () => {
     mockUsePackDetail.mockReturnValue({
       data: {
         name: "CS Pack",
@@ -365,8 +365,8 @@ describe("WorkflowDraftReadPage", () => {
     renderPage("/workspaces/1/domain-packs/2/workflows/10?versionId=3");
     fireEvent.click(screen.getByTestId("edit-toggle"));
 
-    expect(await screen.findByText("진행 중인 Draft가 있습니다")).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "기존 Draft로 이동" }));
+    expect(await screen.findByText("진행 중인 검토본이 있습니다")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "기존 검토본으로 이동" }));
     await waitFor(() =>
       expect(screen.getByTestId("location")).toHaveTextContent(
         "/workspaces/1/domain-packs/2/workflows/55?versionId=5",
@@ -405,10 +405,10 @@ describe("WorkflowDraftReadPage", () => {
 
     await waitFor(() =>
       expect(mockToastError).toHaveBeenCalledWith(
-        "진행 중인 Draft를 확인할 수 없습니다. Domain Pack 화면에서 상태를 확인해 주세요.",
+        "진행 중인 검토본을 확인할 수 없습니다. 도메인팩 화면에서 상태를 확인해 주세요.",
       ),
     );
-    expect(screen.queryByText("진행 중인 Draft가 있습니다")).not.toBeInTheDocument();
+    expect(screen.queryByText("진행 중인 검토본이 있습니다")).not.toBeInTheDocument();
   });
 
   it("기존 DRAFT 충돌 후 같은 workflow를 찾지 못하면 이동 dialog를 열지 않는다", async () => {
@@ -448,10 +448,10 @@ describe("WorkflowDraftReadPage", () => {
 
     await waitFor(() =>
       expect(mockToastError).toHaveBeenCalledWith(
-        "기존 Draft에서 같은 워크플로우를 찾지 못했습니다.",
+        "기존 검토본에서 같은 응대 흐름을 찾지 못했습니다.",
       ),
     );
-    expect(screen.queryByText("진행 중인 Draft가 있습니다")).not.toBeInTheDocument();
+    expect(screen.queryByText("진행 중인 검토본이 있습니다")).not.toBeInTheDocument();
   });
 
   it("기존 DRAFT 충돌 후 pack refetch가 실패하면 에러를 안내하고 dialog를 열지 않는다", async () => {
@@ -486,7 +486,7 @@ describe("WorkflowDraftReadPage", () => {
         "Failed to resolve existing workflow draft",
         expect.any(Error),
       );
-      expect(screen.queryByText("진행 중인 Draft가 있습니다")).not.toBeInTheDocument();
+      expect(screen.queryByText("진행 중인 검토본이 있습니다")).not.toBeInTheDocument();
     } finally {
       consoleError.mockRestore();
     }

--- a/frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.tsx
@@ -116,7 +116,7 @@ export function WorkflowDraftReadPage() {
     (workflowId !== undefined && wfId === null)
   ) {
     return (
-      <OstoneShell active="domain" crumbs={["Domain Packs"]}>
+      <OstoneShell active="domain" crumbs={["도메인팩 관리"]}>
         <div role="alert" style={{ padding: "24px", color: "var(--danger)" }}>
           잘못된 URL 파라미터입니다.
         </div>
@@ -160,7 +160,7 @@ export function WorkflowDraftReadPage() {
 
       if (drafts.length !== 1 || drafts[0].versionId == null) {
         toast.error(
-          "진행 중인 Draft를 확인할 수 없습니다. Domain Pack 화면에서 상태를 확인해 주세요.",
+          "진행 중인 검토본을 확인할 수 없습니다. 도메인팩 화면에서 상태를 확인해 주세요.",
         );
         return;
       }
@@ -169,7 +169,7 @@ export function WorkflowDraftReadPage() {
       const draftWorkflowId = await findWorkflowIdByCode(draftVersionId, workflowCode);
 
       if (draftWorkflowId == null) {
-        toast.error("기존 Draft에서 같은 워크플로우를 찾지 못했습니다.");
+        toast.error("기존 검토본에서 같은 응대 흐름을 찾지 못했습니다.");
         return;
       }
 
@@ -182,7 +182,7 @@ export function WorkflowDraftReadPage() {
       toast.error(
         resolveWorkflowActionErrorMessage(
           error,
-          "진행 중인 Draft를 확인하지 못했습니다. 잠시 후 다시 시도해 주세요.",
+          "진행 중인 검토본을 확인하지 못했습니다. 잠시 후 다시 시도해 주세요.",
         ),
       );
     }
@@ -205,7 +205,7 @@ export function WorkflowDraftReadPage() {
     }
 
     if (!workflow.workflowCode) {
-      toast.error("워크플로우 코드를 확인할 수 없어 수정 초안을 만들 수 없습니다.");
+      toast.error("응대 코드를 확인할 수 없어 수정 검토본을 만들 수 없습니다.");
       return;
     }
 
@@ -215,21 +215,21 @@ export function WorkflowDraftReadPage() {
       await packQuery.refetch();
       const draftWorkflowId = await findWorkflowIdByCode(draftVersionId, workflow.workflowCode);
       if (draftWorkflowId === null) {
-        toast.error("수정 초안에서 같은 워크플로우를 찾지 못했습니다.");
+        toast.error("수정 검토본에서 같은 응대 흐름을 찾지 못했습니다.");
         navigateToWorkflow(draftVersionId, null);
         return;
       }
       navigateToWorkflow(draftVersionId, draftWorkflowId);
       setIsEditing(true);
       setEditDirty(false);
-      toast.success("워크플로우 수정 초안이 생성되었습니다.");
+      toast.success("응대 흐름 수정 검토본이 생성되었습니다.");
     } catch (error) {
       if (error instanceof ApiRequestError && error.code === "DOMAIN_PACK_DRAFT_ALREADY_EXISTS") {
         await resolveExistingDraft(workflow.workflowCode);
         return;
       }
       toast.error(
-        resolveWorkflowActionErrorMessage(error, "워크플로우 수정 초안 생성에 실패했습니다."),
+        resolveWorkflowActionErrorMessage(error, "응대 흐름 수정 검토본 생성에 실패했습니다."),
       );
     } finally {
       setCreatingDraft(false);
@@ -257,7 +257,7 @@ export function WorkflowDraftReadPage() {
     vId: vId!,
     packName,
     versionNo,
-    section: { label: "WORKFLOWS", path: "workflows" },
+    section: { label: "응대 흐름", path: "workflows" },
     selectedLabel: workflow?.workflowCode ?? (wfId !== null ? `#${wfId}` : null),
   });
 
@@ -283,7 +283,7 @@ export function WorkflowDraftReadPage() {
   } else {
     graphContent = (
       <div data-testid="workflow-empty-graph" style={{ padding: "32px" }}>
-        <EmptyState message="이 워크플로우에는 아직 그래프가 정의되어 있지 않습니다." />
+        <EmptyState message="이 응대 흐름에는 아직 흐름도가 정의되어 있지 않습니다." />
       </div>
     );
   }
@@ -295,15 +295,17 @@ export function WorkflowDraftReadPage() {
           <div className={styles.titleGroup}>
             <div className={styles.titleStack}>
               <h2 data-testid="workflow-detail-title" className={styles.detailTitle}>
-                {workflow?.name || (query.isLoading ? "워크플로우 로드 중..." : "워크플로우")}
+                {workflow?.name || (query.isLoading ? "응대 흐름 로드 중..." : "응대 흐름")}
               </h2>
               {workflow?.description && (
                 <p className={styles.detailDescription}>{workflow.description}</p>
               )}
             </div>
-            {workflow && lifecycleStatus && <Pill tone="signal">{lifecycleStatus}</Pill>}
-            {workflow && isEditing && <Pill tone="ink">EDITING</Pill>}
-            {workflow && <Mono className={styles.nodeCount}>{nodeCount} nodes</Mono>}
+            {workflow && lifecycleStatus && (
+              <Pill tone="signal">{formatLifecycleStatus(lifecycleStatus)}</Pill>
+            )}
+            {workflow && isEditing && <Pill tone="ink">수정 중</Pill>}
+            {workflow && <Mono className={styles.nodeCount}>노드 {nodeCount}개</Mono>}
           </div>
 
           <div className={styles.headerActions}>
@@ -337,21 +339,21 @@ export function WorkflowDraftReadPage() {
         <div className={styles.canvasFrame} data-editing={isEditing ? "true" : "false"}>
           {!enabled && (
             <div data-testid="workflow-select-empty" className={styles.centerState}>
-              좌측 사이드바에서 워크플로우를 선택하세요.
+              좌측 사이드바에서 응대 흐름을 선택하세요.
             </div>
           )}
 
           {enabled && query.isLoading && (
             <div data-testid="workflow-loading" className={styles.loadingState}>
               <LoadingSpinner />
-              <Mono className={styles.loadingText}>워크플로우 로드 중...</Mono>
+              <Mono className={styles.loadingText}>응대 흐름 로드 중...</Mono>
             </div>
           )}
 
           {enabled && query.isError && (
             <div data-testid="workflow-error" className={styles.errorState}>
               <ErrorState
-                message="워크플로우를 불러오지 못했습니다."
+                message="응대 흐름을 불러오지 못했습니다."
                 onRetry={() => query.refetch()}
               />
             </div>
@@ -388,17 +390,17 @@ export function WorkflowDraftReadPage() {
         }}
       >
         <AlertDialogContent size="sm">
-          <AlertDialogTitle>진행 중인 Draft가 있습니다</AlertDialogTitle>
+          <AlertDialogTitle>진행 중인 검토본이 있습니다</AlertDialogTitle>
           <AlertDialogDescription>
-            새 Draft를 만들 수 없습니다. 기존 Draft에서 계속 편집하거나, Domain Pack 화면에서
-            Draft를 적용 또는 폐기한 뒤 다시 시도하세요.
+            새 검토본을 만들 수 없습니다. 기존 검토본에서 계속 편집하거나, 도메인팩 화면에서
+            검토본을 적용 또는 폐기한 뒤 다시 시도하세요.
           </AlertDialogDescription>
           <AlertDialogFooter>
             <Button type="button" variant="outline" onClick={() => setExistingDraftTarget(null)}>
               취소
             </Button>
             <Button type="button" onClick={confirmExistingDraftNavigation}>
-              기존 Draft로 이동
+              기존 검토본으로 이동
             </Button>
           </AlertDialogFooter>
         </AlertDialogContent>
@@ -411,6 +413,12 @@ function readWorkflowReturnTo(state: unknown): string | null {
   if (typeof state !== "object" || state === null) return null;
   const value = (state as { workflowReturnTo?: unknown }).workflowReturnTo;
   return typeof value === "string" && value.startsWith("/") ? value : null;
+}
+
+function formatLifecycleStatus(status: string): string {
+  if (status === "PUBLISHED") return "운영 가능";
+  if (status === "DRAFT") return "검토 중";
+  return status;
 }
 
 function resolveWorkflowActionErrorMessage(error: unknown, fallback: string): string {

--- a/frontend/src/pages/domain-pack/ui/WorkflowGraphViewerPage.test.tsx
+++ b/frontend/src/pages/domain-pack/ui/WorkflowGraphViewerPage.test.tsx
@@ -68,6 +68,14 @@ function renderPage(path = "/workspaces/1/domain-packs/2/workflows/4/graph?versi
   );
 }
 
+function VersionSearchWrapper({ children }: { children: React.ReactNode }) {
+  return (
+    <MemoryRouter initialEntries={["/workspaces/1/domain-packs/2/workflows/4/graph?versionId=3"]}>
+      {children}
+    </MemoryRouter>
+  );
+}
+
 describe("WorkflowGraphViewerPage", () => {
   beforeEach(() => {
     mockUseGetWorkflowDefinition.mockReset();
@@ -121,6 +129,25 @@ describe("WorkflowGraphViewerPage", () => {
     expect(screen.getByTestId("graph-viewer")).toBeInTheDocument();
   });
 
+  it("shows GraphViewer when graphJson is already an object and versionId exists", () => {
+    const mockData: WorkflowDefinitionDetail = {
+      workflowCode: "WF_REFUND",
+      graphJson: {
+        nodes: [],
+        edges: [],
+      },
+    };
+    mockUseGetWorkflowDefinition.mockReturnValue({
+      data: mockData,
+      isLoading: false,
+      error: null,
+    });
+
+    render(<WorkflowGraphViewerPage />, { wrapper: VersionSearchWrapper });
+
+    expect(screen.getByTestId("graph-viewer")).toBeInTheDocument();
+  });
+
   it("shows empty state when graphJson is null", () => {
     const mockData: WorkflowDefinitionDetail = {
       graphJson: undefined,
@@ -158,7 +185,7 @@ describe("WorkflowGraphViewerPage", () => {
 
     renderPage();
     expect(screen.getByTestId("graph-data-error-state")).toHaveTextContent(
-      "워크플로우 그래프 데이터 형식이 올바르지 않습니다.",
+      "응대 흐름도 데이터 형식이 올바르지 않습니다.",
     );
     expect(screen.queryByTestId("empty-state")).not.toBeInTheDocument();
   });

--- a/frontend/src/pages/domain-pack/ui/WorkflowGraphViewerPage.test.tsx
+++ b/frontend/src/pages/domain-pack/ui/WorkflowGraphViewerPage.test.tsx
@@ -68,14 +68,6 @@ function renderPage(path = "/workspaces/1/domain-packs/2/workflows/4/graph?versi
   );
 }
 
-function VersionSearchWrapper({ children }: { children: React.ReactNode }) {
-  return (
-    <MemoryRouter initialEntries={["/workspaces/1/domain-packs/2/workflows/4/graph?versionId=3"]}>
-      {children}
-    </MemoryRouter>
-  );
-}
-
 describe("WorkflowGraphViewerPage", () => {
   beforeEach(() => {
     mockUseGetWorkflowDefinition.mockReset();
@@ -143,7 +135,7 @@ describe("WorkflowGraphViewerPage", () => {
       error: null,
     });
 
-    render(<WorkflowGraphViewerPage />, { wrapper: VersionSearchWrapper });
+    renderPage();
 
     expect(screen.getByTestId("graph-viewer")).toBeInTheDocument();
   });

--- a/frontend/src/pages/domain-pack/ui/WorkflowGraphViewerPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/WorkflowGraphViewerPage.tsx
@@ -76,7 +76,7 @@ export function WorkflowGraphViewerPage() {
 
   useEffect(() => {
     if (error) {
-      toast.error("워크플로우 데이터를 불러오지 못했습니다.");
+      toast.error("응대 흐름 데이터를 불러오지 못했습니다.");
     }
   }, [error]);
 
@@ -88,10 +88,10 @@ export function WorkflowGraphViewerPage() {
           vId: vsId,
           packName,
           versionNo,
-          section: { label: "WORKFLOWS", path: "workflows" },
-          selectedLabel: data?.workflowCode ?? (wfId !== null ? `#${wfId}` : "GRAPH"),
+          section: { label: "응대 흐름", path: "workflows" },
+          selectedLabel: data?.workflowCode ?? (wfId !== null ? `#${wfId} 흐름도` : "흐름도"),
         })
-      : ["워크플로우 설계", "Workflow Graph"];
+      : ["도메인팩 관리", "응대 흐름도"];
 
   const listPath =
     wsId !== null && pkId !== null
@@ -103,7 +103,7 @@ export function WorkflowGraphViewerPage() {
       : null;
 
   const pageTitle =
-    data?.name ?? data?.workflowCode ?? (wfId !== null ? `워크플로우 #${wfId}` : "워크플로우 그래프");
+    data?.name ?? data?.workflowCode ?? (wfId !== null ? `응대 흐름 #${wfId}` : "응대 흐름도");
 
   const shell = (children: ReactNode) => (
     <OstoneShell active="workflows" crumbs={crumbs}>
@@ -152,7 +152,7 @@ export function WorkflowGraphViewerPage() {
     return shell(
       <div data-testid="loading-state" className={styles.loadingState}>
         <LoadingSpinner />
-        <span className={styles.loadingText}>워크플로우 데이터를 불러오는 중...</span>
+        <span className={styles.loadingText}>응대 흐름 데이터를 불러오는 중...</span>
       </div>,
     );
   }
@@ -172,7 +172,7 @@ export function WorkflowGraphViewerPage() {
   if (graphResult.status === "invalid") {
     return shell(
       <div data-testid="graph-data-error-state" className={styles.centerState}>
-        <ErrorState message="워크플로우 그래프 데이터 형식이 올바르지 않습니다." />
+        <ErrorState message="응대 흐름도 데이터 형식이 올바르지 않습니다." />
       </div>,
     );
   }
@@ -180,7 +180,7 @@ export function WorkflowGraphViewerPage() {
   if (graphResult.status === "empty") {
     return shell(
       <div data-testid="empty-state" className={styles.centerState}>
-        <EmptyState message="이 워크플로우에는 아직 그래프가 정의되어 있지 않습니다." />
+        <EmptyState message="표시할 응대 흐름도가 없습니다." />
       </div>,
     );
   }

--- a/frontend/src/pages/domain-pack/ui/sections/PackHeader.tsx
+++ b/frontend/src/pages/domain-pack/ui/sections/PackHeader.tsx
@@ -48,7 +48,7 @@ export function PackHeader() {
           }}
         >
           {" "}
-          — 환불 정책 v2 적용
+          — 환불 응대 기준 v2 적용
         </span>
       </h1>
 
@@ -57,7 +57,7 @@ export function PackHeader() {
         {[
           { label: "문의 유형", count: 28 },
           { label: "필요 정보", count: 14 },
-          { label: "응대 정책", count: 9 },
+          { label: "응대 기준", count: 9 },
           { label: "주의 사항", count: 6 },
           { label: "응대 흐름", count: 3 },
         ].map((meta) => (

--- a/frontend/src/pages/domain-pack/ui/sections/PackTabs.tsx
+++ b/frontend/src/pages/domain-pack/ui/sections/PackTabs.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 const TABS = [
   { label: "문의 유형", count: 3 },
   { label: "필요 정보", count: 2 },
-  { label: "응대 정책", count: 4 },
+  { label: "응대 기준", count: 4 },
   { label: "주의 사항", count: 5 },
   { label: "응대 흐름", count: 3 },
   { label: "테스트", count: 0 },

--- a/frontend/src/pages/generated-api-screen.integration.test.tsx
+++ b/frontend/src/pages/generated-api-screen.integration.test.tsx
@@ -230,7 +230,7 @@ describe("generated API affected read screens", () => {
       />,
     );
 
-    expect(screen.getByText("1 · LIST")).toBeInTheDocument();
+    expect(screen.getByText("1개")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /POL_REFUND/ })).toHaveTextContent("환불 정책");
     fireEvent.click(screen.getByRole("button", { name: /POL_REFUND/ }));
     expect(onSelect).toHaveBeenCalledWith(41);
@@ -253,7 +253,7 @@ describe("generated API affected read screens", () => {
     expect(screen.getAllByText("POL_REFUND").length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("환불 승인 조건")).toBeInTheDocument();
     expect(screen.getByText(/REFUND_REVIEW/)).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: /POL_REFUND 정책 수정/ }));
+    fireEvent.click(screen.getByRole("button", { name: /POL_REFUND 응대 기준 수정/ }));
     expect(onEdit).toHaveBeenCalledWith(41);
     expect(mocks.useGetPolicy).toHaveBeenCalledWith(1, 2, 3, 41, expect.any(Object));
   });
@@ -282,12 +282,12 @@ describe("generated API affected read screens", () => {
     );
 
     fireEvent.click(
-      within(screen.getByLabelText("위험요소 목록")).getByRole("button", { name: /RISK_FRAUD/ }),
+      within(screen.getByLabelText("주의 사항 목록")).getByRole("button", { name: /RISK_FRAUD/ }),
     );
     expect(onSelect).toHaveBeenCalledWith(51);
     expect(screen.getByText("부정 거래 징후")).toBeInTheDocument();
     expect(screen.getByText(/MANUAL_REVIEW/)).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: /RISK_FRAUD 위험요소 수정/ }));
+    fireEvent.click(screen.getByRole("button", { name: /RISK_FRAUD 주의 사항 수정/ }));
     expect(onEdit).toHaveBeenCalledWith(51);
   });
 
@@ -305,7 +305,7 @@ describe("generated API affected read screens", () => {
     expect(onSelect).toHaveBeenCalledWith(61);
     expect(screen.getAllByText("배송 주소").length).toBeGreaterThanOrEqual(1);
     expect(screen.getAllByText("STRING").length).toBeGreaterThanOrEqual(1);
-    expect(screen.getByText("NO")).toBeInTheDocument();
+    expect(screen.getByText("아니오")).toBeInTheDocument();
   });
 
   it("workflow 목록/상세 화면은 generated list/detail/transition/policy 응답을 함께 소비한다", () => {
@@ -321,8 +321,8 @@ describe("generated API affected read screens", () => {
     fireEvent.click(screen.getByRole("button", { name: /WF_REFUND/ }));
     expect(onSelect).toHaveBeenCalledWith(71);
     expect(screen.getAllByText("환불 처리").length).toBeGreaterThanOrEqual(1);
-    expect(screen.getByText("그래프 데이터 없음")).toBeInTheDocument();
-    expect(screen.queryByText("정책 목록을 불러오지 못했습니다.")).not.toBeInTheDocument();
+    expect(screen.getByText("흐름도 데이터 없음")).toBeInTheDocument();
+    expect(screen.queryByText("응대 기준 목록을 불러오지 못했습니다.")).not.toBeInTheDocument();
     expect(mocks.useListTransitions).toHaveBeenCalledWith(1, 2, 3, 71, expect.any(Object));
   });
 });

--- a/frontend/src/pages/workspace/ui/WorkspaceWorkflowsPage.test.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceWorkflowsPage.test.tsx
@@ -68,10 +68,10 @@ describe("WorkspaceWorkflowsPage", () => {
   });
 
   it("error 상태에서는 ErrorState를 보여준다", () => {
-    mockHook.mockReturnValue({ loading: false, error: "워크플로우 목록 조회 실패", entries: [] });
+    mockHook.mockReturnValue({ loading: false, error: "응대 흐름 목록 조회 실패", entries: [] });
     renderPage();
     expect(screen.getByTestId("workspace-workflows-error")).toBeInTheDocument();
-    expect(screen.getByText("워크플로우 목록 조회 실패")).toBeInTheDocument();
+    expect(screen.getByText("응대 흐름 목록 조회 실패")).toBeInTheDocument();
   });
 
   it("entries 비어 있으면 empty state를 보여준다", () => {
@@ -124,11 +124,11 @@ describe("WorkspaceWorkflowsPage", () => {
     );
   });
 
-  it("새 워크플로우 버튼 클릭 시 toast 호출", async () => {
+  it("새 응대 흐름 버튼 클릭 시 toast 호출", async () => {
     mockHook.mockReturnValue({ loading: false, error: null, entries: [] });
     const sonner = await import("sonner");
     renderPage();
-    fireEvent.click(screen.getByText("새 워크플로우"));
+    fireEvent.click(screen.getByText("새 응대 흐름"));
     expect(sonner.toast).toHaveBeenCalledWith("준비 중입니다");
   });
 });

--- a/frontend/src/pages/workspace/ui/WorkspaceWorkflowsPage.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceWorkflowsPage.tsx
@@ -45,17 +45,17 @@ export function WorkspaceWorkflowsPage() {
   return (
     <div className={styles.pageWrapper}>
       <div className={styles.pageHeader}>
-        <h1 className={styles.pageTitle}>Workflows</h1>
+        <h1 className={styles.pageTitle}>응대 흐름</h1>
         <Button variant="outline" size="sm" onClick={handleNewWorkflow}>
           <PlusIcon className={styles.pageHeaderIcon} />
-          <span>새 워크플로우</span>
+          <span>새 응대 흐름</span>
         </Button>
       </div>
 
       {loading && (
         <div className={styles.statePanel} data-testid="workspace-workflows-loading">
           <LoadingSpinner />
-          <p className={styles.stateText}>워크플로우 목록을 불러오는 중입니다.</p>
+          <p className={styles.stateText}>응대 흐름 목록을 불러오는 중입니다.</p>
         </div>
       )}
 
@@ -67,7 +67,7 @@ export function WorkspaceWorkflowsPage() {
 
       {!loading && !error && entries.length === 0 && (
         <div className={styles.statePanel} data-testid="workspace-workflows-empty">
-          <EmptyState message="아직 등록된 워크플로우가 없습니다. 도메인팩에서 워크플로우를 생성해 주세요." />
+          <EmptyState message="아직 등록된 응대 흐름이 없습니다. 도메인팩에서 응대 흐름을 생성해 주세요." />
         </div>
       )}
 

--- a/frontend/src/shared/lib/domainPackRoutes.ts
+++ b/frontend/src/shared/lib/domainPackRoutes.ts
@@ -1,11 +1,11 @@
 export type DomainPackSection = "intents" | "slots" | "policies" | "risks" | "workflows";
 
 export const SECTION_LABEL: Record<DomainPackSection, string> = {
-  intents: "INTENTS",
-  slots: "SLOTS",
-  policies: "POLICIES",
-  risks: "RISKS",
-  workflows: "WORKFLOWS",
+  intents: "상담 유형",
+  slots: "확인 항목",
+  policies: "응대 기준",
+  risks: "주의 사항",
+  workflows: "응대 흐름",
 };
 
 export interface DomainPackCrumbInput {

--- a/frontend/src/shared/lib/workflowSettings.ts
+++ b/frontend/src/shared/lib/workflowSettings.ts
@@ -31,12 +31,12 @@ const PAGE_KEY = "ostone:page:workflow-settings";
 export const PAGE_SIZE_OPTIONS = [6, 12, 24] as const;
 export const TOP_N_OPTIONS = [3, 5, 10, 20] as const;
 export const SORT_FIELD_OPTIONS: ReadonlyArray<{ value: WorkflowSortField; label: string }> = [
-  { value: "workflowCode", label: "Code" },
-  { value: "name", label: "Name" },
+  { value: "workflowCode", label: "응대 코드" },
+  { value: "name", label: "이름" },
 ];
 export const SORT_DIR_OPTIONS: ReadonlyArray<{ value: SortDir; label: string }> = [
-  { value: "asc", label: "Asc" },
-  { value: "desc", label: "Desc" },
+  { value: "asc", label: "오름차순" },
+  { value: "desc", label: "내림차순" },
 ];
 
 function safeParse<T>(raw: string | null, fallback: T, validate: (v: unknown) => v is T): T {

--- a/frontend/src/shared/ui/file-upload/FileUploader.test.tsx
+++ b/frontend/src/shared/ui/file-upload/FileUploader.test.tsx
@@ -7,14 +7,14 @@ describe("FileUploader", () => {
   it("shows the default JSON 50MB upload policy", () => {
     render(<FileUploader onFileSelect={vi.fn()} />);
 
-    expect(screen.getByText("Support for a single JSON file upload up to 50MB.")).toBeInTheDocument();
+    expect(screen.getByText(/JSON 파일 1개를 업로드할 수 있습니다\. 최대 50MB\./)).toBeInTheDocument();
     expect(screen.getByText("JSON")).toBeInTheDocument();
   });
 
   it("uses JSON wording while analyzing", () => {
     render(<FileUploader onFileSelect={vi.fn()} status="analyzing" />);
 
-    expect(screen.getByText("Analyzing JSON Log...")).toBeInTheDocument();
-    expect(screen.queryByText("Analyzing CSV Log...")).not.toBeInTheDocument();
+    expect(screen.getByText("상담 로그 분석 중...")).toBeInTheDocument();
+    expect(screen.queryByText("CSV 로그 분석 중...")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/shared/ui/file-upload/FileUploader.tsx
+++ b/frontend/src/shared/ui/file-upload/FileUploader.tsx
@@ -61,8 +61,8 @@ export const FileUploader: React.FC<FileUploaderProps> = ({
     return (
       <div className={`${styles.uploaderBox} ${styles.successBox}`}>
         <CheckCircle2 size={48} className={styles.successIcon} />
-        <h3 className={styles.title}>Upload Complete</h3>
-        <p className={styles.mutedText}>Log data has been successfully processed.</p>
+        <h3 className={styles.title}>업로드 완료</h3>
+        <p className={styles.mutedText}>상담 로그 처리가 완료되었습니다.</p>
       </div>
     );
   }
@@ -73,7 +73,7 @@ export const FileUploader: React.FC<FileUploaderProps> = ({
         <div className={styles.loaderArea}>
           <div className={styles.spinner} />
           <h3 className={`${styles.statusText} ${styles.title}`}>
-            {status === "analyzing" ? "Analyzing JSON Log..." : "Uploading File..."}
+            {status === "analyzing" ? "상담 로그 분석 중..." : "파일 업로드 중..."}
           </h3>
           <div className={styles.progressBarContainer}>
             <div className={styles.progressBar} style={{ width: `${progress}%` }} />
@@ -103,9 +103,9 @@ export const FileUploader: React.FC<FileUploaderProps> = ({
       <div className={styles.iconWrapper}>
         <UploadCloud size={40} className={styles.uploadIcon} />
       </div>
-      <h3 className={styles.title}>Click or drag file to this area to upload</h3>
+      <h3 className={styles.title}>파일을 클릭하거나 끌어다 놓으세요</h3>
       <p className={styles.mutedText}>
-        Support for a single {acceptedTypeLabel} file upload up to {maxSizeLabel}.
+        {acceptedTypeLabel} 파일 1개를 업로드할 수 있습니다. 최대 {maxSizeLabel}.
       </p>
 
       <div className={styles.fileTypesHint}>

--- a/frontend/src/shared/ui/layout/DashboardLayout.tsx
+++ b/frontend/src/shared/ui/layout/DashboardLayout.tsx
@@ -33,19 +33,19 @@ export const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children }) =>
       {/* Top Navbar */}
       <header className={styles.topbar}>
         <div className={styles.logo}>
-          <span className={styles.logoHighlight}>Ostone</span> Workflow
+          <span className={styles.logoHighlight}>Ostone</span> 응대 흐름
         </div>
         <nav className={styles.navMenu}>
           <NavLink to="/workspaces" className={getNavLinkClass}>
-            Workspaces
+            워크스페이스
           </NavLink>
           <NavLink to="/workspaces" className={getNavLinkClass}>
-            Upload Log
+            상담 로그 수집
           </NavLink>
           <NavLink to="/workspaces" className={getNavLinkClass}>
-            Consultation
+            상담 응대
           </NavLink>
-          <span className={`${styles.navItem} ${styles.disabled}`}>Settings</span>
+          <span className={`${styles.navItem} ${styles.disabled}`}>설정</span>
         </nav>
         <div className={styles.profileArea}>
           <div className={styles.avatar}>{userInitial}</div>

--- a/frontend/src/shared/ui/ostone/chrome/Sidebar.test.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/Sidebar.test.tsx
@@ -23,13 +23,13 @@ describe("Sidebar", () => {
     const nav = screen.getByLabelText("주요 내비게이션");
     expect(nav).toHaveAttribute("data-collapsed", "false");
     expect(nav).toHaveStyle({ width: "200px" });
-    expect(screen.getByTitle("Consultation")).toBeInTheDocument();
+    expect(screen.getByTitle("상담 응대")).toBeInTheDocument();
     expect(screen.getByTitle("사용자 화면 미리보기")).toBeInTheDocument();
-    expect(screen.getByTitle("Uploads")).toBeInTheDocument();
-    expect(screen.getByTitle("Domain Packs")).toBeInTheDocument();
-    expect(screen.getByText("Consultation")).toBeInTheDocument();
+    expect(screen.getByTitle("상담 로그 수집")).toBeInTheDocument();
+    expect(screen.getByTitle("도메인팩 관리")).toBeInTheDocument();
+    expect(screen.getByText("상담 응대")).toBeInTheDocument();
     expect(screen.getByText("사용자 화면 미리보기")).toBeInTheDocument();
-    expect(screen.getByText("Uploads")).toBeInTheDocument();
+    expect(screen.getByText("상담 로그 수집")).toBeInTheDocument();
     expect(screen.queryByTitle("Workflows")).not.toBeInTheDocument();
   });
 
@@ -71,13 +71,13 @@ describe("Sidebar", () => {
   it("active=consult일 때 Consultation 항목이 강조된다", () => {
     renderSidebar({ active: "consult" });
 
-    expect(screen.getByTitle("Consultation")).toHaveAttribute("data-active", "true");
+    expect(screen.getByTitle("상담 응대")).toHaveAttribute("data-active", "true");
   });
 
   it("basePath prop을 지정하면 링크에 반영된다", () => {
     renderSidebar({ basePath: "/workspaces/7" });
 
-    expect(screen.getByTitle("Consultation")).toHaveAttribute("href", "/workspaces/7/consultation");
+    expect(screen.getByTitle("상담 응대")).toHaveAttribute("href", "/workspaces/7/consultation");
     expect(screen.getByTitle("사용자 화면 미리보기")).toHaveAttribute(
       "href",
       "/demo/workspaces/7/chat",
@@ -87,7 +87,7 @@ describe("Sidebar", () => {
       "rel",
       "noopener noreferrer",
     );
-    expect(screen.getByTitle("Domain Packs")).toHaveAttribute("href", "/workspaces/7/domain-packs");
+    expect(screen.getByTitle("도메인팩 관리")).toHaveAttribute("href", "/workspaces/7/domain-packs");
   });
 
   it("workspaceId를 추출할 수 없으면 사용자 화면 미리보기 링크를 안전한 내부 경로로 보낸다", () => {
@@ -104,7 +104,7 @@ describe("Sidebar", () => {
 
   it("inactive 항목에 mouseEnter/Leave 시 배경이 토글된다", () => {
     renderSidebar({ active: "consult" });
-    const link = screen.getByTitle("Uploads") as HTMLElement;
+    const link = screen.getByTitle("상담 로그 수집") as HTMLElement;
 
     fireEvent.mouseEnter(link);
     expect(link.style.background).toBe("var(--paper-3)");
@@ -115,8 +115,8 @@ describe("Sidebar", () => {
   it("redesign: active 링크는 fontWeight 540, idle은 450 으로 그려진다", () => {
     renderSidebar({ active: "consult" });
 
-    const activeLink = screen.getByTitle("Consultation") as HTMLElement;
-    const idleLink = screen.getByTitle("Uploads") as HTMLElement;
+    const activeLink = screen.getByTitle("상담 응대") as HTMLElement;
+    const idleLink = screen.getByTitle("상담 로그 수집") as HTMLElement;
 
     expect(activeLink.style.fontWeight).toBe("540");
     expect(idleLink.style.fontWeight).toBe("450");
@@ -125,7 +125,7 @@ describe("Sidebar", () => {
   it("redesign: 모든 링크는 13.5px / letter-spacing -0.18px / Pretendard 변수 폰트를 사용한다", () => {
     renderSidebar({ active: "consult" });
 
-    const link = screen.getByTitle("Consultation") as HTMLElement;
+    const link = screen.getByTitle("상담 응대") as HTMLElement;
     expect(link.style.fontSize).toBe("13.5px");
     expect(link.style.letterSpacing).toBe("-0.18px");
     expect(link.style.fontFamily).toBe("var(--font-sans)");

--- a/frontend/src/shared/ui/ostone/chrome/Sidebar.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/Sidebar.tsx
@@ -43,7 +43,7 @@ const TOP_NAV_ITEMS: TopNavItem[] = [
   {
     key: "consult",
     icon: "book",
-    label: "Consultation",
+    label: "상담 응대",
     getPath: (base) => `${base}/consultation`,
   },
   {
@@ -56,12 +56,12 @@ const TOP_NAV_ITEMS: TopNavItem[] = [
   {
     key: "upload",
     icon: "upload",
-    label: "Uploads",
+    label: "상담 로그 수집",
     getPath: (base) => `${base}/upload`,
   },
 ];
 
-const DOMAIN_PACKS_LABEL = "Domain Packs";
+const DOMAIN_PACKS_LABEL = "도메인팩 관리";
 const DOMAIN_PACKS_ICON: IconName = "folder";
 const SIDEBAR_WIDTH = "200px";
 

--- a/frontend/src/widgets/ostone-shell/ui/OstoneShell.test.tsx
+++ b/frontend/src/widgets/ostone-shell/ui/OstoneShell.test.tsx
@@ -21,10 +21,10 @@ describe("OstoneShell", () => {
     );
     expect(screen.queryByTitle("Operator")).not.toBeInTheDocument();
     expect(screen.queryByTitle("Pipeline")).not.toBeInTheDocument();
-    expect(screen.getByTitle("Consultation")).toBeInTheDocument();
+    expect(screen.getByTitle("상담 응대")).toBeInTheDocument();
     expect(screen.getByTitle("사용자 화면 미리보기")).toBeInTheDocument();
-    expect(screen.getByTitle("Uploads")).toBeInTheDocument();
-    expect(screen.getByTitle("Domain Packs")).toBeInTheDocument();
+    expect(screen.getByTitle("상담 로그 수집")).toBeInTheDocument();
+    expect(screen.getByTitle("도메인팩 관리")).toBeInTheDocument();
     expect(screen.queryByTitle("Workflows")).not.toBeInTheDocument();
   });
 
@@ -37,7 +37,7 @@ describe("OstoneShell", () => {
     );
     expect(screen.getByText("CStone")).toBeInTheDocument();
     expect(screen.getByText("CARD-CS")).toBeInTheDocument();
-    expect(screen.getAllByText("Domain Packs")).toHaveLength(2);
+    expect(screen.getAllByText("도메인팩 관리")).toHaveLength(2);
   });
 
   it("상위 화면의 workspace breadcrumb를 업무 라벨로 표시한다", () => {
@@ -49,7 +49,7 @@ describe("OstoneShell", () => {
     );
 
     expect(screen.queryByText("CARD-CS")).not.toBeInTheDocument();
-    expect(screen.getByText("상담 로그 수집")).toBeInTheDocument();
+    expect(screen.getAllByText("상담 로그 수집").length).toBeGreaterThanOrEqual(1);
   });
 
   it("상세 화면의 여러 breadcrumb는 그대로 유지한다", () => {
@@ -61,8 +61,8 @@ describe("OstoneShell", () => {
     );
 
     expect(screen.getByText("WS · 1")).toBeInTheDocument();
-    expect(screen.getAllByText("Domain Packs")).toHaveLength(2);
-    expect(screen.getByText("Workflows")).toBeInTheDocument();
+    expect(screen.getAllByText("도메인팩 관리")).toHaveLength(2);
+    expect(screen.getByText("응대 흐름")).toBeInTheDocument();
   });
 
   it("renders children in main area", () => {

--- a/frontend/src/widgets/ostone-shell/ui/OstoneShell.tsx
+++ b/frontend/src/widgets/ostone-shell/ui/OstoneShell.tsx
@@ -22,10 +22,15 @@ interface SidebarBaseProps {
 }
 
 const TOP_LEVEL_CRUMB_BY_ACTIVE: Partial<Record<SidebarActive, string>> = {
-  workflows: "워크플로우 설계",
+  workflows: "응대 흐름 관리",
   upload: "상담 로그 수집",
   consult: "상담 응대",
   domain: "도메인팩 관리",
+  chat: "사용자 화면 미리보기",
+  intent: "상담 유형",
+  slot: "확인 항목",
+  policy: "응대 기준",
+  risk: "주의 사항",
 };
 
 function labelOf(c: Crumb): string {
@@ -45,6 +50,26 @@ function resolveDisplayCrumbs(active: SidebarActive, crumbs: Crumb[]): Crumb[] {
 
   if (first === "CARD-CS" && second === "Pipeline · Datasets") {
     return ["상담 로그 수집"];
+  }
+
+  if (second === "Domain Packs") {
+    const sectionMap: Record<string, string> = {
+      Workflows: "응대 흐름",
+      WORKFLOWS: "응대 흐름",
+      Intents: "상담 유형",
+      INTENTS: "상담 유형",
+      Slots: "확인 항목",
+      SLOTS: "확인 항목",
+      Policies: "응대 기준",
+      POLICIES: "응대 기준",
+      Risks: "주의 사항",
+      RISKS: "주의 사항",
+    };
+    return crumbs.map((crumb) => {
+      const label = labelOf(crumb);
+      const nextLabel = label === "Domain Packs" ? "도메인팩 관리" : (sectionMap[label] ?? label);
+      return typeof crumb === "string" ? nextLabel : { ...crumb, label: nextLabel };
+    });
   }
 
   const topLevelCrumb = TOP_LEVEL_CRUMB_BY_ACTIVE[active];


### PR DESCRIPTION
## Summary
- 사이드바와 주요 CTA를 한국어 업무 용어로 정리했습니다.
- `Workflow`, `Intent`, `Slot`, `Policy`, `Risk`, `Draft` 계열 표시 문구를 각각 `응대 흐름`, `상담 유형`, `확인 항목`, `응대 기준`, `주의 사항`, `검토본` 중심으로 맞췄습니다.
- 도메인팩 상세/검토 화면, 상담 로그 수집 화면, 상담 화면, 관련 테스트 기대값을 함께 갱신했습니다.

## Why
CS 운영자용 도구에서 영어/개발자식 용어가 섞여 보이던 문제를 줄이고, 실제 상담사가 이해하기 쉬운 업무 표현으로 일관시키기 위함입니다.

Closes #324

## Validation
- `cd frontend && pnpm test -- --run`
- `cd frontend && pnpm build`

## Notes
- `cd frontend && pnpm lint`는 기존 코드베이스의 `no-explicit-any`, React hooks compiler, fast-refresh 규칙 위반 등 64건으로 실패합니다. 이번 변경 검증은 전체 테스트와 production build로 확인했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **스타일**
  * UI 전반(페이지, 버튼, 라벨, 접근성 텍스트 등)이 영어/기술용어에서 한국어 상담업무 용어로 일관되게 현지화되었습니다(예: 워크플로우→응대 흐름 등).
* **버그 수정**
  * 에러/빈 상태/성공·실패 토스트 및 접근성 라벨 등 사용자 피드백 문구가 한국어로 정렬되어 일관성 있는 안내를 제공합니다.
* **개선**
  * 상태·중요도·위험도 등 도메인 값 표기가 업무 친화적 한국어로 매핑되어 가독성이 향상되었습니다.
* **문서화**
  * 사용자-facing 테스트 기대값과 메시지들이 한국어 기준으로 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->