### PR TITLE
feat(pipeline-review): 체크포인트 상태별 다음 행동 제공

### DIFF
--- a/.agent/specs/426.md
+++ b/.agent/specs/426.md
@@ -1,0 +1,115 @@
+# Frontend Spec: 체크포인트 상태별 다음 행동 안내
+
+## Goal
+
+파이프라인 리뷰 화면에서 체크포인트 조회 오류, 완료, 실패, 활성 리뷰 없음 상태마다 사용자가 바로 실행할 수 있는 다음 행동 CTA를 제공한다.
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A[시작: 파이프라인 리뷰 화면] --> B{체크포인트 조회}
+    B -->|로딩| C[로딩 안내]
+    B -->|오류| D[오류 안내 + 재시도 CTA]
+    B -->|성공| E{활성 reviewKind 존재?}
+    E -->|예| F{열린 task 존재?}
+    F -->|예| G[기존 도메인 확정 또는 피드백 제출]
+    F -->|아니오| H[열린 작업 없음 + 새로고침 CTA]
+    E -->|아니오| I{pipelineStatus}
+    I -->|SUCCEEDED| J[완료 안내 + 도메인팩 관리 CTA]
+    I -->|FAILED| K[실패 안내 + 업로드 재시도 CTA + 새로고침 CTA]
+    I -->|기타| L[활성 체크포인트 없음 + 새로고침/목록 CTA]
+```
+
+## Design Diff
+
+### As-is vs To-be
+
+| 영역 | As-is | To-be | 변경 내용 |
+|------|-------|-------|----------|
+| 조회 오류 | 텍스트 안내만 표시 | 재시도 버튼 제공 | 화면 안에서 체크포인트를 다시 조회할 수 있다 |
+| 파이프라인 완료 | 완료 설명만 표시 | 도메인팩 관리 화면 이동 CTA 제공 | 생성된 초안 확인 경로를 명확히 안내한다 |
+| 파이프라인 실패 | 실패 설명만 표시 | 업로드 재시도 및 현재 job 새로고침 CTA 제공 | 실패 후 재시작 또는 상태 재확인을 선택할 수 있다 |
+| 활성 체크포인트 없음 | 상태 설명만 표시 | 상태 설명과 새로고침/목록 이동 CTA 제공 | 대기 상태가 멈춘 것처럼 보이지 않게 한다 |
+| 열린 작업 없음 | 텍스트 안내만 표시 | 새로고침 CTA 제공 | resolved task만 있는 활성 세션에서도 다음 확인 행동을 제공한다 |
+
+## Component Tree
+
+```text
+PipelineReviewPage
+└─ PipelineReviewCheckpointCard
+   ├─ StateActionCard
+   │  └─ StateActions
+   ├─ DomainConfirmationCard
+   └─ HumanFeedbackCard
+```
+
+## API Integration
+
+### Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/v1/workspaces/{workspaceId}/pipeline-jobs/{pipelineJobId}/review-checkpoint` | 체크포인트 상태 및 리뷰 task 조회 |
+| POST | `/api/v1/workspaces/{workspaceId}/pipeline-jobs/{pipelineJobId}/review-checkpoint/domain-confirmation` | 도메인 후보 확정 |
+| POST | `/api/v1/workspaces/{workspaceId}/pipeline-jobs/{pipelineJobId}/review-checkpoint/human-feedback` | 클러스터 경계 피드백 제출 |
+
+기존 `frontend/src/features/pipeline-review/api/pipelineReviewApi.ts` 훅과 TanStack Query `refetch`를 사용한다. 신규 API는 만들지 않는다.
+
+## Data Flow
+
+```text
+PipelineReviewPage route params
+  -> PipelineReviewCheckpointCard props(workspaceId, pipelineJobId)
+  -> usePipelineReviewCheckpoint query
+  -> status branch
+  -> CTA: query.refetch() 또는 기존 라우트 Link
+```
+
+## 수정 대상 파일
+
+| 파일 | 변경 유형 | 설명 |
+|------|----------|------|
+| `frontend/src/features/pipeline-review/ui/PipelineReviewCheckpointCard.tsx` | modify | 상태별 CTA 렌더링, 기존 도메인 확정/피드백 플로우 유지 |
+| `frontend/src/features/pipeline-review/ui/PipelineReviewCheckpointCard.module.css` | modify | 상태 카드 CTA 레이아웃과 버튼/링크 스타일 추가 |
+| `frontend/src/features/pipeline-review/ui/PipelineReviewCheckpointCard.test.tsx` | modify | 오류, 완료, 실패, 활성 체크포인트 없음 상태별 CTA 검증 |
+
+## State Management
+
+- 서버 상태는 기존 `usePipelineReviewCheckpoint`의 TanStack Query 결과를 그대로 사용한다.
+- 재시도/새로고침 CTA는 `query.refetch()`를 호출한다.
+- 화면 이동 CTA는 검증된 기존 라우트만 사용한다.
+  - `/workspaces/{workspaceId}/domain-packs`
+  - `/workspaces/{workspaceId}/upload`
+- `pipelineJobId`가 없으면 기존처럼 렌더링하지 않는다.
+
+## Tests
+
+### Test Strategy
+
+| 구분 | 방법 | 도구 | 비고 |
+|------|------|------|------|
+| 컴포넌트 테스트 | 상태별 렌더링 및 CTA 동작 검증 | Vitest, React Testing Library | `PipelineReviewCheckpointCard.test.tsx` |
+| 회귀 테스트 | 기존 도메인 확정/피드백 제출 동작 유지 확인 | Vitest, React Testing Library | 기존 테스트 유지 |
+
+### Test Scenarios
+
+| # | 시나리오 | 조작 | 기대 결과 |
+|---|---------|------|----------|
+| 1 | 체크포인트 조회 실패 | `다시 시도` 클릭 | `query.refetch()`가 호출된다 |
+| 2 | `SUCCEEDED` + no review | `도메인팩 관리로 이동` 확인 | `/workspaces/{workspaceId}/domain-packs` 링크가 표시된다 |
+| 3 | `FAILED` + no review | `업로드 다시 시작` 확인 | `/workspaces/{workspaceId}/upload` 링크가 표시된다 |
+| 4 | no review 대기 상태 | `상태 새로고침` 클릭 | `query.refetch()`가 호출된다 |
+| 5 | 열린 작업 없는 활성 리뷰 | `작업 새로고침` 클릭 | `query.refetch()`가 호출된다 |
+| 6 | 도메인 확정/피드백 제출 | 기존 버튼 조작 | 기존 mutation 호출이 유지된다 |
+
+## Non-goals
+
+- 파이프라인 job 상세/목록 화면을 새로 만들지 않는다.
+- 신규 backend endpoint 또는 OpenAPI generated 파일을 변경하지 않는다.
+- 도메인팩 상세로 직접 이동하기 위한 pack id 추론을 하지 않는다.
+- 기존 도메인 확정, feedback replay API 계약을 변경하지 않는다.
+
+## Open Questions
+
+- 파이프라인 job 상세/목록 화면이 별도로 제공되면 실패 상태의 보조 CTA를 해당 화면으로 대체할 수 있다.

