### PR TITLE
docs: 데모 채팅 AI 이관 가드 스펙 추가

### DIFF
--- a/.agent/specs/0353.md
+++ b/.agent/specs/0353.md
@@ -1,0 +1,244 @@
+# 0353: 데모 채팅 상담사 배정 후 봇 타이핑 상태 정리
+
+> **Issue**: #0353
+> **Bounded Context**: `chat-demo` Frontend
+> **Template**: `_TEMPLATE_FE.md` 기반
+> **Branch**: `fix/0353-chat-demo-bot-typing-after-assignment`
+> **Canonical Number**: `0353`
+> **Type**: Frontend FSD
+> **작성일**: 2026-06-01
+
+---
+
+## Goal
+
+상담사 배정 이후 Backend가 데모 채팅 봇 자동응답을 생성하지 않을 때, 고객 채팅 화면이 봇 타이핑 상태를 남기지 않고 사용자 메시지만 자연스럽게 반영하도록 한다.
+
+---
+
+## Background
+
+데모 채팅 화면은 `frontend/src/pages/user-chat/ui/UserChatPage.tsx`에서 메시지 전송 시 `startBotTypingDelay()`를 먼저 실행하고, `sendDemoChatMessage()` 응답 또는 WebSocket 메시지를 통해 봇 응답을 병합한다.
+
+Backend 이슈 #0354에서 상담사 배정 이후 `DemoChatSessionRegistrationService.appendMessage()`가 사용자 메시지만 저장하고 `ASSISTANT` 메시지를 생성하지 않도록 바뀌면, 프론트는 응답 목록에 봇 메시지가 없는 정상 케이스를 처리해야 한다. 그렇지 않으면 화면에 봇 입력 중 표시가 남거나, 고객이 응답 생성 실패로 오해할 수 있다.
+
+---
+
+## Scope
+
+### In Scope
+
+- 데모 채팅 메시지 전송 응답에 `BOT`/`ASSISTANT` 메시지가 없을 때 봇 타이핑 상태를 종료한다.
+- 사용자 메시지 1개만 반환되는 응답을 성공으로 처리한다.
+- WebSocket으로 뒤늦게 상담사 메시지 또는 시스템 메시지가 들어와도 기존 병합 흐름을 유지한다.
+- 기존 로컬 optimistic USER 메시지 치환 동작을 유지한다.
+
+### Out of Scope
+
+- 상담사 화면의 응대 모드 UI 변경
+- 데모 채팅 입력창 비활성화 또는 상담사 배정 배너 추가
+- Backend 자동응답 차단 로직 구현
+- WebSocket 프로토콜 또는 endpoint 변경
+
+---
+
+## Existing Context
+
+아래 경로는 현재 repository에서 존재 확인 완료했다.
+
+| Existing file | 현재 역할 | 변경 기준 |
+| --- | --- | --- |
+| `frontend/DESIGN.md` | 프론트 디자인 가이드 | 기존 채팅 UI의 monochrome/focus/spacing 기준 유지 |
+| `frontend/src/pages/user-chat/ui/UserChatPage.tsx` | 데모 고객 채팅 페이지, 세션 시작/전송/동기화/타이핑 상태 관리 | 봇 메시지 없는 성공 응답에서 타이핑 상태 종료 |
+| `frontend/src/pages/user-chat/ui/UserChatPage.test.tsx` | 고객 채팅 페이지 동작 테스트 | 사용자 메시지만 반환되는 성공 케이스 추가 |
+| `frontend/src/entities/chat/api/chatApi.ts` | 데모 채팅 REST 호출 wrapper | `sendDemoChatMessage()` 응답 shape 유지 |
+| `frontend/src/entities/chat/lib/chatMessageSync.ts` | backend 메시지 sender role 변환 및 merge 유틸 | sender type 판별 기준 확인 |
+| `frontend/src/features/user-chat/ui/MessageList.tsx` | 메시지 목록과 bot typing indicator 렌더링 | 기존 표시 정책 유지 |
+
+---
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A["고객이 데모 채팅 메시지 입력"] --> B["로컬 USER 메시지 optimistic 추가"]
+    B --> C["봇 타이핑 표시 시작"]
+    C --> D["POST demo chat message"]
+    D --> E{"응답에 봇 메시지 포함?"}
+    E -->|"Yes"| F["최소 타이핑 지연 후 BOT 메시지 표시"]
+    E -->|"No"| G["USER 메시지만 병합하고 봇 타이핑 종료"]
+    D --> H{"요청 실패?"}
+    H -->|"Yes"| I["로컬 USER 메시지 제거 + 오류 표시"]
+    F --> J["채팅 유지"]
+    G --> J
+    I --> J
+```
+
+---
+
+## Design Diff
+
+| 영역 | As-is | To-be | 변경 내용 |
+| --- | --- | --- | --- |
+| 전송 직후 상태 | 모든 전송에서 봇 타이핑 표시 시작 | 기존과 동일 | 사용자에게 즉시 반응 유지 |
+| 응답 처리 | 봇 메시지 수신을 전제로 타이핑 종료 | 봇 메시지가 없으면 즉시 타이핑 종료 | 상담사 배정 이후 정상 흐름 처리 |
+| 오류 표시 | 요청 실패 시 오류 문구 표시 | 동일 | 사용자 메시지만 반환되는 성공을 오류로 보지 않음 |
+| 메시지 병합 | USER/BOT 응답 모두 병합 | USER-only 응답도 성공 병합 | optimistic USER 메시지 중복 방지 |
+
+---
+
+## Component Tree
+
+```text
+UserChatPage
+├─ ChatEntryScreen
+└─ ChatConversationScreen
+   ├─ ChatHeader
+   ├─ MessageList
+   │  └─ botTyping indicator
+   └─ MessageInput
+```
+
+---
+
+## API Integration
+
+### Existing Endpoint
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `POST` | `/api/v1/workspaces/{workspaceId}/demo/chat-sessions/{sessionId}/messages` | 데모 고객 메시지 전송 |
+
+### Response Cases
+
+#### AI 자동응답 허용
+
+```json
+[
+  {
+    "id": 10,
+    "seqNo": 2,
+    "senderRole": "USER",
+    "messageType": "TEXT",
+    "content": "환불 문의입니다",
+    "createdAt": "2026-06-01T10:00:00Z"
+  },
+  {
+    "id": 11,
+    "seqNo": 3,
+    "senderRole": "ASSISTANT",
+    "messageType": "TEXT",
+    "content": "환불 정책을 확인해드릴게요.",
+    "createdAt": "2026-06-01T10:00:01Z"
+  }
+]
+```
+
+#### 상담사 배정 또는 AI 보조 모드
+
+```json
+[
+  {
+    "id": 10,
+    "seqNo": 2,
+    "senderRole": "USER",
+    "messageType": "TEXT",
+    "content": "아직 답변 없나요?",
+    "createdAt": "2026-06-01T10:00:00Z"
+  }
+]
+```
+
+프론트는 두 응답 모두 성공으로 처리한다. 응답 배열에 `ASSISTANT` 또는 `BOT`으로 변환되는 메시지가 없으면 봇 타이핑 상태를 종료한다.
+
+---
+
+## Data Flow
+
+```text
+MessageInput submit
+  -> UserChatPage.handleSendMessage()
+      -> createLocalUserMessage()
+      -> startBotTypingDelay()
+      -> sendDemoChatMessage()
+          -> ChatMessage[]
+      -> hasBotLikeMessage(response)?
+          -> yes: existing realtime/queued bot rendering
+          -> no: clear pending bot messages + setBotTyping(false)
+```
+
+---
+
+## 수정 대상 파일
+
+| 파일 | 변경 유형 | 설명 |
+| --- | --- | --- |
+| `.agent/specs/0353.md` | new | FE 변경 의도와 검증 기준 문서화 |
+| `frontend/src/pages/user-chat/ui/UserChatPage.tsx` | modify | `sendDemoChatMessage()` 성공 응답에 봇 메시지가 없을 때 타이핑 상태 종료 |
+| `frontend/src/pages/user-chat/ui/UserChatPage.test.tsx` | modify | USER-only 응답을 성공 처리하고 bot typing indicator가 사라지는지 검증 |
+
+---
+
+## State Management
+
+새 전역 상태는 추가하지 않는다. `UserChatPage`의 기존 local state와 refs를 유지한다.
+
+| State/Ref | 역할 | 변경 기준 |
+| --- | --- | --- |
+| `isBotTyping` | `MessageList`의 bot typing indicator 제어 | USER-only 성공 응답 시 `false` |
+| `pendingBotMessagesRef` | 최소 타이핑 지연 중 받은 봇 메시지 큐 | USER-only 성공 응답 시 비움 |
+| `botTypingTimeoutRef` | 지연 표시 timeout | USER-only 성공 응답 시 clear |
+| `chatState.session.messages` | 화면 메시지 목록 | USER-only 응답도 persisted/realtime merge 흐름으로 정리 |
+
+---
+
+## Tests
+
+### Test Strategy
+
+| 구분 | 방법 | 도구 | 비고 |
+| --- | --- | --- | --- |
+| 컴포넌트 테스트 | 고객 메시지 전송 후 화면 상태 검증 | Vitest + React Testing Library | 응답 shape별 타이핑 상태 확인 |
+| API wrapper 테스트 | 기존 `sendDemoChatMessage()` 변환 유지 확인 | Vitest | 필요 시 USER-only 응답 fixture 추가 |
+
+### Test Scenarios
+
+#### Happy Path
+
+| # | 시나리오 | 사전 조건 | 조작 | 기대 결과 |
+| --- | --- | --- | --- | --- |
+| 1 | AI 자동응답 허용 | `sendDemoChatMessage()`가 USER + ASSISTANT 반환 | 고객 메시지 전송 | 봇 타이핑 후 ASSISTANT 메시지 표시 |
+| 2 | 상담사 배정 후 USER-only 성공 | `sendDemoChatMessage()`가 USER 1개만 반환 | 고객 메시지 전송 | 사용자 메시지는 유지되고 봇 타이핑이 종료됨 |
+| 3 | 연속 전송 | 첫 응답은 USER-only, 다음 응답도 USER-only | 고객 메시지 2회 전송 | 타이핑 indicator가 누적되거나 고착되지 않음 |
+
+#### Error & Edge Cases
+
+| # | 시나리오 | 기대 결과 |
+| --- | --- | --- |
+| 1 | `sendDemoChatMessage()` 실패 | 기존처럼 optimistic USER 메시지 제거, 오류 문구 표시, 타이핑 종료 |
+| 2 | 응답 배열이 비어 있음 | 요청 성공으로 보되 타이핑 종료, 기존 메시지 유지 |
+| 3 | WebSocket으로 상담사 메시지가 도착 | bot typing과 무관하게 메시지 목록에 병합 |
+
+---
+
+## Acceptance Criteria
+
+- 상담사 배정 이후 데모 고객이 메시지를 보내도 화면에 봇 타이핑 표시가 남지 않는다.
+- Backend가 USER 메시지만 반환하는 응답을 실패로 취급하지 않는다.
+- 기존 AI 자동응답이 허용된 데모 채팅에서는 봇 타이핑 지연과 ASSISTANT 메시지 표시가 유지된다.
+- 로컬 optimistic USER 메시지와 서버 USER 메시지가 중복 표시되지 않는다.
+- `frontend/DESIGN.md`의 기존 채팅 UI 스타일 기준을 변경하지 않는다.
+
+---
+
+## Non-goals
+
+- 상담사 배정 여부를 프론트가 자체 판단해 메시지 전송을 막지 않는다.
+- AI 응대 모드 전환 API를 고객 채팅 화면에 추가하지 않는다.
+- 데모 채팅 REST endpoint의 응답 계약을 새 envelope로 바꾸지 않는다.
+
+---
+
+## Open Questions
+
+- 후속 이슈에서 고객 화면에 “상담사가 응대 중입니다” 같은 상태 문구를 표시할지 결정한다.

--- a/.agent/specs/0354.md
+++ b/.agent/specs/0354.md
@@ -1,0 +1,298 @@
+# 0354: 데모 채팅 상담사 배정 후 봇 자동응답 차단
+
+> **Issue**: #0354
+> **Bounded Context**: `chat-demo` Backend
+> **Template**: `_TEMPLATE_BE.md` 기반
+> **Branch**: `fix/0354-chat-demo-ai-handoff-guard`
+> **Canonical Number**: `0354`
+> **Type**: Backend DDD
+> **작성일**: 2026-06-01
+
+---
+
+## Goal
+
+데모 채팅 세션이 상담사에게 배정되거나 AI 보조 모드로 전환된 이후에는 고객 메시지를 저장하되 봇 자동응답 생성과 `ASSISTANT` 메시지 저장을 차단한다.
+
+---
+
+## Background
+
+일반 WebSocket 기반 고객 채팅 경로는 `ChatSession.responseMode`와 `ChatSession.allowsAiAutoResponse()`를 기준으로 LLM 자동응답을 차단한다. `CounselorService.assignSession()`은 `ChatSession.assignTo()`를 호출하며, 이때 세션은 `HUMAN_ACTIVE`로 전환된다. `LlmResponseHandler`는 LLM 호출 전과 저장 직전에 `allowsAiAutoResponse()`를 확인한다.
+
+반면 데모 채팅 REST 경로는 `DemoChatSessionRegistrationService.appendMessage()`에서 사용자 메시지를 저장한 뒤 `llmAssistantService.generateResponse(...)`를 무조건 호출하고 `ASSISTANT` 메시지를 저장한다. 이 때문에 상담사 배정 이후에도 데모 고객 화면에서 봇 응답이 생성될 수 있다.
+
+---
+
+## Scope
+
+### In Scope
+
+- 데모 채팅 메시지 append 경로에 `ChatSession.allowsAiAutoResponse()` 가드를 추가한다.
+- AI 자동응답이 금지된 세션에서는 USER 메시지만 저장하고 반환한다.
+- AI 자동응답이 금지된 세션에서는 `llmAssistantService.generateResponse(...)`를 호출하지 않는다.
+- 기존 세션 workspace 검증, content 검증, message seqNo 계산 흐름은 유지한다.
+- `HUMAN_ACTIVE`, `AI_ASSIST_ONLY` 모두 자동응답 금지 상태로 처리한다.
+
+### Out of Scope
+
+- 일반 `ChatWebSocketService`/`LlmResponseHandler` 자동응답 흐름 변경
+- 상담사 배정 API 또는 응대 모드 API 변경
+- DB schema 변경
+- 프론트 타이핑 상태 처리
+- 데모 domain pack fixture 변경
+
+---
+
+## Existing Context
+
+아래 경로는 현재 repository에서 존재 확인 완료했다.
+
+| Existing file | 현재 역할 | 변경 기준 |
+| --- | --- | --- |
+| `backend/src/main/java/com/init/chatdemo/application/DemoChatSessionRegistrationService.java` | 데모 채팅 세션 등록과 데모 메시지 append 처리 | `appendMessage()`에 AI 자동응답 가드 추가 |
+| `backend/src/main/java/com/init/chatdemo/presentation/DemoRuntimeController.java` | 데모 채팅 REST controller | endpoint 계약 유지 |
+| `backend/src/main/java/com/init/workflowruntime/domain/ChatSession.java` | 상담 세션 aggregate | `allowsAiAutoResponse()`를 자동응답 허용 기준으로 재사용 |
+| `backend/src/main/java/com/init/workflowruntime/domain/ChatSessionResponseMode.java` | 응대 모드 enum | `AI_ACTIVE`만 자동응답 허용 |
+| `backend/src/main/java/com/init/workflowruntime/application/CounselorService.java` | 상담사 배정/해제/응대 모드 변경 | 배정 시 `HUMAN_ACTIVE` 전환 흐름 유지 |
+| `backend/src/main/java/com/init/workflowruntime/application/LlmResponseHandler.java` | 일반 채팅 LLM 자동응답 handler | 동일한 guard 정책의 참조 구현 |
+| `backend/src/test/java/com/init/chatdemo/application/DemoChatSessionRegistrationServiceTest.java` | 데모 채팅 service 단위 테스트 | USER-only 성공 케이스 추가 |
+| `backend/src/test/java/com/init/chatdemo/presentation/DemoRuntimeControllerTest.java` | 데모 REST controller 테스트 | 필요 시 응답 배열 shape 유지 확인 |
+| `backend/src/test/java/com/init/workflowruntime/domain/ChatSessionTest.java` | 응대 모드 domain rule 테스트 | 기존 `allowsAiAutoResponse()` 기대값 유지 |
+
+---
+
+## Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    actor c as Demo Customer
+    participant ctrl as DemoRuntimeController
+    participant svc as DemoChatSessionRegistrationService
+    participant repo as ChatSessionRepository
+    participant msg as ChatMessageRepository
+    participant llm as LlmAssistantService
+
+    c ->> ctrl: POST /demo/chat-sessions/{sessionId}/messages
+    ctrl ->> svc: appendMessage(workspaceId, sessionId, content)
+    svc ->> repo: findByIdForUpdate(sessionId)
+    repo -->> svc: ChatSession
+    svc ->> svc: validate workspace and content
+    svc ->> msg: findTopByChatSessionIdOrderBySeqNoDesc(sessionId)
+    msg -->> svc: last message
+    svc ->> msg: save(USER message)
+    svc ->> svc: session.allowsAiAutoResponse()
+    alt AI_ACTIVE
+        svc ->> msg: findTop5ByChatSessionIdOrderBySeqNoDesc(sessionId)
+        msg -->> svc: recent messages
+        svc ->> llm: generateResponse(context, content)
+        llm -->> svc: assistant content
+        svc ->> msg: save(ASSISTANT message)
+        svc -->> ctrl: [USER, ASSISTANT]
+    else HUMAN_ACTIVE or AI_ASSIST_ONLY
+        svc -->> ctrl: [USER]
+    end
+    ctrl -->> c: 200 OK
+```
+
+---
+
+## REST API
+
+### Endpoint
+
+기존 endpoint를 유지한다.
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `POST` | `/api/v1/workspaces/{workspaceId}/demo/chat-sessions/{sessionId}/messages` | 데모 고객 메시지 append |
+
+### Request
+
+```json
+{
+  "content": "아직 답변 없나요?"
+}
+```
+
+### Response
+
+#### 200 OK: AI 자동응답 허용
+
+```json
+[
+  {
+    "id": 10,
+    "seqNo": 2,
+    "senderRole": "USER",
+    "messageType": "TEXT",
+    "content": "환불 문의입니다",
+    "createdAt": "2026-06-01T10:00:00Z"
+  },
+  {
+    "id": 11,
+    "seqNo": 3,
+    "senderRole": "ASSISTANT",
+    "messageType": "TEXT",
+    "content": "환불 정책을 확인해드릴게요.",
+    "createdAt": "2026-06-01T10:00:01Z"
+  }
+]
+```
+
+#### 200 OK: 상담사 배정 또는 AI 보조 모드
+
+```json
+[
+  {
+    "id": 10,
+    "seqNo": 2,
+    "senderRole": "USER",
+    "messageType": "TEXT",
+    "content": "아직 답변 없나요?",
+    "createdAt": "2026-06-01T10:00:00Z"
+  }
+]
+```
+
+### Error Responses
+
+기존 오류 정책을 유지한다.
+
+| Status | Code | 조건 |
+| --- | --- | --- |
+| `400` | `VALIDATION_ERROR` | `content`가 blank |
+| `404` | `SESSION_NOT_FOUND` | 세션이 없거나 workspace가 불일치 |
+| `404` | `DOMAIN_PACK_CURRENT_VERSION_NOT_FOUND` | 데모 세션 생성 시 운영 버전 없음 |
+
+---
+
+## Application Rules
+
+- `appendMessage()`는 항상 `findByIdForUpdate(sessionId)`로 세션을 잠근 뒤 처리한다.
+- `workspaceId`가 세션의 workspace와 다르면 기존처럼 `SESSION_NOT_FOUND`로 숨긴다.
+- 세션 상태 검증은 현재 데모 append 흐름을 유지한다. 이번 이슈는 자동응답 생성 여부만 다룬다.
+- USER 메시지는 자동응답 가능 여부와 관계없이 저장한다.
+- `session.allowsAiAutoResponse()`가 `false`이면 아래 작업을 수행하지 않는다.
+  - 최근 대화 context 조회
+  - `llmAssistantService.generateResponse(...)` 호출
+  - `ASSISTANT` 메시지 저장
+- `session.allowsAiAutoResponse()`가 `true`이면 기존처럼 USER와 ASSISTANT 메시지를 모두 반환한다.
+- WebSocket broadcast는 실제 반환된 메시지 목록만 대상으로 한다.
+
+---
+
+## Class Design
+
+```mermaid
+classDiagram
+    class DemoRuntimeController {
+        +appendChatMessage(Long, Long, SendDemoChatMessageRequest): ResponseEntity~List~ChatMessageResponse~~
+    }
+
+    class DemoChatSessionRegistrationService {
+        +appendMessage(Long, Long, String): List~ChatMessageResponse~
+        -createConversationContext(Long): String
+        -broadcastAfterCommit(Long, List~ChatMessageResponse~): void
+    }
+
+    class ChatSession {
+        +allowsAiAutoResponse(): boolean
+        +assignTo(Long): void
+        +switchResponseMode(ChatSessionResponseMode): void
+    }
+
+    class LlmAssistantService {
+        +generateResponse(String, String): String
+    }
+
+    DemoRuntimeController --> DemoChatSessionRegistrationService
+    DemoChatSessionRegistrationService --> ChatSession
+    DemoChatSessionRegistrationService --> LlmAssistantService
+```
+
+### Pseudocode
+
+```java
+ChatMessage userMessage = saveUserMessage(sessionId, nextSeqNo, normalizedContent);
+if (!session.allowsAiAutoResponse()) {
+  List<ChatMessageResponse> responses = List.of(ChatMessageResponse.from(userMessage));
+  broadcastAfterCommit(sessionId, responses);
+  return responses;
+}
+
+String assistantContent =
+    llmAssistantService.generateResponse(createConversationContext(sessionId), normalizedContent);
+ChatMessage assistantMessage = saveAssistantMessage(sessionId, nextSeqNo + 1, assistantContent);
+List<ChatMessageResponse> responses =
+    List.of(ChatMessageResponse.from(userMessage), ChatMessageResponse.from(assistantMessage));
+broadcastAfterCommit(sessionId, responses);
+return responses;
+```
+
+---
+
+## 수정 대상 파일
+
+| 파일 | 변경 유형 | 설명 |
+| --- | --- | --- |
+| `.agent/specs/0354.md` | new | BE 변경 의도와 검증 기준 문서화 |
+| `backend/src/main/java/com/init/chatdemo/application/DemoChatSessionRegistrationService.java` | modify | `appendMessage()`에 `allowsAiAutoResponse()` 기반 guard 추가 |
+| `backend/src/test/java/com/init/chatdemo/application/DemoChatSessionRegistrationServiceTest.java` | modify | HUMAN_ACTIVE/AI_ASSIST_ONLY에서 LLM 미호출 및 USER-only 반환 검증 |
+
+---
+
+## Tests
+
+### Test Strategy
+
+| 구분 | 방법 | 도구 | 비고 |
+| --- | --- | --- | --- |
+| Application unit | service 단위 mock 테스트 | JUnit 5 + Mockito | LLM 호출 여부와 저장 메시지 수 검증 |
+| Domain regression | 기존 ChatSession rule 유지 | JUnit 5 | `allowsAiAutoResponse()` 기준 확인 |
+| Controller contract | 기존 REST response shape 유지 | MockMvc | 필요 시 USER-only response 허용 검증 |
+
+### Test Scenarios
+
+#### Happy Path
+
+| # | 시나리오 | 사전 조건 | 기대 결과 |
+| --- | --- | --- | --- |
+| 1 | AI_ACTIVE 데모 세션 메시지 append | `responseMode=AI_ACTIVE` | USER 저장, LLM 호출, ASSISTANT 저장, 응답 2개 |
+| 2 | 상담사 배정 세션 메시지 append | `assignTo(counselorId)` 호출로 `HUMAN_ACTIVE` | USER 저장, LLM 미호출, ASSISTANT 미저장, 응답 1개 |
+| 3 | AI 보조 모드 세션 메시지 append | 배정 후 `AI_ASSIST_ONLY` | USER 저장, LLM 미호출, ASSISTANT 미저장, 응답 1개 |
+
+#### Error & Edge Cases
+
+| # | 시나리오 | 기대 결과 |
+| --- | --- | --- |
+| 1 | content blank | 기존처럼 `BadRequestException` |
+| 2 | session 없음 | 기존처럼 `NotFoundException` |
+| 3 | workspace mismatch | 기존처럼 `NotFoundException` |
+| 4 | 자동응답 금지 상태에서 broadcast 수행 | USER 메시지만 broadcast 대상 |
+
+---
+
+## Acceptance Criteria
+
+- 상담사에게 배정된 데모 채팅 세션에서는 고객 메시지 이후 `ASSISTANT` 메시지가 새로 저장되지 않는다.
+- `HUMAN_ACTIVE`와 `AI_ASSIST_ONLY` 세션에서는 `llmAssistantService.generateResponse(...)`가 호출되지 않는다.
+- `AI_ACTIVE` 세션의 기존 데모 봇 응답 생성 동작은 유지된다.
+- 자동응답 금지 상태에서도 고객 USER 메시지는 저장되고 REST 응답에 포함된다.
+- WebSocket broadcast는 실제 저장된 USER-only 응답만 전송한다.
+- DB schema나 REST endpoint path는 변경하지 않는다.
+
+---
+
+## Non-goals
+
+- 고객 메시지 전송 자체를 막지 않는다.
+- 상담사 배정 시 기존 대기열/알림 이벤트 정책을 변경하지 않는다.
+- LLM 응답 품질, prompt, workflow-aware 응답 정책을 변경하지 않는다.
+- 데모 fixture 기반 읽기 전용 API의 정적 메시지를 변경하지 않는다.
+
+---
+
+## Open Questions
+
+- 데모 고객 화면에 상담사 배정 상태를 명시적으로 표시할지는 #0353 이후 별도 UX 이슈로 결정한다.


### PR DESCRIPTION
## 요약

- FE 스펙 #0353 추가
  - 상담사 배정 이후 백엔드가 USER-only 응답을 반환할 때 데모 채팅의 봇 타이핑 상태를 정리하는 범위 정의
- BE 스펙 #0354 추가
  - 세션 응대 모드가 `HUMAN_ACTIVE` 또는 `AI_ASSIST_ONLY`일 때 데모 채팅 AI 자동응답 생성을 차단하는 범위 정의

## 참고

- 이 PR은 스펙 문서만 추가합니다.
- 런타임 코드 변경은 포함하지 않습니다.
- 브랜치는 `docs/*`라 spec-check 필수 대상은 아니지만, 후속 FE/BE 수정 작업을 위해 실제 스펙 파일을 추가했습니다.

## 테스트

- 미실행: 문서 변경만 포함

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added specifications for demo chat behavior when counselor is assigned, including message handling and assistant mode interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->