### PR TITLE
fix(upload): datasetKey를 안전한 object key 세그먼트로 제한

### DIFF
--- a/.agent/specs/581.md
+++ b/.agent/specs/581.md
@@ -1,0 +1,77 @@
+# Raw file datasetKey object key segment validation
+
+## Goal
+
+원본 파일 업로드 초기화에서 `datasetKey`가 S3 object key의 단일 안전 세그먼트로만 사용되도록 제한한다.
+
+## Problem
+
+`POST /api/v1/workspaces/{workspaceId}/datasets/uploads:init`는 `datasetKey`를 blank와 길이만 검증한 뒤 `pending/workspaces/{workspaceId}/datasets/{datasetKey}/...` object key에 삽입한다. 이 값에 `/`, `../`, 제어 문자처럼 경로 구조를 흐리게 만드는 문자가 들어오면 업로드 객체 정리와 추적이 어려운 key가 생성될 수 있다.
+
+## Scope
+
+- `backend/src/main/java/com/init/corpus/application/InitRawFileUploadCommand.java`의 애플리케이션 입력 검증 강화
+- `backend/src/main/java/com/init/corpus/application/RawFileUploadDatasetKeyPolicy.java`의 안전 object key segment 정책 정의
+- `backend/src/main/java/com/init/corpus/presentation/dto/InitRawFileUploadRequest.java`의 HTTP request validation/API 계약 명시
+- `backend/src/main/java/com/init/corpus/application/InitRawFileUploadService.java`의 기존 object key 생성 흐름 회귀 확인
+- `backend/src/test/java/com/init/corpus/application/InitRawFileUploadCommandTest.java` 및 `backend/src/test/java/com/init/corpus/presentation/DatasetControllerRawFileTest.java` 검증 보강
+
+## Non-Goals
+
+- 기존 구조화 dataset 업로드(`POST /datasets`)와 raw JSON 업로드(`POST /datasets/raw`)의 `datasetKey` 계약 변경
+- S3 object key 전체 구조 또는 파일명 정규화 규칙 변경
+- 데이터베이스 스키마, unique constraint, 저장소 어댑터 변경
+- 기존 datasetKey를 자동 변환하거나 인코딩해서 저장하는 동작 추가
+
+## REST API
+
+| Method | Path | Description |
+| --- | --- | --- |
+| POST | `/api/v1/workspaces/{workspaceId}/datasets/uploads:init` | presigned raw-file 업로드 세션 초기화 |
+
+### Request Contract
+
+`datasetKey`는 1~100자이며 다음 안전 slug 패턴을 만족해야 한다.
+
+```text
+^[A-Za-z0-9][A-Za-z0-9_-]{0,99}$
+```
+
+허용 예시:
+
+- `support-logs`
+- `crm_2026`
+- `dataset1`
+
+거절 예시:
+
+- `../dataset`
+- `foo/bar`
+- `dataset.key`
+- `dataset\nkey`
+
+## Design Diff
+
+| 영역 | As-is | To-be |
+| --- | --- | --- |
+| 애플리케이션 입력 | `datasetKey` blank/100자 초과만 거절 | 안전 slug 패턴을 벗어난 값도 `VALIDATION_ERROR`로 거절 |
+| API DTO | `@NotBlank`, `@Size(max = 100)`만 명시 | 같은 안전 slug 패턴을 `@Pattern`으로 명시 |
+| Object key 생성 | `pending/workspaces/{workspaceId}/datasets/{datasetKey}/{uuid}_{filename}` | 정상 slug 입력에서는 동일한 구조 유지 |
+
+## Acceptance Criteria
+
+- `datasetKey`에 `/`, `../`, 마침표, 제어 문자가 포함되면 업로드 초기화가 400 또는 `BadRequestException`으로 거절된다.
+- `test-key`, `crm_2026`처럼 정상 slug 입력은 기존처럼 `pending/workspaces/{workspaceId}/datasets/{datasetKey}/...` object key를 생성한다.
+- HTTP request validation과 application command validation이 같은 허용 패턴을 사용한다.
+- 검증 테스트가 추가되어 path separator, relative path, control character 거절을 확인한다.
+
+## Validation Plan
+
+| 구분 | 명령 | 기대 결과 |
+| --- | --- | --- |
+| Backend targeted tests | `cd backend && ./gradlew test --tests com.init.corpus.application.InitRawFileUploadCommandTest --tests com.init.corpus.application.InitRawFileUploadServiceTest --tests com.init.corpus.presentation.DatasetControllerRawFileTest` | datasetKey slug 검증과 기존 presigned object key 생성 회귀 통과 |
+| Backend full tests | `cd backend && ./gradlew test` | 백엔드 단위 테스트 회귀 없음 |
+
+## Open Questions
+
+- 없음. 이슈는 presigned raw-file 업로드 초기화 경로의 object key segment 안전성으로 범위가 한정되어 있다.

