### PR TITLE
fix(corpus): JSON 원본 로그 업로드 본문 크기 제한

### DIFF
--- a/.agent/specs/592.md
+++ b/.agent/specs/592.md
@@ -1,0 +1,89 @@
+# JSON 원본 로그 업로드 본문 크기 제한
+
+## Goal
+
+JSON 원본 로그 업로드가 컨트롤러 역직렬화 전에 명확한 최대 본문 크기와 실패 응답을 갖도록 한다.
+
+## Problem
+
+`POST /api/v1/workspaces/{workspaceId}/datasets/raw`는 `@RequestBody`로 전체 JSON을 역직렬화한 뒤 `conversations` 개수와 `consulting_content` 길이를 검증한다. 현재 DTO 검증은 개별 필드 제한을 제공하지만, 요청 본문 자체가 컨트롤러 진입 전에 큰 메모리 비용을 만들 수 있다. 대용량 데이터셋은 이미 presigned raw-file 업로드 흐름이 있으므로 JSON 업로드는 작은 데이터셋용 계약으로 제한해야 한다.
+
+## Scope
+
+- `backend/src/main/java/com/init/corpus/presentation/DatasetController.java`
+- `backend/src/main/java/com/init/corpus/presentation/RawDatasetUploadJsonSizeFilter.java`
+- `backend/src/main/java/com/init/corpus/presentation/dto/RawDatasetUploadRequest.java`
+- `backend/src/main/java/com/init/corpus/application/RawDatasetUploadService.java`
+- `backend/src/main/java/com/init/corpus/application/InitRawFileUploadService.java`
+- `backend/src/test/java/com/init/corpus/presentation/RawDatasetUploadControllerTest.java`
+- `backend/src/test/java/com/init/corpus/presentation/RawDatasetUploadJsonSizeFilterTest.java`
+- `backend/src/main/resources/application.yml`
+
+Issue에 적힌 `backend/src/main/java/com/example/backend/...` 경로는 현재 체크아웃에 존재하지 않으며, 실제 corpus 패키지는 `backend/src/main/java/com/init/corpus`이다.
+
+## Non-Goals
+
+- JSON 원본 로그 업로드를 streaming parser 기반 저장 방식으로 재작성하지 않는다.
+- presigned raw-file 업로드 API의 request/response와 4GB ZIP 제한을 변경하지 않는다.
+- `RawDatasetUploadService`의 파싱, 저장, 보상 트랜잭션 흐름을 변경하지 않는다.
+- DB 스키마나 Airflow ingestion 계약을 변경하지 않는다.
+
+## Current Contract
+
+| Endpoint | 확인된 파일 | 현재 계약 |
+| --- | --- | --- |
+| `POST /api/v1/workspaces/{workspaceId}/datasets/raw` | `backend/src/main/java/com/init/corpus/presentation/DatasetController.java` | JSON body를 `RawDatasetUploadRequest`로 역직렬화한 뒤 저장 |
+| Raw JSON DTO | `backend/src/main/java/com/init/corpus/presentation/dto/RawDatasetUploadRequest.java` | `conversations`는 1~1000개, `consulting_content`는 5000자 이하 |
+| Presigned file init | `backend/src/main/java/com/init/corpus/application/InitRawFileUploadService.java` | ZIP 원본 파일은 최대 4GB까지 presigned PUT 흐름으로 업로드 |
+
+## Design Diff
+
+| 영역 | As-is | To-be |
+| --- | --- | --- |
+| JSON body limit | DTO 검증 전 요청 본문 크기 계약이 없음 | `app.corpus.raw-json-upload.max-body-size` 설정으로 raw JSON endpoint의 최대 body size를 명시 |
+| 실패 응답 | 큰 JSON 입력이 파싱/메모리 상태에 따라 불명확하게 실패 가능 | 초과 시 `413 Payload Too Large`와 `RAW_JSON_UPLOAD_TOO_LARGE` 응답 반환 |
+| 대용량 안내 | JSON upload와 file upload 역할 분리가 응답에 드러나지 않음 | 초과 응답 메시지에서 `/uploads:init` presigned 파일 업로드 흐름 사용을 안내 |
+| 기존 file upload | 별도 presigned flow 존재 | 기존 flow 유지 |
+
+## REST API
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `POST` | `/api/v1/workspaces/{workspaceId}/datasets/raw` | 작은 원본 로그 JSON 업로드 |
+| `POST` | `/api/v1/workspaces/{workspaceId}/datasets/uploads:init` | 대용량 ZIP 원본 로그 presigned 업로드 시작 |
+
+### Over-limit Response
+
+```json
+{
+  "code": "RAW_JSON_UPLOAD_TOO_LARGE",
+  "message": "JSON 업로드 본문은 최대 1MB입니다. 대용량 데이터셋은 presigned 파일 업로드(/api/v1/workspaces/{workspaceId}/datasets/uploads:init) 흐름을 사용하세요."
+}
+```
+
+## Requirements
+
+- raw JSON upload endpoint는 요청 본문이 설정값을 초과하면 컨트롤러 역직렬화 전에 거절한다.
+- 기본 최대 body size는 설정 파일에 명시하고 환경 변수로 조정할 수 있다.
+- `Content-Length`가 제한을 초과하는 요청은 본문을 읽지 않고 413으로 응답한다.
+- `Content-Length`가 없는 요청은 제한까지만 읽고 초과 시 413으로 응답한다.
+- 제한 이하 요청은 기존 JSON 업로드 흐름과 응답을 유지한다.
+- 초과 응답은 대용량 데이터셋을 presigned file upload 경로로 안내한다.
+
+## Acceptance Criteria
+
+- JSON 원본 로그 업로드의 최대 body size가 `application.yml`에 명시된다.
+- over-limit JSON upload는 `413 Payload Too Large`와 `RAW_JSON_UPLOAD_TOO_LARGE`를 반환한다.
+- over-limit 요청에서는 `RawDatasetUploadService.upload(...)`가 호출되지 않는다.
+- 실패 메시지는 큰 데이터셋에 대해 `/uploads:init` file upload flow를 안내한다.
+- 기존 정상 JSON upload controller 테스트는 계속 통과한다.
+
+## Validation
+
+- `cd backend && ./gradlew test --tests com.init.corpus.presentation.RawDatasetUploadControllerTest`
+- `cd backend && ./gradlew test --tests com.init.corpus.presentation.RawDatasetUploadJsonSizeFilterTest`
+- `cd backend && ./gradlew test --tests com.init.corpus.presentation.DatasetControllerRawFileTest`
+
+## Open Questions
+
+- 운영 기본값 1MB가 실제 고객 JSON 샘플의 small-upload 기준에 맞는지는 배포 환경에서 `RAW_DATASET_JSON_MAX_BODY_SIZE`로 조정할 수 있다.

