### PR TITLE
fix(upload): ECS ingestion에 업로드 원본 키 전달

### DIFF
--- a/.agent/specs/558.md
+++ b/.agent/specs/558.md
@@ -1,0 +1,64 @@
+# Airflow ingestion 업로드 파일 수신 복구
+
+## Goal
+
+상담 로그 ZIP 업로드 완료 후 생성된 Airflow ingestion 단계가 업로드된 raw object key를 빠뜨리지 않고 전달받아 실제 파일을 읽도록 복구한다.
+
+## Problem
+
+업로드 완료 경로는 `corpus.dataset_raw_file.object_key`에 `completed/...` object key를 저장하고 Airflow `dag_run.conf.object_key`에도 같은 값을 싣는다. 하지만 ECS stage 실행 모드에서는 ingestion stage worker가 Airflow 프로세스 밖에서 실행되므로 `dag_run.conf`를 직접 읽을 수 없다. 이때 `ml/src/pipeline/ecs_stage_task.py`가 conf의 object key를 `PIPELINE_RAW_OBJECT_KEY` 환경 변수로 전달하지 않으면 ingestion 첫 단계가 업로드 파일 위치를 알 수 없다.
+
+## Scope
+
+- `backend/src/main/java/com/init/corpus/application/CompleteRawFileUploadService.java`의 업로드 완료 메타 저장 및 trigger 흐름 확인
+- `backend/src/main/java/com/init/pipelinejob/application/TriggerIngestionUseCase.java`의 pipeline job payload 및 object key 전달 계약 확인
+- `backend/src/main/java/com/init/pipelinejob/infrastructure/airflow/AirflowIngestionTriggerAdapter.java`의 Airflow `dag_run.conf` 계약 확인
+- `ml/src/dags/domain_pack_generation.py`의 ingestion stage ECS 실행 입력 전달 보강
+- `ml/src/pipeline/ecs_stage_task.py`의 ECS container environment 보강
+- `ml/src/pipeline/ecs_stage_worker.py`의 실패 결과 payload 보강
+- 관련 ML orchestration 단위 테스트 보강
+
+## Non-Goals
+
+- 업로드 API request/response contract 변경
+- `corpus.dataset_raw_file` 또는 `pipeline.pipeline_job` 스키마 변경
+- ZIP 내부 JSON/JSONL 파싱 규칙 변경
+- Airflow DAG stage 순서 변경
+- 프론트엔드 업로드 화면 변경
+
+## Current Contract
+
+| 구간 | 확인된 파일 | 계약 |
+| --- | --- | --- |
+| Upload complete | `backend/src/main/java/com/init/corpus/application/CompleteRawFileUploadService.java` | `pending/...` object를 `completed/...`로 복사하고 `DatasetRawFile.createPending(..., completedKey, ...)` 저장 후 trigger 호출 |
+| Pipeline job 생성 | `backend/src/main/java/com/init/pipelinejob/application/TriggerIngestionUseCase.java` | request payload에 `workspaceId`, `datasetId`, `pipelineJobId`, `objectKey` 저장 |
+| Airflow trigger | `backend/src/main/java/com/init/pipelinejob/infrastructure/airflow/AirflowIngestionTriggerAdapter.java` | `dag_run.conf`에 `workspace_id`, `dataset_id`, `pipeline_job_id`, `object_key` 전달 |
+| Ingestion stage | `ml/src/pipeline/stages/ingestion/main.py` | Airflow context의 `object_key` 또는 `PIPELINE_RAW_OBJECT_KEY`로 raw object를 S3/MinIO에서 읽음 |
+
+## Design Diff
+
+| 영역 | As-is | To-be |
+| --- | --- | --- |
+| ECS ingestion 입력 | Airflow DAG가 ECS task를 띄울 때 raw object key를 container env로 전달하지 않음 | ingestion stage에 한해 Airflow conf의 `object_key`/`objectKey`를 `PIPELINE_RAW_OBJECT_KEY`로 전달 |
+| Direct mode | ingestion stage가 Airflow context에서 `object_key`를 직접 읽음 | 기존 동작 유지 |
+| 실패 추적 | ECS container가 실패하면 Airflow 쪽에는 container exit reason 중심의 오류만 남을 수 있음 | worker가 result URI에 `status=failed`와 실제 exception message를 기록하고 Airflow task 오류에 포함 |
+
+## Acceptance Criteria
+
+- 업로드 완료 후 Airflow trigger payload에 `dataset_id`, `pipeline_job_id`, `object_key`가 유지된다.
+- ECS stage 실행 모드에서 ingestion container가 `PIPELINE_RAW_OBJECT_KEY=completed/...` 값을 받는다.
+- ingestion stage가 object storage에서 파일을 읽지 못하면 object key가 포함된 오류 메시지가 ECS result payload와 pipeline failure callback 경로에 남는다.
+- direct stage 실행 모드의 Airflow context 기반 ingestion 동작은 유지된다.
+- 로컬 단위 테스트로 DAG → ECS environment 전달 및 worker 실패 결과 기록을 검증한다.
+
+## Validation Plan
+
+| 구분 | 명령 | 기대 결과 |
+| --- | --- | --- |
+| ML targeted tests | `cd ml && uv run pytest tests/test_domain_pack_generation_dag.py tests/test_ecs_stage_task.py tests/test_ecs_stage_worker.py tests/stages/test_ingestion_main.py` | object key 전달, ECS failure payload, ingestion runtime context 회귀 통과 |
+| ML full smoke | `cd ml && uv run pytest` | 전체 파이프라인 테스트 회귀 없음 |
+| Docker compose flow | `docker compose up -d` 후 업로드 → trigger → ingestion 실행 | 업로드 ZIP이 ingestion에서 읽히고 실패 시 job/log에서 object key 포함 오류 확인 |
+
+## Open Questions
+
+- 로컬 docker compose 환경에서 실제 업로드 ZIP end-to-end 검증은 MinIO/Airflow/Backend 컨테이너 기동 상태와 테스트 계정 데이터 준비가 필요하다.

