### PR TITLE
feat(infra): enable ecs airflow ml pipeline deploy

### DIFF
--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -7,6 +7,7 @@ on:
       - "backend/**"
       - "frontend/**"
       - "ml/**"
+      - "infra/terraform/**"
       - ".github/workflows/prod-deploy.yml"
   workflow_dispatch:
 
@@ -24,7 +25,8 @@ jobs:
     outputs:
       backend: ${{ steps.filter.outputs.backend }}
       frontend: ${{ steps.filter.outputs.frontend }}
-      ml_embedder: ${{ steps.filter.outputs.ml_embedder }}
+      airflow: ${{ steps.filter.outputs.airflow }}
+      ml: ${{ steps.filter.outputs.ml }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
@@ -35,14 +37,21 @@ jobs:
           filters: |
             backend:
               - "backend/**"
+              - "infra/terraform/**"
               - ".github/workflows/prod-deploy.yml"
             frontend:
               - "frontend/**"
+              - "infra/terraform/**"
               - ".github/workflows/prod-deploy.yml"
-            ml_embedder:
+            airflow:
+              - "ml/airflow/**"
+              - "ml/src/**"
+              - "infra/terraform/**"
+              - ".github/workflows/prod-deploy.yml"
+            ml:
               - "ml/**"
+              - "infra/terraform/**"
               - ".github/workflows/prod-deploy.yml"
-
   terraform:
     runs-on: ubuntu-latest
     environment: prod
@@ -51,12 +60,18 @@ jobs:
       cloudfront_distribution_id: ${{ steps.tf_outputs.outputs.cloudfront_distribution_id }}
       ecs_cluster_name: ${{ steps.tf_outputs.outputs.ecs_cluster_name }}
       backend_service_name: ${{ steps.tf_outputs.outputs.backend_service_name }}
+      airflow_init_task_definition_arn: ${{ steps.tf_outputs.outputs.airflow_init_task_definition_arn }}
+      airflow_apiserver_service_name: ${{ steps.tf_outputs.outputs.airflow_apiserver_service_name }}
+      airflow_scheduler_service_name: ${{ steps.tf_outputs.outputs.airflow_scheduler_service_name }}
+      airflow_dag_processor_service_name: ${{ steps.tf_outputs.outputs.airflow_dag_processor_service_name }}
+      private_subnet_ids: ${{ steps.tf_outputs.outputs.private_subnet_ids }}
+      ecs_airflow_security_group_id: ${{ steps.tf_outputs.outputs.ecs_airflow_security_group_id }}
     env:
       TF_VAR_domain_name: ${{ vars.PROD_DOMAIN_NAME }}
       TF_VAR_route53_zone_id: ${{ vars.PROD_ROUTE53_ZONE_ID || '' }}
       TF_VAR_manage_route53_zone: ${{ vars.PROD_MANAGE_ROUTE53_ZONE || 'false' }}
       TF_VAR_admin_cidr: ${{ vars.PROD_ADMIN_CIDR }}
-      TF_VAR_airflow_api_base_url: ${{ vars.PROD_AIRFLOW_API_BASE_URL }}
+      TF_VAR_airflow_api_base_url: ${{ vars.PROD_AIRFLOW_API_BASE_URL || '' }}
       TF_VAR_airflow_api_allow_insecure_http: ${{ vars.PROD_AIRFLOW_API_ALLOW_INSECURE_HTTP || 'false' }}
       TF_VAR_gpu_instance_type: ${{ vars.PROD_GPU_INSTANCE_TYPE || 'g6.2xlarge' }}
       TF_VAR_gpu_asg_max_size: ${{ vars.PROD_GPU_ASG_MAX_SIZE || '1' }}
@@ -76,6 +91,11 @@ jobs:
       TF_VAR_airflow_api_username: ${{ secrets.PROD_AIRFLOW_API_USERNAME }}
       TF_VAR_airflow_api_password: ${{ secrets.PROD_AIRFLOW_API_PASSWORD }}
       TF_VAR_airflow_webhook_secret: ${{ secrets.PROD_AIRFLOW_WEBHOOK_SECRET }}
+      TF_VAR_airflow_fernet_key: ${{ secrets.PROD_AIRFLOW_FERNET_KEY }}
+      TF_VAR_airflow_api_secret_key: ${{ secrets.PROD_AIRFLOW_API_SECRET_KEY }}
+      TF_VAR_airflow_api_auth_jwt_secret: ${{ secrets.PROD_AIRFLOW_API_AUTH_JWT_SECRET }}
+      TF_VAR_airflow_simple_admin_password: ${{ secrets.PROD_AIRFLOW_SIMPLE_ADMIN_PASSWORD }}
+      TF_VAR_airflow_simple_viewer_password: ${{ secrets.PROD_AIRFLOW_SIMPLE_VIEWER_PASSWORD }}
       TF_VAR_llm_runtime_api_key: ${{ secrets.PROD_LLM_RUNTIME_API_KEY || '' }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -104,7 +124,6 @@ jobs:
           required=(
             TF_VAR_domain_name
             TF_VAR_admin_cidr
-            TF_VAR_airflow_api_base_url
             TF_VAR_db_master_password
             TF_VAR_app_db_password
             TF_VAR_airflow_db_password
@@ -112,6 +131,11 @@ jobs:
             TF_VAR_airflow_api_username
             TF_VAR_airflow_api_password
             TF_VAR_airflow_webhook_secret
+            TF_VAR_airflow_fernet_key
+            TF_VAR_airflow_api_secret_key
+            TF_VAR_airflow_api_auth_jwt_secret
+            TF_VAR_airflow_simple_admin_password
+            TF_VAR_airflow_simple_viewer_password
           )
           for name in "${required[@]}"; do
             test -n "${!name:-}" || { echo "$name is required"; exit 1; }
@@ -131,6 +155,12 @@ jobs:
             echo "cloudfront_distribution_id=$(terraform output -raw cloudfront_distribution_id)"
             echo "ecs_cluster_name=$(terraform output -raw ecs_cluster_name)"
             echo "backend_service_name=$(terraform output -raw backend_service_name)"
+            echo "airflow_init_task_definition_arn=$(terraform output -raw airflow_init_task_definition_arn)"
+            echo "airflow_apiserver_service_name=$(terraform output -raw airflow_apiserver_service_name)"
+            echo "airflow_scheduler_service_name=$(terraform output -raw airflow_scheduler_service_name)"
+            echo "airflow_dag_processor_service_name=$(terraform output -raw airflow_dag_processor_service_name)"
+            echo "ecs_airflow_security_group_id=$(terraform output -raw ecs_airflow_security_group_id)"
+            echo "private_subnet_ids=$(terraform output -json private_subnet_ids | jq -r 'join(\",\")')"
           } >> "$GITHUB_OUTPUT"
 
   backend:
@@ -271,9 +301,9 @@ jobs:
         run: |
           aws cloudfront create-invalidation --distribution-id "$CLOUDFRONT_DISTRIBUTION_ID" --paths "/*"
 
-  ml-embedder:
+  ml:
     needs: [paths-filter, terraform]
-    if: ${{ github.event_name == 'workflow_dispatch' || needs.paths-filter.outputs.ml_embedder == 'true' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.paths-filter.outputs.ml == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -290,9 +320,20 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419
 
-      - name: Build, tag, and push ML embedder image to ECR
+      - name: Build, tag, and push ML stage CPU image to ECR
         env:
-          ECR_REPOSITORY: ostone/ml-embedder
+          ECR_REPOSITORY: ostone/ml-stage-cpu
+          IMAGE_TAG: ${{ github.sha }}
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        run: |
+          docker build -t "$ECR_REPOSITORY:$IMAGE_TAG" -f ml/Dockerfile.cpu .
+          docker tag "$ECR_REPOSITORY:$IMAGE_TAG" "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+          docker tag "$ECR_REPOSITORY:$IMAGE_TAG" "$ECR_REGISTRY/$ECR_REPOSITORY:latest"
+          docker push --all-tags "$ECR_REGISTRY/$ECR_REPOSITORY"
+
+      - name: Build, tag, and push ML stage GPU image to ECR
+        env:
+          ECR_REPOSITORY: ostone/ml-stage-gpu
           IMAGE_TAG: ${{ github.sha }}
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         run: |
@@ -300,3 +341,123 @@ jobs:
           docker tag "$ECR_REPOSITORY:$IMAGE_TAG" "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
           docker tag "$ECR_REPOSITORY:$IMAGE_TAG" "$ECR_REGISTRY/$ECR_REPOSITORY:latest"
           docker push --all-tags "$ECR_REGISTRY/$ECR_REPOSITORY"
+
+  airflow:
+    needs: [paths-filter, terraform, ml]
+    if: ${{ always() && (github.event_name == 'workflow_dispatch' || needs.paths-filter.outputs.airflow == 'true' || needs.paths-filter.outputs.ml == 'true') && needs.terraform.result == 'success' && (needs.ml.result == 'success' || needs.ml.result == 'skipped') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a
+        with:
+          aws-region: ap-northeast-2
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419
+
+      - name: Build, tag, and push Airflow image to ECR
+        env:
+          ECR_REPOSITORY: ostone/airflow
+          IMAGE_TAG: ${{ github.sha }}
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        run: |
+          docker build -t "$ECR_REPOSITORY:$IMAGE_TAG" -f ml/airflow/Dockerfile ml
+          docker tag "$ECR_REPOSITORY:$IMAGE_TAG" "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+          docker tag "$ECR_REPOSITORY:$IMAGE_TAG" "$ECR_REGISTRY/$ECR_REPOSITORY:latest"
+          docker push --all-tags "$ECR_REGISTRY/$ECR_REPOSITORY"
+
+      - name: Deploy Airflow services
+        env:
+          IMAGE_TAG: ${{ github.sha }}
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECS_CLUSTER: ${{ needs.terraform.outputs.ecs_cluster_name }}
+          AIRFLOW_INIT_TASK_DEFINITION: ${{ needs.terraform.outputs.airflow_init_task_definition_arn }}
+          AIRFLOW_API_SERVICE: ${{ needs.terraform.outputs.airflow_apiserver_service_name }}
+          AIRFLOW_SCHEDULER_SERVICE: ${{ needs.terraform.outputs.airflow_scheduler_service_name }}
+          AIRFLOW_DAG_PROCESSOR_SERVICE: ${{ needs.terraform.outputs.airflow_dag_processor_service_name }}
+          PRIVATE_SUBNET_IDS: ${{ needs.terraform.outputs.private_subnet_ids }}
+          AIRFLOW_SECURITY_GROUP_ID: ${{ needs.terraform.outputs.ecs_airflow_security_group_id }}
+        run: |
+          IFS=',' read -ra SUBNETS <<< "$PRIVATE_SUBNET_IDS"
+          SUBNET_JSON="$(printf '%s\n' "${SUBNETS[@]}" | jq -R . | jq -cs .)"
+          NETWORK_CONFIG="$(jq -cn \
+            --argjson subnets "$SUBNET_JSON" \
+            --arg sg "$AIRFLOW_SECURITY_GROUP_ID" \
+            '{awsvpcConfiguration:{subnets:$subnets,securityGroups:[$sg],assignPublicIp:"DISABLED"}}')"
+
+          INIT_TASK_ARN="$(aws ecs run-task \
+            --cluster "$ECS_CLUSTER" \
+            --task-definition "$AIRFLOW_INIT_TASK_DEFINITION" \
+            --launch-type FARGATE \
+            --platform-version LATEST \
+            --network-configuration "$NETWORK_CONFIG" \
+            --query 'tasks[0].taskArn' \
+            --output text \
+            --region ap-northeast-2)"
+          test "$INIT_TASK_ARN" != "None"
+          aws ecs wait tasks-stopped --cluster "$ECS_CLUSTER" --tasks "$INIT_TASK_ARN" --region ap-northeast-2
+          EXIT_CODE="$(aws ecs describe-tasks \
+            --cluster "$ECS_CLUSTER" \
+            --tasks "$INIT_TASK_ARN" \
+            --query 'tasks[0].containers[0].exitCode' \
+            --output text \
+            --region ap-northeast-2)"
+          test "$EXIT_CODE" = "0"
+
+          update_service_image() {
+            local service="$1"
+            local container="$2"
+            local repository="ostone/airflow"
+            local image_uri="$ECR_REGISTRY/$repository:$IMAGE_TAG"
+            local task_def_arn
+            task_def_arn="$(aws ecs describe-services \
+              --cluster "$ECS_CLUSTER" \
+              --services "$service" \
+              --region ap-northeast-2 \
+              --query 'services[0].taskDefinition' \
+              --output text)"
+            aws ecs describe-task-definition \
+              --task-definition "$task_def_arn" \
+              --region ap-northeast-2 \
+              --query 'taskDefinition' > "task-definition-${service}.json"
+            jq --arg image "$image_uri" --arg container "$container" '
+              .containerDefinitions |= map(
+                if .name == $container then .image = $image else . end
+              )
+              | del(
+                .taskDefinitionArn,
+                .revision,
+                .status,
+                .requiresAttributes,
+                .compatibilities,
+                .registeredAt,
+                .registeredBy
+              )
+            ' "task-definition-${service}.json" > "new-task-definition-${service}.json"
+            local new_task_def_arn
+            new_task_def_arn="$(aws ecs register-task-definition \
+              --cli-input-json "file://new-task-definition-${service}.json" \
+              --region ap-northeast-2 \
+              --query 'taskDefinition.taskDefinitionArn' \
+              --output text)"
+            aws ecs update-service \
+              --cluster "$ECS_CLUSTER" \
+              --service "$service" \
+              --task-definition "$new_task_def_arn" \
+              --force-new-deployment \
+              --region ap-northeast-2
+          }
+
+          update_service_image "$AIRFLOW_API_SERVICE" "airflow-apiserver"
+          update_service_image "$AIRFLOW_SCHEDULER_SERVICE" "airflow-scheduler"
+          update_service_image "$AIRFLOW_DAG_PROCESSOR_SERVICE" "airflow-dag-processor"
+          aws ecs wait services-stable \
+            --cluster "$ECS_CLUSTER" \
+            --services "$AIRFLOW_API_SERVICE" "$AIRFLOW_SCHEDULER_SERVICE" "$AIRFLOW_DAG_PROCESSOR_SERVICE" \
+            --region ap-northeast-2

--- a/.github/workflows/terraform-cd.yml
+++ b/.github/workflows/terraform-cd.yml
@@ -1,11 +1,6 @@
 name: Terraform CD
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'infra/terraform/**'
-      - '.github/workflows/terraform-cd.yml'
   workflow_dispatch:
 
 concurrency:
@@ -24,7 +19,7 @@ jobs:
       TF_VAR_route53_zone_id: ${{ vars.PROD_ROUTE53_ZONE_ID || '' }}
       TF_VAR_manage_route53_zone: ${{ vars.PROD_MANAGE_ROUTE53_ZONE || 'false' }}
       TF_VAR_admin_cidr: ${{ vars.PROD_ADMIN_CIDR }}
-      TF_VAR_airflow_api_base_url: ${{ vars.PROD_AIRFLOW_API_BASE_URL }}
+      TF_VAR_airflow_api_base_url: ${{ vars.PROD_AIRFLOW_API_BASE_URL || '' }}
       TF_VAR_airflow_api_allow_insecure_http: ${{ vars.PROD_AIRFLOW_API_ALLOW_INSECURE_HTTP || 'false' }}
       TF_VAR_gpu_instance_type: ${{ vars.PROD_GPU_INSTANCE_TYPE || 'g6.2xlarge' }}
       TF_VAR_gpu_asg_max_size: ${{ vars.PROD_GPU_ASG_MAX_SIZE || '1' }}
@@ -44,6 +39,11 @@ jobs:
       TF_VAR_airflow_api_username: ${{ secrets.PROD_AIRFLOW_API_USERNAME }}
       TF_VAR_airflow_api_password: ${{ secrets.PROD_AIRFLOW_API_PASSWORD }}
       TF_VAR_airflow_webhook_secret: ${{ secrets.PROD_AIRFLOW_WEBHOOK_SECRET }}
+      TF_VAR_airflow_fernet_key: ${{ secrets.PROD_AIRFLOW_FERNET_KEY }}
+      TF_VAR_airflow_api_secret_key: ${{ secrets.PROD_AIRFLOW_API_SECRET_KEY }}
+      TF_VAR_airflow_api_auth_jwt_secret: ${{ secrets.PROD_AIRFLOW_API_AUTH_JWT_SECRET }}
+      TF_VAR_airflow_simple_admin_password: ${{ secrets.PROD_AIRFLOW_SIMPLE_ADMIN_PASSWORD }}
+      TF_VAR_airflow_simple_viewer_password: ${{ secrets.PROD_AIRFLOW_SIMPLE_VIEWER_PASSWORD }}
       TF_VAR_llm_runtime_api_key: ${{ secrets.PROD_LLM_RUNTIME_API_KEY || '' }}
     outputs:
       has_changes: ${{ steps.plan.outputs.has_changes }}
@@ -75,7 +75,6 @@ jobs:
           required=(
             TF_VAR_domain_name
             TF_VAR_admin_cidr
-            TF_VAR_airflow_api_base_url
             TF_VAR_db_master_password
             TF_VAR_app_db_password
             TF_VAR_airflow_db_password
@@ -83,6 +82,11 @@ jobs:
             TF_VAR_airflow_api_username
             TF_VAR_airflow_api_password
             TF_VAR_airflow_webhook_secret
+            TF_VAR_airflow_fernet_key
+            TF_VAR_airflow_api_secret_key
+            TF_VAR_airflow_api_auth_jwt_secret
+            TF_VAR_airflow_simple_admin_password
+            TF_VAR_airflow_simple_viewer_password
           )
           for name in "${required[@]}"; do
             test -n "${!name:-}" || { echo "$name is required"; exit 1; }
@@ -120,7 +124,7 @@ jobs:
       TF_VAR_route53_zone_id: ${{ vars.PROD_ROUTE53_ZONE_ID || '' }}
       TF_VAR_manage_route53_zone: ${{ vars.PROD_MANAGE_ROUTE53_ZONE || 'false' }}
       TF_VAR_admin_cidr: ${{ vars.PROD_ADMIN_CIDR }}
-      TF_VAR_airflow_api_base_url: ${{ vars.PROD_AIRFLOW_API_BASE_URL }}
+      TF_VAR_airflow_api_base_url: ${{ vars.PROD_AIRFLOW_API_BASE_URL || '' }}
       TF_VAR_airflow_api_allow_insecure_http: ${{ vars.PROD_AIRFLOW_API_ALLOW_INSECURE_HTTP || 'false' }}
       TF_VAR_gpu_instance_type: ${{ vars.PROD_GPU_INSTANCE_TYPE || 'g6.2xlarge' }}
       TF_VAR_gpu_asg_max_size: ${{ vars.PROD_GPU_ASG_MAX_SIZE || '1' }}
@@ -140,6 +144,11 @@ jobs:
       TF_VAR_airflow_api_username: ${{ secrets.PROD_AIRFLOW_API_USERNAME }}
       TF_VAR_airflow_api_password: ${{ secrets.PROD_AIRFLOW_API_PASSWORD }}
       TF_VAR_airflow_webhook_secret: ${{ secrets.PROD_AIRFLOW_WEBHOOK_SECRET }}
+      TF_VAR_airflow_fernet_key: ${{ secrets.PROD_AIRFLOW_FERNET_KEY }}
+      TF_VAR_airflow_api_secret_key: ${{ secrets.PROD_AIRFLOW_API_SECRET_KEY }}
+      TF_VAR_airflow_api_auth_jwt_secret: ${{ secrets.PROD_AIRFLOW_API_AUTH_JWT_SECRET }}
+      TF_VAR_airflow_simple_admin_password: ${{ secrets.PROD_AIRFLOW_SIMPLE_ADMIN_PASSWORD }}
+      TF_VAR_airflow_simple_viewer_password: ${{ secrets.PROD_AIRFLOW_SIMPLE_VIEWER_PASSWORD }}
       TF_VAR_llm_runtime_api_key: ${{ secrets.PROD_LLM_RUNTIME_API_KEY || '' }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -168,7 +177,6 @@ jobs:
           required=(
             TF_VAR_domain_name
             TF_VAR_admin_cidr
-            TF_VAR_airflow_api_base_url
             TF_VAR_db_master_password
             TF_VAR_app_db_password
             TF_VAR_airflow_db_password
@@ -176,6 +184,11 @@ jobs:
             TF_VAR_airflow_api_username
             TF_VAR_airflow_api_password
             TF_VAR_airflow_webhook_secret
+            TF_VAR_airflow_fernet_key
+            TF_VAR_airflow_api_secret_key
+            TF_VAR_airflow_api_auth_jwt_secret
+            TF_VAR_airflow_simple_admin_password
+            TF_VAR_airflow_simple_viewer_password
           )
           for name in "${required[@]}"; do
             test -n "${!name:-}" || { echo "$name is required"; exit 1; }

--- a/infra/terraform/alb.tf
+++ b/infra/terraform/alb.tf
@@ -34,6 +34,28 @@ resource "aws_lb_target_group" "backend" {
   tags = local.common_tags
 }
 
+resource "aws_lb_target_group" "airflow_api" {
+  name        = "${local.name_prefix}-airflow-api-tg"
+  port        = 8080
+  protocol    = "HTTP"
+  vpc_id      = aws_vpc.main.id
+  target_type = "ip"
+
+  health_check {
+    enabled             = true
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+    interval            = 30
+    timeout             = 5
+    path                = "/api/v2/version"
+    port                = "traffic-port"
+    protocol            = "HTTP"
+    matcher             = "200-399"
+  }
+
+  tags = local.common_tags
+}
+
 # HTTPS Listener (443) with ACM certificate
 resource "aws_lb_listener" "backend_https" {
   load_balancer_arn = aws_lb.backend.arn
@@ -45,6 +67,49 @@ resource "aws_lb_listener" "backend_https" {
   default_action {
     type             = "forward"
     target_group_arn = aws_lb_target_group.backend.arn
+  }
+}
+
+resource "aws_lb_listener_rule" "airflow_admin" {
+  listener_arn = aws_lb_listener.backend_https.arn
+  priority     = 10
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.airflow_api.arn
+  }
+
+  condition {
+    host_header {
+      values = ["airflow.${var.domain_name}"]
+    }
+  }
+
+  condition {
+    source_ip {
+      values = [var.admin_cidr]
+    }
+  }
+}
+
+resource "aws_lb_listener_rule" "airflow_forbidden" {
+  listener_arn = aws_lb_listener.backend_https.arn
+  priority     = 11
+
+  action {
+    type = "fixed-response"
+
+    fixed_response {
+      content_type = "text/plain"
+      message_body = "Forbidden"
+      status_code  = "403"
+    }
+  }
+
+  condition {
+    host_header {
+      values = ["airflow.${var.domain_name}"]
+    }
   }
 }
 
@@ -69,6 +134,18 @@ resource "aws_lb_listener" "backend_http" {
 resource "aws_route53_record" "api" {
   zone_id = local.route53_zone_id
   name    = "api.${var.domain_name}"
+  type    = "A"
+
+  alias {
+    name                   = aws_lb.backend.dns_name
+    zone_id                = aws_lb.backend.zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "airflow" {
+  zone_id = local.route53_zone_id
+  name    = "airflow.${var.domain_name}"
   type    = "A"
 
   alias {

--- a/infra/terraform/ecr.tf
+++ b/infra/terraform/ecr.tf
@@ -1,9 +1,11 @@
 locals {
   ecr_repositories = {
-    backend     = "ostone/backend"
-    airflow     = "ostone/airflow"
-    ml_embedder = "ostone/ml-embedder"
-    ml_llm      = "ostone/ml-llm"
+    backend      = "ostone/backend"
+    airflow      = "ostone/airflow"
+    ml_embedder  = "ostone/ml-embedder"
+    ml_stage_cpu = "ostone/ml-stage-cpu"
+    ml_stage_gpu = "ostone/ml-stage-gpu"
+    ml_llm       = "ostone/ml-llm"
   }
 }
 

--- a/infra/terraform/ecs-airflow.tf
+++ b/infra/terraform/ecs-airflow.tf
@@ -1,0 +1,446 @@
+resource "aws_service_discovery_private_dns_namespace" "main" {
+  name        = local.airflow_private_namespace_name
+  description = "Private service discovery namespace for ${local.name_prefix} ECS services."
+  vpc         = aws_vpc.main.id
+
+  tags = local.common_tags
+}
+
+resource "aws_service_discovery_service" "airflow_api" {
+  name = "airflow-api"
+
+  dns_config {
+    namespace_id = aws_service_discovery_private_dns_namespace.main.id
+
+    dns_records {
+      ttl  = 10
+      type = "A"
+    }
+
+    routing_policy = "MULTIVALUE"
+  }
+
+  health_check_custom_config {
+    failure_threshold = 1
+  }
+
+  tags = local.common_tags
+}
+
+resource "aws_cloudwatch_log_group" "airflow" {
+  name              = "/ecs/${local.name_prefix}/airflow"
+  retention_in_days = 30
+  kms_key_id        = aws_kms_key.observability.arn
+
+  tags = local.common_tags
+}
+
+locals {
+  airflow_environment = [
+    {
+      name  = "AIRFLOW__CORE__EXECUTOR"
+      value = "LocalExecutor"
+    },
+    {
+      name  = "AIRFLOW__API__BASE_URL"
+      value = "https://airflow.${var.domain_name}"
+    },
+    {
+      name  = "AIRFLOW__CORE__EXECUTION_API_SERVER_URL"
+      value = "${local.airflow_private_api_base_url}/execution/"
+    },
+    {
+      name  = "AIRFLOW__CORE__LOAD_EXAMPLES"
+      value = "False"
+    },
+    {
+      name  = "AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION"
+      value = "False"
+    },
+    {
+      name  = "AIRFLOW__CORE__SIMPLE_AUTH_MANAGER_USERS"
+      value = "admin:admin,viewer:viewer"
+    },
+    {
+      name  = "AIRFLOW__CORE__SIMPLE_AUTH_MANAGER_PASSWORDS_FILE"
+      value = "/opt/airflow/auth/simple_auth_manager_passwords.json.generated"
+    },
+    {
+      name  = "AIRFLOW__CORE__DAGS_FOLDER"
+      value = "/opt/airflow/src/dags"
+    },
+    {
+      name  = "AIRFLOW__LOGGING__BASE_LOG_FOLDER"
+      value = "/opt/airflow/logs"
+    },
+    {
+      name  = "PIPELINE_STAGE_EXECUTION_MODE"
+      value = "ecs"
+    },
+    {
+      name  = "PIPELINE_BACKEND_BASE_URL"
+      value = "https://api.${var.domain_name}"
+    },
+    {
+      name  = "PIPELINE_ARTIFACT_ROOT"
+      value = "/opt/airflow/artifacts"
+    },
+    {
+      name  = "PIPELINE_CALLBACK_ENABLED"
+      value = "true"
+    },
+    {
+      name  = "PIPELINE_CALLBACK_TIMEOUT_SECONDS"
+      value = "10"
+    },
+    {
+      name  = "ML_ARTIFACT_STORE"
+      value = "s3"
+    },
+    {
+      name  = "ML_ARTIFACT_BUCKET"
+      value = aws_s3_bucket.buckets["ml_artifacts"].bucket
+    },
+    {
+      name  = "ML_ARTIFACT_PREFIX"
+      value = "domain-pack"
+    },
+    {
+      name  = "ML_EMBEDDING_RUNTIME"
+      value = "flag_embedding"
+    },
+    {
+      name  = "EMBEDDING_MODEL_NAME"
+      value = var.embedding_model_name
+    },
+    {
+      name  = "ML_RUNTIME_PROFILE"
+      value = var.ml_runtime_profile
+    },
+    {
+      name  = "GPU_TASK_MODE"
+      value = "run_task"
+    },
+    {
+      name  = "PIPELINE_ECS_CLUSTER"
+      value = aws_ecs_cluster.main.name
+    },
+    {
+      name  = "PIPELINE_ECS_CPU_TASK_DEFINITION"
+      value = aws_ecs_task_definition.ml_stage_cpu.arn
+    },
+    {
+      name  = "PIPELINE_ECS_CPU_CONTAINER_NAME"
+      value = "ml-stage-cpu"
+    },
+    {
+      name  = "PIPELINE_ECS_GPU_TASK_DEFINITION"
+      value = aws_ecs_task_definition.ml_stage_gpu.arn
+    },
+    {
+      name  = "PIPELINE_ECS_GPU_CONTAINER_NAME"
+      value = "ml-stage-gpu"
+    },
+    {
+      name  = "PIPELINE_ECS_GPU_CAPACITY_PROVIDER"
+      value = aws_ecs_capacity_provider.gpu.name
+    },
+    {
+      name  = "PIPELINE_ECS_SUBNET_IDS"
+      value = join(",", values(aws_subnet.private)[*].id)
+    },
+    {
+      name  = "PIPELINE_ECS_SECURITY_GROUP_IDS"
+      value = aws_security_group.gpu_task.id
+    },
+    {
+      name  = "PIPELINE_ECS_RESULT_BUCKET"
+      value = aws_s3_bucket.buckets["ml_artifacts"].bucket
+    },
+    {
+      name  = "PIPELINE_ECS_RESULT_PREFIX"
+      value = "ecs-stage-results"
+    },
+    {
+      name  = "PIPELINE_ECS_GPU_STAGES"
+      value = "representation"
+    },
+    {
+      name  = "LLM_MODEL_NAME"
+      value = var.llm_model_name
+    },
+    {
+      name  = "LLM_RUNTIME_BASE_URL"
+      value = "http://${aws_lb.ml_llm_internal.dns_name}:${var.llm_service_container_port}/v1"
+    },
+    {
+      name  = "S3_EXPECTED_BUCKET_OWNER"
+      value = data.aws_caller_identity.current.account_id
+    },
+    {
+      name  = "AWS_REGION"
+      value = var.aws_region
+    },
+    {
+      name  = "AWS_DEFAULT_REGION"
+      value = var.aws_region
+    },
+    {
+      name  = "PYTHONPATH"
+      value = "/opt/airflow/src"
+    }
+  ]
+
+  airflow_secrets = [
+    {
+      name      = "AIRFLOW__DATABASE__SQL_ALCHEMY_CONN"
+      valueFrom = "${aws_secretsmanager_secret.app.arn}:airflow_sql_alchemy_conn::"
+    },
+    {
+      name      = "AIRFLOW__DATABASE__SQL_ALCHEMY_CONN_ASYNC"
+      valueFrom = "${aws_secretsmanager_secret.app.arn}:airflow_sql_alchemy_conn_async::"
+    },
+    {
+      name      = "AIRFLOW__CORE__FERNET_KEY"
+      valueFrom = "${aws_secretsmanager_secret.app.arn}:airflow_fernet_key::"
+    },
+    {
+      name      = "AIRFLOW__API__SECRET_KEY"
+      valueFrom = "${aws_secretsmanager_secret.app.arn}:airflow_api_secret_key::"
+    },
+    {
+      name      = "AIRFLOW__API_AUTH__JWT_SECRET"
+      valueFrom = "${aws_secretsmanager_secret.app.arn}:airflow_api_auth_jwt_secret::"
+    },
+    {
+      name      = "AIRFLOW_SIMPLE_ADMIN_PASSWORD"
+      valueFrom = "${aws_secretsmanager_secret.app.arn}:airflow_simple_admin_password::"
+    },
+    {
+      name      = "AIRFLOW_SIMPLE_VIEWER_PASSWORD"
+      valueFrom = "${aws_secretsmanager_secret.app.arn}:airflow_simple_viewer_password::"
+    },
+    {
+      name      = "AIRFLOW_WEBHOOK_SECRET"
+      valueFrom = "${aws_secretsmanager_secret.app.arn}:airflow_webhook_secret::"
+    },
+    {
+      name      = "LLM_RUNTIME_API_KEY"
+      valueFrom = "${aws_secretsmanager_secret.app.arn}:llm_runtime_api_key::"
+    }
+  ]
+}
+
+resource "aws_ecs_task_definition" "airflow_init" {
+  family                   = "${local.name_prefix}-airflow-init-task"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = "1024"
+  memory                   = "2048"
+  execution_role_arn       = aws_iam_role.ecs_task_execution.arn
+  task_role_arn            = aws_iam_role.ecs_airflow_task.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "airflow-init"
+      image     = "${aws_ecr_repository.repos["airflow"].repository_url}:latest"
+      essential = true
+      entryPoint = [
+        "/opt/airflow/scripts/init-airflow.sh"
+      ]
+      environment = local.airflow_environment
+      secrets     = local.airflow_secrets
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = aws_cloudwatch_log_group.airflow.name
+          "awslogs-region"        = var.aws_region
+          "awslogs-stream-prefix" = "init"
+          "awslogs-create-group"  = "true"
+        }
+      }
+    }
+  ])
+
+  tags = local.common_tags
+}
+
+resource "aws_ecs_task_definition" "airflow_apiserver" {
+  family                   = "${local.name_prefix}-airflow-apiserver-task"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = "1024"
+  memory                   = "2048"
+  execution_role_arn       = aws_iam_role.ecs_task_execution.arn
+  task_role_arn            = aws_iam_role.ecs_airflow_task.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "airflow-apiserver"
+      image     = "${aws_ecr_repository.repos["airflow"].repository_url}:latest"
+      essential = true
+      command   = ["airflow", "api-server"]
+      portMappings = [
+        {
+          containerPort = 8080
+          protocol      = "tcp"
+        }
+      ]
+      environment = local.airflow_environment
+      secrets     = local.airflow_secrets
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = aws_cloudwatch_log_group.airflow.name
+          "awslogs-region"        = var.aws_region
+          "awslogs-stream-prefix" = "apiserver"
+          "awslogs-create-group"  = "true"
+        }
+      }
+    }
+  ])
+
+  tags = local.common_tags
+}
+
+resource "aws_ecs_task_definition" "airflow_scheduler" {
+  family                   = "${local.name_prefix}-airflow-scheduler-task"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = "1024"
+  memory                   = "2048"
+  execution_role_arn       = aws_iam_role.ecs_task_execution.arn
+  task_role_arn            = aws_iam_role.ecs_airflow_task.arn
+
+  container_definitions = jsonencode([
+    {
+      name        = "airflow-scheduler"
+      image       = "${aws_ecr_repository.repos["airflow"].repository_url}:latest"
+      essential   = true
+      command     = ["airflow", "scheduler"]
+      environment = local.airflow_environment
+      secrets     = local.airflow_secrets
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = aws_cloudwatch_log_group.airflow.name
+          "awslogs-region"        = var.aws_region
+          "awslogs-stream-prefix" = "scheduler"
+          "awslogs-create-group"  = "true"
+        }
+      }
+    }
+  ])
+
+  tags = local.common_tags
+}
+
+resource "aws_ecs_task_definition" "airflow_dag_processor" {
+  family                   = "${local.name_prefix}-airflow-dag-processor-task"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = "1024"
+  memory                   = "2048"
+  execution_role_arn       = aws_iam_role.ecs_task_execution.arn
+  task_role_arn            = aws_iam_role.ecs_airflow_task.arn
+
+  container_definitions = jsonencode([
+    {
+      name        = "airflow-dag-processor"
+      image       = "${aws_ecr_repository.repos["airflow"].repository_url}:latest"
+      essential   = true
+      command     = ["airflow", "dag-processor"]
+      environment = local.airflow_environment
+      secrets     = local.airflow_secrets
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = aws_cloudwatch_log_group.airflow.name
+          "awslogs-region"        = var.aws_region
+          "awslogs-stream-prefix" = "dag-processor"
+          "awslogs-create-group"  = "true"
+        }
+      }
+    }
+  ])
+
+  tags = local.common_tags
+}
+
+resource "aws_ecs_service" "airflow_apiserver" {
+  name             = "ostone-airflow-apiserver"
+  cluster          = aws_ecs_cluster.main.id
+  task_definition  = aws_ecs_task_definition.airflow_apiserver.arn
+  desired_count    = var.airflow_api_desired_count
+  launch_type      = "FARGATE"
+  platform_version = "LATEST"
+
+  health_check_grace_period_seconds = 120
+
+  network_configuration {
+    subnets          = values(aws_subnet.private)[*].id
+    security_groups  = [aws_security_group.ecs_airflow.id]
+    assign_public_ip = false
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.airflow_api.arn
+    container_name   = "airflow-apiserver"
+    container_port   = 8080
+  }
+
+  service_registries {
+    registry_arn = aws_service_discovery_service.airflow_api.arn
+  }
+
+  depends_on = [
+    aws_lb_listener_rule.airflow_admin,
+    terraform_data.db_bootstrap
+  ]
+
+  lifecycle {
+    ignore_changes = [task_definition]
+  }
+}
+
+resource "aws_ecs_service" "airflow_scheduler" {
+  name             = "ostone-airflow-scheduler"
+  cluster          = aws_ecs_cluster.main.id
+  task_definition  = aws_ecs_task_definition.airflow_scheduler.arn
+  desired_count    = var.airflow_scheduler_desired_count
+  launch_type      = "FARGATE"
+  platform_version = "LATEST"
+
+  network_configuration {
+    subnets          = values(aws_subnet.private)[*].id
+    security_groups  = [aws_security_group.ecs_airflow.id]
+    assign_public_ip = false
+  }
+
+  depends_on = [terraform_data.db_bootstrap]
+
+  lifecycle {
+    ignore_changes = [task_definition]
+  }
+}
+
+resource "aws_ecs_service" "airflow_dag_processor" {
+  name             = "ostone-airflow-dag-processor"
+  cluster          = aws_ecs_cluster.main.id
+  task_definition  = aws_ecs_task_definition.airflow_dag_processor.arn
+  desired_count    = var.airflow_dag_processor_desired_count
+  launch_type      = "FARGATE"
+  platform_version = "LATEST"
+
+  network_configuration {
+    subnets          = values(aws_subnet.private)[*].id
+    security_groups  = [aws_security_group.ecs_airflow.id]
+    assign_public_ip = false
+  }
+
+  depends_on = [terraform_data.db_bootstrap]
+
+  lifecycle {
+    ignore_changes = [task_definition]
+  }
+}

