### PR TITLE
feat(consultation): 상담 기록 검색과 페이지 이동을 제공

### DIFF
--- a/.agent/specs/352.md
+++ b/.agent/specs/352.md
@@ -1,0 +1,269 @@
+# 352: 상담 기록 검색/필터/페이지 이동 제공
+
+> **Issue**: [#352](https://github.com/ajou-2026-1-capstone-5/ostone/issues/352)
+> **Bounded Context**: `workflow-runtime` FE/BE
+> **Template**: `_TEMPLATE_FE.md` 기반, Backend 계약 섹션 포함
+> **Branch**: `feature/352-chat-history-search-filters`
+> **Canonical Number**: `352`
+> **Type**: Mixed (Frontend FSD + Backend DDD)
+> **작성일**: 2026-06-01
+
+---
+
+## Goal
+
+상담 기록 화면에서 상담사가 고객명/키워드, 기간, 상태, 담당 상담사 조건으로 이전 상담을 찾고 페이지를 이동할 수 있게 한다.
+
+---
+
+## Background
+
+상담 기록은 상담사가 이전 응대 맥락과 후속 처리 내용을 찾는 작업 화면이다. 현재 확인된 구현은 `frontend/src/pages/consultation/ui/chat-history/ChatHistoryPage.tsx`가 세션 목록을 가져온 뒤 `COMPLETED`/`RESOLVED`만 클라이언트에서 걸러 보여주고, `frontend/src/features/consultation/ui/chat-history/SessionList.tsx`는 검색/필터/페이지 이동 UI를 제공하지 않는다.
+
+Backend의 `GET /api/v1/workspaces/{workspaceId}/consultation/sessions`는 `status`, `page`, `size` 수준의 조건만 처리한다. 기록이 많아지면 고객명, 메시지 키워드, 기간, 담당 상담사 기준으로 서버에서 먼저 좁혀야 한다.
+
+---
+
+## Scope
+
+### In Scope
+
+- 상담 기록 목록에 고객명 또는 메시지 키워드 검색 입력을 제공한다.
+- 기간, 상태, 담당 상담사 ID 필터를 제공한다.
+- 이전/다음 페이지 이동 UI를 제공하고 현재 페이지와 전체 건수를 표시한다.
+- 검색/필터/페이지 조건을 URL query에 반영해 새로고침 후에도 유지한다.
+- Backend 세션 목록 API에 검색/필터 조건을 추가한다.
+- #327에서 정리된 workspace-scoped URL과 선택 상태를 유지한다.
+
+### Out of Scope
+
+- 담당 상담사 이름 자동완성 또는 사용자 디렉터리 조회
+- 상담 기록 export, 저장된 검색 조건, 고급 정렬
+- 상담 메시지 본문 전용 검색 API 분리
+- ML pipeline 또는 Domain Pack 생성 흐름 변경
+
+### Issue Requirement Trace
+
+| Issue 요구사항 | 스펙 반영 위치 |
+| --- | --- |
+| 고객명/키워드 검색 | Frontend Design, Backend Contract |
+| 기간, 상태, 담당 상담사 필터 | Frontend Design, Backend Contract |
+| 페이지 이동 또는 더 보기 | Pagination |
+| URL query 유지 | Route State |
+| Backend 검색 조건 추가 | Backend Contract |
+| #327 workspace scope 이후에도 워크스페이스 내부 검색 | Backend Contract, Acceptance Criteria |
+
+---
+
+## Existing Context
+
+아래 경로는 현재 repository에서 존재 확인 완료했다.
+
+| Existing file | 현재 역할 | 변경 기준 |
+| --- | --- | --- |
+| `frontend/DESIGN.md` | 프론트 디자인 가이드 | 검색/필터/버튼/focus 스타일 기준 |
+| `frontend/src/pages/consultation/ui/chat-history/ChatHistoryPage.tsx` | 상담 기록 화면과 URL 선택 상태 조합 | URL query 기반 필터 상태 추가 |
+| `frontend/src/features/consultation/ui/chat-history/SessionList.tsx` | 상담 기록 목록 표시 | 검색/필터/페이지 UI 추가 |
+| `frontend/src/features/consultation/api/chatHistoryApi.ts` | 상담 기록 query hook | filter 조건과 page response 반영 |
+| `frontend/src/features/consultation/api/consultationApi.ts` | 상담 API wrapper | 세션 목록 query parameter 확장 |
+| `backend/src/main/java/com/init/workflowruntime/presentation/CounselorSessionController.java` | 상담사 세션 REST controller | query parameter 확장 |
+| `backend/src/main/java/com/init/workflowruntime/application/CounselorService.java` | 상담사 세션 application service | 조건 검증 및 검색 query orchestration |
+| `backend/src/main/java/com/init/workflowruntime/domain/ChatSessionRepository.java` | ChatSession repository port | 검색 조건을 받는 page 조회 port 추가 |
+| `backend/src/main/java/com/init/workflowruntime/infrastructure/persistence/JpaChatSessionRepository.java` | JPA repository adapter | workspace-scoped 검색 query 구현 |
+
+---
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A["상담 기록 화면 진입"] --> B["URL query 파싱"]
+    B --> C["워크스페이스 범위 세션 목록 요청"]
+    C --> D{"결과 있음?"}
+    D -->|"Yes"| E["세션 카드와 페이지 정보 표시"]
+    D -->|"No"| F["검색 조건에 맞는 빈 상태 표시"]
+    E --> G{"사용자 액션"}
+    G -->|"검색어 입력"| H["q query 갱신 + page 0"]
+    G -->|"필터 변경"| I["status/date/counselor query 갱신 + page 0"]
+    G -->|"다음/이전"| J["page query 갱신"]
+    G -->|"세션 선택"| K["sessionId route 갱신, query 유지"]
+    H --> C
+    I --> C
+    J --> C
+    K --> L["메시지 기록 표시"]
+```
+
+---
+
+## Design Diff
+
+| 영역 | As-is | To-be | 변경 내용 |
+| --- | --- | --- | --- |
+| 검색 | 없음 | 고객명/키워드 입력 | 세션 metadata와 메시지 본문을 대상으로 검색 |
+| 상태 | 기록 화면에서 사실상 고정 | 전체/OPEN/ACTIVE/RESOLVED/COMPLETED 선택 | 상태별 기록 탐색 가능 |
+| 기간 | 없음 | 시작일/종료일 date input | `startedAt` 기준 기간 필터 |
+| 담당 상담사 | 없음 | 상담사 ID 숫자 입력 | `assignedCounselorId` 기준 필터 |
+| 페이지 | API param만 존재 | 이전/다음 버튼과 카운트 표시 | 20개 초과 세션 탐색 가능 |
+| URL 상태 | sessionId만 반영 | 필터와 page query 보존 | 새로고침 후 동일 조건 복원 |
+
+---
+
+## Frontend Design
+
+### Component Tree
+
+```text
+ChatHistoryPage
+├─ SessionList
+│  ├─ SearchInput
+│  ├─ StatusSelect
+│  ├─ DateRangeInputs
+│  ├─ CounselorIdInput
+│  ├─ ResetFiltersButton
+│  ├─ SessionCard[]
+│  └─ PaginationControls
+└─ MessageHistory
+```
+
+### Route State
+
+상담 기록 route는 기존 경로를 유지하고 query string만 확장한다.
+
+```text
+/workspaces/:workspaceId/consultation/history?q=환불&status=COMPLETED&startedFrom=2026-05-01&startedTo=2026-05-31&assignedCounselorId=42&page=1
+/workspaces/:workspaceId/consultation/history/:sessionId?q=환불&status=COMPLETED&page=1
+```
+
+- `q`: 고객명, 세션 제목, 최근 메시지, 메시지 본문 등 키워드 검색어
+- `status`: `ALL | OPEN | ACTIVE | RESOLVED | COMPLETED`; 기본값은 상담 기록의 기존 동작과 가까운 `COMPLETED`
+  - `ALL`은 프론트엔드 URL 상태 전용 값이며 Backend API에는 `status` 조건을 보내지 않는다.
+- `startedFrom`, `startedTo`: `YYYY-MM-DD`
+- `assignedCounselorId`: 양수 숫자
+- `page`: backend와 동일한 0-based page index
+- 필터 조건 변경 시 `page`는 `0`으로 초기화한다.
+- 세션 선택 시 현재 query string은 유지한다.
+
+### Loading/Error/Empty
+
+- 로딩 중에도 필터 컨트롤은 유지하고 목록 영역에 loading state를 표시한다.
+- 에러 시 재시도 버튼을 제공한다.
+- 검색/필터 조건이 있는 빈 결과는 “검색 조건에 맞는 상담 기록이 없습니다”로 표시한다.
+
+---
+
+## Backend Contract
+
+### REST API
+
+기존 endpoint를 확장한다.
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `GET` | `/api/v1/workspaces/{workspaceId}/consultation/sessions` | 워크스페이스 상담 세션 목록 검색 |
+
+### Query Parameters
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `status` | string | no | 세션 상태 필터 |
+| `keyword` | string | no | 세션 channel/metaJson 또는 메시지 content 검색어 |
+| `startedFrom` | date | no | `startedAt` 시작일, `YYYY-MM-DD` |
+| `startedTo` | date | no | `startedAt` 종료일, `YYYY-MM-DD` |
+| `assignedCounselorId` | number | no | 담당 상담사 ID |
+| `page` | number | no | 0-based page, 기본값 `0` |
+| `size` | number | no | page size, 기본값 `20`, 최대 `100` |
+
+### Response
+
+기존 `CounselorSessionResponse` page envelope를 유지한다.
+
+```json
+{
+  "content": [
+    {
+      "id": 7,
+      "status": "COMPLETED",
+      "channel": "WEB",
+      "metaJson": "{\"title\":\"홍길동 환불 상담\"}",
+      "startedAt": "2026-05-22T09:00:00+09:00",
+      "assignedCounselorId": 42,
+      "endedAt": "2026-05-22T09:30:00+09:00"
+    }
+  ],
+  "page": 0,
+  "size": 20,
+  "totalElements": 1,
+  "totalPages": 1
+}
+```
+
+### Application Rules
+
+- `workspaceId`는 양수여야 한다.
+- `status`가 있으면 `ChatSessionStatus`로 검증한다.
+- `assignedCounselorId`가 있으면 양수여야 한다.
+- `startedFrom`과 `startedTo`가 모두 있으면 `startedFrom <= startedTo`여야 한다.
+- 날짜 필터는 `Asia/Seoul` 업무 날짜 기준으로 `startedFrom` 00:00:00 이상, `startedTo + 1 day` 00:00:00 미만을 조회한다.
+- keyword는 앞뒤 공백을 제거하고 빈 문자열이면 조건에서 제외한다.
+- 검색은 항상 `workspaceId` 조건 안에서만 수행한다.
+
+---
+
+## 수정 대상 파일
+
+| 파일 | 변경 유형 | 설명 |
+| --- | --- | --- |
+| `.agent/specs/352.md` | new | 이슈 요구사항과 검증 기준 문서화 |
+| `backend/src/main/java/com/init/workflowruntime/presentation/CounselorSessionController.java` | modify | 검색/필터 query parameter 추가 |
+| `backend/src/main/java/com/init/workflowruntime/application/CounselorService.java` | modify | query validation과 검색 조회 orchestration |
+| `backend/src/main/java/com/init/workflowruntime/domain/ChatSessionRepository.java` | modify | 검색 조건 기반 page 조회 port 추가 |
+| `backend/src/main/java/com/init/workflowruntime/infrastructure/persistence/JpaChatSessionRepository.java` | modify | native query 기반 workspace-scoped 검색 구현 |
+| `backend/src/test/java/com/init/workflowruntime/application/CounselorServiceTest.java` | modify | 검색/필터 검증 추가 |
+| `backend/src/test/java/com/init/workflowruntime/presentation/CounselorSessionControllerTest.java` | modify | query parameter 전달 검증 |
+| `frontend/src/features/consultation/api/consultationApi.ts` | modify | page response와 query parameter 확장 |
+| `frontend/src/features/consultation/api/chatHistoryApi.ts` | modify | filter-aware query key와 hook 응답 적용 |
+| `frontend/src/features/consultation/api/chatHistoryKeys.ts` | modify | 검색 조건 포함 query key |
+| `frontend/src/pages/consultation/ui/chat-history/ChatHistoryPage.tsx` | modify | URL query 기반 filter state |
+| `frontend/src/features/consultation/ui/chat-history/SessionList.tsx` | modify | 검색/필터/페이지 UI |
+| `frontend/src/features/consultation/ui/chat-history/SessionList.module.css` | modify | 필터/페이지 스타일 |
+| `frontend/src/**/__tests__ 또는 *.test.tsx` | modify | API/hook/page/list 테스트 갱신 |
+
+---
+
+## Acceptance Criteria
+
+- 상담사가 고객명 또는 메시지 키워드로 이전 상담을 찾을 수 있다.
+- 기간, 상태, 담당 상담사 조건으로 목록을 좁힐 수 있다.
+- 세션이 20개를 넘어도 이전/다음 페이지로 이동할 수 있다.
+- 새로고침해도 query string의 검색/필터/페이지 조건이 유지된다.
+- 세션 선택 후에도 검색/필터 query가 유지된다.
+- 검색은 `workspaceId` 조건과 함께 적용되어 다른 워크스페이스 세션이 섞이지 않는다.
+- 검색/필터 결과가 없으면 빈 상태를 명확히 표시한다.
+
+---
+
+## Test Plan
+
+### Backend
+
+- `CounselorServiceTest`
+  - keyword, 기간, 상태, 담당 상담사 필터가 repository 검색 조건으로 전달된다.
+  - 유효하지 않은 status는 `BadRequestException`을 반환한다.
+  - 유효하지 않은 workspaceId/page/size/assignedCounselorId/date range를 거부한다.
+- `CounselorSessionControllerTest`
+  - 확장된 query parameter를 service에 전달한다.
+
+### Frontend
+
+- `consultationApi.test.ts`
+  - `getSessionPage`가 확장 query parameter를 URL에 반영한다.
+  - 기존 `getSessions`는 page envelope의 content를 반환한다.
+- `chatHistoryApi.test.ts`
+  - filter 조건을 API 호출과 query key에 반영한다.
+  - `workspaceId`가 없으면 query를 실행하지 않는다.
+- `ChatHistoryPage.test.tsx`
+  - URL query 조건으로 세션 목록을 조회한다.
+  - 필터 변경 시 URL query가 갱신되고 page가 초기화된다.
+  - 세션 선택 시 query string이 유지된다.
+- `SessionList.test.tsx`
+  - 검색/필터 컨트롤, 빈 상태, pagination button 동작을 검증한다.

--- a/backend/src/main/java/com/init/workflowruntime/application/CounselorService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/CounselorService.java
@@ -304,7 +304,12 @@ public class CounselorService {
     if (keyword == null || keyword.isBlank()) {
       return null;
     }
-    return keyword.trim().toLowerCase(Locale.ROOT);
+    return keyword
+        .trim()
+        .toLowerCase(Locale.ROOT)
+        .replace("\\", "\\\\")
+        .replace("%", "\\%")
+        .replace("_", "\\_");
   }
 
   private OffsetDateTime toStartOfDay(LocalDate date) {

--- a/backend/src/main/java/com/init/workflowruntime/application/CounselorService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/CounselorService.java
@@ -17,7 +17,11 @@ import com.init.workflowruntime.domain.event.ConsultationQueueEventType;
 import com.init.workflowruntime.domain.event.SessionAssignedEvent;
 import com.init.workspace.application.exception.WorkspaceAccessDeniedException;
 import com.init.workspace.domain.repository.WorkspaceMemberRepository;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import org.springframework.context.ApplicationEventPublisher;
@@ -32,6 +36,8 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 @Service
 @Transactional(readOnly = true)
 public class CounselorService {
+
+  private static final ZoneId HISTORY_FILTER_ZONE = ZoneId.of("Asia/Seoul");
 
   private final ChatSessionRepository chatSessionRepository;
   private final ChatMessageRepository chatMessageRepository;
@@ -206,13 +212,31 @@ public class CounselorService {
     return CounselorSessionResponse.from(session);
   }
 
-  public CounselorSessionResponse getSessions(Long workspaceId, String status, int page, int size) {
+  public CounselorSessionResponse getSessions(
+      Long workspaceId,
+      Long userId,
+      String status,
+      String keyword,
+      LocalDate startedFrom,
+      LocalDate startedTo,
+      Long assignedCounselorId,
+      int page,
+      int size) {
     if (workspaceId == null || workspaceId <= 0) {
       throw new BadRequestException(
           "INVALID_WORKSPACE_ID", "workspaceId must be a positive number");
     }
+    validateWorkspaceMembership(workspaceId, userId);
     if (page < 0 || size <= 0) {
       throw new BadRequestException("INVALID_PAGING", "page must be >= 0 and size must be > 0");
+    }
+    if (assignedCounselorId != null && assignedCounselorId <= 0) {
+      throw new BadRequestException(
+          "INVALID_COUNSELOR_ID", "assignedCounselorId must be a positive number");
+    }
+    if (startedFrom != null && startedTo != null && startedFrom.isAfter(startedTo)) {
+      throw new BadRequestException(
+          "INVALID_DATE_RANGE", "startedFrom must be before or equal to startedTo");
     }
 
     ChatSessionStatus sessionStatus = null;
@@ -224,14 +248,19 @@ public class CounselorService {
       }
     }
 
+    String normalizedKeyword = normalizeKeyword(keyword);
+    OffsetDateTime startedFromDateTime = toStartOfDay(startedFrom);
+    OffsetDateTime startedBeforeDateTime = toExclusiveEndDate(startedTo);
     PageRequest pageRequest = PageRequest.of(page, size);
-    Page<ChatSession> sessionPage;
-    if (sessionStatus != null) {
-      sessionPage =
-          chatSessionRepository.findByWorkspaceIdAndStatus(workspaceId, sessionStatus, pageRequest);
-    } else {
-      sessionPage = chatSessionRepository.findByWorkspaceId(workspaceId, pageRequest);
-    }
+    Page<ChatSession> sessionPage =
+        chatSessionRepository.searchByWorkspace(
+            workspaceId,
+            sessionStatus != null ? sessionStatus.name() : null,
+            normalizedKeyword,
+            startedFromDateTime,
+            startedBeforeDateTime,
+            assignedCounselorId,
+            pageRequest);
 
     List<ChatSessionResponse> content =
         sessionPage.getContent().stream()
@@ -269,5 +298,26 @@ public class CounselorService {
       throw new BadRequestException(
           "UNSUPPORTED_RESPONSE_MODE", "Unsupported response mode: " + responseMode);
     }
+  }
+
+  private String normalizeKeyword(String keyword) {
+    if (keyword == null || keyword.isBlank()) {
+      return null;
+    }
+    return keyword.trim().toLowerCase(Locale.ROOT);
+  }
+
+  private OffsetDateTime toStartOfDay(LocalDate date) {
+    if (date == null) {
+      return null;
+    }
+    return date.atStartOfDay(HISTORY_FILTER_ZONE).toOffsetDateTime();
+  }
+
+  private OffsetDateTime toExclusiveEndDate(LocalDate date) {
+    if (date == null) {
+      return null;
+    }
+    return date.plusDays(1).atStartOfDay(HISTORY_FILTER_ZONE).toOffsetDateTime();
   }
 }

--- a/backend/src/main/java/com/init/workflowruntime/domain/ChatSessionRepository.java
+++ b/backend/src/main/java/com/init/workflowruntime/domain/ChatSessionRepository.java
@@ -1,5 +1,6 @@
 package com.init.workflowruntime.domain;
 
+import java.time.OffsetDateTime;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -35,4 +36,13 @@ public interface ChatSessionRepository {
   Page<ChatSession> findByStatus(ChatSessionStatus status, Pageable pageable);
 
   Page<ChatSession> findAll(Pageable pageable);
+
+  Page<ChatSession> searchByWorkspace(
+      Long workspaceId,
+      String status,
+      String keyword,
+      OffsetDateTime startedFrom,
+      OffsetDateTime startedBefore,
+      Long assignedCounselorId,
+      Pageable pageable);
 }

--- a/backend/src/main/java/com/init/workflowruntime/infrastructure/persistence/JpaChatSessionRepository.java
+++ b/backend/src/main/java/com/init/workflowruntime/infrastructure/persistence/JpaChatSessionRepository.java
@@ -51,13 +51,13 @@ public interface JpaChatSessionRepository
             AND (:startedBefore IS NULL OR cs.started_at < :startedBefore)
             AND (
               :keyword IS NULL
-              OR LOWER(cs.channel) LIKE CONCAT('%', :keyword, '%')
-              OR LOWER(CAST(cs.meta_json AS text)) LIKE CONCAT('%', :keyword, '%')
+              OR LOWER(cs.channel) LIKE CONCAT('%', :keyword, '%') ESCAPE '\\'
+              OR LOWER(CAST(cs.meta_json AS text)) LIKE CONCAT('%', :keyword, '%') ESCAPE '\\'
               OR EXISTS (
                 SELECT 1
                 FROM runtime.chat_message cm
                 WHERE cm.chat_session_id = cs.id
-                  AND LOWER(COALESCE(cm.content, '')) LIKE CONCAT('%', :keyword, '%')
+                  AND LOWER(COALESCE(cm.content, '')) LIKE CONCAT('%', :keyword, '%') ESCAPE '\\'
               )
             )
           ORDER BY cs.started_at DESC, cs.id DESC
@@ -73,13 +73,13 @@ public interface JpaChatSessionRepository
             AND (:startedBefore IS NULL OR cs.started_at < :startedBefore)
             AND (
               :keyword IS NULL
-              OR LOWER(cs.channel) LIKE CONCAT('%', :keyword, '%')
-              OR LOWER(CAST(cs.meta_json AS text)) LIKE CONCAT('%', :keyword, '%')
+              OR LOWER(cs.channel) LIKE CONCAT('%', :keyword, '%') ESCAPE '\\'
+              OR LOWER(CAST(cs.meta_json AS text)) LIKE CONCAT('%', :keyword, '%') ESCAPE '\\'
               OR EXISTS (
                 SELECT 1
                 FROM runtime.chat_message cm
                 WHERE cm.chat_session_id = cs.id
-                  AND LOWER(COALESCE(cm.content, '')) LIKE CONCAT('%', :keyword, '%')
+                  AND LOWER(COALESCE(cm.content, '')) LIKE CONCAT('%', :keyword, '%') ESCAPE '\\'
               )
             )
           """,

--- a/backend/src/main/java/com/init/workflowruntime/infrastructure/persistence/JpaChatSessionRepository.java
+++ b/backend/src/main/java/com/init/workflowruntime/infrastructure/persistence/JpaChatSessionRepository.java
@@ -4,6 +4,7 @@ import com.init.workflowruntime.domain.ChatSession;
 import com.init.workflowruntime.domain.ChatSessionRepository;
 import com.init.workflowruntime.domain.ChatSessionStatus;
 import jakarta.persistence.LockModeType;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
@@ -36,4 +37,59 @@ public interface JpaChatSessionRepository
 
   @Override
   Page<ChatSession> findByStatus(ChatSessionStatus status, Pageable pageable);
+
+  @Override
+  @Query(
+      value =
+          """
+          SELECT cs.*
+          FROM runtime.chat_session cs
+          WHERE cs.workspace_id = :workspaceId
+            AND (:status IS NULL OR cs.status = :status)
+            AND (:assignedCounselorId IS NULL OR cs.assigned_counselor_id = :assignedCounselorId)
+            AND (:startedFrom IS NULL OR cs.started_at >= :startedFrom)
+            AND (:startedBefore IS NULL OR cs.started_at < :startedBefore)
+            AND (
+              :keyword IS NULL
+              OR LOWER(cs.channel) LIKE CONCAT('%', :keyword, '%')
+              OR LOWER(CAST(cs.meta_json AS text)) LIKE CONCAT('%', :keyword, '%')
+              OR EXISTS (
+                SELECT 1
+                FROM runtime.chat_message cm
+                WHERE cm.chat_session_id = cs.id
+                  AND LOWER(COALESCE(cm.content, '')) LIKE CONCAT('%', :keyword, '%')
+              )
+            )
+          ORDER BY cs.started_at DESC, cs.id DESC
+          """,
+      countQuery =
+          """
+          SELECT COUNT(*)
+          FROM runtime.chat_session cs
+          WHERE cs.workspace_id = :workspaceId
+            AND (:status IS NULL OR cs.status = :status)
+            AND (:assignedCounselorId IS NULL OR cs.assigned_counselor_id = :assignedCounselorId)
+            AND (:startedFrom IS NULL OR cs.started_at >= :startedFrom)
+            AND (:startedBefore IS NULL OR cs.started_at < :startedBefore)
+            AND (
+              :keyword IS NULL
+              OR LOWER(cs.channel) LIKE CONCAT('%', :keyword, '%')
+              OR LOWER(CAST(cs.meta_json AS text)) LIKE CONCAT('%', :keyword, '%')
+              OR EXISTS (
+                SELECT 1
+                FROM runtime.chat_message cm
+                WHERE cm.chat_session_id = cs.id
+                  AND LOWER(COALESCE(cm.content, '')) LIKE CONCAT('%', :keyword, '%')
+              )
+            )
+          """,
+      nativeQuery = true)
+  Page<ChatSession> searchByWorkspace(
+      @Param("workspaceId") Long workspaceId,
+      @Param("status") String status,
+      @Param("keyword") String keyword,
+      @Param("startedFrom") OffsetDateTime startedFrom,
+      @Param("startedBefore") OffsetDateTime startedBefore,
+      @Param("assignedCounselorId") Long assignedCounselorId,
+      Pageable pageable);
 }

--- a/backend/src/main/java/com/init/workflowruntime/presentation/CounselorSessionController.java
+++ b/backend/src/main/java/com/init/workflowruntime/presentation/CounselorSessionController.java
@@ -7,6 +7,8 @@ import com.init.workflowruntime.application.dto.UpdateResponseModeRequest;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import java.time.LocalDate;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -55,8 +57,26 @@ public class CounselorSessionController {
   public ResponseEntity<CounselorSessionResponse> getSessions(
       @PathVariable Long workspaceId,
       @RequestParam(required = false) String status,
+      @RequestParam(required = false) String keyword,
+      @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+          LocalDate startedFrom,
+      @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+          LocalDate startedTo,
+      @RequestParam(required = false) Long assignedCounselorId,
       @RequestParam(defaultValue = "0") @Min(0) int page,
-      @RequestParam(defaultValue = "20") @Min(1) @Max(100) int size) {
-    return ResponseEntity.ok(counselorService.getSessions(workspaceId, status, page, size));
+      @RequestParam(defaultValue = "20") @Min(1) @Max(100) int size,
+      Authentication authentication) {
+    Long userId = AuthenticationUtils.getUserId(authentication);
+    return ResponseEntity.ok(
+        counselorService.getSessions(
+            workspaceId,
+            userId,
+            status,
+            keyword,
+            startedFrom,
+            startedTo,
+            assignedCounselorId,
+            page,
+            size));
   }
 }

--- a/backend/src/test/java/com/init/workflowruntime/application/CounselorServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/CounselorServiceTest.java
@@ -30,6 +30,8 @@ import com.init.workspace.application.exception.WorkspaceAccessDeniedException;
 import com.init.workspace.domain.model.WorkspaceMember;
 import com.init.workspace.domain.model.WorkspaceMemberRole;
 import com.init.workspace.domain.repository.WorkspaceMemberRepository;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -345,13 +347,32 @@ class CounselorServiceTest {
   void should_returnWorkspaceSessions_when_noStatusFilter() {
     ChatSession session = createSession(1L, ChatSessionStatus.OPEN);
     Page<ChatSession> page = new PageImpl<>(List.of(session));
-    given(chatSessionRepository.findByWorkspaceId(eq(1L), any(Pageable.class))).willReturn(page);
+    givenWorkspaceMember(1L, 7L);
+    given(
+            chatSessionRepository.searchByWorkspace(
+                eq(1L),
+                eq(null),
+                eq(null),
+                eq(null),
+                eq(null),
+                eq(null),
+                any(Pageable.class)))
+        .willReturn(page);
 
-    CounselorSessionResponse result = service.getSessions(1L, null, 0, 20);
+    CounselorSessionResponse result =
+        service.getSessions(1L, 7L, null, null, null, null, null, 0, 20);
 
     assertThat(result.getContent()).hasSize(1);
     assertThat(result.getTotalElements()).isEqualTo(1);
-    verify(chatSessionRepository).findByWorkspaceId(eq(1L), any(Pageable.class));
+    verify(chatSessionRepository)
+        .searchByWorkspace(
+            eq(1L),
+            eq(null),
+            eq(null),
+            eq(null),
+            eq(null),
+            eq(null),
+            any(Pageable.class));
   }
 
   @Test
@@ -359,22 +380,80 @@ class CounselorServiceTest {
   void should_returnFilteredWorkspaceSessions_when_statusGiven() {
     ChatSession session = createSession(1L, ChatSessionStatus.OPEN);
     Page<ChatSession> page = new PageImpl<>(List.of(session));
+    givenWorkspaceMember(1L, 7L);
     given(
-            chatSessionRepository.findByWorkspaceIdAndStatus(
-                eq(1L), eq(ChatSessionStatus.OPEN), any(Pageable.class)))
+            chatSessionRepository.searchByWorkspace(
+                eq(1L),
+                eq("OPEN"),
+                eq(null),
+                eq(null),
+                eq(null),
+                eq(null),
+                any(Pageable.class)))
         .willReturn(page);
 
-    CounselorSessionResponse result = service.getSessions(1L, "OPEN", 0, 20);
+    CounselorSessionResponse result =
+        service.getSessions(1L, 7L, "OPEN", null, null, null, null, 0, 20);
 
     assertThat(result.getContent()).hasSize(1);
     verify(chatSessionRepository)
-        .findByWorkspaceIdAndStatus(eq(1L), eq(ChatSessionStatus.OPEN), any(Pageable.class));
+        .searchByWorkspace(
+            eq(1L),
+            eq("OPEN"),
+            eq(null),
+            eq(null),
+            eq(null),
+            eq(null),
+            any(Pageable.class));
+  }
+
+  @Test
+  @DisplayName("getSessions: 검색/기간/상담사 필터를 정규화해 전달")
+  void should_passSearchFilters_when_filtersGiven() {
+    Page<ChatSession> page = new PageImpl<>(List.of());
+    givenWorkspaceMember(1L, 7L);
+    given(
+            chatSessionRepository.searchByWorkspace(
+                eq(1L),
+                eq("COMPLETED"),
+                eq("홍길동"),
+                any(OffsetDateTime.class),
+                any(OffsetDateTime.class),
+                eq(42L),
+                any(Pageable.class)))
+        .willReturn(page);
+
+    CounselorSessionResponse result =
+        service.getSessions(
+            1L,
+            7L,
+            "completed",
+            "  홍길동  ",
+            LocalDate.of(2026, 5, 1),
+            LocalDate.of(2026, 5, 31),
+            42L,
+            0,
+            20);
+
+    assertThat(result.getContent()).isEmpty();
+    verify(chatSessionRepository)
+        .searchByWorkspace(
+            eq(1L),
+            eq("COMPLETED"),
+            eq("홍길동"),
+            any(OffsetDateTime.class),
+            any(OffsetDateTime.class),
+            eq(42L),
+            any(Pageable.class));
   }
 
   @Test
   @DisplayName("getSessions: 지원하지 않는 상태 → BadRequestException")
   void should_throwBadRequest_when_invalidStatus() {
-    assertThatThrownBy(() -> service.getSessions(1L, "INVALID", 0, 20))
+    givenWorkspaceMember(1L, 7L);
+
+    assertThatThrownBy(
+            () -> service.getSessions(1L, 7L, "INVALID", null, null, null, null, 0, 20))
         .isInstanceOf(BadRequestException.class)
         .hasMessageContaining("Unsupported status");
   }
@@ -382,9 +461,40 @@ class CounselorServiceTest {
   @Test
   @DisplayName("getSessions: 유효하지 않은 workspaceId → BadRequestException")
   void should_throwBadRequest_when_invalidWorkspaceId() {
-    assertThatThrownBy(() -> service.getSessions(0L, null, 0, 20))
+    assertThatThrownBy(() -> service.getSessions(0L, 7L, null, null, null, null, null, 0, 20))
         .isInstanceOf(BadRequestException.class)
         .hasMessageContaining("workspaceId");
+  }
+
+  @Test
+  @DisplayName("getSessions: 유효하지 않은 담당 상담사 ID → BadRequestException")
+  void should_throwBadRequest_when_invalidAssignedCounselorId() {
+    givenWorkspaceMember(1L, 7L);
+
+    assertThatThrownBy(() -> service.getSessions(1L, 7L, null, null, null, null, 0L, 0, 20))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("assignedCounselorId");
+  }
+
+  @Test
+  @DisplayName("getSessions: 시작일이 종료일보다 늦으면 BadRequestException")
+  void should_throwBadRequest_when_invalidDateRange() {
+    givenWorkspaceMember(1L, 7L);
+
+    assertThatThrownBy(
+            () ->
+                service.getSessions(
+                    1L,
+                    7L,
+                    null,
+                    null,
+                    LocalDate.of(2026, 6, 1),
+                    LocalDate.of(2026, 5, 31),
+                    null,
+                    0,
+                    20))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("startedFrom");
   }
 
   @Test

--- a/backend/src/test/java/com/init/workflowruntime/application/CounselorServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/CounselorServiceTest.java
@@ -424,6 +424,31 @@ class CounselorServiceTest {
   }
 
   @Test
+  @DisplayName("getSessions: LIKE 와일드카드를 리터럴 검색어로 escape")
+  void should_escapeLikeWildcards_when_keywordContainsSpecialChars() {
+    Page<ChatSession> page = new PageImpl<>(List.of());
+    givenWorkspaceMember(1L, 7L);
+    given(
+            chatSessionRepository.searchByWorkspace(
+                eq(1L),
+                eq(null),
+                eq("\\%\\_\\\\"),
+                eq(null),
+                eq(null),
+                eq(null),
+                any(Pageable.class)))
+        .willReturn(page);
+
+    CounselorSessionResponse result =
+        service.getSessions(1L, 7L, null, "%_\\", null, null, null, 0, 20);
+
+    assertThat(result.getContent()).isEmpty();
+    verify(chatSessionRepository)
+        .searchByWorkspace(
+            eq(1L), eq(null), eq("\\%\\_\\\\"), eq(null), eq(null), eq(null), any(Pageable.class));
+  }
+
+  @Test
   @DisplayName("getSessions: 지원하지 않는 상태 → BadRequestException")
   void should_throwBadRequest_when_invalidStatus() {
     givenWorkspaceMember(1L, 7L);

--- a/backend/src/test/java/com/init/workflowruntime/application/CounselorServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/CounselorServiceTest.java
@@ -350,13 +350,7 @@ class CounselorServiceTest {
     givenWorkspaceMember(1L, 7L);
     given(
             chatSessionRepository.searchByWorkspace(
-                eq(1L),
-                eq(null),
-                eq(null),
-                eq(null),
-                eq(null),
-                eq(null),
-                any(Pageable.class)))
+                eq(1L), eq(null), eq(null), eq(null), eq(null), eq(null), any(Pageable.class)))
         .willReturn(page);
 
     CounselorSessionResponse result =
@@ -366,13 +360,7 @@ class CounselorServiceTest {
     assertThat(result.getTotalElements()).isEqualTo(1);
     verify(chatSessionRepository)
         .searchByWorkspace(
-            eq(1L),
-            eq(null),
-            eq(null),
-            eq(null),
-            eq(null),
-            eq(null),
-            any(Pageable.class));
+            eq(1L), eq(null), eq(null), eq(null), eq(null), eq(null), any(Pageable.class));
   }
 
   @Test
@@ -383,13 +371,7 @@ class CounselorServiceTest {
     givenWorkspaceMember(1L, 7L);
     given(
             chatSessionRepository.searchByWorkspace(
-                eq(1L),
-                eq("OPEN"),
-                eq(null),
-                eq(null),
-                eq(null),
-                eq(null),
-                any(Pageable.class)))
+                eq(1L), eq("OPEN"), eq(null), eq(null), eq(null), eq(null), any(Pageable.class)))
         .willReturn(page);
 
     CounselorSessionResponse result =
@@ -398,13 +380,7 @@ class CounselorServiceTest {
     assertThat(result.getContent()).hasSize(1);
     verify(chatSessionRepository)
         .searchByWorkspace(
-            eq(1L),
-            eq("OPEN"),
-            eq(null),
-            eq(null),
-            eq(null),
-            eq(null),
-            any(Pageable.class));
+            eq(1L), eq("OPEN"), eq(null), eq(null), eq(null), eq(null), any(Pageable.class));
   }
 
   @Test
@@ -452,8 +428,7 @@ class CounselorServiceTest {
   void should_throwBadRequest_when_invalidStatus() {
     givenWorkspaceMember(1L, 7L);
 
-    assertThatThrownBy(
-            () -> service.getSessions(1L, 7L, "INVALID", null, null, null, null, 0, 20))
+    assertThatThrownBy(() -> service.getSessions(1L, 7L, "INVALID", null, null, null, null, 0, 20))
         .isInstanceOf(BadRequestException.class)
         .hasMessageContaining("Unsupported status");
   }

--- a/backend/src/test/java/com/init/workflowruntime/presentation/CounselorSessionControllerTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/presentation/CounselorSessionControllerTest.java
@@ -200,15 +200,7 @@ class CounselorSessionControllerTest {
 
     given(
             counselorService.getSessions(
-                eq(1L),
-                eq(7L),
-                eq(null),
-                eq(null),
-                eq(null),
-                eq(null),
-                eq(null),
-                eq(0),
-                eq(20)))
+                eq(1L), eq(7L), eq(null), eq(null), eq(null), eq(null), eq(null), eq(0), eq(20)))
         .willReturn(response);
 
     mockMvc
@@ -216,7 +208,7 @@ class CounselorSessionControllerTest {
             get("/api/v1/workspaces/1/consultation/sessions")
                 .param("page", "0")
                 .param("size", "20")
-                .principal(auth()))
+                .principal(auth(7L)))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.content").isArray());
   }
@@ -228,15 +220,7 @@ class CounselorSessionControllerTest {
 
     given(
             counselorService.getSessions(
-                eq(1L),
-                eq(7L),
-                eq("OPEN"),
-                eq(null),
-                eq(null),
-                eq(null),
-                eq(null),
-                eq(0),
-                eq(20)))
+                eq(1L), eq(7L), eq("OPEN"), eq(null), eq(null), eq(null), eq(null), eq(0), eq(20)))
         .willReturn(response);
 
     mockMvc
@@ -245,7 +229,7 @@ class CounselorSessionControllerTest {
                 .param("status", "OPEN")
                 .param("page", "0")
                 .param("size", "20")
-                .principal(auth()))
+                .principal(auth(7L)))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.content").isArray());
   }
@@ -278,7 +262,7 @@ class CounselorSessionControllerTest {
                 .param("assignedCounselorId", "42")
                 .param("page", "1")
                 .param("size", "20")
-                .principal(auth()))
+                .principal(auth(7L)))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.page").value(1));
   }
@@ -305,7 +289,7 @@ class CounselorSessionControllerTest {
                 .param("status", "INVALID")
                 .param("page", "0")
                 .param("size", "20")
-                .principal(auth()))
+                .principal(auth(7L)))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.code").value("UNSUPPORTED_STATUS"));
   }

--- a/backend/src/test/java/com/init/workflowruntime/presentation/CounselorSessionControllerTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/presentation/CounselorSessionControllerTest.java
@@ -16,6 +16,7 @@ import com.init.shared.infrastructure.security.JwtAuthenticationFilter;
 import com.init.workflowruntime.application.CounselorService;
 import com.init.workflowruntime.application.dto.CounselorSessionResponse;
 import com.init.workspace.application.exception.WorkspaceAccessDeniedException;
+import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -197,13 +198,25 @@ class CounselorSessionControllerTest {
   void should_returnSessions_when_noStatusFilter() throws Exception {
     CounselorSessionResponse response = new CounselorSessionResponse(List.of(), 0, 20, 0, 0);
 
-    given(counselorService.getSessions(eq(1L), eq(null), eq(0), eq(20))).willReturn(response);
+    given(
+            counselorService.getSessions(
+                eq(1L),
+                eq(7L),
+                eq(null),
+                eq(null),
+                eq(null),
+                eq(null),
+                eq(null),
+                eq(0),
+                eq(20)))
+        .willReturn(response);
 
     mockMvc
         .perform(
             get("/api/v1/workspaces/1/consultation/sessions")
                 .param("page", "0")
-                .param("size", "20"))
+                .param("size", "20")
+                .principal(auth()))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.content").isArray());
   }
@@ -213,22 +226,77 @@ class CounselorSessionControllerTest {
   void should_returnSessions_when_statusFilter() throws Exception {
     CounselorSessionResponse response = new CounselorSessionResponse(List.of(), 0, 20, 0, 0);
 
-    given(counselorService.getSessions(eq(1L), eq("OPEN"), eq(0), eq(20))).willReturn(response);
+    given(
+            counselorService.getSessions(
+                eq(1L),
+                eq(7L),
+                eq("OPEN"),
+                eq(null),
+                eq(null),
+                eq(null),
+                eq(null),
+                eq(0),
+                eq(20)))
+        .willReturn(response);
 
     mockMvc
         .perform(
             get("/api/v1/workspaces/1/consultation/sessions")
                 .param("status", "OPEN")
                 .param("page", "0")
-                .param("size", "20"))
+                .param("size", "20")
+                .principal(auth()))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.content").isArray());
   }
 
   @Test
+  @DisplayName("GET /api/v1/workspaces/{workspaceId}/consultation/sessions - 검색/필터 query 전달")
+  void should_returnSessions_when_searchFiltersGiven() throws Exception {
+    CounselorSessionResponse response = new CounselorSessionResponse(List.of(), 1, 20, 0, 0);
+
+    given(
+            counselorService.getSessions(
+                eq(1L),
+                eq(7L),
+                eq("COMPLETED"),
+                eq("환불"),
+                eq(LocalDate.of(2026, 5, 1)),
+                eq(LocalDate.of(2026, 5, 31)),
+                eq(42L),
+                eq(1),
+                eq(20)))
+        .willReturn(response);
+
+    mockMvc
+        .perform(
+            get("/api/v1/workspaces/1/consultation/sessions")
+                .param("status", "COMPLETED")
+                .param("keyword", "환불")
+                .param("startedFrom", "2026-05-01")
+                .param("startedTo", "2026-05-31")
+                .param("assignedCounselorId", "42")
+                .param("page", "1")
+                .param("size", "20")
+                .principal(auth()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.page").value(1));
+  }
+
+  @Test
   @DisplayName("GET /api/v1/workspaces/{workspaceId}/consultation/sessions - 유효하지 않은 상태 → 400")
   void should_return400_when_invalidStatus() throws Exception {
-    given(counselorService.getSessions(eq(1L), eq("INVALID"), anyInt(), anyInt()))
+    given(
+            counselorService.getSessions(
+                eq(1L),
+                eq(7L),
+                eq("INVALID"),
+                eq(null),
+                eq(null),
+                eq(null),
+                eq(null),
+                anyInt(),
+                anyInt()))
         .willThrow(new BadRequestException("UNSUPPORTED_STATUS", "Unsupported status: INVALID"));
 
     mockMvc
@@ -236,7 +304,8 @@ class CounselorSessionControllerTest {
             get("/api/v1/workspaces/1/consultation/sessions")
                 .param("status", "INVALID")
                 .param("page", "0")
-                .param("size", "20"))
+                .param("size", "20")
+                .principal(auth()))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.code").value("UNSUPPORTED_STATUS"));
   }

--- a/frontend/src/features/consultation/api/chatHistoryApi.test.ts
+++ b/frontend/src/features/consultation/api/chatHistoryApi.test.ts
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("./consultationApi", () => ({
   consultationApi: {
-    getSessions: vi.fn(),
+    getSessionPage: vi.fn(),
     getMessages: vi.fn(),
   },
 }));
@@ -14,7 +14,7 @@ import { ChatSessionResponse, ChatMessageResponse } from "../../../shared/api/ge
 import { useChatSessions, useChatMessages } from "./chatHistoryApi";
 import { consultationApi } from "./consultationApi";
 
-const mockedGetSessions = vi.mocked(consultationApi.getSessions);
+const mockedGetSessionPage = vi.mocked(consultationApi.getSessionPage);
 const mockedGetMessages = vi.mocked(consultationApi.getMessages);
 
 const stubSession: ChatSessionResponse = {
@@ -45,11 +45,18 @@ function makeWrapper() {
 
 describe("useChatSessions", () => {
   beforeEach(() => {
-    mockedGetSessions.mockReset();
+    mockedGetSessionPage.mockReset();
   });
 
   it("세션 목록을 조회한다", async () => {
-    mockedGetSessions.mockResolvedValue([stubSession]);
+    const stubPage = {
+      content: [stubSession],
+      page: 0,
+      size: 20,
+      totalElements: 1,
+      totalPages: 1,
+    };
+    mockedGetSessionPage.mockResolvedValue(stubPage);
 
     const { result } = renderHook(
       () =>
@@ -59,26 +66,53 @@ describe("useChatSessions", () => {
       { wrapper: makeWrapper() },
     );
 
-    await waitFor(() => expect(result.current.data).toEqual([stubSession]));
-    expect(mockedGetSessions).toHaveBeenCalledWith(1, { status: undefined, page: 0, size: 20 });
+    await waitFor(() => expect(result.current.data).toEqual(stubPage));
+    expect(mockedGetSessionPage).toHaveBeenCalledWith(1, {
+      status: undefined,
+      keyword: undefined,
+      startedFrom: undefined,
+      startedTo: undefined,
+      assignedCounselorId: undefined,
+      page: 0,
+      size: 20,
+    });
   });
 
   it("상태 필터로 세션 목록을 조회한다", async () => {
-    mockedGetSessions.mockResolvedValue([stubSession]);
+    const stubPage = {
+      content: [stubSession],
+      page: 1,
+      size: 10,
+      totalElements: 11,
+      totalPages: 2,
+    };
+    mockedGetSessionPage.mockResolvedValue(stubPage);
 
     const { result } = renderHook(
       () =>
         useChatSessions({
           workspaceId: 1,
           status: "COMPLETED",
+          keyword: "환불",
+          startedFrom: "2026-05-01",
+          startedTo: "2026-05-31",
+          assignedCounselorId: 42,
           page: 1,
           size: 10,
         }),
       { wrapper: makeWrapper() },
     );
 
-    await waitFor(() => expect(result.current.data).toEqual([stubSession]));
-    expect(mockedGetSessions).toHaveBeenCalledWith(1, { status: "COMPLETED", page: 1, size: 10 });
+    await waitFor(() => expect(result.current.data).toEqual(stubPage));
+    expect(mockedGetSessionPage).toHaveBeenCalledWith(1, {
+      status: "COMPLETED",
+      keyword: "환불",
+      startedFrom: "2026-05-01",
+      startedTo: "2026-05-31",
+      assignedCounselorId: 42,
+      page: 1,
+      size: 10,
+    });
   });
 
   it("workspaceId가 없으면 세션 목록을 조회하지 않는다", () => {
@@ -91,7 +125,7 @@ describe("useChatSessions", () => {
     );
 
     expect(result.current.fetchStatus).toBe("idle");
-    expect(mockedGetSessions).not.toHaveBeenCalled();
+    expect(mockedGetSessionPage).not.toHaveBeenCalled();
   });
 });
 

--- a/frontend/src/features/consultation/api/chatHistoryApi.ts
+++ b/frontend/src/features/consultation/api/chatHistoryApi.ts
@@ -1,25 +1,44 @@
 import { useQuery } from "@tanstack/react-query";
-import { consultationApi } from "./consultationApi";
+import { consultationApi, type ChatSessionListParams } from "./consultationApi";
 import { chatHistoryKeys } from "./chatHistoryKeys";
 
-export interface UseChatSessionsParams {
+export interface UseChatSessionsParams extends ChatSessionListParams {
   workspaceId: number | null;
-  status?: string;
-  page?: number;
-  size?: number;
 }
 
 export function useChatSessions({
   workspaceId,
   status,
+  keyword,
+  startedFrom,
+  startedTo,
+  assignedCounselorId,
   page = 0,
   size = 20,
 }: UseChatSessionsParams) {
+  const params = {
+    status,
+    keyword,
+    startedFrom,
+    startedTo,
+    assignedCounselorId,
+    page,
+    size,
+  };
+
   return useQuery({
-    queryKey: chatHistoryKeys.sessionList(workspaceId, status, page, size),
+    queryKey: chatHistoryKeys.sessionList(workspaceId, params),
     queryFn: () => {
-      if (workspaceId === null) return [];
-      return consultationApi.getSessions(workspaceId, { status, page, size });
+      if (workspaceId === null) {
+        return {
+          content: [],
+          page,
+          size,
+          totalElements: 0,
+          totalPages: 0,
+        };
+      }
+      return consultationApi.getSessionPage(workspaceId, params);
     },
     enabled: workspaceId !== null,
   });

--- a/frontend/src/features/consultation/api/chatHistoryKeys.ts
+++ b/frontend/src/features/consultation/api/chatHistoryKeys.ts
@@ -1,7 +1,9 @@
+import type { ChatSessionListParams } from "./consultationApi";
+
 export const chatHistoryKeys = {
   all: ["chat-history"] as const,
-  sessionList: (workspaceId: number | null, status?: string, page?: number, size?: number) =>
-    ["chat-history", "session-list", workspaceId, status ?? "all", page ?? 0, size ?? 20] as const,
+  sessionList: (workspaceId: number | null, params: ChatSessionListParams) =>
+    ["chat-history", "session-list", workspaceId, params] as const,
   messages: (sessionId: string, page?: number, size?: number) =>
     ["chat-history", "messages", sessionId, page ?? 0, size ?? 50] as const,
 };

--- a/frontend/src/features/consultation/api/consultationApi.test.ts
+++ b/frontend/src/features/consultation/api/consultationApi.test.ts
@@ -278,6 +278,45 @@ describe("consultationApi", () => {
     );
   });
 
+  it("getSessionPage가 검색/필터 파라미터를 전달하고 page envelope를 반환한다", async () => {
+    const stubSessions: ChatSessionResponse[] = [];
+    mockedCustomFetch.mockResolvedValue({
+      data: {
+        content: stubSessions,
+        page: 1,
+        size: 20,
+        totalElements: 24,
+        totalPages: 2,
+      },
+      status: 200,
+      headers: new Headers(),
+    });
+
+    const result = await consultationApi.getSessionPage(2, {
+      status: "COMPLETED",
+      keyword: "환불",
+      startedFrom: "2026-05-01",
+      startedTo: "2026-05-31",
+      assignedCounselorId: 42,
+      page: 1,
+      size: 20,
+    });
+
+    expect(mockedCustomFetch).toHaveBeenCalledWith(
+      "/api/v1/workspaces/2/consultation/sessions?status=COMPLETED&keyword=%ED%99%98%EB%B6%88&startedFrom=2026-05-01&startedTo=2026-05-31&assignedCounselorId=42&page=1&size=20",
+      {
+        method: "GET",
+      },
+    );
+    expect(result).toEqual({
+      content: stubSessions,
+      page: 1,
+      size: 20,
+      totalElements: 24,
+      totalPages: 2,
+    });
+  });
+
   it("getMessages가 params 없이 호출되면 generated 함수를 사용한다", async () => {
     const stubMessages: ChatMessageResponse[] = [];
     mockedGetMessages.mockResolvedValue({

--- a/frontend/src/features/consultation/api/consultationApi.ts
+++ b/frontend/src/features/consultation/api/consultationApi.ts
@@ -19,6 +19,22 @@ export type ChatMessage = ChatMessageResponse;
 export type ConsultationSessionStatus = "OPEN" | "ACTIVE" | "RESOLVED" | "COMPLETED";
 export type ConsultationResponseMode = "AI_ACTIVE" | "HUMAN_ACTIVE" | "AI_ASSIST_ONLY";
 export type ResolutionOutcome = "RESOLVED" | "CUSTOMER_LEFT" | "PENDING" | "FOLLOW_UP_REQUIRED";
+export interface ChatSessionPage {
+  content: ChatSession[];
+  page: number;
+  size: number;
+  totalElements: number;
+  totalPages: number;
+}
+export interface ChatSessionListParams {
+  status?: string;
+  keyword?: string;
+  startedFrom?: string;
+  startedTo?: string;
+  assignedCounselorId?: number;
+  page?: number;
+  size?: number;
+}
 export interface UpdateSessionStatusPayload {
   status: ConsultationSessionStatus;
   resolutionOutcome?: ResolutionOutcome;
@@ -50,16 +66,39 @@ export interface DraftResponse {
 
 type SessionListResponse =
   | ChatSession[]
-  | { data?: ChatSession[] | { content?: ChatSession[] }; content?: ChatSession[] };
+  | {
+      data?: ChatSession[] | Partial<ChatSessionPage>;
+      content?: ChatSession[];
+      page?: number;
+      size?: number;
+      totalElements?: number;
+      totalPages?: number;
+    };
 
 type MessageListResponse =
   | ChatMessage[]
   | { data?: ChatMessage[] | { content?: ChatMessage[] }; content?: ChatMessage[] };
 
-function unwrapSessionList(response: SessionListResponse): ChatSession[] {
-  const unwrapped = selectApiData<ChatSession[] | { content?: ChatSession[] }>(response);
-  if (Array.isArray(unwrapped)) return unwrapped;
-  return unwrapped?.content ?? [];
+function unwrapSessionPage(response: SessionListResponse): ChatSessionPage {
+  const unwrapped = selectApiData<ChatSession[] | Partial<ChatSessionPage>>(response);
+  if (Array.isArray(unwrapped)) {
+    return {
+      content: unwrapped,
+      page: 0,
+      size: unwrapped.length,
+      totalElements: unwrapped.length,
+      totalPages: unwrapped.length > 0 ? 1 : 0,
+    };
+  }
+
+  const content = unwrapped?.content ?? [];
+  return {
+    content,
+    page: unwrapped?.page ?? 0,
+    size: unwrapped?.size ?? content.length,
+    totalElements: unwrapped?.totalElements ?? content.length,
+    totalPages: unwrapped?.totalPages ?? (content.length > 0 ? 1 : 0),
+  };
 }
 
 function unwrapMessageList(response: MessageListResponse): ChatMessage[] {
@@ -79,20 +118,30 @@ export const consultationApi = {
 
   getSessions: async (
     workspaceId: number,
-    params?: {
-      status?: string;
-      page?: number;
-      size?: number;
-    },
+    params?: ChatSessionListParams,
   ): Promise<ChatSession[]> => {
+    const page = await consultationApi.getSessionPage(workspaceId, params);
+    return page.content;
+  },
+
+  getSessionPage: async (
+    workspaceId: number,
+    params?: ChatSessionListParams,
+  ): Promise<ChatSessionPage> => {
     const searchParams = new URLSearchParams();
     if (params?.status) searchParams.set("status", params.status);
+    if (params?.keyword) searchParams.set("keyword", params.keyword);
+    if (params?.startedFrom) searchParams.set("startedFrom", params.startedFrom);
+    if (params?.startedTo) searchParams.set("startedTo", params.startedTo);
+    if (params?.assignedCounselorId !== undefined) {
+      searchParams.set("assignedCounselorId", String(params.assignedCounselorId));
+    }
     if (params?.page !== undefined) searchParams.set("page", String(params.page));
     if (params?.size !== undefined) searchParams.set("size", String(params.size));
     const query = searchParams.toString();
     const url = `/api/v1/workspaces/${workspaceId}/consultation/sessions${query ? `?${query}` : ""}`;
     const response = await customFetch<SessionListResponse>(url, { method: "GET" });
-    return unwrapSessionList(response);
+    return unwrapSessionPage(response);
   },
 
   getMessages: async (

--- a/frontend/src/features/consultation/lib/chatHistoryFilterDefaults.ts
+++ b/frontend/src/features/consultation/lib/chatHistoryFilterDefaults.ts
@@ -1,0 +1,2 @@
+export const CHAT_HISTORY_ALL_STATUS = "ALL";
+export const CHAT_HISTORY_DEFAULT_STATUS = "COMPLETED";

--- a/frontend/src/features/consultation/ui/chat-history/SessionList.module.css
+++ b/frontend/src/features/consultation/ui/chat-history/SessionList.module.css
@@ -19,12 +19,121 @@
   background: var(--paper);
 }
 
+.filters {
+  display: flex;
+  flex-direction: column;
+  gap: var(--s-3);
+  padding: var(--s-3);
+  border-bottom: 1px solid var(--line-2);
+  background: var(--paper);
+}
+
+.searchBox {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.searchIcon {
+  position: absolute;
+  left: 12px;
+  color: var(--ink-3);
+  pointer-events: none;
+}
+
+.searchInput,
+.input,
+.select {
+  width: 100%;
+  min-width: 0;
+  height: 34px;
+  border: 1px solid var(--line-2);
+  border-radius: var(--r-3);
+  background: var(--paper-2);
+  color: var(--ink);
+  font-family: var(--sans);
+  font-size: 13px;
+  letter-spacing: 0;
+}
+
+.searchInput {
+  padding: 0 12px 0 34px;
+}
+
+.input,
+.select {
+  padding: 0 10px;
+}
+
+.searchInput:focus,
+.input:focus,
+.select:focus {
+  outline: none;
+  border-color: var(--ink);
+  box-shadow: var(--focus-ring);
+}
+
+.field {
+  min-width: 0;
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 6px;
+  color: var(--ink-3);
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0;
+}
+
+.dateRow,
+.filterActions {
+  display: flex;
+  align-items: flex-end;
+  gap: var(--s-2);
+  min-width: 0;
+}
+
+.iconButton,
+.pageButton {
+  width: 34px;
+  height: 34px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--line-2);
+  border-radius: 50%;
+  background: var(--paper-2);
+  color: var(--ink);
+  cursor: pointer;
+  transition:
+    background 0.15s,
+    border-color 0.15s,
+    opacity 0.15s;
+}
+
+.iconButton:hover,
+.pageButton:hover:not(:disabled) {
+  border-color: var(--line);
+  background: var(--paper);
+}
+
+.iconButton:focus-visible,
+.pageButton:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.pageButton:disabled {
+  cursor: not-allowed;
+  opacity: 0.35;
+}
+
 .count {
   color: var(--ink-3);
   font-family: var(--mono);
   font-size: 11px;
   font-variant-numeric: tabular-nums;
-  letter-spacing: 0.02em;
+  letter-spacing: 0;
   white-space: nowrap;
 }
 
@@ -45,4 +154,34 @@
   align-items: center;
   justify-content: center;
   padding: var(--s-6);
+}
+
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--s-3);
+  padding: var(--s-3);
+  border-top: 1px solid var(--line-2);
+  background: var(--paper);
+}
+
+.pageStatus {
+  min-width: 52px;
+  color: var(--ink-3);
+  font-family: var(--mono);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0;
+  text-align: center;
+}
+
+@media (max-width: 760px) {
+  .wrapper {
+    width: 100%;
+    min-width: 0;
+    height: 45%;
+    border-right: 0;
+    border-bottom: 1px solid var(--line-2);
+  }
 }

--- a/frontend/src/features/consultation/ui/chat-history/SessionList.test.tsx
+++ b/frontend/src/features/consultation/ui/chat-history/SessionList.test.tsx
@@ -22,6 +22,19 @@ function renderSessionList(props?: Partial<ComponentProps<typeof SessionList>>) 
       sessions={[]}
       selectedSessionId={null}
       onSelectSession={vi.fn()}
+      filters={{
+        keyword: "",
+        status: "COMPLETED",
+        startedFrom: "",
+        startedTo: "",
+        assignedCounselorId: "",
+      }}
+      onFiltersChange={vi.fn()}
+      onResetFilters={vi.fn()}
+      page={0}
+      totalPages={0}
+      totalElements={0}
+      onPageChange={vi.fn()}
       onRetry={vi.fn()}
       {...props}
     />,
@@ -39,6 +52,21 @@ describe("SessionList", () => {
     renderSessionList({ sessions: [] });
 
     expect(screen.getByText("아직 채팅 기록이 없습니다")).toBeTruthy();
+  });
+
+  it("검색 조건이 있으면 필터 빈 상태 메시지를 표시한다", () => {
+    renderSessionList({
+      sessions: [],
+      filters: {
+        keyword: "환불",
+        status: "COMPLETED",
+        startedFrom: "",
+        startedTo: "",
+        assignedCounselorId: "",
+      },
+    });
+
+    expect(screen.getByText("검색 조건에 맞는 상담 기록이 없습니다")).toBeTruthy();
   });
 
   it("오류 상태에서 메시지와 다시 시도 버튼을 표시한다", () => {
@@ -63,7 +91,7 @@ describe("SessionList", () => {
       screen.getByText(new Date("2026-05-22T09:00:00+09:00").toLocaleDateString("ko-KR")),
     ).toBeTruthy();
     expect(screen.getByText("메시지 3개")).toBeTruthy();
-    expect(screen.getByText("상담 종료")).toBeTruthy();
+    expect(screen.getAllByText("상담 종료").length).toBeGreaterThan(0);
     expect(screen.getByText("배송 상태를 확인해주세요")).toBeTruthy();
   });
 
@@ -83,7 +111,7 @@ describe("SessionList", () => {
       ],
     });
 
-    expect(screen.getByText("해결됨")).toBeTruthy();
+    expect(screen.getAllByText("해결됨").length).toBeGreaterThan(0);
     expect(screen.getAllByText("후속 연락 필요")).toHaveLength(2);
     expect(screen.getByText("배송사 확인 필요")).toBeTruthy();
   });
@@ -108,5 +136,23 @@ describe("SessionList", () => {
     fireEvent.click(screen.getByRole("button", { name: /카카오톡/ }));
 
     expect(onSelect).toHaveBeenCalledWith("7");
+  });
+
+  it("검색과 페이지 이동 이벤트를 전달한다", () => {
+    const onFiltersChange = vi.fn();
+    const onPageChange = vi.fn();
+    renderSessionList({
+      sessions: [makeSession(7)],
+      totalPages: 3,
+      totalElements: 45,
+      onFiltersChange,
+      onPageChange,
+    });
+
+    fireEvent.change(screen.getByLabelText("상담 기록 검색"), { target: { value: "배송" } });
+    fireEvent.click(screen.getByRole("button", { name: "다음 페이지" }));
+
+    expect(onFiltersChange).toHaveBeenCalledWith({ keyword: "배송" });
+    expect(onPageChange).toHaveBeenCalledWith(1);
   });
 });

--- a/frontend/src/features/consultation/ui/chat-history/SessionList.tsx
+++ b/frontend/src/features/consultation/ui/chat-history/SessionList.tsx
@@ -1,5 +1,9 @@
 import { ChevronLeftIcon, ChevronRightIcon, RotateCcwIcon, SearchIcon } from "lucide-react";
 import { EmptyState, ErrorState, Eyebrow, LoadingSpinner } from "@/shared/ui/ostone/atoms";
+import {
+  CHAT_HISTORY_ALL_STATUS,
+  CHAT_HISTORY_DEFAULT_STATUS,
+} from "../../lib/chatHistoryFilterDefaults";
 import type { ChatSession } from "../../api/consultationApi";
 import { SessionCard } from "./SessionCard";
 import styles from "./SessionList.module.css";
@@ -55,7 +59,7 @@ export function SessionList({
   );
   const hasFilters =
     Boolean(filters.keyword) ||
-    filters.status !== "COMPLETED" ||
+    filters.status !== CHAT_HISTORY_DEFAULT_STATUS ||
     Boolean(filters.startedFrom) ||
     Boolean(filters.startedTo) ||
     Boolean(filters.assignedCounselorId);
@@ -137,7 +141,7 @@ export function SessionList({
             onChange={(event) => onFiltersChange({ status: event.target.value })}
             className={styles.select}
           >
-            <option value="ALL">전체 상태</option>
+            <option value={CHAT_HISTORY_ALL_STATUS}>전체 상태</option>
             <option value="COMPLETED">상담 종료</option>
             <option value="RESOLVED">해결됨</option>
             <option value="ACTIVE">진행 중</option>

--- a/frontend/src/features/consultation/ui/chat-history/SessionList.tsx
+++ b/frontend/src/features/consultation/ui/chat-history/SessionList.tsx
@@ -1,12 +1,28 @@
+import { ChevronLeftIcon, ChevronRightIcon, RotateCcwIcon, SearchIcon } from "lucide-react";
 import { EmptyState, ErrorState, Eyebrow, LoadingSpinner } from "@/shared/ui/ostone/atoms";
 import type { ChatSession } from "../../api/consultationApi";
 import { SessionCard } from "./SessionCard";
 import styles from "./SessionList.module.css";
 
+export interface SessionListFilters {
+  keyword: string;
+  status: string;
+  startedFrom: string;
+  startedTo: string;
+  assignedCounselorId: string;
+}
+
 interface SessionListProps {
   sessions: ChatSession[];
   selectedSessionId?: string | null;
   onSelectSession: (sessionId: string) => void;
+  filters: SessionListFilters;
+  onFiltersChange: (filters: Partial<SessionListFilters>) => void;
+  onResetFilters: () => void;
+  page: number;
+  totalPages: number;
+  totalElements: number;
+  onPageChange: (page: number) => void;
   isLoading?: boolean;
   isError?: boolean;
   error?: unknown;
@@ -22,70 +38,183 @@ export function SessionList({
   sessions,
   selectedSessionId,
   onSelectSession,
+  filters,
+  onFiltersChange,
+  onResetFilters,
+  page,
+  totalPages,
+  totalElements,
+  onPageChange,
   isLoading = false,
   isError = false,
   error,
   onRetry,
 }: SessionListProps) {
   const validSessions = sessions.filter(
-    (session): session is typeof session & { id: number } =>
-      session.id != null && (session.status === "COMPLETED" || session.status === "RESOLVED"),
+    (session): session is typeof session & { id: number } => session.id != null,
   );
+  const hasFilters =
+    Boolean(filters.keyword) ||
+    filters.status !== "COMPLETED" ||
+    Boolean(filters.startedFrom) ||
+    Boolean(filters.startedTo) ||
+    Boolean(filters.assignedCounselorId);
+  const emptyMessage = hasFilters
+    ? "검색 조건에 맞는 상담 기록이 없습니다"
+    : "아직 채팅 기록이 없습니다";
+  const canGoPrev = page > 0 && !isLoading;
+  const canGoNext = page + 1 < totalPages && !isLoading;
+  const pageLabel = totalPages > 0 ? `${page + 1} / ${totalPages}` : "0 / 0";
 
-  if (isLoading) {
-    return (
-      <aside className={styles.wrapper} aria-label="채팅 기록 목록">
-        <div className={styles.header}>
-          <Eyebrow>상담 이력</Eyebrow>
-          <span className={styles.count}>불러오는 중</span>
-        </div>
+  const renderContent = () => {
+    if (isLoading) {
+      return (
         <div className={styles.stateArea}>
           <LoadingSpinner />
         </div>
-      </aside>
-    );
-  }
+      );
+    }
 
-  if (isError) {
-    return (
-      <aside className={styles.wrapper} aria-label="채팅 기록 목록">
-        <div className={styles.header}>
-          <Eyebrow>상담 이력</Eyebrow>
-          <span className={styles.count}>오류</span>
-        </div>
+    if (isError) {
+      return (
         <div className={styles.stateArea}>
           <ErrorState message={getErrorMessage(error)} onRetry={onRetry} />
         </div>
-      </aside>
+      );
+    }
+
+    if (validSessions.length === 0) {
+      return (
+        <div className={styles.stateArea}>
+          <EmptyState message={emptyMessage} />
+        </div>
+      );
+    }
+
+    return (
+      <div className={styles.list}>
+        {validSessions.map((session) => {
+          const sessionId = String(session.id);
+          return (
+            <SessionCard
+              key={sessionId}
+              session={session}
+              isSelected={selectedSessionId === sessionId}
+              onSelectSession={onSelectSession}
+            />
+          );
+        })}
+      </div>
     );
-  }
+  };
 
   return (
     <aside className={styles.wrapper} aria-label="채팅 기록 목록">
       <div className={styles.header}>
         <Eyebrow>상담 이력</Eyebrow>
-        <span className={styles.count}>{validSessions.length}개 세션</span>
+        <span className={styles.count}>
+          {isError ? "오류" : isLoading ? "불러오는 중" : `${totalElements}개 세션`}
+        </span>
       </div>
 
-      {validSessions.length === 0 ? (
-        <div className={styles.stateArea}>
-          <EmptyState message="아직 채팅 기록이 없습니다" />
+      <div className={styles.filters} aria-label="상담 기록 검색 필터">
+        <label className={styles.searchBox}>
+          <SearchIcon size={14} className={styles.searchIcon} aria-hidden="true" />
+          <input
+            aria-label="상담 기록 검색"
+            value={filters.keyword}
+            onChange={(event) => onFiltersChange({ keyword: event.target.value })}
+            placeholder="고객명, 키워드"
+            className={styles.searchInput}
+          />
+        </label>
+
+        <label className={styles.field}>
+          <span>상태</span>
+          <select
+            aria-label="상태 필터"
+            value={filters.status}
+            onChange={(event) => onFiltersChange({ status: event.target.value })}
+            className={styles.select}
+          >
+            <option value="ALL">전체 상태</option>
+            <option value="COMPLETED">상담 종료</option>
+            <option value="RESOLVED">해결됨</option>
+            <option value="ACTIVE">진행 중</option>
+            <option value="OPEN">대기 중</option>
+          </select>
+        </label>
+
+        <div className={styles.dateRow}>
+          <label className={styles.field}>
+            <span>시작일</span>
+            <input
+              aria-label="시작일 필터"
+              type="date"
+              value={filters.startedFrom}
+              onChange={(event) => onFiltersChange({ startedFrom: event.target.value })}
+              className={styles.input}
+            />
+          </label>
+          <label className={styles.field}>
+            <span>종료일</span>
+            <input
+              aria-label="종료일 필터"
+              type="date"
+              value={filters.startedTo}
+              onChange={(event) => onFiltersChange({ startedTo: event.target.value })}
+              className={styles.input}
+            />
+          </label>
         </div>
-      ) : (
-        <div className={styles.list}>
-          {validSessions.map((session) => {
-            const sessionId = String(session.id);
-            return (
-              <SessionCard
-                key={sessionId}
-                session={session}
-                isSelected={selectedSessionId === sessionId}
-                onSelectSession={onSelectSession}
-              />
-            );
-          })}
+
+        <div className={styles.filterActions}>
+          <label className={styles.field}>
+            <span>상담사 ID</span>
+            <input
+              aria-label="담당 상담사 필터"
+              type="number"
+              min="1"
+              inputMode="numeric"
+              value={filters.assignedCounselorId}
+              onChange={(event) => onFiltersChange({ assignedCounselorId: event.target.value })}
+              className={styles.input}
+            />
+          </label>
+          <button
+            type="button"
+            className={styles.iconButton}
+            onClick={onResetFilters}
+            aria-label="검색 필터 초기화"
+          >
+            <RotateCcwIcon size={15} aria-hidden="true" />
+          </button>
         </div>
-      )}
+      </div>
+
+      {renderContent()}
+
+      <div className={styles.pagination} aria-label="상담 기록 페이지 이동">
+        <button
+          type="button"
+          className={styles.pageButton}
+          onClick={() => onPageChange(page - 1)}
+          disabled={!canGoPrev}
+          aria-label="이전 페이지"
+        >
+          <ChevronLeftIcon size={16} aria-hidden="true" />
+        </button>
+        <span className={styles.pageStatus}>{pageLabel}</span>
+        <button
+          type="button"
+          className={styles.pageButton}
+          onClick={() => onPageChange(page + 1)}
+          disabled={!canGoNext}
+          aria-label="다음 페이지"
+        >
+          <ChevronRightIcon size={16} aria-hidden="true" />
+        </button>
+      </div>
     </aside>
   );
 }

--- a/frontend/src/pages/consultation/ui/chat-history/ChatHistoryPage.test.tsx
+++ b/frontend/src/pages/consultation/ui/chat-history/ChatHistoryPage.test.tsx
@@ -32,7 +32,13 @@ type MockChatMessagesResult = Pick<
 
 const makeSessionsResult = (overrides?: Partial<MockChatSessionsResult>) =>
   ({
-    data: [makeSession(7)],
+    data: {
+      content: [makeSession(7)],
+      page: 0,
+      size: 20,
+      totalElements: 1,
+      totalPages: 1,
+    },
     isLoading: false,
     isError: false,
     error: null,
@@ -73,12 +79,14 @@ function makeMessage(overrides?: Partial<ChatMessage>): ChatMessage {
 }
 
 let currentPathname = "";
+let currentSearch = "";
 
 function LocationProbe() {
   const location = useLocation();
   useEffect(() => {
     currentPathname = location.pathname;
-  }, [location.pathname]);
+    currentSearch = location.search;
+  }, [location.pathname, location.search]);
   return null;
 }
 
@@ -110,6 +118,45 @@ describe("ChatHistoryPage", () => {
 
     expect(mockedUseChatSessions).toHaveBeenCalledWith({
       workspaceId: 1,
+      status: "COMPLETED",
+      keyword: undefined,
+      startedFrom: undefined,
+      startedTo: undefined,
+      assignedCounselorId: undefined,
+      page: 0,
+      size: 20,
+    });
+  });
+
+  it("URL query로 상담 이력 검색 조건을 복원한다", () => {
+    renderPage(
+      "/workspaces/1/consultation/history?q=환불&status=RESOLVED&startedFrom=2026-05-01&startedTo=2026-05-31&assignedCounselorId=42&page=2",
+    );
+
+    expect(mockedUseChatSessions).toHaveBeenCalledWith({
+      workspaceId: 1,
+      status: "RESOLVED",
+      keyword: "환불",
+      startedFrom: "2026-05-01",
+      startedTo: "2026-05-31",
+      assignedCounselorId: 42,
+      page: 2,
+      size: 20,
+    });
+  });
+
+  it("전체 상태 query는 백엔드 status 조건 없이 조회한다", () => {
+    renderPage("/workspaces/1/consultation/history?status=ALL");
+
+    expect(mockedUseChatSessions).toHaveBeenCalledWith({
+      workspaceId: 1,
+      status: undefined,
+      keyword: undefined,
+      startedFrom: undefined,
+      startedTo: undefined,
+      assignedCounselorId: undefined,
+      page: 0,
+      size: 20,
     });
   });
 
@@ -133,6 +180,36 @@ describe("ChatHistoryPage", () => {
       screen.getByText(new Date("2026-05-22T09:10:00+09:00").toLocaleString("ko-KR")),
     ).toBeTruthy();
     expect(currentPathname).toBe("/workspaces/1/consultation/history/7");
+  });
+
+  it("세션 선택 시 검색 query를 유지한다", () => {
+    renderPage("/workspaces/1/consultation/history?q=환불&status=RESOLVED&page=1");
+    fireEvent.click(screen.getByRole("button", { name: /카카오톡/ }));
+
+    expect(currentPathname).toBe("/workspaces/1/consultation/history/7");
+    const search = new URLSearchParams(currentSearch);
+    expect(search.get("q")).toBe("환불");
+    expect(search.get("status")).toBe("RESOLVED");
+    expect(search.get("page")).toBe("1");
+  });
+
+  it("검색어를 변경하면 URL query를 갱신하고 page를 초기화한다", () => {
+    renderPage("/workspaces/1/consultation/history?page=3");
+
+    fireEvent.change(screen.getByLabelText("상담 기록 검색"), { target: { value: "배송" } });
+
+    const search = new URLSearchParams(currentSearch);
+    expect(search.get("q")).toBe("배송");
+    expect(search.has("page")).toBe(false);
+  });
+
+  it("전체 상태 선택을 URL query에 유지한다", () => {
+    renderPage("/workspaces/1/consultation/history");
+
+    fireEvent.change(screen.getByLabelText("상태 필터"), { target: { value: "ALL" } });
+
+    const search = new URLSearchParams(currentSearch);
+    expect(search.get("status")).toBe("ALL");
   });
 
   it("상담사 메시지는 상담사 역할로 표시한다", () => {

--- a/frontend/src/pages/consultation/ui/chat-history/ChatHistoryPage.tsx
+++ b/frontend/src/pages/consultation/ui/chat-history/ChatHistoryPage.tsx
@@ -1,7 +1,8 @@
 import { useMemo } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { useChatSessions } from "../../../../features/consultation/api/chatHistoryApi";
 import { MessageHistory } from "../../../../features/consultation/ui/chat-history/MessageHistory";
+import type { SessionListFilters } from "../../../../features/consultation/ui/chat-history/SessionList";
 import { SessionList } from "../../../../features/consultation/ui/chat-history/SessionList";
 import { parseRouteId } from "../../../../shared/lib/parseRouteId";
 import styles from "./ChatHistoryPage.module.css";
@@ -10,38 +11,59 @@ interface ChatHistoryPageProps {
   workspaceId?: number;
 }
 
+const DEFAULT_STATUS = "COMPLETED";
+const ALL_STATUS = "ALL";
+const PAGE_SIZE = 20;
+
+function parsePage(value: string | null): number {
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : 0;
+}
+
+function parsePositiveNumber(value: string | null): number | undefined {
+  if (!value) return undefined;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
 export function ChatHistoryPage({ workspaceId: workspaceIdProp }: ChatHistoryPageProps) {
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   const { workspaceId: workspaceIdParam, sessionId: sessionIdParam } = useParams<{
     workspaceId: string;
     sessionId: string;
   }>();
   const workspaceId = workspaceIdProp ?? parseRouteId(workspaceIdParam);
   const selectedSessionId = sessionIdParam ?? null;
+  const page = parsePage(searchParams.get("page"));
+  const filters: SessionListFilters = {
+    keyword: searchParams.get("q") ?? "",
+    status: searchParams.get("status") ?? DEFAULT_STATUS,
+    startedFrom: searchParams.get("startedFrom") ?? "",
+    startedTo: searchParams.get("startedTo") ?? "",
+    assignedCounselorId: searchParams.get("assignedCounselorId") ?? "",
+  };
   const {
-    data: sessions = [],
+    data: sessionPage,
     isLoading,
     isError,
     error,
     refetch,
   } = useChatSessions({
     workspaceId,
+    status: filters.status === ALL_STATUS ? undefined : filters.status || undefined,
+    keyword: filters.keyword || undefined,
+    startedFrom: filters.startedFrom || undefined,
+    startedTo: filters.startedTo || undefined,
+    assignedCounselorId: parsePositiveNumber(filters.assignedCounselorId),
+    page,
+    size: PAGE_SIZE,
   });
-  const historySessions = useMemo(
-    () =>
-      sessions.filter(
-        (session) => session.status === "COMPLETED" || session.status === "RESOLVED",
-      ),
-    [sessions],
-  );
+  const sessions = useMemo(() => sessionPage?.content ?? [], [sessionPage?.content]);
   const selectableSessionIds = useMemo(
     () =>
-      new Set(
-        historySessions
-          .filter((session) => session.id != null)
-          .map((session) => String(session.id)),
-      ),
-    [historySessions],
+      new Set(sessions.filter((session) => session.id != null).map((session) => String(session.id))),
+    [sessions],
   );
   const hasSelectedSession =
     selectedSessionId !== null && selectableSessionIds.has(selectedSessionId);
@@ -53,15 +75,91 @@ export function ChatHistoryPage({ workspaceId: workspaceIdProp }: ChatHistoryPag
 
   const handleSelectSession = (sessionId: string) => {
     if (workspaceId === null) return;
-    navigate(`/workspaces/${workspaceId}/consultation/history/${sessionId}`);
+    const query = searchParams.toString();
+    navigate({
+      pathname: `/workspaces/${workspaceId}/consultation/history/${sessionId}`,
+      search: query ? `?${query}` : "",
+    });
+  };
+
+  const updateFilters = (nextFilters: Partial<SessionListFilters>) => {
+    setSearchParams(
+      (current) => {
+        const next = new URLSearchParams(current);
+        const entries: Array<[keyof SessionListFilters, string]> = [
+          ["keyword", nextFilters.keyword ?? filters.keyword],
+          ["status", nextFilters.status ?? filters.status],
+          ["startedFrom", nextFilters.startedFrom ?? filters.startedFrom],
+          ["startedTo", nextFilters.startedTo ?? filters.startedTo],
+          ["assignedCounselorId", nextFilters.assignedCounselorId ?? filters.assignedCounselorId],
+        ];
+        const queryKeyMap: Record<keyof SessionListFilters, string> = {
+          keyword: "q",
+          status: "status",
+          startedFrom: "startedFrom",
+          startedTo: "startedTo",
+          assignedCounselorId: "assignedCounselorId",
+        };
+
+        entries.forEach(([key, value]) => {
+          const queryKey = queryKeyMap[key];
+          if (value) {
+            next.set(queryKey, value);
+          } else {
+            next.delete(queryKey);
+          }
+        });
+        next.delete("page");
+        return next;
+      },
+      { replace: true },
+    );
+  };
+
+  const resetFilters = () => {
+    setSearchParams(
+      (current) => {
+        const next = new URLSearchParams(current);
+        next.delete("q");
+        next.set("status", DEFAULT_STATUS);
+        next.delete("startedFrom");
+        next.delete("startedTo");
+        next.delete("assignedCounselorId");
+        next.delete("page");
+        return next;
+      },
+      { replace: true },
+    );
+  };
+
+  const handlePageChange = (nextPage: number) => {
+    setSearchParams(
+      (current) => {
+        const next = new URLSearchParams(current);
+        if (nextPage <= 0) {
+          next.delete("page");
+        } else {
+          next.set("page", String(nextPage));
+        }
+        return next;
+      },
+      { replace: true },
+    );
   };
 
   return (
     <main className={styles.page}>
       <SessionList
-        sessions={historySessions}
+        sessions={sessions}
         selectedSessionId={selectedSessionId}
         onSelectSession={handleSelectSession}
+        filters={filters}
+        onFiltersChange={updateFilters}
+        onResetFilters={resetFilters}
+        page={sessionPage?.page ?? page}
+        totalPages={sessionPage?.totalPages ?? 0}
+        totalElements={sessionPage?.totalElements ?? 0}
+        onPageChange={handlePageChange}
         isLoading={isLoading}
         isError={isError}
         error={error}

--- a/frontend/src/pages/consultation/ui/chat-history/ChatHistoryPage.tsx
+++ b/frontend/src/pages/consultation/ui/chat-history/ChatHistoryPage.tsx
@@ -1,6 +1,10 @@
 import { useMemo } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { useChatSessions } from "../../../../features/consultation/api/chatHistoryApi";
+import {
+  CHAT_HISTORY_ALL_STATUS,
+  CHAT_HISTORY_DEFAULT_STATUS,
+} from "../../../../features/consultation/lib/chatHistoryFilterDefaults";
 import { MessageHistory } from "../../../../features/consultation/ui/chat-history/MessageHistory";
 import type { SessionListFilters } from "../../../../features/consultation/ui/chat-history/SessionList";
 import { SessionList } from "../../../../features/consultation/ui/chat-history/SessionList";
@@ -11,8 +15,6 @@ interface ChatHistoryPageProps {
   workspaceId?: number;
 }
 
-const DEFAULT_STATUS = "COMPLETED";
-const ALL_STATUS = "ALL";
 const PAGE_SIZE = 20;
 
 function parsePage(value: string | null): number {
@@ -38,7 +40,7 @@ export function ChatHistoryPage({ workspaceId: workspaceIdProp }: ChatHistoryPag
   const page = parsePage(searchParams.get("page"));
   const filters: SessionListFilters = {
     keyword: searchParams.get("q") ?? "",
-    status: searchParams.get("status") ?? DEFAULT_STATUS,
+    status: searchParams.get("status") ?? CHAT_HISTORY_DEFAULT_STATUS,
     startedFrom: searchParams.get("startedFrom") ?? "",
     startedTo: searchParams.get("startedTo") ?? "",
     assignedCounselorId: searchParams.get("assignedCounselorId") ?? "",
@@ -51,7 +53,7 @@ export function ChatHistoryPage({ workspaceId: workspaceIdProp }: ChatHistoryPag
     refetch,
   } = useChatSessions({
     workspaceId,
-    status: filters.status === ALL_STATUS ? undefined : filters.status || undefined,
+    status: filters.status === CHAT_HISTORY_ALL_STATUS ? undefined : filters.status || undefined,
     keyword: filters.keyword || undefined,
     startedFrom: filters.startedFrom || undefined,
     startedTo: filters.startedTo || undefined,
@@ -121,7 +123,7 @@ export function ChatHistoryPage({ workspaceId: workspaceIdProp }: ChatHistoryPag
       (current) => {
         const next = new URLSearchParams(current);
         next.delete("q");
-        next.set("status", DEFAULT_STATUS);
+        next.set("status", CHAT_HISTORY_DEFAULT_STATUS);
         next.delete("startedFrom");
         next.delete("startedTo");
         next.delete("assignedCounselorId");


### PR DESCRIPTION
## Summary
- 상담 기록 목록에 키워드, 기간, 상태, 담당 상담사 필터와 이전/다음 페이지 이동을 제공합니다.
- 검색/필터/page 조건을 URL query에 유지하고 세션 선택 시에도 같은 query를 보존합니다.
- 워크스페이스 멤버십 검증을 유지한 채 backend 상담 세션 목록 API에 workspace-scoped 검색 조건을 추가했습니다.
- 구현 기준을 `.agent/specs/352.md`에 함께 정리했습니다.

## Validation
- `docker run --rm -v "$PWD:/workspace" -v "$HOME/.gradle:/root/.gradle" -w /workspace/backend eclipse-temurin:21-jdk ./gradlew --no-daemon test --tests com.init.workflowruntime.application.CounselorServiceTest --tests com.init.workflowruntime.presentation.CounselorSessionControllerTest spotlessCheck`
- `cd frontend && pnpm test -- src/features/consultation/api/chatHistoryApi.test.ts src/features/consultation/api/consultationApi.test.ts src/features/consultation/ui/chat-history/SessionList.test.tsx src/pages/consultation/ui/chat-history/ChatHistoryPage.test.tsx`
- `cd frontend && pnpm exec eslint src/features/consultation/api/consultationApi.ts src/pages/consultation/ui/chat-history/ChatHistoryPage.tsx src/features/consultation/api/chatHistoryApi.ts src/features/consultation/api/chatHistoryKeys.ts src/features/consultation/ui/chat-history/SessionList.tsx src/features/consultation/ui/chat-history/SessionList.test.tsx src/features/consultation/api/chatHistoryApi.test.ts src/features/consultation/api/consultationApi.test.ts src/pages/consultation/ui/chat-history/ChatHistoryPage.test.tsx`
- `git diff --check`
- `git diff --cached --check`

## Notes
- 호스트에는 Java 21 toolchain이 없어 backend 검증은 JDK 21 Docker 컨테이너에서 실행했습니다.
- 전체 `cd frontend && pnpm lint`는 이번 변경과 무관한 기존 lint 오류들로 실패해, 변경 파일 대상으로 eslint를 확인했습니다.

Closes #352

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 상담 기록을 키워드로 검색할 수 있습니다.
  * 기간, 상태, 담당 상담사로 상담 기록을 필터링할 수 있습니다.
  * 이전/다음 페이지 버튼을 통해 목록을 탐색할 수 있습니다.
  * 검색 및 필터 조건이 세션 선택 후에도 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->