### PR TITLE
feat(demo): 하나카드 워크플로우 데모 seed 추가

### DIFF
--- a/.agent/specs/529.md
+++ b/.agent/specs/529.md
@@ -1,0 +1,280 @@
+# 하나카드 하드코딩 워크플로우 로컬 시연 Seed
+
+## 1. 목적
+
+하나카드 상담 로그 100건을 기준으로 카드 상담 도메인팩(intent/slot/policy/risk/workflow)을
+로컬/dev 환경에서 바로 시연 가능한 seed JSON으로 만든다.
+
+이 문서는 ML 파이프라인 전체 실행 결과를 설명하지 않는다. 최종 seed에 어떤 intent/slot/policy가
+몇 개 들어가고, JSON이 어떤 구조로 저장되는지만 정리한다.
+
+- workspace 2: `hanacard-card-service`
+- 데모 진입점: `http://localhost:5173/demo/chat/2?name=박하나`
+- seed 파일: `backend/src/main/resources/seed/hanacard-workflow-candidate.json`
+
+## 2. 최종 Seed 구성
+
+| 항목 | 개수 |
+| --- | ---: |
+| intent | 14 |
+| slot | 42 |
+| policy | 18 |
+| risk | 8 |
+| workflow | 14 |
+| intentSlotBinding | 75 |
+
+- packKey: `hanacard-card-service`
+- packName: `하나카드 카드 상담 도메인팩`
+- 입력 표본: 하나카드 상담 로그 100건
+- intent 배정 방식: 고객 발화와 상담원 확인/질문/정책/처리 발화를 함께 반영한 non-exclusive multi-intent
+
+## 3. 최종 Intent
+
+| intentCode | 상담 수 |
+| --- | ---: |
+| `lost_card_report_and_status` | 19 |
+| `payment_history_and_charge_inquiry` | 22 |
+| `cancellation_refund_status` | 9 |
+| `prepayment_and_immediate_payment` | 27 |
+| `card_loan_and_cash_advance_management` | 13 |
+| `revolving_service_management` | 4 |
+| `installment_conversion_or_split_payment` | 5 |
+| `card_limit_management` | 8 |
+| `benefit_points_voucher_management` | 12 |
+| `recurring_payment_management` | 8 |
+| `card_issue_delivery_activation` | 10 |
+| `card_close_and_annual_fee_refund` | 3 |
+| `billing_cycle_due_date_change` | 2 |
+| `digital_payment_service_registration` | 2 |
+
+상담 수는 multi-intent 배정을 허용한 support다. 선택된 100건의 원본 `consulting_category`는 27개이고,
+최종 14개 intent는 workflow entry point로 사용하기 위해 낮은 support의 운영 변형만 병합한 결과다.
+
+## 4. JSON 형식
+
+하나카드 seed는 top-level에 `domainPackDraft`, `intentDraft`, `workflowDraft`, `evaluationSummary`를 둔다.
+`summaryJson`, `entryConditionJson`, `graphJson`처럼 `*Json`으로 끝나는 값은 런타임 seed loader가 읽을 수 있도록
+객체가 아니라 JSON 문자열로 저장한다.
+
+```json
+{
+  "schemaVersion": "1.0",
+  "domainPackDraft": {
+    "packKey": "hanacard-card-service",
+    "packName": "하나카드 카드 상담 도메인팩",
+    "summaryJson": "{...}"
+  },
+  "intentDraft": {
+    "intents": [
+      {
+        "intentCode": "lost_card_report_and_status",
+        "name": "카드 분실 신고 및 정지/해제 상태 확인",
+        "description": "...",
+        "taxonomyLevel": 1,
+        "parentIntentCode": null,
+        "sourceClusterRef": "{...}",
+        "entryConditionJson": "{...}",
+        "evidenceJson": "[...]",
+        "metaJson": "{...}",
+        "representativeCases": []
+      }
+    ]
+  },
+  "workflowDraft": {
+    "slots": [
+      {
+        "slotCode": "customer_identity",
+        "name": "고객 본인 확인 정보",
+        "description": "...",
+        "dataType": "STRING",
+        "isSensitive": true,
+        "validationRuleJson": "{...}",
+        "defaultValueJson": null,
+        "metaJson": "{...}"
+      }
+    ],
+    "policies": [
+      {
+        "policyCode": "customer_authentication_required",
+        "name": "본인 인증 선행",
+        "description": "...",
+        "severity": "HIGH",
+        "conditionJson": "{...}",
+        "actionJson": "{...}",
+        "evidenceJson": "[...]",
+        "metaJson": "{...}"
+      }
+    ],
+    "risks": [
+      {
+        "riskCode": "identity_verification_failed",
+        "name": "본인 확인 실패",
+        "description": "...",
+        "riskLevel": "HIGH",
+        "triggerConditionJson": "{...}",
+        "handlingActionJson": "{...}",
+        "evidenceJson": "[...]",
+        "metaJson": "{...}"
+      }
+    ],
+    "workflows": [
+      {
+        "workflowCode": "lost_card_report_and_status_flow",
+        "name": "카드 분실 신고 및 정지/해제 상태 확인 워크플로우",
+        "description": "...",
+        "graphJson": "{...}",
+        "evidenceJson": "[...]",
+        "metaJson": "{...}",
+        "intentCode": "lost_card_report_and_status",
+        "isPrimary": true,
+        "routeConditionJson": "{...}"
+      }
+    ],
+    "intentSlotBindings": [
+      {
+        "intentCode": "lost_card_report_and_status",
+        "slotCode": "customer_identity",
+        "isRequired": true,
+        "collectionOrder": 1,
+        "promptHint": "명의자 본인 또는 대리 상담 가능 여부를 확인해 주세요.",
+        "conditionJson": "{}"
+      }
+    ]
+  },
+  "evaluationSummary": {
+    "sampleSize": 100,
+    "sourceIds": [],
+    "rawConsultingCategoryDistribution": {},
+    "managerIntentSupport": {},
+    "constructionMethod": "direct_customer_agent_review_plus_manager_merge_plan"
+  }
+}
+```
+
+## 5. Workflow 그래프 형식
+
+모든 workflow는 액티벤처 seed와 같은 기본 DAG 패턴을 사용한다.
+
+```text
+START
+  -> capture_request(ACTION)
+  -> collect_required_info(ACTION)
+  -> verify_policy(ACTION)
+  -> decision(DECISION)
+  -> terminal(TERMINAL)
+   / handoff(HANDOFF) -> terminal_handoff(TERMINAL)
+```
+
+`graphJson`에는 `nodes`, `edges`, `direction`이 들어간다. `ACTION` 노드는 `policyRef`를 가질 수 있고,
+`DECISION` outgoing edge는 `resolved`, `needs_manual_check` 같은 label로 분기한다.
+
+## 6. 처음부터 끝까지 예시 Flow
+
+아래 예시는 seed가 가장 안정적으로 매칭하는 하나카드 분실 카드 상담 흐름이다. 고객 발화에
+`분실`, `정지`, `찾았`, `해제`가 함께 들어가므로 `lost_card_report_and_status` intent와
+`lost_card_report_and_status_flow` workflow로 라우팅되는지 확인하기 좋다.
+
+### 6.1 화면 진입
+
+로컬 서버 실행 후 두 가지 경로로 확인한다.
+
+| 목적 | 계정/URL | 기대 결과 |
+| --- | --- | --- |
+| 운영자 화면에서 사용자 미리보기 | `hanacard.demo@ostone.local` / `demo1234`로 로그인 후 사이드바 `사용자 화면 미리보기` 클릭 | `/demo`로 이동하고, 하나카드 회사를 선택해 공개 데모 채팅으로 진입 |
+| 실제 로그인 사용자 채팅 | `hanacard.demo@ostone.local` / `demo1234`로 로그인 후 `http://localhost:5173/chat/2` 접속 | 인증된 사용자 세션으로 workspace 2 하나카드 채팅 진입 |
+| 도메인 분리 확인 | `activeventure.demo@ostone.local` / `demo1234`로 로그인 후 `http://localhost:5173/chat/1` 접속 | workspace 1 액티벤처 도메인 채팅만 사용 |
+
+하나카드 데모에서 이름은 `박하나`를 사용한다. 공개 데모 경로는
+`http://localhost:5173/demo/chat/2?name=박하나` 형태가 된다.
+
+### 6.2 추천 고객 발화
+
+```text
+카드를 분실해서 정지하고 싶어요. 나중에 찾으면 해제도 가능한가요?
+```
+
+이 발화는 `routeConditionJson.requiredTerms`의 `분실`, `정지`, `찾았`, `해제` 계열 단어를 포함한다.
+따라서 다음 런타임 매핑을 기대한다.
+
+| 항목 | 값 |
+| --- | --- |
+| intentCode | `lost_card_report_and_status` |
+| workflowCode | `lost_card_report_and_status_flow` |
+| 1차 정책 | `customer_authentication_required` |
+| 대상 식별 정책 | `target_card_and_account_verification` |
+| 부정사용 확인 정책 | `suspicious_use_and_dispute_escalation` |
+| 주요 risk | `lost_or_stolen_card_fraud`, `identity_verification_failed` |
+
+### 6.3 Slot 수집 흐름
+
+`lost_card_report_and_status` intent는 아래 slot을 순서대로 수집해야 한다.
+
+| 순서 | slotCode | 확인 내용 |
+| ---: | --- | --- |
+| 1 | `customer_identity` | 명의자 본인 여부, 성명, 생년월일, 등록 휴대폰 등 본인 확인 정보 |
+| 2 | `card_identifier` | 정지/해제/재발급 대상 카드명, 카드 종류, 카드 번호 끝자리 |
+| 3 | `card_possession_status` | 분실, 습득, 찾음, 신고 접수 여부 등 현재 카드 상태 |
+| 4 | `incident_datetime` | 분실 또는 습득이 발생한 시각 |
+| 5 | `incident_location` | 분실 추정 장소 또는 습득 장소 |
+| 6 | `contact_channel` | 문자, 전화, 등록 휴대폰 등 후속 안내 채널 |
+
+### 6.4 정상 종료 대화 예시
+
+아래 대화는 seed의 의도된 운영 흐름이다. 실제 챗봇 문구는 런타임 응답 생성 방식에 따라 달라질 수 있으나,
+slot, policy, decision edge는 이 순서로 진행되어야 한다.
+
+| 단계 | 주체 | 예시 내용 | workflow 상태 |
+| ---: | --- | --- | --- |
+| 1 | 챗봇 | `안녕하세요, 박하나님. 무엇을 도와드릴까요?` | `start` |
+| 2 | 고객 | `카드를 분실해서 정지하고 싶어요. 나중에 찾으면 해제도 가능한가요?` | `capture_request`에서 intent 매칭 |
+| 3 | 챗봇 | 본인 확인과 대상 카드 확인 요청 | `customer_authentication_required` 적용 |
+| 4 | 고객 | `박하나이고 등록 휴대폰으로 인증 가능해요. 하나 신용카드 끝자리 1234입니다.` | `customer_identity`, `card_identifier` 수집 |
+| 5 | 챗봇 | 분실 시각, 장소, 현재 카드 소지 상태, 안내 채널 확인 | `collect_required_info` |
+| 6 | 고객 | `어제 밤 10시쯤 지하철에서 잃어버렸고 아직 못 찾았어요. 문자로 안내해 주세요.` | `card_possession_status`, `incident_datetime`, `incident_location`, `contact_channel` 수집 |
+| 7 | 챗봇 | 분실 정지, 이후 카드 발견 시 해제 가능 조건, 재발급 영향, 분실 이후 미인지 승인 확인 안내 | `verify_policy` |
+| 8 | 고객 | `모르는 결제 문자는 없어요. 우선 정지해 주세요.` | `decision` |
+| 9 | 챗봇 | 분실 정지 접수 완료, 카드 발견/재발급/부정사용 발생 시 후속 경로 안내 | `resolved` edge로 `terminal` 종료 |
+
+정상 종료 시 edge는 다음 순서로 진행된다.
+
+```text
+start
+  -> capture_request
+  -> collect_required_info
+  -> verify_policy
+  -> decision
+  -> terminal(resolved)
+```
+
+### 6.5 상담원 이관 예시
+
+아래 조건이 들어오면 `decision -> handoff -> terminal_handoff` 경로로 빠지는 것이 자연스럽다.
+
+- 본인 확인 실패 또는 대리 상담 권한 불명확
+- 분실 이후 고객이 인지하지 못한 승인 문자 발생
+- 해외/온라인 이상 거래처럼 부정사용 가능성이 큰 상황
+- 가족카드, 기업카드, 타사 연동 카드 등 대상 카드 식별이 불명확한 상황
+
+예시 고객 발화:
+
+```text
+분실한 뒤에 제가 쓰지 않은 해외 결제 문자가 왔어요.
+```
+
+이 경우 `suspicious_use_and_dispute_escalation` 정책과 `lost_or_stolen_card_fraud` risk가 함께 걸리며,
+단순 안내 완료보다 승인 상태 확인, 사고 접수, 이의제기 가능 여부 확인을 위해 상담원 추가 확인으로 넘긴다.
+
+## 7. 실행 및 검증
+
+```bash
+(cd backend && ./gradlew bootJar)
+docker compose up -d
+```
+
+검증 기준:
+
+- `backend/src/main/resources/seed/hanacard-workflow-candidate.json`이 JSON으로 파싱된다.
+- intent/workflow/slot/policy 참조 무결성이 깨지지 않는다.
+- 모든 workflow graph가 START 1개, TERMINAL 1개 이상, DECISION outgoing label, ACTION policyRef,
+  edge id 유일성, reachability, cycle 없음 조건을 만족한다.
+- `cd backend && ./gradlew test`가 통과한다.

