### PR TITLE
feat(dashboard): 워크플로우 상세 병목 분석 제공

### DIFF
--- a/.agent/specs/521.md
+++ b/.agent/specs/521.md
@@ -1,555 +1,187 @@
-# 521. Get Current Workflow LLM Tool
+# 521. 워크플로우 상세 병목 분석
 
 ## Goal
 
-외부 LLM이 현재 상담 세션에 묶인 워크플로우 그래프(`pack.workflow_definition.graph_json` 포함)와 현재 실행 메타데이터(`runtime.workflow_execution.status`, `current_state`)를 한 번에 조회할 수 있는 REST tool을 제공한다.
-
-이 endpoint는 결정론적 워크플로우 엔진의 입구다. LLM은 본 응답의 graph + currentState를 기준으로 다음 액션 후보를 좁힌다.
-
-본 spec은 5.2.x tool 시리즈 중 첫 번째이며, 기존 4개 slot tool (5.2.x 시리즈가 아닌 5.2.3에 문서화됨, 코드는 같은 base path) 옆에 5번째 tool로 추가된다. 5.2.2~5.2.4가 같은 DTO를 공유한다는 청사진은 source materials의 fact가 아니므로 본 spec 범위 밖이다 (`uncertainty-register-521.md` U-005 참조).
-
----
+워크플로우 상세 화면에서 운영 실행 로그를 기준으로 상태 전이, 병목 state, slot/policy/risk hit, 상담사 개입 지점을 확인할 수 있게 한다.
 
 ## Background
 
-### 기존 인프라 (재사용)
+고객사는 핫패스 workflow가 어디서 막히는지 이해하고, 어떤 slot/policy/risk를 검토해야 하는지 판단해야 한다. 선행 이슈 #517은 워크스페이스 대시보드 셸을 제공했고, #519는 workflow 랭킹과 상세 이동 경로를 제공했다. 이번 범위는 그 상세 화면에서 특정 workflow의 병목 원인을 분석하는 기능이다.
 
-- `LlmToolController` (`backend/src/main/java/com/init/workflowruntime/presentation/LlmToolController.java`): base path `/api/v1/llm-tools/sessions/{sessionId}`, 기존 4개 slot endpoint.
-- `LlmToolService` (`backend/src/main/java/com/init/workflowruntime/application/LlmToolService.java`): `ChatSessionRepository`, `WorkflowExecutionRepository`, `SlotDefinitionRepository`, `IntentSlotBindingRepository`, `ObjectMapper` 주입. `findExecution(sessionId)` private helper는 `workflowExecutionRepository.findTopByChatSessionIdOrderByStartedAtDescIdDesc(sessionId).orElse(null)` 형태로 최신 execution을 반환.
-- `WorkflowExecution` (`backend/src/main/java/com/init/workflowruntime/domain/WorkflowExecution.java`): `workflowDefinitionId` 컬럼은 nullable. `WorkflowExecution.create(sessionId)` factory는 `workflowDefinitionId`를 null로 둔다.
-- `WorkflowDefinition` (`backend/src/main/java/com/init/domainpack/domain/model/WorkflowDefinition.java`): `pack.workflow_definition` 매핑. `graphJson`, `initialState`, `terminalStatesJson` 필드 Java type은 모두 `String`이며 `@JdbcTypeCode(SqlTypes.JSON)`로 jsonb에 저장.
-- `WorkflowDefinitionRepository` (`backend/src/main/java/com/init/domainpack/domain/repository/WorkflowDefinitionRepository.java`): `findByIdAndDomainPackVersionId(Long id, Long domainPackVersionId)` 기존 메서드 보유. **단독 `findById(Long id)` 메서드는 의도적으로 추가하지 않는다** (U-004 결정).
-- Security: `/api/v1/llm-tools/**` → `ROLE_OPERATOR` (`backend/src/main/java/com/init/shared/infrastructure/security/SecurityConfig.java:65-66`). 본 endpoint도 동일 규칙으로 자동 보호된다.
+확인된 기존 경로와 모듈:
 
-### DB DDL (이미 존재)
+| Path | 역할 |
+| --- | --- |
+| `backend/src/main/java/com/init/workflowruntime/presentation/WorkspaceWorkflowRankingController.java` | 대시보드 workflow 랭킹 API |
+| `backend/src/main/java/com/init/workflowruntime/application/WorkspaceWorkflowRankingService.java` | 기간 해석과 멤버십 검증 패턴 |
+| `backend/src/main/java/com/init/workflowruntime/infrastructure/persistence/JpaWorkflowRankingRepository.java` | 운영 상담/simulation 제외 SQL 패턴 |
+| `backend/src/main/java/com/init/workflowruntime/domain/WorkflowExecutionStep.java` | state transition 로그 |
+| `backend/src/main/java/com/init/workflowruntime/domain/DecisionLog.java` | missing slot, policy hit, risk hit 로그 |
+| `frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.tsx` | workflow 상세 화면 |
+| `frontend/src/features/consultation/api/consultationApi.ts` | OpenAPI 미생성 dashboard API 수동 wrapper |
 
-- `runtime.workflow_execution`: `backend/src/main/resources/db/changelog/db.changelog-master.sql:518-532`.
-- `pack.workflow_definition`: `backend/src/main/resources/db/changelog/db.changelog-master.sql:230-245`. `graph_json` NOT NULL, `terminal_states_json` NOT NULL DEFAULT `'[]'`.
+## User Flow Chart
 
-신규 migration 없음.
-
-### Integration adapter
-
-- `integrations/llm-tools/tool-schema.mjs`: 기존 4개 slot tool schema. `LLM_SLOT_TOOL_NAMES` 상수 `getContext` / `listSlots` / `getSlot` / `upsertSlotValue` 패턴 (`*_current_*`). 신규 tool도 동일 패턴 따른다.
-- `integrations/llm-tools/llm-tool-adapter.mjs`: tool call → backend REST 매핑.
-- `integrations/llm-tools/README.md`: 외부 LLM 공개 인터페이스 문서.
-
----
+```mermaid
+flowchart TD
+    A["대시보드 workflow 랭킹"] --> B["상세 가능한 workflow row 클릭"]
+    B --> C["워크플로우 상세 화면"]
+    C --> D["병목 분석 API 호출"]
+    D --> E{"운영 실행 로그 존재?"}
+    E -->|"Yes"| F["상태 전이 흐름과 통과 수 표시"]
+    F --> G["병목 state와 완료/실패/진행 중 분리 표시"]
+    G --> H["missing slot / policy hit / risk hit TOP 5 표시"]
+    H --> I["상담사 개입 지점과 개선 설명 표시"]
+    E -->|"No"| J["분석 데이터 없음 상태 표시"]
+```
 
 ## REST API
 
-### Endpoint
-
 | Method | Path | Description |
 | --- | --- | --- |
-| GET | `/api/v1/llm-tools/sessions/{sessionId}/workflow` | 현재 세션의 최신 workflow execution과 정의된 workflow graph를 조회 |
+| GET | `/api/v1/workspaces/{workspaceId}/dashboard/workflows/{workflowDefinitionId}/bottleneck-analysis` | 특정 workflow의 선택 기간 병목 분석 조회 |
 
-Security: `ROLE_OPERATOR` (기존 wildcard 규칙으로 자동 적용).
+### Query Parameters
 
-### Request
-
-Path variables only.
-
-| Variable | Type | Description |
+| 이름 | 필수 | 설명 |
 | --- | --- | --- |
-| `sessionId` | `Long` | `runtime.chat_session.id` |
+| `from` | 아니오 | `yyyy-MM-dd`; `to`와 함께 전달 |
+| `to` | 아니오 | `yyyy-MM-dd`; 포함 종료일이며 서버에서 다음 날 0시 exclusive로 변환 |
 
-Request body 없음.
-
-### Response
-
-**200 OK** — `LlmToolWorkflowResponse`
+### Response Shape
 
 ```json
 {
-  "sessionId": 1,
-  "workspaceId": 10,
-  "domainPackVersionId": 101,
-  "executionId": 50,
-  "executionStatus": "RUNNING",
-  "currentState": "collect_slots",
-  "workflowDefinitionId": 77,
-  "workflowCode": "refund_v1",
-  "workflowName": "환불 처리 워크플로우",
-  "workflowDescription": "환불 요청 분류와 정책 적용",
-  "graphJson": {
-    "nodes": [{ "id": "collect_slots", "type": "STATE" }],
-    "edges": [{ "from": "collect_slots", "to": "decide_refund" }]
+  "workspaceId": 1,
+  "workflowDefinitionId": 10,
+  "periodStart": "2026-05-29T00:00:00+09:00",
+  "periodEnd": "2026-06-05T00:00:00+09:00",
+  "totalExecutionCount": 48,
+  "completedCount": 32,
+  "failedCount": 8,
+  "runningCount": 8,
+  "transitions": [
+    {
+      "stateFrom": "collect_slots",
+      "stateTo": "verify_policy",
+      "passCount": 35
+    }
+  ],
+  "longestDwellState": {
+    "stateName": "collect_slots",
+    "metricValue": 420,
+    "executionCount": 12,
+    "description": "평균 7분 동안 머문 state"
   },
-  "initialState": "collect_slots",
-  "terminalStates": ["refund_granted", "refund_denied"]
+  "mostStoppedState": {
+    "stateName": "verify_policy",
+    "metricValue": 6,
+    "executionCount": 6,
+    "description": "실패/진행 중 실행이 가장 많이 멈춘 state"
+  },
+  "missingSlotTop": [
+    {
+      "name": "order_id",
+      "count": 18,
+      "stateName": "collect_slots",
+      "description": "collect_slots에서 자주 비어 있는 slot"
+    }
+  ],
+  "policyHitTop": [],
+  "riskHitTop": [],
+  "humanInterventionPoints": [
+    {
+      "stateName": "handoff",
+      "count": 5,
+      "description": "상담사 개입 action이 자주 발생한 state"
+    }
+  ],
+  "improvementHints": [
+    "order_id slot 수집 문구와 검증 규칙을 우선 점검하세요."
+  ]
 }
 ```
 
-응답 필드:
+## Backend Rules
 
-| Field | Type | Nullable | Source |
-| --- | --- | --- | --- |
-| `sessionId` | Long | No | `ChatSession.id` |
-| `workspaceId` | Long | No | `ChatSession.workspaceId` |
-| `domainPackVersionId` | Long | No | `ChatSession.domainPackVersionId` |
-| `executionId` | Long | Yes | `WorkflowExecution.id` — execution이 없으면 null |
-| `executionStatus` | String | Yes | `WorkflowExecution.status` — execution이 없으면 null |
-| `currentState` | String | Yes | `WorkflowExecution.currentState` — execution이 없거나 정의되지 않으면 null |
-| `workflowDefinitionId` | Long | Yes | `WorkflowDefinition.id` — execution이 없거나 `workflowDefinitionId`가 null이면 null |
-| `workflowCode` | String | Yes | `WorkflowDefinition.workflowCode` — workflow가 없으면 null |
-| `workflowName` | String | Yes | `WorkflowDefinition.name` — workflow가 없으면 null |
-| `workflowDescription` | String | Yes | `WorkflowDefinition.description` — workflow가 없으면 null |
-| `graphJson` | JsonNode | Yes | `WorkflowDefinition.graphJson` 을 `ObjectMapper.readTree`로 파싱. workflow가 없으면 null |
-| `initialState` | String | Yes | `WorkflowDefinition.initialState` — workflow가 없으면 null |
-| `terminalStates` | JsonNode (array) | Yes | `WorkflowDefinition.terminalStatesJson` 을 파싱한 JSON array. workflow가 없으면 null |
+- workspace membership 검증은 #519와 같은 `WorkspaceMemberRepository.findByWorkspaceIdAndUserId` 패턴을 따른다.
+- 기간 해석은 #519와 같은 Asia/Seoul 일자 기준을 사용한다.
+- 운영 실행 모집단은 `runtime.workflow_execution.started_at` 기준으로 집계한다.
+- simulation/demo 채널은 제외한다: `DEMO`, `DEMO_WEB`, `SIMULATION`, `SIMULATION_WEB`, `SIMULATION%`.
+- 상태 전이는 `runtime.workflow_execution_step.state_from`, `state_to`와 `action_type`으로 집계한다.
+- 완료/실패/진행 중 분리는 `runtime.workflow_execution.status` 기준이며, `COMPLETED`, `FAILED` 외 상태는 진행 중으로 본다.
+- 가장 오래 머문 state는 동일 execution 안에서 연속 step 사이의 시간 차이를 state별 평균으로 계산한다. 계산 가능한 연속 step이 없으면 null을 반환한다.
+- 가장 많이 멈춘 state는 실패/진행 중 execution의 `current_state` 기준으로 집계한다.
+- missing slot, policy hit, risk hit는 `runtime.decision_log.missing_slots_json`, `policy_hits_json`, `risk_hits_json` 배열을 파싱해 TOP 5를 만든다.
+- JSON payload가 비어 있거나 파싱할 수 없으면 해당 로그만 빈 배열처럼 처리하고 응답은 실패시키지 않는다.
+- 상담사 개입 지점은 step `action_type` 또는 decision `selected_action`에 handoff 계열 값이 있는 state로 집계한다.
 
-**404 Not Found**
+## Frontend Integration
 
