### PR TITLE
fix(infra): 운영 앱에서 원본 ZIP S3 업로드 허용

### DIFF
--- a/infra/terraform/s3.tf
+++ b/infra/terraform/s3.tf
@@ -1,4 +1,9 @@
 locals {
+  raw_input_cors_allowed_origins = distinct(concat(
+    ["https://app.${var.domain_name}"],
+    var.raw_input_cors_allowed_origins
+  ))
+
   s3_buckets = {
     ml_artifacts = {
       name = var.s3_bucket_names.ml_artifacts
@@ -142,21 +147,21 @@ resource "aws_s3_bucket_cors_configuration" "buckets" {
 # Browsers upload raw-file ZIPs straight to the ml_input bucket via presigned
 # PUT, so only the headers required to sign and complete that flow are allowed.
 resource "aws_s3_bucket_cors_configuration" "raw_input" {
-  count = length(var.raw_input_cors_allowed_origins) == 0 ? 0 : 1
+  count = length(local.raw_input_cors_allowed_origins) == 0 ? 0 : 1
 
   bucket = aws_s3_bucket.buckets["ml_input"].id
 
   cors_rule {
     allowed_headers = [
-      "Content-Type",
-      "Content-Length",
+      "content-type",
+      "content-length",
       "x-amz-server-side-encryption",
       "x-amz-content-sha256",
       "x-amz-date",
-      "Authorization"
+      "authorization"
     ]
     allowed_methods = ["PUT", "HEAD", "GET"]
-    allowed_origins = var.raw_input_cors_allowed_origins
+    allowed_origins = local.raw_input_cors_allowed_origins
     expose_headers  = ["ETag"]
     max_age_seconds = 3000
   }

--- a/infra/terraform/terraform.tfvars.example
+++ b/infra/terraform/terraform.tfvars.example
@@ -59,9 +59,9 @@ cors_allowed_origins = [
   "https://app.example.com"
 ]
 
-# Browser origins allowed to presigned-PUT raw-file ZIPs to the ml_input bucket.
+# Additional browser origins allowed to presigned-PUT raw-file ZIPs to the ml_input bucket.
+# https://app.${domain_name} is included automatically.
 raw_input_cors_allowed_origins = [
-  "https://app.example.com"
 ]
 
 # Orphaned pending/ uploads in ml_input expire after this many days.

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -215,7 +215,7 @@ variable "cors_allowed_origins" {
 }
 
 variable "raw_input_cors_allowed_origins" {
-  description = "Browser origins allowed to upload raw-file ZIPs to the ml_input bucket via presigned PUT. Empty disables raw-input CORS."
+  description = "Additional browser origins allowed to upload raw-file ZIPs to the ml_input bucket via presigned PUT. The app domain is always included."
   type        = list(string)
   default     = []
 }


### PR DESCRIPTION
## 변경 사항

- `ml_input` S3 버킷의 raw-file presigned PUT CORS에 `https://app.${domain_name}` 오리진을 기본 포함합니다.
- 브라우저 preflight가 보내는 업로드 요청 헤더(`content-type`, `x-amz-server-side-encryption` 등)를 raw input CORS 허용 헤더에 맞춥니다.
- `raw_input_cors_allowed_origins`는 운영 앱 도메인 외 추가 오리진을 넣는 변수라는 점을 예시와 설명에 반영했습니다.

## 검증

- `terraform -chdir=infra/terraform init -backend=false`
- `terraform -chdir=infra/terraform validate`
- `git diff --check`

## 참고

- 원인은 운영 앱(`https://app.ajou-cstone.com`)에서 `ostone-prod-ml-input` presigned PUT을 호출할 때 S3 preflight 응답에 허용 오리진이 없어 브라우저 CORS 검사를 통과하지 못한 것입니다.
- 운영 반영에는 Terraform apply가 필요합니다.