### PR TITLE
feat(consultation): 상담 배정 해제 확인 흐름 제공

### DIFF
--- a/.agent/specs/363.md
+++ b/.agent/specs/363.md
@@ -1,0 +1,106 @@
+# Issue 363 Spec: 상담 배정 해제 전 확인과 작성 중 내용 보호
+
+## Goal
+
+상담사가 현재 배정된 상담을 해제하기 전에 해제 결과와 유실 가능성이 있는 작성 중 상태를 확인하고, 취소하면 기존 작업 맥락을 그대로 유지할 수 있게 한다.
+
+## Problem
+
+상담 화면의 `배정 해제` 버튼은 클릭 즉시 release API를 호출한다. 해제 성공 후 현재 대화, 선택된 메시지, 작성 중인 답변, 내부 메모 화면이 비워질 수 있지만, 상담사는 이 영향을 사전에 확인할 수 없다. 상담 종료에는 확인 모달이 있으나 배정 해제에는 별도 보호 흐름이 없다.
+
+## Scope
+
+- `frontend/src/pages/consultation/ui/ConsultationPage.tsx`
+- `frontend/src/pages/consultation/ui/consultation-page.module.css`
+- `frontend/src/features/consultation/ui/ChatPanel.tsx`
+- `frontend/src/features/consultation/ui/ChatPanel.test.tsx`
+- `frontend/src/pages/consultation/ui/ConsultationPage.test.tsx`
+
+## Non-goals
+
+- 배정 해제 사유를 서버에 저장하거나 release API request body를 변경하지 않는다.
+- Backend domain 또는 REST endpoint 동작은 변경하지 않는다.
+- 자동 임시저장, 브라우저 이탈 방지, 세션 간 작성 내용 복원 정책은 이번 범위에 포함하지 않는다.
+- 상담 종료 모달 정책은 변경하지 않는다.
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A[상담사가 배정 해제 클릭] --> B[배정 해제 확인 모달 표시]
+    B --> C{작성 중 답변/내부 메모/선택 메시지 있음?}
+    C -->|Yes| D[유실 가능 상태 경고 표시]
+    C -->|No| E[기본 해제 안내 표시]
+    D --> F{사용자 선택}
+    E --> F
+    F -->|취소| G[모달 닫기 및 기존 입력/메모/선택 유지]
+    F -->|해제 확인| H[release API 호출]
+    H -->|성공| I[큐 갱신, active conversation 초기화, 상담 루트 이동]
+    H -->|실패| J[모달 유지 또는 닫힘 없이 실패 토스트 표시]
+```
+
+## Design Diff
+
+| 영역 | As-is | To-be | 변경 내용 |
+| --- | --- | --- | --- |
+| 배정 해제 액션 | 버튼 클릭 즉시 API 호출 | 확인 모달에서 명시 확인 후 API 호출 | 실수 방지 |
+| 작성 중 답변 | 해제 전 감지 불가 | 답변 입력창에 내용이 있으면 경고 | 유실 인지 |
+| 내부 메모 | 해제 전 감지 불가 | 우측 내부 메모 textarea에 내용이 있으면 경고 | 유실 인지 |
+| 선택 메시지 | 해제 전 감지 불가 | 메시지 상세 선택 상태가 있으면 경고 | 맥락 유실 인지 |
+| 취소 | API 호출 이후 되돌릴 수 없음 | API 호출 없이 모달만 닫음 | 기존 상태 유지 |
+
+## Component Tree
+
+```text
+ConsultationPage
+├─ QueuePanel
+├─ ChatPanel
+│    └─ controlled composer draft state
+├─ CustomerPanel
+└─ ReleaseAssignmentDialog
+     ├─ release result notice
+     ├─ unsaved-state warning list
+     └─ cancel / confirm actions
+```
+
+## API Integration
+
+기존 endpoint를 유지한다.
+
+| Method | Path | Description |
+| --- | --- | --- |
+| POST | `/api/v1/consultation/sessions/:id/release` | 현재 상담사 배정 해제 |
+
+release API는 사용자가 모달에서 `해제 확인`을 누른 뒤에만 호출한다. API payload 또는 response DTO 변경은 없다.
+
+## State Management
+
+- `ChatPanel`은 작성 중 답변과 NOTE 모드 여부를 부모가 관찰할 수 있도록 composer draft 값을 props로 받거나 변경 이벤트를 전달한다.
+- `ConsultationPage`는 활성 세션별 작성 중 답변, 우측 내부 메모, 선택 메시지 상태를 기준으로 배정 해제 경고 항목을 계산한다.
+- 취소는 release API를 호출하지 않고 모달만 닫는다.
+- 해제 성공은 기존 동작처럼 queue row를 서버 응답 기준으로 갱신하고 active conversation을 초기화한다.
+- 해제 실패는 API 실패 토스트를 표시하고 사용자가 입력 상태를 잃지 않도록 active conversation을 유지한다.
+
+## Acceptance Criteria
+
+- `배정 해제` 버튼 클릭만으로 release API가 호출되지 않는다.
+- 확인 모달은 해제 후 세션이 미배정 대기열로 돌아간다는 점을 안내한다.
+- 작성 중 답변, 내부 메모, 선택된 메시지 중 하나라도 있으면 별도 경고가 표시된다.
+- 모달에서 취소하면 작성 중 답변, 내부 메모, 선택 메시지 상태가 유지된다.
+- 모달에서 해제 확인을 누른 뒤에만 release API가 호출된다.
+- 해제 성공 후 큐와 active conversation 상태는 서버 release 응답에 맞춰 갱신된다.
+
+## Validation
+
+- Frontend tests:
+  - `ConsultationPage`에서 배정 해제 클릭만으로 `releaseSession`이 호출되지 않는지 검증한다.
+  - 작성 중 답변/내부 메모/선택 메시지가 있을 때 경고가 표시되는지 검증한다.
+  - 취소 시 입력/메모/선택 상태가 유지되는지 검증한다.
+  - 확인 시 release API가 호출되고 기존 성공 흐름이 유지되는지 검증한다.
+  - `ChatPanel`이 composer draft 변경을 부모에 전달하고 controlled draft를 렌더링하는지 검증한다.
+- Targeted local command:
+  - `cd frontend && pnpm test -- --run src/features/consultation/ui/ChatPanel.test.tsx src/pages/consultation/ui/ConsultationPage.test.tsx`
+
+## Open Questions
+
+- 배정 해제 사유 선택/입력은 서버 계약 변경이 필요한 제품 정책이다. 이번 이슈에서는 검토 대상으로 남기고 구현 범위에 포함하지 않는다.

--- a/frontend/src/features/consultation/ui/ChatPanel.test.tsx
+++ b/frontend/src/features/consultation/ui/ChatPanel.test.tsx
@@ -102,7 +102,9 @@ describe("ChatPanel", () => {
 
   it("답변 초안을 입력창에 삽입하되 자동 전송하지 않는다", async () => {
     const onSendMessage = vi.fn();
-    const onInsert = vi.fn(() => Promise.resolve("주문번호를 확인해주시면 환불 상태를 안내드리겠습니다."));
+    const onInsert = vi.fn(() =>
+      Promise.resolve("주문번호를 확인해주시면 환불 상태를 안내드리겠습니다."),
+    );
 
     render(
       <ChatPanel
@@ -149,6 +151,55 @@ describe("ChatPanel", () => {
       expect(onInsert).toHaveBeenCalled();
     });
     expect(input).toHaveValue("기존 작성 내용");
+  });
+
+  it("controlled composer draft 값을 입력창에 표시한다", () => {
+    render(
+      <ChatPanel
+        customerName="김민지"
+        channel="카카오톡"
+        messages={[]}
+        onSendMessage={vi.fn()}
+        selectedMessageId={null}
+        onSelectMessage={vi.fn()}
+        composerDraft={{ input: "저장된 내부 메모", isNoteMode: true }}
+      />,
+    );
+
+    expect(
+      screen.getByPlaceholderText("내부 메모로 타임라인에 남길 내용을 입력하세요..."),
+    ).toHaveValue("저장된 내부 메모");
+  });
+
+  it("composer draft 변경을 부모 핸들러에 전달한다", () => {
+    const onComposerDraftChange = vi.fn();
+
+    render(
+      <ChatPanel
+        customerName="김민지"
+        channel="카카오톡"
+        messages={[]}
+        onSendMessage={vi.fn()}
+        selectedMessageId={null}
+        onSelectMessage={vi.fn()}
+        composerDraft={{ input: "", isNoteMode: false }}
+        onComposerDraftChange={onComposerDraftChange}
+      />,
+    );
+
+    fireEvent.change(screen.getByPlaceholderText("메시지를 입력하세요..."), {
+      target: { value: "작성 중 답변" },
+    });
+    expect(onComposerDraftChange).toHaveBeenLastCalledWith({
+      input: "작성 중 답변",
+      isNoteMode: false,
+    });
+
+    fireEvent.click(screen.getByTitle("내부 메모로 남기기"));
+    expect(onComposerDraftChange).toHaveBeenLastCalledWith({
+      input: "",
+      isNoteMode: true,
+    });
   });
 
   it("답변 초안 액션이 없으면 초안 삽입 버튼을 숨긴다", () => {

--- a/frontend/src/features/consultation/ui/ChatPanel.tsx
+++ b/frontend/src/features/consultation/ui/ChatPanel.tsx
@@ -19,6 +19,11 @@ export interface ChatMessage {
   errorMessage?: string;
 }
 
+export interface ChatComposerDraft {
+  input: string;
+  isNoteMode: boolean;
+}
+
 interface ChatPanelProps {
   sessionId?: string | null;
   customerName: string | null;
@@ -36,6 +41,8 @@ interface ChatPanelProps {
     isLoading: boolean;
     onInsert: () => Promise<string>;
   };
+  composerDraft?: ChatComposerDraft;
+  onComposerDraftChange?: (draft: ChatComposerDraft) => void;
 }
 
 const BOTTOM_SCROLL_THRESHOLD_PX = 96;
@@ -73,12 +80,23 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
   disabled = false,
   disabledReason,
   draftResponseAction,
+  composerDraft,
+  onComposerDraftChange,
 }) => {
-  const [input, setInput] = useState("");
-  const [isNoteMode, setIsNoteMode] = useState(false);
+  const [uncontrolledDraft, setUncontrolledDraft] = useState<ChatComposerDraft>({
+    input: "",
+    isNoteMode: false,
+  });
   const listRef = useRef<HTMLDivElement>(null);
   const customerInitial = customerName?.trim().charAt(0) || "?";
   const sessionKey = sessionId ?? customerName;
+  const activeDraft = composerDraft ?? uncontrolledDraft;
+  const setActiveDraft = (nextDraft: ChatComposerDraft) => {
+    if (!composerDraft) {
+      setUncontrolledDraft(nextDraft);
+    }
+    onComposerDraftChange?.(nextDraft);
+  };
   const [scrollState, setScrollState] = useState<MessageScrollState>(() => ({
     sessionKey,
     messageCount: messages.length,
@@ -174,8 +192,7 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
     try {
       const draft = await draftResponseAction.onInsert();
       if (draft.trim()) {
-        setInput(draft);
-        setIsNoteMode(false);
+        setActiveDraft({ input: draft, isNoteMode: false });
       }
     } catch {
       // The page-level handler owns user-facing error feedback and the existing input is preserved.
@@ -187,9 +204,9 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
    * 공백 검사 및 한글 IME 입력 충돌 방지 로직을 포함합니다.
    */
   const handleSend = () => {
-    if (disabled || !input.trim()) return;
-    onSendMessage(input.trim(), isNoteMode);
-    setInput("");
+    if (disabled || !activeDraft.input.trim()) return;
+    onSendMessage(activeDraft.input.trim(), activeDraft.isNoteMode);
+    setActiveDraft({ ...activeDraft, input: "" });
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -352,18 +369,16 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
       </div>
 
       {disabled && disabledReason && (
-        <output className={styles.disabledNotice}>
-          {disabledReason}
-        </output>
+        <output className={styles.disabledNotice}>{disabledReason}</output>
       )}
 
       {/* Input */}
       <div className={styles.inputArea}>
         <button
-          className={`${styles.noteToggle} ${isNoteMode ? styles.noteToggleActive : ""}`}
-          onClick={() => setIsNoteMode(!isNoteMode)}
+          className={`${styles.noteToggle} ${activeDraft.isNoteMode ? styles.noteToggleActive : ""}`}
+          onClick={() => setActiveDraft({ ...activeDraft, isNoteMode: !activeDraft.isNoteMode })}
           disabled={disabled}
-          title={isNoteMode ? "일반 메시지로 전환" : "내부 메모로 남기기"}
+          title={activeDraft.isNoteMode ? "일반 메시지로 전환" : "내부 메모로 남기기"}
         >
           <StickyNote size={18} />
         </button>
@@ -384,21 +399,21 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
           className={styles.messageInput}
           rows={1}
           placeholder={
-            isNoteMode
+            activeDraft.isNoteMode
               ? "내부 메모로 타임라인에 남길 내용을 입력하세요..."
               : "메시지를 입력하세요..."
           }
-          value={input}
-          onChange={(e) => setInput(e.target.value)}
+          value={activeDraft.input}
+          onChange={(e) => setActiveDraft({ ...activeDraft, input: e.target.value })}
           onKeyDown={handleKeyDown}
           disabled={disabled}
         />
         <button
           className={styles.sendBtn}
           onClick={handleSend}
-          disabled={disabled || !input.trim()}
-          aria-label={isNoteMode ? "내부 메모 남기기" : "메시지 전송"}
-          title={isNoteMode ? "내부 메모로 남기기" : "메시지 전송"}
+          disabled={disabled || !activeDraft.input.trim()}
+          aria-label={activeDraft.isNoteMode ? "내부 메모 남기기" : "메시지 전송"}
+          title={activeDraft.isNoteMode ? "내부 메모로 남기기" : "메시지 전송"}
         >
           <Send size={18} />
         </button>

--- a/frontend/src/pages/consultation/ui/ConsultationPage.test.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.test.tsx
@@ -653,7 +653,9 @@ describe("ConsultationPage", () => {
       );
       expect(mockSendTo).not.toHaveBeenCalledWith(
         "/app/chat.counselor.send",
-        expect.objectContaining({ content: "주문번호를 확인해주시면 환불 상태를 안내드리겠습니다." }),
+        expect.objectContaining({
+          content: "주문번호를 확인해주시면 환불 상태를 안내드리겠습니다.",
+        }),
       );
     });
 
@@ -1149,7 +1151,7 @@ describe("ConsultationPage", () => {
     expect(screen.getByRole("button", { name: "AI 보조만 사용" })).toBeDisabled();
   });
 
-  it("releases the current counselor assignment through the backend API", async () => {
+  it("opens confirmation before releasing the current counselor assignment", async () => {
     saveTestUser(7);
 
     render(<ConsultationPage />, { wrapper: Wrapper });
@@ -1169,9 +1171,62 @@ describe("ConsultationPage", () => {
 
     fireEvent.click(screen.getByText("배정 해제"));
 
+    expect(consultationApi.releaseSession).not.toHaveBeenCalled();
+    expect(screen.getByRole("dialog")).toHaveTextContent("김민지 고객 배정 해제");
+    expect(screen.getByText(/다시 미배정 대기열로 돌아가며/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "해제 확인" }));
+
     await waitFor(() => {
       expect(consultationApi.releaseSession).toHaveBeenCalledWith(1);
     });
+  });
+
+  it("warns about in-progress content and preserves it when release is cancelled", async () => {
+    const user = userEvent.setup();
+    render(<ConsultationPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("김민지")).toBeInTheDocument();
+    });
+
+    const customerItem = screen.getByText("김민지").closest('[role="button"]');
+    if (customerItem) {
+      fireEvent.click(customerItem);
+    }
+
+    const input = await screen.findByPlaceholderText("메시지를 입력하세요...");
+    await user.type(input, "임시 답변");
+
+    const memo = await screen.findByPlaceholderText(
+      "타임라인에 내부 메모로 남길 내용을 입력하세요...",
+    );
+    await user.type(memo, "카드사 확인 필요");
+
+    const messageGroup = screen.getByText("환불 문의 드립니다.").closest('[role="button"]');
+    if (!messageGroup) throw new Error("message group not found");
+    fireEvent.click(messageGroup);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("message-domain-empty")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("배정 해제"));
+
+    expect(screen.getByText("메시지 입력창에 작성 중인 답변이 있습니다.")).toBeInTheDocument();
+    expect(screen.getByText("우측 패널에 저장하지 않은 내부 메모가 있습니다.")).toBeInTheDocument();
+    expect(screen.getByText("선택한 메시지 상세 맥락이 닫힙니다.")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "취소" }));
+
+    expect(consultationApi.releaseSession).not.toHaveBeenCalled();
+    expect(input).toHaveValue("임시 답변");
+    expect(screen.getByTestId("message-domain-empty")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "닫기" }));
+    expect(
+      screen.getByPlaceholderText("타임라인에 내부 메모로 남길 내용을 입력하세요..."),
+    ).toHaveValue("카드사 확인 필요");
   });
 
   it("does not render hard-coded suggestion strip when customer is active", async () => {

--- a/frontend/src/pages/consultation/ui/ConsultationPage.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.tsx
@@ -110,6 +110,13 @@ const EMPTY_COMPOSER_DRAFT: ChatComposerDraft = {
   isNoteMode: false,
 };
 
+const getComposerDraftReleaseWarning = (draft: ChatComposerDraft) => {
+  if (!draft.input.trim()) return null;
+  return draft.isNoteMode
+    ? "메시지 입력창에 작성 중인 내부 메모가 있습니다."
+    : "메시지 입력창에 작성 중인 답변이 있습니다.";
+};
+
 const getResponseModeView = (mode?: ConsultationResponseMode | null) =>
   RESPONSE_MODE_OPTIONS.find((option) => option.value === mode) ?? RESPONSE_MODE_OPTIONS[0];
 
@@ -628,11 +635,7 @@ export const ConsultationPage: React.FC = () => {
     : EMPTY_COMPOSER_DRAFT;
   const activeMemoDraft = activeCustomerId ? (memos[activeCustomerId] ?? "") : "";
   const releaseWarningItems = [
-    activeComposerDraft.input.trim()
-      ? activeComposerDraft.isNoteMode
-        ? "메시지 입력창에 작성 중인 내부 메모가 있습니다."
-        : "메시지 입력창에 작성 중인 답변이 있습니다."
-      : null,
+    getComposerDraftReleaseWarning(activeComposerDraft),
     activeMemoDraft.trim() ? "우측 패널에 저장하지 않은 내부 메모가 있습니다." : null,
     selectedMessage ? "선택한 메시지 상세 맥락이 닫힙니다." : null,
   ].filter((item): item is string => item !== null);

--- a/frontend/src/pages/consultation/ui/ConsultationPage.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.tsx
@@ -8,7 +8,10 @@ import { getAuthUser } from "@/shared/lib/auth";
 import { QueuePanel } from "../../../features/consultation/ui/QueuePanel";
 import type { QueueCustomer } from "../../../features/consultation/ui/QueuePanel";
 import { ChatPanel } from "../../../features/consultation/ui/ChatPanel";
-import type { ChatMessage as UiChatMessage } from "../../../features/consultation/ui/ChatPanel";
+import type {
+  ChatComposerDraft,
+  ChatMessage as UiChatMessage,
+} from "../../../features/consultation/ui/ChatPanel";
 import {
   normalizeChatSenderRole,
   type ChatSenderRole,
@@ -102,6 +105,10 @@ const RESPONSE_MODE_OPTIONS: ResponseModeView[] = [
 ];
 
 const DEFAULT_RESPONSE_MODE: ConsultationResponseMode = "AI_ACTIVE";
+const EMPTY_COMPOSER_DRAFT: ChatComposerDraft = {
+  input: "",
+  isNoteMode: false,
+};
 
 const getResponseModeView = (mode?: ConsultationResponseMode | null) =>
   RESPONSE_MODE_OPTIONS.find((option) => option.value === mode) ?? RESPONSE_MODE_OPTIONS[0];
@@ -114,6 +121,16 @@ type EndSessionModalState =
       customerName: string;
       outcome: ResolutionOutcome | null;
       reason: string;
+      isSubmitting: boolean;
+      error: string | null;
+    };
+
+type ReleaseAssignmentModalState =
+  | { open: false }
+  | {
+      open: true;
+      sessionId: string;
+      customerName: string;
       isSubmitting: boolean;
       error: string | null;
     };
@@ -514,6 +531,7 @@ export const ConsultationPage: React.FC = () => {
   const [isMetricsLoading, setIsMetricsLoading] = useState(false);
   const [metricsError, setMetricsError] = useState<string | null>(null);
   const [memos, setMemos] = useState<Record<string, string>>({});
+  const [composerDrafts, setComposerDrafts] = useState<Record<string, ChatComposerDraft>>({});
   const [selectedMessageId, setSelectedMessageId] = useState<string | null>(null);
   const [isQueueLoading, setIsQueueLoading] = useState(false);
   const [queueLoadError, setQueueLoadError] = useState<string | null>(null);
@@ -521,9 +539,16 @@ export const ConsultationPage: React.FC = () => {
   const [isMatchedWorkflowLoading, setIsMatchedWorkflowLoading] = useState(false);
   const [isDraftResponseLoading, setIsDraftResponseLoading] = useState(false);
   const [endSessionModal, setEndSessionModal] = useState<EndSessionModalState>({ open: false });
+  const [releaseAssignmentModal, setReleaseAssignmentModal] = useState<ReleaseAssignmentModalState>(
+    { open: false },
+  );
   const [isResponseModeUpdating, setIsResponseModeUpdating] = useState(false);
   const isEndSessionModalOpen = endSessionModal.open;
   const isEndSessionSubmitting = endSessionModal.open ? endSessionModal.isSubmitting : false;
+  const isReleaseAssignmentModalOpen = releaseAssignmentModal.open;
+  const isReleaseAssignmentSubmitting = releaseAssignmentModal.open
+    ? releaseAssignmentModal.isSubmitting
+    : false;
   const [hasQueueLoaded, setHasQueueLoaded] = useState(false);
   const [urlSessionUnavailable, setUrlSessionUnavailable] = useState(false);
   const [claimingSessionId, setClaimingSessionId] = useState<string | null>(null);
@@ -598,6 +623,19 @@ export const ConsultationPage: React.FC = () => {
   const visibleMessages =
     activeCustomer && messagesCustomerId === activeCustomer.id ? messages : [];
   const selectedMessage = visibleMessages.find((m) => m.id === selectedMessageId) || null;
+  const activeComposerDraft = activeCustomerId
+    ? (composerDrafts[activeCustomerId] ?? EMPTY_COMPOSER_DRAFT)
+    : EMPTY_COMPOSER_DRAFT;
+  const activeMemoDraft = activeCustomerId ? (memos[activeCustomerId] ?? "") : "";
+  const releaseWarningItems = [
+    activeComposerDraft.input.trim()
+      ? activeComposerDraft.isNoteMode
+        ? "메시지 입력창에 작성 중인 내부 메모가 있습니다."
+        : "메시지 입력창에 작성 중인 답변이 있습니다."
+      : null,
+    activeMemoDraft.trim() ? "우측 패널에 저장하지 않은 내부 메모가 있습니다." : null,
+    selectedMessage ? "선택한 메시지 상세 맥락이 닫힙니다." : null,
+  ].filter((item): item is string => item !== null);
   const activeAssignment = activeCustomer
     ? getAssignmentView(
         activeCustomer.status,
@@ -614,7 +652,8 @@ export const ConsultationPage: React.FC = () => {
   const isActiveSessionClosed =
     activeCustomer?.status === "COMPLETED" || activeCustomer?.status === "RESOLVED";
   const isActiveSessionUnassigned = !!activeCustomer && !activeCustomer.assignedCounselorId;
-  const isClaimingActiveSession = activeCustomerId != null && claimingSessionId === activeCustomerId;
+  const isClaimingActiveSession =
+    activeCustomerId != null && claimingSessionId === activeCustomerId;
   const messageInputDisabledReason = isAssignedToCurrentCounselor
     ? undefined
     : activeAssignment?.description;
@@ -629,6 +668,7 @@ export const ConsultationPage: React.FC = () => {
     setIsMatchedWorkflowLoading(false);
     setIsDraftResponseLoading(false);
     setEndSessionModal({ open: false });
+    setReleaseAssignmentModal({ open: false });
     clearPendingMessages();
   }, [clearPendingMessages]);
 
@@ -828,20 +868,17 @@ export const ConsultationPage: React.FC = () => {
     void loadQueue();
   }, [loadQueue]);
 
-  const activateCustomer = useCallback(
-    (id: string) => {
-      setActiveCustomerId(id);
-      setSelectedMessageId(null);
-      setQueue((prev) =>
-        prev.some((customer) => customer.id === id && customer.hasUnread)
-          ? prev.map((customer) =>
-              customer.id === id ? { ...customer, hasUnread: false } : customer,
-            )
-          : prev,
-      );
-    },
-    [],
-  );
+  const activateCustomer = useCallback((id: string) => {
+    setActiveCustomerId(id);
+    setSelectedMessageId(null);
+    setQueue((prev) =>
+      prev.some((customer) => customer.id === id && customer.hasUnread)
+        ? prev.map((customer) =>
+            customer.id === id ? { ...customer, hasUnread: false } : customer,
+          )
+        : prev,
+    );
+  }, []);
 
   useEffect(() => {
     if (!routeSessionIdParam) {
@@ -1197,6 +1234,21 @@ export const ConsultationPage: React.FC = () => {
     };
   }, [isEndSessionModalOpen, isEndSessionSubmitting]);
 
+  useEffect(() => {
+    if (!isReleaseAssignmentModalOpen || isReleaseAssignmentSubmitting) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setReleaseAssignmentModal({ open: false });
+      }
+    };
+
+    globalThis.addEventListener("keydown", handleKeyDown);
+    return () => {
+      globalThis.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isReleaseAssignmentModalOpen, isReleaseAssignmentSubmitting]);
+
   const handleSelectResolutionOutcome = (outcome: ResolutionOutcome) => {
     setEndSessionModal((prev) => (prev.open ? { ...prev, outcome, error: null } : prev));
   };
@@ -1243,9 +1295,34 @@ export const ConsultationPage: React.FC = () => {
     }
   };
 
-  const handleReleaseAssignment = async () => {
+  const handleOpenReleaseAssignment = () => {
     if (!activeCustomerId || !currentCounselorId || !isAssignedToCurrentCounselor) return;
-    const releasedSessionId = activeCustomerId;
+    setReleaseAssignmentModal({
+      open: true,
+      sessionId: activeCustomerId,
+      customerName: activeCustomerName,
+      isSubmitting: false,
+      error: null,
+    });
+  };
+
+  const handleCancelReleaseAssignment = () => {
+    setReleaseAssignmentModal({ open: false });
+  };
+
+  const handleConfirmReleaseAssignment = async () => {
+    if (
+      !releaseAssignmentModal.open ||
+      releaseAssignmentModal.isSubmitting ||
+      !currentCounselorId
+    ) {
+      return;
+    }
+
+    const releasedSessionId = releaseAssignmentModal.sessionId;
+    setReleaseAssignmentModal((prev) =>
+      prev.open ? { ...prev, isSubmitting: true, error: null } : prev,
+    );
 
     try {
       const releasedSession = await consultationApi.releaseSession(Number(releasedSessionId));
@@ -1258,11 +1335,31 @@ export const ConsultationPage: React.FC = () => {
           ),
         ),
       );
+      setMemos((prev) => {
+        const next = { ...prev };
+        delete next[releasedSessionId];
+        return next;
+      });
+      setComposerDrafts((prev) => {
+        const next = { ...prev };
+        delete next[releasedSessionId];
+        return next;
+      });
       toast.success("상담 배정이 해제되었습니다.");
       clearActiveConversation();
+      setReleaseAssignmentModal({ open: false });
       navigateToConsultationRoot();
     } catch (error) {
       console.error("Failed to release session:", error);
+      setReleaseAssignmentModal((prev) =>
+        prev.open
+          ? {
+              ...prev,
+              isSubmitting: false,
+              error: "상담 배정 해제를 완료하지 못했습니다.",
+            }
+          : prev,
+      );
       toast.error("상담 배정 해제에 실패했습니다.");
     }
   };
@@ -1399,7 +1496,7 @@ export const ConsultationPage: React.FC = () => {
               </div>
               <button
                 className={styles.linkButton}
-                onClick={handleReleaseAssignment}
+                onClick={handleOpenReleaseAssignment}
                 disabled={!isAssignedToCurrentCounselor}
               >
                 배정 해제
@@ -1445,6 +1542,11 @@ export const ConsultationPage: React.FC = () => {
                     }
                   : undefined
               }
+              composerDraft={activeComposerDraft}
+              onComposerDraftChange={(draft) => {
+                if (!activeCustomerId) return;
+                setComposerDrafts((prev) => ({ ...prev, [activeCustomerId]: draft }));
+              }}
             />
           )}
         </div>
@@ -1572,6 +1674,71 @@ export const ConsultationPage: React.FC = () => {
                 disabled={endSessionModal.isSubmitting || !endSessionModal.outcome}
               >
                 {endSessionModal.isSubmitting ? "종료 중..." : "종료 확인"}
+              </button>
+            </div>
+          </dialog>
+        </div>
+      )}
+
+      {releaseAssignmentModal.open && (
+        <div className={styles.modalOverlay}>
+          <button
+            type="button"
+            className={styles.modalBackdrop}
+            aria-label="배정 해제 모달 닫기"
+            onClick={handleCancelReleaseAssignment}
+            disabled={releaseAssignmentModal.isSubmitting}
+          />
+          <dialog
+            open
+            className={styles.endSessionDialog}
+            aria-modal="true"
+            aria-labelledby="release-assignment-title"
+          >
+            <div className={styles.modalHeader}>
+              <Mono className={styles.modalEyebrow}>RELEASE ASSIGNMENT</Mono>
+              <h2 id="release-assignment-title" className={styles.modalTitle}>
+                {releaseAssignmentModal.customerName} 고객 배정 해제
+              </h2>
+            </div>
+
+            <div className={styles.releaseNotice}>
+              해제하면 이 세션은 다시 미배정 대기열로 돌아가며, 현재 상담 화면은 비워집니다.
+            </div>
+
+            {releaseWarningItems.length > 0 && (
+              <div className={styles.releaseWarning} role="alert">
+                <strong>해제 전에 확인하세요</strong>
+                <ul className={styles.releaseWarningList}>
+                  {releaseWarningItems.map((item) => (
+                    <li key={item}>{item}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            {releaseAssignmentModal.error && (
+              <div className={styles.modalError} role="alert">
+                {releaseAssignmentModal.error}
+              </div>
+            )}
+
+            <div className={styles.modalActions}>
+              <button
+                type="button"
+                className={styles.secondaryAction}
+                onClick={handleCancelReleaseAssignment}
+                disabled={releaseAssignmentModal.isSubmitting}
+              >
+                취소
+              </button>
+              <button
+                type="button"
+                className={styles.confirmDangerAction}
+                onClick={handleConfirmReleaseAssignment}
+                disabled={releaseAssignmentModal.isSubmitting}
+              >
+                {releaseAssignmentModal.isSubmitting ? "해제 중..." : "해제 확인"}
               </button>
             </div>
           </dialog>

--- a/frontend/src/pages/consultation/ui/consultation-page.module.css
+++ b/frontend/src/pages/consultation/ui/consultation-page.module.css
@@ -178,7 +178,9 @@
 
 .responseModeButton:focus-visible {
   outline: none;
-  box-shadow: inset 0 0 0 1px var(--ink), var(--focus-ring);
+  box-shadow:
+    inset 0 0 0 1px var(--ink),
+    var(--focus-ring);
 }
 
 .responseModeButton:disabled {
@@ -401,7 +403,9 @@
 }
 
 .followUpNotice,
-.modalError {
+.modalError,
+.releaseNotice,
+.releaseWarning {
   margin-top: 10px;
   padding: 10px 12px;
   border-radius: var(--r-3);
@@ -412,6 +416,34 @@
 .followUpNotice {
   border: 1px solid var(--line);
   background: var(--paper-2);
+  color: var(--ink-2);
+}
+
+.releaseNotice {
+  border: 1px solid var(--line);
+  background: var(--paper-2);
+  color: var(--ink-2);
+}
+
+.releaseWarning {
+  border: 1px solid var(--ink);
+  background: var(--paper);
+  color: var(--ink);
+}
+
+.releaseWarning strong {
+  display: block;
+  margin-bottom: 6px;
+  font-size: 12.5px;
+  font-weight: 700;
+  letter-spacing: -0.1px;
+}
+
+.releaseWarningList {
+  display: grid;
+  gap: 4px;
+  margin: 0;
+  padding-left: 18px;
   color: var(--ink-2);
 }
 


### PR DESCRIPTION
## Summary
- 상담 배정 해제 버튼이 즉시 API를 호출하지 않고 확인 모달을 먼저 표시하도록 했습니다.
- 작성 중 답변, 저장하지 않은 내부 메모, 선택된 메시지 맥락이 있을 때 해제 전 경고를 보여줍니다.
- 해제 취소 시 기존 입력/메모/선택 상태를 유지하고, 해제 확인 후에만 기존 release 성공 흐름으로 큐와 활성 대화를 갱신합니다.
- 구현 기준을 `.agent/specs/363.md`에 함께 정리했습니다.

## Validation
- `cd frontend && pnpm test -- --run src/features/consultation/ui/ChatPanel.test.tsx src/pages/consultation/ui/ConsultationPage.test.tsx`
- `cd frontend && pnpm exec eslint src/features/consultation/ui/ChatPanel.tsx src/features/consultation/ui/ChatPanel.test.tsx src/pages/consultation/ui/ConsultationPage.tsx src/pages/consultation/ui/ConsultationPage.test.tsx --quiet`
- `cd frontend && pnpm build`
- `git diff --check`
- `git diff --cached --check`

## Notes
- 전체 `cd frontend && pnpm exec eslint . --quiet`는 이번 변경과 무관한 기존 lint 오류 58개로 실패해, 변경 파일 대상으로 eslint를 확인했습니다.

Closes #363