### PR TITLE
feat(dashboard): 고객 액션 추천 제공

### DIFF
--- a/.agent/specs/523.md
+++ b/.agent/specs/523.md
@@ -1,311 +1,98 @@
-# 523. External LLM Slot Tool API
+# Issue 523 feat(dashboard): 고객 액션 추천
 
 ## Goal
 
-외부 LLM이 고객 상담 중 현재 세션의 워크플로우 실행 컨텍스트와 slot 정의/값을 조회하고, 필요한 slot 값을 저장할 수 있는 REST 기반 tool API를 제공한다.
+워크스페이스 대시보드에서 운영 지표를 바탕으로 고객이 바로 실행할 수 있는 rule-based 추천 액션을 최대 3개까지 제공한다.
 
-이 기능은 MCP 서버 구현이 아니라, 외부 LLM adapter 또는 function calling layer가 HTTP tool로 호출할 수 있는 backend API이다.
+## Background
 
-## Current Implementation Status
+선행 대시보드 이슈는 고객용 대시보드 셸, 상담 KPI, workflow 랭킹, 운영 지식팩 건강도, 병목 분석 API를 추가했다. 이번 범위는 이 지표들을 backend application service에서 deterministic rule로 해석해 “무엇을 먼저 볼지”를 제안하고, frontend는 추천 카드와 빈 상태만 렌더링한다.
 
-현재 구현은 backend `workflow-runtime` bounded context와 루트 `integrations/llm-tools` adapter에 추가된 상태다. 구현 파일은 아직 Git 기준 untracked 파일을 포함한다.
+## Scope
 
-### 생성/변경된 코드
+- Backend에서 deterministic recommendation rule을 관리한다.
+- 추천은 최대 3개만 반환하며 priority는 고객 영향도와 실행 가능성을 기준으로 정렬한다.
+- 각 추천은 근거 지표 label/value와 관련 화면 이동 링크를 포함한다.
+- 추천 근거에 필요한 선행 지표가 없거나 산출 불가능하면 해당 rule은 skip한다.
+- Frontend는 대시보드 필터 기간과 동일한 `from`, `to` 기준으로 추천 API를 호출해 카드 UI를 표시한다.
+- 추천이 없으면 “현재 큰 이상 없음” 상태를 표시한다.
 
-| Path | Layer | 역할 |
-| --- | --- | --- |
-| `backend/src/main/java/com/init/workflowruntime/presentation/LlmToolController.java` | presentation | `/api/v1/llm-tools/sessions/{sessionId}` 하위 REST endpoint 제공 |
-| `backend/src/main/java/com/init/workflowruntime/application/LlmToolService.java` | application | 세션, workflow execution, slot definition, intent-slot binding을 조합해 tool 응답 생성 |
-| `backend/src/main/java/com/init/workflowruntime/application/dto/LlmToolContextResponse.java` | application DTO | 세션 전체 tool context 응답 |
-| `backend/src/main/java/com/init/workflowruntime/application/dto/LlmToolSlotResponse.java` | application DTO | slot 단건/목록 응답 |
-| `backend/src/main/java/com/init/workflowruntime/application/dto/LlmToolSlotValueResponse.java` | application DTO | slot 값 저장 결과 응답 |
-| `backend/src/main/java/com/init/workflowruntime/application/dto/UpsertSlotValueRequest.java` | application DTO | slot 값 저장 요청 body |
-| `backend/src/main/java/com/init/workflowruntime/domain/WorkflowExecution.java` | domain | `runtime.workflow_execution` 매핑, `slot_values_json` 저장 |
-| `backend/src/main/java/com/init/workflowruntime/domain/WorkflowExecutionRepository.java` | domain repository | 최신 workflow execution 조회 및 저장 port |
-| `backend/src/main/java/com/init/workflowruntime/infrastructure/persistence/JpaWorkflowExecutionRepository.java` | infrastructure | Spring Data JPA repository adapter |
-| `backend/src/main/java/com/init/domainpack/domain/repository/SlotDefinitionRepository.java` | domain repository | `domainPackVersionId + slotCode` 조회 메서드 추가 |
-| `backend/src/main/java/com/init/domainpack/infrastructure/persistence/JpaSlotDefinitionRepository.java` | infrastructure | `domainPackVersionId + slotCode` JPA derived query 추가 |
-| `backend/src/main/java/com/init/shared/infrastructure/security/SecurityConfig.java` | infrastructure/security | `/api/v1/llm-tools/**`를 `OPERATOR` 권한으로 보호 |
-| `backend/src/test/java/com/init/workflowruntime/application/LlmToolServiceTest.java` | test | context 조회, slot 값 저장, 없는 slot 404 검증 |
-| `backend/src/test/java/com/init/workflowruntime/presentation/LlmToolControllerTest.java` | test | REST endpoint 응답과 validation 검증 |
-| `integrations/llm-tools/tool-schema.mjs` | integration | 외부 LLM에 등록할 function tool schema 정의 |
-| `integrations/llm-tools/llm-tool-adapter.mjs` | integration | LLM tool call을 backend REST API 호출로 변환 |
-| `integrations/llm-tools/README.md` | integration docs | adapter 사용 예시와 tool 이름 정리 |
-| `integrations/llm-tools/llm-tool-adapter.test.mjs` | integration test | schema/adapter 동작 검증 |
+## Non-goals
 
-## LLM Tool Schema And Adapter
+- LLM 기반 추천
+- 자동 수정 실행
+- 알림 발송
+- 시뮬레이션 기반 추천
 
-외부 LLM에는 `integrations/llm-tools/tool-schema.mjs`의 `llmSlotTools`를 tools로 등록한다.
+## Affected Modules
 
-Tool schema는 `sessionId`를 노출하지 않는다. 현재 상담 세션 ID는 adapter 생성 시 서버 코드가 주입한다. 이렇게 해야 LLM이 임의 session ID를 조작하는 것을 막을 수 있다.
-
-Tool names:
-
-| Tool | Parameters | Backend call |
-| --- | --- | --- |
-| `get_current_slot_context` | none | `GET /api/v1/llm-tools/sessions/{sessionId}/context` |
-| `list_current_slots` | none | `GET /api/v1/llm-tools/sessions/{sessionId}/slots` |
-| `get_current_slot` | `slotCode` | `GET /api/v1/llm-tools/sessions/{sessionId}/slots/{slotCode}` |
-| `upsert_current_slot_value` | `slotCode`, `value` | `PUT /api/v1/llm-tools/sessions/{sessionId}/slots/{slotCode}` |
-
-사용 예시:
-
-```js
-import {
-  createLlmSlotToolHandler,
-  llmSlotTools,
-} from "./integrations/llm-tools/llm-tool-adapter.mjs";
-
-const handleToolCall = createLlmSlotToolHandler({
-  backendBaseUrl: "http://localhost:8080",
-  bearerToken: process.env.OPERATOR_JWT,
-  sessionId: currentSessionId,
-});
-
-// LLM 요청에 llmSlotTools를 tools로 전달한다.
-// LLM이 tool_call을 반환하면 handler에 넘겨 backend REST API를 호출한다.
-const toolResult = await handleToolCall(toolCall);
-```
+| Path | Role |
+| --- | --- |
+| `backend/src/main/java/com/init/workspace/presentation/WorkspaceDashboardController.java` | workspace dashboard recommendation endpoint |
+| `backend/src/main/java/com/init/workspace/application/` | recommendation use case, response records, deterministic rules |
+| `backend/src/main/java/com/init/workspace/infrastructure/persistence/JdbcWorkspaceDashboardQueryAdapter.java` | dashboard recommendation read model query |
+| `frontend/src/features/workspace-dashboard-health/api/workspaceDashboardHealthApi.ts` | OpenAPI 미생성 dashboard endpoint wrapper |
+| `frontend/src/pages/workspace/ui/WorkspaceDashboardPage.tsx` | recommendation panel rendering |
+| `frontend/src/pages/workspace/ui/workspace-dashboard-page.module.css` | recommendation panel styles |
 
 ## REST API
 
-Base path:
+### `GET /api/v1/workspaces/{workspaceId}/dashboard/action-recommendations`
 
-```text
-/api/v1/llm-tools/sessions/{sessionId}
-```
+Query:
 
-Security:
-
-```text
-ROLE_OPERATOR required
-```
-
-### GET `/context`
-
-현재 상담 세션 기준으로 외부 LLM이 필요한 전체 tool context를 반환한다.
-
-Response fields:
-
-| Field | Description |
-| --- | --- |
-| `sessionId` | 상담 세션 ID |
-| `workspaceId` | 세션이 속한 workspace ID |
-| `domainPackVersionId` | 세션이 사용하는 domain pack version ID |
-| `executionId` | 최신 workflow execution ID. 없으면 `null` |
-| `executionStatus` | 최신 workflow execution 상태. 없으면 `null` |
-| `currentState` | 최신 workflow execution 현재 상태. 없으면 `null` |
-| `slotValues` | 현재까지 저장된 slot 값 JSON object |
-| `missingSlots` | active slot 중 값이 없는 slotCode 목록 |
-| `slots` | active slot 정의, binding 정보, 현재 값 목록 |
-
-Example:
-
-```json
-{
-  "sessionId": 1,
-  "workspaceId": 10,
-  "domainPackVersionId": 101,
-  "executionId": 50,
-  "executionStatus": "RUNNING",
-  "currentState": "collect_slots",
-  "slotValues": {
-    "order_id": "A-100"
-  },
-  "missingSlots": ["customer_name"],
-  "slots": [
-    {
-      "id": 11,
-      "slotCode": "order_id",
-      "name": "주문번호",
-      "description": "주문 식별자",
-      "dataType": "STRING",
-      "isSensitive": false,
-      "validationRule": { "type": "string" },
-      "defaultValue": null,
-      "meta": {},
-      "status": "ACTIVE",
-      "required": true,
-      "collectionOrder": 1,
-      "promptHint": "주문번호를 물어본다",
-      "hasValue": true,
-      "value": "A-100"
-    }
-  ]
-}
-```
-
-### GET `/slots`
-
-현재 상담 세션의 domain pack version에 속한 active slot 목록을 반환한다.
-
-동작:
-
-- `ChatSession.domainPackVersionId` 기준으로 slot definition 목록을 조회한다.
-- `SlotDefinition.STATUS_ACTIVE`인 slot만 노출한다.
-- 최신 workflow execution의 `intentDefinitionId`가 있으면 intent-slot binding을 붙여 `required`, `collectionOrder`, `promptHint`를 채운다.
-- 최신 workflow execution이 없으면 stored slot value는 빈 object로 본다.
-
-### GET `/slots/{slotCode}`
-
-특정 slotCode의 정의와 현재 값을 반환한다.
-
-동작:
-
-- 세션의 `domainPackVersionId`에 해당 `slotCode`가 있는지 확인한다.
-- slot status가 `ACTIVE`가 아니면 404와 동일하게 처리한다.
-- 현재 저장 값이 있으면 `hasValue=true`, 없으면 `hasValue=false`와 `value=null`에 준하는 JSON null을 반환한다.
-
-### PUT `/slots/{slotCode}`
-
-외부 LLM이 고객에게서 확보한 slot 값을 저장한다.
-
-Request:
-
-```json
-{
-  "value": "A-200"
-}
-```
+| Name | Required | Description |
+| --- | --- | --- |
+| `from` | no | 대시보드 공통 필터 시작일, ISO date |
+| `to` | no | 대시보드 공통 필터 종료일, ISO date |
 
 Response:
 
 ```json
 {
-  "sessionId": 1,
-  "executionId": 50,
-  "slotCode": "order_id",
-  "hasValue": true,
-  "value": "A-200"
+  "workspaceId": 1,
+  "periodStart": "2026-05-29T00:00:00+09:00",
+  "periodEnd": "2026-06-05T00:00:00+09:00",
+  "recommendations": [
+    {
+      "ruleCode": "HOTPATH_SURGE",
+      "priority": 90,
+      "title": "환불 처리 workflow 점검",
+      "description": "선택 기간 실행량이 전 기간보다 크게 증가했습니다.",
+      "evidenceLabel": "전 기간 대비",
+      "evidenceValue": "+33.3%",
+      "targetPath": "/workspaces/1/domain-packs/11/workflows/100?versionId=22"
+    }
+  ]
 }
 ```
 
