### PR TITLE
feat(dashboard): 운영 지식팩 건강도 제공

### DIFF
--- a/.agent/specs/520.md
+++ b/.agent/specs/520.md
@@ -1,0 +1,145 @@
+# Issue 520 feat(dashboard): 도메인팩 운영 건강도
+
+## Goal
+
+워크스페이스 대시보드에서 고객사가 현재 운영 중인 지식팩 상태, 최근 상담 로그 업로드, 최근 지식팩 생성 상태, 검토 대기 항목을 고객용 표현으로 확인하고 다음 행동으로 이동할 수 있게 한다.
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A["워크스페이스 대시보드 진입"] --> B["운영 지식팩 건강도 조회"]
+    B --> C{"운영 지식팩 존재?"}
+    C -->|Yes| D["운영 버전과 운영 반영일 표시"]
+    C -->|No| E["지식팩 생성 CTA 표시"]
+    B --> F{"최근 상담 로그 존재?"}
+    F -->|Yes| G["마지막 상담 로그 업로드일 표시"]
+    F -->|No| H["상담 로그 업로드 CTA 표시"]
+    B --> I{"검토 대기 또는 생성 실패?"}
+    I -->|Yes| J["고객용 경고와 검토/재생성 CTA 표시"]
+    I -->|No| K["정상 운영 문구 표시"]
+```
+
+## Design Diff
+
+| 영역 | As-is | To-be | 변경 내용 |
+|------|-------|-------|----------|
+| 대시보드 본문 | 빈 상태와 placeholder 슬롯만 표시 | 운영 지식팩 건강도 패널 표시 | 기존 shell 위에 실제 운영 상태 카드 추가 |
+| 용어 | Domain Pack / Pipeline / Review 혼재 | 운영 지식팩 / 지식팩 생성 / 검토 대기 / 운영 반영 | 고객용 표현으로 상태 설명 |
+| CTA | 초기 empty CTA만 표시 | 상황별 상담 로그 업로드, 검토 화면, 지식팩 생성 CTA 표시 | 실패/대기/미업로드 상태별 다음 행동 제공 |
+
+## Component Tree
+
+```
+WorkspaceDashboardPage
+├─ DashboardFilters
+├─ FilterSummary
+├─ KnowledgePackHealthPanel
+│  ├─ HealthMetric
+│  ├─ HealthAlertList
+│  └─ HealthCtaList
+└─ DashboardSlot
+```
+
+## API Integration
+
+### Endpoint
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/v1/workspaces/{workspaceId}/dashboard/knowledge-pack-health` | 운영 지식팩 건강도 조회 |
+
+### Response Shape
+
+```json
+{
+  "activeKnowledgePack": {
+    "packId": 1,
+    "packName": "고객지원 운영 지식팩",
+    "versionId": 12,
+    "versionNo": 4,
+    "publishedAt": "2026-06-03T10:00:00Z",
+    "createdAt": "2026-06-02T10:00:00Z",
+    "sourcePipelineJobId": 77
+  },
+  "lastLogUpload": {
+    "datasetId": 9,
+    "datasetKey": "june-cs-log",
+    "datasetName": "6월 상담 로그",
+    "datasetStatus": "READY",
+    "uploadedAt": "2026-06-03T09:00:00Z"
+  },
+  "lastKnowledgePackGeneration": {
+    "pipelineJobId": 77,
+    "datasetId": 9,
+    "domainPackId": 1,
+    "status": "SUCCEEDED",
+    "requestedAt": "2026-06-03T09:10:00Z",
+    "startedAt": "2026-06-03T09:11:00Z",
+    "finishedAt": "2026-06-03T09:30:00Z",
+    "lastErrorMessage": null
+  },
+  "pendingReviewCount": 0
+}
+```
+
+## Data Flow
+
+```
+WorkspaceDashboardPage
+  -> useWorkspaceDashboardHealth(workspaceId)
+  -> customFetch("/api/v1/workspaces/{workspaceId}/dashboard/knowledge-pack-health")
+  -> WorkspaceDashboardController
+  -> GetWorkspaceDashboardHealthUseCase
+  -> WorkspaceDashboardQueryPort
+  -> JdbcWorkspaceDashboardQueryAdapter
+```
+
+## Affected Files
+
+| 파일 | 변경 유형 | 설명 |
+|------|----------|------|
+| `.agent/specs/520.md` | new | 이슈 스펙 |
+| `backend/src/main/java/com/init/workspace/application/WorkspaceDashboardQueryPort.java` | new | 대시보드 read model port |
+| `backend/src/main/java/com/init/workspace/application/GetWorkspaceDashboardHealthUseCase.java` | new | 멤버십 검증 후 건강도 조회 |
+| `backend/src/main/java/com/init/workspace/application/WorkspaceDashboardHealthResult.java` | new | 건강도 응답 record |
+| `backend/src/main/java/com/init/workspace/application/WorkspaceDashboardKnowledgePackResult.java` | new | 운영 지식팩 응답 record |
+| `backend/src/main/java/com/init/workspace/application/WorkspaceDashboardLogUploadResult.java` | new | 최근 상담 로그 업로드 응답 record |
+| `backend/src/main/java/com/init/workspace/application/WorkspaceDashboardGenerationResult.java` | new | 최근 지식팩 생성 응답 record |
+| `backend/src/main/java/com/init/workspace/infrastructure/persistence/JdbcWorkspaceDashboardQueryAdapter.java` | new | 기존 schema에서 운영 상태 조회 |
+| `backend/src/main/java/com/init/workspace/presentation/WorkspaceDashboardController.java` | new | 고객 대시보드 건강도 API |
+| `frontend/src/features/workspace-dashboard-health/` | new | API hook, view model, 건강도 패널 |
+| `frontend/src/pages/workspace/ui/WorkspaceDashboardPage.tsx` | modify | 대시보드에 건강도 패널 연결 |
+
+## State Management
+
+- Server state: TanStack Query로 workspace별 건강도 조회.
+- Client state: 기존 dashboard filter local state 유지.
+- OpenAPI generated endpoint가 아직 없으므로 `workspace-dashboard-health/api`에 직접 wrapper를 두고, OpenAPI 미생성 사유를 파일에 명시한다.
+
+## Alerts and CTA Rules
+
+| 조건 | 경고 | CTA |
+|------|------|-----|
+| 운영 지식팩 없음 | 운영에 반영된 지식팩이 없다는 문구 | 지식팩 생성 |
+| 마지막 상담 로그 없음 | 상담 로그가 아직 없다는 문구 | 상담 로그 업로드 |
+| 마지막 상담 로그 업로드일이 운영 반영일보다 최신 | 새 로그가 운영 지식팩에 아직 반영되지 않았다는 문구 | 지식팩 생성 |
+| 최근 지식팩 생성 상태가 `FAILED` | 지식팩 생성 실패를 고객용 문구로 표시 | 지식팩 생성 |
+| 검토 대기 항목 수 > 0 | 검토 대기 항목 수 표시 | 검토 화면 |
+
+## Non-goals
+
+- 상세 pipeline job 로그 표시
+- admin 운영 관제 기능
+- 자동 추천 생성
+- 새로운 지표 계산 또는 chart 구현
+
+## Validation
+
+- Backend: `GetWorkspaceDashboardHealthUseCaseTest`, `WorkspaceDashboardControllerTest`
+- Frontend: `buildWorkspaceDashboardHealthView.test.ts`, `KnowledgePackHealthPanel.test.tsx`, `WorkspaceDashboardPage.test.tsx`
+- Local verification: backend/frontend targeted tests and module build/lint where feasible
+
+## Open Questions
+
+- "오래된 지식팩"의 절대 기간 기준은 아직 issue에서 확정되지 않았다. 이번 범위에서는 운영 반영 이후 더 최신 상담 로그가 있으면 오래된 상태로 간주한다.

