### PR TITLE
fix(fe/be): 상담 기록을 워크스페이스별로 조회

### DIFF
--- a/.agent/specs/327.md
+++ b/.agent/specs/327.md
@@ -1,211 +1,158 @@
-# 327: [BE] Policy / Policy Status 수정 API
+# 327: 상담 기록 화면의 워크스페이스 스코프와 URL 선택 상태 정리
 
 ## Goal
 
-운영자가 특정 `domain_pack_version`의 `policy_definition`을 수정할 수 있도록 두 개의 REST API를 제공한다.
-
-1. Policy 일반 필드 수정
-2. Policy status 전환
-
-두 API 모두 `DomainPackVersion.lifecycle_status = 'DRAFT'`인 경우에만 허용한다.
+상담 기록 화면이 워크스페이스별 상담 세션만 조회하고, 선택한 세션을 URL 상태와 일관되게 동기화한다.
 
 ---
 
-## Endpoints
+## Background
+
+상담 기록 화면은 `/workspaces/:workspaceId/consultation/history` 하위 라우트에 있지만 세션 목록 API와 선택 상태가 워크스페이스 경계를 충분히 반영하지 않았다. 상담 로그는 운영 데이터이므로 다른 워크스페이스의 세션이 섞이지 않아야 하고, 공유 가능한 URL로 동일한 선택 상태를 복원할 수 있어야 한다.
+
+---
+
+## REST API
 
 | Method | Path | Description |
 | --- | --- | --- |
-| `PATCH` | `/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/policies/{policyId}` | Policy 일반 필드 수정 |
-| `PATCH` | `/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/policies/{policyId}/status` | Policy status 전환 |
+| `GET` | `/api/v1/workspaces/{workspaceId}/consultation/sessions` | 워크스페이스 상담 세션 목록 조회 |
 
----
+### Query Parameters
 
-## Request / Response
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `status` | string | no | 세션 상태 필터 |
+| `page` | number | no | 페이지 번호, 기본값 `0` |
+| `size` | number | no | 페이지 크기, 기본값 `20`, 최대 `100` |
 
-### 1. Policy 일반 수정
+### Response
 
-Request
-
-```json
-{
-  "name": "환불 정책",
-  "description": "환불 가능 여부를 검증하는 정책",
-  "severity": "HIGH",
-  "conditionJson": "{}",
-  "actionJson": "{}",
-  "evidenceJson": "[]",
-  "metaJson": "{}"
-}
-```
-
-수정 가능 필드
-- `name`
-- `description`
-- `severity`
-- `conditionJson`
-- `actionJson`
-- `evidenceJson`
-- `metaJson`
-
-수정 불가 필드
-- `policyCode`
-- `domainPackVersionId`
-
-### 2. Policy status 전환
-
-Request
+기존 `CounselorSessionResponse` 형태를 유지한다.
 
 ```json
 {
-  "status": "INACTIVE"
-}
-```
-
-허용 값
-- `ACTIVE`
-- `INACTIVE`
-
-### 3. 성공 응답
-
-```json
-{
-  "id": 55,
-  "domainPackVersionId": 10,
-  "policyCode": "refund_check",
-  "name": "환불 정책",
-  "description": "환불 가능 여부를 검증하는 정책",
-  "severity": "HIGH",
-  "conditionJson": "{}",
-  "actionJson": "{}",
-  "evidenceJson": "[]",
-  "metaJson": "{}",
-  "status": "ACTIVE",
-  "createdAt": "2026-04-16T10:00:00Z",
-  "updatedAt": "2026-04-16T10:30:00Z"
-}
-```
-
-### 4. 오류 응답
-
-`400 POLICY_NOT_EDITABLE`
-
-```json
-{
-  "code": "POLICY_NOT_EDITABLE",
-  "message": "DRAFT 상태의 버전에서만 정책을 수정할 수 있습니다."
-}
-```
-
-`400 VALIDATION_ERROR`
-
-```json
-{
-  "code": "VALIDATION_ERROR",
-  "errors": ["name은 필수 항목입니다."]
-}
-```
-
-`404 NOT_FOUND`
-
-```json
-{
-  "code": "NOT_FOUND",
-  "message": "정책을 찾을 수 없습니다: 55"
+  "content": [
+    {
+      "id": 7,
+      "status": "COMPLETED",
+      "channel": "WEB",
+      "metaJson": "{}",
+      "startedAt": "2026-05-22T09:00:00+09:00"
+    }
+  ],
+  "page": 0,
+  "size": 20,
+  "totalElements": 1,
+  "totalPages": 1
 }
 ```
 
 ---
 
-## Application Flow
+## Backend Design
 
-두 use case 모두 동일한 검증 순서를 따른다.
+### Controller
 
-1. `workspaceId` 존재 확인
-2. 요청 사용자의 워크스페이스 멤버십/역할 확인
-3. `packId`가 해당 `workspaceId` 소속인지 검증
-4. `versionId`로 `DomainPackVersion` 조회
-5. `version.domainPackId == packId` 검증
-6. `version.lifecycleStatus == DRAFT` 검증
-7. `policyId`로 `PolicyDefinition` 조회
-8. `policy.domainPackVersionId == versionId` 검증
-9. 일반 수정이면 `policy.updateFields(...)`
-10. status 수정이면 `policy.changeStatus(...)`
-11. 저장 후 `PolicyDefinitionResponse` 반환
+`CounselorSessionController#getSessions`는 `workspaceId` path variable을 받는다.
 
-핵심 포인트
-- 실제 조회 키는 `versionId`, `policyId`다.
-- `packId`는 경로 일관성 검증용이다.
-- `workspaceId`는 권한 확인에만 쓰이지 않고, `packId`의 워크스페이스 소속 검증에도 사용된다.
-- 다른 version에 속한 policy를 path 조합으로 접근하면 `404`로 처리한다.
-- 다른 workspace에 속한 pack/version/policy를 path 조합으로 접근하면 `404`로 처리한다.
+```text
+GET /api/v1/workspaces/{workspaceId}/consultation/sessions
+```
 
----
+기존 assign/release endpoint는 `/api/v1/consultation/sessions/{sessionId}/...` 경로를 유지한다.
 
-## Domain / Persistence Changes
+### Application Service
 
