### PR TITLE
chore(infra): 운영 Terraform 초기 배포 안정화

### DIFF
--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -123,6 +123,7 @@ jobs:
             --cluster ostone-prod-cluster \
             --service ostone-backend \
             --task-definition "$NEW_TASK_DEF_ARN" \
+            --desired-count 1 \
             --force-new-deployment \
             --region ap-northeast-2
           aws ecs wait services-stable \

--- a/.github/workflows/terraform-cd.yml
+++ b/.github/workflows/terraform-cd.yml
@@ -21,10 +21,11 @@ jobs:
     runs-on: ubuntu-latest
     env:
       TF_VAR_domain_name: ${{ vars.PROD_DOMAIN_NAME }}
+      TF_VAR_route53_zone_id: ${{ vars.PROD_ROUTE53_ZONE_ID || '' }}
+      TF_VAR_manage_route53_zone: ${{ vars.PROD_MANAGE_ROUTE53_ZONE || 'false' }}
       TF_VAR_admin_cidr: ${{ vars.PROD_ADMIN_CIDR }}
       TF_VAR_airflow_api_base_url: ${{ vars.PROD_AIRFLOW_API_BASE_URL }}
       TF_VAR_airflow_api_allow_insecure_http: ${{ vars.PROD_AIRFLOW_API_ALLOW_INSECURE_HTTP || 'false' }}
-      TF_VAR_sns_email: ${{ vars.PROD_SNS_EMAIL }}
       TF_VAR_gpu_instance_type: ${{ vars.PROD_GPU_INSTANCE_TYPE || 'g6.2xlarge' }}
       TF_VAR_gpu_asg_max_size: ${{ vars.PROD_GPU_ASG_MAX_SIZE || '1' }}
       TF_VAR_gpu_asg_desired_capacity: ${{ vars.PROD_GPU_ASG_DESIRED_CAPACITY || '0' }}
@@ -33,6 +34,9 @@ jobs:
       TF_VAR_llm_model_name: ${{ vars.PROD_LLM_MODEL_NAME || 'Qwen/Qwen3-14B' }}
       TF_VAR_llm_model_path: ${{ vars.PROD_LLM_MODEL_PATH || '/models/model.gguf' }}
       TF_VAR_llm_service_desired_count: ${{ vars.PROD_LLM_SERVICE_DESIRED_COUNT || '0' }}
+      TF_VAR_backend_desired_count: ${{ vars.PROD_BACKEND_DESIRED_COUNT || '0' }}
+      TF_VAR_backend_autoscaling_min_capacity: ${{ vars.PROD_BACKEND_AUTOSCALING_MIN_CAPACITY || '0' }}
+      TF_VAR_backend_autoscaling_max_capacity: ${{ vars.PROD_BACKEND_AUTOSCALING_MAX_CAPACITY || '3' }}
       TF_VAR_db_master_password: ${{ secrets.PROD_DB_MASTER_PASSWORD }}
       TF_VAR_app_db_password: ${{ secrets.PROD_APP_DB_PASSWORD }}
       TF_VAR_airflow_db_password: ${{ secrets.PROD_AIRFLOW_DB_PASSWORD }}
@@ -71,7 +75,6 @@ jobs:
             TF_VAR_domain_name
             TF_VAR_admin_cidr
             TF_VAR_airflow_api_base_url
-            TF_VAR_sns_email
             TF_VAR_db_master_password
             TF_VAR_app_db_password
             TF_VAR_airflow_db_password
@@ -113,10 +116,11 @@ jobs:
     environment: prod
     env:
       TF_VAR_domain_name: ${{ vars.PROD_DOMAIN_NAME }}
+      TF_VAR_route53_zone_id: ${{ vars.PROD_ROUTE53_ZONE_ID || '' }}
+      TF_VAR_manage_route53_zone: ${{ vars.PROD_MANAGE_ROUTE53_ZONE || 'false' }}
       TF_VAR_admin_cidr: ${{ vars.PROD_ADMIN_CIDR }}
       TF_VAR_airflow_api_base_url: ${{ vars.PROD_AIRFLOW_API_BASE_URL }}
       TF_VAR_airflow_api_allow_insecure_http: ${{ vars.PROD_AIRFLOW_API_ALLOW_INSECURE_HTTP || 'false' }}
