### PR TITLE
feat(dashboard): 핫패스 워크플로우 랭킹 제공

### DIFF
--- a/.agent/specs/519.md
+++ b/.agent/specs/519.md
@@ -1,0 +1,198 @@
+# 519. 핫패스 워크플로우 랭킹
+
+## Goal
+
+선택 기간에 많이 실행된 워크플로우를 실행량, 비중, 완료율, 실패율, 평균 처리 시간, 상담사 개입률, 전 기간 대비 증가율로 랭킹화하여 고객용 대시보드에서 우선 개선 대상을 찾을 수 있게 한다.
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A["워크스페이스 대시보드 진입"] --> B["공통 기간 필터 선택"]
+    B --> C["워크플로우 랭킹 API 호출"]
+    C --> D{랭킹 데이터 존재?}
+    D -->|Yes| E["TOP 5 카드 표시"]
+    E --> F["전체 랭킹 테이블 표시"]
+    F --> G{워크플로우 상세 링크 가능?}
+    G -->|Yes| H["워크플로우 row 클릭"]
+    H --> I["워크플로우 상세 화면 이동"]
+    G -->|No| J["상세 불가 상태 표시"]
+    D -->|No| K["빈 상태 표시"]
+```
+
+## Design Diff
+
+| 영역 | As-is | To-be | 변경 내용 |
+| --- | --- | --- | --- |
+| 대시보드 데이터 | 상담 처리 KPI와 운영 지식팩 건강도만 표시 | 핫패스 워크플로우 TOP 5와 전체 랭킹 표시 | 워크플로우 실행량 기반 패널을 추가한다 |
+| 워크플로우 슬롯 | 향후 연결용 placeholder | 실제 랭킹 카드/테이블 | placeholder 한 칸을 실행 가능한 데이터 영역으로 대체한다 |
+| 상세 이동 | 워크플로우 목록 버튼만 제공 | 각 row별 상세 링크 상태 제공 | pack/version/workflow 식별자가 확인되는 row는 상세 화면으로 이동한다 |
+| 과거 데이터 | 정의 join 실패 시 화면 요구 없음 | 정의가 없거나 링크를 만들 수 없어도 row 유지 | left join 기반 fallback 이름과 상세 불가 상태를 제공한다 |
+
+## Component Tree
+
+```text
+WorkspaceDashboardPage
+├─ DashboardFilters
+├─ DashboardMetricsGrid
+├─ KnowledgePackHealthPanel
+├─ HotpathWorkflowRankingPanel
+│  ├─ TopWorkflowCard
+│  └─ WorkflowRankingTable
+└─ DashboardStatePanel
+```
+
+## API Integration
+
+### Endpoints
+
+| Method | Path | Description |
+| --- | --- | --- |
+| GET | `/api/v1/workspaces/{workspaceId}/dashboard/workflow-rankings` | 선택 기간 workflow 랭킹 조회 |
+
+### Query Parameters
+
+| 이름 | 필수 | 설명 |
+| --- | --- | --- |
+| `from` | 아니오 | `yyyy-MM-dd`; `to`와 함께 전달한다 |
+| `to` | 아니오 | `yyyy-MM-dd`; 포함 종료일이며 서버에서 다음 날 0시 exclusive로 변환한다 |
+
+### Response Shape
+
+```json
+{
+  "workspaceId": 1,
+  "periodStart": "2026-05-29T00:00:00+09:00",
+  "periodEnd": "2026-06-05T00:00:00+09:00",
+  "totalConsultationCount": 120,
+  "rankings": [
+    {
+      "rank": 1,
+      "workflowDefinitionId": 10,
+      "domainPackId": 2,
+      "domainPackVersionId": 3,
+      "workflowCode": "refund_flow",
+      "workflowName": "환불 처리",
+      "executionCount": 48,
+      "shareRate": 40.0,
+      "completedCount": 42,
+      "failedCount": 3,
+      "runningCount": 3,
+      "completionRate": 87.5,
+      "failureRate": 6.3,
+      "averageHandlingSeconds": 180,
+      "humanInterventionRate": 25.0,
+      "changeRate": 33.3,
+      "surging": true,
+      "detailPath": "/workspaces/1/domain-packs/2/workflows/10?versionId=3"
+    }
+  ],
+  "topRankings": [
+    {
+      "rank": 1,
+      "workflowDefinitionId": 10,
+      "domainPackId": 2,
+      "domainPackVersionId": 3,
+      "workflowCode": "refund_flow",
+      "workflowName": "환불 처리",
+      "executionCount": 48,
+      "shareRate": 40.0,
+      "completedCount": 42,
+      "failedCount": 3,
+      "runningCount": 3,
+      "completionRate": 87.5,
+      "failureRate": 6.3,
+      "averageHandlingSeconds": 180,
+      "humanInterventionRate": 25.0,
+      "changeRate": 33.3,
+      "surging": true,
+      "detailPath": "/workspaces/1/domain-packs/2/workflows/10?versionId=3"
+    }
+  ]
+}
+```
+
+## Data Flow
+
+```text
+WorkspaceDashboardPage local filters
+  -> buildMetricDateRange(filters)
+  -> consultationApi.getWorkflowRankings(workspaceId, dateRange)
+  -> GET /api/v1/workspaces/{workspaceId}/dashboard/workflow-rankings
+  -> WorkspaceWorkflowRankingService
+  -> WorkflowRankingRepository
+  -> runtime.workflow_execution + runtime.chat_session + pack.workflow_definition
+```
+
+## 수정 대상 파일
+
+| 파일 | 변경 유형 | 설명 |
+| --- | --- | --- |
+| `backend/src/main/java/com/init/workflowruntime/presentation/WorkspaceWorkflowRankingController.java` | new | 대시보드 workflow 랭킹 API |
+| `backend/src/main/java/com/init/workflowruntime/application/WorkspaceWorkflowRankingService.java` | new | 기간 해석, 멤버십 검증, 변화율 계산 |
+| `backend/src/main/java/com/init/workflowruntime/application/command/GetWorkspaceWorkflowRankingsCommand.java` | new | workspace/user/date 요청 값 검증 |
+| `backend/src/main/java/com/init/workflowruntime/application/dto/WorkspaceWorkflowRankingResponse.java` | new | 랭킹 응답 DTO |
+| `backend/src/main/java/com/init/workflowruntime/application/dto/WorkspaceWorkflowRankingItemResponse.java` | new | 랭킹 row 응답 DTO |
+| `backend/src/main/java/com/init/workflowruntime/domain/WorkflowRankingRepository.java` | new | 랭킹 조회 포트 |
+| `backend/src/main/java/com/init/workflowruntime/domain/WorkflowRankingExecutionRow.java` | new | workflow 실행 row 모델 |
+| `backend/src/main/java/com/init/workflowruntime/infrastructure/persistence/JpaWorkflowRankingRepository.java` | new | Native SQL 집계 |
+| `frontend/src/features/consultation/api/consultationApi.ts` | update | workflow ranking 수동 API 함수와 타입 추가 |
+| `frontend/src/pages/workspace/ui/WorkspaceDashboardPage.tsx` | update | 핫패스 랭킹 패널 연결 |
+| `frontend/src/pages/workspace/ui/workspace-dashboard-page.module.css` | update | TOP 5 카드와 랭킹 테이블 스타일 |
+
+## State Management
+
+- 서버 상태는 현재 `WorkspaceDashboardPage`의 local loading/error 패턴을 따른다.
+- 기간이 `custom`이고 시작/종료일 중 하나라도 비어 있으면 API를 호출하지 않고 빈 랭킹 상태를 유지한다.
+- domain pack version, channel, workflow status 공통 필터는 #517의 화면 상태로 유지하되, 이번 API 쿼리에는 기간만 전달한다.
+
+## Backend Rules
+
+- workspace membership 검증은 상담 KPI와 같은 `WorkspaceMemberRepository` 기반으로 수행한다.
+- simulation/demo 채널은 제외한다: `DEMO`, `DEMO_WEB`, `SIMULATION`, `SIMULATION_WEB`, `SIMULATION%`.
+- 현재 기간 집계는 `runtime.workflow_execution.started_at` 기준이다.
+- 전체 상담 대비 비중의 분모는 같은 기간에 시작한 운영 `runtime.chat_session` 수다.
+- 완료율은 `status = 'COMPLETED'`, 실패율은 `status = 'FAILED'`, 진행 중은 그 외 terminal이 아닌 상태를 `runningCount`로 집계한다.
+- 평균 처리 시간은 `finished_at`이 존재하는 실행의 `finished_at - started_at` 초 단위 평균이다.
+- 상담사 개입률은 해당 workflow 실행의 `chat_session`에 `COUNSELOR` 또는 `AGENT` 메시지가 있는 비율이다.
+- workflow 정의가 없거나 링크 구성에 필요한 pack/version/workflow id가 없으면 집계 row는 유지하고 `detailPath`를 `null`로 반환한다.
+- 확인된 DB FK 기준으로 `pack.workflow_definition` 물리 삭제는 기존 실행이 참조 중이면 제한된다. 그래도 legacy/null 참조나 join 누락이 있어도 랭킹 응답과 화면이 깨지지 않아야 한다.
+
+## Tests
+
+### Backend
+
+| 구분 | 대상 | 기대 |
+| --- | --- | --- |
+| Unit | `WorkspaceWorkflowRankingService` | 현재/전 기간 실행량으로 rank, 비중, 완료율, 실패율, 평균 처리 시간, 상담사 개입률, 증가율, 급증 여부를 계산한다 |
+| Unit | `WorkspaceWorkflowRankingService` | 멤버가 아니면 repository를 호출하지 않고 접근을 거부한다 |
+| Repository | `JpaWorkflowRankingRepository` | workflow 실행을 집계하고 simulation/demo 채널과 삭제/미연결 정의 row를 안전하게 처리한다 |
+
+### Frontend
+
+| 구분 | 대상 | 기대 |
+| --- | --- | --- |
+| API | `consultationApi.getWorkflowRankings` | 기간 쿼리를 endpoint에 전달하고 응답을 unwrap한다 |
+| Page | `WorkspaceDashboardPage` | TOP 5 카드, 전체 랭킹 row, 급증 표시, 상세 링크 가능/불가 상태를 표시한다 |
+| Page | `WorkspaceDashboardPage` | metrics와 ranking 중 하나만 실패해도 대시보드 전체가 깨지지 않는다 |
+
+## Acceptance Criteria
+
+1. 선택 기간의 workflow TOP N이 대시보드에 표시된다.
+2. 각 workflow row에 실행 수, 전체 대비 비중, 완료율, 평균 처리 시간이 표시된다.
+3. 각 workflow row에 상담사 개입률과 실패율이 표시된다.
+4. 전 기간 대비 실행 수가 급증한 workflow가 시각적으로 강조된다.
+5. 링크 구성에 필요한 식별자가 있는 workflow row는 상세 화면으로 이동할 수 있다.
+6. workflow 정의가 변경되거나 API join에서 누락되어도 과거 실행 row는 fallback 이름과 상세 불가 상태로 표시된다.
+7. simulation/demo 채널 실행은 랭킹에서 제외된다.
+
+## Non-goals
+
+- 상태 전이별 병목 분석은 포함하지 않는다.
+- missing slot/policy/risk 상세 분석은 포함하지 않는다.
+- 추천 액션 생성은 포함하지 않는다.
+- domain pack version, channel, workflow status 공통 필터의 서버 쿼리 적용은 후속 확장으로 둔다.
+
+## Open Questions
+
+- workflow 정의 변경 전의 과거 이름을 완전히 보존하려면 runtime 실행 스냅샷 컬럼이 필요하지만, 현재 확인된 스키마에는 해당 컬럼이 없다. 이번 범위에서는 현재 정의명 또는 left join fallback으로 화면 깨짐을 방지한다.

--- a/backend/src/main/java/com/init/workflowruntime/application/WorkspaceWorkflowRankingService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/WorkspaceWorkflowRankingService.java
@@ -1,5 +1,6 @@
 package com.init.workflowruntime.application;
 
+import com.init.shared.application.exception.BadRequestException;
 import com.init.workflowruntime.application.command.GetWorkspaceWorkflowRankingsCommand;
 import com.init.workflowruntime.application.dto.WorkspaceWorkflowRankingItemResponse;
 import com.init.workflowruntime.application.dto.WorkspaceWorkflowRankingResponse;
@@ -93,9 +94,16 @@ public class WorkspaceWorkflowRankingService {
   }
 
   private RankingPeriod resolvePeriod(GetWorkspaceWorkflowRankingsCommand command) {
+    boolean hasFrom = command.fromDate() != null;
+    boolean hasTo = command.toDate() != null;
+    if (hasFrom != hasTo) {
+      throw new BadRequestException(
+          "INVALID_WORKFLOW_RANKING_PERIOD", "fromDate and toDate must be provided together");
+    }
+
     LocalDate startDate;
     LocalDate endDateExclusive;
-    if (command.fromDate() != null) {
+    if (hasFrom) {
       startDate = command.fromDate();
       endDateExclusive = command.toDate().plusDays(1);
     } else {

--- a/backend/src/main/java/com/init/workflowruntime/application/WorkspaceWorkflowRankingService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/WorkspaceWorkflowRankingService.java
@@ -1,0 +1,348 @@
+package com.init.workflowruntime.application;
+
+import com.init.workflowruntime.application.command.GetWorkspaceWorkflowRankingsCommand;
+import com.init.workflowruntime.application.dto.WorkspaceWorkflowRankingItemResponse;
+import com.init.workflowruntime.application.dto.WorkspaceWorkflowRankingResponse;
+import com.init.workflowruntime.domain.WorkflowExecution;
+import com.init.workflowruntime.domain.WorkflowRankingExecutionRow;
+import com.init.workflowruntime.domain.WorkflowRankingRepository;
+import com.init.workspace.application.exception.WorkspaceAccessDeniedException;
+import com.init.workspace.domain.repository.WorkspaceMemberRepository;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class WorkspaceWorkflowRankingService {
+
+  private static final ZoneId METRIC_ZONE = ZoneId.of("Asia/Seoul");
+  private static final int TOP_RANKING_LIMIT = 5;
+  private static final double SURGE_CHANGE_RATE_THRESHOLD = 30.0;
+  private static final String WORKSPACE_ACCESS_DENIED_MESSAGE = "워크스페이스에 접근 권한이 없습니다.";
+
+  private final WorkflowRankingRepository workflowRankingRepository;
+  private final WorkspaceMemberRepository workspaceMemberRepository;
+  private final Clock clock;
+
+  public WorkspaceWorkflowRankingService(
+      WorkflowRankingRepository workflowRankingRepository,
+      WorkspaceMemberRepository workspaceMemberRepository,
+      Clock clock) {
+    this.workflowRankingRepository = workflowRankingRepository;
+    this.workspaceMemberRepository = workspaceMemberRepository;
+    this.clock = clock;
+  }
+
+  public WorkspaceWorkflowRankingResponse getRankings(GetWorkspaceWorkflowRankingsCommand command) {
+    Long workspaceId = command.workspaceId();
+    validateWorkspaceMembership(workspaceId, command.userId());
+
+    RankingPeriod period = resolvePeriod(command);
+    long totalConsultationCount =
+        workflowRankingRepository.countOperationalConsultations(
+            workspaceId, period.start(), period.endExclusive());
+    Map<String, WorkflowAggregate> current =
+        aggregate(
+            workflowRankingRepository.findExecutionRows(
+                workspaceId, period.start(), period.endExclusive()));
+    Map<String, WorkflowAggregate> previous =
+        aggregate(
+            workflowRankingRepository.findExecutionRows(
+                workspaceId, period.previousStart(), period.start()));
+
+    List<WorkspaceWorkflowRankingItemResponse> unrankedItems =
+        current.values().stream()
+            .sorted(
+                Comparator.comparingLong(WorkflowAggregate::executionCount)
+                    .reversed()
+                    .thenComparing(WorkflowAggregate::workflowName))
+            .map(
+                aggregate ->
+                    toResponse(
+                        workspaceId,
+                        aggregate,
+                        previous.get(aggregate.groupKey()),
+                        totalConsultationCount))
+            .toList();
+
+    List<WorkspaceWorkflowRankingItemResponse> rankedItems = assignRanks(unrankedItems);
+    return new WorkspaceWorkflowRankingResponse(
+        workspaceId,
+        period.start(),
+        period.endExclusive(),
+        totalConsultationCount,
+        rankedItems,
+        rankedItems.stream().limit(TOP_RANKING_LIMIT).toList());
+  }
+
+  private void validateWorkspaceMembership(Long workspaceId, Long userId) {
+    workspaceMemberRepository
+        .findByWorkspaceIdAndUserId(workspaceId, userId)
+        .orElseThrow(() -> new WorkspaceAccessDeniedException(WORKSPACE_ACCESS_DENIED_MESSAGE));
+  }
+
+  private RankingPeriod resolvePeriod(GetWorkspaceWorkflowRankingsCommand command) {
+    LocalDate startDate;
+    LocalDate endDateExclusive;
+    if (command.fromDate() != null) {
+      startDate = command.fromDate();
+      endDateExclusive = command.toDate().plusDays(1);
+    } else {
+      LocalDate today = LocalDate.now(clock.withZone(METRIC_ZONE));
+      startDate = today;
+      endDateExclusive = today.plusDays(1);
+    }
+
+    long days = ChronoUnit.DAYS.between(startDate, endDateExclusive);
+    OffsetDateTime start = startDate.atStartOfDay(METRIC_ZONE).toOffsetDateTime();
+    OffsetDateTime end = endDateExclusive.atStartOfDay(METRIC_ZONE).toOffsetDateTime();
+    OffsetDateTime previousStart =
+        startDate.minusDays(days).atStartOfDay(METRIC_ZONE).toOffsetDateTime();
+    return new RankingPeriod(start, end, previousStart);
+  }
+
+  private Map<String, WorkflowAggregate> aggregate(List<WorkflowRankingExecutionRow> rows) {
+    Map<String, WorkflowAggregate> aggregates = new LinkedHashMap<>();
+    for (WorkflowRankingExecutionRow row : rows) {
+      String groupKey = groupKey(row);
+      aggregates
+          .computeIfAbsent(groupKey, ignored -> WorkflowAggregate.from(row, groupKey))
+          .add(row);
+    }
+    return aggregates;
+  }
+
+  private String groupKey(WorkflowRankingExecutionRow row) {
+    if (row.workflowDefinitionId() != null) {
+      return "workflow:" + row.workflowDefinitionId();
+    }
+    if (row.workflowCode() != null && !row.workflowCode().isBlank()) {
+      return "code:" + row.workflowCode();
+    }
+    return "unknown";
+  }
+
+  private WorkspaceWorkflowRankingItemResponse toResponse(
+      Long workspaceId,
+      WorkflowAggregate aggregate,
+      WorkflowAggregate previous,
+      long totalConsultationCount) {
+    Double changeRate =
+        previous == null ? null : changeRate(aggregate.executionCount(), previous.executionCount());
+    return new WorkspaceWorkflowRankingItemResponse(
+        0,
+        aggregate.workflowDefinitionId(),
+        aggregate.domainPackId(),
+        aggregate.domainPackVersionId(),
+        aggregate.workflowCode(),
+        aggregate.workflowName(),
+        aggregate.executionCount(),
+        percentage(aggregate.executionCount(), totalConsultationCount),
+        aggregate.completedCount(),
+        aggregate.failedCount(),
+        aggregate.runningCount(),
+        percentage(aggregate.completedCount(), aggregate.executionCount()),
+        percentage(aggregate.failedCount(), aggregate.executionCount()),
+        aggregate.averageHandlingSeconds(),
+        percentage(aggregate.humanInterventionCount(), aggregate.executionCount()),
+        changeRate,
+        changeRate != null && changeRate >= SURGE_CHANGE_RATE_THRESHOLD,
+        detailPath(workspaceId, aggregate));
+  }
+
+  private List<WorkspaceWorkflowRankingItemResponse> assignRanks(
+      List<WorkspaceWorkflowRankingItemResponse> items) {
+    List<WorkspaceWorkflowRankingItemResponse> ranked = new ArrayList<>();
+    for (int index = 0; index < items.size(); index++) {
+      WorkspaceWorkflowRankingItemResponse item = items.get(index);
+      ranked.add(
+          new WorkspaceWorkflowRankingItemResponse(
+              index + 1,
+              item.workflowDefinitionId(),
+              item.domainPackId(),
+              item.domainPackVersionId(),
+              item.workflowCode(),
+              item.workflowName(),
+              item.executionCount(),
+              item.shareRate(),
+              item.completedCount(),
+              item.failedCount(),
+              item.runningCount(),
+              item.completionRate(),
+              item.failureRate(),
+              item.averageHandlingSeconds(),
+              item.humanInterventionRate(),
+              item.changeRate(),
+              item.surging(),
+              item.detailPath()));
+    }
+    return ranked;
+  }
+
+  private String detailPath(Long workspaceId, WorkflowAggregate aggregate) {
+    if (aggregate.domainPackId() == null
+        || aggregate.domainPackVersionId() == null
+        || aggregate.workflowDefinitionId() == null) {
+      return null;
+    }
+    return "/workspaces/%d/domain-packs/%d/workflows/%d?versionId=%d"
+        .formatted(
+            workspaceId,
+            aggregate.domainPackId(),
+            aggregate.workflowDefinitionId(),
+            aggregate.domainPackVersionId());
+  }
+
+  private double percentage(long numerator, long denominator) {
+    if (denominator <= 0) {
+      return 0.0;
+    }
+    return roundOneDecimal((numerator * 100.0) / denominator);
+  }
+
+  private Double changeRate(long current, long previous) {
+    if (previous == 0) {
+      return null;
+    }
+    return roundOneDecimal(((current - previous) * 100.0) / previous);
+  }
+
+  private double roundOneDecimal(double value) {
+    return Math.round(value * 10.0) / 10.0;
+  }
+
+  private record RankingPeriod(
+      OffsetDateTime start, OffsetDateTime endExclusive, OffsetDateTime previousStart) {}
+
+  private static final class WorkflowAggregate {
+    private final String groupKey;
+    private final Long workflowDefinitionId;
+    private final Long domainPackId;
+    private final Long domainPackVersionId;
+    private final String workflowCode;
+    private final String workflowName;
+    private long executionCount;
+    private long completedCount;
+    private long failedCount;
+    private long humanInterventionCount;
+    private long handlingSecondsSum;
+    private long handlingSecondsCount;
+
+    private WorkflowAggregate(
+        String groupKey,
+        Long workflowDefinitionId,
+        Long domainPackId,
+        Long domainPackVersionId,
+        String workflowCode,
+        String workflowName) {
+      this.groupKey = groupKey;
+      this.workflowDefinitionId = workflowDefinitionId;
+      this.domainPackId = domainPackId;
+      this.domainPackVersionId = domainPackVersionId;
+      this.workflowCode = workflowCode;
+      this.workflowName = workflowName;
+    }
+
+    static WorkflowAggregate from(WorkflowRankingExecutionRow row, String groupKey) {
+      String fallbackName =
+          row.workflowDefinitionId() == null ? "미확인 워크플로우" : "워크플로우 #" + row.workflowDefinitionId();
+      return new WorkflowAggregate(
+          groupKey,
+          row.workflowDefinitionId(),
+          row.domainPackId(),
+          row.domainPackVersionId(),
+          row.workflowCode(),
+          nonBlank(row.workflowName(), fallbackName));
+    }
+
+    void add(WorkflowRankingExecutionRow row) {
+      executionCount++;
+      if (WorkflowExecution.STATUS_COMPLETED.equals(row.status())) {
+        completedCount++;
+      } else if (WorkflowExecution.STATUS_FAILED.equals(row.status())) {
+        failedCount++;
+      }
+      if (row.hasHumanMessage()) {
+        humanInterventionCount++;
+      }
+      Long seconds = handlingSeconds(row.startedAt(), row.finishedAt());
+      if (seconds != null) {
+        handlingSecondsSum += seconds;
+        handlingSecondsCount++;
+      }
+    }
+
+    private Long handlingSeconds(OffsetDateTime startedAt, OffsetDateTime finishedAt) {
+      if (startedAt == null || finishedAt == null || finishedAt.isBefore(startedAt)) {
+        return null;
+      }
+      return Duration.between(startedAt, finishedAt).getSeconds();
+    }
+
+    private static String nonBlank(String value, String fallback) {
+      return value == null || value.isBlank() ? fallback : value;
+    }
+
+    String groupKey() {
+      return groupKey;
+    }
+
+    Long workflowDefinitionId() {
+      return workflowDefinitionId;
+    }
+
+    Long domainPackId() {
+      return domainPackId;
+    }
+
+    Long domainPackVersionId() {
+      return domainPackVersionId;
+    }
+
+    String workflowCode() {
+      return workflowCode;
+    }
+
+    String workflowName() {
+      return workflowName;
+    }
+
+    long executionCount() {
+      return executionCount;
+    }
+
+    long completedCount() {
+      return completedCount;
+    }
+
+    long failedCount() {
+      return failedCount;
+    }
+
+    long runningCount() {
+      return executionCount - completedCount - failedCount;
+    }
+
+    long humanInterventionCount() {
+      return humanInterventionCount;
+    }
+
+    Long averageHandlingSeconds() {
+      if (handlingSecondsCount == 0) {
+        return null;
+      }
+      return Math.round((double) handlingSecondsSum / handlingSecondsCount);
+    }
+  }
+}

--- a/backend/src/main/java/com/init/workflowruntime/application/command/GetWorkspaceWorkflowRankingsCommand.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/command/GetWorkspaceWorkflowRankingsCommand.java
@@ -1,0 +1,25 @@
+package com.init.workflowruntime.application.command;
+
+import com.init.shared.application.exception.BadRequestException;
+import java.time.LocalDate;
+import java.util.Objects;
+
+public record GetWorkspaceWorkflowRankingsCommand(
+    Long workspaceId, Long userId, LocalDate fromDate, LocalDate toDate) {
+  public GetWorkspaceWorkflowRankingsCommand {
+    Objects.requireNonNull(workspaceId, "workspaceId must not be null");
+    Objects.requireNonNull(userId, "userId must not be null");
+    if ((fromDate == null) != (toDate == null)) {
+      throw new BadRequestException(
+          "INVALID_WORKFLOW_RANKING_PERIOD", "fromDate and toDate must be provided together");
+    }
+    if (fromDate != null && fromDate.isAfter(toDate)) {
+      throw new BadRequestException(
+          "INVALID_WORKFLOW_RANKING_PERIOD", "fromDate must be before or equal to toDate");
+    }
+  }
+
+  public GetWorkspaceWorkflowRankingsCommand(Long workspaceId, Long userId) {
+    this(workspaceId, userId, null, null);
+  }
+}

--- a/backend/src/main/java/com/init/workflowruntime/application/dto/WorkspaceWorkflowRankingItemResponse.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/dto/WorkspaceWorkflowRankingItemResponse.java
@@ -1,0 +1,21 @@
+package com.init.workflowruntime.application.dto;
+
+public record WorkspaceWorkflowRankingItemResponse(
+    int rank,
+    Long workflowDefinitionId,
+    Long domainPackId,
+    Long domainPackVersionId,
+    String workflowCode,
+    String workflowName,
+    long executionCount,
+    double shareRate,
+    long completedCount,
+    long failedCount,
+    long runningCount,
+    double completionRate,
+    double failureRate,
+    Long averageHandlingSeconds,
+    double humanInterventionRate,
+    Double changeRate,
+    boolean surging,
+    String detailPath) {}

--- a/backend/src/main/java/com/init/workflowruntime/application/dto/WorkspaceWorkflowRankingResponse.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/dto/WorkspaceWorkflowRankingResponse.java
@@ -1,0 +1,12 @@
+package com.init.workflowruntime.application.dto;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+public record WorkspaceWorkflowRankingResponse(
+    Long workspaceId,
+    OffsetDateTime periodStart,
+    OffsetDateTime periodEnd,
+    long totalConsultationCount,
+    List<WorkspaceWorkflowRankingItemResponse> rankings,
+    List<WorkspaceWorkflowRankingItemResponse> topRankings) {}

--- a/backend/src/main/java/com/init/workflowruntime/domain/WorkflowRankingExecutionRow.java
+++ b/backend/src/main/java/com/init/workflowruntime/domain/WorkflowRankingExecutionRow.java
@@ -1,0 +1,15 @@
+package com.init.workflowruntime.domain;
+
+import java.time.OffsetDateTime;
+
+public record WorkflowRankingExecutionRow(
+    Long executionId,
+    Long workflowDefinitionId,
+    Long domainPackId,
+    Long domainPackVersionId,
+    String workflowCode,
+    String workflowName,
+    String status,
+    OffsetDateTime startedAt,
+    OffsetDateTime finishedAt,
+    boolean hasHumanMessage) {}

--- a/backend/src/main/java/com/init/workflowruntime/domain/WorkflowRankingRepository.java
+++ b/backend/src/main/java/com/init/workflowruntime/domain/WorkflowRankingRepository.java
@@ -1,0 +1,13 @@
+package com.init.workflowruntime.domain;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+public interface WorkflowRankingRepository {
+
+  long countOperationalConsultations(
+      Long workspaceId, OffsetDateTime periodStart, OffsetDateTime periodEnd);
+
+  List<WorkflowRankingExecutionRow> findExecutionRows(
+      Long workspaceId, OffsetDateTime periodStart, OffsetDateTime periodEnd);
+}

--- a/backend/src/main/java/com/init/workflowruntime/infrastructure/persistence/JpaWorkflowRankingRepository.java
+++ b/backend/src/main/java/com/init/workflowruntime/infrastructure/persistence/JpaWorkflowRankingRepository.java
@@ -1,0 +1,120 @@
+package com.init.workflowruntime.infrastructure.persistence;
+
+import com.init.shared.infrastructure.persistence.NativeQueryColumnConverter;
+import com.init.workflowruntime.domain.WorkflowRankingExecutionRow;
+import com.init.workflowruntime.domain.WorkflowRankingRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class JpaWorkflowRankingRepository implements WorkflowRankingRepository {
+
+  private final EntityManager entityManager;
+
+  public JpaWorkflowRankingRepository(EntityManager entityManager) {
+    this.entityManager = entityManager;
+  }
+
+  @Override
+  public long countOperationalConsultations(
+      Long workspaceId, OffsetDateTime periodStart, OffsetDateTime periodEnd) {
+    Query query =
+        entityManager.createNativeQuery(
+            """
+            select count(*)
+            from runtime.chat_session cs
+            where cs.workspace_id = :workspaceId
+              and cs.started_at >= :periodStart
+              and cs.started_at < :periodEnd
+              and (
+                cs.channel is null
+                or (
+                  upper(cs.channel) not in ('DEMO', 'DEMO_WEB', 'SIMULATION', 'SIMULATION_WEB')
+                  and upper(cs.channel) not like 'SIMULATION%'
+                )
+              )
+            """);
+    query.setParameter("workspaceId", workspaceId);
+    query.setParameter("periodStart", periodStart);
+    query.setParameter("periodEnd", periodEnd);
+    return ((Number) query.getSingleResult()).longValue();
+  }
+
+  @Override
+  public List<WorkflowRankingExecutionRow> findExecutionRows(
+      Long workspaceId, OffsetDateTime periodStart, OffsetDateTime periodEnd) {
+    Query query =
+        entityManager.createNativeQuery(
+            """
+            select
+              we.id as execution_id,
+              we.workflow_definition_id,
+              dp.id as domain_pack_id,
+              wd.domain_pack_version_id,
+              wd.workflow_code,
+              wd.name as workflow_name,
+              we.status,
+              we.started_at,
+              we.finished_at,
+              exists (
+                select 1
+                from runtime.chat_message cm
+                where cm.chat_session_id = cs.id
+                  and cm.sender_role in ('COUNSELOR', 'AGENT')
+              ) as has_human_message
+            from runtime.workflow_execution we
+            join runtime.chat_session cs on cs.id = we.chat_session_id
+            left join pack.workflow_definition wd on wd.id = we.workflow_definition_id
+            left join pack.domain_pack_version dpv on dpv.id = wd.domain_pack_version_id
+            left join pack.domain_pack dp on dp.id = dpv.domain_pack_id
+            where cs.workspace_id = :workspaceId
+              and we.started_at >= :periodStart
+              and we.started_at < :periodEnd
+              and (
+                cs.channel is null
+                or (
+                  upper(cs.channel) not in ('DEMO', 'DEMO_WEB', 'SIMULATION', 'SIMULATION_WEB')
+                  and upper(cs.channel) not like 'SIMULATION%'
+                )
+              )
+            """);
+    query.setParameter("workspaceId", workspaceId);
+    query.setParameter("periodStart", periodStart);
+    query.setParameter("periodEnd", periodEnd);
+
+    @SuppressWarnings("unchecked")
+    List<Object[]> rows = query.getResultList();
+    return rows.stream().map(this::toExecutionRow).toList();
+  }
+
+  private WorkflowRankingExecutionRow toExecutionRow(Object[] row) {
+    return new WorkflowRankingExecutionRow(
+        NativeQueryColumnConverter.toLong(row[0]),
+        NativeQueryColumnConverter.toLong(row[1]),
+        NativeQueryColumnConverter.toLong(row[2]),
+        NativeQueryColumnConverter.toLong(row[3]),
+        toStringValue(row[4]),
+        toStringValue(row[5]),
+        toStringValue(row[6]),
+        NativeQueryColumnConverter.toOffsetDateTime(row[7]),
+        NativeQueryColumnConverter.toOffsetDateTime(row[8]),
+        toBoolean(row[9]));
+  }
+
+  private String toStringValue(Object value) {
+    return value == null ? null : String.valueOf(value);
+  }
+
+  private boolean toBoolean(Object value) {
+    if (value instanceof Boolean bool) {
+      return bool;
+    }
+    if (value instanceof Number number) {
+      return number.intValue() != 0;
+    }
+    return Boolean.parseBoolean(String.valueOf(value));
+  }
+}

--- a/backend/src/main/java/com/init/workflowruntime/presentation/WorkspaceWorkflowRankingController.java
+++ b/backend/src/main/java/com/init/workflowruntime/presentation/WorkspaceWorkflowRankingController.java
@@ -1,0 +1,39 @@
+package com.init.workflowruntime.presentation;
+
+import com.init.shared.presentation.AuthenticationUtils;
+import com.init.workflowruntime.application.WorkspaceWorkflowRankingService;
+import com.init.workflowruntime.application.command.GetWorkspaceWorkflowRankingsCommand;
+import com.init.workflowruntime.application.dto.WorkspaceWorkflowRankingResponse;
+import java.time.LocalDate;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/workspaces/{workspaceId}/dashboard")
+public class WorkspaceWorkflowRankingController {
+
+  private final WorkspaceWorkflowRankingService workspaceWorkflowRankingService;
+
+  public WorkspaceWorkflowRankingController(
+      WorkspaceWorkflowRankingService workspaceWorkflowRankingService) {
+    this.workspaceWorkflowRankingService = workspaceWorkflowRankingService;
+  }
+
+  @GetMapping("/workflow-rankings")
+  public ResponseEntity<WorkspaceWorkflowRankingResponse> getWorkflowRankings(
+      @PathVariable Long workspaceId,
+      @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+      @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to,
+      Authentication authentication) {
+    Long userId = AuthenticationUtils.getUserId(authentication);
+    return ResponseEntity.ok(
+        workspaceWorkflowRankingService.getRankings(
+            new GetWorkspaceWorkflowRankingsCommand(workspaceId, userId, from, to)));
+  }
+}

--- a/backend/src/test/java/com/init/workflowruntime/application/WorkspaceWorkflowRankingServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/WorkspaceWorkflowRankingServiceTest.java
@@ -1,0 +1,197 @@
+package com.init.workflowruntime.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import com.init.workflowruntime.application.command.GetWorkspaceWorkflowRankingsCommand;
+import com.init.workflowruntime.application.dto.WorkspaceWorkflowRankingResponse;
+import com.init.workflowruntime.domain.WorkflowExecution;
+import com.init.workflowruntime.domain.WorkflowRankingExecutionRow;
+import com.init.workflowruntime.domain.WorkflowRankingRepository;
+import com.init.workspace.application.exception.WorkspaceAccessDeniedException;
+import com.init.workspace.domain.model.WorkspaceMember;
+import com.init.workspace.domain.model.WorkspaceMemberRole;
+import com.init.workspace.domain.repository.WorkspaceMemberRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("WorkspaceWorkflowRankingService")
+class WorkspaceWorkflowRankingServiceTest {
+
+  private static final Long WORKSPACE_ID = 2L;
+  private static final Long USER_ID = 7L;
+  private static final ZoneId SEOUL = ZoneId.of("Asia/Seoul");
+
+  @Mock private WorkflowRankingRepository workflowRankingRepository;
+  @Mock private WorkspaceMemberRepository workspaceMemberRepository;
+
+  private WorkspaceWorkflowRankingService service;
+
+  @BeforeEach
+  void setUp() {
+    Clock clock = Clock.fixed(Instant.parse("2026-05-27T03:00:00Z"), SEOUL);
+    service =
+        new WorkspaceWorkflowRankingService(
+            workflowRankingRepository, workspaceMemberRepository, clock);
+  }
+
+  @Test
+  @DisplayName("현재/전 기간 workflow 실행량으로 랭킹 지표를 계산한다")
+  void should_calculateWorkflowRankingMetrics_when_executionRowsExist() {
+    OffsetDateTime start = OffsetDateTime.parse("2026-05-21T00:00:00+09:00");
+    OffsetDateTime end = OffsetDateTime.parse("2026-05-28T00:00:00+09:00");
+    OffsetDateTime previousStart = OffsetDateTime.parse("2026-05-14T00:00:00+09:00");
+    givenMember();
+    given(workflowRankingRepository.countOperationalConsultations(WORKSPACE_ID, start, end))
+        .willReturn(10L);
+    given(workflowRankingRepository.findExecutionRows(WORKSPACE_ID, start, end))
+        .willReturn(
+            List.of(
+                row(
+                    1L,
+                    100L,
+                    "refund_flow",
+                    "환불 처리",
+                    WorkflowExecution.STATUS_COMPLETED,
+                    at("2026-05-21T09:00:00+09:00"),
+                    at("2026-05-21T09:02:00+09:00"),
+                    false),
+                row(
+                    2L,
+                    100L,
+                    "refund_flow",
+                    "환불 처리",
+                    WorkflowExecution.STATUS_COMPLETED,
+                    at("2026-05-21T10:00:00+09:00"),
+                    at("2026-05-21T10:04:00+09:00"),
+                    true),
+                row(
+                    3L,
+                    100L,
+                    "refund_flow",
+                    "환불 처리",
+                    WorkflowExecution.STATUS_FAILED,
+                    at("2026-05-21T11:00:00+09:00"),
+                    null,
+                    false),
+                new WorkflowRankingExecutionRow(
+                    4L,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    WorkflowExecution.STATUS_RUNNING,
+                    at("2026-05-21T12:00:00+09:00"),
+                    null,
+                    true)));
+    given(workflowRankingRepository.findExecutionRows(WORKSPACE_ID, previousStart, start))
+        .willReturn(
+            List.of(
+                row(
+                    5L,
+                    100L,
+                    "refund_flow",
+                    "환불 처리",
+                    WorkflowExecution.STATUS_COMPLETED,
+                    at("2026-05-14T09:00:00+09:00"),
+                    at("2026-05-14T09:03:00+09:00"),
+                    false)));
+
+    WorkspaceWorkflowRankingResponse response =
+        service.getRankings(
+            new GetWorkspaceWorkflowRankingsCommand(
+                WORKSPACE_ID,
+                USER_ID,
+                LocalDate.parse("2026-05-21"),
+                LocalDate.parse("2026-05-27")));
+
+    assertThat(response.periodStart()).isEqualTo(start);
+    assertThat(response.periodEnd()).isEqualTo(end);
+    assertThat(response.totalConsultationCount()).isEqualTo(10);
+    assertThat(response.rankings()).hasSize(2);
+    assertThat(response.topRankings()).hasSize(2);
+
+    var refund = response.rankings().get(0);
+    assertThat(refund.rank()).isEqualTo(1);
+    assertThat(refund.workflowDefinitionId()).isEqualTo(100L);
+    assertThat(refund.executionCount()).isEqualTo(3);
+    assertThat(refund.shareRate()).isEqualTo(30.0);
+    assertThat(refund.completedCount()).isEqualTo(2);
+    assertThat(refund.failedCount()).isEqualTo(1);
+    assertThat(refund.runningCount()).isZero();
+    assertThat(refund.completionRate()).isEqualTo(66.7);
+    assertThat(refund.failureRate()).isEqualTo(33.3);
+    assertThat(refund.averageHandlingSeconds()).isEqualTo(180L);
+    assertThat(refund.humanInterventionRate()).isEqualTo(33.3);
+    assertThat(refund.changeRate()).isEqualTo(200.0);
+    assertThat(refund.surging()).isTrue();
+    assertThat(refund.detailPath())
+        .isEqualTo("/workspaces/2/domain-packs/11/workflows/100?versionId=22");
+
+    var unknown = response.rankings().get(1);
+    assertThat(unknown.workflowName()).isEqualTo("미확인 워크플로우");
+    assertThat(unknown.detailPath()).isNull();
+    assertThat(unknown.runningCount()).isEqualTo(1);
+    assertThat(unknown.humanInterventionRate()).isEqualTo(100.0);
+  }
+
+  @Test
+  @DisplayName("워크스페이스 멤버가 아니면 랭킹 조회를 거부한다")
+  void should_throwAccessDenied_when_userIsNotWorkspaceMember() {
+    given(workspaceMemberRepository.findByWorkspaceIdAndUserId(WORKSPACE_ID, USER_ID))
+        .willReturn(Optional.empty());
+
+    assertThatThrownBy(
+            () ->
+                service.getRankings(new GetWorkspaceWorkflowRankingsCommand(WORKSPACE_ID, USER_ID)))
+        .isInstanceOf(WorkspaceAccessDeniedException.class);
+    verifyNoInteractions(workflowRankingRepository);
+  }
+
+  private void givenMember() {
+    given(workspaceMemberRepository.findByWorkspaceIdAndUserId(WORKSPACE_ID, USER_ID))
+        .willReturn(
+            Optional.of(WorkspaceMember.create(WORKSPACE_ID, USER_ID, WorkspaceMemberRole.OWNER)));
+  }
+
+  private WorkflowRankingExecutionRow row(
+      Long executionId,
+      Long workflowDefinitionId,
+      String workflowCode,
+      String workflowName,
+      String status,
+      OffsetDateTime startedAt,
+      OffsetDateTime finishedAt,
+      boolean hasHumanMessage) {
+    return new WorkflowRankingExecutionRow(
+        executionId,
+        workflowDefinitionId,
+        11L,
+        22L,
+        workflowCode,
+        workflowName,
+        status,
+        startedAt,
+        finishedAt,
+        hasHumanMessage);
+  }
+
+  private OffsetDateTime at(String value) {
+    return OffsetDateTime.parse(value);
+  }
+}

--- a/backend/src/test/java/com/init/workflowruntime/infrastructure/persistence/JpaWorkflowRankingRepositoryTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/infrastructure/persistence/JpaWorkflowRankingRepositoryTest.java
@@ -1,0 +1,219 @@
+package com.init.workflowruntime.infrastructure.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.init.workflowruntime.domain.WorkflowExecution;
+import com.init.workflowruntime.domain.WorkflowRankingExecutionRow;
+import jakarta.persistence.EntityManager;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(JpaWorkflowRankingRepository.class)
+@DisplayName("JpaWorkflowRankingRepository")
+class JpaWorkflowRankingRepositoryTest {
+
+  private static final OffsetDateTime PERIOD_START =
+      OffsetDateTime.parse("2026-05-27T00:00:00+09:00");
+  private static final OffsetDateTime PERIOD_END =
+      OffsetDateTime.parse("2026-05-28T00:00:00+09:00");
+
+  @Autowired private JpaWorkflowRankingRepository repository;
+
+  @Autowired private EntityManager entityManager;
+
+  @Test
+  @DisplayName("findExecutionRows: 운영 실행만 조회하고 미연결 정의도 유지한다")
+  void should_findExecutionRows_when_operationalWorkflowExecutionsExist() {
+    Long workspaceId = persistWorkspaceAndWorkflow();
+
+    Long refundSessionId = persistSession(workspaceId, "WEB", "COMPLETED", 22L);
+    persistMessage(refundSessionId, 1, "CUSTOMER");
+    persistMessage(refundSessionId, 2, "AGENT");
+    Long refundExecutionId =
+        persistExecution(
+            refundSessionId,
+            100L,
+            WorkflowExecution.STATUS_COMPLETED,
+            at("2026-05-27T09:00:00+09:00"),
+            at("2026-05-27T09:03:00+09:00"));
+
+    Long unknownSessionId = persistSession(workspaceId, "WEB", "OPEN", 22L);
+    Long unknownExecutionId =
+        persistExecution(
+            unknownSessionId,
+            null,
+            WorkflowExecution.STATUS_RUNNING,
+            at("2026-05-27T10:00:00+09:00"),
+            null);
+
+    Long simulationSessionId = persistSession(workspaceId, "SIMULATION_WEB", "COMPLETED", 22L);
+    persistExecution(
+        simulationSessionId,
+        100L,
+        WorkflowExecution.STATUS_COMPLETED,
+        at("2026-05-27T11:00:00+09:00"),
+        at("2026-05-27T11:01:00+09:00"));
+
+    assertThat(repository.countOperationalConsultations(workspaceId, PERIOD_START, PERIOD_END))
+        .isEqualTo(2L);
+
+    List<WorkflowRankingExecutionRow> rows =
+        repository.findExecutionRows(workspaceId, PERIOD_START, PERIOD_END);
+    Map<Long, WorkflowRankingExecutionRow> byExecutionId =
+        rows.stream()
+            .collect(
+                Collectors.toMap(WorkflowRankingExecutionRow::executionId, Function.identity()));
+
+    assertThat(byExecutionId).containsOnlyKeys(refundExecutionId, unknownExecutionId);
+    assertThat(byExecutionId.get(refundExecutionId).workflowDefinitionId()).isEqualTo(100L);
+    assertThat(byExecutionId.get(refundExecutionId).domainPackId()).isEqualTo(11L);
+    assertThat(byExecutionId.get(refundExecutionId).domainPackVersionId()).isEqualTo(22L);
+    assertThat(byExecutionId.get(refundExecutionId).workflowCode()).isEqualTo("refund_flow");
+    assertThat(byExecutionId.get(refundExecutionId).workflowName()).isEqualTo("환불 처리");
+    assertThat(byExecutionId.get(refundExecutionId).hasHumanMessage()).isTrue();
+    assertThat(byExecutionId.get(unknownExecutionId).workflowDefinitionId()).isNull();
+    assertThat(byExecutionId.get(unknownExecutionId).workflowName()).isNull();
+  }
+
+  private Long persistWorkspaceAndWorkflow() {
+    update(
+        """
+        insert into app.workspace
+          (id, workspace_key, name, status, free_onboarding_status, created_at, updated_at)
+        values (2, 'workflow-ranking', 'Workflow Ranking', 'ACTIVE', 'AVAILABLE', :now, :now)
+        """,
+        Map.of("now", PERIOD_START));
+    update(
+        """
+        insert into pack.domain_pack
+          (id, workspace_id, pack_key, name, status, created_at, updated_at)
+        values (11, 2, 'workflow-ranking-pack', 'Workflow Ranking Pack', 'ACTIVE', :now, :now)
+        """,
+        Map.of("now", PERIOD_START));
+    update(
+        """
+        insert into pack.domain_pack_version
+          (id, domain_pack_id, version_no, lifecycle_status, summary_json,
+           created_at, updated_at, version)
+        values (22, 11, 1, 'PUBLISHED', '{}', :now, :now, 0)
+        """,
+        Map.of("now", PERIOD_START));
+    update(
+        """
+        insert into pack.intent_definition
+          (id, domain_pack_version_id, intent_code, name, taxonomy_level, status,
+           source_cluster_ref,
+           entry_condition_json, evidence_json, meta_json, created_at, updated_at)
+        values (33, 22, 'refund', '환불', 1, 'PUBLISHED', '{}', '{}', '[]', '{}', :now, :now)
+        """,
+        Map.of("now", PERIOD_START));
+    update(
+        """
+        insert into pack.workflow_definition
+          (id, domain_pack_version_id, intent_definition_id, workflow_code, name, graph_json,
+           terminal_states_json, is_primary, route_condition_json, evidence_json, meta_json,
+           created_at, updated_at)
+        values (100, 22, 33, 'refund_flow', '환불 처리', '{}', '[]', true, '{}', '[]', '{}',
+                :now, :now)
+        """,
+        Map.of("now", PERIOD_START));
+    return 2L;
+  }
+
+  private Long persistSession(
+      Long workspaceId, String channel, String status, Long domainPackVersionId) {
+    Long sessionId = nextId("runtime.chat_session");
+    var query =
+        entityManager.createNativeQuery(
+            """
+            insert into runtime.chat_session
+              (id, workspace_id, domain_pack_version_id, status, channel, meta_json, response_mode,
+               started_at, ended_at)
+            values (:id, :workspaceId, :domainPackVersionId, :status, :channel, '{}', 'AI_ACTIVE',
+                    :startedAt, :endedAt)
+            """);
+    query.setParameter("id", sessionId);
+    query.setParameter("workspaceId", workspaceId);
+    query.setParameter("domainPackVersionId", domainPackVersionId);
+    query.setParameter("status", status);
+    query.setParameter("channel", channel);
+    query.setParameter("startedAt", at("2026-05-27T09:00:00+09:00"));
+    query.setParameter(
+        "endedAt", "COMPLETED".equals(status) ? at("2026-05-27T09:05:00+09:00") : null);
+    query.executeUpdate();
+    return sessionId;
+  }
+
+  private Long persistExecution(
+      Long sessionId,
+      Long workflowDefinitionId,
+      String status,
+      OffsetDateTime startedAt,
+      OffsetDateTime finishedAt) {
+    Long executionId = nextId("runtime.workflow_execution");
+    var query =
+        entityManager.createNativeQuery(
+            """
+            insert into runtime.workflow_execution
+              (id, chat_session_id, workflow_definition_id, status, slot_values_json,
+               policy_snapshot_json, risk_snapshot_json, started_at, finished_at)
+            values (:id, :sessionId, :workflowDefinitionId, :status, '{}', '{}', '{}',
+                    :startedAt, :finishedAt)
+            """);
+    query.setParameter("id", executionId);
+    query.setParameter("sessionId", sessionId);
+    query.setParameter("workflowDefinitionId", workflowDefinitionId);
+    query.setParameter("status", status);
+    query.setParameter("startedAt", startedAt);
+    query.setParameter("finishedAt", finishedAt);
+    query.executeUpdate();
+    return executionId;
+  }
+
+  private void persistMessage(Long sessionId, int seqNo, String senderRole) {
+    Long messageId = nextId("runtime.chat_message");
+    var query =
+        entityManager.createNativeQuery(
+            """
+            insert into runtime.chat_message
+              (id, chat_session_id, seq_no, sender_role, message_type, content, payload_json,
+               created_at)
+            values (:id, :sessionId, :seqNo, :senderRole, 'TEXT', :senderRole, '{}', :createdAt)
+            """);
+    query.setParameter("id", messageId);
+    query.setParameter("sessionId", sessionId);
+    query.setParameter("seqNo", seqNo);
+    query.setParameter("senderRole", senderRole);
+    query.setParameter("createdAt", at("2026-05-27T09:01:00+09:00"));
+    query.executeUpdate();
+  }
+
+  private Long nextId(String table) {
+    return ((Number)
+            entityManager
+                .createNativeQuery("select coalesce(max(id), 0) + 1 from " + table)
+                .getSingleResult())
+        .longValue();
+  }
+
+  private void update(String sql, Map<String, Object> params) {
+    var query = entityManager.createNativeQuery(sql);
+    params.forEach(query::setParameter);
+    query.executeUpdate();
+  }
+
+  private OffsetDateTime at(String value) {
+    return OffsetDateTime.parse(value);
+  }
+}

--- a/frontend/src/features/consultation/api/consultationApi.test.ts
+++ b/frontend/src/features/consultation/api/consultationApi.test.ts
@@ -652,4 +652,76 @@ describe("consultationApi", () => {
     );
     expect(result).toEqual(stubMetrics);
   });
+
+  it("getWorkflowRankings가 워크스페이스 대시보드 랭킹 endpoint를 호출한다", async () => {
+    const stubRanking = {
+      workspaceId: 2,
+      periodStart: "2026-05-21T00:00:00+09:00",
+      periodEnd: "2026-05-28T00:00:00+09:00",
+      totalConsultationCount: 20,
+      topRankings: [],
+      rankings: [
+        {
+          rank: 1,
+          workflowDefinitionId: 10,
+          domainPackId: 3,
+          domainPackVersionId: 4,
+          workflowCode: "refund_flow",
+          workflowName: "환불 처리",
+          executionCount: 8,
+          shareRate: 40,
+          completedCount: 6,
+          failedCount: 1,
+          runningCount: 1,
+          completionRate: 75,
+          failureRate: 12.5,
+          averageHandlingSeconds: 180,
+          humanInterventionRate: 25,
+          changeRate: 33.3,
+          surging: true,
+          detailPath: "/workspaces/2/domain-packs/3/workflows/10?versionId=4",
+        },
+      ],
+    };
+    mockedCustomFetch.mockResolvedValue({
+      data: stubRanking,
+      status: 200,
+      headers: new Headers(),
+    });
+
+    const result = await consultationApi.getWorkflowRankings(2);
+
+    expect(mockedCustomFetch).toHaveBeenCalledWith(
+      "/api/v1/workspaces/2/dashboard/workflow-rankings",
+      { method: "GET" },
+    );
+    expect(result).toEqual(stubRanking);
+  });
+
+  it("getWorkflowRankings가 기간 파라미터를 쿼리스트링으로 전달한다", async () => {
+    const stubRanking = {
+      workspaceId: 2,
+      periodStart: "2026-05-21T00:00:00+09:00",
+      periodEnd: "2026-05-28T00:00:00+09:00",
+      totalConsultationCount: 0,
+      topRankings: [],
+      rankings: [],
+    };
+    mockedCustomFetch.mockResolvedValue({
+      data: stubRanking,
+      status: 200,
+      headers: new Headers(),
+    });
+
+    const result = await consultationApi.getWorkflowRankings(2, {
+      from: "2026-05-21",
+      to: "2026-05-27",
+    });
+
+    expect(mockedCustomFetch).toHaveBeenCalledWith(
+      "/api/v1/workspaces/2/dashboard/workflow-rankings?from=2026-05-21&to=2026-05-27",
+      { method: "GET" },
+    );
+    expect(result).toEqual(stubRanking);
+  });
 });

--- a/frontend/src/features/consultation/api/consultationApi.ts
+++ b/frontend/src/features/consultation/api/consultationApi.ts
@@ -9,9 +9,9 @@ import { requireApiData, selectApiData } from "@/shared/api";
 import type { ChatMessageResponse, ChatSessionResponse } from "@/shared/api/generated/zod";
 
 // OpenAPI 미생성 endpoint: workspace-scoped queue/metrics/sessions list,
-// assign/release, draft-response는 수동 호출로 유지한다.
+// dashboard workflow rankings, assign/release, draft-response는 수동 호출로 유지한다.
 
-export type ChatSession = Omit<ChatSessionResponse, 'responseMode'> & {
+export type ChatSession = Omit<ChatSessionResponse, "responseMode"> & {
   assignedCounselorId?: number | null;
   responseMode?: ConsultationResponseMode | null;
 };
@@ -111,6 +111,36 @@ export interface ConsultationCoverageTrendPoint {
 export interface ConsultationMetricsParams {
   from?: string;
   to?: string;
+}
+
+export interface WorkspaceWorkflowRanking {
+  rank: number;
+  workflowDefinitionId: number | null;
+  domainPackId: number | null;
+  domainPackVersionId: number | null;
+  workflowCode: string | null;
+  workflowName: string;
+  executionCount: number;
+  shareRate: number;
+  completedCount: number;
+  failedCount: number;
+  runningCount: number;
+  completionRate: number;
+  failureRate: number;
+  averageHandlingSeconds: number | null;
+  humanInterventionRate: number;
+  changeRate: number | null;
+  surging: boolean;
+  detailPath: string | null;
+}
+
+export interface WorkspaceWorkflowRankingResponse {
+  workspaceId: number;
+  periodStart: string;
+  periodEnd: string;
+  totalConsultationCount: number;
+  rankings: WorkspaceWorkflowRanking[];
+  topRankings: WorkspaceWorkflowRanking[];
 }
 
 export interface DraftResponse {
@@ -351,11 +381,28 @@ export const consultationApi = {
     if (params.to) searchParams.set("to", params.to);
     const query = searchParams.toString();
     const url = `/api/v1/workspaces/${workspaceId}/consultation/metrics${query ? `?${query}` : ""}`;
-    const response = await customFetch<ConsultationMetrics | { data?: ConsultationMetrics }>(
-      url,
-      { method: "GET" },
-    );
+    const response = await customFetch<ConsultationMetrics | { data?: ConsultationMetrics }>(url, {
+      method: "GET",
+    });
     return requireApiData<ConsultationMetrics>(response, "상담 지표 응답을 확인할 수 없습니다.");
+  },
+
+  getWorkflowRankings: async (
+    workspaceId: number,
+    params: ConsultationMetricsParams = {},
+  ): Promise<WorkspaceWorkflowRankingResponse> => {
+    const searchParams = new URLSearchParams();
+    if (params.from) searchParams.set("from", params.from);
+    if (params.to) searchParams.set("to", params.to);
+    const query = searchParams.toString();
+    const url = `/api/v1/workspaces/${workspaceId}/dashboard/workflow-rankings${query ? `?${query}` : ""}`;
+    const response = await customFetch<
+      WorkspaceWorkflowRankingResponse | { data?: WorkspaceWorkflowRankingResponse }
+    >(url, { method: "GET" });
+    return requireApiData<WorkspaceWorkflowRankingResponse>(
+      response,
+      "워크플로우 랭킹 응답을 확인할 수 없습니다.",
+    );
   },
 
   generateDraftResponse: async (sessionId: number): Promise<DraftResponse> => {

--- a/frontend/src/pages/workspace/ui/WorkspaceDashboardPage.test.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceDashboardPage.test.tsx
@@ -8,6 +8,7 @@ import { DashboardStatePanel, WorkspaceDashboardPage } from "./WorkspaceDashboar
 
 const setCrumbs = vi.fn();
 const mockedGetMetrics = vi.mocked(consultationApi.getMetrics);
+const mockedGetWorkflowRankings = vi.mocked(consultationApi.getWorkflowRankings);
 
 const metricsResponse = {
   workspaceId: 1,
@@ -64,6 +65,77 @@ const metricsResponse = {
   humanHandledTodayCount: 26,
 };
 
+const workflowRankingResponse = {
+  workspaceId: 1,
+  periodStart: "2026-05-28T00:00:00+09:00",
+  periodEnd: "2026-06-04T00:00:00+09:00",
+  totalConsultationCount: 120,
+  topRankings: [
+    {
+      rank: 1,
+      workflowDefinitionId: 100,
+      domainPackId: 11,
+      domainPackVersionId: 22,
+      workflowCode: "refund_flow",
+      workflowName: "환불 처리",
+      executionCount: 48,
+      shareRate: 40,
+      completedCount: 42,
+      failedCount: 3,
+      runningCount: 3,
+      completionRate: 87.5,
+      failureRate: 6.3,
+      averageHandlingSeconds: 180,
+      humanInterventionRate: 25,
+      changeRate: 33.3,
+      surging: true,
+      detailPath: "/workspaces/1/domain-packs/11/workflows/100?versionId=22",
+    },
+  ],
+  rankings: [
+    {
+      rank: 1,
+      workflowDefinitionId: 100,
+      domainPackId: 11,
+      domainPackVersionId: 22,
+      workflowCode: "refund_flow",
+      workflowName: "환불 처리",
+      executionCount: 48,
+      shareRate: 40,
+      completedCount: 42,
+      failedCount: 3,
+      runningCount: 3,
+      completionRate: 87.5,
+      failureRate: 6.3,
+      averageHandlingSeconds: 180,
+      humanInterventionRate: 25,
+      changeRate: 33.3,
+      surging: true,
+      detailPath: "/workspaces/1/domain-packs/11/workflows/100?versionId=22",
+    },
+    {
+      rank: 2,
+      workflowDefinitionId: null,
+      domainPackId: null,
+      domainPackVersionId: null,
+      workflowCode: null,
+      workflowName: "미확인 워크플로우",
+      executionCount: 12,
+      shareRate: 10,
+      completedCount: 8,
+      failedCount: 1,
+      runningCount: 3,
+      completionRate: 66.7,
+      failureRate: 8.3,
+      averageHandlingSeconds: null,
+      humanInterventionRate: 50,
+      changeRate: null,
+      surging: false,
+      detailPath: null,
+    },
+  ],
+};
+
 function renderPage(path = "/workspaces/1/dashboard") {
   setCrumbs.mockClear();
   render(
@@ -87,6 +159,7 @@ vi.mock("react-router-dom", async () => {
 vi.mock("@/features/consultation/api/consultationApi", () => ({
   consultationApi: {
     getMetrics: vi.fn(),
+    getWorkflowRankings: vi.fn(),
   },
 }));
 
@@ -105,16 +178,19 @@ vi.mock("@/features/workspace-dashboard-health", () => ({
 describe("WorkspaceDashboardPage", () => {
   beforeEach(() => {
     mockedGetMetrics.mockReset();
+    mockedGetWorkflowRankings.mockReset();
     mockedGetMetrics.mockResolvedValue(metricsResponse);
+    mockedGetWorkflowRankings.mockResolvedValue(workflowRankingResponse);
   });
 
   it("잘못된 workspaceId면 /workspaces로 리다이렉트한다", () => {
     renderPage("/workspaces/abc/dashboard");
     expect(screen.getByTestId("workspace-root")).toBeInTheDocument();
     expect(mockedGetMetrics).not.toHaveBeenCalled();
+    expect(mockedGetWorkflowRankings).not.toHaveBeenCalled();
   });
 
-  it("공통 필터와 상담 처리 KPI, 운영 지식팩 건강도 영역을 표시한다", async () => {
+  it("공통 필터와 상담 처리 KPI, 운영 지식팩 건강도, 핫패스 랭킹을 표시한다", async () => {
     renderPage();
 
     expect(screen.getByRole("heading", { name: "대시보드" })).toBeInTheDocument();
@@ -133,7 +209,18 @@ describe("WorkspaceDashboardPage", () => {
     expect(screen.getByText("72.9%")).toBeInTheDocument();
     expect(screen.getByText("2026-05-29")).toBeInTheDocument();
     expect(screen.getByTestId("knowledge-health-panel")).toHaveTextContent("workspace 1 health");
+    expect(await screen.findByText("핫패스 워크플로우 랭킹")).toBeInTheDocument();
+    expect(screen.getByTestId("hotpath-top-1")).toHaveTextContent("환불 처리");
+    expect(screen.getByTestId("hotpath-row-1")).toHaveTextContent("급증");
+    expect(screen.getAllByRole("link", { name: /환불 처리/ })[0]).toHaveAttribute(
+      "href",
+      "/workspaces/1/domain-packs/11/workflows/100?versionId=22",
+    );
+    expect(screen.getByTestId("hotpath-row-2")).toHaveTextContent("상세 준비 중");
     await waitFor(() => expect(mockedGetMetrics).toHaveBeenCalledWith(1, expect.any(Object)));
+    await waitFor(() =>
+      expect(mockedGetWorkflowRankings).toHaveBeenCalledWith(1, expect.any(Object)),
+    );
   });
 
   it("기간과 공통 필터 변경을 요약 상태와 API 요청에 반영한다", async () => {
@@ -157,6 +244,12 @@ describe("WorkspaceDashboardPage", () => {
     expect(summary).toHaveTextContent("상담원 연결");
     await waitFor(() =>
       expect(mockedGetMetrics).toHaveBeenLastCalledWith(1, {
+        from: "2026-06-01",
+        to: "2026-06-03",
+      }),
+    );
+    await waitFor(() =>
+      expect(mockedGetWorkflowRankings).toHaveBeenLastCalledWith(1, {
         from: "2026-06-01",
         to: "2026-06-03",
       }),
@@ -201,6 +294,11 @@ describe("WorkspaceDashboardPage", () => {
         trend: [],
       },
     });
+    mockedGetWorkflowRankings.mockResolvedValueOnce({
+      ...workflowRankingResponse,
+      topRankings: [],
+      rankings: [],
+    });
 
     renderPage();
 
@@ -217,6 +315,16 @@ describe("WorkspaceDashboardPage", () => {
       "/workspaces/1/domain-packs",
     );
     expect(screen.getByTestId("dashboard-simulation-cta")).toHaveAttribute("href", "/demo/chat/1");
+  });
+
+  it("상담 KPI가 실패해도 워크플로우 랭킹은 같은 화면에 남긴다", async () => {
+    mockedGetMetrics.mockRejectedValueOnce(new Error("metrics failed"));
+
+    renderPage();
+
+    expect(await screen.findByText("핫패스 워크플로우 랭킹")).toBeInTheDocument();
+    expect(screen.getByTestId("hotpath-row-1")).toHaveTextContent("환불 처리");
+    expect(screen.queryByTestId("dashboard-error")).not.toBeInTheDocument();
   });
 
   it("loading, error, partial 상태 패널이 같은 shell 영역에서 렌더링된다", () => {

--- a/frontend/src/pages/workspace/ui/WorkspaceDashboardPage.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceDashboardPage.tsx
@@ -13,6 +13,8 @@ import { consultationApi } from "@/features/consultation/api/consultationApi";
 import type {
   ConsultationCoverageMetrics,
   ConsultationMetrics,
+  WorkspaceWorkflowRanking,
+  WorkspaceWorkflowRankingResponse,
 } from "@/features/consultation/api/consultationApi";
 import { KnowledgePackHealthPanel } from "@/features/workspace-dashboard-health";
 import type { ShellContext } from "@/shared/ui/ostone/chrome";
@@ -198,6 +200,10 @@ function hasMetricData(metrics: ConsultationMetrics | null): boolean {
   );
 }
 
+function hasWorkflowRankingData(rankings: WorkspaceWorkflowRankingResponse | null): boolean {
+  return (rankings?.rankings?.length ?? 0) > 0;
+}
+
 function DashboardMetricCard({
   label,
   value,
@@ -306,6 +312,57 @@ function CoverageMetricCard({
   );
 }
 
+function TopWorkflowCard({
+  item,
+  state,
+}: {
+  item: WorkspaceWorkflowRanking;
+  state: DashboardDataState;
+}) {
+  const body = (
+    <>
+      <div className={styles.hotpathCardHeader}>
+        <span className={styles.rankBadge}>#{item.rank}</span>
+        {item.surging ? <span className={styles.surgeBadge}>급증</span> : null}
+      </div>
+      <h3>{item.workflowName}</h3>
+      <dl>
+        <div>
+          <dt>실행</dt>
+          <dd>{formatCount(item.executionCount, state)}</dd>
+        </div>
+        <div>
+          <dt>완료율</dt>
+          <dd>{formatPercent(item.completionRate, state)}</dd>
+        </div>
+        <div>
+          <dt>개입률</dt>
+          <dd>{formatPercent(item.humanInterventionRate, state)}</dd>
+        </div>
+      </dl>
+    </>
+  );
+
+  if (item.detailPath) {
+    return (
+      <Link
+        to={item.detailPath}
+        className={styles.hotpathCard}
+        data-testid={`hotpath-top-${item.rank}`}
+      >
+        {body}
+      </Link>
+    );
+  }
+
+  return (
+    <article className={styles.hotpathCard} data-testid={`hotpath-top-${item.rank}`}>
+      {body}
+      <span className={styles.unavailableText}>상세 준비 중</span>
+    </article>
+  );
+}
+
 function AutomationCoveragePanel({
   coverage,
   state,
@@ -317,7 +374,13 @@ function AutomationCoveragePanel({
   const measurementStatus =
     state === "loading" ? "LOADING" : coverage?.measurementStatus ?? "EMPTY";
   const measurementLabel =
-    state === "loading" ? "계산 중" : needsInstrumentation ? "계측 필요" : coverage ? "계측 확인" : "--";
+    state === "loading"
+      ? "계산 중"
+      : needsInstrumentation
+        ? "계측 필요"
+        : coverage
+          ? "계측 확인"
+          : "--";
   const trend = coverage?.trend ?? [];
   const maxTrendTotal = Math.max(1, ...trend.map((point) => point.totalConsultationCount));
 
@@ -325,7 +388,7 @@ function AutomationCoveragePanel({
     <section className={styles.coveragePanel} aria-labelledby="automation-coverage-title">
       <div className={styles.coverageHeader}>
         <div>
-        <span className={styles.panelEyebrow}>Automation Coverage</span>
+          <span className={styles.panelEyebrow}>Automation Coverage</span>
           <h2 id="automation-coverage-title" className={styles.sectionTitle}>
             자동화 커버리지
           </h2>
@@ -400,6 +463,143 @@ function AutomationCoveragePanel({
           <p className={styles.trendEmpty}>기간별 커버리지 추이가 없습니다.</p>
         )}
       </div>
+    </section>
+  );
+}
+
+function WorkflowRankingTable({
+  rankings,
+  state,
+}: {
+  rankings: WorkspaceWorkflowRanking[];
+  state: DashboardDataState;
+}) {
+  return (
+    <div className={styles.rankingTableWrap}>
+      <table className={styles.rankingTable}>
+        <thead>
+          <tr>
+            <th scope="col">Rank</th>
+            <th scope="col">Workflow</th>
+            <th scope="col">실행</th>
+            <th scope="col">비중</th>
+            <th scope="col">완료율</th>
+            <th scope="col">실패율</th>
+            <th scope="col">평균 처리</th>
+            <th scope="col">상담사 개입</th>
+            <th scope="col">증가율</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rankings.map((item) => {
+            const workflowName = (
+              <span className={styles.workflowNameCell}>
+                <strong>{item.workflowName}</strong>
+                <span>{item.workflowCode ?? "코드 없음"}</span>
+              </span>
+            );
+            return (
+              <tr
+                key={`${item.rank}-${item.workflowDefinitionId ?? item.workflowCode ?? "unknown"}`}
+                className={item.surging ? styles.surgingRow : undefined}
+                data-testid={`hotpath-row-${item.rank}`}
+              >
+                <td>#{item.rank}</td>
+                <td>
+                  {item.detailPath ? (
+                    <Link to={item.detailPath} className={styles.workflowDetailLink}>
+                      {workflowName}
+                    </Link>
+                  ) : (
+                    <span className={styles.workflowDetailDisabled}>
+                      {workflowName}
+                      <em>상세 준비 중</em>
+                    </span>
+                  )}
+                </td>
+                <td>{formatCount(item.executionCount, state)}</td>
+                <td>{formatPercent(item.shareRate, state)}</td>
+                <td>{formatPercent(item.completionRate, state)}</td>
+                <td>{formatPercent(item.failureRate, state)}</td>
+                <td>{formatDuration(item.averageHandlingSeconds, state)}</td>
+                <td>{formatPercent(item.humanInterventionRate, state)}</td>
+                <td>
+                  <span className={styles.changeCell}>
+                    {formatDelta(item.changeRate, state)}
+                    {item.surging ? <span className={styles.surgeBadge}>급증</span> : null}
+                  </span>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function HotpathWorkflowRankingPanel({
+  rankings,
+  state,
+  error,
+}: {
+  rankings: WorkspaceWorkflowRankingResponse | null;
+  state: DashboardDataState;
+  error: string | null;
+}) {
+  const topRankings = rankings?.topRankings ?? [];
+  const allRankings = rankings?.rankings ?? [];
+
+  return (
+    <section className={styles.hotpathPanel} aria-labelledby="hotpath-ranking-title">
+      <div className={styles.panelHeader}>
+        <div>
+          <span className={styles.panelEyebrow}>HOTPATH</span>
+          <h2 id="hotpath-ranking-title" className={styles.sectionTitle}>
+            핫패스 워크플로우 랭킹
+          </h2>
+          <p className={styles.sectionDescription}>
+            선택 기간의 실행량과 전 기간 대비 증가율을 기준으로 우선 개선 대상을 확인합니다.
+          </p>
+        </div>
+        <span className={styles.totalBadge}>
+          전체 상담 {formatCount(rankings?.totalConsultationCount, state)}
+        </span>
+      </div>
+
+      {error ? (
+        <div className={styles.hotpathState} data-testid="hotpath-error">
+          <ErrorState message={error} />
+        </div>
+      ) : null}
+
+      {!error && state === "loading" ? (
+        <div className={styles.hotpathState} data-testid="hotpath-loading">
+          <LoadingSpinner />
+          <p className={styles.stateText}>워크플로우 랭킹을 불러오는 중입니다.</p>
+        </div>
+      ) : null}
+
+      {!error && state !== "loading" && allRankings.length === 0 ? (
+        <div className={styles.hotpathState} data-testid="hotpath-empty">
+          <p className={styles.stateText}>선택 기간에 집계할 워크플로우 실행이 없습니다.</p>
+        </div>
+      ) : null}
+
+      {!error && allRankings.length > 0 ? (
+        <>
+          <div className={styles.hotpathTopGrid} aria-label="워크플로우 TOP 5">
+            {topRankings.map((item) => (
+              <TopWorkflowCard
+                key={`${item.rank}-${item.workflowName}`}
+                item={item}
+                state={state}
+              />
+            ))}
+          </div>
+          <WorkflowRankingTable rankings={allRankings} state={state} />
+        </>
+      ) : null}
     </section>
   );
 }
@@ -610,13 +810,38 @@ export function WorkspaceDashboardPage() {
   const [metrics, setMetrics] = useState<ConsultationMetrics | null>(null);
   const [isMetricsLoading, setIsMetricsLoading] = useState(false);
   const [metricsError, setMetricsError] = useState<string | null>(null);
+  const [workflowRankings, setWorkflowRankings] = useState<WorkspaceWorkflowRankingResponse | null>(
+    null,
+  );
+  const [isWorkflowRankingsLoading, setIsWorkflowRankingsLoading] = useState(false);
+  const [workflowRankingsError, setWorkflowRankingsError] = useState<string | null>(null);
   const metricDateRange = useMemo(() => buildMetricDateRange(filters), [filters]);
-  const dataState = useMemo<DashboardDataState>(() => {
+  const metricsState = useMemo<DashboardDataState>(() => {
     if (isMetricsLoading) return "loading";
     if (metricsError) return "error";
     if (hasMetricData(metrics)) return "partial";
     return "empty";
   }, [isMetricsLoading, metricsError, metrics]);
+  const workflowRankingState = useMemo<DashboardDataState>(() => {
+    if (isWorkflowRankingsLoading) return "loading";
+    if (workflowRankingsError) return "error";
+    if (hasWorkflowRankingData(workflowRankings)) return "partial";
+    return "empty";
+  }, [isWorkflowRankingsLoading, workflowRankingsError, workflowRankings]);
+  const dataState = useMemo<DashboardDataState>(() => {
+    const hasAnyData = hasMetricData(metrics) || hasWorkflowRankingData(workflowRankings);
+    if ((isMetricsLoading || isWorkflowRankingsLoading) && !hasAnyData) return "loading";
+    if (hasAnyData) return "partial";
+    if (metricsError && workflowRankingsError) return "error";
+    return "empty";
+  }, [
+    isMetricsLoading,
+    isWorkflowRankingsLoading,
+    metrics,
+    workflowRankings,
+    metricsError,
+    workflowRankingsError,
+  ]);
 
   useEffect(() => {
     setCrumbs(["대시보드"]);
@@ -667,6 +892,50 @@ export function WorkspaceDashboardPage() {
     };
   }, [parsedWorkspaceId, metricDateRange]);
 
+  useEffect(() => {
+    let ignore = false;
+
+    async function loadWorkflowRankings() {
+      if (parsedWorkspaceId === null) {
+        setWorkflowRankings(null);
+        setWorkflowRankingsError(null);
+        setIsWorkflowRankingsLoading(false);
+        return;
+      }
+
+      if (!metricDateRange.from || !metricDateRange.to) {
+        setWorkflowRankings(null);
+        setWorkflowRankingsError(null);
+        setIsWorkflowRankingsLoading(false);
+        return;
+      }
+
+      setIsWorkflowRankingsLoading(true);
+      setWorkflowRankingsError(null);
+      try {
+        const data = await consultationApi.getWorkflowRankings(parsedWorkspaceId, metricDateRange);
+        if (ignore) return;
+        setWorkflowRankings(data);
+      } catch (error) {
+        if (ignore) return;
+        console.error("Failed to load workflow rankings:", error);
+        setWorkflowRankings(null);
+        setWorkflowRankingsError("워크플로우 랭킹을 불러오지 못했습니다.");
+        toast.error("워크플로우 랭킹을 불러오지 못했습니다.");
+      } finally {
+        if (!ignore) {
+          setIsWorkflowRankingsLoading(false);
+        }
+      }
+    }
+
+    void loadWorkflowRankings();
+
+    return () => {
+      ignore = true;
+    };
+  }, [parsedWorkspaceId, metricDateRange]);
+
   if (parsedWorkspaceId === null) {
     return <Navigate to="/workspaces" replace />;
   }
@@ -691,9 +960,14 @@ export function WorkspaceDashboardPage() {
 
       <DashboardFilters filters={filters} onChange={setFilters} />
       <FilterSummary filters={filters} />
-      <DashboardMetricsGrid metrics={metrics} state={dataState} />
-      <AutomationCoveragePanel coverage={metrics?.coverage} state={dataState} />
+      <DashboardMetricsGrid metrics={metrics} state={metricsState} />
+      <AutomationCoveragePanel coverage={metrics?.coverage} state={metricsState} />
       <KnowledgePackHealthPanel workspaceId={parsedWorkspaceId} />
+      <HotpathWorkflowRankingPanel
+        rankings={workflowRankings}
+        state={workflowRankingState}
+        error={workflowRankingsError}
+      />
       <DashboardStatePanel state={dataState} workspaceId={parsedWorkspaceId} />
 
       <section className={styles.slotGrid} aria-label="대시보드 카드와 차트 배치 영역">

--- a/frontend/src/pages/workspace/ui/workspace-dashboard-page.module.css
+++ b/frontend/src/pages/workspace/ui/workspace-dashboard-page.module.css
@@ -58,6 +58,13 @@
   gap: var(--s-3);
 }
 
+.panelHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--s-4);
+}
+
 .sectionTitle {
   margin: 0;
   font-family: var(--sans);
@@ -223,7 +230,8 @@
   line-height: 1.55;
 }
 
-.coveragePanel {
+.coveragePanel,
+.hotpathPanel {
   display: flex;
   flex-direction: column;
   gap: var(--s-4);
@@ -253,7 +261,41 @@
   white-space: nowrap;
 }
 
+.totalBadge,
+.surgeBadge,
+.rankBadge,
+.unavailableText {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  min-height: 26px;
+  border: 1px solid var(--line);
+  border-radius: var(--r-pill);
+  padding: 0 var(--s-3);
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0;
+  white-space: nowrap;
+}
+
 .measurementBadge[data-status="NEEDS_INSTRUMENTATION"] {
+  color: var(--ink);
+  background: var(--paper);
+}
+
+.totalBadge {
+  color: var(--ink-2);
+  background: var(--paper-2);
+}
+
+.surgeBadge {
+  border-color: var(--ink);
+  color: var(--paper);
+  background: var(--ink);
+}
+
+.rankBadge {
   color: var(--ink);
   background: var(--paper);
 }
@@ -343,6 +385,185 @@
   margin: 0;
   color: var(--ink-2);
   font-size: 13px;
+}
+
+.unavailableText {
+  color: var(--ink-3);
+  background: var(--paper-2);
+}
+
+.hotpathState {
+  min-height: 150px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--s-3);
+  border: 1px dashed var(--line);
+  border-radius: var(--r-3);
+  background: var(--paper-2);
+  text-align: center;
+}
+
+.hotpathTopGrid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: var(--s-3);
+}
+
+.hotpathCard {
+  min-width: 0;
+  min-height: 190px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: var(--s-3);
+  border: 1px solid var(--line);
+  border-radius: var(--r-3);
+  padding: var(--s-4);
+  background: var(--paper-2);
+  color: inherit;
+  text-decoration: none;
+  transition:
+    border-color 160ms ease,
+    background 160ms ease;
+}
+
+.hotpathCard:hover,
+.hotpathCard:focus-visible {
+  border-color: var(--ink);
+  background: var(--paper);
+}
+
+.hotpathCardHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--s-2);
+}
+
+.hotpathCard h3 {
+  margin: 0;
+  color: var(--ink);
+  font-size: 16px;
+  font-weight: 540;
+  line-height: 1.35;
+  letter-spacing: 0;
+}
+
+.hotpathCard dl {
+  display: grid;
+  gap: var(--s-2);
+  margin: 0;
+}
+
+.hotpathCard dl div {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--s-2);
+}
+
+.hotpathCard dt {
+  color: var(--ink-3);
+  font-size: 12px;
+  font-weight: 450;
+}
+
+.hotpathCard dd {
+  margin: 0;
+  color: var(--ink);
+  font-size: 13px;
+  font-weight: 540;
+}
+
+.rankingTableWrap {
+  overflow-x: auto;
+  border: 1px solid var(--line);
+  border-radius: var(--r-3);
+}
+
+.rankingTable {
+  width: 100%;
+  min-width: 940px;
+  border-collapse: collapse;
+  background: var(--paper);
+}
+
+.rankingTable th,
+.rankingTable td {
+  padding: var(--s-3);
+  border-bottom: 1px solid var(--line-2);
+  color: var(--ink-2);
+  font-size: 13px;
+  line-height: 1.4;
+  text-align: left;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+
+.rankingTable th {
+  color: var(--ink-3);
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0;
+  text-transform: uppercase;
+  background: var(--paper-2);
+}
+
+.rankingTable tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+.surgingRow td {
+  background: var(--paper-2);
+  color: var(--ink);
+}
+
+.workflowDetailLink,
+.workflowDetailDisabled,
+.workflowNameCell,
+.changeCell {
+  display: inline-flex;
+  min-width: 0;
+}
+
+.changeCell {
+  align-items: center;
+  gap: var(--s-2);
+}
+
+.workflowDetailLink,
+.workflowDetailDisabled {
+  align-items: center;
+  gap: var(--s-2);
+  color: inherit;
+  text-decoration: none;
+}
+
+.workflowDetailLink:hover,
+.workflowDetailLink:focus-visible {
+  color: var(--ink);
+  text-decoration: underline;
+}
+
+.workflowNameCell {
+  flex-direction: column;
+  gap: 2px;
+}
+
+.workflowNameCell strong {
+  color: var(--ink);
+  font-size: 13px;
+  font-weight: 540;
+}
+
+.workflowNameCell span,
+.workflowDetailDisabled em {
+  color: var(--ink-3);
+  font-size: 12px;
+  font-style: normal;
 }
 
 .statePanel,
@@ -472,7 +693,8 @@
   .filterSummary,
   .metricGrid,
   .coverageGrid,
-  .slotGrid {
+  .slotGrid,
+  .hotpathTopGrid {
     grid-template-columns: 1fr;
   }
 


### PR DESCRIPTION
Closes #519

## 변경 사항

- 선택 기간의 운영 workflow 실행량을 집계하는 `/api/v1/workspaces/{workspaceId}/dashboard/workflow-rankings` API를 제공합니다.
- workflow별 실행 수, 전체 상담 대비 비중, 완료/실패/진행 중 수, 평균 처리 시간, 상담사 개입률, 전 기간 대비 증가율과 급증 여부를 계산합니다.
- 데모/시뮬레이션 상담은 랭킹에서 제외하고, workflow 정의 join이 누락된 과거 실행도 fallback 이름과 상세 불가 상태로 유지합니다.
- 워크스페이스 대시보드에 핫패스 TOP 5 카드와 전체 랭킹 테이블을 추가하고, 가능한 row는 workflow 상세 링크로 이동합니다.
- 이슈 519 스펙을 `.agent/specs/519.md`에 정리했습니다.

## 검증

- `git diff --check`
- `cd frontend && pnpm test -- App.test.tsx WorkspaceDashboardPage.test.tsx consultationApi.test.ts`
- `cd frontend && pnpm exec eslint src/app/App.test.tsx src/features/consultation/api/consultationApi.ts src/features/consultation/api/consultationApi.test.ts src/pages/workspace/ui/WorkspaceDashboardPage.tsx src/pages/workspace/ui/WorkspaceDashboardPage.test.tsx`
- `cd frontend && pnpm build`
- `docker run --rm -v "$PWD":/workspace -v "$HOME/.gradle-cache-ostone-519":/home/gradle/.gradle -w /workspace/backend gradle:9.4.0-jdk21 ./gradlew spotlessCheck test --tests 'com.init.workflowruntime.application.WorkspaceWorkflowRankingServiceTest' --tests 'com.init.workflowruntime.infrastructure.persistence.JpaWorkflowRankingRepositoryTest'`
- `docker run --rm -v "$PWD":/workspace -v "$HOME/.gradle-cache-ostone-519":/home/gradle/.gradle -w /workspace/backend gradle:9.4.0-jdk21 ./gradlew build -x checkstyleMain -x checkstyleTest`

## 참고

- 로컬 호스트에 Java 21 toolchain이 없어 backend 검증은 `gradle:9.4.0-jdk21` Docker 컨테이너로 실행했습니다.
- `cd frontend && pnpm lint`는 기존 unrelated lint 오류 58개로 실패합니다. 이번 변경 파일 대상 eslint는 통과했습니다.