### PR TITLE
fix(auth): reset-required 로그인 응답에서 재설정 토큰 제외

### DIFF
--- a/.agent/specs/570.md
+++ b/.agent/specs/570.md
@@ -1,0 +1,119 @@
+# Issue 570: reset-required 로그인 응답의 재설정 토큰 노출 제한
+
+## Goal
+
+비밀번호 재설정이 필요한 로그인 흐름에서 public HTTP 응답에 raw password reset token이 포함되지 않도록 하고, 클라이언트가 `PASSWORD_RESET_REQUIRED` 코드와 메시지만으로 재설정 필요 상태를 처리하도록 응답 계약을 정리한다.
+
+## Background
+
+현재 로그인 시 사용자가 `passwordResetRequired` 상태이면 백엔드가 새 reset token을 생성해 사용자 계정에 저장한 뒤 `PasswordResetRequiredException`을 던진다. `AuthExceptionHandler`는 이 예외를 `PasswordResetRequiredResponse`로 변환하면서 raw token을 `resetToken` 필드로 반환한다.
+
+반면 `POST /api/v1/auth/password-reset/init`은 응답 본문에 토큰을 포함하지 않고 안내 메시지만 반환하며, 컨트롤러에는 이메일 등 외부 전달 채널로 토큰을 보내는 TODO가 남아 있다. 두 흐름의 public 응답 보안 모델이 서로 다르므로 로그인 오류 응답에서도 raw token을 제거해야 한다.
+
+## Verified Paths
+
+| Path | Purpose |
+| --- | --- |
+| `backend/src/main/java/com/init/auth/application/AuthService.java` | reset-required 로그인에서 reset token 생성 및 저장 |
+| `backend/src/main/java/com/init/auth/application/exception/PasswordResetRequiredException.java` | reset-required 상태를 나타내는 auth 예외 |
+| `backend/src/main/java/com/init/auth/presentation/AuthExceptionHandler.java` | reset-required 예외를 HTTP 응답으로 변환 |
+| `backend/src/main/java/com/init/shared/presentation/dto/ErrorResponse.java` | 공통 에러 응답 계약 |
+| `backend/src/test/java/com/init/auth/application/AuthServiceTest.java` | auth 서비스 단위 테스트 |
+| `backend/src/test/java/com/init/auth/presentation/AuthControllerTest.java` | auth 컨트롤러 슬라이스 테스트 |
+| `frontend/src/features/auth/ui/login-form/LoginForm.tsx` | `PASSWORD_RESET_REQUIRED` 코드 처리 |
+
+## Current Sequence
+
+```mermaid
+sequenceDiagram
+    actor c as Client
+    participant ctrl as AuthController
+    participant svc as AuthService
+    participant repo as AppUserRepository
+    participant advice as AuthExceptionHandler
+
+    c ->> ctrl: POST /api/v1/auth/login
+    ctrl ->> svc: login(command)
+    svc ->> repo: findByEmail(email)
+    repo -->> svc: AppUser(passwordResetRequired=true)
+    svc ->> svc: generate raw reset token
+    svc ->> repo: save(user with reset token hash)
+    svc -->> advice: PasswordResetRequiredException
+    advice -->> c: 403 { code, message, resetToken }
+```
+
+## Target Sequence
+
+```mermaid
+sequenceDiagram
+    actor c as Client
+    participant ctrl as AuthController
+    participant svc as AuthService
+    participant repo as AppUserRepository
+    participant advice as AuthExceptionHandler
+
+    c ->> ctrl: POST /api/v1/auth/login
+    ctrl ->> svc: login(command)
+    svc ->> repo: findByEmail(email)
+    repo -->> svc: AppUser(passwordResetRequired=true)
+    svc ->> svc: generate raw reset token
+    svc ->> repo: save(user with reset token hash)
+    svc -->> advice: PasswordResetRequiredException
+    advice -->> c: 403 { code, message }
+```
+
+## REST API Contract
+
+### POST `/api/v1/auth/login`
+
+When credentials are valid but the account requires password reset:
+
+**403 Forbidden**
+
+```json
+{
+  "code": "PASSWORD_RESET_REQUIRED",
+  "message": "비밀번호 재설정이 필요합니다."
+}
+```
+
+The response must not include `resetToken`, `rawToken`, `token`, or any equivalent raw password reset secret.
+
+## Scope
+
+- Replace the reset-required login error response body with the common `(code, message)` error shape.
+- Keep the `PASSWORD_RESET_REQUIRED` error code and `403 Forbidden` status.
+- Keep the existing token hash persistence behavior inside `AuthService` unless implementation review finds a direct security regression.
+- Update backend tests so they fail if `resetToken` is present in the public login response.
+
+## Non-Goals
+
+- Implement an email delivery service for password reset tokens.
+- Add a development-only reset token exposure mode.
+- Change `/api/v1/auth/password-reset/init` or `/api/v1/auth/password-reset/complete` request/response semantics.
+- Change frontend password reset pages or generated API files unless the backend contract change requires regeneration.
+
+## Affected Module
+
+- Bounded context: `auth`
+- Backend layer impact: `application` exception contract, `presentation` response mapping, and backend tests
+- Database impact: none
+- Frontend impact: no behavior change expected because the login form checks `PASSWORD_RESET_REQUIRED` by error code and does not read a reset token.
+
+## Acceptance Criteria
+
+- `POST /api/v1/auth/login` returns `403 Forbidden` with `code=PASSWORD_RESET_REQUIRED` and a user-facing `message` when password reset is required.
+- The public login error response contains no raw reset token field.
+- The response contract is represented by the common error response shape or an equivalent DTO without token fields.
+- A backend test verifies both the error code and absence of `resetToken`.
+- Existing successful login, invalid credential, password reset init, and password reset complete flows are not intentionally changed.
+
+## Validation Plan
+
+- Run the focused auth controller test that covers reset-required login.
+- Run the relevant backend auth tests or the full backend test suite when feasible.
+- Confirm `rg` finds no `resetToken` field in a reset-required response DTO after the change.
+
+## Open Questions
+
+- The repository still lacks a concrete out-of-band password reset delivery implementation. This issue can align the public response contract now, but operational delivery remains a separate follow-up unless another issue covers it.

