### PR TITLE
fix(infra): Airflow task 로그 조회와 실행 API 통신 안정화

### DIFF
--- a/infra/terraform/ecs-airflow.tf
+++ b/infra/terraform/ecs-airflow.tf
@@ -62,6 +62,10 @@ locals {
       value = "False"
     },
     {
+      name  = "AIRFLOW__CORE__PARALLELISM"
+      value = "4"
+    },
+    {
       name  = "AIRFLOW__CORE__SIMPLE_AUTH_MANAGER_USERS"
       value = "admin:admin,viewer:viewer"
     },
@@ -78,8 +82,40 @@ locals {
       value = "/opt/airflow/logs"
     },
     {
+      name  = "AIRFLOW__LOGGING__REMOTE_LOGGING"
+      value = "True"
+    },
+    {
+      name  = "AIRFLOW__LOGGING__DELETE_LOCAL_LOGS"
+      value = "True"
+    },
+    {
+      name  = "AIRFLOW__LOGGING__REMOTE_BASE_LOG_FOLDER"
+      value = "s3://${aws_s3_bucket.buckets["airflow_logs"].bucket}/task-logs"
+    },
+    {
+      name  = "AIRFLOW__LOGGING__REMOTE_LOG_CONN_ID"
+      value = "aws_default"
+    },
+    {
+      name  = "AIRFLOW__LOGGING__ENCRYPT_S3_LOGS"
+      value = "False"
+    },
+    {
+      name  = "AIRFLOW_CONN_AWS_DEFAULT"
+      value = "aws://@/?region_name=${var.aws_region}"
+    },
+    {
       name  = "PIPELINE_STAGE_EXECUTION_MODE"
       value = "ecs"
+    },
+    {
+      name  = "PIPELINE_DAG_MAX_ACTIVE_RUNS"
+      value = "4"
+    },
+    {
+      name  = "PIPELINE_DAG_MAX_ACTIVE_TASKS"
+      value = "1"
     },
     {
       name  = "PIPELINE_BACKEND_BASE_URL"
@@ -455,6 +491,10 @@ resource "aws_ecs_service" "airflow_apiserver" {
 
   depends_on = [
     aws_lb_listener_rule.airflow,
+    aws_security_group_rule.ecs_airflow_egress_self_execution_api,
+    aws_security_group_rule.ecs_airflow_egress_self_worker_logs,
+    aws_security_group_rule.ecs_airflow_ingress_self_execution_api,
+    aws_security_group_rule.ecs_airflow_ingress_self_worker_logs,
     terraform_data.airflow_init
   ]
 
@@ -477,7 +517,13 @@ resource "aws_ecs_service" "airflow_scheduler" {
     assign_public_ip = false
   }
 
-  depends_on = [terraform_data.airflow_init]
+  depends_on = [
+    aws_security_group_rule.ecs_airflow_egress_self_execution_api,
+    aws_security_group_rule.ecs_airflow_egress_self_worker_logs,
+    aws_security_group_rule.ecs_airflow_ingress_self_execution_api,
+    aws_security_group_rule.ecs_airflow_ingress_self_worker_logs,
+    terraform_data.airflow_init
+  ]
 
   lifecycle {
     ignore_changes = [task_definition]
@@ -498,7 +544,13 @@ resource "aws_ecs_service" "airflow_dag_processor" {
     assign_public_ip = false
   }
 
-  depends_on = [terraform_data.airflow_init]
+  depends_on = [
+    aws_security_group_rule.ecs_airflow_egress_self_execution_api,
+    aws_security_group_rule.ecs_airflow_egress_self_worker_logs,
+    aws_security_group_rule.ecs_airflow_ingress_self_execution_api,
+    aws_security_group_rule.ecs_airflow_ingress_self_worker_logs,
+    terraform_data.airflow_init
+  ]
 
   lifecycle {
     ignore_changes = [task_definition]

--- a/infra/terraform/security-groups.tf
+++ b/infra/terraform/security-groups.tf
@@ -128,6 +128,26 @@ resource "aws_security_group_rule" "ecs_airflow_ingress_backend" {
   protocol                 = "tcp"
 }
 
+resource "aws_security_group_rule" "ecs_airflow_ingress_self_execution_api" {
+  type                     = "ingress"
+  security_group_id        = aws_security_group.ecs_airflow.id
+  source_security_group_id = aws_security_group.ecs_airflow.id
+  description              = "Airflow task execution API traffic between Airflow ECS services."
+  from_port                = 8080
+  to_port                  = 8080
+  protocol                 = "tcp"
+}
+
+resource "aws_security_group_rule" "ecs_airflow_ingress_self_worker_logs" {
+  type                     = "ingress"
+  security_group_id        = aws_security_group.ecs_airflow.id
+  source_security_group_id = aws_security_group.ecs_airflow.id
+  description              = "Airflow served task log traffic between Airflow ECS services."
+  from_port                = 8793
+  to_port                  = 8793
+  protocol                 = "tcp"
+}
+
 resource "aws_security_group_rule" "ecs_airflow_egress_rds" {
   type                     = "egress"
   security_group_id        = aws_security_group.ecs_airflow.id
@@ -136,6 +156,26 @@ resource "aws_security_group_rule" "ecs_airflow_egress_rds" {
   to_port                  = 5432
   protocol                 = "tcp"
   source_security_group_id = aws_security_group.rds.id
+}
+
+resource "aws_security_group_rule" "ecs_airflow_egress_self_execution_api" {
+  type                     = "egress"
+  security_group_id        = aws_security_group.ecs_airflow.id
+  source_security_group_id = aws_security_group.ecs_airflow.id
+  description              = "Allow Airflow ECS services to call the execution API."
+  from_port                = 8080
+  to_port                  = 8080
+  protocol                 = "tcp"
+}
+
+resource "aws_security_group_rule" "ecs_airflow_egress_self_worker_logs" {
+  type                     = "egress"
+  security_group_id        = aws_security_group.ecs_airflow.id
+  source_security_group_id = aws_security_group.ecs_airflow.id
+  description              = "Allow Airflow ECS services to fetch served task logs."
+  from_port                = 8793
+  to_port                  = 8793
+  protocol                 = "tcp"
 }
 
 resource "aws_security_group_rule" "ecs_airflow_egress_https" {

--- a/ml/airflow/requirements.txt
+++ b/ml/airflow/requirements.txt
@@ -1,4 +1,5 @@
 apache-airflow==3.2.0
+apache-airflow-providers-amazon==9.29.0
 --extra-index-url https://download.pytorch.org/whl/cpu
 asyncpg>=0.30,<1.0
 boto3>=1.35


### PR DESCRIPTION
## 증상

Airflow UI에서 `domain_pack_generation.ingestion` task log 조회 시 `Could not read served logs: Invalid URL 'http://:8793/...': No host supplied` 메시지가 발생했다.

## 근본 원인 (prod CloudWatch 확인)

- LocalExecutor task가 시작 직후 execution API로 `PATCH /task-instances/{id}/run`을 호출하는 과정에서 `httpx.ConnectTimeout`이 발생했다.
- Airflow ECS security group은 ALB/backend에서 들어오는 8080만 허용하고, Airflow scheduler/apiserver 간 self 8080 통신을 허용하지 않았다.
- task start 기록이 남지 않아 task hostname이 비어 있었고, 이후 served log URL이 `http://:8793/...`처럼 host 없이 생성됐다.
- 추가로 prod scheduler는 기본 LocalExecutor parallelism 32를 사용해 1 vCPU/2GB Fargate task에서 불필요하게 많은 worker process를 띄우고 있었다.

## 변경 사항

- Airflow ECS service 간 execution API(8080)와 served task log(8793) self ingress/egress를 허용한다.
- Airflow task log를 S3 `airflow_logs` bucket의 `task-logs` prefix로 remote logging하도록 설정한다.
- S3 task log handler를 사용할 수 있도록 Amazon provider를 Airflow image requirements에 포함한다.
- prod Airflow scheduler parallelism과 DAG active run/task 값을 명시해 Fargate 용량에 맞춘다.

## 검증

- `terraform -chdir=infra/terraform fmt -check`
- `terraform -chdir=infra/terraform init -backend=false`
- `terraform -chdir=infra/terraform validate`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 파이프라인 동시성(전체/태스크) 설정이 추가되어 처리 성능을 조정할 수 있습니다.
  * 원격 로그 저장 및 연동이 활성화되었습니다.

* **보안**
  * 서비스 간 내부 통신을 위해 보안 규칙이 강화되어 동일 서비스 간 포트 통신이 허용됩니다.

* **의존성**
  * Airflow의 AWS 제공자 패키지가 명시된 버전으로 추가/고정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->