### PR TITLE
feat(domain-pack): 상세 진입 시 기본 버전 선택

### DIFF
--- a/.agent/specs/428.md
+++ b/.agent/specs/428.md
@@ -1,0 +1,111 @@
+# Issue 428 [FE] 도메인팩 상세 기본 버전 자동 선택
+
+## Goal
+
+`versionId` 없이 도메인팩 상세 화면에 진입한 사용자가 별도 클릭 없이 적절한 버전 상세를 바로 확인하고, 자동 선택된 버전이 URL query와 버전 목록 active 상태에 함께 반영되도록 한다.
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A["도메인팩 카드 또는 공유 링크에서 상세 진입"] --> B{"URL versionId 존재?"}
+    B -->|Yes| C["해당 versionId 상세 조회"]
+    B -->|No| D["Pack 상세의 versions/currentVersionId 확인"]
+    D --> E{"선택 가능한 버전 존재?"}
+    E -->|No| F["기존 빈 상태 유지"]
+    E -->|Yes| G["기본 버전 선택"]
+    G --> H["URL query에 versionId replace 반영"]
+    H --> I["버전 상세와 목록 active 상태 표시"]
+    C --> I
+```
+
+## Design Diff
+
+### As-is vs To-be
+
+| 영역 | As-is | To-be | 변경 내용 |
+|------|-------|-------|----------|
+| 상세 진입 | `versionId`가 없으면 상세 패널이 "버전을 선택하세요." placeholder 표시 | 기본 버전을 즉시 선택해 상세 표시 | 탐색 클릭 1회 제거 |
+| URL 상태 | 기본 버전 선택이 URL에 반영되지 않음 | 자동 선택된 `versionId`를 query에 `replace` 반영 | 공유/새로고침 안정화 |
+| 버전 목록 | `selectedId`가 없을 때 tab stop만 내부 계산 | 기본 버전이 active 선택값으로 전달 | 상세 패널, 목록, URL 일관성 |
+| 빈 버전 pack | 기존 빈 상태 | 기존 빈 상태 유지 | 안전한 fallback 유지 |
+
+## Component Tree
+
+```text
+DomainPackSummaryPage
+├─ DomainPackSummaryPageContent
+│  ├─ usePackDetail
+│  ├─ resolveDefaultVersionId
+│  ├─ useVersionDetail(effectiveSelectedVersionId)
+│  ├─ VersionListPanel(selectedId=effectiveSelectedVersionId)
+│  └─ SummaryDetailPanel(query=selected version query)
+```
+
+## API Integration
+
+### Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/v1/workspaces/{workspaceId}/domain-packs/{packId}` | Pack 상세와 버전 요약 목록 조회 |
+| GET | `/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}` | 선택 버전 상세 조회 |
+
+새 endpoint는 추가하지 않는다. `frontend/src/features/domain-pack-summary-read/model/usePackDetail.ts`의 기존 generated API hook을 사용한다.
+
+## Data Flow
+
+```text
+URL search versionId
+  └─ 없으면 DomainPackDetail.versions/currentVersionId에서 기본 versionId 계산
+      ├─ useVersionDetail 조회 파라미터
+      ├─ VersionListPanel selectedId
+      ├─ breadcrumb version label
+      └─ URLSearchParams versionId replace
+```
+
+## 수정 대상 파일
+
+| 파일 | 변경 유형 | 설명 |
+|------|----------|------|
+| `frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.tsx` | modify | 기본 버전 선택 우선순위 계산 및 URL query 자동 반영 |
+| `frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.test.tsx` | modify | 기본 버전 선택, URL 반영, 빈 버전 유지 테스트 |
+
+## State Management
+
+- 서버 상태는 기존 `usePackDetail`, `useVersionDetail` TanStack Query 흐름을 유지한다.
+- 클라이언트 상태는 별도 store 없이 URL query를 단일 공유 가능한 선택 상태로 사용한다.
+- `versionId`가 URL에 있으면 사용자의 명시 선택으로 보고 자동 선택으로 덮어쓰지 않는다.
+- `versionId`가 없을 때 기본 선택 우선순위는 다음과 같다.
+  1. `currentVersionId`가 `versions`에 존재하면 현재 배포중 버전
+  2. `lifecycleStatus === "DRAFT"` 중 최신 버전
+  3. 전체 버전 중 최신 버전
+- 최신 판정은 `versionNo`, `createdAt`, `versionId` 순으로 큰 값을 우선한다.
+
+## Tests
+
+### Test Strategy
+
+| 구분 | 방법 | 도구 | 비고 |
+|------|------|------|------|
+| 통합 테스트 | 페이지 렌더링 후 route/search와 hook 호출 검증 | Vitest + React Testing Library | URL query 자동 반영과 selected version query 확인 |
+| 회귀 테스트 | 빈 버전 pack에서 `versionId`가 추가되지 않는지 검증 | Vitest + React Testing Library | 기존 빈 상태 보존 |
+
+### Acceptance Criteria
+
+- `/workspaces/{wsId}/domain-packs/{packId}` 진입 시 버전이 있으면 기본 버전 상세 조회가 시작된다.
+- 자동 선택된 기본 버전은 URL `versionId`, `VersionListPanel.selectedId`, breadcrumb 버전 라벨에 일관되게 반영된다.
+- 배포중 버전이 있으면 draft나 최신 버전보다 우선 선택된다.
+- 배포중 버전이 없고 draft가 있으면 최신 draft가 선택된다.
+- draft도 없으면 최신 버전이 선택된다.
+- 버전이 없는 pack은 URL을 변경하지 않고 기존 빈 상태를 유지한다.
+
+## Non-goals
+
+- Backend API나 Domain Pack 버전 정렬 계약 변경은 하지 않는다.
+- 유효하지 않거나 존재하지 않는 `versionId` query의 복구 정책은 변경하지 않는다.
+- 버전 목록 UI 스타일 변경은 하지 않는다.
+
+## Open Questions
+
+- 없음. 이슈 본문에 명시된 정책 범위 안에서 frontend metadata 기반 기본 선택으로 해결한다.

