### PR TITLE
feat(user-chat): 사용자 채팅 미리보기 실시간 연결 상태 표시

### DIFF
--- a/.agent/specs/343.md
+++ b/.agent/specs/343.md
@@ -3,7 +3,7 @@
 > **Issue**: [#343](https://github.com/ajou-2026-1-capstone-5/ostone/issues/343)
 > **Bounded Context**: `chat-demo` FE
 > **Template**: `_TEMPLATE_FE.md`
-> **Branch**: `spec/343`
+> **Branch**: `feature/343-realtime-connection-status`
 > **Canonical Number**: `343`
 > **Type**: Frontend (FSD)
 > **작성일**: 2026-05-31

--- a/frontend/src/pages/user-chat/ui/ChatConversationScreen.test.tsx
+++ b/frontend/src/pages/user-chat/ui/ChatConversationScreen.test.tsx
@@ -36,13 +36,14 @@ function setup(overrides: Partial<Parameters<typeof ChatConversationScreen>[0]> 
     customerName: "김민지",
     workspaceId: 42,
     isSending: false,
+    connectionStatus: "CONNECTED",
     messageError: null,
     onSend: vi.fn(),
     onStartNewSession: vi.fn(),
     ...overrides,
   };
-  render(<ChatConversationScreen {...props} />);
-  return props;
+  const view = render(<ChatConversationScreen {...props} />);
+  return { props, ...view };
 }
 
 describe("ChatConversationScreen", () => {
@@ -54,6 +55,8 @@ describe("ChatConversationScreen", () => {
     expect(screen.getByTestId("chat-meta-strip")).toHaveTextContent("Workspace #42");
     expect(screen.getByTestId("chat-meta-strip")).toHaveTextContent("운영 도메인 팩 기준");
     expect(screen.getByTestId("chat-session-reuse-note")).toHaveTextContent("김민지 테스트 세션");
+    expect(screen.queryByTestId("chat-connection-notice")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("메시지 입력")).toBeEnabled();
   });
 
   it("session.messages 의 본문이 화면에 렌더된다", () => {
@@ -63,12 +66,19 @@ describe("ChatConversationScreen", () => {
     expect(screen.getByText("결제 오류 환불 진행 상태 알려주세요.")).toBeInTheDocument();
   });
 
-  it("messageError 가 주어지면 role=alert 으로 에러 배너를 렌더", () => {
-    setup({ messageError: "응답을 생성하지 못했습니다." });
+  it("messageError 와 연결 안내가 동시에 필요한 경우 각각 렌더", () => {
+    setup({
+      connectionStatus: "DISCONNECTED",
+      messageError: "응답을 생성하지 못했습니다.",
+    });
 
     const alert = screen.getByTestId("chat-message-error");
     expect(alert).toHaveAttribute("role", "alert");
     expect(alert).toHaveTextContent("응답을 생성하지 못했습니다.");
+
+    const notice = screen.getByTestId("chat-connection-notice");
+    expect(notice).toHaveAttribute("role", "status");
+    expect(notice).toHaveTextContent("자동 재연결을 시도합니다.");
   });
 
   it("MessageInput 의 send 클릭이 onSend 호출", () => {
@@ -85,6 +95,58 @@ describe("ChatConversationScreen", () => {
 
     expect(screen.getByLabelText("메시지 입력")).toBeDisabled();
     expect(screen.getByLabelText("메시지 보내기")).toBeDisabled();
+  });
+
+  it("입력값이 비어 있으면 연결됨 상태에서도 전송 버튼이 disabled", () => {
+    setup();
+
+    expect(screen.getByLabelText("메시지 입력")).toBeEnabled();
+    expect(screen.getByLabelText("메시지 보내기")).toBeDisabled();
+  });
+
+  it.each([
+    {
+      status: "CONNECTING" as const,
+      label: "연결 중",
+      notice: "실시간 연결을 준비하는 중입니다.",
+      dotColor: "var(--ink-4)",
+    },
+    {
+      status: "DISCONNECTED" as const,
+      label: "재연결 중",
+      notice: "실시간 연결이 끊어졌습니다.",
+      dotColor: "var(--ink-4)",
+    },
+    {
+      status: "ERROR" as const,
+      label: "오프라인",
+      notice: "네트워크 상태를 확인한 뒤 다시 시도해 주세요.",
+      dotColor: "var(--danger)",
+    },
+  ])(
+    "$label 상태에서는 연결 안내를 표시하고 입력을 비활성화한다",
+    ({ status, label, notice, dotColor }) => {
+      setup({ connectionStatus: status });
+
+      expect(screen.getByTestId("chat-meta-strip")).toHaveTextContent(label);
+      expect(screen.getByTestId("chat-connection-dot").style.background).toBe(dotColor);
+      expect(screen.getByTestId("chat-connection-notice")).toHaveTextContent(notice);
+      expect(screen.getByLabelText("메시지 입력")).toBeDisabled();
+      expect(screen.getByLabelText("메시지 보내기")).toBeDisabled();
+    },
+  );
+
+  it("연결이 복구되면 안내가 사라지고 입력 가능 상태로 돌아온다", () => {
+    const { props, rerender } = setup({ connectionStatus: "DISCONNECTED" });
+
+    expect(screen.getByTestId("chat-connection-notice")).toHaveTextContent("자동 재연결");
+    expect(screen.getByLabelText("메시지 입력")).toBeDisabled();
+
+    rerender(<ChatConversationScreen {...props} connectionStatus="CONNECTED" />);
+
+    expect(screen.getByTestId("chat-meta-strip")).toHaveTextContent("연결됨");
+    expect(screen.queryByTestId("chat-connection-notice")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("메시지 입력")).toBeEnabled();
   });
 
   it("새 테스트 세션 시작 클릭이 onStartNewSession 호출", () => {

--- a/frontend/src/pages/user-chat/ui/ChatConversationScreen.tsx
+++ b/frontend/src/pages/user-chat/ui/ChatConversationScreen.tsx
@@ -1,5 +1,6 @@
-import type { ConnectionStatus, DemoChatSession } from "@/entities/chat";
+import type { DemoChatSession } from "@/entities/chat";
 import { MessageInput, MessageList } from "@/features/user-chat";
+import type { ConnectionStatus } from "@/shared/lib/websocket";
 import { ChatHeader } from "./ChatHeader";
 
 interface ChatConversationScreenProps {
@@ -7,16 +8,68 @@ interface ChatConversationScreenProps {
   customerName: string;
   workspaceId: number;
   isSending: boolean;
-  connectionStatus?: ConnectionStatus;
+  connectionStatus: ConnectionStatus;
   messageError: string | null;
   onSend: (content: string) => void;
   onStartNewSession: () => void;
 }
 
-function getConnectionLabel(status: ConnectionStatus): string {
-  if (status === "CONNECTED") return "연결됨";
-  if (status === "CONNECTING") return "연결 중";
-  return "연결 끊김";
+interface RealtimeConnectionDisplay {
+  label: string;
+  notice: string | null;
+  dotColor: string;
+  noticeBorder: string;
+  noticeBackground: string;
+  noticeColor: string;
+  canSend: boolean;
+}
+
+function resolveRealtimeConnectionDisplay(status: ConnectionStatus): RealtimeConnectionDisplay {
+  if (status === "CONNECTED") {
+    return {
+      label: "연결됨",
+      notice: null,
+      dotColor: "var(--signal)",
+      noticeBorder: "var(--line-2)",
+      noticeBackground: "var(--paper)",
+      noticeColor: "var(--ink-3)",
+      canSend: true,
+    };
+  }
+
+  if (status === "CONNECTING") {
+    return {
+      label: "연결 중",
+      notice: "실시간 연결을 준비하는 중입니다. 연결 후 메시지를 보낼 수 있습니다.",
+      dotColor: "var(--ink-4)",
+      noticeBorder: "var(--line)",
+      noticeBackground: "var(--paper-3)",
+      noticeColor: "var(--ink-3)",
+      canSend: false,
+    };
+  }
+
+  if (status === "DISCONNECTED") {
+    return {
+      label: "재연결 중",
+      notice: "실시간 연결이 끊어졌습니다. 잠시 후 자동 재연결을 시도합니다.",
+      dotColor: "var(--ink-4)",
+      noticeBorder: "var(--line)",
+      noticeBackground: "var(--paper-3)",
+      noticeColor: "var(--ink-3)",
+      canSend: false,
+    };
+  }
+
+  return {
+    label: "오프라인",
+    notice: "실시간 연결에 문제가 있습니다. 네트워크 상태를 확인한 뒤 다시 시도해 주세요.",
+    dotColor: "var(--danger)",
+    noticeBorder: "var(--danger)",
+    noticeBackground: "var(--danger-bg)",
+    noticeColor: "var(--danger)",
+    canSend: false,
+  };
 }
 
 export function ChatConversationScreen({
@@ -24,12 +77,13 @@ export function ChatConversationScreen({
   customerName,
   workspaceId,
   isSending,
-  connectionStatus = "CONNECTED",
+  connectionStatus,
   messageError,
   onSend,
   onStartNewSession,
 }: ChatConversationScreenProps) {
-  const connectionLabel = getConnectionLabel(connectionStatus);
+  const connectionDisplay = resolveRealtimeConnectionDisplay(connectionStatus);
+  const isInputDisabled = isSending || !connectionDisplay.canSend;
 
   return (
     <div
@@ -73,14 +127,15 @@ export function ChatConversationScreen({
           <span style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
             <span
               aria-hidden="true"
+              data-testid="chat-connection-dot"
               style={{
                 width: 6,
                 height: 6,
                 borderRadius: 999,
-                background: connectionStatus === "CONNECTED" ? "var(--signal)" : "var(--danger)",
+                background: connectionDisplay.dotColor,
               }}
             />
-            {connectionLabel}
+            {connectionDisplay.label}
           </span>
           <span>Workspace #{workspaceId} · 운영 도메인 팩 기준</span>
         </div>
@@ -145,11 +200,28 @@ export function ChatConversationScreen({
           {messageError}
         </div>
       )}
+      {connectionDisplay.notice && (
+        <div
+          role="status"
+          data-testid="chat-connection-notice"
+          style={{
+            borderTop: `1px solid ${connectionDisplay.noticeBorder}`,
+            background: connectionDisplay.noticeBackground,
+            padding: "9px 20px",
+            fontSize: 12.5,
+            lineHeight: 1.45,
+            color: connectionDisplay.noticeColor,
+            fontWeight: 450,
+          }}
+        >
+          {connectionDisplay.notice}
+        </div>
+      )}
       <MessageInput
         onSend={(content) => {
           onSend(content);
         }}
-        disabled={isSending}
+        disabled={isInputDisabled}
       />
     </div>
   );

--- a/frontend/src/pages/user-chat/ui/UserChatPage.tsx
+++ b/frontend/src/pages/user-chat/ui/UserChatPage.tsx
@@ -452,7 +452,7 @@ export function UserChatPage() {
       session={activeChatState.session}
       customerName={customerName}
       workspaceId={workspaceId}
-      isSending={isSending || connectionStatus !== "CONNECTED"}
+      isSending={isSending}
       connectionStatus={connectionStatus}
       messageError={messageError}
       onSend={(content) => {


### PR DESCRIPTION
## Summary
- 사용자 채팅 미리보기 메타 스트립이 WebSocket 실제 상태에 따라 `연결 중`, `연결됨`, `재연결 중`, `오프라인`을 표시하도록 변경했습니다.
- 연결이 안정적이지 않을 때 입력 영역 근처에 상태 안내를 표시하고 메시지 입력/전송을 비활성화합니다.
- 연결 복구, 전송 실패 배너와 연결 안내 동시 표시, 상태별 disabled 동작을 `ChatConversationScreen` 테스트로 검증했습니다.

## Root Cause
- 기존 `ChatConversationScreen`은 실제 WebSocket 상태와 관계없이 메타 스트립에 `연결됨`을 표시했습니다.
- `UserChatPage`의 `connectionStatus`가 화면 표시보다 구독 조건에만 사용되어, 연결 지연이나 실패를 도메인 팩 응답 문제로 오해할 수 있었습니다.

## Validation
- `cd frontend && pnpm test -- ChatConversationScreen`
- `cd frontend && pnpm exec eslint src/pages/user-chat/ui/ChatConversationScreen.tsx src/pages/user-chat/ui/ChatConversationScreen.test.tsx src/pages/user-chat/ui/UserChatPage.tsx`
- `git diff --check`

## Notes
- `cd frontend && pnpm lint`는 현재 작업 범위 밖의 기존 ESLint 오류 60개로 실패합니다. 이번 변경 파일 대상 lint는 통과했습니다.

Closes #343
