### PR TITLE
fix(consultation): 상담 큐 재연결 구독 유지

### DIFF
--- a/.agent/specs/415.md
+++ b/.agent/specs/415.md
@@ -34,6 +34,7 @@
 | Backend application | `backend/src/main/java/com/init/chatdemo/application/DemoChatSessionRegistrationService.java` | 데모 세션 생성/메시지 append 후 큐 upsert 이벤트 발행 |
 | Frontend page | `frontend/src/pages/consultation/ui/ConsultationPage.tsx` | 연결 복구 시 큐 스냅샷 재조회 및 불안정 상태 표시 |
 | Frontend shared UI | `frontend/src/features/consultation/ui/QueuePanel.tsx` | 큐 동기화 안내 표시 |
+| Frontend shared lib | `frontend/src/shared/lib/websocket/useStomp.ts` | 연결 복구 시 기존 토픽 구독 재등록 |
 
 ## Backend Requirements
 
@@ -49,11 +50,13 @@
 2. 이전 상태가 비연결 상태였고 다시 `CONNECTED`가 되면 `consultationApi.getQueue(workspaceId)`를 호출해 큐 스냅샷을 보정한다.
 3. 재조회 성공 시 기존 큐 load error는 해제되고, 기존 route session 선택/활성 대화 정리 규칙은 유지된다.
 4. 재조회 실패 시 기존 큐 오류 처리와 재시도 UI를 사용한다.
+5. `useStomp`의 custom topic subscribe는 일시적 연결 끊김 중에도 구독 의도를 유지하고, 재연결 `onConnect`에서 다시 active subscription으로 등록한다.
 
 ## Acceptance Criteria
 
 - 큐 이벤트 수신 시 기존처럼 `SESSION_UPSERTED`는 삽입/갱신, `SESSION_REMOVED`는 제거로 처리된다.
 - 웹소켓 연결 오류 또는 끊김 뒤 `CONNECTED`로 복구되면 `getQueue`가 다시 호출된다.
+- 웹소켓 연결 오류 또는 끊김 뒤에도 상담 큐와 활성 채팅 토픽 구독 의도는 유지되고, 재연결 후 다시 구독된다.
 - 연결 불안정 상태에서 상담사는 큐 최신성이 보정 중임을 인지할 수 있다.
 - 상담사 메시지와 내부 메모 전송 후 큐의 마지막 메시지 표시값이 이벤트로 갱신된다.
 - 데모 세션 생성과 데모 메시지 append 후 상담 큐 upsert 이벤트가 발행된다.
@@ -63,6 +66,7 @@
 
 - Backend: 관련 application service 단위 테스트로 큐 이벤트 발행 여부를 검증한다.
 - Frontend: `ConsultationPage` 테스트로 reconnect snapshot refetch와 연결 불안정 안내를 검증한다.
+- Frontend: `useStomp` 테스트로 연결 전 등록한 custom subscribe와 재연결 시 재구독을 검증한다.
 - Frontend: 기존 큐 upsert/remove/unread 테스트가 계속 통과해야 한다.
 - Regression: backend/frontend의 관련 테스트를 실행한다.
 

--- a/frontend/src/pages/consultation/ui/ConsultationPage.test.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.test.tsx
@@ -1971,6 +1971,20 @@ describe("ConsultationPage", () => {
     ).toBeInTheDocument();
   });
 
