### PR TITLE
fix(corpus): s3 head object 404를 업로드 미완료로 처리

### DIFF
--- a/.agent/specs/574.md
+++ b/.agent/specs/574.md
@@ -1,0 +1,61 @@
+# S3 headObject 404 업로드 미완료 처리
+
+## Goal
+
+presigned raw file 업로드 완료 처리에서 S3 `headObject`가 404 상태를 반환해도 서버 오류가 아니라 업로드 미완료 상태로 응답되도록 한다.
+
+## Problem
+
+`backend/src/main/java/com/init/corpus/infrastructure/storage/S3RawFileStorageAdapter.java`는 `headObject` 실패 중 `NoSuchKeyException`만 객체 없음으로 처리한다. AWS SDK의 `headObject`는 객체가 없을 때 상황에 따라 일반 `S3Exception`에 `statusCode=404`를 담아 반환할 수 있다.
+
+이 경우 `backend/src/main/java/com/init/corpus/application/CompleteRawFileUploadService.java`까지 예외가 전파되어 사용자는 업로드 미완료 안내 대신 서버 오류를 볼 수 있다. 서비스는 이미 `RawFileStoragePort.headObject(...)`의 `Optional.empty()`를 `InvalidUploadStateException`으로 매핑하므로, 저장소 어댑터가 404 응답을 객체 없음으로 정규화해야 한다.
+
+## Scope
+
+- `backend/src/main/java/com/init/corpus/infrastructure/storage/S3RawFileStorageAdapter.java`의 S3 `headObject` 예외 매핑
+- `backend/src/test/java/com/init/corpus/infrastructure/storage/S3RawFileStorageAdapterTest.java`의 404 및 non-404 S3 오류 구분 회귀 테스트
+- `.agent/specs/574.md`에 요구사항과 검증 기준 문서화
+
+## Non-Goals
+
+- 업로드 완료 API request/response contract 변경
+- `CompleteRawFileUploadService`의 상태 전이, 객체 승격, Airflow trigger 흐름 변경
+- S3/MinIO 설정, 버킷 정책, lifecycle 정책 변경
+- `putObject`, `copyObject`, `deleteObject`, presigned URL 발급 동작 변경
+
+## Current Contract
+
+| 파일 | 현재 역할 | 확인된 이슈 |
+| --- | --- | --- |
+| `backend/src/main/java/com/init/corpus/infrastructure/storage/S3RawFileStorageAdapter.java` | S3 raw file 저장소 어댑터, `headObject` 메타데이터 조회 | `NoSuchKeyException`만 객체 없음으로 처리하고 일반 `S3Exception` 404는 전파될 수 있음 |
+| `backend/src/main/java/com/init/corpus/application/CompleteRawFileUploadService.java` | 업로드 완료 검증과 `pending/` -> `completed/` 승격 | `headObject`가 `Optional.empty()`를 반환하면 업로드 미완료 `InvalidUploadStateException`으로 매핑하는 기존 계약 존재 |
+| `backend/src/test/java/com/init/corpus/infrastructure/storage/S3RawFileStorageAdapterTest.java` | S3 어댑터 단위 테스트 | `NoSuchKeyException` 누락 케이스는 검증하지만 `S3Exception` status code 구분 테스트가 없음 |
+| `backend/src/test/java/com/init/corpus/application/CompleteRawFileUploadServiceTest.java` | 업로드 완료 서비스 단위 테스트 | storage port의 empty 결과가 업로드 미완료 예외로 매핑되는 테스트 존재 |
+
+## Design Diff
+
+| 영역 | As-is | To-be |
+| --- | --- | --- |
+| `NoSuchKeyException` | `Optional.empty()` 반환 | 유지 |
+| `S3Exception` 404 | 예외 전파 가능 | `Optional.empty()` 반환 |
+| `S3Exception` non-404 | 예외 전파 | 유지 |
+| 업로드 완료 서비스 | storage empty를 업로드 미완료 예외로 변환 | 유지 |
+
+## Acceptance Criteria
+
+- S3 `headObject`가 `NoSuchKeyException`을 던지면 기존처럼 `Optional.empty()`를 반환한다.
+- S3 `headObject`가 `S3Exception`과 `statusCode=404`를 반환하면 `Optional.empty()`를 반환한다.
+- S3 `headObject`가 404가 아닌 `S3Exception`을 반환하면 객체 없음으로 오분류하지 않고 예외를 전파한다.
+- 업로드 완료 서비스는 storage empty 결과를 기존 `InvalidUploadStateException` 업로드 미완료 응답으로 유지한다.
+- 404와 non-404 S3 오류 구분을 단위 테스트로 검증한다.
+
+## Validation Plan
+
+| 구분 | 명령 | 기대 결과 |
+| --- | --- | --- |
+| Backend targeted tests | `cd backend && ./gradlew test --tests com.init.corpus.infrastructure.storage.S3RawFileStorageAdapterTest --tests com.init.corpus.application.CompleteRawFileUploadServiceTest` | S3 404 매핑, non-404 전파, 업로드 완료 서비스 회귀 통과 |
+| Backend full tests | `cd backend && ./gradlew test` | 백엔드 테스트 회귀 없음 |
+
+## Open Questions
+
+- 없음. 이슈 본문은 S3 `headObject` 404와 그 외 S3 오류를 구분하라는 범위를 명확히 제시한다.

