### PR TITLE
fix(corpus): 업로드 객체 승격 rollback orphan 방지

### DIFF
--- a/.agent/specs/572.md
+++ b/.agent/specs/572.md
@@ -1,0 +1,97 @@
+# Backend Spec: 업로드 객체 승격 rollback orphan 방지
+
+## Goal
+
+presigned 원본 로그 업로드 완료 처리에서 DB 트랜잭션이 commit되지 못하더라도 `completed/` 위치로 복사된 S3 객체가 orphan으로 남지 않게 한다.
+
+## Background
+
+이슈 #572는 업로드 완료 처리 중 `pending/` 객체를 `completed/` 객체로 복사한 뒤 DB 저장을 수행하는 현재 흐름에서 발생할 수 있는 orphan을 다룬다. S3 복사는 외부 저장소 변경이라 DB 트랜잭션으로 되돌릴 수 없으므로, 복사 성공 후 DB commit 실패 또는 rollback이 발생하면 `completed/` 객체가 남을 수 있다.
+
+확인된 관련 경로:
+
+- `backend/src/main/java/com/init/corpus/application/CompleteRawFileUploadService.java`
+- `backend/src/main/java/com/init/corpus/application/port/RawFileStoragePort.java`
+- `backend/src/main/java/com/init/corpus/infrastructure/storage/S3RawFileStorageAdapter.java`
+- `backend/src/test/java/com/init/corpus/application/CompleteRawFileUploadServiceTest.java`
+
+## Scope
+
+- `CompleteRawFileUploadService`의 presigned 업로드 완료 경로를 보강한다.
+- S3 `pending/` -> `completed/` 복사 성공 후 DB rollback이 발생하면 `completed/` 객체를 보상 삭제한다.
+- S3 승격 실패 시 DB 저장, dataset 상태 전이, pending 삭제, ingestion trigger가 진행되지 않음을 테스트한다.
+- DB 저장 실패, commit 실패 또는 트랜잭션 rollback 시 final 객체가 삭제되는지 테스트한다.
+
+## Non-Goals
+
+- outbox 테이블 또는 별도 cleanup worker를 새로 도입하지 않는다.
+- 업로드 API 계약, 요청/응답 DTO, DB schema는 변경하지 않는다.
+- S3 multipart copy나 4GB 초과 업로드 정책은 변경하지 않는다.
+- ingestion trigger 실패 후 재시도 정책은 이 이슈에서 다루지 않는다.
+
+## Current Flow
+
+```mermaid
+sequenceDiagram
+    actor client as Client
+    participant svc as CompleteRawFileUploadService
+    participant s3 as RawFileStoragePort
+    participant repo as Dataset/RawFile Repository
+    participant tx as DB Transaction
+    participant airflow as IngestionTriggerPort
+
+    client ->> svc: complete(command)
+    svc ->> repo: find dataset for update
+    svc ->> s3: headObject(pendingKey)
+    svc ->> s3: copyObject(pendingKey, completedKey)
+    svc ->> repo: save dataset_raw_file
+    svc ->> repo: save dataset(PROCESSING)
+    tx -->> svc: commit
+    svc ->> s3: delete(pendingKey) afterCommit
+    svc ->> airflow: trigger(workspaceId, datasetId, completedKey) afterCommit
+```
+
+## Required Behavior
+
+### S3 승격 성공 + DB commit 성공
+
+- `pending/` 객체를 `completed/` 객체로 복사한다.
+- `dataset_raw_file.object_key`는 `completed/` key로 저장한다.
+- dataset은 `PROCESSING`으로 전이한다.
+- commit 이후에만 pending 원본 삭제와 ingestion trigger가 실행된다.
+
+### S3 승격 실패
+
+- `copyObject(pendingKey, completedKey)` 실패가 호출자에게 전파된다.
+- `dataset_raw_file` 저장과 dataset `PROCESSING` 전이는 실행되지 않는다.
+- pending 원본 삭제와 ingestion trigger는 실행되지 않는다.
+- `completed/` 객체 삭제 보상은 복사 성공이 확인되지 않은 경우 실행하지 않는다.
+
+### DB 저장 실패, commit 실패 또는 rollback
+
+- S3 복사 성공 이후 DB 저장 단계에서 예외가 발생하거나 트랜잭션이 commit되지 못하면 `completed/` 객체를 삭제한다.
+- 보상 삭제 실패는 원래 DB 실패를 가리지 않도록 warn 로그만 남긴다.
+- commit되지 않은 트랜잭션에서는 pending 원본 삭제와 ingestion trigger를 실행하지 않는다.
+
+## Implementation Notes
+
+- 기존 `TransactionSynchronizationManager` 기반 afterCommit 후처리 패턴을 유지한다.
+- S3 복사 성공 직후 rollback cleanup synchronization을 등록한다.
+- cleanup은 `TransactionSynchronization.afterCompletion(int status)`에서 `STATUS_COMMITTED`가 아닌 종료 상태일 때 `completedKey` 삭제를 시도한다.
+- 트랜잭션 synchronization이 없는 단위 테스트 컨텍스트에서는 기존처럼 즉시 후처리를 수행하되, rollback cleanup은 실제 트랜잭션 경계에서만 검증한다.
+
+## Acceptance Criteria
+
+- DB rollback 또는 commit 실패 시 `completed/` final S3 객체가 남지 않는다.
+- S3 승격 실패 시 DB 저장 및 ingestion trigger가 진행되지 않는다.
+- DB 저장 실패 시 `completed/` 객체 삭제 보상 동작이 테스트된다.
+- 성공 경로에서는 기존처럼 commit 이후 pending 원본 삭제와 ingestion trigger가 실행된다.
+
+## Validation Plan
+
+- `cd backend && ./gradlew test --tests com.init.corpus.application.CompleteRawFileUploadServiceTest`
+- 필요 시 backend 전체 회귀 확인으로 `cd backend && ./gradlew test`를 실행한다.
+
+## Open Questions
+
+- 없음. 이 이슈에서는 별도 outbox/cleanup worker 없이 현재 트랜잭션 synchronization 기반 흐름을 보강한다.

