### PR TITLE
feat(payment): 워크스페이스 quota 초과 사용 차단

### DIFF
--- a/.agent/specs/498.md
+++ b/.agent/specs/498.md
@@ -1,0 +1,188 @@
+# [BE] 498 — 워크스페이스 quota 하드 차단
+
+> 출처: GitHub Issue #498 (`feat(payment)`, enhancement). 댓글 없음.
+
+---
+
+## Goal
+
+워크스페이스의 현재 결제 기간 사용량을 plan quota와 비교해 dataset 업로드와 Domain Pack Generation trigger를 하드 차단하고, 초과 응답에 사용량 계약을 포함한다.
+
+---
+
+## Scope
+
+- 현재 결제 기간 기준 dataset 업로드 수 계산
+- 현재 결제 기간 기준 Domain Pack Generation pipeline 실행 수 계산
+- `POST /api/v1/workspaces/{workspaceId}/datasets`, `/datasets/raw`, `/datasets/raw-file` quota 차단
+- `POST /api/v1/workspaces/{workspaceId}/datasets/{datasetId}/pipeline-jobs/domain-pack-generation` quota 차단
+- `409 QUOTA_EXCEEDED` 응답에 `resource`, `limit`, `used` 포함
+- `payment.plan`에 `memberLimit`, `datasetUploadLimit`, `pipelineRunLimit` 보관
+- 무료 온보딩 첫 생성 권리가 남아 있으면 quota 차단보다 우선 허용
+
+**Out of scope**
+
+- quota 초과 알림 발송
+- SUPER_ADMIN quota override
+- 멤버 추가/초대 기능의 실제 차단
+- 사용량 기반 과금
+- Toss 결제 승인/정기결제/웹훅 처리
+
+---
+
+## Existing Context
+
+현재 브랜치에는 `com.init.payment` 구현 패키지와 payment DB 테이블이 없다. 따라서 이 작업은 Toss 결제 전체 구현이 아니라 quota 판단에 필요한 최소 read model을 새 `payment` bounded context로 만든다.
+
+확인된 기존 경로:
+
+| Path | 역할 |
+|------|------|
+| `backend/src/main/java/com/init/corpus/application/DatasetUploadService.java` | 구조화 dataset 업로드 |
+| `backend/src/main/java/com/init/corpus/application/RawDatasetUploadService.java` | raw 상담 로그 dataset 업로드 |
+| `backend/src/main/java/com/init/corpus/application/RawFileUploadService.java` | raw-file 업로드 + dataset 생성 + ingestion trigger |
+| `backend/src/main/java/com/init/pipelinejob/application/TriggerDomainPackGenerationUseCase.java` | Domain Pack Generation trigger |
+| `backend/src/main/java/com/init/shared/presentation/GlobalExceptionHandler.java` | 공통 BusinessException HTTP 응답 매핑 |
+| `backend/src/main/resources/db/changelog/db.changelog-master.sql` | Liquibase formatted SQL changelog |
+
+---
+
+## Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    actor c as Client
+    participant ctrl as Controller
+    participant svc as Upload/Trigger UseCase
+    participant quota as WorkspaceQuotaService
+    participant db as PostgreSQL
+
+    c ->> ctrl: POST upload or generation trigger
+    ctrl ->> svc: execute(command)
+    svc ->> svc: workspace membership / duplicate / dataset 검증
+    svc ->> quota: assertDatasetUploadAllowed or assertPipelineRunAllowed
+    quota ->> db: current subscription + plan 조회
+    quota ->> db: current period usage count 조회
+    alt quota allowed
+        svc ->> db: dataset or pipeline_job 생성
+        ctrl -->> c: 201 Created
+    else quota exceeded
+        quota -->> svc: QuotaExceededException
+        ctrl -->> c: 409 QUOTA_EXCEEDED
+    end
+```
+
+---
+
+## REST API
+
+기존 endpoint path는 변경하지 않는다. quota 차단은 기존 성공/검증/권한 플로우 사이에 추가된다.
+
+| Method | Path | Quota resource |
+|--------|------|----------------|
+| POST | `/api/v1/workspaces/{workspaceId}/datasets` | `DATASET_UPLOAD` |
+| POST | `/api/v1/workspaces/{workspaceId}/datasets/raw` | `DATASET_UPLOAD` |
+| POST | `/api/v1/workspaces/{workspaceId}/datasets/raw-file` | `DATASET_UPLOAD` |
+| POST | `/api/v1/workspaces/{workspaceId}/datasets/{datasetId}/pipeline-jobs/domain-pack-generation` | `PIPELINE_RUN` |
+
+### Quota Exceeded Response
+
+**409 Conflict**
+
+```json
+{
+  "code": "QUOTA_EXCEEDED",
+  "message": "워크스페이스 사용량 한도를 초과했습니다.",
+  "resource": "DATASET_UPLOAD",
+  "limit": 3,
+  "used": 3
+}
+```
+
+`PIPELINE_RUN` 초과도 동일 스키마를 사용한다.
+
+---
+
+## Class Design
+
+### New payment bounded context
+
+```
+com.init.payment
+├── application/
+│   ├── WorkspaceQuotaService
+│   ├── WorkspaceQuotaQueryPort
+│   ├── WorkspaceQuotaUsagePort
+│   ├── WorkspaceQuota
+│   └── QuotaResource
+├── infrastructure/
+│   ├── JdbcWorkspaceQuotaRepository
+│   └── JdbcWorkspaceQuotaUsageRepository
+├── domain/package-info.java
+└── presentation/package-info.java
+```
+
+- `WorkspaceQuotaService`: quota 판정 application service. `Clock`으로 현재 시각을 받아 current period subscription을 조회한다.
+- `WorkspaceQuotaQueryPort`: `payment.subscription`, `payment.plan`, `payment.free_onboarding_entitlement` 조회.
+- `WorkspaceQuotaUsagePort`: `corpus.dataset`, `pipeline.pipeline_job` count 조회.
+- `QuotaExceededException`: shared exception으로 두 bounded context(corpus, pipelinejob)에서 동일 응답 계약을 사용한다.
+
+### Decision Rules
+
+1. 현재 시각이 `subscription.current_period_start <= now < current_period_end`이고 status가 `ACTIVE` 또는 `PAST_DUE`인 subscription을 현재 결제 기간으로 본다.
+2. dataset upload count는 `corpus.dataset.created_at`이 current period에 포함되는 row 수다.
+3. pipeline run count는 `pipeline.pipeline_job.job_type = 'DOMAIN_PACK_GENERATION'`이고 `requested_at`이 current period에 포함되는 row 수다.
+4. `used < limit`이면 허용한다.
+5. `used >= limit`이더라도 `payment.free_onboarding_entitlement.first_creation_allowance_remaining > 0`이고 해당 resource의 기존 사용량이 0이면 허용한다.
+6. 현재 subscription이 없으면 무료 온보딩 첫 생성 권리만 허용하고, 권리가 없으면 `limit = 0`으로 차단한다.
+
+---
+
+## Database
+
+`backend/src/main/resources/db/changelog/db.changelog-master.sql`에 `payment` schema와 quota read model을 추가한다.
+
+| Table | 주요 컬럼 |
+|-------|-----------|
+| `payment.plan` | `plan_key`, `member_limit`, `dataset_upload_limit`, `pipeline_run_limit` |
+| `payment.subscription` | `workspace_id`, `plan_id`, `status`, `current_period_start`, `current_period_end` |
+| `payment.free_onboarding_entitlement` | `workspace_id`, `first_creation_allowance_remaining` |
+
+`member_limit`은 이번 PR에서 조회 응답 endpoint를 새로 만들지는 않지만, 후속 멤버 초대/추가 차단 적용을 위해 plan에 포함한다.
+
+---
+
+## Tests
+
+- `WorkspaceQuotaServiceTest`
+  - current period 사용량이 한도 미만이면 허용
+  - current period 사용량이 한도에 도달하면 `QuotaExceededException`
+  - subscription이 없어도 무료 온보딩 첫 pipeline 실행은 허용
+  - subscription과 무료 온보딩 권리가 없으면 `PIPELINE_RUN` 차단
+- `DatasetUploadServiceTest`, `RawDatasetUploadServiceTest`
+  - quota 초과 시 dataset 저장 전 예외
+- `RawDatasetUploadControllerTest`, `DatasetControllerRawFileTest`
+  - upload quota 초과 응답 body 검증
+- `TriggerDomainPackGenerationUseCaseTest`
+  - pipeline quota 초과 시 job 생성/Airflow trigger 없음
+- `DomainPackGenerationTriggerControllerTest`
+  - pipeline quota 초과 응답 body 검증
+
+---
+
+## Acceptance Criteria
+
+- [ ] dataset 업로드 수가 plan의 `dataset_upload_limit`에 도달하면 추가 업로드 API가 `409 QUOTA_EXCEEDED`를 반환한다.
+- [ ] raw-file 업로드도 같은 `DATASET_UPLOAD` quota로 차단된다.
+- [ ] Domain Pack Generation pipeline 실행 수가 plan의 `pipeline_run_limit`에 도달하면 trigger API가 `409 QUOTA_EXCEEDED`를 반환한다.
+- [ ] quota 초과 응답에는 `resource`, `limit`, `used`가 포함된다.
+- [ ] plan read model은 `member_limit`, `dataset_upload_limit`, `pipeline_run_limit`을 포함한다.
+- [ ] 무료 온보딩 첫 생성 권리가 남아 있고 해당 resource 사용량이 0이면 quota 차단보다 우선 허용한다.
+- [ ] 구독이 없고 무료 온보딩 권리도 없으면 dataset 업로드와 generation trigger를 차단한다.
+
+---
+
+## Open Questions
+
+- 무료 온보딩 권리 차감 시점은 이번 이슈 본문에 명시되지 않았다. 본 PR은 `remaining > 0`과 resource별 기존 사용량 0회를 함께 보아 "첫 생성 플로우"를 1회로 제한한다.
+- 멤버 수 quota 조회를 노출할 구독/plan API는 현재 코드에 존재하지 않아 이번 PR에서는 DB read model까지만 포함한다.

--- a/backend/src/main/java/com/init/corpus/application/DatasetUploadService.java
+++ b/backend/src/main/java/com/init/corpus/application/DatasetUploadService.java
@@ -14,6 +14,7 @@ import com.init.corpus.domain.repository.ConversationTurnRepository;
 import com.init.corpus.domain.repository.DatasetRepository;
 import com.init.corpus.domain.repository.WorkspaceExistenceRepository;
 import com.init.corpus.domain.repository.WorkspaceMembershipRepository;
+import com.init.shared.application.quota.WorkspaceQuotaValidator;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -31,18 +32,21 @@ public class DatasetUploadService {
   private final ConversationTurnRepository conversationTurnRepository;
   private final WorkspaceExistenceRepository workspaceExistenceRepository;
   private final WorkspaceMembershipRepository workspaceMembershipRepository;
+  private final WorkspaceQuotaValidator workspaceQuotaValidator;
 
   public DatasetUploadService(
       DatasetRepository datasetRepository,
       ConversationRepository conversationRepository,
       ConversationTurnRepository conversationTurnRepository,
       WorkspaceExistenceRepository workspaceExistenceRepository,
-      WorkspaceMembershipRepository workspaceMembershipRepository) {
+      WorkspaceMembershipRepository workspaceMembershipRepository,
+      WorkspaceQuotaValidator workspaceQuotaValidator) {
     this.datasetRepository = datasetRepository;
     this.conversationRepository = conversationRepository;
     this.conversationTurnRepository = conversationTurnRepository;
     this.workspaceExistenceRepository = workspaceExistenceRepository;
     this.workspaceMembershipRepository = workspaceMembershipRepository;
+    this.workspaceQuotaValidator = workspaceQuotaValidator;
   }
 
   @Transactional
@@ -59,6 +63,7 @@ public class DatasetUploadService {
         command.workspaceId(), command.datasetKey())) {
       throw new DatasetKeyConflictException("이미 사용 중인 데이터셋 키입니다: " + command.datasetKey());
     }
+    workspaceQuotaValidator.assertDatasetUploadAllowed(command.workspaceId());
 
     Dataset dataset =
         Dataset.create(

--- a/backend/src/main/java/com/init/corpus/application/RawDatasetUploadService.java
+++ b/backend/src/main/java/com/init/corpus/application/RawDatasetUploadService.java
@@ -17,6 +17,7 @@ import com.init.corpus.domain.repository.ConversationTurnRepository;
 import com.init.corpus.domain.repository.DatasetRepository;
 import com.init.corpus.domain.repository.WorkspaceExistenceRepository;
 import com.init.corpus.domain.repository.WorkspaceMembershipRepository;
+import com.init.shared.application.quota.WorkspaceQuotaValidator;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -51,6 +52,7 @@ public class RawDatasetUploadService {
   private final ConversationTurnRepository conversationTurnRepository;
   private final WorkspaceExistenceRepository workspaceExistenceRepository;
   private final WorkspaceMembershipRepository workspaceMembershipRepository;
+  private final WorkspaceQuotaValidator workspaceQuotaValidator;
   private final ObjectMapper objectMapper;
   private final TransactionTemplate transactionTemplate;
 
@@ -60,6 +62,7 @@ public class RawDatasetUploadService {
       ConversationTurnRepository conversationTurnRepository,
       WorkspaceExistenceRepository workspaceExistenceRepository,
       WorkspaceMembershipRepository workspaceMembershipRepository,
+      WorkspaceQuotaValidator workspaceQuotaValidator,
       ObjectMapper objectMapper,
       PlatformTransactionManager transactionManager) {
     this.datasetRepository = datasetRepository;
@@ -67,6 +70,7 @@ public class RawDatasetUploadService {
     this.conversationTurnRepository = conversationTurnRepository;
     this.workspaceExistenceRepository = workspaceExistenceRepository;
     this.workspaceMembershipRepository = workspaceMembershipRepository;
+    this.workspaceQuotaValidator = workspaceQuotaValidator;
     this.objectMapper = objectMapper;
     TransactionTemplate t = new TransactionTemplate(transactionManager);
     t.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
@@ -86,6 +90,7 @@ public class RawDatasetUploadService {
         command.workspaceId(), command.datasetKey())) {
       throw new DatasetKeyConflictException("이미 사용 중인 데이터셋 키입니다: " + command.datasetKey());
     }
+    workspaceQuotaValidator.assertDatasetUploadAllowed(command.workspaceId());
 
     // 1. Parse all conversations upfront — any ConsultingContentParseException
     //    propagates here before any DB write occurs.

--- a/backend/src/main/java/com/init/corpus/application/RawFileUploadService.java
+++ b/backend/src/main/java/com/init/corpus/application/RawFileUploadService.java
@@ -14,6 +14,7 @@ import com.init.corpus.domain.repository.DatasetRawFileRepository;
 import com.init.corpus.domain.repository.DatasetRepository;
 import com.init.corpus.domain.repository.WorkspaceExistenceRepository;
 import com.init.corpus.domain.repository.WorkspaceMembershipRepository;
+import com.init.shared.application.quota.WorkspaceQuotaValidator;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -49,6 +50,7 @@ public class RawFileUploadService {
   private final DatasetRawFileRepository rawFileRepository;
   private final IngestionTriggerPort triggerPort;
   private final ObjectMapper objectMapper;
+  private final WorkspaceQuotaValidator workspaceQuotaValidator;
 
   public RawFileUploadService(
       WorkspaceExistenceRepository workspaceExistenceRepository,
@@ -58,7 +60,8 @@ public class RawFileUploadService {
       RawDatasetUploadService rawDatasetUploadService,
       DatasetRawFileRepository rawFileRepository,
       IngestionTriggerPort triggerPort,
-      ObjectMapper objectMapper) {
+      ObjectMapper objectMapper,
+      WorkspaceQuotaValidator workspaceQuotaValidator) {
     this.workspaceExistenceRepository = workspaceExistenceRepository;
     this.workspaceMembershipRepository = workspaceMembershipRepository;
     this.datasetRepository = datasetRepository;
@@ -67,6 +70,7 @@ public class RawFileUploadService {
     this.rawFileRepository = rawFileRepository;
     this.triggerPort = triggerPort;
     this.objectMapper = objectMapper;
+    this.workspaceQuotaValidator = workspaceQuotaValidator;
   }
 
   @Transactional
@@ -84,6 +88,7 @@ public class RawFileUploadService {
         command.workspaceId(), command.datasetKey())) {
       throw new DatasetKeyConflictException("이미 사용 중인 데이터셋 키입니다: " + command.datasetKey());
     }
+    workspaceQuotaValidator.assertDatasetUploadAllowed(command.workspaceId());
     validateZipFile(command.fileBytes());
 
     // 2. Build objectKey and compute SHA-256 checksum (U-06: Assumption adopted from Recommended

--- a/backend/src/main/java/com/init/payment/application/QuotaResource.java
+++ b/backend/src/main/java/com/init/payment/application/QuotaResource.java
@@ -1,0 +1,16 @@
+package com.init.payment.application;
+
+public enum QuotaResource {
+  DATASET_UPLOAD("DATASET_UPLOAD"),
+  PIPELINE_RUN("PIPELINE_RUN");
+
+  private final String code;
+
+  QuotaResource(String code) {
+    this.code = code;
+  }
+
+  public String code() {
+    return code;
+  }
+}

--- a/backend/src/main/java/com/init/payment/application/SubscriptionResult.java
+++ b/backend/src/main/java/com/init/payment/application/SubscriptionResult.java
@@ -12,7 +12,10 @@ public record SubscriptionResult(
     OffsetDateTime currentPeriodStart,
     OffsetDateTime currentPeriodEnd,
     boolean cancelAtPeriodEnd,
-    String customerKey) {
+    String customerKey,
+    int memberLimit,
+    int datasetUploadLimit,
+    int pipelineRunLimit) {
 
   public static SubscriptionResult from(Subscription subscription, Plan plan) {
     return new SubscriptionResult(
@@ -23,6 +26,9 @@ public record SubscriptionResult(
         subscription.getCurrentPeriodStart(),
         subscription.getCurrentPeriodEnd(),
         subscription.isCancelAtPeriodEnd(),
-        subscription.getCustomerKey());
+        subscription.getCustomerKey(),
+        plan.getMemberLimit(),
+        plan.getDatasetUploadLimit(),
+        plan.getPipelineRunLimit());
   }
 }

--- a/backend/src/main/java/com/init/payment/application/WorkspaceQuota.java
+++ b/backend/src/main/java/com/init/payment/application/WorkspaceQuota.java
@@ -1,0 +1,12 @@
+package com.init.payment.application;
+
+import java.time.OffsetDateTime;
+
+public record WorkspaceQuota(
+    Long workspaceId,
+    String planKey,
+    int memberLimit,
+    int datasetUploadLimit,
+    int pipelineRunLimit,
+    OffsetDateTime currentPeriodStart,
+    OffsetDateTime currentPeriodEnd) {}

--- a/backend/src/main/java/com/init/payment/application/WorkspaceQuotaQueryPort.java
+++ b/backend/src/main/java/com/init/payment/application/WorkspaceQuotaQueryPort.java
@@ -1,0 +1,11 @@
+package com.init.payment.application;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+public interface WorkspaceQuotaQueryPort {
+
+  Optional<WorkspaceQuota> findCurrentQuota(Long workspaceId, OffsetDateTime at);
+
+  boolean hasFreeOnboardingAllowance(Long workspaceId);
+}

--- a/backend/src/main/java/com/init/payment/application/WorkspaceQuotaService.java
+++ b/backend/src/main/java/com/init/payment/application/WorkspaceQuotaService.java
@@ -1,0 +1,82 @@
+package com.init.payment.application;
+
+import com.init.shared.application.exception.QuotaExceededException;
+import com.init.shared.application.quota.WorkspaceQuotaValidator;
+import java.time.Clock;
+import java.time.OffsetDateTime;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class WorkspaceQuotaService implements WorkspaceQuotaValidator {
+
+  private final WorkspaceQuotaQueryPort quotaQueryPort;
+  private final WorkspaceQuotaUsagePort usagePort;
+  private final Clock clock;
+
+  public WorkspaceQuotaService(
+      WorkspaceQuotaQueryPort quotaQueryPort, WorkspaceQuotaUsagePort usagePort, Clock clock) {
+    this.quotaQueryPort = quotaQueryPort;
+    this.usagePort = usagePort;
+    this.clock = clock;
+  }
+
+  @Override
+  public void assertDatasetUploadAllowed(Long workspaceId) {
+    OffsetDateTime now = OffsetDateTime.now(clock);
+    quotaQueryPort
+        .findCurrentQuota(workspaceId, now)
+        .ifPresentOrElse(
+            quota ->
+                assertWithinLimit(
+                    workspaceId,
+                    QuotaResource.DATASET_UPLOAD,
+                    quota.datasetUploadLimit(),
+                    usagePort.countDatasetUploads(
+                        workspaceId, quota.currentPeriodStart(), quota.currentPeriodEnd())),
+            () ->
+                assertFreeOnboardingAllowed(
+                    workspaceId,
+                    QuotaResource.DATASET_UPLOAD,
+                    usagePort.countDatasetUploads(workspaceId)));
+  }
+
+  @Override
+  public void assertPipelineRunAllowed(Long workspaceId) {
+    OffsetDateTime now = OffsetDateTime.now(clock);
+    quotaQueryPort
+        .findCurrentQuota(workspaceId, now)
+        .ifPresentOrElse(
+            quota ->
+                assertWithinLimit(
+                    workspaceId,
+                    QuotaResource.PIPELINE_RUN,
+                    quota.pipelineRunLimit(),
+                    usagePort.countPipelineRuns(
+                        workspaceId, quota.currentPeriodStart(), quota.currentPeriodEnd())),
+            () ->
+                assertFreeOnboardingAllowed(
+                    workspaceId,
+                    QuotaResource.PIPELINE_RUN,
+                    usagePort.countPipelineRuns(workspaceId)));
+  }
+
+  private void assertWithinLimit(Long workspaceId, QuotaResource resource, int limit, long used) {
+    if (used < limit || canUseFreeOnboarding(workspaceId, used)) {
+      return;
+    }
+    throw new QuotaExceededException(resource.code(), limit, used);
+  }
+
+  private void assertFreeOnboardingAllowed(Long workspaceId, QuotaResource resource, long used) {
+    if (canUseFreeOnboarding(workspaceId, used)) {
+      return;
+    }
+    throw new QuotaExceededException(resource.code(), 0, used);
+  }
+
+  private boolean canUseFreeOnboarding(Long workspaceId, long used) {
+    return used == 0 && quotaQueryPort.hasFreeOnboardingAllowance(workspaceId);
+  }
+}

--- a/backend/src/main/java/com/init/payment/application/WorkspaceQuotaUsagePort.java
+++ b/backend/src/main/java/com/init/payment/application/WorkspaceQuotaUsagePort.java
@@ -1,0 +1,16 @@
+package com.init.payment.application;
+
+import java.time.OffsetDateTime;
+
+public interface WorkspaceQuotaUsagePort {
+
+  long countDatasetUploads(
+      Long workspaceId, OffsetDateTime fromInclusive, OffsetDateTime toExclusive);
+
+  long countPipelineRuns(
+      Long workspaceId, OffsetDateTime fromInclusive, OffsetDateTime toExclusive);
+
+  long countDatasetUploads(Long workspaceId);
+
+  long countPipelineRuns(Long workspaceId);
+}

--- a/backend/src/main/java/com/init/payment/domain/model/Plan.java
+++ b/backend/src/main/java/com/init/payment/domain/model/Plan.java
@@ -41,6 +41,15 @@ public class Plan {
   @Column(name = "status", nullable = false)
   private String status;
 
+  @Column(name = "member_limit", nullable = false)
+  private int memberLimit;
+
+  @Column(name = "dataset_upload_limit", nullable = false)
+  private int datasetUploadLimit;
+
+  @Column(name = "pipeline_run_limit", nullable = false)
+  private int pipelineRunLimit;
+
   @Column(name = "created_at", nullable = false, updatable = false)
   private OffsetDateTime createdAt;
 
@@ -69,6 +78,9 @@ public class Plan {
     plan.currency = money.currency();
     plan.billingInterval = billingInterval;
     plan.status = STATUS_ACTIVE;
+    plan.memberLimit = 10;
+    plan.datasetUploadLimit = 10;
+    plan.pipelineRunLimit = 10;
     return plan;
   }
 
@@ -114,6 +126,18 @@ public class Plan {
 
   public String getStatus() {
     return status;
+  }
+
+  public int getMemberLimit() {
+    return memberLimit;
+  }
+
+  public int getDatasetUploadLimit() {
+    return datasetUploadLimit;
+  }
+
+  public int getPipelineRunLimit() {
+    return pipelineRunLimit;
   }
 
   public OffsetDateTime getCreatedAt() {

--- a/backend/src/main/java/com/init/payment/infrastructure/JdbcWorkspaceQuotaRepository.java
+++ b/backend/src/main/java/com/init/payment/infrastructure/JdbcWorkspaceQuotaRepository.java
@@ -1,0 +1,69 @@
+package com.init.payment.infrastructure;
+
+import com.init.payment.application.WorkspaceQuota;
+import com.init.payment.application.WorkspaceQuotaQueryPort;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class JdbcWorkspaceQuotaRepository implements WorkspaceQuotaQueryPort {
+
+  private final JdbcClient jdbcClient;
+
+  public JdbcWorkspaceQuotaRepository(JdbcClient jdbcClient) {
+    this.jdbcClient = jdbcClient;
+  }
+
+  @Override
+  public Optional<WorkspaceQuota> findCurrentQuota(Long workspaceId, OffsetDateTime at) {
+    return jdbcClient
+        .sql(
+            """
+            SELECT s.workspace_id,
+                   p.plan_key,
+                   p.member_limit,
+                   p.dataset_upload_limit,
+                   p.pipeline_run_limit,
+                   s.current_period_start,
+                   s.current_period_end
+              FROM payment.subscription s
+              JOIN payment.plan p ON p.id = s.plan_id
+             WHERE s.workspace_id = :workspaceId
+               AND s.status IN ('ACTIVE', 'PAST_DUE')
+               AND s.current_period_start <= :at
+               AND s.current_period_end > :at
+             ORDER BY s.current_period_end DESC, s.id DESC
+             LIMIT 1
+            """)
+        .param("workspaceId", workspaceId)
+        .param("at", at)
+        .query(
+            (rs, rowNum) ->
+                new WorkspaceQuota(
+                    rs.getLong("workspace_id"),
+                    rs.getString("plan_key"),
+                    rs.getInt("member_limit"),
+                    rs.getInt("dataset_upload_limit"),
+                    rs.getInt("pipeline_run_limit"),
+                    rs.getObject("current_period_start", OffsetDateTime.class),
+                    rs.getObject("current_period_end", OffsetDateTime.class)))
+        .optional();
+  }
+
+  @Override
+  public boolean hasFreeOnboardingAllowance(Long workspaceId) {
+    return Boolean.TRUE.equals(
+        jdbcClient
+            .sql(
+                """
+                SELECT COALESCE(MAX(first_creation_allowance_remaining), 0) > 0
+                  FROM payment.free_onboarding_entitlement
+                 WHERE workspace_id = :workspaceId
+                """)
+            .param("workspaceId", workspaceId)
+            .query(Boolean.class)
+            .single());
+  }
+}

--- a/backend/src/main/java/com/init/payment/infrastructure/JdbcWorkspaceQuotaUsageRepository.java
+++ b/backend/src/main/java/com/init/payment/infrastructure/JdbcWorkspaceQuotaUsageRepository.java
@@ -1,0 +1,79 @@
+package com.init.payment.infrastructure;
+
+import com.init.payment.application.WorkspaceQuotaUsagePort;
+import java.time.OffsetDateTime;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class JdbcWorkspaceQuotaUsageRepository implements WorkspaceQuotaUsagePort {
+
+  private final JdbcClient jdbcClient;
+
+  public JdbcWorkspaceQuotaUsageRepository(JdbcClient jdbcClient) {
+    this.jdbcClient = jdbcClient;
+  }
+
+  @Override
+  public long countDatasetUploads(
+      Long workspaceId, OffsetDateTime fromInclusive, OffsetDateTime toExclusive) {
+    return jdbcClient
+        .sql(
+            """
+            SELECT COUNT(*)
+              FROM corpus.dataset
+             WHERE workspace_id = :workspaceId
+               AND created_at >= :fromInclusive
+               AND created_at < :toExclusive
+            """)
+        .param("workspaceId", workspaceId)
+        .param("fromInclusive", fromInclusive)
+        .param("toExclusive", toExclusive)
+        .query(Long.class)
+        .single();
+  }
+
+  @Override
+  public long countPipelineRuns(
+      Long workspaceId, OffsetDateTime fromInclusive, OffsetDateTime toExclusive) {
+    return jdbcClient
+        .sql(
+            """
+            SELECT COUNT(*)
+              FROM pipeline.pipeline_job
+             WHERE workspace_id = :workspaceId
+               AND job_type = 'DOMAIN_PACK_GENERATION'
+               AND requested_at >= :fromInclusive
+               AND requested_at < :toExclusive
+            """)
+        .param("workspaceId", workspaceId)
+        .param("fromInclusive", fromInclusive)
+        .param("toExclusive", toExclusive)
+        .query(Long.class)
+        .single();
+  }
+
+  @Override
+  public long countDatasetUploads(Long workspaceId) {
+    return jdbcClient
+        .sql("SELECT COUNT(*) FROM corpus.dataset WHERE workspace_id = :workspaceId")
+        .param("workspaceId", workspaceId)
+        .query(Long.class)
+        .single();
+  }
+
+  @Override
+  public long countPipelineRuns(Long workspaceId) {
+    return jdbcClient
+        .sql(
+            """
+            SELECT COUNT(*)
+              FROM pipeline.pipeline_job
+             WHERE workspace_id = :workspaceId
+               AND job_type = 'DOMAIN_PACK_GENERATION'
+            """)
+        .param("workspaceId", workspaceId)
+        .query(Long.class)
+        .single();
+  }
+}

--- a/backend/src/main/java/com/init/payment/presentation/dto/SubscriptionResponse.java
+++ b/backend/src/main/java/com/init/payment/presentation/dto/SubscriptionResponse.java
@@ -11,7 +11,10 @@ public record SubscriptionResponse(
     OffsetDateTime currentPeriodStart,
     OffsetDateTime currentPeriodEnd,
     boolean cancelAtPeriodEnd,
-    String customerKey) {
+    String customerKey,
+    int memberLimit,
+    int datasetUploadLimit,
+    int pipelineRunLimit) {
 
   public static SubscriptionResponse from(SubscriptionResult result) {
     return new SubscriptionResponse(
@@ -22,6 +25,9 @@ public record SubscriptionResponse(
         result.currentPeriodStart(),
         result.currentPeriodEnd(),
         result.cancelAtPeriodEnd(),
-        result.customerKey());
+        result.customerKey(),
+        result.memberLimit(),
+        result.datasetUploadLimit(),
+        result.pipelineRunLimit());
   }
 }

--- a/backend/src/main/java/com/init/pipelinejob/application/TriggerDomainPackGenerationUseCase.java
+++ b/backend/src/main/java/com/init/pipelinejob/application/TriggerDomainPackGenerationUseCase.java
@@ -11,6 +11,7 @@ import com.init.pipelinejob.application.exception.PipelineJobWorkspaceNotFoundEx
 import com.init.pipelinejob.domain.model.PipelineJob;
 import com.init.pipelinejob.domain.repository.PipelineJobRepository;
 import com.init.shared.application.exception.NotFoundException;
+import com.init.shared.application.quota.WorkspaceQuotaValidator;
 import java.time.Clock;
 import java.time.OffsetDateTime;
 import java.util.Set;
@@ -36,6 +37,7 @@ public class TriggerDomainPackGenerationUseCase {
   private final ObjectMapper objectMapper;
   private final Clock clock;
   private final TransactionTemplate transactionTemplate;
+  private final WorkspaceQuotaValidator workspaceQuotaValidator;
 
   public TriggerDomainPackGenerationUseCase(
       PipelineJobRepository pipelineJobRepository,
@@ -46,7 +48,8 @@ public class TriggerDomainPackGenerationUseCase {
       DomainPackGenerationTriggerPort triggerPort,
       ObjectMapper objectMapper,
       Clock clock,
-      PlatformTransactionManager transactionManager) {
+      PlatformTransactionManager transactionManager,
+      WorkspaceQuotaValidator workspaceQuotaValidator) {
     this.pipelineJobRepository = pipelineJobRepository;
     this.workspaceMembershipPort = workspaceMembershipPort;
     this.datasetOwnershipPort = datasetOwnershipPort;
@@ -56,6 +59,7 @@ public class TriggerDomainPackGenerationUseCase {
     this.objectMapper = objectMapper;
     this.clock = clock;
     this.transactionTemplate = new TransactionTemplate(transactionManager);
+    this.workspaceQuotaValidator = workspaceQuotaValidator;
   }
 
   public TriggerDomainPackGenerationResult execute(TriggerDomainPackGenerationCommand command) {
@@ -105,6 +109,7 @@ public class TriggerDomainPackGenerationUseCase {
                   job -> {
                     throw new PipelineJobAlreadyRunningException(job.getId(), job.getStatus());
                   });
+          workspaceQuotaValidator.assertPipelineRunAllowed(command.workspaceId());
 
           String dagId = triggerPort.dagId();
           String objectKey = resolveRawFileObjectKey(command);

--- a/backend/src/main/java/com/init/shared/application/exception/QuotaExceededException.java
+++ b/backend/src/main/java/com/init/shared/application/exception/QuotaExceededException.java
@@ -1,0 +1,27 @@
+package com.init.shared.application.exception;
+
+public class QuotaExceededException extends BusinessException {
+
+  private final String resource;
+  private final int limit;
+  private final long used;
+
+  public QuotaExceededException(String resource, int limit, long used) {
+    super("QUOTA_EXCEEDED", "워크스페이스 사용량 한도를 초과했습니다.");
+    this.resource = resource;
+    this.limit = limit;
+    this.used = used;
+  }
+
+  public String getResource() {
+    return resource;
+  }
+
+  public int getLimit() {
+    return limit;
+  }
+
+  public long getUsed() {
+    return used;
+  }
+}

--- a/backend/src/main/java/com/init/shared/application/quota/WorkspaceQuotaValidator.java
+++ b/backend/src/main/java/com/init/shared/application/quota/WorkspaceQuotaValidator.java
@@ -1,0 +1,8 @@
+package com.init.shared.application.quota;
+
+public interface WorkspaceQuotaValidator {
+
+  void assertDatasetUploadAllowed(Long workspaceId);
+
+  void assertPipelineRunAllowed(Long workspaceId);
+}

--- a/backend/src/main/java/com/init/shared/presentation/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/init/shared/presentation/GlobalExceptionHandler.java
@@ -8,8 +8,10 @@ import com.init.shared.application.exception.InternalException;
 import com.init.shared.application.exception.InvalidCredentialsException;
 import com.init.shared.application.exception.InvalidTokenException;
 import com.init.shared.application.exception.NotFoundException;
+import com.init.shared.application.exception.QuotaExceededException;
 import com.init.shared.application.exception.UnauthorizedException;
 import com.init.shared.presentation.dto.ErrorResponse;
+import com.init.shared.presentation.dto.QuotaExceededErrorResponse;
 import com.init.shared.presentation.dto.ValidationErrorResponse;
 import java.util.List;
 import java.util.Objects;
@@ -68,6 +70,14 @@ public class GlobalExceptionHandler {
   public ResponseEntity<ErrorResponse> handleNotFound(NotFoundException ex) {
     return ResponseEntity.status(HttpStatus.NOT_FOUND)
         .body(new ErrorResponse(ex.getCode(), ex.getMessage()));
+  }
+
+  @ExceptionHandler(QuotaExceededException.class)
+  public ResponseEntity<QuotaExceededErrorResponse> handleQuotaExceeded(QuotaExceededException ex) {
+    return ResponseEntity.status(HttpStatus.CONFLICT)
+        .body(
+            new QuotaExceededErrorResponse(
+                ex.getCode(), ex.getMessage(), ex.getResource(), ex.getLimit(), ex.getUsed()));
   }
 
   @ExceptionHandler(DuplicateException.class)

--- a/backend/src/main/java/com/init/shared/presentation/dto/QuotaExceededErrorResponse.java
+++ b/backend/src/main/java/com/init/shared/presentation/dto/QuotaExceededErrorResponse.java
@@ -1,0 +1,4 @@
+package com.init.shared.presentation.dto;
+
+public record QuotaExceededErrorResponse(
+    String code, String message, String resource, int limit, long used) {}

--- a/backend/src/main/resources/db/changelog/db.changelog-master.sql
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.sql
@@ -1063,3 +1063,24 @@ create unique index uq_payment_subscription_workspace_open
 --changeset init:20260603-add-idempotency-key-payment-cancel
 --comment: Per-cancel-attempt idempotency key for Toss API — prevents partial-cancel collisions (V-EC-004)
 alter table payment.payment_cancel add column idempotency_key varchar(255);
+
+--changeset init:20260604-add-payment-plan-quota-limits
+--comment: Add workspace quota limits to subscription plans for hard usage blocking
+alter table payment.plan add column member_limit integer not null default 10;
+alter table payment.plan add column dataset_upload_limit integer not null default 10;
+alter table payment.plan add column pipeline_run_limit integer not null default 10;
+alter table payment.plan
+    add constraint chk_payment_plan_member_limit check (member_limit >= 0),
+    add constraint chk_payment_plan_dataset_upload_limit check (dataset_upload_limit >= 0),
+    add constraint chk_payment_plan_pipeline_run_limit check (pipeline_run_limit >= 0);
+
+--changeset init:20260604-create-free-onboarding-entitlement-table
+--comment: Track free onboarding first creation allowance before subscription quota applies
+create table payment.free_onboarding_entitlement (
+    id                                 bigserial primary key,
+    workspace_id                       bigint not null unique references app.workspace(id) on delete cascade,
+    first_creation_allowance_remaining integer not null default 1,
+    created_at                         timestamptz not null default now(),
+    updated_at                         timestamptz not null default now(),
+    constraint chk_free_onboarding_allowance_remaining check (first_creation_allowance_remaining >= 0)
+);

--- a/backend/src/test/java/com/init/corpus/application/DatasetUploadServiceTest.java
+++ b/backend/src/test/java/com/init/corpus/application/DatasetUploadServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -20,6 +21,8 @@ import com.init.corpus.domain.repository.ConversationTurnRepository;
 import com.init.corpus.domain.repository.DatasetRepository;
 import com.init.corpus.domain.repository.WorkspaceExistenceRepository;
 import com.init.corpus.domain.repository.WorkspaceMembershipRepository;
+import com.init.shared.application.exception.QuotaExceededException;
+import com.init.shared.application.quota.WorkspaceQuotaValidator;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -38,6 +41,7 @@ class DatasetUploadServiceTest {
   @Mock private ConversationTurnRepository conversationTurnRepository;
   @Mock private WorkspaceExistenceRepository workspaceExistenceRepository;
   @Mock private WorkspaceMembershipRepository workspaceMembershipRepository;
+  @Mock private WorkspaceQuotaValidator workspaceQuotaValidator;
 
   private DatasetUploadService service;
 
@@ -49,7 +53,8 @@ class DatasetUploadServiceTest {
             conversationRepository,
             conversationTurnRepository,
             workspaceExistenceRepository,
-            workspaceMembershipRepository);
+            workspaceMembershipRepository,
+            workspaceQuotaValidator);
   }
 
   @Test
@@ -90,6 +95,24 @@ class DatasetUploadServiceTest {
     // when & then
     assertThatThrownBy(() -> service.upload(buildCommand(1L, 1L)))
         .isInstanceOf(DatasetKeyConflictException.class);
+
+    verify(datasetRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("quota 초과 → QuotaExceededException, DB write 없음")
+  void should_QuotaExceededException발생_when_quota초과() {
+    // given
+    given(workspaceExistenceRepository.existsById(1L)).willReturn(true);
+    given(workspaceMembershipRepository.existsByWorkspaceIdAndUserId(1L, 1L)).willReturn(true);
+    given(datasetRepository.existsByWorkspaceIdAndDatasetKey(1L, "test-key")).willReturn(false);
+    willThrow(new QuotaExceededException("DATASET_UPLOAD", 3, 3))
+        .given(workspaceQuotaValidator)
+        .assertDatasetUploadAllowed(1L);
+
+    // when & then
+    assertThatThrownBy(() -> service.upload(buildCommand(1L, 1L)))
+        .isInstanceOf(QuotaExceededException.class);
 
     verify(datasetRepository, never()).save(any());
   }

--- a/backend/src/test/java/com/init/corpus/application/RawDatasetUploadServiceTest.java
+++ b/backend/src/test/java/com/init/corpus/application/RawDatasetUploadServiceTest.java
@@ -29,6 +29,8 @@ import com.init.corpus.domain.repository.DatasetRepository;
 import com.init.corpus.domain.repository.WorkspaceExistenceRepository;
 import com.init.corpus.domain.repository.WorkspaceMembershipRepository;
 import com.init.fixtures.Fixtures;
+import com.init.shared.application.exception.QuotaExceededException;
+import com.init.shared.application.quota.WorkspaceQuotaValidator;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
@@ -51,6 +53,7 @@ class RawDatasetUploadServiceTest {
   @Mock private ConversationTurnRepository conversationTurnRepository;
   @Mock private WorkspaceExistenceRepository workspaceExistenceRepository;
   @Mock private WorkspaceMembershipRepository workspaceMembershipRepository;
+  @Mock private WorkspaceQuotaValidator workspaceQuotaValidator;
   @Mock private PlatformTransactionManager transactionManager;
 
   private RawDatasetUploadService service;
@@ -68,6 +71,7 @@ class RawDatasetUploadServiceTest {
             conversationTurnRepository,
             workspaceExistenceRepository,
             workspaceMembershipRepository,
+            workspaceQuotaValidator,
             new ObjectMapper(),
             transactionManager);
   }
@@ -111,6 +115,25 @@ class RawDatasetUploadServiceTest {
     // when & then
     assertThatThrownBy(() -> service.upload(Fixtures.rawDatasetUploadCommand(1L, 1L)))
         .isInstanceOf(DatasetKeyConflictException.class);
+
+    verify(datasetRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("quota 초과 → QuotaExceededException, DB write 없음")
+  void should_QuotaExceededException발생_when_quota초과() {
+    // given
+    given(workspaceExistenceRepository.existsById(1L)).willReturn(true);
+    given(workspaceMembershipRepository.existsByWorkspaceIdAndUserId(1L, 1L)).willReturn(true);
+    given(datasetRepository.existsByWorkspaceIdAndDatasetKey(1L, "test-dataset-key"))
+        .willReturn(false);
+    willThrow(new QuotaExceededException("DATASET_UPLOAD", 3, 3))
+        .given(workspaceQuotaValidator)
+        .assertDatasetUploadAllowed(1L);
+
+    // when & then
+    assertThatThrownBy(() -> service.upload(Fixtures.rawDatasetUploadCommand(1L, 1L)))
+        .isInstanceOf(QuotaExceededException.class);
 
     verify(datasetRepository, never()).save(any());
   }

--- a/backend/src/test/java/com/init/corpus/application/RawFileUploadServiceTest.java
+++ b/backend/src/test/java/com/init/corpus/application/RawFileUploadServiceTest.java
@@ -25,6 +25,8 @@ import com.init.corpus.domain.repository.DatasetRawFileRepository;
 import com.init.corpus.domain.repository.DatasetRepository;
 import com.init.corpus.domain.repository.WorkspaceExistenceRepository;
 import com.init.corpus.domain.repository.WorkspaceMembershipRepository;
+import com.init.shared.application.exception.QuotaExceededException;
+import com.init.shared.application.quota.WorkspaceQuotaValidator;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -50,6 +52,7 @@ class RawFileUploadServiceTest {
   @Mock private RawDatasetUploadService rawDatasetUploadService;
   @Mock private DatasetRawFileRepository rawFileRepository;
   @Mock private IngestionTriggerPort triggerPort;
+  @Mock private WorkspaceQuotaValidator workspaceQuotaValidator;
 
   private RawFileUploadService service;
 
@@ -71,7 +74,8 @@ class RawFileUploadServiceTest {
             rawDatasetUploadService,
             rawFileRepository,
             triggerPort,
-            new ObjectMapper());
+            new ObjectMapper(),
+            workspaceQuotaValidator);
   }
 
   @Test
@@ -112,6 +116,36 @@ class RawFileUploadServiceTest {
     verify(rawDatasetUploadService).upload(any());
     verify(rawFileRepository).save(any());
     verify(triggerPort).trigger(anyLong(), anyLong(), anyString());
+  }
+
+  @Test
+  @DisplayName("quota 초과 시 S3 업로드 전에 차단한다")
+  void upload_quotaExceeded_doesNotPutFile() {
+    given(workspaceExistenceRepository.existsById(1L)).willReturn(true);
+    given(workspaceMembershipRepository.existsByWorkspaceIdAndUserId(1L, 1L)).willReturn(true);
+    given(datasetRepository.existsByWorkspaceIdAndDatasetKey(1L, "test-key")).willReturn(false);
+    willThrow(new QuotaExceededException("DATASET_UPLOAD", 3, 3))
+        .given(workspaceQuotaValidator)
+        .assertDatasetUploadAllowed(1L);
+
+    byte[] zipBytes = validZipBytes();
+    RawFileUploadCommand command =
+        new RawFileUploadCommand(
+            1L,
+            "test-key",
+            "테스트",
+            "CRM",
+            1L,
+            zipBytes,
+            "test.zip",
+            "application/zip",
+            (long) zipBytes.length);
+
+    assertThatThrownBy(() -> service.upload(command)).isInstanceOf(QuotaExceededException.class);
+
+    verify(storagePort, never()).put(anyString(), any(), anyString());
+    verify(rawDatasetUploadService, never()).upload(any());
+    verify(triggerPort, never()).trigger(anyLong(), anyLong(), anyString());
   }
 
   @Test

--- a/backend/src/test/java/com/init/corpus/presentation/DatasetControllerRawFileTest.java
+++ b/backend/src/test/java/com/init/corpus/presentation/DatasetControllerRawFileTest.java
@@ -18,6 +18,7 @@ import com.init.corpus.application.exception.WorkspaceNotFoundException;
 import com.init.corpus.domain.model.DatasetStatus;
 import com.init.corpus.domain.model.PiiRedactionStatus;
 import com.init.fixtures.WithLongPrincipal;
+import com.init.shared.application.exception.QuotaExceededException;
 import com.init.shared.infrastructure.security.JwtAuthenticationFilter;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -227,5 +228,30 @@ class DatasetControllerRawFileTest {
                 .with(csrf()))
         .andExpect(status().isConflict())
         .andExpect(jsonPath("$.code").value("DATASET_KEY_CONFLICT"));
+  }
+
+  @Test
+  @DisplayName("POST /raw-file — quota 초과 → 409 QUOTA_EXCEEDED")
+  @WithLongPrincipal(1L)
+  void uploadRawFile_quotaExceeded_returns409() throws Exception {
+    given(rawFileUploadService.upload(any()))
+        .willThrow(new QuotaExceededException("DATASET_UPLOAD", 3, 3));
+
+    MockMultipartFile mockFile =
+        new MockMultipartFile("file", "test.zip", "application/zip", VALID_ZIP);
+
+    mockMvc
+        .perform(
+            multipart("/api/v1/workspaces/1/datasets/raw-file")
+                .file(mockFile)
+                .param("datasetKey", "next-key")
+                .param("name", "테스트")
+                .param("sourceType", "CRM")
+                .with(csrf()))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("QUOTA_EXCEEDED"))
+        .andExpect(jsonPath("$.resource").value("DATASET_UPLOAD"))
+        .andExpect(jsonPath("$.limit").value(3))
+        .andExpect(jsonPath("$.used").value(3));
   }
 }

--- a/backend/src/test/java/com/init/corpus/presentation/RawDatasetUploadControllerTest.java
+++ b/backend/src/test/java/com/init/corpus/presentation/RawDatasetUploadControllerTest.java
@@ -20,6 +20,7 @@ import com.init.corpus.domain.model.DatasetStatus;
 import com.init.corpus.domain.model.PiiRedactionStatus;
 import com.init.fixtures.Fixtures;
 import com.init.fixtures.WithLongPrincipal;
+import com.init.shared.application.exception.QuotaExceededException;
 import com.init.shared.infrastructure.security.JwtAuthenticationFilter;
 import java.util.List;
 import java.util.Map;
@@ -83,6 +84,35 @@ class RawDatasetUploadControllerTest {
                         Fixtures.validConsultingContent()))));
   }
 
+  private String validStructuredRequestBody() throws Exception {
+    return objectMapper.writeValueAsString(
+        Map.of(
+            "datasetKey",
+            "structured-key",
+            "name",
+            "Structured Dataset",
+            "sourceType",
+            "csv",
+            "conversations",
+            List.of(
+                Map.of(
+                    "externalCaseId",
+                    "case-001",
+                    "channel",
+                    "CRM",
+                    "languageCode",
+                    "ko",
+                    "turns",
+                    List.of(
+                        Map.of(
+                            "turnIndex",
+                            0,
+                            "speakerRole",
+                            "CUSTOMER",
+                            "messageText",
+                            "주문 관련 문의입니다."))))));
+  }
+
   @Test
   @DisplayName("유효한 요청 → 201 Created")
   @WithLongPrincipal(1L)
@@ -135,6 +165,46 @@ class RawDatasetUploadControllerTest {
                 .with(csrf()))
         .andExpect(status().isConflict())
         .andExpect(jsonPath("$.code").value("DATASET_KEY_CONFLICT"));
+  }
+
+  @Test
+  @DisplayName("quota 초과 → 409 QUOTA_EXCEEDED")
+  @WithLongPrincipal(1L)
+  void uploadRawDataset_quotaExceeded_returns409() throws Exception {
+    given(rawDatasetUploadService.upload(any()))
+        .willThrow(new QuotaExceededException("DATASET_UPLOAD", 3, 3));
+
+    mockMvc
+        .perform(
+            post("/api/v1/workspaces/1/datasets/raw")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(validRequestBody())
+                .with(csrf()))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("QUOTA_EXCEEDED"))
+        .andExpect(jsonPath("$.resource").value("DATASET_UPLOAD"))
+        .andExpect(jsonPath("$.limit").value(3))
+        .andExpect(jsonPath("$.used").value(3));
+  }
+
+  @Test
+  @DisplayName("구조화 dataset quota 초과 → 409 QUOTA_EXCEEDED")
+  @WithLongPrincipal(1L)
+  void uploadDataset_quotaExceeded_returns409() throws Exception {
+    given(datasetUploadService.upload(any()))
+        .willThrow(new QuotaExceededException("DATASET_UPLOAD", 3, 3));
+
+    mockMvc
+        .perform(
+            post("/api/v1/workspaces/1/datasets")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(validStructuredRequestBody())
+                .with(csrf()))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("QUOTA_EXCEEDED"))
+        .andExpect(jsonPath("$.resource").value("DATASET_UPLOAD"))
+        .andExpect(jsonPath("$.limit").value(3))
+        .andExpect(jsonPath("$.used").value(3));
   }
 
   @Test

--- a/backend/src/test/java/com/init/payment/application/WorkspaceQuotaServiceTest.java
+++ b/backend/src/test/java/com/init/payment/application/WorkspaceQuotaServiceTest.java
@@ -1,0 +1,100 @@
+package com.init.payment.application;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import com.init.shared.application.exception.QuotaExceededException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("WorkspaceQuotaService")
+class WorkspaceQuotaServiceTest {
+
+  @Mock private WorkspaceQuotaQueryPort quotaQueryPort;
+  @Mock private WorkspaceQuotaUsagePort usagePort;
+
+  private WorkspaceQuotaService service;
+  private final Clock fixedClock =
+      Clock.fixed(Instant.parse("2026-06-04T00:00:00Z"), ZoneOffset.UTC);
+  private final OffsetDateTime periodStart = OffsetDateTime.parse("2026-06-01T00:00:00Z");
+  private final OffsetDateTime periodEnd = OffsetDateTime.parse("2026-07-01T00:00:00Z");
+
+  @BeforeEach
+  void setUp() {
+    service = new WorkspaceQuotaService(quotaQueryPort, usagePort, fixedClock);
+  }
+
+  @Test
+  @DisplayName("현재 기간 dataset 사용량이 한도 미만이면 허용한다")
+  void assertDatasetUploadAllowed_underLimit_allows() {
+    given(quotaQueryPort.findCurrentQuota(1L, OffsetDateTime.now(fixedClock)))
+        .willReturn(Optional.of(quota(3, 5)));
+    given(usagePort.countDatasetUploads(1L, periodStart, periodEnd)).willReturn(2L);
+
+    assertThatCode(() -> service.assertDatasetUploadAllowed(1L)).doesNotThrowAnyException();
+  }
+
+  @Test
+  @DisplayName("현재 기간 dataset 사용량이 한도에 도달하면 QUOTA_EXCEEDED를 던진다")
+  void assertDatasetUploadAllowed_atLimit_throws() {
+    given(quotaQueryPort.findCurrentQuota(1L, OffsetDateTime.now(fixedClock)))
+        .willReturn(Optional.of(quota(3, 5)));
+    given(usagePort.countDatasetUploads(1L, periodStart, periodEnd)).willReturn(3L);
+
+    assertThatThrownBy(() -> service.assertDatasetUploadAllowed(1L))
+        .isInstanceOfSatisfying(
+            QuotaExceededException.class,
+            ex -> {
+              org.assertj.core.api.Assertions.assertThat(ex.getResource())
+                  .isEqualTo("DATASET_UPLOAD");
+              org.assertj.core.api.Assertions.assertThat(ex.getLimit()).isEqualTo(3);
+              org.assertj.core.api.Assertions.assertThat(ex.getUsed()).isEqualTo(3);
+            });
+  }
+
+  @Test
+  @DisplayName("구독이 없어도 무료 온보딩 첫 pipeline 실행 권리가 남아 있으면 허용한다")
+  void assertPipelineRunAllowed_freeOnboardingFirstRun_allows() {
+    given(quotaQueryPort.findCurrentQuota(1L, OffsetDateTime.now(fixedClock)))
+        .willReturn(Optional.empty());
+    given(usagePort.countPipelineRuns(1L)).willReturn(0L);
+    given(quotaQueryPort.hasFreeOnboardingAllowance(1L)).willReturn(true);
+
+    assertThatCode(() -> service.assertPipelineRunAllowed(1L)).doesNotThrowAnyException();
+  }
+
+  @Test
+  @DisplayName("구독과 무료 온보딩 권리가 없으면 pipeline 실행을 차단한다")
+  void assertPipelineRunAllowed_noSubscriptionNoFreeAllowance_throws() {
+    given(quotaQueryPort.findCurrentQuota(1L, OffsetDateTime.now(fixedClock)))
+        .willReturn(Optional.empty());
+    given(usagePort.countPipelineRuns(1L)).willReturn(0L);
+    given(quotaQueryPort.hasFreeOnboardingAllowance(1L)).willReturn(false);
+
+    assertThatThrownBy(() -> service.assertPipelineRunAllowed(1L))
+        .isInstanceOfSatisfying(
+            QuotaExceededException.class,
+            ex -> {
+              org.assertj.core.api.Assertions.assertThat(ex.getResource())
+                  .isEqualTo("PIPELINE_RUN");
+              org.assertj.core.api.Assertions.assertThat(ex.getLimit()).isZero();
+              org.assertj.core.api.Assertions.assertThat(ex.getUsed()).isZero();
+            });
+  }
+
+  private WorkspaceQuota quota(int datasetLimit, int pipelineLimit) {
+    return new WorkspaceQuota(
+        1L, "pro_monthly", 10, datasetLimit, pipelineLimit, periodStart, periodEnd);
+  }
+}

--- a/backend/src/test/java/com/init/payment/presentation/SubscriptionControllerTest.java
+++ b/backend/src/test/java/com/init/payment/presentation/SubscriptionControllerTest.java
@@ -56,7 +56,10 @@ class SubscriptionControllerTest {
         .perform(get(BASE_URL + "/subscription"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.status").value("ACTIVE"))
-        .andExpect(jsonPath("$.planKey").value("pro_monthly"));
+        .andExpect(jsonPath("$.planKey").value("pro_monthly"))
+        .andExpect(jsonPath("$.memberLimit").value(10))
+        .andExpect(jsonPath("$.datasetUploadLimit").value(10))
+        .andExpect(jsonPath("$.pipelineRunLimit").value(10));
   }
 
   @Test
@@ -147,6 +150,9 @@ class SubscriptionControllerTest {
         OffsetDateTime.parse("2026-06-01T00:00:00Z"),
         OffsetDateTime.parse("2026-07-01T00:00:00Z"),
         false,
-        "wsk_1_abc");
+        "wsk_1_abc",
+        10,
+        10,
+        10);
   }
 }

--- a/backend/src/test/java/com/init/pipelinejob/application/TriggerDomainPackGenerationUseCaseTest.java
+++ b/backend/src/test/java/com/init/pipelinejob/application/TriggerDomainPackGenerationUseCaseTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -16,6 +17,8 @@ import com.init.pipelinejob.application.exception.PipelineJobWorkspaceAccessDeni
 import com.init.pipelinejob.domain.model.PipelineJob;
 import com.init.pipelinejob.domain.repository.PipelineJobRepository;
 import com.init.shared.application.exception.NotFoundException;
+import com.init.shared.application.exception.QuotaExceededException;
+import com.init.shared.application.quota.WorkspaceQuotaValidator;
 import java.lang.reflect.Constructor;
 import java.time.Clock;
 import java.time.Instant;
@@ -44,6 +47,7 @@ class TriggerDomainPackGenerationUseCaseTest {
   @Mock private DatasetRawFileLookupPort datasetRawFileLookupPort;
   @Mock private DomainPackGenerationConcurrencyGuard concurrencyGuard;
   @Mock private DomainPackGenerationTriggerPort triggerPort;
+  @Mock private WorkspaceQuotaValidator workspaceQuotaValidator;
   @Mock private PlatformTransactionManager transactionManager;
 
   private TriggerDomainPackGenerationUseCase useCase;
@@ -84,7 +88,8 @@ class TriggerDomainPackGenerationUseCaseTest {
             triggerPort,
             new ObjectMapper(),
             fixedClock,
-            transactionManager);
+            transactionManager,
+            workspaceQuotaValidator);
   }
 
   @Test
@@ -215,6 +220,22 @@ class TriggerDomainPackGenerationUseCaseTest {
             throwable ->
                 assertThat(((NotFoundException) throwable).getCode())
                     .isEqualTo("RAW_FILE_NOT_FOUND"));
+
+    verify(pipelineJobRepository, never()).saveAndFlush(any());
+    verify(triggerPort, never()).trigger(any());
+  }
+
+  @Test
+  @DisplayName("pipeline run quota 초과 시 job 생성과 Airflow trigger를 실행하지 않는다")
+  void execute_quotaExceeded_doesNotCreateJob() {
+    allowAccess();
+    given(pipelineJobRepository.findActiveDomainPackGenerationJob(1L, 7L))
+        .willReturn(Optional.empty());
+    willThrow(new QuotaExceededException("PIPELINE_RUN", 5, 5))
+        .given(workspaceQuotaValidator)
+        .assertPipelineRunAllowed(1L);
+
+    assertThatThrownBy(() -> useCase.execute(command())).isInstanceOf(QuotaExceededException.class);
 
     verify(pipelineJobRepository, never()).saveAndFlush(any());
     verify(triggerPort, never()).trigger(any());

--- a/backend/src/test/java/com/init/pipelinejob/presentation/DomainPackGenerationTriggerControllerTest.java
+++ b/backend/src/test/java/com/init/pipelinejob/presentation/DomainPackGenerationTriggerControllerTest.java
@@ -12,6 +12,7 @@ import com.init.pipelinejob.application.TriggerDomainPackGenerationResult;
 import com.init.pipelinejob.application.TriggerDomainPackGenerationUseCase;
 import com.init.pipelinejob.application.exception.AirflowTriggerFailedException;
 import com.init.pipelinejob.domain.model.PipelineJob;
+import com.init.shared.application.exception.QuotaExceededException;
 import com.init.shared.infrastructure.security.JwtAuthenticationFilter;
 import java.time.OffsetDateTime;
 import org.junit.jupiter.api.DisplayName;
@@ -81,6 +82,21 @@ class DomainPackGenerationTriggerControllerTest {
         .andExpect(jsonPath("$.code").value("AIRFLOW_TRIGGER_FAILED"))
         .andExpect(jsonPath("$.pipelineJobId").value(123))
         .andExpect(jsonPath("$.status").value("FAILED"));
+  }
+
+  @Test
+  @DisplayName("pipeline run quota 초과 시 409 QUOTA_EXCEEDED를 반환한다")
+  @WithLongPrincipal(55L)
+  void trigger_quotaExceeded_returns409() throws Exception {
+    given(useCase.execute(any())).willThrow(new QuotaExceededException("PIPELINE_RUN", 5, 5));
+
+    mockMvc
+        .perform(post(BASE_URL).with(csrf()))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("QUOTA_EXCEEDED"))
+        .andExpect(jsonPath("$.resource").value("PIPELINE_RUN"))
+        .andExpect(jsonPath("$.limit").value(5))
+        .andExpect(jsonPath("$.used").value(5));
   }
 
   @Test


### PR DESCRIPTION
Closes #498

## 변경 사항

- 워크스페이스의 현재 구독 기간 quota를 조회하는 payment read model과 사용량 계산 포트를 추가했습니다.
- 상담 로그 데이터셋 업로드와 Domain Pack 생성 파이프라인 트리거가 dataset/pipeline quota 초과 시 저장·업로드·Airflow 호출 전에 차단됩니다.
- quota 초과 응답은 `409 QUOTA_EXCEEDED`와 함께 `resource`, `limit`, `used`를 반환합니다.
- 구독 정보가 없더라도 무료 온보딩 권한이 남아 있고 해당 리소스 사용량이 0이면 첫 생성은 허용합니다.
- 기존 subscription 응답에 `memberLimit`, `datasetUploadLimit`, `pipelineRunLimit`를 포함해 plan/query 응답에서 quota 값을 확인할 수 있습니다.

## 검증

- `git diff --check`
- `cd backend && JAVA_HOME=/Users/owen/.local/share/mise/installs/java/temurin-21.0.11+10.0.LTS ./gradlew spotlessApply spotlessCheck test --tests 'com.init.payment.application.WorkspaceQuotaServiceTest' --tests 'com.init.payment.presentation.SubscriptionControllerTest' --tests 'com.init.corpus.application.DatasetUploadServiceTest' --tests 'com.init.corpus.application.RawDatasetUploadServiceTest' --tests 'com.init.corpus.application.RawFileUploadServiceTest' --tests 'com.init.pipelinejob.application.TriggerDomainPackGenerationUseCaseTest' --tests 'com.init.corpus.presentation.RawDatasetUploadControllerTest' --tests 'com.init.corpus.presentation.DatasetControllerRawFileTest' --tests 'com.init.pipelinejob.presentation.DomainPackGenerationTriggerControllerTest'`
- `cd backend && JAVA_HOME=/Users/owen/.local/share/mise/installs/java/temurin-21.0.11+10.0.LTS ./gradlew test`
- `cd backend && JAVA_HOME=/Users/owen/.local/share/mise/installs/java/temurin-21.0.11+10.0.LTS ./gradlew check`

## 참고

- `./gradlew check`는 기존 checkstyle warning backlog를 출력하지만 `BUILD SUCCESSFUL`로 종료됩니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 워크스페이스 데이터셋 업로드 및 파이프라인 실행 할당량 관리 기능 추가
  * 할당량 초과 시 409 응답으로 자원, 제한값, 사용량 정보 제공
  * 무료 온보딩 첫 생성 권리를 통한 할당량 한도 예외 처리
  * 구독 조회 응답에 멤버, 업로드, 파이프라인 실행 한도 정보 포함

* **테스트**
  * 할당량 검증 시나리오별 단위 및 통합 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->