### PR TITLE
fix(auth): 비밀번호 재설정 후 기존 refresh token 폐기

### DIFF
--- a/.agent/specs/569.md
+++ b/.agent/specs/569.md
@@ -1,0 +1,62 @@
+# 비밀번호 재설정 후 기존 refresh token 폐기
+
+## Goal
+
+비밀번호 재설정이 완료된 계정의 기존 refresh token이 더 이상 access token 재발급에 사용되지 않도록 한다.
+
+## Problem
+
+`backend/src/main/java/com/init/auth/application/AuthService.java`의 `passwordResetComplete`는 재설정 토큰을 검증하고 새 비밀번호를 저장하지만, 이미 발급된 refresh token은 그대로 남긴다. 따라서 비밀번호가 재설정된 뒤에도 기존 refresh token이 만료 전까지 `POST /api/v1/auth/refresh` 경로에서 access token 재발급에 사용될 수 있다.
+
+## Scope
+
+- `backend/src/main/java/com/init/auth/application/AuthService.java`의 비밀번호 재설정 완료 흐름
+- `backend/src/main/java/com/init/auth/domain/repository/RefreshTokenRepository.java`의 사용자 단위 refresh token 폐기 계약
+- `backend/src/main/java/com/init/auth/infrastructure/persistence/JpaRefreshTokenRepository.java`의 사용자 단위 revoke persistence 구현
+- `backend/src/test/java/com/init/auth/application/AuthServiceTest.java`의 서비스 단위 회귀 테스트
+- `backend/src/test/java/com/init/auth/application/AuthServiceConcurrencyTest.java`의 실제 refresh 실패 회귀 테스트
+
+## Non-Goals
+
+- refresh token DB 스키마 변경
+- JWT claim 구조 또는 token version claim 추가
+- password reset HTTP request/response contract 변경
+- refresh token cookie 정책 변경
+- 비밀번호 재설정 토큰 발급 방식 변경
+
+## Current Contract
+
+| 파일 | 현재 역할 | 확인된 이슈 |
+| --- | --- | --- |
+| `backend/src/main/java/com/init/auth/application/AuthService.java` | 로그인, refresh rotation, logout, 비밀번호 재설정 유스케이스 처리 | `passwordResetComplete`가 사용자 비밀번호만 변경하고 기존 refresh token을 폐기하지 않음 |
+| `backend/src/main/java/com/init/auth/domain/model/RefreshToken.java` | refresh token의 만료/폐기 상태 보관 및 `revoke()` 제공 | 개별 토큰 폐기 도메인 동작은 있으나 사용자 단위 폐기 계약이 없음 |
+| `backend/src/main/java/com/init/auth/domain/repository/RefreshTokenRepository.java` | refresh token 저장, 해시 조회, refresh rotation용 row lock 조회 | 사용자에게 발급된 토큰 전체 폐기 메서드가 없음 |
+| `backend/src/main/java/com/init/auth/infrastructure/persistence/JpaRefreshTokenRepository.java` | Spring Data JPA 기반 refresh token repository 구현 | 사용자 단위 revoke update가 없음 |
+
+## Design Diff
+
+| 영역 | As-is | To-be |
+| --- | --- | --- |
+| 비밀번호 재설정 완료 | 새 비밀번호 저장 후 종료 | 새 비밀번호 저장 후 해당 사용자에게 발급된 미폐기 refresh token을 모두 폐기 |
+| refresh 검증 | 저장된 token hash가 존재하고 `RefreshToken.isValid()`가 true면 refresh 가능 | password reset 이후 기존 token은 `revokedAt`이 채워져 `isValid()`가 false가 됨 |
+| 실패한 reset token | 사용자 조회 실패 또는 만료 시 예외 발생 | 기존과 동일하며 refresh token 폐기는 수행하지 않음 |
+
+## Acceptance Criteria
+
+- 비밀번호 재설정 완료 후 기존 refresh token으로 refresh 요청을 수행하면 `InvalidTokenException`이 발생한다.
+- 사용자에게 발급된 기존 refresh token은 비밀번호 재설정 완료 시 사용자 단위로 폐기된다.
+- 유효하지 않거나 만료된 비밀번호 재설정 토큰은 refresh token 폐기를 유발하지 않는다.
+- refresh token rotation, logout, 비밀번호 재설정 토큰 검증의 기존 동작은 유지된다.
+- 사용자별 refresh token 폐기 또는 refresh 실패를 검증하는 backend 테스트가 추가된다.
+
+## Validation Plan
+
+| 구분 | 명령 | 기대 결과 |
+| --- | --- | --- |
+| Backend targeted unit | `cd backend && ./gradlew test --tests com.init.auth.application.AuthServiceTest` | 비밀번호 재설정 완료 시 사용자 refresh token 폐기 호출과 invalid reset token 회귀 통과 |
+| Backend refresh behavior | `cd backend && ./gradlew test --tests com.init.auth.application.AuthServiceConcurrencyTest` | 비밀번호 재설정 후 기존 refresh token이 인증 실패하고 기존 rotation 동시성 테스트 통과 |
+| Backend full tests | `cd backend && ./gradlew test` | 백엔드 테스트 회귀 없음 |
+
+## Open Questions
+
+- 없음. 이슈는 사용자별 refresh token 폐기 또는 token version 검증 중 하나를 허용하며, 현재 `RefreshToken` 모델의 폐기 상태를 활용하는 사용자 단위 revoke가 가장 작은 변경이다.

