### PR TITLE
fix(ml): DAG boolean conf 오타를 초기 실패로 처리

### DIFF
--- a/.agent/specs/591.md
+++ b/.agent/specs/591.md
@@ -1,0 +1,63 @@
+# DAG boolean conf 엄격 파싱
+
+## Goal
+
+Airflow `domain_pack_generation` DAG의 boolean `dag_run.conf` 값이 허용된 true/false 문자열만 통과하고, 알 수 없는 값은 DAG 초기에 명확하게 실패하도록 한다.
+
+## Problem
+
+`ml/src/dags/domain_pack_generation.py`의 `_conf_bool`은 true로 인식되는 문자열만 확인하고 나머지 문자열을 모두 false로 처리한다. 이 때문에 `skip_feedback_checkpoint=treu` 같은 오타가 들어오면 사용자는 체크포인트를 건너뛰려 했는지, 기본 false 동작을 의도했는지 구분할 수 없고 파이프라인이 의도와 다르게 진행될 수 있다.
+
+`ml/src/pipeline/common/config.py`의 runtime config boolean parser는 알 수 없는 값을 `PipelineConfigurationError`로 실패시키므로, DAG conf parser도 같은 실패 우선 계약을 가져야 한다.
+
+## Scope
+
+- `ml/src/dags/domain_pack_generation.py`의 `_conf_bool` 파싱 규칙 보강
+- `ml/tests/test_domain_pack_generation_dag.py`에 DAG conf parser 회귀 테스트 추가
+- `.agent/specs/591.md`에 요구사항과 검증 기준 문서화
+
+## Non-Goals
+
+- Airflow DAG stage 순서 변경
+- `run_mode` 또는 JSON conf 파싱 규칙 변경
+- `ml/src/pipeline/common/config.py`의 환경 변수 parser 계약 변경
+- Backend Airflow trigger payload 변경
+
+## Current Contract
+
+| 파일 | 현재 역할 | 확인된 이슈 |
+| --- | --- | --- |
+| `ml/src/dags/domain_pack_generation.py` | `skip_feedback_checkpoint` 같은 DAG conf boolean 값을 `_conf_bool`로 파싱 | true 문자열 외 모든 문자열이 false로 처리됨 |
+| `ml/src/pipeline/common/config.py` | `PIPELINE_CALLBACK_ENABLED` 같은 환경 변수 boolean 값을 `_parse_bool`로 파싱 | 알 수 없는 문자열은 `PipelineConfigurationError`로 실패 |
+| `ml/tests/test_domain_pack_generation_dag.py` | DAG helper와 orchestration 회귀 테스트 | `_conf_bool` 허용/거부 값 테스트가 없음 |
+
+## Design Diff
+
+| 영역 | As-is | To-be |
+| --- | --- | --- |
+| true 값 | `1`, `true`, `yes`, `y`, `on`이면 true | 기존 true 값 유지 |
+| false 값 | true 값이 아니면 암묵적으로 false | `0`, `false`, `no`, `n`, `off`만 false |
+| 알 수 없는 문자열 | 조용히 false | `PipelineConfigurationError`로 DAG 초기에 실패 |
+| 누락된 conf | default 인자 반환 | 기존 default 반환 유지 |
+
+## Acceptance Criteria
+
+- `_conf_bool`은 `true`, `1`, `yes`, `y`, `on`을 true로 파싱한다.
+- `_conf_bool`은 `false`, `0`, `no`, `n`, `off`를 false로 파싱한다.
+- JSON boolean 또는 numeric conf 값도 동일한 문자열 표현 기준으로 파싱된다.
+- 대소문자와 앞뒤 공백은 기존처럼 허용한다.
+- conf 값이 없으면 호출자가 넘긴 default 값을 유지한다.
+- 알 수 없는 문자열은 false로 폴백하지 않고 `PipelineConfigurationError`를 발생시킨다.
+- DAG conf parser 테스트가 허용 true/false 값, default, 거부 값을 모두 검증한다.
+
+## Validation Plan
+
+| 구분 | 명령 | 기대 결과 |
+| --- | --- | --- |
+| ML DAG targeted tests | `cd ml && uv run pytest tests/test_domain_pack_generation_dag.py` | `_conf_bool` 허용/거부 값과 기존 DAG helper 회귀 통과 |
+| ML changed-file lint | `cd ml && uv run ruff check src/dags/domain_pack_generation.py tests/test_domain_pack_generation_dag.py` | 변경 파일 Python lint 통과 |
+| ML full tests | `cd ml && uv run pytest` | 전체 ML 테스트 회귀 없음 |
+
+## Open Questions
+
+- 없음. 이슈 본문과 현재 parser 계약만으로 허용/거부 범위가 확인된다.

--- a/ml/src/dags/domain_pack_generation.py
+++ b/ml/src/dags/domain_pack_generation.py
@@ -79,7 +79,12 @@ def _conf_bool(key: str, default: bool = False) -> bool:
     value = _conf_value(key)
     if value is None:
         return default
