### PR TITLE
fix: demo 챗봇 응답·실시간 연결 안정화(Bedrock 권한·WS heartbeat)와 macOS ZIP 업로드 수정

### DIFF
--- a/backend/src/main/java/com/init/corpus/application/RawFileUploadService.java
+++ b/backend/src/main/java/com/init/corpus/application/RawFileUploadService.java
@@ -197,7 +197,9 @@ public class RawFileUploadService {
         if (!isSafeZipEntryName(entryName)) {
           throw new RawFileParseException("ZIP 파일에 안전하지 않은 경로가 포함되어 있습니다: " + entryName);
         }
-        if (entry.isDirectory() || !isSupportedZipEntry(entryName)) {
+        if (entry.isDirectory()
+            || isMacOsMetadataEntry(entryName)
+            || !isSupportedZipEntry(entryName)) {
           zip.closeEntry();
           continue;
         }
@@ -251,6 +253,22 @@ public class RawFileUploadService {
   private boolean isSupportedZipEntry(String entryName) {
     String lowered = entryName.toLowerCase();
     return lowered.endsWith(".json") || lowered.endsWith(".jsonl");
+  }
+
+  /**
+   * macOS가 ZIP을 만들 때 끼워 넣는 메타데이터 항목 여부. {@code __MACOSX/} 디렉터리, AppleDouble
+   * 리소스 포크({@code ._*}), {@code .DS_Store}는 데이터가 아니므로 OS와 무관하게 건너뛴다.
+   * 이를 처리하지 않으면 {@code __MACOSX/._x.json} 같은 항목이 .json 확장자 때문에 파싱 대상이
+   * 되어 NUL 바이트로 인한 JSON 파싱 실패가 발생한다.
+   */
+  private boolean isMacOsMetadataEntry(String entryName) {
+    String normalized = entryName.replace('\\', '/');
+    for (String part : normalized.split("/")) {
+      if (part.equals("__MACOSX") || part.equals(".DS_Store") || part.startsWith("._")) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private List<RawConversationInput> parseJsonConversations(byte[] fileBytes, String sourceName) {

--- a/backend/src/main/java/com/init/corpus/application/RawFileUploadService.java
+++ b/backend/src/main/java/com/init/corpus/application/RawFileUploadService.java
@@ -256,10 +256,9 @@ public class RawFileUploadService {
   }
 
   /**
-   * macOS가 ZIP을 만들 때 끼워 넣는 메타데이터 항목 여부. {@code __MACOSX/} 디렉터리, AppleDouble
-   * 리소스 포크({@code ._*}), {@code .DS_Store}는 데이터가 아니므로 OS와 무관하게 건너뛴다.
-   * 이를 처리하지 않으면 {@code __MACOSX/._x.json} 같은 항목이 .json 확장자 때문에 파싱 대상이
-   * 되어 NUL 바이트로 인한 JSON 파싱 실패가 발생한다.
+   * macOS가 ZIP을 만들 때 끼워 넣는 메타데이터 항목 여부. {@code __MACOSX/} 디렉터리, AppleDouble 리소스 포크({@code ._*}),
+   * {@code .DS_Store}는 데이터가 아니므로 OS와 무관하게 건너뛴다. 이를 처리하지 않으면 {@code __MACOSX/._x.json} 같은 항목이 .json
+   * 확장자 때문에 파싱 대상이 되어 NUL 바이트로 인한 JSON 파싱 실패가 발생한다.
    */
   private boolean isMacOsMetadataEntry(String entryName) {
     String normalized = entryName.replace('\\', '/');

--- a/backend/src/main/java/com/init/workflowruntime/config/WebSocketConfig.java
+++ b/backend/src/main/java/com/init/workflowruntime/config/WebSocketConfig.java
@@ -6,6 +6,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
@@ -15,8 +17,16 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 @EnableWebSocketMessageBroker
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
+  // STOMP heartbeat 주기(ms). ALB idle timeout(60s)보다 짧은 주기로 양방향 heartbeat가 흐르도록
+  // 하여, 유휴 상태의 WebSocket이 끊겨 "실시간 연결에 문제가 있습니다"가 뜨는 것을 방지한다.
+  private static final long HEARTBEAT_INTERVAL_MS = 10_000L;
+
   private final JwtChannelInterceptor jwtChannelInterceptor;
   private final List<String> allowedOrigins;
+
+  // SimpleBroker heartbeat 전용 스케줄러. Spring Boot 기본 TaskScheduler(@Scheduled 공용)와
+  // 분리하기 위해 Bean으로 노출하지 않고 직접 생성/초기화한다.
+  private final ThreadPoolTaskScheduler heartbeatScheduler = createHeartbeatScheduler();
 
   public WebSocketConfig(
       JwtChannelInterceptor jwtChannelInterceptor,
@@ -27,7 +37,10 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
   @Override
   public void configureMessageBroker(MessageBrokerRegistry config) {
-    config.enableSimpleBroker("/topic", "/queue");
+    config
+        .enableSimpleBroker("/topic", "/queue")
+        .setHeartbeatValue(new long[] {HEARTBEAT_INTERVAL_MS, HEARTBEAT_INTERVAL_MS})
+        .setTaskScheduler(heartbeatScheduler);
     config.setApplicationDestinationPrefixes("/app");
     config.setUserDestinationPrefix("/user");
   }
@@ -42,5 +55,18 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
   @Override
   public void configureClientInboundChannel(ChannelRegistration registration) {
     registration.interceptors(jwtChannelInterceptor);
+  }
+
+  /** 테스트에서 heartbeat 스케줄러 초기화 여부를 확인하기 위한 접근자입니다. */
+  TaskScheduler heartbeatScheduler() {
+    return heartbeatScheduler;
+  }
+
+  private static ThreadPoolTaskScheduler createHeartbeatScheduler() {
+    ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+    scheduler.setPoolSize(1);
+    scheduler.setThreadNamePrefix("ws-heartbeat-");
+    scheduler.initialize();
+    return scheduler;
   }
 }

--- a/backend/src/test/java/com/init/corpus/application/RawFileUploadServiceTest.java
+++ b/backend/src/test/java/com/init/corpus/application/RawFileUploadServiceTest.java
@@ -181,7 +181,8 @@ class RawFileUploadServiceTest {
   void upload_zipWithMacOsMetadataDirectory_ignoresMetadataEntries() throws IOException {
     given(workspaceExistenceRepository.existsById(1L)).willReturn(true);
     given(workspaceMembershipRepository.existsByWorkspaceIdAndUserId(1L, 1L)).willReturn(true);
-    given(datasetRepository.existsByWorkspaceIdAndDatasetKey(1L, "macos-dir-zip")).willReturn(false);
+    given(datasetRepository.existsByWorkspaceIdAndDatasetKey(1L, "macos-dir-zip"))
+        .willReturn(false);
     given(storagePort.put(anyString(), any(), anyString())).willReturn("some-key");
     given(rawDatasetUploadService.upload(any()))
         .willReturn(
@@ -194,8 +195,7 @@ class RawFileUploadServiceTest {
 
     // macOS Archive Utility가 끼워 넣는 __MACOSX/._*.json AppleDouble 항목(NUL 바이트 포함).
     // 무시되지 않으면 .json 확장자 때문에 파싱 대상이 되어 RawFileParseException이 발생한다.
-    byte[] zipBytes =
-        zip("__MACOSX/._logs.json", "  mac-metadata", "logs.json", VALID_JSON_TEXT);
+    byte[] zipBytes = zip("__MACOSX/._logs.json", "  mac-metadata", "logs.json", VALID_JSON_TEXT);
     RawFileUploadCommand command =
         new RawFileUploadCommand(
             1L,
@@ -237,8 +237,7 @@ class RawFileUploadServiceTest {
                 51L, "some-key", "apple.zip", "application/zip", 100L, "1".repeat(64)));
 
     // __MACOSX 디렉터리 없이 최상위에 놓인 ._*.json AppleDouble 항목도 무시되어야 한다.
-    byte[] zipBytes =
-        zip("._logs.json", " mac-resource-fork", "logs.json", VALID_JSON_TEXT);
+    byte[] zipBytes = zip("._logs.json", " mac-resource-fork", "logs.json", VALID_JSON_TEXT);
     RawFileUploadCommand command =
         new RawFileUploadCommand(
             1L,

--- a/backend/src/test/java/com/init/corpus/application/RawFileUploadServiceTest.java
+++ b/backend/src/test/java/com/init/corpus/application/RawFileUploadServiceTest.java
@@ -177,6 +177,90 @@ class RawFileUploadServiceTest {
   }
 
   @Test
+  @DisplayName("should_ignore_macos_metadata_directory_entries_in_zip")
+  void upload_zipWithMacOsMetadataDirectory_ignoresMetadataEntries() throws IOException {
+    given(workspaceExistenceRepository.existsById(1L)).willReturn(true);
+    given(workspaceMembershipRepository.existsByWorkspaceIdAndUserId(1L, 1L)).willReturn(true);
+    given(datasetRepository.existsByWorkspaceIdAndDatasetKey(1L, "macos-dir-zip")).willReturn(false);
+    given(storagePort.put(anyString(), any(), anyString())).willReturn("some-key");
+    given(rawDatasetUploadService.upload(any()))
+        .willReturn(
+            new DatasetUploadResult(
+                50L, "macos-dir-zip", 1L, DatasetStatus.READY, PiiRedactionStatus.PENDING, 1));
+    given(rawFileRepository.save(any()))
+        .willReturn(
+            DatasetRawFile.create(
+                50L, "some-key", "macos.zip", "application/zip", 100L, "f".repeat(64)));
+
+    // macOS Archive Utility가 끼워 넣는 __MACOSX/._*.json AppleDouble 항목(NUL 바이트 포함).
+    // 무시되지 않으면 .json 확장자 때문에 파싱 대상이 되어 RawFileParseException이 발생한다.
+    byte[] zipBytes =
+        zip("__MACOSX/._logs.json", "  mac-metadata", "logs.json", VALID_JSON_TEXT);
+    RawFileUploadCommand command =
+        new RawFileUploadCommand(
+            1L,
+            "macos-dir-zip",
+            "맥 메타데이터 ZIP",
+            "PARSED_FLAT_ZIP",
+            1L,
+            zipBytes,
+            "macos.zip",
+            "application/zip",
+            (long) zipBytes.length);
+
+    RawFileUploadResult result = service.upload(command);
+
+    assertThat(result.datasetId()).isEqualTo(50L);
+    ArgumentCaptor<RawDatasetUploadCommand> commandCaptor =
+        ArgumentCaptor.forClass(RawDatasetUploadCommand.class);
+    verify(rawDatasetUploadService).upload(commandCaptor.capture());
+    List<RawConversationInput> conversations = commandCaptor.getValue().conversations();
+    assertThat(conversations).hasSize(1);
+    assertThat(conversations.get(0).sourceId()).isEqualTo("001");
+  }
+
+  @Test
+  @DisplayName("should_ignore_top_level_apple_double_entries_in_zip")
+  void upload_zipWithAppleDoubleEntry_ignoresMetadataEntries() throws IOException {
+    given(workspaceExistenceRepository.existsById(1L)).willReturn(true);
+    given(workspaceMembershipRepository.existsByWorkspaceIdAndUserId(1L, 1L)).willReturn(true);
+    given(datasetRepository.existsByWorkspaceIdAndDatasetKey(1L, "apple-double-zip"))
+        .willReturn(false);
+    given(storagePort.put(anyString(), any(), anyString())).willReturn("some-key");
+    given(rawDatasetUploadService.upload(any()))
+        .willReturn(
+            new DatasetUploadResult(
+                51L, "apple-double-zip", 1L, DatasetStatus.READY, PiiRedactionStatus.PENDING, 1));
+    given(rawFileRepository.save(any()))
+        .willReturn(
+            DatasetRawFile.create(
+                51L, "some-key", "apple.zip", "application/zip", 100L, "1".repeat(64)));
+
+    // __MACOSX 디렉터리 없이 최상위에 놓인 ._*.json AppleDouble 항목도 무시되어야 한다.
+    byte[] zipBytes =
+        zip("._logs.json", " mac-resource-fork", "logs.json", VALID_JSON_TEXT);
+    RawFileUploadCommand command =
+        new RawFileUploadCommand(
+            1L,
+            "apple-double-zip",
+            "AppleDouble ZIP",
+            "PARSED_FLAT_ZIP",
+            1L,
+            zipBytes,
+            "apple.zip",
+            "application/zip",
+            (long) zipBytes.length);
+
+    RawFileUploadResult result = service.upload(command);
+
+    assertThat(result.datasetId()).isEqualTo(51L);
+    ArgumentCaptor<RawDatasetUploadCommand> commandCaptor =
+        ArgumentCaptor.forClass(RawDatasetUploadCommand.class);
+    verify(rawDatasetUploadService).upload(commandCaptor.capture());
+    assertThat(commandCaptor.getValue().conversations()).hasSize(1);
+  }
+
+  @Test
   @DisplayName("should_parse_json_object_with_data_array_inside_zip")
   void upload_zipEntryWithJsonObjectDataArray_parsesConversations() throws IOException {
     given(workspaceExistenceRepository.existsById(1L)).willReturn(true);

--- a/backend/src/test/java/com/init/workflowruntime/config/WebSocketConfigTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/config/WebSocketConfigTest.java
@@ -1,0 +1,35 @@
+package com.init.workflowruntime.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.mock;
+
+import com.init.workflowruntime.interceptor.JwtChannelInterceptor;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.messaging.SubscribableChannel;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.messaging.support.ExecutorSubscribableChannel;
+
+@DisplayName("WebSocketConfig")
+class WebSocketConfigTest {
+
+  private final WebSocketConfig config =
+      new WebSocketConfig(mock(JwtChannelInterceptor.class), List.of("https://app.example.com"));
+
+  @Test
+  @DisplayName("heartbeat 전용 스케줄러가 초기화되어 제공된다")
+  void should_initializeHeartbeatScheduler() {
+    assertThat(config.heartbeatScheduler()).isNotNull();
+  }
+
+  @Test
+  @DisplayName("configureMessageBroker는 heartbeat가 설정된 simple broker를 예외 없이 구성한다")
+  void should_configureSimpleBrokerWithHeartbeat() {
+    SubscribableChannel channel = new ExecutorSubscribableChannel();
+    MessageBrokerRegistry registry = new MessageBrokerRegistry(channel, channel);
+
+    assertThatCode(() -> config.configureMessageBroker(registry)).doesNotThrowAnyException();
+  }
+}

--- a/infra/terraform/iam.tf
+++ b/infra/terraform/iam.tf
@@ -144,14 +144,24 @@ data "aws_iam_policy_document" "ecs_backend_task" {
   }
 
   statement {
+    # Spring AI BedrockProxyChatModel은 Converse / ConverseStream API를 호출하는데, 이 API는
+    # IAM action bedrock:InvokeModel / bedrock:InvokeModelWithResponseStream 으로 인가된다
+    # (bedrock:Converse 라는 IAM action은 존재하지 않아 항상 AccessDenied → "응답을 생성하지
+    # 못했습니다").
+    # 또한 global cross-Region inference profile(global.anthropic.claude-sonnet-4-6)은
+    # inference-profile + in-region foundation-model + region 미지정(global) foundation-model
+    # 세 리소스 권한이 필요하다(AWS 문서: global cross-Region inference IAM policy).
+    # 런타임 chat region이 AI_CHAT_BEDROCK_REGION 부재 시 embedding region으로 폴백되는
+    # 드리프트가 있어, 호출 출처 region에 관계없이 인가되도록 region을 와일드카드로 둔다.
     sid = "InvokeBedrockChatModel"
     actions = [
-      "bedrock:Converse",
-      "bedrock:ConverseStream"
+      "bedrock:InvokeModel",
+      "bedrock:InvokeModelWithResponseStream"
     ]
     resources = [
-      "arn:aws:bedrock:${var.ai_chat_bedrock_region}::foundation-model/${var.ai_chat_bedrock_model}",
-      "arn:aws:bedrock:${var.ai_chat_bedrock_region}:${data.aws_caller_identity.current.account_id}:inference-profile/${local.ai_chat_bedrock_runtime_model}"
+      "arn:aws:bedrock:*::foundation-model/${var.ai_chat_bedrock_model}",
+      "arn:aws:bedrock:::foundation-model/${var.ai_chat_bedrock_model}",
+      "arn:aws:bedrock:*:${data.aws_caller_identity.current.account_id}:inference-profile/${local.ai_chat_bedrock_runtime_model}"
     ]
   }
 }

--- a/infra/terraform/iam.tf
+++ b/infra/terraform/iam.tf
@@ -135,11 +135,17 @@ data "aws_iam_policy_document" "ecs_backend_task" {
   }
 
   statement {
+    # embedding(cohere.embed-v4:0)도 global cross-Region inference profile
+    # (global.cohere.embed-v4:0)을 사용하므로 in-region + global(region 미지정)
+    # foundation-model + inference-profile 권한이 모두 필요하다. 런타임 embedding
+    # region(AI_EMBEDDING_BEDROCK_REGION)이 정책 region과 어긋나는 드리프트에 대응해 region을
+    # 와일드카드로 둔다(InvokeBedrockChatModel과 동일 패턴).
     sid     = "InvokeBedrockEmbeddingModel"
     actions = ["bedrock:InvokeModel"]
     resources = [
-      "arn:aws:bedrock:${var.ai_embedding_bedrock_region}::foundation-model/${var.ai_embedding_model}",
-      "arn:aws:bedrock:${var.ai_embedding_bedrock_region}:${data.aws_caller_identity.current.account_id}:inference-profile/${local.ai_embedding_bedrock_runtime_model}"
+      "arn:aws:bedrock:*::foundation-model/${var.ai_embedding_model}",
+      "arn:aws:bedrock:::foundation-model/${var.ai_embedding_model}",
+      "arn:aws:bedrock:*:${data.aws_caller_identity.current.account_id}:inference-profile/${local.ai_embedding_bedrock_runtime_model}"
     ]
   }
 


### PR DESCRIPTION
# PR Body

세션 중 발견된 미머지 수정 3건을 한 브랜치로 통합한다. (배포 안정화 #494, 익명 데모
연결 #493은 이미 main에 머지되어 본 PR에 포함되지 않는다.)

## 1) 챗봇이 답변하지 못함 — Bedrock chat 호출 권한 누락
배포 backend 로그(직접 확인):
```
AccessDeniedException: ostone-prod-ecs-backend-task-role is not authorized to perform:
bedrock:InvokeModel on resource:
arn:aws:bedrock:ap-northeast-1:...:inference-profile/global.anthropic.claude-sonnet-4-6 (403)
```
- 봇 응답 생성은 Spring AI `BedrockProxyChatModel`(Converse API)을 호출한다. Converse/
  ConverseStream API는 IAM action **`bedrock:InvokeModel`/`InvokeModelWithResponseStream`**
  로 인가되는데, task role 정책이 **존재하지 않는 action `bedrock:Converse`/`ConverseStream`**
  을 부여하고 있어 403 → FE "응답을 생성하지 못했습니다".
- `global.anthropic.claude-sonnet-4-6`는 **global cross-Region inference profile**이라
  inference-profile + in-region foundation-model + **global(region 미지정) foundation-model**
  권한이 모두 필요한데 global 리소스가 누락. 런타임 chat region이 embedding region으로
  폴백되는 드리프트도 있어 정책 region과 불일치.
- 수정(`iam.tf` InvokeBedrockChatModel): action → InvokeModel/InvokeModelWithResponseStream,
  global foundation-model 추가, region 와일드카드.

## 2) 기다리면 "실시간 연결에 문제가 있습니다" — 유휴 WebSocket 끊김
- `WebSocketConfig` SimpleBroker에 TaskScheduler가 없어 STOMP heartbeat가 `0,0`(비활성).
  ALB `idle_timeout=60s`(live 확인)에 유휴 WebSocket이 끊겨 배너 표시.
- 수정(`WebSocketConfig`): 전용 ThreadPoolTaskScheduler + `setHeartbeatValue(10s,10s)`로
  heartbeat 활성화(@Scheduled 공용 스케줄러와 분리).

## 3) Bedrock embedding 권한 — (1)과 동일 root cause
- embedding도 global inference profile(`global.cohere.embed-v4:0`) 사용 + region 드리프트.
  워크플로 매칭이 embedding을 호출하면 동일 403이 날 수 있음.
- 수정(`iam.tf` InvokeBedrockEmbeddingModel): global foundation-model 추가 + region 와일드카드.

## 4) macOS ZIP 업로드 파싱 실패
```
__MACOSX/._액티벤처_1.json JSON 파일을 파싱할 수 없습니다:
Illegal character ((CTRL-CHAR, code 0)) ...
```
- macOS가 ZIP에 넣는 AppleDouble(`__MACOSX/._*`)·`.DS_Store`가 `.json` 확장자 때문에 파싱
  대상이 되고, 내용은 NUL 바이트 바이너리라 실패 → 업로드 전체 중단.
- 수정(`RawFileUploadService`): `isMacOsMetadataEntry`로 `__MACOSX` 경로·`._` 접두·
  `.DS_Store` 항목을 파싱 전에 skip. ZIP 생성/해제 OS와 무관하게 동작(platform-free).

## 검증 (apply/deploy/push 없음)
- `tofu validate` Success / `fmt` OK (통합 브랜치 기준).
- `aws iam simulate-custom-policy`: 수정 chat/embedding 정책이 403 났던 ap-northeast-1
  inference-profile/foundation-model에 InvokeModel allowed.
- `aws bedrock-runtime converse`(ap-northeast-1, global.anthropic.claude-sonnet-4-6): 정상
  응답 → 모델 가용 + 계정 model access 활성.
- backend 테스트: `WebSocketConfigTest`, `RawFileUploadServiceTest` 추가, 두 변경 공존 통과.
  new-code coverage 100% (WebSocketConfig 11/11, RawFileUploadService 8/8).
- 로컬 런타임: CONNECTED 프레임 heart-beat `0,0` → `10000,10000` 협상 확인.

## 적용 경로
- 머지 시 prod-deploy의 terraform job이 IAM(chat/embedding) 적용, backend job이 heartbeat +
  ZIP 수정 이미지 배포 → 봇 응답 + 연결 안정 + macOS ZIP 업로드 정상화.

## 후속(선택)
- `AI_CHAT_BEDROCK_REGION` env가 live task def에 누락되어 embedding region으로 폴백되는
  드리프트(CI가 image-swap만 해 terraform env 변경 미반영). task def 재정렬은 별도 작업.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WebSocket 연결 안정성 향상을 위한 양방향 하트비트 설정 추가

* **Bug Fixes**
  * ZIP 업로드 파싱에서 macOS 메타데이터 엔트리 필터링 추가로 파싱 오류 방지

* **Tests**
  * WebSocket 구성 및 하트비트 스케줄러 동작 검증을 위한 테스트 추가

* **Chores**
  * Bedrock AI 호출 권한 관련 IAM 정책 업데이트 (호출 권한·리소스 범위 조정)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->