### PR TITLE
fix(payment): 구독 동시 생성 충돌을 409로 정리

### DIFF
--- a/.agent/specs/577.md
+++ b/.agent/specs/577.md
@@ -1,0 +1,64 @@
+# 구독 동시 생성 unique 충돌 409 매핑
+
+## Goal
+
+동시 활성 구독 생성 경합에서 `payment.subscription`의 open subscription partial unique index 충돌이 500으로 노출되지 않고 기존 구독 중복 도메인 예외의 409 응답으로 정리되도록 한다.
+
+## Problem
+
+`backend/src/main/java/com/init/payment/application/SubscriptionService.java`의 `createSubscription`은 저장 전에 `findCurrentByWorkspaceId`로 기존 구독을 조회한다. 그러나 두 요청이 동시에 같은 워크스페이스에 구독을 만들면 두 요청 모두 조회 시점에는 기존 구독을 보지 못할 수 있다.
+
+DB는 `backend/src/main/resources/db/changelog/db.changelog-master.sql`의 `uq_payment_subscription_workspace_open` partial unique index로 `INCOMPLETE`, `ACTIVE`, `PAST_DUE` 구독 중복 저장을 최종 방어한다. 현재 서비스가 이 저장 시점의 `DataIntegrityViolationException`을 도메인 예외로 변환하지 않으면 API 경계에서 500으로 노출될 수 있다.
+
+## Scope
+
+- `backend/src/main/java/com/init/payment/application/SubscriptionService.java`의 구독 생성 저장 경합 처리
+- `backend/src/main/java/com/init/payment/application/exception/ActiveSubscriptionExistsException.java`의 원인 예외 보존 지원
+- `backend/src/main/java/com/init/shared/application/exception/DuplicateException.java`의 중복 예외 원인 보존 생성자
+- `backend/src/test/java/com/init/payment/application/SubscriptionServiceTest.java`의 partial unique index 충돌 회귀 테스트
+- `.agent/specs/577.md`에 요구사항과 검증 기준 문서화
+
+## Non-Goals
+
+- 결제 플랜, billing key 발급, 정기결제 실행 흐름 변경
+- `payment.subscription` 스키마 또는 `uq_payment_subscription_workspace_open` index 변경
+- 동시 요청에 기존 구독을 멱등 응답으로 반환하는 API 계약 추가
+- 권한 검증 또는 workspace membership 정책 변경
+
+## Current Contract
+
+| 파일 | 현재 역할 | 확인된 이슈 |
+| --- | --- | --- |
+| `backend/src/main/java/com/init/payment/application/SubscriptionService.java` | 구독 생성 전 기존 open subscription 조회 후 저장 | 저장 직전 경합에서 DB unique 충돌이 발생하면 도메인 예외로 매핑되지 않을 수 있음 |
+| `backend/src/main/java/com/init/payment/application/exception/ActiveSubscriptionExistsException.java` | 활성 구독 중복을 `DuplicateException` 계열로 표현 | 원인 `DataIntegrityViolationException`을 보존하는 생성자가 없음 |
+| `backend/src/main/java/com/init/shared/application/exception/DuplicateException.java` | 중복 비즈니스 예외의 공통 409 계층 | 원인 예외를 전달하는 생성자가 없음 |
+| `backend/src/main/resources/db/changelog/db.changelog-master.sql` | `uq_payment_subscription_workspace_open` partial unique index 정의 | DB 방어선은 존재하지만 애플리케이션 예외 매핑 테스트가 없음 |
+| `backend/src/test/java/com/init/payment/application/SubscriptionServiceTest.java` | 구독 생성/조회/취소/billingKey 발급 서비스 테스트 | 저장 시점 partial unique index 충돌 회귀 테스트가 없음 |
+
+## Design Diff
+
+| 영역 | As-is | To-be |
+| --- | --- | --- |
+| 저장 전 중복 | 기존 open subscription 조회 시 `ActiveSubscriptionExistsException` | 유지 |
+| 저장 시점 DB 충돌 | `DataIntegrityViolationException`이 상위로 전파될 수 있음 | `uq_payment_subscription_workspace_open` 충돌이면 `ActiveSubscriptionExistsException`으로 변환 |
+| 기타 DB 무결성 오류 | 중복 구독처럼 보일 수 있음 | 해당 index 충돌이 아니면 기존 예외를 그대로 전파 |
+| HTTP 응답 | unique race가 500이 될 수 있음 | `DuplicateException` 핸들러를 통해 409 응답 |
+
+## Acceptance Criteria
+
+- `createSubscription` 저장 중 `uq_payment_subscription_workspace_open` partial unique index 충돌이 발생하면 `ActiveSubscriptionExistsException`이 발생한다.
+- `ActiveSubscriptionExistsException`은 `DuplicateException` 계열이므로 기존 `GlobalExceptionHandler`에서 409로 응답된다.
+- `uq_payment_subscription_workspace_open`이 아닌 `DataIntegrityViolationException`은 중복 구독으로 오분류하지 않고 원래 예외를 유지한다.
+- 저장 전 기존 open subscription 조회로 중복을 차단하는 기존 동작은 유지된다.
+- partial unique index 충돌 케이스를 검증하는 서비스 테스트가 추가된다.
+
+## Validation Plan
+
+| 구분 | 명령 | 기대 결과 |
+| --- | --- | --- |
+| Backend targeted tests | `cd backend && ./gradlew test --tests com.init.payment.application.SubscriptionServiceTest` | 구독 생성 경합 예외 매핑과 기존 SubscriptionService 회귀 통과 |
+| Backend full tests | `cd backend && ./gradlew test` | 백엔드 테스트 회귀 없음 |
+
+## Open Questions
+
+- 없음. 이슈 본문은 409 또는 명확한 멱등 응답 중 하나를 허용하며, 현재 예외/응답 체계에는 `ActiveSubscriptionExistsException` 기반 409 매핑이 이미 존재한다.

