### PR TITLE
refactor(consultation): 상담 응대 상태 표시 단순화

### DIFF
--- a/frontend/src/pages/consultation/ui/ConsultationPage.test.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.test.tsx
@@ -1322,8 +1322,7 @@ describe("ConsultationPage", () => {
     expect(screen.getByLabelText("메시지 전송")).toBeDisabled();
   });
 
-  it("updates AI response mode for the assigned session", async () => {
-    const user = userEvent.setup();
+  it("shows counselor response status for the assigned session without mode controls", async () => {
     saveTestUser(7);
 
     render(<ConsultationPage />, { wrapper: Wrapper });
@@ -1338,54 +1337,15 @@ describe("ConsultationPage", () => {
     }
 
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: "AI 보조만 사용" })).toBeEnabled();
+      expect(screen.getAllByText("상담사 응대중").length).toBeGreaterThan(0);
     });
-
-    await user.click(screen.getByRole("button", { name: "AI 보조만 사용" }));
-
-    await waitFor(() => {
-      expect(consultationApi.updateResponseMode).toHaveBeenCalledWith(1, 7, "AI_ASSIST_ONLY");
-    });
-    expect(toast.success).toHaveBeenCalledWith("AI 응대 모드가 변경되었습니다.");
-    await waitFor(() => {
-      expect(screen.getByRole("button", { name: "AI 보조만 사용" })).toHaveAttribute(
-        "aria-pressed",
-        "true",
-      );
-    });
+    expect(screen.getByTestId("conversation-response-status")).toHaveTextContent("상담사 응대중");
+    expect(screen.queryByText("AI MODE")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "AI 보조만 사용" })).not.toBeInTheDocument();
+    expect(consultationApi.updateResponseMode).not.toHaveBeenCalled();
   });
 