--- a/backend/src/main/java/com/init/corpus/infrastructure/storage/S3RawFileStorageAdapter.java
+++ b/backend/src/main/java/com/init/corpus/infrastructure/storage/S3RawFileStorageAdapter.java
@@ -12,6 +12,7 @@ import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.s3.model.ServerSideEncryption;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
@@ -101,6 +102,11 @@ public class S3RawFileStorageAdapter implements RawFileStoragePort {
       return Optional.of(new ObjectMetadata(response.contentLength(), response.eTag()));
     } catch (NoSuchKeyException e) {
       return Optional.empty();
+    } catch (S3Exception e) {
+      if (e.statusCode() == 404) {
+        return Optional.empty();
+      }
+      throw e;
     }
   }
 }

--- a/backend/src/test/java/com/init/corpus/infrastructure/storage/S3RawFileStorageAdapterTest.java
+++ b/backend/src/test/java/com/init/corpus/infrastructure/storage/S3RawFileStorageAdapterTest.java
@@ -1,6 +1,7 @@
 package com.init.corpus.infrastructure.storage;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
@@ -28,6 +29,7 @@ import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
@@ -193,5 +195,27 @@ class S3RawFileStorageAdapterTest {
     Optional<ObjectMetadata> result = adapterSseOff.headObject("workspaces/1/missing.zip");
 
     assertThat(result).isEmpty();
+  }
+
+  @Test
+  @DisplayName("S3 headObject가 404를 반환하면 empty를 반환한다")
+  void headObject_s3NotFoundStatus_returnsEmpty() {
+    given(s3Client.headObject(any(HeadObjectRequest.class)))
+        .willThrow(S3Exception.builder().statusCode(404).message("Not Found").build());
+
+    Optional<ObjectMetadata> result = adapterSseOff.headObject("workspaces/1/missing.zip");
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  @DisplayName("S3 headObject가 404 외 오류를 반환하면 예외를 전파한다")
+  void headObject_s3NonNotFoundStatus_propagatesException() {
+    given(s3Client.headObject(any(HeadObjectRequest.class)))
+        .willThrow(S3Exception.builder().statusCode(503).message("Slow Down").build());
+
+    assertThatThrownBy(() -> adapterSseOff.headObject("workspaces/1/file.zip"))
+        .isInstanceOf(S3Exception.class)
+        .hasMessageContaining("Slow Down");
   }
 }


### PR DESCRIPTION
Closes #574

## 변경 사항

- S3 raw file storage adapter가 `headObject`의 `S3Exception` 404를 객체 없음으로 정규화해 기존 업로드 미완료 응답 경로를 타도록 했습니다.
- 404가 아닌 S3 오류는 객체 없음으로 오분류하지 않고 그대로 전파하도록 유지했습니다.
- 이슈 574 스펙을 `.agent/specs/574.md`에 정리하고, `S3RawFileStorageAdapterTest`에 404/non-404 회귀 테스트를 추가했습니다.

## 검증

- `git diff --check`
- `cd backend && JAVA_HOME=/Users/owen/.cache/codex-runtimes/jdk21/Contents/Home GRADLE_USER_HOME=/Users/owen/.codex/worktrees/39ac/ostone/.gradle-local ./gradlew test --tests com.init.corpus.infrastructure.storage.S3RawFileStorageAdapterTest --tests com.init.corpus.application.CompleteRawFileUploadServiceTest`
- `cd backend && JAVA_HOME=/Users/owen/.cache/codex-runtimes/jdk21/Contents/Home GRADLE_USER_HOME=/Users/owen/.codex/worktrees/39ac/ostone/.gradle-local ./gradlew spotlessCheck`
- `cd backend && JAVA_HOME=/Users/owen/.cache/codex-runtimes/jdk21/Contents/Home GRADLE_USER_HOME=/Users/owen/.codex/worktrees/39ac/ostone/.gradle-local ./gradlew test`

## 참고

- 로컬 기본 Java가 17이고 전역 Gradle artifact cache lock 경합이 있어 backend Gradle 검증은 번들 JDK 21과 별도 `GRADLE_USER_HOME`으로 실행했습니다.