-동작:
+Rules:
 
-- `value`가 없으면 validation error를 반환한다.
-- 세션의 domain pack version에 active slotCode가 있는지 검증한다.
-- 최신 workflow execution이 있으면 해당 row의 `slot_values_json`을 갱신한다.
-- workflow execution이 없으면 `WorkflowExecution.create(sessionId)`로 `RUNNING` execution을 생성한 뒤 저장한다.
-- 기존 `slot_values_json` object에 `{slotCode: value}`를 upsert한다.
-
-## Sequence Diagram
-
-```mermaid
-sequenceDiagram
-    actor llm as External LLM Adapter
-    participant ctrl as LlmToolController
-    participant svc as LlmToolService
-    participant sessionRepo as ChatSessionRepository
-    participant execRepo as WorkflowExecutionRepository
-    participant slotRepo as SlotDefinitionRepository
-    participant bindingRepo as IntentSlotBindingRepository
-    participant db as PostgreSQL
-
-    llm ->> ctrl: GET /api/v1/llm-tools/sessions/{sessionId}/context
-    ctrl ->> svc: getContext(sessionId)
-    svc ->> sessionRepo: findById(sessionId)
-    sessionRepo ->> db: SELECT runtime.chat_session
-    db -->> sessionRepo: ChatSession
-    svc ->> execRepo: findTopByChatSessionIdOrderByStartedAtDesc(sessionId)
-    execRepo ->> db: SELECT runtime.workflow_execution
-    db -->> execRepo: latest execution or empty
-    svc ->> slotRepo: findAllByDomainPackVersionIdOrderBySlotCodeAsc(versionId)
-    slotRepo ->> db: SELECT pack.slot_definition
-    db -->> slotRepo: slots
-    svc ->> bindingRepo: findAllByIntentDefinitionIdIn(intentDefinitionId)
-    bindingRepo ->> db: SELECT pack.intent_slot_binding
-    db -->> bindingRepo: bindings
-    svc -->> ctrl: LlmToolContextResponse
-    ctrl -->> llm: 200 OK
-```
-
-## Application Logic
-
-### `LlmToolService.getContext`
-
-세션, 최신 workflow execution, active slot 목록, 저장된 slot 값을 한 번에 반환한다. 외부 LLM이 다음 질문을 결정하거나 이미 확보한 정보를 확인할 때 사용하는 기본 endpoint이다.
-
-### `LlmToolService.listSlots`
-
-slot 정의 목록만 필요한 경우 사용한다. 전체 context보다 응답 범위가 작지만, 각 slot의 현재 저장 값과 binding 정보도 포함한다.
-
-### `LlmToolService.getSlot`
-
-외부 LLM이 특정 정보가 필요한 시점에 `slotCode`로 단건 조회한다. 예를 들어 `order_id`가 필요한 tool call을 실행하기 전에 현재 값이 있는지 확인할 수 있다.
-
-### `LlmToolService.upsertSlotValue`
-
-외부 LLM이 고객에게서 slot 값을 얻었을 때 저장한다. 저장 대상은 `runtime.workflow_execution.slot_values_json`이며, 실행이 없으면 새 execution을 생성한다.
-
-## Data Model
-
-### `WorkflowExecution`
-
-`runtime.workflow_execution` table에 대응한다.
-
-주요 필드:
-
-| Field | DB column | Purpose |
+| Rule | Condition | Link |
 | --- | --- | --- |
-| `chatSessionId` | `chat_session_id` | 상담 세션 연결 |
-| `workflowDefinitionId` | `workflow_definition_id` | 실행 workflow 연결 |
-| `intentDefinitionId` | `intent_definition_id` | 현재 intent 연결 |
-| `status` | `status` | 실행 상태 |
-| `currentState` | `current_state` | 현재 workflow state |
-| `slotValuesJson` | `slot_values_json` | 외부 LLM/tool이 수집한 slot 값 |
-| `policySnapshotJson` | `policy_snapshot_json` | 정책 스냅샷 |
-| `riskSnapshotJson` | `risk_snapshot_json` | 리스크 스냅샷 |
+| `PIPELINE_FAILED` | 최근 domain pack generation job이 실패 | `/workspaces/{workspaceId}/upload?jobId={pipelineJobId}` |
+| `RISK_HIT_SURGE` | risk hit가 전 기간 대비 급증 | `/workspaces/{workspaceId}/domain-packs` |
+| `HOTPATH_SURGE` | 실행량이 급증한 workflow 존재 | workflow detail path, 없으면 `/workspaces/{workspaceId}/workflows` |
+| `LOW_COMPLETION_RATE` | 충분한 실행량이 있는 workflow의 완료율이 낮음 | workflow detail path, 없으면 `/workspaces/{workspaceId}/workflows` |
+| `MISSING_SLOT_HIGH` | missing slot hit 비율이 높음 | `/workspaces/{workspaceId}/domain-packs` |
+| `LOW_CONFIDENCE_HIGH` | low confidence 비율이 높음 | `/workspaces/{workspaceId}/upload` |
+| `STALE_KNOWLEDGE_PACK` | 운영 지식팩 publish 시점이 오래됨 | `/workspaces/{workspaceId}/upload` |
 
-현재 구현은 `slotValuesJson`만 직접 갱신한다.
+## Frontend Behavior
 
-## Error Handling
+- 대시보드 페이지는 기존 공통 기간 필터의 `from`, `to`와 같은 값으로 추천 API를 호출한다.
+- 추천 loading/error/empty 상태는 상담 KPI, 건강도, 핫패스 랭킹과 독립적으로 처리한다.
+- 추천 카드는 `title`, `description`, `evidenceLabel`, `evidenceValue`를 표시하고 `targetPath`로 이동한다.
+- 추천이 없으면 “현재 큰 이상 없음” 상태를 보여준다.
 
-| Case | Current behavior |
-| --- | --- |
-| sessionId가 없음 | `SESSION_NOT_FOUND` `NotFoundException` |
-| slotCode가 세션 version에 없음 | `SLOT_DEFINITION_NOT_FOUND` `NotFoundException` |
-| slotCode가 있지만 status가 active가 아님 | `SLOT_DEFINITION_NOT_FOUND` `NotFoundException` |
-| PUT body에 `value` 없음 | validation error |
-| 저장된 JSON이 object가 아님 | `JSON_OBJECT_EXPECTED` `InternalException` |
-| 저장된 JSON parse 실패 | `JSON_PARSE_FAILED` `InternalException` |
-| slot value serialization 실패 | `JSON_WRITE_FAILED` `InternalException` |
+## Validation
 
-## Verification
+- Backend unit test: recommendation use case가 priority 정렬, 최대 3개 제한, missing prerequisite skip을 검증한다.
+- Backend controller test: endpoint가 인증 사용자 ID와 기간 쿼리를 use case로 전달하고 추천 응답을 반환한다.
+- Frontend API test: `action-recommendations` endpoint가 기간 쿼리와 함께 호출되는지 검증한다.
+- Frontend page test: 추천 카드, 링크, 근거 지표, 추천 없음 상태를 검증한다.
 
-현재 확인된 검증:
+## Open Questions
 
-```bash
-cd backend
-./gradlew compileJava test --tests 'com.init.workflowruntime.application.LlmToolServiceTest' --tests 'com.init.workflowruntime.presentation.LlmToolControllerTest'
-
-cd ..
-node --test integrations/llm-tools/llm-tool-adapter.test.mjs
-```
-
-검증 결과:
-
-```text
-BUILD SUCCESSFUL
-tests 5
-pass 5
-```
-
-테스트 커버리지:
-
-- `getContext`가 세션 기준 slot 정의와 저장 값을 함께 반환하는지 검증
-- `upsertSlotValue`가 execution이 없을 때 생성 후 slot 값을 저장하는지 검증
-- 존재하지 않는 slotCode가 404 계열 예외로 처리되는지 검증
-- controller가 context, slot 단건, slot 값 저장 응답을 반환하는지 검증
-- PUT body에 `value`가 없으면 400 validation error가 나는지 검증
-- tool schema가 `sessionId`를 노출하지 않는지 검증
-- OpenAI-style function tool call parsing을 검증
-- `get_current_slot`, `upsert_current_slot_value`가 backend endpoint로 매핑되는지 검증
-
-## Remaining Decisions
-
-1. 외부 연동 표준을 현재 REST tool adapter로 확정할지, 별도 MCP server를 추가할지 결정해야 한다.
-2. 외부 LLM이 사용할 인증 방식은 현재 `ROLE_OPERATOR` JWT 전제다. 서버 간 호출용 token 또는 scoped API key가 필요한지 결정해야 한다.
-3. `slot_values_json` 저장 값에 대한 dataType별 validation은 현재 `SlotDefinition.validationRuleJson`을 응답으로 제공할 뿐, backend가 직접 강제하지 않는다.
-4. sensitive slot 응답 정책은 현재 `isSensitive`를 노출하지만 value masking은 하지 않는다.
-5. 최신 workflow execution 선택 기준은 `startedAt DESC` 하나다. 세션당 execution 수명 정책과 동시성 정책을 정해야 한다.
-6. OpenAPI/Orval generated client 반영 여부는 별도 작업으로 확인해야 한다.
+- 없음. 추천 threshold는 v1 rule-based 기준으로 backend 상수에 고정하고, 운영 데이터가 쌓이면 별도 이슈에서 조정한다.

--- a/backend/src/main/java/com/init/workspace/application/GetWorkspaceDashboardActionRecommendationsCommand.java
+++ b/backend/src/main/java/com/init/workspace/application/GetWorkspaceDashboardActionRecommendationsCommand.java
@@ -1,0 +1,6 @@
+package com.init.workspace.application;
+
+import java.time.LocalDate;
+
+public record GetWorkspaceDashboardActionRecommendationsCommand(
+    Long workspaceId, Long userId, LocalDate fromDate, LocalDate toDate) {}

