### PR TITLE
fix(consultation): 배정 경쟁 실패 후 상담 큐 상태 복구

### DIFF
--- a/.agent/specs/361.md
+++ b/.agent/specs/361.md
@@ -1,0 +1,155 @@
+# Frontend FSD Spec: 상담 세션 배정 경쟁 실패 시 화면 상태 복구
+
+## Goal
+
+두 상담사가 같은 미배정 세션을 거의 동시에 배정받으려 할 때, 실패한 상담사의 화면을 서버 최신 상태로 복구하고 메시지 입력이 잘못 활성화되지 않도록 한다.
+
+---
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A[상담사가 미배정 세션 선택] --> B[세션을 읽기 전용으로 표시]
+    B --> C[상담사가 배정받기 클릭]
+    C --> D{assign 성공?}
+    D -->|Yes| E[내게 배정됨 상태로 큐와 입력창 갱신]
+    D -->|No: 이미 다른 상담사 배정| F[경쟁 배정 안내 토스트]
+    D -->|No: 기타 오류| G[원인별 오류 안내 토스트]
+    F --> H[상담 큐 재조회]
+    G --> H
+    H --> I{최신 큐에 세션 존재?}
+    I -->|Yes| J[assigned counselor/status 라벨 갱신]
+    I -->|No| K[선택 해제 및 상담 루트로 이동]
+    J --> L[내 배정이 아니면 메시지 입력 비활성화]
+    K --> L
+```
+
+---
+
+## Design Diff
+
+### As-is vs To-be
+
+| 영역 | As-is | To-be | 변경 내용 |
+|------|-------|-------|----------|
+| 배정 실패 안내 | `상담 세션 배정에 실패했습니다.` 단일 토스트 | 경쟁 배정, 권한, 세션 없음, 일반 오류를 구분 | 서버 에러 코드 기반 메시지 매핑 |
+| 배정 실패 후 큐 | 즉시 refetch하지 않음 | 실패 직후 workspace queue를 재조회 | assigned counselor/status 라벨을 서버 상태로 복구 |
+| 실패한 세션 선택 상태 | 선택된 상태가 유지될 수 있음 | 최신 큐에서 내 배정이 아니거나 사라지면 선택 해제 | 메시지 입력창이 활성화되지 않도록 보장 |
+| optimistic 상태 | 선택과 실제 배정 상태가 혼재될 수 있음 | 선택은 읽기 전용, assign 성공 후에만 내 배정 상태 반영 | `배정받기` 버튼 흐름과 입력 가능 조건 분리 |
+
+---
+
+## Component Tree
+
+```text
+ConsultationPage
+├─ QueuePanel
+│    └─ QueueCustomer rows
+├─ ConversationHeader
+│    ├─ assignment status badge
+│    ├─ claim button
+│    └─ response mode controls
+└─ ChatPanel
+     ├─ assignment status
+     ├─ disabled notice
+     └─ message input
+```
+
+---
+
+## API Integration
+
+### Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/v1/workspaces/{workspaceId}/consultation/queue` | 상담 큐 최신 상태 조회 |
+| POST | `/api/v1/consultation/sessions/{sessionId}/assign` | 상담 세션 배정 |
+
+### Error Code Handling
+
+| Code | UI reaction |
+|------|-------------|
+| `SESSION_ALREADY_ASSIGNED` | "이미 다른 상담사에게 배정된 상담입니다." 안내 후 큐 재조회 및 선택 해제/읽기 전용 복구 |
+| `SESSION_NOT_ASSIGNABLE` | "현재 배정할 수 없는 상담 상태입니다." 안내 후 큐 재조회 |
+| `SESSION_NOT_FOUND` | "상담 세션을 찾을 수 없습니다." 안내 후 큐 재조회 및 선택 해제 |
+| `WORKSPACE_ACCESS_DENIED` | "상담 배정 권한이 없습니다." 안내 후 큐 재조회 |
+| `FORBIDDEN` | "상담 배정 권한이 없습니다." 안내 후 큐 재조회 |
+| 기타/네트워크 | "상담 세션 배정에 실패했습니다." 안내 후 큐 재조회 시도 |
+
+---
+
+## Data Flow
+
+```text
+QueuePanel selection
+  -> ConsultationPage.activeCustomerId
+  -> read-only ChatPanel unless assignedCounselorId === currentCounselorId
+  -> claim button
+  -> consultationApi.assignSession
+  -> success: replace queue item from response
+  -> failure: toast by ApiRequestError.code
+  -> consultationApi.getQueue(workspaceId)
+  -> reconcile active selection against latest queue
+```
+
+---
+
+## 수정 대상 파일
+
+| 파일 | 변경 유형 | 설명 |
+|------|----------|------|
+| `frontend/src/pages/consultation/ui/ConsultationPage.tsx` | update | 배정 실패 코드 매핑, 실패 후 큐 동기화, 선택 상태 복구 |
+| `frontend/src/pages/consultation/ui/ConsultationPage.test.tsx` | update | 경쟁 배정 실패 후 큐 재조회/선택 해제/입력 비활성화 검증 |
+| `backend/src/main/java/com/init/workflowruntime/application/CounselorService.java` | update | assign 실패 원인을 구분할 수 있는 에러 코드 반환 |
+
+---
+
+## State Management
+
+### Server State
+
+- 상담 큐는 `consultationApi.getQueue(workspaceId)` 응답을 기준으로 정렬 및 표시한다.
+- assign 성공 시에는 assign 응답의 `ChatSession`으로 해당 큐 항목을 갱신한다.
+- assign 실패 시에는 항상 큐 재조회를 시도해 서버 상태와 화면을 다시 맞춘다.
+
+### Client State
+
+- `activeCustomerId`는 선택된 세션을 나타내며, 배정 성공을 의미하지 않는다.
+- 메시지 입력 가능 여부는 기존처럼 `assignedCounselorId === currentCounselorId` 조건만 따른다.
+- assign 실패 후 최신 큐에서 active session이 없거나 다른 상담사에게 배정되어 있으면 active selection을 해제한다.
+
+---
+
+## Tests
+
+### Test Strategy
+
+| 구분 | 방법 | 도구 | 비고 |
+|------|------|------|------|
+| 컴포넌트 테스트 | 배정 실패 시나리오 렌더링 | Vitest + React Testing Library | 큐 refetch, 토스트, 선택 해제, 입력 비활성화 확인 |
+| API/서비스 테스트 | assign 실패 코드 확인 | 기존 backend test 범위에 맞춰 필요 시 추가 | 세션 상태 guard 동작 |
+| 수동 테스트 | 두 상담사 동시 배정 | 브라우저 2개 세션 | 실패한 쪽 최신 큐 라벨 확인 |
+
+### Test Scenarios
+
+| # | 시나리오 | 조작 | 기대 결과 |
+|---|---------|------|----------|
+| 1 | 경쟁 배정 실패 | 미배정 세션 선택 후 assign API가 `SESSION_ALREADY_ASSIGNED` 반환 | 별도 토스트, 큐 재조회, 선택 해제, 입력 비활성화 |
+| 2 | 실패 후 세션이 최신 큐에 남음 | refetch 응답에 같은 session이 다른 상담사 배정 상태로 포함 | 큐 라벨이 "다른 상담사 배정"으로 갱신 |
+| 3 | 권한/네트워크 오류 | assign API 실패 | 오류 안내 후 큐 재조회 시도, 메시지 입력은 내 배정이 아니면 비활성화 |
+
+---
+
+## Non-goals
+
+- 자동 재시도 또는 배정 대기열 잠금 UX는 포함하지 않는다.
+- 상담 큐 WebSocket 프로토콜을 변경하지 않는다.
+- 메시지 전송 권한 판정 조건을 확장하지 않는다.
+
+---
+
+## Open Questions
+
+- HTTP 상태를 409 Conflict로 분리할지 여부는 현재 공통 예외 계층과 호환성을 고려해 별도 후속 논의로 남긴다. 이번 범위에서는 명확한 error code 제공과 FE 반응을 우선한다.