--- a/backend/src/main/java/com/init/corpus/application/CompleteRawFileUploadService.java
+++ b/backend/src/main/java/com/init/corpus/application/CompleteRawFileUploadService.java
@@ -63,9 +63,9 @@ public class CompleteRawFileUploadService {
   private static final String COMPLETED_PREFIX = "completed/";
 
   /**
-   * presigned 업로드를 완료 처리한다. DB 상태 전이(객체 승격, {@code dataset_raw_file} 저장, {@code PROCESSING} 전이)는
-   * 트랜잭션 내에서 커밋하고, Airflow 트리거는 커밋이 성공한 뒤(afterCommit)에 수행한다. 트리거가 실패해도 이미 커밋된 DB 상태는 롤백되지 않으며, 트리거
-   * 구현체가 실패한 데이터셋을 복구 가능한 상태로 별도 전이한다.
+   * presigned 업로드를 완료 처리한다. {@code completed/} 객체 승격 후 DB 상태 전이({@code dataset_raw_file} 저장, {@code
+   * PROCESSING} 전이)는 트랜잭션 내에서 커밋하고, Airflow 트리거는 커밋이 성공한 뒤(afterCommit)에 수행한다. 트리거가 실패해도 이미 커밋된 DB
+   * 상태는 롤백되지 않으며, 트리거 구현체가 실패한 데이터셋을 복구 가능한 상태로 별도 전이한다.
    */
   @Transactional
   public CompleteRawFileUploadResult complete(CompleteRawFileUploadCommand command) {
@@ -121,6 +121,7 @@ public class CompleteRawFileUploadService {
           "업로드 세션 objectKey가 pending/ 접두사를 가져야 합니다. objectKey=" + session.objectKey());
     }
     storagePort.copyObject(session.objectKey(), completedKey);
+    registerRollbackCleanup(completedKey);
 
     DatasetRawFile rawFile =
         DatasetRawFile.createPending(
@@ -148,6 +149,21 @@ public class CompleteRawFileUploadService {
         saved.getStatus());
   }
 
+  private void registerRollbackCleanup(String completedKey) {
+    if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+      return;
+    }
+    TransactionSynchronizationManager.registerSynchronization(
+        new TransactionSynchronization() {
+          @Override
+          public void afterCompletion(int status) {
+            if (status != STATUS_COMMITTED) {
+              deleteCompletedObject(completedKey);
+            }
+          }
+        });
+  }
+
   private void registerAfterCommitActions(
       Long workspaceId, Long datasetId, String pendingKey, String completedKey) {
     if (!TransactionSynchronizationManager.isSynchronizationActive()) {
@@ -171,6 +187,14 @@ public class CompleteRawFileUploadService {
       storagePort.delete(pendingKey);
     } catch (RuntimeException ex) {
       log.warn("[complete] pending 원본 객체 삭제 실패. objectKey={}", pendingKey, ex);
+    }
+  }
+
+  private void deleteCompletedObject(String completedKey) {
+    try {
+      storagePort.delete(completedKey);
+    } catch (RuntimeException ex) {
+      log.warn("[complete] rollback 보상 completed 객체 삭제 실패. objectKey={}", completedKey, ex);
     }
   }
 

--- a/backend/src/test/java/com/init/corpus/application/CompleteRawFileUploadServiceTest.java
+++ b/backend/src/test/java/com/init/corpus/application/CompleteRawFileUploadServiceTest.java
@@ -110,8 +110,11 @@ class CompleteRawFileUploadServiceTest {
 
       List<TransactionSynchronization> synchronizations =
           List.copyOf(TransactionSynchronizationManager.getSynchronizations());
-      assertThat(synchronizations).hasSize(1);
+      assertThat(synchronizations).hasSize(2);
       synchronizations.forEach(TransactionSynchronization::afterCommit);
+      synchronizations.forEach(
+          synchronization ->
+              synchronization.afterCompletion(TransactionSynchronization.STATUS_COMMITTED));
     } finally {
       TransactionSynchronizationManager.clearSynchronization();
     }
@@ -123,6 +126,7 @@ class CompleteRawFileUploadServiceTest {
 
     // pending 원본 삭제와 트리거는 커밋 이후에 수행된다.
     verify(storagePort).delete(OBJECT_KEY);
+    verify(storagePort, never()).delete(COMPLETED_KEY);
 
     ArgumentCaptor<DatasetRawFile> rawFileCaptor = ArgumentCaptor.forClass(DatasetRawFile.class);
     verify(rawFileRepository).save(rawFileCaptor.capture());
@@ -133,6 +137,94 @@ class CompleteRawFileUploadServiceTest {
     assertThat(saved.getEtag()).isEqualTo("\"etag-123\"");
 
     verify(triggerPort).trigger(1L, 42L, COMPLETED_KEY);
+  }
+
+  @Test
+  @DisplayName("should_not_persist_or_trigger_when_storage_promotion_fails")
+  void complete_copyFails_doesNotPersistOrTrigger() {
+    given(workspaceMembershipRepository.existsByWorkspaceIdAndUserId(1L, 1L)).willReturn(true);
+    Dataset dataset = uploadingDataset();
+    given(datasetRepository.findByIdAndWorkspaceIdForUpdate(42L, 1L))
+        .willReturn(Optional.of(dataset));
+    given(storagePort.headObject(OBJECT_KEY))
+        .willReturn(Optional.of(new ObjectMetadata(EXPECTED_SIZE, "\"etag-123\"")));
+    org.mockito.BDDMockito.willThrow(new IllegalStateException("copy failed"))
+        .given(storagePort)
+        .copyObject(OBJECT_KEY, COMPLETED_KEY);
+
+    assertThatThrownBy(() -> service.complete(command())).isInstanceOf(IllegalStateException.class);
+
+    assertThat(dataset.getStatus()).isEqualTo(DatasetStatus.UPLOADING);
+    verify(rawFileRepository, never()).save(any());
+    verify(datasetRepository, never()).save(any());
+    verify(storagePort, never()).delete(anyString());
+    verify(triggerPort, never()).trigger(anyLong(), anyLong(), anyString());
+  }
+
+  @Test
+  @DisplayName("should_delete_completed_object_when_db_save_rolls_back_after_promotion")
+  void complete_dbSaveFails_deletesCompletedObjectOnRollback() {
+    given(workspaceMembershipRepository.existsByWorkspaceIdAndUserId(1L, 1L)).willReturn(true);
+    Dataset dataset = uploadingDataset();
+    given(datasetRepository.findByIdAndWorkspaceIdForUpdate(42L, 1L))
+        .willReturn(Optional.of(dataset));
+    given(storagePort.headObject(OBJECT_KEY))
+        .willReturn(Optional.of(new ObjectMetadata(EXPECTED_SIZE, "\"etag-123\"")));
+    org.mockito.BDDMockito.willThrow(new IllegalStateException("db down"))
+        .given(rawFileRepository)
+        .save(any());
+
+    TransactionSynchronizationManager.initSynchronization();
+    try {
+      assertThatThrownBy(() -> service.complete(command()))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("db down");
+
+      List<TransactionSynchronization> synchronizations =
+          List.copyOf(TransactionSynchronizationManager.getSynchronizations());
+      assertThat(synchronizations).hasSize(1);
+      synchronizations.forEach(
+          synchronization ->
+              synchronization.afterCompletion(TransactionSynchronization.STATUS_ROLLED_BACK));
+    } finally {
+      TransactionSynchronizationManager.clearSynchronization();
+    }
+
+    verify(storagePort).copyObject(OBJECT_KEY, COMPLETED_KEY);
+    verify(storagePort).delete(COMPLETED_KEY);
+    verify(storagePort, never()).delete(OBJECT_KEY);
+    verify(datasetRepository, never()).save(any());
+    verify(triggerPort, never()).trigger(anyLong(), anyLong(), anyString());
+  }
+
+  @Test
+  @DisplayName("should_delete_completed_object_when_transaction_completion_is_unknown")
+  void complete_transactionUnknown_deletesCompletedObject() {
+    given(workspaceMembershipRepository.existsByWorkspaceIdAndUserId(1L, 1L)).willReturn(true);
+    Dataset dataset = uploadingDataset();
+    given(datasetRepository.findByIdAndWorkspaceIdForUpdate(42L, 1L))
+        .willReturn(Optional.of(dataset));
+    given(storagePort.headObject(OBJECT_KEY))
+        .willReturn(Optional.of(new ObjectMetadata(EXPECTED_SIZE, "\"etag-123\"")));
+    given(datasetRepository.save(any())).willAnswer(invocation -> invocation.getArgument(0));
+
+    TransactionSynchronizationManager.initSynchronization();
+    try {
+      service.complete(command());
+
+      List<TransactionSynchronization> synchronizations =
+          List.copyOf(TransactionSynchronizationManager.getSynchronizations());
+      assertThat(synchronizations).hasSize(2);
+      synchronizations.forEach(
+          synchronization ->
+              synchronization.afterCompletion(TransactionSynchronization.STATUS_UNKNOWN));
+    } finally {
+      TransactionSynchronizationManager.clearSynchronization();
+    }
+
+    verify(storagePort).delete(COMPLETED_KEY);
+    verify(storagePort, never()).delete(OBJECT_KEY);
+    verify(triggerPort, never()).trigger(anyLong(), anyLong(), anyString());
   }
 
   @Test


### PR DESCRIPTION
Closes #572

## 변경 사항

- presigned 업로드 완료에서 `pending/` 객체가 `completed/`로 복사된 뒤 DB 트랜잭션이 commit되지 못하면 `completed/` 객체를 보상 삭제하도록 했습니다.
- S3 승격 실패 시 raw file 저장, dataset `PROCESSING` 전이, pending 원본 삭제, ingestion trigger가 진행되지 않도록 기존 흐름을 고정했습니다.
- 이슈 572 스펙을 `.agent/specs/572.md`에 정리하고, rollback/unknown transaction completion과 copy 실패 경로를 서비스 테스트로 검증했습니다.

## 검증

- `git diff --check`
- `cd backend && GRADLE_USER_HOME=/Users/owen/.codex/worktrees/7b95/ostone/.gradle-user-home mise exec java@temurin-21.0.11+10.0.LTS -- ./gradlew --no-daemon test --tests com.init.corpus.application.CompleteRawFileUploadServiceTest`
- `cd backend && GRADLE_USER_HOME=/Users/owen/.codex/worktrees/7b95/ostone/.gradle-user-home mise exec java@temurin-21.0.11+10.0.LTS -- ./gradlew --no-daemon spotlessCheck test`
- 커밋 pre-commit hook: `cd backend && ./gradlew spotlessCheck`

## 참고

- 로컬 기본 shell은 Java 17을 사용하므로, 저장소 mise Java 21 환경을 명시해 검증했습니다.
- 전역 Gradle journal cache lock 경합을 피하기 위해 backend Gradle 검증은 별도 `GRADLE_USER_HOME`으로 실행했습니다.