### PR TITLE
feat(admin): 고객사 현황 대시보드 제공

### DIFF
--- a/.agent/specs/499.md
+++ b/.agent/specs/499.md
@@ -1,0 +1,144 @@
+# [Mixed] 499 — cstone 고객사 현황 대시보드
+
+## Goal
+
+`SUPER_ADMIN`이 cstone admin shell 안에서 고객사 워크스페이스 목록과 상세 운영 요약을 확인할 수 있게 한다.
+
+## Issue Context
+
+- GitHub Issue #499: `feat(admin): cstone 고객사 현황 대시보드`
+- 선행 이슈 #510에서 admin 권한, `/api/v1/admin/**` 접근 제어, frontend admin shell이 제공된다.
+- 이 이슈는 고객사 목록/상세 조회와 화면 연결을 다룬다.
+
+## Scope
+
+- Backend: `workspace` 모듈에 admin 고객사 read query를 추가한다.
+- Frontend: `/admin/customers` placeholder를 실제 고객사 현황 화면으로 교체한다.
+- Access control: 기존 `SecurityConfig`의 `/api/v1/admin/**` `SUPER_ADMIN` 제한과 `AdminRoute`를 사용한다.
+- Billing: payment/billing 구현이 아직 없으므로 응답 필드는 null/empty summary로 제공한다.
+
+## Non-goals
+
+- admin 권한 모델과 admin shell 생성
+- `SUPER_ADMIN` 계정 생성 UI/API 변경
+- 결제/구독 bounded context 또는 payment schema 구현
+- 고객사 health/risk score
+- 감사 로그 화면
+- 고객사 workspace 강제 보관/복구
+- 고객사 멤버 직접 조작
+
+## Affected Paths
+
+| Path | Role |
+| --- | --- |
+| `backend/src/main/java/com/init/workspace/application` | admin 고객사 목록/상세 use case와 read projection |
+| `backend/src/main/java/com/init/workspace/infrastructure/persistence/JdbcAdminCustomerQueryAdapter.java` | `app`, `corpus`, `pipeline` schema 기반 read query |
+| `backend/src/main/java/com/init/workspace/presentation/AdminCustomerController.java` | `/api/v1/admin/customers` API |
+| `frontend/src/features/admin` | admin 고객사 API와 dashboard component |
+| `frontend/src/pages/admin/ui/AdminCustomersPage.tsx` | `/admin/customers` page |
+| `frontend/src/app/App.tsx` | admin customer route 연결 |
+
+## Backend Contract
+
+### `GET /api/v1/admin/customers`
+
+Query params:
+
+| Name | Required | Description |
+| --- | --- | --- |
+| `q` | no | 고객사명 또는 `workspaceKey` 부분 검색 |
+| `status` | no | `ACTIVE`, `ARCHIVED` |
+| `page` | no | 0-based page, default `0` |
+| `size` | no | 1-100, default `20` |
+
+Response:
+
+```json
+{
+  "content": [
+    {
+      "workspace": {
+        "id": 1,
+        "workspaceKey": "acme",
+        "name": "Acme",
+        "description": "고객사",
+        "status": "ACTIVE",
+        "createdAt": "2026-06-01T00:00:00Z",
+        "updatedAt": "2026-06-02T00:00:00Z"
+      },
+      "memberCount": 3,
+      "billing": {
+        "subscriptionStatus": null,
+        "planName": null,
+        "currentPeriodEnd": null,
+        "updatedAt": null
+      },
+      "latestUpload": {
+        "datasetId": 10,
+        "datasetKey": "upload-1",
+        "name": "상담 로그",
+        "status": "READY",
+        "uploadedAt": "2026-06-02T01:00:00Z"
+      },
+      "latestPipelineJob": {
+        "id": 20,
+        "jobType": "DOMAIN_PACK_GENERATION",
+        "status": "SUCCEEDED",
+        "requestedAt": "2026-06-02T02:00:00Z",
+        "startedAt": "2026-06-02T02:01:00Z",
+        "finishedAt": "2026-06-02T02:05:00Z"
+      }
+    }
+  ],
+  "page": 0,
+  "size": 20,
+  "hasNext": false
+}
+```
+
+### `GET /api/v1/admin/customers/{workspaceId}`
+
+Response includes:
+
+- `workspace`: workspace 기본 정보
+- `members`: 총원, role별 count, 최근 가입 멤버 최대 5명
+- `billing`: subscription summary, payment 구현 전에는 null fields
+- `latestUpload`: 최근 dataset upload summary
+- `pipeline`: 총 job 수, running/succeeded/failed count, 최근 job 최대 5개
+
+## Frontend Behavior
+
+- `/admin/customers`는 목록 대시보드를 렌더링한다.
+- 검색 입력은 고객사명과 workspace key 기준으로 동작한다.
+- 상태 필터는 전체/활성/보관 상태를 제공한다.
+- 고객사 행을 선택하면 같은 화면 안에서 상세 패널을 표시한다.
+- loading, error, empty 상태를 각각 제공한다.
+- billing summary가 null이면 미연동 상태로 표시한다.
+
+## Acceptance Criteria
+
+1. `SUPER_ADMIN`은 `/admin/customers`에서 고객사 현황 메뉴에 접근할 수 있다.
+2. 목록에서 workspace 상태, 멤버 수, 구독 상태, 최근 업로드, 최근 pipeline job 상태를 확인할 수 있다.
+3. 고객사명 또는 workspace key 검색이 API와 화면에서 동작한다.
+4. workspace 상태 필터가 API와 화면에서 동작한다.
+5. 상세 패널에서 workspace 기본 정보, 멤버 요약, billing summary, pipeline summary를 확인할 수 있다.
+6. `OPERATOR` 또는 workspace `ADMIN`은 `/api/v1/admin/customers` API와 `/admin/customers` 화면에 접근할 수 없다.
+7. 목록/상세 loading, error, empty 상태가 제공된다.
+8. 목록 조회는 `size + 1` slice 방식으로 `hasNext`를 계산해 과도한 전체 조회를 피한다.
+
+## Validation Plan
+
+- Backend unit/controller tests:
+  - `GetAdminCustomerListUseCaseTest`
+  - `AdminCustomerControllerTest`
+- Frontend tests:
+  - admin customer API hook parameter 전달
+  - dashboard 검색/필터/empty/error/detail 상태
+- Local commands:
+  - `cd backend && ./gradlew test --tests '*AdminCustomer*'`
+  - `cd frontend && pnpm test -- --run AdminCustomerDashboard adminCustomersApi`
+  - `cd frontend && pnpm exec eslint src/features/admin/api/adminCustomersApi.ts src/features/admin/api/adminCustomersApi.test.ts src/features/admin/ui/AdminCustomerDashboard.tsx src/features/admin/ui/AdminCustomerDashboard.test.tsx src/pages/admin/ui/AdminCustomersPage.tsx src/app/App.tsx`
+
+## Open Questions
+
+- payment bounded context가 구현된 뒤 billing summary source table과 status vocabulary를 확정해야 한다.

--- a/backend/src/main/java/com/init/workspace/application/AdminCustomerBillingSummaryResult.java
+++ b/backend/src/main/java/com/init/workspace/application/AdminCustomerBillingSummaryResult.java
@@ -1,0 +1,14 @@
+package com.init.workspace.application;
+
+import java.time.OffsetDateTime;
+
+public record AdminCustomerBillingSummaryResult(
+    String subscriptionStatus,
+    String planName,
+    OffsetDateTime currentPeriodEnd,
+    OffsetDateTime updatedAt) {
+
+  public static AdminCustomerBillingSummaryResult unavailable() {
+    return new AdminCustomerBillingSummaryResult(null, null, null, null);
+  }
+}

--- a/backend/src/main/java/com/init/workspace/application/AdminCustomerDetailResult.java
+++ b/backend/src/main/java/com/init/workspace/application/AdminCustomerDetailResult.java
@@ -1,0 +1,8 @@
+package com.init.workspace.application;
+
+public record AdminCustomerDetailResult(
+    AdminCustomerWorkspaceResult workspace,
+    AdminCustomerMemberSummaryResult members,
+    AdminCustomerBillingSummaryResult billing,
+    AdminCustomerUploadSummaryResult latestUpload,
+    AdminCustomerPipelineSummaryResult pipeline) {}

--- a/backend/src/main/java/com/init/workspace/application/AdminCustomerListQuery.java
+++ b/backend/src/main/java/com/init/workspace/application/AdminCustomerListQuery.java
@@ -1,0 +1,3 @@
+package com.init.workspace.application;
+
+public record AdminCustomerListQuery(String search, String status, int page, int size) {}

--- a/backend/src/main/java/com/init/workspace/application/AdminCustomerMemberEntryResult.java
+++ b/backend/src/main/java/com/init/workspace/application/AdminCustomerMemberEntryResult.java
@@ -1,0 +1,12 @@
+package com.init.workspace.application;
+
+import java.time.OffsetDateTime;
+
+public record AdminCustomerMemberEntryResult(
+    Long memberId,
+    Long userId,
+    String name,
+    String email,
+    String workspaceRole,
+    String accountStatus,
+    OffsetDateTime joinedAt) {}

--- a/backend/src/main/java/com/init/workspace/application/AdminCustomerMemberSummaryResult.java
+++ b/backend/src/main/java/com/init/workspace/application/AdminCustomerMemberSummaryResult.java
@@ -1,0 +1,11 @@
+package com.init.workspace.application;
+
+import java.util.List;
+
+public record AdminCustomerMemberSummaryResult(
+    long totalCount,
+    long ownerCount,
+    long adminCount,
+    long reviewerCount,
+    long operatorCount,
+    List<AdminCustomerMemberEntryResult> recentMembers) {}

--- a/backend/src/main/java/com/init/workspace/application/AdminCustomerPipelineJobResult.java
+++ b/backend/src/main/java/com/init/workspace/application/AdminCustomerPipelineJobResult.java
@@ -1,0 +1,11 @@
+package com.init.workspace.application;
+
+import java.time.OffsetDateTime;
+
+public record AdminCustomerPipelineJobResult(
+    Long id,
+    String jobType,
+    String status,
+    OffsetDateTime requestedAt,
+    OffsetDateTime startedAt,
+    OffsetDateTime finishedAt) {}

--- a/backend/src/main/java/com/init/workspace/application/AdminCustomerPipelineSummaryResult.java
+++ b/backend/src/main/java/com/init/workspace/application/AdminCustomerPipelineSummaryResult.java
@@ -1,0 +1,11 @@
+package com.init.workspace.application;
+
+import java.util.List;
+
+public record AdminCustomerPipelineSummaryResult(
+    long totalCount,
+    long runningCount,
+    long succeededCount,
+    long failedCount,
+    AdminCustomerPipelineJobResult latestJob,
+    List<AdminCustomerPipelineJobResult> recentJobs) {}

