### PR TITLE
feat(consultation): 매칭 워크플로우 답변 초안 삽입 제공

### DIFF
--- a/.agent/specs/353.md
+++ b/.agent/specs/353.md
@@ -1,0 +1,145 @@
+# Frontend/Backend Spec: 매칭 워크플로우 기반 답변 초안 삽입
+
+## Goal
+
+매칭된 워크플로우가 있는 상담 세션에서 상담사가 워크플로우 맥락 기반 답변 초안을 입력창에 삽입하고, 직접 편집한 뒤 수동으로 전송할 수 있게 한다.
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A[상담사가 상담 세션 선택] --> B{매칭 워크플로우 있음?}
+    B -->|No| C[초안 삽입 액션 숨김 또는 비활성화]
+    B -->|Yes| D[워크플로우 바와 입력 영역 액션 표시]
+    D --> E[상담사가 답변 초안 삽입 클릭]
+    E --> F{초안 생성 성공?}
+    F -->|Yes| G[상담 입력창에 초안 삽입]
+    G --> H[상담사가 편집]
+    H --> I[상담사가 직접 전송]
+    F -->|No| J[입력창 기존 내용 유지]
+    J --> K[toast 또는 인라인 안내 표시]
+```
+
+## Problem
+
+현재 `MatchedWorkflowBar`는 매칭된 워크플로우 정보를 보여주고 상세 화면으로 이동할 수 있지만, 상담사가 실제 응대 문장을 작성하는 입력창으로 워크플로우 맥락을 연결하지 않는다. 기존 하드코딩 추천 답변 strip은 제거되어 있어 상담사가 워크플로우 내용을 읽고 직접 문장화해야 한다.
+
+## Scope
+
+- 상담 세션에 매칭 워크플로우가 있을 때 답변 초안 삽입 액션을 제공한다.
+- 현재 워크플로우 상태가 추가 정보를 요구하는 단계라면 삽입되는 초안은 상담사가 보낼 다음 질문 형태가 될 수 있다.
+- 초안은 상담 입력창에만 채워지며 자동 전송하지 않는다.
+- 상담사는 삽입된 초안을 편집한 뒤 기존 전송 흐름으로 직접 전송한다.
+- 초안 생성 실패 시 입력창의 기존 내용을 변경하지 않고 오류 안내를 표시한다.
+- 매칭 워크플로우가 없는 세션에서는 삽입 액션을 숨기거나 비활성화한다.
+- 백엔드는 상담사 검토용 draft response API를 자동 채팅 응답 저장 흐름과 분리해 제공한다.
+
+## Non-goals
+
+- 고객에게 자동으로 메시지를 전송하지 않는다.
+- 기존 자동 LLM 응답 생성 이벤트 흐름을 대체하지 않는다.
+- 워크플로우 실행 상태를 초안 생성만으로 진행시키지 않는다.
+- #323의 매칭 근거 표시 범위를 확장하지 않는다.
+- 새로운 데이터베이스 테이블이나 영속 이력 저장을 추가하지 않는다.
+
+## Design Diff
+
+| 영역 | As-is | To-be | 변경 내용 |
+|------|-------|-------|----------|
+| 워크플로우 연결 | `MatchedWorkflowBar`에서 정보 확인/상세 이동 | 입력창 초안 삽입 액션 제공 | 매칭된 워크플로우를 응대 작성 행동으로 연결 |
+| 전송 방식 | 상담사가 직접 문장 작성 후 전송 | 초안 삽입 후 상담사가 편집/전송 | 자동 전송 없이 입력 보조만 수행 |
+| 실패 처리 | 초안 생성 흐름 없음 | 실패 시 기존 입력 유지 및 안내 | 입력 손실 방지 |
+| 백엔드 API | 사용자 자동응답 흐름 중심 | 상담사 draft response API 분리 | 메시지 저장과 워크플로우 진행 없이 초안만 반환 |
+
+## Affected Modules
+
+### Frontend
+
+- `frontend/src/pages/consultation/ui/ConsultationPage.tsx`
+- `frontend/src/pages/consultation/ui/sections/MatchedWorkflowBar.tsx`
+- `frontend/src/features/consultation/ui/ChatPanel.tsx`
+- `frontend/src/features/consultation/api/consultationApi.ts`
+
+### Backend
+
+- `backend/src/main/java/com/init/workflowruntime/presentation/ConsultationController.java`
+- `backend/src/main/java/com/init/workflowruntime/application/CounselorDraftResponseService.java`
+- `backend/src/main/java/com/init/workflowruntime/application/command/GenerateDraftResponseCommand.java`
+- `backend/src/main/java/com/init/workflowruntime/application/LlmAssistantService.java`
+- `backend/src/main/java/com/init/workflowruntime/application/dto/GenerateWorkflowAwareResponseResult.java`
+
+## Component Tree
+
+```text
+ConsultationPage
+├─ MatchedWorkflowBar
+│  └─ Matched workflow visibility source
+└─ ChatPanel
+   ├─ Input textarea
+   ├─ Draft insertion action state
+   └─ Send button
+```
+
+## API Integration
+
+### New Endpoint
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/api/v1/consultation/sessions/{sessionId}/draft-response` | 현재 상담 세션과 매칭 워크플로우 맥락을 기반으로 상담사 입력창에 삽입할 답변 초안을 생성한다. |
+
+### Response Shape
+
+```json
+{
+  "content": "확인해주신 주문 건은 환불 접수 후 영업일 기준 3일 내 처리될 예정입니다."
+}
+```
+
+### Error Handling
+
+- 세션이 없으면 기존 예외 응답 규칙에 따라 `404`를 반환한다.
+- 매칭 워크플로우가 없거나 초안 생성이 불가능하면 `4xx` 또는 `5xx` 오류를 반환할 수 있다.
+- 프론트엔드는 오류 시 입력창 값을 덮어쓰지 않고 toast로 안내한다.
+
+## Data Flow
+
+```text
+MatchedWorkflowBar/ChatPanel action
+  -> ConsultationPage handler
+  -> consultationApi.generateDraftResponse(sessionId)
+  -> POST /api/v1/consultation/sessions/{sessionId}/draft-response
+  -> backend draft service
+  -> { content }
+  -> ChatPanel textarea value update
+```
+
+## State Management
+
+- 서버 상태 캐시는 필요하지 않다. 초안 생성은 사용자 액션 기반 mutation으로 취급한다.
+- `ChatPanel`은 입력창 내용을 로컬 상태로 유지한다.
+- `ConsultationPage`는 현재 세션, 매칭 워크플로우 유무, 상담사 배정 상태를 기준으로 초안 액션 활성 여부를 결정한다.
+- 초안 요청 중에는 중복 클릭을 막기 위해 액션을 loading/disabled 처리한다.
+
+## Acceptance Criteria
+
+- 매칭 워크플로우가 있는 세션에서 상담사가 답변 초안을 입력창에 삽입할 수 있다.
+- 삽입된 초안은 고객에게 자동 전송되지 않는다.
+- 상담사는 삽입된 초안을 편집한 뒤 직접 전송할 수 있다.
+- 초안 생성 실패 시 기존 입력 내용이 보존된다.
+- 매칭 워크플로우가 없는 세션에서는 삽입 액션이 숨겨지거나 비활성화된다.
+- 백엔드 draft response API는 초안 생성 결과를 반환하고 상담 메시지를 저장하지 않는다.
+- 초안 생성 API와 UI 흐름은 기존 상담 메시지 전송/재시도 흐름을 깨뜨리지 않는다.
+
+## Validation Plan
+
+- Backend: `ConsultationController`와 신규 draft service 테스트로 성공, 세션 없음, 매칭 워크플로우 없음, 저장 부작용 없음 시나리오를 검증한다.
+- Frontend: `ChatPanel` 테스트로 초안 삽입, 자동 전송 방지, 실패 시 기존 입력 보존, disabled 상태를 검증한다.
+- Frontend page integration: `ConsultationPage` 테스트로 매칭 워크플로우가 있을 때만 초안 요청이 가능하고 오류 toast가 표시되는지 확인한다.
+- Targeted commands:
+  - `cd backend && ./gradlew test --tests com.init.workflowruntime.presentation.ConsultationControllerTest`
+  - `cd frontend && pnpm test -- ChatPanel ConsultationPage`
+
+## Open Questions
+
+- 없음.

