### PR TITLE
fix(consultation): 상담 큐 실시간 동기화 안정화

### DIFF
--- a/.agent/specs/415.md
+++ b/.agent/specs/415.md
@@ -1,0 +1,71 @@
+# Issue 415: 상담 큐 실시간 동기화 안정화
+
+## Goal
+
+상담 큐에 영향을 주는 세션/메시지 변경이 누락 없이 전파되고, 웹소켓 연결 복구 뒤에는 최신 큐 스냅샷으로 보정되어 상담사가 수동 새로고침 없이 현재 큐 상태를 볼 수 있게 한다.
+
+## Problem
+
+상담사 화면은 최초 진입 시 `frontend/src/pages/consultation/ui/ConsultationPage.tsx`에서 `consultationApi.getQueue(workspaceId)`를 호출한 뒤 `/topic/workspaces.{workspaceId}.consultation.queue` 이벤트에 의존한다. 연결 끊김, 재연결, 이벤트 유실이 발생하면 큐를 다시 조회하는 보정이 없어서 오래된 목록, 미처리 표시, 마지막 메시지, 정렬이 남을 수 있다.
+
+백엔드는 `backend/src/main/java/com/init/workflowruntime/application/ChatWebSocketService.java`, `backend/src/main/java/com/init/workflowruntime/application/ConsultationService.java`, `backend/src/main/java/com/init/workflowruntime/application/CounselorService.java`, `backend/src/main/java/com/init/chatdemo/application/DemoChatSessionRegistrationService.java`의 메시지/세션 변경 흐름에서 큐 표시값을 갱신하지만, 일부 메시지 경로가 `ConsultationQueueChangedEvent` 발행 계약을 일관되게 지키지 않는다.
+
+## Scope
+
+- `workflow-runtime`의 상담 메시지, 상담사 메시지/메모, 응답 모드/배정/해제/상태 변경 후 큐 upsert/remove 이벤트 발행 기준을 일관화한다.
+- `chat-demo`의 세션 생성과 메시지 append 후 상담 큐 이벤트가 발행되도록 한다.
+- `ConsultationPage`가 웹소켓 연결 오류/끊김을 사용자에게 표시하고, 연결이 복구되면 `getQueue`로 최신 큐 스냅샷을 재조회한다.
+- 기존 큐 이벤트 수신 시 upsert/remove, unread 처리, route session 선택 동작은 유지한다.
+
+## Non-Goals
+
+- STOMP 브로커, 인증 인터셉터, 토픽 주소 체계를 변경하지 않는다.
+- 큐 이벤트 payload 형식을 새 버전으로 확장하지 않는다.
+- 상담 큐의 권한 정책이나 조회 API 응답 스키마를 변경하지 않는다.
+- 데모 채팅의 LLM 응답 생성 정책을 변경하지 않는다.
+
+## Affected Modules
+
+| Area | Path | Impact |
+| --- | --- | --- |
+| Backend application | `backend/src/main/java/com/init/workflowruntime/application/ChatWebSocketService.java` | 메시지 저장 후 큐 upsert 이벤트 발행 |
+| Backend application | `backend/src/main/java/com/init/workflowruntime/application/ConsultationService.java` | HTTP 메시지 전송 후 큐 upsert 이벤트 발행 |
+| Backend application | `backend/src/main/java/com/init/workflowruntime/application/CounselorService.java` | 상담사 메시지/메모 전송 후 큐 upsert 이벤트 발행 |
+| Backend application | `backend/src/main/java/com/init/chatdemo/application/DemoChatSessionRegistrationService.java` | 데모 세션 생성/메시지 append 후 큐 upsert 이벤트 발행 |
+| Frontend page | `frontend/src/pages/consultation/ui/ConsultationPage.tsx` | 연결 복구 시 큐 스냅샷 재조회 및 불안정 상태 표시 |
+| Frontend shared UI | `frontend/src/features/consultation/ui/QueuePanel.tsx` | 큐 동기화 안내 표시 |
+
+## Backend Requirements
+
+1. `ConsultationQueueChangedEvent`는 큐 row의 표시값 또는 정렬 기준에 영향을 주는 변경 뒤에 발행된다.
+2. 고객 메시지, 상담사 메시지, 내부 메모는 `ChatSessionMetadataService.updateAfterMessage(...)`로 `lastMessagePreview`, `lastMessageRole`, `lastMessageAt` 등을 갱신한 뒤 `SESSION_UPSERTED` 이벤트를 발행한다.
+3. 데모 세션 생성 시 생성된 세션이 상담 큐에 나타나도록 `SESSION_UPSERTED` 이벤트를 발행한다.
+4. 데모 메시지 append 시 사용자 메시지 기준으로 세션 메타데이터를 갱신하고 `SESSION_UPSERTED` 이벤트를 발행한다.
+5. `ConsultationQueueEventListener`가 `AFTER_COMMIT`에서 동작하므로 큐 이벤트는 트랜잭션 안에서 발행되어야 한다.
+
+## Frontend Requirements
+
+1. `connectionStatus`가 `DISCONNECTED` 또는 `ERROR`이면 상담 큐 영역에 실시간 연결이 불안정하다는 안내를 표시한다.
+2. 이전 상태가 비연결 상태였고 다시 `CONNECTED`가 되면 `consultationApi.getQueue(workspaceId)`를 호출해 큐 스냅샷을 보정한다.
+3. 재조회 성공 시 기존 큐 load error는 해제되고, 기존 route session 선택/활성 대화 정리 규칙은 유지된다.
+4. 재조회 실패 시 기존 큐 오류 처리와 재시도 UI를 사용한다.
+
+## Acceptance Criteria
+
+- 큐 이벤트 수신 시 기존처럼 `SESSION_UPSERTED`는 삽입/갱신, `SESSION_REMOVED`는 제거로 처리된다.
+- 웹소켓 연결 오류 또는 끊김 뒤 `CONNECTED`로 복구되면 `getQueue`가 다시 호출된다.
+- 연결 불안정 상태에서 상담사는 큐 최신성이 보정 중임을 인지할 수 있다.
+- 상담사 메시지와 내부 메모 전송 후 큐의 마지막 메시지 표시값이 이벤트로 갱신된다.
+- 데모 세션 생성과 데모 메시지 append 후 상담 큐 upsert 이벤트가 발행된다.
+- 같은 워크스페이스를 보는 여러 상담사 화면은 수동 새로고침 없이 동일한 큐 변경을 관찰할 수 있다.
+
+## Validation Plan
+
+- Backend: 관련 application service 단위 테스트로 큐 이벤트 발행 여부를 검증한다.
+- Frontend: `ConsultationPage` 테스트로 reconnect snapshot refetch와 연결 불안정 안내를 검증한다.
+- Frontend: 기존 큐 upsert/remove/unread 테스트가 계속 통과해야 한다.
+- Regression: backend/frontend의 관련 테스트를 실행한다.
+
+## Open Questions
+
+- 데모 채팅 append에서 AI 응답까지 큐 마지막 메시지로 표시할지, 고객 입력을 미처리 신호로 우선 표시할지는 운영 정책으로 더 구체화할 수 있다. 본 이슈에서는 고객 입력이 큐 최신성 신호가 되도록 보정한다.

