### PR TITLE
fix(upload): 상담 로그 업로드 ZIP 파일만 허용

### DIFF
--- a/.agent/specs/421.md
+++ b/.agent/specs/421.md
@@ -1,0 +1,103 @@
+# Issue 421: 상담 로그 업로드 ZIP-only 정책 정렬
+
+## Goal
+
+상담 로그 원본 업로드 경로가 프론트엔드와 백엔드 모두에서 ZIP 파일만 허용하도록 정책, 안내 문구, 검증, 테스트를 일관되게 정렬한다.
+
+## Problem
+
+현재 상담 로그 업로드는 운영 정책상 압축된 원본 로그 묶음인 ZIP 파일만 받는 것이 기대 동작이지만, 구현은 서로 다른 정책을 표현한다.
+
+- `frontend/src/shared/lib/rawLogUploadPolicy.ts`는 JSON 파일만 허용한다.
+- `frontend/src/features/log-upload/ui/LogUploadForm.test.tsx`와 `frontend/src/shared/lib/rawLogUploadPolicy.test.ts`는 JSON 업로드를 성공 기준으로 검증한다.
+- `backend/src/main/java/com/init/corpus/application/RawFileUploadService.java`는 ZIP 파일이면 내부 `.json`/`.jsonl`을 파싱하지만, ZIP이 아니면 원본 바이트를 JSON으로 파싱한다.
+- `backend/src/test/java/com/init/corpus/presentation/DatasetControllerRawFileTest.java`와 `backend/src/test/java/com/init/corpus/application/RawFileUploadServiceTest.java`는 단일 JSON 파일 업로드 성공을 허용한다.
+
+그 결과 사용자는 UI에서 실제 정책과 다른 JSON 안내를 보게 되고, API 직접 호출자는 ZIP이 아닌 JSON 단일 파일을 업로드할 수 있다.
+
+## Scope
+
+### Frontend
+
+- `frontend/src/shared/lib/rawLogUploadPolicy.ts`
+  - 파일 선택 accept 값을 ZIP 기준으로 변경한다.
+  - 업로드 안내 라벨과 검증 오류 문구를 ZIP 기준으로 변경한다.
+  - `.zip` 확장자가 아닌 `.json`, `.csv`, `.xlsx` 등은 클라이언트 검증에서 거부한다.
+- `frontend/src/shared/lib/rawLogUploadPolicy.test.ts`
+  - ZIP 정책 노출, 정상 ZIP 허용, 비-ZIP 거부, 크기 제한을 검증한다.
+- `frontend/src/features/log-upload/ui/LogUploadForm.test.tsx`
+  - 파일 선택/안내/토스트/업로드 플로우 테스트를 ZIP 기준으로 갱신한다.
+
+### Backend
+
+- `backend/src/main/java/com/init/corpus/application/RawFileUploadService.java`
+  - 워크스페이스/멤버십/데이터셋 키 검증 뒤, S3/MinIO 저장과 파싱 전에 ZIP 매직 바이트가 아닌 파일을 `RawFileParseException`으로 거부한다.
+  - 정상 ZIP 내부의 `.json`/`.jsonl` 파싱, ZIP entry count/size 제한, 경로 traversal 방어는 유지한다.
+- `backend/src/test/java/com/init/corpus/application/RawFileUploadServiceTest.java`
+  - 정상 업로드와 JSON/JSONL 파싱 검증을 ZIP 입력 기준으로 변경한다.
+  - ZIP이 아닌 파일이 저장/파싱 전에 거부되는 시나리오를 추가한다.
+  - ZIP 내부의 빈 JSON, 잘못된 JSON, 필수 상담 내용 누락 등 기존 실패 시나리오는 유지한다.
+- `backend/src/test/java/com/init/corpus/presentation/DatasetControllerRawFileTest.java`
+  - multipart 성공 케이스는 ZIP 파일 기준으로 변경한다.
+  - 서비스에서 ZIP-only 위반을 보고할 때 400 계열 응답으로 매핑되는지 검증한다.
+
+## Non-goals
+
+- ZIP 내부 상담 데이터 스키마를 변경하지 않는다.
+- ZIP 폭탄 방어 임계값을 변경하지 않는다.
+- OpenAPI generated 클라이언트 파일을 직접 수정하지 않는다.
+- 별도 파일 업로드 UI 레이아웃이나 디자인 시스템을 변경하지 않는다.
+- 기존 `/api/v1/workspaces/{workspaceId}/datasets/raw` JSON body 업로드 API 정책은 변경하지 않는다.
+
+## Expected Behavior
+
+```mermaid
+sequenceDiagram
+    actor u as Operator
+    participant fe as Frontend Upload UI
+    participant be as DatasetController
+    participant svc as RawFileUploadService
+    participant store as Raw File Storage
+    participant ingest as RawDatasetUploadService
+
+    u ->> fe: Select or drop file
+    fe ->> fe: Validate .zip and max 50MB
+    fe ->> be: POST multipart ZIP
+    be ->> svc: RawFileUploadCommand
+    svc ->> svc: Validate workspace, membership, datasetKey
+    svc ->> svc: Reject non-ZIP magic bytes
+    svc ->> store: Store original ZIP
+    svc ->> svc: Parse .json/.jsonl entries
+    svc ->> ingest: Create raw conversations
+    svc ->> u: Upload success
+```
+
+## API and Data Impact
+
+- Endpoint path and request shape stay unchanged:
+  - `POST /api/v1/workspaces/{workspaceId}/datasets/raw-file`
+  - `multipart/form-data` with `file`, `datasetKey`, `name`, `sourceType`
+- Non-ZIP multipart files must fail with an existing 400 validation-style error response through `RawFileParseException` handling.
+- Stored raw file metadata continues to record the original uploaded ZIP filename, content type, size, object key, and checksum.
+- No database schema changes are required.
+
+## Acceptance Criteria
+
+- `RAW_LOG_UPLOAD_ACCEPT`, accepted type label, file type label, and validation message all say ZIP rather than JSON.
+- The log upload UI accepts `.zip` files and rejects `.json`, `.csv`, `.xlsx`, and other non-ZIP filenames before upload.
+- `RawFileUploadService` rejects non-ZIP bytes before `RawFileStoragePort.put(...)` is called.
+- ZIP files containing `.json` and `.jsonl` entries continue to parse into conversations.
+- ZIP entry path traversal and ZIP size/count limits remain active.
+- `rawLogUploadPolicy`, `LogUploadForm`, `DatasetControllerRawFileTest`, and `RawFileUploadServiceTest` cover ZIP-only behavior.
+
+## Validation Plan
+
+- Run targeted frontend tests:
+  - `cd frontend && pnpm test -- rawLogUploadPolicy LogUploadForm`
+- Run targeted backend tests:
+  - `cd backend && ./gradlew test --tests com.init.corpus.application.RawFileUploadServiceTest --tests com.init.corpus.presentation.DatasetControllerRawFileTest`
+- Run broader module checks if targeted verification exposes integration risk.
+
+## Open Questions
+
+- None. The issue explicitly defines ZIP-only upload as the expected policy while preserving `.json`/`.jsonl` support inside ZIP archives.