--- a/infra/terraform/ecs-cluster.tf
+++ b/infra/terraform/ecs-cluster.tf
@@ -94,11 +94,11 @@ resource "aws_ecs_task_definition" "backend" {
         },
         {
           name  = "AIRFLOW_API_BASE_URL"
-          value = var.airflow_api_base_url
+          value = local.airflow_backend_api_base_url
         },
         {
           name  = "AIRFLOW_API_ALLOW_INSECURE_HTTP"
-          value = tostring(var.airflow_api_allow_insecure_http)
+          value = tostring(var.airflow_api_allow_insecure_http || var.airflow_api_base_url == "")
         },
         {
           name  = "AI_EMBEDDING_PROVIDER"

--- a/infra/terraform/ecs-ml-stages.tf
+++ b/infra/terraform/ecs-ml-stages.tf
@@ -1,0 +1,152 @@
+resource "aws_cloudwatch_log_group" "ml_stage_cpu" {
+  name              = "/ecs/${local.name_prefix}/ml-stage-cpu"
+  retention_in_days = 30
+  kms_key_id        = aws_kms_key.observability.arn
+
+  tags = local.common_tags
+}
+
+resource "aws_cloudwatch_log_group" "ml_stage_gpu" {
+  name              = "/ecs/${local.name_prefix}/ml-stage-gpu"
+  retention_in_days = 30
+  kms_key_id        = aws_kms_key.observability.arn
+
+  tags = local.common_tags
+}
+
+resource "aws_ecs_task_definition" "ml_stage_cpu" {
+  family                   = "${local.name_prefix}-ml-stage-cpu-task"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = "2048"
+  memory                   = "8192"
+  execution_role_arn       = aws_iam_role.ecs_task_execution.arn
+  task_role_arn            = aws_iam_role.gpu_task.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "ml-stage-cpu"
+      image     = "${aws_ecr_repository.repos["ml_stage_cpu"].repository_url}:latest"
+      essential = true
+      environment = [
+        {
+          name  = "ML_ARTIFACT_STORE"
+          value = "s3"
+        },
+        {
+          name  = "ML_ARTIFACT_BUCKET"
+          value = aws_s3_bucket.buckets["ml_artifacts"].bucket
+        },
+        {
+          name  = "ML_ARTIFACT_PREFIX"
+          value = "domain-pack"
+        },
+        {
+          name  = "S3_EXPECTED_BUCKET_OWNER"
+          value = data.aws_caller_identity.current.account_id
+        }
+      ]
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = aws_cloudwatch_log_group.ml_stage_cpu.name
+          "awslogs-region"        = var.aws_region
+          "awslogs-stream-prefix" = "stage"
+          "awslogs-create-group"  = "true"
+        }
+      }
+      cpu    = 0
+      memory = 8192
+    }
+  ])
+
+  tags = local.common_tags
+}
+
+resource "aws_ecs_task_definition" "ml_stage_gpu" {
+  family                   = "${local.name_prefix}-ml-stage-gpu-task"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["EC2"]
+  cpu                      = "4096"
+  memory                   = "16384"
+  execution_role_arn       = aws_iam_role.ecs_task_execution.arn
+  task_role_arn            = aws_iam_role.gpu_task.arn
+
+  volume {
+    name = "embedding-model-cache"
+
+    efs_volume_configuration {
+      file_system_id     = aws_efs_file_system.embedding_model_cache.id
+      transit_encryption = "ENABLED"
+
+      authorization_config {
+        access_point_id = aws_efs_access_point.embedding_model_cache.id
+        iam             = "ENABLED"
+      }
+    }
+  }
+
+  container_definitions = jsonencode([
+    {
+      name      = "ml-stage-gpu"
+      image     = "${aws_ecr_repository.repos["ml_stage_gpu"].repository_url}:latest"
+      essential = true
+      mountPoints = [
+        {
+          sourceVolume  = "embedding-model-cache"
+          containerPath = var.embedding_model_cache_mount_path
+          readOnly      = false
+        }
+      ]
+      environment = [
+        {
+          name  = "ML_ARTIFACT_STORE"
+          value = "s3"
+        },
+        {
+          name  = "ML_ARTIFACT_BUCKET"
+          value = aws_s3_bucket.buckets["ml_artifacts"].bucket
+        },
+        {
+          name  = "ML_ARTIFACT_PREFIX"
+          value = "domain-pack"
+        },
+        {
+          name  = "ML_EMBEDDING_RUNTIME"
+          value = "flag_embedding"
+        },
+        {
+          name  = "EMBEDDING_MODEL_NAME"
+          value = var.embedding_model_name
+        },
+        {
+          name  = "HF_HOME"
+          value = var.embedding_model_cache_mount_path
+        },
+        {
+          name  = "S3_EXPECTED_BUCKET_OWNER"
+          value = data.aws_caller_identity.current.account_id
+        }
+      ]
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = aws_cloudwatch_log_group.ml_stage_gpu.name
+          "awslogs-region"        = var.aws_region
+          "awslogs-stream-prefix" = "stage"
+          "awslogs-create-group"  = "true"
+        }
+      }
+      resourceRequirements = [
+        {
+          type  = "GPU"
+          value = "1"
+        }
+      ]
+      cpu    = 0
+      memory = 16384
+    }
+  ])
+
+  tags = local.common_tags
+}