--- a/backend/src/main/java/com/init/workspace/application/GetWorkspaceDashboardHealthUseCase.java
+++ b/backend/src/main/java/com/init/workspace/application/GetWorkspaceDashboardHealthUseCase.java
@@ -1,0 +1,37 @@
+package com.init.workspace.application;
+
+import com.init.workspace.application.exception.WorkspaceAccessDeniedException;
+import com.init.workspace.application.exception.WorkspaceNotFoundException;
+import com.init.workspace.domain.repository.WorkspaceMemberRepository;
+import com.init.workspace.domain.repository.WorkspaceRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class GetWorkspaceDashboardHealthUseCase {
+
+  private final WorkspaceRepository workspaceRepository;
+  private final WorkspaceMemberRepository workspaceMemberRepository;
+  private final WorkspaceDashboardQueryPort workspaceDashboardQueryPort;
+
+  public GetWorkspaceDashboardHealthUseCase(
+      WorkspaceRepository workspaceRepository,
+      WorkspaceMemberRepository workspaceMemberRepository,
+      WorkspaceDashboardQueryPort workspaceDashboardQueryPort) {
+    this.workspaceRepository = workspaceRepository;
+    this.workspaceMemberRepository = workspaceMemberRepository;
+    this.workspaceDashboardQueryPort = workspaceDashboardQueryPort;
+  }
+
+  public WorkspaceDashboardHealthResult execute(Long workspaceId, Long userId) {
+    if (!workspaceRepository.existsById(workspaceId)) {
+      throw new WorkspaceNotFoundException("워크스페이스를 찾을 수 없습니다.");
+    }
+    workspaceMemberRepository
+        .findByWorkspaceIdAndUserId(workspaceId, userId)
+        .orElseThrow(() -> new WorkspaceAccessDeniedException("워크스페이스에 접근 권한이 없습니다."));
+
+    return workspaceDashboardQueryPort.findKnowledgePackHealth(workspaceId);
+  }
+}

--- a/backend/src/main/java/com/init/workspace/application/WorkspaceDashboardGenerationResult.java
+++ b/backend/src/main/java/com/init/workspace/application/WorkspaceDashboardGenerationResult.java
@@ -1,0 +1,13 @@
+package com.init.workspace.application;
+
+import java.time.OffsetDateTime;
+
+public record WorkspaceDashboardGenerationResult(
+    Long pipelineJobId,
+    Long datasetId,
+    Long domainPackId,
+    String status,
+    OffsetDateTime requestedAt,
+    OffsetDateTime startedAt,
+    OffsetDateTime finishedAt,
+    String lastErrorMessage) {}

--- a/backend/src/main/java/com/init/workspace/application/WorkspaceDashboardHealthResult.java
+++ b/backend/src/main/java/com/init/workspace/application/WorkspaceDashboardHealthResult.java
@@ -1,0 +1,7 @@
+package com.init.workspace.application;
+
+public record WorkspaceDashboardHealthResult(
+    WorkspaceDashboardKnowledgePackResult activeKnowledgePack,
+    WorkspaceDashboardLogUploadResult lastLogUpload,
+    WorkspaceDashboardGenerationResult lastKnowledgePackGeneration,
+    long pendingReviewCount) {}

--- a/backend/src/main/java/com/init/workspace/application/WorkspaceDashboardKnowledgePackResult.java
+++ b/backend/src/main/java/com/init/workspace/application/WorkspaceDashboardKnowledgePackResult.java
@@ -1,0 +1,12 @@
+package com.init.workspace.application;
+
+import java.time.OffsetDateTime;
+
+public record WorkspaceDashboardKnowledgePackResult(
+    Long packId,
+    String packName,
+    Long versionId,
+    Integer versionNo,
+    OffsetDateTime publishedAt,
+    OffsetDateTime createdAt,
+    Long sourcePipelineJobId) {}

--- a/backend/src/main/java/com/init/workspace/application/WorkspaceDashboardLogUploadResult.java
+++ b/backend/src/main/java/com/init/workspace/application/WorkspaceDashboardLogUploadResult.java
@@ -1,0 +1,10 @@
+package com.init.workspace.application;
+
+import java.time.OffsetDateTime;
+
+public record WorkspaceDashboardLogUploadResult(
+    Long datasetId,
+    String datasetKey,
+    String datasetName,
+    String datasetStatus,
+    OffsetDateTime uploadedAt) {}

--- a/backend/src/main/java/com/init/workspace/application/WorkspaceDashboardQueryPort.java
+++ b/backend/src/main/java/com/init/workspace/application/WorkspaceDashboardQueryPort.java
@@ -1,0 +1,6 @@
+package com.init.workspace.application;
+
+public interface WorkspaceDashboardQueryPort {
+
+  WorkspaceDashboardHealthResult findKnowledgePackHealth(Long workspaceId);
+}

--- a/backend/src/main/java/com/init/workspace/infrastructure/persistence/JdbcWorkspaceDashboardQueryAdapter.java
+++ b/backend/src/main/java/com/init/workspace/infrastructure/persistence/JdbcWorkspaceDashboardQueryAdapter.java
@@ -1,0 +1,166 @@
+package com.init.workspace.infrastructure.persistence;
+
+import com.init.workspace.application.WorkspaceDashboardGenerationResult;
+import com.init.workspace.application.WorkspaceDashboardHealthResult;
+import com.init.workspace.application.WorkspaceDashboardKnowledgePackResult;
+import com.init.workspace.application.WorkspaceDashboardLogUploadResult;
+import com.init.workspace.application.WorkspaceDashboardQueryPort;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class JdbcWorkspaceDashboardQueryAdapter implements WorkspaceDashboardQueryPort {
+
+  private final NamedParameterJdbcTemplate jdbcTemplate;
+
+  public JdbcWorkspaceDashboardQueryAdapter(NamedParameterJdbcTemplate jdbcTemplate) {
+    this.jdbcTemplate = jdbcTemplate;
+  }
+
+  @Override
+  public WorkspaceDashboardHealthResult findKnowledgePackHealth(Long workspaceId) {
+    return new WorkspaceDashboardHealthResult(
+        findActiveKnowledgePack(workspaceId),
+        findLastLogUpload(workspaceId),
+        findLastKnowledgePackGeneration(workspaceId),
+        countPendingReviewTasks(workspaceId));
+  }
+
+  private WorkspaceDashboardKnowledgePackResult findActiveKnowledgePack(Long workspaceId) {
+    List<WorkspaceDashboardKnowledgePackResult> rows =
+        jdbcTemplate.query(
+            """
+            SELECT
+              p.id AS pack_id,
+              p.name AS pack_name,
+              v.id AS version_id,
+              v.version_no,
+              v.published_at,
+              v.created_at,
+              v.source_pipeline_job_id
+            FROM pack.domain_pack_version v
+            JOIN pack.domain_pack p ON p.id = v.domain_pack_id
+            WHERE p.workspace_id = :workspaceId
+              AND p.status = 'ACTIVE'
+              AND v.lifecycle_status = 'PUBLISHED'
+              AND NOT EXISTS (
+                SELECT 1
+                FROM pack.intent_definition i
+                WHERE i.domain_pack_version_id = v.id
+                  AND i.status = 'DRAFT'
+              )
+            ORDER BY v.published_at DESC NULLS LAST, v.version_no DESC, v.id DESC
+            LIMIT 1
+            """,
+            Map.of("workspaceId", workspaceId),
+            (rs, rowNum) -> mapKnowledgePack(rs));
+    return rows.stream().findFirst().orElse(null);
+  }
+
+  private WorkspaceDashboardLogUploadResult findLastLogUpload(Long workspaceId) {
+    List<WorkspaceDashboardLogUploadResult> rows =
+        jdbcTemplate.query(
+            """
+            SELECT
+              id AS dataset_id,
+              dataset_key,
+              name AS dataset_name,
+              status AS dataset_status,
+              created_at AS uploaded_at
+            FROM corpus.dataset
+            WHERE workspace_id = :workspaceId
+            ORDER BY created_at DESC, id DESC
+            LIMIT 1
+            """,
+            Map.of("workspaceId", workspaceId),
+            (rs, rowNum) -> mapLogUpload(rs));
+    return rows.stream().findFirst().orElse(null);
+  }
+
+  private WorkspaceDashboardGenerationResult findLastKnowledgePackGeneration(Long workspaceId) {
+    List<WorkspaceDashboardGenerationResult> rows =
+        jdbcTemplate.query(
+            """
+            SELECT
+              id AS pipeline_job_id,
+              dataset_id,
+              domain_pack_id,
+              status,
+              requested_at,
+              started_at,
+              finished_at,
+              last_error_message
+            FROM pipeline.pipeline_job
+            WHERE workspace_id = :workspaceId
+              AND job_type = 'DOMAIN_PACK_GENERATION'
+            ORDER BY requested_at DESC, id DESC
+            LIMIT 1
+            """,
+            Map.of("workspaceId", workspaceId),
+            (rs, rowNum) -> mapGeneration(rs));
+    return rows.stream().findFirst().orElse(null);
+  }
+
+  private long countPendingReviewTasks(Long workspaceId) {
+    Long count =
+        jdbcTemplate.queryForObject(
+            """
+            SELECT COUNT(*)
+            FROM review.review_task rt
+            JOIN review.review_session rs ON rs.id = rt.review_session_id
+            WHERE rs.workspace_id = :workspaceId
+              AND rs.status = 'OPEN'
+              AND rt.status = 'OPEN'
+            """,
+            new MapSqlParameterSource("workspaceId", workspaceId),
+            Long.class);
+    return count != null ? count : 0L;
+  }
+
+  private WorkspaceDashboardKnowledgePackResult mapKnowledgePack(ResultSet rs) throws SQLException {
+    return new WorkspaceDashboardKnowledgePackResult(
+        rs.getLong("pack_id"),
+        rs.getString("pack_name"),
+        rs.getLong("version_id"),
+        rs.getInt("version_no"),
+        offsetDateTime(rs, "published_at"),
+        offsetDateTime(rs, "created_at"),
+        nullableLong(rs, "source_pipeline_job_id"));
+  }
+
+  private WorkspaceDashboardLogUploadResult mapLogUpload(ResultSet rs) throws SQLException {
+    return new WorkspaceDashboardLogUploadResult(
+        rs.getLong("dataset_id"),
+        rs.getString("dataset_key"),
+        rs.getString("dataset_name"),
+        rs.getString("dataset_status"),
+        offsetDateTime(rs, "uploaded_at"));
+  }
+
+  private WorkspaceDashboardGenerationResult mapGeneration(ResultSet rs) throws SQLException {
+    return new WorkspaceDashboardGenerationResult(
+        rs.getLong("pipeline_job_id"),
+        nullableLong(rs, "dataset_id"),
+        nullableLong(rs, "domain_pack_id"),
+        rs.getString("status"),
+        offsetDateTime(rs, "requested_at"),
+        offsetDateTime(rs, "started_at"),
+        offsetDateTime(rs, "finished_at"),
+        rs.getString("last_error_message"));
+  }
+
+  private Long nullableLong(ResultSet rs, String columnName) throws SQLException {
+    long value = rs.getLong(columnName);
+    return rs.wasNull() ? null : value;
+  }
+
+  private OffsetDateTime offsetDateTime(ResultSet rs, String columnName) throws SQLException {
+    return rs.getObject(columnName, OffsetDateTime.class);
+  }
+}

