### PR TITLE
fix(domain-pack): Risk 상세 오류 원인 구분

### DIFF
--- a/.agent/specs/555.md
+++ b/.agent/specs/555.md
@@ -1,0 +1,112 @@
+# Risk 상세 오류 원인 분리
+
+## Goal
+
+Risk 목록에서 상세로 진입할 때 발생하는 실패를 404, 권한, 서버/API, 응답 계약 오류로 구분해 운영자가 복구 가능한 안내와 재시도 액션을 받을 수 있게 한다.
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A["Risk 목록 진입"] --> B["Risk 항목 선택"]
+    B --> C["/risks/:riskId?versionId=... 이동"]
+    C --> D["useRiskDetail 상세 조회"]
+    D --> E{"조회 결과"}
+    E -->|"정상"| F["RiskDetailPanel 상세 표시"]
+    E -->|"404"| G["찾을 수 없음 안내 + 재시도"]
+    E -->|"401/403"| H["인증/권한 안내 + 재시도"]
+    E -->|"5xx/API 실패"| I["서버 오류 안내 + 재시도"]
+    E -->|"응답 누락/파싱 오류"| J["응답 형식 오류 안내 + 재시도"]
+    F --> K{"JSON 필드 상태"}
+    K -->|"빈 값"| L["대시 표시"]
+    K -->|"파싱 불가"| M["원문 표시"]
+    K -->|"객체/배열"| N["포맷된 JSON 표시"]
+```
+
+## Design Diff
+
+### As-is vs To-be
+
+| 영역 | As-is | To-be | 변경 내용 |
+| --- | --- | --- | --- |
+| 상세 진입 파라미터 | `RiskDraftReadPage`가 URL의 `workspaceId`, `packId`, `versionId`, `riskId`를 파싱해 상세 패널에 전달 | 기존 전달 구조 유지 | 목록 선택 시 `domainPackSectionPath`로 `versionId`와 `riskId`가 함께 유지되는지 회귀 테스트로 확인 |
+| API 에러 메시지 | 알려진 Risk not found 외 다수 오류가 `알 수 없는 오류`로 표시될 수 있음 | 401/403/404/400/422/5xx/응답 계약 오류를 서로 다른 메시지로 표시 | 사용자가 원인과 다음 행동을 구분할 수 있음 |
+| 상세 fallback | error placeholder와 toast가 같은 일반 메시지를 사용할 수 있음 | placeholder, toast, error code가 구체 메시지와 API code를 함께 표시 | 재시도 버튼은 유지 |
+| JSON 필드 표시 | 문자열 JSON 기준 표시 | 빈 값, 파싱 불가 문자열, 객체/배열 값을 모두 화면 실패 없이 표시 | 응답 필드 변동에도 상세 전체가 무너지지 않음 |
+
+## Component Tree
+
+```text
+RiskDraftReadPage
+├─ RiskListPanel
+│  └─ onSelect(id) -> /workspaces/:workspaceId/domain-packs/:packId/risks/:id?versionId=:versionId
+└─ RiskDetailPanel
+   ├─ useRiskDetail
+   │  └─ mapApiError
+   ├─ error placeholder + retry button
+   └─ JsonCard(triggerConditionJson, handlingActionJson, evidenceJson, metaJson)
+```
+
+## API Integration
+
+### Endpoints
+
+| Method | Path | Description |
+| --- | --- | --- |
+| GET | `/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/risks/{riskId}` | Risk 상세 조회 |
+
+### Generated Contract
+
+- `frontend/src/shared/api/generated/endpoints/risk-definition-controller/risk-definition-controller.ts`의 `useGetRisk`를 사용한다.
+- `frontend/src/shared/api/generated/zod/riskDefinitionResponse.zod.ts` 기준 Risk 상세 JSON 필드는 optional string이다.
+- generated 파일은 직접 수정하지 않는다.
+
+## 수정 대상 파일
+
+| 파일 | 변경 유형 | 설명 |
+| --- | --- | --- |
+| `frontend/src/features/risk-draft-read/model/mapApiError.ts` | modify | Risk 상세 조회 에러를 HTTP 상태, API code, 응답 계약 오류별 메시지로 분리 |
+| `frontend/src/features/risk-draft-read/model/mapApiError.test.ts` | modify | 404, 403, 5xx, 응답 계약, 네트워크 오류 매핑 검증 |
+| `frontend/src/features/risk-draft-read/ui/RiskDetailPanel.tsx` | modify | JSON 필드가 비어 있거나 문자열이 아니거나 파싱 실패해도 상세 화면 유지 |
+| `frontend/src/features/risk-draft-read/ui/RiskDetailPanel.test.tsx` | modify | 상세 오류 메시지와 JSON fallback 렌더링 검증 |
+| `frontend/src/pages/domain-pack/ui/RiskDraftReadPage.test.tsx` | existing | Risk 선택 시 URL 파라미터 유지 검증이 이미 존재 |
+| `.agent/specs/555.md` | new | 이슈 요구사항과 검증 기준 문서화 |
+
+## State Management
+
+- 상세 서버 상태는 `riskQueryKeys.detail(workspaceId, packId, versionId, riskId)`로 관리한다.
+- `riskId`가 없으면 상세 조회는 `idle` 상태이며 API 호출을 비활성화한다.
+- 재시도 버튼은 `retryKey` 증가를 통해 같은 query의 `refetch()`를 호출한다.
+- 에러 상태는 `code`, `message`, `httpStatus`를 유지해 UI와 toast에서 같은 원인을 표시한다.
+
+## Tests
+
+### Test Strategy
+
+| 구분 | 방법 | 도구 | 비고 |
+| --- | --- | --- | --- |
+| 에러 매핑 단위 | `mapApiError` 입력별 반환값 검증 | Vitest | API code/HTTP status/일반 Error 구분 |
+| 상세 패널 컴포넌트 | `useRiskDetail` mock 상태별 렌더링 검증 | Vitest, React Testing Library | JSON fallback과 toast 메시지 확인 |
+| 라우팅 회귀 | Risk 선택 시 navigate path 검증 | Vitest, React Testing Library | 기존 `RiskDraftReadPage.test.tsx` 유지 |
+| 수동 확인 | 실제 액티벤처 데이터 Risk 항목 클릭 | 로컬/검증 환경 브라우저 | 데이터 접근 가능 환경에서 정상 상세 표시 확인 |
+
+### Error & Edge Cases
+
+| # | 시나리오 | 기대 결과 |
+| --- | --- | --- |
+| 1 | 존재하지 않는 risk 상세 조회 | `주의 사항을 찾을 수 없습니다.` 표시 |
+| 2 | 권한 없음 | `이 워크스페이스의 주의 사항을 볼 권한이 없습니다.` 표시 |
+| 3 | 서버 오류 | 서버 처리 실패 안내와 재시도 버튼 표시 |
+| 4 | 상세 응답 data 누락 또는 JSON 파싱 실패 | 응답 형식 오류 안내와 재시도 버튼 표시 |
+| 5 | JSON 필드 빈 값 | 상세 화면은 유지되고 해당 필드는 `—` 표시 |
+| 6 | JSON 필드 파싱 실패 문자열 | 상세 화면은 유지되고 원문 문자열 표시 |
+
+## Acceptance Criteria
+
+- 정상 Risk 항목 클릭 시 `workspaceId`, `packId`, `versionId`, `riskId`가 유지된 상세 URL로 이동하고 상세 정보가 표시된다.
+- 존재하지 않는 Risk는 찾을 수 없음 메시지로 구분된다.
+- 권한 오류와 서버/API 오류는 서로 다른 메시지와 API code로 추적 가능하다.
+- 오류 placeholder에는 재시도 버튼이 유지된다.
+- JSON 필드가 비어 있거나 파싱되지 않아도 상세 화면 전체가 실패하지 않는다.
+- Risk 상세 오류 케이스가 Vitest로 검증된다.
+- 실제 액티벤처 데이터 접근이 가능한 검증 환경에서는 정상 Risk 항목 클릭 시 상세 필드가 표시되는지 수동 확인한다.

--- a/frontend/src/features/risk-draft-read/model/mapApiError.test.ts
+++ b/frontend/src/features/risk-draft-read/model/mapApiError.test.ts
@@ -12,17 +12,42 @@ describe("mapApiError", () => {
     });
   });
 
-  it("알 수 없는 ApiRequestError 코드는 기본 메시지로 매핑한다", () => {
+  it("서버 오류는 추적 가능한 서버 메시지로 매핑한다", () => {
     expect(mapApiError(new ApiRequestError(500, "SERVER_ERROR", "서버 오류"))).toEqual({
       status: "error",
       code: "SERVER_ERROR",
-      message: RISK_READ_ERROR_MESSAGES.UNKNOWN,
+      message: RISK_READ_ERROR_MESSAGES.SERVER_ERROR,
       httpStatus: 500,
     });
   });
 
-  it("알 수 없는 오류는 UNKNOWN_ERROR로 변환한다", () => {
+  it("권한 오류는 권한 안내 메시지로 매핑한다", () => {
+    expect(mapApiError(new ApiRequestError(403, "FORBIDDEN", "권한 없음"))).toEqual({
+      status: "error",
+      code: "FORBIDDEN",
+      message: RISK_READ_ERROR_MESSAGES.FORBIDDEN,
+      httpStatus: 403,
+    });
+  });
+
+  it("응답 계약 오류는 상세 응답 형식 오류로 변환한다", () => {
+    expect(mapApiError(new Error("Risk 상세 응답을 확인할 수 없습니다."))).toEqual({
+      status: "error",
+      code: "RISK_DETAIL_RESPONSE_INVALID",
+      message: RISK_READ_ERROR_MESSAGES.RESPONSE_CONTRACT_ERROR,
+    });
+  });
+
+  it("네트워크 오류는 재시도 가능한 연결 안내로 변환한다", () => {
     expect(mapApiError(new Error("network"))).toEqual({
+      status: "error",
+      code: "NETWORK_ERROR",
+      message: RISK_READ_ERROR_MESSAGES.NETWORK_ERROR,
+    });
+  });
+
+  it("분류할 수 없는 오류는 UNKNOWN_ERROR로 변환한다", () => {
+    expect(mapApiError(new Error("unexpected"))).toEqual({
       status: "error",
       code: "UNKNOWN_ERROR",
       message: RISK_READ_ERROR_MESSAGES.UNKNOWN,

--- a/frontend/src/features/risk-draft-read/model/mapApiError.ts
+++ b/frontend/src/features/risk-draft-read/model/mapApiError.ts
@@ -1,16 +1,50 @@
 import { ApiRequestError } from "@/shared/api";
 
 export const RISK_READ_ERROR_MESSAGES = {
+  UNAUTHORIZED: "로그인이 만료되었거나 인증이 필요합니다. 다시 로그인 후 시도해 주세요.",
+  FORBIDDEN: "이 워크스페이스의 주의 사항을 볼 권한이 없습니다.",
+  BAD_REQUEST: "주의 사항 조회 요청값을 확인할 수 없습니다.",
   NOT_FOUND: "주의 사항을 찾을 수 없습니다.",
   LOAD_LIST_FAILED: "주의 사항 목록을 불러오지 못했습니다.",
   LOAD_DETAIL_FAILED: "주의 사항 상세 정보를 불러오지 못했습니다.",
+  SERVER_ERROR: "서버에서 주의 사항 요청을 처리하지 못했습니다. 잠시 후 다시 시도해 주세요.",
+  RESPONSE_CONTRACT_ERROR: "주의 사항 응답 형식이 예상과 다릅니다. 관리자에게 문의해 주세요.",
+  NETWORK_ERROR: "네트워크 연결을 확인한 뒤 다시 시도해 주세요.",
   UNKNOWN: "알 수 없는 오류가 발생했습니다.",
 } as const;
 
 const RISK_ERROR_MESSAGE_BY_CODE: Record<string, string> = {
   RISK_DEFINITION_NOT_FOUND: RISK_READ_ERROR_MESSAGES.NOT_FOUND,
   RISK_NOT_FOUND: RISK_READ_ERROR_MESSAGES.NOT_FOUND,
+  WORKSPACE_ACCESS_DENIED: RISK_READ_ERROR_MESSAGES.FORBIDDEN,
+  FORBIDDEN: RISK_READ_ERROR_MESSAGES.FORBIDDEN,
+  UNAUTHORIZED: RISK_READ_ERROR_MESSAGES.UNAUTHORIZED,
+  BAD_REQUEST: RISK_READ_ERROR_MESSAGES.BAD_REQUEST,
+  VALIDATION_ERROR: RISK_READ_ERROR_MESSAGES.BAD_REQUEST,
 };
+
+function mapHttpStatusToMessage(status: number): string {
+  if (status === 401) return RISK_READ_ERROR_MESSAGES.UNAUTHORIZED;
+  if (status === 403) return RISK_READ_ERROR_MESSAGES.FORBIDDEN;
+  if (status === 404) return RISK_READ_ERROR_MESSAGES.NOT_FOUND;
+  if (status === 400 || status === 422) return RISK_READ_ERROR_MESSAGES.BAD_REQUEST;
+  if (status >= 500) return RISK_READ_ERROR_MESSAGES.SERVER_ERROR;
+  return RISK_READ_ERROR_MESSAGES.LOAD_DETAIL_FAILED;
+}
+
+function isResponseContractError(e: Error): boolean {
+  return (
+    e instanceof SyntaxError ||
+    e.message.includes("Risk 상세 응답") ||
+    e.message.includes("JSON") ||
+    e.message.includes("Unexpected token")
+  );
+}
+
+function isNetworkError(e: Error): boolean {
+  const message = e.message.toLowerCase();
+  return e instanceof TypeError || message.includes("network") || message.includes("fetch");
+}
 
 export function mapApiError(e: unknown): {
   status: "error";
@@ -22,9 +56,30 @@ export function mapApiError(e: unknown): {
     return {
       status: "error",
       code: e.code,
-      message: RISK_ERROR_MESSAGE_BY_CODE[e.code] ?? RISK_READ_ERROR_MESSAGES.UNKNOWN,
+      message: RISK_ERROR_MESSAGE_BY_CODE[e.code] ?? mapHttpStatusToMessage(e.status),
       httpStatus: e.status,
     };
   }
+
+  if (e instanceof Error) {
+    if (isResponseContractError(e)) {
+      return {
+        status: "error",
+        code: "RISK_DETAIL_RESPONSE_INVALID",
+        message: RISK_READ_ERROR_MESSAGES.RESPONSE_CONTRACT_ERROR,
+      };
+    }
+
+    if (isNetworkError(e)) {
+      return {
+        status: "error",
+        code: "NETWORK_ERROR",
+        message: RISK_READ_ERROR_MESSAGES.NETWORK_ERROR,
+      };
+    }
+
+    return { status: "error", code: "UNKNOWN_ERROR", message: RISK_READ_ERROR_MESSAGES.UNKNOWN };
+  }
+
   return { status: "error", code: "UNKNOWN_ERROR", message: RISK_READ_ERROR_MESSAGES.UNKNOWN };
 }

--- a/frontend/src/features/risk-draft-read/ui/RiskDetailPanel.test.tsx
+++ b/frontend/src/features/risk-draft-read/ui/RiskDetailPanel.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { toast } from "sonner";
+import { RISK_READ_ERROR_MESSAGES } from "../model/mapApiError";
 import { useRiskDetail } from "../model/useRiskDetail";
 import { RiskDetailPanel } from "./RiskDetailPanel";
 
@@ -87,6 +88,23 @@ describe("RiskDetailPanel", () => {
     expect(screen.getByText("수정일 · 확인 전")).toBeInTheDocument();
   });
 
+  it("JSON 필드가 객체이거나 파싱되지 않는 문자열이어도 상세 화면을 유지한다", () => {
+    mockedUseRiskDetail.mockReturnValue({
+      status: "ready",
+      data: {
+        ...stubRisk,
+        triggerConditionJson: { channel: "web" } as never,
+        handlingActionJson: "{invalid-json",
+      },
+    });
+
+    renderPanel();
+
+    expect(screen.getByText(/"channel": "web"/)).toBeInTheDocument();
+    expect(screen.getByText("{invalid-json")).toBeInTheDocument();
+    expect(screen.getByText("사기 위험")).toBeInTheDocument();
+  });
+
   it("수정 버튼을 누르면 onEdit에 riskId를 전달한다", () => {
     mockedUseRiskDetail.mockReturnValue({ status: "ready", data: stubRisk });
     const { onEdit } = renderPanel();
@@ -111,6 +129,23 @@ describe("RiskDetailPanel", () => {
     expect(toast.error).toHaveBeenCalledWith(
       "주의 사항을 찾을 수 없습니다.",
       expect.objectContaining({ id: expect.stringContaining("risk-detail-error") }),
+    );
+  });
+
+  it("서버 오류는 찾을 수 없음과 다른 안내로 toast와 placeholder에 표시한다", () => {
+    mockedUseRiskDetail.mockReturnValue({
+      status: "error",
+      code: "SERVER_ERROR",
+      message: RISK_READ_ERROR_MESSAGES.SERVER_ERROR,
+      httpStatus: 500,
+    });
+
+    renderPanel();
+
+    expect(screen.getByText(RISK_READ_ERROR_MESSAGES.SERVER_ERROR)).toBeInTheDocument();
+    expect(toast.error).toHaveBeenCalledWith(
+      RISK_READ_ERROR_MESSAGES.SERVER_ERROR,
+      expect.objectContaining({ id: expect.stringContaining("SERVER_ERROR") }),
     );
   });
 });

--- a/frontend/src/features/risk-draft-read/ui/RiskDetailPanel.tsx
+++ b/frontend/src/features/risk-draft-read/ui/RiskDetailPanel.tsx
@@ -189,13 +189,13 @@ function InfoGrid({ fields }: Readonly<{ fields: readonly RiskInfoField[] }>) {
 function JsonCard({
   label,
   value,
-}: Readonly<{ label: string; value: RiskDefinition[RiskJsonKey] }>) {
+}: Readonly<{ label: string; value: RiskDefinition[RiskJsonKey] | unknown }>) {
   return (
     <article className={styles.card} data-json-field={label.toLowerCase()}>
       <div className={styles.cardHeader}>{label}</div>
       <div className={styles.cardBody}>
         <pre className={styles.jsonBlock}>
-          <code>{formatJsonForDisplay((value ?? "") as string)}</code>
+          <code>{formatJsonForDisplay(value)}</code>
         </pre>
       </div>
     </article>
@@ -212,7 +212,17 @@ function StatusBadge({ status }: Readonly<{ status: RiskDefinition["status"] }>)
   );
 }
 
-function formatJsonForDisplay(raw: string): string {
+function formatJsonForDisplay(raw: unknown): string {
+  if (raw === null || raw === undefined) return "—";
+
+  if (typeof raw !== "string") {
+    try {
+      return JSON.stringify(raw, null, 2);
+    } catch {
+      return String(raw);
+    }
+  }
+
   if (!raw.trim()) return "—";
 
   try {


### PR DESCRIPTION
Closes #555

## 변경 사항

- Risk 상세 조회 실패 시 404, 인증/권한, 요청값, 서버 오류, 응답 계약 오류, 네트워크 오류를 서로 다른 안내 메시지로 구분합니다.
- 상세 패널의 toast와 fallback 영역이 같은 원인 메시지와 API code를 보여주고, 재시도 버튼을 유지합니다.
- Risk JSON 필드가 비어 있거나 파싱되지 않는 문자열이거나 객체/배열 형태로 내려와도 상세 화면 전체가 실패하지 않도록 표시를 보강했습니다.
- 이슈 555 스펙을 `.agent/specs/555.md`에 정리했습니다.

## 검증

- `git diff --check`
- `cd frontend && pnpm test -- features/risk-draft-read/model/mapApiError.test.ts features/risk-draft-read/ui/RiskDetailPanel.test.tsx features/risk-draft-read/model/useRiskDetail.test.ts pages/domain-pack/ui/RiskDraftReadPage.test.tsx`
- `cd frontend && pnpm exec eslint src/features/risk-draft-read/model/mapApiError.ts src/features/risk-draft-read/model/mapApiError.test.ts src/features/risk-draft-read/ui/RiskDetailPanel.tsx src/features/risk-draft-read/ui/RiskDetailPanel.test.tsx`
- `cd frontend && pnpm build`

## 참고

- `cd frontend && pnpm lint`는 기존 unrelated lint 오류 58개로 실패합니다. 이번 변경 파일 대상 ESLint는 통과했습니다.