--- a/backend/src/main/java/com/init/chatdemo/application/DemoChatSessionRegistrationService.java
+++ b/backend/src/main/java/com/init/chatdemo/application/DemoChatSessionRegistrationService.java
@@ -8,6 +8,7 @@ import com.init.domainpack.domain.model.DomainPackVersion;
 import com.init.domainpack.domain.repository.DomainPackVersionRepository;
 import com.init.shared.application.exception.BadRequestException;
 import com.init.shared.application.exception.NotFoundException;
+import com.init.workflowruntime.application.ChatSessionMetadataService;
 import com.init.workflowruntime.application.LlmAssistantService;
 import com.init.workflowruntime.application.dto.ChatMessageResponse;
 import com.init.workflowruntime.application.dto.ChatSessionResponse;
@@ -16,11 +17,14 @@ import com.init.workflowruntime.domain.ChatMessageRepository;
 import com.init.workflowruntime.domain.ChatSession;
 import com.init.workflowruntime.domain.ChatSessionRepository;
 import com.init.workflowruntime.domain.ChatSessionStatus;
+import com.init.workflowruntime.domain.event.ConsultationQueueChangedEvent;
+import com.init.workflowruntime.domain.event.ConsultationQueueEventType;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -41,18 +45,24 @@ public class DemoChatSessionRegistrationService {
   private final ChatMessageRepository chatMessageRepository;
   private final LlmAssistantService llmAssistantService;
   private final SimpMessagingTemplate messagingTemplate;
+  private final ApplicationEventPublisher eventPublisher;
+  private final ChatSessionMetadataService chatSessionMetadataService;
 
   public DemoChatSessionRegistrationService(
       DomainPackVersionRepository domainPackVersionRepository,
       ChatSessionRepository chatSessionRepository,
       ChatMessageRepository chatMessageRepository,
       LlmAssistantService llmAssistantService,
-      SimpMessagingTemplate messagingTemplate) {
+      SimpMessagingTemplate messagingTemplate,
+      ApplicationEventPublisher eventPublisher,
+      ChatSessionMetadataService chatSessionMetadataService) {
     this.domainPackVersionRepository = domainPackVersionRepository;
     this.chatSessionRepository = chatSessionRepository;
     this.chatMessageRepository = chatMessageRepository;
     this.llmAssistantService = llmAssistantService;
     this.messagingTemplate = messagingTemplate;
+    this.eventPublisher = eventPublisher;
+    this.chatSessionMetadataService = chatSessionMetadataService;
   }
 
   @Transactional
@@ -77,9 +87,12 @@ public class DemoChatSessionRegistrationService {
                 createMetaJson(normalizedName),
                 null));
 