--- a/backend/src/main/java/com/init/corpus/presentation/RawDatasetUploadJsonSizeFilter.java
+++ b/backend/src/main/java/com/init/corpus/presentation/RawDatasetUploadJsonSizeFilter.java
@@ -1,0 +1,229 @@
+package com.init.corpus.presentation;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.init.shared.presentation.dto.ErrorResponse;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.regex.Pattern;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.unit.DataSize;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class RawDatasetUploadJsonSizeFilter extends OncePerRequestFilter {
+
+  static final String ERROR_CODE = "RAW_JSON_UPLOAD_TOO_LARGE";
+
+  private static final Pattern RAW_JSON_UPLOAD_PATH =
+      Pattern.compile("/api/v1/workspaces/[^/]+/datasets/raw");
+  private static final int BUFFER_SIZE = 8192;
+
+  private final ObjectMapper objectMapper;
+  private final long maxBodyBytes;
+
+  public RawDatasetUploadJsonSizeFilter(
+      ObjectMapper objectMapper,
+      @Value("${app.corpus.raw-json-upload.max-body-size:1MB}") DataSize maxBodySize) {
+    if (maxBodySize.toBytes() <= 0) {
+      throw new IllegalArgumentException("raw JSON upload max body size must be positive");
+    }
+    this.objectMapper = objectMapper;
+    this.maxBodyBytes = maxBodySize.toBytes();
+  }
+
+  @Override
+  protected boolean shouldNotFilter(HttpServletRequest request) {
+    return !HttpMethod.POST.matches(request.getMethod()) || !isRawJsonUploadPath(request);
+  }
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+    long contentLength = request.getContentLengthLong();
+    if (contentLength > maxBodyBytes) {
+      writePayloadTooLarge(response);
+      return;
+    }
+    if (contentLength >= 0) {
+      filterChain.doFilter(request, response);
+      return;
+    }
+
+    LimitedBody body = readBodyWithinLimit(request);
+    if (body.exceeded()) {
+      writePayloadTooLarge(response);
+      return;
+    }
+    filterChain.doFilter(new CachedBodyRequest(request, body.bytes()), response);
+  }
+
+  private boolean isRawJsonUploadPath(HttpServletRequest request) {
+    String path = request.getRequestURI();
+    String contextPath = request.getContextPath();
+    if (contextPath != null && !contextPath.isBlank() && path.startsWith(contextPath)) {
+      path = path.substring(contextPath.length());
+    }
+    return RAW_JSON_UPLOAD_PATH.matcher(path).matches();
+  }
+
+  private LimitedBody readBodyWithinLimit(HttpServletRequest request) throws IOException {
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    ServletInputStream inputStream = request.getInputStream();
+    byte[] buffer = new byte[BUFFER_SIZE];
+    long totalBytes = 0;
+    int readBytes;
+    while ((readBytes = inputStream.read(buffer)) != -1) {
+      totalBytes += readBytes;
+      if (totalBytes > maxBodyBytes) {
+        return LimitedBody.overLimit();
+      }
+      output.write(buffer, 0, readBytes);
+    }
+    return LimitedBody.withinLimit(output.toByteArray());
+  }
+
+  private void writePayloadTooLarge(HttpServletResponse response) throws IOException {
+    response.setStatus(HttpStatus.PAYLOAD_TOO_LARGE.value());
+    response.setHeader("X-Raw-Json-Max-Body-Bytes", Long.toString(maxBodyBytes));
+    response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+    objectMapper.writeValue(
+        response.getWriter(),
+        new ErrorResponse(
+            ERROR_CODE,
+            "JSON 업로드 본문은 최대 "
+                + maxBodySizeLabel()
+                + "입니다. 대용량 데이터셋은 presigned 파일 업로드"
+                + "(/api/v1/workspaces/{workspaceId}/datasets/uploads:init) 흐름을 사용하세요."));
+  }
+
+  private String maxBodySizeLabel() {
+    long mebibyte = 1024L * 1024;
+    if (maxBodyBytes % mebibyte == 0) {
+      return (maxBodyBytes / mebibyte) + "MB";
+    }
+    if (maxBodyBytes % 1024 == 0) {
+      return (maxBodyBytes / 1024) + "KB";
+    }
+    return maxBodyBytes + "B";
+  }
+
+  private static final class LimitedBody {
+
+    private final byte[] bytes;
+    private final boolean exceeded;
+
+    private LimitedBody(byte[] bytes, boolean exceeded) {
+      this.bytes = bytes.clone();
+      this.exceeded = exceeded;
+    }
+
+    private static LimitedBody withinLimit(byte[] bytes) {
+      return new LimitedBody(bytes, false);
+    }
+
+    private static LimitedBody overLimit() {
+      return new LimitedBody(new byte[0], true);
+    }
+
+    private byte[] bytes() {
+      return bytes.clone();
+    }
+
+    private boolean exceeded() {
+      return exceeded;
+    }
+  }
+
+  private static class CachedBodyRequest extends HttpServletRequestWrapper {
+
+    private final byte[] body;
+
+    CachedBodyRequest(HttpServletRequest request, byte[] body) {
+      super(request);
+      this.body = body.clone();
+    }
+
+    @Override
+    public ServletInputStream getInputStream() {
+      return new CachedBodyServletInputStream(body);
+    }
+
+    @Override
+    public BufferedReader getReader() throws IOException {
+      Charset charset =
+          getCharacterEncoding() == null
+              ? StandardCharsets.UTF_8
+              : Charset.forName(getCharacterEncoding());
+      return new BufferedReader(new InputStreamReader(getInputStream(), charset));
+    }
+
+    @Override
+    public int getContentLength() {
+      return body.length;
+    }
+
+    @Override
+    public long getContentLengthLong() {
+      return body.length;
+    }
+  }
+
+  private static class CachedBodyServletInputStream extends ServletInputStream {
+
+    private final ByteArrayInputStream inputStream;
+
+    CachedBodyServletInputStream(byte[] body) {
+      this.inputStream = new ByteArrayInputStream(body);
+    }
+
+    @Override
+    public int read() {
+      return inputStream.read();
+    }
+
+    @Override
+    public boolean isFinished() {
+      return inputStream.available() == 0;
+    }
+
+    @Override
+    public boolean isReady() {
+      return true;
+    }
+
+    @Override
+    public void setReadListener(ReadListener readListener) {
+      if (readListener == null) {
+        throw new IllegalArgumentException("readListener must not be null");
+      }
+      try {
+        if (!isFinished()) {
+          readListener.onDataAvailable();
+        }
+        if (isFinished()) {
+          readListener.onAllDataRead();
+        }
+      } catch (IOException e) {
+        readListener.onError(e);
+      }
+    }
+  }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -99,6 +99,9 @@ springdoc:
     version: openapi_3_0
 
 app:
