### PR TITLE
feat(dx): 개발 도구 버전 기준을 루트 핀으로 통합

### DIFF
--- a/.agent/specs/625.md
+++ b/.agent/specs/625.md
@@ -1,0 +1,70 @@
+# 루트 개발 도구 버전 핀 확장
+
+## Goal
+
+신규 개발자와 CI가 Java, Node.js, pnpm, Python, uv 버전 기준을 루트에서 한 번에 확인하고 같은 기준으로 사용할 수 있게 한다.
+
+## Problem
+
+현재 도구 버전 정보가 여러 파일에 나뉘어 있다.
+
+| 파일 | 현재 역할 |
+| --- | --- |
+| `mise.toml` | Java만 명시 |
+| `frontend/package.json` | frontend pnpm `packageManager` 명시 |
+| `ml/.python-version` | ML Python 버전 명시 |
+| `.github/workflows/ci.yml` | CI Java / Node.js / pnpm / uv setup 값 명시 |
+| `.github/workflows/prod-deploy.yml` | production deploy Java / Node.js / pnpm setup 값 명시 |
+| `README.md` | 설치 요구사항을 큰 범위로만 안내 |
+
+이 때문에 루트에서 필요한 주요 도구 버전을 한 번에 확인하기 어렵고, 로컬과 CI의 setup 값이 서로 다른 기준으로 관리될 수 있다.
+
+## Scope
+
+- `mise.toml`에 Java, Node.js, pnpm, Python, uv 버전을 함께 명시한다.
+- 루트 `package.json`에 pnpm `packageManager` 정책을 명시한다.
+- `README.md`의 사전 요구사항을 실제 핀 파일과 연결한다.
+- `.github/workflows/ci.yml`의 Java / Node.js / pnpm / Python / uv setup 값을 루트 기준과 맞춘다.
+- `.github/workflows/ci.yml`에서 root / frontend / ML / workflow 핀의 일관성을 검증한다.
+- `.github/workflows/prod-deploy.yml`의 Java / Node.js / pnpm setup 값을 루트 기준과 맞춘다.
+
+## Non-Goals
+
+- 애플리케이션 의존성 버전 변경
+- lockfile 재생성
+- Docker 이미지 내부 런타임 버전 변경
+- Terraform CLI 버전 정책 변경
+- 새로운 도구 버전 관리자를 도입하거나 CI 실행 방식을 재구성
+
+## Design Diff
+
+| 영역 | As-is | To-be |
+| --- | --- | --- |
+| 루트 도구 핀 | `mise.toml`에 Java만 표시 | `mise.toml`에 Java / Node.js / pnpm / Python / uv 표시 |
+| root package manager | 루트 `package.json`에 `packageManager` 없음 | 루트 `package.json`에 `pnpm@10.33.0` 명시 |
+| README | Java 21, Node.js + pnpm, uv/Python 3.13+처럼 범위 안내 | 실제 핀 버전과 참조 파일 안내 |
+| CI frontend setup | Node.js `22`, pnpm `10` | Node.js `22.13.0`, pnpm `10.33.0` |
+| CI ML setup | uv setup만 사용 | `ml/.python-version` 기반 Python setup과 uv `0.11.19` setup |
+| CI drift guard | 파일 간 도구 버전 불일치를 별도 검증하지 않음 | `tool-version-check`가 `mise.toml`, package manifests, workflow env, `ml/.python-version` 일관성 검증 |
+
+## Acceptance Criteria
+
+- 신규 개발자는 루트 `mise.toml`에서 Java / Node.js / pnpm / Python / uv 버전을 확인할 수 있다.
+- 루트 `package.json`과 `frontend/package.json`의 `packageManager`가 같은 pnpm 버전을 가리킨다.
+- `mise.toml`의 Python 기준은 `ml/.python-version`과 충돌하지 않는다.
+- CI의 Java / Node.js / pnpm / Python / uv setup 값이 루트 기준과 크게 어긋나지 않는다.
+- CI는 도구 버전 핀 파일 간 불일치를 감지한다.
+- README의 사전 요구사항은 실제 버전 핀 파일을 안내한다.
+
+## Validation Plan
+
+| 구분 | 명령 | 기대 결과 |
+| --- | --- | --- |
+| YAML syntax | `ruby -e 'require "psych"; %w[.github/workflows/ci.yml .github/workflows/prod-deploy.yml].each { |f| Psych.load_file(f) }'` | 변경된 GitHub Actions YAML 파싱 성공 |
+| JSON syntax | `node -e 'JSON.parse(require("fs").readFileSync("package.json", "utf8")); JSON.parse(require("fs").readFileSync("frontend/package.json", "utf8"))'` | root / frontend package manifest 파싱 성공 |
+| Version consistency | `ruby -e 'mise=File.read("mise.toml"); root=File.read("package.json"); fe=File.read("frontend/package.json"); py=File.read("ml/.python-version").strip; abort unless mise.include?("pnpm = \"10.33.0\"") && root.include?("\"packageManager\": \"pnpm@10.33.0\"") && fe.include?("\"packageManager\": \"pnpm@10.33.0\"") && mise.include?("python = \"#{py}\"")'` | pnpm과 Python 기준 일치 확인 |
+| CI drift guard | `ruby` script in `.github/workflows/ci.yml` `tool-version-check` | root / frontend / ML / workflow 핀 불일치 감지 |
+
+## Open Questions
+
+- 없음. 이슈 본문과 현재 파일의 핀 정보만으로 변경 범위가 확인된다.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,13 @@ on:
     branches:
       - main
 