--- a/ml/src/dags/domain_pack_generation.py
+++ b/ml/src/dags/domain_pack_generation.py
@@ -123,7 +123,13 @@ def _run_stage(
     stage_context = _build_stage_context(stage_name)
     runtime_config = PipelineRuntimeConfig.from_env()
     if _stage_execution_mode() == STAGE_EXECUTION_MODE_ECS:
-        return run_stage_task(stage_name, stage_context, runtime_config, upstream_manifest_path)
+        return run_stage_task(
+            stage_name,
+            stage_context,
+            runtime_config,
+            upstream_manifest_path,
+            raw_object_key=_raw_object_key_for_stage(stage_name),
+        )
     if stage_callable is None:
         stage_callable = _stage_callable(stage_name)
     manifest_payload: dict[str, object] = {
@@ -154,6 +160,12 @@ def _run_stage(
         manifest_payload["status"] = "completed"
         manifest_path: Path = write_stage_manifest(stage_context, runtime_config, manifest_payload)
     return {"artifact_manifest_path": str(manifest_path)}
+
+
+def _raw_object_key_for_stage(stage_name: str) -> str | None:
+    if stage_name != "ingestion":
+        return None
+    return _conf_value("object_key") or _conf_value("objectKey")
 
 
 def _manifest_payload_from_exception(exc: BaseException) -> dict[str, object]:
@@ -206,7 +218,9 @@ def _validated_replay_manifest_s3_uri(
         raise PipelineConfigurationError("S3 upstream_manifest_path requires ML_ARTIFACT_STORE=s3.")
     if not upstream_manifest_path.endswith("/manifest.json"):
         raise PipelineConfigurationError("upstream_manifest_path must point to a manifest.json file.")
-    if runtime_config.artifact_bucket and not upstream_manifest_path.startswith(f"s3://{runtime_config.artifact_bucket}/"):
+    if runtime_config.artifact_bucket and not upstream_manifest_path.startswith(
+        f"s3://{runtime_config.artifact_bucket}/"
+    ):
         raise PipelineConfigurationError("upstream_manifest_path must be under ML_ARTIFACT_BUCKET.")
     return upstream_manifest_path
 

--- a/ml/src/pipeline/ecs_stage_task.py
+++ b/ml/src/pipeline/ecs_stage_task.py
@@ -69,6 +69,7 @@ def run_stage_task(
     stage_context: StageContext,
     runtime_config: PipelineRuntimeConfig,
     upstream_manifest_path: str | None,
+    raw_object_key: str | None = None,
 ) -> dict[str, str]:
     ecs_config = EcsStageTaskConfig.from_env(runtime_config)
     result_uri = _result_uri(ecs_config, stage_context)
@@ -79,9 +80,16 @@ def run_stage_task(
         runtime_config,
         upstream_manifest_path,
         result_uri,
+        raw_object_key,
     )
     task_arn = _task_arn(task_payload)
-    _wait_for_task(ecs_config, task_arn)
+    try:
+        _wait_for_task(ecs_config, task_arn)
+    except PipelineStageError as exc:
+        failure_message = _failure_message_from_result(result_uri)
+        if failure_message:
+            raise PipelineStageError(f"{exc}; stage error: {failure_message}") from exc
+        raise
     result = read_json_uri(result_uri)
     manifest_uri = result.get("artifact_manifest_path") or result.get("manifestUri")
     if not isinstance(manifest_uri, str) or not manifest_uri:
@@ -96,6 +104,7 @@ def _submit_task(
     runtime_config: PipelineRuntimeConfig,
     upstream_manifest_path: str | None,
     result_uri: str,
+    raw_object_key: str | None,
 ) -> Mapping[str, Any]:
     task_definition = _task_definition_for_stage(ecs_config, stage_name)
     container_name = _container_name_for_stage(ecs_config, stage_name)
@@ -121,6 +130,7 @@ def _submit_task(
                         runtime_config,
                         upstream_manifest_path,
                         result_uri,
+                        raw_object_key,
                     ),
                 }
             ]
@@ -172,6 +182,7 @@ def _container_environment(
     runtime_config: PipelineRuntimeConfig,
     upstream_manifest_path: str | None,
     result_uri: str,
+    raw_object_key: str | None,
 ) -> list[dict[str, str]]:
     values: dict[str, str | None] = {
         "PIPELINE_STAGE_NAME": stage_name,
@@ -185,7 +196,7 @@ def _container_environment(
         "PIPELINE_WORKSPACE_ID": stage_context.workspace_id,
         "PIPELINE_DATASET_ID": stage_context.dataset_id,
         "PIPELINE_JOB_ID": stage_context.pipeline_job_id,
-        "PIPELINE_RAW_OBJECT_KEY": _conf_env("PIPELINE_RAW_OBJECT_KEY", "AIRFLOW_OBJECT_KEY"),
+        "PIPELINE_RAW_OBJECT_KEY": raw_object_key or _conf_env("PIPELINE_RAW_OBJECT_KEY", "AIRFLOW_OBJECT_KEY"),
         "ML_ARTIFACT_STORE": runtime_config.artifact_store,
         "ML_ARTIFACT_BUCKET": runtime_config.artifact_bucket,
         "ML_ARTIFACT_PREFIX": runtime_config.artifact_prefix,
@@ -254,6 +265,20 @@ def _result_uri(ecs_config: EcsStageTaskConfig, stage_context: StageContext) -> 
         if part
     )
     return f"s3://{ecs_config.result_bucket}/{key}"
+
+
+def _failure_message_from_result(result_uri: str) -> str | None:
+    try:
+        result = read_json_uri(result_uri)
+    except Exception:
+        return None
+    error = result.get("error")
+    if not isinstance(error, Mapping):
+        return None
+    message = error.get("message")
+    if isinstance(message, str) and message.strip():
+        return message.strip()
+    return None
 
 
 def _required_env(name: str) -> str:

--- a/ml/src/pipeline/ecs_stage_worker.py
+++ b/ml/src/pipeline/ecs_stage_worker.py
@@ -130,13 +130,36 @@ def main() -> None:
     try:
         run_worker()
     except (PipelineConfigurationError, StageWorkerError) as exc:
+        _write_failure_result(exc)
         print(f"ERROR: {exc}", file=sys.stderr)
         sys.exit(1)
     except Exception as exc:
         logger.exception("Stage worker failed")
+        _write_failure_result(exc)
         print(f"ERROR: {exc}", file=sys.stderr)
         sys.exit(1)
     sys.exit(0)
+
+
+def _write_failure_result(exc: BaseException) -> None:
+    result_uri = os.getenv("PIPELINE_STAGE_RESULT_URI", "").strip()
+    if not result_uri:
+        return
+    stage_name = os.getenv("PIPELINE_STAGE_NAME", "").strip() or "unknown"
+    try:
+        write_json_uri(
+            result_uri,
+            {
+                "stageName": stage_name,
+                "status": "failed",
+                "error": {
+                    "type": type(exc).__name__,
+                    "message": str(exc),
+                },
+            },
+        )
+    except Exception:
+        logger.exception("Failed to write ECS stage failure result.")
 
 
 if __name__ == "__main__":

--- a/ml/tests/test_domain_pack_generation_dag.py
+++ b/ml/tests/test_domain_pack_generation_dag.py
@@ -125,6 +125,56 @@ def test_failed_stage_writes_failure_manifest(monkeypatch: pytest.MonkeyPatch, t
     assert manifest["payload"]["error"]["type"] == "StageFailure"
 
 
+def test_ecs_ingestion_stage_forwards_conf_object_key(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    dag_module = _import_dag_module(monkeypatch)
+    monkeypatch.setenv("PIPELINE_ARTIFACT_ROOT", str(tmp_path))
+    monkeypatch.setenv("PIPELINE_BACKEND_BASE_URL", "http://backend:8080")
+    monkeypatch.setenv("PIPELINE_STAGE_EXECUTION_MODE", "ecs")
+    calls: dict[str, object] = {}
+
+    class DagRun:
+        conf = {
+            "workspace_id": "3",
+            "dataset_id": "5",
+            "pipeline_job_id": "11",
+            "object_key": "completed/workspaces/3/datasets/raw.zip",
+        }
+
+    monkeypatch.setattr(
+        dag_module,
+        "get_current_context",
+        lambda: {
+            "dag": type("Dag", (), {"dag_id": "domain_pack_generation"})(),
+            "run_id": "manual__run",
+            "dag_run": DagRun(),
+        },
+    )
+
+    def fake_run_stage_task(
+        stage_name: str,
+        stage_context: object,
+        runtime_config: object,
+        upstream_manifest_path: str | None,
+        raw_object_key: str | None = None,
+    ) -> dict[str, str]:
+        calls["stage_name"] = stage_name
+        calls["raw_object_key"] = raw_object_key
+        calls["upstream_manifest_path"] = upstream_manifest_path
+        return {"artifact_manifest_path": "/tmp/manifest.json"}
+
+    monkeypatch.setattr(dag_module, "run_stage_task", fake_run_stage_task)
+
+    assert dag_module._run_stage("ingestion") == {"artifact_manifest_path": "/tmp/manifest.json"}
+    assert calls == {
+        "stage_name": "ingestion",
+        "raw_object_key": "completed/workspaces/3/datasets/raw.zip",
+        "upstream_manifest_path": None,
+    }
+
+
 def test_run_evaluation_stage_requires_upstream_manifest(monkeypatch: pytest.MonkeyPatch) -> None:
     dag_module = _import_dag_module(monkeypatch)
 

--- a/ml/tests/test_domain_pack_generation_dag.py
+++ b/ml/tests/test_domain_pack_generation_dag.py
@@ -175,6 +175,12 @@ def test_ecs_ingestion_stage_forwards_conf_object_key(
     }
 
 
+def test_raw_object_key_for_stage_ignores_non_ingestion(monkeypatch: pytest.MonkeyPatch) -> None:
+    dag_module = _import_dag_module(monkeypatch)
+
+    assert dag_module._raw_object_key_for_stage("preprocessing") is None
+
+
 def test_run_evaluation_stage_requires_upstream_manifest(monkeypatch: pytest.MonkeyPatch) -> None:
     dag_module = _import_dag_module(monkeypatch)
 
@@ -217,6 +223,21 @@ def test_validated_replay_manifest_path_requires_artifact_root(
 
     with pytest.raises(PipelineConfigurationError, match="manifest.json"):
         dag_module._validated_replay_manifest_path(str(valid_manifest.with_name("payload.json")), runtime_config)
+
+
+def test_validated_replay_manifest_path_accepts_s3_manifest_under_bucket(monkeypatch: pytest.MonkeyPatch) -> None:
+    dag_module = _import_dag_module(monkeypatch)
+    runtime_config = dag_module.PipelineRuntimeConfig(
+        artifact_root=Path("/tmp/artifacts"),
+        backend_base_url="http://backend:8080",
+        callback_enabled=False,
+        artifact_store="s3",
+        artifact_bucket="artifacts",
+    )
+
+    manifest_uri = "s3://artifacts/domain_pack_generation/run/representation/manifest.json"
+
+    assert dag_module._validated_replay_manifest_path(manifest_uri, runtime_config) == manifest_uri
 
 
 def test_checkpoint_callback_requires_enabled_callbacks(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/ml/tests/test_ecs_stage_task.py
+++ b/ml/tests/test_ecs_stage_task.py
@@ -78,6 +78,45 @@ def test_run_stage_task_submits_ecs_task_and_returns_manifest(monkeypatch) -> No
     } in environment
 
 
+def test_run_stage_task_forwards_raw_object_key_to_ingestion(monkeypatch) -> None:
+    calls: dict[str, Any] = {}
+
+    class FakeEcsClient:
+        def run_task(self, **kwargs: Any) -> dict[str, Any]:
+            calls["run_task"] = kwargs
+            return {"tasks": [{"taskArn": "arn:aws:ecs:task/ingestion"}]}
+
+        def describe_tasks(self, **_kwargs: Any) -> dict[str, Any]:
+            return {
+                "tasks": [
+                    {
+                        "lastStatus": "STOPPED",
+                        "stoppedReason": "Essential container in task exited",
+                        "containers": [{"name": "ml-stage-cpu", "exitCode": 0}],
+                    }
+                ]
+            }
+
+    monkeypatch.setattr("pipeline.ecs_stage_task.boto3.client", lambda service: FakeEcsClient())
+    monkeypatch.setattr(
+        "pipeline.ecs_stage_task.read_json_uri",
+        lambda uri: {"artifact_manifest_path": "s3://artifacts/domain-pack/dag/run/ingestion/manifest.json"},
+    )
+    _set_required_ecs_env(monkeypatch)
+
+    result = run_stage_task(
+        "ingestion",
+        _stage_context("ingestion"),
+        _runtime_config(),
+        None,
+        raw_object_key="completed/workspaces/1/raw.zip",
+    )
+
+    assert result["artifact_manifest_path"] == "s3://artifacts/domain-pack/dag/run/ingestion/manifest.json"
+    environment = calls["run_task"]["overrides"]["containerOverrides"][0]["environment"]
+    assert {"name": "PIPELINE_RAW_OBJECT_KEY", "value": "completed/workspaces/1/raw.zip"} in environment
+
+
 def test_config_from_env_requires_network_settings(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setenv("PIPELINE_ECS_CLUSTER", "cluster")
     monkeypatch.setenv("PIPELINE_ECS_CPU_TASK_DEFINITION", "cpu-task")
@@ -162,6 +201,36 @@ def test_run_stage_task_raises_on_container_failure(monkeypatch: pytest.MonkeyPa
 
     with pytest.raises(PipelineStageError, match="exitCode=2"):
         run_stage_task("preprocessing", _stage_context("preprocessing"), _runtime_config(), None)
+
+
+def test_run_stage_task_includes_worker_failure_result(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeEcsClient:
+        def run_task(self, **_kwargs: Any) -> dict[str, Any]:
+            return {"tasks": [{"taskArn": "arn:aws:ecs:task/failed"}]}
+
+        def describe_tasks(self, **_kwargs: Any) -> dict[str, Any]:
+            return {
+                "tasks": [
+                    {
+                        "lastStatus": "STOPPED",
+                        "stoppedReason": "Essential container in task exited",
+                        "containers": [{"name": "ml-stage-cpu", "exitCode": 1}],
+                    }
+                ]
+            }
+
+    monkeypatch.setattr("pipeline.ecs_stage_task.boto3.client", lambda service: FakeEcsClient())
+    monkeypatch.setattr(
+        "pipeline.ecs_stage_task.read_json_uri",
+        lambda uri: {
+            "status": "failed",
+            "error": {"type": "PipelineStageError", "message": "Failed to read raw object from S3/MinIO: key=raw.zip"},
+        },
+    )
+    _set_required_ecs_env(monkeypatch)
+
+    with pytest.raises(PipelineStageError, match="Failed to read raw object from S3/MinIO: key=raw.zip"):
+        run_stage_task("ingestion", _stage_context("ingestion"), _runtime_config(), None)
 
 
 def test_run_stage_task_requires_manifest_uri_in_result(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/ml/tests/test_ecs_stage_task.py
+++ b/ml/tests/test_ecs_stage_task.py
@@ -8,7 +8,7 @@ import pytest
 from pipeline.common.config import PipelineRuntimeConfig
 from pipeline.common.context import StageContext
 from pipeline.common.exceptions import PipelineConfigurationError, PipelineStageError
-from pipeline.ecs_stage_task import EcsStageTaskConfig, run_stage_task
+from pipeline.ecs_stage_task import EcsStageTaskConfig, _failure_message_from_result, run_stage_task
 
 
 def test_run_stage_task_submits_ecs_task_and_returns_manifest(monkeypatch) -> None:
@@ -231,6 +231,21 @@ def test_run_stage_task_includes_worker_failure_result(monkeypatch: pytest.Monke
 
     with pytest.raises(PipelineStageError, match="Failed to read raw object from S3/MinIO: key=raw.zip"):
         run_stage_task("ingestion", _stage_context("ingestion"), _runtime_config(), None)
+
+
+def test_failure_message_from_result_ignores_missing_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("pipeline.ecs_stage_task.read_json_uri", lambda _uri: {"status": "failed"})
+
+    assert _failure_message_from_result("s3://artifacts/result.json") is None
+
+
+def test_failure_message_from_result_ignores_blank_message(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "pipeline.ecs_stage_task.read_json_uri",
+        lambda _uri: {"error": {"type": "PipelineStageError", "message": "  "}},
+    )
+
+    assert _failure_message_from_result("s3://artifacts/result.json") is None
 
 
 def test_run_stage_task_requires_manifest_uri_in_result(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/ml/tests/test_ecs_stage_worker.py
+++ b/ml/tests/test_ecs_stage_worker.py
@@ -10,7 +10,8 @@ from typing import Any
 import pytest
 
 import pipeline.ecs_stage_worker as worker
-from pipeline.ecs_stage_worker import StageWorkerError, _stage_callable, run_worker
+from pipeline.common.exceptions import PipelineStageError
+from pipeline.ecs_stage_worker import StageWorkerError, _stage_callable, main, run_worker
 
 
 def _install_stage_module(monkeypatch: pytest.MonkeyPatch, name: str, run: Any) -> None:
@@ -120,6 +121,34 @@ def test_run_worker_requires_stage_name(monkeypatch: pytest.MonkeyPatch, tmp_pat
 
     with pytest.raises(StageWorkerError, match="PIPELINE_STAGE_NAME"):
         run_worker()
+
+
+def test_main_writes_failure_result_when_stage_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    result_path = tmp_path / "result.json"
+
+    def run_stage(_upstream_manifest_path: str | None) -> dict[str, object]:
+        raise PipelineStageError("Failed to read raw object from S3/MinIO: key=raw.zip")
+
+    _install_stage_module(monkeypatch, "tests.fake_stage_failure", run_stage)
+    monkeypatch.setenv("PIPELINE_STAGE_NAME", "test_stage")
+    monkeypatch.setenv("PIPELINE_STAGE_RESULT_URI", str(result_path))
+    monkeypatch.setenv("PIPELINE_STAGE_SCRATCH_ROOT", str(tmp_path / "scratch"))
+    monkeypatch.setenv("PIPELINE_BACKEND_BASE_URL", "http://backend:8080")
+    monkeypatch.setenv("PIPELINE_CALLBACK_ENABLED", "false")
+
+    with pytest.raises(SystemExit) as exc_info:
+        main()
+
+    assert exc_info.value.code == 1
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert payload["status"] == "failed"
+    assert payload["error"] == {
+        "type": "PipelineStageError",
+        "message": "Failed to read raw object from S3/MinIO: key=raw.zip",
+    }
 
 
 def test_stage_callable_rejects_unsupported_stage() -> None:

--- a/ml/tests/test_ecs_stage_worker.py
+++ b/ml/tests/test_ecs_stage_worker.py
@@ -11,7 +11,7 @@ import pytest
 
 import pipeline.ecs_stage_worker as worker
 from pipeline.common.exceptions import PipelineStageError
-from pipeline.ecs_stage_worker import StageWorkerError, _stage_callable, main, run_worker
+from pipeline.ecs_stage_worker import StageWorkerError, _stage_callable, _write_failure_result, main, run_worker
 
 
 def _install_stage_module(monkeypatch: pytest.MonkeyPatch, name: str, run: Any) -> None:
@@ -149,6 +149,47 @@ def test_main_writes_failure_result_when_stage_fails(
         "type": "PipelineStageError",
         "message": "Failed to read raw object from S3/MinIO: key=raw.zip",
     }
+
+
+def test_main_writes_failure_result_when_worker_configuration_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    result_path = tmp_path / "result.json"
+    monkeypatch.setenv("PIPELINE_STAGE_RESULT_URI", str(result_path))
+
+    with pytest.raises(SystemExit) as exc_info:
+        main()
+
+    assert exc_info.value.code == 1
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert payload["stageName"] == "unknown"
+    assert payload["status"] == "failed"
+    assert payload["error"]["type"] == "StageWorkerError"
+    assert "PIPELINE_STAGE_NAME" in payload["error"]["message"]
+
+
+def test_write_failure_result_ignores_missing_result_uri(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("PIPELINE_STAGE_RESULT_URI", raising=False)
+
+    _write_failure_result(RuntimeError("boom"))
+
+
+def test_write_failure_result_logs_write_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setenv("PIPELINE_STAGE_RESULT_URI", "s3://artifacts/result.json")
+    monkeypatch.setenv("PIPELINE_STAGE_NAME", "ingestion")
+
+    def failing_write(_uri: str, _payload: object) -> None:
+        raise RuntimeError("write failed")
+
+    monkeypatch.setattr("pipeline.ecs_stage_worker.write_json_uri", failing_write)
+
+    _write_failure_result(RuntimeError("stage failed"))
+
+    assert "Failed to write ECS stage failure result." in caplog.text
 
 
 def test_stage_callable_rejects_unsupported_stage() -> None:


### PR DESCRIPTION
Closes #558

## 변경 사항

- Airflow `domain_pack_generation` DAG가 ECS stage 실행 모드에서 ingestion task를 띄울 때 `dag_run.conf.object_key`/`objectKey`를 `PIPELINE_RAW_OBJECT_KEY`로 전달합니다.
- ECS stage worker가 실패 시 result URI에 실제 exception type/message를 기록하고, ECS task wrapper가 해당 메시지를 Airflow task 오류에 포함해 object storage 접근 실패 원인을 추적할 수 있게 했습니다.
- 이슈 558 스펙을 `.agent/specs/558.md`에 정리했습니다.

## 검증

- `git diff --check`
- `cd ml && uv run ruff format --check src/dags/domain_pack_generation.py src/pipeline/ecs_stage_task.py src/pipeline/ecs_stage_worker.py tests/test_domain_pack_generation_dag.py tests/test_ecs_stage_task.py tests/test_ecs_stage_worker.py && uv run ruff check src/dags/domain_pack_generation.py src/pipeline/ecs_stage_task.py src/pipeline/ecs_stage_worker.py tests/test_domain_pack_generation_dag.py tests/test_ecs_stage_task.py tests/test_ecs_stage_worker.py`
- `cd ml && uv run mypy src/dags/domain_pack_generation.py src/pipeline/ecs_stage_task.py src/pipeline/ecs_stage_worker.py`
- `cd ml && uv run pytest tests/test_domain_pack_generation_dag.py tests/test_ecs_stage_task.py tests/test_ecs_stage_worker.py tests/stages/test_ingestion_main.py`
- `cd ml && uv run pytest`
- `cd ml && uv run pytest --cov=src --cov-report=xml:coverage.xml --cov-report=term-missing:skip-covered`
- `cd backend && ./gradlew test --tests com.init.corpus.application.CompleteRawFileUploadServiceTest --tests com.init.pipelinejob.application.TriggerIngestionUseCaseTest --tests com.init.pipelinejob.infrastructure.airflow.AirflowIngestionTriggerAdapterTest`

## 참고

- `cd ml && uv run ruff check .`는 기존 unrelated unused-import lint 오류로 실패합니다. 이번 변경 파일 대상 ruff check와 mypy는 통과했습니다.