### PR TITLE
fix(infra): RDS master password 제약 사전 검증

### DIFF
--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -92,6 +92,16 @@ variable "db_master_password" {
   description = "RDS PostgreSQL master password."
   type        = string
   sensitive   = true
+
+  validation {
+    condition = (
+      length(var.db_master_password) >= 8
+      && length(var.db_master_password) <= 128
+      && can(regex("^[!-~]+$", var.db_master_password))
+      && length(regexall("[/@\"]", var.db_master_password)) == 0
+    )
+    error_message = "db_master_password must be 8-128 printable ASCII characters and cannot contain '/', '@', double quote, or spaces."
+  }
 }
 
 variable "app_db_password" {


### PR DESCRIPTION
## 변경 내용
- RDS master password 변수에 AWS RDS PostgreSQL 제약과 동일한 길이/문자 검증을 추가했습니다.
- 금지 문자(`/`, `@`, double quote, 공백)가 포함된 값은 Terraform 단계에서 먼저 실패하도록 했습니다.

## 확인 사항
- GitHub Secret `PROD_DB_MASTER_PASSWORD`를 RDS 허용 문자만 포함하는 새 hex 값으로 교체했습니다.
- `terraform -chdir=infra/terraform fmt -check`
- `terraform -chdir=infra/terraform init -backend=false`
- `terraform -chdir=infra/terraform validate`