--- a/frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.test.tsx
+++ b/frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.test.tsx
@@ -317,6 +317,71 @@ describe("DomainPackSummaryPage", () => {
     expect(screen.getByTestId("selected-version-id")).toHaveTextContent("6");
   });
 
+  it("versionNo가 같으면 생성일이 더 최신인 draft를 기본 선택한다", async () => {
+    vi.mocked(usePackDetail).mockReturnValue(
+      makePackQuery({
+        data: {
+          packId: 2,
+          name: "CS Pack",
+          code: "CS",
+          versions: [
+            {
+              versionId: 5,
+              versionNo: 2,
+              lifecycleStatus: "DRAFT",
+              createdAt: "2026-05-30T00:00:00+09:00",
+            },
+            {
+              versionId: 6,
+              versionNo: 2,
+              lifecycleStatus: "DRAFT",
+              createdAt: "2026-05-31T00:00:00+09:00",
+            },
+          ],
+        },
+      }),
+    );
+
+    renderPage("/workspaces/1/domain-packs/2");
+
+    await waitFor(() =>
+      expect(screen.getByTestId("location")).toHaveTextContent(
+        "/workspaces/1/domain-packs/2?versionId=6",
+      ),
+    );
+    expect(useVersionDetail).toHaveBeenCalledWith(1, 2, 6);
+  });
+
+  it("versionNo와 생성일 비교가 불가능하면 versionId가 더 큰 draft를 기본 선택한다", async () => {
+    vi.mocked(usePackDetail).mockReturnValue(
+      makePackQuery({
+        data: {
+          packId: 2,
+          name: "CS Pack",
+          code: "CS",
+          versions: [
+            { versionId: 5, versionNo: 2, lifecycleStatus: "DRAFT" },
+            {
+              versionId: 6,
+              versionNo: 2,
+              lifecycleStatus: "DRAFT",
+              createdAt: "invalid-date",
+            },
+          ],
+        },
+      }),
+    );
+
+    renderPage("/workspaces/1/domain-packs/2");
+
+    await waitFor(() =>
+      expect(screen.getByTestId("location")).toHaveTextContent(
+        "/workspaces/1/domain-packs/2?versionId=6",
+      ),
+    );
+    expect(useVersionDetail).toHaveBeenCalledWith(1, 2, 6);
+  });
+
   it("버전이 없는 pack은 versionId를 자동 추가하지 않는다", async () => {
     vi.mocked(usePackDetail).mockReturnValue(
       makePackQuery({
@@ -481,6 +546,53 @@ describe("DomainPackSummaryPage", () => {
       "검토 중인 버전이 운영 버전으로 적용되었습니다.",
     );
     expect(toast.error).not.toHaveBeenCalledWith("검토 중인 버전을 적용하지 못했습니다.");
+  });
+
+  it("Draft 적용 성공 응답이 data.id 형태여도 적용된 버전으로 이동한다", async () => {
+    let activateOnSuccess:
+      | ((
+          result: unknown,
+          variables: { workspaceId: number; packId: number; versionId: number },
+          context: unknown,
+        ) => unknown)
+      | undefined;
+    const mutate = vi.fn((variables) => {
+      void activateOnSuccess?.({ data: { id: 7 } }, variables, undefined);
+    });
+    vi.mocked(useActivate).mockImplementation((options) => {
+      activateOnSuccess = options?.mutation?.onSuccess;
+      return {
+        mutate,
+        isPending: false,
+        variables: undefined,
+      } as unknown as ReturnType<typeof useActivate>;
+    });
+    vi.mocked(usePackDetail).mockReturnValue(
+      makePackQuery({
+        data: {
+          packId: 2,
+          name: "CS Pack",
+          code: "CS",
+          versions: [{ versionId: 5, versionNo: 3, lifecycleStatus: "DRAFT" }],
+        },
+        refetch: vi.fn(),
+      }),
+    );
+    vi.mocked(useVersionDetail).mockReturnValue(
+      makePackQuery({
+        data: { versionId: 5, lifecycleStatus: "DRAFT" },
+        refetch: vi.fn(),
+      }),
+    );
+
+    renderPage("/workspaces/1/domain-packs/2?versionId=5");
+    fireEvent.click(screen.getByRole("button", { name: "apply draft" }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("location")).toHaveTextContent(
+        "/workspaces/1/domain-packs/2?versionId=7",
+      ),
+    );
   });
 
   it("Draft 적용 실패 시 상담사 용어의 실패 toast를 띄운다", () => {

--- a/frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.test.tsx
+++ b/frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.test.tsx
@@ -50,8 +50,15 @@ vi.mock("@/shared/ui/ostone/atoms/ErrorState", () => ({
 vi.mock("@/features/domain-pack-summary-read", () => ({
   usePackDetail: vi.fn(),
   useVersionDetail: vi.fn(),
-  VersionListPanel: ({ onSelect }: { onSelect: (versionId: number) => void }) => (
+  VersionListPanel: ({
+    selectedId,
+    onSelect,
+  }: {
+    selectedId: number | null;
+    onSelect: (versionId: number) => void;
+  }) => (
     <div data-testid="version-list-panel">
+      <span data-testid="selected-version-id">{selectedId ?? "none"}</span>
       <button type="button" onClick={() => onSelect(4)}>
         select version
       </button>
@@ -208,14 +215,116 @@ describe("DomainPackSummaryPage", () => {
     expect(screen.getByTestId("shell-crumbs")).not.toHaveTextContent("WS · 1");
   });
 
-  it("도메인팩 상위 route에서는 최신 버전으로 자동 이동하지 않는다", async () => {
+  it("versionId가 없으면 배포중 버전을 기본 선택하고 URL에 반영한다", async () => {
     vi.mocked(usePackDetail).mockReturnValue(
       makePackQuery({
         data: {
           packId: 2,
           name: "CS Pack",
           code: "CS",
-          versions: [{ versionId: 3, versionNo: 1 }],
+          currentVersionId: 3,
+          versions: [
+            { versionId: 5, versionNo: 3, lifecycleStatus: "DRAFT" },
+            { versionId: 3, versionNo: 2, lifecycleStatus: "PUBLISHED" },
+          ],
+        },
+      }),
+    );
+
+    renderPage("/workspaces/1/domain-packs/2");
+
+    await waitFor(() =>
+      expect(screen.getByTestId("location")).toHaveTextContent(
+        "/workspaces/1/domain-packs/2?versionId=3",
+      ),
+    );
+    expect(useVersionDetail).toHaveBeenCalledWith(1, 2, 3);
+    expect(screen.getByTestId("selected-version-id")).toHaveTextContent("3");
+    expect(screen.getByTestId("shell-crumbs")).toHaveTextContent("도메인팩 / CS Pack / #2");
+  });
+
+  it("배포중 버전이 없으면 최신 draft 버전을 기본 선택한다", async () => {
+    vi.mocked(usePackDetail).mockReturnValue(
+      makePackQuery({
+        data: {
+          packId: 2,
+          name: "CS Pack",
+          code: "CS",
+          versions: [
+            { versionId: 5, versionNo: 2, lifecycleStatus: "DRAFT" },
+            { versionId: 4, versionNo: 1, lifecycleStatus: "PUBLISHED" },
+          ],
+        },
+      }),
+    );
+
+    renderPage("/workspaces/1/domain-packs/2");
+
+    await waitFor(() =>
+      expect(screen.getByTestId("location")).toHaveTextContent(
+        "/workspaces/1/domain-packs/2?versionId=5",
+      ),
+    );
+    expect(useVersionDetail).toHaveBeenCalledWith(1, 2, 5);
+    expect(screen.getByTestId("selected-version-id")).toHaveTextContent("5");
+  });
+
+  it("기본 버전을 URL에 반영할 때 기존 query parameter를 유지한다", async () => {
+    vi.mocked(usePackDetail).mockReturnValue(
+      makePackQuery({
+        data: {
+          packId: 2,
+          name: "CS Pack",
+          code: "CS",
+          versions: [{ versionId: 5, versionNo: 2, lifecycleStatus: "DRAFT" }],
+        },
+      }),
+    );
+
+    renderPage("/workspaces/1/domain-packs/2?tab=history");
+
+    await waitFor(() =>
+      expect(screen.getByTestId("location")).toHaveTextContent(
+        "/workspaces/1/domain-packs/2?tab=history&versionId=5",
+      ),
+    );
+    expect(useVersionDetail).toHaveBeenCalledWith(1, 2, 5);
+  });
+
+  it("배포중 버전과 draft가 없으면 최신 버전을 기본 선택한다", async () => {
+    vi.mocked(usePackDetail).mockReturnValue(
+      makePackQuery({
+        data: {
+          packId: 2,
+          name: "CS Pack",
+          code: "CS",
+          versions: [
+            { versionId: 4, versionNo: 1, lifecycleStatus: "PUBLISHED" },
+            { versionId: 6, versionNo: 3, lifecycleStatus: "PUBLISHED" },
+          ],
+        },
+      }),
+    );
+
+    renderPage("/workspaces/1/domain-packs/2");
+
+    await waitFor(() =>
+      expect(screen.getByTestId("location")).toHaveTextContent(
+        "/workspaces/1/domain-packs/2?versionId=6",
+      ),
+    );
+    expect(useVersionDetail).toHaveBeenCalledWith(1, 2, 6);
+    expect(screen.getByTestId("selected-version-id")).toHaveTextContent("6");
+  });
+
+  it("버전이 없는 pack은 versionId를 자동 추가하지 않는다", async () => {
+    vi.mocked(usePackDetail).mockReturnValue(
+      makePackQuery({
+        data: {
+          packId: 2,
+          name: "CS Pack",
+          code: "CS",
+          versions: [],
         },
       }),
     );
@@ -226,6 +335,7 @@ describe("DomainPackSummaryPage", () => {
       expect(screen.getByTestId("location")).toHaveTextContent("/workspaces/1/domain-packs/2"),
     );
     expect(useVersionDetail).toHaveBeenCalledWith(1, 2, null);
+    expect(screen.getByTestId("selected-version-id")).toHaveTextContent("none");
   });
 
   it("query string versionId로 선택 버전 상세를 조회한다", () => {

--- a/frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.tsx
@@ -18,7 +18,11 @@ import {
   VersionListPanel,
   SummaryDetailPanel,
 } from "@/features/domain-pack-summary-read";
-import type { DomainPackDetail, DomainPackVersionDetail } from "@/entities/domain-pack";
+import type {
+  DomainPackDetail,
+  DomainPackVersionDetail,
+  DomainPackVersionSummary,
+} from "@/entities/domain-pack";
 import styles from "./domain-pack-summary-page.module.css";
 
 export function DomainPackSummaryPage() {
@@ -64,6 +68,9 @@ function DomainPackSummaryPageContent({
   setSearch,
 }: ContentProps) {
   const packQuery = usePackDetail(wsId, packId) as UseQueryResult<DomainPackDetail>;
+  const pack = packQuery.data;
+  const defaultVersionId = resolveDefaultVersionId(pack);
+  const effectiveSelectedVersionId = selectedVersionId ?? defaultVersionId;
 
   useEffect(() => {
     if (!packQuery.isError) return;
@@ -71,15 +78,26 @@ function DomainPackSummaryPageContent({
     toast.error(is404 ? "Pack을 찾을 수 없습니다." : "Pack 정보를 불러오지 못했습니다.");
   }, [packQuery.isError, packQuery.error]);
 
+  useEffect(() => {
+    if (selectedVersionId !== null || defaultVersionId === null) return;
+    setSearch(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        next.set("versionId", String(defaultVersionId));
+        return next;
+      },
+      { replace: true },
+    );
+  }, [defaultVersionId, selectedVersionId, setSearch]);
+
   const versionQuery = useVersionDetail(
     wsId,
     packId,
-    selectedVersionId,
+    effectiveSelectedVersionId,
   ) as UseQueryResult<DomainPackVersionDetail>;
-  const pack = packQuery.data;
   const currentVersionId = pack?.currentVersionId ?? null;
   const selectedVersionNo =
-    pack?.versions?.find((v) => v.versionId === selectedVersionId)?.versionNo ?? null;
+    pack?.versions?.find((v) => v.versionId === effectiveSelectedVersionId)?.versionNo ?? null;
 
   const deployMutation = useDeploy({
     mutation: {
@@ -172,10 +190,10 @@ function DomainPackSummaryPageContent({
         href: domainPackPath(wsId, packId),
       },
     ];
-    if (selectedVersionId !== null && selectedVersionNo !== null) {
+    if (effectiveSelectedVersionId !== null && selectedVersionNo !== null) {
       items.push({
         label: `#${selectedVersionNo}`,
-        href: withVersionSearch(domainPackPath(wsId, packId), selectedVersionId),
+        href: withVersionSearch(domainPackPath(wsId, packId), effectiveSelectedVersionId),
       });
     }
     return items;
@@ -218,7 +236,7 @@ function DomainPackSummaryPageContent({
         <div className={styles.twoPane}>
           <VersionListPanel
             query={packQuery}
-            selectedId={selectedVersionId}
+            selectedId={effectiveSelectedVersionId}
             currentVersionId={currentVersionId}
             onSelect={handleSelectVersion}
           />
@@ -258,6 +276,57 @@ function resolveVersionActionErrorMessage(error: unknown, fallback: string): str
     return error.message;
   }
   return fallback;
+}
+
+function resolveDefaultVersionId(pack?: DomainPackDetail): number | null {
+  const versions = pack?.versions?.filter((version) => version.versionId != null) ?? [];
+  if (versions.length === 0) return null;
+
+  if (
+    pack?.currentVersionId != null &&
+    versions.some((version) => version.versionId === pack.currentVersionId)
+  ) {
+    return pack.currentVersionId;
+  }
+
+  return (
+    pickLatestVersionId(versions.filter((version) => version.lifecycleStatus === "DRAFT")) ??
+    pickLatestVersionId(versions)
+  );
+}
+
+function pickLatestVersionId(versions: DomainPackVersionSummary[]): number | null {
+  const latest = versions.reduce<DomainPackVersionSummary | null>((best, version) => {
+    if (version.versionId == null) return best;
+    if (best === null) return version;
+    return compareVersionSummary(version, best) > 0 ? version : best;
+  }, null);
+
+  return latest?.versionId ?? null;
+}
+
+function compareVersionSummary(
+  left: DomainPackVersionSummary,
+  right: DomainPackVersionSummary,
+): number {
+  const leftVersionNo = left.versionNo ?? Number.NEGATIVE_INFINITY;
+  const rightVersionNo = right.versionNo ?? Number.NEGATIVE_INFINITY;
+  if (leftVersionNo !== rightVersionNo) return leftVersionNo - rightVersionNo;
+
+  const leftCreatedAt = parseTime(left.createdAt);
+  const rightCreatedAt = parseTime(right.createdAt);
+  if (leftCreatedAt !== rightCreatedAt) return leftCreatedAt - rightCreatedAt;
+
+  return (
+    (left.versionId ?? Number.NEGATIVE_INFINITY) -
+    (right.versionId ?? Number.NEGATIVE_INFINITY)
+  );
+}
+
+function parseTime(value?: string): number {
+  if (value == null) return Number.NEGATIVE_INFINITY;
+  const time = Date.parse(value);
+  return Number.isNaN(time) ? Number.NEGATIVE_INFINITY : time;
 }
 
 function resolveActivatedVersionId(result: unknown, fallback: number): number {


### PR DESCRIPTION
## Summary
- `versionId` 없이 도메인팩 상세에 진입하면 배포중 버전, 최신 draft, 최신 버전 순으로 기본 버전을 선택합니다.
- 기본 선택값을 버전 상세 조회, 버전 목록 active 상태, breadcrumb, URL query에 일관되게 반영합니다.
- 버전이 없는 pack은 기존 빈 상태를 유지하고, 이슈 요구사항을 `.agent/specs/428.md`에 정리했습니다.

## Validation
- `cd frontend && pnpm test -- DomainPackSummaryPage.test.tsx --run`
- `cd frontend && pnpm exec eslint src/pages/domain-pack/ui/DomainPackSummaryPage.tsx src/pages/domain-pack/ui/DomainPackSummaryPage.test.tsx`
- `cd frontend && pnpm build`
- `cd frontend && pnpm test -- --run`
- `cd frontend && pnpm test -- --coverage DomainPackSummaryPage.test.tsx --run`
- `git diff --check HEAD~1 HEAD`

## Notes
- `cd frontend && pnpm lint` still reports existing unrelated lint errors outside this diff, primarily workflow/auth test `no-explicit-any`, React hook lint findings, and unused variables.
- SonarCloud quality gate passes after the coverage-focused test follow-up.

Closes #428