--- a/backend/src/main/java/com/init/auth/application/AuthService.java
+++ b/backend/src/main/java/com/init/auth/application/AuthService.java
@@ -13,6 +13,7 @@ import com.init.shared.application.TokenHasher;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.Optional;
 import java.util.UUID;
@@ -189,6 +190,7 @@ public class AuthService {
 
     user.completePasswordReset(passwordEncoder.encode(command.newPassword()));
     userRepository.save(user);
+    refreshTokenRepository.revokeAllByUserId(user.getId(), OffsetDateTime.now(ZoneOffset.UTC));
   }
 
   private LoginResult issueTokens(AppUser user) {

--- a/backend/src/main/java/com/init/auth/domain/repository/RefreshTokenRepository.java
+++ b/backend/src/main/java/com/init/auth/domain/repository/RefreshTokenRepository.java
@@ -1,6 +1,7 @@
 package com.init.auth.domain.repository;
 
 import com.init.auth.domain.model.RefreshToken;
+import java.time.OffsetDateTime;
 import java.util.Optional;
 
 public interface RefreshTokenRepository {
@@ -10,4 +11,6 @@ public interface RefreshTokenRepository {
   Optional<RefreshToken> findByTokenHash(String tokenHash);
 
   Optional<RefreshToken> findByTokenHashForUpdate(String tokenHash);
+
+  int revokeAllByUserId(Long userId, OffsetDateTime revokedAt);
 }

--- a/backend/src/main/java/com/init/auth/infrastructure/persistence/JpaRefreshTokenRepository.java
+++ b/backend/src/main/java/com/init/auth/infrastructure/persistence/JpaRefreshTokenRepository.java
@@ -3,9 +3,11 @@ package com.init.auth.infrastructure.persistence;
 import com.init.auth.domain.model.RefreshToken;
 import com.init.auth.domain.repository.RefreshTokenRepository;
 import jakarta.persistence.LockModeType;
+import java.time.OffsetDateTime;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -18,4 +20,15 @@ public interface JpaRefreshTokenRepository
   @Lock(LockModeType.PESSIMISTIC_WRITE)
   @Query("select token from RefreshToken token where token.tokenHash = :tokenHash")
   Optional<RefreshToken> findByTokenHashForUpdate(@Param("tokenHash") String tokenHash);
+
+  @Override
+  @Modifying
+  @Query(
+      """
+      update RefreshToken token
+         set token.revokedAt = :revokedAt
+       where token.userId = :userId
+         and token.revokedAt is null
+      """)
+  int revokeAllByUserId(@Param("userId") Long userId, @Param("revokedAt") OffsetDateTime revokedAt);
 }

--- a/backend/src/test/java/com/init/auth/application/AuthServiceConcurrencyTest.java
+++ b/backend/src/test/java/com/init/auth/application/AuthServiceConcurrencyTest.java
@@ -1,6 +1,7 @@
 package com.init.auth.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.init.auth.application.exception.InvalidTokenException;
 import com.init.shared.infrastructure.Sha256TokenHasher;
@@ -99,6 +100,32 @@ class AuthServiceConcurrencyTest {
     } finally {
       executor.shutdownNow();
     }
+  }
+
+  @Test
+  @Transactional(propagation = Propagation.NOT_SUPPORTED)
+  @DisplayName("passwordResetComplete: 비밀번호 재설정 후 기존 리프레시 토큰 → InvalidTokenException")
+  void shouldRejectExistingRefreshTokenAfterPasswordResetComplete() {
+    // given
+    String email = "reset-revokes-refresh@example.com";
+    String password = "password123";
+    authService.signup(new SignupCommand("재설정 사용자", email, password));
+    LoginResult loginResult = authService.login(new LoginCommand(email, password));
+
+    PasswordResetInitResult resetResult =
+        authService.passwordResetInit(new PasswordResetInitCommand(email));
+    assertThat(resetResult.accepted()).isTrue();
+    assertThat(resetResult.rawToken()).isNotBlank();
+
+    // when
+    authService.passwordResetComplete(
+        new PasswordResetCompleteCommand(resetResult.rawToken(), "new-password123"));
+    TokenRefreshCommand refreshCommand = new TokenRefreshCommand(loginResult.refreshToken());
+
+    // then
+    assertThatThrownBy(() -> authService.refresh(refreshCommand))
+        .isInstanceOf(InvalidTokenException.class)
+        .hasMessageContaining("만료되거나 폐기된 리프레시 토큰입니다.");
   }
 
   private Callable<RefreshAttempt> refreshAttempt(

--- a/backend/src/test/java/com/init/auth/application/AuthServiceTest.java
+++ b/backend/src/test/java/com/init/auth/application/AuthServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -302,5 +303,48 @@ class AuthServiceTest {
 
     // then
     verify(refreshTokenRepository, never()).save(any());
+  }
+
+  // ── password reset ────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("passwordResetComplete: 유효한 재설정 토큰 → 비밀번호 변경 후 사용자 리프레시 토큰 전체 폐기")
+  void should_사용자리프레시토큰전체폐기_when_비밀번호재설정완료() {
+    // given
+    PasswordResetCompleteCommand command =
+        new PasswordResetCompleteCommand("reset-token", "new-password123");
+    given(tokenHasher.hash("reset-token")).willReturn("reset-token-hash");
+
+    AppUser user = AppUser.create("홍길동", "hong@example.com", "$2a$10$oldhash");
+    ReflectionTestUtils.setField(user, "id", 1L);
+    user.initiatePasswordReset("reset-token-hash", OffsetDateTime.parse("2999-01-01T00:00:00Z"));
+    given(userRepository.findByPasswordResetTokenHash("reset-token-hash"))
+        .willReturn(Optional.of(user));
+    given(passwordEncoder.encode("new-password123")).willReturn("$2a$10$newhash");
+
+    // when
+    authService.passwordResetComplete(command);
+
+    // then
+    assertThat(user.getPasswordHash()).isEqualTo("$2a$10$newhash");
+    verify(userRepository).save(user);
+    verify(refreshTokenRepository).revokeAllByUserId(eq(1L), any(OffsetDateTime.class));
+  }
+
+  @Test
+  @DisplayName("passwordResetComplete: 유효하지 않은 재설정 토큰 → 리프레시 토큰 폐기하지 않음")
+  void should_리프레시토큰폐기하지않음_when_유효하지않은재설정토큰() {
+    // given
+    PasswordResetCompleteCommand command =
+        new PasswordResetCompleteCommand("invalid-reset-token", "new-password123");
+    given(tokenHasher.hash("invalid-reset-token")).willReturn("invalid-reset-token-hash");
+    given(userRepository.findByPasswordResetTokenHash("invalid-reset-token-hash"))
+        .willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> authService.passwordResetComplete(command))
+        .isInstanceOf(InvalidTokenException.class)
+        .hasMessageContaining("유효하지 않은 비밀번호 재설정 토큰입니다.");
+    verify(refreshTokenRepository, never()).revokeAllByUserId(any(), any());
   }
 }


