### PR TITLE
fix(pipeline): 인제스천 트리거 실패 데이터셋을 복구 가능하게 표시

### DIFF
--- a/.agent/specs/573.md
+++ b/.agent/specs/573.md
@@ -1,0 +1,152 @@
+# [BE] 573 — 인제스천 트리거 실패 시 데이터셋 복구 가능 상태 보존
+
+**Issue**: #573
+**Branch**: `fix/573-ingestion-trigger-failure`
+**Template Base**: `_TEMPLATE_BE.md`
+**Bounded Context**: `corpus`, `pipeline-job`
+
+---
+
+## Goal
+
+원본 로그 업로드 완료 후 Airflow 인제스천 트리거가 실패하더라도 데이터셋이 `PROCESSING`에 무기한 머물지 않고 운영자가 실패 상태를 확인할 수 있게 한다.
+
+---
+
+## Problem
+
+presigned 원본 로그 업로드 완료 흐름은 커밋 이후 `IngestionTriggerPort`를 호출한다. 실제 구현은 `pipeline-job`의 `TriggerIngestionUseCase`로 연결되어 `pipeline_job`을 만들고 Airflow DAG를 트리거한다.
+
+현재 동작은 Airflow 트리거 실패 시 `PipelineJob`만 `FAILED`로 전환하고, 이미 커밋된 `Dataset`은 `PROCESSING` 상태로 남길 수 있다. 이 상태는 운영자에게 진행 중처럼 보이며 실패 원인 확인과 후속 조치를 어렵게 만든다.
+
+이슈 본문에 적힌 `com/example/...` 경로는 현재 저장소에는 없으며, 확인된 실제 경로는 아래와 같다.
+
+- `backend/src/main/java/com/init/corpus/application/CompleteRawFileUploadService.java`
+- `backend/src/main/java/com/init/pipelinejob/application/TriggerIngestionUseCase.java`
+- `backend/src/main/java/com/init/corpus/domain/model/Dataset.java`
+- `backend/src/main/java/com/init/corpus/domain/model/DatasetStatus.java`
+
+---
+
+## Scope
+
+- Airflow 인제스천 트리거 실패 시 해당 데이터셋을 `ERROR` 상태로 전환한다.
+- `PipelineJob`은 기존처럼 `FAILED` 상태와 실패 메시지를 보존한다.
+- 업로드 완료로 생성된 `dataset_raw_file` 및 completed object key는 유지해 운영자가 원인을 확인하고 이후 별도 재처리 전략을 붙일 수 있게 한다.
+- 트리거 실패 케이스의 backend 테스트를 추가 또는 갱신한다.
+
+## Non-goals
+
+- 신규 인제스천 재시도 API 추가
+- outbox 기반 재시도 큐 도입
+- Airflow DAG 내부 실행 실패 콜백 전체의 데이터셋 상태 정책 확장
+- 프론트엔드 화면 변경
+- DB migration
+
+---
+
+## Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    actor op as Operator
+    participant complete as CompleteRawFileUploadService
+    participant corpusDb as corpus.dataset
+    participant trigger as IngestionTriggerPort
+    participant ingest as TriggerIngestionUseCase
+    participant jobDb as pipeline.pipeline_job
+    participant airflow as Airflow
+    participant statusPort as IngestionDatasetStatusPort
+
+    op ->> complete: complete raw file upload
+    complete ->> corpusDb: Dataset UPLOADING -> PROCESSING
+    complete ->> trigger: afterCommit trigger(workspaceId, datasetId, objectKey)
+    trigger ->> ingest: execute(...)
+    ingest ->> jobDb: create ingestion PipelineJob QUEUED
+    ingest ->> airflow: create DAG run
+    airflow --x ingest: trigger failure
+    ingest ->> jobDb: mark PipelineJob FAILED
+    ingest ->> statusPort: markIngestionTriggerFailed(workspaceId, datasetId)
+    statusPort ->> corpusDb: Dataset PROCESSING -> ERROR
+    ingest --x complete: AirflowTriggerFailedException
+```
+
+---
+
+## Design
+
+### Dataset State
+
+`DatasetStatus.ERROR` already exists, so no schema or enum expansion is required.
+
+`Dataset` should expose a domain method that records an ingestion-trigger failure only when the dataset is still in an upload/processing state. This keeps the transition meaningful and avoids overwriting later terminal states such as `DONE`.
+
+Expected transition:
+
+```text
+UPLOADING or PROCESSING -> ERROR
+READY, DONE, ERROR -> unchanged
+```
+
+### Pipeline to Corpus Port
+
+`pipeline-job` should not directly encode corpus state rules in the use case. Add a narrow application port owned by `pipeline-job`:
+
+```java
+interface IngestionDatasetStatusPort {
+  void markIngestionTriggerFailed(Long workspaceId, Long datasetId);
+}
+```
+
+Implement the port in the existing `pipelinejob.infrastructure.corpus` adapter style, using `DatasetRepository.findByIdAndWorkspaceIdForUpdate(...)` and `Dataset.save(...)`.
+
+### Trigger Failure Handling
+
+`TriggerIngestionUseCase` keeps the current behavior:
+
+- create ingestion `PipelineJob`
+- call Airflow
+- on `AirflowTriggerFailedException`, mark the job `FAILED`
+- rethrow the exception
+
+New behavior:
+
+- after marking the job failed, also mark the dataset `ERROR`
+- do this in its own `REQUIRES_NEW` transaction path so it is not rolled back by the caller's after-commit exception propagation
+
+---
+
+## Acceptance Criteria
+
+- Airflow ingestion trigger failure after raw upload completion no longer leaves the dataset in `PROCESSING`.
+- The related ingestion `PipelineJob` remains `FAILED` with its error message.
+- A failed dataset is clearly visible as `ERROR` through existing dataset status responses.
+- The completed raw file metadata remains available for later operator investigation or future retry design.
+- A backend test covers the trigger-failure case.
+
+---
+
+## Validation
+
+Expected local verification:
+
+```bash
+cd backend && ./gradlew test \
+  --tests '*TriggerIngestionUseCaseTest' \
+  --tests '*CompleteRawFileUploadServiceTest' \
+  --tests '*DatasetTest' \
+  --tests '*CorpusIngestionDatasetStatusAdapterTest'
+```
+
+Broader backend verification can use:
+
+```bash
+cd backend && ./gradlew test
+```
+
+---
+
+## Open Questions
+
+- 인제스천 재시도 API는 별도 요구사항으로 설계할지 결정이 필요하다.
+- Airflow DAG가 성공적으로 시작된 뒤 내부 stage 실패 콜백이 도착하는 경우에도 `DatasetStatus.ERROR`로 전환할지는 별도 정책 결정이 필요하다.

--- a/backend/src/main/java/com/init/corpus/application/CompleteRawFileUploadService.java
+++ b/backend/src/main/java/com/init/corpus/application/CompleteRawFileUploadService.java
@@ -64,8 +64,8 @@ public class CompleteRawFileUploadService {
 
   /**
    * presigned 업로드를 완료 처리한다. DB 상태 전이(객체 승격, {@code dataset_raw_file} 저장, {@code PROCESSING} 전이)는
-   * 트랜잭션 내에서 커밋하고, Airflow 트리거는 커밋이 성공한 뒤(afterCommit)에 수행한다. 트리거가 실패해도 이미 커밋된 DB 상태는 롤백되지 않으며
-   * 데이터셋은 {@code PROCESSING}으로 유지된다(재트리거는 별도 재시도 경로).
+   * 트랜잭션 내에서 커밋하고, Airflow 트리거는 커밋이 성공한 뒤(afterCommit)에 수행한다. 트리거가 실패해도 이미 커밋된 DB 상태는 롤백되지 않으며, 트리거
+   * 구현체가 실패한 데이터셋을 복구 가능한 상태로 별도 전이한다.
    */
   @Transactional
   public CompleteRawFileUploadResult complete(CompleteRawFileUploadCommand command) {

--- a/backend/src/main/java/com/init/corpus/domain/model/Dataset.java
+++ b/backend/src/main/java/com/init/corpus/domain/model/Dataset.java
@@ -106,6 +106,14 @@ public class Dataset {
     return false;
   }
 
+  public boolean markIngestionTriggerFailed() {
+    if (status == DatasetStatus.UPLOADING || status == DatasetStatus.PROCESSING) {
+      this.status = DatasetStatus.ERROR;
+      return true;
+    }
+    return false;
+  }
+
   @PrePersist
   protected void onPersist() {
     OffsetDateTime now = OffsetDateTime.now();

--- a/backend/src/main/java/com/init/pipelinejob/application/IngestionDatasetStatusPort.java
+++ b/backend/src/main/java/com/init/pipelinejob/application/IngestionDatasetStatusPort.java
@@ -1,0 +1,6 @@
+package com.init.pipelinejob.application;
+
+public interface IngestionDatasetStatusPort {
+
+  void markIngestionTriggerFailed(Long workspaceId, Long datasetId);
+}

--- a/backend/src/main/java/com/init/pipelinejob/application/TriggerIngestionUseCase.java
+++ b/backend/src/main/java/com/init/pipelinejob/application/TriggerIngestionUseCase.java
@@ -22,6 +22,7 @@ public class TriggerIngestionUseCase {
 
   private final PipelineJobRepository pipelineJobRepository;
   private final IngestionAirflowTriggerPort airflowTriggerPort;
+  private final IngestionDatasetStatusPort ingestionDatasetStatusPort;
   private final ObjectMapper objectMapper;
   private final Clock clock;
   private final TransactionTemplate requiresNewTx;
@@ -29,11 +30,13 @@ public class TriggerIngestionUseCase {
   public TriggerIngestionUseCase(
       PipelineJobRepository pipelineJobRepository,
       IngestionAirflowTriggerPort airflowTriggerPort,
+      IngestionDatasetStatusPort ingestionDatasetStatusPort,
       ObjectMapper objectMapper,
       Clock clock,
       PlatformTransactionManager transactionManager) {
     this.pipelineJobRepository = pipelineJobRepository;
     this.airflowTriggerPort = airflowTriggerPort;
+    this.ingestionDatasetStatusPort = ingestionDatasetStatusPort;
     this.objectMapper = objectMapper;
     this.clock = clock;
     this.requiresNewTx = buildRequiresNewTemplate(transactionManager);
@@ -67,6 +70,7 @@ public class TriggerIngestionUseCase {
               objectKey));
     } catch (AirflowTriggerFailedException ex) {
       markFailed(createdJob.pipelineJobId(), ex.getMessage());
+      markDatasetTriggerFailed(workspaceId, datasetId);
       throw ex;
     }
 
@@ -101,6 +105,11 @@ public class TriggerIngestionUseCase {
             pipelineJobRepository.saveAndFlush(job);
           }
         });
+  }
+
+  private void markDatasetTriggerFailed(Long workspaceId, Long datasetId) {
+    requiresNewTx.executeWithoutResult(
+        status -> ingestionDatasetStatusPort.markIngestionTriggerFailed(workspaceId, datasetId));
   }
 
   private String buildPayloadJson(

--- a/backend/src/main/java/com/init/pipelinejob/infrastructure/corpus/CorpusIngestionDatasetStatusAdapter.java
+++ b/backend/src/main/java/com/init/pipelinejob/infrastructure/corpus/CorpusIngestionDatasetStatusAdapter.java
@@ -1,0 +1,23 @@
+package com.init.pipelinejob.infrastructure.corpus;
+
+import com.init.corpus.domain.repository.DatasetRepository;
+import com.init.pipelinejob.application.IngestionDatasetStatusPort;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CorpusIngestionDatasetStatusAdapter implements IngestionDatasetStatusPort {
+
+  private final DatasetRepository datasetRepository;
+
+  public CorpusIngestionDatasetStatusAdapter(DatasetRepository datasetRepository) {
+    this.datasetRepository = datasetRepository;
+  }
+
+  @Override
+  public void markIngestionTriggerFailed(Long workspaceId, Long datasetId) {
+    datasetRepository
+        .findByIdAndWorkspaceIdForUpdate(datasetId, workspaceId)
+        .filter(dataset -> dataset.markIngestionTriggerFailed())
+        .ifPresent(datasetRepository::save);
+  }
+}

--- a/backend/src/test/java/com/init/corpus/application/CompleteRawFileUploadServiceTest.java
+++ b/backend/src/test/java/com/init/corpus/application/CompleteRawFileUploadServiceTest.java
@@ -136,8 +136,8 @@ class CompleteRawFileUploadServiceTest {
   }
 
   @Test
-  @DisplayName("should_keep_processing_state_when_trigger_fails_after_commit")
-  void complete_triggerFails_keepsProcessingState() {
+  @DisplayName("should_propagate_afterCommit_trigger_failure_after_processing_transition")
+  void complete_triggerFails_propagatesAfterCommitFailure() {
     given(workspaceMembershipRepository.existsByWorkspaceIdAndUserId(1L, 1L)).willReturn(true);
     Dataset dataset = uploadingDataset();
     given(datasetRepository.findByIdAndWorkspaceIdForUpdate(42L, 1L))

--- a/backend/src/test/java/com/init/corpus/domain/model/DatasetTest.java
+++ b/backend/src/test/java/com/init/corpus/domain/model/DatasetTest.java
@@ -56,6 +56,31 @@ class DatasetTest {
   }
 
   @Test
+  @DisplayName("markIngestionTriggerFailed: PROCESSING → ERROR로 전이하고 true를 반환한다")
+  void markIngestionTriggerFailed_fromProcessing_transitionsToError() {
+    Dataset dataset = Dataset.createUploading(1L, "key", "테스트", "CRM", 1L);
+    dataset.markProcessing();
+
+    boolean changed = dataset.markIngestionTriggerFailed();
+
+    assertThat(changed).isTrue();
+    assertThat(dataset.getStatus()).isEqualTo(DatasetStatus.ERROR);
+  }
+
+  @Test
+  @DisplayName("markIngestionTriggerFailed: DONE 상태면 전이 없이 false를 반환한다")
+  void markIngestionTriggerFailed_fromDone_returnsFalse() {
+    Dataset dataset = Dataset.createUploading(1L, "key", "테스트", "CRM", 1L);
+    org.springframework.test.util.ReflectionTestUtils.setField(
+        dataset, "status", DatasetStatus.DONE);
+
+    boolean changed = dataset.markIngestionTriggerFailed();
+
+    assertThat(changed).isFalse();
+    assertThat(dataset.getStatus()).isEqualTo(DatasetStatus.DONE);
+  }
+
+  @Test
   @DisplayName("updateMetaJson: null을 전달하면 NullPointerException을 던진다")
   void updateMetaJson_null_throwsNpe() {
     Dataset dataset = Dataset.createUploading(1L, "key", "테스트", "CRM", 1L);

--- a/backend/src/test/java/com/init/pipelinejob/application/TriggerIngestionUseCaseTest.java
+++ b/backend/src/test/java/com/init/pipelinejob/application/TriggerIngestionUseCaseTest.java
@@ -39,6 +39,7 @@ class TriggerIngestionUseCaseTest {
 
   @Mock private PipelineJobRepository pipelineJobRepository;
   @Mock private IngestionAirflowTriggerPort airflowTriggerPort;
+  @Mock private IngestionDatasetStatusPort ingestionDatasetStatusPort;
   @Mock private PlatformTransactionManager transactionManager;
 
   private TriggerIngestionUseCase useCase;
@@ -75,6 +76,7 @@ class TriggerIngestionUseCaseTest {
         new TriggerIngestionUseCase(
             pipelineJobRepository,
             airflowTriggerPort,
+            ingestionDatasetStatusPort,
             new ObjectMapper(),
             fixedClock,
             transactionManager);
@@ -92,6 +94,7 @@ class TriggerIngestionUseCaseTest {
     assertThat(job.getAirflowRunId()).isEqualTo("pipeline_job_99");
     assertThat(job.getStartedAt().toInstant()).isEqualTo(fixedClock.instant());
     verify(airflowTriggerPort).trigger(any(IngestionTriggerCommand.class));
+    verify(ingestionDatasetStatusPort, never()).markIngestionTriggerFailed(any(), any());
   }
 
   @Test
@@ -123,6 +126,7 @@ class TriggerIngestionUseCaseTest {
 
     assertThat(savedJob.get().getStatus()).isEqualTo(PipelineJob.STATUS_FAILED);
     assertThat(savedJob.get().getFinishedAt().toInstant()).isEqualTo(fixedClock.instant());
+    verify(ingestionDatasetStatusPort).markIngestionTriggerFailed(1L, 42L);
   }
 
   @Test

--- a/backend/src/test/java/com/init/pipelinejob/infrastructure/corpus/CorpusIngestionDatasetStatusAdapterTest.java
+++ b/backend/src/test/java/com/init/pipelinejob/infrastructure/corpus/CorpusIngestionDatasetStatusAdapterTest.java
@@ -1,0 +1,56 @@
+package com.init.pipelinejob.infrastructure.corpus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.init.corpus.domain.model.Dataset;
+import com.init.corpus.domain.model.DatasetStatus;
+import com.init.corpus.domain.repository.DatasetRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CorpusIngestionDatasetStatusAdapter")
+class CorpusIngestionDatasetStatusAdapterTest {
+
+  @Mock private DatasetRepository datasetRepository;
+
+  @Test
+  @DisplayName("인제스천 트리거 실패 시 PROCESSING dataset을 ERROR로 저장한다")
+  void markIngestionTriggerFailed_fromProcessing_savesErrorDataset() {
+    Dataset dataset = Dataset.createUploading(1L, "key", "테스트", "CRM", 1L);
+    dataset.markProcessing();
+    given(datasetRepository.findByIdAndWorkspaceIdForUpdate(42L, 1L))
+        .willReturn(Optional.of(dataset));
+    CorpusIngestionDatasetStatusAdapter adapter =
+        new CorpusIngestionDatasetStatusAdapter(datasetRepository);
+
+    adapter.markIngestionTriggerFailed(1L, 42L);
+
+    assertThat(dataset.getStatus()).isEqualTo(DatasetStatus.ERROR);
+    verify(datasetRepository).save(dataset);
+  }
+
+  @Test
+  @DisplayName("이미 DONE dataset이면 상태를 바꾸거나 저장하지 않는다")
+  void markIngestionTriggerFailed_fromDone_doesNotSave() {
+    Dataset dataset = Dataset.createUploading(1L, "key", "테스트", "CRM", 1L);
+    ReflectionTestUtils.setField(dataset, "status", DatasetStatus.DONE);
+    given(datasetRepository.findByIdAndWorkspaceIdForUpdate(42L, 1L))
+        .willReturn(Optional.of(dataset));
+    CorpusIngestionDatasetStatusAdapter adapter =
+        new CorpusIngestionDatasetStatusAdapter(datasetRepository);
+
+    adapter.markIngestionTriggerFailed(1L, 42L);
+
+    assertThat(dataset.getStatus()).isEqualTo(DatasetStatus.DONE);
+    verify(datasetRepository, never()).save(dataset);
+  }
+}


### PR DESCRIPTION
Closes #573

## 변경 사항

- Airflow 인제스천 트리거 실패 시 ingestion `PipelineJob`을 `FAILED`로 남긴 뒤 연결된 데이터셋을 `ERROR`로 전환합니다.
- `pipeline-job`에서 corpus 데이터셋 상태를 갱신하는 전용 포트와 adapter를 추가해 기존 BC 경계를 유지했습니다.
- 이슈 573 스펙을 `.agent/specs/573.md`에 정리하고, 데이터셋 상태 전이·adapter persistence·trigger 실패 경로 회귀 테스트를 추가했습니다.

## 검증

- `git diff --check`
- `cd backend && JAVA_HOME=/Users/owen/.local/share/mise/installs/java/temurin-21.0.11+10.0.LTS GRADLE_USER_HOME=/tmp/ostone-gradle-7486 ./gradlew test --tests '*TriggerIngestionUseCaseTest' --tests '*CompleteRawFileUploadServiceTest' --tests '*DatasetTest' --tests '*CorpusIngestionDatasetStatusAdapterTest'`
- `cd backend && JAVA_HOME=/Users/owen/.local/share/mise/installs/java/temurin-21.0.11+10.0.LTS GRADLE_USER_HOME=/tmp/ostone-gradle-7486 ./gradlew spotlessCheck`
- `cd backend && JAVA_HOME=/Users/owen/.local/share/mise/installs/java/temurin-21.0.11+10.0.LTS GRADLE_USER_HOME=/tmp/ostone-gradle-7486 ./gradlew test`

## 참고

- 전역 Gradle artifact cache lock 경합을 피하기 위해 backend Gradle 검증은 별도 `GRADLE_USER_HOME`으로 실행했습니다.