--- a/backend/src/main/java/com/init/workspace/application/GetWorkspaceDashboardActionRecommendationsUseCase.java
+++ b/backend/src/main/java/com/init/workspace/application/GetWorkspaceDashboardActionRecommendationsUseCase.java
@@ -1,0 +1,315 @@
+package com.init.workspace.application;
+
+import com.init.shared.application.exception.BadRequestException;
+import com.init.workspace.application.exception.WorkspaceAccessDeniedException;
+import com.init.workspace.application.exception.WorkspaceNotFoundException;
+import com.init.workspace.domain.repository.WorkspaceMemberRepository;
+import com.init.workspace.domain.repository.WorkspaceRepository;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class GetWorkspaceDashboardActionRecommendationsUseCase {
+
+  private static final ZoneId METRIC_ZONE = ZoneId.of("Asia/Seoul");
+  private static final int MAX_RECOMMENDATIONS = 3;
+  private static final int STALE_KNOWLEDGE_PACK_DAYS = 30;
+  private static final double RISK_SURGE_THRESHOLD = 30.0;
+  private static final double MISSING_SLOT_RATE_THRESHOLD = 20.0;
+  private static final double LOW_CONFIDENCE_RATE_THRESHOLD = 10.0;
+
+  private final WorkspaceRepository workspaceRepository;
+  private final WorkspaceMemberRepository workspaceMemberRepository;
+  private final WorkspaceDashboardQueryPort workspaceDashboardQueryPort;
+  private final Clock clock;
+
+  public GetWorkspaceDashboardActionRecommendationsUseCase(
+      WorkspaceRepository workspaceRepository,
+      WorkspaceMemberRepository workspaceMemberRepository,
+      WorkspaceDashboardQueryPort workspaceDashboardQueryPort,
+      Clock clock) {
+    this.workspaceRepository = workspaceRepository;
+    this.workspaceMemberRepository = workspaceMemberRepository;
+    this.workspaceDashboardQueryPort = workspaceDashboardQueryPort;
+    this.clock = clock;
+  }
+
+  public WorkspaceDashboardActionRecommendationsResult execute(
+      GetWorkspaceDashboardActionRecommendationsCommand command) {
+    Long workspaceId = command.workspaceId();
+    validateWorkspaceAccess(workspaceId, command.userId());
+
+    RecommendationPeriod period = resolvePeriod(command);
+    WorkspaceDashboardRecommendationSignalsResult signals =
+        workspaceDashboardQueryPort.findRecommendationSignals(
+            workspaceId, period.start(), period.endExclusive(), period.previousStart());
+
+    List<WorkspaceDashboardActionRecommendationResult> recommendations = new ArrayList<>();
+    addPipelineFailedRecommendation(workspaceId, signals, recommendations);
+    addRiskHitSurgeRecommendation(workspaceId, signals, recommendations);
+    addHotpathSurgeRecommendation(workspaceId, signals, recommendations);
+    addLowCompletionRecommendation(workspaceId, signals, recommendations);
+    addMissingSlotRecommendation(workspaceId, signals, recommendations);
+    addLowConfidenceRecommendation(workspaceId, signals, recommendations);
+    addStaleKnowledgePackRecommendation(workspaceId, signals, recommendations);
+
+    List<WorkspaceDashboardActionRecommendationResult> topRecommendations =
+        recommendations.stream()
+            .sorted(
+                Comparator.comparingInt(WorkspaceDashboardActionRecommendationResult::priority)
+                    .reversed()
+                    .thenComparing(WorkspaceDashboardActionRecommendationResult::ruleCode))
+            .limit(MAX_RECOMMENDATIONS)
+            .toList();
+
+    return new WorkspaceDashboardActionRecommendationsResult(
+        workspaceId, signals.periodStart(), signals.periodEnd(), topRecommendations);
+  }
+
+  private void validateWorkspaceAccess(Long workspaceId, Long userId) {
+    if (!workspaceRepository.existsById(workspaceId)) {
+      throw new WorkspaceNotFoundException("워크스페이스를 찾을 수 없습니다.");
+    }
+    workspaceMemberRepository
+        .findByWorkspaceIdAndUserId(workspaceId, userId)
+        .orElseThrow(() -> new WorkspaceAccessDeniedException("워크스페이스에 접근 권한이 없습니다."));
+  }
+
+  private RecommendationPeriod resolvePeriod(
+      GetWorkspaceDashboardActionRecommendationsCommand command) {
+    boolean hasFrom = command.fromDate() != null;
+    boolean hasTo = command.toDate() != null;
+    if (hasFrom != hasTo) {
+      throw new BadRequestException(
+          "INVALID_DASHBOARD_RECOMMENDATION_PERIOD",
+          "fromDate and toDate must be provided together");
+    }
+
+    LocalDate startDate;
+    LocalDate endDateExclusive;
+    if (hasFrom) {
+      startDate = command.fromDate();
+      endDateExclusive = command.toDate().plusDays(1);
+    } else {
+      LocalDate today = LocalDate.now(clock.withZone(METRIC_ZONE));
+      startDate = today;
+      endDateExclusive = today.plusDays(1);
+    }
+
+    long days = ChronoUnit.DAYS.between(startDate, endDateExclusive);
+    OffsetDateTime start = startDate.atStartOfDay(METRIC_ZONE).toOffsetDateTime();
+    OffsetDateTime end = endDateExclusive.atStartOfDay(METRIC_ZONE).toOffsetDateTime();
+    OffsetDateTime previousStart =
+        startDate.minusDays(days).atStartOfDay(METRIC_ZONE).toOffsetDateTime();
+    return new RecommendationPeriod(start, end, previousStart);
+  }
+
+  private void addPipelineFailedRecommendation(
+      Long workspaceId,
+      WorkspaceDashboardRecommendationSignalsResult signals,
+      List<WorkspaceDashboardActionRecommendationResult> recommendations) {
+    WorkspaceDashboardGenerationResult generation = signals.health().lastKnowledgePackGeneration();
+    if (generation == null || !"FAILED".equalsIgnoreCase(generation.status())) {
+      return;
+    }
+
+    recommendations.add(
+        new WorkspaceDashboardActionRecommendationResult(
+            "PIPELINE_FAILED",
+            100,
+            "생성 실패 확인",
+            "최근 지식팩 생성이 실패했습니다. 실패 사유를 확인하고 다시 실행하세요.",
+            "Pipeline job",
+            "#" + generation.pipelineJobId() + " FAILED",
+            "/workspaces/%d/upload?jobId=%d".formatted(workspaceId, generation.pipelineJobId())));
+  }
+
+  private void addRiskHitSurgeRecommendation(
+      Long workspaceId,
+      WorkspaceDashboardRecommendationSignalsResult signals,
+      List<WorkspaceDashboardActionRecommendationResult> recommendations) {
+    long current = signals.currentDecisionSignals().riskHitCount();
+    long previous = signals.previousDecisionSignals().riskHitCount();
+    Double changeRate = changeRate(current, previous);
+    if (changeRate == null || changeRate < RISK_SURGE_THRESHOLD) {
+      return;
+    }
+
+    recommendations.add(
+        new WorkspaceDashboardActionRecommendationResult(
+            "RISK_HIT_SURGE",
+            90,
+            "주의 사항 검토",
+            "선택 기간 risk hit가 전 기간보다 크게 증가했습니다.",
+            "Risk hit",
+            "%s (%s)".formatted(formatCount(current), formatSignedPercent(changeRate)),
+            "/workspaces/%d/domain-packs".formatted(workspaceId)));
+  }
+
+  private void addHotpathSurgeRecommendation(
+      Long workspaceId,
+      WorkspaceDashboardRecommendationSignalsResult signals,
+      List<WorkspaceDashboardActionRecommendationResult> recommendations) {
+    WorkspaceDashboardWorkflowRecommendationSignal workflow = signals.hotpathSurgeWorkflow();
+    if (workflow == null || workflow.changeRate() == null) {
+      return;
+    }
+
+    recommendations.add(
+        new WorkspaceDashboardActionRecommendationResult(
+            "HOTPATH_SURGE",
+            85,
+            workflow.workflowName() + " workflow 점검",
+            "선택 기간 실행량이 전 기간보다 크게 증가했습니다.",
+            "전 기간 대비",
+            formatSignedPercent(workflow.changeRate()),
+            workflowPath(workspaceId, workflow)));
+  }
+
+  private void addLowCompletionRecommendation(
+      Long workspaceId,
+      WorkspaceDashboardRecommendationSignalsResult signals,
+      List<WorkspaceDashboardActionRecommendationResult> recommendations) {
+    WorkspaceDashboardWorkflowRecommendationSignal workflow = signals.lowCompletionWorkflow();
+    if (workflow == null || workflow.completionRate() == null) {
+      return;
+    }
+
+    recommendations.add(
+        new WorkspaceDashboardActionRecommendationResult(
+            "LOW_COMPLETION_RATE",
+            80,
+            "병목 state 확인",
+            workflow.workflowName() + " workflow 완료율이 낮습니다.",
+            "완료율",
+            formatPercent(workflow.completionRate()),
+            workflowPath(workspaceId, workflow)));
+  }
+
+  private void addMissingSlotRecommendation(
+      Long workspaceId,
+      WorkspaceDashboardRecommendationSignalsResult signals,
+      List<WorkspaceDashboardActionRecommendationResult> recommendations) {
+    WorkspaceDashboardDecisionSignalResult current = signals.currentDecisionSignals();
+    Double rate = rate(current.missingSlotHitCount(), current.decisionLogCount());
+    if (rate == null || rate < MISSING_SLOT_RATE_THRESHOLD) {
+      return;
+    }
+
+    recommendations.add(
+        new WorkspaceDashboardActionRecommendationResult(
+            "MISSING_SLOT_HIGH",
+            75,
+            "확인 항목 수정",
+            "상담 중 필요한 slot을 채우지 못한 결정 로그 비율이 높습니다.",
+            "Missing slot",
+            "%s (%s)".formatted(formatCount(current.missingSlotHitCount()), formatPercent(rate)),
+            "/workspaces/%d/domain-packs".formatted(workspaceId)));
+  }
+
+  private void addLowConfidenceRecommendation(
+      Long workspaceId,
+      WorkspaceDashboardRecommendationSignalsResult signals,
+      List<WorkspaceDashboardActionRecommendationResult> recommendations) {
+    WorkspaceDashboardDecisionSignalResult current = signals.currentDecisionSignals();
+    Double rate = rate(current.lowConfidenceCount(), current.decisionLogCount());
+    if (rate == null || rate < LOW_CONFIDENCE_RATE_THRESHOLD) {
+      return;
+    }
+
+    recommendations.add(
+        new WorkspaceDashboardActionRecommendationResult(
+            "LOW_CONFIDENCE_HIGH",
+            70,
+            "상담 로그 추가 업로드",
+            "저신뢰 decision 비율이 높아 최근 상담 로그 보강이 필요합니다.",
+            "Low confidence",
+            "%s (%s)".formatted(formatCount(current.lowConfidenceCount()), formatPercent(rate)),
+            "/workspaces/%d/upload".formatted(workspaceId)));
+  }
+
+  private void addStaleKnowledgePackRecommendation(
+      Long workspaceId,
+      WorkspaceDashboardRecommendationSignalsResult signals,
+      List<WorkspaceDashboardActionRecommendationResult> recommendations) {
+    WorkspaceDashboardKnowledgePackResult knowledgePack = signals.health().activeKnowledgePack();
+    if (knowledgePack == null || knowledgePack.publishedAt() == null) {
+      return;
+    }
+
+    LocalDate publishedDate =
+        knowledgePack.publishedAt().atZoneSameInstant(METRIC_ZONE).toLocalDate();
+    LocalDate today = LocalDate.now(clock.withZone(METRIC_ZONE));
+    long ageDays = ChronoUnit.DAYS.between(publishedDate, today);
+    if (ageDays < STALE_KNOWLEDGE_PACK_DAYS) {
+      return;
+    }
+
+    recommendations.add(
+        new WorkspaceDashboardActionRecommendationResult(
+            "STALE_KNOWLEDGE_PACK",
+            60,
+            "새 로그로 지식팩 업데이트",
+            "운영 중인 지식팩이 오래되어 최근 상담 패턴 반영이 필요할 수 있습니다.",
+            "Published",
+            ageDays + "일 전",
+            "/workspaces/%d/upload".formatted(workspaceId)));
+  }
+
+  private String workflowPath(
+      Long workspaceId, WorkspaceDashboardWorkflowRecommendationSignal workflow) {
+    if (workflow.domainPackId() == null
+        || workflow.domainPackVersionId() == null
+        || workflow.workflowDefinitionId() == null) {
+      return "/workspaces/%d/workflows".formatted(workspaceId);
+    }
+    return "/workspaces/%d/domain-packs/%d/workflows/%d?versionId=%d"
+        .formatted(
+            workspaceId,
+            workflow.domainPackId(),
+            workflow.workflowDefinitionId(),
+            workflow.domainPackVersionId());
+  }
+
+  private Double changeRate(long current, long previous) {
+    if (previous <= 0) {
+      return null;
+    }
+    return roundOneDecimal(((current - previous) * 100.0) / previous);
+  }
+
+  private Double rate(long numerator, long denominator) {
+    if (denominator <= 0) {
+      return null;
+    }
+    return roundOneDecimal((numerator * 100.0) / denominator);
+  }
+
+  private double roundOneDecimal(double value) {
+    return Math.round(value * 10.0) / 10.0;
+  }
+
+  private String formatCount(long value) {
+    return String.format("%,d건", value);
+  }
+
+  private String formatPercent(double value) {
+    return "%.1f%%".formatted(value);
+  }
+
+  private String formatSignedPercent(double value) {
+    return "%s%.1f%%".formatted(value > 0 ? "+" : "", value);
+  }
+
+  private record RecommendationPeriod(
+      OffsetDateTime start, OffsetDateTime endExclusive, OffsetDateTime previousStart) {}
+}

