### PR TITLE
feat(dx): backend 테스트 DB 전략을 CI 재현 경로로 분리

### DIFF
--- a/.agent/specs/622.md
+++ b/.agent/specs/622.md
@@ -1,0 +1,71 @@
+# Backend 테스트 DB 전략 정리
+
+## Goal
+
+Backend 테스트 실행 경로를 H2 기반 빠른 검증과 PostgreSQL/Liquibase 기반 CI 재현 검증으로 명확히 분리해, 문서와 CI가 같은 테스트 DB 전략을 설명하도록 정렬한다.
+
+## Problem
+
+README와 AGENTS 문서는 backend 테스트가 H2 인메모리 DB와 Liquibase 비활성화를 사용한다고 설명한다. 반면 CI backend job은 `pgvector/pgvector:pg16` 서비스를 띄우고 PostgreSQL 연결 정보와 Liquibase 활성 조건을 주입한 뒤 backend build를 수행한다. 이 차이 때문에 CI에서 실패한 backend 테스트를 로컬에서 어떤 DB 조건으로 재현해야 하는지 불명확하다.
+
+## Scope
+
+- Backend Gradle 테스트 task를 H2 기본 경로와 PostgreSQL 재현 경로로 구분한다.
+- CI backend job이 PostgreSQL/Liquibase 재현 경로를 명시적으로 실행하도록 정리한다.
+- README, AGENTS, backend README에 H2와 PostgreSQL 테스트의 목적, Liquibase 활성 조건, 로컬 재현 방법을 같은 기준으로 문서화한다.
+
+## Non-goals
+
+- 개별 테스트 클래스를 H2 전용/ PostgreSQL 전용 suite로 재분류하지 않는다.
+- PostgreSQL schema나 Liquibase changelog를 변경하지 않는다.
+- frontend, ML, production deploy workflow의 테스트 전략은 변경하지 않는다.
+
+## Affected Paths
+
+- `backend/build.gradle.kts`
+- `.github/workflows/ci.yml`
+- `README.md`
+- `AGENTS.md`
+- `backend/README.md`
+
+## Requirements
+
+1. `./gradlew test`는 기존처럼 빠른 로컬 검증 경로로 유지한다.
+2. `./gradlew testH2`는 H2 인메모리 DB와 Liquibase 비활성 조건을 사용하는 기본 테스트 경로를 명시적으로 가리킨다.
+3. `./gradlew testPg`는 PostgreSQL 연결, Liquibase 활성화, Hibernate `ddl-auto=validate` 조건으로 backend 테스트를 실행한다.
+4. `testPg`는 CI와 로컬 재현이 같은 환경 변수 이름을 사용해야 한다.
+5. CI backend job은 PostgreSQL/pgvector 서비스 준비 후 `testPg`를 실행해, 실패한 backend 테스트를 로컬에서 같은 DB 조건으로 재현할 수 있어야 한다.
+6. 문서는 H2 테스트와 PostgreSQL 테스트의 목적, Liquibase 활성/비활성 조건, CI 재현 커맨드를 구분해서 설명해야 한다.
+7. 문서는 로컬 PostgreSQL 재현을 위해 `pgvector/pgvector:pg16` DB와 `vector` extension 준비가 필요함을 설명해야 한다.
+
+## Test DB Contract
+
+| 경로 | 목적 | DB | Liquibase | Hibernate DDL |
+| --- | --- | --- | --- | --- |
+| `./gradlew test` | 빠른 로컬 단위/슬라이스 검증 | H2 in-memory | disabled | `create-drop` |
+| `./gradlew testH2` | H2 기본 경로를 명시적으로 호출 | H2 in-memory | disabled | `create-drop` |
+| `./gradlew testPg` | 통합/CI 재현 검증 | PostgreSQL/pgvector | enabled | `validate` |
+
+## Data/API Impact
+
+- API 계약, database schema, migration 파일은 변경하지 않는다.
+- CI backend job의 실행 커맨드와 Gradle verification task만 변경한다.
+
+## Acceptance Criteria
+
+- CI backend job이 PostgreSQL/Liquibase 조건을 `testPg` task 이름으로 드러낸다.
+- `./gradlew testH2`와 `./gradlew testPg`가 Gradle task 목록에서 확인된다.
+- README, AGENTS, backend README가 더 이상 backend 테스트를 H2 단일 전략으로 설명하지 않는다.
+- Liquibase는 H2 경로에서 비활성, PostgreSQL 경로에서 활성으로 설명된다.
+- CI 실패 재현 절차가 PostgreSQL/pgvector 준비 후 `./gradlew testPg` 실행으로 문서화된다.
+
+## Validation
+
+- `cd backend && ./gradlew tasks --all`
+- `cd backend && ./gradlew test --dry-run`
+- `cd backend && ./gradlew testPg --dry-run`
+- CI 변경은 pull request backend job에서 `testPg` 실행으로 검증한다.
+
+## Open Questions
+
+- H2 전용 테스트와 PostgreSQL 전용 테스트를 tag 또는 source set으로 물리 분리할지는 후속 결정으로 남긴다.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,9 +97,9 @@ jobs:
       - name: Install pgvector extension
         run: docker exec "${{ job.services.postgres.id }}" psql -U postgres -d testdb -c "CREATE EXTENSION IF NOT EXISTS vector;"
 
