### PR TITLE
chore(frontend): apply Pretendard font

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,12 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@300;350;400;450;500;600&family=JetBrains+Mono:wght@400;500;600&family=Instrument+Serif:ital@0;1&display=swap"
-      rel="stylesheet"
-    />
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
     <title>frontend</title>
   </head>
   <body>

--- a/frontend/src/app/index.css
+++ b/frontend/src/app/index.css
@@ -18,8 +18,10 @@
 }
 
 :root {
-  --font-sans: "pretendard variable", -apple-system, blinkmacsystemfont, "Segoe UI", sans-serif;
-  --font-mono: "Geist Mono", monospace;
+  --font-sans: "Pretendard Variable", Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto,
+    "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR", "Malgun Gothic",
+    "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif;
+  --font-mono: "Geist Mono", "SF Mono", Menlo, Monaco, Consolas, monospace;
   --font-size-xs: 11px;
   --font-size-sm: 13px;
   --font-size-base: 15px;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3,6 +3,11 @@
 @custom-variant dark (&:is(.dark *));
 
 :root {
+  --font-sans: "Pretendard Variable", Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto,
+    "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR", "Malgun Gothic",
+    "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif;
+  --font-mono: "Geist Mono", "SF Mono", Menlo, Monaco, Consolas, monospace;
+
   --background: 0 0% 100%;
   --foreground: 0 0% 0%;
   --card: 0 0% 100%;

--- a/frontend/src/shared/ui/ostone/tokens.css
+++ b/frontend/src/shared/ui/ostone/tokens.css
@@ -33,9 +33,9 @@
   --dark-ink-3: oklch(0.58 0.012 260);
 
   /* type */
-  --sans: "Inter Tight", "Inter", -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
-  --mono: "JetBrains Mono", "IBM Plex Mono", ui-monospace, "SF Mono", Menlo, monospace;
-  --serif: "Instrument Serif", "Times New Roman", serif;
+  --sans: var(--font-sans);
+  --mono: var(--font-mono);
+  --serif: var(--font-sans);
 
   /* radii — small, technical */
   --r-1: 2px;


### PR DESCRIPTION
## Summary

- Apply the official Pretendard variable font as the frontend global sans stack.
- Remove unused Google Fonts loading and route shared typography tokens (`--sans`, `--serif`) through Pretendard.
- Re-declare the font tokens after Tailwind globals so the final cascade keeps Pretendard active.

## Why

The UI typography stack was mixed across Google Fonts, shared design tokens, and Tailwind-generated defaults. This made Korean text readability inconsistent across screens. Pretendard is now the single sans baseline for the site.

## Validation

- `cd frontend && pnpm install`
- `cd frontend && pnpm build`
- Confirmed the built bundle no longer references Google Fonts / Inter Tight / Instrument Serif.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Style**
  * 폰트 시스템 개선: 더 확장된 폰트 페일오버 체인을 적용하여 다양한 플랫폼과 브라우저에서의 폰트 표시 안정성 향상
  * 산세리프 및 모노스페이스 폰트 스택 강화

* **Chores**
  * CDN 소스 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->