--- a/backend/src/main/java/com/init/workspace/application/WorkspaceDashboardActionRecommendationResult.java
+++ b/backend/src/main/java/com/init/workspace/application/WorkspaceDashboardActionRecommendationResult.java
@@ -1,0 +1,10 @@
+package com.init.workspace.application;
+
+public record WorkspaceDashboardActionRecommendationResult(
+    String ruleCode,
+    int priority,
+    String title,
+    String description,
+    String evidenceLabel,
+    String evidenceValue,
+    String targetPath) {}

--- a/backend/src/main/java/com/init/workspace/application/WorkspaceDashboardActionRecommendationsResult.java
+++ b/backend/src/main/java/com/init/workspace/application/WorkspaceDashboardActionRecommendationsResult.java
@@ -1,0 +1,10 @@
+package com.init.workspace.application;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+public record WorkspaceDashboardActionRecommendationsResult(
+    Long workspaceId,
+    OffsetDateTime periodStart,
+    OffsetDateTime periodEnd,
+    List<WorkspaceDashboardActionRecommendationResult> recommendations) {}

--- a/backend/src/main/java/com/init/workspace/application/WorkspaceDashboardDecisionSignalResult.java
+++ b/backend/src/main/java/com/init/workspace/application/WorkspaceDashboardDecisionSignalResult.java
@@ -1,0 +1,4 @@
+package com.init.workspace.application;
+
+public record WorkspaceDashboardDecisionSignalResult(
+    long decisionLogCount, long missingSlotHitCount, long riskHitCount, long lowConfidenceCount) {}

--- a/backend/src/main/java/com/init/workspace/application/WorkspaceDashboardQueryPort.java
+++ b/backend/src/main/java/com/init/workspace/application/WorkspaceDashboardQueryPort.java
@@ -3,4 +3,10 @@ package com.init.workspace.application;
 public interface WorkspaceDashboardQueryPort {
 
   WorkspaceDashboardHealthResult findKnowledgePackHealth(Long workspaceId);
+
+  WorkspaceDashboardRecommendationSignalsResult findRecommendationSignals(
+      Long workspaceId,
+      java.time.OffsetDateTime periodStart,
+      java.time.OffsetDateTime periodEnd,
+      java.time.OffsetDateTime previousPeriodStart);
 }

--- a/backend/src/main/java/com/init/workspace/application/WorkspaceDashboardRecommendationSignalsResult.java
+++ b/backend/src/main/java/com/init/workspace/application/WorkspaceDashboardRecommendationSignalsResult.java
@@ -1,0 +1,12 @@
+package com.init.workspace.application;
+
+import java.time.OffsetDateTime;
+
+public record WorkspaceDashboardRecommendationSignalsResult(
+    OffsetDateTime periodStart,
+    OffsetDateTime periodEnd,
+    WorkspaceDashboardHealthResult health,
+    WorkspaceDashboardDecisionSignalResult currentDecisionSignals,
+    WorkspaceDashboardDecisionSignalResult previousDecisionSignals,
+    WorkspaceDashboardWorkflowRecommendationSignal hotpathSurgeWorkflow,
+    WorkspaceDashboardWorkflowRecommendationSignal lowCompletionWorkflow) {}

--- a/backend/src/main/java/com/init/workspace/application/WorkspaceDashboardWorkflowRecommendationSignal.java
+++ b/backend/src/main/java/com/init/workspace/application/WorkspaceDashboardWorkflowRecommendationSignal.java
@@ -1,0 +1,10 @@
+package com.init.workspace.application;
+
+public record WorkspaceDashboardWorkflowRecommendationSignal(
+    Long workflowDefinitionId,
+    Long domainPackId,
+    Long domainPackVersionId,
+    String workflowName,
+    long executionCount,
+    Double completionRate,
+    Double changeRate) {}

--- a/backend/src/main/java/com/init/workspace/infrastructure/persistence/JdbcWorkspaceDashboardQueryAdapter.java
+++ b/backend/src/main/java/com/init/workspace/infrastructure/persistence/JdbcWorkspaceDashboardQueryAdapter.java
@@ -1,10 +1,13 @@
 package com.init.workspace.infrastructure.persistence;
 
+import com.init.workspace.application.WorkspaceDashboardDecisionSignalResult;
 import com.init.workspace.application.WorkspaceDashboardGenerationResult;
 import com.init.workspace.application.WorkspaceDashboardHealthResult;
 import com.init.workspace.application.WorkspaceDashboardKnowledgePackResult;
 import com.init.workspace.application.WorkspaceDashboardLogUploadResult;
 import com.init.workspace.application.WorkspaceDashboardQueryPort;
+import com.init.workspace.application.WorkspaceDashboardRecommendationSignalsResult;
+import com.init.workspace.application.WorkspaceDashboardWorkflowRecommendationSignal;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.OffsetDateTime;
@@ -16,6 +19,11 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public class JdbcWorkspaceDashboardQueryAdapter implements WorkspaceDashboardQueryPort {
+
+  private static final double LOW_CONFIDENCE_THRESHOLD = 0.6;
+  private static final int LOW_COMPLETION_MIN_EXECUTION_COUNT = 3;
+  private static final double LOW_COMPLETION_RATE_THRESHOLD = 70.0;
+  private static final double HOTPATH_SURGE_CHANGE_RATE_THRESHOLD = 30.0;
 
   private final NamedParameterJdbcTemplate jdbcTemplate;
 
@@ -30,6 +38,22 @@ public class JdbcWorkspaceDashboardQueryAdapter implements WorkspaceDashboardQue
         findLastLogUpload(workspaceId),
         findLastKnowledgePackGeneration(workspaceId),
         countPendingReviewTasks(workspaceId));
+  }
+
+  @Override
+  public WorkspaceDashboardRecommendationSignalsResult findRecommendationSignals(
+      Long workspaceId,
+      OffsetDateTime periodStart,
+      OffsetDateTime periodEnd,
+      OffsetDateTime previousPeriodStart) {
+    return new WorkspaceDashboardRecommendationSignalsResult(
+        periodStart,
+        periodEnd,
+        findKnowledgePackHealth(workspaceId),
+        findDecisionSignals(workspaceId, periodStart, periodEnd),
+        findDecisionSignals(workspaceId, previousPeriodStart, periodStart),
+        findHotpathSurgeWorkflow(workspaceId, periodStart, periodEnd, previousPeriodStart),
+        findLowCompletionWorkflow(workspaceId, periodStart, periodEnd));
   }
 
   private WorkspaceDashboardKnowledgePackResult findActiveKnowledgePack(Long workspaceId) {
@@ -123,6 +147,161 @@ public class JdbcWorkspaceDashboardQueryAdapter implements WorkspaceDashboardQue
     return count != null ? count : 0L;
   }
 