--- a/backend/src/main/java/com/init/corpus/application/InitRawFileUploadCommand.java
+++ b/backend/src/main/java/com/init/corpus/application/InitRawFileUploadCommand.java
@@ -26,6 +26,10 @@ public record InitRawFileUploadCommand(
       throw new BadRequestException(
           "VALIDATION_ERROR", "datasetKey must not exceed 100 characters");
     }
+    if (!RawFileUploadDatasetKeyPolicy.isSafeObjectKeySegment(datasetKey)) {
+      throw new BadRequestException(
+          "VALIDATION_ERROR", RawFileUploadDatasetKeyPolicy.SAFE_OBJECT_KEY_SEGMENT_DESCRIPTION);
+    }
     if (name == null || name.isBlank()) {
       throw new BadRequestException("VALIDATION_ERROR", "name must not be blank");
     }

--- a/backend/src/main/java/com/init/corpus/application/RawFileUploadDatasetKeyPolicy.java
+++ b/backend/src/main/java/com/init/corpus/application/RawFileUploadDatasetKeyPolicy.java
@@ -1,0 +1,19 @@
+package com.init.corpus.application;
+
+import java.util.regex.Pattern;
+
+public final class RawFileUploadDatasetKeyPolicy {
+
+  public static final String SAFE_OBJECT_KEY_SEGMENT_REGEXP = "^[A-Za-z0-9][A-Za-z0-9_-]{0,99}$";
+  public static final String SAFE_OBJECT_KEY_SEGMENT_DESCRIPTION =
+      "datasetKey must match ^[A-Za-z0-9][A-Za-z0-9_-]{0,99}$";
+
+  private static final Pattern SAFE_OBJECT_KEY_SEGMENT_PATTERN =
+      Pattern.compile(SAFE_OBJECT_KEY_SEGMENT_REGEXP);
+
+  private RawFileUploadDatasetKeyPolicy() {}
+
+  public static boolean isSafeObjectKeySegment(String value) {
+    return value != null && SAFE_OBJECT_KEY_SEGMENT_PATTERN.matcher(value).matches();
+  }
+}

--- a/backend/src/main/java/com/init/corpus/presentation/dto/InitRawFileUploadRequest.java
+++ b/backend/src/main/java/com/init/corpus/presentation/dto/InitRawFileUploadRequest.java
@@ -1,12 +1,17 @@
 package com.init.corpus.presentation.dto;
 
