### PR TITLE
fix(upload): 도메인팩 초안 생성 중복 트리거 방지

### DIFF
--- a/.agent/specs/551.md
+++ b/.agent/specs/551.md
@@ -1,0 +1,109 @@
+# Backend DDD Spec
+
+## Goal
+
+같은 workspace/dataset에 대한 Domain Pack Generation trigger가 빠르게 반복되어도 pipeline job은 하나만 유지되고, 사용자는 기존 진행 중 job 상태를 명확히 확인할 수 있다.
+
+## Background
+
+상담 로그 업로드 후 `도메인팩 초안 생성 시작` 버튼은 프론트엔드의 `frontend/src/features/log-upload/ui/LogUploadForm.tsx`에서 호출된다. 실제 trigger API는 `backend/src/main/java/com/init/pipelinejob/presentation/DomainPackGenerationTriggerController.java`가 받고, `backend/src/main/java/com/init/pipelinejob/application/TriggerDomainPackGenerationUseCase.java`가 pipeline job 생성과 Airflow trigger를 조율한다.
+
+현재 백엔드는 `backend/src/main/java/com/init/pipelinejob/infrastructure/persistence/PostgreSqlDomainPackGenerationConcurrencyGuard.java`의 advisory lock과 active job 조회로 중복 생성 경로를 제한하지만, active job이 있으면 충돌 오류로 응답한다. 이 방식은 새 job 생성을 막더라도 사용자에게 이미 진행 중인 job으로 이어지는 명확한 성공 상태를 제공하지 못한다.
+
+## Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    actor user as User
+    participant form as LogUploadForm
+    participant ctrl as DomainPackGenerationTriggerController
+    participant usecase as TriggerDomainPackGenerationUseCase
+    participant repo as PipelineJobRepository
+    participant airflow as Airflow
+
+    user ->> form: 도메인팩 초안 생성 시작 클릭
+    form ->> form: in-flight guard 활성화
+    form ->> ctrl: POST /api/v1/workspaces/{workspaceId}/datasets/{datasetId}/pipeline-jobs/domain-pack-generation
+    ctrl ->> usecase: execute(command)
+    usecase ->> repo: findActiveDomainPackGenerationJob(workspaceId, datasetId)
+    alt active job exists
+        repo -->> usecase: active PipelineJob
+        usecase -->> ctrl: existing job result
+        ctrl -->> form: existing job status
+    else no active job
+        usecase ->> repo: save QUEUED job
+        usecase ->> airflow: trigger DAG
+        usecase ->> repo: mark RUNNING
+        usecase -->> ctrl: new job result
+        ctrl -->> form: new job status
+    end
+    form ->> form: 성공/실패 상태 표시 및 guard 해제
+```
+
+## Scope
+
+- `frontend/src/features/log-upload/ui/LogUploadForm.tsx`
+  - 생성 요청 pending 중 CTA를 비활성화한다.
+  - 빠른 중복 클릭과 toast retry action의 중복 실행을 방지한다.
+  - 요청 실패 후 재시도는 같은 dataset 기준으로 한 번씩만 다시 요청한다.
+- `backend/src/main/java/com/init/pipelinejob/application/TriggerDomainPackGenerationUseCase.java`
+  - active Domain Pack Generation job이 있으면 새 job과 Airflow trigger를 만들지 않고 기존 job 결과를 반환한다.
+  - 기존 active job 상태는 클라이언트가 검토 화면 이동이나 상태 표시를 할 수 있도록 기존 response 형태로 전달한다.
+- 테스트
+  - `backend/src/test/java/com/init/pipelinejob/application/TriggerDomainPackGenerationUseCaseTest.java`
+  - `frontend/src/features/log-upload/ui/LogUploadForm.test.tsx`
+
+## Non-goals
+
+- Airflow DAG 내부 idempotency 변경은 포함하지 않는다.
+- 이미 final 상태인 과거 job의 재사용 정책은 변경하지 않는다.
+- generated OpenAPI 파일을 직접 수정하지 않는다.
+- 관리자 retry 정책 전반을 재설계하지 않는다.
+
+## REST API
+
+| Method | Path | Description |
+| --- | --- | --- |
+| POST | `/api/v1/workspaces/{workspaceId}/datasets/{datasetId}/pipeline-jobs/domain-pack-generation` | Domain Pack Generation pipeline job trigger 또는 기존 active job 반환 |
+
+### Response
+
+새 trigger와 중복 trigger 모두 기존 `DomainPackGenerationTriggerResponse` 형태를 유지한다.
+
+```json
+{
+  "pipelineJobId": 123,
+  "workspaceId": 1,
+  "datasetId": 7,
+  "jobType": "DOMAIN_PACK_GENERATION",
+  "status": "RUNNING",
+  "airflowDagId": "domain_pack_generation",
+  "airflowRunId": "pipeline_job_123",
+  "requestedAt": "2026-05-04T10:00:00Z",
+  "startedAt": "2026-05-04T10:00:01Z"
+}
+```
+
+## Requirements
+
+- 같은 workspace/dataset에 active Domain Pack Generation job이 있으면 backend는 새 `PipelineJob`을 저장하지 않는다.
+- active job이 있을 때 backend는 Airflow trigger port를 호출하지 않는다.
+- active job 반환 전에 workspace 존재, 사용자 role, dataset 소속 검증은 유지한다.
+- 정상 신규 trigger 경로의 quota 검증과 무료 온보딩 claim 동작은 유지한다.
+- 생성 버튼은 업로드된 dataset id가 없거나 생성 요청이 pending일 때 비활성화된다.
+- 빠른 중복 클릭은 한 번의 mutation 호출로 수렴한다.
+- 실패 상태의 재시도 버튼도 pending 중 중복 실행되지 않는다.
+- duplicate active job은 프론트엔드에서 실패가 아니라 기존 job id/status를 가진 성공 상태로 표시된다.
+
+## Acceptance Criteria
+
+- 같은 dataset에서 생성 버튼을 여러 번 눌러도 backend `saveAndFlush`와 Airflow trigger는 추가 실행되지 않는다.
+- active job이 있는 backend 요청은 기존 `pipelineJobId`와 `status`를 포함한 response를 반환한다.
+- 생성 요청 중 사용자는 `생성 요청 중` 상태를 보고 CTA 중복 클릭을 할 수 없다.
+- 요청 실패 후 `다시 생성 요청`을 빠르게 반복해도 mutation은 한 번씩만 실행된다.
+- backend와 frontend 테스트가 중복 방어 동작을 검증한다.
+
+## Validation
+
+- `cd backend && ./gradlew test --tests com.init.pipelinejob.application.TriggerDomainPackGenerationUseCaseTest`
+- `cd frontend && pnpm test -- LogUploadForm.test.tsx`

--- a/backend/src/main/java/com/init/pipelinejob/application/TriggerDomainPackGenerationUseCase.java
+++ b/backend/src/main/java/com/init/pipelinejob/application/TriggerDomainPackGenerationUseCase.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.init.pipelinejob.application.exception.AirflowTriggerFailedException;
 import com.init.pipelinejob.application.exception.DatasetNotFoundException;
-import com.init.pipelinejob.application.exception.PipelineJobAlreadyRunningException;
 import com.init.pipelinejob.application.exception.PipelineJobWorkspaceAccessDeniedException;
 import com.init.pipelinejob.application.exception.PipelineJobWorkspaceNotFoundException;
 import com.init.pipelinejob.domain.model.PipelineJob;
@@ -15,6 +14,7 @@ import com.init.shared.application.quota.WorkspaceQuotaValidator;
 import com.init.workspace.application.WorkspaceFreeOnboardingService;
 import java.time.Clock;
 import java.time.OffsetDateTime;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 import org.springframework.stereotype.Service;
@@ -67,18 +67,21 @@ public class TriggerDomainPackGenerationUseCase {
   }
 
   public TriggerDomainPackGenerationResult execute(TriggerDomainPackGenerationCommand command) {
-    CreatedPipelineJob createdJob = createQueuedPipelineJob(command);
+    TriggerPreparation preparation = prepareTrigger(command);
+    if (!preparation.created()) {
+      return toResult(preparation.job());
+    }
 
     try {
       triggerPort.trigger(
           DomainPackGenerationTriggerCommand.initial(
               command.workspaceId(),
               command.datasetId(),
-              createdJob.pipelineJobId(),
-              createdJob.airflowRunId(),
-              createdJob.objectKey()));
+              preparation.job().getId(),
+              preparation.job().getAirflowRunId(),
+              preparation.objectKey()));
     } catch (AirflowTriggerFailedException ex) {
-      markFailed(createdJob.pipelineJobId(), ex.getMessage());
+      markFailed(preparation.job().getId(), ex.getMessage());
       throw ex;
     }
 
@@ -87,11 +90,11 @@ public class TriggerDomainPackGenerationUseCase {
             () -> {
               PipelineJob job =
                   pipelineJobRepository
-                      .findById(createdJob.pipelineJobId())
+                      .findById(preparation.job().getId())
                       .orElseThrow(
                           () ->
                               new IllegalStateException(
-                                  "생성된 pipeline job을 찾을 수 없습니다. id=" + createdJob.pipelineJobId()));
+                                  "생성된 pipeline job을 찾을 수 없습니다. id=" + preparation.job().getId()));
               if (!PipelineJob.STATUS_QUEUED.equals(job.getStatus())) {
                 return job;
               }
@@ -102,17 +105,17 @@ public class TriggerDomainPackGenerationUseCase {
     return toResult(runningJob);
   }
 
-  private CreatedPipelineJob createQueuedPipelineJob(TriggerDomainPackGenerationCommand command) {
+  private TriggerPreparation prepareTrigger(TriggerDomainPackGenerationCommand command) {
     return executeInTransaction(
         () -> {
           concurrencyGuard.lockTriggerCreation(command.workspaceId(), command.datasetId());
           validateAccess(command);
-          pipelineJobRepository
-              .findActiveDomainPackGenerationJob(command.workspaceId(), command.datasetId())
-              .ifPresent(
-                  job -> {
-                    throw new PipelineJobAlreadyRunningException(job.getId(), job.getStatus());
-                  });
+          Optional<PipelineJob> activeJob =
+              pipelineJobRepository.findActiveDomainPackGenerationJob(
+                  command.workspaceId(), command.datasetId());
+          if (activeJob.isPresent()) {
+            return TriggerPreparation.existing(activeJob.get());
+          }
           workspaceQuotaValidator.assertPipelineRunAllowed(command.workspaceId());
 
           String dagId = triggerPort.dagId();
@@ -132,7 +135,7 @@ public class TriggerDomainPackGenerationUseCase {
           PipelineJob queuedJob = pipelineJobRepository.saveAndFlush(savedJob);
           freeOnboardingService.claimGenerationIfNeeded(
               command.workspaceId(), command.datasetId(), queuedJob.getId());
-          return new CreatedPipelineJob(queuedJob.getId(), queuedJob.getAirflowRunId(), objectKey);
+          return TriggerPreparation.created(queuedJob, objectKey);
         });
   }
 
@@ -226,5 +229,14 @@ public class TriggerDomainPackGenerationUseCase {
     return transactionTemplate.execute(status -> callback.get());
   }
 
-  private record CreatedPipelineJob(Long pipelineJobId, String airflowRunId, String objectKey) {}
+  private record TriggerPreparation(PipelineJob job, String objectKey, boolean created) {
+
+    static TriggerPreparation existing(PipelineJob job) {
+      return new TriggerPreparation(job, null, false);
+    }
+
+    static TriggerPreparation created(PipelineJob job, String objectKey) {
+      return new TriggerPreparation(job, objectKey, true);
+    }
+  }
 }

--- a/backend/src/test/java/com/init/pipelinejob/application/TriggerDomainPackGenerationUseCaseTest.java
+++ b/backend/src/test/java/com/init/pipelinejob/application/TriggerDomainPackGenerationUseCaseTest.java
@@ -7,12 +7,12 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.init.pipelinejob.application.exception.AirflowConfigurationInvalidException;
 import com.init.pipelinejob.application.exception.AirflowTriggerFailedException;
-import com.init.pipelinejob.application.exception.PipelineJobAlreadyRunningException;
 import com.init.pipelinejob.application.exception.PipelineJobWorkspaceAccessDeniedException;
 import com.init.pipelinejob.domain.model.PipelineJob;
 import com.init.pipelinejob.domain.repository.PipelineJobRepository;
@@ -160,19 +160,26 @@ class TriggerDomainPackGenerationUseCaseTest {
   }
 
   @Test
-  @DisplayName("active job이 있으면 409 예외를 던진다")
-  void execute_activeJob_throwsAlreadyRunning() {
+  @DisplayName("active job이 있으면 기존 job을 반환하고 새 Airflow trigger를 만들지 않는다")
+  void execute_activeJob_returnsExistingJob() {
     allowAccess();
     given(pipelineJobRepository.findActiveDomainPackGenerationJob(1L, 7L))
         .willReturn(Optional.of(pipelineJob(11L, PipelineJob.STATUS_RUNNING)));
 
-    assertThatThrownBy(() -> useCase.execute(command()))
-        .isInstanceOf(PipelineJobAlreadyRunningException.class);
+    TriggerDomainPackGenerationResult result = useCase.execute(command());
+
+    assertThat(result.pipelineJobId()).isEqualTo(11L);
+    assertThat(result.status()).isEqualTo(PipelineJob.STATUS_RUNNING);
+    verify(pipelineJobRepository, never()).saveAndFlush(any());
+    verify(triggerPort, never()).dagId();
+    verify(triggerPort, never()).trigger(any());
+    verify(workspaceQuotaValidator, never()).assertPipelineRunAllowed(any());
+    verify(freeOnboardingService, never()).claimGenerationIfNeeded(any(), any(), any());
   }
 
   @Test
-  @DisplayName("대기 콜백 상태까지 active job으로 판단해 중복 실행을 막는다")
-  void execute_callbackWaitingStatuses_throwAlreadyRunning() {
+  @DisplayName("대기 콜백 상태까지 active job으로 판단해 기존 job을 반환한다")
+  void execute_callbackWaitingStatuses_returnExistingJob() {
     allowAccess();
     given(pipelineJobRepository.findActiveDomainPackGenerationJob(1L, 7L))
         .willAnswer(invocation -> Optional.of(pipelineJob(11L, activeStatus.get())));
@@ -181,17 +188,23 @@ class TriggerDomainPackGenerationUseCaseTest {
         new String[] {
           PipelineJob.STATUS_QUEUED,
           PipelineJob.STATUS_RUNNING,
+          PipelineJob.STATUS_WAITING_DOMAIN_CONFIRMATION,
+          PipelineJob.STATUS_WAITING_HUMAN_FEEDBACK,
           PipelineJob.STATUS_WAITING_INTENT_CALLBACK,
           PipelineJob.STATUS_WAITING_WORKFLOW_CALLBACK
         }) {
       activeStatus.set(status);
 
-      assertThatThrownBy(() -> useCase.execute(command()))
-          .as("status=%s", status)
-          .isInstanceOf(PipelineJobAlreadyRunningException.class);
+      TriggerDomainPackGenerationResult result = useCase.execute(command());
+
+      assertThat(result.status()).as("status=%s", status).isEqualTo(status);
     }
 
     verify(triggerPort, never()).trigger(any());
+    verify(pipelineJobRepository, never()).saveAndFlush(any());
+    verify(workspaceQuotaValidator, never()).assertPipelineRunAllowed(any());
+    verify(freeOnboardingService, times(6)).assertCanTriggerDomainPackGeneration(1L, 7L);
+    verify(freeOnboardingService, never()).claimGenerationIfNeeded(any(), any(), any());
   }
 
   @Test

--- a/frontend/src/features/log-upload/ui/LogUploadForm.test.tsx
+++ b/frontend/src/features/log-upload/ui/LogUploadForm.test.tsx
@@ -37,6 +37,7 @@ let startError = "업로드 실패";
 let lastStartParams: StartParams | null = null;
 let callTriggerOnSuccess: ((response: unknown, variables: TriggerVariables) => void) | null = null;
 let callTriggerOnError: ((error: unknown) => void) | null = null;
+let mockTriggerIsPending = false;
 
 vi.mock("../model/useRawFileUpload", () => ({
   useRawFileUpload: () => ({
@@ -81,7 +82,7 @@ vi.mock(
         mutate: (...args: unknown[]) => {
           mockTriggerMutate(...args);
         },
-        isPending: false,
+        isPending: mockTriggerIsPending,
         reset: mockTriggerReset,
       };
     },
@@ -142,6 +143,7 @@ describe("LogUploadForm", () => {
     lastStartParams = null;
     callTriggerOnSuccess = null;
     callTriggerOnError = null;
+    mockTriggerIsPending = false;
   });
 
   it("renders upload header and file uploader", () => {
@@ -324,6 +326,33 @@ describe("LogUploadForm", () => {
     expect(mockTriggerMutate).toHaveBeenCalledWith({ workspaceId: 1, datasetId: 42 });
   });
 
+  it("ignores rapid duplicate generation clicks before pending state re-renders", () => {
+    render(<LogUploadForm workspaceId={1} />, { wrapper: MemoryRouter });
+    const file = new File(["data"], "data.zip", { type: "application/zip" });
+    const input = screen.getByTestId("file-input");
+    fireEvent.change(input, { target: { files: [file] } });
+    fireEvent.click(screen.getByText("처리 시작"));
+
+    const triggerButton = screen.getByText("도메인팩 초안 생성 시작");
+    fireEvent.click(triggerButton);
+    fireEvent.click(triggerButton);
+
+    expect(mockTriggerMutate).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("생성 요청 중")).toBeInTheDocument();
+  });
+
+  it("disables generation CTA while mutation is pending", () => {
+    mockTriggerIsPending = true;
+
+    render(<LogUploadForm workspaceId={1} />, { wrapper: MemoryRouter });
+    const file = new File(["data"], "data.zip", { type: "application/zip" });
+    const input = screen.getByTestId("file-input");
+    fireEvent.change(input, { target: { files: [file] } });
+    fireEvent.click(screen.getByText("처리 시작"));
+
+    expect(screen.getByText("도메인팩 초안 생성 시작").closest("button")).toBeDisabled();
+  });
+
   it("shows review CTA after generation request succeeds with pipeline job id", () => {
     render(<LogUploadForm workspaceId={1} />, { wrapper: MemoryRouter });
     const file = new File(["data"], "data.zip", { type: "application/zip" });
@@ -377,7 +406,9 @@ describe("LogUploadForm", () => {
 
     expect(screen.getByText("생성 요청 실패")).toBeInTheDocument();
     expect(screen.getByText("Airflow 연결 실패")).toBeInTheDocument();
-    fireEvent.click(screen.getByText("다시 생성 요청"));
+    const retryButton = screen.getByText("다시 생성 요청");
+    fireEvent.click(retryButton);
+    fireEvent.click(retryButton);
     expect(mockTriggerMutate).toHaveBeenCalledTimes(2);
   });
 

--- a/frontend/src/features/log-upload/ui/LogUploadForm.tsx
+++ b/frontend/src/features/log-upload/ui/LogUploadForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 import { toast } from "sonner";
 import { useNavigate } from "react-router-dom";
 
@@ -88,16 +88,19 @@ export const LogUploadForm: React.FC<LogUploadFormProps> = ({
   const [status, setStatus] = useState<UploadStatus>("idle");
   const [uploadedDataset, setUploadedDataset] = useState<UploadedDataset | null>(null);
   const [generationStatus, setGenerationStatus] = useState<GenerationStatus>({ kind: "idle" });
+  const generationRequestInFlightRef = useRef(false);
 
   const rawFileUpload = useRawFileUpload();
 
   const generationMutation = useTriggerDomainPackGeneration({
     mutation: {
       onSuccess: (response) => {
+        generationRequestInFlightRef.current = false;
         setGenerationStatus({ kind: "success", ...readGenerationResponse(response) });
         toast.success("도메인팩 초안 생성 요청 완료");
       },
       onError: (error) => {
+        generationRequestInFlightRef.current = false;
         const message = getErrorMessage(error, "도메인팩 초안 생성 요청에 실패했습니다.");
         setGenerationStatus({ kind: "error", message });
         toast.error(message, {
@@ -132,6 +135,7 @@ export const LogUploadForm: React.FC<LogUploadFormProps> = ({
     setStatus("idle");
     setUploadedDataset(null);
     setGenerationStatus({ kind: "idle" });
+    generationRequestInFlightRef.current = false;
     rawFileUpload.reset();
     generationMutation.reset();
   };
@@ -152,6 +156,7 @@ export const LogUploadForm: React.FC<LogUploadFormProps> = ({
           fileName: fileToUpload.name,
         });
         setGenerationStatus({ kind: "idle" });
+        generationRequestInFlightRef.current = false;
         setStatus("success");
         toast.success("업로드 완료");
       },
@@ -159,6 +164,7 @@ export const LogUploadForm: React.FC<LogUploadFormProps> = ({
         setStatus("idle");
         setUploadedDataset(null);
         setGenerationStatus({ kind: "idle" });
+        generationRequestInFlightRef.current = false;
         toast.error(message, {
           action: {
             label: "재시도",
@@ -179,7 +185,11 @@ export const LogUploadForm: React.FC<LogUploadFormProps> = ({
       toast.error("생성 요청에 필요한 데이터셋 정보를 확인할 수 없습니다.");
       return;
     }
+    if (generationRequestInFlightRef.current || generationMutation.isPending) {
+      return;
+    }
 
+    generationRequestInFlightRef.current = true;
     setGenerationStatus({ kind: "triggering" });
     generationMutation.mutate({
       workspaceId,
@@ -194,6 +204,7 @@ export const LogUploadForm: React.FC<LogUploadFormProps> = ({
     setUploadedDataset(null);
     setStatus("idle");
     setGenerationStatus({ kind: "idle" });
+    generationRequestInFlightRef.current = false;
   };
 
   const domainPacksPath = workspaceId ? `/workspaces/${workspaceId}/domain-packs` : "/workspaces";
@@ -274,7 +285,10 @@ export const LogUploadForm: React.FC<LogUploadFormProps> = ({
                 <Button variant="secondary" onClick={handleReset}>
                   다른 파일 업로드
                 </Button>
-                <Button onClick={handleStartGeneration} disabled={!canStartGeneration}>
+                <Button
+                  onClick={handleStartGeneration}
+                  disabled={!canStartGeneration || isGenerationPending}
+                >
                   도메인팩 초안 생성 시작
                 </Button>
               </div>
@@ -303,7 +317,10 @@ export const LogUploadForm: React.FC<LogUploadFormProps> = ({
                 <Button variant="secondary" onClick={handleReset}>
                   다른 파일 업로드
                 </Button>
-                <Button onClick={handleStartGeneration} disabled={!canStartGeneration}>
+                <Button
+                  onClick={handleStartGeneration}
+                  disabled={!canStartGeneration || isGenerationPending}
+                >
                   다시 생성 요청
                 </Button>
               </div>


### PR DESCRIPTION
Closes #551

## 변경 사항

- 업로드 화면의 도메인팩 초안 생성 버튼이 요청 pending 상태와 빠른 중복 클릭 구간에서 한 번만 mutation을 실행하도록 막았습니다.
- 동일 workspace/dataset에 active Domain Pack Generation job이 있으면 백엔드가 새 pipeline job과 Airflow trigger를 만들지 않고 기존 job 상태를 반환합니다.
- 이슈 551 스펙을 `.agent/specs/551.md`에 정리했습니다.

## 검증

- `git diff --check`
- `cd backend && ./gradlew test --tests com.init.pipelinejob.application.TriggerDomainPackGenerationUseCaseTest spotlessCheck`
- `cd frontend && pnpm test -- LogUploadForm.test.tsx`
- `cd frontend && pnpm exec eslint src/features/log-upload/ui/LogUploadForm.tsx src/features/log-upload/ui/LogUploadForm.test.tsx`

## 참고

- `cd frontend && pnpm lint`는 기존 unrelated lint 오류 58개로 실패합니다. 이번 변경 파일 대상 ESLint는 통과했습니다.