--- a/frontend/src/features/pipeline-review/ui/PipelineReviewCheckpointCard.module.css
+++ b/frontend/src/features/pipeline-review/ui/PipelineReviewCheckpointCard.module.css
@@ -8,11 +8,16 @@
 
 .stateCard {
   display: grid;
-  gap: var(--s-2);
+  gap: var(--s-4);
   padding: var(--s-5);
   color: var(--ink-2);
   font-size: 13px;
   letter-spacing: -0.1px;
+}
+
+.stateCopy {
+  display: grid;
+  gap: var(--s-2);
 }
 
 .stateTitle {
@@ -20,6 +25,68 @@
   font-size: 15px;
   font-weight: 540;
   letter-spacing: -0.14px;
+}
+
+.stateActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--s-2);
+}
+
+.stateActionPrimary,
+.stateActionSecondary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--s-2);
+  min-height: 36px;
+  padding: 0 14px;
+  border: 1px solid var(--ink);
+  border-radius: var(--r-pill);
+  font-size: 12px;
+  font-weight: 450;
+  letter-spacing: -0.1px;
+  line-height: 1;
+  text-decoration: none;
+  cursor: pointer;
+  transition:
+    opacity var(--transition-fast),
+    border-color var(--transition-fast),
+    background var(--transition-fast);
+}
+
+.stateActionPrimary svg,
+.stateActionSecondary svg {
+  width: 14px;
+  height: 14px;
+  flex: 0 0 auto;
+}
+
+.stateActionPrimary {
+  background: var(--ink);
+  color: var(--paper);
+}
+
+.stateActionSecondary {
+  background: var(--paper);
+  color: var(--ink);
+}
+
+.stateActionPrimary:hover,
+.stateActionSecondary:hover {
+  opacity: 0.84;
+}
+
+.stateActionPrimary:focus-visible,
+.stateActionSecondary:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.stateActionPrimary:disabled,
+.stateActionSecondary:disabled {
+  cursor: wait;
+  opacity: 0.56;
 }
 
 .card {
@@ -413,5 +480,15 @@
 
   .caseGrid {
     grid-template-columns: 1fr;
+  }
+
+  .stateActions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .stateActionPrimary,
+  .stateActionSecondary {
+    width: 100%;
   }
 }