-      TF_VAR_sns_email: ${{ vars.PROD_SNS_EMAIL }}
       TF_VAR_gpu_instance_type: ${{ vars.PROD_GPU_INSTANCE_TYPE || 'g6.2xlarge' }}
       TF_VAR_gpu_asg_max_size: ${{ vars.PROD_GPU_ASG_MAX_SIZE || '1' }}
       TF_VAR_gpu_asg_desired_capacity: ${{ vars.PROD_GPU_ASG_DESIRED_CAPACITY || '0' }}
@@ -125,6 +129,9 @@ jobs:
       TF_VAR_llm_model_name: ${{ vars.PROD_LLM_MODEL_NAME || 'Qwen/Qwen3-14B' }}
       TF_VAR_llm_model_path: ${{ vars.PROD_LLM_MODEL_PATH || '/models/model.gguf' }}
       TF_VAR_llm_service_desired_count: ${{ vars.PROD_LLM_SERVICE_DESIRED_COUNT || '0' }}
+      TF_VAR_backend_desired_count: ${{ vars.PROD_BACKEND_DESIRED_COUNT || '0' }}
+      TF_VAR_backend_autoscaling_min_capacity: ${{ vars.PROD_BACKEND_AUTOSCALING_MIN_CAPACITY || '0' }}
+      TF_VAR_backend_autoscaling_max_capacity: ${{ vars.PROD_BACKEND_AUTOSCALING_MAX_CAPACITY || '3' }}
       TF_VAR_db_master_password: ${{ secrets.PROD_DB_MASTER_PASSWORD }}
       TF_VAR_app_db_password: ${{ secrets.PROD_APP_DB_PASSWORD }}
       TF_VAR_airflow_db_password: ${{ secrets.PROD_AIRFLOW_DB_PASSWORD }}
@@ -160,7 +167,6 @@ jobs:
             TF_VAR_domain_name
             TF_VAR_admin_cidr
             TF_VAR_airflow_api_base_url
-            TF_VAR_sns_email
             TF_VAR_db_master_password
             TF_VAR_app_db_password
             TF_VAR_airflow_db_password

--- a/infra/terraform/.terraform.lock.hcl
+++ b/infra/terraform/.terraform.lock.hcl
@@ -23,3 +23,24 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.9.0"
+  constraints = ">= 3.6.0, < 4.0.0"
+  hashes = [
+    "h1:OO+IuvQJSPmWdN8AyyIEvPJbLvDQpgX/zbktoa9KsJE=",
+    "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
+    "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
+    "zh:269eda8fe42daa7974d5a34d166c3ba9defe80cde86c01e4dadcfdf2e1f05e5f",
+    "zh:373f7c65566f8f2cc7f45d698654feb9d988996957e1266a69ca00c52d6d16d0",
+    "zh:5599d16804c41c83009ec621b6d6b6f74e102f5827678a4750f8809055546b61",
+    "zh:583be0440469a22bff70dcfa56593b01566860b29607437264adb51060cf46fc",
+    "zh:5f211d8ec3f2e1f414870d9584bfe26e6995560ef81c748f8447a48164767398",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b547fd16216761ef86efc3ed516ac5ac0c5c42b7c7eb24a08cef2d93f69ed5e",
+    "zh:7e7c0679daf2a382151d05068c8c3f0dae6b7b7dccf818827b73dd08638df2ef",
+    "zh:8089dec888a8038b9b4fb23b3df7e1057293dbc5b60b42cc47ff690d69d4b61b",
+    "zh:c51f15a031edfd6f23ce8ced3446ca7f8d8d647e2499890d7d5d10d5016d7257",
+    "zh:c94784f005708890dc6895afd53636ec00ec1e430b15d41e5aebfb1d4b39bd04",
+  ]
+}

