### PR TITLE
feat(consultation): 상담 이력 검색 제출 흐름 제공

### DIFF
--- a/.agent/specs/430.md
+++ b/.agent/specs/430.md
@@ -1,0 +1,143 @@
+# Frontend Spec: 상담 이력 검색 입력 경험 개선
+
+## Goal
+
+상담 이력 화면의 키워드 입력이 매 글자마다 URL과 목록 조회를 갱신하지 않고, 사용자가 Enter 또는 검색 버튼으로 의도를 확정했을 때만 검색을 실행하도록 개선한다.
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A[상담 이력 화면 진입] --> B[키워드 입력]
+    B --> C{검색 제출?}
+    C -->|No| D[입력값만 화면에 유지]
+    C -->|Enter 또는 검색 버튼| E[URL q 갱신 및 page 초기화]
+    E --> F[상담 이력 목록 재조회]
+    A --> G[상태/날짜/상담사 필터 변경]
+    G --> H[즉시 URL 갱신 및 page 초기화]
+    H --> F
+    A --> I[필터 초기화]
+    I --> J[기존 초기화 동작 유지]
+    J --> F
+```
+
+## Design Diff
+
+### As-is vs To-be
+
+| 영역 | As-is | To-be | 변경 내용 |
+|------|-------|-------|----------|
+| 키워드 검색 | 입력 `onChange`마다 `q` query 갱신 | Enter 또는 검색 버튼 제출 시 `q` query 갱신 | 입력 중 URL/API 갱신 빈도 감소 |
+| 상태/날짜/상담사 필터 | 변경 즉시 query 갱신 | 기존처럼 변경 즉시 query 갱신 | 비키워드 필터의 예측 가능한 즉시 반영 유지 |
+| 필터 초기화 | query와 page 초기화 | 기존처럼 query와 page 초기화 | 기존 페이지네이션/초기화 흐름 유지 |
+
+## Component Tree
+
+```text
+ChatHistoryPage
+├─ SessionList
+│  ├─ KeywordSearchForm
+│  │  ├─ SearchInput
+│  │  └─ SearchButton
+│  ├─ StatusFilter
+│  ├─ DateRangeFilters
+│  ├─ CounselorFilter
+│  ├─ ResetFiltersButton
+│  ├─ SessionCard[]
+│  └─ PaginationControls
+└─ MessageHistory
+```
+
+## API Integration
+
+### Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/v1/workspaces/{workspaceId}/consultation/sessions` | 상담 이력 목록 조회 |
+
+### Query Key Pattern
+
+- `frontend/src/features/consultation/api/chatHistoryKeys.ts`의 상담 이력 목록 query key는 URL search params에서 복원된 필터 값을 기반으로 유지한다.
+- 키워드 입력 중에는 `q` search param을 갱신하지 않으므로 `useChatSessions` 파라미터와 query key도 변경되지 않는다.
+
+## Data Flow
+
+```text
+SessionList local keyword draft
+  ├─ input change: local draft만 갱신
+  ├─ form submit: onFiltersChange({ keyword }) 호출
+  └─ filters.keyword 변경: URL에서 복원된 값으로 draft 동기화
+
+ChatHistoryPage
+  ├─ onFiltersChange 수신
+  ├─ URL search params 갱신
+  ├─ page query 제거
+  └─ useChatSessions 파라미터 변경
+```
+
+## 수정 대상 파일
+
+| 파일 | 변경 유형 | 설명 |
+|------|----------|------|
+| `frontend/src/features/consultation/ui/chat-history/SessionList.tsx` | modify | 키워드 입력을 로컬 draft로 분리하고 Enter/검색 버튼 제출 시에만 필터 변경 전달 |
+| `frontend/src/features/consultation/ui/chat-history/SessionList.module.css` | modify | 검색 제출 버튼과 입력 padding 스타일 조정 |
+| `frontend/src/features/consultation/ui/chat-history/SessionList.test.tsx` | modify | 입력 중 필터 변경 미호출, 제출 시 필터 변경 호출 검증 |
+| `frontend/src/pages/consultation/ui/chat-history/ChatHistoryPage.test.tsx` | modify | URL query가 검색 제출 이후에만 갱신되는지 검증 |
+
+## State Management
+
+### Server State
+
+- 기존 `useChatSessions` 기반 TanStack Query 흐름을 유지한다.
+- query 파라미터가 제출 후에만 바뀌도록 하여 서버 목록 조회 빈도를 줄인다.
+
+### Client State
+
+- `SessionList`가 키워드 입력 draft를 로컬 state로 보관한다.
+- `filters.keyword`가 URL 복원, 초기화, 외부 변경으로 바뀌면 draft를 동기화한다.
+
+## Tests
+
+### Test Strategy
+
+| 구분 | 방법 | 도구 | 비고 |
+|------|------|------|------|
+| 컴포넌트 테스트 | 검색 입력/제출 이벤트 검증 | Vitest + React Testing Library | `SessionList.test.tsx` |
+| 페이지 테스트 | URL search params 갱신 시점 검증 | Vitest + React Testing Library | `ChatHistoryPage.test.tsx` |
+
+### Test Scenarios
+
+#### Happy Path
+
+| # | 시나리오 | 조작 | 기대 결과 |
+|---|---------|------|----------|
+| 1 | 키워드 입력 중 | 검색 input에 텍스트 입력 | `onFiltersChange`가 호출되지 않는다 |
+| 2 | 키워드 검색 제출 | Enter 또는 검색 버튼 클릭 | `onFiltersChange({ keyword })`가 호출되고 URL `q`가 갱신된다 |
+| 3 | 페이지가 있는 상태에서 키워드 검색 | `page=3`에서 검색 제출 | `q`가 갱신되고 `page` query가 제거된다 |
+
+#### Error & Edge Cases
+
+| # | 시나리오 | 조작 | 기대 결과 |
+|---|---------|------|----------|
+| 1 | 같은 키워드 제출 | 기존 키워드와 같은 값 제출 | 불필요한 필터 변경 호출을 하지 않는다 |
+| 2 | 필터 초기화 | 초기화 버튼 클릭 | 키워드 draft와 URL query가 기존 초기화 동작대로 비워진다 |
+| 3 | 다른 필터 변경 | 상태/날짜/상담사 변경 | 기존처럼 즉시 URL query가 갱신된다 |
+
+#### 반응형 & 접근성
+
+| # | 확인 항목 | 기대 결과 |
+|---|---------|----------|
+| 1 | 키보드 제출 | 검색 input에서 Enter | 검색이 제출된다 |
+| 2 | 검색 버튼 | 버튼에 접근 가능한 이름 제공 | 스크린 리더가 검색 버튼 목적을 읽을 수 있다 |
+| 3 | 모바일 폭 | 320px 목록 영역 | input과 원형 버튼이 겹치지 않는다 |
+
+## Non-goals
+
+- 백엔드 상담 이력 API 계약은 변경하지 않는다.
+- 상태/날짜/상담사 필터를 debounce 또는 제출 방식으로 바꾸지 않는다.
+- generated API 파일은 변경하지 않는다.
+
+## Open Questions
+
+- 없음.