--- a/frontend/src/features/pipeline-review/ui/PipelineReviewCheckpointCard.test.tsx
+++ b/frontend/src/features/pipeline-review/ui/PipelineReviewCheckpointCard.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   useConfirmPipelineDomain,
@@ -17,6 +18,14 @@ const mockedUseCheckpoint = vi.mocked(usePipelineReviewCheckpoint);
 const mockedUseConfirmDomain = vi.mocked(useConfirmPipelineDomain);
 const mockedUseSubmitFeedback = vi.mocked(useSubmitPipelineFeedback);
 
+function renderCard(props: { workspaceId?: number; pipelineJobId?: number } = { workspaceId: 1, pipelineJobId: 7 }) {
+  return render(
+    <MemoryRouter>
+      <PipelineReviewCheckpointCard {...props} />
+    </MemoryRouter>,
+  );
+}
+
 beforeEach(() => {
   mockedUseCheckpoint.mockReset();
   mockedUseConfirmDomain.mockReset();
@@ -29,7 +38,7 @@ describe("PipelineReviewCheckpointCard", () => {
   it("renders nothing without a pipeline job id", () => {
     mockedUseCheckpoint.mockReturnValue({ isLoading: false } as never);
 
-    const { container } = render(<PipelineReviewCheckpointCard workspaceId={1} />);
+    const { container } = renderCard({ workspaceId: 1 });
 
     expect(container).toBeEmptyDOMElement();
   });
@@ -37,17 +46,25 @@ describe("PipelineReviewCheckpointCard", () => {
   it("renders loading state", () => {
     mockedUseCheckpoint.mockReturnValue({ isLoading: true } as never);
 
-    render(<PipelineReviewCheckpointCard workspaceId={1} pipelineJobId={7} />);
+    renderCard();
 
     expect(screen.getByText("리뷰 체크포인트를 불러오는 중입니다.")).toBeInTheDocument();
   });
 
-  it("renders error state", () => {
-    mockedUseCheckpoint.mockReturnValue({ isLoading: false, isError: true } as never);
+  it("retries checkpoint loading from the error state", () => {
+    const refetch = vi.fn();
+    mockedUseCheckpoint.mockReturnValue({
+      isLoading: false,
+      isError: true,
+      isFetching: false,
+      refetch,
+    } as never);
 
-    render(<PipelineReviewCheckpointCard workspaceId={1} pipelineJobId={7} />);
+    renderCard();
 
     expect(screen.getByText("리뷰 체크포인트를 불러오지 못했습니다.")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "다시 시도" }));
+    expect(refetch).toHaveBeenCalledTimes(1);
   });
 
   it("confirms selected domain candidate", () => {
@@ -78,7 +95,7 @@ describe("PipelineReviewCheckpointCard", () => {
       },
     } as never);
 
-    render(<PipelineReviewCheckpointCard workspaceId={1} pipelineJobId={7} />);
+    renderCard();
 
     fireEvent.click(screen.getByRole("button", { name: /카드 상담/ }));
 
@@ -86,10 +103,13 @@ describe("PipelineReviewCheckpointCard", () => {
     expect(mutate).toHaveBeenCalledWith(101);
   });
 
-  it("shows an empty task state for active review sessions without open tasks", () => {
+  it("refreshes active review sessions without open tasks", () => {
+    const refetch = vi.fn();
     mockedUseCheckpoint.mockReturnValue({
       isLoading: false,
       isError: false,
+      isFetching: false,
+      refetch,
       data: {
         pipelineJobId: 7,
         pipelineStatus: "WAITING_DOMAIN_CONFIRMATION",
@@ -107,9 +127,11 @@ describe("PipelineReviewCheckpointCard", () => {
       },
     } as never);
 
-    render(<PipelineReviewCheckpointCard workspaceId={1} pipelineJobId={7} />);
+    renderCard();
 
     expect(screen.getByText("현재 확인할 리뷰 작업이 없습니다.")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "작업 새로고침" }));
+    expect(refetch).toHaveBeenCalledTimes(1);
   });
 
   it("submits pairwise feedback with conversation evidence", () => {
@@ -158,7 +180,7 @@ describe("PipelineReviewCheckpointCard", () => {
       },
     } as never);
 
-    render(<PipelineReviewCheckpointCard workspaceId={1} pipelineJobId={7} />);
+    renderCard();
 
     expect(screen.getByText("카드를 잃어버렸어요.")).toBeInTheDocument();
     expect(screen.getByText("고객: 결제 한도를 올리고 싶어요.")).toBeInTheDocument();
@@ -206,35 +228,74 @@ describe("PipelineReviewCheckpointCard", () => {
       },
     } as never);
 
-    render(<PipelineReviewCheckpointCard workspaceId={1} pipelineJobId={7} />);
+    renderCard();
 
     expect(screen.getByText("같은 클러스터에서 서로 다른 workflow 후보로 갈라졌습니다.")).toBeInTheDocument();
     expect(screen.getByText("운영자 확인이 필요한 후보입니다.")).toBeInTheDocument();
     expect(screen.getAllByText("업무 내용을 확인할 수 없습니다.")).toHaveLength(3);
   });
 
-  it("shows completed state when there is no active review kind", () => {
+  it("shows completed state with a domain pack management CTA when there is no active review kind", () => {
+    const refetch = vi.fn();
     mockedUseCheckpoint.mockReturnValue({
       isLoading: false,
       isError: false,
+      isFetching: false,
+      refetch,
       data: { pipelineJobId: 7, pipelineStatus: "SUCCEEDED", reviewKind: null, tasks: [] },
     } as never);
 
-    render(<PipelineReviewCheckpointCard workspaceId={1} pipelineJobId={7} />);
+    renderCard();
 
     expect(screen.getByText("리뷰 체크포인트가 완료되었습니다.")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "도메인팩 관리로 이동" })).toHaveAttribute(
+      "href",
+      "/workspaces/1/domain-packs",
+    );
+    fireEvent.click(screen.getByRole("button", { name: "상태 새로고침" }));
+    expect(refetch).toHaveBeenCalledTimes(1);
   });
 
-  it("shows failed state when pipeline failed without an active review kind", () => {
+  it("shows failed state with upload retry and job refresh actions", () => {
+    const refetch = vi.fn();
     mockedUseCheckpoint.mockReturnValue({
       isLoading: false,
       isError: false,
+      isFetching: false,
+      refetch,
       data: { pipelineJobId: 7, pipelineStatus: "FAILED", reviewKind: null, tasks: [] },
     } as never);
 
-    render(<PipelineReviewCheckpointCard workspaceId={1} pipelineJobId={7} />);
+    renderCard();
 
     expect(screen.getByText("파이프라인이 실패했습니다.")).toBeInTheDocument();
-    expect(screen.getByText("실패 원인은 파이프라인 job 상세에서 확인할 수 있습니다.")).toBeInTheDocument();
+    expect(screen.getByText("업로드를 다시 시작하거나 현재 job 상태를 다시 조회할 수 있습니다.")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "업로드 다시 시작" })).toHaveAttribute(
+      "href",
+      "/workspaces/1/upload",
+    );
+    fireEvent.click(screen.getByRole("button", { name: "현재 job 새로고침" }));
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows refresh and list navigation for no active checkpoint waiting states", () => {
+    const refetch = vi.fn();
+    mockedUseCheckpoint.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      isFetching: false,
+      refetch,
+      data: { pipelineJobId: 7, pipelineStatus: "RUNNING", reviewKind: null, tasks: [] },
+    } as never);
+
+    renderCard();
+
+    expect(screen.getByText("활성 리뷰 체크포인트가 없습니다.")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "도메인팩 목록 보기" })).toHaveAttribute(
+      "href",
+      "/workspaces/1/domain-packs",
+    );
+    fireEvent.click(screen.getByRole("button", { name: "상태 새로고침" }));
+    expect(refetch).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/features/pipeline-review/ui/PipelineReviewCheckpointCard.tsx
+++ b/frontend/src/features/pipeline-review/ui/PipelineReviewCheckpointCard.tsx
@@ -1,10 +1,18 @@
-import { useMemo, useState } from "react";
+import { useMemo, useState, type ReactNode } from "react";
+import {
+  ArrowRightIcon,
+  ListChecksIcon,
+  RefreshCwIcon,
+  UploadIcon,
+} from "lucide-react";
+import { Link } from "react-router-dom";
 import {
   type ReviewCaseContext,
   useConfirmPipelineDomain,
   usePipelineReviewCheckpoint,
   useSubmitPipelineFeedback,
 } from "../api/pipelineReviewApi";
+import { domainPackListPath } from "@/shared/lib/domainPackRoutes";
 import styles from "./PipelineReviewCheckpointCard.module.css";
 
 interface Props {
@@ -25,7 +33,7 @@ export function PipelineReviewCheckpointCard({ workspaceId, pipelineJobId }: Pro
   const allFeedbackResolved =
     openTasks.length > 0 && openTasks.every((task) => feedbackDecisions[task.id] !== undefined);
 
-  if (pipelineJobId == null) {
+  if (workspaceId == null || pipelineJobId == null) {
     return null;
   }
 
@@ -34,24 +42,99 @@ export function PipelineReviewCheckpointCard({ workspaceId, pipelineJobId }: Pro
   }
 
   if (query.isError) {
-    return <section className={styles.stateCard}>리뷰 체크포인트를 불러오지 못했습니다.</section>;
+    return (
+      <StateActionCard
+        title="리뷰 체크포인트를 불러오지 못했습니다."
+        description="네트워크 상태를 확인한 뒤 같은 화면에서 다시 조회할 수 있습니다."
+      >
+        <button
+          type="button"
+          className={styles.stateActionPrimary}
+          disabled={query.isFetching}
+          onClick={() => void query.refetch()}
+        >
+          <RefreshCwIcon aria-hidden="true" />
+          다시 시도
+        </button>
+      </StateActionCard>
+    );
   }
 
   if (!query.data?.reviewKind) {
     return (
-      <section className={styles.stateCard}>
-        <strong className={styles.stateTitle}>{checkpointStateTitle(query.data?.pipelineStatus)}</strong>
-        <span>{checkpointStateDescription(query.data?.pipelineStatus)}</span>
-      </section>
+      <StateActionCard
+        title={checkpointStateTitle(query.data?.pipelineStatus)}
+        description={checkpointStateDescription(query.data?.pipelineStatus)}
+      >
+        {query.data?.pipelineStatus === "SUCCEEDED" ? (
+          <>
+            <Link to={domainPackListPath(workspaceId)} className={styles.stateActionPrimary}>
+              <ListChecksIcon aria-hidden="true" />
+              도메인팩 관리로 이동
+            </Link>
+            <button
+              type="button"
+              className={styles.stateActionSecondary}
+              disabled={query.isFetching}
+              onClick={() => void query.refetch()}
+            >
+              <RefreshCwIcon aria-hidden="true" />
+              상태 새로고침
+            </button>
+          </>
+        ) : query.data?.pipelineStatus === "FAILED" ? (
+          <>
+            <Link to={`/workspaces/${workspaceId}/upload`} className={styles.stateActionPrimary}>
+              <UploadIcon aria-hidden="true" />
+              업로드 다시 시작
+            </Link>
+            <button
+              type="button"
+              className={styles.stateActionSecondary}
+              disabled={query.isFetching}
+              onClick={() => void query.refetch()}
+            >
+              <RefreshCwIcon aria-hidden="true" />
+              현재 job 새로고침
+            </button>
+          </>
+        ) : (
+          <>
+            <button
+              type="button"
+              className={styles.stateActionPrimary}
+              disabled={query.isFetching}
+              onClick={() => void query.refetch()}
+            >
+              <RefreshCwIcon aria-hidden="true" />
+              상태 새로고침
+            </button>
+            <Link to={domainPackListPath(workspaceId)} className={styles.stateActionSecondary}>
+              <ArrowRightIcon aria-hidden="true" />
+              도메인팩 목록 보기
+            </Link>
+          </>
+        )}
+      </StateActionCard>
     );
   }
 
   if (openTasks.length === 0) {
     return (
-      <section className={styles.stateCard}>
-        <strong className={styles.stateTitle}>현재 확인할 리뷰 작업이 없습니다.</strong>
-        <span>열린 작업이 생기면 이 화면에서 바로 이어서 검토할 수 있습니다.</span>
-      </section>
+      <StateActionCard
+        title="현재 확인할 리뷰 작업이 없습니다."
+        description="열린 작업이 생기면 이 화면에서 바로 이어서 검토할 수 있습니다."
+      >
+        <button
+          type="button"
+          className={styles.stateActionPrimary}
+          disabled={query.isFetching}
+          onClick={() => void query.refetch()}
+        >
+          <RefreshCwIcon aria-hidden="true" />
+          작업 새로고침
+        </button>
+      </StateActionCard>
     );
   }
 
@@ -170,6 +253,26 @@ export function PipelineReviewCheckpointCard({ workspaceId, pipelineJobId }: Pro
   );
 }
 
+function StateActionCard({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className={styles.stateCard}>
+      <div className={styles.stateCopy}>
+        <strong className={styles.stateTitle}>{title}</strong>
+        <span>{description}</span>
+      </div>
+      <div className={styles.stateActions}>{children}</div>
+    </section>
+  );
+}
+
 function CaseContextCard({
   label,
   context,
@@ -274,7 +377,7 @@ function checkpointStateDescription(pipelineStatus?: string): string {
     return "생성된 Domain Pack 초안에서 최종 검토를 이어갈 수 있습니다.";
   }
   if (pipelineStatus === "FAILED") {
-    return "실패 원인은 파이프라인 job 상세에서 확인할 수 있습니다.";
+    return "업로드를 다시 시작하거나 현재 job 상태를 다시 조회할 수 있습니다.";
   }
   return "파이프라인이 검토 입력을 기다리는 상태가 되면 이 화면에 작업이 표시됩니다.";
 }


### PR DESCRIPTION
## Summary
- 체크포인트 조회 실패, 완료, 실패, 활성 체크포인트 없음 상태에 재시도/이동 CTA를 제공합니다.
- 완료 상태는 도메인팩 관리 화면으로, 실패 상태는 업로드 재시작과 현재 job 새로고침으로 이어지게 했습니다.
- 이슈 요구사항과 검증 기준을 `.agent/specs/426.md`에 정리했습니다.

## Validation
- `cd frontend && pnpm test -- PipelineReviewCheckpointCard.test.tsx`
- `cd frontend && pnpm exec tsc --noEmit --pretty false`
- `cd frontend && pnpm exec eslint src/features/pipeline-review/ui/PipelineReviewCheckpointCard.tsx src/features/pipeline-review/ui/PipelineReviewCheckpointCard.test.tsx`
- `cd frontend && pnpm test -- PipelineReview`
- `cd frontend && pnpm build`
- `git diff --check`
- `git diff --cached --check`

## Notes
- `cd frontend && pnpm lint` still reports existing unrelated lint errors outside this diff, primarily workflow/auth test `no-explicit-any`, React hook lint findings, and an unused variable in `WorkspaceShell.tsx`.

Closes #426