--- a/backend/src/main/java/com/init/workspace/application/AdminCustomerQueryPort.java
+++ b/backend/src/main/java/com/init/workspace/application/AdminCustomerQueryPort.java
@@ -1,0 +1,10 @@
+package com.init.workspace.application;
+
+import java.util.Optional;
+
+public interface AdminCustomerQueryPort {
+
+  AdminCustomerSliceResult findCustomers(AdminCustomerListQuery query);
+
+  Optional<AdminCustomerDetailResult> findCustomerDetail(Long workspaceId);
+}

--- a/backend/src/main/java/com/init/workspace/application/AdminCustomerSliceResult.java
+++ b/backend/src/main/java/com/init/workspace/application/AdminCustomerSliceResult.java
@@ -1,0 +1,6 @@
+package com.init.workspace.application;
+
+import java.util.List;
+
+public record AdminCustomerSliceResult(
+    List<AdminCustomerSummaryResult> content, int page, int size, boolean hasNext) {}

--- a/backend/src/main/java/com/init/workspace/application/AdminCustomerSummaryResult.java
+++ b/backend/src/main/java/com/init/workspace/application/AdminCustomerSummaryResult.java
@@ -1,0 +1,8 @@
+package com.init.workspace.application;
+
+public record AdminCustomerSummaryResult(
+    AdminCustomerWorkspaceResult workspace,
+    long memberCount,
+    AdminCustomerBillingSummaryResult billing,
+    AdminCustomerUploadSummaryResult latestUpload,
+    AdminCustomerPipelineJobResult latestPipelineJob) {}

--- a/backend/src/main/java/com/init/workspace/application/AdminCustomerUploadSummaryResult.java
+++ b/backend/src/main/java/com/init/workspace/application/AdminCustomerUploadSummaryResult.java
@@ -1,0 +1,6 @@
+package com.init.workspace.application;
+
+import java.time.OffsetDateTime;
+
+public record AdminCustomerUploadSummaryResult(
+    Long datasetId, String datasetKey, String name, String status, OffsetDateTime uploadedAt) {}

--- a/backend/src/main/java/com/init/workspace/application/AdminCustomerWorkspaceResult.java
+++ b/backend/src/main/java/com/init/workspace/application/AdminCustomerWorkspaceResult.java
@@ -1,0 +1,12 @@
+package com.init.workspace.application;
+
+import java.time.OffsetDateTime;
+
+public record AdminCustomerWorkspaceResult(
+    Long id,
+    String workspaceKey,
+    String name,
+    String description,
+    String status,
+    OffsetDateTime createdAt,
+    OffsetDateTime updatedAt) {}

--- a/backend/src/main/java/com/init/workspace/application/GetAdminCustomerDetailUseCase.java
+++ b/backend/src/main/java/com/init/workspace/application/GetAdminCustomerDetailUseCase.java
@@ -1,0 +1,22 @@
+package com.init.workspace.application;
+
+import com.init.shared.application.exception.NotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class GetAdminCustomerDetailUseCase {
+
+  private final AdminCustomerQueryPort adminCustomerQueryPort;
+
+  public GetAdminCustomerDetailUseCase(AdminCustomerQueryPort adminCustomerQueryPort) {
+    this.adminCustomerQueryPort = adminCustomerQueryPort;
+  }
+
+  public AdminCustomerDetailResult execute(Long workspaceId) {
+    return adminCustomerQueryPort
+        .findCustomerDetail(workspaceId)
+        .orElseThrow(() -> new NotFoundException("WORKSPACE_NOT_FOUND", "워크스페이스를 찾을 수 없습니다."));
+  }
+}

--- a/backend/src/main/java/com/init/workspace/application/GetAdminCustomerListUseCase.java
+++ b/backend/src/main/java/com/init/workspace/application/GetAdminCustomerListUseCase.java
@@ -1,0 +1,58 @@
+package com.init.workspace.application;
+
+import com.init.shared.application.exception.BadRequestException;
+import java.util.Locale;
+import java.util.Set;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class GetAdminCustomerListUseCase {
+
+  private static final int DEFAULT_PAGE_SIZE = 20;
+  private static final int MAX_PAGE_SIZE = 100;
+  private static final Set<String> WORKSPACE_STATUSES = Set.of("ACTIVE", "ARCHIVED");
+
+  private final AdminCustomerQueryPort adminCustomerQueryPort;
+
+  public GetAdminCustomerListUseCase(AdminCustomerQueryPort adminCustomerQueryPort) {
+    this.adminCustomerQueryPort = adminCustomerQueryPort;
+  }
+
+  public AdminCustomerSliceResult execute(
+      String search, String status, Integer page, Integer size) {
+    int normalizedPage = page == null ? 0 : page;
+    int normalizedSize = size == null ? DEFAULT_PAGE_SIZE : size;
+    if (normalizedPage < 0) {
+      throw new BadRequestException("INVALID_PAGE", "page는 0 이상이어야 합니다.");
+    }
+    if (normalizedSize < 1 || normalizedSize > MAX_PAGE_SIZE) {
+      throw new BadRequestException("INVALID_PAGE_SIZE", "size는 1 이상 100 이하이어야 합니다.");
+    }
+    String normalizedSearch = normalizeSearch(search);
+    String normalizedStatus = normalizeStatus(status);
+    return adminCustomerQueryPort.findCustomers(
+        new AdminCustomerListQuery(
+            normalizedSearch, normalizedStatus, normalizedPage, normalizedSize));
+  }
+
+  private String normalizeSearch(String search) {
+    if (search == null || search.isBlank()) {
+      return null;
+    }
+    return search.trim();
+  }
+
+  private String normalizeStatus(String status) {
+    if (status == null || status.isBlank()) {
+      return null;
+    }
+    String normalized = status.trim().toUpperCase(Locale.ROOT);
+    if (!WORKSPACE_STATUSES.contains(normalized)) {
+      throw new BadRequestException(
+          "INVALID_WORKSPACE_STATUS", "지원하지 않는 workspace status입니다: " + status);
+    }
+    return normalized;
+  }
+}

