### PR TITLE
feat(domain-pack): 버전 액션 확인 모달에 대상 정보 표시

### DIFF
--- a/.agent/specs/429.md
+++ b/.agent/specs/429.md
@@ -1,0 +1,103 @@
+# Frontend Spec: 버전 액션 확인 모달 대상 정보 표시
+
+## Goal
+
+도메인팩 버전 배포, 적용, 삭제 확인 모달에서 사용자가 확정하려는 대상 버전과 운영 전환 맥락을 명확히 확인할 수 있게 한다.
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A["Domain Pack 상세 화면"] --> B["버전 선택"]
+    B --> C{"사용자 액션"}
+    C -->|배포| D["배포 확인 모달"]
+    C -->|검토본 적용| E["적용 확인 모달"]
+    C -->|검토본 삭제| F["삭제 확인 모달"]
+    D --> G["대상 v번호, 상태, 생성일, 운영 전환 정보 확인"]
+    E --> G
+    F --> H["삭제 대상 v번호, 상태, 생성일, 삭제 범위 확인"]
+    G --> I{"확정?"}
+    H --> I
+    I -->|취소| B
+    I -->|확정| J["기존 mutation 실행"]
+```
+
+## Design Diff
+
+### As-is vs To-be
+
+| 영역 | As-is | To-be | 변경 내용 |
+|------|-------|-------|----------|
+| 배포 확인 모달 | "이 버전" 중심 안내 | 대상 버전 번호와 상태, 생성일, 운영 전환 방향 표시 | 배포 전환 맥락 추가 |
+| 적용 확인 모달 | 검토 중 버전 적용 문구만 표시 | 현재 운영 버전에서 대상 draft 버전으로 바뀌는 흐름 표시 | 적용 대상 혼동 감소 |
+| 삭제 확인 모달 | 검토 중 버전 삭제 안내만 표시 | 삭제되는 draft 버전 번호, 상태, 생성일, 변경 요약 또는 생성 정보를 표시 | 되돌릴 수 없는 삭제 범위 명확화 |
+
+## Component Tree
+
+```text
+DomainPackSummaryPage
+├─ VersionListPanel
+└─ SummaryDetailPanel
+   ├─ AlertDialog (deploy)
+   │  └─ VersionActionContext
+   ├─ AlertDialog (apply draft)
+   │  └─ VersionActionContext
+   └─ AlertDialog (discard draft)
+      └─ VersionActionContext
+```
+
+## API Integration
+
+기존 도메인팩 상세/버전 상세 API 응답을 사용한다. 새로운 endpoint, request payload, generated API 변경은 없다.
+
+| 데이터 | 출처 | 용도 |
+|--------|------|------|
+| `currentVersionId`, `currentVersionNo` | Domain Pack 상세 | 현재 운영 버전 표시 |
+| `versionId`, `versionNo`, `lifecycleStatus`, `createdAt`, `summaryJson` | Version 상세 | 확인 모달 대상 버전 맥락 표시 |
+
+## Data Flow
+
+`DomainPackSummaryPage`가 pack 상세의 현재 운영 버전 번호를 `SummaryDetailPanel`에 전달한다. `SummaryDetailPanel`은 선택된 버전 상세 데이터로 확인 모달 안의 대상 버전 정보와 전환 문구를 구성한다.
+
+## 수정 대상 파일
+
+| 파일 | 변경 유형 | 설명 |
+|------|----------|------|
+| `frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.tsx` | modify | 현재 운영 버전 번호를 상세 패널에 전달 |
+| `frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.test.tsx` | modify | 상세 패널 prop 전달 검증 보강 |
+| `frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.tsx` | modify | 배포/적용/삭제 확인 모달에 대상 버전 컨텍스트 표시 |
+| `frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.module.css` | modify | 확인 모달 컨텍스트 블록 스타일 추가 |
+| `frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.test.tsx` | modify | 모달별 대상 버전, 전환 정보, 삭제 범위 표시 검증 |
+
+## State Management
+
+새로운 client/server state는 추가하지 않는다. 확인 모달 open state와 기존 mutation pending state를 그대로 사용한다.
+
+## Tests
+
+### Test Strategy
+
+| 구분 | 방법 | 도구 | 비고 |
+|------|------|------|------|
+| 컴포넌트 테스트 | 확인 모달 렌더링 검증 | Vitest + React Testing Library | 대상 버전/전환/삭제 범위 확인 |
+| 페이지 테스트 | prop 전달 검증 | Vitest + React Testing Library | 현재 운영 버전 번호 전달 확인 |
+| 정적 검증 | 타입/빌드 확인 | `pnpm test`, `pnpm build` | frontend 변경 범위 |
+
+### Test Scenarios
+
+| # | 시나리오 | 조작 | 기대 결과 |
+|---|---------|------|----------|
+| 1 | PUBLISHED 버전 배포 확인 | 배포 버튼 클릭 | 모달에 대상 `v{versionNo}`, 상태, 현재 운영 버전에서 대상 버전으로 전환되는 문구가 보인다 |
+| 2 | DRAFT 버전 적용 확인 | 적용 버튼 클릭 | 모달에 대상 draft 버전과 운영 전환 문구가 보인다 |
+| 3 | DRAFT 버전 삭제 확인 | 삭제 버튼 클릭 | 모달에 삭제 대상 draft 버전, 생성일, 삭제 범위 안내가 보인다 |
+| 4 | 변경 요약이 있는 버전 | 액션 모달 열기 | 파싱 가능한 `summaryJson`의 topic 또는 reason이 변경 요약으로 표시된다 |
+
+## Non-goals
+
+- 도메인팩 version detail API에 description 필드를 새로 추가하지 않는다.
+- 배포/적용/삭제 mutation 계약을 변경하지 않는다.
+- 확인 모달 외 화면의 버전 목록, 요약 카드, JSON 표시 방식을 변경하지 않는다.
+
+## Open Questions
+
+- 백엔드에서 버전별 사람이 작성한 description을 제공하면, 이후 확인 모달의 변경 요약 우선순위를 description 우선으로 조정할 수 있다.

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.module.css
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.module.css
@@ -360,6 +360,50 @@
   letter-spacing: -0.14px;
 }
 
+.versionActionContext {
+  margin: 0;
+  display: grid;
+  gap: 8px;
+  padding: 12px;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: var(--radius-lg);
+  background: #ffffff;
+}
+
+.versionActionRow {
+  display: grid;
+  grid-template-columns: 78px minmax(0, 1fr);
+  gap: 10px;
+  align-items: start;
+  color: #000000;
+  font-size: 12px;
+  line-height: 1.5;
+  letter-spacing: -0.14px;
+}
+
+.versionActionRow dt {
+  color: var(--text-muted);
+}
+
+.versionActionRow dd {
+  min-width: 0;
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+  overflow-wrap: anywhere;
+}
+
+.versionActionRow strong {
+  font-family: var(--font-mono);
+  font-weight: 540;
+}
+
+.versionActionRow span {
+  color: var(--text-secondary);
+}
+
 .approvalDialogFooter {
   display: grid;
   grid-template-columns: 1fr 1fr;
@@ -395,5 +439,10 @@
   .approvalActions,
   .approvalButton {
     width: 100%;
+  }
+
+  .versionActionRow {
+    grid-template-columns: 1fr;
+    gap: 2px;
   }
 }

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.test.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.test.tsx
@@ -59,7 +59,9 @@ const stubDetail: DomainPackVersionDetail = {
 
 const publishedDetail: DomainPackVersionDetail = {
   ...stubDetail,
+  versionNo: 2,
   lifecycleStatus: "PUBLISHED",
+  summaryJson: '{"topic":"환불 정책 업데이트"}',
 };
 
 function renderSummaryDetailPanel(ui: React.ReactElement) {
@@ -172,8 +174,27 @@ describe("SummaryDetailPanel", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "배포" }));
 
-    expect(screen.getByText("이 버전을 배포할까요?")).toBeInTheDocument();
+    expect(screen.getByText("v2 버전을 배포할까요?")).toBeInTheDocument();
     expect(onDeploy).not.toHaveBeenCalled();
+  });
+
+  it("배포 확인 다이얼로그에 대상 버전과 운영 전환 정보를 표시한다", () => {
+    renderSummaryDetailPanel(
+      <SummaryDetailPanel
+        query={makeQuery({ data: publishedDetail })}
+        wsId={1}
+        packId={2}
+        currentVersionId={9}
+        currentVersionNo={1}
+        onDeploy={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "배포" }));
+
+    expect(screen.getByLabelText("대상 버전 정보")).toHaveTextContent("대상 버전v2운영 가능");
+    expect(screen.getByLabelText("대상 버전 정보")).toHaveTextContent("운영 전환현재 v1 → v2");
+    expect(screen.getByLabelText("대상 버전 정보")).toHaveTextContent("변경 요약환불 정책 업데이트");
   });
 
   it("배포 확인 시 현재 versionId를 전달한다", () => {
@@ -302,6 +323,33 @@ describe("SummaryDetailPanel", () => {
     expect(onApplyDraft).toHaveBeenCalledWith(3);
   });
 
+  it("Draft 적용 확인 다이얼로그에 대상 draft 버전과 운영 전환 정보를 표시한다", () => {
+    renderSummaryDetailPanel(
+      <SummaryDetailPanel
+        query={makeQuery({
+          data: {
+            ...stubDetail,
+            versionNo: 3,
+            summaryJson:
+              '{"draftSource":{"baseVersionNo":2,"reason":"상담 유형 이름을 정리했습니다."}}',
+          },
+        })}
+        wsId={1}
+        packId={2}
+        currentVersionId={8}
+        currentVersionNo={2}
+        onApplyDraft={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "적용" }));
+
+    const context = screen.getByLabelText("대상 버전 정보");
+    expect(context).toHaveTextContent("대상 버전v3검토 중");
+    expect(context).toHaveTextContent("운영 전환현재 v2 → v3");
+    expect(context).toHaveTextContent("변경 요약상담 유형 이름을 정리했습니다.");
+  });
+
   it("Draft 삭제 확인 시 현재 versionId를 전달한다", () => {
     const onDiscardDraft = vi.fn();
 
@@ -315,10 +363,14 @@ describe("SummaryDetailPanel", () => {
     );
 
     fireEvent.click(screen.getByRole("button", { name: "삭제" }));
-    expect(screen.getByText("검토 중인 버전을 삭제할까요?")).toBeInTheDocument();
+    expect(screen.getByText("검토 중인 v1 버전을 삭제할까요?")).toBeInTheDocument();
     expect(
-      screen.getByText("삭제하면 이 검토 중인 버전과 저장된 수정 내용이 모두 삭제됩니다."),
+      screen.getByText("삭제하면 v1 검토본과 저장된 수정 내용이 모두 삭제되며 되돌릴 수 없습니다."),
     ).toBeInTheDocument();
+    expect(screen.getByLabelText("대상 버전 정보")).toHaveTextContent("삭제 범위");
+    expect(screen.getByLabelText("대상 버전 정보")).toHaveTextContent(
+      "버전 메타데이터와 저장된 draft 수정 내용",
+    );
     fireEvent.click(screen.getByRole("button", { name: "삭제하기" }));
 
     expect(onDiscardDraft).toHaveBeenCalledWith(3);

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.test.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.test.tsx
@@ -197,6 +197,86 @@ describe("SummaryDetailPanel", () => {
     expect(screen.getByLabelText("대상 버전 정보")).toHaveTextContent("변경 요약환불 정책 업데이트");
   });
 
+  it("배포 확인 다이얼로그는 review issue 문자열을 변경 요약으로 표시한다", () => {
+    renderSummaryDetailPanel(
+      <SummaryDetailPanel
+        query={makeQuery({
+          data: {
+            ...publishedDetail,
+            summaryJson: '{"review":{"topIssues":["워크플로우 미매핑"]}}',
+          },
+        })}
+        wsId={1}
+        packId={2}
+        onDeploy={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "배포" }));
+
+    expect(screen.getByLabelText("대상 버전 정보")).toHaveTextContent("변경 요약워크플로우 미매핑");
+  });
+
+  it("배포 확인 다이얼로그는 review issue 객체의 메시지를 변경 요약으로 표시한다", () => {
+    renderSummaryDetailPanel(
+      <SummaryDetailPanel
+        query={makeQuery({
+          data: {
+            ...publishedDetail,
+            summaryJson: '{"review":{"issues":[{"message":"슬롯 확인 필요"}]}}',
+          },
+        })}
+        wsId={1}
+        packId={2}
+        onDeploy={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "배포" }));
+
+    expect(screen.getByLabelText("대상 버전 정보")).toHaveTextContent("변경 요약슬롯 확인 필요");
+  });
+
+  it("배포 확인 다이얼로그는 변경 요약을 해석할 수 없으면 요약 행을 표시하지 않는다", () => {
+    renderSummaryDetailPanel(
+      <SummaryDetailPanel
+        query={makeQuery({
+          data: {
+            ...publishedDetail,
+            summaryJson: "{bad}",
+          },
+        })}
+        wsId={1}
+        packId={2}
+        onDeploy={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "배포" }));
+
+    expect(screen.getByLabelText("대상 버전 정보")).not.toHaveTextContent("변경 요약");
+  });
+
+  it("배포 확인 다이얼로그는 빈 review issue 객체만 있으면 요약 행을 표시하지 않는다", () => {
+    renderSummaryDetailPanel(
+      <SummaryDetailPanel
+        query={makeQuery({
+          data: {
+            ...publishedDetail,
+            summaryJson: '{"review":{"topIssues":[{}]}}',
+          },
+        })}
+        wsId={1}
+        packId={2}
+        onDeploy={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "배포" }));
+
+    expect(screen.getByLabelText("대상 버전 정보")).not.toHaveTextContent("변경 요약");
+  });
+
   it("배포 확인 시 현재 versionId를 전달한다", () => {
     const onDeploy = vi.fn();
 

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.tsx
@@ -21,6 +21,7 @@ interface SummaryDetailPanelProps {
   wsId: number;
   packId: number;
   currentVersionId?: number | null;
+  currentVersionNo?: number | null;
   deployingVersionId?: number | null;
   applyingVersionId?: number | null;
   discardingVersionId?: number | null;
@@ -34,6 +35,7 @@ export function SummaryDetailPanel({
   wsId,
   packId,
   currentVersionId = null,
+  currentVersionNo = null,
   deployingVersionId = null,
   applyingVersionId = null,
   discardingVersionId = null,
@@ -51,6 +53,8 @@ export function SummaryDetailPanel({
   const isApplying = versionId != null && versionId === applyingVersionId;
   const isDiscarding = versionId != null && versionId === discardingVersionId;
   const isDraftVersion = v?.lifecycleStatus === "DRAFT";
+  const targetVersionLabel = formatVersionNo(v?.versionNo);
+  const currentVersionLabel = formatCurrentVersionLabel(currentVersionNo, currentVersionId);
   const canDeploy =
     onDeploy != null && versionId != null && !isCurrentVersion && !isDeploying && !isDraftVersion;
   const canApplyDraft =
@@ -183,11 +187,15 @@ export function SummaryDetailPanel({
       >
         <AlertDialogContent size="sm" className={styles.approvalDialogContent}>
           <AlertDialogTitle className={styles.approvalDialogTitle}>
-            이 버전을 배포할까요?
+            {targetVersionLabel} 버전을 배포할까요?
           </AlertDialogTitle>
           <AlertDialogDescription className={styles.approvalDialogDescription}>
-            배포하면 현재 운영 중인 도메인팩 버전이 선택한 버전으로 전환됩니다.
+            배포하면 현재 운영 중인 도메인팩이 아래 대상 버전으로 전환됩니다.
           </AlertDialogDescription>
+          <VersionActionContext
+            version={v}
+            transitionLabel={`${currentVersionLabel} → ${targetVersionLabel}`}
+          />
           <AlertDialogFooter className={styles.approvalDialogFooter}>
             <Button
               type="button"
@@ -225,11 +233,15 @@ export function SummaryDetailPanel({
       >
         <AlertDialogContent size="sm" className={styles.approvalDialogContent}>
           <AlertDialogTitle className={styles.approvalDialogTitle}>
-            검토 중인 버전을 적용할까요?
+            검토 중인 {targetVersionLabel} 버전을 적용할까요?
           </AlertDialogTitle>
           <AlertDialogDescription className={styles.approvalDialogDescription}>
-            적용하면 이 버전이 상담 응대에 사용할 수 있는 운영 버전으로 전환됩니다.
+            적용하면 검토 중인 {targetVersionLabel}이 상담 응대에 사용할 운영 버전으로 전환됩니다.
           </AlertDialogDescription>
+          <VersionActionContext
+            version={v}
+            transitionLabel={`${currentVersionLabel} → ${targetVersionLabel}`}
+          />
           <AlertDialogFooter className={styles.approvalDialogFooter}>
             <Button
               type="button"
@@ -267,11 +279,18 @@ export function SummaryDetailPanel({
       >
         <AlertDialogContent size="sm" className={styles.approvalDialogContent}>
           <AlertDialogTitle className={styles.approvalDialogTitle}>
-            검토 중인 버전을 삭제할까요?
+            검토 중인 {targetVersionLabel} 버전을 삭제할까요?
           </AlertDialogTitle>
           <AlertDialogDescription className={styles.approvalDialogDescription}>
-            삭제하면 이 검토 중인 버전과 저장된 수정 내용이 모두 삭제됩니다.
+            삭제하면 {targetVersionLabel} 검토본과 저장된 수정 내용이 모두 삭제되며 되돌릴 수
+            없습니다.
           </AlertDialogDescription>
+          <VersionActionContext
+            version={v}
+            transitionLabel={`${targetVersionLabel} 검토본 삭제`}
+            scopeLabel="삭제 범위"
+            scopeValue="버전 메타데이터와 저장된 draft 수정 내용"
+          />
           <AlertDialogFooter className={styles.approvalDialogFooter}>
             <Button
               type="button"
@@ -327,8 +346,108 @@ function formatDate(iso: string): string {
   return d.toLocaleString("ko-KR");
 }
 
+function formatVersionNo(versionNo?: number | null): string {
+  return versionNo == null ? "선택한 버전" : `v${versionNo}`;
+}
+
+function formatCurrentVersionLabel(
+  currentVersionNo?: number | null,
+  currentVersionId?: number | null,
+): string {
+  if (currentVersionNo != null) return `현재 v${currentVersionNo}`;
+  if (currentVersionId != null) return "현재 운영 버전";
+  return "운영 버전 없음";
+}
+
 function formatLifecycleStatus(status?: string | null): string {
   if (status === "PUBLISHED") return "운영 가능";
   if (status === "DRAFT") return "검토 중";
   return status ?? "상태 없음";
+}
+
+function VersionActionContext({
+  version,
+  transitionLabel,
+  scopeLabel = "운영 전환",
+  scopeValue,
+}: Readonly<{
+  version: DomainPackVersionDetail;
+  transitionLabel: string;
+  scopeLabel?: string;
+  scopeValue?: string;
+}>) {
+  const summary = buildActionSummary(version.summaryJson);
+
+  return (
+    <dl className={styles.versionActionContext} aria-label="대상 버전 정보">
+      <div className={styles.versionActionRow}>
+        <dt>대상 버전</dt>
+        <dd>
+          <strong>{formatVersionNo(version.versionNo)}</strong>
+          <span>{formatLifecycleStatus(version.lifecycleStatus)}</span>
+        </dd>
+      </div>
+      <div className={styles.versionActionRow}>
+        <dt>{scopeLabel}</dt>
+        <dd>{scopeValue ?? transitionLabel}</dd>
+      </div>
+      <div className={styles.versionActionRow}>
+        <dt>생성</dt>
+        <dd>{formatDate(version.createdAt ?? "") || "생성일 없음"}</dd>
+      </div>
+      {summary && (
+        <div className={styles.versionActionRow}>
+          <dt>변경 요약</dt>
+          <dd>{summary}</dd>
+        </div>
+      )}
+    </dl>
+  );
+}
+
+function buildActionSummary(summaryJson?: string | null): string | null {
+  if (!summaryJson) return null;
+
+  try {
+    const parsed: unknown = JSON.parse(summaryJson);
+    if (!isRecord(parsed)) return null;
+    return (
+      readTrimmedString(parsed.topic) ??
+      readNestedString(parsed, ["draftSource", "reason"]) ??
+      readNestedString(parsed, ["generation", "description"]) ??
+      readFirstString(parsed, ["review", "topIssues"]) ??
+      readFirstString(parsed, ["review", "issues"])
+    );
+  } catch {
+    return null;
+  }
+}
+
+function readNestedString(data: Record<string, unknown>, path: string[]): string | null {
+  const value = path.reduce<unknown>((acc, key) => (isRecord(acc) ? acc[key] : undefined), data);
+  return readTrimmedString(value);
+}
+
+function readFirstString(data: Record<string, unknown>, path: string[]): string | null {
+  const value = path.reduce<unknown>((acc, key) => (isRecord(acc) ? acc[key] : undefined), data);
+  if (!Array.isArray(value)) return null;
+  for (const item of value) {
+    const text = readTrimmedString(item);
+    if (text) return text;
+    if (isRecord(item)) {
+      const message = readTrimmedString(item.message) ?? readTrimmedString(item.title);
+      if (message) return message;
+    }
+  }
+  return null;
+}
+
+function readTrimmedString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed || null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.test.tsx
+++ b/frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.test.tsx
@@ -59,17 +59,20 @@ vi.mock("@/features/domain-pack-summary-read", () => ({
   ),
   SummaryDetailPanel: ({
     currentVersionId,
+    currentVersionNo,
     onDeploy,
     onApplyDraft,
     onDiscardDraft,
   }: {
     currentVersionId?: number | null;
+    currentVersionNo?: number | null;
     onDeploy: (versionId: number) => void;
     onApplyDraft: (versionId: number) => void;
     onDiscardDraft: (versionId: number) => void;
   }) => (
     <div data-testid="summary-detail-panel">
       <span data-testid="current-version-id">{currentVersionId ?? "none"}</span>
+      <span data-testid="current-version-no">{currentVersionNo ?? "none"}</span>
       <button type="button" onClick={() => onDeploy(4)}>
         deploy version
       </button>
@@ -478,6 +481,45 @@ describe("DomainPackSummaryPage", () => {
     renderPage("/workspaces/1/domain-packs/2?versionId=4");
 
     expect(screen.getByTestId("current-version-id")).toHaveTextContent("none");
+  });
+
+  it("packDetail의 현재 운영 버전 번호를 SummaryDetailPanel에 전달한다", () => {
+    vi.mocked(usePackDetail).mockReturnValue(
+      makePackQuery({
+        data: {
+          packId: 2,
+          name: "CS Pack",
+          code: "CS",
+          currentVersionId: 3,
+          currentVersionNo: 7,
+          versions: [{ versionId: 3, versionNo: 7, lifecycleStatus: "PUBLISHED" }],
+        },
+      }),
+    );
+
+    renderPage("/workspaces/1/domain-packs/2?versionId=4");
+
+    expect(screen.getByTestId("current-version-id")).toHaveTextContent("3");
+    expect(screen.getByTestId("current-version-no")).toHaveTextContent("7");
+  });
+
+  it("currentVersionNo가 없으면 currentVersionId와 버전 목록으로 현재 운영 버전 번호를 전달한다", () => {
+    vi.mocked(usePackDetail).mockReturnValue(
+      makePackQuery({
+        data: {
+          packId: 2,
+          name: "CS Pack",
+          code: "CS",
+          currentVersionId: 3,
+          currentVersionNo: null,
+          versions: [{ versionId: 3, versionNo: 2, lifecycleStatus: "PUBLISHED" }],
+        },
+      }),
+    );
+
+    renderPage("/workspaces/1/domain-packs/2?versionId=4");
+
+    expect(screen.getByTestId("current-version-no")).toHaveTextContent("2");
   });
 
   it("currentVersionId가 없고 PUBLISHED 버전이 여러 개면 운영 버전을 추론하지 않는다", () => {

--- a/frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.tsx
@@ -78,6 +78,10 @@ function DomainPackSummaryPageContent({
   ) as UseQueryResult<DomainPackVersionDetail>;
   const pack = packQuery.data;
   const currentVersionId = pack?.currentVersionId ?? null;
+  const currentVersionNo =
+    pack?.currentVersionNo ??
+    pack?.versions?.find((version) => version.versionId === currentVersionId)?.versionNo ??
+    null;
   const selectedVersionNo =
     pack?.versions?.find((v) => v.versionId === selectedVersionId)?.versionNo ?? null;
 
@@ -227,6 +231,7 @@ function DomainPackSummaryPageContent({
             wsId={wsId}
             packId={packId}
             currentVersionId={currentVersionId}
+            currentVersionNo={currentVersionNo}
             deployingVersionId={
               deployMutation.isPending ? deployMutation.variables?.versionId : null
             }


### PR DESCRIPTION
## Summary
- 도메인팩 버전 배포/적용/삭제 확인 모달에 대상 버전 번호, 상태, 생성일, 운영 전환 정보를 표시합니다.
- 삭제 확인 모달은 삭제되는 draft 버전과 되돌릴 수 없는 삭제 범위를 더 명확히 안내합니다.
- 이슈 요구사항과 검증 기준을 `.agent/specs/429.md`에 정리했습니다.

## Validation
- `cd frontend && pnpm test -- src/features/domain-pack-summary-read/ui/SummaryDetailPanel.test.tsx src/pages/domain-pack/ui/DomainPackSummaryPage.test.tsx`
- `cd frontend && pnpm exec eslint src/features/domain-pack-summary-read/ui/SummaryDetailPanel.tsx src/features/domain-pack-summary-read/ui/SummaryDetailPanel.test.tsx src/pages/domain-pack/ui/DomainPackSummaryPage.tsx src/pages/domain-pack/ui/DomainPackSummaryPage.test.tsx`
- `cd frontend && pnpm test`
- `cd frontend && pnpm build`
- `git diff --check`
- `git diff --cached --check`

## Notes
- `cd frontend && pnpm lint`는 변경 범위 밖의 기존 lint 오류 58개로 실패했습니다. 변경 파일은 targeted eslint를 통과했습니다.

Closes #429