--- a/backend/src/main/java/com/init/workspace/presentation/WorkspaceDashboardController.java
+++ b/backend/src/main/java/com/init/workspace/presentation/WorkspaceDashboardController.java
@@ -1,0 +1,30 @@
+package com.init.workspace.presentation;
+
+import com.init.shared.presentation.AuthenticationUtils;
+import com.init.workspace.application.GetWorkspaceDashboardHealthUseCase;
+import com.init.workspace.application.WorkspaceDashboardHealthResult;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/workspaces/{workspaceId}/dashboard")
+public class WorkspaceDashboardController {
+
+  private final GetWorkspaceDashboardHealthUseCase getWorkspaceDashboardHealthUseCase;
+
+  public WorkspaceDashboardController(
+      GetWorkspaceDashboardHealthUseCase getWorkspaceDashboardHealthUseCase) {
+    this.getWorkspaceDashboardHealthUseCase = getWorkspaceDashboardHealthUseCase;
+  }
+
+  @GetMapping("/knowledge-pack-health")
+  public ResponseEntity<WorkspaceDashboardHealthResult> getKnowledgePackHealth(
+      @PathVariable Long workspaceId, Authentication authentication) {
+    Long userId = AuthenticationUtils.getUserId(authentication);
+    return ResponseEntity.ok(getWorkspaceDashboardHealthUseCase.execute(workspaceId, userId));
+  }
+}

