### PR TITLE
fix(user-chat): 데모 채팅 중복 렌더링 및 입력 UX 개선

### DIFF
--- a/frontend/src/entities/chat/api/chatApi.test.ts
+++ b/frontend/src/entities/chat/api/chatApi.test.ts
@@ -126,15 +126,7 @@ describe("chatApi", () => {
       id: "77",
       status: "OPEN",
       startedAt: "2026-05-22T00:00:00Z",
-      messages: [
-        {
-          id: "backend-greeting-77",
-          sessionId: 77,
-          senderType: "BOT",
-          content: "안녕하세요, 김민지님. 무엇을 도와드릴까요?",
-          createdAt: "2026-05-22T00:00:00Z",
-        },
-      ],
+      messages: [],
     });
 
     expect(customFetchMock).toHaveBeenCalledWith("/api/v1/workspaces/2/demo/chat-sessions", {

--- a/frontend/src/entities/chat/api/chatApi.ts
+++ b/frontend/src/entities/chat/api/chatApi.ts
@@ -117,15 +117,7 @@ export async function registerDemoChatSession(
     id: String(sessionId),
     status: response.status ?? "OPEN",
     startedAt,
-    messages: [
-      {
-        id: `backend-greeting-${sessionId}`,
-        sessionId,
-        content: `안녕하세요, ${customerName}님. 무엇을 도와드릴까요?`,
-        senderType: "BOT",
-        createdAt: startedAt,
-      },
-    ],
+    messages: [],
   };
 }
 

--- a/frontend/src/entities/chat/lib/chatMessageSync.test.ts
+++ b/frontend/src/entities/chat/lib/chatMessageSync.test.ts
@@ -4,7 +4,6 @@ import {
   isChatMessageResponse,
   isRealtimeChatMessage,
   mergeMessages,
-  mergePersistedMessages,
   parseDemoSessionId,
   toChatMessage,
   toRealtimeChatMessage,
@@ -147,31 +146,8 @@ describe("chatMessageSync", () => {
     ]);
   });
 
