### PR TITLE
feat(demo): 사용자 채팅 미리보기 URL 정리

### DIFF
--- a/.agent/specs/435.md
+++ b/.agent/specs/435.md
@@ -1,0 +1,139 @@
+# 435 [FE] 사용자 채팅 미리보기 라우트 정리
+
+---
+
+## Goal
+
+`/demo` 진입 흐름에서 시작되는 사용자 채팅 미리보기 URL을 짧고 일관된 `/demo/chat/{workspaceId}` 형태로 정리하고, 기존 `/demo/workspaces/{workspaceId}/chat` 직접 링크는 안전하게 유지한다.
+
+---
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A["사용자가 /demo 진입"] --> B["회사 선택"]
+    B --> C{"상담 가능 회사인가?"}
+    C -->|No| D["시작 버튼 비활성 / 안내 메시지"]
+    C -->|Yes| E["이름 입력"]
+    E --> F["/demo/chat/{workspaceId}?name=... 이동"]
+    F --> G["UserChatPage에서 데모 채팅 시작"]
+
+    H["기존 /demo/workspaces/{workspaceId}/chat 직접 접근"] --> I["/demo/chat/{workspaceId}로 redirect"]
+    I --> G
+
+    J["운영자 사이드바 미리보기"] --> F
+```
+
+---
+
+## Design Diff
+
+### As-is vs To-be
+
+| 영역                      | As-is                                 | To-be                                   | 변경 내용                                             |
+| ------------------------- | ------------------------------------- | --------------------------------------- | ----------------------------------------------------- |
+| 공개 데모 채팅 URL        | `/demo/workspaces/{workspaceId}/chat` | `/demo/chat/{workspaceId}`              | 내부 리소스 구조가 드러나는 `workspaces` segment 제거 |
+| `/demo` 회사 선택 후 이동 | 기존 긴 경로로 이동                   | 새 canonical 경로로 이동                | URL 구조를 `/demo` 진입점과 일관되게 정리             |
+| 운영자 사이드바 미리보기  | 기존 긴 경로를 새 탭으로 오픈         | 새 canonical 경로를 새 탭으로 오픈      | 운영자 미리보기와 공개 데모 흐름의 URL 통일           |
+| 기존 직접 링크            | 같은 화면 직접 렌더링                 | 새 canonical 경로로 query 보존 redirect | 외부 공유 링크 및 북마크 호환성 유지                  |
+
+---
+
+## Component Tree
+
+```text
+App
+├─ /demo
+│  └─ DemoPage
+├─ /demo/chat/:workspaceId
+│  └─ UserChatPage
+└─ /demo/workspaces/:workspaceId/chat
+   └─ LegacyDemoChatRedirect
+
+Sidebar
+└─ 사용자 화면 미리보기 링크 -> /demo/chat/{workspaceId}
+```
+
+---
+
+## 수정 대상 파일
+
+| 파일                                                                   | 변경 유형 | 설명                                                                    |
+| ---------------------------------------------------------------------- | --------- | ----------------------------------------------------------------------- |
+| `frontend/src/app/App.tsx`                                             | modify    | 새 `/demo/chat/:workspaceId` 라우트와 기존 경로 redirect 정의           |
+| `frontend/src/pages/demo/ui/DemoPage.tsx`                              | modify    | 회사/이름 선택 후 새 canonical 채팅 경로로 이동                         |
+| `frontend/src/shared/ui/ostone/chrome/Sidebar.tsx`                     | modify    | 사용자 화면 미리보기 링크를 새 경로로 생성                              |
+| `frontend/src/shared/lib/demoRoutes.ts`                                | new       | 데모 채팅 경로 생성 helper                                              |
+| `frontend/src/features/auth/model/resolvePostLoginDestination.ts`      | modify    | 로그인 후 복귀 허용 경로에 새 데모 채팅 prefix 포함, legacy prefix 유지 |
+| `frontend/src/app/App.test.tsx`                                        | modify    | legacy 경로 redirect 검증                                               |
+| `frontend/src/pages/demo/ui/DemoPage.test.tsx`                         | modify    | 새 채팅 이동 경로 검증                                                  |
+| `frontend/src/shared/ui/ostone/chrome/Sidebar.test.tsx`                | modify    | 사이드바 미리보기 링크 검증                                             |
+| `frontend/src/features/auth/model/resolvePostLoginDestination.test.ts` | modify    | 새/기존 데모 채팅 복귀 경로 허용 검증                                   |
+| `frontend/e2e/demo.spec.ts`                                            | modify    | `/demo` 시작 플로우의 새 URL 검증                                       |
+| `frontend/e2e/user-chat.spec.ts`                                       | modify    | 새 직접 진입 URL과 legacy redirect 검증                                 |
+
+---
+
+## API Integration
+
+백엔드 API 변경은 없다. 사용자 채팅 화면은 기존과 동일하게 workspace id를 route parameter에서 읽고, 기존 데모 채팅 API를 호출한다.
+
+| Method | Path                                                                       | 변경 여부 |
+| ------ | -------------------------------------------------------------------------- | --------- |
+| POST   | `/api/v1/workspaces/{workspaceId}/demo/chat-sessions`                      | 변경 없음 |
+| GET    | `/api/v1/workspaces/{workspaceId}/demo/chat-sessions/{sessionId}/messages` | 변경 없음 |
+| POST   | `/api/v1/workspaces/{workspaceId}/demo/chat-sessions/{sessionId}/messages` | 변경 없음 |
+
+---
+
+## State Management
+
+새 전역 상태는 추가하지 않는다. `UserChatPage`의 기존 route parameter 기반 `workspaceId` 해석과 query string 기반 `name` 자동 시작 흐름을 유지한다.
+
+---
+
+## Requirements
+
+1. `/demo`에서 상담 가능 회사를 선택하고 이름을 입력하면 `/demo/chat/{workspaceId}?name=...`로 이동한다.
+2. `/demo/chat/{workspaceId}` 직접 접근 시 기존 `UserChatPage`가 렌더링되고 동일한 데모 채팅 API를 호출한다.
+3. `/demo/workspaces/{workspaceId}/chat` 직접 접근 시 query string을 보존하며 `/demo/chat/{workspaceId}`로 redirect한다.
+4. 운영자 사이드바의 “사용자 화면 미리보기” 링크는 현재 워크스페이스 기준 `/demo/chat/{workspaceId}`를 새 탭으로 연다.
+5. 로그인 후 복귀 경로 검증은 새 `/demo/chat/*` 경로를 허용하고 기존 `/demo/workspaces/*` 경로도 호환을 위해 유지한다.
+
+---
+
+## Non-goals
+
+- 데모 채팅 API 경로 변경.
+- `UserChatPage`의 대화 상태, localStorage key, WebSocket 구독 로직 변경.
+- `/demo` 회사 선택 화면의 시각 디자인 변경.
+- 워크스페이스 id가 아닌 slug 기반 공개 URL 도입.
+
+---
+
+## Tests
+
+### Test Strategy
+
+| 구분          | 방법                           | 비고                                                   |
+| ------------- | ------------------------------ | ------------------------------------------------------ |
+| 단위/컴포넌트 | `pnpm test`                    | 라우팅 helper 사용처, redirect, Sidebar, DemoPage 검증 |
+| E2E           | `pnpm e2e` 또는 대상 spec 실행 | `/demo` 시작 플로우, 직접 진입, legacy redirect 검증   |
+| 빌드          | `pnpm build`                   | route/import/type 오류 검증                            |
+
+### Acceptance Criteria
+
+| #   | 시나리오                                            | 기대 결과                                                        |
+| --- | --------------------------------------------------- | ---------------------------------------------------------------- |
+| 1   | `/demo`에서 enabled 회사 선택 후 이름 입력          | URL이 `/demo/chat/{workspaceId}?name=...`이고 채팅 화면이 열린다 |
+| 2   | `/demo/chat/{workspaceId}` 직접 접근                | 이름 입력 또는 `name` query 기반 자동 시작이 기존처럼 동작한다   |
+| 3   | `/demo/workspaces/{workspaceId}/chat?name=...` 접근 | `/demo/chat/{workspaceId}?name=...`로 redirect된다               |
+| 4   | 운영자 사이드바에서 “사용자 화면 미리보기” 클릭     | 새 탭 링크 href가 `/demo/chat/{workspaceId}`다                   |
+| 5   | 로그인 후 복귀 대상이 `/demo/chat/{workspaceId}`    | 안전한 내부 경로로 허용된다                                      |
+
+---
+
+## Open Questions
+
+- 없음. 이 이슈 범위에서는 workspace id 기반 URL을 유지하고 path segment만 정리한다.

--- a/frontend/e2e/demo.spec.ts
+++ b/frontend/e2e/demo.spec.ts
@@ -18,7 +18,10 @@ test.describe("Demo company picker", () => {
           const path = url.pathname.replace(/^\/api\/v1/, "");
           const method = request.method();
 
-          if (method === "POST" && path === "/workspaces/1/demo/chat-sessions") {
+          if (
+            method === "POST" &&
+            path === "/workspaces/1/demo/chat-sessions"
+          ) {
             expect(request.postDataJSON()).toEqual({ customerName: "김민지" });
             await route.fulfill({
               status: 200,
@@ -33,7 +36,10 @@ test.describe("Demo company picker", () => {
             return;
           }
 
-          if (method === "GET" && path === "/workspaces/1/demo/chat-sessions/91/messages") {
+          if (
+            method === "GET" &&
+            path === "/workspaces/1/demo/chat-sessions/91/messages"
+          ) {
             await route.fulfill({
               status: 200,
               contentType: "application/json",
@@ -42,8 +48,13 @@ test.describe("Demo company picker", () => {
             return;
           }
 
-          if (method === "POST" && path === "/workspaces/1/demo/chat-sessions/91/messages") {
-            expect(request.postDataJSON()).toEqual({ content: "환불 문의입니다" });
+          if (
+            method === "POST" &&
+            path === "/workspaces/1/demo/chat-sessions/91/messages"
+          ) {
+            expect(request.postDataJSON()).toEqual({
+              content: "환불 문의입니다",
+            });
             await route.fulfill({
               status: 200,
               contentType: "application/json",
@@ -72,7 +83,10 @@ test.describe("Demo company picker", () => {
           await route.fulfill({
             status: 500,
             contentType: "application/json",
-            body: JSON.stringify({ code: "E2E_UNMOCKED", message: `${method} ${path}` }),
+            body: JSON.stringify({
+              code: "E2E_UNMOCKED",
+              message: `${method} ${path}`,
+            }),
           });
         });
 
@@ -81,21 +95,29 @@ test.describe("Demo company picker", () => {
         await page.getByTestId("demo-name-input").fill("김민지");
         await page.getByTestId("demo-start-chat").click();
 
-        await expect(page).toHaveURL(/\/demo\/workspaces\/1\/chat\?name=/);
-        await expect(page.getByTestId("chat-conversation-screen")).toBeVisible();
+        await expect(page).toHaveURL(/\/demo\/chat\/1\?name=/);
+        await expect(
+          page.getByTestId("chat-conversation-screen"),
+        ).toBeVisible();
         await expect(page.getByTestId("chat-entry-screen")).toHaveCount(0);
-        await expect(page.getByText("안녕하세요, 김민지님. 무엇을 도와드릴까요?")).toBeVisible();
+        await expect(
+          page.getByText("안녕하세요, 김민지님. 무엇을 도와드릴까요?"),
+        ).toBeVisible();
 
         await page.getByLabel("메시지 입력").fill("환불 문의입니다");
         await page.getByRole("button", { name: "메시지 보내기" }).click();
 
         await expect(page.getByText("환불 문의입니다")).toBeVisible();
-        await expect(page.getByText("환불 절차를 안내해드릴게요.")).toBeVisible();
+        await expect(
+          page.getByText("환불 절차를 안내해드릴게요."),
+        ).toBeVisible();
       });
     });
 
     test.describe("When a user focuses a preview company", () => {
-      test("Then its info shows but the chat cannot be started", async ({ page }) => {
+      test("Then its info shows but the chat cannot be started", async ({
+        page,
+      }) => {
         await page.goto("/demo");
         await page.getByTestId("demo-company-card-2").click();
 

--- a/frontend/e2e/user-chat.spec.ts
+++ b/frontend/e2e/user-chat.spec.ts
@@ -9,7 +9,9 @@ test.describe("User demo chat", () => {
 
   test.describe("Given a demo workspace chat entry point", () => {
     test.describe("When a user starts a chat and sends a message", () => {
-      test("Then the screen creates the session and renders the saved reply", async ({ page }) => {
+      test("Then the screen creates the session and renders the saved reply", async ({
+        page,
+      }) => {
         const seen: string[] = [];
 
         await page.route("**/api/v1/**", async (route) => {
@@ -19,7 +21,10 @@ test.describe("User demo chat", () => {
           const method = request.method();
           seen.push(`${method} ${path}`);
 
-          if (method === "POST" && path === "/workspaces/42/demo/chat-sessions") {
+          if (
+            method === "POST" &&
+            path === "/workspaces/42/demo/chat-sessions"
+          ) {
             expect(request.postDataJSON()).toEqual({ customerName: "김민지" });
             await route.fulfill({
               status: 200,
@@ -34,7 +39,10 @@ test.describe("User demo chat", () => {
             return;
           }
 
-          if (method === "GET" && path === "/workspaces/42/demo/chat-sessions/77/messages") {
+          if (
+            method === "GET" &&
+            path === "/workspaces/42/demo/chat-sessions/77/messages"
+          ) {
             await route.fulfill({
               status: 200,
               contentType: "application/json",
@@ -43,8 +51,13 @@ test.describe("User demo chat", () => {
             return;
           }
 
-          if (method === "POST" && path === "/workspaces/42/demo/chat-sessions/77/messages") {
-            expect(request.postDataJSON()).toEqual({ content: "배송 문의입니다" });
+          if (
+            method === "POST" &&
+            path === "/workspaces/42/demo/chat-sessions/77/messages"
+          ) {
+            expect(request.postDataJSON()).toEqual({
+              content: "배송 문의입니다",
+            });
             await route.fulfill({
               status: 200,
               contentType: "application/json",
@@ -73,24 +86,45 @@ test.describe("User demo chat", () => {
           await route.fulfill({
             status: 500,
             contentType: "application/json",
-            body: JSON.stringify({ code: "E2E_UNMOCKED", message: `${method} ${path}` }),
+            body: JSON.stringify({
+              code: "E2E_UNMOCKED",
+              message: `${method} ${path}`,
+            }),
           });
         });
 
-        await page.goto("/demo/workspaces/42/chat");
+        await page.goto("/demo/chat/42");
         await page.getByTestId("chat-name-input").fill("김민지");
         await page.getByRole("button", { name: "채팅 시작" }).click();
 
-        await expect(page.getByTestId("chat-conversation-screen")).toBeVisible();
-        await expect(page.getByText("안녕하세요, 김민지님. 무엇을 도와드릴까요?")).toBeVisible();
+        await expect(
+          page.getByTestId("chat-conversation-screen"),
+        ).toBeVisible();
+        await expect(
+          page.getByText("안녕하세요, 김민지님. 무엇을 도와드릴까요?"),
+        ).toBeVisible();
 
         await page.getByLabel("메시지 입력").fill("배송 문의입니다");
         await page.getByRole("button", { name: "메시지 보내기" }).click();
 
         await expect(page.getByText("배송 문의입니다")).toBeVisible();
-        await expect(page.getByText("배송 상태를 확인해드릴게요.")).toBeVisible();
+        await expect(
+          page.getByText("배송 상태를 확인해드릴게요."),
+        ).toBeVisible();
         expect(seen).toContain("POST /workspaces/42/demo/chat-sessions");
-        expect(seen).toContain("POST /workspaces/42/demo/chat-sessions/77/messages");
+        expect(seen).toContain(
+          "POST /workspaces/42/demo/chat-sessions/77/messages",
+        );
+      });
+
+      test("Then the legacy workspace URL redirects to the canonical chat URL", async ({
+        page,
+      }) => {
+        await page.goto(
+          "/demo/workspaces/42/chat?name=%EA%B9%80%EB%AF%BC%EC%A7%80",
+        );
+
+        await expect(page).toHaveURL(/\/demo\/chat\/42\?name=/);
       });
     });
   });

--- a/frontend/src/app/App.test.tsx
+++ b/frontend/src/app/App.test.tsx
@@ -1,5 +1,12 @@
 import { render, screen, waitFor } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vite-plus/test";
 import { App } from "./App";
 import { AppProviders } from "./providers";
 
@@ -54,6 +61,25 @@ describe("App", () => {
       </AppProviders>,
     );
     expect(screen.getByText(/CS Workflow Generator/i)).toBeInTheDocument();
+  });
+
+  it("redirects legacy demo workspace chat URLs to the canonical demo chat URL", async () => {
+    window.history.pushState(
+      {},
+      "",
+      "/demo/workspaces/42/chat?name=%EA%B9%80%EB%AF%BC%EC%A7%80",
+    );
+
+    render(
+      <AppProviders>
+        <App />
+      </AppProviders>,
+    );
+
+    await waitFor(() => {
+      expect(window.location.pathname).toBe("/demo/chat/42");
+      expect(window.location.search).toBe("?name=%EA%B9%80%EB%AF%BC%EC%A7%80");
+    });
   });
 
   it("redirects workspace home alias to workflows and renders the empty workflow state when there are no domain packs", async () => {

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -1,4 +1,11 @@
-import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
+import {
+  BrowserRouter,
+  Routes,
+  Route,
+  Navigate,
+  useLocation,
+  useParams,
+} from "react-router-dom";
 import { LoginPage } from "../pages/login/ui/LoginPage";
 import { SignupPage } from "../pages/signup/ui/SignupPage";
 import { WorkspaceRootRedirect } from "../pages/workspace/ui/WorkspaceRootRedirect";
@@ -27,6 +34,18 @@ import { ErrorBoundary } from "../shared/ui/ErrorBoundary";
 import { Toaster } from "../shared/ui/sonner";
 import { WorkflowGraphViewerPage } from "../pages/domain-pack/ui/WorkflowGraphViewerPage";
 import { LegacyDomainPackVersionRedirect } from "../pages/domain-pack/ui/LegacyDomainPackVersionRedirect";
+import { buildDemoChatPath } from "../shared/lib/demoRoutes";
+
+function LegacyDemoChatRedirect() {
+  const { workspaceId } = useParams<{ workspaceId: string }>();
+  const { search } = useLocation();
+
+  if (!workspaceId) {
+    return <Navigate to="/demo" replace />;
+  }
+
+  return <Navigate to={`${buildDemoChatPath(workspaceId)}${search}`} replace />;
+}
 
 export function App() {
   return (
@@ -37,7 +56,10 @@ export function App() {
         <Route path="/login" element={<LoginPage />} />
         <Route path="/signup" element={<SignupPage />} />
         <Route path="/password-reset" element={<PasswordResetInitPage />} />
-        <Route path="/password-reset/complete" element={<PasswordResetCompletePage />} />
+        <Route
+          path="/password-reset/complete"
+          element={<PasswordResetCompletePage />}
+        />
         <Route
           path="/workspaces"
           element={
@@ -58,22 +80,37 @@ export function App() {
           <Route path="workflows" element={<WorkspaceWorkflowsPage />} />
           <Route path="pipeline" element={<Navigate to="upload" replace />} />
           <Route path="consultation/history" element={<ChatHistoryPage />} />
-          <Route path="consultation/history/:sessionId" element={<ChatHistoryPage />} />
+          <Route
+            path="consultation/history/:sessionId"
+            element={<ChatHistoryPage />}
+          />
           <Route path="consultation" element={<ConsultationPage />} />
-          <Route path="consultation/:sessionId" element={<ConsultationPage />} />
+          <Route
+            path="consultation/:sessionId"
+            element={<ConsultationPage />}
+          />
           <Route path="upload" element={<WorkspaceUploadPage />} />
-          <Route path="pipeline-jobs/:pipelineJobId/review" element={<PipelineReviewPage />} />
+          <Route
+            path="pipeline-jobs/:pipelineJobId/review"
+            element={<PipelineReviewPage />}
+          />
           <Route path="domain-packs" element={<DomainPackListPage />} />
         </Route>
         <Route
           path="/demo"
           element={
-            <ErrorBoundary fallback={<div>페이지를 불러오는 중 오류가 발생했습니다.</div>}>
+            <ErrorBoundary
+              fallback={<div>페이지를 불러오는 중 오류가 발생했습니다.</div>}
+            >
               <DemoPage />
             </ErrorBoundary>
           }
         />
-        <Route path="/demo/workspaces/:workspaceId/chat" element={<UserChatPage />} />
+        <Route path="/demo/chat/:workspaceId" element={<UserChatPage />} />
+        <Route
+          path="/demo/workspaces/:workspaceId/chat"
+          element={<LegacyDemoChatRedirect />}
+        />
         <Route
           path="/upload"
           element={
@@ -122,10 +159,19 @@ export function App() {
           <Route path="workflows">
             <Route index element={<PackWorkflowListPage />} />
             <Route path=":workflowId" element={<WorkflowDraftReadPage />} />
-            <Route path=":workflowId/graph" element={<WorkflowGraphViewerPage />} />
+            <Route
+              path=":workflowId/graph"
+              element={<WorkflowGraphViewerPage />}
+            />
           </Route>
-          <Route path="versions/:versionId/*" element={<LegacyDomainPackVersionRedirect />} />
-          <Route path="versions/:versionId" element={<LegacyDomainPackVersionRedirect />} />
+          <Route
+            path="versions/:versionId/*"
+            element={<LegacyDomainPackVersionRedirect />}
+          />
+          <Route
+            path="versions/:versionId"
+            element={<LegacyDomainPackVersionRedirect />}
+          />
         </Route>
         <Route path="*" element={<NotFoundPage />} />
       </Routes>

--- a/frontend/src/features/auth/model/resolvePostLoginDestination.test.ts
+++ b/frontend/src/features/auth/model/resolvePostLoginDestination.test.ts
@@ -15,7 +15,12 @@ describe("resolvePostLoginDestination", () => {
     ).toBe("/workspaces/1/upload?tab=logs");
   });
 
-  it("allows demo workspace chat paths", () => {
+  it("allows canonical and legacy demo chat paths", () => {
+    expect(
+      resolvePostLoginDestination({
+        from: { pathname: "/demo/chat/1", search: "?preview=true" },
+      }),
+    ).toBe("/demo/chat/1?preview=true");
     expect(
       resolvePostLoginDestination({
         from: { pathname: "/demo/workspaces/1/chat", search: "?preview=true" },
@@ -24,20 +29,26 @@ describe("resolvePostLoginDestination", () => {
   });
 
   it("falls back for auth routes", () => {
-    expect(resolvePostLoginDestination({ from: { pathname: "/login" } })).toBe("/workspaces");
-    expect(resolvePostLoginDestination({ from: { pathname: "/signup" } })).toBe("/workspaces");
+    expect(resolvePostLoginDestination({ from: { pathname: "/login" } })).toBe(
+      "/workspaces",
+    );
+    expect(resolvePostLoginDestination({ from: { pathname: "/signup" } })).toBe(
+      "/workspaces",
+    );
   });
 
   it("falls back for paths outside the workspace route boundary", () => {
-    expect(resolvePostLoginDestination({ from: { pathname: "/workspaces-public" } })).toBe(
-      "/workspaces",
-    );
+    expect(
+      resolvePostLoginDestination({ from: { pathname: "/workspaces-public" } }),
+    ).toBe("/workspaces");
   });
 
   it("falls back for dot-segment workspace paths", () => {
-    expect(resolvePostLoginDestination({ from: { pathname: "/workspaces/../login" } })).toBe(
-      "/workspaces",
-    );
+    expect(
+      resolvePostLoginDestination({
+        from: { pathname: "/workspaces/../login" },
+      }),
+    ).toBe("/workspaces");
     expect(
       resolvePostLoginDestination({
         from: { pathname: "/workspaces/%2e%2e/login" },

--- a/frontend/src/features/auth/model/resolvePostLoginDestination.ts
+++ b/frontend/src/features/auth/model/resolvePostLoginDestination.ts
@@ -1,5 +1,9 @@
 const DEFAULT_POST_LOGIN_PATH = "/workspaces";
-const ALLOWED_RETURN_PREFIXES = ["/workspaces", "/demo/workspaces"];
+const ALLOWED_RETURN_PREFIXES = [
+  "/workspaces",
+  "/demo/chat",
+  "/demo/workspaces",
+];
 
 interface ReturnLocation {
   pathname?: unknown;
@@ -25,7 +29,9 @@ function extractReturnLocation(state: unknown): ReturnLocation | null {
 }
 
 function isExternalUrl(pathname: string): boolean {
-  return /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(pathname) || pathname.startsWith("//");
+  return (
+    /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(pathname) || pathname.startsWith("//")
+  );
 }
 
 function isAllowedPath(pathname: string): boolean {

--- a/frontend/src/pages/demo/ui/DemoPage.test.tsx
+++ b/frontend/src/pages/demo/ui/DemoPage.test.tsx
@@ -28,22 +28,28 @@ describe("DemoPage", () => {
     expect(screen.getByTestId("demo-company-card-1")).toBeInTheDocument();
     expect(screen.getByTestId("demo-company-card-2")).toBeInTheDocument();
     expect(screen.getByTestId("demo-company-card-3")).toBeInTheDocument();
-    expect(screen.getByTestId("demo-company-info")).toHaveTextContent("컴플레인 테스트 워크스페이스");
+    expect(screen.getByTestId("demo-company-info")).toHaveTextContent(
+      "컴플레인 테스트 워크스페이스",
+    );
   });
 
   it("shows a company's info on hover", () => {
     renderDemoPage();
     fireEvent.mouseEnter(screen.getByTestId("demo-company-card-2"));
-    expect(screen.getByTestId("demo-company-info")).toHaveTextContent("카드 이용내역 조회 상담");
+    expect(screen.getByTestId("demo-company-info")).toHaveTextContent(
+      "카드 이용내역 조회 상담",
+    );
   });
 
   it("navigates to the chat with an encoded name for an enabled company", () => {
     renderDemoPage();
     fireEvent.click(screen.getByTestId("demo-company-card-1"));
-    fireEvent.change(screen.getByTestId("demo-name-input"), { target: { value: "김민지" } });
+    fireEvent.change(screen.getByTestId("demo-name-input"), {
+      target: { value: "김민지" },
+    });
     fireEvent.click(screen.getByTestId("demo-start-chat"));
     expect(navigateMock).toHaveBeenCalledWith(
-      `/demo/workspaces/1/chat?name=${encodeURIComponent("김민지")}`,
+      `/demo/chat/1?name=${encodeURIComponent("김민지")}`,
     );
   });
 
@@ -60,7 +66,9 @@ describe("DemoPage", () => {
     fireEvent.click(screen.getByTestId("demo-company-card-2"));
     expect(screen.getByTestId("demo-start-chat")).toBeDisabled();
     fireEvent.submit(screen.getByTestId("demo-name-form"));
-    expect(screen.getByTestId("demo-name-error")).toHaveTextContent("데모를 준비 중");
+    expect(screen.getByTestId("demo-name-error")).toHaveTextContent(
+      "데모를 준비 중",
+    );
     expect(navigateMock).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/demo/ui/DemoPage.tsx
+++ b/frontend/src/pages/demo/ui/DemoPage.tsx
@@ -1,7 +1,12 @@
 import { type FormEvent, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { buildDemoChatPath } from "@/shared/lib/demoRoutes";
 import { CompanyCard } from "./CompanyCard";
-import { DEMO_COMPANIES, type DemoCompany, getDefaultDemoCompany } from "../model/demoCompanies";
+import {
+  DEMO_COMPANIES,
+  type DemoCompany,
+  getDefaultDemoCompany,
+} from "../model/demoCompanies";
 
 const labelStyle = {
   fontFamily: "var(--mono)",
@@ -13,7 +18,9 @@ const labelStyle = {
 
 export function DemoPage() {
   const navigate = useNavigate();
-  const [activeCompany, setActiveCompany] = useState<DemoCompany>(getDefaultDemoCompany);
+  const [activeCompany, setActiveCompany] = useState<DemoCompany>(
+    getDefaultDemoCompany,
+  );
   const [draftName, setDraftName] = useState("");
   const [nameError, setNameError] = useState<string | null>(null);
 
@@ -21,7 +28,9 @@ export function DemoPage() {
     event.preventDefault();
 
     if (!activeCompany.enabled) {
-      setNameError("선택한 회사는 아직 데모를 준비 중입니다. 다른 회사를 선택해 주세요.");
+      setNameError(
+        "선택한 회사는 아직 데모를 준비 중입니다. 다른 회사를 선택해 주세요.",
+      );
       return;
     }
 
@@ -32,7 +41,12 @@ export function DemoPage() {
     }
 
     setNameError(null);
-    navigate(`/demo/workspaces/${activeCompany.workspaceId}/chat?name=${encodeURIComponent(name)}`);
+    navigate(
+      buildDemoChatPath(
+        activeCompany.workspaceId,
+        new URLSearchParams({ name }),
+      ),
+    );
   };
 
   return (
@@ -62,13 +76,34 @@ export function DemoPage() {
           style={{ display: "flex", flexDirection: "column", gap: 12 }}
         >
           <div style={labelStyle}>Step 1 · 회사 선택</div>
-          <h1 style={{ margin: 0, fontSize: 24, fontWeight: 540, letterSpacing: "-0.4px" }}>
+          <h1
+            style={{
+              margin: 0,
+              fontSize: 24,
+              fontWeight: 540,
+              letterSpacing: "-0.4px",
+            }}
+          >
             상담할 회사를 선택하세요
           </h1>
-          <p style={{ margin: 0, fontSize: 13, lineHeight: 1.6, color: "var(--ink-2)" }}>
+          <p
+            style={{
+              margin: 0,
+              fontSize: 13,
+              lineHeight: 1.6,
+              color: "var(--ink-2)",
+            }}
+          >
             카드를 클릭하거나 마우스를 올리면 회사 정보를 볼 수 있습니다.
           </p>
-          <div style={{ display: "flex", flexDirection: "column", gap: 10, marginTop: 4 }}>
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: 10,
+              marginTop: 4,
+            }}
+          >
             {DEMO_COMPANIES.map((company) => (
               <CompanyCard
                 key={company.workspaceId}
@@ -90,7 +125,8 @@ export function DemoPage() {
             borderRadius: 12,
             border: "1px solid var(--line)",
             background: "var(--paper)",
-            boxShadow: "0 1px 2px rgba(15, 23, 42, 0.04), 0 18px 36px rgba(15, 23, 42, 0.06)",
+            boxShadow:
+              "0 1px 2px rgba(15, 23, 42, 0.04), 0 18px 36px rgba(15, 23, 42, 0.06)",
           }}
         >
           <div
@@ -98,10 +134,24 @@ export function DemoPage() {
             style={{ display: "flex", flexDirection: "column", gap: 12 }}
           >
             <div style={labelStyle}>{activeCompany.industry}</div>
-            <h2 style={{ margin: 0, fontSize: 22, fontWeight: 540, letterSpacing: "-0.3px" }}>
+            <h2
+              style={{
+                margin: 0,
+                fontSize: 22,
+                fontWeight: 540,
+                letterSpacing: "-0.3px",
+              }}
+            >
               {activeCompany.name}
             </h2>
-            <p style={{ margin: 0, fontSize: 13.5, lineHeight: 1.65, color: "var(--ink-2)" }}>
+            <p
+              style={{
+                margin: 0,
+                fontSize: 13.5,
+                lineHeight: 1.65,
+                color: "var(--ink-2)",
+              }}
+            >
               {activeCompany.blurb}
             </p>
             <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
@@ -141,7 +191,10 @@ export function DemoPage() {
             }}
           >
             <div style={labelStyle}>Step 2 · 이름 입력</div>
-            <label htmlFor="demo-customer-name" style={{ ...labelStyle, marginBottom: 0 }}>
+            <label
+              htmlFor="demo-customer-name"
+              style={{ ...labelStyle, marginBottom: 0 }}
+            >
               이름
             </label>
             <input
@@ -185,7 +238,9 @@ export function DemoPage() {
                 padding: "0 18px",
                 borderRadius: 999,
                 border: "none",
-                background: activeCompany.enabled ? "var(--ink)" : "var(--ink-3)",
+                background: activeCompany.enabled
+                  ? "var(--ink)"
+                  : "var(--ink-3)",
                 color: "var(--paper)",
                 fontSize: 14,
                 fontWeight: 540,

--- a/frontend/src/shared/lib/demoRoutes.ts
+++ b/frontend/src/shared/lib/demoRoutes.ts
@@ -1,0 +1,7 @@
+export function buildDemoChatPath(
+  workspaceId: number | string,
+  searchParams?: URLSearchParams,
+): string {
+  const search = searchParams?.toString();
+  return `/demo/chat/${encodeURIComponent(String(workspaceId))}${search ? `?${search}` : ""}`;
+}

--- a/frontend/src/shared/ui/ostone/chrome/Sidebar.test.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/Sidebar.test.tsx
@@ -59,7 +59,10 @@ describe("Sidebar", () => {
   it("Domain Packs 링크는 active=consult이면 비활성이다", () => {
     renderSidebar({ active: "consult" });
 
-    expect(screen.getByTestId("sidebar-domain-link")).toHaveAttribute("data-active", "false");
+    expect(screen.getByTestId("sidebar-domain-link")).toHaveAttribute(
+      "data-active",
+      "false",
+    );
   });
 
   it("접기 버튼을 렌더하지 않는다", () => {
@@ -71,29 +74,44 @@ describe("Sidebar", () => {
   it("active=consult일 때 Consultation 항목이 강조된다", () => {
     renderSidebar({ active: "consult" });
 
-    expect(screen.getByTitle("상담 응대")).toHaveAttribute("data-active", "true");
+    expect(screen.getByTitle("상담 응대")).toHaveAttribute(
+      "data-active",
+      "true",
+    );
   });
 
   it("basePath prop을 지정하면 링크에 반영된다", () => {
     renderSidebar({ basePath: "/workspaces/7" });
 
-    expect(screen.getByTitle("상담 응대")).toHaveAttribute("href", "/workspaces/7/consultation");
+    expect(screen.getByTitle("상담 응대")).toHaveAttribute(
+      "href",
+      "/workspaces/7/consultation",
+    );
     expect(screen.getByTitle("사용자 화면 미리보기")).toHaveAttribute(
       "href",
-      "/demo/workspaces/7/chat",
+      "/demo/chat/7",
     );
-    expect(screen.getByTitle("사용자 화면 미리보기")).toHaveAttribute("target", "_blank");
+    expect(screen.getByTitle("사용자 화면 미리보기")).toHaveAttribute(
+      "target",
+      "_blank",
+    );
     expect(screen.getByTitle("사용자 화면 미리보기")).toHaveAttribute(
       "rel",
       "noopener noreferrer",
     );
-    expect(screen.getByTitle("도메인팩 관리")).toHaveAttribute("href", "/workspaces/7/domain-packs");
+    expect(screen.getByTitle("도메인팩 관리")).toHaveAttribute(
+      "href",
+      "/workspaces/7/domain-packs",
+    );
   });
 
   it("workspaceId를 추출할 수 없으면 사용자 화면 미리보기 링크를 안전한 내부 경로로 보낸다", () => {
     renderSidebar({ basePath: "/workspaces" });
 
-    expect(screen.getByTitle("사용자 화면 미리보기")).toHaveAttribute("href", "/workspaces");
+    expect(screen.getByTitle("사용자 화면 미리보기")).toHaveAttribute(
+      "href",
+      "/workspaces",
+    );
   });
 
   it("switcher가 주어지면 렌더링된다", () => {

--- a/frontend/src/shared/ui/ostone/chrome/Sidebar.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/Sidebar.tsx
@@ -1,5 +1,6 @@
 import type { CSSProperties, MouseEvent, ReactNode } from "react";
 import { NavLink } from "react-router-dom";
+import { buildDemoChatPath } from "@/shared/lib/demoRoutes";
 import { Icon } from "../atoms/Icon";
 import type { IconName } from "../atoms/Icon";
 import { AccountMenu } from "./AccountMenu";
@@ -36,7 +37,7 @@ function getDemoChatPath(base: string): string {
     return "/workspaces";
   }
 
-  return `/demo/workspaces/${match[1]}/chat`;
+  return buildDemoChatPath(match[1]);
 }
 
 const TOP_NAV_ITEMS: TopNavItem[] = [
@@ -93,8 +94,14 @@ export function Sidebar({
   basePath = "/workspaces",
   switcher,
 }: SidebarProps) {
-  const { containerBg, borderColor, defaultColor, hoverBg, activeBg, activeColor } =
-    deriveSidebarColors(dark);
+  const {
+    containerBg,
+    borderColor,
+    defaultColor,
+    hoverBg,
+    activeBg,
+    activeColor,
+  } = deriveSidebarColors(dark);
 
   return (
     <nav


### PR DESCRIPTION
## Summary
- `/demo/chat/:workspaceId`를 사용자 채팅 미리보기 canonical route로 추가하고 기존 `/demo/workspaces/:workspaceId/chat`는 query를 보존해 redirect합니다.
- `/demo` 회사 선택 화면과 운영자 사이드바 미리보기 링크가 새 canonical URL을 사용하도록 정리했습니다.
- 로그인 후 복귀 허용 경로, 관련 unit/E2E 기대값, 이슈 스펙 `.agent/specs/435.md`를 갱신했습니다.

## Validation
- `cd frontend && pnpm test -- App.test.tsx DemoPage.test.tsx Sidebar.test.tsx resolvePostLoginDestination.test.ts UserChatPage.test.tsx`
- `cd frontend && pnpm exec eslint src/app/App.tsx src/app/App.test.tsx src/features/auth/model/resolvePostLoginDestination.ts src/features/auth/model/resolvePostLoginDestination.test.ts src/pages/demo/ui/DemoPage.tsx src/pages/demo/ui/DemoPage.test.tsx src/shared/lib/demoRoutes.ts src/shared/ui/ostone/chrome/Sidebar.tsx src/shared/ui/ostone/chrome/Sidebar.test.tsx`
- `cd frontend && pnpm build`
- `git diff --check`
- `git diff --cached --check`
- `pnpm exec prettier --check .agent/specs/435.md frontend/e2e/demo.spec.ts frontend/e2e/user-chat.spec.ts frontend/src/app/App.tsx frontend/src/app/App.test.tsx frontend/src/features/auth/model/resolvePostLoginDestination.ts frontend/src/features/auth/model/resolvePostLoginDestination.test.ts frontend/src/pages/demo/ui/DemoPage.tsx frontend/src/pages/demo/ui/DemoPage.test.tsx frontend/src/shared/lib/demoRoutes.ts frontend/src/shared/ui/ostone/chrome/Sidebar.tsx frontend/src/shared/ui/ostone/chrome/Sidebar.test.tsx`
- Browser preview: `http://127.0.0.1:4173/demo/workspaces/42/chat?name=...` redirects to `/demo/chat/42?name=...`

## Notes
- `cd frontend && pnpm lint`는 변경 범위 밖의 기존 lint 오류로 실패했습니다. 변경 파일은 targeted eslint와 commit hook lint-staged를 통과했습니다.
- `cd frontend && pnpm e2e -- demo.spec.ts user-chat.spec.ts`는 로컬 port 3000에 다른 프로세스가 떠 있어 신뢰 가능한 결과를 얻지 못했습니다.

Closes #435