-      - name: Build Backend
+      - name: Build Backend with PostgreSQL test DB
         working-directory: ./backend
-        run: ./gradlew build -x checkstyleMain -x checkstyleTest
+        run: ./gradlew testPg build -x test -x checkstyleMain -x checkstyleTest
         env:
           SPRING_DATASOURCE_URL: jdbc:postgresql://localhost:5432/testdb
           SPRING_DATASOURCE_USERNAME: postgres

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,7 +196,8 @@ docker compose logs -f airflow-apiserver
 | 목적            | 커맨드                                    |
 | --------------- | ----------------------------------------- |
 | 빌드            | `./gradlew build`                         |
-| 테스트          | `./gradlew test`                          |
+| 빠른 H2 테스트  | `./gradlew test` 또는 `./gradlew testH2`  |
+| PostgreSQL 테스트 | `./gradlew testPg`                      |
 | 실행            | `./gradlew bootRun`                       |
 | JAR 패키징      | `./gradlew bootJar`                       |
 | 코드 포맷팅     | `./gradlew spotlessApply`                 |
@@ -207,7 +208,19 @@ docker compose logs -f airflow-apiserver
 
 - `default`: PostgreSQL + Liquibase
 - `local`: SQL 로깅 활성화 (`application-local.yml`)
-- `test`: H2 인메모리 + Liquibase 비활성화
+- `test`: 기본 테스트 리소스 기준 H2 인메모리 + Liquibase 비활성화
+
+**테스트 DB 전략**:
+
+- `./gradlew test`와 `./gradlew testH2`는 빠른 단위/슬라이스 검증용 기본 경로이며, `backend/src/test/resources/application.yml`의 H2 인메모리 DB와 Hibernate `create-drop`을 사용하고 Liquibase를 비활성화한다.
+- `./gradlew testPg`는 통합/CI 재현용 경로이며, PostgreSQL에 연결하고 Liquibase를 활성화한 뒤 Hibernate `ddl-auto=validate`로 검증한다. 기본 연결값은 `jdbc:postgresql://localhost:5432/testdb`, `postgres/postgres`이며 필요하면 `SPRING_DATASOURCE_URL`, `SPRING_DATASOURCE_USERNAME`, `SPRING_DATASOURCE_PASSWORD`로 덮어쓴다.
+- CI backend job은 `pgvector/pgvector:pg16` 서비스를 띄우고 `CREATE EXTENSION IF NOT EXISTS vector;`를 적용한 뒤 `./gradlew testPg build -x test -x checkstyleMain -x checkstyleTest`를 실행한다. CI 실패를 로컬에서 같은 조건으로 재현하려면 동일한 PostgreSQL/pgvector DB를 준비한 뒤 `./gradlew testPg`를 실행한다.
+
+```bash
+docker run --rm --name ostone-test-pg -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=testdb -p 5432:5432 -d pgvector/pgvector:pg16
+docker exec ostone-test-pg psql -U postgres -d testdb -c "CREATE EXTENSION IF NOT EXISTS vector;"
+(cd backend && ./gradlew testPg)
+```
 
 ### Frontend (pnpm)
 
@@ -274,10 +287,11 @@ ml: # uv sync && uv run pytest
 
 **Gotchas**:
 
-- CI: `./gradlew build -x checkstyleMain -x checkstyleTest` (체크스타일 스킵)
+- CI: `./gradlew testPg build -x test -x checkstyleMain -x checkstyleTest` (PostgreSQL/Liquibase 테스트 + 체크스타일 스킵)
   - 실제 빌드 영향 없음, CI 속도 최적화를 위한 건너뛰기
   - 로컬에서는 `./gradlew check`로 전체 검사 권장