--- a/backend/src/main/java/com/init/workflowruntime/application/CounselorDraftResponseService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/CounselorDraftResponseService.java
@@ -1,0 +1,133 @@
+package com.init.workflowruntime.application;
+
+import com.init.domainpack.domain.model.WorkflowDefinition;
+import com.init.domainpack.domain.repository.WorkflowDefinitionRepository;
+import com.init.shared.application.exception.BadRequestException;
+import com.init.shared.application.exception.NotFoundException;
+import com.init.workflowruntime.application.command.GenerateDraftResponseCommand;
+import com.init.workflowruntime.application.dto.GenerateWorkflowAwareResponseResult;
+import com.init.workflowruntime.domain.ChatMessage;
+import com.init.workflowruntime.domain.ChatMessageRepository;
+import com.init.workflowruntime.domain.ChatSession;
+import com.init.workflowruntime.domain.ChatSessionRepository;
+import com.init.workflowruntime.domain.WorkflowExecution;
+import com.init.workflowruntime.domain.WorkflowExecutionRepository;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class CounselorDraftResponseService {
+
+  private final ChatSessionRepository chatSessionRepository;
+  private final ChatMessageRepository chatMessageRepository;
+  private final WorkflowExecutionRepository workflowExecutionRepository;
+  private final WorkflowDefinitionRepository workflowDefinitionRepository;
+  private final LlmAssistantService llmAssistantService;
+
+  public CounselorDraftResponseService(
+      ChatSessionRepository chatSessionRepository,
+      ChatMessageRepository chatMessageRepository,
+      WorkflowExecutionRepository workflowExecutionRepository,
+      WorkflowDefinitionRepository workflowDefinitionRepository,
+      LlmAssistantService llmAssistantService) {
+    this.chatSessionRepository = chatSessionRepository;
+    this.chatMessageRepository = chatMessageRepository;
+    this.workflowExecutionRepository = workflowExecutionRepository;
+    this.workflowDefinitionRepository = workflowDefinitionRepository;
+    this.llmAssistantService = llmAssistantService;
+  }
+
+  public GenerateWorkflowAwareResponseResult generateDraft(GenerateDraftResponseCommand command) {
+    ChatSession session =
+        chatSessionRepository
+            .findById(command.sessionId())
+            .orElseThrow(
+                () ->
+                    new NotFoundException(
+                        "SESSION_NOT_FOUND", "Session not found: " + command.sessionId()));
+    WorkflowExecution execution =
+        workflowExecutionRepository
+            .findTopByChatSessionIdOrderByStartedAtDescIdDesc(command.sessionId())
+            .orElse(null);
+    WorkflowDefinition workflow = resolveWorkflow(command.sessionId(), session, execution);
+
+    List<ChatMessage> recentMessages =
+        new ArrayList<>(
+            chatMessageRepository.findTop5ByChatSessionIdOrderBySeqNoDesc(command.sessionId()));
+    Collections.reverse(recentMessages);
+    String conversationContext =
+        recentMessages.stream()
+            .map(message -> message.getSenderRole() + ": " + nullToEmpty(message.getContent()))
+            .collect(Collectors.joining("\n"));
+    String latestCustomerMessage =
+        latestCustomerMessage(recentMessages);
+
+    return llmAssistantService.generateCounselorDraftResponse(
+        workflowSummary(workflow),
+        execution != null ? execution.getCurrentState() : workflow.getInitialState(),
+        conversationContext,
+        latestCustomerMessage);
+  }
+
+  private WorkflowDefinition resolveWorkflow(
+      Long sessionId, ChatSession session, WorkflowExecution execution) {
+    if (execution != null && execution.getWorkflowDefinitionId() != null) {
+      return workflowDefinitionRepository
+          .findByIdAndDomainPackVersionId(
+              execution.getWorkflowDefinitionId(), session.getDomainPackVersionId())
+          .orElseThrow(() -> matchedWorkflowMissing(sessionId));
+    }
+
+    return workflowDefinitionRepository
+        .findAllByDomainPackVersionId(session.getDomainPackVersionId())
+        .stream()
+        .findFirst()
+        .orElseThrow(() -> matchedWorkflowMissing(sessionId));
+  }
+
+  private BadRequestException matchedWorkflowMissing(Long sessionId) {
+    return new BadRequestException(
+        "MATCHED_WORKFLOW_NOT_FOUND", "Matched workflow not found for session: " + sessionId);
+  }
+
+  private String workflowSummary(WorkflowDefinition workflow) {
+    StringBuilder builder = new StringBuilder();
+    builder.append(workflow.getName()).append(" (").append(workflow.getWorkflowCode()).append(")");
+    if (workflow.getDescription() != null && !workflow.getDescription().isBlank()) {
+      builder.append("\n").append(workflow.getDescription());
+    }
+    if (workflow.getGraphJson() != null && !workflow.getGraphJson().isBlank()) {
+      builder.append("\nGraph JSON: ").append(workflow.getGraphJson());
+    }
+    return builder.toString();
+  }
+
+  private boolean isCustomerMessage(ChatMessage message) {
+    String role = message.getSenderRole();
+    if (role == null) return false;
+    String normalized = role.toUpperCase(Locale.ROOT);
+    return normalized.equals("USER") || normalized.equals("CUSTOMER");
+  }
+
+  private String latestCustomerMessage(List<ChatMessage> recentMessages) {
+    for (int index = recentMessages.size() - 1; index >= 0; index--) {
+      ChatMessage message = recentMessages.get(index);
+      if (isCustomerMessage(message)
+          && message.getContent() != null
+          && !message.getContent().isBlank()) {
+        return message.getContent();
+      }
+    }
+    return "";
+  }
+
+  private String nullToEmpty(String value) {
+    return value == null ? "" : value;
+  }
+}

