### PR TITLE
fix(consultation): 상담 이력 직접 진입 상세 표시 안정화

### DIFF
--- a/.agent/specs/431.md
+++ b/.agent/specs/431.md
@@ -1,0 +1,164 @@
+# 431 [FE] 직접 진입한 상담 이력 상세 안정화
+
+## Goal
+
+상담 이력 상세 URL(`/workspaces/{workspaceId}/consultation/history/{sessionId}`)로 직접 진입하거나 새로고침해도, 현재 목록 페이지/필터에 세션이 포함되어 있는지와 무관하게 URL의 `sessionId` 기준으로 메시지 상세 조회를 시도한다.
+
+---
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A[상담 이력 URL 진입] --> B[목록은 현재 query filter/page로 조회]
+    A --> C{URL sessionId 존재?}
+    C -->|No| D[세션 선택 안내 표시]
+    C -->|Yes| E[sessionId 기준 메시지 상세 조회]
+    E --> F{상세 조회 성공?}
+    F -->|Yes| G[메시지 내역 표시]
+    F -->|No: 404/권한/기타 오류| H[오류 또는 찾을 수 없음 상태 표시]
+    B --> I[목록 필터/페이지네이션 유지]
+```
+
+---
+
+## Design Diff
+
+### As-is vs To-be
+
+| 영역 | As-is | To-be | 변경 내용 |
+|------|-------|-------|----------|
+| 상세 조회 조건 | `sessionId`가 현재 페이지의 `sessions`에 있을 때만 `MessageHistory`에 전달 | URL에 `sessionId`가 있으면 바로 `MessageHistory`에 전달 | 목록 페이지 포함 여부와 상세 조회를 분리 |
+| 직접 진입 | 현재 필터/페이지 결과에 없으면 missing 상태 표시 | 메시지 상세 API가 실제 존재/권한 여부를 판단 | 공유 링크와 새로고침 안정화 |
+| 목록 동작 | 필터/페이지네이션/query 유지 | 기존 동작 유지 | 상세 패널만 URL `sessionId` 기준으로 독립 조회 |
+
+---
+
+## Component Tree
+
+```
+ChatHistoryPage
+├─ SessionList
+│    ├─ filters
+│    ├─ pagination
+│    └─ selectedSessionId highlight
+└─ MessageHistory
+     └─ useChatMessagePage(sessionId)
+```
+
+---
+
+## API Integration
+
+### Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/v1/workspaces/{workspaceId}/consultation/sessions` | 상담 이력 목록 조회 |
+| GET | `/api/v1/consultation/sessions/{sessionId}/messages` | 상담 메시지 상세 조회 |
+
+### Query Key Pattern
+
+- 목록은 기존 `chatHistoryKeys.sessionList(workspaceId, params)`를 유지한다.
+- 메시지는 기존 `chatHistoryKeys.messages(sessionId, page, size)`를 유지한다.
+- URL `sessionId`가 현재 목록 결과에 없더라도 메시지 query key는 해당 `sessionId`로 생성되어야 한다.
+
+---
+
+## Data Flow
+
+```
+URL params
+  ├─ workspaceId -> useChatSessions(workspaceId, filters, page)
+  └─ sessionId   -> MessageHistory -> useChatMessagePage(sessionId)
+```
+
+- `SessionList`는 현재 필터/페이지 결과만 표시한다.
+- `MessageHistory`는 목록 결과에 의존하지 않고 URL `sessionId`를 직접 사용한다.
+- 실제 미존재/권한 오류는 메시지 상세 API의 오류 상태로 표현한다.
+
+---
+
+## 수정 대상 파일
+
+| 파일 | 변경 유형 | 설명 |
+|------|----------|------|
+| `frontend/src/pages/consultation/ui/chat-history/ChatHistoryPage.tsx` | modify | 현재 목록 포함 여부에 따른 상세 조회 차단 로직 제거 |
+| `frontend/src/pages/consultation/ui/chat-history/ChatHistoryPage.test.tsx` | modify | 현재 목록에 없는 URL `sessionId`도 메시지 조회를 시도하는 회귀 테스트 추가/수정 |
+| `frontend/src/features/consultation/ui/chat-history/MessageHistory.tsx` | modify | 유효하지 않은 `sessionId`는 메시지 조회 없이 찾을 수 없음 상태 표시 |
+| `frontend/src/features/consultation/ui/chat-history/MessageHistory.test.tsx` | modify | 유효하지 않은 `sessionId` 처리 회귀 테스트 추가 |
+
+---
+
+## State Management
+
+### Server State (TanStack Query)
+
+- 목록 server state: 기존 필터와 페이지 query parameter를 기반으로 유지한다.
+- 메시지 server state: URL `sessionId`를 기반으로 독립 조회한다.
+
+### Client State
+
+- 별도 전역 상태를 추가하지 않는다.
+- URL path parameter와 search parameter를 기존처럼 source of truth로 유지한다.
+
+---
+
+## Tests
+
+### Test Strategy
+
+| 구분 | 방법 | 도구 | 비고 |
+|------|------|------|------|
+| 통합 테스트 | 라우터 URL과 mock query hook 검증 | Vitest + React Testing Library | 직접 진입/목록 선택 회귀 검증 |
+
+### Test Environment & 사전 조건
+
+| 항목 | 값 |
+|------|---|
+| 환경 | `cd frontend && pnpm test -- ChatHistoryPage.test.tsx MessageHistory.test.tsx` |
+| API Mock | `useChatSessions`, `useChatMessagePage` mock |
+| 사전 조건 | 목록에 없는 `sessionId`를 가진 URL로 진입 |
+
+### Test Scenarios
+
+#### Happy Path
+
+| # | 시나리오 | 사전 조건 | 조작 | 기대 결과 |
+|---|---------|---------|------|----------|
+| 1 | URL `sessionId`가 현재 목록에 있음 | 목록에 session `7` 존재 | `/history/7` 진입 | `useChatMessagePage("7")` 호출 |
+| 2 | URL `sessionId`가 현재 목록에 없음 | 목록에는 session `7`만 존재 | `/history/999` 진입 | `useChatMessagePage("999")` 호출 후 메시지 상세 상태 표시 |
+| 3 | 목록 세션 선택 | 목록에 session `7` 존재 | 세션 카드 클릭 | 기존 query를 유지하며 `/history/7` 이동 |
+
+#### Error & Edge Cases
+
+| # | 시나리오 | 조작 | 기대 결과 |
+|---|---------|------|----------|
+| 1 | 상세 API 오류 | `/history/999` 진입 후 메시지 조회 오류 | 오류 상태와 다시 시도 표시 |
+| 2 | 세션 미선택 | `/history` 진입 | 세션 선택 안내 표시 |
+| 3 | 목록 로딩 중 직접 진입 | `/history/{sessionId}` 진입 | 목록 로딩 여부와 무관하게 메시지 조회 시도 |
+| 4 | 유효하지 않은 sessionId | `/history/invalid` 진입 | 메시지 조회 없이 찾을 수 없음 상태 표시 |
+
+---
+
+## Non-Goals
+
+- 백엔드 API 경로, 권한 정책, 응답 envelope 변경은 하지 않는다.
+- 목록 필터가 선택된 `sessionId`를 포함하도록 자동 보정하지 않는다.
+- 목록에 없는 선택 세션을 임시 카드로 삽입하지 않는다.
+- 메시지 상세의 오류 문구 체계를 새로 설계하지 않는다.
+
+---
+
+## Acceptance Criteria
+
+- 현재 목록 페이지에 없는 `sessionId`로 직접 진입해도 메시지 상세 조회가 시도된다.
+- 실제 404/권한 오류 등 상세 API 오류인 경우에만 오류 상태를 표시한다.
+- 기존 목록 선택, 필터, 페이지네이션 동작은 유지된다.
+- 스펙 파일은 `.agent/specs/431.md`에 위치한다.
+
+---
+
+## Open Questions
+
+- 없음. 이슈 본문만으로 구현 범위가 충분히 확정된다.