--- a/frontend/src/features/consultation/ui/chat-history/SessionList.module.css
+++ b/frontend/src/features/consultation/ui/chat-history/SessionList.module.css
@@ -57,7 +57,33 @@
 }
 
 .searchInput {
-  padding: 0 12px 0 34px;
+  padding: 0 42px 0 34px;
+}
+
+.searchButton {
+  position: absolute;
+  top: 50%;
+  right: 4px;
+  transform: translateY(-50%);
+  width: 26px;
+  height: 26px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--line-2);
+  border-radius: 50%;
+  background: var(--ink);
+  color: var(--paper);
+  cursor: pointer;
+  transition:
+    background 0.15s,
+    border-color 0.15s,
+    opacity 0.15s;
+}
+
+.searchButton:hover {
+  background: var(--ink-2);
+  border-color: var(--ink-2);
 }
 
 .input,
@@ -70,6 +96,11 @@
 .select:focus {
   outline: none;
   border-color: var(--ink);
+  box-shadow: var(--focus-ring);
+}
+
+.searchButton:focus-visible {
+  outline: none;
   box-shadow: var(--focus-ring);
 }
 

--- a/frontend/src/features/consultation/ui/chat-history/SessionList.test.tsx
+++ b/frontend/src/features/consultation/ui/chat-history/SessionList.test.tsx
@@ -138,7 +138,19 @@ describe("SessionList", () => {
     expect(onSelect).toHaveBeenCalledWith("7");
   });
 
