### PR TITLE
fix(infra): provision Toss Payments v2 prod config & harden Sonar CI

### DIFF
--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -376,9 +376,11 @@ jobs:
         env:
           VITE_API_BASE_URL: ${{ vars.PROD_API_BASE_URL }}
           VITE_WS_URL: ${{ vars.PROD_WS_URL }}
+          VITE_TOSS_CLIENT_KEY: ${{ vars.PROD_TOSS_CLIENT_KEY }}
         run: |
           test -n "$VITE_API_BASE_URL"
           test -n "$VITE_WS_URL"
+          test -n "$VITE_TOSS_CLIENT_KEY"
           cd frontend
           pnpm install --frozen-lockfile
           pnpm build

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -97,6 +97,9 @@ jobs:
       TF_VAR_airflow_simple_admin_password: ${{ secrets.PROD_AIRFLOW_SIMPLE_ADMIN_PASSWORD }}
       TF_VAR_airflow_simple_viewer_password: ${{ secrets.PROD_AIRFLOW_SIMPLE_VIEWER_PASSWORD }}
       TF_VAR_llm_runtime_api_key: ${{ secrets.PROD_LLM_RUNTIME_API_KEY || '' }}
+      TF_VAR_toss_secret_key: ${{ secrets.PROD_TOSS_SECRET_KEY }}
+      TF_VAR_toss_webhook_secret: ${{ secrets.PROD_TOSS_WEBHOOK_SECRET }}
+      TF_VAR_toss_billing_key_encryption_key: ${{ secrets.PROD_TOSS_BILLING_KEY_ENCRYPTION_KEY }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
@@ -146,6 +149,9 @@ jobs:
             TF_VAR_airflow_api_auth_jwt_secret
             TF_VAR_airflow_simple_admin_password
             TF_VAR_airflow_simple_viewer_password
+            TF_VAR_toss_secret_key
+            TF_VAR_toss_webhook_secret
+            TF_VAR_toss_billing_key_encryption_key
           )
           for name in "${required[@]}"; do
             test -n "${!name:-}" || { echo "$name is required"; exit 1; }

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -60,6 +60,7 @@ jobs:
       cloudfront_distribution_id: ${{ steps.tf_outputs.outputs.cloudfront_distribution_id }}
       ecs_cluster_name: ${{ steps.tf_outputs.outputs.ecs_cluster_name }}
       backend_service_name: ${{ steps.tf_outputs.outputs.backend_service_name }}
+      backend_task_definition_arn: ${{ steps.tf_outputs.outputs.backend_task_definition_arn }}
       airflow_init_task_definition_arn: ${{ steps.tf_outputs.outputs.airflow_init_task_definition_arn }}
       airflow_apiserver_service_name: ${{ steps.tf_outputs.outputs.airflow_apiserver_service_name }}
       airflow_scheduler_service_name: ${{ steps.tf_outputs.outputs.airflow_scheduler_service_name }}
@@ -175,6 +176,7 @@ jobs:
             echo "cloudfront_distribution_id=$(terraform output -raw cloudfront_distribution_id)"
             echo "ecs_cluster_name=$(terraform output -raw ecs_cluster_name)"
             echo "backend_service_name=$(terraform output -raw backend_service_name)"
+            echo "backend_task_definition_arn=$(terraform output -raw backend_task_definition_arn)"
             echo "airflow_init_task_definition_arn=$(terraform output -raw airflow_init_task_definition_arn)"
             echo "airflow_apiserver_service_name=$(terraform output -raw airflow_apiserver_service_name)"
             echo "airflow_scheduler_service_name=$(terraform output -raw airflow_scheduler_service_name)"
@@ -245,6 +247,7 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECS_CLUSTER: ${{ needs.terraform.outputs.ecs_cluster_name }}
           ECS_SERVICE: ${{ needs.terraform.outputs.backend_service_name }}
+          ECS_TASK_DEFINITION: ${{ needs.terraform.outputs.backend_task_definition_arn }}
           BACKEND_AUTOSCALING_MAX_CAPACITY: ${{ vars.PROD_BACKEND_AUTOSCALING_MAX_CAPACITY || '3' }}
         run: |
           IMAGE_URI="$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
@@ -309,14 +312,12 @@ jobs:
             --max-capacity "$BACKEND_MAX_CAPACITY" \
             --region ap-northeast-2
 
-          TASK_DEF_ARN="$(aws ecs describe-services \
-            --cluster "$ECS_CLUSTER" \
-            --services "$ECS_SERVICE" \
-            --region ap-northeast-2 \
-            --query 'services[0].taskDefinition' \
-            --output text)"
+          # Terraform이 이번 apply에서 등록한 backend task definition을 기준으로 이미지만 교체한다.
+          # 서비스의 현재 task definition을 읽으면 aws_ecs_service.backend의
+          # ignore_changes=[task_definition] 때문에 Terraform이 새로 추가한 env/secret(TOSS_* 등)이
+          # 반영되지 않아 컨테이너가 빈 값으로 부팅하다 실패한다.
           aws ecs describe-task-definition \