--- a/backend/src/main/java/com/init/payment/application/SubscriptionService.java
+++ b/backend/src/main/java/com/init/payment/application/SubscriptionService.java
@@ -232,8 +232,7 @@ public class SubscriptionService {
       return constraintName != null && constraintName.contains(OPEN_SUBSCRIPTION_UNIQUE_INDEX);
     }
 
-    Throwable rootCause = ex.getMostSpecificCause();
-    String message = rootCause != null ? rootCause.getMessage() : null;
+    String message = ex.getMostSpecificCause().getMessage();
     return message != null && message.contains(OPEN_SUBSCRIPTION_UNIQUE_INDEX);
   }
 }

--- a/backend/src/main/java/com/init/payment/application/SubscriptionService.java
+++ b/backend/src/main/java/com/init/payment/application/SubscriptionService.java
@@ -21,6 +21,7 @@ import com.init.shared.application.exception.BadRequestException;
 import java.time.Clock;
 import java.time.OffsetDateTime;
 import java.util.function.Supplier;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.Transactional;
@@ -34,6 +35,9 @@ import org.springframework.transaction.support.TransactionTemplate;
  */
 @Service
 public class SubscriptionService {
+
+  private static final String OPEN_SUBSCRIPTION_UNIQUE_INDEX =
+      "uq_payment_subscription_workspace_open";
 
   private final SubscriptionRepository subscriptionRepository;
   private final PlanRepository planRepository;
@@ -87,7 +91,7 @@ public class SubscriptionService {
 
     Subscription subscription = Subscription.create(command.workspaceId(), plan.getId());
     subscription.assignCustomerKey(PaymentIdentifiers.customerKey(command.workspaceId()));
-    Subscription saved = subscriptionRepository.save(subscription);
+    Subscription saved = saveNewSubscription(subscription, command.workspaceId());
     return SubscriptionResult.from(saved, plan);
   }
 
@@ -208,5 +212,28 @@ public class SubscriptionService {
 
   private <T> T inTx(Supplier<T> callback) {
     return transactionTemplate.execute(status -> callback.get());
+  }
+
+  private Subscription saveNewSubscription(Subscription subscription, Long workspaceId) {
+    try {
+      return subscriptionRepository.save(subscription);
+    } catch (DataIntegrityViolationException ex) {
+      if (isOpenSubscriptionUniqueIndexViolation(ex)) {
+        throw new ActiveSubscriptionExistsException(workspaceId, ex);
+      }
+      throw ex;
+    }
+  }
+
+  private boolean isOpenSubscriptionUniqueIndexViolation(DataIntegrityViolationException ex) {
+    Throwable cause = ex.getCause();
+    if (cause instanceof org.hibernate.exception.ConstraintViolationException violationException) {
+      String constraintName = violationException.getConstraintName();
+      return constraintName != null && constraintName.contains(OPEN_SUBSCRIPTION_UNIQUE_INDEX);
+    }
+
+    Throwable rootCause = ex.getMostSpecificCause();
+    String message = rootCause != null ? rootCause.getMessage() : null;
+    return message != null && message.contains(OPEN_SUBSCRIPTION_UNIQUE_INDEX);
   }
 }

--- a/backend/src/main/java/com/init/payment/application/exception/ActiveSubscriptionExistsException.java
+++ b/backend/src/main/java/com/init/payment/application/exception/ActiveSubscriptionExistsException.java
@@ -6,4 +6,8 @@ public class ActiveSubscriptionExistsException extends DuplicateException {
   public ActiveSubscriptionExistsException(Long workspaceId) {
     super("SUBSCRIPTION_ALREADY_EXISTS", "이미 진행 중인 구독이 있습니다. workspaceId=" + workspaceId);
   }
+
+  public ActiveSubscriptionExistsException(Long workspaceId, Throwable cause) {
+    super("SUBSCRIPTION_ALREADY_EXISTS", "이미 진행 중인 구독이 있습니다. workspaceId=" + workspaceId, cause);
+  }
 }

--- a/backend/src/main/java/com/init/shared/application/exception/DuplicateException.java
+++ b/backend/src/main/java/com/init/shared/application/exception/DuplicateException.java
@@ -4,4 +4,8 @@ public class DuplicateException extends BusinessException {
   public DuplicateException(String code, String message) {
     super(code, message);
   }
+
+  public DuplicateException(String code, String message, Throwable cause) {
+    super(code, message, cause);
+  }
 }

--- a/backend/src/test/java/com/init/payment/application/SubscriptionServiceTest.java
+++ b/backend/src/test/java/com/init/payment/application/SubscriptionServiceTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.SimpleTransactionStatus;
@@ -114,6 +115,40 @@ class SubscriptionServiceTest {
                 subscriptionService.createSubscription(
                     new CreateSubscriptionCommand(1L, 99L, "pro_monthly")))
         .isInstanceOf(ActiveSubscriptionExistsException.class);
+  }
+
+  @Test
+  @DisplayName("구독 저장 중 open subscription partial unique index 충돌 시 409 예외로 변환한다")
+  void createSubscription_openSubscriptionUniqueViolation_throwsActiveSubscriptionExists() {
+    given(planRepository.findByPlanKey("pro_monthly")).willReturn(Optional.of(plan(10L)));
+    given(subscriptionRepository.findCurrentByWorkspaceId(1L)).willReturn(Optional.empty());
+    given(subscriptionRepository.save(any()))
+        .willThrow(
+            new DataIntegrityViolationException(
+                "duplicate key value violates unique constraint "
+                    + "\"uq_payment_subscription_workspace_open\""));
+
+    assertThatThrownBy(
+            () ->
+                subscriptionService.createSubscription(
+                    new CreateSubscriptionCommand(1L, 99L, "pro_monthly")))
+        .isInstanceOf(ActiveSubscriptionExistsException.class)
+        .hasCauseInstanceOf(DataIntegrityViolationException.class);
+  }
+
+  @Test
+  @DisplayName("구독 저장 중 open subscription partial unique index 외 무결성 오류는 그대로 전파한다")
+  void createSubscription_otherIntegrityViolation_rethrowsOriginalException() {
+    given(planRepository.findByPlanKey("pro_monthly")).willReturn(Optional.of(plan(10L)));
+    given(subscriptionRepository.findCurrentByWorkspaceId(1L)).willReturn(Optional.empty());
+    given(subscriptionRepository.save(any()))
+        .willThrow(new DataIntegrityViolationException("foreign key violation"));
+
+    assertThatThrownBy(
+            () ->
+                subscriptionService.createSubscription(
+                    new CreateSubscriptionCommand(1L, 99L, "pro_monthly")))
+        .isInstanceOf(DataIntegrityViolationException.class);
   }
 
   @Test