--- a/infra/terraform/iam.tf
+++ b/infra/terraform/iam.tf
@@ -253,6 +253,78 @@ resource "aws_iam_role_policy" "ec2_airflow" {
   policy = data.aws_iam_policy_document.ec2_airflow.json
 }
 
+resource "aws_iam_role" "ecs_airflow_task" {
+  name                 = "${local.name_prefix}-ecs-airflow-task-role"
+  assume_role_policy   = data.aws_iam_policy_document.ecs_tasks_assume_role.json
+  permissions_boundary = var.permissions_boundary_arn
+
+  tags = {
+    Name = "${local.name_prefix}-ecs-airflow-task-role"
+  }
+}
+
+data "aws_iam_policy_document" "ecs_airflow_task" {
+  statement {
+    sid = "RunStageTasks"
+    actions = [
+      "ecs:RunTask",
+      "ecs:DescribeTasks",
+      "ecs:StopTask",
+      "ecs:DescribeTaskDefinition"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid     = "PassStageTaskRoles"
+    actions = ["iam:PassRole"]
+    resources = [
+      aws_iam_role.ecs_task_execution.arn,
+      aws_iam_role.gpu_task.arn
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "iam:PassedToService"
+      values   = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+
+  statement {
+    sid = "S3ReadWriteProjectBuckets"
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:DeleteObject",
+      "s3:ListBucket"
+    ]
+    resources = local.all_bucket_arns
+  }
+
+  statement {
+    sid       = "ReadAirflowSecrets"
+    actions   = ["secretsmanager:GetSecretValue"]
+    resources = local.secrets_resource_arns
+  }
+
+  statement {
+    sid = "CloudWatchLogs"
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "logs:DescribeLogStreams"
+    ]
+    resources = ["arn:aws:logs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:log-group:/ecs/${local.name_prefix}*:*"]
+  }
+}
+
+resource "aws_iam_role_policy" "ecs_airflow_task" {
+  name   = "${local.name_prefix}-ecs-airflow-task-policy"
+  role   = aws_iam_role.ecs_airflow_task.id
+  policy = data.aws_iam_policy_document.ecs_airflow_task.json
+}
+
 resource "aws_iam_role" "gpu_task" {
   name                 = "${local.name_prefix}-gpu-task-role"
   assume_role_policy   = data.aws_iam_policy_document.ecs_tasks_assume_role.json

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -53,4 +53,8 @@ locals {
   }
 
   availability_zones = slice(data.aws_availability_zones.available.names, 0, 2)
+
+  airflow_private_namespace_name = "${local.name_prefix}.local"
+  airflow_private_api_base_url   = "http://airflow-api.${local.airflow_private_namespace_name}:8080"
+  airflow_backend_api_base_url   = var.airflow_api_base_url != "" ? var.airflow_api_base_url : local.airflow_private_api_base_url
 }

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -33,6 +33,11 @@ output "ec2_airflow_security_group_id" {
   value       = aws_security_group.ec2_airflow.id
 }
 
+output "ecs_airflow_security_group_id" {
+  description = "ECS Airflow service security group ID."
+  value       = aws_security_group.ecs_airflow.id
+}
+
 output "gpu_task_security_group_id" {
   description = "GPU task security group ID."
   value       = aws_security_group.gpu_task.id
@@ -211,6 +216,56 @@ output "ml_embedder_task_definition_arn" {
 output "ml_embedder_container_name" {
   description = "ML embedder ECS container name used by Airflow overrides."
   value       = "ml-embedder"
+}
+
+output "ml_stage_cpu_task_definition_arn" {
+  description = "CPU ML stage ECS task definition ARN."
+  value       = aws_ecs_task_definition.ml_stage_cpu.arn
+}
+
+output "ml_stage_gpu_task_definition_arn" {
+  description = "GPU ML stage ECS task definition ARN."
+  value       = aws_ecs_task_definition.ml_stage_gpu.arn
+}
+
+output "ml_stage_cpu_container_name" {
+  description = "CPU ML stage ECS container name used by Airflow overrides."
+  value       = "ml-stage-cpu"
+}
+
+output "ml_stage_gpu_container_name" {
+  description = "GPU ML stage ECS container name used by Airflow overrides."
+  value       = "ml-stage-gpu"
+}
+
+output "airflow_endpoint" {
+  description = "Administrator-restricted Airflow endpoint URL."
+  value       = "https://airflow.${var.domain_name}"
+}
+
+output "airflow_private_api_base_url" {
+  description = "VPC-private Airflow API base URL for backend ECS."
+  value       = local.airflow_private_api_base_url
+}
+
+output "airflow_apiserver_service_name" {
+  description = "Airflow API server ECS service name."
+  value       = aws_ecs_service.airflow_apiserver.name
+}
+
+output "airflow_scheduler_service_name" {
+  description = "Airflow scheduler ECS service name."
+  value       = aws_ecs_service.airflow_scheduler.name
+}
+
+output "airflow_dag_processor_service_name" {
+  description = "Airflow DAG processor ECS service name."
+  value       = aws_ecs_service.airflow_dag_processor.name
+}
+
+output "airflow_init_task_definition_arn" {
+  description = "Airflow DB/auth init ECS task definition ARN."
+  value       = aws_ecs_task_definition.airflow_init.arn
 }
 
 output "embedding_model_cache_file_system_id" {

--- a/infra/terraform/secrets.tf
+++ b/infra/terraform/secrets.tf
@@ -13,15 +13,32 @@ resource "aws_secretsmanager_secret_version" "app" {
   secret_id = aws_secretsmanager_secret.app.id
 
   secret_string = jsonencode({
-    db_username            = "app_user"
-    db_password            = var.app_db_password
-    jwt_secret             = var.jwt_secret
-    airflow_api_username   = var.airflow_api_username
-    airflow_api_password   = var.airflow_api_password
-    app_db_password        = var.app_db_password
-    airflow_db_password    = var.airflow_db_password
-    airflow_webhook_secret = var.airflow_webhook_secret
-    llm_runtime_api_key    = var.llm_runtime_api_key
+    db_username          = "app_user"
+    db_password          = var.app_db_password
+    jwt_secret           = var.jwt_secret
+    airflow_api_username = var.airflow_api_username
+    airflow_api_password = var.airflow_api_password
+    app_db_password      = var.app_db_password
+    airflow_db_password  = var.airflow_db_password
+    airflow_sql_alchemy_conn = format(
+      "postgresql+psycopg2://airflow_user:%s@%s:5432/%s",
+      var.airflow_db_password,
+      aws_db_instance.postgres.address,
+      var.db_name
+    )
+    airflow_sql_alchemy_conn_async = format(
+      "postgresql+asyncpg://airflow_user:%s@%s:5432/%s",
+      var.airflow_db_password,
+      aws_db_instance.postgres.address,
+      var.db_name
+    )
+    airflow_webhook_secret         = var.airflow_webhook_secret
+    airflow_fernet_key             = var.airflow_fernet_key
+    airflow_api_secret_key         = var.airflow_api_secret_key
+    airflow_api_auth_jwt_secret    = var.airflow_api_auth_jwt_secret
+    airflow_simple_admin_password  = var.airflow_simple_admin_password
+    airflow_simple_viewer_password = var.airflow_simple_viewer_password
+    llm_runtime_api_key            = var.llm_runtime_api_key
   })
 }
 

--- a/infra/terraform/security-groups.tf
+++ b/infra/terraform/security-groups.tf
@@ -38,6 +38,16 @@ resource "aws_security_group_rule" "alb_egress" {
   source_security_group_id = aws_security_group.ecs_backend.id
 }
 
+resource "aws_security_group_rule" "alb_egress_airflow" {
+  type                     = "egress"
+  security_group_id        = aws_security_group.alb.id
+  description              = "Allow outbound traffic to Airflow API on 8080."
+  from_port                = 8080
+  to_port                  = 8080
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.ecs_airflow.id
+}
+
 resource "aws_security_group" "ecs_backend" {
   name        = "${local.name_prefix}-ecs-backend-sg"
   description = "Allow backend traffic from the ALB."
@@ -72,6 +82,66 @@ resource "aws_security_group_rule" "ecs_backend_egress_https" {
   type              = "egress"
   security_group_id = aws_security_group.ecs_backend.id
   description       = "Allow outbound HTTPS traffic for SDK/API calls."
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "ecs_backend_egress_airflow" {
+  type                     = "egress"
+  security_group_id        = aws_security_group.ecs_backend.id
+  description              = "Allow backend to call the private Airflow API."
+  from_port                = 8080
+  to_port                  = 8080
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.ecs_airflow.id
+}
+
+resource "aws_security_group" "ecs_airflow" {
+  name        = "${local.name_prefix}-ecs-airflow-sg"
+  description = "Airflow ECS service security group."
+  vpc_id      = aws_vpc.main.id
+
+  tags = {
+    Name = "${local.name_prefix}-ecs-airflow-sg"
+  }
+}
+
+resource "aws_security_group_rule" "ecs_airflow_ingress_alb" {
+  type                     = "ingress"
+  security_group_id        = aws_security_group.ecs_airflow.id
+  source_security_group_id = aws_security_group.alb.id
+  description              = "Airflow UI/API traffic from ALB."
+  from_port                = 8080
+  to_port                  = 8080
+  protocol                 = "tcp"
+}
+
+resource "aws_security_group_rule" "ecs_airflow_ingress_backend" {
+  type                     = "ingress"
+  security_group_id        = aws_security_group.ecs_airflow.id
+  source_security_group_id = aws_security_group.ecs_backend.id
+  description              = "Private Airflow API traffic from backend ECS."
+  from_port                = 8080
+  to_port                  = 8080
+  protocol                 = "tcp"
+}
+
+resource "aws_security_group_rule" "ecs_airflow_egress_rds" {
+  type                     = "egress"
+  security_group_id        = aws_security_group.ecs_airflow.id
+  description              = "Allow Airflow ECS to reach RDS PostgreSQL."
+  from_port                = 5432
+  to_port                  = 5432
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.rds.id
+}
+
+resource "aws_security_group_rule" "ecs_airflow_egress_https" {
+  type              = "egress"
+  security_group_id = aws_security_group.ecs_airflow.id
+  description       = "Allow Airflow ECS to reach AWS APIs and backend callbacks over HTTPS."
   from_port         = 443
   to_port           = 443
   protocol          = "tcp"
@@ -178,6 +248,16 @@ resource "aws_security_group_rule" "rds_ec2_airflow_ingress" {
   protocol                 = "tcp"
 }
 
+resource "aws_security_group_rule" "rds_ecs_airflow_ingress" {
+  type                     = "ingress"
+  security_group_id        = aws_security_group.rds.id
+  source_security_group_id = aws_security_group.ecs_airflow.id
+  description              = "PostgreSQL from Airflow ECS tasks."
+  from_port                = 5432
+  to_port                  = 5432
+  protocol                 = "tcp"
+}
+
 resource "aws_security_group" "gpu_host" {
   name        = "${local.name_prefix}-gpu-host-sg"
   description = "GPU ECS host security group."
@@ -238,6 +318,16 @@ resource "aws_security_group_rule" "gpu_task_egress_efs_model_cache" {
   source_security_group_id = aws_security_group.efs_model_cache.id
 }
 
+resource "aws_security_group_rule" "gpu_task_egress_ml_llm" {
+  type                     = "egress"
+  security_group_id        = aws_security_group.gpu_task.id
+  description              = "Allow stage tasks to call the internal LLM service."
+  from_port                = var.llm_service_container_port
+  to_port                  = var.llm_service_container_port
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.ml_llm_alb.id
+}
+
 resource "aws_security_group" "efs_model_cache" {
   name        = "${local.name_prefix}-efs-model-cache-sg"
   description = "Allow NFS access to the embedding model cache EFS."
@@ -293,6 +383,16 @@ resource "aws_security_group_rule" "ml_llm_alb_ingress_airflow" {
   security_group_id        = aws_security_group.ml_llm_alb.id
   source_security_group_id = aws_security_group.ec2_airflow.id
   description              = "LLM API traffic from Airflow."
+  from_port                = var.llm_service_container_port
+  to_port                  = var.llm_service_container_port
+  protocol                 = "tcp"
+}
+
+resource "aws_security_group_rule" "ml_llm_alb_ingress_stage_tasks" {
+  type                     = "ingress"
+  security_group_id        = aws_security_group.ml_llm_alb.id
+  source_security_group_id = aws_security_group.gpu_task.id
+  description              = "LLM API traffic from one-shot ML stage tasks."
   from_port                = var.llm_service_container_port
   to_port                  = var.llm_service_container_port
   protocol                 = "tcp"

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -251,8 +251,9 @@ variable "airflow_api_password" {
 }
 
 variable "airflow_api_base_url" {
-  description = "Backend-reachable URL for the production Airflow API."
+  description = "Optional override for the backend-reachable production Airflow API URL. Blank uses the private ECS Cloud Map endpoint."
   type        = string
+  default     = ""
 }
 
 variable "airflow_api_allow_insecure_http" {
@@ -265,6 +266,54 @@ variable "airflow_webhook_secret" {
   description = "Shared secret for Airflow callback webhooks."
   type        = string
   sensitive   = true
+}
+
+variable "airflow_fernet_key" {
+  description = "Airflow Fernet key used to encrypt Airflow metadata DB values."
+  type        = string
+  sensitive   = true
+}
+
+variable "airflow_api_secret_key" {
+  description = "Airflow API secret key."
+  type        = string
+  sensitive   = true
+}
+
+variable "airflow_api_auth_jwt_secret" {
+  description = "Airflow API auth JWT secret."
+  type        = string
+  sensitive   = true
+}
+
+variable "airflow_simple_admin_password" {
+  description = "Airflow simple auth admin password."
+  type        = string
+  sensitive   = true
+}
+
+variable "airflow_simple_viewer_password" {
+  description = "Airflow simple auth viewer password."
+  type        = string
+  sensitive   = true
+}
+
+variable "airflow_api_desired_count" {
+  description = "Desired ECS task count for Airflow API server."
+  type        = number
+  default     = 1
+}
+
+variable "airflow_scheduler_desired_count" {
+  description = "Desired ECS task count for Airflow scheduler."
+  type        = number
+  default     = 1
+}
+
+variable "airflow_dag_processor_desired_count" {
+  description = "Desired ECS task count for Airflow DAG processor."
+  type        = number
+  default     = 1
 }
 
 variable "gpu_instance_type" {

--- a/ml/Dockerfile.cpu
+++ b/ml/Dockerfile.cpu
@@ -1,0 +1,26 @@
+# ML stage worker — one-shot CPU batch task for ECS RunTask
+FROM python:3.13-slim-bookworm
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl ca-certificates build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
+WORKDIR /app
+ENV UV_PYTHON=3.13
+ENV HF_HOME=/app/.cache/huggingface
+ENV TORCH_HOME=/app/.cache/torch
+ENV PYTHONPATH=/app/src
+
+COPY ml/pyproject.toml ml/uv.lock ./
+RUN uv sync --python 3.13 --frozen --no-dev
+
+COPY ml/src/ ./src/
+
+RUN groupadd --system appgroup \
+    && useradd --system --gid appgroup --home-dir /app appuser \
+    && chown -R appuser:appgroup /app
+USER appuser
+
+ENTRYPOINT ["uv", "run", "python", "-m", "pipeline.ecs_stage_worker"]

--- a/ml/Dockerfile.gpu
+++ b/ml/Dockerfile.gpu
@@ -1,4 +1,4 @@
-# ML embedder — one-shot GPU batch task for ECS RunTask
+# ML stage worker — one-shot GPU batch task for ECS RunTask
 FROM nvidia/cuda:12.2.2-runtime-ubuntu22.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -12,6 +12,7 @@ WORKDIR /app
 ENV UV_PYTHON=3.13
 ENV HF_HOME=/app/.cache/huggingface
 ENV TORCH_HOME=/app/.cache/torch
+ENV PYTHONPATH=/app/src
 
 # Copy dependency files first for layer caching
 COPY ml/pyproject.toml ml/uv.lock ./
@@ -27,6 +28,5 @@ RUN groupadd --system appgroup && useradd --system --gid appgroup --home-dir /ap
     && chown -R appuser:appgroup /app
 USER appuser
 
-# AWS credentials via ECS task role
-# Expected env vars: S3_INPUT_BUCKET, S3_INPUT_KEY, S3_OUTPUT_BUCKET, S3_OUTPUT_KEY, S3_EXPECTED_BUCKET_OWNER
-ENTRYPOINT ["uv", "run", "python", "-m", "pipeline.ecs_embedder_worker"]
+# AWS credentials are provided through the ECS task role.
+ENTRYPOINT ["uv", "run", "python", "-m", "pipeline.ecs_stage_worker"]

--- a/ml/airflow/Dockerfile
+++ b/ml/airflow/Dockerfile
@@ -11,13 +11,15 @@ RUN mkdir -p /opt/airflow/dags /opt/airflow/src /opt/airflow/logs /opt/airflow/a
     && chown -R airflow:0 /opt/airflow \
     && chmod -R g+rwX /opt/airflow
 
-COPY requirements.txt /requirements.txt
-COPY scripts/init-airflow.sh /opt/airflow/scripts/init-airflow.sh
+COPY airflow/requirements.txt /requirements.txt
+COPY airflow/scripts/init-airflow.sh /opt/airflow/scripts/init-airflow.sh
+COPY src/ /opt/airflow/src/
 
 RUN chmod +x /opt/airflow/scripts/init-airflow.sh
 
 USER airflow
 
 ENV HF_HOME=/opt/airflow/.cache/huggingface
+ENV PYTHONPATH=/opt/airflow/src
 
 RUN pip install --no-cache-dir -r /requirements.txt

--- a/ml/docker-compose.yml
+++ b/ml/docker-compose.yml
@@ -1,7 +1,7 @@
 x-airflow-common: &airflow-common
   build:
-    context: ./airflow
-    dockerfile: Dockerfile
+    context: .
+    dockerfile: airflow/Dockerfile
   environment:
     AIRFLOW__CORE__EXECUTOR: LocalExecutor
     AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql+psycopg2://${DB_USER:-init}:${DB_PASSWORD}@postgres:5432/${DB_NAME:-init}

--- a/ml/src/dags/domain_pack_generation.py
+++ b/ml/src/dags/domain_pack_generation.py
@@ -14,22 +14,15 @@ from typing import Any
 from airflow.exceptions import AirflowSkipException
 from airflow.sdk import dag, get_current_context, task
 
+from pipeline.common.artifact_io import is_s3_uri, read_json_uri, write_json_uri
 from pipeline.common.artifacts import write_stage_manifest
 from pipeline.common.callbacks import post_callback
 from pipeline.common.config import PipelineRuntimeConfig
 from pipeline.common.context import StageContext
 from pipeline.common.dag_defaults import default_dag_args
 from pipeline.common.exceptions import PipelineConfigurationError
-from pipeline.stages.domain_candidate_generation.main import run as domain_candidate_generation_run
-from pipeline.stages.draft_generation.main import run as draft_generation_run
-from pipeline.stages.evaluation.main import run as evaluation_run
-from pipeline.stages.feedback_candidate_generation.main import run as feedback_candidate_generation_run
-from pipeline.stages.flow_splitting.main import run as flow_splitting_run
-from pipeline.stages.ingestion.main import run as ingestion_run
-from pipeline.stages.intent_discovery.main import run as intent_discovery_run
-from pipeline.stages.preprocessing.main import run as preprocessing_run
-from pipeline.stages.publish_candidate.main import run as publish_candidate_run
-from pipeline.stages.representation.main import run as representation_run
+from pipeline.ecs_stage_task import run_stage_task
+from pipeline.ecs_stage_worker import STAGE_MODULES
 
 logger = logging.getLogger(__name__)
 
@@ -39,6 +32,9 @@ RUN_MODE_FEEDBACK_REPLAY = "FEEDBACK_REPLAY"
 CALLBACK_DOMAIN_CONFIRMATION = "domain-confirmation-checkpoints"
 CALLBACK_HUMAN_FEEDBACK = "human-feedback-checkpoints"
 CALLBACK_FAILURE = "failures"
+STAGE_EXECUTION_MODE_DIRECT = "direct"
+STAGE_EXECUTION_MODE_ECS = "ecs"
+evaluation_run: Callable[[str], Mapping[str, object] | None] | None = None
 
 
 def _build_stage_context(stage_name: str) -> StageContext:
@@ -92,22 +88,44 @@ def _conf_json_file(key: str, filename: str) -> str | None:
         return None
     context = get_current_context()
     runtime_config = PipelineRuntimeConfig.from_env()
-    input_dir = (
-        runtime_config.artifact_root / context["dag"].dag_id / context["run_id"].replace("/", "__") / "review_inputs"
-    )
+    dag_id = context["dag"].dag_id
+    run_id = context["run_id"].replace("/", "__")
+    if _stage_execution_mode() == STAGE_EXECUTION_MODE_ECS:
+        if not runtime_config.artifact_bucket:
+            raise PipelineConfigurationError("ML_ARTIFACT_BUCKET is required for ECS review input materialization.")
+        key_parts = [runtime_config.artifact_prefix, dag_id, run_id, "review_inputs", filename]
+        uri = f"s3://{runtime_config.artifact_bucket}/{'/'.join(part.strip('/') for part in key_parts if part)}"
+        try:
+            payload = json.loads(value)
+        except json.JSONDecodeError as exc:
+            raise PipelineConfigurationError(f"{key} must be valid JSON.") from exc
+        write_json_uri(uri, payload)
+        return uri
+    input_dir = runtime_config.artifact_root / dag_id / run_id / "review_inputs"
     input_dir.mkdir(parents=True, exist_ok=True)
     path = input_dir / filename
     path.write_text(value, encoding="utf-8")
     return str(path.resolve())
 
 
+def _stage_execution_mode() -> str:
+    value = os.getenv("PIPELINE_STAGE_EXECUTION_MODE", STAGE_EXECUTION_MODE_DIRECT).strip().lower()
+    if value not in {STAGE_EXECUTION_MODE_DIRECT, STAGE_EXECUTION_MODE_ECS}:
+        raise PipelineConfigurationError("PIPELINE_STAGE_EXECUTION_MODE must be one of: direct, ecs.")
+    return value
+
+
 def _run_stage(
     stage_name: str,
-    stage_callable: Callable[[str | None], Mapping[str, object] | None],
+    stage_callable: Callable[[str | None], Mapping[str, object] | None] | None = None,
     upstream_manifest_path: str | None = None,
 ) -> dict[str, str]:
     stage_context = _build_stage_context(stage_name)
     runtime_config = PipelineRuntimeConfig.from_env()
+    if _stage_execution_mode() == STAGE_EXECUTION_MODE_ECS:
+        return run_stage_task(stage_name, stage_context, runtime_config, upstream_manifest_path)
+    if stage_callable is None:
+        stage_callable = _stage_callable(stage_name)
     manifest_payload: dict[str, object] = {
         "backend_base_url": runtime_config.backend_base_url,
         "upstream_manifest_path": upstream_manifest_path,
@@ -157,13 +175,18 @@ def _passthrough_manifest_from_conf() -> dict[str, str]:
     if not upstream_manifest_path:
         raise PipelineConfigurationError("Replay run requires upstream_manifest_path.")
     runtime_config = PipelineRuntimeConfig.from_env()
-    return _materialize_replay_manifest(_validated_replay_manifest_path(upstream_manifest_path, runtime_config))
+    validated_manifest_path = _validated_replay_manifest_path(upstream_manifest_path, runtime_config)
+    if isinstance(validated_manifest_path, str):
+        return {"artifact_manifest_path": validated_manifest_path}
+    return _materialize_replay_manifest(validated_manifest_path)
 
 
 def _validated_replay_manifest_path(
     upstream_manifest_path: str,
     runtime_config: PipelineRuntimeConfig,
-) -> Path:
+) -> Path | str:
+    if is_s3_uri(upstream_manifest_path):
+        return _validated_replay_manifest_s3_uri(upstream_manifest_path, runtime_config)
     resolved = Path(upstream_manifest_path).expanduser().resolve()
     artifact_root = runtime_config.artifact_root.expanduser().resolve()
     try:
@@ -173,6 +196,19 @@ def _validated_replay_manifest_path(
     if resolved.name != "manifest.json":
         raise PipelineConfigurationError("upstream_manifest_path must point to a manifest.json file.")
     return resolved
+
+
+def _validated_replay_manifest_s3_uri(
+    upstream_manifest_path: str,
+    runtime_config: PipelineRuntimeConfig,
+) -> str:
+    if runtime_config.artifact_store != "s3":
+        raise PipelineConfigurationError("S3 upstream_manifest_path requires ML_ARTIFACT_STORE=s3.")
+    if not upstream_manifest_path.endswith("/manifest.json"):
+        raise PipelineConfigurationError("upstream_manifest_path must point to a manifest.json file.")
+    if runtime_config.artifact_bucket and not upstream_manifest_path.startswith(f"s3://{runtime_config.artifact_bucket}/"):
+        raise PipelineConfigurationError("upstream_manifest_path must be under ML_ARTIFACT_BUCKET.")
+    return upstream_manifest_path
 
 
 def _materialize_replay_manifest(upstream_manifest_path: Path) -> dict[str, str]:
@@ -239,18 +275,15 @@ def _post_checkpoint_callback(
     runtime_config = PipelineRuntimeConfig.from_env()
     if not runtime_config.callback_enabled:
         raise PipelineConfigurationError(f"{stage_name} requires PIPELINE_CALLBACK_ENABLED=true.")
-    manifest = _load_manifest(Path(upstream_manifest_path))
+    manifest = _load_manifest_uri(upstream_manifest_path)
     payload = manifest.get("payload")
     if not isinstance(payload, dict):
         raise PipelineConfigurationError(f"{stage_name} upstream manifest payload must be an object.")
     artifact_name = payload.get(artifact_path_key)
     if not isinstance(artifact_name, str) or not artifact_name:
         raise PipelineConfigurationError(f"{stage_name} upstream manifest missing {artifact_path_key}.")
-    artifact_path = Path(artifact_name)
-    resolved_artifact_path = (
-        artifact_path if artifact_path.is_absolute() else Path(upstream_manifest_path).parent / artifact_path
-    )
-    artifact_payload = _load_manifest(resolved_artifact_path)
+    resolved_artifact_path = _resolve_artifact_uri(upstream_manifest_path, artifact_name)
+    artifact_payload = _load_manifest_uri(resolved_artifact_path)
     response = post_callback(
         runtime_config.backend_base_url,
         _require_pipeline_job_id(stage_context.pipeline_job_id),
@@ -262,7 +295,7 @@ def _post_checkpoint_callback(
             "runMode": _run_mode(),
             "parentPipelineJobId": _conf_value("parent_pipeline_job_id"),
             "upstreamManifestPath": str(_representation_manifest_path(stage_context, runtime_config)),
-            artifact_path_key: str(resolved_artifact_path),
+            artifact_path_key: resolved_artifact_path,
             artifact_payload_key: artifact_payload,
         },
         runtime_config.airflow_webhook_secret or "",
@@ -280,18 +313,31 @@ def _load_manifest(path: Path) -> dict[str, Any]:
     return payload
 
 
-def _representation_manifest_path(stage_context: StageContext, runtime_config: PipelineRuntimeConfig) -> Path:
-    return (
-        StageContext(
-            dag_id=stage_context.dag_id,
-            run_id=stage_context.run_id,
-            stage_name="representation",
-            workspace_id=stage_context.workspace_id,
-            dataset_id=stage_context.dataset_id,
-            pipeline_job_id=stage_context.pipeline_job_id,
-        ).artifact_dir(runtime_config)
-        / "manifest.json"
+def _load_manifest_uri(uri: str) -> dict[str, Any]:
+    return read_json_uri(uri) if is_s3_uri(uri) else _load_manifest(Path(uri))
+
+
+def _resolve_artifact_uri(manifest_uri: str, artifact_name: str) -> str:
+    if is_s3_uri(manifest_uri):
+        return f"{manifest_uri.rsplit('/', 1)[0]}/{artifact_name.lstrip('/')}"
+    artifact_path = Path(artifact_name)
+    return str(artifact_path if artifact_path.is_absolute() else Path(manifest_uri).parent / artifact_path)
+
+
+def _representation_manifest_path(stage_context: StageContext, runtime_config: PipelineRuntimeConfig) -> str:
+    representation_context = StageContext(
+        dag_id=stage_context.dag_id,
+        run_id=stage_context.run_id,
+        stage_name="representation",
+        workspace_id=stage_context.workspace_id,
+        dataset_id=stage_context.dataset_id,
+        pipeline_job_id=stage_context.pipeline_job_id,
     )
+    if runtime_config.artifact_store == "s3":
+        from pipeline.common.artifact_io import stage_manifest_s3_uri
+
+        return stage_manifest_s3_uri(representation_context, runtime_config)
+    return str(representation_context.artifact_dir(runtime_config) / "manifest.json")
 
 
 def _external_event_id(stage_context: object, callback_type: str) -> str:
@@ -356,7 +402,21 @@ def _failure_external_event_id(dag_id: str, dag_run_id: str, failed_stage: str) 
 def _run_evaluation_stage(upstream_manifest_path: str | None) -> Mapping[str, object] | None:
     if upstream_manifest_path is None:
         raise PipelineConfigurationError("evaluation stage requires an upstream manifest path.")
-    return evaluation_run(upstream_manifest_path)
+    evaluation_run = globals().get("evaluation_run")
+    run = evaluation_run if callable(evaluation_run) else _stage_callable("evaluation")
+    return run(upstream_manifest_path)
+
+
+def _stage_callable(stage_name: str) -> Callable[[str | None], Mapping[str, object] | None]:
+    module_name = STAGE_MODULES.get(stage_name)
+    if module_name is None:
+        raise PipelineConfigurationError(f"Unsupported pipeline stage: {stage_name}")
+    from importlib import import_module
+
+    run = getattr(import_module(module_name), "run", None)
+    if not callable(run):
+        raise PipelineConfigurationError(f"Stage module does not expose run(): {module_name}")
+    return run
 
 
 @dag(
@@ -382,7 +442,7 @@ def domain_pack_generation() -> None:  # pragma: no cover - Airflow imports this
     def ingestion() -> dict[str, str]:
         if _run_mode() != RUN_MODE_INITIAL:
             return _passthrough_manifest_from_conf()
-        return _run_stage("ingestion", ingestion_run)
+        return _run_stage("ingestion")
 
     @task(task_id="preprocessing")
     def preprocessing(ingestion_result: dict[str, str]) -> dict[str, str]:
@@ -390,8 +450,7 @@ def domain_pack_generation() -> None:  # pragma: no cover - Airflow imports this
             return ingestion_result
         return _run_stage(
             "preprocessing",
-            preprocessing_run,
-            ingestion_result["artifact_manifest_path"],
+            upstream_manifest_path=ingestion_result["artifact_manifest_path"],
         )
 
     @task(task_id="intent_discovery")
@@ -408,8 +467,7 @@ def domain_pack_generation() -> None:  # pragma: no cover - Airflow imports this
         ):
             return _run_stage(
                 "intent_discovery",
-                intent_discovery_run,
-                representation_result["artifact_manifest_path"],
+                upstream_manifest_path=representation_result["artifact_manifest_path"],
             )
 
     @task(task_id="domain_candidate_generation")
@@ -418,8 +476,7 @@ def domain_pack_generation() -> None:  # pragma: no cover - Airflow imports this
             return representation_result
         return _run_stage(
             "domain_candidate_generation",
-            domain_candidate_generation_run,
-            representation_result["artifact_manifest_path"],
+            upstream_manifest_path=representation_result["artifact_manifest_path"],
         )
 
     @task(task_id="domain_confirmation_checkpoint")
@@ -440,16 +497,14 @@ def domain_pack_generation() -> None:  # pragma: no cover - Airflow imports this
             return preprocessing_result
         return _run_stage(
             "representation",
-            representation_run,
-            preprocessing_result["artifact_manifest_path"],
+            upstream_manifest_path=preprocessing_result["artifact_manifest_path"],
         )
 
     @task(task_id="flow_splitting")
     def flow_splitting(intent_discovery_result: dict[str, str]) -> dict[str, str]:
         return _run_stage(
             "flow_splitting",
-            flow_splitting_run,
-            intent_discovery_result["artifact_manifest_path"],
+            upstream_manifest_path=intent_discovery_result["artifact_manifest_path"],
         )
 
     @task(task_id="feedback_candidate_generation")
@@ -458,8 +513,7 @@ def domain_pack_generation() -> None:  # pragma: no cover - Airflow imports this
             return flow_splitting_result
         return _run_stage(
             "feedback_candidate_generation",
-            feedback_candidate_generation_run,
-            flow_splitting_result["artifact_manifest_path"],
+            upstream_manifest_path=flow_splitting_result["artifact_manifest_path"],
         )
 
     @task(task_id="human_feedback_checkpoint")
@@ -479,8 +533,7 @@ def domain_pack_generation() -> None:  # pragma: no cover - Airflow imports this
     def draft_generation(human_feedback_result: dict[str, str]) -> dict[str, str]:
         return _run_stage(
             "draft_generation",
-            draft_generation_run,
-            human_feedback_result["artifact_manifest_path"],
+            upstream_manifest_path=human_feedback_result["artifact_manifest_path"],
         )
 
     @task(task_id="evaluation")
@@ -495,8 +548,7 @@ def domain_pack_generation() -> None:  # pragma: no cover - Airflow imports this
     def publish_candidate(evaluation_result: dict[str, str]) -> dict[str, str]:
         return _run_stage(
             "publish_candidate",
-            publish_candidate_run,
-            evaluation_result["artifact_manifest_path"],
+            upstream_manifest_path=evaluation_result["artifact_manifest_path"],
         )
 
     ingestion_task = ingestion()

--- a/ml/src/dags/domain_pack_generation.py
+++ b/ml/src/dags/domain_pack_generation.py
@@ -14,7 +14,7 @@ from typing import Any
 from airflow.exceptions import AirflowSkipException
 from airflow.sdk import dag, get_current_context, task
 
-from pipeline.common.artifact_io import is_s3_uri, read_json_uri, write_json_uri
+from pipeline.common.artifact_io import is_s3_uri, read_json_file, read_json_uri, write_json_uri
 from pipeline.common.artifacts import write_stage_manifest
 from pipeline.common.callbacks import post_callback
 from pipeline.common.config import PipelineRuntimeConfig
@@ -222,7 +222,7 @@ def _materialize_replay_manifest(upstream_manifest_path: Path) -> dict[str, str]
         pipeline_job_id=_context_value(context, "pipeline_job_id"),
     )
     runtime_config = PipelineRuntimeConfig.from_env()
-    upstream_manifest = _load_manifest(upstream_manifest_path)
+    upstream_manifest = _load_manifest(upstream_manifest_path, runtime_config)
     source_representation_dir = upstream_manifest_path.parent
     source_preprocessing_dir = source_representation_dir.parent / "preprocessing"
     target_representation_dir = stage_context.artifact_dir(runtime_config)
@@ -306,15 +306,15 @@ def _post_checkpoint_callback(
     return {"artifact_manifest_path": upstream_manifest_path}
 
 
-def _load_manifest(path: Path) -> dict[str, Any]:
-    payload = json.loads(path.read_text(encoding="utf-8"))
-    if not isinstance(payload, dict):
-        raise PipelineConfigurationError(f"JSON payload must be an object: {path}")
-    return payload
+def _load_manifest(path: Path, runtime_config: PipelineRuntimeConfig | None = None) -> dict[str, Any]:
+    artifact_root = (runtime_config or PipelineRuntimeConfig.from_env()).artifact_root
+    return read_json_file(path, allowed_root=artifact_root)
 
 
 def _load_manifest_uri(uri: str) -> dict[str, Any]:
-    return read_json_uri(uri) if is_s3_uri(uri) else _load_manifest(Path(uri))
+    if is_s3_uri(uri):
+        return read_json_uri(uri)
+    return _load_manifest(Path(uri))
 
 
 def _resolve_artifact_uri(manifest_uri: str, artifact_name: str) -> str:

--- a/ml/src/pipeline/common/artifact_io.py
+++ b/ml/src/pipeline/common/artifact_io.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any
+from urllib.parse import urlparse
+
+import boto3
+
+from pipeline.common.config import PipelineRuntimeConfig
+from pipeline.common.context import StageContext
+from pipeline.common.exceptions import PipelineConfigurationError
+
+
+@dataclass(frozen=True)
+class S3Uri:
+    bucket: str
+    key: str
+
+    @classmethod
+    def parse(cls, value: str) -> "S3Uri":
+        parsed = urlparse(value)
+        if parsed.scheme != "s3" or not parsed.netloc or not parsed.path.strip("/"):
+            raise PipelineConfigurationError(f"Invalid S3 URI: {value}")
+        return cls(bucket=parsed.netloc, key=parsed.path.lstrip("/"))
+
+    def __str__(self) -> str:
+        return f"s3://{self.bucket}/{self.key}"
+
+
+def is_s3_uri(value: str | None) -> bool:
+    return isinstance(value, str) and value.startswith("s3://")
+
+
+def stage_s3_prefix(stage_context: StageContext, runtime_config: PipelineRuntimeConfig) -> str:
+    safe_run_id = stage_context.run_id.replace("/", "__")
+    parts = [
+        runtime_config.artifact_prefix,
+        stage_context.dag_id,
+        safe_run_id,
+        stage_context.stage_name,
+    ]
+    return "/".join(part.strip("/") for part in parts if part)
+
+
+def stage_manifest_s3_uri(stage_context: StageContext, runtime_config: PipelineRuntimeConfig) -> str:
+    if not runtime_config.artifact_bucket:
+        raise PipelineConfigurationError("ML_ARTIFACT_BUCKET is required to build an S3 artifact URI.")
+    return f"s3://{runtime_config.artifact_bucket}/{stage_s3_prefix(stage_context, runtime_config)}/manifest.json"
+
+
+def manifest_s3_uri_from_local_manifest(manifest_path: Path) -> str:
+    manifest = read_json_file(manifest_path)
+    bucket = _required_manifest_str(manifest, "artifact_bucket", manifest_path)
+    prefix = _optional_manifest_str(manifest, "artifact_prefix") or ""
+    stage_context = StageContext(
+        dag_id=_required_manifest_str(manifest, "dag_id", manifest_path),
+        run_id=_required_manifest_str(manifest, "run_id", manifest_path),
+        stage_name=_required_manifest_str(manifest, "stage_name", manifest_path),
+        workspace_id=_optional_manifest_str(manifest, "workspace_id"),
+        dataset_id=_optional_manifest_str(manifest, "dataset_id"),
+        pipeline_job_id=_optional_manifest_str(manifest, "pipeline_job_id"),
+    )
+    runtime_config = PipelineRuntimeConfig(
+        artifact_root=Path(_required_manifest_str(manifest, "artifact_root", manifest_path)),
+        backend_base_url=os.getenv("PIPELINE_BACKEND_BASE_URL", "http://localhost"),
+        callback_enabled=False,
+        artifact_store="s3",
+        artifact_bucket=bucket,
+        artifact_prefix=prefix,
+    )
+    return stage_manifest_s3_uri(stage_context, runtime_config)
+
+
+def materialize_manifest_uri(
+    manifest_uri: str,
+    target_root: Path,
+    runtime_config: PipelineRuntimeConfig | None = None,
+) -> Path:
+    if not is_s3_uri(manifest_uri):
+        return Path(manifest_uri)
+    if runtime_config is None:
+        runtime_config = PipelineRuntimeConfig.from_env()
+    s3_uri = S3Uri.parse(manifest_uri)
+    if not s3_uri.key.endswith("/manifest.json"):
+        raise PipelineConfigurationError("S3 upstream manifest URI must end with /manifest.json.")
+    run_prefix = _run_prefix_from_manifest_key(s3_uri.key, runtime_config)
+    download_s3_prefix(
+        s3_uri.bucket,
+        run_prefix,
+        target_root,
+        strip_prefix=runtime_config.artifact_prefix,
+    )
+    return target_root / _relative_key_path(_strip_prefix(s3_uri.key, runtime_config.artifact_prefix))
+
+
+def download_s3_prefix(bucket: str, prefix: str, target_dir: Path, *, strip_prefix: str = "") -> None:
+    target_dir.mkdir(parents=True, exist_ok=True)
+    s3 = boto3.client("s3")
+    expected_owner = _expected_bucket_owner()
+    list_kwargs: dict[str, Any] = {"Bucket": bucket, "Prefix": f"{prefix.rstrip('/')}/"}
+    if expected_owner:
+        list_kwargs["ExpectedBucketOwner"] = expected_owner
+    while True:
+        response = s3.list_objects_v2(**list_kwargs)
+        for item in response.get("Contents", []):
+            key = item.get("Key")
+            if not isinstance(key, str) or key.endswith("/"):
+                continue
+            local_path = target_dir / _relative_key_path(_strip_prefix(key, strip_prefix))
+            local_path.parent.mkdir(parents=True, exist_ok=True)
+            download_kwargs: dict[str, Any] = (
+                {"ExtraArgs": {"ExpectedBucketOwner": expected_owner}} if expected_owner else {}
+            )
+            s3.download_file(bucket, key, str(local_path), **download_kwargs)
+        if not response.get("IsTruncated"):
+            break
+        token = response.get("NextContinuationToken")
+        if not isinstance(token, str) or not token:
+            break
+        list_kwargs["ContinuationToken"] = token
+
+
+def write_json_uri(uri: str, payload: dict[str, Any]) -> None:
+    if is_s3_uri(uri):
+        s3_uri = S3Uri.parse(uri)
+        extra_args = {"ExpectedBucketOwner": _expected_bucket_owner()} if _expected_bucket_owner() else None
+        body = json.dumps(payload, indent=2, ensure_ascii=False).encode("utf-8")
+        kwargs: dict[str, Any] = {
+            "Bucket": s3_uri.bucket,
+            "Key": s3_uri.key,
+            "Body": body,
+            "ContentType": "application/json",
+        }
+        if extra_args:
+            kwargs["ExpectedBucketOwner"] = extra_args["ExpectedBucketOwner"]
+        boto3.client("s3").put_object(**kwargs)
+        return
+    path = Path(uri)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+
+
+def read_json_uri(uri: str) -> dict[str, Any]:
+    if is_s3_uri(uri):
+        s3_uri = S3Uri.parse(uri)
+        kwargs: dict[str, Any] = {"Bucket": s3_uri.bucket, "Key": s3_uri.key}
+        expected_owner = _expected_bucket_owner()
+        if expected_owner:
+            kwargs["ExpectedBucketOwner"] = expected_owner
+        response = boto3.client("s3").get_object(**kwargs)
+        payload = json.loads(response["Body"].read().decode("utf-8"))
+    else:
+        payload = read_json_file(Path(uri))
+    if not isinstance(payload, dict):
+        raise PipelineConfigurationError(f"JSON URI must contain an object: {uri}")
+    return payload
+
+
+def download_s3_uri(uri: str, target_path: Path) -> Path:
+    s3_uri = S3Uri.parse(uri)
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    kwargs: dict[str, Any] = {}
+    expected_owner = _expected_bucket_owner()
+    if expected_owner:
+        kwargs["ExtraArgs"] = {"ExpectedBucketOwner": expected_owner}
+    boto3.client("s3").download_file(s3_uri.bucket, s3_uri.key, str(target_path), **kwargs)
+    return target_path
+
+
+def read_json_file(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise PipelineConfigurationError(f"JSON file must contain an object: {path}")
+    return payload
+
+
+def _run_prefix_from_manifest_key(key: str, runtime_config: PipelineRuntimeConfig) -> str:
+    relative_key = _strip_prefix(key, runtime_config.artifact_prefix)
+    parts = PurePosixPath(relative_key).parts
+    if len(parts) < 4 or parts[-1] != "manifest.json":
+        raise PipelineConfigurationError("S3 upstream manifest URI must include dag/run/stage/manifest.json.")
+    dag_id, run_id = parts[0], parts[1]
+    run_relative = f"{dag_id}/{run_id}"
+    return "/".join(part for part in (runtime_config.artifact_prefix, run_relative) if part)
+
+
+def _strip_prefix(key: str, strip_prefix: str) -> str:
+    normalized_prefix = strip_prefix.strip("/")
+    normalized_key = key.strip("/")
+    if normalized_prefix and normalized_key.startswith(f"{normalized_prefix}/"):
+        return normalized_key[len(normalized_prefix) + 1 :]
+    return normalized_key
+
+
+def _relative_key_path(key: str) -> Path:
+    relative = PurePosixPath(key)
+    if any(part in {"", ".", ".."} for part in relative.parts):
+        raise PipelineConfigurationError(f"Unsafe S3 artifact key: {key}")
+    return Path(*relative.parts)
+
+
+def _required_manifest_str(manifest: dict[str, Any], key: str, path: Path) -> str:
+    value = manifest.get(key)
+    if isinstance(value, str) and value:
+        return value
+    raise PipelineConfigurationError(f"Manifest field {key!r} must be a non-empty string: {path}")
+
+
+def _optional_manifest_str(manifest: dict[str, Any], key: str) -> str | None:
+    value = manifest.get(key)
+    return value if isinstance(value, str) and value else None
+
+
+def _expected_bucket_owner() -> str | None:
+    value = os.getenv("S3_EXPECTED_BUCKET_OWNER", "").strip()
+    return value or None

--- a/ml/src/pipeline/common/artifact_io.py
+++ b/ml/src/pipeline/common/artifact_io.py
@@ -51,8 +51,8 @@ def stage_manifest_s3_uri(stage_context: StageContext, runtime_config: PipelineR
     return f"s3://{runtime_config.artifact_bucket}/{stage_s3_prefix(stage_context, runtime_config)}/manifest.json"
 
 
-def manifest_s3_uri_from_local_manifest(manifest_path: Path) -> str:
-    manifest = read_json_file(manifest_path)
+def manifest_s3_uri_from_local_manifest(manifest_path: Path, *, allowed_root: Path | None = None) -> str:
+    manifest = read_json_file(manifest_path, allowed_root=allowed_root)
     bucket = _required_manifest_str(manifest, "artifact_bucket", manifest_path)
     prefix = _optional_manifest_str(manifest, "artifact_prefix") or ""
     stage_context = StageContext(
@@ -111,10 +111,11 @@ def download_s3_prefix(bucket: str, prefix: str, target_dir: Path, *, strip_pref
                 continue
             local_path = target_dir / _relative_key_path(_strip_prefix(key, strip_prefix))
             local_path.parent.mkdir(parents=True, exist_ok=True)
-            download_kwargs: dict[str, Any] = (
-                {"ExtraArgs": {"ExpectedBucketOwner": expected_owner}} if expected_owner else {}
-            )
-            s3.download_file(bucket, key, str(local_path), **download_kwargs)
+            get_kwargs: dict[str, Any] = {"Bucket": bucket, "Key": key}
+            if expected_owner:
+                get_kwargs["ExpectedBucketOwner"] = expected_owner
+            response = s3.get_object(**get_kwargs)
+            local_path.write_bytes(response["Body"].read())
         if not response.get("IsTruncated"):
             break
         token = response.get("NextContinuationToken")
@@ -143,7 +144,7 @@ def write_json_uri(uri: str, payload: dict[str, Any]) -> None:
     path.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
 
 
-def read_json_uri(uri: str) -> dict[str, Any]:
+def read_json_uri(uri: str, *, allowed_root: Path | None = None) -> dict[str, Any]:
     if is_s3_uri(uri):
         s3_uri = S3Uri.parse(uri)
         kwargs: dict[str, Any] = {"Bucket": s3_uri.bucket, "Key": s3_uri.key}
@@ -153,7 +154,7 @@ def read_json_uri(uri: str) -> dict[str, Any]:
         response = boto3.client("s3").get_object(**kwargs)
         payload = json.loads(response["Body"].read().decode("utf-8"))
     else:
-        payload = read_json_file(Path(uri))
+        payload = read_json_file(Path(uri), allowed_root=allowed_root)
     if not isinstance(payload, dict):
         raise PipelineConfigurationError(f"JSON URI must contain an object: {uri}")
     return payload
@@ -162,19 +163,33 @@ def read_json_uri(uri: str) -> dict[str, Any]:
 def download_s3_uri(uri: str, target_path: Path) -> Path:
     s3_uri = S3Uri.parse(uri)
     target_path.parent.mkdir(parents=True, exist_ok=True)
-    kwargs: dict[str, Any] = {}
+    kwargs: dict[str, Any] = {"Bucket": s3_uri.bucket, "Key": s3_uri.key}
     expected_owner = _expected_bucket_owner()
     if expected_owner:
-        kwargs["ExtraArgs"] = {"ExpectedBucketOwner": expected_owner}
-    boto3.client("s3").download_file(s3_uri.bucket, s3_uri.key, str(target_path), **kwargs)
+        kwargs["ExpectedBucketOwner"] = expected_owner
+    response = boto3.client("s3").get_object(**kwargs)
+    target_path.write_bytes(response["Body"].read())
     return target_path
 
 
-def read_json_file(path: Path) -> dict[str, Any]:
-    payload = json.loads(path.read_text(encoding="utf-8"))
+def read_json_file(path: Path, *, allowed_root: Path | None = None) -> dict[str, Any]:
+    safe_path = _safe_local_file_path(path, allowed_root=allowed_root)
+    payload = json.loads(safe_path.read_text(encoding="utf-8"))  # NOSONAR: validated artifact path.
     if not isinstance(payload, dict):
-        raise PipelineConfigurationError(f"JSON file must contain an object: {path}")
+        raise PipelineConfigurationError(f"JSON file must contain an object: {safe_path}")
     return payload
+
+
+def _safe_local_file_path(path: Path, *, allowed_root: Path | None = None) -> Path:
+    resolved = path.expanduser().resolve()
+    root = (allowed_root or resolved.parent).expanduser().resolve()
+    try:
+        resolved.relative_to(root)
+    except ValueError as exc:
+        raise PipelineConfigurationError(f"JSON file must be under the allowed artifact root: {root}") from exc
+    if resolved.name in {"", ".", ".."}:
+        raise PipelineConfigurationError(f"Unsafe JSON file path: {path}")
+    return resolved
 
 
 def _run_prefix_from_manifest_key(key: str, runtime_config: PipelineRuntimeConfig) -> str:

--- a/ml/src/pipeline/common/artifacts.py
+++ b/ml/src/pipeline/common/artifacts.py
@@ -170,7 +170,7 @@ def _mirror_stage_directory_to_s3(
     prefix_parts = [
         runtime_config.artifact_prefix,
         stage_context.dag_id,
-        stage_context.run_id,
+        stage_context.run_id.replace("/", "__"),
         stage_context.stage_name,
     ]
     prefix = "/".join(part.strip("/") for part in prefix_parts if part)

--- a/ml/src/pipeline/ecs_stage_task.py
+++ b/ml/src/pipeline/ecs_stage_task.py
@@ -203,7 +203,12 @@ def _container_environment(
         "PIPELINE_CONFIRMED_DOMAIN_PROFILE_PATH": _env("PIPELINE_CONFIRMED_DOMAIN_PROFILE_PATH"),
         "PIPELINE_FEEDBACK_CONSTRAINTS_PATH": _env("PIPELINE_FEEDBACK_CONSTRAINTS_PATH"),
     }
-    return [{"name": key, "value": value} for key, value in values.items() if value not in (None, "")]
+    environment: list[dict[str, str]] = []
+    for key, value in values.items():
+        if value is None or value == "":
+            continue
+        environment.append({"name": key, "value": value})
+    return environment
 
 
 def _placement_for_stage(ecs_config: EcsStageTaskConfig, stage_name: str) -> dict[str, Any]:

--- a/ml/src/pipeline/ecs_stage_task.py
+++ b/ml/src/pipeline/ecs_stage_task.py
@@ -1,0 +1,281 @@
+"""Submit one ML pipeline stage as a separate ECS task."""
+
+from __future__ import annotations
+
+import os
+import time
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+import boto3
+
+from pipeline.common.artifact_io import read_json_uri
+from pipeline.common.config import PipelineRuntimeConfig
+from pipeline.common.context import StageContext
+from pipeline.common.exceptions import PipelineConfigurationError, PipelineStageError
+
+DEFAULT_GPU_STAGES = {"representation"}
+
+
+@dataclass(frozen=True)
+class EcsStageTaskConfig:
+    cluster: str
+    cpu_task_definition: str
+    cpu_container_name: str
+    gpu_task_definition: str | None
+    gpu_container_name: str
+    gpu_capacity_provider: str | None
+    subnet_ids: tuple[str, ...]
+    security_group_ids: tuple[str, ...]
+    assign_public_ip: str
+    result_bucket: str
+    result_prefix: str
+    poll_interval_seconds: float
+    task_timeout_seconds: float
+    gpu_stages: frozenset[str]
+
+    @classmethod
+    def from_env(cls, runtime_config: PipelineRuntimeConfig) -> "EcsStageTaskConfig":
+        result_bucket = _env("PIPELINE_ECS_RESULT_BUCKET") or runtime_config.artifact_bucket
+        if not result_bucket:
+            raise PipelineConfigurationError("PIPELINE_ECS_RESULT_BUCKET or ML_ARTIFACT_BUCKET is required.")
+        subnet_ids = _csv_env("PIPELINE_ECS_SUBNET_IDS")
+        security_group_ids = _csv_env("PIPELINE_ECS_SECURITY_GROUP_IDS")
+        if not subnet_ids:
+            raise PipelineConfigurationError("PIPELINE_ECS_SUBNET_IDS is required for ECS stage execution.")
+        if not security_group_ids:
+            raise PipelineConfigurationError("PIPELINE_ECS_SECURITY_GROUP_IDS is required for ECS stage execution.")
+        return cls(
+            cluster=_required_env("PIPELINE_ECS_CLUSTER"),
+            cpu_task_definition=_required_env("PIPELINE_ECS_CPU_TASK_DEFINITION"),
+            cpu_container_name=_env("PIPELINE_ECS_CPU_CONTAINER_NAME") or "ml-stage-cpu",
+            gpu_task_definition=_env("PIPELINE_ECS_GPU_TASK_DEFINITION"),
+            gpu_container_name=_env("PIPELINE_ECS_GPU_CONTAINER_NAME") or "ml-stage-gpu",
+            gpu_capacity_provider=_env("PIPELINE_ECS_GPU_CAPACITY_PROVIDER"),
+            subnet_ids=subnet_ids,
+            security_group_ids=security_group_ids,
+            assign_public_ip=(_env("PIPELINE_ECS_ASSIGN_PUBLIC_IP") or "DISABLED").upper(),
+            result_bucket=result_bucket,
+            result_prefix=(_env("PIPELINE_ECS_RESULT_PREFIX") or "ecs-stage-results").strip("/"),
+            poll_interval_seconds=float(_env("PIPELINE_ECS_POLL_INTERVAL_SECONDS") or "15"),
+            task_timeout_seconds=float(_env("PIPELINE_ECS_TASK_TIMEOUT_SECONDS") or "21600"),
+            gpu_stages=frozenset(_csv_env("PIPELINE_ECS_GPU_STAGES") or DEFAULT_GPU_STAGES),
+        )
+
+
+def run_stage_task(
+    stage_name: str,
+    stage_context: StageContext,
+    runtime_config: PipelineRuntimeConfig,
+    upstream_manifest_path: str | None,
+) -> dict[str, str]:
+    ecs_config = EcsStageTaskConfig.from_env(runtime_config)
+    result_uri = _result_uri(ecs_config, stage_context)
+    task_payload = _submit_task(
+        ecs_config,
+        stage_name,
+        stage_context,
+        runtime_config,
+        upstream_manifest_path,
+        result_uri,
+    )
+    task_arn = _task_arn(task_payload)
+    _wait_for_task(ecs_config, task_arn)
+    result = read_json_uri(result_uri)
+    manifest_uri = result.get("artifact_manifest_path") or result.get("manifestUri")
+    if not isinstance(manifest_uri, str) or not manifest_uri:
+        raise PipelineStageError(f"ECS stage result missing artifact_manifest_path: {result_uri}")
+    return {"artifact_manifest_path": manifest_uri}
+
+
+def _submit_task(
+    ecs_config: EcsStageTaskConfig,
+    stage_name: str,
+    stage_context: StageContext,
+    runtime_config: PipelineRuntimeConfig,
+    upstream_manifest_path: str | None,
+    result_uri: str,
+) -> Mapping[str, Any]:
+    task_definition = _task_definition_for_stage(ecs_config, stage_name)
+    container_name = _container_name_for_stage(ecs_config, stage_name)
+    response = boto3.client("ecs").run_task(
+        cluster=ecs_config.cluster,
+        taskDefinition=task_definition,
+        count=1,
+        **_placement_for_stage(ecs_config, stage_name),
+        networkConfiguration={
+            "awsvpcConfiguration": {
+                "subnets": list(ecs_config.subnet_ids),
+                "securityGroups": list(ecs_config.security_group_ids),
+                "assignPublicIp": ecs_config.assign_public_ip,
+            }
+        },
+        overrides={
+            "containerOverrides": [
+                {
+                    "name": container_name,
+                    "environment": _container_environment(
+                        stage_name,
+                        stage_context,
+                        runtime_config,
+                        upstream_manifest_path,
+                        result_uri,
+                    ),
+                }
+            ]
+        },
+    )
+    failures = response.get("failures") or []
+    if failures:
+        raise PipelineStageError(f"ECS RunTask failed for {stage_name}: {failures}")
+    return response
+
+
+def _wait_for_task(ecs_config: EcsStageTaskConfig, task_arn: str) -> None:
+    ecs = boto3.client("ecs")
+    deadline = time.monotonic() + ecs_config.task_timeout_seconds
+    while True:
+        response = ecs.describe_tasks(cluster=ecs_config.cluster, tasks=[task_arn])
+        tasks = response.get("tasks") or []
+        if not tasks:
+            raise PipelineStageError(f"ECS task disappeared before completion: {task_arn}")
+        task = tasks[0]
+        status = task.get("lastStatus")
+        if status == "STOPPED":
+            _raise_for_stopped_task(task)
+            return
+        if time.monotonic() >= deadline:
+            raise PipelineStageError(f"ECS task timed out: {task_arn}")
+        time.sleep(ecs_config.poll_interval_seconds)
+
+
+def _raise_for_stopped_task(task: Mapping[str, Any]) -> None:
+    containers = task.get("containers") or []
+    failed_containers = [
+        container
+        for container in containers
+        if isinstance(container, Mapping) and int(container.get("exitCode") or 0) != 0
+    ]
+    if failed_containers:
+        reason = failed_containers[0].get("reason") or task.get("stoppedReason") or "container failed"
+        exit_code = failed_containers[0].get("exitCode")
+        raise PipelineStageError(f"ECS stage task failed with exitCode={exit_code}: {reason}")
+    stopped_reason = str(task.get("stoppedReason") or "")
+    if stopped_reason and "Essential container in task exited" not in stopped_reason:
+        raise PipelineStageError(f"ECS stage task stopped unexpectedly: {stopped_reason}")
+
+
+def _container_environment(
+    stage_name: str,
+    stage_context: StageContext,
+    runtime_config: PipelineRuntimeConfig,
+    upstream_manifest_path: str | None,
+    result_uri: str,
+) -> list[dict[str, str]]:
+    values: dict[str, str | None] = {
+        "PIPELINE_STAGE_NAME": stage_name,
+        "PIPELINE_STAGE_RESULT_URI": result_uri,
+        "PIPELINE_UPSTREAM_MANIFEST_URI": upstream_manifest_path,
+        "PIPELINE_BACKEND_BASE_URL": runtime_config.backend_base_url,
+        "PIPELINE_CALLBACK_ENABLED": str(runtime_config.callback_enabled).lower(),
+        "PIPELINE_CALLBACK_TIMEOUT_SECONDS": str(runtime_config.callback_timeout_seconds),
+        "AIRFLOW_DAG_ID": stage_context.dag_id,
+        "AIRFLOW_RUN_ID": stage_context.run_id,
+        "PIPELINE_WORKSPACE_ID": stage_context.workspace_id,
+        "PIPELINE_DATASET_ID": stage_context.dataset_id,
+        "PIPELINE_JOB_ID": stage_context.pipeline_job_id,
+        "PIPELINE_RAW_OBJECT_KEY": _conf_env("PIPELINE_RAW_OBJECT_KEY", "AIRFLOW_OBJECT_KEY"),
+        "ML_ARTIFACT_STORE": runtime_config.artifact_store,
+        "ML_ARTIFACT_BUCKET": runtime_config.artifact_bucket,
+        "ML_ARTIFACT_PREFIX": runtime_config.artifact_prefix,
+        "EMBEDDING_MODEL_NAME": runtime_config.embedding_model_name,
+        "ML_EMBEDDING_RUNTIME": runtime_config.embedding_runtime,
+        "LLM_MODEL_NAME": runtime_config.llm_model_name,
+        "LLM_RUNTIME_BASE_URL": runtime_config.llm_runtime_base_url,
+        "LLM_RUNTIME_API_KEY": runtime_config.llm_runtime_api_key,
+        "ML_RUNTIME_PROFILE": runtime_config.runtime_profile,
+        "GPU_TASK_MODE": runtime_config.gpu_task_mode,
+        "AIRFLOW_WEBHOOK_SECRET": runtime_config.airflow_webhook_secret,
+        "S3_EXPECTED_BUCKET_OWNER": _env("S3_EXPECTED_BUCKET_OWNER"),
+        "AWS_REGION": _env("AWS_REGION") or _env("AWS_DEFAULT_REGION"),
+        "AWS_DEFAULT_REGION": _env("AWS_DEFAULT_REGION") or _env("AWS_REGION"),
+        "PIPELINE_CONFIRMED_DOMAIN_PROFILE_PATH": _env("PIPELINE_CONFIRMED_DOMAIN_PROFILE_PATH"),
+        "PIPELINE_FEEDBACK_CONSTRAINTS_PATH": _env("PIPELINE_FEEDBACK_CONSTRAINTS_PATH"),
+    }
+    return [{"name": key, "value": value} for key, value in values.items() if value not in (None, "")]
+
+
+def _placement_for_stage(ecs_config: EcsStageTaskConfig, stage_name: str) -> dict[str, Any]:
+    if stage_name in ecs_config.gpu_stages:
+        if ecs_config.gpu_capacity_provider:
+            return {"capacityProviderStrategy": [{"capacityProvider": ecs_config.gpu_capacity_provider, "weight": 1}]}
+        return {"launchType": "EC2"}
+    return {"launchType": "FARGATE", "platformVersion": "LATEST"}
+
+
+def _task_definition_for_stage(ecs_config: EcsStageTaskConfig, stage_name: str) -> str:
+    if stage_name in ecs_config.gpu_stages:
+        return ecs_config.gpu_task_definition or ecs_config.cpu_task_definition
+    return ecs_config.cpu_task_definition
+
+
+def _container_name_for_stage(ecs_config: EcsStageTaskConfig, stage_name: str) -> str:
+    if stage_name in ecs_config.gpu_stages and ecs_config.gpu_task_definition:
+        return ecs_config.gpu_container_name
+    return ecs_config.cpu_container_name
+
+
+def _task_arn(response: Mapping[str, Any]) -> str:
+    tasks = response.get("tasks") or []
+    if not tasks or not isinstance(tasks[0], Mapping):
+        raise PipelineStageError(f"ECS RunTask returned no tasks: {response}")
+    task_arn = tasks[0].get("taskArn")
+    if not isinstance(task_arn, str) or not task_arn:
+        raise PipelineStageError(f"ECS RunTask returned no taskArn: {response}")
+    return task_arn
+
+
+def _result_uri(ecs_config: EcsStageTaskConfig, stage_context: StageContext) -> str:
+    safe_run_id = stage_context.run_id.replace("/", "__")
+    key = "/".join(
+        part
+        for part in (
+            ecs_config.result_prefix,
+            stage_context.dag_id,
+            safe_run_id,
+            f"{stage_context.stage_name}.json",
+        )
+        if part
+    )
+    return f"s3://{ecs_config.result_bucket}/{key}"
+
+
+def _required_env(name: str) -> str:
+    value = _env(name)
+    if not value:
+        raise PipelineConfigurationError(f"{name} is required for ECS stage execution.")
+    return value
+
+
+def _env(name: str) -> str | None:
+    value = os.getenv(name)
+    if value is None:
+        return None
+    normalized = value.strip()
+    return normalized or None
+
+
+def _csv_env(name: str) -> tuple[str, ...]:
+    value = _env(name)
+    if not value:
+        return ()
+    return tuple(item.strip() for item in value.split(",") if item.strip())
+
+
+def _conf_env(*names: str) -> str | None:
+    for name in names:
+        value = _env(name)
+        if value:
+            return value
+    return None

--- a/ml/src/pipeline/ecs_stage_worker.py
+++ b/ml/src/pipeline/ecs_stage_worker.py
@@ -1,0 +1,135 @@
+"""ECS one-shot worker that executes a single ML pipeline stage."""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Any, Callable
+
+from pipeline.common.artifact_io import (
+    download_s3_uri,
+    is_s3_uri,
+    manifest_s3_uri_from_local_manifest,
+    materialize_manifest_uri,
+    write_json_uri,
+)
+from pipeline.common.config import PipelineRuntimeConfig
+from pipeline.common.exceptions import PipelineConfigurationError
+
+logger = logging.getLogger(__name__)
+
+StageCallable = Callable[[str | None], dict[str, object] | None]
+
+STAGE_MODULES: dict[str, str] = {
+    "ingestion": "pipeline.stages.ingestion.main",
+    "preprocessing": "pipeline.stages.preprocessing.main",
+    "representation": "pipeline.stages.representation.main",
+    "domain_candidate_generation": "pipeline.stages.domain_candidate_generation.main",
+    "intent_discovery": "pipeline.stages.intent_discovery.main",
+    "flow_splitting": "pipeline.stages.flow_splitting.main",
+    "feedback_candidate_generation": "pipeline.stages.feedback_candidate_generation.main",
+    "draft_generation": "pipeline.stages.draft_generation.main",
+    "evaluation": "pipeline.stages.evaluation.main",
+    "publish_candidate": "pipeline.stages.publish_candidate.main",
+}
+
+
+class StageWorkerError(RuntimeError):
+    """Raised when a one-shot stage worker cannot complete."""
+
+
+def run_worker() -> dict[str, Any]:
+    stage_name = _required_env("PIPELINE_STAGE_NAME")
+    result_uri = _required_env("PIPELINE_STAGE_RESULT_URI")
+    scratch_root = Path(os.getenv("PIPELINE_STAGE_SCRATCH_ROOT", "/tmp/ostone-stage-worker"))
+    artifact_root = scratch_root / "artifacts"
+    artifact_root.mkdir(parents=True, exist_ok=True)
+    os.environ["PIPELINE_ARTIFACT_ROOT"] = str(artifact_root)
+    runtime_config = PipelineRuntimeConfig.from_env()
+
+    upstream_manifest = _optional_env("PIPELINE_UPSTREAM_MANIFEST_URI")
+    local_upstream = None
+    if upstream_manifest:
+        local_upstream = str(materialize_manifest_uri(upstream_manifest, artifact_root, runtime_config))
+    _materialize_optional_file_env("PIPELINE_CONFIRMED_DOMAIN_PROFILE_PATH", scratch_root / "review_inputs")
+    _materialize_optional_file_env("PIPELINE_FEEDBACK_CONSTRAINTS_PATH", scratch_root / "review_inputs")
+
+    stage_callable = _stage_callable(stage_name)
+    logger.info("Running stage=%s upstream=%s", stage_name, upstream_manifest or "")
+    result = stage_callable(local_upstream) or {}
+    local_manifest_path = _artifact_manifest_path(result)
+    manifest_uri = (
+        manifest_s3_uri_from_local_manifest(local_manifest_path)
+        if runtime_config.artifact_store == "s3" or is_s3_uri(upstream_manifest)
+        else str(local_manifest_path)
+    )
+    payload = {
+        "stageName": stage_name,
+        "artifact_manifest_path": manifest_uri,
+        "manifestUri": manifest_uri,
+        "localManifestPath": str(local_manifest_path),
+    }
+    write_json_uri(result_uri, payload)
+    logger.info("Stage completed stage=%s manifest=%s", stage_name, manifest_uri)
+    return payload
+
+
+def _stage_callable(stage_name: str) -> StageCallable:
+    module_name = STAGE_MODULES.get(stage_name)
+    if module_name is None:
+        allowed = ", ".join(sorted(STAGE_MODULES))
+        raise StageWorkerError(f"Unsupported PIPELINE_STAGE_NAME: {stage_name}. allowed={allowed}")
+    module = importlib.import_module(module_name)
+    run = getattr(module, "run", None)
+    if not callable(run):
+        raise StageWorkerError(f"Stage module does not expose a callable run(): {module_name}")
+    return run
+
+
+def _artifact_manifest_path(result: dict[str, object]) -> Path:
+    value = result.get("artifact_manifest_path")
+    if not isinstance(value, str) or not value:
+        raise StageWorkerError("Stage result must include artifact_manifest_path.")
+    return Path(value)
+
+
+def _required_env(name: str) -> str:
+    value = os.getenv(name, "").strip()
+    if not value:
+        raise StageWorkerError(f"{name} is required")
+    return value
+
+
+def _optional_env(name: str) -> str | None:
+    value = os.getenv(name, "").strip()
+    return value or None
+
+
+def _materialize_optional_file_env(name: str, target_dir: Path) -> None:
+    value = _optional_env(name)
+    if not is_s3_uri(value):
+        return
+    target_path = target_dir / Path(value.rsplit("/", 1)[-1]).name
+    download_s3_uri(value, target_path)
+    os.environ[name] = str(target_path)
+
+
+def main() -> None:
+    logging.basicConfig(level=os.getenv("LOG_LEVEL", "INFO"))
+    try:
+        run_worker()
+    except (PipelineConfigurationError, StageWorkerError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as exc:
+        logger.exception("Stage worker failed")
+        print(f"ERROR: {exc}", file=sys.stderr)
+        sys.exit(1)
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/ml/src/pipeline/ecs_stage_worker.py
+++ b/ml/src/pipeline/ecs_stage_worker.py
@@ -6,6 +6,7 @@ import importlib
 import logging
 import os
 import sys
+import tempfile
 from pathlib import Path
 from typing import Any, Callable
 
@@ -44,7 +45,7 @@ class StageWorkerError(RuntimeError):
 def run_worker() -> dict[str, Any]:
     stage_name = _required_env("PIPELINE_STAGE_NAME")
     result_uri = _required_env("PIPELINE_STAGE_RESULT_URI")
-    scratch_root = Path(os.getenv("PIPELINE_STAGE_SCRATCH_ROOT", "/tmp/ostone-stage-worker"))
+    scratch_root = _scratch_root()
     artifact_root = scratch_root / "artifacts"
     artifact_root.mkdir(parents=True, exist_ok=True)
     os.environ["PIPELINE_ARTIFACT_ROOT"] = str(artifact_root)
@@ -62,7 +63,7 @@ def run_worker() -> dict[str, Any]:
     result = stage_callable(local_upstream) or {}
     local_manifest_path = _artifact_manifest_path(result)
     manifest_uri = (
-        manifest_s3_uri_from_local_manifest(local_manifest_path)
+        manifest_s3_uri_from_local_manifest(local_manifest_path, allowed_root=artifact_root)
         if runtime_config.artifact_store == "s3" or is_s3_uri(upstream_manifest)
         else str(local_manifest_path)
     )
@@ -103,6 +104,13 @@ def _required_env(name: str) -> str:
     return value
 
 
+def _scratch_root() -> Path:
+    configured = os.getenv("PIPELINE_STAGE_SCRATCH_ROOT", "").strip()
+    if configured:
+        return Path(configured)
+    return Path(tempfile.mkdtemp(prefix="ostone-stage-worker-"))
+
+
 def _optional_env(name: str) -> str | None:
     value = os.getenv(name, "").strip()
     return value or None
@@ -110,7 +118,7 @@ def _optional_env(name: str) -> str | None:
 
 def _materialize_optional_file_env(name: str, target_dir: Path) -> None:
     value = _optional_env(name)
-    if not is_s3_uri(value):
+    if value is None or not is_s3_uri(value):
         return
     target_path = target_dir / Path(value.rsplit("/", 1)[-1]).name
     download_s3_uri(value, target_path)

--- a/ml/tests/test_artifact_io.py
+++ b/ml/tests/test_artifact_io.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from pipeline.common.artifact_io import (
+    S3Uri,
+    download_s3_prefix,
+    download_s3_uri,
+    manifest_s3_uri_from_local_manifest,
+    materialize_manifest_uri,
+    read_json_file,
+    read_json_uri,
+    stage_manifest_s3_uri,
+    stage_s3_prefix,
+    write_json_uri,
+)
+from pipeline.common.config import PipelineRuntimeConfig
+from pipeline.common.context import StageContext
+from pipeline.common.exceptions import PipelineConfigurationError
+
+
+class _Body:
+    def __init__(self, payload: bytes) -> None:
+        self._payload = payload
+
+    def read(self) -> bytes:
+        return self._payload
+
+
+class _FakeS3:
+    def __init__(self) -> None:
+        self.objects: dict[tuple[str, str], bytes] = {}
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def list_objects_v2(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(("list", kwargs))
+        bucket = kwargs["Bucket"]
+        prefix = kwargs["Prefix"]
+        contents = [
+            {"Key": key} for object_bucket, key in self.objects if object_bucket == bucket and key.startswith(prefix)
+        ]
+        return {"Contents": contents, "IsTruncated": False}
+
+    def get_object(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(("get", kwargs))
+        return {"Body": _Body(self.objects[(kwargs["Bucket"], kwargs["Key"])])}
+
+    def put_object(self, **kwargs: Any) -> None:
+        self.calls.append(("put", kwargs))
+        self.objects[(kwargs["Bucket"], kwargs["Key"])] = kwargs["Body"]
+
+
+def _runtime(tmp_path: Path, *, store: str = "s3") -> PipelineRuntimeConfig:
+    return PipelineRuntimeConfig(
+        artifact_root=tmp_path / "artifacts",
+        backend_base_url="http://backend:8080",
+        callback_enabled=False,
+        artifact_store=store,
+        artifact_bucket="artifact-bucket",
+        artifact_prefix="domain-pack",
+    )
+
+
+def test_s3_uri_and_stage_manifest_uri(tmp_path: Path) -> None:
+    parsed = S3Uri.parse("s3://artifact-bucket/domain-pack/manifest.json")
+    context = StageContext(dag_id="dag", run_id="manual/run", stage_name="representation")
+
+    assert str(parsed) == "s3://artifact-bucket/domain-pack/manifest.json"
+    assert stage_s3_prefix(context, _runtime(tmp_path)) == "domain-pack/dag/manual__run/representation"
+    assert (
+        stage_manifest_s3_uri(context, _runtime(tmp_path))
+        == "s3://artifact-bucket/domain-pack/dag/manual__run/representation/manifest.json"
+    )
+
+    with pytest.raises(PipelineConfigurationError):
+        S3Uri.parse("https://artifact-bucket/domain-pack/manifest.json")
+
+
+def test_local_json_read_requires_allowed_root(tmp_path: Path) -> None:
+    allowed = tmp_path / "allowed"
+    outside = tmp_path / "outside.json"
+    manifest = allowed / "manifest.json"
+    manifest.parent.mkdir()
+    manifest.write_text('{"ok": true}', encoding="utf-8")
+    outside.write_text('{"ok": false}', encoding="utf-8")
+
+    assert read_json_file(manifest, allowed_root=allowed) == {"ok": True}
+    with pytest.raises(PipelineConfigurationError, match="allowed artifact root"):
+        read_json_file(outside, allowed_root=allowed)
+
+
+def test_manifest_s3_uri_from_local_manifest(tmp_path: Path) -> None:
+    manifest = tmp_path / "artifacts" / "dag" / "run" / "stage" / "manifest.json"
+    manifest.parent.mkdir(parents=True)
+    manifest.write_text(
+        json.dumps(
+            {
+                "artifact_bucket": "artifact-bucket",
+                "artifact_prefix": "domain-pack",
+                "artifact_root": str(tmp_path / "artifacts"),
+                "dag_id": "dag",
+                "run_id": "manual/run",
+                "stage_name": "stage",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert (
+        manifest_s3_uri_from_local_manifest(manifest, allowed_root=tmp_path / "artifacts")
+        == "s3://artifact-bucket/domain-pack/dag/manual__run/stage/manifest.json"
+    )
+
+
+def test_s3_json_roundtrip_uses_expected_bucket_owner(monkeypatch: pytest.MonkeyPatch) -> None:
+    s3 = _FakeS3()
+    monkeypatch.setattr("pipeline.common.artifact_io.boto3.client", lambda service: s3)
+    monkeypatch.setenv("S3_EXPECTED_BUCKET_OWNER", "123456789012")
+
+    write_json_uri("s3://artifact-bucket/path/manifest.json", {"value": 7})
+
+    assert read_json_uri("s3://artifact-bucket/path/manifest.json") == {"value": 7}
+    assert s3.calls[0][0] == "put"
+    assert s3.calls[0][1]["ExpectedBucketOwner"] == "123456789012"
+    assert s3.calls[1][0] == "get"
+    assert s3.calls[1][1]["ExpectedBucketOwner"] == "123456789012"
+
+
+def test_materialize_manifest_uri_downloads_run_prefix(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    s3 = _FakeS3()
+    s3.objects[("artifact-bucket", "domain-pack/dag/run/ingestion/manifest.json")] = b'{"stage":"ingestion"}'
+    s3.objects[("artifact-bucket", "domain-pack/dag/run/preprocessing/manifest.json")] = b'{"stage":"pre"}'
+    monkeypatch.setattr("pipeline.common.artifact_io.boto3.client", lambda service: s3)
+    monkeypatch.setenv("S3_EXPECTED_BUCKET_OWNER", "123456789012")
+
+    local_manifest = materialize_manifest_uri(
+        "s3://artifact-bucket/domain-pack/dag/run/preprocessing/manifest.json",
+        tmp_path / "downloaded",
+        _runtime(tmp_path),
+    )
+
+    assert local_manifest == tmp_path / "downloaded" / "dag" / "run" / "preprocessing" / "manifest.json"
+    assert json.loads(local_manifest.read_text(encoding="utf-8")) == {"stage": "pre"}
+    get_calls = [kwargs for name, kwargs in s3.calls if name == "get"]
+    assert all(call["ExpectedBucketOwner"] == "123456789012" for call in get_calls)
+
+
+def test_download_s3_prefix_rejects_unsafe_keys(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    s3 = _FakeS3()
+    s3.objects[("artifact-bucket", "domain-pack/dag/run/../manifest.json")] = b"{}"
+    monkeypatch.setattr("pipeline.common.artifact_io.boto3.client", lambda service: s3)
+
+    with pytest.raises(PipelineConfigurationError, match="Unsafe S3 artifact key"):
+        download_s3_prefix(
+            "artifact-bucket",
+            "domain-pack/dag/run",
+            tmp_path / "downloaded",
+            strip_prefix="domain-pack",
+        )
+
+
+def test_download_s3_uri_writes_file(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    s3 = _FakeS3()
+    s3.objects[("artifact-bucket", "domain-pack/input.json")] = b'{"input": true}'
+    monkeypatch.setattr("pipeline.common.artifact_io.boto3.client", lambda service: s3)
+
+    target = download_s3_uri("s3://artifact-bucket/domain-pack/input.json", tmp_path / "input.json")
+
+    assert target.read_text(encoding="utf-8") == '{"input": true}'

--- a/ml/tests/test_ecs_stage_task.py
+++ b/ml/tests/test_ecs_stage_task.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from pipeline.common.config import PipelineRuntimeConfig
+from pipeline.common.context import StageContext
+from pipeline.ecs_stage_task import run_stage_task
+
+
+def test_run_stage_task_submits_ecs_task_and_returns_manifest(monkeypatch) -> None:
+    calls: dict[str, Any] = {}
+
+    class FakeEcsClient:
+        def run_task(self, **kwargs: Any) -> dict[str, Any]:
+            calls["run_task"] = kwargs
+            return {"tasks": [{"taskArn": "arn:aws:ecs:task/123"}]}
+
+        def describe_tasks(self, **kwargs: Any) -> dict[str, Any]:
+            calls["describe_tasks"] = kwargs
+            return {
+                "tasks": [
+                    {
+                        "lastStatus": "STOPPED",
+                        "stoppedReason": "Essential container in task exited",
+                        "containers": [{"name": "ml-stage-cpu", "exitCode": 0}],
+                    }
+                ]
+            }
+
+    monkeypatch.setattr("pipeline.ecs_stage_task.boto3.client", lambda service: FakeEcsClient())
+    monkeypatch.setattr(
+        "pipeline.ecs_stage_task.read_json_uri",
+        lambda uri: {"artifact_manifest_path": "s3://artifacts/domain-pack/dag/run/preprocessing/manifest.json"},
+    )
+    monkeypatch.setenv("PIPELINE_ECS_CLUSTER", "cluster")
+    monkeypatch.setenv("PIPELINE_ECS_CPU_TASK_DEFINITION", "cpu-task")
+    monkeypatch.setenv("PIPELINE_ECS_SUBNET_IDS", "subnet-a,subnet-b")
+    monkeypatch.setenv("PIPELINE_ECS_SECURITY_GROUP_IDS", "sg-stage")
+    monkeypatch.setenv("PIPELINE_ECS_POLL_INTERVAL_SECONDS", "0")
+
+    runtime_config = PipelineRuntimeConfig(
+        artifact_root=Path("/tmp/artifacts"),
+        backend_base_url="https://api.example.com",
+        callback_enabled=False,
+        artifact_store="s3",
+        artifact_bucket="artifacts",
+        artifact_prefix="domain-pack",
+    )
+    stage_context = StageContext(
+        dag_id="dag",
+        run_id="run",
+        stage_name="preprocessing",
+        workspace_id="1",
+        dataset_id="2",
+        pipeline_job_id="3",
+    )
+
+    result = run_stage_task(
+        "preprocessing",
+        stage_context,
+        runtime_config,
+        "s3://artifacts/domain-pack/dag/run/ingestion/manifest.json",
+    )
+
+    assert result == {"artifact_manifest_path": "s3://artifacts/domain-pack/dag/run/preprocessing/manifest.json"}
+    assert calls["run_task"]["cluster"] == "cluster"
+    assert calls["run_task"]["taskDefinition"] == "cpu-task"
+    assert calls["run_task"]["launchType"] == "FARGATE"
+    environment = calls["run_task"]["overrides"]["containerOverrides"][0]["environment"]
+    assert {"name": "PIPELINE_STAGE_NAME", "value": "preprocessing"} in environment
+    assert {
+        "name": "PIPELINE_UPSTREAM_MANIFEST_URI",
+        "value": "s3://artifacts/domain-pack/dag/run/ingestion/manifest.json",
+    } in environment

--- a/ml/tests/test_ecs_stage_task.py
+++ b/ml/tests/test_ecs_stage_task.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 from pipeline.common.config import PipelineRuntimeConfig
 from pipeline.common.context import StageContext
-from pipeline.ecs_stage_task import run_stage_task
+from pipeline.common.exceptions import PipelineConfigurationError, PipelineStageError
+from pipeline.ecs_stage_task import EcsStageTaskConfig, run_stage_task
 
 
 def test_run_stage_task_submits_ecs_task_and_returns_manifest(monkeypatch) -> None:
@@ -73,3 +76,143 @@ def test_run_stage_task_submits_ecs_task_and_returns_manifest(monkeypatch) -> No
         "name": "PIPELINE_UPSTREAM_MANIFEST_URI",
         "value": "s3://artifacts/domain-pack/dag/run/ingestion/manifest.json",
     } in environment
+
+
+def test_config_from_env_requires_network_settings(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("PIPELINE_ECS_CLUSTER", "cluster")
+    monkeypatch.setenv("PIPELINE_ECS_CPU_TASK_DEFINITION", "cpu-task")
+    runtime_config = PipelineRuntimeConfig(
+        artifact_root=tmp_path,
+        backend_base_url="https://api.example.com",
+        callback_enabled=False,
+        artifact_store="s3",
+        artifact_bucket="artifacts",
+    )
+
+    with pytest.raises(PipelineConfigurationError, match="PIPELINE_ECS_SUBNET_IDS"):
+        EcsStageTaskConfig.from_env(runtime_config)
+
+
+def test_run_stage_task_uses_gpu_capacity_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: dict[str, Any] = {}
+
+    class FakeEcsClient:
+        def run_task(self, **kwargs: Any) -> dict[str, Any]:
+            calls["run_task"] = kwargs
+            return {"tasks": [{"taskArn": "arn:aws:ecs:task/gpu"}]}
+
+        def describe_tasks(self, **_kwargs: Any) -> dict[str, Any]:
+            return {
+                "tasks": [
+                    {
+                        "lastStatus": "STOPPED",
+                        "stoppedReason": "Essential container in task exited",
+                        "containers": [{"name": "ml-stage-gpu", "exitCode": 0}],
+                    }
+                ]
+            }
+
+    monkeypatch.setattr("pipeline.ecs_stage_task.boto3.client", lambda service: FakeEcsClient())
+    monkeypatch.setattr(
+        "pipeline.ecs_stage_task.read_json_uri",
+        lambda uri: {"manifestUri": "s3://artifacts/domain-pack/dag/run/representation/manifest.json"},
+    )
+    _set_required_ecs_env(monkeypatch)
+    monkeypatch.setenv("PIPELINE_ECS_GPU_TASK_DEFINITION", "gpu-task")
+    monkeypatch.setenv("PIPELINE_ECS_GPU_CAPACITY_PROVIDER", "gpu-provider")
+
+    result = run_stage_task("representation", _stage_context("representation"), _runtime_config(), None)
+
+    assert result["artifact_manifest_path"] == "s3://artifacts/domain-pack/dag/run/representation/manifest.json"
+    assert calls["run_task"]["taskDefinition"] == "gpu-task"
+    assert calls["run_task"]["capacityProviderStrategy"] == [{"capacityProvider": "gpu-provider", "weight": 1}]
+    assert calls["run_task"]["overrides"]["containerOverrides"][0]["name"] == "ml-stage-gpu"
+
+
+def test_run_stage_task_raises_on_runtask_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeEcsClient:
+        def run_task(self, **_kwargs: Any) -> dict[str, Any]:
+            return {"failures": [{"arn": "task", "reason": "capacity"}]}
+
+    monkeypatch.setattr("pipeline.ecs_stage_task.boto3.client", lambda service: FakeEcsClient())
+    _set_required_ecs_env(monkeypatch)
+
+    with pytest.raises(PipelineStageError, match="ECS RunTask failed"):
+        run_stage_task("preprocessing", _stage_context("preprocessing"), _runtime_config(), None)
+
+
+def test_run_stage_task_raises_on_container_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeEcsClient:
+        def run_task(self, **_kwargs: Any) -> dict[str, Any]:
+            return {"tasks": [{"taskArn": "arn:aws:ecs:task/failed"}]}
+
+        def describe_tasks(self, **_kwargs: Any) -> dict[str, Any]:
+            return {
+                "tasks": [
+                    {
+                        "lastStatus": "STOPPED",
+                        "stoppedReason": "Task failed",
+                        "containers": [{"name": "ml-stage-cpu", "exitCode": 2, "reason": "boom"}],
+                    }
+                ]
+            }
+
+    monkeypatch.setattr("pipeline.ecs_stage_task.boto3.client", lambda service: FakeEcsClient())
+    _set_required_ecs_env(monkeypatch)
+
+    with pytest.raises(PipelineStageError, match="exitCode=2"):
+        run_stage_task("preprocessing", _stage_context("preprocessing"), _runtime_config(), None)
+
+
+def test_run_stage_task_requires_manifest_uri_in_result(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeEcsClient:
+        def run_task(self, **_kwargs: Any) -> dict[str, Any]:
+            return {"tasks": [{"taskArn": "arn:aws:ecs:task/123"}]}
+
+        def describe_tasks(self, **_kwargs: Any) -> dict[str, Any]:
+            return {
+                "tasks": [
+                    {
+                        "lastStatus": "STOPPED",
+                        "stoppedReason": "Essential container in task exited",
+                        "containers": [{"name": "ml-stage-cpu", "exitCode": 0}],
+                    }
+                ]
+            }
+
+    monkeypatch.setattr("pipeline.ecs_stage_task.boto3.client", lambda service: FakeEcsClient())
+    monkeypatch.setattr("pipeline.ecs_stage_task.read_json_uri", lambda uri: {"stageName": "preprocessing"})
+    _set_required_ecs_env(monkeypatch)
+
+    with pytest.raises(PipelineStageError, match="missing artifact_manifest_path"):
+        run_stage_task("preprocessing", _stage_context("preprocessing"), _runtime_config(), None)
+
+
+def _runtime_config() -> PipelineRuntimeConfig:
+    return PipelineRuntimeConfig(
+        artifact_root=Path("/tmp/artifacts"),
+        backend_base_url="https://api.example.com",
+        callback_enabled=False,
+        artifact_store="s3",
+        artifact_bucket="artifacts",
+        artifact_prefix="domain-pack",
+    )
+
+
+def _stage_context(stage_name: str) -> StageContext:
+    return StageContext(
+        dag_id="dag",
+        run_id="run",
+        stage_name=stage_name,
+        workspace_id="1",
+        dataset_id="2",
+        pipeline_job_id="3",
+    )
+
+
+def _set_required_ecs_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PIPELINE_ECS_CLUSTER", "cluster")
+    monkeypatch.setenv("PIPELINE_ECS_CPU_TASK_DEFINITION", "cpu-task")
+    monkeypatch.setenv("PIPELINE_ECS_SUBNET_IDS", "subnet-a")
+    monkeypatch.setenv("PIPELINE_ECS_SECURITY_GROUP_IDS", "sg-stage")
+    monkeypatch.setenv("PIPELINE_ECS_POLL_INTERVAL_SECONDS", "0")

--- a/ml/tests/test_ecs_stage_worker.py
+++ b/ml/tests/test_ecs_stage_worker.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import pipeline.ecs_stage_worker as worker
+from pipeline.ecs_stage_worker import StageWorkerError, _stage_callable, run_worker
+
+
+def _install_stage_module(monkeypatch: pytest.MonkeyPatch, name: str, run: Any) -> None:
+    module = types.ModuleType(name)
+    setattr(module, "run", run)
+    monkeypatch.setitem(sys.modules, name, module)
+    monkeypatch.setitem(worker.STAGE_MODULES, "test_stage", name)
+
+
+def test_run_worker_executes_stage_and_writes_local_result(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    scratch = tmp_path / "scratch"
+    result_path = tmp_path / "result.json"
+
+    def run_stage(upstream_manifest_path: str | None) -> dict[str, object]:
+        assert upstream_manifest_path is None
+        artifact_root = Path(os.environ["PIPELINE_ARTIFACT_ROOT"])
+        manifest = artifact_root / "dag" / "run" / "test_stage" / "manifest.json"
+        manifest.parent.mkdir(parents=True)
+        manifest.write_text('{"payload":{"status":"completed"}}', encoding="utf-8")
+        return {"artifact_manifest_path": str(manifest)}
+
+    _install_stage_module(monkeypatch, "tests.fake_stage_local", run_stage)
+    monkeypatch.setenv("PIPELINE_STAGE_NAME", "test_stage")
+    monkeypatch.setenv("PIPELINE_STAGE_RESULT_URI", str(result_path))
+    monkeypatch.setenv("PIPELINE_STAGE_SCRATCH_ROOT", str(scratch))
+    monkeypatch.setenv("PIPELINE_BACKEND_BASE_URL", "http://backend:8080")
+    monkeypatch.setenv("PIPELINE_CALLBACK_ENABLED", "false")
+
+    payload = run_worker()
+
+    assert payload["manifestUri"] == str(scratch / "artifacts" / "dag" / "run" / "test_stage" / "manifest.json")
+    assert json.loads(result_path.read_text(encoding="utf-8"))["stageName"] == "test_stage"
+
+
+def test_run_worker_materializes_s3_inputs_and_returns_s3_manifest(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    scratch = tmp_path / "scratch"
+    result_path = tmp_path / "result.json"
+    calls: dict[str, str] = {}
+
+    def fake_materialize(uri: str, target_root: Path, _runtime_config: object) -> Path:
+        calls["upstream"] = uri
+        manifest = target_root / "dag" / "run" / "previous" / "manifest.json"
+        manifest.parent.mkdir(parents=True)
+        manifest.write_text("{}", encoding="utf-8")
+        return manifest
+
+    def fake_download(uri: str, target_path: Path) -> Path:
+        calls["review_input"] = uri
+        target_path.parent.mkdir(parents=True)
+        target_path.write_text("{}", encoding="utf-8")
+        return target_path
+
+    def run_stage(upstream_manifest_path: str | None) -> dict[str, object]:
+        assert upstream_manifest_path == str(scratch / "artifacts" / "dag" / "run" / "previous" / "manifest.json")
+        assert Path(os.environ["PIPELINE_CONFIRMED_DOMAIN_PROFILE_PATH"]).exists()
+        artifact_root = Path(os.environ["PIPELINE_ARTIFACT_ROOT"])
+        manifest = artifact_root / "dag" / "manual__run" / "test_stage" / "manifest.json"
+        manifest.parent.mkdir(parents=True)
+        manifest.write_text(
+            json.dumps(
+                {
+                    "artifact_bucket": "artifact-bucket",
+                    "artifact_prefix": "domain-pack",
+                    "artifact_root": str(artifact_root),
+                    "dag_id": "dag",
+                    "run_id": "manual/run",
+                    "stage_name": "test_stage",
+                    "payload": {},
+                }
+            ),
+            encoding="utf-8",
+        )
+        return {"artifact_manifest_path": str(manifest)}
+
+    _install_stage_module(monkeypatch, "tests.fake_stage_s3", run_stage)
+    monkeypatch.setattr("pipeline.ecs_stage_worker.materialize_manifest_uri", fake_materialize)
+    monkeypatch.setattr("pipeline.ecs_stage_worker.download_s3_uri", fake_download)
+    monkeypatch.setenv("PIPELINE_STAGE_NAME", "test_stage")
+    monkeypatch.setenv("PIPELINE_STAGE_RESULT_URI", str(result_path))
+    monkeypatch.setenv("PIPELINE_STAGE_SCRATCH_ROOT", str(scratch))
+    monkeypatch.setenv("PIPELINE_BACKEND_BASE_URL", "http://backend:8080")
+    monkeypatch.setenv("PIPELINE_CALLBACK_ENABLED", "false")
+    monkeypatch.setenv("ML_ARTIFACT_STORE", "s3")
+    monkeypatch.setenv("ML_ARTIFACT_BUCKET", "artifact-bucket")
+    monkeypatch.setenv("ML_ARTIFACT_PREFIX", "domain-pack")
+    monkeypatch.setenv(
+        "PIPELINE_UPSTREAM_MANIFEST_URI", "s3://artifact-bucket/domain-pack/dag/run/previous/manifest.json"
+    )
+    monkeypatch.setenv("PIPELINE_CONFIRMED_DOMAIN_PROFILE_PATH", "s3://artifact-bucket/review/domain.json")
+
+    payload = run_worker()
+
+    assert calls == {
+        "upstream": "s3://artifact-bucket/domain-pack/dag/run/previous/manifest.json",
+        "review_input": "s3://artifact-bucket/review/domain.json",
+    }
+    assert (
+        payload["artifact_manifest_path"] == "s3://artifact-bucket/domain-pack/dag/manual__run/test_stage/manifest.json"
+    )
+
+
+def test_run_worker_requires_stage_name(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("PIPELINE_STAGE_RESULT_URI", str(tmp_path / "result.json"))
+
+    with pytest.raises(StageWorkerError, match="PIPELINE_STAGE_NAME"):
+        run_worker()
+
+
+def test_stage_callable_rejects_unsupported_stage() -> None:
+    with pytest.raises(StageWorkerError, match="Unsupported PIPELINE_STAGE_NAME"):
+        _stage_callable("unknown")


### PR DESCRIPTION
## Summary
- Airflow production runtime을 ECS api-server/scheduler/dag-processor 서비스와 init task로 배포하도록 구성했습니다.
- Airflow DAG가 production에서 각 ML stage를 별도 ECS task로 실행하고, stage artifact를 S3 manifest 기준으로 전달하도록 했습니다.
- Production Deploy가 infra 변경까지 감지해 Terraform, backend/frontend, ML stage image, Airflow image/service 배포를 함께 수행하도록 정리했습니다.
- Terraform CD는 push 자동 apply 없이 수동 실행용으로 제한했습니다.

## Validation
- `cd ml && uv run pytest` (`589 passed, 2 skipped`)
- `terraform -chdir=infra/terraform fmt -check -recursive`
- `terraform -chdir=infra/terraform init -backend=false && terraform -chdir=infra/terraform validate`
- GitHub Actions workflow YAML parse check
- commit hook: `ruff check`, `ruff format`, `mypy`

## Notes
- 새 GitHub Secrets `PROD_AIRFLOW_FERNET_KEY`, `PROD_AIRFLOW_API_SECRET_KEY`, `PROD_AIRFLOW_API_AUTH_JWT_SECRET`, `PROD_AIRFLOW_SIMPLE_ADMIN_PASSWORD`, `PROD_AIRFLOW_SIMPLE_VIEWER_PASSWORD`를 repo-level secret으로 등록했습니다.
- Airflow UI admin/viewer password는 로컬 macOS Keychain의 `ostone-prod-airflow` service에 저장했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Airflow 워크플로우 관리 서비스 추가 배포
  * ML 파이프라인 처리 단계(CPU/GPU) 확장 지원
  * 프라이빗 API 엔드포인트를 통한 내부 서비스 통신 개선

* **인프라 개선**
  * 로드 밸런서에 Airflow 도메인 라우팅 추가
  * 확장된 데이터베이스 연결 지원
  * 보안 그룹 규칙 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->