-    chatMessageRepository.save(
-        ChatMessage.create(
-            session.getId(), 1, "ASSISTANT", "TEXT", createGreeting(normalizedName)));
+    ChatMessage greeting =
+        chatMessageRepository.save(
+            ChatMessage.create(
+                session.getId(), 1, "ASSISTANT", "TEXT", createGreeting(normalizedName)));
+    chatSessionMetadataService.updateAfterMessage(session, greeting);
+    publishQueueUpsert(session);
 
     return ChatSessionResponse.from(session);
   }
@@ -105,6 +118,7 @@ public class DemoChatSessionRegistrationService {
     ChatMessage userMessage =
         chatMessageRepository.save(
             ChatMessage.create(sessionId, nextSeqNo, "USER", "TEXT", normalizedContent));
+    chatSessionMetadataService.updateAfterMessage(session, userMessage);
 
     String assistantContent =
         llmAssistantService.generateResponse(
@@ -115,6 +129,7 @@ public class DemoChatSessionRegistrationService {
 
     List<ChatMessageResponse> responses =
         List.of(ChatMessageResponse.from(userMessage), ChatMessageResponse.from(assistantMessage));
+    publishQueueUpsert(session);
     broadcastAfterCommit(sessionId, responses);
     return responses;
   }
@@ -170,6 +185,14 @@ public class DemoChatSessionRegistrationService {
     return recentDesc.reversed().stream()
         .map(message -> message.getSenderRole() + ": " + message.getContent())
         .collect(Collectors.joining("\n"));
+  }
+
+  private void publishQueueUpsert(ChatSession session) {
+    eventPublisher.publishEvent(
+        new ConsultationQueueChangedEvent(
+            session.getWorkspaceId(),
+            session.getId(),
+            ConsultationQueueEventType.SESSION_UPSERTED));
   }
 
   private void broadcastAfterCommit(Long sessionId, List<ChatMessageResponse> responses) {

--- a/backend/src/main/java/com/init/workflowruntime/application/ChatWebSocketService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/ChatWebSocketService.java
@@ -77,12 +77,11 @@ public class ChatWebSocketService {
     ChatMessage savedMessage = chatMessageRepository.save(message);
     chatSessionMetadataService.updateAfterMessage(session, savedMessage);
     ConsultationQueueChangedEvent queueChangedEvent =
-        isCustomerRole(command.senderRole())
-            ? new ConsultationQueueChangedEvent(
-                session.getWorkspaceId(),
-                command.sessionId(),
-                ConsultationQueueEventType.SESSION_UPSERTED)
-            : null;
+        new ConsultationQueueChangedEvent(
+            session.getWorkspaceId(),
+            command.sessionId(),
+            ConsultationQueueEventType.SESSION_UPSERTED);
+    eventPublisher.publishEvent(queueChangedEvent);
 
     ChatMessageResponse response = ChatMessageResponse.from(savedMessage);
     String destination = "/topic/chat." + command.sessionId();
@@ -96,17 +95,10 @@ public class ChatWebSocketService {
             } finally {
               eventPublisher.publishEvent(
                   new ChatMessageReceivedEvent(command.sessionId(), command.content(), null));
-              if (queueChangedEvent != null) {
-                eventPublisher.publishEvent(queueChangedEvent);
-              }
             }
           }
         });
 
     return response;
-  }
-
-  private static boolean isCustomerRole(String senderRole) {
-    return "USER".equals(senderRole) || "CUSTOMER".equals(senderRole);
   }
 }

