### PR TITLE
fix(chat-demo): 단문 입력 워크플로우 매칭 방지

### DIFF
--- a/.agent/specs/453.md
+++ b/.agent/specs/453.md
@@ -1,0 +1,78 @@
+# Backend Spec: 단문 인사말 워크플로우 매칭 방지
+
+## Goal
+
+데모 채팅에서 `안녕` 같은 컨텍스트가 부족한 단문 입력이 업무 워크플로우로 자동 매칭되지 않고, 추가 설명을 요청하는 fallback 응답으로 분기되게 한다.
+
+## Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    actor user as User
+    participant chat as Chat Demo
+    participant assistant as Workflow Assistant
+    participant matcher as WorkflowMatchingService
+    participant repo as Match Decision Repository
+
+    user ->> chat: "안녕"
+    chat ->> assistant: classify_intent
+    assistant ->> matcher: match(sessionId, latestMessage, context)
+    matcher ->> matcher: low-signal input 검사
+    matcher ->> repo: UNKNOWN / insufficient_context 기록
+    matcher ->> assistant: UNKNOWN + clarification message
+    assistant ->> chat: 추가 설명 요청 응답
+```
+
+## Problem
+
+현재 워크플로우 매칭은 임베딩 유사도와 후보 점수만으로 판단할 수 있어, 인사말이나 짧은 감탄사처럼 업무 의도를 확정하기 어려운 입력에도 특정 워크플로우 후보가 선택될 수 있다. 이 경우 사용자가 의도하지 않은 상담 플로우에 진입한다.
+
+## Scope
+
+- `backend/src/main/java/com/init/workflowruntime/application/matching/WorkflowMatchingService.java`
+  - 최신 사용자 발화와 대화 문맥에 업무 의도 신호가 부족한지 먼저 판단한다.
+  - 부족하면 후보 조회와 자동 실행 판단으로 진행하지 않고 `UNKNOWN` 결과와 clarification 메시지를 반환한다.
+  - 감사 로그에는 `insufficient_context` 실패 사유를 남긴다.
+- `backend/src/test/java/com/init/workflowruntime/application/matching/WorkflowMatchingServiceTest.java`
+  - `안녕` 같은 인사말은 workflow 후보가 있더라도 `UNKNOWN`으로 분기되는지 검증한다.
+  - `환불하고 싶어요`처럼 실제 문의 의도가 충분한 입력은 기존처럼 `CONFIDENT` 매칭되는지 유지 검증한다.
+
+## Requirements
+
+1. `안녕`, `안녕하세요`, `hi` 같은 인사말 단문은 업무 워크플로우로 자동 매칭하지 않는다.
+2. 의미 있는 업무 키워드가 없는 짧은 일반 발화는 사용자에게 추가 설명을 요청하는 fallback 메시지로 분기한다.
+3. fallback 메시지는 업무 의도를 더 자세히 말해 달라는 자연스러운 한국어 문장이어야 한다.
+4. 실제 문의 의도가 충분한 입력은 기존 워크플로우 매칭 경로를 유지한다.
+5. 매칭 실패 사유는 이후 운영 분석이 가능하도록 decision log에 남긴다.
+
+## Non-goals
+
+- 프론트엔드 채팅 UI 변경.
+- Domain Pack 또는 workflow schema 변경.
+- 임베딩 모델, profile build 파이프라인, Airflow DAG 변경.
+- small-talk 전용 워크플로우 신규 도입.
+
+## API / Data Impact
+
+- 외부 REST API 계약 변경은 없다.
+- DB 스키마 변경은 없다.
+- `workflow_match_decision` 기록의 `failureReason` 값으로 `insufficient_context`가 추가될 수 있다.
+
+## Validation
+
+| 구분 | 확인 항목 |
+|------|----------|
+| Unit Test | `WorkflowMatchingServiceTest`에서 인사말 단문이 `UNKNOWN`과 clarification 메시지를 반환한다 |
+| Regression Test | 기존 명확한 문의 입력이 `CONFIDENT` 매칭을 유지한다 |
+| Manual Check | 데모 채팅에서 `안녕` 입력 시 업무 플로우가 시작되지 않고 추가 설명 요청 응답이 나온다 |
+
+## Acceptance Criteria
+
+1. `안녕` 입력은 workflow 후보가 존재해도 `CONFIDENT` 또는 `AMBIGUOUS`가 아니라 `UNKNOWN`으로 처리된다.
+2. `UNKNOWN` 결과에는 `어떤 내용으로 문의하시려는지 조금 더 자세히 말씀해 주세요.` 메시지가 포함된다.
+3. `decisionRepository.record` 호출에는 `insufficient_context` 실패 사유가 기록된다.
+4. `환불하고 싶어요`와 같은 기존 명확한 업무 문의는 계속 `CONFIDENT`로 매칭된다.
+
+## Open Questions
+
+- 없음.

--- a/backend/src/main/java/com/init/workflowruntime/application/matching/WorkflowMatchingService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/matching/WorkflowMatchingService.java
@@ -27,10 +27,47 @@ import org.springframework.stereotype.Service;
 public class WorkflowMatchingService {
 
   private static final int MAX_CACHE_SIZE = 1_000;
+  private static final String CLARIFICATION_MESSAGE = "어떤 내용으로 문의하시려는지 조금 더 자세히 말씀해 주세요.";
   private static final Set<String> LEXICAL_STOP_WORDS =
       Set.of(
-          "고객", "고객님", "사용자", "문의", "요청", "확인", "처리", "관련", "하고", "싶어요", "합니다", "해주세요", "가능",
-          "가능한가", "어떻게", "무엇", "무슨", "어떤", "그럼", "그리고", "근데");
+          "고객",
+          "고객님",
+          "사용자",
+          "문의",
+          "문의하고",
+          "요청",
+          "요청하고",
+          "확인",
+          "확인하고",
+          "처리",
+          "처리하고",
+          "관련",
+          "하고",
+          "싶어요",
+          "합니다",
+          "해주세요",
+          "가능",
+          "가능한가",
+          "어떻게",
+          "무엇",
+          "무슨",
+          "어떤",
+          "그럼",
+          "그리고",
+          "근데",
+          "상담",
+          "도움",
+          "도와주세요",
+          "가능한가요",
+          "가능해요",
+          "user",
+          "assistant",
+          "system",
+          "counselor");
+  private static final Set<String> LOW_SIGNAL_TERMS =
+      Set.of(
+          "안녕", "안녕하세요", "안녕하십니까", "하이", "헬로", "hello", "hi", "네", "넵", "예", "응", "음", "아", "오",
+          "와", "감사", "감사합니다", "고마워", "고맙습니다");
 
   private final EmbeddingProperties properties;
   private final EmbeddingClient embeddingClient;
@@ -87,6 +124,13 @@ public class WorkflowMatchingService {
     String textHash = VectorUtils.sha256(redactedText);
 
     try {
+      if (lacksIntentSignal(latestUserMessage, conversationContext)) {
+        recordNoCandidate(session, textHash, "insufficient_context");
+        meterRegistry.counter("workflow_matching.insufficient_context").increment();
+        meterRegistry.counter("workflow_matching.result", "status", "UNKNOWN").increment();
+        return WorkflowMatchResult.unknown(CLARIFICATION_MESSAGE);
+      }
+
       int activeProfiles = profileRepository.countActiveProfiles(session.getDomainPackVersionId());
       if (activeProfiles == 0) {
         recordNoCandidate(session, textHash, "profile_missing");
@@ -119,6 +163,30 @@ public class WorkflowMatchingService {
     } finally {
       sample.stop(meterRegistry.timer("workflow_matching.match.latency"));
     }
+  }
+
+  private boolean lacksIntentSignal(String latestUserMessage, String conversationContext) {
+    String latest = normalizeForMatch(latestUserMessage);
+    if (latest.isBlank()) {
+      return !hasIntentSignal(conversationContext);
+    }
+    if (isLowSignalUtterance(latest)) {
+      return !hasIntentSignal(conversationContext);
+    }
+    return !hasIntentSignal(latestUserMessage) && !hasIntentSignal(conversationContext);
+  }
+
+  private boolean hasIntentSignal(String value) {
+    return lexicalTokens(value).stream().anyMatch(token -> !LOW_SIGNAL_TERMS.contains(token));
+  }
+
+  private boolean isLowSignalUtterance(String normalizedText) {
+    String compact = normalizedText.replace(" ", "");
+    if (LOW_SIGNAL_TERMS.contains(compact)) {
+      return true;
+    }
+    Set<String> tokens = rawTokens(normalizedText);
+    return !tokens.isEmpty() && tokens.stream().allMatch(LOW_SIGNAL_TERMS::contains);
   }
 
   private WorkflowMatchResult decide(List<WorkflowMatchCandidate> ranked) {
@@ -691,6 +759,14 @@ public class WorkflowMatchingService {
     Arrays.stream(nullToEmpty(value).toLowerCase(Locale.ROOT).split("[^0-9a-z가-힣]+"))
         .filter(token -> token.length() >= 2)
         .filter(token -> !LEXICAL_STOP_WORDS.contains(token))
+        .forEach(tokens::add);
+    return tokens;
+  }
+
+  private Set<String> rawTokens(String value) {
+    Set<String> tokens = new LinkedHashSet<>();
+    Arrays.stream(nullToEmpty(value).toLowerCase(Locale.ROOT).split("[^0-9a-z가-힣]+"))
+        .filter(token -> !token.isBlank())
         .forEach(tokens::add);
     return tokens;
   }

--- a/backend/src/test/java/com/init/workflowruntime/application/matching/WorkflowMatchingServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/matching/WorkflowMatchingServiceTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.init.workflowruntime.domain.ChatSession;
@@ -51,6 +52,66 @@ class WorkflowMatchingServiceTest {
             new ObjectMapper(),
             new SimpleMeterRegistry(),
             Clock.fixed(Instant.parse("2026-05-31T00:00:00Z"), ZoneOffset.UTC));
+  }
+
+  @Test
+  @DisplayName("단문 인사말은 프로필 조회 없이 UNKNOWN으로 분기하고 추가 설명을 요청한다")
+  void should_returnUnknown_when_shortGreetingLacksIntentSignal() {
+    givenSession();
+
+    WorkflowMatchResult result = service.match(1L, "안녕", "USER: 안녕");
+
+    assertThat(result.status()).isEqualTo("UNKNOWN");
+    assertThat(result.message()).isEqualTo("어떤 내용으로 문의하시려는지 조금 더 자세히 말씀해 주세요.");
+    assertThat(result.candidates()).isEmpty();
+    verifyNoInteractions(embeddingClient, profileRepository);
+    verify(decisionRepository)
+        .record(
+            eq(1L),
+            eq(101L),
+            eq(null),
+            eq(null),
+            eq("UNKNOWN"),
+            eq(0.0),
+            anyString(),
+            eq(null),
+            eq("bedrock"),
+            eq("cohere.embed-multilingual-v3"),
+            eq("ap-northeast-1"),
+            anyString(),
+            eq("{}"),
+            eq("[]"),
+            eq("insufficient_context"));
+  }
+
+  @Test
+  @DisplayName("업무 키워드 없는 일반 문의 표현은 UNKNOWN으로 분기한다")
+  void should_returnUnknown_when_genericInquiryLacksIntentSignal() {
+    givenSession();
+
+    WorkflowMatchResult result = service.match(1L, "문의하고 싶어요", "USER: 문의하고 싶어요");
+
+    assertThat(result.status()).isEqualTo("UNKNOWN");
+    assertThat(result.message()).isEqualTo("어떤 내용으로 문의하시려는지 조금 더 자세히 말씀해 주세요.");
+    assertThat(result.candidates()).isEmpty();
+    verifyNoInteractions(embeddingClient, profileRepository);
+    verify(decisionRepository)
+        .record(
+            eq(1L),
+            eq(101L),
+            eq(null),
+            eq(null),
+            eq("UNKNOWN"),
+            eq(0.0),
+            anyString(),
+            eq(null),
+            eq("bedrock"),
+            eq("cohere.embed-multilingual-v3"),
+            eq("ap-northeast-1"),
+            anyString(),
+            eq("{}"),
+            eq("[]"),
+            eq("insufficient_context"));
   }
 
   @Test


### PR DESCRIPTION
## Summary
- 데모 채팅 워크플로우 매칭 전에 최신 발화와 대화 문맥의 업무 의도 신호를 검사합니다.
- `안녕`, `문의하고 싶어요`처럼 컨텍스트가 부족한 입력은 프로필 조회와 임베딩 없이 clarification fallback으로 분기합니다.
- `insufficient_context` decision log와 회귀 테스트를 추가해 실제 업무 문의의 기존 CONFIDENT 매칭은 유지합니다.

## Validation
- `docker run --rm --user "$(id -u):$(id -g)" -e GRADLE_USER_HOME=/tmp/gradle-cache -v "$PWD":/workspace -v "$HOME/.gradle":/tmp/gradle-cache -w /workspace/backend gradle:9.2-jdk21 ./gradlew spotlessCheck --no-daemon`
- `docker run --rm --user "$(id -u):$(id -g)" -e GRADLE_USER_HOME=/tmp/gradle-cache -e GRADLE_OPTS="-Dorg.gradle.jvmargs=-Xmx256m -XX:MaxMetaspaceSize=256m" -v "$PWD":/workspace -v "$HOME/.gradle":/tmp/gradle-cache -w /workspace/backend gradle:9.2-jdk21 ./gradlew test --no-daemon --max-workers=1`
- `git diff --check`
- `git diff --cached --check`

Closes #453