--- a/infra/terraform/alb.tf
+++ b/infra/terraform/alb.tf
@@ -67,7 +67,7 @@ resource "aws_lb_listener" "backend_http" {
 
 # Route53 A record for api.${domain_name} -> ALB
 resource "aws_route53_record" "api" {
-  zone_id = aws_route53_zone.main.zone_id
+  zone_id = local.route53_zone_id
   name    = "api.${var.domain_name}"
   type    = "A"
 

--- a/infra/terraform/cloudwatch.tf
+++ b/infra/terraform/cloudwatch.tf
@@ -1,24 +1,4 @@
 # =============================================================================
-# SNS Topic for Alarm Notifications
-# =============================================================================
-
-resource "aws_sns_topic" "alerts" {
-  name              = "${local.name_prefix}-alerts"
-  kms_master_key_id = aws_kms_key.observability.arn
-
-  tags = local.common_tags
-}
-
-resource "aws_sns_topic_subscription" "alerts_email" {
-  topic_arn = aws_sns_topic.alerts.arn
-  protocol  = "email"
-  endpoint  = var.sns_email
-
-  # After terraform apply, confirm the subscription via the email received
-  # from AWS SNS. The subscription remains PendingConfirmation until confirmed.
-}
-
-# =============================================================================
 # CloudWatch Metric Alarms
 # =============================================================================
 
@@ -40,9 +20,6 @@ resource "aws_cloudwatch_metric_alarm" "alb_5xx" {
     LoadBalancer = aws_lb.backend.arn_suffix
     TargetGroup  = aws_lb_target_group.backend.arn_suffix
   }
-
-  alarm_actions = [aws_sns_topic.alerts.arn]
-  ok_actions    = [aws_sns_topic.alerts.arn]
 
   tags = local.common_tags
 }
@@ -66,9 +43,6 @@ resource "aws_cloudwatch_metric_alarm" "ecs_backend_cpu" {
     ServiceName = aws_ecs_service.backend.name
   }
 
-  alarm_actions = [aws_sns_topic.alerts.arn]
-  ok_actions    = [aws_sns_topic.alerts.arn]
-
   tags = local.common_tags
 }
 
@@ -89,9 +63,6 @@ resource "aws_cloudwatch_metric_alarm" "rds_cpu" {
   dimensions = {
     DBInstanceIdentifier = aws_db_instance.postgres.identifier
   }
-
-  alarm_actions = [aws_sns_topic.alerts.arn]
-  ok_actions    = [aws_sns_topic.alerts.arn]
 
   tags = local.common_tags
 }
@@ -114,9 +85,6 @@ resource "aws_cloudwatch_metric_alarm" "rds_storage" {
     DBInstanceIdentifier = aws_db_instance.postgres.identifier
   }
 
-  alarm_actions = [aws_sns_topic.alerts.arn]
-  ok_actions    = [aws_sns_topic.alerts.arn]
-
   tags = local.common_tags
 }
 
@@ -138,9 +106,6 @@ resource "aws_cloudwatch_metric_alarm" "gpu_cpu" {
   dimensions = {
     AutoScalingGroupName = aws_autoscaling_group.gpu.name
   }
-
-  alarm_actions = [aws_sns_topic.alerts.arn]
-  ok_actions    = [aws_sns_topic.alerts.arn]
 
   tags = local.common_tags
 }

