### PR TITLE
fix(simulation): consultation feature 직접 의존 제거

### DIFF
--- a/.agent/specs/588.md
+++ b/.agent/specs/588.md
@@ -1,0 +1,127 @@
+# Frontend FSD Spec: Simulation API의 Consultation Feature 의존성 분리
+
+## Goal
+
+`simulation` feature가 `consultation` feature의 타입을 직접 import하지 않도록 상담 세션/메시지 및 매칭 워크플로우 응답 타입을 하위 계층의 공통 모델에 둔다.
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A[시뮬레이션 세션 API 호출] --> B[shared api client로 응답 수신]
+    B --> C[entities 계층의 공통 타입으로 응답 해석]
+    C --> D[simulation feature가 세션 상세와 목록 반환]
+```
+
+## Design Diff
+
+### As-is vs To-be
+
+| 영역 | As-is | To-be | 변경 내용 |
+|------|-------|-------|----------|
+| 시뮬레이션 API 타입 의존성 | `frontend/src/features/simulation/api/simulationApi.ts`가 `frontend/src/features/consultation/api/consultationApi.ts`의 `ChatMessage`, `ChatSession` 타입을 import | `simulation`과 `consultation`이 `entities/chat`의 공통 상담 API 타입을 참조 | feature 간 cross-slice import 제거 |
+| 매칭 워크플로우 응답 타입 | `simulationApi.ts`가 `frontend/src/features/consultation/api/llmToolWorkflowApi.ts`의 `LlmToolWorkflowPayload` 타입을 import | `entities/workflow`의 공통 매칭 워크플로우 타입을 참조 | simulation feature의 consultation feature 직접 의존 제거 |
+| 런타임 동작 | API endpoint와 unwrap 로직은 유지 | API endpoint와 unwrap 로직은 유지 | 타입 위치만 정리하고 사용자 동작은 변경하지 않음 |
+
+## Component Tree
+
+UI 컴포넌트 변경 없음.
+
+```
+features/simulation/api/simulationApi.ts
+├─ entities/chat: 상담 세션/메시지 API 타입
+├─ entities/workflow: 매칭 워크플로우 API 타입
+└─ shared/api: customFetch, response unwrap helper
+```
+
+## API Integration
+
+### Endpoints
+
+이번 변경은 API endpoint를 추가하거나 수정하지 않는다. 기존 수동 호출 endpoint를 유지한다.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/v1/workspaces/{workspaceId}/simulation/sessions` | 시뮬레이션 세션 목록 조회 |
+| POST | `/api/v1/workspaces/{workspaceId}/simulation/sessions` | 시뮬레이션 세션 생성 |
+| GET | `/api/v1/workspaces/{workspaceId}/simulation/sessions/{sessionId}` | 시뮬레이션 세션 상세 조회 |
+| POST | `/api/v1/workspaces/{workspaceId}/simulation/sessions/{sessionId}/messages` | 시뮬레이션 메시지 전송 |
+| GET | `/api/v1/consultation/sessions/{sessionId}/matched-workflow` | 상담 세션의 매칭 워크플로우 조회 |
+
+## Data Flow
+
+```
+features/simulation
+  -> entities/chat
+  -> entities/workflow
+  -> shared/api
+
+features/consultation
+  -> entities/chat
+  -> entities/workflow
+  -> shared/api
+```
+
+FSD 의존성 방향은 `features -> entities -> shared`로 유지한다. `simulation`과 `consultation` 간 직접 import는 허용하지 않는다.
+
+## 수정 대상 파일
+
+| 파일 | 변경 유형 | 설명 |
+|------|----------|------|
+| `frontend/src/entities/chat/model/consultationTypes.ts` | new | consultation/simulation API가 공유하는 상담 세션·메시지 타입 정의 |
+| `frontend/src/entities/chat/index.ts` | modify | 공유 상담 API 타입 export |
+| `frontend/src/entities/workflow/model/matchedWorkflow.ts` | new | 매칭 워크플로우 응답 타입 정의 |
+| `frontend/src/entities/workflow/index.ts` | modify | 매칭 워크플로우 타입 export |
+| `frontend/src/features/consultation/api/consultationApi.ts` | modify | 상담 세션·메시지 타입을 `entities/chat`에서 참조 |
+| `frontend/src/features/consultation/api/llmToolWorkflowApi.ts` | modify | 매칭 워크플로우 타입을 `entities/workflow`에서 참조 |
+| `frontend/src/features/simulation/api/simulationApi.ts` | modify | consultation feature 직접 import 제거 |
+
+## State Management
+
+상태 관리 변경 없음. TanStack Query key, cache, hook 동작은 변경하지 않는다.
+
+## Tests
+
+### Test Strategy
+
+| 구분 | 방법 | 도구 | 비고 |
+|------|------|------|------|
+| 타입 검사 | frontend build | `pnpm build` | FSD import 변경 후 타입 연결 확인 |
+| API 단위 테스트 | Vitest | `pnpm test -- --run src/features/simulation/api/simulationApi.test.ts src/features/consultation/api/consultationApi.test.ts src/features/consultation/api/llmToolWorkflowApi.test.ts src/entities/chat/model/consultationTypes.test.ts` | 변경된 API 타입 사용 경로의 기존 동작 유지 확인 |
+
+### Test Scenarios
+
+#### Happy Path
+
+| # | 시나리오 | 사전 조건 | 조작 | 기대 결과 |
+|---|---------|---------|------|----------|
+| 1 | 시뮬레이션 세션 목록 조회 | API가 세션 page 응답 반환 | `simulationApi.listSessions` 호출 | 기존 page shape으로 unwrap된다 |
+| 2 | 시뮬레이션 세션 상세 조회 | API가 세션·메시지·매칭 워크플로우 응답 반환 | `simulationApi.getSession` 호출 | 공통 타입 기반 상세 응답을 반환한다 |
+| 3 | 상담 세션 목록 조회 | API가 상담 세션 page 응답 반환 | `consultationApi.getSessionPage` 호출 | 기존 page shape으로 unwrap된다 |
+| 4 | 상담 매칭 워크플로우 조회 | API가 `workflowDefinitionId` 포함 응답 반환 | `getCurrentWorkflow` 호출 | `MatchedWorkflow`로 판별된다 |
+
+#### Error & Edge Cases
+
+| # | 시나리오 | 조작 | 기대 결과 |
+|---|---------|------|----------|
+| 1 | simulation API 응답이 `{ data }`로 감싸짐 | detail/list API 호출 | 기존 helper로 동일하게 unwrap된다 |
+| 2 | 매칭 워크플로우가 없음 | `workflowDefinitionId`가 null인 응답 | `getCurrentWorkflow`가 null을 반환한다 |
+| 3 | 매칭 워크플로우 조회 실패 | 네트워크 또는 서버 오류 | 기존처럼 null로 degrade한다 |
+
+## Acceptance Criteria
+
+- `frontend/src/features/simulation/api/simulationApi.ts`에서 `@/features/consultation/*` import가 사라진다.
+- 상담 세션/메시지 API 타입은 `features`보다 하위 계층인 `entities/chat`에서 제공한다.
+- 매칭 워크플로우 API 타입은 `features`보다 하위 계층인 `entities/workflow`에서 제공한다.
+- `consultation`과 `simulation` feature는 공통 타입에 의존하며 서로 직접 의존하지 않는다.
+- 관련 frontend 타입 검사와 API 테스트가 통과한다.
+
+## Non-goals
+
+- OpenAPI generated client를 재생성하지 않는다.
+- API endpoint, response unwrap 방식, UI 상태, UX 문구를 변경하지 않는다.
+- 기존 normalized demo chat 모델의 `ChatMessage`, `ChatSession` 타입 의미를 변경하지 않는다.
+
+## Open Questions
+
+- 없음.

