### PR TITLE
fix(ml): restore ml stage image build

### DIFF
--- a/ml/Dockerfile.cpu
+++ b/ml/Dockerfile.cpu
@@ -2,7 +2,7 @@
 FROM python:3.13-slim-bookworm
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends curl ca-certificates build-essential \
+    && apt-get install -y --no-install-recommends curl ca-certificates build-essential zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
@@ -13,7 +13,8 @@ ENV HF_HOME=/app/.cache/huggingface
 ENV TORCH_HOME=/app/.cache/torch
 ENV PYTHONPATH=/app/src
 
-COPY ml/pyproject.toml ml/uv.lock ./
+COPY ml/pyproject.toml ml/uv.lock ml/README.md ./
+COPY ml/src/ml/ ./src/ml/
 RUN uv sync --python 3.13 --frozen --no-dev
 
 COPY ml/src/ ./src/

--- a/ml/Dockerfile.gpu
+++ b/ml/Dockerfile.gpu
@@ -2,7 +2,7 @@
 FROM nvidia/cuda:12.2.2-runtime-ubuntu22.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl ca-certificates \
+    curl ca-certificates zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Install uv
@@ -15,7 +15,8 @@ ENV TORCH_HOME=/app/.cache/torch
 ENV PYTHONPATH=/app/src
 
 # Copy dependency files first for layer caching
-COPY ml/pyproject.toml ml/uv.lock ./
+COPY ml/pyproject.toml ml/uv.lock ml/README.md ./
+COPY ml/src/ml/ ./src/ml/
 
 # Install runtime dependencies and the local BGE-M3 backend used in production.
 RUN uv sync --python 3.13 --frozen --no-dev \


### PR DESCRIPTION
## Summary
- ML stage CPU/GPU Docker images now copy the package metadata required by `uv_build` before running `uv sync`.
- The images install `zlib1g-dev` so transitive native dependencies that compile against `zlib.h` can build when wheels are unavailable.

## Why
- Production Deploy failed in the ML job because `uv sync --frozen --no-dev` tried to build the `ml` project before `src/ml/__init__.py` and `README.md` existed in the Docker build context.

## Validation
- `uv sync --python 3.13 --frozen --no-dev` with the same pre-copy layout used by the Dockerfiles
- `docker build --check -f ml/Dockerfile.cpu .`
- `docker build --check -f ml/Dockerfile.gpu .`
- `git diff --check`
- `git diff --cached --check`

## Notes
- A local CPU image build passed through dependency sync, native `zlib-state` build, source copy, and app user setup; the final image export was stopped after it remained slow locally.