-  it("검색과 페이지 이동 이벤트를 전달한다", () => {
+  it("검색어 입력 중에는 필터 변경을 전달하지 않는다", () => {
+    const onFiltersChange = vi.fn();
+    renderSessionList({
+      sessions: [makeSession(7)],
+      onFiltersChange,
+    });
+
+    fireEvent.change(screen.getByLabelText("상담 기록 검색"), { target: { value: "배송" } });
+
+    expect(onFiltersChange).not.toHaveBeenCalled();
+  });
+
+  it("검색어 제출과 페이지 이동 이벤트를 전달한다", () => {
     const onFiltersChange = vi.fn();
     const onPageChange = vi.fn();
     renderSessionList({
@@ -150,9 +162,66 @@ describe("SessionList", () => {
     });
 
     fireEvent.change(screen.getByLabelText("상담 기록 검색"), { target: { value: "배송" } });
+    fireEvent.click(screen.getByRole("button", { name: "검색어로 상담 기록 검색" }));
     fireEvent.click(screen.getByRole("button", { name: "다음 페이지" }));
 
     expect(onFiltersChange).toHaveBeenCalledWith({ keyword: "배송" });
     expect(onPageChange).toHaveBeenCalledWith(1);
+  });
+
+  it("기존 검색어와 같은 값은 다시 제출하지 않는다", () => {
+    const onFiltersChange = vi.fn();
+    renderSessionList({
+      filters: {
+        keyword: "배송",
+        status: "COMPLETED",
+        startedFrom: "",
+        startedTo: "",
+        assignedCounselorId: "",
+      },
+      onFiltersChange,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "검색어로 상담 기록 검색" }));
+
+    expect(onFiltersChange).not.toHaveBeenCalled();
+  });
+
+  it("외부 필터 검색어가 바뀌면 입력값을 동기화한다", () => {
+    const { rerender } = renderSessionList({
+      filters: {
+        keyword: "배송",
+        status: "COMPLETED",
+        startedFrom: "",
+        startedTo: "",
+        assignedCounselorId: "",
+      },
+    });
+
+    expect(screen.getByLabelText("상담 기록 검색")).toHaveValue("배송");
+
+    rerender(
+      <SessionList
+        sessions={[]}
+        selectedSessionId={null}
+        onSelectSession={vi.fn()}
+        filters={{
+          keyword: "",
+          status: "COMPLETED",
+          startedFrom: "",
+          startedTo: "",
+          assignedCounselorId: "",
+        }}
+        onFiltersChange={vi.fn()}
+        onResetFilters={vi.fn()}
+        page={0}
+        totalPages={0}
+        totalElements={0}
+        onPageChange={vi.fn()}
+        onRetry={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByLabelText("상담 기록 검색")).toHaveValue("");
   });
 });

--- a/frontend/src/features/consultation/ui/chat-history/SessionList.tsx
+++ b/frontend/src/features/consultation/ui/chat-history/SessionList.tsx
@@ -1,3 +1,4 @@
+import { useState, type FormEvent } from "react";
 import { ChevronLeftIcon, ChevronRightIcon, RotateCcwIcon, SearchIcon } from "lucide-react";
 import { EmptyState, ErrorState, Eyebrow, LoadingSpinner } from "@/shared/ui/ostone/atoms";
 import {
@@ -33,9 +34,41 @@ interface SessionListProps {
   onRetry: () => void;
 }
 
+interface KeywordSearchFormProps {
+  keyword: string;
+  onSubmitKeyword: (keyword: string) => void;
+}
+
 function getErrorMessage(error: unknown): string {
   if (error instanceof Error) return error.message;
   return "채팅 기록을 불러오지 못했습니다";
+}
+
+function KeywordSearchForm({ keyword, onSubmitKeyword }: KeywordSearchFormProps) {
+  const [keywordDraft, setKeywordDraft] = useState(keyword);
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (keywordDraft === keyword) return;
+    onSubmitKeyword(keywordDraft);
+  };
+
+  return (
+    <form className={styles.searchBox} onSubmit={handleSubmit}>
+      <SearchIcon size={14} className={styles.searchIcon} aria-hidden="true" />
+      <input
+        aria-label="상담 기록 검색"
+        value={keywordDraft}
+        onChange={(event) => setKeywordDraft(event.target.value)}
+        placeholder="고객명, 키워드"
+        className={styles.searchInput}
+      />
+      <button type="submit" className={styles.searchButton} aria-label="검색어로 상담 기록 검색">
+        <SearchIcon size={14} aria-hidden="true" />
+      </button>
+    </form>
+  );
 }
 
 export function SessionList({
@@ -122,16 +155,11 @@ export function SessionList({
       </div>
 
       <div className={styles.filters} aria-label="상담 기록 검색 필터">
-        <label className={styles.searchBox}>
-          <SearchIcon size={14} className={styles.searchIcon} aria-hidden="true" />
-          <input
-            aria-label="상담 기록 검색"
-            value={filters.keyword}
-            onChange={(event) => onFiltersChange({ keyword: event.target.value })}
-            placeholder="고객명, 키워드"
-            className={styles.searchInput}
-          />
-        </label>
+        <KeywordSearchForm
+          key={filters.keyword}
+          keyword={filters.keyword}
+          onSubmitKeyword={(keyword) => onFiltersChange({ keyword })}
+        />
 
         <label className={styles.field}>
           <span>상태</span>

--- a/frontend/src/pages/consultation/ui/chat-history/ChatHistoryPage.test.tsx
+++ b/frontend/src/pages/consultation/ui/chat-history/ChatHistoryPage.test.tsx
@@ -213,10 +213,21 @@ describe("ChatHistoryPage", () => {
     expect(search.get("page")).toBe("1");
   });
 
-  it("검색어를 변경하면 URL query를 갱신하고 page를 초기화한다", () => {
+  it("검색어 입력 중에는 URL query를 갱신하지 않는다", () => {
     renderPage("/workspaces/1/consultation/history?page=3");
 
     fireEvent.change(screen.getByLabelText("상담 기록 검색"), { target: { value: "배송" } });
+
+    const search = new URLSearchParams(currentSearch);
+    expect(search.has("q")).toBe(false);
+    expect(search.get("page")).toBe("3");
+  });
+
+  it("검색어를 제출하면 URL query를 갱신하고 page를 초기화한다", () => {
+    renderPage("/workspaces/1/consultation/history?page=3");
+
+    fireEvent.change(screen.getByLabelText("상담 기록 검색"), { target: { value: "배송" } });
+    fireEvent.click(screen.getByRole("button", { name: "검색어로 상담 기록 검색" }));
 
     const search = new URLSearchParams(currentSearch);
     expect(search.get("q")).toBe("배송");


### PR DESCRIPTION
## Summary
- 상담 이력 키워드 입력을 로컬 draft로 분리해 입력 중 URL search params와 목록 query가 갱신되지 않도록 했습니다.
- Enter 또는 검색 버튼 제출 시에만 `q` query를 갱신하고 기존처럼 page query를 초기화합니다.
- 필터 초기화/외부 keyword 변경 시 검색 입력값이 다시 동기화되도록 하고, 이슈 요구사항을 `.agent/specs/430.md`에 정리했습니다.

## Validation
- `cd frontend && pnpm test -- src/features/consultation/ui/chat-history/SessionList.test.tsx src/pages/consultation/ui/chat-history/ChatHistoryPage.test.tsx`
- `cd frontend && pnpm exec eslint src/features/consultation/ui/chat-history/SessionList.tsx src/features/consultation/ui/chat-history/SessionList.test.tsx src/pages/consultation/ui/chat-history/ChatHistoryPage.test.tsx`
- `cd frontend && pnpm build`
- `git diff --check`
- `git diff --cached --check`

## Notes
- `cd frontend && pnpm lint`는 변경 범위 밖의 기존 lint 오류 58개로 실패했습니다. 변경 파일은 targeted eslint를 통과했습니다.

Closes #430