### PR TITLE
fix(workflow): 워크플로우 표기 복원

### DIFF
--- a/.agent/specs/457.md
+++ b/.agent/specs/457.md
@@ -1,0 +1,75 @@
+# Frontend Spec: 워크플로우 표기 복원
+
+## Goal
+
+사용자에게 노출되는 workflow 개념의 일반 표기를 `응대 흐름`에서 `워크플로우`로 되돌려 제품 화면 전반의 용어를 일관화한다.
+
+## Background
+
+워크플로우 관련 화면과 메시지 일부가 `응대 흐름`으로 표시되고 있다. 제품과 도메인 모델에서는 workflow가 핵심 개념이며, 운영자 화면에서도 `워크플로우`가 더 명확한 표현이다. 이 변경은 사용자 노출 문구와 그 문구를 검증하는 테스트 기대값을 대상으로 한다.
+
+## Scope
+
+- 화면 제목, 내비게이션, 탭, 카드, 빈 상태, 로딩/에러 메시지, 토스트 문구에서 workflow 개념을 `워크플로우`로 표시한다.
+- workflow code를 설명하는 사용자 노출 라벨은 `워크플로우 코드`로 표시한다.
+- 변경된 문구를 기준으로 프론트엔드 단위/통합/e2e 테스트 기대값을 갱신한다.
+
+## Non-goals
+
+- `workflow`, `workflowCode`, `workflows` 같은 코드/API/라우트/도메인 모델 명명은 변경하지 않는다.
+- `응대 기준`, `응대 방법`, `상담 응대`처럼 workflow가 아닌 기존 상담/정책 용어는 변경하지 않는다.
+- 디자인 레이아웃, API 연동, 데이터 구조, 백엔드/ML 동작은 변경하지 않는다.
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A["사용자가 워크스페이스 또는 도메인팩 화면 진입"] --> B["워크플로우 관련 내비게이션/탭/카드 확인"]
+    B --> C{"워크플로우 데이터 상태"}
+    C -->|Loading| D["워크플로우 로딩 문구 표시"]
+    C -->|Error| E["워크플로우 오류 문구 표시"]
+    C -->|Empty| F["워크플로우 빈 상태 문구 표시"]
+    C -->|Ready| G["워크플로우 목록/상세/그래프 표시"]
+```
+
+## Design Diff
+
+| 영역 | As-is | To-be | 변경 내용 |
+| --- | --- | --- | --- |
+| Workflow navigation | `응대 흐름` | `워크플로우` | 셸, 사이드바, 탭 라벨 복원 |
+| Workflow list/detail states | `응대 흐름 목록`, `응대 흐름 없음` | `워크플로우 목록`, `워크플로우 없음` | 로딩/오류/빈 상태 문구 복원 |
+| Workflow edit/revision feedback | `응대 흐름 수정`, `응대 흐름 수정 검토본` | `워크플로우 수정`, `워크플로우 수정 검토본` | 폼, 시트, 토스트, validation 문구 복원 |
+| Workflow code label | `응대 코드` | `워크플로우 코드` | workflowCode 표시 라벨 복원 |
+
+## Affected Frontend Modules
+
+| 경로 | 변경 유형 | 설명 |
+| --- | --- | --- |
+| `frontend/src/widgets/ostone-shell/ui` | modify | 워크플로우 내비게이션 라벨과 테스트 기대값 갱신 |
+| `frontend/src/pages/domain-pack/ui` | modify | 도메인팩 워크플로우 목록/상세/그래프 화면 문구와 테스트 기대값 갱신 |
+| `frontend/src/pages/workspace/ui` | modify | 워크스페이스 워크플로우 목록 화면 문구와 테스트 기대값 갱신 |
+| `frontend/src/features/workflow-draft-read/ui` | modify | 워크플로우 초안 목록/상세 패널 문구와 테스트 기대값 갱신 |
+| `frontend/src/features/workflow-list/ui` | modify | 워크플로우 목록/검색 UI 문구 갱신 |
+| `frontend/src/features/update-workflow` | modify | 워크플로우 수정 API 메시지, 스키마, 폼/시트 문구와 테스트 기대값 갱신 |
+| `frontend/src/entities/workflow` | modify | 워크플로우 API 오류/그래프 렌더링 상태 문구와 테스트 기대값 갱신 |
+| `frontend/src/features/domain-pack-summary-read/ui` | modify | 워크플로우 요약/미리보기 문구와 테스트 기대값 갱신 |
+| `frontend/e2e` | modify | e2e 기대 문구 갱신 |
+| `frontend/src/shared/lib` | modify | 도메인팩 섹션/정렬 라벨 갱신 |
+
+## Acceptance Criteria
+
+1. 주요 화면에서 workflow 개념의 일반 표기가 `워크플로우`로 표시된다.
+2. `응대 흐름` 문구가 frontend 사용자 노출 문자열 또는 변경 대상 테스트 기대값에 남지 않는다.
+3. workflow code 사용자 노출 라벨은 `워크플로우 코드`로 표시된다.
+4. workflow 관련 코드/API/라우트 식별자는 기존 `workflow` 명명을 유지한다.
+5. `응대 기준`, `응대 방법`, `상담 응대` 등 workflow가 아닌 상담/정책 용어는 유지된다.
+
+## Validation
+
+- `cd frontend && pnpm test`
+- `cd frontend && pnpm build`
+- 필요 시 `frontend/e2e` 중 workflow 라벨을 검증하는 시나리오를 별도로 실행한다.
+
+## Open Questions
+
+- 없음. 이슈 본문 기준으로 사용자 노출 workflow 표기를 `워크플로우`로 복원하는 범위가 명확하다.

--- a/frontend/e2e/auth-login.spec.ts
+++ b/frontend/e2e/auth-login.spec.ts
@@ -95,7 +95,7 @@ test.describe("Login screen", () => {
         await page.getByRole("button", { name: "시스템 로그인" }).click();
 
         await expect(page).toHaveURL(/\/workspaces\/1\/workflows/);
-        await expect(page.getByText("응대 흐름")).toBeVisible();
+        await expect(page.getByText("워크플로우")).toBeVisible();
         await expect
           .poll(() => page.evaluate(() => window.localStorage.getItem("accessToken")))
           .toBeTruthy();

--- a/frontend/e2e/domain-pack-read.spec.ts
+++ b/frontend/e2e/domain-pack-read.spec.ts
@@ -82,7 +82,7 @@ test.describe("Domain pack generated read screens", () => {
         );
         await expect(page.getByText("환불 workflow")).toBeVisible();
         await expect(
-          page.getByText("이 응대 흐름에는 아직 흐름도가 정의되어 있지 않습니다."),
+          page.getByText("이 워크플로우에는 아직 흐름도가 정의되어 있지 않습니다."),
         ).toBeVisible();
         expect(seen).toContain("GET /workspaces/1/domain-packs/1/versions/1/workflows");
         expect(seen).toContain("GET /workspaces/1/domain-packs/1/versions/1/workflows/401");

--- a/frontend/e2e/workspace-create.spec.ts
+++ b/frontend/e2e/workspace-create.spec.ts
@@ -82,7 +82,7 @@ test.describe("Workspace creation", () => {
 
         await expect(page).toHaveURL(/\/workspaces\/777\/workflows/);
         await expect(page.getByText("워크스페이스를 생성했습니다.")).toBeVisible();
-        await expect(page.getByText("응대 흐름")).toBeVisible();
+        await expect(page.getByText("워크플로우")).toBeVisible();
         expect(seen).toContain("POST /workspaces");
       });
     });

--- a/frontend/src/app/App.test.tsx
+++ b/frontend/src/app/App.test.tsx
@@ -131,10 +131,10 @@ describe("App", () => {
       expect(window.location.pathname).toBe("/workspaces/1/workflows");
     });
 
-    expect(await screen.findByText("응대 흐름")).toBeInTheDocument();
+    expect(await screen.findByText("워크플로우")).toBeInTheDocument();
     expect(
       await screen.findByText(
-        "아직 등록된 응대 흐름이 없습니다. 응대 흐름은 도메인팩에서 생성하고 관리합니다.",
+        "아직 등록된 워크플로우가 없습니다. 워크플로우는 도메인팩에서 생성하고 관리합니다.",
       ),
     ).toBeInTheDocument();
     expect(fetchMock).toHaveBeenCalledWith(

--- a/frontend/src/entities/workflow/api/useListAllWorkspaceWorkflows.ts
+++ b/frontend/src/entities/workflow/api/useListAllWorkspaceWorkflows.ts
@@ -90,7 +90,7 @@ export function useListAllWorkspaceWorkflows({
   } else if (detailQueries.find((q) => q.isError)) {
     error = "도메인팩 상세 조회 실패";
   } else if (workflowQueries.find((q) => q.isError)) {
-    error = "응대 흐름 목록 조회 실패";
+    error = "워크플로우 목록 조회 실패";
   }
 
   const entries: WorkspaceWorkflowEntry[] = [];

--- a/frontend/src/entities/workflow/api/useListWorkflowsByIntent.test.ts
+++ b/frontend/src/entities/workflow/api/useListWorkflowsByIntent.test.ts
@@ -141,7 +141,7 @@ describe("useListWorkflowsByIntent", () => {
     );
 
     await waitFor(() => expect(result.current.error).not.toBeNull());
-    expect(result.current.error).toBe("응대 흐름 목록 조회 실패");
+    expect(result.current.error).toBe("워크플로우 목록 조회 실패");
   });
 
   it("workflows 응답이 비어있을 때 빈 entries", async () => {

--- a/frontend/src/entities/workflow/api/useListWorkflowsByIntent.ts
+++ b/frontend/src/entities/workflow/api/useListWorkflowsByIntent.ts
@@ -87,7 +87,7 @@ export function useListWorkflowsByIntent({
 
   const loading = enabled && (packQuery.isLoading || workflowsQuery.isLoading);
   const error = workflowsQuery.isError
-    ? "응대 흐름 목록 조회 실패"
+    ? "워크플로우 목록 조회 실패"
     : packQuery.isError
       ? "도메인팩 정보 조회 실패"
       : null;

--- a/frontend/src/entities/workflow/ui/GraphRenderer.test.tsx
+++ b/frontend/src/entities/workflow/ui/GraphRenderer.test.tsx
@@ -51,7 +51,7 @@ describe("GraphRenderer", () => {
   it("노드/엣지 없는 그래프도 오류 없이 렌더링한다", () => {
     const emptyGraph = { direction: "TB" as const, nodes: [], edges: [] };
     render(<GraphRenderer graph={emptyGraph} />);
-    expect(screen.getByText("응대 흐름 데이터 없음")).toBeInTheDocument();
+    expect(screen.getByText("워크플로우 데이터 없음")).toBeInTheDocument();
   });
 
   it("interaction props가 spec대로 설정된다", () => {

--- a/frontend/src/entities/workflow/ui/GraphRenderer.tsx
+++ b/frontend/src/entities/workflow/ui/GraphRenderer.tsx
@@ -70,13 +70,13 @@ export default function GraphRenderer({
   return (
     <div className={styles.container}>
       {isLoading ? (
-        <div className={styles.loading}>응대 흐름을 불러오는 중...</div>
+        <div className={styles.loading}>워크플로우를 불러오는 중...</div>
       ) : error ? (
         <div className={styles.error}>
           Error: {typeof error === "string" ? error : error.message}
         </div>
       ) : !nodes || nodes.length === 0 ? (
-        <div className={styles.empty}>{emptyMessage ?? "응대 흐름 데이터 없음"}</div>
+        <div className={styles.empty}>{emptyMessage ?? "워크플로우 데이터 없음"}</div>
       ) : (
         <ErrorBoundary fallback={<div className={styles.error}>흐름도를 표시할 수 없습니다</div>}>
           <ReactFlow

--- a/frontend/src/features/domain-pack-summary-read/ui/ComponentCountGrid.test.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/ComponentCountGrid.test.tsx
@@ -50,7 +50,7 @@ describe("ComponentCountGrid", () => {
     render(<ComponentCountGrid {...defaultProps} />);
     expect(screen.getByText("상담 유형")).toBeInTheDocument();
     expect(screen.getByText("2")).toBeInTheDocument();
-    expect(screen.getByText("응대 흐름")).toBeInTheDocument();
+    expect(screen.getByText("워크플로우")).toBeInTheDocument();
     expect(screen.getByText("4")).toBeInTheDocument();
   });
 
@@ -59,7 +59,7 @@ describe("ComponentCountGrid", () => {
     expect(screen.getByRole("button", { name: "상담 유형 상세 보기" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "확인 항목 상세 보기" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "응대 기준 상세 보기" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "응대 흐름 상세 보기" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "워크플로우 상세 보기" })).toBeInTheDocument();
   });
 
   it("Intent, Policy 화살표 클릭 시 상세 목록으로 이동한다", () => {
@@ -115,7 +115,7 @@ describe("ComponentCountGrid", () => {
     vi.mocked(previewLists.useWorkflowPreview).mockReturnValue(makeHook({ isError: true }));
     render(<ComponentCountGrid {...defaultProps} />);
     await waitFor(() =>
-      expect(toast.error).toHaveBeenCalledWith("응대 흐름 미리보기를 불러오지 못했습니다."),
+      expect(toast.error).toHaveBeenCalledWith("워크플로우 미리보기를 불러오지 못했습니다."),
     );
   });
 

--- a/frontend/src/features/domain-pack-summary-read/ui/ComponentCountGrid.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/ComponentCountGrid.tsx
@@ -50,7 +50,7 @@ export function ComponentCountGrid({
   }, [policyPreview.isError]);
 
   useEffect(() => {
-    if (workflowPreview.isError) toast.error("응대 흐름 미리보기를 불러오지 못했습니다.");
+    if (workflowPreview.isError) toast.error("워크플로우 미리보기를 불러오지 못했습니다.");
   }, [workflowPreview.isError]);
 
   return (
@@ -88,7 +88,7 @@ export function ComponentCountGrid({
         isLoadingPreview={policyPreview.isLoading}
       />
       <CountCard
-        label="응대 흐름"
+        label="워크플로우"
         count={workflowCount}
         disabled={false}
         onNavigate={() => navigate(domainPackSectionPath(wsId, packId, versionId, "workflows"))}

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryJsonCard.test.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryJsonCard.test.tsx
@@ -22,7 +22,7 @@ describe("SummaryJsonCard", () => {
     expect(screen.getByText("82%")).toBeInTheDocument();
     expect(screen.getByText("이탈률")).toBeInTheDocument();
     expect(screen.getByText("7%")).toBeInTheDocument();
-    expect(screen.getByText("응대 흐름 분리도")).toBeInTheDocument();
+    expect(screen.getByText("워크플로우 분리도")).toBeInTheDocument();
     expect(screen.getByText("76%")).toBeInTheDocument();
     expect(screen.getByText("검토 포인트")).toBeInTheDocument();
     expect(screen.getByText("워크플로우 미매핑")).toBeInTheDocument();

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryJsonCard.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryJsonCard.tsx
@@ -92,7 +92,7 @@ function buildSummary(data: SummaryData) {
       value: formatRate(firstValue(data, [["quality", "outlierRate"], ["outlierRate"]])) ?? "",
     },
     {
-      label: "응대 흐름 분리도",
+      label: "워크플로우 분리도",
       value:
         formatRate(
           firstValue(data, [["quality", "workflowSeparability"], ["workflowSeparability"]]),

--- a/frontend/src/features/intent-draft-read/ui/MatchedWorkflowSection.test.tsx
+++ b/frontend/src/features/intent-draft-read/ui/MatchedWorkflowSection.test.tsx
@@ -75,7 +75,7 @@ describe("MatchedWorkflowSection", () => {
           versionId: 4,
           workflowId: 7,
           workflowCode: "wf.x",
-          name: "응대 흐름",
+          name: "워크플로우",
           description: "d",
           intentDefinitionId: 100,
         },

--- a/frontend/src/features/intent-draft-read/ui/MatchedWorkflowSection.tsx
+++ b/frontend/src/features/intent-draft-read/ui/MatchedWorkflowSection.tsx
@@ -52,14 +52,14 @@ export function MatchedWorkflowSection({
     >
       <header className={styles.header}>
         <h2 id="matched-workflow-section-title" className={styles.title}>
-          연결된 응대 흐름
+          연결된 워크플로우
         </h2>
         <Mono className={styles.count}>{loading ? "확인 중…" : `${entries.length}개`}</Mono>
       </header>
 
       {loading && (
         <div className={styles.placeholder} data-testid="matched-workflow-section-loading">
-          <Mono>응대 흐름을 불러오는 중…</Mono>
+          <Mono>워크플로우를 불러오는 중…</Mono>
         </div>
       )}
 
@@ -71,7 +71,7 @@ export function MatchedWorkflowSection({
 
       {!loading && !error && entries.length === 0 && (
         <div className={styles.placeholder} data-testid="matched-workflow-section-empty">
-          <Mono>이 상담 유형에 연결된 응대 흐름이 없습니다.</Mono>
+          <Mono>이 상담 유형에 연결된 워크플로우가 없습니다.</Mono>
         </div>
       )}
 

--- a/frontend/src/features/update-policy/api/messages.ts
+++ b/frontend/src/features/update-policy/api/messages.ts
@@ -1,7 +1,7 @@
 export const POLICY_ERROR_MESSAGES = {
   POLICY_NOT_EDITABLE: "검토 중인 버전에서만 응대 기준을 수정할 수 있습니다.",
   POLICY_CODE_REFERENCED_BY_WORKFLOW:
-    "이 응대 기준을 참조하는 응대 흐름이 있어 비활성화할 수 없습니다.",
+    "이 응대 기준을 참조하는 워크플로우가 있어 비활성화할 수 없습니다.",
   VALIDATION_ERROR: "응대 기준 데이터 검증에 실패했습니다. 입력값을 확인해주세요.",
   NOT_FOUND: "응대 기준을 찾을 수 없습니다.",
   UPDATE_FAILED: "응대 기준 수정에 실패했습니다.",

--- a/frontend/src/features/update-workflow/api/useUpdateWorkflow.test.ts
+++ b/frontend/src/features/update-workflow/api/useUpdateWorkflow.test.ts
@@ -80,7 +80,7 @@ describe("useUpdateWorkflow", () => {
       await result.current.mutateAsync(mutateParams);
     });
 
-    expect(toast.success).toHaveBeenCalledWith("응대 흐름이 수정되었습니다.");
+    expect(toast.success).toHaveBeenCalledWith("워크플로우가 수정되었습니다.");
   });
 
   it("알려진 에러 코드 WORKFLOW_NOT_EDITABLE에 대해 매핑된 메시지를 표시한다", async () => {
@@ -97,7 +97,7 @@ describe("useUpdateWorkflow", () => {
 
     await waitFor(() =>
       expect(toast.error).toHaveBeenCalledWith(
-        "검토 중인 버전에서만 응대 흐름을 수정할 수 있습니다.",
+        "검토 중인 버전에서만 워크플로우를 수정할 수 있습니다.",
       ),
     );
   });
@@ -147,7 +147,7 @@ describe("useUpdateWorkflow", () => {
     });
 
     await waitFor(() =>
-      expect(toast.error).toHaveBeenCalledWith("응대 흐름 수정에 실패했습니다."),
+      expect(toast.error).toHaveBeenCalledWith("워크플로우 수정에 실패했습니다."),
     );
   });
 });

--- a/frontend/src/features/update-workflow/api/useUpdateWorkflow.ts
+++ b/frontend/src/features/update-workflow/api/useUpdateWorkflow.ts
@@ -13,7 +13,7 @@ interface UpdateWorkflowParams {
 }
 
 const ERROR_MESSAGES: Record<string, string> = {
-  WORKFLOW_NOT_EDITABLE: "검토 중인 버전에서만 응대 흐름을 수정할 수 있습니다.",
+  WORKFLOW_NOT_EDITABLE: "검토 중인 버전에서만 워크플로우를 수정할 수 있습니다.",
   GRAPH_JSON_REQUIRED: "그래프 데이터가 필요합니다.",
   GRAPH_JSON_TOO_LARGE: "그래프 데이터가 너무 큽니다.",
   WORKFLOW_GRAPH_JSON_INVALID: "그래프 데이터 형식이 유효하지 않습니다.",
@@ -46,12 +46,12 @@ export function useUpdateWorkflow() {
       queryClient.invalidateQueries({
         queryKey: workflowQueryKeys.list(wsId, packId, versionId),
       });
-      toast.success("응대 흐름이 수정되었습니다.");
+      toast.success("워크플로우가 수정되었습니다.");
     },
     onError: (error: unknown) => {
       const code = error instanceof ApiRequestError ? error.code : "";
       const message = error instanceof ApiRequestError ? error.message : "";
-      toast.error((ERROR_MESSAGES[code] ?? message) || "응대 흐름 수정에 실패했습니다.");
+      toast.error((ERROR_MESSAGES[code] ?? message) || "워크플로우 수정에 실패했습니다.");
     },
   });
 }

--- a/frontend/src/features/update-workflow/model/schema.ts
+++ b/frontend/src/features/update-workflow/model/schema.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 export const workflowEditSchema = z.object({
-  name: z.string().trim().min(1, "응대 흐름 이름은 필수입니다."),
+  name: z.string().trim().min(1, "워크플로우 이름은 필수입니다."),
   description: z.string().nullable().optional(),
 });
 

--- a/frontend/src/features/update-workflow/ui/WorkflowEditForm.test.tsx
+++ b/frontend/src/features/update-workflow/ui/WorkflowEditForm.test.tsx
@@ -32,7 +32,7 @@ const mockedUseUpdateWorkflow = vi.mocked(useUpdateWorkflow);
 const stubWorkflow = {
   id: 10,
   workflowCode: "WF-REFUND-01",
-  name: "환불 처리 응대 흐름",
+  name: "환불 처리 워크플로우",
   description: "표준 환불 처리 절차",
   graphJson: JSON.stringify({ direction: "LR", nodes: [], edges: [] }),
   createdAt: "2025-01-01T00:00:00+09:00",
@@ -96,7 +96,7 @@ describe("WorkflowEditForm", () => {
 
   it("renders workflow name and description in form fields", () => {
     renderForm();
-    expect(screen.getByDisplayValue("환불 처리 응대 흐름")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("환불 처리 워크플로우")).toBeInTheDocument();
     expect(screen.getByDisplayValue("표준 환불 처리 절차")).toBeInTheDocument();
   });
 
@@ -131,8 +131,8 @@ describe("WorkflowEditForm", () => {
 
   it("calls mutate on form submit with updated values", async () => {
     renderForm();
-    const nameInput = screen.getByDisplayValue("환불 처리 응대 흐름");
-    fireEvent.change(nameInput, { target: { value: "수정된 응대 흐름" } });
+    const nameInput = screen.getByDisplayValue("환불 처리 워크플로우");
+    fireEvent.change(nameInput, { target: { value: "수정된 워크플로우" } });
     fireEvent.click(screen.getByRole("button", { name: "저장" }));
     await waitFor(() => expect(mutateWorkflow).toHaveBeenCalled());
     expect(mutateWorkflow).toHaveBeenCalledWith(
@@ -141,7 +141,7 @@ describe("WorkflowEditForm", () => {
         packId: 2,
         versionId: 3,
         workflowId: 10,
-        body: expect.objectContaining({ name: "수정된 응대 흐름" }),
+        body: expect.objectContaining({ name: "수정된 워크플로우" }),
       }),
       expect.objectContaining({ onSuccess: expect.any(Function) }),
     );
@@ -154,8 +154,8 @@ describe("WorkflowEditForm", () => {
       options?.onSuccess?.();
     });
     renderForm({ onSaved, onDirtyChange });
-    const nameInput = screen.getByDisplayValue("환불 처리 응대 흐름");
-    fireEvent.change(nameInput, { target: { value: "수정된 응대 흐름" } });
+    const nameInput = screen.getByDisplayValue("환불 처리 워크플로우");
+    fireEvent.change(nameInput, { target: { value: "수정된 워크플로우" } });
 
     await waitFor(() => expect(onDirtyChange).toHaveBeenCalledWith(true));
     fireEvent.click(screen.getByRole("button", { name: "저장" }));
@@ -176,11 +176,11 @@ describe("WorkflowEditForm", () => {
 
   it("shows validation error when name is cleared", async () => {
     renderForm();
-    const nameInput = screen.getByDisplayValue("환불 처리 응대 흐름");
+    const nameInput = screen.getByDisplayValue("환불 처리 워크플로우");
     fireEvent.change(nameInput, { target: { value: "" } });
     fireEvent.click(screen.getByRole("button", { name: "저장" }));
     await waitFor(() => {
-      expect(screen.getByText("응대 흐름 이름은 필수입니다.")).toBeInTheDocument();
+      expect(screen.getByText("워크플로우 이름은 필수입니다.")).toBeInTheDocument();
     });
     expect(mutateWorkflow).not.toHaveBeenCalled();
   });

--- a/frontend/src/features/update-workflow/ui/WorkflowEditForm.tsx
+++ b/frontend/src/features/update-workflow/ui/WorkflowEditForm.tsx
@@ -167,7 +167,7 @@ export function WorkflowEditForm({
                 id="wf-name"
                 {...field}
                 className={styles.fieldInput}
-                placeholder="응대 흐름 이름"
+                placeholder="워크플로우 이름"
                 aria-invalid={errors.name ? "true" : "false"}
                 data-testid="workflow-edit-name"
               />
@@ -182,7 +182,7 @@ export function WorkflowEditForm({
 
         <div className={styles.field}>
           <label className={styles.fieldLabel} htmlFor="wf-code">
-            응대 코드
+            워크플로우 코드
           </label>
           <input
             id="wf-code"
@@ -210,7 +210,7 @@ export function WorkflowEditForm({
                 name={field.name}
                 ref={field.ref}
                 className={styles.fieldInput}
-                placeholder="이 응대 흐름의 목적을 한 줄로 설명"
+                placeholder="이 워크플로우의 목적을 한 줄로 설명"
                 data-testid="workflow-edit-description"
               />
             )}

--- a/frontend/src/features/update-workflow/ui/WorkflowEditSheet.test.tsx
+++ b/frontend/src/features/update-workflow/ui/WorkflowEditSheet.test.tsx
@@ -110,7 +110,7 @@ describe("WorkflowEditSheet", () => {
       refetch: vi.fn(),
     } as unknown as ReturnType<typeof useGetWorkflow>);
     render(<WorkflowEditSheet {...makeProps()} />);
-    expect(screen.getByText("응대 흐름 정보를 불러오지 못했습니다.")).toBeInTheDocument();
+    expect(screen.getByText("워크플로우 정보를 불러오지 못했습니다.")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "다시 시도" })).toBeInTheDocument();
   });
 
@@ -157,7 +157,7 @@ describe("WorkflowEditSheet", () => {
       refetch: vi.fn(),
     } as unknown as ReturnType<typeof useGetWorkflow>);
     render(<WorkflowEditSheet {...makeProps()} />);
-    expect(screen.getByText("응대 흐름 수정")).toBeInTheDocument();
+    expect(screen.getByText("워크플로우 수정")).toBeInTheDocument();
   });
 
   it("Sheet onOpenChange(!open) 시 onClose가 호출된다", () => {

--- a/frontend/src/features/update-workflow/ui/WorkflowEditSheet.tsx
+++ b/frontend/src/features/update-workflow/ui/WorkflowEditSheet.tsx
@@ -38,9 +38,9 @@ export function WorkflowEditSheet({
       <SheetContent side="right" className="w-full sm:max-w-4xl overflow-y-auto flex flex-col">
         <SheetHeader className="px-4 pt-4">
           <SheetTitle>
-            {workflow ? `${workflow.workflowCode} · ${workflow.name}` : "응대 흐름 수정"}
+            {workflow ? `${workflow.workflowCode} · ${workflow.name}` : "워크플로우 수정"}
           </SheetTitle>
-          <SheetDescription>응대 흐름 이름, 설명, 흐름도를 수정합니다.</SheetDescription>
+          <SheetDescription>워크플로우 이름, 설명, 흐름도를 수정합니다.</SheetDescription>
         </SheetHeader>
 
         {isLoading && (
@@ -51,7 +51,7 @@ export function WorkflowEditSheet({
 
         {isError && (
           <div className="flex flex-col items-center justify-center gap-4 py-12 px-4 text-sm text-muted-foreground">
-            <span>응대 흐름 정보를 불러오지 못했습니다.</span>
+            <span>워크플로우 정보를 불러오지 못했습니다.</span>
             <Button variant="outline" size="sm" onClick={() => refetch()}>
               다시 시도
             </Button>

--- a/frontend/src/features/workflow-draft-read/ui/WorkflowDetailPanel.test.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/WorkflowDetailPanel.test.tsx
@@ -47,7 +47,7 @@ const mockedUseListPolicies = vi.mocked(useListPolicies);
 const stubDetail = {
   id: 10,
   workflowCode: "W001",
-  name: "테스트 응대 흐름",
+  name: "테스트 워크플로우",
   description: "설명입니다",
   graphJson: { direction: "LR" as const, nodes: [], edges: [] },
   initialState: "START",
@@ -107,7 +107,7 @@ describe("WorkflowDetailPanel", () => {
       refetch: vi.fn(),
     } as unknown as ReturnType<typeof useWorkflowDetail>);
     renderPanel({ workflowId: null });
-    expect(screen.getByText("좌측 목록에서 응대 흐름을 선택해 주세요.")).toBeInTheDocument();
+    expect(screen.getByText("좌측 목록에서 워크플로우를 선택해 주세요.")).toBeInTheDocument();
   });
 
   it("loading 상태에서는 skeleton 영역을 렌더링한다", () => {
@@ -119,7 +119,7 @@ describe("WorkflowDetailPanel", () => {
       refetch: vi.fn(),
     } as unknown as ReturnType<typeof useWorkflowDetail>);
     renderPanel();
-    expect(screen.getByRole("region", { name: "응대 흐름 상세" })).toBeInTheDocument();
+    expect(screen.getByRole("region", { name: "워크플로우 상세" })).toBeInTheDocument();
   });
 
   it("error 상태에서는 에러 메시지와 재시도 버튼을 보여준다", async () => {
@@ -144,7 +144,7 @@ describe("WorkflowDetailPanel", () => {
     await waitFor(() => expect(toast.error).toHaveBeenCalledWith("서버 오류"));
   });
 
-  it("404 error 시 응대 흐름 미존재 메시지로 toast를 호출한다", async () => {
+  it("404 error 시 워크플로우 미존재 메시지로 toast를 호출한다", async () => {
     const err = new ApiRequestError(404, "NOT_FOUND", "없음");
     mockedUseWorkflowDetail.mockReturnValue({
       data: undefined,
@@ -154,7 +154,7 @@ describe("WorkflowDetailPanel", () => {
       refetch: vi.fn(),
     } as unknown as ReturnType<typeof useWorkflowDetail>);
     renderPanel();
-    await waitFor(() => expect(toast.error).toHaveBeenCalledWith("응대 흐름을 찾을 수 없습니다."));
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith("워크플로우를 찾을 수 없습니다."));
   });
 
   it("성공 상태에서는 헤더 정보와 탭 목록을 보여준다", () => {
@@ -167,7 +167,7 @@ describe("WorkflowDetailPanel", () => {
     } as unknown as ReturnType<typeof useWorkflowDetail>);
     renderPanel();
     expect(screen.getByText("W001")).toBeInTheDocument();
-    expect(screen.getByText("테스트 응대 흐름")).toBeInTheDocument();
+    expect(screen.getByText("테스트 워크플로우")).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "흐름도" })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "JSON" })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "상세 정보" })).toBeInTheDocument();

--- a/frontend/src/features/workflow-draft-read/ui/WorkflowDetailPanel.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/WorkflowDetailPanel.tsx
@@ -120,7 +120,7 @@ export function WorkflowDetailPanel({
     if (!isError) return;
     const msg =
       apiErrorStatus === 404
-        ? "응대 흐름을 찾을 수 없습니다."
+        ? "워크플로우를 찾을 수 없습니다."
         : apiErrorCode === "WORKFLOW_GRAPH_JSON_INVALID"
           ? "흐름도 데이터가 손상되어 표시할 수 없습니다."
           : apiErrorMessage || "상세 정보를 불러오지 못했습니다.";
@@ -143,9 +143,9 @@ export function WorkflowDetailPanel({
 
   if (workflowId === null) {
     return (
-      <section className={styles.panel} aria-label="응대 흐름 상세">
+      <section className={styles.panel} aria-label="워크플로우 상세">
         <div className={styles.placeholder}>
-          <span>좌측 목록에서 응대 흐름을 선택해 주세요.</span>
+          <span>좌측 목록에서 워크플로우를 선택해 주세요.</span>
         </div>
       </section>
     );
@@ -153,7 +153,7 @@ export function WorkflowDetailPanel({
 
   if (isLoading) {
     return (
-      <section className={styles.panel} aria-label="응대 흐름 상세">
+      <section className={styles.panel} aria-label="워크플로우 상세">
         <div className={styles.body}>
           <div className={styles.skeleton} />
         </div>
@@ -163,7 +163,7 @@ export function WorkflowDetailPanel({
 
   if (isError) {
     return (
-      <section className={styles.panel} aria-label="응대 흐름 상세">
+      <section className={styles.panel} aria-label="워크플로우 상세">
         <div className={styles.placeholder}>
           <span>상세 정보를 불러오지 못했습니다.</span>
           <button type="button" className={styles.retryButton} onClick={() => void refetch()}>
@@ -177,9 +177,9 @@ export function WorkflowDetailPanel({
   if (!detail) return null;
 
   return (
-    <section className={styles.panel} aria-label="응대 흐름 상세">
+    <section className={styles.panel} aria-label="워크플로우 상세">
       <DetailHeader detail={detail} onEdit={onEdit} />
-      <nav className={styles.tabs} role="tablist" aria-label="응대 흐름 상세 뷰">
+      <nav className={styles.tabs} role="tablist" aria-label="워크플로우 상세 뷰">
         {TABS.map((t, i) => (
           <button
             key={t}

--- a/frontend/src/features/workflow-draft-read/ui/WorkflowListPanel.test.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/WorkflowListPanel.test.tsx
@@ -16,7 +16,7 @@ const mockedUseWorkflowList = vi.mocked(useWorkflowList);
 const stubWorkflow = {
   id: 1,
   workflowCode: "W001",
-  name: "테스트 응대 흐름",
+  name: "테스트 워크플로우",
   description: null,
   initialState: "START",
   terminalStatesJson: '["DONE", "CANCEL"]',
@@ -49,11 +49,11 @@ describe("WorkflowListPanel", () => {
       refetch: vi.fn(),
     } as unknown as ReturnType<typeof useWorkflowList>);
     renderPanel();
-    expect(screen.getByLabelText("응대 흐름 목록")).toBeInTheDocument();
+    expect(screen.getByLabelText("워크플로우 목록")).toBeInTheDocument();
     expect(screen.getByText("—개")).toBeInTheDocument();
   });
 
-  it("success 상태에서는 응대 흐름 목록과 항목 수를 렌더링한다", () => {
+  it("success 상태에서는 워크플로우 목록과 항목 수를 렌더링한다", () => {
     mockedUseWorkflowList.mockReturnValue({
       isLoading: false,
       isError: false,
@@ -65,7 +65,7 @@ describe("WorkflowListPanel", () => {
     renderPanel();
     expect(screen.getByText("1개")).toBeInTheDocument();
     expect(screen.getByText("W001")).toBeInTheDocument();
-    expect(screen.getByText("테스트 응대 흐름")).toBeInTheDocument();
+    expect(screen.getByText("테스트 워크플로우")).toBeInTheDocument();
   });
 
   it("success 상태에서 항목 클릭 시 onSelect를 호출한다", () => {
@@ -93,7 +93,7 @@ describe("WorkflowListPanel", () => {
       refetch: vi.fn(),
     } as unknown as ReturnType<typeof useWorkflowList>);
     renderPanel();
-    expect(screen.getByText("해당 버전에 등록된 응대 흐름 초안이 없습니다.")).toBeInTheDocument();
+    expect(screen.getByText("해당 버전에 등록된 워크플로우 초안이 없습니다.")).toBeInTheDocument();
   });
 
   it("error 상태에서는 에러 메시지와 재시도 버튼을 보여준다", () => {

--- a/frontend/src/features/workflow-draft-read/ui/WorkflowListPanel.tsx
+++ b/frontend/src/features/workflow-draft-read/ui/WorkflowListPanel.tsx
@@ -40,9 +40,9 @@ export function WorkflowListPanel({
   }, [isError, errorMessage]);
 
   return (
-    <aside className={styles.panel} aria-label="응대 흐름 목록">
+    <aside className={styles.panel} aria-label="워크플로우 목록">
       <header className={styles.header}>
-        <span className={styles.headerTitle}>응대 흐름</span>
+        <span className={styles.headerTitle}>워크플로우</span>
         <span className={styles.headerMeta}>
           {isSuccess ? `${data.length}개` : "—개"}
         </span>
@@ -68,7 +68,7 @@ export function WorkflowListPanel({
 
         {isSuccess && data.length === 0 && (
           <div className={styles.emptyState}>
-            <span>해당 버전에 등록된 응대 흐름 초안이 없습니다.</span>
+            <span>해당 버전에 등록된 워크플로우 초안이 없습니다.</span>
           </div>
         )}
 

--- a/frontend/src/features/workflow-list/ui/WorkflowListView.tsx
+++ b/frontend/src/features/workflow-list/ui/WorkflowListView.tsx
@@ -22,7 +22,7 @@ import { WorkflowSearchBar } from "./WorkflowSearchBar";
 import styles from "./workflow-list-view.module.css";
 
 const SORT_FIELD_KO_LABELS: Record<(typeof SORT_FIELD_OPTIONS)[number]["value"], string> = {
-  workflowCode: "응대 코드",
+  workflowCode: "워크플로우 코드",
   name: "이름",
 };
 
@@ -167,7 +167,7 @@ export function WorkflowListView({
       )}
 
       {pageEntries.length === 0 && (
-        <EmptyState message={filterWorkflowId !== null ? "필터 결과 없음" : "응대 흐름 없음"} />
+        <EmptyState message={filterWorkflowId !== null ? "필터 결과 없음" : "워크플로우 없음"} />
       )}
 
       <div className={styles.list} data-testid={`${testIdPrefix}-list`}>

--- a/frontend/src/features/workflow-list/ui/WorkflowSearchBar.tsx
+++ b/frontend/src/features/workflow-list/ui/WorkflowSearchBar.tsx
@@ -86,7 +86,7 @@ export function WorkflowSearchBar({
         onFocus={() => {
           if (query) setOpen(true);
         }}
-        placeholder="응대 흐름 검색"
+        placeholder="워크플로우 검색"
         data-testid={`${testIdPrefix}-input`}
         style={inputStyle}
       />

--- a/frontend/src/pages/consultation/ui/sections/MatchedWorkflowBar.test.tsx
+++ b/frontend/src/pages/consultation/ui/sections/MatchedWorkflowBar.test.tsx
@@ -72,7 +72,7 @@ describe("MatchedWorkflowBar", () => {
     expect(screen.getByText("진행 중")).toBeInTheDocument();
     expect(screen.getByText("의도 환불 요청")).toBeInTheDocument();
     expect(screen.getByTestId("matched-workflow-bar-meta")).toHaveTextContent(
-      "응대 코드 REFUND_FLOW · v12 · COLLECT_INFO",
+      "워크플로우 코드 REFUND_FLOW · v12 · COLLECT_INFO",
     );
     expect(screen.getByTestId("matched-workflow-bar-basis")).toHaveTextContent(
       "최근 AI 응답이 COLLECT_INFO 단계와 연결되어 표시 중입니다.",
@@ -137,7 +137,7 @@ describe("MatchedWorkflowBar", () => {
   it("falls back to literal label when both workflowName and workflowCode are null", () => {
     renderBar({ ...baseWorkflow, workflowName: null, workflowCode: null });
 
-    expect(screen.getByTestId("matched-workflow-bar-title")).toHaveTextContent("응대 흐름");
+    expect(screen.getByTestId("matched-workflow-bar-title")).toHaveTextContent("워크플로우");
   });
 
   it("shows graph unavailable placeholder when graphJson is missing (after hover)", () => {

--- a/frontend/src/pages/consultation/ui/sections/MatchedWorkflowBar.tsx
+++ b/frontend/src/pages/consultation/ui/sections/MatchedWorkflowBar.tsx
@@ -26,7 +26,7 @@ function resolveStatusTone(status: string | null): PillTone {
 
 function buildMeta(workflow: MatchedWorkflow): string {
   const parts: string[] = [];
-  if (workflow.workflowCode) parts.push(`응대 코드 ${workflow.workflowCode}`);
+  if (workflow.workflowCode) parts.push(`워크플로우 코드 ${workflow.workflowCode}`);
   if (workflow.domainPackVersionId != null) parts.push(`v${workflow.domainPackVersionId}`);
   if (workflow.currentState) parts.push(workflow.currentState);
   return parts.join(" · ");
@@ -46,7 +46,7 @@ function buildMatchBasis(workflow: MatchedWorkflow): string {
 export function MatchedWorkflowBar({ workflow }: MatchedWorkflowBarProps) {
   const navigate = useNavigate();
   const [previewOpen, setPreviewOpen] = useState(false);
-  const title = workflow.workflowName ?? workflow.workflowCode ?? "응대 흐름";
+  const title = workflow.workflowName ?? workflow.workflowCode ?? "워크플로우";
   const meta = buildMeta(workflow);
   const intentLabel = workflow.intentName ?? workflow.intentCode;
   const matchBasis = buildMatchBasis(workflow);
@@ -89,7 +89,7 @@ export function MatchedWorkflowBar({ workflow }: MatchedWorkflowBarProps) {
       className={styles.bar}
       data-testid="matched-workflow-bar"
       data-state={previewOpen ? "open" : "closed"}
-      aria-label="매칭된 응대 흐름"
+      aria-label="매칭된 워크플로우"
       onMouseEnter={() => setPreviewOpen(true)}
       onMouseLeave={handleMouseLeave}
       onFocusCapture={() => setPreviewOpen(true)}
@@ -102,7 +102,7 @@ export function MatchedWorkflowBar({ workflow }: MatchedWorkflowBarProps) {
         disabled={!canNavigate}
         data-testid="matched-workflow-bar-open"
       >
-        <span className={styles.label}>응대 흐름</span>
+        <span className={styles.label}>워크플로우</span>
         <span className={styles.title} data-testid="matched-workflow-bar-title">
           {title}
         </span>
@@ -157,7 +157,7 @@ export function MatchedWorkflowBarSkeleton() {
       className={styles.skeleton}
       data-testid="matched-workflow-bar-skeleton"
       aria-busy="true"
-      aria-label="매칭된 응대 흐름 로딩 중"
+      aria-label="매칭된 워크플로우 로딩 중"
     >
       <span className={styles.skeletonBar} />
     </div>

--- a/frontend/src/pages/domain-pack/ui/PackWorkflowListPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/PackWorkflowListPage.tsx
@@ -62,7 +62,7 @@ export function PackWorkflowListPage() {
     vId,
     packName,
     versionNo,
-    section: { label: "응대 흐름", path: "workflows" },
+    section: { label: "워크플로우", path: "workflows" },
   });
 
   const handleOpen = (entry: WorkspaceWorkflowEntry) => {
@@ -87,20 +87,20 @@ export function PackWorkflowListPage() {
           >
             <LoadingSpinner />
             <p style={{ color: "var(--ink)", fontSize: "14px" }}>
-              응대 흐름 목록을 불러오는 중입니다.
+              워크플로우 목록을 불러오는 중입니다.
             </p>
           </div>
         )}
 
         {!query.isLoading && query.isError && (
           <div data-testid="pack-workflows-error">
-            <ErrorState message="응대 흐름 목록을 불러오지 못했습니다." onRetry={query.refetch} />
+            <ErrorState message="워크플로우 목록을 불러오지 못했습니다." onRetry={query.refetch} />
           </div>
         )}
 
         {!query.isLoading && !query.isError && entries.length === 0 && (
           <div data-testid="pack-workflows-empty">
-            <EmptyState message="아직 등록된 응대 흐름이 없습니다." />
+            <EmptyState message="아직 등록된 워크플로우가 없습니다." />
           </div>
         )}
 

--- a/frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.test.tsx
+++ b/frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.test.tsx
@@ -280,7 +280,7 @@ describe("WorkflowDraftReadPage", () => {
 
     await waitFor(() =>
       expect(mockToastError).toHaveBeenCalledWith(
-        "응대 코드를 확인할 수 없어 수정 검토본을 만들 수 없습니다.",
+        "워크플로우 코드를 확인할 수 없어 수정 검토본을 만들 수 없습니다.",
       ),
     );
     expect(mockCreateRevisionDraft).not.toHaveBeenCalled();
@@ -322,7 +322,7 @@ describe("WorkflowDraftReadPage", () => {
 
     await waitFor(() =>
       expect(mockToastError).toHaveBeenCalledWith(
-        "수정 검토본에서 같은 응대 흐름을 찾지 못했습니다.",
+        "수정 검토본에서 같은 워크플로우를 찾지 못했습니다.",
       ),
     );
     expect(screen.getByTestId("location")).toHaveTextContent(
@@ -448,7 +448,7 @@ describe("WorkflowDraftReadPage", () => {
 
     await waitFor(() =>
       expect(mockToastError).toHaveBeenCalledWith(
-        "기존 검토본에서 같은 응대 흐름을 찾지 못했습니다.",
+        "기존 검토본에서 같은 워크플로우를 찾지 못했습니다.",
       ),
     );
     expect(screen.queryByText("진행 중인 검토본이 있습니다")).not.toBeInTheDocument();

--- a/frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.tsx
@@ -169,7 +169,7 @@ export function WorkflowDraftReadPage() {
       const draftWorkflowId = await findWorkflowIdByCode(draftVersionId, workflowCode);
 
       if (draftWorkflowId == null) {
-        toast.error("기존 검토본에서 같은 응대 흐름을 찾지 못했습니다.");
+        toast.error("기존 검토본에서 같은 워크플로우를 찾지 못했습니다.");
         return;
       }
 
@@ -205,7 +205,7 @@ export function WorkflowDraftReadPage() {
     }
 
     if (!workflow.workflowCode) {
-      toast.error("응대 코드를 확인할 수 없어 수정 검토본을 만들 수 없습니다.");
+      toast.error("워크플로우 코드를 확인할 수 없어 수정 검토본을 만들 수 없습니다.");
       return;
     }
 
@@ -215,21 +215,21 @@ export function WorkflowDraftReadPage() {
       await packQuery.refetch();
       const draftWorkflowId = await findWorkflowIdByCode(draftVersionId, workflow.workflowCode);
       if (draftWorkflowId === null) {
-        toast.error("수정 검토본에서 같은 응대 흐름을 찾지 못했습니다.");
+        toast.error("수정 검토본에서 같은 워크플로우를 찾지 못했습니다.");
         navigateToWorkflow(draftVersionId, null);
         return;
       }
       navigateToWorkflow(draftVersionId, draftWorkflowId);
       setIsEditing(true);
       setEditDirty(false);
-      toast.success("응대 흐름 수정 검토본이 생성되었습니다.");
+      toast.success("워크플로우 수정 검토본이 생성되었습니다.");
     } catch (error) {
       if (error instanceof ApiRequestError && error.code === "DOMAIN_PACK_DRAFT_ALREADY_EXISTS") {
         await resolveExistingDraft(workflow.workflowCode);
         return;
       }
       toast.error(
-        resolveWorkflowActionErrorMessage(error, "응대 흐름 수정 검토본 생성에 실패했습니다."),
+        resolveWorkflowActionErrorMessage(error, "워크플로우 수정 검토본 생성에 실패했습니다."),
       );
     } finally {
       setCreatingDraft(false);
@@ -257,7 +257,7 @@ export function WorkflowDraftReadPage() {
     vId: vId!,
     packName,
     versionNo,
-    section: { label: "응대 흐름", path: "workflows" },
+    section: { label: "워크플로우", path: "workflows" },
     selectedLabel: workflow?.workflowCode ?? (wfId !== null ? `#${wfId}` : null),
   });
 
