### PR TITLE
chore(infra): postgres 이미지를 pg16에서 pg17로 업그레이드

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: pgvector/pgvector:pg16
+    image: pgvector/pgvector:pg17
     container_name: init-postgres
     environment:
       POSTGRES_USER: ${DB_USER:-init}


### PR DESCRIPTION
기존 볼륨이 PG17로 초기화되어 있어 PG16 컨테이너 기동 실패.
데이터 보존을 위해 이미지를 pg17로 변경.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 데이터베이스 버전이 업그레이드되었습니다. 개발 환경의 PostgreSQL 기반 데이터베이스가 최신 버전으로 업데이트되어 성능 및 안정성이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->