### PR TITLE
fix(infra): ECS 백엔드 배포 health check grace 부족으로 인한 deploy 실패 수정

### DIFF
--- a/infra/terraform/alb.tf
+++ b/infra/terraform/alb.tf
@@ -20,9 +20,12 @@ resource "aws_lb_target_group" "backend" {
   target_type = "ip"
 
   health_check {
-    enabled             = true
-    healthy_threshold   = 2
-    unhealthy_threshold = 3
+    enabled           = true
+    healthy_threshold = 2
+    # 0.5 vCPU 백엔드는 GC 일시정지/순간 부하 시 /actuator/health 응답이 일시적으로 느려질 수
+    # 있다. unhealthy_threshold 3(=90s)은 정상 태스크를 성급히 내릴 여지가 있어 5(=150s)로
+    # 완화해 런타임 flap-kill 여지를 줄인다(복구는 healthy_threshold 2로 빠르게 유지).
+    unhealthy_threshold = 5
     interval            = 30
     timeout             = 5
     path                = "/actuator/health"

--- a/infra/terraform/ecs-cluster.tf
+++ b/infra/terraform/ecs-cluster.tf
@@ -219,7 +219,13 @@ resource "aws_ecs_service" "backend" {
   launch_type      = "FARGATE"
   platform_version = "LATEST"
 
-  health_check_grace_period_seconds = 60
+  # 백엔드는 0.5 vCPU(cpu=512)에서 JPA 32개 + Spring AI 부트스트랩으로 기동에 약 93~106초가
+  # 걸린다(CloudWatch 측정치). grace 60초는 앱이 준비되기 전에 ELB health check 실패가
+  # 누적되어(unhealthy_threshold 3 × interval 30s ≈ 90s) ECS가 정상 기동 중인 태스크를
+  # SIGTERM(exit 143)으로 죽이는 경계 race를 유발했다 → 배포가 steady state에 도달하지 못함.
+  # 최대 기동 시간(~106s) + ELB healthy 판정(healthy_threshold 2 × 30s ≈ 60s)을 충분히
+  # 포괄하도록 240초로 상향한다.
+  health_check_grace_period_seconds = 240
 
   network_configuration {
     subnets          = values(aws_subnet.private)[*].id


### PR DESCRIPTION
## 증상
prod-deploy의 backend ECS 배포가 `aws ecs wait services-stable` 단계에서 "Waiter ServicesStable failed: Max attempts exceeded"로 실패. 태스크가 "Task failed ELB health checks"로 반복 SIGTERM(exit 143)되어 steady state에 도달하지 못함.

## 근본 원인 (CloudWatch 직접 확인)
- 백엔드는 0.5 vCPU(cpu=512)에서 기동 완료까지 93~106초 소요 ("Started Application in 93.283~106.391 seconds", 최근 태스크 7개 측정).
- ECS 서비스 health_check_grace_period_seconds=60(초)이라 grace 만료 후 앱이 준비되기 전에 ALB 타깃그룹 health check 실패가 누적 (unhealthy_threshold 3 × interval 30s ≈ 90s)되어 ECS가 정상 기동 중인 태스크를 죽인다. startup(~93-106s)과 kill 시점(~90s)이 겹치는 경계 race라 taskDef 11은 통과(07:10 steady state), taskDef 12는 실패하는 비결정적 동작.
- 앱 자체는 정상 기동한다(이전 openAiAudioSpeechModel 빈 크래시는 #491/#492에서 이미 해결됨).

## 수정
- aws_ecs_service.backend: health_check_grace_period_seconds 60 → 240 (최대 기동 ~106s + ELB healthy 판정 ~60s를 충분히 포괄).
- aws_lb_target_group.backend health_check: unhealthy_threshold 3 → 5 (런타임에서 0.5vCPU 태스크의 일시적 지연으로 인한 flap-kill 완화).

## 검증
- tofu validate: Success / tofu fmt: OK
- live 값 확인: grace=60, unhealthy=3 → 둘 다 in-place update 대상 (서비스/타깃그룹 재생성 없음). apply/배포는 수행하지 않음 (머지 후 prod-deploy의 terraform job이 적용).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * 배포 중 서비스 안정성 개선을 위한 헬스 체크 설정 조정
  * 서비스 시작 시 안정성 개선을 위한 헬스 체크 유예 시간 연장

<!-- end of auto-generated comment: release notes by coderabbit.ai -->