### PR TITLE
chore(infra): 상담 로그 업로드 'Upstream service error' 수정 (prod ingestion DAG id)

### DIFF
--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -102,7 +102,11 @@ airflow:
     domain-pack-generation:
       dag-id: ${AIRFLOW_DOMAIN_PACK_GENERATION_DAG_ID:domain_pack_generation}
     ingestion:
-      dag-id: ${AIRFLOW_INGESTION_DAG_ID:ingestion}
+      # 상담 로그 업로드는 별도 ingestion DAG가 아니라 domain_pack_generation DAG(8개 stage 중
+      # ingestion이 1번째)를 트리거한다. ingestion이라는 이름의 DAG는 존재하지 않으며, 잘못된 기본값은
+      # Airflow trigger 404(AIRFLOW_TRIGGER_FAILED → "Upstream service error")를 유발한다.
+      # local(application.yml) 기본값과 동일하게 맞춘다.
+      dag-id: ${AIRFLOW_INGESTION_DAG_ID:domain_pack_generation}
   webhook:
     secret: ${AIRFLOW_WEBHOOK_SECRET}
 


### PR DESCRIPTION
## 증상
상담 로그 수집 화면에서 ZIP(아카이브.zip)을 업로드하면 **"Upstream service error"** 토스트가 뜨고 처리가 실패한다.

## 근본 원인 (prod CloudWatch 확정)
업로드·S3 저장·파싱·dataset/pipeline_job 생성까지는 성공하고, **마지막 Airflow ingestion DAG 트리거에서 404**가 난다.

- `backend`: `Airflow Ingestion DAG run creation failed: dagId=ingestion, status=404 NOT_FOUND` → `AirflowTriggerFailedException`(BadGateway) → `GlobalExceptionHandler`가 "Upstream service error"(502) 반환.
- `airflow`: `POST /api/v2/dags/ingestion/dagRuns → 404`.

`ingestion` 이라는 DAG는 ml 코드에 **존재한 적이 없다**(git 이력 확인). 실제 DAG는 `domain_pack_generation` 하나뿐이며 8개 stage 중 ingestion이 1번째다. 이 DAG는 트리거가 보내는 conf(`workspace_id`/`dataset_id`/`pipeline_job_id`/`object_key`)를 그대로 소비한다.

설정 불일치가 원인이다:
| | ingestion dag-id 기본값 |
|---|---|
| `application.yml` (local) | `domain_pack_generation` ✅ |
| `application-prod.yml` | `ingestion` ❌ |

## 수정
`application-prod.yml` 의 ingestion `dag-id` 기본값을 local과 동일하게 `domain_pack_generation` 으로 교정.

## 확인
- prod ECS / terraform 에 `AIRFLOW_INGESTION_DAG_ID` override **없음** → prod는 이 yml 기본값을 사용하므로 본 변경으로 트리거가 실존 DAG를 가리킨다.
- YAML 유효성 확인. config-only 변경(Java 변경 없음).
- 배포 후 업로드 시 Airflow `domain_pack_generation` DAG run 이 생성되어 502가 사라진다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 상담 로그 업로드 프로세스의 Airflow 설정값을 수정하여 올바른 워크플로우가 실행되도록 개선했습니다.
  * 잘못된 기본값으로 인한 404 오류 발생을 방지했습니다.
  * 설정 관련 설명을 추가하여 운영 시 혼동을 줄였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->