--- a/backend/src/test/java/com/init/workspace/application/GetWorkspaceDashboardHealthUseCaseTest.java
+++ b/backend/src/test/java/com/init/workspace/application/GetWorkspaceDashboardHealthUseCaseTest.java
@@ -1,0 +1,82 @@
+package com.init.workspace.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import com.init.workspace.application.exception.WorkspaceAccessDeniedException;
+import com.init.workspace.application.exception.WorkspaceNotFoundException;
+import com.init.workspace.domain.model.WorkspaceMember;
+import com.init.workspace.domain.model.WorkspaceMemberRole;
+import com.init.workspace.domain.repository.WorkspaceMemberRepository;
+import com.init.workspace.domain.repository.WorkspaceRepository;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetWorkspaceDashboardHealthUseCase")
+class GetWorkspaceDashboardHealthUseCaseTest {
+
+  @Mock private WorkspaceRepository workspaceRepository;
+  @Mock private WorkspaceMemberRepository workspaceMemberRepository;
+  @Mock private WorkspaceDashboardQueryPort workspaceDashboardQueryPort;
+
+  private GetWorkspaceDashboardHealthUseCase useCase;
+
+  @BeforeEach
+  void setUp() {
+    useCase =
+        new GetWorkspaceDashboardHealthUseCase(
+            workspaceRepository, workspaceMemberRepository, workspaceDashboardQueryPort);
+  }
+
+  @Test
+  @DisplayName("멤버인 사용자 → 운영 지식팩 건강도 반환")
+  void should_health반환_when_멤버인사용자() {
+    WorkspaceDashboardHealthResult health = healthResult();
+    given(workspaceRepository.existsById(1L)).willReturn(true);
+    given(workspaceMemberRepository.findByWorkspaceIdAndUserId(1L, 7L))
+        .willReturn(Optional.of(WorkspaceMember.create(1L, 7L, WorkspaceMemberRole.ADMIN)));
+    given(workspaceDashboardQueryPort.findKnowledgePackHealth(1L)).willReturn(health);
+
+    WorkspaceDashboardHealthResult result = useCase.execute(1L, 7L);
+
+    assertThat(result.activeKnowledgePack().versionNo()).isEqualTo(4);
+    assertThat(result.pendingReviewCount()).isEqualTo(2);
+  }
+
+  @Test
+  @DisplayName("workspace 없음 → WorkspaceNotFoundException")
+  void should_WorkspaceNotFoundException_when_workspace없음() {
+    given(workspaceRepository.existsById(1L)).willReturn(false);
+
+    assertThatThrownBy(() -> useCase.execute(1L, 7L))
+        .isInstanceOf(WorkspaceNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("멤버 아님 → WorkspaceAccessDeniedException")
+  void should_WorkspaceAccessDeniedException_when_멤버아님() {
+    given(workspaceRepository.existsById(1L)).willReturn(true);
+    given(workspaceMemberRepository.findByWorkspaceIdAndUserId(1L, 7L))
+        .willReturn(Optional.empty());
+
+    assertThatThrownBy(() -> useCase.execute(1L, 7L))
+        .isInstanceOf(WorkspaceAccessDeniedException.class);
+  }
+
+  private WorkspaceDashboardHealthResult healthResult() {
+    OffsetDateTime now = OffsetDateTime.parse("2026-06-03T10:00:00Z");
+    return new WorkspaceDashboardHealthResult(
+        new WorkspaceDashboardKnowledgePackResult(11L, "CS Pack", 12L, 4, now, now, 77L),
+        new WorkspaceDashboardLogUploadResult(8L, "june-log", "6월 상담 로그", "READY", now),
+        new WorkspaceDashboardGenerationResult(77L, 8L, 11L, "SUCCEEDED", now, now, now, null),
+        2L);
+  }
+}

--- a/backend/src/test/java/com/init/workspace/presentation/WorkspaceDashboardControllerTest.java
+++ b/backend/src/test/java/com/init/workspace/presentation/WorkspaceDashboardControllerTest.java
@@ -1,0 +1,68 @@
+package com.init.workspace.presentation;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.init.shared.infrastructure.security.JwtAuthenticationFilter;
+import com.init.workspace.application.GetWorkspaceDashboardHealthUseCase;
+import com.init.workspace.application.WorkspaceDashboardGenerationResult;
+import com.init.workspace.application.WorkspaceDashboardHealthResult;
+import com.init.workspace.application.WorkspaceDashboardKnowledgePackResult;
+import com.init.workspace.application.WorkspaceDashboardLogUploadResult;
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(
+    value = WorkspaceDashboardController.class,
+    excludeFilters =
+        @ComponentScan.Filter(
+            type = FilterType.ASSIGNABLE_TYPE,
+            classes = JwtAuthenticationFilter.class))
+@AutoConfigureMockMvc(addFilters = false)
+@DisplayName("WorkspaceDashboardController")
+class WorkspaceDashboardControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private GetWorkspaceDashboardHealthUseCase getWorkspaceDashboardHealthUseCase;
+
+  @Test
+  @DisplayName("GET 운영 지식팩 건강도 → 200 OK")
+  void should_200반환_when_운영지식팩건강도조회() throws Exception {
+    given(getWorkspaceDashboardHealthUseCase.execute(1L, 7L)).willReturn(healthResult());
+
+    mockMvc
+        .perform(get("/api/v1/workspaces/1/dashboard/knowledge-pack-health").principal(auth()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.activeKnowledgePack.versionNo").value(4))
+        .andExpect(jsonPath("$.lastLogUpload.datasetName").value("6월 상담 로그"))
+        .andExpect(jsonPath("$.lastKnowledgePackGeneration.status").value("SUCCEEDED"))
+        .andExpect(jsonPath("$.pendingReviewCount").value(2));
+  }
+
+  private WorkspaceDashboardHealthResult healthResult() {
+    OffsetDateTime now = OffsetDateTime.parse("2026-06-03T10:00:00Z");
+    return new WorkspaceDashboardHealthResult(
+        new WorkspaceDashboardKnowledgePackResult(11L, "CS Pack", 12L, 4, now, now, 77L),
+        new WorkspaceDashboardLogUploadResult(8L, "june-log", "6월 상담 로그", "READY", now),
+        new WorkspaceDashboardGenerationResult(77L, 8L, 11L, "SUCCEEDED", now, now, now, null),
+        2L);
+  }
+
+  private UsernamePasswordAuthenticationToken auth() {
+    return new UsernamePasswordAuthenticationToken(
+        7L, null, java.util.List.of(new SimpleGrantedAuthority("ROLE_USER")));
+  }
+}

--- a/frontend/src/app/App.test.tsx
+++ b/frontend/src/app/App.test.tsx
@@ -1,12 +1,5 @@
 import { render, screen, waitFor } from "@testing-library/react";
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-} from "vite-plus/test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import { App } from "./App";
 import { AppProviders } from "./providers";
 
@@ -64,11 +57,7 @@ describe("App", () => {
   });
 
   it("redirects legacy demo workspace chat URLs to the canonical demo chat URL", async () => {
-    window.history.pushState(
-      {},
-      "",
-      "/demo/workspaces/42/chat?name=%EA%B9%80%EB%AF%BC%EC%A7%80",
-    );
+    window.history.pushState({}, "", "/demo/workspaces/42/chat?name=%EA%B9%80%EB%AF%BC%EC%A7%80");
 
     render(
       <AppProviders>
@@ -98,7 +87,7 @@ describe("App", () => {
     });
   });
 
-  it("redirects workspace home alias to dashboard and renders the dashboard empty state", async () => {
+  it("redirects workspace home alias to dashboard and renders the health panel", async () => {
     seedAuthenticatedSession();
 
     const workspaceBody = {
@@ -118,6 +107,18 @@ describe("App", () => {
           ok: true,
           status: 200,
           json: async () => [workspaceBody],
+        });
+      }
+      if (url === "/api/v1/workspaces/1/dashboard/knowledge-pack-health") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            activeKnowledgePack: null,
+            lastLogUpload: null,
+            lastKnowledgePackGeneration: null,
+            pendingReviewCount: 0,
+          }),
         });
       }
       return Promise.resolve({
@@ -141,11 +142,13 @@ describe("App", () => {
     });
 
     expect(await screen.findByText("Workspace Dashboard")).toBeInTheDocument();
-    expect(
-      await screen.findByText("아직 대시보드에 표시할 운영 데이터가 없습니다."),
-    ).toBeInTheDocument();
+    expect(await screen.findByText("운영 지식팩 건강도")).toBeInTheDocument();
     expect(fetchMock).toHaveBeenCalledWith(
       "/api/v1/workspaces/1",
+      expect.objectContaining({ method: "GET" }),
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/v1/workspaces/1/dashboard/knowledge-pack-health",
       expect.objectContaining({ method: "GET" }),
     );
   });

--- a/frontend/src/features/workspace-dashboard-health/api/workspaceDashboardHealthApi.ts
+++ b/frontend/src/features/workspace-dashboard-health/api/workspaceDashboardHealthApi.ts
@@ -1,0 +1,57 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { customFetch } from "@/shared/api/mutator";
+
+// OpenAPI is not generated for this dashboard read endpoint yet.
+
+export interface WorkspaceDashboardKnowledgePack {
+  packId: number;
+  packName: string;
+  versionId: number;
+  versionNo: number;
+  publishedAt?: string | null;
+  createdAt?: string | null;
+  sourcePipelineJobId?: number | null;
+}
+
+export interface WorkspaceDashboardLogUpload {
+  datasetId: number;
+  datasetKey: string;
+  datasetName: string;
+  datasetStatus: string;
+  uploadedAt?: string | null;
+}
+
+export interface WorkspaceDashboardGeneration {
+  pipelineJobId: number;
+  datasetId?: number | null;
+  domainPackId?: number | null;
+  status: string;
+  requestedAt?: string | null;
+  startedAt?: string | null;
+  finishedAt?: string | null;
+  lastErrorMessage?: string | null;
+}
+
+export interface WorkspaceDashboardHealth {
+  activeKnowledgePack?: WorkspaceDashboardKnowledgePack | null;
+  lastLogUpload?: WorkspaceDashboardLogUpload | null;
+  lastKnowledgePackGeneration?: WorkspaceDashboardGeneration | null;
+  pendingReviewCount: number;
+}
+
+export const workspaceDashboardHealthKeys = {
+  all: ["workspace-dashboard-health"] as const,
+  detail: (workspaceId: number) => [...workspaceDashboardHealthKeys.all, workspaceId] as const,
+};
+
+export function useWorkspaceDashboardHealth(workspaceId: number) {
+  return useQuery({
+    queryKey: workspaceDashboardHealthKeys.detail(workspaceId),
+    queryFn: ({ signal }) =>
+      customFetch<WorkspaceDashboardHealth>(
+        `/api/v1/workspaces/${workspaceId}/dashboard/knowledge-pack-health`,
+        { method: "GET", signal },
+      ),
+  });
+}

--- a/frontend/src/features/workspace-dashboard-health/index.ts
+++ b/frontend/src/features/workspace-dashboard-health/index.ts
@@ -1,0 +1,1 @@
+export { KnowledgePackHealthPanel } from "./ui/KnowledgePackHealthPanel";

--- a/frontend/src/features/workspace-dashboard-health/model/buildWorkspaceDashboardHealthView.test.ts
+++ b/frontend/src/features/workspace-dashboard-health/model/buildWorkspaceDashboardHealthView.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+
+import { buildWorkspaceDashboardHealthView } from "./buildWorkspaceDashboardHealthView";
+
+describe("buildWorkspaceDashboardHealthView", () => {
+  it("정상 운영 상태를 고객용 문구로 요약한다", () => {
+    const view = buildWorkspaceDashboardHealthView(1, {
+      activeKnowledgePack: {
+        packId: 11,
+        packName: "CS Pack",
+        versionId: 12,
+        versionNo: 4,
+        publishedAt: "2026-06-03T10:00:00Z",
+        createdAt: "2026-06-03T09:00:00Z",
+        sourcePipelineJobId: 77,
+      },
+      lastLogUpload: {
+        datasetId: 8,
+        datasetKey: "june-log",
+        datasetName: "6월 상담 로그",
+        datasetStatus: "READY",
+        uploadedAt: "2026-06-03T09:00:00Z",
+      },
+      lastKnowledgePackGeneration: {
+        pipelineJobId: 77,
+        datasetId: 8,
+        domainPackId: 11,
+        status: "SUCCEEDED",
+        requestedAt: "2026-06-03T09:10:00Z",
+        startedAt: "2026-06-03T09:11:00Z",
+        finishedAt: "2026-06-03T09:30:00Z",
+      },
+      pendingReviewCount: 0,
+    });
+
+    expect(view.statusTitle).toBe("운영 지식팩이 정상적으로 유지되고 있습니다.");
+    expect(view.alerts).toHaveLength(0);
+    expect(view.ctas).toHaveLength(0);
+    expect(view.metrics.find((metric) => metric.label === "운영 지식팩")?.value).toBe("v4");
+  });
+
+  it("새 로그, 검토 대기, 생성 실패를 경고와 CTA로 변환한다", () => {
+    const view = buildWorkspaceDashboardHealthView(1, {
+      activeKnowledgePack: {
+        packId: 11,
+        packName: "CS Pack",
+        versionId: 12,
+        versionNo: 4,
+        publishedAt: "2026-06-01T10:00:00Z",
+        createdAt: "2026-06-01T09:00:00Z",
+      },
+      lastLogUpload: {
+        datasetId: 8,
+        datasetKey: "june-log",
+        datasetName: "6월 상담 로그",
+        datasetStatus: "READY",
+        uploadedAt: "2026-06-03T09:00:00Z",
+      },
+      lastKnowledgePackGeneration: {
+        pipelineJobId: 77,
+        datasetId: 8,
+        domainPackId: 11,
+        status: "FAILED",
+        requestedAt: "2026-06-03T09:10:00Z",
+        startedAt: "2026-06-03T09:11:00Z",
+        finishedAt: "2026-06-03T09:30:00Z",
+      },
+      pendingReviewCount: 2,
+    });
+
+    expect(view.alerts.map((alert) => alert.title)).toEqual(
+      expect.arrayContaining([
+        "새 상담 로그가 운영 지식팩에 아직 반영되지 않았습니다.",
+        "검토 대기 항목 2개가 남아 있습니다.",
+        "최근 지식팩 생성이 실패했습니다.",
+      ]),
+    );
+    expect(view.ctas).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "review",
+          to: "/workspaces/1/pipeline-jobs/77/review",
+        }),
+        expect.objectContaining({ kind: "generate", to: "/workspaces/1/domain-packs" }),
+      ]),
+    );
+  });
+
+  it("업로드와 운영 지식팩이 없으면 초기 행동을 제안한다", () => {
+    const view = buildWorkspaceDashboardHealthView(3, {
+      activeKnowledgePack: null,
+      lastLogUpload: null,
+      lastKnowledgePackGeneration: null,
+      pendingReviewCount: 0,
+    });
+
+    expect(view.alerts.map((alert) => alert.title)).toEqual([
+      "운영 지식팩이 아직 반영되지 않았습니다.",
+      "상담 로그 업로드 기록이 없습니다.",
+    ]);
+    expect(view.ctas).toEqual([
+      { kind: "upload", label: "상담 로그 업로드", to: "/workspaces/3/upload" },
+      { kind: "generate", label: "지식팩 생성", to: "/workspaces/3/domain-packs" },
+    ]);
+  });
+});

