### PR TITLE
fix(frontend): 도메인팩 요약 Slot 카드 목록 진입 흐름 연결

### DIFF
--- a/frontend/src/features/domain-pack-summary-read/ui/ComponentCountGrid.generated-api.test.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/ComponentCountGrid.generated-api.test.tsx
@@ -79,9 +79,6 @@ function renderGrid() {
       slotCount={1}
       policyCount={1}
       workflowCount={1}
-      renderSlotEditSheet={(slotId, isOpen) =>
-        isOpen ? <div role="dialog">slot edit {slotId}</div> : null
-      }
     />,
   );
 }
@@ -132,11 +129,21 @@ describe("ComponentCountGrid generated API integration", () => {
     );
   });
 
-  it("generated slot preview가 있으면 Slot 카드에서 편집 sheet를 연다", () => {
+  it("generated slot preview가 있으면 Slot 카드에서 목록으로 이동한다", () => {
     renderGrid();
 
     fireEvent.click(screen.getByRole("button", { name: /Slot/ }));
 
-    expect(screen.getByRole("dialog")).toHaveTextContent("slot edit 11");
+    expect(mocks.navigate).toHaveBeenCalledWith("/workspaces/1/domain-packs/2/slots?versionId=3");
+  });
+
+  it("generated slot preview 항목 클릭 시 해당 slot 상세로 이동한다", () => {
+    renderGrid();
+
+    fireEvent.click(screen.getByText("배송 주소"));
+
+    expect(mocks.navigate).toHaveBeenCalledWith(
+      "/workspaces/1/domain-packs/2/slots/11?versionId=3",
+    );
   });
 });

--- a/frontend/src/features/domain-pack-summary-read/ui/ComponentCountGrid.test.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/ComponentCountGrid.test.tsx
@@ -36,10 +36,6 @@ const defaultProps = {
   workflowCount: 4,
 };
 
