### PR TITLE
feat(admin): 결제 관리에서 고객사별 전체 환불 지원

### DIFF
--- a/.agent/specs/500.md
+++ b/.agent/specs/500.md
@@ -1,0 +1,199 @@
+# [Mixed] 500 — cstone 결제 관리와 전체 환불
+
+## Goal
+
+`SUPER_ADMIN`이 CStone 관리자 콘솔에서 고객사별 구독·결제 상태를 조회하고, 결제 완료 건에 한해 Toss cancel API를 통한 전체 환불을 실행할 수 있게 한다.
+
+## Scope
+
+- `SUPER_ADMIN` 전용 결제 관리 API와 화면을 제공한다.
+- 고객사별 구독 상태, 결제 기간, 다음 결제일, 최근 결제, 실패 상태를 조회한다.
+- 결제 상태가 `DONE`인 결제에 대해서만 전체 환불을 실행한다.
+- 환불 사유는 요청 값으로 받아 `payment.payment_cancel.reason`에 저장한다.
+- Toss cancel API 요청에는 `cancelReason`만 전달하고 환불 금액 입력은 받지 않는다.
+- 응답과 화면에는 `secretKey`, `billingKey`, `paymentKey`, 원본 카드번호를 포함하지 않는다.
+
+## Non-goals
+
+- 부분 환불
+- 구독 상태 직접 변경
+- 수동 청구
+- 별도 감사 로그 테이블
+- billingKey 발급, 정기결제 실행, 웹훅 동기화 전체 구현
+
+## Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    actor admin as SUPER_ADMIN
+    participant page as AdminBillingPage
+    participant ctrl as AdminBillingController
+    participant svc as AdminBillingUseCase
+    participant toss as TossPaymentGateway
+    participant db as payment schema
+
+    admin ->> page: 결제 관리 진입
+    page ->> ctrl: GET /api/v1/admin/billing/customers
+    ctrl ->> svc: findCustomerSummaries()
+    svc ->> db: workspace + subscription + recent payment 조회
+    db -->> svc: summaries
+    svc -->> page: 고객사별 결제 현황
+
+    admin ->> page: DONE 결제 전체 환불 + 사유 입력
+    page ->> ctrl: POST /api/v1/admin/billing/payments/{paymentId}/refunds
+    ctrl ->> svc: refundFull(paymentId, reason)
+    svc ->> db: payment row pessimistic lock
+    svc ->> toss: POST /v1/payments/{paymentKey}/cancel {cancelReason}
+    toss -->> svc: cancel transaction
+    svc ->> db: payment.status=CANCELED, payment_cancel 저장
+    svc -->> page: refund result
+```
+
+## REST API
+
+### Endpoint
+
+| Method | Path | Description | Auth |
+|--------|------|-------------|------|
+| GET | `/api/v1/admin/billing/customers` | 고객사별 결제 현황 조회 | `SUPER_ADMIN` |
+| POST | `/api/v1/admin/billing/payments/{paymentId}/refunds` | 결제 완료 건 전체 환불 | `SUPER_ADMIN` |
+
+`/api/v1/admin/**`는 기존 `backend/src/main/java/com/init/shared/infrastructure/security/SecurityConfig.java`의 `hasRole("SUPER_ADMIN")` 규칙을 따른다. 따라서 일반 `OPERATOR`와 workspace `ADMIN`은 API 접근이 차단된다.
+
+### Response
+
+**GET `/api/v1/admin/billing/customers`**
+
+```json
+[
+  {
+    "workspaceId": 1,
+    "workspaceKey": "acme",
+    "workspaceName": "Acme",
+    "subscription": {
+      "status": "ACTIVE",
+      "currentPeriodStart": "2026-06-01T00:00:00Z",
+      "currentPeriodEnd": "2026-07-01T00:00:00Z",
+      "nextBillingAt": "2026-07-01T00:00:00Z",
+      "planName": "Pro",
+      "planAmount": 29000
+    },
+    "recentPayment": {
+      "id": 10,
+      "amount": 29000,
+      "status": "DONE",
+      "approvedAt": "2026-06-01T00:00:00Z"
+    },
+    "failedStatus": null
+  }
+]
+```
+
+**POST `/api/v1/admin/billing/payments/{paymentId}/refunds`**
+
+```json
+{
+  "reason": "고객 요청으로 전체 환불"
+}
+```
+
+```json
+{
+  "paymentId": 10,
+  "workspaceId": 1,
+  "refundAmount": 29000,
+  "paymentStatus": "CANCELED",
+  "transactionKey": "cancel_tx",
+  "canceledAt": "2026-06-03T12:00:00Z",
+  "reason": "고객 요청으로 전체 환불"
+}
+```
+
+### Error Mapping
+
+| Case | Code | Status |
+|------|------|--------|
+| 결제 없음 | `PAYMENT_NOT_FOUND` | 404 |
+| 이미 환불 기록 있음 | `PAYMENT_ALREADY_REFUNDED` | 409 |
+| `DONE`이 아닌 결제 | `PAYMENT_NOT_REFUNDABLE` | 400 |
+| `paymentKey`가 없거나 공백인 결제 | `PAYMENT_NOT_REFUNDABLE` | 400 |
+| Toss 4xx 거절 | `PAYMENT_GATEWAY_REJECTED` | 400 |
+| Toss 5xx/network | `PAYMENT_GATEWAY_UNAVAILABLE` | 502 |
+| Toss 설정 누락/오류 | `PAYMENT_CONFIGURATION_INVALID` | 500 |
+
+## Class Design
+
+### Backend
+
+```
+backend/src/main/java/com/init/payment/
+├── presentation/
+│   ├── AdminBillingController.java
+│   └── dto/
+├── application/
+│   ├── AdminBillingUseCase.java
+│   ├── AdminBillingCustomerSummary.java
+│   ├── AdminBillingRefundCommand.java
+│   ├── AdminBillingRefundResult.java
+│   ├── exception/
+│   └── gateway/
+├── domain/
+│   ├── model/
+│   │   ├── Payment.java
+│   │   ├── PaymentCancel.java
+│   │   ├── PaymentStatus.java
+│   │   └── SubscriptionStatus.java
+│   └── repository/
+└── infrastructure/
+    ├── persistence/
+    └── toss/
+```
+
+- `Payment.refundFull()`이 결제 상태 전이와 `PaymentCancel` 생성을 담당한다.
+- `AdminBillingUseCase.refundFull()`은 결제 row를 잠그고, 중복 환불 기록을 확인한 뒤 Toss cancel API를 호출한다.
+- `TossPaymentClient`는 Basic auth와 `Idempotency-Key`를 사용하며 민감 값을 로그·응답으로 노출하지 않는다.
+- `AdminBillingJdbcQueryRepository`는 고객사별 결제 현황 조회용 read model을 제공한다.
+
+### Frontend
+
+```
+frontend/src/pages/admin/ui/AdminBillingPage.tsx
+frontend/src/features/admin-billing/
+├── api/adminBillingApi.ts
+├── index.ts
+└── ui/AdminBillingManagement.tsx
+```
+
+- `AdminBillingPage`는 기존 admin layout의 `/admin/billing` route에 연결된다.
+- `AdminBillingManagement`는 loading/error/empty 상태, 고객사 검색, 새로고침, 환불 확인 dialog를 제공한다.
+- `adminBillingApi.ts`는 이 브랜치에서 새로 추가된 backend endpoint라 generated endpoint가 아직 없음을 명시하고 `apiClient`를 직접 사용한다.
+
+## Database
+
+`backend/src/main/resources/db/changelog/db.changelog-master.sql`에 `payment` schema와 다음 테이블을 추가한다.
+
+- `payment.plan`
+- `payment.subscription`
+- `payment.billing_key`
+- `payment.payment`
+- `payment.payment_cancel`
+- `payment.webhook_event`
+
+`payment.payment_cancel`은 `payment_id` unique 제약으로 전체 환불 중복 기록을 막는다. `payment.billing_key`는 원문 billingKey를 저장하지 않는다.
+
+## Validation
+
+- Backend unit: `Payment.refundFull()`은 `DONE` 결제만 `CANCELED`로 전이하고 전체 금액 cancel 기록을 만든다.
+- Backend application: 이미 환불 기록이 있으면 Toss 호출 없이 실패한다.
+- Backend WebMvc: `SUPER_ADMIN`은 조회/환불 가능, `OPERATOR`는 `/api/v1/admin/**` 접근이 403이어야 한다.
+- Frontend component: 목록 로딩/렌더링, 사유 없는 환불 차단, 정상 환불 시 API 호출과 새로고침을 검증한다.
+- Local verification target: `cd backend && ./gradlew test`, `cd frontend && pnpm test`.
+
+## Acceptance Criteria
+
+- [ ] `SUPER_ADMIN`이 고객사별 구독 상태, 결제 기간, 다음 결제일, 최근 결제, 실패 상태를 조회할 수 있다.
+- [ ] `SUPER_ADMIN`이 결제 완료 건에 대해 전체 환불을 실행할 수 있다.
+- [ ] 환불은 Toss cancel API를 통해 실행된다.
+- [ ] 환불 성공 시 결제 상태와 환불 기록이 반영된다.
+- [ ] 환불 사유는 요청 값으로 받아 payment cancel 기록에 남긴다.
+- [ ] 일반 `OPERATOR`와 workspace `ADMIN`은 결제 admin API와 화면에 접근할 수 없다.

--- a/.agent/specs/500.md
+++ b/.agent/specs/500.md
@@ -117,7 +117,8 @@ sequenceDiagram
 | 이미 환불 기록 있음 | `PAYMENT_ALREADY_REFUNDED` | 409 |
 | `DONE`이 아닌 결제 | `PAYMENT_NOT_REFUNDABLE` | 400 |
 | `paymentKey`가 없거나 공백인 결제 | `PAYMENT_NOT_REFUNDABLE` | 400 |
-| Toss 4xx 거절 | `PAYMENT_GATEWAY_REJECTED` | 400 |
+| 빈 환불 사유 | `VALIDATION_ERROR` | 400 |
+| Toss 요청/취소 불가 거절 | `PAYMENT_GATEWAY_REJECTED` | 400 |
 | Toss 5xx/network | `PAYMENT_GATEWAY_UNAVAILABLE` | 502 |
 | Toss 설정 누락/오류 | `PAYMENT_CONFIGURATION_INVALID` | 500 |
 

--- a/backend/src/main/java/com/init/payment/application/AdminBillingCustomerSummary.java
+++ b/backend/src/main/java/com/init/payment/application/AdminBillingCustomerSummary.java
@@ -1,0 +1,20 @@
+package com.init.payment.application;
+
+import java.time.OffsetDateTime;
+import org.springframework.lang.Nullable;
+
+public record AdminBillingCustomerSummary(
+    Long workspaceId,
+    String workspaceKey,
+    String workspaceName,
+    @Nullable String subscriptionStatus,
+    @Nullable OffsetDateTime currentPeriodStart,
+    @Nullable OffsetDateTime currentPeriodEnd,
+    @Nullable OffsetDateTime nextBillingAt,
+    @Nullable String planName,
+    @Nullable Long planAmount,
+    @Nullable Long recentPaymentId,
+    @Nullable Long recentPaymentAmount,
+    @Nullable String recentPaymentStatus,
+    @Nullable OffsetDateTime recentPaymentApprovedAt,
+    @Nullable String failedStatus) {}

--- a/backend/src/main/java/com/init/payment/application/AdminBillingQueryRepository.java
+++ b/backend/src/main/java/com/init/payment/application/AdminBillingQueryRepository.java
@@ -1,0 +1,7 @@
+package com.init.payment.application;
+
+import java.util.List;
+
+public interface AdminBillingQueryRepository {
+  List<AdminBillingCustomerSummary> findCustomerSummaries();
+}

--- a/backend/src/main/java/com/init/payment/application/AdminBillingRefundCommand.java
+++ b/backend/src/main/java/com/init/payment/application/AdminBillingRefundCommand.java
@@ -1,0 +1,15 @@
+package com.init.payment.application;
+
+import com.init.shared.application.exception.BadRequestException;
+
+public record AdminBillingRefundCommand(Long paymentId, String reason) {
+  public AdminBillingRefundCommand {
+    if (paymentId == null) {
+      throw new BadRequestException("PAYMENT_INVALID_REFUND_REQUEST", "paymentId must not be null");
+    }
+    if (reason == null || reason.isBlank()) {
+      throw new BadRequestException(
+          "PAYMENT_INVALID_REFUND_REQUEST", "reason must not be null or blank");
+    }
+  }
+}

--- a/backend/src/main/java/com/init/payment/application/AdminBillingRefundResult.java
+++ b/backend/src/main/java/com/init/payment/application/AdminBillingRefundResult.java
@@ -1,0 +1,13 @@
+package com.init.payment.application;
+
+import com.init.payment.domain.model.PaymentStatus;
+import java.time.OffsetDateTime;
+
+public record AdminBillingRefundResult(
+    Long paymentId,
+    Long workspaceId,
+    Long refundAmount,
+    PaymentStatus paymentStatus,
+    String transactionKey,
+    OffsetDateTime canceledAt,
+    String reason) {}

--- a/backend/src/main/java/com/init/payment/application/AdminBillingUseCase.java
+++ b/backend/src/main/java/com/init/payment/application/AdminBillingUseCase.java
@@ -13,6 +13,7 @@ import java.util.function.Supplier;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.support.TransactionTemplate;
 
 @Service
@@ -35,6 +36,7 @@ public class AdminBillingUseCase {
     this.paymentCancelRepository = paymentCancelRepository;
     this.tossPaymentGateway = tossPaymentGateway;
     this.transactionTemplate = new TransactionTemplate(transactionManager);
+    this.transactionTemplate.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
     this.transactionTemplate.setReadOnly(false);
   }
 

--- a/backend/src/main/java/com/init/payment/application/AdminBillingUseCase.java
+++ b/backend/src/main/java/com/init/payment/application/AdminBillingUseCase.java
@@ -9,55 +9,72 @@ import com.init.payment.domain.model.PaymentStatus;
 import com.init.payment.domain.repository.PaymentCancelRepository;
 import com.init.payment.domain.repository.PaymentRepository;
 import java.util.List;
+import java.util.function.Supplier;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
 
 @Service
-@Transactional(readOnly = true)
 public class AdminBillingUseCase {
 
   private final AdminBillingQueryRepository queryRepository;
   private final PaymentRepository paymentRepository;
   private final PaymentCancelRepository paymentCancelRepository;
   private final TossPaymentGateway tossPaymentGateway;
+  private final TransactionTemplate transactionTemplate;
 
   public AdminBillingUseCase(
       AdminBillingQueryRepository queryRepository,
       PaymentRepository paymentRepository,
       PaymentCancelRepository paymentCancelRepository,
-      TossPaymentGateway tossPaymentGateway) {
+      TossPaymentGateway tossPaymentGateway,
+      PlatformTransactionManager transactionManager) {
     this.queryRepository = queryRepository;
     this.paymentRepository = paymentRepository;
     this.paymentCancelRepository = paymentCancelRepository;
     this.tossPaymentGateway = tossPaymentGateway;
+    this.transactionTemplate = new TransactionTemplate(transactionManager);
+    this.transactionTemplate.setReadOnly(false);
   }
 
   public List<AdminBillingCustomerSummary> findCustomerSummaries() {
     return queryRepository.findCustomerSummaries();
   }
 
-  @Transactional
   public AdminBillingRefundResult refundFull(AdminBillingRefundCommand command) {
-    Payment payment =
-        paymentRepository
-            .findByIdForUpdate(command.paymentId())
-            .orElseThrow(() -> PaymentExceptions.notFound("결제 건을 찾을 수 없습니다."));
-    if (paymentCancelRepository.existsByPaymentId(payment.getId())) {
-      throw PaymentExceptions.alreadyRefunded("이미 환불 기록이 있는 결제입니다.");
-    }
-    if (payment.getStatus() != PaymentStatus.DONE) {
-      throw PaymentExceptions.notRefundable("결제 완료 상태의 건만 전체 환불할 수 있습니다.");
-    }
-    if (isBlank(payment.getPaymentKey())) {
-      throw PaymentExceptions.notRefundable("환불을 실행할 결제 키가 없습니다.");
-    }
+    RefundContext context = inTx(() -> prepareRefund(command.paymentId()));
 
     TossCancelResult tossResult =
         tossPaymentGateway.cancelPayment(
-            payment.getPaymentKey(), command.reason(), refundIdempotencyKey(payment));
+            context.paymentKey(), command.reason(), context.idempotencyKey());
+
+    return inTx(() -> finalizeRefund(context, command.reason(), tossResult));
+  }
+
+  private RefundContext prepareRefund(Long paymentId) {
+    Payment payment =
+        paymentRepository
+            .findByIdForUpdate(paymentId)
+            .orElseThrow(() -> PaymentExceptions.notFound("결제 건을 찾을 수 없습니다."));
+    validateRefundable(payment);
+    return new RefundContext(
+        payment.getId(), payment.getPaymentKey(), refundIdempotencyKey(payment));
+  }
+
+  private AdminBillingRefundResult finalizeRefund(
+      RefundContext context, String reason, TossCancelResult tossResult) {
+    Payment payment =
+        paymentRepository
+            .findByIdForUpdate(context.paymentId())
+            .orElseThrow(() -> PaymentExceptions.notFound("결제 건을 찾을 수 없습니다."));
+    validateRefundable(payment);
+    if (!context.paymentKey().equals(payment.getPaymentKey())) {
+      throw PaymentExceptions.notRefundable("환불 대상 결제 키가 변경되었습니다.");
+    }
+
     PaymentCancel cancel =
-        payment.refundFull(command.reason(), tossResult.transactionKey(), tossResult.canceledAt());
+        payment.refundFull(reason, tossResult.transactionKey(), tossResult.canceledAt());
     paymentCancelRepository.save(cancel);
 
     return new AdminBillingRefundResult(
@@ -68,6 +85,18 @@ public class AdminBillingUseCase {
         cancel.getTransactionKey(),
         cancel.getCanceledAt(),
         cancel.getReason());
+  }
+
+  private void validateRefundable(Payment payment) {
+    if (paymentCancelRepository.existsByPaymentId(payment.getId())) {
+      throw PaymentExceptions.alreadyRefunded("이미 환불 기록이 있는 결제입니다.");
+    }
+    if (payment.getStatus() != PaymentStatus.DONE) {
+      throw PaymentExceptions.notRefundable("결제 완료 상태의 건만 전체 환불할 수 있습니다.");
+    }
+    if (isBlank(payment.getPaymentKey())) {
+      throw PaymentExceptions.notRefundable("환불을 실행할 결제 키가 없습니다.");
+    }
   }
 
   private boolean isBlank(@Nullable String value) {
@@ -81,4 +110,10 @@ public class AdminBillingUseCase {
     }
     return "admin-full-refund-" + paymentId;
   }
+
+  private <T> T inTx(Supplier<T> callback) {
+    return transactionTemplate.execute(status -> callback.get());
+  }
+
+  private record RefundContext(Long paymentId, String paymentKey, String idempotencyKey) {}
 }

--- a/backend/src/main/java/com/init/payment/application/AdminBillingUseCase.java
+++ b/backend/src/main/java/com/init/payment/application/AdminBillingUseCase.java
@@ -1,0 +1,84 @@
+package com.init.payment.application;
+
+import com.init.payment.application.exception.PaymentExceptions;
+import com.init.payment.application.gateway.TossCancelResult;
+import com.init.payment.application.gateway.TossPaymentGateway;
+import com.init.payment.domain.model.Payment;
+import com.init.payment.domain.model.PaymentCancel;
+import com.init.payment.domain.model.PaymentStatus;
+import com.init.payment.domain.repository.PaymentCancelRepository;
+import com.init.payment.domain.repository.PaymentRepository;
+import java.util.List;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class AdminBillingUseCase {
+
+  private final AdminBillingQueryRepository queryRepository;
+  private final PaymentRepository paymentRepository;
+  private final PaymentCancelRepository paymentCancelRepository;
+  private final TossPaymentGateway tossPaymentGateway;
+
+  public AdminBillingUseCase(
+      AdminBillingQueryRepository queryRepository,
+      PaymentRepository paymentRepository,
+      PaymentCancelRepository paymentCancelRepository,
+      TossPaymentGateway tossPaymentGateway) {
+    this.queryRepository = queryRepository;
+    this.paymentRepository = paymentRepository;
+    this.paymentCancelRepository = paymentCancelRepository;
+    this.tossPaymentGateway = tossPaymentGateway;
+  }
+
+  public List<AdminBillingCustomerSummary> findCustomerSummaries() {
+    return queryRepository.findCustomerSummaries();
+  }
+
+  @Transactional
+  public AdminBillingRefundResult refundFull(AdminBillingRefundCommand command) {
+    Payment payment =
+        paymentRepository
+            .findByIdForUpdate(command.paymentId())
+            .orElseThrow(() -> PaymentExceptions.notFound("결제 건을 찾을 수 없습니다."));
+    if (paymentCancelRepository.existsByPaymentId(payment.getId())) {
+      throw PaymentExceptions.alreadyRefunded("이미 환불 기록이 있는 결제입니다.");
+    }
+    if (payment.getStatus() != PaymentStatus.DONE) {
+      throw PaymentExceptions.notRefundable("결제 완료 상태의 건만 전체 환불할 수 있습니다.");
+    }
+    if (isBlank(payment.getPaymentKey())) {
+      throw PaymentExceptions.notRefundable("환불을 실행할 결제 키가 없습니다.");
+    }
+
+    TossCancelResult tossResult =
+        tossPaymentGateway.cancelPayment(
+            payment.getPaymentKey(), command.reason(), refundIdempotencyKey(payment));
+    PaymentCancel cancel =
+        payment.refundFull(command.reason(), tossResult.transactionKey(), tossResult.canceledAt());
+    paymentCancelRepository.save(cancel);
+
+    return new AdminBillingRefundResult(
+        payment.getId(),
+        payment.getWorkspaceId(),
+        cancel.getCancelAmount(),
+        payment.getStatus(),
+        cancel.getTransactionKey(),
+        cancel.getCanceledAt(),
+        cancel.getReason());
+  }
+
+  private boolean isBlank(@Nullable String value) {
+    return value == null || value.isBlank();
+  }
+
+  private String refundIdempotencyKey(Payment payment) {
+    Long paymentId = payment.getId();
+    if (paymentId == null) {
+      throw PaymentExceptions.notRefundable("환불 대상 결제 식별자가 없습니다.");
+    }
+    return "admin-full-refund-" + paymentId;
+  }
+}

--- a/backend/src/main/java/com/init/payment/application/exception/PaymentExceptions.java
+++ b/backend/src/main/java/com/init/payment/application/exception/PaymentExceptions.java
@@ -1,0 +1,43 @@
+package com.init.payment.application.exception;
+
+import com.init.shared.application.exception.BadGatewayException;
+import com.init.shared.application.exception.BadRequestException;
+import com.init.shared.application.exception.DuplicateException;
+import com.init.shared.application.exception.InternalException;
+import com.init.shared.application.exception.NotFoundException;
+
+public final class PaymentExceptions {
+
+  private PaymentExceptions() {}
+
+  public static DuplicateException alreadyRefunded(String message) {
+    return new DuplicateException("PAYMENT_ALREADY_REFUNDED", message);
+  }
+
+  public static InternalException configurationInvalid() {
+    return new InternalException(
+        "PAYMENT_CONFIGURATION_INVALID", "Payment gateway configuration is invalid.");
+  }
+
+  public static InternalException configurationInvalid(Throwable cause) {
+    return new InternalException(
+        "PAYMENT_CONFIGURATION_INVALID", "Payment gateway configuration is invalid.", cause);
+  }
+
+  public static BadRequestException gatewayRejected(String message) {
+    return new BadRequestException("PAYMENT_GATEWAY_REJECTED", message);
+  }
+
+  public static BadGatewayException gatewayUnavailable(Throwable cause) {
+    return new BadGatewayException(
+        "PAYMENT_GATEWAY_UNAVAILABLE", "Toss cancel API request failed.", cause);
+  }
+
+  public static NotFoundException notFound(String message) {
+    return new NotFoundException("PAYMENT_NOT_FOUND", message);
+  }
+
+  public static BadRequestException notRefundable(String message) {
+    return new BadRequestException("PAYMENT_NOT_REFUNDABLE", message);
+  }
+}

--- a/backend/src/main/java/com/init/payment/application/exception/PaymentExceptions.java
+++ b/backend/src/main/java/com/init/payment/application/exception/PaymentExceptions.java
@@ -33,6 +33,11 @@ public final class PaymentExceptions {
         "PAYMENT_GATEWAY_UNAVAILABLE", "Toss cancel API request failed.", cause);
   }
 
+  public static BadGatewayException gatewayUnavailable() {
+    return new BadGatewayException(
+        "PAYMENT_GATEWAY_UNAVAILABLE", "Toss cancel API request failed.");
+  }
+
   public static NotFoundException notFound(String message) {
     return new NotFoundException("PAYMENT_NOT_FOUND", message);
   }

--- a/backend/src/main/java/com/init/payment/application/exception/package-info.java
+++ b/backend/src/main/java/com/init/payment/application/exception/package-info.java
@@ -1,0 +1,2 @@
+@org.springframework.lang.NonNullApi
+package com.init.payment.application.exception;

--- a/backend/src/main/java/com/init/payment/application/gateway/TossCancelResult.java
+++ b/backend/src/main/java/com/init/payment/application/gateway/TossCancelResult.java
@@ -1,0 +1,6 @@
+package com.init.payment.application.gateway;
+
+import java.time.OffsetDateTime;
+import org.springframework.lang.Nullable;
+
+public record TossCancelResult(String transactionKey, @Nullable OffsetDateTime canceledAt) {}

--- a/backend/src/main/java/com/init/payment/application/gateway/TossPaymentGateway.java
+++ b/backend/src/main/java/com/init/payment/application/gateway/TossPaymentGateway.java
@@ -1,0 +1,5 @@
+package com.init.payment.application.gateway;
+
+public interface TossPaymentGateway {
+  TossCancelResult cancelPayment(String paymentKey, String reason, String idempotencyKey);
+}

--- a/backend/src/main/java/com/init/payment/application/gateway/package-info.java
+++ b/backend/src/main/java/com/init/payment/application/gateway/package-info.java
@@ -1,0 +1,2 @@
+@org.springframework.lang.NonNullApi
+package com.init.payment.application.gateway;

--- a/backend/src/main/java/com/init/payment/domain/model/Payment.java
+++ b/backend/src/main/java/com/init/payment/domain/model/Payment.java
@@ -13,6 +13,7 @@ import jakarta.persistence.Table;
 import java.time.OffsetDateTime;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
+import org.springframework.lang.Nullable;
 
 @Entity
 @Table(name = "payment", schema = "payment")
@@ -180,6 +181,21 @@ public class Payment {
     this.rawResponse = rawResponse;
   }
 
+  public PaymentCancel refundFull(
+      @Nullable String reason,
+      @Nullable String transactionKey,
+      @Nullable OffsetDateTime canceledAt) {
+    if (status != PaymentStatus.DONE) {
+      throw new IllegalStateException("DONE payment is required for full refund");
+    }
+    validateRequired(reason, "reason");
+    validateRequired(transactionKey, "transactionKey");
+    PaymentCancel cancel =
+        PaymentCancel.create(id, amount, reason, transactionKey, null, canceledAt);
+    this.status = PaymentStatus.CANCELED;
+    return cancel;
+  }
+
   public boolean isDone() {
     return status == PaymentStatus.DONE;
   }
@@ -266,5 +282,11 @@ public class Payment {
 
   public OffsetDateTime getUpdatedAt() {
     return updatedAt;
+  }
+
+  private static void validateRequired(@Nullable String value, String name) {
+    if (value == null || value.isBlank()) {
+      throw new IllegalArgumentException(name + " must not be null or blank");
+    }
   }
 }

--- a/backend/src/main/java/com/init/payment/domain/model/PaymentCancel.java
+++ b/backend/src/main/java/com/init/payment/domain/model/PaymentCancel.java
@@ -43,6 +43,16 @@ public class PaymentCancel {
       String reason,
       String transactionKey,
       String idempotencyKey) {
+    return create(paymentId, cancelAmount, reason, transactionKey, idempotencyKey, null);
+  }
+
+  public static PaymentCancel create(
+      Long paymentId,
+      long cancelAmount,
+      String reason,
+      String transactionKey,
+      String idempotencyKey,
+      OffsetDateTime canceledAt) {
     if (paymentId == null) {
       throw new IllegalArgumentException("paymentId must not be null");
     }
@@ -56,12 +66,15 @@ public class PaymentCancel {
     cancel.reason = reason;
     cancel.transactionKey = transactionKey;
     cancel.idempotencyKey = idempotencyKey;
+    cancel.canceledAt = canceledAt;
     return cancel;
   }
 
   @PrePersist
   protected void onPersist() {
-    this.canceledAt = OffsetDateTime.now();
+    if (canceledAt == null) {
+      this.canceledAt = OffsetDateTime.now();
+    }
   }
 
   public Long getId() {

--- a/backend/src/main/java/com/init/payment/domain/repository/PaymentCancelRepository.java
+++ b/backend/src/main/java/com/init/payment/domain/repository/PaymentCancelRepository.java
@@ -7,6 +7,8 @@ public interface PaymentCancelRepository {
 
   PaymentCancel save(PaymentCancel paymentCancel);
 
+  boolean existsByPaymentId(Long paymentId);
+
   /** 결제의 이미 취소된 합계를 반환한다. 없으면 0. */
   long sumCancelAmountByPaymentId(Long paymentId);
 

