### PR TITLE
fix(domain-pack): workflow 변경 내역을 요약에 표시

### DIFF
--- a/.agent/specs/404.md
+++ b/.agent/specs/404.md
@@ -1,0 +1,148 @@
+# Frontend FSD Spec: workflow 변경 요약 표시
+
+## Goal
+
+도메인 팩 수정 검토본에서 workflow 이름, 설명, 그래프 텍스트, 그래프 구조 변경을 intent 변경과 함께 변경 요약 및 도메인팩 정보 화면에 표시한다.
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A[운영 버전의 상담 유형 또는 응대 흐름 화면] --> B[수정 검토본 생성]
+    B --> C[검토본에서 intent 또는 workflow 수정]
+    C --> D[변경 요약 계산]
+    D --> E{변경된 구성 요소 존재?}
+    E -->|Yes| F[intent/workflow 변경 구분 표시]
+    E -->|No| G[변경 없음 표시]
+    F --> H[도메인팩 정보 화면에서 구성 변경 확인]
+    G --> H
+```
+
+## Design Diff
+
+### As-is vs To-be
+
+| 영역 | As-is | To-be | 변경 내용 |
+| --- | --- | --- | --- |
+| 변경 요약 계산 | `intentCode` 기준 intent name/description만 비교 | intent와 workflow를 함께 비교 | workflow 변경도 변경 있음 상태에 포함 |
+| workflow 변경 분류 | 표시 없음 | 이름, 설명, 그래프 텍스트, 그래프 구조로 구분 | 그래프 node/edge label 변경과 구조 변경을 분리 |
+| 도메인팩 정보 | `summaryJson`의 생성/품질/검토 필드 중심 표시 | revision diff가 확인되면 구성 변경 섹션 표시 | intent/workflow 변경 구성 요소를 구분 |
+| 변경 없음 상태 | intent 변경이 없으면 변경 없음 | intent와 workflow 모두 없을 때만 변경 없음 | workflow-only 수정도 변경 있음으로 처리 |
+
+## Component Tree
+
+```text
+IntentDraftReadPage
+├─ useIntentDraftReadController
+│  └─ useIntentRevisionSummary
+│     └─ buildDomainPackRevisionSummary
+└─ IntentRevisionDraftActions
+
+SummaryDetailPanel
+├─ useDomainPackRevisionSummary
+│  └─ buildDomainPackRevisionSummary
+└─ SummaryJsonCard
+   └─ 구성 변경 섹션
+```
+
+## API Integration
+
+### Endpoints
+
+| Method | Path | Description |
+| --- | --- | --- |
+| GET | `/api/v1/workspaces/:workspaceId/domain-packs/:packId/versions/:versionId/intents` | base/draft intent 목록 조회 |
+| GET | `/api/v1/workspaces/:workspaceId/domain-packs/:packId/versions/:versionId/workflows` | base/draft workflow 목록 조회 |
+| GET | `/api/v1/workspaces/:workspaceId/domain-packs/:packId/versions/:versionId/workflows/:workflowId` | workflow graphJson 포함 상세 조회 |
+
+### Query Key Pattern
+
+기존 generated endpoint 함수와 feature-local hook state를 사용한다. 새 서버 API나 generated 파일 직접 수정은 포함하지 않는다.
+
+## Data Flow
+
+```text
+base version intents/workflows
+        │
+        ├─ compare by intentCode / workflowCode
+        │
+draft version intents/workflows
+        │
+        ▼
+buildDomainPackRevisionSummary
+        │
+        ├─ IntentRevisionDraftActions: 변경된 구성 요소 개수
+        └─ SummaryJsonCard: intent/workflow 구성 변경 목록
+```
+
+## 수정 대상 파일
+
+| 파일 | 변경 유형 | 설명 |
+| --- | --- | --- |
+| `frontend/src/shared/lib/domainPackRevisionSummary.ts` | new | intent/workflow 변경 요약 계산 |
+| `frontend/src/features/intent-revision-draft/model/useIntentRevisionSummary.ts` | modify | workflow 상세를 함께 조회해 요약에 포함 |
+| `frontend/src/features/intent-revision-draft/api/intentRevisionDraftApi.ts` | modify | workflow list/detail generated API wrapper 추가 |
+| `frontend/src/features/intent-revision-draft/ui/IntentRevisionDraftActions.tsx` | modify | 변경된 구성 요소 수를 intent/workflow로 구분 |
+| `frontend/src/pages/domain-pack/model/useIntentDraftReadController.ts` | modify | workflow-only 변경도 적용 가능하게 판단 |
+| `frontend/src/features/domain-pack-summary-read/model/useDomainPackRevisionSummary.ts` | new | 도메인팩 정보 화면용 revision diff 조회 |
+| `frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.tsx` | modify | revision diff를 도메인팩 정보 카드에 전달 |
+| `frontend/src/features/domain-pack-summary-read/ui/SummaryJsonCard.tsx` | modify | 구성 변경 섹션 렌더링 |
+| `frontend/src/features/domain-pack-summary-read/ui/SummaryJsonCard.module.css` | modify | 구성 변경 목록 스타일 |
+
+## State Management
+
+- 서버 상태는 기존 generated API 함수로 조회한다.
+- 변경 요약은 저장하지 않고 화면에서 base/draft 버전을 비교해 계산한다.
+- workflow graph diff는 `graphJson` 상세 응답을 기준으로 계산한다.
+
+## Tests
+
+### Test Strategy
+
+| 구분 | 방법 | 도구 | 비고 |
+| --- | --- | --- | --- |
+| 단위 테스트 | diff builder 검증 | Vitest | workflow name/description/graph text/structure |
+| Hook 테스트 | 요약 조회 흐름 검증 | React Testing Library | intent와 workflow API 호출 |
+| 컴포넌트 테스트 | 도메인팩 정보 구성 변경 표시 | React Testing Library | intent/workflow 구분 렌더링 |
+
+### Test Scenarios
+
+#### Happy Path
+
+| # | 시나리오 | 사전 조건 | 조작 | 기대 결과 |
+| --- | --- | --- | --- | --- |
+| 1 | workflow 이름/설명 변경 | base/draft workflowCode 동일 | 요약 계산 | workflow 변경 필드에 이름/설명 표시 |
+| 2 | workflow graph label 변경 | node/edge 구조 동일, label 변경 | 요약 계산 | 그래프 텍스트 변경 표시 |
+| 3 | workflow graph 구조 변경 | node/edge 추가 또는 연결 변경 | 요약 계산 | 그래프 구조 변경 표시 |
+| 4 | workflow-only 변경 적용 | intent 변경 없음, workflow 변경 있음 | 검토본 적용 | 변경 있음으로 판단 |
+| 5 | 도메인팩 정보 확인 | revision draft source 존재 | 정보 화면 진입 | 구성 변경에 상담 유형/응대 흐름 구분 표시 |
+
+#### Error & Edge Cases
+
+| # | 시나리오 | 조작 | 기대 결과 |
+| --- | --- | --- | --- |
+| 1 | 변경 없음 | base/draft intent와 workflow 동일 | 변경된 구성 요소 없음 표시 |
+| 2 | base에 없는 draft workflow | 새 workflowCode만 존재 | diff 대상에서 제외 |
+| 3 | workflow 상세 조회 실패 | 상세 API 에러 | 요약 에러 표시 |
+
+## Non-goals
+
+- backend summaryJson 스키마 변경은 포함하지 않는다.
+- workflow 생성/삭제 diff 표시는 이번 범위에 포함하지 않는다.
+- generated API 파일 직접 수정은 포함하지 않는다.
+
+## Self-review
+
+### Pass 1: Issue Fidelity
+
+- workflow 이름/설명 변경 표시 요구를 포함했다.
+- workflow 그래프 node/edge 텍스트 및 구조 변경 표시 요구를 포함했다.
+- 도메인팩 정보 화면에서 intent/workflow 구성 요소를 구분하는 요구를 포함했다.
+- 변경 없음/변경 있음 상태가 workflow 수정에도 반영되는 요구를 포함했다.
+
+### Pass 2: Ostone Compliance
+
+- issue 번호만 사용한 `.agent/specs/404.md` 파일명이다.
+- 프론트엔드 FSD 템플릿을 기준으로 작성했다.
+- 참조한 파일과 디렉터리는 repository에서 존재를 확인했다.
+- feature 간 cross-slice import를 피하기 위해 공통 diff builder는 `frontend/src/shared/lib/`에 둔다.

--- a/frontend/src/features/domain-pack-summary-read/model/useDomainPackRevisionSummary.test.ts
+++ b/frontend/src/features/domain-pack-summary-read/model/useDomainPackRevisionSummary.test.ts
@@ -1,0 +1,136 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { listIntents } from "@/shared/api/generated/endpoints/intent-definition-controller/intent-definition-controller";
+import {
+  getWorkflow,
+  listWorkflows,
+} from "@/shared/api/generated/endpoints/workflow-definition-controller/workflow-definition-controller";
+import { useDomainPackRevisionSummary } from "./useDomainPackRevisionSummary";
+
+vi.mock("@/shared/api/generated/endpoints/intent-definition-controller/intent-definition-controller", () => ({
+  listIntents: vi.fn(),
+}));
+
+vi.mock(
+  "@/shared/api/generated/endpoints/workflow-definition-controller/workflow-definition-controller",
+  () => ({
+    getWorkflow: vi.fn(),
+    listWorkflows: vi.fn(),
+  }),
+);
+
+const mockedListIntents = vi.mocked(listIntents);
+const mockedListWorkflows = vi.mocked(listWorkflows);
+const mockedGetWorkflow = vi.mocked(getWorkflow);
+
+const revisionSummaryJson = JSON.stringify({
+  draftSource: {
+    type: "INTENT_REVISION",
+    baseVersionId: 3,
+    baseVersionNo: 1,
+  },
+});
+
+describe("useDomainPackRevisionSummary", () => {
+  beforeEach(() => {
+    mockedListIntents.mockReset();
+    mockedListWorkflows.mockReset();
+    mockedGetWorkflow.mockReset();
+  });
+
+  it("intent revision 출처가 아니면 idle 상태로 API를 호출하지 않는다", () => {
+    const { result } = renderHook(() =>
+      useDomainPackRevisionSummary({
+        workspaceId: 1,
+        packId: 2,
+        versionId: 4,
+        summaryJson: '{"draftSource":{"type":"PIPELINE"}}',
+      }),
+    );
+
+    expect(result.current).toEqual({ status: "idle" });
+    expect(mockedListIntents).not.toHaveBeenCalled();
+    expect(mockedListWorkflows).not.toHaveBeenCalled();
+    expect(mockedGetWorkflow).not.toHaveBeenCalled();
+  });
+
+  it("baseVersionId가 있는 revision draft는 intent와 workflow 변경 요약을 계산한다", async () => {
+    mockedListIntents
+      .mockResolvedValueOnce({
+        data: [{ id: 10, intentCode: "refund", name: "환불", description: "" }],
+      })
+      .mockResolvedValueOnce([
+        { id: 20, intentCode: "refund", name: "환불 문의", description: "새 설명" },
+      ]);
+    mockedListWorkflows
+      .mockResolvedValueOnce({ data: [{ id: 30, workflowCode: "refund-flow" }] })
+      .mockResolvedValueOnce([{ id: 40, workflowCode: "refund-flow" }]);
+    mockedGetWorkflow
+      .mockResolvedValueOnce({
+        data: {
+          id: 30,
+          workflowCode: "refund-flow",
+          name: "환불 흐름",
+          graphJson: JSON.stringify({
+            nodes: [{ id: "start", type: "START", label: "접수" }],
+            edges: [],
+          }),
+        },
+      })
+      .mockResolvedValueOnce({
+        id: 40,
+        workflowCode: "refund-flow",
+        name: "환불 흐름",
+        graphJson: JSON.stringify({
+          nodes: [{ id: "start", type: "START", label: "상담 접수" }],
+          edges: [],
+        }),
+      });
+
+    const { result } = renderHook(() =>
+      useDomainPackRevisionSummary({
+        workspaceId: 1,
+        packId: 2,
+        versionId: 4,
+        summaryJson: revisionSummaryJson,
+      }),
+    );
+
+    expect(result.current.status).toBe("loading");
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+    if (result.current.status !== "ready") throw new Error("summary not ready");
+    expect(result.current.data.changedIntents[0]).toMatchObject({
+      intentId: 20,
+      intentCode: "refund",
+      fields: ["name", "description"],
+    });
+    expect(result.current.data.changedWorkflows[0]).toMatchObject({
+      workflowId: 40,
+      workflowCode: "refund-flow",
+      fields: ["graphText"],
+    });
+    expect(mockedListWorkflows).toHaveBeenCalledWith(1, 2, 3, undefined, {
+      signal: expect.any(AbortSignal),
+    });
+  });
+
+  it("요약 조회 실패는 error 상태로 반환한다", async () => {
+    mockedListIntents.mockRejectedValueOnce(new Error("revision summary failed"));
+    mockedListWorkflows.mockResolvedValue([]);
+
+    const { result } = renderHook(() =>
+      useDomainPackRevisionSummary({
+        workspaceId: 1,
+        packId: 2,
+        versionId: 4,
+        summaryJson: revisionSummaryJson,
+      }),
+    );
+
+    await waitFor(() => expect(result.current.status).toBe("error"));
+    expect(result.current).toEqual({
+      status: "error",
+      message: "revision summary failed",
+    });
+  });
+});

--- a/frontend/src/features/domain-pack-summary-read/model/useDomainPackRevisionSummary.ts
+++ b/frontend/src/features/domain-pack-summary-read/model/useDomainPackRevisionSummary.ts
@@ -1,0 +1,148 @@
+import { useEffect, useMemo, useState } from "react";
+import { listIntents } from "@/shared/api/generated/endpoints/intent-definition-controller/intent-definition-controller";
+import {
+  getWorkflow,
+  listWorkflows,
+} from "@/shared/api/generated/endpoints/workflow-definition-controller/workflow-definition-controller";
+import type {
+  IntentDefinitionSummary,
+  WorkflowDefinitionDetail,
+  WorkflowDefinitionSummary,
+} from "@/shared/api/generated/zod";
+import { selectApiData } from "@/shared/api";
+import {
+  buildDomainPackRevisionSummary,
+  type IntentRevisionSummary,
+} from "@/shared/lib/domainPackRevisionSummary";
+
+export type DomainPackRevisionSummaryState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "ready"; data: IntentRevisionSummary }
+  | { status: "error"; message: string };
+
+function readRevisionBaseVersionId(summaryJson?: string | null): number | null {
+  if (!summaryJson) return null;
+
+  try {
+    const parsed: unknown = JSON.parse(summaryJson);
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return null;
+    const draftSource = (parsed as { draftSource?: unknown }).draftSource;
+    if (typeof draftSource !== "object" || draftSource === null || Array.isArray(draftSource)) {
+      return null;
+    }
+    const source = draftSource as Record<string, unknown>;
+    return source.type === "INTENT_REVISION" && typeof source.baseVersionId === "number"
+      ? source.baseVersionId
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchIntents(
+  workspaceId: number,
+  packId: number,
+  versionId: number,
+  options: { signal: AbortSignal },
+): Promise<IntentDefinitionSummary[]> {
+  const response = await listIntents(workspaceId, packId, versionId, options);
+  if (Array.isArray(response)) return response as IntentDefinitionSummary[];
+  return selectApiData<IntentDefinitionSummary[]>(response) ?? [];
+}
+
+async function fetchWorkflowDetails(
+  workspaceId: number,
+  packId: number,
+  versionId: number,
+  options: { signal: AbortSignal },
+): Promise<WorkflowDefinitionDetail[]> {
+  const response = await listWorkflows(workspaceId, packId, versionId, undefined, options);
+  const workflows = Array.isArray(response)
+    ? (response as WorkflowDefinitionSummary[])
+    : selectApiData<WorkflowDefinitionSummary[]>(response) ?? [];
+
+  return Promise.all(
+    workflows.flatMap((workflow) => {
+      if (typeof workflow.id !== "number") return [];
+      return getWorkflow(workspaceId, packId, versionId, workflow.id, options).then(
+        (detailResponse) =>
+          selectApiData<WorkflowDefinitionDetail>(detailResponse) ?? {
+            ...workflow,
+            id: workflow.id,
+          },
+      );
+    }),
+  );
+}
+
+export function useDomainPackRevisionSummary({
+  workspaceId,
+  packId,
+  versionId,
+  summaryJson,
+}: {
+  workspaceId: number;
+  packId: number;
+  versionId: number | null | undefined;
+  summaryJson?: string | null;
+}): DomainPackRevisionSummaryState {
+  const baseVersionId = readRevisionBaseVersionId(summaryJson);
+  const requestKey =
+    versionId != null && baseVersionId != null
+      ? `${workspaceId}:${packId}:${baseVersionId}:${versionId}:${summaryJson ?? ""}`
+      : null;
+  const [state, setState] = useState<{
+    requestKey: string | null;
+    value: DomainPackRevisionSummaryState;
+  }>({ requestKey: null, value: { status: "idle" } });
+
+  useEffect(() => {
+    if (requestKey === null || versionId == null || baseVersionId == null) return;
+
+    const controller = new AbortController();
+    const options = { signal: controller.signal };
+
+    Promise.all([
+      fetchIntents(workspaceId, packId, baseVersionId, options),
+      fetchIntents(workspaceId, packId, versionId, options),
+      fetchWorkflowDetails(workspaceId, packId, baseVersionId, options),
+      fetchWorkflowDetails(workspaceId, packId, versionId, options),
+    ])
+      .then(([baseIntents, draftIntents, baseWorkflows, draftWorkflows]) => {
+        if (controller.signal.aborted) return;
+        setState({
+          requestKey,
+          value: {
+            status: "ready",
+            data: buildDomainPackRevisionSummary({
+              baseIntents,
+              draftIntents,
+              baseWorkflows,
+              draftWorkflows,
+            }),
+          },
+        });
+      })
+      .catch((error: unknown) => {
+        if (controller.signal.aborted) return;
+        setState({
+          requestKey,
+          value: {
+            status: "error",
+            message:
+              error instanceof Error
+                ? error.message
+                : "도메인팩 변경 요약을 불러오지 못했습니다.",
+          },
+        });
+      });
+
+    return () => controller.abort();
+  }, [baseVersionId, packId, requestKey, versionId, workspaceId]);
+
+  return useMemo(() => {
+    if (requestKey === null) return { status: "idle" };
+    return state.requestKey === requestKey ? state.value : { status: "loading" };
+  }, [requestKey, state]);
+}

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/shared/ui/alert-dialog";
 import { SummaryJsonCard } from "./SummaryJsonCard";
 import { ComponentCountGrid } from "./ComponentCountGrid";
+import { useDomainPackRevisionSummary } from "../model/useDomainPackRevisionSummary";
 import styles from "./SummaryDetailPanel.module.css";
 
 interface SummaryDetailPanelProps {
@@ -61,6 +62,12 @@ export function SummaryDetailPanel({
     onApplyDraft != null && versionId != null && isDraftVersion && !isApplying && !isDiscarding;
   const canDiscardDraft =
     onDiscardDraft != null && versionId != null && isDraftVersion && !isApplying && !isDiscarding;
+  const revisionSummaryState = useDomainPackRevisionSummary({
+    workspaceId: wsId,
+    packId,
+    versionId,
+    summaryJson: v?.summaryJson,
+  });
 
   const handleConfirmDeploy = () => {
     if (!canDeploy) return;
@@ -319,7 +326,16 @@ export function SummaryDetailPanel({
         </AlertDialogContent>
       </AlertDialog>
 
-      <SummaryJsonCard summaryJson={v.summaryJson ?? ""} />
+      <SummaryJsonCard
+        summaryJson={v.summaryJson ?? ""}
+        revisionSummary={
+          revisionSummaryState.status === "ready" ? revisionSummaryState.data : undefined
+        }
+        isRevisionSummaryLoading={revisionSummaryState.status === "loading"}
+        revisionSummaryError={
+          revisionSummaryState.status === "error" ? revisionSummaryState.message : null
+        }
+      />
 
       <div>
         <div className={styles.sectionTitle}>구성요소</div>

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryJsonCard.module.css
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryJsonCard.module.css
@@ -154,6 +154,51 @@
   line-height: 1.55;
 }
 
+.changeList {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.changeList li {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 6px 10px;
+  padding: 9px 0;
+  border-bottom: 1px solid var(--divider-subtle);
+  color: var(--text-secondary);
+  font-size: var(--font-size-sm);
+  line-height: 1.45;
+}
+
+.changeList li:last-child {
+  border-bottom: none;
+}
+
+.changeList strong {
+  min-width: 0;
+  color: var(--text-primary);
+  font-weight: var(--font-weight-heading);
+  overflow-wrap: anywhere;
+}
+
+.changeType,
+.changeCode {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-label);
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+.changeList li > span:last-child {
+  grid-column: 2 / 4;
+  overflow-wrap: anywhere;
+}
+
 .jsonList {
   display: flex;
   flex-direction: column;

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryJsonCard.test.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryJsonCard.test.tsx
@@ -62,6 +62,68 @@ describe("SummaryJsonCard", () => {
     expect(screen.queryByText(/INTENT_REVISION/)).not.toBeInTheDocument();
   });
 
+  it("revision summary가 있으면 intent와 workflow 변경을 구성 변경으로 구분해 렌더링한다", () => {
+    render(
+      <SummaryJsonCard
+        summaryJson='{"draftSource":{"type":"INTENT_REVISION","baseVersionNo":2}}'
+        revisionSummary={{
+          changedIntents: [
+            {
+              intentId: 10,
+              intentCode: "refund",
+              name: "환불 문의",
+              fields: ["name"],
+              before: { name: "환불", description: "" },
+              after: { name: "환불 문의", description: "" },
+            },
+          ],
+          changedWorkflows: [
+            {
+              workflowId: 20,
+              workflowCode: "refund-flow",
+              name: "환불 응대 흐름",
+              fields: ["name", "graphText", "graphStructure"],
+              before: { name: "환불 흐름", description: "", nodeCount: 2, edgeCount: 1 },
+              after: { name: "환불 응대 흐름", description: "", nodeCount: 3, edgeCount: 2 },
+            },
+          ],
+          changedFieldCounts: { name: 1, description: 0 },
+          changedWorkflowFieldCounts: { name: 1, description: 0, graphText: 1, graphStructure: 1 },
+          changedByDraftIntentId: {},
+          changedByDraftWorkflowId: {},
+          totalChangedComponents: 2,
+        }}
+      />,
+    );
+
+    expect(screen.getByText("구성 변경")).toBeInTheDocument();
+    expect(screen.getByText("상담 유형")).toBeInTheDocument();
+    expect(screen.getByText("환불 문의")).toBeInTheDocument();
+    expect(screen.getByText("응대 흐름")).toBeInTheDocument();
+    expect(screen.getByText("환불 응대 흐름")).toBeInTheDocument();
+    expect(screen.getByText("이름, 그래프 텍스트, 그래프 구조")).toBeInTheDocument();
+  });
+
+  it("revision summary가 있고 변경된 구성 요소가 없으면 empty 문구를 렌더링한다", () => {
+    render(
+      <SummaryJsonCard
+        summaryJson='{"draftSource":{"type":"INTENT_REVISION","baseVersionNo":2}}'
+        revisionSummary={{
+          changedIntents: [],
+          changedWorkflows: [],
+          changedFieldCounts: { name: 0, description: 0 },
+          changedWorkflowFieldCounts: { name: 0, description: 0, graphText: 0, graphStructure: 0 },
+          changedByDraftIntentId: {},
+          changedByDraftWorkflowId: {},
+          totalChangedComponents: 0,
+        }}
+      />,
+    );
+
+    expect(screen.getByText("구성 변경")).toBeInTheDocument();
+    expect(screen.getByText("변경된 구성 요소가 없습니다.")).toBeInTheDocument();
+  });
+
   it("빈 JSON 객체는 '내용 없음'을 표시한다", () => {
     render(<SummaryJsonCard summaryJson="{}" />);
     expect(screen.getByText("내용 없음")).toBeInTheDocument();

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryJsonCard.test.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryJsonCard.test.tsx
@@ -124,6 +124,30 @@ describe("SummaryJsonCard", () => {
     expect(screen.getByText("변경된 구성 요소가 없습니다.")).toBeInTheDocument();
   });
 
+  it("revision summary 계산 중이면 구성 변경 로딩 문구를 렌더링한다", () => {
+    render(
+      <SummaryJsonCard
+        summaryJson='{"draftSource":{"type":"INTENT_REVISION","baseVersionNo":2}}'
+        isRevisionSummaryLoading
+      />,
+    );
+
+    expect(screen.getByText("구성 변경")).toBeInTheDocument();
+    expect(screen.getByText("변경 요약 계산 중")).toBeInTheDocument();
+  });
+
+  it("revision summary 조회 실패 문구를 구성 변경 영역에 렌더링한다", () => {
+    render(
+      <SummaryJsonCard
+        summaryJson='{"draftSource":{"type":"INTENT_REVISION","baseVersionNo":2}}'
+        revisionSummaryError="도메인팩 변경 요약을 불러오지 못했습니다."
+      />,
+    );
+
+    expect(screen.getByText("구성 변경")).toBeInTheDocument();
+    expect(screen.getByText("도메인팩 변경 요약을 불러오지 못했습니다.")).toBeInTheDocument();
+  });
+
   it("빈 JSON 객체는 '내용 없음'을 표시한다", () => {
     render(<SummaryJsonCard summaryJson="{}" />);
     expect(screen.getByText("내용 없음")).toBeInTheDocument();

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryJsonCard.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryJsonCard.tsx
@@ -152,12 +152,19 @@ interface SummaryJsonCardProps {
   revisionSummaryError?: string | null;
 }
 
+interface ReadableSummaryProps {
+  data: SummaryData;
+  revisionSummary?: IntentRevisionSummary;
+  isRevisionSummaryLoading: boolean;
+  revisionSummaryError: string | null;
+}
+
 export function SummaryJsonCard({
   summaryJson,
   revisionSummary,
   isRevisionSummaryLoading = false,
   revisionSummaryError = null,
-}: SummaryJsonCardProps) {
+}: Readonly<SummaryJsonCardProps>) {
   const [mode, setMode] = useState<"card" | "raw">("card");
 
   const parsed = useMemo(() => parseSummaryJson(summaryJson), [summaryJson]);
@@ -219,12 +226,7 @@ function ReadableSummary({
   revisionSummary,
   isRevisionSummaryLoading,
   revisionSummaryError,
-}: {
-  data: SummaryData;
-  revisionSummary?: IntentRevisionSummary;
-  isRevisionSummaryLoading: boolean;
-  revisionSummaryError: string | null;
-}) {
+}: Readonly<ReadableSummaryProps>) {
   const summary = buildSummary(data, revisionSummary);
   const hasRevisionSummary = revisionSummary !== undefined;
   const hasContent =
@@ -238,6 +240,12 @@ function ReadableSummary({
     revisionSummaryError;
 
   if (!hasContent) return <span className={styles.empty}>내용 없음</span>;
+
+  const revisionChangeContent = renderRevisionChangeContent({
+    changes: summary.revisionChanges,
+    isLoading: isRevisionSummaryLoading,
+    error: revisionSummaryError,
+  });
 
   return (
     <div className={styles.summaryLayout}>
@@ -279,24 +287,7 @@ function ReadableSummary({
         revisionSummaryError) && (
         <section className={styles.summarySection}>
           <h4 className={styles.summarySectionTitle}>구성 변경</h4>
-          {isRevisionSummaryLoading ? (
-            <span className={styles.empty}>변경 요약 계산 중</span>
-          ) : revisionSummaryError ? (
-            <span className={styles.empty}>{revisionSummaryError}</span>
-          ) : summary.revisionChanges.length === 0 ? (
-            <span className={styles.empty}>변경된 구성 요소가 없습니다.</span>
-          ) : (
-            <ul className={styles.changeList}>
-              {summary.revisionChanges.map((change) => (
-                <li key={`${change.type}-${change.code}`}>
-                  <span className={styles.changeType}>{change.type}</span>
-                  <strong>{change.name || change.code}</strong>
-                  <span className={styles.changeCode}>{change.code}</span>
-                  <span>{change.fields}</span>
-                </li>
-              ))}
-            </ul>
-          )}
+          {revisionChangeContent}
         </section>
       )}
 
@@ -314,13 +305,42 @@ function ReadableSummary({
   );
 }
 
+function renderRevisionChangeContent({
+  changes,
+  isLoading,
+  error,
+}: Readonly<{
+  changes: RevisionChangeItem[];
+  isLoading: boolean;
+  error: string | null;
+}>) {
+  if (isLoading) return <span className={styles.empty}>변경 요약 계산 중</span>;
+  if (error) return <span className={styles.empty}>{error}</span>;
+  if (changes.length === 0) {
+    return <span className={styles.empty}>변경된 구성 요소가 없습니다.</span>;
+  }
+
+  return (
+    <ul className={styles.changeList}>
+      {changes.map((change) => (
+        <li key={`${change.type}-${change.code}`}>
+          <span className={styles.changeType}>{change.type}</span>
+          <strong>{change.name || change.code}</strong>
+          <span className={styles.changeCode}>{change.code}</span>
+          <span>{change.fields}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
 function StructuredJsonView({
   parsed,
   raw,
-}: {
+}: Readonly<{
   parsed: ReturnType<typeof parseSummaryJson>;
   raw: string;
-}) {
+}>) {
   if (!parsed.ok) {
     return (
       <pre className={styles.rawPre}>
@@ -344,7 +364,7 @@ function StructuredJsonView({
   );
 }
 
-function JsonValue({ value }: { value: unknown }) {
+function JsonValue({ value }: Readonly<{ value: unknown }>) {
   if (isRecord(value) || Array.isArray(value)) {
     return <code className={styles.jsonCode}>{JSON.stringify(value, null, 2)}</code>;
   }

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryJsonCard.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryJsonCard.tsx
@@ -1,4 +1,8 @@
 import { useState, useMemo } from "react";
+import type {
+  IntentRevisionSummary,
+  WorkflowRevisionChangedField,
+} from "@/shared/lib/domainPackRevisionSummary";
 import { parseSummaryJson } from "../model/parseSummaryJson";
 import styles from "./SummaryJsonCard.module.css";
 
@@ -7,6 +11,13 @@ type SummaryData = Record<string, unknown>;
 interface SummaryItem {
   label: string;
   value: string;
+}
+
+interface RevisionChangeItem {
+  type: "상담 유형" | "응대 흐름";
+  code: string;
+  name: string;
+  fields: string;
 }
 
 function renderValue(v: unknown): string {
@@ -66,7 +77,32 @@ function readStringList(value: unknown): string[] {
     .filter((item): item is string => Boolean(item));
 }
 
-function buildSummary(data: SummaryData) {
+function workflowFieldLabel(field: WorkflowRevisionChangedField): string {
+  if (field === "graphText") return "그래프 텍스트";
+  if (field === "graphStructure") return "그래프 구조";
+  if (field === "name") return "이름";
+  return "설명";
+}
+
+function buildRevisionChanges(summary?: IntentRevisionSummary): RevisionChangeItem[] {
+  if (!summary) return [];
+  return [
+    ...summary.changedIntents.map((change) => ({
+      type: "상담 유형" as const,
+      code: change.intentCode,
+      name: change.name,
+      fields: change.fields.map((field) => (field === "name" ? "이름" : "설명")).join(", "),
+    })),
+    ...summary.changedWorkflows.map((change) => ({
+      type: "응대 흐름" as const,
+      code: change.workflowCode,
+      name: change.name,
+      fields: change.fields.map(workflowFieldLabel).join(", "),
+    })),
+  ];
+}
+
+function buildSummary(data: SummaryData, revisionSummary?: IntentRevisionSummary) {
   const topic = typeof data.topic === "string" ? data.topic.trim() : "";
   const source = firstValue(data, [["generation", "source"], ["source"], ["sourceType"]]);
   const clusterCount = firstValue(data, [["generation", "clusterCount"], ["clusterCount"]]);
@@ -104,15 +140,24 @@ function buildSummary(data: SummaryData) {
     ...readStringList(firstValue(data, [["review", "topIssues"], ["topIssues"]])),
     ...readStringList(firstValue(data, [["review", "issues"], ["issues"]])),
   ];
+  const revisionChanges = buildRevisionChanges(revisionSummary);
 
-  return { topic, highlights, metrics, issues };
+  return { topic, highlights, metrics, issues, revisionChanges };
 }
 
 interface SummaryJsonCardProps {
   summaryJson: string;
+  revisionSummary?: IntentRevisionSummary;
+  isRevisionSummaryLoading?: boolean;
+  revisionSummaryError?: string | null;
 }
 
-export function SummaryJsonCard({ summaryJson }: SummaryJsonCardProps) {
+export function SummaryJsonCard({
+  summaryJson,
+  revisionSummary,
+  isRevisionSummaryLoading = false,
+  revisionSummaryError = null,
+}: SummaryJsonCardProps) {
   const [mode, setMode] = useState<"card" | "raw">("card");
 
   const parsed = useMemo(() => parseSummaryJson(summaryJson), [summaryJson]);
@@ -149,7 +194,12 @@ export function SummaryJsonCard({ summaryJson }: SummaryJsonCardProps) {
               </p>
             )}
             {parsed.ok ? (
-              <ReadableSummary data={parsed.data} />
+              <ReadableSummary
+                data={parsed.data}
+                revisionSummary={revisionSummary}
+                isRevisionSummaryLoading={isRevisionSummaryLoading}
+                revisionSummaryError={revisionSummaryError}
+              />
             ) : (
               <pre className={styles.rawPre}>
                 <code>{parsed.raw}</code>
@@ -164,13 +214,28 @@ export function SummaryJsonCard({ summaryJson }: SummaryJsonCardProps) {
   );
 }
 
-function ReadableSummary({ data }: { data: SummaryData }) {
-  const summary = buildSummary(data);
+function ReadableSummary({
+  data,
+  revisionSummary,
+  isRevisionSummaryLoading,
+  revisionSummaryError,
+}: {
+  data: SummaryData;
+  revisionSummary?: IntentRevisionSummary;
+  isRevisionSummaryLoading: boolean;
+  revisionSummaryError: string | null;
+}) {
+  const summary = buildSummary(data, revisionSummary);
+  const hasRevisionSummary = revisionSummary !== undefined;
   const hasContent =
     summary.topic ||
     summary.highlights.length > 0 ||
     summary.metrics.length > 0 ||
-    summary.issues.length > 0;
+    summary.issues.length > 0 ||
+    summary.revisionChanges.length > 0 ||
+    hasRevisionSummary ||
+    isRevisionSummaryLoading ||
+    revisionSummaryError;
 
   if (!hasContent) return <span className={styles.empty}>내용 없음</span>;
 
@@ -205,6 +270,33 @@ function ReadableSummary({ data }: { data: SummaryData }) {
               </div>
             ))}
           </div>
+        </section>
+      )}
+
+      {(summary.revisionChanges.length > 0 ||
+        hasRevisionSummary ||
+        isRevisionSummaryLoading ||
+        revisionSummaryError) && (
+        <section className={styles.summarySection}>
+          <h4 className={styles.summarySectionTitle}>구성 변경</h4>
+          {isRevisionSummaryLoading ? (
+            <span className={styles.empty}>변경 요약 계산 중</span>
+          ) : revisionSummaryError ? (
+            <span className={styles.empty}>{revisionSummaryError}</span>
+          ) : summary.revisionChanges.length === 0 ? (
+            <span className={styles.empty}>변경된 구성 요소가 없습니다.</span>
+          ) : (
+            <ul className={styles.changeList}>
+              {summary.revisionChanges.map((change) => (
+                <li key={`${change.type}-${change.code}`}>
+                  <span className={styles.changeType}>{change.type}</span>
+                  <strong>{change.name || change.code}</strong>
+                  <span className={styles.changeCode}>{change.code}</span>
+                  <span>{change.fields}</span>
+                </li>
+              ))}
+            </ul>
+          )}
         </section>
       )}
 

--- a/frontend/src/features/intent-revision-draft/api/intentRevisionDraftApi.test.ts
+++ b/frontend/src/features/intent-revision-draft/api/intentRevisionDraftApi.test.ts
@@ -9,6 +9,10 @@ import {
   listIntents,
 } from "@/shared/api/generated/endpoints/intent-definition-controller/intent-definition-controller";
 import { update } from "@/shared/api/generated/endpoints/update-draft-intent-controller/update-draft-intent-controller";
+import {
+  getWorkflow,
+  listWorkflows,
+} from "@/shared/api/generated/endpoints/workflow-definition-controller/workflow-definition-controller";
 import { intentRevisionDraftApi } from "./intentRevisionDraftApi";
 
 vi.mock(
@@ -47,12 +51,22 @@ vi.mock(
   }),
 );
 
+vi.mock(
+  "@/shared/api/generated/endpoints/workflow-definition-controller/workflow-definition-controller",
+  () => ({
+    getWorkflow: vi.fn(),
+    listWorkflows: vi.fn(),
+  }),
+);
+
 const mockedCreate = vi.mocked(create);
 const mockedActivate = vi.mocked(activate);
 const mockedDiscard = vi.mocked(discard);
 const mockedListIntents = vi.mocked(listIntents);
 const mockedGetIntent = vi.mocked(getIntent);
 const mockedUpdate = vi.mocked(update);
+const mockedListWorkflows = vi.mocked(listWorkflows);
+const mockedGetWorkflow = vi.mocked(getWorkflow);
 
 vi.mock("@/shared/api/generated/endpoints/domain-pack-controller/domain-pack-controller", () => ({
   getDomainPackVersion: vi.fn(),
@@ -68,6 +82,8 @@ describe("intentRevisionDraftApi", () => {
     mockedListIntents.mockReset();
     mockedGetIntent.mockReset();
     mockedUpdate.mockReset();
+    mockedListWorkflows.mockReset();
+    mockedGetWorkflow.mockReset();
     mockedWarn.mockClear();
   });
 
@@ -130,6 +146,35 @@ describe("intentRevisionDraftApi", () => {
     mockedListIntents.mockResolvedValue(intents as never);
 
     await expect(intentRevisionDraftApi.listIntents(1, 2, 3)).resolves.toEqual(intents);
+  });
+
+  it("workflow list/detail 응답을 unwrap하고 generated endpoint 옵션을 전달한다", async () => {
+    const signal = new AbortController().signal;
+    mockedListWorkflows.mockResolvedValue({
+      data: [{ id: 10, workflowCode: "refund-flow" }],
+    });
+    mockedGetWorkflow.mockResolvedValue({
+      data: { id: 10, workflowCode: "refund-flow", name: "환불 흐름" },
+    });
+
+    await expect(
+      intentRevisionDraftApi.listWorkflows(1, 2, 3, { signal }),
+    ).resolves.toEqual([{ id: 10, workflowCode: "refund-flow" }]);
+    await expect(intentRevisionDraftApi.getWorkflow(1, 2, 3, 10, { signal })).resolves.toMatchObject(
+      {
+        id: 10,
+        workflowCode: "refund-flow",
+      },
+    );
+    expect(mockedListWorkflows).toHaveBeenCalledWith(1, 2, 3, undefined, { signal });
+    expect(mockedGetWorkflow).toHaveBeenCalledWith(1, 2, 3, 10, { signal });
+  });
+
+  it("workflow list 응답이 직접 배열이면 그대로 반환한다", async () => {
+    const workflows = [{ id: 10, workflowCode: "refund-flow" }];
+    mockedListWorkflows.mockResolvedValue(workflows);
+
+    await expect(intentRevisionDraftApi.listWorkflows(1, 2, 3)).resolves.toEqual(workflows);
   });
 
   it("draft intent update와 discard는 generated endpoint를 호출한다", async () => {

--- a/frontend/src/features/intent-revision-draft/api/intentRevisionDraftApi.ts
+++ b/frontend/src/features/intent-revision-draft/api/intentRevisionDraftApi.ts
@@ -8,9 +8,17 @@ import {
   listIntents,
 } from "@/shared/api/generated/endpoints/intent-definition-controller/intent-definition-controller";
 import { update } from "@/shared/api/generated/endpoints/update-draft-intent-controller/update-draft-intent-controller";
+import {
+  getWorkflow,
+  listWorkflows,
+} from "@/shared/api/generated/endpoints/workflow-definition-controller/workflow-definition-controller";
 import type { DomainPackVersionDetail } from "@/entities/domain-pack";
 import type { IntentDetail, IntentSummary } from "@/entities/intent";
-import type { UpdateDraftIntentRequest } from "@/shared/api/generated/zod";
+import type {
+  UpdateDraftIntentRequest,
+  WorkflowDefinitionDetail,
+  WorkflowDefinitionSummary,
+} from "@/shared/api/generated/zod";
 
 export interface UpdateDraftIntentBody {
   name: UpdateDraftIntentRequest["name"];
@@ -131,6 +139,31 @@ export const intentRevisionDraftApi = {
     return requireApiData<DomainPackVersionDetail>(
       response,
       "Domain pack version 상세 응답을 확인할 수 없습니다.",
+    );
+  },
+
+  async listWorkflows(
+    workspaceId: number,
+    packId: number,
+    versionId: number,
+    options?: { signal?: AbortSignal },
+  ): Promise<WorkflowDefinitionSummary[]> {
+    const response = await listWorkflows(workspaceId, packId, versionId, undefined, options);
+    if (Array.isArray(response)) return response as WorkflowDefinitionSummary[];
+    return selectApiData<WorkflowDefinitionSummary[]>(response) ?? [];
+  },
+
+  async getWorkflow(
+    workspaceId: number,
+    packId: number,
+    versionId: number,
+    workflowId: number,
+    options?: { signal?: AbortSignal },
+  ): Promise<WorkflowDefinitionDetail> {
+    const response = await getWorkflow(workspaceId, packId, versionId, workflowId, options);
+    return requireApiData<WorkflowDefinitionDetail>(
+      response,
+      "Workflow 상세 응답을 확인할 수 없습니다.",
     );
   },
 };

--- a/frontend/src/features/intent-revision-draft/model/useIntentRevisionMarkers.test.ts
+++ b/frontend/src/features/intent-revision-draft/model/useIntentRevisionMarkers.test.ts
@@ -16,8 +16,12 @@ const readySummary: IntentRevisionSummaryState = {
         after: { name: "환불 문의", description: "" },
       },
     ],
+    changedWorkflows: [],
     changedFieldCounts: { name: 1, description: 0 },
+    changedWorkflowFieldCounts: { name: 0, description: 0, graphText: 0, graphStructure: 0 },
     changedByDraftIntentId: {},
+    changedByDraftWorkflowId: {},
+    totalChangedComponents: 1,
   },
 };
 

--- a/frontend/src/features/intent-revision-draft/model/useIntentRevisionSummary.hook.test.ts
+++ b/frontend/src/features/intent-revision-draft/model/useIntentRevisionSummary.hook.test.ts
@@ -43,10 +43,10 @@ describe("useIntentRevisionSummary hook", () => {
     mockedListIntents
       .mockResolvedValueOnce([
         { id: 10, intentCode: "refund", name: "환불", description: "" },
-      ] as never)
+      ])
       .mockResolvedValueOnce([
         { id: 20, intentCode: "refund", name: "환불 문의", description: "새 설명" },
-      ] as never);
+      ]);
 
     const { result } = renderHook(() =>
       useIntentRevisionSummary({
@@ -83,8 +83,8 @@ describe("useIntentRevisionSummary hook", () => {
   it("base와 draft workflow를 조회해 workflow 변경 요약을 만든다", async () => {
     mockedListIntents.mockResolvedValue([]);
     mockedListWorkflows
-      .mockResolvedValueOnce([{ id: 10, workflowCode: "refund-flow" }] as never)
-      .mockResolvedValueOnce([{ id: 20, workflowCode: "refund-flow" }] as never);
+      .mockResolvedValueOnce([{ id: 10, workflowCode: "refund-flow" }])
+      .mockResolvedValueOnce([{ id: 20, workflowCode: "refund-flow" }]);
     mockedGetWorkflow
       .mockResolvedValueOnce({
         id: 10,
@@ -95,7 +95,7 @@ describe("useIntentRevisionSummary hook", () => {
           nodes: [{ id: "start", type: "START", label: "접수" }],
           edges: [],
         }),
-      } as never)
+      })
       .mockResolvedValueOnce({
         id: 20,
         workflowCode: "refund-flow",
@@ -105,7 +105,7 @@ describe("useIntentRevisionSummary hook", () => {
           nodes: [{ id: "start", type: "START", label: "상담 접수" }],
           edges: [],
         }),
-      } as never);
+      });
 
     const { result } = renderHook(() =>
       useIntentRevisionSummary({

--- a/frontend/src/features/intent-revision-draft/model/useIntentRevisionSummary.hook.test.ts
+++ b/frontend/src/features/intent-revision-draft/model/useIntentRevisionSummary.hook.test.ts
@@ -6,14 +6,21 @@ import { useIntentRevisionSummary } from "./useIntentRevisionSummary";
 vi.mock("../api/intentRevisionDraftApi", () => ({
   intentRevisionDraftApi: {
     listIntents: vi.fn(),
+    listWorkflows: vi.fn(),
+    getWorkflow: vi.fn(),
   },
 }));
 
 const mockedListIntents = vi.mocked(intentRevisionDraftApi.listIntents);
+const mockedListWorkflows = vi.mocked(intentRevisionDraftApi.listWorkflows);
+const mockedGetWorkflow = vi.mocked(intentRevisionDraftApi.getWorkflow);
 
 describe("useIntentRevisionSummary hook", () => {
   beforeEach(() => {
     mockedListIntents.mockReset();
+    mockedListWorkflows.mockReset();
+    mockedGetWorkflow.mockReset();
+    mockedListWorkflows.mockResolvedValue([]);
   });
 
   it("비활성 상태에서는 idle을 반환하고 API를 호출하지 않는다", () => {
@@ -29,6 +36,7 @@ describe("useIntentRevisionSummary hook", () => {
 
     expect(result.current).toEqual({ status: "idle" });
     expect(mockedListIntents).not.toHaveBeenCalled();
+    expect(mockedListWorkflows).not.toHaveBeenCalled();
   });
 
   it("base와 draft intent를 조회해 변경 요약을 만든다", async () => {
@@ -64,6 +72,59 @@ describe("useIntentRevisionSummary hook", () => {
     expect(mockedListIntents).toHaveBeenCalledWith(1, 2, 4, {
       signal: expect.any(AbortSignal),
     });
+    expect(mockedListWorkflows).toHaveBeenCalledWith(1, 2, 3, {
+      signal: expect.any(AbortSignal),
+    });
+    expect(mockedListWorkflows).toHaveBeenCalledWith(1, 2, 4, {
+      signal: expect.any(AbortSignal),
+    });
+  });
+
+  it("base와 draft workflow를 조회해 workflow 변경 요약을 만든다", async () => {
+    mockedListIntents.mockResolvedValue([]);
+    mockedListWorkflows
+      .mockResolvedValueOnce([{ id: 10, workflowCode: "refund-flow" }] as never)
+      .mockResolvedValueOnce([{ id: 20, workflowCode: "refund-flow" }] as never);
+    mockedGetWorkflow
+      .mockResolvedValueOnce({
+        id: 10,
+        workflowCode: "refund-flow",
+        name: "환불 흐름",
+        description: "기존",
+        graphJson: JSON.stringify({
+          nodes: [{ id: "start", type: "START", label: "접수" }],
+          edges: [],
+        }),
+      } as never)
+      .mockResolvedValueOnce({
+        id: 20,
+        workflowCode: "refund-flow",
+        name: "환불 상담 흐름",
+        description: "새 설명",
+        graphJson: JSON.stringify({
+          nodes: [{ id: "start", type: "START", label: "상담 접수" }],
+          edges: [],
+        }),
+      } as never);
+
+    const { result } = renderHook(() =>
+      useIntentRevisionSummary({
+        workspaceId: 1,
+        packId: 2,
+        draftVersionId: 4,
+        baseVersionId: 3,
+        enabled: true,
+      }),
+    );
+
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+    if (result.current.status !== "ready") throw new Error("summary not ready");
+    expect(result.current.data.changedWorkflows[0]).toMatchObject({
+      workflowId: 20,
+      workflowCode: "refund-flow",
+      fields: ["name", "description", "graphText"],
+    });
+    expect(result.current.data.totalChangedComponents).toBe(1);
   });
 
   it("조회 실패 시 error 상태를 반환한다", async () => {

--- a/frontend/src/features/intent-revision-draft/model/useIntentRevisionSummary.ts
+++ b/frontend/src/features/intent-revision-draft/model/useIntentRevisionSummary.ts
@@ -3,11 +3,7 @@ import type { IntentSummary } from "@/entities/intent";
 import type { WorkflowDefinitionDetail, WorkflowDefinitionSummary } from "@/shared/api/generated/zod";
 import {
   buildDomainPackRevisionSummary,
-  type IntentRevisionChange,
   type IntentRevisionSummary,
-  type WorkflowRevisionChange,
-  type RevisionChangedField,
-  type WorkflowRevisionChangedField,
 } from "@/shared/lib/domainPackRevisionSummary";
 import { intentRevisionDraftApi } from "../api/intentRevisionDraftApi";
 
@@ -17,7 +13,7 @@ export type {
   RevisionChangedField,
   WorkflowRevisionChange,
   WorkflowRevisionChangedField,
-};
+} from "@/shared/lib/domainPackRevisionSummary";
 
 export type IntentRevisionSummaryState =
   | { status: "idle" }

--- a/frontend/src/features/intent-revision-draft/model/useIntentRevisionSummary.ts
+++ b/frontend/src/features/intent-revision-draft/model/useIntentRevisionSummary.ts
@@ -1,29 +1,23 @@
 import { useEffect, useMemo, useState } from "react";
 import type { IntentSummary } from "@/entities/intent";
+import type { WorkflowDefinitionDetail, WorkflowDefinitionSummary } from "@/shared/api/generated/zod";
+import {
+  buildDomainPackRevisionSummary,
+  type IntentRevisionChange,
+  type IntentRevisionSummary,
+  type WorkflowRevisionChange,
+  type RevisionChangedField,
+  type WorkflowRevisionChangedField,
+} from "@/shared/lib/domainPackRevisionSummary";
 import { intentRevisionDraftApi } from "../api/intentRevisionDraftApi";
 
-export type RevisionChangedField = "name" | "description";
-
-export interface IntentRevisionChange {
-  intentId: number;
-  intentCode: string;
-  name: string;
-  fields: RevisionChangedField[];
-  before: {
-    name: string;
-    description: string;
-  };
-  after: {
-    name: string;
-    description: string;
-  };
-}
-
-export interface IntentRevisionSummary {
-  changedIntents: IntentRevisionChange[];
-  changedFieldCounts: Record<RevisionChangedField, number>;
-  changedByDraftIntentId: Record<number, IntentRevisionChange>;
-}
+export type {
+  IntentRevisionChange,
+  IntentRevisionSummary,
+  RevisionChangedField,
+  WorkflowRevisionChange,
+  WorkflowRevisionChangedField,
+};
 
 export type IntentRevisionSummaryState =
   | { status: "idle" }
@@ -31,62 +25,38 @@ export type IntentRevisionSummaryState =
   | { status: "ready"; data: IntentRevisionSummary }
   | { status: "error"; message: string };
 
-function normalizeText(value: string | null | undefined): string {
-  return value ?? "";
-}
-
 export function buildIntentRevisionSummary(
   baseIntents: IntentSummary[],
   draftIntents: IntentSummary[],
+  baseWorkflows: WorkflowDefinitionDetail[] = [],
+  draftWorkflows: WorkflowDefinitionDetail[] = [],
 ): IntentRevisionSummary {
-  const baseByCode = new Map(
-    baseIntents
-      .filter((intent) => intent.intentCode)
-      .map((intent) => [intent.intentCode as string, intent]),
-  );
-
-  const changedIntents = draftIntents.flatMap<IntentRevisionChange>((draft) => {
-    if (draft.id == null || !draft.intentCode) return [];
-
-    const base = baseByCode.get(draft.intentCode);
-    if (!base) return [];
-
-    const fields: RevisionChangedField[] = [];
-    const before = {
-      name: normalizeText(base.name),
-      description: normalizeText(base.description),
-    };
-    const after = {
-      name: normalizeText(draft.name),
-      description: normalizeText(draft.description),
-    };
-
-    if (before.name !== after.name) fields.push("name");
-    if (before.description !== after.description) fields.push("description");
-    if (fields.length === 0) return [];
-
-    return [
-      {
-        intentId: draft.id,
-        intentCode: draft.intentCode,
-        name: after.name,
-        fields,
-        before,
-        after,
-      },
-    ];
+  return buildDomainPackRevisionSummary({
+    baseIntents,
+    draftIntents,
+    baseWorkflows,
+    draftWorkflows,
   });
+}
 
-  return {
-    changedIntents,
-    changedFieldCounts: {
-      name: changedIntents.filter((change) => change.fields.includes("name")).length,
-      description: changedIntents.filter((change) => change.fields.includes("description")).length,
-    },
-    changedByDraftIntentId: Object.fromEntries(
-      changedIntents.map((change) => [change.intentId, change]),
-    ),
-  };
+async function fetchWorkflowDetails(
+  workspaceId: number,
+  packId: number,
+  versionId: number,
+  options: { signal: AbortSignal },
+): Promise<WorkflowDefinitionDetail[]> {
+  const summaries = await intentRevisionDraftApi.listWorkflows(
+    workspaceId,
+    packId,
+    versionId,
+    options,
+  );
+  return Promise.all(
+    summaries.flatMap((workflow: WorkflowDefinitionSummary) => {
+      if (typeof workflow.id !== "number") return [];
+      return intentRevisionDraftApi.getWorkflow(workspaceId, packId, versionId, workflow.id, options);
+    }),
+  );
 }
 
 export function useIntentRevisionSummary({
@@ -127,14 +97,25 @@ export function useIntentRevisionSummary({
       intentRevisionDraftApi.listIntents(workspaceId, packId, draftVersionId, {
         signal: controller.signal,
       }),
+      fetchWorkflowDetails(workspaceId, packId, baseVersionId, {
+        signal: controller.signal,
+      }),
+      fetchWorkflowDetails(workspaceId, packId, draftVersionId, {
+        signal: controller.signal,
+      }),
     ])
-      .then(([baseIntents, draftIntents]) => {
+      .then(([baseIntents, draftIntents, baseWorkflows, draftWorkflows]) => {
         if (controller.signal.aborted) return;
         setState({
           requestKey,
           value: {
             status: "ready",
-            data: buildIntentRevisionSummary(baseIntents, draftIntents),
+            data: buildIntentRevisionSummary(
+              baseIntents,
+              draftIntents,
+              baseWorkflows,
+              draftWorkflows,
+            ),
           },
         });
       })

--- a/frontend/src/features/intent-revision-draft/ui/IntentRevisionDraftActions.test.tsx
+++ b/frontend/src/features/intent-revision-draft/ui/IntentRevisionDraftActions.test.tsx
@@ -14,8 +14,12 @@ const summary: IntentRevisionSummary = {
       after: { name: "환불 문의", description: "새 설명" },
     },
   ],
+  changedWorkflows: [],
   changedFieldCounts: { name: 1, description: 1 },
+  changedWorkflowFieldCounts: { name: 0, description: 0, graphText: 0, graphStructure: 0 },
   changedByDraftIntentId: {},
+  changedByDraftWorkflowId: {},
+  totalChangedComponents: 1,
 };
 
 function renderActions(
@@ -37,7 +41,9 @@ describe("IntentRevisionDraftActions", () => {
   it("변경 요약과 Domain Pack 화면 안내 문구를 보여준다", () => {
     renderActions();
 
-    expect(screen.getByText("변경된 상담 유형 1개")).toBeInTheDocument();
+    expect(
+      screen.getByText("변경된 구성 요소 1개 (상담 유형 1개 · 응대 흐름 0개)"),
+    ).toBeInTheDocument();
     expect(
       screen.getByText("수정 내용의 적용 및 삭제는 도메인팩 화면에서 진행할 수 있습니다."),
     ).toBeInTheDocument();
@@ -66,7 +72,7 @@ describe("IntentRevisionDraftActions", () => {
     });
 
     expect(screen.getByRole("button", { name: "다시 시도" })).toBeInTheDocument();
-    expect(screen.queryByText("변경된 상담 유형이 없습니다.")).not.toBeInTheDocument();
+    expect(screen.queryByText("변경된 구성 요소가 없습니다.")).not.toBeInTheDocument();
   });
 
   it("요약 로딩 중에는 로딩 문구와 안내 문구만 보여준다", () => {
@@ -83,11 +89,15 @@ describe("IntentRevisionDraftActions", () => {
     renderActions({
       summary: {
         changedIntents: [],
+        changedWorkflows: [],
         changedFieldCounts: { name: 0, description: 0 },
+        changedWorkflowFieldCounts: { name: 0, description: 0, graphText: 0, graphStructure: 0 },
         changedByDraftIntentId: {},
+        changedByDraftWorkflowId: {},
+        totalChangedComponents: 0,
       },
     });
 
-    expect(screen.getByText("변경된 상담 유형이 없습니다.")).toBeInTheDocument();
+    expect(screen.getByText("변경된 구성 요소가 없습니다.")).toBeInTheDocument();
   });
 });

--- a/frontend/src/features/intent-revision-draft/ui/IntentRevisionDraftActions.tsx
+++ b/frontend/src/features/intent-revision-draft/ui/IntentRevisionDraftActions.tsx
@@ -18,10 +18,16 @@ export function IntentRevisionDraftActions({
   isPending,
   onRetrySummary,
 }: IntentRevisionDraftActionsProps) {
-  const changedCount = summary?.changedIntents.length ?? 0;
+  const intentChangedCount = summary?.changedIntents.length ?? 0;
+  const workflowChangedCount = summary?.changedWorkflows.length ?? 0;
+  const changedCount = summary?.totalChangedComponents ?? intentChangedCount + workflowChangedCount;
   const hasSummaryError = summaryError != null;
   const rawErrorMessage = summaryError instanceof Error ? summaryError.message : summaryError;
   const errorMessage = rawErrorMessage ?? "변경 요약을 불러오지 못했습니다.";
+  const changedLabel =
+    changedCount > 0
+      ? `변경된 구성 요소 ${changedCount}개 (상담 유형 ${intentChangedCount}개 · 응대 흐름 ${workflowChangedCount}개)`
+      : "변경된 구성 요소가 없습니다.";
 
   return (
     <div className={styles.actions}>
@@ -30,9 +36,7 @@ export function IntentRevisionDraftActions({
           ? "변경 요약을 불러오는 중입니다."
           : hasSummaryError
             ? errorMessage
-            : changedCount > 0
-              ? `변경된 상담 유형 ${changedCount}개`
-              : "변경된 상담 유형이 없습니다."}
+            : changedLabel}
       </div>
       <div className={styles.summaryText}>
         수정 내용의 적용 및 삭제는 도메인팩 화면에서 진행할 수 있습니다.

--- a/frontend/src/pages/domain-pack/model/useIntentDraftReadController.ts
+++ b/frontend/src/pages/domain-pack/model/useIntentDraftReadController.ts
@@ -494,7 +494,7 @@ function useApplyRevisionDraftHandler({
   return useCallback(
     async (intentCode?: string | null) => {
       const summary = summaryState.status === "ready" ? summaryState.data : null;
-      if (!summary || summary.changedIntents.length === 0) return;
+      if (!summary || summary.totalChangedComponents === 0) return;
 
       setVersionActionPending(true);
       try {

--- a/frontend/src/pages/domain-pack/ui/IntentDraftReadPage.test.tsx
+++ b/frontend/src/pages/domain-pack/ui/IntentDraftReadPage.test.tsx
@@ -34,8 +34,12 @@ const mocks = vi.hoisted(() => ({
           after: { name: "환불 문의", description: "" },
         },
       ],
+      changedWorkflows: [],
       changedFieldCounts: { name: 1, description: 0 },
+      changedWorkflowFieldCounts: { name: 0, description: 0, graphText: 0, graphStructure: 0 },
       changedByDraftIntentId: {},
+      changedByDraftWorkflowId: {},
+      totalChangedComponents: 1,
     },
   },
   packData: {
@@ -337,8 +341,12 @@ describe("IntentDraftReadPage", () => {
             after: { name: "환불 문의", description: "" },
           },
         ],
+        changedWorkflows: [],
         changedFieldCounts: { name: 1, description: 0 },
+        changedWorkflowFieldCounts: { name: 0, description: 0, graphText: 0, graphStructure: 0 },
         changedByDraftIntentId: {},
+        changedByDraftWorkflowId: {},
+        totalChangedComponents: 1,
       },
     };
     mocks.packRefetch.mockResolvedValue({ data: mocks.packData });

--- a/frontend/src/shared/lib/domainPackRevisionSummary.test.ts
+++ b/frontend/src/shared/lib/domainPackRevisionSummary.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { buildDomainPackRevisionSummary } from "./domainPackRevisionSummary";
+
+const baseGraph = JSON.stringify({
+  direction: "LR",
+  nodes: [
+    { id: "start", type: "START", label: "접수" },
+    { id: "answer", type: "ANSWER", label: "안내" },
+  ],
+  edges: [{ id: "e1", from: "start", to: "answer", label: "다음" }],
+});
+
+describe("buildDomainPackRevisionSummary", () => {
+  it("workflow 이름과 설명 변경을 구성 변경으로 계산한다", () => {
+    const summary = buildDomainPackRevisionSummary({
+      baseIntents: [],
+      draftIntents: [],
+      baseWorkflows: [
+        {
+          id: 1,
+          workflowCode: "refund-flow",
+          name: "환불 흐름",
+          description: "기존 설명",
+          graphJson: baseGraph,
+        },
+      ],
+      draftWorkflows: [
+        {
+          id: 2,
+          workflowCode: "refund-flow",
+          name: "환불 검토 흐름",
+          description: "새 설명",
+          graphJson: baseGraph,
+        },
+      ],
+    });
+
+    expect(summary.changedWorkflows).toHaveLength(1);
+    expect(summary.changedWorkflows[0]).toMatchObject({
+      workflowId: 2,
+      workflowCode: "refund-flow",
+      fields: ["name", "description"],
+      before: { name: "환불 흐름", description: "기존 설명", nodeCount: 2, edgeCount: 1 },
+      after: { name: "환불 검토 흐름", description: "새 설명", nodeCount: 2, edgeCount: 1 },
+    });
+    expect(summary.changedWorkflowFieldCounts).toMatchObject({
+      name: 1,
+      description: 1,
+      graphText: 0,
+      graphStructure: 0,
+    });
+    expect(summary.totalChangedComponents).toBe(1);
+  });
+
+  it("workflow 그래프 텍스트와 구조 변경을 분리해서 계산한다", () => {
+    const textOnlyGraph = JSON.stringify({
+      direction: "LR",
+      nodes: [
+        { id: "start", type: "START", label: "상담 접수" },
+        { id: "answer", type: "ANSWER", label: "안내" },
+      ],
+      edges: [{ id: "e1", from: "start", to: "answer", label: "진행" }],
+    });
+    const structuralGraph = JSON.stringify({
+      direction: "LR",
+      nodes: [
+        { id: "start", type: "START", label: "접수" },
+        { id: "answer", type: "ANSWER", label: "안내" },
+        { id: "handoff", type: "HANDOFF", label: "이관" },
+      ],
+      edges: [
+        { id: "e1", from: "start", to: "answer", label: "다음" },
+        { id: "e2", from: "answer", to: "handoff", label: "이관" },
+      ],
+    });
+
+    const textSummary = buildDomainPackRevisionSummary({
+      baseIntents: [],
+      draftIntents: [],
+      baseWorkflows: [{ id: 1, workflowCode: "refund-flow", graphJson: baseGraph }],
+      draftWorkflows: [{ id: 2, workflowCode: "refund-flow", graphJson: textOnlyGraph }],
+    });
+    const structureSummary = buildDomainPackRevisionSummary({
+      baseIntents: [],
+      draftIntents: [],
+      baseWorkflows: [{ id: 1, workflowCode: "refund-flow", graphJson: baseGraph }],
+      draftWorkflows: [{ id: 2, workflowCode: "refund-flow", graphJson: structuralGraph }],
+    });
+
+    expect(textSummary.changedWorkflows[0]?.fields).toEqual(["graphText"]);
+    expect(structureSummary.changedWorkflows[0]?.fields).toEqual([
+      "graphText",
+      "graphStructure",
+    ]);
+    expect(structureSummary.changedWorkflows[0]?.after).toMatchObject({
+      nodeCount: 3,
+      edgeCount: 2,
+    });
+  });
+});

--- a/frontend/src/shared/lib/domainPackRevisionSummary.test.ts
+++ b/frontend/src/shared/lib/domainPackRevisionSummary.test.ts
@@ -97,4 +97,51 @@ describe("buildDomainPackRevisionSummary", () => {
       edgeCount: 2,
     });
   });
+
+  it("그래프 JSON key 순서만 다른 workflow는 변경으로 계산하지 않는다", () => {
+    const summary = buildDomainPackRevisionSummary({
+      baseIntents: [],
+      draftIntents: [],
+      baseWorkflows: [
+        {
+          id: 1,
+          workflowCode: "refund-flow",
+          graphJson: JSON.stringify({
+            nodes: [{ id: "start", type: "START", label: "접수" }],
+            edges: [],
+          }),
+        },
+      ],
+      draftWorkflows: [
+        {
+          id: 2,
+          workflowCode: "refund-flow",
+          graphJson: JSON.stringify({
+            edges: [],
+            nodes: [{ label: "접수", type: "START", id: "start" }],
+          }),
+        },
+      ],
+    });
+
+    expect(summary.changedWorkflows).toHaveLength(0);
+    expect(summary.totalChangedComponents).toBe(0);
+  });
+
+  it("파싱할 수 없는 workflow graph도 원문 차이를 변경으로 계산한다", () => {
+    const summary = buildDomainPackRevisionSummary({
+      baseIntents: [],
+      draftIntents: [],
+      baseWorkflows: [{ id: 1, workflowCode: "refund-flow", graphJson: "old graph" }],
+      draftWorkflows: [{ id: 2, workflowCode: "refund-flow", graphJson: "new graph" }],
+    });
+
+    expect(summary.changedWorkflows[0]).toMatchObject({
+      workflowId: 2,
+      workflowCode: "refund-flow",
+      fields: ["graphText", "graphStructure"],
+      before: { nodeCount: null, edgeCount: null },
+      after: { nodeCount: null, edgeCount: null },
+    });
+  });
 });

--- a/frontend/src/shared/lib/domainPackRevisionSummary.ts
+++ b/frontend/src/shared/lib/domainPackRevisionSummary.ts
@@ -99,7 +99,7 @@ function stableStringify(value: unknown): string {
   if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
   if (!isRecord(value)) return JSON.stringify(value);
   return `{${Object.keys(value)
-    .sort()
+    .sort((a, b) => a.localeCompare(b))
     .map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`)
     .join(",")}}`;
 }

--- a/frontend/src/shared/lib/domainPackRevisionSummary.ts
+++ b/frontend/src/shared/lib/domainPackRevisionSummary.ts
@@ -1,0 +1,312 @@
+export type RevisionChangedField = "name" | "description";
+export type WorkflowRevisionChangedField =
+  | "name"
+  | "description"
+  | "graphText"
+  | "graphStructure";
+
+export interface IntentRevisionSource {
+  id?: number;
+  intentCode?: string | null;
+  name?: string | null;
+  description?: string | null;
+}
+
+export interface WorkflowRevisionSource {
+  id?: number;
+  workflowCode?: string | null;
+  name?: string | null;
+  description?: string | null;
+  graphJson?: string | null;
+  initialState?: string | null;
+  terminalStatesJson?: string | null;
+}
+
+export interface IntentRevisionChange {
+  intentId: number;
+  intentCode: string;
+  name: string;
+  fields: RevisionChangedField[];
+  before: {
+    name: string;
+    description: string;
+  };
+  after: {
+    name: string;
+    description: string;
+  };
+}
+
+export interface WorkflowRevisionChange {
+  workflowId: number;
+  workflowCode: string;
+  name: string;
+  fields: WorkflowRevisionChangedField[];
+  before: {
+    name: string;
+    description: string;
+    nodeCount: number | null;
+    edgeCount: number | null;
+  };
+  after: {
+    name: string;
+    description: string;
+    nodeCount: number | null;
+    edgeCount: number | null;
+  };
+}
+
+export interface IntentRevisionSummary {
+  changedIntents: IntentRevisionChange[];
+  changedWorkflows: WorkflowRevisionChange[];
+  changedFieldCounts: Record<RevisionChangedField, number>;
+  changedWorkflowFieldCounts: Record<WorkflowRevisionChangedField, number>;
+  changedByDraftIntentId: Record<number, IntentRevisionChange>;
+  changedByDraftWorkflowId: Record<number, WorkflowRevisionChange>;
+  totalChangedComponents: number;
+}
+
+type JsonRecord = Record<string, unknown>;
+
+interface GraphFingerprint {
+  text: string;
+  structure: string;
+  nodeCount: number | null;
+  edgeCount: number | null;
+}
+
+function normalizeText(value: string | null | undefined): string {
+  return value ?? "";
+}
+
+function isRecord(value: unknown): value is JsonRecord {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function readString(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function readNodeId(value: JsonRecord): string {
+  return readString(value.id);
+}
+
+function readEdgeId(value: JsonRecord): string {
+  return readString(value.id) || `${readString(value.from)}>${readString(value.to)}`;
+}
+
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+  if (!isRecord(value)) return JSON.stringify(value);
+  return `{${Object.keys(value)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`)
+    .join(",")}}`;
+}
+
+function parseGraph(raw: string): unknown {
+  if (!raw.trim()) return null;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw.trim();
+  }
+}
+
+function fingerprintGraph(workflow: WorkflowRevisionSource): GraphFingerprint {
+  const rawGraph = normalizeText(workflow.graphJson);
+  const parsed = parseGraph(rawGraph);
+
+  if (!isRecord(parsed)) {
+    const fallback = stableStringify({
+      graphJson: parsed,
+      initialState: normalizeText(workflow.initialState),
+      terminalStatesJson: normalizeText(workflow.terminalStatesJson),
+    });
+    return {
+      text: fallback,
+      structure: fallback,
+      nodeCount: null,
+      edgeCount: null,
+    };
+  }
+
+  const nodes = Array.isArray(parsed.nodes) ? parsed.nodes.filter(isRecord) : [];
+  const edges = Array.isArray(parsed.edges) ? parsed.edges.filter(isRecord) : [];
+
+  const nodeText = nodes
+    .map((node) => ({
+      id: readNodeId(node),
+      label: readString(node.label),
+      description: readString(node.description),
+    }))
+    .sort((a, b) => a.id.localeCompare(b.id));
+  const edgeText = edges
+    .map((edge) => ({
+      id: readEdgeId(edge),
+      label: readString(edge.label),
+    }))
+    .sort((a, b) => a.id.localeCompare(b.id));
+  const nodeStructure = nodes
+    .map((node) => ({
+      id: readNodeId(node),
+      type: readString(node.type),
+    }))
+    .sort((a, b) => a.id.localeCompare(b.id));
+  const edgeStructure = edges
+    .map((edge) => ({
+      id: readEdgeId(edge),
+      from: readString(edge.from),
+      to: readString(edge.to),
+      sourceHandle: readString(edge.sourceHandle),
+      targetHandle: readString(edge.targetHandle),
+    }))
+    .sort((a, b) => a.id.localeCompare(b.id));
+
+  return {
+    text: stableStringify({ nodes: nodeText, edges: edgeText }),
+    structure: stableStringify({
+      direction: readString(parsed.direction),
+      initialState: normalizeText(workflow.initialState),
+      terminalStatesJson: normalizeText(workflow.terminalStatesJson),
+      nodes: nodeStructure,
+      edges: edgeStructure,
+    }),
+    nodeCount: nodes.length,
+    edgeCount: edges.length,
+  };
+}
+
+function buildIntentChanges(
+  baseIntents: IntentRevisionSource[],
+  draftIntents: IntentRevisionSource[],
+): IntentRevisionChange[] {
+  const baseByCode = new Map(
+    baseIntents
+      .filter((intent) => intent.intentCode)
+      .map((intent) => [intent.intentCode as string, intent]),
+  );
+
+  return draftIntents.flatMap<IntentRevisionChange>((draft) => {
+    if (draft.id == null || !draft.intentCode) return [];
+
+    const base = baseByCode.get(draft.intentCode);
+    if (!base) return [];
+
+    const fields: RevisionChangedField[] = [];
+    const before = {
+      name: normalizeText(base.name),
+      description: normalizeText(base.description),
+    };
+    const after = {
+      name: normalizeText(draft.name),
+      description: normalizeText(draft.description),
+    };
+
+    if (before.name !== after.name) fields.push("name");
+    if (before.description !== after.description) fields.push("description");
+    if (fields.length === 0) return [];
+
+    return [
+      {
+        intentId: draft.id,
+        intentCode: draft.intentCode,
+        name: after.name,
+        fields,
+        before,
+        after,
+      },
+    ];
+  });
+}
+
+function buildWorkflowChanges(
+  baseWorkflows: WorkflowRevisionSource[],
+  draftWorkflows: WorkflowRevisionSource[],
+): WorkflowRevisionChange[] {
+  const baseByCode = new Map(
+    baseWorkflows
+      .filter((workflow) => workflow.workflowCode)
+      .map((workflow) => [workflow.workflowCode as string, workflow]),
+  );
+
+  return draftWorkflows.flatMap<WorkflowRevisionChange>((draft) => {
+    if (draft.id == null || !draft.workflowCode) return [];
+
+    const base = baseByCode.get(draft.workflowCode);
+    if (!base) return [];
+
+    const baseGraph = fingerprintGraph(base);
+    const draftGraph = fingerprintGraph(draft);
+    const fields: WorkflowRevisionChangedField[] = [];
+    const before = {
+      name: normalizeText(base.name),
+      description: normalizeText(base.description),
+      nodeCount: baseGraph.nodeCount,
+      edgeCount: baseGraph.edgeCount,
+    };
+    const after = {
+      name: normalizeText(draft.name),
+      description: normalizeText(draft.description),
+      nodeCount: draftGraph.nodeCount,
+      edgeCount: draftGraph.edgeCount,
+    };
+
+    if (before.name !== after.name) fields.push("name");
+    if (before.description !== after.description) fields.push("description");
+    if (baseGraph.text !== draftGraph.text) fields.push("graphText");
+    if (baseGraph.structure !== draftGraph.structure) fields.push("graphStructure");
+    if (fields.length === 0) return [];
+
+    return [
+      {
+        workflowId: draft.id,
+        workflowCode: draft.workflowCode,
+        name: after.name,
+        fields,
+        before,
+        after,
+      },
+    ];
+  });
+}
+
+export function buildDomainPackRevisionSummary({
+  baseIntents,
+  draftIntents,
+  baseWorkflows = [],
+  draftWorkflows = [],
+}: {
+  baseIntents: IntentRevisionSource[];
+  draftIntents: IntentRevisionSource[];
+  baseWorkflows?: WorkflowRevisionSource[];
+  draftWorkflows?: WorkflowRevisionSource[];
+}): IntentRevisionSummary {
+  const changedIntents = buildIntentChanges(baseIntents, draftIntents);
+  const changedWorkflows = buildWorkflowChanges(baseWorkflows, draftWorkflows);
+
+  return {
+    changedIntents,
+    changedWorkflows,
+    changedFieldCounts: {
+      name: changedIntents.filter((change) => change.fields.includes("name")).length,
+      description: changedIntents.filter((change) => change.fields.includes("description")).length,
+    },
+    changedWorkflowFieldCounts: {
+      name: changedWorkflows.filter((change) => change.fields.includes("name")).length,
+      description: changedWorkflows.filter((change) => change.fields.includes("description"))
+        .length,
+      graphText: changedWorkflows.filter((change) => change.fields.includes("graphText")).length,
+      graphStructure: changedWorkflows.filter((change) =>
+        change.fields.includes("graphStructure"),
+      ).length,
+    },
+    changedByDraftIntentId: Object.fromEntries(
+      changedIntents.map((change) => [change.intentId, change]),
+    ),
+    changedByDraftWorkflowId: Object.fromEntries(
+      changedWorkflows.map((change) => [change.workflowId, change]),
+    ),
+    totalChangedComponents: changedIntents.length + changedWorkflows.length,
+  };
+}


### PR DESCRIPTION
## Summary
- 변경 요약 계산에 workflow 이름, 설명, 그래프 텍스트, 그래프 구조 diff를 포함했습니다.
- 도메인팩 정보 화면에서 intent/workflow 구성 변경을 구분해 표시하고, 변경 없음 상태도 명시합니다.
- workflow-only 수정 검토본도 변경 있음으로 판단해 적용 흐름에 진입할 수 있도록 했습니다.
- 이슈 요구사항과 검증 기준을 `.agent/specs/404.md`에 정리했습니다.

## Validation
- `cd frontend && pnpm test -- --run src/shared/lib/domainPackRevisionSummary.test.ts src/features/intent-revision-draft/model/useIntentRevisionSummary.test.ts src/features/intent-revision-draft/model/useIntentRevisionSummary.hook.test.ts src/features/intent-revision-draft/ui/IntentRevisionDraftActions.test.tsx src/features/domain-pack-summary-read/ui/SummaryJsonCard.test.tsx src/features/domain-pack-summary-read/ui/SummaryDetailPanel.test.tsx src/pages/domain-pack/ui/IntentDraftReadPage.test.tsx`
- `cd frontend && pnpm exec eslint src/shared/lib/domainPackRevisionSummary.ts src/shared/lib/domainPackRevisionSummary.test.ts src/features/domain-pack-summary-read/model/useDomainPackRevisionSummary.ts src/features/domain-pack-summary-read/ui/SummaryDetailPanel.tsx src/features/domain-pack-summary-read/ui/SummaryJsonCard.tsx src/features/domain-pack-summary-read/ui/SummaryJsonCard.test.tsx src/features/intent-revision-draft/api/intentRevisionDraftApi.ts src/features/intent-revision-draft/model/useIntentRevisionSummary.ts src/features/intent-revision-draft/model/useIntentRevisionSummary.hook.test.ts src/features/intent-revision-draft/model/useIntentRevisionMarkers.test.ts src/features/intent-revision-draft/ui/IntentRevisionDraftActions.tsx src/features/intent-revision-draft/ui/IntentRevisionDraftActions.test.tsx src/pages/domain-pack/model/useIntentDraftReadController.ts src/pages/domain-pack/ui/IntentDraftReadPage.test.tsx`
- `cd frontend && pnpm exec tsc -b --pretty false`
- `git diff --check`

## Notes
- `cd frontend && pnpm lint`는 변경 범위 밖의 기존 lint 오류 57개로 실패했습니다. 변경 파일은 targeted eslint를 통과했습니다.

Closes #404