### PR TITLE
docs(spec): 데모 세션 상담 큐 반영 기준 정의

### DIFF
--- a/.agent/specs/402.md
+++ b/.agent/specs/402.md
@@ -1,0 +1,61 @@
+# Issue 402: 데모 채팅 세션 생성 상담 큐 반영
+
+## Goal
+
+데모 채팅에서 새 사용자가 세션을 시작하면 상담사 화면의 상담 큐에 해당 세션이 수동 새로고침 없이 반영되도록 한다.
+
+## Problem
+
+상담사 화면은 워크스페이스별 `/topic/workspaces.{workspaceId}.consultation.queue` 이벤트를 구독해 상담 큐를 갱신한다. 일반 사용자 세션 생성 경로는 세션 저장 후 `ConsultationQueueChangedEvent`를 발행하지만, 데모 채팅 세션 생성 경로가 동일한 큐 변경 계약을 지키지 않으면 새 데모 사용자가 상담 큐에 즉시 나타나지 않을 수 있다.
+
+## Scope
+
+- 데모 채팅 세션 생성 후 `SESSION_UPSERTED` 큐 이벤트가 발행된다.
+- 이벤트에는 생성된 세션의 `workspaceId`와 `sessionId`가 포함된다.
+- 기존 일반 사용자 세션 생성 경로와 상담 큐 이벤트 구독/전송 계약은 유지한다.
+- 데모 채팅의 최초 인사 메시지 저장, metadata 갱신, 응답 DTO 형식은 유지한다.
+
+## Non-Goals
+
+- 상담 큐 WebSocket topic 주소 또는 payload 형식을 변경하지 않는다.
+- 데모 채팅의 LLM 응답 생성, fallback 응답, 메시지 broadcast 정책을 변경하지 않는다.
+- 상담 큐 정렬, 필터, unread 정책을 변경하지 않는다.
+- 새로운 DB 컬럼, migration, API endpoint를 추가하지 않는다.
+
+## Affected Modules
+
+| Area | Path | Impact |
+| --- | --- | --- |
+| Backend application | `backend/src/main/java/com/init/chatdemo/application/DemoChatSessionRegistrationService.java` | 데모 세션 생성 후 상담 큐 upsert 이벤트 발행 계약을 보장 |
+| Backend domain event | `backend/src/main/java/com/init/workflowruntime/domain/event/ConsultationQueueChangedEvent.java` | 기존 큐 변경 이벤트 record 재사용 |
+| Backend domain event | `backend/src/main/java/com/init/workflowruntime/domain/event/ConsultationQueueEventType.java` | 기존 `SESSION_UPSERTED` 이벤트 타입 재사용 |
+| Backend application | `backend/src/main/java/com/init/workflowruntime/application/ConsultationQueueEventListener.java` | 트랜잭션 커밋 후 큐 event를 WebSocket topic으로 전송하는 기존 listener |
+| Backend test | `backend/src/test/java/com/init/chatdemo/application/DemoChatSessionRegistrationServiceTest.java` | 데모 세션 생성 시 큐 upsert 이벤트가 발행되는지 검증 |
+
+## Backend Requirements
+
+1. `DemoChatSessionRegistrationService#createSession(workspaceId, customerName)`은 세션과 최초 인사 메시지를 저장한 뒤 생성된 `ChatSession` 기준으로 `ConsultationQueueChangedEvent`를 발행한다.
+2. 발행되는 이벤트의 `workspaceId`는 요청 workspace id와 동일해야 한다.
+3. 발행되는 이벤트의 `sessionId`는 저장된 `ChatSession` id와 동일해야 한다.
+4. 발행되는 이벤트 type은 `ConsultationQueueEventType.SESSION_UPSERTED`여야 한다.
+5. 운영 중인 published domain pack version이 없거나 customer name이 blank인 기존 오류 흐름에서는 큐 이벤트를 발행하지 않는다.
+6. 일반 사용자 세션 생성 경로의 기존 큐 이벤트 발행 동작은 변경하지 않는다.
+
+## Acceptance Criteria
+
+1. 데모 채팅 세션 생성 성공 후 `ConsultationQueueChangedEvent`가 정확히 한 번 발행된다.
+2. 발행된 이벤트는 생성된 데모 세션의 workspace id, session id, `SESSION_UPSERTED` type을 가진다.
+3. `ConsultationQueueEventListener`는 기존처럼 해당 이벤트를 workspace 상담 큐 topic으로 전송할 수 있다.
+4. 상담사 화면은 해당 topic을 구독 중일 때 새 데모 사용자를 수동 새로고침 없이 큐에 반영할 수 있다.
+5. 일반 사용자 세션 생성 경로의 이벤트 발행 계약은 유지된다.
+
+## Validation Plan
+
+- Backend: `DemoChatSessionRegistrationServiceTest`에서 `createSession` 성공 후 `ApplicationEventPublisher#publishEvent`로 `ConsultationQueueChangedEvent`가 발행되는지 검증한다.
+- Backend: `DemoChatSessionRegistrationServiceTest`에서 published domain pack version 누락 또는 blank customer name 오류 흐름이 세션 생성과 큐 이벤트 발행으로 이어지지 않는지 확인한다.
+- Backend: 기존 `UserChatSessionServiceTest`로 일반 사용자 세션 생성 경로의 큐 이벤트 발행 계약이 유지되는지 확인한다.
+- Regression: `ConsultationQueueEventListenerTest`로 큐 이벤트가 workspace topic payload로 변환되는 기존 흐름이 유지되는지 확인한다.
+
+## Open Questions
+
+- 없음. 이 이슈는 데모 세션 생성 성공 직후 기존 큐 이벤트 계약을 적용하는 것으로 범위를 한정한다.


### PR DESCRIPTION
## Summary
- 데모 채팅 세션 생성 시 상담 큐 upsert 이벤트가 발행되어야 하는 요구사항을 `.agent/specs/402.md`에 정리했습니다.
- 관련 backend application, domain event, listener, regression test 경로와 검증 기준을 명확히 했습니다.
- 런타임 코드는 변경하지 않습니다. 현재 `main`의 데모 세션 큐 이벤트 발행 계약을 이슈 402 기준으로 문서화합니다.

## Validation
- `cd backend && GRADLE_USER_HOME=/tmp/ostone-gradle-402 mise exec -- ./gradlew test --tests com.init.chatdemo.application.DemoChatSessionRegistrationServiceTest --tests com.init.workflowruntime.application.UserChatSessionServiceTest --tests com.init.workflowruntime.application.ConsultationQueueEventListenerTest`

Closes #402