### PR TITLE
feat(consultation): 상담사 연결 요청 라벨 제공

### DIFF
--- a/.agent/specs/414.md
+++ b/.agent/specs/414.md
@@ -1,0 +1,116 @@
+# Frontend FSD Spec: 상담사 연결 요청 라벨 개선
+
+## Goal
+
+상담 응대 화면에서 `handoffRequired` 상태를 내부 구현처럼 보이는 `AI 이관`이 아니라 상담사가 바로 이해할 수 있는 상담사 연결/확인 요청 맥락으로 표시한다.
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A[상담사가 상담 큐 진입] --> B[QueuePanel 목록 확인]
+    B --> C{handoffRequired 세션 존재?}
+    C -->|Yes| D[필터, 정렬, 배지, 카운트에 상담사 연결 요청 문구 표시]
+    C -->|No| E[일반 상담 큐 문구 표시]
+    D --> F[세션 선택]
+    F --> G[ConsultationPage 상태 라벨 확인]
+    G --> H[CustomerPanel 상세 카드 확인]
+    H --> I[상담사 확인 필요, 사유, 발생 시각 확인]
+    E --> J[종료]
+    I --> J
+```
+
+## Design Diff
+
+### As-is vs To-be
+
+| 영역 | As-is | To-be | 변경 내용 |
+|------|-------|-------|----------|
+| 상담 큐 필터 | `AI 이관` | `상담사 연결 요청` | 내부 AI 처리보다 상담사 행동 의미를 우선 표시 |
+| 상담 큐 정렬 | `AI 이관 우선` | `연결 요청 우선` | 짧고 업무 중심인 정렬명으로 변경 |
+| 상담 큐 검색 대상 | `AI 이관` | `상담사 연결 요청` | 검색어 매칭도 화면 라벨과 일치 |
+| 상담 큐 배지 | `AI 이관` | `상담사 연결 요청` | 카드 상태 의미를 상담사 연결 요청으로 표시 |
+| 상담 큐 카운트 | `AI 이관 N건` | `연결 요청 N건` | 헤더 요약은 짧은 표현 사용 |
+| 상담 큐 빈 상태 | `AI 이관 상담이 없습니다` | `상담사 연결 요청이 없습니다` | 필터 빈 상태 문구 변경 |
+| 상담 상세 상태 prefix | `AI 이관 · ...` | `상담사 연결 요청 · ...` | active status prefix를 사용자 맥락으로 변경 |
+| 고객 상세 카드 제목 | `AI 이관` | `상담사 확인 필요` | 상세 카드에서 사유/발생 시각과 함께 확인 요청 의미 표시 |
+
+## Component Tree
+
+```text
+ConsultationPage
+├─ QueuePanel
+│  ├─ filter tabs
+│  ├─ sort buttons
+│  ├─ search input
+│  ├─ queue item handoff badge
+│  └─ queue summary / empty state
+└─ CustomerPanel
+   └─ handoffRequired detail InfoCard
+      ├─ 상태: 상담사 확인 필요
+      ├─ 사유
+      └─ 발생 시각
+```
+
+## API Integration
+
+이번 변경은 프론트엔드 표시 문구만 변경하며 API 호출, generated endpoint, query key, 응답 스키마를 변경하지 않는다.
+
+## 수정 대상 파일
+
+| 파일 | 변경 유형 | 설명 |
+|------|----------|------|
+| `frontend/src/features/consultation/ui/QueuePanel.tsx` | modify | 필터, 정렬, 검색 대상, 빈 상태, 배지, 카운트 문구 변경 |
+| `frontend/src/features/consultation/ui/QueuePanel.test.tsx` | modify | 상담 큐 문구 기대값 갱신 |
+| `frontend/src/pages/consultation/ui/ConsultationPage.tsx` | modify | `handoffRequired` active status prefix 문구 변경 |
+| `frontend/src/pages/consultation/ui/ConsultationPage.test.tsx` | modify | 페이지 통합 테스트 기대 문구 갱신 |
+| `frontend/src/pages/consultation/ui/sections/CustomerPanel.tsx` | modify | 상세 카드 제목을 상담사 확인 필요로 변경 |
+| `frontend/src/pages/consultation/ui/sections/consultation-sections.test.tsx` | modify | 상세 패널 테스트 기대 문구 갱신 |
+
+## State Management
+
+상태 모델은 유지한다.
+
+- `handoffRequired` 값은 계속 상담사 확인/연결 요청 표시 여부를 결정한다.
+- 정렬, 필터, 검색 로직은 기존 기준을 유지하고 표시 문자열만 변경한다.
+- 고객 상세 패널의 사유와 발생 시각 표시 조건은 기존 `handoffRequired` 조건을 유지한다.
+
+## Requirements
+
+1. 상담 큐 필터/정렬/배지/요약/빈 상태에서 `AI 이관` 문구를 제거한다.
+2. `handoffRequired` 상태는 기본적으로 `상담사 연결 요청`으로 표시한다.
+3. 짧은 헤더 카운트 요약은 `연결 요청 N건` 형식을 사용한다.
+4. 정렬 옵션은 `연결 요청 우선`을 사용한다.
+5. 상세 패널은 `상담사 확인 필요` 제목 아래에 상태, 사유, 발생 시각을 함께 표시한다.
+6. API, 데이터 구조, 상담 큐 정렬 우선순위, 필터 동작은 변경하지 않는다.
+
+## Non-goals
+
+- 백엔드 `handoffRequired` 필드명 또는 API 응답 스키마 변경은 하지 않는다.
+- 상담 큐 정렬 기준, 필터 기준, 배정 상태 계산 방식을 변경하지 않는다.
+- 새로운 디자인 컴포넌트나 색상 체계를 도입하지 않는다.
+
+## Tests
+
+### Test Strategy
+
+| 구분 | 방법 | 도구 | 비고 |
+|------|------|------|------|
+| 컴포넌트 테스트 | 라벨/배지/빈 상태/정렬 버튼 기대값 검증 | Vitest + React Testing Library | `QueuePanel`, `CustomerPanel` |
+| 페이지 통합 테스트 | 상담 큐 요약 문구와 상태 prefix 검증 | Vitest + React Testing Library | `ConsultationPage` |
+| 정적 확인 | 남은 `AI 이관` 문구 검색 | `rg` | 사용자-facing 잔존 문구 확인 |
+
+### Test Scenarios
+
+| # | 시나리오 | 기대 결과 |
+|---|---------|----------|
+| 1 | 상담 큐 헤더 표시 | `연결 요청 N건 · 미배정 N건 · 진행 N건` 표시 |
+| 2 | `handoffRequired` 고객 카드 표시 | `상담사 연결 요청` 배지와 사유 표시 |
+| 3 | 기본 정렬 표시 | `연결 요청 우선` 버튼이 활성화되고 기존 정렬 순서 유지 |
+| 4 | 상담사 연결 요청 필터 선택 | `handoffRequired` 세션만 표시 |
+| 5 | 상담사 연결 요청 필터 결과 없음 | `상담사 연결 요청이 없습니다` 표시 |
+| 6 | 상세 패널 표시 | `상담사 확인 필요`, 사유, 발생 시각 표시 |
+
+## Open Questions
+
+- 없음. 이슈에 추천 용어와 확인 기준이 명시되어 있어 별도 제품 결정이 필요하지 않다.

--- a/frontend/src/features/consultation/ui/QueuePanel.test.tsx
+++ b/frontend/src/features/consultation/ui/QueuePanel.test.tsx
@@ -82,7 +82,7 @@ describe("QueuePanel", () => {
     renderQueuePanel({ customers });
 
     expect(screen.getByText("상담 큐")).toBeInTheDocument();
-    expect(screen.getByText("AI 이관 0건 · 미배정 1건 · 진행 2건")).toBeInTheDocument();
+    expect(screen.getByText("연결 요청 0건 · 미배정 1건 · 진행 2건")).toBeInTheDocument();
     expect(screen.queryByText(/대기중$/)).not.toBeInTheDocument();
   });
 
@@ -92,14 +92,14 @@ describe("QueuePanel", () => {
     expect(screen.getByText("카드 오류")).toBeInTheDocument();
   });
 
-  it("handoffRequired 세션은 AI 이관 배지와 사유를 표시한다", () => {
+  it("handoffRequired 세션은 상담사 연결 요청 배지와 사유를 표시한다", () => {
     renderQueuePanel({
       customers: [makeCustomer("1", { handoffRequired: true, handoffReason: "관리자 승인 필요" })],
     });
 
-    expect(screen.getAllByText("AI 이관").length).toBeGreaterThanOrEqual(2);
+    expect(screen.getAllByText("상담사 연결 요청").length).toBeGreaterThanOrEqual(2);
     expect(screen.getByText("사유: 관리자 승인 필요")).toBeInTheDocument();
-    expect(screen.getByText("AI 이관 1건 · 미배정 1건 · 진행 0건")).toBeInTheDocument();
+    expect(screen.getByText("연결 요청 1건 · 미배정 1건 · 진행 0건")).toBeInTheDocument();
   });
 
   it("title이 있으면 handoffReason보다 우선 표시한다", () => {
@@ -193,7 +193,7 @@ describe("QueuePanel", () => {
     expect(screen.queryByText("20분 전")).not.toBeInTheDocument();
   });
 
-  it("기본 정렬은 AI 이관을 우선하고 이관 시각이 오래된 고객을 먼저 표시한다", () => {
+  it("기본 정렬은 연결 요청을 우선하고 이관 시각이 오래된 고객을 먼저 표시한다", () => {
     renderQueuePanel({
       customers: [
         makeCustomer("1", {
@@ -217,7 +217,7 @@ describe("QueuePanel", () => {
       ],
     });
 
-    expect(getSortButton("AI 이관 우선")).toHaveAttribute("aria-pressed", "true");
+    expect(getSortButton("연결 요청 우선")).toHaveAttribute("aria-pressed", "true");
     expect(getRenderedQueueItems().map((button) => button.textContent)).toEqual([
       expect.stringContaining("오래된 이관 고객"),
       expect.stringContaining("새 이관 고객"),
@@ -326,7 +326,7 @@ describe("QueuePanel", () => {
     expect(screen.queryByText("고객2")).not.toBeInTheDocument();
   });
 
-  it("AI 이관 필터를 선택하면 handoffRequired 세션만 표시한다", () => {
+  it("상담사 연결 요청 필터를 선택하면 handoffRequired 세션만 표시한다", () => {
     renderQueuePanel({
       customers: [
         makeCustomer("1", { handoffRequired: true, handoffReason: "상담사 확인 필요" }),
@@ -334,10 +334,20 @@ describe("QueuePanel", () => {
       ],
     });
 
-    fireEvent.click(getFilterButton("AI 이관"));
+    fireEvent.click(getFilterButton("상담사 연결 요청"));
 
     expect(screen.getByText("고객1")).toBeInTheDocument();
     expect(screen.queryByText("고객2")).not.toBeInTheDocument();
+  });
+
+  it("상담사 연결 요청 필터 결과가 없으면 연결 요청 빈 상태를 표시한다", () => {
+    renderQueuePanel({
+      customers: [makeCustomer("1", { handoffRequired: false })],
+    });
+
+    fireEvent.click(getFilterButton("상담사 연결 요청"));
+
+    expect(screen.getByText("상담사 연결 요청이 없습니다")).toBeInTheDocument();
   });
 
   it("읽지 않음 필터를 선택하면 읽지 않은 세션만 표시한다", () => {

--- a/frontend/src/features/consultation/ui/QueuePanel.tsx
+++ b/frontend/src/features/consultation/ui/QueuePanel.tsx
@@ -52,14 +52,14 @@ interface QueueSortOption {
 
 const FILTER_OPTIONS: QueueFilterOption[] = [
   { value: "all", label: "전체" },
-  { value: "handoff", label: "AI 이관" },
+  { value: "handoff", label: "상담사 연결 요청" },
   { value: "mine", label: "내 상담" },
   { value: "unassigned", label: "미배정" },
   { value: "unread", label: "읽지 않음" },
 ];
 
 const SORT_OPTIONS: QueueSortOption[] = [
-  { value: "handoffPriority", label: "AI 이관 우선" },
+  { value: "handoffPriority", label: "연결 요청 우선" },
   { value: "waitLongest", label: "오래 기다린 순" },
   { value: "latest", label: "최신순" },
 ];
@@ -103,7 +103,7 @@ const matchesSearch = (customer: QueueCustomer, searchTerm: string) => {
     customer.lastMessage,
     customer.lastMessagePreview,
     customer.handoffReason,
-    customer.handoffRequired ? "AI 이관" : "",
+    customer.handoffRequired ? "상담사 연결 요청" : "",
   ]
     .filter(Boolean)
     .some((value) => normalizeSearch(String(value)).includes(normalizedTerm));
@@ -189,7 +189,7 @@ const getEmptyMessage = (
   if (customers.length === 0) return "현재 상담 큐가 비어 있습니다";
   if (normalizeSearch(searchTerm)) return "검색 조건에 맞는 상담이 없습니다";
   if (selectedFilter === "mine") return "내 상담이 없습니다";
-  if (selectedFilter === "handoff") return "AI 이관 상담이 없습니다";
+  if (selectedFilter === "handoff") return "상담사 연결 요청이 없습니다";
   if (selectedFilter === "unassigned") return "미배정 상담이 없습니다";
   if (selectedFilter === "unread") return "읽지 않은 상담이 없습니다";
   return "표시할 상담이 없습니다";
@@ -288,7 +288,7 @@ export const QueuePanel: React.FC<QueuePanelProps> = ({
           <div className={styles.queueItemInfo}>
             <div className={styles.customerNameRow}>
               <div className={styles.customerName}>{displayName}</div>
-              {c.handoffRequired && <span className={styles.handoffBadge}>AI 이관</span>}
+              {c.handoffRequired && <span className={styles.handoffBadge}>상담사 연결 요청</span>}
             </div>
             <div className={styles.handoffPreview}>{subject}</div>
             {c.handoffRequired && c.handoffReason && (
@@ -314,7 +314,7 @@ export const QueuePanel: React.FC<QueuePanelProps> = ({
       <div className={styles.queueHeader}>
         <h3 className={styles.queueTitle}>상담 큐</h3>
         <span className={styles.queueCount}>
-          AI 이관 {filterCounts.handoff}건 · 미배정 {filterCounts.unassigned}건 · 진행{" "}
+          연결 요청 {filterCounts.handoff}건 · 미배정 {filterCounts.unassigned}건 · 진행{" "}
           {inProgressCount}건
         </span>
         <label className={styles.searchBox}>

--- a/frontend/src/pages/consultation/ui/ConsultationPage.test.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.test.tsx
@@ -464,7 +464,8 @@ describe("ConsultationPage", () => {
       expect.stringContaining("새 이관 고객"),
       expect.stringContaining("일반 고객"),
     ]);
-    expect(screen.getByText("AI 이관 2건 · 미배정 3건 · 진행 0건")).toBeInTheDocument();
+    expect(screen.getByText("연결 요청 2건 · 미배정 3건 · 진행 0건")).toBeInTheDocument();
+    expect(screen.getAllByText("상담사 연결 요청 · 미배정").length).toBeGreaterThan(0);
   });
 
   it("selects the route session and restores messages when opening a session URL directly", async () => {

--- a/frontend/src/pages/consultation/ui/ConsultationPage.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.tsx
@@ -346,7 +346,7 @@ const getSessionStatusLabel = (
   currentCounselorId?: number | null,
   handoffRequired?: boolean,
 ) => {
-  const prefix = handoffRequired ? "AI 이관 · " : "";
+  const prefix = handoffRequired ? "상담사 연결 요청 · " : "";
   if (status === "COMPLETED") return "상담 종료";
   if (status === "RESOLVED") return "해결됨";
   if (assignedCounselorId && assignedCounselorId === currentCounselorId)

--- a/frontend/src/pages/consultation/ui/sections/CustomerPanel.tsx
+++ b/frontend/src/pages/consultation/ui/sections/CustomerPanel.tsx
@@ -151,7 +151,7 @@ export function CustomerPanel({
       </InfoCard>
 
       {customer.handoffRequired && (
-        <InfoCard title="AI 이관" meta="HANDOFF">
+        <InfoCard title="상담사 확인 필요" meta="HANDOFF">
           <InfoRow label="상태" tone="warn" value={<Pill tone="warn">상담사 확인 필요</Pill>} />
           <InfoRow label="사유" value={customer.handoffReason || "상담원 확인이 필요합니다."} />
           <InfoRow label="발생 시각" value={customer.handoffAt || "기록 없음"} />

--- a/frontend/src/pages/consultation/ui/sections/consultation-sections.test.tsx
+++ b/frontend/src/pages/consultation/ui/sections/consultation-sections.test.tsx
@@ -274,8 +274,7 @@ describe("CustomerPanel", () => {
       />,
     );
 
-    expect(screen.getByText("AI 이관")).toBeInTheDocument();
-    expect(screen.getByText("상담사 확인 필요")).toBeInTheDocument();
+    expect(screen.getAllByText("상담사 확인 필요")).toHaveLength(2);
     expect(screen.getByText("관리자 승인 필요")).toBeInTheDocument();
     expect(screen.getByText("2026-06-01T10:00:00+09:00")).toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary
- 상담 큐의 handoffRequired 표시를 `AI 이관` 대신 상담사가 이해하기 쉬운 `상담사 연결 요청`/`연결 요청` 문구로 정리했습니다.
- 상담 상세 상태 prefix와 고객 상세 카드 제목을 상담사 연결/확인 요청 맥락에 맞게 변경했습니다.
- 이슈 요구사항과 검증 기준을 `.agent/specs/414.md`에 정리하고 관련 상담 화면 테스트 기대값을 갱신했습니다.

## Validation
- `cd frontend && pnpm test -- --run src/features/consultation/ui/QueuePanel.test.tsx src/pages/consultation/ui/ConsultationPage.test.tsx src/pages/consultation/ui/sections/consultation-sections.test.tsx`
- `cd frontend && pnpm exec eslint src/features/consultation/ui/QueuePanel.tsx src/features/consultation/ui/QueuePanel.test.tsx src/pages/consultation/ui/ConsultationPage.tsx src/pages/consultation/ui/ConsultationPage.test.tsx src/pages/consultation/ui/sections/CustomerPanel.tsx src/pages/consultation/ui/sections/consultation-sections.test.tsx`
- `cd frontend && pnpm build`
- `git diff --check`
- `git diff --cached --check`
- `rg -n "AI 이관" frontend/src frontend --glob "*.{ts,tsx,css,md}"`

## Notes
- `cd frontend && pnpm lint`는 변경 범위 밖의 기존 lint 오류 58개로 실패했습니다. 변경 파일은 targeted eslint를 통과했습니다.

Closes #414