--- a/backend/src/main/java/com/init/workflowruntime/application/CounselorService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/CounselorService.java
@@ -67,6 +67,7 @@ public class CounselorService {
                     new NotFoundException("SESSION_NOT_FOUND", "Session not found: " + sessionId));
 
     validateWorkspaceMembership(session.getWorkspaceId(), counselorId);
+    validateAssignableForAssignment(session);
     session.assignTo(counselorId);
     chatSessionRepository.save(session);
 
@@ -256,6 +257,15 @@ public class CounselorService {
     workspaceMemberRepository
         .findByWorkspaceIdAndUserId(workspaceId, userId)
         .orElseThrow(() -> new WorkspaceAccessDeniedException("워크스페이스에 접근 권한이 없습니다."));
+  }
+
+  private void validateAssignableForAssignment(ChatSession session) {
+    if (session.getAssignedCounselorId() != null) {
+      throw new BadRequestException("SESSION_ALREADY_ASSIGNED", "이미 다른 상담사에게 배정된 상담입니다.");
+    }
+    if (session.getStatus() != ChatSessionStatus.OPEN) {
+      throw new BadRequestException("SESSION_NOT_ASSIGNABLE", "현재 배정할 수 없는 상담 상태입니다.");
+    }
   }
 
   private ChatSessionResponseMode parseResponseMode(String responseMode) {

--- a/backend/src/test/java/com/init/workflowruntime/application/CounselorServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/CounselorServiceTest.java
@@ -22,7 +22,6 @@ import com.init.workflowruntime.domain.ChatSession;
 import com.init.workflowruntime.domain.ChatSessionRepository;
 import com.init.workflowruntime.domain.ChatSessionResponseMode;
 import com.init.workflowruntime.domain.ChatSessionStatus;
-import com.init.workflowruntime.domain.InvalidSessionStateException;
 import com.init.workflowruntime.domain.event.ConsultationQueueChangedEvent;
 import com.init.workflowruntime.domain.event.ConsultationQueueEventType;
 import com.init.workflowruntime.domain.event.SessionAssignedEvent;
@@ -116,7 +115,7 @@ class CounselorServiceTest {
   }
 
   @Test
-  @DisplayName("assignSession: 이미 배정된 세션 → InvalidSessionStateException")
+  @DisplayName("assignSession: 이미 배정된 세션 → SESSION_ALREADY_ASSIGNED")
   void should_throwInvalidState_when_alreadyAssigned() {
     ChatSession session = createSession(1L, ChatSessionStatus.OPEN);
     ReflectionTestUtils.setField(session, "assignedCounselorId", 10L);
@@ -124,20 +123,28 @@ class CounselorServiceTest {
     givenWorkspaceMember(1L, 42L);
 
     assertThatThrownBy(() -> service.assignSession(1L, 42L))
-        .isInstanceOf(InvalidSessionStateException.class)
-        .hasMessageContaining("already assigned");
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("이미 다른 상담사에게 배정된 상담입니다.")
+        .satisfies(
+            ex ->
+                assertThat(((BadRequestException) ex).getCode())
+                    .isEqualTo("SESSION_ALREADY_ASSIGNED"));
   }
 
   @Test
-  @DisplayName("assignSession: OPEN이 아닌 세션 → InvalidSessionStateException")
+  @DisplayName("assignSession: OPEN이 아닌 세션 → SESSION_NOT_ASSIGNABLE")
   void should_throwInvalidState_when_notOpen() {
     ChatSession session = createSession(1L, ChatSessionStatus.COMPLETED);
     given(chatSessionRepository.findByIdForUpdate(1L)).willReturn(Optional.of(session));
     givenWorkspaceMember(1L, 42L);
 
     assertThatThrownBy(() -> service.assignSession(1L, 42L))
-        .isInstanceOf(com.init.workflowruntime.domain.InvalidSessionStateException.class)
-        .hasMessageContaining("requires status OPEN");
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("현재 배정할 수 없는 상담 상태입니다.")
+        .satisfies(
+            ex ->
+                assertThat(((BadRequestException) ex).getCode())
+                    .isEqualTo("SESSION_NOT_ASSIGNABLE"));
   }
 
   // ── releaseSession ────────────────────────────────────────────────────────

--- a/frontend/src/pages/consultation/ui/ConsultationPage.test.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.test.tsx
@@ -7,6 +7,7 @@ import { ConsultationPage } from "./ConsultationPage";
 import { consultationApi } from "../../../features/consultation/api/consultationApi";
 import { getCurrentWorkflow } from "../../../features/consultation/api/llmToolWorkflowApi";
 import { toast } from "sonner";
+import { ApiRequestError } from "@/shared/api";
 
 vi.mock("sonner", () => ({
   toast: {
@@ -987,16 +988,17 @@ describe("ConsultationPage", () => {
 
   it("keeps the session read-only when claim fails", async () => {
     saveTestUser(7);
-    vi.mocked(consultationApi.getQueue).mockResolvedValueOnce([
-      {
-        id: 1,
-        status: "OPEN",
-        channel: "카카오톡",
-        metaJson: JSON.stringify({ customerName: "김민지", handoffReason: "환불 문의" }),
-        startedAt: new Date(Date.now() - 4 * 60000).toISOString(),
-        assignedCounselorId: null,
-      },
-    ]);
+    const unassignedSession = {
+      id: 1,
+      status: "OPEN" as const,
+      channel: "카카오톡",
+      metaJson: JSON.stringify({ customerName: "김민지", handoffReason: "환불 문의" }),
+      startedAt: new Date(Date.now() - 4 * 60000).toISOString(),
+      assignedCounselorId: null,
+    };
+    vi.mocked(consultationApi.getQueue)
+      .mockResolvedValueOnce([unassignedSession])
+      .mockResolvedValueOnce([unassignedSession]);
     vi.mocked(consultationApi.assignSession).mockRejectedValueOnce(new Error("already assigned"));
 
     render(<ConsultationPage />, { wrapper: Wrapper });
@@ -1018,8 +1020,68 @@ describe("ConsultationPage", () => {
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith("상담 세션 배정에 실패했습니다.");
     });
+    expect(consultationApi.getQueue).toHaveBeenCalledTimes(2);
     expect(screen.getByRole("button", { name: "배정받기" })).toBeInTheDocument();
     expect(screen.getByLabelText("메시지 전송")).toBeDisabled();
+  });
+
+  it("syncs queue and clears the selected chat when claim fails because another counselor assigned it", async () => {
+    saveTestUser(7);
+    vi.mocked(consultationApi.getQueue)
+      .mockResolvedValueOnce([
+        {
+          id: 1,
+          status: "OPEN",
+          channel: "카카오톡",
+          metaJson: JSON.stringify({ customerName: "김민지", handoffReason: "환불 문의" }),
+          startedAt: new Date(Date.now() - 4 * 60000).toISOString(),
+          assignedCounselorId: null,
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: 1,
+          status: "ACTIVE",
+          channel: "카카오톡",
+          metaJson: JSON.stringify({ customerName: "김민지", handoffReason: "환불 문의" }),
+          startedAt: new Date(Date.now() - 4 * 60000).toISOString(),
+          assignedCounselorId: 99,
+          responseMode: "HUMAN_ACTIVE",
+        },
+      ]);
+    vi.mocked(consultationApi.assignSession).mockRejectedValueOnce(
+      new ApiRequestError(
+        400,
+        "SESSION_ALREADY_ASSIGNED",
+        "이미 다른 상담사에게 배정된 상담입니다.",
+      ),
+    );
+
+    render(<ConsultationPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("김민지")).toBeInTheDocument();
+    });
+
+    const customerItem = screen.getByText("김민지").closest('[role="button"]');
+    if (customerItem) {
+      fireEvent.click(customerItem);
+    }
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "배정받기" })).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole("button", { name: "배정받기" }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("이미 다른 상담사에게 배정된 상담입니다.");
+    });
+    await waitFor(() => {
+      expect(consultationApi.getQueue).toHaveBeenCalledTimes(2);
+      expect(screen.getAllByText("다른 상담사 배정").length).toBeGreaterThan(0);
+    });
+    expect(screen.getByText("좌측 대기 목록에서 고객을 선택해주세요")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "배정받기" })).not.toBeInTheDocument();
   });
 
   it("keeps sessions assigned to another counselor read-only with a reason", async () => {

--- a/frontend/src/pages/consultation/ui/ConsultationPage.test.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.test.tsx
@@ -203,6 +203,17 @@ function saveTestUser(id: number) {
   );
 }
 
+function createUnassignedQueueSession() {
+  return {
+    id: 1,
+    status: "OPEN" as const,
+    channel: "카카오톡",
+    metaJson: JSON.stringify({ customerName: "김민지", handoffReason: "환불 문의" }),
+    startedAt: new Date(Date.now() - 4 * 60000).toISOString(),
+    assignedCounselorId: null,
+  };
+}
+
 describe("ConsultationPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -988,14 +999,7 @@ describe("ConsultationPage", () => {
 
   it("keeps the session read-only when claim fails", async () => {
     saveTestUser(7);
-    const unassignedSession = {
-      id: 1,
-      status: "OPEN" as const,
-      channel: "카카오톡",
-      metaJson: JSON.stringify({ customerName: "김민지", handoffReason: "환불 문의" }),
-      startedAt: new Date(Date.now() - 4 * 60000).toISOString(),
-      assignedCounselorId: null,
-    };
+    const unassignedSession = createUnassignedQueueSession();
     vi.mocked(consultationApi.getQueue)
       .mockResolvedValueOnce([unassignedSession])
       .mockResolvedValueOnce([unassignedSession]);
@@ -1023,6 +1027,77 @@ describe("ConsultationPage", () => {
     expect(consultationApi.getQueue).toHaveBeenCalledTimes(2);
     expect(screen.getByRole("button", { name: "배정받기" })).toBeInTheDocument();
     expect(screen.getByLabelText("메시지 전송")).toBeDisabled();
+  });
+
+  it.each([
+    ["SESSION_NOT_ASSIGNABLE", "현재 배정할 수 없는 상담 상태입니다."],
+    ["SESSION_NOT_FOUND", "상담 세션을 찾을 수 없습니다."],
+    ["WORKSPACE_ACCESS_DENIED", "상담 배정 권한이 없습니다."],
+    ["FORBIDDEN", "상담 배정 권한이 없습니다."],
+    ["UNKNOWN_ERROR", "상담 세션 배정에 실패했습니다."],
+  ])("shows a claim failure message for %s", async (code, message) => {
+    saveTestUser(7);
+    const unassignedSession = createUnassignedQueueSession();
+    vi.mocked(consultationApi.getQueue)
+      .mockResolvedValueOnce([unassignedSession])
+      .mockResolvedValueOnce([unassignedSession]);
+    vi.mocked(consultationApi.assignSession).mockRejectedValueOnce(
+      new ApiRequestError(400, code, "배정 실패"),
+    );
+
+    render(<ConsultationPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("김민지")).toBeInTheDocument();
+    });
+
+    const customerItem = screen.getByText("김민지").closest('[role="button"]');
+    if (customerItem) {
+      fireEvent.click(customerItem);
+    }
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "배정받기" })).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole("button", { name: "배정받기" }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(message);
+    });
+    expect(consultationApi.getQueue).toHaveBeenCalledTimes(2);
+    expect(screen.getByRole("button", { name: "배정받기" })).toBeInTheDocument();
+  });
+
+  it("shows a queue sync error when refetching after claim failure fails", async () => {
+    saveTestUser(7);
+    const unassignedSession = createUnassignedQueueSession();
+    vi.mocked(consultationApi.getQueue)
+      .mockResolvedValueOnce([unassignedSession])
+      .mockRejectedValueOnce(new Error("queue sync failed"));
+    vi.mocked(consultationApi.assignSession).mockRejectedValueOnce(new Error("claim failed"));
+
+    render(<ConsultationPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("김민지")).toBeInTheDocument();
+    });
+
+    const customerItem = screen.getByText("김민지").closest('[role="button"]');
+    if (customerItem) {
+      fireEvent.click(customerItem);
+    }
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "배정받기" })).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole("button", { name: "배정받기" }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        "배정 실패 후 최신 대기열을 불러오지 못했습니다.",
+      );
+    });
+    expect(screen.getByText("대기열을 불러오지 못했습니다.")).toBeInTheDocument();
   });
 
   it("syncs queue and clears the selected chat when claim fails because another counselor assigned it", async () => {

--- a/frontend/src/pages/consultation/ui/ConsultationPage.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useCallback, useRef } from "react";
 import { useNavigate, useOutletContext, useParams } from "react-router-dom";
 import { toast } from "sonner";
+import { ApiRequestError } from "@/shared/api";
 import type { ShellContext } from "@/shared/ui/ostone/chrome";
 import { Dot, Mono, Avatar } from "@/shared/ui/ostone/atoms";
 import { useStomp } from "@/shared/lib/websocket";
@@ -425,6 +426,25 @@ const replaceAssignedQueueCustomer = (
     ),
   );
 
