### PR TITLE
fix(infra): ECS autoscaling과 RDS 파라미터 적용 오류 해결

### DIFF
--- a/infra/terraform/ecs-cluster.tf
+++ b/infra/terraform/ecs-cluster.tf
@@ -239,7 +239,7 @@ resource "aws_ecs_service" "backend" {
 
 resource "aws_appautoscaling_target" "backend" {
   service_namespace  = "ecs"
-  resource_id        = "service/${local.name_prefix}-cluster/ostone-backend"
+  resource_id        = "service/${aws_ecs_cluster.main.name}/${aws_ecs_service.backend.name}"
   scalable_dimension = "ecs:service:DesiredCount"
   min_capacity       = var.backend_autoscaling_min_capacity
   max_capacity       = var.backend_autoscaling_max_capacity
@@ -249,8 +249,8 @@ resource "aws_appautoscaling_policy" "backend_cpu" {
   name               = "${local.name_prefix}-backend-cpu-scaling"
   policy_type        = "TargetTrackingScaling"
   service_namespace  = "ecs"
-  resource_id        = "service/${local.name_prefix}-cluster/ostone-backend"
-  scalable_dimension = "ecs:service:DesiredCount"
+  resource_id        = aws_appautoscaling_target.backend.resource_id
+  scalable_dimension = aws_appautoscaling_target.backend.scalable_dimension
 
   target_tracking_scaling_policy_configuration {
     target_value       = 70

--- a/infra/terraform/rds.tf
+++ b/infra/terraform/rds.tf
@@ -12,8 +12,9 @@ resource "aws_db_parameter_group" "postgres" {
   family = "postgres16"
 
   parameter {
-    name  = "max_connections"
-    value = "200"
+    name         = "max_connections"
+    value        = "200"
+    apply_method = "pending-reboot"
   }
 
   parameter {


### PR DESCRIPTION
## 변경 내용
- ECS backend autoscaling target이 실제 ECS cluster/service 리소스를 참조하도록 변경했습니다.
- RDS PostgreSQL `max_connections` static parameter를 `pending-reboot` 적용 방식으로 지정했습니다.

## 배경
Terraform apply 중 ECS 서비스 생성 전 autoscaling target 등록이 시도되거나, static RDS parameter를 immediate 방식으로 적용하면서 production 인프라 배포가 실패할 수 있었습니다.

## 확인
- `terraform -chdir=infra/terraform fmt -check`
- `terraform -chdir=infra/terraform validate`
- `git diff --check`