### PR TITLE
chore(frontend): 워크플로우 목록 CTA를 도메인팩 이동으로 정리

### DIFF
--- a/frontend/src/app/App.test.tsx
+++ b/frontend/src/app/App.test.tsx
@@ -108,7 +108,7 @@ describe("App", () => {
     expect(await screen.findByText("응대 흐름")).toBeInTheDocument();
     expect(
       await screen.findByText(
-        "아직 등록된 응대 흐름이 없습니다. 도메인팩에서 응대 흐름을 생성해 주세요.",
+        "아직 등록된 응대 흐름이 없습니다. 응대 흐름은 도메인팩에서 생성하고 관리합니다.",
       ),
     ).toBeInTheDocument();
     expect(fetchMock).toHaveBeenCalledWith(

--- a/frontend/src/pages/workspace/ui/WorkspaceWorkflowsPage.test.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceWorkflowsPage.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
+
 import { WorkspaceWorkflowsPage } from "./WorkspaceWorkflowsPage";
 
 const mockNavigate = vi.fn();
@@ -16,8 +17,6 @@ const mockHook = vi.fn();
 vi.mock("@/entities/workflow", () => ({
   useListAllWorkspaceWorkflows: (...args: unknown[]) => mockHook(...args),
 }));
-
-vi.mock("sonner", () => ({ toast: vi.fn() }));
 
 vi.mock("@/features/workflow-list", () => ({
   WorkflowListView: vi.fn(({ entries, onOpen }) => (
@@ -78,6 +77,11 @@ describe("WorkspaceWorkflowsPage", () => {
     mockHook.mockReturnValue({ loading: false, error: null, entries: [] });
     renderPage();
     expect(screen.getByTestId("workspace-workflows-empty")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "아직 등록된 응대 흐름이 없습니다. 응대 흐름은 도메인팩에서 생성하고 관리합니다.",
+      ),
+    ).toBeInTheDocument();
   });
 
   it("entries가 있으면 WorkflowListView로 전달한다", () => {
@@ -124,11 +128,17 @@ describe("WorkspaceWorkflowsPage", () => {
     );
   });
 
-  it("새 응대 흐름 버튼 클릭 시 toast 호출", async () => {
+  it("헤더 CTA 클릭 시 도메인팩 목록으로 이동한다", () => {
     mockHook.mockReturnValue({ loading: false, error: null, entries: [] });
-    const sonner = await import("sonner");
     renderPage();
-    fireEvent.click(screen.getByText("새 응대 흐름"));
-    expect(sonner.toast).toHaveBeenCalledWith("준비 중입니다");
+    fireEvent.click(screen.getByText("도메인팩 관리"));
+    expect(mockNavigate).toHaveBeenCalledWith("/workspaces/1/domain-packs");
+  });
+
+  it("empty state CTA 클릭 시 도메인팩 목록으로 이동한다", () => {
+    mockHook.mockReturnValue({ loading: false, error: null, entries: [] });
+    renderPage();
+    fireEvent.click(screen.getByText("도메인팩으로 이동"));
+    expect(mockNavigate).toHaveBeenCalledWith("/workspaces/1/domain-packs");
   });
 });

--- a/frontend/src/pages/workspace/ui/WorkspaceWorkflowsPage.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceWorkflowsPage.tsx
@@ -1,9 +1,8 @@
-import { PlusIcon } from "lucide-react";
+import { ArrowRightIcon } from "lucide-react";
 import { Navigate, useNavigate, useParams } from "react-router-dom";
-import { toast } from "sonner";
 
 import { useListAllWorkspaceWorkflows } from "@/entities/workflow";
-import { domainPackSectionPath } from "@/shared/lib/domainPackRoutes";
+import { domainPackListPath, domainPackSectionPath } from "@/shared/lib/domainPackRoutes";
 import { parseRouteId } from "@/shared/lib/parseRouteId";
 import { Button } from "@/shared/ui/button";
 import { LoadingSpinner } from "@/shared/ui/ostone/atoms/LoadingSpinner";
@@ -38,17 +37,17 @@ export function WorkspaceWorkflowsPage() {
     );
   };
 
-  const handleNewWorkflow = () => {
-    toast("준비 중입니다");
+  const handleOpenDomainPacks = () => {
+    navigate(domainPackListPath(parsedWorkspaceId));
   };
 
   return (
     <div className={styles.pageWrapper}>
       <div className={styles.pageHeader}>
         <h1 className={styles.pageTitle}>응대 흐름</h1>
-        <Button variant="outline" size="sm" onClick={handleNewWorkflow}>
-          <PlusIcon className={styles.pageHeaderIcon} />
-          <span>새 응대 흐름</span>
+        <Button variant="outline" size="sm" onClick={handleOpenDomainPacks}>
+          <span>도메인팩 관리</span>
+          <ArrowRightIcon className={styles.pageHeaderIcon} />
         </Button>
       </div>
 
@@ -67,7 +66,11 @@ export function WorkspaceWorkflowsPage() {
 
       {!loading && !error && entries.length === 0 && (
         <div className={styles.statePanel} data-testid="workspace-workflows-empty">
-          <EmptyState message="아직 등록된 응대 흐름이 없습니다. 도메인팩에서 응대 흐름을 생성해 주세요." />
+          <EmptyState message="아직 등록된 응대 흐름이 없습니다. 응대 흐름은 도메인팩에서 생성하고 관리합니다." />
+          <Button variant="outline" size="sm" onClick={handleOpenDomainPacks}>
+            <span>도메인팩으로 이동</span>
+            <ArrowRightIcon className={styles.pageHeaderIcon} />
+          </Button>
         </div>
       )}
 

--- a/frontend/src/shared/lib/domainPackRoutes.test.ts
+++ b/frontend/src/shared/lib/domainPackRoutes.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  domainPackListPath,
   domainPackPath,
   domainPackPathFromBase,
   domainPackSectionPath,
@@ -26,6 +27,7 @@ describe("domainPackRoutes", () => {
   });
 
   it("domain pack 기본 경로를 만든다", () => {
+    expect(domainPackListPath(1)).toBe("/workspaces/1/domain-packs");
     expect(domainPackPath(1, 2)).toBe("/workspaces/1/domain-packs/2");
     expect(domainPackPathFromBase("/workspaces/1", 2)).toBe("/workspaces/1/domain-packs/2");
   });

--- a/frontend/src/shared/lib/domainPackRoutes.ts
+++ b/frontend/src/shared/lib/domainPackRoutes.ts
@@ -53,8 +53,12 @@ export function withVersionSearch(path: string, versionId: number | null): strin
   return `${path}${separator}versionId=${versionId}`;
 }
 
+export function domainPackListPath(workspaceId: number): string {
+  return `/workspaces/${workspaceId}/domain-packs`;
+}
+
 export function domainPackPath(workspaceId: number, packId: number): string {
-  return `/workspaces/${workspaceId}/domain-packs/${packId}`;
+  return `${domainPackListPath(workspaceId)}/${packId}`;
 }
 
 export function domainPackSectionPath(


### PR DESCRIPTION
## Summary
- 워크스페이스 워크플로우 목록의 `새 워크플로우` CTA를 실제 동작하는 `도메인팩 관리` 이동으로 변경했습니다.
- 워크플로우 empty state 문구를 도메인팩 산출물이라는 제품 모델에 맞춰 정리하고, `도메인팩으로 이동` CTA를 추가했습니다.
- 도메인팩 목록 경로 헬퍼를 추가해 워크플로우 화면의 이동 경로를 공통 라우트 유틸로 관리합니다.

## Root Cause
- 워크플로우 목록 화면의 주요 CTA가 독립 생성처럼 보였지만 실제로는 `준비 중입니다` 토스트만 표시했습니다.
- empty state는 도메인팩에서 워크플로우를 생성하라고 안내해 버튼 동작과 제품 모델이 서로 맞지 않았습니다.

## Validation
- `cd frontend && pnpm test -- WorkspaceWorkflowsPage App.test.tsx domainPackRoutes.test.ts`
- `cd frontend && pnpm exec eslint src/pages/workspace/ui/WorkspaceWorkflowsPage.tsx src/pages/workspace/ui/WorkspaceWorkflowsPage.test.tsx src/app/App.test.tsx src/shared/lib/domainPackRoutes.ts src/shared/lib/domainPackRoutes.test.ts`
- `cd frontend && pnpm build`

## Notes
- `cd frontend && pnpm lint`는 기존 코드베이스의 `no-explicit-any`, React hooks compiler, fast-refresh 규칙 위반 등 64건으로 실패합니다. 이번 변경 파일 대상 lint는 통과했습니다.

Closes #322