### PR TITLE
chore(frontend): compose API 프록시 대상 설정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,6 +101,7 @@ services:
       - /app/node_modules
     environment:
       VITE_API_BASE_URL: ${COMPOSE_VITE_API_BASE_URL:-http://localhost:8080/api/v1}
+      VITE_API_PROXY_TARGET: ${COMPOSE_VITE_API_PROXY_TARGET:-http://backend:8080}
       CHOKIDAR_USEPOLLING: "true"
     depends_on:
       backend:

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,6 +5,7 @@ import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const apiProxyTarget = process.env.VITE_API_PROXY_TARGET ?? "http://localhost:8080";
 
 export default defineConfig({
   fmt: {},
@@ -21,7 +22,7 @@ export default defineConfig({
     strictPort: true,
     proxy: {
       "/api": {
-        target: "http://localhost:8080",
+        target: apiProxyTarget,
         changeOrigin: true,
       },
     },


### PR DESCRIPTION
## 요약
- Vite dev server의 `/api` proxy target을 `VITE_API_PROXY_TARGET`로 설정할 수 있게 변경
- Docker Compose frontend 환경의 기본 proxy target을 `http://backend:8080`으로 지정
- 호스트에서 직접 frontend dev server를 실행하는 경우에는 기존처럼 `http://localhost:8080` 기본값을 유지

## 배경
Docker Compose 내부에서 frontend 컨테이너가 `/api` 요청을 프록시할 때 `localhost:8080`은 backend가 아니라 frontend 컨테이너 자신을 가리킴

compose 환경에서는 backend 서비스명인 `backend:8080`을 사용해야 API 요청이 정상 전달

## 검증
- pnpm build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * API 프록시 타겟 설정이 환경변수로 관리되도록 변경되었습니다. 이를 통해 배포 환경에서 더 유연한 구성이 가능해졌습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ajou-2026-1-capstone-5/ostone/pull/537?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->