--- a/frontend/src/features/consultation/ui/chat-history/MessageHistory.test.tsx
+++ b/frontend/src/features/consultation/ui/chat-history/MessageHistory.test.tsx
@@ -119,4 +119,19 @@ describe("MessageHistory", () => {
       expect(toastErrorMock).toHaveBeenCalledWith("이전 메시지를 불러오지 못했습니다.");
     });
   });
+
+  it("유효하지 않은 sessionId는 메시지 조회 없이 찾을 수 없음 상태를 표시한다", () => {
+    useChatMessagePageMock.mockReturnValue({
+      data: null,
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(<MessageHistory sessionId="invalid" />);
+
+    expect(useChatMessagePageMock).toHaveBeenCalledWith("");
+    expect(screen.getByText("현재 워크스페이스에서 해당 상담 세션을 찾을 수 없습니다")).toBeTruthy();
+  });
 });

--- a/frontend/src/features/consultation/ui/chat-history/MessageHistory.tsx
+++ b/frontend/src/features/consultation/ui/chat-history/MessageHistory.tsx
@@ -71,7 +71,11 @@ export function MessageHistory({
   isSelectionPending = false,
   missingSessionId = null,
 }: MessageHistoryProps) {
-  const activeSessionId = isSelectionPending || missingSessionId ? "" : (sessionId ?? "");
+  const parsedSessionId = Number(sessionId);
+  const hasInvalidSessionId =
+    sessionId != null && (!Number.isSafeInteger(parsedSessionId) || parsedSessionId <= 0);
+  const activeSessionId =
+    isSelectionPending || missingSessionId || hasInvalidSessionId ? "" : (sessionId ?? "");
   const [loadedPages, setLoadedPages] = useState<ChatMessagePage[]>([]);
   const [isLoadingPrevious, setIsLoadingPrevious] = useState(false);
   const {
@@ -130,7 +134,7 @@ export function MessageHistory({
     }
   };
 
-  if (missingSessionId) {
+  if (missingSessionId || hasInvalidSessionId) {
     return (
       <section className={styles.wrapper} aria-label="채팅 메시지 내역">
         <div className={styles.stateArea}>

--- a/frontend/src/pages/consultation/ui/chat-history/ChatHistoryPage.test.tsx
+++ b/frontend/src/pages/consultation/ui/chat-history/ChatHistoryPage.test.tsx
@@ -307,12 +307,37 @@ describe("ChatHistoryPage", () => {
     expect(mockedUseChatMessagePage).toHaveBeenLastCalledWith("7");
   });
 
-  it("URL의 sessionId가 현재 워크스페이스 목록에 없으면 메시지를 조회하지 않고 안내한다", () => {
+  it("URL의 sessionId가 현재 목록 페이지에 없어도 메시지 조회를 시도한다", async () => {
+    mockMessagePageForSession(
+      "999",
+      makeMessagePageResult({ data: [makeMessage({ content: "직접 진입 상세입니다" })] }),
+    );
+
     renderPage("/workspaces/1/consultation/history/999");
 
-    expect(mockedUseChatMessagePage).toHaveBeenLastCalledWith("");
-    expect(
-      screen.getByText("현재 워크스페이스에서 해당 상담 세션을 찾을 수 없습니다"),
-    ).toBeTruthy();
+    expect(mockedUseChatMessagePage).toHaveBeenLastCalledWith("999");
+    expect(await screen.findByText("직접 진입 상세입니다")).toBeTruthy();
+  });
+
+  it("현재 목록 로딩 중에도 URL sessionId로 메시지 조회를 시도한다", () => {
+    mockedUseChatSessions.mockReturnValue(makeSessionsResult({ isLoading: true }));
+
+    renderPage("/workspaces/1/consultation/history/999");
+
+    expect(mockedUseChatMessagePage).toHaveBeenLastCalledWith("999");
+  });
+
+  it("URL sessionId의 메시지 조회가 실패하면 오류 상태를 표시한다", () => {
+    const refetch = vi.fn();
+    mockMessagePageForSession(
+      "999",
+      makeMessagePageResult({ isError: true, error: new Error("세션을 찾을 수 없습니다"), refetch }),
+    );
+
+    renderPage("/workspaces/1/consultation/history/999");
+
+    expect(screen.getByText("세션을 찾을 수 없습니다")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "다시 시도" }));
+    expect(refetch).toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/consultation/ui/chat-history/ChatHistoryPage.tsx
+++ b/frontend/src/pages/consultation/ui/chat-history/ChatHistoryPage.tsx
@@ -62,19 +62,6 @@ export function ChatHistoryPage({ workspaceId: workspaceIdProp }: ChatHistoryPag
     size: PAGE_SIZE,
   });
   const sessions = useMemo(() => sessionPage?.content ?? [], [sessionPage?.content]);
-  const selectableSessionIds = useMemo(
-    () =>
-      new Set(sessions.filter((session) => session.id != null).map((session) => String(session.id))),
-    [sessions],
-  );
-  const hasSelectedSession =
-    selectedSessionId !== null && selectableSessionIds.has(selectedSessionId);
-  const isSelectionPending = selectedSessionId !== null && isLoading;
-  const missingSessionId =
-    selectedSessionId !== null && !isLoading && !isError && !hasSelectedSession
-      ? selectedSessionId
-      : null;
-
   const handleSelectSession = (sessionId: string) => {
     if (workspaceId === null) return;
     const query = searchParams.toString();
@@ -168,11 +155,7 @@ export function ChatHistoryPage({ workspaceId: workspaceIdProp }: ChatHistoryPag
         onRetry={refetch}
       />
       <div className={styles.contentPane}>
-        <MessageHistory
-          sessionId={hasSelectedSession ? selectedSessionId : null}
-          isSelectionPending={isSelectionPending}
-          missingSessionId={missingSessionId}
-        />
+        <MessageHistory sessionId={selectedSessionId} />
       </div>
     </main>
   );


### PR DESCRIPTION
## Summary
- URL의 상담 이력 sessionId를 현재 목록 페이지 포함 여부와 분리해 메시지 상세 조회에 직접 사용합니다.
- 직접 진입한 sessionId가 현재 필터/페이지 결과에 없어도 상세 패널이 독립적으로 메시지 query를 실행합니다.
- 유효하지 않은 sessionId는 메시지 조회 없이 찾을 수 없음 상태로 처리하고, 이슈 요구사항을 `.agent/specs/431.md`에 정리했습니다.

## Validation
- `cd frontend && pnpm test -- ChatHistoryPage.test.tsx MessageHistory.test.tsx`
- `cd frontend && pnpm exec eslint src/pages/consultation/ui/chat-history/ChatHistoryPage.tsx src/pages/consultation/ui/chat-history/ChatHistoryPage.test.tsx src/features/consultation/ui/chat-history/MessageHistory.tsx src/features/consultation/ui/chat-history/MessageHistory.test.tsx`
- `git diff --check`

## Notes
- `cd frontend && pnpm lint` still reports existing unrelated lint errors outside this diff, primarily workflow/auth test `no-explicit-any` and React hook lint findings.

Closes #431

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 상담 세션 목록에 없어도 URL의 세션 ID로 직접 상담 이력에 접근 가능하도록 개선했습니다.

* **Bug Fixes**
  * 잘못된 세션 ID 입력 시 검증 로직을 추가하여 안정성을 향상시켰습니다.

* **Documentation**
  * 상담 이력 직접 진입 안정화 기능에 대한 스펙 문서를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->