### PR TITLE
fix(payment): 동시 부분취소 잔여 금액 초과를 차단

### DIFF
--- a/.agent/specs/575.md
+++ b/.agent/specs/575.md
@@ -1,0 +1,105 @@
+# 동시 부분취소의 취소 가능 금액 race 방지
+
+## Goal
+
+결제 부분취소 요청이 동시에 들어와도 같은 결제의 취소 가능 금액 계산과 저장이 직렬화되고, 같은 idempotency key 재시도가 취소 내역을 중복 저장하지 않도록 한다.
+
+## Problem
+
+부분취소 흐름은 기존 취소 합계를 읽어 잔여 취소 가능 금액을 계산한 뒤 Toss 취소 요청과 DB 저장을 수행한다. 이 구간에서 같은 `payment` 행을 잠그지 않으면 두 요청이 같은 잔여 금액을 보고 각각 승인되어 로컬 취소 합계가 결제 금액을 초과할 수 있다. 또한 `payment_cancel.idempotency_key` 컬럼은 존재하지만 unique 제약과 key 기반 중복 조회가 없어 같은 취소 시도 key가 중복 저장될 수 있다.
+
+Issue 본문에 적힌 `backend/src/main/java/com/example/backend/payment/...` 경로는 현재 체크아웃에 존재하지 않으며, 실제 payment 패키지는 `backend/src/main/java/com/init/payment`이다.
+
+## Scope
+
+- `backend/src/main/java/com/init/payment/application/PaymentService.java`
+- `backend/src/main/java/com/init/payment/presentation/PaymentController.java`
+- `backend/src/main/java/com/init/payment/domain/model/Payment.java`
+- `backend/src/main/java/com/init/payment/domain/repository/PaymentRepository.java`
+- `backend/src/main/java/com/init/payment/domain/repository/PaymentCancelRepository.java`
+- `backend/src/main/java/com/init/payment/infrastructure/persistence/JpaPaymentRepository.java`
+- `backend/src/main/java/com/init/payment/infrastructure/persistence/JpaPaymentCancelRepository.java`
+- `backend/src/main/resources/db/changelog/db.changelog-master.sql`
+- `backend/src/test/java/com/init/payment/application/PaymentServiceTest.java`
+- `backend/src/test/java/com/init/payment/presentation/PaymentControllerTest.java`
+- `backend/src/test/java/com/init/payment/domain/model/PaymentTest.java`
+
+## Non-Goals
+
+- Toss 취소 API의 request/response 계약을 변경하지 않는다.
+- 결제 승인 confirm 흐름의 멱등 처리 방식을 변경하지 않는다.
+- 관리자 전액 환불 유스케이스의 권한, 조회, 화면 계약을 변경하지 않는다.
+- payment 스키마 전체를 재설계하거나 취소 시도 테이블을 새로 분리하지 않는다.
+
+## Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    actor c as Client
+    participant ctrl as PaymentController
+    participant svc as PaymentService
+    participant payRepo as PaymentRepository
+    participant cancelRepo as PaymentCancelRepository
+    participant toss as Toss
+    participant db as PostgreSQL
+
+    c ->> ctrl: POST /payments/{paymentKey}/cancel
+    ctrl ->> svc: cancelPayment(command)
+    svc ->> payRepo: findByPaymentKeyAndWorkspaceIdForUpdate(...)
+    payRepo ->> db: SELECT ... FOR UPDATE
+    db -->> payRepo: locked payment
+    svc ->> cancelRepo: findByPaymentIdAndIdempotencyKey(...)
+    alt duplicate idempotency key
+        svc -->> ctrl: current payment result
+    else new cancel attempt
+        svc ->> cancelRepo: sumCancelAmountByPaymentId(paymentId)
+        svc ->> svc: validate cancelAmount <= remaining
+        svc ->> toss: cancelPayment(...)
+        svc ->> cancelRepo: save(payment_cancel)
+        svc ->> payRepo: save(payment status)
+        svc -->> ctrl: updated payment result
+    end
+    ctrl -->> c: 200 OK or validation error
+```
+
+## REST API
+
+기존 결제 취소 엔드포인트를 유지한다.
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `POST` | `/api/v1/workspaces/{workspaceId}/payments/{paymentKey}/cancel` | 결제 전액 취소 또는 부분취소 |
+
+### Header
+
+| Header | Required | Description |
+| --- | --- | --- |
+| `Idempotency-Key` | No | 같은 취소 시도 재시도 여부를 판단한다. 없으면 서버가 내부 key를 생성한다. |
+
+## Requirements
+
+- 결제 취소 처리에서 payment row를 pessimistic write lock으로 조회한다.
+- 같은 payment의 잔여 취소 가능 금액 계산, Toss 취소 요청, `payment_cancel` 저장, `payment` 상태 저장은 잠긴 payment row 기준으로 직렬화한다.
+- `cancelAmount`가 명시된 부분취소는 최신 취소 합계 기준 잔여 금액을 초과하면 Toss를 호출하지 않고 거부한다.
+- `cancelAmount`가 없는 전액 취소는 이미 부분취소된 금액을 제외한 남은 금액만 `payment_cancel.cancel_amount`에 기록한다.
+- 같은 `(payment_id, idempotency_key)` 취소 기록이 있으면 Toss를 재호출하거나 `payment_cancel`을 중복 저장하지 않는다.
+- DB는 기존 duplicate non-null idempotency key row를 정리한 뒤 `(payment_id, idempotency_key)` unique index를 가진다.
+- `PARTIAL_CANCELED` 상태 결제는 남은 금액 전액 취소 후 `CANCELED`로 전이될 수 있다.
+
+## Acceptance Criteria
+
+- 동시 부분취소 요청 중 첫 요청 이후 잔여 금액을 초과하는 후속 요청은 승인되지 않는다.
+- 같은 idempotency key로 재시도한 취소 요청은 중복 취소 내역을 저장하지 않는다.
+- payment cancel idempotency key 중복 정리와 unique 제약이 changelog에 추가된다.
+- 결제 취소 controller는 클라이언트가 보낸 `Idempotency-Key` 헤더를 서비스 command로 전달한다.
+- 동시 부분취소 직렬화, idempotency key 중복 방지, 부분취소 후 전액 취소 전이가 테스트로 검증된다.
+
+## Validation
+
+- `cd backend && ./gradlew test --tests com.init.payment.application.PaymentServiceTest`
+- `cd backend && ./gradlew test --tests com.init.payment.presentation.PaymentControllerTest`
+- `cd backend && ./gradlew test --tests com.init.payment.domain.model.PaymentTest`
+
+## Open Questions
+
+- 없음.

--- a/backend/src/main/java/com/init/payment/application/PaymentService.java
+++ b/backend/src/main/java/com/init/payment/application/PaymentService.java
@@ -30,7 +30,8 @@ import org.springframework.transaction.support.TransactionTemplate;
 /**
  * 일회성 결제 confirm(금액검증 + 멱등), 결제 내역 조회, 취소/부분환불.
  *
- * <p>NOTE: Toss 호출과 DB 갱신을 interleave하므로 TransactionTemplate으로 2-phase 처리한다.
+ * <p>NOTE: confirm은 Toss 호출과 DB 갱신을 interleave하므로 TransactionTemplate으로 2-phase 처리한다. 취소는 잔여 취소 가능
+ * 금액 계산과 저장을 같은 payment 행 잠금 안에서 직렬화한다.
  */
 @Service
 public class PaymentService {
@@ -141,54 +142,38 @@ public class PaymentService {
   public PaymentResult cancelPayment(CancelPaymentCommand command) {
     accessGuard.requireMember(command.workspaceId(), command.userId());
 
-    Payment loaded =
-        inTx(
-            () ->
-                paymentRepository
-                    .findByPaymentKeyAndWorkspaceId(command.paymentKey(), command.workspaceId())
-                    .orElseThrow(
-                        () -> new PaymentNotFoundException("paymentKey=" + command.paymentKey())));
-
-    if (!isCancelable(loaded)) {
-      throw new PaymentCancelNotAllowedException("취소할 수 없는 결제 상태입니다. status=" + loaded.getStatus());
-    }
-
-    long resolvedCancelAmount =
-        command.cancelAmount() != null ? command.cancelAmount() : loaded.getAmount();
-
-    if (command.cancelAmount() != null) {
-      long alreadyCanceled = paymentCancelRepository.sumCancelAmountByPaymentId(loaded.getId());
-      long remainingCancelable = loaded.getAmount() - alreadyCanceled;
-      if (command.cancelAmount() <= 0 || command.cancelAmount() > remainingCancelable) {
-        throw new PaymentCancelNotAllowedException(
-            "취소 금액이 유효하지 않습니다. cancelAmount="
-                + command.cancelAmount()
-                + ", remainingCancelable="
-                + remainingCancelable);
-      }
-    }
-
-    String cancelIdempotencyKey =
-        paymentCancelRepository
-            .findFirstByPaymentIdAndCancelAmountOrderByIdDesc(loaded.getId(), resolvedCancelAmount)
-            .map(PaymentCancel::getIdempotencyKey)
-            .filter(k -> k != null && !k.isBlank())
-            .orElse(command.cancelIdempotencyKey());
-
-    TossPaymentResult result =
-        tossPaymentPort.cancelPayment(
-            command.paymentKey(),
-            command.cancelReason(),
-            command.cancelAmount(),
-            cancelIdempotencyKey);
-
     Payment finalized =
         inTx(
             () -> {
               Payment payment =
                   paymentRepository
-                      .findById(loaded.getId())
-                      .orElseThrow(() -> new PaymentNotFoundException("id=" + loaded.getId()));
+                      .findByPaymentKeyAndWorkspaceIdForUpdate(
+                          command.paymentKey(), command.workspaceId())
+                      .orElseThrow(
+                          () -> new PaymentNotFoundException("paymentKey=" + command.paymentKey()));
+              String cancelIdempotencyKey = cancelIdempotencyKey(command);
+              if (hasText(cancelIdempotencyKey)
+                  && paymentCancelRepository
+                      .findByPaymentIdAndIdempotencyKey(payment.getId(), cancelIdempotencyKey)
+                      .isPresent()) {
+                return payment;
+              }
+              if (!isCancelable(payment)) {
+                throw new PaymentCancelNotAllowedException(
+                    "취소할 수 없는 결제 상태입니다. status=" + payment.getStatus());
+              }
+
+              long alreadyCanceled =
+                  paymentCancelRepository.sumCancelAmountByPaymentId(payment.getId());
+              long remainingCancelable = payment.getAmount() - alreadyCanceled;
+              long resolvedCancelAmount = resolveCancelAmount(command, remainingCancelable);
+
+              TossPaymentResult result =
+                  tossPaymentPort.cancelPayment(
+                      command.paymentKey(),
+                      command.cancelReason(),
+                      command.cancelAmount(),
+                      cancelIdempotencyKey);
               paymentCancelRepository.save(
                   PaymentCancel.create(
                       payment.getId(),
@@ -196,7 +181,8 @@ public class PaymentService {
                       command.cancelReason(),
                       result.transactionKey(),
                       cancelIdempotencyKey));
-              if (isPartialCancel(result, resolvedCancelAmount, payment.getAmount())) {
+              long canceledTotal = alreadyCanceled + resolvedCancelAmount;
+              if (isPartialCancel(result, canceledTotal, payment.getAmount())) {
                 payment.markPartialCanceled(result.maskedRawJson());
               } else {
                 payment.markCanceled(result.maskedRawJson());
@@ -205,6 +191,30 @@ public class PaymentService {
             });
 
     return PaymentResult.from(finalized);
+  }
+
+  private long resolveCancelAmount(CancelPaymentCommand command, long remainingCancelable) {
+    if (remainingCancelable <= 0) {
+      throw new PaymentCancelNotAllowedException("취소 가능한 금액이 없습니다.");
+    }
+    if (command.cancelAmount() == null) {
+      return remainingCancelable;
+    }
+    if (command.cancelAmount() <= 0 || command.cancelAmount() > remainingCancelable) {
+      throw new PaymentCancelNotAllowedException(
+          "취소 금액이 유효하지 않습니다. cancelAmount="
+              + command.cancelAmount()
+              + ", remainingCancelable="
+              + remainingCancelable);
+    }
+    return command.cancelAmount();
+  }
+
+  private String cancelIdempotencyKey(CancelPaymentCommand command) {
+    if (hasText(command.cancelIdempotencyKey())) {
+      return command.cancelIdempotencyKey().trim();
+    }
+    return PaymentIdentifiers.idempotencyKey();
   }
 
   private void activateSubscription(Long subscriptionId, Plan plan) {
@@ -236,14 +246,18 @@ public class PaymentService {
         || payment.getStatus() == PaymentStatus.PARTIAL_CANCELED;
   }
 
-  private boolean isPartialCancel(TossPaymentResult result, long cancelAmount, long totalAmount) {
+  private boolean isPartialCancel(TossPaymentResult result, long canceledTotal, long totalAmount) {
     if (result.isPartialCanceled()) {
       return true;
     }
     if (result.isCanceled()) {
       return false;
     }
-    return cancelAmount < totalAmount;
+    return canceledTotal < totalAmount;
+  }
+
+  private boolean hasText(String value) {
+    return value != null && !value.isBlank();
   }
 
   private OffsetDateTime approvedAt(TossPaymentResult result) {

--- a/backend/src/main/java/com/init/payment/domain/model/Payment.java
+++ b/backend/src/main/java/com/init/payment/domain/model/Payment.java
@@ -163,9 +163,9 @@ public class Payment {
     this.rawResponse = rawResponse;
   }
 
-  /** 전액 취소. DONE -> CANCELED. */
+  /** 전액 취소. DONE/PARTIAL_CANCELED -> CANCELED. */
   public void markCanceled(String rawResponse) {
-    if (status != PaymentStatus.DONE) {
+    if (status != PaymentStatus.DONE && status != PaymentStatus.PARTIAL_CANCELED) {
       throw new IllegalStateException("markCanceled() 선행 상태가 올바르지 않습니다: " + status);
     }
     this.status = PaymentStatus.CANCELED;

--- a/backend/src/main/java/com/init/payment/domain/repository/PaymentCancelRepository.java
+++ b/backend/src/main/java/com/init/payment/domain/repository/PaymentCancelRepository.java
@@ -12,7 +12,5 @@ public interface PaymentCancelRepository {
   /** 결제의 이미 취소된 합계를 반환한다. 없으면 0. */
   long sumCancelAmountByPaymentId(Long paymentId);
 
-  /** 동일 (paymentId, cancelAmount)의 가장 최근 취소 내역을 조회한다. 재시도 시 idempotencyKey 재사용 목적. */
-  Optional<PaymentCancel> findFirstByPaymentIdAndCancelAmountOrderByIdDesc(
-      Long paymentId, long cancelAmount);
+  Optional<PaymentCancel> findByPaymentIdAndIdempotencyKey(Long paymentId, String idempotencyKey);
 }

--- a/backend/src/main/java/com/init/payment/domain/repository/PaymentRepository.java
+++ b/backend/src/main/java/com/init/payment/domain/repository/PaymentRepository.java
@@ -20,6 +20,8 @@ public interface PaymentRepository {
 
   Optional<Payment> findByPaymentKeyAndWorkspaceId(String paymentKey, Long workspaceId);
 
+  Optional<Payment> findByPaymentKeyAndWorkspaceIdForUpdate(String paymentKey, Long workspaceId);
+
   List<Payment> findByWorkspaceIdOrderByCreatedAtDesc(Long workspaceId);
 
   /** 동일 주기 결제를 찾는다. 존재 시 재시도는 해당 행을 재사용하여 중복청구를 방지한다 (U-011). */

--- a/backend/src/main/java/com/init/payment/infrastructure/persistence/JpaPaymentCancelRepository.java
+++ b/backend/src/main/java/com/init/payment/infrastructure/persistence/JpaPaymentCancelRepository.java
@@ -22,6 +22,5 @@ public interface JpaPaymentCancelRepository
   long sumCancelAmountByPaymentId(@Param("paymentId") Long paymentId);
 
   @Override
-  Optional<PaymentCancel> findFirstByPaymentIdAndCancelAmountOrderByIdDesc(
-      @Param("paymentId") Long paymentId, @Param("cancelAmount") long cancelAmount);
+  Optional<PaymentCancel> findByPaymentIdAndIdempotencyKey(Long paymentId, String idempotencyKey);
 }

--- a/backend/src/main/java/com/init/payment/infrastructure/persistence/JpaPaymentRepository.java
+++ b/backend/src/main/java/com/init/payment/infrastructure/persistence/JpaPaymentRepository.java
@@ -32,6 +32,14 @@ public interface JpaPaymentRepository extends JpaRepository<Payment, Long>, Paym
   Optional<Payment> findByPaymentKeyAndWorkspaceId(String paymentKey, Long workspaceId);
 
   @Override
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query(
+      "SELECT p FROM Payment p WHERE p.paymentKey = :paymentKey"
+          + " AND p.workspaceId = :workspaceId")
+  Optional<Payment> findByPaymentKeyAndWorkspaceIdForUpdate(
+      @Param("paymentKey") String paymentKey, @Param("workspaceId") Long workspaceId);
+
+  @Override
   List<Payment> findByWorkspaceIdOrderByCreatedAtDesc(Long workspaceId);
 
   @Override

--- a/backend/src/main/java/com/init/payment/presentation/PaymentController.java
+++ b/backend/src/main/java/com/init/payment/presentation/PaymentController.java
@@ -10,13 +10,13 @@ import com.init.payment.presentation.dto.PaymentResponse;
 import com.init.shared.presentation.AuthenticationUtils;
 import jakarta.validation.Valid;
 import java.util.List;
-import java.util.UUID;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -59,6 +59,7 @@ public class PaymentController {
       @PathVariable Long workspaceId,
       @PathVariable String paymentKey,
       @Valid @RequestBody CancelPaymentRequest request,
+      @RequestHeader(value = "Idempotency-Key", required = false) String idempotencyKey,
       Authentication authentication) {
     Long userId = AuthenticationUtils.getUserId(authentication);
     PaymentResult result =
@@ -69,7 +70,7 @@ public class PaymentController {
                 paymentKey,
                 request.cancelReason(),
                 request.cancelAmount(),
-                UUID.randomUUID().toString().replace("-", "")));
+                idempotencyKey));
     return ResponseEntity.ok(PaymentResponse.from(result));
   }
 }

--- a/backend/src/main/resources/db/changelog/db.changelog-master.sql
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.sql
@@ -1171,6 +1171,21 @@ create unique index uq_payment_subscription_workspace_open
 --comment: Per-cancel-attempt idempotency key for Toss API — prevents partial-cancel collisions (V-EC-004)
 alter table payment.payment_cancel add column idempotency_key varchar(255);
 
+--changeset init:20260605-deduplicate-payment-cancel-idempotency-key
+--comment: Keep the first cancel row before enforcing per-payment idempotency uniqueness
+delete from payment.payment_cancel pc
+using payment.payment_cancel first_pc
+where pc.payment_id = first_pc.payment_id
+    and pc.idempotency_key = first_pc.idempotency_key
+    and pc.idempotency_key is not null
+    and pc.id > first_pc.id;
+
+--changeset init:20260605-unique-payment-cancel-idempotency-key
+--comment: Prevent duplicate cancel rows for the same payment idempotency key
+create unique index uq_payment_cancel_payment_id_idempotency_key
+    on payment.payment_cancel (payment_id, idempotency_key)
+    where idempotency_key is not null;
+
 --changeset init:20260604-add-payment-plan-quota-limits
 --comment: Add workspace quota limits to subscription plans for hard usage blocking
 alter table payment.plan add column member_limit integer not null default 10;

--- a/backend/src/test/java/com/init/payment/application/PaymentServiceTest.java
+++ b/backend/src/test/java/com/init/payment/application/PaymentServiceTest.java
@@ -7,8 +7,10 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.init.payment.application.exception.PaymentAmountMismatchException;
@@ -18,6 +20,7 @@ import com.init.payment.application.port.TossPaymentPort;
 import com.init.payment.application.port.TossPaymentResult;
 import com.init.payment.domain.model.BillingInterval;
 import com.init.payment.domain.model.Payment;
+import com.init.payment.domain.model.PaymentCancel;
 import com.init.payment.domain.model.Plan;
 import com.init.payment.domain.model.Subscription;
 import com.init.payment.domain.repository.PaymentCancelRepository;
@@ -28,11 +31,21 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReentrantLock;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -60,6 +73,9 @@ class PaymentServiceTest {
     lenient()
         .when(transactionManager.getTransaction(any()))
         .thenReturn(new SimpleTransactionStatus());
+    lenient()
+        .when(paymentCancelRepository.findByPaymentIdAndIdempotencyKey(anyLong(), any()))
+        .thenReturn(Optional.empty());
     paymentService =
         new PaymentService(
             paymentRepository,
@@ -135,14 +151,9 @@ class PaymentServiceTest {
     Payment payment = Payment.createOrder(1L, 5L, "ord_1", 29000, "KRW", "Pro");
     payment.complete("pay_1", "카드", OffsetDateTime.now(clock), null, "{}");
     ReflectionTestUtils.setField(payment, "id", 7L);
-    given(paymentRepository.findByPaymentKeyAndWorkspaceId("pay_1", 1L))
+    given(paymentRepository.findByPaymentKeyAndWorkspaceIdForUpdate("pay_1", 1L))
         .willReturn(Optional.of(payment));
-    given(paymentRepository.findById(7L)).willReturn(Optional.of(payment));
     given(paymentRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
-    given(
-            paymentCancelRepository.findFirstByPaymentIdAndCancelAmountOrderByIdDesc(
-                eq(7L), eq(29000L)))
-        .willReturn(Optional.empty());
     given(tossPaymentPort.cancelPayment(eq("pay_1"), eq("전액취소"), isNull(), any()))
         .willReturn(canceledResult());
 
@@ -160,7 +171,7 @@ class PaymentServiceTest {
     Payment payment = Payment.createOrder(1L, 5L, "ord_1", 29000, "KRW", "Pro");
     payment.complete("pay_1", "카드", OffsetDateTime.now(clock), null, "{}");
     ReflectionTestUtils.setField(payment, "id", 7L);
-    given(paymentRepository.findByPaymentKeyAndWorkspaceId("pay_1", 1L))
+    given(paymentRepository.findByPaymentKeyAndWorkspaceIdForUpdate("pay_1", 1L))
         .willReturn(Optional.of(payment));
     given(paymentCancelRepository.sumCancelAmountByPaymentId(7L)).willReturn(15000L);
 
@@ -175,7 +186,7 @@ class PaymentServiceTest {
   @Test
   @DisplayName("결제를 찾을 수 없으면 cancelPayment 시 PaymentNotFoundException을 던진다")
   void cancel_paymentNotFound_throws() {
-    given(paymentRepository.findByPaymentKeyAndWorkspaceId("pay_x", 1L))
+    given(paymentRepository.findByPaymentKeyAndWorkspaceIdForUpdate("pay_x", 1L))
         .willReturn(Optional.empty());
 
     assertThatThrownBy(
@@ -233,14 +244,9 @@ class PaymentServiceTest {
     Payment payment = Payment.createOrder(1L, 5L, "ord_1", 29000, "KRW", "Pro");
     payment.complete("pay_1", "카드", OffsetDateTime.now(clock), null, "{}");
     ReflectionTestUtils.setField(payment, "id", 7L);
-    given(paymentRepository.findByPaymentKeyAndWorkspaceId("pay_1", 1L))
+    given(paymentRepository.findByPaymentKeyAndWorkspaceIdForUpdate("pay_1", 1L))
         .willReturn(Optional.of(payment));
-    given(paymentRepository.findById(7L)).willReturn(Optional.of(payment));
     given(paymentRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
-    given(
-            paymentCancelRepository.findFirstByPaymentIdAndCancelAmountOrderByIdDesc(
-                eq(7L), eq(10000L)))
-        .willReturn(Optional.empty());
     given(tossPaymentPort.cancelPayment(eq("pay_1"), eq("고객 요청"), eq(10000L), any()))
         .willReturn(partialCanceledResult());
 
@@ -250,6 +256,166 @@ class PaymentServiceTest {
 
     assertThat(result.status()).isEqualTo("PARTIAL_CANCELED");
     verify(paymentCancelRepository).save(any());
+  }
+
+  @Test
+  @DisplayName("같은 idempotency key 재시도는 Toss 재호출과 취소 내역 중복 저장 없이 기존 결제를 반환한다")
+  void cancel_sameIdempotencyKey_returnsExistingPayment() {
+    Payment payment = Payment.createOrder(1L, 5L, "ord_1", 29000, "KRW", "Pro");
+    payment.complete("pay_1", "카드", OffsetDateTime.now(clock), null, "{}");
+    payment.markPartialCanceled("{}");
+    ReflectionTestUtils.setField(payment, "id", 7L);
+    PaymentCancel existingCancel = PaymentCancel.create(7L, 10000L, "고객 요청", "txn_1", "idem-dup-1");
+    given(paymentRepository.findByPaymentKeyAndWorkspaceIdForUpdate("pay_1", 1L))
+        .willReturn(Optional.of(payment));
+    given(paymentCancelRepository.findByPaymentIdAndIdempotencyKey(7L, "idem-dup-1"))
+        .willReturn(Optional.of(existingCancel));
+
+    PaymentResult result =
+        paymentService.cancelPayment(
+            new CancelPaymentCommand(1L, 99L, "pay_1", "고객 요청", 10000L, "idem-dup-1"));
+
+    assertThat(result.status()).isEqualTo("PARTIAL_CANCELED");
+    verify(tossPaymentPort, never()).cancelPayment(any(), any(), any(), any());
+    verify(paymentCancelRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("부분 취소 후 전액 취소는 남은 금액만 기록하고 CANCELED로 전이한다")
+  void cancel_fullAfterPartial_savesRemainingAmount() {
+    Payment payment = Payment.createOrder(1L, 5L, "ord_1", 29000, "KRW", "Pro");
+    payment.complete("pay_1", "카드", OffsetDateTime.now(clock), null, "{}");
+    payment.markPartialCanceled("{}");
+    ReflectionTestUtils.setField(payment, "id", 7L);
+    given(paymentRepository.findByPaymentKeyAndWorkspaceIdForUpdate("pay_1", 1L))
+        .willReturn(Optional.of(payment));
+    given(paymentCancelRepository.sumCancelAmountByPaymentId(7L)).willReturn(10000L);
+    given(paymentRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+    given(tossPaymentPort.cancelPayment(eq("pay_1"), eq("남은 금액 취소"), isNull(), any()))
+        .willReturn(canceledResult());
+
+    PaymentResult result =
+        paymentService.cancelPayment(
+            new CancelPaymentCommand(1L, 99L, "pay_1", "남은 금액 취소", null, "idem-remain-1"));
+
+    ArgumentCaptor<PaymentCancel> cancelCaptor = ArgumentCaptor.forClass(PaymentCancel.class);
+    verify(paymentCancelRepository).save(cancelCaptor.capture());
+    assertThat(cancelCaptor.getValue().getCancelAmount()).isEqualTo(19000L);
+    assertThat(result.status()).isEqualTo("CANCELED");
+  }
+
+  @Test
+  @DisplayName("동시 부분 취소는 결제 행 잠금으로 직렬화되어 잔여 금액 초과 요청 하나만 거부한다")
+  void cancel_concurrentPartial_excessRejected() throws Exception {
+    ReentrantLock txLock = new ReentrantLock();
+    given(transactionManager.getTransaction(any()))
+        .willAnswer(
+            invocation -> {
+              txLock.lock();
+              return new SimpleTransactionStatus();
+            });
+    doAnswer(
+            invocation -> {
+              txLock.unlock();
+              return null;
+            })
+        .when(transactionManager)
+        .commit(any());
+    doAnswer(
+            invocation -> {
+              txLock.unlock();
+              return null;
+            })
+        .when(transactionManager)
+        .rollback(any());
+
+    Payment payment = Payment.createOrder(1L, 5L, "ord_1", 29000, "KRW", "Pro");
+    payment.complete("pay_1", "카드", OffsetDateTime.now(clock), null, "{}");
+    ReflectionTestUtils.setField(payment, "id", 7L);
+    AtomicLong canceledTotal = new AtomicLong(0);
+    given(paymentRepository.findByPaymentKeyAndWorkspaceIdForUpdate("pay_1", 1L))
+        .willReturn(Optional.of(payment));
+    given(paymentCancelRepository.sumCancelAmountByPaymentId(7L))
+        .willAnswer(invocation -> canceledTotal.get());
+    given(paymentCancelRepository.save(any()))
+        .willAnswer(
+            invocation -> {
+              PaymentCancel cancel = invocation.getArgument(0);
+              canceledTotal.addAndGet(cancel.getCancelAmount());
+              return cancel;
+            });
+    given(paymentRepository.save(any())).willAnswer(invocation -> invocation.getArgument(0));
+    given(tossPaymentPort.cancelPayment(eq("pay_1"), eq("고객 요청"), eq(20000L), any()))
+        .willReturn(partialCanceledResult());
+
+    CountDownLatch ready = new CountDownLatch(2);
+    CountDownLatch start = new CountDownLatch(1);
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+
+    try {
+      List<Future<CancelAttempt>> futures =
+          List.of(
+              executor.submit(cancelAttempt(ready, start)),
+              executor.submit(cancelAttempt(ready, start)));
+
+      assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
+      start.countDown();
+
+      List<CancelAttempt> attempts =
+          futures.stream().map(PaymentServiceTest::getCancelAttempt).toList();
+
+      assertThat(attempts.stream().filter(CancelAttempt::succeeded).count()).isEqualTo(1);
+      assertThat(attempts.stream().filter(CancelAttempt::failedWithCancelNotAllowed).count())
+          .isEqualTo(1);
+      assertThat(canceledTotal.get()).isEqualTo(20000L);
+      verify(tossPaymentPort, times(1)).cancelPayment(eq("pay_1"), eq("고객 요청"), eq(20000L), any());
+      verify(paymentCancelRepository, times(1)).save(any());
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  private Callable<CancelAttempt> cancelAttempt(CountDownLatch ready, CountDownLatch start) {
+    return () -> {
+      ready.countDown();
+      if (!start.await(5, TimeUnit.SECONDS)) {
+        throw new IllegalStateException("cancel attempts were not released");
+      }
+      try {
+        return CancelAttempt.success(
+            paymentService.cancelPayment(
+                new CancelPaymentCommand(
+                    1L, 99L, "pay_1", "고객 요청", 20000L, PaymentIdentifiers.idempotencyKey())));
+      } catch (RuntimeException ex) {
+        return CancelAttempt.failure(ex);
+      }
+    };
+  }
+
+  private static CancelAttempt getCancelAttempt(Future<CancelAttempt> future) {
+    try {
+      return future.get(10, TimeUnit.SECONDS);
+    } catch (Exception ex) {
+      throw new IllegalStateException("cancel attempt did not finish", ex);
+    }
+  }
+
+  private record CancelAttempt(PaymentResult result, Throwable failure) {
+    static CancelAttempt success(PaymentResult result) {
+      return new CancelAttempt(result, null);
+    }
+
+    static CancelAttempt failure(Throwable failure) {
+      return new CancelAttempt(null, failure);
+    }
+
+    boolean succeeded() {
+      return result != null && failure == null;
+    }
+
+    boolean failedWithCancelNotAllowed() {
+      return failure instanceof PaymentCancelNotAllowedException;
+    }
   }
 
   private Subscription subscription(Long id, Long planId) {

--- a/backend/src/test/java/com/init/payment/application/PaymentServiceTest.java
+++ b/backend/src/test/java/com/init/payment/application/PaymentServiceTest.java
@@ -184,6 +184,67 @@ class PaymentServiceTest {
   }
 
   @Test
+  @DisplayName("취소 가능 금액이 남지 않으면 Toss를 호출하지 않는다")
+  void cancel_noRemaining_throws() {
+    Payment payment = Payment.createOrder(1L, 5L, "ord_1", 29000, "KRW", "Pro");
+    payment.complete("pay_1", "카드", OffsetDateTime.now(clock), null, "{}");
+    payment.markPartialCanceled("{}");
+    ReflectionTestUtils.setField(payment, "id", 7L);
+    given(paymentRepository.findByPaymentKeyAndWorkspaceIdForUpdate("pay_1", 1L))
+        .willReturn(Optional.of(payment));
+    given(paymentCancelRepository.sumCancelAmountByPaymentId(7L)).willReturn(29000L);
+
+    assertThatThrownBy(
+            () ->
+                paymentService.cancelPayment(
+                    new CancelPaymentCommand(1L, 99L, "pay_1", "고객요청", null, "idem-none-1")))
+        .isInstanceOf(PaymentCancelNotAllowedException.class);
+    verify(tossPaymentPort, never()).cancelPayment(any(), any(), any(), any());
+  }
+
+  @Test
+  @DisplayName("취소 idempotency key가 없으면 서비스가 생성한 key로 Toss 요청과 취소 내역 저장을 수행한다")
+  void cancel_missingIdempotencyKey_generatesKey() {
+    Payment payment = Payment.createOrder(1L, 5L, "ord_1", 29000, "KRW", "Pro");
+    payment.complete("pay_1", "카드", OffsetDateTime.now(clock), null, "{}");
+    ReflectionTestUtils.setField(payment, "id", 7L);
+    given(paymentRepository.findByPaymentKeyAndWorkspaceIdForUpdate("pay_1", 1L))
+        .willReturn(Optional.of(payment));
+    given(paymentRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+    given(tossPaymentPort.cancelPayment(eq("pay_1"), eq("고객 요청"), eq(10000L), any()))
+        .willReturn(partialCanceledResult());
+
+    PaymentResult result =
+        paymentService.cancelPayment(
+            new CancelPaymentCommand(1L, 99L, "pay_1", "고객 요청", 10000L, null));
+
+    ArgumentCaptor<String> keyCaptor = ArgumentCaptor.forClass(String.class);
+    verify(tossPaymentPort)
+        .cancelPayment(eq("pay_1"), eq("고객 요청"), eq(10000L), keyCaptor.capture());
+    ArgumentCaptor<PaymentCancel> cancelCaptor = ArgumentCaptor.forClass(PaymentCancel.class);
+    verify(paymentCancelRepository).save(cancelCaptor.capture());
+    assertThat(keyCaptor.getValue()).isNotBlank();
+    assertThat(cancelCaptor.getValue().getIdempotencyKey()).isEqualTo(keyCaptor.getValue());
+    assertThat(result.status()).isEqualTo("PARTIAL_CANCELED");
+  }
+
+  @Test
+  @DisplayName("취소할 수 없는 결제 상태이면 Toss를 호출하지 않는다")
+  void cancel_nonCancelableStatus_throws() {
+    Payment payment = Payment.createOrder(1L, 5L, "ord_1", 29000, "KRW", "Pro");
+    ReflectionTestUtils.setField(payment, "id", 7L);
+    given(paymentRepository.findByPaymentKeyAndWorkspaceIdForUpdate("pay_1", 1L))
+        .willReturn(Optional.of(payment));
+
+    assertThatThrownBy(
+            () ->
+                paymentService.cancelPayment(
+                    new CancelPaymentCommand(1L, 99L, "pay_1", "고객요청", null, "idem-ready-1")))
+        .isInstanceOf(PaymentCancelNotAllowedException.class);
+    verify(tossPaymentPort, never()).cancelPayment(any(), any(), any(), any());
+  }
+
+  @Test
   @DisplayName("결제를 찾을 수 없으면 cancelPayment 시 PaymentNotFoundException을 던진다")
   void cancel_paymentNotFound_throws() {
     given(paymentRepository.findByPaymentKeyAndWorkspaceIdForUpdate("pay_x", 1L))

--- a/backend/src/test/java/com/init/payment/domain/model/PaymentTest.java
+++ b/backend/src/test/java/com/init/payment/domain/model/PaymentTest.java
@@ -64,6 +64,8 @@ class PaymentTest {
     partial.complete("pay_b", "카드", NOW, null, "{}");
     partial.markPartialCanceled("{}");
     assertThat(partial.getStatus()).isEqualTo(PaymentStatus.PARTIAL_CANCELED);
+    partial.markCanceled("{}");
+    assertThat(partial.getStatus()).isEqualTo(PaymentStatus.CANCELED);
 
     Payment aborted = Payment.createOrder(1L, 5L, "ord_c", 29000, "KRW", "Pro");
     aborted.markAborted("{}");

--- a/backend/src/test/java/com/init/payment/presentation/PaymentControllerTest.java
+++ b/backend/src/test/java/com/init/payment/presentation/PaymentControllerTest.java
@@ -1,7 +1,9 @@
 package com.init.payment.presentation;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -9,6 +11,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.init.fixtures.WithLongPrincipal;
+import com.init.payment.application.CancelPaymentCommand;
 import com.init.payment.application.PaymentResult;
 import com.init.payment.application.PaymentService;
 import com.init.payment.application.exception.PaymentAmountMismatchException;
@@ -17,6 +20,7 @@ import java.time.OffsetDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.ComponentScan;
@@ -117,6 +121,28 @@ class PaymentControllerTest {
                 .content("{\"cancelReason\":\"고객 요청\"}"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.status").value("CANCELED"));
+  }
+
+  @Test
+  @DisplayName("결제 취소 시 Idempotency-Key 헤더를 서비스 명령으로 전달한다")
+  @WithLongPrincipal(55L)
+  void cancel_passesIdempotencyKeyHeader() throws Exception {
+    given(paymentService.cancelPayment(any())).willReturn(paymentResult("PARTIAL_CANCELED"));
+
+    mockMvc
+        .perform(
+            post(BASE_URL + "/pay_1/cancel")
+                .with(csrf())
+                .header("Idempotency-Key", "cancel-key-1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"cancelReason\":\"고객 요청\",\"cancelAmount\":10000}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.status").value("PARTIAL_CANCELED"));
+
+    ArgumentCaptor<CancelPaymentCommand> commandCaptor =
+        ArgumentCaptor.forClass(CancelPaymentCommand.class);
+    verify(paymentService).cancelPayment(commandCaptor.capture());
+    assertThat(commandCaptor.getValue().cancelIdempotencyKey()).isEqualTo("cancel-key-1");
   }
 
   @Test


### PR DESCRIPTION
Closes #575

## 변경 사항

- 결제 취소 흐름에서 `payment` 행을 비관적 쓰기 잠금으로 조회하고, 최신 취소 합계 기준으로 잔여 취소 가능 금액을 검증합니다.
- `Idempotency-Key` 헤더를 결제 취소 명령으로 전달하고, 같은 `(payment_id, idempotency_key)` 취소 재시도는 Toss 재호출과 취소 내역 중복 저장 없이 기존 결제 상태를 반환합니다.
- 기존 duplicate cancel idempotency row를 정리한 뒤 unique index를 적용하도록 changelog를 보강했습니다.
- 부분취소 후 남은 금액 전액 취소 시 남은 금액만 취소 내역에 기록하고 `CANCELED`로 전이되도록 테스트로 고정했습니다.
- 이슈 575 스펙을 `.agent/specs/575.md`에 정리했습니다.

## 검증

- `git diff --check`
- `cd backend && JAVA_HOME=/Users/owen/.local/share/mise/installs/java/temurin-21.0.11+10.0.LTS PATH=/Users/owen/.local/share/mise/installs/java/temurin-21.0.11+10.0.LTS/bin:$PATH GRADLE_USER_HOME=/Users/owen/.codex/worktrees/d17f/ostone/.gradle-user-home ./gradlew --no-daemon --no-watch-fs spotlessCheck test --tests com.init.payment.application.PaymentServiceTest --tests com.init.payment.presentation.PaymentControllerTest --tests com.init.payment.domain.model.PaymentTest`
- `cd backend && JAVA_HOME=/Users/owen/.local/share/mise/installs/java/temurin-21.0.11+10.0.LTS PATH=/Users/owen/.local/share/mise/installs/java/temurin-21.0.11+10.0.LTS/bin:$PATH GRADLE_USER_HOME=/Users/owen/.codex/worktrees/d17f/ostone/.gradle-user-home ./gradlew --no-daemon --no-watch-fs spotlessCheck test --tests com.init.payment.application.PaymentServiceTest`
- 커밋 pre-commit hook: `cd backend && ./gradlew spotlessCheck`

## 참고

- 전역 Gradle artifact cache lock 경합을 피하기 위해 backend Gradle 검증은 별도 `GRADLE_USER_HOME`으로 실행했습니다.