--- a/.agent/specs/588.md
+++ b/.agent/specs/588.md
@@ -38,7 +38,9 @@ features/simulation/api/simulationApi.ts
 
 ### Endpoints
 
-이번 변경은 API endpoint를 추가하거나 수정하지 않는다. 기존 수동 호출 endpoint를 유지한다.
+이번 변경은 API endpoint를 추가하거나 수정하지 않는다. 기존 수동 호출 endpoint는 유지한다.
+프론트엔드 API 호출은 원칙적으로 `frontend/src/shared/api/generated/`의 generated endpoint/hook을 우선 사용한다.
+`customFetch` 또는 `apiClient` 직접 호출은 generated 코드에 아직 없는 backend endpoint에 한해 허용하며, 해당 호출부에는 `OpenAPI 미생성 endpoint`임을 인라인 주석으로 남긴다.
 
 | Method | Path | Description |
 |--------|------|-------------|

--- a/frontend/src/entities/chat/index.ts
+++ b/frontend/src/entities/chat/index.ts
@@ -9,3 +9,8 @@ export {
 } from "@/entities/chat/api/chatApi";
 export type { DemoChatSession } from "@/entities/chat/api/chatApi";
 export type { ChatMessage, ChatSession, ConnectionStatus } from "@/entities/chat/model/types";
+export type {
+  ConsultationChatMessage,
+  ConsultationChatSession,
+  ConsultationResponseMode,
+} from "@/entities/chat/model/consultationTypes";