+  corpus:
+    raw-json-upload:
+      max-body-size: ${RAW_DATASET_JSON_MAX_BODY_SIZE:1MB}
   ai:
     embedding:
       provider: ${AI_EMBEDDING_PROVIDER:bedrock}

--- a/backend/src/test/java/com/init/corpus/presentation/RawDatasetUploadControllerTest.java
+++ b/backend/src/test/java/com/init/corpus/presentation/RawDatasetUploadControllerTest.java
@@ -1,7 +1,9 @@
 package com.init.corpus.presentation;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -287,5 +289,24 @@ class RawDatasetUploadControllerTest {
                 .with(csrf()))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+  }
+
+  @Test
+  @DisplayName("JSON 본문 크기 초과 → 413 RAW_JSON_UPLOAD_TOO_LARGE")
+  @WithLongPrincipal(1L)
+  void uploadRawDatasetOversizedJsonBodyReturns413BeforeService() throws Exception {
+    String oversizedBody = "{\"oversized\":\"" + "x".repeat(1024 * 1024 + 1) + "\"}";
+
+    mockMvc
+        .perform(
+            post("/api/v1/workspaces/1/datasets/raw")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(oversizedBody)
+                .with(csrf()))
+        .andExpect(status().is(413))
+        .andExpect(jsonPath("$.code").value(RawDatasetUploadJsonSizeFilter.ERROR_CODE))
+        .andExpect(jsonPath("$.message").value(containsString("uploads:init")));
+
+    verifyNoInteractions(rawDatasetUploadService);
   }
 }