--- a/backend/src/main/java/com/init/auth/application/AuthService.java
+++ b/backend/src/main/java/com/init/auth/application/AuthService.java
@@ -70,7 +70,7 @@ public class AuthService {
       OffsetDateTime expiresAt = OffsetDateTime.now().plusMinutes(30);
       user.initiatePasswordReset(tokenHash, expiresAt);
       userRepository.save(user);
-      throw new PasswordResetRequiredException("비밀번호 재설정이 필요합니다.", rawToken);
+      throw new PasswordResetRequiredException("비밀번호 재설정이 필요합니다.");
     }
 
     return issueTokens(user);

--- a/backend/src/main/java/com/init/auth/application/exception/PasswordResetRequiredException.java
+++ b/backend/src/main/java/com/init/auth/application/exception/PasswordResetRequiredException.java
@@ -3,14 +3,7 @@ package com.init.auth.application.exception;
 import com.init.shared.application.exception.UnauthorizedException;
 
 public class PasswordResetRequiredException extends UnauthorizedException {
-  private final String resetToken;
-
-  public PasswordResetRequiredException(String message, String resetToken) {
+  public PasswordResetRequiredException(String message) {
     super("PASSWORD_RESET_REQUIRED", message);
-    this.resetToken = resetToken;
-  }
-
-  public String getResetToken() {
-    return resetToken;
   }
 }

--- a/backend/src/main/java/com/init/auth/presentation/AuthExceptionHandler.java
+++ b/backend/src/main/java/com/init/auth/presentation/AuthExceptionHandler.java
@@ -1,7 +1,7 @@
 package com.init.auth.presentation;
 
 import com.init.auth.application.exception.PasswordResetRequiredException;
-import com.init.auth.presentation.dto.PasswordResetRequiredResponse;
+import com.init.shared.presentation.dto.ErrorResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -11,9 +11,9 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class AuthExceptionHandler {
 
   @ExceptionHandler(PasswordResetRequiredException.class)
-  public ResponseEntity<PasswordResetRequiredResponse> handlePasswordResetRequired(
+  public ResponseEntity<ErrorResponse> handlePasswordResetRequired(
       PasswordResetRequiredException ex) {
     return ResponseEntity.status(HttpStatus.FORBIDDEN)
-        .body(new PasswordResetRequiredResponse(ex.getCode(), ex.getMessage(), ex.getResetToken()));
+        .body(new ErrorResponse(ex.getCode(), ex.getMessage()));
   }
 }

--- a/backend/src/main/java/com/init/auth/presentation/dto/PasswordResetRequiredResponse.java
+++ b/backend/src/main/java/com/init/auth/presentation/dto/PasswordResetRequiredResponse.java
@@ -1,3 +1,0 @@
-package com.init.auth.presentation.dto;
-
-public record PasswordResetRequiredResponse(String code, String message, String resetToken) {}

--- a/backend/src/test/java/com/init/auth/application/AuthServiceTest.java
+++ b/backend/src/test/java/com/init/auth/application/AuthServiceTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.verify;
 import com.init.auth.application.exception.EmailAlreadyExistsException;
 import com.init.auth.application.exception.InvalidCredentialsException;
 import com.init.auth.application.exception.InvalidTokenException;
+import com.init.auth.application.exception.PasswordResetRequiredException;
 import com.init.auth.domain.model.AppUser;
 import com.init.auth.domain.model.RefreshToken;
 import com.init.auth.domain.model.UserStatus;
@@ -168,6 +169,29 @@ class AuthServiceTest {
     assertThatThrownBy(() -> authService.login(command))
         .isInstanceOf(InvalidCredentialsException.class)
         .hasMessageContaining("비활성화된 계정입니다.");
+  }
+
+  @Test
+  @DisplayName("login: 비밀번호 재설정 필요 → reset token hash 저장 후 PasswordResetRequiredException 발생")
+  void should_재설정토큰저장하고예외발생_when_비밀번호재설정필요() {
+    // given
+    LoginCommand command = new LoginCommand("hong@example.com", "password123");
+
+    AppUser user = AppUser.create("홍길동", "hong@example.com", "$2a$10$hashedpassword");
+    ReflectionTestUtils.setField(user, "id", 1L);
+    ReflectionTestUtils.setField(user, "passwordResetRequired", true);
+    given(userRepository.findByEmail("hong@example.com")).willReturn(Optional.of(user));
+    given(passwordEncoder.matches("password123", "$2a$10$hashedpassword")).willReturn(true);
+    given(tokenHasher.hash(anyString())).willReturn("sha256-reset-hash");
+
+    // when & then
+    assertThatThrownBy(() -> authService.login(command))
+        .isInstanceOf(PasswordResetRequiredException.class)
+        .hasMessageContaining("비밀번호 재설정이 필요합니다.");
+    assertThat(user.isPasswordResetTokenValid()).isTrue();
+    verify(userRepository).save(user);
+    verify(jwtService, never()).generateAccessToken(any(), anyString(), anyString());
+    verify(refreshTokenRepository, never()).save(any());
   }
 
   // ── refresh ───────────────────────────────────────────────────────────────

--- a/backend/src/test/java/com/init/auth/presentation/AuthControllerTest.java
+++ b/backend/src/test/java/com/init/auth/presentation/AuthControllerTest.java
@@ -215,11 +215,11 @@ class AuthControllerTest {
   }
 
   @Test
-  @DisplayName("login: 비밀번호 재설정 필요 → 403 Forbidden, PASSWORD_RESET_REQUIRED 코드 반환")
+  @DisplayName("login: 비밀번호 재설정 필요 → 403 Forbidden, resetToken 없이 PASSWORD_RESET_REQUIRED 코드 반환")
   void should_403반환_when_비밀번호재설정필요() throws Exception {
     // given
     given(authService.login(any()))
-        .willThrow(new PasswordResetRequiredException("비밀번호 재설정이 필요합니다.", "reset-token-123"));
+        .willThrow(new PasswordResetRequiredException("비밀번호 재설정이 필요합니다."));
 
     // when & then
     mockMvc
@@ -235,7 +235,8 @@ class AuthControllerTest {
                     """))
         .andExpect(status().isForbidden())
         .andExpect(jsonPath("$.code").value("PASSWORD_RESET_REQUIRED"))
-        .andExpect(jsonPath("$.resetToken").value("reset-token-123"));
+        .andExpect(jsonPath("$.message").value("비밀번호 재설정이 필요합니다."))
+        .andExpect(jsonPath("$.resetToken").doesNotExist());
   }
 
   // ── refresh ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #570

## 변경 사항

- reset-required 로그인 예외가 raw reset token을 보관하지 않도록 정리했습니다.
- reset-required 로그인 오류 응답을 공통 `ErrorResponse(code, message)` 계약으로 통일해 `resetToken` 필드가 public 응답에 포함되지 않도록 했습니다.
- 이슈 570 스펙을 `.agent/specs/570.md`에 정리하고, 응답 토큰 미노출 및 reset token hash 저장 동작을 테스트로 고정했습니다.

## 검증

- `git diff --check`
- `cd backend && JAVA_HOME=/opt/homebrew/Cellar/openjdk@21/21.0.11/libexec/openjdk.jdk/Contents/Home ./gradlew --gradle-user-home /tmp/ostone-gradle-570 test --tests com.init.auth.presentation.AuthControllerTest --tests com.init.auth.application.AuthServiceTest`
- `cd backend && JAVA_HOME=/opt/homebrew/Cellar/openjdk@21/21.0.11/libexec/openjdk.jdk/Contents/Home ./gradlew --gradle-user-home /tmp/ostone-gradle-570 test`
- `cd backend && JAVA_HOME=/opt/homebrew/Cellar/openjdk@21/21.0.11/libexec/openjdk.jdk/Contents/Home ./gradlew --gradle-user-home /tmp/ostone-gradle-570 spotlessCheck`

## 참고

- 전역 Gradle artifact cache lock 경합을 피하기 위해 backend Gradle 검증은 별도 `--gradle-user-home`으로 실행했습니다.