--- a/backend/src/test/java/com/init/payment/application/SubscriptionServiceTest.java
+++ b/backend/src/test/java/com/init/payment/application/SubscriptionServiceTest.java
@@ -21,6 +21,7 @@ import com.init.payment.domain.repository.PaymentRepository;
 import com.init.payment.domain.repository.PlanRepository;
 import com.init.payment.domain.repository.SubscriptionRepository;
 import com.init.shared.application.exception.BadRequestException;
+import java.sql.SQLException;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -127,11 +128,29 @@ class SubscriptionServiceTest {
             new DataIntegrityViolationException(
                 "duplicate key value violates unique constraint "
                     + "\"uq_payment_subscription_workspace_open\""));
+    CreateSubscriptionCommand command = new CreateSubscriptionCommand(1L, 99L, "pro_monthly");
 
-    assertThatThrownBy(
-            () ->
-                subscriptionService.createSubscription(
-                    new CreateSubscriptionCommand(1L, 99L, "pro_monthly")))
+    assertThatThrownBy(() -> subscriptionService.createSubscription(command))
+        .isInstanceOf(ActiveSubscriptionExistsException.class)
+        .hasCauseInstanceOf(DataIntegrityViolationException.class);
+  }
+
+  @Test
+  @DisplayName("구독 저장 중 Hibernate constraintName으로 open subscription index가 전달되면 409 예외로 변환한다")
+  void createSubscription_openSubscriptionConstraintName_throwsActiveSubscriptionExists() {
+    given(planRepository.findByPlanKey("pro_monthly")).willReturn(Optional.of(plan(10L)));
+    given(subscriptionRepository.findCurrentByWorkspaceId(1L)).willReturn(Optional.empty());
+    given(subscriptionRepository.save(any()))
+        .willThrow(
+            new DataIntegrityViolationException(
+                "duplicate",
+                new org.hibernate.exception.ConstraintViolationException(
+                    "duplicate",
+                    new SQLException("duplicate"),
+                    "uq_payment_subscription_workspace_open")));
+    CreateSubscriptionCommand command = new CreateSubscriptionCommand(1L, 99L, "pro_monthly");
+
+    assertThatThrownBy(() -> subscriptionService.createSubscription(command))
         .isInstanceOf(ActiveSubscriptionExistsException.class)
         .hasCauseInstanceOf(DataIntegrityViolationException.class);
   }