-function renderSlotEditSheet(_slotId: number, isOpen: boolean) {
-  return isOpen ? <div role="dialog">슬롯 수정</div> : null;
-}
-
 describe("ComponentCountGrid", () => {
   beforeEach(() => {
     mockNavigate.mockReset();
@@ -51,7 +47,7 @@ describe("ComponentCountGrid", () => {
   });
 
   it("카드 레이블과 카운트를 렌더링한다", () => {
-    render(<ComponentCountGrid {...defaultProps} renderSlotEditSheet={renderSlotEditSheet} />);
+    render(<ComponentCountGrid {...defaultProps} />);
     expect(screen.getByText("Intent")).toBeInTheDocument();
     expect(screen.getByText("2")).toBeInTheDocument();
     expect(screen.getByText("Workflow")).toBeInTheDocument();
@@ -59,7 +55,7 @@ describe("ComponentCountGrid", () => {
   });
 
   it("Intent, Policy 카드 클릭 시 상세 목록으로 이동한다", () => {
-    render(<ComponentCountGrid {...defaultProps} renderSlotEditSheet={renderSlotEditSheet} />);
+    render(<ComponentCountGrid {...defaultProps} />);
     fireEvent.click(screen.getByRole("button", { name: /Intent/ }));
     expect(mockNavigate).toHaveBeenCalledWith("/workspaces/1/domain-packs/2/intents?versionId=3");
 
@@ -67,13 +63,22 @@ describe("ComponentCountGrid", () => {
     expect(mockNavigate).toHaveBeenCalledWith("/workspaces/1/domain-packs/2/policies?versionId=3");
   });
 
-  it("Slot 카드 클릭 시 SlotEditSheet를 연다", () => {
+  it("Slot 카드 클릭 시 Slot 목록으로 이동한다", () => {
     vi.mocked(previewLists.useSlotPreview).mockReturnValue(
       makeHook({ data: [{ id: 9, name: "slot-1" }] }),
     );
-    render(<ComponentCountGrid {...defaultProps} renderSlotEditSheet={renderSlotEditSheet} />);
+    render(<ComponentCountGrid {...defaultProps} />);
     fireEvent.click(screen.getByRole("button", { name: /Slot/ }));
-    expect(screen.getByRole("dialog")).toHaveTextContent("슬롯 수정");
+    expect(mockNavigate).toHaveBeenCalledWith("/workspaces/1/domain-packs/2/slots?versionId=3");
+  });
+
+  it("Slot 미리보기 항목 클릭 시 해당 id로 navigate를 호출한다", () => {
+    vi.mocked(previewLists.useSlotPreview).mockReturnValue(
+      makeHook({ data: [{ id: 9, name: "slot-1" }] }),
+    );
+    render(<ComponentCountGrid {...defaultProps} />);
+    fireEvent.click(screen.getByText("slot-1"));
+    expect(mockNavigate).toHaveBeenCalledWith("/workspaces/1/domain-packs/2/slots/9?versionId=3");
   });
 
   it("로딩 중일 때 스켈레톤을 렌더링한다", () => {

--- a/frontend/src/features/domain-pack-summary-read/ui/ComponentCountGrid.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/ComponentCountGrid.tsx
@@ -1,5 +1,4 @@
-import { useEffect, useState } from "react";
-import type { ReactNode } from "react";
+import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { toast } from "sonner";
 import { domainPackSectionPath } from "@/shared/lib/domainPackRoutes";
@@ -19,7 +18,6 @@ interface ComponentCountGridProps {
   slotCount: number;
   policyCount: number;
   workflowCount: number;
-  renderSlotEditSheet?: (slotId: number, isOpen: boolean, onClose: () => void) => ReactNode;
 }
 
 export function ComponentCountGrid({
@@ -30,10 +28,8 @@ export function ComponentCountGrid({
   slotCount,
   policyCount,
   workflowCount,
-  renderSlotEditSheet,
 }: ComponentCountGridProps) {
   const navigate = useNavigate();
-  const [slotEditOpen, setSlotEditOpen] = useState(false);
 
   const intentPreview = useIntentPreview(wsId, packId, versionId);
   const slotPreview = useSlotPreview(wsId, packId, versionId);
@@ -56,56 +52,57 @@ export function ComponentCountGrid({
     if (workflowPreview.isError) toast.error("Workflow 미리보기 로드 실패");
   }, [workflowPreview.isError]);
 
-  const firstSlotId = slotPreview.data?.[0]?.id;
-
   return (
-    <>
-      <div className={styles.grid}>
-        <CountCard
-          label="Intent"
-          count={intentCount}
-          disabled={false}
-          onNavigate={() => navigate(domainPackSectionPath(wsId, packId, versionId, "intents"))}
-          previewNames={intentPreview.data?.map((i) => i.name) as string[]}
-          isLoadingPreview={intentPreview.isLoading}
-        />
-        <CountCard
-          label="Slot"
-          count={slotCount}
-          disabled={firstSlotId === undefined}
-          tooltip="수정할 Slot이 없습니다"
-          onNavigate={() => setSlotEditOpen(true)}
-          previewNames={slotPreview.data?.map((s) => s.name) as string[]}
-          isLoadingPreview={slotPreview.isLoading}
-        />
-        <CountCard
-          label="Policy"
-          count={policyCount}
-          disabled={false}
-          onNavigate={() => navigate(domainPackSectionPath(wsId, packId, versionId, "policies"))}
-          previewNames={policyPreview.data?.map((p) => p.name) as string[]}
-          isLoadingPreview={policyPreview.isLoading}
-        />
-        <CountCard
-          label="Workflow"
-          count={workflowCount}
-          disabled={false}
-          onNavigate={() => navigate(domainPackSectionPath(wsId, packId, versionId, "workflows"))}
-          previewItems={
-            workflowPreview.data?.map((w) => ({ id: w.id, name: w.name })) as {
-              id: number;
-              name: string;
-            }[]
-          }
-          isLoadingPreview={workflowPreview.isLoading}
-          onPreviewItemClick={(id) =>
-            navigate(domainPackSectionPath(wsId, packId, versionId, "workflows", id))
-          }
-        />
-      </div>
-      {firstSlotId !== undefined &&
-        renderSlotEditSheet?.(firstSlotId, slotEditOpen, () => setSlotEditOpen(false))}
-    </>
+    <div className={styles.grid}>
+      <CountCard
+        label="Intent"
+        count={intentCount}
+        disabled={false}
+        onNavigate={() => navigate(domainPackSectionPath(wsId, packId, versionId, "intents"))}
+        previewNames={intentPreview.data?.map((i) => i.name) as string[]}
+        isLoadingPreview={intentPreview.isLoading}
+      />
+      <CountCard
+        label="Slot"
+        count={slotCount}
+        disabled={false}
+        onNavigate={() => navigate(domainPackSectionPath(wsId, packId, versionId, "slots"))}
+        previewItems={
+          slotPreview.data?.map((s) => ({ id: s.id, name: s.name })) as {
+            id: number;
+            name: string;
+          }[]
+        }
+        isLoadingPreview={slotPreview.isLoading}
+        onPreviewItemClick={(id) =>
+          navigate(domainPackSectionPath(wsId, packId, versionId, "slots", id))
+        }
+      />
+      <CountCard
+        label="Policy"
+        count={policyCount}
+        disabled={false}
+        onNavigate={() => navigate(domainPackSectionPath(wsId, packId, versionId, "policies"))}
+        previewNames={policyPreview.data?.map((p) => p.name) as string[]}
+        isLoadingPreview={policyPreview.isLoading}
+      />
+      <CountCard
+        label="Workflow"
+        count={workflowCount}
+        disabled={false}
+        onNavigate={() => navigate(domainPackSectionPath(wsId, packId, versionId, "workflows"))}
+        previewItems={
+          workflowPreview.data?.map((w) => ({ id: w.id, name: w.name })) as {
+            id: number;
+            name: string;
+          }[]
+        }
+        isLoadingPreview={workflowPreview.isLoading}
+        onPreviewItemClick={(id) =>
+          navigate(domainPackSectionPath(wsId, packId, versionId, "workflows", id))
+        }
+      />
+    </div>
   );
 }
 

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.tsx
@@ -27,7 +27,6 @@ interface SummaryDetailPanelProps {
   onDeploy?: (versionId: number) => void;
   onApplyDraft?: (versionId: number) => void;
   onDiscardDraft?: (versionId: number) => void;
-  renderSlotEditSheet?: (slotId: number, isOpen: boolean, onClose: () => void) => React.ReactNode;
 }
 
 export function SummaryDetailPanel({
@@ -41,7 +40,6 @@ export function SummaryDetailPanel({
   onDeploy,
   onApplyDraft,
   onDiscardDraft,
-  renderSlotEditSheet,
 }: Readonly<SummaryDetailPanelProps>) {
   const [isDeployDialogOpen, setDeployDialogOpen] = useState(false);
   const [isApplyDialogOpen, setApplyDialogOpen] = useState(false);
@@ -316,7 +314,6 @@ export function SummaryDetailPanel({
             slotCount={v.slotCount ?? 0}
             policyCount={v.policyCount ?? 0}
             workflowCount={v.workflowCount ?? 0}
-            renderSlotEditSheet={renderSlotEditSheet}
           />
         )}
       </div>


### PR DESCRIPTION
## Summary
- 도메인팩 요약 화면의 Slot 카드 클릭을 Slot 목록 라우트로 연결했습니다.
- Slot 미리보기 항목 클릭 시 해당 Slot 상세 URL로 이동하도록 맞췄습니다.
- 실제 사용처에서 연결되지 않던 `renderSlotEditSheet` 경로와 관련 테스트 기대값을 정리했습니다.

## Root Cause
- Slot 카드가 목록 라우팅 대신 선택적 편집 시트 상태만 열도록 구현되어 있었습니다.
- 실제 `DomainPackSummaryPage`는 편집 시트를 전달하지 않아, Slot이 있어도 클릭 가능한 카드가 화면 변화 없이 끝났습니다.

## Validation
- `cd frontend && pnpm test ComponentCountGrid --run`
- `cd frontend && pnpm test SlotDraftReadPage --run`
- `cd frontend && pnpm exec tsc -b --pretty false`
- `cd frontend && pnpm exec eslint src/features/domain-pack-summary-read/ui/ComponentCountGrid.tsx src/features/domain-pack-summary-read/ui/SummaryDetailPanel.tsx src/features/domain-pack-summary-read/ui/ComponentCountGrid.test.tsx src/features/domain-pack-summary-read/ui/ComponentCountGrid.generated-api.test.tsx`

## Notes
- `cd frontend && pnpm lint`는 기존 코드베이스의 `no-explicit-any`, React hooks compiler, fast-refresh 규칙 위반 등 64건으로 실패합니다. 이번 변경 파일 대상 eslint는 통과했습니다.

Closes #328