### PR TITLE
feat(ux): 상담 안내·자동 갱신·내비/메모/빈화면 UX 개선 (#403 #405 #412 #417 #424)

### DIFF
--- a/backend/src/main/java/com/init/workflowruntime/application/CounselorService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/CounselorService.java
@@ -38,6 +38,7 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 public class CounselorService {
 
   private static final ZoneId HISTORY_FILTER_ZONE = ZoneId.of("Asia/Seoul");
+  private static final String SESSION_ASSIGNED_SYSTEM_MESSAGE = "상담사가 배정되었습니다.";
 
   private final ChatSessionRepository chatSessionRepository;
   private final ChatMessageRepository chatMessageRepository;
@@ -77,12 +78,36 @@ public class CounselorService {
     session.assignTo(counselorId);
     chatSessionRepository.save(session);
 
+    broadcastSessionAssignedSystemMessage(sessionId);
+
     eventPublisher.publishEvent(new SessionAssignedEvent(sessionId, counselorId));
     eventPublisher.publishEvent(
         new ConsultationQueueChangedEvent(
             session.getWorkspaceId(), sessionId, ConsultationQueueEventType.SESSION_UPSERTED));
 
     return CounselorSessionResponse.from(session);
+  }
+
+  private void broadcastSessionAssignedSystemMessage(Long sessionId) {
+    Integer nextSeqNo =
+        chatMessageRepository
+            .findTopByChatSessionIdOrderBySeqNoDesc(sessionId)
+            .map(msg -> msg.getSeqNo() + 1)
+            .orElse(1);
+    ChatMessage systemMessage =
+        ChatMessage.create(
+            sessionId, nextSeqNo, "SYSTEM", "SYSTEM", SESSION_ASSIGNED_SYSTEM_MESSAGE);
+    ChatMessage savedMessage = chatMessageRepository.save(systemMessage);
+
+    ChatMessageResponse response = ChatMessageResponse.from(savedMessage);
+    String destination = "/topic/chat." + sessionId;
+    TransactionSynchronizationManager.registerSynchronization(
+        new TransactionSynchronization() {
+          @Override
+          public void afterCommit() {
+            messagingTemplate.convertAndSend(destination, response);
+          }
+        });
   }
 
   @Transactional

--- a/backend/src/test/java/com/init/workflowruntime/application/CounselorServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/CounselorServiceTest.java
@@ -79,16 +79,55 @@ class CounselorServiceTest {
   void should_assignSession_when_sessionOpen() {
     ChatSession session = createSession(1L, ChatSessionStatus.OPEN);
     given(chatSessionRepository.findByIdForUpdate(1L)).willReturn(Optional.of(session));
+    given(chatMessageRepository.findTopByChatSessionIdOrderBySeqNoDesc(1L))
+        .willReturn(Optional.empty());
+    given(chatMessageRepository.save(any()))
+        .willReturn(createMessage(1L, 1, "SYSTEM", "상담사가 배정되었습니다."));
     givenWorkspaceMember(1L, 42L);
 
-    CounselorSessionResponse result = service.assignSession(1L, 42L);
+    TransactionSynchronizationManager.initSynchronization();
+    try {
+      CounselorSessionResponse result = service.assignSession(1L, 42L);
 
-    assertThat(result.getStatus()).isEqualTo("ACTIVE");
-    assertThat(result.getAssignedCounselorId()).isEqualTo(42L);
-    assertThat(result.getResponseMode()).isEqualTo("HUMAN_ACTIVE");
-    verify(chatSessionRepository).save(session);
-    verify(eventPublisher).publishEvent(any(SessionAssignedEvent.class));
-    verifyQueueEventPublished(1L, 1L, ConsultationQueueEventType.SESSION_UPSERTED);
+      assertThat(result.getStatus()).isEqualTo("ACTIVE");
+      assertThat(result.getAssignedCounselorId()).isEqualTo(42L);
+      assertThat(result.getResponseMode()).isEqualTo("HUMAN_ACTIVE");
+      verify(chatSessionRepository).save(session);
+      verify(eventPublisher).publishEvent(any(SessionAssignedEvent.class));
+      verifyQueueEventPublished(1L, 1L, ConsultationQueueEventType.SESSION_UPSERTED);
+    } finally {
+      TransactionSynchronizationManager.clearSynchronization();
+    }
+  }
+
+  @Test
+  @DisplayName("assignSession: 사용자 채팅방에 SYSTEM 안내 메시지를 저장하고 afterCommit broadcast")
+  void should_persistAndBroadcastSystemMessage_when_assigned() {
+    ChatSession session = createSession(1L, ChatSessionStatus.OPEN);
+    given(chatSessionRepository.findByIdForUpdate(1L)).willReturn(Optional.of(session));
+    given(chatMessageRepository.findTopByChatSessionIdOrderBySeqNoDesc(1L))
+        .willReturn(Optional.of(createMessage(1L, 3, "USER", "기존 메시지")));
+    ChatMessage savedSystemMessage = createMessage(1L, 4, "SYSTEM", "상담사가 배정되었습니다.");
+    given(chatMessageRepository.save(any())).willReturn(savedSystemMessage);
+    givenWorkspaceMember(1L, 42L);
+
+    TransactionSynchronizationManager.initSynchronization();
+    try {
+      service.assignSession(1L, 42L);
+
+      ArgumentCaptor<ChatMessage> captor = ArgumentCaptor.forClass(ChatMessage.class);
+      verify(chatMessageRepository).save(captor.capture());
+      ChatMessage persisted = captor.getValue();
+      assertThat(persisted.getSenderRole()).isEqualTo("SYSTEM");
+      assertThat(persisted.getSeqNo()).isEqualTo(4);
+      assertThat(persisted.getContent()).isEqualTo("상담사가 배정되었습니다.");
+
+      verify(messagingTemplate, never()).convertAndSend(anyString(), any(Object.class));
+      TransactionSynchronizationManager.getSynchronizations().forEach(s -> s.afterCommit());
+      verify(messagingTemplate).convertAndSend(eq("/topic/chat.1"), any(ChatMessageResponse.class));
+    } finally {
+      TransactionSynchronizationManager.clearSynchronization();
+    }
   }
 
   @Test

--- a/frontend/src/app/providers.test.tsx
+++ b/frontend/src/app/providers.test.tsx
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { queryClientConfig } from "./queryClient";
+
+describe("queryClientConfig", () => {
+  it("도메인 팩 변경이 명시적 새로고침 없이 반영되도록 자동 refetch를 활성화한다", () => {
+    const queries = queryClientConfig.defaultOptions?.queries;
+
+    expect(queries?.refetchOnWindowFocus).toBe(true);
+    expect(queries?.refetchOnMount).toBe(true);
+    expect(queries?.refetchOnReconnect).toBe(true);
+  });
+
+  it("호출 폭증을 막기 위해 staleTime을 유지하고 mutation 재시도를 끈다", () => {
+    const queries = queryClientConfig.defaultOptions?.queries;
+    const mutations = queryClientConfig.defaultOptions?.mutations;
+
+    expect(queries?.staleTime).toBe(60 * 1000);
+    expect(queries?.retry).toBe(0);
+    expect(mutations?.retry).toBe(0);
+  });
+});

--- a/frontend/src/app/providers.tsx
+++ b/frontend/src/app/providers.tsx
@@ -1,20 +1,6 @@
 import type { ReactNode } from "react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      staleTime: 60 * 1000,
-      retry: 0,
-      refetchOnWindowFocus: false,
-      refetchOnMount: false,
-      refetchOnReconnect: false,
-    },
-    mutations: {
-      retry: 0,
-    },
-  },
-});
+import { QueryClientProvider } from "@tanstack/react-query";
+import { queryClient } from "./queryClient";
 
 export function AppProviders({ children }: { children: ReactNode }) {
   return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;

--- a/frontend/src/app/queryClient.ts
+++ b/frontend/src/app/queryClient.ts
@@ -1,0 +1,21 @@
+import { QueryClient, type QueryClientConfig } from "@tanstack/react-query";
+
+// 도메인 팩/워크플로우/intent 변경은 pipeline·review 등 다른 화면에서도 발생하므로
+// 현재 화면이 명시적 새로고침 없이 최신 상태를 반영하도록 자동 refetch를 활성화한다.
+// staleTime(60초)으로 빠른 재진입·포커스 전환 시의 호출 폭증은 방지한다.
+export const queryClientConfig: QueryClientConfig = {
+  defaultOptions: {
+    queries: {
+      staleTime: 60 * 1000,
+      retry: 0,
+      refetchOnWindowFocus: true,
+      refetchOnMount: true,
+      refetchOnReconnect: true,
+    },
+    mutations: {
+      retry: 0,
+    },
+  },
+};
+
+export const queryClient = new QueryClient(queryClientConfig);

--- a/frontend/src/entities/chat/lib/chatMessageSync.test.ts
+++ b/frontend/src/entities/chat/lib/chatMessageSync.test.ts
@@ -78,6 +78,8 @@ describe("chatMessageSync", () => {
     ).toBe(true);
     expect(isRealtimeChatMessage({ id: "local-1", senderRole: "USER" })).toBe(false);
     expect(toSenderType("ASSISTANT")).toBe("BOT");
+    expect(toSenderType("SYSTEM")).toBe("SYSTEM");
+    expect(toSenderType("system")).toBe("SYSTEM");
 
     expect(
       toRealtimeChatMessage(

--- a/frontend/src/entities/chat/lib/chatMessageSync.ts
+++ b/frontend/src/entities/chat/lib/chatMessageSync.ts
@@ -79,6 +79,7 @@ export function toSenderType(senderRole: string): ChatMessage["senderType"] {
   const normalizedRole = senderRole.toUpperCase();
   if (normalizedRole === "USER" || normalizedRole === "CUSTOMER") return "USER";
   if (normalizedRole === "AGENT" || normalizedRole === "COUNSELOR") return "AGENT";
+  if (normalizedRole === "SYSTEM") return "SYSTEM";
   return "BOT";
 }
 

--- a/frontend/src/entities/chat/model/types.ts
+++ b/frontend/src/entities/chat/model/types.ts
@@ -2,7 +2,7 @@ export interface ChatMessage {
   id: string;
   sessionId: number;
   content: string;
-  senderType: "USER" | "BOT" | "AGENT";
+  senderType: "USER" | "BOT" | "AGENT" | "SYSTEM";
   senderId?: number;
   senderName?: string;
   createdAt: string;

--- a/frontend/src/features/user-chat/ui/MessageList.test.tsx
+++ b/frontend/src/features/user-chat/ui/MessageList.test.tsx
@@ -58,6 +58,24 @@ describe("MessageList", () => {
     expect(screen.getByTestId("message-m2")).toHaveAttribute("data-sender", "bot");
   });
 
+  it("시스템 메시지를 중앙 안내로 렌더링한다", () => {
+    const systemMessages: ChatMessage[] = [
+      {
+        id: "sys-1",
+        sessionId: 1,
+        content: "상담사가 배정되었습니다.",
+        senderType: "SYSTEM",
+        createdAt: "2026-05-22T08:02:00Z",
+      },
+    ];
+    render(<MessageList messages={systemMessages} />);
+
+    const systemMessage = screen.getByTestId("message-sys-1");
+    expect(systemMessage).toHaveAttribute("data-sender", "system");
+    expect(systemMessage).toHaveAttribute("role", "status");
+    expect(systemMessage).toHaveTextContent("상담사가 배정되었습니다.");
+  });
+
   it("새 메시지가 렌더링되면 하단으로 스크롤한다", () => {
     const originalScrollIntoView = window.HTMLElement.prototype.scrollIntoView;
     const scrollIntoView = vi.fn();

--- a/frontend/src/features/user-chat/ui/MessageList.tsx
+++ b/frontend/src/features/user-chat/ui/MessageList.tsx
@@ -103,6 +103,31 @@ export function MessageList({
     >
       <div style={{ display: "flex", flexDirection: "column", gap: 18 }}>
         {messages.map((message) => {
+          if (message.senderType === "SYSTEM") {
+            return (
+              <div
+                key={message.id}
+                data-testid={`message-${message.id}`}
+                data-sender="system"
+                role="status"
+                style={{
+                  alignSelf: "center",
+                  maxWidth: "82%",
+                  padding: "6px 14px",
+                  borderRadius: 999,
+                  background: "var(--paper-3)",
+                  border: "1px solid var(--line)",
+                  color: "var(--ink-3)",
+                  fontSize: 12,
+                  lineHeight: 1.5,
+                  textAlign: "center",
+                  letterSpacing: "-0.1px",
+                }}
+              >
+                {message.content}
+              </div>
+            );
+          }
           const isUser = message.senderType === "USER";
           const sender = isUser ? "user" : "bot";
           return (

--- a/frontend/src/pages/consultation/ui/sections/CustomerPanel.module.css
+++ b/frontend/src/pages/consultation/ui/sections/CustomerPanel.module.css
@@ -1,0 +1,62 @@
+.memoComposer {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding-top: 2px;
+}
+
+.memoTextarea {
+  width: 100%;
+  min-height: 92px;
+  padding: 11px 12px;
+  font-size: 12.5px;
+  line-height: 1.6;
+  border: 1px solid var(--line);
+  border-radius: var(--r-3);
+  background: var(--paper);
+  color: var(--ink);
+  resize: vertical;
+  font-family: inherit;
+  letter-spacing: -0.1px;
+}
+
+.memoTextarea::placeholder {
+  color: var(--ink-4);
+}
+
+.memoTextarea:focus-visible {
+  outline: none;
+  border-color: var(--ink);
+  box-shadow: var(--focus-ring);
+}
+
+.memoSaveButton {
+  width: 100%;
+  height: 38px;
+  padding: 0 14px;
+  border: 1px solid var(--ink);
+  border-radius: var(--r-3);
+  background: var(--ink);
+  color: var(--paper);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 12.5px;
+  font-weight: 540;
+  letter-spacing: -0.1px;
+  transition:
+    background 160ms ease,
+    border-color 160ms ease,
+    color 160ms ease;
+}
+
+.memoSaveButton:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.memoSaveButton:disabled {
+  border-color: var(--line);
+  background: var(--paper-2);
+  color: var(--ink-4);
+  cursor: not-allowed;
+}

--- a/frontend/src/pages/consultation/ui/sections/CustomerPanel.tsx
+++ b/frontend/src/pages/consultation/ui/sections/CustomerPanel.tsx
@@ -1,4 +1,5 @@
 import { Pill } from "@/shared/ui/ostone/atoms";
+import styles from "./CustomerPanel.module.css";
 import { InfoCard } from "./InfoCard";
 import { InfoRow } from "./InfoRow";
 import { ProgressStepper, type ProgressStepperStep } from "./ProgressStepper";
@@ -161,7 +162,10 @@ export function CustomerPanel({
       <InfoCard title="문의 관련 주문" meta={displayText(orderInfo?.orderNumber, "연동 정보 없음")}>
         {hasOrderInfo(orderInfo) ? (
           <>
-            <InfoRow label="주문번호" value={displayText(orderInfo?.orderNumber, "연동 정보 없음")} />
+            <InfoRow
+              label="주문번호"
+              value={displayText(orderInfo?.orderNumber, "연동 정보 없음")}
+            />
             <InfoRow label="주문일" value={displayText(orderInfo?.orderDate, "연동 정보 없음")} />
             <InfoRow
               label="결제금액"
@@ -184,7 +188,10 @@ export function CustomerPanel({
         )}
       </InfoCard>
 
-      <InfoCard title="처리 단계" meta={workflowSteps?.length ? `${workflowSteps.length} 단계` : "연동 정보 없음"}>
+      <InfoCard
+        title="처리 단계"
+        meta={workflowSteps?.length ? `${workflowSteps.length} 단계` : "연동 정보 없음"}
+      >
         {workflowSteps?.length ? (
           <ProgressStepper steps={workflowSteps} />
         ) : (
@@ -219,49 +226,26 @@ export function CustomerPanel({
         )}
       </InfoCard>
 
-      <InfoCard title="내부 메모" meta="NOTE 메시지">
-        <textarea
-          data-testid="customer-memo-textarea"
-          value={memo}
-          onChange={(e) => onMemoChange(e.target.value)}
-          placeholder="타임라인에 내부 메모로 남길 내용을 입력하세요..."
-          aria-label="내부 메모 입력"
-          style={{
-            width: "100%",
-            minHeight: 84,
-            padding: 10,
-            fontSize: 12.5,
-            lineHeight: 1.5,
-            border: "1px solid var(--line)",
-            borderRadius: "var(--r-3)",
-            background: "var(--paper)",
-            color: "var(--ink)",
-            resize: "vertical",
-            fontFamily: "inherit",
-          }}
-        />
-        <button
-          type="button"
-          data-testid="customer-memo-save"
-          onClick={onMemoSave}
-          disabled={isMemoSaveDisabled}
-          style={{
-            width: "100%",
-            marginTop: 10,
-            height: 36,
-            padding: "0 14px",
-            border: isMemoSaveDisabled ? "1px solid var(--line)" : "1px solid var(--ink)",
-            borderRadius: "var(--r-3)",
-            background: isMemoSaveDisabled ? "var(--paper-2)" : "var(--ink)",
-            color: isMemoSaveDisabled ? "var(--ink-4)" : "var(--paper)",
-            cursor: isMemoSaveDisabled ? "not-allowed" : "pointer",
-            fontSize: 12.5,
-            fontWeight: 600,
-            letterSpacing: "-0.1px",
-          }}
-        >
-          {isMemoSaving ? "남기는 중..." : "내부 메모로 남기기"}
-        </button>
+      <InfoCard title="내부 메모" meta="NOTE 메시지" style={{ padding: "14px 14px 14px" }}>
+        <div className={styles.memoComposer}>
+          <textarea
+            data-testid="customer-memo-textarea"
+            className={styles.memoTextarea}
+            value={memo}
+            onChange={(e) => onMemoChange(e.target.value)}
+            placeholder="타임라인에 내부 메모로 남길 내용을 입력하세요..."
+            aria-label="내부 메모 입력"
+          />
+          <button
+            type="button"
+            data-testid="customer-memo-save"
+            className={styles.memoSaveButton}
+            onClick={onMemoSave}
+            disabled={isMemoSaveDisabled}
+          >
+            {isMemoSaving ? "남기는 중..." : "내부 메모로 남기기"}
+          </button>
+        </div>
       </InfoCard>
     </div>
   );

--- a/frontend/src/pages/consultation/ui/sections/consultation-sections.test.tsx
+++ b/frontend/src/pages/consultation/ui/sections/consultation-sections.test.tsx
@@ -279,4 +279,55 @@ describe("CustomerPanel", () => {
     expect(screen.getByText("관리자 승인 필요")).toBeInTheDocument();
     expect(screen.getByText("2026-06-01T10:00:00+09:00")).toBeInTheDocument();
   });
+
+  it("내부 메모 입력 시 onMemoChange를 호출하고 작성형 카드 레이아웃을 사용한다", () => {
+    const onMemoChange = vi.fn();
+    render(
+      <CustomerPanel
+        customer={{ name: "김민지", channel: "WEB" }}
+        memo=""
+        onMemoChange={onMemoChange}
+        onMemoSave={vi.fn()}
+      />,
+    );
+
+    const textarea = screen.getByTestId("customer-memo-textarea");
+    fireEvent.change(textarea, { target: { value: "환불 확인 필요" } });
+    expect(onMemoChange).toHaveBeenCalledWith("환불 확인 필요");
+
+    // textarea와 저장 버튼을 감싸는 작성형 컨테이너가 존재한다.
+    const composer = textarea.parentElement;
+    expect(composer).not.toBeNull();
+    expect(composer).toContainElement(screen.getByTestId("customer-memo-save"));
+  });
+
+  it("내부 메모가 비어 있으면 저장 버튼이 비활성화되고, 내용이 있으면 클릭 시 onMemoSave를 호출한다", () => {
+    const onMemoSave = vi.fn();
+    const { rerender } = render(
+      <CustomerPanel
+        customer={{ name: "김민지", channel: "WEB" }}
+        memo="   "
+        onMemoChange={vi.fn()}
+        onMemoSave={onMemoSave}
+      />,
+    );
+
+    const saveButton = screen.getByTestId("customer-memo-save");
+    expect(saveButton).toBeDisabled();
+    fireEvent.click(saveButton);
+    expect(onMemoSave).not.toHaveBeenCalled();
+
+    rerender(
+      <CustomerPanel
+        customer={{ name: "김민지", channel: "WEB" }}
+        memo="환불 확인 필요"
+        onMemoChange={vi.fn()}
+        onMemoSave={onMemoSave}
+      />,
+    );
+
+    expect(saveButton).toBeEnabled();
+    fireEvent.click(saveButton);
+    expect(onMemoSave).toHaveBeenCalledTimes(1);
+  });
 });

--- a/frontend/src/pages/domain-pack/ui/DomainPackListPage.test.tsx
+++ b/frontend/src/pages/domain-pack/ui/DomainPackListPage.test.tsx
@@ -75,7 +75,7 @@ describe("DomainPackListPage", () => {
     expect(refetch).toHaveBeenCalled();
   });
 
-  it("빈 목록일 때 EmptyState를 표시하고 업로드 링크는 표시하지 않는다", () => {
+  it("빈 목록일 때 EmptyState와 업로드 화면으로 이동하는 CTA를 표시한다", () => {
     useListDomainPacks.mockReturnValue({
       isLoading: false,
       isError: false,
@@ -84,7 +84,10 @@ describe("DomainPackListPage", () => {
     });
     renderPage();
     expect(screen.getByTestId("empty-state")).toHaveTextContent("아직 도메인팩이 없습니다");
-    expect(screen.queryByText("상담 로그 업로드")).not.toBeInTheDocument();
+
+    const cta = screen.getByTestId("empty-upload-cta");
+    expect(cta).toHaveTextContent("상담 로그 업로드");
+    expect(cta).toHaveAttribute("href", "/workspaces/1/upload");
   });
 
   it("데이터가 있을 때 도메인팩 관리 제목과 목록을 렌더링한다", () => {
@@ -228,10 +231,7 @@ describe("DomainPackListPage", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "전체 2" }));
 
-    expect(screen.getByRole("button", { name: "전체 2" })).toHaveAttribute(
-      "aria-pressed",
-      "true",
-    );
+    expect(screen.getByRole("button", { name: "전체 2" })).toHaveAttribute("aria-pressed", "true");
     expect(screen.getByText("Live Pack")).toBeInTheDocument();
     expect(screen.getByText("Draft Pack")).toBeInTheDocument();
     expect(screen.getByText("운영중인 도메인팩")).toBeInTheDocument();
@@ -253,10 +253,7 @@ describe("DomainPackListPage", () => {
 
     renderPage("/workspaces/1/domain-packs?status=unknown");
 
-    expect(screen.getByRole("button", { name: "전체 2" })).toHaveAttribute(
-      "aria-pressed",
-      "true",
-    );
+    expect(screen.getByRole("button", { name: "전체 2" })).toHaveAttribute("aria-pressed", "true");
     expect(screen.getByText("Live Pack")).toBeInTheDocument();
     expect(screen.getByText("Draft Pack")).toBeInTheDocument();
   });

--- a/frontend/src/pages/domain-pack/ui/DomainPackListPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/DomainPackListPage.tsx
@@ -193,6 +193,13 @@ export function DomainPackListPage() {
       <div className={styles.pageWrapper}>
         <div className={styles.emptyPanel}>
           <EmptyState message="아직 도메인팩이 없습니다. 상담 로그를 업로드하여 첫 도메인팩을 생성하세요." />
+          <Link
+            to={`/workspaces/${parsedWorkspaceId}/upload`}
+            className={styles.uploadCta}
+            data-testid="empty-upload-cta"
+          >
+            상담 로그 업로드
+          </Link>
         </div>
       </div>
     );

--- a/frontend/src/pages/domain-pack/ui/domain-pack-list-page.module.css
+++ b/frontend/src/pages/domain-pack/ui/domain-pack-list-page.module.css
@@ -229,6 +229,37 @@
   margin: var(--s-6) var(--s-8);
 }
 
+.uploadCta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 40px;
+  padding: 0 var(--s-5);
+  border: 1px solid var(--ink);
+  border-radius: var(--r-pill);
+  background: var(--ink);
+  color: var(--paper);
+  font-family: var(--sans);
+  font-size: 13.5px;
+  font-weight: 540;
+  letter-spacing: -0.14px;
+  text-decoration: none;
+  transition:
+    background 160ms ease,
+    border-color 160ms ease,
+    color 160ms ease;
+}
+
+.uploadCta:hover {
+  background: var(--ink-2);
+  border-color: var(--ink-2);
+}
+
+.uploadCta:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
 .errorPanel {
   padding: var(--s-6) var(--s-8);
 }

--- a/frontend/src/shared/ui/ostone/chrome/Sidebar.test.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/Sidebar.test.tsx
@@ -59,10 +59,7 @@ describe("Sidebar", () => {
   it("Domain Packs 링크는 active=consult이면 비활성이다", () => {
     renderSidebar({ active: "consult" });
 
-    expect(screen.getByTestId("sidebar-domain-link")).toHaveAttribute(
-      "data-active",
-      "false",
-    );
+    expect(screen.getByTestId("sidebar-domain-link")).toHaveAttribute("data-active", "false");
   });
 
   it("접기 버튼을 렌더하지 않는다", () => {
@@ -74,31 +71,16 @@ describe("Sidebar", () => {
   it("active=consult일 때 Consultation 항목이 강조된다", () => {
     renderSidebar({ active: "consult" });
 
-    expect(screen.getByTitle("상담 응대")).toHaveAttribute(
-      "data-active",
-      "true",
-    );
+    expect(screen.getByTitle("상담 응대")).toHaveAttribute("data-active", "true");
   });
 
   it("basePath prop을 지정하면 링크에 반영된다", () => {
     renderSidebar({ basePath: "/workspaces/7" });
 
-    expect(screen.getByTitle("상담 응대")).toHaveAttribute(
-      "href",
-      "/workspaces/7/consultation",
-    );
-    expect(screen.getByTitle("사용자 화면 미리보기")).toHaveAttribute(
-      "href",
-      "/demo/chat/7",
-    );
-    expect(screen.getByTitle("사용자 화면 미리보기")).toHaveAttribute(
-      "target",
-      "_blank",
-    );
-    expect(screen.getByTitle("사용자 화면 미리보기")).toHaveAttribute(
-      "rel",
-      "noopener noreferrer",
-    );
+    expect(screen.getByTitle("상담 응대")).toHaveAttribute("href", "/workspaces/7/consultation");
+    expect(screen.getByTitle("사용자 화면 미리보기")).toHaveAttribute("href", "/demo/chat/7");
+    expect(screen.getByTitle("사용자 화면 미리보기")).toHaveAttribute("target", "_blank");
+    expect(screen.getByTitle("사용자 화면 미리보기")).toHaveAttribute("rel", "noopener noreferrer");
     expect(screen.getByTitle("도메인팩 관리")).toHaveAttribute(
       "href",
       "/workspaces/7/domain-packs",
@@ -108,10 +90,23 @@ describe("Sidebar", () => {
   it("workspaceId를 추출할 수 없으면 사용자 화면 미리보기 링크를 안전한 내부 경로로 보낸다", () => {
     renderSidebar({ basePath: "/workspaces" });
 
-    expect(screen.getByTitle("사용자 화면 미리보기")).toHaveAttribute(
-      "href",
-      "/workspaces",
-    );
+    expect(screen.getByTitle("사용자 화면 미리보기")).toHaveAttribute("href", "/workspaces");
+  });
+
+  it("외부 링크(사용자 화면 미리보기)에만 새 탭 안내 아이콘을 표시한다", () => {
+    renderSidebar({ basePath: "/workspaces/7" });
+
+    const externalIcon = screen.getByLabelText("새 탭에서 열림");
+    expect(externalIcon).toBeInTheDocument();
+    expect(screen.getByTestId("sidebar-link-chat")).toContainElement(externalIcon);
+    expect(screen.getAllByLabelText("새 탭에서 열림")).toHaveLength(1);
+
+    expect(
+      screen.getByTestId("sidebar-link-consult").querySelector('[aria-label="새 탭에서 열림"]'),
+    ).toBeNull();
+    expect(
+      screen.getByTestId("sidebar-domain-link").querySelector('[aria-label="새 탭에서 열림"]'),
+    ).toBeNull();
   });
 
   it("switcher가 주어지면 렌더링된다", () => {

--- a/frontend/src/shared/ui/ostone/chrome/Sidebar.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/Sidebar.tsx
@@ -1,4 +1,5 @@
 import type { CSSProperties, MouseEvent, ReactNode } from "react";
+import { ExternalLink } from "lucide-react";
 import { NavLink } from "react-router-dom";
 import { buildDemoChatPath } from "@/shared/lib/demoRoutes";
 import { Icon } from "../atoms/Icon";
@@ -94,14 +95,8 @@ export function Sidebar({
   basePath = "/workspaces",
   switcher,
 }: SidebarProps) {
-  const {
-    containerBg,
-    borderColor,
-    defaultColor,
-    hoverBg,
-    activeBg,
-    activeColor,
-  } = deriveSidebarColors(dark);
+  const { containerBg, borderColor, defaultColor, hoverBg, activeBg, activeColor } =
+    deriveSidebarColors(dark);
 
   return (
     <nav
@@ -284,14 +279,23 @@ function SidebarLink({
     }
   };
 
+  const isExternal = target === "_blank";
   const content = (
     <>
       <Icon name={icon} size={16} />
-      <span>{label}</span>
+      <span style={{ flex: 1, minWidth: 0 }}>{label}</span>
+      {isExternal ? (
+        <ExternalLink
+          size={13}
+          role="img"
+          aria-label="새 탭에서 열림"
+          style={{ flexShrink: 0, color: "var(--ink-3)" }}
+        />
+      ) : null}
     </>
   );
 
-  if (target === "_blank") {
+  if (isExternal) {
     return (
       <a
         href={to}


### PR DESCRIPTION
## 개요

상담 운영자 UX 관련 enhancement 이슈 5건을 취합해 수정합니다.

Closes #403, Closes #405, Closes #412, Closes #417, Closes #424

## 변경 사항

### #403 상담사 배정 사실을 사용자 채팅방에 안내 (BE + FE)
- `CounselorService.assignSession`에서 `SYSTEM` 역할 메시지("상담사가 배정되었습니다.")를 영속화하고 `/topic/chat.{sessionId}`로 afterCommit 브로드캐스트
- 기존 상담사 알림(`SessionAssignedEvent`)·상담 큐 갱신(`ConsultationQueueChangedEvent`)은 그대로 유지
- FE: `ChatMessage.senderType`에 `SYSTEM` 추가, 사용자 채팅에서 중앙 안내(pill, `role="status"`)로 렌더링 → 실시간 표시 + 새로고침 후 이력에서도 확인 가능

### #405 도메인 팩 변경 후 관련 화면 자동 갱신 (FE)
- 전역 QueryClient의 `refetchOnWindowFocus / refetchOnMount / refetchOnReconnect`를 활성화
- `staleTime`(60초)은 유지해 빠른 재진입·포커스 전환 시 API 호출 폭증 방지
- react-refresh 규칙 준수를 위해 설정을 `queryClient.ts`로 분리

### #412 사용자 화면 미리보기 링크에 외부 링크 아이콘 (FE)
- 사이드바 `external` 항목에만 lucide `ExternalLink` 아이콘 + `aria-label="새 탭에서 열림"` 표시 (내부 이동 메뉴에는 미표시)

### #417 내부 메모 입력 UI 여백·밀도 개선 (FE)
- 인라인 스타일을 `CustomerPanel.module.css`로 정리, `.memoComposer`(gap)로 textarea↔버튼 간격 확보
- 디자인 토큰 준수: weight 540, `:focus-visible` ring, `:disabled` 상태. 다른 정보 카드 밀도는 변경하지 않음

### #424 빈 도메인팩 화면에서 업로드로 연결 (FE)
- 빈 상태에 `/workspaces/{workspaceId}/upload`로 이동하는 CTA 추가 (잘못된 workspaceId fallback은 기존 동작 유지)

## 테스트 / 검증
- ✅ FE 1555 tests 통과 (신규/수정 6파일), BE 전체 `BUILD SUCCESSFUL`
- ✅ 신규 코드 커버리지: FE **95.62%**, BE 신규 메서드 **100%** (jacoco missed=0) — 임계 80% 상회
- ✅ reliability / security rating **A**, duplication 도입 없음
- ✅ Playwright MCP 런타임 검증 (local): #403 배정 시 시스템 메시지 실시간 표시·새로고침 이력 보존·상담사 뷰/큐 갱신, #412 외부 아이콘, #417 메모 카드 여백, #424 CTA 이동

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 세션 배정 시 채팅에 시스템 안내 메시지 표시
  * 상담 패널에 고객 메모 작성 및 저장 기능 추가
  * 도메인팩 빈 목록 상태에서 상담 로그 업로드 링크 제공

* **개선사항**
  * 외부 링크에 새 탭 아이콘 표시로 사용성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->