### PR TITLE
fix(infra): 백엔드 ECS 배포 기동 안정성 개선

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -309,6 +309,7 @@ cd frontend && pnpm build && docker build -t init-frontend .
 - **YAGNI**: 실제로 필요한 기능만 구현
 - **DRY**: 중복 허용 안 함, 3번 반복 시 추출
 - **Rule of Three**: 복잡한 추상화는 3번 반복 후 도입
+- **불필요한 주석 금지**: 코드·설정 자체로 드러나는 내용이나 일시적 맥락을 장황하게 남기지 않음. 비자명한 제약, 장애 재발 방지 근거, 운영상 주의점처럼 유지보수에 필요한 경우에만 간결하게 작성
 
 ### Backend (Java/Spring)
 

--- a/docs/ops/runbook.md
+++ b/docs/ops/runbook.md
@@ -266,7 +266,7 @@ aws rds restore-db-instance-from-db-snapshot \
 | --- | --- |
 | AWS Region | `ap-northeast-2` |
 | ECS Cluster | `ostone-prod-cluster` |
-| ECS Service | `ostone-backend`, Fargate, 0.5 vCPU, 1GB |
+| ECS Service | `ostone-backend`, Fargate, 1 vCPU, 2GB |
 | Backend Task Definition | `ostone-prod-backend-task` |
 | ALB DNS | `api.ostone.io`, Backend Target Group 8080 |
 | RDS | `ostone-prod-postgres`, `db.t4g.medium`, 20GB gp3, PostgreSQL 16, Multi-AZ |

--- a/infra/terraform/alb.tf
+++ b/infra/terraform/alb.tf
@@ -20,11 +20,8 @@ resource "aws_lb_target_group" "backend" {
   target_type = "ip"
 
   health_check {
-    enabled           = true
-    healthy_threshold = 2
-    # 0.5 vCPU 백엔드는 GC 일시정지/순간 부하 시 /actuator/health 응답이 일시적으로 느려질 수
-    # 있다. unhealthy_threshold 3(=90s)은 정상 태스크를 성급히 내릴 여지가 있어 5(=150s)로
-    # 완화해 런타임 flap-kill 여지를 줄인다(복구는 healthy_threshold 2로 빠르게 유지).
+    enabled             = true
+    healthy_threshold   = 2
     unhealthy_threshold = 5
     interval            = 30
     timeout             = 5

--- a/infra/terraform/ecs-cluster.tf
+++ b/infra/terraform/ecs-cluster.tf
@@ -33,8 +33,8 @@ resource "aws_ecs_task_definition" "backend" {
   family                   = "${local.name_prefix}-backend-task"
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
-  cpu                      = "512"
-  memory                   = "1024"
+  cpu                      = "1024"
+  memory                   = "2048"
   execution_role_arn       = aws_iam_role.ecs_task_execution.arn
   task_role_arn            = aws_iam_role.ecs_backend_task.arn
 
@@ -204,7 +204,7 @@ resource "aws_ecs_task_definition" "backend" {
       }
 
       cpu    = 0
-      memory = 1024
+      memory = 2048
     }
   ])
 
@@ -219,13 +219,7 @@ resource "aws_ecs_service" "backend" {
   launch_type      = "FARGATE"
   platform_version = "LATEST"
 
-  # 백엔드는 0.5 vCPU(cpu=512)에서 JPA 32개 + Spring AI 부트스트랩으로 기동에 약 93~106초가
-  # 걸린다(CloudWatch 측정치). grace 60초는 앱이 준비되기 전에 ELB health check 실패가
-  # 누적되어(unhealthy_threshold 3 × interval 30s ≈ 90s) ECS가 정상 기동 중인 태스크를
-  # SIGTERM(exit 143)으로 죽이는 경계 race를 유발했다 → 배포가 steady state에 도달하지 못함.
-  # 최대 기동 시간(~106s) + ELB healthy 판정(healthy_threshold 2 × 30s ≈ 60s)을 충분히
-  # 포괄하도록 240초로 상향한다.
-  health_check_grace_period_seconds = 240
+  health_check_grace_period_seconds = 180
 
   network_configuration {
     subnets          = values(aws_subnet.private)[*].id


### PR DESCRIPTION
## Summary
- Backend ECS task resources now use 1 vCPU / 2GB so production startup has more CPU headroom.
- Backend ECS service health check grace period is reduced to 180 seconds to keep deployment recovery faster while still covering startup.
- The backend target group no longer carries the long transient health-check comment, and AGENTS.md now records the rule to avoid unnecessary comments.
- The ops runbook reflects the updated backend ECS service size.

## 확인
- `terraform fmt -check infra/terraform`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * 코딩 컨벤션에 불필요한 주석 금지 규칙 추가
  * 운영 정보 문서 업데이트

* **Chores**
  * 백엔드 서버 리소스 업스케일 (CPU 및 메모리 증가)
  * 배포 헬스 체크 타임아웃 시간 연장으로 배포 안정성 개선
  * 인프라 설정 정렬 및 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->