--- a/backend/src/main/java/com/init/workflowruntime/application/ConsultationService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/ConsultationService.java
@@ -136,6 +136,9 @@ public class ConsultationService {
         ChatMessage.create(session.getId(), nextSeqNo, role, messageType, request.getContent());
     ChatMessage savedMessage = chatMessageRepository.save(newMessage);
     chatSessionMetadataService.updateAfterMessage(session, savedMessage);
+    eventPublisher.publishEvent(
+        new ConsultationQueueChangedEvent(
+            session.getWorkspaceId(), sessionId, ConsultationQueueEventType.SESSION_UPSERTED));
 
     return ChatMessageResponse.from(savedMessage);
   }

--- a/backend/src/main/java/com/init/workflowruntime/application/CounselorService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/CounselorService.java
@@ -166,6 +166,9 @@ public class CounselorService {
       session.markHumanResponding();
     }
     chatSessionMetadataService.updateAfterMessage(session, savedMessage);
+    eventPublisher.publishEvent(
+        new ConsultationQueueChangedEvent(
+            session.getWorkspaceId(), sessionId, ConsultationQueueEventType.SESSION_UPSERTED));
 
     ChatMessageResponse response = ChatMessageResponse.from(savedMessage);
     String destination = "/topic/chat." + sessionId;

--- a/backend/src/test/java/com/init/chatdemo/application/DemoChatSessionRegistrationServiceTest.java
+++ b/backend/src/test/java/com/init/chatdemo/application/DemoChatSessionRegistrationServiceTest.java
@@ -17,6 +17,7 @@ import com.init.domainpack.domain.model.DomainPackVersion;
 import com.init.domainpack.domain.repository.DomainPackVersionRepository;
 import com.init.shared.application.exception.BadRequestException;
 import com.init.shared.application.exception.NotFoundException;
+import com.init.workflowruntime.application.ChatSessionMetadataService;
 import com.init.workflowruntime.application.LlmAssistantService;
 import com.init.workflowruntime.application.dto.ChatMessageResponse;
 import com.init.workflowruntime.application.dto.ChatSessionResponse;
@@ -25,6 +26,8 @@ import com.init.workflowruntime.domain.ChatMessageRepository;
 import com.init.workflowruntime.domain.ChatSession;
 import com.init.workflowruntime.domain.ChatSessionRepository;
 import com.init.workflowruntime.domain.ChatSessionStatus;
+import com.init.workflowruntime.domain.event.ConsultationQueueChangedEvent;
+import com.init.workflowruntime.domain.event.ConsultationQueueEventType;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -34,6 +37,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.support.TransactionSynchronization;
@@ -52,6 +56,8 @@ class DemoChatSessionRegistrationServiceTest {
   @Mock private ChatMessageRepository chatMessageRepository;
   @Mock private LlmAssistantService llmAssistantService;
   @Mock private SimpMessagingTemplate messagingTemplate;
+  @Mock private ApplicationEventPublisher eventPublisher;
+  @Mock private ChatSessionMetadataService chatSessionMetadataService;
 
   private DemoChatSessionRegistrationService service;
 
@@ -63,7 +69,9 @@ class DemoChatSessionRegistrationServiceTest {
             chatSessionRepository,
             chatMessageRepository,
             llmAssistantService,
-            messagingTemplate);
+            messagingTemplate,
+            eventPublisher,
+            chatSessionMetadataService);
   }
 
   @Test