+  it("registers queue subscription intent while initially disconnected", async () => {
+    stompState.connectionStatus = "DISCONNECTED";
+
+    render(<ConsultationPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("김민지")).toBeInTheDocument();
+    });
+    expect(mockSubscribe).toHaveBeenCalledWith(
+      "/topic/workspaces.2.consultation.queue",
+      expect.any(Function),
+    );
+  });
+
   it("refetches the queue snapshot after websocket reconnect", async () => {
     stompState.connectionStatus = "DISCONNECTED";
     const { rerender } = render(<ConsultationPage />, { wrapper: Wrapper });

--- a/frontend/src/pages/consultation/ui/ConsultationPage.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.tsx
@@ -1069,7 +1069,7 @@ export const ConsultationPage: React.FC = () => {
   ]);
 
   useEffect(() => {
-    if (connectionStatus !== "CONNECTED" || !workspaceId) return;
+    if (!workspaceId) return;
 
     const unsubscribe = subscribe(
       `/topic/workspaces.${workspaceId}.consultation.queue`,
@@ -1079,7 +1079,7 @@ export const ConsultationPage: React.FC = () => {
     return () => {
       unsubscribe();
     };
-  }, [connectionStatus, handleQueueEvent, subscribe, workspaceId]);
+  }, [handleQueueEvent, subscribe, workspaceId]);
 
   useEffect(() => {
     if (!activeCustomerId) {
@@ -1196,7 +1196,7 @@ export const ConsultationPage: React.FC = () => {
   }, [activeCustomerId, messagePagination, messagesCustomerId]);
 
   useEffect(() => {
-    if (connectionStatus !== "CONNECTED" || !activeCustomerId) return;
+    if (!activeCustomerId) return;
 
     const topic = `/topic/chat.${activeCustomerId}`;
     const unsubscribe = subscribe(topic, (raw) => {
@@ -1233,7 +1233,7 @@ export const ConsultationPage: React.FC = () => {
         workflowRefetchTimerRef.current = null;
       }
     };
-  }, [connectionStatus, activeCustomerId, subscribe, scheduleMatchedWorkflowRefresh]);
+  }, [activeCustomerId, subscribe, scheduleMatchedWorkflowRefresh]);
 
   const registerPendingMessage = useCallback(
     (message: Omit<PendingMessage, "timeoutId">) => {

--- a/frontend/src/shared/lib/websocket/useStomp.test.tsx
+++ b/frontend/src/shared/lib/websocket/useStomp.test.tsx
@@ -159,7 +159,7 @@ describe("useStomp", () => {
     expect(subscription.unsubscribe).toHaveBeenCalledTimes(1);
   });
 
-  it("연결되지 않은 상태에서 subscribe를 호출하면 빈 함수를 반환한다", async () => {
+  it("연결되지 않은 상태에서 subscribe를 호출하면 활성 구독 없이 cleanup 함수를 반환한다", async () => {
     const { result } = await renderUseStompHelper();
 
     let unsubscribeFn: (() => void) | undefined;
@@ -173,6 +173,49 @@ describe("useStomp", () => {
       unsubscribeFn?.();
     });
     expect(subscription.unsubscribe).not.toHaveBeenCalled();
+  });
+
+  it("연결 전 등록한 custom subscribe를 onConnect 시 구독한다", async () => {
+    const { result } = await renderUseStompHelper();
+    const topicCallback = vi.fn();
+
+    act(() => {
+      result.current.subscribe("/topic/test", topicCallback);
+    });
+
+    expect(client.subscribe).not.toHaveBeenCalledWith("/topic/test", expect.any(Function));
+
+    act(() => {
+      client.connected = true;
+      client.onConnect?.(dummyFrame);
+    });
+
+    expect(client.subscribe).toHaveBeenCalledWith("/topic/test", expect.any(Function));
+  });
+
+  it("재연결 onConnect 시 custom subscribe를 다시 등록한다", async () => {
+    const { result } = await renderUseStompHelper();
+
+    act(() => {
+      client.connected = true;
+      client.onConnect?.(dummyFrame);
+    });
+    act(() => {
+      result.current.subscribe("/topic/test", vi.fn());
+    });
+    client.subscribe.mockClear();
+
+    act(() => {
+      client.connected = false;
+      client.onDisconnect?.(dummyFrame);
+    });
+    act(() => {
+      client.connected = true;
+      client.onConnect?.(dummyFrame);
+    });
+
+    expect(client.subscribe).toHaveBeenCalledWith("/user/queue/errors", expect.any(Function));
+    expect(client.subscribe).toHaveBeenCalledWith("/topic/test", expect.any(Function));
   });
 
   it("이미 동일 토픽을 subscribe 중일 때 재호출하면 이전 구독을 해제하고 덮어쓴다", async () => {

--- a/frontend/src/shared/lib/websocket/useStomp.ts
+++ b/frontend/src/shared/lib/websocket/useStomp.ts
@@ -20,10 +20,19 @@ export interface UseStompOptions {
   onServerError?: (error: unknown) => void;
 }
 
+const parseMessageBody = (body: string): unknown | null => {
+  try {
+    return JSON.parse(body) as unknown;
+  } catch {
+    return null;
+  }
+};
+
 export function useStomp(options: UseStompOptions = {}): UseStompResult {
   const clientRef = useRef<Client | null>(null);
   const errorSubscriptionRef = useRef<StompSubscription | null>(null);
-  const customSubscriptionsRef = useRef<Map<string, StompSubscription>>(new Map());
+  const desiredSubscriptionsRef = useRef<Map<string, (msg: unknown) => void>>(new Map());
+  const activeSubscriptionsRef = useRef<Map<string, StompSubscription>>(new Map());
   const connectionStatusRef = useRef<ConnectionStatus>("DISCONNECTED");
   const onServerErrorRef = useRef<UseStompOptions["onServerError"]>(options.onServerError);
   const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>("DISCONNECTED");
@@ -36,16 +45,35 @@ export function useStomp(options: UseStompOptions = {}): UseStompResult {
     onServerErrorRef.current = options.onServerError;
   }, [options.onServerError]);
 
+  const unsubscribeActiveSubscriptions = useCallback(() => {
+    activeSubscriptionsRef.current.forEach((sub) => sub.unsubscribe());
+    activeSubscriptionsRef.current.clear();
+  }, []);
+
+  const subscribeActiveTopic = useCallback(
+    (client: Client, topic: string, cb: (msg: unknown) => void) => {
+      const subscription = client.subscribe(topic, (message) => {
+        const parsed = parseMessageBody(message.body);
+        if (parsed !== null) {
+          cb(parsed);
+        }
+      });
+      activeSubscriptionsRef.current.get(topic)?.unsubscribe();
+      activeSubscriptionsRef.current.set(topic, subscription);
+    },
+    [],
+  );
+
   const disconnect = useCallback(() => {
     errorSubscriptionRef.current?.unsubscribe();
     errorSubscriptionRef.current = null;
-    customSubscriptionsRef.current.forEach((sub) => sub.unsubscribe());
-    customSubscriptionsRef.current.clear();
+    unsubscribeActiveSubscriptions();
+    desiredSubscriptionsRef.current.clear();
     clientRef.current?.deactivate();
     clientRef.current = null;
     connectionStatusRef.current = "DISCONNECTED";
     setConnectionStatus("DISCONNECTED");
-  }, []);
+  }, [unsubscribeActiveSubscriptions]);
 
   const connect = useCallback(() => {
     if (
@@ -65,37 +93,49 @@ export function useStomp(options: UseStompOptions = {}): UseStompResult {
       if (clientRef.current !== client) return;
       connectionStatusRef.current = "CONNECTED";
       setConnectionStatus("CONNECTED");
+      errorSubscriptionRef.current?.unsubscribe();
       errorSubscriptionRef.current = client.subscribe(ERROR_QUEUE, (message) => {
-        try {
-          const error = JSON.parse(message.body) as unknown;
+        const error = parseMessageBody(message.body);
+        if (error !== null) {
           console.error("WebSocket server error:", error);
           onServerErrorRef.current?.(error);
-        } catch {
-          // ignore malformed error frames
         }
+      });
+      unsubscribeActiveSubscriptions();
+      desiredSubscriptionsRef.current.forEach((cb, topic) => {
+        subscribeActiveTopic(client, topic, cb);
       });
     };
 
     client.onDisconnect = () => {
       if (clientRef.current !== client) return;
+      errorSubscriptionRef.current?.unsubscribe();
+      errorSubscriptionRef.current = null;
+      unsubscribeActiveSubscriptions();
       connectionStatusRef.current = "DISCONNECTED";
       setConnectionStatus("DISCONNECTED");
     };
 
     client.onStompError = () => {
       if (clientRef.current !== client) return;
+      errorSubscriptionRef.current?.unsubscribe();
+      errorSubscriptionRef.current = null;
+      unsubscribeActiveSubscriptions();
       connectionStatusRef.current = "ERROR";
       setConnectionStatus("ERROR");
     };
 
     client.onWebSocketError = () => {
       if (clientRef.current !== client) return;
+      errorSubscriptionRef.current?.unsubscribe();
+      errorSubscriptionRef.current = null;
+      unsubscribeActiveSubscriptions();
       connectionStatusRef.current = "ERROR";
       setConnectionStatus("ERROR");
     };
 
     client.activate();
-  }, []);
+  }, [subscribeActiveTopic, unsubscribeActiveSubscriptions]);
 
   const sendMessage = useCallback((message: unknown) => {
     const client = clientRef.current;
@@ -108,30 +148,20 @@ export function useStomp(options: UseStompOptions = {}): UseStompResult {
   }, []);
 
   const subscribe = useCallback((topic: string, cb: (msg: unknown) => void): (() => void) => {
+    desiredSubscriptionsRef.current.set(topic, cb);
     const client = clientRef.current;
-    if (!client?.connected) {
-      return () => {};
+    if (client?.connected) {
+      subscribeActiveTopic(client, topic, cb);
     }
 
-    const subscription = client.subscribe(topic, (message) => {
-      try {
-        cb(JSON.parse(message.body) as unknown);
-      } catch {
-        // Skip malformed messages
-      }
-    });
-    const prev = customSubscriptionsRef.current.get(topic);
-    prev?.unsubscribe();
-    customSubscriptionsRef.current.set(topic, subscription);
-
     return () => {
-      subscription.unsubscribe();
-      const current = customSubscriptionsRef.current.get(topic);
-      if (current === subscription) {
-        customSubscriptionsRef.current.delete(topic);
+      if (desiredSubscriptionsRef.current.get(topic) === cb) {
+        desiredSubscriptionsRef.current.delete(topic);
+        activeSubscriptionsRef.current.get(topic)?.unsubscribe();
+        activeSubscriptionsRef.current.delete(topic);
       }
     };
-  }, []);
+  }, [subscribeActiveTopic]);
 
   const sendTo = useCallback((destination: string, body: unknown) => {
     const client = clientRef.current;


### PR DESCRIPTION
## Summary
- STOMP custom topic subscribe가 연결 끊김 중에도 구독 의도를 유지하고, 재연결 onConnect에서 기존 토픽을 다시 구독하도록 했습니다.
- 상담 큐와 활성 채팅 토픽 구독을 connectionStatus 변화로 해제하지 않도록 해 재연결 시 큐/채팅 이벤트 수신을 유지합니다.
- 이슈 415 스펙에 재연결 구독 유지 요구사항과 검증 기준을 보강했습니다.

## Validation
- `cd frontend && pnpm test -- ConsultationPage.test.tsx useStomp.test.tsx`
- `cd frontend && pnpm exec eslint src/pages/consultation/ui/ConsultationPage.tsx src/pages/consultation/ui/ConsultationPage.test.tsx src/shared/lib/websocket/useStomp.ts src/shared/lib/websocket/useStomp.test.tsx`
- `git diff --check`

## Notes
- `cd frontend && pnpm lint`는 이 변경 범위 밖의 기존 lint 오류 57건으로 실패합니다.

Closes #415