### PR TITLE
fix(chat-demo-BE): 상담사 배정 후 데모 봇 자동응답 차단

### DIFF
--- a/backend/src/main/java/com/init/chatdemo/application/DemoChatSessionRegistrationService.java
+++ b/backend/src/main/java/com/init/chatdemo/application/DemoChatSessionRegistrationService.java
@@ -120,6 +120,13 @@ public class DemoChatSessionRegistrationService {
             ChatMessage.create(sessionId, nextSeqNo, "USER", "TEXT", normalizedContent));
     chatSessionMetadataService.updateAfterMessage(session, userMessage);
 
+    if (!session.allowsAiAutoResponse()) {
+      List<ChatMessageResponse> responses = List.of(ChatMessageResponse.from(userMessage));
+      publishQueueUpsert(session);
+      broadcastAfterCommit(sessionId, responses);
+      return responses;
+    }
+
     String assistantContent =
         llmAssistantService.generateResponse(
             createConversationContext(sessionId), normalizedContent);

--- a/backend/src/test/java/com/init/chatdemo/application/DemoChatSessionRegistrationServiceTest.java
+++ b/backend/src/test/java/com/init/chatdemo/application/DemoChatSessionRegistrationServiceTest.java
@@ -25,6 +25,7 @@ import com.init.workflowruntime.domain.ChatMessage;
 import com.init.workflowruntime.domain.ChatMessageRepository;
 import com.init.workflowruntime.domain.ChatSession;
 import com.init.workflowruntime.domain.ChatSessionRepository;
+import com.init.workflowruntime.domain.ChatSessionResponseMode;
 import com.init.workflowruntime.domain.ChatSessionStatus;
 import com.init.workflowruntime.domain.event.ConsultationQueueChangedEvent;
 import com.init.workflowruntime.domain.event.ConsultationQueueEventType;