+env:
+  TOOL_JAVA_VERSION: "21"
+  TOOL_NODE_VERSION: "22.13.0"
+  TOOL_PNPM_VERSION: "10.33.0"
+  TOOL_PYTHON_VERSION_FILE: "ml/.python-version"
+  TOOL_UV_VERSION: "0.11.19"
+
 jobs:
   paths-filter:
     runs-on: ubuntu-latest
@@ -23,12 +30,17 @@ jobs:
           filters: |
             backend:
               - 'backend/**'
+              - 'mise.toml'
               - '.github/workflows/ci.yml'
             frontend:
               - 'frontend/**'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'mise.toml'
               - '.github/workflows/ci.yml'
             ml:
               - 'ml/**'
+              - 'mise.toml'
               - '.github/workflows/ci.yml'
 
   spec-check:
@@ -67,6 +79,53 @@ jobs:
           fi
           echo "✅ Spec file found: $SPEC_FILE"
 
+  tool-version-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check tool version pin consistency
+        run: |
+          ruby <<'RUBY'
+          require "json"
+          require "yaml"
+
+          mise_tools = File.read("mise.toml").scan(/^(\w+)\s*=\s*"([^"]+)"/).to_h
+          root_package = JSON.parse(File.read("package.json"))
+          frontend_package = JSON.parse(File.read("frontend/package.json"))
+          python_version = File.read("ml/.python-version").strip
+          ci_env = YAML.load_file(".github/workflows/ci.yml").fetch("env")
+          prod_env = YAML.load_file(".github/workflows/prod-deploy.yml").fetch("env")
+
+          expected = {
+            "TOOL_JAVA_VERSION" => "21",
+            "TOOL_NODE_VERSION" => "22.13.0",
+            "TOOL_PNPM_VERSION" => "10.33.0",
+            "TOOL_PYTHON_VERSION_FILE" => "ml/.python-version",
+            "TOOL_UV_VERSION" => "0.11.19",
+          }
+
+          failures = []
+          expected.each do |key, value|
+            failures << ".github/workflows/ci.yml env #{key} must be #{value}" unless ci_env[key] == value
+          end
+          expected.slice("TOOL_JAVA_VERSION", "TOOL_NODE_VERSION", "TOOL_PNPM_VERSION").each do |key, value|
+            failures << ".github/workflows/prod-deploy.yml env #{key} must be #{value}" unless prod_env[key] == value
+          end
+          failures << "mise.toml java must be temurin-21" unless mise_tools["java"] == "temurin-21"
+          failures << "mise.toml node must be #{expected["TOOL_NODE_VERSION"]}" unless mise_tools["node"] == expected["TOOL_NODE_VERSION"]
+          failures << "mise.toml pnpm must be #{expected["TOOL_PNPM_VERSION"]}" unless mise_tools["pnpm"] == expected["TOOL_PNPM_VERSION"]
+          failures << "mise.toml python must match ml/.python-version" unless mise_tools["python"] == python_version
+          failures << "mise.toml uv must be #{expected["TOOL_UV_VERSION"]}" unless mise_tools["uv"] == expected["TOOL_UV_VERSION"]
+          failures << "root packageManager must match pnpm #{expected["TOOL_PNPM_VERSION"]}" unless root_package["packageManager"] == "pnpm@#{expected["TOOL_PNPM_VERSION"]}"
+          failures << "frontend packageManager must match pnpm #{expected["TOOL_PNPM_VERSION"]}" unless frontend_package["packageManager"] == "pnpm@#{expected["TOOL_PNPM_VERSION"]}"
+
+          if failures.any?
+            puts failures.join("\n")
+            exit 1
+          end
+          RUBY
+
   backend:
     needs: paths-filter
     if: ${{ github.event_name == 'workflow_dispatch' || needs.paths-filter.outputs.backend == 'true' }}
