### PR TITLE
feat(domain-pack): 버전 description 필드 추가 및 버전 상세 화면 UI 개선

### DIFF
--- a/backend/src/main/java/com/init/domainpack/application/DomainPackVersionCloneService.java
+++ b/backend/src/main/java/com/init/domainpack/application/DomainPackVersionCloneService.java
@@ -81,7 +81,8 @@ public class DomainPackVersionCloneService {
             nextVersionNo,
             command.createdBy(),
             null,
-            buildSummaryJson(command.baseVersion(), command.sourceType(), command.reason()));
+            buildSummaryJson(command.baseVersion(), command.sourceType(), command.reason()),
+            command.reason());
 
     DomainPackVersion savedDraft;
     try {
@@ -110,7 +111,8 @@ public class DomainPackVersionCloneService {
             nextVersionNo,
             command.createdBy(),
             command.sourcePipelineJobId(),
-            command.summaryJson());
+            command.summaryJson(),
+            null);
     try {
       return versionRepository.saveAndFlush(draft);
     } catch (DataIntegrityViolationException | ObjectOptimisticLockingFailureException ex) {

--- a/backend/src/main/java/com/init/domainpack/application/DomainPackVersionDetailResult.java
+++ b/backend/src/main/java/com/init/domainpack/application/DomainPackVersionDetailResult.java
@@ -9,6 +9,7 @@ public record DomainPackVersionDetailResult(
     String lifecycleStatus,
     Long sourcePipelineJobId,
     String summaryJson,
+    String description,
     long intentCount,
     long slotCount,
     long policyCount,

--- a/backend/src/main/java/com/init/domainpack/application/DomainPackVersionSummaryEntry.java
+++ b/backend/src/main/java/com/init/domainpack/application/DomainPackVersionSummaryEntry.java
@@ -7,6 +7,7 @@ public record DomainPackVersionSummaryEntry(
     Long versionId,
     Integer versionNo,
     String lifecycleStatus,
+    String description,
     Long sourcePipelineJobId,
     OffsetDateTime createdAt,
     OffsetDateTime updatedAt) {
@@ -16,6 +17,7 @@ public record DomainPackVersionSummaryEntry(
         v.getId(),
         v.getVersionNo(),
         v.getLifecycleStatus(),
+        v.getDescription(),
         v.getSourcePipelineJobId(),
         v.getCreatedAt(),
         v.getUpdatedAt());

--- a/backend/src/main/java/com/init/domainpack/application/GetDomainPackVersionDetailUseCase.java
+++ b/backend/src/main/java/com/init/domainpack/application/GetDomainPackVersionDetailUseCase.java
@@ -63,6 +63,7 @@ public class GetDomainPackVersionDetailUseCase {
         version.getLifecycleStatus(),
         version.getSourcePipelineJobId(),
         version.getSummaryJson(),
+        version.getDescription(),
         intentCount,
         slotDefinitionRepository.countByDomainPackVersionId(version.getId()),
         policyDefinitionRepository.countByDomainPackVersionId(version.getId()),

--- a/backend/src/main/java/com/init/domainpack/domain/model/DomainPackVersion.java
+++ b/backend/src/main/java/com/init/domainpack/domain/model/DomainPackVersion.java
@@ -41,6 +41,9 @@ public class DomainPackVersion {
   @Column(name = "summary_json", columnDefinition = "jsonb", nullable = false)
   private String summaryJson;
 
+  @Column(name = "description")
+  private String description;
+
   @Column(name = "published_at")
   private OffsetDateTime publishedAt;
 
@@ -92,6 +95,7 @@ public class DomainPackVersion {
    * @param createdBy 생성자 ID
    * @param sourcePipelineJobId 파이프라인 Job ID (nullable)
    * @param summaryJson 요약 JSON
+   * @param description 버전 설명 (commit-log 성격, nullable)
    * @return 새로운 DRAFT 상태의 DomainPackVersion
    */
   public static DomainPackVersion createDraft(
@@ -99,7 +103,8 @@ public class DomainPackVersion {
       Integer versionNo,
       Long createdBy,
       Long sourcePipelineJobId,
-      String summaryJson) {
+      String summaryJson,
+      String description) {
     Objects.requireNonNull(domainPackId, "domainPackId must not be null");
     Objects.requireNonNull(versionNo, "versionNo must not be null");
 
@@ -110,6 +115,7 @@ public class DomainPackVersion {
     v.createdBy = createdBy;
     v.sourcePipelineJobId = sourcePipelineJobId;
     v.summaryJson = summaryJson != null ? summaryJson : "{}";
+    v.description = description;
     return v;
   }
 
@@ -156,6 +162,10 @@ public class DomainPackVersion {
 
   public String getSummaryJson() {
     return summaryJson;
+  }
+
+  public String getDescription() {
+    return description;
   }
 
   public OffsetDateTime getPublishedAt() {

--- a/backend/src/main/resources/db/changelog/db.changelog-master.sql
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.sql
@@ -934,3 +934,8 @@ WHERE assigned_counselor_id IS NOT NULL;
 ALTER TABLE runtime.chat_session
     ADD CONSTRAINT chk_chat_session_response_mode
     CHECK (response_mode IN ('AI_ACTIVE', 'HUMAN_ACTIVE', 'AI_ASSIST_ONLY'));
+
+--changeset init:20260601-add-description-to-domain-pack-version
+--comment: Add commit-log style description to pack.domain_pack_version
+ALTER TABLE pack.domain_pack_version
+    ADD COLUMN description text;

--- a/backend/src/test/java/com/init/domainpack/application/DomainPackVersionCloneServiceTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/DomainPackVersionCloneServiceTest.java
@@ -133,6 +133,12 @@ class DomainPackVersionCloneServiceTest {
     assertThat(result.sourceType()).isEqualTo(DomainPackDraftSourceType.INTENT_REVISION);
     assertThat(result.baseVersionId()).isEqualTo(100L);
 
+    // clone reason은 새 draft version의 description(commit-log 성격)으로 영속화된다.
+    ArgumentCaptor<DomainPackVersion> savedVersion =
+        ArgumentCaptor.forClass(DomainPackVersion.class);
+    verify(versionRepository).saveAndFlush(savedVersion.capture());
+    assertThat(savedVersion.getValue().getDescription()).isEqualTo("보정");
+
     ArgumentCaptor<Iterable<IntentSlotBinding>> slotBindings =
         ArgumentCaptor.forClass(Iterable.class);
     verify(intentSlotBindingRepository).saveAllAndFlush(slotBindings.capture());
@@ -209,6 +215,31 @@ class DomainPackVersionCloneServiceTest {
                 service.createEmptyDraft(
                     new DomainPackVersionCreateCommand(1L, 7L, 10L, null, "{}")))
         .isInstanceOf(DomainPackDraftAlreadyExistsException.class);
+  }
+
+  @Test
+  @DisplayName("createEmptyDraft: 사유 없는 빈 DRAFT는 description이 null이다")
+  void createEmptyDraft_createsDraftWithoutDescription() {
+    given(domainPackRepository.findByIdAndWorkspaceIdForUpdate(7L, 1L))
+        .willReturn(Optional.of(DomainPack.create(1L, "cs", "CS", null, 10L)));
+    given(
+            versionRepository.existsByDomainPackIdAndLifecycleStatus(
+                7L, DomainPackVersion.STATUS_DRAFT))
+        .willReturn(false);
+    given(versionRepository.findMaxVersionNoByDomainPackId(7L)).willReturn(Optional.of(2));
+    given(versionRepository.saveAndFlush(any(DomainPackVersion.class)))
+        .willAnswer(
+            invocation -> {
+              DomainPackVersion draft = invocation.getArgument(0);
+              ReflectionTestUtils.setField(draft, "id", 200L);
+              return draft;
+            });
+
+    DomainPackVersion result =
+        service.createEmptyDraft(new DomainPackVersionCreateCommand(1L, 7L, 10L, null, "{}"));
+
+    assertThat(result.getDescription()).isNull();
+    assertThat(result.getVersionNo()).isEqualTo(3);
   }
 
   @Test

--- a/backend/src/test/java/com/init/domainpack/application/GetDomainPackDetailUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/GetDomainPackDetailUseCaseTest.java
@@ -65,6 +65,7 @@ class GetDomainPackDetailUseCaseTest {
     StubDomainPack pack = new StubDomainPack(PACK_ID, WORKSPACE_ID, "my-key", "My Pack", null);
     DomainPackVersion version =
         DomainPackVersion.ofForTest(2L, PACK_ID, DomainPackVersion.STATUS_DRAFT);
+    ReflectionTestUtils.setField(version, "description", "사이드바 설명");
     given(domainPackRepository.findByIdAndWorkspaceId(PACK_ID, WORKSPACE_ID))
         .willReturn(Optional.of(pack));
     given(domainPackVersionRepository.findAllByDomainPackIdOrderByVersionNoDesc(PACK_ID))
@@ -87,6 +88,7 @@ class GetDomainPackDetailUseCaseTest {
     assertThat(result.currentVersionPublishedAt())
         .isEqualTo(OffsetDateTime.parse("2025-04-03T10:00:00+09:00"));
     assertThat(result.versions()).hasSize(1);
+    assertThat(result.versions().get(0).description()).isEqualTo("사이드바 설명");
   }
 
   @Test

--- a/backend/src/test/java/com/init/domainpack/application/GetDomainPackVersionDetailUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/GetDomainPackVersionDetailUseCaseTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("GetDomainPackVersionDetailUseCase")
@@ -106,6 +107,7 @@ class GetDomainPackVersionDetailUseCaseTest {
 
     DomainPackVersion version =
         DomainPackVersion.ofForTest(VERSION_ID, PACK_ID, DomainPackVersion.STATUS_DRAFT);
+    ReflectionTestUtils.setField(version, "description", "복원: v3 기준");
     given(domainPackVersionRepository.findById(VERSION_ID)).willReturn(Optional.of(version));
     given(domainPackVersionRepository.findByIdAndWorkspaceId(WORKSPACE_ID, VERSION_ID))
         .willReturn(Optional.of(version));
@@ -125,6 +127,7 @@ class GetDomainPackVersionDetailUseCaseTest {
 
     assertThat(result.versionId()).isEqualTo(VERSION_ID);
     assertThat(result.packId()).isEqualTo(PACK_ID);
+    assertThat(result.description()).isEqualTo("복원: v3 기준");
     assertThat(result.intentCount()).isEqualTo(4L);
     assertThat(result.slotCount()).isEqualTo(3L);
     assertThat(result.policyCount()).isEqualTo(2L);

--- a/backend/src/test/java/com/init/domainpack/infrastructure/JpaDomainPackVersionRepositoryTest.java
+++ b/backend/src/test/java/com/init/domainpack/infrastructure/JpaDomainPackVersionRepositoryTest.java
@@ -46,7 +46,7 @@ class JpaDomainPackVersionRepositoryTest {
 
     DomainPackVersion version =
         ((DomainPackVersionRepository) repository)
-            .saveAndFlush(DomainPackVersion.createDraft(pack.getId(), 1, null, null, "{}"));
+            .saveAndFlush(DomainPackVersion.createDraft(pack.getId(), 1, null, null, "{}", null));
 
     // when
     Optional<DomainPackVersion> result = repository.findByIdAndWorkspaceId(1L, version.getId());
@@ -66,7 +66,7 @@ class JpaDomainPackVersionRepositoryTest {
 
     DomainPackVersion version =
         ((DomainPackVersionRepository) repository)
-            .saveAndFlush(DomainPackVersion.createDraft(pack.getId(), 1, null, null, "{}"));
+            .saveAndFlush(DomainPackVersion.createDraft(pack.getId(), 1, null, null, "{}", null));
 
     // when — workspaceId=99L은 해당 pack의 workspaceId(1L)가 아님
     Optional<DomainPackVersion> result = repository.findByIdAndWorkspaceId(99L, version.getId());
@@ -116,7 +116,7 @@ class JpaDomainPackVersionRepositoryTest {
   private static DomainPackVersion publishedVersion(
       Long domainPackId, Integer versionNo, String publishedAt) {
     DomainPackVersion version =
-        DomainPackVersion.createDraft(domainPackId, versionNo, null, null, "{}");
+        DomainPackVersion.createDraft(domainPackId, versionNo, null, null, "{}", null);
     version.activate(OffsetDateTime.parse(publishedAt));
     return version;
   }

--- a/backend/src/test/java/com/init/domainpack/presentation/DomainPackControllerTest.java
+++ b/backend/src/test/java/com/init/domainpack/presentation/DomainPackControllerTest.java
@@ -152,7 +152,7 @@ class DomainPackControllerTest {
   void should_200_when_getDomainPackVersion() throws Exception {
     DomainPackVersionDetailResult fixture =
         new DomainPackVersionDetailResult(
-            1L, 10L, 1, "DRAFT", null, "{}", 5L, 3L, 2L, 1L, 4L, NOW, NOW);
+            1L, 10L, 1, "DRAFT", null, "{}", "v1 초안 생성", 5L, 3L, 2L, 1L, 4L, NOW, NOW);
     given(
             versionDetailUseCase.execute(
                 argThat(
@@ -168,6 +168,7 @@ class DomainPackControllerTest {
         .andExpect(jsonPath("$.versionId").value(1))
         .andExpect(jsonPath("$.packId").value(10))
         .andExpect(jsonPath("$.summaryJson").isString())
+        .andExpect(jsonPath("$.description").value("v1 초안 생성"))
         .andExpect(jsonPath("$.intentCount").value(5))
         .andExpect(jsonPath("$.slotCount").value(3))
         .andExpect(jsonPath("$.policyCount").value(2))

--- a/frontend/src/features/domain-pack-summary-read/ui/ComponentCountGrid.module.css
+++ b/frontend/src/features/domain-pack-summary-read/ui/ComponentCountGrid.module.css
@@ -14,10 +14,6 @@
   transition: box-shadow var(--transition-fast);
 }
 
-.countCard:not(.disabled) {
-  cursor: pointer;
-}
-
 .countCard:not(.disabled):hover {
   box-shadow: var(--shadow-card);
 }
@@ -27,12 +23,47 @@
   cursor: default;
 }
 
+.cardHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
 .cardLabel {
   font-size: var(--font-size-label);
   font-weight: var(--font-weight-heading);
   color: var(--text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.04em;
+}
+
+.cardArrowButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  padding: 2px;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  transition: color var(--transition-fast);
+}
+
+.cardArrowButton:hover {
+  color: var(--text-primary);
+}
+
+.cardArrowButton:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.cardArrowButton svg {
+  width: 18px;
+  height: 18px;
 }
 
 .countNumber {

--- a/frontend/src/features/domain-pack-summary-read/ui/ComponentCountGrid.test.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/ComponentCountGrid.test.tsx
@@ -54,21 +54,29 @@ describe("ComponentCountGrid", () => {
     expect(screen.getByText("4")).toBeInTheDocument();
   });
 
-  it("Intent, Policy 카드 클릭 시 상세 목록으로 이동한다", () => {
+  it("각 구성요소 카드 헤더에 상세 보기 화살표 버튼을 렌더링한다", () => {
     render(<ComponentCountGrid {...defaultProps} />);
-    fireEvent.click(screen.getByRole("button", { name: /상담 유형/ }));
+    expect(screen.getByRole("button", { name: "상담 유형 상세 보기" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "확인 항목 상세 보기" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "응대 기준 상세 보기" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "응대 흐름 상세 보기" })).toBeInTheDocument();
+  });
+
+  it("Intent, Policy 화살표 클릭 시 상세 목록으로 이동한다", () => {
+    render(<ComponentCountGrid {...defaultProps} />);
+    fireEvent.click(screen.getByRole("button", { name: "상담 유형 상세 보기" }));
     expect(mockNavigate).toHaveBeenCalledWith("/workspaces/1/domain-packs/2/intents?versionId=3");
 
-    fireEvent.click(screen.getByRole("button", { name: /응대 기준/ }));
+    fireEvent.click(screen.getByRole("button", { name: "응대 기준 상세 보기" }));
     expect(mockNavigate).toHaveBeenCalledWith("/workspaces/1/domain-packs/2/policies?versionId=3");
   });
 
-  it("Slot 카드 클릭 시 Slot 목록으로 이동한다", () => {
+  it("Slot 화살표 클릭 시 Slot 목록으로 이동한다", () => {
     vi.mocked(previewLists.useSlotPreview).mockReturnValue(
       makeHook({ data: [{ id: 9, name: "slot-1" }] }),
     );
     render(<ComponentCountGrid {...defaultProps} />);
-    fireEvent.click(screen.getByRole("button", { name: /확인 항목/ }));
+    fireEvent.click(screen.getByRole("button", { name: "확인 항목 상세 보기" }));
     expect(mockNavigate).toHaveBeenCalledWith("/workspaces/1/domain-packs/2/slots?versionId=3");
   });
 

--- a/frontend/src/features/domain-pack-summary-read/ui/ComponentCountGrid.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/ComponentCountGrid.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
+import { ChevronRightIcon } from "lucide-react";
 import { toast } from "sonner";
 import { domainPackSectionPath } from "@/shared/lib/domainPackRoutes";
 import {
@@ -129,29 +130,24 @@ function CountCard({
   isLoadingPreview,
   onPreviewItemClick,
 }: CountCardProps) {
-  const handleClick = () => {
-    if (!disabled && onNavigate) onNavigate();
-  };
-
   return (
     <div
       className={`${styles.countCard} ${disabled ? styles.disabled : ""}`}
       title={disabled ? tooltip : undefined}
-      onClick={handleClick}
-      role={!disabled ? "button" : undefined}
-      tabIndex={!disabled ? 0 : undefined}
-      onKeyDown={
-        !disabled
-          ? (e) => {
-              if (e.key === "Enter" || e.key === " ") {
-                e.preventDefault();
-                handleClick();
-              }
-            }
-          : undefined
-      }
     >
-      <span className={styles.cardLabel}>{label}</span>
+      <div className={styles.cardHeader}>
+        <span className={styles.cardLabel}>{label}</span>
+        {!disabled && onNavigate && (
+          <button
+            type="button"
+            className={styles.cardArrowButton}
+            aria-label={`${label} 상세 보기`}
+            onClick={onNavigate}
+          >
+            <ChevronRightIcon aria-hidden />
+          </button>
+        )}
+      </div>
       <span className={styles.countNumber}>{count}</span>
       {isLoadingPreview ? (
         <div>

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.module.css
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.module.css
@@ -125,13 +125,17 @@
 
 .versionDescription {
   margin: 0;
-  max-width: 240px;
+  max-width: 280px;
   font-size: 12px;
   line-height: 1.45;
   text-align: right;
-  color: var(--text-muted);
-  white-space: pre-wrap;
+  color: var(--text-secondary);
   word-break: break-word;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
 .deployActions {

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.module.css
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.module.css
@@ -115,6 +115,25 @@
   border-color: var(--text-primary);
 }
 
+.metaSide {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  justify-content: center;
+  gap: 8px;
+}
+
+.versionDescription {
+  margin: 0;
+  max-width: 240px;
+  font-size: 12px;
+  line-height: 1.45;
+  text-align: right;
+  color: var(--text-muted);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
 .deployActions {
   display: flex;
   align-items: center;
@@ -179,6 +198,45 @@
   text-transform: uppercase;
   letter-spacing: 0.04em;
   margin-bottom: 8px;
+}
+
+.sectionHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.sectionHeader .sectionTitle {
+  margin-bottom: 0;
+}
+
+.sectionArrowButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  transition: color 0.15s ease;
+}
+
+.sectionArrowButton:hover {
+  color: var(--text-primary);
+}
+
+.sectionArrowButton:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.sectionArrowButton svg {
+  width: 22px;
+  height: 22px;
 }
 
 .approvalCard {

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.module.css
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.module.css
@@ -130,7 +130,9 @@
   line-height: 1.45;
   text-align: right;
   color: var(--text-secondary);
-  word-break: break-word;
+  word-break: keep-all;
+  overflow-wrap: anywhere;
+  text-wrap: balance;
   display: -webkit-box;
   -webkit-line-clamp: 2;
   line-clamp: 2;
@@ -202,45 +204,6 @@
   text-transform: uppercase;
   letter-spacing: 0.04em;
   margin-bottom: 8px;
-}
-
-.sectionHeader {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-  margin-bottom: 8px;
-}
-
-.sectionHeader .sectionTitle {
-  margin-bottom: 0;
-}
-
-.sectionArrowButton {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 2px;
-  border: none;
-  background: transparent;
-  color: var(--text-secondary);
-  cursor: pointer;
-  border-radius: var(--radius-sm);
-  transition: color 0.15s ease;
-}
-
-.sectionArrowButton:hover {
-  color: var(--text-primary);
-}
-
-.sectionArrowButton:focus-visible {
-  outline: none;
-  box-shadow: var(--focus-ring);
-}
-
-.sectionArrowButton svg {
-  width: 22px;
-  height: 22px;
 }
 
 .approvalCard {

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.test.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.test.tsx
@@ -2,8 +2,15 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { QueryClient, QueryClientProvider, type UseQueryResult } from "@tanstack/react-query";
 import type { DomainPackVersionDetail } from "@/entities/domain-pack";
+import { domainPackSectionPath } from "@/shared/lib/domainPackRoutes";
 import { ApiRequestError } from "@/shared/api";
 import { SummaryDetailPanel } from "./SummaryDetailPanel";
+
+const mockNavigate = vi.fn();
+
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => mockNavigate,
+}));
 
 vi.mock("./SummaryJsonCard", () => ({
   SummaryJsonCard: ({ summaryJson }: { summaryJson: string }) => (
@@ -322,5 +329,47 @@ describe("SummaryDetailPanel", () => {
     fireEvent.click(screen.getByRole("button", { name: "삭제하기" }));
 
     expect(onDiscardDraft).toHaveBeenCalledWith(3);
+  });
+
+  it("PUBLISHED 버전은 운영 가능 배지를 렌더링하지 않는다", () => {
+    renderSummaryDetailPanel(
+      <SummaryDetailPanel query={makeQuery({ data: publishedDetail })} wsId={1} packId={2} />,
+    );
+
+    expect(screen.queryByText("운영 가능")).not.toBeInTheDocument();
+  });
+
+  it("description이 있으면 우측에 연하게 렌더링한다", () => {
+    renderSummaryDetailPanel(
+      <SummaryDetailPanel
+        query={makeQuery({ data: { ...stubDetail, description: "복원: v3 기준" } })}
+        wsId={1}
+        packId={2}
+      />,
+    );
+
+    expect(screen.getByText("복원: v3 기준")).toBeInTheDocument();
+  });
+
+  it("description이 없으면 설명 텍스트를 렌더링하지 않는다", () => {
+    renderSummaryDetailPanel(
+      <SummaryDetailPanel
+        query={makeQuery({ data: { ...stubDetail, description: undefined } })}
+        wsId={1}
+        packId={2}
+      />,
+    );
+
+    expect(screen.queryByText("복원: v3 기준")).not.toBeInTheDocument();
+  });
+
+  it("구성요소 상세 보기 버튼 클릭 시 intents 섹션으로 이동한다", () => {
+    renderSummaryDetailPanel(
+      <SummaryDetailPanel query={makeQuery({ data: stubDetail })} wsId={1} packId={2} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "구성요소 상세 보기" }));
+
+    expect(mockNavigate).toHaveBeenCalledWith(domainPackSectionPath(1, 2, 3, "intents"));
   });
 });

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.test.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.test.tsx
@@ -2,15 +2,8 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { QueryClient, QueryClientProvider, type UseQueryResult } from "@tanstack/react-query";
 import type { DomainPackVersionDetail } from "@/entities/domain-pack";
-import { domainPackSectionPath } from "@/shared/lib/domainPackRoutes";
 import { ApiRequestError } from "@/shared/api";
 import { SummaryDetailPanel } from "./SummaryDetailPanel";
-
-const mockNavigate = vi.fn();
-
-vi.mock("react-router-dom", () => ({
-  useNavigate: () => mockNavigate,
-}));
 
 vi.mock("./SummaryJsonCard", () => ({
   SummaryJsonCard: ({ summaryJson }: { summaryJson: string }) => (
@@ -361,15 +354,5 @@ describe("SummaryDetailPanel", () => {
     );
 
     expect(screen.queryByText("복원: v3 기준")).not.toBeInTheDocument();
-  });
-
-  it("구성요소 상세 보기 버튼 클릭 시 intents 섹션으로 이동한다", () => {
-    renderSummaryDetailPanel(
-      <SummaryDetailPanel query={makeQuery({ data: stubDetail })} wsId={1} packId={2} />,
-    );
-
-    fireEvent.click(screen.getByRole("button", { name: "구성요소 상세 보기" }));
-
-    expect(mockNavigate).toHaveBeenCalledWith(domainPackSectionPath(1, 2, 3, "intents"));
   });
 });

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.tsx
@@ -1,9 +1,6 @@
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
-import { ChevronRightIcon } from "lucide-react";
 import type { UseQueryResult } from "@tanstack/react-query";
 import type { DomainPackVersionDetail } from "@/entities/domain-pack";
-import { domainPackSectionPath } from "@/shared/lib/domainPackRoutes";
 import { ApiRequestError } from "@/shared/api";
 import { Button } from "@/shared/ui/button";
 import { ErrorState } from "@/shared/ui/ostone/atoms/ErrorState";
@@ -47,7 +44,6 @@ export function SummaryDetailPanel({
   const [isDeployDialogOpen, setDeployDialogOpen] = useState(false);
   const [isApplyDialogOpen, setApplyDialogOpen] = useState(false);
   const [isDiscardDialogOpen, setDiscardDialogOpen] = useState(false);
-  const navigate = useNavigate();
   const v = query.data;
   const versionId = v?.versionId;
   const isCurrentVersion = versionId != null && versionId === currentVersionId;
@@ -307,19 +303,7 @@ export function SummaryDetailPanel({
       <SummaryJsonCard summaryJson={v.summaryJson ?? ""} />
 
       <div>
-        <div className={styles.sectionHeader}>
-          <div className={styles.sectionTitle}>구성요소</div>
-          {versionId != null && (
-            <button
-              type="button"
-              className={styles.sectionArrowButton}
-              aria-label="구성요소 상세 보기"
-              onClick={() => navigate(domainPackSectionPath(wsId, packId, versionId, "intents"))}
-            >
-              <ChevronRightIcon aria-hidden />
-            </button>
-          )}
-        </div>
+        <div className={styles.sectionTitle}>구성요소</div>
         {versionId != null && (
           <ComponentCountGrid
             wsId={wsId}

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.tsx
@@ -1,6 +1,9 @@
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { ChevronRightIcon } from "lucide-react";
 import type { UseQueryResult } from "@tanstack/react-query";
 import type { DomainPackVersionDetail } from "@/entities/domain-pack";
+import { domainPackSectionPath } from "@/shared/lib/domainPackRoutes";
 import { ApiRequestError } from "@/shared/api";
 import { Button } from "@/shared/ui/button";
 import { ErrorState } from "@/shared/ui/ostone/atoms/ErrorState";
@@ -44,6 +47,7 @@ export function SummaryDetailPanel({
   const [isDeployDialogOpen, setDeployDialogOpen] = useState(false);
   const [isApplyDialogOpen, setApplyDialogOpen] = useState(false);
   const [isDiscardDialogOpen, setDiscardDialogOpen] = useState(false);
+  const navigate = useNavigate();
   const v = query.data;
   const versionId = v?.versionId;
   const isCurrentVersion = versionId != null && versionId === currentVersionId;
@@ -115,13 +119,9 @@ export function SummaryDetailPanel({
           <div className={styles.metaHeader}>
             <div className={styles.metaTitleRow}>
               <span className={styles.versionNoLabel}>v{v.versionNo}</span>
-              <span
-                className={`${styles.badge} ${
-                  v.lifecycleStatus === "PUBLISHED" ? styles.badgePublished : ""
-                }`}
-              >
-                {formatLifecycleStatus(v.lifecycleStatus)}
-              </span>
+              {v.lifecycleStatus !== "PUBLISHED" && (
+                <span className={styles.badge}>{formatLifecycleStatus(v.lifecycleStatus)}</span>
+              )}
               {isCurrentVersion && (
                 <span className={`${styles.badge} ${styles.badgeOperating}`}>배포중</span>
               )}
@@ -132,47 +132,50 @@ export function SummaryDetailPanel({
             <span className={styles.metaValue}>{formatDate(v.createdAt ?? "")}</span>
           </div>
         </div>
-        {isDraftVersion && versionId != null && (onApplyDraft || onDiscardDraft) ? (
-          <div className={styles.deployActions}>
-            {onDiscardDraft && (
-              <button
-                type="button"
-                className={`${styles.deployButton} ${styles.discardButton}`}
-                disabled={!canDiscardDraft}
-                onClick={() => {
-                  if (canDiscardDraft) setDiscardDialogOpen(true);
-                }}
-              >
-                {isDiscarding ? "삭제 중..." : "삭제"}
-              </button>
-            )}
-            {onApplyDraft && (
+        <div className={styles.metaSide}>
+          {v.description ? <p className={styles.versionDescription}>{v.description}</p> : null}
+          {isDraftVersion && versionId != null && (onApplyDraft || onDiscardDraft) ? (
+            <div className={styles.deployActions}>
+              {onDiscardDraft && (
+                <button
+                  type="button"
+                  className={`${styles.deployButton} ${styles.discardButton}`}
+                  disabled={!canDiscardDraft}
+                  onClick={() => {
+                    if (canDiscardDraft) setDiscardDialogOpen(true);
+                  }}
+                >
+                  {isDiscarding ? "삭제 중..." : "삭제"}
+                </button>
+              )}
+              {onApplyDraft && (
+                <button
+                  type="button"
+                  className={styles.deployButton}
+                  disabled={!canApplyDraft}
+                  onClick={() => {
+                    if (canApplyDraft) setApplyDialogOpen(true);
+                  }}
+                >
+                  {isApplying ? "적용 중..." : "적용"}
+                </button>
+              )}
+            </div>
+          ) : onDeploy && versionId != null ? (
+            <div className={styles.deployActions}>
               <button
                 type="button"
                 className={styles.deployButton}
-                disabled={!canApplyDraft}
+                disabled={!canDeploy}
                 onClick={() => {
-                  if (canApplyDraft) setApplyDialogOpen(true);
+                  if (canDeploy) setDeployDialogOpen(true);
                 }}
               >
-                {isApplying ? "적용 중..." : "적용"}
+                {isCurrentVersion ? "배포중" : isDeploying ? "배포 중..." : "배포"}
               </button>
-            )}
-          </div>
-        ) : onDeploy && versionId != null ? (
-          <div className={styles.deployActions}>
-            <button
-              type="button"
-              className={styles.deployButton}
-              disabled={!canDeploy}
-              onClick={() => {
-                if (canDeploy) setDeployDialogOpen(true);
-              }}
-            >
-              {isCurrentVersion ? "배포중" : isDeploying ? "배포 중..." : "배포"}
-            </button>
-          </div>
-        ) : null}
+            </div>
+          ) : null}
+        </div>
       </div>
 
       <AlertDialog
@@ -304,7 +307,19 @@ export function SummaryDetailPanel({
       <SummaryJsonCard summaryJson={v.summaryJson ?? ""} />
 
       <div>
-        <div className={styles.sectionTitle}>구성요소</div>
+        <div className={styles.sectionHeader}>
+          <div className={styles.sectionTitle}>구성요소</div>
+          {versionId != null && (
+            <button
+              type="button"
+              className={styles.sectionArrowButton}
+              aria-label="구성요소 상세 보기"
+              onClick={() => navigate(domainPackSectionPath(wsId, packId, versionId, "intents"))}
+            >
+              <ChevronRightIcon aria-hidden />
+            </button>
+          )}
+        </div>
         {versionId != null && (
           <ComponentCountGrid
             wsId={wsId}

--- a/frontend/src/features/domain-pack-summary-read/ui/VersionListPanel.module.css
+++ b/frontend/src/features/domain-pack-summary-read/ui/VersionListPanel.module.css
@@ -99,6 +99,18 @@
   color: var(--text-muted);
 }
 
+.description {
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--text-secondary);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  word-break: break-word;
+}
+
 .skeleton {
   padding: 16px;
   display: flex;

--- a/frontend/src/features/domain-pack-summary-read/ui/VersionListPanel.module.css
+++ b/frontend/src/features/domain-pack-summary-read/ui/VersionListPanel.module.css
@@ -108,7 +108,9 @@
   line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
-  word-break: break-word;
+  word-break: keep-all;
+  overflow-wrap: anywhere;
+  text-wrap: balance;
 }
 
 .skeleton {

--- a/frontend/src/features/domain-pack-summary-read/ui/VersionListPanel.test.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/VersionListPanel.test.tsx
@@ -152,7 +152,7 @@ describe("VersionListPanel", () => {
     expect(screen.getByRole("button", { name: /v1/ })).toHaveTextContent("배포중");
   });
 
-  it("운영 가능 버전과 상태가 없는 버전을 상담사 용어로 표시한다", () => {
+  it("PUBLISHED 버전은 운영 가능 배지를 숨기고 배포중/상태 배지만 표시한다", () => {
     render(
       <VersionListPanel
         query={makeQuery({
@@ -160,7 +160,12 @@ describe("VersionListPanel", () => {
             ...stubPack,
             versions: [
               { ...stubVersion, lifecycleStatus: "PUBLISHED", createdAt: "날짜 확인 전" },
-              { ...stubVersion2, versionNo: null, lifecycleStatus: null, createdAt: "날짜 확인 전" },
+              {
+                ...stubVersion2,
+                versionNo: null,
+                lifecycleStatus: null,
+                createdAt: "날짜 확인 전",
+              },
               {
                 ...stubVersion2,
                 versionId: 3,
@@ -177,7 +182,7 @@ describe("VersionListPanel", () => {
       />,
     );
 
-    expect(screen.getByRole("button", { name: /v1/ })).toHaveTextContent("운영 가능");
+    expect(screen.getByRole("button", { name: /v1/ })).not.toHaveTextContent("운영 가능");
     expect(screen.getByRole("button", { name: /v1/ })).toHaveTextContent("배포중");
     expect(screen.getByRole("button", { name: /v-/ })).toHaveTextContent("상태 없음");
     expect(screen.getByRole("button", { name: /v3/ })).toHaveTextContent("상태 없음");

--- a/frontend/src/features/domain-pack-summary-read/ui/VersionListPanel.test.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/VersionListPanel.test.tsx
@@ -189,4 +189,21 @@ describe("VersionListPanel", () => {
     expect(screen.getByRole("button", { name: /v3/ })).not.toHaveTextContent("ARCHIVED");
     expect(screen.getAllByText("날짜 확인 전")).toHaveLength(3);
   });
+
+  it("description이 있는 버전은 목록에 설명을 렌더링한다", () => {
+    render(
+      <VersionListPanel
+        query={makeQuery({
+          data: {
+            ...stubPack,
+            versions: [{ ...stubVersion, description: "환불 정책 재구성" }],
+          },
+        })}
+        selectedId={1}
+        onSelect={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("환불 정책 재구성")).toBeInTheDocument();
+  });
 });

--- a/frontend/src/features/domain-pack-summary-read/ui/VersionListPanel.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/VersionListPanel.tsx
@@ -122,6 +122,9 @@ function VersionListItem({
           )}
         </div>
         <span className={styles.createdAt}>{formatDate(version.createdAt ?? "")}</span>
+        {version.description ? (
+          <span className={styles.description}>{version.description}</span>
+        ) : null}
       </button>
     </li>
   );

--- a/frontend/src/features/domain-pack-summary-read/ui/VersionListPanel.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/VersionListPanel.tsx
@@ -112,11 +112,11 @@ function VersionListItem({
       >
         <div className={styles.itemRow}>
           <span className={styles.versionNo}>v{versionNo}</span>
-          <span
-            className={`${styles.badge} ${isPublished ? styles.badgePublished : styles.badgeDraft}`}
-          >
-            {formatLifecycleStatus(version.lifecycleStatus)}
-          </span>
+          {!isPublished && (
+            <span className={`${styles.badge} ${styles.badgeDraft}`}>
+              {formatLifecycleStatus(version.lifecycleStatus)}
+            </span>
+          )}
           {isCurrentVersion && (
             <span className={`${styles.badge} ${styles.badgeOperating}`}>배포중</span>
           )}

--- a/frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.tsx
@@ -301,7 +301,7 @@ export function WorkflowDraftReadPage() {
                 <p className={styles.detailDescription}>{workflow.description}</p>
               )}
             </div>
-            {workflow && lifecycleStatus && (
+            {workflow && lifecycleStatus && lifecycleStatus !== "PUBLISHED" && (
               <Pill tone="signal">{formatLifecycleStatus(lifecycleStatus)}</Pill>
             )}
             {workflow && isEditing && <Pill tone="ink">수정 중</Pill>}
@@ -369,9 +369,7 @@ export function WorkflowDraftReadPage() {
         }}
       >
         <AlertDialogContent size="sm" className={styles.discardDialog}>
-          <AlertDialogTitle className={styles.discardTitle}>
-            변경 내역을 버릴까요?
-          </AlertDialogTitle>
+          <AlertDialogTitle className={styles.discardTitle}>변경 내역을 버릴까요?</AlertDialogTitle>
           <AlertDialogDescription className={styles.discardDescription}>
             저장하지 않고 이동하면 현재 편집 중인 변경 내역이 버려집니다.
           </AlertDialogDescription>

--- a/frontend/src/shared/api/generated/zod/domainPackDetailResult.zod.ts
+++ b/frontend/src/shared/api/generated/zod/domainPackDetailResult.zod.ts
@@ -21,6 +21,7 @@ export const DomainPackDetailResult = zod.object({
         versionId: zod.number().optional(),
         versionNo: zod.number().optional(),
         lifecycleStatus: zod.string().optional(),
+        description: zod.string().optional(),
         sourcePipelineJobId: zod.number().optional(),
         createdAt: zod.iso.datetime({ offset: true }).optional(),
         updatedAt: zod.iso.datetime({ offset: true }).optional(),

--- a/frontend/src/shared/api/generated/zod/domainPackVersionDetailResult.zod.ts
+++ b/frontend/src/shared/api/generated/zod/domainPackVersionDetailResult.zod.ts
@@ -13,6 +13,7 @@ export const DomainPackVersionDetailResult = zod.object({
   lifecycleStatus: zod.string().optional(),
   sourcePipelineJobId: zod.number().optional(),
   summaryJson: zod.string().optional(),
+  description: zod.string().optional(),
   intentCount: zod.number().optional(),
   slotCount: zod.number().optional(),
   policyCount: zod.number().optional(),

--- a/frontend/src/shared/api/generated/zod/domainPackVersionSummaryEntry.zod.ts
+++ b/frontend/src/shared/api/generated/zod/domainPackVersionSummaryEntry.zod.ts
@@ -10,6 +10,7 @@ export const DomainPackVersionSummaryEntry = zod.object({
   versionId: zod.number().optional(),
   versionNo: zod.number().optional(),
   lifecycleStatus: zod.string().optional(),
+  description: zod.string().optional(),
   sourcePipelineJobId: zod.number().optional(),
   createdAt: zod.iso.datetime({ offset: true }).optional(),
   updatedAt: zod.iso.datetime({ offset: true }).optional(),


### PR DESCRIPTION
## 배경 / 목적
도메인팩 **버전 상세 화면**(`DomainPackSummaryPage`)의 UX를 다듬고, 버전마다
commit-log 성격의 설명을 남길 수 있도록 데이터 모델을 확장한다.

- base: `main` ← head: `chore/route-to-related-intents`

## 변경 사항

### 1. 버전 단위 `description` 필드 추가 (feat) — `6af6dd4`
- `pack.domain_pack_version`에 nullable `description` 컬럼 추가 (Liquibase 변경셋
  `init:20260601-add-description-to-domain-pack-version`).
- `DomainPackVersion.createDraft(...)`에 description 인자 추가.
  - clone(개정/복원) draft 생성 시 **`reason`을 description으로 영속화**.
  - 파이프라인 empty draft는 `null`.
- `DomainPackVersionDetailResult` / `GetDomainPackVersionDetailUseCase` 및
  OpenAPI(zod) 스키마에 `description` 노출.

### 2. 버전 상세 패널 UI 개선 (feat) — `9ccef4e`
- PUBLISHED **"운영 가능" 배지 제거** (검토 중 / 배포중은 유지).
- 버전 `description`을 메타 카드 **우측에 연하게(muted)** 표시 (값이 있을 때만).
- "구성요소" 헤더에 **상세 이동(`>`) 화살표 버튼** 추가 → intents 섹션으로 이동.

### 3. 버전 목록·워크플로우 화면 배지 정리 (chore) — `4e6941e`
- `VersionListPanel`, `WorkflowDraftReadPage`에서도 PUBLISHED "운영 가능" 배지 숨김.

> 참고: "상담사 응대중(HUMAN_ACTIVE) 모드에서 AI 미응답"은 이미 #389에서 구현·머지되어
> 본 PR 범위에 포함하지 않음.

## 테스트
- **Backend**: `./gradlew check` (checkstyle + 전체 테스트) 통과.
  - 신규/보강: clone `reason`→`description`(ArgumentCaptor), empty draft `null`,
    UseCase description 매핑, Controller `$.description` jsonPath.
- **Frontend**: `pnpm build`(typecheck) + 전체 **1510 테스트 통과**.
  - 신규: 운영 가능 배지 미표시, description 유무 2분기, 화살표 내비게이션.
- **Runtime (Playwright MCP, localhost:5173)**:
  - v1(PUBLISHED/현재): "배포중"만 표시(운영 가능 없음).
  - v2(DRAFT): "검토 중" + 우측 연한 description 렌더.
  - 화살표 클릭 → `/workspaces/1/domain-packs/1/intents?versionId=2` 이동.
  - 신규 콘솔 에러 없음.

## 영향 / 마이그레이션
- DB 마이그레이션 1건(nullable 컬럼 추가, 백필 불필요).
- 기존 버전은 `description`이 비어 있어 화면에 표시되지 않음(의도된 동작).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 버전 설명(description) 저장 및 UI에 표시(우측 메타 영역, 최대 2줄 클램프)  
  * 구성요소 카드에 별도 "상세 보기" 화살표 버튼 추가 및 키보드 접근성 개선

* **버그 수정**
  * 퍼블리시드(PUBLISHED) 버전에 대해 "운영 가능"/수명주기 배지를 더 이상 표시하지 않도록 수정

* **스타일**
  * 버전 설명 영역 및 섹션 헤더 레이아웃/버튼 스타일 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->