+  private WorkspaceDashboardDecisionSignalResult findDecisionSignals(
+      Long workspaceId, OffsetDateTime periodStart, OffsetDateTime periodEnd) {
+    MapSqlParameterSource params =
+        new MapSqlParameterSource()
+            .addValue("workspaceId", workspaceId)
+            .addValue("periodStart", periodStart)
+            .addValue("periodEnd", periodEnd)
+            .addValue("lowConfidenceThreshold", LOW_CONFIDENCE_THRESHOLD);
+    return jdbcTemplate.queryForObject(
+        """
+        SELECT
+          COUNT(dl.id) AS decision_log_count,
+          COALESCE(SUM(jsonb_array_length(dl.missing_slots_json)), 0) AS missing_slot_hit_count,
+          COALESCE(SUM(jsonb_array_length(dl.risk_hits_json)), 0) AS risk_hit_count,
+          COUNT(dl.id) FILTER (
+            WHERE dl.confidence_score IS NOT NULL
+              AND dl.confidence_score < :lowConfidenceThreshold
+          ) AS low_confidence_count
+        FROM runtime.decision_log dl
+        JOIN runtime.workflow_execution we ON we.id = dl.workflow_execution_id
+        JOIN runtime.chat_session cs ON cs.id = we.chat_session_id
+        WHERE cs.workspace_id = :workspaceId
+          AND we.started_at >= :periodStart
+          AND we.started_at < :periodEnd
+          AND (
+            cs.channel IS NULL
+            OR (
+              UPPER(cs.channel) NOT IN ('DEMO', 'DEMO_WEB', 'SIMULATION', 'SIMULATION_WEB')
+              AND UPPER(cs.channel) NOT LIKE 'SIMULATION%'
+            )
+          )
+        """,
+        params,
+        (rs, rowNum) ->
+            new WorkspaceDashboardDecisionSignalResult(
+                rs.getLong("decision_log_count"),
+                rs.getLong("missing_slot_hit_count"),
+                rs.getLong("risk_hit_count"),
+                rs.getLong("low_confidence_count")));
+  }
+
+  private WorkspaceDashboardWorkflowRecommendationSignal findHotpathSurgeWorkflow(
+      Long workspaceId,
+      OffsetDateTime periodStart,
+      OffsetDateTime periodEnd,
+      OffsetDateTime previousPeriodStart) {
+    MapSqlParameterSource params =
+        new MapSqlParameterSource()
+            .addValue("workspaceId", workspaceId)
+            .addValue("periodStart", periodStart)
+            .addValue("periodEnd", periodEnd)
+            .addValue("previousPeriodStart", previousPeriodStart)
+            .addValue("surgeThreshold", HOTPATH_SURGE_CHANGE_RATE_THRESHOLD);
+    List<WorkspaceDashboardWorkflowRecommendationSignal> rows =
+        jdbcTemplate.query(
+            workflowAggregateQuery(
+                """
+                WHERE p.execution_count > 0
+                  AND ((c.execution_count - p.execution_count) * 100.0 / p.execution_count) >= :surgeThreshold
+                ORDER BY change_rate DESC, c.execution_count DESC, workflow_name ASC
+                LIMIT 1
+                """),
+            params,
+            (rs, rowNum) -> mapWorkflowSignal(rs));
+    return rows.stream().findFirst().orElse(null);
+  }
+
+  private WorkspaceDashboardWorkflowRecommendationSignal findLowCompletionWorkflow(
+      Long workspaceId, OffsetDateTime periodStart, OffsetDateTime periodEnd) {
+    MapSqlParameterSource params =
+        new MapSqlParameterSource()
+            .addValue("workspaceId", workspaceId)
+            .addValue("periodStart", periodStart)
+            .addValue("periodEnd", periodEnd)
+            .addValue("previousPeriodStart", periodStart)
+            .addValue("minExecutionCount", LOW_COMPLETION_MIN_EXECUTION_COUNT)
+            .addValue("completionRateThreshold", LOW_COMPLETION_RATE_THRESHOLD);
+    List<WorkspaceDashboardWorkflowRecommendationSignal> rows =
+        jdbcTemplate.query(
+            workflowAggregateQuery(
+                """
+                WHERE c.execution_count >= :minExecutionCount
+                  AND (c.completed_count * 100.0 / c.execution_count) < :completionRateThreshold
+                ORDER BY completion_rate ASC, c.execution_count DESC, workflow_name ASC
+                LIMIT 1
+                """),
+            params,
+            (rs, rowNum) -> mapWorkflowSignal(rs));
+    return rows.stream().findFirst().orElse(null);
+  }
+
+  private String workflowAggregateQuery(String tailSql) {
+    return """
+        WITH current_workflows AS (
+          SELECT
+            COALESCE('workflow:' || we.workflow_definition_id::text, 'code:' || wd.workflow_code, 'unknown') AS group_key,
+            we.workflow_definition_id,
+            dp.id AS domain_pack_id,
+            wd.domain_pack_version_id,
+            COALESCE(NULLIF(wd.name, ''), '워크플로우 #' || we.workflow_definition_id::text, '미확인 워크플로우') AS workflow_name,
+            COUNT(*) AS execution_count,
+            COUNT(*) FILTER (WHERE we.status = 'COMPLETED') AS completed_count
+          FROM runtime.workflow_execution we
+          JOIN runtime.chat_session cs ON cs.id = we.chat_session_id
+          LEFT JOIN pack.workflow_definition wd ON wd.id = we.workflow_definition_id
+          LEFT JOIN pack.domain_pack_version dpv ON dpv.id = wd.domain_pack_version_id
+          LEFT JOIN pack.domain_pack dp ON dp.id = dpv.domain_pack_id
+          WHERE cs.workspace_id = :workspaceId
+            AND we.started_at >= :periodStart
+            AND we.started_at < :periodEnd
+            AND (
+              cs.channel IS NULL
+              OR (
+                UPPER(cs.channel) NOT IN ('DEMO', 'DEMO_WEB', 'SIMULATION', 'SIMULATION_WEB')
+                AND UPPER(cs.channel) NOT LIKE 'SIMULATION%'
+              )
+            )
+          GROUP BY group_key, we.workflow_definition_id, dp.id, wd.domain_pack_version_id, workflow_name
+        ),
+        previous_workflows AS (
+          SELECT
+            COALESCE('workflow:' || we.workflow_definition_id::text, 'code:' || wd.workflow_code, 'unknown') AS group_key,
+            COUNT(*) AS execution_count
+          FROM runtime.workflow_execution we
+          JOIN runtime.chat_session cs ON cs.id = we.chat_session_id
+          LEFT JOIN pack.workflow_definition wd ON wd.id = we.workflow_definition_id
+          WHERE cs.workspace_id = :workspaceId
+            AND we.started_at >= :previousPeriodStart
+            AND we.started_at < :periodStart
+            AND (
+              cs.channel IS NULL
+              OR (
+                UPPER(cs.channel) NOT IN ('DEMO', 'DEMO_WEB', 'SIMULATION', 'SIMULATION_WEB')
+                AND UPPER(cs.channel) NOT LIKE 'SIMULATION%'
+              )
+            )
+          GROUP BY group_key
+        )
+        SELECT
+          c.workflow_definition_id,
+          c.domain_pack_id,
+          c.domain_pack_version_id,
+          c.workflow_name,
+          c.execution_count,
+          ROUND((c.completed_count * 100.0 / c.execution_count)::numeric, 1) AS completion_rate,
+          CASE
+            WHEN p.execution_count > 0 THEN ROUND(((c.execution_count - p.execution_count) * 100.0 / p.execution_count)::numeric, 1)
+            ELSE NULL
+          END AS change_rate
+        FROM current_workflows c
+        LEFT JOIN previous_workflows p ON p.group_key = c.group_key
+        """
+        + tailSql;
+  }
+
   private WorkspaceDashboardKnowledgePackResult mapKnowledgePack(ResultSet rs) throws SQLException {
     return new WorkspaceDashboardKnowledgePackResult(
         rs.getLong("pack_id"),
@@ -155,8 +334,25 @@ public class JdbcWorkspaceDashboardQueryAdapter implements WorkspaceDashboardQue
         rs.getString("last_error_message"));
   }
 
+  private WorkspaceDashboardWorkflowRecommendationSignal mapWorkflowSignal(ResultSet rs)
+      throws SQLException {
+    return new WorkspaceDashboardWorkflowRecommendationSignal(
+        nullableLong(rs, "workflow_definition_id"),
+        nullableLong(rs, "domain_pack_id"),
+        nullableLong(rs, "domain_pack_version_id"),
+        rs.getString("workflow_name"),
+        rs.getLong("execution_count"),
+        nullableDouble(rs, "completion_rate"),
+        nullableDouble(rs, "change_rate"));
+  }
+
   private Long nullableLong(ResultSet rs, String columnName) throws SQLException {
     long value = rs.getLong(columnName);
+    return rs.wasNull() ? null : value;
+  }
+
+  private Double nullableDouble(ResultSet rs, String columnName) throws SQLException {
+    double value = rs.getDouble(columnName);
     return rs.wasNull() ? null : value;
   }
 

--- a/backend/src/main/java/com/init/workspace/presentation/WorkspaceDashboardController.java
+++ b/backend/src/main/java/com/init/workspace/presentation/WorkspaceDashboardController.java
@@ -1,13 +1,19 @@
 package com.init.workspace.presentation;
 
 import com.init.shared.presentation.AuthenticationUtils;
+import com.init.workspace.application.GetWorkspaceDashboardActionRecommendationsCommand;
+import com.init.workspace.application.GetWorkspaceDashboardActionRecommendationsUseCase;
 import com.init.workspace.application.GetWorkspaceDashboardHealthUseCase;
+import com.init.workspace.application.WorkspaceDashboardActionRecommendationsResult;
 import com.init.workspace.application.WorkspaceDashboardHealthResult;
+import java.time.LocalDate;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -15,10 +21,16 @@ import org.springframework.web.bind.annotation.RestController;
 public class WorkspaceDashboardController {
 
   private final GetWorkspaceDashboardHealthUseCase getWorkspaceDashboardHealthUseCase;
+  private final GetWorkspaceDashboardActionRecommendationsUseCase
+      getWorkspaceDashboardActionRecommendationsUseCase;
 
   public WorkspaceDashboardController(
-      GetWorkspaceDashboardHealthUseCase getWorkspaceDashboardHealthUseCase) {
+      GetWorkspaceDashboardHealthUseCase getWorkspaceDashboardHealthUseCase,
+      GetWorkspaceDashboardActionRecommendationsUseCase
+          getWorkspaceDashboardActionRecommendationsUseCase) {
     this.getWorkspaceDashboardHealthUseCase = getWorkspaceDashboardHealthUseCase;
+    this.getWorkspaceDashboardActionRecommendationsUseCase =
+        getWorkspaceDashboardActionRecommendationsUseCase;
   }
 
   @GetMapping("/knowledge-pack-health")
@@ -26,5 +38,17 @@ public class WorkspaceDashboardController {
       @PathVariable Long workspaceId, Authentication authentication) {
     Long userId = AuthenticationUtils.getUserId(authentication);
     return ResponseEntity.ok(getWorkspaceDashboardHealthUseCase.execute(workspaceId, userId));
+  }
+
+  @GetMapping("/action-recommendations")
+  public ResponseEntity<WorkspaceDashboardActionRecommendationsResult> getActionRecommendations(
+      @PathVariable Long workspaceId,
+      @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+      @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to,
+      Authentication authentication) {
+    Long userId = AuthenticationUtils.getUserId(authentication);
+    return ResponseEntity.ok(
+        getWorkspaceDashboardActionRecommendationsUseCase.execute(
+            new GetWorkspaceDashboardActionRecommendationsCommand(workspaceId, userId, from, to)));
   }
 }

