### PR TITLE
fix(payment): billing key 발급 중 첫 과금 중복 실행 차단

### DIFF
--- a/.agent/specs/576.md
+++ b/.agent/specs/576.md
@@ -1,0 +1,93 @@
+# Backend Spec: billing key authorization 직렬화
+
+## Goal
+
+동일 구독에 대한 billing key 발급 요청이 동시에 들어와도 외부 billing key 발급과 첫 과금이 중복 실행되지 않도록 구독 단위 authorization 흐름을 직렬화한다.
+
+## Problem
+
+현재 billing key 발급 흐름은 구독 상태가 `INCOMPLETE`인지 확인한 뒤 외부 Toss billing key 발급과 첫 과금을 수행하고, 마지막 트랜잭션에서 결제와 구독 활성화를 저장한다. 같은 구독에 대해 동시 요청이 들어오면 두 요청이 모두 초기 상태 확인을 통과한 뒤 외부 첫 과금을 각각 실행할 수 있다.
+
+## Scope
+
+- `backend/src/main/java/com/init/payment/application/SubscriptionService.java`
+- `backend/src/main/java/com/init/payment/domain/model/Subscription.java`
+- `backend/src/main/java/com/init/payment/domain/model/SubscriptionStatus.java`
+- `backend/src/main/java/com/init/payment/domain/repository/SubscriptionRepository.java`
+- `backend/src/main/java/com/init/payment/infrastructure/persistence/JpaSubscriptionRepository.java`
+- `backend/src/main/resources/db/changelog/db.changelog-master.sql`
+- `backend/src/test/java/com/init/payment/application/SubscriptionServiceTest.java`
+- `backend/src/test/java/com/init/payment/application/SubscriptionServiceConcurrencyTest.java`
+
+## Non-Goals
+
+- Toss API의 원격 멱등성 정책을 새로 설계하지 않는다.
+- billing key 저장 구조나 암호화 방식은 변경하지 않는다.
+- 정기결제 스케줄러의 동주기 중복청구 방어 로직은 변경하지 않는다.
+
+## Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    actor c1 as Client A
+    actor c2 as Client B
+    participant svc as SubscriptionService
+    participant repo as SubscriptionRepository
+    participant toss as TossPaymentPort
+    participant db as PostgreSQL
+
+    c1 ->> svc: issueBillingKey
+    svc ->> repo: findCurrentByWorkspaceIdForUpdate
+    repo ->> db: SELECT ... FOR UPDATE
+    svc ->> svc: INCOMPLETE -> AUTHORIZING
+    svc ->> db: commit claim
+    c2 ->> svc: issueBillingKey
+    svc ->> repo: findCurrentByWorkspaceIdForUpdate
+    repo ->> db: SELECT ... FOR UPDATE
+    svc -->> c2: 409 SUBSCRIPTION_ALREADY_EXISTS
+    svc ->> toss: issueBillingKey
+    svc ->> toss: executeBilling
+    svc ->> repo: findByIdForUpdate
+    svc ->> svc: AUTHORIZING 상태 재검증
+    svc ->> db: payment 저장 및 ACTIVE 전환
+    svc -->> c1: BillingAuthorizationResult
+```
+
+## Behavior
+
+- billing key 발급 시작 시 현재 구독 row를 pessimistic write lock으로 조회하고, `INCOMPLETE` 상태인 경우에만 `AUTHORIZING`으로 전환한다.
+- 이미 `AUTHORIZING`, `ACTIVE`, `PAST_DUE` 또는 그 외 비-`INCOMPLETE` 상태인 현재 구독에 대한 billing key 발급 요청은 기존 `ActiveSubscriptionExistsException` 경로로 409 응답을 반환한다.
+- 첫 과금 저장 직전에는 구독 row를 다시 lock으로 조회하고 `AUTHORIZING` 상태인지 검증한다.
+- Toss billing key 발급 또는 첫 과금 호출이 게이트웨이 오류/거절로 실패하면 구독 상태를 다시 `INCOMPLETE`로 되돌려 사용자가 재시도할 수 있게 한다.
+- 첫 과금 결과가 완료 상태가 아니면 결제는 `ABORTED`로 기록하고 구독은 `INCOMPLETE`로 되돌린다.
+- `AUTHORIZING`도 워크스페이스의 open subscription으로 간주되도록 partial unique index 조건에 포함한다.
+
+## API Impact
+
+기존 endpoint와 response schema는 변경하지 않는다.
+
+| Method | Path | Change |
+|--------|------|--------|
+| POST | `/api/v1/workspaces/{workspaceId}/billing/authorizations` | 동일 구독의 진행 중/중복 요청은 409 `SUBSCRIPTION_ALREADY_EXISTS`로 정리 |
+
+## Data Impact
+
+- `payment.subscription.status` enum 값에 `AUTHORIZING`을 추가한다.
+- `payment.subscription`의 open subscription partial unique index 조건에 `AUTHORIZING`을 포함한다.
+
+## Acceptance Criteria
+
+- 동일 구독에 대해 billing key 발급 요청 2개가 동시에 실행되어도 `TossPaymentPort.executeBilling`은 한 번만 호출된다.
+- 중복 요청은 외부 billing key 발급이나 첫 과금을 실행하기 전에 409로 실패한다.
+- 첫 과금 저장 직전 `AUTHORIZING` 상태 재검증이 수행된다.
+- 게이트웨이 실패 또는 거절이 발생하면 구독은 재시도 가능한 `INCOMPLETE` 상태로 돌아간다.
+- 동시성 테스트가 추가되어 중복 첫 과금 방지를 검증한다.
+
+## Validation
+
+- `cd backend && ./gradlew test --tests com.init.payment.application.SubscriptionServiceTest --tests com.init.payment.application.SubscriptionServiceConcurrencyTest`
+- 필요 시 전체 backend 회귀 확인: `cd backend && ./gradlew test`
+
+## Open Questions
+
+- 없음.

--- a/backend/src/main/java/com/init/payment/application/SubscriptionService.java
+++ b/backend/src/main/java/com/init/payment/application/SubscriptionService.java
@@ -1,6 +1,8 @@
 package com.init.payment.application;
 
 import com.init.payment.application.exception.ActiveSubscriptionExistsException;
+import com.init.payment.application.exception.PaymentGatewayException;
+import com.init.payment.application.exception.PaymentRejectedException;
 import com.init.payment.application.exception.PlanNotFoundException;
 import com.init.payment.application.exception.SubscriptionNotFoundException;
 import com.init.payment.application.port.BillingKeyCipher;
@@ -128,76 +130,129 @@ public class SubscriptionService {
   public BillingAuthorizationResult issueBillingKey(IssueBillingKeyCommand command) {
     accessGuard.requireMember(command.workspaceId(), command.userId());
 
-    Subscription subscription =
-        inTx(
-            () ->
-                subscriptionRepository
-                    .findCurrentByWorkspaceId(command.workspaceId())
-                    .orElseThrow(() -> new SubscriptionNotFoundException(command.workspaceId())));
-    if (subscription.getStatus() != SubscriptionStatus.INCOMPLETE) {
-      throw new ActiveSubscriptionExistsException(command.workspaceId());
-    }
-    Plan plan = requirePlan(subscription.getPlanId());
-    String customerKey = subscription.getCustomerKey();
+    BillingAuthorizationClaim claim = claimBillingAuthorization(command.workspaceId());
+    Plan plan = requirePlan(claim.planId());
 
-    TossBillingKeyResult issued = tossPaymentPort.issueBillingKey(command.authKey(), customerKey);
-    byte[] encrypted = billingKeyCipher.encrypt(issued.billingKey());
+    try {
+      String customerKey = claim.customerKey();
+      TossBillingKeyResult issued = tossPaymentPort.issueBillingKey(command.authKey(), customerKey);
+      byte[] encrypted = billingKeyCipher.encrypt(issued.billingKey());
 
-    BillingKey billingKey =
-        inTx(
-            () ->
-                billingKeyRepository.save(
-                    BillingKey.create(
-                        command.workspaceId(),
-                        customerKey,
-                        encrypted,
-                        issued.cardCompany(),
-                        issued.cardNumberMasked())));
+      BillingKey billingKey =
+          inTx(
+              () ->
+                  billingKeyRepository.save(
+                      BillingKey.create(
+                          command.workspaceId(),
+                          customerKey,
+                          encrypted,
+                          issued.cardCompany(),
+                          issued.cardNumberMasked())));
 
-    OffsetDateTime periodStart = OffsetDateTime.now(clock);
-    OffsetDateTime periodEnd = plan.getBillingInterval().advance(periodStart);
-    String orderId = PaymentIdentifiers.orderId();
-    String periodKey = PaymentIdentifiers.periodKey(periodStart);
+      OffsetDateTime periodStart = OffsetDateTime.now(clock);
+      OffsetDateTime periodEnd = plan.getBillingInterval().advance(periodStart);
+      String orderId = PaymentIdentifiers.orderId();
+      String periodKey = PaymentIdentifiers.periodKey(periodStart);
 
-    TossPaymentResult charge =
-        tossPaymentPort.executeBilling(
-            new TossBillingExecuteCommand(
-                issued.billingKey(), customerKey, plan.getAmount(), orderId, plan.getName()));
+      TossPaymentResult charge =
+          tossPaymentPort.executeBilling(
+              new TossBillingExecuteCommand(
+                  issued.billingKey(), customerKey, plan.getAmount(), orderId, plan.getName()));
 
-    Subscription activated =
-        inTx(
-            () -> {
-              Subscription current =
-                  subscriptionRepository
-                      .findById(subscription.getId())
-                      .orElseThrow(() -> new SubscriptionNotFoundException(command.workspaceId()));
-              Payment payment =
-                  Payment.createRecurring(
+      Subscription finalized =
+          inTx(
+              () ->
+                  finalizeBillingAuthorization(
                       command.workspaceId(),
-                      current.getId(),
+                      claim.subscriptionId(),
+                      plan,
+                      customerKey,
                       orderId,
-                      plan.getAmount(),
-                      plan.getCurrency(),
-                      plan.getName(),
                       periodKey,
-                      PaymentIdentifiers.idempotencyKey());
-              if (charge.isDone()) {
-                payment.complete(
-                    charge.paymentKey(),
-                    charge.method(),
-                    chargeApprovedAt(charge),
-                    charge.receiptUrl(),
-                    charge.maskedRawJson());
-                current.activate(periodStart, periodEnd, customerKey);
-              } else {
-                payment.markAborted(charge.maskedRawJson());
-              }
-              paymentRepository.save(payment);
-              return subscriptionRepository.save(current);
-            });
+                      periodStart,
+                      periodEnd,
+                      charge));
 
-    return new BillingAuthorizationResult(
-        SubscriptionResult.from(activated, plan), BillingKeySummary.from(billingKey));
+      return new BillingAuthorizationResult(
+          SubscriptionResult.from(finalized, plan), BillingKeySummary.from(billingKey));
+    } catch (PaymentGatewayException | PaymentRejectedException ex) {
+      resetBillingAuthorization(claim.subscriptionId());
+      throw ex;
+    }
+  }
+
+  private BillingAuthorizationClaim claimBillingAuthorization(Long workspaceId) {
+    return inTx(
+        () -> {
+          Subscription subscription =
+              subscriptionRepository
+                  .findCurrentByWorkspaceIdForUpdate(workspaceId)
+                  .orElseThrow(() -> new SubscriptionNotFoundException(workspaceId));
+          if (subscription.getStatus() != SubscriptionStatus.INCOMPLETE) {
+            throw new ActiveSubscriptionExistsException(workspaceId);
+          }
+          subscription.beginAuthorization();
+          Subscription saved = subscriptionRepository.save(subscription);
+          return new BillingAuthorizationClaim(
+              saved.getId(), saved.getPlanId(), saved.getCustomerKey());
+        });
+  }
+
+  private Subscription finalizeBillingAuthorization(
+      Long workspaceId,
+      Long subscriptionId,
+      Plan plan,
+      String customerKey,
+      String orderId,
+      String periodKey,
+      OffsetDateTime periodStart,
+      OffsetDateTime periodEnd,
+      TossPaymentResult charge) {
+    Subscription current =
+        subscriptionRepository
+            .findByIdForUpdate(subscriptionId)
+            .orElseThrow(() -> new SubscriptionNotFoundException(workspaceId));
+    if (current.getStatus() != SubscriptionStatus.AUTHORIZING) {
+      throw new ActiveSubscriptionExistsException(workspaceId);
+    }
+
+    Payment payment =
+        Payment.createRecurring(
+            workspaceId,
+            current.getId(),
+            orderId,
+            plan.getAmount(),
+            plan.getCurrency(),
+            plan.getName(),
+            periodKey,
+            PaymentIdentifiers.idempotencyKey());
+    if (charge.isDone()) {
+      payment.complete(
+          charge.paymentKey(),
+          charge.method(),
+          chargeApprovedAt(charge),
+          charge.receiptUrl(),
+          charge.maskedRawJson());
+      current.activate(periodStart, periodEnd, customerKey);
+    } else {
+      payment.markAborted(charge.maskedRawJson());
+      current.resetAuthorization();
+    }
+    paymentRepository.save(payment);
+    return subscriptionRepository.save(current);
+  }
+
+  private void resetBillingAuthorization(Long subscriptionId) {
+    inTxRun(
+        () ->
+            subscriptionRepository
+                .findByIdForUpdate(subscriptionId)
+                .filter(subscription -> subscription.getStatus() == SubscriptionStatus.AUTHORIZING)
+                .ifPresent(
+                    subscription -> {
+                      subscription.resetAuthorization();
+                      subscriptionRepository.save(subscription);
+                    }));
   }
 
   private OffsetDateTime chargeApprovedAt(TossPaymentResult charge) {
@@ -213,6 +268,12 @@ public class SubscriptionService {
   private <T> T inTx(Supplier<T> callback) {
     return transactionTemplate.execute(status -> callback.get());
   }
+
+  private void inTxRun(Runnable callback) {
+    transactionTemplate.executeWithoutResult(status -> callback.run());
+  }
+
+  private record BillingAuthorizationClaim(Long subscriptionId, Long planId, String customerKey) {}
 
   private Subscription saveNewSubscription(Subscription subscription, Long workspaceId) {
     try {

--- a/backend/src/main/java/com/init/payment/domain/model/Subscription.java
+++ b/backend/src/main/java/com/init/payment/domain/model/Subscription.java
@@ -86,7 +86,24 @@ public class Subscription {
     this.customerKey = customerKey;
   }
 
-  /** 첫 결제 성공 시 구독 활성화. INCOMPLETE/PAST_DUE -> ACTIVE. */
+  /** billing key 발급과 첫 과금을 진행 중으로 표시해 동일 구독의 외부 과금 중복 실행을 막는다. */
+  public void beginAuthorization() {
+    if (status != SubscriptionStatus.INCOMPLETE) {
+      throw new IllegalStateException(
+          "billing authorization은 INCOMPLETE 구독에서만 시작할 수 있습니다: " + status);
+    }
+    this.status = SubscriptionStatus.AUTHORIZING;
+  }
+
+  /** billing key 발급 또는 첫 과금이 완료되지 못하면 재시도 가능한 상태로 되돌린다. */
+  public void resetAuthorization() {
+    if (status != SubscriptionStatus.AUTHORIZING) {
+      throw new IllegalStateException("AUTHORIZING 구독만 재시도 상태로 되돌릴 수 있습니다: " + status);
+    }
+    this.status = SubscriptionStatus.INCOMPLETE;
+  }
+
+  /** 첫 결제 성공 시 구독 활성화. INCOMPLETE/AUTHORIZING/PAST_DUE -> ACTIVE. */
   public void activate(OffsetDateTime periodStart, OffsetDateTime periodEnd, String customerKey) {
     if (periodStart == null || periodEnd == null || !periodEnd.isAfter(periodStart)) {
       throw new IllegalArgumentException("periodEnd는 periodStart 이후여야 합니다.");

--- a/backend/src/main/java/com/init/payment/domain/model/SubscriptionStatus.java
+++ b/backend/src/main/java/com/init/payment/domain/model/SubscriptionStatus.java
@@ -2,6 +2,7 @@ package com.init.payment.domain.model;
 
 public enum SubscriptionStatus {
   INCOMPLETE,
+  AUTHORIZING,
   ACTIVE,
   PAST_DUE,
   CANCELED;

--- a/backend/src/main/java/com/init/payment/domain/repository/SubscriptionRepository.java
+++ b/backend/src/main/java/com/init/payment/domain/repository/SubscriptionRepository.java
@@ -11,8 +11,12 @@ public interface SubscriptionRepository {
 
   Optional<Subscription> findById(Long id);
 
+  Optional<Subscription> findByIdForUpdate(Long id);
+
   /** 워크스페이스의 현재(미해지) 구독. 워크스페이스당 활성 구독은 1개 (U-010). */
   Optional<Subscription> findCurrentByWorkspaceId(Long workspaceId);
+
+  Optional<Subscription> findCurrentByWorkspaceIdForUpdate(Long workspaceId);
 
   /** 정기결제 대상: ACTIVE, 기간 만료, 기간말 해지 예약 없음. */
   List<Subscription> findChargeable(OffsetDateTime now);

--- a/backend/src/main/java/com/init/payment/infrastructure/persistence/JpaSubscriptionRepository.java
+++ b/backend/src/main/java/com/init/payment/infrastructure/persistence/JpaSubscriptionRepository.java
@@ -3,10 +3,14 @@ package com.init.payment.infrastructure.persistence;
 import com.init.payment.domain.model.Subscription;
 import com.init.payment.domain.model.SubscriptionStatus;
 import com.init.payment.domain.repository.SubscriptionRepository;
+import jakarta.persistence.LockModeType;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -18,6 +22,23 @@ public interface JpaSubscriptionRepository
     return findFirstByWorkspaceIdAndStatusNotOrderByIdDesc(
         workspaceId, SubscriptionStatus.CANCELED);
   }
+
+  @Override
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query("select s from Subscription s where s.id = :id")
+  Optional<Subscription> findByIdForUpdate(@Param("id") Long id);
+
+  @Override
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query(
+      """
+      select s
+      from Subscription s
+      where s.workspaceId = :workspaceId
+        and s.status <> com.init.payment.domain.model.SubscriptionStatus.CANCELED
+      order by s.id desc
+      """)
+  Optional<Subscription> findCurrentByWorkspaceIdForUpdate(@Param("workspaceId") Long workspaceId);
 
   @Override
   default List<Subscription> findChargeable(OffsetDateTime now) {

--- a/backend/src/main/resources/db/changelog/db.changelog-master.sql
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.sql
@@ -1167,6 +1167,13 @@ create unique index uq_payment_subscription_workspace_open
     on payment.subscription (workspace_id)
     where status in ('INCOMPLETE', 'ACTIVE', 'PAST_DUE');
 
+--changeset init:20260605-include-authorizing-subscription-open-index
+--comment: Treat billing-key authorization in progress as an open subscription
+drop index if exists payment.uq_payment_subscription_workspace_open;
+create unique index uq_payment_subscription_workspace_open
+    on payment.subscription (workspace_id)
+    where status in ('INCOMPLETE', 'AUTHORIZING', 'ACTIVE', 'PAST_DUE');
+
 --changeset init:20260603-add-idempotency-key-payment-cancel
 --comment: Per-cancel-attempt idempotency key for Toss API — prevents partial-cancel collisions (V-EC-004)
 alter table payment.payment_cancel add column idempotency_key varchar(255);

--- a/backend/src/test/java/com/init/payment/application/SubscriptionServiceConcurrencyTest.java
+++ b/backend/src/test/java/com/init/payment/application/SubscriptionServiceConcurrencyTest.java
@@ -1,0 +1,211 @@
+package com.init.payment.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+import com.init.payment.application.exception.ActiveSubscriptionExistsException;
+import com.init.payment.application.port.BillingKeyCipher;
+import com.init.payment.application.port.TossBillingKeyResult;
+import com.init.payment.application.port.TossPaymentPort;
+import com.init.payment.application.port.TossPaymentResult;
+import com.init.payment.domain.model.BillingInterval;
+import com.init.payment.domain.model.Plan;
+import com.init.payment.domain.model.Subscription;
+import com.init.payment.domain.repository.PlanRepository;
+import com.init.payment.domain.repository.SubscriptionRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Testcontainers(disabledWithoutDocker = true)
+@Import({SubscriptionService.class, SubscriptionServiceConcurrencyTest.ClockTestConfig.class})
+@DisplayName("SubscriptionService billing authorization concurrency")
+class SubscriptionServiceConcurrencyTest {
+
+  @Container static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16");
+
+  static {
+    postgres.start();
+  }
+
+  @DynamicPropertySource
+  static void configureDataSource(DynamicPropertyRegistry registry) {
+    registry.add("spring.datasource.url", postgres::getJdbcUrl);
+    registry.add("spring.datasource.username", postgres::getUsername);
+    registry.add("spring.datasource.password", postgres::getPassword);
+    registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+    registry.add("spring.jpa.hibernate.ddl-auto", () -> "create");
+    registry.add(
+        "spring.jpa.properties.hibernate.dialect", () -> "org.hibernate.dialect.PostgreSQLDialect");
+    registry.add("spring.jpa.properties.hibernate.hbm2ddl.create_namespaces", () -> "true");
+    registry.add("spring.liquibase.enabled", () -> "false");
+  }
+
+  @Autowired private SubscriptionService subscriptionService;
+  @Autowired private PlanRepository planRepository;
+  @Autowired private SubscriptionRepository subscriptionRepository;
+
+  @MockitoBean private PaymentAccessGuard accessGuard;
+  @MockitoBean private TossPaymentPort tossPaymentPort;
+  @MockitoBean private BillingKeyCipher billingKeyCipher;
+
+  @Test
+  @Transactional(propagation = Propagation.NOT_SUPPORTED)
+  @DisplayName("billingKey 동시 발급 요청은 첫 과금을 한 번만 실행한다")
+  void shouldExecuteFirstChargeOnlyOnceWhenBillingKeyIssuedConcurrently() throws Exception {
+    // given
+    Plan plan = planRepository.save(plan());
+    Subscription subscription = Subscription.create(1L, plan.getId());
+    subscription.assignCustomerKey("wsk_1_abc");
+    subscriptionRepository.save(subscription);
+
+    AtomicInteger issueBillingKeyCalls = new AtomicInteger();
+    AtomicInteger executeBillingCalls = new AtomicInteger();
+    given(tossPaymentPort.issueBillingKey(eq("auth_xxx"), eq("wsk_1_abc")))
+        .willAnswer(
+            invocation -> {
+              issueBillingKeyCalls.incrementAndGet();
+              return new TossBillingKeyResult(
+                  "bk_PLAINTEXT_SECRET",
+                  "wsk_1_abc",
+                  "신한",
+                  "1234-****-****-5678",
+                  "{\"billingKey\":\"***\"}");
+            });
+    given(billingKeyCipher.encrypt("bk_PLAINTEXT_SECRET")).willReturn(new byte[] {1, 2, 3});
+    given(tossPaymentPort.executeBilling(any()))
+        .willAnswer(
+            invocation -> {
+              executeBillingCalls.incrementAndGet();
+              return new TossPaymentResult(
+                  "pay_1",
+                  "ord_1",
+                  29000,
+                  "DONE",
+                  "카드",
+                  OffsetDateTime.parse("2026-06-01T00:00:00Z"),
+                  "https://receipt",
+                  null,
+                  "{\"status\":\"DONE\"}");
+            });
+
+    IssueBillingKeyCommand command = new IssueBillingKeyCommand(1L, 99L, "auth_xxx", "wsk_1_abc");
+    CountDownLatch ready = new CountDownLatch(2);
+    CountDownLatch start = new CountDownLatch(1);
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+
+    try {
+      List<Future<BillingAuthorizationAttempt>> futures =
+          List.of(
+              executor.submit(issueBillingKeyAttempt(command, ready, start)),
+              executor.submit(issueBillingKeyAttempt(command, ready, start)));
+
+      assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
+      start.countDown();
+
+      List<BillingAuthorizationAttempt> attempts =
+          futures.stream()
+              .map(SubscriptionServiceConcurrencyTest::getBillingAuthorizationAttempt)
+              .toList();
+
+      assertThat(attempts.stream().filter(BillingAuthorizationAttempt::succeeded).count())
+          .describedAs("attempts=%s", attempts)
+          .isEqualTo(1);
+      assertThat(
+              attempts.stream()
+                  .filter(BillingAuthorizationAttempt::failedWithActiveSubscriptionExists)
+                  .count())
+          .describedAs("attempts=%s", attempts)
+          .isEqualTo(1);
+      assertThat(issueBillingKeyCalls).hasValue(1);
+      assertThat(executeBillingCalls).hasValue(1);
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  private Callable<BillingAuthorizationAttempt> issueBillingKeyAttempt(
+      IssueBillingKeyCommand command, CountDownLatch ready, CountDownLatch start) {
+    return () -> {
+      ready.countDown();
+      if (!start.await(5, TimeUnit.SECONDS)) {
+        throw new IllegalStateException("billing authorization attempts were not released");
+      }
+
+      try {
+        return BillingAuthorizationAttempt.success(subscriptionService.issueBillingKey(command));
+      } catch (RuntimeException ex) {
+        return BillingAuthorizationAttempt.failure(ex);
+      }
+    };
+  }
+
+  private static BillingAuthorizationAttempt getBillingAuthorizationAttempt(
+      Future<BillingAuthorizationAttempt> future) {
+    try {
+      return future.get(10, TimeUnit.SECONDS);
+    } catch (Exception ex) {
+      throw new IllegalStateException("billing authorization attempt did not finish", ex);
+    }
+  }
+
+  private Plan plan() {
+    return Plan.create("pro_monthly", "Pro", 29000, "KRW", BillingInterval.MONTH);
+  }
+
+  private record BillingAuthorizationAttempt(BillingAuthorizationResult result, Throwable failure) {
+    static BillingAuthorizationAttempt success(BillingAuthorizationResult result) {
+      return new BillingAuthorizationAttempt(result, null);
+    }
+
+    static BillingAuthorizationAttempt failure(Throwable failure) {
+      return new BillingAuthorizationAttempt(null, failure);
+    }
+
+    boolean succeeded() {
+      return result != null && failure == null;
+    }
+
+    boolean failedWithActiveSubscriptionExists() {
+      return failure instanceof ActiveSubscriptionExistsException;
+    }
+  }
+
+  @TestConfiguration
+  static class ClockTestConfig {
+
+    @Bean
+    Clock clock() {
+      return Clock.fixed(Instant.parse("2026-06-01T00:00:00Z"), ZoneOffset.UTC);
+    }
+  }
+}

--- a/backend/src/test/java/com/init/payment/application/SubscriptionServiceTest.java
+++ b/backend/src/test/java/com/init/payment/application/SubscriptionServiceTest.java
@@ -4,9 +4,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.init.payment.application.exception.ActiveSubscriptionExistsException;
+import com.init.payment.application.exception.PaymentGatewayException;
 import com.init.payment.application.exception.SubscriptionNotFoundException;
 import com.init.payment.application.port.BillingKeyCipher;
 import com.init.payment.application.port.TossBillingKeyResult;
@@ -16,6 +18,7 @@ import com.init.payment.domain.model.BillingInterval;
 import com.init.payment.domain.model.BillingKey;
 import com.init.payment.domain.model.Plan;
 import com.init.payment.domain.model.Subscription;
+import com.init.payment.domain.model.SubscriptionStatus;
 import com.init.payment.domain.repository.BillingKeyRepository;
 import com.init.payment.domain.repository.PaymentRepository;
 import com.init.payment.domain.repository.PlanRepository;
@@ -239,7 +242,7 @@ class SubscriptionServiceTest {
         java.time.OffsetDateTime.parse("2026-06-01T00:00:00Z"),
         "wsk_1_abc");
     org.springframework.test.util.ReflectionTestUtils.setField(activeSubscription, "id", 5L);
-    given(subscriptionRepository.findCurrentByWorkspaceId(1L))
+    given(subscriptionRepository.findCurrentByWorkspaceIdForUpdate(1L))
         .willReturn(Optional.of(activeSubscription));
 
     assertThatThrownBy(
@@ -248,6 +251,27 @@ class SubscriptionServiceTest {
                     new IssueBillingKeyCommand(1L, 99L, "auth_xxx", "wsk_1_abc")))
         .isInstanceOf(ActiveSubscriptionExistsException.class);
     verify(accessGuard).requireMember(1L, 99L);
+    verify(tossPaymentPort, never()).issueBillingKey(any(), any());
+    verify(tossPaymentPort, never()).executeBilling(any());
+  }
+
+  @Test
+  @DisplayName("AUTHORIZING 구독에 billingKey 발급 시 외부 호출 전에 409 예외를 던진다")
+  void issueBillingKey_authorizing_throwsBeforeExternalCall() {
+    given(transactionManager.getTransaction(any())).willReturn(new SimpleTransactionStatus());
+    Subscription subscription = subscription(5L);
+    subscription.beginAuthorization();
+    given(subscriptionRepository.findCurrentByWorkspaceIdForUpdate(1L))
+        .willReturn(Optional.of(subscription));
+
+    assertThatThrownBy(
+            () ->
+                subscriptionService.issueBillingKey(
+                    new IssueBillingKeyCommand(1L, 99L, "auth_xxx", "wsk_1_abc")))
+        .isInstanceOf(ActiveSubscriptionExistsException.class);
+
+    verify(tossPaymentPort, never()).issueBillingKey(any(), any());
+    verify(tossPaymentPort, never()).executeBilling(any());
   }
 
   @Test
@@ -255,9 +279,9 @@ class SubscriptionServiceTest {
   void issueBillingKey_encryptsAndDoesNotExposePlaintext() {
     Subscription subscription = subscription(5L);
     given(transactionManager.getTransaction(any())).willReturn(new SimpleTransactionStatus());
-    given(subscriptionRepository.findCurrentByWorkspaceId(1L))
+    given(subscriptionRepository.findCurrentByWorkspaceIdForUpdate(1L))
         .willReturn(Optional.of(subscription));
-    given(subscriptionRepository.findById(5L)).willReturn(Optional.of(subscription));
+    given(subscriptionRepository.findByIdForUpdate(5L)).willReturn(Optional.of(subscription));
     given(subscriptionRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
     given(planRepository.findById(10L)).willReturn(Optional.of(plan(10L)));
     given(tossPaymentPort.issueBillingKey("auth_xxx", "wsk_1_abc"))
@@ -296,6 +320,71 @@ class SubscriptionServiceTest {
     assertThat(result.billingKey().cardNumberMasked()).isEqualTo("1234-****-****-5678");
     assertThat(result.subscription().status()).isEqualTo("ACTIVE");
     assertThat(result.toString()).doesNotContain("bk_PLAINTEXT_SECRET");
+  }
+
+  @Test
+  @DisplayName("billingKey 발급 중 게이트웨이 오류가 발생하면 AUTHORIZING을 INCOMPLETE로 되돌린다")
+  void issueBillingKey_gatewayFailure_resetsAuthorization() {
+    Subscription subscription = subscription(5L);
+    given(transactionManager.getTransaction(any())).willReturn(new SimpleTransactionStatus());
+    given(subscriptionRepository.findCurrentByWorkspaceIdForUpdate(1L))
+        .willReturn(Optional.of(subscription));
+    given(subscriptionRepository.findByIdForUpdate(5L)).willReturn(Optional.of(subscription));
+    given(subscriptionRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+    given(planRepository.findById(10L)).willReturn(Optional.of(plan(10L)));
+    given(tossPaymentPort.issueBillingKey("auth_xxx", "wsk_1_abc"))
+        .willThrow(new PaymentGatewayException("gateway down"));
+
+    assertThatThrownBy(
+            () ->
+                subscriptionService.issueBillingKey(
+                    new IssueBillingKeyCommand(1L, 99L, "auth_xxx", "wsk_1_abc")))
+        .isInstanceOf(PaymentGatewayException.class);
+
+    assertThat(subscription.getStatus()).isEqualTo(SubscriptionStatus.INCOMPLETE);
+    verify(tossPaymentPort, never()).executeBilling(any());
+  }
+
+  @Test
+  @DisplayName("첫 과금이 DONE이 아니면 결제를 중단 기록하고 AUTHORIZING을 INCOMPLETE로 되돌린다")
+  void issueBillingKey_chargeNotDone_resetsAuthorization() {
+    Subscription subscription = subscription(5L);
+    given(transactionManager.getTransaction(any())).willReturn(new SimpleTransactionStatus());
+    given(subscriptionRepository.findCurrentByWorkspaceIdForUpdate(1L))
+        .willReturn(Optional.of(subscription));
+    given(subscriptionRepository.findByIdForUpdate(5L)).willReturn(Optional.of(subscription));
+    given(subscriptionRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+    given(planRepository.findById(10L)).willReturn(Optional.of(plan(10L)));
+    given(tossPaymentPort.issueBillingKey("auth_xxx", "wsk_1_abc"))
+        .willReturn(
+            new TossBillingKeyResult(
+                "bk_PLAINTEXT_SECRET",
+                "wsk_1_abc",
+                "신한",
+                "1234-****-****-5678",
+                "{\"billingKey\":\"***\"}"));
+    given(billingKeyCipher.encrypt("bk_PLAINTEXT_SECRET")).willReturn(new byte[] {1, 2, 3});
+    given(billingKeyRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+    given(paymentRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+    given(tossPaymentPort.executeBilling(any()))
+        .willReturn(
+            new TossPaymentResult(
+                null,
+                "ord_1",
+                29000,
+                "ABORTED",
+                null,
+                null,
+                null,
+                null,
+                "{\"status\":\"ABORTED\"}"));
+
+    BillingAuthorizationResult result =
+        subscriptionService.issueBillingKey(
+            new IssueBillingKeyCommand(1L, 99L, "auth_xxx", "wsk_1_abc"));
+
+    assertThat(result.subscription().status()).isEqualTo("INCOMPLETE");
+    assertThat(subscription.getStatus()).isEqualTo(SubscriptionStatus.INCOMPLETE);
   }
 
   private Subscription subscription(Long id) {

--- a/backend/src/test/java/com/init/payment/domain/model/StatusEnumTest.java
+++ b/backend/src/test/java/com/init/payment/domain/model/StatusEnumTest.java
@@ -30,6 +30,7 @@ class StatusEnumTest {
   void subscriptionStatus_isActive() {
     assertThat(SubscriptionStatus.ACTIVE.isActive()).isTrue();
     assertThat(SubscriptionStatus.INCOMPLETE.isActive()).isFalse();
+    assertThat(SubscriptionStatus.AUTHORIZING.isActive()).isFalse();
     assertThat(SubscriptionStatus.PAST_DUE.isActive()).isFalse();
     assertThat(SubscriptionStatus.CANCELED.isActive()).isFalse();
   }
@@ -39,6 +40,7 @@ class StatusEnumTest {
   void subscriptionStatus_isTerminated() {
     assertThat(SubscriptionStatus.CANCELED.isTerminated()).isTrue();
     assertThat(SubscriptionStatus.ACTIVE.isTerminated()).isFalse();
+    assertThat(SubscriptionStatus.AUTHORIZING.isTerminated()).isFalse();
     assertThat(SubscriptionStatus.PAST_DUE.isTerminated()).isFalse();
   }
 }

--- a/backend/src/test/java/com/init/payment/domain/model/SubscriptionTest.java
+++ b/backend/src/test/java/com/init/payment/domain/model/SubscriptionTest.java
@@ -37,6 +37,22 @@ class SubscriptionTest {
   }
 
   @Test
+  @DisplayName("billing authorization 시작과 실패 재시도 전이는 INCOMPLETE와 AUTHORIZING 사이에서만 허용한다")
+  void billingAuthorization_transitions() {
+    Subscription subscription = Subscription.create(1L, 10L);
+
+    subscription.beginAuthorization();
+    assertThat(subscription.getStatus()).isEqualTo(SubscriptionStatus.AUTHORIZING);
+
+    subscription.resetAuthorization();
+    assertThat(subscription.getStatus()).isEqualTo(SubscriptionStatus.INCOMPLETE);
+
+    subscription.activate(START, END, "wsk_1_abc");
+    assertThatThrownBy(subscription::beginAuthorization).isInstanceOf(IllegalStateException.class);
+    assertThatThrownBy(subscription::resetAuthorization).isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
   @DisplayName("정기결제 실패 4회차에 재시도가 소진되어 해지된다 (U-004)")
   void recurringFailure_exhaustsRetryAndCancels() {
     Subscription subscription = activeSubscription();


### PR DESCRIPTION
Closes #576

## 변경 사항

- billing key 발급 시작 시 구독을 `AUTHORIZING`으로 먼저 전환하고, 동일 구독의 중복 요청은 외부 Toss 호출 전에 409로 거절하도록 했습니다.
- 첫 과금 저장 직전에 구독 row를 다시 잠금 조회해 `AUTHORIZING` 상태를 재검증하고, 성공 시에만 `ACTIVE`로 전환합니다.
- 게이트웨이 오류/거절 또는 첫 과금 미완료 결과는 구독을 `INCOMPLETE`로 되돌려 재시도 가능하게 처리합니다.
- `AUTHORIZING`을 open subscription unique index 조건에 포함하고, 이슈 576 스펙을 `.agent/specs/576.md`에 정리했습니다.
- 동시 billing key 발급 요청에서 billing key 발급과 첫 과금이 한 번만 실행되는지 Testcontainers 기반 서비스 테스트로 고정했습니다.

## 검증

- `git diff --check`
- `cd backend && JAVA_HOME=/Users/owen/.cache/codex-runtimes/jdk21/Contents/Home GRADLE_USER_HOME=/tmp/ostone-1992-gradle ./gradlew test --tests 'com.init.payment.domain.model.SubscriptionTest' --tests 'com.init.payment.domain.model.StatusEnumTest' --tests 'com.init.payment.application.SubscriptionServiceTest' --tests 'com.init.payment.application.SubscriptionServiceConcurrencyTest'`
- `cd backend && JAVA_HOME=/Users/owen/.cache/codex-runtimes/jdk21/Contents/Home GRADLE_USER_HOME=/tmp/ostone-1992-gradle ./gradlew spotlessCheck`
- 커밋 pre-commit hook: `cd backend && ./gradlew spotlessCheck`

## 참고

- 전역 Gradle artifact cache lock 경합을 피하기 위해 backend Gradle 검증은 별도 `GRADLE_USER_HOME`으로 실행했습니다.