-            --task-definition "$TASK_DEF_ARN" \
+            --task-definition "$ECS_TASK_DEFINITION" \
             --region ap-northeast-2 \
             --query 'taskDefinition' > task-definition.json
           jq --arg image "$IMAGE_URI" '

--- a/.github/workflows/terraform-cd.yml
+++ b/.github/workflows/terraform-cd.yml
@@ -45,6 +45,9 @@ jobs:
       TF_VAR_airflow_simple_admin_password: ${{ secrets.PROD_AIRFLOW_SIMPLE_ADMIN_PASSWORD }}
       TF_VAR_airflow_simple_viewer_password: ${{ secrets.PROD_AIRFLOW_SIMPLE_VIEWER_PASSWORD }}
       TF_VAR_llm_runtime_api_key: ${{ secrets.PROD_LLM_RUNTIME_API_KEY || '' }}
+      TF_VAR_toss_secret_key: ${{ secrets.PROD_TOSS_SECRET_KEY }}
+      TF_VAR_toss_webhook_secret: ${{ secrets.PROD_TOSS_WEBHOOK_SECRET }}
+      TF_VAR_toss_billing_key_encryption_key: ${{ secrets.PROD_TOSS_BILLING_KEY_ENCRYPTION_KEY }}
     outputs:
       has_changes: ${{ steps.plan.outputs.has_changes }}
     steps:
@@ -97,6 +100,9 @@ jobs:
             TF_VAR_airflow_api_auth_jwt_secret
             TF_VAR_airflow_simple_admin_password
             TF_VAR_airflow_simple_viewer_password
+            TF_VAR_toss_secret_key
+            TF_VAR_toss_webhook_secret
+            TF_VAR_toss_billing_key_encryption_key
           )
           for name in "${required[@]}"; do
             test -n "${!name:-}" || { echo "$name is required"; exit 1; }
@@ -160,6 +166,9 @@ jobs:
       TF_VAR_airflow_simple_admin_password: ${{ secrets.PROD_AIRFLOW_SIMPLE_ADMIN_PASSWORD }}
       TF_VAR_airflow_simple_viewer_password: ${{ secrets.PROD_AIRFLOW_SIMPLE_VIEWER_PASSWORD }}
       TF_VAR_llm_runtime_api_key: ${{ secrets.PROD_LLM_RUNTIME_API_KEY || '' }}
+      TF_VAR_toss_secret_key: ${{ secrets.PROD_TOSS_SECRET_KEY }}
+      TF_VAR_toss_webhook_secret: ${{ secrets.PROD_TOSS_WEBHOOK_SECRET }}
+      TF_VAR_toss_billing_key_encryption_key: ${{ secrets.PROD_TOSS_BILLING_KEY_ENCRYPTION_KEY }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
@@ -209,6 +218,9 @@ jobs:
             TF_VAR_airflow_api_auth_jwt_secret
             TF_VAR_airflow_simple_admin_password
             TF_VAR_airflow_simple_viewer_password
+            TF_VAR_toss_secret_key
+            TF_VAR_toss_webhook_secret
+            TF_VAR_toss_billing_key_encryption_key
           )
           for name in "${required[@]}"; do
             test -n "${!name:-}" || { echo "$name is required"; exit 1; }

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -95,6 +95,10 @@ sonar {
         property("sonar.projectKey", "ajou-2026-1-capstone-5_ostone_backend")
         property("sonar.organization", "ajou-2026-1-capstone-5")
         property("sonar.host.url", "https://sonarcloud.io")
+        // CI 러너에 이미 설치된 JDK 21을 스캐너 런타임으로 사용한다. SonarCloud JRE 자동
+        // 프로비저닝(api.sonarcloud.io/analysis/jres)이 간헐적으로 403을 반환해 backend-sonar가
+        // flaky하게 실패하던 것을 방지한다. frontend/ml은 JRE 번들 scan-action이라 영향 없음.
+        property("sonar.scanner.skipJreProvisioning", "true")
         property("sonar.coverage.jacoco.xmlReportPaths",
             "${layout.buildDirectory.get().asFile.path}/reports/jacoco/test/jacocoTestReport.xml")
         property("sonar.exclusions",

--- a/infra/terraform/ecs-cluster.tf
+++ b/infra/terraform/ecs-cluster.tf
@@ -190,6 +190,18 @@ resource "aws_ecs_task_definition" "backend" {
         {
           name      = "AIRFLOW_WEBHOOK_SECRET"
           valueFrom = "${aws_secretsmanager_secret.app.arn}:airflow_webhook_secret::"
+        },
+        {
+          name      = "TOSS_SECRET_KEY"
+          valueFrom = "${aws_secretsmanager_secret.app.arn}:toss_secret_key::"
+        },
+        {
+          name      = "TOSS_WEBHOOK_SECRET"
+          valueFrom = "${aws_secretsmanager_secret.app.arn}:toss_webhook_secret::"
+        },
+        {
+          name      = "TOSS_BILLING_KEY_ENCRYPTION_KEY"
+          valueFrom = "${aws_secretsmanager_secret.app.arn}:toss_billing_key_encryption_key::"
         }
       ]
 

--- a/infra/terraform/secrets.tf
+++ b/infra/terraform/secrets.tf
@@ -39,6 +39,9 @@ resource "aws_secretsmanager_secret_version" "app" {
     airflow_simple_admin_password  = var.airflow_simple_admin_password
     airflow_simple_viewer_password = var.airflow_simple_viewer_password
     llm_runtime_api_key            = var.llm_runtime_api_key
+    toss_secret_key                = var.toss_secret_key
+    toss_webhook_secret            = var.toss_webhook_secret
+    toss_billing_key_encryption_key = var.toss_billing_key_encryption_key
   })
 }
 