--- a/infra/terraform/ecs-cluster.tf
+++ b/infra/terraform/ecs-cluster.tf
@@ -203,7 +203,7 @@ resource "aws_ecs_service" "backend" {
   name             = "ostone-backend"
   cluster          = aws_ecs_cluster.main.id
   task_definition  = aws_ecs_task_definition.backend.arn
-  desired_count    = 1
+  desired_count    = var.backend_desired_count
   launch_type      = "FARGATE"
   platform_version = "LATEST"
 
@@ -228,14 +228,21 @@ resource "aws_ecs_service" "backend" {
     aws_lb_listener.backend_https,
     terraform_data.db_bootstrap
   ]
+
+  lifecycle {
+    ignore_changes = [
+      desired_count,
+      task_definition
+    ]
+  }
 }
 
 resource "aws_appautoscaling_target" "backend" {
   service_namespace  = "ecs"
   resource_id        = "service/${local.name_prefix}-cluster/ostone-backend"
   scalable_dimension = "ecs:service:DesiredCount"
-  min_capacity       = 1
-  max_capacity       = 3
+  min_capacity       = var.backend_autoscaling_min_capacity
+  max_capacity       = var.backend_autoscaling_max_capacity
 }
 
 resource "aws_appautoscaling_policy" "backend_cpu" {

--- a/infra/terraform/kms.tf
+++ b/infra/terraform/kms.tf
@@ -25,23 +25,10 @@ data "aws_iam_policy_document" "observability_kms" {
     resources = ["*"]
   }
 
-  statement {
-    sid = "AllowSns"
-    principals {
-      type        = "Service"
-      identifiers = ["sns.amazonaws.com"]
-    }
-    actions = [
-      "kms:Decrypt",
-      "kms:GenerateDataKey",
-      "kms:DescribeKey"
-    ]
-    resources = ["*"]
-  }
 }
 
 resource "aws_kms_key" "observability" {
-  description             = "KMS key for ${local.name_prefix} CloudWatch Logs and SNS alerts."
+  description             = "KMS key for ${local.name_prefix} CloudWatch Logs."
   deletion_window_in_days = 30
   enable_key_rotation     = true
   policy                  = data.aws_iam_policy_document.observability_kms.json

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -6,6 +6,10 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 5.80, < 6.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.6, < 4.0"
+    }
   }
 
   backend "s3" {}

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -90,7 +90,12 @@ output "s3_bucket_names" {
 
 output "route53_zone_id" {
   description = "Route53 hosted zone ID."
-  value       = aws_route53_zone.main.zone_id
+  value       = local.route53_zone_id
+}
+
+output "route53_name_servers" {
+  description = "Name servers for the Terraform-created hosted zone. Empty when using an existing hosted zone."
+  value       = local.route53_name_servers
 }
 
 output "acm_certificate_arn" {

--- a/infra/terraform/rds.tf
+++ b/infra/terraform/rds.tf
@@ -36,6 +36,40 @@ resource "aws_db_option_group" "postgres" {
   }
 }
 
+data "aws_iam_policy_document" "rds_enhanced_monitoring_assume_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["monitoring.rds.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "rds_enhanced_monitoring" {
+  name                 = "${local.name_prefix}-rds-enhanced-monitoring-role"
+  assume_role_policy   = data.aws_iam_policy_document.rds_enhanced_monitoring_assume_role.json
+  permissions_boundary = var.permissions_boundary_arn
+
+  tags = {
+    Name = "${local.name_prefix}-rds-enhanced-monitoring-role"
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "rds_enhanced_monitoring" {
+  role       = aws_iam_role.rds_enhanced_monitoring.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
+}
+
+resource "random_id" "rds_final_snapshot" {
+  byte_length = 4
+
+  keepers = {
+    db_instance_identifier = "${local.name_prefix}-postgres"
+  }
+}
+
 resource "aws_db_instance" "postgres" {
   identifier = "${local.name_prefix}-postgres"
 
@@ -58,14 +92,19 @@ resource "aws_db_instance" "postgres" {
   parameter_group_name   = aws_db_parameter_group.postgres.name
   option_group_name      = aws_db_option_group.postgres.name
 
-  multi_az                  = var.rds_multi_az
-  publicly_accessible       = false
-  backup_retention_period   = var.rds_backup_retention_period
-  backup_window             = "18:00-19:00"
-  maintenance_window        = "sun:19:00-sun:20:00"
-  deletion_protection       = true
-  skip_final_snapshot       = false
-  final_snapshot_identifier = "${local.name_prefix}-postgres-final"
+  multi_az                              = var.rds_multi_az
+  publicly_accessible                   = false
+  backup_retention_period               = var.rds_backup_retention_period
+  backup_window                         = "18:00-19:00"
+  maintenance_window                    = "sun:19:00-sun:20:00"
+  deletion_protection                   = true
+  skip_final_snapshot                   = false
+  final_snapshot_identifier             = "${local.name_prefix}-postgres-final-${random_id.rds_final_snapshot.hex}"
+  enabled_cloudwatch_logs_exports       = ["postgresql", "upgrade"]
+  performance_insights_enabled          = true
+  performance_insights_retention_period = var.rds_performance_insights_retention_period
+  monitoring_interval                   = var.rds_monitoring_interval
+  monitoring_role_arn                   = var.rds_monitoring_interval > 0 ? aws_iam_role.rds_enhanced_monitoring.arn : null
 
   copy_tags_to_snapshot = true
   apply_immediately     = false

--- a/infra/terraform/route53-acm.tf
+++ b/infra/terraform/route53-acm.tf
@@ -1,9 +1,26 @@
+data "aws_route53_zone" "main" {
+  count = trimspace(var.route53_zone_id) == "" && !var.manage_route53_zone ? 1 : 0
+
+  name         = var.domain_name
+  private_zone = false
+}
+
 resource "aws_route53_zone" "main" {
+  count = var.manage_route53_zone ? 1 : 0
+
   name = var.domain_name
 
   tags = {
     Name = var.domain_name
   }
+}
+
+locals {
+  route53_zone_id = trimspace(var.route53_zone_id) != "" ? trimspace(var.route53_zone_id) : (
+    var.manage_route53_zone ? aws_route53_zone.main[0].zone_id : data.aws_route53_zone.main[0].zone_id
+  )
+
+  route53_name_servers = var.manage_route53_zone ? aws_route53_zone.main[0].name_servers : []
 }
 
 resource "aws_acm_certificate" "regional" {
@@ -54,7 +71,7 @@ locals {
 resource "aws_route53_record" "acm_validation" {
   for_each = local.acm_validation_records
 
-  zone_id = aws_route53_zone.main.zone_id
+  zone_id = local.route53_zone_id
   name    = each.value.name
   type    = each.value.type
   ttl     = 60

--- a/infra/terraform/s3-frontend.tf
+++ b/infra/terraform/s3-frontend.tf
@@ -143,7 +143,7 @@ resource "aws_cloudfront_distribution" "frontend" {
 
 # Route53 A record → CloudFront
 resource "aws_route53_record" "app" {
-  zone_id = aws_route53_zone.main.zone_id
+  zone_id = local.route53_zone_id
   name    = "app.${var.domain_name}"
   type    = "A"
 

--- a/infra/terraform/scripts/init.sql
+++ b/infra/terraform/scripts/init.sql
@@ -34,7 +34,8 @@ ALTER SCHEMA airflow OWNER TO airflow_user;
 ALTER ROLE app_user SET search_path TO app, corpus, pack, review, pipeline, runtime, public;
 ALTER ROLE airflow_user SET search_path TO airflow, public;
 
-GRANT CONNECT, CREATE ON DATABASE :"db_name" TO app_user;
+REVOKE CREATE ON DATABASE :"db_name" FROM app_user;
+GRANT CONNECT ON DATABASE :"db_name" TO app_user;
 GRANT CONNECT ON DATABASE :"db_name" TO airflow_user;
 
 GRANT USAGE, CREATE ON SCHEMA app, corpus, pack, review, pipeline, runtime TO app_user;

--- a/infra/terraform/terraform.tfvars.example
+++ b/infra/terraform/terraform.tfvars.example
@@ -1,5 +1,7 @@
 aws_region  = "ap-northeast-2"
 domain_name = "example.com"
+route53_zone_id = ""
+manage_route53_zone = false
 admin_cidr  = "203.0.113.10/32"
 
 db_name             = "ostone"
@@ -13,7 +15,10 @@ airflow_api_password = "replace-with-secure-airflow-api-password"
 airflow_api_base_url = "http://<airflow-private-ip>:8080"
 airflow_api_allow_insecure_http = true
 airflow_webhook_secret = "replace-with-secure-webhook-secret"
-sns_email           = "alerts@example.com"
+
+backend_desired_count = 0
+backend_autoscaling_min_capacity = 0
+backend_autoscaling_max_capacity = 3
 
 gpu_instance_type          = "g6.2xlarge"
 gpu_asg_min_size           = 0

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -21,6 +21,18 @@ variable "domain_name" {
   type        = string
 }
 
+variable "route53_zone_id" {
+  description = "Existing public Route53 hosted zone ID for domain_name. When blank, Terraform looks up an existing zone unless manage_route53_zone is true."
+  type        = string
+  default     = ""
+}
+
+variable "manage_route53_zone" {
+  description = "Whether Terraform should create the public Route53 hosted zone. Keep false when the domain already has a delegated hosted zone."
+  type        = bool
+  default     = false
+}
+
 variable "vpc_cidr" {
   description = "CIDR block for the production VPC."
   type        = string
@@ -124,10 +136,45 @@ variable "rds_backup_retention_period" {
   default     = 7
 }
 
+variable "rds_performance_insights_retention_period" {
+  description = "Performance Insights retention period in days."
+  type        = number
+  default     = 7
+}
+
+variable "rds_monitoring_interval" {
+  description = "Enhanced Monitoring interval in seconds. Set 0 to disable."
+  type        = number
+  default     = 60
+
+  validation {
+    condition     = contains([0, 1, 5, 10, 15, 30, 60], var.rds_monitoring_interval)
+    error_message = "rds_monitoring_interval must be one of 0, 1, 5, 10, 15, 30, or 60."
+  }
+}
+
 variable "rds_multi_az" {
   description = "Whether to enable Multi-AZ failover for the production RDS instance."
   type        = bool
   default     = true
+}
+
+variable "backend_desired_count" {
+  description = "Initial desired count for the backend ECS service. Keep 0 for first infrastructure apply before an application image exists."
+  type        = number
+  default     = 0
+}
+
+variable "backend_autoscaling_min_capacity" {
+  description = "Minimum backend ECS service capacity managed by application autoscaling."
+  type        = number
+  default     = 0
+}
+
+variable "backend_autoscaling_max_capacity" {
+  description = "Maximum backend ECS service capacity managed by application autoscaling."
+  type        = number
+  default     = 3
 }
 
 variable "s3_bucket_names" {
@@ -203,11 +250,6 @@ variable "airflow_webhook_secret" {
   description = "Shared secret for Airflow callback webhooks."
   type        = string
   sensitive   = true
-}
-
-variable "sns_email" {
-  description = "Email address for SNS alarm notifications. Confirm subscription via AWS console after terraform apply."
-  type        = string
 }
 
 variable "gpu_instance_type" {


### PR DESCRIPTION
## Summary
- Terraform이 기존 Route53 hosted zone을 기본 재사용하도록 하고, 필요 시 zone 생성/명시 zone ID를 선택할 수 있게 했습니다.
- backend ECS service를 초기 desired count 0으로 생성하고, production deploy가 이미지 push 후 desired count 1로 기동하도록 했습니다.
- RDS에 PostgreSQL 로그 export, Performance Insights, Enhanced Monitoring, 고유 final snapshot 이름을 적용하고 앱 DB 계정의 database-level CREATE 권한을 제거했습니다.
- 사용하지 않는 SNS 알림 topic/subscription 의존성과 GitHub Actions 변수 주입을 제거했습니다.

## Validation
- `terraform init -backend=false`
- `terraform fmt -check`
- `terraform validate`
- `git diff --check`
- `git diff --cached --check`

## Notes
- `PROD_MANAGE_ROUTE53_ZONE=false` 기준으로 기존 public hosted zone을 조회합니다. hosted zone이 여러 개이거나 다른 계정에 있으면 `PROD_ROUTE53_ZONE_ID`를 지정해야 합니다.
- Terraform 초기 apply 후 production deploy workflow가 backend service desired count를 1로 올립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Infrastructure**
  * RDS 데이터베이스 향상된 모니터링 기능 활성화
  * ECS 백엔드 서비스 탄력적 스케일링 설정 개선
  * Route53 호스팅 존 관리 유연성 증대

* **Chores**
  * 배포 워크플로우 및 인프라 관리 프로세스 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->