### PR TITLE
feat(simulation): 시뮬레이션 피드백 수집 제공

### DIFF
--- a/.agent/specs/526.md
+++ b/.agent/specs/526.md
@@ -1,0 +1,216 @@
+# Backend DDD Spec: simulation feedback collection
+
+> Issue: #526 `feat(simulation): 시뮬레이션 피드백 수집`
+> Bounded Context: `workflow-runtime`
+> Frontend Surface: `frontend/src/pages/workspace/ui/WorkspaceSimulationPage.tsx`
+> Branch: `feature/526-simulation-feedback`
+
+---
+
+## Goal
+
+상담사가 시뮬레이션 session 또는 turn 단위로 현장 판단을 구조화해 남기고, workspace 기준으로 상태별 피드백을 조회할 수 있게 한다.
+
+---
+
+## Problem
+
+현재 simulation 기능은 `runtime.chat_session`과 `runtime.chat_message`를 통해 운영 로그와 분리된 `SIMULATION` 채널 대화를 만들 수 있지만, 시뮬레이션 중 발견한 잘못된 intent 매칭, slot 질문 누락, 부적절한 응답 문구, policy/risk/workflow 오류를 별도 운영 지식 입력으로 저장할 수 없다. 후속 개선 후보 생성 이슈에서 참조하려면 피드백마다 안정적인 식별자와 session/turn 연결 정보가 필요하다.
+
+---
+
+## Scope
+
+- simulation session 단위 피드백 작성
+- simulation turn(`chat_message`) 단위 피드백 작성
+- 피드백 유형, 설명, 기대 응답/행동, 심각도 저장
+- 피드백 상태 `OPEN`, `CANDIDATE_CREATED`, `RESOLVED`, `DISMISSED` 관리
+- session 상세 응답에서 피드백이 있는 turn 식별 가능
+- workspace별 feedback 목록을 상태별로 조회
+- workspace membership 기반 조회/작성 권한 검증
+
+---
+
+## Non-Goals
+
+- 첨부파일/이미지 피드백
+- 자동 개선 후보 생성
+- review draft 반영
+- golden case 등록
+- 운영 상담 로그(`corpus.*`, non-simulation `runtime.chat_session`)에 피드백을 섞는 변경
+
+---
+
+## Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    actor op as Counselor
+    participant page as Simulation Page
+    participant ctrl as SimulationController
+    participant svc as SimulationService
+    participant sessionRepo as ChatSessionRepository
+    participant msgRepo as ChatMessageRepository
+    participant feedbackRepo as SimulationFeedbackRepository
+    participant db as PostgreSQL
+
+    op ->> page: turn/session feedback submit
+    page ->> ctrl: POST /simulation/sessions/{sessionId}/feedback
+    ctrl ->> svc: createFeedback(command)
+    svc ->> svc: validate workspace membership
+    svc ->> sessionRepo: find simulation session
+    sessionRepo ->> db: SELECT runtime.chat_session
+    svc ->> msgRepo: find turn when messageId exists
+    msgRepo ->> db: SELECT runtime.chat_message
+    svc ->> feedbackRepo: save(feedback)
+    feedbackRepo ->> db: INSERT runtime.simulation_feedback
+    svc ->> feedbackRepo: find by session
+    svc ->> ctrl: refreshed SimulationSessionDetailResponse
+    ctrl ->> page: detail with feedback markers
+```
+
+---
+
+## Affected Paths
+
+| Path | Change |
+| --- | --- |
+| `backend/src/main/resources/db/changelog/db.changelog-master.sql` | `runtime.simulation_feedback` table and indexes |
+| `backend/src/main/java/com/init/workflowruntime/domain/` | feedback entity, enums, repository port |
+| `backend/src/main/java/com/init/workflowruntime/infrastructure/persistence/` | Spring Data repository adapter |
+| `backend/src/main/java/com/init/workflowruntime/application/SimulationService.java` | create/list feedback use cases and detail feedback markers |
+| `backend/src/main/java/com/init/workflowruntime/application/dto/` | feedback response/page DTOs and detail extension |
+| `backend/src/main/java/com/init/workflowruntime/presentation/SimulationController.java` | session feedback create endpoint |
+| `backend/src/main/java/com/init/workflowruntime/presentation/SimulationFeedbackController.java` | workspace feedback list endpoint |
+| `backend/src/main/java/com/init/workflowruntime/presentation/dto/` | feedback request DTO |
+| `frontend/src/features/simulation/api/simulationApi.ts` | OpenAPI 미생성 feedback endpoint wrapper |
+| `frontend/src/pages/workspace/ui/WorkspaceSimulationPage.tsx` | feedback form, turn marker, workspace feedback list |
+| `frontend/src/pages/workspace/ui/simulation/workspace-simulation-page.module.css` | feedback UI styling |
+
+---
+
+## Storage
+
+`runtime.simulation_feedback` stores feedback separately from operational 상담 로그.
+
+| Column | Notes |
+| --- | --- |
+| `id` | stable feedback identifier for follow-up candidate generation |
+| `workspace_id` | workspace boundary and list filter |
+| `chat_session_id` | required simulation session link |
+| `chat_message_id` | optional turn link; null means session-level feedback |
+| `feedback_type` | enum string: `INTENT_MISMATCH`, `MISSING_SLOT_QUESTION`, `INAPPROPRIATE_RESPONSE`, `POLICY_CONDITION_MISSING`, `RISK_HANDOFF_REQUIRED`, `WORKFLOW_BRANCH_ERROR`, `OTHER` |
+| `description` | required counselor explanation |
+| `expected_behavior` | expected response or expected action |
+| `severity` | enum string: `LOW`, `MEDIUM`, `HIGH`, `CRITICAL` |
+| `status` | enum string: `OPEN`, `CANDIDATE_CREATED`, `RESOLVED`, `DISMISSED`; default `OPEN` |
+| `created_by` | member who submitted feedback |
+| `created_at`, `updated_at` | audit timestamps |
+
+---
+
+## REST API
+
+### Create Feedback
+
+| Method | Path | Description |
+| --- | --- | --- |
+| POST | `/api/v1/workspaces/{workspaceId}/simulation/sessions/{sessionId}/feedback` | session 또는 turn feedback 작성 |
+
+Request:
+
+```json
+{
+  "chatMessageId": 42,
+  "feedbackType": "MISSING_SLOT_QUESTION",
+  "description": "주문번호 없이 바로 환불 가능 여부를 답했다.",
+  "expectedBehavior": "주문번호를 먼저 요청해야 한다.",
+  "severity": "HIGH"
+}
+```
+
+Response: refreshed `SimulationSessionDetailResponse`.
+
+### List Workspace Feedback
+
+| Method | Path | Description |
+| --- | --- | --- |
+| GET | `/api/v1/workspaces/{workspaceId}/simulation/feedback?status=OPEN&page=0&size=20` | workspace feedback 목록 조회 |
+
+Response:
+
+```json
+{
+  "content": [
+    {
+      "id": 1,
+      "workspaceId": 10,
+      "sessionId": 55,
+      "chatMessageId": 42,
+      "feedbackType": "MISSING_SLOT_QUESTION",
+      "description": "주문번호 없이 바로 환불 가능 여부를 답했다.",
+      "expectedBehavior": "주문번호를 먼저 요청해야 한다.",
+      "severity": "HIGH",
+      "status": "OPEN",
+      "createdBy": 7,
+      "createdAt": "2026-06-04T10:00:00Z",
+      "updatedAt": "2026-06-04T10:00:00Z"
+    }
+  ],
+  "page": 0,
+  "size": 20,
+  "totalElements": 1,
+  "totalPages": 1
+}
+```
+
+---
+
+## Detail Response Impact
+
+`SimulationSessionDetailResponse` adds `feedback` with:
+
+- `items`: feedback rows for the current session
+- `messageFeedbackCounts`: map keyed by `chatMessageId`
+
+This allows the UI to mark turns that already have feedback without embedding feedback into `ChatMessageResponse` or modifying operational chat message shape.
+
+---
+
+## Validation
+
+- `feedbackType`, `description`, `expectedBehavior`, `severity` are required.
+- `description` and `expectedBehavior` are trimmed and length-limited.
+- `chatMessageId` is optional; when present, it must belong to the selected simulation session.
+- feedback can only be created/listed by a workspace member.
+- feedback can only target `SIMULATION` channel sessions.
+- `status` filter is optional; invalid status values fail with a 400-style business error.
+
+---
+
+## Acceptance Criteria
+
+1. 상담사는 simulation turn 단위로 feedback을 남길 수 있다.
+2. 상담사는 simulation session 단위로 feedback을 남길 수 있다.
+3. feedback includes 유형, 설명, 기대 응답/기대 행동, 심각도.
+4. session 상세에서 feedback이 있는 turn이 표시된다.
+5. workspace feedback 목록은 상태별로 조회할 수 있다.
+6. feedback rows are stored in `runtime.simulation_feedback`, separate from operational 상담 로그.
+7. workspace member가 아닌 사용자는 feedback 조회/작성에 실패한다.
+8. 후속 개선 후보 생성에서 참조할 수 있는 stable feedback id가 응답에 포함된다.
+
+---
+
+## Validation Plan
+
+- Backend service tests for feedback creation, turn ownership validation, status filtering, and membership denial.
+- Backend controller tests for create/list endpoints and request mapping.
+- Frontend API tests for create/list feedback wrappers.
+- Frontend page tests for turn feedback submission and feedback markers.
+- Run focused backend and frontend tests for the changed simulation surfaces.
+
+---
+
+## Open Questions
+
+- 후속 이슈에서 `CANDIDATE_CREATED`, `RESOLVED`, `DISMISSED` 전이를 담당할 별도 endpoint가 필요한지 여부는 이 이슈 범위 밖이다.

--- a/backend/src/main/java/com/init/workflowruntime/application/SimulationService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/SimulationService.java
@@ -11,6 +11,7 @@ import com.init.domainpack.domain.repository.IntentDefinitionRepository;
 import com.init.domainpack.domain.repository.WorkflowDefinitionRepository;
 import com.init.shared.application.exception.BadRequestException;
 import com.init.shared.application.exception.NotFoundException;
+import com.init.workflowruntime.application.command.CreateSimulationFeedbackCommand;
 import com.init.workflowruntime.application.command.CreateSimulationSessionCommand;
 import com.init.workflowruntime.application.command.GenerateWorkflowAwareResponseCommand;
 import com.init.workflowruntime.application.command.GetCurrentWorkflowCommand;
@@ -22,6 +23,8 @@ import com.init.workflowruntime.application.dto.ChatSessionResponse;
 import com.init.workflowruntime.application.dto.GenerateWorkflowAwareResponseResult;
 import com.init.workflowruntime.application.dto.LlmToolContextResponse;
 import com.init.workflowruntime.application.dto.LlmToolWorkflowResponse;
+import com.init.workflowruntime.application.dto.SimulationFeedbackPageResponse;
+import com.init.workflowruntime.application.dto.SimulationFeedbackSessionResponse;
 import com.init.workflowruntime.application.dto.SimulationSessionDetailResponse;
 import com.init.workflowruntime.application.dto.SimulationSessionPageResponse;
 import com.init.workflowruntime.domain.ChatMessage;
@@ -31,9 +34,14 @@ import com.init.workflowruntime.domain.ChatSessionRepository;
 import com.init.workflowruntime.domain.ChatSessionStatus;
 import com.init.workflowruntime.domain.DomainPage;
 import com.init.workflowruntime.domain.DomainPageRequest;
+import com.init.workflowruntime.domain.SimulationFeedback;
+import com.init.workflowruntime.domain.SimulationFeedbackContent;
+import com.init.workflowruntime.domain.SimulationFeedbackRepository;
+import com.init.workflowruntime.domain.SimulationFeedbackStatus;
 import com.init.workspace.application.exception.WorkspaceAccessDeniedException;
 import com.init.workspace.domain.repository.WorkspaceMemberRepository;
 import java.util.List;
+import java.util.Locale;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -52,6 +60,7 @@ public class SimulationService {
 
   private final ChatSessionRepository chatSessionRepository;
   private final ChatMessageRepository chatMessageRepository;
+  private final SimulationFeedbackRepository simulationFeedbackRepository;
   private final DomainPackVersionRepository domainPackVersionRepository;
   private final IntentDefinitionRepository intentDefinitionRepository;
   private final WorkflowDefinitionRepository workflowDefinitionRepository;
@@ -64,6 +73,7 @@ public class SimulationService {
   public SimulationService(
       ChatSessionRepository chatSessionRepository,
       ChatMessageRepository chatMessageRepository,
+      SimulationFeedbackRepository simulationFeedbackRepository,
       DomainPackVersionRepository domainPackVersionRepository,
       IntentDefinitionRepository intentDefinitionRepository,
       WorkflowDefinitionRepository workflowDefinitionRepository,
@@ -74,6 +84,7 @@ public class SimulationService {
       ObjectMapper objectMapper) {
     this.chatSessionRepository = chatSessionRepository;
     this.chatMessageRepository = chatMessageRepository;
+    this.simulationFeedbackRepository = simulationFeedbackRepository;
     this.domainPackVersionRepository = domainPackVersionRepository;
     this.intentDefinitionRepository = intentDefinitionRepository;
     this.workflowDefinitionRepository = workflowDefinitionRepository;
@@ -129,6 +140,39 @@ public class SimulationService {
     validateWorkspaceMembership(workspaceId, userId);
     ChatSession session = findSimulationSession(workspaceId, sessionId);
     return detail(session, userId);
+  }
+
+  @Transactional
+  public SimulationSessionDetailResponse createFeedback(CreateSimulationFeedbackCommand command) {
+    validateWorkspaceMembership(command.workspaceId(), command.userId());
+    ChatSession session = findSimulationSession(command.workspaceId(), command.sessionId());
+    validateFeedbackMessage(session.getId(), command.chatMessageId());
+    SimulationFeedback feedback =
+        SimulationFeedback.create(
+            command.workspaceId(),
+            session.getId(),
+            command.chatMessageId(),
+            new SimulationFeedbackContent(
+                command.feedbackType(),
+                command.description(),
+                command.expectedBehavior(),
+                command.severity()),
+            command.userId());
+    simulationFeedbackRepository.save(feedback);
+    return detail(session, command.userId());
+  }
+
+  public SimulationFeedbackPageResponse listFeedback(
+      Long workspaceId, Long userId, String status, int page, int size) {
+    validateWorkspaceMembership(workspaceId, userId);
+    SimulationFeedbackStatus parsedStatus = parseFeedbackStatus(status);
+    DomainPageRequest pageRequest = normalizedPageRequest(page, size);
+    DomainPage<SimulationFeedback> feedbackPage =
+        parsedStatus == null
+            ? simulationFeedbackRepository.findByWorkspaceId(workspaceId, pageRequest)
+            : simulationFeedbackRepository.findByWorkspaceIdAndStatus(
+                workspaceId, parsedStatus, pageRequest);
+    return SimulationFeedbackPageResponse.from(feedbackPage);
   }
 
   @Transactional
@@ -229,6 +273,35 @@ public class SimulationService {
     }
   }
 
+  private void validateFeedbackMessage(Long sessionId, Long chatMessageId) {
+    if (chatMessageId == null) {
+      return;
+    }
+    ChatMessage message =
+        chatMessageRepository
+            .findById(chatMessageId)
+            .orElseThrow(
+                () ->
+                    new NotFoundException(
+                        "SIMULATION_MESSAGE_NOT_FOUND",
+                        "Simulation message not found: " + chatMessageId));
+    if (!sessionId.equals(message.getChatSessionId())) {
+      throw new NotFoundException(
+          "SIMULATION_MESSAGE_NOT_FOUND", "Simulation message not found: " + chatMessageId);
+    }
+  }
+
+  private SimulationFeedbackStatus parseFeedbackStatus(String status) {
+    if (status == null || status.isBlank()) {
+      return null;
+    }
+    try {
+      return SimulationFeedbackStatus.valueOf(status.trim().toUpperCase(Locale.ROOT));
+    } catch (IllegalArgumentException e) {
+      throw new BadRequestException("INVALID_FEEDBACK_STATUS", "지원하지 않는 피드백 상태입니다: " + status);
+    }
+  }
+
   private void validateWorkspaceMembership(Long workspaceId, Long userId) {
     workspaceMemberRepository
         .findByWorkspaceIdAndUserId(workspaceId, userId)
@@ -250,7 +323,9 @@ public class SimulationService {
         messages,
         matchedWorkflow,
         context.slotValues(),
-        context.slots());
+        context.slots(),
+        SimulationFeedbackSessionResponse.from(
+            simulationFeedbackRepository.findByChatSessionIdOrderByCreatedAtAsc(session.getId())));
   }
 
   private ChatMessage saveMessage(ChatSession session, String senderRole, String content) {

--- a/backend/src/main/java/com/init/workflowruntime/application/command/CreateSimulationFeedbackCommand.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/command/CreateSimulationFeedbackCommand.java
@@ -1,0 +1,14 @@
+package com.init.workflowruntime.application.command;
+
+import com.init.workflowruntime.domain.SimulationFeedbackSeverity;
+import com.init.workflowruntime.domain.SimulationFeedbackType;
+
+public record CreateSimulationFeedbackCommand(
+    Long workspaceId,
+    Long sessionId,
+    Long userId,
+    Long chatMessageId,
+    SimulationFeedbackType feedbackType,
+    String description,
+    String expectedBehavior,
+    SimulationFeedbackSeverity severity) {}

--- a/backend/src/main/java/com/init/workflowruntime/application/dto/SimulationFeedbackPageResponse.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/dto/SimulationFeedbackPageResponse.java
@@ -1,0 +1,22 @@
+package com.init.workflowruntime.application.dto;
+
+import com.init.workflowruntime.domain.DomainPage;
+import com.init.workflowruntime.domain.SimulationFeedback;
+import java.util.List;
+
+public record SimulationFeedbackPageResponse(
+    List<SimulationFeedbackResponse> content,
+    int page,
+    int size,
+    long totalElements,
+    int totalPages) {
+
+  public static SimulationFeedbackPageResponse from(DomainPage<SimulationFeedback> page) {
+    return new SimulationFeedbackPageResponse(
+        page.content().stream().map(SimulationFeedbackResponse::from).toList(),
+        page.page(),
+        page.size(),
+        page.totalElements(),
+        page.totalPages());
+  }
+}

--- a/backend/src/main/java/com/init/workflowruntime/application/dto/SimulationFeedbackResponse.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/dto/SimulationFeedbackResponse.java
@@ -1,0 +1,38 @@
+package com.init.workflowruntime.application.dto;
+
+import com.init.workflowruntime.domain.SimulationFeedback;
+import com.init.workflowruntime.domain.SimulationFeedbackSeverity;
+import com.init.workflowruntime.domain.SimulationFeedbackStatus;
+import com.init.workflowruntime.domain.SimulationFeedbackType;
+import java.time.OffsetDateTime;
+
+public record SimulationFeedbackResponse(
+    Long id,
+    Long workspaceId,
+    Long sessionId,
+    Long chatMessageId,
+    SimulationFeedbackType feedbackType,
+    String description,
+    String expectedBehavior,
+    SimulationFeedbackSeverity severity,
+    SimulationFeedbackStatus status,
+    Long createdBy,
+    OffsetDateTime createdAt,
+    OffsetDateTime updatedAt) {
+
+  public static SimulationFeedbackResponse from(SimulationFeedback feedback) {
+    return new SimulationFeedbackResponse(
+        feedback.getId(),
+        feedback.getWorkspaceId(),
+        feedback.getChatSessionId(),
+        feedback.getChatMessageId(),
+        feedback.getFeedbackType(),
+        feedback.getDescription(),
+        feedback.getExpectedBehavior(),
+        feedback.getSeverity(),
+        feedback.getStatus(),
+        feedback.getCreatedBy(),
+        feedback.getCreatedAt(),
+        feedback.getUpdatedAt());
+  }
+}

--- a/backend/src/main/java/com/init/workflowruntime/application/dto/SimulationFeedbackSessionResponse.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/dto/SimulationFeedbackSessionResponse.java
@@ -1,0 +1,20 @@
+package com.init.workflowruntime.application.dto;
+
+import com.init.workflowruntime.domain.SimulationFeedback;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public record SimulationFeedbackSessionResponse(
+    List<SimulationFeedbackResponse> items, Map<Long, Long> messageFeedbackCounts) {
+
+  public static SimulationFeedbackSessionResponse from(List<SimulationFeedback> feedbacks) {
+    Map<Long, Long> messageFeedbackCounts =
+        feedbacks.stream()
+            .filter(feedback -> feedback.getChatMessageId() != null)
+            .collect(
+                Collectors.groupingBy(SimulationFeedback::getChatMessageId, Collectors.counting()));
+    return new SimulationFeedbackSessionResponse(
+        feedbacks.stream().map(SimulationFeedbackResponse::from).toList(), messageFeedbackCounts);
+  }
+}

--- a/backend/src/main/java/com/init/workflowruntime/application/dto/SimulationSessionDetailResponse.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/dto/SimulationSessionDetailResponse.java
@@ -8,4 +8,5 @@ public record SimulationSessionDetailResponse(
     List<ChatMessageResponse> messages,
     LlmToolWorkflowResponse matchedWorkflow,
     JsonNode slotValues,
-    List<LlmToolSlotResponse> slots) {}
+    List<LlmToolSlotResponse> slots,
+    SimulationFeedbackSessionResponse feedback) {}

--- a/backend/src/main/java/com/init/workflowruntime/domain/InvalidSimulationFeedbackException.java
+++ b/backend/src/main/java/com/init/workflowruntime/domain/InvalidSimulationFeedbackException.java
@@ -1,0 +1,10 @@
+package com.init.workflowruntime.domain;
+
+import com.init.shared.application.exception.BadRequestException;
+
+public class InvalidSimulationFeedbackException extends BadRequestException {
+
+  public InvalidSimulationFeedbackException(String message) {
+    super("INVALID_SIMULATION_FEEDBACK", message);
+  }
+}

--- a/backend/src/main/java/com/init/workflowruntime/domain/SimulationFeedback.java
+++ b/backend/src/main/java/com/init/workflowruntime/domain/SimulationFeedback.java
@@ -1,0 +1,178 @@
+package com.init.workflowruntime.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "simulation_feedback", schema = "runtime")
+public class SimulationFeedback {
+
+  private static final int TEXT_MAX_LENGTH = 2000;
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "workspace_id", nullable = false)
+  private Long workspaceId;
+
+  @Column(name = "chat_session_id", nullable = false)
+  private Long chatSessionId;
+
+  @Column(name = "chat_message_id")
+  private Long chatMessageId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "feedback_type", nullable = false)
+  private SimulationFeedbackType feedbackType;
+
+  @Column(name = "description", nullable = false, columnDefinition = "TEXT")
+  private String description;
+
+  @Column(name = "expected_behavior", nullable = false, columnDefinition = "TEXT")
+  private String expectedBehavior;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "severity", nullable = false)
+  private SimulationFeedbackSeverity severity;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "status", nullable = false)
+  private SimulationFeedbackStatus status;
+
+  @Column(name = "created_by", nullable = false)
+  private Long createdBy;
+
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private OffsetDateTime createdAt;
+
+  @Column(name = "updated_at", nullable = false)
+  private OffsetDateTime updatedAt;
+
+  protected SimulationFeedback() {
+    // JPA constructor
+  }
+
+  public static SimulationFeedback create(
+      Long workspaceId,
+      Long chatSessionId,
+      Long chatMessageId,
+      SimulationFeedbackContent content,
+      Long createdBy) {
+    SimulationFeedback feedback = new SimulationFeedback();
+    feedback.workspaceId = requireId(workspaceId, "workspaceId");
+    feedback.chatSessionId = requireId(chatSessionId, "chatSessionId");
+    feedback.chatMessageId = chatMessageId;
+    SimulationFeedbackContent requiredContent = requireNonNull(content, "content");
+    feedback.feedbackType = requireNonNull(requiredContent.feedbackType(), "feedbackType");
+    feedback.description = normalizeText(requiredContent.description(), "description");
+    feedback.expectedBehavior =
+        normalizeText(requiredContent.expectedBehavior(), "expectedBehavior");
+    feedback.severity = requireNonNull(requiredContent.severity(), "severity");
+    feedback.status = SimulationFeedbackStatus.OPEN;
+    feedback.createdBy = requireId(createdBy, "createdBy");
+    return feedback;
+  }
+
+  @PrePersist
+  protected void onPersist() {
+    OffsetDateTime now = OffsetDateTime.now();
+    if (this.createdAt == null) {
+      this.createdAt = now;
+    }
+    if (this.updatedAt == null) {
+      this.updatedAt = now;
+    }
+    if (this.status == null) {
+      this.status = SimulationFeedbackStatus.OPEN;
+    }
+  }
+
+  @PreUpdate
+  protected void onUpdate() {
+    this.updatedAt = OffsetDateTime.now();
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public Long getWorkspaceId() {
+    return workspaceId;
+  }
+
+  public Long getChatSessionId() {
+    return chatSessionId;
+  }
+
+  public Long getChatMessageId() {
+    return chatMessageId;
+  }
+
+  public SimulationFeedbackType getFeedbackType() {
+    return feedbackType;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public String getExpectedBehavior() {
+    return expectedBehavior;
+  }
+
+  public SimulationFeedbackSeverity getSeverity() {
+    return severity;
+  }
+
+  public SimulationFeedbackStatus getStatus() {
+    return status;
+  }
+
+  public Long getCreatedBy() {
+    return createdBy;
+  }
+
+  public OffsetDateTime getCreatedAt() {
+    return createdAt;
+  }
+
+  public OffsetDateTime getUpdatedAt() {
+    return updatedAt;
+  }
+
+  private static Long requireId(Long value, String fieldName) {
+    if (value == null) {
+      throw new InvalidSimulationFeedbackException(fieldName + " must not be null");
+    }
+    return value;
+  }
+
+  private static <T> T requireNonNull(T value, String fieldName) {
+    if (value == null) {
+      throw new InvalidSimulationFeedbackException(fieldName + " must not be null");
+    }
+    return value;
+  }
+
+  private static String normalizeText(String value, String fieldName) {
+    if (value == null || value.isBlank()) {
+      throw new InvalidSimulationFeedbackException(fieldName + " must not be blank");
+    }
+    String normalized = value.trim();
+    if (normalized.length() > TEXT_MAX_LENGTH) {
+      throw new InvalidSimulationFeedbackException(
+          fieldName + " must be at most " + TEXT_MAX_LENGTH);
+    }
+    return normalized;
+  }
+}

--- a/backend/src/main/java/com/init/workflowruntime/domain/SimulationFeedbackContent.java
+++ b/backend/src/main/java/com/init/workflowruntime/domain/SimulationFeedbackContent.java
@@ -1,0 +1,7 @@
+package com.init.workflowruntime.domain;
+
+public record SimulationFeedbackContent(
+    SimulationFeedbackType feedbackType,
+    String description,
+    String expectedBehavior,
+    SimulationFeedbackSeverity severity) {}

--- a/backend/src/main/java/com/init/workflowruntime/domain/SimulationFeedbackRepository.java
+++ b/backend/src/main/java/com/init/workflowruntime/domain/SimulationFeedbackRepository.java
@@ -1,0 +1,15 @@
+package com.init.workflowruntime.domain;
+
+import java.util.List;
+
+public interface SimulationFeedbackRepository {
+
+  SimulationFeedback save(SimulationFeedback feedback);
+
+  List<SimulationFeedback> findByChatSessionIdOrderByCreatedAtAsc(Long chatSessionId);
+
+  DomainPage<SimulationFeedback> findByWorkspaceId(Long workspaceId, DomainPageRequest pageRequest);
+
+  DomainPage<SimulationFeedback> findByWorkspaceIdAndStatus(
+      Long workspaceId, SimulationFeedbackStatus status, DomainPageRequest pageRequest);
+}

--- a/backend/src/main/java/com/init/workflowruntime/domain/SimulationFeedbackSeverity.java
+++ b/backend/src/main/java/com/init/workflowruntime/domain/SimulationFeedbackSeverity.java
@@ -1,0 +1,8 @@
+package com.init.workflowruntime.domain;
+
+public enum SimulationFeedbackSeverity {
+  LOW,
+  MEDIUM,
+  HIGH,
+  CRITICAL
+}

--- a/backend/src/main/java/com/init/workflowruntime/domain/SimulationFeedbackStatus.java
+++ b/backend/src/main/java/com/init/workflowruntime/domain/SimulationFeedbackStatus.java
@@ -1,0 +1,8 @@
+package com.init.workflowruntime.domain;
+
+public enum SimulationFeedbackStatus {
+  OPEN,
+  CANDIDATE_CREATED,
+  RESOLVED,
+  DISMISSED
+}

--- a/backend/src/main/java/com/init/workflowruntime/domain/SimulationFeedbackType.java
+++ b/backend/src/main/java/com/init/workflowruntime/domain/SimulationFeedbackType.java
@@ -1,0 +1,11 @@
+package com.init.workflowruntime.domain;
+
+public enum SimulationFeedbackType {
+  INTENT_MISMATCH,
+  MISSING_SLOT_QUESTION,
+  INAPPROPRIATE_RESPONSE,
+  POLICY_CONDITION_MISSING,
+  RISK_HANDOFF_REQUIRED,
+  WORKFLOW_BRANCH_ERROR,
+  OTHER
+}

--- a/backend/src/main/java/com/init/workflowruntime/infrastructure/persistence/JpaSimulationFeedbackRepository.java
+++ b/backend/src/main/java/com/init/workflowruntime/infrastructure/persistence/JpaSimulationFeedbackRepository.java
@@ -1,0 +1,21 @@
+package com.init.workflowruntime.infrastructure.persistence;
+
+import com.init.workflowruntime.domain.SimulationFeedback;
+import com.init.workflowruntime.domain.SimulationFeedbackStatus;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface JpaSimulationFeedbackRepository extends JpaRepository<SimulationFeedback, Long> {
+
+  List<SimulationFeedback> findByChatSessionIdOrderByCreatedAtAsc(Long chatSessionId);
+
+  Page<SimulationFeedback> findByWorkspaceIdOrderByCreatedAtDesc(
+      Long workspaceId, Pageable pageable);
+
+  Page<SimulationFeedback> findByWorkspaceIdAndStatusOrderByCreatedAtDesc(
+      Long workspaceId, SimulationFeedbackStatus status, Pageable pageable);
+}

--- a/backend/src/main/java/com/init/workflowruntime/infrastructure/persistence/SimulationFeedbackRepositoryAdapter.java
+++ b/backend/src/main/java/com/init/workflowruntime/infrastructure/persistence/SimulationFeedbackRepositoryAdapter.java
@@ -1,0 +1,56 @@
+package com.init.workflowruntime.infrastructure.persistence;
+
+import com.init.workflowruntime.domain.DomainPage;
+import com.init.workflowruntime.domain.DomainPageRequest;
+import com.init.workflowruntime.domain.SimulationFeedback;
+import com.init.workflowruntime.domain.SimulationFeedbackRepository;
+import com.init.workflowruntime.domain.SimulationFeedbackStatus;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class SimulationFeedbackRepositoryAdapter implements SimulationFeedbackRepository {
+
+  private final JpaSimulationFeedbackRepository jpaRepository;
+
+  public SimulationFeedbackRepositoryAdapter(JpaSimulationFeedbackRepository jpaRepository) {
+    this.jpaRepository = jpaRepository;
+  }
+
+  @Override
+  public SimulationFeedback save(SimulationFeedback feedback) {
+    return jpaRepository.save(feedback);
+  }
+
+  @Override
+  public List<SimulationFeedback> findByChatSessionIdOrderByCreatedAtAsc(Long chatSessionId) {
+    return jpaRepository.findByChatSessionIdOrderByCreatedAtAsc(chatSessionId);
+  }
+
+  @Override
+  public DomainPage<SimulationFeedback> findByWorkspaceId(
+      Long workspaceId, DomainPageRequest pageRequest) {
+    return toDomainPage(
+        jpaRepository.findByWorkspaceIdOrderByCreatedAtDesc(
+            workspaceId, PageRequest.of(pageRequest.page(), pageRequest.size())));
+  }
+
+  @Override
+  public DomainPage<SimulationFeedback> findByWorkspaceIdAndStatus(
+      Long workspaceId, SimulationFeedbackStatus status, DomainPageRequest pageRequest) {
+    return toDomainPage(
+        jpaRepository.findByWorkspaceIdAndStatusOrderByCreatedAtDesc(
+            workspaceId, status, PageRequest.of(pageRequest.page(), pageRequest.size())));
+  }
+
+  private DomainPage<SimulationFeedback> toDomainPage(Page<SimulationFeedback> page) {
+    return new DomainPage<>(
+        page.getContent(),
+        page.getNumber(),
+        page.getSize(),
+        page.getTotalElements(),
+        page.getTotalPages());
+  }
+}

--- a/backend/src/main/java/com/init/workflowruntime/presentation/SimulationController.java
+++ b/backend/src/main/java/com/init/workflowruntime/presentation/SimulationController.java
@@ -2,10 +2,14 @@ package com.init.workflowruntime.presentation;
 
 import com.init.shared.presentation.AuthenticationUtils;
 import com.init.workflowruntime.application.SimulationService;
+import com.init.workflowruntime.application.command.CreateSimulationFeedbackCommand;
 import com.init.workflowruntime.application.command.CreateSimulationSessionCommand;
 import com.init.workflowruntime.application.command.SendSimulationMessageCommand;
 import com.init.workflowruntime.application.dto.SimulationSessionDetailResponse;
 import com.init.workflowruntime.application.dto.SimulationSessionPageResponse;
+import com.init.workflowruntime.domain.SimulationFeedbackSeverity;
+import com.init.workflowruntime.domain.SimulationFeedbackType;
+import com.init.workflowruntime.presentation.dto.CreateSimulationFeedbackRequest;
 import com.init.workflowruntime.presentation.dto.CreateSimulationSessionRequest;
 import com.init.workflowruntime.presentation.dto.SendSimulationMessageRequest;
 import jakarta.validation.Valid;
@@ -74,5 +78,25 @@ public class SimulationController {
     return ResponseEntity.ok(
         simulationService.sendMessage(
             new SendSimulationMessageCommand(workspaceId, sessionId, userId, request.content())));
+  }
+
+  @PostMapping("/{sessionId}/feedback")
+  public ResponseEntity<SimulationSessionDetailResponse> createFeedback(
+      @PathVariable Long workspaceId,
+      @PathVariable Long sessionId,
+      @Valid @RequestBody CreateSimulationFeedbackRequest request,
+      Authentication authentication) {
+    Long userId = AuthenticationUtils.getUserId(authentication);
+    return ResponseEntity.ok(
+        simulationService.createFeedback(
+            new CreateSimulationFeedbackCommand(
+                workspaceId,
+                sessionId,
+                userId,
+                request.chatMessageId(),
+                SimulationFeedbackType.valueOf(request.feedbackType().name()),
+                request.description(),
+                request.expectedBehavior(),
+                SimulationFeedbackSeverity.valueOf(request.severity().name()))));
   }
 }

--- a/backend/src/main/java/com/init/workflowruntime/presentation/SimulationFeedbackController.java
+++ b/backend/src/main/java/com/init/workflowruntime/presentation/SimulationFeedbackController.java
@@ -1,0 +1,37 @@
+package com.init.workflowruntime.presentation;
+
+import com.init.shared.presentation.AuthenticationUtils;
+import com.init.workflowruntime.application.SimulationService;
+import com.init.workflowruntime.application.dto.SimulationFeedbackPageResponse;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/workspaces/{workspaceId}/simulation/feedback")
+public class SimulationFeedbackController {
+
+  private final SimulationService simulationService;
+
+  public SimulationFeedbackController(SimulationService simulationService) {
+    this.simulationService = simulationService;
+  }
+
+  @GetMapping
+  public ResponseEntity<SimulationFeedbackPageResponse> listFeedback(
+      @PathVariable Long workspaceId,
+      @RequestParam(required = false) String status,
+      @RequestParam(defaultValue = "0") @Min(0) int page,
+      @RequestParam(defaultValue = "20") @Min(1) @Max(100) int size,
+      Authentication authentication) {
+    Long userId = AuthenticationUtils.getUserId(authentication);
+    return ResponseEntity.ok(
+        simulationService.listFeedback(workspaceId, userId, status, page, size));
+  }
+}

--- a/backend/src/main/java/com/init/workflowruntime/presentation/dto/CreateSimulationFeedbackRequest.java
+++ b/backend/src/main/java/com/init/workflowruntime/presentation/dto/CreateSimulationFeedbackRequest.java
@@ -1,0 +1,12 @@
+package com.init.workflowruntime.presentation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record CreateSimulationFeedbackRequest(
+    Long chatMessageId,
+    @NotNull SimulationFeedbackTypeRequest feedbackType,
+    @NotBlank @Size(max = 2000) String description,
+    @NotBlank @Size(max = 2000) String expectedBehavior,
+    @NotNull SimulationFeedbackSeverityRequest severity) {}

--- a/backend/src/main/java/com/init/workflowruntime/presentation/dto/SimulationFeedbackSeverityRequest.java
+++ b/backend/src/main/java/com/init/workflowruntime/presentation/dto/SimulationFeedbackSeverityRequest.java
@@ -1,0 +1,8 @@
+package com.init.workflowruntime.presentation.dto;
+
+public enum SimulationFeedbackSeverityRequest {
+  LOW,
+  MEDIUM,
+  HIGH,
+  CRITICAL
+}

--- a/backend/src/main/java/com/init/workflowruntime/presentation/dto/SimulationFeedbackTypeRequest.java
+++ b/backend/src/main/java/com/init/workflowruntime/presentation/dto/SimulationFeedbackTypeRequest.java
@@ -1,0 +1,11 @@
+package com.init.workflowruntime.presentation.dto;
+
+public enum SimulationFeedbackTypeRequest {
+  INTENT_MISMATCH,
+  MISSING_SLOT_QUESTION,
+  INAPPROPRIATE_RESPONSE,
+  POLICY_CONDITION_MISSING,
+  RISK_HANDOFF_REQUIRED,
+  WORKFLOW_BRANCH_ERROR,
+  OTHER
+}

--- a/backend/src/main/resources/db/changelog/db.changelog-master.sql
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.sql
@@ -930,6 +930,46 @@ CREATE INDEX idx_workflow_match_decision_recent_confident_workflow
     WHERE status = 'CONFIDENT'
       AND selected_workflow_id IS NOT NULL;
 
+--changeset init:20260604-create-simulation-feedback
+--comment: Store structured simulation feedback separately from operational consultation logs
+CREATE TABLE runtime.simulation_feedback (
+    id                BIGSERIAL PRIMARY KEY,
+    workspace_id      BIGINT NOT NULL REFERENCES app.workspace(id) ON DELETE CASCADE,
+    chat_session_id   BIGINT NOT NULL REFERENCES runtime.chat_session(id) ON DELETE CASCADE,
+    chat_message_id   BIGINT REFERENCES runtime.chat_message(id) ON DELETE SET NULL,
+    feedback_type     VARCHAR(50) NOT NULL,
+    description       TEXT NOT NULL,
+    expected_behavior TEXT NOT NULL,
+    severity          VARCHAR(50) NOT NULL,
+    status            VARCHAR(50) NOT NULL DEFAULT 'OPEN',
+    created_by        BIGINT NOT NULL REFERENCES app.app_user(id),
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT chk_simulation_feedback_type
+        CHECK (feedback_type IN (
+            'INTENT_MISMATCH',
+            'MISSING_SLOT_QUESTION',
+            'INAPPROPRIATE_RESPONSE',
+            'POLICY_CONDITION_MISSING',
+            'RISK_HANDOFF_REQUIRED',
+            'WORKFLOW_BRANCH_ERROR',
+            'OTHER'
+        )),
+    CONSTRAINT chk_simulation_feedback_severity
+        CHECK (severity IN ('LOW', 'MEDIUM', 'HIGH', 'CRITICAL')),
+    CONSTRAINT chk_simulation_feedback_status
+        CHECK (status IN ('OPEN', 'CANDIDATE_CREATED', 'RESOLVED', 'DISMISSED'))
+);
+
+CREATE INDEX idx_simulation_feedback_session_created
+    ON runtime.simulation_feedback (chat_session_id, created_at);
+
+CREATE INDEX idx_simulation_feedback_workspace_status_created
+    ON runtime.simulation_feedback (workspace_id, status, created_at DESC);
+
+CREATE INDEX idx_simulation_feedback_workspace_created
+    ON runtime.simulation_feedback (workspace_id, created_at DESC);
+
 --changeset init:20260601-add-response-mode-to-chat-session
 --comment: Add session-level AI response mode for counselor intervention control
 ALTER TABLE runtime.chat_session

--- a/backend/src/test/java/com/init/workflowruntime/application/SimulationServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/SimulationServiceTest.java
@@ -17,6 +17,7 @@ import com.init.domainpack.domain.repository.IntentDefinitionRepository;
 import com.init.domainpack.domain.repository.WorkflowDefinitionRepository;
 import com.init.shared.application.exception.BadRequestException;
 import com.init.shared.application.exception.NotFoundException;
+import com.init.workflowruntime.application.command.CreateSimulationFeedbackCommand;
 import com.init.workflowruntime.application.command.CreateSimulationSessionCommand;
 import com.init.workflowruntime.application.command.GenerateWorkflowAwareResponseCommand;
 import com.init.workflowruntime.application.command.GetCurrentWorkflowCommand;
@@ -34,10 +35,18 @@ import com.init.workflowruntime.domain.ChatSessionRepository;
 import com.init.workflowruntime.domain.ChatSessionStatus;
 import com.init.workflowruntime.domain.DomainPage;
 import com.init.workflowruntime.domain.DomainPageRequest;
+import com.init.workflowruntime.domain.SimulationFeedback;
+import com.init.workflowruntime.domain.SimulationFeedbackContent;
+import com.init.workflowruntime.domain.SimulationFeedbackRepository;
+import com.init.workflowruntime.domain.SimulationFeedbackSeverity;
+import com.init.workflowruntime.domain.SimulationFeedbackStatus;
+import com.init.workflowruntime.domain.SimulationFeedbackType;
+import com.init.workspace.application.exception.WorkspaceAccessDeniedException;
 import com.init.workspace.domain.model.WorkspaceMember;
 import com.init.workspace.domain.model.WorkspaceMemberRole;
 import com.init.workspace.domain.repository.WorkspaceMemberRepository;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -60,6 +69,7 @@ class SimulationServiceTest {
 
   @Mock private ChatSessionRepository chatSessionRepository;
   @Mock private ChatMessageRepository chatMessageRepository;
+  @Mock private SimulationFeedbackRepository simulationFeedbackRepository;
   @Mock private DomainPackVersionRepository domainPackVersionRepository;
   @Mock private IntentDefinitionRepository intentDefinitionRepository;
   @Mock private WorkflowDefinitionRepository workflowDefinitionRepository;
@@ -77,6 +87,7 @@ class SimulationServiceTest {
         new SimulationService(
             chatSessionRepository,
             chatMessageRepository,
+            simulationFeedbackRepository,
             domainPackVersionRepository,
             intentDefinitionRepository,
             workflowDefinitionRepository,
@@ -319,6 +330,249 @@ class SimulationServiceTest {
     assertThat(messageCaptor.getAllValues().get(1).getContent()).contains("현재 응답을 생성할 수 없습니다");
   }
 
+  @Test
+  @DisplayName("createFeedback: simulation turn 피드백을 저장하고 상세에 피드백 표시를 포함한다")
+  void should_createFeedback_forSimulationTurn() {
+    givenMembership();
+    ChatSession session = withId(simulationSession(), 55L);
+    ChatMessage targetMessage = withMessageId(message(55L, 2, "ASSISTANT", "바로 환불됩니다."), 2L);
+    SimulationFeedback savedFeedback =
+        withFeedbackId(
+            SimulationFeedback.create(
+                WORKSPACE_ID,
+                55L,
+                2L,
+                new SimulationFeedbackContent(
+                    SimulationFeedbackType.MISSING_SLOT_QUESTION,
+                    "주문번호를 묻지 않았습니다.",
+                    "주문번호를 먼저 요청합니다.",
+                    SimulationFeedbackSeverity.HIGH),
+                USER_ID),
+            900L);
+    given(chatSessionRepository.findById(55L)).willReturn(Optional.of(session));
+    given(chatMessageRepository.findById(2L)).willReturn(Optional.of(targetMessage));
+    given(simulationFeedbackRepository.save(any(SimulationFeedback.class)))
+        .willReturn(savedFeedback);
+    givenDetailDependencies(55L, List.of(savedFeedback));
+
+    SimulationSessionDetailResponse result =
+        service.createFeedback(
+            new CreateSimulationFeedbackCommand(
+                WORKSPACE_ID,
+                55L,
+                USER_ID,
+                2L,
+                SimulationFeedbackType.MISSING_SLOT_QUESTION,
+                "  주문번호를 묻지 않았습니다.  ",
+                "주문번호를 먼저 요청합니다.",
+                SimulationFeedbackSeverity.HIGH));
+
+    ArgumentCaptor<SimulationFeedback> feedbackCaptor =
+        ArgumentCaptor.forClass(SimulationFeedback.class);
+    verify(simulationFeedbackRepository).save(feedbackCaptor.capture());
+    assertThat(feedbackCaptor.getValue().getDescription()).isEqualTo("주문번호를 묻지 않았습니다.");
+    assertThat(result.feedback().items()).hasSize(1);
+    assertThat(result.feedback().messageFeedbackCounts()).containsEntry(2L, 1L);
+  }
+
+  @Test
+  @DisplayName("createFeedback: 다른 세션의 메시지를 turn 피드백 대상으로 지정하면 실패한다")
+  void should_throw_when_feedbackMessageBelongsToDifferentSession() {
+    givenMembership();
+    ChatSession session = withId(simulationSession(), 55L);
+    ChatMessage otherSessionMessage = withMessageId(message(99L, 1, "ASSISTANT", "다른 세션 메시지"), 2L);
+    given(chatSessionRepository.findById(55L)).willReturn(Optional.of(session));
+    given(chatMessageRepository.findById(2L)).willReturn(Optional.of(otherSessionMessage));
+    CreateSimulationFeedbackCommand command =
+        new CreateSimulationFeedbackCommand(
+            WORKSPACE_ID,
+            55L,
+            USER_ID,
+            2L,
+            SimulationFeedbackType.WORKFLOW_BRANCH_ERROR,
+            "분기가 맞지 않습니다.",
+            "handoff 분기로 이동해야 합니다.",
+            SimulationFeedbackSeverity.CRITICAL);
+
+    assertThatThrownBy(() -> service.createFeedback(command))
+        .isInstanceOf(NotFoundException.class)
+        .hasMessageContaining("Simulation message not found");
+  }
+
+  @Test
+  @DisplayName("createFeedback: 세션 전체 피드백은 메시지 조회 없이 저장한다")
+  void should_createFeedback_forSession() {
+    givenMembership();
+    ChatSession session = withId(simulationSession(), 55L);
+    SimulationFeedback savedFeedback =
+        withFeedbackId(
+            SimulationFeedback.create(
+                WORKSPACE_ID,
+                55L,
+                null,
+                new SimulationFeedbackContent(
+                    SimulationFeedbackType.OTHER,
+                    "세션 전체 흐름이 어색합니다.",
+                    "질문 순서를 조정합니다.",
+                    SimulationFeedbackSeverity.MEDIUM),
+                USER_ID),
+            901L);
+    given(chatSessionRepository.findById(55L)).willReturn(Optional.of(session));
+    given(simulationFeedbackRepository.save(any(SimulationFeedback.class)))
+        .willReturn(savedFeedback);
+    givenDetailDependencies(55L, List.of(savedFeedback));
+
+    SimulationSessionDetailResponse result =
+        service.createFeedback(
+            new CreateSimulationFeedbackCommand(
+                WORKSPACE_ID,
+                55L,
+                USER_ID,
+                null,
+                SimulationFeedbackType.OTHER,
+                "세션 전체 흐름이 어색합니다.",
+                "질문 순서를 조정합니다.",
+                SimulationFeedbackSeverity.MEDIUM));
+
+    verify(chatMessageRepository, org.mockito.Mockito.never()).findById(any());
+    assertThat(result.feedback().items()).hasSize(1);
+    assertThat(result.feedback().messageFeedbackCounts()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("createFeedback: 없는 메시지를 turn 피드백 대상으로 지정하면 실패한다")
+  void should_throw_when_feedbackMessageMissing() {
+    givenMembership();
+    ChatSession session = withId(simulationSession(), 55L);
+    given(chatSessionRepository.findById(55L)).willReturn(Optional.of(session));
+    given(chatMessageRepository.findById(2L)).willReturn(Optional.empty());
+    CreateSimulationFeedbackCommand command =
+        new CreateSimulationFeedbackCommand(
+            WORKSPACE_ID,
+            55L,
+            USER_ID,
+            2L,
+            SimulationFeedbackType.WORKFLOW_BRANCH_ERROR,
+            "분기가 맞지 않습니다.",
+            "handoff 분기로 이동해야 합니다.",
+            SimulationFeedbackSeverity.CRITICAL);
+
+    assertThatThrownBy(() -> service.createFeedback(command))
+        .isInstanceOf(NotFoundException.class)
+        .hasMessageContaining("Simulation message not found");
+  }
+
+  @Test
+  @DisplayName("listFeedback: status 필터로 workspace feedback을 페이지 조회한다")
+  void should_listFeedback_byStatus() {
+    givenMembership();
+    SimulationFeedback feedback =
+        withFeedbackId(
+            SimulationFeedback.create(
+                WORKSPACE_ID,
+                55L,
+                null,
+                new SimulationFeedbackContent(
+                    SimulationFeedbackType.OTHER,
+                    "세션 전체 흐름이 어색합니다.",
+                    "질문 순서를 조정합니다.",
+                    SimulationFeedbackSeverity.MEDIUM),
+                USER_ID),
+            901L);
+    given(simulationFeedbackRepository.findByWorkspaceIdAndStatus(any(), any(), any()))
+        .willReturn(new DomainPage<>(List.of(feedback), 0, 20, 1, 1));
+
+    var result = service.listFeedback(WORKSPACE_ID, USER_ID, "OPEN", 0, 20);
+
+    assertThat(result.content()).hasSize(1);
+    verify(simulationFeedbackRepository)
+        .findByWorkspaceIdAndStatus(eq(WORKSPACE_ID), eq(SimulationFeedbackStatus.OPEN), any());
+  }
+
+  @Test
+  @DisplayName("listFeedback: status 필터 대문자 변환은 기본 Locale 영향을 받지 않는다")
+  void should_listFeedback_parseStatusWithRootLocale() {
+    Locale previousLocale = Locale.getDefault();
+    try {
+      Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+      givenMembership();
+      given(simulationFeedbackRepository.findByWorkspaceIdAndStatus(any(), any(), any()))
+          .willReturn(new DomainPage<>(List.of(), 0, 20, 0, 0));
+
+      service.listFeedback(WORKSPACE_ID, USER_ID, "candidate_created", 0, 20);
+
+      verify(simulationFeedbackRepository)
+          .findByWorkspaceIdAndStatus(
+              eq(WORKSPACE_ID), eq(SimulationFeedbackStatus.CANDIDATE_CREATED), any());
+    } finally {
+      Locale.setDefault(previousLocale);
+    }
+  }
+
+  @Test
+  @DisplayName("listFeedback: status 필터가 없으면 workspace 전체 feedback을 페이지 조회한다")
+  void should_listFeedback_withoutStatus() {
+    givenMembership();
+    SimulationFeedback feedback =
+        withFeedbackId(
+            SimulationFeedback.create(
+                WORKSPACE_ID,
+                55L,
+                null,
+                new SimulationFeedbackContent(
+                    SimulationFeedbackType.OTHER,
+                    "세션 전체 흐름이 어색합니다.",
+                    "질문 순서를 조정합니다.",
+                    SimulationFeedbackSeverity.MEDIUM),
+                USER_ID),
+            901L);
+    given(simulationFeedbackRepository.findByWorkspaceId(any(), any()))
+        .willReturn(new DomainPage<>(List.of(feedback), 0, 20, 1, 1));
+
+    var result = service.listFeedback(WORKSPACE_ID, USER_ID, " ", -1, 0);
+
+    assertThat(result.content()).hasSize(1);
+    verify(simulationFeedbackRepository)
+        .findByWorkspaceId(eq(WORKSPACE_ID), eq(new DomainPageRequest(0, 20)));
+  }
+
+  @Test
+  @DisplayName("createFeedback: workspace 멤버가 아니면 피드백을 작성할 수 없다")
+  void should_throw_when_creatingFeedback_withoutMembership() {
+    CreateSimulationFeedbackCommand command =
+        new CreateSimulationFeedbackCommand(
+            WORKSPACE_ID,
+            55L,
+            USER_ID,
+            null,
+            SimulationFeedbackType.OTHER,
+            "세션 전체 흐름이 어색합니다.",
+            "질문 순서를 조정합니다.",
+            SimulationFeedbackSeverity.MEDIUM);
+
+    assertThatThrownBy(() -> service.createFeedback(command))
+        .isInstanceOf(WorkspaceAccessDeniedException.class)
+        .hasMessageContaining("워크스페이스에 접근 권한이 없습니다.");
+  }
+
+  @Test
+  @DisplayName("listFeedback: workspace 멤버가 아니면 피드백 목록을 조회할 수 없다")
+  void should_throw_when_listingFeedback_withoutMembership() {
+    assertThatThrownBy(() -> service.listFeedback(WORKSPACE_ID, USER_ID, "OPEN", 0, 20))
+        .isInstanceOf(WorkspaceAccessDeniedException.class)
+        .hasMessageContaining("워크스페이스에 접근 권한이 없습니다.");
+  }
+
+  @Test
+  @DisplayName("listFeedback: 지원하지 않는 status 필터는 거절한다")
+  void should_throw_when_feedbackStatusInvalid() {
+    givenMembership();
+
+    assertThatThrownBy(() -> service.listFeedback(WORKSPACE_ID, USER_ID, "WAITING", 0, 20))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("지원하지 않는 피드백 상태입니다");
+  }
+
   private void givenMembership() {
     given(workspaceMemberRepository.findByWorkspaceIdAndUserId(WORKSPACE_ID, USER_ID))
         .willReturn(
@@ -326,6 +580,10 @@ class SimulationServiceTest {
   }
 
   private void givenDetailDependencies(Long sessionId) {
+    givenDetailDependencies(sessionId, List.of());
+  }
+
+  private void givenDetailDependencies(Long sessionId, List<SimulationFeedback> feedbacks) {
     ChatSession session = withId(simulationSession(), sessionId);
     ChatMessage customer = withMessageId(message(sessionId, 1, "USER", "환불 상태 알려주세요"), 1L);
     ChatMessage assistant = withMessageId(message(sessionId, 2, "ASSISTANT", "확인해드릴게요."), 2L);
@@ -364,6 +622,8 @@ class SimulationServiceTest {
                 null,
                 List.of(),
                 List.of()));
+    given(simulationFeedbackRepository.findByChatSessionIdOrderByCreatedAtAsc(sessionId))
+        .willReturn(feedbacks);
   }
 
   private ChatSession simulationSession() {
@@ -416,5 +676,10 @@ class SimulationServiceTest {
   private ChatMessage withMessageId(ChatMessage message, Long id) {
     ReflectionTestUtils.setField(message, "id", id);
     return message;
+  }
+
+  private SimulationFeedback withFeedbackId(SimulationFeedback feedback, Long id) {
+    ReflectionTestUtils.setField(feedback, "id", id);
+    return feedback;
   }
 }

--- a/backend/src/test/java/com/init/workflowruntime/domain/SimulationFeedbackTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/domain/SimulationFeedbackTest.java
@@ -1,0 +1,186 @@
+package com.init.workflowruntime.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.OffsetDateTime;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@DisplayName("SimulationFeedback")
+class SimulationFeedbackTest {
+
+  @Test
+  @DisplayName("create: 피드백 본문을 정규화하고 OPEN 상태로 생성한다")
+  void shouldCreateFeedbackWithNormalizedContent() {
+    SimulationFeedback feedback =
+        SimulationFeedback.create(
+            10L,
+            55L,
+            100L,
+            new SimulationFeedbackContent(
+                SimulationFeedbackType.MISSING_SLOT_QUESTION,
+                "  주문번호를 묻지 않았습니다.  ",
+                "  주문번호를 먼저 요청합니다.  ",
+                SimulationFeedbackSeverity.HIGH),
+            7L);
+
+    assertThat(feedback.getWorkspaceId()).isEqualTo(10L);
+    assertThat(feedback.getChatSessionId()).isEqualTo(55L);
+    assertThat(feedback.getChatMessageId()).isEqualTo(100L);
+    assertThat(feedback.getFeedbackType()).isEqualTo(SimulationFeedbackType.MISSING_SLOT_QUESTION);
+    assertThat(feedback.getDescription()).isEqualTo("주문번호를 묻지 않았습니다.");
+    assertThat(feedback.getExpectedBehavior()).isEqualTo("주문번호를 먼저 요청합니다.");
+    assertThat(feedback.getSeverity()).isEqualTo(SimulationFeedbackSeverity.HIGH);
+    assertThat(feedback.getStatus()).isEqualTo(SimulationFeedbackStatus.OPEN);
+    assertThat(feedback.getCreatedBy()).isEqualTo(7L);
+  }
+
+  @Test
+  @DisplayName("onPersist: 생성/수정 시각과 기본 상태를 채운다")
+  void shouldFillLifecycleDefaultsOnPersist() {
+    SimulationFeedback feedback = feedback();
+    ReflectionTestUtils.setField(feedback, "status", null);
+
+    feedback.onPersist();
+
+    assertThat(feedback.getCreatedAt()).isNotNull();
+    assertThat(feedback.getUpdatedAt()).isNotNull();
+    assertThat(feedback.getStatus()).isEqualTo(SimulationFeedbackStatus.OPEN);
+  }
+
+  @Test
+  @DisplayName("onPersist: 이미 있는 생성/수정 시각과 상태는 유지한다")
+  void shouldKeepExistingLifecycleValuesOnPersist() {
+    SimulationFeedback feedback = feedback();
+    OffsetDateTime createdAt = OffsetDateTime.parse("2026-06-04T10:00:00+09:00");
+    OffsetDateTime updatedAt = OffsetDateTime.parse("2026-06-04T10:05:00+09:00");
+    ReflectionTestUtils.setField(feedback, "createdAt", createdAt);
+    ReflectionTestUtils.setField(feedback, "updatedAt", updatedAt);
+    ReflectionTestUtils.setField(feedback, "status", SimulationFeedbackStatus.RESOLVED);
+
+    feedback.onPersist();
+
+    assertThat(feedback.getCreatedAt()).isEqualTo(createdAt);
+    assertThat(feedback.getUpdatedAt()).isEqualTo(updatedAt);
+    assertThat(feedback.getStatus()).isEqualTo(SimulationFeedbackStatus.RESOLVED);
+  }
+
+  @Test
+  @DisplayName("onUpdate: 수정 시각을 갱신한다")
+  void shouldRefreshUpdatedAtOnUpdate() {
+    SimulationFeedback feedback = feedback();
+    OffsetDateTime updatedAt = OffsetDateTime.parse("2026-06-04T10:05:00+09:00");
+    ReflectionTestUtils.setField(feedback, "updatedAt", updatedAt);
+
+    feedback.onUpdate();
+
+    assertThat(feedback.getUpdatedAt()).isAfter(updatedAt);
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("invalidFeedbackArguments")
+  @DisplayName("create: 필수 입력이 없거나 본문이 유효하지 않으면 거절한다")
+  void shouldRejectInvalidFeedback(String scenario, FeedbackFactory factory, String message) {
+    assertThat(scenario).isNotBlank();
+    assertThatThrownBy(factory::create)
+        .isInstanceOf(InvalidSimulationFeedbackException.class)
+        .hasMessageContaining(message);
+  }
+
+  private static Stream<Arguments> invalidFeedbackArguments() {
+    return Stream.of(
+        Arguments.of(
+            "workspaceId null",
+            (FeedbackFactory) () -> SimulationFeedback.create(null, 55L, null, content(), 7L),
+            "workspaceId must not be null"),
+        Arguments.of(
+            "chatSessionId null",
+            (FeedbackFactory) () -> SimulationFeedback.create(10L, null, null, content(), 7L),
+            "chatSessionId must not be null"),
+        Arguments.of(
+            "content null",
+            (FeedbackFactory) () -> SimulationFeedback.create(10L, 55L, null, null, 7L),
+            "content must not be null"),
+        Arguments.of(
+            "feedbackType null",
+            (FeedbackFactory)
+                () ->
+                    SimulationFeedback.create(
+                        10L,
+                        55L,
+                        null,
+                        new SimulationFeedbackContent(
+                            null, "설명", "기대 행동", SimulationFeedbackSeverity.HIGH),
+                        7L),
+            "feedbackType must not be null"),
+        Arguments.of(
+            "description blank",
+            (FeedbackFactory)
+                () ->
+                    SimulationFeedback.create(
+                        10L,
+                        55L,
+                        null,
+                        new SimulationFeedbackContent(
+                            SimulationFeedbackType.OTHER,
+                            "  ",
+                            "기대 행동",
+                            SimulationFeedbackSeverity.HIGH),
+                        7L),
+            "description must not be blank"),
+        Arguments.of(
+            "expectedBehavior too long",
+            (FeedbackFactory)
+                () ->
+                    SimulationFeedback.create(
+                        10L,
+                        55L,
+                        null,
+                        new SimulationFeedbackContent(
+                            SimulationFeedbackType.OTHER,
+                            "설명",
+                            "a".repeat(2001),
+                            SimulationFeedbackSeverity.HIGH),
+                        7L),
+            "expectedBehavior must be at most 2000"),
+        Arguments.of(
+            "severity null",
+            (FeedbackFactory)
+                () ->
+                    SimulationFeedback.create(
+                        10L,
+                        55L,
+                        null,
+                        new SimulationFeedbackContent(
+                            SimulationFeedbackType.OTHER, "설명", "기대 행동", null),
+                        7L),
+            "severity must not be null"),
+        Arguments.of(
+            "createdBy null",
+            (FeedbackFactory) () -> SimulationFeedback.create(10L, 55L, null, content(), null),
+            "createdBy must not be null"));
+  }
+
+  private static SimulationFeedbackContent content() {
+    return new SimulationFeedbackContent(
+        SimulationFeedbackType.OTHER,
+        "세션 전체 흐름이 어색합니다.",
+        "질문 순서를 조정합니다.",
+        SimulationFeedbackSeverity.MEDIUM);
+  }
+
+  private static SimulationFeedback feedback() {
+    return SimulationFeedback.create(10L, 55L, null, content(), 7L);
+  }
+
+  @FunctionalInterface
+  private interface FeedbackFactory {
+    SimulationFeedback create();
+  }
+}

--- a/backend/src/test/java/com/init/workflowruntime/infrastructure/persistence/SimulationFeedbackRepositoryAdapterTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/infrastructure/persistence/SimulationFeedbackRepositoryAdapterTest.java
@@ -1,0 +1,93 @@
+package com.init.workflowruntime.infrastructure.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import com.init.workflowruntime.domain.DomainPage;
+import com.init.workflowruntime.domain.DomainPageRequest;
+import com.init.workflowruntime.domain.SimulationFeedback;
+import com.init.workflowruntime.domain.SimulationFeedbackContent;
+import com.init.workflowruntime.domain.SimulationFeedbackSeverity;
+import com.init.workflowruntime.domain.SimulationFeedbackStatus;
+import com.init.workflowruntime.domain.SimulationFeedbackType;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SimulationFeedbackRepositoryAdapter")
+class SimulationFeedbackRepositoryAdapterTest {
+
+  @Mock private JpaSimulationFeedbackRepository jpaRepository;
+
+  @Test
+  @DisplayName("findByWorkspaceId: workspace feedback 페이지를 도메인 페이지로 변환한다")
+  void shouldFindFeedbackByWorkspace() {
+    SimulationFeedback feedback = feedback();
+    PageRequest expectedPageRequest = PageRequest.of(1, 10);
+    given(jpaRepository.findByWorkspaceIdOrderByCreatedAtDesc(10L, expectedPageRequest))
+        .willReturn(new PageImpl<>(List.of(feedback), expectedPageRequest, 21));
+    SimulationFeedbackRepositoryAdapter adapter =
+        new SimulationFeedbackRepositoryAdapter(jpaRepository);
+
+    DomainPage<SimulationFeedback> page =
+        adapter.findByWorkspaceId(10L, new DomainPageRequest(1, 10));
+
+    assertThat(page.content()).containsExactly(feedback);
+    assertThat(page.page()).isEqualTo(1);
+    assertThat(page.size()).isEqualTo(10);
+    assertThat(page.totalElements()).isEqualTo(21);
+    assertThat(page.totalPages()).isEqualTo(3);
+  }
+
+  @Test
+  @DisplayName("findByWorkspaceIdAndStatus: status 필터를 JPA repository로 위임한다")
+  void shouldFindFeedbackByWorkspaceAndStatus() {
+    SimulationFeedback feedback = feedback();
+    PageRequest expectedPageRequest = PageRequest.of(0, 20);
+    given(
+            jpaRepository.findByWorkspaceIdAndStatusOrderByCreatedAtDesc(
+                10L, SimulationFeedbackStatus.OPEN, expectedPageRequest))
+        .willReturn(new PageImpl<>(List.of(feedback), expectedPageRequest, 1));
+    SimulationFeedbackRepositoryAdapter adapter =
+        new SimulationFeedbackRepositoryAdapter(jpaRepository);
+
+    DomainPage<SimulationFeedback> page =
+        adapter.findByWorkspaceIdAndStatus(
+            10L, SimulationFeedbackStatus.OPEN, new DomainPageRequest(0, 20));
+
+    assertThat(page.content()).containsExactly(feedback);
+    assertThat(page.totalElements()).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("save/findByChatSessionId...: JPA repository에 단순 위임한다")
+  void shouldDelegateSaveAndSessionLookup() {
+    SimulationFeedback feedback = feedback();
+    given(jpaRepository.save(feedback)).willReturn(feedback);
+    given(jpaRepository.findByChatSessionIdOrderByCreatedAtAsc(55L)).willReturn(List.of(feedback));
+    SimulationFeedbackRepositoryAdapter adapter =
+        new SimulationFeedbackRepositoryAdapter(jpaRepository);
+
+    assertThat(adapter.save(feedback)).isSameAs(feedback);
+    assertThat(adapter.findByChatSessionIdOrderByCreatedAtAsc(55L)).containsExactly(feedback);
+  }
+
+  private SimulationFeedback feedback() {
+    return SimulationFeedback.create(
+        10L,
+        55L,
+        100L,
+        new SimulationFeedbackContent(
+            SimulationFeedbackType.MISSING_SLOT_QUESTION,
+            "주문번호를 묻지 않았습니다.",
+            "주문번호를 먼저 요청합니다.",
+            SimulationFeedbackSeverity.HIGH),
+        7L);
+  }
+}

--- a/backend/src/test/java/com/init/workflowruntime/presentation/SimulationControllerTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/presentation/SimulationControllerTest.java
@@ -8,12 +8,17 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.init.shared.infrastructure.security.JwtAuthenticationFilter;
 import com.init.workflowruntime.application.SimulationService;
+import com.init.workflowruntime.application.command.CreateSimulationFeedbackCommand;
 import com.init.workflowruntime.application.command.CreateSimulationSessionCommand;
 import com.init.workflowruntime.application.command.SendSimulationMessageCommand;
 import com.init.workflowruntime.application.dto.ChatSessionResponse;
+import com.init.workflowruntime.application.dto.SimulationFeedbackSessionResponse;
 import com.init.workflowruntime.application.dto.SimulationSessionDetailResponse;
 import com.init.workflowruntime.application.dto.SimulationSessionPageResponse;
+import com.init.workflowruntime.domain.SimulationFeedbackSeverity;
+import com.init.workflowruntime.domain.SimulationFeedbackType;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -47,7 +52,9 @@ class SimulationControllerTest {
     given(
             simulationService.createSession(
                 new CreateSimulationSessionCommand(10L, 7L, "테스트 고객", null, 501L)))
-        .willReturn(new SimulationSessionDetailResponse(session, List.of(), null, null, List.of()));
+        .willReturn(
+            new SimulationSessionDetailResponse(
+                session, List.of(), null, null, List.of(), emptyFeedback()));
 
     mockMvc
         .perform(
@@ -82,13 +89,54 @@ class SimulationControllerTest {
     given(
             simulationService.sendMessage(
                 new SendSimulationMessageCommand(10L, 55L, 7L, "환불 상태 알려주세요")))
-        .willReturn(new SimulationSessionDetailResponse(session, List.of(), null, null, List.of()));
+        .willReturn(
+            new SimulationSessionDetailResponse(
+                session, List.of(), null, null, List.of(), emptyFeedback()));
 
     mockMvc
         .perform(
             post("/api/v1/workspaces/10/simulation/sessions/55/messages")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"content\":\"환불 상태 알려주세요\"}")
+                .principal(auth()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.session.id").value(55));
+  }
+
+  @Test
+  @DisplayName(
+      "POST /api/v1/workspaces/{workspaceId}/simulation/sessions/{sessionId}/feedback - 피드백 요청 위임")
+  void shouldCreateSimulationFeedback() throws Exception {
+    ChatSessionResponse session = simulationSession(55L);
+    given(
+            simulationService.createFeedback(
+                new CreateSimulationFeedbackCommand(
+                    10L,
+                    55L,
+                    7L,
+                    2L,
+                    SimulationFeedbackType.MISSING_SLOT_QUESTION,
+                    "주문번호를 묻지 않았습니다.",
+                    "주문번호를 먼저 요청합니다.",
+                    SimulationFeedbackSeverity.HIGH)))
+        .willReturn(
+            new SimulationSessionDetailResponse(
+                session, List.of(), null, null, List.of(), emptyFeedback()));
+
+    mockMvc
+        .perform(
+            post("/api/v1/workspaces/10/simulation/sessions/55/feedback")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "chatMessageId": 2,
+                      "feedbackType": "MISSING_SLOT_QUESTION",
+                      "description": "주문번호를 묻지 않았습니다.",
+                      "expectedBehavior": "주문번호를 먼저 요청합니다.",
+                      "severity": "HIGH"
+                    }
+                    """)
                 .principal(auth()))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.session.id").value(55));
@@ -107,5 +155,9 @@ class SimulationControllerTest {
     response.setMetaJson("{\"simulation\":true}");
     response.setResponseMode("AI_ACTIVE");
     return response;
+  }
+
+  private SimulationFeedbackSessionResponse emptyFeedback() {
+    return new SimulationFeedbackSessionResponse(List.of(), Map.of());
   }
 }

--- a/backend/src/test/java/com/init/workflowruntime/presentation/SimulationFeedbackControllerTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/presentation/SimulationFeedbackControllerTest.java
@@ -1,0 +1,57 @@
+package com.init.workflowruntime.presentation;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.init.shared.infrastructure.security.JwtAuthenticationFilter;
+import com.init.workflowruntime.application.SimulationService;
+import com.init.workflowruntime.application.dto.SimulationFeedbackPageResponse;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(
+    value = SimulationFeedbackController.class,
+    excludeFilters =
+        @ComponentScan.Filter(
+            type = FilterType.ASSIGNABLE_TYPE,
+            classes = JwtAuthenticationFilter.class))
+@AutoConfigureMockMvc(addFilters = false)
+class SimulationFeedbackControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private SimulationService simulationService;
+
+  @Test
+  @DisplayName("GET /api/v1/workspaces/{workspaceId}/simulation/feedback - 상태별 목록 반환")
+  void shouldListSimulationFeedback() throws Exception {
+    given(simulationService.listFeedback(10L, 7L, "OPEN", 0, 20))
+        .willReturn(new SimulationFeedbackPageResponse(List.of(), 0, 20, 0, 0));
+
+    mockMvc
+        .perform(
+            get("/api/v1/workspaces/10/simulation/feedback")
+                .param("status", "OPEN")
+                .principal(auth()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.page").value(0))
+        .andExpect(jsonPath("$.content").isArray());
+  }
+
+  private UsernamePasswordAuthenticationToken auth() {
+    return new UsernamePasswordAuthenticationToken(
+        7L, null, List.of(new SimpleGrantedAuthority("ROLE_USER")));
+  }
+}

--- a/frontend/src/features/simulation/api/simulationApi.test.ts
+++ b/frontend/src/features/simulation/api/simulationApi.test.ts
@@ -75,10 +75,9 @@ describe("simulationApi", () => {
 
     const result = await simulationApi.getSession(7, 20);
 
-    expect(mockedCustomFetch).toHaveBeenCalledWith(
-      "/api/v1/workspaces/7/simulation/sessions/20",
-      { method: "GET" },
-    );
+    expect(mockedCustomFetch).toHaveBeenCalledWith("/api/v1/workspaces/7/simulation/sessions/20", {
+      method: "GET",
+    });
     expect(result).toEqual(detail);
   });
 
@@ -102,5 +101,69 @@ describe("simulationApi", () => {
       },
     );
     expect(result).toEqual(detail);
+  });
+
+  it("createFeedback이 session feedback endpoint로 구조화된 피드백을 보낸다", async () => {
+    const detail = {
+      session: { id: 20, channel: "SIMULATION", status: "ACTIVE", metaJson: "{}" },
+      messages: [],
+      matchedWorkflow: null,
+      slotValues: {},
+      slots: [],
+      feedback: { items: [], messageFeedbackCounts: {} },
+    };
+    const payload = {
+      chatMessageId: 2,
+      feedbackType: "MISSING_SLOT_QUESTION" as const,
+      description: "주문번호를 묻지 않았습니다.",
+      expectedBehavior: "주문번호를 먼저 요청합니다.",
+      severity: "HIGH" as const,
+    };
+    mockedCustomFetch.mockResolvedValue({ data: detail });
+
+    const result = await simulationApi.createFeedback(7, 20, payload);
+
+    expect(mockedCustomFetch).toHaveBeenCalledWith(
+      "/api/v1/workspaces/7/simulation/sessions/20/feedback",
+      {
+        method: "POST",
+        body: JSON.stringify(payload),
+      },
+    );
+    expect(result).toEqual(detail);
+  });
+
+  it("listFeedback이 status query와 기본 page shape을 반환한다", async () => {
+    const feedback = [
+      {
+        id: 1,
+        workspaceId: 7,
+        sessionId: 20,
+        chatMessageId: 2,
+        feedbackType: "MISSING_SLOT_QUESTION",
+        description: "주문번호를 묻지 않았습니다.",
+        expectedBehavior: "주문번호를 먼저 요청합니다.",
+        severity: "HIGH",
+        status: "OPEN",
+        createdBy: 3,
+        createdAt: "2026-06-04T10:00:00Z",
+        updatedAt: "2026-06-04T10:00:00Z",
+      },
+    ];
+    mockedCustomFetch.mockResolvedValue({ data: { content: feedback, page: 0, size: 20 } });
+
+    const result = await simulationApi.listFeedback(7, { status: "OPEN", page: 0, size: 20 });
+
+    expect(mockedCustomFetch).toHaveBeenCalledWith(
+      "/api/v1/workspaces/7/simulation/feedback?status=OPEN&page=0&size=20",
+      { method: "GET" },
+    );
+    expect(result).toEqual({
+      content: feedback,
+      page: 0,
+      size: 20,
+      totalElements: 1,
+      totalPages: 0,
+    });
   });
 });

--- a/frontend/src/features/simulation/api/simulationApi.ts
+++ b/frontend/src/features/simulation/api/simulationApi.ts
@@ -9,6 +9,7 @@ export interface SimulationSessionDetail {
   matchedWorkflow: LlmToolWorkflowPayload | null;
   slotValues: Record<string, unknown> | null;
   slots: Array<Record<string, unknown>>;
+  feedback?: SimulationFeedbackSession;
 }
 
 export interface SimulationSessionPage {
@@ -26,6 +27,55 @@ export interface CreateSimulationSessionPayload {
 
 export interface SendSimulationMessagePayload {
   content: string;
+}
+
+export type SimulationFeedbackType =
+  | "INTENT_MISMATCH"
+  | "MISSING_SLOT_QUESTION"
+  | "INAPPROPRIATE_RESPONSE"
+  | "POLICY_CONDITION_MISSING"
+  | "RISK_HANDOFF_REQUIRED"
+  | "WORKFLOW_BRANCH_ERROR"
+  | "OTHER";
+
+export type SimulationFeedbackSeverity = "LOW" | "MEDIUM" | "HIGH" | "CRITICAL";
+
+export type SimulationFeedbackStatus = "OPEN" | "CANDIDATE_CREATED" | "RESOLVED" | "DISMISSED";
+
+export interface SimulationFeedback {
+  id: number;
+  workspaceId: number;
+  sessionId: number;
+  chatMessageId: number | null;
+  feedbackType: SimulationFeedbackType;
+  description: string;
+  expectedBehavior: string;
+  severity: SimulationFeedbackSeverity;
+  status: SimulationFeedbackStatus;
+  createdBy: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface SimulationFeedbackSession {
+  items: SimulationFeedback[];
+  messageFeedbackCounts: Record<string, number>;
+}
+
+export interface SimulationFeedbackPage {
+  content: SimulationFeedback[];
+  page: number;
+  size: number;
+  totalElements: number;
+  totalPages: number;
+}
+
+export interface CreateSimulationFeedbackPayload {
+  chatMessageId?: number | null;
+  feedbackType: SimulationFeedbackType;
+  description: string;
+  expectedBehavior: string;
+  severity: SimulationFeedbackSeverity;
 }
 
 type MaybeWrapped<T> = T | { data?: T };
@@ -102,5 +152,48 @@ export const simulationApi = {
       response,
       "시뮬레이션 메시지 응답을 확인할 수 없습니다.",
     );
+  },
+
+  createFeedback: async (
+    workspaceId: number,
+    sessionId: number,
+    payload: CreateSimulationFeedbackPayload,
+  ): Promise<SimulationSessionDetail> => {
+    const response = await customFetch<MaybeWrapped<SimulationSessionDetail>>(
+      `/api/v1/workspaces/${workspaceId}/simulation/sessions/${sessionId}/feedback`,
+      {
+        method: "POST",
+        body: JSON.stringify(payload),
+      },
+    );
+    return requireApiData<SimulationSessionDetail>(
+      response,
+      "시뮬레이션 피드백 응답을 확인할 수 없습니다.",
+    );
+  },
+
+  listFeedback: async (
+    workspaceId: number,
+    params: { status?: SimulationFeedbackStatus | ""; page?: number; size?: number } = {},
+  ): Promise<SimulationFeedbackPage> => {
+    const searchParams = new URLSearchParams();
+    if (params.status) searchParams.set("status", params.status);
+    if (params.page !== undefined) searchParams.set("page", String(params.page));
+    if (params.size !== undefined) searchParams.set("size", String(params.size));
+    const query = searchParams.toString();
+    const path = query
+      ? `/api/v1/workspaces/${workspaceId}/simulation/feedback?${query}`
+      : `/api/v1/workspaces/${workspaceId}/simulation/feedback`;
+    const response = await customFetch<MaybeWrapped<SimulationFeedbackPage>>(path, {
+      method: "GET",
+    });
+    const data = selectApiData<SimulationFeedbackPage>(response);
+    return {
+      content: data?.content ?? [],
+      page: data?.page ?? 0,
+      size: data?.size ?? 20,
+      totalElements: data?.totalElements ?? data?.content?.length ?? 0,
+      totalPages: data?.totalPages ?? 0,
+    };
   },
 };

--- a/frontend/src/features/simulation/index.ts
+++ b/frontend/src/features/simulation/index.ts
@@ -1,6 +1,13 @@
 export { simulationApi } from "./api/simulationApi";
 export type {
   CreateSimulationSessionPayload,
+  CreateSimulationFeedbackPayload,
+  SimulationFeedback,
+  SimulationFeedbackPage,
+  SimulationFeedbackSeverity,
+  SimulationFeedbackSession,
+  SimulationFeedbackStatus,
+  SimulationFeedbackType,
   SendSimulationMessagePayload,
   SimulationSessionDetail,
   SimulationSessionPage,

--- a/frontend/src/pages/workspace/ui/WorkspaceSimulationPage.test.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceSimulationPage.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { toast } from "sonner";
 
 import { WorkspaceSimulationPage } from "./WorkspaceSimulationPage";
 import { simulationApi } from "@/features/simulation";
@@ -26,6 +27,15 @@ vi.mock("@/features/simulation", () => ({
     createSession: vi.fn(),
     getSession: vi.fn(),
     sendMessage: vi.fn(),
+    createFeedback: vi.fn(),
+    listFeedback: vi.fn(),
+  },
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
   },
 }));
 
@@ -38,6 +48,14 @@ const session = {
   status: "OPEN",
   metaJson: JSON.stringify({ customerName: "테스트 고객" }),
   startedAt: "2026-06-04T10:30:00Z",
+};
+
+const otherSession = {
+  id: 20,
+  channel: "SIMULATION",
+  status: "OPEN",
+  metaJson: JSON.stringify({ customerName: "다른 고객" }),
+  startedAt: "2026-06-04T11:30:00Z",
 };
 
 const detail = {
@@ -60,6 +78,44 @@ const detail = {
   },
   slotValues: { orderNo: "A-100" },
   slots: [],
+  feedback: {
+    items: [
+      {
+        id: 900,
+        workspaceId: 1,
+        sessionId: 10,
+        chatMessageId: 1,
+        feedbackType: "MISSING_SLOT_QUESTION",
+        description: "주문번호를 묻지 않았습니다.",
+        expectedBehavior: "주문번호를 먼저 요청합니다.",
+        severity: "HIGH",
+        status: "OPEN",
+        createdBy: 7,
+        createdAt: "2026-06-04T10:40:00Z",
+        updatedAt: "2026-06-04T10:40:00Z",
+      },
+    ],
+    messageFeedbackCounts: { "1": 1 },
+  },
+};
+
+const otherDetail = {
+  ...detail,
+  session: otherSession,
+  messages: [
+    {
+      id: 3,
+      seqNo: 1,
+      senderRole: "USER",
+      messageType: "TEXT",
+      content: "배송지를 바꾸고 싶어요",
+      createdAt: "2026-06-04T11:31:00Z",
+    },
+  ],
+  feedback: {
+    items: [],
+    messageFeedbackCounts: {},
+  },
 };
 
 function renderPage(path = "/workspaces/1/simulation") {
@@ -98,8 +154,18 @@ beforeEach(() => {
     totalElements: 1,
     totalPages: 1,
   });
-  mockedSimulationApi.getSession.mockResolvedValue(detail);
+  mockedSimulationApi.getSession.mockImplementation(async (_workspaceId, sessionId) =>
+    sessionId === otherSession.id ? otherDetail : detail,
+  );
   mockedSimulationApi.createSession.mockResolvedValue(detail);
+  mockedSimulationApi.createFeedback.mockResolvedValue(detail);
+  mockedSimulationApi.listFeedback.mockResolvedValue({
+    content: detail.feedback.items,
+    page: 0,
+    size: 20,
+    totalElements: 1,
+    totalPages: 1,
+  });
   mockedSimulationApi.sendMessage.mockResolvedValue({
     ...detail,
     messages: [
@@ -164,6 +230,96 @@ describe("WorkspaceSimulationPage", () => {
       });
     });
     expect(await screen.findByText("주문번호를 알려주세요.")).toBeInTheDocument();
+  });
+
+  it("turn 단위 피드백을 작성하고 session 상세를 갱신한다", async () => {
+    renderPage();
+
+    fireEvent.click(await screen.findByLabelText("Turn 1 피드백 대상 선택"));
+    fireEvent.change(screen.getByLabelText("피드백 유형 선택"), {
+      target: { value: "MISSING_SLOT_QUESTION" },
+    });
+    fireEvent.change(screen.getByLabelText("피드백 심각도 선택"), {
+      target: { value: "HIGH" },
+    });
+    fireEvent.change(screen.getByLabelText("설명"), {
+      target: { value: "주문번호를 묻지 않았습니다." },
+    });
+    fireEvent.change(screen.getByLabelText("기대 응답/행동"), {
+      target: { value: "주문번호를 먼저 요청합니다." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "피드백 저장" }));
+
+    await waitFor(() => {
+      expect(mockedSimulationApi.createFeedback).toHaveBeenCalledWith(1, 10, {
+        chatMessageId: 1,
+        feedbackType: "MISSING_SLOT_QUESTION",
+        description: "주문번호를 묻지 않았습니다.",
+        expectedBehavior: "주문번호를 먼저 요청합니다.",
+        severity: "HIGH",
+      });
+    });
+  });
+
+  it("세션을 바꾸면 피드백 입력 상태를 초기화한다", async () => {
+    mockedSimulationApi.listSessions.mockResolvedValue({
+      content: [session, otherSession],
+      page: 0,
+      size: 20,
+      totalElements: 2,
+      totalPages: 1,
+    });
+    renderPage();
+
+    fireEvent.click(await screen.findByLabelText("Turn 1 피드백 대상 선택"));
+    fireEvent.change(screen.getByLabelText("피드백 유형 선택"), {
+      target: { value: "OTHER" },
+    });
+    fireEvent.change(screen.getByLabelText("피드백 심각도 선택"), {
+      target: { value: "CRITICAL" },
+    });
+    fireEvent.change(screen.getByLabelText("설명"), {
+      target: { value: "이전 세션 피드백" },
+    });
+    fireEvent.change(screen.getByLabelText("기대 응답/행동"), {
+      target: { value: "다른 응답" },
+    });
+
+    fireEvent.click(await screen.findByRole("button", { name: /다른 고객/ }));
+
+    await waitFor(() => {
+      expect(mockedSimulationApi.getSession).toHaveBeenCalledWith(1, 20);
+    });
+    await waitFor(() => {
+      expect(screen.getByLabelText("피드백 대상 선택")).toHaveValue("session");
+    });
+    expect(screen.getByLabelText("피드백 유형 선택")).toHaveValue("INTENT_MISMATCH");
+    expect(screen.getByLabelText("피드백 심각도 선택")).toHaveValue("MEDIUM");
+    expect(screen.getByLabelText("설명")).toHaveValue("");
+    expect(screen.getByLabelText("기대 응답/행동")).toHaveValue("");
+  });
+
+  it("피드백 저장 후 목록 새로고침 실패는 저장 실패로 처리하지 않는다", async () => {
+    renderPage();
+
+    expect(await screen.findByText("환불하고 싶어요")).toBeInTheDocument();
+    fireEvent.change(await screen.findByLabelText("설명"), {
+      target: { value: "주문번호를 묻지 않았습니다." },
+    });
+    fireEvent.change(screen.getByLabelText("기대 응답/행동"), {
+      target: { value: "주문번호를 먼저 요청합니다." },
+    });
+    mockedSimulationApi.listFeedback.mockRejectedValueOnce(new Error("refresh failed"));
+    fireEvent.click(screen.getByRole("button", { name: "피드백 저장" }));
+
+    await waitFor(() => {
+      expect(mockedSimulationApi.createFeedback).toHaveBeenCalled();
+    });
+    expect(toast.success).toHaveBeenCalledWith("시뮬레이션 피드백을 남겼습니다.");
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("피드백 목록 새로고침에 실패했습니다.");
+    });
+    expect(toast.error).not.toHaveBeenCalledWith("시뮬레이션 피드백을 저장하지 못했습니다.");
   });
 
   it("Enter 키로 고객 메시지를 전송한다", async () => {

--- a/frontend/src/pages/workspace/ui/WorkspaceSimulationPage.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceSimulationPage.tsx
@@ -1,10 +1,17 @@
 import { useEffect, useMemo, useState } from "react";
 import { Navigate, useOutletContext, useParams } from "react-router-dom";
-import { PlusIcon, RefreshCwIcon, SendIcon } from "lucide-react";
+import { FlagIcon, PlusIcon, RefreshCwIcon, SendIcon } from "lucide-react";
 import { toast } from "sonner";
 
 import { useListAllWorkspaceWorkflows } from "@/entities/workflow";
-import { simulationApi, type SimulationSessionDetail } from "@/features/simulation";
+import {
+  simulationApi,
+  type SimulationFeedback,
+  type SimulationFeedbackSeverity,
+  type SimulationFeedbackStatus,
+  type SimulationFeedbackType,
+  type SimulationSessionDetail,
+} from "@/features/simulation";
 import type { ChatMessage, ChatSession } from "@/features/consultation/api/consultationApi";
 import { parseRouteId } from "@/shared/lib/parseRouteId";
 import type { ShellContext } from "@/shared/ui/ostone/chrome";
@@ -17,6 +24,33 @@ import { EmptyState } from "@/shared/ui/ostone/atoms/EmptyState";
 import styles from "./simulation/workspace-simulation-page.module.css";
 
 const PAGE_SIZE = 20;
+const DEFAULT_FEEDBACK_TYPE: SimulationFeedbackType = "INTENT_MISMATCH";
+const DEFAULT_FEEDBACK_SEVERITY: SimulationFeedbackSeverity = "MEDIUM";
+
+const FEEDBACK_TYPES: Array<{ value: SimulationFeedbackType; label: string }> = [
+  { value: "INTENT_MISMATCH", label: "잘못된 intent 매칭" },
+  { value: "MISSING_SLOT_QUESTION", label: "누락된 slot 질문" },
+  { value: "INAPPROPRIATE_RESPONSE", label: "부적절한 응답 문구" },
+  { value: "POLICY_CONDITION_MISSING", label: "policy 조건 누락" },
+  { value: "RISK_HANDOFF_REQUIRED", label: "risk/handoff 필요" },
+  { value: "WORKFLOW_BRANCH_ERROR", label: "workflow 분기 오류" },
+  { value: "OTHER", label: "기타" },
+];
+
+const FEEDBACK_SEVERITIES: Array<{ value: SimulationFeedbackSeverity; label: string }> = [
+  { value: "LOW", label: "낮음" },
+  { value: "MEDIUM", label: "보통" },
+  { value: "HIGH", label: "높음" },
+  { value: "CRITICAL", label: "긴급" },
+];
+
+const FEEDBACK_STATUSES: Array<{ value: SimulationFeedbackStatus | ""; label: string }> = [
+  { value: "OPEN", label: "OPEN" },
+  { value: "CANDIDATE_CREATED", label: "CANDIDATE_CREATED" },
+  { value: "RESOLVED", label: "RESOLVED" },
+  { value: "DISMISSED", label: "DISMISSED" },
+  { value: "", label: "전체" },
+];
 
 type Meta = {
   customerName?: string;
@@ -68,6 +102,10 @@ function slotEntries(detail: SimulationSessionDetail | null) {
   return Object.entries(values).filter(([, value]) => value !== null && value !== undefined);
 }
 
+function feedbackTypeLabel(type: SimulationFeedbackType): string {
+  return FEEDBACK_TYPES.find((item) => item.value === type)?.label ?? type;
+}
+
 export function WorkspaceSimulationPage() {
   const { workspaceId } = useParams();
   const parsedWorkspaceId = parseRouteId(workspaceId);
@@ -78,10 +116,22 @@ export function WorkspaceSimulationPage() {
   const [customerNameInput, setCustomerNameInput] = useState("시뮬레이션 고객");
   const [workflowDefinitionId, setWorkflowDefinitionId] = useState("");
   const [messageInput, setMessageInput] = useState("");
+  const [feedbackItems, setFeedbackItems] = useState<SimulationFeedback[]>([]);
+  const [feedbackStatusFilter, setFeedbackStatusFilter] = useState<SimulationFeedbackStatus | "">(
+    "OPEN",
+  );
+  const [feedbackTarget, setFeedbackTarget] = useState("session");
+  const [feedbackType, setFeedbackType] = useState<SimulationFeedbackType>(DEFAULT_FEEDBACK_TYPE);
+  const [feedbackSeverity, setFeedbackSeverity] =
+    useState<SimulationFeedbackSeverity>(DEFAULT_FEEDBACK_SEVERITY);
+  const [feedbackDescription, setFeedbackDescription] = useState("");
+  const [feedbackExpectedBehavior, setFeedbackExpectedBehavior] = useState("");
   const [isLoadingSessions, setIsLoadingSessions] = useState(false);
   const [isLoadingDetail, setIsLoadingDetail] = useState(false);
+  const [isLoadingFeedback, setIsLoadingFeedback] = useState(false);
   const [isCreating, setIsCreating] = useState(false);
   const [isSending, setIsSending] = useState(false);
+  const [isSubmittingFeedback, setIsSubmittingFeedback] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const workflows = useListAllWorkspaceWorkflows({ workspaceId: parsedWorkspaceId });
@@ -90,10 +140,28 @@ export function WorkspaceSimulationPage() {
     return workflows.entries.find((entry) => entry.workflowId === numericId) ?? null;
   }, [workflowDefinitionId, workflows.entries]);
 
+  const reloadFeedback = async (status = feedbackStatusFilter) => {
+    if (parsedWorkspaceId === null) return;
+    const page = await simulationApi.listFeedback(parsedWorkspaceId, {
+      status,
+      page: 0,
+      size: PAGE_SIZE,
+    });
+    setFeedbackItems(page.content);
+  };
+
   useEffect(() => {
     setCrumbs(["시뮬레이션"]);
     return () => setCrumbs([]);
   }, [setCrumbs]);
+
+  useEffect(() => {
+    setFeedbackTarget("session");
+    setFeedbackType(DEFAULT_FEEDBACK_TYPE);
+    setFeedbackSeverity(DEFAULT_FEEDBACK_SEVERITY);
+    setFeedbackDescription("");
+    setFeedbackExpectedBehavior("");
+  }, [selectedSessionId]);
 
   useEffect(() => {
     if (parsedWorkspaceId === null) return;
@@ -122,6 +190,32 @@ export function WorkspaceSimulationPage() {
       active = false;
     };
   }, [parsedWorkspaceId, selectedSessionId]);
+
+  useEffect(() => {
+    if (parsedWorkspaceId === null) return;
+
+    let active = true;
+    setIsLoadingFeedback(true);
+    simulationApi
+      .listFeedback(parsedWorkspaceId, {
+        status: feedbackStatusFilter,
+        page: 0,
+        size: PAGE_SIZE,
+      })
+      .then((page) => {
+        if (active) setFeedbackItems(page.content);
+      })
+      .catch(() => {
+        if (active) toast.error("시뮬레이션 피드백 목록을 불러오지 못했습니다.");
+      })
+      .finally(() => {
+        if (active) setIsLoadingFeedback(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [feedbackStatusFilter, parsedWorkspaceId]);
 
   useEffect(() => {
     if (parsedWorkspaceId === null || selectedSessionId === null) {
@@ -195,9 +289,43 @@ export function WorkspaceSimulationPage() {
     }
   };
 
+  const handleSubmitFeedback = async () => {
+    const description = feedbackDescription.trim();
+    const expectedBehavior = feedbackExpectedBehavior.trim();
+    if (!description || !expectedBehavior || detail?.session.id == null) return;
+    const chatMessageId = feedbackTarget === "session" ? null : Number.parseInt(feedbackTarget, 10);
+    setIsSubmittingFeedback(true);
+    try {
+      const nextDetail = await simulationApi.createFeedback(parsedWorkspaceId, detail.session.id, {
+        chatMessageId: Number.isNaN(chatMessageId) ? null : chatMessageId,
+        feedbackType,
+        description,
+        expectedBehavior,
+        severity: feedbackSeverity,
+      });
+      setDetail(nextDetail);
+      setFeedbackDescription("");
+      setFeedbackExpectedBehavior("");
+      toast.success("시뮬레이션 피드백을 남겼습니다.");
+      try {
+        await reloadFeedback();
+      } catch {
+        toast.error("피드백 목록 새로고침에 실패했습니다.");
+      }
+    } catch {
+      toast.error("시뮬레이션 피드백을 저장하지 못했습니다.");
+    } finally {
+      setIsSubmittingFeedback(false);
+    }
+  };
+
   const messages = detail?.messages ?? [];
   const slots = slotEntries(detail);
   const matched = detail?.matchedWorkflow ?? null;
+  const feedbackCounts = detail?.feedback?.messageFeedbackCounts ?? {};
+  const selectedFeedbackTarget = messages.find((message) => String(message.id) === feedbackTarget);
+  const selectedTargetLabel =
+    feedbackTarget === "session" ? "세션 전체" : `Turn ${selectedFeedbackTarget?.seqNo ?? ""}`;
 
   return (
     <div className={styles.pageWrapper}>
@@ -206,8 +334,7 @@ export function WorkspaceSimulationPage() {
           <p className={styles.eyebrow}>Simulation Lab</p>
           <h1 className={styles.pageTitle}>상담 시뮬레이션</h1>
           <p className={styles.pageSubtitle}>
-            운영 중인 Domain Pack 기준으로 고객 문의를 시험하고 매칭된 workflow 상태를
-            확인합니다.
+            운영 중인 Domain Pack 기준으로 고객 문의를 시험하고 매칭된 workflow 상태를 확인합니다.
           </p>
         </div>
         <Button
@@ -333,6 +460,10 @@ export function WorkspaceSimulationPage() {
                     <MessageBubble
                       key={message.id ?? `${message.seqNo ?? index}-${message.createdAt ?? ""}`}
                       message={message}
+                      feedbackCount={message.id ? (feedbackCounts[String(message.id)] ?? 0) : 0}
+                      onFeedbackClick={
+                        message.id ? () => setFeedbackTarget(String(message.id)) : undefined
+                      }
                     />
                   ))
                 )}
@@ -400,19 +531,161 @@ export function WorkspaceSimulationPage() {
               </ul>
             )}
           </div>
+
+          <div className={styles.feedbackPanel}>
+            <div className={styles.feedbackPanelHeader}>
+              <h3>Feedback</h3>
+              <span>{selectedTargetLabel}</span>
+            </div>
+            <label className={styles.feedbackField}>
+              <span>대상</span>
+              <NativeSelect
+                value={feedbackTarget}
+                onChange={(event) => setFeedbackTarget(event.target.value)}
+                aria-label="피드백 대상 선택"
+              >
+                <NativeSelectOption value="session">세션 전체</NativeSelectOption>
+                {messages.map((message) => (
+                  <NativeSelectOption
+                    key={message.id ?? message.seqNo}
+                    value={String(message.id ?? "")}
+                    disabled={message.id == null}
+                  >
+                    Turn {message.seqNo} · {roleLabel(message.senderRole)}
+                  </NativeSelectOption>
+                ))}
+              </NativeSelect>
+            </label>
+            <label className={styles.feedbackField}>
+              <span>유형</span>
+              <NativeSelect
+                value={feedbackType}
+                onChange={(event) => setFeedbackType(event.target.value as SimulationFeedbackType)}
+                aria-label="피드백 유형 선택"
+              >
+                {FEEDBACK_TYPES.map((item) => (
+                  <NativeSelectOption key={item.value} value={item.value}>
+                    {item.label}
+                  </NativeSelectOption>
+                ))}
+              </NativeSelect>
+            </label>
+            <label className={styles.feedbackField}>
+              <span>심각도</span>
+              <NativeSelect
+                value={feedbackSeverity}
+                onChange={(event) =>
+                  setFeedbackSeverity(event.target.value as SimulationFeedbackSeverity)
+                }
+                aria-label="피드백 심각도 선택"
+              >
+                {FEEDBACK_SEVERITIES.map((item) => (
+                  <NativeSelectOption key={item.value} value={item.value}>
+                    {item.label}
+                  </NativeSelectOption>
+                ))}
+              </NativeSelect>
+            </label>
+            <label className={styles.feedbackField}>
+              <span>설명</span>
+              <textarea
+                value={feedbackDescription}
+                onChange={(event) => setFeedbackDescription(event.target.value)}
+                maxLength={2000}
+                rows={3}
+              />
+            </label>
+            <label className={styles.feedbackField}>
+              <span>기대 응답/행동</span>
+              <textarea
+                value={feedbackExpectedBehavior}
+                onChange={(event) => setFeedbackExpectedBehavior(event.target.value)}
+                maxLength={2000}
+                rows={3}
+              />
+            </label>
+            <Button
+              type="button"
+              onClick={handleSubmitFeedback}
+              disabled={
+                isSubmittingFeedback ||
+                detail === null ||
+                !feedbackDescription.trim() ||
+                !feedbackExpectedBehavior.trim()
+              }
+            >
+              <FlagIcon className={styles.buttonIcon} />
+              <span>{isSubmittingFeedback ? "저장 중" : "피드백 저장"}</span>
+            </Button>
+          </div>
+
+          <div className={styles.feedbackListPanel}>
+            <div className={styles.feedbackPanelHeader}>
+              <h3>Workspace Feedback</h3>
+              <NativeSelect
+                value={feedbackStatusFilter}
+                onChange={(event) =>
+                  setFeedbackStatusFilter(event.target.value as SimulationFeedbackStatus | "")
+                }
+                aria-label="피드백 상태 필터"
+              >
+                {FEEDBACK_STATUSES.map((item) => (
+                  <NativeSelectOption key={item.value || "ALL"} value={item.value}>
+                    {item.label}
+                  </NativeSelectOption>
+                ))}
+              </NativeSelect>
+            </div>
+            {isLoadingFeedback ? (
+              <p className={styles.feedbackMuted}>피드백을 불러오는 중입니다.</p>
+            ) : feedbackItems.length === 0 ? (
+              <p className={styles.feedbackMuted}>조건에 맞는 피드백이 없습니다.</p>
+            ) : (
+              <ul className={styles.feedbackList}>
+                {feedbackItems.map((feedback) => (
+                  <li key={feedback.id}>
+                    <strong>{feedbackTypeLabel(feedback.feedbackType)}</strong>
+                    <span>
+                      {feedback.severity} · {feedback.status}
+                    </span>
+                    <p>{feedback.description}</p>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
         </aside>
       </div>
     </div>
   );
 }
 
-function MessageBubble({ message }: { message: ChatMessage }) {
+type MessageBubbleProps = Readonly<{
+  message: ChatMessage;
+  feedbackCount: number;
+  onFeedbackClick?: () => void;
+}>;
+
+function MessageBubble({ message, feedbackCount, onFeedbackClick }: MessageBubbleProps) {
   const isCustomer = message.senderRole === "USER" || message.senderRole === "CUSTOMER";
   return (
     <article className={`${styles.message} ${isCustomer ? styles.messageCustomer : ""}`}>
       <div className={styles.messageMeta}>
         <span>{roleLabel(message.senderRole)}</span>
-        <time>{formatTime(message.createdAt)}</time>
+        <div className={styles.messageActions}>
+          {feedbackCount > 0 ? <span className={styles.feedbackBadge}>{feedbackCount}</span> : null}
+          {onFeedbackClick ? (
+            <button
+              type="button"
+              className={styles.messageFeedbackButton}
+              onClick={onFeedbackClick}
+              aria-label={`Turn ${message.seqNo ?? ""} 피드백 대상 선택`}
+            >
+              <FlagIcon className={styles.buttonIcon} />
+            </button>
+          ) : null}
+          <time>{formatTime(message.createdAt)}</time>
+        </div>
       </div>
       <p>{message.content}</p>
     </article>

--- a/frontend/src/pages/workspace/ui/simulation/workspace-simulation-page.module.css
+++ b/frontend/src/pages/workspace/ui/simulation/workspace-simulation-page.module.css
@@ -264,6 +264,44 @@
   font-weight: 540;
 }
 
+.messageActions {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--s-2);
+}
+
+.feedbackBadge {
+  min-width: 20px;
+  border: 1px solid var(--ink);
+  border-radius: var(--r-pill);
+  color: var(--ink);
+  font-size: 11px;
+  line-height: 1;
+  padding: 4px 7px;
+  text-align: center;
+}
+
+.messageFeedbackButton {
+  display: inline-flex;
+  width: 28px;
+  height: 28px;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--line);
+  border-radius: var(--r-full);
+  background: var(--paper);
+  color: var(--ink-2);
+  cursor: pointer;
+}
+
+.messageFeedbackButton:hover,
+.messageFeedbackButton:focus-visible {
+  outline: none;
+  border-color: var(--ink);
+  color: var(--ink);
+  box-shadow: 0 0 0 3px rgb(0 0 0 / 10%);
+}
+
 .message p {
   margin: var(--s-2) 0 0;
   color: var(--ink);
@@ -300,7 +338,9 @@
 }
 
 .stateList div,
-.slotPanel {
+.slotPanel,
+.feedbackPanel,
+.feedbackListPanel {
   border: 1px solid var(--line);
   border-radius: var(--r-3);
   background: var(--paper-2);
@@ -359,6 +399,106 @@
   color: var(--ink);
   font-weight: 540;
   overflow-wrap: anywhere;
+}
+
+.feedbackPanel,
+.feedbackListPanel {
+  display: grid;
+  gap: var(--s-3);
+  margin-top: var(--s-4);
+}
+
+.feedbackPanelHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--s-3);
+}
+
+.feedbackPanelHeader h3 {
+  margin: 0;
+  color: var(--ink);
+  font-size: 14px;
+  font-weight: 540;
+}
+
+.feedbackPanelHeader span {
+  max-width: 140px;
+  overflow: hidden;
+  color: var(--ink-3);
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.feedbackField {
+  display: grid;
+  gap: var(--s-2);
+  color: var(--ink-2);
+  font-size: 12px;
+  font-weight: 540;
+}
+
+.feedbackField textarea {
+  min-height: 72px;
+  resize: vertical;
+  border: 1px solid hsl(var(--input));
+  border-radius: 8px;
+  background: var(--paper);
+  color: var(--ink);
+  font: inherit;
+  font-size: 13px;
+  line-height: 1.5;
+  padding: var(--s-3);
+}
+
+.feedbackField textarea:focus-visible {
+  outline: none;
+  border-color: hsl(var(--ring));
+  box-shadow: 0 0 0 3px hsl(var(--ring) / 0.5);
+}
+
+.feedbackMuted {
+  margin: 0;
+  color: var(--ink-3);
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.feedbackList {
+  display: grid;
+  gap: var(--s-2);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.feedbackList li {
+  display: grid;
+  gap: var(--s-1);
+  border: 1px solid var(--line);
+  border-radius: var(--r-3);
+  background: var(--paper);
+  padding: var(--s-3);
+}
+
+.feedbackList strong {
+  color: var(--ink);
+  font-size: 13px;
+  font-weight: 540;
+}
+
+.feedbackList span {
+  color: var(--ink-3);
+  font-size: 11px;
+  font-weight: 540;
+}
+
+.feedbackList p {
+  margin: 0;
+  color: var(--ink-2);
+  font-size: 12px;
+  line-height: 1.5;
 }
 
 @media (max-width: 1180px) {


### PR DESCRIPTION
Closes #526

## 변경 사항

- 워크스페이스 멤버가 시뮬레이션 세션 또는 특정 turn에 대해 피드백 유형, 기대 응답/행동, 심각도를 남길 수 있습니다.
- 시뮬레이션 피드백을 `runtime.simulation_feedback`에 운영 상담 로그와 분리 저장하고, 세션 상세에는 turn별 피드백 개수와 피드백 목록을 함께 반환합니다.
- 워크스페이스 단위 피드백 목록 API가 상태 필터(`OPEN`, `CANDIDATE_CREATED`, `RESOLVED`, `DISMISSED`)와 paging을 제공합니다.
- 시뮬레이션 화면에 turn 피드백 마커, 피드백 입력 폼, 상태별 workspace feedback 목록을 추가했습니다.
- 이슈 526 스펙을 `.agent/specs/526.md`에 정리했습니다.

## 검증

- `git diff --check`
- `cd backend && ./gradlew spotlessApply`
- `cd backend && JAVA_HOME=/Users/owen/.cache/codex-runtimes/jdk21/Contents/Home ./gradlew test --tests com.init.workflowruntime.domain.SimulationFeedbackTest --tests com.init.workflowruntime.application.SimulationServiceTest --tests com.init.workflowruntime.presentation.SimulationControllerTest --tests com.init.workflowruntime.presentation.SimulationFeedbackControllerTest --tests com.init.workflowruntime.infrastructure.persistence.SimulationFeedbackRepositoryAdapterTest`
- `cd backend && JAVA_HOME=/Users/owen/.cache/codex-runtimes/jdk21/Contents/Home ./gradlew test jacocoTestReport`
- `cd backend && JAVA_HOME=/Users/owen/.cache/codex-runtimes/jdk21/Contents/Home ./gradlew checkstyleMain checkstyleTest --quiet`
- `cd frontend && pnpm exec eslint src/features/simulation/api/simulationApi.ts src/features/simulation/api/simulationApi.test.ts src/pages/workspace/ui/WorkspaceSimulationPage.tsx src/pages/workspace/ui/WorkspaceSimulationPage.test.tsx`
- `cd frontend && pnpm test -- src/features/simulation/api/simulationApi.test.ts src/pages/workspace/ui/WorkspaceSimulationPage.test.tsx --run`
- `cd frontend && pnpm build`

## 참고

- `cd frontend && pnpm lint -- ...`는 lint script가 전체 저장소를 검사하면서 기존 unrelated lint 오류로 실패합니다. 이번 변경 파일 대상 ESLint는 통과했습니다.
- backend checkstyle 태스크는 기존 warning backlog를 출력할 수 있지만 `BUILD SUCCESSFUL`로 종료됩니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **신기능**
  * 시뮬레이션 세션 내 특정 턴(메시지)에 피드백을 생성할 수 있습니다. 피드백 유형, 심각도, 설명, 기대되는 행동을 함께 제출할 수 있습니다.
  * 워크스페이스 피드백 목록을 조회하고 상태(열림, 후보 생성, 해결, 무시)로 필터링할 수 있습니다.
  * 세션 상세 보기에서 각 메시지별 피드백 개수를 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->