### PR TITLE
fix(workspace): 워크스페이스 생성 후 리다이렉트 오류 수정

### DIFF
--- a/.agent/specs/0351.md
+++ b/.agent/specs/0351.md
@@ -1,0 +1,277 @@
+# 0351: [FE] 워크스페이스 생성 성공 후 리다이렉트 오류 수정
+
+> **Issue**: [#351](https://github.com/ajou-2026-1-capstone-5/ostone/issues/351)
+> **Bounded Context**: `workspace` FE
+> **Template**: `_TEMPLATE_FE.md`
+> **Branch**: `fix/0351-workspace-create-redirect`
+> **Canonical Number**: `0351`
+> **Type**: Frontend (FSD Bug Fix)
+> **작성일**: 2026-06-01
+
+---
+
+## Goal
+
+워크스페이스 생성이 성공했는데도 이상한 오류 토스트가 표시되고 생성된 워크스페이스로 즉시 이동하지 않는 문제를 수정한다.
+
+---
+
+## Background
+
+현재 워크스페이스 생성 API는 백엔드에서 `WorkspaceResponse`를 JSON body로 직접 반환한다. 하지만 프론트의 `CreateWorkspaceDialog`는 generated client 타입을 기준으로 응답이 `{ data: WorkspaceResponse }` 형태라고 가정하고 `result.data`를 읽는다.
+
+런타임 실제 응답이 raw `WorkspaceResponse`이면 `result.data`는 `undefined`가 된다. 이후 `WorkspaceRootRedirect`의 `onSuccess`에서 `created.id`를 사용하려 할 때 예외가 발생하고, 이 예외가 `CreateWorkspaceDialog`의 catch 블록에 잡혀 `워크스페이스 목록을 새로고침하지 못했습니다...` 토스트로 표시된다.
+
+결과적으로 워크스페이스 생성은 정상 완료되지만 사용자는 실패처럼 보이는 메시지를 보고, 생성된 워크스페이스의 `/workspaces/{id}/workflows` 화면으로 이동하지 못한다.
+
+---
+
+## Scope
+
+### In Scope
+
+- `CreateWorkspaceDialog`의 생성 성공 응답 처리 방식을 수정한다.
+- raw `WorkspaceResponse`와 `{ data: WorkspaceResponse }` 응답을 모두 처리할 수 있도록 기존 공용 API 응답 유틸리티를 사용한다.
+- 생성 응답에서 유효한 `id`를 확보한 경우에만 `onSuccess(created)`를 호출한다.
+- 생성 응답이 비정상인 경우 `created.id` 접근 예외 대신 명확한 오류 토스트를 표시한다.
+- 워크스페이스 생성 성공 후 `/workspaces/{created.id}/workflows`로 즉시 리다이렉트되는 동작을 테스트한다.
+- API 응답 형태 차이에 대한 회귀 테스트를 추가한다.
+
+### Out of Scope
+
+- 백엔드 `WorkspaceController` 응답 구조 변경
+- Orval generated 파일 직접 수정
+- workspace create endpoint 재생성
+- 워크스페이스 목록, 수정, 삭제 UI 재설계
+- 로그인/인증 흐름 변경
+- 전체 API client 구조 개편
+
+---
+
+## Existing Context
+
+아래 경로는 현재 repository에서 존재 확인 완료했다.
+
+| Existing file | 현재 역할 | 변경 기준 |
+| --- | --- | --- |
+| `frontend/src/features/workspace/ui/CreateWorkspaceDialog.tsx` | 워크스페이스 생성 모달, 생성 mutation 성공/실패 처리 | `result.data` 직접 접근 제거, 안전한 응답 unwrap 적용 |
+| `frontend/src/pages/workspace/ui/WorkspaceRootRedirect.tsx` | `/workspaces` 진입 시 목록 조회, 빈 목록이면 생성 모달 표시, 생성 성공 시 navigate | `onSuccess(created)`가 유효한 workspace를 받으면 기존 navigate 흐름 유지 |
+| `frontend/src/pages/workspace/ui/WorkspaceRootRedirect.test.tsx` | `/workspaces` redirect 및 생성 성공 navigate 테스트 | 생성 성공 후 navigate 기대값 유지 |
+| `frontend/src/shared/api/apiResponse.ts` | raw 응답과 `{ data }` 응답을 모두 처리하는 `selectApiData`, `selectApiList` 제공 | 새 helper 추가 없이 기존 `selectApiData` 재사용 |
+| `frontend/src/shared/api/unwrapApiResponse.ts` | API 응답 unwrap 유틸리티 | 직접 수정하지 않음 |
+| `frontend/src/shared/api/generated/endpoints/workspace-controller/workspace-controller.ts` | Orval generated workspace endpoint hooks | 직접 수정하지 않음 |
+| `backend/src/main/java/com/init/workspace/presentation/WorkspaceController.java` | workspace REST controller | 현재 raw `WorkspaceResponse` 반환 계약 유지 |
+
+---
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A["사용자가 /workspaces 진입"] --> B{"워크스페이스 목록 존재?"}
+    B -->|"Yes"| C["첫 워크스페이스 workflows로 이동"]
+    B -->|"No"| D["워크스페이스 생성 모달 표시"]
+    D --> E["사용자가 이름 입력 후 생성 클릭"]
+    E --> F["POST /api/v1/workspaces 요청"]
+    F --> G{"생성 성공?"}
+    G -->|"No"| H["API 오류 메시지 표시"]
+    G -->|"Yes"| I["응답에서 WorkspaceResponse 추출"]
+    I --> J{"id 유효?"}
+    J -->|"No"| K["응답 오류 토스트 표시, 리다이렉트 중단"]
+    J -->|"Yes"| L["성공 토스트 표시"]
+    L --> M["모달 닫기"]
+    M --> N["/workspaces/{id}/workflows로 이동"]
+```
+
+---
+
+## Design Diff
+
+### As-is vs To-be
+
+| 영역 | As-is | To-be | 변경 내용 |
+| --- | --- | --- | --- |
+| 생성 성공 응답 읽기 | `result.data` 직접 접근 | `selectApiData<WorkspaceResponse>(result)` 사용 | raw 응답과 `{ data }` 응답 모두 지원 |
+| 생성 후 리다이렉트 | `created`가 `undefined`가 되어 `created.id` 접근 예외 발생 | 유효한 `created.id`가 있을 때만 `onSuccess` 호출 | 생성 직후 workflows 화면 이동 보장 |
+| 오류 메시지 | 응답 파싱 문제도 "목록 새로고침 실패"로 표시 | 생성 응답 오류를 별도 메시지로 표시 | 사용자가 원인을 더 정확히 이해 |
+| API 계약 | generated 타입과 런타임 응답 형태가 혼재 | 호출부에서 기존 unwrap 유틸로 흡수 | backend/generated 파일 변경 없이 회귀 방지 |
+
+---
+
+## API Integration
+
+새 endpoint 또는 backend 계약 변경은 없다.
+
+| Method | Path | Response | 설명 |
+| --- | --- | --- | --- |
+| `POST` | `/api/v1/workspaces` | `WorkspaceResponse` | 워크스페이스 생성 |
+| `GET` | `/api/v1/workspaces` | `WorkspaceResponse[]` | 워크스페이스 목록 조회 |
+| `GET` | `/api/v1/workspaces/{id}` | `WorkspaceResponse` | 워크스페이스 단건 조회 |
+
+### Response Handling Contract
+
+`CreateWorkspaceDialog`는 생성 mutation 성공 결과를 아래 두 형태 모두에서 같은 `WorkspaceResponse`로 해석해야 한다.
+
+```typescript
+// 실제 backend/customFetch 런타임 응답
+{
+  id: 12,
+  workspaceKey: "support-team-abc123",
+  name: "Support Team",
+  status: "ACTIVE"
+}
+```
+
+```typescript
+// generated type 또는 일부 테스트 mock에서 사용할 수 있는 래핑 응답
+{
+  data: {
+    id: 12,
+    workspaceKey: "support-team-abc123",
+    name: "Support Team",
+    status: "ACTIVE"
+  }
+}
+```
+
+구현은 기존 유틸리티를 사용한다.
+
+```typescript
+const created = selectApiData<WorkspaceResponse>(
+  result as WorkspaceResponse | { data?: WorkspaceResponse },
+);
+```
+
+---
+
+## Component Tree
+
+```text
+WorkspaceRootRedirect
+└─ CreateWorkspaceDialog
+   ├─ Workspace name input
+   ├─ Cancel button
+   └─ Submit button
+      └─ useCreateWorkspace mutation
+         ├─ onSuccess: unwrap response and call parent onSuccess
+         └─ onError: field error or toast
+```
+
+---
+
+## Data Flow
+
+```text
+CreateWorkspaceDialog submit
+  -> generateWorkspaceKey(trimmedName)
+  -> useCreateWorkspace.mutate({ data: { workspaceKey, name } })
+  -> onSuccess(result)
+  -> selectApiData<WorkspaceResponse>(result)
+  -> validate created.id
+  -> toast.success
+  -> onOpenChange(false)
+  -> WorkspaceRootRedirect.onSuccess(created)
+  -> navigate(`/workspaces/${created.id}/workflows`, { replace: true })
+```
+
+---
+
+## 수정 대상 파일
+
+| 파일 | 변경 유형 | 설명 |
+| --- | --- | --- |
+| `frontend/src/features/workspace/ui/CreateWorkspaceDialog.tsx` | modify | 생성 성공 응답 unwrap, `id` 검증, 명확한 오류 토스트 처리 |
+| `frontend/src/features/workspace/ui/CreateWorkspaceDialog.test.tsx` | new | raw 응답, `{ data }` 응답, 비정상 응답 케이스 테스트 |
+| `frontend/src/pages/workspace/ui/WorkspaceRootRedirect.test.tsx` | optional modify | 생성 성공 navigate 회귀 테스트가 충분하지 않으면 보강 |
+
+### Optional Follow-up
+
+| 파일 | 변경 유형 | 설명 |
+| --- | --- | --- |
+| `frontend/src/pages/workspace/ui/WorkspaceLayout.tsx` | optional modify | `useGetWorkspace` 결과도 `selectApiData`로 정규화해 API 응답 형태 혼재에 더 강하게 만든다 |
+
+Optional follow-up은 이번 버그의 직접 원인이 아니므로, 구현 중 불필요하면 제외한다.
+
+---
+
+## Implementation Notes
+
+- `frontend/src/shared/api/generated/endpoints/workspace-controller/workspace-controller.ts`는 generated 파일이므로 직접 수정하지 않는다.
+- `frontend/src/shared/api/apiResponse.ts`에 이미 `selectApiData`가 있으므로 새 unwrap helper를 만들지 않는다.
+- 생성 성공 후 `onSuccess`에서 throw가 발생하는 경우는 parent callback 실패로 보고 기존 "목록 갱신 실패" 계열 메시지를 유지할 수 있다.
+- 생성 응답 자체가 비정상인 경우와 parent callback 실패는 서로 다른 메시지로 구분한다.
+- `isSubmitting`은 성공적으로 navigate가 시작되는 happy path에서는 별도 reset이 필요 없다. 오류 path에서는 기존처럼 `false`로 되돌린다.
+- `created.id`는 `null` 또는 `undefined`일 수 있다고 보고 방어한다. `0`은 정상 workspace id로 사용하지 않는 것이 일반적이지만, 프론트에서는 `typeof created.id === "number"` 또는 `created.id != null` 기준으로 충분하다.
+
+---
+
+## Acceptance Criteria
+
+| # | 기준 | 검증 방법 |
+| --- | --- | --- |
+| 1 | backend가 raw `WorkspaceResponse`를 반환해도 생성 성공 후 `/workspaces/{id}/workflows`로 이동한다 | 컴포넌트 테스트 |
+| 2 | `{ data: WorkspaceResponse }` 형태의 mock 응답에서도 동일하게 이동한다 | 컴포넌트 테스트 |
+| 3 | 생성 성공 응답에서 `id`를 확인할 수 없으면 `onSuccess`와 navigate를 호출하지 않는다 | 컴포넌트 테스트 |
+| 4 | 응답 파싱 문제로 인해 "목록 새로고침 실패" 메시지가 표시되지 않는다 | 컴포넌트 테스트 |
+| 5 | `WORKSPACE_INVALID_NAME`, `WORKSPACE_KEY_CONFLICT` 필드 오류 처리는 기존 동작을 유지한다 | 기존/추가 테스트 |
+| 6 | generated 파일은 수정하지 않는다 | git diff 확인 |
+
+---
+
+## Tests
+
+### Test Strategy
+
+| 구분 | 방법 | 도구 | 비고 |
+| --- | --- | --- | --- |
+| 컴포넌트 테스트 | 생성 모달 submit과 mutation callback mock | Vitest, Testing Library | 핵심 회귀 검증 |
+| 라우팅 테스트 | `WorkspaceRootRedirect` 생성 성공 navigate 확인 | Vitest, MemoryRouter mock | 기존 테스트 유지 또는 보강 |
+| 정적 검사 | 타입/린트 확인 | `pnpm lint` | 가능하면 실행 |
+
+### Test Scenarios
+
+#### Happy Path
+
+| # | 시나리오 | 사전 조건 | 조작 | 기대 결과 |
+| --- | --- | --- | --- | --- |
+| 1 | raw 응답 생성 성공 | `useCreateWorkspace`가 raw `WorkspaceResponse` 반환 | 이름 입력 후 생성 | `onSuccess`가 생성 workspace로 호출됨 |
+| 2 | wrapped 응답 생성 성공 | `useCreateWorkspace`가 `{ data: WorkspaceResponse }` 반환 | 이름 입력 후 생성 | `onSuccess`가 생성 workspace로 호출됨 |
+| 3 | 빈 워크스페이스 목록에서 생성 성공 | `/workspaces`, 목록 없음 | 생성 완료 | `/workspaces/{id}/workflows`로 navigate |
+
+#### Error & Edge Cases
+
+| # | 시나리오 | 조작 | 기대 결과 |
+| --- | --- | --- | --- |
+| 1 | 생성 응답에 `id` 없음 | mutation success가 `{ name: "WS" }` 반환 | 오류 토스트 표시, `onSuccess` 미호출 |
+| 2 | 생성 응답이 `undefined` | mutation success가 `undefined` 반환 | 오류 토스트 표시, `onSuccess` 미호출 |
+| 3 | workspace name validation 실패 | 빈 이름 제출 | API 호출 없음, 필드 오류 표시 |
+| 4 | `WORKSPACE_INVALID_NAME` | mutation error | name field error 표시 |
+| 5 | `WORKSPACE_KEY_CONFLICT` | mutation error | "다른 워크스페이스 이름으로 다시 시도해주세요." 표시 |
+
+### Suggested Commands
+
+```bash
+cd frontend && pnpm test -- CreateWorkspaceDialog
+cd frontend && pnpm test -- WorkspaceRootRedirect
+cd frontend && pnpm lint
+```
+
+---
+
+## Risk & Mitigation
+
+| Risk | 영향 | 대응 |
+| --- | --- | --- |
+| generated 타입과 실제 응답이 계속 어긋남 | 다른 생성/수정 화면에서도 유사 버그 가능 | 이번 변경은 workspace create에 한정하고, 반복 발견 시 API client 정규화 이슈로 분리 |
+| `onSuccess` callback 오류와 응답 오류가 섞임 | 잘못된 toast 표시 | 응답 검증 실패와 callback 실패 메시지를 분리 |
+| 테스트 mock이 generated 타입만 가정 | raw 응답 회귀를 놓침 | raw 응답과 `{ data }` 응답을 모두 테스트 |
+
+---
+
+## Non-Functional Requirements
+
+- 기존 FSD 의존성 방향을 유지한다.
+- shared API 유틸은 재사용하고 새 추상화는 추가하지 않는다.
+- generated 파일은 직접 수정하지 않는다.
+- UI 레이아웃 변경 없이 동작 오류만 수정한다.
+- 사용자가 생성 성공을 실패로 오해하지 않도록 오류 메시지를 구체화한다.

--- a/.agent/specs/0351.md
+++ b/.agent/specs/0351.md
@@ -22,7 +22,7 @@
 
 런타임 실제 응답이 raw `WorkspaceResponse`이면 `result.data`는 `undefined`가 된다. 이후 `WorkspaceRootRedirect`의 `onSuccess`에서 `created.id`를 사용하려 할 때 예외가 발생하고, 이 예외가 `CreateWorkspaceDialog`의 catch 블록에 잡혀 `워크스페이스 목록을 새로고침하지 못했습니다...` 토스트로 표시된다.
 
-결과적으로 워크스페이스 생성은 정상 완료되지만 사용자는 실패처럼 보이는 메시지를 보고, 생성된 워크스페이스의 `/workspaces/{id}/workflows` 화면으로 이동하지 못한다.
+결과적으로 워크스페이스 생성은 정상 완료되지만 사용자는 실패처럼 보이는 메시지를 보고, 생성된 워크스페이스의 `/workspaces/{id}/upload` 화면으로 이동하지 못한다.
 
 ---
 
@@ -34,7 +34,7 @@
 - raw `WorkspaceResponse`와 `{ data: WorkspaceResponse }` 응답을 모두 처리할 수 있도록 기존 공용 API 응답 유틸리티를 사용한다.
 - 생성 응답에서 유효한 `id`를 확보한 경우에만 `onSuccess(created)`를 호출한다.
 - 생성 응답이 비정상인 경우 `created.id` 접근 예외 대신 명확한 오류 토스트를 표시한다.
-- 워크스페이스 생성 성공 후 `/workspaces/{created.id}/workflows`로 즉시 리다이렉트되는 동작을 테스트한다.
+- 워크스페이스 생성 성공 후 `/workspaces/{created.id}/upload`로 즉시 리다이렉트되는 동작을 테스트한다.
 - API 응답 형태 차이에 대한 회귀 테스트를 추가한다.
 
 ### Out of Scope
@@ -80,7 +80,7 @@ flowchart TD
     J -->|"No"| K["응답 오류 토스트 표시, 리다이렉트 중단"]
     J -->|"Yes"| L["성공 토스트 표시"]
     L --> M["모달 닫기"]
-    M --> N["/workspaces/{id}/workflows로 이동"]
+    M --> N["/workspaces/{id}/upload로 이동"]
 ```
 
 ---
@@ -92,7 +92,7 @@ flowchart TD
 | 영역 | As-is | To-be | 변경 내용 |
 | --- | --- | --- | --- |
 | 생성 성공 응답 읽기 | `result.data` 직접 접근 | `selectApiData<WorkspaceResponse>(result)` 사용 | raw 응답과 `{ data }` 응답 모두 지원 |
-| 생성 후 리다이렉트 | `created`가 `undefined`가 되어 `created.id` 접근 예외 발생 | 유효한 `created.id`가 있을 때만 `onSuccess` 호출 | 생성 직후 workflows 화면 이동 보장 |
+| 생성 후 리다이렉트 | `created`가 `undefined`가 되어 `created.id` 접근 예외 발생 | 유효한 `created.id`가 있을 때만 `onSuccess` 호출 | 생성 직후 업로드 화면 이동 보장 |
 | 오류 메시지 | 응답 파싱 문제도 "목록 새로고침 실패"로 표시 | 생성 응답 오류를 별도 메시지로 표시 | 사용자가 원인을 더 정확히 이해 |
 | API 계약 | generated 타입과 런타임 응답 형태가 혼재 | 호출부에서 기존 unwrap 유틸로 흡수 | backend/generated 파일 변경 없이 회귀 방지 |
 
@@ -171,7 +171,7 @@ CreateWorkspaceDialog submit
   -> toast.success
   -> onOpenChange(false)
   -> WorkspaceRootRedirect.onSuccess(created)
-  -> navigate(`/workspaces/${created.id}/workflows`, { replace: true })
+  -> navigate(`/workspaces/${created.id}/upload`, { replace: true })
 ```
 
 ---
@@ -209,7 +209,7 @@ Optional follow-up은 이번 버그의 직접 원인이 아니므로, 구현 중
 
 | # | 기준 | 검증 방법 |
 | --- | --- | --- |
-| 1 | backend가 raw `WorkspaceResponse`를 반환해도 생성 성공 후 `/workspaces/{id}/workflows`로 이동한다 | 컴포넌트 테스트 |
+| 1 | backend가 raw `WorkspaceResponse`를 반환해도 생성 성공 후 `/workspaces/{id}/upload`로 이동한다 | 컴포넌트 테스트 |
 | 2 | `{ data: WorkspaceResponse }` 형태의 mock 응답에서도 동일하게 이동한다 | 컴포넌트 테스트 |
 | 3 | 생성 성공 응답에서 `id`를 확인할 수 없으면 `onSuccess`와 navigate를 호출하지 않는다 | 컴포넌트 테스트 |
 | 4 | 응답 파싱 문제로 인해 "목록 새로고침 실패" 메시지가 표시되지 않는다 | 컴포넌트 테스트 |
@@ -236,7 +236,7 @@ Optional follow-up은 이번 버그의 직접 원인이 아니므로, 구현 중
 | --- | --- | --- | --- | --- |
 | 1 | raw 응답 생성 성공 | `useCreateWorkspace`가 raw `WorkspaceResponse` 반환 | 이름 입력 후 생성 | `onSuccess`가 생성 workspace로 호출됨 |
 | 2 | wrapped 응답 생성 성공 | `useCreateWorkspace`가 `{ data: WorkspaceResponse }` 반환 | 이름 입력 후 생성 | `onSuccess`가 생성 workspace로 호출됨 |
-| 3 | 빈 워크스페이스 목록에서 생성 성공 | `/workspaces`, 목록 없음 | 생성 완료 | `/workspaces/{id}/workflows`로 navigate |
+| 3 | 빈 워크스페이스 목록에서 생성 성공 | `/workspaces`, 목록 없음 | 생성 완료 | `/workspaces/{id}/upload`로 navigate |
 
 #### Error & Edge Cases
 

--- a/frontend/src/features/workspace/ui/CreateWorkspaceDialog.test.tsx
+++ b/frontend/src/features/workspace/ui/CreateWorkspaceDialog.test.tsx
@@ -1,0 +1,110 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { toast } from "sonner";
+
+import type { WorkspaceResponse } from "@/entities/workspace";
+
+import { CreateWorkspaceDialog } from "./CreateWorkspaceDialog";
+
+const mocks = vi.hoisted(() => ({
+  mutate: vi.fn(),
+}));
+
+vi.mock("@/shared/api/generated/endpoints/workspace-controller/workspace-controller", () => ({
+  useCreateWorkspace: () => ({
+    mutate: mocks.mutate,
+  }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+type CreateWorkspaceCallbacks = {
+  onSuccess?: (result: unknown) => Promise<void> | void;
+  onError?: (error: unknown) => void;
+};
+
+const createdWorkspace: WorkspaceResponse = {
+  id: 351,
+  workspaceKey: "support-team-abc123",
+  name: "Support Team",
+  status: "ACTIVE",
+};
+
+function renderDialog() {
+  const onOpenChange = vi.fn();
+  const onSuccess = vi.fn();
+
+  render(<CreateWorkspaceDialog open={true} onOpenChange={onOpenChange} onSuccess={onSuccess} />);
+
+  return { onOpenChange, onSuccess };
+}
+
+function submitWorkspaceName(name = "Support Team") {
+  fireEvent.change(screen.getByLabelText("제목"), { target: { value: name } });
+  fireEvent.click(screen.getByRole("button", { name: "생성" }));
+}
+
+describe("CreateWorkspaceDialog", () => {
+  beforeEach(() => {
+    mocks.mutate.mockReset();
+    vi.mocked(toast.success).mockReset();
+    vi.mocked(toast.error).mockReset();
+  });
+
+  it("raw WorkspaceResponse 응답이면 생성 성공 콜백을 호출한다", async () => {
+    mocks.mutate.mockImplementation((_variables: unknown, callbacks: CreateWorkspaceCallbacks) => {
+      callbacks.onSuccess?.(createdWorkspace);
+    });
+    const { onOpenChange, onSuccess } = renderDialog();
+
+    submitWorkspaceName();
+
+    await waitFor(() => expect(onSuccess).toHaveBeenCalledWith(createdWorkspace));
+    expect(toast.success).toHaveBeenCalledWith("워크스페이스를 생성했습니다.");
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("{ data: WorkspaceResponse } 응답이어도 생성 성공 콜백을 호출한다", async () => {
+    mocks.mutate.mockImplementation((_variables: unknown, callbacks: CreateWorkspaceCallbacks) => {
+      callbacks.onSuccess?.({ data: createdWorkspace });
+    });
+    const { onSuccess } = renderDialog();
+
+    submitWorkspaceName();
+
+    await waitFor(() => expect(onSuccess).toHaveBeenCalledWith(createdWorkspace));
+    expect(toast.success).toHaveBeenCalledWith("워크스페이스를 생성했습니다.");
+  });
+
+  it("생성 응답에서 id를 확인할 수 없으면 성공 콜백을 호출하지 않는다", async () => {
+    mocks.mutate.mockImplementation((_variables: unknown, callbacks: CreateWorkspaceCallbacks) => {
+      callbacks.onSuccess?.({ name: "Support Team", status: "ACTIVE" });
+    });
+    const { onOpenChange, onSuccess } = renderDialog();
+
+    submitWorkspaceName();
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(
+        "워크스페이스 생성 응답을 확인하지 못했습니다. 잠시 후 다시 시도해주세요.",
+      ),
+    );
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  it("이름이 비어 있으면 생성 mutation을 호출하지 않는다", () => {
+    renderDialog();
+
+    fireEvent.click(screen.getByRole("button", { name: "생성" }));
+
+    expect(mocks.mutate).not.toHaveBeenCalled();
+    expect(screen.getByRole("alert")).toHaveTextContent("이름을 입력해주세요.");
+  });
+});

--- a/frontend/src/features/workspace/ui/CreateWorkspaceDialog.test.tsx
+++ b/frontend/src/features/workspace/ui/CreateWorkspaceDialog.test.tsx
@@ -222,6 +222,17 @@ describe("CreateWorkspaceDialog", () => {
     expect(onOpenChange).toHaveBeenCalledWith(true);
   });
 
+  it("Dialog open 이벤트는 기존 검증 오류를 reset하지 않는다", () => {
+    const { onOpenChange } = renderDialog();
+    fireEvent.click(screen.getByRole("button", { name: "생성" }));
+    expect(screen.getByRole("alert")).toHaveTextContent("이름을 입력해주세요.");
+
+    fireEvent.click(screen.getByRole("button", { name: "mock keep dialog open" }));
+
+    expect(screen.getByRole("alert")).toHaveTextContent("이름을 입력해주세요.");
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+  });
+
   it("이름이 비어 있으면 생성 mutation을 호출하지 않는다", () => {
     renderDialog();
 

--- a/frontend/src/features/workspace/ui/CreateWorkspaceDialog.test.tsx
+++ b/frontend/src/features/workspace/ui/CreateWorkspaceDialog.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { toast } from "sonner";
 
 import type { WorkspaceResponse } from "@/entities/workspace";
+import { ApiRequestError } from "@/shared/api";
 
 import { CreateWorkspaceDialog } from "./CreateWorkspaceDialog";
 
@@ -69,6 +70,23 @@ describe("CreateWorkspaceDialog", () => {
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
+  it("워크스페이스 이름을 trim하고 생성 요청 payload를 만든다", () => {
+    mocks.mutate.mockImplementation(() => undefined);
+    renderDialog();
+
+    submitWorkspaceName("  Support Team  ");
+
+    expect(mocks.mutate).toHaveBeenCalledWith(
+      {
+        data: {
+          name: "Support Team",
+          workspaceKey: expect.stringMatching(/^support-team-[a-z0-9]{6}$/),
+        },
+      },
+      expect.any(Object),
+    );
+  });
+
   it("{ data: WorkspaceResponse } 응답이어도 생성 성공 콜백을 호출한다", async () => {
     mocks.mutate.mockImplementation((_variables: unknown, callbacks: CreateWorkspaceCallbacks) => {
       callbacks.onSuccess?.({ data: createdWorkspace });
@@ -99,6 +117,41 @@ describe("CreateWorkspaceDialog", () => {
     expect(toast.success).not.toHaveBeenCalled();
   });
 
+  it("부모 성공 콜백이 실패하면 목록 갱신 실패 toast를 표시한다", async () => {
+    mocks.mutate.mockImplementation((_variables: unknown, callbacks: CreateWorkspaceCallbacks) => {
+      callbacks.onSuccess?.(createdWorkspace);
+    });
+    const onOpenChange = vi.fn();
+    const onSuccess = vi.fn().mockRejectedValue(new Error("navigation failed"));
+    render(<CreateWorkspaceDialog open={true} onOpenChange={onOpenChange} onSuccess={onSuccess} />);
+
+    submitWorkspaceName();
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(
+        "워크스페이스 목록을 새로고침하지 못했습니다. 잠시 후 다시 시도해주세요.",
+      ),
+    );
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("생성 요청 중에는 제출 버튼을 비활성화한다", async () => {
+    mocks.mutate.mockImplementation(() => undefined);
+    renderDialog();
+
+    submitWorkspaceName();
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "생성 중..." })).toBeDisabled());
+  });
+
+  it("취소 버튼을 누르면 모달 닫기 콜백을 호출한다", () => {
+    const { onOpenChange } = renderDialog();
+
+    fireEvent.click(screen.getByRole("button", { name: "취소" }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
   it("이름이 비어 있으면 생성 mutation을 호출하지 않는다", () => {
     renderDialog();
 
@@ -106,5 +159,50 @@ describe("CreateWorkspaceDialog", () => {
 
     expect(mocks.mutate).not.toHaveBeenCalled();
     expect(screen.getByRole("alert")).toHaveTextContent("이름을 입력해주세요.");
+  });
+
+  it("서버 이름 검증 오류는 name field error로 표시한다", async () => {
+    mocks.mutate.mockImplementation((_variables: unknown, callbacks: CreateWorkspaceCallbacks) => {
+      callbacks.onError?.(
+        new ApiRequestError(400, "WORKSPACE_INVALID_NAME", "이름은 255자 이하여야 합니다."),
+      );
+    });
+    renderDialog();
+
+    submitWorkspaceName();
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent("이름은 255자 이하여야 합니다."),
+    );
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it("workspace key 충돌은 이름 재시도 안내로 표시한다", async () => {
+    mocks.mutate.mockImplementation((_variables: unknown, callbacks: CreateWorkspaceCallbacks) => {
+      callbacks.onError?.(
+        new ApiRequestError(409, "WORKSPACE_KEY_CONFLICT", "이미 사용 중인 키입니다."),
+      );
+    });
+    renderDialog();
+
+    submitWorkspaceName();
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "다른 워크스페이스 이름으로 다시 시도해주세요.",
+      ),
+    );
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it("알 수 없는 생성 실패는 공통 오류 toast로 표시한다", async () => {
+    mocks.mutate.mockImplementation((_variables: unknown, callbacks: CreateWorkspaceCallbacks) => {
+      callbacks.onError?.(new Error("network error"));
+    });
+    renderDialog();
+
+    submitWorkspaceName();
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith("서버에 연결할 수 없습니다."));
   });
 });

--- a/frontend/src/features/workspace/ui/CreateWorkspaceDialog.test.tsx
+++ b/frontend/src/features/workspace/ui/CreateWorkspaceDialog.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { toast } from "sonner";
+import type { ComponentProps, ReactNode } from "react";
 
 import type { WorkspaceResponse } from "@/entities/workspace";
 import { ApiRequestError } from "@/shared/api";
@@ -22,6 +23,38 @@ vi.mock("sonner", () => ({
     success: vi.fn(),
     error: vi.fn(),
   },
+}));
+
+vi.mock("@/shared/ui/dialog", () => ({
+  Dialog: ({
+    open,
+    onOpenChange,
+    children,
+  }: {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    children: ReactNode;
+  }) =>
+    open ? (
+      <div data-testid="dialog-root">
+        <button type="button" onClick={() => onOpenChange(false)}>
+          mock close dialog
+        </button>
+        <button type="button" onClick={() => onOpenChange(true)}>
+          mock keep dialog open
+        </button>
+        {children}
+      </div>
+    ) : null,
+  DialogContent: ({ children, ...props }: ComponentProps<"div">) => (
+    <div data-testid="dialog-content" {...props}>
+      {children}
+    </div>
+  ),
+  DialogDescription: ({ children }: { children: ReactNode }) => <p>{children}</p>,
+  DialogFooter: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
 }));
 
 type CreateWorkspaceCallbacks = {
@@ -144,12 +177,49 @@ describe("CreateWorkspaceDialog", () => {
     await waitFor(() => expect(screen.getByRole("button", { name: "생성 중..." })).toBeDisabled());
   });
 
+  it("생성 요청 중 재제출되어도 mutation을 중복 호출하지 않는다", async () => {
+    mocks.mutate.mockImplementation(() => undefined);
+    renderDialog();
+
+    submitWorkspaceName();
+    await waitFor(() => expect(screen.getByRole("button", { name: "생성 중..." })).toBeDisabled());
+    const form = screen.getByLabelText("제목").closest("form");
+    if (!form) {
+      throw new Error("workspace create form not found");
+    }
+
+    fireEvent.submit(form);
+
+    expect(mocks.mutate).toHaveBeenCalledTimes(1);
+  });
+
   it("취소 버튼을 누르면 모달 닫기 콜백을 호출한다", () => {
     const { onOpenChange } = renderDialog();
 
     fireEvent.click(screen.getByRole("button", { name: "취소" }));
 
     expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("Dialog close 이벤트로 닫히면 입력 오류를 초기화하고 닫기 콜백을 호출한다", async () => {
+    const { onOpenChange } = renderDialog();
+    fireEvent.click(screen.getByRole("button", { name: "생성" }));
+    expect(screen.getByRole("alert")).toHaveTextContent("이름을 입력해주세요.");
+
+    fireEvent.click(screen.getByRole("button", { name: "mock close dialog" }));
+
+    await waitFor(() => expect(screen.queryByRole("alert")).not.toBeInTheDocument());
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("Dialog open 이벤트는 입력값을 유지하고 열림 상태를 전달한다", () => {
+    const { onOpenChange } = renderDialog();
+    fireEvent.change(screen.getByLabelText("제목"), { target: { value: "Support Team" } });
+
+    fireEvent.click(screen.getByRole("button", { name: "mock keep dialog open" }));
+
+    expect(screen.getByLabelText("제목")).toHaveValue("Support Team");
+    expect(onOpenChange).toHaveBeenCalledWith(true);
   });
 
   it("이름이 비어 있으면 생성 mutation을 호출하지 않는다", () => {
@@ -204,5 +274,21 @@ describe("CreateWorkspaceDialog", () => {
     submitWorkspaceName();
 
     await waitFor(() => expect(toast.error).toHaveBeenCalledWith("서버에 연결할 수 없습니다."));
+  });
+
+  it("필드 오류가 아닌 ApiRequestError는 공통 workspace 오류 메시지를 표시한다", async () => {
+    mocks.mutate.mockImplementation((_variables: unknown, callbacks: CreateWorkspaceCallbacks) => {
+      callbacks.onError?.(
+        new ApiRequestError(400, "WORKSPACE_INVALID_KEY", "workspaceKey 형식이 올바르지 않습니다."),
+      );
+    });
+    renderDialog();
+
+    submitWorkspaceName();
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith("워크스페이스 키 형식이 올바르지 않습니다."),
+    );
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/features/workspace/ui/CreateWorkspaceDialog.tsx
+++ b/frontend/src/features/workspace/ui/CreateWorkspaceDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import type { FormEvent } from "react";
 import { AlertCircleIcon } from "lucide-react";
 import { toast } from "sonner";
@@ -11,7 +11,7 @@ import {
   type WorkspaceResponse,
 } from "@/entities/workspace";
 import { useCreateWorkspace } from "@/shared/api/generated/endpoints/workspace-controller/workspace-controller";
-import { ApiRequestError } from "@/shared/api";
+import { ApiRequestError, selectApiData } from "@/shared/api";
 import { Button } from "@/shared/ui/button";
 import {
   Dialog,
@@ -43,13 +43,23 @@ export function CreateWorkspaceDialog({
   const nameErrorId = fieldErrors.name ? "workspace-name-error" : undefined;
   const createWorkspace = useCreateWorkspace();
 
-  useEffect(() => {
-    if (!open) {
-      setName("");
-      setFieldErrors({});
-      setIsSubmitting(false);
+  const resetForm = () => {
+    setName("");
+    setFieldErrors({});
+    setIsSubmitting(false);
+  };
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) {
+      resetForm();
     }
-  }, [open]);
+    onOpenChange(nextOpen);
+  };
+
+  const closeDialog = () => {
+    resetForm();
+    onOpenChange(false);
+  };
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -70,9 +80,15 @@ export function CreateWorkspaceDialog({
       { data: { workspaceKey, name: trimmedName } },
       {
         onSuccess: async (result) => {
-          const created = result.data;
+          const created = selectApiData<WorkspaceResponse>(result);
+          if (created?.id == null) {
+            toast.error("워크스페이스 생성 응답을 확인하지 못했습니다. 잠시 후 다시 시도해주세요.");
+            setIsSubmitting(false);
+            return;
+          }
+
           toast.success("워크스페이스를 생성했습니다.");
-          onOpenChange(false);
+          closeDialog();
           try {
             await onSuccess(created);
           } catch {
@@ -101,7 +117,7 @@ export function CreateWorkspaceDialog({
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className={styles.dialogContent}>
         <DialogHeader>
           <DialogTitle>워크스페이스 생성</DialogTitle>
@@ -133,7 +149,7 @@ export function CreateWorkspaceDialog({
               type="button"
               variant="outline"
               className={styles.cancelButton}
-              onClick={() => onOpenChange(false)}
+              onClick={closeDialog}
               disabled={isSubmitting}
             >
               취소

--- a/frontend/src/pages/workspace/ui/WorkspaceRootRedirect.test.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceRootRedirect.test.tsx
@@ -144,7 +144,7 @@ describe("WorkspaceRootRedirect", () => {
     renderPage();
     const createBtn = screen.getByText("생성 완료");
     createBtn.click();
-    expect(mockNavigate).toHaveBeenCalledWith("/workspaces/999/workflows", { replace: true });
+    expect(mockNavigate).toHaveBeenCalledWith("/workspaces/999/upload", { replace: true });
   });
 
   it("CreateWorkspaceDialog 닫기 시 페이지를 새로고침하지 않고 현재 route를 유지한다", () => {

--- a/frontend/src/pages/workspace/ui/WorkspaceRootRedirect.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceRootRedirect.tsx
@@ -54,7 +54,7 @@ export function WorkspaceRootRedirect() {
           navigate("/workspaces", { replace: true });
         }}
         onSuccess={async (created) => {
-          navigate(`/workspaces/${created.id}/workflows`, { replace: true });
+          navigate(`/workspaces/${created.id}/upload`, { replace: true });
         }}
       />
     </div>


### PR DESCRIPTION
## 요약

- 워크스페이스 생성 성공 후 오류 토스트가 표시되는 문제를 수정합니다.
- 생성된 워크스페이스의 `/workspaces/{id}/workflows` 화면으로 즉시 이동하지 않는 문제를 수정합니다.
- 원인과 구현 방향을 `.agent/specs/0351.md`에 정리하고, 같은 PR에서 구현까지 진행합니다.

## 원인

백엔드는 `POST /api/v1/workspaces` 성공 응답으로 raw `WorkspaceResponse`를 반환하지만, 프론트의 `CreateWorkspaceDialog`는 generated 타입을 기준으로 `result.data`를 직접 읽고 있었습니다.

이 때문에 실제 런타임에서 `created`가 `undefined`가 되고, 이후 `created.id` 접근 과정에서 예외가 발생해 생성은 성공했지만 실패처럼 보이는 토스트가 표시되었습니다.

## 변경 내용

- `0351` 스펙 문서 추가
- `CreateWorkspaceDialog`의 생성 성공 응답 처리 수정
- raw `WorkspaceResponse`와 `{ data: WorkspaceResponse }` 응답을 모두 처리하도록 정규화
- 생성 응답에 유효한 `id`가 없을 때 명확한 오류 처리 추가
- 워크스페이스 생성 후 redirect 회귀 테스트 추가

## 테스트

- [ ] `cd frontend && pnpm test -- CreateWorkspaceDialog`
- [ ] `cd frontend && pnpm test -- WorkspaceRootRedirect`
- [ ] `cd frontend && pnpm lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * 워크스페이스 생성 후 잘못된 오류 토스트 및 리다이렉트 문제에 대한 스펙 문서 추가(정상/비정상 응답 예시, 수용기준 포함)

* **Bug Fixes**
  * 생성 성공 시에만 성공 토스트 표시하고 모달 초기화 후 /workspaces/{id}/upload로 리다이렉트
  * 생성 응답에서 id 누락 시 성공 흐름 중단 및 명확한 오류 토스트 표시
  * 다이얼로그 열림/닫힘 및 폼 상태 초기화 동작 개선

* **Tests**
  * 생성 성공(원시/래핑), id 누락, 입력 검증, 제출/취소, 서버 오류 분기 등 시나리오 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->