### PR TITLE
feat(navigation): 로그인 후 기본 워크스페이스로 바로 진입

### DIFF
--- a/.agent/specs/423.md
+++ b/.agent/specs/423.md
@@ -1,0 +1,152 @@
+# Frontend Spec: 로그인 후 기본 워크스페이스 화면 직접 진입
+
+## Goal
+
+로그인 성공 후 명시적인 return-to 경로가 없으면 사용자가 사용할 기본 워크스페이스의 대표 화면인 `/workspaces/{workspaceId}/workflows`로 바로 이동한다.
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A[로그인 폼 제출] --> B{인증 성공?}
+    B -->|No| C[기존 로그인 오류 표시]
+    B -->|Yes| D{허용된 return-to 경로 있음?}
+    D -->|Yes| E[return-to 경로로 이동]
+    D -->|No| F[워크스페이스 목록 조회]
+    F --> G{기본 워크스페이스 확인?}
+    G -->|Yes| H[/workspaces/{id}/workflows 이동]
+    G -->|No| I[/workspaces fallback 이동]
+    I --> J{기존 WorkspaceRootRedirect 처리}
+    J -->|목록 없음| K[워크스페이스 생성 흐름]
+    J -->|조회 실패| L[기존 fallback/error UI]
+```
+
+## Design Diff
+
+### As-is vs To-be
+
+| 영역 | As-is | To-be | 변경 내용 |
+|------|-------|-------|----------|
+| 기본 로그인 목적지 | `resolvePostLoginDestination`이 `/workspaces`를 반환한다. | 기본 로그인 목적지는 로그인 성공 직후 확인한 기본 워크스페이스의 `/workflows` 화면이다. | `/workspaces` 중간 경유를 기본 흐름에서 제거한다. |
+| return-to 흐름 | 보호 라우트에서 전달한 `/workspaces/*`, `/demo/workspaces/*` 경로를 유지한다. | 동일하게 유지한다. | 명시적인 복귀 경로는 워크스페이스 목록 조회보다 우선한다. |
+| fallback | `/workspaces`에서 워크스페이스 목록 조회 후 redirect, 생성, error UI를 처리한다. | 기본 워크스페이스를 확인할 수 없을 때만 `/workspaces` fallback을 사용한다. | 기존 예외 처리 UI와 생성 흐름은 유지한다. |
+
+## Component Tree
+
+```
+LoginPage
+└─ LoginForm
+   ├─ resolveReturnToPostLoginDestination()
+   ├─ resolveDefaultPostLoginDestination()
+   │  └─ listWorkspaces()
+   └─ navigate()
+
+WorkspaceRootRedirect
+└─ 기존 /workspaces fallback 처리
+```
+
+## API Integration
+
+### Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/v1/workspaces` | 로그인 성공 후 기본 워크스페이스 후보 목록 조회 |
+
+### Generated API
+
+- `frontend/src/shared/api/generated/endpoints/workspace-controller/workspace-controller.ts`의 `listWorkspaces`를 사용한다.
+- `frontend/src/shared/api/generated/` 하위 파일은 직접 수정하지 않는다.
+
+## Data Flow
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ LoginForm                                                │
+│  - loginApi 성공                                         │
+│  - saveAuthSession                                       │
+│  - return-to 경로 우선 확인                              │
+└─────────────────────────────────────────────────────────┘
+                           │
+                           ▼
+┌─────────────────────────────────────────────────────────┐
+│ Feature / Entity Model                                   │
+│  - 기본 워크스페이스 선택                                │
+│  - ACTIVE 워크스페이스 우선, 없으면 첫 워크스페이스       │
+└─────────────────────────────────────────────────────────┘
+                           │
+                           ▼
+┌─────────────────────────────────────────────────────────┐
+│ Router                                                   │
+│  - 확인 성공: /workspaces/{id}/workflows                 │
+│  - 확인 실패/없음: /workspaces                           │
+└─────────────────────────────────────────────────────────┘
+```
+
+## 수정 대상 파일
+
+| 파일 | 변경 유형 | 설명 |
+|------|----------|------|
+| `frontend/src/features/auth/model/resolvePostLoginDestination.ts` | modify | 기본 fallback 경로와 return-to 판별을 분리한다. |
+| `frontend/src/features/auth/model/resolvePostLoginDestination.test.ts` | modify | 기본 fallback과 return-to 유지 조건을 검증한다. |
+| `frontend/src/features/auth/ui/login-form/LoginForm.tsx` | modify | 로그인 성공 후 기본 워크스페이스 목적지를 확인한다. |
+| `frontend/src/features/auth/ui/login-form/LoginForm.test.tsx` | new | 로그인 성공 시 직접 이동, return-to 우선, fallback을 검증한다. |
+| `frontend/src/entities/workspace/model/selectDefaultWorkspace.ts` | new | 기본 워크스페이스 선택 규칙을 공유한다. |
+| `frontend/src/entities/workspace/model/selectDefaultWorkspace.test.ts` | new | ACTIVE 우선 선택 규칙을 검증한다. |
+| `frontend/src/entities/workspace/index.ts` | modify | 기본 워크스페이스 선택 유틸을 공개한다. |
+| `frontend/src/pages/workspace/ui/WorkspaceRootRedirect.tsx` | modify | 동일한 기본 워크스페이스 선택 규칙을 재사용한다. |
+| `frontend/src/pages/workspace/ui/WorkspaceRootRedirect.test.tsx` | modify | 기존 fallback redirect 기대값을 유지한다. |
+
+## State Management
+
+- 서버 상태는 로그인 성공 직후 1회 `listWorkspaces` 호출로 확인한다.
+- 별도 전역 상태나 캐시 선반영은 추가하지 않는다.
+- `/workspaces` route의 기존 TanStack Query 기반 fallback 흐름은 유지한다.
+
+## Tests
+
+### Test Strategy
+
+| 구분 | 방법 | 도구 | 비고 |
+|------|------|------|------|
+| 단위 테스트 | 기본 워크스페이스 선택, post-login destination 판별 | Vitest | 라우팅 조건을 빠르게 검증 |
+| 컴포넌트 테스트 | LoginForm submit 후 navigate 결과 | React Testing Library | 사용자 로그인 흐름 검증 |
+| 회귀 테스트 | WorkspaceRootRedirect 기존 fallback | Vitest | 예외 경로 유지 확인 |
+
+### Test Scenarios
+
+#### Happy Path
+
+| # | 시나리오 | 사전 조건 | 기대 결과 |
+|---|---------|---------|----------|
+| 1 | return-to 없는 로그인 성공 | ACTIVE 워크스페이스 존재 | `/workspaces/{id}/workflows`로 replace 이동 |
+| 2 | 보호 라우트에서 로그인 진입 | `state.from.pathname`이 허용 경로 | 원래 return-to 경로로 replace 이동 |
+| 3 | ACTIVE가 없고 목록이 존재 | 첫 워크스페이스 존재 | 첫 워크스페이스의 workflows로 이동 |
+
+#### Error & Edge Cases
+
+| # | 시나리오 | 기대 결과 |
+|---|---------|----------|
+| 1 | 워크스페이스 목록이 비어 있음 | `/workspaces` fallback 이동 후 기존 생성 흐름 표시 |
+| 2 | 워크스페이스 목록 조회 실패 | `/workspaces` fallback 이동 후 기존 error/fallback 처리 |
+| 3 | 로그인 실패 | 기존 로그인 오류 표시, 워크스페이스 조회 없음 |
+| 4 | 외부 URL 또는 dot segment return-to | `/workspaces` fallback 대상 취급 |
+
+## Non-goals
+
+- 워크스페이스 선택/생성 UI를 새로 만들지 않는다.
+- 기본 워크스페이스 결정 규칙을 서버 API로 확장하지 않는다.
+- 인증 토큰 저장 방식이나 보호 라우트 정책을 변경하지 않는다.
+- `/workspaces` route의 기존 fallback UI를 제거하지 않는다.
+
+## Acceptance Criteria
+
+- 로그인 성공 기본 흐름에서 유효한 기본 워크스페이스가 있으면 브라우저 경로가 `/workspaces/{id}/workflows`로 끝난다.
+- 기존 return-to 로그인 흐름은 기존 허용 경로와 query string을 유지한다.
+- 워크스페이스가 없거나 조회 실패하면 기존 `/workspaces` fallback 흐름으로 이동한다.
+- `/workspaces` fallback은 기존처럼 401, 일반 오류, 빈 목록, 생성 성공을 처리한다.
+- 변경된 로직에 대한 frontend 테스트가 추가 또는 갱신된다.
+
+## Open Questions
+
+- 서버가 별도의 "최근 사용 워크스페이스" 또는 "기본 워크스페이스" 필드를 제공하지 않으므로, 이번 범위에서는 기존 `/workspaces` redirect와 동일하게 ACTIVE 우선, 없으면 첫 워크스페이스 규칙을 사용한다.

--- a/frontend/src/entities/workspace/index.ts
+++ b/frontend/src/entities/workspace/index.ts
@@ -13,3 +13,4 @@ export {
   validateCreateWorkspaceForm,
   validateUpdateWorkspaceForm,
 } from "@/entities/workspace/model/types";
+export { selectDefaultWorkspace } from "@/entities/workspace/model/selectDefaultWorkspace";

--- a/frontend/src/entities/workspace/model/selectDefaultWorkspace.test.ts
+++ b/frontend/src/entities/workspace/model/selectDefaultWorkspace.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vite-plus/test";
+import type { WorkspaceResponse } from "./types";
+import { selectDefaultWorkspace } from "./selectDefaultWorkspace";
+
+function workspace(id: number, status: WorkspaceResponse["status"]): WorkspaceResponse {
+  return {
+    id,
+    workspaceKey: `workspace-${id}`,
+    name: `Workspace ${id}`,
+    description: null,
+    status,
+    myRole: "OWNER",
+    createdAt: "2026-06-01T00:00:00Z",
+    updatedAt: "2026-06-01T00:00:00Z",
+  };
+}
+
+describe("selectDefaultWorkspace", () => {
+  it("ACTIVE 워크스페이스를 우선 선택한다", () => {
+    expect(
+      selectDefaultWorkspace([workspace(1, "ARCHIVED"), workspace(2, "ACTIVE")])?.id,
+    ).toBe(2);
+  });
+
+  it("ACTIVE 워크스페이스가 없으면 첫 워크스페이스를 선택한다", () => {
+    expect(selectDefaultWorkspace([workspace(3, "ARCHIVED"), workspace(4, "ARCHIVED")])?.id).toBe(
+      3,
+    );
+  });
+
+  it("워크스페이스가 없으면 null을 반환한다", () => {
+    expect(selectDefaultWorkspace([])).toBeNull();
+  });
+});

--- a/frontend/src/entities/workspace/model/selectDefaultWorkspace.ts
+++ b/frontend/src/entities/workspace/model/selectDefaultWorkspace.ts
@@ -1,0 +1,7 @@
+import type { WorkspaceResponse } from "./types";
+
+export function selectDefaultWorkspace(
+  workspaces: readonly WorkspaceResponse[],
+): WorkspaceResponse | null {
+  return workspaces.find((workspace) => workspace.status === "ACTIVE") ?? workspaces[0] ?? null;
+}

--- a/frontend/src/features/auth/model/resolveDefaultPostLoginDestination.test.ts
+++ b/frontend/src/features/auth/model/resolveDefaultPostLoginDestination.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { listWorkspaces } from "@/shared/api/generated/endpoints/workspace-controller/workspace-controller";
+import type { WorkspaceResponse } from "@/shared/api/generated/zod";
+import { DEFAULT_POST_LOGIN_PATH } from "./resolvePostLoginDestination";
+import { resolveDefaultPostLoginDestination } from "./resolveDefaultPostLoginDestination";
+
+vi.mock("@/shared/api/generated/endpoints/workspace-controller/workspace-controller", () => ({
+  listWorkspaces: vi.fn(),
+}));
+
+const mockedListWorkspaces = vi.mocked(listWorkspaces);
+
+function listResponse(data: WorkspaceResponse[]): Awaited<ReturnType<typeof listWorkspaces>> {
+  return {
+    data,
+    status: 200,
+    headers: new Headers(),
+  };
+}
+
+describe("resolveDefaultPostLoginDestination", () => {
+  beforeEach(() => {
+    mockedListWorkspaces.mockReset();
+  });
+
+  it("ACTIVE 워크스페이스의 workflows 경로를 반환한다", async () => {
+    mockedListWorkspaces.mockResolvedValueOnce(
+      listResponse([
+        { id: 1, name: "Archived", status: "ARCHIVED" },
+        { id: 2, name: "Active", status: "ACTIVE" },
+      ]),
+    );
+
+    await expect(resolveDefaultPostLoginDestination()).resolves.toBe("/workspaces/2/workflows");
+  });
+
+  it("워크스페이스가 없으면 /workspaces fallback을 반환한다", async () => {
+    mockedListWorkspaces.mockResolvedValueOnce(listResponse([]));
+
+    await expect(resolveDefaultPostLoginDestination()).resolves.toBe(DEFAULT_POST_LOGIN_PATH);
+  });
+
+  it("기본 워크스페이스 id가 없으면 /workspaces fallback을 반환한다", async () => {
+    mockedListWorkspaces.mockResolvedValueOnce(
+      listResponse([{ name: "Missing id", status: "ACTIVE" }]),
+    );
+
+    await expect(resolveDefaultPostLoginDestination()).resolves.toBe(DEFAULT_POST_LOGIN_PATH);
+  });
+
+  it("워크스페이스 조회 실패 시 /workspaces fallback을 반환한다", async () => {
+    mockedListWorkspaces.mockRejectedValueOnce(new Error("network error"));
+
+    await expect(resolveDefaultPostLoginDestination()).resolves.toBe(DEFAULT_POST_LOGIN_PATH);
+  });
+});

--- a/frontend/src/features/auth/model/resolveDefaultPostLoginDestination.ts
+++ b/frontend/src/features/auth/model/resolveDefaultPostLoginDestination.ts
@@ -1,0 +1,19 @@
+import { selectDefaultWorkspace } from "@/entities/workspace";
+import { selectApiData } from "@/shared/api";
+import { listWorkspaces } from "@/shared/api/generated/endpoints/workspace-controller/workspace-controller";
+import type { WorkspaceResponse } from "@/shared/api/generated/zod";
+import { DEFAULT_POST_LOGIN_PATH } from "./resolvePostLoginDestination";
+
+export async function resolveDefaultPostLoginDestination(): Promise<string> {
+  try {
+    const response = await listWorkspaces();
+    const workspaces = selectApiData<WorkspaceResponse[]>(response) ?? [];
+    const workspace = selectDefaultWorkspace(workspaces);
+
+    return typeof workspace?.id === "number"
+      ? `/workspaces/${workspace.id}/workflows`
+      : DEFAULT_POST_LOGIN_PATH;
+  } catch {
+    return DEFAULT_POST_LOGIN_PATH;
+  }
+}

--- a/frontend/src/features/auth/model/resolvePostLoginDestination.test.ts
+++ b/frontend/src/features/auth/model/resolvePostLoginDestination.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vite-plus/test";
-import { resolvePostLoginDestination } from "./resolvePostLoginDestination";
+import {
+  DEFAULT_POST_LOGIN_PATH,
+  resolvePostLoginDestination,
+  resolveReturnToPostLoginDestination,
+} from "./resolvePostLoginDestination";
 
 describe("resolvePostLoginDestination", () => {
   it("allows /workspaces paths", () => {
@@ -30,30 +34,29 @@ describe("resolvePostLoginDestination", () => {
 
   it("falls back for auth routes", () => {
     expect(resolvePostLoginDestination({ from: { pathname: "/login" } })).toBe(
-      "/workspaces",
+      DEFAULT_POST_LOGIN_PATH,
     );
     expect(resolvePostLoginDestination({ from: { pathname: "/signup" } })).toBe(
-      "/workspaces",
+      DEFAULT_POST_LOGIN_PATH,
     );
+    expect(resolveReturnToPostLoginDestination({ from: { pathname: "/login" } })).toBeNull();
   });
 
   it("falls back for paths outside the workspace route boundary", () => {
-    expect(
-      resolvePostLoginDestination({ from: { pathname: "/workspaces-public" } }),
-    ).toBe("/workspaces");
+    expect(resolvePostLoginDestination({ from: { pathname: "/workspaces-public" } })).toBe(
+      DEFAULT_POST_LOGIN_PATH,
+    );
   });
 
   it("falls back for dot-segment workspace paths", () => {
-    expect(
-      resolvePostLoginDestination({
-        from: { pathname: "/workspaces/../login" },
-      }),
-    ).toBe("/workspaces");
+    expect(resolvePostLoginDestination({ from: { pathname: "/workspaces/../login" } })).toBe(
+      DEFAULT_POST_LOGIN_PATH,
+    );
     expect(
       resolvePostLoginDestination({
         from: { pathname: "/workspaces/%2e%2e/login" },
       }),
-    ).toBe("/workspaces");
+    ).toBe(DEFAULT_POST_LOGIN_PATH);
   });
 
   it("falls back for external URLs", () => {
@@ -61,17 +64,18 @@ describe("resolvePostLoginDestination", () => {
       resolvePostLoginDestination({
         from: { pathname: "https://example.com/workspaces" },
       }),
-    ).toBe("/workspaces");
+    ).toBe(DEFAULT_POST_LOGIN_PATH);
     expect(
       resolvePostLoginDestination({
         from: { pathname: "//example.com/workspaces" },
       }),
-    ).toBe("/workspaces");
+    ).toBe(DEFAULT_POST_LOGIN_PATH);
   });
 
   it("falls back when pathname is missing", () => {
-    expect(resolvePostLoginDestination(undefined)).toBe("/workspaces");
-    expect(resolvePostLoginDestination({ from: {} })).toBe("/workspaces");
+    expect(resolvePostLoginDestination(undefined)).toBe(DEFAULT_POST_LOGIN_PATH);
+    expect(resolvePostLoginDestination({ from: {} })).toBe(DEFAULT_POST_LOGIN_PATH);
+    expect(resolveReturnToPostLoginDestination(undefined)).toBeNull();
   });
 
   it("ignores malformed search values", () => {

--- a/frontend/src/features/auth/model/resolvePostLoginDestination.ts
+++ b/frontend/src/features/auth/model/resolvePostLoginDestination.ts
@@ -1,4 +1,4 @@
-const DEFAULT_POST_LOGIN_PATH = "/workspaces";
+export const DEFAULT_POST_LOGIN_PATH = "/workspaces";
 const ALLOWED_RETURN_PREFIXES = [
   "/workspaces",
   "/demo/chat",
@@ -59,21 +59,25 @@ function extractSearch(location: ReturnLocation): string {
   return location.search.startsWith("?") ? location.search : "";
 }
 
-export function resolvePostLoginDestination(state: unknown): string {
+export function resolveReturnToPostLoginDestination(state: unknown): string | null {
   const location = extractReturnLocation(state);
   const pathname = location?.pathname;
 
   if (typeof pathname !== "string" || !pathname || isExternalUrl(pathname)) {
-    return DEFAULT_POST_LOGIN_PATH;
+    return null;
   }
 
   if (hasDotSegment(pathname)) {
-    return DEFAULT_POST_LOGIN_PATH;
+    return null;
   }
 
   if (!isAllowedPath(pathname)) {
-    return DEFAULT_POST_LOGIN_PATH;
+    return null;
   }
 
   return `${pathname}${extractSearch(location)}`;
+}
+
+export function resolvePostLoginDestination(state: unknown): string {
+  return resolveReturnToPostLoginDestination(state) ?? DEFAULT_POST_LOGIN_PATH;
 }

--- a/frontend/src/features/auth/ui/login-form/LoginForm.test.tsx
+++ b/frontend/src/features/auth/ui/login-form/LoginForm.test.tsx
@@ -1,0 +1,113 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import { loginApi } from "../../api/authApi";
+import { listWorkspaces } from "@/shared/api/generated/endpoints/workspace-controller/workspace-controller";
+import type { WorkspaceResponse } from "@/shared/api/generated/zod";
+import { LoginForm } from "./LoginForm";
+
+vi.mock("../../api/authApi", () => ({
+  loginApi: vi.fn(),
+}));
+
+vi.mock("@/shared/api/generated/endpoints/workspace-controller/workspace-controller", () => ({
+  listWorkspaces: vi.fn(),
+}));
+
+const mockedLoginApi = vi.mocked(loginApi);
+const mockedListWorkspaces = vi.mocked(listWorkspaces);
+
+function listResponse(data: WorkspaceResponse[]): Awaited<ReturnType<typeof listWorkspaces>> {
+  return {
+    data,
+    status: 200,
+    headers: new Headers(),
+  };
+}
+
+function LocationProbe() {
+  const location = useLocation();
+  return <div data-testid="location">{`${location.pathname}${location.search}`}</div>;
+}
+
+function renderLoginForm(state?: unknown) {
+  render(
+    <MemoryRouter initialEntries={[{ pathname: "/login", state }]}>
+      <Routes>
+        <Route
+          path="/login"
+          element={
+            <>
+              <LoginForm />
+              <LocationProbe />
+            </>
+          }
+        />
+        <Route path="*" element={<LocationProbe />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+async function submitLoginForm() {
+  const user = userEvent.setup();
+  await user.type(screen.getByLabelText("이메일 주소"), "admin@ostone.com");
+  await user.type(screen.getByLabelText("비밀번호"), "password123");
+  await user.click(screen.getByRole("button", { name: "시스템 로그인" }));
+}
+
+describe("LoginForm", () => {
+  beforeEach(() => {
+    mockedLoginApi.mockReset();
+    mockedListWorkspaces.mockReset();
+    localStorage.clear();
+    mockedLoginApi.mockResolvedValue({
+      accessToken: "access-token",
+      refreshToken: "refresh-token",
+      tokenType: "Bearer",
+      expiresIn: 1800,
+      user: { id: 1, email: "admin@ostone.com", name: "Admin", role: "OWNER" },
+    });
+  });
+
+  it("return-to가 없으면 기본 워크스페이스 workflows 화면으로 바로 이동한다", async () => {
+    mockedListWorkspaces.mockResolvedValueOnce(
+      listResponse([
+        { id: 1, name: "Archived", status: "ARCHIVED" },
+        { id: 7, name: "Active", status: "ACTIVE" },
+      ]),
+    );
+
+    renderLoginForm();
+    await submitLoginForm();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("location")).toHaveTextContent("/workspaces/7/workflows");
+    });
+    expect(mockedListWorkspaces).toHaveBeenCalledTimes(1);
+  });
+
+  it("허용된 return-to 경로가 있으면 워크스페이스 조회 없이 해당 경로를 우선한다", async () => {
+    renderLoginForm({
+      from: { pathname: "/workspaces/4/upload", search: "?tab=logs" },
+    });
+    await submitLoginForm();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("location")).toHaveTextContent("/workspaces/4/upload?tab=logs");
+    });
+    expect(mockedListWorkspaces).not.toHaveBeenCalled();
+  });
+
+  it("기본 워크스페이스를 확인할 수 없으면 /workspaces fallback으로 이동한다", async () => {
+    mockedListWorkspaces.mockRejectedValueOnce(new Error("network error"));
+
+    renderLoginForm();
+    await submitLoginForm();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("location")).toHaveTextContent("/workspaces");
+    });
+  });
+});

--- a/frontend/src/features/auth/ui/login-form/LoginForm.tsx
+++ b/frontend/src/features/auth/ui/login-form/LoginForm.tsx
@@ -5,7 +5,8 @@ import { toast } from "sonner";
 import { Input } from "../../../../shared/ui/input/Input";
 import { Button } from "../../../../shared/ui/button/Button";
 import { loginApi } from "../../api/authApi";
-import { resolvePostLoginDestination } from "../../model/resolvePostLoginDestination";
+import { resolveDefaultPostLoginDestination } from "../../model/resolveDefaultPostLoginDestination";
+import { resolveReturnToPostLoginDestination } from "../../model/resolvePostLoginDestination";
 import { saveAuthSession } from "../../../../shared/lib/auth";
 import { ApiRequestError } from "../../../../shared/api";
 import styles from "./login-form.module.css";
@@ -57,10 +58,17 @@ export const LoginForm: React.FC = () => {
           tokenType: result.tokenType ?? "Bearer",
           expiresIn: result.expiresIn ?? 0,
         },
-        result.user as any,
+        {
+          id: result.user?.id ?? 0,
+          email: result.user?.email ?? email,
+          name: result.user?.name ?? email,
+          role: result.user?.role ?? "OPERATOR",
+        },
       );
 
-      navigate(resolvePostLoginDestination(location.state), { replace: true });
+      const returnToDestination = resolveReturnToPostLoginDestination(location.state);
+      const destination = returnToDestination ?? (await resolveDefaultPostLoginDestination());
+      navigate(destination, { replace: true });
     } catch (err) {
       if (err instanceof ApiRequestError) {
         if (err.code === "INVALID_CREDENTIALS") {

--- a/frontend/src/pages/workspace/ui/WorkspaceRootRedirect.test.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceRootRedirect.test.tsx
@@ -139,6 +139,16 @@ describe("WorkspaceRootRedirect", () => {
     expect(screen.getByTestId("navigate-to")).toHaveTextContent("/workspaces/3/workflows");
   });
 
+  it("기본 워크스페이스 id를 확인할 수 없으면 CreateWorkspaceDialog를 표시한다", () => {
+    useListWorkspaces.mockReturnValue({
+      data: [{ name: "WS without id", status: "ACTIVE" }],
+      isLoading: false,
+      isError: false,
+    });
+    renderPage();
+    expect(screen.getByTestId("create-dialog")).toBeInTheDocument();
+  });
+
   it("CreateWorkspaceDialog onSuccess가 navigate를 호출한다", () => {
     useListWorkspaces.mockReturnValue({ data: [], isLoading: false, isError: false });
     renderPage();

--- a/frontend/src/pages/workspace/ui/WorkspaceRootRedirect.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceRootRedirect.tsx
@@ -2,9 +2,10 @@ import { Navigate, useNavigate } from "react-router-dom";
 
 import type { WorkspaceResponse } from "@/shared/api/generated/zod";
 import { useListWorkspaces } from "@/shared/api/generated/endpoints/workspace-controller/workspace-controller";
+import { selectDefaultWorkspace } from "@/entities/workspace";
 import { CreateWorkspaceDialog } from "@/features/workspace";
 import { Spinner } from "@/shared/ui/spinner";
-import { ApiRequestError } from "@/shared/api";
+import { ApiRequestError, selectApiData } from "@/shared/api";
 import { ErrorState } from "@/shared/ui/ostone/atoms/ErrorState";
 
 export function WorkspaceRootRedirect() {
@@ -38,10 +39,10 @@ export function WorkspaceRootRedirect() {
     );
   }
 
-  const workspaces = (workspacesData ?? []) as unknown as WorkspaceResponse[];
-  if (workspaces.length > 0) {
-    const active = workspaces.find((w) => w.status === "ACTIVE") ?? workspaces[0];
-    return <Navigate to={`/workspaces/${active.id}/workflows`} replace />;
+  const workspaces = selectApiData<WorkspaceResponse[]>(workspacesData) ?? [];
+  const workspace = selectDefaultWorkspace(workspaces);
+  if (typeof workspace?.id === "number") {
+    return <Navigate to={`/workspaces/${workspace.id}/workflows`} replace />;
   }
 
   return (


### PR DESCRIPTION
## Summary
- 로그인 성공 후 return-to 경로가 없으면 워크스페이스 목록을 즉시 확인해 기본 워크스페이스의 `/workflows` 화면으로 이동합니다.
- 기본 워크스페이스 선택 규칙을 ACTIVE 우선, 없으면 첫 워크스페이스로 공유하고 `/workspaces` fallback redirect와 동일하게 사용합니다.
- 워크스페이스를 확인할 수 없거나 목록 조회가 실패하면 기존 `/workspaces` 생성/error fallback 흐름을 유지하고, 이슈 요구사항을 `.agent/specs/423.md`에 정리했습니다.

## Validation
- `cd frontend && pnpm test src/features/auth/model/resolvePostLoginDestination.test.ts src/features/auth/model/resolveDefaultPostLoginDestination.test.ts src/features/auth/ui/login-form/LoginForm.test.tsx src/entities/workspace/model/selectDefaultWorkspace.test.ts src/pages/workspace/ui/WorkspaceRootRedirect.test.tsx --run`
- `cd frontend && pnpm exec eslint src/features/auth/model/resolvePostLoginDestination.ts src/features/auth/model/resolvePostLoginDestination.test.ts src/features/auth/model/resolveDefaultPostLoginDestination.ts src/features/auth/model/resolveDefaultPostLoginDestination.test.ts src/features/auth/ui/login-form/LoginForm.tsx src/features/auth/ui/login-form/LoginForm.test.tsx src/entities/workspace/index.ts src/entities/workspace/model/selectDefaultWorkspace.ts src/entities/workspace/model/selectDefaultWorkspace.test.ts src/pages/workspace/ui/WorkspaceRootRedirect.tsx src/pages/workspace/ui/WorkspaceRootRedirect.test.tsx`
- `cd frontend && pnpm build`
- `cd frontend && pnpm test --run`
- `git diff --check`
- `git diff --cached --check`

## Notes
- `cd frontend && pnpm lint`는 변경 범위 밖의 기존 lint 오류로 실패했습니다. 변경 파일은 targeted eslint를 통과했습니다.

Closes #423