### PR TITLE
fix(consultation): 상담 처리 후 오늘 처리 지표 갱신

### DIFF
--- a/.agent/specs/413.md
+++ b/.agent/specs/413.md
@@ -1,0 +1,120 @@
+# Issue 413: 상담 오늘 처리 지표 갱신
+
+## Goal
+
+상담사가 상담을 처리하면 상담 화면 상단의 `오늘 처리` 지표가 처리 결과 선택지와 동일한 기준으로 즉시 갱신되도록 한다.
+
+## Problem
+
+상담 화면은 진입 시 `GET /api/v1/workspaces/{workspaceId}/consultation/metrics`를 한 번 호출해 상단 지표를 채운다. 상담 종료 모달에서 `해결됨`, `고객 이탈`, `보류`, `후속 연락 필요` 중 하나를 선택해 상태 변경 요청이 성공해도 큐에서 세션만 제거되고 metrics는 다시 조회되지 않는다.
+
+Backend 집계도 `status = 'COMPLETED'`이고 오늘 `ended_at`이 있는 세션만 `handledTodayCount`로 계산한다. 현재 UI 선택지 중 `해결됨`, `보류`, `후속 연락 필요`는 `RESOLVED` 상태로 저장되므로 상담사가 처리했다고 인식한 세션이 오늘 처리에 포함되지 않을 수 있다.
+
+## Scope
+
+- `RESOLVED`와 `COMPLETED` 모두 상담사가 처리한 종료 결과로 본다.
+- `COMPLETED`는 `runtime.chat_session.ended_at`이 오늘 기간 안에 있으면 오늘 처리로 집계한다.
+- `RESOLVED`는 `meta_json.resolution.resolvedAt`이 오늘 기간 안에 있으면 오늘 처리로 집계한다.
+- 상담 종료/해결 요청 성공 후 `ConsultationPage`는 metrics를 재조회해 상단 지표를 갱신한다.
+- 관련 frontend/backend 테스트를 갱신하거나 추가한다.
+
+## Non-goals
+
+- `runtime.chat_session`에 별도 `resolved_at` 컬럼을 추가하지 않는다.
+- 상담 처리 선택지나 상태 enum을 새로 늘리지 않는다.
+- metrics endpoint 응답 필드를 변경하지 않는다.
+- 상담 이력 화면의 필터 기본값은 이 이슈에서 변경하지 않는다.
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A["상담사가 활성 상담 선택"] --> B["상담 종료 클릭"]
+    B --> C["처리 결과 선택"]
+    C --> D["종료 확인"]
+    D --> E{"상태 변경 성공?"}
+    E -->|Yes| F["큐에서 세션 제거"]
+    F --> G["metrics 재조회"]
+    G --> H["오늘 처리 지표 갱신"]
+    E -->|No| I["모달 오류와 토스트 표시"]
+```
+
+## Design Diff
+
+| 영역 | As-is | To-be | 변경 내용 |
+| --- | --- | --- | --- |
+| Frontend metrics 로딩 | 화면 진입 시 1회 조회 | 화면 진입 및 상담 처리 성공 후 조회 | 종료 성공 handler에서 metrics reload 호출 |
+| Backend 처리 기준 | `COMPLETED` + 오늘 `ended_at` | `COMPLETED` + 오늘 `ended_at`, 또는 `RESOLVED` + 오늘 `resolution.resolvedAt` | UI 처리 결과 선택지와 집계 기준 정렬 |
+| 사용자 피드백 | 큐에서는 사라지지만 상단 지표가 이전 값 유지 가능 | 처리 직후 최신 지표 반영 | 낙관 업데이트보다 서버 재조회 우선 |
+
+## Affected Files
+
+| 파일 | 변경 유형 | 설명 |
+| --- | --- | --- |
+| `frontend/src/pages/consultation/ui/ConsultationPage.tsx` | modify | metrics 로딩 함수를 재사용 가능하게 정리하고 상담 처리 성공 후 재조회 |
+| `frontend/src/pages/consultation/ui/ConsultationPage.test.tsx` | modify | 상담 처리 성공 후 metrics 재조회 검증 |
+| `frontend/src/pages/consultation/ui/ConsultationPage.generated-api.test.tsx` | modify | generated updateStatus 흐름에서 metrics 재조회 검증 |
+| `backend/src/main/java/com/init/workflowruntime/infrastructure/persistence/JpaConsultationMetricsRepository.java` | modify | `RESOLVED` 처리 기준을 `meta_json.resolution.resolvedAt` 기반으로 포함 |
+| `backend/src/test/java/com/init/workflowruntime/infrastructure/persistence/JpaConsultationMetricsRepositoryTest.java` | modify | `RESOLVED` 오늘 처리 포함 및 기간 밖 제외 검증 |
+
+## API Integration
+
+### Existing Endpoints
+
+| Method | Path | Description |
+| --- | --- | --- |
+| GET | `/api/v1/workspaces/{workspaceId}/consultation/metrics` | 상담 지표 조회 |
+| PATCH | `/api/v1/consultation/sessions/{sessionId}/status` | 상담 세션 상태 및 처리 결과 변경 |
+
+### Response Contract
+
+`handledTodayCount`, `llmHandledTodayCount`, `humanHandledTodayCount`의 응답 필드는 유지한다. 단, 처리 대상 세션 판정은 다음으로 명확히 한다.
+
+| 상태 | 오늘 처리 기준 |
+| --- | --- |
+| `COMPLETED` | `ended_at >= periodStart and ended_at < periodEnd` |
+| `RESOLVED` | `meta_json.resolution.resolvedAt >= periodStart and meta_json.resolution.resolvedAt < periodEnd` |
+
+## Backend Data Flow
+
+```mermaid
+sequenceDiagram
+    participant UI as ConsultationPage
+    participant API as ConsultationMetricsController
+    participant SVC as ConsultationMetricsService
+    participant REPO as JpaConsultationMetricsRepository
+    participant DB as PostgreSQL
+
+    UI->>API: GET metrics
+    API->>SVC: getWorkspaceMetrics(command)
+    SVC->>REPO: findSessionFacts(workspaceId, periodStart, periodEnd)
+    REPO->>DB: query chat_session/chat_message
+    DB-->>REPO: facts with handled_today
+    REPO-->>SVC: ConsultationMetricsSessionFact[]
+    SVC-->>API: ConsultationMetricsResponse
+    API-->>UI: metrics
+```
+
+## Frontend State Management
+
+- metrics는 기존처럼 `ConsultationPage` local state로 유지한다.
+- `loadMetrics`를 `useCallback`으로 분리해 화면 진입과 상담 처리 성공 흐름에서 공유한다.
+- 처리 성공 후 metrics 조회가 실패해도 이미 성공한 상담 종료/해결을 되돌리지 않는다. 기존 metrics 오류 토스트 정책을 사용한다.
+
+## Acceptance Criteria
+
+1. 상담 종료 모달에서 `고객 이탈`을 선택해 `COMPLETED`로 저장하면 성공 후 metrics가 다시 조회된다.
+2. 상담 종료 모달에서 `해결됨`, `보류`, `후속 연락 필요`을 선택해 `RESOLVED`로 저장하면 성공 후 metrics가 다시 조회된다.
+3. Backend `handledTodayCount`는 오늘 `ended_at`이 있는 `COMPLETED`와 오늘 `meta_json.resolution.resolvedAt`이 있는 `RESOLVED`를 포함한다.
+4. Backend `handledTodayCount`는 기간 밖 `resolvedAt`을 가진 `RESOLVED`를 오늘 처리로 포함하지 않는다.
+5. `humanHandledTodayCount`와 `llmHandledTodayCount`는 변경된 `handledToday` 기준을 동일하게 사용한다.
+6. metrics 재조회 실패는 상담 처리 성공을 취소하지 않고 기존 오류 표시/토스트 흐름으로 처리한다.
+
+## Validation
+
+- Backend: `cd backend && ./gradlew test --tests com.init.workflowruntime.infrastructure.persistence.JpaConsultationMetricsRepositoryTest`
+- Frontend: `cd frontend && pnpm test -- ConsultationPage.test.tsx ConsultationPage.generated-api.test.tsx`
+
+## Open Questions
+
+- 없음. 이 이슈에서는 `RESOLVED`도 처리 건수에 포함하고, 기존 metadata의 `resolution.resolvedAt`을 기준 시각으로 사용한다.

--- a/backend/src/main/java/com/init/workflowruntime/infrastructure/persistence/JpaConsultationMetricsRepository.java
+++ b/backend/src/main/java/com/init/workflowruntime/infrastructure/persistence/JpaConsultationMetricsRepository.java
@@ -1,19 +1,27 @@
 package com.init.workflowruntime.infrastructure.persistence;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.init.workflowruntime.domain.ConsultationMetricsRepository;
 import com.init.workflowruntime.domain.ConsultationMetricsSessionFact;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.Query;
+import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.time.format.DateTimeParseException;
 import java.util.List;
+import java.util.Objects;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public class JpaConsultationMetricsRepository implements ConsultationMetricsRepository {
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   private final EntityManager entityManager;
 
@@ -28,12 +36,18 @@ public class JpaConsultationMetricsRepository implements ConsultationMetricsRepo
         entityManager.createNativeQuery(
             """
             with scoped_sessions as (
-              select cs.id, cs.status, cs.started_at, cs.ended_at
+              select
+                cs.id,
+                cs.status,
+                cs.started_at,
+                cs.ended_at,
+                cs.meta_json
               from runtime.chat_session cs
               where cs.workspace_id = :workspaceId
                 and (
                   (cs.started_at >= :periodStart and cs.started_at < :periodEnd)
                   or (cs.ended_at >= :periodStart and cs.ended_at < :periodEnd and cs.status = 'COMPLETED')
+                  or cs.status = 'RESOLVED'
                 )
             ),
             first_customer as (
@@ -76,7 +90,7 @@ public class JpaConsultationMetricsRepository implements ConsultationMetricsRepo
                 ss.status = 'COMPLETED'
                 and ss.ended_at >= :periodStart
                 and ss.ended_at < :periodEnd
-              ) as handled_today,
+              ) as completed_today,
               exists (
                 select 1
                 from runtime.chat_message llm_message
@@ -88,7 +102,10 @@ public class JpaConsultationMetricsRepository implements ConsultationMetricsRepo
                 from runtime.chat_message human_message
                 where human_message.chat_session_id = ss.id
                   and human_message.sender_role in ('COUNSELOR', 'AGENT')
-              ) as has_human_message
+              ) as has_human_message,
+              ss.status,
+              ss.started_at,
+              ss.meta_json
             from scoped_sessions ss
             left join first_customer fc on fc.session_id = ss.id
             """);
@@ -99,19 +116,70 @@ public class JpaConsultationMetricsRepository implements ConsultationMetricsRepo
 
     @SuppressWarnings("unchecked")
     List<Object[]> rows = query.getResultList();
-    return rows.stream().map(this::toSessionFact).toList();
+    return rows.stream()
+        .map(row -> toSessionFact(row, periodStart, periodEnd))
+        .filter(Objects::nonNull)
+        .toList();
   }
 
-  private ConsultationMetricsSessionFact toSessionFact(Object[] row) {
+  private ConsultationMetricsSessionFact toSessionFact(
+      Object[] row, OffsetDateTime periodStart, OffsetDateTime periodEnd) {
+    boolean handledToday =
+        toBoolean(row[5]) || isResolvedToday(row[8], row[10], periodStart, periodEnd);
+    if (!isInPeriod(toOffsetDateTime(row[9]), periodStart, periodEnd) && !handledToday) {
+      return null;
+    }
     return new ConsultationMetricsSessionFact(
         toLong(row[0]),
         toOffsetDateTime(row[1]),
         toOffsetDateTime(row[2]),
         toOffsetDateTime(row[3]),
         toOffsetDateTime(row[4]),
-        toBoolean(row[5]),
+        handledToday,
         toBoolean(row[6]),
         toBoolean(row[7]));
+  }
+
+  private boolean isResolvedToday(
+      Object statusValue,
+      Object metaJsonValue,
+      OffsetDateTime periodStart,
+      OffsetDateTime periodEnd) {
+    if (!"RESOLVED".equals(String.valueOf(statusValue))) {
+      return false;
+    }
+    String metaJson = toJsonText(metaJsonValue);
+    if (metaJson == null || metaJson.isBlank()) {
+      return false;
+    }
+    try {
+      JsonNode meta = OBJECT_MAPPER.readTree(metaJson);
+      if (meta.isTextual()) {
+        meta = OBJECT_MAPPER.readTree(meta.asText());
+      }
+      String resolvedAtValue = meta.path("resolution").path("resolvedAt").asText(null);
+      if (resolvedAtValue == null || resolvedAtValue.isBlank()) {
+        return false;
+      }
+      return isInPeriod(OffsetDateTime.parse(resolvedAtValue), periodStart, periodEnd);
+    } catch (JsonProcessingException | DateTimeParseException e) {
+      return false;
+    }
+  }
+
+  private boolean isInPeriod(
+      OffsetDateTime value, OffsetDateTime periodStart, OffsetDateTime periodEnd) {
+    return value != null && !value.isBefore(periodStart) && value.isBefore(periodEnd);
+  }
+
+  private String toJsonText(Object value) {
+    if (value == null) {
+      return null;
+    }
+    if (value instanceof byte[] bytes) {
+      return new String(bytes, StandardCharsets.UTF_8);
+    }
+    return String.valueOf(value);
   }
 
   private Long toLong(Object value) {

--- a/backend/src/test/java/com/init/workflowruntime/infrastructure/persistence/JpaConsultationMetricsRepositoryTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/infrastructure/persistence/JpaConsultationMetricsRepositoryTest.java
@@ -66,6 +66,18 @@ class JpaConsultationMetricsRepositoryTest {
     persistMessage(oldHumanCompletedSessionId, 1, "USER", at("2026-05-26T15:00:00+09:00"));
     persistMessage(oldHumanCompletedSessionId, 2, "COUNSELOR", at("2026-05-26T15:02:00+09:00"));
 
+    Long resolvedTodaySessionId =
+        persistResolvedSession(
+            workspaceId, at("2026-05-26T16:00:00+09:00"), at("2026-05-27T13:00:00+09:00"));
+    persistMessage(resolvedTodaySessionId, 1, "CUSTOMER", at("2026-05-26T16:00:00+09:00"));
+    persistMessage(resolvedTodaySessionId, 2, "AGENT", at("2026-05-26T16:01:00+09:00"));
+
+    Long oldResolvedSessionId =
+        persistResolvedSession(
+            workspaceId, at("2026-05-26T17:00:00+09:00"), at("2026-05-26T18:00:00+09:00"));
+    persistMessage(oldResolvedSessionId, 1, "CUSTOMER", at("2026-05-26T17:00:00+09:00"));
+    persistMessage(oldResolvedSessionId, 2, "AGENT", at("2026-05-26T17:01:00+09:00"));
+
     persistSession(workspaceId, ChatSessionStatus.OPEN, at("2026-05-26T16:00:00+09:00"), null);
 
     List<ConsultationMetricsSessionFact> facts =
@@ -76,7 +88,8 @@ class JpaConsultationMetricsRepositoryTest {
                 Collectors.toMap(ConsultationMetricsSessionFact::sessionId, Function.identity()));
 
     assertThat(bySessionId)
-        .containsOnlyKeys(llmOnlySessionId, mixedSessionId, oldHumanCompletedSessionId);
+        .containsOnlyKeys(
+            llmOnlySessionId, mixedSessionId, oldHumanCompletedSessionId, resolvedTodaySessionId);
     assertThat(
             Duration.between(
                     bySessionId.get(llmOnlySessionId).firstCustomerAt(),
@@ -112,6 +125,11 @@ class JpaConsultationMetricsRepositoryTest {
     assertThat(bySessionId.get(oldHumanCompletedSessionId).firstCustomerAt()).isNull();
     assertThat(bySessionId.get(oldHumanCompletedSessionId).handledToday()).isTrue();
     assertThat(bySessionId.get(oldHumanCompletedSessionId).hasHumanMessage()).isTrue();
+
+    assertThat(bySessionId.get(resolvedTodaySessionId).firstCustomerAt()).isNull();
+    assertThat(bySessionId.get(resolvedTodaySessionId).handledToday()).isTrue();
+    assertThat(bySessionId.get(resolvedTodaySessionId).hasHumanMessage()).isTrue();
+    assertThat(bySessionId).doesNotContainKey(oldResolvedSessionId);
   }
 
   private Long persistWorkspaceAndVersion() {
@@ -143,6 +161,25 @@ class JpaConsultationMetricsRepositoryTest {
       ChatSessionStatus status,
       OffsetDateTime startedAt,
       OffsetDateTime endedAt) {
+    return persistSession(workspaceId, status, startedAt, endedAt, "{}");
+  }
+
+  private Long persistResolvedSession(
+      Long workspaceId, OffsetDateTime startedAt, OffsetDateTime resolvedAt) {
+    String metaJson =
+        """
+        {"resolution":{"outcome":"RESOLVED","label":"해결됨","status":"RESOLVED","resolvedAt":"%s"}}
+        """
+            .formatted(resolvedAt);
+    return persistSession(workspaceId, ChatSessionStatus.RESOLVED, startedAt, null, metaJson);
+  }
+
+  private Long persistSession(
+      Long workspaceId,
+      ChatSessionStatus status,
+      OffsetDateTime startedAt,
+      OffsetDateTime endedAt,
+      String metaJson) {
     Long sessionId =
         ((Number)
                 entityManager
@@ -154,11 +191,12 @@ class JpaConsultationMetricsRepositoryTest {
             """
             insert into runtime.chat_session
               (id, workspace_id, domain_pack_version_id, status, channel, meta_json, response_mode, started_at, ended_at)
-            values (:id, :workspaceId, 20, :status, 'WEB', '{}', 'AI_ACTIVE', :startedAt, :endedAt)
+            values (:id, :workspaceId, 20, :status, 'WEB', cast(:metaJson as jsonb), 'AI_ACTIVE', :startedAt, :endedAt)
             """);
     query.setParameter("id", sessionId);
     query.setParameter("workspaceId", workspaceId);
     query.setParameter("status", status.name());
+    query.setParameter("metaJson", metaJson);
     query.setParameter("startedAt", startedAt);
     query.setParameter("endedAt", endedAt);
     query.executeUpdate();

--- a/frontend/src/pages/consultation/ui/ConsultationPage.generated-api.test.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.generated-api.test.tsx
@@ -171,6 +171,12 @@ describe("ConsultationPage generated API integration", () => {
         followUpRequired: true,
       });
     });
+    await waitFor(() => {
+      const metricsCalls = mocks.customFetch.mock.calls.filter(
+        ([url]) => url === "/api/v1/workspaces/2/consultation/metrics",
+      );
+      expect(metricsCalls).toHaveLength(2);
+    });
     expect(mocks.toastSuccess).toHaveBeenCalledWith("상담이 종료되었습니다.");
   });
 });

--- a/frontend/src/pages/consultation/ui/ConsultationPage.test.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.test.tsx
@@ -1544,6 +1544,9 @@ describe("ConsultationPage", () => {
         followUpRequired: false,
       });
     });
+    await waitFor(() => {
+      expect(consultationApi.getMetrics).toHaveBeenCalledTimes(2);
+    });
 
     await waitFor(() => {
       expect(screen.queryByText("상담 종료")).not.toBeInTheDocument();

--- a/frontend/src/pages/consultation/ui/ConsultationPage.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.tsx
@@ -653,6 +653,7 @@ export const ConsultationPage: React.FC = () => {
   const tempCounterRef = useRef(0);
   const activeCustomerIdRef = useRef<string | null>(null);
   const metricsErrorToastShownRef = useRef(false);
+  const metricsRequestIdRef = useRef(0);
   const queueErrorToastShownRef = useRef(false);
   const currentCounselorId = getAuthUser()?.id ?? null;
 
@@ -832,27 +833,32 @@ export const ConsultationPage: React.FC = () => {
     };
   }, [setCrumbs]);
 
-  useEffect(() => {
-    if (!workspaceId) {
-      setMetrics(null);
+  const loadMetrics = useCallback(
+    async (options: { resetErrorToast?: boolean } = {}) => {
+      if (!workspaceId) {
+        metricsRequestIdRef.current += 1;
+        setMetrics(null);
+        setMetricsError(null);
+        setIsMetricsLoading(false);
+        return null;
+      }
+
+      const requestId = metricsRequestIdRef.current + 1;
+      metricsRequestIdRef.current = requestId;
+      if (options.resetErrorToast) {
+        metricsErrorToastShownRef.current = false;
+      }
+      setIsMetricsLoading(true);
       setMetricsError(null);
-      setIsMetricsLoading(false);
-      return;
-    }
 
-    let cancelled = false;
-    metricsErrorToastShownRef.current = false;
-    setIsMetricsLoading(true);
-    setMetricsError(null);
-
-    const loadMetrics = async () => {
       try {
         const data = await consultationApi.getMetrics(workspaceId);
-        if (cancelled) return;
+        if (metricsRequestIdRef.current !== requestId) return null;
         setMetrics(data);
         setMetricsError(null);
+        return data;
       } catch (error) {
-        if (cancelled) return;
+        if (metricsRequestIdRef.current !== requestId) return null;
         console.error("Failed to load consultation metrics:", error);
         setMetrics(null);
         setMetricsError("상담 지표를 불러오지 못했습니다.");
@@ -860,19 +866,23 @@ export const ConsultationPage: React.FC = () => {
           metricsErrorToastShownRef.current = true;
           toast.error("상담 지표를 불러오지 못했습니다.");
         }
+        return null;
       } finally {
-        if (!cancelled) {
+        if (metricsRequestIdRef.current === requestId) {
           setIsMetricsLoading(false);
         }
       }
-    };
+    },
+    [workspaceId],
+  );
 
-    void loadMetrics();
+  useEffect(() => {
+    void loadMetrics({ resetErrorToast: true });
 
     return () => {
-      cancelled = true;
+      metricsRequestIdRef.current += 1;
     };
-  }, [workspaceId]);
+  }, [loadMetrics]);
 
   const loadQueue = useCallback(
     async (isManualRetry = false) => {
@@ -1453,6 +1463,7 @@ export const ConsultationPage: React.FC = () => {
       });
       toast.success("상담이 종료되었습니다.");
       setQueue((prev) => prev.filter((customer) => customer.id !== endedSessionId));
+      void loadMetrics();
       clearActiveConversation();
       setEndSessionModal({ open: false });
       navigateToConsultationRoot();


### PR DESCRIPTION
## Summary
- 상담 처리 성공 후 상담 화면 상단 metrics를 다시 조회해 `오늘 처리`가 즉시 갱신되도록 했습니다.
- `RESOLVED` 세션도 `meta_json.resolution.resolvedAt` 기준으로 오늘 처리 집계에 포함해 처리 결과 선택지와 backend 기준을 맞췄습니다.
- 이슈 요구사항과 검증 기준을 `.agent/specs/413.md`에 정리했습니다.

## Validation
- `cd frontend && pnpm test -- ConsultationPage.test.tsx ConsultationPage.generated-api.test.tsx`
- `cd frontend && pnpm exec eslint src/pages/consultation/ui/ConsultationPage.tsx src/pages/consultation/ui/ConsultationPage.test.tsx src/pages/consultation/ui/ConsultationPage.generated-api.test.tsx`
- `cd backend && GRADLE_USER_HOME=/tmp/ostone-gradle-413 ./gradlew spotlessCheck test --tests com.init.workflowruntime.infrastructure.persistence.JpaConsultationMetricsRepositoryTest --no-daemon`
- `git diff --check`
- `git diff --cached --check`

## Notes
- `cd frontend && pnpm lint`는 변경 범위 밖의 기존 lint 오류 58개로 실패했습니다. 변경 파일은 targeted eslint를 통과했습니다.

Closes #413