--- a/frontend/src/features/workspace-dashboard-health/model/buildWorkspaceDashboardHealthView.ts
+++ b/frontend/src/features/workspace-dashboard-health/model/buildWorkspaceDashboardHealthView.ts
@@ -1,0 +1,247 @@
+import type { WorkspaceDashboardHealth } from "../api/workspaceDashboardHealthApi";
+
+export type HealthTone = "normal" | "warning" | "danger";
+export type HealthCtaKind = "upload" | "review" | "generate";
+
+export interface HealthMetricView {
+  label: string;
+  value: string;
+  description: string;
+  tone: HealthTone;
+}
+
+export interface HealthAlertView {
+  title: string;
+  description: string;
+  tone: Exclude<HealthTone, "normal">;
+}
+
+export interface HealthCtaView {
+  kind: HealthCtaKind;
+  label: string;
+  to: string;
+}
+
+export interface WorkspaceDashboardHealthView {
+  statusTitle: string;
+  statusDescription: string;
+  metrics: HealthMetricView[];
+  alerts: HealthAlertView[];
+  ctas: HealthCtaView[];
+}
+
+const RUNNING_STATUSES = new Set([
+  "QUEUED",
+  "RUNNING",
+  "WAITING_INTENT_CALLBACK",
+  "WAITING_WORKFLOW_CALLBACK",
+]);
+
+const REVIEW_STATUSES = new Set(["WAITING_DOMAIN_CONFIRMATION", "WAITING_HUMAN_FEEDBACK"]);
+
+export function buildWorkspaceDashboardHealthView(
+  workspaceId: number,
+  health: WorkspaceDashboardHealth,
+): WorkspaceDashboardHealthView {
+  const activePack = health.activeKnowledgePack ?? null;
+  const lastUpload = health.lastLogUpload ?? null;
+  const lastGeneration = health.lastKnowledgePackGeneration ?? null;
+  const pendingReviewCount = health.pendingReviewCount ?? 0;
+  const isGenerationFailed = lastGeneration?.status === "FAILED";
+  const isGenerationRunning = lastGeneration ? RUNNING_STATUSES.has(lastGeneration.status) : false;
+  const isReviewWaiting =
+    pendingReviewCount > 0 || (lastGeneration ? REVIEW_STATUSES.has(lastGeneration.status) : false);
+  const hasNewerUpload =
+    activePack?.publishedAt && lastUpload?.uploadedAt
+      ? new Date(lastUpload.uploadedAt).getTime() > new Date(activePack.publishedAt).getTime()
+      : false;
+
+  const alerts: HealthAlertView[] = [];
+  if (!activePack) {
+    alerts.push({
+      title: "운영 지식팩이 아직 반영되지 않았습니다.",
+      description: "상담 로그를 업로드한 뒤 지식팩을 생성하고 운영에 반영해 주세요.",
+      tone: "warning",
+    });
+  }
+  if (!lastUpload) {
+    alerts.push({
+      title: "상담 로그 업로드 기록이 없습니다.",
+      description: "최근 상담 흐름을 반영하려면 먼저 상담 로그를 업로드해 주세요.",
+      tone: "warning",
+    });
+  }
+  if (hasNewerUpload) {
+    alerts.push({
+      title: "새 상담 로그가 운영 지식팩에 아직 반영되지 않았습니다.",
+      description: "마지막 운영 반영 이후 업로드된 상담 로그로 지식팩을 다시 생성해 주세요.",
+      tone: "warning",
+    });
+  }
+  if (pendingReviewCount > 0) {
+    alerts.push({
+      title: `검토 대기 항목 ${pendingReviewCount}개가 남아 있습니다.`,
+      description: "검토를 마치면 새 지식팩을 운영에 반영할 수 있습니다.",
+      tone: "warning",
+    });
+  }
+  if (isGenerationFailed) {
+    alerts.push({
+      title: "최근 지식팩 생성이 실패했습니다.",
+      description: "상담 로그와 생성 조건을 확인한 뒤 다시 생성해 주세요.",
+      tone: "danger",
+    });
+  }
+
+  const ctas: HealthCtaView[] = [];
+  if (!lastUpload) {
+    ctas.push({
+      kind: "upload",
+      label: "상담 로그 업로드",
+      to: `/workspaces/${workspaceId}/upload`,
+    });
+  }
+  if (isReviewWaiting && lastGeneration?.pipelineJobId) {
+    ctas.push({
+      kind: "review",
+      label: "검토 화면으로 이동",
+      to: `/workspaces/${workspaceId}/pipeline-jobs/${lastGeneration.pipelineJobId}/review`,
+    });
+  }
+  if (!activePack || hasNewerUpload || isGenerationFailed || (lastUpload && !lastGeneration)) {
+    ctas.push({
+      kind: "generate",
+      label: "지식팩 생성",
+      to: `/workspaces/${workspaceId}/domain-packs`,
+    });
+  }
+
+  const statusTone: HealthTone =
+    isGenerationFailed || !activePack ? "danger" : alerts.length > 0 ? "warning" : "normal";
+
+  return {
+    statusTitle: resolveStatusTitle(statusTone, isGenerationRunning, isReviewWaiting),
+    statusDescription: resolveStatusDescription(
+      statusTone,
+      isGenerationRunning,
+      isReviewWaiting,
+      activePack?.packName,
+    ),
+    metrics: [
+      {
+        label: "운영 지식팩",
+        value: activePack ? `v${activePack.versionNo}` : "미반영",
+        description: activePack?.packName ?? "운영에 반영된 지식팩이 없습니다.",
+        tone: activePack ? "normal" : "warning",
+      },
+      {
+        label: "마지막 운영 반영",
+        value: formatDate(activePack?.publishedAt),
+        description: "고객 상담에 적용된 마지막 지식팩 반영일입니다.",
+        tone: activePack?.publishedAt ? "normal" : "warning",
+      },
+      {
+        label: "마지막 상담 로그 업로드",
+        value: formatDate(lastUpload?.uploadedAt),
+        description: lastUpload?.datasetName ?? "업로드된 상담 로그가 없습니다.",
+        tone: lastUpload ? "normal" : "warning",
+      },
+      {
+        label: "마지막 지식팩 생성",
+        value: generationStatusLabel(lastGeneration?.status),
+        description: formatDate(lastGeneration?.finishedAt ?? lastGeneration?.requestedAt),
+        tone: isGenerationFailed ? "danger" : isReviewWaiting ? "warning" : "normal",
+      },
+      {
+        label: "검토 대기",
+        value: `${pendingReviewCount}개`,
+        description:
+          pendingReviewCount > 0
+            ? "운영 반영 전에 확인해야 할 항목입니다."
+            : "현재 검토 대기 항목이 없습니다.",
+        tone: pendingReviewCount > 0 ? "warning" : "normal",
+      },
+    ],
+    alerts,
+    ctas,
+  };
+}
+
+function resolveStatusTitle(
+  tone: HealthTone,
+  isGenerationRunning: boolean,
+  isReviewWaiting: boolean,
+): string {
+  if (tone === "danger") {
+    return "운영 지식팩 확인이 필요합니다.";
+  }
+  if (isReviewWaiting) {
+    return "검토 후 운영 반영을 기다리고 있습니다.";
+  }
+  if (isGenerationRunning) {
+    return "지식팩 생성이 진행 중입니다.";
+  }
+  if (tone === "warning") {
+    return "운영 지식팩을 최신 상태로 맞춰 주세요.";
+  }
+  return "운영 지식팩이 정상적으로 유지되고 있습니다.";
+}
+
+function resolveStatusDescription(
+  tone: HealthTone,
+  isGenerationRunning: boolean,
+  isReviewWaiting: boolean,
+  packName?: string,
+): string {
+  if (tone === "danger") {
+    return "아래 경고를 확인하고 다음 행동을 진행해 주세요.";
+  }
+  if (isReviewWaiting) {
+    return "검토 대기 항목을 처리하면 새 지식팩을 운영에 반영할 수 있습니다.";
+  }
+  if (isGenerationRunning) {
+    return "최근 상담 로그를 기준으로 지식팩 생성이 진행 중입니다.";
+  }
+  if (tone === "warning") {
+    return "최근 상담 로그와 운영 반영 상태를 함께 확인해 주세요.";
+  }
+  return packName
+    ? `${packName}이 현재 상담 운영에 적용 중입니다.`
+    : "현재 운영 상태가 안정적입니다.";
+}
+
+function generationStatusLabel(status?: string | null): string {
+  if (!status) {
+    return "생성 기록 없음";
+  }
+  if (status === "SUCCEEDED") {
+    return "생성 완료";
+  }
+  if (status === "FAILED") {
+    return "생성 실패";
+  }
+  if (REVIEW_STATUSES.has(status)) {
+    return "검토 대기";
+  }
+  if (RUNNING_STATUSES.has(status)) {
+    return "생성 중";
+  }
+  return status;
+}
+
+function formatDate(value?: string | null): string {
+  if (!value) {
+    return "기록 없음";
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "기록 없음";
+  }
+  return new Intl.DateTimeFormat("ko-KR", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(date);
+}

--- a/frontend/src/features/workspace-dashboard-health/ui/KnowledgePackHealthPanel.test.tsx
+++ b/frontend/src/features/workspace-dashboard-health/ui/KnowledgePackHealthPanel.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+
+import { useWorkspaceDashboardHealth } from "../api/workspaceDashboardHealthApi";
+import { KnowledgePackHealthPanel } from "./KnowledgePackHealthPanel";
+
+vi.mock("../api/workspaceDashboardHealthApi", () => ({
+  useWorkspaceDashboardHealth: vi.fn(),
+}));
+
+const mockedUseWorkspaceDashboardHealth = vi.mocked(useWorkspaceDashboardHealth);
+
+describe("KnowledgePackHealthPanel", () => {
+  it("loading 상태를 표시한다", () => {
+    mockedUseWorkspaceDashboardHealth.mockReturnValue({
+      isLoading: true,
+      isError: false,
+      data: undefined,
+    } as ReturnType<typeof useWorkspaceDashboardHealth>);
+
+    renderPanel();
+
+    expect(screen.getByTestId("knowledge-health-loading")).toBeInTheDocument();
+  });
+
+  it("운영 지식팩 건강도와 상황별 CTA를 표시한다", () => {
+    mockedUseWorkspaceDashboardHealth.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: {
+        activeKnowledgePack: {
+          packId: 11,
+          packName: "CS Pack",
+          versionId: 12,
+          versionNo: 4,
+          publishedAt: "2026-06-01T10:00:00Z",
+          createdAt: "2026-06-01T09:00:00Z",
+        },
+        lastLogUpload: {
+          datasetId: 8,
+          datasetKey: "june-log",
+          datasetName: "6월 상담 로그",
+          datasetStatus: "READY",
+          uploadedAt: "2026-06-03T09:00:00Z",
+        },
+        lastKnowledgePackGeneration: {
+          pipelineJobId: 77,
+          datasetId: 8,
+          domainPackId: 11,
+          status: "WAITING_HUMAN_FEEDBACK",
+          requestedAt: "2026-06-03T09:10:00Z",
+        },
+        pendingReviewCount: 2,
+      },
+    } as ReturnType<typeof useWorkspaceDashboardHealth>);
+
+    renderPanel();
+
+    expect(screen.getByRole("heading", { name: "운영 지식팩 건강도" })).toBeInTheDocument();
+    expect(screen.getByText("v4")).toBeInTheDocument();
+    expect(screen.getByText("검토 대기 항목 2개가 남아 있습니다.")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /검토 화면으로 이동/ })).toHaveAttribute(
+      "href",
+      "/workspaces/1/pipeline-jobs/77/review",
+    );
+  });
+
+  it("error 상태를 표시한다", () => {
+    mockedUseWorkspaceDashboardHealth.mockReturnValue({
+      isLoading: false,
+      isError: true,
+      data: undefined,
+    } as ReturnType<typeof useWorkspaceDashboardHealth>);
+
+    renderPanel();
+
+    expect(screen.getByTestId("knowledge-health-error")).toBeInTheDocument();
+  });
+});
+
+function renderPanel() {
+  render(
+    <MemoryRouter>
+      <KnowledgePackHealthPanel workspaceId={1} />
+    </MemoryRouter>,
+  );
+}