@@ -283,7 +283,7 @@ export function WorkflowDraftReadPage() {
   } else {
     graphContent = (
       <div data-testid="workflow-empty-graph" style={{ padding: "32px" }}>
-        <EmptyState message="이 응대 흐름에는 아직 흐름도가 정의되어 있지 않습니다." />
+        <EmptyState message="이 워크플로우에는 아직 흐름도가 정의되어 있지 않습니다." />
       </div>
     );
   }
@@ -295,7 +295,7 @@ export function WorkflowDraftReadPage() {
           <div className={styles.titleGroup}>
             <div className={styles.titleStack}>
               <h2 data-testid="workflow-detail-title" className={styles.detailTitle}>
-                {workflow?.name || (query.isLoading ? "응대 흐름 로드 중..." : "응대 흐름")}
+                {workflow?.name || (query.isLoading ? "워크플로우 로드 중..." : "워크플로우")}
               </h2>
               {workflow?.description && (
                 <p className={styles.detailDescription}>{workflow.description}</p>
@@ -339,21 +339,21 @@ export function WorkflowDraftReadPage() {
         <div className={styles.canvasFrame} data-editing={isEditing ? "true" : "false"}>
           {!enabled && (
             <div data-testid="workflow-select-empty" className={styles.centerState}>
-              좌측 사이드바에서 응대 흐름을 선택하세요.
+              좌측 사이드바에서 워크플로우를 선택하세요.
             </div>
           )}
 
           {enabled && query.isLoading && (
             <div data-testid="workflow-loading" className={styles.loadingState}>
               <LoadingSpinner />
-              <Mono className={styles.loadingText}>응대 흐름 로드 중...</Mono>
+              <Mono className={styles.loadingText}>워크플로우 로드 중...</Mono>
             </div>
           )}
 
           {enabled && query.isError && (
             <div data-testid="workflow-error" className={styles.errorState}>
               <ErrorState
-                message="응대 흐름을 불러오지 못했습니다."
+                message="워크플로우를 불러오지 못했습니다."
                 onRetry={() => query.refetch()}
               />
             </div>

--- a/frontend/src/pages/domain-pack/ui/WorkflowGraphViewerPage.test.tsx
+++ b/frontend/src/pages/domain-pack/ui/WorkflowGraphViewerPage.test.tsx
@@ -177,7 +177,7 @@ describe("WorkflowGraphViewerPage", () => {
 
     renderPage();
     expect(screen.getByTestId("graph-data-error-state")).toHaveTextContent(
-      "응대 흐름도 데이터 형식이 올바르지 않습니다.",
+      "워크플로우 그래프 데이터 형식이 올바르지 않습니다.",
     );
     expect(screen.queryByTestId("empty-state")).not.toBeInTheDocument();
   });

--- a/frontend/src/pages/domain-pack/ui/WorkflowGraphViewerPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/WorkflowGraphViewerPage.tsx
@@ -76,7 +76,7 @@ export function WorkflowGraphViewerPage() {
 
   useEffect(() => {
     if (error) {
-      toast.error("응대 흐름 데이터를 불러오지 못했습니다.");
+      toast.error("워크플로우 데이터를 불러오지 못했습니다.");
     }
   }, [error]);
 
@@ -88,10 +88,10 @@ export function WorkflowGraphViewerPage() {
           vId: vsId,
           packName,
           versionNo,
-          section: { label: "응대 흐름", path: "workflows" },
+          section: { label: "워크플로우", path: "workflows" },
           selectedLabel: data?.workflowCode ?? (wfId !== null ? `#${wfId} 흐름도` : "흐름도"),
         })
-      : ["도메인팩 관리", "응대 흐름도"];
+      : ["도메인팩 관리", "워크플로우 그래프"];
 
   const listPath =
     wsId !== null && pkId !== null
@@ -103,7 +103,7 @@ export function WorkflowGraphViewerPage() {
       : null;
 
   const pageTitle =
-    data?.name ?? data?.workflowCode ?? (wfId !== null ? `응대 흐름 #${wfId}` : "응대 흐름도");
+    data?.name ?? data?.workflowCode ?? (wfId !== null ? `워크플로우 #${wfId}` : "워크플로우 그래프");
 
   const shell = (children: ReactNode) => (
     <OstoneShell active="workflows" crumbs={crumbs}>
@@ -152,7 +152,7 @@ export function WorkflowGraphViewerPage() {
     return shell(
       <div data-testid="loading-state" className={styles.loadingState}>
         <LoadingSpinner />
-        <span className={styles.loadingText}>응대 흐름 데이터를 불러오는 중...</span>
+        <span className={styles.loadingText}>워크플로우 데이터를 불러오는 중...</span>
       </div>,
     );
   }
@@ -172,7 +172,7 @@ export function WorkflowGraphViewerPage() {
   if (graphResult.status === "invalid") {
     return shell(
       <div data-testid="graph-data-error-state" className={styles.centerState}>
-        <ErrorState message="응대 흐름도 데이터 형식이 올바르지 않습니다." />
+        <ErrorState message="워크플로우 그래프 데이터 형식이 올바르지 않습니다." />
       </div>,
     );
   }
@@ -180,7 +180,7 @@ export function WorkflowGraphViewerPage() {
   if (graphResult.status === "empty") {
     return shell(
       <div data-testid="empty-state" className={styles.centerState}>
-        <EmptyState message="표시할 응대 흐름도가 없습니다." />
+        <EmptyState message="표시할 워크플로우 그래프가 없습니다." />
       </div>,
     );
   }

--- a/frontend/src/pages/domain-pack/ui/sections/PackHeader.tsx
+++ b/frontend/src/pages/domain-pack/ui/sections/PackHeader.tsx
@@ -59,7 +59,7 @@ export function PackHeader() {
           { label: "필요 정보", count: 14 },
           { label: "응대 기준", count: 9 },
           { label: "주의 사항", count: 6 },
-          { label: "응대 흐름", count: 3 },
+          { label: "워크플로우", count: 3 },
         ].map((meta) => (
           <div key={meta.label} style={{ display: "inline-flex", gap: "4px" }}>
             <Mono style={{ color: "var(--ink-3)", fontSize: "11px" }}>{meta.label}</Mono>

--- a/frontend/src/pages/domain-pack/ui/sections/PackTabs.tsx
+++ b/frontend/src/pages/domain-pack/ui/sections/PackTabs.tsx
@@ -5,7 +5,7 @@ const TABS = [
   { label: "필요 정보", count: 2 },
   { label: "응대 기준", count: 4 },
   { label: "주의 사항", count: 5 },
-  { label: "응대 흐름", count: 3 },
+  { label: "워크플로우", count: 3 },
   { label: "테스트", count: 0 },
   { label: "버전 기록", count: null },
 ];

--- a/frontend/src/pages/workspace/ui/WorkspaceWorkflowsPage.test.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceWorkflowsPage.test.tsx
@@ -67,10 +67,10 @@ describe("WorkspaceWorkflowsPage", () => {
   });
 
   it("error 상태에서는 ErrorState를 보여준다", () => {
-    mockHook.mockReturnValue({ loading: false, error: "응대 흐름 목록 조회 실패", entries: [] });
+    mockHook.mockReturnValue({ loading: false, error: "워크플로우 목록 조회 실패", entries: [] });
     renderPage();
     expect(screen.getByTestId("workspace-workflows-error")).toBeInTheDocument();
-    expect(screen.getByText("응대 흐름 목록 조회 실패")).toBeInTheDocument();
+    expect(screen.getByText("워크플로우 목록 조회 실패")).toBeInTheDocument();
   });
 
   it("entries 비어 있으면 empty state를 보여준다", () => {
@@ -79,7 +79,7 @@ describe("WorkspaceWorkflowsPage", () => {
     expect(screen.getByTestId("workspace-workflows-empty")).toBeInTheDocument();
     expect(
       screen.getByText(
-        "아직 등록된 응대 흐름이 없습니다. 응대 흐름은 도메인팩에서 생성하고 관리합니다.",
+        "아직 등록된 워크플로우가 없습니다. 워크플로우는 도메인팩에서 생성하고 관리합니다.",
       ),
     ).toBeInTheDocument();
   });

--- a/frontend/src/pages/workspace/ui/WorkspaceWorkflowsPage.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceWorkflowsPage.tsx
@@ -44,7 +44,7 @@ export function WorkspaceWorkflowsPage() {
   return (
     <div className={styles.pageWrapper}>
       <div className={styles.pageHeader}>
-        <h1 className={styles.pageTitle}>응대 흐름</h1>
+        <h1 className={styles.pageTitle}>워크플로우</h1>
         <Button variant="outline" size="sm" onClick={handleOpenDomainPacks}>
           <span>도메인팩 관리</span>
           <ArrowRightIcon className={styles.pageHeaderIcon} />
@@ -54,7 +54,7 @@ export function WorkspaceWorkflowsPage() {
       {loading && (
         <div className={styles.statePanel} data-testid="workspace-workflows-loading">
           <LoadingSpinner />
-          <p className={styles.stateText}>응대 흐름 목록을 불러오는 중입니다.</p>
+          <p className={styles.stateText}>워크플로우 목록을 불러오는 중입니다.</p>
         </div>
       )}
 
@@ -66,7 +66,7 @@ export function WorkspaceWorkflowsPage() {
 
       {!loading && !error && entries.length === 0 && (
         <div className={styles.statePanel} data-testid="workspace-workflows-empty">
-          <EmptyState message="아직 등록된 응대 흐름이 없습니다. 응대 흐름은 도메인팩에서 생성하고 관리합니다." />
+          <EmptyState message="아직 등록된 워크플로우가 없습니다. 워크플로우는 도메인팩에서 생성하고 관리합니다." />
           <Button variant="outline" size="sm" onClick={handleOpenDomainPacks}>
             <span>도메인팩으로 이동</span>
             <ArrowRightIcon className={styles.pageHeaderIcon} />

--- a/frontend/src/shared/lib/domainPackRoutes.ts
+++ b/frontend/src/shared/lib/domainPackRoutes.ts
@@ -5,7 +5,7 @@ export const SECTION_LABEL: Record<DomainPackSection, string> = {
   slots: "확인 항목",
   policies: "응대 기준",
   risks: "주의 사항",
-  workflows: "응대 흐름",
+  workflows: "워크플로우",
 };
 
 export interface DomainPackCrumbInput {

--- a/frontend/src/shared/lib/workflowSettings.ts
+++ b/frontend/src/shared/lib/workflowSettings.ts
@@ -31,7 +31,7 @@ const PAGE_KEY = "ostone:page:workflow-settings";
 export const PAGE_SIZE_OPTIONS = [6, 12, 24] as const;
 export const TOP_N_OPTIONS = [3, 5, 10, 20] as const;
 export const SORT_FIELD_OPTIONS: ReadonlyArray<{ value: WorkflowSortField; label: string }> = [
-  { value: "workflowCode", label: "응대 코드" },
+  { value: "workflowCode", label: "워크플로우 코드" },
   { value: "name", label: "이름" },
 ];
 export const SORT_DIR_OPTIONS: ReadonlyArray<{ value: SortDir; label: string }> = [

--- a/frontend/src/shared/ui/layout/DashboardLayout.tsx
+++ b/frontend/src/shared/ui/layout/DashboardLayout.tsx
@@ -33,7 +33,7 @@ export const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children }) =>
       {/* Top Navbar */}
       <header className={styles.topbar}>
         <div className={styles.logo}>
-          <span className={styles.logoHighlight}>Ostone</span> 응대 흐름
+          <span className={styles.logoHighlight}>Ostone</span> 워크플로우
         </div>
         <nav className={styles.navMenu}>
           <NavLink to="/workspaces" className={getNavLinkClass}>

--- a/frontend/src/widgets/ostone-shell/ui/OstoneShell.test.tsx
+++ b/frontend/src/widgets/ostone-shell/ui/OstoneShell.test.tsx
@@ -62,7 +62,7 @@ describe("OstoneShell", () => {
 
     expect(screen.getByText("WS · 1")).toBeInTheDocument();
     expect(screen.getAllByText("도메인팩 관리")).toHaveLength(2);
-    expect(screen.getByText("응대 흐름")).toBeInTheDocument();
+    expect(screen.getByText("워크플로우")).toBeInTheDocument();
   });
 
   it("renders children in main area", () => {

--- a/frontend/src/widgets/ostone-shell/ui/OstoneShell.tsx
+++ b/frontend/src/widgets/ostone-shell/ui/OstoneShell.tsx
@@ -22,7 +22,7 @@ interface SidebarBaseProps {
 }
 
 const TOP_LEVEL_CRUMB_BY_ACTIVE: Partial<Record<SidebarActive, string>> = {
-  workflows: "응대 흐름 관리",
+  workflows: "워크플로우 관리",
   upload: "상담 로그 수집",
   consult: "상담 응대",
   domain: "도메인팩 관리",
@@ -54,8 +54,8 @@ function resolveDisplayCrumbs(active: SidebarActive, crumbs: Crumb[]): Crumb[] {
 
   if (second === "Domain Packs") {
     const sectionMap: Record<string, string> = {
-      Workflows: "응대 흐름",
-      WORKFLOWS: "응대 흐름",
+      Workflows: "워크플로우",
+      WORKFLOWS: "워크플로우",
       Intents: "상담 유형",
       INTENTS: "상담 유형",
       Slots: "확인 항목",


### PR DESCRIPTION
## Summary
- 워크플로우 관련 사용자 노출 문구를 `응대 흐름`에서 `워크플로우`로 되돌렸습니다.
- 워크플로우 코드 라벨과 목록/상세/그래프/수정/미리보기 상태 문구를 함께 정리했습니다.
- 이슈 요구사항과 검증 기준을 `.agent/specs/457.md`에 정리했습니다.

## Validation
- `cd frontend && pnpm test`
- `cd frontend && pnpm build`
- `git diff --check`

## Notes
- `cd frontend && pnpm lint`는 변경 범위 밖의 기존 lint 오류 57개로 실패했습니다.

Closes #457

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **UI/UX 개선**
  * 애플리케이션 전반의 용어를 통일했습니다. 화면 텍스트, 버튼 라벨, 에러 메시지, 입력 필드 안내문 등 사용자 인터페이스의 "응대 흐름" 표기를 "워크플로우"로 변경했습니다.

* **테스트**
  * 업데이트된 UI 텍스트에 맞춰 테스트 코드를 수정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->