### PR TITLE
feat(dashboard): 시뮬레이션 기반 개선 추천 제공

### DIFF
--- a/.agent/specs/530.md
+++ b/.agent/specs/530.md
@@ -1,0 +1,195 @@
+# Frontend FSD Spec: 시뮬레이션 기반 개선 추천
+
+## Goal
+
+워크스페이스 대시보드의 추천 액션 영역에서 운영 상담 지표 기반 추천과 시뮬레이션 피드백/개선 후보/검증 케이스 실패 기반 추천을 같은 우선순위 체계로 보여준다.
+
+---
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A["사용자: /workspaces/{workspaceId}/dashboard 진입"] --> B["대시보드 추천 API 조회"]
+    B --> C{"추천 후보 존재?"}
+    C -->|Yes| D["운영 지표 및 시뮬레이션 추천을 priority 기준 표시"]
+    C -->|No| E["현재 큰 이상 없음 상태 표시"]
+    D --> F{"추천 클릭"}
+    F -->|Open feedback| G["시뮬레이션 피드백 화면 이동"]
+    F -->|Review 대기 후보| H["시뮬레이션 개선 후보/검토 화면 이동"]
+    F -->|Golden case 실패| I["시뮬레이션 검증 케이스/replay 화면 이동"]
+    F -->|운영 지표| J["기존 관련 운영 화면 이동"]
+    G --> K["종료"]
+    H --> K
+    I --> K
+    J --> K
+    E --> K
+```
+
+---
+
+## Design Diff
+
+### As-is vs To-be
+
+| 영역 | As-is | To-be | 변경 내용 |
+|------|-------|-------|----------|
+| 추천 후보 | 운영 상담 지표 기반 rule만 표시 | 운영 지표와 시뮬레이션 신호 기반 rule을 함께 표시 | backend 추천 rule 확장 |
+| 추천 근거 | 단일 evidence label/value | open feedback, review 대기 후보, golden case 실패 수 등 시뮬레이션 근거 표시 | card evidence 확장 |
+| 추천 출처 | rule code만 노출 | “운영 지표 기반” 또는 “시뮬레이션에서 발견됨” 출처 표시 | card source label 추가 |
+| 이동 링크 | upload/domain-pack/workflow 등 운영 화면 | simulation feedback/candidate/golden case 관련 화면 링크 포함 | targetPath 확장 |
+| 데이터 분리 | 운영 지표 쿼리에서 simulation/demo channel 제외 | 시뮬레이션 데이터는 추천 근거로만 별도 조회 | 운영 상담 KPI와 분리 유지 |
+
+---
+
+## Component Tree
+
+```text
+WorkspaceDashboardPage
+├─ DashboardFilters
+├─ DashboardMetricsGrid
+├─ ActionRecommendationsPanel
+│    └─ ActionRecommendationCard
+│         ├─ source label
+│         ├─ title/description
+│         ├─ evidence label/value
+│         └─ target link
+├─ KnowledgePackHealthPanel
+└─ WorkflowRankingPanel
+```
+
+---
+
+## API Integration
+
+### Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/v1/workspaces/{workspaceId}/dashboard/action-recommendations` | 운영 지표 및 시뮬레이션 기반 추천 조회 |
+
+### Response Contract
+
+`WorkspaceDashboardActionRecommendationResult`에 추천 출처를 나타내는 필드를 추가한다.
+
+```json
+{
+  "ruleCode": "SIMULATION_OPEN_FEEDBACK",
+  "priority": 95,
+  "sourceLabel": "시뮬레이션에서 발견됨",
+  "title": "개선 후보 생성",
+  "description": "미처리 시뮬레이션 피드백이 있어 지식팩 개선 후보로 정리할 수 있습니다.",
+  "evidenceLabel": "Open feedback",
+  "evidenceValue": "4건",
+  "targetPath": "/workspaces/1/simulation?feedbackStatus=OPEN"
+}
+```
+
+---
+
+## Data Flow
+
+```text
+WorkspaceDashboardPage
+  -> fetchWorkspaceDashboardActionRecommendations()
+  -> WorkspaceDashboardController
+  -> GetWorkspaceDashboardActionRecommendationsUseCase
+  -> WorkspaceDashboardQueryPort.findRecommendationSignals()
+  -> JdbcWorkspaceDashboardQueryAdapter
+  -> runtime.simulation_feedback
+  -> runtime.simulation_improvement_candidate
+  -> runtime.simulation_golden_case_replay_result
+```
+
+운영 상담 지표용 `runtime.decision_log`, `runtime.workflow_execution` 집계는 기존처럼 simulation/demo channel을 제외한다. 시뮬레이션 집계는 추천 근거로만 사용하며 상담 KPI, 핫패스, completion rate에는 섞지 않는다.
+
+---
+
+## 수정 대상 파일
+
+| 파일 | 변경 유형 | 설명 |
+|------|----------|------|
+| `backend/src/main/java/com/init/workspace/application/GetWorkspaceDashboardActionRecommendationsUseCase.java` | modify | 시뮬레이션 기반 추천 rule 및 priority 정렬 확장 |
+| `backend/src/main/java/com/init/workspace/application/WorkspaceDashboardActionRecommendationResult.java` | modify | 추천 출처 필드 추가 |
+| `backend/src/main/java/com/init/workspace/application/WorkspaceDashboardRecommendationSignalsResult.java` | modify | 시뮬레이션 추천 신호 포함 |
+| `backend/src/main/java/com/init/workspace/application/WorkspaceDashboardSimulationSignalResult.java` | new | 시뮬레이션 추천 집계 결과 |
+| `backend/src/main/java/com/init/workspace/infrastructure/persistence/JdbcWorkspaceDashboardQueryAdapter.java` | modify | open feedback, review 대기 후보, failed golden case 집계 |
+| `frontend/src/features/workspace-dashboard-health/api/workspaceDashboardHealthApi.ts` | modify | recommendation 타입에 source label 반영 |
+| `frontend/src/pages/workspace/ui/WorkspaceDashboardPage.tsx` | modify | 추천 카드 출처 표시 |
+| `frontend/src/pages/workspace/ui/workspace-dashboard-page.module.css` | modify | 추천 출처 UI 스타일 |
+| `frontend/src/pages/workspace/ui/WorkspaceSimulationPage.tsx` | modify | dashboard link query로 feedback/candidate 필터 초기화 |
+
+---
+
+## State Management
+
+### Server State
+
+- 추천 응답은 기존 `WorkspaceDashboardActionRecommendations` 형태를 유지한다.
+- `recommendations` 배열의 각 item은 기존 priority 체계를 공유한다.
+- simulation 기능을 사용하지 않은 workspace에서는 simulation signal count가 모두 0으로 계산되어 simulation rule은 skip된다.
+
+### Client State
+
+- 대시보드 추천 영역은 기존 loading/error/empty 상태를 유지한다.
+- `sourceLabel`은 card 내부 보조 라벨로 표시한다.
+- simulation 화면은 URL query의 `feedbackStatus`, `candidateStatus`가 유효하면 초기 필터값에 반영한다.
+
+---
+
+## Recommendation Rules
+
+| Rule | 조건 | Priority | Evidence | Link |
+|------|------|----------|----------|------|
+| `SIMULATION_OPEN_FEEDBACK` | `OPEN` feedback count > 0 | 95 | Open feedback 수 | `/workspaces/{workspaceId}/simulation?feedbackStatus=OPEN` |
+| `SIMULATION_REVIEW_PENDING_CANDIDATE` | `READY_FOR_REVIEW` candidate count > 0 | 92 | Review 대기 후보 수 | `/workspaces/{workspaceId}/simulation?candidateStatus=READY_FOR_REVIEW` |
+| `SIMULATION_GOLDEN_CASE_FAILED` | latest replay가 `FAIL`인 golden case count > 0 | 88 | 실패한 검증 케이스 수 | `/workspaces/{workspaceId}/simulation?focus=golden-cases` |
+| `SIMULATION_REPEATED_FEEDBACK_TYPE` | 같은 유형의 open feedback count >= 3 | 82 | 반복 feedback 유형/count | `/workspaces/{workspaceId}/simulation?feedbackStatus=OPEN` |
+
+운영 지표 기반 rule은 기존 priority와 targetPath를 유지한다.
+
+---
+
+## Tests
+
+### Test Strategy
+
+| 구분 | 방법 | 도구 | 비고 |
+|------|------|------|------|
+| Backend unit | 추천 rule, priority, empty skip 검증 | JUnit 5 + Mockito | deterministic rule 검증 |
+| Backend MVC | 응답 JSON contract 검증 | MockMvc | source label 포함 |
+| Frontend component | 추천 카드 source/evidence/link 표시 검증 | Vitest + React Testing Library | existing dashboard test 확장 |
+| Frontend state | simulation query filter 초기화 검증 | Vitest + React Testing Library | dashboard link landing 검증 |
+
+### Happy Path
+
+| # | 시나리오 | 사전 조건 | 기대 결과 |
+|---|---------|---------|----------|
+| 1 | open feedback 존재 | `OPEN` feedback count > 0 | 개선 후보 생성 추천과 count 표시 |
+| 2 | review 대기 후보 존재 | `READY_FOR_REVIEW` candidate count > 0 | 검토 진행 추천과 count 표시 |
+| 3 | latest replay 실패 존재 | latest replay status `FAIL` | 변경 영향 확인 추천과 count 표시 |
+| 4 | 운영/시뮬레이션 추천 혼재 | 여러 rule이 동시에 match | priority 내림차순으로 최대 3개 표시 |
+
+### Error & Edge Cases
+
+| # | 시나리오 | 기대 결과 |
+|---|---------|----------|
+| 1 | simulation 데이터 없음 | simulation rule skip, 기존 추천 또는 empty state 표시 |
+| 2 | same feedback type count가 threshold 미만 | 반복 feedback rule skip |
+| 3 | 운영 decision/workflow 집계에 simulation channel 존재 | 운영 지표에는 포함하지 않음 |
+| 4 | invalid simulation query parameter | simulation 화면 기본 필터 사용 |
+
+---
+
+## Non-goals
+
+- LLM 기반 추천은 구현하지 않는다.
+- 피드백 기반 자동 후보 생성 또는 자동 승인은 구현하지 않는다.
+- 알림 발송은 구현하지 않는다.
+- 상담 KPI, 핫패스 랭킹, 운영 지식팩 건강도 수치에 simulation 데이터를 섞지 않는다.
+
+---
+
+## Open Questions
+
+- 현재 review 대기 개선 후보는 별도 review route가 아니라 `WorkspaceSimulationPage`의 후보 목록에서 상태별로 다룬다. 전용 review 화면이 생기면 targetPath를 그 화면으로 바꿀 수 있다.

