### PR TITLE
fix(infra): allow production services to start

### DIFF
--- a/backend/src/test/java/com/init/shared/infrastructure/LiquibasePgvectorMigrationTest.java
+++ b/backend/src/test/java/com/init/shared/infrastructure/LiquibasePgvectorMigrationTest.java
@@ -23,20 +23,52 @@ class LiquibasePgvectorMigrationTest {
   }
 
   @Test
-  @DisplayName("pgvector extension이 준비된 PostgreSQL에 master changelog를 적용할 수 있다")
-  void should_applyMasterChangelog_when_pgvectorExtensionExists() throws Exception {
+  @DisplayName("운영 app_user 권한으로 master changelog가 앱 스키마를 생성할 수 있다")
+  void should_applyMasterChangelogAndCreateApplicationSchemas_when_appUserHasCreatePrivilege()
+      throws Exception {
+    DriverManagerDataSource adminDataSource = new DriverManagerDataSource();
+    adminDataSource.setUrl(postgres.getJdbcUrl());
+    adminDataSource.setUsername(postgres.getUsername());
+    adminDataSource.setPassword(postgres.getPassword());
+    JdbcTemplate adminJdbcTemplate = new JdbcTemplate(adminDataSource);
+    adminJdbcTemplate.execute("CREATE EXTENSION IF NOT EXISTS vector");
+    adminJdbcTemplate.execute(
+        """
+        DO $$
+        BEGIN
+          IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = 'app_user') THEN
+            CREATE ROLE app_user LOGIN PASSWORD 'app-password';
+          END IF;
+        END
+        $$;
+        """);
+    String databaseName = postgres.getDatabaseName();
+    adminJdbcTemplate.execute("GRANT CONNECT ON DATABASE " + databaseName + " TO app_user");
+    adminJdbcTemplate.execute("GRANT CREATE ON DATABASE " + databaseName + " TO app_user");
+    adminJdbcTemplate.execute("GRANT USAGE, CREATE ON SCHEMA public TO app_user");
+    adminJdbcTemplate.execute(
+        "ALTER ROLE app_user SET search_path TO app, corpus, pack, review, pipeline, runtime, public");
+
     DriverManagerDataSource dataSource = new DriverManagerDataSource();
     dataSource.setUrl(postgres.getJdbcUrl());
-    dataSource.setUsername(postgres.getUsername());
-    dataSource.setPassword(postgres.getPassword());
+    dataSource.setUsername("app_user");
+    dataSource.setPassword("app-password");
     JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-    jdbcTemplate.execute("CREATE EXTENSION IF NOT EXISTS vector");
 
     SpringLiquibase liquibase = new SpringLiquibase();
     liquibase.setDataSource(dataSource);
     liquibase.setChangeLog("classpath:db/changelog/db.changelog-master.sql");
     liquibase.afterPropertiesSet();
 
+    Integer changelogCount =
+        jdbcTemplate.queryForObject(
+            """
+            SELECT COUNT(*)
+            FROM information_schema.tables
+            WHERE table_schema = 'public'
+              AND table_name = 'databasechangelog'
+            """,
+            Integer.class);
     Integer count =
         jdbcTemplate.queryForObject(
             """
@@ -47,6 +79,7 @@ class LiquibasePgvectorMigrationTest {
             """,
             Integer.class);
 
+    assertThat(changelogCount).isEqualTo(1);
     assertThat(count).isEqualTo(1);
   }
 }

--- a/infra/terraform/alb.tf
+++ b/infra/terraform/alb.tf
@@ -70,40 +70,18 @@ resource "aws_lb_listener" "backend_https" {
   }
 }
 