-    return value.strip().lower() in {"1", "true", "yes", "y", "on"}
+    normalized = value.strip().lower()
+    if normalized in {"1", "true", "yes", "y", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "n", "off"}:
+        return False
+    raise PipelineConfigurationError(f"{key} must be a boolean value.")
 
 
 def _conf_json_file(key: str, filename: str) -> str | None:

--- a/ml/tests/test_domain_pack_generation_dag.py
+++ b/ml/tests/test_domain_pack_generation_dag.py
@@ -202,6 +202,86 @@ def test_run_evaluation_stage_delegates_to_evaluation_run(monkeypatch: pytest.Mo
     assert calls == ["/tmp/upstream.json"]
 
 
+@pytest.mark.parametrize("value", ["true", "TRUE", " 1 ", "yes", "Y", "on"])
+def test_conf_bool_accepts_true_values(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    dag_module = _import_dag_module(monkeypatch)
+
+    class DagRun:
+        conf = {"skip_feedback_checkpoint": value}
+
+    monkeypatch.setattr(
+        dag_module,
+        "get_current_context",
+        lambda: {"dag_run": DagRun()},
+    )
+
+    assert dag_module._conf_bool("skip_feedback_checkpoint") is True
+
+
+@pytest.mark.parametrize("value", ["false", "FALSE", " 0 ", "no", "N", "off"])
+def test_conf_bool_accepts_false_values(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    dag_module = _import_dag_module(monkeypatch)
+
+    class DagRun:
+        conf = {"skip_feedback_checkpoint": value}
+
+    monkeypatch.setattr(
+        dag_module,
+        "get_current_context",
+        lambda: {"dag_run": DagRun()},
+    )
+
+    assert dag_module._conf_bool("skip_feedback_checkpoint", default=True) is False
+
+
+@pytest.mark.parametrize(("raw_value", "expected"), [(True, True), (False, False), (1, True), (0, False)])
+def test_conf_bool_accepts_json_boolean_and_numeric_values(
+    monkeypatch: pytest.MonkeyPatch,
+    raw_value: bool | int,
+    expected: bool,
+) -> None:
+    dag_module = _import_dag_module(monkeypatch)
+
+    class DagRun:
+        conf = {"skip_feedback_checkpoint": raw_value}
+
+    monkeypatch.setattr(
+        dag_module,
+        "get_current_context",
+        lambda: {"dag_run": DagRun()},
+    )
+
+    assert dag_module._conf_bool("skip_feedback_checkpoint", default=not expected) is expected
+
+
+def test_conf_bool_uses_default_when_value_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    dag_module = _import_dag_module(monkeypatch)
+
+    monkeypatch.setattr(
+        dag_module,
+        "get_current_context",
+        lambda: {"dag_run": type("DagRun", (), {"conf": {}})()},
+    )
+
+    assert dag_module._conf_bool("skip_feedback_checkpoint", default=True) is True
+
+
+def test_conf_bool_rejects_unknown_strings(monkeypatch: pytest.MonkeyPatch) -> None:
+    dag_module = _import_dag_module(monkeypatch)
+
+    class DagRun:
+        conf = {"skip_feedback_checkpoint": "treu"}
+
+    monkeypatch.setattr(
+        dag_module,
+        "get_current_context",
+        lambda: {"dag_run": DagRun()},
+    )
+
+    with pytest.raises(PipelineConfigurationError, match="skip_feedback_checkpoint"):
+        dag_module._conf_bool("skip_feedback_checkpoint")
+
+
 def test_validated_replay_manifest_path_requires_artifact_root(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
Closes #591

## 변경 사항

- Airflow `domain_pack_generation` DAG의 `_conf_bool`이 허용된 true/false 값만 파싱하도록 변경했습니다.
- `0`, `false`, `no`, `n`, `off`는 명시적으로 false로 처리하고, 알 수 없는 문자열은 `PipelineConfigurationError`로 초기에 실패시킵니다.
- 문자열뿐 아니라 JSON boolean/numeric conf 값도 회귀 테스트에 포함했습니다.
- 이슈 591 스펙을 `.agent/specs/591.md`에 정리했습니다.

## 검증

- `git diff --check HEAD~1 HEAD`
- `cd ml && uv run pytest tests/test_domain_pack_generation_dag.py`
- `cd ml && uv run ruff check src/dags/domain_pack_generation.py tests/test_domain_pack_generation_dag.py`
- `cd ml && uv run pytest`

## 참고

- `cd ml && uv run ruff check .`는 기존 unrelated unused-import/import-sort lint 오류로 실패합니다. 이번 변경 파일 대상 ruff check는 통과했습니다.
- 로컬 Husky hook 파일이 executable이 아니어서 commit hook은 실행되지 않았고, 위 검증을 수동으로 실행했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 설정값 불리언 파싱이 개선되었습니다. 유효하지 않은 값은 이제 오류를 발생시켜 설정 오류를 조기에 감지합니다.

* **테스트**
  * 불리언 파싱 동작을 검증하는 포괄적인 테스트 케이스가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->