@@ -143,11 +162,9 @@ class SubscriptionServiceTest {
     given(subscriptionRepository.findCurrentByWorkspaceId(1L)).willReturn(Optional.empty());
     given(subscriptionRepository.save(any()))
         .willThrow(new DataIntegrityViolationException("foreign key violation"));
+    CreateSubscriptionCommand command = new CreateSubscriptionCommand(1L, 99L, "pro_monthly");
 
-    assertThatThrownBy(
-            () ->
-                subscriptionService.createSubscription(
-                    new CreateSubscriptionCommand(1L, 99L, "pro_monthly")))
+    assertThatThrownBy(() -> subscriptionService.createSubscription(command))
         .isInstanceOf(DataIntegrityViolationException.class);
   }
 


### PR DESCRIPTION
Closes #577

## 변경 사항

- 활성 구독 생성 저장 중 `uq_payment_subscription_workspace_open` partial unique index 충돌이 발생하면 `ActiveSubscriptionExistsException`으로 변환해 기존 409 응답 경로를 타도록 했습니다.
- 해당 partial unique index 충돌이 아닌 `DataIntegrityViolationException`은 중복 구독으로 오분류하지 않고 그대로 전파합니다.
- 중복 예외 계층이 원인 예외를 보존할 수 있게 하고, 이슈 577 스펙을 `.agent/specs/577.md`에 정리했습니다.
- `SubscriptionServiceTest`에 저장 시점 partial unique index 충돌과 기타 무결성 오류 guardrail 테스트를 추가했습니다.

## 검증

- `git diff --check`
- `cd backend && JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home ./gradlew test --tests com.init.payment.application.SubscriptionServiceTest`
- `cd backend && JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home ./gradlew test`
- `cd backend && JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home ./gradlew spotlessCheck checkstyleMain checkstyleTest`

## 참고

- 로컬 Husky hook 파일이 executable이 아니어서 commit hook은 실행되지 않았고, 위 검증을 수동으로 실행했습니다.
- `checkstyleMain checkstyleTest`는 기존 warning-level violations를 출력하지만 Gradle task는 성공했습니다.