### PR TITLE
feat(upload): 초안 생성 후 검토 화면 CTA 제공

### DIFF
--- a/.agent/specs/425.md
+++ b/.agent/specs/425.md
@@ -1,0 +1,107 @@
+# Frontend Spec: 업로드 후 파이프라인 검토 CTA 안내
+
+## Goal
+
+상담 로그 업로드 후 도메인팩 초안 생성 요청이 성공하면, 사용자가 바로 파이프라인 검토 화면으로 이어갈 수 있는 CTA를 제공한다.
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A[상담 로그 업로드 완료] --> B[도메인팩 초안 생성 시작]
+    B --> C{생성 요청 성공?}
+    C -->|No| D[실패 메시지와 재시도 CTA 표시]
+    C -->|Yes| E{pipelineJobId 존재?}
+    E -->|Yes| F[파이프라인 검토 화면 CTA 표시]
+    E -->|No| G[기존 도메인팩 목록 fallback CTA 표시]
+    F --> H[/workspaces/:workspaceId/pipeline-jobs/:pipelineJobId/review 이동]
+    G --> I[/workspaces/:workspaceId/domain-packs 이동]
+```
+
+## Design Diff
+
+### As-is vs To-be
+
+| 영역 | As-is | To-be | 변경 내용 |
+|------|-------|-------|----------|
+| 생성 요청 성공 CTA | `도메인팩 보기`가 주요 행동 | `pipelineJobId`가 있으면 검토 화면 CTA가 주요 행동 | 생성 직후 이어서 확인할 다음 단계를 명확히 안내 |
+| 도메인팩 목록 이동 | 성공 상태에서 주요 CTA | 보조 CTA 또는 fallback | 초안 생성 완료 전 빈 목록으로 이동하는 혼란 감소 |
+| 예외 응답 | `pipelineJobId`가 없어도 도메인팩 목록 이동 가능 | 동일 유지 | API 응답에 job id가 없는 경우 기존 fallback 보존 |
+
+## Component Tree
+
+```text
+WorkspaceUploadPage
+└─ LogUploadForm
+   ├─ FileUploader
+   ├─ 업로드 성공 요약
+   └─ 생성 요청 성공 패널
+      ├─ 다른 파일 업로드 Button
+      ├─ 도메인팩 보기 Button
+      └─ 파이프라인 검토 화면 Button (pipelineJobId 있을 때)
+```
+
+## API Integration
+
+### Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/api/v1/workspaces/{workspaceId}/datasets/{datasetId}/pipeline-jobs/domain-pack-generation` | 도메인팩 초안 생성 파이프라인 요청 |
+
+기존 Orval generated hook `useTriggerDomainPackGeneration` 응답의 `pipelineJobId`를 사용한다. 새 API 호출이나 generated 파일 변경은 필요하지 않다.
+
+## Data Flow
+
+```text
+LogUploadForm
+  -> useTriggerDomainPackGeneration 성공 응답 수신
+  -> readGenerationResponse(response)
+  -> generationStatus.success.pipelineJobId 저장
+  -> pipelineJobId가 있으면 /workspaces/{workspaceId}/pipeline-jobs/{pipelineJobId}/review CTA 표시
+```
+
+## 수정 대상 파일
+
+| 파일 | 변경 유형 | 설명 |
+|------|----------|------|
+| `frontend/src/features/log-upload/ui/LogUploadForm.tsx` | modify | 생성 요청 성공 상태에서 파이프라인 검토 화면 CTA를 노출 |
+| `frontend/src/features/log-upload/ui/LogUploadForm.test.tsx` | modify | 성공 후 review CTA 이동과 `pipelineJobId` 없는 fallback 검증 |
+
+## State Management
+
+기존 로컬 상태 `generationStatus`를 유지한다. `pipelineJobId`가 `number`이면 review CTA 경로를 계산하고, `null`이면 기존 도메인팩 목록 CTA만 fallback으로 제공한다.
+
+## Tests
+
+### Test Strategy
+
+| 구분 | 방법 | 도구 | 비고 |
+|------|------|------|------|
+| 컴포넌트 테스트 | 생성 요청 성공 상태 렌더링 및 CTA 클릭 검증 | Vitest, React Testing Library | API hook은 기존 테스트 mock 사용 |
+
+### Test Scenarios
+
+#### Happy Path
+
+| # | 시나리오 | 사전 조건 | 조작 | 기대 결과 |
+|---|---------|---------|------|----------|
+| 1 | 생성 요청 성공 후 검토 화면 이동 | `pipelineJobId=11`, `workspaceId=1` | `검토 화면으로 이동` 클릭 | `/workspaces/1/pipeline-jobs/11/review`로 navigate |
+| 2 | 도메인팩 목록 보조 이동 | `pipelineJobId=11`, `workspaceId=1` | `도메인팩 보기` 클릭 | `/workspaces/1/domain-packs`로 navigate |
+
+#### Error & Edge Cases
+
+| # | 시나리오 | 조작 | 기대 결과 |
+|---|---------|------|----------|
+| 1 | `pipelineJobId` 없는 성공 응답 | 생성 요청 성공 응답에 `status`만 포함 | 기존 `도메인팩 보기` fallback이 유지되고 review CTA는 표시되지 않음 |
+| 2 | 생성 요청 실패 | 실패 응답 수신 | 기존 실패 메시지와 재시도 CTA 유지 |
+
+## Non-goals
+
+- 파이프라인 검토 화면의 데이터 로딩, 체크포인트 UI, 권한 정책은 변경하지 않는다.
+- 도메인팩 생성 API 계약 또는 Orval generated 파일은 변경하지 않는다.
+- `WorkspaceUploadPage`의 `?jobId=` redirect 동작은 이미 존재하므로 변경하지 않는다.
+
+## Open Questions
+
+- 없음. 이슈 본문에서 `pipelineJobId`가 있는 경우의 직접 CTA와 없는 경우의 fallback 유지 기준이 명확하다.

