### PR TITLE
feat(payment): 토스페이먼츠 v2 자동결제 기반 워크스페이스 구독 백엔드 (#488)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -113,5 +113,11 @@ PIPELINE_STABILITY_MAX_INPUTS=5000
 # model is downloaded into the container runtime cache.
 # AIRFLOW_MODEL_CACHE_PATH=/mnt/ostone-model-cache/huggingface
 
+# 토스페이먼츠 v2 자동결제 (워크스페이스 구독). secret 값은 Toss 콘솔에서 발급.
+TOSS_API_BASE_URL=https://api.tosspayments.com
+TOSS_BILLING_KEY_ENCRYPTION_KEY=<your-toss-billing-key-encryption-key>
+TOSS_SECRET_KEY=<your-toss-secret-key>
+TOSS_WEBHOOK_SECRET=change-me-toss-webhook-secret
+
 # production 배포용 값은 GitHub Actions prod environment와 AWS Secrets Manager에서 관리한다.
 # 상세 변수 목록은 .agent/docs/deployment.md와 docs/ops/runbook.md를 참조한다.

--- a/.handoff/488/artifact-registry-488.json
+++ b/.handoff/488/artifact-registry-488.json
@@ -1,0 +1,232 @@
+{
+  "canonical": "488",
+  "artifacts": [
+    {
+      "stage": "recon",
+      "kind": "recon-report",
+      "path": ".handoff/488/recon-report-488.md",
+      "scope": "handoff",
+      "createdAt": "2026-06-02T00:00:00+09:00",
+      "updatedAt": "2026-06-02T00:00:00+09:00",
+      "producer": "specRecon",
+      "requiredBy": ["specArchitect", "codeBuilder", "codeAuditor", "codeRemediator", "prAuthor"],
+      "version": 1,
+      "triggers": ["initial"]
+    },
+    {
+      "stage": "decision",
+      "kind": "spec",
+      "path": ".agent/specs/488.md",
+      "scope": "external-spec",
+      "createdAt": "2026-06-02T11:54:23+09:00",
+      "updatedAt": "2026-06-02T12:13:30+09:00",
+      "producer": "specArchitect",
+      "requiredBy": ["specGatekeeper", "codeBuilder", "codeAuditor", "prAuthor"],
+      "notes": "BE spec. U-001~U-004 사용자 결정 반영 완료(Spring @Scheduled / pgcrypto / 웹훅 시크릿 헤더+재조회 / 3일 재시도). specGatekeeper CONSISTENT 후 CSC-001(SC-B4) 반영: TossApiProperties nested record로 수정(YAML toss.api.*/toss.webhook.* 바인딩 정합). LOW 2건(SC-B7 rollback=관행 일치, SC-B8 403 code=codeBuilder 확인)은 spec 변경 불요. CGV: spec-conflict 0."
+    },
+    {
+      "stage": "decision",
+      "kind": "uncertainty-register",
+      "path": ".handoff/488/uncertainty-register-488.md",
+      "scope": "handoff",
+      "createdAt": "2026-06-02T11:54:23+09:00",
+      "updatedAt": "2026-06-02T12:01:32+09:00",
+      "producer": "specArchitect",
+      "requiredBy": ["codeBuilder", "codeAuditor", "prAuthor"],
+      "notes": "16 항목. Q-001~Q-004 답변 완료 → U-001~U-004 Confirmed. Q-002는 Recommended Default(A) 대신 사용자가 B(pgcrypto) 선택. U-015 recon 재호출 권고(Strong Recommendation)."
+    },
+    {
+      "stage": "check-spec-consistency",
+      "kind": "spec-consistency-report",
+      "path": ".handoff/488/spec-consistency-report-488.json",
+      "scope": "handoff",
+      "createdAt": "2026-06-02T00:00:00+09:00",
+      "updatedAt": "2026-06-02T00:00:00+09:00",
+      "producer": "5stone-cross-specGatekeeper",
+      "requiredBy": ["codeBuilder", "codeAuditor", "prAuthor"],
+      "notes": "BE mode. verdict=CONSISTENT. 1 MEDIUM finding (SC-B4: TossApiProperties config structure mismatch), 2 LOW findings."
+    },
+    {
+      "stage": "build",
+      "kind": "uncertainty-execution-log",
+      "path": ".handoff/488/uncertainty-execution-log-488.md",
+      "scope": "handoff",
+      "createdAt": "2026-06-03T00:00:00+09:00",
+      "updatedAt": "2026-06-03T00:00:00+09:00",
+      "producer": "5stone-any-codeBuilder",
+      "requiredBy": ["codeAuditor", "prAuthor"],
+      "notes": "U-001~U-016 1:1 execution log. U-001~U-004 Confirmed Implemented; U-005~U-013/U-016 Assumption adopted from Decision; U-014 fixture 경로 확정; U-015 pipelinejob 멤버십 선례 미러로 구현(recon 재호출 없이 코드 근거)."
+    },
+    {
+      "stage": "build",
+      "kind": "audit-handoff",
+      "path": ".handoff/488/audit-handoff-488.md",
+      "scope": "handoff",
+      "createdAt": "2026-06-03T00:00:00+09:00",
+      "updatedAt": "2026-06-03T00:00:00+09:00",
+      "producer": "5stone-any-codeBuilder",
+      "requiredBy": ["codeAuditor"],
+      "notes": "신규 com.init.payment BC 풀스코프. Spec/Uncertainty-Critical Checks, Potential Weak Spots, Evidence Pointers. source of truth 아님."
+    },
+    {
+      "stage": "sonar-pseudo-check",
+      "kind": "sonar-pseudo-check-report",
+      "path": ".handoff/488/sonar-pseudo-check-report-488.json",
+      "scope": "handoff",
+      "createdAt": "2026-06-03T01:09:40+00:00",
+      "updatedAt": "2026-06-03T04:30:00+00:00",
+      "producer": "5stone-cross-sonarSentinel",
+      "requiredBy": ["codeAuditor", "prAuthor"],
+      "verdict": "FAIL",
+      "headSha": "bf04622800682f9f4495ba5bb3c87aa662fe438a",
+      "notes": "Re-run (HEAD bf046228). Phase 2b Cloud PR #514: new_reliability_rating=C (ERROR) — 4 MAJOR BUG (java:S2259, TransactionTemplate.execute() @Nullable NPE in inTx() wrapper: RecurringBillingService.java:70/73/76, :252). new_coverage=88.4% OK, new_security=A OK. Phase 2a local: backend 83.0% PASS, frontend 86.36% PASS. buildFailure: false."
+    },
+    {
+      "stage": "audit-preprocess",
+      "kind": "audit-input",
+      "path": ".handoff/488/audit-input-488.json",
+      "scope": "handoff",
+      "createdAt": "2026-06-03T10:17:16+09:00",
+      "updatedAt": "2026-06-03T10:17:16+09:00",
+      "producer": "5stone-any-codeAuditor",
+      "requiredBy": ["codeAuditor"],
+      "verdict": "BLOCKED",
+      "headSha": "222dacae5df6eb382471b24dd8eef45e5843dfea",
+      "notes": "preprocess 자동 생성. BLOCKED: newCoverage < 80% blocking. 6 missing non-required artifacts."
+    },
+    {
+      "stage": "audit",
+      "kind": "audit-report",
+      "path": ".handoff/488/audit-report-488-2026-06-03-1023.md",
+      "scope": "handoff",
+      "createdAt": "2026-06-03T10:23:00+09:00",
+      "updatedAt": "2026-06-03T10:23:00+09:00",
+      "producer": "5stone-any-codeAuditor",
+      "requiredBy": ["codeRemediator", "prAuthor"],
+      "verdict": "FAIL",
+      "headSha": "222dacae5df6eb382471b24dd8eef45e5843dfea",
+      "notes": "Critical 3건 (V-001 Coverage, V-002 Sonar MAJOR CODE_SMELL, V-003 DDD Layer). Warning 2건. FAIL.",
+      "fixRuns": [
+        {
+          "iteration": 1,
+          "fixedAt": "2026-06-03T10:42:00+09:00",
+          "headShaBefore": "222dacae5df6eb382471b24dd8eef45e5843dfea",
+          "headShaAfter": "39b4d5c186e611ae34afc4fc6447f9499ae8d35b",
+          "fixedViolationIds": ["V-001", "V-002", "V-003", "V-004", "V-005"],
+          "blockedViolationIds": [],
+          "skippedViolationIds": [],
+          "deferredViolationIds": [],
+          "totalCommits": 1
+        }
+      ]
+    },
+    {
+      "stage": "pr-author",
+      "kind": "pr-notes",
+      "path": ".handoff/488/pr-notes-488.md",
+      "scope": "handoff",
+      "createdAt": "2026-06-03T11:00:00+09:00",
+      "updatedAt": "2026-06-03T11:00:00+09:00",
+      "producer": "5stone-any-prAuthor",
+      "requiredBy": [],
+      "notes": "PR notes for review. Audit FAIL (initial) + codeRemediator run #1 all fixed. Post-fix re-audit not yet generated."
+    },
+    {
+      "stage": "audit-preprocess",
+      "kind": "audit-input",
+      "path": ".handoff/488/audit-input-488.json",
+      "scope": "handoff",
+      "createdAt": "2026-06-03T11:28:16+09:00",
+      "updatedAt": "2026-06-03T11:28:16+09:00",
+      "producer": "5stone-any-codeAuditor",
+      "requiredBy": ["codeAuditor"],
+      "verdict": "BLOCKED",
+      "headSha": "1fde5edaacea01bb630d4ff15f30b0d2eee2842d",
+      "notes": "preprocess 재실행 (stale 재생성). BLOCKED: sonar-pseudo-check-report STALE 기반. 6 missing non-required artifacts."
+    },
+    {
+      "stage": "audit-preprocess",
+      "kind": "audit-input",
+      "path": ".handoff/488/audit-input-488.json",
+      "scope": "handoff",
+      "createdAt": "2026-06-03T13:34:05+09:00",
+      "updatedAt": "2026-06-03T13:34:05+09:00",
+      "producer": "5stone-any-codeAuditor",
+      "requiredBy": ["codeAuditor"],
+      "verdict": "BLOCKED",
+      "headSha": "bf04622800682f9f4495ba5bb3c87aa662fe438a",
+      "notes": "preprocess 재실행 (PR Run 2 전처리). BLOCKED: sonar FAIL (4 MAJOR BUG java:S2259). 6 missing non-required artifacts."
+    },
+    {
+      "stage": "audit",
+      "kind": "external-review",
+      "path": ".handoff/488/external-review-488.md",
+      "scope": "handoff",
+      "createdAt": "2026-06-03T11:28:00+09:00",
+      "updatedAt": "2026-06-03T13:33:00+09:00",
+      "producer": "codeAuditor",
+      "ingestionRunCount": 2,
+      "prNumbers": [514],
+      "requiredBy": ["codeRemediator", "prAuthor"]
+    },
+    {
+      "stage": "audit",
+      "kind": "audit-report",
+      "path": ".handoff/488/audit-report-488-2026-06-03-1130.md",
+      "scope": "handoff",
+      "createdAt": "2026-06-03T11:30:00+09:00",
+      "updatedAt": "2026-06-03T11:30:00+09:00",
+      "producer": "5stone-any-codeAuditor",
+      "requiredBy": ["codeRemediator", "prAuthor"],
+      "verdict": "FAIL",
+      "headSha": "1fde5edaacea01bb630d4ff15f30b0d2eee2842d",
+      "notes": "PR Review Ingestion mode (PR #514, 21 EC). Critical 2건: V-001 Coverage 76%<80% (SonarQube CI 실측, 미해결) + V-NEW-001 IDOR (EC-002). Warning 16건. FAIL.",
+      "fixRuns": [
+        {
+          "iteration": 1,
+          "fixedAt": "2026-06-03T12:14:00+09:00",
+          "headShaBefore": "1fde5edaacea01bb630d4ff15f30b0d2eee2842d",
+          "headShaAfter": "321bebe4d397f6c52b7f7aab3a91c53026e7ad0b",
+          "fixedViolationIds": [
+            "V-001", "V-NEW-001", "V-NEW-002", "V-NEW-003", "V-NEW-004", "V-NEW-005",
+            "V-NEW-006", "V-NEW-007", "V-NEW-008", "V-NEW-009", "V-NEW-010", "V-NEW-011",
+            "V-NEW-012", "V-NEW-013", "V-NEW-014",
+            "V-EC-001", "V-EC-002", "V-EC-003", "V-EC-004", "V-EC-005"
+          ],
+          "blockedViolationIds": [],
+          "skippedViolationIds": [],
+          "deferredViolationIds": [],
+          "totalCommits": 1
+        }
+      ]
+    },
+    {
+      "stage": "audit",
+      "kind": "audit-report",
+      "path": ".handoff/488/audit-report-488-2026-06-03-1400.md",
+      "scope": "handoff",
+      "createdAt": "2026-06-03T14:00:00+09:00",
+      "updatedAt": "2026-06-03T14:00:00+09:00",
+      "producer": "5stone-any-codeAuditor",
+      "requiredBy": ["codeRemediator", "prAuthor"],
+      "verdict": "FAIL",
+      "headSha": "bf04622800682f9f4495ba5bb3c87aa662fe438a",
+      "notes": "PR Review Ingestion mode (PR #514 Run 2, EC-022~EC-055, 34 new EC). Critical 5건: V-001~V-004 inTx @Nullable NPE (java:S2259) + V-005 Quality Gate FAIL. Warning 7건 (V-EC-004 carryover + V-006~V-011). Info 1건. 이전 audit 대비 해소: coverage 88.4% PASS, V-EC-001/002/003/005, V-NEW-001~014 전원 해소. FAIL.",
+      "fixRuns": [
+        {
+          "iteration": 1,
+          "fixedAt": "2026-06-03T14:30:00+09:00",
+          "headShaBefore": "bf04622800682f9f4495ba5bb3c87aa662fe438a",
+          "headShaAfter": "f2175a48",
+          "fixedViolationIds": ["V-001", "V-002", "V-003", "V-004", "V-005", "V-006", "V-007", "V-008", "V-009", "V-010", "V-011", "V-012", "V-EC-004"],
+          "blockedViolationIds": [],
+          "skippedViolationIds": [],
+          "deferredViolationIds": [],
+          "totalCommits": 1
+        }
+      ]
+    }
+  ],
+  "generatedAt": "2026-06-03T14:30:00+09:00",
+  "verdict": "FAIL"
+}

--- a/.handoff/488/audit-report-488-2026-06-03-1400.md
+++ b/.handoff/488/audit-report-488-2026-06-03-1400.md
@@ -1,0 +1,612 @@
+# Audit Report — 488 (PR Review Ingestion, Run 2)
+
+**Mode**: PR Review Ingestion (--pr 514)
+**Date**: 2026-06-03
+**Branch**: feature/488-tosspayments-v2-subscription
+**Scope**: 토스페이먼츠 v2 자동결제 기반 워크스페이스 구독 백엔드 (backend/payment BC)
+**Diff Base**: main...HEAD + staged + unstaged
+**Rules Applied**: java.md, error-handling.md, testing.md, module-creation.md, principles.md, code-review.md, git.md
+**PR Number**: 514
+**Result**: **FAIL**
+
+---
+
+## Referenced Artifacts
+
+- audit-input:             .handoff/488/audit-input-488.json (refreshed, sha=bf046228, verdict=BLOCKED)
+- verify-fe-summary:       N/A
+- recon report:            .handoff/488/recon-report-488.md (version=null)
+- audit handoff:           .handoff/488/audit-handoff-488.md
+- uncertainty exec log:    .handoff/488/uncertainty-execution-log-488.md
+- fe-review-report:        N/A
+- playwright-mcp-report:   N/A
+- playwright-test-report:  N/A
+- sonar-pseudo-check-report: .handoff/488/sonar-pseudo-check-report-488.json (verdict=FAIL)
+- test results:            Missing Test Evidence
+- spec-consistency-report: .handoff/488/spec-consistency-report-488.json (mode=be, verdict=CONSISTENT)
+- external-review:         .handoff/488/external-review-488.md (runs=2, EC-001~EC-055)
+- artifact registry:       .handoff/488/artifact-registry-488.json
+- previous audit (Run 1):  .handoff/488/audit-report-488-2026-06-03-1130.md (verdict=FAIL, EC-001~EC-021 처리됨)
+
+---
+
+## PR Ingest Summary
+
+| 항목 | 값 |
+|---|---|
+| canonical | 488 |
+| PR | 514 (ajou-2026-1-capstone-5/ostone) |
+| output | .handoff/488/external-review-488.md |
+| ingestion runs (total) | 2 |
+| total EC entries | 55 |
+| this run new EC | 34 (EC-022~EC-055) |
+| Run 1 처리 | EC-001~EC-021은 audit-report-488-2026-06-03-1130.md에서 처리됨 |
+
+---
+
+## Preprocessing
+
+- verdict: **BLOCKED** (새 artifact로 갱신됨, sha=bf046228)
+- artifacts: discovered=12, parsed=4, missing=6, stale=1 (audit-input 자체가 이전 sha 기준으로 stale → 본 실행 중 갱신됨)
+- blocking findings: 4 (모두 sonar-pseudo-check-report의 java:S2259 NPE BUG)
+- warning findings: 2 (SONAR-SMELL-001 non-final field, CSC-001 config mismatch — 후자는 현재 코드에서 해소됨)
+- registryIntegrity: consistent=true
+- **preprocessing verdict는 final Audit verdict 아님. 최종 PASS/FAIL은 본 codeAuditor가 결정.**
+
+---
+
+## Sonar Pseudo Check Summary
+
+- sonar-pseudo-check verdict: **FAIL**
+- Blocking Sonar issues: 4 (BUG, java:S2259 — inTx() @Nullable NPE)
+- Warning Sonar issues: 1 (CODE_SMELL LOW, java:S1170 — non-final mutable restClient)
+- Sonar way approximation (issue 기반):
+  - new_security_rating: APPROX_PASS
+  - new_reliability_rating: APPROX_FAIL (4 MAJOR BUG)
+  - new_maintainability_rating: APPROX_PASS
+- New Code (per projectKey):
+  - **ajou-2026-1-capstone-5_ostone_backend**:
+    - source: `local-measure`
+    - qualityGateSource: `sonarqube-mcp-cache`
+    - new_coverage: 83.0% / threshold 80.0% — **PASS** (local-measure); Phase 2b Cloud: **88.4%** / 80% — OK
+    - new_reliability_rating: C / threshold A — **FAIL** (new_bugs: 4); Phase 2b: actualValue=3(C), threshold=1(A) — **ERROR**
+    - new_security_rating: A / threshold A — PASS (new_vulnerabilities: 0)
+    - new_duplicated_lines_density: NOT_APPLICABLE for local measure (SonarQube Cloud only)
+  - **ajou-2026-1-capstone-5_ostone_frontend**:
+    - source: `local-measure`
+    - new_coverage: 86.36% / 80.0% — PASS
+    - new_reliability_rating: A / A — PASS (new_bugs: 0)
+    - new_security_rating: A / A — PASS
+- Quality Gate level (Phase 2b SonarQube Cloud):
+  - ajou-2026-1-capstone-5_ostone_backend: **ERROR**
+  - failingConditions: [`new_reliability_rating`]
+    - new_reliability_rating: actualValue=3(C), errorThreshold=1(A) — **ERROR**
+  - 기타 조건 all OK (coverage 88.4%, security A, maintainability A, duplication 0.9%, hotspots 100%)
+- Cross-Verify Warnings (Phase 2a vs 2b): N/A (none)
+- Build Failure: occurred=false (backend/frontend/ml 전층 clean)
+- Not covered by this pseudo-check: duplication / security_hotspots_reviewed (coverage는 New Code에서 cover됨)
+- Final source of truth: SonarQube Cloud CI Quality Gate (이 audit는 그 결과를 대체하지 않는다)
+
+---
+
+## 이전 Audit (2026-06-03-1130.md) 대비 해소 현황
+
+| 이전 위반 | 상태 | 근거 |
+|---|---|---|
+| V-001 Coverage 76%<80% (Critical) | **해소** | Phase 2b 88.4% > 80%, Quality Gate OK |
+| V-NEW-001 IDOR — PaymentService orderId 무스코프 조회 | **해소** | `findByWorkspaceIdAndOrderId()` 사용 확인 |
+| V-NEW-002 부분취소 검증 원금 기준 (Warning) | **해소** | `sumCancelAmountByPaymentId` + `remainingCancelable` 계산 확인 |
+| V-NEW-003 SubscriptionService issueBillingKey 상태 검증 없음 | **해소** | INCOMPLETE != status → ActiveSubscriptionExistsException (devjhan/EC-044 + EC-045 확인) |
+| V-NEW-004 Payment.createRecurring 필드 미검증 | **해소** | billingPeriodKey/idempotencyKey blank check 구현 확인 |
+| V-NEW-005 Payment 상태전이 가드 없음 | **해소** | complete/markAborted/markCanceled/markPartialCanceled 가드 확인 |
+| V-NEW-006 Subscription.assignCustomerKey 재할당 허용 | **해소** | 재설정 불가 guard 구현 확인 |
+| V-NEW-007 Subscription.activate/renew 기간 검증 없음 | **해소** | null+isAfter 검증 구현 확인 |
+| V-NEW-008 scheduleCancelAtPeriodEnd ACTIVE 전용 아님 | **해소** | `status != ACTIVE` guard 구현 확인 |
+| V-NEW-009 WebhookEvent.markProcessed null 허용 | **해소** | `requireNonNull` 구현 확인 |
+| V-NEW-010 BillingAuthorizationRequest @NotBlank 없음 | **해소** | `@NotBlank` 적용 확인 |
+| V-NEW-011 resolveTransmissionId Controller 내 위치 | **해소** | HandleTossWebhookCommand (application layer) 이동 확인 |
+| V-NEW-012 PaymentWebhookControllerTest @WithMockUser/csrf | **해소** | 테스트에서 @WithMockUser/csrf 제거 확인 |
+| V-NEW-013/014 SubscriptionControllerTest 검증 미흡 | **해소** | `{\"planKey\":\"\"}`, `{\"authKey\":\"\",\"customerKey\":\"wsk_1_abc\"}` 확인 |
+| V-EC-001 markProcessed Payment 미존재 시 skip 미구현 | **해소** | `paymentFound` flag 분기 구현 확인 (lines 64-72) |
+| V-EC-002 concurrent 중복청구 방지 누락 | **해소** | `findBySubscriptionIdAndBillingPeriodKeyForUpdate` (pessimistic lock) 확인 |
+| V-EC-003 TossApiProperties @Validated 없음 | **해소** | `@Validated`, `@NotBlank`, `@NotNull @Valid` 적용 확인 |
+| V-EC-004 TossPaymentClient UUID.randomUUID idempotency | **부분 해소** | UUID→결정적 키 전환됨, cancel의 paymentKey 단독 사용은 하단 V-EC-004 참조 |
+| V-EC-005 DB subscription 중복 active 부재 | **해소** | `uq_payment_subscription_workspace_open` partial index 추가 확인 |
+
+---
+
+## Summary
+
+| Severity | Count |
+|----------|-------|
+| Critical | 5     |
+| Warning  | 7     |
+| Info     | 1     |
+| Ignored  | 0     |
+
+**Result: FAIL** — Critical 5건 (V-001~V-005: inTx @Nullable NPE 4건 + Quality Gate FAIL 1건)
+
+---
+
+## Violations
+
+### V-001 [Critical] — RecurringBillingService.inTx() @Nullable NPE — findExpiringCancellations 체인 (NORMALIZED-001)
+
+| 항목 | 값 |
+|---|---|
+| **Type** | BUG |
+| **Rule** | sonar-pseudo-check-report (java:S2259) |
+| **File** | backend/src/main/java/com/init/payment/application/RecurringBillingService.java:70 |
+| **Source** | SONAR-BUG-001 |
+| **Description** | `inTx(() -> subscriptionRepository.findExpiringCancellations(now)).stream()` — `inTx()`가 `transactionTemplate.execute(...)` (@Nullable T) 를 그대로 반환. null 체크 없이 `.stream()` 체인 → NPE 가능성. |
+| **Expected** | null-safe stream chain (inTx 내 requireNonNull 또는 호출부 Optional.ofNullable 처리) |
+| **Actual** | `return transactionTemplate.execute(status -> callback.get())` — @Nullable T 직접 반환 후 `.stream()` 체인 |
+| **Requires User Decision** | No |
+| **Fix Direction** | `inTx()` 내부에서 `Objects.requireNonNull(transactionTemplate.execute(...), "inTx returned null")` 추가. 혹은 각 호출부를 `Optional.ofNullable(inTx(...)).orElse(List.of())` 방식으로 처리. V-001~V-003의 공통 원인이므로 inTx() 선언(V-004)을 fix하면 일괄 해소됨. |
+| **Fix Result** | Fixed (auto) |
+
+---
+
+### V-002 [Critical] — RecurringBillingService.inTx() @Nullable NPE — findChargeable 체인 (NORMALIZED-002)
+
+| 항목 | 값 |
+|---|---|
+| **Type** | BUG |
+| **Rule** | sonar-pseudo-check-report (java:S2259) |
+| **File** | backend/src/main/java/com/init/payment/application/RecurringBillingService.java:73 |
+| **Source** | SONAR-BUG-002 |
+| **Description** | `inTx(() -> subscriptionRepository.findChargeable(now)).stream()` — V-001과 동일 @Nullable NPE 패턴. |
+| **Expected** | null-safe stream chain |
+| **Actual** | `.stream()` 직접 체인 |
+| **Requires User Decision** | No |
+| **Fix Direction** | V-001/V-004와 동일 처리. |
+| **Fix Result** | Fixed (auto) |
+
+---
+
+### V-003 [Critical] — RecurringBillingService.inTx() @Nullable NPE — findRetryDue 체인 (NORMALIZED-003)
+
+| 항목 | 값 |
+|---|---|
+| **Type** | BUG |
+| **Rule** | sonar-pseudo-check-report (java:S2259) |
+| **File** | backend/src/main/java/com/init/payment/application/RecurringBillingService.java:76 |
+| **Source** | SONAR-BUG-003 |
+| **Description** | `inTx(() -> subscriptionRepository.findRetryDue(now)).stream()` — V-001과 동일 패턴. |
+| **Expected** | null-safe stream chain |
+| **Actual** | `.stream()` 직접 체인 |
+| **Requires User Decision** | No |
+| **Fix Direction** | V-001/V-004와 동일 처리. |
+| **Fix Result** | Fixed (auto) |
+
+---
+
+### V-004 [Critical] — RecurringBillingService.inTx() @Nullable T 반환 선언이 NPE 소스 (NORMALIZED-004)
+
+| 항목 | 값 |
+|---|---|
+| **Type** | BUG |
+| **Rule** | sonar-pseudo-check-report (java:S2259) |
+| **File** | backend/src/main/java/com/init/payment/application/RecurringBillingService.java:252 |
+| **Source** | SONAR-BUG-004 |
+| **Description** | `private <T> T inTx(Supplier<T> callback) { return transactionTemplate.execute(status -> callback.get()); }` — `transactionTemplate.execute()` 반환 타입이 Spring @Nullable T. 메서드 시그니처는 T(non-null 암시)이나 실제 null 반환 가능. Sonar가 이 선언을 NPE 소스(V-001~V-003의 근본 원인)로 지목. |
+| **Expected** | @NonNull 보장 또는 null-safe 래핑 후 반환 |
+| **Actual** | @Nullable 값을 T로 직접 반환 |
+| **Requires User Decision** | No |
+| **Fix Direction** | `return Objects.requireNonNull(transactionTemplate.execute(status -> callback.get()), "inTx callback must not return null")` 로 교체. 이 단일 변경으로 V-001~V-003의 Sonar 소스 경고가 일괄 해소됨. |
+| **Fix Result** | Fixed (auto) |
+
+---
+
+### V-005 [Critical] — SonarQube Cloud Quality Gate FAIL — new_reliability_rating (Phase 2b)
+
+| 항목 | 값 |
+|---|---|
+| **Type** | Reliability |
+| **Rule** | severity-model.md "newReliabilityRating.passed=false → Audit FAIL 후보 (Critical)" + "qualityGateStatus.level=ERROR → failingConditions 모두 Critical" |
+| **File** | (layer-level: backend) |
+| **Source** | sonar-pseudo-check-report.qualityGateStatus.byProject.ajou-2026-1-capstone-5_ostone_backend |
+| **Description** | Phase 2b SonarQube Cloud PR #514 실측 Quality Gate ERROR. `new_reliability_rating = 3(C)`, 임계값 = 1(A). V-001~V-004(inTx NPE 4 MAJOR BUG)가 직접 원인. coverage/security/maintainability/duplication/hotspots 조건은 모두 OK. |
+| **Expected** | new_reliability_rating ≤ A (new_bugs=0) |
+| **Actual** | new_reliability_rating = C (new_bugs=4) |
+| **Requires User Decision** | No |
+| **Fix Direction** | V-004 수정 후 CI 재실행으로 Quality Gate 해소 예상. |
+| **Fix Result** | Fixed (auto) — V-004 수정으로 4 BUG 해소, CI 재실행 시 Quality Gate PASS 예상 |
+
+---
+
+### V-EC-004 (carryover) [Warning] — TossPaymentClient.cancelPayment Idempotency-Key = paymentKey: 부분취소 복수 시도 시나리오 (EC-047)
+
+| 항목 | 값 |
+|---|---|
+| **Type** | Engineering-Concern |
+| **Cited Rule** | `CLAUDE.md` — "Only validate at system boundaries (user input, external APIs)"; `.agent/rules/principles.md` — YAGNI. 외부 API(Toss v2) 멱등성은 system boundary concern으로 인정됨. |
+| **Severity** | Warning |
+| **Rule** | java.md + code-review.md |
+| **File** | backend/src/main/java/com/init/payment/infrastructure/toss/TossPaymentClient.java:87 |
+| **Source** | EC-047 (coderabbitai[bot], inline-review); 이전 audit V-EC-004(EC-014, Q-004 B Confirmed)의 carryover |
+| **Description** | 이전 audit V-EC-004에서 UUID.randomUUID() → orderId/paymentKey 결정적 키 전환(B 결정 이행)으로 부분 해소됨. 현재 `cancelPayment`는 `paymentKey`를 Idempotency-Key로 사용. Toss v2 명세 상 "같은 Idempotency-Key = 첫 응답 캐시(body 무관)". PARTIAL_CANCELED 상태에서 서로 다른 cancelAmount로 부분취소를 2회 시도하면 Toss가 첫 취소 금액으로 두 번째 요청도 처리하여 DB ↔ Toss 불일치 발생 가능. |
+| **Expected** | 취소 시도 단위를 식별하는 Idempotency-Key (예: PaymentCancel 시도마다 UUID 생성 후 DB 저장, 재시도 시 재사용) |
+| **Actual** | `post(".../cancel", body, "결제 취소", paymentKey)` — 모든 취소 시도에 동일 paymentKey 사용 |
+| **Requires User Decision** | Yes |
+| **Fix Direction** | [**Q-EC-004 결정: B**] `CancelPaymentCommand`에 `String cancelIdempotencyKey` 추가(서비스 진입 시 UUID 생성), `PaymentCancel` 도메인/스키마에 `idempotency_key` 컬럼 추가, `TossPaymentClient.cancelPayment()`에 해당 키 전달. PaymentCancel 재시도 시 DB에서 키 조회해 재사용. |
+| **Fix Result** | Fixed (approved) — cancelPayment 시그니처 변경, PaymentCancel.idempotency_key 추가, 컨트롤러 UUID 생성, 재시도 DB lookup 구현 |
+
+---
+
+### V-006 [Warning] — HandleTossWebhookCommand.resolveTransmissionId: null 체크 전용 → blank 웹훅 키 충돌 (EC-043)
+
+| 항목 | 값 |
+|---|---|
+| **Type** | Rule Violation |
+| **Rule** | java.md §입력 경계 검증 + principles.md (KISS — 예상 외 입력 처리) |
+| **File** | backend/src/main/java/com/init/payment/application/HandleTossWebhookCommand.java:17 |
+| **Source** | EC-043 (coderabbitai[bot], inline-review) |
+| **Description** | `resolveTransmissionId()`에서 `!= null` 체크만 수행. `lastTransactionKey=""`, `eventId=" "` 같은 blank 값이 그대로 transmissionId로 반환됨. 서로 다른 비정상 웹훅이 동일 빈 멱등 키를 공유 → 후속 이벤트 손실 가능. fallback 조합(paymentKey+status)도 null 확인만 하므로 `"null:null"` 같은 키가 생성될 수 있음. |
+| **Expected** | `!= null && !isBlank()` 체크; fallback base 값 부재 시 IllegalArgumentException |
+| **Actual** | `if (lastTransactionKey != null) return lastTransactionKey;` — blank 문자열 허용 |
+| **Requires User Decision** | No |
+| **Fix Direction** | 세 조건(lastTransactionKey, eventId, base+status)을 각각 `value != null && !value.isBlank()` 조건으로 교체. fallback 조합 시 `base`나 `status`가 blank이면 `throw new IllegalArgumentException("Unable to resolve webhook transmissionId: " + ...)`. |
+| **Fix Result** | Fixed (auto) |
+
+---
+
+### V-007 [Warning] — PaymentWebhookService.applyStatus() CANCELED/PARTIAL_CANCELED 경로 no-op guard 없음 (EC-046) [Engineering-Concern]
+
+| 항목 | 값 |
+|---|---|
+| **Type** | Engineering-Concern |
+| **Cited Rule** | `CLAUDE.md` — "Only validate at system boundaries (user input, external APIs)". Toss webhook 재전달/재시도는 공식 spec의 system boundary event임. `.agent/rules/error-handling.md` — 예외 계층. |
+| **Severity** | Warning |
+| **Rule** | java.md (도메인 불변식 보호) + error-handling.md |
+| **File** | backend/src/main/java/com/init/payment/application/PaymentWebhookService.java:128 |
+| **Source** | EC-046 (coderabbitai[bot], inline-review) |
+| **Description** | `applyStatus()`에서 DONE 경로는 `!payment.isDone()` no-op guard가 있으나, CANCELED(`payment.markCanceled(...)`) 및 PARTIAL_CANCELED(`payment.markPartialCanceled(...)`) 경로는 없음. 동일 웹훅이 재전달·재시도되면 이미 CANCELED 상태인 payment에 `markCanceled()` 재호출 → domain guard가 `IllegalStateException`("선행 상태 CANCELED") 던짐 → 처리 실패 반복. |
+| **Expected** | DONE 경로와 같이 "이미 목표 상태이면 no-op return" guard 추가 |
+| **Actual** | `else if (authoritative.isCanceled()) { payment.markCanceled(...); ... }` — 현재 status 확인 없음 |
+| **Requires User Decision** | Yes |
+| **Fix Direction** | [**Q-007 결정: A**] `applyStatus()` 내 CANCELED 분기를 `else if (authoritative.isCanceled() && payment.getStatus() != PaymentStatus.CANCELED)`, PARTIAL_CANCELED 분기를 `else if (authoritative.isPartialCanceled() && payment.getStatus() != PaymentStatus.PARTIAL_CANCELED)` 로 교체. 도메인 가드(markCanceled/markPartialCanceled 내 상태 체크) 유지. |
+| **Fix Result** | Fixed (approved) — applyStatus() CANCELED/PARTIAL_CANCELED 분기에 PaymentStatus 비교 guard 추가 |
+
+---
+
+### V-008 [Warning] — PaymentAccessGuardTest 성공 경로 단언 누락 (EC-048)
+
+| 항목 | 값 |
+|---|---|
+| **Type** | Rule Violation |
+| **Rule** | testing.md (BDD 패턴 — "무엇을 테스트하는가 명확해야 함") + SonarCloud Issue AZ6LtFDjplZwmm2XQPYa |
+| **File** | backend/src/test/java/com/init/payment/application/PaymentAccessGuardTest.java:52 |
+| **Source** | EC-048 (coderabbitai[bot], inline-review) + SonarCloud CI Check |
+| **Description** | `requireMember_validMember_passes()` — `guard.requireMember(1L, 99L)` 호출 후 단언 없음. SonarCloud "Add at least one assertion to this test case" 실패. 예외 없이 통과한다는 의도가 코드로 표현되지 않음. |
+| **Expected** | `assertThatCode(() -> guard.requireMember(1L, 99L)).doesNotThrowAnyException()` |
+| **Actual** | 단언 없는 단순 호출 |
+| **Requires User Decision** | No |
+| **Fix Direction** | `assertThatCode(() -> guard.requireMember(1L, 99L)).doesNotThrowAnyException()` 로 교체. `import static org.assertj.core.api.Assertions.assertThatCode;` 추가. |
+| **Fix Result** | Fixed (auto) |
+
+---
+
+### V-009 [Warning] — PaymentWebhookServiceTest.paymentNotFound 무의미 단언 (EC-049)
+
+| 항목 | 값 |
+|---|---|
+| **Type** | Rule Violation |
+| **Rule** | testing.md ("무엇을 테스트하는가 명확해야 함" — 동작 검증 필수) |
+| **File** | backend/src/test/java/com/init/payment/application/PaymentWebhookServiceTest.java:223 |
+| **Source** | EC-049 (coderabbitai[bot], inline-review) |
+| **Description** | `verify(webhookEventRepository, never()).findByTransmissionId(eq("txn_nr__processed"))` — `"txn_nr__processed"`는 프로덕션 코드 어디에도 존재하지 않는 리터럴. 이 검증은 어떤 상황에서도 항상 PASS. V-EC-001 의도(Payment 미존재 시 markProcessed skip)를 실제로 검증하지 못함. |
+| **Expected** | `verify(webhookEventRepository, times(1)).findByTransmissionId("txn_nr"); verify(webhookEventRepository, never()).save(any());` |
+| **Actual** | `never().findByTransmissionId("txn_nr__processed")` — 항상 통과하는 무의미 단언 |
+| **Requires User Decision** | No |
+| **Fix Direction** | 위 두 verify 구문으로 교체. `import static org.mockito.ArgumentMatchers.eq;` 필요 여부 확인. |
+| **Fix Result** | Fixed (auto) — `never().findByTransmissionId("txn_nr__processed")` → `times(1).findByTransmissionId("txn_nr")` 로 교체 (ensureReceived save는 정상 호출이므로 never().save 대신 times(1) 기준 적용) |
+
+---
+
+### V-010 [Warning] — RecurringBillingSchedulerTest 예외 삼킴 검증 단언 누락 (EC-050)
+
+| 항목 | 값 |
+|---|---|
+| **Type** | Rule Violation |
+| **Rule** | testing.md (BDD 패턴, 단언 의무) + SonarCloud Issue AZ6LtFDVplZwmm2XQPYZ |
+| **File** | backend/src/test/java/com/init/payment/application/RecurringBillingSchedulerTest.java:36 |
+| **Source** | EC-050 (coderabbitai[bot], inline-review) + SonarCloud CI Check |
+| **Description** | `runRecurringBilling_catchesRuntimeException()` — `scheduler.runRecurringBilling()` 호출 후 단언 없음. SonarCloud "Add at least one assertion" 실패. 예외 삼킴 의도(스케줄러가 서비스 예외를 swallow)를 테스트가 표현하지 못함. |
+| **Expected** | `assertThatCode(() -> scheduler.runRecurringBilling()).doesNotThrowAnyException(); verify(recurringBillingService).run();` |
+| **Actual** | 단언 없는 단순 호출 |
+| **Requires User Decision** | No |
+| **Fix Direction** | assertThatCode 래핑 + verify(recurringBillingService).run() 추가. `import static org.assertj.core.api.Assertions.assertThatCode;` 추가. |
+| **Fix Result** | Fixed (auto) |
+
+---
+
+### V-011 [Warning] — SubscriptionServiceTest accessGuard.requireMember 호출 검증 누락 (EC-052)
+
+| 항목 | 값 |
+|---|---|
+| **Type** | Rule Violation |
+| **Rule** | testing.md ("무엇을 테스트하는가 명확해야 함" — 권한 체크 회귀 방지) |
+| **File** | backend/src/test/java/com/init/payment/application/SubscriptionServiceTest.java:101 |
+| **Source** | EC-052 (coderabbitai[bot], review-submission nitpick) |
+| **Description** | `getSubscription_success`, `getSubscription_notFound`, `cancelSubscription_incomplete_immediateCancel`, `cancelSubscription_active_scheduleAtPeriodEnd`, `issueBillingKey_nonIncomplete_throws` 등에 `verify(accessGuard).requireMember(workspaceId, userId)` 단언 없음. 향후 권한 체크 코드가 누락돼도 테스트에서 잡지 못함. |
+| **Expected** | 각 케이스에 `verify(accessGuard).requireMember(1L, 99L)` 추가 |
+| **Actual** | accessGuard 호출 검증 없음 |
+| **Requires User Decision** | No |
+| **Fix Direction** | 해당 5개 테스트 메서드의 When/Then 부분에 `verify(accessGuard).requireMember(1L, 99L)` 추가. Mockito verify import 확인. |
+| **Fix Result** | Fixed (auto) |
+
+---
+
+### V-012 [Info] — TossPaymentClient restClient 비-final 가변 필드 (NORMALIZED-005)
+
+| 항목 | 값 |
+|---|---|
+| **Type** | Rule Violation |
+| **Rule** | sonar-pseudo-check-report (java:S1170 LOW CODE_SMELL) |
+| **File** | backend/src/main/java/com/init/payment/infrastructure/toss/TossPaymentClient.java:35 |
+| **Source** | SONAR-SMELL-001 |
+| **Description** | `private RestClient restClient` — non-final mutable field with lazy synchronized initialization. Sonar S1170 LOW severity. |
+| **Expected** | 생성자 또는 @PostConstruct 초기화 + final 선언 |
+| **Actual** | lazy init via synchronized method |
+| **Requires User Decision** | No |
+| **Fix Direction** | 생성자에서 `this.restClient = buildRestClient()` 초기화 후 final 선언. 테스트 환경에서 TossApiProperties mock이 생성자 시점에 주입되어야 하므로 Spring 빈 주입 순서 확인 필요. |
+| **Fix Result** | Fixed (auto) — restClient final 선언, buildRestClient(properties) static 메서드로 추출 후 생성자 초기화 |
+
+---
+
+## External Review Ingestion
+
+| 항목 | 값 |
+|---|---|
+| **PR** | https://github.com/ajou-2026-1-capstone-5/ostone/pull/514 |
+| **Ingested at** | 2026-06-03 13:33 |
+| **Total EC entries (Run 2)** | 34 (EC-022~EC-055) |
+| **Aligned — ingested as Violations** | 5 (EC-043→V-006, EC-046→V-007, EC-047→V-EC-004 carryover, EC-048→V-008, EC-049→V-009, EC-050→V-010, EC-052→V-011) = 7개 violation에 기여 |
+| **Aligned-Resolved** | 19 (EC-024~EC-042, see below) |
+| **Out-of-Scope (spec conflict)** | 1 (EC-021/EC-051 CORS webhook secret header NITPICK) |
+| **False-Positive** | 0 |
+| **Style-Only** | 0 |
+| **Needs-User-Decision** | 0 |
+| **No-Action (PR summary/empty)** | 9 (EC-022 PR summary, EC-023 SonarQube CI badge, EC-053/EC-054 empty body, EC-051 duplicate of EC-021, EC-055 duplicates of EC-046/EC-047/EC-048/EC-049/EC-050) |
+| **Source artifact** | .handoff/488/external-review-488.md |
+
+---
+
+## Rejected External Findings (Run 2 — EC-022~EC-055)
+
+### REF-001 [Aligned-Resolved] — EC-024 (PaymentService.java:85 workspace scope)
+
+- **Source**: EC-024 (coderabbitai[bot], inline-review) — Run 2 duplicate of EC-002
+- **Reviewer**: coderabbitai[bot]
+- **File/Line (claim)**: PaymentService.java:77-85
+- **Verdict**: Aligned-Resolved
+- **Reason**: 현재 코드에서 `paymentRepository.findByWorkspaceIdAndOrderId(command.workspaceId(), command.orderId())` 사용 확인 (line 79). 이전 audit V-NEW-001에서 수정 완료.
+- **Spec Reference**: .agent/specs/488.md §인증/인가
+
+### REF-002 [Aligned-Resolved] — EC-025 (PaymentService.java:177 partial cancel remaining amount)
+
+- **Source**: EC-025 (coderabbitai[bot], inline-review) — Run 2 duplicate of EC-003
+- **Reviewer**: coderabbitai[bot]
+- **File/Line (claim)**: PaymentService.java:152-177
+- **Verdict**: Aligned-Resolved
+- **Reason**: `sumCancelAmountByPaymentId` + `remainingCancelable` 계산 + 검증 구현 확인 (lines 156-163). 이전 audit V-NEW-002에서 수정 완료.
+- **Spec Reference**: .agent/specs/488.md §취소
+
+### REF-003 [Aligned-Resolved] — EC-026 (PaymentWebhookService.java:68 markProcessed on missing Payment)
+
+- **Source**: EC-026 (coderabbitai[bot], inline-review) — Run 2 duplicate of EC-004
+- **Reviewer**: coderabbitai[bot]
+- **File/Line (claim)**: PaymentWebhookService.java:63-68
+- **Verdict**: Aligned-Resolved
+- **Reason**: `paymentFound` flag 도입으로 해소. `if (paymentFound) markProcessed(...)` 분기 확인 (lines 64-72). 이전 audit V-EC-001에서 수정 완료.
+- **Spec Reference**: .agent/specs/488.md §U-003
+
+### REF-004 [Aligned-Resolved] — EC-027 (RecurringBillingService.java:172 concurrent duplicate billing)
+
+- **Source**: EC-027 (coderabbitai[bot], inline-review) — Run 2 duplicate of EC-005
+- **Reviewer**: coderabbitai[bot]
+- **File/Line (claim)**: RecurringBillingService.java:153-172
+- **Verdict**: Aligned-Resolved
+- **Reason**: `findBySubscriptionIdAndBillingPeriodKeyForUpdate` (pessimistic lock) 구현 확인. 이전 audit V-EC-002에서 수정 완료.
+- **Spec Reference**: .agent/specs/488.md §U-011
+
+### REF-005 [Aligned-Resolved] — EC-028 (SubscriptionService.java:156 issueBillingKey no state guard)
+
+- **Source**: EC-028 (coderabbitai[bot], inline-review) — Run 2 duplicate of EC-006
+- **Reviewer**: coderabbitai[bot]
+- **File/Line (claim)**: SubscriptionService.java:122-153
+- **Verdict**: Aligned-Resolved
+- **Reason**: `status != INCOMPLETE` → `ActiveSubscriptionExistsException` 가드 구현. devjhan EC-044 자체 확인, coderabbitai EC-045 인정. 이전 audit V-NEW-003에서 수정 완료.
+- **Spec Reference**: .agent/specs/488.md §구독 생성
+
+### REF-006 [Aligned-Resolved] — EC-029 (Payment.java:110 createRecurring validation)
+
+- **Source**: EC-029 (coderabbitai[bot], inline-review) — Run 2 duplicate of EC-007
+- **Reviewer**: coderabbitai[bot]
+- **File/Line (claim)**: Payment.java:91-104
+- **Verdict**: Aligned-Resolved
+- **Reason**: `billingPeriodKey`/`idempotencyKey` blank check 구현 확인 (lines 100-104). 이전 audit V-NEW-004에서 수정 완료.
+- **Spec Reference**: .agent/specs/488.md §Payment 도메인
+
+### REF-007 [Aligned-Resolved] — EC-030 (Payment.java:181 state transition guards)
+
+- **Source**: EC-030 (coderabbitai[bot], inline-review) — Run 2 duplicate of EC-008
+- **Reviewer**: coderabbitai[bot]
+- **File/Line (claim)**: Payment.java:132-163
+- **Verdict**: Aligned-Resolved
+- **Reason**: complete/markAborted/markCanceled/markPartialCanceled 모두 선행 상태 guard 구현 확인 (lines 145-180). 이전 audit V-NEW-005에서 수정 완료.
+- **Spec Reference**: .agent/specs/488.md §Payment 상태머신
+
+### REF-008 [Aligned-Resolved] — EC-031 (Subscription.java:87 activate/renew period validation)
+
+- **Source**: EC-031 (coderabbitai[bot], inline-review) — Run 2 duplicate of EC-009
+- **Reviewer**: coderabbitai[bot]
+- **File/Line (claim)**: Subscription.java:87-113
+- **Verdict**: Aligned-Resolved
+- **Reason**: `periodStart == null || periodEnd == null || !periodEnd.isAfter(periodStart)` 검증 구현 확인 (lines 91, 109). 이전 audit V-NEW-007에서 수정 완료.
+- **Spec Reference**: .agent/specs/488.md §Subscription 도메인
+
+### REF-009 [Aligned-Resolved] — EC-032 (Subscription.java:122 scheduleCancelAtPeriodEnd guard)
+
+- **Source**: EC-032 (coderabbitai[bot], inline-review) — Run 2 duplicate of EC-010
+- **Reviewer**: coderabbitai[bot]
+- **File/Line (claim)**: Subscription.java:128-134
+- **Verdict**: Aligned-Resolved
+- **Reason**: `status != SubscriptionStatus.ACTIVE` guard 구현 확인 (line 139). 이전 audit V-NEW-008에서 수정 완료.
+- **Spec Reference**: .agent/specs/488.md §U-005
+
+### REF-010 [Aligned-Resolved] — EC-033 (Subscription.java:143 assignCustomerKey reassignment)
+
+- **Source**: EC-033 (coderabbitai[bot], inline-review) — Run 2 duplicate of EC-011
+- **Reviewer**: coderabbitai[bot]
+- **File/Line (claim)**: Subscription.java:78-84
+- **Verdict**: Aligned-Resolved
+- **Reason**: `this.customerKey != null && !this.customerKey.equals(customerKey)` → IllegalStateException 구현 확인 (lines 83-84). 이전 audit V-NEW-006에서 수정 완료.
+- **Spec Reference**: .agent/specs/488.md §U-006
+
+### REF-011 [Aligned-Resolved] — EC-034 (WebhookEvent.java:56 markProcessed null)
+
+- **Source**: EC-034 (coderabbitai[bot], inline-review) — Run 2 duplicate of EC-012
+- **Reviewer**: coderabbitai[bot]
+- **File/Line (claim)**: WebhookEvent.java:52-53
+- **Verdict**: Aligned-Resolved
+- **Reason**: `processedAt == null` → IllegalArgumentException 구현 확인 (lines 52-56). 이전 audit V-NEW-009에서 수정 완료.
+- **Spec Reference**: .agent/specs/488.md §WebhookEvent
+
+### REF-012 [Aligned-Resolved] — EC-035 (TossApiProperties.java:16 @Validated @NotBlank)
+
+- **Source**: EC-035 (coderabbitai[bot], inline-review) — Run 2 duplicate of EC-013
+- **Reviewer**: coderabbitai[bot]
+- **File/Line (claim)**: TossApiProperties.java:10-16
+- **Verdict**: Aligned-Resolved
+- **Reason**: `@Validated`, `@NotNull @Valid Api`, `@NotBlank secretKey/secret/billingKeyEncryptionKey` 구현 확인. 이전 audit V-EC-003에서 수정 완료.
+- **Spec Reference**: .agent/specs/488.md §설정
+
+### REF-013 [Aligned-Resolved] — EC-036 (TossPaymentClient.java:123 UUID idempotency key)
+
+- **Source**: EC-036 (coderabbitai[bot], inline-review) — Run 2 duplicate of EC-014
+- **Reviewer**: coderabbitai[bot]
+- **File/Line (claim)**: TossPaymentClient.java:108-123
+- **Verdict**: Aligned-Resolved (부분)
+- **Reason**: `post()` 메서드가 `idempotencyKey` 파라미터를 받도록 개선됨. UUID.randomUUID 문제 해소. 단 cancelPayment의 paymentKey 단독 사용 문제는 V-EC-004로 carryover.
+- **Spec Reference**: .agent/specs/488.md §멱등성
+
+### REF-014 [Aligned-Resolved] — EC-037 (BillingAuthorizationRequest.java:5 @NotBlank customerKey)
+
+- **Source**: EC-037 (coderabbitai[bot], inline-review) — Run 2 duplicate of EC-015
+- **Reviewer**: coderabbitai[bot]
+- **File/Line (claim)**: BillingAuthorizationRequest.java:5
+- **Verdict**: Aligned-Resolved
+- **Reason**: `@NotBlank String customerKey` 구현 확인. 이전 audit V-NEW-010에서 수정 완료.
+- **Spec Reference**: .agent/specs/488.md §DTO
+
+### REF-015 [Aligned-Resolved] — EC-038 (PaymentWebhookController.java:76 resolveTransmissionId layer)
+
+- **Source**: EC-038 (coderabbitai[bot], inline-review) — Run 2 duplicate of EC-016
+- **Reviewer**: coderabbitai[bot]
+- **File/Line (claim)**: PaymentWebhookController.java:63-76
+- **Verdict**: Aligned-Resolved
+- **Reason**: `HandleTossWebhookCommand.resolveTransmissionId()`(application layer static method)로 이동 확인. Controller는 위임만 수행. 이전 audit V-NEW-011에서 수정 완료.
+- **Spec Reference**: java.md §계층 규칙
+
+### REF-016 [Aligned-Resolved] — EC-039 (db.changelog-master.sql:990 partial unique index subscription)
+
+- **Source**: EC-039 (coderabbitai[bot], inline-review) — Run 2 duplicate of EC-017
+- **Reviewer**: coderabbitai[bot]
+- **File/Line (claim)**: db.changelog-master.sql:965-978
+- **Verdict**: Aligned-Resolved
+- **Reason**: `changeset init:20260603-add-partial-unique-index-subscription-open` 추가 확인. `uq_payment_subscription_workspace_open` on payment.subscription(workspace_id) where status IN ('INCOMPLETE','ACTIVE','PAST_DUE'). 이전 audit V-EC-005에서 수정 완료.
+- **Spec Reference**: .agent/specs/488.md §DB
+
+### REF-017 [Aligned-Resolved] — EC-040 (PaymentWebhookControllerTest.java:102 @WithMockUser/csrf)
+
+- **Source**: EC-040 (coderabbitai[bot], inline-review) — Run 2 duplicate of EC-018
+- **Reviewer**: coderabbitai[bot]
+- **File/Line (claim)**: PaymentWebhookControllerTest.java:45-99
+- **Verdict**: Aligned-Resolved
+- **Reason**: 현재 테스트에서 @WithMockUser, .with(csrf()) 없음 확인. 이전 audit V-NEW-012에서 수정 완료.
+- **Spec Reference**: .agent/specs/488.md §Tests
+
+### REF-018 [Aligned-Resolved] — EC-041 (SubscriptionControllerTest.java:89 planKey blank test)
+
+- **Source**: EC-041 (coderabbitai[bot], inline-review) — Run 2 duplicate of EC-019
+- **Reviewer**: coderabbitai[bot]
+- **File/Line (claim)**: SubscriptionControllerTest.java:83-89
+- **Verdict**: Aligned-Resolved
+- **Reason**: `content("{\"planKey\":\"\"}")` 확인 (line 88). 이전 audit V-NEW-013에서 수정 완료.
+- **Spec Reference**: .agent/specs/488.md §Tests
+
+### REF-019 [Aligned-Resolved] — EC-042 (SubscriptionControllerTest.java:132 authKey test missing customerKey)
+
+- **Source**: EC-042 (coderabbitai[bot], inline-review) — Run 2 duplicate of EC-020
+- **Reviewer**: coderabbitai[bot]
+- **File/Line (claim)**: SubscriptionControllerTest.java:126-132
+- **Verdict**: Aligned-Resolved
+- **Reason**: `content("{\"authKey\":\"\",\"customerKey\":\"wsk_1_abc\"}")` 확인 (line 131). 이전 audit V-NEW-014에서 수정 완료.
+- **Spec Reference**: .agent/specs/488.md §Tests
+
+### REF-020 [Out-of-Scope] — EC-021/EC-051 NITPICK: SecurityConfig CORS allowedHeaders에서 webhook 시크릿 헤더 제거
+
+- **Source**: EC-021 (Run 1), EC-051 (Run 2) (coderabbitai[bot], review-submission nitpick)
+- **Reviewer**: coderabbitai[bot]
+- **File/Line (claim)**: SecurityConfig.java:93-98
+- **Verdict**: Out-of-Scope
+- **Reason**: `.agent/specs/488.md` §보안 설정 변경(line 269): "CORS `allowedHeaders`(line 91-93)는 웹훅이 서버-서버(브라우저 아님)이므로 등록 불요 — **단 일관성 위해 추가 가능(구현 판단)**". spec이 두 구현 방식을 명시적으로 모두 허용. 현재 구현은 spec의 "구현 판단" 범위 내.
+- **Spec Reference**: .agent/specs/488.md §보안 설정 변경
+
+---
+
+## Spec Consistency
+
+- spec-consistency-report verdict: **CONSISTENT**
+- CSC-001(CONFIG_STRUCTURE_MISMATCH) — `audit-input-488.json` warning으로 등재됐으나 현재 `TossApiProperties`가 `@ConfigurationProperties(prefix = "toss")` + nested `Api`/`Webhook` sub-record 구조로 spec YAML 바인딩과 정합됨. NORMALIZED-006 경고는 stale 기준에서 발생한 것으로 현 코드에서는 해소 확인.
+
+## Uncertainty Handling
+
+| Uncertainty ID | Expected Handling | Actual Handling | Severity |
+|---|---|---|---|
+| U-004/U-005 (취소 시맨틱) | 기간말 취소 + 즉시 취소 분기 | scheduleCancelAtPeriodEnd(ACTIVE 전용 guard) + cancel() 구현 확인 | — |
+| U-011 (중복청구 키) | subscription_id + billing_period_key unique | DB constraint + pessimistic lock 구현 확인 | — |
+
+## Execution Log Consistency
+
+| Area | Execution Log | Actual Code | Severity |
+|---|---|---|---|
+| V-EC-001 markProcessed skip | 구현 완료 기록 | paymentFound flag 확인 — 정합 | — |
+| V-EC-002 concurrent lock | 구현 완료 기록 | ForUpdate 메서드 확인 — 정합 | — |
+
+---
+
+## Ignored (auditignore)
+
+(없음 — .auditignore 파일 없음)
+
+---
+
+## Safe Fix Candidates
+
+Requires User Decision: No 항목 (codeRemediator 자율 수정 가능):
+
+| V-ID | File | Fix 요약 |
+|---|---|---|
+| V-004 | RecurringBillingService.java:252 | `inTx()` 내 `Objects.requireNonNull()` 추가 → V-001~V-005 일괄 해소 |
+| V-006 | HandleTossWebhookCommand.java:17 | `isBlank()` 체크 + fallback 실패 throw |
+| V-008 | PaymentAccessGuardTest.java:52 | assertThatCode 래핑 |
+| V-009 | PaymentWebhookServiceTest.java:223 | `"txn_nr__processed"` → `"txn_nr"` + save never 검증 교체 |
+| V-010 | RecurringBillingSchedulerTest.java:36 | assertThatCode + verify(recurringBillingService).run() |
+| V-011 | SubscriptionServiceTest.java:101 | verify(accessGuard).requireMember(1L, 99L) 5개 메서드에 추가 |
+| V-012 | TossPaymentClient.java:35 | restClient final 화 (low priority, Info) |
+
+---
+
+## User Decision Required
+
+V-EC-004와 V-007은 `Requires User Decision: Yes` (Engineering-Concern)로 분류됐으며, 사용자 결정 수신 완료:
+
+| V-ID | 결정 | 내용 |
+|---|---|---|
+| V-EC-004 | **B 확정** | PaymentCancel별 UUID 생성 + DB 저장 + 재시도 시 재사용 |
+| V-007 | **A 확정** | applyStatus() CANCELED/PARTIAL_CANCELED 경로에 no-op guard 추가 |
+
+두 항목 모두 codeRemediator 처리 대상으로 전환됨.

--- a/backend/src/main/java/com/init/payment/application/BillingAuthorizationResult.java
+++ b/backend/src/main/java/com/init/payment/application/BillingAuthorizationResult.java
@@ -1,0 +1,4 @@
+package com.init.payment.application;
+
+public record BillingAuthorizationResult(
+    SubscriptionResult subscription, BillingKeySummary billingKey) {}

--- a/backend/src/main/java/com/init/payment/application/BillingKeySummary.java
+++ b/backend/src/main/java/com/init/payment/application/BillingKeySummary.java
@@ -1,0 +1,16 @@
+package com.init.payment.application;
+
+import com.init.payment.domain.model.BillingKey;
+
+/** billingKey 응답 요약. 암호화된 billingKey 원문은 절대 포함하지 않는다 (U-012). */
+public record BillingKeySummary(
+    Long id, String cardCompany, String cardNumberMasked, String status) {
+
+  public static BillingKeySummary from(BillingKey billingKey) {
+    return new BillingKeySummary(
+        billingKey.getId(),
+        billingKey.getCardCompany(),
+        billingKey.getCardNumberMasked(),
+        billingKey.getStatus().name());
+  }
+}

--- a/backend/src/main/java/com/init/payment/application/CancelPaymentCommand.java
+++ b/backend/src/main/java/com/init/payment/application/CancelPaymentCommand.java
@@ -1,4 +1,9 @@
 package com.init.payment.application;
 
 public record CancelPaymentCommand(
-    Long workspaceId, Long userId, String paymentKey, String cancelReason, Long cancelAmount) {}
+    Long workspaceId,
+    Long userId,
+    String paymentKey,
+    String cancelReason,
+    Long cancelAmount,
+    String cancelIdempotencyKey) {}

--- a/backend/src/main/java/com/init/payment/application/CancelPaymentCommand.java
+++ b/backend/src/main/java/com/init/payment/application/CancelPaymentCommand.java
@@ -1,0 +1,4 @@
+package com.init.payment.application;
+
+public record CancelPaymentCommand(
+    Long workspaceId, Long userId, String paymentKey, String cancelReason, Long cancelAmount) {}

--- a/backend/src/main/java/com/init/payment/application/ConfirmPaymentCommand.java
+++ b/backend/src/main/java/com/init/payment/application/ConfirmPaymentCommand.java
@@ -1,0 +1,4 @@
+package com.init.payment.application;
+
+public record ConfirmPaymentCommand(
+    Long workspaceId, Long userId, String paymentKey, String orderId, long amount) {}

--- a/backend/src/main/java/com/init/payment/application/CreateSubscriptionCommand.java
+++ b/backend/src/main/java/com/init/payment/application/CreateSubscriptionCommand.java
@@ -1,0 +1,3 @@
+package com.init.payment.application;
+
+public record CreateSubscriptionCommand(Long workspaceId, Long userId, String planKey) {}

--- a/backend/src/main/java/com/init/payment/application/HandleTossWebhookCommand.java
+++ b/backend/src/main/java/com/init/payment/application/HandleTossWebhookCommand.java
@@ -14,13 +14,20 @@ public record HandleTossWebhookCommand(
       String paymentKey,
       String status,
       String eventType) {
-    if (lastTransactionKey != null) {
+    if (lastTransactionKey != null && !lastTransactionKey.isBlank()) {
       return lastTransactionKey;
     }
-    if (eventId != null) {
+    if (eventId != null && !eventId.isBlank()) {
       return eventId;
     }
-    String base = paymentKey != null ? paymentKey : eventType;
+    String base = (paymentKey != null && !paymentKey.isBlank()) ? paymentKey : eventType;
+    if (base == null || base.isBlank() || status == null || status.isBlank()) {
+      throw new IllegalArgumentException(
+          "Unable to resolve webhook transmissionId: paymentKey="
+              + paymentKey
+              + ", status="
+              + status);
+    }
     return base + ":" + status;
   }
 }

--- a/backend/src/main/java/com/init/payment/application/HandleTossWebhookCommand.java
+++ b/backend/src/main/java/com/init/payment/application/HandleTossWebhookCommand.java
@@ -5,4 +5,22 @@ public record HandleTossWebhookCommand(
     String transmissionId,
     String eventType,
     String paymentKey,
-    String maskedPayload) {}
+    String maskedPayload) {
+
+  /** 웹훅 멱등 키. lastTransactionKey → eventId → paymentKey:status 우선순위 (U-003). */
+  public static String resolveTransmissionId(
+      String lastTransactionKey,
+      String eventId,
+      String paymentKey,
+      String status,
+      String eventType) {
+    if (lastTransactionKey != null) {
+      return lastTransactionKey;
+    }
+    if (eventId != null) {
+      return eventId;
+    }
+    String base = paymentKey != null ? paymentKey : eventType;
+    return base + ":" + status;
+  }
+}

--- a/backend/src/main/java/com/init/payment/application/HandleTossWebhookCommand.java
+++ b/backend/src/main/java/com/init/payment/application/HandleTossWebhookCommand.java
@@ -1,0 +1,8 @@
+package com.init.payment.application;
+
+public record HandleTossWebhookCommand(
+    String secretHeader,
+    String transmissionId,
+    String eventType,
+    String paymentKey,
+    String maskedPayload) {}

--- a/backend/src/main/java/com/init/payment/application/IssueBillingKeyCommand.java
+++ b/backend/src/main/java/com/init/payment/application/IssueBillingKeyCommand.java
@@ -1,0 +1,4 @@
+package com.init.payment.application;
+
+public record IssueBillingKeyCommand(
+    Long workspaceId, Long userId, String authKey, String customerKey) {}

--- a/backend/src/main/java/com/init/payment/application/PaymentAccessGuard.java
+++ b/backend/src/main/java/com/init/payment/application/PaymentAccessGuard.java
@@ -1,0 +1,29 @@
+package com.init.payment.application;
+
+import com.init.payment.application.exception.PaymentWorkspaceAccessDeniedException;
+import com.init.payment.application.exception.PaymentWorkspaceNotFoundException;
+import com.init.payment.application.port.WorkspaceMembershipPort;
+import java.util.Set;
+import org.springframework.stereotype.Component;
+
+/** 결제·구독 endpoint 공통 워크스페이스 멤버십 인가 (U-015). */
+@Component
+public class PaymentAccessGuard {
+
+  private static final Set<String> ALLOWED_ROLES = Set.of("OWNER", "ADMIN", "OPERATOR");
+
+  private final WorkspaceMembershipPort workspaceMembershipPort;
+
+  public PaymentAccessGuard(WorkspaceMembershipPort workspaceMembershipPort) {
+    this.workspaceMembershipPort = workspaceMembershipPort;
+  }
+
+  public void requireMember(Long workspaceId, Long userId) {
+    if (!workspaceMembershipPort.existsById(workspaceId)) {
+      throw new PaymentWorkspaceNotFoundException(workspaceId);
+    }
+    if (!workspaceMembershipPort.hasAnyRole(workspaceId, userId, ALLOWED_ROLES)) {
+      throw new PaymentWorkspaceAccessDeniedException();
+    }
+  }
+}

--- a/backend/src/main/java/com/init/payment/application/PaymentIdentifiers.java
+++ b/backend/src/main/java/com/init/payment/application/PaymentIdentifiers.java
@@ -1,0 +1,31 @@
+package com.init.payment.application;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+/** 결제 식별자 생성 유틸. customerKey는 워크스페이스 스코프 랜덤 UUID (U-006, PII 미포함). */
+final class PaymentIdentifiers {
+
+  private PaymentIdentifiers() {}
+
+  static String customerKey(Long workspaceId) {
+    return "wsk_" + workspaceId + "_" + uuid();
+  }
+
+  static String orderId() {
+    return "ord_" + uuid();
+  }
+
+  static String idempotencyKey() {
+    return uuid();
+  }
+
+  /** 동주기 중복청구 방지 키 (U-011). 같은 주기에 대해 안정적인 값. */
+  static String periodKey(OffsetDateTime periodStart) {
+    return periodStart.toInstant().toString();
+  }
+
+  private static String uuid() {
+    return UUID.randomUUID().toString().replace("-", "");
+  }
+}

--- a/backend/src/main/java/com/init/payment/application/PaymentResult.java
+++ b/backend/src/main/java/com/init/payment/application/PaymentResult.java
@@ -1,0 +1,31 @@
+package com.init.payment.application;
+
+import com.init.payment.domain.model.Payment;
+import java.time.OffsetDateTime;
+
+public record PaymentResult(
+    Long id,
+    String orderId,
+    String paymentKey,
+    long amount,
+    String currency,
+    String status,
+    String method,
+    OffsetDateTime approvedAt,
+    String receiptUrl,
+    OffsetDateTime createdAt) {
+
+  public static PaymentResult from(Payment payment) {
+    return new PaymentResult(
+        payment.getId(),
+        payment.getOrderId(),
+        payment.getPaymentKey(),
+        payment.getAmount(),
+        payment.getCurrency(),
+        payment.getStatus().name(),
+        payment.getMethod(),
+        payment.getApprovedAt(),
+        payment.getReceiptUrl(),
+        payment.getCreatedAt());
+  }
+}

--- a/backend/src/main/java/com/init/payment/application/PaymentService.java
+++ b/backend/src/main/java/com/init/payment/application/PaymentService.java
@@ -1,0 +1,242 @@
+package com.init.payment.application;
+
+import com.init.payment.application.exception.PaymentAmountMismatchException;
+import com.init.payment.application.exception.PaymentCancelNotAllowedException;
+import com.init.payment.application.exception.PaymentNotFoundException;
+import com.init.payment.application.exception.PlanNotFoundException;
+import com.init.payment.application.exception.SubscriptionNotFoundException;
+import com.init.payment.application.port.TossPaymentPort;
+import com.init.payment.application.port.TossPaymentResult;
+import com.init.payment.domain.model.Payment;
+import com.init.payment.domain.model.PaymentCancel;
+import com.init.payment.domain.model.PaymentStatus;
+import com.init.payment.domain.model.Plan;
+import com.init.payment.domain.model.Subscription;
+import com.init.payment.domain.model.SubscriptionStatus;
+import com.init.payment.domain.repository.PaymentCancelRepository;
+import com.init.payment.domain.repository.PaymentRepository;
+import com.init.payment.domain.repository.PlanRepository;
+import com.init.payment.domain.repository.SubscriptionRepository;
+import java.time.Clock;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.function.Supplier;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * 일회성 결제 confirm(금액검증 + 멱등), 결제 내역 조회, 취소/부분환불.
+ *
+ * <p>NOTE: Toss 호출과 DB 갱신을 interleave하므로 TransactionTemplate으로 2-phase 처리한다.
+ */
+@Service
+public class PaymentService {
+
+  private final PaymentRepository paymentRepository;
+  private final PaymentCancelRepository paymentCancelRepository;
+  private final SubscriptionRepository subscriptionRepository;
+  private final PlanRepository planRepository;
+  private final TossPaymentPort tossPaymentPort;
+  private final PaymentAccessGuard accessGuard;
+  private final Clock clock;
+  private final TransactionTemplate transactionTemplate;
+
+  public PaymentService(
+      PaymentRepository paymentRepository,
+      PaymentCancelRepository paymentCancelRepository,
+      SubscriptionRepository subscriptionRepository,
+      PlanRepository planRepository,
+      TossPaymentPort tossPaymentPort,
+      PaymentAccessGuard accessGuard,
+      Clock clock,
+      PlatformTransactionManager transactionManager) {
+    this.paymentRepository = paymentRepository;
+    this.paymentCancelRepository = paymentCancelRepository;
+    this.subscriptionRepository = subscriptionRepository;
+    this.planRepository = planRepository;
+    this.tossPaymentPort = tossPaymentPort;
+    this.accessGuard = accessGuard;
+    this.clock = clock;
+    this.transactionTemplate = new TransactionTemplate(transactionManager);
+  }
+
+  public PaymentResult confirmPayment(ConfirmPaymentCommand command) {
+    accessGuard.requireMember(command.workspaceId(), command.userId());
+
+    ConfirmContext context =
+        inTx(
+            () -> {
+              Subscription subscription =
+                  subscriptionRepository
+                      .findCurrentByWorkspaceId(command.workspaceId())
+                      .orElseThrow(() -> new SubscriptionNotFoundException(command.workspaceId()));
+              Plan plan = requirePlan(subscription.getPlanId());
+              Payment existing = paymentRepository.findByOrderId(command.orderId()).orElse(null);
+              if (existing != null && existing.isDone()) {
+                return new ConfirmContext(existing, plan, subscription.getId(), true);
+              }
+              long expected = existing != null ? existing.getAmount() : plan.getAmount();
+              if (command.amount() != expected) {
+                throw new PaymentAmountMismatchException(expected, command.amount());
+              }
+              return new ConfirmContext(existing, plan, subscription.getId(), false);
+            });
+
+    if (context.idempotentHit()) {
+      return PaymentResult.from(context.existing());
+    }
+
+    TossPaymentResult result =
+        tossPaymentPort.confirmPayment(command.paymentKey(), command.orderId(), command.amount());
+
+    Payment finalized =
+        inTx(
+            () -> {
+              Payment payment =
+                  paymentRepository
+                      .findByOrderId(command.orderId())
+                      .orElseGet(
+                          () ->
+                              Payment.createOrder(
+                                  command.workspaceId(),
+                                  context.subscriptionId(),
+                                  command.orderId(),
+                                  command.amount(),
+                                  context.plan().getCurrency(),
+                                  context.plan().getName()));
+              if (payment.isDone()) {
+                return payment;
+              }
+              if (result.isDone()) {
+                payment.complete(
+                    command.paymentKey(),
+                    result.method(),
+                    approvedAt(result),
+                    result.receiptUrl(),
+                    result.maskedRawJson());
+                activateSubscription(context.subscriptionId(), context.plan());
+              } else {
+                payment.markAborted(result.maskedRawJson());
+              }
+              return savePayment(payment, command.orderId());
+            });
+
+    return PaymentResult.from(finalized);
+  }
+
+  @Transactional(readOnly = true)
+  public List<PaymentResult> getPayments(Long workspaceId, Long userId) {
+    accessGuard.requireMember(workspaceId, userId);
+    return paymentRepository.findByWorkspaceIdOrderByCreatedAtDesc(workspaceId).stream()
+        .map(PaymentResult::from)
+        .toList();
+  }
+
+  public PaymentResult cancelPayment(CancelPaymentCommand command) {
+    accessGuard.requireMember(command.workspaceId(), command.userId());
+
+    Payment loaded =
+        inTx(
+            () ->
+                paymentRepository
+                    .findByPaymentKeyAndWorkspaceId(command.paymentKey(), command.workspaceId())
+                    .orElseThrow(
+                        () -> new PaymentNotFoundException("paymentKey=" + command.paymentKey())));
+
+    if (!isCancelable(loaded)) {
+      throw new PaymentCancelNotAllowedException("취소할 수 없는 결제 상태입니다. status=" + loaded.getStatus());
+    }
+    if (command.cancelAmount() != null
+        && (command.cancelAmount() <= 0 || command.cancelAmount() > loaded.getAmount())) {
+      throw new PaymentCancelNotAllowedException(
+          "취소 금액이 유효하지 않습니다. cancelAmount=" + command.cancelAmount());
+    }
+
+    TossPaymentResult result =
+        tossPaymentPort.cancelPayment(
+            command.paymentKey(), command.cancelReason(), command.cancelAmount());
+
+    long resolvedCancelAmount =
+        command.cancelAmount() != null ? command.cancelAmount() : loaded.getAmount();
+
+    Payment finalized =
+        inTx(
+            () -> {
+              Payment payment =
+                  paymentRepository
+                      .findById(loaded.getId())
+                      .orElseThrow(() -> new PaymentNotFoundException("id=" + loaded.getId()));
+              paymentCancelRepository.save(
+                  PaymentCancel.create(
+                      payment.getId(),
+                      resolvedCancelAmount,
+                      command.cancelReason(),
+                      result.transactionKey()));
+              if (isPartialCancel(result, resolvedCancelAmount, payment.getAmount())) {
+                payment.markPartialCanceled(result.maskedRawJson());
+              } else {
+                payment.markCanceled(result.maskedRawJson());
+              }
+              return paymentRepository.save(payment);
+            });
+
+    return PaymentResult.from(finalized);
+  }
+
+  private void activateSubscription(Long subscriptionId, Plan plan) {
+    Subscription subscription =
+        subscriptionRepository
+            .findById(subscriptionId)
+            .orElseThrow(() -> new SubscriptionNotFoundException(subscriptionId));
+    if (subscription.getStatus() == SubscriptionStatus.CANCELED || subscription.isActive()) {
+      return;
+    }
+    OffsetDateTime periodStart = OffsetDateTime.now(clock);
+    OffsetDateTime periodEnd = plan.getBillingInterval().advance(periodStart);
+    subscription.activate(periodStart, periodEnd, subscription.getCustomerKey());
+    subscriptionRepository.save(subscription);
+  }
+
+  private Payment savePayment(Payment payment, String orderId) {
+    try {
+      return paymentRepository.save(payment);
+    } catch (DataIntegrityViolationException ex) {
+      return paymentRepository.findByOrderId(orderId).orElseThrow(() -> ex);
+    }
+  }
+
+  private boolean isCancelable(Payment payment) {
+    return payment.getStatus() == PaymentStatus.DONE
+        || payment.getStatus() == PaymentStatus.PARTIAL_CANCELED;
+  }
+
+  private boolean isPartialCancel(TossPaymentResult result, long cancelAmount, long totalAmount) {
+    if (result.isPartialCanceled()) {
+      return true;
+    }
+    if (result.isCanceled()) {
+      return false;
+    }
+    return cancelAmount < totalAmount;
+  }
+
+  private OffsetDateTime approvedAt(TossPaymentResult result) {
+    return result.approvedAt() != null ? result.approvedAt() : OffsetDateTime.now(clock);
+  }
+
+  private Plan requirePlan(Long planId) {
+    return planRepository
+        .findById(planId)
+        .orElseThrow(() -> new PlanNotFoundException("id=" + planId));
+  }
+
+  private <T> T inTx(Supplier<T> callback) {
+    return transactionTemplate.execute(status -> callback.get());
+  }
+
+  private record ConfirmContext(
+      Payment existing, Plan plan, Long subscriptionId, boolean idempotentHit) {}
+}

--- a/backend/src/main/java/com/init/payment/application/PaymentService.java
+++ b/backend/src/main/java/com/init/payment/application/PaymentService.java
@@ -74,7 +74,10 @@ public class PaymentService {
                       .findCurrentByWorkspaceId(command.workspaceId())
                       .orElseThrow(() -> new SubscriptionNotFoundException(command.workspaceId()));
               Plan plan = requirePlan(subscription.getPlanId());
-              Payment existing = paymentRepository.findByOrderId(command.orderId()).orElse(null);
+              Payment existing =
+                  paymentRepository
+                      .findByWorkspaceIdAndOrderId(command.workspaceId(), command.orderId())
+                      .orElse(null);
               if (existing != null && existing.isDone()) {
                 return new ConfirmContext(existing, plan, subscription.getId(), true);
               }
@@ -97,7 +100,7 @@ public class PaymentService {
             () -> {
               Payment payment =
                   paymentRepository
-                      .findByOrderId(command.orderId())
+                      .findByWorkspaceIdAndOrderId(command.workspaceId(), command.orderId())
                       .orElseGet(
                           () ->
                               Payment.createOrder(
@@ -121,7 +124,7 @@ public class PaymentService {
               } else {
                 payment.markAborted(result.maskedRawJson());
               }
-              return savePayment(payment, command.orderId());
+              return savePayment(payment, command.workspaceId(), command.orderId());
             });
 
     return PaymentResult.from(finalized);
@@ -149,10 +152,16 @@ public class PaymentService {
     if (!isCancelable(loaded)) {
       throw new PaymentCancelNotAllowedException("취소할 수 없는 결제 상태입니다. status=" + loaded.getStatus());
     }
-    if (command.cancelAmount() != null
-        && (command.cancelAmount() <= 0 || command.cancelAmount() > loaded.getAmount())) {
-      throw new PaymentCancelNotAllowedException(
-          "취소 금액이 유효하지 않습니다. cancelAmount=" + command.cancelAmount());
+    if (command.cancelAmount() != null) {
+      long alreadyCanceled = paymentCancelRepository.sumCancelAmountByPaymentId(loaded.getId());
+      long remainingCancelable = loaded.getAmount() - alreadyCanceled;
+      if (command.cancelAmount() <= 0 || command.cancelAmount() > remainingCancelable) {
+        throw new PaymentCancelNotAllowedException(
+            "취소 금액이 유효하지 않습니다. cancelAmount="
+                + command.cancelAmount()
+                + ", remainingCancelable="
+                + remainingCancelable);
+      }
     }
 
     TossPaymentResult result =
@@ -200,11 +209,13 @@ public class PaymentService {
     subscriptionRepository.save(subscription);
   }
 
-  private Payment savePayment(Payment payment, String orderId) {
+  private Payment savePayment(Payment payment, Long workspaceId, String orderId) {
     try {
       return paymentRepository.save(payment);
     } catch (DataIntegrityViolationException ex) {
-      return paymentRepository.findByOrderId(orderId).orElseThrow(() -> ex);
+      return paymentRepository
+          .findByWorkspaceIdAndOrderId(workspaceId, orderId)
+          .orElseThrow(() -> ex);
     }
   }
 

--- a/backend/src/main/java/com/init/payment/application/PaymentService.java
+++ b/backend/src/main/java/com/init/payment/application/PaymentService.java
@@ -152,6 +152,10 @@ public class PaymentService {
     if (!isCancelable(loaded)) {
       throw new PaymentCancelNotAllowedException("취소할 수 없는 결제 상태입니다. status=" + loaded.getStatus());
     }
+
+    long resolvedCancelAmount =
+        command.cancelAmount() != null ? command.cancelAmount() : loaded.getAmount();
+
     if (command.cancelAmount() != null) {
       long alreadyCanceled = paymentCancelRepository.sumCancelAmountByPaymentId(loaded.getId());
       long remainingCancelable = loaded.getAmount() - alreadyCanceled;
@@ -164,12 +168,19 @@ public class PaymentService {
       }
     }
 
+    String cancelIdempotencyKey =
+        paymentCancelRepository
+            .findFirstByPaymentIdAndCancelAmountOrderByIdDesc(loaded.getId(), resolvedCancelAmount)
+            .map(PaymentCancel::getIdempotencyKey)
+            .filter(k -> k != null && !k.isBlank())
+            .orElse(command.cancelIdempotencyKey());
+
     TossPaymentResult result =
         tossPaymentPort.cancelPayment(
-            command.paymentKey(), command.cancelReason(), command.cancelAmount());
-
-    long resolvedCancelAmount =
-        command.cancelAmount() != null ? command.cancelAmount() : loaded.getAmount();
+            command.paymentKey(),
+            command.cancelReason(),
+            command.cancelAmount(),
+            cancelIdempotencyKey);
 
     Payment finalized =
         inTx(
@@ -183,7 +194,8 @@ public class PaymentService {
                       payment.getId(),
                       resolvedCancelAmount,
                       command.cancelReason(),
-                      result.transactionKey()));
+                      result.transactionKey(),
+                      cancelIdempotencyKey));
               if (isPartialCancel(result, resolvedCancelAmount, payment.getAmount())) {
                 payment.markPartialCanceled(result.maskedRawJson());
               } else {

--- a/backend/src/main/java/com/init/payment/application/PaymentWebhookService.java
+++ b/backend/src/main/java/com/init/payment/application/PaymentWebhookService.java
@@ -7,13 +7,13 @@ import com.init.payment.domain.model.Payment;
 import com.init.payment.domain.model.WebhookEvent;
 import com.init.payment.domain.repository.PaymentRepository;
 import com.init.payment.domain.repository.WebhookEventRepository;
-import com.init.payment.infrastructure.config.TossApiProperties;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.time.Clock;
 import java.time.OffsetDateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -31,7 +31,7 @@ public class PaymentWebhookService {
   private final WebhookEventRepository webhookEventRepository;
   private final PaymentRepository paymentRepository;
   private final TossPaymentPort tossPaymentPort;
-  private final TossApiProperties properties;
+  private final String webhookSecret;
   private final Clock clock;
   private final TransactionTemplate transactionTemplate;
 
@@ -39,13 +39,13 @@ public class PaymentWebhookService {
       WebhookEventRepository webhookEventRepository,
       PaymentRepository paymentRepository,
       TossPaymentPort tossPaymentPort,
-      TossApiProperties properties,
+      @Value("${toss.webhook.secret:}") String webhookSecret,
       Clock clock,
       PlatformTransactionManager transactionManager) {
     this.webhookEventRepository = webhookEventRepository;
     this.paymentRepository = paymentRepository;
     this.tossPaymentPort = tossPaymentPort;
-    this.properties = properties;
+    this.webhookSecret = webhookSecret;
     this.clock = clock;
     this.transactionTemplate = new TransactionTemplate(transactionManager);
   }
@@ -69,9 +69,10 @@ public class PaymentWebhookService {
   }
 
   private void validateSecret(String providedSecret) {
-    String configured = properties.webhook() == null ? null : properties.webhook().secret();
     byte[] expected =
-        configured == null ? new byte[0] : configured.getBytes(StandardCharsets.UTF_8);
+        (webhookSecret == null || webhookSecret.isBlank())
+            ? new byte[0]
+            : webhookSecret.getBytes(StandardCharsets.UTF_8);
     byte[] actual =
         providedSecret == null ? new byte[0] : providedSecret.getBytes(StandardCharsets.UTF_8);
     if (expected.length == 0 || !MessageDigest.isEqual(actual, expected)) {

--- a/backend/src/main/java/com/init/payment/application/PaymentWebhookService.java
+++ b/backend/src/main/java/com/init/payment/application/PaymentWebhookService.java
@@ -4,6 +4,7 @@ import com.init.payment.application.exception.PaymentWebhookUnauthorizedExceptio
 import com.init.payment.application.port.TossPaymentPort;
 import com.init.payment.application.port.TossPaymentResult;
 import com.init.payment.domain.model.Payment;
+import com.init.payment.domain.model.PaymentStatus;
 import com.init.payment.domain.model.WebhookEvent;
 import com.init.payment.domain.repository.PaymentRepository;
 import com.init.payment.domain.repository.WebhookEventRepository;
@@ -125,10 +126,11 @@ public class PaymentWebhookService {
           authoritative.receiptUrl(),
           authoritative.maskedRawJson());
       paymentRepository.save(payment);
-    } else if (authoritative.isCanceled()) {
+    } else if (authoritative.isCanceled() && payment.getStatus() != PaymentStatus.CANCELED) {
       payment.markCanceled(authoritative.maskedRawJson());
       paymentRepository.save(payment);
-    } else if (authoritative.isPartialCanceled()) {
+    } else if (authoritative.isPartialCanceled()
+        && payment.getStatus() != PaymentStatus.PARTIAL_CANCELED) {
       payment.markPartialCanceled(authoritative.maskedRawJson());
       paymentRepository.save(payment);
     }

--- a/backend/src/main/java/com/init/payment/application/PaymentWebhookService.java
+++ b/backend/src/main/java/com/init/payment/application/PaymentWebhookService.java
@@ -11,6 +11,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.time.Clock;
 import java.time.OffsetDateTime;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -60,12 +61,15 @@ public class PaymentWebhookService {
     }
     ensureReceived(command);
 
+    boolean paymentFound = true;
     if (command.paymentKey() != null && !command.paymentKey().isBlank()) {
       TossPaymentResult authoritative = tossPaymentPort.getPayment(command.paymentKey());
-      reflectAuthoritativeStatus(authoritative);
+      paymentFound = reflectAuthoritativeStatus(authoritative);
     }
 
-    markProcessed(command.transmissionId());
+    if (paymentFound) {
+      markProcessed(command.transmissionId());
+    }
   }
 
   private void validateSecret(String providedSecret) {
@@ -92,12 +96,22 @@ public class PaymentWebhookService {
     }
   }
 
-  private void reflectAuthoritativeStatus(TossPaymentResult authoritative) {
-    transactionTemplate.executeWithoutResult(
-        status ->
-            paymentRepository
-                .findByPaymentKey(authoritative.paymentKey())
-                .ifPresent(payment -> applyStatus(payment, authoritative)));
+  /**
+   * Toss 권위 상태를 Payment에 반영한다.
+   *
+   * @return true: Payment 레코드가 존재하여 반영(또는 반영 불필요)함. false: Payment 미존재 — Toss 재시도를 허용하기 위해
+   *     markProcessed()를 건너뜀.
+   */
+  private boolean reflectAuthoritativeStatus(TossPaymentResult authoritative) {
+    Boolean found =
+        transactionTemplate.execute(
+            status -> {
+              Optional<Payment> optPayment =
+                  paymentRepository.findByPaymentKey(authoritative.paymentKey());
+              optPayment.ifPresent(payment -> applyStatus(payment, authoritative));
+              return optPayment.isPresent();
+            });
+    return Boolean.TRUE.equals(found);
   }
 
   private void applyStatus(Payment payment, TossPaymentResult authoritative) {

--- a/backend/src/main/java/com/init/payment/application/PaymentWebhookService.java
+++ b/backend/src/main/java/com/init/payment/application/PaymentWebhookService.java
@@ -1,0 +1,135 @@
+package com.init.payment.application;
+
+import com.init.payment.application.exception.PaymentWebhookUnauthorizedException;
+import com.init.payment.application.port.TossPaymentPort;
+import com.init.payment.application.port.TossPaymentResult;
+import com.init.payment.domain.model.Payment;
+import com.init.payment.domain.model.WebhookEvent;
+import com.init.payment.domain.repository.PaymentRepository;
+import com.init.payment.domain.repository.WebhookEventRepository;
+import com.init.payment.infrastructure.config.TossApiProperties;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.time.Clock;
+import java.time.OffsetDateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * Toss 웹훅 처리 (U-003). 시크릿 헤더 상수시간 비교 -> transmission_id 멱등 -> 본문 무신뢰, Toss 재조회로 권위 상태 확정 -> Payment
+ * 상태 반영.
+ */
+@Service
+public class PaymentWebhookService {
+
+  private static final Logger log = LoggerFactory.getLogger(PaymentWebhookService.class);
+
+  private final WebhookEventRepository webhookEventRepository;
+  private final PaymentRepository paymentRepository;
+  private final TossPaymentPort tossPaymentPort;
+  private final TossApiProperties properties;
+  private final Clock clock;
+  private final TransactionTemplate transactionTemplate;
+
+  public PaymentWebhookService(
+      WebhookEventRepository webhookEventRepository,
+      PaymentRepository paymentRepository,
+      TossPaymentPort tossPaymentPort,
+      TossApiProperties properties,
+      Clock clock,
+      PlatformTransactionManager transactionManager) {
+    this.webhookEventRepository = webhookEventRepository;
+    this.paymentRepository = paymentRepository;
+    this.tossPaymentPort = tossPaymentPort;
+    this.properties = properties;
+    this.clock = clock;
+    this.transactionTemplate = new TransactionTemplate(transactionManager);
+  }
+
+  public void handle(HandleTossWebhookCommand command) {
+    validateSecret(command.secretHeader());
+
+    WebhookEvent existing =
+        webhookEventRepository.findByTransmissionId(command.transmissionId()).orElse(null);
+    if (existing != null && existing.isProcessed()) {
+      return;
+    }
+    ensureReceived(command);
+
+    if (command.paymentKey() != null && !command.paymentKey().isBlank()) {
+      TossPaymentResult authoritative = tossPaymentPort.getPayment(command.paymentKey());
+      reflectAuthoritativeStatus(authoritative);
+    }
+
+    markProcessed(command.transmissionId());
+  }
+
+  private void validateSecret(String providedSecret) {
+    String configured = properties.webhook() == null ? null : properties.webhook().secret();
+    byte[] expected =
+        configured == null ? new byte[0] : configured.getBytes(StandardCharsets.UTF_8);
+    byte[] actual =
+        providedSecret == null ? new byte[0] : providedSecret.getBytes(StandardCharsets.UTF_8);
+    if (expected.length == 0 || !MessageDigest.isEqual(actual, expected)) {
+      throw new PaymentWebhookUnauthorizedException();
+    }
+  }
+
+  private void ensureReceived(HandleTossWebhookCommand command) {
+    try {
+      transactionTemplate.executeWithoutResult(
+          status ->
+              webhookEventRepository.save(
+                  WebhookEvent.received(
+                      command.transmissionId(), command.eventType(), command.maskedPayload())));
+    } catch (DataIntegrityViolationException ex) {
+      log.debug("Toss 웹훅 동시 수신 감지(멱등): transmissionId={}", command.transmissionId());
+    }
+  }
+
+  private void reflectAuthoritativeStatus(TossPaymentResult authoritative) {
+    transactionTemplate.executeWithoutResult(
+        status ->
+            paymentRepository
+                .findByPaymentKey(authoritative.paymentKey())
+                .ifPresent(payment -> applyStatus(payment, authoritative)));
+  }
+
+  private void applyStatus(Payment payment, TossPaymentResult authoritative) {
+    if (authoritative.isDone() && !payment.isDone()) {
+      payment.complete(
+          authoritative.paymentKey(),
+          authoritative.method(),
+          authoritative.approvedAt() != null
+              ? authoritative.approvedAt()
+              : OffsetDateTime.now(clock),
+          authoritative.receiptUrl(),
+          authoritative.maskedRawJson());
+      paymentRepository.save(payment);
+    } else if (authoritative.isCanceled()) {
+      payment.markCanceled(authoritative.maskedRawJson());
+      paymentRepository.save(payment);
+    } else if (authoritative.isPartialCanceled()) {
+      payment.markPartialCanceled(authoritative.maskedRawJson());
+      paymentRepository.save(payment);
+    }
+  }
+
+  private void markProcessed(String transmissionId) {
+    transactionTemplate.executeWithoutResult(
+        status ->
+            webhookEventRepository
+                .findByTransmissionId(transmissionId)
+                .ifPresent(
+                    event -> {
+                      if (!event.isProcessed()) {
+                        event.markProcessed(OffsetDateTime.now(clock));
+                        webhookEventRepository.save(event);
+                      }
+                    }));
+  }
+}

--- a/backend/src/main/java/com/init/payment/application/RecurringBillingScheduler.java
+++ b/backend/src/main/java/com/init/payment/application/RecurringBillingScheduler.java
@@ -1,0 +1,31 @@
+package com.init.payment.application;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * 정기결제 인앱 스케줄러 (U-001: Spring @Scheduled). 만기/재시도/기간말 해지 대상을 주기 스캔한다. 다중 인스턴스 배포 시 중복 실행 방지는 배포
+ * 형상(단일 인스턴스 또는 분산 락)에 따르며, DB unique 제약(U-011)이 최종 중복청구 안전망이다.
+ */
+@Component
+public class RecurringBillingScheduler {
+
+  private static final Logger log = LoggerFactory.getLogger(RecurringBillingScheduler.class);
+
+  private final RecurringBillingService recurringBillingService;
+
+  public RecurringBillingScheduler(RecurringBillingService recurringBillingService) {
+    this.recurringBillingService = recurringBillingService;
+  }
+
+  @Scheduled(cron = "${toss.scheduler.recurring-billing-cron:0 */30 * * * *}")
+  public void runRecurringBilling() {
+    try {
+      recurringBillingService.run();
+    } catch (RuntimeException ex) {
+      log.error("정기결제 스케줄러 실행 중 오류", ex);
+    }
+  }
+}

--- a/backend/src/main/java/com/init/payment/application/RecurringBillingService.java
+++ b/backend/src/main/java/com/init/payment/application/RecurringBillingService.java
@@ -19,6 +19,7 @@ import com.init.payment.domain.repository.PlanRepository;
 import com.init.payment.domain.repository.SubscriptionRepository;
 import java.time.Clock;
 import java.time.OffsetDateTime;
+import java.util.Objects;
 import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -249,7 +250,9 @@ public class RecurringBillingService {
   }
 
   private <T> T inTx(Supplier<T> callback) {
-    return transactionTemplate.execute(status -> callback.get());
+    return Objects.requireNonNull(
+        transactionTemplate.execute(status -> callback.get()),
+        "inTx callback must not return null");
   }
 
   private void inTxRun(Runnable callback) {

--- a/backend/src/main/java/com/init/payment/application/RecurringBillingService.java
+++ b/backend/src/main/java/com/init/payment/application/RecurringBillingService.java
@@ -1,0 +1,246 @@
+package com.init.payment.application;
+
+import com.init.payment.application.exception.BillingKeyNotFoundException;
+import com.init.payment.application.exception.PaymentGatewayException;
+import com.init.payment.application.exception.PaymentRejectedException;
+import com.init.payment.application.exception.PlanNotFoundException;
+import com.init.payment.application.port.BillingKeyCipher;
+import com.init.payment.application.port.TossBillingExecuteCommand;
+import com.init.payment.application.port.TossPaymentPort;
+import com.init.payment.application.port.TossPaymentResult;
+import com.init.payment.domain.model.BillingKey;
+import com.init.payment.domain.model.Payment;
+import com.init.payment.domain.model.Plan;
+import com.init.payment.domain.model.Subscription;
+import com.init.payment.domain.model.SubscriptionStatus;
+import com.init.payment.domain.repository.BillingKeyRepository;
+import com.init.payment.domain.repository.PaymentRepository;
+import com.init.payment.domain.repository.PlanRepository;
+import com.init.payment.domain.repository.SubscriptionRepository;
+import java.time.Clock;
+import java.time.OffsetDateTime;
+import java.util.function.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * 정기결제 실행 도메인 서비스. 만기 구독을 청구하고, 실패 시 PAST_DUE 전이 + 일 1회 재시도(최대 3일) 후 해지하며, 기간말 해지 예약을 처리한다 (U-004,
+ * U-005). 동주기 중복청구는 payment 행 재사용 + DB unique 제약(subscription_id, billing_period_key)으로 차단한다
+ * (U-011).
+ */
+@Service
+public class RecurringBillingService {
+
+  private static final Logger log = LoggerFactory.getLogger(RecurringBillingService.class);
+
+  private final SubscriptionRepository subscriptionRepository;
+  private final PlanRepository planRepository;
+  private final PaymentRepository paymentRepository;
+  private final BillingKeyRepository billingKeyRepository;
+  private final TossPaymentPort tossPaymentPort;
+  private final BillingKeyCipher billingKeyCipher;
+  private final Clock clock;
+  private final TransactionTemplate transactionTemplate;
+
+  public RecurringBillingService(
+      SubscriptionRepository subscriptionRepository,
+      PlanRepository planRepository,
+      PaymentRepository paymentRepository,
+      BillingKeyRepository billingKeyRepository,
+      TossPaymentPort tossPaymentPort,
+      BillingKeyCipher billingKeyCipher,
+      Clock clock,
+      PlatformTransactionManager transactionManager) {
+    this.subscriptionRepository = subscriptionRepository;
+    this.planRepository = planRepository;
+    this.paymentRepository = paymentRepository;
+    this.billingKeyRepository = billingKeyRepository;
+    this.tossPaymentPort = tossPaymentPort;
+    this.billingKeyCipher = billingKeyCipher;
+    this.clock = clock;
+    this.transactionTemplate = new TransactionTemplate(transactionManager);
+  }
+
+  public void run() {
+    OffsetDateTime now = OffsetDateTime.now(clock);
+    inTx(() -> subscriptionRepository.findExpiringCancellations(now)).stream()
+        .map(Subscription::getId)
+        .forEach(this::cancelExpiring);
+    inTx(() -> subscriptionRepository.findChargeable(now)).stream()
+        .map(Subscription::getId)
+        .forEach(this::chargeSubscriptionSafely);
+    inTx(() -> subscriptionRepository.findRetryDue(now)).stream()
+        .map(Subscription::getId)
+        .forEach(this::chargeSubscriptionSafely);
+  }
+
+  private void chargeSubscriptionSafely(Long subscriptionId) {
+    try {
+      chargeSubscription(subscriptionId);
+    } catch (RuntimeException ex) {
+      log.error("정기결제 처리 실패: subscriptionId={}", subscriptionId, ex);
+    }
+  }
+
+  private void chargeSubscription(Long subscriptionId) {
+    ChargePrep prep = inTx(() -> prepareCharge(subscriptionId));
+    if (prep == null) {
+      return;
+    }
+
+    boolean charged = false;
+    TossPaymentResult result = null;
+    try {
+      BillingKey billingKey =
+          billingKeyRepository
+              .findActiveByWorkspaceId(prep.workspaceId())
+              .orElseThrow(() -> new BillingKeyNotFoundException(prep.workspaceId()));
+      String plainBillingKey = billingKeyCipher.decrypt(billingKey.getBillingKeyEncrypted());
+      result =
+          tossPaymentPort.executeBilling(
+              new TossBillingExecuteCommand(
+                  plainBillingKey,
+                  prep.customerKey(),
+                  prep.amount(),
+                  prep.orderId(),
+                  prep.orderName()));
+      charged = result.isDone();
+    } catch (BillingKeyNotFoundException | PaymentGatewayException | PaymentRejectedException ex) {
+      log.warn("정기결제 청구 실패: subscriptionId={}, reason={}", subscriptionId, ex.getMessage());
+    }
+
+    boolean success = charged;
+    TossPaymentResult tossResult = result;
+    inTxRun(() -> finalizeCharge(subscriptionId, prep, success, tossResult));
+  }
+
+  private ChargePrep prepareCharge(Long subscriptionId) {
+    Subscription subscription = subscriptionRepository.findById(subscriptionId).orElse(null);
+    if (subscription == null || subscription.getStatus() == SubscriptionStatus.CANCELED) {
+      return null;
+    }
+    OffsetDateTime periodStart = subscription.getCurrentPeriodEnd();
+    if (periodStart == null) {
+      log.warn("구독에 현재 주기 정보가 없어 정기결제를 건너뜁니다. subscriptionId={}", subscriptionId);
+      return null;
+    }
+    Plan plan = requirePlan(subscription.getPlanId());
+    OffsetDateTime periodEnd = plan.getBillingInterval().advance(periodStart);
+    String periodKey = PaymentIdentifiers.periodKey(periodStart);
+
+    Payment existing =
+        paymentRepository
+            .findBySubscriptionIdAndBillingPeriodKey(subscriptionId, periodKey)
+            .orElse(null);
+    if (existing != null && existing.isDone()) {
+      subscription.renew(periodStart, periodEnd);
+      subscriptionRepository.save(subscription);
+      return null;
+    }
+
+    Payment payment = existing;
+    if (payment == null) {
+      try {
+        payment =
+            paymentRepository.save(
+                Payment.createRecurring(
+                    subscription.getWorkspaceId(),
+                    subscriptionId,
+                    PaymentIdentifiers.orderId(),
+                    plan.getAmount(),
+                    plan.getCurrency(),
+                    plan.getName(),
+                    periodKey,
+                    PaymentIdentifiers.idempotencyKey()));
+      } catch (DataIntegrityViolationException ex) {
+        Payment concurrent =
+            paymentRepository
+                .findBySubscriptionIdAndBillingPeriodKey(subscriptionId, periodKey)
+                .orElse(null);
+        if (concurrent == null || concurrent.isDone()) {
+          return null;
+        }
+        payment = concurrent;
+      }
+    }
+
+    return new ChargePrep(
+        payment.getId(),
+        payment.getOrderId(),
+        subscription.getWorkspaceId(),
+        subscription.getCustomerKey(),
+        plan.getAmount(),
+        plan.getName(),
+        periodStart,
+        periodEnd);
+  }
+
+  private void finalizeCharge(
+      Long subscriptionId, ChargePrep prep, boolean success, TossPaymentResult result) {
+    Subscription subscription = subscriptionRepository.findById(subscriptionId).orElse(null);
+    Payment payment = paymentRepository.findById(prep.paymentId()).orElse(null);
+    if (subscription == null || payment == null) {
+      return;
+    }
+    if (success) {
+      payment.complete(
+          result.paymentKey(),
+          result.method(),
+          result.approvedAt() != null ? result.approvedAt() : OffsetDateTime.now(clock),
+          result.receiptUrl(),
+          result.maskedRawJson());
+      subscription.renew(prep.periodStart(), prep.periodEnd());
+    } else {
+      payment.markAborted(result != null ? result.maskedRawJson() : null);
+      subscription.markPastDue(OffsetDateTime.now(clock).plusDays(1));
+      if (subscription.isRetryExhausted()) {
+        subscription.cancel();
+      }
+    }
+    paymentRepository.save(payment);
+    subscriptionRepository.save(subscription);
+  }
+
+  private void cancelExpiring(Long subscriptionId) {
+    inTxRun(
+        () -> {
+          Subscription subscription = subscriptionRepository.findById(subscriptionId).orElse(null);
+          if (subscription == null) {
+            return;
+          }
+          if (subscription.isCancelAtPeriodEnd()
+              && subscription.getStatus() == SubscriptionStatus.ACTIVE) {
+            subscription.cancel();
+            subscriptionRepository.save(subscription);
+          }
+        });
+  }
+
+  private Plan requirePlan(Long planId) {
+    return planRepository
+        .findById(planId)
+        .orElseThrow(() -> new PlanNotFoundException("id=" + planId));
+  }
+
+  private <T> T inTx(Supplier<T> callback) {
+    return transactionTemplate.execute(status -> callback.get());
+  }
+
+  private void inTxRun(Runnable callback) {
+    transactionTemplate.executeWithoutResult(status -> callback.run());
+  }
+
+  private record ChargePrep(
+      Long paymentId,
+      String orderId,
+      Long workspaceId,
+      String customerKey,
+      long amount,
+      String orderName,
+      OffsetDateTime periodStart,
+      OffsetDateTime periodEnd) {}
+}

--- a/backend/src/main/java/com/init/payment/application/RecurringBillingService.java
+++ b/backend/src/main/java/com/init/payment/application/RecurringBillingService.java
@@ -88,7 +88,7 @@ public class RecurringBillingService {
   }
 
   private void chargeSubscription(Long subscriptionId) {
-    ChargePrep prep = inTx(() -> prepareCharge(subscriptionId));
+    ChargePrep prep = inTxNullable(() -> prepareCharge(subscriptionId));
     if (prep == null) {
       return;
     }
@@ -253,6 +253,11 @@ public class RecurringBillingService {
     return Objects.requireNonNull(
         transactionTemplate.execute(status -> callback.get()),
         "inTx callback must not return null");
+  }
+
+  /** prepareCharge처럼 "건너뛰기" 신호로 null을 반환할 수 있는 콜백 전용. inTx와 달리 null을 그대로 통과시킨다. */
+  private <T> T inTxNullable(Supplier<T> callback) {
+    return transactionTemplate.execute(status -> callback.get());
   }
 
   private void inTxRun(Runnable callback) {

--- a/backend/src/main/java/com/init/payment/application/RecurringBillingService.java
+++ b/backend/src/main/java/com/init/payment/application/RecurringBillingService.java
@@ -159,7 +159,7 @@ public class RecurringBillingService {
       OffsetDateTime periodEnd) {
     Payment existing =
         paymentRepository
-            .findBySubscriptionIdAndBillingPeriodKey(subscriptionId, periodKey)
+            .findBySubscriptionIdAndBillingPeriodKeyForUpdate(subscriptionId, periodKey)
             .orElse(null);
     if (existing != null && existing.isDone()) {
       subscription.renew(periodStart, periodEnd);

--- a/backend/src/main/java/com/init/payment/application/RecurringBillingService.java
+++ b/backend/src/main/java/com/init/payment/application/RecurringBillingService.java
@@ -132,40 +132,11 @@ public class RecurringBillingService {
     OffsetDateTime periodEnd = plan.getBillingInterval().advance(periodStart);
     String periodKey = PaymentIdentifiers.periodKey(periodStart);
 
-    Payment existing =
-        paymentRepository
-            .findBySubscriptionIdAndBillingPeriodKey(subscriptionId, periodKey)
-            .orElse(null);
-    if (existing != null && existing.isDone()) {
-      subscription.renew(periodStart, periodEnd);
-      subscriptionRepository.save(subscription);
-      return null;
-    }
-
-    Payment payment = existing;
+    Payment payment =
+        findOrCreatePeriodPayment(
+            subscriptionId, periodKey, plan, subscription, periodStart, periodEnd);
     if (payment == null) {
-      try {
-        payment =
-            paymentRepository.save(
-                Payment.createRecurring(
-                    subscription.getWorkspaceId(),
-                    subscriptionId,
-                    PaymentIdentifiers.orderId(),
-                    plan.getAmount(),
-                    plan.getCurrency(),
-                    plan.getName(),
-                    periodKey,
-                    PaymentIdentifiers.idempotencyKey()));
-      } catch (DataIntegrityViolationException ex) {
-        Payment concurrent =
-            paymentRepository
-                .findBySubscriptionIdAndBillingPeriodKey(subscriptionId, periodKey)
-                .orElse(null);
-        if (concurrent == null || concurrent.isDone()) {
-          return null;
-        }
-        payment = concurrent;
-      }
+      return null;
     }
 
     return new ChargePrep(
@@ -177,6 +148,57 @@ public class RecurringBillingService {
         plan.getName(),
         periodStart,
         periodEnd);
+  }
+
+  private Payment findOrCreatePeriodPayment(
+      Long subscriptionId,
+      String periodKey,
+      Plan plan,
+      Subscription subscription,
+      OffsetDateTime periodStart,
+      OffsetDateTime periodEnd) {
+    Payment existing =
+        paymentRepository
+            .findBySubscriptionIdAndBillingPeriodKey(subscriptionId, periodKey)
+            .orElse(null);
+    if (existing != null && existing.isDone()) {
+      subscription.renew(periodStart, periodEnd);
+      subscriptionRepository.save(subscription);
+      return null;
+    }
+    if (existing != null) {
+      return existing;
+    }
+    return createPeriodPayment(subscriptionId, periodKey, plan, subscription);
+  }
+
+  private Payment createPeriodPayment(
+      Long subscriptionId, String periodKey, Plan plan, Subscription subscription) {
+    try {
+      return paymentRepository.save(
+          Payment.createRecurring(
+              subscription.getWorkspaceId(),
+              subscriptionId,
+              PaymentIdentifiers.orderId(),
+              plan.getAmount(),
+              plan.getCurrency(),
+              plan.getName(),
+              periodKey,
+              PaymentIdentifiers.idempotencyKey()));
+    } catch (DataIntegrityViolationException ex) {
+      return handleConcurrentInsert(subscriptionId, periodKey);
+    }
+  }
+
+  private Payment handleConcurrentInsert(Long subscriptionId, String periodKey) {
+    Payment concurrent =
+        paymentRepository
+            .findBySubscriptionIdAndBillingPeriodKey(subscriptionId, periodKey)
+            .orElse(null);
+    if (concurrent == null || concurrent.isDone()) {
+      return null;
+    }
+    return concurrent;
   }
 
   private void finalizeCharge(

--- a/backend/src/main/java/com/init/payment/application/SubscriptionResult.java
+++ b/backend/src/main/java/com/init/payment/application/SubscriptionResult.java
@@ -1,0 +1,28 @@
+package com.init.payment.application;
+
+import com.init.payment.domain.model.Plan;
+import com.init.payment.domain.model.Subscription;
+import java.time.OffsetDateTime;
+
+public record SubscriptionResult(
+    Long id,
+    Long workspaceId,
+    String planKey,
+    String status,
+    OffsetDateTime currentPeriodStart,
+    OffsetDateTime currentPeriodEnd,
+    boolean cancelAtPeriodEnd,
+    String customerKey) {
+
+  public static SubscriptionResult from(Subscription subscription, Plan plan) {
+    return new SubscriptionResult(
+        subscription.getId(),
+        subscription.getWorkspaceId(),
+        plan.getPlanKey(),
+        subscription.getStatus().name(),
+        subscription.getCurrentPeriodStart(),
+        subscription.getCurrentPeriodEnd(),
+        subscription.isCancelAtPeriodEnd(),
+        subscription.getCustomerKey());
+  }
+}

--- a/backend/src/main/java/com/init/payment/application/SubscriptionService.java
+++ b/backend/src/main/java/com/init/payment/application/SubscriptionService.java
@@ -125,6 +125,9 @@ public class SubscriptionService {
                 subscriptionRepository
                     .findCurrentByWorkspaceId(command.workspaceId())
                     .orElseThrow(() -> new SubscriptionNotFoundException(command.workspaceId())));
+    if (subscription.getStatus() != SubscriptionStatus.INCOMPLETE) {
+      throw new ActiveSubscriptionExistsException(command.workspaceId());
+    }
     Plan plan = requirePlan(subscription.getPlanId());
     String customerKey = subscription.getCustomerKey();
 

--- a/backend/src/main/java/com/init/payment/application/SubscriptionService.java
+++ b/backend/src/main/java/com/init/payment/application/SubscriptionService.java
@@ -1,0 +1,204 @@
+package com.init.payment.application;
+
+import com.init.payment.application.exception.ActiveSubscriptionExistsException;
+import com.init.payment.application.exception.PlanNotFoundException;
+import com.init.payment.application.exception.SubscriptionNotFoundException;
+import com.init.payment.application.port.BillingKeyCipher;
+import com.init.payment.application.port.TossBillingExecuteCommand;
+import com.init.payment.application.port.TossBillingKeyResult;
+import com.init.payment.application.port.TossPaymentPort;
+import com.init.payment.application.port.TossPaymentResult;
+import com.init.payment.domain.model.BillingKey;
+import com.init.payment.domain.model.Payment;
+import com.init.payment.domain.model.Plan;
+import com.init.payment.domain.model.Subscription;
+import com.init.payment.domain.model.SubscriptionStatus;
+import com.init.payment.domain.repository.BillingKeyRepository;
+import com.init.payment.domain.repository.PaymentRepository;
+import com.init.payment.domain.repository.PlanRepository;
+import com.init.payment.domain.repository.SubscriptionRepository;
+import java.time.Clock;
+import java.time.OffsetDateTime;
+import java.util.function.Supplier;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * 구독 생성/조회/취소 및 billingKey 발급 기반 구독 활성화.
+ *
+ * <p>NOTE: 외부 Toss 호출과 DB 갱신을 interleave하는 issueBillingKey는 선언적 @Transactional 대신
+ * TransactionTemplate으로 2-phase 처리한다(트랜잭션 내 외부 HTTP 호출 회피, pipelinejob 패턴 미러).
+ */
+@Service
+public class SubscriptionService {
+
+  private final SubscriptionRepository subscriptionRepository;
+  private final PlanRepository planRepository;
+  private final BillingKeyRepository billingKeyRepository;
+  private final PaymentRepository paymentRepository;
+  private final TossPaymentPort tossPaymentPort;
+  private final BillingKeyCipher billingKeyCipher;
+  private final PaymentAccessGuard accessGuard;
+  private final Clock clock;
+  private final TransactionTemplate transactionTemplate;
+
+  public SubscriptionService(
+      SubscriptionRepository subscriptionRepository,
+      PlanRepository planRepository,
+      BillingKeyRepository billingKeyRepository,
+      PaymentRepository paymentRepository,
+      TossPaymentPort tossPaymentPort,
+      BillingKeyCipher billingKeyCipher,
+      PaymentAccessGuard accessGuard,
+      Clock clock,
+      PlatformTransactionManager transactionManager) {
+    this.subscriptionRepository = subscriptionRepository;
+    this.planRepository = planRepository;
+    this.billingKeyRepository = billingKeyRepository;
+    this.paymentRepository = paymentRepository;
+    this.tossPaymentPort = tossPaymentPort;
+    this.billingKeyCipher = billingKeyCipher;
+    this.accessGuard = accessGuard;
+    this.clock = clock;
+    this.transactionTemplate = new TransactionTemplate(transactionManager);
+  }
+
+  @Transactional
+  public SubscriptionResult createSubscription(CreateSubscriptionCommand command) {
+    accessGuard.requireMember(command.workspaceId(), command.userId());
+    Plan plan =
+        planRepository
+            .findByPlanKey(command.planKey())
+            .orElseThrow(() -> new PlanNotFoundException(command.planKey()));
+
+    subscriptionRepository
+        .findCurrentByWorkspaceId(command.workspaceId())
+        .ifPresent(
+            existing -> {
+              throw new ActiveSubscriptionExistsException(command.workspaceId());
+            });
+
+    Subscription subscription = Subscription.create(command.workspaceId(), plan.getId());
+    subscription.assignCustomerKey(PaymentIdentifiers.customerKey(command.workspaceId()));
+    Subscription saved = subscriptionRepository.save(subscription);
+    return SubscriptionResult.from(saved, plan);
+  }
+
+  @Transactional(readOnly = true)
+  public SubscriptionResult getSubscription(Long workspaceId, Long userId) {
+    accessGuard.requireMember(workspaceId, userId);
+    Subscription subscription =
+        subscriptionRepository
+            .findCurrentByWorkspaceId(workspaceId)
+            .orElseThrow(() -> new SubscriptionNotFoundException(workspaceId));
+    Plan plan = requirePlan(subscription.getPlanId());
+    return SubscriptionResult.from(subscription, plan);
+  }
+
+  /** 구독 취소. INCOMPLETE는 즉시 해지, 그 외는 기간말 해지 예약 (U-005). */
+  @Transactional
+  public SubscriptionResult cancelSubscription(Long workspaceId, Long userId) {
+    accessGuard.requireMember(workspaceId, userId);
+    Subscription subscription =
+        subscriptionRepository
+            .findCurrentByWorkspaceId(workspaceId)
+            .orElseThrow(() -> new SubscriptionNotFoundException(workspaceId));
+
+    if (subscription.getStatus() == SubscriptionStatus.INCOMPLETE) {
+      subscription.cancel();
+    } else {
+      subscription.scheduleCancelAtPeriodEnd();
+    }
+    Subscription saved = subscriptionRepository.save(subscription);
+    return SubscriptionResult.from(saved, requirePlan(saved.getPlanId()));
+  }
+
+  /** billingKey 발급 + 첫 정기결제 + 구독 활성화 (Sequence 1). */
+  public BillingAuthorizationResult issueBillingKey(IssueBillingKeyCommand command) {
+    accessGuard.requireMember(command.workspaceId(), command.userId());
+
+    Subscription subscription =
+        inTx(
+            () ->
+                subscriptionRepository
+                    .findCurrentByWorkspaceId(command.workspaceId())
+                    .orElseThrow(() -> new SubscriptionNotFoundException(command.workspaceId())));
+    Plan plan = requirePlan(subscription.getPlanId());
+    String customerKey = subscription.getCustomerKey();
+
+    TossBillingKeyResult issued = tossPaymentPort.issueBillingKey(command.authKey(), customerKey);
+    byte[] encrypted = billingKeyCipher.encrypt(issued.billingKey());
+
+    BillingKey billingKey =
+        inTx(
+            () ->
+                billingKeyRepository.save(
+                    BillingKey.create(
+                        command.workspaceId(),
+                        customerKey,
+                        encrypted,
+                        issued.cardCompany(),
+                        issued.cardNumberMasked())));
+
+    OffsetDateTime periodStart = OffsetDateTime.now(clock);
+    OffsetDateTime periodEnd = plan.getBillingInterval().advance(periodStart);
+    String orderId = PaymentIdentifiers.orderId();
+    String periodKey = PaymentIdentifiers.periodKey(periodStart);
+
+    TossPaymentResult charge =
+        tossPaymentPort.executeBilling(
+            new TossBillingExecuteCommand(
+                issued.billingKey(), customerKey, plan.getAmount(), orderId, plan.getName()));
+
+    Subscription activated =
+        inTx(
+            () -> {
+              Subscription current =
+                  subscriptionRepository
+                      .findById(subscription.getId())
+                      .orElseThrow(() -> new SubscriptionNotFoundException(command.workspaceId()));
+              Payment payment =
+                  Payment.createRecurring(
+                      command.workspaceId(),
+                      current.getId(),
+                      orderId,
+                      plan.getAmount(),
+                      plan.getCurrency(),
+                      plan.getName(),
+                      periodKey,
+                      PaymentIdentifiers.idempotencyKey());
+              if (charge.isDone()) {
+                payment.complete(
+                    charge.paymentKey(),
+                    charge.method(),
+                    chargeApprovedAt(charge),
+                    charge.receiptUrl(),
+                    charge.maskedRawJson());
+                current.activate(periodStart, periodEnd, customerKey);
+              } else {
+                payment.markAborted(charge.maskedRawJson());
+              }
+              paymentRepository.save(payment);
+              return subscriptionRepository.save(current);
+            });
+
+    return new BillingAuthorizationResult(
+        SubscriptionResult.from(activated, plan), BillingKeySummary.from(billingKey));
+  }
+
+  private OffsetDateTime chargeApprovedAt(TossPaymentResult charge) {
+    return charge.approvedAt() != null ? charge.approvedAt() : OffsetDateTime.now(clock);
+  }
+
+  private Plan requirePlan(Long planId) {
+    return planRepository
+        .findById(planId)
+        .orElseThrow(() -> new PlanNotFoundException("id=" + planId));
+  }
+
+  private <T> T inTx(Supplier<T> callback) {
+    return transactionTemplate.execute(status -> callback.get());
+  }
+}

--- a/backend/src/main/java/com/init/payment/application/TossPayloadMasker.java
+++ b/backend/src/main/java/com/init/payment/application/TossPayloadMasker.java
@@ -1,0 +1,50 @@
+package com.init.payment.application;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.Set;
+
+/**
+ * Toss 응답/웹훅 페이로드에서 민감정보(billingKey/secretKey/authKey/전체 PAN)를 제거한다 (U-012). 저장(raw_response,
+ * webhook_event.payload)과 로깅 전 공통 적용한다.
+ */
+public final class TossPayloadMasker {
+
+  private static final Set<String> SENSITIVE_FIELDS = Set.of("billingKey", "secretKey", "authKey");
+
+  private TossPayloadMasker() {}
+
+  public static String mask(JsonNode node) {
+    if (node == null || node.isNull() || node.isMissingNode()) {
+      return null;
+    }
+    return maskNode(node.deepCopy()).toString();
+  }
+
+  private static JsonNode maskNode(JsonNode node) {
+    if (node instanceof ObjectNode objectNode) {
+      objectNode
+          .fieldNames()
+          .forEachRemaining(
+              field -> {
+                if (SENSITIVE_FIELDS.contains(field)) {
+                  objectNode.put(field, "***");
+                } else if ("number".equals(field) && objectNode.get(field).isTextual()) {
+                  objectNode.put(field, maskPan(objectNode.get(field).asText()));
+                } else {
+                  maskNode(objectNode.get(field));
+                }
+              });
+    } else if (node.isArray()) {
+      node.forEach(TossPayloadMasker::maskNode);
+    }
+    return node;
+  }
+
+  private static String maskPan(String pan) {
+    if (pan == null || pan.length() <= 4) {
+      return "****";
+    }
+    return "****-****-****-" + pan.substring(pan.length() - 4);
+  }
+}

--- a/backend/src/main/java/com/init/payment/application/exception/ActiveSubscriptionExistsException.java
+++ b/backend/src/main/java/com/init/payment/application/exception/ActiveSubscriptionExistsException.java
@@ -1,0 +1,9 @@
+package com.init.payment.application.exception;
+
+import com.init.shared.application.exception.DuplicateException;
+
+public class ActiveSubscriptionExistsException extends DuplicateException {
+  public ActiveSubscriptionExistsException(Long workspaceId) {
+    super("SUBSCRIPTION_ALREADY_EXISTS", "이미 진행 중인 구독이 있습니다. workspaceId=" + workspaceId);
+  }
+}

--- a/backend/src/main/java/com/init/payment/application/exception/BillingKeyNotFoundException.java
+++ b/backend/src/main/java/com/init/payment/application/exception/BillingKeyNotFoundException.java
@@ -1,0 +1,9 @@
+package com.init.payment.application.exception;
+
+import com.init.shared.application.exception.NotFoundException;
+
+public class BillingKeyNotFoundException extends NotFoundException {
+  public BillingKeyNotFoundException(Long workspaceId) {
+    super("BILLING_KEY_NOT_FOUND", "등록된 결제수단(billingKey)이 없습니다. workspaceId=" + workspaceId);
+  }
+}

--- a/backend/src/main/java/com/init/payment/application/exception/PaymentAmountMismatchException.java
+++ b/backend/src/main/java/com/init/payment/application/exception/PaymentAmountMismatchException.java
@@ -1,0 +1,10 @@
+package com.init.payment.application.exception;
+
+import com.init.shared.application.exception.BadRequestException;
+
+public class PaymentAmountMismatchException extends BadRequestException {
+  public PaymentAmountMismatchException(long expected, long actual) {
+    super(
+        "PAYMENT_AMOUNT_MISMATCH", "결제 금액이 일치하지 않습니다. expected=" + expected + ", actual=" + actual);
+  }
+}

--- a/backend/src/main/java/com/init/payment/application/exception/PaymentCancelNotAllowedException.java
+++ b/backend/src/main/java/com/init/payment/application/exception/PaymentCancelNotAllowedException.java
@@ -1,0 +1,9 @@
+package com.init.payment.application.exception;
+
+import com.init.shared.application.exception.BadRequestException;
+
+public class PaymentCancelNotAllowedException extends BadRequestException {
+  public PaymentCancelNotAllowedException(String message) {
+    super("PAYMENT_CANCEL_NOT_ALLOWED", message);
+  }
+}

--- a/backend/src/main/java/com/init/payment/application/exception/PaymentGatewayException.java
+++ b/backend/src/main/java/com/init/payment/application/exception/PaymentGatewayException.java
@@ -1,0 +1,15 @@
+package com.init.payment.application.exception;
+
+import com.init.shared.application.exception.BadGatewayException;
+
+/** Toss 게이트웨이 오류(5xx/timeout/통신 실패) (U-008). */
+public class PaymentGatewayException extends BadGatewayException {
+
+  public PaymentGatewayException(String message) {
+    super("PAYMENT_GATEWAY_ERROR", message);
+  }
+
+  public PaymentGatewayException(String message, Throwable cause) {
+    super("PAYMENT_GATEWAY_ERROR", message, cause);
+  }
+}

--- a/backend/src/main/java/com/init/payment/application/exception/PaymentNotFoundException.java
+++ b/backend/src/main/java/com/init/payment/application/exception/PaymentNotFoundException.java
@@ -1,0 +1,9 @@
+package com.init.payment.application.exception;
+
+import com.init.shared.application.exception.NotFoundException;
+
+public class PaymentNotFoundException extends NotFoundException {
+  public PaymentNotFoundException(String reference) {
+    super("PAYMENT_NOT_FOUND", "결제 내역을 찾을 수 없습니다. " + reference);
+  }
+}

--- a/backend/src/main/java/com/init/payment/application/exception/PaymentRejectedException.java
+++ b/backend/src/main/java/com/init/payment/application/exception/PaymentRejectedException.java
@@ -1,0 +1,15 @@
+package com.init.payment.application.exception;
+
+import com.init.shared.application.exception.BadRequestException;
+
+/** Toss가 4xx로 거절한 결제(카드 거절, 잘못된 요청 등) (U-008). */
+public class PaymentRejectedException extends BadRequestException {
+
+  public PaymentRejectedException(String message) {
+    super("PAYMENT_REJECTED", message);
+  }
+
+  public PaymentRejectedException(String message, Throwable cause) {
+    super("PAYMENT_REJECTED", message, cause);
+  }
+}

--- a/backend/src/main/java/com/init/payment/application/exception/PaymentWebhookUnauthorizedException.java
+++ b/backend/src/main/java/com/init/payment/application/exception/PaymentWebhookUnauthorizedException.java
@@ -1,0 +1,10 @@
+package com.init.payment.application.exception;
+
+import com.init.shared.application.exception.UnauthorizedException;
+
+/** Toss 웹훅 시크릿 헤더 불일치 (U-003). */
+public class PaymentWebhookUnauthorizedException extends UnauthorizedException {
+  public PaymentWebhookUnauthorizedException() {
+    super("PAYMENT_WEBHOOK_UNAUTHORIZED", "유효하지 않은 Toss webhook secret입니다.");
+  }
+}

--- a/backend/src/main/java/com/init/payment/application/exception/PaymentWorkspaceAccessDeniedException.java
+++ b/backend/src/main/java/com/init/payment/application/exception/PaymentWorkspaceAccessDeniedException.java
@@ -1,0 +1,9 @@
+package com.init.payment.application.exception;
+
+import com.init.shared.application.exception.UnauthorizedException;
+
+public class PaymentWorkspaceAccessDeniedException extends UnauthorizedException {
+  public PaymentWorkspaceAccessDeniedException() {
+    super("WORKSPACE_ACCESS_DENIED", "해당 워크스페이스의 결제를 관리할 권한이 없습니다.");
+  }
+}

--- a/backend/src/main/java/com/init/payment/application/exception/PaymentWorkspaceNotFoundException.java
+++ b/backend/src/main/java/com/init/payment/application/exception/PaymentWorkspaceNotFoundException.java
@@ -1,0 +1,9 @@
+package com.init.payment.application.exception;
+
+import com.init.shared.application.exception.NotFoundException;
+
+public class PaymentWorkspaceNotFoundException extends NotFoundException {
+  public PaymentWorkspaceNotFoundException(Long workspaceId) {
+    super("WORKSPACE_NOT_FOUND", "워크스페이스를 찾을 수 없습니다. id=" + workspaceId);
+  }
+}

--- a/backend/src/main/java/com/init/payment/application/exception/PlanNotFoundException.java
+++ b/backend/src/main/java/com/init/payment/application/exception/PlanNotFoundException.java
@@ -1,0 +1,9 @@
+package com.init.payment.application.exception;
+
+import com.init.shared.application.exception.NotFoundException;
+
+public class PlanNotFoundException extends NotFoundException {
+  public PlanNotFoundException(String planKey) {
+    super("PLAN_NOT_FOUND", "요금제를 찾을 수 없습니다. planKey=" + planKey);
+  }
+}

--- a/backend/src/main/java/com/init/payment/application/exception/SubscriptionNotFoundException.java
+++ b/backend/src/main/java/com/init/payment/application/exception/SubscriptionNotFoundException.java
@@ -1,0 +1,9 @@
+package com.init.payment.application.exception;
+
+import com.init.shared.application.exception.NotFoundException;
+
+public class SubscriptionNotFoundException extends NotFoundException {
+  public SubscriptionNotFoundException(Long workspaceId) {
+    super("SUBSCRIPTION_NOT_FOUND", "구독을 찾을 수 없습니다. workspaceId=" + workspaceId);
+  }
+}

--- a/backend/src/main/java/com/init/payment/application/package-info.java
+++ b/backend/src/main/java/com/init/payment/application/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Payment bounded context - application layer.
+ *
+ * <p>구독/결제 유스케이스 오케스트레이션, 정기결제 스케줄러, 웹훅 처리, 외부 연동 port.
+ */
+package com.init.payment.application;

--- a/backend/src/main/java/com/init/payment/application/port/BillingKeyCipher.java
+++ b/backend/src/main/java/com/init/payment/application/port/BillingKeyCipher.java
@@ -1,0 +1,12 @@
+package com.init.payment.application.port;
+
+/**
+ * billingKey 암복호화 port (U-002). 운영 구현은 PostgreSQL pgcrypto 네이티브 쿼리를 사용한다. 평문 billingKey는 호출부 메모리에서만
+ * 일시 사용하고 도메인/로그/응답에 노출하지 않는다.
+ */
+public interface BillingKeyCipher {
+
+  byte[] encrypt(String plaintext);
+
+  String decrypt(byte[] ciphertext);
+}

--- a/backend/src/main/java/com/init/payment/application/port/TossBillingExecuteCommand.java
+++ b/backend/src/main/java/com/init/payment/application/port/TossBillingExecuteCommand.java
@@ -1,0 +1,4 @@
+package com.init.payment.application.port;
+
+public record TossBillingExecuteCommand(
+    String billingKey, String customerKey, long amount, String orderId, String orderName) {}

--- a/backend/src/main/java/com/init/payment/application/port/TossBillingKeyResult.java
+++ b/backend/src/main/java/com/init/payment/application/port/TossBillingKeyResult.java
@@ -1,0 +1,12 @@
+package com.init.payment.application.port;
+
+/**
+ * billingKey 발급 결과. {@code billingKey}는 평문이며 호출부에서 즉시 암호화 저장 후 폐기한다. {@code maskedRawJson}은
+ * billingKey가 제거된 마스킹 응답이다 (U-012).
+ */
+public record TossBillingKeyResult(
+    String billingKey,
+    String customerKey,
+    String cardCompany,
+    String cardNumberMasked,
+    String maskedRawJson) {}

--- a/backend/src/main/java/com/init/payment/application/port/TossPaymentPort.java
+++ b/backend/src/main/java/com/init/payment/application/port/TossPaymentPort.java
@@ -1,0 +1,23 @@
+package com.init.payment.application.port;
+
+/**
+ * 토스페이먼츠 v2 서버 API port. 운영 구현(TossPaymentClient)은 Basic auth + Idempotency-Key 헤더로 호출하며
+ * secretKey/billingKey를 로그·응답에 노출하지 않는다. 게이트웨이 오류는 PaymentGatewayException으로 변환한다 (U-008).
+ */
+public interface TossPaymentPort {
+
+  /** authKey -> billingKey 발급. */
+  TossBillingKeyResult issueBillingKey(String authKey, String customerKey);
+
+  /** 일회성 결제 승인. */
+  TossPaymentResult confirmPayment(String paymentKey, String orderId, long amount);
+
+  /** billingKey 기반 정기결제 실행. */
+  TossPaymentResult executeBilling(TossBillingExecuteCommand command);
+
+  /** 결제 취소/부분환불. cancelAmount가 null이면 전액 취소. */
+  TossPaymentResult cancelPayment(String paymentKey, String cancelReason, Long cancelAmount);
+
+  /** 웹훅 권위 상태 확정을 위한 결제 재조회 (U-003). */
+  TossPaymentResult getPayment(String paymentKey);
+}

--- a/backend/src/main/java/com/init/payment/application/port/TossPaymentPort.java
+++ b/backend/src/main/java/com/init/payment/application/port/TossPaymentPort.java
@@ -15,8 +15,9 @@ public interface TossPaymentPort {
   /** billingKey 기반 정기결제 실행. */
   TossPaymentResult executeBilling(TossBillingExecuteCommand command);
 
-  /** 결제 취소/부분환불. cancelAmount가 null이면 전액 취소. */
-  TossPaymentResult cancelPayment(String paymentKey, String cancelReason, Long cancelAmount);
+  /** 결제 취소/부분환불. cancelAmount가 null이면 전액 취소. cancelIdempotencyKey는 시도별 UUID. */
+  TossPaymentResult cancelPayment(
+      String paymentKey, String cancelReason, Long cancelAmount, String cancelIdempotencyKey);
 
   /** 웹훅 권위 상태 확정을 위한 결제 재조회 (U-003). */
   TossPaymentResult getPayment(String paymentKey);

--- a/backend/src/main/java/com/init/payment/application/port/TossPaymentResult.java
+++ b/backend/src/main/java/com/init/payment/application/port/TossPaymentResult.java
@@ -1,0 +1,28 @@
+package com.init.payment.application.port;
+
+import java.time.OffsetDateTime;
+
+/** Toss 결제 승인/취소/조회 결과. {@code maskedRawJson}은 민감정보가 제거된 응답이다 (U-012). */
+public record TossPaymentResult(
+    String paymentKey,
+    String orderId,
+    long totalAmount,
+    String status,
+    String method,
+    OffsetDateTime approvedAt,
+    String receiptUrl,
+    String transactionKey,
+    String maskedRawJson) {
+
+  public boolean isDone() {
+    return "DONE".equals(status);
+  }
+
+  public boolean isCanceled() {
+    return "CANCELED".equals(status);
+  }
+
+  public boolean isPartialCanceled() {
+    return "PARTIAL_CANCELED".equals(status);
+  }
+}

--- a/backend/src/main/java/com/init/payment/application/port/WorkspaceMembershipPort.java
+++ b/backend/src/main/java/com/init/payment/application/port/WorkspaceMembershipPort.java
@@ -1,0 +1,11 @@
+package com.init.payment.application.port;
+
+import java.util.Set;
+
+/** 결제 BC가 워크스페이스 멤버십 인가를 확인하기 위한 anti-corruption port (U-015). */
+public interface WorkspaceMembershipPort {
+
+  boolean existsById(Long workspaceId);
+
+  boolean hasAnyRole(Long workspaceId, Long userId, Set<String> roles);
+}

--- a/backend/src/main/java/com/init/payment/domain/model/BillingInterval.java
+++ b/backend/src/main/java/com/init/payment/domain/model/BillingInterval.java
@@ -1,0 +1,15 @@
+package com.init.payment.domain.model;
+
+import java.time.OffsetDateTime;
+
+public enum BillingInterval {
+  MONTH,
+  YEAR;
+
+  public OffsetDateTime advance(OffsetDateTime from) {
+    return switch (this) {
+      case MONTH -> from.plusMonths(1);
+      case YEAR -> from.plusYears(1);
+    };
+  }
+}

--- a/backend/src/main/java/com/init/payment/domain/model/BillingKey.java
+++ b/backend/src/main/java/com/init/payment/domain/model/BillingKey.java
@@ -1,0 +1,135 @@
+package com.init.payment.domain.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import java.time.OffsetDateTime;
+
+/**
+ * billingKey aggregate. {@code billingKeyEncrypted}는 pgcrypto로 암호화된 bytea만 보유한다 (U-002). 평문
+ * billingKey는 도메인 객체에 저장하지 않으며, 정기결제 호출 직전 cipher로 복호화하여 메모리에서만 일시 사용한다.
+ */
+@Entity
+@Table(name = "billing_key", schema = "payment")
+public class BillingKey {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "workspace_id", nullable = false)
+  private Long workspaceId;
+
+  @Column(name = "customer_key", nullable = false)
+  private String customerKey;
+
+  @Column(name = "billing_key_encrypted", nullable = false)
+  private byte[] billingKeyEncrypted;
+
+  @Column(name = "card_company")
+  private String cardCompany;
+
+  @Column(name = "card_number_masked")
+  private String cardNumberMasked;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "status", nullable = false)
+  private BillingKeyStatus status;
+
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private OffsetDateTime createdAt;
+
+  @Column(name = "updated_at", nullable = false)
+  private OffsetDateTime updatedAt;
+
+  protected BillingKey() {}
+
+  public static BillingKey create(
+      Long workspaceId,
+      String customerKey,
+      byte[] billingKeyEncrypted,
+      String cardCompany,
+      String cardNumberMasked) {
+    if (workspaceId == null) {
+      throw new IllegalArgumentException("workspaceId must not be null");
+    }
+    if (customerKey == null || customerKey.isBlank()) {
+      throw new IllegalArgumentException("customerKey must not be blank");
+    }
+    if (billingKeyEncrypted == null || billingKeyEncrypted.length == 0) {
+      throw new IllegalArgumentException("billingKeyEncrypted must not be empty");
+    }
+
+    BillingKey billingKey = new BillingKey();
+    billingKey.workspaceId = workspaceId;
+    billingKey.customerKey = customerKey;
+    billingKey.billingKeyEncrypted = billingKeyEncrypted.clone();
+    billingKey.cardCompany = cardCompany;
+    billingKey.cardNumberMasked = cardNumberMasked;
+    billingKey.status = BillingKeyStatus.ACTIVE;
+    return billingKey;
+  }
+
+  public void revoke() {
+    this.status = BillingKeyStatus.DELETED;
+  }
+
+  public boolean isActive() {
+    return status == BillingKeyStatus.ACTIVE;
+  }
+
+  public byte[] getBillingKeyEncrypted() {
+    return billingKeyEncrypted.clone();
+  }
+
+  @PrePersist
+  protected void onPersist() {
+    OffsetDateTime now = OffsetDateTime.now();
+    this.createdAt = now;
+    this.updatedAt = now;
+  }
+
+  @PreUpdate
+  protected void onUpdate() {
+    this.updatedAt = OffsetDateTime.now();
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public Long getWorkspaceId() {
+    return workspaceId;
+  }
+
+  public String getCustomerKey() {
+    return customerKey;
+  }
+
+  public String getCardCompany() {
+    return cardCompany;
+  }
+
+  public String getCardNumberMasked() {
+    return cardNumberMasked;
+  }
+
+  public BillingKeyStatus getStatus() {
+    return status;
+  }
+
+  public OffsetDateTime getCreatedAt() {
+    return createdAt;
+  }
+
+  public OffsetDateTime getUpdatedAt() {
+    return updatedAt;
+  }
+}

--- a/backend/src/main/java/com/init/payment/domain/model/BillingKeyStatus.java
+++ b/backend/src/main/java/com/init/payment/domain/model/BillingKeyStatus.java
@@ -1,0 +1,7 @@
+package com.init.payment.domain.model;
+
+/** billingKey 상태값 (U-013: 최소 상태). */
+public enum BillingKeyStatus {
+  ACTIVE,
+  DELETED
+}

--- a/backend/src/main/java/com/init/payment/domain/model/Money.java
+++ b/backend/src/main/java/com/init/payment/domain/model/Money.java
@@ -1,0 +1,28 @@
+package com.init.payment.domain.model;
+
+/** 금액 Value Object. 음수 금액과 빈 통화를 거부한다. */
+public record Money(long amount, String currency) {
+
+  public static final String DEFAULT_CURRENCY = "KRW";
+
+  public Money {
+    if (amount < 0) {
+      throw new IllegalArgumentException("amount must not be negative: " + amount);
+    }
+    if (currency == null || currency.isBlank()) {
+      throw new IllegalArgumentException("currency must not be blank");
+    }
+  }
+
+  public static Money of(long amount, String currency) {
+    return new Money(amount, currency);
+  }
+
+  public static Money krw(long amount) {
+    return new Money(amount, DEFAULT_CURRENCY);
+  }
+
+  public boolean isSameAmount(long other) {
+    return this.amount == other;
+  }
+}

--- a/backend/src/main/java/com/init/payment/domain/model/Payment.java
+++ b/backend/src/main/java/com/init/payment/domain/model/Payment.java
@@ -1,0 +1,252 @@
+package com.init.payment.domain.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import java.time.OffsetDateTime;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+@Entity
+@Table(name = "payment", schema = "payment")
+public class Payment {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "order_id", nullable = false, unique = true)
+  private String orderId;
+
+  @Column(name = "payment_key")
+  private String paymentKey;
+
+  @Column(name = "workspace_id", nullable = false)
+  private Long workspaceId;
+
+  @Column(name = "subscription_id")
+  private Long subscriptionId;
+
+  @Column(name = "amount", nullable = false)
+  private long amount;
+
+  @Column(name = "currency", nullable = false)
+  private String currency;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "status", nullable = false)
+  private PaymentStatus status;
+
+  @Column(name = "method")
+  private String method;
+
+  @Column(name = "order_name")
+  private String orderName;
+
+  @Column(name = "billing_period_key")
+  private String billingPeriodKey;
+
+  @Column(name = "approved_at")
+  private OffsetDateTime approvedAt;
+
+  @Column(name = "receipt_url")
+  private String receiptUrl;
+
+  @JdbcTypeCode(SqlTypes.JSON)
+  @Column(name = "raw_response", columnDefinition = "jsonb")
+  private String rawResponse;
+
+  @Column(name = "idempotency_key")
+  private String idempotencyKey;
+
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private OffsetDateTime createdAt;
+
+  @Column(name = "updated_at", nullable = false)
+  private OffsetDateTime updatedAt;
+
+  protected Payment() {}
+
+  /** 위젯 일회성 결제 주문(READY). confirm 시 기대 금액 검증 기준이 된다. */
+  public static Payment createOrder(
+      Long workspaceId,
+      Long subscriptionId,
+      String orderId,
+      long amount,
+      String currency,
+      String orderName) {
+    Payment payment = baseOrder(workspaceId, subscriptionId, orderId, amount, currency, orderName);
+    payment.status = PaymentStatus.READY;
+    return payment;
+  }
+
+  /** 정기결제 시도(IN_PROGRESS). billingPeriodKey로 동주기 중복청구를 차단한다 (U-011). */
+  public static Payment createRecurring(
+      Long workspaceId,
+      Long subscriptionId,
+      String orderId,
+      long amount,
+      String currency,
+      String orderName,
+      String billingPeriodKey,
+      String idempotencyKey) {
+    Payment payment = baseOrder(workspaceId, subscriptionId, orderId, amount, currency, orderName);
+    payment.status = PaymentStatus.IN_PROGRESS;
+    payment.billingPeriodKey = billingPeriodKey;
+    payment.idempotencyKey = idempotencyKey;
+    return payment;
+  }
+
+  private static Payment baseOrder(
+      Long workspaceId,
+      Long subscriptionId,
+      String orderId,
+      long amount,
+      String currency,
+      String orderName) {
+    if (workspaceId == null) {
+      throw new IllegalArgumentException("workspaceId must not be null");
+    }
+    if (orderId == null || orderId.isBlank()) {
+      throw new IllegalArgumentException("orderId must not be blank");
+    }
+
+    Money money = Money.of(amount, currency);
+    Payment payment = new Payment();
+    payment.amount = money.amount();
+    payment.currency = money.currency();
+    payment.workspaceId = workspaceId;
+    payment.subscriptionId = subscriptionId;
+    payment.orderId = orderId;
+    payment.orderName = orderName;
+    return payment;
+  }
+
+  /** 결제 승인 완료. READY/IN_PROGRESS -> DONE. */
+  public void complete(
+      String paymentKey,
+      String method,
+      OffsetDateTime approvedAt,
+      String receiptUrl,
+      String rawResponse) {
+    this.status = PaymentStatus.DONE;
+    this.paymentKey = paymentKey;
+    this.method = method;
+    this.approvedAt = approvedAt;
+    this.receiptUrl = receiptUrl;
+    this.rawResponse = rawResponse;
+  }
+
+  /** 결제 실패/중단. -> ABORTED. */
+  public void markAborted(String rawResponse) {
+    this.status = PaymentStatus.ABORTED;
+    this.rawResponse = rawResponse;
+  }
+
+  /** 전액 취소. DONE -> CANCELED. */
+  public void markCanceled(String rawResponse) {
+    this.status = PaymentStatus.CANCELED;
+    this.rawResponse = rawResponse;
+  }
+
+  /** 부분 취소. DONE -> PARTIAL_CANCELED. */
+  public void markPartialCanceled(String rawResponse) {
+    this.status = PaymentStatus.PARTIAL_CANCELED;
+    this.rawResponse = rawResponse;
+  }
+
+  public boolean isDone() {
+    return status == PaymentStatus.DONE;
+  }
+
+  public boolean matchesAmount(long requested) {
+    return this.amount == requested;
+  }
+
+  public Money money() {
+    return Money.of(amount, currency);
+  }
+
+  @PrePersist
+  protected void onPersist() {
+    OffsetDateTime now = OffsetDateTime.now();
+    this.createdAt = now;
+    this.updatedAt = now;
+  }
+
+  @PreUpdate
+  protected void onUpdate() {
+    this.updatedAt = OffsetDateTime.now();
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public String getOrderId() {
+    return orderId;
+  }
+
+  public String getPaymentKey() {
+    return paymentKey;
+  }
+
+  public Long getWorkspaceId() {
+    return workspaceId;
+  }
+
+  public Long getSubscriptionId() {
+    return subscriptionId;
+  }
+
+  public long getAmount() {
+    return amount;
+  }
+
+  public String getCurrency() {
+    return currency;
+  }
+
+  public PaymentStatus getStatus() {
+    return status;
+  }
+
+  public String getMethod() {
+    return method;
+  }
+
+  public String getOrderName() {
+    return orderName;
+  }
+
+  public String getBillingPeriodKey() {
+    return billingPeriodKey;
+  }
+
+  public OffsetDateTime getApprovedAt() {
+    return approvedAt;
+  }
+
+  public String getReceiptUrl() {
+    return receiptUrl;
+  }
+
+  public String getIdempotencyKey() {
+    return idempotencyKey;
+  }
+
+  public OffsetDateTime getCreatedAt() {
+    return createdAt;
+  }
+
+  public OffsetDateTime getUpdatedAt() {
+    return updatedAt;
+  }
+}

--- a/backend/src/main/java/com/init/payment/domain/model/Payment.java
+++ b/backend/src/main/java/com/init/payment/domain/model/Payment.java
@@ -97,6 +97,12 @@ public class Payment {
       String orderName,
       String billingPeriodKey,
       String idempotencyKey) {
+    if (billingPeriodKey == null || billingPeriodKey.isBlank()) {
+      throw new IllegalArgumentException("billingPeriodKey must not be blank");
+    }
+    if (idempotencyKey == null || idempotencyKey.isBlank()) {
+      throw new IllegalArgumentException("idempotencyKey must not be blank");
+    }
     Payment payment = baseOrder(workspaceId, subscriptionId, orderId, amount, currency, orderName);
     payment.status = PaymentStatus.IN_PROGRESS;
     payment.billingPeriodKey = billingPeriodKey;
@@ -136,6 +142,9 @@ public class Payment {
       OffsetDateTime approvedAt,
       String receiptUrl,
       String rawResponse) {
+    if (status != PaymentStatus.READY && status != PaymentStatus.IN_PROGRESS) {
+      throw new IllegalStateException("complete() 선행 상태가 올바르지 않습니다: " + status);
+    }
     this.status = PaymentStatus.DONE;
     this.paymentKey = paymentKey;
     this.method = method;
@@ -144,20 +153,29 @@ public class Payment {
     this.rawResponse = rawResponse;
   }
 
-  /** 결제 실패/중단. -> ABORTED. */
+  /** 결제 실패/중단. READY/IN_PROGRESS -> ABORTED. */
   public void markAborted(String rawResponse) {
+    if (status != PaymentStatus.READY && status != PaymentStatus.IN_PROGRESS) {
+      throw new IllegalStateException("markAborted() 선행 상태가 올바르지 않습니다: " + status);
+    }
     this.status = PaymentStatus.ABORTED;
     this.rawResponse = rawResponse;
   }
 
   /** 전액 취소. DONE -> CANCELED. */
   public void markCanceled(String rawResponse) {
+    if (status != PaymentStatus.DONE) {
+      throw new IllegalStateException("markCanceled() 선행 상태가 올바르지 않습니다: " + status);
+    }
     this.status = PaymentStatus.CANCELED;
     this.rawResponse = rawResponse;
   }
 
-  /** 부분 취소. DONE -> PARTIAL_CANCELED. */
+  /** 부분 취소. DONE/PARTIAL_CANCELED -> PARTIAL_CANCELED. */
   public void markPartialCanceled(String rawResponse) {
+    if (status != PaymentStatus.DONE && status != PaymentStatus.PARTIAL_CANCELED) {
+      throw new IllegalStateException("markPartialCanceled() 선행 상태가 올바르지 않습니다: " + status);
+    }
     this.status = PaymentStatus.PARTIAL_CANCELED;
     this.rawResponse = rawResponse;
   }

--- a/backend/src/main/java/com/init/payment/domain/model/PaymentCancel.java
+++ b/backend/src/main/java/com/init/payment/domain/model/PaymentCancel.java
@@ -29,13 +29,20 @@ public class PaymentCancel {
   @Column(name = "transaction_key")
   private String transactionKey;
 
+  @Column(name = "idempotency_key")
+  private String idempotencyKey;
+
   @Column(name = "canceled_at", nullable = false, updatable = false)
   private OffsetDateTime canceledAt;
 
   protected PaymentCancel() {}
 
   public static PaymentCancel create(
-      Long paymentId, long cancelAmount, String reason, String transactionKey) {
+      Long paymentId,
+      long cancelAmount,
+      String reason,
+      String transactionKey,
+      String idempotencyKey) {
     if (paymentId == null) {
       throw new IllegalArgumentException("paymentId must not be null");
     }
@@ -48,6 +55,7 @@ public class PaymentCancel {
     cancel.cancelAmount = cancelAmount;
     cancel.reason = reason;
     cancel.transactionKey = transactionKey;
+    cancel.idempotencyKey = idempotencyKey;
     return cancel;
   }
 
@@ -74,6 +82,10 @@ public class PaymentCancel {
 
   public String getTransactionKey() {
     return transactionKey;
+  }
+
+  public String getIdempotencyKey() {
+    return idempotencyKey;
   }
 
   public OffsetDateTime getCanceledAt() {

--- a/backend/src/main/java/com/init/payment/domain/model/PaymentCancel.java
+++ b/backend/src/main/java/com/init/payment/domain/model/PaymentCancel.java
@@ -1,0 +1,82 @@
+package com.init.payment.domain.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "payment_cancel", schema = "payment")
+public class PaymentCancel {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "payment_id", nullable = false)
+  private Long paymentId;
+
+  @Column(name = "cancel_amount", nullable = false)
+  private long cancelAmount;
+
+  @Column(name = "reason")
+  private String reason;
+
+  @Column(name = "transaction_key")
+  private String transactionKey;
+
+  @Column(name = "canceled_at", nullable = false, updatable = false)
+  private OffsetDateTime canceledAt;
+
+  protected PaymentCancel() {}
+
+  public static PaymentCancel create(
+      Long paymentId, long cancelAmount, String reason, String transactionKey) {
+    if (paymentId == null) {
+      throw new IllegalArgumentException("paymentId must not be null");
+    }
+    if (cancelAmount <= 0) {
+      throw new IllegalArgumentException("cancelAmount must be positive: " + cancelAmount);
+    }
+
+    PaymentCancel cancel = new PaymentCancel();
+    cancel.paymentId = paymentId;
+    cancel.cancelAmount = cancelAmount;
+    cancel.reason = reason;
+    cancel.transactionKey = transactionKey;
+    return cancel;
+  }
+
+  @PrePersist
+  protected void onPersist() {
+    this.canceledAt = OffsetDateTime.now();
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public Long getPaymentId() {
+    return paymentId;
+  }
+
+  public long getCancelAmount() {
+    return cancelAmount;
+  }
+
+  public String getReason() {
+    return reason;
+  }
+
+  public String getTransactionKey() {
+    return transactionKey;
+  }
+
+  public OffsetDateTime getCanceledAt() {
+    return canceledAt;
+  }
+}

--- a/backend/src/main/java/com/init/payment/domain/model/PaymentStatus.java
+++ b/backend/src/main/java/com/init/payment/domain/model/PaymentStatus.java
@@ -1,0 +1,20 @@
+package com.init.payment.domain.model;
+
+/** Toss v2 결제 status와 1:1 매핑 (U-009). */
+public enum PaymentStatus {
+  READY,
+  IN_PROGRESS,
+  DONE,
+  CANCELED,
+  PARTIAL_CANCELED,
+  ABORTED,
+  EXPIRED;
+
+  public boolean isDone() {
+    return this == DONE;
+  }
+
+  public boolean isCanceled() {
+    return this == CANCELED || this == PARTIAL_CANCELED;
+  }
+}

--- a/backend/src/main/java/com/init/payment/domain/model/Plan.java
+++ b/backend/src/main/java/com/init/payment/domain/model/Plan.java
@@ -1,0 +1,126 @@
+package com.init.payment.domain.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "plan", schema = "payment")
+public class Plan {
+
+  public static final String STATUS_ACTIVE = "ACTIVE";
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "plan_key", nullable = false, unique = true)
+  private String planKey;
+
+  @Column(name = "name", nullable = false)
+  private String name;
+
+  @Column(name = "amount", nullable = false)
+  private long amount;
+
+  @Column(name = "currency", nullable = false)
+  private String currency;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "bill_interval", nullable = false)
+  private BillingInterval billingInterval;
+
+  @Column(name = "status", nullable = false)
+  private String status;
+
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private OffsetDateTime createdAt;
+
+  @Column(name = "updated_at", nullable = false)
+  private OffsetDateTime updatedAt;
+
+  protected Plan() {}
+
+  public static Plan create(
+      String planKey, String name, long amount, String currency, BillingInterval billingInterval) {
+    if (planKey == null || planKey.isBlank()) {
+      throw new IllegalArgumentException("planKey must not be blank");
+    }
+    if (name == null || name.isBlank()) {
+      throw new IllegalArgumentException("name must not be blank");
+    }
+    if (billingInterval == null) {
+      throw new IllegalArgumentException("billingInterval must not be null");
+    }
+    Money money = Money.of(amount, currency);
+
+    Plan plan = new Plan();
+    plan.planKey = planKey;
+    plan.name = name;
+    plan.amount = money.amount();
+    plan.currency = money.currency();
+    plan.billingInterval = billingInterval;
+    plan.status = STATUS_ACTIVE;
+    return plan;
+  }
+
+  public Money price() {
+    return Money.of(amount, currency);
+  }
+
+  @PrePersist
+  protected void onPersist() {
+    OffsetDateTime now = OffsetDateTime.now();
+    this.createdAt = now;
+    this.updatedAt = now;
+  }
+
+  @PreUpdate
+  protected void onUpdate() {
+    this.updatedAt = OffsetDateTime.now();
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public String getPlanKey() {
+    return planKey;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public long getAmount() {
+    return amount;
+  }
+
+  public String getCurrency() {
+    return currency;
+  }
+
+  public BillingInterval getBillingInterval() {
+    return billingInterval;
+  }
+
+  public String getStatus() {
+    return status;
+  }
+
+  public OffsetDateTime getCreatedAt() {
+    return createdAt;
+  }
+
+  public OffsetDateTime getUpdatedAt() {
+    return updatedAt;
+  }
+}

--- a/backend/src/main/java/com/init/payment/domain/model/Subscription.java
+++ b/backend/src/main/java/com/init/payment/domain/model/Subscription.java
@@ -80,11 +80,17 @@ public class Subscription {
     if (customerKey == null || customerKey.isBlank()) {
       throw new IllegalArgumentException("customerKey must not be blank");
     }
+    if (this.customerKey != null && !this.customerKey.equals(customerKey)) {
+      throw new IllegalStateException("customerKey를 다른 값으로 재설정할 수 없습니다.");
+    }
     this.customerKey = customerKey;
   }
 
   /** 첫 결제 성공 시 구독 활성화. INCOMPLETE/PAST_DUE -> ACTIVE. */
   public void activate(OffsetDateTime periodStart, OffsetDateTime periodEnd, String customerKey) {
+    if (periodStart == null || periodEnd == null || !periodEnd.isAfter(periodStart)) {
+      throw new IllegalArgumentException("periodEnd는 periodStart 이후여야 합니다.");
+    }
     if (status == SubscriptionStatus.CANCELED) {
       throw new IllegalStateException("취소된 구독은 활성화할 수 없습니다.");
     }
@@ -100,6 +106,9 @@ public class Subscription {
 
   /** 정기결제 성공으로 다음 주기로 갱신. ACTIVE 유지. */
   public void renew(OffsetDateTime periodStart, OffsetDateTime periodEnd) {
+    if (periodStart == null || periodEnd == null || !periodEnd.isAfter(periodStart)) {
+      throw new IllegalArgumentException("periodEnd는 periodStart 이후여야 합니다.");
+    }
     this.status = SubscriptionStatus.ACTIVE;
     this.currentPeriodStart = periodStart;
     this.currentPeriodEnd = periodEnd;
@@ -127,8 +136,8 @@ public class Subscription {
 
   /** 기간말 해지 예약 (U-005). ACTIVE 유지, 기간 종료 시 스케줄러가 해지. */
   public void scheduleCancelAtPeriodEnd() {
-    if (status == SubscriptionStatus.CANCELED) {
-      throw new IllegalStateException("이미 해지된 구독입니다.");
+    if (status != SubscriptionStatus.ACTIVE) {
+      throw new IllegalStateException("기간말 해지 예약은 ACTIVE 구독에만 가능합니다: " + status);
     }
     this.cancelAtPeriodEnd = true;
   }

--- a/backend/src/main/java/com/init/payment/domain/model/Subscription.java
+++ b/backend/src/main/java/com/init/payment/domain/model/Subscription.java
@@ -1,0 +1,203 @@
+package com.init.payment.domain.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "subscription", schema = "payment")
+public class Subscription {
+
+  /** 초기 실패 1회 + 일 1회 재시도 3회 = 4회차 실패 시 해지 (U-004). */
+  public static final int MAX_RECURRING_ATTEMPTS = 4;
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "workspace_id", nullable = false)
+  private Long workspaceId;
+
+  @Column(name = "plan_id", nullable = false)
+  private Long planId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "status", nullable = false)
+  private SubscriptionStatus status;
+
+  @Column(name = "current_period_start")
+  private OffsetDateTime currentPeriodStart;
+
+  @Column(name = "current_period_end")
+  private OffsetDateTime currentPeriodEnd;
+
+  @Column(name = "customer_key")
+  private String customerKey;
+
+  @Column(name = "cancel_at_period_end", nullable = false)
+  private boolean cancelAtPeriodEnd;
+
+  @Column(name = "failed_attempt_count", nullable = false)
+  private int failedAttemptCount;
+
+  @Column(name = "next_retry_at")
+  private OffsetDateTime nextRetryAt;
+
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private OffsetDateTime createdAt;
+
+  @Column(name = "updated_at", nullable = false)
+  private OffsetDateTime updatedAt;
+
+  protected Subscription() {}
+
+  public static Subscription create(Long workspaceId, Long planId) {
+    if (workspaceId == null) {
+      throw new IllegalArgumentException("workspaceId must not be null");
+    }
+    if (planId == null) {
+      throw new IllegalArgumentException("planId must not be null");
+    }
+    Subscription subscription = new Subscription();
+    subscription.workspaceId = workspaceId;
+    subscription.planId = planId;
+    subscription.status = SubscriptionStatus.INCOMPLETE;
+    subscription.cancelAtPeriodEnd = false;
+    subscription.failedAttemptCount = 0;
+    return subscription;
+  }
+
+  /** 워크스페이스 단위 customerKey 부여 (U-006). 최초 1회 생성 후 재사용. */
+  public void assignCustomerKey(String customerKey) {
+    if (customerKey == null || customerKey.isBlank()) {
+      throw new IllegalArgumentException("customerKey must not be blank");
+    }
+    this.customerKey = customerKey;
+  }
+
+  /** 첫 결제 성공 시 구독 활성화. INCOMPLETE/PAST_DUE -> ACTIVE. */
+  public void activate(OffsetDateTime periodStart, OffsetDateTime periodEnd, String customerKey) {
+    if (status == SubscriptionStatus.CANCELED) {
+      throw new IllegalStateException("취소된 구독은 활성화할 수 없습니다.");
+    }
+    this.status = SubscriptionStatus.ACTIVE;
+    this.currentPeriodStart = periodStart;
+    this.currentPeriodEnd = periodEnd;
+    if (customerKey != null) {
+      this.customerKey = customerKey;
+    }
+    this.failedAttemptCount = 0;
+    this.nextRetryAt = null;
+  }
+
+  /** 정기결제 성공으로 다음 주기로 갱신. ACTIVE 유지. */
+  public void renew(OffsetDateTime periodStart, OffsetDateTime periodEnd) {
+    this.status = SubscriptionStatus.ACTIVE;
+    this.currentPeriodStart = periodStart;
+    this.currentPeriodEnd = periodEnd;
+    this.failedAttemptCount = 0;
+    this.nextRetryAt = null;
+  }
+
+  /** PAST_DUE 상태에서 재시도 성공으로 복구. */
+  public void recover(OffsetDateTime periodStart, OffsetDateTime periodEnd) {
+    renew(periodStart, periodEnd);
+  }
+
+  /** 정기결제 실패. ACTIVE/PAST_DUE -> PAST_DUE, 실패 카운트 증가. */
+  public void markPastDue(OffsetDateTime nextRetryAt) {
+    this.status = SubscriptionStatus.PAST_DUE;
+    this.failedAttemptCount += 1;
+    this.nextRetryAt = nextRetryAt;
+  }
+
+  /** 사용자 취소 또는 재시도 소진으로 즉시 해지. */
+  public void cancel() {
+    this.status = SubscriptionStatus.CANCELED;
+    this.nextRetryAt = null;
+  }
+
+  /** 기간말 해지 예약 (U-005). ACTIVE 유지, 기간 종료 시 스케줄러가 해지. */
+  public void scheduleCancelAtPeriodEnd() {
+    if (status == SubscriptionStatus.CANCELED) {
+      throw new IllegalStateException("이미 해지된 구독입니다.");
+    }
+    this.cancelAtPeriodEnd = true;
+  }
+
+  public boolean isRetryExhausted() {
+    return failedAttemptCount >= MAX_RECURRING_ATTEMPTS;
+  }
+
+  public boolean isActive() {
+    return status == SubscriptionStatus.ACTIVE;
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public Long getWorkspaceId() {
+    return workspaceId;
+  }
+
+  public Long getPlanId() {
+    return planId;
+  }
+
+  public SubscriptionStatus getStatus() {
+    return status;
+  }
+
+  public OffsetDateTime getCurrentPeriodStart() {
+    return currentPeriodStart;
+  }
+
+  public OffsetDateTime getCurrentPeriodEnd() {
+    return currentPeriodEnd;
+  }
+
+  public String getCustomerKey() {
+    return customerKey;
+  }
+
+  public boolean isCancelAtPeriodEnd() {
+    return cancelAtPeriodEnd;
+  }
+
+  public int getFailedAttemptCount() {
+    return failedAttemptCount;
+  }
+
+  public OffsetDateTime getNextRetryAt() {
+    return nextRetryAt;
+  }
+
+  public OffsetDateTime getCreatedAt() {
+    return createdAt;
+  }
+
+  public OffsetDateTime getUpdatedAt() {
+    return updatedAt;
+  }
+
+  @PrePersist
+  protected void onPersist() {
+    OffsetDateTime now = OffsetDateTime.now();
+    this.createdAt = now;
+    this.updatedAt = now;
+  }
+
+  @PreUpdate
+  protected void onUpdate() {
+    this.updatedAt = OffsetDateTime.now();
+  }
+}

--- a/backend/src/main/java/com/init/payment/domain/model/SubscriptionStatus.java
+++ b/backend/src/main/java/com/init/payment/domain/model/SubscriptionStatus.java
@@ -1,0 +1,16 @@
+package com.init.payment.domain.model;
+
+public enum SubscriptionStatus {
+  INCOMPLETE,
+  ACTIVE,
+  PAST_DUE,
+  CANCELED;
+
+  public boolean isActive() {
+    return this == ACTIVE;
+  }
+
+  public boolean isTerminated() {
+    return this == CANCELED;
+  }
+}

--- a/backend/src/main/java/com/init/payment/domain/model/WebhookEvent.java
+++ b/backend/src/main/java/com/init/payment/domain/model/WebhookEvent.java
@@ -50,6 +50,9 @@ public class WebhookEvent {
   }
 
   public void markProcessed(OffsetDateTime processedAt) {
+    if (processedAt == null) {
+      throw new IllegalArgumentException("processedAt must not be null");
+    }
     this.processedAt = processedAt;
   }
 

--- a/backend/src/main/java/com/init/payment/domain/model/WebhookEvent.java
+++ b/backend/src/main/java/com/init/payment/domain/model/WebhookEvent.java
@@ -1,0 +1,88 @@
+package com.init.payment.domain.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import java.time.OffsetDateTime;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+/** Toss 웹훅 멱등 기록. transmission_id unique로 중복 처리를 차단한다 (U-003). */
+@Entity
+@Table(name = "webhook_event", schema = "payment")
+public class WebhookEvent {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "transmission_id", nullable = false, unique = true)
+  private String transmissionId;
+
+  @Column(name = "event_type")
+  private String eventType;
+
+  @JdbcTypeCode(SqlTypes.JSON)
+  @Column(name = "payload", columnDefinition = "jsonb")
+  private String payload;
+
+  @Column(name = "processed_at")
+  private OffsetDateTime processedAt;
+
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private OffsetDateTime createdAt;
+
+  protected WebhookEvent() {}
+
+  public static WebhookEvent received(String transmissionId, String eventType, String payload) {
+    if (transmissionId == null || transmissionId.isBlank()) {
+      throw new IllegalArgumentException("transmissionId must not be blank");
+    }
+    WebhookEvent event = new WebhookEvent();
+    event.transmissionId = transmissionId;
+    event.eventType = eventType;
+    event.payload = payload;
+    return event;
+  }
+
+  public void markProcessed(OffsetDateTime processedAt) {
+    this.processedAt = processedAt;
+  }
+
+  public boolean isProcessed() {
+    return processedAt != null;
+  }
+
+  @PrePersist
+  protected void onPersist() {
+    this.createdAt = OffsetDateTime.now();
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public String getTransmissionId() {
+    return transmissionId;
+  }
+
+  public String getEventType() {
+    return eventType;
+  }
+
+  public String getPayload() {
+    return payload;
+  }
+
+  public OffsetDateTime getProcessedAt() {
+    return processedAt;
+  }
+
+  public OffsetDateTime getCreatedAt() {
+    return createdAt;
+  }
+}

--- a/backend/src/main/java/com/init/payment/domain/package-info.java
+++ b/backend/src/main/java/com/init/payment/domain/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Payment bounded context - domain layer.
+ *
+ * <p>토스페이먼츠 v2 자동결제 기반 워크스페이스 구독: Subscription / Payment / BillingKey / Plan aggregate.
+ */
+package com.init.payment.domain;

--- a/backend/src/main/java/com/init/payment/domain/repository/BillingKeyRepository.java
+++ b/backend/src/main/java/com/init/payment/domain/repository/BillingKeyRepository.java
@@ -1,0 +1,11 @@
+package com.init.payment.domain.repository;
+
+import com.init.payment.domain.model.BillingKey;
+import java.util.Optional;
+
+public interface BillingKeyRepository {
+
+  BillingKey save(BillingKey billingKey);
+
+  Optional<BillingKey> findActiveByWorkspaceId(Long workspaceId);
+}

--- a/backend/src/main/java/com/init/payment/domain/repository/PaymentCancelRepository.java
+++ b/backend/src/main/java/com/init/payment/domain/repository/PaymentCancelRepository.java
@@ -1,6 +1,7 @@
 package com.init.payment.domain.repository;
 
 import com.init.payment.domain.model.PaymentCancel;
+import java.util.Optional;
 
 public interface PaymentCancelRepository {
 
@@ -8,4 +9,8 @@ public interface PaymentCancelRepository {
 
   /** 결제의 이미 취소된 합계를 반환한다. 없으면 0. */
   long sumCancelAmountByPaymentId(Long paymentId);
+
+  /** 동일 (paymentId, cancelAmount)의 가장 최근 취소 내역을 조회한다. 재시도 시 idempotencyKey 재사용 목적. */
+  Optional<PaymentCancel> findFirstByPaymentIdAndCancelAmountOrderByIdDesc(
+      Long paymentId, long cancelAmount);
 }

--- a/backend/src/main/java/com/init/payment/domain/repository/PaymentCancelRepository.java
+++ b/backend/src/main/java/com/init/payment/domain/repository/PaymentCancelRepository.java
@@ -1,0 +1,8 @@
+package com.init.payment.domain.repository;
+
+import com.init.payment.domain.model.PaymentCancel;
+
+public interface PaymentCancelRepository {
+
+  PaymentCancel save(PaymentCancel paymentCancel);
+}

--- a/backend/src/main/java/com/init/payment/domain/repository/PaymentCancelRepository.java
+++ b/backend/src/main/java/com/init/payment/domain/repository/PaymentCancelRepository.java
@@ -5,4 +5,7 @@ import com.init.payment.domain.model.PaymentCancel;
 public interface PaymentCancelRepository {
 
   PaymentCancel save(PaymentCancel paymentCancel);
+
+  /** 결제의 이미 취소된 합계를 반환한다. 없으면 0. */
+  long sumCancelAmountByPaymentId(Long paymentId);
 }

--- a/backend/src/main/java/com/init/payment/domain/repository/PaymentRepository.java
+++ b/backend/src/main/java/com/init/payment/domain/repository/PaymentRepository.java
@@ -1,0 +1,24 @@
+package com.init.payment.domain.repository;
+
+import com.init.payment.domain.model.Payment;
+import java.util.List;
+import java.util.Optional;
+
+public interface PaymentRepository {
+
+  Payment save(Payment payment);
+
+  Optional<Payment> findById(Long id);
+
+  Optional<Payment> findByOrderId(String orderId);
+
+  Optional<Payment> findByPaymentKey(String paymentKey);
+
+  Optional<Payment> findByPaymentKeyAndWorkspaceId(String paymentKey, Long workspaceId);
+
+  List<Payment> findByWorkspaceIdOrderByCreatedAtDesc(Long workspaceId);
+
+  /** 동일 주기 결제를 찾는다. 존재 시 재시도는 해당 행을 재사용하여 중복청구를 방지한다 (U-011). */
+  Optional<Payment> findBySubscriptionIdAndBillingPeriodKey(
+      Long subscriptionId, String billingPeriodKey);
+}

--- a/backend/src/main/java/com/init/payment/domain/repository/PaymentRepository.java
+++ b/backend/src/main/java/com/init/payment/domain/repository/PaymentRepository.java
@@ -12,6 +12,8 @@ public interface PaymentRepository {
 
   Optional<Payment> findByOrderId(String orderId);
 
+  Optional<Payment> findByWorkspaceIdAndOrderId(Long workspaceId, String orderId);
+
   Optional<Payment> findByPaymentKey(String paymentKey);
 
   Optional<Payment> findByPaymentKeyAndWorkspaceId(String paymentKey, Long workspaceId);
@@ -20,5 +22,9 @@ public interface PaymentRepository {
 
   /** 동일 주기 결제를 찾는다. 존재 시 재시도는 해당 행을 재사용하여 중복청구를 방지한다 (U-011). */
   Optional<Payment> findBySubscriptionIdAndBillingPeriodKey(
+      Long subscriptionId, String billingPeriodKey);
+
+  /** 동일 주기 결제를 비관적 락으로 조회한다. 동시 스케줄러 중복 실행 방지 (V-EC-002). */
+  Optional<Payment> findBySubscriptionIdAndBillingPeriodKeyForUpdate(
       Long subscriptionId, String billingPeriodKey);
 }

--- a/backend/src/main/java/com/init/payment/domain/repository/PlanRepository.java
+++ b/backend/src/main/java/com/init/payment/domain/repository/PlanRepository.java
@@ -1,0 +1,13 @@
+package com.init.payment.domain.repository;
+
+import com.init.payment.domain.model.Plan;
+import java.util.Optional;
+
+public interface PlanRepository {
+
+  Plan save(Plan plan);
+
+  Optional<Plan> findById(Long id);
+
+  Optional<Plan> findByPlanKey(String planKey);
+}

--- a/backend/src/main/java/com/init/payment/domain/repository/SubscriptionRepository.java
+++ b/backend/src/main/java/com/init/payment/domain/repository/SubscriptionRepository.java
@@ -1,0 +1,25 @@
+package com.init.payment.domain.repository;
+
+import com.init.payment.domain.model.Subscription;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface SubscriptionRepository {
+
+  Subscription save(Subscription subscription);
+
+  Optional<Subscription> findById(Long id);
+
+  /** 워크스페이스의 현재(미해지) 구독. 워크스페이스당 활성 구독은 1개 (U-010). */
+  Optional<Subscription> findCurrentByWorkspaceId(Long workspaceId);
+
+  /** 정기결제 대상: ACTIVE, 기간 만료, 기간말 해지 예약 없음. */
+  List<Subscription> findChargeable(OffsetDateTime now);
+
+  /** 기간말 해지 대상: ACTIVE, 기간 만료, 기간말 해지 예약됨 (U-005). */
+  List<Subscription> findExpiringCancellations(OffsetDateTime now);
+
+  /** 재시도 대상: PAST_DUE, 재시도 시각 도래 (U-004). */
+  List<Subscription> findRetryDue(OffsetDateTime now);
+}

--- a/backend/src/main/java/com/init/payment/domain/repository/WebhookEventRepository.java
+++ b/backend/src/main/java/com/init/payment/domain/repository/WebhookEventRepository.java
@@ -1,0 +1,11 @@
+package com.init.payment.domain.repository;
+
+import com.init.payment.domain.model.WebhookEvent;
+import java.util.Optional;
+
+public interface WebhookEventRepository {
+
+  WebhookEvent save(WebhookEvent webhookEvent);
+
+  Optional<WebhookEvent> findByTransmissionId(String transmissionId);
+}

--- a/backend/src/main/java/com/init/payment/infrastructure/config/PaymentSchedulingConfig.java
+++ b/backend/src/main/java/com/init/payment/infrastructure/config/PaymentSchedulingConfig.java
@@ -1,0 +1,9 @@
+package com.init.payment.infrastructure.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+/** 정기결제 인앱 스케줄러 활성화 (U-001: Spring @Scheduled). */
+@Configuration
+@EnableScheduling
+public class PaymentSchedulingConfig {}

--- a/backend/src/main/java/com/init/payment/infrastructure/config/TossApiConfig.java
+++ b/backend/src/main/java/com/init/payment/infrastructure/config/TossApiConfig.java
@@ -1,0 +1,8 @@
+package com.init.payment.infrastructure.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(TossApiProperties.class)
+public class TossApiConfig {}

--- a/backend/src/main/java/com/init/payment/infrastructure/config/TossApiProperties.java
+++ b/backend/src/main/java/com/init/payment/infrastructure/config/TossApiProperties.java
@@ -1,17 +1,28 @@
 package com.init.payment.infrastructure.config;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import java.time.Duration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
 
 /**
  * 토스페이먼츠 v2 설정. AirflowApiProperties의 nested sub-record 패턴을 미러링하여 YAML {@code toss.api.*} / {@code
  * toss.webhook.secret} / {@code toss.billing-key-encryption-key}와 바인딩을 정합한다 (SC-B4 해소).
  */
 @ConfigurationProperties(prefix = "toss")
-public record TossApiProperties(Api api, Webhook webhook, String billingKeyEncryptionKey) {
+@Validated
+public record TossApiProperties(
+    @NotNull @Valid Api api,
+    @NotNull @Valid Webhook webhook,
+    @NotBlank String billingKeyEncryptionKey) {
 
   public record Api(
-      String baseUrl, String secretKey, Duration connectTimeout, Duration readTimeout) {}
+      @NotBlank String baseUrl,
+      @NotBlank String secretKey,
+      Duration connectTimeout,
+      Duration readTimeout) {}
 
-  public record Webhook(String secret) {}
+  public record Webhook(@NotBlank String secret) {}
 }

--- a/backend/src/main/java/com/init/payment/infrastructure/config/TossApiProperties.java
+++ b/backend/src/main/java/com/init/payment/infrastructure/config/TossApiProperties.java
@@ -1,0 +1,17 @@
+package com.init.payment.infrastructure.config;
+
+import java.time.Duration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * 토스페이먼츠 v2 설정. AirflowApiProperties의 nested sub-record 패턴을 미러링하여 YAML {@code toss.api.*} / {@code
+ * toss.webhook.secret} / {@code toss.billing-key-encryption-key}와 바인딩을 정합한다 (SC-B4 해소).
+ */
+@ConfigurationProperties(prefix = "toss")
+public record TossApiProperties(Api api, Webhook webhook, String billingKeyEncryptionKey) {
+
+  public record Api(
+      String baseUrl, String secretKey, Duration connectTimeout, Duration readTimeout) {}
+
+  public record Webhook(String secret) {}
+}

--- a/backend/src/main/java/com/init/payment/infrastructure/crypto/PgcryptoBillingKeyCipher.java
+++ b/backend/src/main/java/com/init/payment/infrastructure/crypto/PgcryptoBillingKeyCipher.java
@@ -1,0 +1,66 @@
+package com.init.payment.infrastructure.crypto;
+
+import com.init.payment.application.port.BillingKeyCipher;
+import com.init.payment.infrastructure.config.TossApiProperties;
+import jakarta.persistence.EntityManager;
+import java.nio.charset.StandardCharsets;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * PostgreSQL pgcrypto 기반 billingKey 컬럼 암복호화 (U-002). 대칭키는 {@code TOSS_BILLING_KEY_ENCRYPTION_KEY}
+ * env로만 주입되며 DB·로그에 평문 billingKey를 남기지 않는다. query-time 키가 필요하므로 JPA Converter가 아닌 네이티브 쿼리로 수행한다.
+ */
+@Component
+public class PgcryptoBillingKeyCipher implements BillingKeyCipher {
+
+  private final EntityManager entityManager;
+  private final TossApiProperties properties;
+
+  public PgcryptoBillingKeyCipher(EntityManager entityManager, TossApiProperties properties) {
+    this.entityManager = entityManager;
+    this.properties = properties;
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public byte[] encrypt(String plaintext) {
+    if (plaintext == null || plaintext.isBlank()) {
+      throw new IllegalArgumentException("plaintext billingKey must not be blank");
+    }
+    Object result =
+        entityManager
+            .createNativeQuery("select pgp_sym_encrypt(cast(:plain as text), cast(:key as text))")
+            .setParameter("plain", plaintext)
+            .setParameter("key", encryptionKey())
+            .getSingleResult();
+    return (byte[]) result;
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public String decrypt(byte[] ciphertext) {
+    if (ciphertext == null || ciphertext.length == 0) {
+      throw new IllegalArgumentException("ciphertext must not be empty");
+    }
+    Object result =
+        entityManager
+            .createNativeQuery("select pgp_sym_decrypt(cast(:cipher as bytea), cast(:key as text))")
+            .setParameter("cipher", ciphertext)
+            .setParameter("key", encryptionKey())
+            .getSingleResult();
+    if (result instanceof byte[] bytes) {
+      return new String(bytes, StandardCharsets.UTF_8);
+    }
+    return (String) result;
+  }
+
+  private String encryptionKey() {
+    String key = properties.billingKeyEncryptionKey();
+    if (key == null || key.isBlank()) {
+      throw new IllegalStateException(
+          "TOSS_BILLING_KEY_ENCRYPTION_KEY가 설정되지 않았습니다. billingKey 암복호화를 수행할 수 없습니다.");
+    }
+    return key;
+  }
+}

--- a/backend/src/main/java/com/init/payment/infrastructure/package-info.java
+++ b/backend/src/main/java/com/init/payment/infrastructure/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Payment bounded context - infrastructure layer.
+ *
+ * <p>JPA Repository, pgcrypto 기반 billingKey 암복호화, Toss API client, 설정.
+ */
+package com.init.payment.infrastructure;

--- a/backend/src/main/java/com/init/payment/infrastructure/persistence/JpaBillingKeyRepository.java
+++ b/backend/src/main/java/com/init/payment/infrastructure/persistence/JpaBillingKeyRepository.java
@@ -1,0 +1,21 @@
+package com.init.payment.infrastructure.persistence;
+
+import com.init.payment.domain.model.BillingKey;
+import com.init.payment.domain.model.BillingKeyStatus;
+import com.init.payment.domain.repository.BillingKeyRepository;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface JpaBillingKeyRepository
+    extends JpaRepository<BillingKey, Long>, BillingKeyRepository {
+
+  @Override
+  default Optional<BillingKey> findActiveByWorkspaceId(Long workspaceId) {
+    return findFirstByWorkspaceIdAndStatusOrderByIdDesc(workspaceId, BillingKeyStatus.ACTIVE);
+  }
+
+  Optional<BillingKey> findFirstByWorkspaceIdAndStatusOrderByIdDesc(
+      Long workspaceId, BillingKeyStatus status);
+}

--- a/backend/src/main/java/com/init/payment/infrastructure/persistence/JpaPaymentCancelRepository.java
+++ b/backend/src/main/java/com/init/payment/infrastructure/persistence/JpaPaymentCancelRepository.java
@@ -3,8 +3,17 @@ package com.init.payment.infrastructure.persistence;
 import com.init.payment.domain.model.PaymentCancel;
 import com.init.payment.domain.repository.PaymentCancelRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface JpaPaymentCancelRepository
-    extends JpaRepository<PaymentCancel, Long>, PaymentCancelRepository {}
+    extends JpaRepository<PaymentCancel, Long>, PaymentCancelRepository {
+
+  @Override
+  @Query(
+      "SELECT COALESCE(SUM(pc.cancelAmount), 0)"
+          + " FROM PaymentCancel pc WHERE pc.paymentId = :paymentId")
+  long sumCancelAmountByPaymentId(@Param("paymentId") Long paymentId);
+}

--- a/backend/src/main/java/com/init/payment/infrastructure/persistence/JpaPaymentCancelRepository.java
+++ b/backend/src/main/java/com/init/payment/infrastructure/persistence/JpaPaymentCancelRepository.java
@@ -2,6 +2,7 @@ package com.init.payment.infrastructure.persistence;
 
 import com.init.payment.domain.model.PaymentCancel;
 import com.init.payment.domain.repository.PaymentCancelRepository;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -16,4 +17,8 @@ public interface JpaPaymentCancelRepository
       "SELECT COALESCE(SUM(pc.cancelAmount), 0)"
           + " FROM PaymentCancel pc WHERE pc.paymentId = :paymentId")
   long sumCancelAmountByPaymentId(@Param("paymentId") Long paymentId);
+
+  @Override
+  Optional<PaymentCancel> findFirstByPaymentIdAndCancelAmountOrderByIdDesc(
+      @Param("paymentId") Long paymentId, @Param("cancelAmount") long cancelAmount);
 }

--- a/backend/src/main/java/com/init/payment/infrastructure/persistence/JpaPaymentCancelRepository.java
+++ b/backend/src/main/java/com/init/payment/infrastructure/persistence/JpaPaymentCancelRepository.java
@@ -1,0 +1,10 @@
+package com.init.payment.infrastructure.persistence;
+
+import com.init.payment.domain.model.PaymentCancel;
+import com.init.payment.domain.repository.PaymentCancelRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface JpaPaymentCancelRepository
+    extends JpaRepository<PaymentCancel, Long>, PaymentCancelRepository {}

--- a/backend/src/main/java/com/init/payment/infrastructure/persistence/JpaPaymentRepository.java
+++ b/backend/src/main/java/com/init/payment/infrastructure/persistence/JpaPaymentRepository.java
@@ -2,9 +2,13 @@ package com.init.payment.infrastructure.persistence;
 
 import com.init.payment.domain.model.Payment;
 import com.init.payment.domain.repository.PaymentRepository;
+import jakarta.persistence.LockModeType;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -12,6 +16,9 @@ public interface JpaPaymentRepository extends JpaRepository<Payment, Long>, Paym
 
   @Override
   Optional<Payment> findByOrderId(String orderId);
+
+  @Override
+  Optional<Payment> findByWorkspaceIdAndOrderId(Long workspaceId, String orderId);
 
   @Override
   Optional<Payment> findByPaymentKey(String paymentKey);
@@ -25,4 +32,13 @@ public interface JpaPaymentRepository extends JpaRepository<Payment, Long>, Paym
   @Override
   Optional<Payment> findBySubscriptionIdAndBillingPeriodKey(
       Long subscriptionId, String billingPeriodKey);
+
+  @Override
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query(
+      "SELECT p FROM Payment p WHERE p.subscriptionId = :subscriptionId"
+          + " AND p.billingPeriodKey = :billingPeriodKey")
+  Optional<Payment> findBySubscriptionIdAndBillingPeriodKeyForUpdate(
+      @Param("subscriptionId") Long subscriptionId,
+      @Param("billingPeriodKey") String billingPeriodKey);
 }

--- a/backend/src/main/java/com/init/payment/infrastructure/persistence/JpaPaymentRepository.java
+++ b/backend/src/main/java/com/init/payment/infrastructure/persistence/JpaPaymentRepository.java
@@ -1,0 +1,28 @@
+package com.init.payment.infrastructure.persistence;
+
+import com.init.payment.domain.model.Payment;
+import com.init.payment.domain.repository.PaymentRepository;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface JpaPaymentRepository extends JpaRepository<Payment, Long>, PaymentRepository {
+
+  @Override
+  Optional<Payment> findByOrderId(String orderId);
+
+  @Override
+  Optional<Payment> findByPaymentKey(String paymentKey);
+
+  @Override
+  Optional<Payment> findByPaymentKeyAndWorkspaceId(String paymentKey, Long workspaceId);
+
+  @Override
+  List<Payment> findByWorkspaceIdOrderByCreatedAtDesc(Long workspaceId);
+
+  @Override
+  Optional<Payment> findBySubscriptionIdAndBillingPeriodKey(
+      Long subscriptionId, String billingPeriodKey);
+}

--- a/backend/src/main/java/com/init/payment/infrastructure/persistence/JpaPlanRepository.java
+++ b/backend/src/main/java/com/init/payment/infrastructure/persistence/JpaPlanRepository.java
@@ -1,0 +1,9 @@
+package com.init.payment.infrastructure.persistence;
+
+import com.init.payment.domain.model.Plan;
+import com.init.payment.domain.repository.PlanRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface JpaPlanRepository extends JpaRepository<Plan, Long>, PlanRepository {}

--- a/backend/src/main/java/com/init/payment/infrastructure/persistence/JpaSubscriptionRepository.java
+++ b/backend/src/main/java/com/init/payment/infrastructure/persistence/JpaSubscriptionRepository.java
@@ -1,0 +1,50 @@
+package com.init.payment.infrastructure.persistence;
+
+import com.init.payment.domain.model.Subscription;
+import com.init.payment.domain.model.SubscriptionStatus;
+import com.init.payment.domain.repository.SubscriptionRepository;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface JpaSubscriptionRepository
+    extends JpaRepository<Subscription, Long>, SubscriptionRepository {
+
+  @Override
+  default Optional<Subscription> findCurrentByWorkspaceId(Long workspaceId) {
+    return findFirstByWorkspaceIdAndStatusNotOrderByIdDesc(
+        workspaceId, SubscriptionStatus.CANCELED);
+  }
+
+  @Override
+  default List<Subscription> findChargeable(OffsetDateTime now) {
+    return findByStatusAndCancelAtPeriodEndFalseAndCurrentPeriodEndLessThanEqual(
+        SubscriptionStatus.ACTIVE, now);
+  }
+
+  @Override
+  default List<Subscription> findExpiringCancellations(OffsetDateTime now) {
+    return findByStatusAndCancelAtPeriodEndTrueAndCurrentPeriodEndLessThanEqual(
+        SubscriptionStatus.ACTIVE, now);
+  }
+
+  @Override
+  default List<Subscription> findRetryDue(OffsetDateTime now) {
+    return findByStatusAndNextRetryAtLessThanEqual(SubscriptionStatus.PAST_DUE, now);
+  }
+
+  Optional<Subscription> findFirstByWorkspaceIdAndStatusNotOrderByIdDesc(
+      Long workspaceId, SubscriptionStatus status);
+
+  List<Subscription> findByStatusAndCancelAtPeriodEndFalseAndCurrentPeriodEndLessThanEqual(
+      SubscriptionStatus status, OffsetDateTime currentPeriodEnd);
+
+  List<Subscription> findByStatusAndCancelAtPeriodEndTrueAndCurrentPeriodEndLessThanEqual(
+      SubscriptionStatus status, OffsetDateTime currentPeriodEnd);
+
+  List<Subscription> findByStatusAndNextRetryAtLessThanEqual(
+      SubscriptionStatus status, OffsetDateTime nextRetryAt);
+}

--- a/backend/src/main/java/com/init/payment/infrastructure/persistence/JpaWebhookEventRepository.java
+++ b/backend/src/main/java/com/init/payment/infrastructure/persistence/JpaWebhookEventRepository.java
@@ -1,0 +1,15 @@
+package com.init.payment.infrastructure.persistence;
+
+import com.init.payment.domain.model.WebhookEvent;
+import com.init.payment.domain.repository.WebhookEventRepository;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface JpaWebhookEventRepository
+    extends JpaRepository<WebhookEvent, Long>, WebhookEventRepository {
+
+  @Override
+  Optional<WebhookEvent> findByTransmissionId(String transmissionId);
+}

--- a/backend/src/main/java/com/init/payment/infrastructure/persistence/PaymentWorkspaceMembershipAdapter.java
+++ b/backend/src/main/java/com/init/payment/infrastructure/persistence/PaymentWorkspaceMembershipAdapter.java
@@ -1,0 +1,36 @@
+package com.init.payment.infrastructure.persistence;
+
+import com.init.payment.application.port.WorkspaceMembershipPort;
+import com.init.workspace.domain.model.WorkspaceMember;
+import com.init.workspace.domain.repository.WorkspaceMemberRepository;
+import com.init.workspace.domain.repository.WorkspaceRepository;
+import java.util.Set;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PaymentWorkspaceMembershipAdapter implements WorkspaceMembershipPort {
+
+  private final WorkspaceRepository workspaceRepository;
+  private final WorkspaceMemberRepository workspaceMemberRepository;
+
+  public PaymentWorkspaceMembershipAdapter(
+      WorkspaceRepository workspaceRepository,
+      WorkspaceMemberRepository workspaceMemberRepository) {
+    this.workspaceRepository = workspaceRepository;
+    this.workspaceMemberRepository = workspaceMemberRepository;
+  }
+
+  @Override
+  public boolean existsById(Long workspaceId) {
+    return workspaceRepository.existsById(workspaceId);
+  }
+
+  @Override
+  public boolean hasAnyRole(Long workspaceId, Long userId, Set<String> roles) {
+    return workspaceMemberRepository
+        .findByWorkspaceIdAndUserId(workspaceId, userId)
+        .map(WorkspaceMember::getMemberRole)
+        .map(role -> roles.contains(role.name()))
+        .orElse(false);
+  }
+}

--- a/backend/src/main/java/com/init/payment/infrastructure/toss/TossPaymentClient.java
+++ b/backend/src/main/java/com/init/payment/infrastructure/toss/TossPaymentClient.java
@@ -1,0 +1,237 @@
+package com.init.payment.infrastructure.toss;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.init.payment.application.TossPayloadMasker;
+import com.init.payment.application.exception.PaymentGatewayException;
+import com.init.payment.application.exception.PaymentRejectedException;
+import com.init.payment.application.port.TossBillingExecuteCommand;
+import com.init.payment.application.port.TossBillingKeyResult;
+import com.init.payment.application.port.TossPaymentPort;
+import com.init.payment.application.port.TossPaymentResult;
+import com.init.payment.infrastructure.config.TossApiProperties;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.http.converter.HttpMessageConversionException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestClientResponseException;
+
+@Component
+public class TossPaymentClient implements TossPaymentPort {
+
+  private static final Logger log = LoggerFactory.getLogger(TossPaymentClient.class);
+  private static final String IDEMPOTENCY_KEY_HEADER = "Idempotency-Key";
+
+  private final TossApiProperties properties;
+  private final ObjectMapper objectMapper;
+  private RestClient restClient;
+
+  public TossPaymentClient(TossApiProperties properties, ObjectMapper objectMapper) {
+    this.properties = properties;
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  public TossBillingKeyResult issueBillingKey(String authKey, String customerKey) {
+    Map<String, Object> body = new LinkedHashMap<>();
+    body.put("authKey", authKey);
+    body.put("customerKey", customerKey);
+    JsonNode root = post("/v1/billing/authorizations/issue", body, "billingKey 발급");
+
+    JsonNode card = root.path("card");
+    return new TossBillingKeyResult(
+        text(root, "billingKey"),
+        text(root, "customerKey"),
+        firstNonBlank(text(card, "company"), text(card, "issuerCode")),
+        text(card, "number"),
+        maskedJson(root));
+  }
+
+  @Override
+  public TossPaymentResult confirmPayment(String paymentKey, String orderId, long amount) {
+    Map<String, Object> body = new LinkedHashMap<>();
+    body.put("paymentKey", paymentKey);
+    body.put("orderId", orderId);
+    body.put("amount", amount);
+    JsonNode root = post("/v1/payments/confirm", body, "결제 승인");
+    return toPaymentResult(root);
+  }
+
+  @Override
+  public TossPaymentResult executeBilling(TossBillingExecuteCommand command) {
+    Map<String, Object> body = new LinkedHashMap<>();
+    body.put("customerKey", command.customerKey());
+    body.put("amount", command.amount());
+    body.put("orderId", command.orderId());
+    body.put("orderName", command.orderName());
+    JsonNode root = post("/v1/billing/" + command.billingKey(), body, "정기결제 실행");
+    return toPaymentResult(root);
+  }
+
+  @Override
+  public TossPaymentResult cancelPayment(
+      String paymentKey, String cancelReason, Long cancelAmount) {
+    Map<String, Object> body = new LinkedHashMap<>();
+    body.put("cancelReason", cancelReason);
+    if (cancelAmount != null) {
+      body.put("cancelAmount", cancelAmount);
+    }
+    JsonNode root = post("/v1/payments/" + paymentKey + "/cancel", body, "결제 취소");
+    return toPaymentResult(root);
+  }
+
+  @Override
+  public TossPaymentResult getPayment(String paymentKey) {
+    try {
+      String raw =
+          restClient()
+              .get()
+              .uri(apiPath("/v1/payments/" + paymentKey))
+              .headers(headers -> headers.setBasicAuth(secretKey(), ""))
+              .retrieve()
+              .body(String.class);
+      return toPaymentResult(readTree(raw));
+    } catch (RestClientException | HttpMessageConversionException ex) {
+      throw gatewayError("결제 재조회", ex);
+    }
+  }
+
+  private JsonNode post(String path, Map<String, Object> body, String action) {
+    try {
+      String raw =
+          restClient()
+              .post()
+              .uri(apiPath(path))
+              .contentType(MediaType.APPLICATION_JSON)
+              .headers(
+                  headers -> {
+                    headers.setBasicAuth(secretKey(), "");
+                    headers.set(IDEMPOTENCY_KEY_HEADER, UUID.randomUUID().toString());
+                  })
+              .body(body)
+              .retrieve()
+              .body(String.class);
+      return readTree(raw);
+    } catch (RestClientResponseException ex) {
+      if (ex.getStatusCode().is4xxClientError()) {
+        log.warn("Toss API가 요청을 거절했습니다: action={}, status={}", action, ex.getStatusCode());
+        throw new PaymentRejectedException("토스페이먼츠가 " + action + " 요청을 거절했습니다.", ex);
+      }
+      throw gatewayError(action, ex);
+    } catch (RestClientException | HttpMessageConversionException ex) {
+      throw gatewayError(action, ex);
+    }
+  }
+
+  private TossPaymentResult toPaymentResult(JsonNode root) {
+    JsonNode cancels = root.path("cancels");
+    String transactionKey = null;
+    if (cancels.isArray() && !cancels.isEmpty()) {
+      transactionKey = text(cancels.get(cancels.size() - 1), "transactionKey");
+    }
+    return new TossPaymentResult(
+        text(root, "paymentKey"),
+        text(root, "orderId"),
+        root.path("totalAmount").asLong(0L),
+        text(root, "status"),
+        text(root, "method"),
+        parseDateTime(text(root, "approvedAt")),
+        text(root.path("receipt"), "url"),
+        transactionKey,
+        maskedJson(root));
+  }
+
+  private JsonNode readTree(String raw) {
+    try {
+      if (raw == null || raw.isBlank()) {
+        return objectMapper.createObjectNode();
+      }
+      return objectMapper.readTree(raw);
+    } catch (com.fasterxml.jackson.core.JsonProcessingException ex) {
+      throw new PaymentGatewayException("Toss 응답 파싱에 실패했습니다.", ex);
+    }
+  }
+
+  /** 민감 필드(billingKey/secretKey/authKey 등)를 제거한 마스킹 JSON 문자열을 반환한다 (U-012). */
+  private String maskedJson(JsonNode root) {
+    return TossPayloadMasker.mask(root);
+  }
+
+  private PaymentGatewayException gatewayError(String action, Exception ex) {
+    log.error("Toss API 호출 실패: action={}", action, ex);
+    return new PaymentGatewayException("토스페이먼츠 " + action + " 호출에 실패했습니다.", ex);
+  }
+
+  private String apiPath(String path) {
+    String baseUrl = properties.api() == null ? null : properties.api().baseUrl();
+    if (baseUrl == null || baseUrl.isBlank()) {
+      throw new PaymentGatewayException("toss.api.base-url이 설정되지 않았습니다.");
+    }
+    return trimTrailingSlashes(baseUrl) + path;
+  }
+
+  private String secretKey() {
+    String secretKey = properties.api() == null ? null : properties.api().secretKey();
+    if (secretKey == null || secretKey.isBlank()) {
+      throw new PaymentGatewayException("TOSS_SECRET_KEY가 설정되지 않았습니다.");
+    }
+    return secretKey;
+  }
+
+  private synchronized RestClient restClient() {
+    if (restClient == null) {
+      SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+      TossApiProperties.Api api = properties.api();
+      requestFactory.setConnectTimeout(
+          durationOrDefault(api == null ? null : api.connectTimeout(), Duration.ofSeconds(3)));
+      requestFactory.setReadTimeout(
+          durationOrDefault(api == null ? null : api.readTimeout(), Duration.ofSeconds(10)));
+      restClient = RestClient.builder().requestFactory(requestFactory).build();
+    }
+    return restClient;
+  }
+
+  private Duration durationOrDefault(Duration duration, Duration defaultValue) {
+    return duration == null ? defaultValue : duration;
+  }
+
+  private String trimTrailingSlashes(String value) {
+    String normalized = value.trim();
+    while (normalized.endsWith("/")) {
+      normalized = normalized.substring(0, normalized.length() - 1);
+    }
+    return normalized;
+  }
+
+  private static String text(JsonNode node, String field) {
+    JsonNode value = node.path(field);
+    return value.isMissingNode() || value.isNull() ? null : value.asText();
+  }
+
+  private static String firstNonBlank(String a, String b) {
+    if (a != null && !a.isBlank()) {
+      return a;
+    }
+    return b;
+  }
+
+  private static OffsetDateTime parseDateTime(String value) {
+    if (value == null || value.isBlank()) {
+      return null;
+    }
+    try {
+      return OffsetDateTime.parse(value);
+    } catch (java.time.format.DateTimeParseException ex) {
+      return null;
+    }
+  }
+}

--- a/backend/src/main/java/com/init/payment/infrastructure/toss/TossPaymentClient.java
+++ b/backend/src/main/java/com/init/payment/infrastructure/toss/TossPaymentClient.java
@@ -173,29 +173,22 @@ public class TossPaymentClient implements TossPaymentPort {
     return new PaymentGatewayException("토스페이먼츠 " + action + " 호출에 실패했습니다.", ex);
   }
 
+  // toss.api.* 설정값은 @Validated TossApiProperties(@NotNull api, @NotBlank baseUrl/secretKey)로
+  // 빈 바인딩 시점에 강제되므로 런타임 재검증은 불필요하다.
   private String apiPath(String path) {
-    String baseUrl = properties.api() == null ? null : properties.api().baseUrl();
-    if (baseUrl == null || baseUrl.isBlank()) {
-      throw new PaymentGatewayException("toss.api.base-url이 설정되지 않았습니다.");
-    }
-    return trimTrailingSlashes(baseUrl) + path;
+    return trimTrailingSlashes(properties.api().baseUrl()) + path;
   }
 
   private String secretKey() {
-    String secretKey = properties.api() == null ? null : properties.api().secretKey();
-    if (secretKey == null || secretKey.isBlank()) {
-      throw new PaymentGatewayException("TOSS_SECRET_KEY가 설정되지 않았습니다.");
-    }
-    return secretKey;
+    return properties.api().secretKey();
   }
 
   private static RestClient buildRestClient(TossApiProperties properties) {
     SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
     TossApiProperties.Api api = properties.api();
     requestFactory.setConnectTimeout(
-        durationOrDefault(api == null ? null : api.connectTimeout(), Duration.ofSeconds(3)));
-    requestFactory.setReadTimeout(
-        durationOrDefault(api == null ? null : api.readTimeout(), Duration.ofSeconds(10)));
+        durationOrDefault(api.connectTimeout(), Duration.ofSeconds(3)));
+    requestFactory.setReadTimeout(durationOrDefault(api.readTimeout(), Duration.ofSeconds(10)));
     return RestClient.builder().requestFactory(requestFactory).build();
   }
 

--- a/backend/src/main/java/com/init/payment/infrastructure/toss/TossPaymentClient.java
+++ b/backend/src/main/java/com/init/payment/infrastructure/toss/TossPaymentClient.java
@@ -32,11 +32,12 @@ public class TossPaymentClient implements TossPaymentPort {
 
   private final TossApiProperties properties;
   private final ObjectMapper objectMapper;
-  private RestClient restClient;
+  private final RestClient restClient;
 
   public TossPaymentClient(TossApiProperties properties, ObjectMapper objectMapper) {
     this.properties = properties;
     this.objectMapper = objectMapper;
+    this.restClient = buildRestClient(properties);
   }
 
   @Override
@@ -78,13 +79,14 @@ public class TossPaymentClient implements TossPaymentPort {
 
   @Override
   public TossPaymentResult cancelPayment(
-      String paymentKey, String cancelReason, Long cancelAmount) {
+      String paymentKey, String cancelReason, Long cancelAmount, String cancelIdempotencyKey) {
     Map<String, Object> body = new LinkedHashMap<>();
     body.put("cancelReason", cancelReason);
     if (cancelAmount != null) {
       body.put("cancelAmount", cancelAmount);
     }
-    JsonNode root = post("/v1/payments/" + paymentKey + "/cancel", body, "결제 취소", paymentKey);
+    JsonNode root =
+        post("/v1/payments/" + paymentKey + "/cancel", body, "결제 취소", cancelIdempotencyKey);
     return toPaymentResult(root);
   }
 
@@ -92,7 +94,7 @@ public class TossPaymentClient implements TossPaymentPort {
   public TossPaymentResult getPayment(String paymentKey) {
     try {
       String raw =
-          restClient()
+          restClient
               .get()
               .uri(apiPath("/v1/payments/" + paymentKey))
               .headers(headers -> headers.setBasicAuth(secretKey(), ""))
@@ -108,7 +110,7 @@ public class TossPaymentClient implements TossPaymentPort {
       String path, Map<String, Object> body, String action, String idempotencyKey) {
     try {
       String raw =
-          restClient()
+          restClient
               .post()
               .uri(apiPath(path))
               .contentType(MediaType.APPLICATION_JSON)
@@ -187,20 +189,17 @@ public class TossPaymentClient implements TossPaymentPort {
     return secretKey;
   }
 
-  private synchronized RestClient restClient() {
-    if (restClient == null) {
-      SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
-      TossApiProperties.Api api = properties.api();
-      requestFactory.setConnectTimeout(
-          durationOrDefault(api == null ? null : api.connectTimeout(), Duration.ofSeconds(3)));
-      requestFactory.setReadTimeout(
-          durationOrDefault(api == null ? null : api.readTimeout(), Duration.ofSeconds(10)));
-      restClient = RestClient.builder().requestFactory(requestFactory).build();
-    }
-    return restClient;
+  private static RestClient buildRestClient(TossApiProperties properties) {
+    SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+    TossApiProperties.Api api = properties.api();
+    requestFactory.setConnectTimeout(
+        durationOrDefault(api == null ? null : api.connectTimeout(), Duration.ofSeconds(3)));
+    requestFactory.setReadTimeout(
+        durationOrDefault(api == null ? null : api.readTimeout(), Duration.ofSeconds(10)));
+    return RestClient.builder().requestFactory(requestFactory).build();
   }
 
-  private Duration durationOrDefault(Duration duration, Duration defaultValue) {
+  private static Duration durationOrDefault(Duration duration, Duration defaultValue) {
     return duration == null ? defaultValue : duration;
   }
 

--- a/backend/src/main/java/com/init/payment/infrastructure/toss/TossPaymentClient.java
+++ b/backend/src/main/java/com/init/payment/infrastructure/toss/TossPaymentClient.java
@@ -14,7 +14,6 @@ import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.MediaType;
@@ -45,7 +44,7 @@ public class TossPaymentClient implements TossPaymentPort {
     Map<String, Object> body = new LinkedHashMap<>();
     body.put("authKey", authKey);
     body.put("customerKey", customerKey);
-    JsonNode root = post("/v1/billing/authorizations/issue", body, "billingKey 발급");
+    JsonNode root = post("/v1/billing/authorizations/issue", body, "billingKey 발급", customerKey);
 
     JsonNode card = root.path("card");
     return new TossBillingKeyResult(
@@ -62,7 +61,7 @@ public class TossPaymentClient implements TossPaymentPort {
     body.put("paymentKey", paymentKey);
     body.put("orderId", orderId);
     body.put("amount", amount);
-    JsonNode root = post("/v1/payments/confirm", body, "결제 승인");
+    JsonNode root = post("/v1/payments/confirm", body, "결제 승인", orderId);
     return toPaymentResult(root);
   }
 
@@ -73,7 +72,7 @@ public class TossPaymentClient implements TossPaymentPort {
     body.put("amount", command.amount());
     body.put("orderId", command.orderId());
     body.put("orderName", command.orderName());
-    JsonNode root = post("/v1/billing/" + command.billingKey(), body, "정기결제 실행");
+    JsonNode root = post("/v1/billing/" + command.billingKey(), body, "정기결제 실행", command.orderId());
     return toPaymentResult(root);
   }
 
@@ -85,7 +84,7 @@ public class TossPaymentClient implements TossPaymentPort {
     if (cancelAmount != null) {
       body.put("cancelAmount", cancelAmount);
     }
-    JsonNode root = post("/v1/payments/" + paymentKey + "/cancel", body, "결제 취소");
+    JsonNode root = post("/v1/payments/" + paymentKey + "/cancel", body, "결제 취소", paymentKey);
     return toPaymentResult(root);
   }
 
@@ -105,7 +104,8 @@ public class TossPaymentClient implements TossPaymentPort {
     }
   }
 
-  private JsonNode post(String path, Map<String, Object> body, String action) {
+  private JsonNode post(
+      String path, Map<String, Object> body, String action, String idempotencyKey) {
     try {
       String raw =
           restClient()
@@ -115,7 +115,7 @@ public class TossPaymentClient implements TossPaymentPort {
               .headers(
                   headers -> {
                     headers.setBasicAuth(secretKey(), "");
-                    headers.set(IDEMPOTENCY_KEY_HEADER, UUID.randomUUID().toString());
+                    headers.set(IDEMPOTENCY_KEY_HEADER, idempotencyKey);
                   })
               .body(body)
               .retrieve()

--- a/backend/src/main/java/com/init/payment/presentation/PaymentController.java
+++ b/backend/src/main/java/com/init/payment/presentation/PaymentController.java
@@ -1,0 +1,69 @@
+package com.init.payment.presentation;
+
+import com.init.payment.application.CancelPaymentCommand;
+import com.init.payment.application.ConfirmPaymentCommand;
+import com.init.payment.application.PaymentResult;
+import com.init.payment.application.PaymentService;
+import com.init.payment.presentation.dto.CancelPaymentRequest;
+import com.init.payment.presentation.dto.ConfirmPaymentRequest;
+import com.init.payment.presentation.dto.PaymentResponse;
+import com.init.shared.presentation.AuthenticationUtils;
+import jakarta.validation.Valid;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/workspaces/{workspaceId}/payments")
+public class PaymentController {
+
+  private final PaymentService paymentService;
+
+  public PaymentController(PaymentService paymentService) {
+    this.paymentService = paymentService;
+  }
+
+  @PostMapping("/confirm")
+  public ResponseEntity<PaymentResponse> confirmPayment(
+      @PathVariable Long workspaceId,
+      @Valid @RequestBody ConfirmPaymentRequest request,
+      Authentication authentication) {
+    Long userId = AuthenticationUtils.getUserId(authentication);
+    PaymentResult result =
+        paymentService.confirmPayment(
+            new ConfirmPaymentCommand(
+                workspaceId, userId, request.paymentKey(), request.orderId(), request.amount()));
+    return ResponseEntity.ok(PaymentResponse.from(result));
+  }
+
+  @GetMapping
+  public ResponseEntity<List<PaymentResponse>> getPayments(
+      @PathVariable Long workspaceId, Authentication authentication) {
+    Long userId = AuthenticationUtils.getUserId(authentication);
+    List<PaymentResponse> payments =
+        paymentService.getPayments(workspaceId, userId).stream()
+            .map(PaymentResponse::from)
+            .toList();
+    return ResponseEntity.ok(payments);
+  }
+
+  @PostMapping("/{paymentKey}/cancel")
+  public ResponseEntity<PaymentResponse> cancelPayment(
+      @PathVariable Long workspaceId,
+      @PathVariable String paymentKey,
+      @Valid @RequestBody CancelPaymentRequest request,
+      Authentication authentication) {
+    Long userId = AuthenticationUtils.getUserId(authentication);
+    PaymentResult result =
+        paymentService.cancelPayment(
+            new CancelPaymentCommand(
+                workspaceId, userId, paymentKey, request.cancelReason(), request.cancelAmount()));
+    return ResponseEntity.ok(PaymentResponse.from(result));
+  }
+}

--- a/backend/src/main/java/com/init/payment/presentation/PaymentController.java
+++ b/backend/src/main/java/com/init/payment/presentation/PaymentController.java
@@ -10,6 +10,7 @@ import com.init.payment.presentation.dto.PaymentResponse;
 import com.init.shared.presentation.AuthenticationUtils;
 import jakarta.validation.Valid;
 import java.util.List;
+import java.util.UUID;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -63,7 +64,12 @@ public class PaymentController {
     PaymentResult result =
         paymentService.cancelPayment(
             new CancelPaymentCommand(
-                workspaceId, userId, paymentKey, request.cancelReason(), request.cancelAmount()));
+                workspaceId,
+                userId,
+                paymentKey,
+                request.cancelReason(),
+                request.cancelAmount(),
+                UUID.randomUUID().toString().replace("-", "")));
     return ResponseEntity.ok(PaymentResponse.from(result));
   }
 }

--- a/backend/src/main/java/com/init/payment/presentation/PaymentWebhookController.java
+++ b/backend/src/main/java/com/init/payment/presentation/PaymentWebhookController.java
@@ -38,11 +38,14 @@ public class PaymentWebhookController {
     String eventType = text(root, "eventType");
     String paymentKey = text(data, "paymentKey");
     String status = text(data, "status");
+    String lastTransactionKey = text(data, "lastTransactionKey");
+    String eventId = text(root, "eventId");
 
     paymentWebhookService.handle(
         new HandleTossWebhookCommand(
             webhookSecret,
-            resolveTransmissionId(root, data, paymentKey, status),
+            HandleTossWebhookCommand.resolveTransmissionId(
+                lastTransactionKey, eventId, paymentKey, status, eventType),
             eventType,
             paymentKey,
             TossPayloadMasker.mask(root)));
@@ -58,21 +61,6 @@ public class PaymentWebhookController {
     } catch (com.fasterxml.jackson.core.JsonProcessingException ex) {
       throw new BadRequestException("INVALID_WEBHOOK_PAYLOAD", "웹훅 본문이 유효한 JSON이 아닙니다.");
     }
-  }
-
-  /** 멱등 키. Toss transaction key를 우선 사용하고, 없으면 paymentKey:status로 대체한다 (U-003). */
-  private String resolveTransmissionId(
-      JsonNode root, JsonNode data, String paymentKey, String status) {
-    String lastTransactionKey = text(data, "lastTransactionKey");
-    if (lastTransactionKey != null) {
-      return lastTransactionKey;
-    }
-    String eventId = text(root, "eventId");
-    if (eventId != null) {
-      return eventId;
-    }
-    String base = paymentKey != null ? paymentKey : text(root, "eventType");
-    return base + ":" + status;
   }
 
   private static String text(JsonNode node, String field) {

--- a/backend/src/main/java/com/init/payment/presentation/PaymentWebhookController.java
+++ b/backend/src/main/java/com/init/payment/presentation/PaymentWebhookController.java
@@ -1,0 +1,82 @@
+package com.init.payment.presentation;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.init.payment.application.HandleTossWebhookCommand;
+import com.init.payment.application.PaymentWebhookService;
+import com.init.payment.application.TossPayloadMasker;
+import com.init.shared.application.exception.BadRequestException;
+import com.init.shared.infrastructure.web.WebhookHeaderNames;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Toss 웹훅 수신(public). 시크릿 헤더 검증은 application 계층에서 수행한다 (U-003). */
+@RestController
+@RequestMapping("/api/v1/payments/webhooks")
+public class PaymentWebhookController {
+
+  private final PaymentWebhookService paymentWebhookService;
+  private final ObjectMapper objectMapper;
+
+  public PaymentWebhookController(
+      PaymentWebhookService paymentWebhookService, ObjectMapper objectMapper) {
+    this.paymentWebhookService = paymentWebhookService;
+    this.objectMapper = objectMapper;
+  }
+
+  @PostMapping("/toss")
+  public ResponseEntity<Void> receiveTossWebhook(
+      @RequestHeader(value = WebhookHeaderNames.TOSS_WEBHOOK_SECRET, required = false)
+          String webhookSecret,
+      @RequestBody String rawBody) {
+    JsonNode root = parse(rawBody);
+    JsonNode data = root.path("data");
+    String eventType = text(root, "eventType");
+    String paymentKey = text(data, "paymentKey");
+    String status = text(data, "status");
+
+    paymentWebhookService.handle(
+        new HandleTossWebhookCommand(
+            webhookSecret,
+            resolveTransmissionId(root, data, paymentKey, status),
+            eventType,
+            paymentKey,
+            TossPayloadMasker.mask(root)));
+    return ResponseEntity.ok().build();
+  }
+
+  private JsonNode parse(String rawBody) {
+    try {
+      if (rawBody == null || rawBody.isBlank()) {
+        throw new BadRequestException("INVALID_WEBHOOK_PAYLOAD", "웹훅 본문이 비어 있습니다.");
+      }
+      return objectMapper.readTree(rawBody);
+    } catch (com.fasterxml.jackson.core.JsonProcessingException ex) {
+      throw new BadRequestException("INVALID_WEBHOOK_PAYLOAD", "웹훅 본문이 유효한 JSON이 아닙니다.");
+    }
+  }
+
+  /** 멱등 키. Toss transaction key를 우선 사용하고, 없으면 paymentKey:status로 대체한다 (U-003). */
+  private String resolveTransmissionId(
+      JsonNode root, JsonNode data, String paymentKey, String status) {
+    String lastTransactionKey = text(data, "lastTransactionKey");
+    if (lastTransactionKey != null) {
+      return lastTransactionKey;
+    }
+    String eventId = text(root, "eventId");
+    if (eventId != null) {
+      return eventId;
+    }
+    String base = paymentKey != null ? paymentKey : text(root, "eventType");
+    return base + ":" + status;
+  }
+
+  private static String text(JsonNode node, String field) {
+    JsonNode value = node.path(field);
+    return value.isMissingNode() || value.isNull() ? null : value.asText();
+  }
+}

--- a/backend/src/main/java/com/init/payment/presentation/SubscriptionController.java
+++ b/backend/src/main/java/com/init/payment/presentation/SubscriptionController.java
@@ -1,0 +1,75 @@
+package com.init.payment.presentation;
+
+import com.init.payment.application.BillingAuthorizationResult;
+import com.init.payment.application.CreateSubscriptionCommand;
+import com.init.payment.application.IssueBillingKeyCommand;
+import com.init.payment.application.SubscriptionResult;
+import com.init.payment.application.SubscriptionService;
+import com.init.payment.presentation.dto.BillingAuthorizationRequest;
+import com.init.payment.presentation.dto.BillingAuthorizationResponse;
+import com.init.payment.presentation.dto.CreateSubscriptionRequest;
+import com.init.payment.presentation.dto.SubscriptionResponse;
+import com.init.shared.presentation.AuthenticationUtils;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/workspaces/{workspaceId}")
+public class SubscriptionController {
+
+  private final SubscriptionService subscriptionService;
+
+  public SubscriptionController(SubscriptionService subscriptionService) {
+    this.subscriptionService = subscriptionService;
+  }
+
+  @GetMapping("/subscription")
+  public ResponseEntity<SubscriptionResponse> getSubscription(
+      @PathVariable Long workspaceId, Authentication authentication) {
+    Long userId = AuthenticationUtils.getUserId(authentication);
+    SubscriptionResult result = subscriptionService.getSubscription(workspaceId, userId);
+    return ResponseEntity.ok(SubscriptionResponse.from(result));
+  }
+
+  @PostMapping("/subscription")
+  public ResponseEntity<SubscriptionResponse> createSubscription(
+      @PathVariable Long workspaceId,
+      @Valid @RequestBody CreateSubscriptionRequest request,
+      Authentication authentication) {
+    Long userId = AuthenticationUtils.getUserId(authentication);
+    SubscriptionResult result =
+        subscriptionService.createSubscription(
+            new CreateSubscriptionCommand(workspaceId, userId, request.planKey()));
+    return ResponseEntity.status(HttpStatus.CREATED).body(SubscriptionResponse.from(result));
+  }
+
+  @DeleteMapping("/subscription")
+  public ResponseEntity<SubscriptionResponse> cancelSubscription(
+      @PathVariable Long workspaceId, Authentication authentication) {
+    Long userId = AuthenticationUtils.getUserId(authentication);
+    SubscriptionResult result = subscriptionService.cancelSubscription(workspaceId, userId);
+    return ResponseEntity.ok(SubscriptionResponse.from(result));
+  }
+
+  @PostMapping("/billing/authorizations")
+  public ResponseEntity<BillingAuthorizationResponse> issueBillingKey(
+      @PathVariable Long workspaceId,
+      @Valid @RequestBody BillingAuthorizationRequest request,
+      Authentication authentication) {
+    Long userId = AuthenticationUtils.getUserId(authentication);
+    BillingAuthorizationResult result =
+        subscriptionService.issueBillingKey(
+            new IssueBillingKeyCommand(
+                workspaceId, userId, request.authKey(), request.customerKey()));
+    return ResponseEntity.ok(BillingAuthorizationResponse.from(result));
+  }
+}

--- a/backend/src/main/java/com/init/payment/presentation/dto/BillingAuthorizationRequest.java
+++ b/backend/src/main/java/com/init/payment/presentation/dto/BillingAuthorizationRequest.java
@@ -1,0 +1,5 @@
+package com.init.payment.presentation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record BillingAuthorizationRequest(@NotBlank String authKey, String customerKey) {}

--- a/backend/src/main/java/com/init/payment/presentation/dto/BillingAuthorizationRequest.java
+++ b/backend/src/main/java/com/init/payment/presentation/dto/BillingAuthorizationRequest.java
@@ -2,4 +2,4 @@ package com.init.payment.presentation.dto;
 
 import jakarta.validation.constraints.NotBlank;
 
-public record BillingAuthorizationRequest(@NotBlank String authKey, String customerKey) {}
+public record BillingAuthorizationRequest(@NotBlank String authKey, @NotBlank String customerKey) {}

--- a/backend/src/main/java/com/init/payment/presentation/dto/BillingAuthorizationResponse.java
+++ b/backend/src/main/java/com/init/payment/presentation/dto/BillingAuthorizationResponse.java
@@ -1,0 +1,13 @@
+package com.init.payment.presentation.dto;
+
+import com.init.payment.application.BillingAuthorizationResult;
+
+public record BillingAuthorizationResponse(
+    SubscriptionResponse subscription, BillingKeyResponse billingKey) {
+
+  public static BillingAuthorizationResponse from(BillingAuthorizationResult result) {
+    return new BillingAuthorizationResponse(
+        SubscriptionResponse.from(result.subscription()),
+        BillingKeyResponse.from(result.billingKey()));
+  }
+}

--- a/backend/src/main/java/com/init/payment/presentation/dto/BillingKeyResponse.java
+++ b/backend/src/main/java/com/init/payment/presentation/dto/BillingKeyResponse.java
@@ -1,0 +1,12 @@
+package com.init.payment.presentation.dto;
+
+import com.init.payment.application.BillingKeySummary;
+
+public record BillingKeyResponse(
+    Long id, String cardCompany, String cardNumberMasked, String status) {
+
+  public static BillingKeyResponse from(BillingKeySummary summary) {
+    return new BillingKeyResponse(
+        summary.id(), summary.cardCompany(), summary.cardNumberMasked(), summary.status());
+  }
+}

--- a/backend/src/main/java/com/init/payment/presentation/dto/CancelPaymentRequest.java
+++ b/backend/src/main/java/com/init/payment/presentation/dto/CancelPaymentRequest.java
@@ -1,0 +1,7 @@
+package com.init.payment.presentation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+
+/** cancelAmount가 null이면 전액 취소. */
+public record CancelPaymentRequest(@NotBlank String cancelReason, @Positive Long cancelAmount) {}

--- a/backend/src/main/java/com/init/payment/presentation/dto/ConfirmPaymentRequest.java
+++ b/backend/src/main/java/com/init/payment/presentation/dto/ConfirmPaymentRequest.java
@@ -1,0 +1,7 @@
+package com.init.payment.presentation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+
+public record ConfirmPaymentRequest(
+    @NotBlank String paymentKey, @NotBlank String orderId, @Positive long amount) {}

--- a/backend/src/main/java/com/init/payment/presentation/dto/CreateSubscriptionRequest.java
+++ b/backend/src/main/java/com/init/payment/presentation/dto/CreateSubscriptionRequest.java
@@ -1,0 +1,5 @@
+package com.init.payment.presentation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CreateSubscriptionRequest(@NotBlank String planKey) {}

--- a/backend/src/main/java/com/init/payment/presentation/dto/PaymentResponse.java
+++ b/backend/src/main/java/com/init/payment/presentation/dto/PaymentResponse.java
@@ -1,0 +1,31 @@
+package com.init.payment.presentation.dto;
+
+import com.init.payment.application.PaymentResult;
+import java.time.OffsetDateTime;
+
+public record PaymentResponse(
+    Long id,
+    String orderId,
+    String paymentKey,
+    long amount,
+    String currency,
+    String status,
+    String method,
+    OffsetDateTime approvedAt,
+    String receiptUrl,
+    OffsetDateTime createdAt) {
+
+  public static PaymentResponse from(PaymentResult result) {
+    return new PaymentResponse(
+        result.id(),
+        result.orderId(),
+        result.paymentKey(),
+        result.amount(),
+        result.currency(),
+        result.status(),
+        result.method(),
+        result.approvedAt(),
+        result.receiptUrl(),
+        result.createdAt());
+  }
+}

--- a/backend/src/main/java/com/init/payment/presentation/dto/SubscriptionResponse.java
+++ b/backend/src/main/java/com/init/payment/presentation/dto/SubscriptionResponse.java
@@ -1,0 +1,27 @@
+package com.init.payment.presentation.dto;
+
+import com.init.payment.application.SubscriptionResult;
+import java.time.OffsetDateTime;
+
+public record SubscriptionResponse(
+    Long id,
+    Long workspaceId,
+    String planKey,
+    String status,
+    OffsetDateTime currentPeriodStart,
+    OffsetDateTime currentPeriodEnd,
+    boolean cancelAtPeriodEnd,
+    String customerKey) {
+
+  public static SubscriptionResponse from(SubscriptionResult result) {
+    return new SubscriptionResponse(
+        result.id(),
+        result.workspaceId(),
+        result.planKey(),
+        result.status(),
+        result.currentPeriodStart(),
+        result.currentPeriodEnd(),
+        result.cancelAtPeriodEnd(),
+        result.customerKey());
+  }
+}

--- a/backend/src/main/java/com/init/payment/presentation/package-info.java
+++ b/backend/src/main/java/com/init/payment/presentation/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Payment bounded context - presentation layer.
+ *
+ * <p>구독/결제 REST Controller, Toss 웹훅 수신 Controller, request/response DTO.
+ */
+package com.init.payment.presentation;

--- a/backend/src/main/java/com/init/shared/infrastructure/security/SecurityConfig.java
+++ b/backend/src/main/java/com/init/shared/infrastructure/security/SecurityConfig.java
@@ -72,6 +72,8 @@ public class SecurityConfig {
                     .permitAll()
                     .requestMatchers(HttpMethod.POST, "/api/v1/pipeline-jobs/*/callbacks/failures")
                     .permitAll()
+                    .requestMatchers(HttpMethod.POST, "/api/v1/payments/webhooks/toss")
+                    .permitAll()
                     .requestMatchers("/api/v1/admin/**")
                     .hasRole("SUPER_ADMIN")
                     .requestMatchers("/api/v1/consultation/**")
@@ -91,7 +93,11 @@ public class SecurityConfig {
     config.setAllowedOrigins(allowedOrigins);
     config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
     config.setAllowedHeaders(
-        List.of("Authorization", "Content-Type", WebhookHeaderNames.AIRFLOW_WEBHOOK_SECRET));
+        List.of(
+            "Authorization",
+            "Content-Type",
+            WebhookHeaderNames.AIRFLOW_WEBHOOK_SECRET,
+            WebhookHeaderNames.TOSS_WEBHOOK_SECRET));
     config.setAllowCredentials(true);
 
     UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/backend/src/main/java/com/init/shared/infrastructure/web/WebhookHeaderNames.java
+++ b/backend/src/main/java/com/init/shared/infrastructure/web/WebhookHeaderNames.java
@@ -3,6 +3,7 @@ package com.init.shared.infrastructure.web;
 public final class WebhookHeaderNames {
 
   public static final String AIRFLOW_WEBHOOK_SECRET = "X-Airflow-Webhook-Secret";
+  public static final String TOSS_WEBHOOK_SECRET = "X-Toss-Webhook-Secret";
 
   private WebhookHeaderNames() {}
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -78,6 +78,18 @@ airflow:
   webhook:
     secret: ${AIRFLOW_WEBHOOK_SECRET}
 
+toss:
+  api:
+    base-url: ${TOSS_API_BASE_URL:https://api.tosspayments.com}
+    secret-key: ${TOSS_SECRET_KEY:}
+    connect-timeout: ${TOSS_API_CONNECT_TIMEOUT:3s}
+    read-timeout: ${TOSS_API_READ_TIMEOUT:10s}
+  webhook:
+    secret: ${TOSS_WEBHOOK_SECRET:}
+  billing-key-encryption-key: ${TOSS_BILLING_KEY_ENCRYPTION_KEY:}
+  scheduler:
+    recurring-billing-cron: ${TOSS_RECURRING_BILLING_CRON:0 */30 * * * *}
+
 springdoc:
   api-docs:
     version: openapi_3_0

--- a/backend/src/main/resources/db/changelog/db.changelog-master.sql
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.sql
@@ -1045,3 +1045,9 @@ create table payment.webhook_event (
 insert into payment.plan (plan_key, name, amount, currency, bill_interval, status)
 values ('pro_monthly', 'Pro (Monthly)', 29000, 'KRW', 'MONTH', 'ACTIVE')
 on conflict (plan_key) do nothing;
+
+--changeset init:20260603-add-partial-unique-index-subscription-open
+--comment: Defense-in-depth: prevent duplicate active subscriptions per workspace (V-EC-005)
+create unique index uq_payment_subscription_workspace_open
+    on payment.subscription (workspace_id)
+    where status in ('INCOMPLETE', 'ACTIVE', 'PAST_DUE');

--- a/backend/src/main/resources/db/changelog/db.changelog-master.sql
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.sql
@@ -951,3 +951,97 @@ WHERE role = 'ADMIN';
 ALTER TABLE app.app_user
     ADD CONSTRAINT chk_app_user_role
     CHECK (role IN ('OPERATOR', 'SUPER_ADMIN'));
+
+--changeset init:20260603-enable-pgcrypto
+--comment: Enable pgcrypto extension for billing key column encryption (U-002)
+create extension if not exists pgcrypto;
+
+--changeset init:20260603-create-payment-schema
+--comment: Create payment schema for workspace subscription billing
+create schema if not exists payment;
+
+--changeset init:20260603-create-payment-tables
+--comment: Create payment domain tables (plan, subscription, billing_key, payment, payment_cancel, webhook_event)
+create table payment.plan (
+    id            bigserial primary key,
+    plan_key      varchar(100) not null unique,
+    name          varchar(255) not null,
+    amount        bigint not null,
+    currency      varchar(10) not null default 'KRW',
+    bill_interval varchar(20) not null,
+    status        varchar(50) not null default 'ACTIVE',
+    created_at    timestamptz not null default now(),
+    updated_at    timestamptz not null default now()
+);
+
+create table payment.subscription (
+    id                   bigserial primary key,
+    workspace_id         bigint not null references app.workspace(id),
+    plan_id              bigint not null references payment.plan(id),
+    status               varchar(50) not null,
+    current_period_start timestamptz,
+    current_period_end   timestamptz,
+    customer_key         varchar(255),
+    cancel_at_period_end boolean not null default false,
+    failed_attempt_count int not null default 0,
+    next_retry_at        timestamptz,
+    created_at           timestamptz not null default now(),
+    updated_at           timestamptz not null default now()
+);
+
+create table payment.billing_key (
+    id                    bigserial primary key,
+    workspace_id          bigint not null references app.workspace(id),
+    customer_key          varchar(255) not null,
+    billing_key_encrypted bytea not null,
+    card_company          varchar(100),
+    card_number_masked    varchar(50),
+    status                varchar(50) not null default 'ACTIVE',
+    created_at            timestamptz not null default now(),
+    updated_at            timestamptz not null default now()
+);
+
+create table payment.payment (
+    id                 bigserial primary key,
+    order_id           varchar(255) not null unique,
+    payment_key        varchar(255),
+    workspace_id       bigint not null references app.workspace(id),
+    subscription_id    bigint references payment.subscription(id),
+    amount             bigint not null,
+    currency           varchar(10) not null default 'KRW',
+    status             varchar(50) not null,
+    method             varchar(50),
+    order_name         varchar(255),
+    billing_period_key varchar(100),
+    approved_at        timestamptz,
+    receipt_url        text,
+    raw_response       jsonb,
+    idempotency_key    varchar(255),
+    created_at         timestamptz not null default now(),
+    updated_at         timestamptz not null default now(),
+    constraint uq_payment_subscription_period unique (subscription_id, billing_period_key)
+);
+
+create table payment.payment_cancel (
+    id              bigserial primary key,
+    payment_id      bigint not null references payment.payment(id),
+    cancel_amount   bigint not null,
+    reason          text,
+    transaction_key varchar(255),
+    canceled_at     timestamptz not null default now()
+);
+
+create table payment.webhook_event (
+    id              bigserial primary key,
+    transmission_id varchar(255) not null unique,
+    event_type      varchar(100),
+    payload         jsonb,
+    processed_at    timestamptz,
+    created_at      timestamptz not null default now()
+);
+
+--changeset init:20260603-seed-payment-default-plan
+--comment: Seed default workspace subscription plan
+insert into payment.plan (plan_key, name, amount, currency, bill_interval, status)
+values ('pro_monthly', 'Pro (Monthly)', 29000, 'KRW', 'MONTH', 'ACTIVE')
+on conflict (plan_key) do nothing;

--- a/backend/src/main/resources/db/changelog/db.changelog-master.sql
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.sql
@@ -1051,3 +1051,7 @@ on conflict (plan_key) do nothing;
 create unique index uq_payment_subscription_workspace_open
     on payment.subscription (workspace_id)
     where status in ('INCOMPLETE', 'ACTIVE', 'PAST_DUE');
+
+--changeset init:20260603-add-idempotency-key-payment-cancel
+--comment: Per-cancel-attempt idempotency key for Toss API — prevents partial-cancel collisions (V-EC-004)
+alter table payment.payment_cancel add column idempotency_key varchar(255);

--- a/backend/src/test/java/com/init/payment/application/PaymentAccessGuardTest.java
+++ b/backend/src/test/java/com/init/payment/application/PaymentAccessGuardTest.java
@@ -1,5 +1,6 @@
 package com.init.payment.application;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 
@@ -54,6 +55,6 @@ class PaymentAccessGuardTest {
     given(workspaceMembershipPort.hasAnyRole(1L, 99L, Set.of("OWNER", "ADMIN", "OPERATOR")))
         .willReturn(true);
 
-    guard.requireMember(1L, 99L);
+    assertThatCode(() -> guard.requireMember(1L, 99L)).doesNotThrowAnyException();
   }
 }

--- a/backend/src/test/java/com/init/payment/application/PaymentAccessGuardTest.java
+++ b/backend/src/test/java/com/init/payment/application/PaymentAccessGuardTest.java
@@ -1,0 +1,59 @@
+package com.init.payment.application;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import com.init.payment.application.exception.PaymentWorkspaceAccessDeniedException;
+import com.init.payment.application.exception.PaymentWorkspaceNotFoundException;
+import com.init.payment.application.port.WorkspaceMembershipPort;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PaymentAccessGuard")
+class PaymentAccessGuardTest {
+
+  @Mock private WorkspaceMembershipPort workspaceMembershipPort;
+
+  private PaymentAccessGuard guard;
+
+  @BeforeEach
+  void setUp() {
+    guard = new PaymentAccessGuard(workspaceMembershipPort);
+  }
+
+  @Test
+  @DisplayName("워크스페이스가 없으면 PaymentWorkspaceNotFoundException을 던진다")
+  void requireMember_workspaceNotFound_throws() {
+    given(workspaceMembershipPort.existsById(99L)).willReturn(false);
+
+    assertThatThrownBy(() -> guard.requireMember(99L, 1L))
+        .isInstanceOf(PaymentWorkspaceNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("멤버십이 없거나 허용 역할이 아니면 PaymentWorkspaceAccessDeniedException을 던진다")
+  void requireMember_notAllowedRole_throws() {
+    given(workspaceMembershipPort.existsById(1L)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(1L, 99L, Set.of("OWNER", "ADMIN", "OPERATOR")))
+        .willReturn(false);
+
+    assertThatThrownBy(() -> guard.requireMember(1L, 99L))
+        .isInstanceOf(PaymentWorkspaceAccessDeniedException.class);
+  }
+
+  @Test
+  @DisplayName("워크스페이스 존재 + 허용 역할이면 통과한다")
+  void requireMember_validMember_passes() {
+    given(workspaceMembershipPort.existsById(1L)).willReturn(true);
+    given(workspaceMembershipPort.hasAnyRole(1L, 99L, Set.of("OWNER", "ADMIN", "OPERATOR")))
+        .willReturn(true);
+
+    guard.requireMember(1L, 99L);
+  }
+}

--- a/backend/src/test/java/com/init/payment/application/PaymentServiceTest.java
+++ b/backend/src/test/java/com/init/payment/application/PaymentServiceTest.java
@@ -1,0 +1,182 @@
+package com.init.payment.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.init.payment.application.exception.PaymentAmountMismatchException;
+import com.init.payment.application.port.TossPaymentPort;
+import com.init.payment.application.port.TossPaymentResult;
+import com.init.payment.domain.model.BillingInterval;
+import com.init.payment.domain.model.Payment;
+import com.init.payment.domain.model.Plan;
+import com.init.payment.domain.model.Subscription;
+import com.init.payment.domain.repository.PaymentCancelRepository;
+import com.init.payment.domain.repository.PaymentRepository;
+import com.init.payment.domain.repository.PlanRepository;
+import com.init.payment.domain.repository.SubscriptionRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.support.SimpleTransactionStatus;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PaymentService")
+class PaymentServiceTest {
+
+  @Mock private PaymentRepository paymentRepository;
+  @Mock private PaymentCancelRepository paymentCancelRepository;
+  @Mock private SubscriptionRepository subscriptionRepository;
+  @Mock private PlanRepository planRepository;
+  @Mock private TossPaymentPort tossPaymentPort;
+  @Mock private PaymentAccessGuard accessGuard;
+  @Mock private org.springframework.transaction.PlatformTransactionManager transactionManager;
+
+  private PaymentService paymentService;
+
+  private final Clock clock = Clock.fixed(Instant.parse("2026-06-01T00:00:00Z"), ZoneOffset.UTC);
+
+  @BeforeEach
+  void setUp() {
+    given(transactionManager.getTransaction(any())).willReturn(new SimpleTransactionStatus());
+    paymentService =
+        new PaymentService(
+            paymentRepository,
+            paymentCancelRepository,
+            subscriptionRepository,
+            planRepository,
+            tossPaymentPort,
+            accessGuard,
+            clock,
+            transactionManager);
+  }
+
+  @Test
+  @DisplayName("금액이 일치하면 Toss confirm 후 DONE으로 기록하고 구독을 활성화한다")
+  void confirm_success() {
+    Subscription subscription = subscription(5L, 10L);
+    Plan plan = plan(10L, 29000);
+    given(subscriptionRepository.findCurrentByWorkspaceId(1L))
+        .willReturn(Optional.of(subscription));
+    given(planRepository.findById(10L)).willReturn(Optional.of(plan));
+    given(paymentRepository.findByOrderId("ord_1")).willReturn(Optional.empty());
+    given(subscriptionRepository.findById(5L)).willReturn(Optional.of(subscription));
+    given(paymentRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+    given(tossPaymentPort.confirmPayment("pay_1", "ord_1", 29000))
+        .willReturn(doneResult("pay_1", "ord_1", 29000));
+
+    PaymentResult result =
+        paymentService.confirmPayment(new ConfirmPaymentCommand(1L, 99L, "pay_1", "ord_1", 29000));
+
+    assertThat(result.status()).isEqualTo("DONE");
+    assertThat(subscription.isActive()).isTrue();
+  }
+
+  @Test
+  @DisplayName("금액이 다르면 PaymentAmountMismatchException을 던지고 Toss를 호출하지 않는다")
+  void confirm_amountMismatch() {
+    Subscription subscription = subscription(5L, 10L);
+    given(subscriptionRepository.findCurrentByWorkspaceId(1L))
+        .willReturn(Optional.of(subscription));
+    given(planRepository.findById(10L)).willReturn(Optional.of(plan(10L, 29000)));
+    given(paymentRepository.findByOrderId("ord_1")).willReturn(Optional.empty());
+
+    assertThatThrownBy(
+            () ->
+                paymentService.confirmPayment(
+                    new ConfirmPaymentCommand(1L, 99L, "pay_1", "ord_1", 10000)))
+        .isInstanceOf(PaymentAmountMismatchException.class);
+
+    verify(tossPaymentPort, never()).confirmPayment(any(), any(), anyLong());
+  }
+
+  @Test
+  @DisplayName("이미 완료된 주문은 멱등하게 기존 결제를 반환하고 Toss를 재호출하지 않는다")
+  void confirm_idempotent() {
+    Subscription subscription = subscription(5L, 10L);
+    Payment done = Payment.createOrder(1L, 5L, "ord_1", 29000, "KRW", "Pro");
+    done.complete("pay_1", "카드", OffsetDateTime.now(clock), null, "{}");
+    given(subscriptionRepository.findCurrentByWorkspaceId(1L))
+        .willReturn(Optional.of(subscription));
+    given(planRepository.findById(10L)).willReturn(Optional.of(plan(10L, 29000)));
+    given(paymentRepository.findByOrderId("ord_1")).willReturn(Optional.of(done));
+
+    PaymentResult result =
+        paymentService.confirmPayment(new ConfirmPaymentCommand(1L, 99L, "pay_1", "ord_1", 29000));
+
+    assertThat(result.status()).isEqualTo("DONE");
+    verify(tossPaymentPort, never()).confirmPayment(any(), any(), anyLong());
+  }
+
+  @Test
+  @DisplayName("부분 취소 시 PARTIAL_CANCELED로 기록하고 취소 내역을 저장한다")
+  void cancel_partial() {
+    Payment payment = Payment.createOrder(1L, 5L, "ord_1", 29000, "KRW", "Pro");
+    payment.complete("pay_1", "카드", OffsetDateTime.now(clock), null, "{}");
+    ReflectionTestUtils.setField(payment, "id", 7L);
+    given(paymentRepository.findByPaymentKeyAndWorkspaceId("pay_1", 1L))
+        .willReturn(Optional.of(payment));
+    given(paymentRepository.findById(7L)).willReturn(Optional.of(payment));
+    given(paymentRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+    given(tossPaymentPort.cancelPayment("pay_1", "고객 요청", 10000L))
+        .willReturn(partialCanceledResult());
+
+    PaymentResult result =
+        paymentService.cancelPayment(new CancelPaymentCommand(1L, 99L, "pay_1", "고객 요청", 10000L));
+
+    assertThat(result.status()).isEqualTo("PARTIAL_CANCELED");
+    verify(paymentCancelRepository).save(any());
+  }
+
+  private Subscription subscription(Long id, Long planId) {
+    Subscription subscription = Subscription.create(1L, planId);
+    subscription.assignCustomerKey("wsk_1_abc");
+    ReflectionTestUtils.setField(subscription, "id", id);
+    return subscription;
+  }
+
+  private Plan plan(Long id, long amount) {
+    Plan plan = Plan.create("pro_monthly", "Pro", amount, "KRW", BillingInterval.MONTH);
+    ReflectionTestUtils.setField(plan, "id", id);
+    return plan;
+  }
+
+  private TossPaymentResult doneResult(String paymentKey, String orderId, long amount) {
+    return new TossPaymentResult(
+        paymentKey,
+        orderId,
+        amount,
+        "DONE",
+        "카드",
+        OffsetDateTime.now(clock),
+        "https://receipt",
+        null,
+        "{\"status\":\"DONE\"}");
+  }
+
+  private TossPaymentResult partialCanceledResult() {
+    return new TossPaymentResult(
+        "pay_1",
+        "ord_1",
+        29000,
+        "PARTIAL_CANCELED",
+        "카드",
+        OffsetDateTime.now(clock),
+        null,
+        "txn_1",
+        "{\"status\":\"PARTIAL_CANCELED\"}");
+  }
+}

--- a/backend/src/test/java/com/init/payment/application/PaymentServiceTest.java
+++ b/backend/src/test/java/com/init/payment/application/PaymentServiceTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
@@ -137,10 +139,16 @@ class PaymentServiceTest {
         .willReturn(Optional.of(payment));
     given(paymentRepository.findById(7L)).willReturn(Optional.of(payment));
     given(paymentRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
-    given(tossPaymentPort.cancelPayment("pay_1", "전액취소", null)).willReturn(canceledResult());
+    given(
+            paymentCancelRepository.findFirstByPaymentIdAndCancelAmountOrderByIdDesc(
+                eq(7L), eq(29000L)))
+        .willReturn(Optional.empty());
+    given(tossPaymentPort.cancelPayment(eq("pay_1"), eq("전액취소"), isNull(), any()))
+        .willReturn(canceledResult());
 
     PaymentResult result =
-        paymentService.cancelPayment(new CancelPaymentCommand(1L, 99L, "pay_1", "전액취소", null));
+        paymentService.cancelPayment(
+            new CancelPaymentCommand(1L, 99L, "pay_1", "전액취소", null, "idem-full-1"));
 
     assertThat(result.status()).isEqualTo("CANCELED");
     verify(paymentCancelRepository).save(any());
@@ -159,9 +167,9 @@ class PaymentServiceTest {
     assertThatThrownBy(
             () ->
                 paymentService.cancelPayment(
-                    new CancelPaymentCommand(1L, 99L, "pay_1", "고객요청", 20000L)))
+                    new CancelPaymentCommand(1L, 99L, "pay_1", "고객요청", 20000L, "idem-ex-1")))
         .isInstanceOf(PaymentCancelNotAllowedException.class);
-    verify(tossPaymentPort, never()).cancelPayment(any(), any(), any());
+    verify(tossPaymentPort, never()).cancelPayment(any(), any(), any(), any());
   }
 
   @Test
@@ -173,7 +181,7 @@ class PaymentServiceTest {
     assertThatThrownBy(
             () ->
                 paymentService.cancelPayment(
-                    new CancelPaymentCommand(1L, 99L, "pay_x", "고객요청", null)))
+                    new CancelPaymentCommand(1L, 99L, "pay_x", "고객요청", null, "idem-notfound-1")))
         .isInstanceOf(PaymentNotFoundException.class);
   }
 
@@ -229,11 +237,16 @@ class PaymentServiceTest {
         .willReturn(Optional.of(payment));
     given(paymentRepository.findById(7L)).willReturn(Optional.of(payment));
     given(paymentRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
-    given(tossPaymentPort.cancelPayment("pay_1", "고객 요청", 10000L))
+    given(
+            paymentCancelRepository.findFirstByPaymentIdAndCancelAmountOrderByIdDesc(
+                eq(7L), eq(10000L)))
+        .willReturn(Optional.empty());
+    given(tossPaymentPort.cancelPayment(eq("pay_1"), eq("고객 요청"), eq(10000L), any()))
         .willReturn(partialCanceledResult());
 
     PaymentResult result =
-        paymentService.cancelPayment(new CancelPaymentCommand(1L, 99L, "pay_1", "고객 요청", 10000L));
+        paymentService.cancelPayment(
+            new CancelPaymentCommand(1L, 99L, "pay_1", "고객 요청", 10000L, "idem-partial-1"));
 
     assertThat(result.status()).isEqualTo("PARTIAL_CANCELED");
     verify(paymentCancelRepository).save(any());

--- a/backend/src/test/java/com/init/payment/application/PaymentServiceTest.java
+++ b/backend/src/test/java/com/init/payment/application/PaymentServiceTest.java
@@ -5,10 +5,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.init.payment.application.exception.PaymentAmountMismatchException;
+import com.init.payment.application.exception.PaymentCancelNotAllowedException;
+import com.init.payment.application.exception.PaymentNotFoundException;
 import com.init.payment.application.port.TossPaymentPort;
 import com.init.payment.application.port.TossPaymentResult;
 import com.init.payment.domain.model.BillingInterval;
@@ -51,7 +54,9 @@ class PaymentServiceTest {
 
   @BeforeEach
   void setUp() {
-    given(transactionManager.getTransaction(any())).willReturn(new SimpleTransactionStatus());
+    lenient()
+        .when(transactionManager.getTransaction(any()))
+        .thenReturn(new SimpleTransactionStatus());
     paymentService =
         new PaymentService(
             paymentRepository,
@@ -72,7 +77,7 @@ class PaymentServiceTest {
     given(subscriptionRepository.findCurrentByWorkspaceId(1L))
         .willReturn(Optional.of(subscription));
     given(planRepository.findById(10L)).willReturn(Optional.of(plan));
-    given(paymentRepository.findByOrderId("ord_1")).willReturn(Optional.empty());
+    given(paymentRepository.findByWorkspaceIdAndOrderId(1L, "ord_1")).willReturn(Optional.empty());
     given(subscriptionRepository.findById(5L)).willReturn(Optional.of(subscription));
     given(paymentRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
     given(tossPaymentPort.confirmPayment("pay_1", "ord_1", 29000))
@@ -92,7 +97,7 @@ class PaymentServiceTest {
     given(subscriptionRepository.findCurrentByWorkspaceId(1L))
         .willReturn(Optional.of(subscription));
     given(planRepository.findById(10L)).willReturn(Optional.of(plan(10L, 29000)));
-    given(paymentRepository.findByOrderId("ord_1")).willReturn(Optional.empty());
+    given(paymentRepository.findByWorkspaceIdAndOrderId(1L, "ord_1")).willReturn(Optional.empty());
 
     assertThatThrownBy(
             () ->
@@ -112,13 +117,77 @@ class PaymentServiceTest {
     given(subscriptionRepository.findCurrentByWorkspaceId(1L))
         .willReturn(Optional.of(subscription));
     given(planRepository.findById(10L)).willReturn(Optional.of(plan(10L, 29000)));
-    given(paymentRepository.findByOrderId("ord_1")).willReturn(Optional.of(done));
+    given(paymentRepository.findByWorkspaceIdAndOrderId(1L, "ord_1")).willReturn(Optional.of(done));
 
     PaymentResult result =
         paymentService.confirmPayment(new ConfirmPaymentCommand(1L, 99L, "pay_1", "ord_1", 29000));
 
     assertThat(result.status()).isEqualTo("DONE");
     verify(tossPaymentPort, never()).confirmPayment(any(), any(), anyLong());
+  }
+
+  @Test
+  @DisplayName("전액 취소 시 CANCELED로 기록한다")
+  void cancel_full() {
+    Payment payment = Payment.createOrder(1L, 5L, "ord_1", 29000, "KRW", "Pro");
+    payment.complete("pay_1", "카드", OffsetDateTime.now(clock), null, "{}");
+    ReflectionTestUtils.setField(payment, "id", 7L);
+    given(paymentRepository.findByPaymentKeyAndWorkspaceId("pay_1", 1L))
+        .willReturn(Optional.of(payment));
+    given(paymentRepository.findById(7L)).willReturn(Optional.of(payment));
+    given(paymentRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+    given(tossPaymentPort.cancelPayment("pay_1", "전액취소", null)).willReturn(canceledResult());
+
+    PaymentResult result =
+        paymentService.cancelPayment(new CancelPaymentCommand(1L, 99L, "pay_1", "전액취소", null));
+
+    assertThat(result.status()).isEqualTo("CANCELED");
+    verify(paymentCancelRepository).save(any());
+  }
+
+  @Test
+  @DisplayName("잔여 취소 가능 금액 초과 시 PaymentCancelNotAllowedException을 던진다 (V-NEW-002)")
+  void cancel_exceedsRemaining_throws() {
+    Payment payment = Payment.createOrder(1L, 5L, "ord_1", 29000, "KRW", "Pro");
+    payment.complete("pay_1", "카드", OffsetDateTime.now(clock), null, "{}");
+    ReflectionTestUtils.setField(payment, "id", 7L);
+    given(paymentRepository.findByPaymentKeyAndWorkspaceId("pay_1", 1L))
+        .willReturn(Optional.of(payment));
+    given(paymentCancelRepository.sumCancelAmountByPaymentId(7L)).willReturn(15000L);
+
+    assertThatThrownBy(
+            () ->
+                paymentService.cancelPayment(
+                    new CancelPaymentCommand(1L, 99L, "pay_1", "고객요청", 20000L)))
+        .isInstanceOf(PaymentCancelNotAllowedException.class);
+    verify(tossPaymentPort, never()).cancelPayment(any(), any(), any());
+  }
+
+  @Test
+  @DisplayName("결제를 찾을 수 없으면 cancelPayment 시 PaymentNotFoundException을 던진다")
+  void cancel_paymentNotFound_throws() {
+    given(paymentRepository.findByPaymentKeyAndWorkspaceId("pay_x", 1L))
+        .willReturn(Optional.empty());
+
+    assertThatThrownBy(
+            () ->
+                paymentService.cancelPayment(
+                    new CancelPaymentCommand(1L, 99L, "pay_x", "고객요청", null)))
+        .isInstanceOf(PaymentNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("결제 목록 조회 시 해당 워크스페이스 결제만 반환한다")
+  void getPayments_returnsWorkspacePayments() {
+    Payment payment = Payment.createOrder(1L, 5L, "ord_1", 29000, "KRW", "Pro");
+    payment.complete("pay_1", "카드", OffsetDateTime.now(clock), null, "{}");
+    given(paymentRepository.findByWorkspaceIdOrderByCreatedAtDesc(1L))
+        .willReturn(java.util.List.of(payment));
+
+    java.util.List<PaymentResult> results = paymentService.getPayments(1L, 99L);
+
+    assertThat(results).hasSize(1);
+    assertThat(results.get(0).status()).isEqualTo("DONE");
   }
 
   @Test
@@ -178,5 +247,18 @@ class PaymentServiceTest {
         null,
         "txn_1",
         "{\"status\":\"PARTIAL_CANCELED\"}");
+  }
+
+  private TossPaymentResult canceledResult() {
+    return new TossPaymentResult(
+        "pay_1",
+        "ord_1",
+        29000,
+        "CANCELED",
+        "카드",
+        OffsetDateTime.now(clock),
+        null,
+        "txn_1",
+        "{\"status\":\"CANCELED\"}");
   }
 }

--- a/backend/src/test/java/com/init/payment/application/PaymentServiceTest.java
+++ b/backend/src/test/java/com/init/payment/application/PaymentServiceTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.support.SimpleTransactionStatus;
 
@@ -174,6 +175,34 @@ class PaymentServiceTest {
                 paymentService.cancelPayment(
                     new CancelPaymentCommand(1L, 99L, "pay_x", "고객요청", null)))
         .isInstanceOf(PaymentNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("confirmPayment 동시삽입 충돌 시 DataIntegrityViolationException → 기존 레코드 반환")
+  void confirm_concurrentInsert_fallsBackToExisting() {
+    Subscription subscription = subscription(5L, 10L);
+    Plan plan = plan(10L, 29000);
+    Payment existing = Payment.createOrder(1L, 5L, "ord_1", 29000, "KRW", "Pro");
+    existing.complete("pay_1", "카드", OffsetDateTime.now(clock), null, "{}");
+
+    given(subscriptionRepository.findCurrentByWorkspaceId(1L))
+        .willReturn(Optional.of(subscription));
+    given(planRepository.findById(10L)).willReturn(Optional.of(plan));
+    // first inTx, second inTx orElseGet, savePayment catch block
+    given(paymentRepository.findByWorkspaceIdAndOrderId(1L, "ord_1"))
+        .willReturn(Optional.empty())
+        .willReturn(Optional.empty())
+        .willReturn(Optional.of(existing));
+    given(subscriptionRepository.findById(5L)).willReturn(Optional.of(subscription));
+    given(tossPaymentPort.confirmPayment("pay_1", "ord_1", 29000))
+        .willReturn(doneResult("pay_1", "ord_1", 29000));
+    given(paymentRepository.save(any()))
+        .willThrow(new DataIntegrityViolationException("duplicate key"));
+
+    PaymentResult result =
+        paymentService.confirmPayment(new ConfirmPaymentCommand(1L, 99L, "pay_1", "ord_1", 29000));
+
+    assertThat(result.status()).isEqualTo("DONE");
   }
 
   @Test

--- a/backend/src/test/java/com/init/payment/application/PaymentWebhookServiceTest.java
+++ b/backend/src/test/java/com/init/payment/application/PaymentWebhookServiceTest.java
@@ -173,6 +173,23 @@ class PaymentWebhookServiceTest {
   }
 
   @Test
+  @DisplayName("Payment DB 미존재 시 markProcessed를 건너뛴다 — Toss 재시도 허용 (V-EC-001)")
+  void paymentNotFound_skips_markProcessed() {
+    given(transactionManager.getTransaction(any())).willReturn(new SimpleTransactionStatus());
+    given(webhookEventRepository.findByTransmissionId("txn_nr")).willReturn(Optional.empty());
+    given(paymentRepository.findByPaymentKey("pay_nr")).willReturn(Optional.empty());
+    given(tossPaymentPort.getPayment("pay_nr"))
+        .willReturn(
+            new TossPaymentResult("pay_nr", "ord_nr", 29000, "DONE", null, null, null, null, "{}"));
+
+    service.handle(
+        new HandleTossWebhookCommand(SECRET, "txn_nr", "PAYMENT_STATUS", "pay_nr", "{}"));
+
+    verify(webhookEventRepository, never())
+        .findByTransmissionId(org.mockito.ArgumentMatchers.eq("txn_nr__processed"));
+  }
+
+  @Test
   @DisplayName("빈 문자열 시크릿으로 구성된 서비스는 모든 웹훅을 거절한다")
   void emptyConfiguredSecret_throws_unauthorized() {
     PaymentWebhookService serviceWithEmptySecret =

--- a/backend/src/test/java/com/init/payment/application/PaymentWebhookServiceTest.java
+++ b/backend/src/test/java/com/init/payment/application/PaymentWebhookServiceTest.java
@@ -15,7 +15,6 @@ import com.init.payment.domain.model.PaymentStatus;
 import com.init.payment.domain.model.WebhookEvent;
 import com.init.payment.domain.repository.PaymentRepository;
 import com.init.payment.domain.repository.WebhookEventRepository;
-import com.init.payment.infrastructure.config.TossApiProperties;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -47,14 +46,12 @@ class PaymentWebhookServiceTest {
 
   @BeforeEach
   void setUp() {
-    TossApiProperties properties =
-        new TossApiProperties(null, new TossApiProperties.Webhook(SECRET), "enc");
     service =
         new PaymentWebhookService(
             webhookEventRepository,
             paymentRepository,
             tossPaymentPort,
-            properties,
+            SECRET,
             clock,
             transactionManager);
   }
@@ -109,5 +106,89 @@ class PaymentWebhookServiceTest {
 
     assertThat(payment.getStatus()).isEqualTo(PaymentStatus.DONE);
     verify(paymentRepository).save(payment);
+  }
+
+  @Test
+  @DisplayName("paymentKey가 null이면 Toss 재조회를 건너뛴다")
+  void nullPaymentKey_skips_toss_call() {
+    given(transactionManager.getTransaction(any())).willReturn(new SimpleTransactionStatus());
+    given(webhookEventRepository.findByTransmissionId("txn_2")).willReturn(Optional.empty());
+
+    service.handle(new HandleTossWebhookCommand(SECRET, "txn_2", "PAYMENT_STATUS", null, "{}"));
+
+    verify(tossPaymentPort, never()).getPayment(any());
+  }
+
+  @Test
+  @DisplayName("paymentKey가 공백이면 Toss 재조회를 건너뛴다")
+  void blankPaymentKey_skips_toss_call() {
+    given(transactionManager.getTransaction(any())).willReturn(new SimpleTransactionStatus());
+    given(webhookEventRepository.findByTransmissionId("txn_3")).willReturn(Optional.empty());
+
+    service.handle(new HandleTossWebhookCommand(SECRET, "txn_3", "PAYMENT_STATUS", "  ", "{}"));
+
+    verify(tossPaymentPort, never()).getPayment(any());
+  }
+
+  @Test
+  @DisplayName("Toss 재조회 결과가 CANCELED이면 결제를 취소로 반영한다")
+  void canceledStatus_marks_payment_canceled() {
+    given(transactionManager.getTransaction(any())).willReturn(new SimpleTransactionStatus());
+    given(webhookEventRepository.findByTransmissionId("txn_4")).willReturn(Optional.empty());
+    Payment payment =
+        Payment.createRecurring(
+            1L, 5L, "ord_1", 29000, "KRW", "Pro", "2026-06-01T00:00:00Z", "idem");
+    payment.complete("pay_1", "카드", OffsetDateTime.now(clock), "url", "{}");
+    given(paymentRepository.findByPaymentKey("pay_1")).willReturn(Optional.of(payment));
+    given(tossPaymentPort.getPayment("pay_1"))
+        .willReturn(
+            new TossPaymentResult(
+                "pay_1", "ord_1", 29000, "CANCELED", null, null, null, "txn_c", "{}"));
+
+    service.handle(new HandleTossWebhookCommand(SECRET, "txn_4", "PAYMENT_STATUS", "pay_1", "{}"));
+
+    assertThat(payment.getStatus()).isEqualTo(PaymentStatus.CANCELED);
+    verify(paymentRepository).save(payment);
+  }
+
+  @Test
+  @DisplayName("Toss 재조회 결과가 PARTIAL_CANCELED이면 결제를 부분취소로 반영한다")
+  void partialCanceledStatus_marks_payment_partial_canceled() {
+    given(transactionManager.getTransaction(any())).willReturn(new SimpleTransactionStatus());
+    given(webhookEventRepository.findByTransmissionId("txn_5")).willReturn(Optional.empty());
+    Payment payment =
+        Payment.createRecurring(
+            1L, 5L, "ord_1", 29000, "KRW", "Pro", "2026-06-01T00:00:00Z", "idem");
+    payment.complete("pay_1", "카드", OffsetDateTime.now(clock), "url", "{}");
+    given(paymentRepository.findByPaymentKey("pay_1")).willReturn(Optional.of(payment));
+    given(tossPaymentPort.getPayment("pay_1"))
+        .willReturn(
+            new TossPaymentResult(
+                "pay_1", "ord_1", 15000, "PARTIAL_CANCELED", null, null, null, "txn_pc", "{}"));
+
+    service.handle(new HandleTossWebhookCommand(SECRET, "txn_5", "PAYMENT_STATUS", "pay_1", "{}"));
+
+    assertThat(payment.getStatus()).isEqualTo(PaymentStatus.PARTIAL_CANCELED);
+    verify(paymentRepository).save(payment);
+  }
+
+  @Test
+  @DisplayName("빈 문자열 시크릿으로 구성된 서비스는 모든 웹훅을 거절한다")
+  void emptyConfiguredSecret_throws_unauthorized() {
+    PaymentWebhookService serviceWithEmptySecret =
+        new PaymentWebhookService(
+            webhookEventRepository,
+            paymentRepository,
+            tossPaymentPort,
+            "",
+            clock,
+            transactionManager);
+
+    assertThatThrownBy(
+            () ->
+                serviceWithEmptySecret.handle(
+                    new HandleTossWebhookCommand(
+                        "any-secret", "txn_6", "PAYMENT_STATUS", "pay_1", "{}")))
+        .isInstanceOf(PaymentWebhookUnauthorizedException.class);
   }
 }

--- a/backend/src/test/java/com/init/payment/application/PaymentWebhookServiceTest.java
+++ b/backend/src/test/java/com/init/payment/application/PaymentWebhookServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.init.payment.application.exception.PaymentWebhookUnauthorizedException;
@@ -220,8 +221,7 @@ class PaymentWebhookServiceTest {
     service.handle(
         new HandleTossWebhookCommand(SECRET, "txn_nr", "PAYMENT_STATUS", "pay_nr", "{}"));
 
-    verify(webhookEventRepository, never())
-        .findByTransmissionId(org.mockito.ArgumentMatchers.eq("txn_nr__processed"));
+    verify(webhookEventRepository, times(1)).findByTransmissionId("txn_nr");
   }
 
   @Test

--- a/backend/src/test/java/com/init/payment/application/PaymentWebhookServiceTest.java
+++ b/backend/src/test/java/com/init/payment/application/PaymentWebhookServiceTest.java
@@ -173,6 +173,41 @@ class PaymentWebhookServiceTest {
   }
 
   @Test
+  @DisplayName("markProcessed 호출 시 미처리 이벤트를 처리 완료로 갱신한다")
+  void markProcessed_updatesUnprocessedEvent() {
+    given(transactionManager.getTransaction(any())).willReturn(new SimpleTransactionStatus());
+    WebhookEvent event = WebhookEvent.received("txn_mp", "PAYMENT_STATUS", "{}");
+    given(webhookEventRepository.findByTransmissionId("txn_mp"))
+        .willReturn(Optional.empty()) // handle() 첫 번째 조회 (중복 체크)
+        .willReturn(Optional.of(event)); // markProcessed() 내부 조회
+    given(tossPaymentPort.getPayment("pay_mp"))
+        .willReturn(
+            new TossPaymentResult("pay_mp", "ord_mp", 29000, "DONE", null, null, null, null, "{}"));
+    Payment payment =
+        Payment.createRecurring(
+            1L, 5L, "ord_mp", 29000, "KRW", "Pro", "2026-06-01T00:00:00Z", "idem");
+    given(paymentRepository.findByPaymentKey("pay_mp")).willReturn(Optional.of(payment));
+
+    service.handle(
+        new HandleTossWebhookCommand(SECRET, "txn_mp", "PAYMENT_STATUS", "pay_mp", "{}"));
+
+    verify(webhookEventRepository).save(event);
+  }
+
+  @Test
+  @DisplayName("동시 수신으로 ensureReceived에서 DataIntegrityViolationException 발생 시 무시한다")
+  void ensureReceived_concurrentDuplicate_isIgnored() {
+    given(transactionManager.getTransaction(any())).willReturn(new SimpleTransactionStatus());
+    given(webhookEventRepository.findByTransmissionId("txn_dup")).willReturn(Optional.empty());
+    given(webhookEventRepository.save(any()))
+        .willThrow(new org.springframework.dao.DataIntegrityViolationException("duplicate"));
+
+    service.handle(new HandleTossWebhookCommand(SECRET, "txn_dup", "PAYMENT_STATUS", null, "{}"));
+
+    verify(tossPaymentPort, never()).getPayment(any());
+  }
+
+  @Test
   @DisplayName("Payment DB 미존재 시 markProcessed를 건너뛴다 — Toss 재시도 허용 (V-EC-001)")
   void paymentNotFound_skips_markProcessed() {
     given(transactionManager.getTransaction(any())).willReturn(new SimpleTransactionStatus());

--- a/backend/src/test/java/com/init/payment/application/PaymentWebhookServiceTest.java
+++ b/backend/src/test/java/com/init/payment/application/PaymentWebhookServiceTest.java
@@ -1,0 +1,113 @@
+package com.init.payment.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.init.payment.application.exception.PaymentWebhookUnauthorizedException;
+import com.init.payment.application.port.TossPaymentPort;
+import com.init.payment.application.port.TossPaymentResult;
+import com.init.payment.domain.model.Payment;
+import com.init.payment.domain.model.PaymentStatus;
+import com.init.payment.domain.model.WebhookEvent;
+import com.init.payment.domain.repository.PaymentRepository;
+import com.init.payment.domain.repository.WebhookEventRepository;
+import com.init.payment.infrastructure.config.TossApiProperties;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.SimpleTransactionStatus;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PaymentWebhookService")
+class PaymentWebhookServiceTest {
+
+  private static final String SECRET = "test-toss-webhook-secret";
+
+  @Mock private WebhookEventRepository webhookEventRepository;
+  @Mock private PaymentRepository paymentRepository;
+  @Mock private TossPaymentPort tossPaymentPort;
+  @Mock private PlatformTransactionManager transactionManager;
+
+  private PaymentWebhookService service;
+
+  private final Clock clock = Clock.fixed(Instant.parse("2026-06-01T00:00:00Z"), ZoneOffset.UTC);
+
+  @BeforeEach
+  void setUp() {
+    TossApiProperties properties =
+        new TossApiProperties(null, new TossApiProperties.Webhook(SECRET), "enc");
+    service =
+        new PaymentWebhookService(
+            webhookEventRepository,
+            paymentRepository,
+            tossPaymentPort,
+            properties,
+            clock,
+            transactionManager);
+  }
+
+  @Test
+  @DisplayName("시크릿 헤더가 불일치하면 PaymentWebhookUnauthorizedException을 던진다")
+  void invalidSecret_throws() {
+    assertThatThrownBy(
+            () ->
+                service.handle(
+                    new HandleTossWebhookCommand(
+                        "wrong", "txn_1", "PAYMENT_STATUS", "pay_1", "{}")))
+        .isInstanceOf(PaymentWebhookUnauthorizedException.class);
+    verify(tossPaymentPort, never()).getPayment(any());
+  }
+
+  @Test
+  @DisplayName("이미 처리된 transmission_id는 멱등하게 재처리하지 않는다 (U-003)")
+  void alreadyProcessed_isIdempotent() {
+    WebhookEvent processed = WebhookEvent.received("txn_1", "PAYMENT_STATUS", "{}");
+    processed.markProcessed(OffsetDateTime.now(clock));
+    given(webhookEventRepository.findByTransmissionId("txn_1")).willReturn(Optional.of(processed));
+
+    service.handle(new HandleTossWebhookCommand(SECRET, "txn_1", "PAYMENT_STATUS", "pay_1", "{}"));
+
+    verify(tossPaymentPort, never()).getPayment(any());
+  }
+
+  @Test
+  @DisplayName("유효한 웹훅은 Toss 재조회 후 권위 상태를 결제에 반영한다 (U-003)")
+  void validWebhook_reflectsAuthoritativeStatus() {
+    given(transactionManager.getTransaction(any())).willReturn(new SimpleTransactionStatus());
+    given(webhookEventRepository.findByTransmissionId("txn_1")).willReturn(Optional.empty());
+    Payment payment =
+        Payment.createRecurring(
+            1L, 5L, "ord_1", 29000, "KRW", "Pro", "2026-06-01T00:00:00Z", "idem");
+    given(paymentRepository.findByPaymentKey("pay_1")).willReturn(Optional.of(payment));
+    given(tossPaymentPort.getPayment("pay_1"))
+        .willReturn(
+            new TossPaymentResult(
+                "pay_1",
+                "ord_1",
+                29000,
+                "DONE",
+                "카드",
+                OffsetDateTime.now(clock),
+                "https://receipt",
+                null,
+                "{\"status\":\"DONE\"}"));
+
+    service.handle(new HandleTossWebhookCommand(SECRET, "txn_1", "PAYMENT_STATUS", "pay_1", "{}"));
+
+    assertThat(payment.getStatus()).isEqualTo(PaymentStatus.DONE);
+    verify(paymentRepository).save(payment);
+  }
+}

--- a/backend/src/test/java/com/init/payment/application/RecurringBillingSchedulerTest.java
+++ b/backend/src/test/java/com/init/payment/application/RecurringBillingSchedulerTest.java
@@ -1,0 +1,41 @@
+package com.init.payment.application;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RecurringBillingScheduler")
+class RecurringBillingSchedulerTest {
+
+  @Mock private RecurringBillingService recurringBillingService;
+
+  private RecurringBillingScheduler scheduler;
+
+  @BeforeEach
+  void setUp() {
+    scheduler = new RecurringBillingScheduler(recurringBillingService);
+  }
+
+  @Test
+  @DisplayName("runRecurringBilling은 RecurringBillingService.run()에 위임한다")
+  void runRecurringBilling_delegates() {
+    scheduler.runRecurringBilling();
+
+    verify(recurringBillingService).run();
+  }
+
+  @Test
+  @DisplayName("RecurringBillingService.run()이 RuntimeException을 던져도 스케줄러가 삼킨다")
+  void runRecurringBilling_catchesRuntimeException() {
+    doThrow(new RuntimeException("service error")).when(recurringBillingService).run();
+
+    scheduler.runRecurringBilling();
+  }
+}

--- a/backend/src/test/java/com/init/payment/application/RecurringBillingSchedulerTest.java
+++ b/backend/src/test/java/com/init/payment/application/RecurringBillingSchedulerTest.java
@@ -1,5 +1,6 @@
 package com.init.payment.application;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 
@@ -36,6 +37,7 @@ class RecurringBillingSchedulerTest {
   void runRecurringBilling_catchesRuntimeException() {
     doThrow(new RuntimeException("service error")).when(recurringBillingService).run();
 
-    scheduler.runRecurringBilling();
+    assertThatCode(() -> scheduler.runRecurringBilling()).doesNotThrowAnyException();
+    verify(recurringBillingService).run();
   }
 }

--- a/backend/src/test/java/com/init/payment/application/RecurringBillingServiceTest.java
+++ b/backend/src/test/java/com/init/payment/application/RecurringBillingServiceTest.java
@@ -82,7 +82,7 @@ class RecurringBillingServiceTest {
     given(subscriptionRepository.findById(5L)).willReturn(Optional.of(subscription));
     given(subscriptionRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
     given(planRepository.findById(10L)).willReturn(Optional.of(plan()));
-    given(paymentRepository.findBySubscriptionIdAndBillingPeriodKey(eq(5L), anyString()))
+    given(paymentRepository.findBySubscriptionIdAndBillingPeriodKeyForUpdate(eq(5L), anyString()))
         .willReturn(Optional.empty());
     given(paymentRepository.save(any()))
         .willAnswer(
@@ -200,7 +200,7 @@ class RecurringBillingServiceTest {
     given(subscriptionRepository.findById(5L)).willReturn(Optional.of(subscription));
     given(subscriptionRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
     given(planRepository.findById(10L)).willReturn(Optional.of(plan()));
-    given(paymentRepository.findBySubscriptionIdAndBillingPeriodKey(eq(5L), anyString()))
+    given(paymentRepository.findBySubscriptionIdAndBillingPeriodKeyForUpdate(eq(5L), anyString()))
         .willReturn(Optional.of(donePayment));
 
     service.run();
@@ -221,7 +221,7 @@ class RecurringBillingServiceTest {
     given(subscriptionRepository.findById(5L)).willReturn(Optional.of(subscription));
     given(subscriptionRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
     given(planRepository.findById(10L)).willReturn(Optional.of(plan()));
-    given(paymentRepository.findBySubscriptionIdAndBillingPeriodKey(eq(5L), anyString()))
+    given(paymentRepository.findBySubscriptionIdAndBillingPeriodKeyForUpdate(eq(5L), anyString()))
         .willReturn(Optional.empty());
     given(paymentRepository.save(any()))
         .willAnswer(
@@ -288,7 +288,7 @@ class RecurringBillingServiceTest {
     given(subscriptionRepository.findRetryDue(any())).willReturn(List.of(subscription));
     given(subscriptionRepository.findById(5L)).willReturn(Optional.of(subscription));
     given(planRepository.findById(10L)).willReturn(Optional.of(plan()));
-    given(paymentRepository.findBySubscriptionIdAndBillingPeriodKey(eq(5L), anyString()))
+    given(paymentRepository.findBySubscriptionIdAndBillingPeriodKeyForUpdate(eq(5L), anyString()))
         .willReturn(Optional.empty());
     given(paymentRepository.save(any()))
         .willThrow(new org.springframework.dao.DataIntegrityViolationException("duplicate"));

--- a/backend/src/test/java/com/init/payment/application/RecurringBillingServiceTest.java
+++ b/backend/src/test/java/com/init/payment/application/RecurringBillingServiceTest.java
@@ -1,0 +1,129 @@
+package com.init.payment.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+import com.init.payment.application.exception.PaymentGatewayException;
+import com.init.payment.application.port.BillingKeyCipher;
+import com.init.payment.application.port.TossPaymentPort;
+import com.init.payment.domain.model.BillingInterval;
+import com.init.payment.domain.model.BillingKey;
+import com.init.payment.domain.model.Payment;
+import com.init.payment.domain.model.PaymentStatus;
+import com.init.payment.domain.model.Plan;
+import com.init.payment.domain.model.Subscription;
+import com.init.payment.domain.model.SubscriptionStatus;
+import com.init.payment.domain.repository.BillingKeyRepository;
+import com.init.payment.domain.repository.PaymentRepository;
+import com.init.payment.domain.repository.PlanRepository;
+import com.init.payment.domain.repository.SubscriptionRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.SimpleTransactionStatus;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RecurringBillingService")
+class RecurringBillingServiceTest {
+
+  @Mock private SubscriptionRepository subscriptionRepository;
+  @Mock private PlanRepository planRepository;
+  @Mock private PaymentRepository paymentRepository;
+  @Mock private BillingKeyRepository billingKeyRepository;
+  @Mock private TossPaymentPort tossPaymentPort;
+  @Mock private BillingKeyCipher billingKeyCipher;
+  @Mock private PlatformTransactionManager transactionManager;
+
+  private RecurringBillingService service;
+
+  private final Clock clock = Clock.fixed(Instant.parse("2026-06-01T00:00:00Z"), ZoneOffset.UTC);
+
+  @BeforeEach
+  void setUp() {
+    given(transactionManager.getTransaction(any())).willReturn(new SimpleTransactionStatus());
+    service =
+        new RecurringBillingService(
+            subscriptionRepository,
+            planRepository,
+            paymentRepository,
+            billingKeyRepository,
+            tossPaymentPort,
+            billingKeyCipher,
+            clock,
+            transactionManager);
+  }
+
+  @Test
+  @DisplayName("재시도 4회차 실패 시 결제는 ABORTED, 구독은 CANCELED로 전이한다 (U-004)")
+  void retryExhausted_cancelsSubscription() {
+    Subscription subscription = pastDueSubscription();
+    Payment[] holder = new Payment[1];
+
+    given(subscriptionRepository.findExpiringCancellations(any())).willReturn(List.of());
+    given(subscriptionRepository.findChargeable(any())).willReturn(List.of());
+    given(subscriptionRepository.findRetryDue(any())).willReturn(List.of(subscription));
+    given(subscriptionRepository.findById(5L)).willReturn(Optional.of(subscription));
+    given(subscriptionRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+    given(planRepository.findById(10L)).willReturn(Optional.of(plan()));
+    given(paymentRepository.findBySubscriptionIdAndBillingPeriodKey(eq(5L), anyString()))
+        .willReturn(Optional.empty());
+    given(paymentRepository.save(any()))
+        .willAnswer(
+            inv -> {
+              Payment payment = inv.getArgument(0);
+              if (payment.getId() == null) {
+                ReflectionTestUtils.setField(payment, "id", 7L);
+              }
+              holder[0] = payment;
+              return payment;
+            });
+    given(paymentRepository.findById(7L)).willAnswer(inv -> Optional.ofNullable(holder[0]));
+    given(billingKeyRepository.findActiveByWorkspaceId(1L)).willReturn(Optional.of(billingKey()));
+    given(billingKeyCipher.decrypt(any())).willReturn("bk_plain");
+    given(tossPaymentPort.executeBilling(any()))
+        .willThrow(new PaymentGatewayException("gateway down"));
+
+    service.run();
+
+    assertThat(subscription.getStatus()).isEqualTo(SubscriptionStatus.CANCELED);
+    assertThat(subscription.getFailedAttemptCount()).isEqualTo(4);
+    assertThat(holder[0].getStatus()).isEqualTo(PaymentStatus.ABORTED);
+  }
+
+  private Subscription pastDueSubscription() {
+    OffsetDateTime start = OffsetDateTime.parse("2026-05-01T00:00:00Z");
+    OffsetDateTime end = OffsetDateTime.parse("2026-06-01T00:00:00Z");
+    Subscription subscription = Subscription.create(1L, 10L);
+    subscription.assignCustomerKey("wsk_1_abc");
+    subscription.activate(start, end, "wsk_1_abc");
+    subscription.markPastDue(end.plusDays(1));
+    subscription.markPastDue(end.plusDays(2));
+    subscription.markPastDue(end.plusDays(3));
+    ReflectionTestUtils.setField(subscription, "id", 5L);
+    return subscription;
+  }
+
+  private Plan plan() {
+    Plan plan = Plan.create("pro_monthly", "Pro", 29000, "KRW", BillingInterval.MONTH);
+    ReflectionTestUtils.setField(plan, "id", 10L);
+    return plan;
+  }
+
+  private BillingKey billingKey() {
+    return BillingKey.create(1L, "wsk_1_abc", new byte[] {1, 2, 3}, "신한", "1234-****-****-5678");
+  }
+}

--- a/backend/src/test/java/com/init/payment/application/RecurringBillingServiceTest.java
+++ b/backend/src/test/java/com/init/payment/application/RecurringBillingServiceTest.java
@@ -5,10 +5,13 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 import com.init.payment.application.exception.PaymentGatewayException;
 import com.init.payment.application.port.BillingKeyCipher;
 import com.init.payment.application.port.TossPaymentPort;
+import com.init.payment.application.port.TossPaymentResult;
 import com.init.payment.domain.model.BillingInterval;
 import com.init.payment.domain.model.BillingKey;
 import com.init.payment.domain.model.Payment;
@@ -125,5 +128,172 @@ class RecurringBillingServiceTest {
 
   private BillingKey billingKey() {
     return BillingKey.create(1L, "wsk_1_abc", new byte[] {1, 2, 3}, "신한", "1234-****-****-5678");
+  }
+
+  @Test
+  @DisplayName("구독 조회 결과가 없으면 청구를 건너뛴다")
+  void subscriptionNotFound_skips() {
+    Subscription stub = Subscription.create(1L, 10L);
+    ReflectionTestUtils.setField(stub, "id", 5L);
+
+    given(subscriptionRepository.findExpiringCancellations(any())).willReturn(List.of());
+    given(subscriptionRepository.findChargeable(any())).willReturn(List.of(stub));
+    given(subscriptionRepository.findRetryDue(any())).willReturn(List.of());
+    given(subscriptionRepository.findById(5L)).willReturn(Optional.empty());
+
+    service.run();
+
+    verify(tossPaymentPort, never()).executeBilling(any());
+  }
+
+  @Test
+  @DisplayName("CANCELED 구독은 청구를 건너뛴다")
+  void canceledSubscription_skips() {
+    OffsetDateTime start = OffsetDateTime.parse("2026-05-01T00:00:00Z");
+    OffsetDateTime end = OffsetDateTime.parse("2026-06-01T00:00:00Z");
+    Subscription subscription = Subscription.create(1L, 10L);
+    subscription.assignCustomerKey("wsk_1_abc");
+    subscription.activate(start, end, "wsk_1_abc");
+    subscription.cancel();
+    ReflectionTestUtils.setField(subscription, "id", 5L);
+
+    given(subscriptionRepository.findExpiringCancellations(any())).willReturn(List.of());
+    given(subscriptionRepository.findChargeable(any())).willReturn(List.of(subscription));
+    given(subscriptionRepository.findRetryDue(any())).willReturn(List.of());
+    given(subscriptionRepository.findById(5L)).willReturn(Optional.of(subscription));
+
+    service.run();
+
+    verify(tossPaymentPort, never()).executeBilling(any());
+  }
+
+  @Test
+  @DisplayName("구독에 현재 주기 종료일이 없으면 청구를 건너뛴다")
+  void periodStartNull_skips() {
+    Subscription subscription = Subscription.create(1L, 10L);
+    ReflectionTestUtils.setField(subscription, "id", 5L);
+    ReflectionTestUtils.setField(subscription, "status", SubscriptionStatus.ACTIVE);
+
+    given(subscriptionRepository.findExpiringCancellations(any())).willReturn(List.of());
+    given(subscriptionRepository.findChargeable(any())).willReturn(List.of(subscription));
+    given(subscriptionRepository.findRetryDue(any())).willReturn(List.of());
+    given(subscriptionRepository.findById(5L)).willReturn(Optional.of(subscription));
+
+    service.run();
+
+    verify(tossPaymentPort, never()).executeBilling(any());
+  }
+
+  @Test
+  @DisplayName("기간 결제가 이미 완료된 경우 재청구 없이 구독을 갱신한다")
+  void existingDonePayment_renewsSubscription() {
+    Subscription subscription = pastDueSubscription();
+    Payment donePayment =
+        Payment.createRecurring(
+            1L, 5L, "ord_1", 29000, "KRW", "Pro", "2026-06-01T00:00:00Z", "idem");
+    donePayment.complete("pay_1", "카드", OffsetDateTime.parse("2026-06-01T10:00:00Z"), "url", "{}");
+    ReflectionTestUtils.setField(donePayment, "id", 7L);
+
+    given(subscriptionRepository.findExpiringCancellations(any())).willReturn(List.of());
+    given(subscriptionRepository.findChargeable(any())).willReturn(List.of());
+    given(subscriptionRepository.findRetryDue(any())).willReturn(List.of(subscription));
+    given(subscriptionRepository.findById(5L)).willReturn(Optional.of(subscription));
+    given(subscriptionRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+    given(planRepository.findById(10L)).willReturn(Optional.of(plan()));
+    given(paymentRepository.findBySubscriptionIdAndBillingPeriodKey(eq(5L), anyString()))
+        .willReturn(Optional.of(donePayment));
+
+    service.run();
+
+    assertThat(subscription.getStatus()).isEqualTo(SubscriptionStatus.ACTIVE);
+    verify(tossPaymentPort, never()).executeBilling(any());
+  }
+
+  @Test
+  @DisplayName("정기결제 성공 시 결제는 DONE, 구독은 ACTIVE로 갱신된다")
+  void successfulCharge_completesPaymentAndRenews() {
+    Subscription subscription = pastDueSubscription();
+    Payment[] holder = new Payment[1];
+
+    given(subscriptionRepository.findExpiringCancellations(any())).willReturn(List.of());
+    given(subscriptionRepository.findChargeable(any())).willReturn(List.of());
+    given(subscriptionRepository.findRetryDue(any())).willReturn(List.of(subscription));
+    given(subscriptionRepository.findById(5L)).willReturn(Optional.of(subscription));
+    given(subscriptionRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+    given(planRepository.findById(10L)).willReturn(Optional.of(plan()));
+    given(paymentRepository.findBySubscriptionIdAndBillingPeriodKey(eq(5L), anyString()))
+        .willReturn(Optional.empty());
+    given(paymentRepository.save(any()))
+        .willAnswer(
+            inv -> {
+              Payment payment = inv.getArgument(0);
+              if (payment.getId() == null) {
+                ReflectionTestUtils.setField(payment, "id", 7L);
+              }
+              holder[0] = payment;
+              return payment;
+            });
+    given(paymentRepository.findById(7L)).willAnswer(inv -> Optional.ofNullable(holder[0]));
+    given(billingKeyRepository.findActiveByWorkspaceId(1L)).willReturn(Optional.of(billingKey()));
+    given(billingKeyCipher.decrypt(any())).willReturn("bk_plain");
+    given(tossPaymentPort.executeBilling(any()))
+        .willReturn(
+            new TossPaymentResult(
+                "pay_1",
+                "ord_1",
+                29000,
+                "DONE",
+                "카드",
+                OffsetDateTime.parse("2026-06-01T10:00:00Z"),
+                "https://receipt",
+                null,
+                "{\"status\":\"DONE\"}"));
+
+    service.run();
+
+    assertThat(subscription.getStatus()).isEqualTo(SubscriptionStatus.ACTIVE);
+    assertThat(holder[0].getStatus()).isEqualTo(PaymentStatus.DONE);
+  }
+
+  @Test
+  @DisplayName("기간말 해지 예약된 ACTIVE 구독은 해지된다")
+  void cancelExpiring_cancelsScheduledSubscription() {
+    OffsetDateTime start = OffsetDateTime.parse("2026-05-01T00:00:00Z");
+    OffsetDateTime end = OffsetDateTime.parse("2026-06-01T00:00:00Z");
+    Subscription subscription = Subscription.create(1L, 10L);
+    subscription.assignCustomerKey("wsk_1_abc");
+    subscription.activate(start, end, "wsk_1_abc");
+    subscription.scheduleCancelAtPeriodEnd();
+    ReflectionTestUtils.setField(subscription, "id", 5L);
+
+    given(subscriptionRepository.findExpiringCancellations(any())).willReturn(List.of(subscription));
+    given(subscriptionRepository.findChargeable(any())).willReturn(List.of());
+    given(subscriptionRepository.findRetryDue(any())).willReturn(List.of());
+    given(subscriptionRepository.findById(5L)).willReturn(Optional.of(subscription));
+    given(subscriptionRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+
+    service.run();
+
+    assertThat(subscription.getStatus()).isEqualTo(SubscriptionStatus.CANCELED);
+  }
+
+  @Test
+  @DisplayName("동시 삽입 충돌 후 재조회 결과가 없으면 청구를 건너뛴다")
+  void concurrentInsert_concurrentNull_skips() {
+    Subscription subscription = pastDueSubscription();
+
+    given(subscriptionRepository.findExpiringCancellations(any())).willReturn(List.of());
+    given(subscriptionRepository.findChargeable(any())).willReturn(List.of());
+    given(subscriptionRepository.findRetryDue(any())).willReturn(List.of(subscription));
+    given(subscriptionRepository.findById(5L)).willReturn(Optional.of(subscription));
+    given(planRepository.findById(10L)).willReturn(Optional.of(plan()));
+    given(paymentRepository.findBySubscriptionIdAndBillingPeriodKey(eq(5L), anyString()))
+        .willReturn(Optional.empty());
+    given(paymentRepository.save(any()))
+        .willThrow(new org.springframework.dao.DataIntegrityViolationException("duplicate"));
+
+    service.run();
+
+    verify(tossPaymentPort, never()).executeBilling(any());
   }
 }

--- a/backend/src/test/java/com/init/payment/application/RecurringBillingServiceTest.java
+++ b/backend/src/test/java/com/init/payment/application/RecurringBillingServiceTest.java
@@ -266,7 +266,8 @@ class RecurringBillingServiceTest {
     subscription.scheduleCancelAtPeriodEnd();
     ReflectionTestUtils.setField(subscription, "id", 5L);
 
-    given(subscriptionRepository.findExpiringCancellations(any())).willReturn(List.of(subscription));
+    given(subscriptionRepository.findExpiringCancellations(any()))
+        .willReturn(List.of(subscription));
     given(subscriptionRepository.findChargeable(any())).willReturn(List.of());
     given(subscriptionRepository.findRetryDue(any())).willReturn(List.of());
     given(subscriptionRepository.findById(5L)).willReturn(Optional.of(subscription));

--- a/backend/src/test/java/com/init/payment/application/SubscriptionServiceTest.java
+++ b/backend/src/test/java/com/init/payment/application/SubscriptionServiceTest.java
@@ -99,12 +99,58 @@ class SubscriptionServiceTest {
   }
 
   @Test
+  @DisplayName("구독 조회 성공 시 SubscriptionResult를 반환한다")
+  void getSubscription_success() {
+    Subscription subscription = subscription(5L);
+    given(subscriptionRepository.findCurrentByWorkspaceId(1L))
+        .willReturn(Optional.of(subscription));
+    given(planRepository.findById(10L)).willReturn(Optional.of(plan(10L)));
+
+    SubscriptionResult result = subscriptionService.getSubscription(1L, 99L);
+
+    assertThat(result.planKey()).isEqualTo("pro_monthly");
+  }
+
+  @Test
   @DisplayName("구독이 없으면 조회 시 SubscriptionNotFoundException을 던진다")
   void getSubscription_notFound() {
     given(subscriptionRepository.findCurrentByWorkspaceId(1L)).willReturn(Optional.empty());
 
     assertThatThrownBy(() -> subscriptionService.getSubscription(1L, 99L))
         .isInstanceOf(SubscriptionNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("INCOMPLETE 구독 취소 시 즉시 CANCELED로 전이한다")
+  void cancelSubscription_incomplete_immediateCancel() {
+    Subscription subscription = subscription(5L);
+    given(subscriptionRepository.findCurrentByWorkspaceId(1L))
+        .willReturn(Optional.of(subscription));
+    given(subscriptionRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+    given(planRepository.findById(10L)).willReturn(Optional.of(plan(10L)));
+
+    SubscriptionResult result = subscriptionService.cancelSubscription(1L, 99L);
+
+    assertThat(result.status()).isEqualTo("CANCELED");
+  }
+
+  @Test
+  @DisplayName("ACTIVE 구독 취소 시 기간말 해지 예약으로 ACTIVE 유지한다 (U-005)")
+  void cancelSubscription_active_scheduleAtPeriodEnd() {
+    Subscription subscription = subscription(5L);
+    subscription.activate(
+        java.time.OffsetDateTime.parse("2026-06-01T00:00:00Z"),
+        java.time.OffsetDateTime.parse("2026-07-01T00:00:00Z"),
+        "wsk_1_abc");
+    given(subscriptionRepository.findCurrentByWorkspaceId(1L))
+        .willReturn(Optional.of(subscription));
+    given(subscriptionRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+    given(planRepository.findById(10L)).willReturn(Optional.of(plan(10L)));
+
+    SubscriptionResult result = subscriptionService.cancelSubscription(1L, 99L);
+
+    assertThat(result.status()).isEqualTo("ACTIVE");
+    assertThat(subscription.isCancelAtPeriodEnd()).isTrue();
   }
 
   @Test

--- a/backend/src/test/java/com/init/payment/application/SubscriptionServiceTest.java
+++ b/backend/src/test/java/com/init/payment/application/SubscriptionServiceTest.java
@@ -109,6 +109,7 @@ class SubscriptionServiceTest {
     SubscriptionResult result = subscriptionService.getSubscription(1L, 99L);
 
     assertThat(result.planKey()).isEqualTo("pro_monthly");
+    verify(accessGuard).requireMember(1L, 99L);
   }
 
   @Test
@@ -118,6 +119,7 @@ class SubscriptionServiceTest {
 
     assertThatThrownBy(() -> subscriptionService.getSubscription(1L, 99L))
         .isInstanceOf(SubscriptionNotFoundException.class);
+    verify(accessGuard).requireMember(1L, 99L);
   }
 
   @Test
@@ -132,6 +134,7 @@ class SubscriptionServiceTest {
     SubscriptionResult result = subscriptionService.cancelSubscription(1L, 99L);
 
     assertThat(result.status()).isEqualTo("CANCELED");
+    verify(accessGuard).requireMember(1L, 99L);
   }
 
   @Test
@@ -151,6 +154,7 @@ class SubscriptionServiceTest {
 
     assertThat(result.status()).isEqualTo("ACTIVE");
     assertThat(subscription.isCancelAtPeriodEnd()).isTrue();
+    verify(accessGuard).requireMember(1L, 99L);
   }
 
   @Test
@@ -173,6 +177,7 @@ class SubscriptionServiceTest {
                 subscriptionService.issueBillingKey(
                     new IssueBillingKeyCommand(1L, 99L, "auth_xxx", "wsk_1_abc")))
         .isInstanceOf(ActiveSubscriptionExistsException.class);
+    verify(accessGuard).requireMember(1L, 99L);
   }
 
   @Test

--- a/backend/src/test/java/com/init/payment/application/SubscriptionServiceTest.java
+++ b/backend/src/test/java/com/init/payment/application/SubscriptionServiceTest.java
@@ -1,0 +1,170 @@
+package com.init.payment.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.init.payment.application.exception.ActiveSubscriptionExistsException;
+import com.init.payment.application.exception.SubscriptionNotFoundException;
+import com.init.payment.application.port.BillingKeyCipher;
+import com.init.payment.application.port.TossBillingKeyResult;
+import com.init.payment.application.port.TossPaymentPort;
+import com.init.payment.application.port.TossPaymentResult;
+import com.init.payment.domain.model.BillingInterval;
+import com.init.payment.domain.model.BillingKey;
+import com.init.payment.domain.model.Plan;
+import com.init.payment.domain.model.Subscription;
+import com.init.payment.domain.repository.BillingKeyRepository;
+import com.init.payment.domain.repository.PaymentRepository;
+import com.init.payment.domain.repository.PlanRepository;
+import com.init.payment.domain.repository.SubscriptionRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.SimpleTransactionStatus;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SubscriptionService")
+class SubscriptionServiceTest {
+
+  @Mock private SubscriptionRepository subscriptionRepository;
+  @Mock private PlanRepository planRepository;
+  @Mock private BillingKeyRepository billingKeyRepository;
+  @Mock private PaymentRepository paymentRepository;
+  @Mock private TossPaymentPort tossPaymentPort;
+  @Mock private BillingKeyCipher billingKeyCipher;
+  @Mock private PaymentAccessGuard accessGuard;
+  @Mock private PlatformTransactionManager transactionManager;
+
+  private SubscriptionService subscriptionService;
+
+  private final Clock clock = Clock.fixed(Instant.parse("2026-06-01T00:00:00Z"), ZoneOffset.UTC);
+
+  @BeforeEach
+  void setUp() {
+    subscriptionService =
+        new SubscriptionService(
+            subscriptionRepository,
+            planRepository,
+            billingKeyRepository,
+            paymentRepository,
+            tossPaymentPort,
+            billingKeyCipher,
+            accessGuard,
+            clock,
+            transactionManager);
+  }
+
+  @Test
+  @DisplayName("구독 생성 시 INCOMPLETE 상태와 workspace 스코프 customerKey를 부여한다")
+  void createSubscription_success() {
+    given(planRepository.findByPlanKey("pro_monthly")).willReturn(Optional.of(plan(10L)));
+    given(subscriptionRepository.findCurrentByWorkspaceId(1L)).willReturn(Optional.empty());
+    given(subscriptionRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+
+    SubscriptionResult result =
+        subscriptionService.createSubscription(
+            new CreateSubscriptionCommand(1L, 99L, "pro_monthly"));
+
+    assertThat(result.status()).isEqualTo("INCOMPLETE");
+    assertThat(result.planKey()).isEqualTo("pro_monthly");
+    assertThat(result.customerKey()).startsWith("wsk_1_");
+  }
+
+  @Test
+  @DisplayName("이미 진행 중인 구독이 있으면 ActiveSubscriptionExistsException을 던진다")
+  void createSubscription_duplicate() {
+    given(planRepository.findByPlanKey("pro_monthly")).willReturn(Optional.of(plan(10L)));
+    given(subscriptionRepository.findCurrentByWorkspaceId(1L))
+        .willReturn(Optional.of(subscription(5L)));
+
+    assertThatThrownBy(
+            () ->
+                subscriptionService.createSubscription(
+                    new CreateSubscriptionCommand(1L, 99L, "pro_monthly")))
+        .isInstanceOf(ActiveSubscriptionExistsException.class);
+  }
+
+  @Test
+  @DisplayName("구독이 없으면 조회 시 SubscriptionNotFoundException을 던진다")
+  void getSubscription_notFound() {
+    given(subscriptionRepository.findCurrentByWorkspaceId(1L)).willReturn(Optional.empty());
+
+    assertThatThrownBy(() -> subscriptionService.getSubscription(1L, 99L))
+        .isInstanceOf(SubscriptionNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("billingKey 발급 시 평문은 암호화되어 저장되고 응답에는 마스킹 카드정보만 포함된다 (U-002, U-012)")
+  void issueBillingKey_encryptsAndDoesNotExposePlaintext() {
+    Subscription subscription = subscription(5L);
+    given(transactionManager.getTransaction(any())).willReturn(new SimpleTransactionStatus());
+    given(subscriptionRepository.findCurrentByWorkspaceId(1L))
+        .willReturn(Optional.of(subscription));
+    given(subscriptionRepository.findById(5L)).willReturn(Optional.of(subscription));
+    given(subscriptionRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+    given(planRepository.findById(10L)).willReturn(Optional.of(plan(10L)));
+    given(tossPaymentPort.issueBillingKey("auth_xxx", "wsk_1_abc"))
+        .willReturn(
+            new TossBillingKeyResult(
+                "bk_PLAINTEXT_SECRET",
+                "wsk_1_abc",
+                "신한",
+                "1234-****-****-5678",
+                "{\"billingKey\":\"***\"}"));
+    given(billingKeyCipher.encrypt("bk_PLAINTEXT_SECRET")).willReturn(new byte[] {1, 2, 3});
+    given(billingKeyRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+    given(paymentRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+    given(tossPaymentPort.executeBilling(any()))
+        .willReturn(
+            new TossPaymentResult(
+                "pay_1",
+                "ord_1",
+                29000,
+                "DONE",
+                "카드",
+                OffsetDateTime.now(clock),
+                "https://receipt",
+                null,
+                "{\"status\":\"DONE\"}"));
+
+    BillingAuthorizationResult result =
+        subscriptionService.issueBillingKey(
+            new IssueBillingKeyCommand(1L, 99L, "auth_xxx", "wsk_1_abc"));
+
+    verify(billingKeyCipher).encrypt("bk_PLAINTEXT_SECRET");
+    ArgumentCaptor<BillingKey> captor = ArgumentCaptor.forClass(BillingKey.class);
+    verify(billingKeyRepository).save(captor.capture());
+    assertThat(captor.getValue().getBillingKeyEncrypted()).containsExactly(1, 2, 3);
+
+    assertThat(result.billingKey().cardNumberMasked()).isEqualTo("1234-****-****-5678");
+    assertThat(result.subscription().status()).isEqualTo("ACTIVE");
+    assertThat(result.toString()).doesNotContain("bk_PLAINTEXT_SECRET");
+  }
+
+  private Subscription subscription(Long id) {
+    Subscription subscription = Subscription.create(1L, 10L);
+    subscription.assignCustomerKey("wsk_1_abc");
+    ReflectionTestUtils.setField(subscription, "id", id);
+    return subscription;
+  }
+
+  private Plan plan(Long id) {
+    Plan plan = Plan.create("pro_monthly", "Pro", 29000, "KRW", BillingInterval.MONTH);
+    ReflectionTestUtils.setField(plan, "id", id);
+    return plan;
+  }
+}

--- a/backend/src/test/java/com/init/payment/application/SubscriptionServiceTest.java
+++ b/backend/src/test/java/com/init/payment/application/SubscriptionServiceTest.java
@@ -108,6 +108,28 @@ class SubscriptionServiceTest {
   }
 
   @Test
+  @DisplayName(
+      "INCOMPLETE가 아닌 구독에 billingKey 발급 시 ActiveSubscriptionExistsException을 던진다 (V-NEW-003)")
+  void issueBillingKey_nonIncomplete_throws() {
+    given(transactionManager.getTransaction(any())).willReturn(new SimpleTransactionStatus());
+    Subscription activeSubscription = Subscription.create(1L, 10L);
+    activeSubscription.assignCustomerKey("wsk_1_abc");
+    activeSubscription.activate(
+        java.time.OffsetDateTime.parse("2026-05-01T00:00:00Z"),
+        java.time.OffsetDateTime.parse("2026-06-01T00:00:00Z"),
+        "wsk_1_abc");
+    org.springframework.test.util.ReflectionTestUtils.setField(activeSubscription, "id", 5L);
+    given(subscriptionRepository.findCurrentByWorkspaceId(1L))
+        .willReturn(Optional.of(activeSubscription));
+
+    assertThatThrownBy(
+            () ->
+                subscriptionService.issueBillingKey(
+                    new IssueBillingKeyCommand(1L, 99L, "auth_xxx", "wsk_1_abc")))
+        .isInstanceOf(ActiveSubscriptionExistsException.class);
+  }
+
+  @Test
   @DisplayName("billingKey 발급 시 평문은 암호화되어 저장되고 응답에는 마스킹 카드정보만 포함된다 (U-002, U-012)")
   void issueBillingKey_encryptsAndDoesNotExposePlaintext() {
     Subscription subscription = subscription(5L);

--- a/backend/src/test/java/com/init/payment/application/TossPayloadMaskerTest.java
+++ b/backend/src/test/java/com/init/payment/application/TossPayloadMaskerTest.java
@@ -1,0 +1,107 @@
+package com.init.payment.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("TossPayloadMasker")
+class TossPayloadMaskerTest {
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  private JsonNode json(String raw) throws Exception {
+    return objectMapper.readTree(raw);
+  }
+
+  @Test
+  @DisplayName("null 노드는 null 반환")
+  void mask_null_returns_null() {
+    assertThat(TossPayloadMasker.mask(null)).isNull();
+  }
+
+  @Test
+  @DisplayName("null JSON 노드는 null 반환")
+  void mask_nullNode_returns_null() throws Exception {
+    assertThat(TossPayloadMasker.mask(objectMapper.nullNode())).isNull();
+  }
+
+  @Test
+  @DisplayName("missing 노드는 null 반환")
+  void mask_missingNode_returns_null() throws Exception {
+    JsonNode missing = json("{}").path("nonexistent");
+    assertThat(TossPayloadMasker.mask(missing)).isNull();
+  }
+
+  @Test
+  @DisplayName("billingKey 필드를 ***로 마스킹한다")
+  void mask_removes_billingKey() throws Exception {
+    String result = TossPayloadMasker.mask(json("{\"billingKey\":\"bk_test_abc\",\"amount\":1000}"));
+    assertThat(result).contains("\"billingKey\":\"***\"");
+    assertThat(result).doesNotContain("bk_test_abc");
+    assertThat(result).contains("\"amount\":1000");
+  }
+
+  @Test
+  @DisplayName("secretKey 필드를 ***로 마스킹한다")
+  void mask_removes_secretKey() throws Exception {
+    String result = TossPayloadMasker.mask(json("{\"secretKey\":\"sk_secret\"}"));
+    assertThat(result).contains("\"secretKey\":\"***\"");
+    assertThat(result).doesNotContain("sk_secret");
+  }
+
+  @Test
+  @DisplayName("authKey 필드를 ***로 마스킹한다")
+  void mask_removes_authKey() throws Exception {
+    String result = TossPayloadMasker.mask(json("{\"authKey\":\"auth_key_val\"}"));
+    assertThat(result).contains("\"authKey\":\"***\"");
+    assertThat(result).doesNotContain("auth_key_val");
+  }
+
+  @Test
+  @DisplayName("number 필드는 마지막 4자리만 남긴다")
+  void mask_pan_preserves_last_four_digits() throws Exception {
+    String result =
+        TossPayloadMasker.mask(json("{\"card\":{\"number\":\"1234-5678-9012-3456\"}}"));
+    assertThat(result).contains("3456");
+    assertThat(result).doesNotContain("1234-5678-9012");
+  }
+
+  @Test
+  @DisplayName("4자리 이하 카드번호는 ****로 마스킹한다")
+  void mask_short_pan_returns_stars() throws Exception {
+    String result = TossPayloadMasker.mask(json("{\"number\":\"123\"}"));
+    assertThat(result).contains("\"****\"");
+  }
+
+  @Test
+  @DisplayName("배열 내 객체의 민감 필드도 마스킹한다")
+  void mask_array_elements() throws Exception {
+    String result =
+        TossPayloadMasker.mask(json("[{\"billingKey\":\"bk_1\"},{\"billingKey\":\"bk_2\"}]"));
+    assertThat(result).doesNotContain("bk_1");
+    assertThat(result).doesNotContain("bk_2");
+    assertThat(result).contains("\"***\"");
+  }
+
+  @Test
+  @DisplayName("민감하지 않은 필드는 그대로 보존한다")
+  void mask_preserves_non_sensitive_fields() throws Exception {
+    String result =
+        TossPayloadMasker.mask(json("{\"orderId\":\"ord_123\",\"totalAmount\":29000}"));
+    assertThat(result).contains("\"orderId\":\"ord_123\"");
+    assertThat(result).contains("\"totalAmount\":29000");
+  }
+
+  @Test
+  @DisplayName("중첩 객체의 민감 필드도 마스킹한다")
+  void mask_nested_sensitive_fields() throws Exception {
+    String result =
+        TossPayloadMasker.mask(
+            json("{\"payment\":{\"billingKey\":\"bk_nested\",\"amount\":5000}}"));
+    assertThat(result).doesNotContain("bk_nested");
+    assertThat(result).contains("\"billingKey\":\"***\"");
+  }
+}

--- a/backend/src/test/java/com/init/payment/application/TossPayloadMaskerTest.java
+++ b/backend/src/test/java/com/init/payment/application/TossPayloadMaskerTest.java
@@ -38,7 +38,8 @@ class TossPayloadMaskerTest {
   @Test
   @DisplayName("billingKey 필드를 ***로 마스킹한다")
   void mask_removes_billingKey() throws Exception {
-    String result = TossPayloadMasker.mask(json("{\"billingKey\":\"bk_test_abc\",\"amount\":1000}"));
+    String result =
+        TossPayloadMasker.mask(json("{\"billingKey\":\"bk_test_abc\",\"amount\":1000}"));
     assertThat(result).contains("\"billingKey\":\"***\"");
     assertThat(result).doesNotContain("bk_test_abc");
     assertThat(result).contains("\"amount\":1000");
@@ -63,8 +64,7 @@ class TossPayloadMaskerTest {
   @Test
   @DisplayName("number 필드는 마지막 4자리만 남긴다")
   void mask_pan_preserves_last_four_digits() throws Exception {
-    String result =
-        TossPayloadMasker.mask(json("{\"card\":{\"number\":\"1234-5678-9012-3456\"}}"));
+    String result = TossPayloadMasker.mask(json("{\"card\":{\"number\":\"1234-5678-9012-3456\"}}"));
     assertThat(result).contains("3456");
     assertThat(result).doesNotContain("1234-5678-9012");
   }
@@ -89,8 +89,7 @@ class TossPayloadMaskerTest {
   @Test
   @DisplayName("민감하지 않은 필드는 그대로 보존한다")
   void mask_preserves_non_sensitive_fields() throws Exception {
-    String result =
-        TossPayloadMasker.mask(json("{\"orderId\":\"ord_123\",\"totalAmount\":29000}"));
+    String result = TossPayloadMasker.mask(json("{\"orderId\":\"ord_123\",\"totalAmount\":29000}"));
     assertThat(result).contains("\"orderId\":\"ord_123\"");
     assertThat(result).contains("\"totalAmount\":29000");
   }

--- a/backend/src/test/java/com/init/payment/domain/model/BillingKeyTest.java
+++ b/backend/src/test/java/com/init/payment/domain/model/BillingKeyTest.java
@@ -1,0 +1,59 @@
+package com.init.payment.domain.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("BillingKey 도메인")
+class BillingKeyTest {
+
+  @Test
+  @DisplayName("정상 파라미터로 생성 시 ACTIVE 상태이다")
+  void create_success() {
+    BillingKey billingKey =
+        BillingKey.create(1L, "wsk_1_abc", new byte[] {1, 2, 3}, "신한", "1234-****");
+
+    assertThat(billingKey.isActive()).isTrue();
+    assertThat(billingKey.getWorkspaceId()).isEqualTo(1L);
+    assertThat(billingKey.getCustomerKey()).isEqualTo("wsk_1_abc");
+    assertThat(billingKey.getCardCompany()).isEqualTo("신한");
+    assertThat(billingKey.getCardNumberMasked()).isEqualTo("1234-****");
+    assertThat(billingKey.getBillingKeyEncrypted()).containsExactly(1, 2, 3);
+  }
+
+  @Test
+  @DisplayName("workspaceId null이면 생성을 거부한다")
+  void create_nullWorkspaceId_throws() {
+    assertThatThrownBy(() -> BillingKey.create(null, "wsk_1_abc", new byte[] {1}, "신한", "1234"))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  @DisplayName("customerKey blank이면 생성을 거부한다")
+  void create_blankCustomerKey_throws() {
+    assertThatThrownBy(() -> BillingKey.create(1L, "", new byte[] {1}, "신한", "1234"))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  @DisplayName("billingKeyEncrypted가 null이거나 비어 있으면 생성을 거부한다")
+  void create_emptyEncryptedKey_throws() {
+    assertThatThrownBy(() -> BillingKey.create(1L, "wsk_1_abc", null, "신한", "1234"))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> BillingKey.create(1L, "wsk_1_abc", new byte[0], "신한", "1234"))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  @DisplayName("revoke() 호출 시 DELETED 상태로 전이한다")
+  void revoke_setsDeleted() {
+    BillingKey billingKey = BillingKey.create(1L, "wsk_1_abc", new byte[] {1}, "신한", "1234");
+
+    billingKey.revoke();
+
+    assertThat(billingKey.isActive()).isFalse();
+    assertThat(billingKey.getStatus()).isEqualTo(BillingKeyStatus.DELETED);
+  }
+}

--- a/backend/src/test/java/com/init/payment/domain/model/MoneyTest.java
+++ b/backend/src/test/java/com/init/payment/domain/model/MoneyTest.java
@@ -1,0 +1,51 @@
+package com.init.payment.domain.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Money 밸류 오브젝트")
+class MoneyTest {
+
+  @Test
+  @DisplayName("of()로 생성 시 amount와 currency를 반환한다")
+  void of_success() {
+    Money money = Money.of(29000, "KRW");
+
+    assertThat(money.amount()).isEqualTo(29000);
+    assertThat(money.currency()).isEqualTo("KRW");
+  }
+
+  @Test
+  @DisplayName("krw() 팩토리는 KRW 통화로 생성한다")
+  void krw_factory() {
+    Money money = Money.krw(5000);
+
+    assertThat(money.amount()).isEqualTo(5000);
+    assertThat(money.currency()).isEqualTo("KRW");
+  }
+
+  @Test
+  @DisplayName("isSameAmount()는 같은 금액에 true를 반환한다")
+  void isSameAmount_match() {
+    Money money = Money.of(29000, "KRW");
+
+    assertThat(money.isSameAmount(29000)).isTrue();
+    assertThat(money.isSameAmount(10000)).isFalse();
+  }
+
+  @Test
+  @DisplayName("음수 금액이면 생성을 거부한다")
+  void negativeAmount_throws() {
+    assertThatThrownBy(() -> Money.of(-1, "KRW")).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  @DisplayName("빈 통화 코드이면 생성을 거부한다")
+  void blankCurrency_throws() {
+    assertThatThrownBy(() -> Money.of(1000, "")).isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> Money.of(1000, null)).isInstanceOf(IllegalArgumentException.class);
+  }
+}

--- a/backend/src/test/java/com/init/payment/domain/model/PaymentCancelTest.java
+++ b/backend/src/test/java/com/init/payment/domain/model/PaymentCancelTest.java
@@ -12,36 +12,38 @@ class PaymentCancelTest {
   @Test
   @DisplayName("정상 파라미터로 생성 시 필드가 올바르게 설정된다")
   void create_success() {
-    PaymentCancel cancel = PaymentCancel.create(10L, 5000L, "고객 요청", "txn_001");
+    PaymentCancel cancel = PaymentCancel.create(10L, 5000L, "고객 요청", "txn_001", "idem_001");
 
     assertThat(cancel.getPaymentId()).isEqualTo(10L);
     assertThat(cancel.getCancelAmount()).isEqualTo(5000L);
     assertThat(cancel.getReason()).isEqualTo("고객 요청");
     assertThat(cancel.getTransactionKey()).isEqualTo("txn_001");
+    assertThat(cancel.getIdempotencyKey()).isEqualTo("idem_001");
   }
 
   @Test
   @DisplayName("paymentId null이면 생성을 거부한다")
   void create_nullPaymentId_throws() {
-    assertThatThrownBy(() -> PaymentCancel.create(null, 5000L, "reason", "txn"))
+    assertThatThrownBy(() -> PaymentCancel.create(null, 5000L, "reason", "txn", "idem"))
         .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   @DisplayName("cancelAmount가 0이하이면 생성을 거부한다")
   void create_zeroOrNegativeAmount_throws() {
-    assertThatThrownBy(() -> PaymentCancel.create(10L, 0L, "reason", "txn"))
+    assertThatThrownBy(() -> PaymentCancel.create(10L, 0L, "reason", "txn", "idem"))
         .isInstanceOf(IllegalArgumentException.class);
-    assertThatThrownBy(() -> PaymentCancel.create(10L, -1L, "reason", "txn"))
+    assertThatThrownBy(() -> PaymentCancel.create(10L, -1L, "reason", "txn", "idem"))
         .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
-  @DisplayName("reason과 transactionKey는 null 허용이다")
+  @DisplayName("reason과 transactionKey와 idempotencyKey는 null 허용이다")
   void create_nullOptionalFields_ok() {
-    PaymentCancel cancel = PaymentCancel.create(10L, 5000L, null, null);
+    PaymentCancel cancel = PaymentCancel.create(10L, 5000L, null, null, null);
 
     assertThat(cancel.getReason()).isNull();
     assertThat(cancel.getTransactionKey()).isNull();
+    assertThat(cancel.getIdempotencyKey()).isNull();
   }
 }

--- a/backend/src/test/java/com/init/payment/domain/model/PaymentCancelTest.java
+++ b/backend/src/test/java/com/init/payment/domain/model/PaymentCancelTest.java
@@ -1,0 +1,47 @@
+package com.init.payment.domain.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("PaymentCancel 도메인")
+class PaymentCancelTest {
+
+  @Test
+  @DisplayName("정상 파라미터로 생성 시 필드가 올바르게 설정된다")
+  void create_success() {
+    PaymentCancel cancel = PaymentCancel.create(10L, 5000L, "고객 요청", "txn_001");
+
+    assertThat(cancel.getPaymentId()).isEqualTo(10L);
+    assertThat(cancel.getCancelAmount()).isEqualTo(5000L);
+    assertThat(cancel.getReason()).isEqualTo("고객 요청");
+    assertThat(cancel.getTransactionKey()).isEqualTo("txn_001");
+  }
+
+  @Test
+  @DisplayName("paymentId null이면 생성을 거부한다")
+  void create_nullPaymentId_throws() {
+    assertThatThrownBy(() -> PaymentCancel.create(null, 5000L, "reason", "txn"))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  @DisplayName("cancelAmount가 0이하이면 생성을 거부한다")
+  void create_zeroOrNegativeAmount_throws() {
+    assertThatThrownBy(() -> PaymentCancel.create(10L, 0L, "reason", "txn"))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> PaymentCancel.create(10L, -1L, "reason", "txn"))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  @DisplayName("reason과 transactionKey는 null 허용이다")
+  void create_nullOptionalFields_ok() {
+    PaymentCancel cancel = PaymentCancel.create(10L, 5000L, null, null);
+
+    assertThat(cancel.getReason()).isNull();
+    assertThat(cancel.getTransactionKey()).isNull();
+  }
+}

--- a/backend/src/test/java/com/init/payment/domain/model/PaymentTest.java
+++ b/backend/src/test/java/com/init/payment/domain/model/PaymentTest.java
@@ -3,12 +3,17 @@ package com.init.payment.domain.model;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.time.Instant;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 @DisplayName("Payment 도메인")
 class PaymentTest {
+
+  private static final OffsetDateTime NOW =
+      OffsetDateTime.ofInstant(Instant.parse("2026-06-01T00:00:00Z"), ZoneOffset.UTC);
 
   @Test
   @DisplayName("주문 생성 시 READY 상태이며 기대 금액을 보관한다")
@@ -47,19 +52,54 @@ class PaymentTest {
   }
 
   @Test
-  @DisplayName("취소/부분취소/중단 상태 전이")
+  @DisplayName("취소/부분취소/중단 상태 전이 — 선행 상태 요건 준수")
   void cancelTransitions() {
     Payment canceled = Payment.createOrder(1L, 5L, "ord_a", 29000, "KRW", "Pro");
+    canceled.complete("pay_a", "카드", NOW, null, "{}");
     canceled.markCanceled("{}");
     assertThat(canceled.getStatus()).isEqualTo(PaymentStatus.CANCELED);
 
     Payment partial = Payment.createOrder(1L, 5L, "ord_b", 29000, "KRW", "Pro");
+    partial.complete("pay_b", "카드", NOW, null, "{}");
     partial.markPartialCanceled("{}");
     assertThat(partial.getStatus()).isEqualTo(PaymentStatus.PARTIAL_CANCELED);
 
     Payment aborted = Payment.createOrder(1L, 5L, "ord_c", 29000, "KRW", "Pro");
     aborted.markAborted("{}");
     assertThat(aborted.getStatus()).isEqualTo(PaymentStatus.ABORTED);
+  }
+
+  @Test
+  @DisplayName("잘못된 선행 상태에서 상태 전이 시 IllegalStateException을 던진다 (V-NEW-005)")
+  void stateTransition_wrongPrecondition_throws() {
+    Payment readyPayment = Payment.createOrder(1L, 5L, "ord_x", 29000, "KRW", "Pro");
+
+    assertThatThrownBy(() -> readyPayment.markCanceled("{}"))
+        .isInstanceOf(IllegalStateException.class);
+    assertThatThrownBy(() -> readyPayment.markPartialCanceled("{}"))
+        .isInstanceOf(IllegalStateException.class);
+
+    Payment donePayment = Payment.createOrder(1L, 5L, "ord_y", 29000, "KRW", "Pro");
+    donePayment.complete("pay_y", "카드", NOW, null, "{}");
+
+    assertThatThrownBy(() -> donePayment.markAborted("{}"))
+        .isInstanceOf(IllegalStateException.class);
+    assertThatThrownBy(() -> donePayment.complete("pay_y2", "카드", NOW, null, "{}"))
+        .isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  @DisplayName("정기결제 생성 시 billingPeriodKey/idempotencyKey null이면 거부한다 (V-NEW-004)")
+  void createRecurring_nullKeys_rejected() {
+    assertThatThrownBy(
+            () -> Payment.createRecurring(1L, 5L, "ord_2", 29000, "KRW", "Pro", null, "idem"))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(
+            () -> Payment.createRecurring(1L, 5L, "ord_2", 29000, "KRW", "Pro", "period", null))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(
+            () -> Payment.createRecurring(1L, 5L, "ord_2", 29000, "KRW", "Pro", "", "idem"))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test

--- a/backend/src/test/java/com/init/payment/domain/model/PaymentTest.java
+++ b/backend/src/test/java/com/init/payment/domain/model/PaymentTest.java
@@ -1,0 +1,71 @@
+package com.init.payment.domain.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Payment 도메인")
+class PaymentTest {
+
+  @Test
+  @DisplayName("주문 생성 시 READY 상태이며 기대 금액을 보관한다")
+  void createOrder_isReady() {
+    Payment payment = Payment.createOrder(1L, 5L, "ord_1", 29000, "KRW", "Pro");
+
+    assertThat(payment.getStatus()).isEqualTo(PaymentStatus.READY);
+    assertThat(payment.matchesAmount(29000)).isTrue();
+    assertThat(payment.matchesAmount(10000)).isFalse();
+    assertThat(payment.isDone()).isFalse();
+  }
+
+  @Test
+  @DisplayName("정기결제 생성 시 IN_PROGRESS이며 주기 키를 보관한다 (U-011)")
+  void createRecurring_hasPeriodKey() {
+    Payment payment =
+        Payment.createRecurring(
+            1L, 5L, "ord_2", 29000, "KRW", "Pro", "2026-07-01T00:00:00Z", "idem");
+
+    assertThat(payment.getStatus()).isEqualTo(PaymentStatus.IN_PROGRESS);
+    assertThat(payment.getBillingPeriodKey()).isEqualTo("2026-07-01T00:00:00Z");
+  }
+
+  @Test
+  @DisplayName("승인 완료 시 DONE으로 전이하고 결제 정보를 채운다")
+  void complete_transitionsToDone() {
+    Payment payment = Payment.createOrder(1L, 5L, "ord_1", 29000, "KRW", "Pro");
+    OffsetDateTime approvedAt = OffsetDateTime.parse("2026-06-01T00:00:00Z");
+
+    payment.complete("pay_key", "카드", approvedAt, "https://receipt", "{\"status\":\"DONE\"}");
+
+    assertThat(payment.getStatus()).isEqualTo(PaymentStatus.DONE);
+    assertThat(payment.getPaymentKey()).isEqualTo("pay_key");
+    assertThat(payment.getApprovedAt()).isEqualTo(approvedAt);
+    assertThat(payment.isDone()).isTrue();
+  }
+
+  @Test
+  @DisplayName("취소/부분취소/중단 상태 전이")
+  void cancelTransitions() {
+    Payment canceled = Payment.createOrder(1L, 5L, "ord_a", 29000, "KRW", "Pro");
+    canceled.markCanceled("{}");
+    assertThat(canceled.getStatus()).isEqualTo(PaymentStatus.CANCELED);
+
+    Payment partial = Payment.createOrder(1L, 5L, "ord_b", 29000, "KRW", "Pro");
+    partial.markPartialCanceled("{}");
+    assertThat(partial.getStatus()).isEqualTo(PaymentStatus.PARTIAL_CANCELED);
+
+    Payment aborted = Payment.createOrder(1L, 5L, "ord_c", 29000, "KRW", "Pro");
+    aborted.markAborted("{}");
+    assertThat(aborted.getStatus()).isEqualTo(PaymentStatus.ABORTED);
+  }
+
+  @Test
+  @DisplayName("음수 금액 주문은 거부한다")
+  void negativeAmount_rejected() {
+    assertThatThrownBy(() -> Payment.createOrder(1L, 5L, "ord_1", -1, "KRW", "Pro"))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+}

--- a/backend/src/test/java/com/init/payment/domain/model/PlanTest.java
+++ b/backend/src/test/java/com/init/payment/domain/model/PlanTest.java
@@ -1,0 +1,58 @@
+package com.init.payment.domain.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Plan 도메인")
+class PlanTest {
+
+  @Test
+  @DisplayName("정상 파라미터로 생성 시 ACTIVE 상태이다")
+  void create_success() {
+    Plan plan = Plan.create("pro_monthly", "Pro (Monthly)", 29000, "KRW", BillingInterval.MONTH);
+
+    assertThat(plan.getPlanKey()).isEqualTo("pro_monthly");
+    assertThat(plan.getName()).isEqualTo("Pro (Monthly)");
+    assertThat(plan.getAmount()).isEqualTo(29000);
+    assertThat(plan.getCurrency()).isEqualTo("KRW");
+    assertThat(plan.getBillingInterval()).isEqualTo(BillingInterval.MONTH);
+    assertThat(plan.getStatus()).isEqualTo(Plan.STATUS_ACTIVE);
+  }
+
+  @Test
+  @DisplayName("planKey blank이면 생성을 거부한다")
+  void create_blankPlanKey_throws() {
+    assertThatThrownBy(() -> Plan.create("", "Pro", 29000, "KRW", BillingInterval.MONTH))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> Plan.create(null, "Pro", 29000, "KRW", BillingInterval.MONTH))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  @DisplayName("name blank이면 생성을 거부한다")
+  void create_blankName_throws() {
+    assertThatThrownBy(() -> Plan.create("pro_monthly", "", 29000, "KRW", BillingInterval.MONTH))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  @DisplayName("billingInterval null이면 생성을 거부한다")
+  void create_nullBillingInterval_throws() {
+    assertThatThrownBy(() -> Plan.create("pro_monthly", "Pro", 29000, "KRW", null))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  @DisplayName("price()는 Money 객체를 반환한다")
+  void price_returnsMoney() {
+    Plan plan = Plan.create("pro_monthly", "Pro", 29000, "KRW", BillingInterval.MONTH);
+
+    Money price = plan.price();
+
+    assertThat(price.amount()).isEqualTo(29000);
+    assertThat(price.currency()).isEqualTo("KRW");
+  }
+}

--- a/backend/src/test/java/com/init/payment/domain/model/StatusEnumTest.java
+++ b/backend/src/test/java/com/init/payment/domain/model/StatusEnumTest.java
@@ -1,0 +1,44 @@
+package com.init.payment.domain.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Payment/Subscription 상태 열거형 유틸리티 메서드")
+class StatusEnumTest {
+
+  @Test
+  @DisplayName("PaymentStatus.isDone() — DONE일 때만 true")
+  void paymentStatus_isDone() {
+    assertThat(PaymentStatus.DONE.isDone()).isTrue();
+    assertThat(PaymentStatus.READY.isDone()).isFalse();
+    assertThat(PaymentStatus.CANCELED.isDone()).isFalse();
+  }
+
+  @Test
+  @DisplayName("PaymentStatus.isCanceled() — CANCELED 또는 PARTIAL_CANCELED일 때 true")
+  void paymentStatus_isCanceled() {
+    assertThat(PaymentStatus.CANCELED.isCanceled()).isTrue();
+    assertThat(PaymentStatus.PARTIAL_CANCELED.isCanceled()).isTrue();
+    assertThat(PaymentStatus.DONE.isCanceled()).isFalse();
+    assertThat(PaymentStatus.ABORTED.isCanceled()).isFalse();
+  }
+
+  @Test
+  @DisplayName("SubscriptionStatus.isActive() — ACTIVE일 때만 true")
+  void subscriptionStatus_isActive() {
+    assertThat(SubscriptionStatus.ACTIVE.isActive()).isTrue();
+    assertThat(SubscriptionStatus.INCOMPLETE.isActive()).isFalse();
+    assertThat(SubscriptionStatus.PAST_DUE.isActive()).isFalse();
+    assertThat(SubscriptionStatus.CANCELED.isActive()).isFalse();
+  }
+
+  @Test
+  @DisplayName("SubscriptionStatus.isTerminated() — CANCELED일 때만 true")
+  void subscriptionStatus_isTerminated() {
+    assertThat(SubscriptionStatus.CANCELED.isTerminated()).isTrue();
+    assertThat(SubscriptionStatus.ACTIVE.isTerminated()).isFalse();
+    assertThat(SubscriptionStatus.PAST_DUE.isTerminated()).isFalse();
+  }
+}

--- a/backend/src/test/java/com/init/payment/domain/model/SubscriptionTest.java
+++ b/backend/src/test/java/com/init/payment/domain/model/SubscriptionTest.java
@@ -1,0 +1,103 @@
+package com.init.payment.domain.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Subscription 도메인")
+class SubscriptionTest {
+
+  private static final OffsetDateTime START = OffsetDateTime.parse("2026-06-01T00:00:00Z");
+  private static final OffsetDateTime END = OffsetDateTime.parse("2026-07-01T00:00:00Z");
+
+  @Test
+  @DisplayName("생성 시 INCOMPLETE 상태로 시작한다")
+  void create_startsIncomplete() {
+    Subscription subscription = Subscription.create(1L, 10L);
+
+    assertThat(subscription.getStatus()).isEqualTo(SubscriptionStatus.INCOMPLETE);
+    assertThat(subscription.getFailedAttemptCount()).isZero();
+    assertThat(subscription.isCancelAtPeriodEnd()).isFalse();
+  }
+
+  @Test
+  @DisplayName("첫 결제 성공 시 ACTIVE로 활성화되고 주기/customerKey가 설정된다")
+  void activate_setsActive() {
+    Subscription subscription = Subscription.create(1L, 10L);
+
+    subscription.activate(START, END, "wsk_1_abc");
+
+    assertThat(subscription.getStatus()).isEqualTo(SubscriptionStatus.ACTIVE);
+    assertThat(subscription.getCurrentPeriodStart()).isEqualTo(START);
+    assertThat(subscription.getCurrentPeriodEnd()).isEqualTo(END);
+    assertThat(subscription.getCustomerKey()).isEqualTo("wsk_1_abc");
+  }
+
+  @Test
+  @DisplayName("정기결제 실패 4회차에 재시도가 소진되어 해지된다 (U-004)")
+  void recurringFailure_exhaustsRetryAndCancels() {
+    Subscription subscription = activeSubscription();
+
+    OffsetDateTime retryAt = END.plusDays(1);
+    subscription.markPastDue(retryAt);
+    assertThat(subscription.getStatus()).isEqualTo(SubscriptionStatus.PAST_DUE);
+    assertThat(subscription.getFailedAttemptCount()).isEqualTo(1);
+    assertThat(subscription.isRetryExhausted()).isFalse();
+
+    subscription.markPastDue(retryAt.plusDays(1));
+    subscription.markPastDue(retryAt.plusDays(2));
+    assertThat(subscription.getFailedAttemptCount()).isEqualTo(3);
+    assertThat(subscription.isRetryExhausted()).isFalse();
+
+    subscription.markPastDue(retryAt.plusDays(3));
+    assertThat(subscription.getFailedAttemptCount()).isEqualTo(4);
+    assertThat(subscription.isRetryExhausted()).isTrue();
+
+    subscription.cancel();
+    assertThat(subscription.getStatus()).isEqualTo(SubscriptionStatus.CANCELED);
+  }
+
+  @Test
+  @DisplayName("재시도 성공 시 ACTIVE로 복구되고 실패 카운트가 초기화된다")
+  void recover_resetsFailureCount() {
+    Subscription subscription = activeSubscription();
+    subscription.markPastDue(END.plusDays(1));
+    subscription.markPastDue(END.plusDays(2));
+
+    subscription.recover(END, END.plusMonths(1));
+
+    assertThat(subscription.getStatus()).isEqualTo(SubscriptionStatus.ACTIVE);
+    assertThat(subscription.getFailedAttemptCount()).isZero();
+    assertThat(subscription.getNextRetryAt()).isNull();
+  }
+
+  @Test
+  @DisplayName("기간말 해지 예약 시 ACTIVE를 유지하고 cancelAtPeriodEnd만 true가 된다 (U-005)")
+  void scheduleCancelAtPeriodEnd_keepsActive() {
+    Subscription subscription = activeSubscription();
+
+    subscription.scheduleCancelAtPeriodEnd();
+
+    assertThat(subscription.getStatus()).isEqualTo(SubscriptionStatus.ACTIVE);
+    assertThat(subscription.isCancelAtPeriodEnd()).isTrue();
+  }
+
+  @Test
+  @DisplayName("취소된 구독은 활성화할 수 없다")
+  void activate_onCanceled_throws() {
+    Subscription subscription = activeSubscription();
+    subscription.cancel();
+
+    assertThatThrownBy(() -> subscription.activate(START, END, "ck"))
+        .isInstanceOf(IllegalStateException.class);
+  }
+
+  private Subscription activeSubscription() {
+    Subscription subscription = Subscription.create(1L, 10L);
+    subscription.activate(START, END, "wsk_1_abc");
+    return subscription;
+  }
+}

--- a/backend/src/test/java/com/init/payment/domain/model/SubscriptionTest.java
+++ b/backend/src/test/java/com/init/payment/domain/model/SubscriptionTest.java
@@ -95,6 +95,48 @@ class SubscriptionTest {
         .isInstanceOf(IllegalStateException.class);
   }
 
+  @Test
+  @DisplayName("activate/renew에서 기간이 null이거나 순서가 잘못되면 거부한다 (V-NEW-007)")
+  void activate_invalidPeriod_throws() {
+    Subscription subscription = Subscription.create(1L, 10L);
+
+    assertThatThrownBy(() -> subscription.activate(null, END, "ck"))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> subscription.activate(START, null, "ck"))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> subscription.activate(END, START, "ck"))
+        .isInstanceOf(IllegalArgumentException.class);
+
+    Subscription active = activeSubscription();
+    assertThatThrownBy(() -> active.renew(null, END)).isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> active.renew(END, START)).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  @DisplayName("customerKey를 다른 값으로 재설정하면 거부한다 (V-NEW-006)")
+  void assignCustomerKey_reassign_throws() {
+    Subscription subscription = Subscription.create(1L, 10L);
+    subscription.assignCustomerKey("wsk_1_abc");
+
+    assertThatThrownBy(() -> subscription.assignCustomerKey("wsk_2_different"))
+        .isInstanceOf(IllegalStateException.class);
+
+    subscription.assignCustomerKey("wsk_1_abc");
+  }
+
+  @Test
+  @DisplayName("ACTIVE가 아닌 구독에 scheduleCancelAtPeriodEnd()를 호출하면 거부한다 (V-NEW-008)")
+  void scheduleCancelAtPeriodEnd_nonActive_throws() {
+    Subscription incomplete = Subscription.create(1L, 10L);
+    assertThatThrownBy(incomplete::scheduleCancelAtPeriodEnd)
+        .isInstanceOf(IllegalStateException.class);
+
+    Subscription canceled = activeSubscription();
+    canceled.cancel();
+    assertThatThrownBy(canceled::scheduleCancelAtPeriodEnd)
+        .isInstanceOf(IllegalStateException.class);
+  }
+
   private Subscription activeSubscription() {
     Subscription subscription = Subscription.create(1L, 10L);
     subscription.activate(START, END, "wsk_1_abc");

--- a/backend/src/test/java/com/init/payment/domain/model/WebhookEventTest.java
+++ b/backend/src/test/java/com/init/payment/domain/model/WebhookEventTest.java
@@ -1,0 +1,52 @@
+package com.init.payment.domain.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("WebhookEvent 도메인")
+class WebhookEventTest {
+
+  @Test
+  @DisplayName("생성 시 미처리 상태이다")
+  void received_isUnprocessed() {
+    WebhookEvent event = WebhookEvent.received("txn_1", "PAYMENT_STATUS", "{}");
+
+    assertThat(event.isProcessed()).isFalse();
+    assertThat(event.getTransmissionId()).isEqualTo("txn_1");
+    assertThat(event.getEventType()).isEqualTo("PAYMENT_STATUS");
+  }
+
+  @Test
+  @DisplayName("markProcessed 후 처리됨 상태로 전이한다")
+  void markProcessed_setsProcessedAt() {
+    WebhookEvent event = WebhookEvent.received("txn_1", "PAYMENT_STATUS", "{}");
+    OffsetDateTime processedAt = OffsetDateTime.parse("2026-06-01T00:00:00Z");
+
+    event.markProcessed(processedAt);
+
+    assertThat(event.isProcessed()).isTrue();
+    assertThat(event.getProcessedAt()).isEqualTo(processedAt);
+  }
+
+  @Test
+  @DisplayName("null processedAt으로 markProcessed 시 거부한다 (V-NEW-009)")
+  void markProcessed_nullProcessedAt_throws() {
+    WebhookEvent event = WebhookEvent.received("txn_1", "PAYMENT_STATUS", "{}");
+
+    assertThatThrownBy(() -> event.markProcessed(null))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  @DisplayName("transmissionId가 blank이면 received() 생성을 거부한다")
+  void received_blankTransmissionId_throws() {
+    assertThatThrownBy(() -> WebhookEvent.received("", "TYPE", "{}"))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> WebhookEvent.received(null, "TYPE", "{}"))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+}

--- a/backend/src/test/java/com/init/payment/infrastructure/crypto/PgcryptoBillingKeyCipherTest.java
+++ b/backend/src/test/java/com/init/payment/infrastructure/crypto/PgcryptoBillingKeyCipherTest.java
@@ -1,0 +1,114 @@
+package com.init.payment.infrastructure.crypto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import com.init.payment.infrastructure.config.TossApiProperties;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PgcryptoBillingKeyCipher")
+class PgcryptoBillingKeyCipherTest {
+
+  @Mock EntityManager entityManager;
+
+  private PgcryptoBillingKeyCipher cipher(String encKey) {
+    TossApiProperties props = new TossApiProperties(null, null, encKey);
+    return new PgcryptoBillingKeyCipher(entityManager, props);
+  }
+
+  @Test
+  @DisplayName("암호화할 평문이 공백이면 IllegalArgumentException")
+  void encrypt_blankPlaintext_throws() {
+    assertThatThrownBy(() -> cipher("my-key").encrypt(""))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  @DisplayName("복호화할 암호문이 null이면 IllegalArgumentException")
+  void decrypt_nullCiphertext_throws() {
+    assertThatThrownBy(() -> cipher("my-key").decrypt(null))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  @DisplayName("복호화할 암호문이 비어있으면 IllegalArgumentException")
+  void decrypt_emptyCiphertext_throws() {
+    assertThatThrownBy(() -> cipher("my-key").decrypt(new byte[0]))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  @DisplayName("암호화 키가 null이면 IllegalStateException")
+  void encrypt_nullKey_throws() {
+    Query query = mock(Query.class);
+    given(entityManager.createNativeQuery(any())).willReturn(query);
+    given(query.setParameter(anyString(), any())).willReturn(query);
+
+    assertThatThrownBy(() -> cipher(null).encrypt("plain-billing-key"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("TOSS_BILLING_KEY_ENCRYPTION_KEY");
+  }
+
+  @Test
+  @DisplayName("암호화 키가 공백이면 IllegalStateException")
+  void encrypt_blankKey_throws() {
+    Query query = mock(Query.class);
+    given(entityManager.createNativeQuery(any())).willReturn(query);
+    given(query.setParameter(anyString(), any())).willReturn(query);
+
+    assertThatThrownBy(() -> cipher("  ").encrypt("plain-billing-key"))
+        .isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  @DisplayName("pgp_sym_encrypt 네이티브 쿼리를 EntityManager에 위임한다")
+  void encrypt_delegates_to_entityManager() {
+    Query query = mock(Query.class);
+    given(entityManager.createNativeQuery(contains("pgp_sym_encrypt"))).willReturn(query);
+    given(query.setParameter(anyString(), any())).willReturn(query);
+    given(query.getSingleResult()).willReturn(new byte[] {1, 2, 3});
+
+    byte[] result = cipher("my-key").encrypt("plain-billing-key");
+
+    assertThat(result).isEqualTo(new byte[] {1, 2, 3});
+  }
+
+  @Test
+  @DisplayName("pgp_sym_decrypt byte[] 결과를 UTF-8 문자열로 반환한다")
+  void decrypt_byteArrayResult_returnsString() {
+    Query query = mock(Query.class);
+    given(entityManager.createNativeQuery(contains("pgp_sym_decrypt"))).willReturn(query);
+    given(query.setParameter(anyString(), any())).willReturn(query);
+    given(query.getSingleResult()).willReturn("plain".getBytes(StandardCharsets.UTF_8));
+
+    String result = cipher("my-key").decrypt(new byte[] {1, 2, 3});
+
+    assertThat(result).isEqualTo("plain");
+  }
+
+  @Test
+  @DisplayName("pgp_sym_decrypt String 결과를 그대로 반환한다")
+  void decrypt_stringResult_returnsAsIs() {
+    Query query = mock(Query.class);
+    given(entityManager.createNativeQuery(contains("pgp_sym_decrypt"))).willReturn(query);
+    given(query.setParameter(anyString(), any())).willReturn(query);
+    given(query.getSingleResult()).willReturn("plain-string");
+
+    String result = cipher("my-key").decrypt(new byte[] {1, 2, 3});
+
+    assertThat(result).isEqualTo("plain-string");
+  }
+}

--- a/backend/src/test/java/com/init/payment/infrastructure/persistence/PaymentWorkspaceMembershipAdapterTest.java
+++ b/backend/src/test/java/com/init/payment/infrastructure/persistence/PaymentWorkspaceMembershipAdapterTest.java
@@ -1,0 +1,75 @@
+package com.init.payment.infrastructure.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import com.init.workspace.domain.model.WorkspaceMember;
+import com.init.workspace.domain.model.WorkspaceMemberRole;
+import com.init.workspace.domain.repository.WorkspaceMemberRepository;
+import com.init.workspace.domain.repository.WorkspaceRepository;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PaymentWorkspaceMembershipAdapter")
+class PaymentWorkspaceMembershipAdapterTest {
+
+  @Mock private WorkspaceRepository workspaceRepository;
+  @Mock private WorkspaceMemberRepository workspaceMemberRepository;
+
+  private PaymentWorkspaceMembershipAdapter adapter;
+
+  @BeforeEach
+  void setUp() {
+    adapter = new PaymentWorkspaceMembershipAdapter(workspaceRepository, workspaceMemberRepository);
+  }
+
+  @Test
+  @DisplayName("existsById는 WorkspaceRepository에 위임한다")
+  void existsById_delegates() {
+    given(workspaceRepository.existsById(1L)).willReturn(true);
+
+    assertThat(adapter.existsById(1L)).isTrue();
+  }
+
+  @Test
+  @DisplayName("hasAnyRole — 멤버 존재 + 허용 역할이면 true")
+  void hasAnyRole_allowedRole_returnsTrue() {
+    WorkspaceMember member = WorkspaceMember.create(1L, 99L, WorkspaceMemberRole.OWNER);
+    given(workspaceMemberRepository.findByWorkspaceIdAndUserId(1L, 99L))
+        .willReturn(Optional.of(member));
+
+    boolean result = adapter.hasAnyRole(1L, 99L, Set.of("OWNER", "ADMIN"));
+
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  @DisplayName("hasAnyRole — 멤버 존재 + 허용되지 않은 역할이면 false")
+  void hasAnyRole_disallowedRole_returnsFalse() {
+    WorkspaceMember member = WorkspaceMember.create(1L, 99L, WorkspaceMemberRole.REVIEWER);
+    given(workspaceMemberRepository.findByWorkspaceIdAndUserId(1L, 99L))
+        .willReturn(Optional.of(member));
+
+    boolean result = adapter.hasAnyRole(1L, 99L, Set.of("OWNER", "ADMIN"));
+
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  @DisplayName("hasAnyRole — 멤버 미존재이면 false")
+  void hasAnyRole_memberNotFound_returnsFalse() {
+    given(workspaceMemberRepository.findByWorkspaceIdAndUserId(1L, 99L))
+        .willReturn(Optional.empty());
+
+    boolean result = adapter.hasAnyRole(1L, 99L, Set.of("OWNER", "ADMIN"));
+
+    assertThat(result).isFalse();
+  }
+}

--- a/backend/src/test/java/com/init/payment/presentation/PaymentControllerTest.java
+++ b/backend/src/test/java/com/init/payment/presentation/PaymentControllerTest.java
@@ -1,0 +1,141 @@
+package com.init.payment.presentation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.init.fixtures.WithLongPrincipal;
+import com.init.payment.application.PaymentResult;
+import com.init.payment.application.PaymentService;
+import com.init.payment.application.exception.PaymentAmountMismatchException;
+import com.init.shared.infrastructure.security.JwtAuthenticationFilter;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(
+    value = PaymentController.class,
+    excludeFilters =
+        @ComponentScan.Filter(
+            type = FilterType.ASSIGNABLE_TYPE,
+            classes = JwtAuthenticationFilter.class))
+@DisplayName("PaymentController")
+class PaymentControllerTest {
+
+  private static final String BASE_URL = "/api/v1/workspaces/1/payments";
+
+  private final MockMvc mockMvc;
+
+  @Autowired
+  PaymentControllerTest(MockMvc mockMvc) {
+    this.mockMvc = mockMvc;
+  }
+
+  @MockitoBean private PaymentService paymentService;
+
+  @Test
+  @DisplayName("결제 confirm 성공 시 200과 DONE 상태를 반환한다")
+  @WithLongPrincipal(55L)
+  void confirm_returns200() throws Exception {
+    given(paymentService.confirmPayment(any())).willReturn(paymentResult("DONE"));
+
+    mockMvc
+        .perform(
+            post(BASE_URL + "/confirm")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"paymentKey\":\"pay_1\",\"orderId\":\"ord_1\",\"amount\":29000}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.status").value("DONE"));
+  }
+
+  @Test
+  @DisplayName("금액 불일치 시 400과 PAYMENT_AMOUNT_MISMATCH 코드를 반환한다")
+  @WithLongPrincipal(55L)
+  void confirm_amountMismatch_returns400() throws Exception {
+    given(paymentService.confirmPayment(any()))
+        .willThrow(new PaymentAmountMismatchException(29000, 10000));
+
+    mockMvc
+        .perform(
+            post(BASE_URL + "/confirm")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"paymentKey\":\"pay_1\",\"orderId\":\"ord_1\",\"amount\":10000}"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("PAYMENT_AMOUNT_MISMATCH"));
+  }
+
+  @Test
+  @DisplayName("amount가 누락되면 400을 반환한다")
+  @WithLongPrincipal(55L)
+  void confirm_missingAmount_returns400() throws Exception {
+    mockMvc
+        .perform(
+            post(BASE_URL + "/confirm")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"paymentKey\":\"pay_1\",\"orderId\":\"ord_1\"}"))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("결제 내역 조회 시 200과 목록을 반환한다")
+  @WithLongPrincipal(55L)
+  void getPayments_returns200() throws Exception {
+    given(paymentService.getPayments(1L, 55L)).willReturn(List.of(paymentResult("DONE")));
+
+    mockMvc
+        .perform(get(BASE_URL))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].status").value("DONE"));
+  }
+
+  @Test
+  @DisplayName("결제 취소 성공 시 200을 반환한다")
+  @WithLongPrincipal(55L)
+  void cancel_returns200() throws Exception {
+    given(paymentService.cancelPayment(any())).willReturn(paymentResult("CANCELED"));
+
+    mockMvc
+        .perform(
+            post(BASE_URL + "/pay_1/cancel")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"cancelReason\":\"고객 요청\"}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.status").value("CANCELED"));
+  }
+
+  @Test
+  @DisplayName("인증 principal이 없으면 401을 반환한다")
+  void getPayments_noAuth_returns401() throws Exception {
+    mockMvc.perform(get(BASE_URL)).andExpect(status().isUnauthorized());
+  }
+
+  private PaymentResult paymentResult(String status) {
+    return new PaymentResult(
+        7L,
+        "ord_1",
+        "pay_1",
+        29000,
+        "KRW",
+        status,
+        "카드",
+        OffsetDateTime.parse("2026-06-01T00:00:00Z"),
+        "https://receipt",
+        OffsetDateTime.parse("2026-06-01T00:00:00Z"));
+  }
+}

--- a/backend/src/test/java/com/init/payment/presentation/PaymentWebhookControllerTest.java
+++ b/backend/src/test/java/com/init/payment/presentation/PaymentWebhookControllerTest.java
@@ -1,0 +1,101 @@
+package com.init.payment.presentation;
+
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.init.payment.application.HandleTossWebhookCommand;
+import com.init.payment.application.PaymentWebhookService;
+import com.init.payment.application.exception.PaymentWebhookUnauthorizedException;
+import com.init.shared.infrastructure.security.JwtAuthenticationFilter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(
+    value = PaymentWebhookController.class,
+    excludeFilters =
+        @ComponentScan.Filter(
+            type = FilterType.ASSIGNABLE_TYPE,
+            classes = JwtAuthenticationFilter.class))
+@DisplayName("PaymentWebhookController")
+class PaymentWebhookControllerTest {
+
+  private static final String URL = "/api/v1/payments/webhooks/toss";
+
+  private final MockMvc mockMvc;
+
+  @Autowired
+  PaymentWebhookControllerTest(MockMvc mockMvc) {
+    this.mockMvc = mockMvc;
+  }
+
+  @MockitoBean private PaymentWebhookService paymentWebhookService;
+
+  @Test
+  @WithMockUser
+  @DisplayName("유효한 웹훅은 시크릿 헤더/paymentKey를 추출해 200을 반환한다")
+  void receive_returns200AndExtractsFields() throws Exception {
+    mockMvc
+        .perform(
+            post(URL)
+                .with(csrf())
+                .header("X-Toss-Webhook-Secret", "secret-value")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    "{\"eventType\":\"PAYMENT_STATUS_CHANGED\","
+                        + "\"data\":{\"paymentKey\":\"pay_1\",\"status\":\"DONE\"}}"))
+        .andExpect(status().isOk());
+
+    ArgumentCaptor<HandleTossWebhookCommand> captor =
+        ArgumentCaptor.forClass(HandleTossWebhookCommand.class);
+    then(paymentWebhookService).should().handle(captor.capture());
+    HandleTossWebhookCommand command = captor.getValue();
+    org.assertj.core.api.Assertions.assertThat(command.secretHeader()).isEqualTo("secret-value");
+    org.assertj.core.api.Assertions.assertThat(command.paymentKey()).isEqualTo("pay_1");
+    org.assertj.core.api.Assertions.assertThat(command.eventType())
+        .isEqualTo("PAYMENT_STATUS_CHANGED");
+  }
+
+  @Test
+  @WithMockUser
+  @DisplayName("시크릿 불일치 시 403을 반환한다 (application 계층 검증)")
+  void receive_invalidSecret_returns403() throws Exception {
+    doThrow(new PaymentWebhookUnauthorizedException())
+        .when(paymentWebhookService)
+        .handle(org.mockito.ArgumentMatchers.any());
+
+    mockMvc
+        .perform(
+            post(URL)
+                .with(csrf())
+                .header("X-Toss-Webhook-Secret", "wrong")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"data\":{\"paymentKey\":\"pay_1\",\"status\":\"DONE\"}}"))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @WithMockUser
+  @DisplayName("본문이 유효한 JSON이 아니면 400을 반환한다")
+  void receive_invalidJson_returns400() throws Exception {
+    mockMvc
+        .perform(
+            post(URL)
+                .with(csrf())
+                .header("X-Toss-Webhook-Secret", "secret-value")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("not-json"))
+        .andExpect(status().isBadRequest());
+  }
+}

--- a/backend/src/test/java/com/init/payment/presentation/PaymentWebhookControllerTest.java
+++ b/backend/src/test/java/com/init/payment/presentation/PaymentWebhookControllerTest.java
@@ -2,7 +2,6 @@ package com.init.payment.presentation;
 
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.doThrow;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -14,20 +13,30 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.http.MediaType;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+/**
+ * 무인증·무CSRF: Toss 서버가 직접 발송하는 실제 조건을 미러링한다.
+ *
+ * <p>보안 Auto-Configuration을 제외하여 인증/CSRF 없이 컨트롤러 동작만 검증한다.
+ */
 @WebMvcTest(
     value = PaymentWebhookController.class,
     excludeFilters =
         @ComponentScan.Filter(
             type = FilterType.ASSIGNABLE_TYPE,
-            classes = JwtAuthenticationFilter.class))
+            classes = JwtAuthenticationFilter.class),
+    excludeAutoConfiguration = {
+      SecurityAutoConfiguration.class,
+      SecurityFilterAutoConfiguration.class
+    })
 @DisplayName("PaymentWebhookController")
 class PaymentWebhookControllerTest {
 
@@ -43,13 +52,11 @@ class PaymentWebhookControllerTest {
   @MockitoBean private PaymentWebhookService paymentWebhookService;
 
   @Test
-  @WithMockUser
   @DisplayName("유효한 웹훅은 시크릿 헤더/paymentKey를 추출해 200을 반환한다")
   void receive_returns200AndExtractsFields() throws Exception {
     mockMvc
         .perform(
             post(URL)
-                .with(csrf())
                 .header("X-Toss-Webhook-Secret", "secret-value")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(
@@ -68,7 +75,6 @@ class PaymentWebhookControllerTest {
   }
 
   @Test
-  @WithMockUser
   @DisplayName("시크릿 불일치 시 403을 반환한다 (application 계층 검증)")
   void receive_invalidSecret_returns403() throws Exception {
     doThrow(new PaymentWebhookUnauthorizedException())
@@ -78,7 +84,6 @@ class PaymentWebhookControllerTest {
     mockMvc
         .perform(
             post(URL)
-                .with(csrf())
                 .header("X-Toss-Webhook-Secret", "wrong")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"data\":{\"paymentKey\":\"pay_1\",\"status\":\"DONE\"}}"))
@@ -86,13 +91,11 @@ class PaymentWebhookControllerTest {
   }
 
   @Test
-  @WithMockUser
   @DisplayName("본문이 유효한 JSON이 아니면 400을 반환한다")
   void receive_invalidJson_returns400() throws Exception {
     mockMvc
         .perform(
             post(URL)
-                .with(csrf())
                 .header("X-Toss-Webhook-Secret", "secret-value")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("not-json"))

--- a/backend/src/test/java/com/init/payment/presentation/SubscriptionControllerTest.java
+++ b/backend/src/test/java/com/init/payment/presentation/SubscriptionControllerTest.java
@@ -1,0 +1,152 @@
+package com.init.payment.presentation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.init.fixtures.WithLongPrincipal;
+import com.init.payment.application.BillingAuthorizationResult;
+import com.init.payment.application.BillingKeySummary;
+import com.init.payment.application.SubscriptionResult;
+import com.init.payment.application.SubscriptionService;
+import com.init.shared.infrastructure.security.JwtAuthenticationFilter;
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(
+    value = SubscriptionController.class,
+    excludeFilters =
+        @ComponentScan.Filter(
+            type = FilterType.ASSIGNABLE_TYPE,
+            classes = JwtAuthenticationFilter.class))
+@DisplayName("SubscriptionController")
+class SubscriptionControllerTest {
+
+  private static final String BASE_URL = "/api/v1/workspaces/1";
+
+  private final MockMvc mockMvc;
+
+  @Autowired
+  SubscriptionControllerTest(MockMvc mockMvc) {
+    this.mockMvc = mockMvc;
+  }
+
+  @MockitoBean private SubscriptionService subscriptionService;
+
+  @Test
+  @DisplayName("구독 조회 성공 시 200을 반환한다")
+  @WithLongPrincipal(55L)
+  void getSubscription_returns200() throws Exception {
+    given(subscriptionService.getSubscription(1L, 55L)).willReturn(subscriptionResult("ACTIVE"));
+
+    mockMvc
+        .perform(get(BASE_URL + "/subscription"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.status").value("ACTIVE"))
+        .andExpect(jsonPath("$.planKey").value("pro_monthly"));
+  }
+
+  @Test
+  @DisplayName("구독 생성 성공 시 201을 반환한다")
+  @WithLongPrincipal(55L)
+  void createSubscription_returns201() throws Exception {
+    given(subscriptionService.createSubscription(any()))
+        .willReturn(subscriptionResult("INCOMPLETE"));
+
+    mockMvc
+        .perform(
+            post(BASE_URL + "/subscription")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"planKey\":\"pro_monthly\"}"))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.status").value("INCOMPLETE"));
+  }
+
+  @Test
+  @DisplayName("planKey가 비어 있으면 400을 반환한다")
+  @WithLongPrincipal(55L)
+  void createSubscription_blankPlanKey_returns400() throws Exception {
+    mockMvc
+        .perform(
+            post(BASE_URL + "/subscription")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("구독 취소 성공 시 200을 반환한다")
+  @WithLongPrincipal(55L)
+  void cancelSubscription_returns200() throws Exception {
+    given(subscriptionService.cancelSubscription(1L, 55L)).willReturn(subscriptionResult("ACTIVE"));
+
+    mockMvc.perform(delete(BASE_URL + "/subscription").with(csrf())).andExpect(status().isOk());
+  }
+
+  @Test
+  @DisplayName("billingKey 발급 성공 시 200과 마스킹 카드정보를 반환한다")
+  @WithLongPrincipal(55L)
+  void issueBillingKey_returns200() throws Exception {
+    given(subscriptionService.issueBillingKey(any()))
+        .willReturn(
+            new BillingAuthorizationResult(
+                subscriptionResult("ACTIVE"),
+                new BillingKeySummary(5L, "신한", "1234-****-****-5678", "ACTIVE")));
+
+    mockMvc
+        .perform(
+            post(BASE_URL + "/billing/authorizations")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"authKey\":\"auth_xxx\",\"customerKey\":\"wsk_1_abc\"}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.subscription.status").value("ACTIVE"))
+        .andExpect(jsonPath("$.billingKey.cardNumberMasked").value("1234-****-****-5678"));
+  }
+
+  @Test
+  @DisplayName("authKey가 비어 있으면 400을 반환한다")
+  @WithLongPrincipal(55L)
+  void issueBillingKey_blankAuthKey_returns400() throws Exception {
+    mockMvc
+        .perform(
+            post(BASE_URL + "/billing/authorizations")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"authKey\":\"\"}"))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("인증 principal이 없으면 401을 반환한다")
+  void getSubscription_noAuth_returns401() throws Exception {
+    mockMvc.perform(get(BASE_URL + "/subscription")).andExpect(status().isUnauthorized());
+  }
+
+  private SubscriptionResult subscriptionResult(String status) {
+    return new SubscriptionResult(
+        10L,
+        1L,
+        "pro_monthly",
+        status,
+        OffsetDateTime.parse("2026-06-01T00:00:00Z"),
+        OffsetDateTime.parse("2026-07-01T00:00:00Z"),
+        false,
+        "wsk_1_abc");
+  }
+}

--- a/backend/src/test/java/com/init/payment/presentation/SubscriptionControllerTest.java
+++ b/backend/src/test/java/com/init/payment/presentation/SubscriptionControllerTest.java
@@ -85,7 +85,7 @@ class SubscriptionControllerTest {
             post(BASE_URL + "/subscription")
                 .with(csrf())
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("{}"))
+                .content("{\"planKey\":\"\"}"))
         .andExpect(status().isBadRequest());
   }
 
@@ -128,7 +128,7 @@ class SubscriptionControllerTest {
             post(BASE_URL + "/billing/authorizations")
                 .with(csrf())
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"authKey\":\"\"}"))
+                .content("{\"authKey\":\"\",\"customerKey\":\"wsk_1_abc\"}"))
         .andExpect(status().isBadRequest());
   }
 

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -1,7 +1,7 @@
 spring:
   datasource:
     # 1. H2 옵션 최적화: PostgreSQL 모드와 식별자 대소문자 설정을 맞춥니다.
-    url: "jdbc:h2:mem:testdb;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH;INIT=CREATE SCHEMA IF NOT EXISTS app\\;CREATE SCHEMA IF NOT EXISTS corpus\\;CREATE SCHEMA IF NOT EXISTS pack\\;CREATE SCHEMA IF NOT EXISTS review\\;CREATE SCHEMA IF NOT EXISTS pipeline\\;CREATE SCHEMA IF NOT EXISTS runtime"
+    url: "jdbc:h2:mem:testdb;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH;INIT=CREATE SCHEMA IF NOT EXISTS app\\;CREATE SCHEMA IF NOT EXISTS corpus\\;CREATE SCHEMA IF NOT EXISTS pack\\;CREATE SCHEMA IF NOT EXISTS review\\;CREATE SCHEMA IF NOT EXISTS pipeline\\;CREATE SCHEMA IF NOT EXISTS runtime\\;CREATE SCHEMA IF NOT EXISTS payment"
     driver-class-name: org.h2.Driver
     username: sa
     password:
@@ -56,6 +56,14 @@ app:
 airflow:
   webhook:
     secret: test-airflow-webhook-secret
+
+toss:
+  api:
+    base-url: https://api.tosspayments.com
+    secret-key: test-toss-secret-key
+  webhook:
+    secret: test-toss-webhook-secret
+  billing-key-encryption-key: test-toss-billing-key-encryption-key
 
 storage:
   s3:


### PR DESCRIPTION
#### Summary

- 신규 `com.init.payment` BC: 빌링키 발급/pgcrypto 암호화, 구독 생성·조회·취소, 일회성 confirm, 정기결제 스케줄러, 웹훅 처리(시크릿 헤더 + Toss 재조회)
- Spring `@Scheduled` 기반 정기결제(cron 기본 30분) — PAST_DUE → 3일 재시도 → CANCELED 상태머신(U-004 확정)
- PostgreSQL `pgcrypto` 컬럼 암호화로 billingKey 저장; 평문은 발급/정기결제 직전 메모리에서만 일시 보유(U-002 확정)
- 웹훅: `X-Toss-Webhook-Secret` 상수시간 비교 + `transmission_id` 멱등 + Toss API 재조회로 권위 상태 확정(U-003 확정)
- `TossPayloadMasker`로 billingKey/secretKey 응답·로그·저장 미노출 구조적 보장

---

#### Context

`.agent/specs/488.md` — [BE] 488 토스페이먼츠 v2 자동결제 기반 워크스페이스 구독 (백엔드)  
관련 FE companion: GitHub Issue #487 (out of scope for this PR).

---

#### What Changed

- **신규 `com.init.payment` BC** — 4계층(presentation / application / domain / infrastructure) + `package-info.java`
  - Controller 3개: `PaymentController`, `SubscriptionController`, `PaymentWebhookController`
  - Application service 4개: `SubscriptionService`, `PaymentService`, `PaymentWebhookService`, `RecurringBillingScheduler` + `RecurringBillingService`
  - Domain: `Subscription`, `Payment`, `BillingKey`, `Plan` aggregate + 상태 enum + VO + 도메인 메서드
  - Infrastructure: `PgcryptoBillingKeyCipher`(네이티브 쿼리 pgcrypto), `TossPaymentClient`(RestClient), `BillingKeyCipher` port, `PaymentWorkspaceMembershipAdapter`
- **`payment` 스키마 신설** — 6개 테이블(`plan`, `subscription`, `billing_key`, `payment`, `payment_cancel`, `webhook_event`) + pgcrypto extension, Liquibase changeset 추가
- **shared 계층 변경** — `SecurityConfig`: `/api/v1/payments/webhooks/toss` permitAll 추가; `WebhookHeaderNames`: `TOSS_WEBHOOK_SECRET` 상수 추가
- **`.env.example`** — `TOSS_API_BASE_URL`, `TOSS_BILLING_KEY_ENCRYPTION_KEY`, `TOSS_SECRET_KEY`, `TOSS_WEBHOOK_SECRET` 4종 추가

---

#### Assumptions Adopted

U-001~U-004는 사용자 결정으로 확정(Confirmed Implemented). 나머지는 execution log 기준 "Assumption adopted from Decision".

| ID | Status | 채택 내용 요약 |
|---|---|---|
| U-001 | Confirmed | Spring `@Scheduled` 인앱 스케줄러, `PaymentSchedulingConfig`에 `@EnableScheduling` 격리 |
| U-002 | Confirmed | pgcrypto 컬럼 암호화, `BillingKeyCipher` port + `PgcryptoBillingKeyCipher` adapter |
| U-003 | Confirmed | `X-Toss-Webhook-Secret` 상수시간 비교 + `transmission_id` 멱등 + Toss 재조회 |
| U-004 | Confirmed | `MAX_RECURRING_ATTEMPTS=4`, `markPastDue`/`recover`/`cancel` 전이 |
| U-005 | Assumption | 기간말 해지(`cancel_at_period_end=true`, ACTIVE 유지; 스케줄러가 만기 시 `cancel()`) |
| U-006 | Assumption | `customerKey = wsk_{workspaceId}_{uuid}` — PII 없음, 구독 생성 시 1회 생성 |
| U-007 | Assumption | BE가 request/response DTO 계약 권위; `POST /subscription` → confirm 기대금액을 plan 금액에서 도출 |
| U-008 | Assumption | Toss 4xx → `PaymentRejectedException`(400), 5xx/timeout → `PaymentGatewayException`(502) |
| U-009 | Assumption | `PaymentStatus` enum = Toss status 1:1(READY/IN_PROGRESS/DONE/CANCELED/PARTIAL_CANCELED/ABORTED/EXPIRED) |
| U-010 | Assumption | 워크스페이스당 활성 구독 1개, `ActiveSubscriptionExistsException` 애플리케이션 레벨 가드 |
| U-011 | Confirmed(요구)/Assumption(메커니즘) | `unique(subscription_id, billing_period_key)` + DataIntegrityViolation 재로드 |
| U-012 | Confirmed(요구)/Assumption(메커니즘) | `TossPayloadMasker` 공통 마스킹, `BillingKeySummary` 구조적 원문 필드 제거 |
| U-013 | Assumption | `BillingKeyStatus`: ACTIVE/DELETED |
| U-014 | Deferred → Resolved | `com.init.fixtures.WithLongPrincipal` 경로 확정; 웹훅은 `@WithMockUser` 사용 |
| U-015 | Assumption | pipelinejob `WorkspaceMembershipPort` 선례 미러, OWNER/ADMIN/OPERATOR 허용 |
| U-016 | Assumption | BE contract 권위; FE(#487) codegen 재생성 필요(이번 PR은 generated/ 미변경) |

---

#### Spec Deviations

| 항목 | 스펙 | 구현 | 사유 |
|---|---|---|---|
| `interval` 컬럼명 | `interval varchar(20)` | `bill_interval varchar(20)` | PostgreSQL 예약어 회피 |
| `PaymentWebhookService` 의존 | `TossApiProperties` 주입 | `@Value("${toss.webhook.secret:}") String webhookSecret` | V-003 DDD 계층 위반 수정 |
| pgcrypto 테스트 경로 | Postgres testcontainer 분리 제안 | `BillingKeyCipher` Mockito mock | YAGNI; cipher port mock으로 H2 test coverage 충분 |
| `prepareCharge` 구조 | 단일 메서드 | `findOrCreatePeriodPayment`/`createPeriodPayment`/`handleConcurrentInsert` 3개 추출 | V-002 인지 복잡도 해소 |

---

#### Blocked / Skipped Items

- **FE companion #487 미검토** — BE-only PR. `frontend/src/shared/api/generated/` 미재생성(의도적; #487과 함께 재생성 예정).
- **pgcrypto Postgres testcontainer 분리 테스트** — 미도입(YAGNI; mock으로 대체).
- **billingKey 암호화 키 회전(rotation)** — 미구현, 향후 과제.
- **분산 락** — 단일 인스턴스 전제. `unique(subscription_id, billing_period_key)` DB 제약이 최종 안전망.
- **Toss 웹훅 payload `transmission_id` 필드명** — 미확정(U-003 risk); fallback 순서로 멱등 키 도출(`data.lastTransactionKey` → `eventId` → `paymentKey:status`).

---

#### Test Notes

- `./gradlew build -x checkstyleMain -x checkstyleTest` **BUILD SUCCESSFUL** (전체 테스트 통과, 감사 전후 모두)
- **V-001 커버리지 보완** (audit fix #1): `PaymentWebhookServiceTest` +3건(null/blank paymentKey, CANCELED, PARTIAL_CANCELED), `RecurringBillingServiceTest` +7건(null subscription/CANCELED/periodStart-null/existing-done/successful/cancelExpiring/concurrentInsert-null), `TossPayloadMaskerTest` 신규 9건, `PgcryptoBillingKeyCipherTest` 신규 7건
- **V-002 인지 복잡도 수정** (audit fix #1): extract-method 리팩토링, 동작 변경 없음, 전체 테스트 통과
- **V-003 DDD 계층 수정** (audit fix #1): `PaymentWebhookService` + `PaymentWebhookServiceTest` 동반 수정, 전체 테스트 통과
- **H2 full-context `ApplicationTest`** 정상 부팅 — payment 스키마/엔티티(bytea, jsonb 포함) create-drop 검증
- **Playwright / FE runtime 검증**: BE-only PR — 미수행(N/A)

---
#### Reviewer Focus

1. **DDD 계층** — `PaymentWebhookService`에서 `TossApiProperties` 제거 후 `@Value` 직접 주입으로 대체된 구조 확인(V-003 fix). application 계층이 `infrastructure.config` 패키지에 의존하지 않는지 검증.
2. **pgcrypto 암호화 경로** — `BillingKeyCipher` port/adapter 구조, `TOSS_BILLING_KEY_ENCRYPTION_KEY` 미설정 시 `IllegalStateException` throw 확인. `BillingKey` 도메인이 `billing_key_encrypted bytea`만 보유하는지 확인.
3. **중복청구 방지** — `unique(subscription_id, billing_period_key)` + `DataIntegrityViolationException` catch→reload 경로(`RecurringBillingService`). 일회성 결제는 `billing_period_key=null`(다중 null 허용).
4. **웹훅 보안** — `MessageDigest.isEqual` 상수시간 비교, 빈 시크릿 거절, `transmission_id` 멱등(webhook_event unique 제약).
5. **TossPayloadMasker** — `billingKey`/`secretKey`/`authKey`/카드번호 마스킹 커버리지. `BillingKeySummary`에 원문 필드 자체가 없는지.
6. **V-002 인지 복잡도** — `manualReviewRequired: true` (LLM 추정치). SonarQube Cloud CI 분석 후 실측값 확인 권장. 실측이 threshold 미만이면 false positive.
7. **HTTP 클라이언트** — `setBasicAuth(secretKey, "")` + `Idempotency-Key: UUID` 헤더가 모든 Toss POST 호출에 일관 적용되는지.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 결제(승인/취소/조회), 구독 생성/조회/취소, 빌링키 발급, 카드정보 마스킹, Toss 웹훅 처리 및 정기청구 스케줄러 추가

* **Configuration**
  * Toss 연동용 환경변수 4종(TOSS_API_BASE_URL, TOSS_BILLING_KEY_ENCRYPTION_KEY, TOSS_SECRET_KEY, TOSS_WEBHOOK_SECRET) 및 관련 설정 추가

* **DB Migration**
  * 결제·구독용 스키마·테이블 및 기본 요금제 시드 추가

* **Security**
  * Toss 웹훅 엔드포인트 공개 허용 및 웹훅 헤더 CORS 허용 확장

* **Tests**
  * 결제·구독·정기청구·웹훅·암호화 등 광범위한 단위/통합 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->