-resource "aws_lb_listener_rule" "airflow_admin" {
+moved {
+  from = aws_lb_listener_rule.airflow_admin
+  to   = aws_lb_listener_rule.airflow
+}
+
+resource "aws_lb_listener_rule" "airflow" {
   listener_arn = aws_lb_listener.backend_https.arn
   priority     = 10
 
   action {
     type             = "forward"
     target_group_arn = aws_lb_target_group.airflow_api.arn
-  }
-
-  condition {
-    host_header {
-      values = ["airflow.${var.domain_name}"]
-    }
-  }
-
-  condition {
-    source_ip {
-      values = [var.admin_cidr]
-    }
-  }
-}
-
-resource "aws_lb_listener_rule" "airflow_forbidden" {
-  listener_arn = aws_lb_listener.backend_https.arn
-  priority     = 11
-
-  action {
-    type = "fixed-response"
-
-    fixed_response {
-      content_type = "text/plain"
-      message_body = "Forbidden"
-      status_code  = "403"
-    }
   }
 
   condition {

--- a/infra/terraform/ecs-airflow.tf
+++ b/infra/terraform/ecs-airflow.tf
@@ -394,7 +394,7 @@ resource "aws_ecs_service" "airflow_apiserver" {
   }
 
   depends_on = [
-    aws_lb_listener_rule.airflow_admin,
+    aws_lb_listener_rule.airflow,
     terraform_data.db_bootstrap
   ]
 

--- a/infra/terraform/scripts/init.sql
+++ b/infra/terraform/scripts/init.sql
@@ -15,33 +15,19 @@ ALTER ROLE airflow_user WITH LOGIN PASSWORD :'airflow_db_password';
 
 CREATE EXTENSION IF NOT EXISTS vector;
 
-CREATE SCHEMA IF NOT EXISTS app AUTHORIZATION app_user;
-CREATE SCHEMA IF NOT EXISTS corpus AUTHORIZATION app_user;
-CREATE SCHEMA IF NOT EXISTS pack AUTHORIZATION app_user;
-CREATE SCHEMA IF NOT EXISTS review AUTHORIZATION app_user;
-CREATE SCHEMA IF NOT EXISTS pipeline AUTHORIZATION app_user;
-CREATE SCHEMA IF NOT EXISTS runtime AUTHORIZATION app_user;
 CREATE SCHEMA IF NOT EXISTS airflow AUTHORIZATION airflow_user;
 
-ALTER SCHEMA app OWNER TO app_user;
-ALTER SCHEMA corpus OWNER TO app_user;
-ALTER SCHEMA pack OWNER TO app_user;
-ALTER SCHEMA review OWNER TO app_user;
-ALTER SCHEMA pipeline OWNER TO app_user;
-ALTER SCHEMA runtime OWNER TO app_user;
 ALTER SCHEMA airflow OWNER TO airflow_user;
 
 ALTER ROLE app_user SET search_path TO app, corpus, pack, review, pipeline, runtime, public;
 ALTER ROLE airflow_user SET search_path TO airflow, public;
 
-REVOKE CREATE ON DATABASE :"db_name" FROM app_user;
 GRANT CONNECT ON DATABASE :"db_name" TO app_user;
+GRANT CREATE ON DATABASE :"db_name" TO app_user;
 GRANT CONNECT ON DATABASE :"db_name" TO airflow_user;
 
-GRANT USAGE, CREATE ON SCHEMA app, corpus, pack, review, pipeline, runtime TO app_user;
+GRANT USAGE, CREATE ON SCHEMA public TO app_user;
 GRANT USAGE, CREATE ON SCHEMA airflow TO airflow_user;
 
-ALTER DEFAULT PRIVILEGES FOR ROLE app_user IN SCHEMA app, corpus, pack, review, pipeline, runtime GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO app_user;
-ALTER DEFAULT PRIVILEGES FOR ROLE app_user IN SCHEMA app, corpus, pack, review, pipeline, runtime GRANT USAGE, SELECT, UPDATE ON SEQUENCES TO app_user;
 ALTER DEFAULT PRIVILEGES FOR ROLE airflow_user IN SCHEMA airflow GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO airflow_user;
 ALTER DEFAULT PRIVILEGES FOR ROLE airflow_user IN SCHEMA airflow GRANT USAGE, SELECT, UPDATE ON SEQUENCES TO airflow_user;


### PR DESCRIPTION
## Summary
- Production DB bootstrap now leaves application schemas to Liquibase and grants `app_user` the database/schema create privileges required for first startup.
- Airflow public host routing now forwards to Airflow directly instead of applying an ALB source-IP allowlist before Airflow authentication.
- The Liquibase pgvector migration test now exercises the production `app_user` privilege model where Liquibase creates the application schemas.

## Why
- Backend ECS tasks were exiting during startup because Liquibase could not create `public.databasechangelog` with the existing production DB privileges.
- `airflow.ajou-cstone.com` returned ALB-level 403 responses when the caller IP did not match the deployed admin CIDR, even though Airflow has its own login flow.

## Validation
- `terraform -chdir=infra/terraform fmt -check -diff`
- `git diff --check`
- `mise exec -- ./gradlew test --tests com.init.shared.infrastructure.LiquibasePgvectorMigrationTest`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Airflow 접근 정책이 호스트 헤더(airflow.{domain}) 기준으로 적용되도록 변경되어 더 간편한 접근 제어가 가능합니다.
  * 데이터베이스 권한 구조가 재구성되어 애플리케이션 사용자의 데이터베이스 생성 권한 및 접속 권한이 조정되었습니다.

* **Tests**
  * 마스터 changelog 적용과 애플리케이션 스키마 생성 권한 시나리오를 검증하는 테스트가 추가/갱신되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->