--- a/frontend/src/features/log-upload/ui/LogUploadForm.test.tsx
+++ b/frontend/src/features/log-upload/ui/LogUploadForm.test.tsx
@@ -222,7 +222,7 @@ describe("LogUploadForm", () => {
     expect(mockTriggerMutate).toHaveBeenCalledWith({ workspaceId: 1, datasetId: 42 });
   });
 
-  it("shows domain pack link after generation request succeeds", () => {
+  it("shows review CTA after generation request succeeds with pipeline job id", () => {
     render(<LogUploadForm workspaceId={1} />, { wrapper: MemoryRouter });
     const file = new File(["data"], "data.json", { type: "application/json" });
     const input = screen.getByTestId("file-input");
@@ -238,6 +238,26 @@ describe("LogUploadForm", () => {
 
     expect(screen.getByText("생성 요청 완료")).toBeInTheDocument();
     expect(screen.getByText(/job 11 · REQUESTED/)).toBeInTheDocument();
+    fireEvent.click(screen.getByText("검토 화면으로 이동"));
+    expect(mockNavigate).toHaveBeenCalledWith("/workspaces/1/pipeline-jobs/11/review");
+
+    fireEvent.click(screen.getByText("도메인팩 보기"));
+    expect(mockNavigate).toHaveBeenCalledWith("/workspaces/1/domain-packs");
+  });
+
+  it("keeps domain pack fallback when generation response has no pipeline job id", () => {
+    render(<LogUploadForm workspaceId={1} />, { wrapper: MemoryRouter });
+    const file = new File(["data"], "data.json", { type: "application/json" });
+    const input = screen.getByTestId("file-input");
+    fireEvent.change(input, { target: { files: [file] } });
+    fireEvent.click(screen.getByText("처리 시작"));
+    fireEvent.click(screen.getByText("도메인팩 초안 생성 시작"));
+    act(() => {
+      callTriggerOnSuccess?.({ status: "REQUESTED" }, { workspaceId: 1, datasetId: 42 });
+    });
+
+    expect(screen.getByText("생성 요청 완료")).toBeInTheDocument();
+    expect(screen.queryByText("검토 화면으로 이동")).not.toBeInTheDocument();
     fireEvent.click(screen.getByText("도메인팩 보기"));
     expect(mockNavigate).toHaveBeenCalledWith("/workspaces/1/domain-packs");
   });

--- a/frontend/src/features/log-upload/ui/LogUploadForm.tsx
+++ b/frontend/src/features/log-upload/ui/LogUploadForm.tsx
@@ -185,6 +185,12 @@ export const LogUploadForm: React.FC<LogUploadFormProps> = ({ workspaceId }) => 
   };
 
   const domainPacksPath = workspaceId ? `/workspaces/${workspaceId}/domain-packs` : "/workspaces";
+  const pipelineReviewPath =
+    workspaceId != null &&
+    generationStatus.kind === "success" &&
+    generationStatus.pipelineJobId != null
+      ? `/workspaces/${workspaceId}/pipeline-jobs/${generationStatus.pipelineJobId}/review`
+      : null;
   const canStartGeneration = Boolean(uploadedDataset?.datasetId);
   const isGenerationPending =
     generationStatus.kind === "triggering" || generationMutation.isPending;
@@ -292,7 +298,15 @@ export const LogUploadForm: React.FC<LogUploadFormProps> = ({ workspaceId }) => 
                 <Button variant="secondary" onClick={handleReset}>
                   다른 파일 업로드
                 </Button>
-                <Button onClick={() => navigate(domainPacksPath)}>도메인팩 보기</Button>
+                {pipelineReviewPath && (
+                  <Button onClick={() => navigate(pipelineReviewPath)}>검토 화면으로 이동</Button>
+                )}
+                <Button
+                  variant={pipelineReviewPath ? "secondary" : "primary"}
+                  onClick={() => navigate(domainPacksPath)}
+                >
+                  도메인팩 보기
+                </Button>
               </div>
             </div>
           )}


### PR DESCRIPTION
## Summary
- 상담 로그 업로드 후 도메인팩 초안 생성 요청이 성공하면 pipeline job 검토 화면으로 바로 이동하는 CTA를 표시합니다.
- `pipelineJobId`가 없는 성공 응답에서는 기존 도메인팩 목록 이동 fallback을 유지합니다.
- 이슈 요구사항과 검증 기준을 `.agent/specs/425.md`에 정리했습니다.

## Validation
- `cd frontend && pnpm test --run src/features/log-upload/ui/LogUploadForm.test.tsx`
- `cd frontend && pnpm exec eslint src/features/log-upload/ui/LogUploadForm.tsx src/features/log-upload/ui/LogUploadForm.test.tsx`
- `cd frontend && pnpm test --run`
- `cd frontend && pnpm build`

Closes #425

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 상담 로그 업로드 성공 후 파이프라인 검토 화면으로 직접 이동할 수 있는 기능이 추가되었습니다. 파이프라인이 생성된 경우 "검토 화면으로 이동" 버튼이 표시되고, 생성되지 않은 경우는 기존의 도메인팩 목록으로 이동하도록 사용자 흐름이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->