### PR TITLE
feat(consultation): 상담 세션 열람과 배정받기 분리

### DIFF
--- a/.agent/specs/357.md
+++ b/.agent/specs/357.md
@@ -1,0 +1,111 @@
+# Frontend FSD Spec: 상담 세션 열람과 배정받기 액션 분리
+
+## Goal
+
+상담사가 대기열의 미배정 세션을 먼저 읽어본 뒤, 별도 `배정받기` 액션으로만 세션을 맡을 수 있게 한다.
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A["상담 큐 진입"] --> B["세션 선택"]
+    B --> C["상세/메시지 읽기 전용 표시"]
+    C --> D{"배정 상태"}
+    D -->|"미배정"| E["배정받기 버튼 표시"]
+    E --> F{"배정받기 클릭"}
+    F -->|"성공"| G["내게 배정됨 상태와 입력 활성화"]
+    F -->|"실패"| H["실패 토스트와 읽기 전용 유지"]
+    D -->|"내게 배정됨"| G
+    D -->|"다른 상담사 배정"| I["읽기 전용 및 입력 비활성 사유 표시"]
+    D -->|"종료됨"| J["읽기 전용 및 종료 사유 표시"]
+```
+
+## Design Diff
+
+| 영역 | As-is | To-be | 변경 내용 |
+| --- | --- | --- | --- |
+| 큐 세션 선택 | 미배정 세션 클릭 시 즉시 배정 API 호출 | 클릭/URL 진입은 세션 열람만 수행 | 읽기와 배정 액션 분리 |
+| 배정 액션 | 선택 동작에 암묵적으로 포함 | 헤더의 `배정받기` 버튼으로 명시 | 성공/실패 토스트 및 버튼 로딩 상태 표시 |
+| 입력 상태 | 배정 이후에만 사실상 응대 가능 | 미배정/타 상담사/종료 세션은 입력 비활성화와 사유 표시 | 읽기 전용 상태를 화면에 명확히 노출 |
+
+## Component Tree
+
+```text
+ConsultationPage
+├─ QueuePanel
+├─ ChatPanel
+│  ├─ assignment status
+│  ├─ message list
+│  └─ disabled reason + input controls
+└─ CustomerPanel
+```
+
+## API Integration
+
+| Method | Path | Description |
+| --- | --- | --- |
+| GET | `/api/v1/workspaces/{workspaceId}/consultation/queue` | 상담 큐 조회 |
+| GET | `/api/v1/consultation/sessions/{sessionId}/messages` | 선택 세션 메시지 조회 |
+| POST | `/api/v1/consultation/sessions/{sessionId}/assign?counselorId={counselorId}` | `배정받기` 클릭 시 상담사 배정 |
+| POST | `/api/v1/consultation/sessions/{sessionId}/release?counselorId={counselorId}` | 내 배정 해제 |
+
+기존 `frontend/src/features/consultation/api/consultationApi.ts`의 수동 API 래퍼를 유지한다. OpenAPI generated endpoint가 없는 상담 큐/배정 계열 엔드포인트이기 때문이다.
+
+## Data Flow
+
+```text
+QueuePanel selection
+  -> ConsultationPage activeCustomerId 변경
+  -> ConsultationPage 메시지 조회
+  -> ChatPanel 읽기 전용/응대 가능 상태 렌더링
+
+배정받기 클릭
+  -> consultationApi.assignSession(sessionId, currentCounselorId)
+  -> queue의 해당 세션 assignedCounselorId 갱신
+  -> ChatPanel 입력 활성화
+```
+
+## 수정 대상 파일
+
+| 파일 | 변경 유형 | 설명 |
+| --- | --- | --- |
+| `frontend/src/pages/consultation/ui/ConsultationPage.tsx` | modify | 선택과 배정을 분리하고 배정받기 액션/상태를 추가 |
+| `frontend/src/pages/consultation/ui/consultation-page.module.css` | modify | 배정받기 버튼과 배정 중 상태 스타일 추가 |
+| `frontend/src/features/consultation/ui/ChatPanel.tsx` | modify | 입력 비활성 사유를 표시 |
+| `frontend/src/features/consultation/ui/chat-panel.module.css` | modify | 읽기 전용 안내 스타일 추가 |
+| `frontend/src/pages/consultation/ui/ConsultationPage.test.tsx` | modify | 클릭 열람, 별도 배정, 타 상담사/미배정 입력 비활성 상태 검증 |
+| `frontend/src/features/consultation/ui/ChatPanel.test.tsx` | modify | disabled reason 렌더링 검증 |
+
+## State Management
+
+- 서버 상태: 상담 큐, 메시지 목록, 배정/해제 결과는 기존 `consultationApi` 호출 결과를 사용한다.
+- 클라이언트 상태: 선택된 세션, 메시지 로딩 대상, 배정 요청 중인 세션 ID를 `ConsultationPage` 로컬 상태로 관리한다.
+
+## Tests
+
+### Test Strategy
+
+| 구분 | 방법 | 도구 | 비고 |
+| --- | --- | --- | --- |
+| 컴포넌트/페이지 테스트 | 사용자 행동 중심 렌더링 및 API 호출 검증 | Vitest + React Testing Library | 핵심 흐름 |
+| 정적 검증 | 타입/빌드 수준 확인 | `pnpm test -- --run ...` | 변경 파일 중심 |
+
+### Test Scenarios
+
+| # | 시나리오 | 기대 결과 |
+| --- | --- | --- |
+| 1 | 미배정 세션을 클릭한다 | 메시지를 읽을 수 있지만 `assignSession`은 호출되지 않는다 |
+| 2 | 미배정 세션에서 `배정받기`를 클릭한다 | `assignSession` 호출, 성공 토스트, 입력 활성화 |
+| 3 | 배정 실패가 발생한다 | 실패 토스트 표시, 읽기 전용 상태 유지 |
+| 4 | 다른 상담사에게 배정된 세션을 연다 | 메시지 입력 비활성화 및 사유 표시 |
+| 5 | 내게 배정된 세션을 연다 | 기존 응대/종료/배정해제 흐름 유지 |
+
+## Non-goals
+
+- 백엔드 배정 정책, 경합 처리, 권한 모델은 변경하지 않는다.
+- 상담 큐 API 응답 스키마 또는 generated API 재생성은 포함하지 않는다.
+- 다른 상담사에게 배정된 세션의 접근 제한 정책을 새로 정의하지 않는다. 프론트엔드는 현재 큐에 노출된 세션을 읽기 전용으로 다룬다.
+
+## Open Questions
+
+- 배정 실패가 경합 때문인지 권한 문제인지 세분화된 서버 에러 코드를 노출할지 여부는 후속 백엔드/API 정책으로 남긴다.

--- a/frontend/src/features/consultation/ui/ChatPanel.test.tsx
+++ b/frontend/src/features/consultation/ui/ChatPanel.test.tsx
@@ -143,6 +143,25 @@ describe("ChatPanel", () => {
     expect(onSendMessage).not.toHaveBeenCalled();
   });
 
+  it("disabled 사유가 있으면 입력 영역 위에 안내한다", () => {
+    render(
+      <ChatPanel
+        customerName="김민지"
+        channel="카카오톡"
+        messages={[]}
+        onSendMessage={vi.fn()}
+        selectedMessageId={null}
+        onSelectMessage={vi.fn()}
+        disabled
+        disabledReason="다른 상담사가 응대 중인 세션이므로 메시지를 보낼 수 없습니다."
+      />,
+    );
+
+    expect(
+      screen.getByText("다른 상담사가 응대 중인 세션이므로 메시지를 보낼 수 없습니다."),
+    ).toBeInTheDocument();
+  });
+
   it("고객 메시지는 선택할 수 있고 키보드로도 선택된다", () => {
     const onSelectMessage = vi.fn();
 

--- a/frontend/src/features/consultation/ui/ChatPanel.tsx
+++ b/frontend/src/features/consultation/ui/ChatPanel.tsx
@@ -334,9 +334,9 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
       </div>
 
       {disabled && disabledReason && (
-        <div className={styles.disabledNotice} role="status">
+        <output className={styles.disabledNotice}>
           {disabledReason}
-        </div>
+        </output>
       )}
 
       {/* Input */}

--- a/frontend/src/features/consultation/ui/ChatPanel.tsx
+++ b/frontend/src/features/consultation/ui/ChatPanel.tsx
@@ -31,6 +31,7 @@ interface ChatPanelProps {
   sessionStatusLabel?: string;
   sessionStatusDescription?: string;
   disabled?: boolean;
+  disabledReason?: string;
 }
 
 const BOTTOM_SCROLL_THRESHOLD_PX = 96;
@@ -66,6 +67,7 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
   sessionStatusLabel,
   sessionStatusDescription,
   disabled = false,
+  disabledReason,
 }) => {
   const [input, setInput] = useState("");
   const [isNoteMode, setIsNoteMode] = useState(false);
@@ -330,6 +332,12 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
           </button>
         )}
       </div>
+
+      {disabled && disabledReason && (
+        <div className={styles.disabledNotice} role="status">
+          {disabledReason}
+        </div>
+      )}
 
       {/* Input */}
       <div className={styles.inputArea}>

--- a/frontend/src/features/consultation/ui/chat-panel.module.css
+++ b/frontend/src/features/consultation/ui/chat-panel.module.css
@@ -355,6 +355,16 @@
   color: var(--ink);
 }
 
+.disabledNotice {
+  padding: 10px 24px;
+  border-top: 1px solid var(--glass-border);
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  font-size: 0.78rem;
+  letter-spacing: -0.1px;
+  line-height: 1.45;
+}
+
 /* Input Area */
 .inputArea {
   display: flex;

--- a/frontend/src/pages/consultation/ui/ConsultationPage.test.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.test.tsx
@@ -65,10 +65,11 @@ vi.mock("../../../features/consultation/api/consultationApi", () => ({
       Promise.resolve([
         {
           id: 1,
-          status: "OPEN",
+          status: "ACTIVE",
           channel: "카카오톡",
           metaJson: JSON.stringify({ customerName: "김민지", handoffReason: "환불 문의" }),
           startedAt: new Date(Date.now() - 4 * 60000).toISOString(),
+          assignedCounselorId: 7,
         },
       ]),
     ),
@@ -308,6 +309,17 @@ describe("ConsultationPage", () => {
   });
 
   it("selects the route session and restores messages when opening a session URL directly", async () => {
+    vi.mocked(consultationApi.getQueue).mockResolvedValueOnce([
+      {
+        id: 1,
+        status: "OPEN",
+        channel: "카카오톡",
+        metaJson: JSON.stringify({ customerName: "김민지", handoffReason: "환불 문의" }),
+        startedAt: new Date(Date.now() - 4 * 60000).toISOString(),
+        assignedCounselorId: null,
+      },
+    ]);
+
     render(<ConsultationPage />, {
       wrapper: createRoutedWrapper("/workspaces/2/consultation/1"),
     });
@@ -317,7 +329,8 @@ describe("ConsultationPage", () => {
     });
     expect(screen.getByText("김민지 고객")).toBeInTheDocument();
     expect(screen.getByText("환불 문의 드립니다.")).toBeInTheDocument();
-    expect(consultationApi.assignSession).toHaveBeenCalledWith(1, 7);
+    expect(consultationApi.assignSession).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "배정받기" })).toBeInTheDocument();
   });
 
   it("updates the browser URL when a queue session is selected", async () => {
@@ -764,8 +777,18 @@ describe("ConsultationPage", () => {
     expect(screen.queryByText("카드 환불 — 부분환불")).not.toBeInTheDocument();
   });
 
-  it("assigns an unassigned session to the current counselor when selected", async () => {
+  it("opens an unassigned session as read-only when selected", async () => {
     saveTestUser(7);
+    vi.mocked(consultationApi.getQueue).mockResolvedValueOnce([
+      {
+        id: 1,
+        status: "OPEN",
+        channel: "카카오톡",
+        metaJson: JSON.stringify({ customerName: "김민지", handoffReason: "환불 문의" }),
+        startedAt: new Date(Date.now() - 4 * 60000).toISOString(),
+        assignedCounselorId: null,
+      },
+    ]);
 
     render(<ConsultationPage />, { wrapper: Wrapper });
 
@@ -779,11 +802,122 @@ describe("ConsultationPage", () => {
     }
 
     await waitFor(() => {
+      expect(consultationApi.getMessages).toHaveBeenCalledWith(1);
+    });
+    expect(consultationApi.assignSession).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "배정받기" })).toBeInTheDocument();
+    expect(
+      screen.getAllByText("배정받기 전에는 메시지와 내부 메모를 보낼 수 없습니다.").length,
+    ).toBeGreaterThan(0);
+    expect(screen.getByLabelText("메시지 전송")).toBeDisabled();
+  });
+
+  it("assigns an unassigned session only when the counselor clicks claim", async () => {
+    saveTestUser(7);
+    vi.mocked(consultationApi.getQueue).mockResolvedValueOnce([
+      {
+        id: 1,
+        status: "OPEN",
+        channel: "카카오톡",
+        metaJson: JSON.stringify({ customerName: "김민지", handoffReason: "환불 문의" }),
+        startedAt: new Date(Date.now() - 4 * 60000).toISOString(),
+        assignedCounselorId: null,
+      },
+    ]);
+
+    render(<ConsultationPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("김민지")).toBeInTheDocument();
+    });
+
+    const customerItem = screen.getByText("김민지").closest('[role="button"]');
+    if (customerItem) {
+      fireEvent.click(customerItem);
+    }
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "배정받기" })).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole("button", { name: "배정받기" }));
+
+    await waitFor(() => {
       expect(consultationApi.assignSession).toHaveBeenCalledWith(1, 7);
     });
     await waitFor(() => {
       expect(screen.getAllByText("내게 배정됨").length).toBeGreaterThan(0);
     });
+    expect(screen.getByPlaceholderText("메시지를 입력하세요...")).not.toBeDisabled();
+  });
+
+  it("keeps the session read-only when claim fails", async () => {
+    saveTestUser(7);
+    vi.mocked(consultationApi.getQueue).mockResolvedValueOnce([
+      {
+        id: 1,
+        status: "OPEN",
+        channel: "카카오톡",
+        metaJson: JSON.stringify({ customerName: "김민지", handoffReason: "환불 문의" }),
+        startedAt: new Date(Date.now() - 4 * 60000).toISOString(),
+        assignedCounselorId: null,
+      },
+    ]);
+    vi.mocked(consultationApi.assignSession).mockRejectedValueOnce(new Error("already assigned"));
+
+    render(<ConsultationPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("김민지")).toBeInTheDocument();
+    });
+
+    const customerItem = screen.getByText("김민지").closest('[role="button"]');
+    if (customerItem) {
+      fireEvent.click(customerItem);
+    }
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "배정받기" })).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole("button", { name: "배정받기" }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("상담 세션 배정에 실패했습니다.");
+    });
+    expect(screen.getByRole("button", { name: "배정받기" })).toBeInTheDocument();
+    expect(screen.getByLabelText("메시지 전송")).toBeDisabled();
+  });
+
+  it("keeps sessions assigned to another counselor read-only with a reason", async () => {
+    vi.mocked(consultationApi.getQueue).mockResolvedValueOnce([
+      {
+        id: 1,
+        status: "ACTIVE",
+        channel: "카카오톡",
+        metaJson: JSON.stringify({ customerName: "김민지", handoffReason: "환불 문의" }),
+        startedAt: new Date(Date.now() - 4 * 60000).toISOString(),
+        assignedCounselorId: 99,
+      },
+    ]);
+
+    render(<ConsultationPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("김민지")).toBeInTheDocument();
+    });
+
+    const customerItem = screen.getByText("김민지").closest('[role="button"]');
+    if (customerItem) {
+      fireEvent.click(customerItem);
+    }
+
+    await waitFor(() => {
+      expect(screen.getAllByText("다른 상담사 배정").length).toBeGreaterThan(0);
+    });
+    expect(
+      screen.getAllByText("다른 상담사가 응대 중인 세션이므로 메시지를 보낼 수 없습니다.").length,
+    ).toBeGreaterThan(0);
+    expect(screen.queryByRole("button", { name: "배정받기" })).not.toBeInTheDocument();
+    expect(screen.getByLabelText("메시지 전송")).toBeDisabled();
   });
 
   it("releases the current counselor assignment through the backend API", async () => {
@@ -801,7 +935,6 @@ describe("ConsultationPage", () => {
     }
 
     await waitFor(() => {
-      expect(consultationApi.assignSession).toHaveBeenCalledWith(1, 7);
       expect(screen.getByText("배정 해제")).toBeEnabled();
     });
 

--- a/frontend/src/pages/consultation/ui/ConsultationPage.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.tsx
@@ -549,6 +549,9 @@ export const ConsultationPage: React.FC = () => {
     activeCustomer?.status === "COMPLETED" || activeCustomer?.status === "RESOLVED";
   const isActiveSessionUnassigned = !!activeCustomer && !activeCustomer.assignedCounselorId;
   const isClaimingActiveSession = activeCustomerId != null && claimingSessionId === activeCustomerId;
+  const messageInputDisabledReason = isAssignedToCurrentCounselor
+    ? undefined
+    : activeAssignment?.description;
 
   const clearActiveConversation = useCallback(() => {
     setActiveCustomerId(null);
@@ -1286,7 +1289,7 @@ export const ConsultationPage: React.FC = () => {
               onSelectMessage={setSelectedMessageId}
               sessionStatusLabel={activeAssignment?.label}
               sessionStatusDescription={activeAssignment?.description}
-              disabledReason={!isAssignedToCurrentCounselor ? activeAssignment?.description : undefined}
+              disabledReason={messageInputDisabledReason}
               disabled={!isAssignedToCurrentCounselor}
             />
           )}

--- a/frontend/src/pages/consultation/ui/ConsultationPage.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.tsx
@@ -280,14 +280,14 @@ const getAssignmentView = (
   if (assignedCounselorId) {
     return {
       label: "다른 상담사 배정",
-      description: "다른 상담사가 응대 중인 세션입니다.",
+      description: "다른 상담사가 응대 중인 세션이므로 메시지를 보낼 수 없습니다.",
       tone: "other",
     };
   }
 
   return {
     label: "미배정",
-    description: "선택하면 자동으로 내게 배정됩니다.",
+    description: "배정받기 전에는 메시지와 내부 메모를 보낼 수 없습니다.",
     tone: "unassigned",
   };
 };
@@ -460,6 +460,7 @@ export const ConsultationPage: React.FC = () => {
   const isEndSessionSubmitting = endSessionModal.open ? endSessionModal.isSubmitting : false;
   const [hasQueueLoaded, setHasQueueLoaded] = useState(false);
   const [urlSessionUnavailable, setUrlSessionUnavailable] = useState(false);
+  const [claimingSessionId, setClaimingSessionId] = useState<string | null>(null);
   const workflowRefetchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pendingMessagesRef = useRef<Map<string, PendingMessage>>(new Map());
   const tempCounterRef = useRef(0);
@@ -544,6 +545,10 @@ export const ConsultationPage: React.FC = () => {
   const isAssignedToCurrentCounselor =
     !!activeCustomer?.assignedCounselorId &&
     activeCustomer.assignedCounselorId === currentCounselorId;
+  const isActiveSessionClosed =
+    activeCustomer?.status === "COMPLETED" || activeCustomer?.status === "RESOLVED";
+  const isActiveSessionUnassigned = !!activeCustomer && !activeCustomer.assignedCounselorId;
+  const isClaimingActiveSession = activeCustomerId != null && claimingSessionId === activeCustomerId;
 
   const clearActiveConversation = useCallback(() => {
     setActiveCustomerId(null);
@@ -753,7 +758,7 @@ export const ConsultationPage: React.FC = () => {
   }, [loadQueue]);
 
   const activateCustomer = useCallback(
-    async (id: string) => {
+    (id: string) => {
       setActiveCustomerId(id);
       setSelectedMessageId(null);
       setQueue((prev) =>
@@ -763,21 +768,8 @@ export const ConsultationPage: React.FC = () => {
             )
           : prev,
       );
-
-      const selected = queue.find((customer) => customer.id === id);
-      if (!selected || !currentCounselorId || selected.assignedCounselorId) return;
-
-      try {
-        const assignedSession = await consultationApi.assignSession(Number(id), currentCounselorId);
-        setQueue((prev) =>
-          replaceAssignedQueueCustomer(prev, id, assignedSession, currentCounselorId),
-        );
-        toast.success("상담 세션이 배정되었습니다.");
-      } catch {
-        toast.error("상담 세션 배정에 실패했습니다.");
-      }
     },
-    [currentCounselorId, queue],
+    [],
   );
 
   useEffect(() => {
@@ -805,7 +797,7 @@ export const ConsultationPage: React.FC = () => {
     }
 
     setUrlSessionUnavailable(false);
-    void activateCustomer(normalizedRouteSessionId);
+    activateCustomer(normalizedRouteSessionId);
   }, [
     activateCustomer,
     clearActiveConversation,
@@ -957,13 +949,50 @@ export const ConsultationPage: React.FC = () => {
   const handleSelectCustomer = useCallback(
     (id: string) => {
       setUrlSessionUnavailable(false);
-      void activateCustomer(id);
+      activateCustomer(id);
       if (workspacePathId) {
         navigate(`/workspaces/${workspacePathId}/consultation/${id}`);
       }
     },
     [activateCustomer, navigate, workspacePathId],
   );
+
+  const handleClaimSession = useCallback(async () => {
+    if (
+      !activeCustomerId ||
+      !currentCounselorId ||
+      !activeCustomer ||
+      activeCustomer.assignedCounselorId ||
+      isActiveSessionClosed ||
+      claimingSessionId
+    ) {
+      return;
+    }
+
+    const targetSessionId = activeCustomerId;
+    setClaimingSessionId(targetSessionId);
+    try {
+      const assignedSession = await consultationApi.assignSession(
+        Number(targetSessionId),
+        currentCounselorId,
+      );
+      setQueue((prev) =>
+        replaceAssignedQueueCustomer(prev, targetSessionId, assignedSession, currentCounselorId),
+      );
+      toast.success("상담 세션이 배정되었습니다.");
+    } catch (error) {
+      console.error("Failed to claim session:", error);
+      toast.error("상담 세션 배정에 실패했습니다.");
+    } finally {
+      setClaimingSessionId((current) => (current === targetSessionId ? null : current));
+    }
+  }, [
+    activeCustomer,
+    activeCustomerId,
+    claimingSessionId,
+    currentCounselorId,
+    isActiveSessionClosed,
+  ]);
 
   const handleSendMessage = useCallback(
     (content: string, isNote: boolean) => {
@@ -1209,6 +1238,16 @@ export const ConsultationPage: React.FC = () => {
                   <small>{activeAssignment.description}</small>
                 </div>
               )}
+              {isActiveSessionUnassigned && !isActiveSessionClosed && (
+                <button
+                  type="button"
+                  className={styles.claimButton}
+                  onClick={handleClaimSession}
+                  disabled={!currentCounselorId || isClaimingActiveSession}
+                >
+                  {isClaimingActiveSession ? "배정 중..." : "배정받기"}
+                </button>
+              )}
               <button
                 className={styles.linkButton}
                 onClick={handleReleaseAssignment}
@@ -1247,6 +1286,7 @@ export const ConsultationPage: React.FC = () => {
               onSelectMessage={setSelectedMessageId}
               sessionStatusLabel={activeAssignment?.label}
               sessionStatusDescription={activeAssignment?.description}
+              disabledReason={!isAssignedToCurrentCounselor ? activeAssignment?.description : undefined}
               disabled={!isAssignedToCurrentCounselor}
             />
           )}

--- a/frontend/src/pages/consultation/ui/consultation-page.module.css
+++ b/frontend/src/pages/consultation/ui/consultation-page.module.css
@@ -115,6 +115,7 @@
   opacity: 0.74;
 }
 
+.claimButton,
 .linkButton,
 .dangerButton {
   padding: 0;
@@ -122,6 +123,21 @@
   background: none;
   cursor: pointer;
   font-size: 12px;
+}
+
+.claimButton {
+  min-height: 32px;
+  padding: 0 14px;
+  border: 1px solid var(--ink);
+  border-radius: 50px;
+  background: var(--ink);
+  color: var(--paper);
+  font-weight: 540;
+  letter-spacing: -0.1px;
+}
+
+.claimButton:hover {
+  background: #000000;
 }
 
 .linkButton {
@@ -134,12 +150,14 @@
   font-weight: 600;
 }
 
+.claimButton:focus-visible,
 .linkButton:focus-visible,
 .dangerButton:focus-visible {
   outline: none;
   box-shadow: var(--focus-ring);
 }
 
+.claimButton:disabled,
 .linkButton:disabled,
 .dangerButton:disabled {
   cursor: not-allowed;


### PR DESCRIPTION
## Summary
- 미배정 상담 세션 선택 시 즉시 배정하지 않고 읽기 전용으로 메시지를 확인할 수 있게 했습니다.
- 상담 헤더에 명시적인 `배정받기` 액션을 추가하고 성공/실패 상태를 토스트와 버튼 상태로 표시합니다.
- 미배정 또는 다른 상담사 배정 세션에서는 메시지 입력을 비활성화하고 사유를 안내합니다.
- 구현 기준을 `.agent/specs/357.md`에 함께 정리했습니다.

## Validation
- `cd frontend && pnpm test -- --run src/pages/consultation/ui/ConsultationPage.test.tsx src/features/consultation/ui/ChatPanel.test.tsx`
- `cd frontend && pnpm exec eslint src/pages/consultation/ui/ConsultationPage.tsx src/pages/consultation/ui/ConsultationPage.test.tsx src/features/consultation/ui/ChatPanel.tsx src/features/consultation/ui/ChatPanel.test.tsx`
- `cd frontend && pnpm exec tsc -b --pretty false`
- `cd frontend && pnpm test -- --run`
- `git diff --check`

## Notes
- 전체 `cd frontend && pnpm lint`는 이번 변경과 무관한 기존 lint 오류들로 실패해, 변경 파일 대상으로 eslint를 확인했습니다.

Closes #357

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 상담 큐에서 세션 열람과 배정 액션을 분리했습니다. 미배정 세션을 선택한 후 별도의 "배정받기" 버튼으로만 배정을 진행할 수 있습니다.
  * 입력 필드가 비활성화된 이유(다른 상담사 배정 등)가 화면에 표시됩니다.

* **Tests**
  * 세션 배정 및 비활성화 상태 관련 테스트 케이스를 추가 및 수정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->