--- a/backend/src/test/java/com/init/workspace/application/GetWorkspaceDashboardActionRecommendationsUseCaseTest.java
+++ b/backend/src/test/java/com/init/workspace/application/GetWorkspaceDashboardActionRecommendationsUseCaseTest.java
@@ -1,0 +1,160 @@
+package com.init.workspace.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import com.init.workspace.application.exception.WorkspaceAccessDeniedException;
+import com.init.workspace.application.exception.WorkspaceNotFoundException;
+import com.init.workspace.domain.model.WorkspaceMember;
+import com.init.workspace.domain.model.WorkspaceMemberRole;
+import com.init.workspace.domain.repository.WorkspaceMemberRepository;
+import com.init.workspace.domain.repository.WorkspaceRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetWorkspaceDashboardActionRecommendationsUseCase")
+class GetWorkspaceDashboardActionRecommendationsUseCaseTest {
+
+  @Mock private WorkspaceRepository workspaceRepository;
+  @Mock private WorkspaceMemberRepository workspaceMemberRepository;
+  @Mock private WorkspaceDashboardQueryPort workspaceDashboardQueryPort;
+
+  private GetWorkspaceDashboardActionRecommendationsUseCase useCase;
+
+  @BeforeEach
+  void setUp() {
+    useCase =
+        new GetWorkspaceDashboardActionRecommendationsUseCase(
+            workspaceRepository,
+            workspaceMemberRepository,
+            workspaceDashboardQueryPort,
+            Clock.fixed(Instant.parse("2026-06-04T00:00:00Z"), ZoneId.of("Asia/Seoul")));
+  }
+
+  @Test
+  @DisplayName("추천 후보가 여러 개이면 priority 기준 최대 3개 반환")
+  void should_top3반환_when_추천후보가여러개() {
+    givenMember();
+    given(
+            workspaceDashboardQueryPort.findRecommendationSignals(
+                1L,
+                odt("2026-05-29T00:00:00+09:00"),
+                odt("2026-06-05T00:00:00+09:00"),
+                odt("2026-05-22T00:00:00+09:00")))
+        .willReturn(signalsWithManyCandidates());
+
+    WorkspaceDashboardActionRecommendationsResult result =
+        useCase.execute(
+            new GetWorkspaceDashboardActionRecommendationsCommand(
+                1L, 7L, LocalDate.parse("2026-05-29"), LocalDate.parse("2026-06-04")));
+
+    assertThat(result.recommendations())
+        .extracting(WorkspaceDashboardActionRecommendationResult::ruleCode)
+        .containsExactly("PIPELINE_FAILED", "RISK_HIT_SURGE", "HOTPATH_SURGE");
+    assertThat(result.recommendations()).hasSize(3);
+    assertThat(result.recommendations().get(0).targetPath())
+        .isEqualTo("/workspaces/1/upload?jobId=77");
+  }
+
+  @Test
+  @DisplayName("선행 지표가 없으면 rule을 안전하게 skip")
+  void should_skip_when_선행지표없음() {
+    givenMember();
+    given(
+            workspaceDashboardQueryPort.findRecommendationSignals(
+                1L,
+                odt("2026-06-04T00:00:00+09:00"),
+                odt("2026-06-05T00:00:00+09:00"),
+                odt("2026-06-03T00:00:00+09:00")))
+        .willReturn(emptySignals());
+
+    WorkspaceDashboardActionRecommendationsResult result =
+        useCase.execute(new GetWorkspaceDashboardActionRecommendationsCommand(1L, 7L, null, null));
+
+    assertThat(result.recommendations()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("workspace 없음 → WorkspaceNotFoundException")
+  void should_WorkspaceNotFoundException_when_workspace없음() {
+    given(workspaceRepository.existsById(1L)).willReturn(false);
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new GetWorkspaceDashboardActionRecommendationsCommand(1L, 7L, null, null)))
+        .isInstanceOf(WorkspaceNotFoundException.class);
+  }
+
+  @Test
+  @DisplayName("멤버 아님 → WorkspaceAccessDeniedException")
+  void should_WorkspaceAccessDeniedException_when_멤버아님() {
+    given(workspaceRepository.existsById(1L)).willReturn(true);
+    given(workspaceMemberRepository.findByWorkspaceIdAndUserId(1L, 7L))
+        .willReturn(Optional.empty());
+
+    assertThatThrownBy(
+            () ->
+                useCase.execute(
+                    new GetWorkspaceDashboardActionRecommendationsCommand(1L, 7L, null, null)))
+        .isInstanceOf(WorkspaceAccessDeniedException.class);
+  }
+
+  private void givenMember() {
+    given(workspaceRepository.existsById(1L)).willReturn(true);
+    given(workspaceMemberRepository.findByWorkspaceIdAndUserId(1L, 7L))
+        .willReturn(Optional.of(WorkspaceMember.create(1L, 7L, WorkspaceMemberRole.ADMIN)));
+  }
+
+  private WorkspaceDashboardRecommendationSignalsResult signalsWithManyCandidates() {
+    OffsetDateTime now = odt("2026-06-03T10:00:00+09:00");
+    WorkspaceDashboardHealthResult health =
+        new WorkspaceDashboardHealthResult(
+            new WorkspaceDashboardKnowledgePackResult(
+                11L, "CS Pack", 22L, 4, odt("2026-04-01T00:00:00+09:00"), now, 77L),
+            new WorkspaceDashboardLogUploadResult(8L, "june-log", "6월 상담 로그", "READY", now),
+            new WorkspaceDashboardGenerationResult(77L, 8L, 11L, "FAILED", now, now, now, "boom"),
+            0);
+    return new WorkspaceDashboardRecommendationSignalsResult(
+        odt("2026-05-29T00:00:00+09:00"),
+        odt("2026-06-05T00:00:00+09:00"),
+        health,
+        new WorkspaceDashboardDecisionSignalResult(100, 30, 20, 15),
+        new WorkspaceDashboardDecisionSignalResult(100, 10, 10, 3),
+        workflow("환불 처리", 48, 87.5, 33.3),
+        workflow("배송 확인", 10, 40.0, null));
+  }
+
+  private WorkspaceDashboardRecommendationSignalsResult emptySignals() {
+    return new WorkspaceDashboardRecommendationSignalsResult(
+        odt("2026-06-04T00:00:00+09:00"),
+        odt("2026-06-05T00:00:00+09:00"),
+        new WorkspaceDashboardHealthResult(null, null, null, 0),
+        new WorkspaceDashboardDecisionSignalResult(0, 0, 0, 0),
+        new WorkspaceDashboardDecisionSignalResult(0, 0, 0, 0),
+        null,
+        null);
+  }
+
+  private WorkspaceDashboardWorkflowRecommendationSignal workflow(
+      String workflowName, long executionCount, Double completionRate, Double changeRate) {
+    return new WorkspaceDashboardWorkflowRecommendationSignal(
+        100L, 11L, 22L, workflowName, executionCount, completionRate, changeRate);
+  }
+
+  private OffsetDateTime odt(String value) {
+    return OffsetDateTime.parse(value);
+  }
+}

--- a/backend/src/test/java/com/init/workspace/presentation/WorkspaceDashboardControllerTest.java
+++ b/backend/src/test/java/com/init/workspace/presentation/WorkspaceDashboardControllerTest.java
@@ -6,12 +6,17 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.init.shared.infrastructure.security.JwtAuthenticationFilter;
+import com.init.workspace.application.GetWorkspaceDashboardActionRecommendationsCommand;
+import com.init.workspace.application.GetWorkspaceDashboardActionRecommendationsUseCase;
 import com.init.workspace.application.GetWorkspaceDashboardHealthUseCase;
+import com.init.workspace.application.WorkspaceDashboardActionRecommendationResult;
+import com.init.workspace.application.WorkspaceDashboardActionRecommendationsResult;
 import com.init.workspace.application.WorkspaceDashboardGenerationResult;
 import com.init.workspace.application.WorkspaceDashboardHealthResult;
 import com.init.workspace.application.WorkspaceDashboardKnowledgePackResult;
 import com.init.workspace.application.WorkspaceDashboardLogUploadResult;
 import java.time.OffsetDateTime;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,6 +43,10 @@ class WorkspaceDashboardControllerTest {
 
   @MockitoBean private GetWorkspaceDashboardHealthUseCase getWorkspaceDashboardHealthUseCase;
 
+  @MockitoBean
+  private GetWorkspaceDashboardActionRecommendationsUseCase
+      getWorkspaceDashboardActionRecommendationsUseCase;
+
   @Test
   @DisplayName("GET 운영 지식팩 건강도 → 200 OK")
   void should_200반환_when_운영지식팩건강도조회() throws Exception {
@@ -52,6 +61,30 @@ class WorkspaceDashboardControllerTest {
         .andExpect(jsonPath("$.pendingReviewCount").value(2));
   }
 
+  @Test
+  @DisplayName("GET 고객 액션 추천 → 200 OK")
+  void should_200반환_when_고객액션추천조회() throws Exception {
+    given(
+            getWorkspaceDashboardActionRecommendationsUseCase.execute(
+                new GetWorkspaceDashboardActionRecommendationsCommand(
+                    1L,
+                    7L,
+                    java.time.LocalDate.parse("2026-05-29"),
+                    java.time.LocalDate.parse("2026-06-04"))))
+        .willReturn(recommendationsResult());
+
+    mockMvc
+        .perform(
+            get("/api/v1/workspaces/1/dashboard/action-recommendations")
+                .queryParam("from", "2026-05-29")
+                .queryParam("to", "2026-06-04")
+                .principal(auth()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.recommendations[0].ruleCode").value("HOTPATH_SURGE"))
+        .andExpect(jsonPath("$.recommendations[0].evidenceValue").value("+33.3%"))
+        .andExpect(jsonPath("$.recommendations[0].targetPath").value("/workspaces/1/workflows"));
+  }
+
   private WorkspaceDashboardHealthResult healthResult() {
     OffsetDateTime now = OffsetDateTime.parse("2026-06-03T10:00:00Z");
     return new WorkspaceDashboardHealthResult(
@@ -59,6 +92,23 @@ class WorkspaceDashboardControllerTest {
         new WorkspaceDashboardLogUploadResult(8L, "june-log", "6월 상담 로그", "READY", now),
         new WorkspaceDashboardGenerationResult(77L, 8L, 11L, "SUCCEEDED", now, now, now, null),
         2L);
+  }
+
+  private WorkspaceDashboardActionRecommendationsResult recommendationsResult() {
+    OffsetDateTime now = OffsetDateTime.parse("2026-06-03T10:00:00Z");
+    return new WorkspaceDashboardActionRecommendationsResult(
+        1L,
+        now,
+        now.plusDays(1),
+        List.of(
+            new WorkspaceDashboardActionRecommendationResult(
+                "HOTPATH_SURGE",
+                85,
+                "workflow 점검",
+                "선택 기간 실행량이 전 기간보다 크게 증가했습니다.",
+                "전 기간 대비",
+                "+33.3%",
+                "/workspaces/1/workflows")));
   }
 
   private UsernamePasswordAuthenticationToken auth() {

--- a/frontend/src/app/App.test.tsx
+++ b/frontend/src/app/App.test.tsx
@@ -121,6 +121,18 @@ describe("App", () => {
           }),
         });
       }
+      if (url.startsWith("/api/v1/workspaces/1/dashboard/action-recommendations")) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            workspaceId: 1,
+            periodStart: "2026-05-28T00:00:00+09:00",
+            periodEnd: "2026-06-04T00:00:00+09:00",
+            recommendations: [],
+          }),
+        });
+      }
       return Promise.resolve({
         ok: true,
         status: 200,

--- a/frontend/src/features/workspace-dashboard-health/api/workspaceDashboardHealthApi.test.ts
+++ b/frontend/src/features/workspace-dashboard-health/api/workspaceDashboardHealthApi.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import { customFetch } from "@/shared/api/mutator";
+
+import { fetchWorkspaceDashboardActionRecommendations } from "./workspaceDashboardHealthApi";
+
+vi.mock("@/shared/api/mutator", () => ({
+  customFetch: vi.fn(),
+}));
+
+const mockedCustomFetch = vi.mocked(customFetch);
+
+describe("workspaceDashboardHealthApi", () => {
+  beforeEach(() => {
+    mockedCustomFetch.mockReset();
+  });
+
+  it("fetchWorkspaceDashboardActionRecommendations가 기간 쿼리와 함께 추천 endpoint를 호출한다", async () => {
+    const response = {
+      workspaceId: 1,
+      periodStart: "2026-05-29T00:00:00+09:00",
+      periodEnd: "2026-06-05T00:00:00+09:00",
+      recommendations: [],
+    };
+    mockedCustomFetch.mockResolvedValueOnce(response);
+
+    const result = await fetchWorkspaceDashboardActionRecommendations(1, {
+      from: "2026-05-29",
+      to: "2026-06-04",
+    });
+
+    expect(mockedCustomFetch).toHaveBeenCalledWith(
+      "/api/v1/workspaces/1/dashboard/action-recommendations?from=2026-05-29&to=2026-06-04",
+      { method: "GET", signal: undefined },
+    );
+    expect(result).toEqual(response);
+  });
+});

--- a/frontend/src/features/workspace-dashboard-health/api/workspaceDashboardHealthApi.ts
+++ b/frontend/src/features/workspace-dashboard-health/api/workspaceDashboardHealthApi.ts
@@ -40,9 +40,37 @@ export interface WorkspaceDashboardHealth {
   pendingReviewCount: number;
 }
 
+export interface WorkspaceDashboardActionRecommendation {
+  ruleCode: string;
+  priority: number;
+  title: string;
+  description: string;
+  evidenceLabel: string;
+  evidenceValue: string;
+  targetPath: string;
+}
+
+export interface WorkspaceDashboardActionRecommendations {
+  workspaceId: number;
+  periodStart: string;
+  periodEnd: string;
+  recommendations: WorkspaceDashboardActionRecommendation[];
+}
+
+export interface WorkspaceDashboardActionRecommendationParams {
+  from?: string;
+  to?: string;
+}
+
 export const workspaceDashboardHealthKeys = {
   all: ["workspace-dashboard-health"] as const,
   detail: (workspaceId: number) => [...workspaceDashboardHealthKeys.all, workspaceId] as const,
+};
+
+export const workspaceDashboardActionRecommendationKeys = {
+  all: ["workspace-dashboard-action-recommendations"] as const,
+  detail: (workspaceId: number, params: WorkspaceDashboardActionRecommendationParams = {}) =>
+    [...workspaceDashboardActionRecommendationKeys.all, workspaceId, params] as const,
 };
 
 export function useWorkspaceDashboardHealth(workspaceId: number) {
@@ -53,5 +81,31 @@ export function useWorkspaceDashboardHealth(workspaceId: number) {
         `/api/v1/workspaces/${workspaceId}/dashboard/knowledge-pack-health`,
         { method: "GET", signal },
       ),
+  });
+}
+
+export function fetchWorkspaceDashboardActionRecommendations(
+  workspaceId: number,
+  params: WorkspaceDashboardActionRecommendationParams = {},
+  signal?: AbortSignal,
+) {
+  const searchParams = new URLSearchParams();
+  if (params.from) searchParams.set("from", params.from);
+  if (params.to) searchParams.set("to", params.to);
+  const query = searchParams.toString();
+  return customFetch<WorkspaceDashboardActionRecommendations>(
+    `/api/v1/workspaces/${workspaceId}/dashboard/action-recommendations${query ? `?${query}` : ""}`,
+    { method: "GET", signal },
+  );
+}
+
+export function useWorkspaceDashboardActionRecommendations(
+  workspaceId: number,
+  params: WorkspaceDashboardActionRecommendationParams = {},
+) {
+  return useQuery({
+    queryKey: workspaceDashboardActionRecommendationKeys.detail(workspaceId, params),
+    queryFn: ({ signal }) =>
+      fetchWorkspaceDashboardActionRecommendations(workspaceId, params, signal),
   });
 }