-- 테스트: H2 인메모리 (`jdbc:h2:mem:testdb`) 사용, Liquibase 비활성화
+- 기본 테스트: H2 인메모리 (`jdbc:h2:mem:testdb`) 사용, Liquibase 비활성화
+- CI 재현 테스트: `./gradlew testPg`로 PostgreSQL + Liquibase 활성화 조건 사용
 - CORS 기본 허용: `http://localhost:5173` (프론트 개발 서버)
 
 ### Docker 이미지 빌드

--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ Backend는 `local` 프로필에서 springdoc 기반 OpenAPI 문서/Swagger UI를
 
 | 모듈 | 빌드 | 테스트 |
 | --- | --- | --- |
-| Backend | `(cd backend && ./gradlew build)` | `(cd backend && ./gradlew test)` |
+| Backend | `(cd backend && ./gradlew build)` | H2: `(cd backend && ./gradlew test)` / PostgreSQL: `(cd backend && ./gradlew testPg)` |
 | Frontend | `(cd frontend && pnpm build)` | `(cd frontend && pnpm test)` |
 | ML | `(cd ml && uv sync)` | `(cd ml && uv run pytest)` |
 
@@ -430,11 +430,18 @@ Backend는 `local` 프로필에서 springdoc 기반 OpenAPI 문서/Swagger UI를
 ### CI
 
 - **paths-filter**: 변경 파일에 따라 관련 모듈만 빌드/테스트한다.
-  - `backend`: `./gradlew build -x checkstyleMain -x checkstyleTest` (CI 속도 최적화용 체크스타일 스킵)
+  - `backend`: `./gradlew testPg build -x test -x checkstyleMain -x checkstyleTest` (PostgreSQL/Liquibase 테스트 후 CI 속도 최적화용 체크스타일 스킵)
   - `frontend`: `pnpm install && pnpm test && pnpm build`
   - `ml`: `uv sync && uv run pytest`
 - **spec-check**: `feature/*`, `fix/*`, `spec/*` 브랜치는 `.agent/specs/{이슈번호}.md` 스펙 파일을 필수 검증한다.
-- 테스트는 H2 인메모리(`jdbc:h2:mem:testdb`)를 사용하고 Liquibase를 비활성화한다.
+- Backend의 빠른 로컬 테스트(`./gradlew test` 또는 `./gradlew testH2`)는 H2 인메모리(`jdbc:h2:mem:testdb`)를 사용하고 Liquibase를 비활성화한다.
+- Backend의 CI 재현 테스트(`./gradlew testPg`)는 PostgreSQL/pgvector DB에 연결하고 Liquibase를 활성화한 뒤 Hibernate `ddl-auto=validate`로 검증한다. 기본 로컬 연결값은 `jdbc:postgresql://localhost:5432/testdb`, `postgres/postgres`이며 `SPRING_DATASOURCE_URL`, `SPRING_DATASOURCE_USERNAME`, `SPRING_DATASOURCE_PASSWORD`로 덮어쓸 수 있다.
+
+```bash
+docker run --rm --name ostone-test-pg -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=testdb -p 5432:5432 -d pgvector/pgvector:pg16
+docker exec ostone-test-pg psql -U postgres -d testdb -c "CREATE EXTENSION IF NOT EXISTS vector;"
+(cd backend && ./gradlew testPg)
+```
 
 ### 정적 분석 / 품질 게이트
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -43,6 +43,9 @@ infrastructure/  → JPA Repository, External Client, Config
 # 테스트
 ./gradlew test
 
+# CI와 같은 PostgreSQL/Liquibase 조건 테스트
+./gradlew testPg
+
 # 실행
 ./gradlew bootRun
 
@@ -80,4 +83,17 @@ Liquibase로 스키마 관리됩니다.
 
 - `default`: PostgreSQL 연결
 - `local`: 로컬 개발용 (SQL 로깅 활성화)