+import com.init.corpus.application.RawFileUploadDatasetKeyPolicy;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 
 public record InitRawFileUploadRequest(
     @NotBlank(message = "datasetKey는 필수입니다.")
         @Size(max = 100, message = "datasetKey는 100자 이하여야 합니다.")
+        @Pattern(
+            regexp = RawFileUploadDatasetKeyPolicy.SAFE_OBJECT_KEY_SEGMENT_REGEXP,
+            message = "datasetKey는 영문자, 숫자, 하이픈(-), 밑줄(_)만 사용하고 영문자 또는 숫자로 시작해야 합니다.")
         String datasetKey,
     @NotBlank(message = "name은 필수입니다.") @Size(max = 255, message = "name은 255자 이하여야 합니다.")
         String name,

--- a/backend/src/test/java/com/init/corpus/application/InitRawFileUploadCommandTest.java
+++ b/backend/src/test/java/com/init/corpus/application/InitRawFileUploadCommandTest.java
@@ -1,10 +1,13 @@
 package com.init.corpus.application;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.init.shared.application.exception.BadRequestException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 @DisplayName("InitRawFileUploadCommand")
 class InitRawFileUploadCommandTest {
@@ -41,12 +44,34 @@ class InitRawFileUploadCommandTest {
   }
 
   @Test
+  @DisplayName("datasetKey가 안전한 slug이면 생성된다")
+  void compact_constructor_accepts_safe_datasetKey_slug() {
+    assertThatCode(
+            () ->
+                new InitRawFileUploadCommand(
+                    WS_ID, "crm_2026-logs", NAME, SOURCE, USER_ID, FILENAME, CONTENT_TYPE, SIZE))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
   @DisplayName("datasetKey가 null이면 BadRequestException을 던진다")
   void compact_constructor_rejects_null_datasetKey() {
     assertThatThrownBy(
             () ->
                 new InitRawFileUploadCommand(
                     WS_ID, null, NAME, SOURCE, USER_ID, FILENAME, CONTENT_TYPE, SIZE))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("datasetKey");
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"../dataset", "foo/bar", "dataset.key", "-dataset", "dataset\nkey"})
+  @DisplayName("datasetKey가 object key 세그먼트로 안전하지 않으면 BadRequestException을 던진다")
+  void compact_constructor_rejects_unsafe_datasetKey_segment(String unsafeKey) {
+    assertThatThrownBy(
+            () ->
+                new InitRawFileUploadCommand(
+                    WS_ID, unsafeKey, NAME, SOURCE, USER_ID, FILENAME, CONTENT_TYPE, SIZE))
         .isInstanceOf(BadRequestException.class)
         .hasMessageContaining("datasetKey");
   }

--- a/backend/src/test/java/com/init/corpus/presentation/DatasetControllerRawFileTest.java
+++ b/backend/src/test/java/com/init/corpus/presentation/DatasetControllerRawFileTest.java
@@ -2,6 +2,8 @@ package com.init.corpus.presentation;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -80,6 +82,26 @@ class DatasetControllerRawFileTest {
         .andExpect(jsonPath("$.uploadUrl").isString())
         .andExpect(jsonPath("$.objectKey").isString())
         .andExpect(jsonPath("$.serverSideEncryptionRequired").value(true));
+  }
+
+  @Test
+  @DisplayName("POST /uploads:init — datasetKey에 경로 구분자가 있으면 400")
+  @WithLongPrincipal(1L)
+  void initUpload_unsafeDatasetKey_returns400() throws Exception {
+    String body =
+        "{\"datasetKey\":\"foo/bar\",\"name\":\"테스트\",\"sourceType\":\"CRM\","
+            + "\"filename\":\"data.zip\",\"contentType\":\"application/zip\",\"sizeBytes\":1024}";
+
+    mockMvc
+        .perform(
+            post("/api/v1/workspaces/1/datasets/uploads:init")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body)
+                .with(csrf()))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+
+    verify(initRawFileUploadService, never()).init(any());
   }
 
   @Test


### PR DESCRIPTION
Closes #581

## 변경 사항

- 원본 파일 업로드 초기화에서 `datasetKey`를 `^[A-Za-z0-9][A-Za-z0-9_-]{0,99}$` 안전 slug 패턴으로 제한합니다.
- HTTP request DTO와 application command가 같은 패턴을 사용해 경로 구분자, 상대 경로 성격의 마침표, 제어 문자를 object key 생성 전에 거절합니다.
- 정상 slug 입력은 기존처럼 `pending/workspaces/{workspaceId}/datasets/{datasetKey}/...` object key를 생성하도록 회귀 테스트를 유지하고, 이슈 581 스펙을 `.agent/specs/581.md`에 정리했습니다.

## 검증

- `git diff --check`
- `cd backend && ./gradlew spotlessApply`
- `cd backend && JAVA_HOME=/Users/owen/.cache/codex-runtimes/jdk21/Contents/Home ./gradlew test --tests com.init.corpus.application.InitRawFileUploadCommandTest --tests com.init.corpus.application.InitRawFileUploadServiceTest --tests com.init.corpus.presentation.DatasetControllerRawFileTest`
- `cd backend && JAVA_HOME=/Users/owen/.cache/codex-runtimes/jdk21/Contents/Home ./gradlew test`

## 참고

- 로컬 Husky hook 파일이 executable이 아니어서 commit hook은 실행되지 않았고, 위 검증을 수동으로 실행했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **버그 수정**
  * Raw 파일 업로드 시 `datasetKey` 필드의 유효성 검증이 강화되었습니다. 경로 구분자, 상대 경로, 제어 문자 등이 포함된 입력은 거절되며, 영문/숫자로 시작하고 영문/숫자, 밑줄, 하이픈만 포함하는 1~100자 형식만 허용됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->