-### `PolicyDefinition`
+`CounselorService#getSessions`는 다음 조건으로만 세션을 조회한다.
 
-추가/변경 사항
-- `status` 필드 추가
-- 기본값 `ACTIVE`
-- `updateFields(...)` 메서드 추가
-- `changeStatus(...)` 메서드 추가
-
-허용 status
-- `ACTIVE`
-- `INACTIVE`
+1. `workspaceId`는 양수여야 한다.
+2. `status`가 있으면 `ChatSessionStatus`로 검증한다.
+3. `page >= 0`, `size > 0` 조건을 검증한다.
+4. 상태 필터가 있으면 `workspaceId + status + pageable`로 조회한다.
+5. 상태 필터가 없으면 `workspaceId + pageable`로 조회한다.
 
 ### Repository
 
-`PolicyDefinitionRepository`
-- `findById(Long id)`
-- `save(PolicyDefinition policy)`
+`ChatSessionRepository`에 워크스페이스 기반 page 조회 메서드를 추가한다.
 
-### DB Migration
+```java
+Page<ChatSession> findByWorkspaceId(Long workspaceId, Pageable pageable);
 
-`pack.policy_definition`에 `status` 컬럼과 체크 제약을 추가한다.
-
-```sql
-ALTER TABLE pack.policy_definition
-    ADD COLUMN status VARCHAR(50) NOT NULL DEFAULT 'ACTIVE',
-    ADD CONSTRAINT chk_policy_definition_status
-        CHECK (status IN ('ACTIVE', 'INACTIVE'));
+Page<ChatSession> findByWorkspaceIdAndStatus(
+    Long workspaceId, ChatSessionStatus status, Pageable pageable);
 ```
+
+---
+
+## Frontend Design
+
+### API Integration
+
+`consultationApi.getSessions`는 `workspaceId`를 필수 인자로 받아 workspace-scoped URL을 호출한다.
+
+```typescript
+consultationApi.getSessions(workspaceId, { status, page, size });
+```
+
+`useChatSessions`는 `workspaceId`를 query key뿐 아니라 실제 요청에도 전달한다. 유효한 `workspaceId`가 없으면 query를 실행하지 않는다.
+
+### Route State
+
+상담 기록 화면은 다음 라우트를 지원한다.
+
+```text
+/workspaces/:workspaceId/consultation/history
+/workspaces/:workspaceId/consultation/history/:sessionId
+```
+
+세션 카드를 선택하면 `navigate`로 `sessionId`가 포함된 URL로 이동한다.
+
+### Invalid Session State
+
+URL의 `sessionId`가 현재 워크스페이스의 세션 목록에 없으면 메시지 조회를 실행하지 않고 명확한 안내 상태를 표시한다.
+
+---
+
+## 수정 대상 파일
+
+| 파일 | 변경 유형 | 설명 |
+| --- | --- | --- |
+| `backend/src/main/java/com/init/workflowruntime/presentation/CounselorSessionController.java` | modify | workspace-scoped 세션 목록 endpoint |
+| `backend/src/main/java/com/init/workflowruntime/application/CounselorService.java` | modify | workspace 기반 조회 조건 적용 |
+| `backend/src/main/java/com/init/workflowruntime/domain/ChatSessionRepository.java` | modify | workspace 기반 page 조회 포트 추가 |
+| `backend/src/main/java/com/init/workflowruntime/infrastructure/persistence/JpaChatSessionRepository.java` | modify | Spring Data JPA 메서드 추가 |
+| `frontend/src/features/consultation/api/consultationApi.ts` | modify | workspace-scoped URL 호출 |
+| `frontend/src/features/consultation/api/chatHistoryApi.ts` | modify | workspaceId를 실제 요청에 반영 |
+| `frontend/src/pages/consultation/ui/chat-history/ChatHistoryPage.tsx` | modify | URL 선택 상태 동기화 |
+| `frontend/src/features/consultation/ui/chat-history/SessionList.tsx` | modify | 목록 조회 상태를 page에서 주입 |
+| `frontend/src/features/consultation/ui/chat-history/MessageHistory.tsx` | modify | 존재하지 않는 세션 URL 안내 상태 |
 
 ---
 
 ## Test Plan
 
-- `UpdatePolicyUseCaseTest`
-  - DRAFT 버전 정상 수정
-  - workspace 없음 / 비멤버
-  - 다른 workspace 소속 pack 접근 차단
-  - version 없음 / packId 불일치
-  - PUBLISHED 버전 수정 시도
-  - policy 없음 / versionId 불일치
+### Backend
 
-- `UpdatePolicyStatusUseCaseTest`
-  - `ACTIVE -> INACTIVE`
-  - `INACTIVE -> ACTIVE`
-  - 허용되지 않는 status 값
-  - workspace 없음 / 비멤버
-  - 다른 workspace 소속 pack 접근 차단
-  - version 없음 / packId 불일치
-  - policy 없음 / versionId 불일치
+- `CounselorServiceTest`
+  - 상태 필터 없이 `workspaceId`로 세션 페이지를 조회한다.
+  - 상태 필터가 있으면 `workspaceId + status`로 세션 페이지를 조회한다.
+  - 유효하지 않은 status는 `BadRequestException`을 반환한다.
+  - 유효하지 않은 workspaceId는 `BadRequestException`을 반환한다.
+- `CounselorSessionControllerTest`
+  - `GET /api/v1/workspaces/{workspaceId}/consultation/sessions` 요청을 service에 위임한다.
+  - status/page/size query parameter를 service에 전달한다.
 
-- `UpdatePolicyControllerTest`
-  - 정상 요청 200
-  - validation 실패 400
-  - `POLICY_NOT_EDITABLE` 400
-  - `NOT_FOUND` 404
-  - 비멤버 403
-  - 인증 없음 401
+### Frontend
 
-- `UpdatePolicyStatusControllerTest`
-  - 정상 요청 200
-  - validation 실패 400
-  - 잘못된 status 400
-  - `POLICY_NOT_EDITABLE` 400
-  - `NOT_FOUND` 404
-  - 비멤버 403
-  - 인증 없음 401
+- `consultationApi.test.ts`
+  - 세션 목록 요청이 `/api/v1/workspaces/{workspaceId}/consultation/sessions`를 호출한다.
+  - status/page/size query parameter를 보존한다.
+- `chatHistoryApi.test.ts`
+  - `workspaceId`를 실제 API 요청에 전달한다.
+  - `workspaceId`가 없으면 query를 실행하지 않는다.
+- `ChatHistoryPage.test.tsx`
+  - URL의 workspaceId로 완료 세션 목록을 조회한다.
+  - 세션 선택 시 URL의 `sessionId`가 갱신된다.
+  - URL의 `sessionId`로 직접 진입하면 해당 세션 메시지를 조회한다.
+  - 현재 워크스페이스에 없는 `sessionId`는 메시지를 조회하지 않고 안내 상태를 표시한다.

--- a/backend/src/main/java/com/init/workflowruntime/application/CounselorService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/CounselorService.java
@@ -161,7 +161,11 @@ public class CounselorService {
     return response;
   }
 
-  public CounselorSessionResponse getSessions(String status, int page, int size) {
+  public CounselorSessionResponse getSessions(Long workspaceId, String status, int page, int size) {
+    if (workspaceId == null || workspaceId <= 0) {
+      throw new BadRequestException(
+          "INVALID_WORKSPACE_ID", "workspaceId must be a positive number");
+    }
     if (page < 0 || size <= 0) {
       throw new BadRequestException("INVALID_PAGING", "page must be >= 0 and size must be > 0");
     }
@@ -178,9 +182,10 @@ public class CounselorService {
     PageRequest pageRequest = PageRequest.of(page, size);
     Page<ChatSession> sessionPage;
     if (sessionStatus != null) {
-      sessionPage = chatSessionRepository.findByStatus(sessionStatus, pageRequest);
+      sessionPage =
+          chatSessionRepository.findByWorkspaceIdAndStatus(workspaceId, sessionStatus, pageRequest);
     } else {
-      sessionPage = chatSessionRepository.findAll(pageRequest);
+      sessionPage = chatSessionRepository.findByWorkspaceId(workspaceId, pageRequest);
     }
 
     List<ChatSessionResponse> content =

--- a/backend/src/main/java/com/init/workflowruntime/domain/ChatSessionRepository.java
+++ b/backend/src/main/java/com/init/workflowruntime/domain/ChatSessionRepository.java
@@ -27,6 +27,11 @@ public interface ChatSessionRepository {
   Optional<ChatSession> findFirstByWorkspaceIdAndStartedByAndStatusInOrderByStartedAtDescIdDesc(
       Long workspaceId, Long startedBy, Collection<ChatSessionStatus> statuses);
 
+  Page<ChatSession> findByWorkspaceId(Long workspaceId, Pageable pageable);
+
+  Page<ChatSession> findByWorkspaceIdAndStatus(
+      Long workspaceId, ChatSessionStatus status, Pageable pageable);
+
   Page<ChatSession> findByStatus(ChatSessionStatus status, Pageable pageable);
 
   Page<ChatSession> findAll(Pageable pageable);

--- a/backend/src/main/java/com/init/workflowruntime/infrastructure/persistence/JpaChatSessionRepository.java
+++ b/backend/src/main/java/com/init/workflowruntime/infrastructure/persistence/JpaChatSessionRepository.java
@@ -28,5 +28,12 @@ public interface JpaChatSessionRepository
   List<ChatSession> findByAssignedCounselorId(Long counselorId);
 
   @Override
+  Page<ChatSession> findByWorkspaceId(Long workspaceId, Pageable pageable);
+
+  @Override
+  Page<ChatSession> findByWorkspaceIdAndStatus(
+      Long workspaceId, ChatSessionStatus status, Pageable pageable);
+
+  @Override
   Page<ChatSession> findByStatus(ChatSessionStatus status, Pageable pageable);
 }

--- a/backend/src/main/java/com/init/workflowruntime/presentation/CounselorSessionController.java
+++ b/backend/src/main/java/com/init/workflowruntime/presentation/CounselorSessionController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/v1/consultation")
+@RequestMapping("/api/v1")
 public class CounselorSessionController {
 
   private final CounselorService counselorService;
@@ -22,23 +22,24 @@ public class CounselorSessionController {
     this.counselorService = counselorService;
   }
 
-  @PostMapping("/sessions/{sessionId}/assign")
+  @PostMapping("/consultation/sessions/{sessionId}/assign")
   public ResponseEntity<CounselorSessionResponse> assignSession(
       @PathVariable Long sessionId, @RequestParam Long counselorId) {
     return ResponseEntity.ok(counselorService.assignSession(counselorId, sessionId));
   }
 
-  @PostMapping("/sessions/{sessionId}/release")
+  @PostMapping("/consultation/sessions/{sessionId}/release")
   public ResponseEntity<CounselorSessionResponse> releaseSession(
       @PathVariable Long sessionId, @RequestParam Long counselorId) {
     return ResponseEntity.ok(counselorService.releaseSession(sessionId, counselorId));
   }
 
-  @GetMapping("/sessions")
+  @GetMapping("/workspaces/{workspaceId}/consultation/sessions")
   public ResponseEntity<CounselorSessionResponse> getSessions(
+      @PathVariable Long workspaceId,
       @RequestParam(required = false) String status,
       @RequestParam(defaultValue = "0") @Min(0) int page,
       @RequestParam(defaultValue = "20") @Min(1) @Max(100) int size) {
-    return ResponseEntity.ok(counselorService.getSessions(status, page, size));
+    return ResponseEntity.ok(counselorService.getSessions(workspaceId, status, page, size));
   }
 }

--- a/backend/src/test/java/com/init/workflowruntime/application/CounselorServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/CounselorServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.never;
@@ -293,37 +294,50 @@ class CounselorServiceTest {
   // ── getSessions ───────────────────────────────────────────────────────────
 
   @Test
-  @DisplayName("getSessions: 상태 필터 없음 → 전체 세션 페이지 반환")
-  void should_returnAllSessions_when_noStatusFilter() {
+  @DisplayName("getSessions: 상태 필터 없음 → 워크스페이스 세션 페이지 반환")
+  void should_returnWorkspaceSessions_when_noStatusFilter() {
     ChatSession session = createSession(1L, ChatSessionStatus.OPEN);
     Page<ChatSession> page = new PageImpl<>(List.of(session));
-    given(chatSessionRepository.findAll(any(Pageable.class))).willReturn(page);
+    given(chatSessionRepository.findByWorkspaceId(eq(1L), any(Pageable.class))).willReturn(page);
 
-    CounselorSessionResponse result = service.getSessions(null, 0, 20);
+    CounselorSessionResponse result = service.getSessions(1L, null, 0, 20);
 
     assertThat(result.getContent()).hasSize(1);
     assertThat(result.getTotalElements()).isEqualTo(1);
+    verify(chatSessionRepository).findByWorkspaceId(eq(1L), any(Pageable.class));
   }
 
   @Test
-  @DisplayName("getSessions: 상태 필터 있음 → 필터링된 페이지 반환")
-  void should_returnFilteredSessions_when_statusGiven() {
+  @DisplayName("getSessions: 상태 필터 있음 → 워크스페이스와 상태로 필터링된 페이지 반환")
+  void should_returnFilteredWorkspaceSessions_when_statusGiven() {
     ChatSession session = createSession(1L, ChatSessionStatus.OPEN);
     Page<ChatSession> page = new PageImpl<>(List.of(session));
-    given(chatSessionRepository.findByStatus(any(ChatSessionStatus.class), any(Pageable.class)))
+    given(
+            chatSessionRepository.findByWorkspaceIdAndStatus(
+                eq(1L), eq(ChatSessionStatus.OPEN), any(Pageable.class)))
         .willReturn(page);
 
-    CounselorSessionResponse result = service.getSessions("OPEN", 0, 20);
+    CounselorSessionResponse result = service.getSessions(1L, "OPEN", 0, 20);
 
     assertThat(result.getContent()).hasSize(1);
+    verify(chatSessionRepository)
+        .findByWorkspaceIdAndStatus(eq(1L), eq(ChatSessionStatus.OPEN), any(Pageable.class));
   }
 
   @Test
   @DisplayName("getSessions: 지원하지 않는 상태 → BadRequestException")
   void should_throwBadRequest_when_invalidStatus() {
-    assertThatThrownBy(() -> service.getSessions("INVALID", 0, 20))
+    assertThatThrownBy(() -> service.getSessions(1L, "INVALID", 0, 20))
         .isInstanceOf(BadRequestException.class)
         .hasMessageContaining("Unsupported status");
+  }
+
+  @Test
+  @DisplayName("getSessions: 유효하지 않은 workspaceId → BadRequestException")
+  void should_throwBadRequest_when_invalidWorkspaceId() {
+    assertThatThrownBy(() -> service.getSessions(0L, null, 0, 20))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("workspaceId");
   }
 
   // ── helpers ───────────────────────────────────────────────────────────────

--- a/backend/src/test/java/com/init/workflowruntime/presentation/CounselorSessionControllerTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/presentation/CounselorSessionControllerTest.java
@@ -101,28 +101,31 @@ class CounselorSessionControllerTest {
   }
 
   @Test
-  @DisplayName("GET /api/v1/consultation/sessions - 전체 세션 목록 조회")
+  @DisplayName("GET /api/v1/workspaces/{workspaceId}/consultation/sessions - 전체 세션 목록 조회")
   void should_returnSessions_when_noStatusFilter() throws Exception {
     CounselorSessionResponse response = new CounselorSessionResponse(List.of(), 0, 20, 0, 0);
 
-    given(counselorService.getSessions(eq(null), eq(0), eq(20))).willReturn(response);
+    given(counselorService.getSessions(eq(1L), eq(null), eq(0), eq(20))).willReturn(response);
 
     mockMvc
-        .perform(get("/api/v1/consultation/sessions").param("page", "0").param("size", "20"))
+        .perform(
+            get("/api/v1/workspaces/1/consultation/sessions")
+                .param("page", "0")
+                .param("size", "20"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.content").isArray());
   }
 
   @Test
-  @DisplayName("GET /api/v1/consultation/sessions - 상태 필터 조회")
+  @DisplayName("GET /api/v1/workspaces/{workspaceId}/consultation/sessions - 상태 필터 조회")
   void should_returnSessions_when_statusFilter() throws Exception {
     CounselorSessionResponse response = new CounselorSessionResponse(List.of(), 0, 20, 0, 0);
 
-    given(counselorService.getSessions(eq("OPEN"), eq(0), eq(20))).willReturn(response);
+    given(counselorService.getSessions(eq(1L), eq("OPEN"), eq(0), eq(20))).willReturn(response);
 
     mockMvc
         .perform(
-            get("/api/v1/consultation/sessions")
+            get("/api/v1/workspaces/1/consultation/sessions")
                 .param("status", "OPEN")
                 .param("page", "0")
                 .param("size", "20"))
@@ -131,14 +134,14 @@ class CounselorSessionControllerTest {
   }
 
   @Test
-  @DisplayName("GET /api/v1/consultation/sessions - 유효하지 않은 상태 → 400")
+  @DisplayName("GET /api/v1/workspaces/{workspaceId}/consultation/sessions - 유효하지 않은 상태 → 400")
   void should_return400_when_invalidStatus() throws Exception {
-    given(counselorService.getSessions(eq("INVALID"), anyInt(), anyInt()))
+    given(counselorService.getSessions(eq(1L), eq("INVALID"), anyInt(), anyInt()))
         .willThrow(new BadRequestException("UNSUPPORTED_STATUS", "Unsupported status: INVALID"));
 
     mockMvc
         .perform(
-            get("/api/v1/consultation/sessions")
+            get("/api/v1/workspaces/1/consultation/sessions")
                 .param("status", "INVALID")
                 .param("page", "0")
                 .param("size", "20"))

--- a/frontend/src/features/consultation/api/chatHistoryApi.test.ts
+++ b/frontend/src/features/consultation/api/chatHistoryApi.test.ts
@@ -54,13 +54,13 @@ describe("useChatSessions", () => {
     const { result } = renderHook(
       () =>
         useChatSessions({
-          workspaceId: "ws-1",
+          workspaceId: 1,
         }),
       { wrapper: makeWrapper() },
     );
 
     await waitFor(() => expect(result.current.data).toEqual([stubSession]));
-    expect(mockedGetSessions).toHaveBeenCalledWith({ status: undefined, page: 0, size: 20 });
+    expect(mockedGetSessions).toHaveBeenCalledWith(1, { status: undefined, page: 0, size: 20 });
   });
 
   it("상태 필터로 세션 목록을 조회한다", async () => {
@@ -69,7 +69,7 @@ describe("useChatSessions", () => {
     const { result } = renderHook(
       () =>
         useChatSessions({
-          workspaceId: "ws-1",
+          workspaceId: 1,
           status: "COMPLETED",
           page: 1,
           size: 10,
@@ -78,7 +78,20 @@ describe("useChatSessions", () => {
     );
 
     await waitFor(() => expect(result.current.data).toEqual([stubSession]));
-    expect(mockedGetSessions).toHaveBeenCalledWith({ status: "COMPLETED", page: 1, size: 10 });
+    expect(mockedGetSessions).toHaveBeenCalledWith(1, { status: "COMPLETED", page: 1, size: 10 });
+  });
+
+  it("workspaceId가 없으면 세션 목록을 조회하지 않는다", () => {
+    const { result } = renderHook(
+      () =>
+        useChatSessions({
+          workspaceId: null,
+        }),
+      { wrapper: makeWrapper() },
+    );
+
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(mockedGetSessions).not.toHaveBeenCalled();
   });
 });
 

--- a/frontend/src/features/consultation/api/chatHistoryApi.ts
+++ b/frontend/src/features/consultation/api/chatHistoryApi.ts
@@ -3,7 +3,7 @@ import { consultationApi } from "./consultationApi";
 import { chatHistoryKeys } from "./chatHistoryKeys";
 
 export interface UseChatSessionsParams {
-  workspaceId: string;
+  workspaceId: number | null;
   status?: string;
   page?: number;
   size?: number;
@@ -17,7 +17,11 @@ export function useChatSessions({
 }: UseChatSessionsParams) {
   return useQuery({
     queryKey: chatHistoryKeys.sessionList(workspaceId, status, page, size),
-    queryFn: () => consultationApi.getSessions({ status, page, size }),
+    queryFn: () => {
+      if (workspaceId === null) return [];
+      return consultationApi.getSessions(workspaceId, { status, page, size });
+    },
+    enabled: workspaceId !== null,
   });
 }
 

--- a/frontend/src/features/consultation/api/chatHistoryKeys.ts
+++ b/frontend/src/features/consultation/api/chatHistoryKeys.ts
@@ -1,6 +1,6 @@
 export const chatHistoryKeys = {
   all: ["chat-history"] as const,
-  sessionList: (workspaceId: string, status?: string, page?: number, size?: number) =>
+  sessionList: (workspaceId: number | null, status?: string, page?: number, size?: number) =>
     ["chat-history", "session-list", workspaceId, status ?? "all", page ?? 0, size ?? 20] as const,
   messages: (sessionId: string, page?: number, size?: number) =>
     ["chat-history", "messages", sessionId, page ?? 0, size ?? 50] as const,

--- a/frontend/src/features/consultation/api/consultationApi.test.ts
+++ b/frontend/src/features/consultation/api/consultationApi.test.ts
@@ -187,9 +187,9 @@ describe("consultationApi", () => {
       headers: new Headers(),
     });
 
-    const result = await consultationApi.getSessions();
+    const result = await consultationApi.getSessions(2);
 
-    expect(mockedCustomFetch).toHaveBeenCalledWith("/api/v1/consultation/sessions", {
+    expect(mockedCustomFetch).toHaveBeenCalledWith("/api/v1/workspaces/2/consultation/sessions", {
       method: "GET",
     });
     expect(result).toEqual(stubSessions);
@@ -207,7 +207,7 @@ describe("consultationApi", () => {
     ];
     mockedCustomFetch.mockResolvedValue({ content: stubSessions, page: 0, size: 20 });
 
-    const result = await consultationApi.getSessions();
+    const result = await consultationApi.getSessions(2);
 
     expect(result).toEqual(stubSessions);
   });
@@ -220,11 +220,14 @@ describe("consultationApi", () => {
       headers: new Headers(),
     });
 
-    await consultationApi.getSessions({ status: "OPEN" });
+    await consultationApi.getSessions(2, { status: "OPEN" });
 
-    expect(mockedCustomFetch).toHaveBeenCalledWith("/api/v1/consultation/sessions?status=OPEN", {
-      method: "GET",
-    });
+    expect(mockedCustomFetch).toHaveBeenCalledWith(
+      "/api/v1/workspaces/2/consultation/sessions?status=OPEN",
+      {
+        method: "GET",
+      },
+    );
   });
 
   it("getSessions가 page/size를 전달한다", async () => {
@@ -235,11 +238,14 @@ describe("consultationApi", () => {
       headers: new Headers(),
     });
 
-    await consultationApi.getSessions({ page: 1, size: 20 });
+    await consultationApi.getSessions(2, { page: 1, size: 20 });
 
-    expect(mockedCustomFetch).toHaveBeenCalledWith("/api/v1/consultation/sessions?page=1&size=20", {
-      method: "GET",
-    });
+    expect(mockedCustomFetch).toHaveBeenCalledWith(
+      "/api/v1/workspaces/2/consultation/sessions?page=1&size=20",
+      {
+        method: "GET",
+      },
+    );
   });
 
   it("getMessages가 params 없이 호출되면 generated 함수를 사용한다", async () => {

--- a/frontend/src/features/consultation/api/consultationApi.ts
+++ b/frontend/src/features/consultation/api/consultationApi.ts
@@ -8,7 +8,7 @@ import { customFetch } from "@/shared/api/mutator";
 import { requireApiData, selectApiData } from "@/shared/api";
 import type { ChatMessageResponse, ChatSessionResponse } from "@/shared/api/generated/zod";
 
-// OpenAPI 미생성 endpoint: workspace-scoped queue/metrics, sessions list, assign/release는 수동 호출로 유지한다.
+// OpenAPI 미생성 endpoint: workspace-scoped queue/metrics/sessions list, assign/release는 수동 호출로 유지한다.
 
 export type ChatSession = ChatSessionResponse & {
   assignedCounselorId?: number | null;
@@ -62,17 +62,20 @@ export const consultationApi = {
     return selectApiData<ChatSession[]>(response) ?? [];
   },
 
-  getSessions: async (params?: {
-    status?: string;
-    page?: number;
-    size?: number;
-  }): Promise<ChatSession[]> => {
+  getSessions: async (
+    workspaceId: number,
+    params?: {
+      status?: string;
+      page?: number;
+      size?: number;
+    },
+  ): Promise<ChatSession[]> => {
     const searchParams = new URLSearchParams();
     if (params?.status) searchParams.set("status", params.status);
     if (params?.page !== undefined) searchParams.set("page", String(params.page));
     if (params?.size !== undefined) searchParams.set("size", String(params.size));
     const query = searchParams.toString();
-    const url = `/api/v1/consultation/sessions${query ? `?${query}` : ""}`;
+    const url = `/api/v1/workspaces/${workspaceId}/consultation/sessions${query ? `?${query}` : ""}`;
     const response = await customFetch<SessionListResponse>(url, { method: "GET" });
     return unwrapSessionList(response);
   },

--- a/frontend/src/features/consultation/ui/chat-history/MessageHistory.tsx
+++ b/frontend/src/features/consultation/ui/chat-history/MessageHistory.tsx
@@ -15,6 +15,8 @@ import styles from "./MessageHistory.module.css";
 
 interface MessageHistoryProps {
   sessionId?: string | null;
+  isSelectionPending?: boolean;
+  missingSessionId?: string | null;
 }
 
 function formatTimestamp(dateStr?: string): string {
@@ -61,8 +63,12 @@ function MessageBubble({ message }: { message: ChatMessage }) {
   );
 }
 
-export function MessageHistory({ sessionId }: MessageHistoryProps) {
-  const activeSessionId = sessionId ?? "";
+export function MessageHistory({
+  sessionId,
+  isSelectionPending = false,
+  missingSessionId = null,
+}: MessageHistoryProps) {
+  const activeSessionId = isSelectionPending || missingSessionId ? "" : (sessionId ?? "");
   const {
     data: messages = [],
     isLoading,
@@ -70,6 +76,27 @@ export function MessageHistory({ sessionId }: MessageHistoryProps) {
     error,
     refetch,
   } = useChatMessages(activeSessionId);
+
+  if (missingSessionId) {
+    return (
+      <section className={styles.wrapper} aria-label="채팅 메시지 내역">
+        <div className={styles.stateArea}>
+          <EmptyState message="현재 워크스페이스에서 해당 상담 세션을 찾을 수 없습니다" />
+        </div>
+      </section>
+    );
+  }
+
+  if (isSelectionPending) {
+    return (
+      <section className={styles.wrapper} aria-label="채팅 메시지 내역">
+        <Header countText="불러오는 중" />
+        <div className={styles.stateArea}>
+          <LoadingSpinner />
+        </div>
+      </section>
+    );
+  }
 
   if (!activeSessionId) {
     return (

--- a/frontend/src/features/consultation/ui/chat-history/SessionList.test.tsx
+++ b/frontend/src/features/consultation/ui/chat-history/SessionList.test.tsx
@@ -1,29 +1,8 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { useChatSessions } from "../../api/chatHistoryApi";
+import type { ComponentProps } from "react";
+import { describe, expect, it, vi } from "vitest";
 import type { ChatSession } from "../../api/consultationApi";
 import { SessionList } from "./SessionList";
-
-vi.mock("../../api/chatHistoryApi", () => ({
-  useChatSessions: vi.fn(),
-}));
-
-const mockedUseChatSessions = vi.mocked(useChatSessions);
-
-type MockChatSessionsResult = Pick<
-  ReturnType<typeof useChatSessions>,
-  "data" | "isLoading" | "isError" | "error" | "refetch"
->;
-
-const makeQueryResult = (overrides?: Partial<MockChatSessionsResult>) =>
-  ({
-    data: [],
-    isLoading: false,
-    isError: false,
-    error: null,
-    refetch: vi.fn(),
-    ...overrides,
-  }) as ReturnType<typeof useChatSessions>;
 
 const makeSession = (id: number, meta?: Record<string, unknown>): ChatSession => ({
   id,
@@ -37,57 +16,38 @@ const makeSession = (id: number, meta?: Record<string, unknown>): ChatSession =>
   startedAt: "2026-05-22T09:00:00+09:00",
 });
 
+function renderSessionList(props?: Partial<ComponentProps<typeof SessionList>>) {
+  return render(
+    <SessionList
+      sessions={[]}
+      selectedSessionId={null}
+      onSelectSession={vi.fn()}
+      onRetry={vi.fn()}
+      {...props}
+    />,
+  );
+}
+
 describe("SessionList", () => {
-  beforeEach(() => {
-    mockedUseChatSessions.mockReset();
-  });
-
-  it("완료된 세션 목록을 기본 필터로 요청한다", () => {
-    mockedUseChatSessions.mockReturnValue(makeQueryResult());
-
-    render(
-      <SessionList workspaceId="workspace-1" selectedSessionId={null} onSelectSession={vi.fn()} />,
-    );
-
-    expect(mockedUseChatSessions).toHaveBeenCalledWith({
-      workspaceId: "workspace-1",
-      status: "completed",
-    });
-  });
-
   it("로딩 상태를 표시한다", () => {
-    mockedUseChatSessions.mockReturnValue(makeQueryResult({ isLoading: true }));
-
-    render(
-      <SessionList workspaceId="workspace-1" selectedSessionId={null} onSelectSession={vi.fn()} />,
-    );
+    renderSessionList({ isLoading: true });
 
     expect(screen.getByText("불러오는 중")).toBeTruthy();
   });
 
   it("세션이 없으면 빈 상태 메시지를 표시한다", () => {
-    mockedUseChatSessions.mockReturnValue(makeQueryResult({ data: [] }));
-
-    render(
-      <SessionList workspaceId="workspace-1" selectedSessionId={null} onSelectSession={vi.fn()} />,
-    );
+    renderSessionList({ sessions: [] });
 
     expect(screen.getByText("아직 채팅 기록이 없습니다")).toBeTruthy();
   });
 
   it("오류 상태에서 메시지와 다시 시도 버튼을 표시한다", () => {
     const refetch = vi.fn();
-    mockedUseChatSessions.mockReturnValue(
-      makeQueryResult({
-        isError: true,
-        error: new Error("목록을 불러오지 못했습니다"),
-        refetch,
-      }),
-    );
-
-    render(
-      <SessionList workspaceId="workspace-1" selectedSessionId={null} onSelectSession={vi.fn()} />,
-    );
+    renderSessionList({
+      isError: true,
+      error: new Error("목록을 불러오지 못했습니다"),
+      onRetry: refetch,
+    });
 
     expect(screen.getByText("목록을 불러오지 못했습니다")).toBeTruthy();
 
@@ -96,11 +56,7 @@ describe("SessionList", () => {
   });
 
   it("세션 카드에 채널, 날짜, 메시지 수, 마지막 메시지를 표시한다", () => {
-    mockedUseChatSessions.mockReturnValue(makeQueryResult({ data: [makeSession(7)] }));
-
-    render(
-      <SessionList workspaceId="workspace-1" selectedSessionId={null} onSelectSession={vi.fn()} />,
-    );
+    renderSessionList({ sessions: [makeSession(7)] });
 
     expect(screen.getByText("카카오톡")).toBeTruthy();
     expect(
@@ -111,35 +67,21 @@ describe("SessionList", () => {
   });
 
   it("세션 카드 제목은 meta title을 우선 표시한다", () => {
-    mockedUseChatSessions.mockReturnValue(
-      makeQueryResult({ data: [makeSession(7, { title: "VIP 환불 상담" })] }),
-    );
-
-    render(
-      <SessionList workspaceId="workspace-1" selectedSessionId={null} onSelectSession={vi.fn()} />,
-    );
+    renderSessionList({ sessions: [makeSession(7, { title: "VIP 환불 상담" })] });
 
     expect(screen.getByText("VIP 환불 상담")).toBeTruthy();
     expect(screen.getByText("카카오톡")).toBeTruthy();
   });
 
   it("선택된 세션은 aria-pressed로 활성 상태를 드러낸다", () => {
-    mockedUseChatSessions.mockReturnValue(makeQueryResult({ data: [makeSession(7)] }));
-
-    render(
-      <SessionList workspaceId="workspace-1" selectedSessionId="7" onSelectSession={vi.fn()} />,
-    );
+    renderSessionList({ sessions: [makeSession(7)], selectedSessionId: "7" });
 
     expect(screen.getByRole("button", { pressed: true })).toBeTruthy();
   });
 
   it("카드를 클릭하면 onSelectSession이 호출된다", () => {
     const onSelect = vi.fn();
-    mockedUseChatSessions.mockReturnValue(makeQueryResult({ data: [makeSession(7)] }));
-
-    render(
-      <SessionList workspaceId="workspace-1" selectedSessionId={null} onSelectSession={onSelect} />,
-    );
+    renderSessionList({ sessions: [makeSession(7)], onSelectSession: onSelect });
 
     fireEvent.click(screen.getByRole("button", { name: /카카오톡/ }));
 

--- a/frontend/src/features/consultation/ui/chat-history/SessionList.tsx
+++ b/frontend/src/features/consultation/ui/chat-history/SessionList.tsx
@@ -1,12 +1,16 @@
 import { EmptyState, ErrorState, Eyebrow, LoadingSpinner } from "@/shared/ui/ostone/atoms";
-import { useChatSessions } from "../../api/chatHistoryApi";
+import type { ChatSession } from "../../api/consultationApi";
 import { SessionCard } from "./SessionCard";
 import styles from "./SessionList.module.css";
 
 interface SessionListProps {
-  workspaceId: string;
+  sessions: ChatSession[];
   selectedSessionId?: string | null;
   onSelectSession: (sessionId: string) => void;
+  isLoading?: boolean;
+  isError?: boolean;
+  error?: unknown;
+  onRetry: () => void;
 }
 
 function getErrorMessage(error: unknown): string {
@@ -14,17 +18,15 @@ function getErrorMessage(error: unknown): string {
   return "채팅 기록을 불러오지 못했습니다";
 }
 
-export function SessionList({ workspaceId, selectedSessionId, onSelectSession }: SessionListProps) {
-  const {
-    data: sessions = [],
-    isLoading,
-    isError,
-    error,
-    refetch,
-  } = useChatSessions({
-    workspaceId,
-    status: "completed",
-  });
+export function SessionList({
+  sessions,
+  selectedSessionId,
+  onSelectSession,
+  isLoading = false,
+  isError = false,
+  error,
+  onRetry,
+}: SessionListProps) {
   const validSessions = sessions.filter(
     (session): session is typeof session & { id: number } => session.id != null,
   );
@@ -51,7 +53,7 @@ export function SessionList({ workspaceId, selectedSessionId, onSelectSession }:
           <span className={styles.count}>오류</span>
         </div>
         <div className={styles.stateArea}>
-          <ErrorState message={getErrorMessage(error)} onRetry={() => refetch()} />
+          <ErrorState message={getErrorMessage(error)} onRetry={onRetry} />
         </div>
       </aside>
     );

--- a/frontend/src/pages/consultation/ui/chat-history/ChatHistoryPage.test.tsx
+++ b/frontend/src/pages/consultation/ui/chat-history/ChatHistoryPage.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   useChatMessages,
@@ -71,9 +71,17 @@ function makeMessage(overrides?: Partial<ChatMessage>): ChatMessage {
   };
 }
 
-function renderPage(path = "/workspaces/workspace-1/consultation/history") {
+let currentPathname = "";
+
+function LocationProbe() {
+  currentPathname = useLocation().pathname;
+  return null;
+}
+
+function renderPage(path = "/workspaces/1/consultation/history") {
   render(
     <MemoryRouter initialEntries={[path]}>
+      <LocationProbe />
       <Routes>
         <Route path="/workspaces/:workspaceId/consultation/history" element={<ChatHistoryPage />} />
         <Route
@@ -97,7 +105,7 @@ describe("ChatHistoryPage", () => {
     renderPage();
 
     expect(mockedUseChatSessions).toHaveBeenCalledWith({
-      workspaceId: "workspace-1",
+      workspaceId: 1,
       status: "completed",
     });
   });
@@ -121,6 +129,7 @@ describe("ChatHistoryPage", () => {
     expect(
       screen.getByText(new Date("2026-05-22T09:10:00+09:00").toLocaleString("ko-KR")),
     ).toBeTruthy();
+    expect(currentPathname).toBe("/workspaces/1/consultation/history/7");
   });
 
   it("상담사 메시지는 상담사 역할로 표시한다", () => {
@@ -190,8 +199,17 @@ describe("ChatHistoryPage", () => {
 
   it("URL의 sessionId로 초기 세션을 선택한다", () => {
     mockedUseChatMessages.mockReturnValue(makeMessagesResult({ data: [makeMessage()] }));
-    renderPage("/workspaces/workspace-1/consultation/history/7");
+    renderPage("/workspaces/1/consultation/history/7");
 
     expect(mockedUseChatMessages).toHaveBeenLastCalledWith("7");
+  });
+
+  it("URL의 sessionId가 현재 워크스페이스 목록에 없으면 메시지를 조회하지 않고 안내한다", () => {
+    renderPage("/workspaces/1/consultation/history/999");
+
+    expect(mockedUseChatMessages).toHaveBeenLastCalledWith("");
+    expect(
+      screen.getByText("현재 워크스페이스에서 해당 상담 세션을 찾을 수 없습니다"),
+    ).toBeTruthy();
   });
 });

--- a/frontend/src/pages/consultation/ui/chat-history/ChatHistoryPage.tsx
+++ b/frontend/src/pages/consultation/ui/chat-history/ChatHistoryPage.tsx
@@ -1,34 +1,70 @@
-import { useEffect, useState } from "react";
-import { useParams } from "react-router-dom";
+import { useMemo } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { useChatSessions } from "../../../../features/consultation/api/chatHistoryApi";
 import { MessageHistory } from "../../../../features/consultation/ui/chat-history/MessageHistory";
 import { SessionList } from "../../../../features/consultation/ui/chat-history/SessionList";
+import { parseRouteId } from "../../../../shared/lib/parseRouteId";
 import styles from "./ChatHistoryPage.module.css";
 
 interface ChatHistoryPageProps {
-  workspaceId?: string;
+  workspaceId?: number;
 }
 
 export function ChatHistoryPage({ workspaceId: workspaceIdProp }: ChatHistoryPageProps) {
+  const navigate = useNavigate();
   const { workspaceId: workspaceIdParam, sessionId: sessionIdParam } = useParams<{
     workspaceId: string;
     sessionId: string;
   }>();
-  const workspaceId = workspaceIdProp ?? workspaceIdParam ?? "";
-  const [selectedSessionId, setSelectedSessionId] = useState<string | null>(sessionIdParam ?? null);
+  const workspaceId = workspaceIdProp ?? parseRouteId(workspaceIdParam);
+  const selectedSessionId = sessionIdParam ?? null;
+  const {
+    data: sessions = [],
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useChatSessions({
+    workspaceId,
+    status: "completed",
+  });
+  const selectableSessionIds = useMemo(
+    () =>
+      new Set(
+        sessions.filter((session) => session.id != null).map((session) => String(session.id)),
+      ),
+    [sessions],
+  );
+  const hasSelectedSession =
+    selectedSessionId !== null && selectableSessionIds.has(selectedSessionId);
+  const isSelectionPending = selectedSessionId !== null && isLoading;
+  const missingSessionId =
+    selectedSessionId !== null && !isLoading && !isError && !hasSelectedSession
+      ? selectedSessionId
+      : null;
 
-  useEffect(() => {
-    setSelectedSessionId(sessionIdParam ?? null);
-  }, [sessionIdParam]);
+  const handleSelectSession = (sessionId: string) => {
+    if (workspaceId === null) return;
+    navigate(`/workspaces/${workspaceId}/consultation/history/${sessionId}`);
+  };
 
   return (
     <main className={styles.page}>
       <SessionList
-        workspaceId={workspaceId}
+        sessions={sessions}
         selectedSessionId={selectedSessionId}
-        onSelectSession={setSelectedSessionId}
+        onSelectSession={handleSelectSession}
+        isLoading={isLoading}
+        isError={isError}
+        error={error}
+        onRetry={refetch}
       />
       <div className={styles.contentPane}>
-        <MessageHistory sessionId={selectedSessionId} />
+        <MessageHistory
+          sessionId={hasSelectedSession ? selectedSessionId : null}
+          isSelectionPending={isSelectionPending}
+          missingSessionId={missingSessionId}
+        />
       </div>
     </main>
   );


### PR DESCRIPTION
## Summary
- 상담 기록 목록 API를 `/api/v1/workspaces/{workspaceId}/consultation/sessions`로 워크스페이스 스코프화했습니다.
- 백엔드 세션 목록 조회를 `workspaceId + status + pagination` 조건으로 제한했습니다.
- 상담 기록 화면에서 URL의 `sessionId`를 선택 상태로 사용하고, 세션 선택 시 `/workspaces/:workspaceId/consultation/history/:sessionId`로 이동하도록 정리했습니다.
- 현재 워크스페이스 목록에 없는 세션 URL은 메시지 조회 없이 명확한 안내 상태를 표시합니다.
- PR 규칙에 맞춰 `.agent/specs/327.md`를 현재 이슈 내용으로 정리했습니다.

## Root Cause
- 기존 상담 기록 목록 API와 서비스 조회가 워크스페이스 조건 없이 전체 세션을 대상으로 동작했습니다.
- 프론트는 `workspaceId`를 query key에만 사용하고 실제 세션 목록 요청 URL에는 반영하지 않았습니다.
- 세션 선택 상태가 URL과 동기화되지 않아 새로고침, 공유 URL, 뒤로가기 흐름이 불안정했습니다.

## Validation
- `mise exec -- ./gradlew test --tests com.init.workflowruntime.application.CounselorServiceTest --tests com.init.workflowruntime.presentation.CounselorSessionControllerTest`
- `cd frontend && pnpm test -- --run src/features/consultation/api/chatHistoryApi.test.ts src/features/consultation/api/consultationApi.test.ts src/features/consultation/ui/chat-history/SessionList.test.tsx src/pages/consultation/ui/chat-history/ChatHistoryPage.test.tsx`
- `cd frontend && pnpm build`
- `cd frontend && pnpm format`
- `cd backend && ./gradlew spotlessApply`
- `git diff --check`

Closes #327