-  it("저장 메시지는 optimistic/greeting 메시지를 유지한 뒤 백엔드 메시지와 병합한다", () => {
-    const currentMessages: ChatMessage[] = [
-      {
-        id: "local-user-1",
-        sessionId: 0,
-        senderType: "USER",
-        content: "전송 중",
-        createdAt: "2026-05-22T00:00:01Z",
-      },
-      {
-        id: "backend-greeting-77",
-        sessionId: 77,
-        senderType: "BOT",
-        content: "안녕하세요",
-        createdAt: "2026-05-22T00:00:00Z",
-      },
-      {
-        id: "old-1",
-        sessionId: 77,
-        senderType: "BOT",
-        content: "오래된 응답",
-        createdAt: "2026-05-22T00:00:00Z",
-      },
-    ];
-    const persistedMessages = withCustomerNames(
+  it("사용자 메시지에 고객 이름을 보강한다", () => {
+    const messages = withCustomerNames(
       [
         {
           id: "91",
@@ -180,16 +156,32 @@ describe("chatMessageSync", () => {
           content: "저장된 질문",
           createdAt: "2026-05-22T00:00:02Z",
         },
+        {
+          id: "92",
+          sessionId: 77,
+          senderType: "BOT",
+          content: "저장된 답변",
+          createdAt: "2026-05-22T00:00:03Z",
+        },
       ],
       "김민지",
     );
 
-    expect(mergePersistedMessages(currentMessages, persistedMessages)).toEqual([
-      currentMessages[1],
-      currentMessages[0],
+    expect(messages).toEqual([
       {
-        ...persistedMessages[0],
+        id: "91",
+        sessionId: 77,
+        senderType: "USER",
         senderName: "김민지",
+        content: "저장된 질문",
+        createdAt: "2026-05-22T00:00:02Z",
+      },
+      {
+        id: "92",
+        sessionId: 77,
+        senderType: "BOT",
+        content: "저장된 답변",
+        createdAt: "2026-05-22T00:00:03Z",
       },
     ]);
   });

--- a/frontend/src/entities/chat/lib/chatMessageSync.ts
+++ b/frontend/src/entities/chat/lib/chatMessageSync.ts
@@ -134,13 +134,3 @@ export function withCustomerNames(messages: ChatMessage[], customerName: string)
     message.senderType === "USER" ? { ...message, senderName: customerName } : message,
   );
 }
-
-export function mergePersistedMessages(
-  currentMessages: ChatMessage[],
-  persistedMessages: ChatMessage[],
-): ChatMessage[] {
-  const locallyOwnedMessages = currentMessages.filter(
-    (message) => message.id.startsWith("local-") || message.id.startsWith("backend-greeting-"),
-  );
-  return mergeMessages(locallyOwnedMessages, persistedMessages);
-}

--- a/frontend/src/features/consultation/ui/chat-panel.module.css
+++ b/frontend/src/features/consultation/ui/chat-panel.module.css
@@ -281,9 +281,11 @@
 
 .messageInput:focus,
 .messageInput:focus-visible {
-  border-color: var(--ink);
+  border-color: var(--glass-border);
   background: var(--paper-2);
-  box-shadow: none;
+  box-shadow:
+    0 0 0 2px rgba(0, 0, 0, 0.045),
+    0 0 0 5px rgba(0, 0, 0, 0.018);
 }
 
 .messageInput:disabled {

--- a/frontend/src/features/consultation/ui/chat-panel.module.css
+++ b/frontend/src/features/consultation/ui/chat-panel.module.css
@@ -274,11 +274,16 @@
   background: var(--bg-color);
   outline: none;
   resize: none;
-  transition: border-color var(--transition-fast);
+  transition:
+    border-color var(--transition-fast),
+    background var(--transition-fast);
 }
 
-.messageInput:focus {
-  border-color: var(--primary-color);
+.messageInput:focus,
+.messageInput:focus-visible {
+  border-color: var(--ink);
+  background: var(--paper-2);
+  box-shadow: none;
 }
 
 .messageInput:disabled {

--- a/frontend/src/features/consultation/ui/chat-panel.module.css
+++ b/frontend/src/features/consultation/ui/chat-panel.module.css
@@ -281,7 +281,7 @@
 
 .messageInput:focus,
 .messageInput:focus-visible {
-  border-color: var(--glass-border);
+  border-color: var(--ink);
   background: var(--paper-2);
   box-shadow:
     0 0 0 2px rgba(0, 0, 0, 0.045),

--- a/frontend/src/features/user-chat/ui/MessageInput.module.css
+++ b/frontend/src/features/user-chat/ui/MessageInput.module.css
@@ -1,0 +1,7 @@
+.input:focus,
+.input:focus-visible {
+  border-color: var(--ink) !important;
+  background: var(--paper-2) !important;
+  outline: none;
+  box-shadow: none !important;
+}

--- a/frontend/src/features/user-chat/ui/MessageInput.module.css
+++ b/frontend/src/features/user-chat/ui/MessageInput.module.css
@@ -1,7 +1,9 @@
 .input:focus,
 .input:focus-visible {
-  border-color: var(--ink) !important;
-  background: var(--paper-2) !important;
+  border-color: var(--ink);
+  background: var(--paper-2);
   outline: none;
-  box-shadow: none !important;
+  box-shadow:
+    0 0 0 2px rgba(0, 0, 0, 0.045),
+    0 0 0 5px rgba(0, 0, 0, 0.018);
 }

--- a/frontend/src/features/user-chat/ui/MessageInput.tsx
+++ b/frontend/src/features/user-chat/ui/MessageInput.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { Paperclip, Send } from "lucide-react";
+import styles from "./MessageInput.module.css";
 
 export interface MessageInputProps {
   onSend: (content: string) => void;
@@ -57,6 +58,7 @@ export function MessageInput({ onSend, disabled = false }: MessageInputProps) {
         <Paperclip size={16} aria-hidden="true" />
       </button>
       <input
+        className={styles.input}
         aria-label="메시지 입력"
         disabled={disabled}
         placeholder="메시지를 입력하세요"
@@ -72,6 +74,7 @@ export function MessageInput({ onSend, disabled = false }: MessageInputProps) {
           fontWeight: 460,
           fontFamily: "inherit",
           letterSpacing: "-0.12px",
+          transition: "border-color 160ms ease, background 160ms ease",
         }}
         value={content}
         onChange={(event) => setContent(event.target.value)}

--- a/frontend/src/pages/user-chat/ui/ChatConversationScreen.tsx
+++ b/frontend/src/pages/user-chat/ui/ChatConversationScreen.tsx
@@ -1,4 +1,4 @@
-import type { DemoChatSession } from "@/entities/chat";
+import type { ConnectionStatus, DemoChatSession } from "@/entities/chat";
 import { MessageInput, MessageList } from "@/features/user-chat";
 import { ChatHeader } from "./ChatHeader";
 
@@ -7,9 +7,16 @@ interface ChatConversationScreenProps {
   customerName: string;
   workspaceId: number;
   isSending: boolean;
+  connectionStatus?: ConnectionStatus;
   messageError: string | null;
   onSend: (content: string) => void;
   onStartNewSession: () => void;
+}
+
+function getConnectionLabel(status: ConnectionStatus): string {
+  if (status === "CONNECTED") return "연결됨";
+  if (status === "CONNECTING") return "연결 중";
+  return "연결 끊김";
 }
 
 export function ChatConversationScreen({
@@ -17,10 +24,13 @@ export function ChatConversationScreen({
   customerName,
   workspaceId,
   isSending,
+  connectionStatus = "CONNECTED",
   messageError,
   onSend,
   onStartNewSession,
 }: ChatConversationScreenProps) {
+  const connectionLabel = getConnectionLabel(connectionStatus);
+
   return (
     <div
       data-testid="chat-conversation-screen"
@@ -67,10 +77,10 @@ export function ChatConversationScreen({
                 width: 6,
                 height: 6,
                 borderRadius: 999,
-                background: "var(--signal)",
+                background: connectionStatus === "CONNECTED" ? "var(--signal)" : "var(--danger)",
               }}
             />
-            연결됨
+            {connectionLabel}
           </span>
           <span>Workspace #{workspaceId} · 운영 도메인 팩 기준</span>
         </div>

--- a/frontend/src/pages/user-chat/ui/UserChatPage.test.tsx
+++ b/frontend/src/pages/user-chat/ui/UserChatPage.test.tsx
@@ -317,7 +317,7 @@ describe("UserChatPage", () => {
     });
   });
 
-  it("메시지 전송 성공 응답만으로는 메시지를 화면에 추가하지 않는다", async () => {
+  it("메시지 전송 직후 사용자 메시지를 표시하고 REST 응답만으로는 봇 답변을 추가하지 않는다", async () => {
     stompState.connectionStatus = "CONNECTED";
 
     render(<UserChatPage />);
@@ -325,14 +325,51 @@ describe("UserChatPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "미리보기 시작" }));
 
     const input = await screen.findByLabelText("메시지 입력");
+    await waitFor(() => {
+      expect(stompState.subscribe).toHaveBeenCalledWith("/topic/chat.77", expect.any(Function));
+    });
     fireEvent.change(input, { target: { value: "Hello" } });
     fireEvent.click(screen.getByRole("button", { name: "메시지 보내기" }));
 
     await waitFor(() => {
       expect(sendDemoChatMessageMock).toHaveBeenCalledWith(42, "77", "Hello");
     });
-    expect(screen.queryByText("Hello")).toBeNull();
+    expect(screen.getByText("Hello")).not.toBeNull();
     expect(screen.queryByText("LLM 응답입니다.")).toBeNull();
+  });
+
+  it("WebSocket user 메시지는 optimistic 메시지를 서버 메시지로 교체한다", async () => {
+    let topicHandler: ((message: unknown) => void) | undefined;
+    stompState.connectionStatus = "CONNECTED";
+    stompState.subscribe.mockImplementation((_topic: string, cb: (message: unknown) => void) => {
+      topicHandler = cb;
+      return () => {};
+    });
+
+    render(<UserChatPage />);
+    fireEvent.change(screen.getByLabelText("이름"), { target: { value: "김민지" } });
+    fireEvent.click(screen.getByRole("button", { name: "미리보기 시작" }));
+
+    const input = await screen.findByLabelText("메시지 입력");
+    await waitFor(() => {
+      expect(stompState.subscribe).toHaveBeenCalledWith("/topic/chat.77", expect.any(Function));
+    });
+    fireEvent.change(input, { target: { value: "Hello" } });
+    fireEvent.click(screen.getByRole("button", { name: "메시지 보내기" }));
+
+    expect(await screen.findByText("Hello")).not.toBeNull();
+
+    act(() => {
+      topicHandler?.({
+        id: 81,
+        senderRole: "USER",
+        content: "Hello",
+        createdAt: "2026-05-22T00:00:01Z",
+      });
+    });
+
+    expect(screen.getAllByText("Hello")).toHaveLength(1);
+    expect(screen.getByTestId("message-81")).not.toBeNull();
   });
 
   it("WebSocket user/assistant 메시지를 표시하고 같은 id는 한 번만 렌더링한다", async () => {

--- a/frontend/src/pages/user-chat/ui/UserChatPage.test.tsx
+++ b/frontend/src/pages/user-chat/ui/UserChatPage.test.tsx
@@ -444,7 +444,9 @@ describe("UserChatPage", () => {
 
     await screen.findByTestId("chat-header-eyebrow");
 
-    expect(stompState.subscribe).toHaveBeenCalledWith("/topic/chat.77", expect.any(Function));
+    await waitFor(() => {
+      expect(stompState.subscribe).toHaveBeenCalledWith("/topic/chat.77", expect.any(Function));
+    });
 
     act(() => {
       topicHandler?.({

--- a/frontend/src/pages/user-chat/ui/UserChatPage.test.tsx
+++ b/frontend/src/pages/user-chat/ui/UserChatPage.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ApiRequestError } from "@/shared/api";
 import { UserChatPage } from "./UserChatPage";
@@ -46,22 +46,22 @@ describe("UserChatPage", () => {
     stompState.subscribe.mockReset();
     stompState.subscribe.mockReturnValue(() => {});
     listDemoChatMessagesMock.mockReset();
-    listDemoChatMessagesMock.mockRejectedValue(new Error("sync unavailable"));
+    listDemoChatMessagesMock.mockResolvedValue([
+      {
+        id: "80",
+        sessionId: 77,
+        content: "안녕하세요, 김민지님. 무엇을 도와드릴까요?",
+        senderType: "BOT",
+        createdAt: "2026-05-22T00:00:00Z",
+      },
+    ]);
     registerDemoChatSessionMock.mockReset();
     sendDemoChatMessageMock.mockReset();
     registerDemoChatSessionMock.mockResolvedValue({
       id: "77",
       status: "OPEN",
       startedAt: "2026-05-22T00:00:00Z",
-      messages: [
-        {
-          id: "backend-greeting-77",
-          sessionId: 77,
-          content: "안녕하세요, 김민지님. 무엇을 도와드릴까요?",
-          senderType: "BOT",
-          createdAt: "2026-05-22T00:00:00Z",
-        },
-      ],
+      messages: [],
     });
     sendDemoChatMessageMock.mockResolvedValue([
       {
@@ -91,21 +91,69 @@ describe("UserChatPage", () => {
     const eyebrow = await screen.findByTestId("chat-header-eyebrow");
     expect(eyebrow).toHaveTextContent("Session #77");
     expect(screen.getByTestId("chat-header-name")).toHaveTextContent("김민지");
-    expect(screen.getByText("안녕하세요, 김민지님. 무엇을 도와드릴까요?")).not.toBeNull();
+    expect(await screen.findByText("안녕하세요, 김민지님. 무엇을 도와드릴까요?")).not.toBeNull();
     expect(registerDemoChatSessionMock).toHaveBeenCalledWith(42, "김민지");
   });
 
-  it("같은 이름으로 다시 진입하면 저장된 세션 메시지를 유지한다", async () => {
+  it("세션 진입 시 메시지를 한 번만 조회하고 polling interval을 만들지 않는다", async () => {
+    const setIntervalSpy = vi.spyOn(window, "setInterval");
+
+    try {
+      render(<UserChatPage />);
+      fireEvent.change(screen.getByLabelText("이름"), { target: { value: "김민지" } });
+      fireEvent.click(screen.getByRole("button", { name: "미리보기 시작" }));
+
+      await waitFor(() => {
+        expect(listDemoChatMessagesMock).toHaveBeenCalledWith(42, "77");
+      });
+      expect(listDemoChatMessagesMock).toHaveBeenCalledTimes(1);
+      expect(setIntervalSpy).not.toHaveBeenCalledWith(expect.any(Function), 3000);
+    } finally {
+      setIntervalSpy.mockRestore();
+    }
+  });
+
+  it("같은 이름으로 다시 진입하면 백엔드 저장 메시지를 다시 불러온다", async () => {
+    listDemoChatMessagesMock
+      .mockResolvedValueOnce([
+        {
+          id: "80",
+          sessionId: 77,
+          content: "안녕하세요, 김민지님. 무엇을 도와드릴까요?",
+          senderType: "BOT",
+          createdAt: "2026-05-22T00:00:00Z",
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: "80",
+          sessionId: 77,
+          content: "안녕하세요, 김민지님. 무엇을 도와드릴까요?",
+          senderType: "BOT",
+          createdAt: "2026-05-22T00:00:00Z",
+        },
+        {
+          id: "81",
+          sessionId: 77,
+          content: "Hello",
+          senderType: "USER",
+          senderName: "김민지",
+          createdAt: "2026-05-22T00:00:01Z",
+        },
+        {
+          id: "82",
+          sessionId: 77,
+          content: "LLM 응답입니다.",
+          senderType: "BOT",
+          createdAt: "2026-05-22T00:00:02Z",
+        },
+      ]);
+
     const firstRender = render(<UserChatPage />);
     fireEvent.change(screen.getByLabelText("이름"), { target: { value: "김민지" } });
     fireEvent.click(screen.getByRole("button", { name: "미리보기 시작" }));
 
-    const input = await screen.findByLabelText("메시지 입력");
-    fireEvent.change(input, { target: { value: "Hello" } });
-    fireEvent.click(screen.getByRole("button", { name: "메시지 보내기" }));
-    expect(await screen.findByText("Hello")).not.toBeNull();
-    expect(await screen.findByText("LLM 응답입니다.")).not.toBeNull();
-    expect(sendDemoChatMessageMock).toHaveBeenCalledWith(42, "77", "Hello");
+    expect(await screen.findByText("안녕하세요, 김민지님. 무엇을 도와드릴까요?")).not.toBeNull();
 
     firstRender.unmount();
     registerDemoChatSessionMock.mockClear();
@@ -118,37 +166,45 @@ describe("UserChatPage", () => {
     expect(screen.getByTestId("chat-header-eyebrow")).toHaveTextContent("Session #77");
     expect(screen.getByTestId("chat-header-name")).toHaveTextContent("김민지");
     expect(registerDemoChatSessionMock).not.toHaveBeenCalled();
+    expect(listDemoChatMessagesMock).toHaveBeenCalledTimes(2);
   });
 
   it("새 테스트 세션 시작은 새 백엔드 세션으로 저장 세션을 교체한다", async () => {
+    listDemoChatMessagesMock.mockImplementation((_workspaceId: number, sessionId: string) =>
+      Promise.resolve(
+        sessionId === "77"
+          ? [
+              {
+                id: "80",
+                sessionId: 77,
+                content: "첫 테스트 세션입니다.",
+                senderType: "BOT",
+                createdAt: "2026-05-22T00:00:00Z",
+              },
+            ]
+          : [
+              {
+                id: "90",
+                sessionId: 88,
+                content: "새 테스트 세션입니다.",
+                senderType: "BOT",
+                createdAt: "2026-05-22T00:10:00Z",
+              },
+            ],
+      ),
+    );
     registerDemoChatSessionMock
       .mockResolvedValueOnce({
         id: "77",
         status: "OPEN",
         startedAt: "2026-05-22T00:00:00Z",
-        messages: [
-          {
-            id: "backend-greeting-77",
-            sessionId: 77,
-            content: "첫 테스트 세션입니다.",
-            senderType: "BOT",
-            createdAt: "2026-05-22T00:00:00Z",
-          },
-        ],
+        messages: [],
       })
       .mockResolvedValueOnce({
         id: "88",
         status: "OPEN",
         startedAt: "2026-05-22T00:10:00Z",
-        messages: [
-          {
-            id: "backend-greeting-88",
-            sessionId: 88,
-            content: "새 테스트 세션입니다.",
-            senderType: "BOT",
-            createdAt: "2026-05-22T00:10:00Z",
-          },
-        ],
+        messages: [],
       });
 
     render(<UserChatPage />);
@@ -165,20 +221,21 @@ describe("UserChatPage", () => {
 
   it("새 테스트 세션 생성 실패 시 운영 도메인팩 안내 에러를 표시한다", async () => {
     const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    listDemoChatMessagesMock.mockResolvedValueOnce([
+      {
+        id: "80",
+        sessionId: 77,
+        content: "첫 테스트 세션입니다.",
+        senderType: "BOT",
+        createdAt: "2026-05-22T00:00:00Z",
+      },
+    ]);
     registerDemoChatSessionMock
       .mockResolvedValueOnce({
         id: "77",
         status: "OPEN",
         startedAt: "2026-05-22T00:00:00Z",
-        messages: [
-          {
-            id: "backend-greeting-77",
-            sessionId: 77,
-            content: "첫 테스트 세션입니다.",
-            senderType: "BOT",
-            createdAt: "2026-05-22T00:00:00Z",
-          },
-        ],
+        messages: [],
       })
       .mockRejectedValueOnce(
         new ApiRequestError(
@@ -229,7 +286,97 @@ describe("UserChatPage", () => {
     expect(listDemoChatMessagesMock).toHaveBeenCalledWith(42, "77");
   });
 
-  it("메시지 전송 실패 시 optimistic 메시지를 되돌린다", async () => {
+  it("기존 localStorage 임시 greeting은 초기 REST 메시지로 대체한다", async () => {
+    const storageKey = `ostone:demo-chat-session:42:${encodeURIComponent("김민지")}`;
+    window.localStorage.setItem(
+      storageKey,
+      JSON.stringify({
+        id: "77",
+        status: "OPEN",
+        startedAt: "2026-05-22T00:00:00Z",
+        messages: [
+          {
+            id: "backend-greeting-77",
+            sessionId: 77,
+            content: "안녕하세요, 김민지님. 무엇을 도와드릴까요?",
+            senderType: "BOT",
+            createdAt: "2026-05-22T00:00:00Z",
+          },
+        ],
+      }),
+    );
+
+    render(<UserChatPage />);
+    fireEvent.change(screen.getByLabelText("이름"), { target: { value: "김민지" } });
+    fireEvent.click(screen.getByRole("button", { name: "미리보기 시작" }));
+
+    expect(await screen.findByText("안녕하세요, 김민지님. 무엇을 도와드릴까요?")).not.toBeNull();
+    expect(screen.getAllByText("안녕하세요, 김민지님. 무엇을 도와드릴까요?")).toHaveLength(1);
+    await waitFor(() => {
+      expect(window.localStorage.getItem(storageKey)).not.toContain("backend-greeting-77");
+    });
+  });
+
+  it("메시지 전송 성공 응답만으로는 메시지를 화면에 추가하지 않는다", async () => {
+    stompState.connectionStatus = "CONNECTED";
+
+    render(<UserChatPage />);
+    fireEvent.change(screen.getByLabelText("이름"), { target: { value: "김민지" } });
+    fireEvent.click(screen.getByRole("button", { name: "미리보기 시작" }));
+
+    const input = await screen.findByLabelText("메시지 입력");
+    fireEvent.change(input, { target: { value: "Hello" } });
+    fireEvent.click(screen.getByRole("button", { name: "메시지 보내기" }));
+
+    await waitFor(() => {
+      expect(sendDemoChatMessageMock).toHaveBeenCalledWith(42, "77", "Hello");
+    });
+    expect(screen.queryByText("Hello")).toBeNull();
+    expect(screen.queryByText("LLM 응답입니다.")).toBeNull();
+  });
+
+  it("WebSocket user/assistant 메시지를 표시하고 같은 id는 한 번만 렌더링한다", async () => {
+    let topicHandler: ((message: unknown) => void) | undefined;
+    stompState.connectionStatus = "CONNECTED";
+    stompState.subscribe.mockImplementation((_topic: string, cb: (message: unknown) => void) => {
+      topicHandler = cb;
+      return () => {};
+    });
+
+    render(<UserChatPage />);
+    fireEvent.change(screen.getByLabelText("이름"), { target: { value: "김민지" } });
+    fireEvent.click(screen.getByRole("button", { name: "미리보기 시작" }));
+
+    await screen.findByTestId("chat-header-eyebrow");
+
+    act(() => {
+      topicHandler?.({
+        id: 81,
+        senderRole: "USER",
+        content: "Hello",
+        createdAt: "2026-05-22T00:00:01Z",
+      });
+      topicHandler?.({
+        id: 82,
+        senderRole: "ASSISTANT",
+        content: "LLM 응답입니다.",
+        createdAt: "2026-05-22T00:00:02Z",
+      });
+      topicHandler?.({
+        id: 82,
+        senderRole: "ASSISTANT",
+        content: "LLM 응답입니다.",
+        createdAt: "2026-05-22T00:00:02Z",
+      });
+    });
+
+    expect(await screen.findByText("Hello")).not.toBeNull();
+    expect(await screen.findByText("LLM 응답입니다.")).not.toBeNull();
+    expect(screen.getAllByText("LLM 응답입니다.")).toHaveLength(1);
+  });
+
+  it("메시지 전송 실패 시 에러를 표시한다", async () => {
+    stompState.connectionStatus = "CONNECTED";
     sendDemoChatMessageMock.mockRejectedValueOnce(new Error("LLM failed"));
 
     render(<UserChatPage />);

--- a/frontend/src/pages/user-chat/ui/UserChatPage.tsx
+++ b/frontend/src/pages/user-chat/ui/UserChatPage.tsx
@@ -5,7 +5,7 @@ import {
   registerDemoChatSession,
   sendDemoChatMessage,
 } from "@/entities/chat";
-import type { DemoChatSession } from "@/entities/chat";
+import type { ChatMessage, DemoChatSession } from "@/entities/chat";
 import {
   isRealtimeChatMessage,
   mergeMessages,
@@ -31,6 +31,7 @@ function resolveSessionStartErrorMessage(error: unknown): string {
 }
 
 const DEMO_SESSION_STORAGE_PREFIX = "ostone:demo-chat-session";
+const LOCAL_USER_MESSAGE_PREFIX = "local-user-";
 
 function createStorageKey(workspaceId: number, customerName: string): string {
   const normalizedName = customerName.trim().toLowerCase();
@@ -51,6 +52,80 @@ function isDemoChatSession(value: unknown): value is DemoChatSession {
 
 function isBackendRegisteredSession(session: DemoChatSession): boolean {
   return tryParseDemoSessionId(session.id) != null;
+}
+
+function isLocalUserMessage(message: ChatMessage): boolean {
+  return message.senderType === "USER" && message.id.startsWith(LOCAL_USER_MESSAGE_PREFIX);
+}
+
+function withoutLocalUserMessages(messages: ChatMessage[]): ChatMessage[] {
+  return messages.filter((message) => !isLocalUserMessage(message));
+}
+
+function createLocalUserMessage(
+  sessionId: number,
+  customerName: string,
+  content: string,
+): ChatMessage {
+  const createdAt = new Date().toISOString();
+  return {
+    id: `${LOCAL_USER_MESSAGE_PREFIX}${sessionId}-${Date.now()}`,
+    sessionId,
+    content,
+    senderType: "USER",
+    senderName: customerName,
+    createdAt,
+  };
+}
+
+function mergePersistedMessagesWithPending(
+  persistedMessages: ChatMessage[],
+  currentMessages: ChatMessage[],
+): ChatMessage[] {
+  const unmatchedPersistedUserCounts = new Map<string, number>();
+  persistedMessages.forEach((message) => {
+    if (message.senderType !== "USER") return;
+    unmatchedPersistedUserCounts.set(
+      message.content,
+      (unmatchedPersistedUserCounts.get(message.content) ?? 0) + 1,
+    );
+  });
+
+  const pendingMessages = currentMessages.filter((message) => {
+    if (!isLocalUserMessage(message)) return false;
+    const matchingPersistedCount = unmatchedPersistedUserCounts.get(message.content) ?? 0;
+    if (matchingPersistedCount === 0) return true;
+    unmatchedPersistedUserCounts.set(message.content, matchingPersistedCount - 1);
+    return false;
+  });
+
+  return mergeMessages(persistedMessages, pendingMessages);
+}
+
+function mergeRealtimeMessage(
+  currentMessages: ChatMessage[],
+  realtimeMessage: ChatMessage,
+): ChatMessage[] {
+  if (realtimeMessage.senderType !== "USER") {
+    return mergeMessages(currentMessages, [realtimeMessage]);
+  }
+
+  let replacedLocalMessage = false;
+  const nextMessages = currentMessages.map((message) => {
+    if (
+      !replacedLocalMessage &&
+      isLocalUserMessage(message) &&
+      message.content === realtimeMessage.content
+    ) {
+      replacedLocalMessage = true;
+      return realtimeMessage;
+    }
+    return message;
+  });
+
+  return replacedLocalMessage
+    ? mergeMessages(nextMessages, [])
+    : mergeMessages(currentMessages, [realtimeMessage]);
 }
 
 function readStoredSession(workspaceId: number, customerName: string): DemoChatSession | null {
@@ -185,17 +260,44 @@ export function UserChatPage() {
   const handleSendMessage = async (content: string) => {
     const activeSession = activeChatState.session;
     if (!activeSession || !customerName || isSending) return;
+    const numericSessionId = tryParseDemoSessionId(activeSession.id);
+    if (numericSessionId == null) return;
     if (connectionStatus !== "CONNECTED") {
       setMessageError("연결이 불안정합니다. 잠시 후 다시 시도해 주세요.");
       return;
     }
 
+    const localMessage = createLocalUserMessage(numericSessionId, customerName, content);
     setMessageError(null);
     setIsSending(true);
+    setChatState((current) => {
+      if (current.session?.id !== activeSession.id || current.customerName !== customerName) {
+        return current;
+      }
+      return {
+        ...current,
+        session: {
+          ...current.session,
+          messages: mergeMessages(current.session.messages, [localMessage]),
+        },
+      };
+    });
 
     try {
       await sendDemoChatMessage(workspaceId, activeSession.id, content);
     } catch {
+      setChatState((current) => {
+        if (current.session?.id !== activeSession.id || current.customerName !== customerName) {
+          return current;
+        }
+        return {
+          ...current,
+          session: {
+            ...current.session,
+            messages: current.session.messages.filter((message) => message.id !== localMessage.id),
+          },
+        };
+      });
       setMessageError("응답을 생성하지 못했습니다. 잠시 후 다시 시도해 주세요.");
     } finally {
       setIsSending(false);
@@ -218,18 +320,25 @@ export function UserChatPage() {
           if (current.session?.id !== activeSessionId || current.customerName !== customerName) {
             return current;
           }
+          const nextMessages = mergePersistedMessagesWithPending(
+            namedMessages,
+            current.session.messages,
+          );
           const nextSession = {
             ...current.session,
-            messages: namedMessages,
+            messages: nextMessages,
           };
-          writeStoredSession(workspaceId, customerName, nextSession);
+          writeStoredSession(workspaceId, customerName, {
+            ...nextSession,
+            messages: namedMessages,
+          });
           return {
             ...current,
             session: nextSession,
           };
         });
       } catch {
-        // Demo chat remains usable through the send response even if background sync fails.
+        // Demo chat can continue with realtime messages even if the initial sync fails.
       }
     };
 
@@ -255,9 +364,12 @@ export function UserChatPage() {
         }
         const nextSession = {
           ...current.session,
-          messages: mergeMessages(current.session.messages, [nextMessage]),
+          messages: mergeRealtimeMessage(current.session.messages, nextMessage),
         };
-        writeStoredSession(workspaceId, customerName, nextSession);
+        writeStoredSession(workspaceId, customerName, {
+          ...nextSession,
+          messages: withoutLocalUserMessages(nextSession.messages),
+        });
         return {
           ...current,
           session: nextSession,

--- a/frontend/src/pages/user-chat/ui/UserChatPage.tsx
+++ b/frontend/src/pages/user-chat/ui/UserChatPage.tsx
@@ -5,11 +5,10 @@ import {
   registerDemoChatSession,
   sendDemoChatMessage,
 } from "@/entities/chat";
-import type { ChatMessage, DemoChatSession } from "@/entities/chat";
+import type { DemoChatSession } from "@/entities/chat";
 import {
   isRealtimeChatMessage,
   mergeMessages,
-  mergePersistedMessages,
   toRealtimeChatMessage,
   tryParseDemoSessionId,
   withCustomerNames,
@@ -186,66 +185,17 @@ export function UserChatPage() {
   const handleSendMessage = async (content: string) => {
     const activeSession = activeChatState.session;
     if (!activeSession || !customerName || isSending) return;
-
-    const now = new Date().toISOString();
-    const userMessage: ChatMessage = {
-      id: `local-user-${Date.now()}`,
-      sessionId: 0,
-      content,
-      senderType: "USER",
-      senderName: customerName,
-      createdAt: now,
-    };
+    if (connectionStatus !== "CONNECTED") {
+      setMessageError("연결이 불안정합니다. 잠시 후 다시 시도해 주세요.");
+      return;
+    }
 
     setMessageError(null);
     setIsSending(true);
-    setChatState((current) => {
-      if (current.session?.id !== activeSession.id) return current;
-      const nextSession = {
-        ...activeSession,
-        messages: [...activeSession.messages, userMessage],
-      };
-      writeStoredSession(workspaceId, customerName, nextSession);
-      return {
-        ...current,
-        session: nextSession,
-      };
-    });
 
     try {
-      const savedMessages = await sendDemoChatMessage(workspaceId, activeSession.id, content);
-      const namedMessages = savedMessages.map((message) =>
-        message.senderType === "USER" ? { ...message, senderName: customerName } : message,
-      );
-
-      setChatState((current) => {
-        if (current.session?.id !== activeSession.id) return current;
-        const nextSession = {
-          ...current.session,
-          messages: [
-            ...current.session.messages.filter((message) => message.id !== userMessage.id),
-            ...namedMessages,
-          ],
-        };
-        writeStoredSession(workspaceId, customerName, nextSession);
-        return {
-          ...current,
-          session: nextSession,
-        };
-      });
+      await sendDemoChatMessage(workspaceId, activeSession.id, content);
     } catch {
-      setChatState((current) => {
-        if (current.session?.id !== activeSession.id) return current;
-        const nextSession = {
-          ...current.session,
-          messages: current.session.messages.filter((message) => message.id !== userMessage.id),
-        };
-        writeStoredSession(workspaceId, customerName, nextSession);
-        return {
-          ...current,
-          session: nextSession,
-        };
-      });
       setMessageError("응답을 생성하지 못했습니다. 잠시 후 다시 시도해 주세요.");
     } finally {
       setIsSending(false);
@@ -270,7 +220,7 @@ export function UserChatPage() {
           }
           const nextSession = {
             ...current.session,
-            messages: mergePersistedMessages(current.session.messages, namedMessages),
+            messages: namedMessages,
           };
           writeStoredSession(workspaceId, customerName, nextSession);
           return {
@@ -284,13 +234,9 @@ export function UserChatPage() {
     };
 
     void syncMessages();
-    const intervalId = window.setInterval(() => {
-      void syncMessages();
-    }, 3000);
 
     return () => {
       cancelled = true;
-      window.clearInterval(intervalId);
     };
   }, [activeSessionId, customerName, workspaceId]);
 
@@ -374,7 +320,8 @@ export function UserChatPage() {
       session={activeChatState.session}
       customerName={customerName}
       workspaceId={workspaceId}
-      isSending={isSending}
+      isSending={isSending || connectionStatus !== "CONNECTED"}
+      connectionStatus={connectionStatus}
       messageError={messageError}
       onSend={(content) => {
         void handleSendMessage(content);


### PR DESCRIPTION
## Summary

- 데모 채팅 화면의 메시지 렌더링 흐름을 초기 REST 1회 + 이후 WebSocket 기준으로 정리
- REST 전송 응답, 3초 polling, 프론트 생성 greeting 때문에 같은 메시지가 중복 표시되던 문제를 제거
- 사용자가 보낸 메시지는 즉시 optimistic 렌더링하고, 이후 WebSocket으로 받은 서버 메시지로 교체되도록 개선
- 고객/운영자 채팅 입력창 focus 스타일을 그림자 대신 1px 선과 은은한 배경 변화로 맞춤

## Changes

- `registerDemoChatSession()`에서 프론트 임시 greeting 생성을 제거
- 데모 채팅 진입 시 `listDemoChatMessages()`를 한 번만 호출하도록 정리
- 3초 polling interval을 제거
- `sendDemoChatMessage()` 성공 응답으로 메시지를 append하지 않도록 변경
- WebSocket 수신 메시지를 canonical 렌더링 소스로 유지
- 사용자 전송 메시지는 `local-user-*` 임시 메시지로 즉시 표시하고, 동일 content의 서버 user 메시지 수신 시 교체
- localStorage에는 임시 메시지를 남기지 않고 서버 기준 메시지만 저장되도록 함
- 채팅 입력창 focus 시 shadow ring을 제거하고 1px border + subtle background 상태로 통일

## Validation

- pnpm test

## Notes

- 백엔드 API/DTO 변경은 없음
- 운영자 화면의 메시지 동시성/렌더링 기준 개선은 이번 범위에 포함하지 않음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 데모 채팅 세션 등록 시 자동 봇 인사말이 더 이상 기본 생성되지 않습니다.
  * 전송 실패 시 즉시 추가한 임시(optimistic) 사용자 메시지가 표시되지 않도록 변경되었습니다.
  * 연결 상태(연결됨/연결 중/연결 끊김)가 메타 정보로 점색 및 텍스트로 명확히 표시됩니다.

* **Refactor**
  * 로컬·실시간·서버 메시지 병합 흐름이 재구성되어 중복 렌더와 충돌이 감소하고 동기화가 단순화되었습니다(주기적 폴링 제거).
  * 고객 이름 표기는 사용자 메시지에만 보강됩니다.

* **Style**
  * 메시지 입력창 포커스 시 테두리·배경 전환 및 포커스 링이 추가되었습니다.

* **Tests**
  * 초기 메시지 공급 방식과 동기화/전송 행위를 반영하도록 테스트가 갱신되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->