### PR TITLE
fix(corpus): 만료되거나 생성자가 다른 업로드 완료 차단

### DIFF
--- a/.agent/specs/571.md
+++ b/.agent/specs/571.md
@@ -1,0 +1,66 @@
+# 원본 파일 업로드 완료 세션 검증
+
+## Goal
+
+presigned 원본 파일 업로드 완료 처리에서 업로드 세션의 만료 시각과 생성자를 검증해, 만료된 세션이나 다른 사용자가 만든 세션을 완료할 수 없도록 한다.
+
+## Problem
+
+`InitRawFileUploadService`는 업로드 세션 메타에 `expiresAt`과 `createdBy`를 저장하지만, `CompleteRawFileUploadService`는 완료 처리에서 해당 값을 읽어 검증하지 않는다. 이 때문에 업로드 URL TTL이 지난 세션이나 같은 워크스페이스의 다른 사용자가 생성한 세션이 완료 처리될 수 있다.
+
+Issue 본문에 적힌 `backend/src/main/java/com/example/backend/...` 경로는 현재 체크아웃에 존재하지 않는다. 확인된 실제 corpus 패키지는 `backend/src/main/java/com/init/corpus`이다.
+
+## Scope
+
+- `backend/src/main/java/com/init/corpus/application/CompleteRawFileUploadService.java`
+- `backend/src/test/java/com/init/corpus/application/CompleteRawFileUploadServiceTest.java`
+- `.agent/specs/571.md`
+
+## Non-Goals
+
+- presigned upload init API의 request/response 계약을 변경하지 않는다.
+- 업로드 URL TTL 값을 변경하지 않는다.
+- S3 object promotion, `dataset_raw_file` 저장, Airflow ingestion trigger 흐름을 재설계하지 않는다.
+- DB 스키마나 `dataset.meta_json` 저장 구조를 변경하지 않는다.
+
+## Current Contract
+
+| 파일 | 현재 역할 | 확인된 이슈 |
+| --- | --- | --- |
+| `backend/src/main/java/com/init/corpus/application/InitRawFileUploadService.java` | `upload.expiresAt`, `upload.createdBy`를 포함한 업로드 세션 메타 저장 | 세션 메타 생성은 이미 수행됨 |
+| `backend/src/main/java/com/init/corpus/application/CompleteRawFileUploadService.java` | 객체 존재/크기/상태를 검증한 뒤 pending object를 completed object로 승격 | `expiresAt`, `createdBy`를 검증하지 않음 |
+| `backend/src/test/java/com/init/corpus/application/CompleteRawFileUploadServiceTest.java` | 완료 처리 서비스 단위 테스트 | 만료 세션과 생성자 불일치 테스트가 없음 |
+
+## Design Diff
+
+| 영역 | As-is | To-be |
+| --- | --- | --- |
+| 세션 만료 | 메타에 저장되지만 완료 시 무시 | `expiresAt`이 현재 시각과 같거나 이전이면 `InvalidUploadStateException`으로 실패 |
+| 세션 생성자 | 메타에 저장되지만 완료 요청 사용자와 비교하지 않음 | `createdBy`가 완료 command의 `createdBy`와 다르면 `InvalidUploadStateException`으로 실패 |
+| 메타 파싱 | `objectKey`, `expectedSizeBytes`, `filename`, `contentType`만 세션 record에 포함 | `expiresAt`, `createdBy`도 세션 record에 포함 |
+| 실패 시 부작용 | 검증 누락으로 object head/copy, raw file 저장, trigger까지 진행 가능 | 실패 시 storage 접근, raw file 저장, dataset 저장, trigger가 수행되지 않음 |
+
+## Requirements
+
+- 완료 처리 서비스는 upload session의 `expiresAt`을 필수 값으로 읽는다.
+- `expiresAt`이 없거나 파싱할 수 없으면 업로드 세션 상태 오류로 실패한다.
+- `expiresAt`이 현재 시각과 같거나 과거이면 업로드 완료를 거절한다.
+- 완료 처리 서비스는 upload session의 `createdBy`를 필수 값으로 읽는다.
+- session `createdBy`와 command `createdBy`가 다르면 업로드 완료를 거절한다.
+- 만료 또는 생성자 불일치 실패는 사용자에게 의미 있는 Bad Request 계열 응답으로 전달된다.
+
+## Acceptance Criteria
+
+- 만료된 업로드 세션은 완료할 수 없다.
+- 다른 사용자가 생성한 업로드 세션은 완료할 수 없다.
+- 두 실패 케이스 모두 `CompleteRawFileUploadServiceTest`에서 검증된다.
+- 두 실패 케이스에서 storage object 조회/승격, raw file 저장, ingestion trigger가 수행되지 않는다.
+- 기존 정상 완료, 멱등 완료, 객체 크기 검증 테스트는 계속 통과한다.
+
+## Validation
+
+- `cd backend && ./gradlew test --tests com.init.corpus.application.CompleteRawFileUploadServiceTest`
+
+## Open Questions
+
+- 없음. 이슈 본문과 현재 upload session meta 계약으로 요구사항이 확인된다.