-```json
-{
-  "error": "SESSION_NOT_FOUND",
-  "message": "Session not found: 1"
-}
+워크플로우 상세 화면 `frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.tsx`에 병목 분석 패널을 추가한다. 기존 랭킹 row의 상세 링크가 이 화면으로 이동하므로 별도 신규 라우트는 만들지 않는다.
+
+### Component Tree
+
+```text
+WorkflowDraftReadPage
+├─ Workflow header
+├─ Workflow graph/editor canvas
+└─ WorkflowBottleneckAnalysisPanel
+   ├─ Execution status summary
+   ├─ Transition pass count list
+   ├─ Bottleneck state summary
+   ├─ Missing slot / policy hit / risk hit TOP 5
+   ├─ Human intervention points
+   └─ Improvement hints
 ```
 
-`sessionId`가 존재하지 않는 경우만 404. workflow execution 부재 / `workflowDefinitionId` null / workflow definition 미일치는 모두 200으로 처리한다 (U-003 결정).
+## 수정 대상 파일
 
-**500 Internal Server Error**
-
-```json
-{
-  "error": "JSON_PARSE_FAILED",
-  "message": "Stored JSON value cannot be parsed"
-}
-```
-
-`graphJson` 또는 `terminalStatesJson` parse 실패 시. 기존 `LlmToolService` 의 `readJsonNode` 헬퍼가 `InternalException("JSON_PARSE_FAILED", ...)`을 던지는 패턴을 그대로 따른다.
-
-### 200 응답의 부재 시나리오 (Hard)
-
-세션이 존재하면 항상 200 이다. 다음 3가지 부재 케이스는 모두 200 + 부분 null 응답으로 처리한다 (`U-003` 결정, 기존 `getContext` 패턴 일치).
-
-1. **execution 없음** (예: 세션이 막 생성되고 아직 slot 입력이 들어오지 않은 상태)
-   - `executionId`, `executionStatus`, `currentState`, `workflowDefinitionId`, `workflowCode`, `workflowName`, `workflowDescription`, `graphJson`, `initialState`, `terminalStates` 모두 null.
-   - `sessionId`, `workspaceId`, `domainPackVersionId` 는 채워짐.
-2. **execution 있으나 `workflowDefinitionId`가 null** (예: `upsertSlotValue`에서 `WorkflowExecution.create(sessionId)`로 생성되어 workflow가 아직 묶이지 않은 상태)
-   - `executionId`, `executionStatus`, `currentState` 채움.
-   - `workflowDefinitionId`, `workflowCode`, `workflowName`, `workflowDescription`, `graphJson`, `initialState`, `terminalStates` 모두 null.
-3. **execution.workflowDefinitionId 가 있으나 session의 domainPackVersionId 와 일치하는 WorkflowDefinition 미존재**
-   - `findByIdAndDomainPackVersionId` 가 `Optional.empty()`를 반환. cross-pack 데이터 누수 방지를 위해 의도적으로 200 + workflow 필드 null 응답.
-   - 이 케이스는 운영상 inconsistency 신호이지만 LLM에는 부재로 보인다 (U-006 engineering-bound).
-
----
-
-## Sequence Diagram
-
-```mermaid
-sequenceDiagram
-    actor llm as External LLM Adapter
-    participant ctrl as LlmToolController
-    participant svc as LlmToolService
-    participant sessionRepo as ChatSessionRepository
-    participant execRepo as WorkflowExecutionRepository
-    participant defRepo as WorkflowDefinitionRepository
-    participant db as PostgreSQL
-
-    llm ->> ctrl: GET /api/v1/llm-tools/sessions/{sessionId}/workflow
-    ctrl ->> svc: getCurrentWorkflow(command)
-    svc ->> sessionRepo: findById(sessionId)
-    sessionRepo ->> db: SELECT runtime.chat_session
-    db -->> sessionRepo: ChatSession
-    sessionRepo -->> svc: ChatSession
-    svc ->> execRepo: findTopByChatSessionIdOrderByStartedAtDescIdDesc(sessionId)
-    execRepo ->> db: SELECT runtime.workflow_execution
-    db -->> execRepo: Optional<WorkflowExecution>
-    execRepo -->> svc: latest execution or empty
-    alt execution exists AND workflowDefinitionId not null
-        svc ->> defRepo: findByIdAndDomainPackVersionId(workflowDefinitionId, domainPackVersionId)
-        defRepo ->> db: SELECT pack.workflow_definition
-        db -->> defRepo: Optional<WorkflowDefinition>
-        defRepo -->> svc: definition or empty
-        svc ->> svc: parse graphJson + terminalStatesJson to JsonNode
-    end
-    svc -->> ctrl: LlmToolWorkflowResponse
-    ctrl -->> llm: 200 OK
-```
-
----
-
-## Class Design
-
-### DDD Layered Structure
-
-```mermaid
-classDiagram
-    class LlmToolController {
-        +getCurrentWorkflow(Long sessionId) ResponseEntity~LlmToolWorkflowResponse~
-    }
-
-    class LlmToolService {
-        -ChatSessionRepository chatSessionRepository
-        -WorkflowExecutionRepository workflowExecutionRepository
-        -WorkflowDefinitionRepository workflowDefinitionRepository
-        -SlotDefinitionRepository slotDefinitionRepository
-        -IntentSlotBindingRepository intentSlotBindingRepository
-        -ObjectMapper objectMapper
-        +getCurrentWorkflow(GetCurrentWorkflowCommand) LlmToolWorkflowResponse
-    }
-
-    class GetCurrentWorkflowCommand {
-        +Long sessionId
-    }
-
-    class LlmToolWorkflowResponse {
-        +Long sessionId
-        +Long workspaceId
-        +Long domainPackVersionId
-        +Long executionId
-        +String executionStatus
-        +String currentState
-        +Long workflowDefinitionId
-        +String workflowCode
-        +String workflowName
-        +String workflowDescription
-        +JsonNode graphJson
-        +String initialState
-        +JsonNode terminalStates
-    }
-
-    LlmToolController --> LlmToolService
-    LlmToolService --> WorkflowDefinitionRepository
-    LlmToolService --> WorkflowExecutionRepository
-    LlmToolService --> ChatSessionRepository
-```
-
-### New Application Files
-
-| File | Layer | 역할 |
+| 파일 | 변경 유형 | 설명 |
 | --- | --- | --- |
-| `backend/src/main/java/com/init/workflowruntime/application/command/GetCurrentWorkflowCommand.java` | application command | `record GetCurrentWorkflowCommand(Long sessionId)` |
-| `backend/src/main/java/com/init/workflowruntime/application/dto/LlmToolWorkflowResponse.java` | application DTO | `record LlmToolWorkflowResponse(...)` |
-
-### Modified Files
-
-| File | 수정 내용 |
-| --- | --- |
-| `backend/src/main/java/com/init/workflowruntime/application/LlmToolService.java` | 생성자 주입에 `WorkflowDefinitionRepository workflowDefinitionRepository` 추가. `public LlmToolWorkflowResponse getCurrentWorkflow(GetCurrentWorkflowCommand command)` 메서드 신설 |
-| `backend/src/main/java/com/init/workflowruntime/presentation/LlmToolController.java` | `@GetMapping("/workflow")` 핸들러 추가 |
-| `integrations/llm-tools/tool-schema.mjs` | `LLM_SLOT_TOOL_NAMES`에 `getCurrentWorkflow: "get_current_workflow"` 추가 (또는 별도 export 객체 — Implementation 시 결정), `llmSlotTools` 배열에 entry 추가 (parameters 없음) |
-| `integrations/llm-tools/llm-tool-adapter.mjs` | `get_current_workflow` → `GET /api/v1/llm-tools/sessions/{sessionId}/workflow` 매핑 추가 |
-| `integrations/llm-tools/README.md` | tool 목록에 `get_current_workflow` 추가 |
-| `integrations/llm-tools/llm-tool-adapter.test.mjs` | schema/adapter 동작 검증 추가 |
-
-### Application Logic
-
-```java
-public LlmToolWorkflowResponse getCurrentWorkflow(GetCurrentWorkflowCommand command) {
-  Long sessionId = command.sessionId();
-  ChatSession session = findSession(sessionId); // 기존 private helper — SESSION_NOT_FOUND 던짐
-  WorkflowExecution execution = findExecution(sessionId); // 기존 private helper — null 가능
-
-  Long executionId = execution != null ? execution.getId() : null;
-  String executionStatus = execution != null ? execution.getStatus() : null;
-  String currentState = execution != null ? execution.getCurrentState() : null;
-  Long workflowDefinitionId = execution != null ? execution.getWorkflowDefinitionId() : null;
-
-  WorkflowDefinition definition = null;
-  if (workflowDefinitionId != null) {
-    definition = workflowDefinitionRepository
-        .findByIdAndDomainPackVersionId(workflowDefinitionId, session.getDomainPackVersionId())
-        .orElse(null);
-  }
-
-  JsonNode graphJson = definition != null ? readJsonNode(definition.getGraphJson(), null) : null;
-  JsonNode terminalStates =
-      definition != null ? readJsonNode(definition.getTerminalStatesJson(), "[]") : null;
-  if (terminalStates != null && !terminalStates.isArray()) {
-    throw new InternalException(
-        "JSON_PARSE_FAILED", "Stored terminalStatesJson must be a JSON array");
-  }
-
-  return new LlmToolWorkflowResponse(
-      session.getId(),
-      session.getWorkspaceId(),
-      session.getDomainPackVersionId(),
-      executionId,
-      executionStatus,
-      currentState,
-      definition != null ? definition.getId() : null,
-      definition != null ? definition.getWorkflowCode() : null,
-      definition != null ? definition.getName() : null,
-      definition != null ? definition.getDescription() : null,
-      graphJson,
-      definition != null ? definition.getInitialState() : null,
-      terminalStates);
-}
-```
-
-**구현 노트**:
-
-- `findSession`, `findExecution`, `readJsonNode`는 기존 `LlmToolService`의 private helper를 그대로 사용.
-- `readJsonNode(null, null)` 호출은 `NullNode.getInstance()` 반환이므로, `definition == null` 일 때는 명시적으로 `null`을 응답 필드에 넣는다 (`NullNode.getInstance()` 대신).
-- `@Transactional(readOnly = true)` 는 class-level 적용으로 그대로 상속됨. 신규 메서드에 별도 어노테이션 불필요.
-- `terminalStates` 의 shape 강제: 기존 `readObjectNode` (`LlmToolService.java:224-230`) 가 `slot_values_json` 을 object로 강제하는 패턴과 동일하게, `terminalStatesJson` 은 array여야 한다. parse 자체는 성공하지만 array가 아닌 (scalar/object/string) 값이 저장돼 있으면 응답 contract 위반이므로 동일 `JSON_PARSE_FAILED` 500 에러로 처리. 신규 helper 도입 없이 inline check.
-
----
-
-## Data Model
-
-신규 entity 없음. 모든 entity는 기존 정의 그대로 사용.
-
-### LlmToolWorkflowResponse (신규 DTO)
-
-```java
-package com.init.workflowruntime.application.dto;
-
-import com.fasterxml.jackson.databind.JsonNode;
-
-public record LlmToolWorkflowResponse(
-    Long sessionId,
-    Long workspaceId,
-    Long domainPackVersionId,
-    Long executionId,
-    String executionStatus,
-    String currentState,
-    Long workflowDefinitionId,
-    String workflowCode,
-    String workflowName,
-    String workflowDescription,
-    JsonNode graphJson,
-    String initialState,
-    JsonNode terminalStates) {}
-```
-
-### GetCurrentWorkflowCommand (신규 command)
-
-```java
-package com.init.workflowruntime.application.command;
-
-public record GetCurrentWorkflowCommand(Long sessionId) {}
-```
-
----
-
-## Integration — `integrations/llm-tools`
-
-### Tool schema 추가
-
-**export 방식 (Hard — codeBuilder 기본값)**: 기존 `LLM_SLOT_TOOL_NAMES`(4개 slot tool)는 그대로 보존하고, 신규 workflow tool은 별도 상수 `LLM_WORKFLOW_TOOL_NAMES` 로 추가한다.
-
-근거:
-
-- `LLM_SLOT_TOOL_NAMES`는 이미 `llm-tool-adapter.mjs`, `llm-tool-adapter.test.mjs`가 import해서 사용 중. 이름 변경 시 import side 광범위 수정 필요.
-- 변수명이 "slot"으로 한정되어 있으므로 workflow 항목을 같은 상수에 넣으면 의미 충돌.
-- 후속 5.2.x tool은 본 spec 범위 밖이므로 (U-005 Deferred), 현재 시점에 5.2.x 공통 상수를 만들지 않는다 (YAGNI).
-
-```js
-// integrations/llm-tools/tool-schema.mjs (수정 후 발췌)
-
-// 기존 (변경 없음)
-export const LLM_SLOT_TOOL_NAMES = Object.freeze({
-  getContext: "get_current_slot_context",
-  listSlots: "list_current_slots",
-  getSlot: "get_current_slot",
-  upsertSlotValue: "upsert_current_slot_value",
-});
-
-// 신규 추가
-export const LLM_WORKFLOW_TOOL_NAMES = Object.freeze({
-  getCurrentWorkflow: "get_current_workflow",
-});
-
-// llmSlotTools 배열에 다음 entry 추가:
-{
-  type: "function",
-  function: {
-    name: LLM_WORKFLOW_TOOL_NAMES.getCurrentWorkflow,
-    description:
-      "현재 상담 세션에 묶인 결정론적 워크플로우 그래프와 현재 실행 상태(state, status)를 조회한다.",
-    parameters: emptyParameters,
-  },
-}
-```
-
-`llmSlotTools` 배열의 이름은 그대로 두되, 후속 spec에서 5.2.x tool이 추가될 때 `llmTools` 같은 통합 이름으로 리네임 검토 (본 spec 범위 밖).
-
-### Adapter 수정
-
-`llm-tool-adapter.mjs` 의 tool name → REST URL 매핑 테이블에 다음 entry 추가:
-
-```js
-import { LLM_SLOT_TOOL_NAMES, LLM_WORKFLOW_TOOL_NAMES, llmSlotTools } from "./tool-schema.mjs";
-
-// switch(toolName) 분기에 추가:
-case LLM_WORKFLOW_TOOL_NAMES.getCurrentWorkflow:
-  return await fetchJson(
-    `${backendBaseUrl}/api/v1/llm-tools/sessions/${sessionId}/workflow`,
-    { method: "GET", headers: { Authorization: `Bearer ${bearerToken}` } }
-  );
-
-// 기존 re-export도 갱신:
-export { LLM_SLOT_TOOL_NAMES, LLM_WORKFLOW_TOOL_NAMES, llmSlotTools };
-```
-
-(실제 코드는 기존 adapter 구조에 맞춰 작성.)
-
-### README 갱신
-
-`integrations/llm-tools/README.md` 의 "Tool Names" 표에 `get_current_workflow` 행 추가.
-
----
-
-## Error Handling
-
-| Case | HTTP | Error code | Source |
-| --- | --- | --- | --- |
-| sessionId 가 없음 | 404 | `SESSION_NOT_FOUND` | 기존 `findSession` 헬퍼 |
-| execution 없음 | 200 | — | 응답 필드 null 처리 |
-| execution.workflowDefinitionId 가 null | 200 | — | 응답 필드 null 처리 |
-| execution.workflowDefinitionId 있으나 session.domainPackVersionId 와 매칭되는 WorkflowDefinition 없음 | 200 | — | 응답 필드 null 처리 (cross-pack 보호) |
-| `graphJson` parse 실패 | 500 | `JSON_PARSE_FAILED` | 기존 `readJsonNode` 헬퍼 |
-| `terminalStatesJson` parse 실패 또는 array가 아님 (scalar/object/string) | 500 | `JSON_PARSE_FAILED` | `readJsonNode` + inline `isArray()` 검증 |
-| 인증 실패 / OPERATOR 권한 없음 | 401 / 403 | (Spring Security 표준) | `SecurityConfig:65-66` |
-
-`spring-validation` 트리거 없음 (request body / query param 없음).
-
----
+| `backend/src/main/java/com/init/workflowruntime/presentation/WorkspaceWorkflowBottleneckAnalysisController.java` | new | 병목 분석 API |
+| `backend/src/main/java/com/init/workflowruntime/application/WorkspaceWorkflowBottleneckAnalysisService.java` | new | 기간 해석, 멤버십 검증, state/hit 집계 |
+| `backend/src/main/java/com/init/workflowruntime/application/command/GetWorkflowBottleneckAnalysisCommand.java` | new | 요청 command |
+| `backend/src/main/java/com/init/workflowruntime/application/dto/*Bottleneck*.java` | new | 응답 DTO |
+| `backend/src/main/java/com/init/workflowruntime/domain/WorkflowBottleneckAnalysisRepository.java` | new | 분석 조회 포트 |
+| `backend/src/main/java/com/init/workflowruntime/domain/WorkflowBottleneck*Row.java` | new | repository row 모델 |
+| `backend/src/main/java/com/init/workflowruntime/infrastructure/persistence/JpaWorkflowBottleneckAnalysisRepository.java` | new | Native SQL 조회 |
+| `frontend/src/features/consultation/api/consultationApi.ts` | update | OpenAPI 미생성 병목 분석 API wrapper |
+| `frontend/src/features/consultation/api/consultationApi.test.ts` | update | API URL/쿼리 검증 |
+| `frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.tsx` | update | 분석 패널 표시 |
+| `frontend/src/pages/domain-pack/ui/workflow-draft-read-page.module.css` | update | 분석 패널 스타일 |
+| `frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.test.tsx` | update | 분석 패널 상태 검증 |
 
 ## Tests
 
-### 테스트 layering (Hard)
+| 구분 | 대상 | 기대 |
+| --- | --- | --- |
+| Backend Unit | `WorkspaceWorkflowBottleneckAnalysisService` | 실행 상태 분리, transition count, longest dwell, stopped state, TOP 5, 설명을 계산한다 |
+| Backend Unit | `WorkspaceWorkflowBottleneckAnalysisService` | JSON 파싱 실패/빈 값을 안전하게 건너뛴다 |
+| Backend Unit | `WorkspaceWorkflowBottleneckAnalysisService` | 멤버가 아니면 repository를 호출하지 않고 접근을 거부한다 |
+| Frontend API | `consultationApi.getWorkflowBottleneckAnalysis` | endpoint와 기간 쿼리를 올바르게 호출한다 |
+| Frontend Page | `WorkflowDraftReadPage` | 분석 로딩/빈/데이터 상태를 표시한다 |
 
-기존 `workflowruntime` 패키지의 테스트 컨벤션을 그대로 따른다 (DB fixture 도입 금지):
+## Acceptance Criteria
 
-- **Service 계층 테스트**: `@ExtendWith(MockitoExtension.class)` + `@Mock` repository — `LlmToolServiceTest.java`가 `ChatSessionRepository`, `WorkflowExecutionRepository`, `SlotDefinitionRepository`, `IntentSlotBindingRepository` 를 모두 mock하는 패턴 그대로. 신규 의존 `WorkflowDefinitionRepository` 도 `@Mock`. `ObjectMapper` 는 real instance.
-- **Controller 계층 테스트**: `@WebMvcTest(LlmToolController.class)` + `@MockitoBean LlmToolService` — 기존 `LlmToolControllerTest.java` 패턴 그대로. `JwtAuthenticationFilter` excludeFilters + `@AutoConfigureMockMvc(addFilters = false)` 유지.
+1. workflow별 상태 전이 흐름과 통과 수가 상세 화면에 표시된다.
+2. 가장 오래 머문 state와 가장 많이 멈춘 state가 표시된다.
+3. 완료/실패/진행 중 실행 수가 분리되어 표시된다.
+4. missing slot, policy hit, risk hit TOP 5가 각각 집계된다.
+5. 상담사 개입이 자주 발생한 지점이 표시된다.
+6. 고객이 어떤 slot/policy/risk를 검토해야 하는지 알 수 있는 설명이 제공된다.
+7. JSON payload가 비어 있거나 파싱 실패해도 화면과 API 응답이 깨지지 않는다.
+8. simulation/demo 채널 실행은 분석에서 제외된다.
 
-따라서 `runtime.chat_session` / `runtime.workflow_execution` / `pack.workflow_definition` row를 DB에 seed할 필요가 없다. `@Sql`, `@DataJpaTest`, `@SpringBootTest(webEnvironment = ...)` 도입 금지.
+## Non-goals
 
-### Unit Tests — `LlmToolServiceTest`
+- 개선 후보 자동 생성
+- workflow graph 직접 편집
+- golden case replay
+- workflow별 비교 분석
+- domain pack version, channel, workflow status 공통 필터의 서버 적용
 
-기존 `backend/src/test/java/com/init/workflowruntime/application/LlmToolServiceTest.java` 에 메서드 추가. `WorkflowDefinitionRepository` 를 `@Mock` 필드로 추가하고 생성자 주입에 포함. WorkflowDefinition fixture는 `WorkflowDefinition.create(...)` 정적 factory + `ReflectionTestUtils.setField` 로 `id`/`domainPackVersionId` 주입 (기존 `LlmToolServiceTest` 가 `WorkflowExecution`/`ChatSession`에 사용 중인 동일 패턴).
+## Open Questions
 
-```java
-@Nested
-@DisplayName("getCurrentWorkflow")
-class GetCurrentWorkflow {
-
-  @Test
-  @DisplayName("세션 + execution + workflow definition이 모두 있으면 graphJson 포함 응답")
-  void returnsFullWorkflowWhenAllPresent();
-
-  @Test
-  @DisplayName("execution 없으면 execution/workflow 필드 모두 null")
-  void returnsNullsWhenExecutionMissing();
-
-  @Test
-  @DisplayName("workflowDefinitionId가 null이면 execution 필드만 채우고 workflow는 null")
-  void returnsExecutionOnlyWhenWorkflowNotBound();
-
-  @Test
-  @DisplayName("workflowDefinitionId와 session domainPackVersionId가 불일치하면 workflow null")
-  void returnsWorkflowNullOnCrossPackMismatch();
-
-  @Test
-  @DisplayName("sessionId가 없으면 SESSION_NOT_FOUND")
-  void throwsWhenSessionMissing();
-
-  @Test
-  @DisplayName("graphJson이 malformed이면 JSON_PARSE_FAILED")
-  void throwsWhenGraphJsonMalformed();
-
-  @Test
-  @DisplayName("terminalStatesJson이 malformed이면 JSON_PARSE_FAILED")
-  void throwsWhenTerminalStatesJsonMalformed();
-
-  @Test
-  @DisplayName("terminalStatesJson이 array가 아니면 JSON_PARSE_FAILED")
-  void throwsWhenTerminalStatesJsonNotArray();
-}
-```
-
-### Controller Slice Tests — `LlmToolControllerTest`
-
-기존 `backend/src/test/java/com/init/workflowruntime/presentation/LlmToolControllerTest.java` 에 추가. `LlmToolService.getCurrentWorkflow(...)` 를 mock하여 `LlmToolWorkflowResponse` 를 반환하도록 stub:
-
-```java
-@Test
-@DisplayName("GET /api/v1/llm-tools/sessions/{sessionId}/workflow returns workflow")
-void getCurrentWorkflow_returnsOk();
-
-@Test
-@DisplayName("GET /workflow returns 404 when service throws SESSION_NOT_FOUND")
-void getCurrentWorkflow_returnsNotFound_whenSessionMissing();
-
-@Test
-@DisplayName("GET /workflow returns 200 with nulls when no execution")
-void getCurrentWorkflow_returnsOk_withNulls_whenNoExecution();
-```
-
-(권한 검증은 별도 `LlmToolControllerSecurityTest.java` 의 기존 패턴 — `/workflow` 경로 1건 추가.)
-
-### Integration Adapter Tests — `llm-tool-adapter.test.mjs`
-
-`integrations/llm-tools/llm-tool-adapter.test.mjs` 에 추가:
-
-```js
-test("get_current_workflow tool schema는 sessionId를 노출하지 않는다");
-test("get_current_workflow tool call은 GET /workflow로 매핑된다");
-```
-
-### Test Checklist
-
-- [ ] 정상 시나리오: full response 반환 (session + execution + definition 모두 존재)
-- [ ] execution 부재: 200 + nulls
-- [ ] workflowDefinitionId null: 200 + execution 필드만
-- [ ] cross-pack mismatch: 200 + workflow null
-- [ ] session 부재: 404
-- [ ] graphJson malformed: 500 `JSON_PARSE_FAILED`
-- [ ] terminalStatesJson malformed: 500 `JSON_PARSE_FAILED`
-- [ ] terminalStatesJson이 array가 아닌 jsonb 값 (예: `"foo"`, `{"k":"v"}`): 500 `JSON_PARSE_FAILED`
-- [ ] 권한: ROLE_OPERATOR 없으면 403 (기존 SecurityConfig 규칙 검증 — 기존 LlmToolControllerTest에 동일 패턴 있다면 1건 추가)
-- [ ] tool schema가 sessionId를 노출하지 않는지 검증
-- [ ] adapter mapping 검증
-
----
-
-## Database
-
-신규 migration 없음. 기존 DDL 재사용.
-
-- `runtime.workflow_execution` (`db.changelog-master.sql:518-532`)
-- `runtime.chat_session` (`db.changelog-master.sql:490-502`)
-- `pack.workflow_definition` (`db.changelog-master.sql:230-245`)
-
----
-
-## Verification
-
-```bash
-cd backend
-./gradlew compileJava test \
-  --tests 'com.init.workflowruntime.application.LlmToolServiceTest' \
-  --tests 'com.init.workflowruntime.presentation.LlmToolControllerTest'
-
-cd ..
-node --test integrations/llm-tools/llm-tool-adapter.test.mjs
-```
-
-기대 결과: BUILD SUCCESSFUL, 모든 신규 테스트 케이스 통과.
-
----
-
-## Out of Scope
-
-- 5.2.5 (decision_log writer) — 본 spec과 별도 backlog로 관리.
-- 5.2.2 ~ 5.2.4 의 tool 목록 — source materials에 정의되지 않음 (recon-report `Missing / Unconfirmed Information` 참조).
-- `LlmToolWorkflowResponse` 의 5.2.x 공통 계약 승격 — 청사진 요약은 fact가 아니므로 본 spec 범위 밖 (U-005).
-- `WorkflowExecution` 의 lifecycle 정책 (start/stop/finish) — 본 tool은 read-only.
-- `decision_log`, `workflow_execution_step` 작성 경로 — 본 spec은 워크플로우 read만 다룬다.
-- MCP server 추가 여부, scoped API key 도입 — 523 spec의 Remaining Decisions 참조.
-- `currentState` 정합성 검증 (`currentState`가 `graphJson.nodes` 중 하나에 속하는지) — 본 tool은 read pass-through. 검증 책임은 작성 경로에 둔다.
-
----
-
-## Additional Notes
-
-- 본 endpoint는 read-only (`@Transactional(readOnly = true)` 상속).
-- `LlmToolService`는 5번째 메서드 추가 후에도 단일 책임을 유지 (모든 메서드가 외부 LLM tool 조회/저장). 추후 6번째 tool 이상이 추가되며 service 비대화되면 분리 검토.
-- `graphJson` 응답이 큰 경우 (수십 KB 이상) 캐시 전략은 본 spec 범위 밖. P95 latency 측정 후 별도 spec에서 다룬다.
+- 상담사 메시지 자체에는 state 컬럼이 없으므로, 상담사 개입 지점은 workflow step/decision action의 handoff 신호로 집계한다.
+- policy/risk hit writer가 아직 빈 배열 위주로 기록되는 실행에서는 해당 TOP 5가 빈 상태로 표시될 수 있다.

--- a/backend/src/main/java/com/init/workflowruntime/application/WorkspaceWorkflowBottleneckAnalysisService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/WorkspaceWorkflowBottleneckAnalysisService.java
@@ -1,0 +1,549 @@
+package com.init.workflowruntime.application;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.init.shared.application.exception.BadRequestException;
+import com.init.workflowruntime.application.command.GetWorkflowBottleneckAnalysisCommand;
+import com.init.workflowruntime.application.dto.WorkflowHitMetricResponse;
+import com.init.workflowruntime.application.dto.WorkflowHumanInterventionMetricResponse;
+import com.init.workflowruntime.application.dto.WorkflowStateBottleneckResponse;
+import com.init.workflowruntime.application.dto.WorkflowTransitionMetricResponse;
+import com.init.workflowruntime.application.dto.WorkspaceWorkflowBottleneckAnalysisResponse;
+import com.init.workflowruntime.domain.WorkflowBottleneckAnalysisRepository;
+import com.init.workflowruntime.domain.WorkflowBottleneckDecisionRow;
+import com.init.workflowruntime.domain.WorkflowBottleneckExecutionRow;
+import com.init.workflowruntime.domain.WorkflowBottleneckStepRow;
+import com.init.workflowruntime.domain.WorkflowExecution;
+import com.init.workspace.application.exception.WorkspaceAccessDeniedException;
+import com.init.workspace.domain.repository.WorkspaceMemberRepository;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class WorkspaceWorkflowBottleneckAnalysisService {
+
+  private static final ZoneId METRIC_ZONE = ZoneId.of("Asia/Seoul");
+  private static final int TOP_LIMIT = 5;
+  private static final String UNKNOWN_STATE = "미확인 state";
+  private static final String WORKSPACE_ACCESS_DENIED_MESSAGE = "워크스페이스에 접근 권한이 없습니다.";
+
+  private final WorkflowBottleneckAnalysisRepository analysisRepository;
+  private final WorkspaceMemberRepository workspaceMemberRepository;
+  private final ObjectMapper objectMapper;
+  private final Clock clock;
+
+  public WorkspaceWorkflowBottleneckAnalysisService(
+      WorkflowBottleneckAnalysisRepository analysisRepository,
+      WorkspaceMemberRepository workspaceMemberRepository,
+      ObjectMapper objectMapper,
+      Clock clock) {
+    this.analysisRepository = analysisRepository;
+    this.workspaceMemberRepository = workspaceMemberRepository;
+    this.objectMapper = objectMapper;
+    this.clock = clock;
+  }
+
+  public WorkspaceWorkflowBottleneckAnalysisResponse getAnalysis(
+      GetWorkflowBottleneckAnalysisCommand command) {
+    validateWorkspaceMembership(command.workspaceId(), command.userId());
+    AnalysisPeriod period = resolvePeriod(command);
+    List<WorkflowBottleneckExecutionRow> executions =
+        analysisRepository.findExecutionRows(
+            command.workspaceId(), command.workflowDefinitionId(), period.start(), period.end());
+    List<WorkflowBottleneckStepRow> steps =
+        analysisRepository.findStepRows(
+            command.workspaceId(), command.workflowDefinitionId(), period.start(), period.end());
+    List<WorkflowBottleneckDecisionRow> decisions =
+        analysisRepository.findDecisionRows(
+            command.workspaceId(), command.workflowDefinitionId(), period.start(), period.end());
+
+    Map<String, StateAggregate> states = new LinkedHashMap<>();
+    List<WorkflowTransitionMetricResponse> transitions = aggregateTransitions(steps, states);
+    WorkflowStateBottleneckResponse longestDwell = aggregateDwell(steps, states);
+    WorkflowStateBottleneckResponse mostStopped = aggregateStoppedExecutions(executions, states);
+    HitAggregation missingSlots = aggregateHits(decisions, HitType.MISSING_SLOT, states);
+    HitAggregation policyHits = aggregateHits(decisions, HitType.POLICY_HIT, states);
+    HitAggregation riskHits = aggregateHits(decisions, HitType.RISK_HIT, states);
+    List<WorkflowHumanInterventionMetricResponse> handoffPoints =
+        aggregateHumanInterventions(steps, decisions, states);
+
+    long completed = countStatus(executions, WorkflowExecution.STATUS_COMPLETED);
+    long failed = countStatus(executions, WorkflowExecution.STATUS_FAILED);
+    long running = executions.size() - completed - failed;
+
+    return new WorkspaceWorkflowBottleneckAnalysisResponse(
+        command.workspaceId(),
+        command.workflowDefinitionId(),
+        period.start(),
+        period.end(),
+        executions.size(),
+        completed,
+        failed,
+        running,
+        transitions,
+        longestDwell,
+        mostStopped,
+        toStateMetrics(states),
+        missingSlots.topHits(),
+        policyHits.topHits(),
+        riskHits.topHits(),
+        handoffPoints,
+        buildImprovementHints(missingSlots, policyHits, riskHits, longestDwell, mostStopped));
+  }
+
+  private void validateWorkspaceMembership(Long workspaceId, Long userId) {
+    workspaceMemberRepository
+        .findByWorkspaceIdAndUserId(workspaceId, userId)
+        .orElseThrow(() -> new WorkspaceAccessDeniedException(WORKSPACE_ACCESS_DENIED_MESSAGE));
+  }
+
+  private AnalysisPeriod resolvePeriod(GetWorkflowBottleneckAnalysisCommand command) {
+    boolean hasFrom = command.fromDate() != null;
+    boolean hasTo = command.toDate() != null;
+    if (hasFrom != hasTo) {
+      throw new BadRequestException(
+          "INVALID_WORKFLOW_BOTTLENECK_PERIOD", "fromDate and toDate must be provided together");
+    }
+
+    LocalDate startDate;
+    LocalDate endDateExclusive;
+    if (hasFrom) {
+      startDate = command.fromDate();
+      endDateExclusive = command.toDate().plusDays(1);
+    } else {
+      LocalDate today = LocalDate.now(clock.withZone(METRIC_ZONE));
+      startDate = today.minusDays(6);
+      endDateExclusive = today.plusDays(1);
+    }
+
+    if (!endDateExclusive.isAfter(startDate)) {
+      throw new BadRequestException(
+          "INVALID_WORKFLOW_BOTTLENECK_PERIOD", "toDate must be on or after fromDate");
+    }
+
+    return new AnalysisPeriod(
+        startDate.atStartOfDay(METRIC_ZONE).toOffsetDateTime(),
+        endDateExclusive.atStartOfDay(METRIC_ZONE).toOffsetDateTime());
+  }
+
+  private List<WorkflowTransitionMetricResponse> aggregateTransitions(
+      List<WorkflowBottleneckStepRow> steps, Map<String, StateAggregate> states) {
+    Map<String, TransitionAggregate> transitions = new LinkedHashMap<>();
+    for (WorkflowBottleneckStepRow step : steps) {
+      String stateTo = normalizeState(step.stateTo());
+      if (stateTo != null) {
+        states.computeIfAbsent(stateTo, StateAggregate::new).transitionInCount++;
+      }
+      String stateFrom = normalizeState(step.stateFrom());
+      if (stateFrom != null) {
+        states.computeIfAbsent(stateFrom, StateAggregate::new).transitionOutCount++;
+      }
+      if (stateTo == null) {
+        continue;
+      }
+      String key = (stateFrom == null ? "" : stateFrom) + "->" + stateTo;
+      transitions.computeIfAbsent(key, ignored -> new TransitionAggregate(stateFrom, stateTo))
+          .passCount++;
+    }
+    return transitions.values().stream()
+        .sorted(
+            Comparator.comparingLong(TransitionAggregate::passCount)
+                .reversed()
+                .thenComparing(TransitionAggregate::stateTo))
+        .map(
+            transition ->
+                new WorkflowTransitionMetricResponse(
+                    transition.stateFrom(), transition.stateTo(), transition.passCount()))
+        .toList();
+  }
+
+  private WorkflowStateBottleneckResponse aggregateDwell(
+      List<WorkflowBottleneckStepRow> steps, Map<String, StateAggregate> states) {
+    Map<Long, WorkflowBottleneckStepRow> previousByExecution = new LinkedHashMap<>();
+    for (WorkflowBottleneckStepRow step : steps) {
+      WorkflowBottleneckStepRow previous = previousByExecution.put(step.executionId(), step);
+      if (previous == null || previous.createdAt() == null || step.createdAt() == null) {
+        continue;
+      }
+      String state = normalizeState(previous.stateTo());
+      if (state == null || step.createdAt().isBefore(previous.createdAt())) {
+        continue;
+      }
+      long seconds = Duration.between(previous.createdAt(), step.createdAt()).getSeconds();
+      StateAggregate aggregate = states.computeIfAbsent(state, StateAggregate::new);
+      aggregate.dwellSecondsSum += seconds;
+      aggregate.dwellSampleCount++;
+    }
+    return states.values().stream()
+        .filter(state -> state.dwellSampleCount > 0)
+        .max(Comparator.comparingLong(StateAggregate::averageDwellSeconds))
+        .map(
+            state ->
+                new WorkflowStateBottleneckResponse(
+                    state.stateName,
+                    state.averageDwellSeconds(),
+                    state.dwellSampleCount,
+                    "평균 %d초 동안 머문 state".formatted(state.averageDwellSeconds())))
+        .orElse(null);
+  }
+
+  private WorkflowStateBottleneckResponse aggregateStoppedExecutions(
+      List<WorkflowBottleneckExecutionRow> executions, Map<String, StateAggregate> states) {
+    for (WorkflowBottleneckExecutionRow execution : executions) {
+      if (WorkflowExecution.STATUS_COMPLETED.equals(execution.status())) {
+        continue;
+      }
+      String state = normalizeState(execution.currentState());
+      if (state == null) {
+        continue;
+      }
+      states.computeIfAbsent(state, StateAggregate::new).stoppedCount++;
+    }
+    return states.values().stream()
+        .filter(state -> state.stoppedCount > 0)
+        .max(Comparator.comparingLong(StateAggregate::stoppedCount))
+        .map(
+            state ->
+                new WorkflowStateBottleneckResponse(
+                    state.stateName,
+                    state.stoppedCount,
+                    state.stoppedCount,
+                    "실패/진행 중 실행이 가장 많이 멈춘 state"))
+        .orElse(null);
+  }
+
+  private HitAggregation aggregateHits(
+      List<WorkflowBottleneckDecisionRow> decisions,
+      HitType hitType,
+      Map<String, StateAggregate> states) {
+    Map<String, HitAggregate> hits = new LinkedHashMap<>();
+    for (WorkflowBottleneckDecisionRow decision : decisions) {
+      String state = normalizeState(decision.stateName());
+      String stateName = state != null ? state : UNKNOWN_STATE;
+      for (String name : parseHitNames(jsonFor(decision, hitType))) {
+        hits.computeIfAbsent(name, ignored -> new HitAggregate(name, hitType)).increment(stateName);
+        StateAggregate stateAggregate = states.computeIfAbsent(stateName, StateAggregate::new);
+        switch (hitType) {
+          case MISSING_SLOT -> stateAggregate.missingSlotCount++;
+          case POLICY_HIT -> stateAggregate.policyHitCount++;
+          case RISK_HIT -> stateAggregate.riskHitCount++;
+        }
+      }
+    }
+    List<WorkflowHitMetricResponse> topHits =
+        hits.values().stream()
+            .sorted(
+                Comparator.comparingLong(HitAggregate::count)
+                    .reversed()
+                    .thenComparing(HitAggregate::name))
+            .limit(TOP_LIMIT)
+            .map(HitAggregate::toResponse)
+            .toList();
+    return new HitAggregation(hitType, topHits);
+  }
+
+  private List<WorkflowHumanInterventionMetricResponse> aggregateHumanInterventions(
+      List<WorkflowBottleneckStepRow> steps,
+      List<WorkflowBottleneckDecisionRow> decisions,
+      Map<String, StateAggregate> states) {
+    Map<String, Long> points = new LinkedHashMap<>();
+    for (WorkflowBottleneckStepRow step : steps) {
+      if (!isHandoffAction(step.actionType())) {
+        continue;
+      }
+      String state = normalizeState(step.stateTo());
+      if (state == null) {
+        state = normalizeState(step.stateFrom());
+      }
+      if (state == null) {
+        state = UNKNOWN_STATE;
+      }
+      points.merge(state, 1L, Long::sum);
+      states.computeIfAbsent(state, StateAggregate::new).humanInterventionCount++;
+    }
+    for (WorkflowBottleneckDecisionRow decision : decisions) {
+      if (!isHandoffAction(decision.selectedAction())) {
+        continue;
+      }
+      String state = normalizeState(decision.stateName());
+      if (state == null) {
+        state = UNKNOWN_STATE;
+      }
+      points.merge(state, 1L, Long::sum);
+      states.computeIfAbsent(state, StateAggregate::new).humanInterventionCount++;
+    }
+    return points.entrySet().stream()
+        .sorted(
+            Map.Entry.<String, Long>comparingByValue().reversed().thenComparing(Map.Entry::getKey))
+        .limit(TOP_LIMIT)
+        .map(
+            entry ->
+                new WorkflowHumanInterventionMetricResponse(
+                    entry.getKey(), entry.getValue(), "상담사 개입 action이 자주 발생한 state"))
+        .toList();
+  }
+
+  private List<WorkflowHitMetricResponse> toStateMetrics(Map<String, StateAggregate> states) {
+    return states.values().stream()
+        .filter(StateAggregate::hasSignal)
+        .sorted(
+            Comparator.comparingLong(StateAggregate::totalSignalCount)
+                .reversed()
+                .thenComparing(StateAggregate::stateName))
+        .limit(TOP_LIMIT)
+        .map(
+            state ->
+                new WorkflowHitMetricResponse(
+                    state.stateName,
+                    state.totalSignalCount(),
+                    state.stateName,
+                    "전이/정지/slot/policy/risk/handoff 신호가 누적된 state"))
+        .toList();
+  }
+
+  private List<String> buildImprovementHints(
+      HitAggregation missingSlots,
+      HitAggregation policyHits,
+      HitAggregation riskHits,
+      WorkflowStateBottleneckResponse longestDwell,
+      WorkflowStateBottleneckResponse mostStopped) {
+    List<String> hints = new ArrayList<>();
+    missingSlots.topHits().stream()
+        .findFirst()
+        .ifPresent(hit -> hints.add("%s slot 수집 문구와 검증 규칙을 우선 점검하세요.".formatted(hit.name())));
+    policyHits.topHits().stream()
+        .findFirst()
+        .ifPresent(hit -> hints.add("%s policy 조건과 예외 처리를 검토하세요.".formatted(hit.name())));
+    riskHits.topHits().stream()
+        .findFirst()
+        .ifPresent(hit -> hints.add("%s risk 감지 기준과 상담사 연결 기준을 확인하세요.".formatted(hit.name())));
+    if (longestDwell != null) {
+      hints.add("%s에서 머무는 시간이 길어 다음 안내 문구나 조건을 점검하세요.".formatted(longestDwell.stateName()));
+    }
+    if (mostStopped != null) {
+      hints.add("%s에서 실패/진행 중 실행이 많이 남아 종료 조건을 확인하세요.".formatted(mostStopped.stateName()));
+    }
+    if (hints.isEmpty()) {
+      hints.add("선택 기간에 개선 우선순위를 판단할 병목 신호가 아직 충분하지 않습니다.");
+    }
+    return hints.stream().limit(TOP_LIMIT).toList();
+  }
+
+  private long countStatus(List<WorkflowBottleneckExecutionRow> executions, String status) {
+    return executions.stream().filter(row -> status.equals(row.status())).count();
+  }
+
+  private String jsonFor(WorkflowBottleneckDecisionRow decision, HitType hitType) {
+    return switch (hitType) {
+      case MISSING_SLOT -> decision.missingSlotsJson();
+      case POLICY_HIT -> decision.policyHitsJson();
+      case RISK_HIT -> decision.riskHitsJson();
+    };
+  }
+
+  private List<String> parseHitNames(String rawJson) {
+    if (rawJson == null || rawJson.isBlank()) {
+      return List.of();
+    }
+    try {
+      JsonNode root = objectMapper.readTree(rawJson);
+      if (!root.isArray()) {
+        return List.of();
+      }
+      List<String> names = new ArrayList<>();
+      for (JsonNode item : root) {
+        String name = extractHitName(item);
+        if (name != null) {
+          names.add(name);
+        }
+      }
+      return names;
+    } catch (JsonProcessingException ignored) {
+      return List.of();
+    }
+  }
+
+  private String extractHitName(JsonNode item) {
+    if (item == null || item.isNull()) {
+      return null;
+    }
+    if (item.isTextual() || item.isNumber() || item.isBoolean()) {
+      return normalizeName(item.asText());
+    }
+    if (item.isObject()) {
+      for (String field :
+          List.of(
+              "slotCode",
+              "policyCode",
+              "riskCode",
+              "code",
+              "name",
+              "id",
+              "ref",
+              "slotRef",
+              "policyRef",
+              "riskRef")) {
+        JsonNode value = item.get(field);
+        if (value != null && value.isValueNode()) {
+          String normalized = normalizeName(value.asText());
+          if (normalized != null) {
+            return normalized;
+          }
+        }
+      }
+    }
+    return null;
+  }
+
+  private boolean isHandoffAction(String action) {
+    if (action == null) {
+      return false;
+    }
+    String normalized = action.trim().toUpperCase();
+    return normalized.contains("HANDOFF") || normalized.contains("COUNSELOR");
+  }
+
+  private String normalizeState(String value) {
+    return normalizeName(value);
+  }
+
+  private String normalizeName(String value) {
+    if (value == null) {
+      return null;
+    }
+    String trimmed = value.trim();
+    return trimmed.isEmpty() ? null : trimmed;
+  }
+
+  private record AnalysisPeriod(OffsetDateTime start, OffsetDateTime end) {}
+
+  private enum HitType {
+    MISSING_SLOT,
+    POLICY_HIT,
+    RISK_HIT
+  }
+
+  private static final class TransitionAggregate {
+    private final String stateFrom;
+    private final String stateTo;
+    private long passCount;
+
+    private TransitionAggregate(String stateFrom, String stateTo) {
+      this.stateFrom = stateFrom;
+      this.stateTo = stateTo;
+    }
+
+    String stateFrom() {
+      return stateFrom;
+    }
+
+    String stateTo() {
+      return stateTo;
+    }
+
+    long passCount() {
+      return passCount;
+    }
+  }
+
+  private record HitAggregation(HitType hitType, List<WorkflowHitMetricResponse> topHits) {}
+
+  private static final class HitAggregate {
+    private final String name;
+    private final HitType hitType;
+    private final Map<String, Long> stateCounts = new LinkedHashMap<>();
+    private long count;
+
+    private HitAggregate(String name, HitType hitType) {
+      this.name = name;
+      this.hitType = hitType;
+    }
+
+    void increment(String stateName) {
+      count++;
+      stateCounts.merge(stateName, 1L, Long::sum);
+    }
+
+    long count() {
+      return count;
+    }
+
+    String name() {
+      return name;
+    }
+
+    WorkflowHitMetricResponse toResponse() {
+      String stateName = dominantStateName();
+      String description =
+          switch (hitType) {
+            case MISSING_SLOT -> stateName + "에서 자주 비어 있는 slot";
+            case POLICY_HIT -> stateName + "에서 자주 hit 된 policy";
+            case RISK_HIT -> stateName + "에서 자주 hit 된 risk";
+          };
+      return new WorkflowHitMetricResponse(name, count, stateName, description);
+    }
+
+    private String dominantStateName() {
+      return stateCounts.entrySet().stream()
+          .max(Map.Entry.<String, Long>comparingByValue().thenComparing(Map.Entry::getKey))
+          .map(Map.Entry::getKey)
+          .orElse(UNKNOWN_STATE);
+    }
+  }
+
+  private static final class StateAggregate {
+    private final String stateName;
+    private long transitionInCount;
+    private long transitionOutCount;
+    private long stoppedCount;
+    private long missingSlotCount;
+    private long policyHitCount;
+    private long riskHitCount;
+    private long humanInterventionCount;
+    private long dwellSecondsSum;
+    private long dwellSampleCount;
+
+    private StateAggregate(String stateName) {
+      this.stateName = Objects.requireNonNull(stateName);
+    }
+
+    String stateName() {
+      return stateName;
+    }
+
+    long stoppedCount() {
+      return stoppedCount;
+    }
+
+    long averageDwellSeconds() {
+      return dwellSampleCount == 0 ? 0 : Math.round((double) dwellSecondsSum / dwellSampleCount);
+    }
+
+    boolean hasSignal() {
+      return totalSignalCount() > 0;
+    }
+
+    long totalSignalCount() {
+      return transitionInCount
+          + transitionOutCount
+          + stoppedCount
+          + missingSlotCount
+          + policyHitCount
+          + riskHitCount
+          + humanInterventionCount;
+    }
+  }
+}

--- a/backend/src/main/java/com/init/workflowruntime/application/command/GetWorkflowBottleneckAnalysisCommand.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/command/GetWorkflowBottleneckAnalysisCommand.java
@@ -1,0 +1,16 @@
+package com.init.workflowruntime.application.command;
+
+import java.time.LocalDate;
+
+public record GetWorkflowBottleneckAnalysisCommand(
+    Long workspaceId,
+    Long userId,
+    Long workflowDefinitionId,
+    LocalDate fromDate,
+    LocalDate toDate) {
+
+  public GetWorkflowBottleneckAnalysisCommand(
+      Long workspaceId, Long userId, Long workflowDefinitionId) {
+    this(workspaceId, userId, workflowDefinitionId, null, null);
+  }
+}

--- a/backend/src/main/java/com/init/workflowruntime/application/dto/WorkflowHitMetricResponse.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/dto/WorkflowHitMetricResponse.java
@@ -1,0 +1,4 @@
+package com.init.workflowruntime.application.dto;
+
+public record WorkflowHitMetricResponse(
+    String name, long count, String stateName, String description) {}

--- a/backend/src/main/java/com/init/workflowruntime/application/dto/WorkflowHumanInterventionMetricResponse.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/dto/WorkflowHumanInterventionMetricResponse.java
@@ -1,0 +1,4 @@
+package com.init.workflowruntime.application.dto;
+
+public record WorkflowHumanInterventionMetricResponse(
+    String stateName, long count, String description) {}

--- a/backend/src/main/java/com/init/workflowruntime/application/dto/WorkflowStateBottleneckResponse.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/dto/WorkflowStateBottleneckResponse.java
@@ -1,0 +1,4 @@
+package com.init.workflowruntime.application.dto;
+
+public record WorkflowStateBottleneckResponse(
+    String stateName, long metricValue, long executionCount, String description) {}

--- a/backend/src/main/java/com/init/workflowruntime/application/dto/WorkflowTransitionMetricResponse.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/dto/WorkflowTransitionMetricResponse.java
@@ -1,0 +1,3 @@
+package com.init.workflowruntime.application.dto;
+
+public record WorkflowTransitionMetricResponse(String stateFrom, String stateTo, long passCount) {}

--- a/backend/src/main/java/com/init/workflowruntime/application/dto/WorkspaceWorkflowBottleneckAnalysisResponse.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/dto/WorkspaceWorkflowBottleneckAnalysisResponse.java
@@ -1,0 +1,23 @@
+package com.init.workflowruntime.application.dto;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+public record WorkspaceWorkflowBottleneckAnalysisResponse(
+    Long workspaceId,
+    Long workflowDefinitionId,
+    OffsetDateTime periodStart,
+    OffsetDateTime periodEnd,
+    long totalExecutionCount,
+    long completedCount,
+    long failedCount,
+    long runningCount,
+    List<WorkflowTransitionMetricResponse> transitions,
+    WorkflowStateBottleneckResponse longestDwellState,
+    WorkflowStateBottleneckResponse mostStoppedState,
+    List<WorkflowHitMetricResponse> stateMetrics,
+    List<WorkflowHitMetricResponse> missingSlotTop,
+    List<WorkflowHitMetricResponse> policyHitTop,
+    List<WorkflowHitMetricResponse> riskHitTop,
+    List<WorkflowHumanInterventionMetricResponse> humanInterventionPoints,
+    List<String> improvementHints) {}

--- a/backend/src/main/java/com/init/workflowruntime/domain/WorkflowBottleneckAnalysisRepository.java
+++ b/backend/src/main/java/com/init/workflowruntime/domain/WorkflowBottleneckAnalysisRepository.java
@@ -1,0 +1,25 @@
+package com.init.workflowruntime.domain;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+public interface WorkflowBottleneckAnalysisRepository {
+
+  List<WorkflowBottleneckExecutionRow> findExecutionRows(
+      Long workspaceId,
+      Long workflowDefinitionId,
+      OffsetDateTime periodStart,
+      OffsetDateTime periodEnd);
+
+  List<WorkflowBottleneckStepRow> findStepRows(
+      Long workspaceId,
+      Long workflowDefinitionId,
+      OffsetDateTime periodStart,
+      OffsetDateTime periodEnd);
+
+  List<WorkflowBottleneckDecisionRow> findDecisionRows(
+      Long workspaceId,
+      Long workflowDefinitionId,
+      OffsetDateTime periodStart,
+      OffsetDateTime periodEnd);
+}

--- a/backend/src/main/java/com/init/workflowruntime/domain/WorkflowBottleneckDecisionRow.java
+++ b/backend/src/main/java/com/init/workflowruntime/domain/WorkflowBottleneckDecisionRow.java
@@ -1,0 +1,12 @@
+package com.init.workflowruntime.domain;
+
+import java.time.OffsetDateTime;
+
+public record WorkflowBottleneckDecisionRow(
+    Long executionId,
+    String stateName,
+    String selectedAction,
+    String missingSlotsJson,
+    String policyHitsJson,
+    String riskHitsJson,
+    OffsetDateTime createdAt) {}

--- a/backend/src/main/java/com/init/workflowruntime/domain/WorkflowBottleneckExecutionRow.java
+++ b/backend/src/main/java/com/init/workflowruntime/domain/WorkflowBottleneckExecutionRow.java
@@ -1,0 +1,10 @@
+package com.init.workflowruntime.domain;
+
+import java.time.OffsetDateTime;
+
+public record WorkflowBottleneckExecutionRow(
+    Long executionId,
+    String status,
+    String currentState,
+    OffsetDateTime startedAt,
+    OffsetDateTime finishedAt) {}

--- a/backend/src/main/java/com/init/workflowruntime/domain/WorkflowBottleneckStepRow.java
+++ b/backend/src/main/java/com/init/workflowruntime/domain/WorkflowBottleneckStepRow.java
@@ -1,0 +1,10 @@
+package com.init.workflowruntime.domain;
+
+import java.time.OffsetDateTime;
+
+public record WorkflowBottleneckStepRow(
+    Long executionId,
+    String stateFrom,
+    String stateTo,
+    String actionType,
+    OffsetDateTime createdAt) {}

--- a/backend/src/main/java/com/init/workflowruntime/infrastructure/persistence/JpaWorkflowBottleneckAnalysisRepository.java
+++ b/backend/src/main/java/com/init/workflowruntime/infrastructure/persistence/JpaWorkflowBottleneckAnalysisRepository.java
@@ -1,0 +1,198 @@
+package com.init.workflowruntime.infrastructure.persistence;
+
+import static com.init.shared.infrastructure.persistence.NativeQueryColumnConverter.toLong;
+import static com.init.shared.infrastructure.persistence.NativeQueryColumnConverter.toOffsetDateTime;
+
+import com.init.workflowruntime.domain.WorkflowBottleneckAnalysisRepository;
+import com.init.workflowruntime.domain.WorkflowBottleneckDecisionRow;
+import com.init.workflowruntime.domain.WorkflowBottleneckExecutionRow;
+import com.init.workflowruntime.domain.WorkflowBottleneckStepRow;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import java.nio.charset.StandardCharsets;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class JpaWorkflowBottleneckAnalysisRepository
+    implements WorkflowBottleneckAnalysisRepository {
+
+  private final EntityManager entityManager;
+
+  public JpaWorkflowBottleneckAnalysisRepository(EntityManager entityManager) {
+    this.entityManager = entityManager;
+  }
+
+  @Override
+  public List<WorkflowBottleneckExecutionRow> findExecutionRows(
+      Long workspaceId,
+      Long workflowDefinitionId,
+      OffsetDateTime periodStart,
+      OffsetDateTime periodEnd) {
+    Query query =
+        scopedQuery(
+            """
+            select
+              we.id,
+              we.status,
+              we.current_state,
+              we.started_at,
+              we.finished_at
+            from runtime.workflow_execution we
+            join runtime.chat_session cs on cs.id = we.chat_session_id
+            where cs.workspace_id = :workspaceId
+              and we.workflow_definition_id = :workflowDefinitionId
+              and we.started_at >= :periodStart
+              and we.started_at < :periodEnd
+              and (
+                cs.channel is null
+                or (
+                  upper(cs.channel) not in ('DEMO', 'DEMO_WEB', 'SIMULATION', 'SIMULATION_WEB')
+                  and upper(cs.channel) not like 'SIMULATION%'
+                )
+              )
+            order by we.started_at asc, we.id asc
+            """,
+            workspaceId, workflowDefinitionId, periodStart, periodEnd);
+
+    @SuppressWarnings("unchecked")
+    List<Object[]> rows = query.getResultList();
+    return rows.stream().map(this::toExecutionRow).toList();
+  }
+
+  @Override
+  public List<WorkflowBottleneckStepRow> findStepRows(
+      Long workspaceId,
+      Long workflowDefinitionId,
+      OffsetDateTime periodStart,
+      OffsetDateTime periodEnd) {
+    Query query =
+        scopedQuery(
+            """
+            select
+              wes.workflow_execution_id,
+              wes.state_from,
+              wes.state_to,
+              wes.action_type,
+              wes.created_at
+            from runtime.workflow_execution_step wes
+            join runtime.workflow_execution we on we.id = wes.workflow_execution_id
+            join runtime.chat_session cs on cs.id = we.chat_session_id
+            where cs.workspace_id = :workspaceId
+              and we.workflow_definition_id = :workflowDefinitionId
+              and we.started_at >= :periodStart
+              and we.started_at < :periodEnd
+              and (
+                cs.channel is null
+                or (
+                  upper(cs.channel) not in ('DEMO', 'DEMO_WEB', 'SIMULATION', 'SIMULATION_WEB')
+                  and upper(cs.channel) not like 'SIMULATION%'
+                )
+              )
+            order by wes.workflow_execution_id asc, wes.seq_no asc, wes.id asc
+            """,
+            workspaceId, workflowDefinitionId, periodStart, periodEnd);
+
+    @SuppressWarnings("unchecked")
+    List<Object[]> rows = query.getResultList();
+    return rows.stream().map(this::toStepRow).toList();
+  }
+
+  @Override
+  public List<WorkflowBottleneckDecisionRow> findDecisionRows(
+      Long workspaceId,
+      Long workflowDefinitionId,
+      OffsetDateTime periodStart,
+      OffsetDateTime periodEnd) {
+    Query query =
+        scopedQuery(
+            """
+            select
+              dl.workflow_execution_id,
+              dl.state_name,
+              dl.selected_action,
+              dl.missing_slots_json,
+              dl.policy_hits_json,
+              dl.risk_hits_json,
+              dl.created_at
+            from runtime.decision_log dl
+            join runtime.workflow_execution we on we.id = dl.workflow_execution_id
+            join runtime.chat_session cs on cs.id = we.chat_session_id
+            where cs.workspace_id = :workspaceId
+              and we.workflow_definition_id = :workflowDefinitionId
+              and we.started_at >= :periodStart
+              and we.started_at < :periodEnd
+              and (
+                cs.channel is null
+                or (
+                  upper(cs.channel) not in ('DEMO', 'DEMO_WEB', 'SIMULATION', 'SIMULATION_WEB')
+                  and upper(cs.channel) not like 'SIMULATION%'
+                )
+              )
+            order by dl.workflow_execution_id asc, dl.step_seq_no asc, dl.id asc
+            """,
+            workspaceId, workflowDefinitionId, periodStart, periodEnd);
+
+    @SuppressWarnings("unchecked")
+    List<Object[]> rows = query.getResultList();
+    return rows.stream().map(this::toDecisionRow).toList();
+  }
+
+  private Query scopedQuery(
+      String sql,
+      Long workspaceId,
+      Long workflowDefinitionId,
+      OffsetDateTime periodStart,
+      OffsetDateTime periodEnd) {
+    Query query = entityManager.createNativeQuery(sql);
+    query.setParameter("workspaceId", workspaceId);
+    query.setParameter("workflowDefinitionId", workflowDefinitionId);
+    query.setParameter("periodStart", periodStart);
+    query.setParameter("periodEnd", periodEnd);
+    return query;
+  }
+
+  private WorkflowBottleneckExecutionRow toExecutionRow(Object[] row) {
+    return new WorkflowBottleneckExecutionRow(
+        toLong(row[0]),
+        toStringValue(row[1]),
+        toStringValue(row[2]),
+        toOffsetDateTime(row[3]),
+        toOffsetDateTime(row[4]));
+  }
+
+  private WorkflowBottleneckStepRow toStepRow(Object[] row) {
+    return new WorkflowBottleneckStepRow(
+        toLong(row[0]),
+        toStringValue(row[1]),
+        toStringValue(row[2]),
+        toStringValue(row[3]),
+        toOffsetDateTime(row[4]));
+  }
+
+  private WorkflowBottleneckDecisionRow toDecisionRow(Object[] row) {
+    return new WorkflowBottleneckDecisionRow(
+        toLong(row[0]),
+        toStringValue(row[1]),
+        toStringValue(row[2]),
+        toJsonText(row[3]),
+        toJsonText(row[4]),
+        toJsonText(row[5]),
+        toOffsetDateTime(row[6]));
+  }
+
+  private String toStringValue(Object value) {
+    return value == null ? null : String.valueOf(value);
+  }
+
+  private String toJsonText(Object value) {
+    if (value == null) {
+      return null;
+    }
+    if (value instanceof byte[] bytes) {
+      return new String(bytes, StandardCharsets.UTF_8);
+    }
+    return String.valueOf(value);
+  }
+}

--- a/backend/src/main/java/com/init/workflowruntime/presentation/WorkspaceWorkflowBottleneckAnalysisController.java
+++ b/backend/src/main/java/com/init/workflowruntime/presentation/WorkspaceWorkflowBottleneckAnalysisController.java
@@ -1,0 +1,41 @@
+package com.init.workflowruntime.presentation;
+
+import com.init.shared.presentation.AuthenticationUtils;
+import com.init.workflowruntime.application.WorkspaceWorkflowBottleneckAnalysisService;
+import com.init.workflowruntime.application.command.GetWorkflowBottleneckAnalysisCommand;
+import com.init.workflowruntime.application.dto.WorkspaceWorkflowBottleneckAnalysisResponse;
+import java.time.LocalDate;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/workspaces/{workspaceId}/dashboard/workflows")
+public class WorkspaceWorkflowBottleneckAnalysisController {
+
+  private final WorkspaceWorkflowBottleneckAnalysisService analysisService;
+
+  public WorkspaceWorkflowBottleneckAnalysisController(
+      WorkspaceWorkflowBottleneckAnalysisService analysisService) {
+    this.analysisService = analysisService;
+  }
+
+  @GetMapping("/{workflowDefinitionId}/bottleneck-analysis")
+  public ResponseEntity<WorkspaceWorkflowBottleneckAnalysisResponse> getBottleneckAnalysis(
+      @PathVariable Long workspaceId,
+      @PathVariable Long workflowDefinitionId,
+      @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+      @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to,
+      Authentication authentication) {
+    Long userId = AuthenticationUtils.getUserId(authentication);
+    return ResponseEntity.ok(
+        analysisService.getAnalysis(
+            new GetWorkflowBottleneckAnalysisCommand(
+                workspaceId, userId, workflowDefinitionId, from, to)));
+  }
+}

--- a/backend/src/test/java/com/init/workflowruntime/application/WorkspaceWorkflowBottleneckAnalysisServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/WorkspaceWorkflowBottleneckAnalysisServiceTest.java
@@ -1,0 +1,170 @@
+package com.init.workflowruntime.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.init.workflowruntime.application.command.GetWorkflowBottleneckAnalysisCommand;
+import com.init.workflowruntime.application.dto.WorkspaceWorkflowBottleneckAnalysisResponse;
+import com.init.workflowruntime.domain.WorkflowBottleneckAnalysisRepository;
+import com.init.workflowruntime.domain.WorkflowBottleneckDecisionRow;
+import com.init.workflowruntime.domain.WorkflowBottleneckExecutionRow;
+import com.init.workflowruntime.domain.WorkflowBottleneckStepRow;
+import com.init.workflowruntime.domain.WorkflowExecution;
+import com.init.workspace.application.exception.WorkspaceAccessDeniedException;
+import com.init.workspace.domain.model.WorkspaceMember;
+import com.init.workspace.domain.model.WorkspaceMemberRole;
+import com.init.workspace.domain.repository.WorkspaceMemberRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("WorkspaceWorkflowBottleneckAnalysisService")
+class WorkspaceWorkflowBottleneckAnalysisServiceTest {
+
+  private static final Long WORKSPACE_ID = 2L;
+  private static final Long USER_ID = 7L;
+  private static final Long WORKFLOW_ID = 100L;
+  private static final ZoneId SEOUL = ZoneId.of("Asia/Seoul");
+
+  @Mock private WorkflowBottleneckAnalysisRepository analysisRepository;
+  @Mock private WorkspaceMemberRepository workspaceMemberRepository;
+
+  private WorkspaceWorkflowBottleneckAnalysisService service;
+
+  @BeforeEach
+  void setUp() {
+    Clock clock = Clock.fixed(Instant.parse("2026-06-04T03:00:00Z"), SEOUL);
+    service =
+        new WorkspaceWorkflowBottleneckAnalysisService(
+            analysisRepository, workspaceMemberRepository, new ObjectMapper(), clock);
+  }
+
+  @Test
+  @DisplayName("상태 전이, 병목 state, TOP hit, 상담사 개입 지점을 계산한다")
+  void should_calculateBottleneckAnalysis_when_runtimeLogsExist() {
+    OffsetDateTime start = OffsetDateTime.parse("2026-05-29T00:00:00+09:00");
+    OffsetDateTime end = OffsetDateTime.parse("2026-06-05T00:00:00+09:00");
+    givenMember();
+    given(analysisRepository.findExecutionRows(WORKSPACE_ID, WORKFLOW_ID, start, end))
+        .willReturn(
+            List.of(
+                execution(1L, WorkflowExecution.STATUS_COMPLETED, "done"),
+                execution(2L, WorkflowExecution.STATUS_FAILED, "verify_policy"),
+                execution(3L, WorkflowExecution.STATUS_RUNNING, "collect_slots"),
+                execution(4L, WorkflowExecution.STATUS_RUNNING, "verify_policy")));
+    given(analysisRepository.findStepRows(WORKSPACE_ID, WORKFLOW_ID, start, end))
+        .willReturn(
+            List.of(
+                step(1L, null, "collect_slots", "ASSIGN_INTENT", "2026-06-01T10:00:00+09:00"),
+                step(1L, "collect_slots", "verify_policy", "ADVANCE", "2026-06-01T10:07:00+09:00"),
+                step(1L, "verify_policy", "done", "COMPLETED", "2026-06-01T10:08:00+09:00"),
+                step(2L, null, "collect_slots", "ASSIGN_INTENT", "2026-06-01T11:00:00+09:00"),
+                step(
+                    2L, "collect_slots", "verify_policy", "HANDOFF", "2026-06-01T11:05:00+09:00")));
+    given(analysisRepository.findDecisionRows(WORKSPACE_ID, WORKFLOW_ID, start, end))
+        .willReturn(
+            List.of(
+                decision(
+                    1L,
+                    "collect_slots",
+                    null,
+                    "[\"order_id\",{\"slotCode\":\"customer_name\"}]",
+                    "[{\"policyCode\":\"refund_window\"}]",
+                    "[]"),
+                decision(2L, "verify_policy", "HANDOFF_REQUIRED", "[\"order_id\"]", "[]", "[]"),
+                decision(3L, "collect_slots", null, "not-json", "[]", "[{\"riskCode\":\"vip\"}]")));
+
+    WorkspaceWorkflowBottleneckAnalysisResponse response =
+        service.getAnalysis(
+            new GetWorkflowBottleneckAnalysisCommand(
+                WORKSPACE_ID,
+                USER_ID,
+                WORKFLOW_ID,
+                LocalDate.parse("2026-05-29"),
+                LocalDate.parse("2026-06-04")));
+
+    assertThat(response.totalExecutionCount()).isEqualTo(4);
+    assertThat(response.completedCount()).isEqualTo(1);
+    assertThat(response.failedCount()).isEqualTo(1);
+    assertThat(response.runningCount()).isEqualTo(2);
+    assertThat(response.transitions())
+        .anySatisfy(
+            transition -> {
+              assertThat(transition.stateFrom()).isEqualTo("collect_slots");
+              assertThat(transition.stateTo()).isEqualTo("verify_policy");
+              assertThat(transition.passCount()).isEqualTo(2);
+            });
+    assertThat(response.longestDwellState().stateName()).isEqualTo("collect_slots");
+    assertThat(response.longestDwellState().metricValue()).isEqualTo(360);
+    assertThat(response.mostStoppedState().stateName()).isEqualTo("verify_policy");
+    assertThat(response.missingSlotTop().get(0).name()).isEqualTo("order_id");
+    assertThat(response.missingSlotTop().get(0).count()).isEqualTo(2);
+    assertThat(response.policyHitTop().get(0).name()).isEqualTo("refund_window");
+    assertThat(response.riskHitTop().get(0).name()).isEqualTo("vip");
+    assertThat(response.humanInterventionPoints().get(0).stateName()).isEqualTo("verify_policy");
+    assertThat(response.improvementHints())
+        .anySatisfy(hint -> assertThat(hint).contains("order_id"));
+  }
+
+  @Test
+  @DisplayName("워크스페이스 멤버가 아니면 분석 조회를 거부한다")
+  void should_throwAccessDenied_when_userIsNotWorkspaceMember() {
+    given(workspaceMemberRepository.findByWorkspaceIdAndUserId(WORKSPACE_ID, USER_ID))
+        .willReturn(Optional.empty());
+
+    assertThatThrownBy(
+            () ->
+                service.getAnalysis(
+                    new GetWorkflowBottleneckAnalysisCommand(WORKSPACE_ID, USER_ID, WORKFLOW_ID)))
+        .isInstanceOf(WorkspaceAccessDeniedException.class);
+    verifyNoInteractions(analysisRepository);
+  }
+
+  private void givenMember() {
+    given(workspaceMemberRepository.findByWorkspaceIdAndUserId(WORKSPACE_ID, USER_ID))
+        .willReturn(
+            Optional.of(WorkspaceMember.create(WORKSPACE_ID, USER_ID, WorkspaceMemberRole.OWNER)));
+  }
+
+  private WorkflowBottleneckExecutionRow execution(Long id, String status, String currentState) {
+    return new WorkflowBottleneckExecutionRow(
+        id, status, currentState, OffsetDateTime.parse("2026-06-01T09:00:00+09:00"), null);
+  }
+
+  private WorkflowBottleneckStepRow step(
+      Long executionId, String from, String to, String actionType, String createdAt) {
+    return new WorkflowBottleneckStepRow(
+        executionId, from, to, actionType, OffsetDateTime.parse(createdAt));
+  }
+
+  private WorkflowBottleneckDecisionRow decision(
+      Long executionId,
+      String state,
+      String selectedAction,
+      String missingSlotsJson,
+      String policyHitsJson,
+      String riskHitsJson) {
+    return new WorkflowBottleneckDecisionRow(
+        executionId,
+        state,
+        selectedAction,
+        missingSlotsJson,
+        policyHitsJson,
+        riskHitsJson,
+        OffsetDateTime.parse("2026-06-01T09:00:00+09:00"));
+  }
+}

--- a/frontend/src/features/consultation/api/consultationApi.test.ts
+++ b/frontend/src/features/consultation/api/consultationApi.test.ts
@@ -724,4 +724,78 @@ describe("consultationApi", () => {
     );
     expect(result).toEqual(stubRanking);
   });
+
+  it("getWorkflowBottleneckAnalysis가 워크플로우 병목 분석 endpoint를 호출한다", async () => {
+    const stubAnalysis = {
+      workspaceId: 2,
+      workflowDefinitionId: 10,
+      periodStart: "2026-05-21T00:00:00+09:00",
+      periodEnd: "2026-05-28T00:00:00+09:00",
+      totalExecutionCount: 3,
+      completedCount: 1,
+      failedCount: 1,
+      runningCount: 1,
+      transitions: [{ stateFrom: "collect_slots", stateTo: "verify_policy", passCount: 2 }],
+      longestDwellState: {
+        stateName: "collect_slots",
+        metricValue: 420,
+        executionCount: 2,
+        description: "평균 420초 동안 머문 state",
+      },
+      mostStoppedState: null,
+      stateMetrics: [],
+      missingSlotTop: [],
+      policyHitTop: [],
+      riskHitTop: [],
+      humanInterventionPoints: [],
+      improvementHints: [],
+    };
+    mockedCustomFetch.mockResolvedValue({
+      data: stubAnalysis,
+      status: 200,
+      headers: new Headers(),
+    });
+
+    const result = await consultationApi.getWorkflowBottleneckAnalysis(2, 10, {
+      from: "2026-05-21",
+      to: "2026-05-27",
+    });
+
+    expect(mockedCustomFetch).toHaveBeenCalledWith(
+      "/api/v1/workspaces/2/dashboard/workflows/10/bottleneck-analysis?from=2026-05-21&to=2026-05-27",
+      { method: "GET" },
+    );
+    expect(result).toEqual(stubAnalysis);
+  });
+
+  it("getWorkflowBottleneckAnalysis가 기간 없이 워크플로우 병목 분석 endpoint를 호출한다", async () => {
+    const stubAnalysis = {
+      workspaceId: 2,
+      workflowDefinitionId: 10,
+      periodStart: "2026-05-29T00:00:00+09:00",
+      periodEnd: "2026-06-05T00:00:00+09:00",
+      totalExecutionCount: 0,
+      completedCount: 0,
+      failedCount: 0,
+      runningCount: 0,
+      transitions: [],
+      longestDwellState: null,
+      mostStoppedState: null,
+      stateMetrics: [],
+      missingSlotTop: [],
+      policyHitTop: [],
+      riskHitTop: [],
+      humanInterventionPoints: [],
+      improvementHints: [],
+    };
+    mockedCustomFetch.mockResolvedValue(stubAnalysis as never);
+
+    const result = await consultationApi.getWorkflowBottleneckAnalysis(2, 10);
+
+    expect(mockedCustomFetch).toHaveBeenCalledWith(
+      "/api/v1/workspaces/2/dashboard/workflows/10/bottleneck-analysis",
+      { method: "GET" },
+    );
+    expect(result).toEqual(stubAnalysis);
+  });
 });

--- a/frontend/src/features/consultation/api/consultationApi.ts
+++ b/frontend/src/features/consultation/api/consultationApi.ts
@@ -9,7 +9,7 @@ import { requireApiData, selectApiData } from "@/shared/api";
 import type { ChatMessageResponse, ChatSessionResponse } from "@/shared/api/generated/zod";
 
 // OpenAPI 미생성 endpoint: workspace-scoped queue/metrics/sessions list,
-// dashboard workflow rankings, assign/release, draft-response는 수동 호출로 유지한다.
+// dashboard workflow rankings/bottleneck analysis, assign/release, draft-response는 수동 호출로 유지한다.
 
 export type ChatSession = Omit<ChatSessionResponse, "responseMode"> & {
   assignedCounselorId?: number | null;
@@ -141,6 +141,52 @@ export interface WorkspaceWorkflowRankingResponse {
   totalConsultationCount: number;
   rankings: WorkspaceWorkflowRanking[];
   topRankings: WorkspaceWorkflowRanking[];
+}
+
+export interface WorkflowTransitionMetric {
+  stateFrom: string | null;
+  stateTo: string;
+  passCount: number;
+}
+
+export interface WorkflowStateBottleneck {
+  stateName: string;
+  metricValue: number;
+  executionCount: number;
+  description: string;
+}
+
+export interface WorkflowHitMetric {
+  name: string;
+  count: number;
+  stateName: string;
+  description: string;
+}
+
+export interface WorkflowHumanInterventionMetric {
+  stateName: string;
+  count: number;
+  description: string;
+}
+
+export interface WorkspaceWorkflowBottleneckAnalysis {
+  workspaceId: number;
+  workflowDefinitionId: number;
+  periodStart: string;
+  periodEnd: string;
+  totalExecutionCount: number;
+  completedCount: number;
+  failedCount: number;
+  runningCount: number;
+  transitions: WorkflowTransitionMetric[];
+  longestDwellState: WorkflowStateBottleneck | null;
+  mostStoppedState: WorkflowStateBottleneck | null;
+  stateMetrics: WorkflowHitMetric[];
+  missingSlotTop: WorkflowHitMetric[];
+  policyHitTop: WorkflowHitMetric[];
+  riskHitTop: WorkflowHitMetric[];
+  humanInterventionPoints: WorkflowHumanInterventionMetric[];
+  improvementHints: string[];
 }
 
 export interface DraftResponse {
@@ -402,6 +448,25 @@ export const consultationApi = {
     return requireApiData<WorkspaceWorkflowRankingResponse>(
       response,
       "워크플로우 랭킹 응답을 확인할 수 없습니다.",
+    );
+  },
+
+  getWorkflowBottleneckAnalysis: async (
+    workspaceId: number,
+    workflowDefinitionId: number,
+    params: ConsultationMetricsParams = {},
+  ): Promise<WorkspaceWorkflowBottleneckAnalysis> => {
+    const searchParams = new URLSearchParams();
+    if (params.from) searchParams.set("from", params.from);
+    if (params.to) searchParams.set("to", params.to);
+    const query = searchParams.toString();
+    const url = `/api/v1/workspaces/${workspaceId}/dashboard/workflows/${workflowDefinitionId}/bottleneck-analysis${query ? `?${query}` : ""}`;
+    const response = await customFetch<
+      WorkspaceWorkflowBottleneckAnalysis | { data?: WorkspaceWorkflowBottleneckAnalysis }
+    >(url, { method: "GET" });
+    return requireApiData<WorkspaceWorkflowBottleneckAnalysis>(
+      response,
+      "워크플로우 병목 분석 응답을 확인할 수 없습니다.",
     );
   },
 

--- a/frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.test.tsx
+++ b/frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.test.tsx
@@ -8,6 +8,7 @@ const mockUseGetWorkflowDefinition = vi.fn();
 const mockUsePackDetail = vi.fn();
 const mockCreateRevisionDraft = vi.fn();
 const mockListWorkflows = vi.fn();
+const mockGetWorkflowBottleneckAnalysis = vi.fn();
 const mockToastSuccess = vi.fn();
 const mockToastError = vi.fn();
 vi.mock("@/entities/workflow", () => ({
@@ -16,6 +17,13 @@ vi.mock("@/entities/workflow", () => ({
 
 vi.mock("@/features/domain-pack-summary-read", () => ({
   usePackDetail: (...args: unknown[]) => mockUsePackDetail(...args),
+}));
+
+vi.mock("@/features/consultation/api/consultationApi", () => ({
+  consultationApi: {
+    getWorkflowBottleneckAnalysis: (...args: unknown[]) =>
+      mockGetWorkflowBottleneckAnalysis(...args),
+  },
 }));
 
 vi.mock("@/features/update-workflow", () => ({
@@ -103,8 +111,28 @@ beforeEach(() => {
   mockUsePackDetail.mockReset();
   mockCreateRevisionDraft.mockReset();
   mockListWorkflows.mockReset();
+  mockGetWorkflowBottleneckAnalysis.mockReset();
   mockToastSuccess.mockReset();
   mockToastError.mockReset();
+  mockGetWorkflowBottleneckAnalysis.mockResolvedValue({
+    workspaceId: 1,
+    workflowDefinitionId: 10,
+    periodStart: "2026-05-29T00:00:00+09:00",
+    periodEnd: "2026-06-05T00:00:00+09:00",
+    totalExecutionCount: 0,
+    completedCount: 0,
+    failedCount: 0,
+    runningCount: 0,
+    transitions: [],
+    longestDwellState: null,
+    mostStoppedState: null,
+    stateMetrics: [],
+    missingSlotTop: [],
+    policyHitTop: [],
+    riskHitTop: [],
+    humanInterventionPoints: [],
+    improvementHints: ["선택 기간에 개선 우선순위를 판단할 병목 신호가 아직 충분하지 않습니다."],
+  });
   mockUsePackDetail.mockReturnValue({
     data: {
       name: "CS Pack",
@@ -170,6 +198,167 @@ describe("WorkflowDraftReadPage", () => {
     expect(screen.queryByText("refund.standard")).not.toBeInTheDocument();
     expect(screen.getByText("노드 2개")).toBeInTheDocument();
     expect(screen.getByTestId("graph-viewer")).toHaveTextContent("graph nodes: 2");
+  });
+
+  it("운영 실행 병목 분석 패널을 표시한다", async () => {
+    mockGetWorkflowBottleneckAnalysis.mockResolvedValueOnce({
+      workspaceId: 1,
+      workflowDefinitionId: 10,
+      periodStart: "2026-05-29T00:00:00+09:00",
+      periodEnd: "2026-06-05T00:00:00+09:00",
+      totalExecutionCount: 3,
+      completedCount: 1,
+      failedCount: 1,
+      runningCount: 1,
+      transitions: [{ stateFrom: "collect_slots", stateTo: "verify_policy", passCount: 2 }],
+      longestDwellState: {
+        stateName: "collect_slots",
+        metricValue: 420,
+        executionCount: 2,
+        description: "평균 420초 동안 머문 state",
+      },
+      mostStoppedState: {
+        stateName: "verify_policy",
+        metricValue: 1,
+        executionCount: 1,
+        description: "실패/진행 중 실행이 가장 많이 멈춘 state",
+      },
+      stateMetrics: [],
+      missingSlotTop: [
+        {
+          name: "order_id",
+          count: 2,
+          stateName: "collect_slots",
+          description: "collect_slots에서 자주 비어 있는 slot",
+        },
+      ],
+      policyHitTop: [],
+      riskHitTop: [],
+      humanInterventionPoints: [
+        {
+          stateName: "verify_policy",
+          count: 1,
+          description: "상담사 개입 action이 자주 발생한 state",
+        },
+      ],
+      improvementHints: ["order_id slot 수집 문구와 검증 규칙을 우선 점검하세요."],
+    });
+    mockUseGetWorkflowDefinition.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: {
+        id: 10,
+        name: "환불 처리",
+        workflowCode: "refund.standard",
+        graphJson: JSON.stringify({ direction: "LR", nodes: [], edges: [] }),
+      },
+    });
+
+    renderPage("/workspaces/1/domain-packs/2/workflows/10?versionId=3");
+
+    expect(await screen.findByTestId("workflow-analysis-panel")).toHaveTextContent(
+      "운영 실행 병목 분석",
+    );
+    expect(screen.getByText("전체 실행")).toBeInTheDocument();
+    expect(screen.getAllByText("collect_slots").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("verify_policy").length).toBeGreaterThan(0);
+    expect(screen.getByText("order_id")).toBeInTheDocument();
+    expect(screen.getByText("2026-05-29 ~ 2026-06-04")).toBeInTheDocument();
+    expect(screen.getByText("7분 평균 체류")).toBeInTheDocument();
+    expect(mockGetWorkflowBottleneckAnalysis).toHaveBeenCalledWith(1, 10);
+  });
+
+  it("운영 실행 병목 분석 로딩 상태를 표시한다", async () => {
+    mockGetWorkflowBottleneckAnalysis.mockReturnValueOnce(new Promise(() => undefined));
+    mockUseGetWorkflowDefinition.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: {
+        id: 10,
+        name: "환불 처리",
+        workflowCode: "refund.standard",
+        graphJson: JSON.stringify({ direction: "LR", nodes: [], edges: [] }),
+      },
+    });
+
+    renderPage("/workspaces/1/domain-packs/2/workflows/10?versionId=3");
+
+    expect(await screen.findByTestId("workflow-analysis-loading")).toHaveTextContent(
+      "워크플로우 병목 분석을 불러오는 중입니다.",
+    );
+  });
+
+  it("운영 실행 병목 분석 데이터가 없으면 빈 상태를 표시한다", async () => {
+    mockUseGetWorkflowDefinition.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: {
+        id: 10,
+        name: "환불 처리",
+        workflowCode: "refund.standard",
+        graphJson: JSON.stringify({ direction: "LR", nodes: [], edges: [] }),
+      },
+    });
+
+    renderPage("/workspaces/1/domain-packs/2/workflows/10?versionId=3");
+
+    expect(await screen.findByTestId("workflow-analysis-empty")).toHaveTextContent(
+      "선택 기간에 분석할 운영 실행 로그가 없습니다.",
+    );
+  });
+
+  it("운영 실행 병목 분석 실패 상태에서 다시 시도할 수 있다", async () => {
+    mockGetWorkflowBottleneckAnalysis
+      .mockRejectedValueOnce(new Error("network"))
+      .mockResolvedValueOnce({
+        workspaceId: 1,
+        workflowDefinitionId: 10,
+        periodStart: "2026-05-29T00:00:00+09:00",
+        periodEnd: "2026-06-05T00:00:00+09:00",
+        totalExecutionCount: 1,
+        completedCount: 0,
+        failedCount: 0,
+        runningCount: 1,
+        transitions: [],
+        longestDwellState: {
+          stateName: "collect_slots",
+          metricValue: 75,
+          executionCount: 1,
+          description: "평균 75초 동안 머문 state",
+        },
+        mostStoppedState: null,
+        stateMetrics: [],
+        missingSlotTop: [],
+        policyHitTop: [],
+        riskHitTop: [],
+        humanInterventionPoints: [],
+        improvementHints: ["collect_slots에서 머무는 시간이 길어 다음 안내 문구나 조건을 점검하세요."],
+      });
+    mockUseGetWorkflowDefinition.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: {
+        id: 10,
+        name: "환불 처리",
+        workflowCode: "refund.standard",
+        graphJson: JSON.stringify({ direction: "LR", nodes: [], edges: [] }),
+      },
+    });
+
+    renderPage("/workspaces/1/domain-packs/2/workflows/10?versionId=3");
+
+    expect(await screen.findByTestId("workflow-analysis-error")).toHaveTextContent(
+      "워크플로우 병목 분석을 불러오지 못했습니다.",
+    );
+    expect(mockToastError).toHaveBeenCalledWith("워크플로우 병목 분석을 불러오지 못했습니다.");
+
+    fireEvent.click(screen.getByRole("button", { name: "다시 시도" }));
+
+    expect(await screen.findByTestId("workflow-analysis-panel")).toHaveTextContent(
+      "1분 15초 평균 체류",
+    );
+    expect(screen.getByText("멈춘 실행이 관측되지 않았습니다.")).toBeInTheDocument();
+    expect(mockGetWorkflowBottleneckAnalysis).toHaveBeenCalledTimes(2);
   });
 
   it("graphJson이 없으면 빈 그래프 안내를 표시한다", () => {

--- a/frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/WorkflowDraftReadPage.tsx
@@ -2,6 +2,11 @@ import { type ReactNode, useEffect, useMemo, useState } from "react";
 import { useLocation, useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { toast } from "sonner";
 import { usePackDetail } from "@/features/domain-pack-summary-read";
+import { consultationApi } from "@/features/consultation/api/consultationApi";
+import type {
+  WorkflowHitMetric,
+  WorkspaceWorkflowBottleneckAnalysis,
+} from "@/features/consultation/api/consultationApi";
 import { InlineWorkflowEditor } from "@/features/update-workflow";
 import { intentRevisionDraftApi } from "@/features/intent-revision-draft";
 import { buildDomainPackCrumbs, domainPackSectionPath } from "@/shared/lib/domainPackRoutes";
@@ -29,6 +34,8 @@ import { unwrapApiResponse } from "@/shared/api/unwrapApiResponse";
 import { GraphViewer } from "@/features/workflow-viewer/ui/GraphViewer";
 import styles from "./workflow-draft-read-page.module.css";
 
+type AnalysisState = "loading" | "error" | "empty" | "ready";
+
 function isWorkflowGraph(v: unknown): v is WorkflowGraph {
   return (
     typeof v === "object" &&
@@ -51,6 +58,201 @@ function parseGraphJson(raw: unknown): WorkflowGraph | null {
   return isWorkflowGraph(raw) ? raw : null;
 }
 
+function formatMetricCount(value: number | null | undefined): string {
+  if (typeof value !== "number" || !Number.isFinite(value)) return "--";
+  return new Intl.NumberFormat("ko-KR").format(value);
+}
+
+function formatSeconds(value: number | null | undefined): string {
+  if (typeof value !== "number" || !Number.isFinite(value)) return "--";
+  if (value < 60) return `${value}초`;
+  const minutes = Math.floor(value / 60);
+  const seconds = value % 60;
+  return seconds === 0 ? `${minutes}분` : `${minutes}분 ${seconds}초`;
+}
+
+function formatInclusivePeriodEnd(value: string): string {
+  const [year, month, day] = value.slice(0, 10).split("-").map(Number);
+  const date = new Date(Date.UTC(year, month - 1, day));
+  if (Number.isNaN(date.getTime())) return value.slice(0, 10);
+  date.setUTCDate(date.getUTCDate() - 1);
+  return date.toISOString().slice(0, 10);
+}
+
+function HitList({ title, items }: { title: string; items: WorkflowHitMetric[] }) {
+  return (
+    <section className={styles.analysisListGroup} aria-label={title}>
+      <h4>{title}</h4>
+      {items.length > 0 ? (
+        <ol>
+          {items.map((item) => (
+            <li key={`${title}-${item.stateName}-${item.name}`}>
+              <span>
+                <strong>{item.name}</strong>
+                <em>{item.stateName}</em>
+              </span>
+              <b>{formatMetricCount(item.count)}</b>
+            </li>
+          ))}
+        </ol>
+      ) : (
+        <p className={styles.analysisEmptyText}>관측된 항목이 없습니다.</p>
+      )}
+    </section>
+  );
+}
+
+function WorkflowBottleneckAnalysisPanel({
+  analysis,
+  state,
+  error,
+  onRetry,
+}: {
+  analysis: WorkspaceWorkflowBottleneckAnalysis | null;
+  state: AnalysisState;
+  error: string | null;
+  onRetry: () => void;
+}) {
+  if (state === "loading") {
+    return (
+      <section className={styles.analysisPanel} data-testid="workflow-analysis-loading">
+        <LoadingSpinner />
+        <p className={styles.analysisEmptyText}>워크플로우 병목 분석을 불러오는 중입니다.</p>
+      </section>
+    );
+  }
+
+  if (state === "error") {
+    return (
+      <section className={styles.analysisPanel} data-testid="workflow-analysis-error">
+        <ErrorState message={error ?? "워크플로우 병목 분석을 불러오지 못했습니다."} onRetry={onRetry} />
+      </section>
+    );
+  }
+
+  if (state === "empty" || !analysis) {
+    return (
+      <section className={styles.analysisPanel} data-testid="workflow-analysis-empty">
+        <div className={styles.analysisHeader}>
+          <div>
+            <span className={styles.analysisEyebrow}>Bottleneck Analysis</span>
+            <h3>운영 실행 병목 분석</h3>
+          </div>
+        </div>
+        <p className={styles.analysisEmptyText}>선택 기간에 분석할 운영 실행 로그가 없습니다.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className={styles.analysisPanel} data-testid="workflow-analysis-panel">
+      <div className={styles.analysisHeader}>
+        <div>
+          <span className={styles.analysisEyebrow}>Bottleneck Analysis</span>
+          <h3>운영 실행 병목 분석</h3>
+          <p>
+            상태 전이와 runtime decision 로그를 기준으로 slot, policy, risk 개선 지점을
+            요약합니다.
+          </p>
+        </div>
+        <span className={styles.analysisPeriod}>
+          {analysis.periodStart.slice(0, 10)} ~ {formatInclusivePeriodEnd(analysis.periodEnd)}
+        </span>
+      </div>
+
+      <div className={styles.analysisMetricGrid} aria-label="워크플로우 실행 상태 요약">
+        <article>
+          <span>전체 실행</span>
+          <strong>{formatMetricCount(analysis.totalExecutionCount)}</strong>
+        </article>
+        <article>
+          <span>완료</span>
+          <strong>{formatMetricCount(analysis.completedCount)}</strong>
+        </article>
+        <article>
+          <span>실패</span>
+          <strong>{formatMetricCount(analysis.failedCount)}</strong>
+        </article>
+        <article>
+          <span>진행 중</span>
+          <strong>{formatMetricCount(analysis.runningCount)}</strong>
+        </article>
+      </div>
+
+      <div className={styles.bottleneckGrid}>
+        <article className={styles.bottleneckCard}>
+          <span>가장 오래 머문 state</span>
+          <strong>{analysis.longestDwellState?.stateName ?? "--"}</strong>
+          <p>
+            {analysis.longestDwellState
+              ? `${formatSeconds(analysis.longestDwellState.metricValue)} 평균 체류`
+              : "계산 가능한 연속 step이 없습니다."}
+          </p>
+        </article>
+        <article className={styles.bottleneckCard}>
+          <span>가장 많이 멈춘 state</span>
+          <strong>{analysis.mostStoppedState?.stateName ?? "--"}</strong>
+          <p>
+            {analysis.mostStoppedState
+              ? `${formatMetricCount(analysis.mostStoppedState.metricValue)}건이 실패 또는 진행 중`
+              : "멈춘 실행이 관측되지 않았습니다."}
+          </p>
+        </article>
+      </div>
+
+      <div className={styles.transitionList} aria-label="상태 전이 통과 수">
+        <h4>상태 전이 흐름</h4>
+        {analysis.transitions.length > 0 ? (
+          analysis.transitions.slice(0, 8).map((transition) => (
+            <div
+              key={`${transition.stateFrom ?? "start"}-${transition.stateTo}`}
+              className={styles.transitionRow}
+            >
+              <span>{transition.stateFrom ?? "시작"}</span>
+              <Icon name="chevron" size={13} />
+              <strong>{transition.stateTo}</strong>
+              <b>{formatMetricCount(transition.passCount)}회</b>
+            </div>
+          ))
+        ) : (
+          <p className={styles.analysisEmptyText}>표시할 상태 전이가 없습니다.</p>
+        )}
+      </div>
+
+      <div className={styles.analysisLists}>
+        <HitList title="Missing Slot TOP 5" items={analysis.missingSlotTop} />
+        <HitList title="Policy Hit TOP 5" items={analysis.policyHitTop} />
+        <HitList title="Risk Hit TOP 5" items={analysis.riskHitTop} />
+      </div>
+
+      <section className={styles.analysisListGroup} aria-label="상담사 개입 발생 지점">
+        <h4>상담사 개입 지점</h4>
+        {analysis.humanInterventionPoints.length > 0 ? (
+          <ol>
+            {analysis.humanInterventionPoints.map((point) => (
+              <li key={point.stateName}>
+                <span>
+                  <strong>{point.stateName}</strong>
+                  <em>{point.description}</em>
+                </span>
+                <b>{formatMetricCount(point.count)}</b>
+              </li>
+            ))}
+          </ol>
+        ) : (
+          <p className={styles.analysisEmptyText}>상담사 개입 지점이 관측되지 않았습니다.</p>
+        )}
+      </section>
+
+      <section className={styles.hintPanel} aria-label="검토 권장 설명">
+        {analysis.improvementHints.map((hint) => (
+          <p key={hint}>{hint}</p>
+        ))}
+      </section>
+    </section>
+  );
+}
+
 export function WorkflowDraftReadPage() {
   const { workspaceId, packId, workflowId } = useParams();
   const [search] = useSearchParams();
@@ -64,6 +266,9 @@ export function WorkflowDraftReadPage() {
     versionId: number;
     workflowId: number;
   } | null>(null);
+  const [analysis, setAnalysis] = useState<WorkspaceWorkflowBottleneckAnalysis | null>(null);
+  const [isAnalysisLoading, setIsAnalysisLoading] = useState(false);
+  const [analysisError, setAnalysisError] = useState<string | null>(null);
 
   const wsId = parseRouteId(workspaceId);
   const pId = parseRouteId(packId);
@@ -96,6 +301,12 @@ export function WorkflowDraftReadPage() {
     [workflow?.graphJson],
   );
   const nodeCount = graph?.nodes?.length ?? 0;
+  const analysisState = useMemo<AnalysisState>(() => {
+    if (isAnalysisLoading) return "loading";
+    if (analysisError) return "error";
+    if ((analysis?.totalExecutionCount ?? 0) > 0) return "ready";
+    return "empty";
+  }, [isAnalysisLoading, analysisError, analysis]);
 
   useEffect(() => {
     if (!isEditDirty) return;
@@ -108,6 +319,66 @@ export function WorkflowDraftReadPage() {
     window.addEventListener("beforeunload", handleBeforeUnload);
     return () => window.removeEventListener("beforeunload", handleBeforeUnload);
   }, [isEditDirty]);
+
+  const loadAnalysis = async () => {
+    if (wsId === null || wfId === null) {
+      setAnalysis(null);
+      setAnalysisError(null);
+      setIsAnalysisLoading(false);
+      return;
+    }
+
+    setIsAnalysisLoading(true);
+    setAnalysisError(null);
+    try {
+      const data = await consultationApi.getWorkflowBottleneckAnalysis(wsId, wfId);
+      setAnalysis(data);
+    } catch (error) {
+      console.error("Failed to load workflow bottleneck analysis:", error);
+      setAnalysis(null);
+      setAnalysisError("워크플로우 병목 분석을 불러오지 못했습니다.");
+      toast.error("워크플로우 병목 분석을 불러오지 못했습니다.");
+    } finally {
+      setIsAnalysisLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    let ignore = false;
+
+    async function run() {
+      if (wsId === null || wfId === null || !enabled) {
+        setAnalysis(null);
+        setAnalysisError(null);
+        setIsAnalysisLoading(false);
+        return;
+      }
+
+      setIsAnalysisLoading(true);
+      setAnalysisError(null);
+      try {
+        const data = await consultationApi.getWorkflowBottleneckAnalysis(wsId, wfId);
+        if (ignore) return;
+        setAnalysis(data);
+      } catch (error) {
+        if (ignore) return;
+        console.error("Failed to load workflow bottleneck analysis:", error);
+        setAnalysis(null);
+        setAnalysisError("워크플로우 병목 분석을 불러오지 못했습니다.");
+        toast.error("워크플로우 병목 분석을 불러오지 못했습니다.");
+      } finally {
+        if (!ignore) {
+          setIsAnalysisLoading(false);
+        }
+      }
+    }
+
+    void run();
+
+    return () => {
+      ignore = true;
+    };
+  }, [wsId, wfId, enabled]);
 
   if (
     wsId === null ||
@@ -361,6 +632,14 @@ export function WorkflowDraftReadPage() {
 
           {enabled && !query.isLoading && !query.isError && workflow && graphContent}
         </div>
+        {enabled && !isEditing && (
+          <WorkflowBottleneckAnalysisPanel
+            analysis={analysis}
+            state={analysisState}
+            error={analysisError}
+            onRetry={() => void loadAnalysis()}
+          />
+        )}
       </div>
       <AlertDialog
         open={pendingClose !== null}

--- a/frontend/src/pages/domain-pack/ui/workflow-draft-read-page.module.css
+++ b/frontend/src/pages/domain-pack/ui/workflow-draft-read-page.module.css
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  overflow: hidden;
+  overflow: auto;
   background: var(--paper);
 }
 
@@ -109,7 +109,7 @@
 }
 
 .canvasFrame {
-  flex: 1;
+  flex: 0 0 min(52vh, 560px);
   position: relative;
   margin: 12px 20px 20px;
   border-radius: var(--r-2);
@@ -142,6 +142,239 @@
 
 .errorState {
   padding: 32px;
+}
+
+.analysisPanel {
+  margin: 0 20px 24px;
+  padding: 18px;
+  border: 1px solid var(--line-2);
+  border-radius: var(--r-2);
+  background: var(--paper);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.analysisHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.analysisHeader h3 {
+  margin: 2px 0 4px;
+  color: var(--ink);
+  font-size: 16px;
+  font-weight: 540;
+  letter-spacing: 0;
+}
+
+.analysisHeader p,
+.analysisEmptyText {
+  margin: 0;
+  color: var(--ink-3);
+  font-size: 12px;
+  font-weight: 340;
+  line-height: 1.5;
+  letter-spacing: 0;
+}
+
+.analysisEyebrow,
+.analysisPeriod {
+  color: var(--ink-3);
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 400;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.analysisPeriod {
+  flex-shrink: 0;
+  padding: 5px 9px;
+  border: 1px solid var(--line-2);
+  border-radius: var(--r-pill);
+  background: var(--paper-2);
+  color: var(--ink-2);
+}
+
+.analysisMetricGrid,
+.bottleneckGrid,
+.analysisLists {
+  display: grid;
+  gap: 10px;
+}
+
+.analysisMetricGrid {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.analysisMetricGrid article,
+.bottleneckCard,
+.analysisListGroup,
+.hintPanel,
+.transitionList {
+  border: 1px solid var(--line-2);
+  border-radius: var(--r-2);
+  background: var(--paper-2);
+}
+
+.analysisMetricGrid article {
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-height: 76px;
+}
+
+.analysisMetricGrid span,
+.bottleneckCard span {
+  color: var(--ink-3);
+  font-size: 11px;
+  font-weight: 340;
+  letter-spacing: 0;
+}
+
+.analysisMetricGrid strong,
+.bottleneckCard strong {
+  color: var(--ink);
+  font-size: 24px;
+  font-weight: 540;
+  letter-spacing: 0;
+}
+
+.bottleneckGrid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.bottleneckCard {
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.bottleneckCard p {
+  margin: 0;
+  color: var(--ink-3);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.transitionList {
+  padding: 14px;
+}
+
+.transitionList h4,
+.analysisListGroup h4 {
+  margin: 0 0 10px;
+  color: var(--ink);
+  font-size: 13px;
+  font-weight: 540;
+  letter-spacing: 0;
+}
+
+.transitionRow {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 18px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  min-height: 36px;
+  padding: 7px 0;
+  border-top: 1px solid var(--line-2);
+  color: var(--ink-2);
+  font-size: 12px;
+}
+
+.transitionRow:first-of-type {
+  border-top: 0;
+}
+
+.transitionRow span,
+.transitionRow strong {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.transitionRow b {
+  color: var(--ink);
+  font-weight: 540;
+}
+
+.analysisLists {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.analysisListGroup {
+  padding: 14px;
+}
+
+.analysisListGroup ol {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.analysisListGroup li {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+  padding-top: 8px;
+  border-top: 1px solid var(--line-2);
+}
+
+.analysisListGroup li:first-child {
+  border-top: 0;
+  padding-top: 0;
+}
+
+.analysisListGroup li span {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.analysisListGroup strong {
+  color: var(--ink);
+  font-size: 13px;
+  font-weight: 540;
+  overflow-wrap: anywhere;
+}
+
+.analysisListGroup em {
+  color: var(--ink-3);
+  font-size: 11px;
+  font-style: normal;
+  line-height: 1.35;
+}
+
+.analysisListGroup b {
+  color: var(--ink);
+  font-family: var(--mono);
+  font-size: 12px;
+  font-weight: 400;
+}
+
+.hintPanel {
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.hintPanel p {
+  margin: 0;
+  color: var(--ink-2);
+  font-size: 12px;
+  font-weight: 340;
+  line-height: 1.45;
 }
 
 .pageWrapper {
@@ -258,6 +491,26 @@
 }
 
 @media (max-width: 767px) {
+  .detailHeader,
+  .analysisHeader {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .canvasFrame {
+    margin: 12px;
+    min-height: 340px;
+  }
+
+  .analysisPanel {
+    margin: 0 12px 16px;
+  }
+
+  .analysisMetricGrid,
+  .bottleneckGrid,
+  .analysisLists {
+    grid-template-columns: 1fr;
+  }
   .twoPane {
     flex-direction: column;
   }


### PR DESCRIPTION
Closes #521

## 변경 사항

- 워크플로우 상세 화면에서 특정 workflow의 운영 실행 상태, 상태 전이 통과 수, 병목 state, missing slot/policy/risk TOP 5, 상담사 개입 지점을 조회할 수 있는 병목 분석 API를 제공합니다.
- `runtime.workflow_execution_step`과 `runtime.decision_log`를 운영 상담 실행 기준으로 집계하고, 데모/시뮬레이션 채널과 파싱 불가능한 JSON payload는 분석에서 안전하게 제외합니다.
- workflow 상세 화면에 병목 분석 패널을 추가해 완료/실패/진행 중 실행 수, 전이 흐름, 개선 권장 설명을 함께 표시합니다.
- 이슈 521 스펙을 `.agent/specs/521.md`에 정리했습니다.

## 검증

- `git diff --check`
- `cd backend && mise exec -- ./gradlew spotlessCheck test --tests com.init.workflowruntime.application.WorkspaceWorkflowBottleneckAnalysisServiceTest`
- `cd backend && mise exec -- ./gradlew build -x checkstyleMain -x checkstyleTest`
- `cd frontend && pnpm exec eslint src/features/consultation/api/consultationApi.ts src/features/consultation/api/consultationApi.test.ts src/pages/domain-pack/ui/WorkflowDraftReadPage.tsx src/pages/domain-pack/ui/WorkflowDraftReadPage.test.tsx`
- `cd frontend && pnpm test src/features/consultation/api/consultationApi.test.ts src/pages/domain-pack/ui/WorkflowDraftReadPage.test.tsx --run`
- `cd frontend && pnpm build`

## 참고

- `cd frontend && pnpm lint`는 기존 unrelated lint 오류 58개로 실패합니다. 이번 변경 파일 대상 ESLint는 통과했습니다.