### PR TITLE
feat(domain-pack): 초안 수정버전 적용 시 변경사항 정리 저장

### DIFF
--- a/backend/src/main/java/com/init/domainpack/application/ActivateDomainPackVersionCommand.java
+++ b/backend/src/main/java/com/init/domainpack/application/ActivateDomainPackVersionCommand.java
@@ -1,4 +1,10 @@
 package com.init.domainpack.application;
 
 public record ActivateDomainPackVersionCommand(
-    Long workspaceId, Long packId, Long versionId, Long userId) {}
+    Long workspaceId, Long packId, Long versionId, Long userId, String description) {
+
+  public ActivateDomainPackVersionCommand(
+      Long workspaceId, Long packId, Long versionId, Long userId) {
+    this(workspaceId, packId, versionId, userId, null);
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/application/ActivateDomainPackVersionResult.java
+++ b/backend/src/main/java/com/init/domainpack/application/ActivateDomainPackVersionResult.java
@@ -8,6 +8,7 @@ public record ActivateDomainPackVersionResult(
     Long domainPackId,
     Integer versionNo,
     String lifecycleStatus,
+    String description,
     OffsetDateTime publishedAt,
     OffsetDateTime updatedAt) {
 
@@ -17,6 +18,7 @@ public record ActivateDomainPackVersionResult(
         version.getDomainPackId(),
         version.getVersionNo(),
         version.getLifecycleStatus(),
+        version.getDescription(),
         version.getPublishedAt(),
         version.getUpdatedAt());
   }

--- a/backend/src/main/java/com/init/domainpack/application/ActivateDomainPackVersionUseCase.java
+++ b/backend/src/main/java/com/init/domainpack/application/ActivateDomainPackVersionUseCase.java
@@ -98,7 +98,7 @@ public class ActivateDomainPackVersionUseCase {
     }
 
     try {
-      version.activate(OffsetDateTime.now(clock));
+      version.activate(OffsetDateTime.now(clock), normalizeOptionalText(command.description()));
     } catch (IllegalStateException e) {
       throw new DomainPackVersionInvalidStateException(e.getMessage());
     }
@@ -113,5 +113,13 @@ public class ActivateDomainPackVersionUseCase {
     } catch (ObjectOptimisticLockingFailureException e) {
       throw new DomainPackVersionConflictException(command.versionId());
     }
+  }
+
+  private static String normalizeOptionalText(String value) {
+    if (value == null) {
+      return null;
+    }
+    String trimmed = value.trim();
+    return trimmed.isEmpty() ? null : trimmed;
   }
 }

--- a/backend/src/main/java/com/init/domainpack/application/ActivateDomainPackVersionUseCase.java
+++ b/backend/src/main/java/com/init/domainpack/application/ActivateDomainPackVersionUseCase.java
@@ -98,7 +98,7 @@ public class ActivateDomainPackVersionUseCase {
     }
 
     try {
-      version.activate(OffsetDateTime.now(clock), normalizeOptionalText(command.description()));
+      version.activate(OffsetDateTime.now(clock), normalizeDescription(command.description()));
     } catch (IllegalStateException e) {
       throw new DomainPackVersionInvalidStateException(e.getMessage());
     }
@@ -115,11 +115,10 @@ public class ActivateDomainPackVersionUseCase {
     }
   }
 
-  private static String normalizeOptionalText(String value) {
+  private static String normalizeDescription(String value) {
     if (value == null) {
       return null;
     }
-    String trimmed = value.trim();
-    return trimmed.isEmpty() ? null : trimmed;
+    return value.trim();
   }
 }

--- a/backend/src/main/java/com/init/domainpack/domain/model/DomainPackVersion.java
+++ b/backend/src/main/java/com/init/domainpack/domain/model/DomainPackVersion.java
@@ -124,10 +124,7 @@ public class DomainPackVersion {
     activate(now, null);
   }
 