-  it("shows an error toast when AI response mode update fails", async () => {
-    const user = userEvent.setup();
-    vi.mocked(consultationApi.updateResponseMode).mockRejectedValueOnce(new Error("forbidden"));
-
-    render(<ConsultationPage />, { wrapper: Wrapper });
-
-    await waitFor(() => {
-      expect(screen.getByText("김민지")).toBeInTheDocument();
-    });
-
-    const customerItem = screen.getByText("김민지").closest('[role="button"]');
-    if (customerItem) {
-      fireEvent.click(customerItem);
-    }
-
-    await waitFor(() => {
-      expect(screen.getByRole("button", { name: "AI 보조만 사용" })).toBeEnabled();
-    });
-
-    await user.click(screen.getByRole("button", { name: "AI 보조만 사용" }));
-
-    await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith("AI 응대 모드 변경에 실패했습니다.");
-    });
-    expect(screen.getByRole("button", { name: "상담사 응대중" })).toHaveAttribute(
-      "aria-pressed",
-      "true",
-    );
-  });
-
-  it("disables AI response mode controls for unassigned sessions", async () => {
+  it("shows AI response status for unassigned sessions without mode controls", async () => {
     vi.mocked(consultationApi.getQueue).mockResolvedValueOnce([
       {
         id: 1,
@@ -1410,10 +1370,13 @@ describe("ConsultationPage", () => {
     }
 
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: "AI 응대중" })).toBeDisabled();
+      expect(screen.getAllByText("AI 응대").length).toBeGreaterThan(0);
     });
-    expect(screen.getByRole("button", { name: "상담사 응대중" })).toBeDisabled();
-    expect(screen.getByRole("button", { name: "AI 보조만 사용" })).toBeDisabled();
+    expect(screen.getByTestId("conversation-response-status")).toHaveTextContent("AI 응대");
+    expect(screen.queryByText("AI MODE")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "AI 응대중" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "상담사 응대중" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "AI 보조만 사용" })).not.toBeInTheDocument();
   });
 
   it("opens confirmation before releasing the current counselor assignment", async () => {

--- a/frontend/src/pages/consultation/ui/ConsultationPage.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.tsx
@@ -22,7 +22,6 @@ import { consultationApi } from "../../../features/consultation/api/consultation
 import type {
   ChatSession,
   ConsultationSessionStatus,
-  ConsultationResponseMode,
   ConsultationMetrics,
   ConsultationQueueEvent,
   ResolutionOutcome,
@@ -106,6 +105,7 @@ type QueueCustomerWithPanelData = QueueCustomer & QueueCustomerPanelData;
 
 const COUNSELOR_MESSAGE_ACK_TIMEOUT_MS = 8000;
 const MESSAGE_PAGE_SIZE = 50;
+const DEFAULT_RESPONSE_MODE = "AI_ACTIVE" as const;
 
 type MessagePaginationState = {
   nextPage: number;
@@ -113,31 +113,6 @@ type MessagePaginationState = {
   isLoadingPrevious: boolean;
 };
 
-type ResponseModeView = {
-  value: ConsultationResponseMode;
-  label: string;
-  description: string;
-};
-
-const RESPONSE_MODE_OPTIONS: ResponseModeView[] = [
-  {
-    value: "AI_ACTIVE",
-    label: "AI 응대중",
-    description: "고객 메시지에 AI가 자동응답합니다.",
-  },
-  {
-    value: "HUMAN_ACTIVE",
-    label: "상담사 응대중",
-    description: "AI 자동응답을 중지합니다.",
-  },
-  {
-    value: "AI_ASSIST_ONLY",
-    label: "AI 보조만 사용",
-    description: "고객 자동 전송 없이 보조 상태로 둡니다.",
-  },
-];
-
-const DEFAULT_RESPONSE_MODE: ConsultationResponseMode = "AI_ACTIVE";
 const EMPTY_COMPOSER_DRAFT: ChatComposerDraft = {
   input: "",
   isNoteMode: false,
@@ -149,9 +124,6 @@ const getComposerDraftReleaseWarning = (draft: ChatComposerDraft) => {
     ? "메시지 입력창에 작성 중인 내부 메모가 있습니다."
     : "메시지 입력창에 작성 중인 답변이 있습니다.";
 };
-
-const getResponseModeView = (mode?: ConsultationResponseMode | null) =>
-  RESPONSE_MODE_OPTIONS.find((option) => option.value === mode) ?? RESPONSE_MODE_OPTIONS[0];
 
 type EndSessionModalState =
   | { open: false }
@@ -391,7 +363,6 @@ const getSessionStatusLabel = (
 type AssignmentView = {
   label: string;
   description: string;
-  tone: "mine" | "unassigned" | "other" | "closed";
 };
 
 const getAssignmentView = (
@@ -403,7 +374,6 @@ const getAssignmentView = (
     return {
       label: status === "RESOLVED" ? "해결됨" : "상담 종료",
       description: "종료된 세션이므로 메시지를 보낼 수 없습니다.",
-      tone: "closed",
     };
   }
 
@@ -411,7 +381,6 @@ const getAssignmentView = (
     return {
       label: "내게 배정됨",
       description: "이 세션에 응답하고 내부 메모를 남길 수 있습니다.",
-      tone: "mine",
     };
   }
 
@@ -419,15 +388,22 @@ const getAssignmentView = (
     return {
       label: "다른 상담사 배정",
       description: "다른 상담사가 응대 중인 세션이므로 메시지를 보낼 수 없습니다.",
-      tone: "other",
     };
   }
 
   return {
     label: "미배정",
     description: "배정받기 전에는 메시지와 내부 메모를 보낼 수 없습니다.",
-    tone: "unassigned",
   };
+};
+
+const getResponseStatusLabel = (
+  status?: string | null,
+  assignedCounselorId?: number | null,
+) => {
+  if (status === "COMPLETED") return "상담 종료";
+  if (status === "RESOLVED") return "해결됨";
+  return assignedCounselorId ? "상담사 응대중" : "AI 응대";
 };
 
 const isCustomerMessageRole = (role?: string | null) => {
@@ -669,7 +645,6 @@ export const ConsultationPage: React.FC = () => {
   const [releaseAssignmentModal, setReleaseAssignmentModal] = useState<ReleaseAssignmentModalState>(
     { open: false },
   );
-  const [isResponseModeUpdating, setIsResponseModeUpdating] = useState(false);
   const isEndSessionModalOpen = endSessionModal.open;
   const isEndSessionSubmitting = endSessionModal.open ? endSessionModal.isSubmitting : false;
   const isReleaseAssignmentModalOpen = releaseAssignmentModal.open;
@@ -773,9 +748,6 @@ export const ConsultationPage: React.FC = () => {
         currentCounselorId,
       )
     : null;
-  const activeAssignmentToneClass = activeAssignment
-    ? styles["assignmentBadge_" + activeAssignment.tone]
-    : "";
   const isAssignedToCurrentCounselor =
     !!activeCustomer?.assignedCounselorId &&
     activeCustomer.assignedCounselorId === currentCounselorId;
@@ -787,7 +759,9 @@ export const ConsultationPage: React.FC = () => {
   const messageInputDisabledReason = isAssignedToCurrentCounselor
     ? undefined
     : activeAssignment?.description;
-  const activeResponseModeView = getResponseModeView(activeCustomer?.responseMode);
+  const activeResponseStatusLabel = activeCustomer
+    ? getResponseStatusLabel(activeCustomer.status, activeCustomer.assignedCounselorId)
+    : null;
   const queueSyncNotice =
     workspaceId && connectionStatus !== "CONNECTED"
       ? "실시간 연결이 불안정합니다. 복구되면 대기열을 다시 동기화합니다."
@@ -1603,42 +1577,6 @@ export const ConsultationPage: React.FC = () => {
     }
   };
 
-  const handleUpdateResponseMode = async (responseMode: ConsultationResponseMode) => {
-    if (
-      !activeCustomerId ||
-      !currentCounselorId ||
-      !isAssignedToCurrentCounselor ||
-      responseMode === activeCustomer?.responseMode ||
-      isResponseModeUpdating
-    ) {
-      return;
-    }
-
-    setIsResponseModeUpdating(true);
-    try {
-      const updatedSession = await consultationApi.updateResponseMode(
-        Number(activeCustomerId),
-        currentCounselorId,
-        responseMode,
-      );
-      setQueue((prev) =>
-        sortQueueCustomers(
-          prev.map((customer) =>
-            customer.id === activeCustomerId
-              ? toQueueCustomer(updatedSession, currentCounselorId, customer)
-              : customer,
-          ),
-        ),
-      );
-      toast.success("AI 응대 모드가 변경되었습니다.");
-    } catch (error) {
-      console.error("Failed to update response mode:", error);
-      toast.error("AI 응대 모드 변경에 실패했습니다.");
-    } finally {
-      setIsResponseModeUpdating(false);
-    }
-  };
-
   const handleSaveMemo = useCallback(() => {
     if (!activeCustomerId || !isAssignedToCurrentCounselor) return;
 
@@ -1689,13 +1627,14 @@ export const ConsultationPage: React.FC = () => {
               </div>
             </div>
             <div className={styles.conversationActions}>
-              {activeAssignment && (
+              {activeResponseStatusLabel && (
                 <div
-                  className={`${styles.assignmentBadge} ${activeAssignmentToneClass}`}
-                  data-testid="conversation-assignment-status"
+                  className={styles.responseStatusBadge}
+                  role="status"
+                  aria-label="응대 상태"
+                  data-testid="conversation-response-status"
                 >
-                  <span>{activeAssignment.label}</span>
-                  <small>{activeAssignment.description}</small>
+                  {activeResponseStatusLabel}
                 </div>
               )}
               {isActiveSessionUnassigned && !isActiveSessionClosed && (
@@ -1708,32 +1647,6 @@ export const ConsultationPage: React.FC = () => {
                   {isClaimingActiveSession ? "배정 중..." : "배정받기"}
                 </button>
               )}
-              <div className={styles.responseModePanel}>
-                <div className={styles.responseModeSummary}>
-                  <Mono className={styles.responseModeEyebrow}>AI MODE</Mono>
-                  <span>{activeResponseModeView.label}</span>
-                </div>
-                <div className={styles.responseModeControl} aria-label="AI 응대 모드">
-                  {RESPONSE_MODE_OPTIONS.map((option) => {
-                    const isSelected = activeResponseModeView.value === option.value;
-                    return (
-                      <button
-                        key={option.value}
-                        type="button"
-                        className={`${styles.responseModeButton} ${
-                          isSelected ? styles.responseModeButtonActive : ""
-                        }`}
-                        aria-pressed={isSelected}
-                        title={option.description}
-                        disabled={!isAssignedToCurrentCounselor || isResponseModeUpdating}
-                        onClick={() => handleUpdateResponseMode(option.value)}
-                      >
-                        {option.label}
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
               <button
                 className={styles.linkButton}
                 onClick={handleOpenReleaseAssignment}
@@ -1770,8 +1683,7 @@ export const ConsultationPage: React.FC = () => {
               onRetryMessage={handleRetryMessage}
               selectedMessageId={selectedMessageId}
               onSelectMessage={setSelectedMessageId}
-              sessionStatusLabel={activeAssignment?.label}
-              sessionStatusDescription={activeAssignment?.description}
+              sessionStatusLabel={activeResponseStatusLabel ?? activeAssignment?.label}
               disabledReason={messageInputDisabledReason}
               disabled={!isAssignedToCurrentCounselor}
               hasPreviousMessages={hasPreviousMessages}

--- a/frontend/src/pages/consultation/ui/consultation-page.module.css
+++ b/frontend/src/pages/consultation/ui/consultation-page.module.css
@@ -66,136 +66,21 @@
   border-top: 1px solid var(--line-2);
 }
 
-.assignmentBadge {
+.responseStatusBadge {
   margin-right: auto;
   min-width: 0;
-  max-width: 360px;
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 6px 10px;
-  border: 1px solid var(--line);
-  border-radius: 50px;
-  background: var(--paper-2);
-  color: var(--ink-2);
-}
-
-.assignmentBadge span {
-  flex-shrink: 0;
-  font-family: var(--mono);
-  font-size: 10.5px;
-  line-height: 1;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-}
-
-.assignmentBadge small {
-  min-width: 0;
-  overflow: hidden;
-  color: var(--ink-3);
-  font-size: 11px;
-  line-height: 1.25;
-  letter-spacing: -0.1px;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.assignmentBadge_mine {
-  border-color: var(--ink);
-  background: var(--ink);
-  color: var(--paper);
-}
-
-.assignmentBadge_mine small {
-  color: rgba(255, 255, 255, 0.72);
-}
-
-.assignmentBadge_other,
-.assignmentBadge_closed {
-  opacity: 0.74;
-}
-
-.responseModePanel {
-  display: flex;
-  min-width: 0;
-  align-items: center;
-  gap: 8px;
-}
-
-.responseModeSummary {
-  display: flex;
-  min-width: 112px;
-  flex-direction: column;
-  gap: 2px;
-}
-
-.responseModeEyebrow {
-  color: var(--ink-3);
-  font-size: 9.5px;
-  letter-spacing: 0.08em;
-}
-
-.responseModeSummary span {
-  color: var(--ink);
-  font-size: 12px;
-  font-weight: 540;
-  letter-spacing: -0.1px;
-  line-height: 1.2;
-}
-
-.responseModeControl {
-  display: flex;
-  flex: 0 1 auto;
-  min-width: 0;
-  overflow: hidden;
-  border: 1px solid var(--line);
+  padding: 8px 12px;
+  border: 1px solid var(--ink);
   border-radius: 50px;
   background: var(--paper);
-}
-
-.responseModeButton {
-  min-height: 30px;
-  padding: 0 10px;
-  border: 0;
-  border-right: 1px solid var(--line);
-  background: transparent;
-  color: var(--ink-2);
-  cursor: pointer;
-  font-size: 11.5px;
-  font-weight: 450;
-  letter-spacing: -0.1px;
-  white-space: nowrap;
-}
-
-.responseModeButton:last-child {
-  border-right: 0;
-}
-
-.responseModeButton:hover:not(:disabled) {
-  background: var(--paper-2);
   color: var(--ink);
-}
-
-.responseModeButton:focus-visible {
-  outline: none;
-  box-shadow:
-    inset 0 0 0 1px var(--ink),
-    var(--focus-ring);
-}
-
-.responseModeButton:disabled {
-  cursor: not-allowed;
-  opacity: 0.48;
-}
-
-.responseModeButtonActive {
-  background: var(--ink);
-  color: var(--paper);
-}
-
-.responseModeButtonActive:hover:not(:disabled) {
-  background: var(--ink);
-  color: var(--paper);
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 400;
+  line-height: 1;
+  white-space: nowrap;
 }
 
 .claimButton,


### PR DESCRIPTION
## 작업 내용
- 상담 화면 상단의 AI MODE 문구와 응대 모드 선택 버튼을 제거
- 미배정 상태에서는 `AI 응대`, 상담사 배정 후에는 `상담사 응대중`만 표시되도록 변경
- 배정 전 메시지/내부 메모 제한 안내는 입력 영역 쪽에만 남기고 상단 상태 영역에서는 제거
- 변경된 UI 동작에 맞춰 상담 페이지 테스트를 수정

## 검증
- pnpm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 상담 페이지의 응대 상태 표시 기능을 세션 상태 기반으로 재구성했습니다.
  * 기존 응대 모드 선택 UI 및 관련 제어 기능을 제거했습니다.
  * 배정 상태와 응대 상태가 더 명확하게 표시되도록 개선됩니다.

* **Tests**
  * 응대 상태 배지 렌더링 검증 중심으로 테스트를 업데이트했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ajou-2026-1-capstone-5/ostone/pull/536?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->