### PR TITLE
fix(infra): ACM 검증 레코드 계획 오류 해결

### DIFF
--- a/infra/terraform/route53-acm.tf
+++ b/infra/terraform/route53-acm.tf
@@ -53,23 +53,14 @@ resource "aws_acm_certificate" "cloudfront" {
   }
 }
 
-locals {
-  acm_validation_options = concat(
-    tolist(aws_acm_certificate.regional.domain_validation_options),
-    tolist(aws_acm_certificate.cloudfront.domain_validation_options)
-  )
-
-  acm_validation_records = {
-    for option in local.acm_validation_options : option.resource_record_name => {
+resource "aws_route53_record" "acm_validation" {
+  for_each = {
+    for option in aws_acm_certificate.regional.domain_validation_options : option.domain_name => {
       name   = option.resource_record_name
       record = option.resource_record_value
       type   = option.resource_record_type
     }
   }
-}
-
-resource "aws_route53_record" "acm_validation" {
-  for_each = local.acm_validation_records
 
   zone_id = local.route53_zone_id
   name    = each.value.name
@@ -84,7 +75,7 @@ resource "aws_acm_certificate_validation" "regional" {
   certificate_arn = aws_acm_certificate.regional.arn
   validation_record_fqdns = [
     for option in aws_acm_certificate.regional.domain_validation_options :
-    aws_route53_record.acm_validation[option.resource_record_name].fqdn
+    aws_route53_record.acm_validation[option.domain_name].fqdn
   ]
 }
 
@@ -94,6 +85,6 @@ resource "aws_acm_certificate_validation" "cloudfront" {
   certificate_arn = aws_acm_certificate.cloudfront.arn
   validation_record_fqdns = [
     for option in aws_acm_certificate.cloudfront.domain_validation_options :
-    aws_route53_record.acm_validation[option.resource_record_name].fqdn
+    aws_route53_record.acm_validation[option.domain_name].fqdn
   ]
 }


### PR DESCRIPTION
## Summary
- ACM DNS validation Route53 record의 `for_each` key를 apply 이후에만 알 수 있는 record name 대신 도메인명 기준으로 변경했습니다.
- regional 인증서에서 생성한 DNS validation record를 CloudFront 인증서 validation에도 재사용해 첫 Terraform plan 단계에서 인스턴스 key를 확정할 수 있게 했습니다.

## Validation
- `terraform fmt -check`
- `terraform init -backend=false`
- `terraform validate`
- `git diff --check -- infra/terraform/route53-acm.tf`

## Notes
- 실제 `terraform plan/apply`는 AWS 계정 리소스 조회가 필요해 GitHub Actions OIDC 실행에서 확인합니다.
- AWS CLI는 로컬에서 사용하지 않았습니다.