### PR TITLE
feat(frontend): 상담 콘솔 운영 맥락과 상태 피드백 보강

### DIFF
--- a/frontend/src/features/consultation/api/llmToolWorkflowApi.ts
+++ b/frontend/src/features/consultation/api/llmToolWorkflowApi.ts
@@ -13,6 +13,12 @@ export interface LlmToolWorkflowPayload {
   workflowName: string | null;
   workflowDescription: string | null;
   graphJson?: unknown;
+  initialState?: string | null;
+  terminalStates?: unknown;
+  intentCode?: string | null;
+  intentName?: string | null;
+  confidence?: number | null;
+  confidenceScore?: number | null;
 }
 
 export type MatchedWorkflow = LlmToolWorkflowPayload & {

--- a/frontend/src/features/consultation/ui/ChatPanel.test.tsx
+++ b/frontend/src/features/consultation/ui/ChatPanel.test.tsx
@@ -73,7 +73,7 @@ describe("ChatPanel", () => {
       />,
     );
 
-    const noteToggle = screen.getByTitle("내부 메모 모드");
+    const noteToggle = screen.getByTitle("내부 메모로 남기기");
     const input = screen.getByPlaceholderText("메시지를 입력하세요...");
     const sendButton = screen.getByLabelText("메시지 전송");
 
@@ -151,11 +151,11 @@ describe("ChatPanel", () => {
     expect(screen.getByText("내부 메모")).toBeInTheDocument();
     expect(screen.getByText("내부 메모 내용")).toBeInTheDocument();
 
-    fireEvent.click(screen.getByTitle("내부 메모 모드"));
+    fireEvent.click(screen.getByTitle("내부 메모로 남기기"));
 
-    const input = screen.getByPlaceholderText("내부 메모를 입력하세요 (고객에게 보이지 않음)...");
+    const input = screen.getByPlaceholderText("내부 메모로 타임라인에 남길 내용을 입력하세요...");
     fireEvent.change(input, { target: { value: "메모로 남길 내용" } });
-    fireEvent.click(screen.getByLabelText("메시지 전송"));
+    fireEvent.click(screen.getByLabelText("내부 메모 남기기"));
 
     expect(onSendMessage).toHaveBeenCalledWith("메모로 남길 내용", true);
     expect(onSelectMessage).not.toHaveBeenCalled();

--- a/frontend/src/features/consultation/ui/ChatPanel.tsx
+++ b/frontend/src/features/consultation/ui/ChatPanel.tsx
@@ -22,6 +22,7 @@ interface ChatPanelProps {
   selectedMessageId: string | null;
   onSelectMessage: (messageId: string | null) => void;
   sessionStatusLabel?: string;
+  sessionStatusDescription?: string;
   disabled?: boolean;
 }
 
@@ -40,6 +41,7 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
   selectedMessageId,
   onSelectMessage,
   sessionStatusLabel,
+  sessionStatusDescription,
   disabled = false,
 }) => {
   const [input, setInput] = useState("");
@@ -94,9 +96,12 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
             <div className={styles.chatChannel}>{channel}</div>
           </div>
         </div>
-        <div className={styles.chatStatus}>
+        <div className={styles.chatStatus} data-testid="chat-assignment-status">
           <span className={styles.statusDot}></span>
-          {sessionStatusLabel ?? "상담 진행중"}
+          <div className={styles.statusCopy}>
+            <span>{sessionStatusLabel ?? "상담 진행중"}</span>
+            {sessionStatusDescription && <small>{sessionStatusDescription}</small>}
+          </div>
         </div>
       </div>
 
@@ -176,7 +181,7 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
           className={`${styles.noteToggle} ${isNoteMode ? styles.noteToggleActive : ""}`}
           onClick={() => setIsNoteMode(!isNoteMode)}
           disabled={disabled}
-          title={isNoteMode ? "일반 메시지로 전환" : "내부 메모 모드"}
+          title={isNoteMode ? "일반 메시지로 전환" : "내부 메모로 남기기"}
         >
           <StickyNote size={18} />
         </button>
@@ -185,7 +190,7 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
           rows={1}
           placeholder={
             isNoteMode
-              ? "내부 메모를 입력하세요 (고객에게 보이지 않음)..."
+              ? "내부 메모로 타임라인에 남길 내용을 입력하세요..."
               : "메시지를 입력하세요..."
           }
           value={input}
@@ -197,8 +202,8 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
           className={styles.sendBtn}
           onClick={handleSend}
           disabled={disabled || !input.trim()}
-          aria-label="메시지 전송"
-          title="메시지 전송"
+          aria-label={isNoteMode ? "내부 메모 남기기" : "메시지 전송"}
+          title={isNoteMode ? "내부 메모로 남기기" : "메시지 전송"}
         >
           <Send size={18} />
         </button>

--- a/frontend/src/features/consultation/ui/MessageDetailPanel.module.css
+++ b/frontend/src/features/consultation/ui/MessageDetailPanel.module.css
@@ -101,6 +101,44 @@
   gap: 6px;
 }
 
+.sectionEmpty {
+  color: var(--ink-3);
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.domainEmpty {
+  margin: 16px;
+  padding: 22px 16px;
+  border: 1px solid var(--line-2);
+  border-radius: 8px;
+  background: var(--paper);
+  color: var(--ink-3);
+  text-align: center;
+}
+
+.domainEmptyIcon {
+  color: var(--ink-4);
+}
+
+.domainEmpty strong {
+  display: block;
+  margin-top: 10px;
+  color: var(--ink);
+  font-size: 12.5px;
+  font-weight: 540;
+  letter-spacing: -0.1px;
+}
+
+.domainEmpty p {
+  margin: 6px 0 0;
+  font-size: 11.5px;
+  line-height: 1.5;
+  letter-spacing: -0.1px;
+}
+
 /* ─── Tag Pill ─── */
 .tag {
   display: inline-flex;

--- a/frontend/src/features/consultation/ui/MessageDetailPanel.test.tsx
+++ b/frontend/src/features/consultation/ui/MessageDetailPanel.test.tsx
@@ -44,8 +44,8 @@ describe("MessageDetailPanel", () => {
     expect(screen.getByText("14:30")).toBeInTheDocument();
   });
 
-  /* ─── Test 3: Slot tags ─── */
-  it("renders Slot tags from MOCK_DATA", () => {
+  /* ─── Test 3: domain empty state ─── */
+  it("shows a stable domain pack empty state when elements are not connected", () => {
     render(
       <MessageDetailPanel
         message={{
@@ -58,32 +58,53 @@ describe("MessageDetailPanel", () => {
       />,
     );
 
+    expect(screen.getByText("연결된 도메인 팩 요소가 없습니다")).toBeInTheDocument();
+    expect(
+      screen.getByText("Slot, Policy, Risk 추출 결과가 연결되면 이 영역에 표시됩니다."),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("가격 문의")).not.toBeInTheDocument();
+  });
+
+  /* ─── Test 4: domain elements ─── */
+  it("renders connected Slot, Policy, and Risk tags", () => {
+    render(
+      <MessageDetailPanel
+        message={{
+          id: "1",
+          senderRole: "CUSTOMER",
+          content: "test",
+          timestamp: "12:00",
+        }}
+        domainPackElements={{
+          slots: [
+            { name: "가격 문의", extracted: true, value: "89,000원" },
+            { name: "배송지 주소", extracted: false },
+          ],
+          policies: [
+            { name: "반품 정책", extracted: true, matched: true },
+            { name: "환불 정책", extracted: true, matched: false },
+          ],
+          risks: [
+            { name: "고객 불만 고조", extracted: true, level: "high" as const },
+            { name: "환불 요청", extracted: true, level: "medium" as const },
+          ],
+        }}
+        onClose={() => {}}
+      />,
+    );
+
+    expect(screen.queryByTestId("message-domain-empty")).not.toBeInTheDocument();
     expect(screen.getByText("가격 문의")).toBeInTheDocument();
     expect(screen.getByText("89,000원")).toBeInTheDocument();
     expect(screen.getByText("배송지 주소")).toBeInTheDocument();
-  });
-
-  /* ─── Test 4: Policy tags ─── */
-  it("renders Policy tags from MOCK_DATA", () => {
-    render(
-      <MessageDetailPanel
-        message={{
-          id: "1",
-          senderRole: "CUSTOMER",
-          content: "test",
-          timestamp: "12:00",
-        }}
-        onClose={() => {}}
-      />,
-    );
-
     expect(screen.getByText("반품 정책")).toBeInTheDocument();
     expect(screen.getByText("환불 정책")).toBeInTheDocument();
-    expect(screen.getByText("교환 정책")).toBeInTheDocument();
+    expect(screen.getByText("고객 불만 고조")).toBeInTheDocument();
+    expect(screen.getByText("환불 요청")).toBeInTheDocument();
   });
 
-  /* ─── Test 5: Risk tags ─── */
-  it("renders Risk tags from MOCK_DATA", () => {
+  /* ─── Test 5: partially connected elements ─── */
+  it("shows section-level empty labels for missing element groups", () => {
     render(
       <MessageDetailPanel
         message={{
@@ -92,13 +113,18 @@ describe("MessageDetailPanel", () => {
           content: "test",
           timestamp: "12:00",
         }}
+        domainPackElements={{
+          slots: [{ name: "주문 번호", extracted: true, value: "#ORD-1" }],
+          policies: [],
+          risks: [],
+        }}
         onClose={() => {}}
       />,
     );
 
-    expect(screen.getByText("고객 불만 고조")).toBeInTheDocument();
-    expect(screen.getByText("환불 요청")).toBeInTheDocument();
-    expect(screen.getByText("법적 대응")).toBeInTheDocument();
+    expect(screen.getByText("주문 번호")).toBeInTheDocument();
+    expect(screen.getByText("매칭된 policy 없음")).toBeInTheDocument();
+    expect(screen.getByText("감지된 risk 없음")).toBeInTheDocument();
   });
 
   /* ─── Test 6: Close button ─── */

--- a/frontend/src/features/consultation/ui/MessageDetailPanel.tsx
+++ b/frontend/src/features/consultation/ui/MessageDetailPanel.tsx
@@ -1,4 +1,4 @@
-import { MessageSquare } from "lucide-react";
+import { FileSearch, MessageSquare } from "lucide-react";
 import type { ReactNode } from "react";
 import { getChatRolePresentation } from "../lib/chatRoleLabels";
 import styles from "./MessageDetailPanel.module.css";
@@ -37,29 +37,6 @@ export interface MessageDetailPanelProps {
   onClose: () => void;
 }
 
-/* ─── Mock Data ─── */
-const MOCK_DATA: {
-  slots: SlotTag[];
-  policies: PolicyTag[];
-  risks: RiskTag[];
-} = {
-  slots: [
-    { name: "가격 문의", extracted: true, value: "89,000원" },
-    { name: "주문 번호", extracted: true, value: "#ORD-2024-08921" },
-    { name: "배송지 주소", extracted: false },
-  ],
-  policies: [
-    { name: "반품 정책", extracted: true, matched: true },
-    { name: "환불 정책", extracted: true, matched: false },
-    { name: "교환 정책", extracted: false, matched: false },
-  ],
-  risks: [
-    { name: "고객 불만 고조", extracted: true, level: "high" as const },
-    { name: "환불 요청", extracted: true, level: "medium" as const },
-    { name: "법적 대응", extracted: false, level: "low" as const },
-  ],
-} as const;
-
 /* ─── Helpers ─── */
 function riskTagClass(risk: RiskTag): string {
   if (!risk.extracted) return `${styles.tag} ${styles.tagNotExtracted}`;
@@ -73,11 +50,23 @@ function riskTagClass(risk: RiskTag): string {
 }
 
 /* ─── Sub-components ─── */
-function Section({ title, children }: { title: string; children: ReactNode }) {
+function Section({
+  title,
+  emptyText,
+  hasItems,
+  children,
+}: {
+  title: string;
+  emptyText: string;
+  hasItems: boolean;
+  children: ReactNode;
+}) {
   return (
     <div className={styles.section}>
       <div className={styles.sectionTitle}>{title}</div>
-      <div className={styles.tagList}>{children}</div>
+      <div className={styles.tagList}>
+        {hasItems ? children : <span className={styles.sectionEmpty}>{emptyText}</span>}
+      </div>
     </div>
   );
 }
@@ -113,7 +102,10 @@ export function MessageDetailPanel({
   domainPackElements,
   onClose,
 }: MessageDetailPanelProps) {
-  const { slots, policies, risks } = domainPackElements ?? MOCK_DATA;
+  const slots = domainPackElements?.slots ?? [];
+  const policies = domainPackElements?.policies ?? [];
+  const risks = domainPackElements?.risks ?? [];
+  const hasDomainPackElements = slots.length > 0 || policies.length > 0 || risks.length > 0;
   const roleLabel = message ? getChatRolePresentation(message.senderRole).label : "";
 
   if (!message) {
@@ -137,23 +129,33 @@ export function MessageDetailPanel({
         <p className={styles.messagePreview}>{message.content}</p>
       </div>
 
-      <Section title="Slot">
-        {slots.map((slot) => (
-          <SlotTagItem key={slot.name} slot={slot} />
-        ))}
-      </Section>
+      {hasDomainPackElements ? (
+        <>
+          <Section title="Slot" emptyText="감지된 slot 없음" hasItems={slots.length > 0}>
+            {slots.map((slot) => (
+              <SlotTagItem key={slot.name} slot={slot} />
+            ))}
+          </Section>
 
-      <Section title="Policy">
-        {policies.map((policy) => (
-          <PolicyTagItem key={policy.name} policy={policy} />
-        ))}
-      </Section>
+          <Section title="Policy" emptyText="매칭된 policy 없음" hasItems={policies.length > 0}>
+            {policies.map((policy) => (
+              <PolicyTagItem key={policy.name} policy={policy} />
+            ))}
+          </Section>
 
-      <Section title="Risk">
-        {risks.map((risk) => (
-          <RiskTagItem key={risk.name} risk={risk} />
-        ))}
-      </Section>
+          <Section title="Risk" emptyText="감지된 risk 없음" hasItems={risks.length > 0}>
+            {risks.map((risk) => (
+              <RiskTagItem key={risk.name} risk={risk} />
+            ))}
+          </Section>
+        </>
+      ) : (
+        <div className={styles.domainEmpty} data-testid="message-domain-empty">
+          <FileSearch size={28} className={styles.domainEmptyIcon} />
+          <strong>연결된 도메인 팩 요소가 없습니다</strong>
+          <p>Slot, Policy, Risk 추출 결과가 연결되면 이 영역에 표시됩니다.</p>
+        </div>
+      )}
 
       <div className={styles.closeArea}>
         <button type="button" className={styles.closeButton} onClick={onClose}>

--- a/frontend/src/features/consultation/ui/chat-panel.module.css
+++ b/frontend/src/features/consultation/ui/chat-panel.module.css
@@ -58,6 +58,8 @@
   letter-spacing: normal;
   color: var(--primary-color);
   font-weight: 500;
+  max-width: 280px;
+  min-width: 0;
 }
 
 .statusDot {
@@ -66,6 +68,35 @@
   border-radius: 50%;
   background: var(--primary-color);
   animation: pulse-dot 2s ease-in-out infinite;
+  flex-shrink: 0;
+}
+
+.statusCopy {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.statusCopy span,
+.statusCopy small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.statusCopy span {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.statusCopy small {
+  color: var(--text-secondary);
+  font-size: 0.72rem;
+  font-weight: 400;
+  letter-spacing: -0.1px;
 }
 
 @keyframes pulse-dot {

--- a/frontend/src/pages/consultation/ui/ConsultationPage.test.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.test.tsx
@@ -341,9 +341,7 @@ describe("ConsultationPage", () => {
         expect(screen.getByTestId("matched-workflow-bar")).toBeInTheDocument();
       });
       expect(screen.queryByTestId("matched-workflow-bar-skeleton")).not.toBeInTheDocument();
-      expect(screen.getByTestId("matched-workflow-bar-title")).toHaveTextContent(
-        "환불 워크플로우",
-      );
+      expect(screen.getByTestId("matched-workflow-bar-title")).toHaveTextContent("환불 워크플로우");
       // collapsed by default — meta only appears after toggle
       expect(screen.queryByTestId("matched-workflow-bar-meta")).not.toBeInTheDocument();
     });
@@ -546,7 +544,7 @@ describe("ConsultationPage", () => {
       expect(consultationApi.assignSession).toHaveBeenCalledWith(1, 7);
     });
     await waitFor(() => {
-      expect(screen.getAllByText("내 상담 진행중").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("내게 배정됨").length).toBeGreaterThan(0);
     });
   });
 
@@ -691,7 +689,7 @@ describe("ConsultationPage", () => {
     fireEvent.click(messageEl);
 
     await waitFor(() => {
-      expect(screen.getByText("가격 문의")).toBeInTheDocument();
+      expect(screen.getByText("연결된 도메인 팩 요소가 없습니다")).toBeInTheDocument();
     });
 
     fireEvent.click(screen.getByText("닫기"));
@@ -719,7 +717,7 @@ describe("ConsultationPage", () => {
     fireEvent.click(messageEl);
 
     await waitFor(() => {
-      expect(screen.getByText("가격 문의")).toBeInTheDocument();
+      expect(screen.getByText("연결된 도메인 팩 요소가 없습니다")).toBeInTheDocument();
     });
 
     fireEvent.click(messageEl);
@@ -749,7 +747,7 @@ describe("ConsultationPage", () => {
     await user.keyboard("{Enter}");
 
     await waitFor(() => {
-      expect(screen.getByText("가격 문의")).toBeInTheDocument();
+      expect(screen.getByText("연결된 도메인 팩 요소가 없습니다")).toBeInTheDocument();
     });
 
     messageButton.focus();
@@ -780,7 +778,7 @@ describe("ConsultationPage", () => {
     await user.keyboard(" ");
 
     await waitFor(() => {
-      expect(screen.getByText("가격 문의")).toBeInTheDocument();
+      expect(screen.getByText("연결된 도메인 팩 요소가 없습니다")).toBeInTheDocument();
     });
   });
 
@@ -939,7 +937,7 @@ describe("ConsultationPage", () => {
     fireEvent.click(messageEl);
 
     await waitFor(() => {
-      expect(screen.getByText("가격 문의")).toBeInTheDocument();
+      expect(screen.getByText("연결된 도메인 팩 요소가 없습니다")).toBeInTheDocument();
     });
 
     vi.mocked(consultationApi.getMessages).mockResolvedValueOnce([]);
@@ -949,7 +947,7 @@ describe("ConsultationPage", () => {
 
     await waitFor(() => {
       expect(screen.getByText("고객 정보")).toBeInTheDocument();
-      expect(screen.queryByText("가격 문의")).not.toBeInTheDocument();
+      expect(screen.queryByText("연결된 도메인 팩 요소가 없습니다")).not.toBeInTheDocument();
     });
   });
 
@@ -975,9 +973,7 @@ describe("ConsultationPage", () => {
     await user.keyboard("{Enter}");
 
     await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith(
-        "연결이 불안정합니다. 잠시 후 다시 시도해주세요.",
-      );
+      expect(toast.error).toHaveBeenCalledWith("연결이 불안정합니다. 잠시 후 다시 시도해주세요.");
     });
     expect(mockSendTo).not.toHaveBeenCalled();
     expect(consultationApi.sendMessage).not.toHaveBeenCalled();
@@ -1144,7 +1140,9 @@ describe("ConsultationPage", () => {
     const customerItem = screen.getByText("김민지").closest("div");
     if (customerItem) customerItem.click();
 
-    const textarea = await screen.findByPlaceholderText("상담 메모를 입력하세요...");
+    const textarea = await screen.findByPlaceholderText(
+      "타임라인에 내부 메모로 남길 내용을 입력하세요...",
+    );
     await user.type(textarea, "고객이 매우 다급함");
 
     expect(textarea).toHaveValue("고객이 매우 다급함");
@@ -1161,9 +1159,11 @@ describe("ConsultationPage", () => {
     const customerItem = screen.getByText("김민지").closest('[role="button"]');
     if (customerItem) fireEvent.click(customerItem);
 
-    const textarea = await screen.findByPlaceholderText("상담 메모를 입력하세요...");
+    const textarea = await screen.findByPlaceholderText(
+      "타임라인에 내부 메모로 남길 내용을 입력하세요...",
+    );
     await user.type(textarea, "카드사 확인 필요");
-    await user.click(screen.getByText("메모 저장"));
+    await user.click(screen.getByText("내부 메모로 남기기"));
 
     await waitFor(() => {
       expect(mockSendTo).toHaveBeenCalledWith("/app/chat.counselor.send", {

--- a/frontend/src/pages/consultation/ui/ConsultationPage.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.tsx
@@ -88,11 +88,53 @@ const getSessionStatusLabel = (
 ) => {
   if (status === "COMPLETED") return "상담 종료";
   if (status === "RESOLVED") return "해결됨";
-  if (assignedCounselorId && assignedCounselorId === currentCounselorId) return "내 상담 진행중";
-  if (assignedCounselorId) return "상담 진행중";
-  if (status === "ACTIVE") return "상담 진행중";
-  if (status === "OPEN") return "대기중";
+  if (assignedCounselorId && assignedCounselorId === currentCounselorId) return "내게 배정됨";
+  if (assignedCounselorId) return "다른 상담사 배정";
+  if (status === "ACTIVE") return "미배정";
+  if (status === "OPEN") return "미배정";
   return status ?? "상태 미확인";
+};
+
+type AssignmentView = {
+  label: string;
+  description: string;
+  tone: "mine" | "unassigned" | "other" | "closed";
+};
+
+const getAssignmentView = (
+  status?: string | null,
+  assignedCounselorId?: number | null,
+  currentCounselorId?: number | null,
+): AssignmentView => {
+  if (status === "COMPLETED" || status === "RESOLVED") {
+    return {
+      label: status === "RESOLVED" ? "해결됨" : "상담 종료",
+      description: "종료된 세션이므로 메시지를 보낼 수 없습니다.",
+      tone: "closed",
+    };
+  }
+
+  if (assignedCounselorId && assignedCounselorId === currentCounselorId) {
+    return {
+      label: "내게 배정됨",
+      description: "이 세션에 응답하고 내부 메모를 남길 수 있습니다.",
+      tone: "mine",
+    };
+  }
+
+  if (assignedCounselorId) {
+    return {
+      label: "다른 상담사 배정",
+      description: "다른 상담사가 응대 중인 세션입니다.",
+      tone: "other",
+    };
+  }
+
+  return {
+    label: "미배정",
+    description: "선택하면 자동으로 내게 배정됩니다.",
+    tone: "unassigned",
+  };
 };
 
 const toQueueCustomer = (
@@ -235,13 +277,13 @@ export const ConsultationPage: React.FC = () => {
   const visibleMessages =
     activeCustomer && messagesCustomerId === activeCustomer.id ? messages : [];
   const selectedMessage = visibleMessages.find((m) => m.id === selectedMessageId) || null;
-  const activeStatusLabel = activeCustomer
-    ? getSessionStatusLabel(
+  const activeAssignment = activeCustomer
+    ? getAssignmentView(
         activeCustomer.status,
         activeCustomer.assignedCounselorId,
         currentCounselorId,
       )
-    : undefined;
+    : null;
   const isAssignedToCurrentCounselor =
     !!activeCustomer?.assignedCounselorId &&
     activeCustomer.assignedCounselorId === currentCounselorId;
@@ -662,7 +704,7 @@ export const ConsultationPage: React.FC = () => {
     if (activeCustomerIdRef.current === requestCustomerId) {
       handleSendMessage(memo, true);
       setMemos((prev) => ({ ...prev, [requestCustomerId]: "" }));
-      toast.success("상담 메모 저장 요청을 전송했습니다.");
+      toast.success("내부 메모를 타임라인에 남겼습니다.");
     }
   }, [activeCustomerId, connectionStatus, handleSendMessage, isAssignedToCurrentCounselor, memos]);
 
@@ -694,6 +736,15 @@ export const ConsultationPage: React.FC = () => {
               </div>
             </div>
             <div className={styles.conversationActions}>
+              {activeAssignment && (
+                <div
+                  className={`${styles.assignmentBadge} ${styles[`assignmentBadge_${activeAssignment.tone}`]}`}
+                  data-testid="conversation-assignment-status"
+                >
+                  <span>{activeAssignment.label}</span>
+                  <small>{activeAssignment.description}</small>
+                </div>
+              )}
               <button
                 className={styles.linkButton}
                 onClick={handleReleaseAssignment}
@@ -720,7 +771,8 @@ export const ConsultationPage: React.FC = () => {
             onSendMessage={handleSendMessage}
             selectedMessageId={selectedMessageId}
             onSelectMessage={setSelectedMessageId}
-            sessionStatusLabel={activeStatusLabel}
+            sessionStatusLabel={activeAssignment?.label}
+            sessionStatusDescription={activeAssignment?.description}
             disabled={!isAssignedToCurrentCounselor}
           />
         </div>
@@ -738,7 +790,6 @@ export const ConsultationPage: React.FC = () => {
         )}
         <div className={styles.detailPaneBody}>
           {selectedMessage ? (
-            // TODO: domainPackElements를 실제 API 응답 데이터로 교체 (별도 API 연동 티켓)
             <MessageDetailPanel
               message={selectedMessage}
               onClose={() => setSelectedMessageId(null)}

--- a/frontend/src/pages/consultation/ui/consultation-page.module.css
+++ b/frontend/src/pages/consultation/ui/consultation-page.module.css
@@ -66,6 +66,55 @@
   border-top: 1px solid var(--line-2);
 }
 
+.assignmentBadge {
+  margin-right: auto;
+  min-width: 0;
+  max-width: 360px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border: 1px solid var(--line);
+  border-radius: 50px;
+  background: var(--paper-2);
+  color: var(--ink-2);
+}
+
+.assignmentBadge span {
+  flex-shrink: 0;
+  font-family: var(--mono);
+  font-size: 10.5px;
+  line-height: 1;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.assignmentBadge small {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--ink-3);
+  font-size: 11px;
+  line-height: 1.25;
+  letter-spacing: -0.1px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.assignmentBadge_mine {
+  border-color: var(--ink);
+  background: var(--ink);
+  color: var(--paper);
+}
+
+.assignmentBadge_mine small {
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.assignmentBadge_other,
+.assignmentBadge_closed {
+  opacity: 0.74;
+}
+
 .linkButton,
 .dangerButton {
   padding: 0;

--- a/frontend/src/pages/consultation/ui/sections/CustomerPanel.tsx
+++ b/frontend/src/pages/consultation/ui/sections/CustomerPanel.tsx
@@ -108,13 +108,13 @@ export function CustomerPanel({
         <InfoRow label="처리 기한" value="2024-05-10" tone="danger" />
       </InfoCard>
 
-      <InfoCard title="상담 메모" meta="private">
+      <InfoCard title="내부 메모" meta="NOTE 메시지">
         <textarea
           data-testid="customer-memo-textarea"
           value={memo}
           onChange={(e) => onMemoChange(e.target.value)}
-          placeholder="상담 메모를 입력하세요..."
-          aria-label="상담 메모 입력"
+          placeholder="타임라인에 내부 메모로 남길 내용을 입력하세요..."
+          aria-label="내부 메모 입력"
           style={{
             width: "100%",
             minHeight: 84,
@@ -149,7 +149,7 @@ export function CustomerPanel({
             letterSpacing: "-0.1px",
           }}
         >
-          {isMemoSaving ? "저장 중..." : "메모 저장"}
+          {isMemoSaving ? "남기는 중..." : "내부 메모로 남기기"}
         </button>
       </InfoCard>
     </div>

--- a/frontend/src/pages/consultation/ui/sections/MatchedWorkflowBar.module.css
+++ b/frontend/src/pages/consultation/ui/sections/MatchedWorkflowBar.module.css
@@ -95,11 +95,28 @@
   line-height: 1.5;
 }
 
+.matchBasis {
+  margin: 0;
+  padding: 8px 10px;
+  border: 1px solid var(--line-2);
+  border-radius: 8px;
+  background: var(--paper-2);
+  color: var(--ink);
+  font-family: var(--sans);
+  font-size: 11.5px;
+  line-height: 1.45;
+  letter-spacing: -0.1px;
+}
+
 .metaRow {
   display: flex;
   align-items: center;
   gap: 6px;
   flex-wrap: wrap;
+}
+
+.intentPill {
+  max-width: 100%;
 }
 
 .meta {

--- a/frontend/src/pages/consultation/ui/sections/MatchedWorkflowBar.test.tsx
+++ b/frontend/src/pages/consultation/ui/sections/MatchedWorkflowBar.test.tsx
@@ -33,6 +33,8 @@ const baseWorkflow: MatchedWorkflow = {
   workflowCode: "REFUND_FLOW",
   workflowName: "환불 워크플로우",
   workflowDescription: "환불 처리 흐름",
+  intentCode: "refund.request",
+  intentName: "환불 요청",
   graphJson: { nodes: [{ id: "n1", type: "START", label: "start" }], edges: [] },
 };
 
@@ -68,8 +70,12 @@ describe("MatchedWorkflowBar", () => {
     expect(bar).toHaveAttribute("data-state", "open");
     expect(screen.getByTestId("matched-workflow-bar-preview")).toBeInTheDocument();
     expect(screen.getByText("RUNNING")).toBeInTheDocument();
+    expect(screen.getByText("intent 환불 요청")).toBeInTheDocument();
     expect(screen.getByTestId("matched-workflow-bar-meta")).toHaveTextContent(
       "wf REFUND_FLOW · v12 · COLLECT_INFO",
+    );
+    expect(screen.getByTestId("matched-workflow-bar-basis")).toHaveTextContent(
+      "최근 AI 응답이 COLLECT_INFO 단계와 연결되어 표시 중입니다.",
     );
     expect(screen.getByTestId("matched-workflow-bar-description")).toHaveTextContent(
       "환불 처리 흐름",
@@ -173,6 +179,15 @@ describe("MatchedWorkflowBar", () => {
     fireEvent.mouseEnter(screen.getByTestId("matched-workflow-bar"));
 
     expect(screen.getByText("UNEXPECTED")).toBeInTheDocument();
+  });
+
+  it("uses confidence as matching basis when present", () => {
+    renderBar({ ...baseWorkflow, confidenceScore: 0.87 });
+    fireEvent.mouseEnter(screen.getByTestId("matched-workflow-bar"));
+
+    expect(screen.getByTestId("matched-workflow-bar-basis")).toHaveTextContent(
+      "최근 분류 신뢰도 87% 기준으로 표시 중입니다.",
+    );
   });
 });
 

--- a/frontend/src/pages/consultation/ui/sections/MatchedWorkflowBar.tsx
+++ b/frontend/src/pages/consultation/ui/sections/MatchedWorkflowBar.tsx
@@ -32,11 +32,34 @@ function buildMeta(workflow: MatchedWorkflow): string {
   return parts.join(" · ");
 }
 
+function formatConfidence(workflow: MatchedWorkflow): string | null {
+  const confidence = workflow.confidenceScore ?? workflow.confidence;
+  if (typeof confidence !== "number" || Number.isNaN(confidence)) return null;
+  const normalized = confidence > 1 ? confidence : confidence * 100;
+  return `${Math.round(normalized)}%`;
+}
+
+function buildMatchBasis(workflow: MatchedWorkflow): string {
+  const confidence = formatConfidence(workflow);
+  if (confidence) {
+    return `최근 분류 신뢰도 ${confidence} 기준으로 표시 중입니다.`;
+  }
+  if (workflow.currentState) {
+    return `최근 AI 응답이 ${workflow.currentState} 단계와 연결되어 표시 중입니다.`;
+  }
+  if (workflow.workflowCode) {
+    return `${workflow.workflowCode} 워크플로우 후보가 현재 세션에 연결되어 표시 중입니다.`;
+  }
+  return "현재 세션에 연결된 워크플로우 후보가 표시 중입니다.";
+}
+
 export function MatchedWorkflowBar({ workflow }: MatchedWorkflowBarProps) {
   const navigate = useNavigate();
   const [previewOpen, setPreviewOpen] = useState(false);
   const title = workflow.workflowName ?? workflow.workflowCode ?? "워크플로우";
   const meta = buildMeta(workflow);
+  const intentLabel = workflow.intentName ?? workflow.intentCode;
+  const matchBasis = buildMatchBasis(workflow);
   const statusLabel = workflow.executionStatus ?? "UNKNOWN";
   const tone = resolveStatusTone(workflow.executionStatus);
 
@@ -101,12 +124,20 @@ export function MatchedWorkflowBar({ workflow }: MatchedWorkflowBarProps) {
             <div className={styles.expanded} data-testid="matched-workflow-bar-preview">
               <div className={styles.metaRow}>
                 <Pill tone={tone}>{statusLabel}</Pill>
+                {intentLabel && (
+                  <Pill tone="mute" className={styles.intentPill}>
+                    intent {intentLabel}
+                  </Pill>
+                )}
                 {meta && (
                   <span data-testid="matched-workflow-bar-meta">
                     <Mono className={styles.meta}>{meta}</Mono>
                   </span>
                 )}
               </div>
+              <p className={styles.matchBasis} data-testid="matched-workflow-bar-basis">
+                {matchBasis}
+              </p>
               {workflow.workflowDescription && (
                 <p className={styles.description} data-testid="matched-workflow-bar-description">
                   {workflow.workflowDescription}


### PR DESCRIPTION
## Summary
- 상담 세션 배정 상태를 `내게 배정됨`, `미배정`, `다른 상담사 배정`으로 구분하고, 상담사가 응답 가능한지 설명 문구를 함께 표시합니다.
- 메모 입력과 전송 문구를 `내부 메모로 남기기` 중심으로 정리해 NOTE 메시지가 타임라인에 남는 동작을 명확히 했습니다.
- 매칭 워크플로우 바에 intent 표시 가능 필드와 confidence/currentState 기반 매칭 근거 문구를 추가했습니다.
- 메시지 상세 패널의 mock domain pack 요소를 제거하고, 실제 연동 전에는 안정적인 empty state를 표시합니다.

## Root Cause
- 고객 선택 시 자동 배정은 동작했지만 화면에서는 내 응답 가능 상태와 다른 상담사 배정 상태가 충분히 구분되지 않았습니다.
- 메모 UI가 NOTE 메시지 전송 방식임에도 저장처럼 읽혀, 결과가 어디에 남는지 오해할 수 있었습니다.
- 매칭 워크플로우 바와 메시지 상세 패널이 운영 판단 근거보다 장식 또는 TODO/mock 데이터처럼 보일 여지가 있었습니다.

## Validation
- `cd frontend && pnpm test -- src/features/consultation/ui/ChatPanel.test.tsx src/features/consultation/ui/MessageDetailPanel.test.tsx src/pages/consultation/ui/sections/MatchedWorkflowBar.test.tsx src/pages/consultation/ui/ConsultationPage.test.tsx`
- `cd frontend && pnpm test`
- `cd frontend && pnpm build`
- `cd frontend && pnpm exec eslint src/pages/consultation/ui/ConsultationPage.tsx src/features/consultation/ui/ChatPanel.tsx src/pages/consultation/ui/sections/CustomerPanel.tsx src/pages/consultation/ui/sections/MatchedWorkflowBar.tsx src/features/consultation/api/llmToolWorkflowApi.ts src/features/consultation/ui/MessageDetailPanel.tsx src/features/consultation/ui/ChatPanel.test.tsx src/features/consultation/ui/MessageDetailPanel.test.tsx src/pages/consultation/ui/sections/MatchedWorkflowBar.test.tsx src/pages/consultation/ui/ConsultationPage.test.tsx`
- `git diff --check`

## Notes
- `cd frontend && pnpm lint`는 기존 코드베이스의 `no-explicit-any`, React hooks compiler, fast-refresh 규칙 위반 등 64건으로 실패합니다. 이번 변경 파일 대상 eslint는 통과했습니다.

Closes #323