--- a/frontend/src/features/workspace-dashboard-health/ui/KnowledgePackHealthPanel.tsx
+++ b/frontend/src/features/workspace-dashboard-health/ui/KnowledgePackHealthPanel.tsx
@@ -1,0 +1,131 @@
+import { Link } from "react-router-dom";
+import {
+  AlertTriangleIcon,
+  CheckCircle2Icon,
+  FileUpIcon,
+  ListChecksIcon,
+  PackagePlusIcon,
+} from "lucide-react";
+
+import { useWorkspaceDashboardHealth } from "../api/workspaceDashboardHealthApi";
+import {
+  buildWorkspaceDashboardHealthView,
+  type HealthCtaKind,
+  type HealthTone,
+} from "../model/buildWorkspaceDashboardHealthView";
+import { Button } from "@/shared/ui/button";
+import { ErrorState } from "@/shared/ui/ostone/atoms/ErrorState";
+import { LoadingSpinner } from "@/shared/ui/ostone/atoms/LoadingSpinner";
+
+import styles from "./knowledge-pack-health-panel.module.css";
+
+interface KnowledgePackHealthPanelProps {
+  workspaceId: number;
+}
+
+const CTA_ICON_BY_KIND: Record<HealthCtaKind, typeof FileUpIcon> = {
+  upload: FileUpIcon,
+  review: ListChecksIcon,
+  generate: PackagePlusIcon,
+};
+
+export function KnowledgePackHealthPanel({ workspaceId }: KnowledgePackHealthPanelProps) {
+  const healthQuery = useWorkspaceDashboardHealth(workspaceId);
+
+  if (healthQuery.isLoading) {
+    return (
+      <section className={styles.panel} data-testid="knowledge-health-loading" aria-live="polite">
+        <LoadingSpinner />
+        <p className={styles.loadingText}>운영 지식팩 상태를 불러오는 중입니다.</p>
+      </section>
+    );
+  }
+
+  if (healthQuery.isError || !healthQuery.data) {
+    return (
+      <section className={styles.panel} data-testid="knowledge-health-error">
+        <ErrorState message="운영 지식팩 상태를 불러오지 못했습니다." />
+      </section>
+    );
+  }
+
+  const view = buildWorkspaceDashboardHealthView(workspaceId, healthQuery.data);
+
+  return (
+    <section className={styles.panel} aria-labelledby="knowledge-health-title">
+      <div className={styles.header}>
+        <div>
+          <span className={styles.eyebrow}>Knowledge Health</span>
+          <h2 id="knowledge-health-title" className={styles.title}>
+            운영 지식팩 건강도
+          </h2>
+          <p className={styles.description}>{view.statusDescription}</p>
+        </div>
+        <StatusBadge
+          tone={
+            view.alerts.some((alert) => alert.tone === "danger")
+              ? "danger"
+              : view.alerts.length > 0
+                ? "warning"
+                : "normal"
+          }
+        >
+          {view.statusTitle}
+        </StatusBadge>
+      </div>
+
+      <div className={styles.metricGrid} aria-label="운영 지식팩 상태 요약">
+        {view.metrics.map((metric) => (
+          <article key={metric.label} className={styles.metric} data-tone={metric.tone}>
+            <span className={styles.metricLabel}>{metric.label}</span>
+            <strong>{metric.value}</strong>
+            <p>{metric.description}</p>
+          </article>
+        ))}
+      </div>
+
+      {view.alerts.length > 0 ? (
+        <div className={styles.alertList} aria-label="운영 지식팩 경고">
+          {view.alerts.map((alert) => (
+            <div key={alert.title} className={styles.alert} data-tone={alert.tone}>
+              <AlertTriangleIcon aria-hidden="true" />
+              <div>
+                <strong>{alert.title}</strong>
+                <p>{alert.description}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className={styles.clearState}>
+          <CheckCircle2Icon aria-hidden="true" />
+          <span>생성 실패나 검토 대기 경고가 없습니다.</span>
+        </div>
+      )}
+
+      {view.ctas.length > 0 ? (
+        <div className={styles.ctaRow} aria-label="운영 지식팩 다음 행동">
+          {view.ctas.map((cta, index) => {
+            const Icon = CTA_ICON_BY_KIND[cta.kind];
+            return (
+              <Button key={cta.kind} asChild variant={index === 0 ? "default" : "outline"}>
+                <Link to={cta.to}>
+                  <Icon aria-hidden="true" />
+                  {cta.label}
+                </Link>
+              </Button>
+            );
+          })}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function StatusBadge({ tone, children }: { tone: HealthTone; children: string }) {
+  return (
+    <span className={styles.statusBadge} data-tone={tone}>
+      {children}
+    </span>
+  );
+}

--- a/frontend/src/features/workspace-dashboard-health/ui/knowledge-pack-health-panel.module.css
+++ b/frontend/src/features/workspace-dashboard-health/ui/knowledge-pack-health-panel.module.css
@@ -1,0 +1,172 @@
+.panel {
+  display: flex;
+  min-height: 240px;
+  flex-direction: column;
+  gap: var(--s-5);
+  padding: var(--s-5);
+  border: 1px solid var(--line);
+  border-radius: var(--r-3);
+  background: var(--paper);
+}
+
+.header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--s-4);
+}
+
+.eyebrow,
+.metricLabel {
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+}
+
+.title {
+  margin: var(--s-1) 0 0;
+  color: var(--ink);
+  font-size: 20px;
+  font-weight: 540;
+  letter-spacing: -0.24px;
+}
+
+.description,
+.loadingText {
+  margin: var(--s-2) 0 0;
+  color: var(--ink-2);
+  font-size: 14px;
+  line-height: 1.6;
+  letter-spacing: -0.14px;
+}
+
+.statusBadge {
+  max-width: 320px;
+  flex: 0 0 auto;
+  padding: var(--s-2) var(--s-3);
+  border: 1px solid var(--line);
+  border-radius: var(--r-pill);
+  color: var(--ink);
+  font-size: 12px;
+  font-weight: 540;
+  line-height: 1.4;
+  text-align: center;
+}
+
+.statusBadge[data-tone="warning"] {
+  border-width: 2px;
+}
+
+.statusBadge[data-tone="danger"] {
+  border-width: 2px;
+}
+
+.metricGrid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: var(--s-3);
+}
+
+.metric {
+  min-width: 0;
+  padding: var(--s-4);
+  border: 1px solid var(--line-2);
+  border-radius: var(--r-3);
+  background: var(--paper-2);
+}
+
+.metric[data-tone="warning"] {
+  border-color: var(--ink-3);
+}
+
+.metric[data-tone="danger"] {
+  border-color: var(--ink);
+}
+
+.metric strong {
+  display: block;
+  margin-top: var(--s-2);
+  color: var(--ink);
+  font-size: 18px;
+  font-weight: 540;
+  letter-spacing: -0.2px;
+  line-height: 1.2;
+}
+
+.metric p {
+  margin: var(--s-2) 0 0;
+  color: var(--ink-2);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.alertList {
+  display: grid;
+  gap: var(--s-2);
+}
+
+.alert,
+.clearState {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--s-3);
+  padding: var(--s-3);
+  border: 1px solid var(--line-2);
+  border-radius: var(--r-3);
+  background: var(--paper-2);
+}
+
+.alert[data-tone="danger"] {
+  border-color: var(--ink);
+}
+
+.alert svg,
+.clearState svg {
+  width: 18px;
+  height: 18px;
+  flex: 0 0 auto;
+  color: var(--ink);
+}
+
+.alert strong,
+.clearState span {
+  color: var(--ink);
+  font-size: 13px;
+  font-weight: 540;
+}
+
+.alert p {
+  margin: var(--s-1) 0 0;
+  color: var(--ink-2);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.ctaRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--s-2);
+}
+
+@media (max-width: 1180px) {
+  .metricGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 720px) {
+  .header {
+    flex-direction: column;
+  }
+
+  .statusBadge {
+    max-width: none;
+  }
+
+  .metricGrid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/pages/workspace/ui/WorkspaceDashboardPage.test.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceDashboardPage.test.tsx
@@ -41,10 +41,7 @@ function renderPage(path = "/workspaces/1/dashboard") {
   render(
     <MemoryRouter initialEntries={[path]}>
       <Routes>
-        <Route
-          path="/workspaces/:workspaceId/dashboard"
-          element={<WorkspaceDashboardPage />}
-        />
+        <Route path="/workspaces/:workspaceId/dashboard" element={<WorkspaceDashboardPage />} />
         <Route path="/workspaces" element={<div data-testid="workspace-root" />} />
       </Routes>
     </MemoryRouter>,
@@ -71,6 +68,12 @@ vi.mock("sonner", () => ({
   },
 }));
 
+vi.mock("@/features/workspace-dashboard-health", () => ({
+  KnowledgePackHealthPanel: ({ workspaceId }: { workspaceId: number }) => (
+    <section data-testid="knowledge-health-panel">workspace {workspaceId} health</section>
+  ),
+}));
+
 describe("WorkspaceDashboardPage", () => {
   beforeEach(() => {
     mockedGetMetrics.mockReset();
@@ -83,18 +86,19 @@ describe("WorkspaceDashboardPage", () => {
     expect(mockedGetMetrics).not.toHaveBeenCalled();
   });
 
-  it("공통 필터와 상담 처리 KPI를 표시한다", async () => {
+  it("공통 필터와 상담 처리 KPI, 운영 지식팩 건강도 영역을 표시한다", async () => {
     renderPage();
 
     expect(screen.getByRole("heading", { name: "대시보드" })).toBeInTheDocument();
     expect(screen.getByLabelText("기간 필터")).toBeInTheDocument();
-    expect(screen.getByLabelText("Domain Pack Version 필터")).toHaveValue("all");
+    expect(screen.getByLabelText("운영 지식팩 버전 필터")).toHaveValue("all");
     expect(screen.getByLabelText("채널 필터")).toHaveValue("all");
     expect(screen.getByLabelText("워크플로우 상태 필터")).toHaveValue("all");
     expect(screen.getByText("총 상담")).toBeInTheDocument();
     expect(await screen.findByText("120")).toBeInTheDocument();
     expect(screen.getByText("1분 15초")).toBeInTheDocument();
     expect(screen.getByText("전 기간 +20.0%")).toBeInTheDocument();
+    expect(screen.getByTestId("knowledge-health-panel")).toHaveTextContent("workspace 1 health");
     await waitFor(() => expect(mockedGetMetrics).toHaveBeenCalledWith(1, expect.any(Object)));
   });
 
@@ -104,7 +108,7 @@ describe("WorkspaceDashboardPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "사용자 지정" }));
     fireEvent.change(screen.getByLabelText("시작일"), { target: { value: "2026-06-01" } });
     fireEvent.change(screen.getByLabelText("종료일"), { target: { value: "2026-06-03" } });
-    fireEvent.change(screen.getByLabelText("Domain Pack Version 필터"), {
+    fireEvent.change(screen.getByLabelText("운영 지식팩 버전 필터"), {
       target: { value: "published" },
     });
     fireEvent.change(screen.getByLabelText("채널 필터"), { target: { value: "email" } });
@@ -161,10 +165,7 @@ describe("WorkspaceDashboardPage", () => {
       "href",
       "/workspaces/1/domain-packs",
     );
-    expect(screen.getByTestId("dashboard-simulation-cta")).toHaveAttribute(
-      "href",
-      "/demo/chat/1",
-    );
+    expect(screen.getByTestId("dashboard-simulation-cta")).toHaveAttribute("href", "/demo/chat/1");
   });
 
   it("loading, error, partial 상태 패널이 같은 shell 영역에서 렌더링된다", () => {

--- a/frontend/src/pages/workspace/ui/WorkspaceDashboardPage.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceDashboardPage.tsx
@@ -11,6 +11,7 @@ import { toast } from "sonner";
 
 import { consultationApi } from "@/features/consultation/api/consultationApi";
 import type { ConsultationMetrics } from "@/features/consultation/api/consultationApi";
+import { KnowledgePackHealthPanel } from "@/features/workspace-dashboard-health";
 import type { ShellContext } from "@/shared/ui/ostone/chrome";
 import { buildDemoChatPath } from "@/shared/lib/demoRoutes";
 import { parseRouteId } from "@/shared/lib/parseRouteId";
@@ -133,7 +134,7 @@ function buildPeriodSummary(filters: DashboardFilters): string {
 function FilterSummary({ filters }: { filters: DashboardFilters }) {
   const summaryItems = [
     ["기간", buildPeriodSummary(filters)],
-    ["도메인팩", getOptionLabel(DOMAIN_PACK_VERSION_OPTIONS, filters.domainPackVersion)],
+    ["운영 지식팩", getOptionLabel(DOMAIN_PACK_VERSION_OPTIONS, filters.domainPackVersion)],
     ["채널", getOptionLabel(CHANNEL_OPTIONS, filters.channel)],
     ["워크플로우", getOptionLabel(WORKFLOW_STATUS_OPTIONS, filters.workflowStatus)],
   ];
@@ -341,11 +342,11 @@ function DashboardFilters({
 
       <div className={styles.selectGrid}>
         <label className={styles.field}>
-          <span>Domain Pack Version</span>
+          <span>운영 지식팩 버전</span>
           <NativeSelect
             value={filters.domainPackVersion}
             onChange={(event) => updateFilter("domainPackVersion", event.target.value)}
-            aria-label="Domain Pack Version 필터"
+            aria-label="운영 지식팩 버전 필터"
           >
             {DOMAIN_PACK_VERSION_OPTIONS.map((option) => (
               <NativeSelectOption key={option.value} value={option.value}>
@@ -446,7 +447,10 @@ export function DashboardStatePanel({ state, workspaceId }: DashboardStatePanelP
       <div className={styles.emptyCopy}>
         <span className={styles.panelEyebrow}>GET STARTED</span>
         <h2>아직 대시보드에 표시할 운영 데이터가 없습니다.</h2>
-        <p>상담 로그를 업로드하고 도메인팩을 준비한 뒤, 시뮬레이션으로 워크플로우 흐름을 확인하세요.</p>
+        <p>
+          상담 로그를 업로드하고 운영 지식팩을 준비한 뒤, 시뮬레이션으로 워크플로우 흐름을
+          확인하세요.
+        </p>
       </div>
       <div className={styles.ctaGrid}>
         <Button asChild variant="default">
@@ -458,7 +462,7 @@ export function DashboardStatePanel({ state, workspaceId }: DashboardStatePanelP
         <Button asChild variant="outline">
           <Link to={`/workspaces/${workspaceId}/domain-packs`} data-testid="dashboard-pack-cta">
             <PackagePlusIcon aria-hidden="true" />
-            도메인팩 생성
+            지식팩 생성
           </Link>
         </Button>
         <Button asChild variant="outline">
@@ -562,6 +566,7 @@ export function WorkspaceDashboardPage() {
       <DashboardFilters filters={filters} onChange={setFilters} />
       <FilterSummary filters={filters} />
       <DashboardMetricsGrid metrics={metrics} state={dataState} />
+      <KnowledgePackHealthPanel workspaceId={parsedWorkspaceId} />
       <DashboardStatePanel state={dataState} workspaceId={parsedWorkspaceId} />
 
       <section className={styles.slotGrid} aria-label="대시보드 카드와 차트 배치 영역">


### PR DESCRIPTION
Closes #520

## 변경 사항

- 워크스페이스 대시보드에서 현재 운영 지식팩 버전, 마지막 운영 반영일, 마지막 상담 로그 업로드, 최근 지식팩 생성 상태, 검토 대기 수를 한 화면에서 확인할 수 있습니다.
- 상담 로그 미업로드, 새 로그 미반영, 검토 대기, 최근 생성 실패 상황을 고객용 문구로 경고하고 업로드/검토/지식팩 생성 CTA를 제공합니다.
- `/api/v1/workspaces/{workspaceId}/dashboard/knowledge-pack-health` 조회 API가 워크스페이스 멤버십을 확인한 뒤 기존 pack/corpus/pipeline/review 스키마의 운영 상태를 반환합니다.
- 대시보드 필터와 빈 상태의 고객 노출 용어를 운영 지식팩 기준으로 정리했습니다.

## 검증

- `git diff --check`
- `cd frontend && pnpm test -- src/app/App.test.tsx src/features/workspace-dashboard-health/model/buildWorkspaceDashboardHealthView.test.ts src/features/workspace-dashboard-health/ui/KnowledgePackHealthPanel.test.tsx src/pages/workspace/ui/WorkspaceDashboardPage.test.tsx`
- `cd frontend && pnpm exec eslint src/app/App.test.tsx src/features/workspace-dashboard-health/api/workspaceDashboardHealthApi.ts src/features/workspace-dashboard-health/model/buildWorkspaceDashboardHealthView.ts src/features/workspace-dashboard-health/model/buildWorkspaceDashboardHealthView.test.ts src/features/workspace-dashboard-health/ui/KnowledgePackHealthPanel.tsx src/features/workspace-dashboard-health/ui/KnowledgePackHealthPanel.test.tsx src/pages/workspace/ui/WorkspaceDashboardPage.tsx src/pages/workspace/ui/WorkspaceDashboardPage.test.tsx`
- `cd frontend && pnpm format --check src/app/App.test.tsx src/features/workspace-dashboard-health/api/workspaceDashboardHealthApi.ts src/features/workspace-dashboard-health/model/buildWorkspaceDashboardHealthView.ts src/features/workspace-dashboard-health/model/buildWorkspaceDashboardHealthView.test.ts src/features/workspace-dashboard-health/ui/KnowledgePackHealthPanel.tsx src/features/workspace-dashboard-health/ui/KnowledgePackHealthPanel.test.tsx src/pages/workspace/ui/WorkspaceDashboardPage.tsx src/pages/workspace/ui/WorkspaceDashboardPage.test.tsx`
- `cd frontend && pnpm build`

## 참고

- 로컬 환경에서 Java 21 toolchain을 찾지 못해 backend targeted tests는 실행 전 실패했습니다: `cd backend && ./gradlew test --tests 'com.init.workspace.application.GetWorkspaceDashboardHealthUseCaseTest' --tests 'com.init.workspace.presentation.WorkspaceDashboardControllerTest'`