--- a/backend/src/main/java/com/init/payment/domain/repository/PaymentRepository.java
+++ b/backend/src/main/java/com/init/payment/domain/repository/PaymentRepository.java
@@ -10,6 +10,8 @@ public interface PaymentRepository {
 
   Optional<Payment> findById(Long id);
 
+  Optional<Payment> findByIdForUpdate(Long id);
+
   Optional<Payment> findByOrderId(String orderId);
 
   Optional<Payment> findByWorkspaceIdAndOrderId(Long workspaceId, String orderId);

--- a/backend/src/main/java/com/init/payment/infrastructure/persistence/AdminBillingJdbcQueryRepository.java
+++ b/backend/src/main/java/com/init/payment/infrastructure/persistence/AdminBillingJdbcQueryRepository.java
@@ -1,0 +1,100 @@
+package com.init.payment.infrastructure.persistence;
+
+import com.init.payment.application.AdminBillingCustomerSummary;
+import com.init.payment.application.AdminBillingQueryRepository;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+@Transactional(readOnly = true)
+public class AdminBillingJdbcQueryRepository implements AdminBillingQueryRepository {
+
+  private static final String SUMMARY_SQL =
+      """
+      WITH latest_subscription AS (
+        SELECT s.*,
+               row_number() OVER (PARTITION BY s.workspace_id ORDER BY s.created_at DESC, s.id DESC) AS rn
+        FROM payment.subscription s
+      ),
+      latest_payment AS (
+        SELECT p.*,
+               row_number() OVER (
+                 PARTITION BY p.workspace_id
+                 ORDER BY COALESCE(p.approved_at, p.created_at) DESC, p.id DESC
+               ) AS rn
+        FROM payment.payment p
+      )
+      SELECT w.id AS workspace_id,
+             w.workspace_key,
+             w.name AS workspace_name,
+             s.status AS subscription_status,
+             s.current_period_start,
+             s.current_period_end,
+             CASE
+               WHEN s.status = 'ACTIVE' THEN s.current_period_end
+               ELSE s.next_retry_at
+             END AS next_billing_at,
+             pl.name AS plan_name,
+             pl.amount AS plan_amount,
+             p.id AS recent_payment_id,
+             p.amount AS recent_payment_amount,
+             p.status AS recent_payment_status,
+             p.approved_at AS recent_payment_approved_at,
+             CASE
+               WHEN s.status = 'PAST_DUE' THEN 'PAST_DUE'
+               WHEN p.status IN ('ABORTED', 'EXPIRED') THEN p.status
+               ELSE NULL
+             END AS failed_status
+      FROM app.workspace w
+      LEFT JOIN latest_subscription s ON s.workspace_id = w.id AND s.rn = 1
+      LEFT JOIN payment.plan pl ON pl.id = s.plan_id
+      LEFT JOIN latest_payment p ON p.workspace_id = w.id AND p.rn = 1
+      ORDER BY w.name ASC, w.id ASC
+      """;
+
+  private final JdbcTemplate jdbcTemplate;
+
+  public AdminBillingJdbcQueryRepository(JdbcTemplate jdbcTemplate) {
+    this.jdbcTemplate = jdbcTemplate;
+  }
+
+  @Override
+  public List<AdminBillingCustomerSummary> findCustomerSummaries() {
+    return jdbcTemplate.query(SUMMARY_SQL, this::mapSummary);
+  }
+
+  private AdminBillingCustomerSummary mapSummary(ResultSet rs, int rowNum) throws SQLException {
+    return new AdminBillingCustomerSummary(
+        rs.getLong("workspace_id"),
+        rs.getString("workspace_key"),
+        rs.getString("workspace_name"),
+        rs.getString("subscription_status"),
+        offsetDateTime(rs, "current_period_start"),
+        offsetDateTime(rs, "current_period_end"),
+        offsetDateTime(rs, "next_billing_at"),
+        rs.getString("plan_name"),
+        nullableLong(rs, "plan_amount"),
+        nullableLong(rs, "recent_payment_id"),
+        nullableLong(rs, "recent_payment_amount"),
+        rs.getString("recent_payment_status"),
+        offsetDateTime(rs, "recent_payment_approved_at"),
+        rs.getString("failed_status"));
+  }
+
+  @Nullable
+  private OffsetDateTime offsetDateTime(ResultSet rs, String columnName) throws SQLException {
+    return rs.getObject(columnName, OffsetDateTime.class);
+  }
+
+  @Nullable
+  private Long nullableLong(ResultSet rs, String columnName) throws SQLException {
+    long value = rs.getLong(columnName);
+    return rs.wasNull() ? null : value;
+  }
+}

--- a/backend/src/main/java/com/init/payment/infrastructure/persistence/JpaPaymentCancelRepository.java
+++ b/backend/src/main/java/com/init/payment/infrastructure/persistence/JpaPaymentCancelRepository.java
@@ -13,6 +13,9 @@ public interface JpaPaymentCancelRepository
     extends JpaRepository<PaymentCancel, Long>, PaymentCancelRepository {
 
   @Override
+  boolean existsByPaymentId(Long paymentId);
+
+  @Override
   @Query(
       "SELECT COALESCE(SUM(pc.cancelAmount), 0)"
           + " FROM PaymentCancel pc WHERE pc.paymentId = :paymentId")

--- a/backend/src/main/java/com/init/payment/infrastructure/persistence/JpaPaymentRepository.java
+++ b/backend/src/main/java/com/init/payment/infrastructure/persistence/JpaPaymentRepository.java
@@ -18,6 +18,11 @@ public interface JpaPaymentRepository extends JpaRepository<Payment, Long>, Paym
   Optional<Payment> findByOrderId(String orderId);
 
   @Override
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query("SELECT p FROM Payment p WHERE p.id = :id")
+  Optional<Payment> findByIdForUpdate(@Param("id") Long id);
+
+  @Override
   Optional<Payment> findByWorkspaceIdAndOrderId(Long workspaceId, String orderId);
 
   @Override

--- a/backend/src/main/java/com/init/payment/infrastructure/toss/TossPaymentClient.java
+++ b/backend/src/main/java/com/init/payment/infrastructure/toss/TossPaymentClient.java
@@ -104,12 +104,9 @@ public class TossPaymentClient implements TossPaymentPort, TossPaymentGateway {
       return new TossCancelResult(
           text(cancel, "transactionKey"), parseDateTime(text(cancel, "canceledAt")));
     } catch (RestClientResponseException ex) {
-      if (ex.getStatusCode().is4xxClientError()) {
-        throw PaymentExceptions.gatewayRejected("Toss가 환불 요청을 거절했습니다.");
-      }
-      throw PaymentExceptions.gatewayUnavailable(ex);
+      throw mapCancelResponseException(ex);
     } catch (RestClientException | HttpMessageConversionException ex) {
-      throw PaymentExceptions.gatewayUnavailable(ex);
+      throw PaymentExceptions.gatewayUnavailable();
     }
   }
 
@@ -190,6 +187,36 @@ public class TossPaymentClient implements TossPaymentPort, TossPaymentGateway {
       throw PaymentExceptions.gatewayRejected("Toss 환불 응답에 거래 키가 없습니다.");
     }
     return cancel;
+  }
+
+  private RuntimeException mapCancelResponseException(RestClientResponseException ex) {
+    int status = ex.getStatusCode().value();
+    String code = tossErrorCode(ex);
+    if (status == 400) {
+      return PaymentExceptions.gatewayRejected("Toss가 환불 요청을 거절했습니다.");
+    }
+    if (status == 403 && isCancelRejected(code)) {
+      return PaymentExceptions.gatewayRejected("Toss가 환불 요청을 거절했습니다.");
+    }
+    return PaymentExceptions.gatewayUnavailable();
+  }
+
+  @Nullable
+  private String tossErrorCode(RestClientResponseException ex) {
+    try {
+      JsonNode root = readTree(ex.getResponseBodyAsString());
+      String code = text(root, "code");
+      return code == null || code.isBlank() ? null : code;
+    } catch (PaymentGatewayException parseFailure) {
+      return null;
+    }
+  }
+
+  private boolean isCancelRejected(@Nullable String code) {
+    return "NOT_CANCELABLE_PAYMENT".equals(code)
+        || "NOT_CANCELABLE_AMOUNT".equals(code)
+        || "NOT_SUPPORTED_REFUND".equals(code)
+        || "REFUND_REJECTED".equals(code);
   }
 
   private JsonNode readTree(String raw) {

--- a/backend/src/main/java/com/init/payment/infrastructure/toss/TossPaymentClient.java
+++ b/backend/src/main/java/com/init/payment/infrastructure/toss/TossPaymentClient.java
@@ -3,8 +3,11 @@ package com.init.payment.infrastructure.toss;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.init.payment.application.TossPayloadMasker;
+import com.init.payment.application.exception.PaymentExceptions;
 import com.init.payment.application.exception.PaymentGatewayException;
 import com.init.payment.application.exception.PaymentRejectedException;
+import com.init.payment.application.gateway.TossCancelResult;
+import com.init.payment.application.gateway.TossPaymentGateway;
 import com.init.payment.application.port.TossBillingExecuteCommand;
 import com.init.payment.application.port.TossBillingKeyResult;
 import com.init.payment.application.port.TossPaymentPort;
@@ -19,13 +22,14 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.http.converter.HttpMessageConversionException;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestClientResponseException;
 
 @Component
-public class TossPaymentClient implements TossPaymentPort {
+public class TossPaymentClient implements TossPaymentPort, TossPaymentGateway {
 
   private static final Logger log = LoggerFactory.getLogger(TossPaymentClient.class);
   private static final String IDEMPOTENCY_KEY_HEADER = "Idempotency-Key";
@@ -91,6 +95,25 @@ public class TossPaymentClient implements TossPaymentPort {
   }
 
   @Override
+  public TossCancelResult cancelPayment(String paymentKey, String reason, String idempotencyKey) {
+    Map<String, Object> body = new LinkedHashMap<>();
+    body.put("cancelReason", reason);
+    try {
+      JsonNode root = postRaw("/v1/payments/" + paymentKey + "/cancel", body, idempotencyKey);
+      JsonNode cancel = latestCancel(root);
+      return new TossCancelResult(
+          text(cancel, "transactionKey"), parseDateTime(text(cancel, "canceledAt")));
+    } catch (RestClientResponseException ex) {
+      if (ex.getStatusCode().is4xxClientError()) {
+        throw PaymentExceptions.gatewayRejected("Toss가 환불 요청을 거절했습니다.");
+      }
+      throw PaymentExceptions.gatewayUnavailable(ex);
+    } catch (RestClientException | HttpMessageConversionException ex) {
+      throw PaymentExceptions.gatewayUnavailable(ex);
+    }
+  }
+
+  @Override
   public TossPaymentResult getPayment(String paymentKey) {
     try {
       String raw =
@@ -109,20 +132,7 @@ public class TossPaymentClient implements TossPaymentPort {
   private JsonNode post(
       String path, Map<String, Object> body, String action, String idempotencyKey) {
     try {
-      String raw =
-          restClient
-              .post()
-              .uri(apiPath(path))
-              .contentType(MediaType.APPLICATION_JSON)
-              .headers(
-                  headers -> {
-                    headers.setBasicAuth(secretKey(), "");
-                    headers.set(IDEMPOTENCY_KEY_HEADER, idempotencyKey);
-                  })
-              .body(body)
-              .retrieve()
-              .body(String.class);
-      return readTree(raw);
+      return postRaw(path, body, idempotencyKey);
     } catch (RestClientResponseException ex) {
       if (ex.getStatusCode().is4xxClientError()) {
         log.warn("Toss API가 요청을 거절했습니다: action={}, status={}", action, ex.getStatusCode());
@@ -132,6 +142,23 @@ public class TossPaymentClient implements TossPaymentPort {
     } catch (RestClientException | HttpMessageConversionException ex) {
       throw gatewayError(action, ex);
     }
+  }
+
+  private JsonNode postRaw(String path, Map<String, Object> body, String idempotencyKey) {
+    String raw =
+        restClient
+            .post()
+            .uri(apiPath(path))
+            .contentType(MediaType.APPLICATION_JSON)
+            .headers(
+                headers -> {
+                  headers.setBasicAuth(secretKey(), "");
+                  headers.set(IDEMPOTENCY_KEY_HEADER, idempotencyKey);
+                })
+            .body(body)
+            .retrieve()
+            .body(String.class);
+    return readTree(raw);
   }
 
   private TossPaymentResult toPaymentResult(JsonNode root) {
@@ -150,6 +177,19 @@ public class TossPaymentClient implements TossPaymentPort {
         text(root.path("receipt"), "url"),
         transactionKey,
         maskedJson(root));
+  }
+
+  private JsonNode latestCancel(JsonNode root) {
+    JsonNode cancels = root.path("cancels");
+    if (!cancels.isArray() || cancels.isEmpty()) {
+      throw PaymentExceptions.gatewayRejected("Toss 환불 응답에 취소 기록이 없습니다.");
+    }
+    JsonNode cancel = cancels.get(cancels.size() - 1);
+    String transactionKey = text(cancel, "transactionKey");
+    if (transactionKey == null || transactionKey.isBlank()) {
+      throw PaymentExceptions.gatewayRejected("Toss 환불 응답에 거래 키가 없습니다.");
+    }
+    return cancel;
   }
 
   private JsonNode readTree(String raw) {
@@ -192,7 +232,7 @@ public class TossPaymentClient implements TossPaymentPort {
     return RestClient.builder().requestFactory(requestFactory).build();
   }
 
-  private static Duration durationOrDefault(Duration duration, Duration defaultValue) {
+  private static Duration durationOrDefault(@Nullable Duration duration, Duration defaultValue) {
     return duration == null ? defaultValue : duration;
   }
 
@@ -216,7 +256,7 @@ public class TossPaymentClient implements TossPaymentPort {
     return b;
   }
 
-  private static OffsetDateTime parseDateTime(String value) {
+  private static OffsetDateTime parseDateTime(@Nullable String value) {
     if (value == null || value.isBlank()) {
       return null;
     }

--- a/backend/src/main/java/com/init/payment/presentation/AdminBillingController.java
+++ b/backend/src/main/java/com/init/payment/presentation/AdminBillingController.java
@@ -1,0 +1,41 @@
+package com.init.payment.presentation;
+
+import com.init.payment.application.AdminBillingRefundCommand;
+import com.init.payment.application.AdminBillingUseCase;
+import com.init.payment.presentation.dto.AdminBillingCustomerResponse;
+import com.init.payment.presentation.dto.AdminBillingRefundRequest;
+import com.init.payment.presentation.dto.AdminBillingRefundResponse;
+import jakarta.validation.Valid;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/admin/billing")
+public class AdminBillingController {
+
+  private final AdminBillingUseCase adminBillingUseCase;
+
+  public AdminBillingController(AdminBillingUseCase adminBillingUseCase) {
+    this.adminBillingUseCase = adminBillingUseCase;
+  }
+
+  @GetMapping("/customers")
+  public List<AdminBillingCustomerResponse> findCustomerBillingSummaries() {
+    return adminBillingUseCase.findCustomerSummaries().stream()
+        .map(AdminBillingCustomerResponse::from)
+        .toList();
+  }
+
+  @PostMapping("/payments/{paymentId}/refunds")
+  public AdminBillingRefundResponse refundFull(
+      @PathVariable Long paymentId, @Valid @RequestBody AdminBillingRefundRequest request) {
+    return AdminBillingRefundResponse.from(
+        adminBillingUseCase.refundFull(
+            new AdminBillingRefundCommand(paymentId, request.reason().trim())));
+  }
+}

--- a/backend/src/main/java/com/init/payment/presentation/dto/AdminBillingCustomerResponse.java
+++ b/backend/src/main/java/com/init/payment/presentation/dto/AdminBillingCustomerResponse.java
@@ -1,0 +1,56 @@
+package com.init.payment.presentation.dto;
+
+import com.init.payment.application.AdminBillingCustomerSummary;
+import java.time.OffsetDateTime;
+import org.springframework.lang.Nullable;
+
+public record AdminBillingCustomerResponse(
+    Long workspaceId,
+    String workspaceKey,
+    String workspaceName,
+    SubscriptionView subscription,
+    @Nullable PaymentView recentPayment,
+    @Nullable String failedStatus) {
+
+  public static AdminBillingCustomerResponse from(AdminBillingCustomerSummary summary) {
+    return new AdminBillingCustomerResponse(
+        summary.workspaceId(),
+        summary.workspaceKey(),
+        summary.workspaceName(),
+        new SubscriptionView(
+            summary.subscriptionStatus(),
+            summary.currentPeriodStart(),
+            summary.currentPeriodEnd(),
+            summary.nextBillingAt(),
+            summary.planName(),
+            summary.planAmount()),
+        paymentView(summary),
+        summary.failedStatus());
+  }
+
+  @Nullable
+  private static PaymentView paymentView(AdminBillingCustomerSummary summary) {
+    if (summary.recentPaymentId() == null) {
+      return null;
+    }
+    return new PaymentView(
+        summary.recentPaymentId(),
+        summary.recentPaymentAmount(),
+        summary.recentPaymentStatus(),
+        summary.recentPaymentApprovedAt());
+  }
+
+  public record SubscriptionView(
+      @Nullable String status,
+      @Nullable OffsetDateTime currentPeriodStart,
+      @Nullable OffsetDateTime currentPeriodEnd,
+      @Nullable OffsetDateTime nextBillingAt,
+      @Nullable String planName,
+      @Nullable Long planAmount) {}
+
+  public record PaymentView(
+      Long id,
+      @Nullable Long amount,
+      @Nullable String status,
+      @Nullable OffsetDateTime approvedAt) {}
+}

--- a/backend/src/main/java/com/init/payment/presentation/dto/AdminBillingRefundRequest.java
+++ b/backend/src/main/java/com/init/payment/presentation/dto/AdminBillingRefundRequest.java
@@ -1,0 +1,8 @@
+package com.init.payment.presentation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record AdminBillingRefundRequest(
+    @NotBlank(message = "환불 사유를 입력해주세요.") @Size(max = 500, message = "환불 사유는 500자 이하로 입력해주세요.")
+        String reason) {}

--- a/backend/src/main/java/com/init/payment/presentation/dto/AdminBillingRefundResponse.java
+++ b/backend/src/main/java/com/init/payment/presentation/dto/AdminBillingRefundResponse.java
@@ -1,0 +1,25 @@
+package com.init.payment.presentation.dto;
+
+import com.init.payment.application.AdminBillingRefundResult;
+import java.time.OffsetDateTime;
+
+public record AdminBillingRefundResponse(
+    Long paymentId,
+    Long workspaceId,
+    Long refundAmount,
+    String paymentStatus,
+    String transactionKey,
+    OffsetDateTime canceledAt,
+    String reason) {
+
+  public static AdminBillingRefundResponse from(AdminBillingRefundResult result) {
+    return new AdminBillingRefundResponse(
+        result.paymentId(),
+        result.workspaceId(),
+        result.refundAmount(),
+        result.paymentStatus().name(),
+        result.transactionKey(),
+        result.canceledAt(),
+        result.reason());
+  }
+}

--- a/backend/src/main/java/com/init/payment/presentation/dto/package-info.java
+++ b/backend/src/main/java/com/init/payment/presentation/dto/package-info.java
@@ -1,0 +1,1 @@
+package com.init.payment.presentation.dto;

--- a/backend/src/test/java/com/init/payment/application/AdminBillingUseCaseTest.java
+++ b/backend/src/test/java/com/init/payment/application/AdminBillingUseCaseTest.java
@@ -8,6 +8,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.init.payment.application.exception.PaymentExceptions;
@@ -32,6 +33,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.support.SimpleTransactionStatus;
 
 @ExtendWith(MockitoExtension.class)
@@ -77,6 +79,14 @@ class AdminBillingUseCaseTest {
     InOrder inOrder = inOrder(transactionManager, tossPaymentGateway);
     inOrder.verify(transactionManager).commit(any());
     inOrder.verify(tossPaymentGateway).cancelPayment("pay_1", "고객 요청", "admin-full-refund-100");
+    ArgumentCaptor<TransactionDefinition> transactionCaptor =
+        ArgumentCaptor.forClass(TransactionDefinition.class);
+    verify(transactionManager, times(2)).getTransaction(transactionCaptor.capture());
+    assertThat(transactionCaptor.getAllValues())
+        .allSatisfy(
+            definition ->
+                assertThat(definition.getPropagationBehavior())
+                    .isEqualTo(TransactionDefinition.PROPAGATION_REQUIRES_NEW));
   }
 
   @Test

--- a/backend/src/test/java/com/init/payment/application/AdminBillingUseCaseTest.java
+++ b/backend/src/test/java/com/init/payment/application/AdminBillingUseCaseTest.java
@@ -5,6 +5,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -19,14 +21,18 @@ import com.init.payment.domain.repository.PaymentRepository;
 import com.init.shared.application.exception.BusinessException;
 import java.time.OffsetDateTime;
 import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.SimpleTransactionStatus;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("AdminBillingUseCase")
@@ -36,7 +42,15 @@ class AdminBillingUseCaseTest {
   @Mock private PaymentRepository paymentRepository;
   @Mock private PaymentCancelRepository paymentCancelRepository;
   @Mock private TossPaymentGateway tossPaymentGateway;
+  @Mock private PlatformTransactionManager transactionManager;
   @InjectMocks private AdminBillingUseCase adminBillingUseCase;
+
+  @BeforeEach
+  void setUp() {
+    lenient()
+        .when(transactionManager.getTransaction(any()))
+        .thenReturn(new SimpleTransactionStatus());
+  }
 
   @Test
   @DisplayName("refundFull: Toss cancel 성공 → 결제 취소와 환불 기록 저장")
@@ -60,6 +74,9 @@ class AdminBillingUseCaseTest {
     ArgumentCaptor<PaymentCancel> cancelCaptor = ArgumentCaptor.forClass(PaymentCancel.class);
     verify(paymentCancelRepository).save(cancelCaptor.capture());
     assertThat(cancelCaptor.getValue().getReason()).isEqualTo("고객 요청");
+    InOrder inOrder = inOrder(transactionManager, tossPaymentGateway);
+    inOrder.verify(transactionManager).commit(any());
+    inOrder.verify(tossPaymentGateway).cancelPayment("pay_1", "고객 요청", "admin-full-refund-100");
   }
 
   @Test
@@ -115,6 +132,48 @@ class AdminBillingUseCaseTest {
         .isInstanceOf(BusinessException.class)
         .hasFieldOrPropertyWithValue("code", "PAYMENT_ALREADY_REFUNDED");
     verify(tossPaymentGateway, never()).cancelPayment(any(), any(), any());
+    verify(paymentCancelRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("refundFull: Toss 호출 후 이미 환불 기록이 생기면 저장 없이 실패")
+  void should_저장없이실패_when_Toss호출후이미환불됨() {
+    // given
+    Payment payment = completedPayment("ord_1", "pay_1");
+    OffsetDateTime canceledAt = OffsetDateTime.parse("2026-06-03T12:00:00Z");
+    given(paymentRepository.findByIdForUpdate(100L)).willReturn(Optional.of(payment));
+    given(paymentCancelRepository.existsByPaymentId(100L)).willReturn(false, true);
+    given(tossPaymentGateway.cancelPayment(eq("pay_1"), eq("고객 요청"), eq("admin-full-refund-100")))
+        .willReturn(new TossCancelResult("tx_cancel_1", canceledAt));
+    AdminBillingRefundCommand command = new AdminBillingRefundCommand(100L, "고객 요청");
+
+    // when & then
+    assertThatThrownBy(() -> adminBillingUseCase.refundFull(command))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue("code", "PAYMENT_ALREADY_REFUNDED");
+    verify(tossPaymentGateway).cancelPayment("pay_1", "고객 요청", "admin-full-refund-100");
+    verify(paymentCancelRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("refundFull: Toss 호출 후 결제 키가 바뀌면 저장 없이 실패")
+  void should_저장없이실패_when_Toss호출후결제키변경됨() {
+    // given
+    Payment payment = completedPayment("ord_1", "pay_1");
+    Payment changedPayment = completedPayment("ord_1", "pay_changed");
+    OffsetDateTime canceledAt = OffsetDateTime.parse("2026-06-03T12:00:00Z");
+    given(paymentRepository.findByIdForUpdate(100L))
+        .willReturn(Optional.of(payment), Optional.of(changedPayment));
+    given(paymentCancelRepository.existsByPaymentId(100L)).willReturn(false);
+    given(tossPaymentGateway.cancelPayment(eq("pay_1"), eq("고객 요청"), eq("admin-full-refund-100")))
+        .willReturn(new TossCancelResult("tx_cancel_1", canceledAt));
+    AdminBillingRefundCommand command = new AdminBillingRefundCommand(100L, "고객 요청");
+
+    // when & then
+    assertThatThrownBy(() -> adminBillingUseCase.refundFull(command))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue("code", "PAYMENT_NOT_REFUNDABLE");
+    verify(tossPaymentGateway).cancelPayment("pay_1", "고객 요청", "admin-full-refund-100");
     verify(paymentCancelRepository, never()).save(any());
   }
 

--- a/backend/src/test/java/com/init/payment/application/AdminBillingUseCaseTest.java
+++ b/backend/src/test/java/com/init/payment/application/AdminBillingUseCaseTest.java
@@ -1,0 +1,189 @@
+package com.init.payment.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.init.payment.application.exception.PaymentExceptions;
+import com.init.payment.application.gateway.TossCancelResult;
+import com.init.payment.application.gateway.TossPaymentGateway;
+import com.init.payment.domain.model.Payment;
+import com.init.payment.domain.model.PaymentCancel;
+import com.init.payment.domain.model.PaymentStatus;
+import com.init.payment.domain.repository.PaymentCancelRepository;
+import com.init.payment.domain.repository.PaymentRepository;
+import com.init.shared.application.exception.BusinessException;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AdminBillingUseCase")
+class AdminBillingUseCaseTest {
+
+  @Mock private AdminBillingQueryRepository queryRepository;
+  @Mock private PaymentRepository paymentRepository;
+  @Mock private PaymentCancelRepository paymentCancelRepository;
+  @Mock private TossPaymentGateway tossPaymentGateway;
+  @InjectMocks private AdminBillingUseCase adminBillingUseCase;
+
+  @Test
+  @DisplayName("refundFull: Toss cancel 성공 → 결제 취소와 환불 기록 저장")
+  void should_결제취소와환불기록저장_when_TossCancel성공() {
+    // given
+    Payment payment = completedPayment("ord_1", "pay_1");
+    OffsetDateTime canceledAt = OffsetDateTime.parse("2026-06-03T12:00:00Z");
+    given(paymentRepository.findByIdForUpdate(100L)).willReturn(Optional.of(payment));
+    given(paymentCancelRepository.existsByPaymentId(100L)).willReturn(false);
+    given(tossPaymentGateway.cancelPayment(eq("pay_1"), eq("고객 요청"), eq("admin-full-refund-100")))
+        .willReturn(new TossCancelResult("tx_cancel_1", canceledAt));
+
+    // when
+    AdminBillingRefundResult result =
+        adminBillingUseCase.refundFull(new AdminBillingRefundCommand(100L, "고객 요청"));
+
+    // then
+    assertThat(result.paymentStatus()).isEqualTo(PaymentStatus.CANCELED);
+    assertThat(result.refundAmount()).isEqualTo(29_000L);
+    assertThat(result.transactionKey()).isEqualTo("tx_cancel_1");
+    ArgumentCaptor<PaymentCancel> cancelCaptor = ArgumentCaptor.forClass(PaymentCancel.class);
+    verify(paymentCancelRepository).save(cancelCaptor.capture());
+    assertThat(cancelCaptor.getValue().getReason()).isEqualTo("고객 요청");
+  }
+
+  @Test
+  @DisplayName("refundFull: Toss 4xx 거절 → gateway rejected 코드로 실패")
+  void should_GatewayRejected코드로실패_when_Toss거절() {
+    // given
+    Payment payment = completedPayment("ord_1", "pay_1");
+    given(paymentRepository.findByIdForUpdate(100L)).willReturn(Optional.of(payment));
+    given(paymentCancelRepository.existsByPaymentId(100L)).willReturn(false);
+    given(tossPaymentGateway.cancelPayment(eq("pay_1"), eq("고객 요청"), eq("admin-full-refund-100")))
+        .willThrow(PaymentExceptions.gatewayRejected("Toss가 환불 요청을 거절했습니다."));
+
+    // when & then
+    AdminBillingRefundCommand command = new AdminBillingRefundCommand(100L, "고객 요청");
+
+    assertThatThrownBy(() -> adminBillingUseCase.refundFull(command))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue("code", "PAYMENT_GATEWAY_REJECTED");
+    verify(paymentCancelRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("refundFull: Toss 장애 → gateway unavailable 코드로 실패")
+  void should_GatewayUnavailable코드로실패_when_Toss장애() {
+    // given
+    Payment payment = completedPayment("ord_1", "pay_1");
+    given(paymentRepository.findByIdForUpdate(100L)).willReturn(Optional.of(payment));
+    given(paymentCancelRepository.existsByPaymentId(100L)).willReturn(false);
+    given(tossPaymentGateway.cancelPayment(eq("pay_1"), eq("고객 요청"), eq("admin-full-refund-100")))
+        .willThrow(PaymentExceptions.gatewayUnavailable(new IllegalStateException("timeout")));
+
+    // when & then
+    AdminBillingRefundCommand command = new AdminBillingRefundCommand(100L, "고객 요청");
+
+    assertThatThrownBy(() -> adminBillingUseCase.refundFull(command))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue("code", "PAYMENT_GATEWAY_UNAVAILABLE");
+    verify(paymentCancelRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("refundFull: 이미 환불 기록 있음 → Toss 호출 없이 실패")
+  void should_Toss호출없이실패_when_이미환불기록있음() {
+    // given
+    Payment payment = completedPayment("ord_1", "pay_1");
+    given(paymentRepository.findByIdForUpdate(100L)).willReturn(Optional.of(payment));
+    given(paymentCancelRepository.existsByPaymentId(100L)).willReturn(true);
+
+    // when & then
+    AdminBillingRefundCommand command = new AdminBillingRefundCommand(100L, "고객 요청");
+
+    assertThatThrownBy(() -> adminBillingUseCase.refundFull(command))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue("code", "PAYMENT_ALREADY_REFUNDED");
+    verify(tossPaymentGateway, never()).cancelPayment(any(), any(), any());
+    verify(paymentCancelRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("refundFull: 결제 키 없음 → Toss 호출 없이 환불 불가")
+  void should_Toss호출없이실패_when_결제키없음() {
+    // given
+    Payment payment = completedPayment("ord_1", "pay_1");
+    ReflectionTestUtils.setField(payment, "paymentKey", null);
+    given(paymentRepository.findByIdForUpdate(100L)).willReturn(Optional.of(payment));
+    given(paymentCancelRepository.existsByPaymentId(100L)).willReturn(false);
+
+    // when & then
+    AdminBillingRefundCommand command = new AdminBillingRefundCommand(100L, "고객 요청");
+
+    assertThatThrownBy(() -> adminBillingUseCase.refundFull(command))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue("code", "PAYMENT_NOT_REFUNDABLE");
+    verify(tossPaymentGateway, never()).cancelPayment(any(), any(), any());
+    verify(paymentCancelRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("refundFull: 결제 없음 → not found 코드로 실패")
+  void should_NotFound코드로실패_when_결제없음() {
+    // given
+    given(paymentRepository.findByIdForUpdate(100L)).willReturn(Optional.empty());
+    AdminBillingRefundCommand command = new AdminBillingRefundCommand(100L, "고객 요청");
+
+    // when & then
+    assertThatThrownBy(() -> adminBillingUseCase.refundFull(command))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue("code", "PAYMENT_NOT_FOUND");
+    verify(tossPaymentGateway, never()).cancelPayment(any(), any(), any());
+  }
+
+  @Test
+  @DisplayName("refundFull: DONE이 아닌 결제 → Toss 호출 없이 환불 불가")
+  void should_Toss호출없이실패_when_완료상태아님() {
+    // given
+    Payment payment = completedPayment("ord_1", "pay_1");
+    payment.refundFull("고객 요청", "tx_cancel_1", OffsetDateTime.now());
+    given(paymentRepository.findByIdForUpdate(100L)).willReturn(Optional.of(payment));
+    given(paymentCancelRepository.existsByPaymentId(100L)).willReturn(false);
+    AdminBillingRefundCommand command = new AdminBillingRefundCommand(100L, "고객 요청");
+
+    // when & then
+    assertThatThrownBy(() -> adminBillingUseCase.refundFull(command))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue("code", "PAYMENT_NOT_REFUNDABLE");
+    verify(tossPaymentGateway, never()).cancelPayment(any(), any(), any());
+    verify(paymentCancelRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("AdminBillingRefundCommand: paymentId와 reason 필수")
+  void should_필수값검증_when_환불명령생성() {
+    assertThatThrownBy(() -> new AdminBillingRefundCommand(null, "고객 요청"))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue("code", "PAYMENT_INVALID_REFUND_REQUEST");
+    assertThatThrownBy(() -> new AdminBillingRefundCommand(100L, " "))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue("code", "PAYMENT_INVALID_REFUND_REQUEST");
+  }
+
+  private Payment completedPayment(String orderId, String paymentKey) {
+    Payment payment = Payment.createOrder(1L, 10L, orderId, 29_000L, "KRW", "Pro");
+    ReflectionTestUtils.setField(payment, "id", 100L);
+    payment.complete(paymentKey, "CARD", OffsetDateTime.now(), "https://receipt", "{}");
+    return payment;
+  }
+}

--- a/backend/src/test/java/com/init/payment/application/exception/PaymentExceptionsTest.java
+++ b/backend/src/test/java/com/init/payment/application/exception/PaymentExceptionsTest.java
@@ -37,6 +37,10 @@ class PaymentExceptionsTest {
         PaymentExceptions.gatewayUnavailable(new IllegalStateException()),
         "PAYMENT_GATEWAY_UNAVAILABLE",
         BadGatewayException.class);
+    assertCode(
+        PaymentExceptions.gatewayUnavailable(),
+        "PAYMENT_GATEWAY_UNAVAILABLE",
+        BadGatewayException.class);
     assertCode(PaymentExceptions.notFound("없음"), "PAYMENT_NOT_FOUND", NotFoundException.class);
     assertCode(
         PaymentExceptions.notRefundable("불가"), "PAYMENT_NOT_REFUNDABLE", BadRequestException.class);

--- a/backend/src/test/java/com/init/payment/application/exception/PaymentExceptionsTest.java
+++ b/backend/src/test/java/com/init/payment/application/exception/PaymentExceptionsTest.java
@@ -1,0 +1,50 @@
+package com.init.payment.application.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.init.shared.application.exception.BadGatewayException;
+import com.init.shared.application.exception.BadRequestException;
+import com.init.shared.application.exception.BusinessException;
+import com.init.shared.application.exception.DuplicateException;
+import com.init.shared.application.exception.InternalException;
+import com.init.shared.application.exception.NotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("PaymentExceptions")
+class PaymentExceptionsTest {
+
+  @Test
+  @DisplayName("payment 예외 코드를 생성한다")
+  void should_결제예외코드생성() {
+    assertCode(
+        PaymentExceptions.alreadyRefunded("이미 환불"),
+        "PAYMENT_ALREADY_REFUNDED",
+        DuplicateException.class);
+    assertCode(
+        PaymentExceptions.configurationInvalid(),
+        "PAYMENT_CONFIGURATION_INVALID",
+        InternalException.class);
+    assertCode(
+        PaymentExceptions.configurationInvalid(new IllegalArgumentException()),
+        "PAYMENT_CONFIGURATION_INVALID",
+        InternalException.class);
+    assertCode(
+        PaymentExceptions.gatewayRejected("거절"),
+        "PAYMENT_GATEWAY_REJECTED",
+        BadRequestException.class);
+    assertCode(
+        PaymentExceptions.gatewayUnavailable(new IllegalStateException()),
+        "PAYMENT_GATEWAY_UNAVAILABLE",
+        BadGatewayException.class);
+    assertCode(PaymentExceptions.notFound("없음"), "PAYMENT_NOT_FOUND", NotFoundException.class);
+    assertCode(
+        PaymentExceptions.notRefundable("불가"), "PAYMENT_NOT_REFUNDABLE", BadRequestException.class);
+  }
+
+  private void assertCode(
+      BusinessException exception, String code, Class<? extends BusinessException> type) {
+    assertThat(exception).isInstanceOf(type);
+    assertThat(exception.getCode()).isEqualTo(code);
+  }
+}

--- a/backend/src/test/java/com/init/payment/domain/model/PaymentCancelTest.java
+++ b/backend/src/test/java/com/init/payment/domain/model/PaymentCancelTest.java
@@ -3,8 +3,10 @@ package com.init.payment.domain.model;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.time.OffsetDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @DisplayName("PaymentCancel 도메인")
 class PaymentCancelTest {
@@ -45,5 +47,19 @@ class PaymentCancelTest {
     assertThat(cancel.getReason()).isNull();
     assertThat(cancel.getTransactionKey()).isNull();
     assertThat(cancel.getIdempotencyKey()).isNull();
+  }
+
+  @Test
+  @DisplayName("취소 시각은 명시값을 보존하고 없으면 저장 시점에 채운다")
+  void create_canceledAt() {
+    OffsetDateTime canceledAt = OffsetDateTime.parse("2026-06-03T12:00:00Z");
+    PaymentCancel explicit = PaymentCancel.create(10L, 5000L, "고객 요청", "txn_001", null, canceledAt);
+    PaymentCancel defaulted = PaymentCancel.create(10L, 5000L, "고객 요청", "txn_002", null);
+
+    ReflectionTestUtils.invokeMethod(explicit, "onPersist");
+    ReflectionTestUtils.invokeMethod(defaulted, "onPersist");
+
+    assertThat(explicit.getCanceledAt()).isEqualTo(canceledAt);
+    assertThat(defaulted.getCanceledAt()).isNotNull();
   }
 }

--- a/backend/src/test/java/com/init/payment/domain/model/PaymentTest.java
+++ b/backend/src/test/java/com/init/payment/domain/model/PaymentTest.java
@@ -8,6 +8,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @DisplayName("Payment 도메인")
 class PaymentTest {
@@ -107,5 +108,62 @@ class PaymentTest {
   void negativeAmount_rejected() {
     assertThatThrownBy(() -> Payment.createOrder(1L, 5L, "ord_1", -1, "KRW", "Pro"))
         .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  @DisplayName("refundFull: DONE 결제를 CANCELED로 전이하고 전액 취소 기록을 만든다")
+  void refundFull_cancelsDonePayment() {
+    Payment payment = completedPayment("ord_refund_1");
+    OffsetDateTime canceledAt = OffsetDateTime.parse("2026-06-02T00:00:00Z");
+
+    PaymentCancel cancel = payment.refundFull("고객 요청", "tx_cancel_1", canceledAt);
+
+    assertThat(payment.getStatus()).isEqualTo(PaymentStatus.CANCELED);
+    assertThat(cancel.getPaymentId()).isEqualTo(100L);
+    assertThat(cancel.getCancelAmount()).isEqualTo(29000L);
+    assertThat(cancel.getReason()).isEqualTo("고객 요청");
+    assertThat(cancel.getTransactionKey()).isEqualTo("tx_cancel_1");
+    assertThat(cancel.getCanceledAt()).isEqualTo(canceledAt);
+  }
+
+  @Test
+  @DisplayName("refundFull: DONE이 아닌 결제는 전액 환불할 수 없다")
+  void refundFull_requiresDonePayment() {
+    Payment payment = Payment.createOrder(1L, 5L, "ord_ready", 29000, "KRW", "Pro");
+
+    assertThatThrownBy(() -> payment.refundFull("고객 요청", "tx_cancel_1", NOW))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("DONE payment is required for full refund");
+  }
+
+  @Test
+  @DisplayName("refundFull: reason과 transactionKey는 필수다")
+  void refundFull_requiresReasonAndTransactionKey() {
+    Payment missingReason = completedPayment("ord_refund_2");
+    Payment missingTransactionKey = completedPayment("ord_refund_3");
+
+    assertThatThrownBy(() -> missingReason.refundFull(" ", "tx_cancel_1", NOW))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("reason must not be null or blank");
+    assertThatThrownBy(() -> missingTransactionKey.refundFull("고객 요청", " ", NOW))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("transactionKey must not be null or blank");
+  }
+
+  @Test
+  @DisplayName("refundFull: 취소 시각이 없으면 저장 시점에 채울 수 있도록 null을 허용한다")
+  void refundFull_allowsNullCanceledAt() {
+    Payment payment = completedPayment("ord_refund_4");
+
+    PaymentCancel cancel = payment.refundFull("고객 요청", "tx_cancel_1", null);
+
+    assertThat(cancel.getCanceledAt()).isNull();
+  }
+
+  private Payment completedPayment(String orderId) {
+    Payment payment = Payment.createOrder(1L, 5L, orderId, 29000, "KRW", "Pro");
+    ReflectionTestUtils.setField(payment, "id", 100L);
+    payment.complete("pay_" + orderId, "카드", NOW, "https://receipt", "{}");
+    return payment;
   }
 }

--- a/backend/src/test/java/com/init/payment/presentation/AdminBillingControllerTest.java
+++ b/backend/src/test/java/com/init/payment/presentation/AdminBillingControllerTest.java
@@ -1,0 +1,181 @@
+package com.init.payment.presentation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.init.auth.application.JwtService;
+import com.init.payment.application.AdminBillingCustomerSummary;
+import com.init.payment.application.AdminBillingRefundResult;
+import com.init.payment.application.AdminBillingUseCase;
+import com.init.payment.domain.model.PaymentStatus;
+import com.init.shared.infrastructure.security.ApiAuthenticationEntryPoint;
+import com.init.shared.infrastructure.security.JwtAuthenticationFilter;
+import com.init.shared.infrastructure.security.SecurityConfig;
+import com.init.shared.presentation.GlobalExceptionHandler;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import java.time.OffsetDateTime;
+import java.util.Date;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(AdminBillingController.class)
+@Import({
+  SecurityConfig.class,
+  JwtAuthenticationFilter.class,
+  ApiAuthenticationEntryPoint.class,
+  GlobalExceptionHandler.class
+})
+@TestPropertySource(properties = "cors.allowed-origins=http://localhost:5173")
+@DisplayName("AdminBillingController")
+class AdminBillingControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private AdminBillingUseCase adminBillingUseCase;
+  @MockitoBean private JwtService jwtService;
+
+  @Test
+  @DisplayName("GET /api/v1/admin/billing/customers: SUPER_ADMIN JWT → 200 OK")
+  void should_200반환_when_SUPER_ADMIN조회요청() throws Exception {
+    // given
+    givenSuperAdminBearerToken("super-admin-token");
+    given(adminBillingUseCase.findCustomerSummaries())
+        .willReturn(
+            List.of(
+                new AdminBillingCustomerSummary(
+                    1L,
+                    "acme",
+                    "Acme",
+                    "ACTIVE",
+                    OffsetDateTime.parse("2026-06-01T00:00:00Z"),
+                    OffsetDateTime.parse("2026-07-01T00:00:00Z"),
+                    OffsetDateTime.parse("2026-07-01T00:00:00Z"),
+                    "Pro",
+                    29_000L,
+                    10L,
+                    29_000L,
+                    "DONE",
+                    OffsetDateTime.parse("2026-06-01T00:00:00Z"),
+                    null)));
+
+    // when & then
+    mockMvc
+        .perform(
+            get("/api/v1/admin/billing/customers")
+                .header("Authorization", "Bearer super-admin-token"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].workspaceName").value("Acme"))
+        .andExpect(jsonPath("$[0].subscription.status").value("ACTIVE"))
+        .andExpect(jsonPath("$[0].recentPayment.id").value(10))
+        .andExpect(jsonPath("$[0].recentPayment.status").value("DONE"))
+        .andExpect(jsonPath("$[0].recentPayment.paymentKey").doesNotExist())
+        .andExpect(jsonPath("$[0].recentPayment.billingKey").doesNotExist())
+        .andExpect(jsonPath("$[0].recentPayment.secretKey").doesNotExist())
+        .andExpect(jsonPath("$[0].recentPayment.cardNumber").doesNotExist())
+        .andExpect(jsonPath("$[0].recentPayment.pan").doesNotExist());
+  }
+
+  @Test
+  @DisplayName("POST /api/v1/admin/billing/payments/{paymentId}/refunds: SUPER_ADMIN JWT → 200 OK")
+  void should_200반환_when_SUPER_ADMIN전체환불요청() throws Exception {
+    // given
+    givenSuperAdminBearerToken("super-admin-token");
+    given(adminBillingUseCase.refundFull(any()))
+        .willReturn(
+            new AdminBillingRefundResult(
+                10L,
+                1L,
+                29_000L,
+                PaymentStatus.CANCELED,
+                "tx_cancel_1",
+                OffsetDateTime.parse("2026-06-03T12:00:00Z"),
+                "고객 요청"));
+
+    // when & then
+    mockMvc
+        .perform(
+            post("/api/v1/admin/billing/payments/10/refunds")
+                .header("Authorization", "Bearer super-admin-token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"reason\":\"고객 요청\"}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.paymentId").value(10))
+        .andExpect(jsonPath("$.paymentStatus").value("CANCELED"))
+        .andExpect(jsonPath("$.refundAmount").value(29000))
+        .andExpect(jsonPath("$.reason").value("고객 요청"));
+  }
+
+  @Test
+  @DisplayName("GET /api/v1/admin/billing/customers: OPERATOR JWT → 403 Forbidden")
+  void should_403반환_when_OPERATOR조회요청() throws Exception {
+    // given
+    givenBearerToken("operator-token", "OPERATOR");
+
+    // when & then
+    mockMvc
+        .perform(
+            get("/api/v1/admin/billing/customers").header("Authorization", "Bearer operator-token"))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @DisplayName("GET /api/v1/admin/billing/customers: WORKSPACE_ADMIN JWT → 403 Forbidden")
+  void should_403반환_when_WORKSPACE_ADMIN조회요청() throws Exception {
+    // given
+    givenBearerToken("workspace-admin-token", "WORKSPACE_ADMIN");
+
+    // when & then
+    mockMvc
+        .perform(
+            get("/api/v1/admin/billing/customers")
+                .header("Authorization", "Bearer workspace-admin-token"))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @DisplayName("POST /api/v1/admin/billing/payments/{paymentId}/refunds: 빈 사유 → 400 Bad Request")
+  void should_400반환_when_환불사유없음() throws Exception {
+    // given
+    givenSuperAdminBearerToken("super-admin-token");
+
+    // when & then
+    mockMvc
+        .perform(
+            post("/api/v1/admin/billing/payments/10/refunds")
+                .header("Authorization", "Bearer super-admin-token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"reason\":\"\"}"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+  }
+
+  private void givenSuperAdminBearerToken(String token) {
+    givenBearerToken(token, "SUPER_ADMIN");
+  }
+
+  private void givenBearerToken(String token, String role) {
+    Claims claims =
+        Jwts.claims()
+            .subject("1")
+            .add("type", "access")
+            .add("role", role)
+            .expiration(new Date(System.currentTimeMillis() + 60_000))
+            .build();
+    given(jwtService.parseClaims(token)).willReturn(claims);
+    given(jwtService.isTokenValid(claims)).willReturn(true);
+    given(jwtService.isAccessToken(claims)).willReturn(true);
+  }
+}

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -9,8 +9,8 @@ import { ConsultationPage } from "../pages/consultation/ui/ConsultationPage";
 import { UserChatPage } from "../pages/user-chat";
 import { DemoPage } from "../pages/demo";
 import { AdminLayout } from "../pages/admin/ui/AdminLayout";
+import { AdminBillingPage } from "../pages/admin/ui/AdminBillingPage";
 import { AdminCustomersPage } from "../pages/admin/ui/AdminCustomersPage";
-import { AdminPlaceholderPage } from "../pages/admin/ui/AdminPlaceholderPage";
 import { AdminPipelineJobsPage } from "../pages/admin/ui/AdminPipelineJobsPage";
 import { AdminSuperAdminsPage } from "../pages/admin/ui/AdminSuperAdminsPage";
 import { NotFoundPage } from "../pages/not-found/ui/NotFoundPage";
@@ -81,10 +81,7 @@ export function App() {
         >
           <Route index element={<Navigate to="super-admins" replace />} />
           <Route path="customers" element={<AdminCustomersPage />} />
-          <Route
-            path="billing"
-            element={<AdminPlaceholderPage eyebrow="Billing" title="결제 관리" />}
-          />
+          <Route path="billing" element={<AdminBillingPage />} />
           <Route path="airflow" element={<AdminPipelineJobsPage />} />
           <Route path="super-admins" element={<AdminSuperAdminsPage />} />
         </Route>

--- a/frontend/src/features/admin-billing/api/adminBillingApi.test.ts
+++ b/frontend/src/features/admin-billing/api/adminBillingApi.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { apiClient } from "@/shared/api";
+import { fetchAdminBillingCustomers, refundAdminBillingPayment } from "./adminBillingApi";
+
+vi.mock("@/shared/api", () => ({
+  apiClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}));
+
+const mockedApiClient = vi.mocked(apiClient);
+
+describe("adminBillingApi", () => {
+  beforeEach(() => {
+    mockedApiClient.get.mockReset();
+    mockedApiClient.post.mockReset();
+  });
+
+  it("고객사 결제 현황을 조회한다", async () => {
+    mockedApiClient.get.mockResolvedValueOnce([]);
+
+    await expect(fetchAdminBillingCustomers()).resolves.toEqual([]);
+
+    expect(mockedApiClient.get).toHaveBeenCalledWith("/admin/billing/customers");
+  });
+
+  it("전체 환불을 요청한다", async () => {
+    mockedApiClient.post.mockResolvedValueOnce({
+      paymentId: 10,
+      workspaceId: 1,
+      refundAmount: 29000,
+      paymentStatus: "CANCELED",
+      transactionKey: "tx_cancel_1",
+      canceledAt: "2026-06-03T12:00:00Z",
+      reason: "고객 요청",
+    });
+
+    await refundAdminBillingPayment(10, "고객 요청");
+
+    expect(mockedApiClient.post).toHaveBeenCalledWith("/admin/billing/payments/10/refunds", {
+      reason: "고객 요청",
+    });
+  });
+});

--- a/frontend/src/features/admin-billing/api/adminBillingApi.ts
+++ b/frontend/src/features/admin-billing/api/adminBillingApi.ts
@@ -1,0 +1,50 @@
+import { apiClient } from "@/shared/api";
+
+export interface AdminBillingCustomerResponse {
+  workspaceId: number;
+  workspaceKey: string;
+  workspaceName: string;
+  subscription: {
+    status: string | null;
+    currentPeriodStart: string | null;
+    currentPeriodEnd: string | null;
+    nextBillingAt: string | null;
+    planName: string | null;
+    planAmount: number | null;
+  };
+  recentPayment: {
+    id: number;
+    amount: number;
+    status: string;
+    approvedAt: string | null;
+  } | null;
+  failedStatus: string | null;
+}
+
+export interface AdminBillingRefundResponse {
+  paymentId: number;
+  workspaceId: number;
+  refundAmount: number;
+  paymentStatus: string;
+  transactionKey: string;
+  canceledAt: string;
+  reason: string;
+}
+
+export async function fetchAdminBillingCustomers(): Promise<AdminBillingCustomerResponse[]> {
+  // OpenAPI generated endpoint is not available until this branch's backend spec is regenerated.
+  return apiClient.get<AdminBillingCustomerResponse[]>("/admin/billing/customers");
+}
+
+export async function refundAdminBillingPayment(
+  paymentId: number,
+  reason: string,
+): Promise<AdminBillingRefundResponse> {
+  // OpenAPI generated endpoint is not available until this branch's backend spec is regenerated.
+  return apiClient.post<AdminBillingRefundResponse>(
+    `/admin/billing/payments/${paymentId}/refunds`,
+    {
+      reason,
+    },
+  );
+}

--- a/frontend/src/features/admin-billing/index.ts
+++ b/frontend/src/features/admin-billing/index.ts
@@ -1,0 +1,1 @@
+export { AdminBillingManagement } from "./ui/AdminBillingManagement";

--- a/frontend/src/features/admin-billing/ui/AdminBillingManagement.test.tsx
+++ b/frontend/src/features/admin-billing/ui/AdminBillingManagement.test.tsx
@@ -1,0 +1,173 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { ApiRequestError } from "@/shared/api";
+import {
+  fetchAdminBillingCustomers,
+  refundAdminBillingPayment,
+  type AdminBillingCustomerResponse,
+} from "../api/adminBillingApi";
+import { AdminBillingManagement } from "./AdminBillingManagement";
+
+vi.mock("../api/adminBillingApi", () => ({
+  fetchAdminBillingCustomers: vi.fn(),
+  refundAdminBillingPayment: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+const mockedFetchAdminBillingCustomers = vi.mocked(fetchAdminBillingCustomers);
+const mockedRefundAdminBillingPayment = vi.mocked(refundAdminBillingPayment);
+
+const customer: AdminBillingCustomerResponse = {
+  workspaceId: 1,
+  workspaceKey: "acme",
+  workspaceName: "Acme",
+  subscription: {
+    status: "ACTIVE",
+    currentPeriodStart: "2026-06-01T00:00:00Z",
+    currentPeriodEnd: "2026-07-01T00:00:00Z",
+    nextBillingAt: "2026-07-01T00:00:00Z",
+    planName: "Pro",
+    planAmount: 29000,
+  },
+  recentPayment: {
+    id: 10,
+    amount: 29000,
+    status: "DONE",
+    approvedAt: "2026-06-01T00:00:00Z",
+  },
+  failedStatus: null,
+};
+
+describe("AdminBillingManagement", () => {
+  beforeEach(() => {
+    mockedFetchAdminBillingCustomers.mockReset();
+    mockedRefundAdminBillingPayment.mockReset();
+  });
+
+  it("고객사별 결제 현황을 표시한다", async () => {
+    mockedFetchAdminBillingCustomers.mockResolvedValueOnce([customer]);
+
+    render(<AdminBillingManagement />);
+
+    expect(await screen.findByText("Acme")).toBeInTheDocument();
+    expect(screen.getByText("acme")).toBeInTheDocument();
+    expect(screen.getByText("ACTIVE")).toBeInTheDocument();
+    expect(screen.getByText("DONE")).toBeInTheDocument();
+  });
+
+  it("조회 결과가 없으면 empty 상태를 표시한다", async () => {
+    mockedFetchAdminBillingCustomers.mockResolvedValueOnce([]);
+
+    render(<AdminBillingManagement />);
+
+    expect(await screen.findByText("조회할 결제 현황이 없습니다.")).toBeInTheDocument();
+  });
+
+  it("조회 실패 후 다시 시도하면 목록을 표시한다", async () => {
+    mockedFetchAdminBillingCustomers
+      .mockRejectedValueOnce(new ApiRequestError(403, "FORBIDDEN", "권한이 없습니다."))
+      .mockResolvedValueOnce([customer]);
+
+    render(<AdminBillingManagement />);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("권한이 없습니다.");
+    await userEvent.click(screen.getByRole("button", { name: "다시 시도" }));
+
+    expect(await screen.findByText("Acme")).toBeInTheDocument();
+  });
+
+  it("검색어에 맞는 고객사만 표시한다", async () => {
+    mockedFetchAdminBillingCustomers.mockResolvedValueOnce([
+      customer,
+      {
+        ...customer,
+        workspaceId: 2,
+        workspaceKey: "beta",
+        workspaceName: "Beta",
+        recentPayment: null,
+        subscription: {
+          status: null,
+          currentPeriodStart: null,
+          currentPeriodEnd: null,
+          nextBillingAt: null,
+          planName: null,
+          planAmount: null,
+        },
+        failedStatus: "PAYMENT_FAILED",
+      },
+    ]);
+
+    render(<AdminBillingManagement />);
+
+    await screen.findByText("Acme");
+    await userEvent.type(screen.getByLabelText("고객사 검색"), "beta");
+
+    expect(screen.queryByText("Acme")).not.toBeInTheDocument();
+    expect(screen.getByText("Beta")).toBeInTheDocument();
+    expect(screen.getByText("결제 없음")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /전체 환불/ })).toBeDisabled();
+  });
+
+  it("환불 사유가 없으면 전체 환불 API를 호출하지 않는다", async () => {
+    mockedFetchAdminBillingCustomers.mockResolvedValueOnce([customer]);
+
+    render(<AdminBillingManagement />);
+
+    await userEvent.click(await screen.findByRole("button", { name: /전체 환불/ }));
+    const dialog = screen.getByRole("dialog");
+    await userEvent.click(within(dialog).getByRole("button", { name: /전체 환불 실행/ }));
+
+    expect(await within(dialog).findByRole("alert")).toHaveTextContent("환불 사유를 입력해주세요.");
+    expect(mockedRefundAdminBillingPayment).not.toHaveBeenCalled();
+  });
+
+  it("환불 사유를 입력하면 전체 환불 API를 호출하고 목록을 다시 불러온다", async () => {
+    mockedFetchAdminBillingCustomers.mockResolvedValue([customer]);
+    mockedRefundAdminBillingPayment.mockResolvedValueOnce({
+      paymentId: 10,
+      workspaceId: 1,
+      refundAmount: 29000,
+      paymentStatus: "CANCELED",
+      transactionKey: "tx_cancel_1",
+      canceledAt: "2026-06-03T12:00:00Z",
+      reason: "고객 요청",
+    });
+
+    render(<AdminBillingManagement />);
+
+    await userEvent.click(await screen.findByRole("button", { name: /전체 환불/ }));
+    const dialog = screen.getByRole("dialog");
+    await userEvent.type(within(dialog).getByLabelText("환불 사유"), "고객 요청");
+    await userEvent.click(within(dialog).getByRole("button", { name: /전체 환불 실행/ }));
+
+    await waitFor(() => {
+      expect(mockedRefundAdminBillingPayment).toHaveBeenCalledWith(10, "고객 요청");
+    });
+    await waitFor(() => {
+      expect(mockedFetchAdminBillingCustomers).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("환불 API 실패 메시지를 dialog에 표시한다", async () => {
+    mockedFetchAdminBillingCustomers.mockResolvedValueOnce([customer]);
+    mockedRefundAdminBillingPayment.mockRejectedValueOnce(
+      new ApiRequestError(409, "PAYMENT_ALREADY_REFUNDED", "이미 환불된 결제입니다."),
+    );
+
+    render(<AdminBillingManagement />);
+
+    await userEvent.click(await screen.findByRole("button", { name: /전체 환불/ }));
+    const dialog = screen.getByRole("dialog");
+    await userEvent.type(within(dialog).getByLabelText("환불 사유"), "고객 요청");
+    await userEvent.click(within(dialog).getByRole("button", { name: /전체 환불 실행/ }));
+
+    expect(await within(dialog).findByRole("alert")).toHaveTextContent("이미 환불된 결제입니다.");
+  });
+});

--- a/frontend/src/features/admin-billing/ui/AdminBillingManagement.tsx
+++ b/frontend/src/features/admin-billing/ui/AdminBillingManagement.tsx
@@ -1,0 +1,277 @@
+import { useEffect, useMemo, useState, type FormEvent } from "react";
+import { RefreshCw, RotateCcw, Search, X } from "lucide-react";
+import { toast } from "sonner";
+import { ApiRequestError } from "@/shared/api";
+import { Button } from "@/shared/ui/button/Button";
+import { Input } from "@/shared/ui/input/Input";
+import {
+  fetchAdminBillingCustomers,
+  refundAdminBillingPayment,
+  type AdminBillingCustomerResponse,
+} from "../api/adminBillingApi";
+import styles from "./admin-billing-management.module.css";
+
+const REFUNDABLE_STATUS = "DONE";
+
+function formatCurrency(value: number | null | undefined): string {
+  if (value == null) return "미등록";
+  return new Intl.NumberFormat("ko-KR", {
+    style: "currency",
+    currency: "KRW",
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
+function formatDate(value: string | null | undefined): string {
+  if (!value) return "미등록";
+  return new Intl.DateTimeFormat("ko-KR", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(new Date(value));
+}
+
+function statusLabel(value: string | null | undefined): string {
+  return value || "미등록";
+}
+
+export function AdminBillingManagement() {
+  const [customers, setCustomers] = useState<AdminBillingCustomerResponse[]>([]);
+  const [query, setQuery] = useState("");
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [selected, setSelected] = useState<AdminBillingCustomerResponse | null>(null);
+  const [reason, setReason] = useState("");
+  const [refundError, setRefundError] = useState("");
+  const [isRefunding, setIsRefunding] = useState(false);
+
+  const loadCustomers = async () => {
+    setIsLoading(true);
+    setError("");
+    try {
+      setCustomers(await fetchAdminBillingCustomers());
+    } catch (err) {
+      const message =
+        err instanceof ApiRequestError
+          ? err.message
+          : "결제 현황을 불러오지 못했습니다. 잠시 후 다시 시도해주세요.";
+      setError(message);
+      toast.error(message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void loadCustomers();
+  }, []);
+
+  const filteredCustomers = useMemo(() => {
+    const trimmedQuery = query.trim().toLowerCase();
+    if (!trimmedQuery) return customers;
+    return customers.filter((customer) =>
+      `${customer.workspaceName} ${customer.workspaceKey}`.toLowerCase().includes(trimmedQuery),
+    );
+  }, [customers, query]);
+
+  const openRefundDialog = (customer: AdminBillingCustomerResponse) => {
+    setSelected(customer);
+    setReason("");
+    setRefundError("");
+  };
+
+  const closeRefundDialog = () => {
+    if (isRefunding) return;
+    setSelected(null);
+    setReason("");
+    setRefundError("");
+  };
+
+  const handleRefund = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!selected?.recentPayment) return;
+
+    const trimmedReason = reason.trim();
+    if (!trimmedReason) {
+      setRefundError("환불 사유를 입력해주세요.");
+      return;
+    }
+
+    setIsRefunding(true);
+    setRefundError("");
+    try {
+      await refundAdminBillingPayment(selected.recentPayment.id, trimmedReason);
+      toast.success("전체 환불이 완료되었습니다.");
+      closeRefundDialog();
+      await loadCustomers();
+    } catch (err) {
+      const message =
+        err instanceof ApiRequestError
+          ? err.message
+          : "전체 환불을 실행하지 못했습니다. 잠시 후 다시 시도해주세요.";
+      setRefundError(message);
+      toast.error(message);
+    } finally {
+      setIsRefunding(false);
+    }
+  };
+
+  return (
+    <div className={styles.surface}>
+      <div className={styles.toolbar}>
+        <Input
+          label="고객사 검색"
+          icon={<Search size={16} />}
+          placeholder="워크스페이스 이름 또는 키"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+        />
+        <Button variant="secondary" onClick={() => void loadCustomers()} isLoading={isLoading}>
+          <RefreshCw size={16} />
+          새로고침
+        </Button>
+      </div>
+
+      {isLoading && <div className={styles.state}>결제 현황을 불러오는 중입니다.</div>}
+
+      {!isLoading && error && (
+        <div className={styles.state} role="alert">
+          <p>{error}</p>
+          <Button variant="secondary" onClick={() => void loadCustomers()}>
+            다시 시도
+          </Button>
+        </div>
+      )}
+
+      {!isLoading && !error && filteredCustomers.length === 0 && (
+        <div className={styles.state}>조회할 결제 현황이 없습니다.</div>
+      )}
+
+      {!isLoading && !error && filteredCustomers.length > 0 && (
+        <div className={styles.tableWrap}>
+          <table className={styles.table}>
+            <thead>
+              <tr>
+                <th>고객사</th>
+                <th>구독</th>
+                <th>기간</th>
+                <th>다음 결제일</th>
+                <th>최근 결제</th>
+                <th>실패 상태</th>
+                <th>환불</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filteredCustomers.map((customer) => {
+                const payment = customer.recentPayment;
+                const canRefund = payment?.status === REFUNDABLE_STATUS;
+                return (
+                  <tr key={customer.workspaceId}>
+                    <td>
+                      <strong>{customer.workspaceName}</strong>
+                      <span>{customer.workspaceKey}</span>
+                    </td>
+                    <td>
+                      <strong>{statusLabel(customer.subscription.status)}</strong>
+                      <span>
+                        {customer.subscription.planName || "요금제 미등록"} ·{" "}
+                        {formatCurrency(customer.subscription.planAmount)}
+                      </span>
+                    </td>
+                    <td>
+                      <span>{formatDate(customer.subscription.currentPeriodStart)}</span>
+                      <span>{formatDate(customer.subscription.currentPeriodEnd)}</span>
+                    </td>
+                    <td>{formatDate(customer.subscription.nextBillingAt)}</td>
+                    <td>
+                      {payment ? (
+                        <>
+                          <strong>{payment.status}</strong>
+                          <span>
+                            {formatCurrency(payment.amount)} · {formatDate(payment.approvedAt)}
+                          </span>
+                        </>
+                      ) : (
+                        "결제 없음"
+                      )}
+                    </td>
+                    <td>{statusLabel(customer.failedStatus)}</td>
+                    <td>
+                      <Button
+                        variant="secondary"
+                        disabled={!canRefund}
+                        onClick={() => openRefundDialog(customer)}
+                      >
+                        <RotateCcw size={15} />
+                        전체 환불
+                      </Button>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {selected?.recentPayment && (
+        <div className={styles.modalBackdrop} role="presentation">
+          <form className={styles.modal} onSubmit={handleRefund} role="dialog" aria-modal="true">
+            <button
+              type="button"
+              className={styles.closeButton}
+              onClick={closeRefundDialog}
+              aria-label="닫기"
+              disabled={isRefunding}
+            >
+              <X size={18} />
+            </button>
+            <div>
+              <p className={styles.modalEyebrow}>Full refund</p>
+              <h2>{selected.workspaceName} 전체 환불</h2>
+            </div>
+            <dl className={styles.refundSummary}>
+              <div>
+                <dt>결제 금액</dt>
+                <dd>{formatCurrency(selected.recentPayment.amount)}</dd>
+              </div>
+              <div>
+                <dt>결제 상태</dt>
+                <dd>{selected.recentPayment.status}</dd>
+              </div>
+            </dl>
+            <label className={styles.reasonField}>
+              <span>환불 사유</span>
+              <textarea
+                value={reason}
+                onChange={(event) => setReason(event.target.value)}
+                maxLength={500}
+                rows={4}
+                placeholder="고객 요청으로 전체 환불"
+              />
+            </label>
+            {refundError && (
+              <p className={styles.errorText} role="alert">
+                {refundError}
+              </p>
+            )}
+            <div className={styles.modalActions}>
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={closeRefundDialog}
+                disabled={isRefunding}
+              >
+                취소
+              </Button>
+              <Button type="submit" isLoading={isRefunding}>
+                <RotateCcw size={16} />
+                전체 환불 실행
+              </Button>
+            </div>
+          </form>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/admin-billing/ui/admin-billing-management.module.css
+++ b/frontend/src/features/admin-billing/ui/admin-billing-management.module.css
@@ -1,0 +1,200 @@
+.surface {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  width: 100%;
+}
+
+.toolbar {
+  display: grid;
+  grid-template-columns: minmax(240px, 420px) auto;
+  align-items: end;
+  gap: 16px;
+}
+
+.state {
+  display: flex;
+  min-height: 220px;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  border-top: 1px solid var(--line);
+  color: var(--text-secondary);
+  font-size: 15px;
+  letter-spacing: 0;
+}
+
+.tableWrap {
+  overflow-x: auto;
+  border-top: 1px solid var(--line);
+}
+
+.table {
+  width: 100%;
+  min-width: 980px;
+  border-collapse: collapse;
+  font-size: 14px;
+  letter-spacing: 0;
+}
+
+.table th {
+  padding: 14px 12px;
+  border-bottom: 1px solid var(--line);
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 450;
+  text-align: left;
+}
+
+.table td {
+  padding: 16px 12px;
+  border-bottom: 1px solid var(--divider-subtle);
+  vertical-align: top;
+}
+
+.table strong,
+.table span {
+  display: block;
+}
+
+.table strong {
+  margin-bottom: 4px;
+  font-weight: 540;
+}
+
+.table span {
+  color: var(--text-secondary);
+  line-height: 1.45;
+}
+
+.modalBackdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: rgba(0, 0, 0, 0.42);
+}
+
+.modal {
+  position: relative;
+  display: flex;
+  width: min(520px, 100%);
+  flex-direction: column;
+  gap: 20px;
+  border-radius: var(--radius-lg);
+  background: #ffffff;
+  padding: 28px;
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.18);
+}
+
+.closeButton {
+  position: absolute;
+  top: 18px;
+  right: 18px;
+  display: inline-flex;
+  width: 34px;
+  height: 34px;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-radius: var(--radius-full);
+  background: var(--glass-dark);
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.closeButton:focus-visible,
+.reasonField textarea:focus-visible {
+  outline: none;
+  border-color: #000000;
+  box-shadow: var(--focus-ring);
+}
+
+.modalEyebrow {
+  margin: 0 0 8px;
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.modal h2 {
+  margin: 0;
+  padding-right: 42px;
+  font-size: 24px;
+  font-weight: 540;
+  letter-spacing: 0;
+  line-height: 1.25;
+}
+
+.refundSummary {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  margin: 0;
+}
+
+.refundSummary div {
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  padding: 12px;
+}
+
+.refundSummary dt {
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+.refundSummary dd {
+  margin: 4px 0 0;
+  font-size: 15px;
+  font-weight: 540;
+}
+
+.reasonField {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+
+.reasonField textarea {
+  width: 100%;
+  resize: vertical;
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  border-radius: var(--radius-lg);
+  padding: 12px;
+  color: var(--text-primary);
+  font-family: inherit;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.errorText {
+  margin: 0;
+  color: var(--error-color);
+  font-size: 14px;
+}
+
+.modalActions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+@media (max-width: 720px) {
+  .toolbar,
+  .refundSummary {
+    grid-template-columns: 1fr;
+  }
+
+  .modalActions {
+    flex-direction: column-reverse;
+  }
+}

--- a/frontend/src/pages/admin/ui/AdminBillingPage.test.tsx
+++ b/frontend/src/pages/admin/ui/AdminBillingPage.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vite-plus/test";
+import { AdminBillingPage } from "./AdminBillingPage";
+
+vi.mock("@/features/admin-billing", () => ({
+  AdminBillingManagement: () => <div>관리 위젯</div>,
+}));
+
+describe("AdminBillingPage", () => {
+  it("결제 관리 페이지 제목과 위젯을 표시한다", () => {
+    render(<AdminBillingPage />);
+
+    expect(screen.getByRole("heading", { name: "결제 관리" })).toBeInTheDocument();
+    expect(screen.getByText("관리 위젯")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/admin/ui/AdminBillingPage.tsx
+++ b/frontend/src/pages/admin/ui/AdminBillingPage.tsx
@@ -1,0 +1,16 @@
+import { AdminBillingManagement } from "@/features/admin-billing";
+import styles from "./admin-page.module.css";
+
+export function AdminBillingPage() {
+  return (
+    <section className={styles.page}>
+      <div className={styles.header}>
+        <p className={styles.eyebrow}>Billing</p>
+        <h1>결제 관리</h1>
+      </div>
+      <div className={styles.panel}>
+        <AdminBillingManagement />
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
Closes #500

## 변경 사항

- SUPER_ADMIN 전용 결제 관리 API와 화면에서 고객사별 구독 상태, 결제 주기, 다음 결제일, 최근 결제 및 실패 상태를 조회할 수 있습니다.
- 완료된 최근 결제에 대해 전체 환불만 요청할 수 있으며, 환불 사유를 받아 Toss cancel API 호출 결과와 함께 취소 이력을 저장합니다.
- OPERATOR 및 워크스페이스 ADMIN 권한은 결제 관리 API와 화면에 접근할 수 없고, 응답에는 secretKey, billingKey, 원본 카드번호, Toss paymentKey가 노출되지 않습니다.
- Toss 게이트웨이 거절/장애와 내부 결제 상태 오류를 분리해 처리합니다.

## 검증

- `git diff --check`
- `cd backend && ./gradlew spotlessApply`
- `cd frontend && pnpm test -- --run src/features/admin-billing/ui/AdminBillingManagement.test.tsx`
- `cd frontend && pnpm build`
- `cd frontend && pnpm exec eslint src/app/App.tsx src/pages/admin/ui/AdminBillingPage.tsx src/features/admin-billing/api/adminBillingApi.ts src/features/admin-billing/ui/AdminBillingManagement.tsx src/features/admin-billing/ui/AdminBillingManagement.test.tsx`

## 참고

- 로컬 backend 테스트 실행은 Java 21 toolchain 미설치로 중단되었습니다. 현재 로컬 환경에서는 Java 17만 감지됩니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 관리자용 결제 대시보드 추가: 고객사 구독·과금 기간·플랜·최근 결제 현황 조회
  * 전체 환불 기능 추가: 결제 완료 건 대상, 사유 입력으로 전체 환불 실행 및 거래키·취소시각 반환
  * 관리자 UI 페이지·클라이언트 API·관리자 전용 엔드포인트 추가

* **Bug Fixes / Security**
  * 민감정보(키·원카드번호 등) 노출 제한 및 슈퍼 관리자 전용 접근(권한 없으면 403)

* **Tests**
  * 환불 흐름·예외·컨트롤러·프론트엔드 통합/단위 테스트 추가

* **Documentation**
  * 관리자 결제·환불 명세와 수락 기준 문서화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->