### PR TITLE
fix(consultation): 채팅 응답 순서와 실패 처리 안정화

### DIFF
--- a/backend/src/main/java/com/init/chatdemo/application/DemoChatSessionRegistrationService.java
+++ b/backend/src/main/java/com/init/chatdemo/application/DemoChatSessionRegistrationService.java
@@ -24,6 +24,8 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.ai.retry.NonTransientAiException;
+import org.springframework.ai.retry.TransientAiException;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
@@ -38,6 +40,8 @@ public class DemoChatSessionRegistrationService {
   private static final Logger log =
       LoggerFactory.getLogger(DemoChatSessionRegistrationService.class);
   private static final String DEFAULT_CHANNEL = "WEB";
+  private static final String AI_FALLBACK_MESSAGE =
+      "죄송합니다. 현재 자동 응답 생성이 원활하지 않습니다. 잠시 후 다시 시도해 주세요.";
 
   private final ObjectMapper objectMapper = new ObjectMapper();
   private final DomainPackVersionRepository domainPackVersionRepository;
@@ -120,9 +124,7 @@ public class DemoChatSessionRegistrationService {
             ChatMessage.create(sessionId, nextSeqNo, "USER", "TEXT", normalizedContent));
     chatSessionMetadataService.updateAfterMessage(session, userMessage);
 
-    String assistantContent =
-        llmAssistantService.generateResponse(
-            createConversationContext(sessionId), normalizedContent);
+    String assistantContent = generateAssistantContent(sessionId, normalizedContent);
     ChatMessage assistantMessage =
         chatMessageRepository.save(
             ChatMessage.create(sessionId, nextSeqNo + 1, "ASSISTANT", "TEXT", assistantContent));
@@ -193,6 +195,16 @@ public class DemoChatSessionRegistrationService {
             session.getWorkspaceId(),
             session.getId(),
             ConsultationQueueEventType.SESSION_UPSERTED));