--- a/frontend/src/entities/chat/model/consultationTypes.test.ts
+++ b/frontend/src/entities/chat/model/consultationTypes.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import type {
+  ConsultationChatMessage,
+  ConsultationChatSession,
+  ConsultationResponseMode,
+} from "./consultationTypes";
+
+describe("consultation chat API types", () => {
+  it("상담 세션 응답 shape을 공통 타입으로 고정한다", () => {
+    const responseMode: ConsultationResponseMode = "AI_ASSIST_ONLY";
+    const session = {
+      id: 20,
+      channel: "SIMULATION",
+      status: "ACTIVE",
+      metaJson: "{}",
+      startedAt: "2026-06-04T10:00:00Z",
+      assignedCounselorId: null,
+      responseMode,
+      endedAt: null,
+    } satisfies ConsultationChatSession;
+
+    expect(session.responseMode).toBe("AI_ASSIST_ONLY");
+  });
+
+  it("상담 메시지 응답 shape을 공통 타입으로 고정한다", () => {
+    const message = {
+      id: 2,
+      seqNo: 1,
+      senderRole: "USER",
+      messageType: "TEXT",
+      content: "환불하고 싶어요",
+      createdAt: "2026-06-04T10:01:00Z",
+    } satisfies ConsultationChatMessage;
+
+    expect(message.senderRole).toBe("USER");
+  });
+});

--- a/frontend/src/entities/chat/model/consultationTypes.ts
+++ b/frontend/src/entities/chat/model/consultationTypes.ts
@@ -1,0 +1,13 @@
+import type { ChatMessageResponse, ChatSessionResponse } from "@/shared/api/generated/zod";
+
+export type ConsultationResponseMode = "AI_ACTIVE" | "HUMAN_ACTIVE" | "AI_ASSIST_ONLY";
+
+export type ConsultationChatSession = Omit<
+  ChatSessionResponse,
+  "assignedCounselorId" | "responseMode"
+> & {
+  assignedCounselorId?: number | null;
+  responseMode?: ConsultationResponseMode | null;
+};
+
+export type ConsultationChatMessage = ChatMessageResponse;

--- a/frontend/src/entities/workflow/index.ts
+++ b/frontend/src/entities/workflow/index.ts
@@ -10,6 +10,11 @@ export type {
 } from "./model/types";
 
 export type { WorkflowTransitionDetail } from "@/shared/api/generated/zod";
+export type {
+  LlmToolWorkflowPayload,
+  MatchedWorkflow,
+  TerminalState,
+} from "./model/matchedWorkflow";
 
 export { toFlow, convertFlowToWorkflowGraph } from "./lib/graphConverter";
 

--- a/frontend/src/entities/workflow/model/matchedWorkflow.ts
+++ b/frontend/src/entities/workflow/model/matchedWorkflow.ts
@@ -1,0 +1,24 @@
+export type TerminalState = string;
+
+export interface LlmToolWorkflowPayload {
+  sessionId: number | null;
+  workspaceId: number | null;
+  domainPackId: number | null;
+  domainPackVersionId: number | null;
+  executionId: number | null;
+  executionStatus: string | null;
+  currentState: string | null;
+  workflowDefinitionId: number | null;
+  workflowCode: string | null;
+  workflowName: string | null;
+  workflowDescription: string | null;
+  graphJson?: unknown;
+  initialState?: string | null;
+  terminalStates?: TerminalState[] | null;
+  intentCode?: string | null;
+  intentName?: string | null;
+}
+
+export type MatchedWorkflow = LlmToolWorkflowPayload & {
+  workflowDefinitionId: number;
+};

--- a/frontend/src/features/consultation/api/consultationApi.ts
+++ b/frontend/src/features/consultation/api/consultationApi.ts
@@ -6,16 +6,17 @@ import {
 } from "@/shared/api/generated/endpoints/consultation-controller/consultation-controller";
 import { customFetch } from "@/shared/api/mutator";
 import { requireApiData, selectApiData } from "@/shared/api";
-import type { ChatMessageResponse, ChatSessionResponse } from "@/shared/api/generated/zod";
+import type {
+  ConsultationChatMessage,
+  ConsultationChatSession,
+  ConsultationResponseMode,
+} from "@/entities/chat";
 
 // OpenAPI 미생성 endpoint: workspace-scoped queue/metrics/sessions list,
 // dashboard workflow rankings/bottleneck analysis, assign/release, draft-response는 수동 호출로 유지한다.
 