--- a/backend/src/main/java/com/init/workspace/infrastructure/persistence/JdbcAdminCustomerQueryAdapter.java
+++ b/backend/src/main/java/com/init/workspace/infrastructure/persistence/JdbcAdminCustomerQueryAdapter.java
@@ -1,0 +1,322 @@
+package com.init.workspace.infrastructure.persistence;
+
+import com.init.workspace.application.AdminCustomerBillingSummaryResult;
+import com.init.workspace.application.AdminCustomerDetailResult;
+import com.init.workspace.application.AdminCustomerListQuery;
+import com.init.workspace.application.AdminCustomerMemberEntryResult;
+import com.init.workspace.application.AdminCustomerMemberSummaryResult;
+import com.init.workspace.application.AdminCustomerPipelineJobResult;
+import com.init.workspace.application.AdminCustomerPipelineSummaryResult;
+import com.init.workspace.application.AdminCustomerQueryPort;
+import com.init.workspace.application.AdminCustomerSliceResult;
+import com.init.workspace.application.AdminCustomerSummaryResult;
+import com.init.workspace.application.AdminCustomerUploadSummaryResult;
+import com.init.workspace.application.AdminCustomerWorkspaceResult;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class JdbcAdminCustomerQueryAdapter implements AdminCustomerQueryPort {
+
+  private final NamedParameterJdbcTemplate jdbcTemplate;
+
+  public JdbcAdminCustomerQueryAdapter(NamedParameterJdbcTemplate jdbcTemplate) {
+    this.jdbcTemplate = jdbcTemplate;
+  }
+
+  @Override
+  public AdminCustomerSliceResult findCustomers(AdminCustomerListQuery query) {
+    MapSqlParameterSource params =
+        new MapSqlParameterSource()
+            .addValue("search", likePattern(query.search()))
+            .addValue("status", query.status())
+            .addValue("limit", query.size() + 1)
+            .addValue("offset", query.page() * query.size());
+    List<AdminCustomerSummaryResult> rows =
+        jdbcTemplate.query(
+            """
+            SELECT
+              w.id,
+              w.workspace_key,
+              w.name,
+              w.description,
+              w.status,
+              w.created_at,
+              w.updated_at,
+              (SELECT COUNT(*) FROM app.workspace_member wm WHERE wm.workspace_id = w.id) AS member_count,
+              d.id AS dataset_id,
+              d.dataset_key,
+              d.name AS dataset_name,
+              d.status AS dataset_status,
+              d.created_at AS dataset_created_at,
+              pj.id AS pipeline_job_id,
+              pj.job_type,
+              pj.status AS pipeline_status,
+              pj.requested_at,
+              pj.started_at,
+              pj.finished_at
+            FROM app.workspace w
+            LEFT JOIN LATERAL (
+              SELECT id, dataset_key, name, status, created_at
+              FROM corpus.dataset
+              WHERE workspace_id = w.id
+              ORDER BY created_at DESC, id DESC
+              LIMIT 1
+            ) d ON TRUE
+            LEFT JOIN LATERAL (
+              SELECT id, job_type, status, requested_at, started_at, finished_at
+              FROM pipeline.pipeline_job
+              WHERE workspace_id = w.id
+              ORDER BY requested_at DESC, id DESC
+              LIMIT 1
+            ) pj ON TRUE
+            WHERE (:search IS NULL OR LOWER(w.name) LIKE :search OR LOWER(w.workspace_key) LIKE :search)
+              AND (:status IS NULL OR w.status = :status)
+            ORDER BY w.id DESC
+            LIMIT :limit OFFSET :offset
+            """,
+            params,
+            (rs, rowNum) -> mapSummary(rs));
+    boolean hasNext = rows.size() > query.size();
+    List<AdminCustomerSummaryResult> content = hasNext ? rows.subList(0, query.size()) : rows;
+    return new AdminCustomerSliceResult(content, query.page(), query.size(), hasNext);
+  }
+
+  @Override
+  public Optional<AdminCustomerDetailResult> findCustomerDetail(Long workspaceId) {
+    Optional<AdminCustomerWorkspaceResult> workspace = findWorkspace(workspaceId);
+    if (workspace.isEmpty()) {
+      return Optional.empty();
+    }
+    AdminCustomerUploadSummaryResult latestUpload = findLatestUpload(workspaceId);
+    AdminCustomerPipelineSummaryResult pipeline = findPipelineSummary(workspaceId);
+    return Optional.of(
+        new AdminCustomerDetailResult(
+            workspace.get(),
+            findMemberSummary(workspaceId),
+            AdminCustomerBillingSummaryResult.unavailable(),
+            latestUpload,
+            pipeline));
+  }
+
+  private Optional<AdminCustomerWorkspaceResult> findWorkspace(Long workspaceId) {
+    List<AdminCustomerWorkspaceResult> rows =
+        jdbcTemplate.query(
+            """
+            SELECT id, workspace_key, name, description, status, created_at, updated_at
+            FROM app.workspace
+            WHERE id = :workspaceId
+            """,
+            Map.of("workspaceId", workspaceId),
+            (rs, rowNum) -> mapWorkspace(rs));
+    return rows.stream().findFirst();
+  }
+
+  private AdminCustomerMemberSummaryResult findMemberSummary(Long workspaceId) {
+    MapSqlParameterSource params = new MapSqlParameterSource("workspaceId", workspaceId);
+    AdminCustomerMemberSummaryResult counts =
+        jdbcTemplate.queryForObject(
+            """
+            SELECT
+              COUNT(*) AS total_count,
+              COUNT(*) FILTER (WHERE member_role = 'OWNER') AS owner_count,
+              COUNT(*) FILTER (WHERE member_role = 'ADMIN') AS admin_count,
+              COUNT(*) FILTER (WHERE member_role = 'REVIEWER') AS reviewer_count,
+              COUNT(*) FILTER (WHERE member_role = 'OPERATOR') AS operator_count
+            FROM app.workspace_member
+            WHERE workspace_id = :workspaceId
+            """,
+            params,
+            (rs, rowNum) ->
+                new AdminCustomerMemberSummaryResult(
+                    rs.getLong("total_count"),
+                    rs.getLong("owner_count"),
+                    rs.getLong("admin_count"),
+                    rs.getLong("reviewer_count"),
+                    rs.getLong("operator_count"),
+                    List.of()));
+    List<AdminCustomerMemberEntryResult> recentMembers =
+        jdbcTemplate.query(
+            """
+            SELECT
+              wm.id AS member_id,
+              wm.user_id,
+              u.name,
+              u.email,
+              wm.member_role,
+              u.status AS account_status,
+              wm.joined_at
+            FROM app.workspace_member wm
+            JOIN app.app_user u ON u.id = wm.user_id
+            WHERE wm.workspace_id = :workspaceId
+            ORDER BY wm.joined_at DESC, wm.id DESC
+            LIMIT 5
+            """,
+            params,
+            (rs, rowNum) ->
+                new AdminCustomerMemberEntryResult(
+                    rs.getLong("member_id"),
+                    rs.getLong("user_id"),
+                    rs.getString("name"),
+                    rs.getString("email"),
+                    rs.getString("member_role"),
+                    rs.getString("account_status"),
+                    offsetDateTime(rs, "joined_at")));
+    return new AdminCustomerMemberSummaryResult(
+        counts.totalCount(),
+        counts.ownerCount(),
+        counts.adminCount(),
+        counts.reviewerCount(),
+        counts.operatorCount(),
+        recentMembers);
+  }
+
+  private AdminCustomerUploadSummaryResult findLatestUpload(Long workspaceId) {
+    List<AdminCustomerUploadSummaryResult> rows =
+        jdbcTemplate.query(
+            """
+            SELECT
+              id AS dataset_id,
+              dataset_key,
+              name AS dataset_name,
+              status AS dataset_status,
+              created_at AS dataset_created_at
+            FROM corpus.dataset
+            WHERE workspace_id = :workspaceId
+            ORDER BY created_at DESC, id DESC
+            LIMIT 1
+            """,
+            Map.of("workspaceId", workspaceId),
+            (rs, rowNum) -> mapUpload(rs));
+    return rows.stream().findFirst().orElse(null);
+  }
+
+  private AdminCustomerPipelineSummaryResult findPipelineSummary(Long workspaceId) {
+    MapSqlParameterSource params = new MapSqlParameterSource("workspaceId", workspaceId);
+    AdminCustomerPipelineSummaryResult counts =
+        jdbcTemplate.queryForObject(
+            """
+            SELECT
+              COUNT(*) AS total_count,
+              COUNT(*) FILTER (
+                WHERE status IN (
+                  'QUEUED',
+                  'RUNNING',
+                  'WAITING_DOMAIN_CONFIRMATION',
+                  'WAITING_HUMAN_FEEDBACK',
+                  'WAITING_INTENT_CALLBACK',
+                  'WAITING_WORKFLOW_CALLBACK'
+                )
+              ) AS running_count,
+              COUNT(*) FILTER (WHERE status = 'SUCCEEDED') AS succeeded_count,
+              COUNT(*) FILTER (WHERE status = 'FAILED') AS failed_count
+            FROM pipeline.pipeline_job
+            WHERE workspace_id = :workspaceId
+            """,
+            params,
+            (rs, rowNum) ->
+                new AdminCustomerPipelineSummaryResult(
+                    rs.getLong("total_count"),
+                    rs.getLong("running_count"),
+                    rs.getLong("succeeded_count"),
+                    rs.getLong("failed_count"),
+                    null,
+                    List.of()));
+    List<AdminCustomerPipelineJobResult> recentJobs =
+        jdbcTemplate.query(
+            """
+            SELECT
+              id AS pipeline_job_id,
+              job_type,
+              status AS pipeline_status,
+              requested_at,
+              started_at,
+              finished_at
+            FROM pipeline.pipeline_job
+            WHERE workspace_id = :workspaceId
+            ORDER BY requested_at DESC, id DESC
+            LIMIT 5
+            """,
+            params,
+            (rs, rowNum) -> mapPipelineJob(rs, "pipeline_"));
+    AdminCustomerPipelineJobResult latestJob = recentJobs.isEmpty() ? null : recentJobs.getFirst();
+    return new AdminCustomerPipelineSummaryResult(
+        counts.totalCount(),
+        counts.runningCount(),
+        counts.succeededCount(),
+        counts.failedCount(),
+        latestJob,
+        recentJobs);
+  }
+
+  private AdminCustomerSummaryResult mapSummary(ResultSet rs) throws SQLException {
+    return new AdminCustomerSummaryResult(
+        mapWorkspace(rs),
+        rs.getLong("member_count"),
+        AdminCustomerBillingSummaryResult.unavailable(),
+        mapUpload(rs),
+        mapPipelineJob(rs, "pipeline_"));
+  }
+
+  private AdminCustomerWorkspaceResult mapWorkspace(ResultSet rs) throws SQLException {
+    return new AdminCustomerWorkspaceResult(
+        rs.getLong("id"),
+        rs.getString("workspace_key"),
+        rs.getString("name"),
+        rs.getString("description"),
+        rs.getString("status"),
+        offsetDateTime(rs, "created_at"),
+        offsetDateTime(rs, "updated_at"));
+  }
+
+  private AdminCustomerUploadSummaryResult mapUpload(ResultSet rs) throws SQLException {
+    Long datasetId = nullableLong(rs, "dataset_id");
+    if (datasetId == null) {
+      return null;
+    }
+    return new AdminCustomerUploadSummaryResult(
+        datasetId,
+        rs.getString("dataset_key"),
+        rs.getString("dataset_name"),
+        rs.getString("dataset_status"),
+        offsetDateTime(rs, "dataset_created_at"));
+  }
+
+  private AdminCustomerPipelineJobResult mapPipelineJob(ResultSet rs, String prefix)
+      throws SQLException {
+    Long id = nullableLong(rs, prefix + "job_id");
+    if (id == null) {
+      return null;
+    }
+    return new AdminCustomerPipelineJobResult(
+        id,
+        rs.getString("job_type"),
+        rs.getString(prefix + "status"),
+        offsetDateTime(rs, "requested_at"),
+        offsetDateTime(rs, "started_at"),
+        offsetDateTime(rs, "finished_at"));
+  }
+
+  private String likePattern(String value) {
+    if (value == null) {
+      return null;
+    }
+    return "%" + value.toLowerCase() + "%";
+  }
+
+  private Long nullableLong(ResultSet rs, String columnName) throws SQLException {
+    long value = rs.getLong(columnName);
+    return rs.wasNull() ? null : value;
+  }
+
+  private OffsetDateTime offsetDateTime(ResultSet rs, String columnName) throws SQLException {
+    return rs.getObject(columnName, OffsetDateTime.class);
+  }
+}

--- a/backend/src/main/java/com/init/workspace/presentation/AdminCustomerController.java
+++ b/backend/src/main/java/com/init/workspace/presentation/AdminCustomerController.java
@@ -1,0 +1,41 @@
+package com.init.workspace.presentation;
+
+import com.init.workspace.application.GetAdminCustomerDetailUseCase;
+import com.init.workspace.application.GetAdminCustomerListUseCase;
+import com.init.workspace.presentation.dto.AdminCustomerDetailResponse;
+import com.init.workspace.presentation.dto.AdminCustomerSliceResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/admin/customers")
+public class AdminCustomerController {
+
+  private final GetAdminCustomerListUseCase getAdminCustomerListUseCase;
+  private final GetAdminCustomerDetailUseCase getAdminCustomerDetailUseCase;
+
+  public AdminCustomerController(
+      GetAdminCustomerListUseCase getAdminCustomerListUseCase,
+      GetAdminCustomerDetailUseCase getAdminCustomerDetailUseCase) {
+    this.getAdminCustomerListUseCase = getAdminCustomerListUseCase;
+    this.getAdminCustomerDetailUseCase = getAdminCustomerDetailUseCase;
+  }
+
+  @GetMapping
+  public AdminCustomerSliceResponse list(
+      @RequestParam(required = false) String q,
+      @RequestParam(required = false) String status,
+      @RequestParam(required = false) Integer page,
+      @RequestParam(required = false) Integer size) {
+    return AdminCustomerSliceResponse.from(
+        getAdminCustomerListUseCase.execute(q, status, page, size));
+  }
+
+  @GetMapping("/{workspaceId}")
+  public AdminCustomerDetailResponse detail(@PathVariable Long workspaceId) {
+    return AdminCustomerDetailResponse.from(getAdminCustomerDetailUseCase.execute(workspaceId));
+  }
+}

--- a/backend/src/main/java/com/init/workspace/presentation/dto/AdminCustomerBillingSummaryResponse.java
+++ b/backend/src/main/java/com/init/workspace/presentation/dto/AdminCustomerBillingSummaryResponse.java
@@ -1,0 +1,22 @@
+package com.init.workspace.presentation.dto;
+
+import com.init.workspace.application.AdminCustomerBillingSummaryResult;
+import java.time.OffsetDateTime;
+
+public record AdminCustomerBillingSummaryResponse(
+    String subscriptionStatus,
+    String planName,
+    OffsetDateTime currentPeriodEnd,
+    OffsetDateTime updatedAt) {
+
+  static AdminCustomerBillingSummaryResponse from(AdminCustomerBillingSummaryResult result) {
+    if (result == null) {
+      return new AdminCustomerBillingSummaryResponse(null, null, null, null);
+    }
+    return new AdminCustomerBillingSummaryResponse(
+        result.subscriptionStatus(),
+        result.planName(),
+        result.currentPeriodEnd(),
+        result.updatedAt());
+  }
+}

