### PR TITLE
fix(frontend): 워크플로우 그래프 화면 오류 상태 정리

### DIFF
--- a/frontend/src/pages/domain-pack/ui/WorkflowGraphViewerPage.module.css
+++ b/frontend/src/pages/domain-pack/ui/WorkflowGraphViewerPage.module.css
@@ -1,22 +1,153 @@
+.page {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+  background: var(--paper);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--s-4);
+  padding: 16px 22px;
+  border-bottom: 1px solid var(--line-2);
+  background: var(--paper);
+}
+
+.titleStack {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.title {
+  margin: 0;
+  color: var(--ink);
+  font-family: var(--sans);
+  font-size: 16px;
+  font-weight: 540;
+  letter-spacing: -0.14px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.description {
+  margin: 0;
+  color: var(--ink-3);
+  font-size: 12px;
+  font-weight: 340;
+  line-height: 1.45;
+  letter-spacing: -0.1px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+}
+
+.headerButton {
+  min-width: 104px;
+  height: 40px;
+  padding: 0 18px;
+  border-radius: var(--r-pill);
+  font-weight: 450;
+  letter-spacing: -0.1px;
+}
+
+.headerButton svg {
+  width: 15px;
+  height: 15px;
+}
+
+.backAction {
+  border-color: var(--line);
+  background: var(--paper);
+  color: var(--ink-2);
+}
+
+.backAction:hover {
+  border-color: var(--ink);
+  background: var(--paper-2);
+  color: var(--ink);
+}
+
+.detailAction {
+  background: var(--ink);
+  color: var(--paper);
+  border: 1px solid var(--ink);
+}
+
+.detailAction:hover {
+  background: var(--ink-2);
+  border-color: var(--ink-2);
+  color: var(--paper);
+}
+
+.canvasFrame {
+  flex: 1;
+  position: relative;
+  margin: 12px 20px 20px;
+  border-radius: var(--r-2);
+  border: 1px solid var(--line-2);
+  background: var(--paper);
+  overflow: hidden;
+  min-height: 400px;
+  box-shadow: inset 0 0 0 1px rgb(0 0 0 / 0.015);
+}
+
+.loadingState,
+.centerState {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  min-height: 360px;
+}
+
 .loadingState {
-  padding: var(--s-8);
-  text-align: center;
-  color: var(--text-3);
+  flex-direction: column;
+  gap: 12px;
 }
 
-.errorState {
-  padding: var(--s-8);
-  text-align: center;
-  color: var(--danger);
-}
-
-.emptyState {
-  padding: var(--s-8);
-  text-align: center;
-  color: var(--text-3);
+.loadingText {
+  color: var(--ink-3);
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.54px;
 }
 
 .graphContainer {
   flex: 1;
+  width: 100%;
+  height: 100%;
   min-height: 0;
+}
+
+@media (max-width: 767px) {
+  .header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .actions {
+    width: 100%;
+  }
+
+  .headerButton {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .canvasFrame {
+    margin: 10px 12px 14px;
+  }
 }

--- a/frontend/src/pages/domain-pack/ui/WorkflowGraphViewerPage.test.tsx
+++ b/frontend/src/pages/domain-pack/ui/WorkflowGraphViewerPage.test.tsx
@@ -1,43 +1,83 @@
-import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
 import type { WorkflowDefinitionDetail } from "@/shared/api/generated/zod";
 import { WorkflowGraphViewerPage } from "./WorkflowGraphViewerPage";
 
-const mockUseGetWorkflowDefinition = vi.hoisted(() => vi.fn());
+const mockUseGetWorkflowDefinition = vi.fn();
+const mockUsePackDetail = vi.fn();
 
 vi.mock("@/features/domain-pack-summary-read", () => ({
-  usePackDetail: () => ({ data: undefined }),
+  usePackDetail: (...args: unknown[]) => mockUsePackDetail(...args),
 }));
 
-vi.mock("react-router-dom", async (importOriginal) => {
-  const actual = await importOriginal();
-  return {
-    ...(actual as object),
-    useParams: () => ({
-      workspaceId: "1",
-      packId: "2",
-      versionId: "3",
-      workflowId: "4",
-    }),
-  };
-});
-
 vi.mock("@/entities/workflow", () => ({
-  useGetWorkflowDefinition: mockUseGetWorkflowDefinition,
+  useGetWorkflowDefinition: (...args: unknown[]) => mockUseGetWorkflowDefinition(...args),
 }));
 
 vi.mock("@/features/workflow-viewer/ui/GraphViewer", () => ({
   GraphViewer: () => <div data-testid="graph-viewer">Graph</div>,
 }));
 
-function Wrapper({ children }: { children: React.ReactNode }) {
-  return <MemoryRouter>{children}</MemoryRouter>;
+vi.mock("@/widgets/ostone-shell", () => ({
+  OstoneShell: ({
+    active,
+    children,
+  }: {
+    active: string;
+    crumbs: unknown[];
+    children: React.ReactNode;
+  }) => (
+    <div>
+      <div data-testid="shell-active">{active}</div>
+      {children}
+    </div>
+  ),
+}));
+
+const ROUTE = "/workspaces/:workspaceId/domain-packs/:packId/workflows/:workflowId/graph";
+
+function LocationProbe() {
+  const location = useLocation();
+  return <div data-testid="location">{`${location.pathname}${location.search}`}</div>;
+}
+
+function renderPage(path = "/workspaces/1/domain-packs/2/workflows/4/graph?versionId=3") {
+  render(
+    <MemoryRouter
+      initialEntries={[
+        {
+          pathname: path.split("?")[0],
+          search: path.includes("?") ? `?${path.split("?")[1]}` : "",
+        },
+      ]}
+    >
+      <Routes>
+        <Route
+          path={ROUTE}
+          element={
+            <>
+              <WorkflowGraphViewerPage />
+              <LocationProbe />
+            </>
+          }
+        />
+        <Route path="*" element={<LocationProbe />} />
+      </Routes>
+    </MemoryRouter>,
+  );
 }
 
 describe("WorkflowGraphViewerPage", () => {
-  afterEach(() => {
-    vi.clearAllMocks();
+  beforeEach(() => {
+    mockUseGetWorkflowDefinition.mockReset();
+    mockUsePackDetail.mockReset();
+    mockUsePackDetail.mockReturnValue({
+      data: {
+        name: "CS Pack",
+        versions: [{ versionId: 3, versionNo: 1 }],
+      },
+    });
   });
 
   it("shows loading state when isLoading is true", () => {
@@ -47,8 +87,9 @@ describe("WorkflowGraphViewerPage", () => {
       error: null,
     });
 
-    render(<WorkflowGraphViewerPage />, { wrapper: Wrapper });
+    renderPage();
     expect(screen.getByTestId("loading-state")).toBeInTheDocument();
+    expect(screen.getByTestId("shell-active")).toHaveTextContent("workflows");
   });
 
   it("shows error state when error is present", () => {
@@ -58,13 +99,14 @@ describe("WorkflowGraphViewerPage", () => {
       error: new Error("Failed to load"),
     });
 
-    render(<WorkflowGraphViewerPage />, { wrapper: Wrapper });
+    renderPage();
     expect(screen.getByTestId("error-state")).toBeInTheDocument();
   });
 
   it("shows GraphViewer when data is loaded", () => {
     const mockData: WorkflowDefinitionDetail = {
       graphJson: JSON.stringify({
+        direction: "LR",
         nodes: [],
         edges: [],
       }),
@@ -75,7 +117,7 @@ describe("WorkflowGraphViewerPage", () => {
       error: null,
     });
 
-    render(<WorkflowGraphViewerPage />, { wrapper: Wrapper });
+    renderPage();
     expect(screen.getByTestId("graph-viewer")).toBeInTheDocument();
   });
 
@@ -89,7 +131,83 @@ describe("WorkflowGraphViewerPage", () => {
       error: null,
     });
 
-    render(<WorkflowGraphViewerPage />, { wrapper: Wrapper });
+    renderPage();
     expect(screen.getByTestId("empty-state")).toBeInTheDocument();
+  });
+
+  it("shows URL error state when versionId query is missing", () => {
+    mockUseGetWorkflowDefinition.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: null,
+    });
+
+    renderPage("/workspaces/1/domain-packs/2/workflows/4/graph");
+    expect(screen.getByTestId("url-error-state")).toHaveTextContent("잘못된 URL 파라미터입니다.");
+  });
+
+  it("shows graph data error state when graphJson is malformed", () => {
+    const mockData: WorkflowDefinitionDetail = {
+      graphJson: "not-json",
+    };
+    mockUseGetWorkflowDefinition.mockReturnValue({
+      data: mockData,
+      isLoading: false,
+      error: null,
+    });
+
+    renderPage();
+    expect(screen.getByTestId("graph-data-error-state")).toHaveTextContent(
+      "워크플로우 그래프 데이터 형식이 올바르지 않습니다.",
+    );
+    expect(screen.queryByTestId("empty-state")).not.toBeInTheDocument();
+  });
+
+  it("moves back to workflow list from graph page", () => {
+    const mockData: WorkflowDefinitionDetail = {
+      id: 4,
+      name: "환불 처리",
+      workflowCode: "refund.standard",
+      graphJson: JSON.stringify({
+        direction: "LR",
+        nodes: [],
+        edges: [],
+      }),
+    };
+    mockUseGetWorkflowDefinition.mockReturnValue({
+      data: mockData,
+      isLoading: false,
+      error: null,
+    });
+
+    renderPage();
+    fireEvent.click(screen.getByRole("button", { name: "목록" }));
+    expect(screen.getByTestId("location")).toHaveTextContent(
+      "/workspaces/1/domain-packs/2/workflows?versionId=3",
+    );
+  });
+
+  it("moves back to workflow detail from graph page", () => {
+    const mockData: WorkflowDefinitionDetail = {
+      id: 4,
+      name: "환불 처리",
+      workflowCode: "refund.standard",
+      graphJson: JSON.stringify({
+        direction: "LR",
+        nodes: [],
+        edges: [],
+      }),
+    };
+    mockUseGetWorkflowDefinition.mockReturnValue({
+      data: mockData,
+      isLoading: false,
+      error: null,
+    });
+
+    renderPage();
+    fireEvent.click(screen.getByRole("button", { name: "상세" }));
+    expect(screen.getByTestId("location")).toHaveTextContent(
+      "/workspaces/1/domain-packs/2/workflows/4?versionId=3",
+    );
   });
 });

--- a/frontend/src/pages/domain-pack/ui/WorkflowGraphViewerPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/WorkflowGraphViewerPage.tsx
@@ -1,19 +1,55 @@
-import { useEffect, useMemo } from "react";
-import { useParams, useSearchParams } from "react-router-dom";
+import { type ReactNode, useEffect, useMemo } from "react";
+import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { toast } from "sonner";
 import { useGetWorkflowDefinition } from "@/entities/workflow";
 import type { WorkflowGraph } from "@/entities/workflow";
 import { usePackDetail } from "@/features/domain-pack-summary-read";
 import { GraphViewer } from "@/features/workflow-viewer/ui/GraphViewer";
-import { buildDomainPackCrumbs } from "@/shared/lib/domainPackRoutes";
+import { buildDomainPackCrumbs, domainPackSectionPath } from "@/shared/lib/domainPackRoutes";
 import { parseRouteId } from "@/shared/lib/parseRouteId";
 import type { Crumb } from "@/shared/ui/ostone/chrome";
+import { Button } from "@/shared/ui/button";
+import { EmptyState } from "@/shared/ui/ostone/atoms/EmptyState";
+import { ErrorState } from "@/shared/ui/ostone/atoms/ErrorState";
+import { Icon } from "@/shared/ui/ostone/atoms";
+import { LoadingSpinner } from "@/shared/ui/ostone/atoms/LoadingSpinner";
 import { OstoneShell } from "@/widgets/ostone-shell";
 import styles from "./WorkflowGraphViewerPage.module.css";
+
+function isWorkflowGraph(value: unknown): value is WorkflowGraph {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const graph = value as { nodes?: unknown; edges?: unknown; direction?: unknown };
+  const hasValidDirection =
+    graph.direction === undefined || graph.direction === "LR" || graph.direction === "TB";
+  return Array.isArray(graph.nodes) && Array.isArray(graph.edges) && hasValidDirection;
+}
+
+type GraphParseResult =
+  | { status: "empty" }
+  | { status: "invalid" }
+  | { status: "ready"; graph: WorkflowGraph };
+
+function parseWorkflowGraph(rawGraph: unknown): GraphParseResult {
+  if (rawGraph === undefined || rawGraph === null || rawGraph === "") {
+    return { status: "empty" };
+  }
+
+  if (typeof rawGraph === "string") {
+    try {
+      const parsed: unknown = JSON.parse(rawGraph);
+      return isWorkflowGraph(parsed) ? { status: "ready", graph: parsed } : { status: "invalid" };
+    } catch {
+      return { status: "invalid" };
+    }
+  }
+
+  return isWorkflowGraph(rawGraph) ? { status: "ready", graph: rawGraph } : { status: "invalid" };
+}
 
 export function WorkflowGraphViewerPage() {
   const { workspaceId, packId, workflowId } = useParams();
   const [search] = useSearchParams();
+  const navigate = useNavigate();
 
   const wsId = parseRouteId(workspaceId);
   const pkId = parseRouteId(packId);
@@ -31,24 +67,12 @@ export function WorkflowGraphViewerPage() {
   });
 
   const packDetail = usePackDetail(wsId ?? 0, pkId ?? 0, {
-    enabled: wsId !== null && pkId !== null,
+    enabled: enabled,
   }).data;
   const packName = packDetail?.name ?? `PACK · ${pkId ?? "?"}`;
   const versionNo = packDetail?.versions?.find((v) => v.versionId === vsId)?.versionNo ?? vsId ?? 0;
 
-  const rawGraph = data?.graphJson;
-  const graph = useMemo<WorkflowGraph | null>(() => {
-    if (!rawGraph) return null;
-    if (typeof rawGraph === "string") {
-      try {
-        return JSON.parse(rawGraph) as WorkflowGraph;
-      } catch {
-        console.error("워크플로우 그래프 JSON 파싱 실패:", rawGraph);
-        return null;
-      }
-    }
-    return rawGraph as WorkflowGraph;
-  }, [rawGraph]);
+  const graphResult = useMemo(() => parseWorkflowGraph(data?.graphJson), [data?.graphJson]);
 
   useEffect(() => {
     if (error) {
@@ -65,48 +89,105 @@ export function WorkflowGraphViewerPage() {
           packName,
           versionNo,
           section: { label: "WORKFLOWS", path: "workflows" },
-          selectedLabel: data?.workflowCode ?? (wfId !== null ? `#${wfId} GRAPH` : "GRAPH"),
+          selectedLabel: data?.workflowCode ?? (wfId !== null ? `#${wfId}` : "GRAPH"),
         })
-      : ["Domain Packs", "Workflow Graph"];
+      : ["워크플로우 설계", "Workflow Graph"];
+
+  const listPath =
+    wsId !== null && pkId !== null
+      ? domainPackSectionPath(wsId, pkId, vsId, "workflows")
+      : "/workspaces";
+  const detailPath =
+    wsId !== null && pkId !== null && vsId !== null && wfId !== null
+      ? domainPackSectionPath(wsId, pkId, vsId, "workflows", wfId)
+      : null;
+
+  const pageTitle =
+    data?.name ?? data?.workflowCode ?? (wfId !== null ? `워크플로우 #${wfId}` : "워크플로우 그래프");
+
+  const shell = (children: ReactNode) => (
+    <OstoneShell active="workflows" crumbs={crumbs}>
+      <div className={styles.page}>
+        <div className={styles.header}>
+          <div className={styles.titleStack}>
+            <h2 className={styles.title}>{pageTitle}</h2>
+            {data?.description && <p className={styles.description}>{data.description}</p>}
+          </div>
+          <div className={styles.actions}>
+            <Button
+              type="button"
+              variant="outline"
+              className={`${styles.headerButton} ${styles.backAction}`}
+              onClick={() => navigate(listPath)}
+            >
+              <Icon name="chevron" size={14} />
+              목록
+            </Button>
+            {detailPath && (
+              <Button
+                type="button"
+                className={`${styles.headerButton} ${styles.detailAction}`}
+                onClick={() => navigate(detailPath)}
+              >
+                <Icon name="flow" size={14} />
+                상세
+              </Button>
+            )}
+          </div>
+        </div>
+        <div className={styles.canvasFrame}>{children}</div>
+      </div>
+    </OstoneShell>
+  );
+
+  if (!enabled) {
+    return shell(
+      <div role="alert" data-testid="url-error-state" className={styles.centerState}>
+        <ErrorState message="잘못된 URL 파라미터입니다." />
+      </div>,
+    );
+  }
 
   if (isLoading) {
-    return (
-      <OstoneShell active="domain" crumbs={crumbs}>
-        <div data-testid="loading-state" className={styles.loadingState}>
-          워크플로우 데이터를 불러오는 중...
-        </div>
-      </OstoneShell>
+    return shell(
+      <div data-testid="loading-state" className={styles.loadingState}>
+        <LoadingSpinner />
+        <span className={styles.loadingText}>워크플로우 데이터를 불러오는 중...</span>
+      </div>,
     );
   }
 
   if (error) {
-    return (
-      <OstoneShell active="domain" crumbs={crumbs}>
-        <div data-testid="error-state" className={styles.errorState}>
-          에러:{" "}
-          {error instanceof Error ? error.message : "데이터를 불러오는 중 오류가 발생했습니다."}
-        </div>
-      </OstoneShell>
+    return shell(
+      <div data-testid="error-state" className={styles.centerState}>
+        <ErrorState
+          message={
+            error instanceof Error ? error.message : "데이터를 불러오는 중 오류가 발생했습니다."
+          }
+        />
+      </div>,
     );
   }
 
-  if (!graph) {
-    return (
-      <OstoneShell active="domain" crumbs={crumbs}>
-        <div data-testid="empty-state" className={styles.emptyState}>
-          표시할 워크플로우 그래프가 없습니다.
-        </div>
-      </OstoneShell>
+  if (graphResult.status === "invalid") {
+    return shell(
+      <div data-testid="graph-data-error-state" className={styles.centerState}>
+        <ErrorState message="워크플로우 그래프 데이터 형식이 올바르지 않습니다." />
+      </div>,
     );
   }
 
-  return (
-    <OstoneShell active="domain" crumbs={crumbs}>
-      <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
-        <div className={styles.graphContainer}>
-          <GraphViewer graph={graph} />
-        </div>
-      </div>
-    </OstoneShell>
+  if (graphResult.status === "empty") {
+    return shell(
+      <div data-testid="empty-state" className={styles.centerState}>
+        <EmptyState message="이 워크플로우에는 아직 그래프가 정의되어 있지 않습니다." />
+      </div>,
+    );
+  }
+
+  return shell(
+    <div className={styles.graphContainer}>
+      <GraphViewer graph={graphResult.graph} />
+    </div>,
   );
 }


### PR DESCRIPTION
## Summary
- 워크플로우 그래프 전용 화면에서 잘못된 URL 파라미터를 빈 그래프가 아니라 URL 오류 상태로 표시합니다.
- 손상된 `graphJson`과 그래프 미정의 상태를 분리해 데이터 오류와 empty state를 다르게 안내합니다.
- 그래프 화면의 사이드바 맥락을 워크플로우로 맞추고 목록/상세 이동 액션을 제공합니다.

## Root Cause
- 전용 그래프 라우트가 `versionId` 누락 또는 유효하지 않은 route id로 API를 비활성화하면서도 이를 잘못된 URL로 표시하지 않았습니다.
- `graphJson` 파싱 실패가 그래프 없음과 같은 empty state로 합쳐져 손상된 데이터를 정상적인 빈 그래프처럼 오해할 수 있었습니다.
- 화면 shell active 값이 `domain`으로 지정되어 워크플로우 전용 화면의 내비게이션 맥락과 어긋났습니다.

## Validation
- `cd frontend && pnpm test -- WorkflowGraphViewerPage.test.tsx --run`
- `cd frontend && pnpm exec eslint src/pages/domain-pack/ui/WorkflowGraphViewerPage.tsx src/pages/domain-pack/ui/WorkflowGraphViewerPage.test.tsx`
- `cd frontend && pnpm build`
- `git diff --check`

## Notes
- `pnpm build`는 성공했으며, 기존 번들 크기 경고가 표시됩니다.

Closes #329

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 워크플로우 그래프 뷰어 페이지의 UI 레이아웃 및 모바일 반응형 디자인 개선

* **버그 수정**
  * 워크플로우 그래프 유효성 검증 강화 및 오류 상태 처리 개선

* **리팩토링**
  * 페이지 상태 관리 로직 정리 및 네비게이션 경로 재구성

* **테스트**
  * 라우팅 컨텍스트 기반 테스트 케이스 구조 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->