-  /**
-   * DRAFT 상태의 버전을 PUBLISHED로 전이하고,
-   * 변경사항 정리가 있으면 버전 설명에 반영한다.
-   */
+  /** DRAFT 상태의 버전을 PUBLISHED로 전이하고, 변경사항 정리가 있으면 버전 설명에 반영한다. */
   public void activate(OffsetDateTime now, String description) {
     Objects.requireNonNull(now, "publishedAt (now) must not be null");
     if (!STATUS_DRAFT.equals(this.lifecycleStatus)) {

--- a/backend/src/main/java/com/init/domainpack/domain/model/DomainPackVersion.java
+++ b/backend/src/main/java/com/init/domainpack/domain/model/DomainPackVersion.java
@@ -121,9 +121,20 @@ public class DomainPackVersion {
 
   /** DRAFT 상태의 버전을 PUBLISHED로 전이한다. */
   public void activate(OffsetDateTime now) {
+    activate(now, null);
+  }
+
+  /**
+   * DRAFT 상태의 버전을 PUBLISHED로 전이하고,
+   * 변경사항 정리가 있으면 버전 설명에 반영한다.
+   */
+  public void activate(OffsetDateTime now, String description) {
     Objects.requireNonNull(now, "publishedAt (now) must not be null");
     if (!STATUS_DRAFT.equals(this.lifecycleStatus)) {
       throw new IllegalStateException("DRAFT 상태의 version에서만 수행할 수 있습니다.");
+    }
+    if (description != null) {
+      this.description = normalizeDescription(description);
     }
     this.lifecycleStatus = STATUS_PUBLISHED;
     this.publishedAt = now;
@@ -182,5 +193,10 @@ public class DomainPackVersion {
 
   public OffsetDateTime getUpdatedAt() {
     return updatedAt;
+  }
+
+  private static String normalizeDescription(String description) {
+    String trimmed = description.trim();
+    return trimmed.isEmpty() ? null : trimmed;
   }
 }

--- a/backend/src/main/java/com/init/domainpack/presentation/ActivateDomainPackVersionController.java
+++ b/backend/src/main/java/com/init/domainpack/presentation/ActivateDomainPackVersionController.java
@@ -3,12 +3,15 @@ package com.init.domainpack.presentation;
 import com.init.domainpack.application.ActivateDomainPackVersionCommand;
 import com.init.domainpack.application.ActivateDomainPackVersionResult;
 import com.init.domainpack.application.ActivateDomainPackVersionUseCase;
+import com.init.domainpack.presentation.dto.ActivateDomainPackVersionRequest;
 import com.init.domainpack.presentation.dto.DomainPackVersionActivateResponse;
 import com.init.shared.presentation.AuthenticationUtils;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -27,10 +30,12 @@ public class ActivateDomainPackVersionController {
       @PathVariable Long workspaceId,
       @PathVariable Long packId,
       @PathVariable Long versionId,
+      @Valid @RequestBody(required = false) ActivateDomainPackVersionRequest request,
       Authentication authentication) {
     Long userId = AuthenticationUtils.getUserId(authentication);
+    String description = request == null ? null : request.description();
     ActivateDomainPackVersionCommand command =
-        new ActivateDomainPackVersionCommand(workspaceId, packId, versionId, userId);
+        new ActivateDomainPackVersionCommand(workspaceId, packId, versionId, userId, description);
     ActivateDomainPackVersionResult result = useCase.execute(command);
     return ResponseEntity.ok(
         new DomainPackVersionActivateResponse(
@@ -38,6 +43,7 @@ public class ActivateDomainPackVersionController {
             result.domainPackId(),
             result.versionNo(),
             result.lifecycleStatus(),
+            result.description(),
             result.publishedAt(),
             result.updatedAt()));
   }

--- a/backend/src/main/java/com/init/domainpack/presentation/dto/ActivateDomainPackVersionRequest.java
+++ b/backend/src/main/java/com/init/domainpack/presentation/dto/ActivateDomainPackVersionRequest.java
@@ -1,0 +1,6 @@
+package com.init.domainpack.presentation.dto;
+
+import jakarta.validation.constraints.Size;
+
+public record ActivateDomainPackVersionRequest(
+    @Size(max = 50, message = "description은 50자 이하여야 합니다.") String description) {}

--- a/backend/src/main/java/com/init/domainpack/presentation/dto/DomainPackVersionActivateResponse.java
+++ b/backend/src/main/java/com/init/domainpack/presentation/dto/DomainPackVersionActivateResponse.java
@@ -7,5 +7,6 @@ public record DomainPackVersionActivateResponse(
     Long domainPackId,
     Integer versionNo,
     String lifecycleStatus,
+    String description,
     OffsetDateTime publishedAt,
     OffsetDateTime updatedAt) {}

--- a/backend/src/test/java/com/init/domainpack/application/ActivateDomainPackVersionUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/ActivateDomainPackVersionUseCaseTest.java
@@ -95,6 +95,32 @@ class ActivateDomainPackVersionUseCaseTest {
   }
 
   @Test
+  @DisplayName("정상 활성화: 변경사항 정리를 버전 description에 반영한다")
+  void should_description반영_when_변경사항정리있음() {
+    given(workspaceExistencePort.existsById(1L)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    givenPackLock();
+
+    DomainPackVersion version = createDraftVersion(42L, 7L);
+    given(versionRepository.findByIdAndWorkspaceId(1L, 42L)).willReturn(Optional.of(version));
+    given(versionRepository.findMaxVersionNoByDomainPackId(7L)).willReturn(Optional.of(1));
+    given(
+            intentDefinitionRepository.countByDomainPackVersionIdAndStatus(
+                42L, IntentDefinition.STATUS_DRAFT))
+        .willReturn(0L);
+    given(versionRepository.saveAndFlush(any()))
+        .willAnswer(invocation -> invocation.getArgument(0));
+
+    ActivateDomainPackVersionCommand command =
+        new ActivateDomainPackVersionCommand(
+            1L, 7L, 42L, 10L, "  상담 유형명을 정리했습니다.  ");
+
+    useCase.execute(command);
+
+    assertThat(version.getDescription()).isEqualTo("상담 유형명을 정리했습니다.");
+  }
+
+  @Test
   @DisplayName("workspace 없음 → DomainPackWorkspaceNotFoundException")
   void should_워크스페이스없음예외발생_when_워크스페이스없음() {
     given(workspaceExistencePort.existsById(1L)).willReturn(false);

--- a/backend/src/test/java/com/init/domainpack/application/ActivateDomainPackVersionUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/ActivateDomainPackVersionUseCaseTest.java
@@ -112,8 +112,7 @@ class ActivateDomainPackVersionUseCaseTest {
         .willAnswer(invocation -> invocation.getArgument(0));
 
     ActivateDomainPackVersionCommand command =
-        new ActivateDomainPackVersionCommand(
-            1L, 7L, 42L, 10L, "  상담 유형명을 정리했습니다.  ");
+        new ActivateDomainPackVersionCommand(1L, 7L, 42L, 10L, "  상담 유형명을 정리했습니다.  ");
 
     useCase.execute(command);
 

--- a/backend/src/test/java/com/init/domainpack/application/ActivateDomainPackVersionUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/ActivateDomainPackVersionUseCaseTest.java
@@ -121,6 +121,32 @@ class ActivateDomainPackVersionUseCaseTest {
   }
 
   @Test
+  @DisplayName("정상 활성화: 빈 변경사항 정리는 기존 description을 제거한다")
+  void should_description제거_when_변경사항정리비어있음() {
+    given(workspaceExistencePort.existsById(1L)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(any(), any(), any())).willReturn(true);
+    givenPackLock();
+
+    DomainPackVersion version = createDraftVersion(42L, 7L);
+    ReflectionTestUtils.setField(version, "description", "기존 수정 메모");
+    given(versionRepository.findByIdAndWorkspaceId(1L, 42L)).willReturn(Optional.of(version));
+    given(versionRepository.findMaxVersionNoByDomainPackId(7L)).willReturn(Optional.of(1));
+    given(
+            intentDefinitionRepository.countByDomainPackVersionIdAndStatus(
+                42L, IntentDefinition.STATUS_DRAFT))
+        .willReturn(0L);
+    given(versionRepository.saveAndFlush(any()))
+        .willAnswer(invocation -> invocation.getArgument(0));
+
+    ActivateDomainPackVersionCommand command =
+        new ActivateDomainPackVersionCommand(1L, 7L, 42L, 10L, "   ");
+
+    useCase.execute(command);
+
+    assertThat(version.getDescription()).isNull();
+  }
+
+  @Test
   @DisplayName("workspace 없음 → DomainPackWorkspaceNotFoundException")
   void should_워크스페이스없음예외발생_when_워크스페이스없음() {
     given(workspaceExistencePort.existsById(1L)).willReturn(false);

--- a/backend/src/test/java/com/init/domainpack/application/ActivateDomainPackVersionUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/ActivateDomainPackVersionUseCaseTest.java
@@ -114,9 +114,10 @@ class ActivateDomainPackVersionUseCaseTest {
     ActivateDomainPackVersionCommand command =
         new ActivateDomainPackVersionCommand(1L, 7L, 42L, 10L, "  상담 유형명을 정리했습니다.  ");
 
-    useCase.execute(command);
+    ActivateDomainPackVersionResult result = useCase.execute(command);
 
     assertThat(version.getDescription()).isEqualTo("상담 유형명을 정리했습니다.");
+    assertThat(result.description()).isEqualTo("상담 유형명을 정리했습니다.");
   }
 
   @Test

--- a/backend/src/test/java/com/init/domainpack/domain/model/DomainPackVersionTest.java
+++ b/backend/src/test/java/com/init/domainpack/domain/model/DomainPackVersionTest.java
@@ -13,8 +13,7 @@ class DomainPackVersionTest {
   @Test
   @DisplayName("activate(now)는 기존 description을 유지한다")
   void should_description유지_when_description없는activate호출() {
-    DomainPackVersion version =
-        DomainPackVersion.createDraft(7L, 1, 10L, null, "{}", "기존 변경사항 정리");
+    DomainPackVersion version = DomainPackVersion.createDraft(7L, 1, 10L, null, "{}", "기존 변경사항 정리");
     OffsetDateTime now = OffsetDateTime.parse("2026-04-09T12:00:00Z");
 
     version.activate(now);
@@ -38,8 +37,7 @@ class DomainPackVersionTest {
   @Test
   @DisplayName("activate(now, description)는 빈 description을 null로 정규화한다")
   void should_descriptionNull_when_description공백() {
-    DomainPackVersion version =
-        DomainPackVersion.createDraft(7L, 1, 10L, null, "{}", "기존 변경사항 정리");
+    DomainPackVersion version = DomainPackVersion.createDraft(7L, 1, 10L, null, "{}", "기존 변경사항 정리");
 
     version.activate(OffsetDateTime.parse("2026-04-09T12:00:00Z"), "   ");
 

--- a/backend/src/test/java/com/init/domainpack/domain/model/DomainPackVersionTest.java
+++ b/backend/src/test/java/com/init/domainpack/domain/model/DomainPackVersionTest.java
@@ -6,47 +6,54 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.time.OffsetDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.test.util.ReflectionTestUtils;
 
 @DisplayName("DomainPackVersion")
 class DomainPackVersionTest {
 
   @Test
-  @DisplayName("activate: PUBLISHED 아닌 상태에서 호출 시 lifecycleStatus가 PUBLISHED로 변경된다")
-  void should_PUBLISHED반환_when_비PUBLISHED상태() {
-    DomainPackVersion version = createDraftVersion();
+  @DisplayName("activate(now)는 기존 description을 유지한다")
+  void should_description유지_when_description없는activate호출() {
+    DomainPackVersion version =
+        DomainPackVersion.createDraft(7L, 1, 10L, null, "{}", "기존 변경사항 정리");
     OffsetDateTime now = OffsetDateTime.parse("2026-04-09T12:00:00Z");
 
     version.activate(now);
 
-    assertThat(version.getLifecycleStatus()).isEqualTo("PUBLISHED");
+    assertThat(version.getLifecycleStatus()).isEqualTo(DomainPackVersion.STATUS_PUBLISHED);
+    assertThat(version.getDescription()).isEqualTo("기존 변경사항 정리");
     assertThat(version.getPublishedAt()).isEqualTo(now);
     assertThat(version.getUpdatedAt()).isEqualTo(now);
   }
 
   @Test
+  @DisplayName("activate(now, description)는 description을 trim한다")
+  void should_descriptionTrim_when_description있음() {
+    DomainPackVersion version = DomainPackVersion.createDraft(7L, 1, 10L, null, "{}", null);
+
+    version.activate(OffsetDateTime.parse("2026-04-09T12:00:00Z"), "  변경사항 정리  ");
+
+    assertThat(version.getDescription()).isEqualTo("변경사항 정리");
+  }
+
+  @Test
+  @DisplayName("activate(now, description)는 빈 description을 null로 정규화한다")
+  void should_descriptionNull_when_description공백() {
+    DomainPackVersion version =
+        DomainPackVersion.createDraft(7L, 1, 10L, null, "{}", "기존 변경사항 정리");
+
+    version.activate(OffsetDateTime.parse("2026-04-09T12:00:00Z"), "   ");
+
+    assertThat(version.getDescription()).isNull();
+  }
+
+  @Test
   @DisplayName("activate: DRAFT가 아닌 상태에서 호출 시 IllegalStateException 발생")
   void should_예외발생_when_DRAFT아님() {
-    DomainPackVersion version = createPublishedVersion();
+    DomainPackVersion version = DomainPackVersion.createDraft(7L, 1, 10L, null, "{}", null);
+    version.activate(OffsetDateTime.parse("2026-04-09T12:00:00Z"));
 
-    assertThatThrownBy(() -> version.activate(OffsetDateTime.now()))
+    assertThatThrownBy(() -> version.activate(OffsetDateTime.parse("2026-04-09T12:01:00Z")))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("DRAFT 상태");
-  }
-
-  // ── factories ──────────────────────────────────────────────────────────────
-
-  private DomainPackVersion createDraftVersion() {
-    DomainPackVersion version = new DomainPackVersion();
-    ReflectionTestUtils.setField(version, "lifecycleStatus", "DRAFT");
-    ReflectionTestUtils.setField(version, "updatedAt", OffsetDateTime.now());
-    return version;
-  }
-
-  private DomainPackVersion createPublishedVersion() {
-    DomainPackVersion version = new DomainPackVersion();
-    ReflectionTestUtils.setField(version, "lifecycleStatus", "PUBLISHED");
-    ReflectionTestUtils.setField(version, "updatedAt", OffsetDateTime.now());
-    return version;
   }
 }

--- a/backend/src/test/java/com/init/domainpack/presentation/ActivateDomainPackVersionControllerTest.java
+++ b/backend/src/test/java/com/init/domainpack/presentation/ActivateDomainPackVersionControllerTest.java
@@ -110,6 +110,49 @@ class ActivateDomainPackVersionControllerTest {
   }
 
   @Test
+  @DisplayName("요청 body가 없으면 command description은 null이다")
+  @WithLongPrincipal(10L)
+  void should_commandDescriptionNull_when_요청Body없음() throws Exception {
+    ActivateDomainPackVersionResult result =
+        new ActivateDomainPackVersionResult(
+            42L,
+            7L,
+            3,
+            "PUBLISHED",
+            null,
+            OffsetDateTime.parse("2026-04-09T12:00:00Z"),
+            OffsetDateTime.parse("2026-04-09T12:00:00Z"));
+    given(useCase.execute(any())).willReturn(result);
+
+    mockMvc.perform(post(BASE_URL).with(csrf())).andExpect(status().isOk());
+
+    verify(useCase)
+        .execute(
+            argThat(
+                command ->
+                    command.workspaceId().equals(1L)
+                        && command.packId().equals(7L)
+                        && command.versionId().equals(42L)
+                        && command.userId().equals(10L)
+                        && command.description() == null));
+  }
+
+  @Test
+  @DisplayName("변경사항 정리가 50자를 초과하면 400")
+  @WithLongPrincipal(10L)
+  void should_400반환_when_변경사항정리50자초과() throws Exception {
+    String longDescription = "가".repeat(51);
+
+    mockMvc
+        .perform(
+            post(BASE_URL)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"description\":\"" + longDescription + "\"}")
+                .with(csrf()))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
   @DisplayName("존재하지 않는 versionId → 404 DOMAIN_PACK_VERSION_NOT_FOUND")
   @WithLongPrincipal(10L)
   void should_404반환_when_존재하지않는버전() throws Exception {

--- a/backend/src/test/java/com/init/domainpack/presentation/ActivateDomainPackVersionControllerTest.java
+++ b/backend/src/test/java/com/init/domainpack/presentation/ActivateDomainPackVersionControllerTest.java
@@ -1,7 +1,9 @@
 package com.init.domainpack.presentation;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -23,6 +25,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -57,6 +60,7 @@ class ActivateDomainPackVersionControllerTest {
             7L,
             3,
             "PUBLISHED",
+            null,
             OffsetDateTime.parse("2026-04-09T12:00:00Z"),
             OffsetDateTime.parse("2026-04-09T12:00:00Z"));
     given(useCase.execute(any())).willReturn(result);
@@ -68,6 +72,42 @@ class ActivateDomainPackVersionControllerTest {
         .andExpect(jsonPath("$.publishedAt").isNotEmpty())
         .andExpect(jsonPath("$.id").value(42))
         .andExpect(jsonPath("$.domainPackId").value(7));
+  }
+
+  @Test
+  @DisplayName("변경사항 정리가 있으면 command description으로 전달한다")
+  @WithLongPrincipal(10L)
+  void should_commandDescription전달_when_변경사항정리있음() throws Exception {
+    ActivateDomainPackVersionResult result =
+        new ActivateDomainPackVersionResult(
+            42L,
+            7L,
+            3,
+            "PUBLISHED",
+            "상담 유형명을 정리했습니다.",
+            OffsetDateTime.parse("2026-04-09T12:00:00Z"),
+            OffsetDateTime.parse("2026-04-09T12:00:00Z"));
+    given(useCase.execute(any())).willReturn(result);
+
+    mockMvc
+        .perform(
+            post(BASE_URL)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"description\":\"상담 유형명을 정리했습니다.\"}")
+                .with(csrf()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.description").value("상담 유형명을 정리했습니다."));
+
+    verify(useCase)
+        .execute(
+            argThat(
+                command ->
+                    command.workspaceId().equals(1L)
+                        && command.packId().equals(7L)
+                        && command.versionId().equals(42L)
+                        && command.userId().equals(10L)
+                        && "상담 유형명을 정리했습니다."
+                            .equals(command.description())));
   }
 
   @Test

--- a/backend/src/test/java/com/init/domainpack/presentation/ActivateDomainPackVersionControllerTest.java
+++ b/backend/src/test/java/com/init/domainpack/presentation/ActivateDomainPackVersionControllerTest.java
@@ -106,8 +106,7 @@ class ActivateDomainPackVersionControllerTest {
                         && command.packId().equals(7L)
                         && command.versionId().equals(42L)
                         && command.userId().equals(10L)
-                        && "상담 유형명을 정리했습니다."
-                            .equals(command.description())));
+                        && "상담 유형명을 정리했습니다.".equals(command.description())));
   }
 
   @Test

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.module.css
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.module.css
@@ -429,6 +429,49 @@
   color: var(--text-secondary);
 }
 
+.applyMessageField {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.applyMessageLabel {
+  font-size: 12px;
+  font-weight: var(--font-weight-heading);
+  color: var(--text-secondary);
+}
+
+.applyMessageInput {
+  min-height: 82px;
+  resize: vertical;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-lg);
+  padding: 10px 12px;
+  background: var(--bg-color);
+  color: var(--text-primary);
+  font: inherit;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.applyMessageInput:focus {
+  outline: none;
+  border-color: var(--text-primary);
+  box-shadow: 0 0 0 3px rgb(0 0 0 / 8%);
+}
+
+.applyMessageInput:disabled {
+  cursor: not-allowed;
+  color: var(--text-muted);
+}
+
+.applyMessageCount {
+  align-self: flex-end;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-muted);
+}
+
 .approvalDialogFooter {
   display: grid;
   grid-template-columns: 1fr 1fr;

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.test.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.test.tsx
@@ -398,12 +398,15 @@ describe("SummaryDetailPanel", () => {
     );
 
     fireEvent.click(screen.getByRole("button", { name: "적용" }));
+    fireEvent.change(screen.getByLabelText("변경사항 정리"), {
+      target: { value: " 상담 유형명을 정리했습니다. " },
+    });
     fireEvent.click(screen.getByRole("button", { name: "적용하기" }));
 
-    expect(onApplyDraft).toHaveBeenCalledWith(3);
+    expect(onApplyDraft).toHaveBeenCalledWith(3, "상담 유형명을 정리했습니다.");
   });
 
-  it("Draft 적용 확인 다이얼로그에 대상 draft 버전과 운영 전환 정보를 표시한다", () => {
+  it("Draft 적용 확인 다이얼로그에 대상 draft 버전과 수정 반영 정보를 표시한다", () => {
     renderSummaryDetailPanel(
       <SummaryDetailPanel
         query={makeQuery({
@@ -426,8 +429,29 @@ describe("SummaryDetailPanel", () => {
 
     const context = screen.getByLabelText("대상 버전 정보");
     expect(context).toHaveTextContent("대상 버전v3검토 중");
-    expect(context).toHaveTextContent("운영 전환현재 v2 → v3");
+    expect(context).toHaveTextContent("수정 반영현재 v2 → v3");
     expect(context).toHaveTextContent("변경 요약상담 유형 이름을 정리했습니다.");
+    expect(screen.getByLabelText("변경사항 정리")).toHaveValue("");
+  });
+
+  it("Draft 변경사항 정리는 기존 description을 기본값으로 표시한다", () => {
+    renderSummaryDetailPanel(
+      <SummaryDetailPanel
+        query={makeQuery({
+          data: {
+            ...stubDetail,
+            description: "기존 수정 메모",
+          },
+        })}
+        wsId={1}
+        packId={2}
+        onApplyDraft={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "적용" }));
+
+    expect(screen.getByLabelText("변경사항 정리")).toHaveValue("기존 수정 메모");
   });
 
   it("Draft 삭제 확인 시 현재 versionId를 전달한다", () => {

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.test.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { QueryClient, QueryClientProvider, type UseQueryResult } from "@tanstack/react-query";
 import type { DomainPackVersionDetail } from "@/entities/domain-pack";
@@ -295,6 +295,42 @@ describe("SummaryDetailPanel", () => {
     expect(onDeploy).toHaveBeenCalledWith(3);
   });
 
+  it("배포 확인 다이얼로그는 취소 버튼으로 닫는다", async () => {
+    renderSummaryDetailPanel(
+      <SummaryDetailPanel
+        query={makeQuery({ data: publishedDetail })}
+        wsId={1}
+        packId={2}
+        onDeploy={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "배포" }));
+    fireEvent.click(screen.getByRole("button", { name: "취소" }));
+
+    await waitFor(() =>
+      expect(screen.queryByText("v2 버전을 배포할까요?")).not.toBeInTheDocument(),
+    );
+  });
+
+  it("배포 확인 다이얼로그는 외부 닫기 이벤트를 반영한다", async () => {
+    renderSummaryDetailPanel(
+      <SummaryDetailPanel
+        query={makeQuery({ data: publishedDetail })}
+        wsId={1}
+        packId={2}
+        onDeploy={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "배포" }));
+    fireEvent.keyDown(screen.getByRole("alertdialog"), { key: "Escape", code: "Escape" });
+
+    await waitFor(() =>
+      expect(screen.queryByText("v2 버전을 배포할까요?")).not.toBeInTheDocument(),
+    );
+  });
+
   it("현재 운영 버전이면 상세 메타 카드의 배포 버튼을 배포중 상태로 비활성화한다", () => {
     renderSummaryDetailPanel(
       <SummaryDetailPanel
@@ -478,6 +514,58 @@ describe("SummaryDetailPanel", () => {
     fireEvent.click(screen.getByRole("button", { name: "적용" }));
 
     expect(screen.getByLabelText("변경사항 정리")).toHaveValue("기존 수정 메모");
+  });
+
+  it("Draft 적용 다이얼로그는 외부 닫기 후 다시 열 때 기존 description으로 초기화한다", async () => {
+    renderSummaryDetailPanel(
+      <SummaryDetailPanel
+        query={makeQuery({
+          data: {
+            ...stubDetail,
+            description: "기존 수정 메모",
+          },
+        })}
+        wsId={1}
+        packId={2}
+        onApplyDraft={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "적용" }));
+    fireEvent.change(screen.getByLabelText("변경사항 정리"), {
+      target: { value: "임시 수정 메모" },
+    });
+    fireEvent.keyDown(screen.getByRole("alertdialog"), { key: "Escape", code: "Escape" });
+
+    await waitFor(() =>
+      expect(screen.queryByText("검토 중인 v1 수정버전을 적용할까요?")).not.toBeInTheDocument(),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "적용" }));
+
+    expect(screen.getByLabelText("변경사항 정리")).toHaveValue("기존 수정 메모");
+  });
+
+  it("Draft 적용 중에는 외부 닫기 이벤트를 무시한다", () => {
+    const queryClient = new QueryClient();
+    const renderPanel = (applyingVersionId?: number) => (
+      <QueryClientProvider client={queryClient}>
+        <SummaryDetailPanel
+          query={makeQuery({ data: stubDetail })}
+          wsId={1}
+          packId={2}
+          applyingVersionId={applyingVersionId}
+          onApplyDraft={vi.fn()}
+        />
+      </QueryClientProvider>
+    );
+    const { rerender } = render(renderPanel());
+
+    fireEvent.click(screen.getByRole("button", { name: "적용" }));
+    rerender(renderPanel(3));
+    fireEvent.keyDown(screen.getByRole("alertdialog"), { key: "Escape", code: "Escape" });
+
+    expect(screen.getByText("검토 중인 v1 수정버전을 적용할까요?")).toBeInTheDocument();
   });
 
   it("Draft 삭제 확인 시 현재 versionId를 전달한다", () => {

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.test.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.test.tsx
@@ -406,6 +406,32 @@ describe("SummaryDetailPanel", () => {
     expect(onApplyDraft).toHaveBeenCalledWith(3, "상담 유형명을 정리했습니다.");
   });
 
+  it("Draft 적용 확인 시 빈 변경사항 정리도 전달한다", () => {
+    const onApplyDraft = vi.fn();
+
+    renderSummaryDetailPanel(
+      <SummaryDetailPanel
+        query={makeQuery({
+          data: {
+            ...stubDetail,
+            description: "기존 수정 메모",
+          },
+        })}
+        wsId={1}
+        packId={2}
+        onApplyDraft={onApplyDraft}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "적용" }));
+    fireEvent.change(screen.getByLabelText("변경사항 정리"), {
+      target: { value: "   " },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "적용하기" }));
+
+    expect(onApplyDraft).toHaveBeenCalledWith(3, "");
+  });
+
   it("Draft 적용 확인 다이얼로그에 대상 draft 버전과 수정 반영 정보를 표시한다", () => {
     renderSummaryDetailPanel(
       <SummaryDetailPanel

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.tsx
@@ -77,7 +77,7 @@ export function SummaryDetailPanel({
   };
   const handleConfirmApply = () => {
     if (!canApplyDraft) return;
-    onApplyDraft(versionId, normalizeOptionalText(applyDescription));
+    onApplyDraft(versionId, normalizeDescription(applyDescription));
     setApplyDialogOpen(false);
   };
   const handleConfirmDiscard = () => {
@@ -487,9 +487,8 @@ function readTrimmedString(value: unknown): string | null {
   return trimmed || null;
 }
 
-function normalizeOptionalText(value: string): string | undefined {
-  const trimmed = value.trim();
-  return trimmed || undefined;
+function normalizeDescription(value: string): string {
+  return value.trim();
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.tsx
@@ -27,7 +27,7 @@ interface SummaryDetailPanelProps {
   applyingVersionId?: number | null;
   discardingVersionId?: number | null;
   onDeploy?: (versionId: number) => void;
-  onApplyDraft?: (versionId: number) => void;
+  onApplyDraft?: (versionId: number, description?: string) => void;
   onDiscardDraft?: (versionId: number) => void;
 }
 
@@ -47,6 +47,7 @@ export function SummaryDetailPanel({
   const [isDeployDialogOpen, setDeployDialogOpen] = useState(false);
   const [isApplyDialogOpen, setApplyDialogOpen] = useState(false);
   const [isDiscardDialogOpen, setDiscardDialogOpen] = useState(false);
+  const [applyDescription, setApplyDescription] = useState("");
   const v = query.data;
   const versionId = v?.versionId;
   const isCurrentVersion = versionId != null && versionId === currentVersionId;
@@ -76,7 +77,7 @@ export function SummaryDetailPanel({
   };
   const handleConfirmApply = () => {
     if (!canApplyDraft) return;
-    onApplyDraft(versionId);
+    onApplyDraft(versionId, normalizeOptionalText(applyDescription));
     setApplyDialogOpen(false);
   };
   const handleConfirmDiscard = () => {
@@ -161,7 +162,10 @@ export function SummaryDetailPanel({
                   className={styles.deployButton}
                   disabled={!canApplyDraft}
                   onClick={() => {
-                    if (canApplyDraft) setApplyDialogOpen(true);
+                    if (canApplyDraft) {
+                      setApplyDescription(v.description ?? "");
+                      setApplyDialogOpen(true);
+                    }
                   }}
                 >
                   {isApplying ? "적용 중..." : "적용"}
@@ -234,20 +238,39 @@ export function SummaryDetailPanel({
       <AlertDialog
         open={isApplyDialogOpen}
         onOpenChange={(next) => {
-          if (!isApplying) setApplyDialogOpen(next);
+          if (isApplying) return;
+          if (next) setApplyDescription(v.description ?? "");
+          setApplyDialogOpen(next);
         }}
       >
         <AlertDialogContent size="sm" className={styles.approvalDialogContent}>
           <AlertDialogTitle className={styles.approvalDialogTitle}>
-            검토 중인 {targetVersionLabel} 버전을 적용할까요?
+            검토 중인 {targetVersionLabel} 수정버전을 적용할까요?
           </AlertDialogTitle>
           <AlertDialogDescription className={styles.approvalDialogDescription}>
-            적용하면 검토 중인 {targetVersionLabel}이 상담 응대에 사용할 운영 버전으로 전환됩니다.
+            적용하면 검토 중인 {targetVersionLabel}의 수정 내용이 도메인 팩에 반영됩니다.
           </AlertDialogDescription>
           <VersionActionContext
             version={v}
             transitionLabel={`${currentVersionLabel} → ${targetVersionLabel}`}
+            scopeLabel="수정 반영"
           />
+          <div className={styles.applyMessageField}>
+            <label htmlFor={`apply-message-${versionId}`} className={styles.applyMessageLabel}>
+              변경사항 정리
+            </label>
+            <textarea
+              id={`apply-message-${versionId}`}
+              className={styles.applyMessageInput}
+              value={applyDescription}
+              maxLength={50}
+              rows={3}
+              disabled={isApplying}
+              placeholder="예: 상담 유형명을 정리하고 확인 항목을 보강했습니다."
+              onChange={(event) => setApplyDescription(event.target.value)}
+            />
+            <span className={styles.applyMessageCount}>{applyDescription.length}/50</span>
+          </div>
           <AlertDialogFooter className={styles.approvalDialogFooter}>
             <Button
               type="button"
@@ -328,6 +351,7 @@ export function SummaryDetailPanel({
 
       <SummaryJsonCard
         summaryJson={v.summaryJson ?? ""}
+        finalMessage={v.description}
         revisionSummary={
           revisionSummaryState.status === "ready" ? revisionSummaryState.data : undefined
         }
@@ -461,6 +485,11 @@ function readTrimmedString(value: unknown): string | null {
   if (typeof value !== "string") return null;
   const trimmed = value.trim();
   return trimmed || null;
+}
+
+function normalizeOptionalText(value: string): string | undefined {
+  const trimmed = value.trim();
+  return trimmed || undefined;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryJsonCard.module.css
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryJsonCard.module.css
@@ -113,6 +113,18 @@
   color: var(--text-primary);
 }
 
+.finalMessage {
+  margin: 0;
+  padding: 10px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-md);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  font-size: var(--font-size-sm);
+  line-height: 1.55;
+  overflow-wrap: anywhere;
+}
+
 .metricGrid {
   display: grid;
   gap: 6px;

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryJsonCard.test.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryJsonCard.test.tsx
@@ -42,11 +42,12 @@ describe("SummaryJsonCard", () => {
     expect(screen.queryByText("내용 없음")).not.toBeInTheDocument();
   });
 
-  it("summaryJson finalMessage를 도메인팩 정보 요약에 렌더링한다", () => {
+  it("summaryJson finalMessage는 변경사항 정리로 렌더링하지 않는다", () => {
     render(<SummaryJsonCard summaryJson='{"finalMessage":"확인 항목을 보강했습니다."}' />);
 
     expect(screen.getByText("변경사항 정리")).toBeInTheDocument();
-    expect(screen.getByText("확인 항목을 보강했습니다.")).toBeInTheDocument();
+    expect(screen.getByText("작성된 변경사항이 없습니다")).toBeInTheDocument();
+    expect(screen.queryByText("확인 항목을 보강했습니다.")).not.toBeInTheDocument();
   });
 
   it("summaryJson draftSource.reason은 변경사항 정리로 렌더링하지 않는다", () => {

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryJsonCard.test.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryJsonCard.test.tsx
@@ -195,6 +195,18 @@ describe("SummaryJsonCard", () => {
     expect(screen.getByText("{bad}")).toBeInTheDocument();
   });
 
+  it("유효하지 않은 JSON의 전체 JSON 화면에서도 원문을 표시한다", () => {
+    render(<SummaryJsonCard summaryJson="{bad}" />);
+    fireEvent.click(screen.getByRole("button", { name: "전체 JSON" }));
+    expect(screen.getByText("{bad}")).toBeInTheDocument();
+  });
+
+  it("빈 JSON 객체의 전체 JSON 화면은 내용 없음 문구를 표시한다", () => {
+    render(<SummaryJsonCard summaryJson="{}" />);
+    fireEvent.click(screen.getByRole("button", { name: "전체 JSON" }));
+    expect(screen.getByText("내용 없음")).toBeInTheDocument();
+  });
+
   it("전체 JSON 버튼 클릭 시 전체 JSON 필드를 카드로 표시한다", () => {
     const json = '{"key":"val"}';
     render(<SummaryJsonCard summaryJson={json} />);

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryJsonCard.test.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryJsonCard.test.tsx
@@ -42,6 +42,13 @@ describe("SummaryJsonCard", () => {
     expect(screen.queryByText("내용 없음")).not.toBeInTheDocument();
   });
 
+  it("공백 변경사항 정리는 빈 상태 문구로 렌더링한다", () => {
+    render(<SummaryJsonCard summaryJson="{}" finalMessage="   " />);
+
+    expect(screen.getByText("변경사항 정리")).toBeInTheDocument();
+    expect(screen.getByText("작성된 변경사항이 없습니다")).toBeInTheDocument();
+  });
+
   it("summaryJson finalMessage는 변경사항 정리로 렌더링하지 않는다", () => {
     render(<SummaryJsonCard summaryJson='{"finalMessage":"확인 항목을 보강했습니다."}' />);
 

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryJsonCard.test.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryJsonCard.test.tsx
@@ -33,10 +33,37 @@ describe("SummaryJsonCard", () => {
     expect(screen.getByText("도메인팩 정보")).toBeInTheDocument();
   });
 
+  it("변경사항 정리를 도메인팩 정보 요약에 렌더링한다", () => {
+    render(<SummaryJsonCard summaryJson="{}" finalMessage="상담 유형명을 정리했습니다." />);
+
+    expect(screen.getByText("도메인팩 정보")).toBeInTheDocument();
+    expect(screen.getByText("변경사항 정리")).toBeInTheDocument();
+    expect(screen.getByText("상담 유형명을 정리했습니다.")).toBeInTheDocument();
+    expect(screen.queryByText("내용 없음")).not.toBeInTheDocument();
+  });
+
+  it("summaryJson finalMessage를 도메인팩 정보 요약에 렌더링한다", () => {
+    render(<SummaryJsonCard summaryJson='{"finalMessage":"확인 항목을 보강했습니다."}' />);
+
+    expect(screen.getByText("변경사항 정리")).toBeInTheDocument();
+    expect(screen.getByText("확인 항목을 보강했습니다.")).toBeInTheDocument();
+  });
+
+  it("summaryJson draftSource.reason은 변경사항 정리로 렌더링하지 않는다", () => {
+    render(
+      <SummaryJsonCard summaryJson='{"draftSource":{"baseVersionNo":19,"reason":"확인 항목을 보강했습니다."}}' />,
+    );
+
+    expect(screen.getByText("변경사항 정리")).toBeInTheDocument();
+    expect(screen.getByText("작성된 변경사항이 없습니다")).toBeInTheDocument();
+    expect(screen.queryByText("확인 항목을 보강했습니다.")).not.toBeInTheDocument();
+  });
+
   it("알려지지 않은 JSON 객체는 요약 화면에 노출하지 않고 전체 JSON에서 확인한다", () => {
     const json = '{"intent":"greeting","count":3}';
     render(<SummaryJsonCard summaryJson={json} />);
-    expect(screen.getByText("내용 없음")).toBeInTheDocument();
+    expect(screen.getByText("변경사항 정리")).toBeInTheDocument();
+    expect(screen.getByText("작성된 변경사항이 없습니다")).toBeInTheDocument();
     expect(screen.queryByText("기타 메타데이터")).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "전체 JSON" }));
     expect(screen.getByText("intent")).toBeInTheDocument();
@@ -148,9 +175,10 @@ describe("SummaryJsonCard", () => {
     expect(screen.getByText("도메인팩 변경 요약을 불러오지 못했습니다.")).toBeInTheDocument();
   });
 
-  it("빈 JSON 객체는 '내용 없음'을 표시한다", () => {
+  it("빈 JSON 객체는 변경사항 정리 빈 상태를 표시한다", () => {
     render(<SummaryJsonCard summaryJson="{}" />);
-    expect(screen.getByText("내용 없음")).toBeInTheDocument();
+    expect(screen.getByText("변경사항 정리")).toBeInTheDocument();
+    expect(screen.getByText("작성된 변경사항이 없습니다")).toBeInTheDocument();
   });
 
   it("유효하지 않은 JSON은 파싱 실패 경고와 원문을 표시한다", () => {

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryJsonCard.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryJsonCard.tsx
@@ -104,9 +104,10 @@ function buildRevisionChanges(summary?: IntentRevisionSummary): RevisionChangeIt
 
 function buildSummary(data: SummaryData, revisionSummary?: IntentRevisionSummary) {
   const topic = typeof data.topic === "string" ? data.topic.trim() : "";
+  const draftSource = firstValue(data, [["draftSource"]]);
+  const finalMessage = typeof data.finalMessage === "string" ? data.finalMessage.trim() : "";
   const source = firstValue(data, [["generation", "source"], ["source"], ["sourceType"]]);
   const clusterCount = firstValue(data, [["generation", "clusterCount"], ["clusterCount"]]);
-  const draftSource = firstValue(data, [["draftSource"]]);
   const needsReviewCount = firstValue(data, [["review", "needsReviewCount"], ["needsReviewCount"]]);
 
   const highlights: SummaryItem[] = [];
@@ -142,11 +143,12 @@ function buildSummary(data: SummaryData, revisionSummary?: IntentRevisionSummary
   ];
   const revisionChanges = buildRevisionChanges(revisionSummary);
 
-  return { topic, highlights, metrics, issues, revisionChanges };
+  return { topic, finalMessage, highlights, metrics, issues, revisionChanges };
 }
 
 interface SummaryJsonCardProps {
   summaryJson: string;
+  finalMessage?: string | null;
   revisionSummary?: IntentRevisionSummary;
   isRevisionSummaryLoading?: boolean;
   revisionSummaryError?: string | null;
@@ -154,6 +156,7 @@ interface SummaryJsonCardProps {
 
 interface ReadableSummaryProps {
   data: SummaryData;
+  finalMessage?: string | null;
   revisionSummary?: IntentRevisionSummary;
   isRevisionSummaryLoading: boolean;
   revisionSummaryError: string | null;
@@ -161,6 +164,7 @@ interface ReadableSummaryProps {
 
 export function SummaryJsonCard({
   summaryJson,
+  finalMessage = null,
   revisionSummary,
   isRevisionSummaryLoading = false,
   revisionSummaryError = null,
@@ -203,6 +207,7 @@ export function SummaryJsonCard({
             {parsed.ok ? (
               <ReadableSummary
                 data={parsed.data}
+                finalMessage={finalMessage}
                 revisionSummary={revisionSummary}
                 isRevisionSummaryLoading={isRevisionSummaryLoading}
                 revisionSummaryError={revisionSummaryError}
@@ -223,24 +228,14 @@ export function SummaryJsonCard({
 
 function ReadableSummary({
   data,
+  finalMessage,
   revisionSummary,
   isRevisionSummaryLoading,
   revisionSummaryError,
 }: Readonly<ReadableSummaryProps>) {
   const summary = buildSummary(data, revisionSummary);
+  const normalizedFinalMessage = finalMessage?.trim() || summary.finalMessage;
   const hasRevisionSummary = revisionSummary !== undefined;
-  const hasContent =
-    summary.topic ||
-    summary.highlights.length > 0 ||
-    summary.metrics.length > 0 ||
-    summary.issues.length > 0 ||
-    summary.revisionChanges.length > 0 ||
-    hasRevisionSummary ||
-    isRevisionSummaryLoading ||
-    revisionSummaryError;
-
-  if (!hasContent) return <span className={styles.empty}>내용 없음</span>;
-
   const revisionChangeContent = renderRevisionChangeContent({
     changes: summary.revisionChanges,
     isLoading: isRevisionSummaryLoading,
@@ -266,6 +261,15 @@ function ReadableSummary({
           ))}
         </div>
       )}
+
+      <section className={styles.summarySection}>
+        <h4 className={styles.summarySectionTitle}>변경사항 정리</h4>
+        {normalizedFinalMessage ? (
+          <p className={styles.finalMessage}>{normalizedFinalMessage}</p>
+        ) : (
+          <span className={styles.empty}>작성된 변경사항이 없습니다</span>
+        )}
+      </section>
 
       {summary.metrics.length > 0 && (
         <section className={styles.summarySection}>

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryJsonCard.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryJsonCard.tsx
@@ -105,7 +105,6 @@ function buildRevisionChanges(summary?: IntentRevisionSummary): RevisionChangeIt
 function buildSummary(data: SummaryData, revisionSummary?: IntentRevisionSummary) {
   const topic = typeof data.topic === "string" ? data.topic.trim() : "";
   const draftSource = firstValue(data, [["draftSource"]]);
-  const finalMessage = typeof data.finalMessage === "string" ? data.finalMessage.trim() : "";
   const source = firstValue(data, [["generation", "source"], ["source"], ["sourceType"]]);
   const clusterCount = firstValue(data, [["generation", "clusterCount"], ["clusterCount"]]);
   const needsReviewCount = firstValue(data, [["review", "needsReviewCount"], ["needsReviewCount"]]);
@@ -143,7 +142,7 @@ function buildSummary(data: SummaryData, revisionSummary?: IntentRevisionSummary
   ];
   const revisionChanges = buildRevisionChanges(revisionSummary);
 
-  return { topic, finalMessage, highlights, metrics, issues, revisionChanges };
+  return { topic, highlights, metrics, issues, revisionChanges };
 }
 
 interface SummaryJsonCardProps {
@@ -234,7 +233,7 @@ function ReadableSummary({
   revisionSummaryError,
 }: Readonly<ReadableSummaryProps>) {
   const summary = buildSummary(data, revisionSummary);
-  const normalizedFinalMessage = finalMessage?.trim() || summary.finalMessage;
+  const normalizedFinalMessage = finalMessage?.trim() ?? "";
   const hasRevisionSummary = revisionSummary !== undefined;
   const revisionChangeContent = renderRevisionChangeContent({
     changes: summary.revisionChanges,

--- a/frontend/src/features/intent-revision-draft/ui/IntentRevisionDraftActions.test.tsx
+++ b/frontend/src/features/intent-revision-draft/ui/IntentRevisionDraftActions.test.tsx
@@ -42,7 +42,7 @@ describe("IntentRevisionDraftActions", () => {
     renderActions();
 
     expect(
-      screen.getByText("변경된 구성 요소 1개 (상담 유형 1개 · 응대 흐름 0개)"),
+      screen.getByText("변경된 구성 요소 1개 (상담 유형 1개 · 워크플로우 0개)"),
     ).toBeInTheDocument();
     expect(
       screen.getByText("수정 내용의 적용 및 삭제는 도메인팩 화면에서 진행할 수 있습니다."),

--- a/frontend/src/features/intent-revision-draft/ui/IntentRevisionDraftActions.tsx
+++ b/frontend/src/features/intent-revision-draft/ui/IntentRevisionDraftActions.tsx
@@ -26,7 +26,7 @@ export function IntentRevisionDraftActions({
   const errorMessage = rawErrorMessage ?? "변경 요약을 불러오지 못했습니다.";
   const changedLabel =
     changedCount > 0
-      ? `변경된 구성 요소 ${changedCount}개 (상담 유형 ${intentChangedCount}개 · 응대 흐름 ${workflowChangedCount}개)`
+      ? `변경된 구성 요소 ${changedCount}개 (상담 유형 ${intentChangedCount}개 · 워크플로우 ${workflowChangedCount}개)`
       : "변경된 구성 요소가 없습니다.";
 
   return (

--- a/frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.test.tsx
+++ b/frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.test.tsx
@@ -5,7 +5,10 @@ import { toast } from "sonner";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ApiRequestError } from "@/shared/api";
 import { useDeploy } from "@/shared/api/generated/endpoints/deploy-domain-pack-version-controller/deploy-domain-pack-version-controller";
-import { activate } from "@/shared/api/generated/endpoints/activate-domain-pack-version-controller/activate-domain-pack-version-controller";
+import {
+  activate,
+  type ActivateMutationResult,
+} from "@/shared/api/generated/endpoints/activate-domain-pack-version-controller/activate-domain-pack-version-controller";
 import { useDiscard } from "@/shared/api/generated/endpoints/discard-draft-version-controller/discard-draft-version-controller";
 import { usePackDetail, useVersionDetail } from "@/features/domain-pack-summary-read";
 import { DomainPackSummaryPage } from "./DomainPackSummaryPage";
@@ -132,6 +135,16 @@ function makePackQuery(overrides: Record<string, unknown> = {}): any {
   };
 }
 
+type ActivateMockData = ActivateMutationResult["data"] & { description?: string };
+
+function makeActivateResponse(data: ActivateMockData): ActivateMutationResult {
+  return {
+    data,
+    status: 200,
+    headers: new Headers(),
+  };
+}
+
 function LocationProbe() {
   const location = useLocation();
   return <div data-testid="location">{`${location.pathname}${location.search}`}</div>;
@@ -170,7 +183,7 @@ describe("DomainPackSummaryPage", () => {
       variables: undefined,
     } as unknown as ReturnType<typeof useDeploy>);
     vi.mocked(activate).mockReset();
-    vi.mocked(activate).mockResolvedValue({ data: { id: 5 } } as never);
+    vi.mocked(activate).mockResolvedValue(makeActivateResponse({ id: 5 }));
     vi.mocked(useDiscard).mockReturnValue({
       mutate: vi.fn(),
       isPending: false,
@@ -478,9 +491,14 @@ describe("DomainPackSummaryPage", () => {
   });
 
   it("버전 배포 실패 시 기본 실패 toast를 띄운다", () => {
+    // useDeploy is mocked here, so mutate triggers the onError callback supplied by the page.
     vi.mocked(useDeploy).mockImplementation((options) => ({
       mutate: vi.fn(() =>
-        options?.mutation?.onError?.(new Error("deploy failed"), {} as never, undefined),
+        options?.mutation?.onError?.(
+          new Error("deploy failed"),
+          { workspaceId: 1, packId: 2, versionId: 4 },
+          undefined,
+        ),
       ),
       isPending: false,
       variables: undefined,
@@ -503,11 +521,12 @@ describe("DomainPackSummaryPage", () => {
   });
 
   it("버전 배포 실패 시 API 에러 메시지를 toast에 사용한다", () => {
+    // Keep this tied to useDeploy's option shape: the mock mutate simulates a failed mutation.
     vi.mocked(useDeploy).mockImplementation((options) => ({
       mutate: vi.fn(() =>
         options?.mutation?.onError?.(
           new ApiRequestError(409, "CONFLICT", "이미 배포된 버전입니다."),
-          {} as never,
+          { workspaceId: 1, packId: 2, versionId: 4 },
           undefined,
         ),
       ),
@@ -607,7 +626,7 @@ describe("DomainPackSummaryPage", () => {
   it("Draft 적용 성공 후 기존 draft 상세 refetch 실패로 실패 toast를 띄우지 않는다", async () => {
     const packRefetch = vi.fn().mockRejectedValue(new Error("refetch failed"));
     const versionRefetch = vi.fn().mockRejectedValue(new Error("old draft missing"));
-    vi.mocked(activate).mockResolvedValue({ id: 6 } as never);
+    vi.mocked(activate).mockResolvedValue(makeActivateResponse({ id: 6 }));
     vi.mocked(usePackDetail).mockReturnValue(
       makePackQuery({
         data: {
@@ -640,8 +659,10 @@ describe("DomainPackSummaryPage", () => {
     expect(toast.error).not.toHaveBeenCalledWith("초안 수정버전을 적용하지 못했습니다.");
   });
 
-  it("Draft 적용 성공 응답의 description이 루트에 있으면 성공 처리한다", async () => {
-    vi.mocked(activate).mockResolvedValue({ id: 6, description: "  응답 변경사항  " } as never);
+  it("Draft 적용 성공 응답의 description이 있으면 성공 처리한다", async () => {
+    vi.mocked(activate).mockResolvedValue(
+      makeActivateResponse({ id: 6, description: "  응답 변경사항  " }),
+    );
     vi.mocked(usePackDetail).mockReturnValue(
       makePackQuery({
         data: {
@@ -671,8 +692,8 @@ describe("DomainPackSummaryPage", () => {
     expect(toast.success).toHaveBeenCalledWith("초안 수정버전이 적용되었습니다.");
   });
 
-  it("Draft 적용 성공 응답이 data.id 형태여도 적용된 버전으로 이동한다", async () => {
-    vi.mocked(activate).mockResolvedValue({ data: { id: 7 } } as never);
+  it("Draft 적용 성공 응답의 data.id로 적용된 버전으로 이동한다", async () => {
+    vi.mocked(activate).mockResolvedValue(makeActivateResponse({ id: 7 }));
     vi.mocked(usePackDetail).mockReturnValue(
       makePackQuery({
         data: {
@@ -702,9 +723,9 @@ describe("DomainPackSummaryPage", () => {
   });
 
   it("Draft 적용 성공 응답의 description이 data에 있으면 성공 처리한다", async () => {
-    vi.mocked(activate).mockResolvedValue({
-      data: { id: 8, description: "  data 변경사항  " },
-    } as never);
+    vi.mocked(activate).mockResolvedValue(
+      makeActivateResponse({ id: 8, description: "  data 변경사항  " }),
+    );
     vi.mocked(usePackDetail).mockReturnValue(
       makePackQuery({
         data: {

--- a/frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.test.tsx
+++ b/frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.test.tsx
@@ -2,9 +2,10 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
 import { toast } from "sonner";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ApiRequestError } from "@/shared/api";
 import { useDeploy } from "@/shared/api/generated/endpoints/deploy-domain-pack-version-controller/deploy-domain-pack-version-controller";
-import { useActivate } from "@/shared/api/generated/endpoints/activate-domain-pack-version-controller/activate-domain-pack-version-controller";
+import { activate } from "@/shared/api/generated/endpoints/activate-domain-pack-version-controller/activate-domain-pack-version-controller";
 import { useDiscard } from "@/shared/api/generated/endpoints/discard-draft-version-controller/discard-draft-version-controller";
 import { usePackDetail, useVersionDetail } from "@/features/domain-pack-summary-read";
 import { DomainPackSummaryPage } from "./DomainPackSummaryPage";
@@ -74,7 +75,7 @@ vi.mock("@/features/domain-pack-summary-read", () => ({
     currentVersionId?: number | null;
     currentVersionNo?: number | null;
     onDeploy: (versionId: number) => void;
-    onApplyDraft: (versionId: number) => void;
+    onApplyDraft: (versionId: number, description?: string) => void;
     onDiscardDraft: (versionId: number) => void;
   }) => (
     <div data-testid="summary-detail-panel">
@@ -83,7 +84,7 @@ vi.mock("@/features/domain-pack-summary-read", () => ({
       <button type="button" onClick={() => onDeploy(4)}>
         deploy version
       </button>
-      <button type="button" onClick={() => onApplyDraft(5)}>
+      <button type="button" onClick={() => onApplyDraft(5, "변경사항 정리 메모")}>
         apply draft
       </button>
       <button type="button" onClick={() => onDiscardDraft(5)}>
@@ -102,7 +103,7 @@ vi.mock(
 vi.mock(
   "@/shared/api/generated/endpoints/activate-domain-pack-version-controller/activate-domain-pack-version-controller",
   () => ({
-    useActivate: vi.fn(),
+    activate: vi.fn(),
   }),
 );
 vi.mock(
@@ -131,20 +132,25 @@ function LocationProbe() {
 }
 
 function renderPage(path = "/workspaces/1/domain-packs/2") {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
   render(
-    <MemoryRouter initialEntries={[path]}>
-      <Routes>
-        <Route
-          path="/workspaces/:workspaceId/domain-packs/:packId"
-          element={
-            <>
-              <DomainPackSummaryPage />
-              <LocationProbe />
-            </>
-          }
-        />
-      </Routes>
-    </MemoryRouter>,
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route
+            path="/workspaces/:workspaceId/domain-packs/:packId"
+            element={
+              <>
+                <DomainPackSummaryPage />
+                <LocationProbe />
+              </>
+            }
+          />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
   );
 }
 
@@ -157,11 +163,8 @@ describe("DomainPackSummaryPage", () => {
       isPending: false,
       variables: undefined,
     } as unknown as ReturnType<typeof useDeploy>);
-    vi.mocked(useActivate).mockReturnValue({
-      mutate: vi.fn(),
-      isPending: false,
-      variables: undefined,
-    } as unknown as ReturnType<typeof useActivate>);
+    vi.mocked(activate).mockReset();
+    vi.mocked(activate).mockResolvedValue({ data: { id: 5 } } as never);
     vi.mocked(useDiscard).mockReturnValue({
       mutate: vi.fn(),
       isPending: false,
@@ -468,13 +471,7 @@ describe("DomainPackSummaryPage", () => {
     });
   });
 
-  it("Draft 적용 버튼 클릭 시 activate mutation을 호출한다", () => {
-    const mutate = vi.fn();
-    vi.mocked(useActivate).mockReturnValue({
-      mutate,
-      isPending: false,
-      variables: undefined,
-    } as unknown as ReturnType<typeof useActivate>);
+  it("Draft 적용 버튼 클릭 시 변경사항 정리와 함께 activate API를 호출한다", async () => {
     vi.mocked(usePackDetail).mockReturnValue(
       makePackQuery({
         data: {
@@ -489,34 +486,22 @@ describe("DomainPackSummaryPage", () => {
     renderPage("/workspaces/1/domain-packs/2?versionId=5");
     fireEvent.click(screen.getByRole("button", { name: "apply draft" }));
 
-    expect(mutate).toHaveBeenCalledWith({
-      workspaceId: 1,
-      packId: 2,
-      versionId: 5,
-    });
+    await waitFor(() => expect(activate).toHaveBeenCalled());
+    expect(activate).toHaveBeenCalledWith(
+      1,
+      2,
+      5,
+      expect.objectContaining({
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ description: "변경사항 정리 메모" }),
+      }),
+    );
   });
 
   it("Draft 적용 성공 후 기존 draft 상세 refetch 실패로 실패 toast를 띄우지 않는다", async () => {
     const packRefetch = vi.fn().mockRejectedValue(new Error("refetch failed"));
     const versionRefetch = vi.fn().mockRejectedValue(new Error("old draft missing"));
-    const mutate = vi.fn((variables) => {
-      void activateOnSuccess?.({ id: 6 }, variables, undefined);
-    });
-    let activateOnSuccess:
-      | ((
-          result: unknown,
-          variables: { workspaceId: number; packId: number; versionId: number },
-          context: unknown,
-        ) => unknown)
-      | undefined;
-    vi.mocked(useActivate).mockImplementation((options) => {
-      activateOnSuccess = options?.mutation?.onSuccess;
-      return {
-        mutate,
-        isPending: false,
-        variables: undefined,
-      } as unknown as ReturnType<typeof useActivate>;
-    });
+    vi.mocked(activate).mockResolvedValue({ id: 6 } as never);
     vi.mocked(usePackDetail).mockReturnValue(
       makePackQuery({
         data: {
@@ -545,31 +530,12 @@ describe("DomainPackSummaryPage", () => {
     );
     expect(packRefetch).toHaveBeenCalled();
     expect(versionRefetch).toHaveBeenCalled();
-    expect(toast.success).toHaveBeenCalledWith(
-      "검토 중인 버전이 운영 버전으로 적용되었습니다.",
-    );
-    expect(toast.error).not.toHaveBeenCalledWith("검토 중인 버전을 적용하지 못했습니다.");
+    expect(toast.success).toHaveBeenCalledWith("초안 수정버전이 적용되었습니다.");
+    expect(toast.error).not.toHaveBeenCalledWith("초안 수정버전을 적용하지 못했습니다.");
   });
 
   it("Draft 적용 성공 응답이 data.id 형태여도 적용된 버전으로 이동한다", async () => {
-    let activateOnSuccess:
-      | ((
-          result: unknown,
-          variables: { workspaceId: number; packId: number; versionId: number },
-          context: unknown,
-        ) => unknown)
-      | undefined;
-    const mutate = vi.fn((variables) => {
-      void activateOnSuccess?.({ data: { id: 7 } }, variables, undefined);
-    });
-    vi.mocked(useActivate).mockImplementation((options) => {
-      activateOnSuccess = options?.mutation?.onSuccess;
-      return {
-        mutate,
-        isPending: false,
-        variables: undefined,
-      } as unknown as ReturnType<typeof useActivate>;
-    });
+    vi.mocked(activate).mockResolvedValue({ data: { id: 7 } } as never);
     vi.mocked(usePackDetail).mockReturnValue(
       makePackQuery({
         data: {
@@ -598,17 +564,8 @@ describe("DomainPackSummaryPage", () => {
     );
   });
 
-  it("Draft 적용 실패 시 상담사 용어의 실패 toast를 띄운다", () => {
-    let activateOnError: ((error: unknown) => unknown) | undefined;
-    const mutate = vi.fn(() => activateOnError?.(new Error("activate failed")));
-    vi.mocked(useActivate).mockImplementation((options) => {
-      activateOnError = options?.mutation?.onError;
-      return {
-        mutate,
-        isPending: false,
-        variables: undefined,
-      } as unknown as ReturnType<typeof useActivate>;
-    });
+  it("Draft 적용 실패 시 상담사 용어의 실패 toast를 띄운다", async () => {
+    vi.mocked(activate).mockRejectedValue(new Error("activate failed"));
     vi.mocked(usePackDetail).mockReturnValue(
       makePackQuery({
         data: {
@@ -623,7 +580,9 @@ describe("DomainPackSummaryPage", () => {
     renderPage("/workspaces/1/domain-packs/2?versionId=5");
     fireEvent.click(screen.getByRole("button", { name: "apply draft" }));
 
-    expect(toast.error).toHaveBeenCalledWith("검토 중인 버전을 적용하지 못했습니다.");
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith("초안 수정버전을 적용하지 못했습니다."),
+    );
   });
 
   it("Draft 삭제 버튼 클릭 시 discard mutation을 호출한다", () => {

--- a/frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.test.tsx
+++ b/frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.test.tsx
@@ -87,6 +87,9 @@ vi.mock("@/features/domain-pack-summary-read", () => ({
       <button type="button" onClick={() => onApplyDraft(5, "변경사항 정리 메모")}>
         apply draft
       </button>
+      <button type="button" onClick={() => onApplyDraft(5, "")}>
+        apply empty draft
+      </button>
       <button type="button" onClick={() => onDiscardDraft(5)}>
         delete draft
       </button>
@@ -494,6 +497,33 @@ describe("DomainPackSummaryPage", () => {
       expect.objectContaining({
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ description: "변경사항 정리 메모" }),
+      }),
+    );
+  });
+
+  it("Draft 적용 버튼 클릭 시 빈 변경사항 정리도 activate API에 전달한다", async () => {
+    vi.mocked(usePackDetail).mockReturnValue(
+      makePackQuery({
+        data: {
+          packId: 2,
+          name: "CS Pack",
+          code: "CS",
+          versions: [{ versionId: 5, versionNo: 3, lifecycleStatus: "DRAFT" }],
+        },
+      }),
+    );
+
+    renderPage("/workspaces/1/domain-packs/2?versionId=5");
+    fireEvent.click(screen.getByRole("button", { name: "apply empty draft" }));
+
+    await waitFor(() => expect(activate).toHaveBeenCalled());
+    expect(activate).toHaveBeenCalledWith(
+      1,
+      2,
+      5,
+      expect.objectContaining({
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ description: "" }),
       }),
     );
   });

--- a/frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.test.tsx
+++ b/frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.test.tsx
@@ -90,6 +90,9 @@ vi.mock("@/features/domain-pack-summary-read", () => ({
       <button type="button" onClick={() => onApplyDraft(5, "")}>
         apply empty draft
       </button>
+      <button type="button" onClick={() => onApplyDraft(5)}>
+        apply draft without description
+      </button>
       <button type="button" onClick={() => onDiscardDraft(5)}>
         delete draft
       </button>
@@ -528,6 +531,25 @@ describe("DomainPackSummaryPage", () => {
     );
   });
 
+  it("Draft 적용 버튼 클릭 시 변경사항 정리가 없으면 요청 body 없이 activate API를 호출한다", async () => {
+    vi.mocked(usePackDetail).mockReturnValue(
+      makePackQuery({
+        data: {
+          packId: 2,
+          name: "CS Pack",
+          code: "CS",
+          versions: [{ versionId: 5, versionNo: 3, lifecycleStatus: "DRAFT" }],
+        },
+      }),
+    );
+
+    renderPage("/workspaces/1/domain-packs/2?versionId=5");
+    fireEvent.click(screen.getByRole("button", { name: "apply draft without description" }));
+
+    await waitFor(() => expect(activate).toHaveBeenCalled());
+    expect(activate).toHaveBeenCalledWith(1, 2, 5, undefined);
+  });
+
   it("Draft 적용 성공 후 기존 draft 상세 refetch 실패로 실패 toast를 띄우지 않는다", async () => {
     const packRefetch = vi.fn().mockRejectedValue(new Error("refetch failed"));
     const versionRefetch = vi.fn().mockRejectedValue(new Error("old draft missing"));
@@ -564,6 +586,37 @@ describe("DomainPackSummaryPage", () => {
     expect(toast.error).not.toHaveBeenCalledWith("초안 수정버전을 적용하지 못했습니다.");
   });
 
+  it("Draft 적용 성공 응답의 description이 루트에 있으면 성공 처리한다", async () => {
+    vi.mocked(activate).mockResolvedValue({ id: 6, description: "  응답 변경사항  " } as never);
+    vi.mocked(usePackDetail).mockReturnValue(
+      makePackQuery({
+        data: {
+          packId: 2,
+          name: "CS Pack",
+          code: "CS",
+          versions: [{ versionId: 5, versionNo: 3, lifecycleStatus: "DRAFT" }],
+        },
+        refetch: vi.fn(),
+      }),
+    );
+    vi.mocked(useVersionDetail).mockReturnValue(
+      makePackQuery({
+        data: { versionId: 5, lifecycleStatus: "DRAFT" },
+        refetch: vi.fn(),
+      }),
+    );
+
+    renderPage("/workspaces/1/domain-packs/2?versionId=5");
+    fireEvent.click(screen.getByRole("button", { name: "apply draft" }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("location")).toHaveTextContent(
+        "/workspaces/1/domain-packs/2?versionId=6",
+      ),
+    );
+    expect(toast.success).toHaveBeenCalledWith("초안 수정버전이 적용되었습니다.");
+  });
+
   it("Draft 적용 성공 응답이 data.id 형태여도 적용된 버전으로 이동한다", async () => {
     vi.mocked(activate).mockResolvedValue({ data: { id: 7 } } as never);
     vi.mocked(usePackDetail).mockReturnValue(
@@ -592,6 +645,39 @@ describe("DomainPackSummaryPage", () => {
         "/workspaces/1/domain-packs/2?versionId=7",
       ),
     );
+  });
+
+  it("Draft 적용 성공 응답의 description이 data에 있으면 성공 처리한다", async () => {
+    vi.mocked(activate).mockResolvedValue({
+      data: { id: 8, description: "  data 변경사항  " },
+    } as never);
+    vi.mocked(usePackDetail).mockReturnValue(
+      makePackQuery({
+        data: {
+          packId: 2,
+          name: "CS Pack",
+          code: "CS",
+          versions: [{ versionId: 5, versionNo: 3, lifecycleStatus: "DRAFT" }],
+        },
+        refetch: vi.fn(),
+      }),
+    );
+    vi.mocked(useVersionDetail).mockReturnValue(
+      makePackQuery({
+        data: { versionId: 5, lifecycleStatus: "DRAFT" },
+        refetch: vi.fn(),
+      }),
+    );
+
+    renderPage("/workspaces/1/domain-packs/2?versionId=5");
+    fireEvent.click(screen.getByRole("button", { name: "apply empty draft" }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("location")).toHaveTextContent(
+        "/workspaces/1/domain-packs/2?versionId=8",
+      ),
+    );
+    expect(toast.success).toHaveBeenCalledWith("초안 수정버전이 적용되었습니다.");
   });
 
   it("Draft 적용 실패 시 상담사 용어의 실패 toast를 띄운다", async () => {

--- a/frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.test.tsx
+++ b/frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.test.tsx
@@ -477,6 +477,60 @@ describe("DomainPackSummaryPage", () => {
     });
   });
 
+  it("버전 배포 실패 시 기본 실패 toast를 띄운다", () => {
+    vi.mocked(useDeploy).mockImplementation((options) => ({
+      mutate: vi.fn(() =>
+        options?.mutation?.onError?.(new Error("deploy failed"), {} as never, undefined),
+      ),
+      isPending: false,
+      variables: undefined,
+    } as unknown as ReturnType<typeof useDeploy>));
+    vi.mocked(usePackDetail).mockReturnValue(
+      makePackQuery({
+        data: {
+          packId: 2,
+          name: "CS Pack",
+          code: "CS",
+          versions: [{ versionId: 4, versionNo: 2 }],
+        },
+      }),
+    );
+
+    renderPage("/workspaces/1/domain-packs/2?versionId=3");
+    fireEvent.click(screen.getByRole("button", { name: "deploy version" }));
+
+    expect(toast.error).toHaveBeenCalledWith("도메인팩 버전을 배포하지 못했습니다.");
+  });
+
+  it("버전 배포 실패 시 API 에러 메시지를 toast에 사용한다", () => {
+    vi.mocked(useDeploy).mockImplementation((options) => ({
+      mutate: vi.fn(() =>
+        options?.mutation?.onError?.(
+          new ApiRequestError(409, "CONFLICT", "이미 배포된 버전입니다."),
+          {} as never,
+          undefined,
+        ),
+      ),
+      isPending: false,
+      variables: undefined,
+    } as unknown as ReturnType<typeof useDeploy>));
+    vi.mocked(usePackDetail).mockReturnValue(
+      makePackQuery({
+        data: {
+          packId: 2,
+          name: "CS Pack",
+          code: "CS",
+          versions: [{ versionId: 4, versionNo: 2 }],
+        },
+      }),
+    );
+
+    renderPage("/workspaces/1/domain-packs/2?versionId=3");
+    fireEvent.click(screen.getByRole("button", { name: "deploy version" }));
+
+    expect(toast.error).toHaveBeenCalledWith("이미 배포된 버전입니다.");
+  });
+
   it("Draft 적용 버튼 클릭 시 변경사항 정리와 함께 activate API를 호출한다", async () => {
     vi.mocked(usePackDetail).mockReturnValue(
       makePackQuery({

--- a/frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.tsx
@@ -1,10 +1,15 @@
 import { useEffect } from "react";
 import { useParams, useSearchParams } from "react-router-dom";
 import { toast } from "sonner";
-import type { UseQueryResult } from "@tanstack/react-query";
-import { ApiRequestError } from "@/shared/api";
+import {
+  useMutation,
+  useQueryClient,
+  type QueryClient,
+  type UseQueryResult,
+} from "@tanstack/react-query";
+import { ApiRequestError, domainPackQueryKeys } from "@/shared/api";
 import { useDeploy } from "@/shared/api/generated/endpoints/deploy-domain-pack-version-controller/deploy-domain-pack-version-controller";
-import { useActivate } from "@/shared/api/generated/endpoints/activate-domain-pack-version-controller/activate-domain-pack-version-controller";
+import { activate } from "@/shared/api/generated/endpoints/activate-domain-pack-version-controller/activate-domain-pack-version-controller";
 import { useDiscard } from "@/shared/api/generated/endpoints/discard-draft-version-controller/discard-draft-version-controller";
 import { OstoneShell } from "@/widgets/ostone-shell";
 import { LoadingSpinner } from "@/shared/ui/ostone/atoms/LoadingSpinner";
@@ -61,12 +66,20 @@ interface ContentProps {
   setSearch: ReturnType<typeof useSearchParams>[1];
 }
 
+interface ActivateDraftVariables {
+  workspaceId: number;
+  packId: number;
+  versionId: number;
+  description?: string;
+}
+
 function DomainPackSummaryPageContent({
   wsId,
   packId,
   selectedVersionId,
   setSearch,
 }: ContentProps) {
+  const queryClient = useQueryClient();
   const packQuery = usePackDetail(wsId, packId) as UseQueryResult<DomainPackDetail>;
   const pack = packQuery.data;
   const defaultVersionId = resolveDefaultVersionId(pack);
@@ -114,24 +127,41 @@ function DomainPackSummaryPageContent({
       },
     },
   });
-  const activateMutation = useActivate({
-    mutation: {
-      onSuccess: async (result, variables) => {
-        const activatedVersionId = resolveActivatedVersionId(result, variables.versionId);
-        setSearch(
-          (prev) => {
-            const next = new URLSearchParams(prev);
-            next.set("versionId", String(activatedVersionId));
-            return next;
-          },
-          { replace: true },
-        );
-        await Promise.allSettled([packQuery.refetch(), versionQuery.refetch()]);
-        toast.success("검토 중인 버전이 운영 버전으로 적용되었습니다.");
-      },
-      onError: (error) => {
-        toast.error(resolveVersionActionErrorMessage(error, "검토 중인 버전을 적용하지 못했습니다."));
-      },
+  const activateMutation = useMutation({
+    mutationKey: ["activate-domain-pack-version"],
+    mutationFn: ({ workspaceId, packId, versionId, description }: ActivateDraftVariables) =>
+      activate(workspaceId, packId, versionId, buildActivateRequest(description)),
+    onSuccess: async (result, variables) => {
+      const activatedVersionId = resolveActivatedVersionId(result, variables.versionId);
+      const activatedDescription =
+        resolveActivatedDescription(result) ?? normalizeOptionalText(variables.description);
+      updateVersionDescriptionCache(
+        queryClient,
+        variables.workspaceId,
+        variables.packId,
+        activatedVersionId,
+        activatedDescription,
+      );
+      setSearch(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          next.set("versionId", String(activatedVersionId));
+          return next;
+        },
+        { replace: true },
+      );
+      await Promise.allSettled([packQuery.refetch(), versionQuery.refetch()]);
+      updateVersionDescriptionCache(
+        queryClient,
+        variables.workspaceId,
+        variables.packId,
+        activatedVersionId,
+        activatedDescription,
+      );
+      toast.success("초안 수정버전이 적용되었습니다.");
+    },
+    onError: (error) => {
+      toast.error(resolveVersionActionErrorMessage(error, "초안 수정버전을 적용하지 못했습니다."));
     },
   });
   const discardMutation = useDiscard({
@@ -174,8 +204,8 @@ function DomainPackSummaryPageContent({
     deployMutation.mutate({ workspaceId: wsId, packId, versionId });
   };
 
-  const handleApplyDraft = (versionId: number) => {
-    activateMutation.mutate({ workspaceId: wsId, packId, versionId });
+  const handleApplyDraft = (versionId: number, description?: string) => {
+    activateMutation.mutate({ workspaceId: wsId, packId, versionId, description });
   };
 
   const handleDiscardDraft = (versionId: number) => {
@@ -283,6 +313,36 @@ function resolveVersionActionErrorMessage(error: unknown, fallback: string): str
   return fallback;
 }
 
+function buildActivateRequest(description?: string): RequestInit | undefined {
+  const normalizedDescription = normalizeOptionalText(description);
+  if (!normalizedDescription) return undefined;
+
+  return {
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ description: normalizedDescription }),
+  };
+}
+
+function normalizeOptionalText(value?: string): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed || undefined;
+}
+
+function updateVersionDescriptionCache(
+  queryClient: QueryClient,
+  workspaceId: number,
+  packId: number,
+  versionId: number,
+  description?: string,
+) {
+  if (description === undefined) return;
+
+  queryClient.setQueryData<DomainPackVersionDetail | undefined>(
+    domainPackQueryKeys.version(workspaceId, packId, versionId),
+    (current) => (current ? { ...current, description } : current),
+  );
+}
+
 function resolveDefaultVersionId(pack?: DomainPackDetail): number | null {
   const versions = pack?.versions?.filter((version) => version.versionId != null) ?? [];
   if (versions.length === 0) return null;
@@ -340,6 +400,18 @@ function resolveActivatedVersionId(result: unknown, fallback: number): number {
   const data = result.data;
   if (isRecord(data) && typeof data.id === "number") return data.id;
   return fallback;
+}
+
+function resolveActivatedDescription(result: unknown): string | undefined {
+  if (!isRecord(result)) return undefined;
+  const direct = readOptionalString(result.description);
+  if (direct !== undefined) return direct;
+  const data = result.data;
+  return isRecord(data) ? readOptionalString(data.description) : undefined;
+}
+
+function readOptionalString(value: unknown): string | undefined {
+  return typeof value === "string" ? normalizeOptionalText(value) : undefined;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.tsx
@@ -134,7 +134,7 @@ function DomainPackSummaryPageContent({
     onSuccess: async (result, variables) => {
       const activatedVersionId = resolveActivatedVersionId(result, variables.versionId);
       const activatedDescription =
-        resolveActivatedDescription(result) ?? normalizeOptionalText(variables.description);
+        resolveActivatedDescription(result) ?? normalizeDescription(variables.description);
       updateVersionDescriptionCache(
         queryClient,
         variables.workspaceId,
@@ -314,8 +314,8 @@ function resolveVersionActionErrorMessage(error: unknown, fallback: string): str
 }
 
 function buildActivateRequest(description?: string): RequestInit | undefined {
-  const normalizedDescription = normalizeOptionalText(description);
-  if (!normalizedDescription) return undefined;
+  const normalizedDescription = normalizeDescription(description);
+  if (normalizedDescription === undefined) return undefined;
 
   return {
     headers: { "Content-Type": "application/json" },
@@ -323,9 +323,8 @@ function buildActivateRequest(description?: string): RequestInit | undefined {
   };
 }
 
-function normalizeOptionalText(value?: string): string | undefined {
-  const trimmed = value?.trim();
-  return trimmed || undefined;
+function normalizeDescription(value?: string): string | undefined {
+  return value === undefined ? undefined : value.trim();
 }
 
 function updateVersionDescriptionCache(
@@ -411,7 +410,7 @@ function resolveActivatedDescription(result: unknown): string | undefined {
 }
 
 function readOptionalString(value: unknown): string | undefined {
-  return typeof value === "string" ? normalizeOptionalText(value) : undefined;
+  return typeof value === "string" ? value.trim() : undefined;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/frontend/src/shared/lib/domainPackRevisionSummary.ts
+++ b/frontend/src/shared/lib/domainPackRevisionSummary.ts
@@ -75,8 +75,10 @@ interface GraphFingerprint {
   edgeCount: number | null;
 }
 
-function normalizeText(value: string | null | undefined): string {
-  return value ?? "";
+function normalizeText(value: unknown): string {
+  if (value == null) return "";
+  if (typeof value === "string") return value;
+  return JSON.stringify(value) ?? String(value);
 }
 
 function isRecord(value: unknown): value is JsonRecord {


### PR DESCRIPTION
## Summary

- 초안 수정버전 적용 모달에 `변경사항 정리` 입력 필드 추가
- 적용 요청 시 변경사항 정리를 `description`으로 전달하고 버전 정보에 저장
- 도메인팩 정보 카드에 `변경사항 정리` 섹션을 항상 표시
- 변경사항 정리가 없을 때 `작성된 변경사항이 없습니다` 표시
- 변경 요약 렌더링 중 non-string 값으로 발생하던 `raw.trim is not a function` 방어 처리

## Test

- [ ] 초안 수정버전 적용 모달에서 변경사항 정리 입력 후 적용
- [ ] 적용된 버전의 도메인팩 정보 카드에 입력한 변경사항 정리 표시 확인
- [ ] 변경사항 정리 없이 적용된 버전에서 빈 상태 문구 표시 확인
- [ ] 기존 도메인팩 요약/전체 JSON 탭 표시 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 초안 버전 적용 시 선택적 50자 이내의 변경사항 정리(설명)를 입력 가능하며, 적용 API 응답 및 요약 카드에 해당 메모가 포함되어 표시됩니다.
  * 적용 확인 다이얼로그에 메모 입력란과 글자 수 표시가 추가되었습니다.

* **동작 개선**
  * 입력된 메모는 앞뒤 공백을 자동으로 제거해 저장/표시됩니다.
  * 메모가 없거나 공백이면 “작성된 변경사항이 없습니다”로 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->