### PR TITLE
fix(consultation): 상담 chat topic 접근을 워크스페이스 멤버로 제한

### DIFF
--- a/.agent/specs/360.md
+++ b/.agent/specs/360.md
@@ -1,0 +1,125 @@
+# Backend Spec: 상담 WebSocket chat topic 워크스페이스 멤버십 검증
+
+## Goal
+
+OPERATOR가 `/topic/chat.{sessionId}` WebSocket topic을 구독할 때도 해당 상담 세션의 워크스페이스 멤버십을 검증해 REST API와 WebSocket 접근 제어를 일관되게 만든다.
+
+## Problem
+
+현재 `backend/src/main/java/com/init/workflowruntime/interceptor/JwtChannelInterceptor.java`는 `/topic/workspaces.{workspaceId}.consultation.queue` 구독에서 OPERATOR role과 워크스페이스 멤버십을 함께 확인한다. 반면 `/topic/chat.{sessionId}` 구독은 OPERATOR role이면 세션을 조회하지 않고 바로 허용한다. 다른 워크스페이스의 `sessionId`를 알게 된 OPERATOR가 해당 채팅 topic을 구독할 수 있는 구조라서 sessionId 기반 REST 접근 제어와 WebSocket topic 접근 제어가 다르게 동작한다.
+
+## Scope
+
+- `backend/src/main/java/com/init/workflowruntime/interceptor/JwtChannelInterceptor.java`
+- `backend/src/test/java/com/init/workflowruntime/interceptor/JwtChannelInterceptorTest.java`
+- 기존 `backend/src/main/java/com/init/workflowruntime/domain/ChatSessionRepository.java`
+- 기존 `backend/src/main/java/com/init/workspace/domain/repository/WorkspaceMemberRepository.java`
+
+## Non-Goals
+
+- WebSocket topic 경로, STOMP command, message payload 계약은 변경하지 않는다.
+- DB schema나 repository port 계약은 변경하지 않는다.
+- assigned counselor 여부 또는 상담 모니터링 권한 정책을 새로 정의하지 않는다. 이번 범위는 이슈 확인 기준인 워크스페이스 멤버십 검증에 한정한다.
+- 고객 사용자의 기존 구독 정책, 즉 본인이 시작한 세션만 구독할 수 있는 정책은 변경하지 않는다.
+
+## Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    actor client as WebSocket Client
+    participant interceptor as JwtChannelInterceptor
+    participant sessionRepo as ChatSessionRepository
+    participant memberRepo as WorkspaceMemberRepository
+    participant db as PostgreSQL
+
+    client ->> interceptor: SUBSCRIBE /topic/chat.{sessionId}
+    interceptor ->> interceptor: parse authenticated userId and role
+    interceptor ->> sessionRepo: findById(sessionId)
+    sessionRepo ->> db: SELECT runtime.chat_session
+    db -->> sessionRepo: ChatSession(workspaceId, startedBy)
+    sessionRepo -->> interceptor: ChatSession
+    alt role is OPERATOR
+        interceptor ->> memberRepo: findByWorkspaceIdAndUserId(session.workspaceId, userId)
+        memberRepo ->> db: SELECT app.workspace_member
+        alt membership exists
+            memberRepo -->> interceptor: WorkspaceMember
+            interceptor -->> client: subscription allowed
+        else membership missing
+            memberRepo -->> interceptor: empty
+            interceptor -->> client: AccessDeniedException
+        end
+    else customer user
+        interceptor ->> interceptor: compare userId with session.startedBy
+        interceptor -->> client: allow or AccessDeniedException
+    end
+```
+
+## WebSocket API
+
+기존 destination 계약은 유지한다.
+
+| STOMP Command | Destination | Access Rule |
+| --- | --- | --- |
+| `SUBSCRIBE` | `/topic/chat.{sessionId}` | OPERATOR는 세션 워크스페이스 멤버여야 한다. 고객 사용자는 본인이 시작한 세션이어야 한다. |
+| `SUBSCRIBE` | `/topic/workspaces.{workspaceId}.consultation.queue` | 기존처럼 OPERATOR role과 워크스페이스 멤버십이 필요하다. |
+
+### Error Cases
+
+| Condition | Expected behavior |
+| --- | --- |
+| chat topic의 `sessionId`가 숫자가 아님 | `BadRequestException` |
+| chat topic의 `sessionId`에 해당하는 세션 없음 | `BadRequestException` with `SESSION_NOT_FOUND` |
+| OPERATOR가 세션 워크스페이스 멤버가 아님 | `AccessDeniedException` |
+| 고객 사용자가 본인이 시작하지 않은 세션 구독 | `AccessDeniedException` |
+
+## Class Design
+
+```mermaid
+classDiagram
+    class JwtChannelInterceptor {
+        -validateSubscribeDestination(String, StompHeaderAccessor)
+        -validateChatTopicSubscription(String, StompHeaderAccessor)
+        -validateWorkspaceQueueSubscription(String, StompHeaderAccessor)
+        -validateWorkspaceMembership(Long, Long)
+    }
+
+    class ChatSessionRepository {
+        <<interface>>
+        +findById(Long): Optional~ChatSession~
+    }
+
+    class WorkspaceMemberRepository {
+        <<interface>>
+        +findByWorkspaceIdAndUserId(Long, Long): Optional~WorkspaceMember~
+    }
+
+    JwtChannelInterceptor --> ChatSessionRepository
+    JwtChannelInterceptor --> WorkspaceMemberRepository
+```
+
+## Requirements
+
+1. `JwtChannelInterceptor`는 `/topic/chat.{sessionId}` 구독 시 role과 무관하게 `ChatSessionRepository.findById(sessionId)`로 세션을 조회한다.
+2. OPERATOR role인 경우 세션의 `workspaceId`와 인증된 `userId`로 `WorkspaceMemberRepository.findByWorkspaceIdAndUserId`를 호출한다.
+3. OPERATOR가 세션 워크스페이스 멤버가 아니면 `AccessDeniedException`으로 구독을 차단한다.
+4. 고객 사용자는 기존처럼 `session.startedBy`가 인증된 `userId`와 같은 경우에만 chat topic 구독을 허용한다.
+5. workspace queue topic의 기존 OPERATOR role 및 워크스페이스 멤버십 검증 동작은 유지한다.
+6. 잘못된 destination 또는 없는 session에 대한 기존 예외 의미를 유지한다.
+
+## Data/API Impacts
+
+- DB migration 없음.
+- WebSocket destination 변경 없음.
+- REST API 변경 없음.
+- repository interface 변경 없음.
+
+## Validation
+
+- `JwtChannelInterceptorTest`에 OPERATOR가 세션 워크스페이스 멤버인 경우 chat topic 구독이 허용되는 케이스를 유지한다.
+- `JwtChannelInterceptorTest`에 OPERATOR가 세션 워크스페이스 멤버가 아닌 경우 chat topic 구독이 `AccessDeniedException`으로 거부되는 케이스를 추가한다.
+- 기존 고객 사용자 owned/other session 구독 테스트를 유지한다.
+- Targeted command: `cd backend && ./gradlew test --tests com.init.workflowruntime.interceptor.JwtChannelInterceptorTest`
+
+## Open Questions
+
+- 없음. assigned counselor 여부 또는 세부 모니터링 권한은 이슈에서 정책 정의 필요 항목으로 언급되었지만, 이번 확인 기준은 워크스페이스 멤버십 일관성이다.

--- a/backend/src/main/java/com/init/workflowruntime/interceptor/JwtChannelInterceptor.java
+++ b/backend/src/main/java/com/init/workflowruntime/interceptor/JwtChannelInterceptor.java
@@ -130,10 +130,6 @@ public class JwtChannelInterceptor implements ChannelInterceptor {
     Long userId = parsePrincipalUserId(accessor);
     String role = sessionRole(accessor);
 
-    if (ROLE_OPERATOR.equals(role)) {
-      return;
-    }
-
     ChatSession session =
         chatSessionRepository
             .findById(sessionId)
@@ -141,6 +137,12 @@ public class JwtChannelInterceptor implements ChannelInterceptor {
                 () ->
                     new BadRequestException(
                         "SESSION_NOT_FOUND", "Session not found: " + sessionId));
+
+    if (ROLE_OPERATOR.equals(role)) {
+      validateWorkspaceMembership(session.getWorkspaceId(), userId);
+      return;
+    }
+
     if (!userId.equals(session.getStartedBy())) {
       throw new AccessDeniedException(
           "User " + userId + " cannot subscribe to chat session " + sessionId);
@@ -155,6 +157,10 @@ public class JwtChannelInterceptor implements ChannelInterceptor {
     }
     Long workspaceId = parseWorkspaceId(destination);
     Long userId = parsePrincipalUserId(accessor);
+    validateWorkspaceMembership(workspaceId, userId);
+  }
+
+  private void validateWorkspaceMembership(Long workspaceId, Long userId) {
     workspaceMemberRepository
         .findByWorkspaceIdAndUserId(workspaceId, userId)
         .orElseThrow(

--- a/backend/src/test/java/com/init/workflowruntime/interceptor/JwtChannelInterceptorTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/interceptor/JwtChannelInterceptorTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 
 import com.init.auth.application.JwtService;
+import com.init.shared.application.exception.BadRequestException;
 import com.init.shared.application.exception.InvalidTokenException;
 import com.init.workflowruntime.domain.ChatSession;
 import com.init.workflowruntime.domain.ChatSessionRepository;
@@ -178,18 +179,56 @@ class JwtChannelInterceptorTest {
   }
 
   @Test
-  @DisplayName("SUBSCRIBE with OPERATOR auth, chat topic → passes through")
-  void should_passThrough_when_operatorSubscribesChatTopic() {
+  @DisplayName("SUBSCRIBE with OPERATOR auth and workspace membership, chat topic → passes through")
+  void should_passThrough_when_operatorSubscribesChatTopicWithWorkspaceMembership() {
     StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.SUBSCRIBE);
     accessor.setUser(() -> "42");
     accessor.setSessionAttributes(new HashMap<>(Map.of("role", "OPERATOR")));
     accessor.setDestination("/topic/chat.1");
     Message<byte[]> message =
         MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+    given(chatSessionRepository.findById(1L)).willReturn(Optional.of(createSession(1L, 2L, 99L)));
+    given(workspaceMemberRepository.findByWorkspaceIdAndUserId(2L, 42L))
+        .willReturn(Optional.of(WorkspaceMember.create(2L, 42L, WorkspaceMemberRole.OPERATOR)));
 
     Message<?> result = interceptor.preSend(message, channel);
 
     assertThat(result).isSameAs(message);
+  }
+
+  @Test
+  @DisplayName(
+      "SUBSCRIBE with OPERATOR auth but no workspace membership, chat topic → AccessDeniedException")
+  void should_throwAccessDenied_when_operatorSubscribesNonMemberChatTopic() {
+    StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.SUBSCRIBE);
+    accessor.setUser(() -> "42");
+    accessor.setSessionAttributes(new HashMap<>(Map.of("role", "OPERATOR")));
+    accessor.setDestination("/topic/chat.1");
+    Message<byte[]> message =
+        MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+    given(chatSessionRepository.findById(1L)).willReturn(Optional.of(createSession(1L, 2L, 99L)));
+    given(workspaceMemberRepository.findByWorkspaceIdAndUserId(2L, 42L))
+        .willReturn(Optional.empty());
+
+    assertThatThrownBy(() -> interceptor.preSend(message, channel))
+        .isInstanceOf(AccessDeniedException.class);
+  }
+
+  @Test
+  @DisplayName("SUBSCRIBE with OPERATOR auth, missing chat session → BadRequestException")
+  void should_throwBadRequest_when_operatorSubscribesMissingChatSession() {
+    StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.SUBSCRIBE);
+    accessor.setUser(() -> "42");
+    accessor.setSessionAttributes(new HashMap<>(Map.of("role", "OPERATOR")));
+    accessor.setDestination("/topic/chat.1");
+    Message<byte[]> message =
+        MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+    given(chatSessionRepository.findById(1L)).willReturn(Optional.empty());
+
+    assertThatThrownBy(() -> interceptor.preSend(message, channel))
+        .isInstanceOfSatisfying(
+            BadRequestException.class,
+            exception -> assertThat(exception.getCode()).isEqualTo("SESSION_NOT_FOUND"));
   }
 
   @Test
@@ -263,6 +302,9 @@ class JwtChannelInterceptorTest {
     accessor.setDestination("/topic/chat.1");
     Message<byte[]> message =
         MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+    given(chatSessionRepository.findById(1L)).willReturn(Optional.of(createSession(1L, 1L, 99L)));
+    given(workspaceMemberRepository.findByWorkspaceIdAndUserId(1L, 42L))
+        .willReturn(Optional.of(WorkspaceMember.create(1L, 42L, WorkspaceMemberRole.OPERATOR)));
 
     Message<?> result = interceptor.preSend(message, channel);
 
@@ -369,8 +411,12 @@ class JwtChannelInterceptorTest {
   }
 
   private ChatSession createSession(Long id, Long startedBy) {
+    return createSession(id, 1L, startedBy);
+  }
+
+  private ChatSession createSession(Long id, Long workspaceId, Long startedBy) {
     ChatSession session =
-        ChatSession.create(1L, 1L, ChatSessionStatus.OPEN, "WEB", "{}", startedBy);
+        ChatSession.create(workspaceId, 1L, ChatSessionStatus.OPEN, "WEB", "{}", startedBy);
     ReflectionTestUtils.setField(session, "id", id);
     return session;
   }


### PR DESCRIPTION
## Summary
- WebSocket chat topic 구독 시 OPERATOR도 sessionId로 상담 세션을 조회하도록 했습니다.
- 세션의 workspaceId 기준으로 현재 사용자의 workspace membership을 검증해 비멤버 workspace chat topic 구독을 차단합니다.
- 고객 사용자는 기존처럼 본인이 시작한 세션만 구독할 수 있게 유지하고, 구현 기준을 `.agent/specs/360.md`에 정리했습니다.
- OPERATOR chat topic에서 세션이 없을 때 `SESSION_NOT_FOUND`로 거부되는 회귀 방지 테스트를 추가했습니다.

## Validation
- `git diff --check`
- `git diff --cached --check`
- GitHub Actions: backend, backend-sonar, spec-check, ci-gate 통과
- CodeRabbit status 통과

## Notes
- `cd backend && ./gradlew test --tests com.init.workflowruntime.interceptor.JwtChannelInterceptorTest`는 로컬 Java 21 toolchain 부재로 실행 전 실패했습니다.

Closes #360