--- a/backend/src/main/java/com/init/corpus/application/CompleteRawFileUploadService.java
+++ b/backend/src/main/java/com/init/corpus/application/CompleteRawFileUploadService.java
@@ -15,6 +15,8 @@ import com.init.corpus.domain.model.DatasetStatus;
 import com.init.corpus.domain.repository.DatasetRawFileRepository;
 import com.init.corpus.domain.repository.DatasetRepository;
 import com.init.corpus.domain.repository.WorkspaceMembershipRepository;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeParseException;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -83,6 +85,7 @@ public class CompleteRawFileUploadService {
                 () -> new DatasetNotFoundException("데이터셋을 찾을 수 없습니다. id=" + command.datasetId()));
 
     UploadSession session = readUploadSession(dataset);
+    validateUploadSession(session, command, dataset);
 
     // 멱등: 이미 처리 단계로 넘어간 데이터셋은 객체를 다시 승격하거나 DAG를 다시 트리거하지 않고 현재 상태를 그대로 반환한다.
     if (dataset.getStatus() != DatasetStatus.UPLOADING) {
@@ -181,6 +184,19 @@ public class CompleteRawFileUploadService {
     return objectKey;
   }
 
+  private void validateUploadSession(
+      UploadSession session, CompleteRawFileUploadCommand command, Dataset dataset) {
+    OffsetDateTime now = OffsetDateTime.now();
+    if (!session.expiresAt().isAfter(now)) {
+      throw new InvalidUploadStateException(
+          "업로드 세션이 만료되었습니다. 다시 업로드를 시작해 주세요. datasetId=" + dataset.getId());
+    }
+    if (!session.createdBy().equals(command.createdBy())) {
+      throw new InvalidUploadStateException(
+          "업로드 세션 생성자와 완료 요청 사용자가 일치하지 않습니다. datasetId=" + dataset.getId());
+    }
+  }
+
   private UploadSession readUploadSession(Dataset dataset) {
     JsonNode upload = parseMeta(dataset).path(UploadSessionMeta.FIELD);
     if (!upload.isObject()) {
@@ -205,7 +221,33 @@ public class CompleteRawFileUploadService {
         Optional.ofNullable(upload.path(UploadSessionMeta.CONTENT_TYPE).asText(null))
             .filter(s -> !s.isBlank())
             .orElse("application/zip");
-    return new UploadSession(objectKey, expectedSizeBytes, filename, contentType);
+    OffsetDateTime expiresAt = readExpiresAt(upload, dataset);
+    Long createdBy = readCreatedBy(upload, dataset);
+    return new UploadSession(
+        objectKey, expectedSizeBytes, filename, contentType, expiresAt, createdBy);
+  }
+
+  private OffsetDateTime readExpiresAt(JsonNode upload, Dataset dataset) {
+    String expiresAt = upload.path(UploadSessionMeta.EXPIRES_AT).asText(null);
+    if (expiresAt == null || expiresAt.isBlank()) {
+      throw new InvalidUploadStateException(
+          "업로드 세션에 expiresAt이 없습니다. datasetId=" + dataset.getId());
+    }
+    try {
+      return OffsetDateTime.parse(expiresAt);
+    } catch (DateTimeParseException e) {
+      throw new InvalidUploadStateException(
+          "업로드 세션 expiresAt 형식이 올바르지 않습니다. datasetId=" + dataset.getId());
+    }
+  }
+
+  private Long readCreatedBy(JsonNode upload, Dataset dataset) {
+    JsonNode createdBy = upload.path(UploadSessionMeta.CREATED_BY);
+    if (!createdBy.isIntegralNumber() || !createdBy.canConvertToLong()) {
+      throw new InvalidUploadStateException(
+          "업로드 세션에 createdBy가 없습니다. datasetId=" + dataset.getId());
+    }
+    return createdBy.asLong();
   }
 
   private JsonNode parseMeta(Dataset dataset) {
@@ -223,5 +265,10 @@ public class CompleteRawFileUploadService {
   }
 
   private record UploadSession(
-      String objectKey, long expectedSizeBytes, String filename, String contentType) {}
+      String objectKey,
+      long expectedSizeBytes,
+      String filename,
+      String contentType,
+      OffsetDateTime expiresAt,
+      Long createdBy) {}
 }

--- a/backend/src/test/java/com/init/corpus/application/CompleteRawFileUploadServiceTest.java
+++ b/backend/src/test/java/com/init/corpus/application/CompleteRawFileUploadServiceTest.java
@@ -253,6 +253,77 @@ class CompleteRawFileUploadServiceTest {
   }
 
   @Test
+  @DisplayName("should_throw_when_upload_session_expiresAt_missing")
+  void complete_missingExpiresAt_throws() {
+    given(workspaceMembershipRepository.existsByWorkspaceIdAndUserId(1L, 1L)).willReturn(true);
+    Dataset dataset = uploadingDataset();
+    dataset.updateMetaJson(
+        "{\"upload\":{\"objectKey\":\""
+            + OBJECT_KEY
+            + "\",\"expectedSizeBytes\":"
+            + EXPECTED_SIZE
+            + ",\"filename\":\"data.zip\",\"contentType\":\"application/zip\",\"createdBy\":1}}");
+    given(datasetRepository.findByIdAndWorkspaceIdForUpdate(42L, 1L))
+        .willReturn(Optional.of(dataset));
+
+    assertThatThrownBy(() -> service.complete(command()))
+        .isInstanceOf(InvalidUploadStateException.class)
+        .hasMessageContaining("expiresAt");
+
+    verify(storagePort, never()).headObject(anyString());
+    verify(rawFileRepository, never()).save(any());
+    verify(triggerPort, never()).trigger(anyLong(), anyLong(), anyString());
+  }
+
+  @Test
+  @DisplayName("should_throw_when_upload_session_expiresAt_malformed")
+  void complete_malformedExpiresAt_throws() {
+    given(workspaceMembershipRepository.existsByWorkspaceIdAndUserId(1L, 1L)).willReturn(true);
+    Dataset dataset = uploadingDataset();
+    dataset.updateMetaJson(
+        "{\"upload\":{\"objectKey\":\""
+            + OBJECT_KEY
+            + "\",\"expectedSizeBytes\":"
+            + EXPECTED_SIZE
+            + ",\"filename\":\"data.zip\",\"contentType\":\"application/zip\",\"expiresAt\":\"not-a-date\",\"createdBy\":1}}");
+    given(datasetRepository.findByIdAndWorkspaceIdForUpdate(42L, 1L))
+        .willReturn(Optional.of(dataset));
+
+    assertThatThrownBy(() -> service.complete(command()))
+        .isInstanceOf(InvalidUploadStateException.class)
+        .hasMessageContaining("expiresAt 형식");
+
+    verify(storagePort, never()).headObject(anyString());
+    verify(rawFileRepository, never()).save(any());
+    verify(triggerPort, never()).trigger(anyLong(), anyLong(), anyString());
+  }
+
+  @Test
+  @DisplayName("should_throw_when_upload_session_createdBy_missing")
+  void complete_missingCreatedBy_throws() {
+    given(workspaceMembershipRepository.existsByWorkspaceIdAndUserId(1L, 1L)).willReturn(true);
+    Dataset dataset = uploadingDataset();
+    dataset.updateMetaJson(
+        "{\"upload\":{\"objectKey\":\""
+            + OBJECT_KEY
+            + "\",\"expectedSizeBytes\":"
+            + EXPECTED_SIZE
+            + ",\"filename\":\"data.zip\",\"contentType\":\"application/zip\",\"expiresAt\":\""
+            + OffsetDateTime.now().plusMinutes(15)
+            + "\"}}");
+    given(datasetRepository.findByIdAndWorkspaceIdForUpdate(42L, 1L))
+        .willReturn(Optional.of(dataset));
+
+    assertThatThrownBy(() -> service.complete(command()))
+        .isInstanceOf(InvalidUploadStateException.class)
+        .hasMessageContaining("createdBy");
+
+    verify(storagePort, never()).headObject(anyString());
+    verify(rawFileRepository, never()).save(any());
+    verify(triggerPort, never()).trigger(anyLong(), anyLong(), anyString());
+  }
+
+  @Test
   @DisplayName("should_throw_when_upload_session_createdBy_mismatches_request_user")
   void complete_createdByMismatch_throws() {
     given(workspaceMembershipRepository.existsByWorkspaceIdAndUserId(1L, 2L)).willReturn(true);

--- a/backend/src/test/java/com/init/corpus/application/CompleteRawFileUploadServiceTest.java
+++ b/backend/src/test/java/com/init/corpus/application/CompleteRawFileUploadServiceTest.java
@@ -79,13 +79,19 @@ class CompleteRawFileUploadServiceTest {
   }
 
   private String buildMeta(long size) {
+    return buildMeta(size, OffsetDateTime.now().plusMinutes(15), 1L);
+  }
+
+  private String buildMeta(long size, OffsetDateTime expiresAt, long createdBy) {
     return "{\"upload\":{\"objectKey\":\""
         + OBJECT_KEY
         + "\",\"expectedSizeBytes\":"
         + size
         + ",\"filename\":\"data.zip\",\"contentType\":\"application/zip\",\"expiresAt\":\""
-        + OffsetDateTime.now().plusMinutes(15)
-        + "\",\"createdBy\":1}}";
+        + expiresAt
+        + "\",\"createdBy\":"
+        + createdBy
+        + "}}";
   }
 
   @Test
@@ -227,6 +233,45 @@ class CompleteRawFileUploadServiceTest {
   }
 
   @Test
+  @DisplayName("should_throw_when_upload_session_expired")
+  void complete_expiredUploadSession_throws() {
+    given(workspaceMembershipRepository.existsByWorkspaceIdAndUserId(1L, 1L)).willReturn(true);
+    Dataset dataset = uploadingDataset();
+    dataset.updateMetaJson(buildMeta(EXPECTED_SIZE, OffsetDateTime.now().minusMinutes(1), 1L));
+    given(datasetRepository.findByIdAndWorkspaceIdForUpdate(42L, 1L))
+        .willReturn(Optional.of(dataset));
+
+    assertThatThrownBy(() -> service.complete(command()))
+        .isInstanceOf(InvalidUploadStateException.class)
+        .hasMessageContaining("만료");
+
+    verify(storagePort, never()).headObject(anyString());
+    verify(storagePort, never()).copyObject(anyString(), anyString());
+    verify(rawFileRepository, never()).save(any());
+    verify(datasetRepository, never()).save(any());
+    verify(triggerPort, never()).trigger(anyLong(), anyLong(), anyString());
+  }
+
+  @Test
+  @DisplayName("should_throw_when_upload_session_createdBy_mismatches_request_user")
+  void complete_createdByMismatch_throws() {
+    given(workspaceMembershipRepository.existsByWorkspaceIdAndUserId(1L, 2L)).willReturn(true);
+    Dataset dataset = uploadingDataset();
+    given(datasetRepository.findByIdAndWorkspaceIdForUpdate(42L, 1L))
+        .willReturn(Optional.of(dataset));
+
+    assertThatThrownBy(() -> service.complete(new CompleteRawFileUploadCommand(1L, 42L, 2L)))
+        .isInstanceOf(InvalidUploadStateException.class)
+        .hasMessageContaining("생성자");
+
+    verify(storagePort, never()).headObject(anyString());
+    verify(storagePort, never()).copyObject(anyString(), anyString());
+    verify(rawFileRepository, never()).save(any());
+    verify(datasetRepository, never()).save(any());
+    verify(triggerPort, never()).trigger(anyLong(), anyLong(), anyString());
+  }
+
+  @Test
   @DisplayName("should_throw_when_object_size_mismatches_expected")
   void complete_sizeMismatch_throws() {
     given(workspaceMembershipRepository.existsByWorkspaceIdAndUserId(1L, 1L)).willReturn(true);
@@ -274,7 +319,9 @@ class CompleteRawFileUploadServiceTest {
     dataset.updateMetaJson(
         "{\"upload\":{\"objectKey\":\"direct/key.zip\",\"expectedSizeBytes\":"
             + EXPECTED_SIZE
-            + ",\"filename\":\"data.zip\",\"contentType\":\"application/zip\"}}");
+            + ",\"filename\":\"data.zip\",\"contentType\":\"application/zip\",\"expiresAt\":\""
+            + OffsetDateTime.now().plusMinutes(15)
+            + "\",\"createdBy\":1}}");
     given(datasetRepository.findByIdAndWorkspaceIdForUpdate(42L, 1L))
         .willReturn(Optional.of(dataset));
     given(storagePort.headObject("direct/key.zip"))
@@ -354,7 +401,9 @@ class CompleteRawFileUploadServiceTest {
             + OBJECT_KEY
             + "\",\"expectedSizeBytes\":"
             + EXPECTED_SIZE
-            + "}}");
+            + ",\"expiresAt\":\""
+            + OffsetDateTime.now().plusMinutes(15)
+            + "\",\"createdBy\":1}}");
     given(datasetRepository.findByIdAndWorkspaceIdForUpdate(42L, 1L))
         .willReturn(Optional.of(dataset));
     given(storagePort.headObject(OBJECT_KEY))
@@ -385,7 +434,9 @@ class CompleteRawFileUploadServiceTest {
     String nonPendingMeta =
         "{\"upload\":{\"objectKey\":\"direct/key.zip\",\"expectedSizeBytes\":"
             + EXPECTED_SIZE
-            + ",\"filename\":\"data.zip\",\"contentType\":\"application/zip\"}}";
+            + ",\"filename\":\"data.zip\",\"contentType\":\"application/zip\",\"expiresAt\":\""
+            + OffsetDateTime.now().plusMinutes(15)
+            + "\",\"createdBy\":1}}";
     dataset.updateMetaJson(nonPendingMeta);
     given(datasetRepository.findByIdAndWorkspaceIdForUpdate(42L, 1L))
         .willReturn(Optional.of(dataset));


### PR DESCRIPTION
Closes #571

## 변경 사항

- 원본 파일 presigned upload 완료 시 세션 메타의 `expiresAt`을 검증해 만료된 세션의 완료 처리를 차단합니다.
- 완료 요청 사용자와 세션 `createdBy`가 다르면 storage 조회, object 승격, raw file 저장, ingestion trigger 전에 실패하도록 했습니다.
- 이슈 571 스펙을 `.agent/specs/571.md`에 정리하고, 만료 세션과 생성자 불일치 케이스를 서비스 테스트로 고정했습니다.

## 검증

- `git diff --check`
- `cd backend && JAVA_HOME=/Users/owen/.local/share/mise/installs/java/temurin-21.0.11+10.0.LTS GRADLE_USER_HOME=/Users/owen/.codex/worktrees/f7e3/ostone/.gradle-user-home ./gradlew --no-daemon test --tests com.init.corpus.application.CompleteRawFileUploadServiceTest`
- `cd backend && JAVA_HOME=/Users/owen/.local/share/mise/installs/java/temurin-21.0.11+10.0.LTS GRADLE_USER_HOME=/Users/owen/.codex/worktrees/f7e3/ostone/.gradle-user-home ./gradlew --no-daemon spotlessCheck`
- 커밋 pre-commit hook: `cd backend && ./gradlew spotlessCheck`

## 참고

- 전역 Gradle journal cache lock 경합을 피하기 위해 backend Gradle 검증은 별도 `GRADLE_USER_HOME`으로 실행했습니다.