### PR TITLE
fix(chat-demo-fe): 상담사 배정 후 봇 타이핑 상태 정리

### DIFF
--- a/frontend/src/pages/user-chat/ui/UserChatPage.test.tsx
+++ b/frontend/src/pages/user-chat/ui/UserChatPage.test.tsx
@@ -51,6 +51,14 @@ function createDeferred<T>() {
   return { promise, resolve, reject };
 }
 
+type DeferredChatMessage = {
+  id: string;
+  sessionId: number;
+  content: string;
+  senderType: "USER" | "BOT";
+  createdAt: string;
+};
+
 describe("UserChatPage", () => {
   beforeEach(() => {
     routeState.workspaceId = "42";
@@ -377,15 +385,7 @@ describe("UserChatPage", () => {
   });
 
   it("USER-only 성공 응답은 사용자 메시지를 유지하고 봇 타이핑을 종료한다", async () => {
-    const response = createDeferred<
-      Array<{
-        id: string;
-        sessionId: number;
-        content: string;
-        senderType: "USER";
-        createdAt: string;
-      }>
-    >();
+    const response = createDeferred<DeferredChatMessage[]>();
     stompState.connectionStatus = "CONNECTED";
     sendDemoChatMessageMock.mockReturnValueOnce(response.promise);
 
@@ -423,6 +423,97 @@ describe("UserChatPage", () => {
     expect(
       screen.queryByText("응답을 생성하지 못했습니다. 잠시 후 다시 시도해 주세요."),
     ).toBeNull();
+  });
+
+  it("이전 세션 전송 응답이 늦게 도착해도 현재 세션 봇 타이핑을 종료하지 않는다", async () => {
+    const previousResponse = createDeferred<DeferredChatMessage[]>();
+    const currentResponse = createDeferred<DeferredChatMessage[]>();
+    stompState.connectionStatus = "CONNECTED";
+    registerDemoChatSessionMock
+      .mockResolvedValueOnce({
+        id: "77",
+        status: "OPEN",
+        startedAt: "2026-05-22T00:00:00Z",
+        messages: [],
+      })
+      .mockResolvedValueOnce({
+        id: "88",
+        status: "OPEN",
+        startedAt: "2026-05-22T00:10:00Z",
+        messages: [],
+      });
+    listDemoChatMessagesMock.mockImplementation((_workspaceId: number, sessionId: string) =>
+      Promise.resolve([
+        {
+          id: `greeting-${sessionId}`,
+          sessionId: Number(sessionId),
+          content: `세션 ${sessionId} 안내입니다.`,
+          senderType: "BOT",
+          createdAt: "2026-05-22T00:00:00Z",
+        },
+      ]),
+    );
+    sendDemoChatMessageMock
+      .mockReturnValueOnce(previousResponse.promise)
+      .mockReturnValueOnce(currentResponse.promise);
+
+    render(<UserChatPage />);
+    fireEvent.change(screen.getByLabelText("이름"), { target: { value: "김민지" } });
+    fireEvent.click(screen.getByRole("button", { name: "미리보기 시작" }));
+
+    const firstInput = await screen.findByLabelText("메시지 입력");
+    await waitFor(() => {
+      expect(stompState.subscribe).toHaveBeenCalledWith("/topic/chat.77", expect.any(Function));
+    });
+    fireEvent.change(firstInput, { target: { value: "첫 번째 문의" } });
+    fireEvent.click(screen.getByRole("button", { name: "메시지 보내기" }));
+    expect(await screen.findByTestId("bot-typing-indicator")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "새 테스트 세션 시작" }));
+    expect(await screen.findByText("세션 88 안내입니다.")).toBeInTheDocument();
+
+    const secondInput = screen.getByLabelText("메시지 입력");
+    fireEvent.change(secondInput, { target: { value: "두 번째 문의" } });
+    fireEvent.click(screen.getByRole("button", { name: "메시지 보내기" }));
+
+    await waitFor(() => {
+      expect(sendDemoChatMessageMock).toHaveBeenCalledWith(42, "88", "두 번째 문의");
+    });
+    expect(screen.getByTestId("bot-typing-indicator")).toBeInTheDocument();
+
+    await act(async () => {
+      previousResponse.resolve([
+        {
+          id: "81",
+          sessionId: 77,
+          content: "첫 번째 문의",
+          senderType: "USER",
+          createdAt: "2026-05-22T00:00:01Z",
+        },
+      ]);
+      await previousResponse.promise;
+    });
+
+    expect(screen.getByTestId("bot-typing-indicator")).toBeInTheDocument();
+    expect(screen.queryByTestId("message-81")).toBeNull();
+
+    await act(async () => {
+      currentResponse.resolve([
+        {
+          id: "91",
+          sessionId: 88,
+          content: "두 번째 문의",
+          senderType: "USER",
+          createdAt: "2026-05-22T00:10:01Z",
+        },
+      ]);
+      await currentResponse.promise;
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("bot-typing-indicator")).not.toBeInTheDocument();
+    });
+    expect(screen.getByTestId("message-91")).toBeInTheDocument();
   });
 
   it("WebSocket user 메시지는 optimistic 메시지를 서버 메시지로 교체한다", async () => {

--- a/frontend/src/pages/user-chat/ui/UserChatPage.test.tsx
+++ b/frontend/src/pages/user-chat/ui/UserChatPage.test.tsx
@@ -41,6 +41,16 @@ vi.mock("react-router-dom", async () => {
   };
 });
 
+function createDeferred<T>() {
+  let resolve: (value: T | PromiseLike<T>) => void = () => {};
+  let reject: (reason?: unknown) => void = () => {};
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
+}
+
 describe("UserChatPage", () => {
   beforeEach(() => {
     routeState.workspaceId = "42";
@@ -340,7 +350,7 @@ describe("UserChatPage", () => {
     });
   });
 
-  it("메시지 전송 직후 사용자 메시지를 표시하고 REST 응답만으로는 봇 답변을 추가하지 않는다", async () => {
+  it("REST 응답에 봇 메시지가 있으면 최소 입력 표시 시간 이후 렌더링한다", async () => {
     stompState.connectionStatus = "CONNECTED";
 
     render(<UserChatPage />);
@@ -359,11 +369,67 @@ describe("UserChatPage", () => {
     });
     expect(screen.getByText("Hello")).not.toBeNull();
     expect(screen.queryByText("LLM 응답입니다.")).toBeNull();
+    expect(screen.getByTestId("bot-typing-indicator")).toBeInTheDocument();
+    expect(
+      await screen.findByText("LLM 응답입니다.", undefined, { timeout: 1500 }),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("bot-typing-indicator")).not.toBeInTheDocument();
+  });
+
+  it("USER-only 성공 응답은 사용자 메시지를 유지하고 봇 타이핑을 종료한다", async () => {
+    const response = createDeferred<
+      Array<{
+        id: string;
+        sessionId: number;
+        content: string;
+        senderType: "USER";
+        createdAt: string;
+      }>
+    >();
+    stompState.connectionStatus = "CONNECTED";
+    sendDemoChatMessageMock.mockReturnValueOnce(response.promise);
+
+    render(<UserChatPage />);
+    fireEvent.change(screen.getByLabelText("이름"), { target: { value: "김민지" } });
+    fireEvent.click(screen.getByRole("button", { name: "미리보기 시작" }));
+
+    const input = await screen.findByLabelText("메시지 입력");
+    await waitFor(() => {
+      expect(stompState.subscribe).toHaveBeenCalledWith("/topic/chat.77", expect.any(Function));
+    });
+    fireEvent.change(input, { target: { value: "아직 답변 없나요?" } });
+    fireEvent.click(screen.getByRole("button", { name: "메시지 보내기" }));
+
+    expect(await screen.findByTestId("bot-typing-indicator")).toBeInTheDocument();
+
+    await act(async () => {
+      response.resolve([
+        {
+          id: "81",
+          sessionId: 77,
+          content: "아직 답변 없나요?",
+          senderType: "USER",
+          createdAt: "2026-05-22T00:00:01Z",
+        },
+      ]);
+      await response.promise;
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("bot-typing-indicator")).not.toBeInTheDocument();
+    });
+    expect(screen.getAllByText("아직 답변 없나요?")).toHaveLength(1);
+    expect(screen.getByTestId("message-81")).toBeInTheDocument();
+    expect(
+      screen.queryByText("응답을 생성하지 못했습니다. 잠시 후 다시 시도해 주세요."),
+    ).toBeNull();
   });
 
   it("WebSocket user 메시지는 optimistic 메시지를 서버 메시지로 교체한다", async () => {
+    const response = createDeferred<[]>();
     let topicHandler: ((message: unknown) => void) | undefined;
     stompState.connectionStatus = "CONNECTED";
+    sendDemoChatMessageMock.mockReturnValueOnce(response.promise);
     stompState.subscribe.mockImplementation((_topic: string, cb: (message: unknown) => void) => {
       topicHandler = cb;
       return () => {};
@@ -393,6 +459,55 @@ describe("UserChatPage", () => {
 
     expect(screen.getAllByText("Hello")).toHaveLength(1);
     expect(screen.getByTestId("message-81")).not.toBeNull();
+
+    await act(async () => {
+      response.resolve([]);
+      await response.promise;
+    });
+  });
+
+  it("상담사 배정 SYSTEM 메시지가 오면 봇 타이핑을 종료한다", async () => {
+    const response = createDeferred<[]>();
+    let topicHandler: ((message: unknown) => void) | undefined;
+    stompState.connectionStatus = "CONNECTED";
+    sendDemoChatMessageMock.mockReturnValueOnce(response.promise);
+    stompState.subscribe.mockImplementation((_topic: string, cb: (message: unknown) => void) => {
+      topicHandler = cb;
+      return () => {};
+    });
+
+    render(<UserChatPage />);
+    fireEvent.change(screen.getByLabelText("이름"), { target: { value: "김민지" } });
+    fireEvent.click(screen.getByRole("button", { name: "미리보기 시작" }));
+
+    const input = await screen.findByLabelText("메시지 입력");
+    await waitFor(() => {
+      expect(topicHandler).toBeDefined();
+    });
+
+    fireEvent.change(input, { target: { value: "상담사 연결 부탁드립니다" } });
+    fireEvent.click(screen.getByRole("button", { name: "메시지 보내기" }));
+
+    expect(await screen.findByTestId("bot-typing-indicator")).toBeInTheDocument();
+
+    act(() => {
+      topicHandler?.({
+        id: 90,
+        senderRole: "SYSTEM",
+        content: "상담사가 배정되었습니다.",
+        createdAt: "2026-05-22T00:00:03Z",
+      });
+    });
+
+    expect(await screen.findByText("상담사가 배정되었습니다.")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByTestId("bot-typing-indicator")).not.toBeInTheDocument();
+    });
+
+    await act(async () => {
+      response.resolve([]);
+      await response.promise;
+    });
   });
 
   it("사용자 전송 후 WebSocket 봇 응답을 최소 입력 표시 시간 이후 렌더링한다", async () => {

--- a/frontend/src/pages/user-chat/ui/UserChatPage.tsx
+++ b/frontend/src/pages/user-chat/ui/UserChatPage.tsx
@@ -63,6 +63,14 @@ function withoutLocalUserMessages(messages: ChatMessage[]): ChatMessage[] {
   return messages.filter((message) => !isLocalUserMessage(message));
 }
 
+function isBotMessage(message: ChatMessage): boolean {
+  return message.senderType === "BOT";
+}
+
+function shouldStopBotTypingForRealtimeMessage(message: ChatMessage): boolean {
+  return message.senderType === "AGENT" || message.senderType === "SYSTEM";
+}
+
 function createLocalUserMessage(
   sessionId: number,
   customerName: string,
@@ -219,6 +227,13 @@ export function UserChatPage() {
     botTypingTimeoutRef.current = null;
   }, []);
 
+  const stopBotTyping = useCallback(() => {
+    pendingBotMessagesRef.current = [];
+    botTypingDelayUntilRef.current = 0;
+    clearBotTypingTimeout();
+    setBotTyping(false);
+  }, [clearBotTypingTimeout, setBotTyping]);
+
   const appendRealtimeMessages = useCallback(
     (nextMessages: ChatMessage[]) => {
       if (!activeSessionId || !customerName || nextMessages.length === 0) return;
@@ -252,6 +267,7 @@ export function UserChatPage() {
     clearBotTypingTimeout();
     const pendingMessages = pendingBotMessagesRef.current;
     pendingBotMessagesRef.current = [];
+    botTypingDelayUntilRef.current = 0;
     appendRealtimeMessages(pendingMessages);
     setBotTyping(false);
   }, [appendRealtimeMessages, clearBotTypingTimeout, setBotTyping]);
@@ -280,11 +296,8 @@ export function UserChatPage() {
   }, [setBotTyping]);
 
   useEffect(() => {
-    pendingBotMessagesRef.current = [];
-    botTypingDelayUntilRef.current = 0;
-    setBotTyping(false);
-    clearBotTypingTimeout();
-  }, [activeSessionId, clearBotTypingTimeout, customerName, setBotTyping]);
+    stopBotTyping();
+  }, [activeSessionId, customerName, stopBotTyping]);
 
   useEffect(() => clearBotTypingTimeout, [clearBotTypingTimeout]);
 
@@ -391,7 +404,18 @@ export function UserChatPage() {
     });
 
     try {
-      await sendDemoChatMessage(workspaceId, activeSession.id, content);
+      const responseMessages = withCustomerNames(
+        await sendDemoChatMessage(workspaceId, activeSession.id, content),
+        customerName,
+      );
+      const botMessages = responseMessages.filter(isBotMessage);
+      appendRealtimeMessages(responseMessages.filter((message) => !isBotMessage(message)));
+
+      if (botMessages.length > 0) {
+        botMessages.forEach(queueBotMessage);
+      } else {
+        stopBotTyping();
+      }
     } catch {
       setChatState((current) => {
         if (current.session?.id !== activeSession.id || current.customerName !== customerName) {
@@ -406,9 +430,7 @@ export function UserChatPage() {
         };
       });
       setMessageError("응답을 생성하지 못했습니다. 잠시 후 다시 시도해 주세요.");
-      pendingBotMessagesRef.current = [];
-      clearBotTypingTimeout();
-      setBotTyping(false);
+      stopBotTyping();
     } finally {
       setIsSending(false);
     }
@@ -473,6 +495,9 @@ export function UserChatPage() {
         return;
       }
       appendRealtimeMessages([nextMessage]);
+      if (isBotTypingRef.current && shouldStopBotTypingForRealtimeMessage(nextMessage)) {
+        stopBotTyping();
+      }
     });
   }, [
     activeSessionId,
@@ -480,6 +505,7 @@ export function UserChatPage() {
     connectionStatus,
     customerName,
     queueBotMessage,
+    stopBotTyping,
     subscribe,
   ]);
 

--- a/frontend/src/pages/user-chat/ui/UserChatPage.tsx
+++ b/frontend/src/pages/user-chat/ui/UserChatPage.tsx
@@ -210,6 +210,11 @@ export function UserChatPage() {
   const botTypingDelayUntilRef = useRef(0);
   const botTypingTimeoutRef = useRef<number | null>(null);
   const pendingBotMessagesRef = useRef<ChatMessage[]>([]);
+  const activeConversationRef = useRef<{ sessionId: string | null; customerName: string | null }>({
+    sessionId: null,
+    customerName: null,
+  });
+  const sendRequestIdRef = useRef(0);
   const [chatState, setChatState] = useState<{
     workspaceId: number | null;
     customerName: string | null;
@@ -222,10 +227,16 @@ export function UserChatPage() {
       ? chatState
       : { session: null, error: null };
   const activeSessionId = activeChatState.session?.id ?? null;
+  activeConversationRef.current = { sessionId: activeSessionId, customerName };
 
   const setBotTyping = useCallback((nextValue: boolean) => {
     isBotTypingRef.current = nextValue;
     setIsBotTyping(nextValue);
+  }, []);
+
+  const isCurrentConversation = useCallback((sessionId: string, nextCustomerName: string) => {
+    const current = activeConversationRef.current;
+    return current.sessionId === sessionId && current.customerName === nextCustomerName;
   }, []);
 
   const clearBotTypingTimeout = useCallback(() => {
@@ -303,6 +314,7 @@ export function UserChatPage() {
   }, [setBotTyping]);
 
   useEffect(() => {
+    setIsSending(false);
     stopBotTyping();
   }, [activeSessionId, customerName, stopBotTyping]);
 
@@ -393,12 +405,15 @@ export function UserChatPage() {
       return;
     }
 
-    const localMessage = createLocalUserMessage(numericSessionId, customerName, content);
+    const requestId = ++sendRequestIdRef.current;
+    const requestSessionId = activeSession.id;
+    const requestCustomerName = customerName;
+    const localMessage = createLocalUserMessage(numericSessionId, requestCustomerName, content);
     setMessageError(null);
     setIsSending(true);
     startBotTypingDelay();
     setChatState((current) => {
-      if (current.session?.id !== activeSession.id || current.customerName !== customerName) {
+      if (current.session?.id !== requestSessionId || current.customerName !== requestCustomerName) {
         return current;
       }
       return {
@@ -412,9 +427,11 @@ export function UserChatPage() {
 
     try {
       const responseMessages = withCustomerNames(
-        await sendDemoChatMessage(workspaceId, activeSession.id, content),
-        customerName,
+        await sendDemoChatMessage(workspaceId, requestSessionId, content),
+        requestCustomerName,
       );
+      if (!isCurrentConversation(requestSessionId, requestCustomerName)) return;
+
       const botMessages = responseMessages.filter(isBotMessage);
       appendRealtimeMessages(responseMessages.filter((message) => !isBotMessage(message)));
 
@@ -425,7 +442,7 @@ export function UserChatPage() {
       }
     } catch (error) {
       setChatState((current) => {
-        if (current.session?.id !== activeSession.id || current.customerName !== customerName) {
+        if (current.session?.id !== requestSessionId || current.customerName !== requestCustomerName) {
           return current;
         }
         return {
@@ -436,10 +453,17 @@ export function UserChatPage() {
           },
         };
       });
-      setMessageError(resolveMessageSendErrorMessage(error));
-      stopBotTyping();
+      if (isCurrentConversation(requestSessionId, requestCustomerName)) {
+        setMessageError(resolveMessageSendErrorMessage(error));
+        stopBotTyping();
+      }
     } finally {
-      setIsSending(false);
+      if (
+        sendRequestIdRef.current === requestId &&
+        isCurrentConversation(requestSessionId, requestCustomerName)
+      ) {
+        setIsSending(false);
+      }
     }
   };
 


### PR DESCRIPTION
## Summary

- 데모 고객 채팅에서 메시지 전송 응답이 USER-only인 경우를 정상 성공으로 처리합니다.
- 상담사 배정 이후 봇 응답이 생성되지 않아도 bot typing indicator가 남지 않도록 정리합니다.
- WebSocket으로 상담사 배정 SYSTEM 메시지 또는 상담사 메시지가 도착하면 진행 중인 bot typing 상태를 종료합니다.
- USER-only 응답, REST 봇 응답 지연 표시, 배정 SYSTEM 메시지 수신 케이스를 테스트에 추가했습니다.

## Why

상담사 배정 이후 백엔드는 데모 고객 메시지만 저장하고 ASSISTANT 자동응답을 생성하지 않을 수 있습니다. 기존 프론트는 전송 직후 봇 타이핑을 시작한 뒤 봇 메시지 수신을 전제로 상태를 종료해서, 정상적인 USER-only 응답에서도 타이핑 표시가 남을 수 있었습니다.

## Validation

- pnpm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 봇 타이핑 상태 관리 개선: 타이머·대기 큐·플래그 일관 초기화 및 세션/고객 변경 시 정리
  * 실시간 수신 시 타이핑 종료 조건 정교화 및 전송 실패 시 중복 정리 방지
  * 응답 처리 시 현재 대화 일치 여부로 상태 변경을 제한해 잘못된 업데이트 방지

* **Tests**
  * 비동기 응답 타이밍 제어로 REST/WebSocket 시나리오 검증 강화
  * 낡은 세션 응답이 현재 세션 동작에 영향 주지 않는지 및 시스템(상담사 배정) 수신 시 타이핑 종료 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->