--- a/frontend/src/pages/workspace/ui/WorkspaceDashboardPage.test.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceDashboardPage.test.tsx
@@ -3,12 +3,14 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 
 import { consultationApi } from "@/features/consultation/api/consultationApi";
+import { fetchWorkspaceDashboardActionRecommendations } from "@/features/workspace-dashboard-health/api/workspaceDashboardHealthApi";
 
 import { DashboardStatePanel, WorkspaceDashboardPage } from "./WorkspaceDashboardPage";
 
 const setCrumbs = vi.fn();
 const mockedGetMetrics = vi.mocked(consultationApi.getMetrics);
 const mockedGetWorkflowRankings = vi.mocked(consultationApi.getWorkflowRankings);
+const mockedFetchActionRecommendations = vi.mocked(fetchWorkspaceDashboardActionRecommendations);
 
 const metricsResponse = {
   workspaceId: 1,
@@ -136,6 +138,23 @@ const workflowRankingResponse = {
   ],
 };
 
+const actionRecommendationResponse = {
+  workspaceId: 1,
+  periodStart: "2026-05-28T00:00:00+09:00",
+  periodEnd: "2026-06-04T00:00:00+09:00",
+  recommendations: [
+    {
+      ruleCode: "HOTPATH_SURGE",
+      priority: 85,
+      title: "환불 처리 workflow 점검",
+      description: "선택 기간 실행량이 전 기간보다 크게 증가했습니다.",
+      evidenceLabel: "전 기간 대비",
+      evidenceValue: "+33.3%",
+      targetPath: "/workspaces/1/domain-packs/11/workflows/100?versionId=22",
+    },
+  ],
+};
+
 function renderPage(path = "/workspaces/1/dashboard") {
   setCrumbs.mockClear();
   render(
@@ -163,6 +182,10 @@ vi.mock("@/features/consultation/api/consultationApi", () => ({
   },
 }));
 
+vi.mock("@/features/workspace-dashboard-health/api/workspaceDashboardHealthApi", () => ({
+  fetchWorkspaceDashboardActionRecommendations: vi.fn(),
+}));
+
 vi.mock("sonner", () => ({
   toast: {
     error: vi.fn(),
@@ -179,8 +202,10 @@ describe("WorkspaceDashboardPage", () => {
   beforeEach(() => {
     mockedGetMetrics.mockReset();
     mockedGetWorkflowRankings.mockReset();
+    mockedFetchActionRecommendations.mockReset();
     mockedGetMetrics.mockResolvedValue(metricsResponse);
     mockedGetWorkflowRankings.mockResolvedValue(workflowRankingResponse);
+    mockedFetchActionRecommendations.mockResolvedValue(actionRecommendationResponse);
   });
 
   it("잘못된 workspaceId면 /workspaces로 리다이렉트한다", () => {
@@ -188,9 +213,10 @@ describe("WorkspaceDashboardPage", () => {
     expect(screen.getByTestId("workspace-root")).toBeInTheDocument();
     expect(mockedGetMetrics).not.toHaveBeenCalled();
     expect(mockedGetWorkflowRankings).not.toHaveBeenCalled();
+    expect(mockedFetchActionRecommendations).not.toHaveBeenCalled();
   });
 
-  it("공통 필터와 상담 처리 KPI, 운영 지식팩 건강도, 핫패스 랭킹을 표시한다", async () => {
+  it("공통 필터와 상담 처리 KPI, 추천 액션, 운영 지식팩 건강도, 핫패스 랭킹을 표시한다", async () => {
     renderPage();
 
     expect(screen.getByRole("heading", { name: "대시보드" })).toBeInTheDocument();
@@ -208,6 +234,13 @@ describe("WorkspaceDashboardPage", () => {
     expect(screen.getByText("21.7%")).toBeInTheDocument();
     expect(screen.getByText("72.9%")).toBeInTheDocument();
     expect(screen.getByText("2026-05-29")).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "추천 액션" })).toBeInTheDocument();
+    expect(screen.getByText("환불 처리 workflow 점검")).toBeInTheDocument();
+    expect(screen.getByText("+33.3%")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /환불 처리 workflow 점검/ })).toHaveAttribute(
+      "href",
+      "/workspaces/1/domain-packs/11/workflows/100?versionId=22",
+    );
     expect(screen.getByTestId("knowledge-health-panel")).toHaveTextContent("workspace 1 health");
     expect(await screen.findByText("핫패스 워크플로우 랭킹")).toBeInTheDocument();
     expect(screen.getByTestId("hotpath-top-1")).toHaveTextContent("환불 처리");
@@ -220,6 +253,9 @@ describe("WorkspaceDashboardPage", () => {
     await waitFor(() => expect(mockedGetMetrics).toHaveBeenCalledWith(1, expect.any(Object)));
     await waitFor(() =>
       expect(mockedGetWorkflowRankings).toHaveBeenCalledWith(1, expect.any(Object)),
+    );
+    await waitFor(() =>
+      expect(mockedFetchActionRecommendations).toHaveBeenCalledWith(1, expect.any(Object)),
     );
   });
 
@@ -250,6 +286,12 @@ describe("WorkspaceDashboardPage", () => {
     );
     await waitFor(() =>
       expect(mockedGetWorkflowRankings).toHaveBeenLastCalledWith(1, {
+        from: "2026-06-01",
+        to: "2026-06-03",
+      }),
+    );
+    await waitFor(() =>
+      expect(mockedFetchActionRecommendations).toHaveBeenLastCalledWith(1, {
         from: "2026-06-01",
         to: "2026-06-03",
       }),
@@ -299,6 +341,10 @@ describe("WorkspaceDashboardPage", () => {
       topRankings: [],
       rankings: [],
     });
+    mockedFetchActionRecommendations.mockResolvedValueOnce({
+      ...actionRecommendationResponse,
+      recommendations: [],
+    });
 
     renderPage();
 
@@ -315,6 +361,7 @@ describe("WorkspaceDashboardPage", () => {
       "/workspaces/1/domain-packs",
     );
     expect(screen.getByTestId("dashboard-simulation-cta")).toHaveAttribute("href", "/demo/chat/1");
+    expect(screen.getByTestId("recommendation-empty")).toHaveTextContent("현재 큰 이상 없음");
   });
 
   it("상담 KPI가 실패해도 워크플로우 랭킹은 같은 화면에 남긴다", async () => {

--- a/frontend/src/pages/workspace/ui/WorkspaceDashboardPage.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceDashboardPage.tsx
@@ -213,7 +213,7 @@ function hasWorkflowRankingData(rankings: WorkspaceWorkflowRankingResponse | nul
 function hasActionRecommendationData(
   recommendations: WorkspaceDashboardActionRecommendations | null,
 ): boolean {
-  return (recommendations?.recommendations.length ?? 0) > 0;
+  return (recommendations?.recommendations?.length ?? 0) > 0;
 }
 
 function DashboardMetricCard({

--- a/frontend/src/pages/workspace/ui/WorkspaceDashboardPage.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceDashboardPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Link, Navigate, useOutletContext, useParams } from "react-router-dom";
 import {
   ArrowRightIcon,
+  CheckCircle2Icon,
   FileUpIcon,
   FlaskConicalIcon,
   PackagePlusIcon,
@@ -17,6 +18,11 @@ import type {
   WorkspaceWorkflowRankingResponse,
 } from "@/features/consultation/api/consultationApi";
 import { KnowledgePackHealthPanel } from "@/features/workspace-dashboard-health";
+import {
+  fetchWorkspaceDashboardActionRecommendations,
+  type WorkspaceDashboardActionRecommendation,
+  type WorkspaceDashboardActionRecommendations,
+} from "@/features/workspace-dashboard-health/api/workspaceDashboardHealthApi";
 import type { ShellContext } from "@/shared/ui/ostone/chrome";
 import { buildDemoChatPath } from "@/shared/lib/demoRoutes";
 import { parseRouteId } from "@/shared/lib/parseRouteId";
@@ -204,6 +210,12 @@ function hasWorkflowRankingData(rankings: WorkspaceWorkflowRankingResponse | nul
   return (rankings?.rankings?.length ?? 0) > 0;
 }
 
+function hasActionRecommendationData(
+  recommendations: WorkspaceDashboardActionRecommendations | null,
+): boolean {
+  return (recommendations?.recommendations.length ?? 0) > 0;
+}
+
 function DashboardMetricCard({
   label,
   value,
@@ -372,7 +384,7 @@ function AutomationCoveragePanel({
 }) {
   const needsInstrumentation = coverage?.measurementStatus === "NEEDS_INSTRUMENTATION";
   const measurementStatus =
-    state === "loading" ? "LOADING" : coverage?.measurementStatus ?? "EMPTY";
+    state === "loading" ? "LOADING" : (coverage?.measurementStatus ?? "EMPTY");
   const measurementLabel =
     state === "loading"
       ? "계산 중"
@@ -604,6 +616,82 @@ function HotpathWorkflowRankingPanel({
   );
 }
 
+function ActionRecommendationCard({ item }: { item: WorkspaceDashboardActionRecommendation }) {
+  return (
+    <Link to={item.targetPath} className={styles.recommendationCard}>
+      <span className={styles.ruleBadge}>{item.ruleCode.replaceAll("_", " ")}</span>
+      <h3>{item.title}</h3>
+      <p>{item.description}</p>
+      <dl>
+        <div>
+          <dt>{item.evidenceLabel}</dt>
+          <dd>{item.evidenceValue}</dd>
+        </div>
+      </dl>
+      <span className={styles.recommendationLink}>
+        바로 보기
+        <ArrowRightIcon aria-hidden="true" />
+      </span>
+    </Link>
+  );
+}
+
+function ActionRecommendationsPanel({
+  recommendations,
+  state,
+  error,
+}: {
+  recommendations: WorkspaceDashboardActionRecommendations | null;
+  state: DashboardDataState;
+  error: string | null;
+}) {
+  const items = recommendations?.recommendations ?? [];
+
+  return (
+    <section className={styles.recommendationPanel} aria-labelledby="action-recommendation-title">
+      <div className={styles.panelHeader}>
+        <div>
+          <span className={styles.panelEyebrow}>Next Actions</span>
+          <h2 id="action-recommendation-title" className={styles.sectionTitle}>
+            추천 액션
+          </h2>
+          <p className={styles.sectionDescription}>
+            운영 지표의 이상 신호를 기준으로 지금 확인할 화면을 제안합니다.
+          </p>
+        </div>
+      </div>
+
+      {error ? (
+        <div className={styles.recommendationState} data-testid="recommendation-error">
+          <ErrorState message={error} />
+        </div>
+      ) : null}
+
+      {!error && state === "loading" ? (
+        <div className={styles.recommendationState} data-testid="recommendation-loading">
+          <LoadingSpinner />
+          <p className={styles.stateText}>추천 액션을 계산하는 중입니다.</p>
+        </div>
+      ) : null}
+
+      {!error && state !== "loading" && items.length === 0 ? (
+        <div className={styles.recommendationState} data-testid="recommendation-empty">
+          <CheckCircle2Icon aria-hidden="true" className={styles.panelIcon} />
+          <p className={styles.stateText}>현재 큰 이상 없음</p>
+        </div>
+      ) : null}
+
+      {!error && items.length > 0 ? (
+        <div className={styles.recommendationGrid} aria-label="고객 액션 추천">
+          {items.map((item) => (
+            <ActionRecommendationCard key={item.ruleCode} item={item} />
+          ))}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
 function DashboardFilters({
   filters,
   onChange,
@@ -815,6 +903,10 @@ export function WorkspaceDashboardPage() {
   );
   const [isWorkflowRankingsLoading, setIsWorkflowRankingsLoading] = useState(false);
   const [workflowRankingsError, setWorkflowRankingsError] = useState<string | null>(null);
+  const [actionRecommendations, setActionRecommendations] =
+    useState<WorkspaceDashboardActionRecommendations | null>(null);
+  const [isActionRecommendationsLoading, setIsActionRecommendationsLoading] = useState(false);
+  const [actionRecommendationsError, setActionRecommendationsError] = useState<string | null>(null);
   const metricDateRange = useMemo(() => buildMetricDateRange(filters), [filters]);
   const metricsState = useMemo<DashboardDataState>(() => {
     if (isMetricsLoading) return "loading";
@@ -828,19 +920,36 @@ export function WorkspaceDashboardPage() {
     if (hasWorkflowRankingData(workflowRankings)) return "partial";
     return "empty";
   }, [isWorkflowRankingsLoading, workflowRankingsError, workflowRankings]);
+  const actionRecommendationState = useMemo<DashboardDataState>(() => {
+    if (isActionRecommendationsLoading) return "loading";
+    if (actionRecommendationsError) return "error";
+    if (hasActionRecommendationData(actionRecommendations)) return "partial";
+    return "empty";
+  }, [isActionRecommendationsLoading, actionRecommendationsError, actionRecommendations]);
   const dataState = useMemo<DashboardDataState>(() => {
-    const hasAnyData = hasMetricData(metrics) || hasWorkflowRankingData(workflowRankings);
-    if ((isMetricsLoading || isWorkflowRankingsLoading) && !hasAnyData) return "loading";
+    const hasAnyData =
+      hasMetricData(metrics) ||
+      hasWorkflowRankingData(workflowRankings) ||
+      hasActionRecommendationData(actionRecommendations);
+    if (
+      (isMetricsLoading || isWorkflowRankingsLoading || isActionRecommendationsLoading) &&
+      !hasAnyData
+    ) {
+      return "loading";
+    }
     if (hasAnyData) return "partial";
-    if (metricsError && workflowRankingsError) return "error";
+    if (metricsError && workflowRankingsError && actionRecommendationsError) return "error";
     return "empty";
   }, [
     isMetricsLoading,
     isWorkflowRankingsLoading,
+    isActionRecommendationsLoading,
     metrics,
     workflowRankings,
+    actionRecommendations,
     metricsError,
     workflowRankingsError,
+    actionRecommendationsError,
   ]);
 
   useEffect(() => {
@@ -886,6 +995,53 @@ export function WorkspaceDashboardPage() {
     }
 
     void loadMetrics();
+
+    return () => {
+      ignore = true;
+    };
+  }, [parsedWorkspaceId, metricDateRange]);
+
+  useEffect(() => {
+    let ignore = false;
+
+    async function loadActionRecommendations() {
+      if (parsedWorkspaceId === null) {
+        setActionRecommendations(null);
+        setActionRecommendationsError(null);
+        setIsActionRecommendationsLoading(false);
+        return;
+      }
+
+      if (!metricDateRange.from || !metricDateRange.to) {
+        setActionRecommendations(null);
+        setActionRecommendationsError(null);
+        setIsActionRecommendationsLoading(false);
+        return;
+      }
+
+      setIsActionRecommendationsLoading(true);
+      setActionRecommendationsError(null);
+      try {
+        const data = await fetchWorkspaceDashboardActionRecommendations(
+          parsedWorkspaceId,
+          metricDateRange,
+        );
+        if (ignore) return;
+        setActionRecommendations(data);
+      } catch (error) {
+        if (ignore) return;
+        console.error("Failed to load dashboard action recommendations:", error);
+        setActionRecommendations(null);
+        setActionRecommendationsError("추천 액션을 불러오지 못했습니다.");
+        toast.error("추천 액션을 불러오지 못했습니다.");
+      } finally {
+        if (!ignore) {
+          setIsActionRecommendationsLoading(false);
+        }
+      }
+    }
+
+    void loadActionRecommendations();
 
     return () => {
       ignore = true;
@@ -960,6 +1116,11 @@ export function WorkspaceDashboardPage() {
 
       <DashboardFilters filters={filters} onChange={setFilters} />
       <FilterSummary filters={filters} />
+      <ActionRecommendationsPanel
+        recommendations={actionRecommendations}
+        state={actionRecommendationState}
+        error={actionRecommendationsError}
+      />
       <DashboardMetricsGrid metrics={metrics} state={metricsState} />
       <AutomationCoveragePanel coverage={metrics?.coverage} state={metricsState} />
       <KnowledgePackHealthPanel workspaceId={parsedWorkspaceId} />

--- a/frontend/src/pages/workspace/ui/workspace-dashboard-page.module.css
+++ b/frontend/src/pages/workspace/ui/workspace-dashboard-page.module.css
@@ -231,6 +231,7 @@
 }
 
 .coveragePanel,
+.recommendationPanel,
 .hotpathPanel {
   display: flex;
   flex-direction: column;
@@ -390,6 +391,113 @@
 .unavailableText {
   color: var(--ink-3);
   background: var(--paper-2);
+}
+
+.recommendationState {
+  min-height: 132px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--s-3);
+  border: 1px dashed var(--line);
+  border-radius: var(--r-3);
+  background: var(--paper-2);
+  text-align: center;
+}
+
+.recommendationGrid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--s-3);
+}
+
+.recommendationCard {
+  min-width: 0;
+  min-height: 196px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: var(--s-3);
+  border: 1px solid var(--line);
+  border-radius: var(--r-3);
+  padding: var(--s-4);
+  background: var(--paper-2);
+  color: inherit;
+  text-decoration: none;
+  transition:
+    border-color 160ms ease,
+    background 160ms ease;
+}
+
+.recommendationCard:hover,
+.recommendationCard:focus-visible {
+  border-color: var(--ink);
+  background: var(--paper);
+}
+
+.recommendationCard h3 {
+  margin: 0;
+  color: var(--ink);
+  font-size: 16px;
+  font-weight: 540;
+  line-height: 1.35;
+  letter-spacing: 0;
+}
+
+.recommendationCard p {
+  margin: 0;
+  color: var(--ink-2);
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.recommendationCard dl {
+  margin: 0;
+  padding: var(--s-3);
+  border: 1px solid var(--line-2);
+  border-radius: var(--r-3);
+  background: var(--paper);
+}
+
+.recommendationCard dl div {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--s-2);
+}
+
+.recommendationCard dt,
+.ruleBadge {
+  color: var(--ink-3);
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.recommendationCard dd {
+  margin: 0;
+  color: var(--ink);
+  font-size: 13px;
+  font-weight: 540;
+  text-align: right;
+}
+
+.recommendationLink {
+  display: inline-flex;
+  width: fit-content;
+  align-items: center;
+  gap: var(--s-2);
+  color: var(--ink);
+  font-size: 13px;
+  font-weight: 540;
+}
+
+.recommendationLink svg {
+  width: 14px;
+  height: 14px;
 }
 
 .hotpathState {
@@ -694,6 +802,7 @@
   .metricGrid,
   .coverageGrid,
   .slotGrid,
+  .recommendationGrid,
   .hotpathTopGrid {
     grid-template-columns: 1fr;
   }


### PR DESCRIPTION
Closes #523

## 변경 사항

- 워크스페이스 대시보드에 `action-recommendations` API를 추가해 pipeline 실패, risk hit 급증, 핫패스 급증, 낮은 workflow 완료율, missing slot, low confidence, 오래된 지식팩 신호를 deterministic rule로 최대 3개까지 추천합니다.
- 추천 응답에 rule code, priority, 설명, 근거 지표, 관련 화면 이동 경로를 포함하고, 필요한 선행 지표가 없으면 해당 rule을 안전하게 제외합니다.
- 대시보드 화면에 추천 액션 패널을 추가해 공통 기간 필터 기준으로 추천을 불러오고, 추천 없음 상태에서는 “현재 큰 이상 없음”을 표시합니다.
- 이슈 523 스펙을 `.agent/specs/523.md`에 정리했습니다.

## 검증

- `git diff --check`
- `cd backend && JAVA_HOME="$(brew --prefix openjdk@21)/libexec/openjdk.jdk/Contents/Home" ./gradlew test --tests com.init.workspace.application.GetWorkspaceDashboardActionRecommendationsUseCaseTest --tests com.init.workspace.presentation.WorkspaceDashboardControllerTest`
- `cd backend && JAVA_HOME="$(brew --prefix openjdk@21)/libexec/openjdk.jdk/Contents/Home" ./gradlew spotlessCheck`
- `cd backend && JAVA_HOME="$(brew --prefix openjdk@21)/libexec/openjdk.jdk/Contents/Home" ./gradlew build -x checkstyleMain -x checkstyleTest`
- `cd frontend && pnpm test -- App.test.tsx WorkspaceDashboardPage.test.tsx workspaceDashboardHealthApi.test.ts`
- `cd frontend && pnpm test`
- `cd frontend && pnpm test -- --coverage`
- `cd frontend && pnpm exec eslint src/app/App.test.tsx src/pages/workspace/ui/WorkspaceDashboardPage.tsx src/pages/workspace/ui/WorkspaceDashboardPage.test.tsx src/features/workspace-dashboard-health/api/workspaceDashboardHealthApi.test.ts`
- `cd frontend && pnpm build`

## 참고

- `cd frontend && pnpm build`는 기존 번들 크기 경고를 출력하지만 성공했습니다.
- `cd frontend && pnpm test`와 coverage 실행은 기존 `BillingFailPage.test.tsx` mock hoisting 경고를 출력하지만 성공했습니다.
- 로컬 Husky hook 파일이 executable이 아니어서 commit hook은 실행되지 않았고, 위 검증을 수동으로 실행했습니다.