### PR TITLE
fix(infra): RDS와 GPU 리소스 생성 조합 안정화

### DIFF
--- a/infra/terraform/.terraform.lock.hcl
+++ b/infra/terraform/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = ">= 5.80.0, < 6.0.0"
   hashes = [
     "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
     "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
     "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
     "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
@@ -29,6 +30,7 @@ provider "registry.terraform.io/hashicorp/random" {
   constraints = ">= 3.6.0, < 4.0.0"
   hashes = [
     "h1:OO+IuvQJSPmWdN8AyyIEvPJbLvDQpgX/zbktoa9KsJE=",
+    "h1:UlBuNVuCGJ39tTv2c5gz2NRZnQbXfbIWbTzWcth5o74=",
     "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
     "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
     "zh:269eda8fe42daa7974d5a34d166c3ba9defe80cde86c01e4dadcfdf2e1f05e5f",

--- a/infra/terraform/db-bootstrap.tf
+++ b/infra/terraform/db-bootstrap.tf
@@ -133,6 +133,7 @@ resource "terraform_data" "db_bootstrap" {
     command = <<-EOT
       set -eu
       TASK_ARN=$(aws ecs run-task \
+        --region '${var.aws_region}' \
         --cluster '${aws_ecs_cluster.main.arn}' \
         --task-definition '${aws_ecs_task_definition.db_bootstrap.arn}' \
         --launch-type FARGATE \
@@ -151,15 +152,16 @@ resource "terraform_data" "db_bootstrap" {
         exit 1
       fi
 
-      aws ecs wait tasks-stopped --cluster '${aws_ecs_cluster.main.arn}' --tasks "$TASK_ARN"
+      aws ecs wait tasks-stopped --region '${var.aws_region}' --cluster '${aws_ecs_cluster.main.arn}' --tasks "$TASK_ARN"
       EXIT_CODE=$(aws ecs describe-tasks \
+        --region '${var.aws_region}' \
         --cluster '${aws_ecs_cluster.main.arn}' \
         --tasks "$TASK_ARN" \
         --query 'tasks[0].containers[0].exitCode' \
         --output text)
 
       if [ "$EXIT_CODE" != "0" ]; then
-        aws ecs describe-tasks --cluster '${aws_ecs_cluster.main.arn}' --tasks "$TASK_ARN" >&2
+        aws ecs describe-tasks --region '${var.aws_region}' --cluster '${aws_ecs_cluster.main.arn}' --tasks "$TASK_ARN" >&2
         exit 1
       fi
     EOT

--- a/infra/terraform/ecs-gpu.tf
+++ b/infra/terraform/ecs-gpu.tf
@@ -2,6 +2,22 @@ data "aws_ssm_parameter" "ecs_gpu_ami" {
   name = "/aws/service/ecs/optimized-ami/amazon-linux-2/gpu/recommended/image_id"
 }
 
+data "aws_ec2_instance_type_offerings" "gpu" {
+  location_type = "availability-zone"
+
+  filter {
+    name   = "instance-type"
+    values = [var.gpu_instance_type]
+  }
+}
+
+locals {
+  gpu_private_subnet_ids = [
+    for subnet in values(aws_subnet.private) : subnet.id
+    if contains(data.aws_ec2_instance_type_offerings.gpu.locations, subnet.availability_zone)
+  ]
+}
+
 resource "aws_iam_instance_profile" "gpu" {
   name = "${local.name_prefix}-gpu-instance-profile"
   role = aws_iam_role.gpu_ec2_instance.name
@@ -59,13 +75,20 @@ resource "aws_autoscaling_group" "gpu" {
     id      = aws_launch_template.gpu.id
     version = "$Latest"
   }
-  vpc_zone_identifier       = values(aws_subnet.private)[*].id
+  vpc_zone_identifier       = local.gpu_private_subnet_ids
   min_size                  = var.gpu_asg_min_size
   max_size                  = var.gpu_asg_max_size
   desired_capacity          = var.gpu_asg_desired_capacity
   health_check_type         = "EC2"
   health_check_grace_period = 300
   protect_from_scale_in     = false
+
+  lifecycle {
+    precondition {
+      condition     = length(local.gpu_private_subnet_ids) > 0
+      error_message = "gpu_instance_type must be offered in at least one selected private subnet availability zone."
+    }
+  }
 
   tag {
     key                 = "Name"

--- a/infra/terraform/ecs-llm.tf
+++ b/infra/terraform/ecs-llm.tf
@@ -138,7 +138,7 @@ resource "aws_ecs_service" "ml_llm" {
   }
 
   network_configuration {
-    subnets          = values(aws_subnet.private)[*].id
+    subnets          = local.gpu_private_subnet_ids
     security_groups  = [aws_security_group.ml_llm_service.id]
     assign_public_ip = false
   }

--- a/infra/terraform/rds.tf
+++ b/infra/terraform/rds.tf
@@ -26,14 +26,11 @@ resource "aws_db_parameter_group" "postgres" {
   }
 }
 
-resource "aws_db_option_group" "postgres" {
-  name                 = "${local.name_prefix}-postgres16"
-  engine_name          = "postgres"
-  major_engine_version = "16"
-
-  tags = {
-    Name = "${local.name_prefix}-postgres16"
-  }
+data "aws_rds_engine_version" "postgres" {
+  engine                 = "postgres"
+  version                = var.rds_engine_version
+  latest                 = true
+  parameter_group_family = "postgres16"
 }
 
 data "aws_iam_policy_document" "rds_enhanced_monitoring_assume_role" {
@@ -74,7 +71,7 @@ resource "aws_db_instance" "postgres" {
   identifier = "${local.name_prefix}-postgres"
 
   engine         = "postgres"
-  engine_version = var.rds_engine_version
+  engine_version = data.aws_rds_engine_version.postgres.version_actual
   instance_class = var.rds_instance_class
 
   allocated_storage     = var.rds_allocated_storage
@@ -90,7 +87,6 @@ resource "aws_db_instance" "postgres" {
   db_subnet_group_name   = aws_db_subnet_group.postgres.name
   vpc_security_group_ids = [aws_security_group.rds.id]
   parameter_group_name   = aws_db_parameter_group.postgres.name
-  option_group_name      = aws_db_option_group.postgres.name
 
   multi_az                              = var.rds_multi_az
   publicly_accessible                   = false

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -107,9 +107,14 @@ variable "airflow_db_password" {
 }
 
 variable "rds_engine_version" {
-  description = "PostgreSQL engine version for RDS."
+  description = "PostgreSQL 16 engine version selector for RDS. Use major version 16 to resolve the latest available regional 16.x version, or an exact available 16.x version."
   type        = string
-  default     = "16.4"
+  default     = "16"
+
+  validation {
+    condition     = can(regex("^16(\\.[0-9]+)?$", var.rds_engine_version))
+    error_message = "rds_engine_version must be 16 or an exact available PostgreSQL 16 minor version such as 16.8."
+  }
 }
 
 variable "rds_instance_class" {


### PR DESCRIPTION
## 변경 내용
- RDS PostgreSQL 16 엔진 버전을 리전에서 사용 가능한 최신 16.x 버전으로 조회해 생성하도록 변경했습니다.
- PostgreSQL에서 사용하지 않는 RDS option group 연결을 제거했습니다.
- GPU 인스턴스 타입이 제공되는 AZ의 private subnet만 GPU ASG와 LLM ECS 서비스에 사용하도록 제한했습니다.
- DB bootstrap ECS 작업의 AWS CLI 호출에 배포 리전을 명시했습니다.

## 확인 사항
- `terraform fmt -check -diff infra/terraform`
- `terraform -chdir=infra/terraform validate`
- `ostone` profile credential을 export한 임시 backend-less plan: `Plan: 161 to add, 0 to change, 0 to destroy`
- `aws rds describe-orderable-db-instance-options --profile ostone --region ap-northeast-2 --engine postgres --engine-version 16.14 --db-instance-class db.t4g.medium`로 gp3/Multi-AZ/Performance Insights 조합 확인
