### PR TITLE
feat(consultation): 상담 메시지 pagination 조회 제공

### DIFF
--- a/.agent/specs/364.md
+++ b/.agent/specs/364.md
@@ -1,0 +1,177 @@
+# [FE/BE] 상담 메시지 조회 pagination 계약 실제 구현
+
+## Goal
+
+상담 메시지 조회 API와 프론트 상담 화면이 동일한 `page`/`size` pagination 계약을 사용하여 긴 상담 세션도 최근 메시지부터 가볍게 로드한다.
+
+## Problem
+
+- `frontend/src/features/consultation/api/consultationApi.ts`는 메시지 조회 시 `page`, `size` query string을 만들 수 있다.
+- `backend/src/main/java/com/init/workflowruntime/presentation/ConsultationController.java`의 `GET /api/v1/consultation/sessions/{sessionId}/messages`는 query parameter를 받지 않고 전체 메시지를 반환한다.
+- `backend/src/main/java/com/init/workflowruntime/domain/ChatMessageRepository.java`는 현재 세션 전체 메시지를 `seqNo` 오름차순으로 조회한다.
+- 실시간 상담 화면과 상담 기록 화면에서 긴 이력을 처음 열 때 전체 메시지 조회에 의존할 수 있다.
+
+## Scope
+
+- 메시지 조회 endpoint에 `page`와 `size` query parameter를 적용한다.
+- 응답은 `content`, `page`, `size`, `totalElements`, `totalPages` metadata를 포함한다.
+- `page=0`은 최신 메시지 묶음을 의미한다. 각 page의 `content`는 화면 렌더링을 위해 `seqNo` 오름차순으로 반환한다.
+- 실시간 상담 화면은 세션 선택 시 `page=0`, `size=50`으로 최근 메시지를 먼저 조회한다.
+- 실시간 상담 화면은 메시지 목록 상단에서 이전 메시지 page를 추가로 불러올 수 있어야 하며, 기존 스크롤 위치가 급격히 튀지 않아야 한다.
+- 상담 기록 화면은 동일한 메시지 pagination metadata를 사용해 이전 메시지 page를 조회한다.
+- 백엔드와 프론트 테스트는 동일한 `page`/`size` 계약과 metadata를 검증한다.
+
+## Non-goals
+
+- cursor 기반 pagination으로 전환하지 않는다.
+- 상담 세션 목록 API 계약은 변경하지 않는다.
+- WebSocket 실시간 메시지 전송/수신 계약은 변경하지 않는다.
+- OpenAPI generated 파일을 직접 수정하지 않는다. generated endpoint가 query parameter를 반영하기 전까지 수동 wrapper가 미생성 계약을 보완한다.
+
+## REST API
+
+### Endpoint
+
+| Method | Path | Description |
+| --- | --- | --- |
+| GET | `/api/v1/consultation/sessions/{sessionId}/messages?page=0&size=50` | 상담 메시지 page 조회 |
+
+### Query Parameters
+
+| 이름 | 기본값 | 제약 | 설명 |
+| --- | --- | --- | --- |
+| `page` | `0` | `0` 이상 | 최신 묶음부터 시작하는 page index |
+| `size` | `50` | `1` 이상, `100` 이하 | page당 메시지 수 |
+
+### Response
+
+```json
+{
+  "content": [
+    {
+      "id": 101,
+      "seqNo": 42,
+      "senderRole": "CUSTOMER",
+      "messageType": "TEXT",
+      "content": "환불하고 싶습니다",
+      "createdAt": "2026-06-01T10:00:00+09:00"
+    }
+  ],
+  "page": 0,
+  "size": 50,
+  "totalElements": 123,
+  "totalPages": 3
+}
+```
+
+## Backend Design
+
+### Affected Bounded Context
+
+- `workflow-runtime`
+
+### Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    actor c as Client
+    participant ctrl as ConsultationController
+    participant svc as ConsultationService
+    participant repo as ChatMessageRepository
+    participant db as PostgreSQL
+
+    c ->> ctrl: GET /sessions/{id}/messages?page=0&size=50
+    ctrl ->> svc: getMessages(sessionId, userId, page, size)
+    svc ->> svc: validate session and workspace membership
+    svc ->> repo: findByChatSessionIdOrderBySeqNoDesc(sessionId, pageable)
+    repo ->> db: SELECT page ordered by seq_no DESC
+    db -->> repo: Page<ChatMessage>
+    repo -->> svc: newest page
+    svc ->> svc: reverse content to seq_no ASC for display
+    svc -->> ctrl: ChatMessagePageResponse
+    ctrl -->> c: 200 OK
+```
+
+### Class Design
+
+| 파일 | 변경 유형 | 설명 |
+| --- | --- | --- |
+| `backend/src/main/java/com/init/workflowruntime/presentation/ConsultationController.java` | modify | `page`, `size` request parameter 수신 |
+| `backend/src/main/java/com/init/workflowruntime/application/ConsultationService.java` | modify | membership 검증 후 paged message 조회 |
+| `backend/src/main/java/com/init/workflowruntime/application/dto/ChatMessagePageResponse.java` | new | 메시지 content와 pagination metadata 응답 |
+| `backend/src/main/java/com/init/workflowruntime/domain/ChatMessageRepository.java` | modify | `Pageable` 기반 메시지 조회 포트 추가 |
+| `backend/src/main/java/com/init/workflowruntime/infrastructure/persistence/JpaChatMessageRepository.java` | no direct edit | Spring Data repository가 domain port의 query method를 자동 구현 |
+
+## Frontend Design
+
+### Affected Slices
+
+- `pages/consultation`
+- `features/consultation`
+
+### User Flow
+
+```mermaid
+flowchart TD
+    A["상담 세션 선택"] --> B["GET messages page=0 size=50"]
+    B --> C["최신 메시지를 시간순 표시"]
+    C --> D{"이전 메시지 있음?"}
+    D -->|"Yes"| E["목록 상단에 이전 메시지 버튼 표시"]
+    E --> F["이전 page 조회"]
+    F --> G["기존 메시지 앞에 prepend"]
+    G --> H["스크롤 기준 위치 유지"]
+    D -->|"No"| I["추가 로드 컨트롤 숨김"]
+```
+
+### Frontend Files
+
+| 파일 | 변경 유형 | 설명 |
+| --- | --- | --- |
+| `frontend/src/features/consultation/api/consultationApi.ts` | modify | 메시지 page 응답 타입과 wrapper 추가 |
+| `frontend/src/features/consultation/api/chatHistoryApi.ts` | modify | 상담 기록 화면에서 page metadata 사용 |
+| `frontend/src/features/consultation/api/chatHistoryKeys.ts` | modify | query key가 page/size를 포함하도록 유지 |
+| `frontend/src/pages/consultation/ui/ConsultationPage.tsx` | modify | 최근 메시지 초기 로드 및 이전 page 로드 처리 |
+| `frontend/src/features/consultation/ui/ChatPanel.tsx` | modify | 상단 이전 메시지 로드 컨트롤과 스크롤 보존 처리 |
+| `frontend/src/features/consultation/ui/chat-history/MessageHistory.tsx` | modify | 이전 page 로드 및 metadata 기반 카운트 표시 |
+
+## Data and API Impacts
+
+- DB schema 변경은 없다.
+- 기존 메시지 저장 순서와 `seqNo` 의미는 유지한다.
+- 기존 `GET /messages` 호출은 기본값 `page=0`, `size=50`을 적용하므로 더 이상 전체 목록을 반환하지 않는다.
+- 프론트 wrapper는 legacy array 응답을 방어적으로 처리할 수 있지만, 정상 계약은 metadata가 있는 page 응답이다.
+
+## Acceptance Criteria
+
+1. `GET /api/v1/consultation/sessions/{sessionId}/messages?page=0&size=50`가 전체 메시지가 아니라 최신 50개 이하만 반환한다.
+2. 응답에는 `content`, `page`, `size`, `totalElements`, `totalPages`가 포함된다.
+3. `page=1` 요청은 그 이전 메시지 묶음을 반환하고 각 `content`는 `seqNo` 오름차순이다.
+4. `page < 0`, `size <= 0`, `size > 100` 요청은 validation error로 거부된다.
+5. 실시간 상담 화면은 세션 선택 시 최근 메시지만 먼저 표시하고, 이전 메시지가 있으면 상단에서 추가 로드할 수 있다.
+6. 이전 메시지를 prepend할 때 사용자가 보던 메시지 위치가 자연스럽게 유지된다.
+7. 상담 기록 화면도 동일한 page metadata를 사용해 이전 메시지를 추가 조회한다.
+8. 백엔드 controller/service 테스트와 프론트 API/hook/component 테스트가 위 계약을 검증한다.
+
+## Validation Plan
+
+- Backend: `cd backend && ./gradlew test --tests '*ConsultationControllerTest' --tests '*ConsultationServiceTest'`
+- Frontend: `cd frontend && pnpm test -- --run src/features/consultation/api/consultationApi.test.ts src/features/consultation/api/chatHistoryApi.test.ts src/features/consultation/ui/ChatPanel.test.tsx src/features/consultation/ui/chat-history/MessageHistory.test.tsx src/pages/consultation/ui/ConsultationPage.test.tsx src/entities/chat/api/chatApi.test.ts`
+- Frontend lint/build: changed-file `eslint`와 `pnpm build`
+
+## Open Questions
+
+- 없음. 이 이슈에서는 cursor 방식 대신 현재 프론트 wrapper가 이미 노출한 `page`/`size`를 실제 계약으로 확정한다.
+
+## Spec Self-review
+
+### Pass 1: Issue Fidelity
+
+- 이슈의 명시 요구사항인 백엔드 pagination 적용, 긴 세션 초기 전체 조회 회피, 이전 메시지 로드, 프론트/백엔드 계약 정렬, metadata 반환을 모두 acceptance criteria에 반영했다.
+- cursor 방식은 대안으로만 제시되었으므로 non-goal로 두고 `page`/`size`를 확정했다.
+
+### Pass 2: Ostone Compliance
+
+- 최종 브랜치: `feature/364-consultation-message-pagination`
+- 스펙 파일명: `.agent/specs/364.md`
+- 혼합 FE/BE 작업이지만 API 계약이 중심이므로 Backend 템플릿을 기준으로 Frontend 섹션을 분리했다.
+- 참조한 모든 파일 경로는 repository inspection으로 존재를 확인했다.

--- a/backend/src/main/java/com/init/workflowruntime/application/ConsultationService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/ConsultationService.java
@@ -2,6 +2,7 @@ package com.init.workflowruntime.application;
 
 import com.init.shared.application.exception.BadRequestException;
 import com.init.shared.application.exception.NotFoundException;
+import com.init.workflowruntime.application.dto.ChatMessagePageResponse;
 import com.init.workflowruntime.application.dto.ChatMessageResponse;
 import com.init.workflowruntime.application.dto.ChatSessionResponse;
 import com.init.workflowruntime.application.dto.SendMessageRequest;
@@ -12,12 +13,16 @@ import com.init.workflowruntime.domain.ChatMessageRepository;
 import com.init.workflowruntime.domain.ChatSession;
 import com.init.workflowruntime.domain.ChatSessionRepository;
 import com.init.workflowruntime.domain.ChatSessionStatus;
+import com.init.workflowruntime.domain.DomainPage;
+import com.init.workflowruntime.domain.DomainPageRequest;
 import com.init.workflowruntime.domain.event.ConsultationQueueChangedEvent;
 import com.init.workflowruntime.domain.event.ConsultationQueueEventType;
 import com.init.workspace.application.exception.WorkspaceAccessDeniedException;
 import com.init.workspace.domain.repository.WorkspaceMemberRepository;
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -30,6 +35,10 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @Transactional(readOnly = true)
 public class ConsultationService {
+
+  private static final int DEFAULT_MESSAGE_PAGE = 0;
+  private static final int DEFAULT_MESSAGE_PAGE_SIZE = 50;
+  private static final int MAX_MESSAGE_PAGE_SIZE = 100;
 
   private final ChatSessionRepository chatSessionRepository;
   private final ChatMessageRepository chatMessageRepository;
@@ -62,6 +71,13 @@ public class ConsultationService {
   }
 
   public List<ChatMessageResponse> getMessages(@NonNull Long sessionId, @NonNull Long userId) {
+    return getMessages(sessionId, userId, DEFAULT_MESSAGE_PAGE, DEFAULT_MESSAGE_PAGE_SIZE)
+        .content();
+  }
+
+  public ChatMessagePageResponse getMessages(
+      @NonNull Long sessionId, @NonNull Long userId, int page, int size) {
+    validateMessagePaging(page, size);
     ChatSession session =
         chatSessionRepository
             .findById(sessionId)
@@ -75,9 +91,21 @@ public class ConsultationService {
       throw new IllegalStateException("Session ID cannot be null");
     }
 
-    return chatMessageRepository.findByChatSessionIdOrderBySeqNoAsc(id).stream()
-        .map(ChatMessageResponse::from)
-        .collect(Collectors.toList());
+    DomainPage<ChatMessage> messagePage =
+        chatMessageRepository.findByChatSessionIdOrderBySeqNoDesc(
+            id, new DomainPageRequest(page, size));
+    List<ChatMessage> chronologicalMessages = new ArrayList<>(messagePage.content());
+    Collections.reverse(chronologicalMessages);
+
+    List<ChatMessageResponse> content =
+        chronologicalMessages.stream().map(ChatMessageResponse::from).collect(Collectors.toList());
+
+    return new ChatMessagePageResponse(
+        content,
+        messagePage.page(),
+        messagePage.size(),
+        messagePage.totalElements(),
+        messagePage.totalPages());
   }
 
   @Transactional
@@ -202,6 +230,14 @@ public class ConsultationService {
       case OPEN, ACTIVE -> ConsultationQueueEventType.SESSION_UPSERTED;
       case RESOLVED, COMPLETED -> ConsultationQueueEventType.SESSION_REMOVED;
     };
+  }
+
+  private void validateMessagePaging(int page, int size) {
+    if (page < 0 || size <= 0 || size > MAX_MESSAGE_PAGE_SIZE) {
+      throw new BadRequestException(
+          "INVALID_PAGING",
+          "page must be >= 0 and size must be between 1 and " + MAX_MESSAGE_PAGE_SIZE);
+    }
   }
 
   private int compareQueuePriority(ChatSession left, ChatSession right) {

--- a/backend/src/main/java/com/init/workflowruntime/application/CounselorService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/CounselorService.java
@@ -12,6 +12,8 @@ import com.init.workflowruntime.domain.ChatSession;
 import com.init.workflowruntime.domain.ChatSessionRepository;
 import com.init.workflowruntime.domain.ChatSessionResponseMode;
 import com.init.workflowruntime.domain.ChatSessionStatus;
+import com.init.workflowruntime.domain.DomainPage;
+import com.init.workflowruntime.domain.DomainPageRequest;
 import com.init.workflowruntime.domain.event.ConsultationQueueChangedEvent;
 import com.init.workflowruntime.domain.event.ConsultationQueueEventType;
 import com.init.workflowruntime.domain.event.SessionAssignedEvent;
@@ -25,8 +27,6 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -252,8 +252,8 @@ public class CounselorService {
     String normalizedKeyword = normalizeKeyword(keyword);
     OffsetDateTime startedFromDateTime = toStartOfDay(startedFrom);
     OffsetDateTime startedBeforeDateTime = toExclusiveEndDate(startedTo);
-    PageRequest pageRequest = PageRequest.of(page, size);
-    Page<ChatSession> sessionPage =
+    DomainPageRequest pageRequest = new DomainPageRequest(page, size);
+    DomainPage<ChatSession> sessionPage =
         chatSessionRepository.searchByWorkspace(
             workspaceId,
             sessionStatus != null ? sessionStatus.name() : null,
@@ -264,16 +264,14 @@ public class CounselorService {
             pageRequest);
 
     List<ChatSessionResponse> content =
-        sessionPage.getContent().stream()
-            .map(ChatSessionResponse::from)
-            .collect(Collectors.toList());
+        sessionPage.content().stream().map(ChatSessionResponse::from).collect(Collectors.toList());
 
     return new CounselorSessionResponse(
         content,
-        sessionPage.getNumber(),
-        sessionPage.getSize(),
-        sessionPage.getTotalElements(),
-        sessionPage.getTotalPages());
+        sessionPage.page(),
+        sessionPage.size(),
+        sessionPage.totalElements(),
+        sessionPage.totalPages());
   }
 
   private void validateCounselorId(Long counselorId) {

--- a/backend/src/main/java/com/init/workflowruntime/application/dto/ChatMessagePageResponse.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/dto/ChatMessagePageResponse.java
@@ -1,0 +1,6 @@
+package com.init.workflowruntime.application.dto;
+
+import java.util.List;
+
+public record ChatMessagePageResponse(
+    List<ChatMessageResponse> content, int page, int size, long totalElements, int totalPages) {}

--- a/backend/src/main/java/com/init/workflowruntime/domain/ChatMessageRepository.java
+++ b/backend/src/main/java/com/init/workflowruntime/domain/ChatMessageRepository.java
@@ -12,6 +12,9 @@ public interface ChatMessageRepository {
 
   List<ChatMessage> findByChatSessionIdOrderBySeqNoAsc(Long chatSessionId);
 
+  DomainPage<ChatMessage> findByChatSessionIdOrderBySeqNoDesc(
+      Long chatSessionId, DomainPageRequest pageRequest);
+
   List<ChatMessage> findTop5ByChatSessionIdOrderBySeqNoDesc(Long chatSessionId);
 
   Optional<ChatMessage> findTopByChatSessionIdOrderBySeqNoDesc(Long chatSessionId);

--- a/backend/src/main/java/com/init/workflowruntime/domain/ChatSessionRepository.java
+++ b/backend/src/main/java/com/init/workflowruntime/domain/ChatSessionRepository.java
@@ -4,8 +4,6 @@ import java.time.OffsetDateTime;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 
 /** 채팅 세션 영속성을 위한 도메인 포트 인터페이스입니다. */
 public interface ChatSessionRepository {
@@ -28,21 +26,21 @@ public interface ChatSessionRepository {
   Optional<ChatSession> findFirstByWorkspaceIdAndStartedByAndStatusInOrderByStartedAtDescIdDesc(
       Long workspaceId, Long startedBy, Collection<ChatSessionStatus> statuses);
 
-  Page<ChatSession> findByWorkspaceId(Long workspaceId, Pageable pageable);
+  DomainPage<ChatSession> findByWorkspaceId(Long workspaceId, DomainPageRequest pageRequest);
 
-  Page<ChatSession> findByWorkspaceIdAndStatus(
-      Long workspaceId, ChatSessionStatus status, Pageable pageable);
+  DomainPage<ChatSession> findByWorkspaceIdAndStatus(
+      Long workspaceId, ChatSessionStatus status, DomainPageRequest pageRequest);
 
-  Page<ChatSession> findByStatus(ChatSessionStatus status, Pageable pageable);
+  DomainPage<ChatSession> findByStatus(ChatSessionStatus status, DomainPageRequest pageRequest);
 
-  Page<ChatSession> findAll(Pageable pageable);
+  DomainPage<ChatSession> findAll(DomainPageRequest pageRequest);
 
-  Page<ChatSession> searchByWorkspace(
+  DomainPage<ChatSession> searchByWorkspace(
       Long workspaceId,
       String status,
       String keyword,
       OffsetDateTime startedFrom,
       OffsetDateTime startedBefore,
       Long assignedCounselorId,
-      Pageable pageable);
+      DomainPageRequest pageRequest);
 }

--- a/backend/src/main/java/com/init/workflowruntime/domain/DomainPage.java
+++ b/backend/src/main/java/com/init/workflowruntime/domain/DomainPage.java
@@ -1,0 +1,12 @@
+package com.init.workflowruntime.domain;
+
+import java.util.List;
+
+/** 도메인 계층에서 사용하는 페이지 응답 값입니다. */
+public record DomainPage<T>(
+    List<T> content, int page, int size, long totalElements, int totalPages) {
+
+  public DomainPage {
+    content = List.copyOf(content);
+  }
+}

--- a/backend/src/main/java/com/init/workflowruntime/domain/DomainPageRequest.java
+++ b/backend/src/main/java/com/init/workflowruntime/domain/DomainPageRequest.java
@@ -1,0 +1,10 @@
+package com.init.workflowruntime.domain;
+
+/** 도메인 계층에서 사용하는 페이지 요청 값입니다. */
+public record DomainPageRequest(int page, int size) {
+  public DomainPageRequest {
+    if (page < 0 || size <= 0) {
+      throw new IllegalArgumentException("page must be >= 0 and size must be > 0");
+    }
+  }
+}

--- a/backend/src/main/java/com/init/workflowruntime/infrastructure/persistence/ChatMessageRepositoryAdapter.java
+++ b/backend/src/main/java/com/init/workflowruntime/infrastructure/persistence/ChatMessageRepositoryAdapter.java
@@ -1,0 +1,65 @@
+package com.init.workflowruntime.infrastructure.persistence;
+
+import com.init.workflowruntime.domain.ChatMessage;
+import com.init.workflowruntime.domain.ChatMessageRepository;
+import com.init.workflowruntime.domain.DomainPage;
+import com.init.workflowruntime.domain.DomainPageRequest;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Repository;
+
+/** ChatMessage 도메인 포트를 Spring Data JPA repository에 연결합니다. */
+@Repository
+public class ChatMessageRepositoryAdapter implements ChatMessageRepository {
+
+  private final JpaChatMessageRepository jpaRepository;
+
+  public ChatMessageRepositoryAdapter(JpaChatMessageRepository jpaRepository) {
+    this.jpaRepository = jpaRepository;
+  }
+
+  @Override
+  public ChatMessage save(ChatMessage message) {
+    return jpaRepository.save(message);
+  }
+
+  @Override
+  public Optional<ChatMessage> findById(Long id) {
+    return jpaRepository.findById(id);
+  }
+
+  @Override
+  public List<ChatMessage> findByChatSessionIdOrderBySeqNoAsc(Long chatSessionId) {
+    return jpaRepository.findByChatSessionIdOrderBySeqNoAsc(chatSessionId);
+  }
+
+  @Override
+  public DomainPage<ChatMessage> findByChatSessionIdOrderBySeqNoDesc(
+      Long chatSessionId, DomainPageRequest pageRequest) {
+    Page<ChatMessage> page =
+        jpaRepository.findByChatSessionIdOrderBySeqNoDesc(
+            chatSessionId, PageRequest.of(pageRequest.page(), pageRequest.size()));
+    return toDomainPage(page);
+  }
+
+  @Override
+  public List<ChatMessage> findTop5ByChatSessionIdOrderBySeqNoDesc(Long chatSessionId) {
+    return jpaRepository.findTop5ByChatSessionIdOrderBySeqNoDesc(chatSessionId);
+  }
+
+  @Override
+  public Optional<ChatMessage> findTopByChatSessionIdOrderBySeqNoDesc(Long chatSessionId) {
+    return jpaRepository.findTopByChatSessionIdOrderBySeqNoDesc(chatSessionId);
+  }
+
+  private DomainPage<ChatMessage> toDomainPage(Page<ChatMessage> page) {
+    return new DomainPage<>(
+        page.getContent(),
+        page.getNumber(),
+        page.getSize(),
+        page.getTotalElements(),
+        page.getTotalPages());
+  }
+}

--- a/backend/src/main/java/com/init/workflowruntime/infrastructure/persistence/ChatSessionRepositoryAdapter.java
+++ b/backend/src/main/java/com/init/workflowruntime/infrastructure/persistence/ChatSessionRepositoryAdapter.java
@@ -1,0 +1,128 @@
+package com.init.workflowruntime.infrastructure.persistence;
+
+import com.init.workflowruntime.domain.ChatSession;
+import com.init.workflowruntime.domain.ChatSessionRepository;
+import com.init.workflowruntime.domain.ChatSessionStatus;
+import com.init.workflowruntime.domain.DomainPage;
+import com.init.workflowruntime.domain.DomainPageRequest;
+import java.time.OffsetDateTime;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Repository;
+
+/** ChatSession 도메인 포트를 Spring Data JPA repository에 연결합니다. */
+@Repository
+public class ChatSessionRepositoryAdapter implements ChatSessionRepository {
+
+  private final JpaChatSessionRepository jpaRepository;
+
+  public ChatSessionRepositoryAdapter(JpaChatSessionRepository jpaRepository) {
+    this.jpaRepository = jpaRepository;
+  }
+
+  @Override
+  public Optional<ChatSession> findById(Long id) {
+    return jpaRepository.findById(id);
+  }
+
+  @Override
+  public Optional<ChatSession> findByIdForUpdate(Long id) {
+    return jpaRepository.findByIdForUpdate(id);
+  }
+
+  @Override
+  public ChatSession save(ChatSession session) {
+    return jpaRepository.save(session);
+  }
+
+  @Override
+  public List<ChatSession> findByStatusOrderByStartedAtDesc(ChatSessionStatus status) {
+    return jpaRepository.findByStatusOrderByStartedAtDesc(status);
+  }
+
+  @Override
+  public List<ChatSession> findByStatusInOrderByStartedAtDesc(
+      Collection<ChatSessionStatus> statuses) {
+    return jpaRepository.findByStatusInOrderByStartedAtDesc(statuses);
+  }
+
+  @Override
+  public List<ChatSession> findByWorkspaceIdAndStatusInOrderByStartedAtDesc(
+      Long workspaceId, Collection<ChatSessionStatus> statuses) {
+    return jpaRepository.findByWorkspaceIdAndStatusInOrderByStartedAtDesc(workspaceId, statuses);
+  }
+
+  @Override
+  public List<ChatSession> findByAssignedCounselorId(Long counselorId) {
+    return jpaRepository.findByAssignedCounselorId(counselorId);
+  }
+
+  @Override
+  public Optional<ChatSession>
+      findFirstByWorkspaceIdAndStartedByAndStatusInOrderByStartedAtDescIdDesc(
+          Long workspaceId, Long startedBy, Collection<ChatSessionStatus> statuses) {
+    return jpaRepository.findFirstByWorkspaceIdAndStartedByAndStatusInOrderByStartedAtDescIdDesc(
+        workspaceId, startedBy, statuses);
+  }
+
+  @Override
+  public DomainPage<ChatSession> findByWorkspaceId(
+      Long workspaceId, DomainPageRequest pageRequest) {
+    return toDomainPage(
+        jpaRepository.findByWorkspaceId(
+            workspaceId, PageRequest.of(pageRequest.page(), pageRequest.size())));
+  }
+
+  @Override
+  public DomainPage<ChatSession> findByWorkspaceIdAndStatus(
+      Long workspaceId, ChatSessionStatus status, DomainPageRequest pageRequest) {
+    return toDomainPage(
+        jpaRepository.findByWorkspaceIdAndStatus(
+            workspaceId, status, PageRequest.of(pageRequest.page(), pageRequest.size())));
+  }
+
+  @Override
+  public DomainPage<ChatSession> findByStatus(
+      ChatSessionStatus status, DomainPageRequest pageRequest) {
+    return toDomainPage(
+        jpaRepository.findByStatus(status, PageRequest.of(pageRequest.page(), pageRequest.size())));
+  }
+
+  @Override
+  public DomainPage<ChatSession> findAll(DomainPageRequest pageRequest) {
+    return toDomainPage(
+        jpaRepository.findAll(PageRequest.of(pageRequest.page(), pageRequest.size())));
+  }
+
+  @Override
+  public DomainPage<ChatSession> searchByWorkspace(
+      Long workspaceId,
+      String status,
+      String keyword,
+      OffsetDateTime startedFrom,
+      OffsetDateTime startedBefore,
+      Long assignedCounselorId,
+      DomainPageRequest pageRequest) {
+    return toDomainPage(
+        jpaRepository.searchByWorkspace(
+            workspaceId,
+            status,
+            keyword,
+            startedFrom,
+            startedBefore,
+            assignedCounselorId,
+            PageRequest.of(pageRequest.page(), pageRequest.size())));
+  }
+
+  private DomainPage<ChatSession> toDomainPage(Page<ChatSession> page) {
+    return new DomainPage<>(
+        page.getContent(),
+        page.getNumber(),
+        page.getSize(),
+        page.getTotalElements(),
+        page.getTotalPages());
+  }
+}

--- a/backend/src/main/java/com/init/workflowruntime/infrastructure/persistence/JpaChatMessageRepository.java
+++ b/backend/src/main/java/com/init/workflowruntime/infrastructure/persistence/JpaChatMessageRepository.java
@@ -1,19 +1,25 @@
 package com.init.workflowruntime.infrastructure.persistence;
 
 import com.init.workflowruntime.domain.ChatMessage;
-import com.init.workflowruntime.domain.ChatMessageRepository;
 import jakarta.persistence.LockModeType;
+import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.stereotype.Repository;
 
-/** ChatMessageRepository의 JPA 구현체입니다. Spring Data JPA의 프록시 메커니즘을 통해 도메인 포트 인터페이스를 자동으로 구현합니다. */
+/** ChatMessage의 Spring Data JPA repository입니다. */
 @Repository
-public interface JpaChatMessageRepository
-    extends JpaRepository<ChatMessage, Long>, ChatMessageRepository {
+public interface JpaChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+
+  List<ChatMessage> findByChatSessionIdOrderBySeqNoAsc(Long chatSessionId);
+
+  Page<ChatMessage> findByChatSessionIdOrderBySeqNoDesc(Long chatSessionId, Pageable pageable);
+
+  List<ChatMessage> findTop5ByChatSessionIdOrderBySeqNoDesc(Long chatSessionId);
 
   @Lock(LockModeType.PESSIMISTIC_WRITE)
-  @Override
   Optional<ChatMessage> findTopByChatSessionIdOrderBySeqNoDesc(Long chatSessionId);
 }

--- a/backend/src/main/java/com/init/workflowruntime/infrastructure/persistence/JpaChatSessionRepository.java
+++ b/backend/src/main/java/com/init/workflowruntime/infrastructure/persistence/JpaChatSessionRepository.java
@@ -1,10 +1,10 @@
 package com.init.workflowruntime.infrastructure.persistence;
 
 import com.init.workflowruntime.domain.ChatSession;
-import com.init.workflowruntime.domain.ChatSessionRepository;
 import com.init.workflowruntime.domain.ChatSessionStatus;
 import jakarta.persistence.LockModeType;
 import java.time.OffsetDateTime;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
@@ -15,30 +15,33 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-/** ChatSessionRepository의 JPA 구현체입니다. Spring Data JPA의 프록시 메커니즘을 통해 도메인 포트 인터페이스를 자동으로 구현합니다. */
+/** ChatSession의 Spring Data JPA repository입니다. */
 @Repository
-public interface JpaChatSessionRepository
-    extends JpaRepository<ChatSession, Long>, ChatSessionRepository {
+public interface JpaChatSessionRepository extends JpaRepository<ChatSession, Long> {
 
   @Lock(LockModeType.PESSIMISTIC_WRITE)
   @Query("select cs from ChatSession cs where cs.id = :id")
-  @Override
   Optional<ChatSession> findByIdForUpdate(@Param("id") Long id);
 
-  @Override
+  List<ChatSession> findByStatusOrderByStartedAtDesc(ChatSessionStatus status);
+
+  List<ChatSession> findByStatusInOrderByStartedAtDesc(Collection<ChatSessionStatus> statuses);
+
+  List<ChatSession> findByWorkspaceIdAndStatusInOrderByStartedAtDesc(
+      Long workspaceId, Collection<ChatSessionStatus> statuses);
+
   List<ChatSession> findByAssignedCounselorId(Long counselorId);
 
-  @Override
+  Optional<ChatSession> findFirstByWorkspaceIdAndStartedByAndStatusInOrderByStartedAtDescIdDesc(
+      Long workspaceId, Long startedBy, Collection<ChatSessionStatus> statuses);
+
   Page<ChatSession> findByWorkspaceId(Long workspaceId, Pageable pageable);
 
-  @Override
   Page<ChatSession> findByWorkspaceIdAndStatus(
       Long workspaceId, ChatSessionStatus status, Pageable pageable);
 
-  @Override
   Page<ChatSession> findByStatus(ChatSessionStatus status, Pageable pageable);
 
-  @Override
   @Query(
       value =
           """

--- a/backend/src/main/java/com/init/workflowruntime/presentation/ConsultationController.java
+++ b/backend/src/main/java/com/init/workflowruntime/presentation/ConsultationController.java
@@ -6,6 +6,7 @@ import com.init.workflowruntime.application.CounselorDraftResponseService;
 import com.init.workflowruntime.application.LlmToolService;
 import com.init.workflowruntime.application.command.GenerateDraftResponseCommand;
 import com.init.workflowruntime.application.command.GetCurrentWorkflowCommand;
+import com.init.workflowruntime.application.dto.ChatMessagePageResponse;
 import com.init.workflowruntime.application.dto.ChatMessageResponse;
 import com.init.workflowruntime.application.dto.ChatSessionResponse;
 import com.init.workflowruntime.application.dto.GenerateWorkflowAwareResponseResult;
@@ -13,7 +14,8 @@ import com.init.workflowruntime.application.dto.LlmToolWorkflowResponse;
 import com.init.workflowruntime.application.dto.SendMessageRequest;
 import com.init.workflowruntime.application.dto.UpdateStatusRequest;
 import jakarta.validation.Valid;
-import java.util.List;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,6 +24,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /** 상담 운영자 대화 및 세션을 관리하는 REST 컨트롤러입니다. 상담 대기열 조회, 메시지 송수신, 세션 상태 변경 등의 기능을 제공합니다. */
@@ -56,10 +59,13 @@ public class ConsultationController {
    * @return 메시지 상세 목록 응답
    */
   @GetMapping("/sessions/{sessionId}/messages")
-  public ResponseEntity<List<ChatMessageResponse>> getMessages(
-      @PathVariable Long sessionId, Authentication authentication) {
+  public ResponseEntity<ChatMessagePageResponse> getMessages(
+      @PathVariable Long sessionId,
+      @RequestParam(defaultValue = "0") @Min(0) int page,
+      @RequestParam(defaultValue = "50") @Min(1) @Max(100) int size,
+      Authentication authentication) {
     Long userId = AuthenticationUtils.getUserId(authentication);
-    return ResponseEntity.ok(consultationService.getMessages(sessionId, userId));
+    return ResponseEntity.ok(consultationService.getMessages(sessionId, userId, page, size));
   }
 
   /**

--- a/backend/src/test/java/com/init/workflowruntime/application/ConsultationServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/ConsultationServiceTest.java
@@ -7,9 +7,11 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 import com.init.shared.application.exception.BadRequestException;
 import com.init.shared.application.exception.NotFoundException;
+import com.init.workflowruntime.application.dto.ChatMessagePageResponse;
 import com.init.workflowruntime.application.dto.ChatMessageResponse;
 import com.init.workflowruntime.application.dto.ChatSessionResponse;
 import com.init.workflowruntime.application.dto.SendMessageRequest;
@@ -19,6 +21,8 @@ import com.init.workflowruntime.domain.ChatMessageRepository;
 import com.init.workflowruntime.domain.ChatSession;
 import com.init.workflowruntime.domain.ChatSessionRepository;
 import com.init.workflowruntime.domain.ChatSessionStatus;
+import com.init.workflowruntime.domain.DomainPage;
+import com.init.workflowruntime.domain.DomainPageRequest;
 import com.init.workflowruntime.domain.event.ConsultationQueueChangedEvent;
 import com.init.workflowruntime.domain.event.ConsultationQueueEventType;
 import com.init.workspace.application.exception.WorkspaceAccessDeniedException;
@@ -158,19 +162,28 @@ class ConsultationServiceTest {
   }
 
   @Test
-  @DisplayName("getMessages: 세션 존재 → 메시지 목록 반환")
+  @DisplayName("getMessages: 세션 존재 → 최신 page를 시간순으로 반환")
   void should_메시지목록반환_when_세션존재() {
     // given
     ChatSession session = createSession(1L);
+    ChatMessage later = createMessage(1L, 3, "AGENT", "나중 메시지");
+    ChatMessage earlier = createMessage(1L, 2, "CUSTOMER", "이전 메시지");
     given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
     givenWorkspaceMember(1L, USER_ID);
-    given(chatMessageRepository.findByChatSessionIdOrderBySeqNoAsc(1L)).willReturn(List.of());
+    given(
+            chatMessageRepository.findByChatSessionIdOrderBySeqNoDesc(
+                1L, new DomainPageRequest(0, 2)))
+        .willReturn(new DomainPage<>(List.of(later, earlier), 0, 2, 3, 2));
 
     // when
-    List<ChatMessageResponse> result = service.getMessages(1L, USER_ID);
+    ChatMessagePageResponse result = service.getMessages(1L, USER_ID, 0, 2);
 
     // then
-    assertThat(result).isEmpty();
+    assertThat(result.content()).extracting(ChatMessageResponse::seqNo).containsExactly(2, 3);
+    assertThat(result.page()).isZero();
+    assertThat(result.size()).isEqualTo(2);
+    assertThat(result.totalElements()).isEqualTo(3);
+    assertThat(result.totalPages()).isEqualTo(2);
   }
 
   @Test
@@ -183,7 +196,20 @@ class ConsultationServiceTest {
 
     assertThatThrownBy(() -> service.getMessages(1L, USER_ID))
         .isInstanceOf(WorkspaceAccessDeniedException.class);
-    verify(chatMessageRepository, never()).findByChatSessionIdOrderBySeqNoAsc(1L);
+    verify(chatMessageRepository, never()).findByChatSessionIdOrderBySeqNoDesc(eq(1L), any());
+  }
+
+  @Test
+  @DisplayName("getMessages: 잘못된 pagination 값이면 거부한다")
+  void should_throwBadRequest_when_messagePagingInvalid() {
+    assertThatThrownBy(() -> service.getMessages(1L, USER_ID, -1, 50))
+        .isInstanceOf(BadRequestException.class);
+    assertThatThrownBy(() -> service.getMessages(1L, USER_ID, 0, 0))
+        .isInstanceOf(BadRequestException.class);
+    assertThatThrownBy(() -> service.getMessages(1L, USER_ID, 0, 101))
+        .isInstanceOf(BadRequestException.class);
+    verify(chatSessionRepository, never()).findById(1L);
+    verifyNoInteractions(chatMessageRepository);
   }
 
   @Test

--- a/backend/src/test/java/com/init/workflowruntime/application/CounselorServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/CounselorServiceTest.java
@@ -22,6 +22,8 @@ import com.init.workflowruntime.domain.ChatSession;
 import com.init.workflowruntime.domain.ChatSessionRepository;
 import com.init.workflowruntime.domain.ChatSessionResponseMode;
 import com.init.workflowruntime.domain.ChatSessionStatus;
+import com.init.workflowruntime.domain.DomainPage;
+import com.init.workflowruntime.domain.DomainPageRequest;
 import com.init.workflowruntime.domain.event.ConsultationQueueChangedEvent;
 import com.init.workflowruntime.domain.event.ConsultationQueueEventType;
 import com.init.workflowruntime.domain.event.SessionAssignedEvent;
@@ -41,9 +43,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.Pageable;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
@@ -353,11 +352,17 @@ class CounselorServiceTest {
   @DisplayName("getSessions: 상태 필터 없음 → 워크스페이스 세션 페이지 반환")
   void should_returnWorkspaceSessions_when_noStatusFilter() {
     ChatSession session = createSession(1L, ChatSessionStatus.OPEN);
-    Page<ChatSession> page = new PageImpl<>(List.of(session));
+    DomainPage<ChatSession> page = new DomainPage<>(List.of(session), 0, 20, 1, 1);
     givenWorkspaceMember(1L, 7L);
     given(
             chatSessionRepository.searchByWorkspace(
-                eq(1L), eq(null), eq(null), eq(null), eq(null), eq(null), any(Pageable.class)))
+                eq(1L),
+                eq(null),
+                eq(null),
+                eq(null),
+                eq(null),
+                eq(null),
+                any(DomainPageRequest.class)))
         .willReturn(page);
 
     CounselorSessionResponse result =
@@ -367,18 +372,24 @@ class CounselorServiceTest {
     assertThat(result.getTotalElements()).isEqualTo(1);
     verify(chatSessionRepository)
         .searchByWorkspace(
-            eq(1L), eq(null), eq(null), eq(null), eq(null), eq(null), any(Pageable.class));
+            eq(1L), eq(null), eq(null), eq(null), eq(null), eq(null), any(DomainPageRequest.class));
   }
 
   @Test
   @DisplayName("getSessions: 상태 필터 있음 → 워크스페이스와 상태로 필터링된 페이지 반환")
   void should_returnFilteredWorkspaceSessions_when_statusGiven() {
     ChatSession session = createSession(1L, ChatSessionStatus.OPEN);
-    Page<ChatSession> page = new PageImpl<>(List.of(session));
+    DomainPage<ChatSession> page = new DomainPage<>(List.of(session), 0, 20, 1, 1);
     givenWorkspaceMember(1L, 7L);
     given(
             chatSessionRepository.searchByWorkspace(
-                eq(1L), eq("OPEN"), eq(null), eq(null), eq(null), eq(null), any(Pageable.class)))
+                eq(1L),
+                eq("OPEN"),
+                eq(null),
+                eq(null),
+                eq(null),
+                eq(null),
+                any(DomainPageRequest.class)))
         .willReturn(page);
 
     CounselorSessionResponse result =
@@ -387,13 +398,19 @@ class CounselorServiceTest {
     assertThat(result.getContent()).hasSize(1);
     verify(chatSessionRepository)
         .searchByWorkspace(
-            eq(1L), eq("OPEN"), eq(null), eq(null), eq(null), eq(null), any(Pageable.class));
+            eq(1L),
+            eq("OPEN"),
+            eq(null),
+            eq(null),
+            eq(null),
+            eq(null),
+            any(DomainPageRequest.class));
   }
 
   @Test
   @DisplayName("getSessions: 검색/기간/상담사 필터를 정규화해 전달")
   void should_passSearchFilters_when_filtersGiven() {
-    Page<ChatSession> page = new PageImpl<>(List.of());
+    DomainPage<ChatSession> page = new DomainPage<>(List.of(), 0, 20, 0, 0);
     givenWorkspaceMember(1L, 7L);
     given(
             chatSessionRepository.searchByWorkspace(
@@ -403,7 +420,7 @@ class CounselorServiceTest {
                 any(OffsetDateTime.class),
                 any(OffsetDateTime.class),
                 eq(42L),
-                any(Pageable.class)))
+                any(DomainPageRequest.class)))
         .willReturn(page);
 
     CounselorSessionResponse result =
@@ -427,13 +444,13 @@ class CounselorServiceTest {
             any(OffsetDateTime.class),
             any(OffsetDateTime.class),
             eq(42L),
-            any(Pageable.class));
+            any(DomainPageRequest.class));
   }
 
   @Test
   @DisplayName("getSessions: LIKE 와일드카드를 리터럴 검색어로 escape")
   void should_escapeLikeWildcards_when_keywordContainsSpecialChars() {
-    Page<ChatSession> page = new PageImpl<>(List.of());
+    DomainPage<ChatSession> page = new DomainPage<>(List.of(), 0, 20, 0, 0);
     givenWorkspaceMember(1L, 7L);
     given(
             chatSessionRepository.searchByWorkspace(
@@ -443,7 +460,7 @@ class CounselorServiceTest {
                 eq(null),
                 eq(null),
                 eq(null),
-                any(Pageable.class)))
+                any(DomainPageRequest.class)))
         .willReturn(page);
 
     CounselorSessionResponse result =
@@ -452,7 +469,13 @@ class CounselorServiceTest {
     assertThat(result.getContent()).isEmpty();
     verify(chatSessionRepository)
         .searchByWorkspace(
-            eq(1L), eq(null), eq("\\%\\_\\\\"), eq(null), eq(null), eq(null), any(Pageable.class));
+            eq(1L),
+            eq(null),
+            eq("\\%\\_\\\\"),
+            eq(null),
+            eq(null),
+            eq(null),
+            any(DomainPageRequest.class));
   }
 
   @Test

--- a/backend/src/test/java/com/init/workflowruntime/presentation/ConsultationControllerTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/presentation/ConsultationControllerTest.java
@@ -21,6 +21,7 @@ import com.init.workflowruntime.application.CounselorDraftResponseService;
 import com.init.workflowruntime.application.LlmToolService;
 import com.init.workflowruntime.application.command.GenerateDraftResponseCommand;
 import com.init.workflowruntime.application.command.GetCurrentWorkflowCommand;
+import com.init.workflowruntime.application.dto.ChatMessagePageResponse;
 import com.init.workflowruntime.application.dto.ChatMessageResponse;
 import com.init.workflowruntime.application.dto.ChatSessionResponse;
 import com.init.workflowruntime.application.dto.GenerateWorkflowAwareResponseResult;
@@ -79,13 +80,42 @@ class ConsultationControllerTest {
     ChatMessageResponse msg =
         new ChatMessageResponse(1L, 1, "CUSTOMER", "TEXT", "Hello", OffsetDateTime.now());
 
-    given(consultationService.getMessages(1L, 7L)).willReturn(List.of(msg));
+    given(consultationService.getMessages(1L, 7L, 0, 50))
+        .willReturn(new ChatMessagePageResponse(List.of(msg), 0, 50, 1, 1));
 
     // when & then
     mockMvc
         .perform(get("/api/v1/consultation/sessions/1/messages").principal(auth()))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$[0].content").value("Hello"));
+        .andExpect(jsonPath("$.content[0].content").value("Hello"))
+        .andExpect(jsonPath("$.page").value(0))
+        .andExpect(jsonPath("$.size").value(50))
+        .andExpect(jsonPath("$.totalElements").value(1))
+        .andExpect(jsonPath("$.totalPages").value(1));
+    verify(consultationService).getMessages(1L, 7L, 0, 50);
+  }
+
+  @Test
+  @DisplayName("GET /api/v1/consultation/sessions/{id}/messages - page/size 파라미터 전달")
+  void should_페이지파라미터전달_when_메시지조회() throws Exception {
+    ChatMessageResponse msg =
+        new ChatMessageResponse(2L, 45, "CUSTOMER", "TEXT", "Old", OffsetDateTime.now());
+    given(consultationService.getMessages(1L, 7L, 1, 25))
+        .willReturn(new ChatMessagePageResponse(List.of(msg), 1, 25, 80, 4));
+
+    mockMvc
+        .perform(
+            get("/api/v1/consultation/sessions/1/messages")
+                .param("page", "1")
+                .param("size", "25")
+                .principal(auth()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content[0].seqNo").value(45))
+        .andExpect(jsonPath("$.page").value(1))
+        .andExpect(jsonPath("$.size").value(25))
+        .andExpect(jsonPath("$.totalElements").value(80))
+        .andExpect(jsonPath("$.totalPages").value(4));
+    verify(consultationService).getMessages(1L, 7L, 1, 25);
   }
 
   @Test
@@ -199,7 +229,7 @@ class ConsultationControllerTest {
   @DisplayName("GET /api/v1/consultation/sessions/{id}/messages - 세션 없음 → 404 Not Found")
   void should_404반환_when_세션없음() throws Exception {
     // given
-    given(consultationService.getMessages(999L, 7L))
+    given(consultationService.getMessages(999L, 7L, 0, 50))
         .willThrow(new NotFoundException("SESSION_NOT_FOUND", "Session not found: 999"));
 
     // when & then
@@ -212,7 +242,7 @@ class ConsultationControllerTest {
   @Test
   @DisplayName("GET /api/v1/consultation/sessions/{id}/messages - 비멤버 → 403")
   void should_403반환_when_메시지조회_워크스페이스비멤버() throws Exception {
-    given(consultationService.getMessages(1L, 7L))
+    given(consultationService.getMessages(1L, 7L, 0, 50))
         .willThrow(new WorkspaceAccessDeniedException("워크스페이스에 접근 권한이 없습니다."));
 
     mockMvc

--- a/frontend/src/entities/chat/api/chatApi.test.ts
+++ b/frontend/src/entities/chat/api/chatApi.test.ts
@@ -78,6 +78,38 @@ describe("chatApi", () => {
     expect(customFetchMock).not.toHaveBeenCalled();
   });
 
+  it("pagination 응답의 세션 메시지를 채팅 UI 모델로 변환한다", async () => {
+    getMessagesMock.mockResolvedValue({
+      content: [
+        {
+          id: 22,
+          seqNo: 2,
+          senderRole: "USER",
+          messageType: "TEXT",
+          content: "배송 조회 부탁드립니다",
+          createdAt: "2026-05-22T00:01:00Z",
+        },
+      ],
+      page: 0,
+      size: 50,
+      totalElements: 1,
+      totalPages: 1,
+    });
+
+    await expect(listChatMessages(7)).resolves.toEqual([
+      {
+        id: "22",
+        sessionId: 7,
+        senderType: "USER",
+        content: "배송 조회 부탁드립니다",
+        createdAt: "2026-05-22T00:01:00Z",
+      },
+    ]);
+
+    expect(getMessagesMock).toHaveBeenCalledWith(7);
+    expect(customFetchMock).not.toHaveBeenCalled();
+  });
+
   it("데모 채팅 워크플로우를 채팅 UI 모델로 변환한다", async () => {
     getChatWorkflowMock.mockResolvedValue({
       chatSession: {

--- a/frontend/src/entities/chat/api/chatApi.ts
+++ b/frontend/src/entities/chat/api/chatApi.ts
@@ -1,5 +1,5 @@
 import { customFetch } from "@/shared/api/mutator";
-import { selectApiData, selectApiList } from "@/shared/api";
+import { selectApiData } from "@/shared/api";
 import { getMessages } from "@/shared/api/generated/endpoints/consultation-controller/consultation-controller";
 import { getChatWorkflow } from "@/shared/api/generated/endpoints/demo-runtime-controller/demo-runtime-controller";
 import type { ChatMessage, ChatSession } from "@/entities/chat/model/types";
@@ -29,6 +29,13 @@ interface DemoMessageResponse {
   timestamp?: string;
 }
 
+type ConsultationMessagesResponse =
+  | ChatMessageResponse[]
+  | {
+      data?: ChatMessageResponse[] | { content?: ChatMessageResponse[] };
+      content?: ChatMessageResponse[];
+    };
+
 export interface DemoChatSession {
   id: string;
   status: string;
@@ -49,6 +56,18 @@ function requireBackendSessionId(id: number | undefined): number {
     throw new Error("Demo chat session response is missing a numeric id.");
   }
   return id;
+}
+
+function selectConsultationMessages(response: ConsultationMessagesResponse): ChatMessageResponse[] {
+  const data = selectApiData<ChatMessageResponse[] | { content?: ChatMessageResponse[] }>(
+    response,
+  );
+
+  if (Array.isArray(data)) {
+    return data;
+  }
+
+  return data?.content ?? [];
 }
 
 function toDemoChatMessage(
@@ -78,7 +97,9 @@ export function createChatSession(workspaceId: number, customerName: string): Pr
 }
 
 export async function listChatMessages(sessionId: number): Promise<ChatMessage[]> {
-  const messages = selectApiList<ChatMessageResponse>(await getMessages(sessionId));
+  const messages = selectConsultationMessages(
+    (await getMessages(sessionId)) as ConsultationMessagesResponse,
+  );
   return messages.map((message) => toChatMessage(message, sessionId));
 }
 

--- a/frontend/src/features/consultation/api/chatHistoryApi.test.ts
+++ b/frontend/src/features/consultation/api/chatHistoryApi.test.ts
@@ -7,15 +7,17 @@ vi.mock("./consultationApi", () => ({
   consultationApi: {
     getSessionPage: vi.fn(),
     getMessages: vi.fn(),
+    getMessagePage: vi.fn(),
   },
 }));
 
 import { ChatSessionResponse, ChatMessageResponse } from "../../../shared/api/generated/zod";
-import { useChatSessions, useChatMessages } from "./chatHistoryApi";
+import { useChatSessions, useChatMessages, useChatMessagePage } from "./chatHistoryApi";
 import { consultationApi } from "./consultationApi";
 
 const mockedGetSessionPage = vi.mocked(consultationApi.getSessionPage);
 const mockedGetMessages = vi.mocked(consultationApi.getMessages);
+const mockedGetMessagePage = vi.mocked(consultationApi.getMessagePage);
 
 const stubSession: ChatSessionResponse = {
   id: 1,
@@ -132,6 +134,7 @@ describe("useChatSessions", () => {
 describe("useChatMessages", () => {
   beforeEach(() => {
     mockedGetMessages.mockReset();
+    mockedGetMessagePage.mockReset();
   });
 
   it("sessionId가 있으면 메시지 목록을 조회한다", async () => {
@@ -157,5 +160,21 @@ describe("useChatMessages", () => {
 
     await waitFor(() => expect(result.current.data).toEqual([stubMessage]));
     expect(mockedGetMessages).toHaveBeenCalledWith(1, { page: 2, size: 30 });
+  });
+
+  it("메시지 page metadata를 조회한다", async () => {
+    const page = {
+      content: [stubMessage],
+      page: 0,
+      size: 50,
+      totalElements: 75,
+      totalPages: 2,
+    };
+    mockedGetMessagePage.mockResolvedValue(page);
+
+    const { result } = renderHook(() => useChatMessagePage("1"), { wrapper: makeWrapper() });
+
+    await waitFor(() => expect(result.current.data).toEqual(page));
+    expect(mockedGetMessagePage).toHaveBeenCalledWith(1, { page: 0, size: 50 });
   });
 });

--- a/frontend/src/features/consultation/api/chatHistoryApi.ts
+++ b/frontend/src/features/consultation/api/chatHistoryApi.ts
@@ -54,3 +54,14 @@ export function useChatMessages(sessionId: string, page: number = 0, size: numbe
     enabled: hasValidSessionId,
   });
 }
+
+export function useChatMessagePage(sessionId: string, page: number = 0, size: number = 50) {
+  const parsedSessionId = Number(sessionId);
+  const hasValidSessionId = Number.isSafeInteger(parsedSessionId) && parsedSessionId > 0;
+
+  return useQuery({
+    queryKey: [...chatHistoryKeys.messages(sessionId, page, size), "page"] as const,
+    queryFn: () => consultationApi.getMessagePage(parsedSessionId, { page, size }),
+    enabled: hasValidSessionId,
+  });
+}

--- a/frontend/src/features/consultation/api/consultationApi.test.ts
+++ b/frontend/src/features/consultation/api/consultationApi.test.ts
@@ -405,6 +405,92 @@ describe("consultationApi", () => {
     expect(result).toEqual(stubMessages);
   });
 
+  it("getMessagePage가 page metadata와 content를 반환한다", async () => {
+    const stubMessages: ChatMessageResponse[] = [
+      {
+        id: 1,
+        seqNo: 51,
+        senderRole: "CUSTOMER",
+        messageType: "TEXT",
+        content: "최근 메시지",
+        createdAt: new Date().toISOString(),
+      },
+    ];
+    mockedCustomFetch.mockResolvedValue({
+      content: stubMessages,
+      page: 0,
+      size: 50,
+      totalElements: 75,
+      totalPages: 2,
+    });
+
+    const result = await consultationApi.getMessagePage(1);
+
+    expect(mockedGetGetMessagesUrl).toHaveBeenCalledWith(1);
+    expect(mockedCustomFetch).toHaveBeenCalledWith(
+      "/api/v1/consultation/sessions/1/messages?page=0&size=50",
+      { method: "GET" },
+    );
+    expect(result).toEqual({
+      content: stubMessages,
+      page: 0,
+      size: 50,
+      totalElements: 75,
+      totalPages: 2,
+    });
+  });
+
+  it("getMessagePage가 legacy array 응답을 metadata로 보정한다", async () => {
+    const stubMessages: ChatMessageResponse[] = [
+      {
+        id: 1,
+        seqNo: 1,
+        senderRole: "AGENT",
+        messageType: "TEXT",
+        content: "legacy",
+        createdAt: new Date().toISOString(),
+      },
+    ];
+    mockedCustomFetch.mockResolvedValue(stubMessages);
+
+    const result = await consultationApi.getMessagePage(1, { page: 2, size: 10 });
+
+    expect(mockedCustomFetch).toHaveBeenCalledWith(
+      "/api/v1/consultation/sessions/1/messages?page=2&size=10",
+      { method: "GET" },
+    );
+    expect(result).toEqual({
+      content: stubMessages,
+      page: 2,
+      size: 10,
+      totalElements: 1,
+      totalPages: 1,
+    });
+  });
+
+  it("getMessagePage가 잘못된 page/size를 요청과 응답에서 보정한다", async () => {
+    mockedCustomFetch.mockResolvedValue({
+      content: [],
+      page: -3,
+      size: 0,
+      totalElements: 12,
+    });
+
+    const result = await consultationApi.getMessagePage(1, { page: -1, size: 0 });
+
+    expect(mockedCustomFetch).toHaveBeenCalledWith(
+      "/api/v1/consultation/sessions/1/messages?page=0&size=1",
+      { method: "GET" },
+    );
+    expect(result).toEqual({
+      content: [],
+      page: 0,
+      size: 1,
+      totalElements: 12,
+      totalPages: 12,
+    });
+  });
+
   it("assignSession이 상담사 ID 없이 assign API를 호출한다", async () => {
     const stubSession = {
       id: 1,
@@ -418,10 +504,9 @@ describe("consultationApi", () => {
 
     const result = await consultationApi.assignSession(1);
 
-    expect(mockedCustomFetch).toHaveBeenCalledWith(
-      "/api/v1/consultation/sessions/1/assign",
-      { method: "POST" },
-    );
+    expect(mockedCustomFetch).toHaveBeenCalledWith("/api/v1/consultation/sessions/1/assign", {
+      method: "POST",
+    });
     expect(result).toEqual(stubSession);
   });
 
@@ -438,10 +523,9 @@ describe("consultationApi", () => {
 
     const result = await consultationApi.releaseSession(1);
 
-    expect(mockedCustomFetch).toHaveBeenCalledWith(
-      "/api/v1/consultation/sessions/1/release",
-      { method: "POST" },
-    );
+    expect(mockedCustomFetch).toHaveBeenCalledWith("/api/v1/consultation/sessions/1/release", {
+      method: "POST",
+    });
     expect(result).toEqual(stubSession);
   });
 

--- a/frontend/src/features/consultation/api/consultationApi.ts
+++ b/frontend/src/features/consultation/api/consultationApi.ts
@@ -16,6 +16,13 @@ export type ChatSession = ChatSessionResponse & {
   responseMode?: ConsultationResponseMode | null;
 };
 export type ChatMessage = ChatMessageResponse;
+export interface ChatMessagePage {
+  content: ChatMessage[];
+  page: number;
+  size: number;
+  totalElements: number;
+  totalPages: number;
+}
 export type ConsultationSessionStatus = "OPEN" | "ACTIVE" | "RESOLVED" | "COMPLETED";
 export type ConsultationResponseMode = "AI_ACTIVE" | "HUMAN_ACTIVE" | "AI_ASSIST_ONLY";
 export type ResolutionOutcome = "RESOLVED" | "CUSTOMER_LEFT" | "PENDING" | "FOLLOW_UP_REQUIRED";
@@ -77,7 +84,33 @@ type SessionListResponse =
 
 type MessageListResponse =
   | ChatMessage[]
-  | { data?: ChatMessage[] | { content?: ChatMessage[] }; content?: ChatMessage[] };
+  | {
+      data?: ChatMessage[] | Partial<ChatMessagePage>;
+      content?: ChatMessage[];
+      page?: number;
+      size?: number;
+      totalElements?: number;
+      totalPages?: number;
+    };
+
+const DEFAULT_MESSAGE_PAGE = 0;
+const DEFAULT_MESSAGE_PAGE_SIZE = 50;
+const MAX_MESSAGE_PAGE_SIZE = 100;
+
+function normalizeMessagePage(page: number | null | undefined): number {
+  if (typeof page !== "number" || !Number.isFinite(page)) return DEFAULT_MESSAGE_PAGE;
+  return Math.max(DEFAULT_MESSAGE_PAGE, Math.floor(page));
+}
+
+function normalizeMessagePageSize(size: number | null | undefined): number {
+  if (typeof size !== "number" || !Number.isFinite(size)) return DEFAULT_MESSAGE_PAGE_SIZE;
+  return Math.min(MAX_MESSAGE_PAGE_SIZE, Math.max(1, Math.floor(size)));
+}
+
+function normalizeMessageTotalPages(totalPages: number | null | undefined): number | undefined {
+  if (typeof totalPages !== "number" || !Number.isFinite(totalPages)) return undefined;
+  return Math.max(0, Math.floor(totalPages));
+}
 
 function unwrapSessionPage(response: SessionListResponse): ChatSessionPage {
   const unwrapped = selectApiData<ChatSession[] | Partial<ChatSessionPage>>(response);
@@ -105,6 +138,53 @@ function unwrapMessageList(response: MessageListResponse): ChatMessage[] {
   const unwrapped = selectApiData<ChatMessage[] | { content?: ChatMessage[] }>(response);
   if (Array.isArray(unwrapped)) return unwrapped;
   return unwrapped?.content ?? [];
+}
+
+function unwrapMessagePage(
+  response: MessageListResponse,
+  fallback: { page: number; size: number },
+): ChatMessagePage {
+  const fallbackPage = normalizeMessagePage(fallback.page);
+  const fallbackSize = normalizeMessagePageSize(fallback.size);
+  const unwrapped = selectApiData<ChatMessage[] | Partial<ChatMessagePage>>(response);
+  if (Array.isArray(unwrapped)) {
+    return {
+      content: unwrapped,
+      page: fallbackPage,
+      size: fallbackSize,
+      totalElements: unwrapped.length,
+      totalPages: unwrapped.length > 0 ? 1 : 0,
+    };
+  }
+
+  const content = unwrapped?.content ?? [];
+  const totalElements = unwrapped?.totalElements ?? content.length;
+  const page = normalizeMessagePage(unwrapped?.page ?? fallbackPage);
+  const size = normalizeMessagePageSize(unwrapped?.size ?? fallbackSize);
+  const totalPages =
+    normalizeMessageTotalPages(unwrapped?.totalPages) ??
+    (totalElements > 0 ? Math.ceil(totalElements / size) : 0);
+  return {
+    content,
+    page,
+    size,
+    totalElements,
+    totalPages,
+  };
+}
+
+async function fetchMessagePage(
+  sessionId: number,
+  params: { page?: number; size?: number } = {},
+): Promise<ChatMessagePage> {
+  const page = normalizeMessagePage(params.page);
+  const size = normalizeMessagePageSize(params.size);
+  const searchParams = new URLSearchParams();
+  searchParams.set("page", String(page));
+  searchParams.set("size", String(size));
+  const url = `${getGetMessagesUrl(sessionId)}?${searchParams.toString()}`;
+  const response = await customFetch<MessageListResponse>(url, { method: "GET" });
+  return unwrapMessagePage(response, { page, size });
 }
 
 export const consultationApi = {
@@ -149,15 +229,16 @@ export const consultationApi = {
     params?: { page?: number; size?: number },
   ): Promise<ChatMessage[]> => {
     if (!params) {
-      return selectApiData<ChatMessage[]>(await getMessages(sessionId)) ?? [];
+      return unwrapMessageList(await getMessages(sessionId));
     }
-    const searchParams = new URLSearchParams();
-    if (params.page !== undefined) searchParams.set("page", String(params.page));
-    if (params.size !== undefined) searchParams.set("size", String(params.size));
-    const query = searchParams.toString();
-    const url = `${getGetMessagesUrl(sessionId)}${query ? `?${query}` : ""}`;
-    const response = await customFetch<MessageListResponse>(url, { method: "GET" });
-    return unwrapMessageList(response);
+    return (await fetchMessagePage(sessionId, params)).content;
+  },
+
+  getMessagePage: async (
+    sessionId: number,
+    params?: { page?: number; size?: number },
+  ): Promise<ChatMessagePage> => {
+    return fetchMessagePage(sessionId, params);
   },
 
   sendMessage: async (

--- a/frontend/src/features/consultation/ui/ChatPanel.test.tsx
+++ b/frontend/src/features/consultation/ui/ChatPanel.test.tsx
@@ -869,4 +869,59 @@ describe("ChatPanel", () => {
 
     expect(screen.queryByRole("button", { name: "새 메시지 보기" })).not.toBeInTheDocument();
   });
+
+  it("이전 메시지를 불러올 때 기존 스크롤 위치를 유지한다", async () => {
+    const onLoadPreviousMessages = vi.fn(() => Promise.resolve());
+    const { rerender } = render(
+      <ChatPanel
+        sessionId="session-1"
+        customerName="김민지"
+        channel="카카오톡"
+        messages={baseMessages}
+        onSendMessage={vi.fn()}
+        selectedMessageId={null}
+        onSelectMessage={vi.fn()}
+        hasPreviousMessages
+        onLoadPreviousMessages={onLoadPreviousMessages}
+      />,
+    );
+    const messageList = screen.getByTestId("chat-message-list");
+    setScrollMetrics(messageList, {
+      scrollHeight: 1200,
+      clientHeight: 300,
+      scrollTop: 48,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "이전 메시지 불러오기" }));
+    await waitFor(() => expect(onLoadPreviousMessages).toHaveBeenCalledTimes(1));
+
+    setScrollMetrics(messageList, {
+      scrollHeight: 1500,
+      clientHeight: 300,
+      scrollTop: 48,
+    });
+    rerender(
+      <ChatPanel
+        sessionId="session-1"
+        customerName="김민지"
+        channel="카카오톡"
+        messages={[
+          {
+            id: "msg-0",
+            senderRole: "CUSTOMER",
+            content: "이전 문의입니다.",
+            timestamp: "10:01",
+          },
+          ...baseMessages,
+        ]}
+        onSendMessage={vi.fn()}
+        selectedMessageId={null}
+        onSelectMessage={vi.fn()}
+        hasPreviousMessages
+        onLoadPreviousMessages={onLoadPreviousMessages}
+      />,
+    );
+
+    expect(messageList.scrollTop).toBe(348);
+  });
 });

--- a/frontend/src/features/consultation/ui/ChatPanel.tsx
+++ b/frontend/src/features/consultation/ui/ChatPanel.tsx
@@ -37,6 +37,9 @@ interface ChatPanelProps {
   sessionStatusDescription?: string;
   disabled?: boolean;
   disabledReason?: string;
+  hasPreviousMessages?: boolean;
+  isLoadingPreviousMessages?: boolean;
+  onLoadPreviousMessages?: () => Promise<void>;
   draftResponseAction?: {
     isLoading: boolean;
     onInsert: () => Promise<string>;
@@ -79,6 +82,9 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
   sessionStatusDescription,
   disabled = false,
   disabledReason,
+  hasPreviousMessages = false,
+  isLoadingPreviousMessages = false,
+  onLoadPreviousMessages,
   draftResponseAction,
   composerDraft,
   onComposerDraftChange,
@@ -88,6 +94,7 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
     isNoteMode: false,
   });
   const listRef = useRef<HTMLDivElement>(null);
+  const previousScrollHeightRef = useRef<number | null>(null);
   const customerInitial = customerName?.trim().charAt(0) || "?";
   const sessionKey = sessionId ?? customerName;
   const activeDraft = composerDraft ?? uncontrolledDraft;
@@ -153,10 +160,18 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
   }, []);
 
   useLayoutEffect(() => {
+    const previousScrollHeight = previousScrollHeightRef.current;
+    const messageList = listRef.current;
+    if (previousScrollHeight !== null && messageList) {
+      messageList.scrollTop += messageList.scrollHeight - previousScrollHeight;
+      previousScrollHeightRef.current = null;
+      return;
+    }
+
     if (scrollState.shouldScrollToBottom) {
       scrollToBottom();
     }
-  }, [scrollState.scrollRequestId, scrollState.shouldScrollToBottom, scrollToBottom]);
+  }, [messages, scrollState.scrollRequestId, scrollState.shouldScrollToBottom, scrollToBottom]);
 
   const handleMessageListScroll = () => {
     const messageList = listRef.current;
@@ -185,6 +200,16 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
       showNewMessageNotice: false,
       shouldScrollToBottom: false,
     }));
+  };
+
+  const handleLoadPreviousMessages = async () => {
+    if (!onLoadPreviousMessages || isLoadingPreviousMessages) return;
+    previousScrollHeightRef.current = listRef.current?.scrollHeight ?? null;
+    try {
+      await onLoadPreviousMessages();
+    } catch {
+      previousScrollHeightRef.current = null;
+    }
   };
 
   const handleInsertDraft = async () => {
@@ -289,6 +314,16 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
           onScroll={handleMessageListScroll}
           data-testid="chat-message-list"
         >
+          {hasPreviousMessages && (
+            <button
+              type="button"
+              className={styles.loadPreviousButton}
+              onClick={() => void handleLoadPreviousMessages()}
+              disabled={isLoadingPreviousMessages}
+            >
+              {isLoadingPreviousMessages ? "불러오는 중..." : "이전 메시지 불러오기"}
+            </button>
+          )}
           {messages.map((msg) => {
             if (msg.senderRole === "SYSTEM") {
               const role = getChatRolePresentation(msg.senderRole);

--- a/frontend/src/features/consultation/ui/chat-history/MessageHistory.module.css
+++ b/frontend/src/features/consultation/ui/chat-history/MessageHistory.module.css
@@ -53,6 +53,41 @@
     linear-gradient(180deg, var(--paper) 0%, var(--bg) 100%);
 }
 
+.loadPreviousButton {
+  align-self: center;
+  border: 1px solid var(--line);
+  border-radius: var(--r-pill);
+  background: var(--paper);
+  color: var(--ink);
+  cursor: pointer;
+  font-family: var(--sans);
+  font-size: 13px;
+  font-weight: 540;
+  letter-spacing: -0.01em;
+  line-height: 1;
+  padding: var(--s-3) var(--s-4);
+  transition:
+    background var(--transition-fast),
+    border-color var(--transition-fast),
+    box-shadow var(--transition-fast);
+}
+
+.loadPreviousButton:hover:not(:disabled) {
+  border-color: var(--ink);
+  background: var(--paper-2);
+}
+
+.loadPreviousButton:disabled {
+  cursor: wait;
+  opacity: 0.58;
+}
+
+.loadPreviousButton:focus-visible {
+  outline: none;
+  border-color: var(--ink);
+  box-shadow: var(--focus-ring);
+}
+
 .messageRow {
   display: flex;
   width: 100%;

--- a/frontend/src/features/consultation/ui/chat-history/MessageHistory.test.tsx
+++ b/frontend/src/features/consultation/ui/chat-history/MessageHistory.test.tsx
@@ -1,0 +1,122 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MessageHistory } from "./MessageHistory";
+
+const { getMessagePageMock, toastErrorMock, useChatMessagePageMock } = vi.hoisted(() => ({
+  getMessagePageMock: vi.fn(),
+  toastErrorMock: vi.fn(),
+  useChatMessagePageMock: vi.fn(),
+}));
+
+vi.mock("../../api/chatHistoryApi", () => ({
+  useChatMessagePage: useChatMessagePageMock,
+}));
+
+vi.mock("../../api/consultationApi", () => ({
+  consultationApi: {
+    getMessagePage: getMessagePageMock,
+  },
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: toastErrorMock,
+  },
+}));
+
+describe("MessageHistory", () => {
+  beforeEach(() => {
+    getMessagePageMock.mockReset();
+    toastErrorMock.mockReset();
+    useChatMessagePageMock.mockReset();
+  });
+
+  it("첫 page 이후 이전 메시지를 추가로 불러온다", async () => {
+    useChatMessagePageMock.mockReturnValue({
+      data: {
+        content: [
+          {
+            id: 2,
+            seqNo: 2,
+            senderRole: "AGENT",
+            messageType: "TEXT",
+            content: "최근 답변입니다",
+            createdAt: "2026-05-22T00:01:00Z",
+          },
+        ],
+        page: 0,
+        size: 50,
+        totalElements: 2,
+        totalPages: 2,
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    getMessagePageMock.mockResolvedValue({
+      content: [
+        {
+          id: 1,
+          seqNo: 1,
+          senderRole: "CUSTOMER",
+          messageType: "TEXT",
+          content: "이전 문의입니다",
+          createdAt: "2026-05-22T00:00:00Z",
+        },
+      ],
+      page: 1,
+      size: 50,
+      totalElements: 2,
+      totalPages: 2,
+    });
+
+    render(<MessageHistory sessionId="7" />);
+
+    expect(screen.getByText("최근 답변입니다")).toBeTruthy();
+    expect(screen.getByText("1/2개 메시지")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "이전 메시지 불러오기" }));
+
+    await waitFor(() => {
+      expect(getMessagePageMock).toHaveBeenCalledWith(7, { page: 1, size: 50 });
+    });
+    expect(await screen.findByText("이전 문의입니다")).toBeTruthy();
+    expect(screen.getByText("2/2개 메시지")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "이전 메시지 불러오기" })).toBeNull();
+  });
+
+  it("이전 메시지 로드 실패 시 toast로 알린다", async () => {
+    useChatMessagePageMock.mockReturnValue({
+      data: {
+        content: [
+          {
+            id: 2,
+            seqNo: 2,
+            senderRole: "AGENT",
+            messageType: "TEXT",
+            content: "최근 답변입니다",
+            createdAt: "2026-05-22T00:01:00Z",
+          },
+        ],
+        page: 0,
+        size: 50,
+        totalElements: 2,
+        totalPages: 2,
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    getMessagePageMock.mockRejectedValue(new Error("load failed"));
+
+    render(<MessageHistory sessionId="7" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "이전 메시지 불러오기" }));
+
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalledWith("이전 메시지를 불러오지 못했습니다.");
+    });
+  });
+});

--- a/frontend/src/features/consultation/ui/chat-history/MessageHistory.tsx
+++ b/frontend/src/features/consultation/ui/chat-history/MessageHistory.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
 import {
   Dot,
   EmptyState,
@@ -9,7 +11,8 @@ import {
   Pill,
 } from "@/shared/ui/ostone/atoms";
 import type { ChatMessage } from "../../api/consultationApi";
-import { useChatMessages } from "../../api/chatHistoryApi";
+import { consultationApi, type ChatMessagePage } from "../../api/consultationApi";
+import { useChatMessagePage } from "../../api/chatHistoryApi";
 import { getChatRolePresentation, isCounselorLikeRole } from "../../lib/chatRoleLabels";
 import styles from "./MessageHistory.module.css";
 
@@ -69,13 +72,63 @@ export function MessageHistory({
   missingSessionId = null,
 }: MessageHistoryProps) {
   const activeSessionId = isSelectionPending || missingSessionId ? "" : (sessionId ?? "");
+  const [loadedPages, setLoadedPages] = useState<ChatMessagePage[]>([]);
+  const [isLoadingPrevious, setIsLoadingPrevious] = useState(false);
   const {
-    data: messages = [],
+    data: firstPage,
     isLoading,
     isError,
     error,
     refetch,
-  } = useChatMessages(activeSessionId);
+  } = useChatMessagePage(activeSessionId);
+
+  useEffect(() => {
+    setLoadedPages([]);
+    setIsLoadingPrevious(false);
+  }, [activeSessionId]);
+
+  useEffect(() => {
+    if (firstPage) {
+      setLoadedPages((current) => [
+        firstPage,
+        ...current.filter((page) => page.page !== firstPage.page),
+      ]);
+    }
+  }, [firstPage]);
+
+  const messages = useMemo(
+    () =>
+      [...loadedPages]
+        .sort((left, right) => right.page - left.page)
+        .flatMap((page) => page.content),
+    [loadedPages],
+  );
+  const latestPage = loadedPages.reduce<ChatMessagePage | null>(
+    (selected, page) => (!selected || page.page > selected.page ? page : selected),
+    null,
+  );
+  const totalCount = firstPage?.totalElements ?? messages.length;
+  const hasPreviousMessages = latestPage ? latestPage.page + 1 < latestPage.totalPages : false;
+
+  const handleLoadPrevious = async () => {
+    if (!activeSessionId || !latestPage || isLoadingPrevious || !hasPreviousMessages) return;
+    setIsLoadingPrevious(true);
+    try {
+      const previousPage = await consultationApi.getMessagePage(Number(activeSessionId), {
+        page: latestPage.page + 1,
+        size: latestPage.size,
+      });
+      setLoadedPages((current) => {
+        if (current.some((page) => page.page === previousPage.page)) return current;
+        return [...current, previousPage];
+      });
+    } catch (error) {
+      console.error("Failed to load previous message history:", error);
+      toast.error("이전 메시지를 불러오지 못했습니다.");
+    } finally {
+      setIsLoadingPrevious(false);
+    }
+  };
 
   if (missingSessionId) {
     return (
@@ -133,13 +186,23 @@ export function MessageHistory({
 
   return (
     <section className={styles.wrapper} aria-label="채팅 메시지 내역">
-      <Header countText={`${messages.length}개 메시지`} />
+      <Header countText={`${messages.length}/${totalCount}개 메시지`} />
       {messages.length === 0 ? (
         <div className={styles.stateArea}>
           <EmptyState message="아직 메시지가 없습니다" />
         </div>
       ) : (
         <div className={styles.messageList}>
+          {hasPreviousMessages && (
+            <button
+              type="button"
+              className={styles.loadPreviousButton}
+              onClick={() => void handleLoadPrevious()}
+              disabled={isLoadingPrevious}
+            >
+              {isLoadingPrevious ? "불러오는 중..." : "이전 메시지 불러오기"}
+            </button>
+          )}
           {messages.map((message) => (
             <MessageBubble key={String(message.id ?? message.seqNo)} message={message} />
           ))}

--- a/frontend/src/features/consultation/ui/chat-panel.module.css
+++ b/frontend/src/features/consultation/ui/chat-panel.module.css
@@ -164,6 +164,41 @@
     var(--focus-ring);
 }
 
+.loadPreviousButton {
+  align-self: center;
+  border: 1px solid rgba(0, 0, 0, 0.16);
+  border-radius: 50px;
+  background: var(--paper);
+  color: var(--ink);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.78rem;
+  font-weight: 540;
+  letter-spacing: -0.1px;
+  line-height: 1;
+  padding: 9px 14px;
+  transition:
+    background var(--transition-fast),
+    border-color var(--transition-fast),
+    box-shadow var(--transition-fast);
+}
+
+.loadPreviousButton:hover:not(:disabled) {
+  border-color: var(--ink);
+  background: rgba(0, 0, 0, 0.04);
+}
+
+.loadPreviousButton:disabled {
+  cursor: wait;
+  opacity: 0.58;
+}
+
+.loadPreviousButton:focus-visible {
+  outline: none;
+  border-color: var(--ink);
+  box-shadow: var(--focus-ring);
+}
+
 .messageGroup {
   display: flex;
   gap: 10px;

--- a/frontend/src/pages/consultation/ui/ConsultationPage.generated-api.test.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.generated-api.test.tsx
@@ -102,19 +102,25 @@ describe("ConsultationPage generated API integration", () => {
       if (url === "/api/v1/workspaces/2/consultation/queue") {
         return Promise.resolve({ data: [assignedSession] });
       }
+      if (url === "/api/v1/consultation/sessions/1/messages?page=0&size=50") {
+        return Promise.resolve({
+          content: [
+            {
+              id: 100,
+              seqNo: 1,
+              senderRole: "CUSTOMER",
+              messageType: "TEXT",
+              content: "generated 상담 메시지",
+              createdAt: "2026-05-22T00:01:00Z",
+            },
+          ],
+          page: 0,
+          size: 50,
+          totalElements: 1,
+          totalPages: 1,
+        });
+      }
       return Promise.reject(new Error(`Unexpected manual endpoint: ${url}`));
-    });
-    mocks.getMessages.mockResolvedValue({
-      data: [
-        {
-          id: 100,
-          seqNo: 1,
-          senderRole: "CUSTOMER",
-          messageType: "TEXT",
-          content: "generated 상담 메시지",
-          createdAt: "2026-05-22T00:01:00Z",
-        },
-      ],
     });
     mocks.updateStatus.mockResolvedValue({
       data: {
@@ -124,7 +130,7 @@ describe("ConsultationPage generated API integration", () => {
     });
   });
 
-  it("상담 화면에서 고객 선택 시 generated getMessages 응답을 렌더링한다", async () => {
+  it("상담 화면에서 고객 선택 시 generated 메시지 URL 응답을 렌더링한다", async () => {
     render(<ConsultationPage />, { wrapper: Wrapper });
 
     const customerItem = await screen.findByText("김민지");
@@ -134,7 +140,11 @@ describe("ConsultationPage generated API integration", () => {
     expect(mocks.customFetch).toHaveBeenCalledWith("/api/v1/workspaces/2/consultation/queue", {
       method: "GET",
     });
-    expect(mocks.getMessages).toHaveBeenCalledWith(1);
+    expect(mocks.customFetch).toHaveBeenCalledWith(
+      "/api/v1/consultation/sessions/1/messages?page=0&size=50",
+      { method: "GET" },
+    );
+    expect(mocks.getMessages).not.toHaveBeenCalled();
   });
 
   it("상담 종료 액션은 확인 모달에서 처리 결과를 선택한 뒤 generated updateStatus로 전송한다", async () => {

--- a/frontend/src/pages/consultation/ui/ConsultationPage.test.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.test.tsx
@@ -87,6 +87,24 @@ vi.mock("../../../features/consultation/api/consultationApi", () => ({
         },
       ]),
     ),
+    getMessagePage: vi.fn(() =>
+      Promise.resolve({
+        content: [
+          {
+            id: 100,
+            seqNo: 1,
+            senderRole: "CUSTOMER",
+            messageType: "TEXT",
+            content: "환불 문의 드립니다.",
+            createdAt: new Date().toISOString(),
+          },
+        ],
+        page: 0,
+        size: 50,
+        totalElements: 1,
+        totalPages: 1,
+      }),
+    ),
     updateStatus: vi.fn(() => Promise.resolve({})),
     assignSession: vi.fn((sessionId: number) =>
       Promise.resolve({
@@ -466,12 +484,64 @@ describe("ConsultationPage", () => {
     });
 
     await waitFor(() => {
-      expect(consultationApi.getMessages).toHaveBeenCalledWith(1);
+      expect(consultationApi.getMessagePage).toHaveBeenCalledWith(1, { page: 0, size: 50 });
     });
     expect(screen.getByText("김민지 고객")).toBeInTheDocument();
     expect(screen.getByText("환불 문의 드립니다.")).toBeInTheDocument();
     expect(consultationApi.assignSession).not.toHaveBeenCalled();
     expect(screen.getByRole("button", { name: "배정받기" })).toBeInTheDocument();
+  });
+
+  it("loads previous message pages from the top of the live chat", async () => {
+    vi.mocked(consultationApi.getMessagePage)
+      .mockResolvedValueOnce({
+        content: [
+          {
+            id: 101,
+            seqNo: 51,
+            senderRole: "CUSTOMER",
+            messageType: "TEXT",
+            content: "최근 문의입니다.",
+            createdAt: new Date().toISOString(),
+          },
+        ],
+        page: 0,
+        size: 50,
+        totalElements: 51,
+        totalPages: 2,
+      })
+      .mockResolvedValueOnce({
+        content: [
+          {
+            id: 10,
+            seqNo: 1,
+            senderRole: "CUSTOMER",
+            messageType: "TEXT",
+            content: "이전 문의입니다.",
+            createdAt: new Date().toISOString(),
+          },
+        ],
+        page: 1,
+        size: 50,
+        totalElements: 51,
+        totalPages: 2,
+      });
+
+    render(<ConsultationPage />, {
+      wrapper: createRoutedWrapper("/workspaces/2/consultation/1"),
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("최근 문의입니다.")).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "이전 메시지 불러오기" }));
+
+    await waitFor(() => {
+      expect(consultationApi.getMessagePage).toHaveBeenLastCalledWith(1, { page: 1, size: 50 });
+    });
+    expect(screen.getByText("이전 문의입니다.")).toBeInTheDocument();
+    expect(screen.getByText("최근 문의입니다.")).toBeInTheDocument();
   });
 
   it("updates the browser URL when a queue session is selected", async () => {
@@ -501,7 +571,9 @@ describe("ConsultationPage", () => {
     await waitFor(() => {
       expect(screen.getByText("요청한 상담 세션을 찾을 수 없습니다")).toBeInTheDocument();
     });
-    expect(consultationApi.getMessages).not.toHaveBeenCalledWith(999);
+    expect(
+      vi.mocked(consultationApi.getMessagePage).mock.calls.some(([sessionId]) => sessionId === 999),
+    ).toBe(false);
   });
 
   it("treats non-numeric route session IDs as unavailable without loading messages", async () => {
@@ -512,7 +584,7 @@ describe("ConsultationPage", () => {
     await waitFor(() => {
       expect(screen.getByText("요청한 상담 세션을 찾을 수 없습니다")).toBeInTheDocument();
     });
-    expect(consultationApi.getMessages).not.toHaveBeenCalled();
+    expect(consultationApi.getMessagePage).not.toHaveBeenCalled();
   });
 
   it("selects a route session when it arrives later through the queue websocket", async () => {
@@ -544,7 +616,7 @@ describe("ConsultationPage", () => {
     await waitFor(() => {
       expect(screen.queryByText("요청한 상담 세션을 찾을 수 없습니다")).not.toBeInTheDocument();
       expect(screen.getByText("박지훈 고객")).toBeInTheDocument();
-      expect(consultationApi.getMessages).toHaveBeenCalledWith(9);
+      expect(consultationApi.getMessagePage).toHaveBeenCalledWith(9, { page: 0, size: 50 });
     });
   });
 
@@ -1005,7 +1077,7 @@ describe("ConsultationPage", () => {
     }
 
     await waitFor(() => {
-      expect(consultationApi.getMessages).toHaveBeenCalledWith(1);
+      expect(consultationApi.getMessagePage).toHaveBeenCalledWith(1, { page: 0, size: 50 });
     });
     expect(consultationApi.assignSession).not.toHaveBeenCalled();
     expect(screen.getByRole("button", { name: "배정받기" })).toBeInTheDocument();
@@ -1919,7 +1991,7 @@ describe("ConsultationPage", () => {
       expect(screen.getByText("김민지")).toBeInTheDocument();
     });
 
-    vi.mocked(consultationApi.getMessages).mockRejectedValueOnce(new Error("DB Error"));
+    vi.mocked(consultationApi.getMessagePage).mockRejectedValueOnce(new Error("DB Error"));
 
     const customerItem = screen.getByText("김민지").closest("div");
     if (customerItem) {
@@ -1973,7 +2045,13 @@ describe("ConsultationPage", () => {
       expect(screen.getByText("연결된 도메인 팩 요소가 없습니다")).toBeInTheDocument();
     });
 
-    vi.mocked(consultationApi.getMessages).mockResolvedValueOnce([]);
+    vi.mocked(consultationApi.getMessagePage).mockResolvedValueOnce({
+      content: [],
+      page: 0,
+      size: 50,
+      totalElements: 0,
+      totalPages: 0,
+    });
 
     const hongEl = screen.getByText("홍길동").closest("div");
     if (hongEl) hongEl.click();

--- a/frontend/src/pages/consultation/ui/ConsultationPage.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.tsx
@@ -103,6 +103,13 @@ type QueueCustomerPanelData = {
 type QueueCustomerWithPanelData = QueueCustomer & QueueCustomerPanelData;
 
 const COUNSELOR_MESSAGE_ACK_TIMEOUT_MS = 8000;
+const MESSAGE_PAGE_SIZE = 50;
+
+type MessagePaginationState = {
+  nextPage: number;
+  totalPages: number;
+  isLoadingPrevious: boolean;
+};
 
 type ResponseModeView = {
   value: ConsultationResponseMode;
@@ -518,6 +525,14 @@ const getClaimSessionErrorMessage = (error: unknown) => {
   return "상담 세션 배정에 실패했습니다.";
 };
 
+const dedupePrependMessages = (
+  olderMessages: UiChatMessage[],
+  currentMessages: UiChatMessage[],
+) => {
+  const existingIds = new Set(currentMessages.map((message) => message.id));
+  return [...olderMessages.filter((message) => !existingIds.has(message.id)), ...currentMessages];
+};
+
 const formatAverageFirstResponse = (seconds?: number | null) => {
   if (seconds == null) return "--";
   const minutes = Math.floor(seconds / 60);
@@ -603,6 +618,11 @@ export const ConsultationPage: React.FC = () => {
   const [activeCustomerId, setActiveCustomerId] = useState<string | null>(null);
   const [messages, setMessages] = useState<UiChatMessage[]>([]);
   const [messagesCustomerId, setMessagesCustomerId] = useState<string | null>(null);
+  const [messagePagination, setMessagePagination] = useState<MessagePaginationState>({
+    nextPage: 0,
+    totalPages: 0,
+    isLoadingPrevious: false,
+  });
   const [metrics, setMetrics] = useState<ConsultationMetrics | null>(null);
   const [isMetricsLoading, setIsMetricsLoading] = useState(false);
   const [metricsError, setMetricsError] = useState<string | null>(null);
@@ -698,6 +718,10 @@ export const ConsultationPage: React.FC = () => {
         : "empty";
   const visibleMessages =
     activeCustomer && messagesCustomerId === activeCustomer.id ? messages : [];
+  const hasPreviousMessages =
+    !!activeCustomer &&
+    messagesCustomerId === activeCustomer.id &&
+    messagePagination.nextPage < messagePagination.totalPages;
   const selectedMessage = visibleMessages.find((m) => m.id === selectedMessageId) || null;
   const activeComposerDraft = activeCustomerId
     ? (composerDrafts[activeCustomerId] ?? EMPTY_COMPOSER_DRAFT)
@@ -736,6 +760,7 @@ export const ConsultationPage: React.FC = () => {
     setSelectedMessageId(null);
     setMessages([]);
     setMessagesCustomerId(null);
+    setMessagePagination({ nextPage: 0, totalPages: 0, isLoadingPrevious: false });
     setMatchedWorkflow(null);
     setIsMatchedWorkflowLoading(false);
     setIsDraftResponseLoading(false);
@@ -1072,6 +1097,7 @@ export const ConsultationPage: React.FC = () => {
       clearPendingMessages();
       setMessages([]);
       setMessagesCustomerId(null);
+      setMessagePagination({ nextPage: 0, totalPages: 0, isLoadingPrevious: false });
       setSelectedMessageId(null);
       return;
     }
@@ -1079,16 +1105,25 @@ export const ConsultationPage: React.FC = () => {
     clearPendingMessages();
     setMessages([]);
     setMessagesCustomerId(null);
+    setMessagePagination({ nextPage: 0, totalPages: 0, isLoadingPrevious: false });
     setSelectedMessageId(null);
 
     let cancelled = false;
 
     const loadMessages = async () => {
       try {
-        const msgs = await consultationApi.getMessages(Number(activeCustomerId));
+        const messagePage = await consultationApi.getMessagePage(Number(activeCustomerId), {
+          page: 0,
+          size: MESSAGE_PAGE_SIZE,
+        });
         if (cancelled) return;
-        setMessages(msgs.map(toUiMessage));
+        setMessages(messagePage.content.map(toUiMessage));
         setMessagesCustomerId(activeCustomerId);
+        setMessagePagination({
+          nextPage: messagePage.page + 1,
+          totalPages: messagePage.totalPages,
+          isLoadingPrevious: false,
+        });
       } catch (error) {
         if (!cancelled) {
           console.error("Failed to load messages:", error);
@@ -1103,6 +1138,41 @@ export const ConsultationPage: React.FC = () => {
       cancelled = true;
     };
   }, [activeCustomerId, clearPendingMessages]);
+
+  const handleLoadPreviousMessages = useCallback(async () => {
+    if (
+      !activeCustomerId ||
+      messagesCustomerId !== activeCustomerId ||
+      messagePagination.isLoadingPrevious ||
+      messagePagination.nextPage >= messagePagination.totalPages
+    ) {
+      return;
+    }
+
+    const targetSessionId = activeCustomerId;
+    const targetPage = messagePagination.nextPage;
+    setMessagePagination((current) => ({ ...current, isLoadingPrevious: true }));
+    try {
+      const messagePage = await consultationApi.getMessagePage(Number(targetSessionId), {
+        page: targetPage,
+        size: MESSAGE_PAGE_SIZE,
+      });
+      if (activeCustomerIdRef.current !== targetSessionId) return;
+      setMessages((current) =>
+        dedupePrependMessages(messagePage.content.map(toUiMessage), current),
+      );
+      setMessagesCustomerId(targetSessionId);
+      setMessagePagination({
+        nextPage: messagePage.page + 1,
+        totalPages: messagePage.totalPages,
+        isLoadingPrevious: false,
+      });
+    } catch (error) {
+      console.error("Failed to load previous messages:", error);
+      toast.error("이전 메시지를 불러오지 못했습니다.");
+      setMessagePagination((current) => ({ ...current, isLoadingPrevious: false }));
+    }
+  }, [activeCustomerId, messagePagination, messagesCustomerId]);
 
   useEffect(() => {
     if (connectionStatus !== "CONNECTED" || !activeCustomerId) return;
@@ -1639,6 +1709,9 @@ export const ConsultationPage: React.FC = () => {
               sessionStatusDescription={activeAssignment?.description}
               disabledReason={messageInputDisabledReason}
               disabled={!isAssignedToCurrentCounselor}
+              hasPreviousMessages={hasPreviousMessages}
+              isLoadingPreviousMessages={messagePagination.isLoadingPrevious}
+              onLoadPreviousMessages={handleLoadPreviousMessages}
               draftResponseAction={
                 matchedWorkflow && isAssignedToCurrentCounselor
                   ? {

--- a/frontend/src/pages/consultation/ui/chat-history/ChatHistoryPage.test.tsx
+++ b/frontend/src/pages/consultation/ui/chat-history/ChatHistoryPage.test.tsx
@@ -3,7 +3,7 @@ import { useEffect } from "react";
 import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  useChatMessages,
+  useChatMessagePage,
   useChatSessions,
 } from "../../../../features/consultation/api/chatHistoryApi";
 import type {
@@ -14,19 +14,19 @@ import { ChatHistoryPage } from "./ChatHistoryPage";
 
 vi.mock("../../../../features/consultation/api/chatHistoryApi", () => ({
   useChatSessions: vi.fn(),
-  useChatMessages: vi.fn(),
+  useChatMessagePage: vi.fn(),
 }));
 
 const mockedUseChatSessions = vi.mocked(useChatSessions);
-const mockedUseChatMessages = vi.mocked(useChatMessages);
+const mockedUseChatMessagePage = vi.mocked(useChatMessagePage);
 
 type MockChatSessionsResult = Pick<
   ReturnType<typeof useChatSessions>,
   "data" | "isLoading" | "isError" | "error" | "refetch"
 >;
 
-type MockChatMessagesResult = Pick<
-  ReturnType<typeof useChatMessages>,
+type MockChatMessagePageResult = Pick<
+  ReturnType<typeof useChatMessagePage>,
   "data" | "isLoading" | "isError" | "error" | "refetch"
 >;
 
@@ -46,15 +46,35 @@ const makeSessionsResult = (overrides?: Partial<MockChatSessionsResult>) =>
     ...overrides,
   }) as ReturnType<typeof useChatSessions>;
 
-const makeMessagesResult = (overrides?: Partial<MockChatMessagesResult>) =>
-  ({
-    data: [],
+const makeMessagePageResult = (
+  overrides?: Partial<MockChatMessagePageResult> & { data?: ChatMessage[] },
+) => {
+  const { data = [], ...rest } = overrides ?? {};
+  return {
+    data: {
+      content: data,
+      page: 0,
+      size: 50,
+      totalElements: data.length,
+      totalPages: data.length ? 1 : 0,
+    },
     isLoading: false,
     isError: false,
     error: null,
     refetch: vi.fn(),
-    ...overrides,
-  }) as ReturnType<typeof useChatMessages>;
+    ...rest,
+  } as ReturnType<typeof useChatMessagePage>;
+};
+
+function mockMessagePageForSession(
+  sessionId: string,
+  result: ReturnType<typeof useChatMessagePage>,
+) {
+  const emptyResult = makeMessagePageResult();
+  mockedUseChatMessagePage.mockImplementation((currentSessionId) =>
+    currentSessionId === sessionId ? result : emptyResult,
+  );
+}
 
 function makeSession(id: number): ChatSession {
   return {
@@ -108,9 +128,9 @@ function renderPage(path = "/workspaces/1/consultation/history") {
 describe("ChatHistoryPage", () => {
   beforeEach(() => {
     mockedUseChatSessions.mockReset();
-    mockedUseChatMessages.mockReset();
+    mockedUseChatMessagePage.mockReset();
     mockedUseChatSessions.mockReturnValue(makeSessionsResult());
-    mockedUseChatMessages.mockReturnValue(makeMessagesResult());
+    mockedUseChatMessagePage.mockReturnValue(makeMessagePageResult());
   });
 
   it("URL의 workspaceId로 상담 이력 목록을 요청한다", () => {
@@ -166,14 +186,14 @@ describe("ChatHistoryPage", () => {
     expect(screen.getByText("좌측 목록에서 세션을 선택해주세요")).toBeTruthy();
   });
 
-  it("세션을 선택하면 해당 세션의 메시지 내역을 표시한다", () => {
-    mockedUseChatMessages.mockReturnValue(makeMessagesResult({ data: [makeMessage()] }));
+  it("세션을 선택하면 해당 세션의 메시지 내역을 표시한다", async () => {
+    mockMessagePageForSession("7", makeMessagePageResult({ data: [makeMessage()] }));
 
     renderPage();
     fireEvent.click(screen.getByRole("button", { name: /카카오톡/ }));
 
-    expect(mockedUseChatMessages).toHaveBeenLastCalledWith("7");
-    expect(screen.getByText("고객")).toBeTruthy();
+    expect(mockedUseChatMessagePage).toHaveBeenLastCalledWith("7");
+    expect(await screen.findByText("고객")).toBeTruthy();
     expect(screen.getByText("환불 문의 드립니다")).toBeTruthy();
     expect(screen.getByText("TEXT")).toBeTruthy();
     expect(
@@ -212,9 +232,10 @@ describe("ChatHistoryPage", () => {
     expect(search.get("status")).toBe("ALL");
   });
 
-  it("상담사 메시지는 상담사 역할로 표시한다", () => {
-    mockedUseChatMessages.mockReturnValue(
-      makeMessagesResult({
+  it("상담사 메시지는 상담사 역할로 표시한다", async () => {
+    mockMessagePageForSession(
+      "7",
+      makeMessagePageResult({
         data: [makeMessage({ senderRole: "AGENT", content: "처리해드리겠습니다" })],
       }),
     );
@@ -222,13 +243,14 @@ describe("ChatHistoryPage", () => {
     renderPage();
     fireEvent.click(screen.getByRole("button", { name: /카카오톡/ }));
 
-    expect(screen.getByText("상담사")).toBeTruthy();
+    expect(await screen.findByText("상담사")).toBeTruthy();
     expect(screen.getByText("처리해드리겠습니다")).toBeTruthy();
   });
 
-  it("AI와 내부 메모 역할을 한국어 라벨로 표시한다", () => {
-    mockedUseChatMessages.mockReturnValue(
-      makeMessagesResult({
+  it("AI와 내부 메모 역할을 한국어 라벨로 표시한다", async () => {
+    mockMessagePageForSession(
+      "7",
+      makeMessagePageResult({
         data: [
           makeMessage({ id: 12, senderRole: "ASSISTANT", content: "AI 안내입니다" }),
           makeMessage({ id: 13, senderRole: "NOTE", content: "내부 공유 메모" }),
@@ -239,14 +261,14 @@ describe("ChatHistoryPage", () => {
     renderPage();
     fireEvent.click(screen.getByRole("button", { name: /카카오톡/ }));
 
-    expect(screen.getByText("AI")).toBeTruthy();
+    expect(await screen.findByText("AI")).toBeTruthy();
     expect(screen.getByText("내부 메모")).toBeTruthy();
     expect(screen.getByText("AI 안내입니다")).toBeTruthy();
     expect(screen.getByText("내부 공유 메모")).toBeTruthy();
   });
 
   it("선택한 세션에 메시지가 없으면 빈 상태를 표시한다", () => {
-    mockedUseChatMessages.mockReturnValue(makeMessagesResult({ data: [] }));
+    mockMessagePageForSession("7", makeMessagePageResult({ data: [] }));
 
     renderPage();
     fireEvent.click(screen.getByRole("button", { name: /카카오톡/ }));
@@ -255,7 +277,7 @@ describe("ChatHistoryPage", () => {
   });
 
   it("메시지 로딩 상태를 표시한다", () => {
-    mockedUseChatMessages.mockReturnValue(makeMessagesResult({ isLoading: true }));
+    mockMessagePageForSession("7", makeMessagePageResult({ isLoading: true }));
 
     renderPage();
     fireEvent.click(screen.getByRole("button", { name: /카카오톡/ }));
@@ -265,8 +287,9 @@ describe("ChatHistoryPage", () => {
 
   it("메시지 오류 상태에서 다시 시도할 수 있다", () => {
     const refetch = vi.fn();
-    mockedUseChatMessages.mockReturnValue(
-      makeMessagesResult({ isError: true, error: new Error("메시지 오류"), refetch }),
+    mockMessagePageForSession(
+      "7",
+      makeMessagePageResult({ isError: true, error: new Error("메시지 오류"), refetch }),
     );
 
     renderPage();
@@ -278,16 +301,16 @@ describe("ChatHistoryPage", () => {
   });
 
   it("URL의 sessionId로 초기 세션을 선택한다", () => {
-    mockedUseChatMessages.mockReturnValue(makeMessagesResult({ data: [makeMessage()] }));
+    mockMessagePageForSession("7", makeMessagePageResult({ data: [makeMessage()] }));
     renderPage("/workspaces/1/consultation/history/7");
 
-    expect(mockedUseChatMessages).toHaveBeenLastCalledWith("7");
+    expect(mockedUseChatMessagePage).toHaveBeenLastCalledWith("7");
   });
 
   it("URL의 sessionId가 현재 워크스페이스 목록에 없으면 메시지를 조회하지 않고 안내한다", () => {
     renderPage("/workspaces/1/consultation/history/999");
 
-    expect(mockedUseChatMessages).toHaveBeenLastCalledWith("");
+    expect(mockedUseChatMessagePage).toHaveBeenLastCalledWith("");
     expect(
       screen.getByText("현재 워크스페이스에서 해당 상담 세션을 찾을 수 없습니다"),
     ).toBeTruthy();


### PR DESCRIPTION
## Summary
- 상담 메시지 조회 API가 `page`/`size`를 받아 최신 메시지 page와 pagination metadata를 반환하도록 했습니다.
- 실시간 상담 화면과 상담 기록 화면이 최근 메시지부터 로드하고, 상단에서 이전 메시지 page를 추가 조회할 수 있게 했습니다.
- stale generated endpoint를 직접 수정하지 않고 wrapper에서 page 응답과 legacy array 응답을 모두 처리하며, 구현 기준을 `.agent/specs/364.md`에 정리했습니다.

## Validation
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21 GRADLE_USER_HOME=/tmp/ostone-gradle-ffc8 cd backend && ./gradlew test --tests '*ConsultationControllerTest' --tests '*ConsultationServiceTest'`
- `cd frontend && pnpm test -- --run src/features/consultation/api/consultationApi.test.ts src/features/consultation/api/chatHistoryApi.test.ts src/features/consultation/ui/ChatPanel.test.tsx src/features/consultation/ui/chat-history/MessageHistory.test.tsx src/pages/consultation/ui/ConsultationPage.test.tsx src/entities/chat/api/chatApi.test.ts`
- `cd frontend && pnpm exec eslint src/entities/chat/api/chatApi.ts src/entities/chat/api/chatApi.test.ts src/features/consultation/api/chatHistoryApi.ts src/features/consultation/api/chatHistoryApi.test.ts src/features/consultation/api/consultationApi.ts src/features/consultation/api/consultationApi.test.ts src/features/consultation/ui/ChatPanel.tsx src/features/consultation/ui/ChatPanel.test.tsx src/features/consultation/ui/chat-history/MessageHistory.tsx src/features/consultation/ui/chat-history/MessageHistory.test.tsx src/pages/consultation/ui/ConsultationPage.tsx src/pages/consultation/ui/ConsultationPage.test.tsx`
- `cd frontend && pnpm build`
- `git diff --check`
- `git diff --cached --check`

## Notes
- 전체 `cd frontend && pnpm lint`는 이번 변경과 무관한 기존 lint 오류 58개로 실패해, 변경 파일 대상으로 eslint를 확인했습니다.
- 동일한 기존 full-lint 실패 때문에 커밋 생성 시 해당 커밋 명령에 한해 Husky를 비활성화했습니다.

Closes #364


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 상담 메시지 조회에 페이지네이션 도입 (기본 page=0, size=50, 최대 size=100)
  * 이전 메시지 페이지를 불러오는 UI 및 누적 로드 지원
  * 이전 메시지 불러오기 시 스크롤 위치 자동 유지 및 메시지 중복 방지

* **동작 개선/검증**
  * 잘못된 page/size 입력은 유효성 오류로 거부

* **문서**
  * 메시지 페이징 계약 및 이용 흐름 명세 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->