--- a/backend/src/main/java/com/init/workspace/presentation/dto/AdminCustomerDetailResponse.java
+++ b/backend/src/main/java/com/init/workspace/presentation/dto/AdminCustomerDetailResponse.java
@@ -1,0 +1,20 @@
+package com.init.workspace.presentation.dto;
+
+import com.init.workspace.application.AdminCustomerDetailResult;
+
+public record AdminCustomerDetailResponse(
+    AdminCustomerWorkspaceResponse workspace,
+    AdminCustomerMemberSummaryResponse members,
+    AdminCustomerBillingSummaryResponse billing,
+    AdminCustomerUploadSummaryResponse latestUpload,
+    AdminCustomerPipelineSummaryResponse pipeline) {
+
+  public static AdminCustomerDetailResponse from(AdminCustomerDetailResult result) {
+    return new AdminCustomerDetailResponse(
+        AdminCustomerWorkspaceResponse.from(result.workspace()),
+        AdminCustomerMemberSummaryResponse.from(result.members()),
+        AdminCustomerBillingSummaryResponse.from(result.billing()),
+        AdminCustomerUploadSummaryResponse.from(result.latestUpload()),
+        AdminCustomerPipelineSummaryResponse.from(result.pipeline()));
+  }
+}

--- a/backend/src/main/java/com/init/workspace/presentation/dto/AdminCustomerMemberEntryResponse.java
+++ b/backend/src/main/java/com/init/workspace/presentation/dto/AdminCustomerMemberEntryResponse.java
@@ -1,0 +1,25 @@
+package com.init.workspace.presentation.dto;
+
+import com.init.workspace.application.AdminCustomerMemberEntryResult;
+import java.time.OffsetDateTime;
+
+public record AdminCustomerMemberEntryResponse(
+    Long memberId,
+    Long userId,
+    String name,
+    String email,
+    String workspaceRole,
+    String accountStatus,
+    OffsetDateTime joinedAt) {
+
+  static AdminCustomerMemberEntryResponse from(AdminCustomerMemberEntryResult result) {
+    return new AdminCustomerMemberEntryResponse(
+        result.memberId(),
+        result.userId(),
+        result.name(),
+        result.email(),
+        result.workspaceRole(),
+        result.accountStatus(),
+        result.joinedAt());
+  }
+}

--- a/backend/src/main/java/com/init/workspace/presentation/dto/AdminCustomerMemberSummaryResponse.java
+++ b/backend/src/main/java/com/init/workspace/presentation/dto/AdminCustomerMemberSummaryResponse.java
@@ -1,0 +1,23 @@
+package com.init.workspace.presentation.dto;
+
+import com.init.workspace.application.AdminCustomerMemberSummaryResult;
+import java.util.List;
+
+public record AdminCustomerMemberSummaryResponse(
+    long totalCount,
+    long ownerCount,
+    long adminCount,
+    long reviewerCount,
+    long operatorCount,
+    List<AdminCustomerMemberEntryResponse> recentMembers) {
+
+  static AdminCustomerMemberSummaryResponse from(AdminCustomerMemberSummaryResult result) {
+    return new AdminCustomerMemberSummaryResponse(
+        result.totalCount(),
+        result.ownerCount(),
+        result.adminCount(),
+        result.reviewerCount(),
+        result.operatorCount(),
+        result.recentMembers().stream().map(AdminCustomerMemberEntryResponse::from).toList());
+  }
+}

--- a/backend/src/main/java/com/init/workspace/presentation/dto/AdminCustomerPipelineJobResponse.java
+++ b/backend/src/main/java/com/init/workspace/presentation/dto/AdminCustomerPipelineJobResponse.java
@@ -1,0 +1,26 @@
+package com.init.workspace.presentation.dto;
+
+import com.init.workspace.application.AdminCustomerPipelineJobResult;
+import java.time.OffsetDateTime;
+
+public record AdminCustomerPipelineJobResponse(
+    Long id,
+    String jobType,
+    String status,
+    OffsetDateTime requestedAt,
+    OffsetDateTime startedAt,
+    OffsetDateTime finishedAt) {
+
+  static AdminCustomerPipelineJobResponse from(AdminCustomerPipelineJobResult result) {
+    if (result == null) {
+      return null;
+    }
+    return new AdminCustomerPipelineJobResponse(
+        result.id(),
+        result.jobType(),
+        result.status(),
+        result.requestedAt(),
+        result.startedAt(),
+        result.finishedAt());
+  }
+}

--- a/backend/src/main/java/com/init/workspace/presentation/dto/AdminCustomerPipelineSummaryResponse.java
+++ b/backend/src/main/java/com/init/workspace/presentation/dto/AdminCustomerPipelineSummaryResponse.java
@@ -1,0 +1,23 @@
+package com.init.workspace.presentation.dto;
+
+import com.init.workspace.application.AdminCustomerPipelineSummaryResult;
+import java.util.List;
+
+public record AdminCustomerPipelineSummaryResponse(
+    long totalCount,
+    long runningCount,
+    long succeededCount,
+    long failedCount,
+    AdminCustomerPipelineJobResponse latestJob,
+    List<AdminCustomerPipelineJobResponse> recentJobs) {
+
+  static AdminCustomerPipelineSummaryResponse from(AdminCustomerPipelineSummaryResult result) {
+    return new AdminCustomerPipelineSummaryResponse(
+        result.totalCount(),
+        result.runningCount(),
+        result.succeededCount(),
+        result.failedCount(),
+        AdminCustomerPipelineJobResponse.from(result.latestJob()),
+        result.recentJobs().stream().map(AdminCustomerPipelineJobResponse::from).toList());
+  }
+}

--- a/backend/src/main/java/com/init/workspace/presentation/dto/AdminCustomerSliceResponse.java
+++ b/backend/src/main/java/com/init/workspace/presentation/dto/AdminCustomerSliceResponse.java
@@ -1,0 +1,16 @@
+package com.init.workspace.presentation.dto;
+
+import com.init.workspace.application.AdminCustomerSliceResult;
+import java.util.List;
+
+public record AdminCustomerSliceResponse(
+    List<AdminCustomerSummaryResponse> content, int page, int size, boolean hasNext) {
+
+  public static AdminCustomerSliceResponse from(AdminCustomerSliceResult result) {
+    return new AdminCustomerSliceResponse(
+        result.content().stream().map(AdminCustomerSummaryResponse::from).toList(),
+        result.page(),
+        result.size(),
+        result.hasNext());
+  }
+}

--- a/backend/src/main/java/com/init/workspace/presentation/dto/AdminCustomerSummaryResponse.java
+++ b/backend/src/main/java/com/init/workspace/presentation/dto/AdminCustomerSummaryResponse.java
@@ -1,0 +1,20 @@
+package com.init.workspace.presentation.dto;
+
+import com.init.workspace.application.AdminCustomerSummaryResult;
+
+public record AdminCustomerSummaryResponse(
+    AdminCustomerWorkspaceResponse workspace,
+    long memberCount,
+    AdminCustomerBillingSummaryResponse billing,
+    AdminCustomerUploadSummaryResponse latestUpload,
+    AdminCustomerPipelineJobResponse latestPipelineJob) {
+
+  static AdminCustomerSummaryResponse from(AdminCustomerSummaryResult result) {
+    return new AdminCustomerSummaryResponse(
+        AdminCustomerWorkspaceResponse.from(result.workspace()),
+        result.memberCount(),
+        AdminCustomerBillingSummaryResponse.from(result.billing()),
+        AdminCustomerUploadSummaryResponse.from(result.latestUpload()),
+        AdminCustomerPipelineJobResponse.from(result.latestPipelineJob()));
+  }
+}

--- a/backend/src/main/java/com/init/workspace/presentation/dto/AdminCustomerUploadSummaryResponse.java
+++ b/backend/src/main/java/com/init/workspace/presentation/dto/AdminCustomerUploadSummaryResponse.java
@@ -1,0 +1,20 @@
+package com.init.workspace.presentation.dto;
+
+import com.init.workspace.application.AdminCustomerUploadSummaryResult;
+import java.time.OffsetDateTime;
+
+public record AdminCustomerUploadSummaryResponse(
+    Long datasetId, String datasetKey, String name, String status, OffsetDateTime uploadedAt) {
+
+  static AdminCustomerUploadSummaryResponse from(AdminCustomerUploadSummaryResult result) {
+    if (result == null) {
+      return null;
+    }
+    return new AdminCustomerUploadSummaryResponse(
+        result.datasetId(),
+        result.datasetKey(),
+        result.name(),
+        result.status(),
+        result.uploadedAt());
+  }
+}

--- a/backend/src/main/java/com/init/workspace/presentation/dto/AdminCustomerWorkspaceResponse.java
+++ b/backend/src/main/java/com/init/workspace/presentation/dto/AdminCustomerWorkspaceResponse.java
@@ -1,0 +1,25 @@
+package com.init.workspace.presentation.dto;
+
+import com.init.workspace.application.AdminCustomerWorkspaceResult;
+import java.time.OffsetDateTime;
+
+public record AdminCustomerWorkspaceResponse(
+    Long id,
+    String workspaceKey,
+    String name,
+    String description,
+    String status,
+    OffsetDateTime createdAt,
+    OffsetDateTime updatedAt) {
+
+  static AdminCustomerWorkspaceResponse from(AdminCustomerWorkspaceResult result) {
+    return new AdminCustomerWorkspaceResponse(
+        result.id(),
+        result.workspaceKey(),
+        result.name(),
+        result.description(),
+        result.status(),
+        result.createdAt(),
+        result.updatedAt());
+  }
+}