@@ -149,6 +150,69 @@ class DemoChatSessionRegistrationServiceTest {
     verify(llmAssistantService).generateResponse("USER: Hello", "Hello");
     verify(messagingTemplate).convertAndSend("/topic/chat.77", responses.get(0));
     verify(messagingTemplate).convertAndSend("/topic/chat.77", responses.get(1));
+  }
+
+  @Test
+  @DisplayName("상담사 배정 세션은 데모 사용자 메시지만 저장하고 assistant 자동응답을 생성하지 않는다")
+  void should_appendOnlyUserMessage_when_humanActiveSession() {
+    ChatSession session =
+        ChatSession.create(WORKSPACE_ID, VERSION_ID, ChatSessionStatus.OPEN, "WEB", "{}");
+    ReflectionTestUtils.setField(session, "id", SESSION_ID);
+    session.assignTo(11L);
+    given(chatSessionRepository.findByIdForUpdate(SESSION_ID)).willReturn(Optional.of(session));
+    given(chatMessageRepository.findTopByChatSessionIdOrderBySeqNoDesc(SESSION_ID))
+        .willReturn(Optional.of(ChatMessage.create(SESSION_ID, 2, "ASSISTANT", "TEXT", "이전 답변")));
+    given(chatMessageRepository.save(any(ChatMessage.class)))
+        .willAnswer(invocation -> invocation.getArgument(0));
+
+    List<ChatMessageResponse> responses =
+        service.appendMessage(WORKSPACE_ID, SESSION_ID, " 아직 답변 없나요? ");
+
+    assertThat(responses).hasSize(1);
+    assertThat(responses.get(0).senderRole()).isEqualTo("USER");
+    assertThat(responses.get(0).seqNo()).isEqualTo(3);
+    assertThat(responses.get(0).content()).isEqualTo("아직 답변 없나요?");
+
+    ArgumentCaptor<ChatMessage> messageCaptor = ArgumentCaptor.forClass(ChatMessage.class);
+    verify(chatMessageRepository).save(messageCaptor.capture());
+    assertThat(messageCaptor.getValue().getSenderRole()).isEqualTo("USER");
+    verify(chatMessageRepository, never()).findTop5ByChatSessionIdOrderBySeqNoDesc(SESSION_ID);
+    verify(llmAssistantService, never()).generateResponse(any(), any());
+    verify(chatSessionMetadataService).updateAfterMessage(session, messageCaptor.getValue());
+    verifyQueueUpsertEventPublished();
+    verify(messagingTemplate).convertAndSend("/topic/chat.77", responses.get(0));
+  }
+
+  @Test
+  @DisplayName("AI 보조 모드 세션은 데모 사용자 메시지만 저장하고 assistant 자동응답을 생성하지 않는다")
+  void should_appendOnlyUserMessage_when_aiAssistOnlySession() {
+    ChatSession session =
+        ChatSession.create(WORKSPACE_ID, VERSION_ID, ChatSessionStatus.OPEN, "WEB", "{}");
+    ReflectionTestUtils.setField(session, "id", SESSION_ID);
+    session.assignTo(11L);
+    session.switchResponseMode(ChatSessionResponseMode.AI_ASSIST_ONLY);
+    given(chatSessionRepository.findByIdForUpdate(SESSION_ID)).willReturn(Optional.of(session));
+    given(chatMessageRepository.findTopByChatSessionIdOrderBySeqNoDesc(SESSION_ID))
+        .willReturn(Optional.empty());
+    given(chatMessageRepository.save(any(ChatMessage.class)))
+        .willAnswer(invocation -> invocation.getArgument(0));
+
+    List<ChatMessageResponse> responses =
+        service.appendMessage(WORKSPACE_ID, SESSION_ID, " 상담사에게 전달해주세요 ");
+
+    assertThat(responses).hasSize(1);
+    assertThat(responses.get(0).senderRole()).isEqualTo("USER");
+    assertThat(responses.get(0).seqNo()).isEqualTo(1);
+    assertThat(responses.get(0).content()).isEqualTo("상담사에게 전달해주세요");
+
+    ArgumentCaptor<ChatMessage> messageCaptor = ArgumentCaptor.forClass(ChatMessage.class);
+    verify(chatMessageRepository).save(messageCaptor.capture());
+    assertThat(messageCaptor.getValue().getSenderRole()).isEqualTo("USER");
+    verify(chatMessageRepository, never()).findTop5ByChatSessionIdOrderBySeqNoDesc(SESSION_ID);
+    verify(llmAssistantService, never()).generateResponse(any(), any());
+    verify(chatSessionMetadataService).updateAfterMessage(session, messageCaptor.getValue());
+    verifyQueueUpsertEventPublished();
+    verify(messagingTemplate).convertAndSend("/topic/chat.77", responses.get(0));
   }
 
   @Test


### PR DESCRIPTION
## 요약

- 데모 채팅 메시지 append 시 `ChatSession.allowsAiAutoResponse()` 가드를 추가했습니다.
- `HUMAN_ACTIVE`, `AI_ASSIST_ONLY` 세션에서는 USER 메시지만 저장/반환하고 LLM 자동응답 생성을 차단했습니다.
- 상담사 배정 및 AI 보조 모드에서 LLM 미호출, ASSISTANT 메시지 미저장을 검증하는 테스트를 추가했습니다.

## 검증

- `./gradlew test --tests com.init.chatdemo.application.DemoChatSessionRegistrationServiceTest`
- `./gradlew spotlessJavaCheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 채팅 세션별로 AI 자동 응답을 선택적으로 비활성화하는 동작이 적용되었습니다. 해당 모드에서는 사용자 메시지는 정상 저장·전송되며, AI 응답 생성(LLM 호출)과 어시스턴트 메시지 저장은 수행되지 않습니다. 큐 업서트 발행과 커밋 후 브로드캐스트는 계속 실행됩니다.

* **테스트**
  * 세션 할당 상태와 AI 응답 비활성화 모드에서의 메시지 처리 흐름을 검증하는 테스트 2건이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->