### PR TITLE
chore(workspace): refine create dialog input

### DIFF
--- a/frontend/src/features/workspace/ui/CreateWorkspaceDialog.tsx
+++ b/frontend/src/features/workspace/ui/CreateWorkspaceDialog.tsx
@@ -106,18 +106,18 @@ export function CreateWorkspaceDialog({
         <DialogHeader>
           <DialogTitle>워크스페이스 생성</DialogTitle>
           <DialogDescription>
-            팀이 함께 사용할 워크스페이스를 만들고 응대 흐름 생성 작업을 시작합니다.
+            워크스페이스를 생성하여 상담 공간을 구축합니다.
           </DialogDescription>
         </DialogHeader>
         <form className={styles.form} onSubmit={handleSubmit}>
           <div className={styles.field}>
-            <Label htmlFor="workspace-name">이름</Label>
+            <Label htmlFor="workspace-name">제목</Label>
             <Input
               id="workspace-name"
               className={styles.dialogInput}
               value={name}
               onChange={(event) => setName(event.target.value)}
-              placeholder="CS Team Alpha"
+              placeholder="예: 아주대학교 운영팀"
               aria-invalid={fieldErrors.name ? "true" : "false"}
               aria-describedby={nameErrorId}
             />
@@ -128,7 +128,6 @@ export function CreateWorkspaceDialog({
               </p>
             )}
           </div>
-          <p className={styles.helperText}>워크스페이스 키는 이름을 바탕으로 자동 생성됩니다.</p>
           <DialogFooter className={styles.buttonRow}>
             <Button
               type="button"

--- a/frontend/src/features/workspace/ui/workspace-dialog.module.css
+++ b/frontend/src/features/workspace/ui/workspace-dialog.module.css
@@ -19,25 +19,38 @@
   gap: 10px;
 }
 
-.dialogInput input {
+.dialogInput {
   min-height: 56px;
   padding: 0 20px;
+  border-color: rgba(0, 0, 0, 0.16);
   background: #ffffff;
-  border-color: rgba(0, 0, 0, 0.14);
-  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.03);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.025);
   font-size: 0.98rem;
+  font-weight: var(--font-weight-base);
   letter-spacing: -0.16px;
 }
 
-.dialogInput input::placeholder {
-  color: rgba(0, 0, 0, 0.36);
+.dialogInput::placeholder {
+  color: rgba(0, 0, 0, 0.46);
 }
 
-.dialogInput input:focus-visible {
+.dialogInput:focus-visible {
   outline: none;
+  border-color: #000000;
+  background: #ffffff;
   box-shadow:
-    0 0 0 1px #000000,
-    0 12px 28px rgba(0, 0, 0, 0.08);
+    0 0 0 3px rgba(0, 0, 0, 0.1),
+    0 12px 28px rgba(0, 0, 0, 0.06);
+}
+
+.dialogInput[aria-invalid="true"] {
+  border-color: var(--error-color);
+}
+
+.dialogInput[aria-invalid="true"]:focus-visible {
+  box-shadow:
+    0 0 0 3px rgba(180, 35, 24, 0.12),
+    0 12px 28px rgba(0, 0, 0, 0.06);
 }
 
 .fieldError {
@@ -54,17 +67,6 @@
   width: 14px;
   height: 14px;
   flex-shrink: 0;
-}
-
-.helperText {
-  color: rgba(0, 0, 0, 0.52);
-  font-size: 0.86rem;
-  line-height: 1.5;
-  letter-spacing: -0.12px;
-  padding: 12px 14px;
-  border-radius: 8px;
-  border: 1px solid rgba(0, 0, 0, 0.08);
-  background: rgba(0, 0, 0, 0.025);
 }
 
 .buttonRow {


### PR DESCRIPTION
## Summary
- 워크스페이스 생성 다이얼로그의 안내 문구를 간결하게 수정했습니다.
- 입력 필드 라벨과 placeholder를 실제 사용 맥락에 맞게 조정했습니다.
- 입력 컴포넌트 스타일 셀렉터를 바로잡아 포커스/placeholder 스타일이 정상 적용되도록 했습니다.

## Changes
- 설명 문구: `워크스페이스를 생성하여 상담 공간을 구축합니다.`
- 라벨: `이름` → `제목`
- placeholder: `예: 아주대학교 운영팀`
- 하단 워크스페이스 키 자동 생성 안내 문구 제거
- 입력창 포커스 시 회색 배경 대신 흰 배경, 검정 보더, 부드러운 링 적용

## Test
- `git diff --check` 통과
- 로컬 환경에 `npx`, `pnpm`, `docker`가 없어 lint/test 및 화면 확인은 미실행

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Style**
  * 워크스페이스 생성 다이얼로그의 입력 필드 레이블이 업데이트되었습니다.
  * 다이얼로그 설명 문구가 추가되었습니다.
  * 입력 필드의 안내 텍스트가 제거되었습니다.
  * 입력 필드의 스타일이 개선되어 포커스 및 유효성 상태가 더 명확하게 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->