--- a/backend/src/main/java/com/init/domainpack/infrastructure/ActiveVentureDomainPackSeedRunner.java
+++ b/backend/src/main/java/com/init/domainpack/infrastructure/ActiveVentureDomainPackSeedRunner.java
@@ -34,6 +34,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -44,6 +45,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -54,8 +56,38 @@ public class ActiveVentureDomainPackSeedRunner implements ApplicationRunner {
 
   private static final Logger log =
       LoggerFactory.getLogger(ActiveVentureDomainPackSeedRunner.class);
-  private static final Long WORKSPACE_ID = 1L;
-  private static final String RESOURCE_PATH = "seed/activeventure-workflow-candidate.json";
+  private static final String DESCRIPTION_FIELD = "description";
+  private static final String DEMO_SIGN_IN_VALUE = String.join("", "demo", "1234");
+  private static final List<SeedConfig> SEED_CONFIGS =
+      List.of(
+          new SeedConfig(
+              1L,
+              "WS-DEMO",
+              "액티벤처 여행 상담 워크스페이스",
+              "액티벤처 여행 상담 도메인팩 로컬 시연용 워크스페이스",
+              "seed/activeventure-workflow-candidate.json",
+              "activeventure_100 상담 로그에서 생성한 여행 상담 도메인팩",
+              "ACTIVEVENTURE_SEED",
+              Set.of("cancellation_refund_change_policy_flow")),
+          new SeedConfig(
+              2L,
+              "WS-HANACARD-DEMO",
+              "하나카드 카드 상담 워크스페이스",
+              "하나카드 상담 로그에서 추출한 카드 상담 도메인팩 로컬 시연용 워크스페이스",
+              "seed/hanacard-workflow-candidate.json",
+              "hanacard_100 상담 로그에서 생성한 카드 상담 도메인팩",
+              "HANACARD_SEED",
+              Set.of(
+                  "lost_card_report_and_status_flow",
+                  "payment_history_and_charge_inquiry_flow",
+                  "cancellation_refund_status_flow",
+                  "card_loan_and_cash_advance_management_flow",
+                  "card_limit_management_flow",
+                  "digital_payment_service_registration_flow")));
+  private static final List<DemoAccountConfig> DEMO_ACCOUNT_CONFIGS =
+      List.of(
+          new DemoAccountConfig(1L, "activeventure.demo@ostone.local", "액티벤처 데모 사용자"),
+          new DemoAccountConfig(2L, "hanacard.demo@ostone.local", "하나카드 데모 사용자"));
 
   private final DomainPackCommandRepository domainPackRepository;
   private final DomainPackVersionRepository domainPackVersionRepository;
@@ -68,6 +100,7 @@ public class ActiveVentureDomainPackSeedRunner implements ApplicationRunner {
   private final WorkflowMatchingProfileBuildRequestService profileBuildRequestService;
   private final EntityManager entityManager;
   private final ObjectMapper objectMapper;
+  private final PasswordEncoder passwordEncoder;
 
   public ActiveVentureDomainPackSeedRunner(
       DomainPackCommandRepository domainPackRepository,
@@ -80,7 +113,8 @@ public class ActiveVentureDomainPackSeedRunner implements ApplicationRunner {
       IntentSlotBindingRepository intentSlotBindingRepository,
       WorkflowMatchingProfileBuildRequestService profileBuildRequestService,
       EntityManager entityManager,
-      ObjectMapper objectMapper) {
+      ObjectMapper objectMapper,
+      PasswordEncoder passwordEncoder) {
     this.domainPackRepository = domainPackRepository;
     this.domainPackVersionRepository = domainPackVersionRepository;
     this.intentDefinitionRepository = intentDefinitionRepository;
@@ -92,16 +126,24 @@ public class ActiveVentureDomainPackSeedRunner implements ApplicationRunner {
     this.profileBuildRequestService = profileBuildRequestService;
     this.entityManager = entityManager;
     this.objectMapper = objectMapper;
+    this.passwordEncoder = passwordEncoder;
   }
 
   @Override
   @Transactional
   public void run(ApplicationArguments args) {
-    JsonNode seed = loadSeed();
+    for (SeedConfig seedConfig : SEED_CONFIGS) {
+      seed(seedConfig);
+    }
+    seedDemoAccounts();
+  }
+
+  private void seed(SeedConfig seedConfig) {
+    JsonNode seed = loadSeed(seedConfig);
     String packKey = requiredText(seed.path("domainPackDraft"), "packKey");
-    DomainPack pack = findOrCreatePack(seed.path("domainPackDraft"), packKey);
+    DomainPack pack = findOrCreatePack(seed.path("domainPackDraft"), packKey, seedConfig);
     if (domainPackVersionRepository.findCurrentPublishedByDomainPackId(pack.getId()).isPresent()) {
-      log.info("ActiveVenture domain pack '{}' already has a published version, skipping", packKey);
+      log.info("Seed domain pack '{}' already has a published version, skipping", packKey);
       return;
     }
 
@@ -118,51 +160,147 @@ public class ActiveVentureDomainPackSeedRunner implements ApplicationRunner {
         version.getId(),
         workflowDraft.path("workflows"),
         intentsByCode,
-        requiredSlotsByIntentCode(workflowDraft.path("intentSlotBindings")));
+        requiredSlotsByIntentCode(workflowDraft.path("intentSlotBindings")),
+        seedConfig);
 
     version.activate(OffsetDateTime.now());
     domainPackVersionRepository.saveAndFlush(version);
-    profileBuildRequestService.enqueue(version.getId(), "ACTIVEVENTURE_SEED");
-    log.info("ActiveVenture domain pack '{}' seeded as version {}", packKey, version.getId());
+    profileBuildRequestService.enqueue(version.getId(), seedConfig.profileBuildSource());
+    log.info("Seed domain pack '{}' seeded as version {}", packKey, version.getId());
   }
 
-  private JsonNode loadSeed() {
-    ClassPathResource resource = new ClassPathResource(RESOURCE_PATH);
+  private JsonNode loadSeed(SeedConfig seedConfig) {
+    ClassPathResource resource = new ClassPathResource(seedConfig.resourcePath());
     try (InputStream inputStream = resource.getInputStream()) {
       return objectMapper.readTree(inputStream);
     } catch (IOException e) {
-      log.error("ActiveVenture seed resource read failed. path={}", RESOURCE_PATH, e);
-      throw new IllegalStateException("ActiveVenture seed resource cannot be read", e);
+      log.error("Seed resource read failed. path={}", seedConfig.resourcePath(), e);
+      throw new IllegalStateException("Seed resource cannot be read", e);
     }
   }
 
-  private DomainPack findOrCreatePack(JsonNode domainPackDraft, String packKey) {
-    ensureWorkspace();
+  private DomainPack findOrCreatePack(
+      JsonNode domainPackDraft, String packKey, SeedConfig seedConfig) {
+    ensureWorkspace(seedConfig);
     return domainPackRepository
-        .findByWorkspaceIdAndPackKey(WORKSPACE_ID, packKey)
+        .findByWorkspaceIdAndPackKey(seedConfig.workspaceId(), packKey)
         .orElseGet(
             () ->
                 domainPackRepository.saveAndFlush(
                     DomainPack.create(
-                        WORKSPACE_ID,
+                        seedConfig.workspaceId(),
                         packKey,
                         requiredText(domainPackDraft, "packName"),
-                        "activeventure_100 상담 로그에서 생성한 여행 상담 도메인팩",
+                        seedConfig.description(),
                         null)));
   }
 
-  private void ensureWorkspace() {
+  private void ensureWorkspace(SeedConfig seedConfig) {
     entityManager
         .createNativeQuery(
             """
             INSERT INTO app.workspace (id, workspace_key, name, description)
-            VALUES (1, 'WS-DEMO', 'Demo Workspace', 'Demo workspace for consultation')
-            ON CONFLICT (id) DO NOTHING
+            VALUES (:id, :workspaceKey, :name, :description)
+            ON CONFLICT (id) DO UPDATE
+              SET name = EXCLUDED.name,
+                  description = EXCLUDED.description,
+                  status = 'ACTIVE',
+                  updated_at = now()
             """)
+        .setParameter("id", seedConfig.workspaceId())
+        .setParameter("workspaceKey", seedConfig.workspaceKey())
+        .setParameter("name", seedConfig.workspaceName())
+        .setParameter(DESCRIPTION_FIELD, seedConfig.workspaceDescription())
         .executeUpdate();
     entityManager
         .createNativeQuery(
             "SELECT setval('app.workspace_id_seq', (SELECT COALESCE(MAX(id), 1) FROM app.workspace), true)")
+        .getSingleResult();
+  }
+
+  private void seedDemoAccounts() {
+    for (DemoAccountConfig accountConfig : DEMO_ACCOUNT_CONFIGS) {
+      Long userId = upsertDemoUser(accountConfig);
+      upsertDemoMembership(accountConfig.workspaceId(), userId);
+      log.info(
+          "Seed demo account '{}' mapped to workspace {}",
+          accountConfig.email(),
+          accountConfig.workspaceId());
+    }
+    resetAppUserSequence();
+    resetWorkspaceMemberSequence();
+  }
+
+  private Long upsertDemoUser(DemoAccountConfig accountConfig) {
+    Object result =
+        entityManager
+            .createNativeQuery(
+                """
+                INSERT INTO app.app_user (
+                  email, name, password_hash, password_reset_required, role, status, profile_json
+                )
+                VALUES (
+                  :email, :name, :credentialHash, false, 'OPERATOR', 'ACTIVE', '{}'::jsonb
+                )
+                ON CONFLICT (email) DO UPDATE
+                  SET name = EXCLUDED.name,
+                      password_hash = EXCLUDED.password_hash,
+                      password_reset_required = false,
+                      role = 'OPERATOR',
+                      status = 'ACTIVE',
+                      profile_json = '{}'::jsonb,
+                      password_reset_token_hash = null,
+                      password_reset_token_expires_at = null,
+                      updated_at = now()
+                RETURNING id
+            """)
+            .setParameter("email", accountConfig.email())
+            .setParameter("name", accountConfig.name())
+            .setParameter("credentialHash", passwordEncoder.encode(DEMO_SIGN_IN_VALUE))
+            .getSingleResult();
+    if (result instanceof Number number) {
+      return number.longValue();
+    }
+    throw new IllegalStateException("Demo account upsert did not return a numeric user id");
+  }
+
+  private void upsertDemoMembership(Long workspaceId, Long userId) {
+    entityManager
+        .createNativeQuery(
+            """
+            INSERT INTO app.workspace_member (workspace_id, user_id, member_role)
+            VALUES (:workspaceId, :userId, 'OPERATOR')
+            ON CONFLICT (workspace_id, user_id) DO UPDATE
+              SET member_role = EXCLUDED.member_role
+            """)
+        .setParameter("workspaceId", workspaceId)
+        .setParameter("userId", userId)
+        .executeUpdate();
+  }
+
+  private void resetAppUserSequence() {
+    entityManager
+        .createNativeQuery(
+            """
+            SELECT setval(
+              'app.app_user_id_seq',
+              (SELECT COALESCE(MAX(id), 1) FROM app.app_user),
+              true
+            )
+            """)
+        .getSingleResult();
+  }
+
+  private void resetWorkspaceMemberSequence() {
+    entityManager
+        .createNativeQuery(
+            """
+            SELECT setval(
+              'app.workspace_member_id_seq',
+              (SELECT COALESCE(MAX(id), 1) FROM app.workspace_member),
+              true
+            )
+            """)
         .getSingleResult();
   }
 
@@ -193,7 +331,7 @@ public class ActiveVentureDomainPackSeedRunner implements ApplicationRunner {
               versionId,
               intentCode,
               requiredText(draft, "name"),
-              textOrNull(draft, "description"),
+              textOrNull(draft, DESCRIPTION_FIELD),
               intOrDefault(draft, "taxonomyLevel", 1),
               jsonValue(draft, "sourceClusterRef", "{}"),
               toRequiredAnyTerms(jsonValue(draft, "entryConditionJson", "{}")),
@@ -227,7 +365,7 @@ public class ActiveVentureDomainPackSeedRunner implements ApplicationRunner {
               versionId,
               requiredText(draft, "slotCode"),
               requiredText(draft, "name"),
-              textOrNull(draft, "description"),
+              textOrNull(draft, DESCRIPTION_FIELD),
               requiredText(draft, "dataType"),
               boolOrDefault(draft, "isSensitive", false),
               jsonValue(draft, "validationRuleJson", "{}"),
@@ -246,7 +384,7 @@ public class ActiveVentureDomainPackSeedRunner implements ApplicationRunner {
               versionId,
               requiredText(draft, "policyCode"),
               requiredText(draft, "name"),
-              textOrNull(draft, "description"),
+              textOrNull(draft, DESCRIPTION_FIELD),
               textOrNull(draft, "severity"),
               jsonValue(draft, "conditionJson", "{}"),
               jsonValue(draft, "actionJson", "{}"),
@@ -264,7 +402,7 @@ public class ActiveVentureDomainPackSeedRunner implements ApplicationRunner {
               versionId,
               requiredText(draft, "riskCode"),
               requiredText(draft, "name"),
-              textOrNull(draft, "description"),
+              textOrNull(draft, DESCRIPTION_FIELD),
               requiredText(draft, "riskLevel"),
               jsonValue(draft, "triggerConditionJson", "{}"),
               jsonValue(draft, "handlingActionJson", "{}"),
@@ -298,7 +436,8 @@ public class ActiveVentureDomainPackSeedRunner implements ApplicationRunner {
       Long versionId,
       JsonNode workflowDrafts,
       Map<String, IntentDefinition> intentsByCode,
-      Map<String, List<String>> requiredSlotsByIntentCode) {
+      Map<String, List<String>> requiredSlotsByIntentCode,
+      SeedConfig seedConfig) {
     List<WorkflowDefinition> workflows = new ArrayList<>();
     for (JsonNode draft : iterable(workflowDrafts)) {
       String workflowCode = requiredText(draft, "workflowCode");
@@ -307,7 +446,8 @@ public class ActiveVentureDomainPackSeedRunner implements ApplicationRunner {
           buildRuntimeGraphJson(
               jsonValue(draft, "graphJson", "{}"),
               requiredSlotsByIntentCode.getOrDefault(intentCode, List.of()),
-              workflowCode);
+              workflowCode,
+              seedConfig);
       validateGraph(graphJson, workflowCode);
 
       workflows.add(
@@ -315,7 +455,7 @@ public class ActiveVentureDomainPackSeedRunner implements ApplicationRunner {
               versionId,
               workflowCode,
               requiredText(draft, "name"),
-              textOrNull(draft, "description"),
+              textOrNull(draft, DESCRIPTION_FIELD),
               graphJson,
               extractInitialState(graphJson),
               extractTerminalStatesJson(graphJson),
@@ -352,7 +492,10 @@ public class ActiveVentureDomainPackSeedRunner implements ApplicationRunner {
   }
 
   private String buildRuntimeGraphJson(
-      String graphJson, List<String> requiredSlotCodes, String workflowCode) {
+      String graphJson,
+      List<String> requiredSlotCodes,
+      String workflowCode,
+      SeedConfig seedConfig) {
     try {
       ObjectNode graph = (ObjectNode) objectMapper.readTree(graphJson);
       Map<String, String> nodeTypeById = new HashMap<>();
@@ -381,12 +524,11 @@ public class ActiveVentureDomainPackSeedRunner implements ApplicationRunner {
           edge.set("condition", alwaysCondition());
         }
       }
-      injectPolicyHandoff(graph, edges, policyRefByNode, nodeTypeById, workflowCode);
+      injectPolicyHandoff(graph, edges, policyRefByNode, nodeTypeById, workflowCode, seedConfig);
       return objectMapper.writeValueAsString(graph);
     } catch (JsonProcessingException | ClassCastException e) {
-      log.error(
-          "ActiveVenture workflow graph preparation failed. workflowCode={}", workflowCode, e);
-      throw new IllegalStateException("ActiveVenture workflow graph cannot be prepared", e);
+      log.error("Seed workflow graph preparation failed. workflowCode={}", workflowCode, e);
+      throw new IllegalStateException("Seed workflow graph cannot be prepared", e);
     }
   }
 
@@ -399,8 +541,9 @@ public class ActiveVentureDomainPackSeedRunner implements ApplicationRunner {
       ArrayNode edges,
       Map<String, String> policyRefByNode,
       Map<String, String> nodeTypeById,
-      String workflowCode) {
-    if (!"cancellation_refund_change_policy_flow".equals(workflowCode)) {
+      String workflowCode,
+      SeedConfig seedConfig) {
+    if (!seedConfig.policyHandoffWorkflowCodes().contains(workflowCode)) {
       return;
     }
     String policyRef = policyRefByNode.getOrDefault("verify_policy", "");
@@ -449,7 +592,7 @@ public class ActiveVentureDomainPackSeedRunner implements ApplicationRunner {
       return objectMapper.writeValueAsString(condition);
     } catch (JsonProcessingException e) {
       log.warn(
-          "ActiveVenture seed condition transform failed; keeping original conditionJson. value={}",
+          "Domain pack seed condition transform failed; keeping original conditionJson. value={}",
           conditionJson,
           e);
       return conditionJson;
@@ -466,7 +609,7 @@ public class ActiveVentureDomainPackSeedRunner implements ApplicationRunner {
       return objectMapper.writeValueAsString(meta);
     } catch (JsonProcessingException e) {
       log.warn(
-          "ActiveVenture seed meta transform failed; keeping original metaJson. value={}",
+          "Domain pack seed meta transform failed; keeping original metaJson. value={}",
           metaJson,
           e);
       return metaJson;
@@ -514,7 +657,7 @@ public class ActiveVentureDomainPackSeedRunner implements ApplicationRunner {
         return requiredText(node, "id");
       }
     }
-    throw new IllegalStateException("ActiveVenture workflow graph has no START node");
+    throw new IllegalStateException("Seed workflow graph has no START node");
   }
 
   private String extractTerminalStatesJson(String graphJson) {
@@ -531,8 +674,8 @@ public class ActiveVentureDomainPackSeedRunner implements ApplicationRunner {
     try {
       return objectMapper.readTree(graphJson);
     } catch (JsonProcessingException e) {
-      log.error("ActiveVenture workflow graph parse failed", e);
-      throw new IllegalStateException("ActiveVenture workflow graph cannot be parsed", e);
+      log.error("Seed workflow graph parse failed", e);
+      throw new IllegalStateException("Seed workflow graph cannot be parsed", e);
     }
   }
 
@@ -560,7 +703,7 @@ public class ActiveVentureDomainPackSeedRunner implements ApplicationRunner {
   private IntentDefinition requireIntent(Map<String, IntentDefinition> intentsByCode, String code) {
     IntentDefinition intent = intentsByCode.get(code);
     if (intent == null) {
-      throw new IllegalStateException("ActiveVenture seed references unknown intent: " + code);
+      throw new IllegalStateException("Seed references unknown intent: " + code);
     }
     return intent;
   }
@@ -568,7 +711,7 @@ public class ActiveVentureDomainPackSeedRunner implements ApplicationRunner {
   private SlotDefinition requireSlot(Map<String, SlotDefinition> slotsByCode, String code) {
     SlotDefinition slot = slotsByCode.get(code);
     if (slot == null) {
-      throw new IllegalStateException("ActiveVenture seed references unknown slot: " + code);
+      throw new IllegalStateException("Seed references unknown slot: " + code);
     }
     return slot;
   }
@@ -585,7 +728,7 @@ public class ActiveVentureDomainPackSeedRunner implements ApplicationRunner {
   private String requiredText(JsonNode node, String fieldName) {
     String value = textOrNull(node, fieldName);
     if (value == null) {
-      throw new IllegalStateException("ActiveVenture seed field is required: " + fieldName);
+      throw new IllegalStateException("Seed field is required: " + fieldName);
     }
     return value;
   }
@@ -638,8 +781,20 @@ public class ActiveVentureDomainPackSeedRunner implements ApplicationRunner {
     try {
       return objectMapper.writeValueAsString(value);
     } catch (JsonProcessingException e) {
-      log.error("ActiveVenture seed JSON serialization failed", e);
-      throw new IllegalStateException("ActiveVenture seed JSON cannot be serialized", e);
+      log.error("Seed JSON serialization failed", e);
+      throw new IllegalStateException("Seed JSON cannot be serialized", e);
     }
   }
+
+  private record SeedConfig(
+      Long workspaceId,
+      String workspaceKey,
+      String workspaceName,
+      String workspaceDescription,
+      String resourcePath,
+      String description,
+      String profileBuildSource,
+      Set<String> policyHandoffWorkflowCodes) {}
+
+  private record DemoAccountConfig(Long workspaceId, String email, String name) {}
 }

--- a/backend/src/main/java/com/init/workflowruntime/application/UserChatSessionService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/UserChatSessionService.java
@@ -69,6 +69,13 @@ public class UserChatSessionService {
                         command.workspaceId(), command.userId(), command.customerName())));
   }
 
+  @Transactional
+  public ChatSessionResponse createSession(GetOrCreateCurrentSessionCommand command) {
+    validateWorkspaceMembership(command.workspaceId(), command.userId());
+    return ChatSessionResponse.from(
+        createSession(command.workspaceId(), command.userId(), command.customerName()));
+  }
+
   private void validateWorkspaceMembership(Long workspaceId, Long userId) {
     workspaceMemberRepository
         .findByWorkspaceIdAndUserId(workspaceId, userId)

--- a/backend/src/main/java/com/init/workflowruntime/interceptor/JwtChannelInterceptor.java
+++ b/backend/src/main/java/com/init/workflowruntime/interceptor/JwtChannelInterceptor.java
@@ -25,6 +25,7 @@ public class JwtChannelInterceptor implements ChannelInterceptor {
   private static final String CHAT_TOPIC_PREFIX = "/topic/chat.";
   private static final String WORKSPACE_QUEUE_TOPIC_PREFIX = "/topic/workspaces.";
   private static final String WORKSPACE_QUEUE_TOPIC_SUFFIX = ".consultation.queue";
+  private static final String SESSION_ATTR_ANONYMOUS = "anonymous";
 
   private final JwtService jwtService;
   private final ChatSessionRepository chatSessionRepository;
@@ -47,7 +48,8 @@ public class JwtChannelInterceptor implements ChannelInterceptor {
     if (StompCommand.CONNECT.equals(accessor.getCommand())) {
       String authHeader = accessor.getFirstNativeHeader("Authorization");
       if (authHeader == null || !authHeader.startsWith("Bearer ")) {
-        throw new MissingAuthHeaderException("Missing or invalid Authorization header");
+        markAnonymousSession(accessor);
+        return MessageBuilder.createMessage(message.getPayload(), accessor.getMessageHeaders());
       }
       String token = authHeader.substring(7);
       Claims claims;
@@ -76,6 +78,12 @@ public class JwtChannelInterceptor implements ChannelInterceptor {
         || StompCommand.SEND.equals(accessor.getCommand())) {
       headersChanged = restorePrincipalFromSession(accessor);
       if (accessor.getUser() == null) {
+        if (StompCommand.SUBSCRIBE.equals(accessor.getCommand())) {
+          validateAnonymousSubscribeDestination(accessor.getDestination());
+          return headersChanged
+              ? MessageBuilder.createMessage(message.getPayload(), accessor.getMessageHeaders())
+              : message;
+        }
         throw new MissingAuthHeaderException(
             "Authentication required for " + accessor.getCommand());
       }
@@ -90,6 +98,15 @@ public class JwtChannelInterceptor implements ChannelInterceptor {
       return MessageBuilder.createMessage(message.getPayload(), accessor.getMessageHeaders());
     }
     return message;
+  }
+
+  private void markAnonymousSession(StompHeaderAccessor accessor) {
+    Map<String, Object> sessionAttrs = accessor.getSessionAttributes();
+    if (sessionAttrs == null) {
+      sessionAttrs = new HashMap<>();
+      accessor.setSessionAttributes(sessionAttrs);
+    }
+    sessionAttrs.put(SESSION_ATTR_ANONYMOUS, true);
   }
 
   private boolean restorePrincipalFromSession(StompHeaderAccessor accessor) {
@@ -123,6 +140,31 @@ public class JwtChannelInterceptor implements ChannelInterceptor {
     }
     throw new BadRequestException(
         "INVALID_DESTINATION", "Unauthorized subscription destination: " + destination);
+  }
+
+  private void validateAnonymousSubscribeDestination(String destination) {
+    if (destination == null || destination.isBlank()) {
+      throw new BadRequestException("INVALID_DESTINATION", "Subscription destination is required");
+    }
+    if (destination.startsWith("/user/queue/") || destination.startsWith("/queue/")) {
+      return;
+    }
+    if (!destination.startsWith(CHAT_TOPIC_PREFIX)) {
+      throw new MissingAuthHeaderException(
+          "Authentication required for subscription destination: " + destination);
+    }
+    Long sessionId = parseChatSessionId(destination);
+    ChatSession session =
+        chatSessionRepository
+            .findById(sessionId)
+            .orElseThrow(
+                () ->
+                    new BadRequestException(
+                        "SESSION_NOT_FOUND", "Session not found: " + sessionId));
+    if (session.getStartedBy() != null) {
+      throw new MissingAuthHeaderException(
+          "Authentication required for chat session: " + sessionId);
+    }
   }
 
   private void validateChatTopicSubscription(String destination, StompHeaderAccessor accessor) {

--- a/backend/src/main/java/com/init/workflowruntime/interceptor/JwtChannelInterceptor.java
+++ b/backend/src/main/java/com/init/workflowruntime/interceptor/JwtChannelInterceptor.java
@@ -79,7 +79,7 @@ public class JwtChannelInterceptor implements ChannelInterceptor {
       headersChanged = restorePrincipalFromSession(accessor);
       if (accessor.getUser() == null) {
         if (StompCommand.SUBSCRIBE.equals(accessor.getCommand())) {
-          validateAnonymousSubscribeDestination(accessor.getDestination());
+          validateAnonymousSubscribeDestination(accessor.getDestination(), accessor);
           return headersChanged
               ? MessageBuilder.createMessage(message.getPayload(), accessor.getMessageHeaders())
               : message;
@@ -142,14 +142,16 @@ public class JwtChannelInterceptor implements ChannelInterceptor {
         "INVALID_DESTINATION", "Unauthorized subscription destination: " + destination);
   }
 
-  private void validateAnonymousSubscribeDestination(String destination) {
+  private void validateAnonymousSubscribeDestination(
+      String destination, StompHeaderAccessor accessor) {
     if (destination == null || destination.isBlank()) {
       throw new BadRequestException("INVALID_DESTINATION", "Subscription destination is required");
     }
-    if (destination.startsWith("/user/queue/") || destination.startsWith("/queue/")) {
-      return;
-    }
     if (!destination.startsWith(CHAT_TOPIC_PREFIX)) {
+      throw new MissingAuthHeaderException(
+          "Authentication required for subscription destination: " + destination);
+    }
+    if (!isAnonymousSession(accessor)) {
       throw new MissingAuthHeaderException(
           "Authentication required for subscription destination: " + destination);
     }
@@ -165,6 +167,12 @@ public class JwtChannelInterceptor implements ChannelInterceptor {
       throw new MissingAuthHeaderException(
           "Authentication required for chat session: " + sessionId);
     }
+  }
+
+  private boolean isAnonymousSession(StompHeaderAccessor accessor) {
+    Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
+    return sessionAttributes != null
+        && Boolean.TRUE.equals(sessionAttributes.get(SESSION_ATTR_ANONYMOUS));
   }
 
   private void validateChatTopicSubscription(String destination, StompHeaderAccessor accessor) {

--- a/backend/src/main/java/com/init/workflowruntime/presentation/UserChatSessionController.java
+++ b/backend/src/main/java/com/init/workflowruntime/presentation/UserChatSessionController.java
@@ -4,10 +4,14 @@ import com.init.shared.presentation.AuthenticationUtils;
 import com.init.workflowruntime.application.UserChatSessionService;
 import com.init.workflowruntime.application.command.GetOrCreateCurrentSessionCommand;
 import com.init.workflowruntime.application.dto.ChatSessionResponse;
+import com.init.workflowruntime.presentation.dto.CreateUserChatSessionRequest;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -31,5 +35,16 @@ public class UserChatSessionController {
     return ResponseEntity.ok(
         userChatSessionService.getOrCreateCurrentSession(
             new GetOrCreateCurrentSessionCommand(workspaceId, userId, customerName)));
+  }
+
+  @PostMapping
+  public ResponseEntity<ChatSessionResponse> createSession(
+      @PathVariable Long workspaceId,
+      @Valid @RequestBody CreateUserChatSessionRequest request,
+      Authentication authentication) {
+    Long userId = AuthenticationUtils.getUserId(authentication);
+    return ResponseEntity.ok(
+        userChatSessionService.createSession(
+            new GetOrCreateCurrentSessionCommand(workspaceId, userId, request.customerName())));
   }
 }

--- a/backend/src/main/java/com/init/workflowruntime/presentation/dto/CreateUserChatSessionRequest.java
+++ b/backend/src/main/java/com/init/workflowruntime/presentation/dto/CreateUserChatSessionRequest.java
@@ -1,0 +1,5 @@
+package com.init.workflowruntime.presentation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CreateUserChatSessionRequest(@NotBlank String customerName) {}

--- a/backend/src/main/resources/seed/hanacard-workflow-candidate.json
+++ b/backend/src/main/resources/seed/hanacard-workflow-candidate.json
@@ -1,0 +1,2031 @@
+{
+  "schemaVersion": "1.0",
+  "domainPackDraft": {
+    "packKey": "hanacard-card-service",
+    "packName": "하나카드 카드 상담 도메인팩",
+    "summaryJson": "{\"domain\": \"하나카드\", \"sourceSplit\": \"Training\", \"consultationCount\": 100, \"turnCount\": 4084, \"sentenceUnitCount\": 5742, \"customerSentenceUnitCount\": 2616, \"agentSentenceUnitCount\": 3126, \"rawConsultingCategoryCount\": 27, \"intentCount\": 14, \"slotCount\": 42, \"policyCount\": 18, \"riskCount\": 8, \"workflowCount\": 14, \"intentAssignmentMode\": \"non_exclusive_multi_intent_from_customer_and_agent_dialogue\", \"notes\": [\"Regenerated after direct review: 10 exclusive workflow clusters were too coarse for sentence/dialogue-level intent.\", \"Final intents use customer requests plus agent verification/question/policy/action turns as evidence.\", \"Raw consulting_category has 27 labels in the selected 100 consultations; final 14 workflow-entry intents merge only low-support operational variants.\"]}"
+  },
+  "intentDraft": {
+    "intents": [
+      {
+        "intentCode": "lost_card_report_and_status",
+        "name": "카드 분실 신고 및 정지/해제 상태 확인",
+        "description": "카드 분실, 습득, 정지, 분실 신고 해제, 재발급 후 사용 가능 여부와 마지막 이용 내역을 확인하는 상담",
+        "taxonomyLevel": 1,
+        "parentIntentCode": null,
+        "sourceClusterRef": "{\"clusterId\":\"HC01\",\"support\":19,\"memberSourceIds\":[\"200001\",\"200002\",\"200005\",\"200006\",\"200007\",\"200008\",\"200009\",\"200010\",\"200011\",\"200012\",\"200013\",\"200014\",\"200015\",\"200016\",\"200017\",\"200019\",\"200039\",\"200053\",\"200098\"]}",
+        "entryConditionJson": "{\"requiredTerms\":[\"분실\",\"정지\",\"습득\",\"찾았\",\"해제\"],\"optionalTerms\":[\"재발급\",\"마지막 사용\",\"외국\",\"가족카드\",\"타사 카드\"]}",
+        "evidenceJson": "[{\"type\":\"source_id\",\"value\":\"200002\"},{\"type\":\"source_id\",\"value\":\"200008\"},{\"type\":\"source_id\",\"value\":\"200039\"}]",
+        "metaJson": "{\"domain\": \"hanacard_100\", \"source\": \"manager_merge_plan\", \"assignmentMode\": \"non_exclusive_multi_intent\", \"evidenceRoles\": [\"CUSTOMER\", \"AGENT\"]}",
+        "representativeCases": [
+          {
+            "conversationId": "200001",
+            "canonicalText": "네, 안녕하세요? 제가 오늘 오전에 전화해가지고 네 ▲▲카드 뭐 단기 요청을 드렸었는데",
+            "customerProblemText": "도난/분실 신청/해제",
+            "endedStatus": "resolved"
+          },
+          {
+            "conversationId": "200002",
+            "canonicalText": "예, 제 카드 분실했는데, 정지를 좀 하고 싶거든요.",
+            "customerProblemText": "도난/분실 신청/해제",
+            "endedStatus": "resolved"
+          },
+          {
+            "conversationId": "200005",
+            "canonicalText": "네 저 제가 ▲▲기업 카드 있는데 그 지금 저기 외국에서 잊어버렸거든요.",
+            "customerProblemText": "도난/분실 신청/해제",
+            "endedStatus": "resolved"
+          }
+        ]
+      },
+      {
+        "intentCode": "payment_history_and_charge_inquiry",
+        "name": "승인/출금/이용 내역 확인",
+        "description": "결제 승인, 문자 미수신, 명세서 금액, 해외/교통/인터넷 쇼핑 이용 내역, 출금 사유를 확인하는 상담",
+        "taxonomyLevel": 1,
+        "parentIntentCode": null,
+        "sourceClusterRef": "{\"clusterId\":\"HC02\",\"support\":22,\"memberSourceIds\":[\"200003\",\"200004\",\"200008\",\"200009\",\"200014\",\"200016\",\"200018\",\"200019\",\"200027\",\"200030\",\"200031\",\"200033\",\"200035\",\"200048\",\"200057\",\"200062\",\"200074\",\"200093\",\"200100\",\"200102\",\"200104\",\"200105\"]}",
+        "entryConditionJson": "{\"requiredTerms\":[\"결제\",\"승인\",\"출금\",\"이용 내역\",\"문자\"],\"optionalTerms\":[\"교통\",\"해외\",\"가맹점\",\"명세서\",\"누적 금액\"]}",
+        "evidenceJson": "[{\"type\":\"source_id\",\"value\":\"200003\"},{\"type\":\"source_id\",\"value\":\"200057\"},{\"type\":\"source_id\",\"value\":\"200100\"}]",
+        "metaJson": "{\"domain\": \"hanacard_100\", \"source\": \"manager_merge_plan\", \"assignmentMode\": \"non_exclusive_multi_intent\", \"evidenceRoles\": [\"CUSTOMER\", \"AGENT\"]}",
+        "representativeCases": [
+          {
+            "conversationId": "200003",
+            "canonicalText": "아 수고하십니다.",
+            "customerProblemText": "이용내역 안내",
+            "endedStatus": "resolved"
+          },
+          {
+            "conversationId": "200004",
+            "canonicalText": "네, 안녕하세요?",
+            "customerProblemText": "이용내역 안내",
+            "endedStatus": "resolved"
+          },
+          {
+            "conversationId": "200008",
+            "canonicalText": "예 저 카드 분실 신고 했었는데 찾았거든요, 네.",
+            "customerProblemText": "도난/분실 신청/해제",
+            "endedStatus": "resolved"
+          }
+        ]
+      },
+      {
+        "intentCode": "cancellation_refund_status",
+        "name": "결제 취소/반품/환불 처리 확인",
+        "description": "가맹점 취소, 반품, 매출 취소 문자, 환불 입금처와 청구 차감 여부를 확인하는 상담",
+        "taxonomyLevel": 1,
+        "parentIntentCode": null,
+        "sourceClusterRef": "{\"clusterId\":\"HC03\",\"support\":9,\"memberSourceIds\":[\"200027\",\"200041\",\"200044\",\"200058\",\"200059\",\"200064\",\"200073\",\"200092\",\"200105\"]}",
+        "entryConditionJson": "{\"requiredTerms\":[\"취소\",\"반품\",\"환불\",\"매출 취소\"],\"optionalTerms\":[\"문자\",\"청구\",\"입금\",\"가맹점\",\"카카오\"]}",
+        "evidenceJson": "[{\"type\":\"source_id\",\"value\":\"200041\"},{\"type\":\"source_id\",\"value\":\"200059\"},{\"type\":\"source_id\",\"value\":\"200073\"}]",
+        "metaJson": "{\"domain\": \"hanacard_100\", \"source\": \"manager_merge_plan\", \"assignmentMode\": \"non_exclusive_multi_intent\", \"evidenceRoles\": [\"CUSTOMER\", \"AGENT\"]}",
+        "representativeCases": [
+          {
+            "conversationId": "200027",
+            "canonicalText": "예, 수고하십니다.",
+            "customerProblemText": "이용내역 안내",
+            "endedStatus": "resolved"
+          },
+          {
+            "conversationId": "200041",
+            "canonicalText": "예, 안녕하세요? 제가 ▲▲이요 ▲▲월 ▲▲날 13시 43분에",
+            "customerProblemText": "승인취소/매출취소 안내",
+            "endedStatus": "resolved"
+          },
+          {
+            "conversationId": "200044",
+            "canonicalText": "아 예 예, 다름이 아니고",
+            "customerProblemText": "이용내역 안내",
+            "endedStatus": "resolved"
+          }
+        ]
+      },
+      {
+        "intentCode": "prepayment_and_immediate_payment",
+        "name": "선결제/즉시출금/가상계좌 납부",
+        "description": "이번 달 결제금액, 일부 또는 전액 선결제, 즉시출금, 가상계좌 발급, 중복 입금과 납부 반영 여부를 처리하는 상담",
+        "taxonomyLevel": 1,
+        "parentIntentCode": null,
+        "sourceClusterRef": "{\"clusterId\":\"HC04\",\"support\":27,\"memberSourceIds\":[\"200018\",\"200020\",\"200024\",\"200026\",\"200034\",\"200038\",\"200040\",\"200043\",\"200045\",\"200047\",\"200053\",\"200055\",\"200056\",\"200060\",\"200068\",\"200071\",\"200075\",\"200076\",\"200078\",\"200080\",\"200084\",\"200089\",\"200094\",\"200095\",\"200097\",\"200098\",\"200102\"]}",
+        "entryConditionJson": "{\"requiredTerms\":[\"선결제\",\"즉시출금\",\"가상계좌\",\"입금\",\"결제금액\"],\"optionalTerms\":[\"전액\",\"일부\",\"잔액\",\"중복\",\"예약\"]}",
+        "evidenceJson": "[{\"type\":\"source_id\",\"value\":\"200024\"},{\"type\":\"source_id\",\"value\":\"200094\"},{\"type\":\"source_id\",\"value\":\"200097\"}]",
+        "metaJson": "{\"domain\": \"hanacard_100\", \"source\": \"manager_merge_plan\", \"assignmentMode\": \"non_exclusive_multi_intent\", \"evidenceRoles\": [\"CUSTOMER\", \"AGENT\"]}",
+        "representativeCases": [
+          {
+            "conversationId": "200018",
+            "canonicalText": "네, 수고합니다.",
+            "customerProblemText": "결제대금 안내",
+            "endedStatus": "resolved"
+          },
+          {
+            "conversationId": "200020",
+            "canonicalText": "그 오토 서비스는 선입금 좀 가상계좌 받을려고 하는데요.",
+            "customerProblemText": "오토할부/오토캐쉬백 안내/신청/취소",
+            "endedStatus": "resolved"
+          },
+          {
+            "conversationId": "200024",
+            "canonicalText": "네, 안녕하세요?",
+            "customerProblemText": "선결제/즉시출금",
+            "endedStatus": "resolved"
+          }
+        ]
+      },
+      {
+        "intentCode": "card_loan_and_cash_advance_management",
+        "name": "카드론/현금서비스 한도 및 상환",
+        "description": "장기카드대출, 단기카드대출, 현금서비스 가능 여부, 한도, 이자, 원금, 즉시 상환 또는 완납을 확인하는 상담",
+        "taxonomyLevel": 1,
+        "parentIntentCode": null,
+        "sourceClusterRef": "{\"clusterId\":\"HC05\",\"support\":13,\"memberSourceIds\":[\"200020\",\"200021\",\"200026\",\"200029\",\"200045\",\"200046\",\"200060\",\"200061\",\"200065\",\"200077\",\"200080\",\"200083\",\"200091\"]}",
+        "entryConditionJson": "{\"requiredTerms\":[\"카드론\",\"장기 대출\",\"단기카드대출\",\"현금서비스\"],\"optionalTerms\":[\"한도\",\"이자\",\"원금\",\"상환\",\"완납\"]}",
+        "evidenceJson": "[{\"type\":\"source_id\",\"value\":\"200021\"},{\"type\":\"source_id\",\"value\":\"200065\"},{\"type\":\"source_id\",\"value\":\"200083\"}]",
+        "metaJson": "{\"domain\": \"hanacard_100\", \"source\": \"manager_merge_plan\", \"assignmentMode\": \"non_exclusive_multi_intent\", \"evidenceRoles\": [\"CUSTOMER\", \"AGENT\"]}",
+        "representativeCases": [
+          {
+            "conversationId": "200020",
+            "canonicalText": "그 오토 서비스는 선입금 좀 가상계좌 받을려고 하는데요.",
+            "customerProblemText": "오토할부/오토캐쉬백 안내/신청/취소",
+            "endedStatus": "resolved"
+          },
+          {
+            "conversationId": "200021",
+            "canonicalText": "네, 카드론 되는지 확인 좀 해볼려고 하는데요.",
+            "customerProblemText": "장기카드대출 안내",
+            "endedStatus": "resolved"
+          },
+          {
+            "conversationId": "200026",
+            "canonicalText": "결제 금액이 이달에 얼마 인가요? 선결제 할려고 그러는데",
+            "customerProblemText": "결제대금 안내",
+            "endedStatus": "resolved"
+          }
+        ]
+      },
+      {
+        "intentCode": "revolving_service_management",
+        "name": "리볼빙 서비스 조회/해지/납부 안내",
+        "description": "리볼빙 약정 여부, 이월 금액, 이자, 결제일 인출 방식, 리볼빙 해지 또는 납부 방법을 확인하는 상담",
+        "taxonomyLevel": 1,
+        "parentIntentCode": null,
+        "sourceClusterRef": "{\"clusterId\":\"HC06\",\"support\":4,\"memberSourceIds\":[\"200034\",\"200070\",\"200087\",\"200095\"]}",
+        "entryConditionJson": "{\"requiredTerms\":[\"리볼빙\"],\"optionalTerms\":[\"이월\",\"이자\",\"해지\",\"소액결제\",\"재인출\"]}",
+        "evidenceJson": "[{\"type\":\"source_id\",\"value\":\"200034\"},{\"type\":\"source_id\",\"value\":\"200087\"}]",
+        "metaJson": "{\"domain\": \"hanacard_100\", \"source\": \"manager_merge_plan\", \"assignmentMode\": \"non_exclusive_multi_intent\", \"evidenceRoles\": [\"CUSTOMER\", \"AGENT\"]}",
+        "representativeCases": [
+          {
+            "conversationId": "200034",
+            "canonicalText": "네 제 리볼빙된 금액 좀 알고 싶어서요.",
+            "customerProblemText": "가상계좌 예약/취소",
+            "endedStatus": "resolved"
+          },
+          {
+            "conversationId": "200070",
+            "canonicalText": "아 네, 안녕하세요?",
+            "customerProblemText": "입금내역 안내",
+            "endedStatus": "resolved"
+          },
+          {
+            "conversationId": "200087",
+            "canonicalText": "예, 안녕하십니까?",
+            "customerProblemText": "일부결제대금이월약정 안내",
+            "endedStatus": "resolved"
+          }
+        ]
+      },
+      {
+        "intentCode": "installment_conversion_or_split_payment",
+        "name": "할부 전환/분할 납부",
+        "description": "일시불 결제를 할부로 변경하거나 분할 납부 가능 여부, 할부 개월 수, 수수료와 확정 시점을 확인하는 상담",
+        "taxonomyLevel": 1,
+        "parentIntentCode": null,
+        "sourceClusterRef": "{\"clusterId\":\"HC07\",\"support\":5,\"memberSourceIds\":[\"200063\",\"200069\",\"200072\",\"200082\",\"200100\"]}",
+        "entryConditionJson": "{\"requiredTerms\":[\"할부\",\"분할 납부\",\"분할 결제\"],\"optionalTerms\":[\"개월\",\"수수료\",\"확정\",\"변경\"]}",
+        "evidenceJson": "[{\"type\":\"source_id\",\"value\":\"200069\"},{\"type\":\"source_id\",\"value\":\"200082\"}]",
+        "metaJson": "{\"domain\": \"hanacard_100\", \"source\": \"manager_merge_plan\", \"assignmentMode\": \"non_exclusive_multi_intent\", \"evidenceRoles\": [\"CUSTOMER\", \"AGENT\"]}",
+        "representativeCases": [
+          {
+            "conversationId": "200063",
+            "canonicalText": "예, 수고하십니다.",
+            "customerProblemText": "매출구분 변경",
+            "endedStatus": "resolved"
+          },
+          {
+            "conversationId": "200069",
+            "canonicalText": "네, 수고하십니다.",
+            "customerProblemText": "매출구분 변경",
+            "endedStatus": "resolved"
+          },
+          {
+            "conversationId": "200072",
+            "canonicalText": "예, 제가 그 그 보험료를 카드로 결제를 했었는데요.",
+            "customerProblemText": "이벤트 안내",
+            "endedStatus": "resolved"
+          }
+        ]
+      },
+      {
+        "intentCode": "card_limit_management",
+        "name": "카드 이용한도 조회/상향",
+        "description": "신용카드 통합 한도, 일시불/할부 가능 한도, 현금서비스 한도, 한도 상향 가능 여부와 요청 금액을 확인하는 상담",
+        "taxonomyLevel": 1,
+        "parentIntentCode": null,
+        "sourceClusterRef": "{\"clusterId\":\"HC08\",\"support\":8,\"memberSourceIds\":[\"200018\",\"200034\",\"200043\",\"200047\",\"200054\",\"200067\",\"200091\",\"200102\"]}",
+        "entryConditionJson": "{\"requiredTerms\":[\"한도\",\"상향\"],\"optionalTerms\":[\"통합 한도\",\"사용 가능\",\"현금서비스\",\"일시불\",\"할부\"]}",
+        "evidenceJson": "[{\"type\":\"source_id\",\"value\":\"200054\"},{\"type\":\"source_id\",\"value\":\"200067\"}]",
+        "metaJson": "{\"domain\": \"hanacard_100\", \"source\": \"manager_merge_plan\", \"assignmentMode\": \"non_exclusive_multi_intent\", \"evidenceRoles\": [\"CUSTOMER\", \"AGENT\"]}",
+        "representativeCases": [
+          {
+            "conversationId": "200018",
+            "canonicalText": "네, 수고합니다.",
+            "customerProblemText": "결제대금 안내",
+            "endedStatus": "resolved"
+          },
+          {
+            "conversationId": "200034",
+            "canonicalText": "네 제 리볼빙된 금액 좀 알고 싶어서요.",
+            "customerProblemText": "가상계좌 예약/취소",
+            "endedStatus": "resolved"
+          },
+          {
+            "conversationId": "200043",
+            "canonicalText": "아 네, 여보세요?",
+            "customerProblemText": "선결제/즉시출금",
+            "endedStatus": "resolved"
+          }
+        ]
+      },
+      {
+        "intentCode": "benefit_points_voucher_management",
+        "name": "혜택/할인/포인트/바우처 처리",
+        "description": "카드 혜택 적용 여부, 캐시백/할인, 포인트 또는 마일 전환, 바우처와 상품권 신청, 프로모션 조건을 확인하는 상담",
+        "taxonomyLevel": 1,
+        "parentIntentCode": null,
+        "sourceClusterRef": "{\"clusterId\":\"HC09\",\"support\":12,\"memberSourceIds\":[\"200021\",\"200022\",\"200025\",\"200028\",\"200032\",\"200033\",\"200036\",\"200042\",\"200079\",\"200085\",\"200086\",\"200103\"]}",
+        "entryConditionJson": "{\"requiredTerms\":[\"혜택\",\"할인\",\"포인트\",\"마일\",\"바우처\",\"상품권\",\"프로모션\"],\"optionalTerms\":[\"캐시백\",\"실적\",\"면세점\",\"적립\",\"전환\"]}",
+        "evidenceJson": "[{\"type\":\"source_id\",\"value\":\"200022\"},{\"type\":\"source_id\",\"value\":\"200032\"},{\"type\":\"source_id\",\"value\":\"200086\"}]",
+        "metaJson": "{\"domain\": \"hanacard_100\", \"source\": \"manager_merge_plan\", \"assignmentMode\": \"non_exclusive_multi_intent\", \"evidenceRoles\": [\"CUSTOMER\", \"AGENT\"]}",
+        "representativeCases": [
+          {
+            "conversationId": "200021",
+            "canonicalText": "네, 카드론 되는지 확인 좀 해볼려고 하는데요.",
+            "customerProblemText": "장기카드대출 안내",
+            "endedStatus": "resolved"
+          },
+          {
+            "conversationId": "200022",
+            "canonicalText": "아 네, 그 ▲▲카드 사용 중이고요. 가족 카드 같이 보유 중인데요.",
+            "customerProblemText": "이용내역 안내",
+            "endedStatus": "resolved"
+          },
+          {
+            "conversationId": "200025",
+            "canonicalText": "예, 안녕하세요? 저 뭐 좀 여쭤볼게요.",
+            "customerProblemText": "정부지원 바우처 (등유, 임신 등)",
+            "endedStatus": "resolved"
+          }
+        ]
+      },
+      {
+        "intentCode": "recurring_payment_management",
+        "name": "자동납부/자동결제 등록 및 상태 확인",
+        "description": "학교, 통신, 정수기, 보험료 등 자동납부 신청, 실패, 카드 재발급 이후 재등록 필요 여부와 결제 상태를 확인하는 상담",
+        "taxonomyLevel": 1,
+        "parentIntentCode": null,
+        "sourceClusterRef": "{\"clusterId\":\"HC10\",\"support\":8,\"memberSourceIds\":[\"200016\",\"200017\",\"200037\",\"200042\",\"200066\",\"200072\",\"200084\",\"200090\"]}",
+        "entryConditionJson": "{\"requiredTerms\":[\"자동납부\",\"자동결제\",\"자동 이체\"],\"optionalTerms\":[\"학교\",\"통신\",\"정수기\",\"보험료\",\"재발급\"]}",
+        "evidenceJson": "[{\"type\":\"source_id\",\"value\":\"200017\"},{\"type\":\"source_id\",\"value\":\"200037\"},{\"type\":\"source_id\",\"value\":\"200066\"}]",
+        "metaJson": "{\"domain\": \"hanacard_100\", \"source\": \"manager_merge_plan\", \"assignmentMode\": \"non_exclusive_multi_intent\", \"evidenceRoles\": [\"CUSTOMER\", \"AGENT\"]}",
+        "representativeCases": [
+          {
+            "conversationId": "200016",
+            "canonicalText": "아 예, 수고하십니다 조금 전에",
+            "customerProblemText": "이용내역 안내",
+            "endedStatus": "resolved"
+          },
+          {
+            "conversationId": "200017",
+            "canonicalText": "예 예 그거 저 ▲▲카드 거기에서 우리 그 정수기 요금이 그 빠져나가거든요?",
+            "customerProblemText": "도난/분실 신청/해제",
+            "endedStatus": "resolved"
+          },
+          {
+            "conversationId": "200037",
+            "canonicalText": "아 네, 수고하세요. 저 뭐 좀 여쭤 볼게요. 저 학생 신용카드 그 자동납부 신청을 좀 하려 그러는데요.",
+            "customerProblemText": "교육비",
+            "endedStatus": "resolved"
+          }
+        ]
+      },
+      {
+        "intentCode": "card_issue_delivery_activation",
+        "name": "카드 발급/배송/수령/사용등록",
+        "description": "신규 또는 갱신 카드 신청, 긴급 배송, 영업점/자택 수령, 가족카드 사용등록, 유효기간 만료 후 사용 가능 여부를 확인하는 상담",
+        "taxonomyLevel": 1,
+        "parentIntentCode": null,
+        "sourceClusterRef": "{\"clusterId\":\"HC11\",\"support\":10,\"memberSourceIds\":[\"200016\",\"200025\",\"200068\",\"200081\",\"200084\",\"200096\",\"200099\",\"200103\",\"200104\",\"200105\"]}",
+        "entryConditionJson": "{\"requiredTerms\":[\"발급\",\"배송\",\"수령\",\"사용 등록\",\"유효기간\"],\"optionalTerms\":[\"긴급\",\"영업점\",\"가족카드\",\"앱 결제\",\"챗봇\"]}",
+        "evidenceJson": "[{\"type\":\"source_id\",\"value\":\"200081\"},{\"type\":\"source_id\",\"value\":\"200099\"},{\"type\":\"source_id\",\"value\":\"200103\"}]",
+        "metaJson": "{\"domain\": \"hanacard_100\", \"source\": \"manager_merge_plan\", \"assignmentMode\": \"non_exclusive_multi_intent\", \"evidenceRoles\": [\"CUSTOMER\", \"AGENT\"]}",
+        "representativeCases": [
+          {
+            "conversationId": "200016",
+            "canonicalText": "아 예, 수고하십니다 조금 전에",
+            "customerProblemText": "이용내역 안내",
+            "endedStatus": "resolved"
+          },
+          {
+            "conversationId": "200025",
+            "canonicalText": "예, 안녕하세요? 저 뭐 좀 여쭤볼게요.",
+            "customerProblemText": "정부지원 바우처 (등유, 임신 등)",
+            "endedStatus": "resolved"
+          },
+          {
+            "conversationId": "200068",
+            "canonicalText": "네, 수고하십니다. 가족 카드가 왔는데  사용 등록을 해야 되죠?",
+            "customerProblemText": "선결제/즉시출금",
+            "endedStatus": "resolved"
+          }
+        ]
+      },
+      {
+        "intentCode": "card_close_and_annual_fee_refund",
+        "name": "카드 해지 및 연회비/잔여금 환급",
+        "description": "신용카드 해지, 해지 후 연회비 환급 또는 차감, 자동결제 잔존 여부, 결제계좌 환급 상태를 확인하는 상담",
+        "taxonomyLevel": 1,
+        "parentIntentCode": null,
+        "sourceClusterRef": "{\"clusterId\":\"HC12\",\"support\":3,\"memberSourceIds\":[\"200088\",\"200090\",\"200105\"]}",
+        "entryConditionJson": "{\"requiredTerms\":[\"해지\",\"연회비\",\"환급\"],\"optionalTerms\":[\"차감\",\"자동결제\",\"결제계좌\",\"갱신\"]}",
+        "evidenceJson": "[{\"type\":\"source_id\",\"value\":\"200088\"},{\"type\":\"source_id\",\"value\":\"200090\"}]",
+        "metaJson": "{\"domain\": \"hanacard_100\", \"source\": \"manager_merge_plan\", \"assignmentMode\": \"non_exclusive_multi_intent\", \"evidenceRoles\": [\"CUSTOMER\", \"AGENT\"]}",
+        "representativeCases": [
+          {
+            "conversationId": "200088",
+            "canonicalText": "네, 안녕하세요? 저 그 이 ▲월 초에 신용 카드 해지를 했거든요.",
+            "customerProblemText": "입금내역 안내",
+            "endedStatus": "resolved"
+          },
+          {
+            "conversationId": "200090",
+            "canonicalText": "네, 카드 해지할려구요.",
+            "customerProblemText": "일부결제대금이월약정 해지",
+            "endedStatus": "resolved"
+          },
+          {
+            "conversationId": "200105",
+            "canonicalText": "아 네, 저 ▲▲카드는 ▲▲카드죠?",
+            "customerProblemText": "결제대금 안내",
+            "endedStatus": "resolved"
+          }
+        ]
+      },
+      {
+        "intentCode": "billing_cycle_due_date_change",
+        "name": "결제일/청구 주기 변경",
+        "description": "카드 결제일 변경, 이용기간 산정, 변경 후 청구월과 이중 청구 가능성을 확인하는 상담",
+        "taxonomyLevel": 1,
+        "parentIntentCode": null,
+        "sourceClusterRef": "{\"clusterId\":\"HC13\",\"support\":2,\"memberSourceIds\":[\"200052\",\"200062\"]}",
+        "entryConditionJson": "{\"requiredTerms\":[\"결제일\",\"변경\"],\"optionalTerms\":[\"청구\",\"이용기간\",\"며칠부터\",\"며칠까지\"]}",
+        "evidenceJson": "[{\"type\":\"source_id\",\"value\":\"200052\"},{\"type\":\"source_id\",\"value\":\"200062\"}]",
+        "metaJson": "{\"domain\": \"hanacard_100\", \"source\": \"manager_merge_plan\", \"assignmentMode\": \"non_exclusive_multi_intent\", \"evidenceRoles\": [\"CUSTOMER\", \"AGENT\"]}",
+        "representativeCases": [
+          {
+            "conversationId": "200052",
+            "canonicalText": "아 예, 제가 카드 대금 날짜가 ▲▲일인데",
+            "customerProblemText": "결제일 안내/변경/취소",
+            "endedStatus": "resolved"
+          },
+          {
+            "conversationId": "200062",
+            "canonicalText": "20,000원이 그 출금된 이제 ▲▲카드로요. 그게 결제일이 언제인지 알 수 있을까요?",
+            "customerProblemText": "입금내역 안내",
+            "endedStatus": "resolved"
+          }
+        ]
+      },
+      {
+        "intentCode": "digital_payment_service_registration",
+        "name": "일반결제/앱 결제 서비스 등록 및 오류",
+        "description": "일반결제서비스 가입 알림, 앱 결제 불가, 온라인 결제 서비스 사용 조건과 보안 동의 여부를 확인하는 상담",
+        "taxonomyLevel": 1,
+        "parentIntentCode": null,
+        "sourceClusterRef": "{\"clusterId\":\"HC14\",\"support\":2,\"memberSourceIds\":[\"200103\",\"200104\"]}",
+        "entryConditionJson": "{\"requiredTerms\":[\"일반결제서비스\",\"앱 결제\",\"온라인 결제\"],\"optionalTerms\":[\"가입 완료\",\"등록\",\"보안\",\"동의\"]}",
+        "evidenceJson": "[{\"type\":\"source_id\",\"value\":\"200103\"},{\"type\":\"source_id\",\"value\":\"200104\"}]",
+        "metaJson": "{\"domain\": \"hanacard_100\", \"source\": \"manager_merge_plan\", \"assignmentMode\": \"non_exclusive_multi_intent\", \"evidenceRoles\": [\"CUSTOMER\", \"AGENT\"]}",
+        "representativeCases": [
+          {
+            "conversationId": "200103",
+            "canonicalText": "네, ▲▲카드 새로 발급 받아서 등록 신청까지 다 했는데",
+            "customerProblemText": "이용방법 안내",
+            "endedStatus": "resolved"
+          },
+          {
+            "conversationId": "200104",
+            "canonicalText": "네, 수고하십니다. 여쭤볼려고요.",
+            "customerProblemText": "안심클릭/▲▲페이/기타페이 안내",
+            "endedStatus": "resolved"
+          }
+        ]
+      }
+    ]
+  },
+  "workflowDraft": {
+    "slots": [
+      {
+        "slotCode": "customer_identity",
+        "name": "고객 본인 확인 정보",
+        "description": "명의자 성명, 생년월일, 휴대폰, 결제은행 등 본인 확인에 필요한 정보",
+        "dataType": "STRING",
+        "isSensitive": true,
+        "validationRuleJson": "{\"keywords\":[\"성함\",\"생년월일\",\"휴대폰\",\"명의자\",\"본인\",\"은행\"]}",
+        "defaultValueJson": null,
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "slotCode": "card_identifier",
+        "name": "대상 카드 식별 정보",
+        "description": "카드명, 카드 종류, 카드 번호 끝자리, 가족/기업/체크/신용 여부",
+        "dataType": "STRING",
+        "isSensitive": true,
+        "validationRuleJson": "{\"keywords\":[\"카드\",\"끝 네 자리\",\"체크\",\"신용\",\"가족\",\"기업\"]}",
+        "defaultValueJson": null,
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "slotCode": "card_possession_status",
+        "name": "카드 소지/분실 상태",
+        "description": "분실, 습득, 찾음, 소지 중, 신고 접수 여부 등 현재 카드 상태",
+        "dataType": "STRING",
+        "isSensitive": false,
+        "validationRuleJson": "{\"keywords\":[\"분실\",\"잃어버\",\"찾았\",\"습득\",\"소지\",\"정지\"]}",
+        "defaultValueJson": null,
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "slotCode": "incident_datetime",
+        "name": "분실/문제 발생 시각",
+        "description": "카드 분실, 도난, 의심 승인, 서비스 문제 발생 일시",
+        "dataType": "STRING",
+        "isSensitive": false,
+        "validationRuleJson": "{\"keywords\":[\"언제\",\"어제\",\"오늘\",\"새벽\",\"오전\",\"오후\",\"시\",\"분\"]}",
+        "defaultValueJson": null,
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "slotCode": "incident_location",
+        "name": "분실/이용 발생 장소",
+        "description": "분실 추정 장소, 습득 장소, 가맹점 또는 이용 지역",
+        "dataType": "STRING",
+        "isSensitive": false,
+        "validationRuleJson": "{\"keywords\":[\"장소\",\"터미널\",\"마트\",\"지하철\",\"공항\",\"가맹점\",\"지역\"]}",
+        "defaultValueJson": null,
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "slotCode": "contact_channel",
+        "name": "연락/인증 채널",
+        "description": "문자, 카카오, 전화, 등록 휴대폰, 해외 연락처 등 고객에게 안내하거나 인증할 채널",
+        "dataType": "STRING",
+        "isSensitive": true,
+        "validationRuleJson": "{\"keywords\":[\"문자\",\"카톡\",\"카카오\",\"전화\",\"휴대폰\",\"연락처\"]}",
+        "defaultValueJson": null,
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "slotCode": "transaction_datetime",
+        "name": "거래 일시",
+        "description": "승인, 출금, 취소, 교통 이용, 해외 결제의 발생 일시",
+        "dataType": "STRING",
+        "isSensitive": false,
+        "validationRuleJson": "{\"keywords\":[\"결제일\",\"승인일\",\"몇 월\",\"며칠\",\"시\",\"분\",\"오늘\"]}",
+        "defaultValueJson": null,
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "slotCode": "transaction_amount",
+        "name": "거래 금액",
+        "description": "승인 금액, 취소 금액, 청구 금액, 출금 금액 또는 선결제 금액",
+        "dataType": "NUMBER",
+        "isSensitive": false,
+        "validationRuleJson": "{\"keywords\":[\"원\",\"금액\",\"얼마\",\"총액\",\"잔액\",\"누적\"]}",
+        "defaultValueJson": null,
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "slotCode": "merchant_or_channel",
+        "name": "가맹점/결제 채널",
+        "description": "가맹점명, 온라인 쇼핑몰, 네이버페이, 교통, 해외, 앱 등 결제 채널",
+        "dataType": "STRING",
+        "isSensitive": false,
+        "validationRuleJson": "{\"keywords\":[\"가맹점\",\"쇼핑\",\"네이버페이\",\"쿠팡\",\"교통\",\"해외\",\"앱\"]}",
+        "defaultValueJson": null,
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "slotCode": "transaction_status_type",
+        "name": "거래 상태 유형",
+        "description": "승인, 매출, 취소, 반품, 환불, 출금, 청구 반영 등 확인하려는 상태",
+        "dataType": "STRING",
+        "isSensitive": false,
+        "validationRuleJson": "{\"keywords\":[\"승인\",\"매출\",\"취소\",\"반품\",\"환불\",\"출금\",\"청구\"]}",
+        "defaultValueJson": null,
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "slotCode": "cancellation_request_date",
+        "name": "취소/반품 요청일",
+        "description": "가맹점이 취소 또는 반품 처리했다고 안내한 날짜",
+        "dataType": "STRING",
+        "isSensitive": false,
+        "validationRuleJson": "{\"keywords\":[\"취소한 날\",\"반품\",\"처리일\",\"문자 받은 날\"]}",
+        "defaultValueJson": null,
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "slotCode": "refund_destination",
+        "name": "환불/입금 대상",
+        "description": "결제계좌, 이전 카드, 새 카드, 청구 차감 등 환불이 반영될 대상",
+        "dataType": "STRING",
+        "isSensitive": true,
+        "validationRuleJson": "{\"keywords\":[\"환불\",\"입금\",\"결제계좌\",\"차감\",\"돌려\"]}",
+        "defaultValueJson": null,
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "slotCode": "payment_due_date",
+        "name": "결제일",
+        "description": "정기 결제일, 이번 달 납부일, 변경 전후 결제일",
+        "dataType": "STRING",
+        "isSensitive": false,
+        "validationRuleJson": "{\"keywords\":[\"결제일\",\"납부일\",\"이번 달\",\"10일\",\"25일\"]}",
+        "defaultValueJson": null,
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "slotCode": "payment_amount",
+        "name": "납부/선결제 금액",
+        "description": "전액, 일부, 현금서비스분, 카드론분 등 결제 요청 금액",
+        "dataType": "NUMBER",
+        "isSensitive": false,
+        "validationRuleJson": "{\"keywords\":[\"선결제\",\"즉시출금\",\"납부\",\"입금\",\"전부\",\"일부\",\"원\"]}",
+        "defaultValueJson": null,
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "slotCode": "payment_method_account",
+        "name": "결제/출금 계좌 또는 가상계좌",
+        "description": "자동 출금 계좌, 다른 명의 계좌, 가상계좌 발급 은행과 계좌 정보",
+        "dataType": "STRING",
+        "isSensitive": true,
+        "validationRuleJson": "{\"keywords\":[\"계좌\",\"가상계좌\",\"은행\",\"출금\",\"입금\"]}",
+        "defaultValueJson": null,
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "slotCode": "loan_type",
+        "name": "대출/현금서비스 유형",
+        "description": "장기카드대출, 단기카드대출, 현금서비스, 오토 서비스 등 금융 서비스 유형",
+        "dataType": "STRING",
+        "isSensitive": false,
+        "validationRuleJson": "{\"keywords\":[\"카드론\",\"장기\",\"단기\",\"현금서비스\",\"오토\"]}",
+        "defaultValueJson": null,
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "slotCode": "loan_action",
+        "name": "대출 처리 요청",
+        "description": "가능 여부 조회, 실행, 일부 상환, 완납, 즉시출금 등 요청 유형",
+        "dataType": "STRING",
+        "isSensitive": false,
+        "validationRuleJson": "{\"keywords\":[\"가능\",\"받을\",\"상환\",\"완납\",\"출금\",\"한도\"]}",
+        "defaultValueJson": null,
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "slotCode": "loan_amount",
+        "name": "대출/상환 금액",
+        "description": "신청 가능 금액, 실행 금액, 일부 상환 또는 완납 금액",
+        "dataType": "NUMBER",
+        "isSensitive": false,
+        "validationRuleJson": "{\"keywords\":[\"금액\",\"원\",\"얼마\",\"원금\",\"이자\"]}",
+        "defaultValueJson": null,
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "slotCode": "repayment_term",
+        "name": "상환 기간/개월 수",
+        "description": "카드론 또는 할부의 상환 개월 수, 납부 예정월",
+        "dataType": "NUMBER",
+        "isSensitive": false,
+        "validationRuleJson": "{\"keywords\":[\"개월\",\"몇 개월\",\"다음 달\",\"월 상환\"]}",
+        "defaultValueJson": null,
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "slotCode": "revolving_action",
+        "name": "리볼빙 요청 유형",
+        "description": "리볼빙 약정 조회, 이월금 확인, 납부, 해지 또는 설명 요청",
+        "dataType": "STRING",
+        "isSensitive": false,
+        "validationRuleJson": "{\"keywords\":[\"리볼빙\",\"이월\",\"해지\",\"약정\",\"소액결제\"]}",
+        "defaultValueJson": null,
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "slotCode": "installment_months",
+        "name": "할부/분할 개월 수",
+        "description": "할부 전환 또는 분할 납부로 원하는 개월 수",
+        "dataType": "NUMBER",
+        "isSensitive": false,
+        "validationRuleJson": "{\"keywords\":[\"개월\",\"할부\",\"분할\"]}",
+        "defaultValueJson": null,
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "slotCode": "limit_type",
+        "name": "한도 유형",
+        "description": "통합 한도, 일시불/할부 한도, 현금서비스 한도 등 조회 또는 상향 대상 한도",
+        "dataType": "STRING",
+        "isSensitive": false,
+        "validationRuleJson": "{\"keywords\":[\"통합 한도\",\"현금서비스\",\"일시불\",\"할부\",\"사용 가능\"]}",
+        "defaultValueJson": null,
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "slotCode": "desired_limit_amount",
+        "name": "희망 한도 금액",
+        "description": "고객이 요청하는 상향 한도 또는 확인하려는 사용 가능 한도",
+        "dataType": "NUMBER",
+        "isSensitive": false,
+        "validationRuleJson": "{\"keywords\":[\"올려\",\"상향\",\"한도\",\"원\"]}",
+        "defaultValueJson": null,
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "slotCode": "limit_change_reason",
+        "name": "한도 변경 사유",
+        "description": "가구 구매, 복지포인트 카드 사용, 출국 전 사용 등 한도 상향 배경",
+        "dataType": "STRING",
+        "isSensitive": false,
+        "validationRuleJson": "{\"keywords\":[\"구매\",\"필요\",\"복지\",\"출국\",\"사용\"]}",
+        "defaultValueJson": null,
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "slotCode": "benefit_program",
+        "name": "혜택/상품 프로그램",
+        "description": "카드 혜택명, 캐시백, 마일리지, 바우처, 상품권, 프로모션명",
+        "dataType": "STRING",
+        "isSensitive": false,
+        "validationRuleJson": "{\"keywords\":[\"혜택\",\"할인\",\"캐시백\",\"마일\",\"바우처\",\"상품권\",\"프로모션\"]}",
+        "defaultValueJson": null,
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "slotCode": "benefit_action",
+        "name": "혜택 처리 요청",
+        "description": "적용 여부 확인, 포인트 전환, 상품권 선택, 바우처 신청 등 요청 유형",
+        "dataType": "STRING",
+        "isSensitive": false,
+        "validationRuleJson": "{\"keywords\":[\"적용\",\"전환\",\"신청\",\"선택\",\"확인\"]}",
+        "defaultValueJson": null,
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "slotCode": "usage_period",
+        "name": "이용/실적 기간",
+        "description": "혜택 또는 청구 확인에 필요한 이용일, 전월 실적 기간, 프로모션 기간",
+        "dataType": "STRING",
+        "isSensitive": false,
+        "validationRuleJson": "{\"keywords\":[\"전월\",\"실적\",\"어제\",\"그제\",\"기간\",\"월\"]}",
+        "defaultValueJson": null,
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "slotCode": "usage_merchant_or_category",
+        "name": "이용 가맹점/업종",
+        "description": "스타벅스, 정수기, 통신, 면세점, 백화점 등 혜택 또는 자동납부 대상",
+        "dataType": "STRING",
+        "isSensitive": false,
+        "validationRuleJson": "{\"keywords\":[\"스타벅스\",\"정수기\",\"통신\",\"면세점\",\"백화점\",\"학교\",\"보험\"]}",
+        "defaultValueJson": null,
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "slotCode": "autopay_biller",
+        "name": "자동납부 기관",
+        "description": "학교, 통신사, 정수기, 보험사 등 자동납부 청구 기관",
+        "dataType": "STRING",
+        "isSensitive": false,
+        "validationRuleJson": "{\"keywords\":[\"학교\",\"통신\",\"정수기\",\"보험료\",\"자동납부\"]}",
+        "defaultValueJson": null,
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "slotCode": "autopay_contract_identifier",
+        "name": "자동납부 식별 정보",
+        "description": "학생 정보, 계약번호, 고객번호, 주소, 납부자 정보 등 자동납부 등록에 필요한 식별값",
+        "dataType": "STRING",
+        "isSensitive": true,
+        "validationRuleJson": "{\"keywords\":[\"번호\",\"주소\",\"학생\",\"계약\",\"고객번호\"]}",
+        "defaultValueJson": null,
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "slotCode": "autopay_action",
+        "name": "자동납부 요청 유형",
+        "description": "신청, 변경, 실패 확인, 재등록 필요 여부 확인 등 자동납부 요청 유형",
+        "dataType": "STRING",
+        "isSensitive": false,
+        "validationRuleJson": "{\"keywords\":[\"신청\",\"변경\",\"안 됐\",\"재등록\",\"확인\"]}",
+        "defaultValueJson": null,
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "slotCode": "issue_request_type",
+        "name": "발급/등록 요청 유형",
+        "description": "신규 신청, 재발급, 갱신, 긴급배송, 수령지 확인, 사용등록, 앱 결제 오류",
+        "dataType": "STRING",
+        "isSensitive": false,
+        "validationRuleJson": "{\"keywords\":[\"신청\",\"재발급\",\"갱신\",\"긴급배송\",\"수령\",\"사용등록\",\"앱 결제\"]}",
+        "defaultValueJson": null,
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "slotCode": "delivery_address_or_branch",
+        "name": "배송지/수령 지점",
+        "description": "자택, 영업점, 본사, 긴급배송 목적지 등 카드 수령 위치",
+        "dataType": "STRING",
+        "isSensitive": true,
+        "validationRuleJson": "{\"keywords\":[\"자택\",\"영업점\",\"주소\",\"수령지\",\"배송\"]}",
+        "defaultValueJson": null,
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "slotCode": "desired_delivery_date",
+        "name": "희망 수령일",
+        "description": "출국 전 수령, 가장 빠른 배송일, 긴급 배송 희망일",
+        "dataType": "STRING",
+        "isSensitive": false,
+        "validationRuleJson": "{\"keywords\":[\"언제까지\",\"출국\",\"화요일\",\"빠르게\",\"오늘\"]}",
+        "defaultValueJson": null,
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "slotCode": "cancellation_reason",
+        "name": "해지/환급 문의 사유",
+        "description": "카드 해지, 연회비 출금, 갱신 후 환급 미반영, 자동결제 여부 등 문의 사유",
+        "dataType": "STRING",
+        "isSensitive": false,
+        "validationRuleJson": "{\"keywords\":[\"해지\",\"연회비\",\"환급\",\"갱신\",\"차감\"]}",
+        "defaultValueJson": null,
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "slotCode": "annual_fee_or_refund_amount",
+        "name": "연회비/환급 금액",
+        "description": "출금된 연회비, 차감 금액, 환급 예상 금액",
+        "dataType": "NUMBER",
+        "isSensitive": false,
+        "validationRuleJson": "{\"keywords\":[\"연회비\",\"환급\",\"차감\",\"원\"]}",
+        "defaultValueJson": null,
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "slotCode": "current_due_date",
+        "name": "현재 결제일",
+        "description": "변경 전 카드 결제일",
+        "dataType": "STRING",
+        "isSensitive": false,
+        "validationRuleJson": "{\"keywords\":[\"원래 결제일\",\"현재 결제일\",\"25일\",\"10일\"]}",
+        "defaultValueJson": null,
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "slotCode": "desired_due_date",
+        "name": "희망 결제일",
+        "description": "고객이 변경하려는 새 결제일",
+        "dataType": "STRING",
+        "isSensitive": false,
+        "validationRuleJson": "{\"keywords\":[\"변경\",\"바꾸\",\"10일\",\"25일\"]}",
+        "defaultValueJson": null,
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "slotCode": "billing_period",
+        "name": "청구 산정 기간",
+        "description": "결제일 변경 후 이용기간 시작일과 종료일, 두 달분 청구 가능성",
+        "dataType": "STRING",
+        "isSensitive": false,
+        "validationRuleJson": "{\"keywords\":[\"며칠부터\",\"며칠까지\",\"이용기간\",\"두 달분\"]}",
+        "defaultValueJson": null,
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "slotCode": "digital_service_name",
+        "name": "디지털 결제 서비스명",
+        "description": "일반결제서비스, 앱 결제, 온라인 결제 등 등록 또는 오류가 발생한 서비스",
+        "dataType": "STRING",
+        "isSensitive": false,
+        "validationRuleJson": "{\"keywords\":[\"일반결제서비스\",\"앱 결제\",\"온라인 결제\",\"서비스\"]}",
+        "defaultValueJson": null,
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "slotCode": "service_request_type",
+        "name": "서비스 요청 유형",
+        "description": "가입 확인, 등록, 오류 해결, 설명 요청, 해지 등 서비스 처리 유형",
+        "dataType": "STRING",
+        "isSensitive": false,
+        "validationRuleJson": "{\"keywords\":[\"가입\",\"등록\",\"오류\",\"해지\",\"설명\",\"확인\"]}",
+        "defaultValueJson": null,
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "slotCode": "authentication_channel",
+        "name": "인증 수단",
+        "description": "카드 인증, 비밀번호 입력, 문자 인증, 계좌 인증 등 인증 수단",
+        "dataType": "STRING",
+        "isSensitive": true,
+        "validationRuleJson": "{\"keywords\":[\"인증\",\"비밀번호\",\"문자\",\"계좌\",\"카드\"]}",
+        "defaultValueJson": null,
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      }
+    ],
+    "policies": [
+      {
+        "policyCode": "customer_authentication_required",
+        "name": "본인 인증 선행",
+        "description": "카드, 결제, 대출, 한도, 해지 등 계정성 업무는 명의자 또는 적법한 대리권을 확인한 뒤 처리한다.",
+        "severity": "HIGH",
+        "conditionJson": "{\"when\":\"account_specific_request\",\"observedSignals\":[\"카드\",\"결제\",\"대출\",\"해지\",\"한도\"]}",
+        "actionJson": "{\"require\":[\"customer_identity\"],\"allowProxyOnlyWithVerification\":true}",
+        "evidenceJson": "[{\"type\":\"source_id\",\"value\":\"200008\"},{\"type\":\"source_id\",\"value\":\"200015\"},{\"type\":\"source_id\",\"value\":\"200090\"}]",
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "policyCode": "target_card_and_account_verification",
+        "name": "대상 카드/계좌 식별 확인",
+        "description": "복수 카드, 가족카드, 체크/신용카드, 이전/새 카드가 혼재할 때 처리 대상 카드를 명확히 식별한다.",
+        "severity": "HIGH",
+        "conditionJson": "{\"when\":\"multiple_card_or_account_possible\",\"observedSignals\":[\"가족카드\",\"체크\",\"신용\",\"끝자리\",\"새 카드\"]}",
+        "actionJson": "{\"require\":[\"card_identifier\"],\"confirmBeforeAction\":true}",
+        "evidenceJson": "[{\"type\":\"source_id\",\"value\":\"200010\"},{\"type\":\"source_id\",\"value\":\"200068\"},{\"type\":\"source_id\",\"value\":\"200100\"}]",
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "policyCode": "sensitive_auth_data_handling",
+        "name": "민감 인증정보 최소 수집",
+        "description": "카드번호, 계좌번호, 주민번호, 비밀번호 등 민감 정보는 필요한 최소 범위와 안전한 입력 채널로만 수집한다.",
+        "severity": "HIGH",
+        "conditionJson": "{\"when\":\"sensitive_data_requested\",\"observedSignals\":[\"비밀번호\",\"계좌번호\",\"주민번호\",\"카드번호\"]}",
+        "actionJson": "{\"minimizeCollection\":true,\"preferSecureInput\":true,\"maskInLogs\":true}",
+        "evidenceJson": "[{\"type\":\"source_id\",\"value\":\"200008\"},{\"type\":\"source_id\",\"value\":\"200086\"},{\"type\":\"source_id\",\"value\":\"200097\"}]",
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "policyCode": "lost_card_block_release_notice",
+        "name": "분실 정지/해제 및 재발급 영향 고지",
+        "description": "분실 정지, 해제, 재발급 요청 시 기존 카드 사용 가능 여부, 재발급 후 자동납부 영향, 해제 가능 조건을 안내한다.",
+        "severity": "HIGH",
+        "conditionJson": "{\"when\":\"lost_card_or_block_status_discussed\",\"observedSignals\":[\"분실\",\"정지\",\"해제\",\"재발급\",\"찾았\"]}",
+        "actionJson": "{\"disclose\":[\"cardUsability\",\"reissueImpact\",\"releaseCondition\",\"nextContactPath\"]}",
+        "evidenceJson": "[{\"type\":\"source_id\",\"value\":\"200007\"},{\"type\":\"source_id\",\"value\":\"200016\"},{\"type\":\"source_id\",\"value\":\"200098\"}]",
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "policyCode": "suspicious_use_and_dispute_escalation",
+        "name": "부정사용 의심 거래 에스컬레이션",
+        "description": "분실 이후 승인, 고객이 인지하지 못한 결제, 해외/온라인 이상 거래는 승인 상태와 이의제기 또는 사고 접수 경로를 안내한다.",
+        "severity": "HIGH",
+        "conditionJson": "{\"when\":\"suspicious_or_unknown_charge\",\"observedSignals\":[\"모르는 결제\",\"분실 후 사용\",\"이상한 금액\",\"해외\",\"인터넷 쇼핑\"]}",
+        "actionJson": "{\"verify\":[\"transaction_status_type\",\"merchant_or_channel\"],\"offerEscalation\":\"dispute_or_fraud_team\"}",
+        "evidenceJson": "[{\"type\":\"source_id\",\"value\":\"200012\"},{\"type\":\"source_id\",\"value\":\"200057\"},{\"type\":\"source_id\",\"value\":\"200093\"}]",
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "policyCode": "transaction_posting_delay_notice",
+        "name": "승인/매출/문자 반영 지연 안내",
+        "description": "승인 문자, 앱 내역, 매출 확정, 교통/해외 이용 내역은 채널별 반영 시점이 다를 수 있음을 안내한다.",
+        "severity": "MEDIUM",
+        "conditionJson": "{\"when\":\"transaction_visibility_or_alert_discussed\",\"observedSignals\":[\"문자 안 옴\",\"앱에 안 보임\",\"승인\",\"교통\",\"해외\"]}",
+        "actionJson": "{\"disclose\":[\"postingDelay\",\"alertChannelDifference\",\"merchantSettlementTiming\"]}",
+        "evidenceJson": "[{\"type\":\"source_id\",\"value\":\"200003\"},{\"type\":\"source_id\",\"value\":\"200041\"},{\"type\":\"source_id\",\"value\":\"200048\"}]",
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "policyCode": "cancellation_refund_timing_notice",
+        "name": "취소/환불 반영 시점 고지",
+        "description": "가맹점 취소 접수, 카드사 매입 취소, 청구 차감, 결제계좌 입금은 처리 단계와 날짜가 다를 수 있음을 안내한다.",
+        "severity": "MEDIUM",
+        "conditionJson": "{\"when\":\"refund_or_cancellation_status_discussed\",\"observedSignals\":[\"취소\",\"반품\",\"환불\",\"매출 취소\",\"입금\"]}",
+        "actionJson": "{\"explain\":[\"merchantCancellation\",\"cardPosting\",\"statementOffset\",\"refundDestination\"]}",
+        "evidenceJson": "[{\"type\":\"source_id\",\"value\":\"200059\"},{\"type\":\"source_id\",\"value\":\"200073\"},{\"type\":\"source_id\",\"value\":\"200092\"}]",
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "policyCode": "payment_execution_consent_and_account_check",
+        "name": "납부 실행 동의 및 계좌 확인",
+        "description": "즉시출금, 가상계좌 발급, 다른 계좌 출금은 금액, 계좌, 실행 시점에 대한 고객 동의를 확인한 뒤 처리한다.",
+        "severity": "HIGH",
+        "conditionJson": "{\"when\":\"payment_execution_requested\",\"observedSignals\":[\"즉시출금\",\"가상계좌\",\"입금\",\"계좌번호\",\"결제해 주세요\"]}",
+        "actionJson": "{\"require\":[\"payment_amount\",\"payment_method_account\"],\"confirmBeforeExecution\":true}",
+        "evidenceJson": "[{\"type\":\"source_id\",\"value\":\"200055\"},{\"type\":\"source_id\",\"value\":\"200094\"},{\"type\":\"source_id\",\"value\":\"200097\"}]",
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "policyCode": "prepayment_allocation_and_duplicate_payment_notice",
+        "name": "선결제 충당/중복 납부 안내",
+        "description": "선결제는 결제 예정금액, 카드론, 현금서비스, 취소 반영분에 따라 충당 순서와 잔여 청구가 달라질 수 있고 중복 입금은 별도 반영될 수 있음을 안내한다.",
+        "severity": "MEDIUM",
+        "conditionJson": "{\"when\":\"prepayment_or_duplicate_payment_discussed\",\"observedSignals\":[\"선결제\",\"중복\",\"잔액\",\"다 갚\",\"두 번\"]}",
+        "actionJson": "{\"disclose\":[\"allocationOrder\",\"remainingBalance\",\"nextStatementImpact\",\"duplicatePaymentHandling\"]}",
+        "evidenceJson": "[{\"type\":\"source_id\",\"value\":\"200024\"},{\"type\":\"source_id\",\"value\":\"200095\"},{\"type\":\"source_id\",\"value\":\"200102\"}]",
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "policyCode": "credit_loan_assessment_and_fee_notice",
+        "name": "카드대출 심사/금리/상환 조건 고지",
+        "description": "카드론, 현금서비스 가능 여부와 한도는 심사 및 시점에 따라 달라지며 금리, 이자, 원금, 상환 개월 수를 함께 안내한다.",
+        "severity": "HIGH",
+        "conditionJson": "{\"when\":\"loan_or_cash_advance_discussed\",\"observedSignals\":[\"카드론\",\"장기\",\"단기\",\"현금서비스\",\"이자\"]}",
+        "actionJson": "{\"disclose\":[\"eligibilityCanChange\",\"interest\",\"repaymentTerm\",\"principal\",\"fees\"]}",
+        "evidenceJson": "[{\"type\":\"source_id\",\"value\":\"200021\"},{\"type\":\"source_id\",\"value\":\"200029\"},{\"type\":\"source_id\",\"value\":\"200065\"}]",
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "policyCode": "revolving_installment_fee_and_statement_notice",
+        "name": "리볼빙/할부 수수료 및 청구 영향 고지",
+        "description": "리볼빙, 할부 전환, 분할 납부는 수수료, 이자, 다음 청구월, 확정 가능 시점이 달라질 수 있음을 안내한다.",
+        "severity": "HIGH",
+        "conditionJson": "{\"when\":\"revolving_or_installment_discussed\",\"observedSignals\":[\"리볼빙\",\"할부\",\"분할납부\",\"수수료\",\"이자\"]}",
+        "actionJson": "{\"disclose\":[\"fees\",\"interest\",\"billingMonth\",\"conversionAvailability\",\"cancellationPath\"]}",
+        "evidenceJson": "[{\"type\":\"source_id\",\"value\":\"200063\"},{\"type\":\"source_id\",\"value\":\"200070\"},{\"type\":\"source_id\",\"value\":\"200087\"}]",
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "policyCode": "limit_change_assessment_notice",
+        "name": "한도 변경 심사 및 적용 범위 고지",
+        "description": "한도 조회 또는 상향은 카드 유형, 통합 한도, 현금서비스 한도, 심사 결과와 즉시 사용 가능 범위를 구분해 안내한다.",
+        "severity": "MEDIUM",
+        "conditionJson": "{\"when\":\"limit_inquiry_or_increase_requested\",\"observedSignals\":[\"한도\",\"상향\",\"사용 가능\",\"현금서비스\"]}",
+        "actionJson": "{\"disclose\":[\"currentLimit\",\"availableLimit\",\"assessmentRequired\",\"scopeByLimitType\"]}",
+        "evidenceJson": "[{\"type\":\"source_id\",\"value\":\"200043\"},{\"type\":\"source_id\",\"value\":\"200054\"},{\"type\":\"source_id\",\"value\":\"200091\"}]",
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "policyCode": "benefit_eligibility_and_exclusion_notice",
+        "name": "혜택 적용 조건 및 제외 기준 고지",
+        "description": "할인, 캐시백, 포인트, 바우처, 프로모션은 전월 실적, 가맹점, 결제 방식, 적용 시점과 제외 조건을 확인해 안내한다.",
+        "severity": "MEDIUM",
+        "conditionJson": "{\"when\":\"benefit_or_points_discussed\",\"observedSignals\":[\"혜택\",\"할인\",\"포인트\",\"마일\",\"바우처\",\"캐시백\"]}",
+        "actionJson": "{\"verify\":[\"benefit_program\",\"usage_period\",\"usage_merchant_or_category\"],\"disclose\":[\"eligibility\",\"excludedTransactions\",\"postingTiming\"]}",
+        "evidenceJson": "[{\"type\":\"source_id\",\"value\":\"200022\"},{\"type\":\"source_id\",\"value\":\"200036\"},{\"type\":\"source_id\",\"value\":\"200079\"}]",
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "policyCode": "recurring_payment_merchant_coordination_notice",
+        "name": "자동납부 기관 연계 안내",
+        "description": "자동납부 신청, 실패, 재발급 후 재등록은 카드사와 청구기관 처리 상태가 다를 수 있어 기관 확인 또는 재신청 필요성을 안내한다.",
+        "severity": "MEDIUM",
+        "conditionJson": "{\"when\":\"recurring_payment_discussed\",\"observedSignals\":[\"자동납부\",\"자동결제\",\"학교\",\"통신\",\"정수기\",\"보험료\"]}",
+        "actionJson": "{\"disclose\":[\"merchantRegistrationStatus\",\"reissueImpact\",\"externalProviderCheck\"]}",
+        "evidenceJson": "[{\"type\":\"source_id\",\"value\":\"200017\"},{\"type\":\"source_id\",\"value\":\"200066\"},{\"type\":\"source_id\",\"value\":\"200090\"}]",
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "policyCode": "card_delivery_activation_and_expiry_notice",
+        "name": "카드 배송/사용등록/유효기간 안내",
+        "description": "신청 카드의 배송 일정, 긴급배송 가능성, 수령지, 사용등록 여부, 유효기간 만료 후 기능 제한을 안내한다.",
+        "severity": "MEDIUM",
+        "conditionJson": "{\"when\":\"card_issue_delivery_or_activation_discussed\",\"observedSignals\":[\"발급\",\"배송\",\"수령\",\"사용등록\",\"유효기간\"]}",
+        "actionJson": "{\"disclose\":[\"deliveryEta\",\"pickupOptions\",\"activationRequired\",\"expiryImpact\"]}",
+        "evidenceJson": "[{\"type\":\"source_id\",\"value\":\"200081\"},{\"type\":\"source_id\",\"value\":\"200099\"},{\"type\":\"source_id\",\"value\":\"200103\"}]",
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "policyCode": "card_close_annual_fee_refund_notice",
+        "name": "해지 후 연회비/잔액 환급 고지",
+        "description": "카드 해지 시 연회비 환급, 미청구 잔액, 자동결제 잔존 여부, 환급 계좌 반영 시점을 안내한다.",
+        "severity": "MEDIUM",
+        "conditionJson": "{\"when\":\"card_close_or_annual_fee_refund_discussed\",\"observedSignals\":[\"해지\",\"연회비\",\"환급\",\"차감\"]}",
+        "actionJson": "{\"disclose\":[\"annualFeeProration\",\"refundTiming\",\"remainingBalance\",\"recurringPaymentCheck\"]}",
+        "evidenceJson": "[{\"type\":\"source_id\",\"value\":\"200088\"},{\"type\":\"source_id\",\"value\":\"200090\"},{\"type\":\"source_id\",\"value\":\"200105\"}]",
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "policyCode": "due_date_change_cycle_notice",
+        "name": "결제일 변경 후 청구 기간 고지",
+        "description": "결제일 변경은 이용기간 산정, 첫 변경월 청구 기간, 두 달분 청구 가능성, 다음 출금일에 영향을 줄 수 있음을 안내한다.",
+        "severity": "MEDIUM",
+        "conditionJson": "{\"when\":\"billing_due_date_change_requested\",\"observedSignals\":[\"결제일 변경\",\"며칠부터\",\"두 달분\"]}",
+        "actionJson": "{\"disclose\":[\"newBillingCycle\",\"firstStatementImpact\",\"nextWithdrawalDate\"]}",
+        "evidenceJson": "[{\"type\":\"source_id\",\"value\":\"200052\"},{\"type\":\"source_id\",\"value\":\"200062\"}]",
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      },
+      {
+        "policyCode": "digital_payment_service_security_notice",
+        "name": "디지털 결제 서비스 보안/동의 안내",
+        "description": "일반결제서비스와 앱 결제 등록은 가입 알림, 본인 동의, 카드 사용 가능 상태, 보안 인증 절차를 확인해 안내한다.",
+        "severity": "HIGH",
+        "conditionJson": "{\"when\":\"digital_payment_service_discussed\",\"observedSignals\":[\"일반결제서비스\",\"앱 결제\",\"가입 완료\",\"등록\"]}",
+        "actionJson": "{\"verify\":[\"service_request_type\",\"authentication_channel\"],\"disclose\":[\"securityConsent\",\"eligibleCardStatus\",\"registrationEffect\"]}",
+        "evidenceJson": "[{\"type\":\"source_id\",\"value\":\"200103\"},{\"type\":\"source_id\",\"value\":\"200104\"}]",
+        "metaJson": "{\"source\":\"manager_merge_plan\"}"
+      }
+    ],
+    "risks": [
+      {
+        "riskCode": "identity_verification_failed",
+        "name": "본인 확인 실패",
+        "description": "본인 인증 또는 대체 인증이 실패해 개인 금융 정보 처리로 진행할 수 없는 상태",
+        "riskLevel": "HIGH",
+        "triggerConditionJson": "{\"signals\": [\"본인\", \"인증\", \"생년월일\"]}",
+        "handlingActionJson": "{\"action\": \"handoff\"}",
+        "evidenceJson": "[{\"type\": \"unit_id\", \"value\": \"200001:10:0\"}, {\"type\": \"unit_id\", \"value\": \"200001:15:1\"}, {\"type\": \"unit_id\", \"value\": \"200001:20:0\"}, {\"type\": \"unit_id\", \"value\": \"200001:27:0\"}, {\"type\": \"unit_id\", \"value\": \"200002:3:1\"}, {\"type\": \"unit_id\", \"value\": \"200002:32:1\"}, {\"type\": \"unit_id\", \"value\": \"200003:15:0\"}, {\"type\": \"unit_id\", \"value\": \"200004:8:2\"}, {\"type\": \"unit_id\", \"value\": \"200005:2:1\"}, {\"type\": \"unit_id\", \"value\": \"200007:5:1\"}, {\"type\": \"unit_id\", \"value\": \"200008:13:1\"}, {\"type\": \"unit_id\", \"value\": \"200008:15:0\"}]",
+        "metaJson": "{\"source\": \"direct_customer_agent_review\"}"
+      },
+      {
+        "riskCode": "lost_or_stolen_card_fraud",
+        "name": "분실/도난 카드 부정사용 위험",
+        "description": "분실 카드, 습득 카드, 미인지 거래가 포함되어 부정사용 확인이 필요한 상태",
+        "riskLevel": "CRITICAL",
+        "triggerConditionJson": "{\"signals\": [\"분실\", \"정지\", \"습득\", \"모르는\"]}",
+        "handlingActionJson": "{\"action\": \"block_or_dispute\"}",
+        "evidenceJson": "[{\"type\": \"unit_id\", \"value\": \"200001:17:0\"}, {\"type\": \"unit_id\", \"value\": \"200001:35:1\"}, {\"type\": \"unit_id\", \"value\": \"200002:1:0\"}, {\"type\": \"unit_id\", \"value\": \"200002:6:1\"}, {\"type\": \"unit_id\", \"value\": \"200002:10:0\"}, {\"type\": \"unit_id\", \"value\": \"200002:10:1\"}, {\"type\": \"unit_id\", \"value\": \"200002:13:0\"}, {\"type\": \"unit_id\", \"value\": \"200002:14:0\"}, {\"type\": \"unit_id\", \"value\": \"200002:15:0\"}, {\"type\": \"unit_id\", \"value\": \"200002:24:0\"}, {\"type\": \"unit_id\", \"value\": \"200002:27:0\"}, {\"type\": \"unit_id\", \"value\": \"200002:30:0\"}]",
+        "metaJson": "{\"source\": \"direct_customer_agent_review\"}"
+      },
+      {
+        "riskCode": "suspicious_or_unrecognized_transaction",
+        "name": "미인지 거래 분쟁 가능성",
+        "description": "고객이 승인/출금/취소 내역을 인지하지 못해 분쟁으로 이어질 수 있는 상태",
+        "riskLevel": "HIGH",
+        "triggerConditionJson": "{\"signals\": [\"승인\", \"문자\", \"취소\", \"이상\"]}",
+        "handlingActionJson": "{\"action\": \"verify_transaction\"}",
+        "evidenceJson": "[{\"type\": \"unit_id\", \"value\": \"200001:20:0\"}, {\"type\": \"unit_id\", \"value\": \"200002:24:0\"}, {\"type\": \"unit_id\", \"value\": \"200003:6:0\"}, {\"type\": \"unit_id\", \"value\": \"200003:12:0\"}, {\"type\": \"unit_id\", \"value\": \"200004:5:0\"}, {\"type\": \"unit_id\", \"value\": \"200006:33:1\"}, {\"type\": \"unit_id\", \"value\": \"200007:13:1\"}, {\"type\": \"unit_id\", \"value\": \"200008:6:0\"}, {\"type\": \"unit_id\", \"value\": \"200008:29:2\"}, {\"type\": \"unit_id\", \"value\": \"200012:3:0\"}, {\"type\": \"unit_id\", \"value\": \"200012:24:0\"}, {\"type\": \"unit_id\", \"value\": \"200012:26:0\"}]",
+        "metaJson": "{\"source\": \"direct_customer_agent_review\"}"
+      },
+      {
+        "riskCode": "payment_execution_error",
+        "name": "납부 실행/중복출금 위험",
+        "description": "선결제, 즉시출금, 가상계좌 입금 과정에서 중복 납부나 반영 지연이 발생할 수 있는 상태",
+        "riskLevel": "HIGH",
+        "triggerConditionJson": "{\"signals\": [\"선결제\", \"즉시출금\", \"가상계좌\", \"중복\"]}",
+        "handlingActionJson": "{\"action\": \"confirm_before_execution\"}",
+        "evidenceJson": "[{\"type\": \"unit_id\", \"value\": \"200020:2:0\"}, {\"type\": \"unit_id\", \"value\": \"200020:5:0\"}, {\"type\": \"unit_id\", \"value\": \"200020:24:0\"}, {\"type\": \"unit_id\", \"value\": \"200020:46:0\"}, {\"type\": \"unit_id\", \"value\": \"200020:46:1\"}, {\"type\": \"unit_id\", \"value\": \"200020:56:4\"}, {\"type\": \"unit_id\", \"value\": \"200024:3:0\"}, {\"type\": \"unit_id\", \"value\": \"200026:2:1\"}, {\"type\": \"unit_id\", \"value\": \"200029:36:0\"}, {\"type\": \"unit_id\", \"value\": \"200030:83:0\"}, {\"type\": \"unit_id\", \"value\": \"200034:22:0\"}, {\"type\": \"unit_id\", \"value\": \"200034:24:0\"}]",
+        "metaJson": "{\"source\": \"direct_customer_agent_review\"}"
+      },
+      {
+        "riskCode": "financial_product_disclosure",
+        "name": "금융상품 설명 부족 위험",
+        "description": "카드론, 현금서비스, 리볼빙, 할부, 한도상향 등 비용/심사 조건 고지가 필요한 상태",
+        "riskLevel": "HIGH",
+        "triggerConditionJson": "{\"signals\": [\"카드론\", \"대출\", \"리볼빙\", \"할부\", \"한도\"]}",
+        "handlingActionJson": "{\"action\": \"disclose_fee_and_terms\"}",
+        "evidenceJson": "[{\"type\": \"unit_id\", \"value\": \"200018:36:1\"}, {\"type\": \"unit_id\", \"value\": \"200020:48:0\"}, {\"type\": \"unit_id\", \"value\": \"200020:48:1\"}, {\"type\": \"unit_id\", \"value\": \"200020:51:2\"}, {\"type\": \"unit_id\", \"value\": \"200021:1:0\"}, {\"type\": \"unit_id\", \"value\": \"200021:11:1\"}, {\"type\": \"unit_id\", \"value\": \"200021:12:0\"}, {\"type\": \"unit_id\", \"value\": \"200021:15:0\"}, {\"type\": \"unit_id\", \"value\": \"200021:15:1\"}, {\"type\": \"unit_id\", \"value\": \"200021:18:1\"}, {\"type\": \"unit_id\", \"value\": \"200021:20:1\"}, {\"type\": \"unit_id\", \"value\": \"200021:22:0\"}]",
+        "metaJson": "{\"source\": \"direct_customer_agent_review\"}"
+      },
+      {
+        "riskCode": "benefit_condition_misunderstanding",
+        "name": "혜택 조건 오인 위험",
+        "description": "바우처, 캐시백, 포인트, 마일리지 조건을 고객이 오인할 수 있는 상태",
+        "riskLevel": "MEDIUM",
+        "triggerConditionJson": "{\"signals\": [\"바우처\", \"캐시백\", \"포인트\", \"마일리지\"]}",
+        "handlingActionJson": "{\"action\": \"explain_conditions\"}",
+        "evidenceJson": "[{\"type\": \"unit_id\", \"value\": \"200020:46:0\"}, {\"type\": \"unit_id\", \"value\": \"200020:51:1\"}, {\"type\": \"unit_id\", \"value\": \"200020:53:0\"}, {\"type\": \"unit_id\", \"value\": \"200020:56:0\"}, {\"type\": \"unit_id\", \"value\": \"200020:56:1\"}, {\"type\": \"unit_id\", \"value\": \"200021:35:0\"}, {\"type\": \"unit_id\", \"value\": \"200025:23:1\"}, {\"type\": \"unit_id\", \"value\": \"200032:3:1\"}, {\"type\": \"unit_id\", \"value\": \"200032:4:0\"}, {\"type\": \"unit_id\", \"value\": \"200032:8:1\"}, {\"type\": \"unit_id\", \"value\": \"200032:9:3\"}, {\"type\": \"unit_id\", \"value\": \"200032:15:0\"}]",
+        "metaJson": "{\"source\": \"direct_customer_agent_review\"}"
+      },
+      {
+        "riskCode": "card_closure_residual_charge",
+        "name": "카드 해지 후 잔여청구 위험",
+        "description": "카드 해지, 연회비 환급, 자동납부 잔여 청구 설명이 필요한 상태",
+        "riskLevel": "MEDIUM",
+        "triggerConditionJson": "{\"signals\": [\"해지\", \"연회비\", \"자동납부\"]}",
+        "handlingActionJson": "{\"action\": \"explain_residual_charge\"}",
+        "evidenceJson": "[{\"type\": \"unit_id\", \"value\": \"200001:35:1\"}, {\"type\": \"unit_id\", \"value\": \"200002:34:0\"}, {\"type\": \"unit_id\", \"value\": \"200008:19:1\"}, {\"type\": \"unit_id\", \"value\": \"200010:25:0\"}, {\"type\": \"unit_id\", \"value\": \"200010:31:0\"}, {\"type\": \"unit_id\", \"value\": \"200011:16:0\"}, {\"type\": \"unit_id\", \"value\": \"200011:17:0\"}, {\"type\": \"unit_id\", \"value\": \"200014:13:0\"}, {\"type\": \"unit_id\", \"value\": \"200021:32:1\"}, {\"type\": \"unit_id\", \"value\": \"200037:1:2\"}, {\"type\": \"unit_id\", \"value\": \"200053:12:0\"}, {\"type\": \"unit_id\", \"value\": \"200071:12:2\"}]",
+        "metaJson": "{\"source\": \"direct_customer_agent_review\"}"
+      },
+      {
+        "riskCode": "digital_payment_security",
+        "name": "디지털 결제 보안 위험",
+        "description": "일반결제, 앱 결제, 인증 서비스 등록/오류 처리 시 보안 확인이 필요한 상태",
+        "riskLevel": "HIGH",
+        "triggerConditionJson": "{\"signals\": [\"일반결제\", \"앱\", \"인증\", \"페이\"]}",
+        "handlingActionJson": "{\"action\": \"security_verify\"}",
+        "evidenceJson": "[{\"type\": \"unit_id\", \"value\": \"200001:10:0\"}, {\"type\": \"unit_id\", \"value\": \"200001:20:0\"}, {\"type\": \"unit_id\", \"value\": \"200001:27:0\"}, {\"type\": \"unit_id\", \"value\": \"200002:32:1\"}, {\"type\": \"unit_id\", \"value\": \"200008:29:1\"}, {\"type\": \"unit_id\", \"value\": \"200011:14:2\"}, {\"type\": \"unit_id\", \"value\": \"200022:57:0\"}, {\"type\": \"unit_id\", \"value\": \"200022:59:0\"}, {\"type\": \"unit_id\", \"value\": \"200022:60:0\"}, {\"type\": \"unit_id\", \"value\": \"200033:22:1\"}, {\"type\": \"unit_id\", \"value\": \"200034:21:1\"}, {\"type\": \"unit_id\", \"value\": \"200034:23:0\"}]",
+        "metaJson": "{\"source\": \"direct_customer_agent_review\"}"
+      }
+    ],
+    "workflows": [
+      {
+        "workflowCode": "lost_card_report_and_status_flow",
+        "name": "카드 분실 신고 및 정지/해제 상태 확인 워크플로우",
+        "description": "카드 분실, 습득, 정지, 분실 신고 해제, 재발급 후 사용 가능 여부와 마지막 이용 내역을 확인하는 상담",
+        "graphJson": "{\"direction\": \"LR\", \"nodes\": [{\"id\": \"start\", \"type\": \"START\", \"label\": \"시작\"}, {\"id\": \"capture_request\", \"type\": \"ACTION\", \"label\": \"요청 내용 확인\", \"policyRef\": \"customer_authentication_required\"}, {\"id\": \"collect_required_info\", \"type\": \"ACTION\", \"label\": \"필수 정보 수집\", \"policyRef\": \"target_card_and_account_verification\"}, {\"id\": \"verify_policy\", \"type\": \"ACTION\", \"label\": \"정책 확인 및 안내\", \"policyRef\": \"suspicious_use_and_dispute_escalation\"}, {\"id\": \"decision\", \"type\": \"DECISION\", \"label\": \"처리 가능 여부 판단\"}, {\"id\": \"terminal\", \"type\": \"TERMINAL\", \"label\": \"안내 완료\"}, {\"id\": \"handoff\", \"type\": \"HANDOFF\", \"label\": \"상담원 추가 확인\"}, {\"id\": \"terminal_handoff\", \"type\": \"TERMINAL\", \"label\": \"추가 확인 종료\"}], \"edges\": [{\"id\": \"e_1\", \"from\": \"start\", \"to\": \"capture_request\"}, {\"id\": \"e_2\", \"from\": \"capture_request\", \"to\": \"collect_required_info\"}, {\"id\": \"e_3\", \"from\": \"collect_required_info\", \"to\": \"verify_policy\"}, {\"id\": \"e_4\", \"from\": \"verify_policy\", \"to\": \"decision\"}, {\"id\": \"e_5\", \"from\": \"decision\", \"to\": \"terminal\", \"label\": \"resolved\"}, {\"id\": \"e_6\", \"from\": \"decision\", \"to\": \"handoff\", \"label\": \"needs_manual_check\"}, {\"id\": \"e_7\", \"from\": \"handoff\", \"to\": \"terminal_handoff\"}]}",
+        "evidenceJson": "[{\"type\": \"exemplar_conv_id\", \"value\": \"200001\"}, {\"type\": \"exemplar_conv_id\", \"value\": \"200002\"}, {\"type\": \"exemplar_conv_id\", \"value\": \"200005\"}, {\"type\": \"member_conv_id\", \"value\": \"200006\"}, {\"type\": \"member_conv_id\", \"value\": \"200007\"}, {\"type\": \"member_conv_id\", \"value\": \"200008\"}, {\"type\": \"member_conv_id\", \"value\": \"200009\"}, {\"type\": \"member_conv_id\", \"value\": \"200010\"}, {\"type\": \"member_conv_id\", \"value\": \"200011\"}, {\"type\": \"member_conv_id\", \"value\": \"200012\"}, {\"type\": \"member_conv_id\", \"value\": \"200013\"}, {\"type\": \"member_conv_id\", \"value\": \"200014\"}, {\"type\": \"member_conv_id\", \"value\": \"200015\"}, {\"type\": \"member_conv_id\", \"value\": \"200016\"}, {\"type\": \"member_conv_id\", \"value\": \"200017\"}]",
+        "metaJson": "{\"source\": \"manager_workflow_constructor_direct_review\", \"policyRefs\": [\"customer_authentication_required\", \"target_card_and_account_verification\", \"sensitive_auth_data_handling\", \"lost_card_block_release_notice\", \"suspicious_use_and_dispute_escalation\"]}",
+        "intentCode": "lost_card_report_and_status",
+        "isPrimary": true,
+        "routeConditionJson": "{\"requiredTerms\":[\"분실\",\"정지\",\"습득\",\"찾았\",\"해제\"],\"optionalTerms\":[\"재발급\",\"마지막 사용\",\"외국\",\"가족카드\",\"타사 카드\"]}"
+      },
+      {
+        "workflowCode": "payment_history_and_charge_inquiry_flow",
+        "name": "승인/출금/이용 내역 확인 워크플로우",
+        "description": "결제 승인, 문자 미수신, 명세서 금액, 해외/교통/인터넷 쇼핑 이용 내역, 출금 사유를 확인하는 상담",
+        "graphJson": "{\"direction\": \"LR\", \"nodes\": [{\"id\": \"start\", \"type\": \"START\", \"label\": \"시작\"}, {\"id\": \"capture_request\", \"type\": \"ACTION\", \"label\": \"요청 내용 확인\", \"policyRef\": \"customer_authentication_required\"}, {\"id\": \"collect_required_info\", \"type\": \"ACTION\", \"label\": \"필수 정보 수집\", \"policyRef\": \"target_card_and_account_verification\"}, {\"id\": \"verify_policy\", \"type\": \"ACTION\", \"label\": \"정책 확인 및 안내\", \"policyRef\": \"suspicious_use_and_dispute_escalation\"}, {\"id\": \"decision\", \"type\": \"DECISION\", \"label\": \"처리 가능 여부 판단\"}, {\"id\": \"terminal\", \"type\": \"TERMINAL\", \"label\": \"안내 완료\"}, {\"id\": \"handoff\", \"type\": \"HANDOFF\", \"label\": \"상담원 추가 확인\"}, {\"id\": \"terminal_handoff\", \"type\": \"TERMINAL\", \"label\": \"추가 확인 종료\"}], \"edges\": [{\"id\": \"e_1\", \"from\": \"start\", \"to\": \"capture_request\"}, {\"id\": \"e_2\", \"from\": \"capture_request\", \"to\": \"collect_required_info\"}, {\"id\": \"e_3\", \"from\": \"collect_required_info\", \"to\": \"verify_policy\"}, {\"id\": \"e_4\", \"from\": \"verify_policy\", \"to\": \"decision\"}, {\"id\": \"e_5\", \"from\": \"decision\", \"to\": \"terminal\", \"label\": \"resolved\"}, {\"id\": \"e_6\", \"from\": \"decision\", \"to\": \"handoff\", \"label\": \"needs_manual_check\"}, {\"id\": \"e_7\", \"from\": \"handoff\", \"to\": \"terminal_handoff\"}]}",
+        "evidenceJson": "[{\"type\": \"exemplar_conv_id\", \"value\": \"200003\"}, {\"type\": \"exemplar_conv_id\", \"value\": \"200004\"}, {\"type\": \"exemplar_conv_id\", \"value\": \"200008\"}, {\"type\": \"member_conv_id\", \"value\": \"200009\"}, {\"type\": \"member_conv_id\", \"value\": \"200014\"}, {\"type\": \"member_conv_id\", \"value\": \"200016\"}, {\"type\": \"member_conv_id\", \"value\": \"200018\"}, {\"type\": \"member_conv_id\", \"value\": \"200019\"}, {\"type\": \"member_conv_id\", \"value\": \"200027\"}, {\"type\": \"member_conv_id\", \"value\": \"200030\"}, {\"type\": \"member_conv_id\", \"value\": \"200031\"}, {\"type\": \"member_conv_id\", \"value\": \"200033\"}, {\"type\": \"member_conv_id\", \"value\": \"200035\"}, {\"type\": \"member_conv_id\", \"value\": \"200048\"}, {\"type\": \"member_conv_id\", \"value\": \"200057\"}]",
+        "metaJson": "{\"source\": \"manager_workflow_constructor_direct_review\", \"policyRefs\": [\"customer_authentication_required\", \"target_card_and_account_verification\", \"sensitive_auth_data_handling\", \"transaction_posting_delay_notice\", \"suspicious_use_and_dispute_escalation\"]}",
+        "intentCode": "payment_history_and_charge_inquiry",
+        "isPrimary": true,
+        "routeConditionJson": "{\"requiredTerms\":[\"결제\",\"승인\",\"출금\",\"이용 내역\",\"문자\"],\"optionalTerms\":[\"교통\",\"해외\",\"가맹점\",\"명세서\",\"누적 금액\"]}"
+      },
+      {
+        "workflowCode": "cancellation_refund_status_flow",
+        "name": "결제 취소/반품/환불 처리 확인 워크플로우",
+        "description": "가맹점 취소, 반품, 매출 취소 문자, 환불 입금처와 청구 차감 여부를 확인하는 상담",
+        "graphJson": "{\"direction\": \"LR\", \"nodes\": [{\"id\": \"start\", \"type\": \"START\", \"label\": \"시작\"}, {\"id\": \"capture_request\", \"type\": \"ACTION\", \"label\": \"요청 내용 확인\", \"policyRef\": \"customer_authentication_required\"}, {\"id\": \"collect_required_info\", \"type\": \"ACTION\", \"label\": \"필수 정보 수집\", \"policyRef\": \"target_card_and_account_verification\"}, {\"id\": \"verify_policy\", \"type\": \"ACTION\", \"label\": \"정책 확인 및 안내\", \"policyRef\": \"cancellation_refund_timing_notice\"}, {\"id\": \"decision\", \"type\": \"DECISION\", \"label\": \"처리 가능 여부 판단\"}, {\"id\": \"terminal\", \"type\": \"TERMINAL\", \"label\": \"안내 완료\"}, {\"id\": \"handoff\", \"type\": \"HANDOFF\", \"label\": \"상담원 추가 확인\"}, {\"id\": \"terminal_handoff\", \"type\": \"TERMINAL\", \"label\": \"추가 확인 종료\"}], \"edges\": [{\"id\": \"e_1\", \"from\": \"start\", \"to\": \"capture_request\"}, {\"id\": \"e_2\", \"from\": \"capture_request\", \"to\": \"collect_required_info\"}, {\"id\": \"e_3\", \"from\": \"collect_required_info\", \"to\": \"verify_policy\"}, {\"id\": \"e_4\", \"from\": \"verify_policy\", \"to\": \"decision\"}, {\"id\": \"e_5\", \"from\": \"decision\", \"to\": \"terminal\", \"label\": \"resolved\"}, {\"id\": \"e_6\", \"from\": \"decision\", \"to\": \"handoff\", \"label\": \"needs_manual_check\"}, {\"id\": \"e_7\", \"from\": \"handoff\", \"to\": \"terminal_handoff\"}]}",
+        "evidenceJson": "[{\"type\": \"exemplar_conv_id\", \"value\": \"200027\"}, {\"type\": \"exemplar_conv_id\", \"value\": \"200041\"}, {\"type\": \"exemplar_conv_id\", \"value\": \"200044\"}, {\"type\": \"member_conv_id\", \"value\": \"200058\"}, {\"type\": \"member_conv_id\", \"value\": \"200059\"}, {\"type\": \"member_conv_id\", \"value\": \"200064\"}, {\"type\": \"member_conv_id\", \"value\": \"200073\"}, {\"type\": \"member_conv_id\", \"value\": \"200092\"}, {\"type\": \"member_conv_id\", \"value\": \"200105\"}]",
+        "metaJson": "{\"source\": \"manager_workflow_constructor_direct_review\", \"policyRefs\": [\"customer_authentication_required\", \"target_card_and_account_verification\", \"transaction_posting_delay_notice\", \"cancellation_refund_timing_notice\"]}",
+        "intentCode": "cancellation_refund_status",
+        "isPrimary": true,
+        "routeConditionJson": "{\"requiredTerms\":[\"취소\",\"반품\",\"환불\",\"매출 취소\"],\"optionalTerms\":[\"문자\",\"청구\",\"입금\",\"가맹점\",\"카카오\"]}"
+      },
+      {
+        "workflowCode": "prepayment_and_immediate_payment_flow",
+        "name": "선결제/즉시출금/가상계좌 납부 워크플로우",
+        "description": "이번 달 결제금액, 일부 또는 전액 선결제, 즉시출금, 가상계좌 발급, 중복 입금과 납부 반영 여부를 처리하는 상담",
+        "graphJson": "{\"direction\": \"LR\", \"nodes\": [{\"id\": \"start\", \"type\": \"START\", \"label\": \"시작\"}, {\"id\": \"capture_request\", \"type\": \"ACTION\", \"label\": \"요청 내용 확인\", \"policyRef\": \"customer_authentication_required\"}, {\"id\": \"collect_required_info\", \"type\": \"ACTION\", \"label\": \"필수 정보 수집\", \"policyRef\": \"target_card_and_account_verification\"}, {\"id\": \"verify_policy\", \"type\": \"ACTION\", \"label\": \"정책 확인 및 안내\", \"policyRef\": \"prepayment_allocation_and_duplicate_payment_notice\"}, {\"id\": \"decision\", \"type\": \"DECISION\", \"label\": \"처리 가능 여부 판단\"}, {\"id\": \"terminal\", \"type\": \"TERMINAL\", \"label\": \"안내 완료\"}, {\"id\": \"handoff\", \"type\": \"HANDOFF\", \"label\": \"상담원 추가 확인\"}, {\"id\": \"terminal_handoff\", \"type\": \"TERMINAL\", \"label\": \"추가 확인 종료\"}], \"edges\": [{\"id\": \"e_1\", \"from\": \"start\", \"to\": \"capture_request\"}, {\"id\": \"e_2\", \"from\": \"capture_request\", \"to\": \"collect_required_info\"}, {\"id\": \"e_3\", \"from\": \"collect_required_info\", \"to\": \"verify_policy\"}, {\"id\": \"e_4\", \"from\": \"verify_policy\", \"to\": \"decision\"}, {\"id\": \"e_5\", \"from\": \"decision\", \"to\": \"terminal\", \"label\": \"resolved\"}, {\"id\": \"e_6\", \"from\": \"decision\", \"to\": \"handoff\", \"label\": \"needs_manual_check\"}, {\"id\": \"e_7\", \"from\": \"handoff\", \"to\": \"terminal_handoff\"}]}",
+        "evidenceJson": "[{\"type\": \"exemplar_conv_id\", \"value\": \"200018\"}, {\"type\": \"exemplar_conv_id\", \"value\": \"200020\"}, {\"type\": \"exemplar_conv_id\", \"value\": \"200024\"}, {\"type\": \"member_conv_id\", \"value\": \"200026\"}, {\"type\": \"member_conv_id\", \"value\": \"200034\"}, {\"type\": \"member_conv_id\", \"value\": \"200038\"}, {\"type\": \"member_conv_id\", \"value\": \"200040\"}, {\"type\": \"member_conv_id\", \"value\": \"200043\"}, {\"type\": \"member_conv_id\", \"value\": \"200045\"}, {\"type\": \"member_conv_id\", \"value\": \"200047\"}, {\"type\": \"member_conv_id\", \"value\": \"200053\"}, {\"type\": \"member_conv_id\", \"value\": \"200055\"}, {\"type\": \"member_conv_id\", \"value\": \"200056\"}, {\"type\": \"member_conv_id\", \"value\": \"200060\"}, {\"type\": \"member_conv_id\", \"value\": \"200068\"}]",
+        "metaJson": "{\"source\": \"manager_workflow_constructor_direct_review\", \"policyRefs\": [\"customer_authentication_required\", \"target_card_and_account_verification\", \"sensitive_auth_data_handling\", \"payment_execution_consent_and_account_check\", \"prepayment_allocation_and_duplicate_payment_notice\"]}",
+        "intentCode": "prepayment_and_immediate_payment",
+        "isPrimary": true,
+        "routeConditionJson": "{\"requiredTerms\":[\"선결제\",\"즉시출금\",\"가상계좌\",\"입금\",\"결제금액\"],\"optionalTerms\":[\"전액\",\"일부\",\"잔액\",\"중복\",\"예약\"]}"
+      },
+      {
+        "workflowCode": "card_loan_and_cash_advance_management_flow",
+        "name": "카드론/현금서비스 한도 및 상환 워크플로우",
+        "description": "장기카드대출, 단기카드대출, 현금서비스 가능 여부, 한도, 이자, 원금, 즉시 상환 또는 완납을 확인하는 상담",
+        "graphJson": "{\"direction\": \"LR\", \"nodes\": [{\"id\": \"start\", \"type\": \"START\", \"label\": \"시작\"}, {\"id\": \"capture_request\", \"type\": \"ACTION\", \"label\": \"요청 내용 확인\", \"policyRef\": \"customer_authentication_required\"}, {\"id\": \"collect_required_info\", \"type\": \"ACTION\", \"label\": \"필수 정보 수집\", \"policyRef\": \"sensitive_auth_data_handling\"}, {\"id\": \"verify_policy\", \"type\": \"ACTION\", \"label\": \"정책 확인 및 안내\", \"policyRef\": \"credit_loan_assessment_and_fee_notice\"}, {\"id\": \"decision\", \"type\": \"DECISION\", \"label\": \"처리 가능 여부 판단\"}, {\"id\": \"terminal\", \"type\": \"TERMINAL\", \"label\": \"안내 완료\"}, {\"id\": \"handoff\", \"type\": \"HANDOFF\", \"label\": \"상담원 추가 확인\"}, {\"id\": \"terminal_handoff\", \"type\": \"TERMINAL\", \"label\": \"추가 확인 종료\"}], \"edges\": [{\"id\": \"e_1\", \"from\": \"start\", \"to\": \"capture_request\"}, {\"id\": \"e_2\", \"from\": \"capture_request\", \"to\": \"collect_required_info\"}, {\"id\": \"e_3\", \"from\": \"collect_required_info\", \"to\": \"verify_policy\"}, {\"id\": \"e_4\", \"from\": \"verify_policy\", \"to\": \"decision\"}, {\"id\": \"e_5\", \"from\": \"decision\", \"to\": \"terminal\", \"label\": \"resolved\"}, {\"id\": \"e_6\", \"from\": \"decision\", \"to\": \"handoff\", \"label\": \"needs_manual_check\"}, {\"id\": \"e_7\", \"from\": \"handoff\", \"to\": \"terminal_handoff\"}]}",
+        "evidenceJson": "[{\"type\": \"exemplar_conv_id\", \"value\": \"200020\"}, {\"type\": \"exemplar_conv_id\", \"value\": \"200021\"}, {\"type\": \"exemplar_conv_id\", \"value\": \"200026\"}, {\"type\": \"member_conv_id\", \"value\": \"200029\"}, {\"type\": \"member_conv_id\", \"value\": \"200045\"}, {\"type\": \"member_conv_id\", \"value\": \"200046\"}, {\"type\": \"member_conv_id\", \"value\": \"200060\"}, {\"type\": \"member_conv_id\", \"value\": \"200061\"}, {\"type\": \"member_conv_id\", \"value\": \"200065\"}, {\"type\": \"member_conv_id\", \"value\": \"200077\"}, {\"type\": \"member_conv_id\", \"value\": \"200080\"}, {\"type\": \"member_conv_id\", \"value\": \"200083\"}, {\"type\": \"member_conv_id\", \"value\": \"200091\"}]",
+        "metaJson": "{\"source\": \"manager_workflow_constructor_direct_review\", \"policyRefs\": [\"customer_authentication_required\", \"sensitive_auth_data_handling\", \"payment_execution_consent_and_account_check\", \"credit_loan_assessment_and_fee_notice\"]}",
+        "intentCode": "card_loan_and_cash_advance_management",
+        "isPrimary": true,
+        "routeConditionJson": "{\"requiredTerms\":[\"카드론\",\"장기 대출\",\"단기카드대출\",\"현금서비스\"],\"optionalTerms\":[\"한도\",\"이자\",\"원금\",\"상환\",\"완납\"]}"
+      },
+      {
+        "workflowCode": "revolving_service_management_flow",
+        "name": "리볼빙 서비스 조회/해지/납부 안내 워크플로우",
+        "description": "리볼빙 약정 여부, 이월 금액, 이자, 결제일 인출 방식, 리볼빙 해지 또는 납부 방법을 확인하는 상담",
+        "graphJson": "{\"direction\": \"LR\", \"nodes\": [{\"id\": \"start\", \"type\": \"START\", \"label\": \"시작\"}, {\"id\": \"capture_request\", \"type\": \"ACTION\", \"label\": \"요청 내용 확인\", \"policyRef\": \"customer_authentication_required\"}, {\"id\": \"collect_required_info\", \"type\": \"ACTION\", \"label\": \"필수 정보 수집\", \"policyRef\": \"target_card_and_account_verification\"}, {\"id\": \"verify_policy\", \"type\": \"ACTION\", \"label\": \"정책 확인 및 안내\", \"policyRef\": \"revolving_installment_fee_and_statement_notice\"}, {\"id\": \"decision\", \"type\": \"DECISION\", \"label\": \"처리 가능 여부 판단\"}, {\"id\": \"terminal\", \"type\": \"TERMINAL\", \"label\": \"안내 완료\"}, {\"id\": \"handoff\", \"type\": \"HANDOFF\", \"label\": \"상담원 추가 확인\"}, {\"id\": \"terminal_handoff\", \"type\": \"TERMINAL\", \"label\": \"추가 확인 종료\"}], \"edges\": [{\"id\": \"e_1\", \"from\": \"start\", \"to\": \"capture_request\"}, {\"id\": \"e_2\", \"from\": \"capture_request\", \"to\": \"collect_required_info\"}, {\"id\": \"e_3\", \"from\": \"collect_required_info\", \"to\": \"verify_policy\"}, {\"id\": \"e_4\", \"from\": \"verify_policy\", \"to\": \"decision\"}, {\"id\": \"e_5\", \"from\": \"decision\", \"to\": \"terminal\", \"label\": \"resolved\"}, {\"id\": \"e_6\", \"from\": \"decision\", \"to\": \"handoff\", \"label\": \"needs_manual_check\"}, {\"id\": \"e_7\", \"from\": \"handoff\", \"to\": \"terminal_handoff\"}]}",
+        "evidenceJson": "[{\"type\": \"exemplar_conv_id\", \"value\": \"200034\"}, {\"type\": \"exemplar_conv_id\", \"value\": \"200070\"}, {\"type\": \"exemplar_conv_id\", \"value\": \"200087\"}, {\"type\": \"member_conv_id\", \"value\": \"200095\"}]",
+        "metaJson": "{\"source\": \"manager_workflow_constructor_direct_review\", \"policyRefs\": [\"customer_authentication_required\", \"target_card_and_account_verification\", \"payment_execution_consent_and_account_check\", \"revolving_installment_fee_and_statement_notice\"]}",
+        "intentCode": "revolving_service_management",
+        "isPrimary": true,
+        "routeConditionJson": "{\"requiredTerms\":[\"리볼빙\"],\"optionalTerms\":[\"이월\",\"이자\",\"해지\",\"소액결제\",\"재인출\"]}"
+      },
+      {
+        "workflowCode": "installment_conversion_or_split_payment_flow",
+        "name": "할부 전환/분할 납부 워크플로우",
+        "description": "일시불 결제를 할부로 변경하거나 분할 납부 가능 여부, 할부 개월 수, 수수료와 확정 시점을 확인하는 상담",
+        "graphJson": "{\"direction\": \"LR\", \"nodes\": [{\"id\": \"start\", \"type\": \"START\", \"label\": \"시작\"}, {\"id\": \"capture_request\", \"type\": \"ACTION\", \"label\": \"요청 내용 확인\", \"policyRef\": \"customer_authentication_required\"}, {\"id\": \"collect_required_info\", \"type\": \"ACTION\", \"label\": \"필수 정보 수집\", \"policyRef\": \"target_card_and_account_verification\"}, {\"id\": \"verify_policy\", \"type\": \"ACTION\", \"label\": \"정책 확인 및 안내\", \"policyRef\": \"revolving_installment_fee_and_statement_notice\"}, {\"id\": \"decision\", \"type\": \"DECISION\", \"label\": \"처리 가능 여부 판단\"}, {\"id\": \"terminal\", \"type\": \"TERMINAL\", \"label\": \"안내 완료\"}, {\"id\": \"handoff\", \"type\": \"HANDOFF\", \"label\": \"상담원 추가 확인\"}, {\"id\": \"terminal_handoff\", \"type\": \"TERMINAL\", \"label\": \"추가 확인 종료\"}], \"edges\": [{\"id\": \"e_1\", \"from\": \"start\", \"to\": \"capture_request\"}, {\"id\": \"e_2\", \"from\": \"capture_request\", \"to\": \"collect_required_info\"}, {\"id\": \"e_3\", \"from\": \"collect_required_info\", \"to\": \"verify_policy\"}, {\"id\": \"e_4\", \"from\": \"verify_policy\", \"to\": \"decision\"}, {\"id\": \"e_5\", \"from\": \"decision\", \"to\": \"terminal\", \"label\": \"resolved\"}, {\"id\": \"e_6\", \"from\": \"decision\", \"to\": \"handoff\", \"label\": \"needs_manual_check\"}, {\"id\": \"e_7\", \"from\": \"handoff\", \"to\": \"terminal_handoff\"}]}",
+        "evidenceJson": "[{\"type\": \"exemplar_conv_id\", \"value\": \"200063\"}, {\"type\": \"exemplar_conv_id\", \"value\": \"200069\"}, {\"type\": \"exemplar_conv_id\", \"value\": \"200072\"}, {\"type\": \"member_conv_id\", \"value\": \"200082\"}, {\"type\": \"member_conv_id\", \"value\": \"200100\"}]",
+        "metaJson": "{\"source\": \"manager_workflow_constructor_direct_review\", \"policyRefs\": [\"customer_authentication_required\", \"target_card_and_account_verification\", \"transaction_posting_delay_notice\", \"revolving_installment_fee_and_statement_notice\"]}",
+        "intentCode": "installment_conversion_or_split_payment",
+        "isPrimary": true,
+        "routeConditionJson": "{\"requiredTerms\":[\"할부\",\"분할 납부\",\"분할 결제\"],\"optionalTerms\":[\"개월\",\"수수료\",\"확정\",\"변경\"]}"
+      },
+      {
+        "workflowCode": "card_limit_management_flow",
+        "name": "카드 이용한도 조회/상향 워크플로우",
+        "description": "신용카드 통합 한도, 일시불/할부 가능 한도, 현금서비스 한도, 한도 상향 가능 여부와 요청 금액을 확인하는 상담",
+        "graphJson": "{\"direction\": \"LR\", \"nodes\": [{\"id\": \"start\", \"type\": \"START\", \"label\": \"시작\"}, {\"id\": \"capture_request\", \"type\": \"ACTION\", \"label\": \"요청 내용 확인\", \"policyRef\": \"customer_authentication_required\"}, {\"id\": \"collect_required_info\", \"type\": \"ACTION\", \"label\": \"필수 정보 수집\", \"policyRef\": \"sensitive_auth_data_handling\"}, {\"id\": \"verify_policy\", \"type\": \"ACTION\", \"label\": \"정책 확인 및 안내\", \"policyRef\": \"limit_change_assessment_notice\"}, {\"id\": \"decision\", \"type\": \"DECISION\", \"label\": \"처리 가능 여부 판단\"}, {\"id\": \"terminal\", \"type\": \"TERMINAL\", \"label\": \"안내 완료\"}, {\"id\": \"handoff\", \"type\": \"HANDOFF\", \"label\": \"상담원 추가 확인\"}, {\"id\": \"terminal_handoff\", \"type\": \"TERMINAL\", \"label\": \"추가 확인 종료\"}], \"edges\": [{\"id\": \"e_1\", \"from\": \"start\", \"to\": \"capture_request\"}, {\"id\": \"e_2\", \"from\": \"capture_request\", \"to\": \"collect_required_info\"}, {\"id\": \"e_3\", \"from\": \"collect_required_info\", \"to\": \"verify_policy\"}, {\"id\": \"e_4\", \"from\": \"verify_policy\", \"to\": \"decision\"}, {\"id\": \"e_5\", \"from\": \"decision\", \"to\": \"terminal\", \"label\": \"resolved\"}, {\"id\": \"e_6\", \"from\": \"decision\", \"to\": \"handoff\", \"label\": \"needs_manual_check\"}, {\"id\": \"e_7\", \"from\": \"handoff\", \"to\": \"terminal_handoff\"}]}",
+        "evidenceJson": "[{\"type\": \"exemplar_conv_id\", \"value\": \"200018\"}, {\"type\": \"exemplar_conv_id\", \"value\": \"200034\"}, {\"type\": \"exemplar_conv_id\", \"value\": \"200043\"}, {\"type\": \"member_conv_id\", \"value\": \"200047\"}, {\"type\": \"member_conv_id\", \"value\": \"200054\"}, {\"type\": \"member_conv_id\", \"value\": \"200067\"}, {\"type\": \"member_conv_id\", \"value\": \"200091\"}, {\"type\": \"member_conv_id\", \"value\": \"200102\"}]",
+        "metaJson": "{\"source\": \"manager_workflow_constructor_direct_review\", \"policyRefs\": [\"customer_authentication_required\", \"sensitive_auth_data_handling\", \"limit_change_assessment_notice\"]}",
+        "intentCode": "card_limit_management",
+        "isPrimary": true,
+        "routeConditionJson": "{\"requiredTerms\":[\"한도\",\"상향\"],\"optionalTerms\":[\"통합 한도\",\"사용 가능\",\"현금서비스\",\"일시불\",\"할부\"]}"
+      },
+      {
+        "workflowCode": "benefit_points_voucher_management_flow",
+        "name": "혜택/할인/포인트/바우처 처리 워크플로우",
+        "description": "카드 혜택 적용 여부, 캐시백/할인, 포인트 또는 마일 전환, 바우처와 상품권 신청, 프로모션 조건을 확인하는 상담",
+        "graphJson": "{\"direction\": \"LR\", \"nodes\": [{\"id\": \"start\", \"type\": \"START\", \"label\": \"시작\"}, {\"id\": \"capture_request\", \"type\": \"ACTION\", \"label\": \"요청 내용 확인\", \"policyRef\": \"customer_authentication_required\"}, {\"id\": \"collect_required_info\", \"type\": \"ACTION\", \"label\": \"필수 정보 수집\", \"policyRef\": \"target_card_and_account_verification\"}, {\"id\": \"verify_policy\", \"type\": \"ACTION\", \"label\": \"정책 확인 및 안내\", \"policyRef\": \"benefit_eligibility_and_exclusion_notice\"}, {\"id\": \"decision\", \"type\": \"DECISION\", \"label\": \"처리 가능 여부 판단\"}, {\"id\": \"terminal\", \"type\": \"TERMINAL\", \"label\": \"안내 완료\"}, {\"id\": \"handoff\", \"type\": \"HANDOFF\", \"label\": \"상담원 추가 확인\"}, {\"id\": \"terminal_handoff\", \"type\": \"TERMINAL\", \"label\": \"추가 확인 종료\"}], \"edges\": [{\"id\": \"e_1\", \"from\": \"start\", \"to\": \"capture_request\"}, {\"id\": \"e_2\", \"from\": \"capture_request\", \"to\": \"collect_required_info\"}, {\"id\": \"e_3\", \"from\": \"collect_required_info\", \"to\": \"verify_policy\"}, {\"id\": \"e_4\", \"from\": \"verify_policy\", \"to\": \"decision\"}, {\"id\": \"e_5\", \"from\": \"decision\", \"to\": \"terminal\", \"label\": \"resolved\"}, {\"id\": \"e_6\", \"from\": \"decision\", \"to\": \"handoff\", \"label\": \"needs_manual_check\"}, {\"id\": \"e_7\", \"from\": \"handoff\", \"to\": \"terminal_handoff\"}]}",
+        "evidenceJson": "[{\"type\": \"exemplar_conv_id\", \"value\": \"200021\"}, {\"type\": \"exemplar_conv_id\", \"value\": \"200022\"}, {\"type\": \"exemplar_conv_id\", \"value\": \"200025\"}, {\"type\": \"member_conv_id\", \"value\": \"200028\"}, {\"type\": \"member_conv_id\", \"value\": \"200032\"}, {\"type\": \"member_conv_id\", \"value\": \"200033\"}, {\"type\": \"member_conv_id\", \"value\": \"200036\"}, {\"type\": \"member_conv_id\", \"value\": \"200042\"}, {\"type\": \"member_conv_id\", \"value\": \"200079\"}, {\"type\": \"member_conv_id\", \"value\": \"200085\"}, {\"type\": \"member_conv_id\", \"value\": \"200086\"}, {\"type\": \"member_conv_id\", \"value\": \"200103\"}]",
+        "metaJson": "{\"source\": \"manager_workflow_constructor_direct_review\", \"policyRefs\": [\"customer_authentication_required\", \"target_card_and_account_verification\", \"transaction_posting_delay_notice\", \"benefit_eligibility_and_exclusion_notice\"]}",
+        "intentCode": "benefit_points_voucher_management",
+        "isPrimary": true,
+        "routeConditionJson": "{\"requiredTerms\":[\"혜택\",\"할인\",\"포인트\",\"마일\",\"바우처\",\"상품권\",\"프로모션\"],\"optionalTerms\":[\"캐시백\",\"실적\",\"면세점\",\"적립\",\"전환\"]}"
+      },
+      {
+        "workflowCode": "recurring_payment_management_flow",
+        "name": "자동납부/자동결제 등록 및 상태 확인 워크플로우",
+        "description": "학교, 통신, 정수기, 보험료 등 자동납부 신청, 실패, 카드 재발급 이후 재등록 필요 여부와 결제 상태를 확인하는 상담",
+        "graphJson": "{\"direction\": \"LR\", \"nodes\": [{\"id\": \"start\", \"type\": \"START\", \"label\": \"시작\"}, {\"id\": \"capture_request\", \"type\": \"ACTION\", \"label\": \"요청 내용 확인\", \"policyRef\": \"customer_authentication_required\"}, {\"id\": \"collect_required_info\", \"type\": \"ACTION\", \"label\": \"필수 정보 수집\", \"policyRef\": \"target_card_and_account_verification\"}, {\"id\": \"verify_policy\", \"type\": \"ACTION\", \"label\": \"정책 확인 및 안내\", \"policyRef\": \"card_delivery_activation_and_expiry_notice\"}, {\"id\": \"decision\", \"type\": \"DECISION\", \"label\": \"처리 가능 여부 판단\"}, {\"id\": \"terminal\", \"type\": \"TERMINAL\", \"label\": \"안내 완료\"}, {\"id\": \"handoff\", \"type\": \"HANDOFF\", \"label\": \"상담원 추가 확인\"}, {\"id\": \"terminal_handoff\", \"type\": \"TERMINAL\", \"label\": \"추가 확인 종료\"}], \"edges\": [{\"id\": \"e_1\", \"from\": \"start\", \"to\": \"capture_request\"}, {\"id\": \"e_2\", \"from\": \"capture_request\", \"to\": \"collect_required_info\"}, {\"id\": \"e_3\", \"from\": \"collect_required_info\", \"to\": \"verify_policy\"}, {\"id\": \"e_4\", \"from\": \"verify_policy\", \"to\": \"decision\"}, {\"id\": \"e_5\", \"from\": \"decision\", \"to\": \"terminal\", \"label\": \"resolved\"}, {\"id\": \"e_6\", \"from\": \"decision\", \"to\": \"handoff\", \"label\": \"needs_manual_check\"}, {\"id\": \"e_7\", \"from\": \"handoff\", \"to\": \"terminal_handoff\"}]}",
+        "evidenceJson": "[{\"type\": \"exemplar_conv_id\", \"value\": \"200016\"}, {\"type\": \"exemplar_conv_id\", \"value\": \"200017\"}, {\"type\": \"exemplar_conv_id\", \"value\": \"200037\"}, {\"type\": \"member_conv_id\", \"value\": \"200042\"}, {\"type\": \"member_conv_id\", \"value\": \"200066\"}, {\"type\": \"member_conv_id\", \"value\": \"200072\"}, {\"type\": \"member_conv_id\", \"value\": \"200084\"}, {\"type\": \"member_conv_id\", \"value\": \"200090\"}]",
+        "metaJson": "{\"source\": \"manager_workflow_constructor_direct_review\", \"policyRefs\": [\"customer_authentication_required\", \"target_card_and_account_verification\", \"sensitive_auth_data_handling\", \"recurring_payment_merchant_coordination_notice\", \"card_delivery_activation_and_expiry_notice\"]}",
+        "intentCode": "recurring_payment_management",
+        "isPrimary": true,
+        "routeConditionJson": "{\"requiredTerms\":[\"자동납부\",\"자동결제\",\"자동 이체\"],\"optionalTerms\":[\"학교\",\"통신\",\"정수기\",\"보험료\",\"재발급\"]}"
+      },
+      {
+        "workflowCode": "card_issue_delivery_activation_flow",
+        "name": "카드 발급/배송/수령/사용등록 워크플로우",
+        "description": "신규 또는 갱신 카드 신청, 긴급 배송, 영업점/자택 수령, 가족카드 사용등록, 유효기간 만료 후 사용 가능 여부를 확인하는 상담",
+        "graphJson": "{\"direction\": \"LR\", \"nodes\": [{\"id\": \"start\", \"type\": \"START\", \"label\": \"시작\"}, {\"id\": \"capture_request\", \"type\": \"ACTION\", \"label\": \"요청 내용 확인\", \"policyRef\": \"customer_authentication_required\"}, {\"id\": \"collect_required_info\", \"type\": \"ACTION\", \"label\": \"필수 정보 수집\", \"policyRef\": \"target_card_and_account_verification\"}, {\"id\": \"verify_policy\", \"type\": \"ACTION\", \"label\": \"정책 확인 및 안내\", \"policyRef\": \"card_delivery_activation_and_expiry_notice\"}, {\"id\": \"decision\", \"type\": \"DECISION\", \"label\": \"처리 가능 여부 판단\"}, {\"id\": \"terminal\", \"type\": \"TERMINAL\", \"label\": \"안내 완료\"}, {\"id\": \"handoff\", \"type\": \"HANDOFF\", \"label\": \"상담원 추가 확인\"}, {\"id\": \"terminal_handoff\", \"type\": \"TERMINAL\", \"label\": \"추가 확인 종료\"}], \"edges\": [{\"id\": \"e_1\", \"from\": \"start\", \"to\": \"capture_request\"}, {\"id\": \"e_2\", \"from\": \"capture_request\", \"to\": \"collect_required_info\"}, {\"id\": \"e_3\", \"from\": \"collect_required_info\", \"to\": \"verify_policy\"}, {\"id\": \"e_4\", \"from\": \"verify_policy\", \"to\": \"decision\"}, {\"id\": \"e_5\", \"from\": \"decision\", \"to\": \"terminal\", \"label\": \"resolved\"}, {\"id\": \"e_6\", \"from\": \"decision\", \"to\": \"handoff\", \"label\": \"needs_manual_check\"}, {\"id\": \"e_7\", \"from\": \"handoff\", \"to\": \"terminal_handoff\"}]}",
+        "evidenceJson": "[{\"type\": \"exemplar_conv_id\", \"value\": \"200016\"}, {\"type\": \"exemplar_conv_id\", \"value\": \"200025\"}, {\"type\": \"exemplar_conv_id\", \"value\": \"200068\"}, {\"type\": \"member_conv_id\", \"value\": \"200081\"}, {\"type\": \"member_conv_id\", \"value\": \"200084\"}, {\"type\": \"member_conv_id\", \"value\": \"200096\"}, {\"type\": \"member_conv_id\", \"value\": \"200099\"}, {\"type\": \"member_conv_id\", \"value\": \"200103\"}, {\"type\": \"member_conv_id\", \"value\": \"200104\"}, {\"type\": \"member_conv_id\", \"value\": \"200105\"}]",
+        "metaJson": "{\"source\": \"manager_workflow_constructor_direct_review\", \"policyRefs\": [\"customer_authentication_required\", \"target_card_and_account_verification\", \"sensitive_auth_data_handling\", \"card_delivery_activation_and_expiry_notice\"]}",
+        "intentCode": "card_issue_delivery_activation",
+        "isPrimary": true,
+        "routeConditionJson": "{\"requiredTerms\":[\"발급\",\"배송\",\"수령\",\"사용 등록\",\"유효기간\"],\"optionalTerms\":[\"긴급\",\"영업점\",\"가족카드\",\"앱 결제\",\"챗봇\"]}"
+      },
+      {
+        "workflowCode": "card_close_and_annual_fee_refund_flow",
+        "name": "카드 해지 및 연회비/잔여금 환급 워크플로우",
+        "description": "신용카드 해지, 해지 후 연회비 환급 또는 차감, 자동결제 잔존 여부, 결제계좌 환급 상태를 확인하는 상담",
+        "graphJson": "{\"direction\": \"LR\", \"nodes\": [{\"id\": \"start\", \"type\": \"START\", \"label\": \"시작\"}, {\"id\": \"capture_request\", \"type\": \"ACTION\", \"label\": \"요청 내용 확인\", \"policyRef\": \"customer_authentication_required\"}, {\"id\": \"collect_required_info\", \"type\": \"ACTION\", \"label\": \"필수 정보 수집\", \"policyRef\": \"target_card_and_account_verification\"}, {\"id\": \"verify_policy\", \"type\": \"ACTION\", \"label\": \"정책 확인 및 안내\", \"policyRef\": \"card_close_annual_fee_refund_notice\"}, {\"id\": \"decision\", \"type\": \"DECISION\", \"label\": \"처리 가능 여부 판단\"}, {\"id\": \"terminal\", \"type\": \"TERMINAL\", \"label\": \"안내 완료\"}, {\"id\": \"handoff\", \"type\": \"HANDOFF\", \"label\": \"상담원 추가 확인\"}, {\"id\": \"terminal_handoff\", \"type\": \"TERMINAL\", \"label\": \"추가 확인 종료\"}], \"edges\": [{\"id\": \"e_1\", \"from\": \"start\", \"to\": \"capture_request\"}, {\"id\": \"e_2\", \"from\": \"capture_request\", \"to\": \"collect_required_info\"}, {\"id\": \"e_3\", \"from\": \"collect_required_info\", \"to\": \"verify_policy\"}, {\"id\": \"e_4\", \"from\": \"verify_policy\", \"to\": \"decision\"}, {\"id\": \"e_5\", \"from\": \"decision\", \"to\": \"terminal\", \"label\": \"resolved\"}, {\"id\": \"e_6\", \"from\": \"decision\", \"to\": \"handoff\", \"label\": \"needs_manual_check\"}, {\"id\": \"e_7\", \"from\": \"handoff\", \"to\": \"terminal_handoff\"}]}",
+        "evidenceJson": "[{\"type\": \"exemplar_conv_id\", \"value\": \"200088\"}, {\"type\": \"exemplar_conv_id\", \"value\": \"200090\"}, {\"type\": \"exemplar_conv_id\", \"value\": \"200105\"}]",
+        "metaJson": "{\"source\": \"manager_workflow_constructor_direct_review\", \"policyRefs\": [\"customer_authentication_required\", \"target_card_and_account_verification\", \"recurring_payment_merchant_coordination_notice\", \"card_close_annual_fee_refund_notice\"]}",
+        "intentCode": "card_close_and_annual_fee_refund",
+        "isPrimary": true,
+        "routeConditionJson": "{\"requiredTerms\":[\"해지\",\"연회비\",\"환급\"],\"optionalTerms\":[\"차감\",\"자동결제\",\"결제계좌\",\"갱신\"]}"
+      },
+      {
+        "workflowCode": "billing_cycle_due_date_change_flow",
+        "name": "결제일/청구 주기 변경 워크플로우",
+        "description": "카드 결제일 변경, 이용기간 산정, 변경 후 청구월과 이중 청구 가능성을 확인하는 상담",
+        "graphJson": "{\"direction\": \"LR\", \"nodes\": [{\"id\": \"start\", \"type\": \"START\", \"label\": \"시작\"}, {\"id\": \"capture_request\", \"type\": \"ACTION\", \"label\": \"요청 내용 확인\", \"policyRef\": \"customer_authentication_required\"}, {\"id\": \"collect_required_info\", \"type\": \"ACTION\", \"label\": \"필수 정보 수집\", \"policyRef\": \"target_card_and_account_verification\"}, {\"id\": \"verify_policy\", \"type\": \"ACTION\", \"label\": \"정책 확인 및 안내\", \"policyRef\": \"due_date_change_cycle_notice\"}, {\"id\": \"decision\", \"type\": \"DECISION\", \"label\": \"처리 가능 여부 판단\"}, {\"id\": \"terminal\", \"type\": \"TERMINAL\", \"label\": \"안내 완료\"}, {\"id\": \"handoff\", \"type\": \"HANDOFF\", \"label\": \"상담원 추가 확인\"}, {\"id\": \"terminal_handoff\", \"type\": \"TERMINAL\", \"label\": \"추가 확인 종료\"}], \"edges\": [{\"id\": \"e_1\", \"from\": \"start\", \"to\": \"capture_request\"}, {\"id\": \"e_2\", \"from\": \"capture_request\", \"to\": \"collect_required_info\"}, {\"id\": \"e_3\", \"from\": \"collect_required_info\", \"to\": \"verify_policy\"}, {\"id\": \"e_4\", \"from\": \"verify_policy\", \"to\": \"decision\"}, {\"id\": \"e_5\", \"from\": \"decision\", \"to\": \"terminal\", \"label\": \"resolved\"}, {\"id\": \"e_6\", \"from\": \"decision\", \"to\": \"handoff\", \"label\": \"needs_manual_check\"}, {\"id\": \"e_7\", \"from\": \"handoff\", \"to\": \"terminal_handoff\"}]}",
+        "evidenceJson": "[{\"type\": \"exemplar_conv_id\", \"value\": \"200052\"}, {\"type\": \"exemplar_conv_id\", \"value\": \"200062\"}]",
+        "metaJson": "{\"source\": \"manager_workflow_constructor_direct_review\", \"policyRefs\": [\"customer_authentication_required\", \"target_card_and_account_verification\", \"prepayment_allocation_and_duplicate_payment_notice\", \"due_date_change_cycle_notice\"]}",
+        "intentCode": "billing_cycle_due_date_change",
+        "isPrimary": true,
+        "routeConditionJson": "{\"requiredTerms\":[\"결제일\",\"변경\"],\"optionalTerms\":[\"청구\",\"이용기간\",\"며칠부터\",\"며칠까지\"]}"
+      },
+      {
+        "workflowCode": "digital_payment_service_registration_flow",
+        "name": "일반결제/앱 결제 서비스 등록 및 오류 워크플로우",
+        "description": "일반결제서비스 가입 알림, 앱 결제 불가, 온라인 결제 서비스 사용 조건과 보안 동의 여부를 확인하는 상담",
+        "graphJson": "{\"direction\": \"LR\", \"nodes\": [{\"id\": \"start\", \"type\": \"START\", \"label\": \"시작\"}, {\"id\": \"capture_request\", \"type\": \"ACTION\", \"label\": \"요청 내용 확인\", \"policyRef\": \"customer_authentication_required\"}, {\"id\": \"collect_required_info\", \"type\": \"ACTION\", \"label\": \"필수 정보 수집\", \"policyRef\": \"target_card_and_account_verification\"}, {\"id\": \"verify_policy\", \"type\": \"ACTION\", \"label\": \"정책 확인 및 안내\", \"policyRef\": \"digital_payment_service_security_notice\"}, {\"id\": \"decision\", \"type\": \"DECISION\", \"label\": \"처리 가능 여부 판단\"}, {\"id\": \"terminal\", \"type\": \"TERMINAL\", \"label\": \"안내 완료\"}, {\"id\": \"handoff\", \"type\": \"HANDOFF\", \"label\": \"상담원 추가 확인\"}, {\"id\": \"terminal_handoff\", \"type\": \"TERMINAL\", \"label\": \"추가 확인 종료\"}], \"edges\": [{\"id\": \"e_1\", \"from\": \"start\", \"to\": \"capture_request\"}, {\"id\": \"e_2\", \"from\": \"capture_request\", \"to\": \"collect_required_info\"}, {\"id\": \"e_3\", \"from\": \"collect_required_info\", \"to\": \"verify_policy\"}, {\"id\": \"e_4\", \"from\": \"verify_policy\", \"to\": \"decision\"}, {\"id\": \"e_5\", \"from\": \"decision\", \"to\": \"terminal\", \"label\": \"resolved\"}, {\"id\": \"e_6\", \"from\": \"decision\", \"to\": \"handoff\", \"label\": \"needs_manual_check\"}, {\"id\": \"e_7\", \"from\": \"handoff\", \"to\": \"terminal_handoff\"}]}",
+        "evidenceJson": "[{\"type\": \"exemplar_conv_id\", \"value\": \"200103\"}, {\"type\": \"exemplar_conv_id\", \"value\": \"200104\"}]",
+        "metaJson": "{\"source\": \"manager_workflow_constructor_direct_review\", \"policyRefs\": [\"customer_authentication_required\", \"target_card_and_account_verification\", \"sensitive_auth_data_handling\", \"digital_payment_service_security_notice\"]}",
+        "intentCode": "digital_payment_service_registration",
+        "isPrimary": true,
+        "routeConditionJson": "{\"requiredTerms\":[\"일반결제서비스\",\"앱 결제\",\"온라인 결제\"],\"optionalTerms\":[\"가입 완료\",\"등록\",\"보안\",\"동의\"]}"
+      }
+    ],
+    "intentSlotBindings": [
+      {
+        "intentCode": "lost_card_report_and_status",
+        "slotCode": "customer_identity",
+        "isRequired": true,
+        "collectionOrder": 1,
+        "promptHint": "명의자 본인 또는 대리 상담 가능 여부를 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "lost_card_report_and_status",
+        "slotCode": "card_identifier",
+        "isRequired": true,
+        "collectionOrder": 2,
+        "promptHint": "정지/해제/재발급 대상 카드를 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "lost_card_report_and_status",
+        "slotCode": "card_possession_status",
+        "isRequired": true,
+        "collectionOrder": 3,
+        "promptHint": "카드를 분실했는지, 찾았는지, 습득했는지 현재 상태를 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "lost_card_report_and_status",
+        "slotCode": "incident_datetime",
+        "isRequired": true,
+        "collectionOrder": 4,
+        "promptHint": "분실 또는 습득이 발생한 시점을 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "lost_card_report_and_status",
+        "slotCode": "incident_location",
+        "isRequired": true,
+        "collectionOrder": 5,
+        "promptHint": "분실 추정 장소 또는 습득 장소를 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "lost_card_report_and_status",
+        "slotCode": "contact_channel",
+        "isRequired": true,
+        "collectionOrder": 6,
+        "promptHint": "인증 또는 후속 안내를 받을 연락 채널을 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "payment_history_and_charge_inquiry",
+        "slotCode": "customer_identity",
+        "isRequired": true,
+        "collectionOrder": 1,
+        "promptHint": "거래 내역 조회를 위해 본인 확인 정보를 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "payment_history_and_charge_inquiry",
+        "slotCode": "card_identifier",
+        "isRequired": true,
+        "collectionOrder": 2,
+        "promptHint": "조회할 카드 또는 계정을 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "payment_history_and_charge_inquiry",
+        "slotCode": "transaction_datetime",
+        "isRequired": true,
+        "collectionOrder": 3,
+        "promptHint": "확인하려는 승인/출금/청구 일시를 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "payment_history_and_charge_inquiry",
+        "slotCode": "transaction_amount",
+        "isRequired": true,
+        "collectionOrder": 4,
+        "promptHint": "확인하려는 금액을 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "payment_history_and_charge_inquiry",
+        "slotCode": "merchant_or_channel",
+        "isRequired": true,
+        "collectionOrder": 5,
+        "promptHint": "가맹점, 결제 채널, 교통/해외 여부를 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "payment_history_and_charge_inquiry",
+        "slotCode": "transaction_status_type",
+        "isRequired": true,
+        "collectionOrder": 6,
+        "promptHint": "승인, 출금, 청구, 문자 미수신 등 확인하려는 상태를 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "cancellation_refund_status",
+        "slotCode": "customer_identity",
+        "isRequired": true,
+        "collectionOrder": 1,
+        "promptHint": "취소/환불 내역 조회를 위해 본인 확인 정보를 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "cancellation_refund_status",
+        "slotCode": "card_identifier",
+        "isRequired": true,
+        "collectionOrder": 2,
+        "promptHint": "취소 또는 환불이 걸린 카드를 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "cancellation_refund_status",
+        "slotCode": "transaction_datetime",
+        "isRequired": true,
+        "collectionOrder": 3,
+        "promptHint": "원 결제일 또는 승인일을 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "cancellation_refund_status",
+        "slotCode": "transaction_amount",
+        "isRequired": true,
+        "collectionOrder": 4,
+        "promptHint": "원 결제 금액 또는 취소 대상 금액을 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "cancellation_refund_status",
+        "slotCode": "merchant_or_channel",
+        "isRequired": true,
+        "collectionOrder": 5,
+        "promptHint": "취소 처리한 가맹점 또는 결제 채널을 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "cancellation_refund_status",
+        "slotCode": "cancellation_request_date",
+        "isRequired": true,
+        "collectionOrder": 6,
+        "promptHint": "가맹점 취소/반품 요청일 또는 문자 수신일을 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "cancellation_refund_status",
+        "slotCode": "refund_destination",
+        "isRequired": true,
+        "collectionOrder": 7,
+        "promptHint": "환불이 계좌 입금인지 청구 차감인지 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "prepayment_and_immediate_payment",
+        "slotCode": "customer_identity",
+        "isRequired": true,
+        "collectionOrder": 1,
+        "promptHint": "납부 처리를 위해 본인 확인 정보를 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "prepayment_and_immediate_payment",
+        "slotCode": "card_identifier",
+        "isRequired": true,
+        "collectionOrder": 2,
+        "promptHint": "선결제 또는 즉시출금 대상 카드를 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "prepayment_and_immediate_payment",
+        "slotCode": "payment_due_date",
+        "isRequired": true,
+        "collectionOrder": 3,
+        "promptHint": "이번 달 결제일 또는 납부 대상 회차를 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "prepayment_and_immediate_payment",
+        "slotCode": "payment_amount",
+        "isRequired": true,
+        "collectionOrder": 4,
+        "promptHint": "납부할 금액이 전액인지 일부인지 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "prepayment_and_immediate_payment",
+        "slotCode": "payment_method_account",
+        "isRequired": true,
+        "collectionOrder": 5,
+        "promptHint": "출금 계좌 또는 발급할 가상계좌 정보를 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "card_loan_and_cash_advance_management",
+        "slotCode": "customer_identity",
+        "isRequired": true,
+        "collectionOrder": 1,
+        "promptHint": "금융 서비스 조회/처리를 위해 본인 확인 정보를 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "card_loan_and_cash_advance_management",
+        "slotCode": "loan_type",
+        "isRequired": true,
+        "collectionOrder": 2,
+        "promptHint": "장기카드대출, 단기카드대출, 현금서비스 중 어떤 서비스인지 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "card_loan_and_cash_advance_management",
+        "slotCode": "loan_action",
+        "isRequired": true,
+        "collectionOrder": 3,
+        "promptHint": "가능 여부 조회, 실행, 상환, 완납 중 요청 유형을 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "card_loan_and_cash_advance_management",
+        "slotCode": "loan_amount",
+        "isRequired": true,
+        "collectionOrder": 4,
+        "promptHint": "신청 또는 상환하려는 금액을 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "card_loan_and_cash_advance_management",
+        "slotCode": "repayment_term",
+        "isRequired": true,
+        "collectionOrder": 5,
+        "promptHint": "상환 개월 수 또는 납부 예정 회차를 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "revolving_service_management",
+        "slotCode": "customer_identity",
+        "isRequired": true,
+        "collectionOrder": 1,
+        "promptHint": "리볼빙 약정 조회를 위해 본인 확인 정보를 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "revolving_service_management",
+        "slotCode": "card_identifier",
+        "isRequired": true,
+        "collectionOrder": 2,
+        "promptHint": "리볼빙이 적용된 카드를 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "revolving_service_management",
+        "slotCode": "revolving_action",
+        "isRequired": true,
+        "collectionOrder": 3,
+        "promptHint": "리볼빙 조회, 설명, 납부, 해지 중 요청 유형을 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "revolving_service_management",
+        "slotCode": "payment_amount",
+        "isRequired": true,
+        "collectionOrder": 4,
+        "promptHint": "이월 또는 납부할 금액을 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "revolving_service_management",
+        "slotCode": "payment_due_date",
+        "isRequired": true,
+        "collectionOrder": 5,
+        "promptHint": "결제일 또는 다음 청구월을 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "installment_conversion_or_split_payment",
+        "slotCode": "customer_identity",
+        "isRequired": true,
+        "collectionOrder": 1,
+        "promptHint": "할부 전환 또는 분할 납부를 위해 본인 확인 정보를 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "installment_conversion_or_split_payment",
+        "slotCode": "card_identifier",
+        "isRequired": true,
+        "collectionOrder": 2,
+        "promptHint": "전환 대상 카드를 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "installment_conversion_or_split_payment",
+        "slotCode": "transaction_datetime",
+        "isRequired": true,
+        "collectionOrder": 3,
+        "promptHint": "할부 전환할 원 결제일을 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "installment_conversion_or_split_payment",
+        "slotCode": "transaction_amount",
+        "isRequired": true,
+        "collectionOrder": 4,
+        "promptHint": "할부 전환 또는 분할 납부 대상 금액을 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "installment_conversion_or_split_payment",
+        "slotCode": "installment_months",
+        "isRequired": true,
+        "collectionOrder": 5,
+        "promptHint": "원하는 할부 또는 분할 개월 수를 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "card_limit_management",
+        "slotCode": "customer_identity",
+        "isRequired": true,
+        "collectionOrder": 1,
+        "promptHint": "한도 조회 또는 상향을 위해 본인 확인 정보를 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "card_limit_management",
+        "slotCode": "card_identifier",
+        "isRequired": true,
+        "collectionOrder": 2,
+        "promptHint": "한도 조회 또는 상향 대상 카드를 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "card_limit_management",
+        "slotCode": "limit_type",
+        "isRequired": true,
+        "collectionOrder": 3,
+        "promptHint": "통합 한도, 일시불/할부 한도, 현금서비스 한도 중 대상을 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "card_limit_management",
+        "slotCode": "desired_limit_amount",
+        "isRequired": true,
+        "collectionOrder": 4,
+        "promptHint": "조회하거나 상향하려는 한도 금액을 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "card_limit_management",
+        "slotCode": "limit_change_reason",
+        "isRequired": true,
+        "collectionOrder": 5,
+        "promptHint": "한도 상향이 필요한 사유를 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "benefit_points_voucher_management",
+        "slotCode": "customer_identity",
+        "isRequired": true,
+        "collectionOrder": 1,
+        "promptHint": "혜택 적용 여부 또는 바우처 처리를 위해 본인 확인 정보를 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "benefit_points_voucher_management",
+        "slotCode": "card_identifier",
+        "isRequired": true,
+        "collectionOrder": 2,
+        "promptHint": "혜택이 연결된 카드를 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "benefit_points_voucher_management",
+        "slotCode": "benefit_program",
+        "isRequired": true,
+        "collectionOrder": 3,
+        "promptHint": "확인할 혜택, 포인트, 마일리지, 바우처 또는 프로모션명을 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "benefit_points_voucher_management",
+        "slotCode": "benefit_action",
+        "isRequired": true,
+        "collectionOrder": 4,
+        "promptHint": "적용 확인, 전환, 신청, 선택 중 요청 유형을 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "benefit_points_voucher_management",
+        "slotCode": "usage_period",
+        "isRequired": true,
+        "collectionOrder": 5,
+        "promptHint": "혜택 산정에 필요한 이용일 또는 실적 기간을 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "benefit_points_voucher_management",
+        "slotCode": "usage_merchant_or_category",
+        "isRequired": true,
+        "collectionOrder": 6,
+        "promptHint": "혜택이 적용될 가맹점 또는 업종을 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "recurring_payment_management",
+        "slotCode": "customer_identity",
+        "isRequired": true,
+        "collectionOrder": 1,
+        "promptHint": "자동납부 등록 또는 조회를 위해 본인 확인 정보를 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "recurring_payment_management",
+        "slotCode": "card_identifier",
+        "isRequired": true,
+        "collectionOrder": 2,
+        "promptHint": "자동납부에 연결할 카드 또는 재발급된 카드를 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "recurring_payment_management",
+        "slotCode": "autopay_biller",
+        "isRequired": true,
+        "collectionOrder": 3,
+        "promptHint": "자동납부 기관 또는 청구 대상을 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "recurring_payment_management",
+        "slotCode": "autopay_contract_identifier",
+        "isRequired": true,
+        "collectionOrder": 4,
+        "promptHint": "자동납부 등록에 필요한 고객번호, 학생 정보, 주소 등 식별 정보를 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "recurring_payment_management",
+        "slotCode": "autopay_action",
+        "isRequired": true,
+        "collectionOrder": 5,
+        "promptHint": "신청, 변경, 실패 확인, 재등록 여부 중 요청 유형을 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "card_issue_delivery_activation",
+        "slotCode": "customer_identity",
+        "isRequired": true,
+        "collectionOrder": 1,
+        "promptHint": "발급/배송/등록 처리를 위해 본인 확인 정보를 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "card_issue_delivery_activation",
+        "slotCode": "card_identifier",
+        "isRequired": true,
+        "collectionOrder": 2,
+        "promptHint": "발급, 배송, 사용등록 대상 카드를 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "card_issue_delivery_activation",
+        "slotCode": "issue_request_type",
+        "isRequired": true,
+        "collectionOrder": 3,
+        "promptHint": "신규 신청, 재발급, 긴급배송, 사용등록 등 요청 유형을 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "card_issue_delivery_activation",
+        "slotCode": "delivery_address_or_branch",
+        "isRequired": true,
+        "collectionOrder": 4,
+        "promptHint": "자택, 영업점, 본사 등 수령지 또는 배송지를 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "card_issue_delivery_activation",
+        "slotCode": "desired_delivery_date",
+        "isRequired": true,
+        "collectionOrder": 5,
+        "promptHint": "희망 수령일 또는 출국 전 수령 필요 여부를 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "card_close_and_annual_fee_refund",
+        "slotCode": "customer_identity",
+        "isRequired": true,
+        "collectionOrder": 1,
+        "promptHint": "카드 해지 또는 환급 확인을 위해 본인 확인 정보를 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "card_close_and_annual_fee_refund",
+        "slotCode": "card_identifier",
+        "isRequired": true,
+        "collectionOrder": 2,
+        "promptHint": "해지 또는 환급 대상 카드를 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "card_close_and_annual_fee_refund",
+        "slotCode": "cancellation_reason",
+        "isRequired": true,
+        "collectionOrder": 3,
+        "promptHint": "해지, 연회비 환급, 갱신 수수료 등 문의 사유를 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "card_close_and_annual_fee_refund",
+        "slotCode": "annual_fee_or_refund_amount",
+        "isRequired": true,
+        "collectionOrder": 4,
+        "promptHint": "출금된 연회비 또는 환급 확인 금액을 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "card_close_and_annual_fee_refund",
+        "slotCode": "refund_destination",
+        "isRequired": true,
+        "collectionOrder": 5,
+        "promptHint": "환급 받을 계좌 또는 청구 차감 여부를 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "billing_cycle_due_date_change",
+        "slotCode": "customer_identity",
+        "isRequired": true,
+        "collectionOrder": 1,
+        "promptHint": "결제일 변경을 위해 본인 확인 정보를 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "billing_cycle_due_date_change",
+        "slotCode": "card_identifier",
+        "isRequired": true,
+        "collectionOrder": 2,
+        "promptHint": "결제일을 변경할 카드를 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "billing_cycle_due_date_change",
+        "slotCode": "current_due_date",
+        "isRequired": true,
+        "collectionOrder": 3,
+        "promptHint": "현재 결제일을 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "billing_cycle_due_date_change",
+        "slotCode": "desired_due_date",
+        "isRequired": true,
+        "collectionOrder": 4,
+        "promptHint": "변경하려는 결제일을 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "billing_cycle_due_date_change",
+        "slotCode": "billing_period",
+        "isRequired": true,
+        "collectionOrder": 5,
+        "promptHint": "변경 후 이용기간과 청구월을 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "digital_payment_service_registration",
+        "slotCode": "customer_identity",
+        "isRequired": true,
+        "collectionOrder": 1,
+        "promptHint": "디지털 결제 서비스 조회를 위해 본인 확인 정보를 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "digital_payment_service_registration",
+        "slotCode": "card_identifier",
+        "isRequired": true,
+        "collectionOrder": 2,
+        "promptHint": "서비스가 연결된 카드를 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "digital_payment_service_registration",
+        "slotCode": "digital_service_name",
+        "isRequired": true,
+        "collectionOrder": 3,
+        "promptHint": "일반결제서비스, 앱 결제 등 서비스명을 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "digital_payment_service_registration",
+        "slotCode": "service_request_type",
+        "isRequired": true,
+        "collectionOrder": 4,
+        "promptHint": "가입 확인, 등록, 오류 해결, 서비스 설명 중 요청 유형을 확인해 주세요.",
+        "conditionJson": "{}"
+      },
+      {
+        "intentCode": "digital_payment_service_registration",
+        "slotCode": "authentication_channel",
+        "isRequired": true,
+        "collectionOrder": 5,
+        "promptHint": "서비스 확인에 필요한 인증 수단 또는 가입 알림 채널을 확인해 주세요.",
+        "conditionJson": "{}"
+      }
+    ]
+  },
+  "evaluationSummary": {
+    "sampleSize": 100,
+    "sourceIds": [
+      "200001",
+      "200002",
+      "200003",
+      "200004",
+      "200005",
+      "200006",
+      "200007",
+      "200008",
+      "200009",
+      "200010",
+      "200011",
+      "200012",
+      "200013",
+      "200014",
+      "200015",
+      "200016",
+      "200017",
+      "200018",
+      "200019",
+      "200020",
+      "200021",
+      "200022",
+      "200024",
+      "200025",
+      "200026",
+      "200027",
+      "200028",
+      "200029",
+      "200030",
+      "200031",
+      "200032",
+      "200033",
+      "200034",
+      "200035",
+      "200036",
+      "200037",
+      "200038",
+      "200039",
+      "200040",
+      "200041",
+      "200042",
+      "200043",
+      "200044",
+      "200045",
+      "200046",
+      "200047",
+      "200048",
+      "200052",
+      "200053",
+      "200054",
+      "200055",
+      "200056",
+      "200057",
+      "200058",
+      "200059",
+      "200060",
+      "200061",
+      "200062",
+      "200063",
+      "200064",
+      "200065",
+      "200066",
+      "200067",
+      "200068",
+      "200069",
+      "200070",
+      "200071",
+      "200072",
+      "200073",
+      "200074",
+      "200075",
+      "200076",
+      "200077",
+      "200078",
+      "200079",
+      "200080",
+      "200081",
+      "200082",
+      "200083",
+      "200084",
+      "200085",
+      "200086",
+      "200087",
+      "200088",
+      "200089",
+      "200090",
+      "200091",
+      "200092",
+      "200093",
+      "200094",
+      "200095",
+      "200096",
+      "200097",
+      "200098",
+      "200099",
+      "200100",
+      "200102",
+      "200103",
+      "200104",
+      "200105"
+    ],
+    "rawConsultingCategoryDistribution": {
+      "선결제/즉시출금": 17,
+      "도난/분실 신청/해제": 16,
+      "이용내역 안내": 16,
+      "결제대금 안내": 6,
+      "장기카드대출 안내": 4,
+      "매출구분 변경": 4,
+      "입금내역 안내": 4,
+      "승인취소/매출취소 안내": 4,
+      "프리미엄 바우처 안내/발급": 3,
+      "가상계좌 예약/취소": 3,
+      "이벤트 안내": 3,
+      "교육비": 2,
+      "한도상향 접수/처리": 2,
+      "긴급 배송 신청": 2,
+      "일부결제대금이월약정 해지": 2,
+      "오토할부/오토캐쉬백 안내/신청/취소": 1,
+      "정부지원 바우처 (등유, 임신 등)": 1,
+      "포인트/마일리지 전환등록": 1,
+      "결제일 안내/변경/취소": 1,
+      "한도 안내": 1,
+      "단기카드대출 안내/실행": 1,
+      "일부결제대금이월약정 안내": 1,
+      "연체대금 안내": 1,
+      "심사 진행사항 안내": 1,
+      "가상계좌 안내": 1,
+      "이용방법 안내": 1,
+      "안심클릭/▲▲페이/기타페이 안내": 1
+    },
+    "managerIntentSupport": {
+      "lost_card_report_and_status": 19,
+      "payment_history_and_charge_inquiry": 22,
+      "cancellation_refund_status": 9,
+      "prepayment_and_immediate_payment": 27,
+      "card_loan_and_cash_advance_management": 13,
+      "revolving_service_management": 4,
+      "installment_conversion_or_split_payment": 5,
+      "card_limit_management": 8,
+      "benefit_points_voucher_management": 12,
+      "recurring_payment_management": 8,
+      "card_issue_delivery_activation": 10,
+      "card_close_and_annual_fee_refund": 3,
+      "billing_cycle_due_date_change": 2,
+      "digital_payment_service_registration": 2
+    },
+    "constructionMethod": "direct_customer_agent_review_plus_manager_merge_plan"
+  }
+}

--- a/backend/src/test/java/com/init/workflowruntime/application/UserChatSessionServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/UserChatSessionServiceTest.java
@@ -193,6 +193,40 @@ class UserChatSessionServiceTest {
   }
 
   @Test
+  @DisplayName("create session: 재사용 세션 조회 없이 새 OPEN 세션을 생성한다")
+  void should_createFreshOpenSession_without_reusingCurrentSession() {
+    given(workspaceMemberRepository.findByWorkspaceIdAndUserId(WORKSPACE_ID, USER_ID))
+        .willReturn(
+            Optional.of(
+                WorkspaceMember.create(WORKSPACE_ID, USER_ID, WorkspaceMemberRole.OPERATOR)));
+    given(domainPackVersionRepository.findCurrentPublishedByWorkspaceId(WORKSPACE_ID))
+        .willReturn(
+            Optional.of(
+                DomainPackVersion.ofForTest(VERSION_ID, 1L, DomainPackVersion.STATUS_PUBLISHED)));
+    given(chatSessionRepository.save(any(ChatSession.class)))
+        .willAnswer(
+            invocation -> {
+              ChatSession saved = invocation.getArgument(0);
+              ReflectionTestUtils.setField(saved, "id", 100L);
+              return saved;
+            });
+
+    ChatSessionResponse result = service.createSession(command());
+
+    assertThat(result.getId()).isEqualTo(100L);
+    assertThat(result.getStatus()).isEqualTo("OPEN");
+    verify(concurrencyGuard, never()).lockCurrentSession(any(), any());
+    verify(chatSessionRepository, never())
+        .findFirstByWorkspaceIdAndStartedByAndStatusInOrderByStartedAtDescIdDesc(
+            any(), any(), any());
+
+    ArgumentCaptor<ChatSession> sessionCaptor = ArgumentCaptor.forClass(ChatSession.class);
+    verify(chatSessionRepository).save(sessionCaptor.capture());
+    assertThat(sessionCaptor.getValue().getStartedBy()).isEqualTo(USER_ID);
+    assertThat(sessionCaptor.getValue().getMetaJson()).contains("\"customerName\":\"김민지\"");
+  }
+
+  @Test
   @DisplayName("current session: 워크스페이스 멤버가 아니면 거부한다")
   void should_throwWorkspaceAccessDenied_when_notWorkspaceMember() {
     given(workspaceMemberRepository.findByWorkspaceIdAndUserId(WORKSPACE_ID, USER_ID))

--- a/backend/src/test/java/com/init/workflowruntime/interceptor/JwtChannelInterceptorTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/interceptor/JwtChannelInterceptorTest.java
@@ -185,6 +185,7 @@ class JwtChannelInterceptorTest {
   @DisplayName("SUBSCRIBE without authentication, anonymous demo chat topic → passes through")
   void should_passThrough_when_anonymousSubscribesDemoChatTopic() {
     StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.SUBSCRIBE);
+    accessor.setSessionAttributes(new HashMap<>(Map.of("anonymous", true)));
     accessor.setDestination("/topic/chat.1");
     Message<byte[]> message =
         MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
@@ -196,10 +197,24 @@ class JwtChannelInterceptorTest {
   }
 
   @Test
+  @DisplayName("SUBSCRIBE without authentication and anonymous marker → MissingAuthHeaderException")
+  void should_throwMissingAuthHeader_when_subscribeWithoutAnonymousMarker() {
+    StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.SUBSCRIBE);
+    accessor.setDestination("/topic/chat.1");
+    Message<byte[]> message =
+        MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+
+    assertThatThrownBy(() -> interceptor.preSend(message, channel))
+        .isInstanceOf(MissingAuthHeaderException.class)
+        .hasMessageContaining("Authentication required for subscription destination");
+  }
+
+  @Test
   @DisplayName(
       "SUBSCRIBE without authentication, user-owned chat topic → MissingAuthHeaderException")
   void should_throwMissingAuthHeader_when_anonymousSubscribesUserOwnedChatTopic() {
     StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.SUBSCRIBE);
+    accessor.setSessionAttributes(new HashMap<>(Map.of("anonymous", true)));
     accessor.setDestination("/topic/chat.1");
     Message<byte[]> message =
         MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
@@ -211,16 +226,17 @@ class JwtChannelInterceptorTest {
   }
 
   @Test
-  @DisplayName("SUBSCRIBE without authentication, user queue → passes through")
-  void should_passThrough_when_anonymousSubscribesUserQueue() {
+  @DisplayName("SUBSCRIBE without authentication, user queue → MissingAuthHeaderException")
+  void should_throwMissingAuthHeader_when_anonymousSubscribesUserQueue() {
     StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.SUBSCRIBE);
+    accessor.setSessionAttributes(new HashMap<>(Map.of("anonymous", true)));
     accessor.setDestination("/user/queue/errors");
     Message<byte[]> message =
         MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
 
-    Message<?> result = interceptor.preSend(message, channel);
-
-    assertThat(result).isSameAs(message);
+    assertThatThrownBy(() -> interceptor.preSend(message, channel))
+        .isInstanceOf(MissingAuthHeaderException.class)
+        .hasMessageContaining("Authentication required for subscription destination");
   }
 
   @Test

--- a/backend/src/test/java/com/init/workflowruntime/interceptor/JwtChannelInterceptorTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/interceptor/JwtChannelInterceptorTest.java
@@ -54,15 +54,17 @@ class JwtChannelInterceptorTest {
   }
 
   @Test
-  @DisplayName("CONNECT without Authorization header → MissingAuthHeaderException")
-  void should_throwMissingAuthHeaderException_when_noAuthHeader() {
+  @DisplayName("CONNECT without Authorization header → anonymous session allowed")
+  void should_allowAnonymousConnect_when_noAuthHeader() {
     StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.CONNECT);
     Message<byte[]> message =
         MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
 
-    assertThatThrownBy(() -> interceptor.preSend(message, channel))
-        .isInstanceOf(MissingAuthHeaderException.class)
-        .hasMessageContaining("Missing or invalid Authorization header");
+    Message<?> result = interceptor.preSend(message, channel);
+
+    StompHeaderAccessor resultAccessor = StompHeaderAccessor.wrap(result);
+    assertThat(resultAccessor.getUser()).isNull();
+    assertThat(resultAccessor.getSessionAttributes()).containsEntry("anonymous", true);
   }
 
   @Test
@@ -171,11 +173,54 @@ class JwtChannelInterceptorTest {
   @DisplayName("SUBSCRIBE without authentication → MissingAuthHeaderException")
   void should_throwMissingAuthHeader_when_subscribeWithoutAuth() {
     StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.SUBSCRIBE);
+    accessor.setDestination("/topic/workspaces.2.consultation.queue");
     Message<byte[]> message =
         MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
 
     assertThatThrownBy(() -> interceptor.preSend(message, channel))
         .isInstanceOf(MissingAuthHeaderException.class);
+  }
+
+  @Test
+  @DisplayName("SUBSCRIBE without authentication, anonymous demo chat topic → passes through")
+  void should_passThrough_when_anonymousSubscribesDemoChatTopic() {
+    StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.SUBSCRIBE);
+    accessor.setDestination("/topic/chat.1");
+    Message<byte[]> message =
+        MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+    given(chatSessionRepository.findById(1L)).willReturn(Optional.of(createSession(1L, null)));
+
+    Message<?> result = interceptor.preSend(message, channel);
+
+    assertThat(result).isSameAs(message);
+  }
+
+  @Test
+  @DisplayName(
+      "SUBSCRIBE without authentication, user-owned chat topic → MissingAuthHeaderException")
+  void should_throwMissingAuthHeader_when_anonymousSubscribesUserOwnedChatTopic() {
+    StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.SUBSCRIBE);
+    accessor.setDestination("/topic/chat.1");
+    Message<byte[]> message =
+        MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+    given(chatSessionRepository.findById(1L)).willReturn(Optional.of(createSession(1L, 42L)));
+
+    assertThatThrownBy(() -> interceptor.preSend(message, channel))
+        .isInstanceOf(MissingAuthHeaderException.class)
+        .hasMessageContaining("Authentication required for chat session");
+  }
+
+  @Test
+  @DisplayName("SUBSCRIBE without authentication, user queue → passes through")
+  void should_passThrough_when_anonymousSubscribesUserQueue() {
+    StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.SUBSCRIBE);
+    accessor.setDestination("/user/queue/errors");
+    Message<byte[]> message =
+        MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+
+    Message<?> result = interceptor.preSend(message, channel);
+
+    assertThat(result).isSameAs(message);
   }
 
   @Test

--- a/backend/src/test/java/com/init/workflowruntime/presentation/UserChatSessionControllerTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/presentation/UserChatSessionControllerTest.java
@@ -2,6 +2,7 @@ package com.init.workflowruntime.presentation;
 
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -17,6 +18,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -60,6 +62,36 @@ class UserChatSessionControllerTest {
                 .principal(authentication))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.id").value(33))
+        .andExpect(jsonPath("$.status").value("OPEN"))
+        .andExpect(jsonPath("$.channel").value("WEB"));
+  }
+
+  @Test
+  @DisplayName("POST /api/v1/workspaces/{workspaceId}/chat/sessions - 새 세션 생성")
+  void should_createSession() throws Exception {
+    ChatSessionResponse response = new ChatSessionResponse();
+    response.setId(44L);
+    response.setStatus("OPEN");
+    response.setChannel("WEB");
+    response.setStartedAt(OffsetDateTime.parse("2026-05-26T10:05:00+09:00"));
+
+    given(
+            userChatSessionService.createSession(
+                new GetOrCreateCurrentSessionCommand(10L, 7L, "박하나")))
+        .willReturn(response);
+
+    UsernamePasswordAuthenticationToken authentication =
+        new UsernamePasswordAuthenticationToken(
+            7L, null, java.util.List.of(new SimpleGrantedAuthority("ROLE_USER")));
+
+    mockMvc
+        .perform(
+            post("/api/v1/workspaces/10/chat/sessions")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"customerName\":\"박하나\"}")
+                .principal(authentication))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(44))
         .andExpect(jsonPath("$.status").value("OPEN"))
         .andExpect(jsonPath("$.channel").value("WEB"));
   }

--- a/frontend/src/app/App.test.tsx
+++ b/frontend/src/app/App.test.tsx
@@ -82,6 +82,22 @@ describe("App", () => {
     });
   });
 
+  it("redirects legacy authenticated workspace chat URLs to the user chat URL", async () => {
+    seedAuthenticatedSession();
+    window.history.pushState({}, "", "/workspaces/42/chat?name=%EA%B9%80%EB%AF%BC%EC%A7%80");
+
+    render(
+      <AppProviders>
+        <App />
+      </AppProviders>,
+    );
+
+    await waitFor(() => {
+      expect(window.location.pathname).toBe("/chat/42");
+      expect(window.location.search).toBe("?name=%EA%B9%80%EB%AF%BC%EC%A7%80");
+    });
+  });
+
   it("redirects workspace home alias to workflows and renders the empty workflow state when there are no domain packs", async () => {
     seedAuthenticatedSession();
 

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -35,6 +35,7 @@ import { Toaster } from "../shared/ui/sonner";
 import { WorkflowGraphViewerPage } from "../pages/domain-pack/ui/WorkflowGraphViewerPage";
 import { LegacyDomainPackVersionRedirect } from "../pages/domain-pack/ui/LegacyDomainPackVersionRedirect";
 import { buildDemoChatPath } from "../shared/lib/demoRoutes";
+import { buildUserChatPath } from "../shared/lib/userChatRoutes";
 
 function LegacyDemoChatRedirect() {
   const { workspaceId } = useParams<{ workspaceId: string }>();
@@ -45,6 +46,17 @@ function LegacyDemoChatRedirect() {
   }
 
   return <Navigate to={`${buildDemoChatPath(workspaceId)}${search}`} replace />;
+}
+
+function LegacyUserChatRedirect() {
+  const { workspaceId } = useParams<{ workspaceId: string }>();
+  const { search } = useLocation();
+
+  if (!workspaceId) {
+    return <Navigate to="/workspaces" replace />;
+  }
+
+  return <Navigate to={`${buildUserChatPath(workspaceId)}${search}`} replace />;
 }
 
 export function App() {
@@ -107,6 +119,22 @@ export function App() {
           }
         />
         <Route path="/demo/chat/:workspaceId" element={<UserChatPage />} />
+        <Route
+          path="/chat/:workspaceId"
+          element={
+            <PrivateRoute>
+              <UserChatPage mode="authenticated" />
+            </PrivateRoute>
+          }
+        />
+        <Route
+          path="/workspaces/:workspaceId/chat"
+          element={
+            <PrivateRoute>
+              <LegacyUserChatRedirect />
+            </PrivateRoute>
+          }
+        />
         <Route
           path="/demo/workspaces/:workspaceId/chat"
           element={<LegacyDemoChatRedirect />}

--- a/frontend/src/entities/chat/api/chatApi.test.ts
+++ b/frontend/src/entities/chat/api/chatApi.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createChatSession,
   createDemoChatSession,
+  createFreshChatSession,
   listChatMessages,
   listDemoChatMessages,
   registerDemoChatSession,
@@ -48,6 +49,23 @@ describe("chatApi", () => {
       "/api/v1/workspaces/3/chat/sessions/current?customerName=%EA%B9%80%EB%AF%BC%EC%A7%80",
       { method: "GET" },
     );
+  });
+
+  it("workspaceId로 새 사용자 채팅 세션을 생성한다", async () => {
+    const session = {
+      id: 13,
+      status: "OPEN" as const,
+      channel: "WEB",
+      startedAt: "2026-05-22T00:10:00Z",
+    };
+    customFetchMock.mockResolvedValue(session);
+
+    await expect(createFreshChatSession(3, "김민지")).resolves.toEqual(session);
+
+    expect(customFetchMock).toHaveBeenCalledWith("/api/v1/workspaces/3/chat/sessions", {
+      method: "POST",
+      body: JSON.stringify({ customerName: "김민지" }),
+    });
   });
 
   it("세션 메시지를 채팅 UI 모델로 변환한다", async () => {
@@ -148,23 +166,46 @@ describe("chatApi", () => {
   });
 
   it("백엔드에 데모 채팅 세션을 등록한다", async () => {
-    customFetchMock.mockResolvedValue({
-      id: 77,
-      status: "OPEN",
-      startedAt: "2026-05-22T00:00:00Z",
-    });
+    customFetchMock
+      .mockResolvedValueOnce({
+        id: 77,
+        status: "OPEN",
+        startedAt: "2026-05-22T00:00:00Z",
+      })
+      .mockResolvedValueOnce([
+        {
+          id: 80,
+          seqNo: 1,
+          senderRole: "ASSISTANT",
+          messageType: "TEXT",
+          content: "안녕하세요, 김민지님. 무엇을 도와드릴까요?",
+          createdAt: "2026-05-22T00:00:00Z",
+        },
+      ]);
 
     await expect(registerDemoChatSession(2, "김민지")).resolves.toEqual({
       id: "77",
       status: "OPEN",
       startedAt: "2026-05-22T00:00:00Z",
-      messages: [],
+      messages: [
+        {
+          id: "80",
+          sessionId: 77,
+          senderType: "BOT",
+          content: "안녕하세요, 김민지님. 무엇을 도와드릴까요?",
+          createdAt: "2026-05-22T00:00:00Z",
+        },
+      ],
     });
 
     expect(customFetchMock).toHaveBeenCalledWith("/api/v1/workspaces/2/demo/chat-sessions", {
       method: "POST",
       body: JSON.stringify({ customerName: "김민지" }),
     });
+    expect(customFetchMock).toHaveBeenCalledWith(
+      "/api/v1/workspaces/2/demo/chat-sessions/77/messages",
+      { method: "GET" },
+    );
   });
 
   it("백엔드 데모 채팅 세션 응답에 숫자 id가 없으면 실패한다", async () => {

--- a/frontend/src/entities/chat/api/chatApi.ts
+++ b/frontend/src/entities/chat/api/chatApi.ts
@@ -10,7 +10,7 @@ import {
   type ChatMessageResponse,
 } from "../lib/chatMessageSync";
 
-// OpenAPI 미생성 endpoint: current chat session, demo session create/send는 수동 호출로 유지한다.
+// OpenAPI 미생성 endpoint: user chat session current/create, demo session create/send는 수동 호출로 유지한다.
 
 interface DemoChatWorkflowResponse {
   chatSession?: {
@@ -96,6 +96,16 @@ export function createChatSession(workspaceId: number, customerName: string): Pr
   );
 }
 
+export function createFreshChatSession(
+  workspaceId: number,
+  customerName: string,
+): Promise<ChatSession> {
+  return customFetch<ChatSession>(`/api/v1/workspaces/${workspaceId}/chat/sessions`, {
+    method: "POST",
+    body: JSON.stringify({ customerName }),
+  });
+}
+
 export async function listChatMessages(sessionId: number): Promise<ChatMessage[]> {
   const messages = selectConsultationMessages(
     (await getMessages(sessionId)) as ConsultationMessagesResponse,
@@ -133,13 +143,22 @@ export async function registerDemoChatSession(
   );
   const sessionId = requireBackendSessionId(response.id);
   const startedAt = response.startedAt ?? new Date().toISOString();
+  const messages = await listDemoChatMessages(workspaceId, String(sessionId));
 
   return {
     id: String(sessionId),
     status: response.status ?? "OPEN",
     startedAt,
-    messages: [],
+    messages: withDemoCustomerNames(messages, customerName),
   };
+}
+
+function withDemoCustomerNames(messages: ChatMessage[], customerName: string): ChatMessage[] {
+  return messages.map((message) =>
+    message.senderType === "USER" && !message.senderName
+      ? { ...message, senderName: customerName }
+      : message,
+  );
 }
 
 export async function sendDemoChatMessage(

--- a/frontend/src/entities/chat/index.ts
+++ b/frontend/src/entities/chat/index.ts
@@ -1,6 +1,7 @@
 export {
   createChatSession,
   createDemoChatSession,
+  createFreshChatSession,
   listChatMessages,
   listDemoChatMessages,
   registerDemoChatSession,

--- a/frontend/src/features/auth/model/resolvePostLoginDestination.test.ts
+++ b/frontend/src/features/auth/model/resolvePostLoginDestination.test.ts
@@ -32,6 +32,14 @@ describe("resolvePostLoginDestination", () => {
     ).toBe("/demo/workspaces/1/chat?preview=true");
   });
 
+  it("falls back for authenticated user chat paths so login lands on workspace first", () => {
+    expect(
+      resolvePostLoginDestination({
+        from: { pathname: "/chat/2", search: "?name=%EB%B0%95%ED%95%98%EB%82%98" },
+      }),
+    ).toBe(DEFAULT_POST_LOGIN_PATH);
+  });
+
   it("falls back for auth routes", () => {
     expect(resolvePostLoginDestination({ from: { pathname: "/login" } })).toBe(
       DEFAULT_POST_LOGIN_PATH,

--- a/frontend/src/pages/demo/model/demoCompanies.test.ts
+++ b/frontend/src/pages/demo/model/demoCompanies.test.ts
@@ -8,16 +8,23 @@ describe("demoCompanies", () => {
     expect(new Set(ids).size).toBe(ids.length);
   });
 
-  it("marks workspace 1 as the enabled complaint scenario", () => {
+  it("marks workspace 1 as the enabled ActiveVenture scenario", () => {
     const company = findDemoCompany(1);
     expect(company).toBeDefined();
     expect(company?.enabled).toBe(true);
-    expect(company?.name).toBe("컴플레인 테스트 워크스페이스");
+    expect(company?.name).toBe("액티벤처 여행 상담");
     expect(company?.focusChips.length).toBeGreaterThan(0);
   });
 
-  it("keeps preview-only companies disabled", () => {
-    expect(findDemoCompany(2)?.enabled).toBe(false);
+  it("marks workspace 2 as the enabled Hana Card scenario", () => {
+    const company = findDemoCompany(2);
+    expect(company).toBeDefined();
+    expect(company?.enabled).toBe(true);
+    expect(company?.name).toBe("하나카드 카드 상담");
+    expect(company?.focusChips).toContain("분실 신고");
+  });
+
+  it("keeps fixture-only companies disabled", () => {
     expect(findDemoCompany(3)?.enabled).toBe(false);
   });
 

--- a/frontend/src/pages/demo/model/demoCompanies.ts
+++ b/frontend/src/pages/demo/model/demoCompanies.ts
@@ -14,32 +14,32 @@ export interface DemoCompany {
 
 /**
  * Static demo roster. There is no JWT-free endpoint to list workspaces, so the
- * company↔workspace mapping is curated here. Workspace 1 is the real
- * "컴플레인 테스트 워크스페이스" with a published pack; 2/3 are themed previews.
+ * company↔workspace mapping is curated here. Workspace 1 and 2 are backed by
+ * local/dev seed runners; workspace 3 remains a fixture-only preview.
  */
 export const DEMO_COMPANIES: DemoCompany[] = [
   {
     workspaceId: 1,
-    name: "컴플레인 테스트 워크스페이스",
-    industry: "리테일 · CS 운영",
+    name: "액티벤처 여행 상담",
+    industry: "여행 · 예약",
     blurb:
-      "환불 · 배송 상담 도메인 팩이 운영 중인 워크스페이스입니다. 컴플레인을 거는 고객 시나리오를 바로 체험할 수 있습니다.",
-    focusChips: ["환불 요청", "배송 조회", "고액 환불 리스크"],
+      "항공권, 예약 취소·환불, 픽업 차량 상담 도메인팩이 운영 중인 워크스페이스입니다. 액티벤처 고객 시나리오를 바로 체험할 수 있습니다.",
+    focusChips: ["항공권 문의", "예약 취소·환불", "픽업 차량"],
     enabled: true,
   },
   {
     workspaceId: 2,
-    name: "카드 이용내역 조회 상담",
+    name: "하나카드 카드 상담",
     industry: "카드 · 금융",
     blurb:
-      "카드 이용내역 및 승인 내역 확인 상담 도메인 팩 데모입니다. 라이브 상담은 곧 준비됩니다.",
-    focusChips: ["이용내역 조회", "본인 확인"],
-    enabled: false,
+      "하나카드 상담 로그 100건에서 추출한 카드 상담 도메인팩입니다. 분실 신고, 이용내역, 선결제, 카드론 상담을 체험할 수 있습니다.",
+    focusChips: ["분실 신고", "이용내역 확인", "선결제·카드론"],
+    enabled: true,
   },
   {
     workspaceId: 3,
-    name: "여행 숙소 예약 상담",
-    industry: "여행 · 예약",
+    name: "인디고발리 숙소 예약",
+    industry: "숙소 · 예약",
     blurb:
       "리조트 객실 예약 가능 여부 및 예약 진행 상담 도메인 팩 데모입니다. 라이브 상담은 곧 준비됩니다.",
     focusChips: ["객실 예약", "프로모션 확인"],

--- a/frontend/src/pages/demo/ui/CompanyCard.test.tsx
+++ b/frontend/src/pages/demo/ui/CompanyCard.test.tsx
@@ -5,17 +5,17 @@ import type { DemoCompany } from "../model/demoCompanies";
 
 const enabledCompany: DemoCompany = {
   workspaceId: 1,
-  name: "컴플레인 테스트 워크스페이스",
-  industry: "리테일 · CS 운영",
-  blurb: "환불 · 배송 상담",
-  focusChips: ["환불 요청"],
+  name: "액티벤처 여행 상담",
+  industry: "여행 · 예약",
+  blurb: "항공권 · 취소 상담",
+  focusChips: ["항공권 문의"],
   enabled: true,
 };
 
 const disabledCompany: DemoCompany = {
   ...enabledCompany,
-  workspaceId: 2,
-  name: "카드 이용내역 조회 상담",
+  workspaceId: 3,
+  name: "인디고발리 숙소 예약",
   enabled: false,
 };
 
@@ -28,8 +28,8 @@ describe("CompanyCard", () => {
 
   it("renders a disabled company as a preview", () => {
     render(<CompanyCard company={disabledCompany} active={false} onActivate={vi.fn()} />);
-    expect(screen.getByTestId("demo-company-card-2")).not.toHaveAttribute("aria-disabled");
-    expect(screen.getByTestId("demo-company-status-2")).toHaveTextContent("데모 준비 중");
+    expect(screen.getByTestId("demo-company-card-3")).not.toHaveAttribute("aria-disabled");
+    expect(screen.getByTestId("demo-company-status-3")).toHaveTextContent("데모 준비 중");
   });
 
   it("activates on click and on hover with the company reference", () => {

--- a/frontend/src/pages/demo/ui/DemoPage.test.tsx
+++ b/frontend/src/pages/demo/ui/DemoPage.test.tsx
@@ -28,17 +28,13 @@ describe("DemoPage", () => {
     expect(screen.getByTestId("demo-company-card-1")).toBeInTheDocument();
     expect(screen.getByTestId("demo-company-card-2")).toBeInTheDocument();
     expect(screen.getByTestId("demo-company-card-3")).toBeInTheDocument();
-    expect(screen.getByTestId("demo-company-info")).toHaveTextContent(
-      "컴플레인 테스트 워크스페이스",
-    );
+    expect(screen.getByTestId("demo-company-info")).toHaveTextContent("액티벤처 여행 상담");
   });
 
   it("shows a company's info on hover", () => {
     renderDemoPage();
     fireEvent.mouseEnter(screen.getByTestId("demo-company-card-2"));
-    expect(screen.getByTestId("demo-company-info")).toHaveTextContent(
-      "카드 이용내역 조회 상담",
-    );
+    expect(screen.getByTestId("demo-company-info")).toHaveTextContent("하나카드 카드 상담");
   });
 
   it("navigates to the chat with an encoded name for an enabled company", () => {
@@ -63,12 +59,24 @@ describe("DemoPage", () => {
 
   it("does not start a chat for a preview company", () => {
     renderDemoPage();
-    fireEvent.click(screen.getByTestId("demo-company-card-2"));
+    fireEvent.click(screen.getByTestId("demo-company-card-3"));
     expect(screen.getByTestId("demo-start-chat")).toBeDisabled();
     fireEvent.submit(screen.getByTestId("demo-name-form"));
     expect(screen.getByTestId("demo-name-error")).toHaveTextContent(
       "데모를 준비 중",
     );
     expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it("navigates to the Hana Card workspace for the enabled card scenario", () => {
+    renderDemoPage();
+    fireEvent.click(screen.getByTestId("demo-company-card-2"));
+    fireEvent.change(screen.getByTestId("demo-name-input"), {
+      target: { value: "박하나" },
+    });
+    fireEvent.click(screen.getByTestId("demo-start-chat"));
+    expect(navigateMock).toHaveBeenCalledWith(
+      `/demo/chat/2?name=${encodeURIComponent("박하나")}`,
+    );
   });
 });

--- a/frontend/src/pages/user-chat/ui/UserChatPage.test.tsx
+++ b/frontend/src/pages/user-chat/ui/UserChatPage.test.tsx
@@ -198,6 +198,66 @@ describe("UserChatPage", () => {
     expect(screen.queryByTestId("chat-entry-screen")).toBeNull();
   });
 
+  it("workspaceId나 name 쿼리가 바뀌면 이전 세션을 버리고 새 세션을 자동 생성한다", async () => {
+    searchState.search = "name=김민지";
+    registerDemoChatSessionMock.mockReset();
+    registerDemoChatSessionMock
+      .mockResolvedValueOnce({
+        id: "77",
+        status: "OPEN",
+        startedAt: "2026-05-22T00:00:00Z",
+        messages: [],
+      })
+      .mockResolvedValueOnce({
+        id: "88",
+        status: "OPEN",
+        startedAt: "2026-05-22T00:10:00Z",
+        messages: [],
+      });
+    listDemoChatMessagesMock.mockReset();
+    listDemoChatMessagesMock.mockImplementation((_workspaceId: number, sessionId: string) =>
+      Promise.resolve(
+        sessionId === "88"
+          ? [
+              {
+                id: "90",
+                sessionId: 88,
+                content: "이하나 세션 안내입니다.",
+                senderType: "BOT",
+                createdAt: "2026-05-22T00:10:00Z",
+              },
+            ]
+          : [
+              {
+                id: "80",
+                sessionId: 77,
+                content: "김민지 세션 안내입니다.",
+                senderType: "BOT",
+                createdAt: "2026-05-22T00:00:00Z",
+              },
+            ],
+      ),
+    );
+
+    const view = render(<UserChatPage />);
+
+    expect(await screen.findByText("김민지 세션 안내입니다.")).toBeInTheDocument();
+    expect(screen.getByTestId("chat-header-eyebrow")).toHaveTextContent("Session #77");
+    expect(screen.getByTestId("chat-header-name")).toHaveTextContent("김민지");
+
+    routeState.workspaceId = "43";
+    searchState.search = "name=이하나";
+    view.rerender(<UserChatPage />);
+
+    await waitFor(() => {
+      expect(registerDemoChatSessionMock).toHaveBeenCalledWith(43, "이하나");
+    });
+    expect(await screen.findByText("이하나 세션 안내입니다.")).toBeInTheDocument();
+    expect(screen.getByTestId("chat-header-eyebrow")).toHaveTextContent("Session #88");
+    expect(screen.getByTestId("chat-header-name")).toHaveTextContent("이하나");
+    expect(screen.queryByText("김민지 세션 안내입니다.")).toBeNull();
+  });
+
   it("name 쿼리 파라미터가 공백이면 이름 입력 화면으로 폴백한다", () => {
     searchState.search = "name=%20%20";
 

--- a/frontend/src/pages/user-chat/ui/UserChatPage.test.tsx
+++ b/frontend/src/pages/user-chat/ui/UserChatPage.test.tsx
@@ -4,32 +4,47 @@ import { ApiRequestError } from "@/shared/api";
 import { UserChatPage } from "./UserChatPage";
 
 const {
+  createChatSessionMock,
+  createFreshChatSessionMock,
+  listChatMessagesMock,
   listDemoChatMessagesMock,
   registerDemoChatSessionMock,
   sendDemoChatMessageMock,
+  useStompOptions,
   routeState,
   searchState,
   stompState,
 } = vi.hoisted(() => ({
+  createChatSessionMock: vi.fn(),
+  createFreshChatSessionMock: vi.fn(),
+  listChatMessagesMock: vi.fn(),
   listDemoChatMessagesMock: vi.fn(),
   registerDemoChatSessionMock: vi.fn(),
   sendDemoChatMessageMock: vi.fn(),
+  useStompOptions: [] as unknown[],
   routeState: { workspaceId: "42" as string | undefined },
   searchState: { search: "" },
   stompState: {
     connectionStatus: "DISCONNECTED",
+    sendMessage: vi.fn(),
     subscribe: vi.fn(),
   },
 }));
 
 vi.mock("@/entities/chat", () => ({
+  createChatSession: createChatSessionMock,
+  createFreshChatSession: createFreshChatSessionMock,
+  listChatMessages: listChatMessagesMock,
   listDemoChatMessages: listDemoChatMessagesMock,
   registerDemoChatSession: registerDemoChatSessionMock,
   sendDemoChatMessage: sendDemoChatMessageMock,
 }));
 
 vi.mock("@/shared/lib/websocket", () => ({
-  useStomp: () => stompState,
+  useStomp: (options: unknown) => {
+    useStompOptions.push(options);
+    return stompState;
+  },
 }));
 
 vi.mock("react-router-dom", async () => {
@@ -59,14 +74,44 @@ type DeferredChatMessage = {
   createdAt: string;
 };
 
+function seedAuthUser(name = "하나카드 데모 사용자") {
+  window.localStorage.setItem(
+    "user",
+    JSON.stringify({
+      id: 2,
+      email: "hanacard.demo@ostone.local",
+      name,
+      role: "OPERATOR",
+    }),
+  );
+}
+
 describe("UserChatPage", () => {
   beforeEach(() => {
     routeState.workspaceId = "42";
     searchState.search = "";
     window.localStorage.clear();
+    useStompOptions.length = 0;
     stompState.connectionStatus = "DISCONNECTED";
+    stompState.sendMessage.mockReset();
     stompState.subscribe.mockReset();
     stompState.subscribe.mockReturnValue(() => {});
+    createChatSessionMock.mockReset();
+    createChatSessionMock.mockResolvedValue({
+      id: 177,
+      status: "OPEN",
+      channel: "WEB",
+      startedAt: "2026-05-22T00:00:00Z",
+    });
+    createFreshChatSessionMock.mockReset();
+    createFreshChatSessionMock.mockResolvedValue({
+      id: 188,
+      status: "OPEN",
+      channel: "WEB",
+      startedAt: "2026-05-22T00:10:00Z",
+    });
+    listChatMessagesMock.mockReset();
+    listChatMessagesMock.mockResolvedValue([]);
     listDemoChatMessagesMock.mockReset();
     listDemoChatMessagesMock.mockResolvedValue([
       {
@@ -83,7 +128,15 @@ describe("UserChatPage", () => {
       id: "77",
       status: "OPEN",
       startedAt: "2026-05-22T00:00:00Z",
-      messages: [],
+      messages: [
+        {
+          id: "80",
+          sessionId: 77,
+          content: "안녕하세요, 김민지님. 무엇을 도와드릴까요?",
+          senderType: "BOT",
+          createdAt: "2026-05-22T00:00:00Z",
+        },
+      ],
     });
     sendDemoChatMessageMock.mockResolvedValue([
       {
@@ -151,6 +204,81 @@ describe("UserChatPage", () => {
     render(<UserChatPage />);
 
     expect(screen.getByTestId("chat-entry-screen")).not.toBeNull();
+    expect(registerDemoChatSessionMock).not.toHaveBeenCalled();
+  });
+
+  it("인증 모드는 로그인 사용자 이름으로 실제 사용자 채팅 세션을 자동 시작한다", async () => {
+    seedAuthUser();
+    listChatMessagesMock.mockResolvedValueOnce([
+      {
+        id: "201",
+        sessionId: 177,
+        content: "하나카드 상담을 시작합니다.",
+        senderType: "BOT",
+        createdAt: "2026-05-22T00:00:00Z",
+      },
+    ]);
+
+    render(<UserChatPage mode="authenticated" />);
+
+    expect(await screen.findByTestId("chat-conversation-screen")).not.toBeNull();
+    expect(screen.getByTestId("chat-header-eyebrow")).toHaveTextContent("Session #177");
+    expect(screen.getByTestId("chat-header-name")).toHaveTextContent("하나카드 데모 사용자");
+    expect(await screen.findByText("하나카드 상담을 시작합니다.")).not.toBeNull();
+    expect(createChatSessionMock).toHaveBeenCalledWith(42, "하나카드 데모 사용자");
+    expect(listChatMessagesMock).toHaveBeenCalledWith(177);
+    expect(registerDemoChatSessionMock).not.toHaveBeenCalled();
+    expect(useStompOptions[useStompOptions.length - 1]).toEqual({ includeAuth: true });
+  });
+
+  it("인증 모드는 메시지를 demo REST가 아니라 인증 WebSocket으로 전송한다", async () => {
+    seedAuthUser("하나카드 고객");
+    stompState.connectionStatus = "CONNECTED";
+
+    render(<UserChatPage mode="authenticated" />);
+
+    const input = await screen.findByLabelText("메시지 입력");
+    await waitFor(() => {
+      expect(stompState.subscribe).toHaveBeenCalledWith("/topic/chat.177", expect.any(Function));
+    });
+
+    fireEvent.change(input, { target: { value: "카드 한도 올리고 싶어요" } });
+    fireEvent.click(screen.getByRole("button", { name: "메시지 보내기" }));
+
+    expect(stompState.sendMessage).toHaveBeenCalledWith({
+      sessionId: 177,
+      content: "카드 한도 올리고 싶어요",
+    });
+    expect(sendDemoChatMessageMock).not.toHaveBeenCalled();
+    expect(screen.getByText("카드 한도 올리고 싶어요")).not.toBeNull();
+  });
+
+  it("인증 모드의 새 테스트 세션 시작은 실제 새 사용자 세션을 생성한다", async () => {
+    seedAuthUser("액티벤처 고객");
+    listChatMessagesMock.mockImplementation((sessionId: number) =>
+      Promise.resolve(
+        sessionId === 188
+          ? [
+              {
+                id: "301",
+                sessionId: 188,
+                content: "새 인증 테스트 세션입니다.",
+                senderType: "BOT",
+                createdAt: "2026-05-22T00:10:00Z",
+              },
+            ]
+          : [],
+      ),
+    );
+
+    render(<UserChatPage mode="authenticated" />);
+
+    expect(await screen.findByTestId("chat-conversation-screen")).not.toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "새 테스트 세션 시작" }));
+
+    expect(await screen.findByText("새 인증 테스트 세션입니다.")).not.toBeNull();
+    expect(screen.getByTestId("chat-header-eyebrow")).toHaveTextContent("Session #188");
+    expect(createFreshChatSessionMock).toHaveBeenCalledWith(42, "액티벤처 고객");
     expect(registerDemoChatSessionMock).not.toHaveBeenCalled();
   });
 
@@ -301,7 +429,7 @@ describe("UserChatPage", () => {
     const storedSession = window.localStorage.getItem(window.localStorage.key(0) ?? "");
     expect(storedSession).toContain("첫 테스트 세션입니다.");
     expect(consoleErrorSpy).toHaveBeenCalledWith(
-      "Failed to restart demo chat session",
+      "Failed to restart user chat session",
       expect.any(ApiRequestError),
     );
 
@@ -356,6 +484,27 @@ describe("UserChatPage", () => {
     await waitFor(() => {
       expect(window.localStorage.getItem(storageKey)).not.toContain("backend-greeting-77");
     });
+  });
+
+  it("빈 데모 저장 세션은 재사용하지 않고 greeting이 있는 새 세션을 만든다", async () => {
+    const storageKey = `ostone:demo-chat-session:42:${encodeURIComponent("김민지")}`;
+    window.localStorage.setItem(
+      storageKey,
+      JSON.stringify({
+        id: "66",
+        status: "OPEN",
+        startedAt: "2026-05-22T00:00:00Z",
+        messages: [],
+      }),
+    );
+
+    render(<UserChatPage />);
+    fireEvent.change(screen.getByLabelText("이름"), { target: { value: "김민지" } });
+    fireEvent.click(screen.getByRole("button", { name: "미리보기 시작" }));
+
+    expect(await screen.findByText("안녕하세요, 김민지님. 무엇을 도와드릴까요?")).not.toBeNull();
+    expect(registerDemoChatSessionMock).toHaveBeenCalledWith(42, "김민지");
+    expect(screen.getByTestId("chat-header-eyebrow")).toHaveTextContent("Session #77");
   });
 
   it("REST 응답에 봇 메시지가 있으면 최소 입력 표시 시간 이후 렌더링한다", async () => {
@@ -803,7 +952,7 @@ describe("UserChatPage", () => {
       ).not.toBeNull();
       expect(screen.getByRole("alert")).not.toBeNull();
       expect(consoleErrorSpy).toHaveBeenCalledWith(
-        "Failed to start demo chat session",
+        "Failed to start user chat session",
         expect.any(ApiRequestError),
       );
     });

--- a/frontend/src/pages/user-chat/ui/UserChatPage.tsx
+++ b/frontend/src/pages/user-chat/ui/UserChatPage.tsx
@@ -326,6 +326,21 @@ export function UserChatPage({ mode = "demo" }: UserChatPageProps) {
     setBotTyping(false);
   }, [clearBotTypingTimeout, setBotTyping]);
 
+  useEffect(() => {
+    const initialName = resolveInitialCustomerName(mode, nameParam);
+    nameRequestIdRef.current += 1;
+    sendRequestIdRef.current += 1;
+    autoStartedRef.current = false;
+    activeConversationRef.current = { sessionId: null, customerName: initialName };
+    setDraftName(initialName ?? "");
+    setCustomerName(initialName);
+    setNameError(null);
+    setMessageError(null);
+    setIsSending(false);
+    stopBotTyping();
+    setChatState({ workspaceId: null, customerName: null, session: null, error: null });
+  }, [mode, raw, nameParam, stopBotTyping]);
+
   const appendRealtimeMessages = useCallback(
     (nextMessages: ChatMessage[]) => {
       if (!activeSessionId || !customerName || nextMessages.length === 0) return;

--- a/frontend/src/pages/user-chat/ui/UserChatPage.tsx
+++ b/frontend/src/pages/user-chat/ui/UserChatPage.tsx
@@ -1,11 +1,14 @@
 import { type FormEvent, useCallback, useEffect, useRef, useState } from "react";
 import { useParams, useSearchParams } from "react-router-dom";
 import {
+  createChatSession,
+  createFreshChatSession,
+  listChatMessages,
   listDemoChatMessages,
   registerDemoChatSession,
   sendDemoChatMessage,
 } from "@/entities/chat";
-import type { ChatMessage, DemoChatSession } from "@/entities/chat";
+import type { ChatMessage, ChatSession, DemoChatSession } from "@/entities/chat";
 import {
   isRealtimeChatMessage,
   mergeMessages,
@@ -14,6 +17,7 @@ import {
   withCustomerNames,
 } from "@/entities/chat/lib/chatMessageSync";
 import { ApiRequestError } from "@/shared/api";
+import { getAuthUser } from "@/shared/lib/auth";
 import { useStomp } from "@/shared/lib/websocket";
 import { ChatConversationScreen } from "./ChatConversationScreen";
 import { ChatEntryScreen } from "./ChatEntryScreen";
@@ -38,12 +42,24 @@ function resolveMessageSendErrorMessage(error: unknown): string {
 }
 
 const DEMO_SESSION_STORAGE_PREFIX = "ostone:demo-chat-session";
+const AUTH_SESSION_STORAGE_PREFIX = "ostone:user-chat-session";
 const LOCAL_USER_MESSAGE_PREFIX = "local-user-";
 const BOT_TYPING_MIN_MS = 1000;
 
-function createStorageKey(workspaceId: number, customerName: string): string {
+export type UserChatPageMode = "demo" | "authenticated";
+
+interface UserChatPageProps {
+  mode?: UserChatPageMode;
+}
+
+function createStorageKey(
+  mode: UserChatPageMode,
+  workspaceId: number,
+  customerName: string,
+): string {
   const normalizedName = customerName.trim().toLowerCase();
-  return `${DEMO_SESSION_STORAGE_PREFIX}:${workspaceId}:${encodeURIComponent(normalizedName)}`;
+  const prefix = mode === "demo" ? DEMO_SESSION_STORAGE_PREFIX : AUTH_SESSION_STORAGE_PREFIX;
+  return `${prefix}:${workspaceId}:${encodeURIComponent(normalizedName)}`;
 }
 
 function isDemoChatSession(value: unknown): value is DemoChatSession {
@@ -144,61 +160,119 @@ function mergeRealtimeMessage(
     : mergeMessages(currentMessages, [realtimeMessage]);
 }
 
-function readStoredSession(workspaceId: number, customerName: string): DemoChatSession | null {
+function toDemoChatSession(session: ChatSession): DemoChatSession {
+  return {
+    id: String(session.id),
+    status: session.status,
+    startedAt: session.startedAt,
+    messages: [],
+  };
+}
+
+function resolveInitialCustomerName(
+  mode: UserChatPageMode,
+  nameParam: string | null,
+): string | null {
+  const queryName = nameParam?.trim();
+  if (queryName) return queryName;
+  if (mode !== "authenticated") return null;
+  const userName = getAuthUser()?.name?.trim();
+  return userName ? userName : null;
+}
+
+function readStoredSession(
+  mode: UserChatPageMode,
+  workspaceId: number,
+  customerName: string,
+): DemoChatSession | null {
   if (typeof window === "undefined") return null;
 
-  const raw = window.localStorage.getItem(createStorageKey(workspaceId, customerName));
+  const raw = window.localStorage.getItem(createStorageKey(mode, workspaceId, customerName));
   if (!raw) return null;
 
   try {
     const parsed = JSON.parse(raw) as unknown;
-    return isDemoChatSession(parsed) && isBackendRegisteredSession(parsed) ? parsed : null;
+    if (!isDemoChatSession(parsed) || !isBackendRegisteredSession(parsed)) {
+      return null;
+    }
+    if (mode === "demo" && parsed.messages.length === 0) {
+      return null;
+    }
+    return parsed;
   } catch {
     return null;
   }
 }
 
 function writeStoredSession(
+  mode: UserChatPageMode,
   workspaceId: number,
   customerName: string,
   session: DemoChatSession,
 ): void {
   if (typeof window === "undefined") return;
 
-  window.localStorage.setItem(createStorageKey(workspaceId, customerName), JSON.stringify(session));
+  window.localStorage.setItem(
+    createStorageKey(mode, workspaceId, customerName),
+    JSON.stringify(session),
+  );
 }
 
 async function getOrCreateStoredSession(
+  mode: UserChatPageMode,
   workspaceId: number,
   customerName: string,
 ): Promise<DemoChatSession> {
-  const storedSession = readStoredSession(workspaceId, customerName);
+  if (mode === "authenticated") {
+    const nextSession = toDemoChatSession(await createChatSession(workspaceId, customerName));
+    writeStoredSession(mode, workspaceId, customerName, nextSession);
+    return nextSession;
+  }
+
+  const storedSession = readStoredSession(mode, workspaceId, customerName);
   if (storedSession) return storedSession;
 
   const nextSession = await registerDemoChatSession(workspaceId, customerName);
-  writeStoredSession(workspaceId, customerName, nextSession);
+  writeStoredSession(mode, workspaceId, customerName, nextSession);
   return nextSession;
 }
 
 async function createFreshStoredSession(
+  mode: UserChatPageMode,
   workspaceId: number,
   customerName: string,
 ): Promise<DemoChatSession> {
-  const nextSession = await registerDemoChatSession(workspaceId, customerName);
-  writeStoredSession(workspaceId, customerName, nextSession);
+  const nextSession =
+    mode === "authenticated"
+      ? toDemoChatSession(await createFreshChatSession(workspaceId, customerName))
+      : await registerDemoChatSession(workspaceId, customerName);
+  writeStoredSession(mode, workspaceId, customerName, nextSession);
   return nextSession;
 }
 
-export function UserChatPage() {
+async function listMessagesForMode(
+  mode: UserChatPageMode,
+  workspaceId: number,
+  sessionId: string,
+): Promise<ChatMessage[]> {
+  if (mode === "authenticated") {
+    const numericSessionId = tryParseDemoSessionId(sessionId);
+    if (numericSessionId == null) return [];
+    return listChatMessages(numericSessionId);
+  }
+  return listDemoChatMessages(workspaceId, sessionId);
+}
+
+export function UserChatPage({ mode = "demo" }: UserChatPageProps) {
   const { workspaceId: raw } = useParams<{ workspaceId: string }>();
   const workspaceId = Number(raw);
   const [searchParams] = useSearchParams();
   const nameParam = searchParams.get("name");
-  const { connectionStatus, subscribe } = useStomp();
-  const [draftName, setDraftName] = useState("");
+  const isDemoMode = mode === "demo";
+  const { connectionStatus, sendMessage, subscribe } = useStomp({ includeAuth: !isDemoMode });
+  const [draftName, setDraftName] = useState(() => resolveInitialCustomerName(mode, nameParam) ?? "");
   const [customerName, setCustomerName] = useState<string | null>(() => {
-    const initialName = nameParam?.trim();
-    return initialName ? initialName : null;
+    return resolveInitialCustomerName(mode, nameParam);
   });
   const [nameError, setNameError] = useState<string | null>(null);
   const [isSending, setIsSending] = useState(false);
@@ -268,7 +342,7 @@ export function UserChatPage() {
             current.session.messages,
           ),
         };
-        writeStoredSession(workspaceId, customerName, {
+        writeStoredSession(mode, workspaceId, customerName, {
           ...nextSession,
           messages: withoutLocalUserMessages(nextSession.messages),
         });
@@ -278,7 +352,7 @@ export function UserChatPage() {
         };
       });
     },
-    [activeSessionId, customerName, workspaceId],
+    [activeSessionId, customerName, mode, workspaceId],
   );
 
   const flushPendingBotMessages = useCallback(() => {
@@ -333,11 +407,11 @@ export function UserChatPage() {
       setCustomerName(nextName);
       setChatState({ workspaceId, customerName: nextName, session: null, error: null });
       try {
-        const nextSession = await getOrCreateStoredSession(workspaceId, nextName);
+        const nextSession = await getOrCreateStoredSession(mode, workspaceId, nextName);
         if (requestId !== nameRequestIdRef.current) return;
         setChatState({ workspaceId, customerName: nextName, session: nextSession, error: null });
       } catch (error) {
-        console.error("Failed to start demo chat session", error);
+        console.error("Failed to start user chat session", error);
         if (requestId !== nameRequestIdRef.current) return;
         setChatState({
           workspaceId,
@@ -347,7 +421,7 @@ export function UserChatPage() {
         });
       }
     },
-    [workspaceId],
+    [mode, workspaceId],
   );
 
   const handleNameSubmit = (event: FormEvent<HTMLFormElement>) => {
@@ -357,11 +431,11 @@ export function UserChatPage() {
 
   useEffect(() => {
     if (autoStartedRef.current || isInvalidWorkspace) return;
-    const trimmedName = nameParam?.trim();
+    const trimmedName = resolveInitialCustomerName(mode, nameParam);
     if (!trimmedName) return;
     autoStartedRef.current = true;
     void startSession(trimmedName);
-  }, [nameParam, isInvalidWorkspace, startSession]);
+  }, [mode, nameParam, isInvalidWorkspace, startSession]);
 
   const handleStartNewSession = async () => {
     if (!customerName) return;
@@ -372,11 +446,11 @@ export function UserChatPage() {
     setChatState({ workspaceId, customerName, session: null, error: null });
 
     try {
-      const nextSession = await createFreshStoredSession(workspaceId, customerName);
+      const nextSession = await createFreshStoredSession(mode, workspaceId, customerName);
       if (requestId !== nameRequestIdRef.current) return;
       setChatState({ workspaceId, customerName, session: nextSession, error: null });
     } catch (error) {
-      console.error("Failed to restart demo chat session", error);
+      console.error("Failed to restart user chat session", error);
       if (requestId !== nameRequestIdRef.current) return;
       setChatState({
         workspaceId,
@@ -426,19 +500,23 @@ export function UserChatPage() {
     });
 
     try {
-      const responseMessages = withCustomerNames(
-        await sendDemoChatMessage(workspaceId, requestSessionId, content),
-        requestCustomerName,
-      );
-      if (!isCurrentConversation(requestSessionId, requestCustomerName)) return;
+      if (isDemoMode) {
+        const responseMessages = withCustomerNames(
+          await sendDemoChatMessage(workspaceId, requestSessionId, content),
+          requestCustomerName,
+        );
+        if (!isCurrentConversation(requestSessionId, requestCustomerName)) return;
 
-      const botMessages = responseMessages.filter(isBotMessage);
-      appendRealtimeMessages(responseMessages.filter((message) => !isBotMessage(message)));
+        const botMessages = responseMessages.filter(isBotMessage);
+        appendRealtimeMessages(responseMessages.filter((message) => !isBotMessage(message)));
 
-      if (botMessages.length > 0) {
-        botMessages.forEach(queueBotMessage);
+        if (botMessages.length > 0) {
+          botMessages.forEach(queueBotMessage);
+        } else {
+          stopBotTyping();
+        }
       } else {
-        stopBotTyping();
+        sendMessage({ sessionId: numericSessionId, content });
       }
     } catch (error) {
       setChatState((current) => {
@@ -476,7 +554,7 @@ export function UserChatPage() {
 
     const syncMessages = async () => {
       try {
-        const persistedMessages = await listDemoChatMessages(workspaceId, activeSessionId);
+        const persistedMessages = await listMessagesForMode(mode, workspaceId, activeSessionId);
         if (cancelled) return;
         const namedMessages = withCustomerNames(persistedMessages, customerName);
         setChatState((current) => {
@@ -491,7 +569,7 @@ export function UserChatPage() {
             ...current.session,
             messages: nextMessages,
           };
-          writeStoredSession(workspaceId, customerName, {
+          writeStoredSession(mode, workspaceId, customerName, {
             ...nextSession,
             messages: namedMessages,
           });
@@ -510,7 +588,7 @@ export function UserChatPage() {
     return () => {
       cancelled = true;
     };
-  }, [activeSessionId, customerName, workspaceId]);
+  }, [activeSessionId, customerName, mode, workspaceId]);
 
   useEffect(() => {
     if (!activeSessionId || !customerName || connectionStatus !== "CONNECTED") return;

--- a/frontend/src/shared/api/index.test.ts
+++ b/frontend/src/shared/api/index.test.ts
@@ -182,6 +182,23 @@ describe("apiClient", () => {
       expect(headers.get("Authorization")).toBeNull();
     });
 
+    it("demo endpoint 요청에는 저장된 access token을 Authorization header로 붙이지 않는다", async () => {
+      const mockResponse = { id: 1 };
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResponse,
+      });
+
+      await apiClient.request<{ id: number }>("/workspaces/2/demo/chat-sessions", {
+        method: "POST",
+        body: { customerName: "박하나" } as unknown as BodyInit,
+      });
+
+      const callArgs = mockFetch.mock.calls[0];
+      const headers = callArgs[1].headers as Headers;
+      expect(headers.get("Authorization")).toBeNull();
+    });
+
     it("body가 object인 경우 JSON.stringify한다", async () => {
       const mockResponse = { id: 1 };
       mockFetch.mockResolvedValueOnce({

--- a/frontend/src/shared/api/index.ts
+++ b/frontend/src/shared/api/index.ts
@@ -71,7 +71,10 @@ class ApiClient {
       ? normalizedPath.slice("/api/v1".length)
       : normalizedPath;
 
-    return pathWithoutApiPrefix !== "/auth" && !pathWithoutApiPrefix.startsWith("/auth/");
+    const isAuthPath =
+      pathWithoutApiPrefix === "/auth" || pathWithoutApiPrefix.startsWith("/auth/");
+    const isDemoPath = /^\/workspaces\/[^/]+\/demo(?:\/|$)/.test(pathWithoutApiPrefix);
+    return !isAuthPath && !isDemoPath;
   }
 
   private getHeaders(path: string): RequestHeaders {

--- a/frontend/src/shared/lib/userChatRoutes.ts
+++ b/frontend/src/shared/lib/userChatRoutes.ts
@@ -1,0 +1,3 @@
+export function buildUserChatPath(workspaceId: string | number): string {
+  return `/chat/${encodeURIComponent(String(workspaceId))}`;
+}

--- a/frontend/src/shared/lib/websocket/stompClient.test.ts
+++ b/frontend/src/shared/lib/websocket/stompClient.test.ts
@@ -37,6 +37,16 @@ describe("createStompClient", () => {
     expect(client.connectHeaders).toEqual({ Authorization: "Bearer access-token" });
   });
 
+  it("includeAuth=false 이면 저장된 access token을 CONNECT header에 붙이지 않는다", () => {
+    localStorage.setItem("accessToken", "access-token");
+
+    const client = createStompClient({ includeAuth: false });
+
+    expect(typeof client.beforeConnect).toBe("function");
+    (client.beforeConnect as () => void)();
+    expect(client.connectHeaders).toEqual({});
+  });
+
   it("VITE_WS_URL 환경 변수가 https 프로토콜일 때 wss로 자동 변환하고 trailing slash를 제거한다", () => {
     vi.stubEnv("VITE_WS_URL", "https://example.com/api/");
 

--- a/frontend/src/shared/lib/websocket/stompClient.ts
+++ b/frontend/src/shared/lib/websocket/stompClient.ts
@@ -4,6 +4,10 @@ import { getAccessToken } from "@/shared/lib/auth";
 const DEFAULT_WS_URL = "ws://localhost:8080";
 const API_BASE_SUFFIX = "/api/v1";
 
+export interface CreateStompClientOptions {
+  includeAuth?: boolean;
+}
+
 function normalizeWsUrl(url: string): string {
   return url
     .replace(/^https:\/\//, "wss://")
@@ -27,7 +31,8 @@ function resolveWsUrlFromApiBase(): string | undefined {
     : apiBaseUrl;
 }
 
-export function createStompClient(): Client {
+export function createStompClient(options: CreateStompClientOptions = {}): Client {
+  const includeAuth = options.includeAuth ?? true;
   const client = new Client({
     brokerURL: `${getWebSocketBaseUrl()}/ws/chat`,
     reconnectDelay: 5000,
@@ -35,6 +40,10 @@ export function createStompClient(): Client {
     heartbeatOutgoing: 10000,
   });
   client.beforeConnect = () => {
+    if (!includeAuth) {
+      client.connectHeaders = {};
+      return;
+    }
     const token = getAccessToken();
     client.connectHeaders = token ? { Authorization: `Bearer ${token}` } : {};
   };

--- a/frontend/src/shared/lib/websocket/useStomp.test.tsx
+++ b/frontend/src/shared/lib/websocket/useStomp.test.tsx
@@ -218,6 +218,38 @@ describe("useStomp", () => {
     expect(client.subscribe).toHaveBeenCalledWith("/topic/test", expect.any(Function));
   });
 
+  it("includeAuth 변경으로 재연결되어도 custom subscribe를 다시 등록한다", async () => {
+    const { result, rerender } = renderHook(
+      ({ includeAuth }: { includeAuth: boolean }) => useStomp({ includeAuth }),
+      { initialProps: { includeAuth: false } },
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    act(() => {
+      client.connected = true;
+      client.onConnect?.(dummyFrame);
+    });
+    act(() => {
+      result.current.subscribe("/topic/test", vi.fn());
+    });
+    client.subscribe.mockClear();
+
+    await act(async () => {
+      client.connected = false;
+      rerender({ includeAuth: true });
+      await Promise.resolve();
+    });
+    act(() => {
+      client.connected = true;
+      client.onConnect?.(dummyFrame);
+    });
+
+    expect(client.subscribe).toHaveBeenCalledWith("/user/queue/errors", expect.any(Function));
+    expect(client.subscribe).toHaveBeenCalledWith("/topic/test", expect.any(Function));
+  });
+
   it("이미 동일 토픽을 subscribe 중일 때 재호출하면 이전 구독을 해제하고 덮어쓴다", async () => {
     const { result } = await renderUseStompHelper();
 

--- a/frontend/src/shared/lib/websocket/useStomp.ts
+++ b/frontend/src/shared/lib/websocket/useStomp.ts
@@ -18,6 +18,7 @@ export interface UseStompResult {
 
 export interface UseStompOptions {
   onServerError?: (error: unknown) => void;
+  includeAuth?: boolean;
 }
 
 const parseMessageBody = (body: string): unknown | null => {
@@ -29,6 +30,7 @@ const parseMessageBody = (body: string): unknown | null => {
 };
 
 export function useStomp(options: UseStompOptions = {}): UseStompResult {
+  const includeAuth = options.includeAuth;
   const clientRef = useRef<Client | null>(null);
   const errorSubscriptionRef = useRef<StompSubscription | null>(null);
   const desiredSubscriptionsRef = useRef<Map<string, (msg: unknown) => void>>(new Map());
@@ -84,7 +86,7 @@ export function useStomp(options: UseStompOptions = {}): UseStompResult {
     }
     if (clientRef.current?.connected) return;
 
-    const client = createStompClient();
+    const client = createStompClient({ includeAuth });
     clientRef.current = client;
     connectionStatusRef.current = "CONNECTING";
     setConnectionStatus("CONNECTING");
@@ -135,7 +137,7 @@ export function useStomp(options: UseStompOptions = {}): UseStompResult {
     };
 
     client.activate();
-  }, [subscribeActiveTopic, unsubscribeActiveSubscriptions]);
+  }, [includeAuth, subscribeActiveTopic, unsubscribeActiveSubscriptions]);
 
   const sendMessage = useCallback((message: unknown) => {
     const client = clientRef.current;

--- a/frontend/src/shared/lib/websocket/useStomp.ts
+++ b/frontend/src/shared/lib/websocket/useStomp.ts
@@ -66,16 +66,22 @@ export function useStomp(options: UseStompOptions = {}): UseStompResult {
     [],
   );
 
-  const disconnect = useCallback(() => {
+  const disconnectInternal = useCallback((clearDesiredSubscriptions: boolean) => {
     errorSubscriptionRef.current?.unsubscribe();
     errorSubscriptionRef.current = null;
     unsubscribeActiveSubscriptions();
-    desiredSubscriptionsRef.current.clear();
+    if (clearDesiredSubscriptions) {
+      desiredSubscriptionsRef.current.clear();
+    }
     clientRef.current?.deactivate();
     clientRef.current = null;
     connectionStatusRef.current = "DISCONNECTED";
     setConnectionStatus("DISCONNECTED");
   }, [unsubscribeActiveSubscriptions]);
+
+  const disconnect = useCallback(() => {
+    disconnectInternal(true);
+  }, [disconnectInternal]);
 
   const connect = useCallback(() => {
     if (
@@ -186,9 +192,9 @@ export function useStomp(options: UseStompOptions = {}): UseStompResult {
     void scheduleConnect();
     return () => {
       isMounted = false;
-      disconnect();
+      disconnectInternal(false);
     };
-  }, [connect, disconnect]);
+  }, [connect, disconnectInternal]);
 
   return { connectionStatus, sendMessage, connect, disconnect, subscribe, sendTo };
 }

--- a/frontend/src/shared/ui/ostone/chrome/Sidebar.test.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/Sidebar.test.tsx
@@ -78,7 +78,7 @@ describe("Sidebar", () => {
     renderSidebar({ basePath: "/workspaces/7" });
 
     expect(screen.getByTitle("상담 응대")).toHaveAttribute("href", "/workspaces/7/consultation");
-    expect(screen.getByTitle("사용자 화면 미리보기")).toHaveAttribute("href", "/demo/chat/7");
+    expect(screen.getByTitle("사용자 화면 미리보기")).toHaveAttribute("href", "/demo");
     expect(screen.getByTitle("사용자 화면 미리보기")).toHaveAttribute("target", "_blank");
     expect(screen.getByTitle("사용자 화면 미리보기")).toHaveAttribute("rel", "noopener noreferrer");
     expect(screen.getByTitle("도메인팩 관리")).toHaveAttribute(
@@ -87,10 +87,10 @@ describe("Sidebar", () => {
     );
   });
 
-  it("workspaceId를 추출할 수 없으면 사용자 화면 미리보기 링크를 안전한 내부 경로로 보낸다", () => {
+  it("workspaceId를 추출할 수 없어도 사용자 화면 미리보기는 데모 선택 화면으로 보낸다", () => {
     renderSidebar({ basePath: "/workspaces" });
 
-    expect(screen.getByTitle("사용자 화면 미리보기")).toHaveAttribute("href", "/workspaces");
+    expect(screen.getByTitle("사용자 화면 미리보기")).toHaveAttribute("href", "/demo");
   });
 
   it("외부 링크(사용자 화면 미리보기)에만 새 탭 안내 아이콘을 표시한다", () => {

--- a/frontend/src/shared/ui/ostone/chrome/Sidebar.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/Sidebar.tsx
@@ -1,7 +1,6 @@
 import type { CSSProperties, MouseEvent, ReactNode } from "react";
 import { ExternalLink } from "lucide-react";
 import { NavLink } from "react-router-dom";
-import { buildDemoChatPath } from "@/shared/lib/demoRoutes";
 import { Icon } from "../atoms/Icon";
 import type { IconName } from "../atoms/Icon";
 import { AccountMenu } from "./AccountMenu";
@@ -32,13 +31,8 @@ interface TopNavItem {
   external?: boolean;
 }
 
-function getDemoChatPath(base: string): string {
-  const match = /^\/workspaces\/([^/]+)(?:\/.*)?$/.exec(base);
-  if (!match) {
-    return "/workspaces";
-  }
-
-  return buildDemoChatPath(match[1]);
+function getDemoPreviewPath(): string {
+  return "/demo";
 }
 
 const TOP_NAV_ITEMS: TopNavItem[] = [
@@ -52,7 +46,7 @@ const TOP_NAV_ITEMS: TopNavItem[] = [
     key: "chat",
     icon: "msg",
     label: "사용자 화면 미리보기",
-    getPath: getDemoChatPath,
+    getPath: getDemoPreviewPath,
     external: true,
   },
   {


### PR DESCRIPTION
## 변경 내용

- `.agent/specs/529.md`에 하나카드 seed 스펙과 화면 진입부터 workflow 종료까지의 전체 예시 flow를 추가했습니다.
- workspace 2에 `hanacard-card-service` 하드코딩 도메인팩 seed를 추가했습니다.
- 하나카드/액티벤처 데모 계정을 seed해 계정별로 다른 workspace/domain 채팅을 테스트할 수 있게 했습니다.
- 사이드바 `사용자 화면 미리보기`는 기존처럼 `/demo`로 이동하도록 복구하고, 실제 로그인 사용자 채팅은 `/chat/:workspaceId`에서 사용할 수 있게 유지했습니다.
- 인증 사용자 채팅 세션 생성, 공개 데모 WebSocket 처리, 라우팅 회귀 테스트를 추가했습니다.
- SonarCloud 보안 게이트 대응을 위해 demo 계정 bcrypt hash 하드코딩을 제거하고, local/dev seed 실행 시 `PasswordEncoder`로 hash를 생성하도록 변경했습니다.

## 배경

529 작업은 전체 ML 파이프라인을 실행하지 않아도 하나카드 상담 도메인을 로컬에서 바로 시연할 수 있어야 합니다. 동시에 실제 로그인 기반 채팅 테스트와 기존 `/demo` 미리보기 흐름이 모두 유지되어야 합니다.

## 검증

- `python3 -m json.tool backend/src/main/resources/seed/hanacard-workflow-candidate.json`
- `git diff --check`
- `./gradlew test --tests com.init.workflowruntime.application.UserChatSessionServiceTest --tests com.init.workflowruntime.presentation.UserChatSessionControllerTest --tests com.init.workflowruntime.interceptor.JwtChannelInterceptorTest`
- `./gradlew test --tests com.init.workflowruntime.application.UserChatSessionServiceTest --tests com.init.workflowruntime.presentation.UserChatSessionControllerTest --tests com.init.workflowruntime.interceptor.JwtChannelInterceptorTest spotlessCheck bootJar`
- `./gradlew spotlessCheck bootJar`
- `pnpm test -- --run src/entities/chat/api/chatApi.test.ts src/pages/user-chat/ui/UserChatPage.test.tsx src/shared/ui/ostone/chrome/Sidebar.test.tsx src/app/App.test.tsx src/pages/demo/ui/DemoPage.test.tsx`
- `pnpm build`

`pnpm build`는 통과했으며, 기존 Vite chunk-size 경고만 발생했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 인증된 사용자용 독립 채팅 모드 및 인증 기반 세션 생성 API 추가
  * 익명 사용자의 제한적 WebSocket 구독 지원 및 인증 포함 제어 옵션 도입
  * UI 경로/리다이렉트 개선(레거시 → 새 사용자 채팅 경로) 및 데모/사용자 모드 분기

* **버그 수정 / 안정성**
  * 데모 API 호출에서 인증 헤더 제외 처리로 불필요한 인증 오류 완화

* **문서**
  * 로컬 시연용 시드 구성 문서화 및 데모 데이터 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->