@@ -91,7 +150,7 @@ jobs:
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: "21"
+          java-version: ${{ env.TOOL_JAVA_VERSION }}
           distribution: "temurin"
 
       - name: Install pgvector extension
@@ -118,12 +177,12 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10
+          version: ${{ env.TOOL_PNPM_VERSION }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: ${{ env.TOOL_NODE_VERSION }}
           cache: "pnpm"
           cache-dependency-path: "./frontend/pnpm-lock.yaml"
 
@@ -146,8 +205,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: ${{ env.TOOL_PYTHON_VERSION_FILE }}
+
       - name: Setup uv
         uses: astral-sh/setup-uv@v5
+        with:
+          version: ${{ env.TOOL_UV_VERSION }}
 
       - name: Sync dependencies
         working-directory: ./ml
@@ -169,7 +235,7 @@ jobs:
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: "21"
+          java-version: ${{ env.TOOL_JAVA_VERSION }}
           distribution: "temurin"
 
       - name: Cache SonarQube packages
@@ -205,18 +271,18 @@ jobs:
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: "21"
+          java-version: ${{ env.TOOL_JAVA_VERSION }}
           distribution: "temurin"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10
+          version: ${{ env.TOOL_PNPM_VERSION }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: ${{ env.TOOL_NODE_VERSION }}
           cache: "pnpm"
           cache-dependency-path: "./frontend/pnpm-lock.yaml"
 
@@ -251,11 +317,18 @@ jobs:
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: "21"
+          java-version: ${{ env.TOOL_JAVA_VERSION }}
           distribution: "temurin"
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: ${{ env.TOOL_PYTHON_VERSION_FILE }}
 
       - name: Setup uv
         uses: astral-sh/setup-uv@v5
+        with:
+          version: ${{ env.TOOL_UV_VERSION }}
 
       - name: Sync dependencies
         working-directory: ./ml
@@ -278,7 +351,7 @@ jobs:
 
   ci-gate:
     if: always()
-    needs: [paths-filter, spec-check, backend, frontend, ml, backend-sonar, frontend-sonar, ml-sonar]
+    needs: [paths-filter, spec-check, tool-version-check, backend, frontend, ml, backend-sonar, frontend-sonar, ml-sonar]
     runs-on: ubuntu-latest
     steps:
       - name: Check CI results
@@ -286,6 +359,7 @@ jobs:
           results=(
             "${{ needs.paths-filter.result }}"
             "${{ needs.spec-check.result }}"
+            "${{ needs.tool-version-check.result }}"
             "${{ needs.backend.result }}"
             "${{ needs.frontend.result }}"
             "${{ needs.ml.result }}"

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -15,6 +15,11 @@ concurrency:
   group: production-${{ github.ref }}
   cancel-in-progress: false
 
+env:
+  TOOL_JAVA_VERSION: "21"
+  TOOL_NODE_VERSION: "22.13.0"
+  TOOL_PNPM_VERSION: "10.33.0"
+
 permissions:
   contents: read
   id-token: write
@@ -196,7 +201,7 @@ jobs:
 
       - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9
         with:
-          java-version: "21"
+          java-version: ${{ env.TOOL_JAVA_VERSION }}
           distribution: "temurin"
 
       - name: Build with Gradle
@@ -365,11 +370,11 @@ jobs:
 
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1
         with:
-          version: 10
+          version: ${{ env.TOOL_PNPM_VERSION }}
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
-          node-version: "22"
+          node-version: ${{ env.TOOL_NODE_VERSION }}
           cache: "pnpm"
           cache-dependency-path: frontend/pnpm-lock.yaml
 

--- a/README.md
+++ b/README.md
@@ -355,9 +355,11 @@ workflow는 발화 트리가 아니라 **상태 기반 graph(state machine)**로
 ### 사전 요구사항
 
 - **Java 21** (Backend)
-- **Node.js + pnpm** (Frontend)
-- **uv** (ML, Python 3.13+)
+- **Node.js 22.13.0 + pnpm 10.33.0** (Frontend)
+- **Python 3.13 + uv 0.11.19** (ML)
 - **Docker / Docker Compose** (전체 스택)
+
+개발 도구 버전은 루트 [`mise.toml`](mise.toml)에서 한 번에 확인한다. 루트 [`package.json`](package.json)과 [`frontend/package.json`](frontend/package.json)의 `packageManager`는 같은 pnpm 버전을 사용하며, Python 기준은 [`ml/.python-version`](ml/.python-version)과 일치한다. GitHub Actions의 Java / Node.js / pnpm / Python / uv setup도 이 루트 기준과 동일한 버전을 사용한다.
 
 ### 환경 변수 (`.env.example` 그룹)
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,6 @@
 [tools]
 java = "temurin-21"
+node = "22.13.0"
+pnpm = "10.33.0"
+python = "3.13"
+uv = "0.11.19"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "ajou-2026-1-capstone-5",
   "private": true,
+  "packageManager": "pnpm@10.33.0",
   "scripts": {
     "prepare": "husky",
     "format": "prettier --write ."


### PR DESCRIPTION
Closes #625

## 변경 사항

- 루트 `mise.toml`에서 Java / Node.js / pnpm / Python / uv 버전을 함께 확인할 수 있도록 확장했습니다.
- 루트 `package.json`에 `packageManager`를 명시해 frontend와 같은 pnpm 버전 정책을 사용하도록 했습니다.
- README 사전 요구사항을 실제 도구 핀 파일과 연결했습니다.
- CI와 production deploy workflow의 Java / Node.js / pnpm / Python / uv setup 값을 루트 기준과 맞추고, `tool-version-check`로 핀 불일치를 감지하도록 했습니다.
- 이슈 625 스펙을 `.agent/specs/625.md`에 정리했습니다.

## 검증

- `git diff --check`
- `actionlint .github/workflows/ci.yml .github/workflows/prod-deploy.yml`
- `ruby -e 'require "psych"; %w[.github/workflows/ci.yml .github/workflows/prod-deploy.yml].each { |f| Psych.load_file(f) }'`
- `node -e 'JSON.parse(require("fs").readFileSync("package.json", "utf8")); JSON.parse(require("fs").readFileSync("frontend/package.json", "utf8"))'`
- `ruby` consistency script matching the new `.github/workflows/ci.yml` `tool-version-check`
- `mise ls-remote uv 0.11.19 && mise ls-remote node 22.13.0 && mise ls-remote pnpm 10.33.0`