--- a/infra/terraform/terraform.tfvars.example
+++ b/infra/terraform/terraform.tfvars.example
@@ -16,6 +16,10 @@ airflow_api_base_url = "http://<airflow-private-ip>:8080"
 airflow_api_allow_insecure_http = true
 airflow_webhook_secret = "replace-with-secure-webhook-secret"
 
+toss_secret_key                 = "replace-with-toss-api-secret-key"
+toss_webhook_secret             = "replace-with-toss-webhook-secret"
+toss_billing_key_encryption_key = "replace-with-billing-key-encryption-key"
+
 backend_desired_count = 0
 backend_autoscaling_min_capacity = 0
 backend_autoscaling_max_capacity = 3

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -298,6 +298,24 @@ variable "airflow_simple_viewer_password" {
   sensitive   = true
 }
 
+variable "toss_secret_key" {
+  description = "Toss Payments v2 API secret key (sk) used by the backend payment client."
+  type        = string
+  sensitive   = true
+}
+
+variable "toss_webhook_secret" {
+  description = "Toss Payments webhook signing secret used to verify inbound payment callbacks."
+  type        = string
+  sensitive   = true
+}
+
+variable "toss_billing_key_encryption_key" {
+  description = "Application-side key used to encrypt stored Toss billing keys at rest."
+  type        = string
+  sensitive   = true
+}
+
 variable "airflow_api_desired_count" {
   description = "Desired ECS task count for Airflow API server."
   type        = number


### PR DESCRIPTION
## 배경
main 배포 파이프라인 실패 3종 + 인접 prod 결제 설정 갭 처리.

1) Production Deploy backend → Deploy to Amazon ECS 실패
   TossApiProperties(@NotBlank) secret-key/webhook.secret/billing-key-encryption-key가
   prod 빈 값 → Spring @Validated 바인딩 실패(APPLICATION FAILED TO START), exit 1.
   토스 v2(#487/#538)가 검증 추가했으나 prod IaC 배선 누락(terraform toss 0건).
2) backend-sonar 실패 → SonarCloud JRE 자동 프로비저닝 일시적 403(토큰 유효,
   동일 토큰 frontend-sonar는 성공). ci-gate는 이 실패의 downstream 집계.
3) (인접) prod 프론트 번들에 VITE_TOSS_CLIENT_KEY 미주입 → 결제 UI prod 비활성화.
   CI는 실패 안 하나 기능 갭.

## 변경
- terraform: toss_secret_key/toss_webhook_secret/toss_billing_key_encryption_key
  변수 → 기존 /prod/ostone/app 시크릿에 키 추가 → backend ECS task secrets[] 매핑
- prod-deploy.yml / terraform-cd.yml: TF_VAR_toss_* 주입 + 필수변수 검증
- prod-deploy.yml frontend: VITE_TOSS_CLIENT_KEY(vars.PROD_TOSS_CLIENT_KEY) 주입 + 가드
- backend/build.gradle.kts: sonar.scanner.skipJreProvisioning=true (러너 JDK 21, flaky 403 회피)
- terraform.tfvars.example: 신규 변수 문서화

## 비용
신규 시크릿 미생성(기존 시크릿에 키만 추가) → 월 추가비용 $0. IAM 변경 없음.

## 선행작업 (배포 전)
- Repo Secrets: PROD_TOSS_SECRET_KEY / PROD_TOSS_WEBHOOK_SECRET /
  PROD_TOSS_BILLING_KEY_ENCRYPTION_KEY
- Repo Variable: PROD_TOSS_CLIENT_KEY ✅(등록 완료)

## 검증
- 변경분 전부 IaC/CI 설정 → 애플리케이션 소스 0줄, coverage-diff.py(82%) 해당없음 통과
- 워크플로 YAML 파싱 OK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 결제(TOSS) 관련 비밀값 3종을 인프라 변수·Secrets Manager·컨테이너 시크릿으로 추가
  * 배포·CD 워크플로우에 TOSS 환경변수 주입 및 필수 변수 검증 강화
  * 프로덕션 배포에서 백엔드 태스크 정의 ARN을 출력해 해당 ARN으로 태스크 정의 조회하도록 변경
  * 프론트엔드 빌드에 클라이언트 키 주입 및 빌드 전 검증 추가
  * 정적분석(Sonar) 실행 안정성 개선 (JRE 프로비저닝 건너뜀)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->