--- a/backend/src/main/java/com/init/workflowruntime/application/CounselorDraftResponseService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/CounselorDraftResponseService.java
@@ -65,8 +65,7 @@ public class CounselorDraftResponseService {
         recentMessages.stream()
             .map(message -> message.getSenderRole() + ": " + nullToEmpty(message.getContent()))
             .collect(Collectors.joining("\n"));
-    String latestCustomerMessage =
-        latestCustomerMessage(recentMessages);
+    String latestCustomerMessage = latestCustomerMessage(recentMessages);
 
     return llmAssistantService.generateCounselorDraftResponse(
         workflowSummary(workflow),

--- a/backend/src/main/java/com/init/workflowruntime/application/LlmAssistantService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/LlmAssistantService.java
@@ -21,6 +21,25 @@ public class LlmAssistantService {
       Latest user message:
       {message}
       """;
+  private static final String COUNSELOR_DRAFT_PROMPT =
+      """
+      You are drafting a Korean customer-service reply for a human counselor.
+      The counselor will review and edit the text before sending it.
+      Do not mention that the text was generated.
+      Return only the draft message body.
+
+      Matched workflow:
+      {workflow}
+
+      Current workflow state:
+      {state}
+
+      Recent conversation:
+      {context}
+
+      Latest customer message:
+      {message}
+      """;
 
   private final ChatClient chatClient;
   private final WorkflowAssistantTools workflowAssistantTools;
@@ -54,6 +73,23 @@ public class LlmAssistantService {
                     u.text(WORKFLOW_AWARE_USER_PROMPT)
                         .param("context", nullToEmpty(command.conversationContext()))
                         .param("message", nullToEmpty(command.userMessage())))
+            .call()
+            .content();
+    return new GenerateWorkflowAwareResponseResult(content);
+  }
+
+  public GenerateWorkflowAwareResponseResult generateCounselorDraftResponse(
+      String workflowSummary, String currentState, String conversationContext, String userMessage) {
+    String content =
+        chatClient
+            .prompt()
+            .user(
+                u ->
+                    u.text(COUNSELOR_DRAFT_PROMPT)
+                        .param("workflow", nullToEmpty(workflowSummary))
+                        .param("state", nullToEmpty(currentState))
+                        .param("context", nullToEmpty(conversationContext))
+                        .param("message", nullToEmpty(userMessage)))
             .call()
             .content();
     return new GenerateWorkflowAwareResponseResult(content);

--- a/backend/src/main/java/com/init/workflowruntime/application/command/GenerateDraftResponseCommand.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/command/GenerateDraftResponseCommand.java
@@ -1,0 +1,3 @@
+package com.init.workflowruntime.application.command;
+
+public record GenerateDraftResponseCommand(Long sessionId) {}

--- a/backend/src/main/java/com/init/workflowruntime/presentation/ConsultationController.java
+++ b/backend/src/main/java/com/init/workflowruntime/presentation/ConsultationController.java
@@ -2,10 +2,13 @@ package com.init.workflowruntime.presentation;
 
 import com.init.shared.presentation.AuthenticationUtils;
 import com.init.workflowruntime.application.ConsultationService;
+import com.init.workflowruntime.application.CounselorDraftResponseService;
 import com.init.workflowruntime.application.LlmToolService;
+import com.init.workflowruntime.application.command.GenerateDraftResponseCommand;
 import com.init.workflowruntime.application.command.GetCurrentWorkflowCommand;
 import com.init.workflowruntime.application.dto.ChatMessageResponse;
 import com.init.workflowruntime.application.dto.ChatSessionResponse;
+import com.init.workflowruntime.application.dto.GenerateWorkflowAwareResponseResult;
 import com.init.workflowruntime.application.dto.LlmToolWorkflowResponse;
 import com.init.workflowruntime.application.dto.SendMessageRequest;
 import com.init.workflowruntime.application.dto.UpdateStatusRequest;
@@ -28,17 +31,22 @@ public class ConsultationController {
 
   private final ConsultationService consultationService;
   private final LlmToolService llmToolService;
+  private final CounselorDraftResponseService counselorDraftResponseService;
 
   /**
    * ConsultationController 생성자입니다.
    *
    * @param consultationService 상담 비즈니스 로직 서비스
    * @param llmToolService 매칭된 워크플로우 조회를 위한 LLM tool 서비스
+   * @param counselorDraftResponseService 상담사 검토용 답변 초안 생성 서비스
    */
   public ConsultationController(
-      ConsultationService consultationService, LlmToolService llmToolService) {
+      ConsultationService consultationService,
+      LlmToolService llmToolService,
+      CounselorDraftResponseService counselorDraftResponseService) {
     this.consultationService = consultationService;
     this.llmToolService = llmToolService;
+    this.counselorDraftResponseService = counselorDraftResponseService;
   }
 
   /**
@@ -101,5 +109,13 @@ public class ConsultationController {
     return ResponseEntity.ok(
         llmToolService.getCurrentWorkflowForOperator(
             new GetCurrentWorkflowCommand(sessionId), userId));
+  }
+
+  /** 매칭 워크플로우 기반 상담사 검토용 답변 초안을 생성합니다. */
+  @PostMapping("/sessions/{sessionId}/draft-response")
+  public ResponseEntity<GenerateWorkflowAwareResponseResult> generateDraftResponse(
+      @PathVariable Long sessionId) {
+    return ResponseEntity.ok(
+        counselorDraftResponseService.generateDraft(new GenerateDraftResponseCommand(sessionId)));
   }
 }

--- a/backend/src/test/java/com/init/workflowruntime/application/CounselorDraftResponseServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/CounselorDraftResponseServiceTest.java
@@ -1,0 +1,182 @@
+package com.init.workflowruntime.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.init.domainpack.domain.model.WorkflowDefinition;
+import com.init.domainpack.domain.repository.WorkflowDefinitionRepository;
+import com.init.shared.application.exception.BadRequestException;
+import com.init.shared.application.exception.NotFoundException;
+import com.init.workflowruntime.application.command.GenerateDraftResponseCommand;
+import com.init.workflowruntime.application.dto.GenerateWorkflowAwareResponseResult;
+import com.init.workflowruntime.domain.ChatMessage;
+import com.init.workflowruntime.domain.ChatMessageRepository;
+import com.init.workflowruntime.domain.ChatSession;
+import com.init.workflowruntime.domain.ChatSessionRepository;
+import com.init.workflowruntime.domain.ChatSessionStatus;
+import com.init.workflowruntime.domain.WorkflowExecution;
+import com.init.workflowruntime.domain.WorkflowExecutionRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CounselorDraftResponseService")
+class CounselorDraftResponseServiceTest {
+
+  private static final String DRAFT_RESPONSE =
+      "주문번호를 확인해주시면 환불 상태를 안내드리겠습니다.";
+  private static final String WORKFLOW_SUMMARY =
+      """
+      환불 워크플로우 (REFUND_FLOW)
+      환불 요청을 확인하고 필요한 정보를 수집합니다.
+      Graph JSON: {"nodes":[]}""";
+
+  @Mock private ChatSessionRepository chatSessionRepository;
+  @Mock private ChatMessageRepository chatMessageRepository;
+  @Mock private WorkflowExecutionRepository workflowExecutionRepository;
+  @Mock private WorkflowDefinitionRepository workflowDefinitionRepository;
+  @Mock private LlmAssistantService llmAssistantService;
+
+  private CounselorDraftResponseService service;
+
+  @BeforeEach
+  void setUp() {
+    service =
+        new CounselorDraftResponseService(
+            chatSessionRepository,
+            chatMessageRepository,
+            workflowExecutionRepository,
+            workflowDefinitionRepository,
+            llmAssistantService);
+  }
+
+  @Test
+  @DisplayName("매칭 워크플로우와 최근 대화를 기반으로 상담사 초안을 생성한다")
+  void should_generateDraft_when_matchedWorkflowExists() {
+    // given
+    ChatSession session = ChatSession.create(2L, 12L, ChatSessionStatus.ACTIVE, "WEB", "{}");
+    WorkflowExecution execution = WorkflowExecution.create(1L);
+    execution.assignIntentWorkflow(30L, 88L, "COLLECT_INFO");
+    WorkflowDefinition workflow =
+        WorkflowDefinition.create(
+            12L,
+            "REFUND_FLOW",
+            "환불 워크플로우",
+            "환불 요청을 확인하고 필요한 정보를 수집합니다.",
+            "{\"nodes\":[]}",
+            "COLLECT_INFO",
+            "[\"END\"]",
+            "[]",
+            "{}",
+            30L,
+            true,
+            "{}");
+    List<ChatMessage> recentDesc =
+        List.of(
+            ChatMessage.create(1L, 3, "COUNSELOR", "TEXT", "확인해보겠습니다."),
+            ChatMessage.create(
+                1L, 2, "CUSTOMER", "TEXT", "주문을 취소했는데 환불되나요?"),
+            ChatMessage.create(1L, 1, "CUSTOMER", "TEXT", "환불 문의드립니다."));
+
+    given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+    given(workflowExecutionRepository.findTopByChatSessionIdOrderByStartedAtDescIdDesc(1L))
+        .willReturn(Optional.of(execution));
+    given(workflowDefinitionRepository.findByIdAndDomainPackVersionId(88L, 12L))
+        .willReturn(Optional.of(workflow));
+    given(chatMessageRepository.findTop5ByChatSessionIdOrderBySeqNoDesc(1L))
+        .willReturn(recentDesc);
+    given(
+            llmAssistantService.generateCounselorDraftResponse(
+                any(), eq("COLLECT_INFO"), any(), eq("주문을 취소했는데 환불되나요?")))
+        .willReturn(new GenerateWorkflowAwareResponseResult(DRAFT_RESPONSE));
+
+    // when
+    GenerateWorkflowAwareResponseResult result =
+        service.generateDraft(new GenerateDraftResponseCommand(1L));
+
+    // then
+    assertThat(result.content()).isEqualTo(DRAFT_RESPONSE);
+    verify(chatMessageRepository, never()).save(any());
+    verify(llmAssistantService)
+        .generateCounselorDraftResponse(
+            eq(WORKFLOW_SUMMARY),
+            eq("COLLECT_INFO"),
+            eq(
+                """
+                CUSTOMER: 환불 문의드립니다.
+                CUSTOMER: 주문을 취소했는데 환불되나요?
+                COUNSELOR: 확인해보겠습니다."""),
+            eq("주문을 취소했는데 환불되나요?"));
+  }
+
+  @Test
+  @DisplayName("실행 이력이 없으면 도메인팩 버전의 워크플로우 후보로 초안을 생성한다")
+  void should_generateDraftWithCandidateWorkflow_when_executionMissing() {
+    // given
+    ChatSession session = ChatSession.create(2L, 12L, ChatSessionStatus.ACTIVE, "WEB", "{}");
+    WorkflowDefinition workflow =
+        WorkflowDefinition.create(
+            12L,
+            "REFUND_FLOW",
+            "환불 워크플로우",
+            null,
+            "{\"nodes\":[]}",
+            "START",
+            "[\"END\"]",
+            "[]",
+            "{}",
+            30L,
+            true,
+            "{}");
+    given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+    given(workflowExecutionRepository.findTopByChatSessionIdOrderByStartedAtDescIdDesc(1L))
+        .willReturn(Optional.empty());
+    given(workflowDefinitionRepository.findAllByDomainPackVersionId(12L))
+        .willReturn(List.of(workflow));
+    given(chatMessageRepository.findTop5ByChatSessionIdOrderBySeqNoDesc(1L)).willReturn(List.of());
+    given(llmAssistantService.generateCounselorDraftResponse(any(), eq("START"), any(), any()))
+        .willReturn(new GenerateWorkflowAwareResponseResult(DRAFT_RESPONSE));
+
+    // when
+    GenerateWorkflowAwareResponseResult result =
+        service.generateDraft(new GenerateDraftResponseCommand(1L));
+
+    // then
+    assertThat(result.content()).isEqualTo(DRAFT_RESPONSE);
+  }
+
+  @Test
+  @DisplayName("세션이 없으면 NotFoundException을 던진다")
+  void should_throwNotFound_when_sessionMissing() {
+    given(chatSessionRepository.findById(999L)).willReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.generateDraft(new GenerateDraftResponseCommand(999L)))
+        .isInstanceOf(NotFoundException.class)
+        .hasMessageContaining("Session not found: 999");
+  }
+
+  @Test
+  @DisplayName("매칭 워크플로우가 없으면 BadRequestException을 던진다")
+  void should_throwBadRequest_when_workflowMissing() {
+    ChatSession session = ChatSession.create(2L, 12L, ChatSessionStatus.ACTIVE, "WEB", "{}");
+    given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+    given(workflowExecutionRepository.findTopByChatSessionIdOrderByStartedAtDescIdDesc(1L))
+        .willReturn(Optional.empty());
+    given(workflowDefinitionRepository.findAllByDomainPackVersionId(12L)).willReturn(List.of());
+
+    assertThatThrownBy(() -> service.generateDraft(new GenerateDraftResponseCommand(1L)))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("Matched workflow not found for session: 1");
+  }
+}

--- a/backend/src/test/java/com/init/workflowruntime/application/CounselorDraftResponseServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/CounselorDraftResponseServiceTest.java
@@ -34,8 +34,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @DisplayName("CounselorDraftResponseService")
 class CounselorDraftResponseServiceTest {
 
-  private static final String DRAFT_RESPONSE =
-      "주문번호를 확인해주시면 환불 상태를 안내드리겠습니다.";
+  private static final String DRAFT_RESPONSE = "주문번호를 확인해주시면 환불 상태를 안내드리겠습니다.";
   private static final String WORKFLOW_SUMMARY =
       """
       환불 워크플로우 (REFUND_FLOW)
@@ -85,8 +84,7 @@ class CounselorDraftResponseServiceTest {
     List<ChatMessage> recentDesc =
         List.of(
             ChatMessage.create(1L, 3, "COUNSELOR", "TEXT", "확인해보겠습니다."),
-            ChatMessage.create(
-                1L, 2, "CUSTOMER", "TEXT", "주문을 취소했는데 환불되나요?"),
+            ChatMessage.create(1L, 2, "CUSTOMER", "TEXT", "주문을 취소했는데 환불되나요?"),
             ChatMessage.create(1L, 1, "CUSTOMER", "TEXT", "환불 문의드립니다."));
 
     given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
@@ -94,8 +92,7 @@ class CounselorDraftResponseServiceTest {
         .willReturn(Optional.of(execution));
     given(workflowDefinitionRepository.findByIdAndDomainPackVersionId(88L, 12L))
         .willReturn(Optional.of(workflow));
-    given(chatMessageRepository.findTop5ByChatSessionIdOrderBySeqNoDesc(1L))
-        .willReturn(recentDesc);
+    given(chatMessageRepository.findTop5ByChatSessionIdOrderBySeqNoDesc(1L)).willReturn(recentDesc);
     given(
             llmAssistantService.generateCounselorDraftResponse(
                 any(), eq("COLLECT_INFO"), any(), eq("주문을 취소했는데 환불되나요?")))

--- a/backend/src/test/java/com/init/workflowruntime/application/LlmAssistantServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/LlmAssistantServiceTest.java
@@ -25,6 +25,9 @@ import org.springframework.ai.chat.client.ChatClient.ChatClientRequestSpec;
 @SuppressWarnings({"unchecked", "rawtypes"})
 class LlmAssistantServiceTest {
 
+  private static final String COUNSELOR_DRAFT_RESPONSE =
+      "주문번호를 확인해주시면 환불 상태를 안내드리겠습니다.";
+
   @Mock private ChatClient chatClient;
   @Mock private ChatClientRequestSpec promptSpec;
   @Mock private CallResponseSpec callSpec;
@@ -100,5 +103,27 @@ class LlmAssistantServiceTest {
         .containsEntry("sessionId", 7L)
         .containsEntry("conversationContext", "")
         .containsEntry("latestUserMessage", "");
+  }
+
+  @Test
+  @DisplayName("generateCounselorDraftResponse: 도구 호출 없이 상담사 검토용 초안을 생성한다")
+  void should_generateCounselorDraftWithoutTools() {
+    given(chatClient.prompt()).willReturn(promptSpec);
+    given(promptSpec.user(any(Consumer.class))).willReturn(promptSpec);
+    given(promptSpec.call()).willReturn(callSpec);
+    given(callSpec.content()).willReturn(COUNSELOR_DRAFT_RESPONSE);
+
+    String result =
+        service
+            .generateCounselorDraftResponse(
+                "환불 워크플로우 (REFUND_FLOW)",
+                "COLLECT_INFO",
+                "CUSTOMER: 환불 문의드립니다.",
+                "환불 문의드립니다.")
+            .content();
+
+    assertThat(result).isEqualTo(COUNSELOR_DRAFT_RESPONSE);
+    verify(promptSpec, org.mockito.Mockito.never()).tools(workflowAssistantTools);
+    verify(promptSpec, org.mockito.Mockito.never()).toolContext(anyMap());
   }
 }

--- a/backend/src/test/java/com/init/workflowruntime/application/LlmAssistantServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/LlmAssistantServiceTest.java
@@ -25,8 +25,7 @@ import org.springframework.ai.chat.client.ChatClient.ChatClientRequestSpec;
 @SuppressWarnings({"unchecked", "rawtypes"})
 class LlmAssistantServiceTest {
 
-  private static final String COUNSELOR_DRAFT_RESPONSE =
-      "주문번호를 확인해주시면 환불 상태를 안내드리겠습니다.";
+  private static final String COUNSELOR_DRAFT_RESPONSE = "주문번호를 확인해주시면 환불 상태를 안내드리겠습니다.";
 
   @Mock private ChatClient chatClient;
   @Mock private ChatClientRequestSpec promptSpec;
@@ -116,10 +115,7 @@ class LlmAssistantServiceTest {
     String result =
         service
             .generateCounselorDraftResponse(
-                "환불 워크플로우 (REFUND_FLOW)",
-                "COLLECT_INFO",
-                "CUSTOMER: 환불 문의드립니다.",
-                "환불 문의드립니다.")
+                "환불 워크플로우 (REFUND_FLOW)", "COLLECT_INFO", "CUSTOMER: 환불 문의드립니다.", "환불 문의드립니다.")
             .content();
 
     assertThat(result).isEqualTo(COUNSELOR_DRAFT_RESPONSE);

--- a/backend/src/test/java/com/init/workflowruntime/presentation/ConsultationControllerTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/presentation/ConsultationControllerTest.java
@@ -54,8 +54,7 @@ import org.springframework.test.web.servlet.MockMvc;
     addFilters = false) // Disable spring security filters for simple controller test
 class ConsultationControllerTest {
 
-  private static final String DRAFT_RESPONSE =
-      "주문번호를 확인해주시면 환불 가능 여부를 안내드리겠습니다.";
+  private static final String DRAFT_RESPONSE = "주문번호를 확인해주시면 환불 가능 여부를 안내드리겠습니다.";
 
   @Autowired private MockMvc mockMvc;
 

--- a/backend/src/test/java/com/init/workflowruntime/presentation/ConsultationControllerTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/presentation/ConsultationControllerTest.java
@@ -17,10 +17,13 @@ import com.init.shared.application.exception.BadRequestException;
 import com.init.shared.application.exception.NotFoundException;
 import com.init.shared.infrastructure.security.JwtAuthenticationFilter;
 import com.init.workflowruntime.application.ConsultationService;
+import com.init.workflowruntime.application.CounselorDraftResponseService;
 import com.init.workflowruntime.application.LlmToolService;
+import com.init.workflowruntime.application.command.GenerateDraftResponseCommand;
 import com.init.workflowruntime.application.command.GetCurrentWorkflowCommand;
 import com.init.workflowruntime.application.dto.ChatMessageResponse;
 import com.init.workflowruntime.application.dto.ChatSessionResponse;
+import com.init.workflowruntime.application.dto.GenerateWorkflowAwareResponseResult;
 import com.init.workflowruntime.application.dto.LlmToolWorkflowResponse;
 import com.init.workflowruntime.application.dto.SendMessageRequest;
 import com.init.workflowruntime.application.dto.UpdateStatusRequest;
@@ -51,6 +54,9 @@ import org.springframework.test.web.servlet.MockMvc;
     addFilters = false) // Disable spring security filters for simple controller test
 class ConsultationControllerTest {
 
+  private static final String DRAFT_RESPONSE =
+      "주문번호를 확인해주시면 환불 가능 여부를 안내드리겠습니다.";
+
   @Autowired private MockMvc mockMvc;
 
   @Autowired private ObjectMapper objectMapper;
@@ -62,6 +68,10 @@ class ConsultationControllerTest {
   @SuppressWarnings("removal")
   @MockBean
   private LlmToolService llmToolService;
+
+  @SuppressWarnings("removal")
+  @MockBean
+  private CounselorDraftResponseService counselorDraftResponseService;
 
   @Test
   @DisplayName("GET /api/v1/consultation/sessions/{id}/messages - 메시지 조회 성공")
@@ -310,6 +320,36 @@ class ConsultationControllerTest {
                 .principal(auth()))
         .andExpect(status().isForbidden())
         .andExpect(jsonPath("$.code").value("WORKSPACE_ACCESS_DENIED"));
+  }
+
+  @Test
+  @DisplayName("POST /api/v1/consultation/sessions/{id}/draft-response - 답변 초안 반환")
+  void should_답변초안반환_when_매칭워크플로우존재() throws Exception {
+    // given
+    given(counselorDraftResponseService.generateDraft(new GenerateDraftResponseCommand(1L)))
+        .willReturn(new GenerateWorkflowAwareResponseResult(DRAFT_RESPONSE));
+
+    // when & then
+    mockMvc
+        .perform(post("/api/v1/consultation/sessions/1/draft-response"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content").value(DRAFT_RESPONSE));
+  }
+
+  @Test
+  @DisplayName("POST /api/v1/consultation/sessions/{id}/draft-response - 매칭 워크플로우 없음 → 400")
+  void should_400반환_when_답변초안_매칭워크플로우없음() throws Exception {
+    // given
+    given(counselorDraftResponseService.generateDraft(new GenerateDraftResponseCommand(1L)))
+        .willThrow(
+            new BadRequestException(
+                "MATCHED_WORKFLOW_NOT_FOUND", "Matched workflow not found for session: 1"));
+
+    // when & then
+    mockMvc
+        .perform(post("/api/v1/consultation/sessions/1/draft-response"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("MATCHED_WORKFLOW_NOT_FOUND"));
   }
 
   @Test

--- a/frontend/src/features/consultation/api/consultationApi.ts
+++ b/frontend/src/features/consultation/api/consultationApi.ts
@@ -8,7 +8,8 @@ import { customFetch } from "@/shared/api/mutator";
 import { requireApiData, selectApiData } from "@/shared/api";
 import type { ChatMessageResponse, ChatSessionResponse } from "@/shared/api/generated/zod";
 
-// OpenAPI 미생성 endpoint: workspace-scoped queue/metrics/sessions list, assign/release는 수동 호출로 유지한다.
+// OpenAPI 미생성 endpoint: workspace-scoped queue/metrics/sessions list,
+// assign/release, draft-response는 수동 호출로 유지한다.
 
 export type ChatSession = ChatSessionResponse & {
   assignedCounselorId?: number | null;
@@ -39,6 +40,10 @@ export interface ConsultationMetrics {
   handledTodayCount: number;
   llmHandledTodayCount: number;
   humanHandledTodayCount: number;
+}
+
+export interface DraftResponse {
+  content: string;
 }
 
 type SessionListResponse =
@@ -149,5 +154,13 @@ export const consultationApi = {
       { method: "GET" },
     );
     return requireApiData<ConsultationMetrics>(response, "상담 지표 응답을 확인할 수 없습니다.");
+  },
+
+  generateDraftResponse: async (sessionId: number): Promise<DraftResponse> => {
+    const response = await customFetch<DraftResponse | { data?: DraftResponse }>(
+      `/api/v1/consultation/sessions/${sessionId}/draft-response`,
+      { method: "POST" },
+    );
+    return requireApiData<DraftResponse>(response, "답변 초안 응답을 확인할 수 없습니다.");
   },
 };

--- a/frontend/src/features/consultation/ui/ChatPanel.test.tsx
+++ b/frontend/src/features/consultation/ui/ChatPanel.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { ChatPanel, type ChatMessage } from "./ChatPanel";
 
 const baseMessages: ChatMessage[] = [
@@ -98,6 +98,63 @@ describe("ChatPanel", () => {
 
     expect(onSendMessage).toHaveBeenCalledWith("처리 도와드리겠습니다.", false);
     expect(screen.getByPlaceholderText("메시지를 입력하세요...")).toHaveValue("");
+  });
+
+  it("답변 초안을 입력창에 삽입하되 자동 전송하지 않는다", async () => {
+    const onSendMessage = vi.fn();
+    const onInsert = vi.fn(() => Promise.resolve("주문번호를 확인해주시면 환불 상태를 안내드리겠습니다."));
+
+    render(
+      <ChatPanel
+        customerName="김민지"
+        channel="카카오톡"
+        messages={[]}
+        onSendMessage={onSendMessage}
+        selectedMessageId={null}
+        onSelectMessage={vi.fn()}
+        draftResponseAction={{ isLoading: false, onInsert }}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText("답변 초안 삽입"));
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("메시지를 입력하세요...")).toHaveValue(
+        "주문번호를 확인해주시면 환불 상태를 안내드리겠습니다.",
+      );
+    });
+    expect(onSendMessage).not.toHaveBeenCalled();
+  });
+
+  it("답변 초안 생성 실패 시 기존 입력값을 유지한다", async () => {
+    const onInsert = vi.fn(() => Promise.reject(new Error("draft failed")));
+
+    render(
+      <ChatPanel
+        customerName="김민지"
+        channel="카카오톡"
+        messages={[]}
+        onSendMessage={vi.fn()}
+        selectedMessageId={null}
+        onSelectMessage={vi.fn()}
+        draftResponseAction={{ isLoading: false, onInsert }}
+      />,
+    );
+
+    const input = screen.getByPlaceholderText("메시지를 입력하세요...");
+    fireEvent.change(input, { target: { value: "기존 작성 내용" } });
+    fireEvent.click(screen.getByLabelText("답변 초안 삽입"));
+
+    await waitFor(() => {
+      expect(onInsert).toHaveBeenCalled();
+    });
+    expect(input).toHaveValue("기존 작성 내용");
+  });
+
+  it("답변 초안 액션이 없으면 초안 삽입 버튼을 숨긴다", () => {
+    renderChatPanel();
+
+    expect(screen.queryByLabelText("답변 초안 삽입")).not.toBeInTheDocument();
   });
 
   it("세션 상태 라벨을 헤더에 표시한다", () => {

--- a/frontend/src/features/consultation/ui/ChatPanel.tsx
+++ b/frontend/src/features/consultation/ui/ChatPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useLayoutEffect, useCallback } from "react";
-import { Send, StickyNote, MessageSquare } from "lucide-react";
+import { Send, StickyNote, MessageSquare, WandSparkles } from "lucide-react";
 import {
   getChatRolePresentation,
   isCounselorLikeRole,
@@ -32,6 +32,10 @@ interface ChatPanelProps {
   sessionStatusDescription?: string;
   disabled?: boolean;
   disabledReason?: string;
+  draftResponseAction?: {
+    isLoading: boolean;
+    onInsert: () => Promise<string>;
+  };
 }
 
 const BOTTOM_SCROLL_THRESHOLD_PX = 96;
@@ -68,6 +72,7 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
   sessionStatusDescription,
   disabled = false,
   disabledReason,
+  draftResponseAction,
 }) => {
   const [input, setInput] = useState("");
   const [isNoteMode, setIsNoteMode] = useState(false);
@@ -162,6 +167,19 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
       showNewMessageNotice: false,
       shouldScrollToBottom: false,
     }));
+  };
+
+  const handleInsertDraft = async () => {
+    if (disabled || !draftResponseAction || draftResponseAction.isLoading) return;
+    try {
+      const draft = await draftResponseAction.onInsert();
+      if (draft.trim()) {
+        setInput(draft);
+        setIsNoteMode(false);
+      }
+    } catch {
+      // The page-level handler owns user-facing error feedback and the existing input is preserved.
+    }
   };
 
   /**
@@ -349,6 +367,19 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
         >
           <StickyNote size={18} />
         </button>
+        {draftResponseAction && (
+          <button
+            type="button"
+            className={styles.draftInsertButton}
+            onClick={() => void handleInsertDraft()}
+            disabled={disabled || draftResponseAction.isLoading}
+            aria-label="답변 초안 삽입"
+            title="답변 초안 삽입"
+            data-testid="insert-draft-response"
+          >
+            <WandSparkles size={18} />
+          </button>
+        )}
         <textarea
           className={styles.messageInput}
           rows={1}

--- a/frontend/src/features/consultation/ui/chat-panel.module.css
+++ b/frontend/src/features/consultation/ui/chat-panel.module.css
@@ -375,7 +375,8 @@
   background: var(--bg-secondary);
 }
 
-.noteToggle {
+.noteToggle,
+.draftInsertButton {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -390,14 +391,22 @@
   flex-shrink: 0;
 }
 
-.noteToggle:hover {
+.noteToggle:hover,
+.draftInsertButton:hover {
   background: rgba(0, 0, 0, 0.05);
   color: var(--text-primary);
 }
 
-.noteToggle:disabled {
+.noteToggle:disabled,
+.draftInsertButton:disabled {
   opacity: 0.4;
   cursor: not-allowed;
+}
+
+.draftInsertButton:focus-visible {
+  outline: none;
+  border-color: var(--ink);
+  box-shadow: var(--focus-ring);
 }
 
 .noteToggleActive {

--- a/frontend/src/pages/consultation/ui/ConsultationPage.test.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.test.tsx
@@ -129,6 +129,11 @@ vi.mock("../../../features/consultation/api/consultationApi", () => ({
         createdAt: new Date().toISOString(),
       }),
     ),
+    generateDraftResponse: vi.fn(() =>
+      Promise.resolve({
+        content: "주문번호를 확인해주시면 환불 상태를 안내드리겠습니다.",
+      }),
+    ),
   },
 }));
 
@@ -605,6 +610,66 @@ describe("ConsultationPage", () => {
         },
         { timeout: 1500 },
       );
+    });
+
+    it("inserts a matched workflow draft into the message input without sending it", async () => {
+      vi.mocked(getCurrentWorkflow).mockResolvedValueOnce(matchedPayload);
+      vi.mocked(consultationApi.generateDraftResponse).mockResolvedValueOnce({
+        content: "주문번호를 확인해주시면 환불 상태를 안내드리겠습니다.",
+      });
+
+      render(<ConsultationPage />, { wrapper: Wrapper });
+
+      await waitFor(() => {
+        expect(screen.getByText("김민지")).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByText("김민지"));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText("답변 초안 삽입")).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByLabelText("답변 초안 삽입"));
+
+      await waitFor(() => {
+        expect(consultationApi.generateDraftResponse).toHaveBeenCalledWith(1);
+      });
+      expect(screen.getByPlaceholderText("메시지를 입력하세요...")).toHaveValue(
+        "주문번호를 확인해주시면 환불 상태를 안내드리겠습니다.",
+      );
+      expect(mockSendTo).not.toHaveBeenCalledWith(
+        "/app/chat.counselor.send",
+        expect.objectContaining({ content: "주문번호를 확인해주시면 환불 상태를 안내드리겠습니다." }),
+      );
+    });
+
+    it("keeps the existing input and shows a toast when draft generation fails", async () => {
+      vi.mocked(getCurrentWorkflow).mockResolvedValueOnce(matchedPayload);
+      vi.mocked(consultationApi.generateDraftResponse).mockRejectedValueOnce(
+        new Error("draft failed"),
+      );
+
+      render(<ConsultationPage />, { wrapper: Wrapper });
+
+      await waitFor(() => {
+        expect(screen.getByText("김민지")).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByText("김민지"));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText("답변 초안 삽입")).toBeInTheDocument();
+      });
+
+      const input = screen.getByPlaceholderText("메시지를 입력하세요...");
+      await userEvent.type(input, "기존 작성 내용");
+      fireEvent.click(screen.getByLabelText("답변 초안 삽입"));
+
+      await waitFor(() => {
+        expect(toast.error).toHaveBeenCalledWith(
+          "답변 초안을 생성하지 못했습니다. 기존 입력 내용은 유지됩니다.",
+        );
+      });
+      expect(input).toHaveValue("기존 작성 내용");
     });
   });
 

--- a/frontend/src/pages/consultation/ui/ConsultationPage.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.tsx
@@ -484,6 +484,7 @@ export const ConsultationPage: React.FC = () => {
   const [queueLoadError, setQueueLoadError] = useState<string | null>(null);
   const [matchedWorkflow, setMatchedWorkflow] = useState<MatchedWorkflow | null>(null);
   const [isMatchedWorkflowLoading, setIsMatchedWorkflowLoading] = useState(false);
+  const [isDraftResponseLoading, setIsDraftResponseLoading] = useState(false);
   const [endSessionModal, setEndSessionModal] = useState<EndSessionModalState>({ open: false });
   const isEndSessionModalOpen = endSessionModal.open;
   const isEndSessionSubmitting = endSessionModal.open ? endSessionModal.isSubmitting : false;
@@ -589,6 +590,7 @@ export const ConsultationPage: React.FC = () => {
     setMessagesCustomerId(null);
     setMatchedWorkflow(null);
     setIsMatchedWorkflowLoading(false);
+    setIsDraftResponseLoading(false);
     setEndSessionModal({ open: false });
     clearPendingMessages();
   }, [clearPendingMessages]);
@@ -860,6 +862,7 @@ export const ConsultationPage: React.FC = () => {
     if (!activeCustomerId) {
       setMatchedWorkflow(null);
       setIsMatchedWorkflowLoading(false);
+      setIsDraftResponseLoading(false);
       return;
     }
 
@@ -1108,6 +1111,26 @@ export const ConsultationPage: React.FC = () => {
     ],
   );
 
+  const handleInsertDraftResponse = useCallback(async () => {
+    if (!activeCustomerId || !matchedWorkflow || !isAssignedToCurrentCounselor) return "";
+    setIsDraftResponseLoading(true);
+    try {
+      const draft = await consultationApi.generateDraftResponse(Number(activeCustomerId));
+      if (!draft.content.trim()) {
+        toast.error("답변 초안을 생성하지 못했습니다. 기존 입력 내용은 유지됩니다.");
+        return "";
+      }
+      toast.success("답변 초안을 입력창에 삽입했습니다.");
+      return draft.content;
+    } catch (error) {
+      console.error("Failed to generate draft response:", error);
+      toast.error("답변 초안을 생성하지 못했습니다. 기존 입력 내용은 유지됩니다.");
+      throw error;
+    } finally {
+      setIsDraftResponseLoading(false);
+    }
+  }, [activeCustomerId, isAssignedToCurrentCounselor, matchedWorkflow]);
+
   const handleOpenEndSession = () => {
     if (!activeCustomerId || !isAssignedToCurrentCounselor) return;
     setEndSessionModal({
@@ -1321,6 +1344,14 @@ export const ConsultationPage: React.FC = () => {
               sessionStatusDescription={activeAssignment?.description}
               disabledReason={messageInputDisabledReason}
               disabled={!isAssignedToCurrentCounselor}
+              draftResponseAction={
+                matchedWorkflow && isAssignedToCurrentCounselor
+                  ? {
+                      isLoading: isDraftResponseLoading,
+                      onInsert: handleInsertDraftResponse,
+                    }
+                  : undefined
+              }
             />
           )}
         </div>


### PR DESCRIPTION
## Summary
- 매칭 워크플로우가 있는 상담 세션에서 답변 초안을 생성하는 REST API를 추가했습니다.
- 초안 생성은 메시지를 저장하거나 워크플로우를 진행하지 않고, 상담사 검토용 문구만 반환합니다.
- 상담 입력창에 초안 삽입 액션을 추가하고 자동 전송 없이 상담사가 편집 후 직접 전송하도록 했습니다.
- 구현 기준을 `.agent/specs/353.md`에 함께 정리했습니다.

## Validation
- `docker run --rm -v "$PWD":/repo -v "$HOME/.gradle":/root/.gradle -w /repo/backend eclipse-temurin:21-jdk ./gradlew --no-daemon -Dorg.gradle.vfs.watch=false test --tests com.init.workflowruntime.presentation.ConsultationControllerTest --tests com.init.workflowruntime.application.CounselorDraftResponseServiceTest --tests com.init.workflowruntime.application.LlmAssistantServiceTest`
- `cd frontend && pnpm test -- ChatPanel ConsultationPage`
- `cd frontend && pnpm exec eslint src/features/consultation/api/consultationApi.ts src/features/consultation/ui/ChatPanel.tsx src/features/consultation/ui/ChatPanel.test.tsx src/pages/consultation/ui/ConsultationPage.tsx src/pages/consultation/ui/ConsultationPage.test.tsx`
- `cd frontend && pnpm exec tsc -b --pretty false`
- `git diff --check`
- `git diff --cached --check`

## Notes
- 호스트에는 Java runtime/Java 21 toolchain이 없어 backend 테스트는 Java 21 Docker 컨테이너에서 검증했습니다.
- 전체 `cd frontend && pnpm lint`는 이번 변경과 무관한 기존 lint 오류 59개로 실패해, 변경된 파일 대상으로 eslint를 확인했습니다.
- 커밋 생성 시 동일한 로컬 Java runtime 부재 및 기존 full-lint 실패 때문에 해당 커밋 명령에 한해 Husky를 비활성화했습니다.

Closes #353