@@ -103,6 +111,8 @@ class DemoChatSessionRegistrationServiceTest {
     assertThat(greeting.getChatSessionId()).isEqualTo(SESSION_ID);
     assertThat(greeting.getSenderRole()).isEqualTo("ASSISTANT");
     assertThat(greeting.getContent()).contains("김민지");
+    verify(chatSessionMetadataService).updateAfterMessage(savedSession, greeting);
+    verifyQueueUpsertEventPublished();
   }
 
   @Test
@@ -133,6 +143,9 @@ class DemoChatSessionRegistrationServiceTest {
         .extracting(ChatMessage::getSeqNo)
         .containsExactly(1, 2);
     assertThat(messageCaptor.getAllValues().get(1).getContent()).isEqualTo("LLM 응답입니다.");
+    verify(chatSessionMetadataService)
+        .updateAfterMessage(session, messageCaptor.getAllValues().get(0));
+    verifyQueueUpsertEventPublished();
     verify(llmAssistantService).generateResponse("USER: Hello", "Hello");
     verify(messagingTemplate).convertAndSend("/topic/chat.77", responses.get(0));
     verify(messagingTemplate).convertAndSend("/topic/chat.77", responses.get(1));
@@ -257,5 +270,15 @@ class DemoChatSessionRegistrationServiceTest {
     } finally {
       TransactionSynchronizationManager.clearSynchronization();
     }
+  }
+
+  private void verifyQueueUpsertEventPublished() {
+    ArgumentCaptor<ConsultationQueueChangedEvent> eventCaptor =
+        ArgumentCaptor.forClass(ConsultationQueueChangedEvent.class);
+    verify(eventPublisher).publishEvent(eventCaptor.capture());
+    assertThat(eventCaptor.getValue().workspaceId()).isEqualTo(WORKSPACE_ID);
+    assertThat(eventCaptor.getValue().sessionId()).isEqualTo(SESSION_ID);
+    assertThat(eventCaptor.getValue().type())
+        .isEqualTo(ConsultationQueueEventType.SESSION_UPSERTED);
   }
 }

--- a/backend/src/test/java/com/init/workflowruntime/application/ChatWebSocketServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/ChatWebSocketServiceTest.java
@@ -93,14 +93,13 @@ class ChatWebSocketServiceTest {
 
       // 즉시 전송되지 않음
       verify(messagingTemplate, never()).convertAndSend(anyString(), any(Object.class));
-      verify(eventPublisher, never()).publishEvent(any(Object.class));
+      assertQueueUpsertEventPublished();
 
       // afterCommit 수동 트리거
       TransactionSynchronizationManager.getSynchronizations().forEach(s -> s.afterCommit());
 
       // 커밋 후 전송 확인
       verify(messagingTemplate).convertAndSend("/topic/chat.1", result);
-      assertQueueUpsertEventPublished();
     } finally {
       TransactionSynchronizationManager.clearSynchronization();
     }
@@ -170,20 +169,19 @@ class ChatWebSocketServiceTest {
       verify(chatSessionMetadataService).updateAfterMessage(session, savedMsg);
 
       verify(messagingTemplate, never()).convertAndSend(anyString(), any(Object.class));
-      verify(eventPublisher, never()).publishEvent(any(Object.class));
+      assertQueueUpsertEventPublished();
 
       TransactionSynchronizationManager.getSynchronizations().forEach(s -> s.afterCommit());
 
       verify(messagingTemplate).convertAndSend("/topic/chat.1", result);
-      assertQueueUpsertEventPublished();
     } finally {
       TransactionSynchronizationManager.clearSynchronization();
     }
   }
 
   @Test