--- a/backend/src/test/java/com/init/corpus/presentation/RawDatasetUploadJsonSizeFilterTest.java
+++ b/backend/src/test/java/com/init/corpus/presentation/RawDatasetUploadJsonSizeFilterTest.java
@@ -1,0 +1,268 @@
+package com.init.corpus.presentation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.util.unit.DataSize;
+
+class RawDatasetUploadJsonSizeFilterTest {
+
+  @Test
+  @DisplayName("본문 크기 제한이 양수가 아니면 필터를 생성하지 않는다")
+  void shouldRejectNonPositiveMaxBodySize() {
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    assertThatThrownBy(() -> new RawDatasetUploadJsonSizeFilter(objectMapper, DataSize.ofBytes(0)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("positive");
+  }
+
+  @Test
+  @DisplayName("Raw JSON 업로드 요청이 아니면 본문 크기를 검사하지 않는다")
+  void shouldBypassWhenRequestDoesNotTargetRawJsonUpload() throws Exception {
+    RawDatasetUploadJsonSizeFilter filter =
+        new RawDatasetUploadJsonSizeFilter(new ObjectMapper(), DataSize.ofBytes(8));
+    MockHttpServletRequest request =
+        new MockHttpServletRequest("POST", "/api/v1/workspaces/1/datasets");
+    request.setContentType(MediaType.APPLICATION_JSON_VALUE);
+    request.setContent("{\"large\":\"payload\"}".getBytes(StandardCharsets.UTF_8));
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    AtomicBoolean downstreamCalled = new AtomicBoolean(false);
+
+    filter.doFilter(
+        request, response, (servletRequest, servletResponse) -> downstreamCalled.set(true));
+
+    assertThat(response.getStatus()).isEqualTo(200);
+    assertThat(downstreamCalled).isTrue();
+  }
+
+  @Test
+  @DisplayName("Raw JSON 업로드 POST가 아니면 본문 크기를 검사하지 않는다")
+  void shouldBypassWhenMethodIsNotPost() throws Exception {
+    RawDatasetUploadJsonSizeFilter filter =
+        new RawDatasetUploadJsonSizeFilter(new ObjectMapper(), DataSize.ofBytes(8));
+    MockHttpServletRequest request =
+        new MockHttpServletRequest("GET", "/api/v1/workspaces/1/datasets/raw");
+    request.setContent("{\"large\":\"payload\"}".getBytes(StandardCharsets.UTF_8));
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    AtomicBoolean downstreamCalled = new AtomicBoolean(false);
+
+    filter.doFilter(
+        request, response, (servletRequest, servletResponse) -> downstreamCalled.set(true));
+
+    assertThat(response.getStatus()).isEqualTo(200);
+    assertThat(downstreamCalled).isTrue();
+  }
+
+  @Test
+  @DisplayName("Content-Length가 제한 이하이면 원본 request를 downstream으로 전달한다")
+  void shouldPassOriginalRequestWhenContentLengthIsWithinLimit() throws Exception {
+    RawDatasetUploadJsonSizeFilter filter =
+        new RawDatasetUploadJsonSizeFilter(new ObjectMapper(), DataSize.ofBytes(128));
+    MockHttpServletRequest request =
+        new MockHttpServletRequest("POST", "/api/v1/workspaces/1/datasets/raw");
+    request.setContentType(MediaType.APPLICATION_JSON_VALUE);
+    request.setContent("{\"ok\":true}".getBytes(StandardCharsets.UTF_8));
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    AtomicReference<Object> downstreamRequest = new AtomicReference<>();
+
+    filter.doFilter(
+        request,
+        response,
+        (servletRequest, servletResponse) -> downstreamRequest.set(servletRequest));
+
+    assertThat(response.getStatus()).isEqualTo(200);
+    assertThat(downstreamRequest.get()).isSameAs(request);
+  }
+
+  @Test
+  @DisplayName("Content-Length가 제한을 넘으면 413과 최대 바이트 정보를 반환한다")
+  void shouldRejectWhenContentLengthExceedsLimit() throws Exception {
+    RawDatasetUploadJsonSizeFilter filter =
+        new RawDatasetUploadJsonSizeFilter(new ObjectMapper(), DataSize.ofBytes(8));
+    MockHttpServletRequest request =
+        new MockHttpServletRequest("POST", "/api/v1/workspaces/1/datasets/raw");
+    request.setContentType(MediaType.APPLICATION_JSON_VALUE);
+    request.setContent("{\"tooLarge\":true}".getBytes(StandardCharsets.UTF_8));
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    AtomicBoolean downstreamCalled = new AtomicBoolean(false);
+
+    filter.doFilter(
+        request, response, (servletRequest, servletResponse) -> downstreamCalled.set(true));
+
+    assertThat(response.getStatus()).isEqualTo(413);
+    assertThat(response.getHeader("X-Raw-Json-Max-Body-Bytes")).isEqualTo("8");
+    assertThat(response.getContentAsString()).contains("8B", "uploads:init");
+    assertThat(downstreamCalled).isFalse();
+  }
+
+  @Test
+  @DisplayName("context path를 제외한 Raw JSON 업로드 경로를 검사한다")
+  void shouldMatchRawJsonUploadPathAfterContextPath() throws Exception {
+    RawDatasetUploadJsonSizeFilter filter =
+        new RawDatasetUploadJsonSizeFilter(new ObjectMapper(), DataSize.ofKilobytes(1));
+    MockHttpServletRequest request =
+        new MockHttpServletRequest("POST", "/app/api/v1/workspaces/1/datasets/raw");
+    request.setContextPath("/app");
+    request.setContentType(MediaType.APPLICATION_JSON_VALUE);
+    request.setContent("x".repeat(1025).getBytes(StandardCharsets.UTF_8));
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    filter.doFilter(request, response, (servletRequest, servletResponse) -> {});
+
+    assertThat(response.getStatus()).isEqualTo(413);
+    assertThat(response.getContentAsString()).contains("1KB");
+  }
+
+  @Test
+  @DisplayName("Content-Length 없는 제한 이하 본문 → downstream에서 동일 body를 읽을 수 있다")
+  void shouldCacheBodyForDownstreamWhenContentLengthUnknownAndWithinLimit() throws Exception {
+    RawDatasetUploadJsonSizeFilter filter =
+        new RawDatasetUploadJsonSizeFilter(new ObjectMapper(), DataSize.ofBytes(128));
+    byte[] payload = "{\"ok\":true}".getBytes(StandardCharsets.UTF_8);
+    MockHttpServletRequest baseRequest =
+        new MockHttpServletRequest("POST", "/api/v1/workspaces/1/datasets/raw");
+    baseRequest.setContentType(MediaType.APPLICATION_JSON_VALUE);
+    baseRequest.setCharacterEncoding(StandardCharsets.UTF_8.name());
+    baseRequest.setContent(payload);
+    HttpServletRequest request = new UnknownContentLengthRequest(baseRequest);
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    AtomicReference<String> downstreamBody = new AtomicReference<>();
+    AtomicReference<String> downstreamReaderBody = new AtomicReference<>();
+    AtomicReference<Integer> downstreamContentLength = new AtomicReference<>();
+    AtomicReference<Long> downstreamContentLengthLong = new AtomicReference<>();
+    AtomicBoolean onDataAvailableCalled = new AtomicBoolean(false);
+    AtomicBoolean onAllDataReadCalled = new AtomicBoolean(false);
+    AtomicBoolean onAllDataReadAfterFinishedCalled = new AtomicBoolean(false);
+    AtomicReference<Throwable> listenerError = new AtomicReference<>();
+    FilterChain chain =
+        (servletRequest, servletResponse) -> {
+          HttpServletRequest cachedRequest = (HttpServletRequest) servletRequest;
+          downstreamContentLength.set(cachedRequest.getContentLength());
+          downstreamContentLengthLong.set(cachedRequest.getContentLengthLong());
+          downstreamReaderBody.set(cachedRequest.getReader().readLine());
+
+          ServletInputStream readyStream = cachedRequest.getInputStream();
+          readyStream.setReadListener(
+              new ReadListener() {
+                @Override
+                public void onDataAvailable() {
+                  onDataAvailableCalled.set(true);
+                }
+
+                @Override
+                public void onAllDataRead() {
+                  onAllDataReadCalled.set(true);
+                }
+
+                @Override
+                public void onError(Throwable throwable) {}
+              });
+
+          ServletInputStream bodyStream = cachedRequest.getInputStream();
+          downstreamBody.set(new String(bodyStream.readAllBytes(), StandardCharsets.UTF_8));
+          assertThat(bodyStream.isReady()).isTrue();
+          assertThat(bodyStream.isFinished()).isTrue();
+
+          ServletInputStream finishedStream = cachedRequest.getInputStream();
+          assertThat(finishedStream.readAllBytes()).isEqualTo(payload);
+          finishedStream.setReadListener(
+              new ReadListener() {
+                @Override
+                public void onDataAvailable() {}
+
+                @Override
+                public void onAllDataRead() {
+                  onAllDataReadAfterFinishedCalled.set(true);
+                }
+
+                @Override
+                public void onError(Throwable throwable) {}
+              });
+          assertThatThrownBy(() -> finishedStream.setReadListener(null))
+              .isInstanceOf(IllegalArgumentException.class);
+
+          ServletInputStream failingStream = cachedRequest.getInputStream();
+          failingStream.setReadListener(
+              new ReadListener() {
+                @Override
+                public void onDataAvailable() throws IOException {
+                  throw new IOException("listener failed");
+                }
+
+                @Override
+                public void onAllDataRead() {}
+
+                @Override
+                public void onError(Throwable throwable) {
+                  listenerError.set(throwable);
+                }
+              });
+        };
+
+    filter.doFilter(request, response, chain);
+
+    assertThat(response.getStatus()).isEqualTo(200);
+    assertThat(downstreamBody.get()).isEqualTo("{\"ok\":true}");
+    assertThat(downstreamReaderBody.get()).isEqualTo("{\"ok\":true}");
+    assertThat(downstreamContentLength.get()).isEqualTo(payload.length);
+    assertThat(downstreamContentLengthLong.get()).isEqualTo(payload.length);
+    assertThat(onDataAvailableCalled).isTrue();
+    assertThat(onAllDataReadCalled).isFalse();
+    assertThat(onAllDataReadAfterFinishedCalled).isTrue();
+    assertThat(listenerError.get()).isInstanceOf(IOException.class);
+  }
+
+  @Test
+  @DisplayName("Content-Length 없는 제한 초과 본문 → 413 반환 후 downstream을 호출하지 않는다")
+  void shouldRejectBeforeDownstreamWhenContentLengthUnknownAndExceeded() throws Exception {
+    RawDatasetUploadJsonSizeFilter filter =
+        new RawDatasetUploadJsonSizeFilter(new ObjectMapper(), DataSize.ofBytes(8));
+    MockHttpServletRequest baseRequest =
+        new MockHttpServletRequest("POST", "/api/v1/workspaces/1/datasets/raw");
+    baseRequest.setContentType(MediaType.APPLICATION_JSON_VALUE);
+    baseRequest.setContent("{\"tooLarge\":true}".getBytes(StandardCharsets.UTF_8));
+    HttpServletRequest request = new UnknownContentLengthRequest(baseRequest);
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    AtomicBoolean downstreamCalled = new AtomicBoolean(false);
+
+    filter.doFilter(
+        request, response, (servletRequest, servletResponse) -> downstreamCalled.set(true));
+
+    assertThat(response.getStatus()).isEqualTo(413);
+    assertThat(response.getContentAsString()).contains(RawDatasetUploadJsonSizeFilter.ERROR_CODE);
+    assertThat(downstreamCalled).isFalse();
+  }
+
+  private static class UnknownContentLengthRequest extends HttpServletRequestWrapper {
+
+    UnknownContentLengthRequest(HttpServletRequest request) {
+      super(request);
+    }
+
+    @Override
+    public int getContentLength() {
+      return -1;
+    }
+
+    @Override
+    public long getContentLengthLong() {
+      return -1;
+    }
+  }
+}


### PR DESCRIPTION
Closes #592

## 변경 사항

- JSON 원본 로그 업로드 엔드포인트(`POST /api/v1/workspaces/{workspaceId}/datasets/raw`)의 요청 본문 크기를 기본 1MB로 제한하고, `app.corpus.raw-json-upload.max-body-size` / `RAW_DATASET_JSON_MAX_BODY_SIZE`로 조정할 수 있게 했습니다.
- `Content-Length`가 제한을 넘거나 길이 헤더 없이 스트리밍된 본문이 제한을 넘으면 `413 Payload Too Large`와 `RAW_JSON_UPLOAD_TOO_LARGE` 코드를 반환합니다.
- 초과 응답에 최대 허용 바이트 헤더와 파일 업로드 초기화 경로(`uploads:init`) 안내 메시지를 포함해 대용량 원본 로그는 기존 presigned 업로드 플로우로 유도합니다.
- 제한 초과 응답, 길이 헤더 없는 요청의 캐싱/차단 동작, 이슈 592 스펙을 `.agent/specs/592.md`에 정리했습니다.

## 검증

- `git diff --check`
- `cd backend && JAVA_HOME=/Users/owen/.local/share/mise/installs/java/temurin-21.0.11+10.0.LTS ./gradlew spotlessApply test --tests com.init.corpus.presentation.RawDatasetUploadControllerTest --tests com.init.corpus.presentation.RawDatasetUploadJsonSizeFilterTest --tests com.init.corpus.presentation.DatasetControllerRawFileTest checkstyleMain checkstyleTest`
- `cd backend && JAVA_HOME=/Users/owen/.local/share/mise/installs/java/temurin-21.0.11+10.0.LTS ./gradlew jacocoTestReport`

## 참고

- 로컬 Husky hook 파일이 executable이 아니어서 commit hook은 실행되지 않았고, 위 검증을 수동으로 실행했습니다.