-- `test`: 테스트용 (H2 인메모리)
+- `test`: 기본 테스트 리소스 기준 H2 인메모리
+
+## 테스트 DB 전략
+
+- `./gradlew test`와 `./gradlew testH2`는 빠른 단위/슬라이스 검증용 경로입니다. `src/test/resources/application.yml`의 H2 인메모리 DB를 사용하고 Liquibase를 비활성화합니다.
+- `./gradlew testPg`는 통합/CI 재현용 경로입니다. PostgreSQL/pgvector DB에 연결하고 Liquibase를 활성화한 뒤 Hibernate `ddl-auto=validate`로 검증합니다.
+- `testPg`의 기본 연결값은 `jdbc:postgresql://localhost:5432/testdb`, `postgres/postgres`입니다. 다른 DB를 사용할 때는 `SPRING_DATASOURCE_URL`, `SPRING_DATASOURCE_USERNAME`, `SPRING_DATASOURCE_PASSWORD`를 지정합니다.
+- CI backend job은 `pgvector/pgvector:pg16` 서비스에 `vector` extension을 만든 뒤 `./gradlew testPg build -x test -x checkstyleMain -x checkstyleTest`를 실행합니다.
+
+```bash
+docker run --rm --name ostone-test-pg -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=testdb -p 5432:5432 -d pgvector/pgvector:pg16
+docker exec ostone-test-pg psql -U postgres -d testdb -c "CREATE EXTENSION IF NOT EXISTS vector;"
+./gradlew testPg
+```

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -62,6 +62,41 @@ tasks.withType<Test> {
     useJUnitPlatform()
 }
 
+tasks.register("testH2") {
+    group = "verification"
+    description = "Runs the backend test suite with the default H2 in-memory test database."
+    dependsOn(tasks.test)
+}
+
+tasks.register<Test>("testPg") {
+    group = "verification"
+    description = "Runs the backend test suite against PostgreSQL with Liquibase enabled."
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    shouldRunAfter(tasks.test)
+    environment(
+        mapOf(
+            "SPRING_DATASOURCE_URL" to
+                providers.environmentVariable("SPRING_DATASOURCE_URL")
+                    .orElse("jdbc:postgresql://localhost:5432/testdb")
+                    .get(),
+            "SPRING_DATASOURCE_USERNAME" to
+                providers.environmentVariable("SPRING_DATASOURCE_USERNAME")
+                    .orElse("postgres")
+                    .get(),
+            "SPRING_DATASOURCE_PASSWORD" to
+                providers.environmentVariable("SPRING_DATASOURCE_PASSWORD")
+                    .orElse("postgres")
+                    .get(),
+            "SPRING_DATASOURCE_DRIVER_CLASS_NAME" to "org.postgresql.Driver",
+            "SPRING_JPA_PROPERTIES_HIBERNATE_DIALECT" to
+                "org.hibernate.dialect.PostgreSQLDialect",
+            "SPRING_LIQUIBASE_ENABLED" to "true",
+            "SPRING_JPA_HIBERNATE_DDL_AUTO" to "validate",
+        ),
+    )
+}
+
 tasks.bootJar {
     archiveFileName.set("app.jar")
 }


### PR DESCRIPTION
Closes #622

## 변경 사항

- Backend Gradle에 H2 기본 테스트 경로를 명시하는 `testH2`와 PostgreSQL/Liquibase 조건을 주입하는 `testPg` task를 추가했습니다.
- CI backend job이 `pgvector/pgvector:pg16` 서비스와 `vector` extension 준비 후 `testPg build -x test -x checkstyleMain -x checkstyleTest`를 실행하도록 정리했습니다.
- README, AGENTS, backend README에서 H2 빠른 테스트와 PostgreSQL/pgvector CI 재현 테스트의 목적, Liquibase 활성 조건, 로컬 재현 절차를 같은 기준으로 설명했습니다.
- 이슈 622 스펙을 `.agent/specs/622.md`에 정리했습니다.

## 검증

- `git diff --check`
- `ruby -e 'require "psych"; Psych.load_file(".github/workflows/ci.yml"); puts "yaml ok"'`
- `actionlint .github/workflows/ci.yml`
- `cd backend && PATH="$JAVA_HOME/bin:$PATH" GRADLE_USER_HOME=/tmp/ostone-gradle-622 ./gradlew --no-daemon --no-watch-fs tasks --all`

## 참고

- `test` / `testPg --dry-run`은 로컬 Gradle toolchain 감지가 JDK 21을 찾지 못해 의존성 해석 단계에서 중단되었습니다. `tasks --all`로 Gradle DSL 평가와 `testH2`/`testPg` task 등록은 확인했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 백엔드 테스트 DB 전략 문서화 추가 (H2 및 PostgreSQL 경로 분리)
  * 테스트 실행 명령어 및 CI 재현 방법 업데이트

* **Chores**
  * H2 기반 빠른 테스트(`testH2`) 및 PostgreSQL 통합 테스트(`testPg`) Gradle 태스크 추가
  * CI 파이프라인에 PostgreSQL pgvector 지원 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->