-  @DisplayName("saveAndBroadcast: 상담사 역할 메시지는 queue unread 이벤트를 발행하지 않는다")
-  void should_notPublishQueueEvent_when_senderIsAgent() {
+  @DisplayName("saveAndBroadcast: 상담사 역할 메시지도 큐 최신화를 위해 upsert 이벤트를 발행한다")
+  void should_publishQueueEvent_when_senderIsAgent() {
     ChatSession session = createSession(1L, ChatSessionStatus.ACTIVE);
     given(chatSessionRepository.findByIdForUpdate(1L)).willReturn(Optional.of(session));
     given(chatMessageRepository.findTopByChatSessionIdOrderBySeqNoDesc(1L))
@@ -197,10 +195,7 @@ class ChatWebSocketServiceTest {
 
       TransactionSynchronizationManager.getSynchronizations().forEach(s -> s.afterCommit());
 
-      ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
-      verify(eventPublisher, atLeastOnce()).publishEvent(eventCaptor.capture());
-      assertThat(eventCaptor.getAllValues())
-          .noneMatch(ConsultationQueueChangedEvent.class::isInstance);
+      assertQueueUpsertEventPublished();
     } finally {
       TransactionSynchronizationManager.clearSynchronization();
     }

--- a/backend/src/test/java/com/init/workflowruntime/application/ConsultationServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/ConsultationServiceTest.java
@@ -237,6 +237,13 @@ class ConsultationServiceTest {
     assertThat(result.senderRole()).isEqualTo("AGENT");
     verify(chatMessageRepository).save(any());
     verify(chatSessionMetadataService).updateAfterMessage(session, savedMsg);
+    ArgumentCaptor<ConsultationQueueChangedEvent> eventCaptor =
+        ArgumentCaptor.forClass(ConsultationQueueChangedEvent.class);
+    verify(eventPublisher).publishEvent(eventCaptor.capture());
+    assertThat(eventCaptor.getValue().workspaceId()).isEqualTo(1L);
+    assertThat(eventCaptor.getValue().sessionId()).isEqualTo(1L);
+    assertThat(eventCaptor.getValue().type())
+        .isEqualTo(ConsultationQueueEventType.SESSION_UPSERTED);
   }
 
   @Test

--- a/backend/src/test/java/com/init/workflowruntime/application/CounselorServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/CounselorServiceTest.java
@@ -286,6 +286,7 @@ class CounselorServiceTest {
       assertThat(session.getResponseMode()).isEqualTo(ChatSessionResponseMode.HUMAN_ACTIVE);
       verify(chatMessageRepository).save(any());
       verify(chatSessionMetadataService).updateAfterMessage(session, savedMsg);
+      verifyQueueEventPublished(1L, 1L, ConsultationQueueEventType.SESSION_UPSERTED);
 
       verify(messagingTemplate, never()).convertAndSend(anyString(), any(Object.class));
 
@@ -317,6 +318,7 @@ class CounselorServiceTest {
       assertThat(result.senderRole()).isEqualTo("NOTE");
       assertThat(session.getResponseMode()).isEqualTo(ChatSessionResponseMode.AI_ACTIVE);
       verify(chatSessionMetadataService).updateAfterMessage(session, savedMsg);
+      verifyQueueEventPublished(1L, 1L, ConsultationQueueEventType.SESSION_UPSERTED);
     } finally {
       TransactionSynchronizationManager.clearSynchronization();
     }

--- a/frontend/src/features/consultation/ui/QueuePanel.tsx
+++ b/frontend/src/features/consultation/ui/QueuePanel.tsx
@@ -34,6 +34,7 @@ interface QueuePanelProps {
   onSelectCustomer: (id: string) => void;
   isLoading?: boolean;
   loadError?: string | null;
+  syncNotice?: string | null;
   onRetry?: () => void;
 }
 
@@ -202,6 +203,7 @@ export const QueuePanel: React.FC<QueuePanelProps> = ({
   onSelectCustomer,
   isLoading = false,
   loadError = null,
+  syncNotice = null,
   onRetry,
 }) => {
   const [selectedFilter, setSelectedFilter] = useState<QueueFilter>("all");
@@ -362,6 +364,11 @@ export const QueuePanel: React.FC<QueuePanelProps> = ({
           </div>
         </div>
         <span className={styles.resultCount}>현재 {visibleCustomers.length}건 표시</span>
+        {syncNotice && (
+          <div className={styles.syncNotice} role="status">
+            {syncNotice}
+          </div>
+        )}
       </div>
 
       <div className={styles.queueList}>{renderQueueState()}</div>

--- a/frontend/src/features/consultation/ui/QueuePanel.tsx
+++ b/frontend/src/features/consultation/ui/QueuePanel.tsx
@@ -365,9 +365,9 @@ export const QueuePanel: React.FC<QueuePanelProps> = ({
         </div>
         <span className={styles.resultCount}>현재 {visibleCustomers.length}건 표시</span>
         {syncNotice && (
-          <div className={styles.syncNotice} role="status">
+          <output className={styles.syncNotice}>
             {syncNotice}
-          </div>
+          </output>
         )}
       </div>
 

--- a/frontend/src/features/consultation/ui/queue-panel.module.css
+++ b/frontend/src/features/consultation/ui/queue-panel.module.css
@@ -170,6 +170,18 @@
   letter-spacing: normal;
 }
 
+.syncNotice {
+  margin-top: 10px;
+  padding: 8px 10px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--paper);
+  color: var(--ink-2);
+  font-size: 0.72rem;
+  line-height: 1.35;
+  letter-spacing: normal;
+}
+
 .queueList {
   flex: 1;
   overflow-y: auto;

--- a/frontend/src/pages/consultation/ui/ConsultationPage.test.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.test.tsx
@@ -29,7 +29,7 @@ type RealtimePayload = {
 const { mockSubscribe, mockSendTo, stompState } = vi.hoisted(() => {
   const mockUnsubscribe = vi.fn();
   const stompState = {
-    connectionStatus: "CONNECTED" as "CONNECTED" | "DISCONNECTED",
+    connectionStatus: "CONNECTED" as "CONNECTING" | "CONNECTED" | "DISCONNECTED" | "ERROR",
     latestCallback: null as ((msg: RealtimePayload) => void) | null,
     onServerError: null as ((error: unknown) => void) | null,
     callbacks: new Map<string, (msg: RealtimePayload) => void>(),
@@ -1955,6 +1955,40 @@ describe("ConsultationPage", () => {
       .mocked(toast.error)
       .mock.calls.filter(([message]) => message === "대기열을 불러오지 못했습니다.");
     expect(errorToasts).toHaveLength(0);
+  });
+
+  it("shows a queue sync notice while the websocket connection is unstable", async () => {
+    stompState.connectionStatus = "ERROR";
+
+    render(<ConsultationPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("김민지")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText("실시간 연결이 불안정합니다. 복구되면 대기열을 다시 동기화합니다."),
+    ).toBeInTheDocument();
+  });
+
+  it("refetches the queue snapshot after websocket reconnect", async () => {
+    stompState.connectionStatus = "DISCONNECTED";
+    const { rerender } = render(<ConsultationPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(consultationApi.getQueue).toHaveBeenCalledTimes(1);
+      expect(screen.getByText("김민지")).toBeInTheDocument();
+    });
+
+    stompState.connectionStatus = "CONNECTED";
+    rerender(<ConsultationPage />);
+
+    await waitFor(() => {
+      expect(consultationApi.getQueue).toHaveBeenCalledTimes(2);
+    });
+    expect(mockSubscribe).toHaveBeenCalledWith(
+      "/topic/workspaces.2.consultation.queue",
+      expect.any(Function),
+    );
   });
 
   it("deduplicates queue error toast across multiple failed loads", async () => {

--- a/frontend/src/pages/consultation/ui/ConsultationPage.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.tsx
@@ -4,7 +4,7 @@ import { toast } from "sonner";
 import { ApiRequestError } from "@/shared/api";
 import type { ShellContext } from "@/shared/ui/ostone/chrome";
 import { Dot, Mono, Avatar } from "@/shared/ui/ostone/atoms";
-import { useStomp } from "@/shared/lib/websocket";
+import { useStomp, type ConnectionStatus } from "@/shared/lib/websocket";
 import { getAuthUser } from "@/shared/lib/auth";
 import { QueuePanel } from "../../../features/consultation/ui/QueuePanel";
 import type { QueueCustomer } from "../../../features/consultation/ui/QueuePanel";
@@ -652,6 +652,8 @@ export const ConsultationPage: React.FC = () => {
   const pendingMessagesRef = useRef<Map<string, PendingMessage>>(new Map());
   const tempCounterRef = useRef(0);
   const activeCustomerIdRef = useRef<string | null>(null);
+  const hasQueueLoadedRef = useRef(false);
+  const previousConnectionStatusRef = useRef<ConnectionStatus>("DISCONNECTED");
   const metricsErrorToastShownRef = useRef(false);
   const queueErrorToastShownRef = useRef(false);
   const currentCounselorId = getAuthUser()?.id ?? null;
@@ -754,6 +756,10 @@ export const ConsultationPage: React.FC = () => {
     ? undefined
     : activeAssignment?.description;
   const activeResponseModeView = getResponseModeView(activeCustomer?.responseMode);
+  const queueSyncNotice =
+    workspaceId && connectionStatus !== "CONNECTED"
+      ? "실시간 연결이 불안정합니다. 복구되면 대기열을 다시 동기화합니다."
+      : null;
 
   const clearActiveConversation = useCallback(() => {
     setActiveCustomerId(null);
@@ -811,6 +817,10 @@ export const ConsultationPage: React.FC = () => {
   useEffect(() => {
     activeCustomerIdRef.current = activeCustomerId;
   }, [activeCustomerId]);
+
+  useEffect(() => {
+    hasQueueLoadedRef.current = hasQueueLoaded;
+  }, [hasQueueLoaded]);
 
   useEffect(() => {
     setTopbarRight(
@@ -995,6 +1005,17 @@ export const ConsultationPage: React.FC = () => {
     queueErrorToastShownRef.current = false;
     void loadQueue();
   }, [loadQueue]);
+
+  useEffect(() => {
+    const previousStatus = previousConnectionStatusRef.current;
+    previousConnectionStatusRef.current = connectionStatus;
+
+    if (!workspaceId) return;
+    if (connectionStatus !== "CONNECTED" || previousStatus === "CONNECTED") return;
+    if (!hasQueueLoadedRef.current) return;
+
+    void loadQueue();
+  }, [connectionStatus, loadQueue, workspaceId]);
 
   const activateCustomer = useCallback((id: string) => {
     setActiveCustomerId(id);
@@ -1604,6 +1625,7 @@ export const ConsultationPage: React.FC = () => {
           onSelectCustomer={handleSelectCustomer}
           isLoading={isQueueLoading}
           loadError={queueLoadError}
+          syncNotice={queueSyncNotice}
           onRetry={handleQueueRetry}
         />
       </div>


### PR DESCRIPTION
## Summary
- 상담 큐 표시값을 바꾸는 사용자/상담사/메모/데모 메시지 흐름에서 큐 upsert 이벤트가 일관되게 발행되도록 했습니다.
- 웹소켓 연결이 끊기거나 오류 상태일 때 상담 큐에 동기화 안내를 표시하고, 연결 복구 시 `getQueue` 스냅샷으로 큐를 재동기화합니다.
- 이슈 요구사항과 검증 기준을 `.agent/specs/415.md`에 정리했습니다.

## Validation
- `GRADLE_USER_HOME=/tmp/ostone-gradle-528d mise exec -- ./gradlew test --tests 'com.init.workflowruntime.application.ChatWebSocketServiceTest' --tests 'com.init.workflowruntime.application.CounselorServiceTest' --tests 'com.init.workflowruntime.application.ConsultationServiceTest' --tests 'com.init.chatdemo.application.DemoChatSessionRegistrationServiceTest' --quiet`\n- `GRADLE_USER_HOME=/tmp/ostone-gradle-528d mise exec -- ./gradlew spotlessCheck --quiet`\n- `pnpm test -- ConsultationPage.test.tsx`\n- `pnpm exec eslint src/pages/consultation/ui/ConsultationPage.tsx src/pages/consultation/ui/ConsultationPage.test.tsx src/features/consultation/ui/QueuePanel.tsx`\n\n참고: `pnpm lint`는 이 변경 범위 밖의 기존 lint 오류들로 실패합니다.\n\nCloses #415