### PR TITLE
fix(domain-pack): 도메인팩 상태 필터 동작 제공

### DIFF
--- a/.agent/specs/418.md
+++ b/.agent/specs/418.md
@@ -1,0 +1,133 @@
+# Frontend FSD Spec: Domain Pack Status Filter
+
+## Goal
+
+도메인팩 관리 화면 상단의 `전체`, `운영중`, `비운영` 상태 pill을 실제 목록 필터로 동작시켜 사용자가 상태별 도메인팩만 확인할 수 있게 한다.
+
+---
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A["도메인팩 관리 화면 진입"] --> B{"Domain Pack 존재?"}
+    B -->|No| C["전체 빈 상태 표시"]
+    B -->|Yes| D["상태별 카운트와 전체 목록 표시"]
+    D --> E{"상태 필터 선택"}
+    E -->|전체| F["운영중/비운영 섹션 모두 표시"]
+    E -->|운영중| G["currentVersionId가 있는 도메인팩만 표시"]
+    E -->|비운영| H["currentVersionId가 없는 도메인팩만 표시"]
+    G --> I{"결과 존재?"}
+    H --> I
+    I -->|Yes| J["필터 결과 카드 표시"]
+    I -->|No| K["선택 상태의 섹션 빈 상태 표시"]
+```
+
+---
+
+## Design Diff
+
+### As-is vs To-be
+
+| 영역 | As-is | To-be | 변경 내용 |
+|------|-------|-------|----------|
+| 상태 pill | `span`으로 렌더링되는 정적 요약 | `button` 기반 필터 컨트롤 | 클릭/키보드 선택 가능 |
+| 선택 상태 | 없음 | active 스타일과 `aria-pressed` 제공 | 현재 필터가 시각적/접근성 상태로 드러남 |
+| 목록 표시 | 운영중/비운영 섹션을 항상 모두 표시 | 선택된 필터에 맞는 섹션만 표시 | `currentVersionId` 기준 클라이언트 필터링 |
+| URL 상태 | 없음 | `status=operating` 또는 `status=idle` query 유지 | 새로고침/공유 시 필터 보존, 전체는 query 제거 |
+
+---
+
+## Component Tree
+
+```
+DomainPackListPage
+├─ Header
+│  └─ StatusFilterButtons
+└─ Sections
+   ├─ PackSection (operating)
+   └─ PackSection (idle)
+```
+
+---
+
+## API Integration
+
+### Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/v1/workspaces/{workspaceId}/domain-packs` | 워크스페이스 도메인팩 전체 목록 조회 |
+
+서버 API는 상태 필터 query parameter를 제공하지 않는다. 이번 변경은 이미 받은 전체 목록을 `currentVersionId` 존재 여부로 클라이언트에서 필터링한다.
+
+---
+
+## 수정 대상 파일
+
+| 파일 | 변경 유형 | 설명 |
+|------|----------|------|
+| `frontend/src/pages/domain-pack/ui/DomainPackListPage.tsx` | modify | 상태 필터 query 파싱, 버튼 이벤트, 조건부 섹션 렌더링 |
+| `frontend/src/pages/domain-pack/ui/domain-pack-list-page.module.css` | modify | 필터 버튼 active/focus/hover 스타일 |
+| `frontend/src/pages/domain-pack/ui/DomainPackListPage.test.tsx` | modify | 필터 선택, URL query 초기 상태, empty state 테스트 |
+
+---
+
+## State Management
+
+필터 상태는 `react-router-dom`의 `useSearchParams`로 관리한다.
+
+| 상태 | Query | 의미 |
+|------|-------|------|
+| 전체 | 없음 또는 미지원 값 | 모든 도메인팩 표시 |
+| 운영중 | `status=operating` | `currentVersionId != null`인 도메인팩 표시 |
+| 비운영 | `status=idle` | `currentVersionId == null`인 도메인팩 표시 |
+
+---
+
+## Tests
+
+### Test Strategy
+
+| 구분 | 방법 | 도구 | 비고 |
+|------|------|------|------|
+| 컴포넌트 테스트 | 필터 버튼 클릭과 query 초기 상태 검증 | Vitest + React Testing Library | 기존 API hook mock 재사용 |
+
+### Test Scenarios
+
+#### Happy Path
+
+| # | 시나리오 | 사전 조건 | 조작 | 기대 결과 |
+|---|---------|---------|------|----------|
+| 1 | 전체 필터 | 운영중/비운영 pack 존재 | `전체` 선택 | 두 섹션과 모든 pack 표시 |
+| 2 | 운영중 필터 | 운영중/비운영 pack 존재 | `운영중` 선택 | 운영중 pack만 표시, active 상태 표시 |
+| 3 | 비운영 필터 | 운영중/비운영 pack 존재 | `비운영` 선택 | 비운영 pack만 표시, active 상태 표시 |
+| 4 | URL query 복원 | `?status=operating`으로 진입 | 페이지 렌더 | 운영중 필터가 선택된 상태로 표시 |
+
+#### Error & Edge Cases
+
+| # | 시나리오 | 기대 결과 |
+|---|---------|----------|
+| 1 | 선택한 상태에 결과 없음 | 해당 섹션의 empty state 표시 |
+| 2 | 미지원 `status` query | 전체 필터로 처리 |
+| 3 | 전체 데이터 없음 | 기존 전체 EmptyState 유지 |
+
+#### 반응형 & 접근성
+
+| # | 확인 항목 | 기대 결과 |
+|---|---------|----------|
+| 1 | 키보드 탐색 | 필터 버튼에 focus-visible ring 표시 |
+| 2 | 스크린 리더 | 필터 그룹 label과 `aria-pressed`로 선택 상태 인지 가능 |
+| 3 | 모바일 | pill 버튼이 줄바꿈되어 겹침 없이 표시 |
+
+---
+
+## Non-goals
+
+- 서버 사이드 필터 API 또는 Orval generated API 변경은 포함하지 않는다.
+- 도메인팩 상태 모델을 새 enum으로 backend에 추가하지 않는다.
+- 검색, 정렬, 페이지네이션을 함께 추가하지 않는다.
+
+## Open Questions
+
+- 없음. 이슈의 확인 기준은 클라이언트 필터링으로 충족 가능하다.