--- a/backend/src/main/java/com/init/workspace/application/GetWorkspaceDashboardActionRecommendationsUseCase.java
+++ b/backend/src/main/java/com/init/workspace/application/GetWorkspaceDashboardActionRecommendationsUseCase.java
@@ -23,9 +23,12 @@ public class GetWorkspaceDashboardActionRecommendationsUseCase {
   private static final ZoneId METRIC_ZONE = ZoneId.of("Asia/Seoul");
   private static final int MAX_RECOMMENDATIONS = 3;
   private static final int STALE_KNOWLEDGE_PACK_DAYS = 30;
+  private static final int REPEATED_FEEDBACK_TYPE_THRESHOLD = 3;
   private static final double RISK_SURGE_THRESHOLD = 30.0;
   private static final double MISSING_SLOT_RATE_THRESHOLD = 20.0;
   private static final double LOW_CONFIDENCE_RATE_THRESHOLD = 10.0;
+  private static final String OPERATIONAL_SOURCE_LABEL = "운영 지표 기반";
+  private static final String SIMULATION_SOURCE_LABEL = "시뮬레이션에서 발견됨";
 
   private final WorkspaceRepository workspaceRepository;
   private final WorkspaceMemberRepository workspaceMemberRepository;
@@ -54,6 +57,10 @@ public class GetWorkspaceDashboardActionRecommendationsUseCase {
             workspaceId, period.start(), period.endExclusive(), period.previousStart());
 
     List<WorkspaceDashboardActionRecommendationResult> recommendations = new ArrayList<>();
+    addOpenSimulationFeedbackRecommendation(workspaceId, signals, recommendations);
+    addSimulationReviewCandidateRecommendation(workspaceId, signals, recommendations);
+    addFailedGoldenCaseRecommendation(workspaceId, signals, recommendations);
+    addRepeatedSimulationFeedbackRecommendation(workspaceId, signals, recommendations);
     addPipelineFailedRecommendation(workspaceId, signals, recommendations);
     addRiskHitSurgeRecommendation(workspaceId, signals, recommendations);
     addHotpathSurgeRecommendation(workspaceId, signals, recommendations);
@@ -113,6 +120,91 @@ public class GetWorkspaceDashboardActionRecommendationsUseCase {
     return new RecommendationPeriod(start, end, previousStart);
   }
 
+  private void addOpenSimulationFeedbackRecommendation(
+      Long workspaceId,
+      WorkspaceDashboardRecommendationSignalsResult signals,
+      List<WorkspaceDashboardActionRecommendationResult> recommendations) {
+    WorkspaceDashboardSimulationSignalResult simulation = simulationSignals(signals);
+    if (simulation.openFeedbackCount() <= 0) {
+      return;
+    }
+
+    recommendations.add(
+        new WorkspaceDashboardActionRecommendationResult(
+            "SIMULATION_OPEN_FEEDBACK",
+            95,
+            SIMULATION_SOURCE_LABEL,
+            "개선 후보 생성",
+            "미처리 시뮬레이션 피드백이 있어 지식팩 개선 후보로 정리할 수 있습니다.",
+            "Open feedback",
+            formatCount(simulation.openFeedbackCount()),
+            "/workspaces/%d/simulation?feedbackStatus=OPEN".formatted(workspaceId)));
+  }
+
+  private void addSimulationReviewCandidateRecommendation(
+      Long workspaceId,
+      WorkspaceDashboardRecommendationSignalsResult signals,
+      List<WorkspaceDashboardActionRecommendationResult> recommendations) {
+    WorkspaceDashboardSimulationSignalResult simulation = simulationSignals(signals);
+    if (simulation.readyForReviewCandidateCount() <= 0) {
+      return;
+    }
+
+    recommendations.add(
+        new WorkspaceDashboardActionRecommendationResult(
+            "SIMULATION_REVIEW_PENDING_CANDIDATE",
+            92,
+            SIMULATION_SOURCE_LABEL,
+            "개선 후보 검토 진행",
+            "시뮬레이션에서 만든 개선 후보가 review 대기 중입니다.",
+            "Review 대기 후보",
+            formatCount(simulation.readyForReviewCandidateCount()),
+            "/workspaces/%d/simulation?candidateStatus=READY_FOR_REVIEW".formatted(workspaceId)));
+  }
+
+  private void addFailedGoldenCaseRecommendation(
+      Long workspaceId,
+      WorkspaceDashboardRecommendationSignalsResult signals,
+      List<WorkspaceDashboardActionRecommendationResult> recommendations) {
+    WorkspaceDashboardSimulationSignalResult simulation = simulationSignals(signals);
+    if (simulation.failedGoldenCaseCount() <= 0) {
+      return;
+    }
+
+    recommendations.add(
+        new WorkspaceDashboardActionRecommendationResult(
+            "SIMULATION_GOLDEN_CASE_FAILED",
+            88,
+            SIMULATION_SOURCE_LABEL,
+            "변경 영향 확인",
+            "최근 replay에서 실패한 검증 케이스가 있어 변경 영향을 확인해야 합니다.",
+            "실패 검증 케이스",
+            formatCount(simulation.failedGoldenCaseCount()),
+            "/workspaces/%d/simulation?focus=golden-cases".formatted(workspaceId)));
+  }
+
+  private void addRepeatedSimulationFeedbackRecommendation(
+      Long workspaceId,
+      WorkspaceDashboardRecommendationSignalsResult signals,
+      List<WorkspaceDashboardActionRecommendationResult> recommendations) {
+    WorkspaceDashboardSimulationSignalResult simulation = simulationSignals(signals);
+    if (simulation.topOpenFeedbackTypeCount() < REPEATED_FEEDBACK_TYPE_THRESHOLD
+        || simulation.topOpenFeedbackType() == null) {
+      return;
+    }
+
+    recommendations.add(
+        new WorkspaceDashboardActionRecommendationResult(
+            "SIMULATION_REPEATED_FEEDBACK_TYPE",
+            82,
+            SIMULATION_SOURCE_LABEL,
+            "workflow/slot/policy 집중 점검",
+            "동일 유형의 시뮬레이션 피드백이 반복되어 관련 정의를 함께 점검해야 합니다.",
+            formatFeedbackType(simulation.topOpenFeedbackType()),
+            formatCount(simulation.topOpenFeedbackTypeCount()),
+            "/workspaces/%d/simulation?feedbackStatus=OPEN".formatted(workspaceId)));
+  }
+
   private void addPipelineFailedRecommendation(
       Long workspaceId,
       WorkspaceDashboardRecommendationSignalsResult signals,
@@ -126,6 +218,7 @@ public class GetWorkspaceDashboardActionRecommendationsUseCase {
         new WorkspaceDashboardActionRecommendationResult(
             "PIPELINE_FAILED",
             100,
+            OPERATIONAL_SOURCE_LABEL,
             "생성 실패 확인",
             "최근 지식팩 생성이 실패했습니다. 실패 사유를 확인하고 다시 실행하세요.",
             "Pipeline job",
@@ -148,6 +241,7 @@ public class GetWorkspaceDashboardActionRecommendationsUseCase {
         new WorkspaceDashboardActionRecommendationResult(
             "RISK_HIT_SURGE",
             90,
+            OPERATIONAL_SOURCE_LABEL,
             "주의 사항 검토",
             "선택 기간 risk hit가 전 기간보다 크게 증가했습니다.",
             "Risk hit",
@@ -168,6 +262,7 @@ public class GetWorkspaceDashboardActionRecommendationsUseCase {
         new WorkspaceDashboardActionRecommendationResult(
             "HOTPATH_SURGE",
             85,
+            OPERATIONAL_SOURCE_LABEL,
             workflow.workflowName() + " workflow 점검",
             "선택 기간 실행량이 전 기간보다 크게 증가했습니다.",
             "전 기간 대비",
@@ -188,6 +283,7 @@ public class GetWorkspaceDashboardActionRecommendationsUseCase {
         new WorkspaceDashboardActionRecommendationResult(
             "LOW_COMPLETION_RATE",
             80,
+            OPERATIONAL_SOURCE_LABEL,
             "병목 state 확인",
             workflow.workflowName() + " workflow 완료율이 낮습니다.",
             "완료율",
@@ -209,6 +305,7 @@ public class GetWorkspaceDashboardActionRecommendationsUseCase {
         new WorkspaceDashboardActionRecommendationResult(
             "MISSING_SLOT_HIGH",
             75,
+            OPERATIONAL_SOURCE_LABEL,
             "확인 항목 수정",
             "상담 중 필요한 slot을 채우지 못한 결정 로그 비율이 높습니다.",
             "Missing slot",
@@ -230,6 +327,7 @@ public class GetWorkspaceDashboardActionRecommendationsUseCase {
         new WorkspaceDashboardActionRecommendationResult(
             "LOW_CONFIDENCE_HIGH",
             70,
+            OPERATIONAL_SOURCE_LABEL,
             "상담 로그 추가 업로드",
             "저신뢰 decision 비율이 높아 최근 상담 로그 보강이 필요합니다.",
             "Low confidence",
@@ -258,6 +356,7 @@ public class GetWorkspaceDashboardActionRecommendationsUseCase {
         new WorkspaceDashboardActionRecommendationResult(
             "STALE_KNOWLEDGE_PACK",
             60,
+            OPERATIONAL_SOURCE_LABEL,
             "새 로그로 지식팩 업데이트",
             "운영 중인 지식팩이 오래되어 최근 상담 패턴 반영이 필요할 수 있습니다.",
             "Published",
@@ -278,6 +377,28 @@ public class GetWorkspaceDashboardActionRecommendationsUseCase {
             workflow.domainPackId(),
             workflow.workflowDefinitionId(),
             workflow.domainPackVersionId());
+  }
+
+  private WorkspaceDashboardSimulationSignalResult simulationSignals(
+      WorkspaceDashboardRecommendationSignalsResult signals) {
+    WorkspaceDashboardSimulationSignalResult simulation = signals.simulationSignals();
+    if (simulation != null) {
+      return simulation;
+    }
+    return new WorkspaceDashboardSimulationSignalResult(0, 0, 0, null, 0);
+  }
+
+  private String formatFeedbackType(String feedbackType) {
+    return switch (feedbackType) {
+      case "INTENT_MISMATCH" -> "Intent mismatch";
+      case "MISSING_SLOT_QUESTION" -> "Missing slot";
+      case "INAPPROPRIATE_RESPONSE" -> "응답 문구";
+      case "POLICY_CONDITION_MISSING" -> "Policy 조건";
+      case "RISK_HANDOFF_REQUIRED" -> "Risk/handoff";
+      case "WORKFLOW_BRANCH_ERROR" -> "Workflow 분기";
+      case "OTHER" -> "기타 feedback";
+      default -> feedbackType;
+    };
   }
 
   private Double changeRate(long current, long previous) {

--- a/backend/src/main/java/com/init/workspace/application/WorkspaceDashboardActionRecommendationResult.java
+++ b/backend/src/main/java/com/init/workspace/application/WorkspaceDashboardActionRecommendationResult.java
@@ -3,6 +3,7 @@ package com.init.workspace.application;
 public record WorkspaceDashboardActionRecommendationResult(
     String ruleCode,
     int priority,
+    String sourceLabel,
     String title,
     String description,
     String evidenceLabel,

--- a/backend/src/main/java/com/init/workspace/application/WorkspaceDashboardRecommendationSignalsResult.java
+++ b/backend/src/main/java/com/init/workspace/application/WorkspaceDashboardRecommendationSignalsResult.java
@@ -9,4 +9,5 @@ public record WorkspaceDashboardRecommendationSignalsResult(
     WorkspaceDashboardDecisionSignalResult currentDecisionSignals,
     WorkspaceDashboardDecisionSignalResult previousDecisionSignals,
     WorkspaceDashboardWorkflowRecommendationSignal hotpathSurgeWorkflow,
-    WorkspaceDashboardWorkflowRecommendationSignal lowCompletionWorkflow) {}
+    WorkspaceDashboardWorkflowRecommendationSignal lowCompletionWorkflow,
+    WorkspaceDashboardSimulationSignalResult simulationSignals) {}

--- a/backend/src/main/java/com/init/workspace/application/WorkspaceDashboardSimulationSignalResult.java
+++ b/backend/src/main/java/com/init/workspace/application/WorkspaceDashboardSimulationSignalResult.java
@@ -1,0 +1,8 @@
+package com.init.workspace.application;
+
+public record WorkspaceDashboardSimulationSignalResult(
+    long openFeedbackCount,
+    long readyForReviewCandidateCount,
+    long failedGoldenCaseCount,
+    String topOpenFeedbackType,
+    long topOpenFeedbackTypeCount) {}

--- a/backend/src/main/java/com/init/workspace/infrastructure/persistence/JdbcWorkspaceDashboardQueryAdapter.java
+++ b/backend/src/main/java/com/init/workspace/infrastructure/persistence/JdbcWorkspaceDashboardQueryAdapter.java
@@ -7,6 +7,7 @@ import com.init.workspace.application.WorkspaceDashboardKnowledgePackResult;
 import com.init.workspace.application.WorkspaceDashboardLogUploadResult;
 import com.init.workspace.application.WorkspaceDashboardQueryPort;
 import com.init.workspace.application.WorkspaceDashboardRecommendationSignalsResult;
+import com.init.workspace.application.WorkspaceDashboardSimulationSignalResult;
 import com.init.workspace.application.WorkspaceDashboardWorkflowRecommendationSignal;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -53,7 +54,8 @@ public class JdbcWorkspaceDashboardQueryAdapter implements WorkspaceDashboardQue
         findDecisionSignals(workspaceId, periodStart, periodEnd),
         findDecisionSignals(workspaceId, previousPeriodStart, periodStart),
         findHotpathSurgeWorkflow(workspaceId, periodStart, periodEnd, previousPeriodStart),
-        findLowCompletionWorkflow(workspaceId, periodStart, periodEnd));
+        findLowCompletionWorkflow(workspaceId, periodStart, periodEnd),
+        findSimulationSignals(workspaceId));
   }
 
   private WorkspaceDashboardKnowledgePackResult findActiveKnowledgePack(Long workspaceId) {
@@ -238,6 +240,78 @@ public class JdbcWorkspaceDashboardQueryAdapter implements WorkspaceDashboardQue
     return rows.stream().findFirst().orElse(null);
   }
 
+  private WorkspaceDashboardSimulationSignalResult findSimulationSignals(Long workspaceId) {
+    MapSqlParameterSource params = new MapSqlParameterSource("workspaceId", workspaceId);
+    WorkspaceDashboardSimulationSignalResult counts =
+        jdbcTemplate.queryForObject(
+            """
+            WITH latest_replay AS (
+              SELECT DISTINCT ON (golden_case_id)
+                golden_case_id,
+                status
+              FROM runtime.simulation_golden_case_replay_result
+              WHERE workspace_id = :workspaceId
+              ORDER BY golden_case_id, created_at DESC, id DESC
+            )
+            SELECT
+              (
+                SELECT COUNT(*)
+                FROM runtime.simulation_feedback
+                WHERE workspace_id = :workspaceId
+                  AND status = 'OPEN'
+              ) AS open_feedback_count,
+              (
+                SELECT COUNT(*)
+                FROM runtime.simulation_improvement_candidate
+                WHERE workspace_id = :workspaceId
+                  AND status = 'READY_FOR_REVIEW'
+              ) AS ready_for_review_candidate_count,
+              (
+                SELECT COUNT(*)
+                FROM latest_replay
+                WHERE status = 'FAIL'
+              ) AS failed_golden_case_count
+            """,
+            params,
+            (rs, rowNum) ->
+                new WorkspaceDashboardSimulationSignalResult(
+                    rs.getLong("open_feedback_count"),
+                    rs.getLong("ready_for_review_candidate_count"),
+                    rs.getLong("failed_golden_case_count"),
+                    null,
+                    0));
+    WorkspaceDashboardSimulationFeedbackTypeSignal topFeedbackType =
+        findTopOpenFeedbackType(workspaceId);
+    if (counts == null) {
+      counts = new WorkspaceDashboardSimulationSignalResult(0, 0, 0, null, 0);
+    }
+    return new WorkspaceDashboardSimulationSignalResult(
+        counts.openFeedbackCount(),
+        counts.readyForReviewCandidateCount(),
+        counts.failedGoldenCaseCount(),
+        topFeedbackType != null ? topFeedbackType.feedbackType() : null,
+        topFeedbackType != null ? topFeedbackType.feedbackCount() : 0);
+  }
+
+  private WorkspaceDashboardSimulationFeedbackTypeSignal findTopOpenFeedbackType(Long workspaceId) {
+    List<WorkspaceDashboardSimulationFeedbackTypeSignal> rows =
+        jdbcTemplate.query(
+            """
+            SELECT feedback_type, COUNT(*) AS feedback_count
+            FROM runtime.simulation_feedback
+            WHERE workspace_id = :workspaceId
+              AND status = 'OPEN'
+            GROUP BY feedback_type
+            ORDER BY feedback_count DESC, feedback_type ASC
+            LIMIT 1
+            """,
+            Map.of("workspaceId", workspaceId),
+            (rs, rowNum) ->
+                new WorkspaceDashboardSimulationFeedbackTypeSignal(
+                    rs.getString("feedback_type"), rs.getLong("feedback_count")));
+    return rows.stream().findFirst().orElse(null);
+  }
+
   private String workflowAggregateQuery(String tailSql) {
     return """
         WITH current_workflows AS (
@@ -359,4 +433,7 @@ public class JdbcWorkspaceDashboardQueryAdapter implements WorkspaceDashboardQue
   private OffsetDateTime offsetDateTime(ResultSet rs, String columnName) throws SQLException {
     return rs.getObject(columnName, OffsetDateTime.class);
   }
+
+  private record WorkspaceDashboardSimulationFeedbackTypeSignal(
+      String feedbackType, long feedbackCount) {}
 }

--- a/backend/src/test/java/com/init/workspace/application/GetWorkspaceDashboardActionRecommendationsUseCaseTest.java
+++ b/backend/src/test/java/com/init/workspace/application/GetWorkspaceDashboardActionRecommendationsUseCaseTest.java
@@ -20,6 +20,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -87,6 +89,107 @@ class GetWorkspaceDashboardActionRecommendationsUseCaseTest {
   }
 
   @Test
+  @DisplayName("시뮬레이션 신호도 운영 지표 추천과 같은 priority 체계로 정렬")
+  void should_priority정렬_when_시뮬레이션추천포함() {
+    givenMember();
+    given(
+            workspaceDashboardQueryPort.findRecommendationSignals(
+                1L,
+                odt("2026-06-04T00:00:00+09:00"),
+                odt("2026-06-05T00:00:00+09:00"),
+                odt("2026-06-03T00:00:00+09:00")))
+        .willReturn(signalsWithSimulationCandidates());
+
+    WorkspaceDashboardActionRecommendationsResult result =
+        useCase.execute(new GetWorkspaceDashboardActionRecommendationsCommand(1L, 7L, null, null));
+
+    assertThat(result.recommendations())
+        .extracting(WorkspaceDashboardActionRecommendationResult::ruleCode)
+        .containsExactly(
+            "PIPELINE_FAILED", "SIMULATION_OPEN_FEEDBACK", "SIMULATION_REVIEW_PENDING_CANDIDATE");
+    assertThat(result.recommendations().get(1).sourceLabel()).isEqualTo("시뮬레이션에서 발견됨");
+    assertThat(result.recommendations().get(1).evidenceValue()).isEqualTo("4건");
+    assertThat(result.recommendations().get(1).targetPath())
+        .isEqualTo("/workspaces/1/simulation?feedbackStatus=OPEN");
+  }
+
+  @Test
+  @DisplayName("시뮬레이션 추천에 open feedback, review 대기 후보, 실패 검증 케이스 수 표시")
+  void should_시뮬레이션카운트표시_when_시뮬레이션신호있음() {
+    givenMember();
+    given(
+            workspaceDashboardQueryPort.findRecommendationSignals(
+                1L,
+                odt("2026-06-04T00:00:00+09:00"),
+                odt("2026-06-05T00:00:00+09:00"),
+                odt("2026-06-03T00:00:00+09:00")))
+        .willReturn(signalsWithOnlySimulationCandidates());
+
+    WorkspaceDashboardActionRecommendationsResult result =
+        useCase.execute(new GetWorkspaceDashboardActionRecommendationsCommand(1L, 7L, null, null));
+
+    assertThat(result.recommendations())
+        .extracting(WorkspaceDashboardActionRecommendationResult::ruleCode)
+        .containsExactly(
+            "SIMULATION_OPEN_FEEDBACK",
+            "SIMULATION_REVIEW_PENDING_CANDIDATE",
+            "SIMULATION_GOLDEN_CASE_FAILED");
+    assertThat(result.recommendations())
+        .extracting(WorkspaceDashboardActionRecommendationResult::evidenceValue)
+        .containsExactly("4건", "2건", "1건");
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "INTENT_MISMATCH, Intent mismatch",
+    "MISSING_SLOT_QUESTION, Missing slot",
+    "INAPPROPRIATE_RESPONSE, 응답 문구",
+    "POLICY_CONDITION_MISSING, Policy 조건",
+    "RISK_HANDOFF_REQUIRED, Risk/handoff",
+    "WORKFLOW_BRANCH_ERROR, Workflow 분기",
+    "OTHER, 기타 feedback",
+    "CUSTOM_TYPE, CUSTOM_TYPE"
+  })
+  @DisplayName("반복 시뮬레이션 피드백 유형을 추천 근거 라벨로 변환")
+  void should_피드백유형라벨표시_when_반복시뮬레이션피드백있음(String feedbackType, String expectedLabel) {
+    givenMember();
+    given(
+            workspaceDashboardQueryPort.findRecommendationSignals(
+                1L,
+                odt("2026-06-04T00:00:00+09:00"),
+                odt("2026-06-05T00:00:00+09:00"),
+                odt("2026-06-03T00:00:00+09:00")))
+        .willReturn(signalsWithRepeatedSimulationFeedback(feedbackType));
+
+    WorkspaceDashboardActionRecommendationsResult result =
+        useCase.execute(new GetWorkspaceDashboardActionRecommendationsCommand(1L, 7L, null, null));
+
+    assertThat(result.recommendations()).hasSize(1);
+    assertThat(result.recommendations().getFirst().ruleCode())
+        .isEqualTo("SIMULATION_REPEATED_FEEDBACK_TYPE");
+    assertThat(result.recommendations().getFirst().evidenceLabel()).isEqualTo(expectedLabel);
+    assertThat(result.recommendations().getFirst().evidenceValue()).isEqualTo("3건");
+  }
+
+  @Test
+  @DisplayName("시뮬레이션 신호가 null이면 빈 신호로 처리")
+  void should_emptySimulationSignals_when_시뮬레이션신호Null() {
+    givenMember();
+    given(
+            workspaceDashboardQueryPort.findRecommendationSignals(
+                1L,
+                odt("2026-06-04T00:00:00+09:00"),
+                odt("2026-06-05T00:00:00+09:00"),
+                odt("2026-06-03T00:00:00+09:00")))
+        .willReturn(signalsWithNullSimulationSignals());
+
+    WorkspaceDashboardActionRecommendationsResult result =
+        useCase.execute(new GetWorkspaceDashboardActionRecommendationsCommand(1L, 7L, null, null));
+
+    assertThat(result.recommendations()).isEmpty();
+  }
+
+  @Test
   @DisplayName("workspace 없음 → WorkspaceNotFoundException")
   void should_WorkspaceNotFoundException_when_workspace없음() {
     given(workspaceRepository.existsById(1L)).willReturn(false);
@@ -134,7 +237,8 @@ class GetWorkspaceDashboardActionRecommendationsUseCaseTest {
         new WorkspaceDashboardDecisionSignalResult(100, 30, 20, 15),
         new WorkspaceDashboardDecisionSignalResult(100, 10, 10, 3),
         workflow("환불 처리", 48, 87.5, 33.3),
-        workflow("배송 확인", 10, 40.0, null));
+        workflow("배송 확인", 10, 40.0, null),
+        emptySimulationSignals());
   }
 
   private WorkspaceDashboardRecommendationSignalsResult emptySignals() {
@@ -145,6 +249,63 @@ class GetWorkspaceDashboardActionRecommendationsUseCaseTest {
         new WorkspaceDashboardDecisionSignalResult(0, 0, 0, 0),
         new WorkspaceDashboardDecisionSignalResult(0, 0, 0, 0),
         null,
+        null,
+        emptySimulationSignals());
+  }
+
+  private WorkspaceDashboardRecommendationSignalsResult signalsWithSimulationCandidates() {
+    OffsetDateTime now = odt("2026-06-03T10:00:00+09:00");
+    WorkspaceDashboardHealthResult health =
+        new WorkspaceDashboardHealthResult(
+            null,
+            null,
+            new WorkspaceDashboardGenerationResult(77L, 8L, 11L, "FAILED", now, now, now, "boom"),
+            0);
+    return new WorkspaceDashboardRecommendationSignalsResult(
+        odt("2026-06-04T00:00:00+09:00"),
+        odt("2026-06-05T00:00:00+09:00"),
+        health,
+        new WorkspaceDashboardDecisionSignalResult(0, 0, 0, 0),
+        new WorkspaceDashboardDecisionSignalResult(0, 0, 0, 0),
+        null,
+        null,
+        new WorkspaceDashboardSimulationSignalResult(4, 2, 1, "MISSING_SLOT_QUESTION", 3));
+  }
+
+  private WorkspaceDashboardRecommendationSignalsResult signalsWithOnlySimulationCandidates() {
+    return new WorkspaceDashboardRecommendationSignalsResult(
+        odt("2026-06-04T00:00:00+09:00"),
+        odt("2026-06-05T00:00:00+09:00"),
+        new WorkspaceDashboardHealthResult(null, null, null, 0),
+        new WorkspaceDashboardDecisionSignalResult(0, 0, 0, 0),
+        new WorkspaceDashboardDecisionSignalResult(0, 0, 0, 0),
+        null,
+        null,
+        new WorkspaceDashboardSimulationSignalResult(4, 2, 1, "MISSING_SLOT_QUESTION", 3));
+  }
+
+  private WorkspaceDashboardRecommendationSignalsResult signalsWithRepeatedSimulationFeedback(
+      String feedbackType) {
+    return new WorkspaceDashboardRecommendationSignalsResult(
+        odt("2026-06-04T00:00:00+09:00"),
+        odt("2026-06-05T00:00:00+09:00"),
+        new WorkspaceDashboardHealthResult(null, null, null, 0),
+        new WorkspaceDashboardDecisionSignalResult(0, 0, 0, 0),
+        new WorkspaceDashboardDecisionSignalResult(0, 0, 0, 0),
+        null,
+        null,
+        new WorkspaceDashboardSimulationSignalResult(0, 0, 0, feedbackType, 3));
+  }
+
+  private WorkspaceDashboardRecommendationSignalsResult signalsWithNullSimulationSignals() {
+    return new WorkspaceDashboardRecommendationSignalsResult(
+        odt("2026-06-04T00:00:00+09:00"),
+        odt("2026-06-05T00:00:00+09:00"),
+        new WorkspaceDashboardHealthResult(null, null, null, 0),
+        new WorkspaceDashboardDecisionSignalResult(0, 0, 0, 0),
+        new WorkspaceDashboardDecisionSignalResult(0, 0, 0, 0),
+        null,
+        null,
         null);
   }
 
@@ -152,6 +313,10 @@ class GetWorkspaceDashboardActionRecommendationsUseCaseTest {
       String workflowName, long executionCount, Double completionRate, Double changeRate) {
     return new WorkspaceDashboardWorkflowRecommendationSignal(
         100L, 11L, 22L, workflowName, executionCount, completionRate, changeRate);
+  }
+
+  private WorkspaceDashboardSimulationSignalResult emptySimulationSignals() {
+    return new WorkspaceDashboardSimulationSignalResult(0, 0, 0, null, 0);
   }
 
   private OffsetDateTime odt(String value) {

--- a/backend/src/test/java/com/init/workspace/presentation/WorkspaceDashboardControllerTest.java
+++ b/backend/src/test/java/com/init/workspace/presentation/WorkspaceDashboardControllerTest.java
@@ -81,6 +81,7 @@ class WorkspaceDashboardControllerTest {
                 .principal(auth()))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.recommendations[0].ruleCode").value("HOTPATH_SURGE"))
+        .andExpect(jsonPath("$.recommendations[0].sourceLabel").value("운영 지표 기반"))
         .andExpect(jsonPath("$.recommendations[0].evidenceValue").value("+33.3%"))
         .andExpect(jsonPath("$.recommendations[0].targetPath").value("/workspaces/1/workflows"));
   }
@@ -104,6 +105,7 @@ class WorkspaceDashboardControllerTest {
             new WorkspaceDashboardActionRecommendationResult(
                 "HOTPATH_SURGE",
                 85,
+                "운영 지표 기반",
                 "workflow 점검",
                 "선택 기간 실행량이 전 기간보다 크게 증가했습니다.",
                 "전 기간 대비",

--- a/frontend/src/features/workspace-dashboard-health/api/workspaceDashboardHealthApi.ts
+++ b/frontend/src/features/workspace-dashboard-health/api/workspaceDashboardHealthApi.ts
@@ -43,6 +43,7 @@ export interface WorkspaceDashboardHealth {
 export interface WorkspaceDashboardActionRecommendation {
   ruleCode: string;
   priority: number;
+  sourceLabel: string;
   title: string;
   description: string;
   evidenceLabel: string;

--- a/frontend/src/pages/workspace/ui/WorkspaceDashboardPage.test.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceDashboardPage.test.tsx
@@ -146,11 +146,22 @@ const actionRecommendationResponse = {
     {
       ruleCode: "HOTPATH_SURGE",
       priority: 85,
+      sourceLabel: "운영 지표 기반",
       title: "환불 처리 workflow 점검",
       description: "선택 기간 실행량이 전 기간보다 크게 증가했습니다.",
       evidenceLabel: "전 기간 대비",
       evidenceValue: "+33.3%",
       targetPath: "/workspaces/1/domain-packs/11/workflows/100?versionId=22",
+    },
+    {
+      ruleCode: "SIMULATION_OPEN_FEEDBACK",
+      priority: 95,
+      sourceLabel: "시뮬레이션에서 발견됨",
+      title: "개선 후보 생성",
+      description: "미처리 시뮬레이션 피드백이 있어 지식팩 개선 후보로 정리할 수 있습니다.",
+      evidenceLabel: "Open feedback",
+      evidenceValue: "4건",
+      targetPath: "/workspaces/1/simulation?feedbackStatus=OPEN",
     },
   ],
 };
@@ -237,9 +248,15 @@ describe("WorkspaceDashboardPage", () => {
     expect(await screen.findByRole("heading", { name: "추천 액션" })).toBeInTheDocument();
     expect(screen.getByText("환불 처리 workflow 점검")).toBeInTheDocument();
     expect(screen.getByText("+33.3%")).toBeInTheDocument();
+    expect(screen.getByText("시뮬레이션에서 발견됨")).toBeInTheDocument();
+    expect(screen.getByText("4건")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /환불 처리 workflow 점검/ })).toHaveAttribute(
       "href",
       "/workspaces/1/domain-packs/11/workflows/100?versionId=22",
+    );
+    expect(screen.getByRole("link", { name: /개선 후보 생성/ })).toHaveAttribute(
+      "href",
+      "/workspaces/1/simulation?feedbackStatus=OPEN",
     );
     expect(screen.getByTestId("knowledge-health-panel")).toHaveTextContent("workspace 1 health");
     expect(await screen.findByText("핫패스 워크플로우 랭킹")).toBeInTheDocument();

--- a/frontend/src/pages/workspace/ui/WorkspaceDashboardPage.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceDashboardPage.tsx
@@ -619,7 +619,10 @@ function HotpathWorkflowRankingPanel({
 function ActionRecommendationCard({ item }: { item: WorkspaceDashboardActionRecommendation }) {
   return (
     <Link to={item.targetPath} className={styles.recommendationCard}>
-      <span className={styles.ruleBadge}>{item.ruleCode.replaceAll("_", " ")}</span>
+      <span className={styles.recommendationMeta}>
+        <span className={styles.sourceBadge}>{item.sourceLabel}</span>
+        <span className={styles.ruleBadge}>{item.ruleCode.replaceAll("_", " ")}</span>
+      </span>
       <h3>{item.title}</h3>
       <p>{item.description}</p>
       <dl>

--- a/frontend/src/pages/workspace/ui/WorkspaceSimulationPage.test.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceSimulationPage.test.tsx
@@ -323,6 +323,27 @@ describe("WorkspaceSimulationPage", () => {
     expect(screen.getByText("A-100")).toBeInTheDocument();
   });
 
+  it("대시보드 추천 query로 피드백과 개선 후보 상태 필터를 초기화한다", async () => {
+    renderPage("/workspaces/1/simulation?feedbackStatus=RESOLVED&candidateStatus=READY_FOR_REVIEW");
+
+    expect(await screen.findByLabelText("피드백 상태 필터")).toHaveValue("RESOLVED");
+    expect(screen.getByLabelText("개선 후보 상태 필터")).toHaveValue("READY_FOR_REVIEW");
+    await waitFor(() => {
+      expect(mockedSimulationApi.listFeedback).toHaveBeenCalledWith(1, {
+        status: "RESOLVED",
+        page: 0,
+        size: 20,
+      });
+    });
+    await waitFor(() => {
+      expect(mockedSimulationApi.listImprovementCandidates).toHaveBeenCalledWith(1, {
+        status: "READY_FOR_REVIEW",
+        page: 0,
+        size: 20,
+      });
+    });
+  });
+
   it("workflow를 선택해 시뮬레이션 세션을 생성한다", async () => {
     renderPage();
 

--- a/frontend/src/pages/workspace/ui/WorkspaceSimulationPage.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceSimulationPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { Navigate, useOutletContext, useParams } from "react-router-dom";
+import { Navigate, useOutletContext, useParams, useSearchParams } from "react-router-dom";
 import {
   CheckCircleIcon,
   FlagIcon,
@@ -77,6 +77,22 @@ const CANDIDATE_STATUSES: Array<{
 ];
 
 const ACTION_TYPES = ["ASK_SLOT", "ADVANCE", "ANSWER", "COMPLETED", "HANDOFF", "WAIT"] as const;
+
+function readFeedbackStatusParam(searchParams: URLSearchParams): SimulationFeedbackStatus | "" {
+  const value = searchParams.get("feedbackStatus");
+  return FEEDBACK_STATUSES.some((status) => status.value === value)
+    ? (value as SimulationFeedbackStatus | "")
+    : "OPEN";
+}
+
+function readCandidateStatusParam(
+  searchParams: URLSearchParams,
+): SimulationImprovementCandidateStatus | "" {
+  const value = searchParams.get("candidateStatus");
+  return CANDIDATE_STATUSES.some((status) => status.value === value)
+    ? (value as SimulationImprovementCandidateStatus | "")
+    : "DRAFT";
+}
 
 type Meta = {
   customerName?: string;
@@ -186,6 +202,17 @@ function optionalText(value?: string | null): string | undefined {
 
 export function WorkspaceSimulationPage() {
   const { workspaceId } = useParams();
+  const [searchParams] = useSearchParams();
+  const searchQuery = searchParams.toString();
+  const querySearchParams = useMemo(() => new URLSearchParams(searchQuery), [searchQuery]);
+  const feedbackStatusFromQuery = useMemo(
+    () => readFeedbackStatusParam(querySearchParams),
+    [querySearchParams],
+  );
+  const candidateStatusFromQuery = useMemo(
+    () => readCandidateStatusParam(querySearchParams),
+    [querySearchParams],
+  );
   const parsedWorkspaceId = parseRouteId(workspaceId);
   const { setCrumbs } = useOutletContext<ShellContext>();
   const [sessions, setSessions] = useState<ChatSession[]>([]);
@@ -196,13 +223,13 @@ export function WorkspaceSimulationPage() {
   const [messageInput, setMessageInput] = useState("");
   const [feedbackItems, setFeedbackItems] = useState<SimulationFeedback[]>([]);
   const [feedbackStatusFilter, setFeedbackStatusFilter] = useState<SimulationFeedbackStatus | "">(
-    "OPEN",
+    () => feedbackStatusFromQuery,
   );
   const [candidateItems, setCandidateItems] = useState<SimulationImprovementCandidate[]>([]);
   const [goldenCases, setGoldenCases] = useState<SimulationGoldenCase[]>([]);
   const [candidateStatusFilter, setCandidateStatusFilter] = useState<
     SimulationImprovementCandidateStatus | ""
-  >("DRAFT");
+  >(() => candidateStatusFromQuery);
   const [feedbackTarget, setFeedbackTarget] = useState("session");
   const [feedbackType, setFeedbackType] = useState<SimulationFeedbackType>(DEFAULT_FEEDBACK_TYPE);
   const [feedbackSeverity, setFeedbackSeverity] =
@@ -267,6 +294,11 @@ export function WorkspaceSimulationPage() {
     setCrumbs(["시뮬레이션"]);
     return () => setCrumbs([]);
   }, [setCrumbs]);
+
+  useEffect(() => {
+    setFeedbackStatusFilter(feedbackStatusFromQuery);
+    setCandidateStatusFilter(candidateStatusFromQuery);
+  }, [candidateStatusFromQuery, feedbackStatusFromQuery]);
 
   useEffect(() => {
     setFeedbackTarget("session");

--- a/frontend/src/pages/workspace/ui/workspace-dashboard-page.module.css
+++ b/frontend/src/pages/workspace/ui/workspace-dashboard-page.module.css
@@ -477,6 +477,28 @@
   text-transform: uppercase;
 }
 
+.recommendationMeta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--s-2);
+}
+
+.sourceBadge {
+  display: inline-flex;
+  width: fit-content;
+  min-height: 24px;
+  align-items: center;
+  border: 1px solid var(--line);
+  border-radius: var(--r-pill);
+  padding: 0 var(--s-3);
+  background: var(--paper);
+  color: var(--ink);
+  font-size: 12px;
+  font-weight: 450;
+  letter-spacing: 0;
+}
+
 .recommendationCard dd {
   margin: 0;
   color: var(--ink);


### PR DESCRIPTION
Closes #530

## 변경 사항

- 대시보드 고객 액션 추천에 시뮬레이션 open feedback, review 대기 개선 후보, golden case replay 실패 기반 rule을 추가했습니다.
- 추천 카드에 “운영 지표 기반” 또는 “시뮬레이션에서 발견됨” 출처와 각 추천 근거 count를 표시하도록 했습니다.
- 시뮬레이션 추천 링크가 feedback/candidate 상태 필터를 포함해 관련 화면으로 이동하도록 했습니다.
- 이슈 530 스펙을 `.agent/specs/530.md`에 정리했습니다.

## 검증

- `git diff --check`
- `cd backend && JAVA_HOME=/Users/owen/.local/share/mise/installs/java/temurin-21.0.11+10.0.LTS GRADLE_USER_HOME=/tmp/ostone-gradle-home-530 ./gradlew test --tests com.init.workspace.application.GetWorkspaceDashboardActionRecommendationsUseCaseTest --tests com.init.workspace.presentation.WorkspaceDashboardControllerTest`
- `cd frontend && pnpm exec eslint src/features/workspace-dashboard-health/api/workspaceDashboardHealthApi.ts src/pages/workspace/ui/WorkspaceDashboardPage.tsx src/pages/workspace/ui/WorkspaceDashboardPage.test.tsx src/pages/workspace/ui/WorkspaceSimulationPage.tsx src/pages/workspace/ui/WorkspaceSimulationPage.test.tsx`
- `cd frontend && pnpm test -- WorkspaceDashboardPage.test.tsx WorkspaceSimulationPage.test.tsx`
- 커밋 pre-commit hook: `cd backend && ./gradlew spotlessCheck`, `cd frontend && pnpm run lint`, `cd frontend && pnpm run format`

## 참고

- 로컬 기본 shell은 Java 17을 사용하므로, backend Gradle 검증은 저장소 mise Java 21 경로를 명시해 실행했습니다.
- 전역 Gradle cache lock 경합을 피하기 위해 backend Gradle 검증은 별도 `GRADLE_USER_HOME`으로 실행했습니다.
- `cd backend && ... ./gradlew checkstyleMain checkstyleTest`는 성공했지만 기존 파일의 checkstyle warning을 다수 출력했습니다.
- `cd frontend && pnpm lint`는 기존 unrelated lint error로 실패해, 이 PR에서 변경한 frontend 파일은 별도 eslint 명령으로 검증했습니다.