+  }
+
+  private String generateAssistantContent(Long sessionId, String normalizedContent) {
+    try {
+      return llmAssistantService.generateResponse(
+          createConversationContext(sessionId), normalizedContent);
+    } catch (NonTransientAiException | TransientAiException e) {
+      log.warn("Demo chat AI response generation failed. sessionId={}", sessionId, e);
+      return AI_FALLBACK_MESSAGE;
+    }
   }
 
   private void broadcastAfterCommit(Long sessionId, List<ChatMessageResponse> responses) {

--- a/backend/src/test/java/com/init/chatdemo/application/DemoChatSessionRegistrationServiceTest.java
+++ b/backend/src/test/java/com/init/chatdemo/application/DemoChatSessionRegistrationServiceTest.java
@@ -37,6 +37,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.ai.retry.NonTransientAiException;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -147,6 +148,33 @@ class DemoChatSessionRegistrationServiceTest {
         .updateAfterMessage(session, messageCaptor.getAllValues().get(0));
     verifyQueueUpsertEventPublished();
     verify(llmAssistantService).generateResponse("USER: Hello", "Hello");
+    verify(messagingTemplate).convertAndSend("/topic/chat.77", responses.get(0));
+    verify(messagingTemplate).convertAndSend("/topic/chat.77", responses.get(1));
+  }
+
+  @Test
+  @DisplayName("데모 LLM 호출이 실패해도 안내 응답을 저장하고 메시지 전송을 완료한다")
+  void should_appendFallbackAssistantMessage_when_llmCallFails() {
+    ChatSession session =
+        ChatSession.create(WORKSPACE_ID, VERSION_ID, ChatSessionStatus.OPEN, "WEB", "{}");
+    ReflectionTestUtils.setField(session, "id", SESSION_ID);
+    given(chatSessionRepository.findByIdForUpdate(SESSION_ID)).willReturn(Optional.of(session));
+    given(chatMessageRepository.findTopByChatSessionIdOrderBySeqNoDesc(SESSION_ID))
+        .willReturn(Optional.empty());
+    given(chatMessageRepository.findTop5ByChatSessionIdOrderBySeqNoDesc(SESSION_ID))
+        .willReturn(List.of());
+    given(llmAssistantService.generateResponse("", "배송 상태 확인하고 싶어요"))
+        .willThrow(new NonTransientAiException("quota exceeded"));
+    given(chatMessageRepository.save(any(ChatMessage.class)))
+        .willAnswer(invocation -> invocation.getArgument(0));
+
+    List<ChatMessageResponse> responses =
+        service.appendMessage(WORKSPACE_ID, SESSION_ID, " 배송 상태 확인하고 싶어요 ");
+
+    assertThat(responses).hasSize(2);
+    assertThat(responses.get(0).senderRole()).isEqualTo("USER");
+    assertThat(responses.get(1).senderRole()).isEqualTo("ASSISTANT");
+    assertThat(responses.get(1).content()).contains("자동 응답 생성이 원활하지 않습니다");
     verify(messagingTemplate).convertAndSend("/topic/chat.77", responses.get(0));
     verify(messagingTemplate).convertAndSend("/topic/chat.77", responses.get(1));
   }

--- a/frontend/src/features/consultation/ui/ChatPanel.tsx
+++ b/frontend/src/features/consultation/ui/ChatPanel.tsx
@@ -11,6 +11,7 @@ export type MessageDeliveryStatus = "sending" | "sent" | "failed";
 
 export interface ChatMessage {
   id: string;
+  seqNo?: number;
   senderRole: ChatSenderRole;
   content: string;
   timestamp: string;

--- a/frontend/src/pages/consultation/ui/ConsultationPage.test.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.test.tsx
@@ -18,6 +18,7 @@ vi.mock("sonner", () => ({
 
 type RealtimePayload = {
   id?: string | number;
+  seqNo?: number;
   senderRole?: string;
   content?: string | null;
   createdAt?: string | null;
@@ -2170,6 +2171,46 @@ describe("ConsultationPage", () => {
 
     await waitFor(() => {
       expect(screen.getByText("새로운 고객 메시지")).toBeInTheDocument();
+    });
+  });
+
+  it("renders realtime customer and assistant messages in server sequence order", async () => {
+    render(<ConsultationPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("김민지")).toBeInTheDocument();
+    });
+
+    const customerItem = screen.getByText("김민지").closest("div");
+    if (customerItem) customerItem.click();
+
+    await waitFor(() => {
+      expect(screen.getByText("환불 문의 드립니다.")).toBeInTheDocument();
+      expect(stompState.callbacks.has("/topic/chat.1")).toBe(true);
+    });
+
+    act(() => {
+      stompState.callbacks.get("/topic/chat.1")?.({
+        id: 302,
+        seqNo: 3,
+        senderRole: "ASSISTANT",
+        content: "챗봇 응답입니다.",
+        createdAt: "2026-05-27T00:00:03+09:00",
+      });
+      stompState.callbacks.get("/topic/chat.1")?.({
+        id: 301,
+        seqNo: 2,
+        senderRole: "CUSTOMER",
+        content: "사용자 응답입니다.",
+        createdAt: "2026-05-27T00:00:02+09:00",
+      });
+    });
+
+    const messageList = screen.getByTestId("chat-message-list");
+    await waitFor(() => {
+      expect(messageList).toHaveTextContent(
+        /환불 문의 드립니다\.[\s\S]*사용자 응답입니다\.[\s\S]*챗봇 응답입니다\./,
+      );
     });
   });
 

--- a/frontend/src/pages/consultation/ui/ConsultationPage.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.tsx
@@ -49,6 +49,7 @@ const formatTime = (isoString: string) => {
 
 type RealtimeChatMessage = {
   id: string | number;
+  seqNo?: number | null;
   senderRole: string;
   content?: string | null;
   createdAt?: string | null;
@@ -57,6 +58,7 @@ type RealtimeChatMessage = {
 
 type MessageLike = {
   id?: string | number | null;
+  seqNo?: number | null;
   senderRole?: string | null;
   content?: string | null;
   createdAt?: string | null;
@@ -219,10 +221,37 @@ const toUiMessage = (message: MessageLike): UiChatMessage => {
   const createdAt = message.createdAt ?? message.timestamp ?? new Date().toISOString();
   return {
     id: String(message.id ?? `message-${createdAt}-${message.content ?? ""}`),
+    ...(message.seqNo != null ? { seqNo: message.seqNo } : {}),
     senderRole: normalizeChatSenderRole(message.senderRole),
     content: message.content ?? "",
     timestamp: formatTime(createdAt),
   };
+};
+
+const sortMessagesByServerOrder = (messages: UiChatMessage[]) =>
+  messages
+    .map((message, index) => ({ message, index }))
+    .sort((a, b) => {
+      const leftSeqNo = a.message.seqNo;
+      const rightSeqNo = b.message.seqNo;
+      if (leftSeqNo != null && rightSeqNo != null && leftSeqNo !== rightSeqNo) {
+        return leftSeqNo - rightSeqNo;
+      }
+      if (leftSeqNo != null && rightSeqNo == null) return -1;
+      if (leftSeqNo == null && rightSeqNo != null) return 1;
+      return a.index - b.index;
+    })
+    .map(({ message }) => message);
+
+const mergeMessagesById = (
+  currentMessages: UiChatMessage[],
+  nextMessages: UiChatMessage[],
+): UiChatMessage[] => {
+  const byId = new Map<string, UiChatMessage>();
+  [...currentMessages, ...nextMessages].forEach((message) => {
+    byId.set(message.id, message);
+  });
+  return sortMessagesByServerOrder(Array.from(byId.values()));
 };
 
 const shouldRefreshMatchedWorkflow = (role: ChatSenderRole) =>
@@ -282,7 +311,9 @@ const reconcileCounselorEchoMessage = (
 
   clearTimeout(pendingMatch.timeoutId);
   pendingMessages.delete(pendingMatch.id);
-  return messages.map((message) => (message.id === pendingMatch.id ? serverMessage : message));
+  return sortMessagesByServerOrder(
+    messages.map((message) => (message.id === pendingMatch.id ? serverMessage : message)),
+  );
 };
 
 const markMessageSending = (messages: UiChatMessage[], messageId: string) =>
@@ -1148,7 +1179,8 @@ export const ConsultationPage: React.FC = () => {
           size: MESSAGE_PAGE_SIZE,
         });
         if (cancelled) return;
-        setMessages(messagePage.content.map(toUiMessage));
+        const loadedMessages = sortMessagesByServerOrder(messagePage.content.map(toUiMessage));
+        setMessages((prev) => mergeMessagesById(prev, loadedMessages));
         setMessagesCustomerId(activeCustomerId);
         setMessagePagination({
           nextPage: messagePage.page + 1,
@@ -1232,7 +1264,7 @@ export const ConsultationPage: React.FC = () => {
       setMessagesCustomerId(activeCustomerId);
       setMessages((prev) => {
         if (prev.some((m) => m.id === msgId)) return prev;
-        return [...prev, toUiMessage(msg)];
+        return sortMessagesByServerOrder([...prev, toUiMessage(msg)]);
       });
     });
 


### PR DESCRIPTION
## 변경 내용
- 데모 채팅 LLM 응답 생성이 일시/비일시 AI 예외로 실패해도 안내 메시지를 저장하고 WebSocket 전송 흐름을 완료하도록 했습니다.
- 상담 화면의 실시간 메시지를 서버 `seqNo` 기준으로 정렬하고, 초기 조회 메시지와 실시간 메시지를 id 기준으로 병합해 순서 역전을 방지합니다.

## 배경
데모 채팅 자동 응답 생성 실패가 메시지 저장 흐름을 중단할 수 있고, 실시간 고객/assistant 메시지가 도착 순서에 따라 서버 순서와 다르게 렌더링될 수 있었습니다.

## 확인
- `cd frontend && pnpm test -- ConsultationPage.test.tsx`
- `cd backend && GRADLE_USER_HOME="$PWD/.gradle-tmp" mise exec -- ./gradlew test --tests com.init.chatdemo.application.DemoChatSessionRegistrationServiceTest`
- `git diff --check`