### PR TITLE
fix(consultation): 상담 배정 주체를 인증 사용자로 제한

### DIFF
--- a/.agent/specs/358.md
+++ b/.agent/specs/358.md
@@ -1,0 +1,158 @@
+# 상담 배정/해제 인증 주체 정합화
+
+## Goal
+
+상담 배정/해제 API가 클라이언트가 전달한 `counselorId`를 신뢰하지 않고, 인증된 사용자 본인의 ID로만 세션을 배정하거나 해제하도록 변경한다.
+
+## Background
+
+현재 상담사 메시지 전송 WebSocket 흐름은 principal에서 상담사 ID를 가져오지만, REST 기반 상담 배정/해제는 `counselorId` request parameter를 사용한다. 이 구조에서는 클라이언트가 다른 상담사 ID를 포함한 요청을 만들 수 있으므로 REST 흐름의 인증 모델이 WebSocket 흐름과 달라진다.
+
+## Scope
+
+- `POST /api/v1/consultation/sessions/{sessionId}/assign` 요청에서 `counselorId` request parameter를 제거한다.
+- `POST /api/v1/consultation/sessions/{sessionId}/release` 요청에서 `counselorId` request parameter를 제거한다.
+- 서버는 Spring Security `Authentication` principal에서 현재 사용자 ID를 읽어 상담사 ID로 사용한다.
+- 상담 세션의 `workspaceId` 기준으로 현재 사용자가 해당 워크스페이스 멤버인지 검증한다.
+- 프론트엔드 상담 API wrapper와 상담 페이지 호출부는 `counselorId` 인자를 넘기지 않는다.
+- 관련 단위/컨트롤러/API wrapper 테스트를 갱신한다.
+
+## Non-goals
+
+- 상담사 역할 체계나 워크스페이스 멤버 역할별 권한을 새로 정의하지 않는다.
+- 상담 세션 상태 전이 규칙(`OPEN`, `ACTIVE`, `RESOLVED`, `COMPLETED`)은 변경하지 않는다.
+- 상담 메시지 전송 WebSocket destination이나 payload 계약은 변경하지 않는다.
+- 상담 목록/큐 조회 endpoint의 경로와 응답 구조는 변경하지 않는다.
+
+## Affected Modules
+
+| Area | Verified path | Change |
+| --- | --- | --- |
+| Backend presentation | `backend/src/main/java/com/init/workflowruntime/presentation/CounselorSessionController.java` | assign/release에서 request parameter 제거, 인증 사용자 ID 추출 |
+| Backend application | `backend/src/main/java/com/init/workflowruntime/application/CounselorService.java` | 현재 사용자 ID로 배정/해제 수행, 세션 workspace membership 검증 |
+| Backend domain support | `backend/src/main/java/com/init/workspace/domain/repository/WorkspaceMemberRepository.java` | 기존 workspace membership 조회 재사용 |
+| Frontend feature API | `frontend/src/features/consultation/api/consultationApi.ts` | assign/release 함수 인자 및 URL query 제거 |
+| Frontend page | `frontend/src/pages/consultation/ui/ConsultationPage.tsx` | assign/release 호출 시 current user ID 전달 제거 |
+| Tests | `backend/src/test/java/com/init/workflowruntime/presentation/CounselorSessionControllerTest.java` | authenticated principal 기반 controller delegation 검증 |
+| Tests | `backend/src/test/java/com/init/workflowruntime/application/CounselorServiceTest.java` | workspace membership 검증 및 다른 상담사 해제 방지 검증 |
+| Tests | `frontend/src/features/consultation/api/consultationApi.test.ts` | query 없는 assign/release 요청 검증 |
+| Tests | `frontend/src/pages/consultation/ui/ConsultationPage.test.tsx` | page가 wrapper에 sessionId만 넘기는지 검증 |
+
+## Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    actor counselor as Counselor UI
+    participant ctrl as CounselorSessionController
+    participant auth as Authentication
+    participant svc as CounselorService
+    participant sessionRepo as ChatSessionRepository
+    participant memberRepo as WorkspaceMemberRepository
+    participant session as ChatSession
+
+    counselor ->> ctrl: POST /api/v1/consultation/sessions/{sessionId}/assign
+    ctrl ->> auth: get principal userId
+    ctrl ->> svc: assignSession(sessionId, userId)
+    svc ->> sessionRepo: findByIdForUpdate(sessionId)
+    sessionRepo -->> svc: ChatSession
+    svc ->> memberRepo: findByWorkspaceIdAndUserId(session.workspaceId, userId)
+    memberRepo -->> svc: WorkspaceMember
+    svc ->> session: assignTo(userId)
+    svc ->> sessionRepo: save(session)
+    svc -->> ctrl: CounselorSessionResponse
+    ctrl -->> counselor: 200 OK
+```
+
+## REST API
+
+### Endpoint
+
+| Method | Path | Description |
+| --- | --- | --- |
+| POST | `/api/v1/consultation/sessions/{sessionId}/assign` | 인증된 사용자를 해당 상담 세션의 상담사로 배정 |
+| POST | `/api/v1/consultation/sessions/{sessionId}/release` | 인증된 사용자가 본인에게 배정된 상담 세션을 해제 |
+
+### Request
+
+두 endpoint 모두 request body와 `counselorId` query parameter를 받지 않는다.
+
+```http
+POST /api/v1/consultation/sessions/123/assign
+Authorization: Bearer {accessToken}
+```
+
+```http
+POST /api/v1/consultation/sessions/123/release
+Authorization: Bearer {accessToken}
+```
+
+### Response
+
+응답은 기존 `CounselorSessionResponse` 형태를 유지한다.
+
+```json
+{
+  "id": 123,
+  "status": "ACTIVE",
+  "channel": "WEB",
+  "assignedCounselorId": 42
+}
+```
+
+### Error Cases
+
+| Condition | Expected behavior |
+| --- | --- |
+| 인증 정보 없음 또는 principal이 Long이 아님 | 기존 인증/인가 예외 처리로 거부 |
+| 세션 없음 | `SESSION_NOT_FOUND` |
+| 현재 사용자가 세션 workspace 멤버가 아님 | `WORKSPACE_ACCESS_DENIED` |
+| 이미 배정된 세션 배정 시도 | 기존 `ChatSession.assignTo` 상태 검증 유지 |
+| 본인에게 배정되지 않은 세션 해제 시도 | `SESSION_NOT_ASSIGNED_TO_COUNSELOR` |
+
+## Frontend API Integration
+
+`frontend/src/features/consultation/api/consultationApi.ts`의 수동 wrapper는 다음처럼 session ID만 받는다.
+
+```typescript
+assignSession(sessionId: number): Promise<ChatSession>
+releaseSession(sessionId: number): Promise<ChatSession>
+```
+
+호출 URL은 각각 아래와 같다.
+
+```text
+/api/v1/consultation/sessions/{sessionId}/assign
+/api/v1/consultation/sessions/{sessionId}/release
+```
+
+`frontend/src/pages/consultation/ui/ConsultationPage.tsx`는 UI 상태 판별을 위해 `currentCounselorId`를 계속 사용할 수 있지만, assign/release 요청에는 전달하지 않는다.
+
+## Data and Migration Impact
+
+- DB schema 변경은 없다.
+- 기존 `runtime.chat_session.assigned_counselor_id` 컬럼 의미는 유지된다.
+- OpenAPI는 controller signature 변경으로 `counselorId` query parameter가 제거되어야 한다. generated API가 해당 endpoint를 사용하지 않는 현재 wrapper 구조에서는 직접 수정 대상 generated 파일은 없다.
+
+## Acceptance Criteria
+
+- 배정 요청은 `counselorId` query parameter 없이 성공한다.
+- 해제 요청은 `counselorId` query parameter 없이 성공한다.
+- 서버는 인증 principal의 사용자 ID를 `assignedCounselorId`로 저장한다.
+- 현재 사용자가 세션 workspace 멤버가 아니면 배정/해제를 거부한다.
+- 다른 사용자 ID를 query parameter로 조작해도 서버 동작에 영향을 주지 않는다.
+- 본인에게 배정되지 않은 세션 해제는 기존처럼 거부된다.
+- 프론트엔드 assign/release wrapper와 페이지 호출부는 `counselorId` 인자를 요구하지 않는다.
+
+## Validation Plan
+
+- Backend unit test: `CounselorServiceTest`
+- Backend controller test: `CounselorSessionControllerTest`
+- Frontend API wrapper test: `consultationApi.test.ts`
+- Frontend page interaction test: `ConsultationPage.test.tsx`
+- Targeted commands:
+  - `cd backend && ./gradlew test --tests com.init.workflowruntime.application.CounselorServiceTest --tests com.init.workflowruntime.presentation.CounselorSessionControllerTest`
+  - `cd frontend && pnpm test -- consultationApi.test.ts ConsultationPage.test.tsx`
+
+## Open Questions
+
+- 없음. 이 이슈에서는 워크스페이스 멤버 여부까지만 검증하고, 역할별 상담사 권한 분리는 별도 정책 이슈로 다룬다.

--- a/backend/src/main/java/com/init/workflowruntime/application/CounselorService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/CounselorService.java
@@ -54,7 +54,7 @@ public class CounselorService {
   }
 
   @Transactional
-  public CounselorSessionResponse assignSession(Long counselorId, Long sessionId, Long userId) {
+  public CounselorSessionResponse assignSession(Long sessionId, Long counselorId) {
     validateCounselorId(counselorId);
 
     ChatSession session =
@@ -63,8 +63,8 @@ public class CounselorService {
             .orElseThrow(
                 () ->
                     new NotFoundException("SESSION_NOT_FOUND", "Session not found: " + sessionId));
-    validateWorkspaceMembership(session.getWorkspaceId(), userId);
 
+    validateWorkspaceMembership(session.getWorkspaceId(), counselorId);
     session.assignTo(counselorId);
     chatSessionRepository.save(session);
 
@@ -77,7 +77,7 @@ public class CounselorService {
   }
 
   @Transactional
-  public CounselorSessionResponse releaseSession(Long sessionId, Long counselorId, Long userId) {
+  public CounselorSessionResponse releaseSession(Long sessionId, Long counselorId) {
     validateCounselorId(counselorId);
 
     ChatSession session =
@@ -86,8 +86,8 @@ public class CounselorService {
             .orElseThrow(
                 () ->
                     new NotFoundException("SESSION_NOT_FOUND", "Session not found: " + sessionId));
-    validateWorkspaceMembership(session.getWorkspaceId(), userId);
 
+    validateWorkspaceMembership(session.getWorkspaceId(), counselorId);
     if (!Objects.equals(counselorId, session.getAssignedCounselorId())) {
       throw new BadRequestException(
           "SESSION_NOT_ASSIGNED_TO_COUNSELOR",

--- a/backend/src/main/java/com/init/workflowruntime/presentation/CounselorSessionController.java
+++ b/backend/src/main/java/com/init/workflowruntime/presentation/CounselorSessionController.java
@@ -26,16 +26,16 @@ public class CounselorSessionController {
 
   @PostMapping("/consultation/sessions/{sessionId}/assign")
   public ResponseEntity<CounselorSessionResponse> assignSession(
-      @PathVariable Long sessionId, @RequestParam Long counselorId, Authentication authentication) {
-    Long userId = AuthenticationUtils.getUserId(authentication);
-    return ResponseEntity.ok(counselorService.assignSession(counselorId, sessionId, userId));
+      @PathVariable Long sessionId, Authentication authentication) {
+    Long counselorId = AuthenticationUtils.getUserId(authentication);
+    return ResponseEntity.ok(counselorService.assignSession(sessionId, counselorId));
   }
 
   @PostMapping("/consultation/sessions/{sessionId}/release")
   public ResponseEntity<CounselorSessionResponse> releaseSession(
-      @PathVariable Long sessionId, @RequestParam Long counselorId, Authentication authentication) {
-    Long userId = AuthenticationUtils.getUserId(authentication);
-    return ResponseEntity.ok(counselorService.releaseSession(sessionId, counselorId, userId));
+      @PathVariable Long sessionId, Authentication authentication) {
+    Long counselorId = AuthenticationUtils.getUserId(authentication);
+    return ResponseEntity.ok(counselorService.releaseSession(sessionId, counselorId));
   }
 
   @GetMapping("/workspaces/{workspaceId}/consultation/sessions")

--- a/backend/src/test/java/com/init/workflowruntime/application/CounselorServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/CounselorServiceTest.java
@@ -49,8 +49,6 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 @DisplayName("CounselorService")
 class CounselorServiceTest {
 
-  private static final Long USER_ID = 7L;
-
   @Mock private ChatSessionRepository chatSessionRepository;
   @Mock private ChatMessageRepository chatMessageRepository;
   @Mock private SimpMessagingTemplate messagingTemplate;
@@ -79,9 +77,9 @@ class CounselorServiceTest {
   void should_assignSession_when_sessionOpen() {
     ChatSession session = createSession(1L, ChatSessionStatus.OPEN);
     given(chatSessionRepository.findByIdForUpdate(1L)).willReturn(Optional.of(session));
-    givenWorkspaceMember(1L, USER_ID);
+    givenWorkspaceMember(1L, 42L);
 
-    CounselorSessionResponse result = service.assignSession(42L, 1L, USER_ID);
+    CounselorSessionResponse result = service.assignSession(1L, 42L);
 
     assertThat(result.getStatus()).isEqualTo("ACTIVE");
     assertThat(result.getAssignedCounselorId()).isEqualTo(42L);
@@ -95,9 +93,23 @@ class CounselorServiceTest {
   void should_throwNotFoundException_when_sessionNotFound() {
     given(chatSessionRepository.findByIdForUpdate(999L)).willReturn(Optional.empty());
 
-    assertThatThrownBy(() -> service.assignSession(1L, 999L, USER_ID))
+    assertThatThrownBy(() -> service.assignSession(999L, 1L))
         .isInstanceOf(NotFoundException.class)
         .hasMessageContaining("Session not found: 999");
+  }
+
+  @Test
+  @DisplayName("assignSession: 세션 workspace 멤버가 아니면 거부")
+  void should_throwAccessDenied_when_assignRequesterIsNotWorkspaceMember() {
+    ChatSession session = createSession(1L, ChatSessionStatus.OPEN);
+    given(chatSessionRepository.findByIdForUpdate(1L)).willReturn(Optional.of(session));
+    given(workspaceMemberRepository.findByWorkspaceIdAndUserId(1L, 42L))
+        .willReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.assignSession(1L, 42L))
+        .isInstanceOf(WorkspaceAccessDeniedException.class);
+
+    verify(chatSessionRepository, never()).save(session);
   }
 
   @Test
@@ -106,9 +118,9 @@ class CounselorServiceTest {
     ChatSession session = createSession(1L, ChatSessionStatus.OPEN);
     ReflectionTestUtils.setField(session, "assignedCounselorId", 10L);
     given(chatSessionRepository.findByIdForUpdate(1L)).willReturn(Optional.of(session));
-    givenWorkspaceMember(1L, USER_ID);
+    givenWorkspaceMember(1L, 42L);
 
-    assertThatThrownBy(() -> service.assignSession(42L, 1L, USER_ID))
+    assertThatThrownBy(() -> service.assignSession(1L, 42L))
         .isInstanceOf(InvalidSessionStateException.class)
         .hasMessageContaining("already assigned");
   }
@@ -118,24 +130,11 @@ class CounselorServiceTest {
   void should_throwInvalidState_when_notOpen() {
     ChatSession session = createSession(1L, ChatSessionStatus.COMPLETED);
     given(chatSessionRepository.findByIdForUpdate(1L)).willReturn(Optional.of(session));
-    givenWorkspaceMember(1L, USER_ID);
+    givenWorkspaceMember(1L, 42L);
 
-    assertThatThrownBy(() -> service.assignSession(42L, 1L, USER_ID))
+    assertThatThrownBy(() -> service.assignSession(1L, 42L))
         .isInstanceOf(com.init.workflowruntime.domain.InvalidSessionStateException.class)
         .hasMessageContaining("requires status OPEN");
-  }
-
-  @Test
-  @DisplayName("assignSession: 세션 워크스페이스 멤버가 아니면 배정하지 않는다")
-  void should_throwAccessDenied_when_assignRequesterIsNotWorkspaceMember() {
-    ChatSession session = createSession(1L, ChatSessionStatus.OPEN);
-    given(chatSessionRepository.findByIdForUpdate(1L)).willReturn(Optional.of(session));
-    given(workspaceMemberRepository.findByWorkspaceIdAndUserId(1L, USER_ID))
-        .willReturn(Optional.empty());
-
-    assertThatThrownBy(() -> service.assignSession(42L, 1L, USER_ID))
-        .isInstanceOf(WorkspaceAccessDeniedException.class);
-    assertThat(session.getStatus()).isEqualTo(ChatSessionStatus.OPEN);
   }
 
   // ── releaseSession ────────────────────────────────────────────────────────
@@ -146,9 +145,9 @@ class CounselorServiceTest {
     ChatSession session = createSession(1L, ChatSessionStatus.ACTIVE);
     ReflectionTestUtils.setField(session, "assignedCounselorId", 42L);
     given(chatSessionRepository.findByIdForUpdate(1L)).willReturn(Optional.of(session));
-    givenWorkspaceMember(1L, USER_ID);
+    givenWorkspaceMember(1L, 42L);
 
-    CounselorSessionResponse result = service.releaseSession(1L, 42L, USER_ID);
+    CounselorSessionResponse result = service.releaseSession(1L, 42L);
 
     assertThat(result.getStatus()).isEqualTo("OPEN");
     assertThat(result.getAssignedCounselorId()).isNull();
@@ -162,11 +161,26 @@ class CounselorServiceTest {
     ChatSession session = createSession(1L, ChatSessionStatus.ACTIVE);
     ReflectionTestUtils.setField(session, "assignedCounselorId", 42L);
     given(chatSessionRepository.findByIdForUpdate(1L)).willReturn(Optional.of(session));
-    givenWorkspaceMember(1L, USER_ID);
+    givenWorkspaceMember(1L, 99L);
 
-    assertThatThrownBy(() -> service.releaseSession(1L, 99L, USER_ID))
+    assertThatThrownBy(() -> service.releaseSession(1L, 99L))
         .isInstanceOf(BadRequestException.class)
         .hasMessageContaining("not assigned to counselor");
+  }
+
+  @Test
+  @DisplayName("releaseSession: 세션 workspace 멤버가 아니면 거부")
+  void should_throwAccessDenied_when_releaseRequesterIsNotWorkspaceMember() {
+    ChatSession session = createSession(1L, ChatSessionStatus.ACTIVE);
+    ReflectionTestUtils.setField(session, "assignedCounselorId", 42L);
+    given(chatSessionRepository.findByIdForUpdate(1L)).willReturn(Optional.of(session));
+    given(workspaceMemberRepository.findByWorkspaceIdAndUserId(1L, 42L))
+        .willReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.releaseSession(1L, 42L))
+        .isInstanceOf(WorkspaceAccessDeniedException.class);
+
+    verify(chatSessionRepository, never()).save(session);
   }
 
   @Test
@@ -174,25 +188,11 @@ class CounselorServiceTest {
   void should_throwBadRequest_when_notAssignedToRelease() {
     ChatSession session = createSession(1L, ChatSessionStatus.OPEN);
     given(chatSessionRepository.findByIdForUpdate(1L)).willReturn(Optional.of(session));
-    givenWorkspaceMember(1L, USER_ID);
+    givenWorkspaceMember(1L, 42L);
 
-    assertThatThrownBy(() -> service.releaseSession(1L, 42L, USER_ID))
+    assertThatThrownBy(() -> service.releaseSession(1L, 42L))
         .isInstanceOf(BadRequestException.class)
         .hasMessageContaining("not assigned to counselor");
-  }
-
-  @Test
-  @DisplayName("releaseSession: 세션 워크스페이스 멤버가 아니면 해제하지 않는다")
-  void should_throwAccessDenied_when_releaseRequesterIsNotWorkspaceMember() {
-    ChatSession session = createSession(1L, ChatSessionStatus.ACTIVE);
-    ReflectionTestUtils.setField(session, "assignedCounselorId", 42L);
-    given(chatSessionRepository.findByIdForUpdate(1L)).willReturn(Optional.of(session));
-    given(workspaceMemberRepository.findByWorkspaceIdAndUserId(1L, USER_ID))
-        .willReturn(Optional.empty());
-
-    assertThatThrownBy(() -> service.releaseSession(1L, 42L, USER_ID))
-        .isInstanceOf(WorkspaceAccessDeniedException.class);
-    assertThat(session.getStatus()).isEqualTo(ChatSessionStatus.ACTIVE);
   }
 
   // ── isSessionAssigned ─────────────────────────────────────────────────────

--- a/backend/src/test/java/com/init/workflowruntime/presentation/CounselorSessionControllerTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/presentation/CounselorSessionControllerTest.java
@@ -53,13 +53,10 @@ class CounselorSessionControllerTest {
     response.setChannel("WEB");
     response.setStartedAt(OffsetDateTime.now());
 
-    given(counselorService.assignSession(eq(42L), eq(1L), eq(7L))).willReturn(response);
+    given(counselorService.assignSession(eq(1L), eq(42L))).willReturn(response);
 
     mockMvc
-        .perform(
-            post("/api/v1/consultation/sessions/1/assign")
-                .param("counselorId", "42")
-                .principal(auth()))
+        .perform(post("/api/v1/consultation/sessions/1/assign").principal(auth(42L)))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.id").value(1))
         .andExpect(jsonPath("$.status").value("ACTIVE"))
@@ -67,16 +64,34 @@ class CounselorSessionControllerTest {
   }
 
   @Test
-  @DisplayName("POST /api/v1/consultation/sessions/{id}/assign - 세션 없음 → 404")
-  void should_return404_when_sessionNotFound() throws Exception {
-    given(counselorService.assignSession(eq(1L), eq(999L), eq(7L)))
-        .willThrow(new NotFoundException("SESSION_NOT_FOUND", "Session not found: 999"));
+  @DisplayName("POST /api/v1/consultation/sessions/{id}/assign - query counselorId를 무시한다")
+  void should_ignoreCounselorIdQuery_when_assigning() throws Exception {
+    CounselorSessionResponse response = new CounselorSessionResponse();
+    response.setId(1L);
+    response.setStatus("ACTIVE");
+    response.setAssignedCounselorId(42L);
+    response.setChannel("WEB");
+    response.setStartedAt(OffsetDateTime.now());
+
+    given(counselorService.assignSession(eq(1L), eq(42L))).willReturn(response);
 
     mockMvc
         .perform(
-            post("/api/v1/consultation/sessions/999/assign")
-                .param("counselorId", "1")
-                .principal(auth()))
+            post("/api/v1/consultation/sessions/1/assign")
+                .param("counselorId", "99")
+                .principal(auth(42L)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.assignedCounselorId").value(42));
+  }
+
+  @Test
+  @DisplayName("POST /api/v1/consultation/sessions/{id}/assign - 세션 없음 → 404")
+  void should_return404_when_sessionNotFound() throws Exception {
+    given(counselorService.assignSession(eq(999L), eq(1L)))
+        .willThrow(new NotFoundException("SESSION_NOT_FOUND", "Session not found: 999"));
+
+    mockMvc
+        .perform(post("/api/v1/consultation/sessions/999/assign").principal(auth(1L)))
         .andExpect(status().isNotFound())
         .andExpect(jsonPath("$.code").value("SESSION_NOT_FOUND"));
   }
@@ -84,14 +99,11 @@ class CounselorSessionControllerTest {
   @Test
   @DisplayName("POST /api/v1/consultation/sessions/{id}/assign - 이미 배정됨 → 400")
   void should_return400_when_alreadyAssigned() throws Exception {
-    given(counselorService.assignSession(eq(1L), eq(999L), eq(7L)))
+    given(counselorService.assignSession(eq(999L), eq(1L)))
         .willThrow(new BadRequestException("ALREADY_ASSIGNED", "Session already assigned"));
 
     mockMvc
-        .perform(
-            post("/api/v1/consultation/sessions/999/assign")
-                .param("counselorId", "1")
-                .principal(auth()))
+        .perform(post("/api/v1/consultation/sessions/999/assign").principal(auth(1L)))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.code").value("ALREADY_ASSIGNED"));
   }
@@ -104,13 +116,10 @@ class CounselorSessionControllerTest {
     response.setStatus("OPEN");
     response.setAssignedCounselorId(null);
 
-    given(counselorService.releaseSession(eq(1L), eq(42L), eq(7L))).willReturn(response);
+    given(counselorService.releaseSession(eq(1L), eq(42L))).willReturn(response);
 
     mockMvc
-        .perform(
-            post("/api/v1/consultation/sessions/1/release")
-                .param("counselorId", "42")
-                .principal(auth()))
+        .perform(post("/api/v1/consultation/sessions/1/release").principal(auth(42L)))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.status").value("OPEN"));
   }
@@ -118,14 +127,11 @@ class CounselorSessionControllerTest {
   @Test
   @DisplayName("POST /api/v1/consultation/sessions/{id}/assign - 비멤버 → 403")
   void should_return403_when_assignRequesterIsNotWorkspaceMember() throws Exception {
-    given(counselorService.assignSession(eq(42L), eq(1L), eq(7L)))
+    given(counselorService.assignSession(eq(1L), eq(42L)))
         .willThrow(new WorkspaceAccessDeniedException("워크스페이스에 접근 권한이 없습니다."));
 
     mockMvc
-        .perform(
-            post("/api/v1/consultation/sessions/1/assign")
-                .param("counselorId", "42")
-                .principal(auth()))
+        .perform(post("/api/v1/consultation/sessions/1/assign").principal(auth(42L)))
         .andExpect(status().isForbidden())
         .andExpect(jsonPath("$.code").value("WORKSPACE_ACCESS_DENIED"));
   }
@@ -133,16 +139,32 @@ class CounselorSessionControllerTest {
   @Test
   @DisplayName("POST /api/v1/consultation/sessions/{id}/release - 비멤버 → 403")
   void should_return403_when_releaseRequesterIsNotWorkspaceMember() throws Exception {
-    given(counselorService.releaseSession(eq(1L), eq(42L), eq(7L)))
+    given(counselorService.releaseSession(eq(1L), eq(42L)))
         .willThrow(new WorkspaceAccessDeniedException("워크스페이스에 접근 권한이 없습니다."));
+
+    mockMvc
+        .perform(post("/api/v1/consultation/sessions/1/release").principal(auth(42L)))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.code").value("WORKSPACE_ACCESS_DENIED"));
+  }
+
+  @Test
+  @DisplayName("POST /api/v1/consultation/sessions/{id}/release - query counselorId를 무시한다")
+  void should_ignoreCounselorIdQuery_when_releasing() throws Exception {
+    CounselorSessionResponse response = new CounselorSessionResponse();
+    response.setId(1L);
+    response.setStatus("OPEN");
+    response.setAssignedCounselorId(null);
+
+    given(counselorService.releaseSession(eq(1L), eq(42L))).willReturn(response);
 
     mockMvc
         .perform(
             post("/api/v1/consultation/sessions/1/release")
-                .param("counselorId", "42")
-                .principal(auth()))
-        .andExpect(status().isForbidden())
-        .andExpect(jsonPath("$.code").value("WORKSPACE_ACCESS_DENIED"));
+                .param("counselorId", "99")
+                .principal(auth(42L)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.assignedCounselorId").isEmpty());
   }
 
   @Test
@@ -194,8 +216,8 @@ class CounselorSessionControllerTest {
         .andExpect(jsonPath("$.code").value("UNSUPPORTED_STATUS"));
   }
 
-  private UsernamePasswordAuthenticationToken auth() {
+  private UsernamePasswordAuthenticationToken auth(Long userId) {
     return new UsernamePasswordAuthenticationToken(
-        7L, null, List.of(new SimpleGrantedAuthority("ROLE_OPERATOR")));
+        userId, null, List.of(new SimpleGrantedAuthority("ROLE_OPERATOR")));
   }
 }

--- a/frontend/src/features/consultation/api/consultationApi.test.ts
+++ b/frontend/src/features/consultation/api/consultationApi.test.ts
@@ -366,7 +366,7 @@ describe("consultationApi", () => {
     expect(result).toEqual(stubMessages);
   });
 
-  it("assignSession이 상담사 ID와 함께 assign API를 호출한다", async () => {
+  it("assignSession이 상담사 ID 없이 assign API를 호출한다", async () => {
     const stubSession = {
       id: 1,
       status: "ACTIVE",
@@ -377,16 +377,16 @@ describe("consultationApi", () => {
     };
     mockedCustomFetch.mockResolvedValue(stubSession);
 
-    const result = await consultationApi.assignSession(1, 7);
+    const result = await consultationApi.assignSession(1);
 
     expect(mockedCustomFetch).toHaveBeenCalledWith(
-      "/api/v1/consultation/sessions/1/assign?counselorId=7",
+      "/api/v1/consultation/sessions/1/assign",
       { method: "POST" },
     );
     expect(result).toEqual(stubSession);
   });
 
-  it("releaseSession이 상담사 ID와 함께 release API를 호출한다", async () => {
+  it("releaseSession이 상담사 ID 없이 release API를 호출한다", async () => {
     const stubSession = {
       id: 1,
       status: "OPEN",
@@ -397,10 +397,10 @@ describe("consultationApi", () => {
     };
     mockedCustomFetch.mockResolvedValue({ data: stubSession });
 
-    const result = await consultationApi.releaseSession(1, 7);
+    const result = await consultationApi.releaseSession(1);
 
     expect(mockedCustomFetch).toHaveBeenCalledWith(
-      "/api/v1/consultation/sessions/1/release?counselorId=7",
+      "/api/v1/consultation/sessions/1/release",
       { method: "POST" },
     );
     expect(result).toEqual(stubSession);

--- a/frontend/src/features/consultation/api/consultationApi.ts
+++ b/frontend/src/features/consultation/api/consultationApi.ts
@@ -127,17 +127,17 @@ export const consultationApi = {
     );
   },
 
-  assignSession: async (sessionId: number, counselorId: number): Promise<ChatSession> => {
+  assignSession: async (sessionId: number): Promise<ChatSession> => {
     const response = await customFetch<ChatSession | { data?: ChatSession }>(
-      `/api/v1/consultation/sessions/${sessionId}/assign?counselorId=${counselorId}`,
+      `/api/v1/consultation/sessions/${sessionId}/assign`,
       { method: "POST" },
     );
     return requireApiData<ChatSession>(response, "상담 배정 응답을 확인할 수 없습니다.");
   },
 
-  releaseSession: async (sessionId: number, counselorId: number): Promise<ChatSession> => {
+  releaseSession: async (sessionId: number): Promise<ChatSession> => {
     const response = await customFetch<ChatSession | { data?: ChatSession }>(
-      `/api/v1/consultation/sessions/${sessionId}/release?counselorId=${counselorId}`,
+      `/api/v1/consultation/sessions/${sessionId}/release`,
       { method: "POST" },
     );
     return requireApiData<ChatSession>(response, "상담 배정 해제 응답을 확인할 수 없습니다.");

--- a/frontend/src/pages/consultation/ui/ConsultationPage.test.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.test.tsx
@@ -86,14 +86,14 @@ vi.mock("../../../features/consultation/api/consultationApi", () => ({
       ]),
     ),
     updateStatus: vi.fn(() => Promise.resolve({})),
-    assignSession: vi.fn((sessionId: number, counselorId: number) =>
+    assignSession: vi.fn((sessionId: number) =>
       Promise.resolve({
         id: sessionId,
         status: "ACTIVE",
         channel: "카카오톡",
         metaJson: JSON.stringify({ customerName: "김민지", handoffReason: "환불 문의" }),
         startedAt: new Date(Date.now() - 4 * 60000).toISOString(),
-        assignedCounselorId: counselorId,
+        assignedCounselorId: 7,
       }),
     ),
     releaseSession: vi.fn(() =>
@@ -898,7 +898,7 @@ describe("ConsultationPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "배정받기" }));
 
     await waitFor(() => {
-      expect(consultationApi.assignSession).toHaveBeenCalledWith(1, 7);
+      expect(consultationApi.assignSession).toHaveBeenCalledWith(1);
     });
     await waitFor(() => {
       expect(screen.getAllByText("내게 배정됨").length).toBeGreaterThan(0);
@@ -997,7 +997,7 @@ describe("ConsultationPage", () => {
     fireEvent.click(screen.getByText("배정 해제"));
 
     await waitFor(() => {
-      expect(consultationApi.releaseSession).toHaveBeenCalledWith(1, 7);
+      expect(consultationApi.releaseSession).toHaveBeenCalledWith(1);
     });
   });
 

--- a/frontend/src/pages/consultation/ui/ConsultationPage.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.tsx
@@ -1004,10 +1004,7 @@ export const ConsultationPage: React.FC = () => {
     const targetSessionId = activeCustomerId;
     setClaimingSessionId(targetSessionId);
     try {
-      const assignedSession = await consultationApi.assignSession(
-        Number(targetSessionId),
-        currentCounselorId,
-      );
+      const assignedSession = await consultationApi.assignSession(Number(targetSessionId));
       setQueue((prev) =>
         replaceAssignedQueueCustomer(prev, targetSessionId, assignedSession, currentCounselorId),
       );
@@ -1191,10 +1188,7 @@ export const ConsultationPage: React.FC = () => {
     const releasedSessionId = activeCustomerId;
 
     try {
-      const releasedSession = await consultationApi.releaseSession(
-        Number(releasedSessionId),
-        currentCounselorId,
-      );
+      const releasedSession = await consultationApi.releaseSession(Number(releasedSessionId));
       setQueue((prev) =>
         sortQueueCustomers(
           prev.map((customer) =>


### PR DESCRIPTION
## Summary
- 상담 배정/해제 REST API에서 `counselorId` query parameter 의존을 제거했습니다.
- 서버가 인증 principal의 사용자 ID로만 세션을 배정/해제하고, 세션 workspace 멤버십을 검증합니다.
- 프론트 상담 API wrapper와 상담 페이지 호출부가 sessionId만 전달하도록 정리했습니다.
- 구현 기준을 `.agent/specs/358.md`에 함께 정리했습니다.

## Root Cause
- 상담사 메시지 전송 WebSocket은 principal에서 상담사 ID를 가져오지만, REST 배정/해제는 클라이언트가 전달한 `counselorId`를 신뢰했습니다.
- 이 때문에 요청 query를 조작하면 다른 상담사 ID로 배정/해제 요청을 만들 수 있는 인증 모델 불일치가 있었습니다.

## Validation
- `cd backend && mise exec -- ./gradlew test --tests com.init.workflowruntime.application.CounselorServiceTest --tests com.init.workflowruntime.presentation.CounselorSessionControllerTest spotlessCheck`
- `cd frontend && pnpm test -- consultationApi.test.ts ConsultationPage.test.tsx`
- `git diff --check`
- `git diff --cached --check`

## Notes
- `cd frontend && pnpm lint`는 이번 변경과 무관한 기존 lint 오류 59개로 실패해, 변경된 상담 테스트와 API wrapper 동작을 targeted test로 확인했습니다.

Closes #358

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 상담 세션 배정/해제 시 워크스페이스 멤버십 검증 추가

* **개선 사항**
  * 상담 세션 배정/해제 API가 요청 파라미터 기반에서 인증된 사용자 기반으로 변경
  * 프론트엔드 API 호출에서 상담사 ID 파라미터 제거

* **테스트**
  * 백엔드/프론트엔드 테스트 케이스 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->