### PR TITLE
fix(auth): refresh token rotation 동시성 충돌을 인증 실패로 처리

### DIFF
--- a/.agent/specs/579.md
+++ b/.agent/specs/579.md
@@ -1,0 +1,98 @@
+# Refresh token rotation concurrency failure mapping
+
+## Goal
+
+같은 refresh token으로 동시에 rotation 요청이 들어와도 하나의 요청만 새 토큰을 받고 나머지는 500이 아닌 인증 실패로 응답하도록 한다.
+
+## Problem
+
+`AuthService.refresh()`는 refresh token row를 조회한 뒤 `RefreshToken.revoke()`와 새 refresh token 발급을 같은 트랜잭션에서 수행한다. `RefreshToken`에는 `@Version`이 있지만, 같은 token hash를 동시에 읽은 두 요청이 모두 유효성 검사를 통과하면 한 요청의 revoke 이후 다른 요청에서 optimistic locking 충돌이 발생할 수 있다. 이 충돌이 인증 실패로 변환되지 않으면 `/api/v1/auth/refresh` 호출자는 이미 사용된 refresh token에 대해 401 대신 500을 받을 수 있다.
+
+이슈 본문은 `backend/src/main/java/com/example/backend/...` 경로를 언급하지만 현재 저장소에서 확인된 실제 auth 경로는 `backend/src/main/java/com/init/auth/...`다.
+
+## Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    actor c1 as Client A
+    actor c2 as Client B
+    participant svc as AuthService
+    participant repo as RefreshTokenRepository
+    participant db as app.refresh_token
+
+    c1 ->> svc: POST /api/v1/auth/refresh
+    svc ->> repo: findByTokenHashForUpdate(hash)
+    repo ->> db: SELECT ... FOR UPDATE
+    db -->> svc: valid refresh token
+    c2 ->> svc: POST /api/v1/auth/refresh
+    svc ->> repo: findByTokenHashForUpdate(hash)
+    repo ->> db: waits for same row
+    svc ->> db: revoke old token and insert new token
+    svc -->> c1: 200 OK
+    db -->> svc: revoked refresh token
+    svc -->> c2: 401 INVALID_TOKEN
+```
+
+## Scope
+
+- `backend/src/main/java/com/init/auth/application/AuthService.java`의 refresh token 조회를 rotation 전용 row lock 조회로 변경한다.
+- `backend/src/main/java/com/init/auth/application/JwtService.java`의 refresh token 발급이 같은 초 안에서도 매번 다른 token value를 만들도록 보장한다.
+- `backend/src/main/java/com/init/auth/domain/repository/RefreshTokenRepository.java`에 rotation용 조회 계약을 추가한다.
+- `backend/src/main/java/com/init/auth/infrastructure/persistence/JpaRefreshTokenRepository.java`에 `PESSIMISTIC_WRITE` lock 기반 구현을 둔다.
+- `backend/src/test/java/com/init/auth/application/AuthServiceTest.java`에 refresh 경로가 lock 조회 계약을 사용하는지 검증을 보강한다.
+- `backend/src/test/java/com/init/auth/application/` 아래에 동시 refresh 요청 회귀 테스트를 추가한다.
+
+## Non-Goals
+
+- refresh token 만료 시간 또는 저장 스키마 변경
+- `/api/v1/auth/refresh` request/response DTO 변경
+- access token 검증, login, logout, password reset 정책 변경
+- refresh token 재사용 감지 감사 로그나 전체 세션 폐기 정책 추가
+
+## REST API
+
+| Method | Path | Description |
+| --- | --- | --- |
+| POST | `/api/v1/auth/refresh` | 기존 refresh token을 폐기하고 새 access/refresh token을 발급 |
+
+### Error Response
+
+동일 refresh token을 이미 다른 요청이 성공적으로 rotation한 경우 실패 요청은 기존 `InvalidTokenException` 매핑을 사용한다.
+
+```json
+{
+  "code": "INVALID_TOKEN",
+  "message": "만료되거나 폐기된 리프레시 토큰입니다."
+}
+```
+
+HTTP status는 401 Unauthorized다.
+
+## Design Diff
+
+| 영역 | As-is | To-be |
+| --- | --- | --- |
+| refresh token 조회 | `findByTokenHash()`로 일반 조회 | refresh rotation에서는 `findByTokenHashForUpdate()`로 같은 row를 직렬화 |
+| 새 refresh token 값 | 같은 사용자에게 같은 초 안에 발급되면 token value가 같아질 수 있음 | refresh token마다 `jti`를 넣어 token hash unique 충돌을 방지 |
+| 동시 요청 처리 | 두 요청이 같은 유효 token 상태를 볼 수 있음 | 두 번째 요청은 첫 번째 요청 commit 이후 revoked 상태를 확인 |
+| 실패 매핑 | optimistic locking 충돌이 500으로 표면화될 수 있음 | 이미 사용된 refresh token은 `InvalidTokenException` 기반 401로 응답 |
+| logout | 일반 조회 후 revoke | 기존 동작 유지 |
+
+## Acceptance Criteria
+
+- 같은 refresh token으로 동시에 `refresh()`가 호출되면 정확히 하나의 호출만 새 refresh token을 받는다.
+- 실패한 동시 호출은 `InvalidTokenException`으로 끝나며 HTTP 경계에서는 401 `INVALID_TOKEN`으로 매핑된다.
+- refresh rotation 경로는 token hash 조회 시 row lock 계약을 사용한다.
+- 같은 사용자에게 refresh token을 즉시 재발급해도 새 refresh token value는 기존 token과 다르다.
+- 기존 만료, 폐기, 존재하지 않는 refresh token 실패 동작은 유지된다.
+
+## Validation Plan
+
+| 구분 | 명령 | 기대 결과 |
+| --- | --- | --- |
+| Backend targeted tests | `cd backend && ./gradlew test --tests com.init.auth.application.JwtServiceTest --tests com.init.auth.application.AuthServiceTest --tests com.init.auth.application.AuthServiceConcurrencyTest --tests com.init.auth.presentation.AuthControllerTest` | refresh token value uniqueness, refresh lock 조회, 동시 rotation, 401 매핑 회귀 통과 |
+| Backend full tests | `cd backend && ./gradlew test` | 백엔드 테스트 회귀 없음 |
+
+## Open Questions
+
+- 없음. 이슈는 같은 refresh token의 동시 rotation 충돌을 인증 실패로 다루는 범위로 한정되어 있다.

--- a/backend/src/main/java/com/init/auth/application/AuthService.java
+++ b/backend/src/main/java/com/init/auth/application/AuthService.java
@@ -98,7 +98,7 @@ public class AuthService {
 
     RefreshToken refreshToken =
         refreshTokenRepository
-            .findByTokenHash(tokenHash)
+            .findByTokenHashForUpdate(tokenHash)
             .orElseThrow(() -> new InvalidTokenException("유효하지 않은 리프레시 토큰입니다."));
 
     if (!refreshToken.isValid()) {

--- a/backend/src/main/java/com/init/auth/application/JwtService.java
+++ b/backend/src/main/java/com/init/auth/application/JwtService.java
@@ -6,6 +6,7 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
+import java.util.UUID;
 import javax.crypto.SecretKey;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -56,6 +57,7 @@ public class JwtService {
   public String generateRefreshToken(Long userId) {
     return Jwts.builder()
         .subject(String.valueOf(userId))
+        .id(UUID.randomUUID().toString())
         .claim("type", TOKEN_TYPE_REFRESH)
         .issuedAt(new Date())
         .expiration(new Date(System.currentTimeMillis() + refreshTokenExpiration))

--- a/backend/src/main/java/com/init/auth/domain/repository/RefreshTokenRepository.java
+++ b/backend/src/main/java/com/init/auth/domain/repository/RefreshTokenRepository.java
@@ -8,4 +8,6 @@ public interface RefreshTokenRepository {
   RefreshToken save(RefreshToken token);
 
   Optional<RefreshToken> findByTokenHash(String tokenHash);
+
+  Optional<RefreshToken> findByTokenHashForUpdate(String tokenHash);
 }

--- a/backend/src/main/java/com/init/auth/infrastructure/persistence/JpaRefreshTokenRepository.java
+++ b/backend/src/main/java/com/init/auth/infrastructure/persistence/JpaRefreshTokenRepository.java
@@ -2,9 +2,20 @@ package com.init.auth.infrastructure.persistence;
 
 import com.init.auth.domain.model.RefreshToken;
 import com.init.auth.domain.repository.RefreshTokenRepository;
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface JpaRefreshTokenRepository
-    extends JpaRepository<RefreshToken, Long>, RefreshTokenRepository {}
+    extends JpaRepository<RefreshToken, Long>, RefreshTokenRepository {
+
+  @Override
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query("select token from RefreshToken token where token.tokenHash = :tokenHash")
+  Optional<RefreshToken> findByTokenHashForUpdate(@Param("tokenHash") String tokenHash);
+}

--- a/backend/src/test/java/com/init/auth/application/AuthServiceConcurrencyTest.java
+++ b/backend/src/test/java/com/init/auth/application/AuthServiceConcurrencyTest.java
@@ -1,0 +1,154 @@
+package com.init.auth.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.init.auth.application.exception.InvalidTokenException;
+import com.init.shared.infrastructure.Sha256TokenHasher;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Testcontainers(disabledWithoutDocker = true)
+@Import({
+  AuthService.class,
+  JwtService.class,
+  Sha256TokenHasher.class,
+  AuthServiceConcurrencyTest.PasswordEncoderTestConfig.class
+})
+@DisplayName("AuthService refresh concurrency")
+class AuthServiceConcurrencyTest {
+
+  @Container static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16");
+
+  static {
+    postgres.start();
+  }
+
+  @DynamicPropertySource
+  static void configureDataSource(DynamicPropertyRegistry registry) {
+    registry.add("spring.datasource.url", postgres::getJdbcUrl);
+    registry.add("spring.datasource.username", postgres::getUsername);
+    registry.add("spring.datasource.password", postgres::getPassword);
+    registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+    registry.add("spring.jpa.hibernate.ddl-auto", () -> "create");
+    registry.add(
+        "spring.jpa.properties.hibernate.dialect", () -> "org.hibernate.dialect.PostgreSQLDialect");
+    registry.add("spring.jpa.properties.hibernate.hbm2ddl.create_namespaces", () -> "true");
+    registry.add("spring.liquibase.enabled", () -> "false");
+  }
+
+  @Autowired private AuthService authService;
+
+  @Test
+  @Transactional(propagation = Propagation.NOT_SUPPORTED)
+  @DisplayName("refresh: 같은 리프레시 토큰 동시 rotation → 하나만 성공하고 나머지는 InvalidTokenException")
+  void shouldAllowOnlyOneRefreshWhenSameRefreshTokenRotatedConcurrently() throws Exception {
+    // given
+    String email = "concurrent-refresh@example.com";
+    String password = "password123";
+    authService.signup(new SignupCommand("동시성 사용자", email, password));
+    LoginResult loginResult = authService.login(new LoginCommand(email, password));
+    TokenRefreshCommand command = new TokenRefreshCommand(loginResult.refreshToken());
+
+    CountDownLatch ready = new CountDownLatch(2);
+    CountDownLatch start = new CountDownLatch(1);
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+
+    try {
+      List<Future<RefreshAttempt>> futures =
+          List.of(
+              executor.submit(refreshAttempt(command, ready, start)),
+              executor.submit(refreshAttempt(command, ready, start)));
+
+      assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
+      start.countDown();
+
+      List<RefreshAttempt> attempts =
+          futures.stream().map(AuthServiceConcurrencyTest::getRefreshAttempt).toList();
+
+      assertThat(attempts).hasSize(2);
+      assertThat(attempts.stream().filter(RefreshAttempt::succeeded).count())
+          .describedAs("attempts=%s", attempts)
+          .isEqualTo(1);
+      assertThat(attempts.stream().filter(RefreshAttempt::failedWithInvalidToken).count())
+          .describedAs("attempts=%s", attempts)
+          .isEqualTo(1);
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  private Callable<RefreshAttempt> refreshAttempt(
+      TokenRefreshCommand command, CountDownLatch ready, CountDownLatch start) {
+    return () -> {
+      ready.countDown();
+      if (!start.await(5, TimeUnit.SECONDS)) {
+        throw new IllegalStateException("refresh attempts were not released");
+      }
+
+      try {
+        return RefreshAttempt.success(authService.refresh(command));
+      } catch (RuntimeException ex) {
+        return RefreshAttempt.failure(ex);
+      }
+    };
+  }
+
+  private static RefreshAttempt getRefreshAttempt(Future<RefreshAttempt> future) {
+    try {
+      return future.get(10, TimeUnit.SECONDS);
+    } catch (Exception ex) {
+      throw new IllegalStateException("refresh attempt did not finish", ex);
+    }
+  }
+
+  private record RefreshAttempt(TokenRefreshResult result, Throwable failure) {
+    static RefreshAttempt success(TokenRefreshResult result) {
+      return new RefreshAttempt(result, null);
+    }
+
+    static RefreshAttempt failure(Throwable failure) {
+      return new RefreshAttempt(null, failure);
+    }
+
+    boolean succeeded() {
+      return result != null && failure == null;
+    }
+
+    boolean failedWithInvalidToken() {
+      return failure instanceof InvalidTokenException;
+    }
+  }
+
+  @TestConfiguration
+  static class PasswordEncoderTestConfig {
+
+    @Bean
+    PasswordEncoder passwordEncoder() {
+      return new BCryptPasswordEncoder();
+    }
+  }
+}

--- a/backend/src/test/java/com/init/auth/application/AuthServiceTest.java
+++ b/backend/src/test/java/com/init/auth/application/AuthServiceTest.java
@@ -181,7 +181,7 @@ class AuthServiceTest {
 
     RefreshToken refreshToken =
         RefreshToken.create(1L, "sha256-hash-of-token", OffsetDateTime.now().plusDays(7));
-    given(refreshTokenRepository.findByTokenHash("sha256-hash-of-token"))
+    given(refreshTokenRepository.findByTokenHashForUpdate("sha256-hash-of-token"))
         .willReturn(Optional.of(refreshToken));
 
     Claims claims = org.mockito.Mockito.mock(Claims.class);
@@ -210,6 +210,8 @@ class AuthServiceTest {
     assertThat(result.accessToken()).isEqualTo("new-access-token");
     assertThat(result.refreshToken()).isEqualTo("new-refresh-token");
     assertThat(result.tokenType()).isEqualTo("Bearer");
+    verify(refreshTokenRepository).findByTokenHashForUpdate("sha256-hash-of-token");
+    verify(refreshTokenRepository, never()).findByTokenHash("sha256-hash-of-token");
   }
 
   @Test
@@ -222,7 +224,7 @@ class AuthServiceTest {
     // 만료된 토큰 (expiresAt이 과거)
     RefreshToken expiredToken =
         RefreshToken.create(1L, "sha256-hash-expired", OffsetDateTime.now().minusSeconds(1));
-    given(refreshTokenRepository.findByTokenHash("sha256-hash-expired"))
+    given(refreshTokenRepository.findByTokenHashForUpdate("sha256-hash-expired"))
         .willReturn(Optional.of(expiredToken));
 
     // when & then
@@ -237,7 +239,7 @@ class AuthServiceTest {
     // given
     TokenRefreshCommand command = new TokenRefreshCommand("unknown-token");
     given(tokenHasher.hash("unknown-token")).willReturn("sha256-hash-unknown");
-    given(refreshTokenRepository.findByTokenHash("sha256-hash-unknown"))
+    given(refreshTokenRepository.findByTokenHashForUpdate("sha256-hash-unknown"))
         .willReturn(Optional.empty());
 
     // when & then
@@ -256,7 +258,7 @@ class AuthServiceTest {
     RefreshToken revokedToken =
         RefreshToken.create(1L, "sha256-hash-revoked", OffsetDateTime.now().plusDays(7));
     revokedToken.revoke();
-    given(refreshTokenRepository.findByTokenHash("sha256-hash-revoked"))
+    given(refreshTokenRepository.findByTokenHashForUpdate("sha256-hash-revoked"))
         .willReturn(Optional.of(revokedToken));
 
     // when & then

--- a/backend/src/test/java/com/init/auth/application/JwtServiceTest.java
+++ b/backend/src/test/java/com/init/auth/application/JwtServiceTest.java
@@ -1,0 +1,30 @@
+package com.init.auth.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.jsonwebtoken.Claims;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("JwtService")
+class JwtServiceTest {
+
+  private static final String SECRET = "test-secret-key-for-testing-purposes-only-min-32-bytes";
+
+  @Test
+  @DisplayName("generateRefreshToken: 같은 사용자에게 즉시 재발급해도 서로 다른 토큰을 생성한다")
+  void shouldGenerateDifferentRefreshTokensWhenIssuedImmediatelyForSameUser() {
+    // given
+    JwtService jwtService = new JwtService(SECRET, 1_800_000L, 604_800_000L);
+
+    // when
+    String first = jwtService.generateRefreshToken(1L);
+    String second = jwtService.generateRefreshToken(1L);
+
+    // then
+    assertThat(second).isNotEqualTo(first);
+    Claims claims = jwtService.parseClaims(first);
+    assertThat(claims.get("type", String.class)).isEqualTo("refresh");
+    assertThat(claims.getId()).isNotBlank();
+  }
+}


### PR DESCRIPTION
Closes #579

## 변경 사항

- refresh token rotation에서 token hash 조회 시 `PESSIMISTIC_WRITE` row lock을 사용해 같은 refresh token의 동시 요청을 직렬화합니다.
- 먼저 성공한 요청이 기존 refresh token을 폐기하면, 뒤따르는 요청은 폐기 상태를 확인하고 기존 `InvalidTokenException` 경로로 인증 실패 처리됩니다.
- 같은 사용자에게 refresh token이 같은 초 안에 재발급되어도 token value가 달라지도록 refresh JWT에 `jti`를 포함했습니다.
- 이슈 579 스펙을 `.agent/specs/579.md`에 정리하고, 동시 rotation/토큰 재발급 회귀 테스트를 추가했습니다.

## 검증

- `git diff --check`
- `cd backend && JAVA_HOME=/Users/owen/.local/share/mise/installs/java/temurin-21.0.11+10.0.LTS ./gradlew test --tests com.init.auth.application.JwtServiceTest --tests com.init.auth.application.AuthServiceTest --tests com.init.auth.application.AuthServiceConcurrencyTest --tests com.init.auth.presentation.AuthControllerTest`
- `cd backend && JAVA_HOME=/Users/owen/.local/share/mise/installs/java/temurin-21.0.11+10.0.LTS ./gradlew spotlessCheck checkstyleMain checkstyleTest`
- `cd backend && JAVA_HOME=/Users/owen/.local/share/mise/installs/java/temurin-21.0.11+10.0.LTS ./gradlew checkstyleTest`
- `cd backend && GRADLE_USER_HOME=/tmp/codex-gradle-ostone-579 JAVA_HOME=/Users/owen/.local/share/mise/installs/java/temurin-21.0.11+10.0.LTS ./gradlew --no-daemon test --rerun-tasks`

## 참고

- 로컬 Husky hook 파일이 executable이 아니어서 commit hook은 실행되지 않았고, 위 검증을 수동으로 실행했습니다.
- 전역 Gradle artifact cache lock 경합이 있어 전체 테스트 강제 실행은 별도 `GRADLE_USER_HOME`으로 분리해 실행했습니다.
- `checkstyleMain checkstyleTest`는 기존 warning-level violations를 출력하지만 Gradle task는 성공했습니다.