### PR TITLE
fix(demo): 익명 데모 채팅 STOMP 에러 큐 구독으로 인한 실시간 연결 실패 수정

### DIFF
--- a/backend/src/main/java/com/init/workflowruntime/interceptor/JwtChannelInterceptor.java
+++ b/backend/src/main/java/com/init/workflowruntime/interceptor/JwtChannelInterceptor.java
@@ -26,6 +26,7 @@ public class JwtChannelInterceptor implements ChannelInterceptor {
   private static final String WORKSPACE_QUEUE_TOPIC_PREFIX = "/topic/workspaces.";
   private static final String WORKSPACE_QUEUE_TOPIC_SUFFIX = ".consultation.queue";
   private static final String SESSION_ATTR_ANONYMOUS = "anonymous";
+  private static final String USER_ERROR_QUEUE = "/user/queue/errors";
 
   private final JwtService jwtService;
   private final ChatSessionRepository chatSessionRepository;
@@ -146,6 +147,11 @@ public class JwtChannelInterceptor implements ChannelInterceptor {
       String destination, StompHeaderAccessor accessor) {
     if (destination == null || destination.isBlank()) {
       throw new BadRequestException("INVALID_DESTINATION", "Subscription destination is required");
+    }
+    // 익명(데모) 세션이 자기 세션의 서버 에러 큐를 구독하는 것은 허용한다.
+    // 프론트엔드 STOMP 클라이언트가 연결 직후 항상 이 큐를 구독하기 때문이다.
+    if (USER_ERROR_QUEUE.equals(destination)) {
+      return;
     }
     if (!destination.startsWith(CHAT_TOPIC_PREFIX)) {
       throw new MissingAuthHeaderException(

--- a/backend/src/test/java/com/init/workflowruntime/interceptor/JwtChannelInterceptorTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/interceptor/JwtChannelInterceptorTest.java
@@ -226,11 +226,25 @@ class JwtChannelInterceptorTest {
   }
 
   @Test
-  @DisplayName("SUBSCRIBE without authentication, user queue → MissingAuthHeaderException")
-  void should_throwMissingAuthHeader_when_anonymousSubscribesUserQueue() {
+  @DisplayName("SUBSCRIBE without authentication, anonymous error queue → passes through")
+  void should_passThrough_when_anonymousSubscribesUserErrorQueue() {
     StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.SUBSCRIBE);
     accessor.setSessionAttributes(new HashMap<>(Map.of("anonymous", true)));
     accessor.setDestination("/user/queue/errors");
+    Message<byte[]> message =
+        MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+
+    Message<?> result = interceptor.preSend(message, channel);
+
+    assertThat(result).isSameAs(message);
+  }
+
+  @Test
+  @DisplayName("SUBSCRIBE without authentication, other user queue → MissingAuthHeaderException")
+  void should_throwMissingAuthHeader_when_anonymousSubscribesNonErrorUserQueue() {
+    StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.SUBSCRIBE);
+    accessor.setSessionAttributes(new HashMap<>(Map.of("anonymous", true)));
+    accessor.setDestination("/user/queue/messages");
     Message<byte[]> message =
         MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
 

--- a/frontend/src/shared/lib/websocket/useStomp.test.tsx
+++ b/frontend/src/shared/lib/websocket/useStomp.test.tsx
@@ -96,6 +96,40 @@ describe("useStomp", () => {
     expect(client.subscribe).toHaveBeenCalledWith("/user/queue/errors", expect.any(Function));
   });
 
+  it("includeAuth가 false인 익명(데모) 모드에서는 에러 큐를 구독하지 않는다", async () => {
+    const { result } = await renderUseStompHelper({ includeAuth: false });
+
+    act(() => {
+      client.connected = true;
+      client.onConnect?.(dummyFrame);
+    });
+
+    expect(result.current.connectionStatus).toBe("CONNECTED");
+    expect(client.subscribe).not.toHaveBeenCalledWith(
+      "/user/queue/errors",
+      expect.any(Function),
+    );
+  });
+
+  it("includeAuth가 false여도 사용자가 등록한 토픽은 구독한다", async () => {
+    const { result } = await renderUseStompHelper({ includeAuth: false });
+    const topicCallback = vi.fn();
+
+    act(() => {
+      result.current.subscribe("/topic/chat.7", topicCallback);
+    });
+    act(() => {
+      client.connected = true;
+      client.onConnect?.(dummyFrame);
+    });
+
+    expect(client.subscribe).toHaveBeenCalledWith("/topic/chat.7", expect.any(Function));
+    expect(client.subscribe).not.toHaveBeenCalledWith(
+      "/user/queue/errors",
+      expect.any(Function),
+    );
+  });
+
   it("연결된 상태에서 채팅 메시지를 publish 한다", async () => {
     const { result } = await renderUseStompHelper();
 

--- a/frontend/src/shared/lib/websocket/useStomp.ts
+++ b/frontend/src/shared/lib/websocket/useStomp.ts
@@ -102,13 +102,18 @@ export function useStomp(options: UseStompOptions = {}): UseStompResult {
       connectionStatusRef.current = "CONNECTED";
       setConnectionStatus("CONNECTED");
       errorSubscriptionRef.current?.unsubscribe();
-      errorSubscriptionRef.current = client.subscribe(ERROR_QUEUE, (message) => {
-        const error = parseMessageBody(message.body);
-        if (error !== null) {
-          console.error("WebSocket server error:", error);
-          onServerErrorRef.current?.(error);
-        }
-      });
+      errorSubscriptionRef.current = null;
+      // 익명(데모) 세션은 서버에서 /user/queue/errors 구독이 허용되지 않으므로 건너뛴다.
+      // 구독을 시도하면 서버가 STOMP ERROR 프레임으로 연결을 끊어 연결 자체가 실패한다.
+      if (includeAuth !== false) {
+        errorSubscriptionRef.current = client.subscribe(ERROR_QUEUE, (message) => {
+          const error = parseMessageBody(message.body);
+          if (error !== null) {
+            console.error("WebSocket server error:", error);
+            onServerErrorRef.current?.(error);
+          }
+        });
+      }
       unsubscribeActiveSubscriptions();
       desiredSubscriptionsRef.current.forEach((cb, topic) => {
         subscribeActiveTopic(client, topic, cb);


### PR DESCRIPTION
## 증상
/demo 상담사 채팅 진입 시 "실시간 연결에 문제가 있습니다. 네트워크 상태를
확인한 뒤 다시 시도해 주세요." 배너가 뜨고 입력창이 비활성화된다. 5초마다
재연결하며 동일 실패가 반복된다.

## 근본 원인 (FE↔BE 계약 불일치)
- FE useStomp는 onConnect 시 includeAuth 여부와 무관하게 항상 `/user/queue/errors`를 구독한다.
- 데모는 익명(includeAuth=false, JWT 미전송)으로 연결한다.
- BE JwtChannelInterceptor.validateAnonymousSubscribeDestination 은 익명 세션에 `/topic/chat.*` 구독만 허용하고 그 외 destination은 거부한다.
- 따라서 `/user/queue/errors` 구독이 거부되어 ChannelInterceptor.preSend 에서 예외가 발생, Spring이 STOMP ERROR 프레임을 보내고 세션을 종료한다 (WS close 1002). FE는 onStompError로 connectionStatus="ERROR"가 되어 배너가 표시된다.
- 익명 구독 화이트리스트는 #489에서 도입됐으나, FE가 항상 보내는 에러 큐 구독을 반영하지 못한 회귀다.

## 수정 (양방향, 방어적)
- FE: 익명(includeAuth===false) 모드에서는 `/user/queue/errors`를 구독하지 않는다. 데모 봇 응답은 `/topic/chat.{id}`로만 오므로 에러 큐는 불필요하다.
- BE: 익명 세션이 자기 세션의 `/user/queue/errors`(user-destination)를 구독하는 것을 허용한다. 그 외 user queue는 여전히 거부해 화이트리스트를 좁게 유지한다.

## 검증
- 단위 테스트: JwtChannelInterceptorTest(익명 에러큐 pass-through + 비-에러 user queue reject), useStomp.test(익명 모드 에러큐 미구독 + 토픽 구독 유지)
- 런타임: 로컬 docker(backend 재빌드)에서 /demo 채팅 Playwright 검증 → 연결 배너 "연결됨", 입력창 활성화. WS 프레임 레벨로 익명 에러큐 구독이 ERROR 없이 통과함을 확인.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 비인증 사용자(데모 모드)도 서버 에러 메시지를 정상적으로 수신할 수 있도록 개선했습니다. 기존에는 인증되지 않은 요청에서 에러 채널 접근이 제한되었습니다.

* **테스트**
  * 비인증 모드에서의 에러 채널 구독 및 메시지 수신 동작에 대한 검증 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->