+const getClaimSessionErrorMessage = (error: unknown) => {
+  if (error instanceof ApiRequestError) {
+    switch (error.code) {
+      case "SESSION_ALREADY_ASSIGNED":
+        return "이미 다른 상담사에게 배정된 상담입니다.";
+      case "SESSION_NOT_ASSIGNABLE":
+        return "현재 배정할 수 없는 상담 상태입니다.";
+      case "SESSION_NOT_FOUND":
+        return "상담 세션을 찾을 수 없습니다.";
+      case "WORKSPACE_ACCESS_DENIED":
+      case "FORBIDDEN":
+        return "상담 배정 권한이 없습니다.";
+      default:
+        return "상담 세션 배정에 실패했습니다.";
+    }
+  }
+  return "상담 세션 배정에 실패했습니다.";
+};
+
 const formatAverageFirstResponse = (seconds?: number | null) => {
   if (seconds == null) return "--";
   const minutes = Math.floor(seconds / 60);
@@ -783,6 +803,37 @@ export const ConsultationPage: React.FC = () => {
     void loadQueue(true);
   }, [loadQueue]);
 
+  const synchronizeQueueAfterClaimFailure = useCallback(
+    async (targetSessionId: string) => {
+      if (!workspaceId) return;
+
+      try {
+        const sessions = await consultationApi.getQueue(workspaceId);
+        const formattedQueue = (Array.isArray(sessions) ? sessions : []).map((s) =>
+          toQueueCustomer(s, currentCounselorId),
+        );
+        setQueue(sortQueueCustomers(formattedQueue));
+        setQueueLoadError(null);
+        setHasQueueLoaded(true);
+        queueErrorToastShownRef.current = false;
+
+        const latestTarget = formattedQueue.find((customer) => customer.id === targetSessionId);
+        const isAssignedToAnotherCounselor =
+          latestTarget?.assignedCounselorId != null &&
+          latestTarget.assignedCounselorId !== currentCounselorId;
+        if (!latestTarget || isAssignedToAnotherCounselor) {
+          clearActiveConversation();
+          navigateToConsultationRoot();
+        }
+      } catch (syncError) {
+        console.error("Failed to synchronize queue after claim failure:", syncError);
+        setQueueLoadError("대기열을 불러오지 못했습니다.");
+        toast.error("배정 실패 후 최신 대기열을 불러오지 못했습니다.");
+      }
+    },
+    [clearActiveConversation, currentCounselorId, navigateToConsultationRoot, workspaceId],
+  );
+
   const handleQueueEvent = useCallback(
     (raw: unknown) => {
       const event = raw as Partial<ConsultationQueueEvent>;
@@ -1051,7 +1102,8 @@ export const ConsultationPage: React.FC = () => {
       toast.success("상담 세션이 배정되었습니다.");
     } catch (error) {
       console.error("Failed to claim session:", error);
-      toast.error("상담 세션 배정에 실패했습니다.");
+      toast.error(getClaimSessionErrorMessage(error));
+      await synchronizeQueueAfterClaimFailure(targetSessionId);
     } finally {
       setClaimingSessionId((current) => (current === targetSessionId ? null : current));
     }
@@ -1061,6 +1113,7 @@ export const ConsultationPage: React.FC = () => {
     claimingSessionId,
     currentCounselorId,
     isActiveSessionClosed,
+    synchronizeQueueAfterClaimFailure,
   ]);
 
   const handleSendMessage = useCallback(


### PR DESCRIPTION
## Summary
- 상담 세션 배정 실패 시 서버 에러 코드별로 상담사에게 원인을 구분해 안내합니다.
- 배정 실패 직후 상담 큐를 재조회하고, 다른 상담사에게 배정되었거나 사라진 세션은 활성 선택을 해제해 입력창이 잘못 활성화되지 않게 했습니다.
- backend assign 흐름에서 경쟁 배정/배정 불가 상태를 명확한 에러 코드로 반환하고, 구현 기준을 `.agent/specs/361.md`에 정리했습니다.

## Validation
- `cd frontend && pnpm test -- ConsultationPage.test.tsx`
- `cd frontend && pnpm exec eslint src/pages/consultation/ui/ConsultationPage.tsx src/pages/consultation/ui/ConsultationPage.test.tsx`
- `docker run --rm -v "$PWD":/workspace -w /workspace/backend eclipse-temurin:21-jdk ./gradlew test --tests com.init.workflowruntime.application.CounselorServiceTest`
- `docker run --rm -v "$PWD":/workspace -w /workspace/backend eclipse-temurin:21-jdk ./gradlew spotlessCheck --no-daemon`
- `git diff --check`
- `git diff --cached --check`

## Notes
- 호스트에는 Java 21 toolchain이 없어 backend 검증은 JDK 21 Docker 컨테이너에서 실행했습니다.
- 전체 `cd frontend && pnpm lint`는 이번 변경과 무관한 기존 lint 오류 58개로 실패해, 변경 파일 대상으로 eslint를 확인했습니다.
- 동일한 로컬 Java 21 toolchain 부재 때문에 커밋 생성 시 해당 커밋 명령에 한해 Husky를 비활성화했습니다.

Closes #361