--- a/backend/src/test/java/com/init/workspace/application/GetAdminCustomerListUseCaseTest.java
+++ b/backend/src/test/java/com/init/workspace/application/GetAdminCustomerListUseCaseTest.java
@@ -1,0 +1,62 @@
+package com.init.workspace.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.init.shared.application.exception.BadRequestException;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetAdminCustomerListUseCase")
+class GetAdminCustomerListUseCaseTest {
+
+  @Mock private AdminCustomerQueryPort adminCustomerQueryPort;
+
+  private GetAdminCustomerListUseCase useCase;
+
+  @BeforeEach
+  void setUp() {
+    useCase = new GetAdminCustomerListUseCase(adminCustomerQueryPort);
+  }
+
+  @Test
+  @DisplayName("execute: 검색어와 상태를 정규화해 고객사 slice를 조회한다")
+  void should_고객사Slice조회_when_검색어와상태전달() {
+    given(adminCustomerQueryPort.findCustomers(org.mockito.ArgumentMatchers.any()))
+        .willReturn(new AdminCustomerSliceResult(List.of(), 1, 10, false));
+
+    AdminCustomerSliceResult result = useCase.execute(" acme ", " active ", 1, 10);
+
+    ArgumentCaptor<AdminCustomerListQuery> captor =
+        ArgumentCaptor.forClass(AdminCustomerListQuery.class);
+    verify(adminCustomerQueryPort).findCustomers(captor.capture());
+    assertThat(captor.getValue()).isEqualTo(new AdminCustomerListQuery("acme", "ACTIVE", 1, 10));
+    assertThat(result.page()).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("execute: 잘못된 workspace status → INVALID_WORKSPACE_STATUS")
+  void should_INVALID_WORKSPACE_STATUS_when_지원하지않는상태() {
+    assertThatThrownBy(() -> useCase.execute(null, "SUSPENDED", 0, 20))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("SUSPENDED");
+  }
+
+  @Test
+  @DisplayName("execute: size 범위 초과 → INVALID_PAGE_SIZE")
+  void should_INVALID_PAGE_SIZE_when_size범위초과() {
+    assertThatThrownBy(() -> useCase.execute(null, null, 0, 101))
+        .isInstanceOf(BadRequestException.class)
+        .extracting("code")
+        .isEqualTo("INVALID_PAGE_SIZE");
+  }
+}

--- a/backend/src/test/java/com/init/workspace/presentation/AdminCustomerControllerTest.java
+++ b/backend/src/test/java/com/init/workspace/presentation/AdminCustomerControllerTest.java
@@ -1,0 +1,167 @@
+package com.init.workspace.presentation;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.init.auth.application.JwtService;
+import com.init.shared.infrastructure.security.ApiAuthenticationEntryPoint;
+import com.init.shared.infrastructure.security.JwtAuthenticationFilter;
+import com.init.shared.infrastructure.security.SecurityConfig;
+import com.init.shared.presentation.GlobalExceptionHandler;
+import com.init.workspace.application.AdminCustomerBillingSummaryResult;
+import com.init.workspace.application.AdminCustomerDetailResult;
+import com.init.workspace.application.AdminCustomerMemberSummaryResult;
+import com.init.workspace.application.AdminCustomerPipelineJobResult;
+import com.init.workspace.application.AdminCustomerPipelineSummaryResult;
+import com.init.workspace.application.AdminCustomerSliceResult;
+import com.init.workspace.application.AdminCustomerSummaryResult;
+import com.init.workspace.application.AdminCustomerUploadSummaryResult;
+import com.init.workspace.application.AdminCustomerWorkspaceResult;
+import com.init.workspace.application.GetAdminCustomerDetailUseCase;
+import com.init.workspace.application.GetAdminCustomerListUseCase;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import java.time.OffsetDateTime;
+import java.util.Date;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(AdminCustomerController.class)
+@Import({
+  SecurityConfig.class,
+  JwtAuthenticationFilter.class,
+  ApiAuthenticationEntryPoint.class,
+  GlobalExceptionHandler.class
+})
+@TestPropertySource(properties = "cors.allowed-origins=http://localhost:5173")
+@DisplayName("AdminCustomerController")
+class AdminCustomerControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private GetAdminCustomerListUseCase getAdminCustomerListUseCase;
+  @MockitoBean private GetAdminCustomerDetailUseCase getAdminCustomerDetailUseCase;
+  @MockitoBean private JwtService jwtService;
+
+  @Test
+  @DisplayName("GET /api/v1/admin/customers: SUPER_ADMIN JWT → 고객사 slice 반환")
+  void should_고객사Slice반환_when_SUPER_ADMIN요청() throws Exception {
+    givenSuperAdminBearerToken("super-admin-token");
+    given(getAdminCustomerListUseCase.execute(eq("acme"), eq("ACTIVE"), eq(0), eq(20)))
+        .willReturn(new AdminCustomerSliceResult(List.of(summary()), 0, 20, false));
+
+    mockMvc
+        .perform(
+            get("/api/v1/admin/customers?q=acme&status=ACTIVE&page=0&size=20")
+                .header("Authorization", "Bearer super-admin-token"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content[0].workspace.id").value(1))
+        .andExpect(jsonPath("$.content[0].workspace.workspaceKey").value("acme"))
+        .andExpect(jsonPath("$.content[0].memberCount").value(3))
+        .andExpect(jsonPath("$.content[0].latestUpload.datasetKey").value("upload-1"))
+        .andExpect(jsonPath("$.content[0].latestPipelineJob.status").value("SUCCEEDED"))
+        .andExpect(jsonPath("$.hasNext").value(false));
+  }
+
+  @Test
+  @DisplayName("GET /api/v1/admin/customers: OPERATOR JWT → 403 Forbidden")
+  void should_403반환_when_OPERATOR요청() throws Exception {
+    givenBearerToken("operator-token", "OPERATOR");
+
+    mockMvc
+        .perform(get("/api/v1/admin/customers").header("Authorization", "Bearer operator-token"))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @DisplayName("GET /api/v1/admin/customers: ADMIN JWT → 403 Forbidden")
+  void should_403반환_when_ADMIN요청() throws Exception {
+    givenBearerToken("admin-token", "ADMIN");
+
+    mockMvc
+        .perform(get("/api/v1/admin/customers").header("Authorization", "Bearer admin-token"))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @DisplayName("GET /api/v1/admin/customers/{workspaceId}: SUPER_ADMIN JWT → 상세 반환")
+  void should_고객사상세반환_when_SUPER_ADMIN요청() throws Exception {
+    givenSuperAdminBearerToken("super-admin-token");
+    given(getAdminCustomerDetailUseCase.execute(1L))
+        .willReturn(
+            new AdminCustomerDetailResult(
+                workspace(),
+                new AdminCustomerMemberSummaryResult(3, 1, 1, 0, 1, List.of()),
+                AdminCustomerBillingSummaryResult.unavailable(),
+                upload(),
+                new AdminCustomerPipelineSummaryResult(
+                    2, 0, 1, 1, pipelineJob(), List.of(pipelineJob()))));
+
+    mockMvc
+        .perform(
+            get("/api/v1/admin/customers/1").header("Authorization", "Bearer super-admin-token"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.workspace.workspaceKey").value("acme"))
+        .andExpect(jsonPath("$.members.totalCount").value(3))
+        .andExpect(jsonPath("$.billing.subscriptionStatus").doesNotExist())
+        .andExpect(jsonPath("$.pipeline.totalCount").value(2));
+  }
+
+  private AdminCustomerSummaryResult summary() {
+    return new AdminCustomerSummaryResult(
+        workspace(), 3, AdminCustomerBillingSummaryResult.unavailable(), upload(), pipelineJob());
+  }
+
+  private AdminCustomerWorkspaceResult workspace() {
+    return new AdminCustomerWorkspaceResult(
+        1L,
+        "acme",
+        "Acme",
+        "고객사",
+        "ACTIVE",
+        OffsetDateTime.parse("2026-06-01T00:00:00Z"),
+        OffsetDateTime.parse("2026-06-02T00:00:00Z"));
+  }
+
+  private AdminCustomerUploadSummaryResult upload() {
+    return new AdminCustomerUploadSummaryResult(
+        10L, "upload-1", "상담 로그", "READY", OffsetDateTime.parse("2026-06-02T01:00:00Z"));
+  }
+
+  private AdminCustomerPipelineJobResult pipelineJob() {
+    return new AdminCustomerPipelineJobResult(
+        20L,
+        "DOMAIN_PACK_GENERATION",
+        "SUCCEEDED",
+        OffsetDateTime.parse("2026-06-02T02:00:00Z"),
+        OffsetDateTime.parse("2026-06-02T02:01:00Z"),
+        OffsetDateTime.parse("2026-06-02T02:05:00Z"));
+  }
+
+  private void givenSuperAdminBearerToken(String token) {
+    givenBearerToken(token, "SUPER_ADMIN");
+  }
+
+  private void givenBearerToken(String token, String role) {
+    Claims claims =
+        Jwts.claims()
+            .subject("1")
+            .add("type", "access")
+            .add("role", role)
+            .expiration(new Date(System.currentTimeMillis() + 60_000))
+            .build();
+    given(jwtService.parseClaims(token)).willReturn(claims);
+    given(jwtService.isTokenValid(claims)).willReturn(true);
+    given(jwtService.isAccessToken(claims)).willReturn(true);
+  }
+}

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -16,6 +16,7 @@ import { ConsultationPage } from "../pages/consultation/ui/ConsultationPage";
 import { UserChatPage } from "../pages/user-chat";
 import { DemoPage } from "../pages/demo";
 import { AdminLayout } from "../pages/admin/ui/AdminLayout";
+import { AdminCustomersPage } from "../pages/admin/ui/AdminCustomersPage";
 import { AdminPlaceholderPage } from "../pages/admin/ui/AdminPlaceholderPage";
 import { AdminSuperAdminsPage } from "../pages/admin/ui/AdminSuperAdminsPage";
 import { NotFoundPage } from "../pages/not-found/ui/NotFoundPage";
@@ -87,7 +88,7 @@ export function App() {
           <Route index element={<Navigate to="super-admins" replace />} />
           <Route
             path="customers"
-            element={<AdminPlaceholderPage eyebrow="Customers" title="고객사 현황" />}
+            element={<AdminCustomersPage />}
           />
           <Route
             path="billing"

--- a/frontend/src/features/admin/api/adminCustomersApi.test.ts
+++ b/frontend/src/features/admin/api/adminCustomersApi.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { apiClient } from "@/shared/api";
+import { getAdminCustomerDetail, listAdminCustomers } from "./adminCustomersApi";
+
+vi.mock("@/shared/api", () => ({
+  apiClient: {
+    get: vi.fn(),
+  },
+}));
+
+const mockedGet = vi.mocked(apiClient.get);
+
+describe("adminCustomersApi", () => {
+  beforeEach(() => {
+    mockedGet.mockReset();
+  });
+
+  it("listAdminCustomers는 검색어와 상태 filter를 query string으로 전달한다", async () => {
+    mockedGet.mockResolvedValueOnce({ content: [], page: 0, size: 20, hasNext: false });
+
+    await listAdminCustomers({ search: " acme ", status: "ACTIVE", page: 0, size: 20 });
+
+    expect(mockedGet).toHaveBeenCalledWith(
+      "/admin/customers?page=0&size=20&q=acme&status=ACTIVE",
+    );
+  });
+
+  it("getAdminCustomerDetail은 workspaceId path로 상세를 조회한다", async () => {
+    mockedGet.mockResolvedValueOnce({});
+
+    await getAdminCustomerDetail(7);
+
+    expect(mockedGet).toHaveBeenCalledWith("/admin/customers/7");
+  });
+});

--- a/frontend/src/features/admin/api/adminCustomersApi.test.ts
+++ b/frontend/src/features/admin/api/adminCustomersApi.test.ts
@@ -1,6 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { useQuery } from "@tanstack/react-query";
 import { apiClient } from "@/shared/api";
-import { getAdminCustomerDetail, listAdminCustomers } from "./adminCustomersApi";
+import {
+  adminCustomerQueryKeys,
+  getAdminCustomerDetail,
+  listAdminCustomers,
+  useAdminCustomerDetail,
+  useAdminCustomers,
+} from "./adminCustomersApi";
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: vi.fn(),
+}));
 
 vi.mock("@/shared/api", () => ({
   apiClient: {
@@ -9,10 +20,12 @@ vi.mock("@/shared/api", () => ({
 }));
 
 const mockedGet = vi.mocked(apiClient.get);
+const mockedUseQuery = vi.mocked(useQuery);
 
 describe("adminCustomersApi", () => {
   beforeEach(() => {
     mockedGet.mockReset();
+    mockedUseQuery.mockReset();
   });
 
   it("listAdminCustomers는 검색어와 상태 filter를 query string으로 전달한다", async () => {
@@ -31,5 +44,35 @@ describe("adminCustomersApi", () => {
     await getAdminCustomerDetail(7);
 
     expect(mockedGet).toHaveBeenCalledWith("/admin/customers/7");
+  });
+
+  it("query key는 검색어를 trim하고 list/detail scope를 분리한다", () => {
+    expect(
+      adminCustomerQueryKeys.list({ search: " acme ", status: "ARCHIVED", page: 2, size: 20 }),
+    ).toEqual(["admin-customers", "list", "acme", "ARCHIVED", 2, 20]);
+    expect(adminCustomerQueryKeys.detail(null)).toEqual(["admin-customers", "detail", null]);
+  });
+
+  it("useAdminCustomers는 list query function을 등록한다", async () => {
+    mockedGet.mockResolvedValueOnce({ content: [], page: 1, size: 10, hasNext: false });
+
+    useAdminCustomers({ search: "", status: "", page: 1, size: 10 });
+
+    const options = mockedUseQuery.mock.calls[0][0];
+    expect(options.queryKey).toEqual(["admin-customers", "list", "", "", 1, 10]);
+    await options.queryFn();
+    expect(mockedGet).toHaveBeenCalledWith("/admin/customers?page=1&size=10");
+  });
+
+  it("useAdminCustomerDetail은 workspaceId가 없으면 query를 비활성화한다", async () => {
+    mockedGet.mockResolvedValueOnce({});
+
+    useAdminCustomerDetail(null);
+
+    const options = mockedUseQuery.mock.calls[0][0];
+    expect(options.enabled).toBe(false);
+    expect(options.queryKey).toEqual(["admin-customers", "detail", null]);
+    await options.queryFn();
+    expect(mockedGet).toHaveBeenCalledWith("/admin/customers/0");
   });
 });

--- a/frontend/src/features/admin/api/adminCustomersApi.ts
+++ b/frontend/src/features/admin/api/adminCustomersApi.ts
@@ -1,0 +1,151 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { apiClient } from "@/shared/api";
+
+// OpenAPI generated endpoints do not include #499 yet; switch this wrapper to generated
+// functions after backend OpenAPI generation is available.
+
+export interface AdminCustomerWorkspace {
+  id: number;
+  workspaceKey: string;
+  name: string;
+  description: string | null;
+  status: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface AdminCustomerBillingSummary {
+  subscriptionStatus: string | null;
+  planName: string | null;
+  currentPeriodEnd: string | null;
+  updatedAt: string | null;
+}
+
+export interface AdminCustomerUploadSummary {
+  datasetId: number;
+  datasetKey: string;
+  name: string;
+  status: string;
+  uploadedAt: string;
+}
+
+export interface AdminCustomerPipelineJob {
+  id: number;
+  jobType: string;
+  status: string;
+  requestedAt: string;
+  startedAt: string | null;
+  finishedAt: string | null;
+}
+
+export interface AdminCustomerSummary {
+  workspace: AdminCustomerWorkspace;
+  memberCount: number;
+  billing: AdminCustomerBillingSummary;
+  latestUpload: AdminCustomerUploadSummary | null;
+  latestPipelineJob: AdminCustomerPipelineJob | null;
+}
+
+export interface AdminCustomerSlice {
+  content: AdminCustomerSummary[];
+  page: number;
+  size: number;
+  hasNext: boolean;
+}
+
+export interface AdminCustomerMemberEntry {
+  memberId: number;
+  userId: number;
+  name: string;
+  email: string;
+  workspaceRole: string;
+  accountStatus: string;
+  joinedAt: string;
+}
+
+export interface AdminCustomerMemberSummary {
+  totalCount: number;
+  ownerCount: number;
+  adminCount: number;
+  reviewerCount: number;
+  operatorCount: number;
+  recentMembers: AdminCustomerMemberEntry[];
+}
+
+export interface AdminCustomerPipelineSummary {
+  totalCount: number;
+  runningCount: number;
+  succeededCount: number;
+  failedCount: number;
+  latestJob: AdminCustomerPipelineJob | null;
+  recentJobs: AdminCustomerPipelineJob[];
+}
+
+export interface AdminCustomerDetail {
+  workspace: AdminCustomerWorkspace;
+  members: AdminCustomerMemberSummary;
+  billing: AdminCustomerBillingSummary;
+  latestUpload: AdminCustomerUploadSummary | null;
+  pipeline: AdminCustomerPipelineSummary;
+}
+
+export interface AdminCustomerListParams {
+  search: string;
+  status: string;
+  page: number;
+  size: number;
+}
+
+export const adminCustomerQueryKeys = {
+  all: ["admin-customers"] as const,
+  list: (params: AdminCustomerListParams) =>
+    [
+      ...adminCustomerQueryKeys.all,
+      "list",
+      params.search.trim(),
+      params.status,
+      params.page,
+      params.size,
+    ] as const,
+  detail: (workspaceId: number | null) =>
+    [...adminCustomerQueryKeys.all, "detail", workspaceId] as const,
+};
+
+function buildQuery(params: AdminCustomerListParams): string {
+  const query = new URLSearchParams({
+    page: String(params.page),
+    size: String(params.size),
+  });
+  const search = params.search.trim();
+  if (search) {
+    query.set("q", search);
+  }
+  if (params.status) {
+    query.set("status", params.status);
+  }
+  return query.toString();
+}
+
+export function listAdminCustomers(params: AdminCustomerListParams): Promise<AdminCustomerSlice> {
+  return apiClient.get<AdminCustomerSlice>(`/admin/customers?${buildQuery(params)}`);
+}
+
+export function getAdminCustomerDetail(workspaceId: number): Promise<AdminCustomerDetail> {
+  return apiClient.get<AdminCustomerDetail>(`/admin/customers/${workspaceId}`);
+}
+
+export function useAdminCustomers(params: AdminCustomerListParams) {
+  return useQuery({
+    queryKey: adminCustomerQueryKeys.list(params),
+    queryFn: () => listAdminCustomers(params),
+  });
+}
+
+export function useAdminCustomerDetail(workspaceId: number | null) {
+  return useQuery({
+    queryKey: adminCustomerQueryKeys.detail(workspaceId),
+    enabled: workspaceId !== null,
+    queryFn: () => getAdminCustomerDetail(workspaceId ?? 0),
+  });
+}

--- a/frontend/src/features/admin/index.ts
+++ b/frontend/src/features/admin/index.ts
@@ -1,3 +1,16 @@
 export { createSuperAdminApi } from "./api/createSuperAdminApi";
 export type { CreateSuperAdminRequest, CreateSuperAdminResponse } from "./api/createSuperAdminApi";
+export {
+  getAdminCustomerDetail,
+  listAdminCustomers,
+  useAdminCustomerDetail,
+  useAdminCustomers,
+} from "./api/adminCustomersApi";
+export type {
+  AdminCustomerDetail,
+  AdminCustomerListParams,
+  AdminCustomerSlice,
+  AdminCustomerSummary,
+} from "./api/adminCustomersApi";
+export { AdminCustomerDashboard } from "./ui/AdminCustomerDashboard";
 export { CreateSuperAdminForm } from "./ui/CreateSuperAdminForm";

--- a/frontend/src/features/admin/ui/AdminCustomerDashboard.test.tsx
+++ b/frontend/src/features/admin/ui/AdminCustomerDashboard.test.tsx
@@ -1,0 +1,171 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import {
+  useAdminCustomerDetail,
+  useAdminCustomers,
+  type AdminCustomerDetail,
+  type AdminCustomerSlice,
+} from "../api/adminCustomersApi";
+import { AdminCustomerDashboard } from "./AdminCustomerDashboard";
+
+vi.mock("../api/adminCustomersApi", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../api/adminCustomersApi")>();
+  return {
+    ...actual,
+    useAdminCustomers: vi.fn(),
+    useAdminCustomerDetail: vi.fn(),
+  };
+});
+
+const mockedUseAdminCustomers = vi.mocked(useAdminCustomers);
+const mockedUseAdminCustomerDetail = vi.mocked(useAdminCustomerDetail);
+
+const listResponse: AdminCustomerSlice = {
+  content: [
+    {
+      workspace: {
+        id: 1,
+        workspaceKey: "acme",
+        name: "Acme",
+        description: "고객사",
+        status: "ACTIVE",
+        createdAt: "2026-06-01T00:00:00Z",
+        updatedAt: "2026-06-02T00:00:00Z",
+      },
+      memberCount: 3,
+      billing: {
+        subscriptionStatus: null,
+        planName: null,
+        currentPeriodEnd: null,
+        updatedAt: null,
+      },
+      latestUpload: {
+        datasetId: 10,
+        datasetKey: "upload-1",
+        name: "상담 로그",
+        status: "READY",
+        uploadedAt: "2026-06-02T01:00:00Z",
+      },
+      latestPipelineJob: {
+        id: 20,
+        jobType: "DOMAIN_PACK_GENERATION",
+        status: "SUCCEEDED",
+        requestedAt: "2026-06-02T02:00:00Z",
+        startedAt: "2026-06-02T02:01:00Z",
+        finishedAt: "2026-06-02T02:05:00Z",
+      },
+    },
+  ],
+  page: 0,
+  size: 20,
+  hasNext: false,
+};
+
+const detailResponse: AdminCustomerDetail = {
+  workspace: listResponse.content[0].workspace,
+  members: {
+    totalCount: 3,
+    ownerCount: 1,
+    adminCount: 1,
+    reviewerCount: 0,
+    operatorCount: 1,
+    recentMembers: [
+      {
+        memberId: 100,
+        userId: 7,
+        name: "운영자",
+        email: "admin@ostone.com",
+        workspaceRole: "ADMIN",
+        accountStatus: "ACTIVE",
+        joinedAt: "2026-06-01T00:00:00Z",
+      },
+    ],
+  },
+  billing: listResponse.content[0].billing,
+  latestUpload: listResponse.content[0].latestUpload,
+  pipeline: {
+    totalCount: 2,
+    runningCount: 0,
+    succeededCount: 1,
+    failedCount: 1,
+    latestJob: listResponse.content[0].latestPipelineJob,
+    recentJobs: [listResponse.content[0].latestPipelineJob],
+  },
+};
+
+describe("AdminCustomerDashboard", () => {
+  beforeEach(() => {
+    mockedUseAdminCustomers.mockReset();
+    mockedUseAdminCustomerDetail.mockReset();
+    mockedUseAdminCustomers.mockReturnValue({
+      data: listResponse,
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as ReturnType<typeof useAdminCustomers>);
+    mockedUseAdminCustomerDetail.mockReturnValue({
+      data: detailResponse,
+      isLoading: false,
+      error: null,
+    } as ReturnType<typeof useAdminCustomerDetail>);
+  });
+
+  it("고객사 목록과 선택된 고객사 상세를 표시한다", async () => {
+    render(<AdminCustomerDashboard />);
+
+    expect(await screen.findByRole("button", { name: /Acme acme/ })).toBeInTheDocument();
+    expect(screen.getAllByText("미연동").length).toBeGreaterThan(0);
+    expect(screen.getByLabelText("고객사 상세")).toHaveTextContent("admin@ostone.com");
+    expect(screen.getByLabelText("고객사 상세")).toHaveTextContent("SUCCEEDED");
+  });
+
+  it("검색 submit과 상태 filter 변경을 query hook params에 반영한다", async () => {
+    const user = userEvent.setup();
+    render(<AdminCustomerDashboard />);
+
+    await user.type(screen.getByPlaceholderText("고객사명 또는 workspace key"), "acme");
+    await user.click(screen.getByRole("button", { name: "검색" }));
+    await user.selectOptions(screen.getByLabelText("상태"), "ARCHIVED");
+
+    expect(mockedUseAdminCustomers).toHaveBeenCalledWith(
+      expect.objectContaining({ search: "acme" }),
+    );
+    expect(mockedUseAdminCustomers).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "ARCHIVED" }),
+    );
+  });
+
+  it("목록이 비어 있으면 empty state를 표시한다", () => {
+    mockedUseAdminCustomers.mockReturnValue({
+      data: { content: [], page: 0, size: 20, hasNext: false },
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as ReturnType<typeof useAdminCustomers>);
+
+    render(<AdminCustomerDashboard />);
+
+    expect(screen.getByText("조건에 맞는 고객사가 없습니다.")).toBeInTheDocument();
+  });
+
+  it("목록 조회 오류를 alert로 표시한다", () => {
+    mockedUseAdminCustomers.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: new Error("boom"),
+    } as ReturnType<typeof useAdminCustomers>);
+
+    render(<AdminCustomerDashboard />);
+
+    expect(screen.getByRole("alert")).toHaveTextContent("고객사 정보를 불러오지 못했습니다.");
+  });
+
+  it("다음 페이지가 없으면 다음 버튼을 비활성화한다", () => {
+    render(<AdminCustomerDashboard />);
+
+    const pagination = screen.getByLabelText("고객사 목록").querySelector("div:last-child");
+    expect(within(pagination as HTMLElement).getByLabelText("다음 페이지")).toBeDisabled();
+  });
+});

--- a/frontend/src/features/admin/ui/AdminCustomerDashboard.test.tsx
+++ b/frontend/src/features/admin/ui/AdminCustomerDashboard.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { ApiRequestError } from "@/shared/api";
 import {
   useAdminCustomerDetail,
   useAdminCustomers,
@@ -162,10 +163,88 @@ describe("AdminCustomerDashboard", () => {
     expect(screen.getByRole("alert")).toHaveTextContent("고객사 정보를 불러오지 못했습니다.");
   });
 
+  it("ApiRequestError가 있으면 서버 메시지를 표시한다", () => {
+    mockedUseAdminCustomers.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: new ApiRequestError(500, "ADMIN_CUSTOMER_ERROR", "서버에서 실패했습니다."),
+    } as ReturnType<typeof useAdminCustomers>);
+
+    render(<AdminCustomerDashboard />);
+
+    expect(screen.getByRole("alert")).toHaveTextContent("서버에서 실패했습니다.");
+  });
+
+  it("목록 loading 상태를 표시한다", () => {
+    mockedUseAdminCustomers.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+      error: null,
+    } as ReturnType<typeof useAdminCustomers>);
+
+    render(<AdminCustomerDashboard />);
+
+    expect(screen.getByText("고객사 현황을 불러오는 중입니다.")).toBeInTheDocument();
+  });
+
   it("다음 페이지가 없으면 다음 버튼을 비활성화한다", () => {
     render(<AdminCustomerDashboard />);
 
     const pagination = screen.getByLabelText("고객사 목록").querySelector("div:last-child");
     expect(within(pagination as HTMLElement).getByLabelText("다음 페이지")).toBeDisabled();
+  });
+
+  it("다음 페이지 이동과 이전 페이지 이동을 query hook params에 반영한다", async () => {
+    const user = userEvent.setup();
+    mockedUseAdminCustomers.mockReturnValue({
+      data: { ...listResponse, hasNext: true },
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as ReturnType<typeof useAdminCustomers>);
+
+    render(<AdminCustomerDashboard />);
+
+    await user.click(screen.getByLabelText("다음 페이지"));
+    expect(mockedUseAdminCustomers).toHaveBeenCalledWith(expect.objectContaining({ page: 1 }));
+
+    await user.click(screen.getByLabelText("이전 페이지"));
+    expect(mockedUseAdminCustomers).toHaveBeenCalledWith(expect.objectContaining({ page: 0 }));
+  });
+
+  it("상세 loading 상태를 표시한다", () => {
+    mockedUseAdminCustomerDetail.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    } as ReturnType<typeof useAdminCustomerDetail>);
+
+    render(<AdminCustomerDashboard />);
+
+    expect(screen.getByText("상세 정보를 불러오는 중입니다.")).toBeInTheDocument();
+  });
+
+  it("상세 오류와 상세 미선택 상태를 표시한다", () => {
+    mockedUseAdminCustomerDetail.mockReturnValueOnce({
+      data: undefined,
+      isLoading: false,
+      error: new ApiRequestError(404, "WORKSPACE_NOT_FOUND", "워크스페이스를 찾을 수 없습니다."),
+    } as ReturnType<typeof useAdminCustomerDetail>);
+
+    const { rerender } = render(<AdminCustomerDashboard />);
+
+    expect(screen.getByRole("alert")).toHaveTextContent("워크스페이스를 찾을 수 없습니다.");
+
+    mockedUseAdminCustomerDetail.mockReturnValueOnce({
+      data: undefined,
+      isLoading: false,
+      error: null,
+    } as ReturnType<typeof useAdminCustomerDetail>);
+
+    rerender(<AdminCustomerDashboard />);
+
+    expect(screen.getByText("선택된 고객사가 없습니다.")).toBeInTheDocument();
   });
 });

--- a/frontend/src/features/admin/ui/AdminCustomerDashboard.tsx
+++ b/frontend/src/features/admin/ui/AdminCustomerDashboard.tsx
@@ -1,0 +1,299 @@
+import { useMemo, useState, type FormEvent } from "react";
+import { ChevronLeft, ChevronRight, Search } from "lucide-react";
+import { ApiRequestError } from "@/shared/api";
+import { Button } from "@/shared/ui/button/Button";
+import {
+  useAdminCustomerDetail,
+  useAdminCustomers,
+  type AdminCustomerDetail,
+  type AdminCustomerSummary,
+} from "../api/adminCustomersApi";
+import styles from "./admin-customer-dashboard.module.css";
+
+const PAGE_SIZE = 20;
+
+function formatDateTime(value: string | null | undefined): string {
+  if (!value) {
+    return "-";
+  }
+  return new Intl.DateTimeFormat("ko-KR", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value));
+}
+
+function formatStatus(value: string | null | undefined): string {
+  return value ?? "미연동";
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof ApiRequestError) {
+    return error.message || "고객사 정보를 불러오지 못했습니다.";
+  }
+  return "고객사 정보를 불러오지 못했습니다.";
+}
+
+export function AdminCustomerDashboard() {
+  const [searchInput, setSearchInput] = useState("");
+  const [search, setSearch] = useState("");
+  const [status, setStatus] = useState("");
+  const [page, setPage] = useState(0);
+  const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<number | null>(null);
+  const listParams = useMemo(
+    () => ({ search, status, page, size: PAGE_SIZE }),
+    [page, search, status],
+  );
+  const customersQuery = useAdminCustomers(listParams);
+  const customers = customersQuery.data?.content ?? [];
+  const selectedWorkspaceIsVisible = customers.some(
+    (customer) => customer.workspace.id === selectedWorkspaceId,
+  );
+  const effectiveSelectedWorkspaceId =
+    selectedWorkspaceIsVisible ? selectedWorkspaceId : (customers[0]?.workspace.id ?? null);
+  const detailQuery = useAdminCustomerDetail(effectiveSelectedWorkspaceId);
+
+  const handleSearch = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setPage(0);
+    setSearch(searchInput.trim());
+  };
+
+  const handleStatusChange = (nextStatus: string) => {
+    setStatus(nextStatus);
+    setPage(0);
+  };
+
+  return (
+    <div className={styles.dashboard}>
+      <form className={styles.toolbar} onSubmit={handleSearch}>
+        <label className={styles.searchField}>
+          <span>검색</span>
+          <div className={styles.searchBox}>
+            <Search size={16} aria-hidden="true" />
+            <input
+              value={searchInput}
+              onChange={(event) => setSearchInput(event.target.value)}
+              placeholder="고객사명 또는 workspace key"
+            />
+          </div>
+        </label>
+        <label className={styles.filterField}>
+          <span>상태</span>
+          <select value={status} onChange={(event) => handleStatusChange(event.target.value)}>
+            <option value="">전체</option>
+            <option value="ACTIVE">활성</option>
+            <option value="ARCHIVED">보관</option>
+          </select>
+        </label>
+        <Button type="submit">
+          <Search size={16} />
+          검색
+        </Button>
+      </form>
+
+      {customersQuery.isLoading && <div className={styles.state}>고객사 현황을 불러오는 중입니다.</div>}
+      {customersQuery.isError && (
+        <div className={styles.state} role="alert">
+          {getErrorMessage(customersQuery.error)}
+        </div>
+      )}
+      {!customersQuery.isLoading && !customersQuery.isError && customers.length === 0 && (
+        <div className={styles.state}>조건에 맞는 고객사가 없습니다.</div>
+      )}
+
+      {customers.length > 0 && (
+        <div className={styles.grid}>
+          <section className={styles.listPanel} aria-label="고객사 목록">
+            <div className={styles.tableWrap}>
+              <table>
+                <thead>
+                  <tr>
+                    <th>고객사</th>
+                    <th>상태</th>
+                    <th>멤버</th>
+                    <th>구독</th>
+                    <th>최근 업로드</th>
+                    <th>최근 파이프라인</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {customers.map((customer) => (
+                    <CustomerRow
+                      key={customer.workspace.id}
+                      customer={customer}
+                      isSelected={customer.workspace.id === effectiveSelectedWorkspaceId}
+                      onSelect={() => setSelectedWorkspaceId(customer.workspace.id)}
+                    />
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <div className={styles.pagination}>
+              <button
+                type="button"
+                onClick={() => setPage((current) => Math.max(0, current - 1))}
+                disabled={page === 0}
+                aria-label="이전 페이지"
+              >
+                <ChevronLeft size={16} />
+              </button>
+              <span>{page + 1}</span>
+              <button
+                type="button"
+                onClick={() => setPage((current) => current + 1)}
+                disabled={!customersQuery.data?.hasNext}
+                aria-label="다음 페이지"
+              >
+                <ChevronRight size={16} />
+              </button>
+            </div>
+          </section>
+
+          <CustomerDetailPanel
+            detail={detailQuery.data}
+            isLoading={detailQuery.isLoading}
+            error={detailQuery.error}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CustomerRow({
+  customer,
+  isSelected,
+  onSelect,
+}: {
+  customer: AdminCustomerSummary;
+  isSelected: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <tr className={isSelected ? styles.selectedRow : ""}>
+      <td>
+        <button
+          type="button"
+          className={styles.customerButton}
+          onClick={onSelect}
+          aria-label={`${customer.workspace.name} ${customer.workspace.workspaceKey}`}
+        >
+          <strong>{customer.workspace.name}</strong>
+          <span>{customer.workspace.workspaceKey}</span>
+        </button>
+      </td>
+      <td>{customer.workspace.status}</td>
+      <td>{customer.memberCount}</td>
+      <td>{formatStatus(customer.billing.subscriptionStatus)}</td>
+      <td>{customer.latestUpload ? formatDateTime(customer.latestUpload.uploadedAt) : "-"}</td>
+      <td>{formatStatus(customer.latestPipelineJob?.status)}</td>
+    </tr>
+  );
+}
+
+function CustomerDetailPanel({
+  detail,
+  isLoading,
+  error,
+}: {
+  detail: AdminCustomerDetail | undefined;
+  isLoading: boolean;
+  error: unknown;
+}) {
+  if (isLoading) {
+    return <aside className={styles.detailPanel}>상세 정보를 불러오는 중입니다.</aside>;
+  }
+  if (error) {
+    return (
+      <aside className={styles.detailPanel} role="alert">
+        {getErrorMessage(error)}
+      </aside>
+    );
+  }
+  if (!detail) {
+    return <aside className={styles.detailPanel}>선택된 고객사가 없습니다.</aside>;
+  }
+  return (
+    <aside className={styles.detailPanel} aria-label="고객사 상세">
+      <div className={styles.detailHeader}>
+        <span>{detail.workspace.workspaceKey}</span>
+        <h2>{detail.workspace.name}</h2>
+        <p>{detail.workspace.description ?? "-"}</p>
+      </div>
+      <div className={styles.metricGrid}>
+        <Metric label="상태" value={detail.workspace.status} />
+        <Metric label="멤버" value={`${detail.members.totalCount}`} />
+        <Metric label="구독" value={formatStatus(detail.billing.subscriptionStatus)} />
+        <Metric label="파이프라인" value={`${detail.pipeline.totalCount}`} />
+      </div>
+      <section className={styles.detailSection}>
+        <h3>멤버 요약</h3>
+        <dl className={styles.compactStats}>
+          <div>
+            <dt>OWNER</dt>
+            <dd>{detail.members.ownerCount}</dd>
+          </div>
+          <div>
+            <dt>ADMIN</dt>
+            <dd>{detail.members.adminCount}</dd>
+          </div>
+          <div>
+            <dt>REVIEWER</dt>
+            <dd>{detail.members.reviewerCount}</dd>
+          </div>
+          <div>
+            <dt>OPERATOR</dt>
+            <dd>{detail.members.operatorCount}</dd>
+          </div>
+        </dl>
+      </section>
+      <section className={styles.detailSection}>
+        <h3>최근 멤버</h3>
+        <ul className={styles.memberList}>
+          {detail.members.recentMembers.length === 0 && <li>멤버 정보가 없습니다.</li>}
+          {detail.members.recentMembers.map((member) => (
+            <li key={member.memberId}>
+              <strong>{member.name}</strong>
+              <span>{member.email}</span>
+              <em>{member.workspaceRole}</em>
+            </li>
+          ))}
+        </ul>
+      </section>
+      <section className={styles.detailSection}>
+        <h3>업로드와 파이프라인</h3>
+        <dl className={styles.definitionList}>
+          <div>
+            <dt>최근 업로드</dt>
+            <dd>
+              {detail.latestUpload
+                ? `${detail.latestUpload.name} · ${formatDateTime(detail.latestUpload.uploadedAt)}`
+                : "-"}
+            </dd>
+          </div>
+          <div>
+            <dt>최근 Job</dt>
+            <dd>{formatStatus(detail.pipeline.latestJob?.status)}</dd>
+          </div>
+          <div>
+            <dt>실행 중</dt>
+            <dd>{detail.pipeline.runningCount}</dd>
+          </div>
+          <div>
+            <dt>실패</dt>
+            <dd>{detail.pipeline.failedCount}</dd>
+          </div>
+        </dl>
+      </section>
+    </aside>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className={styles.metric}>
+      <span>{label}</span>
+      <strong>{value}</strong>
+    </div>
+  );
+}

--- a/frontend/src/features/admin/ui/admin-customer-dashboard.module.css
+++ b/frontend/src/features/admin/ui/admin-customer-dashboard.module.css
@@ -1,0 +1,286 @@
+.dashboard {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.toolbar {
+  display: flex;
+  align-items: end;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.searchField,
+.filterField {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 12px;
+  font-weight: 540;
+}
+
+.searchField {
+  min-width: min(100%, 340px);
+}
+
+.searchBox {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 40px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 0 12px;
+  background: var(--paper);
+}
+
+.searchBox:focus-within,
+.filterField select:focus {
+  border-color: var(--ink);
+  box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.08);
+  outline: none;
+}
+
+.searchBox input {
+  width: 100%;
+  border: 0;
+  background: transparent;
+  color: var(--ink);
+  font: inherit;
+  min-width: 0;
+  outline: none;
+}
+
+.filterField select {
+  min-height: 40px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--paper);
+  color: var(--ink);
+  padding: 0 12px;
+}
+
+.state {
+  border-top: 1px solid var(--line);
+  padding-top: 24px;
+  color: var(--ink-2);
+  font-size: 14px;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(300px, 360px);
+  gap: 24px;
+  align-items: start;
+}
+
+.listPanel,
+.detailPanel {
+  border-top: 1px solid var(--line);
+  padding-top: 24px;
+}
+
+.tableWrap {
+  overflow-x: auto;
+}
+
+.tableWrap table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.tableWrap th {
+  color: var(--ink-2);
+  font-weight: 540;
+  text-align: left;
+}
+
+.tableWrap th,
+.tableWrap td {
+  border-bottom: 1px solid var(--line);
+  padding: 12px 10px;
+  white-space: nowrap;
+}
+
+.selectedRow {
+  background: var(--paper-2);
+}
+
+.customerButton {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  border: 0;
+  background: transparent;
+  color: var(--ink);
+  cursor: pointer;
+  font: inherit;
+  padding: 0;
+  text-align: left;
+}
+
+.customerButton strong {
+  font-weight: 540;
+}
+
+.customerButton span,
+.detailHeader span {
+  color: var(--ink-2);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0;
+}
+
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+  padding-top: 16px;
+}
+
+.pagination button {
+  display: inline-flex;
+  width: 32px;
+  height: 32px;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--line);
+  border-radius: 50%;
+  background: var(--paper);
+  color: var(--ink);
+}
+
+.pagination button:disabled {
+  color: var(--ink-3);
+  cursor: not-allowed;
+}
+
+.detailPanel {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  min-width: 0;
+}
+
+.detailHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.detailHeader h2 {
+  font-size: 24px;
+  font-weight: 540;
+  line-height: 1.2;
+}
+
+.detailHeader p {
+  color: var(--ink-2);
+}
+
+.metricGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.metric {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 12px;
+}
+
+.metric span,
+.detailSection h3,
+.definitionList dt,
+.compactStats dt {
+  color: var(--ink-2);
+  font-size: 12px;
+  font-weight: 540;
+}
+
+.metric strong {
+  display: block;
+  margin-top: 8px;
+  font-size: 18px;
+  font-weight: 540;
+}
+
+.detailSection {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.compactStats,
+.definitionList {
+  display: grid;
+  gap: 8px;
+}
+
+.compactStats {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.compactStats div,
+.definitionList div {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  border-bottom: 1px solid var(--line);
+  padding-bottom: 8px;
+}
+
+.memberList {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.memberList li {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 2px 8px;
+}
+
+.memberList strong,
+.memberList span {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.memberList span {
+  color: var(--ink-2);
+  font-size: 12px;
+}
+
+.memberList em {
+  grid-row: span 2;
+  align-self: center;
+  color: var(--ink-2);
+  font-style: normal;
+  font-size: 12px;
+}
+
+@media (max-width: 1080px) {
+  .grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .toolbar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .searchField {
+    min-width: 0;
+  }
+}

--- a/frontend/src/pages/admin/ui/AdminCustomersPage.test.tsx
+++ b/frontend/src/pages/admin/ui/AdminCustomersPage.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vite-plus/test";
+import { AdminCustomersPage } from "./AdminCustomersPage";
+
+vi.mock("@/features/admin", () => ({
+  AdminCustomerDashboard: () => <div data-testid="admin-customer-dashboard" />,
+}));
+
+describe("AdminCustomersPage", () => {
+  it("고객사 현황 page heading과 dashboard를 표시한다", () => {
+    render(<AdminCustomersPage />);
+
+    expect(screen.getByRole("heading", { name: "고객사 현황" })).toBeInTheDocument();
+    expect(screen.getByTestId("admin-customer-dashboard")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/admin/ui/AdminCustomersPage.tsx
+++ b/frontend/src/pages/admin/ui/AdminCustomersPage.tsx
@@ -1,0 +1,16 @@
+import { AdminCustomerDashboard } from "@/features/admin";
+import styles from "./admin-page.module.css";
+
+export function AdminCustomersPage() {
+  return (
+    <section className={styles.page}>
+      <div className={styles.header}>
+        <p className={styles.eyebrow}>Customers</p>
+        <h1>고객사 현황</h1>
+      </div>
+      <div className={styles.panel}>
+        <AdminCustomerDashboard />
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
Closes #499

## 변경 사항

- `SUPER_ADMIN` 전용 고객사 목록/상세 API에서 workspace 상태, 멤버 수와 멤버 요약, 최근 업로드, 최근 pipeline job 상태를 조회할 수 있습니다.
- `/admin/customers` placeholder를 검색, 상태 필터, slice pagination, 상세 패널을 갖춘 고객사 현황 대시보드로 교체합니다.
- 목록/상세 loading, error, empty 상태를 제공하고, 결제 구현 전 billing summary는 null/미연동 상태로 노출합니다.
- `OPERATOR` 및 workspace `ADMIN` 역할은 admin API 접근이 거부되도록 controller 테스트로 확인했습니다.

## 검증

- `git diff --check`
- `cd backend && mise exec -- ./gradlew spotlessApply`
- `cd backend && mise exec -- ./gradlew test --tests '*AdminCustomer*'`
- `cd frontend && pnpm test -- --run AdminCustomerDashboard adminCustomersApi`
- `cd frontend && pnpm exec eslint src/features/admin/api/adminCustomersApi.ts src/features/admin/api/adminCustomersApi.test.ts src/features/admin/ui/AdminCustomerDashboard.tsx src/features/admin/ui/AdminCustomerDashboard.test.tsx src/pages/admin/ui/AdminCustomersPage.tsx src/app/App.tsx`
- `cd frontend && pnpm build`

## 참고

- `frontend/src/shared/api/generated/`에 #499 endpoint가 아직 없어 admin customer API wrapper에 generated 전환 TODO를 명시했습니다.
- `cd frontend && pnpm lint`는 기존 unrelated lint 오류가 있어, 이번 변경 파일 대상 eslint로 검증했습니다.