--- a/backend/src/main/java/com/init/corpus/application/RawFileUploadService.java
+++ b/backend/src/main/java/com/init/corpus/application/RawFileUploadService.java
@@ -84,6 +84,7 @@ public class RawFileUploadService {
         command.workspaceId(), command.datasetKey())) {
       throw new DatasetKeyConflictException("이미 사용 중인 데이터셋 키입니다: " + command.datasetKey());
     }
+    validateZipFile(command.fileBytes());
 
     // 2. Build objectKey and compute SHA-256 checksum (U-06: Assumption adopted from Recommended
     //    Default — computed from byte[] before upload)
@@ -163,10 +164,13 @@ public class RawFileUploadService {
   }
 
   private List<RawConversationInput> parseConversations(byte[] fileBytes) {
-    if (isZip(fileBytes)) {
-      return parseZipConversations(fileBytes);
+    return parseZipConversations(fileBytes);
+  }
+
+  private void validateZipFile(byte[] fileBytes) {
+    if (!isZip(fileBytes)) {
+      throw new RawFileParseException("ZIP 파일만 업로드할 수 있습니다.");
     }
-    return parseJsonConversations(fileBytes, "file");
   }
 
   private boolean isZip(byte[] fileBytes) {

--- a/backend/src/test/java/com/init/corpus/application/RawFileUploadServiceTest.java
+++ b/backend/src/test/java/com/init/corpus/application/RawFileUploadServiceTest.java
@@ -53,12 +53,12 @@ class RawFileUploadServiceTest {
 
   private RawFileUploadService service;
 
-  private static final byte[] VALID_JSON =
-      ("[{\"source_id\":\"001\",\"source\":\"테스트\","
-              + "\"consulting_category\":\"배송\",\"client_gender\":\"\","
-              + "\"client_age\":\"\",\"consulting_content\":"
-              + "\"상담사: 안녕하세요.\\n고객: 문의가 있어요.\"}]")
-          .getBytes(StandardCharsets.UTF_8);
+  private static final String VALID_JSON_TEXT =
+      "[{\"source_id\":\"001\",\"source\":\"테스트\","
+          + "\"consulting_category\":\"배송\",\"client_gender\":\"\","
+          + "\"client_age\":\"\",\"consulting_content\":"
+          + "\"상담사: 안녕하세요.\\n고객: 문의가 있어요.\"}]";
+  private static final byte[] VALID_JSON = VALID_JSON_TEXT.getBytes(StandardCharsets.UTF_8);
 
   @BeforeEach
   void setUp() {
@@ -88,10 +88,10 @@ class RawFileUploadServiceTest {
     given(rawDatasetUploadService.upload(any())).willReturn(uploadResult);
 
     DatasetRawFile savedFile =
-        DatasetRawFile.create(
-            42L, "some-key", "test.json", "application/json", 100L, "a".repeat(64));
+        DatasetRawFile.create(42L, "some-key", "test.zip", "application/zip", 100L, "a".repeat(64));
     given(rawFileRepository.save(any())).willReturn(savedFile);
 
+    byte[] zipBytes = validZipBytes();
     RawFileUploadCommand command =
         new RawFileUploadCommand(
             1L,
@@ -99,10 +99,10 @@ class RawFileUploadServiceTest {
             "테스트",
             "CRM",
             1L,
-            VALID_JSON,
-            "test.json",
-            "application/json",
-            VALID_JSON.length);
+            zipBytes,
+            "test.zip",
+            "application/zip",
+            (long) zipBytes.length);
 
     RawFileUploadResult result = service.upload(command);
 
@@ -177,8 +177,8 @@ class RawFileUploadServiceTest {
   }
 
   @Test
-  @DisplayName("should_parse_json_object_with_data_array")
-  void upload_jsonObjectWithDataArray_parsesConversations() {
+  @DisplayName("should_parse_json_object_with_data_array_inside_zip")
+  void upload_zipEntryWithJsonObjectDataArray_parsesConversations() throws IOException {
     given(workspaceExistenceRepository.existsById(1L)).willReturn(true);
     given(workspaceMembershipRepository.existsByWorkspaceIdAndUserId(1L, 1L)).willReturn(true);
     given(datasetRepository.existsByWorkspaceIdAndDatasetKey(1L, "object-json")).willReturn(false);
@@ -190,27 +190,28 @@ class RawFileUploadServiceTest {
     given(rawFileRepository.save(any()))
         .willReturn(
             DatasetRawFile.create(
-                44L, "some-key", "object.json", "application/json", 100L, "c".repeat(64)));
-    byte[] bytes =
-        """
+                44L, "some-key", "object.zip", "application/zip", 100L, "c".repeat(64)));
+    byte[] zipBytes =
+        zip(
+            "object.json",
+            """
         {"data":[
           {"id":"obj-001","channel":"톡","consulting_category":"카드","full_text":"분실 정지 문의"},
           {"case_id":"obj-002","source":"전화","conversation":"한도 상향 문의"}
         ]}
-        """
-            .getBytes(StandardCharsets.UTF_8);
+        """);
 
     service.upload(
         new RawFileUploadCommand(
             1L,
             "object-json",
             "객체 JSON",
-            "PARSED_FLAT_JSON",
+            "PARSED_FLAT_ZIP",
             1L,
-            bytes,
-            "object.json",
-            "application/json",
-            bytes.length));
+            zipBytes,
+            "object.zip",
+            "application/zip",
+            (long) zipBytes.length));
 
     ArgumentCaptor<RawDatasetUploadCommand> commandCaptor =
         ArgumentCaptor.forClass(RawDatasetUploadCommand.class);
@@ -273,7 +274,7 @@ class RawFileUploadServiceTest {
 
   @Test
   @DisplayName("should_build_content_from_turns_with_korean_speaker_roles")
-  void upload_turnsWithKoreanSpeakerRoles_buildsConsultingContent() {
+  void upload_turnsWithKoreanSpeakerRoles_buildsConsultingContent() throws IOException {
     given(workspaceExistenceRepository.existsById(1L)).willReturn(true);
     given(workspaceMembershipRepository.existsByWorkspaceIdAndUserId(1L, 1L)).willReturn(true);
     given(datasetRepository.existsByWorkspaceIdAndDatasetKey(1L, "turn-json")).willReturn(false);
@@ -285,28 +286,29 @@ class RawFileUploadServiceTest {
     given(rawFileRepository.save(any()))
         .willReturn(
             DatasetRawFile.create(
-                46L, "some-key", "turns.json", "application/json", 100L, "e".repeat(64)));
-    byte[] bytes =
-        """
+                46L, "some-key", "turns.zip", "application/zip", 100L, "e".repeat(64)));
+    byte[] zipBytes =
+        zip(
+            "turns.json",
+            """
         [{"source_id":"turn-001","turns":[
           {"화자":"직원","발화":"본인 확인 도와드리겠습니다."},
           {"role":"customer","utterance":"네."},
           {"speaker":"system","text":""}
         ]}]
-        """
-            .getBytes(StandardCharsets.UTF_8);
+        """);
 
     service.upload(
         new RawFileUploadCommand(
             1L,
             "turn-json",
             "턴 JSON",
-            "PARSED_FLAT_JSON",
+            "PARSED_FLAT_ZIP",
             1L,
-            bytes,
-            "turns.json",
-            "application/json",
-            bytes.length));
+            zipBytes,
+            "turns.zip",
+            "application/zip",
+            (long) zipBytes.length));
 
     ArgumentCaptor<RawDatasetUploadCommand> commandCaptor =
         ArgumentCaptor.forClass(RawDatasetUploadCommand.class);
@@ -317,25 +319,25 @@ class RawFileUploadServiceTest {
   }
 
   @Test
-  @DisplayName("should_reject_empty_json_file")
-  void upload_emptyJsonFile_throwsRawFileParseException() {
+  @DisplayName("should_reject_empty_json_entry_inside_zip")
+  void upload_zipWithEmptyJsonEntry_throwsRawFileParseException() throws IOException {
     given(workspaceExistenceRepository.existsById(1L)).willReturn(true);
     given(workspaceMembershipRepository.existsByWorkspaceIdAndUserId(1L, 1L)).willReturn(true);
     given(datasetRepository.existsByWorkspaceIdAndDatasetKey(1L, "empty-json")).willReturn(false);
     given(storagePort.put(anyString(), any(), anyString())).willReturn("some-key");
 
-    byte[] emptyJson = "  \n ".getBytes(StandardCharsets.UTF_8);
+    byte[] zipBytes = zip("empty.json", "  \n ");
     RawFileUploadCommand command =
         new RawFileUploadCommand(
             1L,
             "empty-json",
             "빈 JSON",
-            "PARSED_FLAT_JSON",
+            "PARSED_FLAT_ZIP",
             1L,
-            emptyJson,
-            "empty.json",
-            "application/json",
-            (long) emptyJson.length);
+            zipBytes,
+            "empty.zip",
+            "application/zip",
+            (long) zipBytes.length);
 
     assertThatThrownBy(() -> service.upload(command))
         .isInstanceOf(RawFileParseException.class)
@@ -346,25 +348,25 @@ class RawFileUploadServiceTest {
   }
 
   @Test
-  @DisplayName("should_reject_json_without_conversation_nodes")
-  void upload_scalarJson_throwsRawFileParseException() {
+  @DisplayName("should_reject_json_entry_without_conversation_nodes")
+  void upload_zipWithScalarJsonEntry_throwsRawFileParseException() throws IOException {
     given(workspaceExistenceRepository.existsById(1L)).willReturn(true);
     given(workspaceMembershipRepository.existsByWorkspaceIdAndUserId(1L, 1L)).willReturn(true);
     given(datasetRepository.existsByWorkspaceIdAndDatasetKey(1L, "scalar-json")).willReturn(false);
     given(storagePort.put(anyString(), any(), anyString())).willReturn("some-key");
 
-    byte[] scalarJson = "123".getBytes(StandardCharsets.UTF_8);
+    byte[] zipBytes = zip("scalar.json", "123");
     RawFileUploadCommand command =
         new RawFileUploadCommand(
             1L,
             "scalar-json",
             "스칼라 JSON",
-            "PARSED_FLAT_JSON",
+            "PARSED_FLAT_ZIP",
             1L,
-            scalarJson,
-            "scalar.json",
-            "application/json",
-            scalarJson.length);
+            zipBytes,
+            "scalar.zip",
+            "application/zip",
+            (long) zipBytes.length);
 
     assertThatThrownBy(() -> service.upload(command))
         .isInstanceOf(RawFileParseException.class)
@@ -375,26 +377,27 @@ class RawFileUploadServiceTest {
   }
 
   @Test
-  @DisplayName("should_reject_json_missing_consulting_content")
-  void upload_jsonMissingConsultingContent_throwsRawFileParseException() {
+  @DisplayName("should_reject_json_entry_missing_consulting_content")
+  void upload_zipWithJsonEntryMissingConsultingContent_throwsRawFileParseException()
+      throws IOException {
     given(workspaceExistenceRepository.existsById(1L)).willReturn(true);
     given(workspaceMembershipRepository.existsByWorkspaceIdAndUserId(1L, 1L)).willReturn(true);
     given(datasetRepository.existsByWorkspaceIdAndDatasetKey(1L, "missing-content"))
         .willReturn(false);
     given(storagePort.put(anyString(), any(), anyString())).willReturn("some-key");
 
-    byte[] bytes = "[{\"source_id\":\"bad-001\",\"turns\":[]}]".getBytes(StandardCharsets.UTF_8);
+    byte[] zipBytes = zip("missing.json", "[{\"source_id\":\"bad-001\",\"turns\":[]}]");
     RawFileUploadCommand command =
         new RawFileUploadCommand(
             1L,
             "missing-content",
             "본문 없음",
-            "PARSED_FLAT_JSON",
+            "PARSED_FLAT_ZIP",
             1L,
-            bytes,
-            "missing.json",
-            "application/json",
-            bytes.length);
+            zipBytes,
+            "missing.zip",
+            "application/zip",
+            (long) zipBytes.length);
 
     assertThatThrownBy(() -> service.upload(command))
         .isInstanceOf(RawFileParseException.class)
@@ -521,6 +524,34 @@ class RawFileUploadServiceTest {
   }
 
   @Test
+  @DisplayName("should_reject_non_zip_before_storage")
+  void upload_nonZipFile_throwsRawFileParseExceptionBeforeStorage() {
+    given(workspaceExistenceRepository.existsById(1L)).willReturn(true);
+    given(workspaceMembershipRepository.existsByWorkspaceIdAndUserId(1L, 1L)).willReturn(true);
+    given(datasetRepository.existsByWorkspaceIdAndDatasetKey(1L, "json-file")).willReturn(false);
+
+    RawFileUploadCommand command =
+        new RawFileUploadCommand(
+            1L,
+            "json-file",
+            "단일 JSON",
+            "PARSED_FLAT_JSON",
+            1L,
+            VALID_JSON,
+            "logs.json",
+            "application/json",
+            (long) VALID_JSON.length);
+
+    assertThatThrownBy(() -> service.upload(command))
+        .isInstanceOf(RawFileParseException.class)
+        .hasMessageContaining("ZIP 파일만 업로드할 수 있습니다.");
+
+    verify(storagePort, never()).put(anyString(), any(), anyString());
+    verify(storagePort, never()).delete(anyString());
+    verify(rawDatasetUploadService, never()).upload(any());
+  }
+
+  @Test
   @DisplayName("should_throw_WorkspaceNotFoundException_when_워크스페이스_없음")
   void upload_workspaceNotFound_throwsException() {
     given(workspaceExistenceRepository.existsById(1L)).willReturn(false);
@@ -593,17 +624,25 @@ class RawFileUploadServiceTest {
   }
 
   @Test
-  @DisplayName("should_throw_RawFileParseException_when_잘못된_JSON")
-  void upload_invalidJson_throwsRawFileParseException() {
+  @DisplayName("should_throw_RawFileParseException_when_ZIP_내부_JSON_잘못됨")
+  void upload_zipWithInvalidJsonEntry_throwsRawFileParseException() throws IOException {
     given(workspaceExistenceRepository.existsById(1L)).willReturn(true);
     given(workspaceMembershipRepository.existsByWorkspaceIdAndUserId(1L, 1L)).willReturn(true);
     given(datasetRepository.existsByWorkspaceIdAndDatasetKey(1L, "key")).willReturn(false);
     given(storagePort.put(anyString(), any(), anyString())).willReturn("some-key");
 
-    byte[] badJson = "NOT JSON".getBytes(StandardCharsets.UTF_8);
+    byte[] zipBytes = zip("bad.json", "NOT JSON");
     RawFileUploadCommand command =
         new RawFileUploadCommand(
-            1L, "key", "name", "src", 1L, badJson, "f.json", "application/json", 8L);
+            1L,
+            "key",
+            "name",
+            "src",
+            1L,
+            zipBytes,
+            "bad.zip",
+            "application/zip",
+            (long) zipBytes.length);
 
     assertThatThrownBy(() -> service.upload(command)).isInstanceOf(RawFileParseException.class);
 
@@ -620,6 +659,7 @@ class RawFileUploadServiceTest {
     given(storagePort.put(anyString(), any(), anyString())).willReturn("some-key");
     given(rawDatasetUploadService.upload(any())).willThrow(new RuntimeException("DB error"));
 
+    byte[] zipBytes = validZipBytes();
     RawFileUploadCommand command =
         new RawFileUploadCommand(
             1L,
@@ -627,10 +667,10 @@ class RawFileUploadServiceTest {
             "name",
             "src",
             1L,
-            VALID_JSON,
-            "f.json",
-            "application/json",
-            (long) VALID_JSON.length);
+            zipBytes,
+            "f.zip",
+            "application/zip",
+            (long) zipBytes.length);
 
     assertThatThrownBy(() -> service.upload(command))
         .isInstanceOf(RuntimeException.class)
@@ -652,6 +692,7 @@ class RawFileUploadServiceTest {
     given(rawDatasetUploadService.upload(any())).willReturn(uploadResult);
     given(rawFileRepository.save(any())).willThrow(new RuntimeException("DB save error"));
 
+    byte[] zipBytes = validZipBytes();
     RawFileUploadCommand command =
         new RawFileUploadCommand(
             1L,
@@ -659,10 +700,10 @@ class RawFileUploadServiceTest {
             "name",
             "src",
             1L,
-            VALID_JSON,
-            "f.json",
-            "application/json",
-            (long) VALID_JSON.length);
+            zipBytes,
+            "f.zip",
+            "application/zip",
+            (long) zipBytes.length);
 
     assertThatThrownBy(() -> service.upload(command))
         .isInstanceOf(RuntimeException.class)
@@ -685,11 +726,12 @@ class RawFileUploadServiceTest {
     given(rawFileRepository.save(any()))
         .willReturn(
             DatasetRawFile.create(
-                42L, "some-key", "f.json", "application/json", 100L, "a".repeat(64)));
+                42L, "some-key", "f.zip", "application/zip", 100L, "a".repeat(64)));
     willThrow(new RuntimeException("trigger error"))
         .given(triggerPort)
         .trigger(anyLong(), anyLong(), anyString());
 
+    byte[] zipBytes = validZipBytes();
     RawFileUploadCommand command =
         new RawFileUploadCommand(
             1L,
@@ -697,10 +739,10 @@ class RawFileUploadServiceTest {
             "name",
             "src",
             1L,
-            VALID_JSON,
-            "f.json",
-            "application/json",
-            (long) VALID_JSON.length);
+            zipBytes,
+            "f.zip",
+            "application/zip",
+            (long) zipBytes.length);
 
     assertThatThrownBy(() -> service.upload(command))
         .isInstanceOf(RuntimeException.class)
@@ -719,6 +761,7 @@ class RawFileUploadServiceTest {
     given(rawDatasetUploadService.upload(any())).willThrow(new RuntimeException("DB error"));
     willThrow(new RuntimeException("S3 delete failed")).given(storagePort).delete(anyString());
 
+    byte[] zipBytes = validZipBytes();
     RawFileUploadCommand command =
         new RawFileUploadCommand(
             1L,
@@ -726,10 +769,10 @@ class RawFileUploadServiceTest {
             "name",
             "src",
             1L,
-            VALID_JSON,
-            "f.json",
-            "application/json",
-            (long) VALID_JSON.length);
+            zipBytes,
+            "f.zip",
+            "application/zip",
+            (long) zipBytes.length);
 
     // original DB exception must propagate, not the S3 delete exception
     assertThatThrownBy(() -> service.upload(command))
@@ -749,6 +792,14 @@ class RawFileUploadServiceTest {
       zip.closeEntry();
     }
     return bytes.toByteArray();
+  }
+
+  private byte[] validZipBytes() {
+    try {
+      return zip("logs.json", VALID_JSON_TEXT);
+    } catch (IOException e) {
+      throw new IllegalStateException("테스트 ZIP 생성 실패", e);
+    }
   }
 
   private byte[] zip(String name, String content) throws IOException {

--- a/backend/src/test/java/com/init/corpus/presentation/DatasetControllerRawFileTest.java
+++ b/backend/src/test/java/com/init/corpus/presentation/DatasetControllerRawFileTest.java
@@ -51,17 +51,16 @@ class DatasetControllerRawFileTest {
 
   @MockitoBean private DatasetUploadService datasetUploadService;
 
-  private static final byte[] VALID_JSON =
-      "[{\"source_id\":\"001\",\"consulting_content\":\"상담사: hi\\n고객: hello\"}]".getBytes();
+  private static final byte[] VALID_ZIP = new byte[] {0x50, 0x4b, 0x03, 0x04};
 
   private RawFileUploadResult validResult() {
     return new RawFileUploadResult(
         42L,
         "test-key",
         1L,
-        "workspaces/1/datasets/test-key/uuid_test.json",
-        "test.json",
-        VALID_JSON.length,
+        "workspaces/1/datasets/test-key/uuid_test.zip",
+        "test.zip",
+        VALID_ZIP.length,
         DatasetStatus.READY,
         PiiRedactionStatus.PENDING,
         1);
@@ -74,7 +73,7 @@ class DatasetControllerRawFileTest {
     given(rawFileUploadService.upload(any())).willReturn(validResult());
 
     MockMultipartFile mockFile =
-        new MockMultipartFile("file", "test.json", "application/json", VALID_JSON);
+        new MockMultipartFile("file", "test.zip", "application/zip", VALID_ZIP);
 
     mockMvc
         .perform(
@@ -95,7 +94,7 @@ class DatasetControllerRawFileTest {
   @WithLongPrincipal(1L)
   void uploadRawFile_emptyFile_returns400() throws Exception {
     MockMultipartFile emptyFile =
-        new MockMultipartFile("file", "empty.json", "application/json", new byte[0]);
+        new MockMultipartFile("file", "empty.zip", "application/zip", new byte[0]);
 
     mockMvc
         .perform(
@@ -110,10 +109,11 @@ class DatasetControllerRawFileTest {
   }
 
   @Test
-  @DisplayName("POST /raw-file — 잘못된 JSON → 400 VALIDATION_ERROR")
+  @DisplayName("POST /raw-file — ZIP이 아닌 파일 → 400 VALIDATION_ERROR")
   @WithLongPrincipal(1L)
-  void uploadRawFile_parseError_returns400() throws Exception {
-    given(rawFileUploadService.upload(any())).willThrow(new RawFileParseException("JSON 파싱 실패"));
+  void uploadRawFile_nonZipFile_returns400() throws Exception {
+    given(rawFileUploadService.upload(any()))
+        .willThrow(new RawFileParseException("ZIP 파일만 업로드할 수 있습니다."));
 
     MockMultipartFile mockFile =
         new MockMultipartFile("file", "bad.json", "application/json", "NOT JSON".getBytes());
@@ -138,7 +138,7 @@ class DatasetControllerRawFileTest {
         .willThrow(new WorkspaceNotFoundException("워크스페이스 없음"));
 
     MockMultipartFile mockFile =
-        new MockMultipartFile("file", "test.json", "application/json", VALID_JSON);
+        new MockMultipartFile("file", "test.zip", "application/zip", VALID_ZIP);
 
     mockMvc
         .perform(
@@ -160,7 +160,7 @@ class DatasetControllerRawFileTest {
         .willThrow(new UnauthorizedWorkspaceAccessException("접근 권한 없음"));
 
     MockMultipartFile mockFile =
-        new MockMultipartFile("file", "test.json", "application/json", VALID_JSON);
+        new MockMultipartFile("file", "test.zip", "application/zip", VALID_ZIP);
 
     mockMvc
         .perform(
@@ -194,7 +194,7 @@ class DatasetControllerRawFileTest {
   @WithLongPrincipal(1L)
   void uploadRawFile_missingDatasetKey_returns400() throws Exception {
     MockMultipartFile mockFile =
-        new MockMultipartFile("file", "test.json", "application/json", VALID_JSON);
+        new MockMultipartFile("file", "test.zip", "application/zip", VALID_ZIP);
 
     mockMvc
         .perform(
@@ -215,7 +215,7 @@ class DatasetControllerRawFileTest {
         .willThrow(new DatasetKeyConflictException("이미 사용 중인 키"));
 
     MockMultipartFile mockFile =
-        new MockMultipartFile("file", "test.json", "application/json", VALID_JSON);
+        new MockMultipartFile("file", "test.zip", "application/zip", VALID_ZIP);
 
     mockMvc
         .perform(

--- a/frontend/src/features/log-upload/ui/LogUploadForm.test.tsx
+++ b/frontend/src/features/log-upload/ui/LogUploadForm.test.tsx
@@ -249,7 +249,7 @@ describe("LogUploadForm", () => {
 
   it("keeps domain pack fallback when generation response has no pipeline job id", () => {
     render(<LogUploadForm workspaceId={1} />, { wrapper: MemoryRouter });
-    const file = new File(["data"], "data.json", { type: "application/json" });
+    const file = new File(["data"], "data.zip", { type: "application/zip" });
     const input = screen.getByTestId("file-input");
     fireEvent.change(input, { target: { files: [file] } });
     fireEvent.click(screen.getByText("처리 시작"));

--- a/frontend/src/features/log-upload/ui/LogUploadForm.test.tsx
+++ b/frontend/src/features/log-upload/ui/LogUploadForm.test.tsx
@@ -129,30 +129,32 @@ describe("LogUploadForm", () => {
       screen.getByText("상담로그를 업로드 하면 챗봇이 작동할 수 있는 데이터가 생성됩니다."),
     ).toBeInTheDocument();
     expect(screen.getByTestId("file-uploader")).toBeInTheDocument();
-    expect(screen.getByTestId("accepted-types")).toHaveTextContent(".json,application/json");
-    expect(screen.getByTestId("policy-copy")).toHaveTextContent("JSON 50MB JSON");
+    expect(screen.getByTestId("accepted-types")).toHaveTextContent(
+      ".zip,application/zip,application/x-zip-compressed",
+    );
+    expect(screen.getByTestId("policy-copy")).toHaveTextContent("ZIP 50MB ZIP");
   });
 
   it("shows file preview and Start Processing button after selecting a file", () => {
     render(<LogUploadForm workspaceId={1} />, { wrapper: MemoryRouter });
-    const file = new File(["test"], "test.json", { type: "application/json" });
+    const file = new File(["test"], "test.zip", { type: "application/zip" });
     const input = screen.getByTestId("file-input");
     fireEvent.change(input, { target: { files: [file] } });
     expect(screen.getByText("처리 시작")).toBeInTheDocument();
-    expect(screen.getByText("test.json")).toBeInTheDocument();
+    expect(screen.getByText("test.zip")).toBeInTheDocument();
   });
 
-  it("rejects non-JSON files with toast error", () => {
+  it("rejects non-ZIP files with toast error", () => {
     render(<LogUploadForm workspaceId={1} />, { wrapper: MemoryRouter });
-    const file = new File(["test"], "test.csv", { type: "text/csv" });
+    const file = new File(["test"], "test.json", { type: "application/json" });
     const input = screen.getByTestId("file-input");
     fireEvent.change(input, { target: { files: [file] } });
-    expect(vi.mocked(toast.error)).toHaveBeenCalledWith("JSON 파일만 업로드할 수 있습니다.");
+    expect(vi.mocked(toast.error)).toHaveBeenCalledWith("ZIP 파일만 업로드할 수 있습니다.");
   });
 
   it("rejects files larger than 50MB with toast error", () => {
     render(<LogUploadForm workspaceId={1} />, { wrapper: MemoryRouter });
-    const file = new File(["test"], "big.json", { type: "application/json" });
+    const file = new File(["test"], "big.zip", { type: "application/zip" });
     Object.defineProperty(file, "size", { value: 51 * 1024 * 1024 });
     const input = screen.getByTestId("file-input");
     fireEvent.change(input, { target: { files: [file] } });
@@ -161,7 +163,7 @@ describe("LogUploadForm", () => {
 
   it("calls mutate on Start Processing click", () => {
     render(<LogUploadForm workspaceId={1} />, { wrapper: MemoryRouter });
-    const file = new File(["data"], "data.json", { type: "application/json" });
+    const file = new File(["data"], "data.zip", { type: "application/zip" });
     const input = screen.getByTestId("file-input");
     fireEvent.change(input, { target: { files: [file] } });
     fireEvent.click(screen.getByText("처리 시작"));
@@ -170,7 +172,7 @@ describe("LogUploadForm", () => {
 
   it("does not call mutate when workspaceId is undefined", () => {
     render(<LogUploadForm />, { wrapper: MemoryRouter });
-    const file = new File(["data"], "data.json", { type: "application/json" });
+    const file = new File(["data"], "data.zip", { type: "application/zip" });
     const input = screen.getByTestId("file-input");
     fireEvent.change(input, { target: { files: [file] } });
     const btn = screen.queryByText("처리 시작");
@@ -180,7 +182,7 @@ describe("LogUploadForm", () => {
 
   it("shows generation CTA after successful upload", () => {
     render(<LogUploadForm workspaceId={1} />, { wrapper: MemoryRouter });
-    const file = new File(["data"], "data.json", { type: "application/json" });
+    const file = new File(["data"], "data.zip", { type: "application/zip" });
     const input = screen.getByTestId("file-input");
     fireEvent.change(input, { target: { files: [file] } });
     fireEvent.click(screen.getByText("처리 시작"));
@@ -193,7 +195,7 @@ describe("LogUploadForm", () => {
   it("shows upload failure toast with retry action", () => {
     mockUploadError = new Error("업로드 실패");
     render(<LogUploadForm workspaceId={1} />, { wrapper: MemoryRouter });
-    const file = new File(["data"], "data.json", { type: "application/json" });
+    const file = new File(["data"], "data.zip", { type: "application/zip" });
     const input = screen.getByTestId("file-input");
     fireEvent.change(input, { target: { files: [file] } });
     fireEvent.click(screen.getByText("처리 시작"));
@@ -214,7 +216,7 @@ describe("LogUploadForm", () => {
 
   it("triggers domain pack generation with uploaded dataset id", () => {
     render(<LogUploadForm workspaceId={1} />, { wrapper: MemoryRouter });
-    const file = new File(["data"], "data.json", { type: "application/json" });
+    const file = new File(["data"], "data.zip", { type: "application/zip" });
     const input = screen.getByTestId("file-input");
     fireEvent.change(input, { target: { files: [file] } });
     fireEvent.click(screen.getByText("처리 시작"));
@@ -224,7 +226,7 @@ describe("LogUploadForm", () => {
 
   it("shows review CTA after generation request succeeds with pipeline job id", () => {
     render(<LogUploadForm workspaceId={1} />, { wrapper: MemoryRouter });
-    const file = new File(["data"], "data.json", { type: "application/json" });
+    const file = new File(["data"], "data.zip", { type: "application/zip" });
     const input = screen.getByTestId("file-input");
     fireEvent.change(input, { target: { files: [file] } });
     fireEvent.click(screen.getByText("처리 시작"));
@@ -264,7 +266,7 @@ describe("LogUploadForm", () => {
 
   it("shows retry action when generation request fails", () => {
     render(<LogUploadForm workspaceId={1} />, { wrapper: MemoryRouter });
-    const file = new File(["data"], "data.json", { type: "application/json" });
+    const file = new File(["data"], "data.zip", { type: "application/zip" });
     const input = screen.getByTestId("file-input");
     fireEvent.change(input, { target: { files: [file] } });
     fireEvent.click(screen.getByText("처리 시작"));
@@ -281,7 +283,7 @@ describe("LogUploadForm", () => {
 
   it("resets form state when Upload Another File is clicked", () => {
     render(<LogUploadForm workspaceId={1} />, { wrapper: MemoryRouter });
-    const file = new File(["data"], "data.json", { type: "application/json" });
+    const file = new File(["data"], "data.zip", { type: "application/zip" });
     const input = screen.getByTestId("file-input");
     fireEvent.change(input, { target: { files: [file] } });
     fireEvent.click(screen.getByText("처리 시작"));

--- a/frontend/src/shared/lib/rawLogUploadPolicy.test.ts
+++ b/frontend/src/shared/lib/rawLogUploadPolicy.test.ts
@@ -10,28 +10,32 @@ import {
 } from "./rawLogUploadPolicy";
 
 describe("rawLogUploadPolicy", () => {
-  it("exposes the JSON 50MB upload policy labels", () => {
-    expect(RAW_LOG_UPLOAD_ACCEPT).toBe(".json,application/json");
-    expect(RAW_LOG_UPLOAD_ACCEPTED_TYPE_LABEL).toBe("JSON");
-    expect(RAW_LOG_UPLOAD_FILE_TYPE_LABELS).toEqual(["JSON"]);
+  it("exposes the ZIP 50MB upload policy labels", () => {
+    expect(RAW_LOG_UPLOAD_ACCEPT).toBe(".zip,application/zip,application/x-zip-compressed");
+    expect(RAW_LOG_UPLOAD_ACCEPTED_TYPE_LABEL).toBe("ZIP");
+    expect(RAW_LOG_UPLOAD_FILE_TYPE_LABELS).toEqual(["ZIP"]);
     expect(RAW_LOG_UPLOAD_MAX_SIZE_LABEL).toBe("50MB");
     expect(RAW_LOG_UPLOAD_MAX_SIZE_BYTES).toBe(50 * 1024 * 1024);
   });
 
-  it("accepts JSON files within the size limit", () => {
-    const file = new File(["{}"], "logs.json", { type: "application/json" });
+  it("accepts ZIP files within the size limit", () => {
+    const file = new File(["PK"], "logs.zip", { type: "application/zip" });
 
     expect(validateRawLogUploadFile(file)).toBeNull();
   });
 
-  it("rejects non-JSON files", () => {
-    const file = new File(["source_id"], "logs.csv", { type: "text/csv" });
+  it.each([
+    ["logs.json", "application/json"],
+    ["logs.csv", "text/csv"],
+    ["logs.xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"],
+  ])("rejects non-ZIP file %s", (fileName, type) => {
+    const file = new File(["source_id"], fileName, { type });
 
-    expect(validateRawLogUploadFile(file)).toBe("JSON 파일만 업로드할 수 있습니다.");
+    expect(validateRawLogUploadFile(file)).toBe("ZIP 파일만 업로드할 수 있습니다.");
   });
 
-  it("rejects JSON files larger than the size limit", () => {
-    const file = new File(["{}"], "logs.json", { type: "application/json" });
+  it("rejects ZIP files larger than the size limit", () => {
+    const file = new File(["PK"], "logs.zip", { type: "application/zip" });
     Object.defineProperty(file, "size", { value: RAW_LOG_UPLOAD_MAX_SIZE_BYTES + 1 });
 
     expect(validateRawLogUploadFile(file)).toBe(

--- a/frontend/src/shared/lib/rawLogUploadPolicy.ts
+++ b/frontend/src/shared/lib/rawLogUploadPolicy.ts
@@ -1,14 +1,14 @@
 export const RAW_LOG_UPLOAD_MAX_SIZE_BYTES = 50 * 1024 * 1024;
 export const RAW_LOG_UPLOAD_MAX_SIZE_LABEL = "50MB";
-export const RAW_LOG_UPLOAD_ACCEPT = ".json,application/json";
-export const RAW_LOG_UPLOAD_ACCEPTED_TYPE_LABEL = "JSON";
-export const RAW_LOG_UPLOAD_FILE_TYPE_LABELS = ["JSON"];
+export const RAW_LOG_UPLOAD_ACCEPT = ".zip,application/zip,application/x-zip-compressed";
+export const RAW_LOG_UPLOAD_ACCEPTED_TYPE_LABEL = "ZIP";
+export const RAW_LOG_UPLOAD_FILE_TYPE_LABELS = ["ZIP"];
 
 export function validateRawLogUploadFile(file: File): string | null {
   const name = file.name.toLowerCase();
 
-  if (!name.endsWith(".json")) {
-    return "JSON 파일만 업로드할 수 있습니다.";
+  if (!name.endsWith(".zip")) {
+    return "ZIP 파일만 업로드할 수 있습니다.";
   }
 
   if (file.size > RAW_LOG_UPLOAD_MAX_SIZE_BYTES) {

--- a/frontend/src/shared/ui/file-upload/FileUploader.test.tsx
+++ b/frontend/src/shared/ui/file-upload/FileUploader.test.tsx
@@ -4,14 +4,14 @@ import { describe, expect, it, vi } from "vitest";
 import { FileUploader } from "./FileUploader";
 
 describe("FileUploader", () => {
-  it("shows the default JSON 50MB upload policy", () => {
+  it("shows the default ZIP 50MB upload policy", () => {
     render(<FileUploader onFileSelect={vi.fn()} />);
 
-    expect(screen.getByText(/JSON 파일 1개를 업로드할 수 있습니다\. 최대 50MB\./)).toBeInTheDocument();
-    expect(screen.getByText("JSON")).toBeInTheDocument();
+    expect(screen.getByText(/ZIP 파일 1개를 업로드할 수 있습니다\. 최대 50MB\./)).toBeInTheDocument();
+    expect(screen.getByText("ZIP")).toBeInTheDocument();
   });
 
-  it("uses JSON wording while analyzing", () => {
+  it("uses 상담 로그 wording while analyzing", () => {
     render(<FileUploader onFileSelect={vi.fn()} status="analyzing" />);
 
     expect(screen.getByText("상담 로그 분석 중...")).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- 상담 로그 업로드 정책을 ZIP 기준으로 정렬해 파일 선택 accept, 안내 라벨, 클라이언트 검증 문구를 갱신했습니다.
- 백엔드 raw-file 업로드가 ZIP 매직 바이트가 아닌 파일을 S3/MinIO 저장과 파싱 전에 거부하도록 했습니다.
- ZIP 내부 `.json`/`.jsonl` 파싱과 ZIP entry 경로/크기 방어를 유지하고, 이슈 요구사항을 `.agent/specs/421.md`에 정리했습니다.

## Validation
- `cd frontend && pnpm test -- rawLogUploadPolicy LogUploadForm FileUploader`
- `cd frontend && pnpm test -- --run`
- `cd frontend && pnpm exec eslint src/shared/lib/rawLogUploadPolicy.ts src/shared/lib/rawLogUploadPolicy.test.ts src/features/log-upload/ui/LogUploadForm.test.tsx src/shared/ui/file-upload/FileUploader.test.tsx`
- `cd backend && GRADLE_USER_HOME=/Users/owen/.codex/tmp/gradle-ostone-421 JAVA_HOME=/Users/owen/.local/share/mise/installs/java/temurin-21.0.10+7.0.LTS PATH=/Users/owen/.local/share/mise/installs/java/temurin-21.0.10+7.0.LTS/bin:$PATH ./gradlew -Dorg.gradle.java.installations.paths=/Users/owen/.local/share/mise/installs/java/temurin-21.0.10+7.0.LTS test --tests com.init.corpus.application.RawFileUploadServiceTest --tests com.init.corpus.presentation.DatasetControllerRawFileTest`
- `cd backend && GRADLE_USER_HOME=/Users/owen/.codex/tmp/gradle-ostone-421 JAVA_HOME=/Users/owen/.local/share/mise/installs/java/temurin-21.0.10+7.0.LTS PATH=/Users/owen/.local/share/mise/installs/java/temurin-21.0.10+7.0.LTS/bin:$PATH ./gradlew -Dorg.gradle.java.installations.paths=/Users/owen/.local/share/mise/installs/java/temurin-21.0.10+7.0.LTS spotlessApply`
- `git diff --check`
- `git diff --cached --check`

참고: `cd frontend && pnpm lint`는 이 변경 범위 밖의 기존 lint 오류들로 실패합니다.

Closes #421