### PR TITLE
fix(consultation): 상담 세션 접근을 워크스페이스 멤버로 제한

### DIFF
--- a/.agent/specs/359.md
+++ b/.agent/specs/359.md
@@ -1,0 +1,169 @@
+# Backend Spec: 상담 Session REST 접근 제어 강화
+
+## Goal
+
+`sessionId` 기반 상담 REST API가 세션이 속한 워크스페이스 멤버십을 확인한 뒤
+상담 메시지, 상태, 매칭 워크플로우, 배정/해제 기능을 제공하도록 강화한다.
+
+## Problem
+
+현재 `/api/v1/consultation/**` 요청은 Spring Security에서 `OPERATOR` 역할만
+확인한다. 워크스페이스 단위 큐 조회는 멤버십을 검증하지만, 세션 ID만 받는 REST
+API는 세션의 `workspaceId`와 현재 인증 사용자의 멤버십을 연결해 확인하지 않는다.
+다른 워크스페이스의 `sessionId`를 알게 되면 상담 기록 조회, 상태 변경,
+워크플로우 조회 같은 작업에 접근할 위험이 있다.
+
+## Scope
+
+- `backend/src/main/java/com/init/workflowruntime/presentation/ConsultationController.java`
+- `backend/src/main/java/com/init/workflowruntime/presentation/CounselorSessionController.java`
+- `backend/src/main/java/com/init/workflowruntime/application/ConsultationService.java`
+- `backend/src/main/java/com/init/workflowruntime/application/CounselorService.java`
+- `backend/src/main/java/com/init/workflowruntime/application/LlmToolService.java`
+- 관련 controller/service 테스트
+
+## Non-Goals
+
+- Spring Security URL role 정책 변경은 포함하지 않는다.
+- 상담 세션 테이블 또는 워크스페이스 멤버십 스키마 변경은 포함하지 않는다.
+- WebSocket 상담 채널 접근 제어는 기존 `JwtChannelInterceptor` 검증을 유지한다.
+- LLM 내부 tool command 전체를 사용자 인증 기반 API로 바꾸지 않는다. 이번 범위는
+  REST controller에서 노출되는 `matched-workflow` 조회에 한정한다.
+
+## Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    actor c as Operator Client
+    participant ctrl as Consultation REST Controller
+    participant svc as Workflow Runtime Service
+    participant sessionRepo as ChatSessionRepository
+    participant memberRepo as WorkspaceMemberRepository
+    participant db as PostgreSQL
+
+    c ->> ctrl: GET/PATCH/POST /api/v1/consultation/sessions/{sessionId}/...
+    ctrl ->> ctrl: AuthenticationUtils.getUserId(authentication)
+    ctrl ->> svc: execute(sessionId, userId, request)
+    svc ->> sessionRepo: find session by sessionId
+    sessionRepo ->> db: SELECT runtime.chat_session
+    db ->> sessionRepo: ChatSession(workspaceId)
+    svc ->> memberRepo: findByWorkspaceIdAndUserId(workspaceId, userId)
+    memberRepo ->> db: SELECT app.workspace_member
+    alt membership exists
+        db ->> memberRepo: WorkspaceMember
+        svc ->> svc: perform read/write workflow
+        svc ->> ctrl: response DTO
+        ctrl ->> c: 200 OK
+    else membership missing
+        db ->> memberRepo: empty
+        svc ->> ctrl: WorkspaceAccessDeniedException
+        ctrl ->> c: 403 WORKSPACE_ACCESS_DENIED
+    end
+```
+
+## REST API
+
+기존 URL과 요청/응답 DTO는 유지한다. 각 endpoint는 현재 인증 principal의 userId를
+사용해 세션 워크스페이스 멤버십을 검증한다.
+
+| Method | Path | Access Rule |
+| --- | --- | --- |
+| `GET` | `/api/v1/consultation/sessions/{sessionId}/messages` | 세션 워크스페이스 멤버 |
+| `POST` | `/api/v1/consultation/sessions/{sessionId}/messages` | 세션 워크스페이스 멤버 |
+| `PATCH` | `/api/v1/consultation/sessions/{sessionId}/status` | 세션 워크스페이스 멤버 |
+| `GET` | `/api/v1/consultation/sessions/{sessionId}/matched-workflow` | 세션 워크스페이스 멤버 |
+| `POST` | `/api/v1/consultation/sessions/{sessionId}/assign` | 세션 워크스페이스 멤버 |
+| `POST` | `/api/v1/consultation/sessions/{sessionId}/release` | 세션 워크스페이스 멤버 |
+
+### Error Response
+
+멤버십 검증 실패는 기존 `WorkspaceAccessDeniedException`을 사용해 일관된 403 응답으로 반환한다.
+
+```json
+{
+  "code": "WORKSPACE_ACCESS_DENIED",
+  "message": "워크스페이스에 접근 권한이 없습니다."
+}
+```
+
+## Class Design
+
+```mermaid
+classDiagram
+    class ConsultationController {
+        +getMessages(Long, Authentication)
+        +sendMessage(Long, SendMessageRequest, Authentication)
+        +updateStatus(Long, UpdateStatusRequest, Authentication)
+        +getMatchedWorkflow(Long, Authentication)
+    }
+
+    class CounselorSessionController {
+        +assignSession(Long, Long, Authentication)
+        +releaseSession(Long, Long, Authentication)
+    }
+
+    class ConsultationService {
+        +getMessages(Long, Long)
+        +sendMessage(Long, SendMessageRequest, Long)
+        +updateSessionStatus(Long, UpdateStatusRequest, Long)
+        -validateWorkspaceMembership(Long, Long)
+    }
+
+    class CounselorService {
+        +assignSession(Long, Long, Long)
+        +releaseSession(Long, Long, Long)
+        -validateWorkspaceMembership(Long, Long)
+    }
+
+    class LlmToolService {
+        +getCurrentWorkflowForOperator(GetCurrentWorkflowCommand, Long)
+        -validateWorkspaceMembership(Long, Long)
+    }
+
+    ConsultationController --> ConsultationService
+    ConsultationController --> LlmToolService
+    CounselorSessionController --> CounselorService
+    ConsultationService --> ChatSessionRepository
+    ConsultationService --> WorkspaceMemberRepository
+    CounselorService --> ChatSessionRepository
+    CounselorService --> WorkspaceMemberRepository
+    LlmToolService --> ChatSessionRepository
+    LlmToolService --> WorkspaceMemberRepository
+```
+
+## Requirements
+
+1. `ConsultationController`는 `AuthenticationUtils.getUserId(authentication)`으로 현재
+   사용자 ID를 추출하고 sessionId 기반 service 호출에 전달한다.
+2. `ConsultationService`의 메시지 조회, 메시지 전송, 상태 변경은 세션 조회 후
+   `session.workspaceId`와 `userId`로 멤버십을 검증한다.
+3. `LlmToolService`는 REST용 매칭 워크플로우 조회 진입점에서 세션 워크스페이스
+   멤버십을 검증한다. 기존 내부 LLM tool 흐름은 현재 command 계약을 유지한다.
+4. `CounselorService`의 REST 배정/해제 흐름은 요청자가 세션 워크스페이스 멤버인지 검증한다.
+5. 검증 실패는 `WorkspaceAccessDeniedException`을 던져 `WORKSPACE_ACCESS_DENIED`
+   코드의 403 응답을 반환한다.
+6. 세션이 존재하지 않는 경우는 기존처럼 `SESSION_NOT_FOUND` 404를 유지한다.
+7. API path와 request/response body 호환성은 유지한다.
+
+## Data/API Impacts
+
+- DB migration 없음.
+- REST path 변경 없음.
+- 기존 response DTO 변경 없음.
+- application service method signature는 인증 사용자 ID를 받을 수 있도록 확장된다.
+
+## Validation
+
+- Backend 단위 테스트에 비멤버가 sessionId 기반 메시지 조회, 메시지 전송, 상태
+  변경, 매칭 워크플로우 조회, 배정/해제에 접근할 때
+  `WorkspaceAccessDeniedException`이 발생하는 케이스를 추가한다.
+- Controller 테스트는 인증 principal에서 추출한 userId가 service로 전달되는지 검증한다.
+- 가능한 경우 `cd backend && ./gradlew test --tests ...`로 변경된 테스트 범위를 실행한다.
+
+## Open Questions
+
+- 상태 변경과 메시지 전송을 반드시 `assignedCounselorId == authenticated userId`인
+  상담사로 제한할지는 정책 결정이 필요하다. 이번 이슈의 확인 기준은 워크스페이스
+  멤버십 검증이므로, 기존 배정 상담사 검증이 있는
+  `CounselorService.sendCounselorMessage` 외의 REST 메시지/상태 변경은 멤버십
+  검증까지만 적용한다.

--- a/backend/src/main/java/com/init/workflowruntime/application/ConsultationService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/ConsultationService.java
@@ -58,13 +58,14 @@ public class ConsultationService {
         .collect(Collectors.toList());
   }
 
-  public List<ChatMessageResponse> getMessages(@NonNull Long sessionId) {
+  public List<ChatMessageResponse> getMessages(@NonNull Long sessionId, @NonNull Long userId) {
     ChatSession session =
         chatSessionRepository
             .findById(sessionId)
             .orElseThrow(
                 () ->
                     new NotFoundException("SESSION_NOT_FOUND", "Session not found: " + sessionId));
+    validateWorkspaceMembership(session.getWorkspaceId(), userId);
 
     Long id = session.getId();
     if (id == null) {
@@ -78,13 +79,14 @@ public class ConsultationService {
 
   @Transactional
   public ChatMessageResponse sendMessage(
-      @NonNull Long sessionId, @NonNull SendMessageRequest request) {
+      @NonNull Long sessionId, @NonNull SendMessageRequest request, @NonNull Long userId) {
     ChatSession session =
         chatSessionRepository
             .findByIdForUpdate(sessionId)
             .orElseThrow(
                 () ->
                     new NotFoundException("SESSION_NOT_FOUND", "Session not found: " + sessionId));
+    validateWorkspaceMembership(session.getWorkspaceId(), userId);
 
     if (session.getId() == null) {
       throw new IllegalStateException("Session ID cannot be null");
@@ -108,21 +110,23 @@ public class ConsultationService {
   }
 
   @Transactional
-  public ChatSessionResponse updateSessionStatus(@NonNull Long sessionId, @NonNull String status) {
+  public ChatSessionResponse updateSessionStatus(
+      @NonNull Long sessionId, @NonNull String status, @NonNull Long userId) {
     UpdateStatusRequest request = new UpdateStatusRequest();
     request.setStatus(status);
-    return updateSessionStatus(sessionId, request);
+    return updateSessionStatus(sessionId, request, userId);
   }
 
   @Transactional
   public ChatSessionResponse updateSessionStatus(
-      @NonNull Long sessionId, @NonNull UpdateStatusRequest request) {
+      @NonNull Long sessionId, @NonNull UpdateStatusRequest request, @NonNull Long userId) {
     ChatSession session =
         chatSessionRepository
             .findById(sessionId)
             .orElseThrow(
                 () ->
                     new NotFoundException("SESSION_NOT_FOUND", "Session not found: " + sessionId));
+    validateWorkspaceMembership(session.getWorkspaceId(), userId);
 
     ChatSessionStatus newStatus = parseStatus(request.getStatus());
     SessionResolutionOutcome outcome = parseOutcome(request.getResolutionOutcome());

--- a/backend/src/main/java/com/init/workflowruntime/application/CounselorService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/CounselorService.java
@@ -13,6 +13,8 @@ import com.init.workflowruntime.domain.ChatSessionStatus;
 import com.init.workflowruntime.domain.event.ConsultationQueueChangedEvent;
 import com.init.workflowruntime.domain.event.ConsultationQueueEventType;
 import com.init.workflowruntime.domain.event.SessionAssignedEvent;
+import com.init.workspace.application.exception.WorkspaceAccessDeniedException;
+import com.init.workspace.domain.repository.WorkspaceMemberRepository;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -34,22 +36,25 @@ public class CounselorService {
   private final SimpMessagingTemplate messagingTemplate;
   private final ApplicationEventPublisher eventPublisher;
   private final ChatSessionMetadataService chatSessionMetadataService;
+  private final WorkspaceMemberRepository workspaceMemberRepository;
 
   public CounselorService(
       ChatSessionRepository chatSessionRepository,
       ChatMessageRepository chatMessageRepository,
       SimpMessagingTemplate messagingTemplate,
       ApplicationEventPublisher eventPublisher,
-      ChatSessionMetadataService chatSessionMetadataService) {
+      ChatSessionMetadataService chatSessionMetadataService,
+      WorkspaceMemberRepository workspaceMemberRepository) {
     this.chatSessionRepository = chatSessionRepository;
     this.chatMessageRepository = chatMessageRepository;
     this.messagingTemplate = messagingTemplate;
     this.eventPublisher = eventPublisher;
     this.chatSessionMetadataService = chatSessionMetadataService;
+    this.workspaceMemberRepository = workspaceMemberRepository;
   }
 
   @Transactional
-  public CounselorSessionResponse assignSession(Long counselorId, Long sessionId) {
+  public CounselorSessionResponse assignSession(Long counselorId, Long sessionId, Long userId) {
     validateCounselorId(counselorId);
 
     ChatSession session =
@@ -58,6 +63,7 @@ public class CounselorService {
             .orElseThrow(
                 () ->
                     new NotFoundException("SESSION_NOT_FOUND", "Session not found: " + sessionId));
+    validateWorkspaceMembership(session.getWorkspaceId(), userId);
 
     session.assignTo(counselorId);
     chatSessionRepository.save(session);
@@ -71,7 +77,7 @@ public class CounselorService {
   }
 
   @Transactional
-  public CounselorSessionResponse releaseSession(Long sessionId, Long counselorId) {
+  public CounselorSessionResponse releaseSession(Long sessionId, Long counselorId, Long userId) {
     validateCounselorId(counselorId);
 
     ChatSession session =
@@ -80,6 +86,7 @@ public class CounselorService {
             .orElseThrow(
                 () ->
                     new NotFoundException("SESSION_NOT_FOUND", "Session not found: " + sessionId));
+    validateWorkspaceMembership(session.getWorkspaceId(), userId);
 
     if (!Objects.equals(counselorId, session.getAssignedCounselorId())) {
       throw new BadRequestException(
@@ -205,5 +212,11 @@ public class CounselorService {
     if (counselorId == null) {
       throw new BadRequestException("INVALID_COUNSELOR_ID", "counselorId must not be null");
     }
+  }
+
+  private void validateWorkspaceMembership(Long workspaceId, Long userId) {
+    workspaceMemberRepository
+        .findByWorkspaceIdAndUserId(workspaceId, userId)
+        .orElseThrow(() -> new WorkspaceAccessDeniedException("워크스페이스에 접근 권한이 없습니다."));
   }
 }

--- a/backend/src/main/java/com/init/workflowruntime/application/LlmToolService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/LlmToolService.java
@@ -45,6 +45,8 @@ import com.init.workflowruntime.domain.WorkflowExecutionRepository;
 import com.init.workflowruntime.domain.WorkflowExecutionStep;
 import com.init.workflowruntime.domain.WorkflowExecutionStepActionType;
 import com.init.workflowruntime.domain.WorkflowExecutionStepRepository;
+import com.init.workspace.application.exception.WorkspaceAccessDeniedException;
+import com.init.workspace.domain.repository.WorkspaceMemberRepository;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -69,6 +71,7 @@ public class LlmToolService {
   private final DecisionLogRepository decisionLogRepository;
   private final WorkflowExecutionStepRepository workflowExecutionStepRepository;
   private final ObjectMapper objectMapper;
+  private final WorkspaceMemberRepository workspaceMemberRepository;
 
   public LlmToolService(
       ChatSessionRepository chatSessionRepository,
@@ -81,7 +84,8 @@ public class LlmToolService {
       WorkflowPolicyRuntimeService workflowPolicyRuntimeService,
       DecisionLogRepository decisionLogRepository,
       WorkflowExecutionStepRepository workflowExecutionStepRepository,
-      ObjectMapper objectMapper) {
+      ObjectMapper objectMapper,
+      WorkspaceMemberRepository workspaceMemberRepository) {
     this.chatSessionRepository = chatSessionRepository;
     this.workflowExecutionRepository = workflowExecutionRepository;
     this.intentDefinitionRepository = intentDefinitionRepository;
@@ -93,6 +97,16 @@ public class LlmToolService {
     this.decisionLogRepository = decisionLogRepository;
     this.workflowExecutionStepRepository = workflowExecutionStepRepository;
     this.objectMapper = objectMapper;
+    this.workspaceMemberRepository = workspaceMemberRepository;
+  }
+
+  @SuppressWarnings("java:S2201") // false positive: PESSIMISTIC_WRITE lock only, return ignored
+  @Transactional
+  public LlmToolWorkflowResponse getCurrentWorkflowForOperator(
+      GetCurrentWorkflowCommand command, Long userId) {
+    ChatSession session = findSession(command.sessionId());
+    validateWorkspaceMembership(session.getWorkspaceId(), userId);
+    return getCurrentWorkflow(command, session);
   }
 
   @SuppressWarnings("java:S2201") // false positive: PESSIMISTIC_WRITE lock only, return ignored
@@ -100,6 +114,12 @@ public class LlmToolService {
   public LlmToolWorkflowResponse getCurrentWorkflow(GetCurrentWorkflowCommand command) {
     Long sessionId = command.sessionId();
     ChatSession session = findSession(sessionId);
+    return getCurrentWorkflow(command, session);
+  }
+
+  private LlmToolWorkflowResponse getCurrentWorkflow(
+      GetCurrentWorkflowCommand command, ChatSession session) {
+    Long sessionId = command.sessionId();
     WorkflowExecution execution = findExecution(sessionId);
 
     Long executionId = execution != null ? execution.getId() : null;
@@ -462,6 +482,12 @@ public class LlmToolService {
         .findById(sessionId)
         .orElseThrow(
             () -> new NotFoundException("SESSION_NOT_FOUND", "Session not found: " + sessionId));
+  }
+
+  private void validateWorkspaceMembership(Long workspaceId, Long userId) {
+    workspaceMemberRepository
+        .findByWorkspaceIdAndUserId(workspaceId, userId)
+        .orElseThrow(() -> new WorkspaceAccessDeniedException("워크스페이스에 접근 권한이 없습니다."));
   }
 
   private WorkflowExecution findExecution(Long sessionId) {

--- a/backend/src/main/java/com/init/workflowruntime/presentation/ConsultationController.java
+++ b/backend/src/main/java/com/init/workflowruntime/presentation/ConsultationController.java
@@ -1,5 +1,6 @@
 package com.init.workflowruntime.presentation;
 
+import com.init.shared.presentation.AuthenticationUtils;
 import com.init.workflowruntime.application.ConsultationService;
 import com.init.workflowruntime.application.LlmToolService;
 import com.init.workflowruntime.application.command.GetCurrentWorkflowCommand;
@@ -11,6 +12,7 @@ import com.init.workflowruntime.application.dto.UpdateStatusRequest;
 import jakarta.validation.Valid;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -46,8 +48,10 @@ public class ConsultationController {
    * @return 메시지 상세 목록 응답
    */
   @GetMapping("/sessions/{sessionId}/messages")
-  public ResponseEntity<List<ChatMessageResponse>> getMessages(@PathVariable Long sessionId) {
-    return ResponseEntity.ok(consultationService.getMessages(sessionId));
+  public ResponseEntity<List<ChatMessageResponse>> getMessages(
+      @PathVariable Long sessionId, Authentication authentication) {
+    Long userId = AuthenticationUtils.getUserId(authentication);
+    return ResponseEntity.ok(consultationService.getMessages(sessionId, userId));
   }
 
   /**
@@ -59,8 +63,11 @@ public class ConsultationController {
    */
   @PostMapping("/sessions/{sessionId}/messages")
   public ResponseEntity<ChatMessageResponse> sendMessage(
-      @PathVariable Long sessionId, @Valid @RequestBody SendMessageRequest request) {
-    return ResponseEntity.ok(consultationService.sendMessage(sessionId, request));
+      @PathVariable Long sessionId,
+      @Valid @RequestBody SendMessageRequest request,
+      Authentication authentication) {
+    Long userId = AuthenticationUtils.getUserId(authentication);
+    return ResponseEntity.ok(consultationService.sendMessage(sessionId, request, userId));
   }
 
   /**
@@ -72,8 +79,11 @@ public class ConsultationController {
    */
   @PatchMapping("/sessions/{sessionId}/status")
   public ResponseEntity<ChatSessionResponse> updateStatus(
-      @PathVariable Long sessionId, @Valid @RequestBody UpdateStatusRequest request) {
-    return ResponseEntity.ok(consultationService.updateSessionStatus(sessionId, request));
+      @PathVariable Long sessionId,
+      @Valid @RequestBody UpdateStatusRequest request,
+      Authentication authentication) {
+    Long userId = AuthenticationUtils.getUserId(authentication);
+    return ResponseEntity.ok(consultationService.updateSessionStatus(sessionId, request, userId));
   }
 
   /**
@@ -85,8 +95,11 @@ public class ConsultationController {
    * @return 워크플로우 정의/실행 상태를 담은 응답
    */
   @GetMapping("/sessions/{sessionId}/matched-workflow")
-  public ResponseEntity<LlmToolWorkflowResponse> getMatchedWorkflow(@PathVariable Long sessionId) {
+  public ResponseEntity<LlmToolWorkflowResponse> getMatchedWorkflow(
+      @PathVariable Long sessionId, Authentication authentication) {
+    Long userId = AuthenticationUtils.getUserId(authentication);
     return ResponseEntity.ok(
-        llmToolService.getCurrentWorkflow(new GetCurrentWorkflowCommand(sessionId)));
+        llmToolService.getCurrentWorkflowForOperator(
+            new GetCurrentWorkflowCommand(sessionId), userId));
   }
 }

--- a/backend/src/main/java/com/init/workflowruntime/presentation/CounselorSessionController.java
+++ b/backend/src/main/java/com/init/workflowruntime/presentation/CounselorSessionController.java
@@ -1,10 +1,12 @@
 package com.init.workflowruntime.presentation;
 
+import com.init.shared.presentation.AuthenticationUtils;
 import com.init.workflowruntime.application.CounselorService;
 import com.init.workflowruntime.application.dto.CounselorSessionResponse;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -24,14 +26,16 @@ public class CounselorSessionController {
 
   @PostMapping("/consultation/sessions/{sessionId}/assign")
   public ResponseEntity<CounselorSessionResponse> assignSession(
-      @PathVariable Long sessionId, @RequestParam Long counselorId) {
-    return ResponseEntity.ok(counselorService.assignSession(counselorId, sessionId));
+      @PathVariable Long sessionId, @RequestParam Long counselorId, Authentication authentication) {
+    Long userId = AuthenticationUtils.getUserId(authentication);
+    return ResponseEntity.ok(counselorService.assignSession(counselorId, sessionId, userId));
   }
 
   @PostMapping("/consultation/sessions/{sessionId}/release")
   public ResponseEntity<CounselorSessionResponse> releaseSession(
-      @PathVariable Long sessionId, @RequestParam Long counselorId) {
-    return ResponseEntity.ok(counselorService.releaseSession(sessionId, counselorId));
+      @PathVariable Long sessionId, @RequestParam Long counselorId, Authentication authentication) {
+    Long userId = AuthenticationUtils.getUserId(authentication);
+    return ResponseEntity.ok(counselorService.releaseSession(sessionId, counselorId, userId));
   }
 
   @GetMapping("/workspaces/{workspaceId}/consultation/sessions")

--- a/backend/src/test/java/com/init/workflowruntime/application/ConsultationServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/ConsultationServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.init.shared.application.exception.BadRequestException;
@@ -40,6 +41,8 @@ import org.springframework.test.util.ReflectionTestUtils;
 @DisplayName("ConsultationService")
 class ConsultationServiceTest {
 
+  private static final Long USER_ID = 7L;
+
   @Mock private ChatSessionRepository chatSessionRepository;
   @Mock private ChatMessageRepository chatMessageRepository;
   @Mock private WorkspaceMemberRepository workspaceMemberRepository;
@@ -64,12 +67,11 @@ class ConsultationServiceTest {
   void should_returnActiveQueue_when_called() {
     ChatSession s1 = createSession(1L, ChatSessionStatus.OPEN);
     ChatSession s2 = createSession(2L, ChatSessionStatus.ACTIVE);
-    given(workspaceMemberRepository.findByWorkspaceIdAndUserId(1L, 7L))
-        .willReturn(Optional.of(WorkspaceMember.create(1L, 7L, WorkspaceMemberRole.OPERATOR)));
+    givenWorkspaceMember(1L, USER_ID);
     given(chatSessionRepository.findByWorkspaceIdAndStatusInOrderByStartedAtDesc(eq(1L), any()))
         .willReturn(List.of(s1, s2));
 
-    List<ChatSessionResponse> result = service.getActiveQueue(1L, 7L);
+    List<ChatSessionResponse> result = service.getActiveQueue(1L, USER_ID);
 
     assertThat(result).hasSize(2);
     assertThat(result.get(0).getId()).isEqualTo(1L);
@@ -79,21 +81,20 @@ class ConsultationServiceTest {
   @Test
   @DisplayName("getActiveQueue: 대기 세션 없음 → 빈 목록 반환")
   void should_returnEmptyList_when_noActiveQueue() {
-    given(workspaceMemberRepository.findByWorkspaceIdAndUserId(1L, 7L))
-        .willReturn(Optional.of(WorkspaceMember.create(1L, 7L, WorkspaceMemberRole.OPERATOR)));
+    givenWorkspaceMember(1L, USER_ID);
     given(chatSessionRepository.findByWorkspaceIdAndStatusInOrderByStartedAtDesc(eq(1L), any()))
         .willReturn(List.of());
 
-    assertThat(service.getActiveQueue(1L, 7L)).isEmpty();
+    assertThat(service.getActiveQueue(1L, USER_ID)).isEmpty();
   }
 
   @Test
   @DisplayName("getActiveQueue: 워크스페이스 멤버가 아니면 거부한다")
   void should_throwAccessDenied_when_queueRequesterIsNotWorkspaceMember() {
-    given(workspaceMemberRepository.findByWorkspaceIdAndUserId(1L, 7L))
+    given(workspaceMemberRepository.findByWorkspaceIdAndUserId(1L, USER_ID))
         .willReturn(Optional.empty());
 
-    assertThatThrownBy(() -> service.getActiveQueue(1L, 7L))
+    assertThatThrownBy(() -> service.getActiveQueue(1L, USER_ID))
         .isInstanceOf(WorkspaceAccessDeniedException.class);
   }
 
@@ -104,7 +105,7 @@ class ConsultationServiceTest {
     given(chatSessionRepository.findById(999L)).willReturn(Optional.empty());
 
     // when & then
-    assertThatThrownBy(() -> service.getMessages(999L))
+    assertThatThrownBy(() -> service.getMessages(999L, USER_ID))
         .isInstanceOf(NotFoundException.class)
         .hasMessageContaining("Session not found");
   }
@@ -115,13 +116,27 @@ class ConsultationServiceTest {
     // given
     ChatSession session = createSession(1L);
     given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+    givenWorkspaceMember(1L, USER_ID);
     given(chatMessageRepository.findByChatSessionIdOrderBySeqNoAsc(1L)).willReturn(List.of());
 
     // when
-    List<ChatMessageResponse> result = service.getMessages(1L);
+    List<ChatMessageResponse> result = service.getMessages(1L, USER_ID);
 
     // then
     assertThat(result).isEmpty();
+  }
+
+  @Test
+  @DisplayName("getMessages: 세션 워크스페이스 멤버가 아니면 거부한다")
+  void should_throwAccessDenied_when_messageRequesterIsNotWorkspaceMember() {
+    ChatSession session = createSession(1L);
+    given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+    given(workspaceMemberRepository.findByWorkspaceIdAndUserId(1L, USER_ID))
+        .willReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.getMessages(1L, USER_ID))
+        .isInstanceOf(WorkspaceAccessDeniedException.class);
+    verify(chatMessageRepository, never()).findByChatSessionIdOrderBySeqNoAsc(1L);
   }
 
   @Test
@@ -130,6 +145,7 @@ class ConsultationServiceTest {
     // given
     ChatSession session = createSession(1L);
     given(chatSessionRepository.findByIdForUpdate(1L)).willReturn(Optional.of(session));
+    givenWorkspaceMember(1L, USER_ID);
     given(chatMessageRepository.findTopByChatSessionIdOrderBySeqNoDesc(1L))
         .willReturn(Optional.empty());
 
@@ -141,7 +157,7 @@ class ConsultationServiceTest {
     request.setNote(false);
 
     // when
-    ChatMessageResponse result = service.sendMessage(1L, request);
+    ChatMessageResponse result = service.sendMessage(1L, request, USER_ID);
 
     // then
     assertThat(result.content()).isEqualTo("Hello");
@@ -151,14 +167,32 @@ class ConsultationServiceTest {
   }
 
   @Test
+  @DisplayName("sendMessage: 세션 워크스페이스 멤버가 아니면 메시지를 저장하지 않는다")
+  void should_throwAccessDenied_when_messageSenderIsNotWorkspaceMember() {
+    ChatSession session = createSession(1L);
+    given(chatSessionRepository.findByIdForUpdate(1L)).willReturn(Optional.of(session));
+    given(workspaceMemberRepository.findByWorkspaceIdAndUserId(1L, USER_ID))
+        .willReturn(Optional.empty());
+
+    SendMessageRequest request = new SendMessageRequest();
+    request.setContent("Hello");
+    request.setNote(false);
+
+    assertThatThrownBy(() -> service.sendMessage(1L, request, USER_ID))
+        .isInstanceOf(WorkspaceAccessDeniedException.class);
+    verify(chatMessageRepository, never()).save(any());
+  }
+
+  @Test
   @DisplayName("updateSessionStatus: COMPLETED → closeSession 호출 후 응답 반환")
   void should_세션응답반환_when_COMPLETED상태로변경() {
     // given
     ChatSession session = createSession(1L, ChatSessionStatus.ACTIVE);
     given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+    givenWorkspaceMember(1L, USER_ID);
 
     // when
-    ChatSessionResponse result = service.updateSessionStatus(1L, "COMPLETED");
+    ChatSessionResponse result = service.updateSessionStatus(1L, "COMPLETED", USER_ID);
 
     // then
     assertThat(result).isNotNull();
@@ -176,12 +210,13 @@ class ConsultationServiceTest {
   void should_recordResolutionMetadata_when_resolutionOutcomeExists() {
     ChatSession session = createSession(1L, ChatSessionStatus.ACTIVE);
     given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+    givenWorkspaceMember(1L, USER_ID);
     UpdateStatusRequest request = new UpdateStatusRequest();
     request.setStatus("RESOLVED");
     request.setResolutionOutcome("FOLLOW_UP_REQUIRED");
     request.setResolutionReason("배송사 확인 필요");
 
-    ChatSessionResponse result = service.updateSessionStatus(1L, request);
+    ChatSessionResponse result = service.updateSessionStatus(1L, request, USER_ID);
 
     assertThat(result.getStatus()).isEqualTo("RESOLVED");
     verify(chatSessionMetadataService)
@@ -193,12 +228,28 @@ class ConsultationServiceTest {
   void should_throwBadRequest_when_unknownResolutionOutcome() {
     ChatSession session = createSession(1L, ChatSessionStatus.ACTIVE);
     given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+    givenWorkspaceMember(1L, USER_ID);
     UpdateStatusRequest request = new UpdateStatusRequest();
     request.setStatus("RESOLVED");
     request.setResolutionOutcome("UNKNOWN_OUTCOME");
 
-    assertThatThrownBy(() -> service.updateSessionStatus(1L, request))
+    assertThatThrownBy(() -> service.updateSessionStatus(1L, request, USER_ID))
         .isInstanceOf(BadRequestException.class);
+  }
+
+  @Test
+  @DisplayName("updateSessionStatus: 세션 워크스페이스 멤버가 아니면 상태를 변경하지 않는다")
+  void should_throwAccessDenied_when_statusRequesterIsNotWorkspaceMember() {
+    ChatSession session = createSession(1L, ChatSessionStatus.ACTIVE);
+    given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+    given(workspaceMemberRepository.findByWorkspaceIdAndUserId(1L, USER_ID))
+        .willReturn(Optional.empty());
+    UpdateStatusRequest request = new UpdateStatusRequest();
+    request.setStatus("COMPLETED");
+
+    assertThatThrownBy(() -> service.updateSessionStatus(1L, request, USER_ID))
+        .isInstanceOf(WorkspaceAccessDeniedException.class);
+    assertThat(session.getStatus()).isEqualTo(ChatSessionStatus.ACTIVE);
   }
 
   @Test
@@ -207,9 +258,10 @@ class ConsultationServiceTest {
     // given
     ChatSession session = createSession(1L);
     given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+    givenWorkspaceMember(1L, USER_ID);
 
     // when & then
-    assertThatThrownBy(() -> service.updateSessionStatus(1L, "INVALID_STATUS"))
+    assertThatThrownBy(() -> service.updateSessionStatus(1L, "INVALID_STATUS", USER_ID))
         .isInstanceOf(BadRequestException.class);
   }
 
@@ -229,5 +281,11 @@ class ConsultationServiceTest {
     ChatMessage msg = ChatMessage.create(sessionId, seqNo, role, "TEXT", content);
     ReflectionTestUtils.setField(msg, "id", 1L);
     return msg;
+  }
+
+  private void givenWorkspaceMember(Long workspaceId, Long userId) {
+    given(workspaceMemberRepository.findByWorkspaceIdAndUserId(workspaceId, userId))
+        .willReturn(
+            Optional.of(WorkspaceMember.create(workspaceId, userId, WorkspaceMemberRole.OPERATOR)));
   }
 }

--- a/backend/src/test/java/com/init/workflowruntime/application/CounselorServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/CounselorServiceTest.java
@@ -24,6 +24,10 @@ import com.init.workflowruntime.domain.InvalidSessionStateException;
 import com.init.workflowruntime.domain.event.ConsultationQueueChangedEvent;
 import com.init.workflowruntime.domain.event.ConsultationQueueEventType;
 import com.init.workflowruntime.domain.event.SessionAssignedEvent;
+import com.init.workspace.application.exception.WorkspaceAccessDeniedException;
+import com.init.workspace.domain.model.WorkspaceMember;
+import com.init.workspace.domain.model.WorkspaceMemberRole;
+import com.init.workspace.domain.repository.WorkspaceMemberRepository;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -45,11 +49,14 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 @DisplayName("CounselorService")
 class CounselorServiceTest {
 
+  private static final Long USER_ID = 7L;
+
   @Mock private ChatSessionRepository chatSessionRepository;
   @Mock private ChatMessageRepository chatMessageRepository;
   @Mock private SimpMessagingTemplate messagingTemplate;
   @Mock private ApplicationEventPublisher eventPublisher;
   @Mock private ChatSessionMetadataService chatSessionMetadataService;
+  @Mock private WorkspaceMemberRepository workspaceMemberRepository;
 
   private CounselorService service;
 
@@ -61,7 +68,8 @@ class CounselorServiceTest {
             chatMessageRepository,
             messagingTemplate,
             eventPublisher,
-            chatSessionMetadataService);
+            chatSessionMetadataService,
+            workspaceMemberRepository);
   }
 
   // ── assignSession ─────────────────────────────────────────────────────────
@@ -71,8 +79,9 @@ class CounselorServiceTest {
   void should_assignSession_when_sessionOpen() {
     ChatSession session = createSession(1L, ChatSessionStatus.OPEN);
     given(chatSessionRepository.findByIdForUpdate(1L)).willReturn(Optional.of(session));
+    givenWorkspaceMember(1L, USER_ID);
 
-    CounselorSessionResponse result = service.assignSession(42L, 1L);
+    CounselorSessionResponse result = service.assignSession(42L, 1L, USER_ID);
 
     assertThat(result.getStatus()).isEqualTo("ACTIVE");
     assertThat(result.getAssignedCounselorId()).isEqualTo(42L);
@@ -86,7 +95,7 @@ class CounselorServiceTest {
   void should_throwNotFoundException_when_sessionNotFound() {
     given(chatSessionRepository.findByIdForUpdate(999L)).willReturn(Optional.empty());
 
-    assertThatThrownBy(() -> service.assignSession(1L, 999L))
+    assertThatThrownBy(() -> service.assignSession(1L, 999L, USER_ID))
         .isInstanceOf(NotFoundException.class)
         .hasMessageContaining("Session not found: 999");
   }
@@ -97,8 +106,9 @@ class CounselorServiceTest {
     ChatSession session = createSession(1L, ChatSessionStatus.OPEN);
     ReflectionTestUtils.setField(session, "assignedCounselorId", 10L);
     given(chatSessionRepository.findByIdForUpdate(1L)).willReturn(Optional.of(session));
+    givenWorkspaceMember(1L, USER_ID);
 
-    assertThatThrownBy(() -> service.assignSession(42L, 1L))
+    assertThatThrownBy(() -> service.assignSession(42L, 1L, USER_ID))
         .isInstanceOf(InvalidSessionStateException.class)
         .hasMessageContaining("already assigned");
   }
@@ -108,10 +118,24 @@ class CounselorServiceTest {
   void should_throwInvalidState_when_notOpen() {
     ChatSession session = createSession(1L, ChatSessionStatus.COMPLETED);
     given(chatSessionRepository.findByIdForUpdate(1L)).willReturn(Optional.of(session));
+    givenWorkspaceMember(1L, USER_ID);
 
-    assertThatThrownBy(() -> service.assignSession(42L, 1L))
+    assertThatThrownBy(() -> service.assignSession(42L, 1L, USER_ID))
         .isInstanceOf(com.init.workflowruntime.domain.InvalidSessionStateException.class)
         .hasMessageContaining("requires status OPEN");
+  }
+
+  @Test
+  @DisplayName("assignSession: 세션 워크스페이스 멤버가 아니면 배정하지 않는다")
+  void should_throwAccessDenied_when_assignRequesterIsNotWorkspaceMember() {
+    ChatSession session = createSession(1L, ChatSessionStatus.OPEN);
+    given(chatSessionRepository.findByIdForUpdate(1L)).willReturn(Optional.of(session));
+    given(workspaceMemberRepository.findByWorkspaceIdAndUserId(1L, USER_ID))
+        .willReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.assignSession(42L, 1L, USER_ID))
+        .isInstanceOf(WorkspaceAccessDeniedException.class);
+    assertThat(session.getStatus()).isEqualTo(ChatSessionStatus.OPEN);
   }
 
   // ── releaseSession ────────────────────────────────────────────────────────
@@ -122,8 +146,9 @@ class CounselorServiceTest {
     ChatSession session = createSession(1L, ChatSessionStatus.ACTIVE);
     ReflectionTestUtils.setField(session, "assignedCounselorId", 42L);
     given(chatSessionRepository.findByIdForUpdate(1L)).willReturn(Optional.of(session));
+    givenWorkspaceMember(1L, USER_ID);
 
-    CounselorSessionResponse result = service.releaseSession(1L, 42L);
+    CounselorSessionResponse result = service.releaseSession(1L, 42L, USER_ID);
 
     assertThat(result.getStatus()).isEqualTo("OPEN");
     assertThat(result.getAssignedCounselorId()).isNull();
@@ -137,8 +162,9 @@ class CounselorServiceTest {
     ChatSession session = createSession(1L, ChatSessionStatus.ACTIVE);
     ReflectionTestUtils.setField(session, "assignedCounselorId", 42L);
     given(chatSessionRepository.findByIdForUpdate(1L)).willReturn(Optional.of(session));
+    givenWorkspaceMember(1L, USER_ID);
 
-    assertThatThrownBy(() -> service.releaseSession(1L, 99L))
+    assertThatThrownBy(() -> service.releaseSession(1L, 99L, USER_ID))
         .isInstanceOf(BadRequestException.class)
         .hasMessageContaining("not assigned to counselor");
   }
@@ -148,10 +174,25 @@ class CounselorServiceTest {
   void should_throwBadRequest_when_notAssignedToRelease() {
     ChatSession session = createSession(1L, ChatSessionStatus.OPEN);
     given(chatSessionRepository.findByIdForUpdate(1L)).willReturn(Optional.of(session));
+    givenWorkspaceMember(1L, USER_ID);
 
-    assertThatThrownBy(() -> service.releaseSession(1L, 42L))
+    assertThatThrownBy(() -> service.releaseSession(1L, 42L, USER_ID))
         .isInstanceOf(BadRequestException.class)
         .hasMessageContaining("not assigned to counselor");
+  }
+
+  @Test
+  @DisplayName("releaseSession: 세션 워크스페이스 멤버가 아니면 해제하지 않는다")
+  void should_throwAccessDenied_when_releaseRequesterIsNotWorkspaceMember() {
+    ChatSession session = createSession(1L, ChatSessionStatus.ACTIVE);
+    ReflectionTestUtils.setField(session, "assignedCounselorId", 42L);
+    given(chatSessionRepository.findByIdForUpdate(1L)).willReturn(Optional.of(session));
+    given(workspaceMemberRepository.findByWorkspaceIdAndUserId(1L, USER_ID))
+        .willReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.releaseSession(1L, 42L, USER_ID))
+        .isInstanceOf(WorkspaceAccessDeniedException.class);
+    assertThat(session.getStatus()).isEqualTo(ChatSessionStatus.ACTIVE);
   }
 
   // ── isSessionAssigned ─────────────────────────────────────────────────────
@@ -367,5 +408,11 @@ class CounselorServiceTest {
               assertThat(queueEvent.sessionId()).isEqualTo(sessionId);
               assertThat(queueEvent.type()).isEqualTo(type);
             });
+  }
+
+  private void givenWorkspaceMember(Long workspaceId, Long userId) {
+    given(workspaceMemberRepository.findByWorkspaceIdAndUserId(workspaceId, userId))
+        .willReturn(
+            Optional.of(WorkspaceMember.create(workspaceId, userId, WorkspaceMemberRole.OPERATOR)));
   }
 }

--- a/backend/src/test/java/com/init/workflowruntime/application/LlmToolServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/LlmToolServiceTest.java
@@ -52,6 +52,10 @@ import com.init.workflowruntime.domain.WorkflowExecutionRepository;
 import com.init.workflowruntime.domain.WorkflowExecutionStep;
 import com.init.workflowruntime.domain.WorkflowExecutionStepActionType;
 import com.init.workflowruntime.domain.WorkflowExecutionStepRepository;
+import com.init.workspace.application.exception.WorkspaceAccessDeniedException;
+import com.init.workspace.domain.model.WorkspaceMember;
+import com.init.workspace.domain.model.WorkspaceMemberRole;
+import com.init.workspace.domain.repository.WorkspaceMemberRepository;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -80,6 +84,7 @@ class LlmToolServiceTest {
   @Mock private WorkflowPolicyRuntimeService workflowPolicyRuntimeService;
   @Mock private DecisionLogRepository decisionLogRepository;
   @Mock private WorkflowExecutionStepRepository workflowExecutionStepRepository;
+  @Mock private WorkspaceMemberRepository workspaceMemberRepository;
 
   private ObjectMapper objectMapper;
   private LlmToolService service;
@@ -99,7 +104,40 @@ class LlmToolServiceTest {
             workflowPolicyRuntimeService,
             decisionLogRepository,
             workflowExecutionStepRepository,
-            objectMapper);
+            objectMapper,
+            workspaceMemberRepository);
+  }
+
+  @Test
+  @DisplayName("getCurrentWorkflowForOperator: 세션 워크스페이스 멤버면 워크플로우를 조회한다")
+  void should_returnCurrentWorkflow_when_operatorIsWorkspaceMember() {
+    ChatSession session = createSession(1L, 10L, 101L);
+    given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+    given(workspaceMemberRepository.findByWorkspaceIdAndUserId(10L, 7L))
+        .willReturn(Optional.of(WorkspaceMember.create(10L, 7L, WorkspaceMemberRole.OPERATOR)));
+    given(workflowExecutionRepository.findTopByChatSessionIdOrderByStartedAtDescIdDesc(1L))
+        .willReturn(Optional.empty());
+
+    LlmToolWorkflowResponse result =
+        service.getCurrentWorkflowForOperator(new GetCurrentWorkflowCommand(1L), 7L);
+
+    assertThat(result.sessionId()).isEqualTo(1L);
+    assertThat(result.workspaceId()).isEqualTo(10L);
+  }
+
+  @Test
+  @DisplayName("getCurrentWorkflowForOperator: 세션 워크스페이스 멤버가 아니면 거부한다")
+  void should_throwAccessDenied_when_operatorIsNotWorkspaceMember() {
+    ChatSession session = createSession(1L, 10L, 101L);
+    given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+    given(workspaceMemberRepository.findByWorkspaceIdAndUserId(10L, 7L))
+        .willReturn(Optional.empty());
+
+    assertThatThrownBy(
+            () -> service.getCurrentWorkflowForOperator(new GetCurrentWorkflowCommand(1L), 7L))
+        .isInstanceOf(WorkspaceAccessDeniedException.class);
+    verify(workflowExecutionRepository, never())
+        .findTopByChatSessionIdOrderByStartedAtDescIdDesc(1L);
   }
 
   @Test

--- a/backend/src/test/java/com/init/workflowruntime/presentation/ConsultationControllerTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/presentation/ConsultationControllerTest.java
@@ -24,6 +24,7 @@ import com.init.workflowruntime.application.dto.ChatSessionResponse;
 import com.init.workflowruntime.application.dto.LlmToolWorkflowResponse;
 import com.init.workflowruntime.application.dto.SendMessageRequest;
 import com.init.workflowruntime.application.dto.UpdateStatusRequest;
+import com.init.workspace.application.exception.WorkspaceAccessDeniedException;
 import java.time.OffsetDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -36,6 +37,8 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(
@@ -67,11 +70,11 @@ class ConsultationControllerTest {
     ChatMessageResponse msg =
         new ChatMessageResponse(1L, 1, "CUSTOMER", "TEXT", "Hello", OffsetDateTime.now());
 
-    given(consultationService.getMessages(1L)).willReturn(List.of(msg));
+    given(consultationService.getMessages(1L, 7L)).willReturn(List.of(msg));
 
     // when & then
     mockMvc
-        .perform(get("/api/v1/consultation/sessions/1/messages"))
+        .perform(get("/api/v1/consultation/sessions/1/messages").principal(auth()))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$[0].content").value("Hello"));
   }
@@ -87,7 +90,7 @@ class ConsultationControllerTest {
     ChatMessageResponse response =
         new ChatMessageResponse(10L, 1, "AGENT", "TEXT", "Hello Operator", OffsetDateTime.now());
 
-    given(consultationService.sendMessage(eq(1L), any(SendMessageRequest.class)))
+    given(consultationService.sendMessage(eq(1L), any(SendMessageRequest.class), eq(7L)))
         .willReturn(response);
 
     // when & then
@@ -98,7 +101,8 @@ class ConsultationControllerTest {
         .perform(
             post("/api/v1/consultation/sessions/1/messages")
                 .contentType(contentType)
-                .content(content))
+                .content(content)
+                .principal(auth()))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.content").value("Hello Operator"))
         .andExpect(jsonPath("$.senderRole").value("AGENT"));
@@ -118,7 +122,7 @@ class ConsultationControllerTest {
     response.setId(1L);
     response.setStatus("COMPLETED");
 
-    given(consultationService.updateSessionStatus(eq(1L), any(UpdateStatusRequest.class)))
+    given(consultationService.updateSessionStatus(eq(1L), any(UpdateStatusRequest.class), eq(7L)))
         .willReturn(response);
 
     // when & then
@@ -129,12 +133,13 @@ class ConsultationControllerTest {
         .perform(
             patch("/api/v1/consultation/sessions/1/status")
                 .contentType(contentType)
-                .content(content))
+                .content(content)
+                .principal(auth()))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.status").value("COMPLETED"));
     ArgumentCaptor<UpdateStatusRequest> requestCaptor =
         ArgumentCaptor.forClass(UpdateStatusRequest.class);
-    verify(consultationService).updateSessionStatus(eq(1L), requestCaptor.capture());
+    verify(consultationService).updateSessionStatus(eq(1L), requestCaptor.capture(), eq(7L));
     UpdateStatusRequest capturedRequest = requestCaptor.getValue();
     assertThat(capturedRequest.getStatus()).isEqualTo("COMPLETED");
     assertThat(capturedRequest.getResolutionOutcome()).isEqualTo("CUSTOMER_LEFT");
@@ -154,7 +159,8 @@ class ConsultationControllerTest {
         .perform(
             post("/api/v1/consultation/sessions/1/messages")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request)))
+                .content(objectMapper.writeValueAsString(request))
+                .principal(auth()))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
         .andExpect(jsonPath("$.errors").isArray())
@@ -162,17 +168,48 @@ class ConsultationControllerTest {
   }
 
   @Test
+  @DisplayName("POST /api/v1/consultation/sessions/{id}/messages - 비멤버 → 403")
+  void should_403반환_when_메시지전송_워크스페이스비멤버() throws Exception {
+    SendMessageRequest request = new SendMessageRequest();
+    request.setContent("Reply");
+    request.setNote(false);
+    given(consultationService.sendMessage(eq(1L), any(SendMessageRequest.class), eq(7L)))
+        .willThrow(new WorkspaceAccessDeniedException("워크스페이스에 접근 권한이 없습니다."));
+
+    mockMvc
+        .perform(
+            post("/api/v1/consultation/sessions/1/messages")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                .principal(auth()))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.code").value("WORKSPACE_ACCESS_DENIED"));
+  }
+
+  @Test
   @DisplayName("GET /api/v1/consultation/sessions/{id}/messages - 세션 없음 → 404 Not Found")
   void should_404반환_when_세션없음() throws Exception {
     // given
-    given(consultationService.getMessages(999L))
+    given(consultationService.getMessages(999L, 7L))
         .willThrow(new NotFoundException("SESSION_NOT_FOUND", "Session not found: 999"));
 
     // when & then
     mockMvc
-        .perform(get("/api/v1/consultation/sessions/999/messages"))
+        .perform(get("/api/v1/consultation/sessions/999/messages").principal(auth()))
         .andExpect(status().isNotFound())
         .andExpect(jsonPath("$.code").value("SESSION_NOT_FOUND"));
+  }
+
+  @Test
+  @DisplayName("GET /api/v1/consultation/sessions/{id}/messages - 비멤버 → 403")
+  void should_403반환_when_메시지조회_워크스페이스비멤버() throws Exception {
+    given(consultationService.getMessages(1L, 7L))
+        .willThrow(new WorkspaceAccessDeniedException("워크스페이스에 접근 권한이 없습니다."));
+
+    mockMvc
+        .perform(get("/api/v1/consultation/sessions/1/messages").principal(auth()))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.code").value("WORKSPACE_ACCESS_DENIED"));
   }
 
   @Test
@@ -196,12 +233,12 @@ class ConsultationControllerTest {
             "collect_slots",
             objectMapper.readTree("[\"refund_granted\"]"));
 
-    given(llmToolService.getCurrentWorkflow(new GetCurrentWorkflowCommand(1L)))
+    given(llmToolService.getCurrentWorkflowForOperator(new GetCurrentWorkflowCommand(1L), 7L))
         .willReturn(response);
 
     // when & then
     mockMvc
-        .perform(get("/api/v1/consultation/sessions/1/matched-workflow"))
+        .perform(get("/api/v1/consultation/sessions/1/matched-workflow").principal(auth()))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.sessionId").value(1))
         .andExpect(jsonPath("$.domainPackId").value(42))
@@ -216,14 +253,14 @@ class ConsultationControllerTest {
       "GET /api/v1/consultation/sessions/{id}/matched-workflow - execution 없으면 200 + null 필드")
   void should_매칭워크플로우_null응답_when_execution없음() throws Exception {
     // given
-    given(llmToolService.getCurrentWorkflow(new GetCurrentWorkflowCommand(1L)))
+    given(llmToolService.getCurrentWorkflowForOperator(new GetCurrentWorkflowCommand(1L), 7L))
         .willReturn(
             new LlmToolWorkflowResponse(
                 1L, 10L, 42L, 101L, null, null, null, null, null, null, null, null, null, null));
 
     // when & then
     mockMvc
-        .perform(get("/api/v1/consultation/sessions/1/matched-workflow"))
+        .perform(get("/api/v1/consultation/sessions/1/matched-workflow").principal(auth()))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.sessionId").value(1))
         .andExpect(jsonPath("$.domainPackId").value(42))
@@ -235,14 +272,44 @@ class ConsultationControllerTest {
   @DisplayName("GET /api/v1/consultation/sessions/{id}/matched-workflow - 세션 없음 → 404")
   void should_404반환_when_매칭워크플로우_세션없음() throws Exception {
     // given
-    given(llmToolService.getCurrentWorkflow(new GetCurrentWorkflowCommand(999L)))
+    given(llmToolService.getCurrentWorkflowForOperator(new GetCurrentWorkflowCommand(999L), 7L))
         .willThrow(new NotFoundException("SESSION_NOT_FOUND", "Session not found: 999"));
 
     // when & then
     mockMvc
-        .perform(get("/api/v1/consultation/sessions/999/matched-workflow"))
+        .perform(get("/api/v1/consultation/sessions/999/matched-workflow").principal(auth()))
         .andExpect(status().isNotFound())
         .andExpect(jsonPath("$.code").value("SESSION_NOT_FOUND"));
+  }
+
+  @Test
+  @DisplayName("GET /api/v1/consultation/sessions/{id}/matched-workflow - 비멤버 → 403")
+  void should_403반환_when_매칭워크플로우_워크스페이스비멤버() throws Exception {
+    given(llmToolService.getCurrentWorkflowForOperator(new GetCurrentWorkflowCommand(1L), 7L))
+        .willThrow(new WorkspaceAccessDeniedException("워크스페이스에 접근 권한이 없습니다."));
+
+    mockMvc
+        .perform(get("/api/v1/consultation/sessions/1/matched-workflow").principal(auth()))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.code").value("WORKSPACE_ACCESS_DENIED"));
+  }
+
+  @Test
+  @DisplayName("PATCH /api/v1/consultation/sessions/{id}/status - 비멤버 → 403")
+  void should_403반환_when_상태변경_워크스페이스비멤버() throws Exception {
+    UpdateStatusRequest request = new UpdateStatusRequest();
+    request.setStatus("COMPLETED");
+    given(consultationService.updateSessionStatus(eq(1L), any(UpdateStatusRequest.class), eq(7L)))
+        .willThrow(new WorkspaceAccessDeniedException("워크스페이스에 접근 권한이 없습니다."));
+
+    mockMvc
+        .perform(
+            patch("/api/v1/consultation/sessions/1/status")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                .principal(auth()))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.code").value("WORKSPACE_ACCESS_DENIED"));
   }
 
   @Test
@@ -254,15 +321,21 @@ class ConsultationControllerTest {
 
     willThrow(new BadRequestException("UNSUPPORTED_STATUS", "Unsupported status: INVALID_STATUS"))
         .given(consultationService)
-        .updateSessionStatus(eq(1L), any(UpdateStatusRequest.class));
+        .updateSessionStatus(eq(1L), any(UpdateStatusRequest.class), eq(7L));
 
     // when & then
     mockMvc
         .perform(
             patch("/api/v1/consultation/sessions/1/status")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request)))
+                .content(objectMapper.writeValueAsString(request))
+                .principal(auth()))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.code").value("UNSUPPORTED_STATUS"));
+  }
+
+  private UsernamePasswordAuthenticationToken auth() {
+    return new UsernamePasswordAuthenticationToken(
+        7L, null, List.of(new SimpleGrantedAuthority("ROLE_OPERATOR")));
   }
 }

--- a/backend/src/test/java/com/init/workflowruntime/presentation/CounselorSessionControllerTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/presentation/CounselorSessionControllerTest.java
@@ -13,6 +13,7 @@ import com.init.shared.application.exception.NotFoundException;
 import com.init.shared.infrastructure.security.JwtAuthenticationFilter;
 import com.init.workflowruntime.application.CounselorService;
 import com.init.workflowruntime.application.dto.CounselorSessionResponse;
+import com.init.workspace.application.exception.WorkspaceAccessDeniedException;
 import java.time.OffsetDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -23,6 +24,8 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(
@@ -50,10 +53,13 @@ class CounselorSessionControllerTest {
     response.setChannel("WEB");
     response.setStartedAt(OffsetDateTime.now());
 
-    given(counselorService.assignSession(eq(42L), eq(1L))).willReturn(response);
+    given(counselorService.assignSession(eq(42L), eq(1L), eq(7L))).willReturn(response);
 
     mockMvc
-        .perform(post("/api/v1/consultation/sessions/1/assign").param("counselorId", "42"))
+        .perform(
+            post("/api/v1/consultation/sessions/1/assign")
+                .param("counselorId", "42")
+                .principal(auth()))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.id").value(1))
         .andExpect(jsonPath("$.status").value("ACTIVE"))
@@ -63,11 +69,14 @@ class CounselorSessionControllerTest {
   @Test
   @DisplayName("POST /api/v1/consultation/sessions/{id}/assign - 세션 없음 → 404")
   void should_return404_when_sessionNotFound() throws Exception {
-    given(counselorService.assignSession(eq(1L), eq(999L)))
+    given(counselorService.assignSession(eq(1L), eq(999L), eq(7L)))
         .willThrow(new NotFoundException("SESSION_NOT_FOUND", "Session not found: 999"));
 
     mockMvc
-        .perform(post("/api/v1/consultation/sessions/999/assign").param("counselorId", "1"))
+        .perform(
+            post("/api/v1/consultation/sessions/999/assign")
+                .param("counselorId", "1")
+                .principal(auth()))
         .andExpect(status().isNotFound())
         .andExpect(jsonPath("$.code").value("SESSION_NOT_FOUND"));
   }
@@ -75,11 +84,14 @@ class CounselorSessionControllerTest {
   @Test
   @DisplayName("POST /api/v1/consultation/sessions/{id}/assign - 이미 배정됨 → 400")
   void should_return400_when_alreadyAssigned() throws Exception {
-    given(counselorService.assignSession(eq(1L), eq(999L)))
+    given(counselorService.assignSession(eq(1L), eq(999L), eq(7L)))
         .willThrow(new BadRequestException("ALREADY_ASSIGNED", "Session already assigned"));
 
     mockMvc
-        .perform(post("/api/v1/consultation/sessions/999/assign").param("counselorId", "1"))
+        .perform(
+            post("/api/v1/consultation/sessions/999/assign")
+                .param("counselorId", "1")
+                .principal(auth()))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.code").value("ALREADY_ASSIGNED"));
   }
@@ -92,12 +104,45 @@ class CounselorSessionControllerTest {
     response.setStatus("OPEN");
     response.setAssignedCounselorId(null);
 
-    given(counselorService.releaseSession(eq(1L), eq(42L))).willReturn(response);
+    given(counselorService.releaseSession(eq(1L), eq(42L), eq(7L))).willReturn(response);
 
     mockMvc
-        .perform(post("/api/v1/consultation/sessions/1/release").param("counselorId", "42"))
+        .perform(
+            post("/api/v1/consultation/sessions/1/release")
+                .param("counselorId", "42")
+                .principal(auth()))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.status").value("OPEN"));
+  }
+
+  @Test
+  @DisplayName("POST /api/v1/consultation/sessions/{id}/assign - 비멤버 → 403")
+  void should_return403_when_assignRequesterIsNotWorkspaceMember() throws Exception {
+    given(counselorService.assignSession(eq(42L), eq(1L), eq(7L)))
+        .willThrow(new WorkspaceAccessDeniedException("워크스페이스에 접근 권한이 없습니다."));
+
+    mockMvc
+        .perform(
+            post("/api/v1/consultation/sessions/1/assign")
+                .param("counselorId", "42")
+                .principal(auth()))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.code").value("WORKSPACE_ACCESS_DENIED"));
+  }
+
+  @Test
+  @DisplayName("POST /api/v1/consultation/sessions/{id}/release - 비멤버 → 403")
+  void should_return403_when_releaseRequesterIsNotWorkspaceMember() throws Exception {
+    given(counselorService.releaseSession(eq(1L), eq(42L), eq(7L)))
+        .willThrow(new WorkspaceAccessDeniedException("워크스페이스에 접근 권한이 없습니다."));
+
+    mockMvc
+        .perform(
+            post("/api/v1/consultation/sessions/1/release")
+                .param("counselorId", "42")
+                .principal(auth()))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.code").value("WORKSPACE_ACCESS_DENIED"));
   }
 
   @Test
@@ -147,5 +192,10 @@ class CounselorSessionControllerTest {
                 .param("size", "20"))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.code").value("UNSUPPORTED_STATUS"));
+  }
+
+  private UsernamePasswordAuthenticationToken auth() {
+    return new UsernamePasswordAuthenticationToken(
+        7L, null, List.of(new SimpleGrantedAuthority("ROLE_OPERATOR")));
   }
 }


### PR DESCRIPTION
## Summary
- sessionId 기반 상담 REST API에서 세션의 workspaceId와 인증 사용자의 workspace membership을 검증합니다.
- 메시지 조회/전송, 상태 변경, 매칭 워크플로우 조회, 상담 세션 배정/해제가 비멤버 접근 시 `WORKSPACE_ACCESS_DENIED` 403을 반환하도록 했습니다.
- 이슈 기준과 검증 범위를 `.agent/specs/359.md`에 정리하고 관련 service/controller 테스트를 보강했습니다.

## Validation
- `git diff --check`

## Notes
- `./gradlew test --tests com.init.workflowruntime.application.ConsultationServiceTest --tests com.init.workflowruntime.application.CounselorServiceTest --tests com.init.workflowruntime.application.LlmToolServiceTest --tests com.init.workflowruntime.presentation.ConsultationControllerTest --tests com.init.workflowruntime.presentation.CounselorSessionControllerTest`는 로컬 Java runtime/Java 21 toolchain 부재로 실행 전 실패했습니다.

Closes #359