### PR TITLE
fix(upload): 원본 로그 업로드 중복 start 거절

### DIFF
--- a/.agent/specs/583.md
+++ b/.agent/specs/583.md
@@ -1,0 +1,129 @@
+# 원본 로그 업로드 start 중복 race 방지
+
+## Goal
+
+원본 로그 ZIP 업로드 hook에서 업로드 진행 중 중복 `start()` 호출이 발생해도 진행 중 업로드의 취소 핸들과 상태가 이전 요청의 비동기 종료 처리에 의해 훼손되지 않도록 한다.
+
+## Background
+
+Issue #583은 원본 로그 업로드 hook이 `start()`마다 새 `AbortController`를 만들고 `abortRef`에 저장하는 구조에서 발생할 수 있는 race를 지적한다. 이전 요청의 `finally`가 나중에 실행되면 새 요청의 controller 참조를 `null`로 지워 `cancel()` 동작이나 업로드 상태 표시가 엇갈릴 수 있다.
+
+이슈 본문은 `frontend/src/features/upload-raw-file/model/useRawFileUpload.ts`를 언급하지만, 현재 저장소에서 확인된 hook 위치는 `frontend/src/features/log-upload/model/useRawFileUpload.ts`다.
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A[사용자가 원본 로그 ZIP 업로드 시작] --> B{업로드 진행 중?}
+    B -->|No| C[새 AbortController 등록]
+    C --> D[init, PUT, complete 진행]
+    D --> E[현재 controller인 경우에만 성공 상태 및 cleanup 반영]
+    B -->|Yes| F[중복 start 거절]
+    F --> G[기존 업로드 controller 유지]
+    E --> H[종료]
+    G --> H
+```
+
+## Design Diff
+
+| 영역 | As-is | To-be |
+| --- | --- | --- |
+| 중복 start | 새 `AbortController`가 기존 `abortRef`를 덮어쓸 수 있음 | `abortRef.current`가 있으면 새 시작을 거절하고 기존 업로드를 유지 |
+| 비동기 cleanup | 모든 요청의 `finally`가 `abortRef.current = null` 실행 | 자신이 등록한 controller일 때만 ref를 비움 |
+| 상태 갱신 | 이전 요청의 progress/success/error 종료 처리가 최신 상태를 덮을 수 있음 | 현재 controller와 일치할 때만 progress와 종료 상태를 반영 |
+| 테스트 | 정상, 실패, 취소, MIME 보정 중심 | 진행 중 재시작 거절과 기존 controller 유지 회귀 추가 |
+
+## Component Tree
+
+```
+features/log-upload
+└─ model
+   ├─ useRawFileUpload.ts
+   └─ useRawFileUpload.test.ts
+```
+
+## API Integration
+
+### Endpoints
+
+기존 업로드 API 계약은 변경하지 않는다.
+
+| Method | Path | Description |
+| --- | --- | --- |
+| POST | `/workspaces/{workspaceId}/datasets/uploads:init` | raw file upload init |
+| POST | `/workspaces/{workspaceId}/datasets/uploads/{datasetId}:complete` | raw file upload complete |
+
+## Data Flow
+
+```
+LogUploadForm
+  -> useRawFileUpload.start()
+    -> initRawFileUpload()
+    -> putPresignedFile(signal: current AbortController.signal)
+    -> completeRawFileUpload()
+    -> current controller guard
+```
+
+## 수정 대상 파일
+
+| 파일 | 변경 유형 | 설명 |
+| --- | --- | --- |
+| `frontend/src/features/log-upload/model/useRawFileUpload.ts` | modify | 중복 start 거절 및 controller identity guard 추가 |
+| `frontend/src/features/log-upload/model/useRawFileUpload.test.ts` | modify | 진행 중 재시작 정책과 기존 controller 유지 검증 추가 |
+
+## State Management
+
+- Hook 내부 local state만 사용한다.
+- 업로드 진행 여부의 동시성 기준은 `abortRef.current !== null`로 둔다.
+- 진행 중 중복 `start()`는 새 요청을 만들지 않고 `onError("이미 업로드가 진행 중입니다.")`로 거절한다.
+- `onProgress`, 성공, 실패, cleanup은 자신이 만든 controller가 현재 ref와 일치할 때만 상태를 변경한다.
+
+## Tests
+
+### Test Strategy
+
+| 구분 | 방법 | 도구 | 비고 |
+| --- | --- | --- | --- |
+| Hook unit | `renderHook`으로 start/cancel/reset 동작 검증 | Vitest, React Testing Library | 기존 hook 테스트 파일에 추가 |
+
+### Test Scenarios
+
+#### Happy Path
+
+| # | 시나리오 | 사전 조건 | 조작 | 기대 결과 |
+| --- | --- | --- | --- | --- |
+| 1 | 정상 업로드 | init, PUT, complete 성공 | `start()` 호출 | `onSuccess` 호출, progress 100 |
+
+#### Error & Edge Cases
+
+| # | 시나리오 | 조작 | 기대 결과 |
+| --- | --- | --- | --- |
+| 1 | 업로드 진행 중 재시작 | 첫 업로드가 끝나기 전 `start()` 재호출 | 두 번째 init/PUT/complete는 호출되지 않고 `onError`로 거절 |
+| 2 | 재시작 거절 후 취소 | 중복 start 거절 뒤 `cancel()` 호출 | 첫 업로드의 `AbortController`가 유지되어 abort됨 |
+| 3 | 이전 요청 cleanup | 이전 요청의 `finally`가 늦게 실행 | 현재 controller가 아닌 경우 ref를 비우지 않음 |
+
+## Non-Goals
+
+- 업로드 API request/response contract 변경
+- `LogUploadForm` UI/문구 변경
+- 업로드 queue 또는 자동 retry 정책 도입
+- generated OpenAPI 파일 수정
+
+## Acceptance Criteria
+
+- 업로드 진행 중 `start()`가 다시 호출되어도 최신 또는 진행 중인 upload controller가 잘못 초기화되지 않는다.
+- 진행 중 재시작은 명시적으로 거절되고 새 init 요청을 만들지 않는다.
+- 이전 async callback과 cleanup은 현재 controller가 아닌 경우 상태와 ref를 변경하지 않는다.
+- 관련 Vitest hook 테스트가 재시작 정책과 controller 유지 동작을 검증한다.
+
+## Validation
+
+- `cd frontend && pnpm test -- useRawFileUpload.test.ts`
+- `cd frontend && pnpm exec eslint src/features/log-upload/model/useRawFileUpload.ts src/features/log-upload/model/useRawFileUpload.test.ts`
+- `cd frontend && pnpm test`
+- `cd frontend && pnpm build`
+- `cd frontend && pnpm test -- --coverage`
+
+## Open Questions
+
+- 없음.

--- a/frontend/src/features/log-upload/model/useRawFileUpload.test.ts
+++ b/frontend/src/features/log-upload/model/useRawFileUpload.test.ts
@@ -126,6 +126,182 @@ describe("useRawFileUpload", () => {
     });
   });
 
+  it("업로드 진행 중 start를 다시 호출하면 새 요청을 만들지 않고 거절한다", async () => {
+    let resolveInit!: (v: typeof initResponse) => void;
+    mockInit.mockReturnValueOnce(
+      new Promise<typeof initResponse>((res) => {
+        resolveInit = res;
+      }),
+    );
+
+    const firstOnError = vi.fn();
+    const duplicateOnError = vi.fn();
+    const { result } = renderHook(() => useRawFileUpload());
+
+    let uploadPromise: Promise<void> = Promise.resolve();
+    act(() => {
+      uploadPromise = result.current.start({
+        workspaceId: 1,
+        file: makeFile(),
+        onSuccess: vi.fn(),
+        onError: firstOnError,
+      });
+    });
+
+    await act(async () => {
+      await result.current.start({
+        workspaceId: 1,
+        file: makeFile("retry.zip"),
+        onSuccess: vi.fn(),
+        onError: duplicateOnError,
+      });
+    });
+
+    expect(mockInit).toHaveBeenCalledTimes(1);
+    expect(duplicateOnError).toHaveBeenCalledWith("이미 업로드가 진행 중입니다.");
+    expect(firstOnError).not.toHaveBeenCalled();
+    expect(result.current.isUploading).toBe(true);
+
+    mockPut.mockResolvedValueOnce(undefined);
+    mockComplete.mockResolvedValueOnce(completeResponse);
+    await act(async () => {
+      resolveInit(initResponse);
+      await uploadPromise;
+    });
+  });
+
+  it("중복 start 거절 후 cancel은 기존 업로드 controller를 abort한다", async () => {
+    let capturedSignal: AbortSignal | undefined;
+    mockInit.mockResolvedValueOnce(initResponse);
+    mockPut.mockImplementationOnce(async ({ signal }) => {
+      capturedSignal = signal;
+      await new Promise<void>((_, reject) => {
+        signal?.addEventListener("abort", () => reject(new PresignedUploadAbortError()));
+      });
+    });
+
+    const duplicateOnError = vi.fn();
+    const { result } = renderHook(() => useRawFileUpload());
+
+    let uploadPromise: Promise<void> = Promise.resolve();
+    act(() => {
+      uploadPromise = result.current.start({
+        workspaceId: 1,
+        file: makeFile(),
+        onSuccess: vi.fn(),
+        onError: vi.fn(),
+      });
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      await result.current.start({
+        workspaceId: 1,
+        file: makeFile("retry.zip"),
+        onSuccess: vi.fn(),
+        onError: duplicateOnError,
+      });
+    });
+
+    act(() => {
+      result.current.cancel();
+    });
+
+    expect(mockInit).toHaveBeenCalledTimes(1);
+    expect(duplicateOnError).toHaveBeenCalledWith("이미 업로드가 진행 중입니다.");
+    expect(capturedSignal?.aborted).toBe(true);
+
+    await act(async () => {
+      await uploadPromise;
+    });
+  });
+
+  it("이전 업로드 cleanup은 reset 후 새 업로드 controller를 지우지 않는다", async () => {
+    let rejectFirstUpload!: (reason?: unknown) => void;
+    let secondSignal: AbortSignal | undefined;
+    let resolveFirstPutStarted!: () => void;
+    let resolveSecondPutStarted!: () => void;
+    const firstPutStarted = new Promise<void>((resolve) => {
+      resolveFirstPutStarted = resolve;
+    });
+    const secondPutStarted = new Promise<void>((resolve) => {
+      resolveSecondPutStarted = resolve;
+    });
+
+    mockInit.mockResolvedValueOnce(initResponse).mockResolvedValueOnce({
+      ...initResponse,
+      datasetId: 43,
+    });
+    mockPut
+      .mockImplementationOnce(async () => {
+        resolveFirstPutStarted();
+        await new Promise<void>((_, reject) => {
+          rejectFirstUpload = reject;
+        });
+      })
+      .mockImplementationOnce(async ({ signal }) => {
+        secondSignal = signal;
+        resolveSecondPutStarted();
+        await new Promise<void>((_, reject) => {
+          signal?.addEventListener("abort", () => reject(new PresignedUploadAbortError()));
+        });
+      });
+
+    const { result } = renderHook(() => useRawFileUpload());
+
+    let firstUploadPromise: Promise<void> = Promise.resolve();
+    act(() => {
+      firstUploadPromise = result.current.start({
+        workspaceId: 1,
+        file: makeFile(),
+        onSuccess: vi.fn(),
+        onError: vi.fn(),
+      });
+    });
+
+    await act(async () => {
+      await firstPutStarted;
+    });
+
+    act(() => {
+      result.current.reset();
+    });
+
+    let secondUploadPromise: Promise<void> = Promise.resolve();
+    act(() => {
+      secondUploadPromise = result.current.start({
+        workspaceId: 1,
+        file: makeFile("next.zip"),
+        onSuccess: vi.fn(),
+        onError: vi.fn(),
+      });
+    });
+
+    await act(async () => {
+      await secondPutStarted;
+    });
+
+    await act(async () => {
+      rejectFirstUpload(new PresignedUploadAbortError());
+      await firstUploadPromise;
+    });
+
+    expect(result.current.isUploading).toBe(true);
+
+    act(() => {
+      result.current.cancel();
+    });
+
+    expect(secondSignal?.aborted).toBe(true);
+
+    await act(async () => {
+      await secondUploadPromise;
+    });
+  });
+
   it("putPresignedFile의 onProgress 콜백으로 progress가 갱신된다", async () => {
     let continueUpload!: () => void;
     let finishUpload!: () => void;

--- a/frontend/src/features/log-upload/model/useRawFileUpload.ts
+++ b/frontend/src/features/log-upload/model/useRawFileUpload.ts
@@ -29,6 +29,7 @@ const PHASE_ERROR_FALLBACK: Record<UploadPhase, string> = {
   transfer: "파일 업로드에 실패했습니다.",
   complete: "업로드 완료 처리에 실패했습니다.",
 };
+const DUPLICATE_UPLOAD_ERROR_MESSAGE = "이미 업로드가 진행 중입니다.";
 
 interface RawFileUploadState {
   readonly isUploading: boolean;
@@ -59,7 +60,13 @@ export function useRawFileUpload() {
 
   const start = useCallback(
     async ({ workspaceId, file, onSuccess, onError }: StartUploadParams) => {
+      if (abortRef.current) {
+        onError(DUPLICATE_UPLOAD_ERROR_MESSAGE);
+        return;
+      }
+
       const controller = new AbortController();
+      const isCurrentUpload = () => abortRef.current === controller;
       abortRef.current = controller;
       setState({ isUploading: true, progress: 0 });
 
@@ -82,22 +89,35 @@ export function useRawFileUpload() {
           contentType: initResult.contentType,
           serverSideEncryptionRequired: initResult.serverSideEncryptionRequired,
           signal: controller.signal,
-          onProgress: (progress) => setState({ isUploading: true, progress }),
+          onProgress: (progress) => {
+            if (isCurrentUpload()) {
+              setState({ isUploading: true, progress });
+            }
+          },
         });
 
         phase = "complete";
         const completeResult = await completeRawFileUpload(workspaceId, initResult.datasetId);
 
-        setState({ isUploading: false, progress: 100 });
-        onSuccess(completeResult);
+        if (isCurrentUpload()) {
+          setState({ isUploading: false, progress: 100 });
+          onSuccess(completeResult);
+        }
       } catch (error) {
-        setState({ isUploading: false, progress: 0 });
         if (error instanceof PresignedUploadAbortError) {
+          if (isCurrentUpload()) {
+            setState({ isUploading: false, progress: 0 });
+          }
           return;
         }
-        onError(getPhaseErrorMessage(error, phase));
+        if (isCurrentUpload()) {
+          setState({ isUploading: false, progress: 0 });
+          onError(getPhaseErrorMessage(error, phase));
+        }
       } finally {
-        abortRef.current = null;
+        if (isCurrentUpload()) {
+          abortRef.current = null;
+        }
       }
     },
     [],


### PR DESCRIPTION
Closes #583

## 변경 사항

- 원본 로그 업로드 hook에서 업로드 진행 중 `start()`가 다시 호출되면 새 init 요청을 만들지 않고 중복 시작을 거절합니다.
- `onProgress`, 성공/실패 상태 반영, `finally` cleanup이 자신이 만든 `AbortController`에만 적용되도록 controller identity guard를 추가했습니다.
- `reset()` 직후 새 업로드가 시작된 경우에도 이전 업로드의 늦은 cleanup이 새 controller를 지우지 않도록 회귀 테스트를 추가했습니다.
- 이슈 583 스펙을 `.agent/specs/583.md`에 정리했습니다.

## 검증

- `git diff --check`
- `cd frontend && pnpm test -- useRawFileUpload.test.ts`
- `cd frontend && pnpm exec eslint src/features/log-upload/model/useRawFileUpload.ts src/features/log-upload/model/useRawFileUpload.test.ts`
- `cd frontend && pnpm test`
- `cd frontend && pnpm build`
- `cd frontend && pnpm test -- --coverage`

## 참고

- `cd frontend && pnpm lint`는 기존 unrelated lint 오류 58개로 실패합니다. 이번 변경 파일 대상 ESLint와 CI 형태의 frontend test/build/coverage는 통과했습니다.
- `pnpm test`와 coverage 실행은 기존 `BillingFailPage.test.tsx` mock hoisting 경고를 출력하지만 성공했습니다.
- `pnpm build`는 기존 chunk size 경고를 출력하지만 성공했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 파일 업로드 중복 호출 방지에 대한 스펙 문서 추가

* **Bug Fixes**
  * 업로드 진행 중 중복 요청 시 명확한 에러 처리 추가
  * 비동기 작업 취소 및 리셋 시 상태 관리 안정성 개선

* **Tests**
  * 중복 업로드 호출, 취소, 리셋 시나리오에 대한 검증 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->