### PR TITLE
fix(frontend): 빈 성공 응답 API client 안전 처리

### DIFF
--- a/.agent/specs/582.md
+++ b/.agent/specs/582.md
@@ -1,0 +1,114 @@
+# 빈 성공 응답 API client 안전 처리
+
+## Goal
+
+공통 API client가 200/201 성공 응답에 빈 본문 또는 JSON이 아닌 본문을 받아도 파싱 예외로 실패하지 않게 한다.
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A["API 요청"] --> B["fetch 응답 수신"]
+    B --> C{"response.ok?"}
+    C -->|"No"| D["기존 ApiRequestError 처리"]
+    C -->|"Yes"| E{"204/205 또는 body 없음?"}
+    E -->|"Yes"| F["undefined 반환"]
+    E -->|"No"| G{"Content-Type이 JSON?"}
+    G -->|"Yes"| H["JSON 파싱 후 반환"]
+    G -->|"No"| F
+```
+
+## Design Diff
+
+### As-is vs To-be
+
+| 영역 | As-is | To-be | 변경 내용 |
+| --- | --- | --- | --- |
+| 성공 응답 처리 | 204가 아니면 항상 `response.json()` 호출 | JSON content type이고 body가 있을 때만 JSON 파싱 | 200/201 빈 본문 성공 응답에서 파싱 오류 방지 |
+| 빈 성공 본문 정책 | 204만 `undefined` 반환 | 200/201 빈 본문도 `undefined` 반환 | API client의 no payload 정책을 명시 |
+| JSON 성공 응답 | 기존처럼 `response.json()` 결과 반환 | response body text를 JSON으로 파싱해 반환 | 정상 JSON payload 동작 유지 |
+| JSON이 아닌 성공 본문 | `response.json()` 파싱 오류 발생 | `undefined` 반환 | JSON API client에서 비 JSON 성공 body를 payload 없음으로 취급 |
+
+## Component Tree
+
+```text
+shared/api
+├─ ApiClient
+│  ├─ get/post/patch/delete/request
+│  └─ handleResponse
+│     └─ parse success body by status, Content-Type, and body text
+└─ ApiRequestError
+```
+
+## API Integration
+
+### Endpoints
+
+공통 API client의 응답 처리 정책 변경이므로 특정 endpoint contract를 새로 추가하거나 변경하지 않는다.
+
+### Query Key Pattern
+
+서버 상태 query key와 generated endpoint 코드는 변경하지 않는다.
+
+## Data Flow
+
+```text
+fetch Response
+  -> non-ok: 기존 error JSON fallback + ApiRequestError
+  -> 204/205: undefined
+  -> JSON Content-Type + non-empty body: JSON.parse(body)
+  -> empty body or non-JSON Content-Type: undefined
+```
+
+## 수정 대상 파일
+
+| 파일 | 변경 유형 | 설명 |
+| --- | --- | --- |
+| `frontend/src/shared/api/index.ts` | modify | 성공 응답의 content type과 body 존재 여부를 확인한 뒤 JSON 파싱 |
+| `frontend/src/shared/api/index.test.ts` | modify | 200 빈 본문, JSON 성공 응답, JSON이 아닌 성공 응답 단위 테스트 추가 |
+| `frontend/src/app/App.test.tsx` | modify | 공통 API client를 지나는 app routing test fetch mock을 실제 JSON `Response`로 정렬 |
+| `.agent/specs/582.md` | new | 이슈 요구사항과 검증 기준 문서화 |
+
+## State Management
+
+상태 관리 변경은 없다. 성공 응답 payload가 없는 API 호출은 `undefined`를 반환하며, 기존 호출자가 `void` 또는 optional payload로 다루는 계약을 따른다.
+
+## Tests
+
+### Test Strategy
+
+| 구분 | 방법 | 도구 | 비고 |
+| --- | --- | --- | --- |
+| API client 단위 | fetch 응답 mock으로 `handleResponse` 경로 검증 | Vitest | 성공 JSON, 204, 200 빈 본문, non-JSON 성공 본문, error fallback |
+| App routing 회귀 | 공통 API client를 지나는 route test의 fetch mock 정렬 | Vitest | 실제 `Response` metadata 기반 파싱 경로 검증 |
+| 회귀 확인 | shared API client test 파일 단독 실행 | `pnpm test` | `frontend/src/shared/api/index.test.ts` 대상 |
+
+### Test Scenarios
+
+#### Happy Path
+
+| # | 시나리오 | 사전 조건 | 조작 | 기대 결과 |
+| --- | --- | --- | --- | --- |
+| 1 | JSON 성공 응답 | 200 + `application/json` + body | `apiClient.get` 호출 | JSON payload 반환 |
+| 2 | 204 응답 | 204 + body 없음 | `apiClient.get` 호출 | `undefined` 반환 |
+| 3 | 200 빈 본문 | 200 + body 없음 | `apiClient.get` 호출 | 예외 없이 `undefined` 반환 |
+
+#### Error & Edge Cases
+
+| # | 시나리오 | 조작 | 기대 결과 |
+| --- | --- | --- | --- |
+| 1 | JSON이 아닌 성공 본문 | 200 + `text/plain` body | 예외 없이 `undefined` 반환 |
+| 2 | non-ok JSON 응답 | 400 + JSON error body | 기존 `ApiRequestError` 발생 |
+| 3 | non-ok JSON 파싱 실패 | 500 + 파싱 불가 body | 기존 기본 오류 메시지 사용 |
+
+## Acceptance Criteria
+
+- 200 빈 본문 성공 응답에서 API client가 예외를 던지지 않고 `undefined`를 반환한다.
+- JSON 성공 응답은 기존처럼 payload를 반환한다.
+- JSON이 아닌 성공 응답은 파싱 예외를 던지지 않고 `undefined`를 반환한다.
+- 기존 non-ok 응답의 `ApiRequestError` 처리와 401 session 정리 동작은 유지된다.
+- API client 단위 테스트로 위 성공/오류 경로를 검증한다.
+
+## Open Questions
+
+- 없음.

--- a/frontend/src/app/App.test.tsx
+++ b/frontend/src/app/App.test.tsx
@@ -24,6 +24,13 @@ function seedAuthenticatedSession() {
   );
 }
 
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
 describe("App", () => {
   beforeEach(() => {
     localStorage.clear();
@@ -103,41 +110,29 @@ describe("App", () => {
 
     const fetchMock = vi.fn().mockImplementation((url: string) => {
       if (url === "/api/v1/workspaces") {
-        return Promise.resolve({
-          ok: true,
-          status: 200,
-          json: async () => [workspaceBody],
-        });
+        return Promise.resolve(jsonResponse([workspaceBody]));
       }
       if (url === "/api/v1/workspaces/1/dashboard/knowledge-pack-health") {
-        return Promise.resolve({
-          ok: true,
-          status: 200,
-          json: async () => ({
+        return Promise.resolve(
+          jsonResponse({
             activeKnowledgePack: null,
             lastLogUpload: null,
             lastKnowledgePackGeneration: null,
             pendingReviewCount: 0,
           }),
-        });
+        );
       }
       if (url.startsWith("/api/v1/workspaces/1/dashboard/action-recommendations")) {
-        return Promise.resolve({
-          ok: true,
-          status: 200,
-          json: async () => ({
+        return Promise.resolve(
+          jsonResponse({
             workspaceId: 1,
             periodStart: "2026-05-28T00:00:00+09:00",
             periodEnd: "2026-06-04T00:00:00+09:00",
             recommendations: [],
           }),
-        });
+        );
       }
-      return Promise.resolve({
-        ok: true,
-        status: 200,
-        json: async () => workspaceBody,
-      });
+      return Promise.resolve(jsonResponse(workspaceBody));
     });
 
     vi.stubGlobal("fetch", fetchMock);

--- a/frontend/src/shared/api/index.test.ts
+++ b/frontend/src/shared/api/index.test.ts
@@ -4,6 +4,35 @@ import { resolveApiBase, ApiRequestError, apiClient } from "./index";
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
 
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  const headers = new Headers(init.headers);
+  headers.set("Content-Type", "application/json");
+
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    ...init,
+    headers,
+  });
+}
+
+function emptyResponse(init: ResponseInit = {}): Response {
+  return new Response(null, {
+    status: 200,
+    ...init,
+  });
+}
+
+function textResponse(body: string, init: ResponseInit = {}): Response {
+  const headers = new Headers(init.headers);
+  headers.set("Content-Type", "text/plain");
+
+  return new Response(body, {
+    status: 200,
+    ...init,
+    headers,
+  });
+}
+
 afterAll(() => {
   vi.unstubAllGlobals();
 });
@@ -46,10 +75,7 @@ describe("apiClient", () => {
   describe("post", () => {
     it("POST 메서드로 fetch를 호출하고 body를 JSON.stringify한다", async () => {
       const mockResponse = { id: 1, name: "test" };
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => mockResponse,
-      });
+      mockFetch.mockResolvedValueOnce(jsonResponse(mockResponse));
 
       const result = await apiClient.post<{ id: number; name: string }>("/test", { name: "test" });
 
@@ -71,10 +97,7 @@ describe("apiClient", () => {
   describe("get", () => {
     it("GET 메서드로 fetch를 호출하고 signal을 전달한다", async () => {
       const mockResponse = { data: "test" };
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => mockResponse,
-      });
+      mockFetch.mockResolvedValueOnce(jsonResponse(mockResponse));
 
       const abortController = new AbortController();
       const result = await apiClient.get<{ data: string }>("/test", {
@@ -96,10 +119,7 @@ describe("apiClient", () => {
   describe("patch", () => {
     it("PATCH 메서드로 fetch를 호출하고 body를 JSON.stringify한다", async () => {
       const mockResponse = { id: 1, name: "updated" };
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => mockResponse,
-      });
+      mockFetch.mockResolvedValueOnce(jsonResponse(mockResponse));
 
       const result = await apiClient.patch<{ id: number; name: string }>("/test/1", {
         name: "updated",
@@ -119,10 +139,7 @@ describe("apiClient", () => {
 
   describe("delete", () => {
     it("DELETE 메서드로 fetch를 호출한다", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        status: 204,
-      });
+      mockFetch.mockResolvedValueOnce(emptyResponse({ status: 204 }));
 
       await apiClient.delete<void>("/test/1");
 
@@ -138,10 +155,7 @@ describe("apiClient", () => {
   describe("request", () => {
     it("임의 메서드로 fetch를 호출하고 headers를 병합한다", async () => {
       const mockResponse = { success: true };
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => mockResponse,
-      });
+      mockFetch.mockResolvedValueOnce(jsonResponse(mockResponse));
 
       const result = await apiClient.request<{ success: boolean }>("/test", {
         method: "PUT",
@@ -167,10 +181,7 @@ describe("apiClient", () => {
 
     it("auth endpoint 요청에는 저장된 access token을 Authorization header로 붙이지 않는다", async () => {
       const mockResponse = { success: true };
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => mockResponse,
-      });
+      mockFetch.mockResolvedValueOnce(jsonResponse(mockResponse));
 
       await apiClient.request<{ success: boolean }>("/auth/login", {
         method: "POST",
@@ -184,10 +195,7 @@ describe("apiClient", () => {
 
     it("demo endpoint 요청에는 저장된 access token을 Authorization header로 붙이지 않는다", async () => {
       const mockResponse = { id: 1 };
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => mockResponse,
-      });
+      mockFetch.mockResolvedValueOnce(jsonResponse(mockResponse));
 
       await apiClient.request<{ id: number }>("/workspaces/2/demo/chat-sessions", {
         method: "POST",
@@ -201,10 +209,7 @@ describe("apiClient", () => {
 
     it("body가 object인 경우 JSON.stringify한다", async () => {
       const mockResponse = { id: 1 };
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => mockResponse,
-      });
+      mockFetch.mockResolvedValueOnce(jsonResponse(mockResponse));
 
       const testData = { name: "test" };
       await apiClient.request<{ id: number }>("/test", {
@@ -222,10 +227,7 @@ describe("apiClient", () => {
 
     it("body가 Blob인 경우 그대로 전달한다", async () => {
       const mockResponse = { id: 1 };
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => mockResponse,
-      });
+      mockFetch.mockResolvedValueOnce(jsonResponse(mockResponse));
 
       const blob = new Blob(["test"], { type: "image/png" });
       await apiClient.request<{ id: number }>("/test", {
@@ -243,10 +245,7 @@ describe("apiClient", () => {
 
     it("body가 FormData인 경우 그대로 전달한다", async () => {
       const mockResponse = { id: 1 };
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => mockResponse,
-      });
+      mockFetch.mockResolvedValueOnce(jsonResponse(mockResponse));
 
       const formData = new FormData();
       formData.append("file", new Blob(["test"]));
@@ -266,10 +265,36 @@ describe("apiClient", () => {
 
   describe("handleResponse", () => {
     it("204 응답 시 undefined를 반환한다", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        status: 204,
-      });
+      mockFetch.mockResolvedValueOnce(emptyResponse({ status: 204 }));
+
+      const result = await apiClient.get<void>("/test");
+
+      expect(result).toBeUndefined();
+    });
+
+    it("200 빈 본문 성공 응답 시 undefined를 반환한다", async () => {
+      mockFetch.mockResolvedValueOnce(
+        emptyResponse({
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+      const result = await apiClient.get<void>("/test");
+
+      expect(result).toBeUndefined();
+    });
+
+    it("JSON 성공 응답은 body를 파싱해 반환한다", async () => {
+      const mockResponse = { id: 1, name: "test" };
+      mockFetch.mockResolvedValueOnce(jsonResponse(mockResponse));
+
+      const result = await apiClient.get<{ id: number; name: string }>("/test");
+
+      expect(result).toEqual(mockResponse);
+    });
+
+    it("JSON이 아닌 성공 응답은 파싱하지 않고 undefined를 반환한다", async () => {
+      mockFetch.mockResolvedValueOnce(textResponse("ok"));
 
       const result = await apiClient.get<void>("/test");
 
@@ -333,14 +358,15 @@ describe("apiClient", () => {
       localStorage.setItem("refreshToken", "valid-refresh-token");
       localStorage.setItem("user", JSON.stringify({ id: 1 }));
       mockFetch
-        .mockResolvedValueOnce({
-          ok: false,
-          status: 401,
-          json: async () => ({
-            code: "UNAUTHORIZED",
-            message: "인증이 필요합니다.",
-          }),
-        })
+        .mockResolvedValueOnce(
+          jsonResponse(
+            {
+              code: "UNAUTHORIZED",
+              message: "인증이 필요합니다.",
+            },
+            { status: 401 },
+          ),
+        )
         .mockResolvedValueOnce({
           ok: true,
           status: 200,
@@ -351,11 +377,7 @@ describe("apiClient", () => {
             expiresIn: 3600,
           }),
         })
-        .mockResolvedValueOnce({
-          ok: true,
-          status: 200,
-          json: async () => ({ id: 1 }),
-        });
+        .mockResolvedValueOnce(jsonResponse({ id: 1 }));
 
       const result = await apiClient.get<{ id: number }>("/test");
 

--- a/frontend/src/shared/api/index.ts
+++ b/frontend/src/shared/api/index.ts
@@ -26,6 +26,11 @@ interface ResponseHandlingOptions {
   clearSessionOnUnauthorized: boolean;
 }
 
+function isJsonContentType(contentType: string): boolean {
+  const normalized = contentType.toLowerCase();
+  return normalized.includes("application/json") || normalized.includes("+json");
+}
+
 function selectTokenRefreshBody(body: unknown): AuthTokens | null {
   const candidate =
     body &&
@@ -185,11 +190,21 @@ class ApiClient {
       throw new ApiRequestError(response.status, errorData.code, errorData.message);
     }
 
-    if (response.status === 204) {
+    if (response.status === 204 || response.status === 205) {
       return undefined as T;
     }
 
-    return response.json() as Promise<T>;
+    const contentType = response.headers.get("Content-Type") ?? "";
+    if (!isJsonContentType(contentType)) {
+      return undefined as T;
+    }
+
+    const bodyText = await response.text();
+    if (bodyText.length === 0) {
+      return undefined as T;
+    }
+
+    return JSON.parse(bodyText) as T;
   }
 
   async post<T>(path: string, body: unknown): Promise<T> {


### PR DESCRIPTION
Closes #582

## 변경 사항

- 공통 API client가 성공 응답을 `Content-Type`과 body 존재 여부 기준으로 처리하도록 변경했습니다.
- 200/201 빈 본문 또는 JSON이 아닌 성공 본문은 파싱 오류를 내지 않고 `undefined`로 반환합니다.
- JSON 성공 응답, non-ok error fallback, 401 session 정리/refresh 흐름은 기존 동작을 유지하도록 회귀 테스트를 보강했습니다.
- 공통 API client를 지나는 app routing test의 fetch mock을 실제 JSON `Response`로 정렬하고, 이슈 582 스펙을 `.agent/specs/582.md`에 정리했습니다.

## 검증

- `git diff --check`
- `cd frontend && pnpm test src/shared/api/index.test.ts`
- `cd frontend && pnpm test src/shared/api/index.test.ts src/app/App.test.tsx`
- `cd frontend && pnpm test`
- `cd frontend && pnpm exec eslint src/shared/api/index.ts src/shared/api/index.test.ts src/app/App.test.tsx`
- `cd frontend && pnpm build`

## 참고

- `cd frontend && pnpm lint`는 기존 unrelated lint 오류 58개로 실패합니다. 이번 변경 파일 대상 ESLint와 frontend test/build는 통과했습니다.
- `pnpm test`와 `pnpm build`는 기존 Node/Vite 경고를 출력하지만 성공했습니다.
- 로컬 Husky hook 파일이 executable이 아니어서 commit hook은 실행되지 않았고, 위 검증을 수동으로 실행했습니다.