### PR TITLE
feat(dashboard): 워크스페이스 고객용 대시보드 셸 제공

### DIFF
--- a/.agent/specs/517.md
+++ b/.agent/specs/517.md
@@ -1,0 +1,175 @@
+# Frontend Spec: 워크스페이스 고객용 대시보드 셸
+
+## Goal
+
+워크스페이스 멤버가 진입 직후 CS 운영 현황 화면을 받을 수 있도록 `/workspaces/{workspaceId}/dashboard` 라우트, 공통 필터 상태, 대시보드 배치 슬롯, 빈/로딩/오류 상태, 초기 CTA를 제공한다.
+
+---
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A["워크스페이스 진입"] --> B["/workspaces/{workspaceId}/dashboard"]
+    B --> C{"대시보드 데이터 연결 상태"}
+    C -->|"loading"| D["레이아웃 유지 + 로딩 상태"]
+    C -->|"error"| E["레이아웃 유지 + 오류 상태"]
+    C -->|"empty"| F["빈 상태 + 초기 CTA"]
+    C -->|"partial/future data"| G["필터 기준을 공유하는 카드/차트 슬롯"]
+    F --> H["상담 로그 업로드"]
+    F --> I["도메인팩 생성"]
+    F --> J["시뮬레이션 시작"]
+```
+
+---
+
+## Design Diff
+
+### As-is vs To-be
+
+| 영역 | As-is | To-be | 변경 내용 |
+|------|-------|-------|----------|
+| 워크스페이스 기본 진입 | `/workspaces/{workspaceId}`가 워크플로우 목록으로 이동 | 대시보드 홈으로 이동 | 고객용 홈을 워크스페이스 첫 화면으로 둔다 |
+| 사이드바 | 상담 응대, 사용자 화면 미리보기, 상담 로그 수집, 워크스페이스 설정, 도메인팩 관리 | 대시보드를 첫 메뉴로 추가 | active state에 `dashboard`를 추가한다 |
+| 대시보드 화면 | 없음 | 필터, CTA, 상태 패널, 카드/차트 슬롯 | 실제 KPI 계산 없이 붙일 수 있는 셸만 제공한다 |
+| 상태 처리 | 화면별 개별 처리 | loading/error/empty/부분 데이터용 안정 레이아웃 | 데이터 섹션 연결 전에도 화면이 깨지지 않게 한다 |
+
+---
+
+## Component Tree
+
+```text
+WorkspaceDashboardPage
+├─ DashboardHeader
+├─ DashboardFilterBar
+│    ├─ PeriodSegmentControl
+│    ├─ CustomDateInputs
+│    ├─ DomainPackVersionSelect
+│    ├─ ChannelSelect
+│    └─ WorkflowStatusSelect
+├─ DashboardStatePanel
+│    ├─ Loading view
+│    ├─ Error view
+│    └─ Empty view
+│         ├─ Upload CTA
+│         ├─ Domain Pack CTA
+│         └─ Simulation CTA
+└─ DashboardSectionGrid
+     ├─ MetricSlot
+     ├─ ChartSlot
+     └─ TableSlot
+```
+
+---
+
+## API Integration
+
+초기 이슈에서는 신규 API를 연결하지 않는다. 필터는 페이지 상태로 관리하고, 이후 대시보드 데이터 API가 추가되면 같은 상태 객체를 query key와 request parameter로 전달할 수 있게 둔다.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| - | - | 신규 API 없음 |
+
+---
+
+## Data Flow
+
+```text
+App routes
+  -> WorkspaceLayout
+    -> OstoneShell(active="dashboard")
+      -> WorkspaceDashboardPage
+        -> DashboardFilters local state
+        -> Future dashboard data hooks
+        -> Cards / charts / empty CTA
+```
+
+필터 상태는 다음 값을 가진다.
+
+| 필드 | 값 |
+|------|----|
+| period | `today`, `7d`, `30d`, `custom` |
+| customFrom | 사용자 지정 시작일 |
+| customTo | 사용자 지정 종료일 |
+| domainPackVersion | 전체 또는 특정 버전 식별자 |
+| channel | 전체, 웹채팅, 이메일, 전화 |
+| workflowStatus | 전체, 진행 중, 완료, 핸드오프, 실패 |
+
+---
+
+## 수정 대상 파일
+
+| 파일 | 변경 유형 | 설명 |
+|------|----------|------|
+| `frontend/src/app/App.tsx` | update | `/workspaces/:workspaceId/dashboard` 라우트와 워크스페이스 index redirect 변경 |
+| `frontend/src/app/App.test.tsx` | update | 워크스페이스 루트가 dashboard로 이동하는 통합 테스트 갱신 |
+| `frontend/src/pages/workspace/ui/WorkspaceRootRedirect.tsx` | update | 기본 워크스페이스 진입 경로를 dashboard로 변경 |
+| `frontend/src/pages/workspace/ui/WorkspaceRootRedirect.test.tsx` | update | 기본 redirect 기대 경로 갱신 |
+| `frontend/src/pages/workspace/ui/WorkspaceLayout.tsx` | update | dashboard active state 인식 |
+| `frontend/src/shared/ui/ostone/chrome/Sidebar.tsx` | update | dashboard 메뉴와 `SidebarActive` 타입 추가 |
+| `frontend/src/widgets/ostone-shell/ui/OstoneShell.tsx` | update | dashboard breadcrumb 라벨 추가 |
+| `frontend/src/widgets/ostone-shell/ui/OstoneShell.test.tsx` | update | 사이드바 첫 메뉴 검증 갱신 |
+| `frontend/src/pages/workspace/ui/WorkspaceDashboardPage.tsx` | new | 대시보드 셸 페이지 |
+| `frontend/src/pages/workspace/ui/WorkspaceDashboardPage.test.tsx` | new | 필터 상태, 상태 패널, CTA 테스트 |
+| `frontend/src/pages/workspace/ui/workspace-dashboard-page.module.css` | new | 대시보드 레이아웃 스타일 |
+
+---
+
+## State Management
+
+서버 상태는 아직 없다. 페이지 내부에서 공통 필터 상태를 한 객체로 관리한다.
+
+```typescript
+interface DashboardFilters {
+  period: "today" | "7d" | "30d" | "custom";
+  customFrom: string;
+  customTo: string;
+  domainPackVersion: string;
+  channel: string;
+  workflowStatus: string;
+}
+```
+
+기간 필터 변경 시 future 카드/차트가 같은 기준으로 갱신될 수 있도록 필터 요약과 상태 객체를 같은 페이지에서 계산한다.
+
+---
+
+## Tests
+
+### Test Strategy
+
+| 구분 | 방법 | 도구 | 비고 |
+|------|------|------|------|
+| 라우팅 테스트 | App 통합 렌더 | Vitest + React Testing Library | 워크스페이스 기본 진입점 확인 |
+| 페이지 테스트 | 컴포넌트 렌더 | Vitest + React Testing Library | 필터, 상태, CTA 확인 |
+| 사이드바 테스트 | 셸 컴포넌트 렌더 | Vitest + React Testing Library | 대시보드 메뉴 노출 확인 |
+
+### Test Scenarios
+
+#### Happy Path
+
+| # | 시나리오 | 조작 | 기대 결과 |
+|---|---------|------|----------|
+| 1 | 워크스페이스 루트 진입 | `/workspaces/{workspaceId}` 접근 | `/dashboard`로 이동한다 |
+| 2 | 기간 필터 변경 | 오늘/7일/30일/사용자 지정 선택 | 필터 요약이 같은 기준으로 갱신된다 |
+| 3 | 공통 필터 변경 | domain pack version, channel, workflow status 선택 | 화면 상태가 변경 값을 반영한다 |
+| 4 | 빈 상태 | 초기 데이터 없음 | 상담 로그 업로드, 도메인팩 생성, 시뮬레이션 시작 CTA가 표시된다 |
+
+#### Error & Edge Cases
+
+| # | 시나리오 | 기대 결과 |
+|---|---------|----------|
+| 1 | 잘못된 workspaceId | `/workspaces`로 이동한다 |
+| 2 | loading 상태 | 로딩 패널이 배치 영역 안에서 표시된다 |
+| 3 | error 상태 | 오류 패널이 배치 영역 안에서 표시된다 |
+| 4 | 모바일 폭 | 필터와 슬롯이 1열로 접힌다 |
+
+---
+
+## Non-goals
+
+- 상담 처리 KPI 계산
+- 핫패스 워크플로우 랭킹 계산
+- 도메인팩 건강도 계산
+- 추천 액션 생성
+- 실제 대시보드 API 또는 mock KPI 데이터 생성

--- a/frontend/src/app/App.test.tsx
+++ b/frontend/src/app/App.test.tsx
@@ -98,7 +98,7 @@ describe("App", () => {
     });
   });
 
-  it("redirects workspace home alias to workflows and renders the empty workflow state when there are no domain packs", async () => {
+  it("redirects workspace home alias to dashboard and renders the dashboard empty state", async () => {
     seedAuthenticatedSession();
 
     const workspaceBody = {
@@ -120,13 +120,6 @@ describe("App", () => {
           json: async () => [workspaceBody],
         });
       }
-      if (url === "/api/v1/workspaces/1/domain-packs") {
-        return Promise.resolve({
-          ok: true,
-          status: 200,
-          json: async () => [],
-        });
-      }
       return Promise.resolve({
         ok: true,
         status: 200,
@@ -144,14 +137,12 @@ describe("App", () => {
     );
 
     await waitFor(() => {
-      expect(window.location.pathname).toBe("/workspaces/1/workflows");
+      expect(window.location.pathname).toBe("/workspaces/1/dashboard");
     });
 
-    expect(await screen.findByText("워크플로우")).toBeInTheDocument();
+    expect(await screen.findByText("Workspace Dashboard")).toBeInTheDocument();
     expect(
-      await screen.findByText(
-        "아직 등록된 워크플로우가 없습니다. 워크플로우는 도메인팩에서 생성하고 관리합니다.",
-      ),
+      await screen.findByText("아직 대시보드에 표시할 운영 데이터가 없습니다."),
     ).toBeInTheDocument();
     expect(fetchMock).toHaveBeenCalledWith(
       "/api/v1/workspaces/1",

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -28,6 +28,7 @@ import { PackWorkflowListPage } from "../pages/domain-pack/ui/PackWorkflowListPa
 import { DomainPackSummaryPage } from "../pages/domain-pack/ui/DomainPackSummaryPage";
 import { DomainPackRouteOutlet } from "../pages/domain-pack/ui/DomainPackRouteOutlet";
 import { WorkspaceLayout } from "../pages/workspace/ui/WorkspaceLayout";
+import { WorkspaceDashboardPage } from "../pages/workspace/ui/WorkspaceDashboardPage";
 import { WorkspaceMembersPage } from "../pages/workspace/ui/WorkspaceMembersPage";
 import { WorkspaceWorkflowsPage } from "../pages/workspace/ui/WorkspaceWorkflowsPage";
 import { WorkspaceUploadPage } from "../pages/upload/ui/WorkspaceUploadPage";
@@ -115,7 +116,8 @@ export function App() {
             </PrivateRoute>
           }
         >
-          <Route index element={<Navigate to="workflows" replace />} />
+          <Route index element={<Navigate to="dashboard" replace />} />
+          <Route path="dashboard" element={<WorkspaceDashboardPage />} />
           <Route path="workflows" element={<WorkspaceWorkflowsPage />} />
           <Route path="pipeline" element={<Navigate to="upload" replace />} />
           <Route path="consultation/history" element={<ChatHistoryPage />} />

--- a/frontend/src/pages/workspace/ui/WorkspaceDashboardPage.test.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceDashboardPage.test.tsx
@@ -1,0 +1,104 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+
+import { DashboardStatePanel, WorkspaceDashboardPage } from "./WorkspaceDashboardPage";
+
+const setCrumbs = vi.fn();
+
+function renderPage(path = "/workspaces/1/dashboard") {
+  setCrumbs.mockClear();
+  render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route
+          path="/workspaces/:workspaceId/dashboard"
+          element={<WorkspaceDashboardPage />}
+        />
+        <Route path="/workspaces" element={<div data-testid="workspace-root" />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  return {
+    ...actual,
+    useOutletContext: () => ({ setCrumbs, workspace: { id: 1, name: "CS Team" } }),
+  };
+});
+
+describe("WorkspaceDashboardPage", () => {
+  it("잘못된 workspaceId면 /workspaces로 리다이렉트한다", () => {
+    renderPage("/workspaces/abc/dashboard");
+    expect(screen.getByTestId("workspace-root")).toBeInTheDocument();
+  });
+
+  it("공통 필터와 빈 상태 CTA를 표시한다", () => {
+    renderPage();
+
+    expect(screen.getByRole("heading", { name: "대시보드" })).toBeInTheDocument();
+    expect(screen.getByLabelText("기간 필터")).toBeInTheDocument();
+    expect(screen.getByLabelText("Domain Pack Version 필터")).toHaveValue("all");
+    expect(screen.getByLabelText("채널 필터")).toHaveValue("all");
+    expect(screen.getByLabelText("워크플로우 상태 필터")).toHaveValue("all");
+    expect(screen.getByTestId("dashboard-empty")).toBeInTheDocument();
+    expect(screen.getByTestId("dashboard-upload-cta")).toHaveAttribute(
+      "href",
+      "/workspaces/1/upload",
+    );
+    expect(screen.getByTestId("dashboard-pack-cta")).toHaveAttribute(
+      "href",
+      "/workspaces/1/domain-packs",
+    );
+    expect(screen.getByTestId("dashboard-simulation-cta")).toHaveAttribute(
+      "href",
+      "/demo/chat/1",
+    );
+  });
+
+  it("기간과 공통 필터 변경을 요약 상태에 반영한다", () => {
+    renderPage();
+
+    fireEvent.click(screen.getByRole("button", { name: "사용자 지정" }));
+    fireEvent.change(screen.getByLabelText("시작일"), { target: { value: "2026-06-01" } });
+    fireEvent.change(screen.getByLabelText("종료일"), { target: { value: "2026-06-03" } });
+    fireEvent.change(screen.getByLabelText("Domain Pack Version 필터"), {
+      target: { value: "published" },
+    });
+    fireEvent.change(screen.getByLabelText("채널 필터"), { target: { value: "email" } });
+    fireEvent.change(screen.getByLabelText("워크플로우 상태 필터"), {
+      target: { value: "handoff" },
+    });
+
+    const summary = screen.getByLabelText("대시보드 필터 요약");
+    expect(summary).toHaveTextContent("2026-06-01 ~ 2026-06-03");
+    expect(summary).toHaveTextContent("운영 버전");
+    expect(summary).toHaveTextContent("이메일");
+    expect(summary).toHaveTextContent("상담원 연결");
+  });
+
+  it("loading, error, partial 상태 패널이 같은 shell 영역에서 렌더링된다", () => {
+    const { rerender } = render(
+      <MemoryRouter>
+        <DashboardStatePanel state="loading" workspaceId={1} />
+      </MemoryRouter>,
+    );
+    expect(screen.getByTestId("dashboard-loading")).toBeInTheDocument();
+
+    rerender(
+      <MemoryRouter>
+        <DashboardStatePanel state="error" workspaceId={1} />
+      </MemoryRouter>,
+    );
+    expect(screen.getByTestId("dashboard-error")).toBeInTheDocument();
+
+    rerender(
+      <MemoryRouter>
+        <DashboardStatePanel state="partial" workspaceId={1} />
+      </MemoryRouter>,
+    );
+    expect(screen.getByTestId("dashboard-partial")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/workspace/ui/WorkspaceDashboardPage.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceDashboardPage.tsx
@@ -1,0 +1,368 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link, Navigate, useOutletContext, useParams } from "react-router-dom";
+import {
+  ArrowRightIcon,
+  FileUpIcon,
+  FlaskConicalIcon,
+  PackagePlusIcon,
+  RefreshCwIcon,
+} from "lucide-react";
+
+import type { ShellContext } from "@/shared/ui/ostone/chrome";
+import { buildDemoChatPath } from "@/shared/lib/demoRoutes";
+import { parseRouteId } from "@/shared/lib/parseRouteId";
+import { Button } from "@/shared/ui/button";
+import { NativeSelect, NativeSelectOption } from "@/shared/ui/native-select";
+import { LoadingSpinner } from "@/shared/ui/ostone/atoms/LoadingSpinner";
+import { ErrorState } from "@/shared/ui/ostone/atoms/ErrorState";
+
+import styles from "./workspace-dashboard-page.module.css";
+
+type DashboardPeriod = "today" | "7d" | "30d" | "custom";
+type DashboardDataState = "loading" | "error" | "empty" | "partial";
+
+interface DashboardFilters {
+  period: DashboardPeriod;
+  customFrom: string;
+  customTo: string;
+  domainPackVersion: string;
+  channel: string;
+  workflowStatus: string;
+}
+
+interface FilterOption<T extends string = string> {
+  value: T;
+  label: string;
+}
+
+interface DashboardStatePanelProps {
+  state: DashboardDataState;
+  workspaceId: number;
+}
+
+const PERIOD_OPTIONS: Array<FilterOption<DashboardPeriod>> = [
+  { value: "today", label: "오늘" },
+  { value: "7d", label: "7일" },
+  { value: "30d", label: "30일" },
+  { value: "custom", label: "사용자 지정" },
+];
+
+const DOMAIN_PACK_VERSION_OPTIONS: FilterOption[] = [
+  { value: "all", label: "전체 버전" },
+  { value: "published", label: "운영 버전" },
+  { value: "draft", label: "검토 중 버전" },
+];
+
+const CHANNEL_OPTIONS: FilterOption[] = [
+  { value: "all", label: "전체 채널" },
+  { value: "web-chat", label: "웹채팅" },
+  { value: "email", label: "이메일" },
+  { value: "phone", label: "전화" },
+];
+
+const WORKFLOW_STATUS_OPTIONS: FilterOption[] = [
+  { value: "all", label: "전체 상태" },
+  { value: "running", label: "진행 중" },
+  { value: "completed", label: "완료" },
+  { value: "handoff", label: "상담원 연결" },
+  { value: "failed", label: "실패" },
+];
+
+const INITIAL_FILTERS: DashboardFilters = {
+  period: "7d",
+  customFrom: "",
+  customTo: "",
+  domainPackVersion: "all",
+  channel: "all",
+  workflowStatus: "all",
+};
+
+function getOptionLabel(options: FilterOption[], value: string): string {
+  return options.find((option) => option.value === value)?.label ?? value;
+}
+
+function buildPeriodSummary(filters: DashboardFilters): string {
+  if (filters.period !== "custom") {
+    return getOptionLabel(PERIOD_OPTIONS, filters.period);
+  }
+
+  if (filters.customFrom && filters.customTo) {
+    return `${filters.customFrom} ~ ${filters.customTo}`;
+  }
+
+  return "사용자 지정 기간";
+}
+
+function FilterSummary({ filters }: { filters: DashboardFilters }) {
+  const summaryItems = [
+    ["기간", buildPeriodSummary(filters)],
+    ["도메인팩", getOptionLabel(DOMAIN_PACK_VERSION_OPTIONS, filters.domainPackVersion)],
+    ["채널", getOptionLabel(CHANNEL_OPTIONS, filters.channel)],
+    ["워크플로우", getOptionLabel(WORKFLOW_STATUS_OPTIONS, filters.workflowStatus)],
+  ];
+
+  return (
+    <dl className={styles.filterSummary} aria-label="대시보드 필터 요약">
+      {summaryItems.map(([label, value]) => (
+        <div key={label} className={styles.summaryItem}>
+          <dt>{label}</dt>
+          <dd>{value}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+function DashboardFilters({
+  filters,
+  onChange,
+}: {
+  filters: DashboardFilters;
+  onChange: (filters: DashboardFilters) => void;
+}) {
+  const updateFilter = <K extends keyof DashboardFilters>(key: K, value: DashboardFilters[K]) => {
+    onChange({ ...filters, [key]: value });
+  };
+
+  return (
+    <section className={styles.filterBar} aria-labelledby="dashboard-filter-title">
+      <div className={styles.filterHeader}>
+        <div>
+          <h2 id="dashboard-filter-title" className={styles.sectionTitle}>
+            공통 필터
+          </h2>
+          <p className={styles.sectionDescription}>
+            아래 카드와 차트가 같은 기준을 바라보도록 필터 상태를 먼저 고정합니다.
+          </p>
+        </div>
+      </div>
+
+      <div className={styles.periodControl} aria-label="기간 필터">
+        {PERIOD_OPTIONS.map((option) => {
+          const selected = filters.period === option.value;
+          return (
+            <button
+              key={option.value}
+              type="button"
+              className={`${styles.segmentButton} ${selected ? styles.segmentButtonActive : ""}`}
+              aria-pressed={selected}
+              onClick={() => updateFilter("period", option.value)}
+            >
+              {option.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {filters.period === "custom" ? (
+        <div className={styles.customDateGrid}>
+          <label className={styles.field}>
+            <span>시작일</span>
+            <input
+              type="date"
+              value={filters.customFrom}
+              onChange={(event) => updateFilter("customFrom", event.target.value)}
+            />
+          </label>
+          <label className={styles.field}>
+            <span>종료일</span>
+            <input
+              type="date"
+              value={filters.customTo}
+              onChange={(event) => updateFilter("customTo", event.target.value)}
+            />
+          </label>
+        </div>
+      ) : null}
+
+      <div className={styles.selectGrid}>
+        <label className={styles.field}>
+          <span>Domain Pack Version</span>
+          <NativeSelect
+            value={filters.domainPackVersion}
+            onChange={(event) => updateFilter("domainPackVersion", event.target.value)}
+            aria-label="Domain Pack Version 필터"
+          >
+            {DOMAIN_PACK_VERSION_OPTIONS.map((option) => (
+              <NativeSelectOption key={option.value} value={option.value}>
+                {option.label}
+              </NativeSelectOption>
+            ))}
+          </NativeSelect>
+        </label>
+        <label className={styles.field}>
+          <span>Channel</span>
+          <NativeSelect
+            value={filters.channel}
+            onChange={(event) => updateFilter("channel", event.target.value)}
+            aria-label="채널 필터"
+          >
+            {CHANNEL_OPTIONS.map((option) => (
+              <NativeSelectOption key={option.value} value={option.value}>
+                {option.label}
+              </NativeSelectOption>
+            ))}
+          </NativeSelect>
+        </label>
+        <label className={styles.field}>
+          <span>Workflow Status</span>
+          <NativeSelect
+            value={filters.workflowStatus}
+            onChange={(event) => updateFilter("workflowStatus", event.target.value)}
+            aria-label="워크플로우 상태 필터"
+          >
+            {WORKFLOW_STATUS_OPTIONS.map((option) => (
+              <NativeSelectOption key={option.value} value={option.value}>
+                {option.label}
+              </NativeSelectOption>
+            ))}
+          </NativeSelect>
+        </label>
+      </div>
+    </section>
+  );
+}
+
+function DashboardSlot({
+  label,
+  title,
+  description,
+}: {
+  label: string;
+  title: string;
+  description: string;
+}) {
+  return (
+    <article className={styles.slotCard}>
+      <span className={styles.slotLabel}>{label}</span>
+      <h3>{title}</h3>
+      <p>{description}</p>
+      <div className={styles.slotPlaceholder} aria-hidden="true">
+        <span />
+        <span />
+        <span />
+      </div>
+    </article>
+  );
+}
+
+export function DashboardStatePanel({ state, workspaceId }: DashboardStatePanelProps) {
+  if (state === "loading") {
+    return (
+      <section className={styles.statePanel} data-testid="dashboard-loading" aria-live="polite">
+        <LoadingSpinner />
+        <p className={styles.stateText}>대시보드 데이터를 불러오는 중입니다.</p>
+      </section>
+    );
+  }
+
+  if (state === "error") {
+    return (
+      <section className={styles.statePanel} data-testid="dashboard-error">
+        <ErrorState message="대시보드 데이터를 불러오지 못했습니다." />
+      </section>
+    );
+  }
+
+  if (state === "partial") {
+    return (
+      <section className={styles.partialPanel} data-testid="dashboard-partial">
+        <div>
+          <span className={styles.panelEyebrow}>PARTIAL DATA</span>
+          <h2>일부 데이터만 연결된 상태입니다.</h2>
+          <p>연결된 카드부터 표시하고, 비어 있는 영역은 동일한 그리드 안에서 유지합니다.</p>
+        </div>
+        <RefreshCwIcon aria-hidden="true" className={styles.panelIcon} />
+      </section>
+    );
+  }
+
+  return (
+    <section className={styles.emptyPanel} data-testid="dashboard-empty">
+      <div className={styles.emptyCopy}>
+        <span className={styles.panelEyebrow}>GET STARTED</span>
+        <h2>아직 대시보드에 표시할 운영 데이터가 없습니다.</h2>
+        <p>상담 로그를 업로드하고 도메인팩을 준비한 뒤, 시뮬레이션으로 워크플로우 흐름을 확인하세요.</p>
+      </div>
+      <div className={styles.ctaGrid}>
+        <Button asChild variant="default">
+          <Link to={`/workspaces/${workspaceId}/upload`} data-testid="dashboard-upload-cta">
+            <FileUpIcon aria-hidden="true" />
+            상담 로그 업로드
+          </Link>
+        </Button>
+        <Button asChild variant="outline">
+          <Link to={`/workspaces/${workspaceId}/domain-packs`} data-testid="dashboard-pack-cta">
+            <PackagePlusIcon aria-hidden="true" />
+            도메인팩 생성
+          </Link>
+        </Button>
+        <Button asChild variant="outline">
+          <Link to={buildDemoChatPath(workspaceId)} data-testid="dashboard-simulation-cta">
+            <FlaskConicalIcon aria-hidden="true" />
+            시뮬레이션 시작
+          </Link>
+        </Button>
+      </div>
+    </section>
+  );
+}
+
+export function WorkspaceDashboardPage() {
+  const { workspaceId } = useParams();
+  const { setCrumbs } = useOutletContext<ShellContext>();
+  const parsedWorkspaceId = parseRouteId(workspaceId);
+  const [filters, setFilters] = useState<DashboardFilters>(INITIAL_FILTERS);
+  const dataState = useMemo<DashboardDataState>(() => "empty", []);
+
+  useEffect(() => {
+    setCrumbs(["대시보드"]);
+    return () => setCrumbs([]);
+  }, [setCrumbs]);
+
+  if (parsedWorkspaceId === null) {
+    return <Navigate to="/workspaces" replace />;
+  }
+
+  return (
+    <div className={styles.pageWrapper}>
+      <header className={styles.pageHeader}>
+        <div>
+          <span className={styles.eyebrow}>Workspace Dashboard</span>
+          <h1 className={styles.pageTitle}>대시보드</h1>
+          <p className={styles.pageSubtitle}>
+            고객 상담 운영 지표가 연결될 공통 홈입니다. 필터와 배치 구조를 먼저 고정합니다.
+          </p>
+        </div>
+        <Button asChild variant="outline" size="sm">
+          <Link to={`/workspaces/${parsedWorkspaceId}/workflows`}>
+            워크플로우 보기
+            <ArrowRightIcon aria-hidden="true" />
+          </Link>
+        </Button>
+      </header>
+
+      <DashboardFilters filters={filters} onChange={setFilters} />
+      <FilterSummary filters={filters} />
+      <DashboardStatePanel state={dataState} workspaceId={parsedWorkspaceId} />
+
+      <section className={styles.slotGrid} aria-label="대시보드 카드와 차트 배치 영역">
+        <DashboardSlot
+          label="Metric"
+          title="상담 처리 KPI"
+          description="처리량, 평균 응답 시간, 완료율 카드가 연결될 자리입니다."
+        />
+        <DashboardSlot
+          label="Chart"
+          title="워크플로우 흐름 추이"
+          description="기간 필터 기준으로 세션과 상태 변화 차트가 연결될 자리입니다."
+        />
+        <DashboardSlot
+          label="Table"
+          title="운영 주의 항목"
+          description="부분 데이터와 오류 상태에서도 같은 폭을 유지하는 목록 슬롯입니다."
+        />
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/pages/workspace/ui/WorkspaceLayout.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceLayout.tsx
@@ -10,6 +10,7 @@ import { OstoneShell } from "@/widgets/ostone-shell";
 import { parseRouteId } from "@/shared/lib/parseRouteId";
 
 const getActiveFromPath = (pathname: string): SidebarActive => {
+  if (pathname.includes("/dashboard")) return "dashboard";
   if (pathname.includes("/domain-packs")) return "domain";
   if (pathname.includes("/consultation")) return "consult";
   if (pathname.includes("/upload")) return "upload";
@@ -17,7 +18,7 @@ const getActiveFromPath = (pathname: string): SidebarActive => {
   if (pathname.includes("/settings")) return "settings";
   if (pathname.includes("/workflows")) return "workflows";
 
-  return "workflows";
+  return "dashboard";
 };
 
 export function WorkspaceLayout() {

--- a/frontend/src/pages/workspace/ui/WorkspaceRootRedirect.test.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceRootRedirect.test.tsx
@@ -126,7 +126,7 @@ describe("WorkspaceRootRedirect", () => {
       isError: false,
     });
     renderPage();
-    expect(screen.getByTestId("navigate-to")).toHaveTextContent("/workspaces/1/workflows");
+    expect(screen.getByTestId("navigate-to")).toHaveTextContent("/workspaces/1/dashboard");
   });
 
   it("ACTIVE 워크스페이스가 없으면 첫 워크스페이스로 리다이렉트한다", () => {
@@ -136,7 +136,7 @@ describe("WorkspaceRootRedirect", () => {
       isError: false,
     });
     renderPage();
-    expect(screen.getByTestId("navigate-to")).toHaveTextContent("/workspaces/3/workflows");
+    expect(screen.getByTestId("navigate-to")).toHaveTextContent("/workspaces/3/dashboard");
   });
 
   it("기본 워크스페이스 id를 확인할 수 없으면 CreateWorkspaceDialog를 표시한다", () => {

--- a/frontend/src/pages/workspace/ui/WorkspaceRootRedirect.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceRootRedirect.tsx
@@ -42,7 +42,7 @@ export function WorkspaceRootRedirect() {
   const workspaces = selectApiData<WorkspaceResponse[]>(workspacesData) ?? [];
   const workspace = selectDefaultWorkspace(workspaces);
   if (typeof workspace?.id === "number") {
-    return <Navigate to={`/workspaces/${workspace.id}/workflows`} replace />;
+    return <Navigate to={`/workspaces/${workspace.id}/dashboard`} replace />;
   }
 
   return (

--- a/frontend/src/pages/workspace/ui/workspace-dashboard-page.module.css
+++ b/frontend/src/pages/workspace/ui/workspace-dashboard-page.module.css
@@ -1,0 +1,330 @@
+.pageWrapper {
+  padding: var(--s-6) var(--s-8) var(--s-10);
+  display: flex;
+  flex-direction: column;
+  gap: var(--s-5);
+}
+
+.pageHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--s-4);
+}
+
+.eyebrow,
+.panelEyebrow,
+.slotLabel {
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+}
+
+.pageTitle {
+  margin: var(--s-1) 0 0;
+  font-family: var(--sans);
+  font-size: 26px;
+  font-weight: 540;
+  color: var(--ink);
+  letter-spacing: -0.32px;
+  line-height: 1.2;
+}
+
+.pageSubtitle {
+  max-width: 620px;
+  margin: var(--s-2) 0 0;
+  color: var(--ink-2);
+  font-size: 14px;
+  line-height: 1.6;
+  letter-spacing: -0.14px;
+}
+
+.filterBar {
+  display: flex;
+  flex-direction: column;
+  gap: var(--s-4);
+  padding: var(--s-5);
+  border: 1px solid var(--line);
+  border-radius: var(--r-3);
+  background: var(--paper);
+}
+
+.filterHeader {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--s-3);
+}
+
+.sectionTitle {
+  margin: 0;
+  font-family: var(--sans);
+  font-size: 17px;
+  font-weight: 540;
+  color: var(--ink);
+  letter-spacing: -0.22px;
+}
+
+.sectionDescription {
+  margin: var(--s-1) 0 0;
+  color: var(--ink-2);
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.periodControl {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--s-2);
+}
+
+.segmentButton {
+  min-height: 36px;
+  padding: 0 var(--s-4);
+  border: 1px solid var(--line);
+  border-radius: var(--r-pill);
+  background: var(--paper);
+  color: var(--ink-2);
+  font-family: var(--sans);
+  font-size: 13px;
+  font-weight: 450;
+  letter-spacing: -0.14px;
+  cursor: pointer;
+  transition:
+    background 160ms ease,
+    border-color 160ms ease,
+    color 160ms ease;
+}
+
+.segmentButton:hover,
+.segmentButtonActive {
+  border-color: var(--ink);
+  background: var(--ink);
+  color: var(--paper);
+}
+
+.customDateGrid,
+.selectGrid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(160px, 1fr));
+  gap: var(--s-3);
+}
+
+.customDateGrid {
+  grid-template-columns: repeat(2, minmax(160px, 240px));
+}
+
+.field {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: var(--s-2);
+  color: var(--ink-2);
+  font-size: 12px;
+  font-weight: 540;
+  letter-spacing: -0.1px;
+}
+
+.field input[type="date"] {
+  height: 36px;
+  min-width: 0;
+  border: 1px solid hsl(var(--input));
+  border-radius: 6px;
+  background: rgba(0, 0, 0, 0.03);
+  color: var(--ink);
+  padding: 0 var(--s-3);
+  font-family: var(--sans);
+  font-size: 14px;
+  letter-spacing: -0.14px;
+}
+
+.field input[type="date"]:focus-visible {
+  border-color: hsl(var(--ring));
+  box-shadow: 0 0 0 3px hsl(var(--ring) / 0.5);
+}
+
+.filterSummary {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: var(--s-3);
+}
+
+.summaryItem {
+  min-width: 0;
+  padding: var(--s-4);
+  border: 1px solid var(--line-2);
+  border-radius: var(--r-3);
+  background: var(--paper-2);
+}
+
+.summaryItem dt {
+  color: var(--ink-3);
+  font-size: 12px;
+  font-weight: 450;
+}
+
+.summaryItem dd {
+  margin: var(--s-1) 0 0;
+  color: var(--ink);
+  font-size: 14px;
+  font-weight: 540;
+}
+
+.statePanel,
+.emptyPanel,
+.partialPanel {
+  min-height: 280px;
+  border: 1px dashed var(--line);
+  border-radius: var(--r-3);
+  background: var(--paper-2);
+}
+
+.statePanel {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--s-3);
+  padding: var(--s-8);
+  text-align: center;
+}
+
+.stateText {
+  color: var(--ink-2);
+  line-height: 1.6;
+}
+
+.emptyPanel,
+.partialPanel {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--s-5);
+  padding: var(--s-8);
+}
+
+.emptyCopy {
+  max-width: 620px;
+}
+
+.emptyCopy h2,
+.partialPanel h2 {
+  margin: var(--s-2) 0 0;
+  color: var(--ink);
+  font-size: 20px;
+  font-weight: 540;
+  letter-spacing: -0.24px;
+}
+
+.emptyCopy p,
+.partialPanel p {
+  margin: var(--s-2) 0 0;
+  color: var(--ink-2);
+  font-size: 14px;
+  line-height: 1.7;
+}
+
+.ctaGrid {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: var(--s-2);
+}
+
+.panelIcon {
+  width: 32px;
+  height: 32px;
+  color: var(--ink-3);
+}
+
+.slotGrid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--s-4);
+}
+
+.slotCard {
+  min-height: 220px;
+  padding: var(--s-5);
+  border: 1px solid var(--line);
+  border-radius: var(--r-3);
+  background: var(--paper);
+}
+
+.slotCard h3 {
+  margin: var(--s-3) 0 0;
+  color: var(--ink);
+  font-size: 17px;
+  font-weight: 540;
+  letter-spacing: -0.2px;
+}
+
+.slotCard p {
+  margin: var(--s-2) 0 var(--s-5);
+  color: var(--ink-2);
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.slotPlaceholder {
+  display: grid;
+  gap: var(--s-2);
+}
+
+.slotPlaceholder span {
+  display: block;
+  height: 12px;
+  border-radius: var(--r-pill);
+  background: var(--paper-3);
+}
+
+.slotPlaceholder span:nth-child(2) {
+  width: 76%;
+}
+
+.slotPlaceholder span:nth-child(3) {
+  width: 52%;
+}
+
+@media (max-width: 960px) {
+  .pageHeader,
+  .emptyPanel,
+  .partialPanel {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .filterSummary,
+  .slotGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .selectGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .ctaGrid {
+    justify-content: flex-start;
+  }
+}
+
+@media (max-width: 560px) {
+  .pageWrapper {
+    padding: var(--s-5) var(--s-4);
+  }
+
+  .customDateGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .periodControl {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .segmentButton {
+    padding: 0 var(--s-2);
+  }
+}

--- a/frontend/src/shared/ui/ostone/chrome/Sidebar.test.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/Sidebar.test.tsx
@@ -23,6 +23,7 @@ describe("Sidebar", () => {
     const nav = screen.getByLabelText("주요 내비게이션");
     expect(nav).toHaveAttribute("data-collapsed", "false");
     expect(nav).toHaveStyle({ width: "200px" });
+    expect(screen.getByTitle("대시보드")).toBeInTheDocument();
     expect(screen.getByTitle("상담 응대")).toBeInTheDocument();
     expect(screen.getByTitle("사용자 화면 미리보기")).toBeInTheDocument();
     expect(screen.getByTitle("상담 로그 수집")).toBeInTheDocument();
@@ -77,6 +78,7 @@ describe("Sidebar", () => {
   it("basePath prop을 지정하면 링크에 반영된다", () => {
     renderSidebar({ basePath: "/workspaces/7" });
 
+    expect(screen.getByTitle("대시보드")).toHaveAttribute("href", "/workspaces/7/dashboard");
     expect(screen.getByTitle("상담 응대")).toHaveAttribute("href", "/workspaces/7/consultation");
     expect(screen.getByTitle("사용자 화면 미리보기")).toHaveAttribute("href", "/demo");
     expect(screen.getByTitle("사용자 화면 미리보기")).toHaveAttribute("target", "_blank");
@@ -147,6 +149,7 @@ describe("Sidebar", () => {
   it("redesign: TOP_NAV 항목마다 sidebar-link-{key} data-testid를 노출한다", () => {
     renderSidebar({ active: "consult" });
 
+    expect(screen.getByTestId("sidebar-link-dashboard")).toBeInTheDocument();
     expect(screen.getByTestId("sidebar-link-consult")).toBeInTheDocument();
     expect(screen.getByTestId("sidebar-link-chat")).toBeInTheDocument();
     expect(screen.getByTestId("sidebar-link-upload")).toBeInTheDocument();

--- a/frontend/src/shared/ui/ostone/chrome/Sidebar.tsx
+++ b/frontend/src/shared/ui/ostone/chrome/Sidebar.tsx
@@ -6,6 +6,7 @@ import type { IconName } from "../atoms/Icon";
 import { AccountMenu } from "./AccountMenu";
 
 export type SidebarActive =
+  | "dashboard"
   | "workflows"
   | "consult"
   | "chat"
@@ -37,6 +38,12 @@ function getDemoPreviewPath(): string {
 }
 
 const TOP_NAV_ITEMS: TopNavItem[] = [
+  {
+    key: "dashboard",
+    icon: "grid",
+    label: "대시보드",
+    getPath: (base) => `${base}/dashboard`,
+  },
   {
     key: "consult",
     icon: "book",

--- a/frontend/src/widgets/ostone-shell/ui/OstoneShell.test.tsx
+++ b/frontend/src/widgets/ostone-shell/ui/OstoneShell.test.tsx
@@ -12,7 +12,7 @@ beforeEach(() => {
 });
 
 describe("OstoneShell", () => {
-  it("renders Sidebar with the new top nav items (workflows lives under Domain Packs, not top-level)", () => {
+  it("renders Sidebar with dashboard as the first workspace nav item", () => {
     render(
       <OstoneShell active="consult" crumbs={[]}>
         <div>content</div>
@@ -21,6 +21,7 @@ describe("OstoneShell", () => {
     );
     expect(screen.queryByTitle("Operator")).not.toBeInTheDocument();
     expect(screen.queryByTitle("Pipeline")).not.toBeInTheDocument();
+    expect(screen.getByTitle("대시보드")).toBeInTheDocument();
     expect(screen.getByTitle("상담 응대")).toBeInTheDocument();
     expect(screen.getByTitle("사용자 화면 미리보기")).toBeInTheDocument();
     expect(screen.getByTitle("상담 로그 수집")).toBeInTheDocument();

--- a/frontend/src/widgets/ostone-shell/ui/OstoneShell.tsx
+++ b/frontend/src/widgets/ostone-shell/ui/OstoneShell.tsx
@@ -22,6 +22,7 @@ interface SidebarBaseProps {
 }
 
 const TOP_LEVEL_CRUMB_BY_ACTIVE: Partial<Record<SidebarActive, string>> = {
+  dashboard: "대시보드",
   workflows: "워크플로우 관리",
   upload: "상담 로그 수집",
   consult: "상담 응대",


### PR DESCRIPTION
Closes #517

## 변경 사항

- 워크스페이스 기본 진입점을 `/workspaces/:workspaceId/dashboard`로 변경하고, 사이드바 첫 메뉴에 대시보드를 추가했습니다.
- 고객용 대시보드 셸에서 기간(오늘/7일/30일/사용자 지정), domain pack version, channel, workflow status 공통 필터 상태를 관리합니다.
- 실제 KPI 계산 없이 데이터 섹션이 연결될 수 있는 카드/차트 슬롯과 empty/loading/error/partial 상태 패널을 제공합니다.
- 초기 빈 상태에서 상담 로그 업로드, 도메인팩 생성, 시뮬레이션 시작 CTA를 제공합니다.

## 검증

- `git diff --check`
- `pnpm --dir frontend test --run src/pages/workspace/ui/WorkspaceDashboardPage.test.tsx src/pages/workspace/ui/WorkspaceRootRedirect.test.tsx src/shared/ui/ostone/chrome/Sidebar.test.tsx src/widgets/ostone-shell/ui/OstoneShell.test.tsx src/app/App.test.tsx`
- `pnpm --dir frontend test --run`
- `pnpm --dir frontend build`
- `pnpm --dir frontend exec eslint src/app/App.tsx src/app/App.test.tsx src/pages/workspace/ui/WorkspaceDashboardPage.tsx src/pages/workspace/ui/WorkspaceDashboardPage.test.tsx src/pages/workspace/ui/WorkspaceLayout.tsx src/pages/workspace/ui/WorkspaceRootRedirect.tsx src/pages/workspace/ui/WorkspaceRootRedirect.test.tsx src/shared/ui/ostone/chrome/Sidebar.tsx src/shared/ui/ostone/chrome/Sidebar.test.tsx src/widgets/ostone-shell/ui/OstoneShell.tsx src/widgets/ostone-shell/ui/OstoneShell.test.tsx`

## 참고

- `pnpm --dir frontend lint`는 기존 unrelated 57개 lint 오류가 있어 실패합니다. 이번 변경 파일 대상 eslint는 통과했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 워크스페이스 대시보드 화면 추가
  * 기간, 도메인팩 버전, 채널, 워크플로우 상태 필터링 기능
  * 데이터 로딩/오류/부분 데이터/빈 상태별 UI 제공
  * 빈 상태에서 상담 로그 업로드, 도메인팩 생성, 시뮬레이션 시작 CTA 버튼
  * 사이드바 네비게이션에 대시보드 항목 추가
  * 워크스페이스 기본 진입점을 대시보드로 변경

* **테스트**
  * 대시보드 페이지 테스트 스위트 추가
  * 라우팅 및 네비게이션 테스트 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->