--- a/frontend/src/pages/domain-pack/ui/DomainPackListPage.test.tsx
+++ b/frontend/src/pages/domain-pack/ui/DomainPackListPage.test.tsx
@@ -137,6 +137,148 @@ describe("DomainPackListPage", () => {
     expect(screen.getByText("비운영 2")).toBeInTheDocument();
   });
 
+  it("운영중 필터를 선택하면 운영중 도메인팩만 표시한다", () => {
+    useListDomainPacks.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: {
+        data: [
+          { packId: 1, name: "Live Pack", currentVersionId: 10 },
+          { packId: 2, name: "Draft Pack" },
+        ],
+      },
+      refetch: vi.fn(),
+    });
+    renderPage();
+
+    fireEvent.click(screen.getByRole("button", { name: "운영중 1" }));
+
+    expect(screen.getByRole("button", { name: "운영중 1" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByText("Live Pack")).toBeInTheDocument();
+    expect(screen.queryByText("Draft Pack")).not.toBeInTheDocument();
+    expect(screen.getByText("운영중인 도메인팩")).toBeInTheDocument();
+    expect(screen.queryByText("비운영 도메인팩")).not.toBeInTheDocument();
+  });
+
+  it("비운영 필터를 선택하면 비운영 도메인팩만 표시한다", () => {
+    useListDomainPacks.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: {
+        data: [
+          { packId: 1, name: "Live Pack", currentVersionId: 10 },
+          { packId: 2, name: "Draft Pack" },
+        ],
+      },
+      refetch: vi.fn(),
+    });
+    renderPage();
+
+    fireEvent.click(screen.getByRole("button", { name: "비운영 1" }));
+
+    expect(screen.getByRole("button", { name: "비운영 1" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByText("Draft Pack")).toBeInTheDocument();
+    expect(screen.queryByText("Live Pack")).not.toBeInTheDocument();
+    expect(screen.getByText("비운영 도메인팩")).toBeInTheDocument();
+    expect(screen.queryByText("운영중인 도메인팩")).not.toBeInTheDocument();
+  });
+
+  it("URL query의 상태 필터를 초기 선택 상태로 반영한다", () => {
+    useListDomainPacks.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: {
+        data: [
+          { packId: 1, name: "Live Pack", currentVersionId: 10 },
+          { packId: 2, name: "Draft Pack" },
+        ],
+      },
+      refetch: vi.fn(),
+    });
+
+    renderPage("/workspaces/1/domain-packs?status=operating");
+
+    expect(screen.getByRole("button", { name: "운영중 1" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByText("Live Pack")).toBeInTheDocument();
+    expect(screen.queryByText("Draft Pack")).not.toBeInTheDocument();
+  });
+
+  it("전체 필터를 선택하면 운영중과 비운영 도메인팩을 모두 표시한다", () => {
+    useListDomainPacks.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: {
+        data: [
+          { packId: 1, name: "Live Pack", currentVersionId: 10 },
+          { packId: 2, name: "Draft Pack" },
+        ],
+      },
+      refetch: vi.fn(),
+    });
+    renderPage("/workspaces/1/domain-packs?status=operating");
+
+    fireEvent.click(screen.getByRole("button", { name: "전체 2" }));
+
+    expect(screen.getByRole("button", { name: "전체 2" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByText("Live Pack")).toBeInTheDocument();
+    expect(screen.getByText("Draft Pack")).toBeInTheDocument();
+    expect(screen.getByText("운영중인 도메인팩")).toBeInTheDocument();
+    expect(screen.getByText("비운영 도메인팩")).toBeInTheDocument();
+  });
+
+  it("지원하지 않는 상태 query는 전체 필터로 처리한다", () => {
+    useListDomainPacks.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: {
+        data: [
+          { packId: 1, name: "Live Pack", currentVersionId: 10 },
+          { packId: 2, name: "Draft Pack" },
+        ],
+      },
+      refetch: vi.fn(),
+    });
+
+    renderPage("/workspaces/1/domain-packs?status=unknown");
+
+    expect(screen.getByRole("button", { name: "전체 2" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByText("Live Pack")).toBeInTheDocument();
+    expect(screen.getByText("Draft Pack")).toBeInTheDocument();
+  });
+
+  it("선택한 상태에 도메인팩이 없으면 섹션 빈 상태를 표시한다", () => {
+    useListDomainPacks.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: {
+        data: [{ packId: 2, name: "Draft Pack" }],
+      },
+      refetch: vi.fn(),
+    });
+    renderPage();
+
+    fireEvent.click(screen.getByRole("button", { name: "운영중 0" }));
+
+    expect(screen.getByText("운영중인 도메인팩")).toBeInTheDocument();
+    expect(screen.getByText("운영중인 도메인팩이 없습니다.")).toBeInTheDocument();
+    expect(screen.queryByText("Draft Pack")).not.toBeInTheDocument();
+  });
+
   it("name이 없으면 Pack {id} 폴백을 표시한다", () => {
     useListDomainPacks.mockReturnValue({
       isLoading: false,

--- a/frontend/src/pages/domain-pack/ui/DomainPackListPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/DomainPackListPage.tsx
@@ -1,5 +1,5 @@
 import { ArrowRightIcon } from "lucide-react";
-import { Link, Navigate, useParams } from "react-router-dom";
+import { Link, Navigate, useParams, useSearchParams } from "react-router-dom";
 
 import { unwrapApiResponse } from "@/shared/api";
 import { useListDomainPacks } from "@/shared/api/generated/endpoints/domain-pack-controller/domain-pack-controller";
@@ -11,6 +11,19 @@ import { ErrorState } from "@/shared/ui/ostone/atoms/ErrorState";
 import { LoadingSpinner } from "@/shared/ui/ostone/atoms/LoadingSpinner";
 
 import styles from "./domain-pack-list-page.module.css";
+
+type DomainPackStatusFilter = "all" | "operating" | "idle";
+
+const STATUS_FILTER_QUERY_KEY = "status";
+const STATUS_FILTERS: Array<{ value: DomainPackStatusFilter; label: string }> = [
+  { value: "all", label: "전체" },
+  { value: "operating", label: "운영중" },
+  { value: "idle", label: "비운영" },
+];
+
+function parseStatusFilter(value: string | null): DomainPackStatusFilter {
+  return value === "operating" || value === "idle" ? value : "all";
+}
 
 function isOperatingPack(pack: DomainPackSummaryResult): boolean {
   return pack.currentVersionId != null;
@@ -125,12 +138,29 @@ function PackSection({ id, title, count, emptyMessage, packs, workspaceId }: Pac
 
 export function DomainPackListPage() {
   const { workspaceId } = useParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const parsedWorkspaceId = parseRouteId(workspaceId);
   const safeWorkspaceId = parsedWorkspaceId ?? 0;
+  const selectedStatusFilter = parseStatusFilter(searchParams.get(STATUS_FILTER_QUERY_KEY));
 
   const query = useListDomainPacks(safeWorkspaceId, {
     query: { enabled: parsedWorkspaceId !== null },
   });
+
+  const handleStatusFilterChange = (nextFilter: DomainPackStatusFilter) => {
+    setSearchParams(
+      (current) => {
+        const next = new URLSearchParams(current);
+        if (nextFilter === "all") {
+          next.delete(STATUS_FILTER_QUERY_KEY);
+        } else {
+          next.set(STATUS_FILTER_QUERY_KEY, nextFilter);
+        }
+        return next;
+      },
+      { replace: true },
+    );
+  };
 
   if (parsedWorkspaceId === null) {
     return <Navigate to="/workspaces" replace />;
@@ -170,37 +200,59 @@ export function DomainPackListPage() {
 
   const operatingPacks = packs.filter(isOperatingPack);
   const idlePacks = packs.filter((pack) => !isOperatingPack(pack));
+  const filterCounts: Record<DomainPackStatusFilter, number> = {
+    all: packs.length,
+    operating: operatingPacks.length,
+    idle: idlePacks.length,
+  };
+  const showOperatingSection = selectedStatusFilter !== "idle";
+  const showIdleSection = selectedStatusFilter !== "operating";
 
   return (
     <div className={styles.pageWrapper}>
       <div className={styles.pageHeader}>
         <div>
           <h1 className={styles.pageTitle}>도메인팩 관리</h1>
-          <div className={styles.summaryRow} aria-label="도메인팩 상태 요약">
-            <span className={styles.summaryPill}>전체 {packs.length}</span>
-            <span className={styles.summaryPill}>운영중 {operatingPacks.length}</span>
-            <span className={styles.summaryPill}>비운영 {idlePacks.length}</span>
+          <div className={styles.summaryRow} aria-label="도메인팩 상태 필터">
+            {STATUS_FILTERS.map((filter) => {
+              const selected = selectedStatusFilter === filter.value;
+              return (
+                <button
+                  key={filter.value}
+                  type="button"
+                  className={`${styles.summaryPill} ${selected ? styles.summaryPillActive : ""}`}
+                  aria-pressed={selected}
+                  onClick={() => handleStatusFilterChange(filter.value)}
+                >
+                  {filter.label} {filterCounts[filter.value]}
+                </button>
+              );
+            })}
           </div>
         </div>
       </div>
 
       <div className={styles.sections}>
-        <PackSection
-          id="operating-domain-packs"
-          title="운영중인 도메인팩"
-          count={operatingPacks.length}
-          emptyMessage="운영중인 도메인팩이 없습니다."
-          packs={operatingPacks}
-          workspaceId={parsedWorkspaceId}
-        />
-        <PackSection
-          id="idle-domain-packs"
-          title="비운영 도메인팩"
-          count={idlePacks.length}
-          emptyMessage="비운영 도메인팩이 없습니다."
-          packs={idlePacks}
-          workspaceId={parsedWorkspaceId}
-        />
+        {showOperatingSection ? (
+          <PackSection
+            id="operating-domain-packs"
+            title="운영중인 도메인팩"
+            count={operatingPacks.length}
+            emptyMessage="운영중인 도메인팩이 없습니다."
+            packs={operatingPacks}
+            workspaceId={parsedWorkspaceId}
+          />
+        ) : null}
+        {showIdleSection ? (
+          <PackSection
+            id="idle-domain-packs"
+            title="비운영 도메인팩"
+            count={idlePacks.length}
+            emptyMessage="비운영 도메인팩이 없습니다."
+            packs={idlePacks}
+            workspaceId={parsedWorkspaceId}
+          />
+        ) : null}
       </div>
     </div>
   );

--- a/frontend/src/pages/domain-pack/ui/domain-pack-list-page.module.css
+++ b/frontend/src/pages/domain-pack/ui/domain-pack-list-page.module.css
@@ -43,9 +43,33 @@
 }
 
 .summaryPill {
+  appearance: none;
   border: 1px solid var(--line);
   color: var(--ink-2);
   background: var(--paper);
+  cursor: pointer;
+  font-family: var(--sans);
+  font-weight: 450;
+  transition:
+    background 160ms ease,
+    border-color 160ms ease,
+    color 160ms ease;
+}
+
+.summaryPill:hover {
+  border-color: var(--ink-4);
+}
+
+.summaryPill:focus-visible {
+  outline: none;
+  border-color: var(--ink);
+  box-shadow: var(--focus-ring);
+}
+
+.summaryPillActive {
+  border-color: var(--ink);
+  background: var(--ink);
+  color: var(--paper);
 }
 
 .sections {


### PR DESCRIPTION
## Summary
- 도메인팩 관리 화면의 상태 요약 pill을 클릭 가능한 필터 버튼으로 전환했습니다.
- `status=operating` / `status=idle` query로 선택 상태를 유지하고, 전체 선택 시 query를 제거합니다.
- `currentVersionId` 기준 운영중/비운영 목록과 선택 상태 empty state를 검증하는 테스트를 추가하고, 이슈 요구사항을 `.agent/specs/418.md`에 정리했습니다.

## Validation
- `cd frontend && pnpm test -- DomainPackListPage.test.tsx`
- `cd frontend && pnpm exec eslint src/pages/domain-pack/ui/DomainPackListPage.tsx src/pages/domain-pack/ui/DomainPackListPage.test.tsx`
- `cd frontend && pnpm build`
- `cd frontend && pnpm test`
- `git diff --check`
- `git diff --cached --check`

## Notes
- `cd frontend && pnpm lint`는 변경 범위 밖의 기존 lint 오류 58개로 실패했습니다. 변경 파일은 targeted eslint를 통과했습니다.

Closes #418
