### PR TITLE
feat(pipeline-review): 피드백 선택 임시 보존 제공

### DIFF
--- a/.agent/specs/427.md
+++ b/.agent/specs/427.md
@@ -1,0 +1,138 @@
+# Frontend FSD Spec: pipeline-review feedback draft preservation
+
+## Goal
+
+파이프라인 human feedback 화면에서 제출 전 선택한 판단을 임시 보존하고, 미제출 선택값이 있을 때 새로고침 이탈을 경고하여 검토자가 같은 판단을 반복하지 않도록 한다.
+
+---
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A["Human feedback 체크포인트 진입"] --> B["열린 feedback 작업 표시"]
+    B --> C{"저장된 임시 선택값 존재?"}
+    C -->|Yes| D["열린 작업에 해당하는 선택값 복원"]
+    C -->|No| E["빈 선택 상태로 시작"]
+    D --> F["검토자가 must_link/cannot_link/unsure 선택"]
+    E --> F
+    F --> G["선택값 임시 저장"]
+    G --> H{"모든 열린 작업 선택 완료?"}
+    H -->|No| I["제출 버튼 비활성 유지"]
+    H -->|Yes| J["제출 버튼 활성"]
+    I --> K{"새로고침/브라우저 이탈?"}
+    J --> K
+    K -->|Yes + 미제출 선택 있음| L["브라우저 기본 이탈 경고"]
+    K -->|No| F
+    J --> M["피드백 제출"]
+    M --> N["임시 저장값 정리 후 checkpoint 재조회"]
+```
+
+---
+
+## Design Diff
+
+### As-is vs To-be
+
+| 영역 | As-is | To-be | 변경 내용 |
+|------|-------|-------|----------|
+| 피드백 선택 상태 | 컴포넌트 local state에만 보관 | workspace/job 단위 localStorage 임시 저장 | 새로고침 또는 재진입 후 열린 작업 선택값 복원 |
+| 이탈 보호 | 없음 | 미제출 선택값이 있으면 beforeunload 경고 | 브라우저 새로고침/탭 닫기 전에 손실 가능성 알림 |
+| 제출 완료 | 서버 제출 후 query invalidate | 제출 성공 시 임시 저장값 제거 후 query invalidate | 완료된 선택값이 다음 세션에 남지 않음 |
+| 제출 버튼 조건 | 모든 열린 작업 선택 시 활성 | 동일 | 기존 활성화 조건 유지 |
+
+---
+
+## Component Tree
+
+```
+PipelineReviewCheckpointCard
+├─ usePipelineReviewCheckpoint
+├─ useConfirmPipelineDomain
+├─ useSubmitPipelineFeedback
+├─ local feedback draft state
+├─ Domain confirmation view
+└─ Human feedback view
+   ├─ feedback task list
+   │  ├─ CaseContextCard
+   │  └─ choice buttons
+   └─ submit replay button
+```
+
+---
+
+## API Integration
+
+### Endpoints
+
+변경 없음. 기존 `frontend/src/features/pipeline-review/api/pipelineReviewApi.ts`의 checkpoint 조회, 도메인 확정, human feedback 제출 API를 그대로 사용한다.
+
+### Client Persistence
+
+| 항목 | 값 |
+|------|----|
+| 저장소 | `window.localStorage` |
+| 범위 | workspaceId + pipelineJobId |
+| 저장 대상 | 열린 feedback task id별 `must_link`, `cannot_link`, `unsure` 선택값 |
+| 복원 조건 | `reviewKind === "HUMAN_FEEDBACK"`이고 현재 열린 작업 id에 해당하는 값만 복원 |
+| 정리 조건 | human feedback 제출 성공 또는 더 이상 human feedback이 아닌 checkpoint |
+
+---
+
+## 수정 대상 파일
+
+| 파일 | 변경 유형 | 설명 |
+|------|----------|------|
+| `frontend/src/features/pipeline-review/ui/PipelineReviewCheckpointCard.tsx` | update | 선택값 localStorage 보존, 열린 작업 기준 pruning, beforeunload 경고, 제출 성공 후 정리 |
+| `frontend/src/features/pipeline-review/ui/PipelineReviewCheckpointCard.test.tsx` | update | 임시 저장 복원, 제출 후 정리, 이탈 경고, 제출 버튼 활성 조건 회귀 테스트 |
+
+---
+
+## State Management
+
+- 서버 상태는 TanStack Query 기반 기존 API 훅을 유지한다.
+- 선택값은 현재 workspace/job의 컴포넌트 state와 localStorage draft를 결합해 표시하되, human feedback checkpoint에서만 localStorage와 동기화한다.
+- localStorage가 비활성화되거나 파싱 실패가 발생해도 화면 렌더링과 제출 흐름은 중단하지 않는다.
+- 저장된 draft에는 현재 열린 task id와 허용된 decision 값만 반영한다.
+
+---
+
+## Non-goals
+
+- 서버 측 draft 저장 API를 추가하지 않는다.
+- React Router route transition blocker는 이번 범위에 포함하지 않는다. 브라우저 새로고침/탭 닫기 경고와 localStorage 복원으로 손실을 줄인다.
+- 도메인 확정 checkpoint에는 임시 저장을 적용하지 않는다.
+- feedback decision 타입이나 백엔드 제출 payload를 변경하지 않는다.
+
+---
+
+## Tests
+
+### Test Strategy
+
+| 구분 | 방법 | 도구 | 비고 |
+|------|------|------|------|
+| 컴포넌트 테스트 | 사용자 선택/제출 동작 검증 | Vitest + React Testing Library | 기존 test 파일 확장 |
+| 스토리지 테스트 | localStorage 복원/정리 검증 | Vitest jsdom | workspace/job scoped key 확인 |
+| 이탈 경고 테스트 | beforeunload 이벤트 검증 | Vitest jsdom | 미제출 선택값 존재 여부 기준 |
+
+### Test Scenarios
+
+| # | 시나리오 | 조작 | 기대 결과 |
+|---|---------|------|----------|
+| 1 | 피드백 선택 후 임시 저장 | choice 버튼 클릭 | workspace/job scoped localStorage에 선택값 저장 |
+| 2 | 재진입 시 임시 선택 복원 | 저장값이 있는 상태에서 렌더 | 해당 choice가 selected 상태이고 제출 버튼 조건에 반영 |
+| 3 | 일부 작업만 선택 | 열린 작업 2개 중 1개 선택 | 제출 버튼 비활성 유지 |
+| 4 | 제출 성공 | 모든 열린 작업 선택 후 submit mutation success 콜백 실행 | localStorage 임시 저장값 제거 |
+| 5 | 미제출 선택값이 있는 새로고침 | beforeunload 이벤트 발생 | event가 취소되어 브라우저 경고 가능 |
+| 6 | human feedback이 아닌 상태 | reviewKind가 null 또는 DOMAIN_CONFIRMATION | 기존 draft가 정리되고 화면 동작 유지 |
+
+---
+
+## Acceptance Criteria
+
+- 피드백 선택 후 새로고침/재진입 시 현재 열린 작업의 선택값이 복원된다.
+- 미제출 선택값이 하나 이상 있으면 브라우저 새로고침/탭 닫기 전에 기본 이탈 경고를 트리거한다.
+- 제출 완료 후 해당 workspace/job의 임시 저장값이 남지 않는다.
+- 열린 작업 전체 선택 여부와 제출 버튼 활성화 조건은 기존과 동일하게 동작한다.
+- localStorage를 사용할 수 없는 환경에서도 선택 및 제출 기능은 중단되지 않는다.

--- a/frontend/src/features/pipeline-review/ui/PipelineReviewCheckpointCard.test.tsx
+++ b/frontend/src/features/pipeline-review/ui/PipelineReviewCheckpointCard.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -17,6 +17,7 @@ vi.mock("../api/pipelineReviewApi", () => ({
 const mockedUseCheckpoint = vi.mocked(usePipelineReviewCheckpoint);
 const mockedUseConfirmDomain = vi.mocked(useConfirmPipelineDomain);
 const mockedUseSubmitFeedback = vi.mocked(useSubmitPipelineFeedback);
+const feedbackDraftKey = "ostone:pipeline-review:feedback-draft:1:7";
 
 function renderCard(props: { workspaceId?: number; pipelineJobId?: number } = { workspaceId: 1, pipelineJobId: 7 }) {
   return render(
@@ -27,6 +28,7 @@ function renderCard(props: { workspaceId?: number; pipelineJobId?: number } = { 
 }
 
 beforeEach(() => {
+  window.localStorage.clear();
   mockedUseCheckpoint.mockReset();
   mockedUseConfirmDomain.mockReset();
   mockedUseSubmitFeedback.mockReset();
@@ -187,7 +189,89 @@ describe("PipelineReviewCheckpointCard", () => {
     fireEvent.click(screen.getByRole("button", { name: "분리하기" }));
     fireEvent.click(screen.getByRole("button", { name: "피드백 반영 후 replay" }));
 
-    expect(mutate).toHaveBeenCalledWith([{ reviewTaskId: 201, decisionType: "cannot_link" }]);
+    expect(mutate.mock.calls[0]?.[0]).toEqual([{ reviewTaskId: 201, decisionType: "cannot_link" }]);
+  });
+
+  it("restores saved feedback choices for the current pipeline job", async () => {
+    window.localStorage.setItem(feedbackDraftKey, JSON.stringify({ 201: "cannot_link" }));
+    mockedUseCheckpoint.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: createHumanFeedbackCheckpoint([201]),
+    } as never);
+
+    renderCard();
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "분리하기" })).toHaveAttribute("aria-pressed", "true"));
+    expect(screen.getByRole("button", { name: "피드백 반영 후 replay" })).not.toBeDisabled();
+  });
+
+  it("keeps submit disabled until every open feedback task is answered", async () => {
+    mockedUseCheckpoint.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: createHumanFeedbackCheckpoint([201, 202]),
+    } as never);
+
+    renderCard();
+
+    fireEvent.click(screen.getAllByRole("button", { name: "분리하기" })[0]);
+
+    await waitFor(() => expect(screen.getByText("1/2 answered")).toBeInTheDocument());
+    expect(screen.getByRole("button", { name: "피드백 반영 후 replay" })).toBeDisabled();
+  });
+
+  it("stores feedback choices and warns before leaving with unsent feedback", async () => {
+    mockedUseCheckpoint.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: createHumanFeedbackCheckpoint([201]),
+    } as never);
+
+    renderCard();
+
+    fireEvent.click(screen.getByRole("button", { name: "판단 보류" }));
+
+    await waitFor(() => expect(window.localStorage.getItem(feedbackDraftKey)).toBe(JSON.stringify({ 201: "unsure" })));
+
+    const event = new Event("beforeunload", { cancelable: true });
+    window.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("clears saved feedback choices after successful submission", async () => {
+    const mutate = vi.fn();
+    mockedUseSubmitFeedback.mockReturnValue({ isPending: false, mutate } as never);
+    mockedUseCheckpoint.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: createHumanFeedbackCheckpoint([201]),
+    } as never);
+
+    renderCard();
+
+    fireEvent.click(screen.getByRole("button", { name: "같은 intent로 묶기" }));
+    fireEvent.click(screen.getByRole("button", { name: "피드백 반영 후 replay" }));
+
+    await waitFor(() => expect(window.localStorage.getItem(feedbackDraftKey)).toBe(JSON.stringify({ 201: "must_link" })));
+
+    mutate.mock.calls[0]?.[1]?.onSuccess?.(undefined, [], undefined);
+
+    expect(window.localStorage.getItem(feedbackDraftKey)).toBeNull();
+  });
+
+  it("clears stale feedback draft outside human feedback checkpoints", async () => {
+    window.localStorage.setItem(feedbackDraftKey, JSON.stringify({ 201: "cannot_link" }));
+    mockedUseCheckpoint.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: { pipelineJobId: 7, pipelineStatus: "SUCCEEDED", reviewKind: null, tasks: [] },
+    } as never);
+
+    renderCard();
+
+    await waitFor(() => expect(window.localStorage.getItem(feedbackDraftKey)).toBeNull());
   });
 
   it("renders feedback reason labels and empty evidence fallback", () => {
@@ -299,3 +383,30 @@ describe("PipelineReviewCheckpointCard", () => {
     expect(refetch).toHaveBeenCalledTimes(1);
   });
 });
+
+function createHumanFeedbackCheckpoint(taskIds: number[]) {
+  return {
+    pipelineJobId: 7,
+    pipelineStatus: "WAITING_HUMAN_FEEDBACK",
+    reviewKind: "HUMAN_FEEDBACK",
+    tasks: taskIds.map((id) => ({
+      id,
+      targetType: "FEEDBACK_PAIR",
+      status: "OPEN",
+      priority: "NORMAL",
+      title: "이 두 상담은 같은 업무인가?",
+      payload: {
+        questionText: "이 두 상담은 같은 업무인가?",
+        reason: "low_confidence_cluster_boundary",
+        sourceReviewContext: {
+          conversationId: `A-${id}`,
+          summary: "카드 분실 후 정지 요청",
+        },
+        targetReviewContext: {
+          conversationId: `B-${id}`,
+          summary: "카드 결제 한도 상향 요청",
+        },
+      },
+    })),
+  };
+}

--- a/frontend/src/features/pipeline-review/ui/PipelineReviewCheckpointCard.tsx
+++ b/frontend/src/features/pipeline-review/ui/PipelineReviewCheckpointCard.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, type ReactNode } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 import {
   ArrowRightIcon,
   ListChecksIcon,
@@ -20,18 +20,81 @@ interface Props {
   pipelineJobId?: number;
 }
 
+const FEEDBACK_DRAFT_KEY_PREFIX = "ostone:pipeline-review:feedback-draft";
+const FEEDBACK_DECISION_VALUES = ["must_link", "cannot_link", "unsure"] as const;
+
+type FeedbackDecision = (typeof FEEDBACK_DECISION_VALUES)[number];
+type FeedbackDecisions = Record<number, FeedbackDecision>;
+
 export function PipelineReviewCheckpointCard({ workspaceId, pipelineJobId }: Props) {
   const query = usePipelineReviewCheckpoint(workspaceId, pipelineJobId);
   const confirmDomain = useConfirmPipelineDomain(workspaceId, pipelineJobId);
   const submitFeedback = useSubmitPipelineFeedback(workspaceId, pipelineJobId);
-  const [feedbackDecisions, setFeedbackDecisions] = useState<Record<number, string>>({});
+  const draftStorageKey = createFeedbackDraftStorageKey(workspaceId, pipelineJobId);
+  const [feedbackDraft, setFeedbackDraft] = useState<{ storageKey: string | null; decisions: FeedbackDecisions }>({
+    storageKey: null,
+    decisions: {},
+  });
 
   const openTasks = useMemo(
     () => query.data?.tasks.filter((task) => task.status === "OPEN") ?? [],
     [query.data?.tasks],
   );
-  const allFeedbackResolved =
-    openTasks.length > 0 && openTasks.every((task) => feedbackDecisions[task.id] !== undefined);
+  const openTaskIds = useMemo(() => openTasks.map((task) => task.id), [openTasks]);
+  const storedFeedbackDecisions = useMemo(() => {
+    if (query.data?.reviewKind !== "HUMAN_FEEDBACK" || !draftStorageKey) {
+      return {};
+    }
+    return readFeedbackDraft(draftStorageKey, openTaskIds);
+  }, [draftStorageKey, openTaskIds, query.data?.reviewKind]);
+  const activeFeedbackDecisions = filterFeedbackDecisions(
+    {
+      ...storedFeedbackDecisions,
+      ...(feedbackDraft.storageKey === draftStorageKey ? feedbackDraft.decisions : {}),
+    },
+    openTaskIds,
+  );
+  const answeredFeedbackCount = openTasks.filter((task) => activeFeedbackDecisions[task.id] !== undefined).length;
+  const allFeedbackResolved = openTasks.length > 0 && answeredFeedbackCount === openTasks.length;
+  const hasUnsavedFeedback = query.data?.reviewKind === "HUMAN_FEEDBACK" && answeredFeedbackCount > 0;
+
+  useEffect(() => {
+    if (query.data?.reviewKind !== undefined && query.data.reviewKind !== "HUMAN_FEEDBACK" && draftStorageKey) {
+      removeFeedbackDraft(draftStorageKey);
+    }
+  }, [draftStorageKey, query.data?.reviewKind]);
+
+  useEffect(() => {
+    if (!hasUnsavedFeedback) {
+      return;
+    }
+
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      event.returnValue = "";
+    };
+
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => window.removeEventListener("beforeunload", handleBeforeUnload);
+  }, [hasUnsavedFeedback]);
+
+  const updateFeedbackDecision = (taskId: number, decision: FeedbackDecision) => {
+    setFeedbackDraft((current) => {
+      const currentDecisions = current.storageKey === draftStorageKey ? current.decisions : {};
+      const next = filterFeedbackDecisions({ ...currentDecisions, [taskId]: decision }, openTaskIds);
+      if (draftStorageKey) {
+        writeFeedbackDraft(draftStorageKey, next);
+      }
+      return { storageKey: draftStorageKey, decisions: next };
+    });
+  };
+
+  const clearFeedbackDraft = () => {
+    if (draftStorageKey) {
+      removeFeedbackDraft(draftStorageKey);
+    }
+    setFeedbackDraft({ storageKey: draftStorageKey, decisions: {} });
+  };
 
   if (workspaceId == null || pipelineJobId == null) {
     return null;
@@ -192,7 +255,7 @@ export function PipelineReviewCheckpointCard({ workspaceId, pipelineJobId }: Pro
           <p className={styles.description}>답변은 같은 업무/다른 업무 제약으로 replay에 반영됩니다.</p>
         </div>
         <span className={styles.badge}>
-          {Object.keys(feedbackDecisions).length}/{openTasks.length} answered
+          {answeredFeedbackCount}/{openTasks.length} answered
         </span>
       </div>
       <div className={styles.feedbackList}>
@@ -215,17 +278,17 @@ export function PipelineReviewCheckpointCard({ workspaceId, pipelineJobId }: Pro
               />
             </div>
             <div className={styles.choiceRow}>
-              {[
+              {([
                 ["must_link", "같은 intent로 묶기"],
                 ["cannot_link", "분리하기"],
                 ["unsure", "판단 보류"],
-              ].map(([value, label]) => (
+              ] satisfies Array<[FeedbackDecision, string]>).map(([value, label]) => (
                 <button
                   key={value}
                   type="button"
-                  className={`${styles.choiceButton} ${feedbackDecisions[task.id] === value ? styles.choiceButtonSelected : ""}`}
-                  aria-pressed={feedbackDecisions[task.id] === value}
-                  onClick={() => setFeedbackDecisions((current) => ({ ...current, [task.id]: value }))}
+                  className={`${styles.choiceButton} ${activeFeedbackDecisions[task.id] === value ? styles.choiceButtonSelected : ""}`}
+                  aria-pressed={activeFeedbackDecisions[task.id] === value}
+                  onClick={() => updateFeedbackDecision(task.id, value)}
                 >
                   {label}
                 </button>
@@ -242,8 +305,9 @@ export function PipelineReviewCheckpointCard({ workspaceId, pipelineJobId }: Pro
           submitFeedback.mutate(
             openTasks.map((task) => ({
               reviewTaskId: task.id,
-              decisionType: feedbackDecisions[task.id] ?? "unsure",
+              decisionType: activeFeedbackDecisions[task.id] ?? "unsure",
             })),
+            { onSuccess: clearFeedbackDraft },
           )
         }
       >
@@ -360,6 +424,74 @@ function reasonLabel(reason?: string): string {
     return "같은 클러스터로 묶였지만 경계 신뢰도가 낮습니다.";
   }
   return "클러스터 경계 판단이 필요합니다.";
+}
+
+function createFeedbackDraftStorageKey(workspaceId?: number, pipelineJobId?: number): string | null {
+  if (workspaceId == null || pipelineJobId == null) {
+    return null;
+  }
+  return `${FEEDBACK_DRAFT_KEY_PREFIX}:${workspaceId}:${pipelineJobId}`;
+}
+
+function readFeedbackDraft(storageKey: string, openTaskIds: number[]): FeedbackDecisions {
+  if (typeof window === "undefined") {
+    return {};
+  }
+
+  try {
+    const raw = window.localStorage.getItem(storageKey);
+    if (!raw) {
+      return {};
+    }
+
+    return filterFeedbackDecisions(JSON.parse(raw) as Record<string, unknown>, openTaskIds);
+  } catch {
+    return {};
+  }
+}
+
+function writeFeedbackDraft(storageKey: string, decisions: FeedbackDecisions) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    if (Object.keys(decisions).length === 0) {
+      window.localStorage.removeItem(storageKey);
+      return;
+    }
+    window.localStorage.setItem(storageKey, JSON.stringify(decisions));
+  } catch {
+    // Feedback can still be submitted even when browser storage is unavailable.
+  }
+}
+
+function removeFeedbackDraft(storageKey: string) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.localStorage.removeItem(storageKey);
+  } catch {
+    // Ignore storage failures; local component state is enough for the current session.
+  }
+}
+
+function filterFeedbackDecisions(decisions: Record<string, unknown>, openTaskIds: number[]): FeedbackDecisions {
+  const openTaskIdSet = new Set(openTaskIds);
+
+  return Object.entries(decisions).reduce<FeedbackDecisions>((filtered, [taskId, decision]) => {
+    const numericTaskId = Number(taskId);
+    if (openTaskIdSet.has(numericTaskId) && isFeedbackDecision(decision)) {
+      filtered[numericTaskId] = decision;
+    }
+    return filtered;
+  }, {});
+}
+
+function isFeedbackDecision(value: unknown): value is FeedbackDecision {
+  return FEEDBACK_DECISION_VALUES.some((decision) => decision === value);
 }
 
 function checkpointStateTitle(pipelineStatus?: string): string {


### PR DESCRIPTION
## Summary
- Human feedback 체크포인트에서 workspace/job 단위로 선택값을 localStorage에 임시 저장하고 현재 열린 작업 기준으로 복원합니다.
- 미제출 선택값이 있으면 새로고침/탭 닫기 전에 beforeunload 경고를 트리거하고, 제출 성공 후 draft를 정리합니다.
- 모든 열린 작업의 선택 여부와 제출 버튼 활성화 조건을 기존처럼 유지하고, 이슈 요구사항을 `.agent/specs/427.md`에 정리했습니다.

## Validation
- `cd frontend && pnpm test -- PipelineReviewCheckpointCard.test.tsx`
- `cd frontend && pnpm exec tsc --noEmit --ignoreDeprecations 5.0`
- `cd frontend && pnpm exec eslint src/features/pipeline-review/ui/PipelineReviewCheckpointCard.tsx src/features/pipeline-review/ui/PipelineReviewCheckpointCard.test.tsx`
- `git diff --check`
- `git diff --cached --check`

## Notes
- `cd frontend && pnpm lint`는 변경 범위 밖의 기존 lint 오류 59개로 실패했습니다. 변경 파일은 targeted eslint를 통과했습니다.

Closes #427