### PR DESCRIPTION
Closes #569

## 변경 사항

- 비밀번호 재설정 완료 시 해당 사용자에게 발급된 미폐기 refresh token을 모두 폐기하도록 했습니다.
- 사용자 단위 refresh token revoke repository 계약과 JPA bulk update를 추가했습니다.
- 이슈 569 스펙을 `.agent/specs/569.md`에 정리하고, 비밀번호 재설정 후 기존 refresh token 인증 실패 동작을 테스트로 고정했습니다.

## 검증

- `git diff --check`
- `cd backend && JAVA_HOME=/Users/owen/.local/share/mise/installs/java/temurin-21.0.11+10.0.LTS PATH=/Users/owen/.local/share/mise/installs/java/temurin-21.0.11+10.0.LTS/bin:$PATH GRADLE_USER_HOME=/tmp/ostone-gradle-569 ./gradlew --no-daemon --no-watch-fs spotlessApply`
- `cd backend && JAVA_HOME=/Users/owen/.local/share/mise/installs/java/temurin-21.0.11+10.0.LTS PATH=/Users/owen/.local/share/mise/installs/java/temurin-21.0.11+10.0.LTS/bin:$PATH GRADLE_USER_HOME=/tmp/ostone-gradle-569 ./gradlew --no-daemon --no-watch-fs test --tests com.init.auth.application.AuthServiceTest`
- `cd backend && JAVA_HOME=/Users/owen/.local/share/mise/installs/java/temurin-21.0.11+10.0.LTS PATH=/Users/owen/.local/share/mise/installs/java/temurin-21.0.11+10.0.LTS/bin:$PATH GRADLE_USER_HOME=/tmp/ostone-gradle-569 ./gradlew --no-daemon --no-watch-fs test --tests com.init.auth.application.AuthServiceConcurrencyTest`
- `cd backend && JAVA_HOME=/Users/owen/.local/share/mise/installs/java/temurin-21.0.11+10.0.LTS PATH=/Users/owen/.local/share/mise/installs/java/temurin-21.0.11+10.0.LTS/bin:$PATH GRADLE_USER_HOME=/tmp/ostone-gradle-569 ./gradlew --no-daemon --no-watch-fs test`

## 참고

- 로컬 기본 shell은 Java 17을 사용해 Gradle Java 21 toolchain 감지에 실패하므로, 저장소 mise Java 21 경로를 명시해 검증했습니다.
- 전역 Gradle journal cache lock 경합을 피하기 위해 backend Gradle 검증은 별도 `GRADLE_USER_HOME`으로 실행했습니다.