-export type ChatSession = Omit<ChatSessionResponse, "responseMode"> & {
-  assignedCounselorId?: number | null;
-  responseMode?: ConsultationResponseMode | null;
-};
-export type ChatMessage = ChatMessageResponse;
+export type ChatSession = ConsultationChatSession;
+export type ChatMessage = ConsultationChatMessage;
 export interface ChatMessagePage {
   content: ChatMessage[];
   page: number;
@@ -24,7 +25,7 @@ export interface ChatMessagePage {
   totalPages: number;
 }
 export type ConsultationSessionStatus = "OPEN" | "ACTIVE" | "RESOLVED" | "COMPLETED";
-export type ConsultationResponseMode = "AI_ACTIVE" | "HUMAN_ACTIVE" | "AI_ASSIST_ONLY";
+export type { ConsultationResponseMode };
 export type ResolutionOutcome = "RESOLVED" | "CUSTOMER_LEFT" | "PENDING" | "FOLLOW_UP_REQUIRED";
 export interface ChatSessionPage {
   content: ChatSession[];

--- a/frontend/src/features/consultation/api/llmToolWorkflowApi.ts
+++ b/frontend/src/features/consultation/api/llmToolWorkflowApi.ts
@@ -1,29 +1,7 @@
 import { customFetch } from "@/shared/api/mutator";
+import type { LlmToolWorkflowPayload, MatchedWorkflow } from "@/entities/workflow";
 
-export type TerminalState = string;
-
-export interface LlmToolWorkflowPayload {
-  sessionId: number | null;
-  workspaceId: number | null;
-  domainPackId: number | null;
-  domainPackVersionId: number | null;
-  executionId: number | null;
-  executionStatus: string | null;
-  currentState: string | null;
-  workflowDefinitionId: number | null;
-  workflowCode: string | null;
-  workflowName: string | null;
-  workflowDescription: string | null;
-  graphJson?: unknown;
-  initialState?: string | null;
-  terminalStates?: TerminalState[] | null;
-  intentCode?: string | null;
-  intentName?: string | null;
-}
-
-export type MatchedWorkflow = LlmToolWorkflowPayload & {
-  workflowDefinitionId: number;
-};
+export type { LlmToolWorkflowPayload, MatchedWorkflow };
 
 export function isMatchedWorkflow(
   payload: LlmToolWorkflowPayload | null,

--- a/frontend/src/features/simulation/api/simulationApi.ts
+++ b/frontend/src/features/simulation/api/simulationApi.ts
@@ -1,7 +1,10 @@
 import { customFetch } from "@/shared/api/mutator";
 import { requireApiData, selectApiData } from "@/shared/api";
-import type { ChatMessage, ChatSession } from "@/features/consultation/api/consultationApi";
-import type { LlmToolWorkflowPayload } from "@/features/consultation/api/llmToolWorkflowApi";
+import type {
+  ConsultationChatMessage as ChatMessage,
+  ConsultationChatSession as ChatSession,
+} from "@/entities/chat";
+import type { LlmToolWorkflowPayload } from "@/entities/workflow";
 
 export interface SimulationSessionDetail {
   session: ChatSession;


### PR DESCRIPTION
Closes #588

## 변경 사항

- 상담 세션/메시지 API 응답 타입을 `entities/chat` 공통 모델로 분리해 `consultationApi`와 `simulationApi`가 같은 하위 계층 타입을 참조하게 했습니다.
- 매칭 워크플로우 응답 타입을 `entities/workflow`로 옮겨 `simulationApi`의 `consultation` feature 직접 import를 제거했습니다.
- 이슈 588 스펙을 `.agent/specs/588.md`에 정리하고 공유 타입 shape 테스트를 추가했습니다.

## 검증

- `git diff --check`
- `cd frontend && pnpm test -- --run src/features/simulation/api/simulationApi.test.ts src/features/consultation/api/consultationApi.test.ts src/features/consultation/api/llmToolWorkflowApi.test.ts src/entities/chat/model/consultationTypes.test.ts`
- `cd frontend && pnpm build`
- `cd frontend && pnpm exec eslint src/entities/chat/index.ts src/entities/chat/model/consultationTypes.ts src/entities/chat/model/consultationTypes.test.ts src/entities/workflow/index.ts src/entities/workflow/model/matchedWorkflow.ts src/features/consultation/api/consultationApi.ts src/features/consultation/api/llmToolWorkflowApi.ts src/features/simulation/api/simulationApi.ts`

## 참고

- `cd frontend && pnpm lint`는 기존 unrelated lint 오류 58개로 실패합니다. 이번 변경 파일 대상 ESLint와 production build는 통과했습니다.
- 로컬 Husky hook 파일이 executable이 아니어서 commit hook은 실행되지 않았고, 위 검증을 수동으로 실행했습니다.