### PR TITLE
test(frontend): 핵심 사용자 흐름 e2e 검증을 CI로 보장

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,46 @@ jobs:
         working-directory: ./frontend
         run: pnpm build
 
+  frontend-e2e:
+    needs: paths-filter
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.paths-filter.outputs.frontend == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.TOOL_NODE_VERSION }}
+          cache: "pnpm"
+          cache-dependency-path: "./frontend/pnpm-lock.yaml"
+
+      - name: Install dependencies
+        working-directory: ./frontend
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright Chromium
+        working-directory: ./frontend
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run mocked E2E tests
+        working-directory: ./frontend
+        run: pnpm e2e
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-e2e-playwright-report
+          path: |
+            frontend/playwright-report
+            frontend/test-results
+          if-no-files-found: ignore
+          retention-days: 7
+
   ml:
     needs: paths-filter
     if: ${{ github.event_name == 'workflow_dispatch' || needs.paths-filter.outputs.ml == 'true' }}
@@ -347,7 +387,7 @@ jobs:
 
   ci-gate:
     if: always()
-    needs: [paths-filter, spec-check, tool-version-check, backend, frontend, ml, backend-sonar, frontend-sonar, ml-sonar]
+    needs: [paths-filter, spec-check, tool-version-check, backend, frontend, frontend-e2e, ml, backend-sonar, frontend-sonar, ml-sonar]
     runs-on: ubuntu-latest
     steps:
       - name: Check CI results
@@ -358,6 +398,7 @@ jobs:
             "${{ needs.tool-version-check.result }}"
             "${{ needs.backend.result }}"
             "${{ needs.frontend.result }}"
+            "${{ needs.frontend-e2e.result }}"
             "${{ needs.ml.result }}"
             "${{ needs.backend-sonar.result }}"
             "${{ needs.frontend-sonar.result }}"

--- a/.github/workflows/live-e2e.yml
+++ b/.github/workflows/live-e2e.yml
@@ -1,0 +1,74 @@
+name: Live E2E
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: "Live target URL"
+        required: true
+        default: "https://app.ajou-cstone.com"
+      confirm_prod:
+        description: "Must equal app.ajou-cstone.com when targeting production"
+        required: true
+        default: "app.ajou-cstone.com"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: live-e2e-${{ github.event.inputs.base_url }}
+  cancel-in-progress: false
+
+jobs:
+  live-e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      E2E_ALLOW_GITHUB_ACTIONS: "true"
+      E2E_BASE_URL: ${{ github.event.inputs.base_url }}
+      E2E_CONFIRM_PROD: ${{ github.event.inputs.confirm_prod }}
+      E2E_EMAIL: ${{ secrets.LIVE_E2E_EMAIL }}
+      E2E_PASSWORD: ${{ secrets.LIVE_E2E_PASSWORD }}
+      E2E_ALLOW_POLLUTING: "true"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+          cache-dependency-path: "./frontend/pnpm-lock.yaml"
+
+      - name: Install dependencies
+        working-directory: ./frontend
+        run: pnpm install
+
+      - name: Install Playwright Chromium
+        working-directory: ./frontend
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run live E2E smoke tests
+        working-directory: ./frontend
+        run: pnpm e2e:live
+
+      - name: Run polluting live E2E specs
+        working-directory: ./frontend
+        run: pnpm e2e:live:pollutes
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: live-e2e-playwright-report
+          path: |
+            frontend/playwright-report
+            frontend/test-results
+            frontend/e2e/live/.cleanup/leftovers.log
+          if-no-files-found: ignore
+          retention-days: 14

--- a/frontend/e2e/admin.spec.ts
+++ b/frontend/e2e/admin.spec.ts
@@ -1,0 +1,121 @@
+import { expect, test } from "@playwright/test";
+
+import { installAuth } from "./support/generated-api-auth";
+import { captureScreen, installAdminApiMocks } from "./support/app-mocks";
+
+test.describe("Admin console screens", () => {
+  let seen: string[];
+
+  test.beforeEach(async ({ page }) => {
+    seen = [];
+    await installAuth(page, {
+      role: "SUPER_ADMIN",
+      name: "관리자",
+      email: "admin@example.com",
+    });
+    await installAdminApiMocks(page, seen);
+  });
+
+  test.describe("Given a SUPER_ADMIN session", () => {
+    test.describe("When they inspect customers", () => {
+      test("Then customer list search and detail panels render operational data", async ({
+        page,
+      }, testInfo) => {
+        await page.goto("/admin/customers");
+        await expect(page.getByRole("heading", { name: "고객사 현황" })).toBeVisible();
+        await expect(page.getByRole("heading", { name: "QA Workspace" })).toBeVisible();
+        await expect(page.getByText("멤버 요약")).toBeVisible();
+
+        await page.getByPlaceholder("고객사명 또는 workspace key").fill("QA");
+        await page.getByRole("button", { name: "검색" }).click();
+        await expect(page.getByText("refund-log.zip")).toBeVisible();
+        await captureScreen(page, testInfo, "admin-customers");
+
+        expect(seen).toContain("GET /admin/customers?page=0&size=20");
+        expect(seen).toContain("GET /admin/customers/1");
+        expect(seen).toContain("GET /admin/customers?page=0&size=20&q=QA");
+      });
+    });
+
+    test.describe("When they refund a customer payment from admin billing", () => {
+      test("Then the full refund endpoint receives the entered reason", async ({ page }) => {
+        await page.goto("/admin/billing");
+        await expect(page.getByRole("heading", { name: "결제 관리" })).toBeVisible();
+        await expect(page.getByText("QA Workspace")).toBeVisible();
+
+        await page.getByRole("button", { name: "전체 환불" }).click();
+        await expect(page.getByRole("dialog")).toContainText("QA Workspace 전체 환불");
+        await page.getByPlaceholder("고객 요청으로 전체 환불").fill("관리자 검증 환불");
+        await page.getByRole("button", { name: "전체 환불 실행" }).click();
+
+        await expect(page.getByText("전체 환불이 완료되었습니다.")).toBeVisible();
+        expect(seen).toContain("POST /admin/billing/payments/7001/refunds");
+      });
+    });
+
+    test.describe("When they retry a failed pipeline job", () => {
+      test("Then Airflow filters are normalized into the list query and can be reset", async ({
+        page,
+      }) => {
+        await page.goto("/admin/airflow");
+        await expect(page.getByRole("heading", { name: "Airflow 운영" })).toBeVisible();
+
+        await page.getByLabel("Status").selectOption("FAILED");
+        await page.getByLabel("Workspace").fill("1");
+        await page.getByLabel("DAG").fill("domain_pack_generation");
+        await page.getByRole("textbox", { name: "Run" }).fill("pipeline_job_8001");
+        await page.getByLabel("Lag threshold").fill("120");
+        await page.getByRole("button", { name: "조회" }).click();
+
+        await expect
+          .poll(() =>
+            [...seen]
+              .reverse()
+              .find((entry) => entry.startsWith("GET /admin/pipeline-jobs?")) ?? "",
+          )
+          .toContain("status=FAILED");
+        const filteredRequest =
+          [...seen].reverse().find((entry) => entry.startsWith("GET /admin/pipeline-jobs?")) ?? "";
+        expect(filteredRequest).toContain("workspaceId=1");
+        expect(filteredRequest).toContain("dagId=domain_pack_generation");
+        expect(filteredRequest).toContain("runId=pipeline_job_8001");
+        expect(filteredRequest).toContain("lagThresholdSeconds=120");
+
+        await page.getByRole("button", { name: "초기화" }).click();
+        await expect(page.getByLabel("Status")).toHaveValue("");
+        await expect(page.getByLabel("Workspace")).toHaveValue("");
+        await expect(page.getByLabel("DAG")).toHaveValue("");
+        await expect(page.getByRole("textbox", { name: "Run" })).toHaveValue("");
+        await expect(page.getByLabel("Lag threshold")).toHaveValue("300");
+      });
+
+      test("Then Airflow operation calls the retry endpoint", async ({ page }) => {
+        await page.goto("/admin/airflow");
+        await expect(page.getByRole("heading", { name: "Airflow 운영" })).toBeVisible();
+        await expect(page.getByText("draft generation timeout")).toBeVisible();
+
+        await page.getByLabel("pipeline job 8001 재시도").click();
+        await expect(page.getByText("새 pipeline job #8002을 생성했습니다.")).toBeVisible();
+        expect(seen).toContain("POST /admin/pipeline-jobs/8001/retry");
+      });
+    });
+
+    test.describe("When they create another SUPER_ADMIN account", () => {
+      test("Then the form posts validated account data and shows the created role", async ({
+        page,
+      }) => {
+        await page.goto("/admin/super-admins");
+        await expect(page.getByRole("heading", { name: "관리자 계정" })).toBeVisible();
+
+        await page.getByLabel("이름").fill("운영 관리자");
+        await page.getByLabel("이메일").fill("super-admin@example.com");
+        await page.getByLabel("임시 비밀번호").fill("password123");
+        await page.getByRole("button", { name: "SUPER_ADMIN 생성" }).click();
+
+        await expect(page.getByText("super-admin@example.com")).toBeVisible();
+        await expect(page.getByText("SUPER_ADMIN", { exact: true })).toBeVisible();
+        expect(seen).toContain("POST /admin/super-admins");
+      });
+    });
+  });
+});

--- a/frontend/e2e/auth-login.spec.ts
+++ b/frontend/e2e/auth-login.spec.ts
@@ -95,7 +95,7 @@ test.describe("Login screen", () => {
         await page.getByRole("button", { name: "시스템 로그인" }).click();
 
         await expect(page).toHaveURL(/\/workspaces\/1\/workflows/);
-        await expect(page.getByText("워크플로우")).toBeVisible();
+        await expect(page.getByRole("heading", { name: "워크플로우", level: 1 })).toBeVisible();
         await expect
           .poll(() => page.evaluate(() => window.localStorage.getItem("accessToken")))
           .toBeTruthy();

--- a/frontend/e2e/auth-password-reset.spec.ts
+++ b/frontend/e2e/auth-password-reset.spec.ts
@@ -1,0 +1,114 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Password reset screens", () => {
+  test.describe("Given a user who forgot their password", () => {
+    test.describe("When they request a password reset email", () => {
+      test("Then the request is sent through the generated auth endpoint", async ({ page }) => {
+        const seen: string[] = [];
+
+        await page.route("**/api/v1/**", async (route) => {
+          const request = route.request();
+          const url = new URL(request.url());
+          const path = url.pathname.replace(/^\/api\/v1/, "");
+          const method = request.method();
+          seen.push(`${method} ${path}`);
+
+          if (method === "POST" && path === "/auth/password-reset/init") {
+            expect(request.postDataJSON()).toEqual({ email: "agent@example.com" });
+            await route.fulfill({
+              status: 200,
+              contentType: "application/json",
+              body: JSON.stringify({ data: { message: "재설정 메일을 발송했습니다." } }),
+            });
+            return;
+          }
+
+          await route.fulfill({
+            status: 500,
+            contentType: "application/json",
+            body: JSON.stringify({ code: "E2E_UNMOCKED", message: `${method} ${path}` }),
+          });
+        });
+
+        await page.goto("/password-reset");
+        await page.getByLabel("이메일").fill("agent@example.com");
+        await page.getByRole("button", { name: "재설정 메일 받기" }).click();
+
+        await expect(page.getByText("재설정 메일을 발송했습니다.")).toBeVisible();
+        expect(seen).toContain("POST /auth/password-reset/init");
+      });
+    });
+  });
+
+  test.describe("Given a valid reset token", () => {
+    test.describe("When the user submits mismatched passwords", () => {
+      test("Then the form blocks completion before calling the API", async ({ page }) => {
+        const seen: string[] = [];
+
+        await page.route("**/api/v1/**", async (route) => {
+          const request = route.request();
+          const url = new URL(request.url());
+          const path = url.pathname.replace(/^\/api\/v1/, "");
+          seen.push(`${request.method()} ${path}`);
+          await route.fulfill({
+            status: 500,
+            contentType: "application/json",
+            body: JSON.stringify({ code: "E2E_UNEXPECTED_API", message: path }),
+          });
+        });
+
+        await page.goto("/password-reset/complete?token=reset-token-e2e");
+        await page.getByLabel("새 비밀번호", { exact: true }).fill("password123");
+        await page.getByLabel("새 비밀번호 확인", { exact: true }).fill("password456");
+        await page.getByRole("button", { name: "비밀번호 변경하기" }).click();
+
+        await expect(page.getByText("비밀번호가 일치하지 않습니다.")).toBeVisible();
+        expect(seen).toEqual([]);
+      });
+    });
+
+    test.describe("When the user submits a new password", () => {
+      test("Then the password is updated and the completion state is rendered", async ({
+        page,
+      }) => {
+        const seen: string[] = [];
+
+        await page.route("**/api/v1/**", async (route) => {
+          const request = route.request();
+          const url = new URL(request.url());
+          const path = url.pathname.replace(/^\/api\/v1/, "");
+          const method = request.method();
+          seen.push(`${method} ${path}`);
+
+          if (method === "POST" && path === "/auth/password-reset/complete") {
+            expect(request.postDataJSON()).toEqual({
+              resetToken: "reset-token-e2e",
+              newPassword: "password123",
+            });
+            await route.fulfill({
+              status: 200,
+              contentType: "application/json",
+              body: JSON.stringify({ data: { message: "비밀번호가 변경되었습니다." } }),
+            });
+            return;
+          }
+
+          await route.fulfill({
+            status: 500,
+            contentType: "application/json",
+            body: JSON.stringify({ code: "E2E_UNMOCKED", message: `${method} ${path}` }),
+          });
+        });
+
+        await page.goto("/password-reset/complete?token=reset-token-e2e");
+        await page.getByLabel("새 비밀번호", { exact: true }).fill("password123");
+        await page.getByLabel("새 비밀번호 확인", { exact: true }).fill("password123");
+        await page.getByRole("button", { name: "비밀번호 변경하기" }).click();
+
+        await expect(page.getByText("완료!")).toBeVisible();
+        await expect(page.getByText("비밀번호가 성공적으로 변경되었습니다.")).toBeVisible();
+        expect(seen).toContain("POST /auth/password-reset/complete");
+      });
+    });
+  });
+});

--- a/frontend/e2e/billing.spec.ts
+++ b/frontend/e2e/billing.spec.ts
@@ -1,0 +1,99 @@
+import { expect, test } from "@playwright/test";
+
+import { installAuth } from "./support/generated-api-auth";
+import { captureScreen, installAppApiMocks } from "./support/app-mocks";
+
+test.describe("Billing screens", () => {
+  let seen: string[];
+
+  test.beforeEach(async ({ page }) => {
+    seen = [];
+    await installAuth(page);
+    await installAppApiMocks(page, seen);
+  });
+
+  test.describe("Given an active workspace subscription", () => {
+    test.describe("When an operator opens billing and manages payments", () => {
+      test("Then refund and cancel subscription actions call the correct endpoints", async ({
+        page,
+      }, testInfo) => {
+        await page.goto("/workspaces/1/billing");
+        await expect(page.getByRole("heading", { name: "구독", level: 1 })).toBeVisible();
+        await expect(page.getByText("신한카드")).toBeVisible();
+        await expect(page.getByText("99,000원")).toBeVisible();
+        await captureScreen(page, testInfo, "billing-overview");
+
+        await page.getByRole("button", { name: "환불" }).click();
+        await expect(page.getByRole("alertdialog")).toContainText("결제를 환불할까요?");
+        await page.getByPlaceholder("환불 사유를 입력해주세요").fill("품질 검증 환불");
+        await page.getByRole("alertdialog").getByRole("button", { name: "환불" }).click();
+        await expect(page.getByText("환불을 요청했습니다.")).toBeVisible();
+
+        await page.getByRole("button", { name: "구독 해지" }).click();
+        await expect(page.getByRole("alertdialog")).toContainText("구독을 해지할까요?");
+        await page.getByRole("alertdialog").getByRole("button", { name: "구독 해지" }).click();
+        await expect(page.getByText("구독을 해지했습니다.")).toBeVisible();
+
+        expect(seen).toContain("POST /workspaces/1/payments/pay_7001/cancel");
+        expect(seen).toContain("DELETE /workspaces/1/subscription");
+      });
+    });
+  });
+
+  test.describe("Given a Toss billing redirect succeeds", () => {
+    test.describe("When the success landing page receives auth parameters", () => {
+      test("Then it confirms billing authorization and returns to billing", async ({ page }) => {
+        await page.goto(
+          "/billing/success?workspaceId=1&flow=billing&authKey=auth-e2e&customerKey=customer-qa-workspace",
+        );
+
+        await expect(page).toHaveURL(/\/workspaces\/1\/billing/);
+        await expect(page.getByRole("heading", { name: "구독", level: 1 })).toBeVisible();
+        expect(seen).toContain("POST /workspaces/1/billing/authorizations");
+      });
+    });
+  });
+
+  test.describe("Given a Toss widget payment succeeds", () => {
+    test.describe("When the success landing page receives payment parameters", () => {
+      test("Then it confirms the one-off payment and returns to billing", async ({ page }) => {
+        await page.goto(
+          "/billing/success?workspaceId=1&flow=widget&paymentKey=payment-e2e&orderId=order-e2e&amount=99000",
+        );
+
+        await expect(page).toHaveURL(/\/workspaces\/1\/billing/);
+        await expect(page.getByRole("heading", { name: "구독", level: 1 })).toBeVisible();
+        expect(seen).toContain("POST /workspaces/1/payments/confirm");
+      });
+    });
+  });
+
+  test.describe("Given a payment redirect fails", () => {
+    test.describe("When the operator retries from the fail landing page", () => {
+      test("Then they are sent back to workspace billing", async ({ page }) => {
+        await page.goto(
+          "/billing/fail?workspaceId=1&code=CARD_DECLINED&message=%EC%B9%B4%EB%93%9C%EA%B0%80%20%EA%B1%B0%EC%A0%88%EB%90%90%EC%8A%B5%EB%8B%88%EB%8B%A4",
+        );
+
+        await expect(page.getByText("카드가 거절됐습니다")).toBeVisible();
+        await expect(page.getByText("오류 코드: CARD_DECLINED")).toBeVisible();
+        await page.getByRole("button", { name: "다시 시도" }).click();
+        await expect(page).toHaveURL(/\/workspaces\/1\/billing/);
+      });
+
+      test("Then a missing workspace id falls back to the workspace entry point", async ({
+        page,
+      }) => {
+        await page.goto(
+          "/billing/fail?code=USER_CANCEL&message=%EA%B2%B0%EC%A0%9C%EA%B0%80%20%EC%B7%A8%EC%86%8C%EB%90%90%EC%8A%B5%EB%8B%88%EB%8B%A4",
+        );
+
+        await expect(page.getByText("결제가 취소됐습니다")).toBeVisible();
+        await expect(page.getByText("오류 코드: USER_CANCEL")).toBeVisible();
+        await page.getByRole("button", { name: "다시 시도" }).click();
+        await expect(page).toHaveURL(/\/workspaces\/1\/dashboard/);
+        await expect(page.getByRole("heading", { name: "대시보드", exact: true })).toBeVisible();
+      });
+    });
+  });
+});

--- a/frontend/e2e/consultation.spec.ts
+++ b/frontend/e2e/consultation.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 
+import { captureScreen } from "./support/app-mocks";
 import { installAuth } from "./support/generated-api-auth";
 import { installConsultationApiMocks } from "./support/generated-api-mocks";
 import { installMockStomp } from "./support/mock-stomp";
@@ -27,9 +28,12 @@ test.describe("Consultation screen", () => {
         await expect(page.getByText("generated 상담 메시지")).toBeVisible();
         await expect(page.getByText("상담 종료")).toBeEnabled();
         await page.getByText("상담 종료").click();
+        await page.getByRole("button", { name: /후속 연락 필요/ }).click();
+        await page.getByLabel("종료 사유 또는 내부 메모").fill("배송사 확인 후 연락");
+        await page.getByRole("button", { name: "종료 확인" }).click();
         await expect(page.getByText("상담이 종료되었습니다.")).toBeVisible();
         expect(seen).toContain("GET /workspaces/1/consultation/queue");
-        expect(seen).toContain("GET /consultation/sessions/601/messages");
+        expect(seen).toContain("GET /consultation/sessions/601/messages?page=0&size=50");
         expect(seen).toContain("PATCH /consultation/sessions/601/status");
       });
     });
@@ -45,6 +49,103 @@ test.describe("Consultation screen", () => {
         await page.getByRole("button", { name: "메시지 전송" }).click();
 
         await expect(page.getByText("상담사 확인했습니다")).toBeVisible();
+      });
+    });
+
+    test.describe("When an operator opens the matched workflow", () => {
+      test("Then the workflow preview and domain pack detail route are connected", async ({
+        page,
+      }, testInfo) => {
+        await page.goto("/workspaces/1/consultation");
+        await page.getByText("김민지").click();
+
+        await expect(page.getByTestId("matched-workflow-bar")).toBeVisible();
+        await expect(page.getByTestId("matched-workflow-bar-title")).toContainText("환불 처리");
+        await page.getByTestId("matched-workflow-bar").hover();
+        await expect(page.getByTestId("matched-workflow-bar-basis")).toContainText(
+          "환불 조건 확인",
+        );
+        await captureScreen(page, testInfo, "consultation-matched-workflow");
+
+        await page.getByTestId("matched-workflow-bar-open").click();
+        await expect(page).toHaveURL(
+          /\/workspaces\/1\/domain-packs\/1\/workflows\/401\?versionId=1/,
+        );
+        await expect(page.getByText("환불 workflow")).toBeVisible();
+        expect(seen).toContain("GET /consultation/sessions/601/matched-workflow");
+        expect(seen).toContain("GET /workspaces/1/domain-packs/1/versions/1/workflows/401");
+      });
+    });
+
+    test.describe("When an operator narrows and sorts the queue", () => {
+      test("Then the visible sessions follow the selected controls", async ({ page }, testInfo) => {
+        await page.goto("/workspaces/1/consultation");
+
+        const queueItems = page.locator("aside").locator('div[role="button"]');
+        await expect(page.getByText("연결 요청 2건 · 미배정 2건 · 진행 4건")).toBeVisible();
+        await expect(queueItems.first()).toContainText("김민지");
+
+        await page.getByLabel("상담 큐 정렬").getByRole("button", { name: "최신순" }).click();
+        await expect(
+          page.getByLabel("상담 큐 정렬").getByRole("button", { name: "최신순" }),
+        ).toHaveAttribute("aria-pressed", "true");
+        await expect(queueItems.first()).toContainText("최하늘");
+
+        await page
+          .getByLabel("상담 큐 필터")
+          .getByRole("button", { name: /상담사 연결 요청/ })
+          .click();
+        await expect(queueItems).toHaveCount(2);
+        await expect(page.getByText("김민지")).toBeVisible();
+        await expect(page.getByText("박준호")).toBeVisible();
+        await expect(page.getByText("이서연")).not.toBeVisible();
+
+        await page.getByLabel("상담 큐 검색").fill("카드");
+        await expect(queueItems).toHaveCount(1);
+        await expect(queueItems.first()).toContainText("박준호");
+        await expect(page.getByText("현재 1건 표시")).toBeVisible();
+        await captureScreen(page, testInfo, "consultation-queue-filter-search");
+
+        await page.getByLabel("상담 큐 필터").getByRole("button", { name: /내 상담/ }).click();
+        await expect(page.getByText("검색 조건에 맞는 상담이 없습니다")).toBeVisible();
+        await expect(page.getByText("현재 0건 표시")).toBeVisible();
+      });
+    });
+
+    test.describe("When an operator loads history and writes an internal note", () => {
+      test("Then older messages render and the note is sent over the counselor socket", async ({
+        page,
+      }) => {
+        await page.goto("/workspaces/1/consultation");
+        await page.getByText("김민지").click();
+
+        await expect(page.getByText("generated 상담 메시지")).toBeVisible();
+        await page.getByRole("button", { name: "이전 메시지 불러오기" }).click();
+        await expect(page.getByText("상담 세션이 생성되었습니다.")).toBeVisible();
+
+        await page.getByTitle("내부 메모로 남기기").click();
+        await page
+          .getByPlaceholder("내부 메모로 타임라인에 남길 내용을 입력하세요...")
+          .fill("배송사 확인 필요 내부 메모");
+        await page.getByRole("button", { name: "내부 메모 남기기" }).click();
+
+        await expect(page.getByText("배송사 확인 필요 내부 메모")).toBeVisible();
+        expect(seen).toContain("GET /consultation/sessions/601/messages?page=1&size=50");
+
+        const frames = await page.evaluate(() => {
+          const state = window as Window & { __e2eWsFrames?: string[] };
+          return state.__e2eWsFrames ?? [];
+        });
+        expect(
+          frames.some(
+            (frame) =>
+              frame.includes("SEND") &&
+              frame.includes("/app/chat.counselor.send") &&
+              frame.includes('"sessionId":601') &&
+              frame.includes('"isNote":true') &&
+              frame.includes("배송사 확인 필요 내부 메모"),
+          ),
+        ).toBe(true);
       });
     });
   });

--- a/frontend/e2e/demo.spec.ts
+++ b/frontend/e2e/demo.spec.ts
@@ -100,9 +100,7 @@ test.describe("Demo company picker", () => {
           page.getByTestId("chat-conversation-screen"),
         ).toBeVisible();
         await expect(page.getByTestId("chat-entry-screen")).toHaveCount(0);
-        await expect(
-          page.getByText("안녕하세요, 김민지님. 무엇을 도와드릴까요?"),
-        ).toBeVisible();
+        await expect(page.getByText("아직 메시지가 없습니다. 첫 메시지를 보내보세요!")).toBeVisible();
 
         await page.getByLabel("메시지 입력").fill("환불 문의입니다");
         await page.getByRole("button", { name: "메시지 보내기" }).click();
@@ -119,10 +117,10 @@ test.describe("Demo company picker", () => {
         page,
       }) => {
         await page.goto("/demo");
-        await page.getByTestId("demo-company-card-2").click();
+        await page.getByTestId("demo-company-card-3").click();
 
         await expect(page.getByTestId("demo-company-info")).toContainText(
-          "카드 이용내역 조회 상담",
+          "인디고발리 숙소 예약",
         );
         await expect(page.getByTestId("demo-start-chat")).toBeDisabled();
       });

--- a/frontend/e2e/domain-pack-core.spec.ts
+++ b/frontend/e2e/domain-pack-core.spec.ts
@@ -1,0 +1,344 @@
+import { expect, test } from "@playwright/test";
+
+import { installAuth } from "./support/generated-api-auth";
+import { captureScreen, installAppApiMocks } from "./support/app-mocks";
+
+test.describe("Domain pack core read flows", () => {
+  let seen: string[];
+
+  test.beforeEach(async ({ page }) => {
+    seen = [];
+    await installAuth(page);
+    await installAppApiMocks(page, seen);
+  });
+
+  test.describe("Given generated domain packs in a workspace", () => {
+    test.describe("When an operator filters the domain pack list", () => {
+      test("Then operating and idle sections stay navigable", async ({ page }, testInfo) => {
+        await page.goto("/workspaces/1/domain-packs");
+        await expect(page.getByRole("heading", { name: "도메인팩 관리" })).toBeVisible();
+        await expect(page.getByText("Generated API Pack")).toBeVisible();
+
+        await page.getByRole("button", { name: "비운영 1" }).click();
+        await expect(page.getByText("검토 대기 팩")).toBeVisible();
+        await expect(page.getByText("Generated API Pack")).toBeHidden();
+
+        await page.getByRole("button", { name: "전체 2" }).click();
+        await expect(page.getByText("Generated API Pack")).toBeVisible();
+        await captureScreen(page, testInfo, "domain-pack-list");
+
+        await page.getByRole("link", { name: /Generated API Pack/ }).click();
+        await expect(page).toHaveURL(/\/workspaces\/1\/domain-packs\/1\?versionId=1/);
+      });
+    });
+
+    test.describe("When they open the pack summary", () => {
+      test("Then summary metrics and component drill-down links are visible", async ({
+        page,
+      }, testInfo) => {
+        await page.goto("/workspaces/1/domain-packs/1");
+
+        await expect(page.getByText("도메인팩 정보")).toBeVisible();
+        await expect(page.getByText("환불 자동화 팩")).toBeVisible();
+        await expect(page.getByText("매핑률")).toBeVisible();
+        await expect(page.getByRole("button", { name: "확인 항목 상세 보기" })).toBeVisible();
+        await captureScreen(page, testInfo, "domain-pack-summary");
+
+        await page.getByRole("button", { name: "확인 항목 상세 보기" }).click();
+        await expect(page).toHaveURL(/\/workspaces\/1\/domain-packs\/1\/slots\?versionId=1/);
+        await expect(seen).toContain("GET /workspaces/1/domain-packs/1/versions/1/slots");
+      });
+    });
+
+    test.describe("When they open legacy version URLs", () => {
+      test("Then saved version links redirect to the current domain pack routes", async ({
+        page,
+      }) => {
+        await page.goto("/workspaces/1/domain-packs/1/versions/1");
+
+        await expect(page).toHaveURL(/\/workspaces\/1\/domain-packs\/1\?versionId=1/);
+        await expect(page.getByText("도메인팩 정보")).toBeVisible();
+
+        await page.goto("/workspaces/1/domain-packs/1/versions/1/workflows/401?source=legacy");
+
+        await expect(page).toHaveURL(
+          /\/workspaces\/1\/domain-packs\/1\/workflows\/401\?source=legacy&versionId=1/,
+        );
+        await expect(page.getByText("환불 처리")).toBeVisible();
+        await expect(page.getByText("주문번호를 확인하고 환불 정책에 따라 안내")).toBeVisible();
+      });
+    });
+
+    test.describe("When they deploy an operating candidate version", () => {
+      test("Then the deploy confirmation calls the version deploy endpoint", async ({ page }) => {
+        await page.goto("/workspaces/1/domain-packs/1?versionId=2");
+
+        await expect(
+          page.getByRole("button", {
+            name: /v2[\s\S]*상담사 연결 조건을 보강한 운영 가능 버전/,
+          }),
+        ).toBeVisible();
+        await expect(page.getByText("상담사 연결 정책")).toBeVisible();
+        await expect(page.getByText("상담사 연결 검토 워크플로우")).toBeVisible();
+        await page.getByRole("button", { name: "배포", exact: true }).click();
+        await expect(page.getByRole("alertdialog")).toContainText("v2 버전을 배포할까요?");
+        await page.getByRole("button", { name: "배포하기" }).click();
+
+        await expect(page.getByText("도메인팩 버전이 배포되었습니다.")).toBeVisible();
+        expect(seen).toContain("POST /workspaces/1/domain-packs/1/versions/2/deploy");
+      });
+    });
+
+    test.describe("When they apply and discard a draft version", () => {
+      test("Then the draft action dialogs send the selected version operations", async ({
+        page,
+      }, testInfo) => {
+        await page.goto("/workspaces/1/domain-packs/1?versionId=3");
+
+        await expect(
+          page.getByRole("button", {
+            name: /v3[\s\S]*검토 중[\s\S]*고액 환불 검토 흐름을 정리한 수정 검토본/,
+          }),
+        ).toBeVisible();
+        await expect(page.getByText("고액 환불 정책")).toBeVisible();
+        await expect(page.getByText("고액 환불 검토 워크플로우")).toBeVisible();
+        await captureScreen(page, testInfo, "domain-pack-draft-actions");
+
+        await page.getByRole("button", { name: "적용", exact: true }).click();
+        await expect(page.getByRole("alertdialog")).toContainText(
+          "검토 중인 v3 수정버전을 적용할까요?",
+        );
+        await page.getByLabel("변경사항 정리").fill("검토본 적용 메모");
+        await page.getByRole("button", { name: "적용하기" }).click();
+        await expect(page.getByText("초안 수정버전이 적용되었습니다.")).toBeVisible();
+        expect(seen).toContain("POST /workspaces/1/domain-packs/1/versions/3/activate");
+
+        await page.goto("/workspaces/1/domain-packs/1?versionId=3");
+        await page.getByRole("button", { name: "삭제", exact: true }).click();
+        await expect(page.getByRole("alertdialog")).toContainText(
+          "검토 중인 v3 버전을 삭제할까요?",
+        );
+        await page.getByRole("button", { name: "삭제하기" }).click();
+
+        await expect(page.getByText("검토 중인 버전이 삭제되었습니다.")).toBeVisible();
+        await expect(page).toHaveURL(/\/workspaces\/1\/domain-packs\/1\?versionId=1/);
+        expect(seen).toContain("DELETE /workspaces/1/domain-packs/1/versions/3/draft");
+      });
+    });
+
+    test.describe("When they inspect an intent", () => {
+      test("Then intent evidence and matched workflow context render", async ({ page }) => {
+        await page.goto("/workspaces/1/domain-packs/1/intents?versionId=1");
+        await page.getByRole("button", { name: /INT_REFUND/ }).click();
+
+        await expect(page).toHaveURL(
+          /\/workspaces\/1\/domain-packs\/1\/intents\/501\?versionId=1/,
+        );
+        await expect(
+          page.getByLabel("상담 유형 상세").getByText("고객이 결제 취소나 환불 가능 여부"),
+        ).toBeVisible();
+        await expect(page.getByRole("heading", { name: "관련 키워드" })).toBeVisible();
+        await expect(page.getByText("#12")).toBeVisible();
+        await expect(page.getByText("36건")).toBeVisible();
+        await expect(page.getByText("취소", { exact: true })).toBeVisible();
+        await expect(page.getByRole("heading", { name: "대표 문장" })).toBeVisible();
+        await expect(page.getByText("결제한 상품을 환불하고 싶어요.")).toBeVisible();
+        await expect(page.getByText("환불 처리")).toBeVisible();
+        expect(seen).toContain("GET /workspaces/1/domain-packs/1/versions/1/intents/501");
+      });
+    });
+
+    test.describe("When they edit a policy from the detail panel", () => {
+      test("Then invalid JSON is blocked before the policy update request", async ({ page }) => {
+        await page.goto("/workspaces/1/domain-packs/1/policies?versionId=1");
+        await page.getByRole("button", { name: /POL_REFUND/ }).click();
+        await expect(page.getByLabel("응대 기준 상세")).toContainText("환불 정책");
+
+        await page.getByRole("button", { name: /POL_REFUND 응대 기준 수정/ }).click();
+        await expect(page.getByLabel("응대 기준 수정")).toBeVisible();
+
+        await page.getByLabel("조건 JSON").fill("[]");
+        await page.getByRole("button", { name: "저장" }).click();
+        await expect(page.getByText("적용 조건 JSON은 객체여야 합니다.")).toBeVisible();
+        expect(
+          seen.some(
+            (entry) => entry === "PATCH /workspaces/1/domain-packs/1/versions/1/policies/101",
+          ),
+        ).toBe(false);
+      });
+
+      test("Then a valid save updates the policy detail", async ({ page }, testInfo) => {
+        await page.goto("/workspaces/1/domain-packs/1/policies?versionId=1");
+        await page.getByRole("button", { name: /POL_REFUND/ }).click();
+
+        await page.getByRole("button", { name: /POL_REFUND 응대 기준 수정/ }).click();
+        await expect(page.getByLabel("응대 기준 수정")).toBeVisible();
+        await captureScreen(page, testInfo, "policy-edit-panel");
+
+        await page.getByLabel("이름 *").fill("고액 환불 정책");
+        await page.getByLabel("설명").fill("고액 환불은 검토 후 안내합니다.");
+        await page
+          .getByLabel("조건 JSON")
+          .fill(JSON.stringify({ amount: { gte: 100000 } }, null, 2));
+        await page
+          .getByLabel("액션 JSON")
+          .fill(JSON.stringify({ type: "MANUAL_REVIEW" }, null, 2));
+        await page
+          .getByLabel("근거 JSON")
+          .fill(JSON.stringify([{ segmentId: "seg-99" }], null, 2));
+        await page.getByLabel("메타 JSON").fill(JSON.stringify({ source: "e2e" }, null, 2));
+        const updateRequest = page.waitForRequest(
+          (request) =>
+            request.method() === "PATCH" &&
+            request.url().includes("/workspaces/1/domain-packs/1/versions/1/policies/101"),
+        );
+        await page.getByRole("button", { name: "저장" }).click();
+        const requestBody = (await updateRequest).postDataJSON();
+
+        expect(requestBody).toEqual(
+          expect.objectContaining({
+            name: "고액 환불 정책",
+            description: "고액 환불은 검토 후 안내합니다.",
+            conditionJson: JSON.stringify({ amount: { gte: 100000 } }, null, 2),
+            actionJson: JSON.stringify({ type: "MANUAL_REVIEW" }, null, 2),
+            evidenceJson: JSON.stringify([{ segmentId: "seg-99" }], null, 2),
+            metaJson: JSON.stringify({ source: "e2e" }, null, 2),
+          }),
+        );
+
+        await expect(page.getByText("응대 기준이 수정되었습니다.")).toBeVisible();
+        await expect(page.getByLabel("응대 기준 상세")).toContainText("고액 환불 정책");
+        expect(seen).toContain("PATCH /workspaces/1/domain-packs/1/versions/1/policies/101");
+      });
+
+      test("Then the status switch updates request body and detail state", async ({ page }) => {
+        await page.goto("/workspaces/1/domain-packs/1/policies?versionId=1");
+        await page.getByRole("button", { name: /POL_REFUND/ }).click();
+
+        await page.getByRole("button", { name: /POL_REFUND 응대 기준 수정/ }).click();
+        const statusSwitch = page.getByRole("switch", { name: "응대 기준 상태" });
+        await expect(statusSwitch).toBeChecked();
+
+        const statusRequest = page.waitForRequest(
+          (request) =>
+            request.method() === "PATCH" &&
+            request
+              .url()
+              .includes("/workspaces/1/domain-packs/1/versions/1/policies/101/status"),
+        );
+        await statusSwitch.click();
+        const requestBody = (await statusRequest).postDataJSON();
+
+        expect(requestBody).toEqual({ status: "INACTIVE" });
+        await expect(statusSwitch).not.toBeChecked();
+        await page.getByRole("button", { name: "취소" }).click();
+        await expect(page.getByLabel("응대 기준 상세")).toContainText("사용 안 함");
+        expect(seen).toContain(
+          "PATCH /workspaces/1/domain-packs/1/versions/1/policies/101/status",
+        );
+      });
+    });
+
+    test.describe("When they edit a risk from the detail panel", () => {
+      test("Then invalid JSON is blocked before the risk update request", async ({ page }) => {
+        await page.goto("/workspaces/1/domain-packs/1/risks?versionId=1");
+        await page.getByRole("button", { name: /RISK_FRAUD/ }).click();
+        await expect(page.getByLabel("주의 사항 상세")).toContainText("부정 환불 위험");
+
+        await page.getByRole("button", { name: /RISK_FRAUD 주의 사항 수정/ }).click();
+        await expect(page.getByLabel("주의 사항 수정")).toBeVisible();
+
+        await page.getByLabel("트리거 조건 JSON").fill("[]");
+        await page.getByRole("button", { name: "저장" }).click();
+        await expect(page.getByText("감지 조건 JSON은 객체여야 합니다.")).toBeVisible();
+        expect(
+          seen.some(
+            (entry) => entry === "PATCH /workspaces/1/domain-packs/1/versions/1/risks/201",
+          ),
+        ).toBe(false);
+      });
+
+      test("Then a valid save updates the risk detail", async ({ page }, testInfo) => {
+        await page.goto("/workspaces/1/domain-packs/1/risks?versionId=1");
+        await page.getByRole("button", { name: /RISK_FRAUD/ }).click();
+
+        await page.getByRole("button", { name: /RISK_FRAUD 주의 사항 수정/ }).click();
+        await expect(page.getByLabel("주의 사항 수정")).toBeVisible();
+        await captureScreen(page, testInfo, "risk-edit-panel");
+
+        await page.getByLabel("이름 *").fill("고액 환불 위험");
+        await page.getByLabel("설명").fill("고액 환불은 상담사 검토로 전환합니다.");
+        await page
+          .getByLabel("트리거 조건 JSON")
+          .fill(JSON.stringify({ amount: { gte: 100000 } }, null, 2));
+        await page
+          .getByLabel("처리 액션 JSON")
+          .fill(JSON.stringify({ type: "MANUAL_REVIEW" }, null, 2));
+        await page
+          .getByLabel("근거 JSON")
+          .fill(JSON.stringify([{ segmentId: "risk-seg-99" }], null, 2));
+        await page.getByLabel("메타 JSON").fill(JSON.stringify({ source: "e2e" }, null, 2));
+        const updateRequest = page.waitForRequest(
+          (request) =>
+            request.method() === "PATCH" &&
+            request.url().includes("/workspaces/1/domain-packs/1/versions/1/risks/201"),
+        );
+        await page.getByRole("button", { name: "저장" }).click();
+        const requestBody = (await updateRequest).postDataJSON();
+
+        expect(requestBody).toEqual(
+          expect.objectContaining({
+            name: "고액 환불 위험",
+            description: "고액 환불은 상담사 검토로 전환합니다.",
+            triggerConditionJson: JSON.stringify({ amount: { gte: 100000 } }, null, 2),
+            handlingActionJson: JSON.stringify({ type: "MANUAL_REVIEW" }, null, 2),
+            evidenceJson: JSON.stringify([{ segmentId: "risk-seg-99" }], null, 2),
+            metaJson: JSON.stringify({ source: "e2e" }, null, 2),
+          }),
+        );
+
+        await expect(page.getByText("주의 사항이 수정되었습니다.")).toBeVisible();
+        await expect(page.getByLabel("주의 사항 상세")).toContainText("고액 환불 위험");
+        expect(seen).toContain("PATCH /workspaces/1/domain-packs/1/versions/1/risks/201");
+      });
+
+      test("Then the status switch updates request body and detail state", async ({ page }) => {
+        await page.goto("/workspaces/1/domain-packs/1/risks?versionId=1");
+        await page.getByRole("button", { name: /RISK_FRAUD/ }).click();
+
+        await page.getByRole("button", { name: /RISK_FRAUD 주의 사항 수정/ }).click();
+        const statusSwitch = page.getByRole("switch", { name: "주의 사항 상태" });
+        await expect(statusSwitch).toBeChecked();
+
+        const statusRequest = page.waitForRequest(
+          (request) =>
+            request.method() === "PATCH" &&
+            request.url().includes("/workspaces/1/domain-packs/1/versions/1/risks/201/status"),
+        );
+        await statusSwitch.click();
+        const requestBody = (await statusRequest).postDataJSON();
+
+        expect(requestBody).toEqual({ status: "INACTIVE" });
+        await expect(statusSwitch).not.toBeChecked();
+        await page.getByRole("button", { name: "취소" }).click();
+        await expect(page.getByLabel("주의 사항 상세")).toContainText("사용 안 함");
+        expect(seen).toContain(
+          "PATCH /workspaces/1/domain-packs/1/versions/1/risks/201/status",
+        );
+      });
+    });
+
+    test.describe("When they open the workflow graph", () => {
+      test("Then the graph view renders the generated state labels", async ({ page }, testInfo) => {
+        await page.goto("/workspaces/1/domain-packs/1/workflows/401/graph?versionId=1");
+
+        await expect(page.getByText("환불 처리")).toBeVisible();
+        await expect(page.getByText("문의 접수")).toBeVisible();
+        await expect(page.getByText("환불 조건 확인")).toBeVisible();
+        await expect(page.getByText("환불 안내 완료")).toBeVisible();
+        await captureScreen(page, testInfo, "workflow-graph");
+        expect(seen).toContain("GET /workspaces/1/domain-packs/1/versions/1/workflows/401");
+      });
+    });
+  });
+});

--- a/frontend/e2e/domain-pack-read.spec.ts
+++ b/frontend/e2e/domain-pack-read.spec.ts
@@ -62,7 +62,7 @@ test.describe("Domain pack generated read screens", () => {
           /\/workspaces\/1\/domain-packs\/1\/slots\/301\?versionId=1/,
         );
         await expect(page.getByText("배송지 주소")).toBeVisible();
-        await expect(page.getByText("NO")).toBeVisible();
+        await expect(page.getByText("아니오")).toBeVisible();
         expect(seen).toContain("GET /workspaces/1/domain-packs/1/versions/1/slots");
         expect(seen).toContain("GET /workspaces/1/domain-packs/1/versions/1/slots/301");
       });

--- a/frontend/e2e/live/README.md
+++ b/frontend/e2e/live/README.md
@@ -8,7 +8,7 @@
 | --- | --- | --- |
 | 대상 | 로컬 preview 서버 + 모든 API mock(`page.route`) | 배포된 운영 백엔드(실제 호출) |
 | 검증 범위 | UI 흐름 + 프론트 로직 | 운영 환경이 실제로 살아 있고 핵심 흐름이 동작하는지 |
-| 실행 | CI 포함 자동 실행 | **로컬 수동 전용(CI 금지)** |
+| 실행 | CI 포함 자동 실행 | **로컬 수동 또는 GitHub Actions 수동 실행** |
 | 데이터 | 메모리상 mock | **운영 실데이터에 영향** (오염 방지가 최우선) |
 
 라이브 스모크는 mock을 일절 쓰지 않는다. 배포 직후 운영 환경의 핵심 경로(로그인, 워크스페이스, 도메인팩 조회 등)가 실제로 동작하는지 확인하는 용도다.
@@ -22,7 +22,9 @@
 
 ## 실행법
 
-### 1. 환경변수 파일 작성
+### 로컬 수동 실행
+
+#### 1. 환경변수 파일 작성
 
 예시 파일을 복사해 실제 값을 채운다. `.env.e2e.local`은 gitignore되며 커밋되지 않는다.
 
@@ -40,7 +42,7 @@ cp .env.e2e.example .env.e2e.local
 | `E2E_PASSWORD` | 전용 테스트 계정 비밀번호. |
 | `E2E_ALLOW_POLLUTING` | @pollutes tier 활성화 여부. 기본 `false`. (아래 참고) |
 
-### 2. 기본 실행 (정리 가능/read-only tier)
+#### 2. 기본 실행 (정리 가능/read-only tier)
 
 ```bash
 pnpm e2e:live
@@ -74,6 +76,22 @@ E2E_ALLOW_POLLUTING=true pnpm e2e:live:pollutes
 - 운영 관리 도구에서 `e2e-` prefix로 검색해 해당 계정/세션을 정리한다.
 - 워크스페이스 자동 정리가 누락된 경우 `e2e/live/.cleanup/leftovers.log`에 잔존 리소스가 기록되니, 이 로그를 확인해 수동 정리한다.
 
-## CI 금지 / 로컬 수동 전용
+## GitHub Actions 수동 실행
 
-라이브 스모크는 운영 백엔드를 실제로 호출하므로 **CI에서 실행할 수 없다.** `CI` 환경변수가 설정되어 있으면 globalSetup이 실행을 차단한다. 반드시 로컬에서 수동으로만 실행한다.
+라이브 스모크는 운영 백엔드를 실제로 호출하므로 pull request/push 자동 CI에서는 실행하지 않는다. GitHub Actions에서는 `Live E2E` workflow를 `workflow_dispatch`로 직접 실행할 때만 허용된다.
+
+필수 repository secrets:
+
+| Secret | 설명 |
+| --- | --- |
+| `LIVE_E2E_EMAIL` | 라이브 스모크 전용 테스트 계정 이메일 |
+| `LIVE_E2E_PASSWORD` | 라이브 스모크 전용 테스트 계정 비밀번호 |
+
+수동 실행 입력:
+
+| Input | 설명 |
+| --- | --- |
+| `base_url` | 대상 배포 URL. 기본값은 `https://app.ajou-cstone.com`. |
+| `confirm_prod` | 운영 host 대상일 때 오실행 방지 확인값. 운영이면 `app.ajou-cstone.com`. |
+
+수동 workflow는 기본 tier와 `@pollutes` tier를 항상 함께 실행한다. 운영 데이터가 잔존할 수 있으므로 실행 후 artifact의 `frontend/e2e/live/.cleanup/leftovers.log`가 있으면 운영자가 수동 정리한다.

--- a/frontend/e2e/live/global-setup.ts
+++ b/frontend/e2e/live/global-setup.ts
@@ -12,6 +12,14 @@ const LIVE_ROOT = dirname(fileURLToPath(import.meta.url));
 const AUTH_DIR = resolve(LIVE_ROOT, ".auth");
 export const STORAGE_STATE_PATH = resolve(AUTH_DIR, "state.json");
 
+function isExplicitGitHubActionsRun(): boolean {
+  return (
+    process.env.GITHUB_ACTIONS === "true" &&
+    process.env.GITHUB_EVENT_NAME === "workflow_dispatch" &&
+    process.env.E2E_ALLOW_GITHUB_ACTIONS === "true"
+  );
+}
+
 // Playwright storageState 형식. origin별 localStorage 항목으로 토큰/유저를 주입한다.
 interface StorageStateOrigin {
   origin: string;
@@ -24,10 +32,11 @@ interface StorageState {
 }
 
 async function globalSetup(): Promise<void> {
-  // 라이브 스모크는 운영 백엔드를 실제로 호출하므로 CI 자동 실행을 차단하고 로컬 수동 전용으로 둔다.
-  if (process.env.CI) {
+  // 라이브 스모크는 운영 백엔드를 실제로 호출하므로 자동 CI 실행을 차단한다.
+  // GitHub Actions에서는 workflow_dispatch + 명시 승인 env가 있는 수동 실행만 허용한다.
+  if (process.env.CI && !isExplicitGitHubActionsRun()) {
     throw new Error(
-      "[live-e2e] 라이브 스모크는 CI에서 실행할 수 없습니다(로컬 수동 전용). CI 환경변수를 해제하세요.",
+      "[live-e2e] 라이브 스모크는 자동 CI에서 실행할 수 없습니다. 로컬에서 수동 실행하거나 Live E2E workflow_dispatch를 사용하세요.",
     );
   }
 

--- a/frontend/e2e/navigation.spec.ts
+++ b/frontend/e2e/navigation.spec.ts
@@ -1,0 +1,144 @@
+import { expect, test } from "@playwright/test";
+
+import { installAuth } from "./support/generated-api-auth";
+import { captureScreen, installAdminApiMocks, installAppApiMocks } from "./support/app-mocks";
+
+test.describe("Application navigation boundaries", () => {
+  test.describe("Given no authenticated session", () => {
+    test("When an anonymous visitor opens a private workspace URL, Then they are sent to login", async ({
+      page,
+    }) => {
+      const seen: string[] = [];
+      await page.route("**/api/v1/**", async (route) => {
+        const request = route.request();
+        const url = new URL(request.url());
+        seen.push(`${request.method()} ${url.pathname.replace(/^\/api\/v1/, "")}`);
+        await route.fulfill({
+          status: 500,
+          contentType: "application/json",
+          body: JSON.stringify({ code: "E2E_UNEXPECTED_API", message: url.pathname }),
+        });
+      });
+
+      await page.goto("/workspaces/1/dashboard");
+
+      await expect(page).toHaveURL(/\/login$/);
+      await expect(page.getByRole("button", { name: "시스템 로그인" })).toBeVisible();
+      expect(seen).toEqual(["POST /auth/refresh"]);
+    });
+
+    test("When a stale refresh token is rejected, Then stored auth state is cleared", async ({
+      page,
+    }) => {
+      const seen: string[] = [];
+      await page.addInitScript(() => {
+        window.localStorage.setItem("refreshToken", "expired-refresh-token");
+        window.localStorage.setItem("user", JSON.stringify({ name: "만료 사용자" }));
+      });
+      await page.route("**/api/v1/auth/refresh", async (route) => {
+        seen.push("POST /auth/refresh");
+        await route.fulfill({
+          status: 401,
+          contentType: "application/json",
+          body: JSON.stringify({ code: "TOKEN_EXPIRED", message: "expired" }),
+        });
+      });
+
+      await page.goto("/workspaces/1/dashboard");
+
+      await expect(page).toHaveURL(/\/login$/);
+      await expect
+        .poll(() =>
+          page.evaluate(() => ({
+            accessToken: window.localStorage.getItem("accessToken"),
+            refreshToken: window.localStorage.getItem("refreshToken"),
+            user: window.localStorage.getItem("user"),
+          })),
+        )
+        .toEqual({ accessToken: null, refreshToken: null, user: null });
+      expect(seen).toEqual(["POST /auth/refresh"]);
+    });
+  });
+
+  test.describe("Given an authenticated operator", () => {
+    let seen: string[];
+
+    test.beforeEach(async ({ page }) => {
+      seen = [];
+      await installAuth(page);
+      await installAppApiMocks(page, seen);
+    });
+
+    test("When they enter workspace shortcut URLs, Then redirects land on the canonical screens", async ({
+      page,
+    }) => {
+      await page.goto("/");
+      await expect(page).toHaveURL(/\/workspaces\/1\/dashboard$/);
+      await expect(page.getByRole("heading", { name: "대시보드", exact: true })).toBeVisible();
+
+      await page.goto("/workspaces/1");
+      await expect(page).toHaveURL(/\/workspaces\/1\/dashboard$/);
+
+      await page.goto("/workspaces/1/pipeline");
+      await expect(page).toHaveURL(/\/workspaces\/1\/upload$/);
+      await expect(page.getByRole("heading", { name: "상담 로그 업로드" })).toBeVisible();
+
+      await page.goto("/upload");
+      await expect(page).toHaveURL(/\/workspaces\/1\/dashboard$/);
+
+      await page.goto("/consultation/601");
+      await expect(page).toHaveURL(/\/workspaces\/1\/dashboard$/);
+      expect(seen).toContain("GET /workspaces");
+      expect(seen).toContain("GET /workspaces/1");
+    });
+
+    test("When they open an admin URL without SUPER_ADMIN role, Then they return to workspace home", async ({
+      page,
+    }) => {
+      await page.goto("/admin/customers");
+
+      await expect(page).toHaveURL(/\/workspaces\/1\/dashboard$/);
+      await expect(page.getByRole("heading", { name: "대시보드", exact: true })).toBeVisible();
+    });
+
+    test("When they use the 404 page actions, Then previous and home navigation remain usable", async ({
+      page,
+    }, testInfo) => {
+      await page.goto("/demo");
+      await page.goto("/missing-route");
+
+      await expect(page.getByRole("heading", { name: "404" })).toBeVisible();
+      await expect(page.getByText("요청하신 페이지를 찾을 수 없습니다.")).toBeVisible();
+      await captureScreen(page, testInfo, "not-found-actions");
+
+      await page.getByRole("button", { name: "이전 페이지" }).click();
+      await expect(page).toHaveURL(/\/demo$/);
+
+      await page.goto("/another-missing-route");
+      await page.getByRole("button", { name: "홈으로 돌아가기" }).click();
+      await expect(page).toHaveURL(/\/workspaces\/1\/dashboard$/);
+      await expect(page.getByRole("heading", { name: "대시보드", exact: true })).toBeVisible();
+    });
+  });
+
+  test.describe("Given a SUPER_ADMIN session", () => {
+    test("When they open the admin root, Then the default console section is selected", async ({
+      page,
+    }) => {
+      const seen: string[] = [];
+      await installAuth(page, {
+        role: "SUPER_ADMIN",
+        name: "관리자",
+        email: "admin@example.com",
+      });
+      await installAdminApiMocks(page, seen);
+
+      await page.goto("/admin");
+
+      await expect(page).toHaveURL(/\/admin\/super-admins$/);
+      await expect(page.getByRole("heading", { name: "관리자 계정" })).toBeVisible();
+      await expect(page.getByRole("button", { name: "SUPER_ADMIN 생성" })).toBeVisible();
+      expect(seen).toEqual([]);
+    });
+  });
+});

--- a/frontend/e2e/support/app-mocks.ts
+++ b/frontend/e2e/support/app-mocks.ts
@@ -1,0 +1,1442 @@
+import { expect, type Page, type Route, type TestInfo } from "@playwright/test";
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+
+const WORKSPACE_ID = 1;
+const PACK_ID = 1;
+const VERSION_ID = 1;
+const WORKFLOW_ID = 401;
+const INTENT_ID = 501;
+const DATASET_ID = 77;
+const PIPELINE_JOB_ID = 900;
+const SIMULATION_SESSION_ID = 8801;
+
+export const e2eIds = {
+  workspaceId: WORKSPACE_ID,
+  packId: PACK_ID,
+  versionId: VERSION_ID,
+  workflowId: WORKFLOW_ID,
+  intentId: INTENT_ID,
+  datasetId: DATASET_ID,
+  pipelineJobId: PIPELINE_JOB_ID,
+  simulationSessionId: SIMULATION_SESSION_ID,
+} as const;
+
+type RouteHandler = (
+  route: Route,
+  method: string,
+  path: string,
+  url: URL,
+) => Promise<boolean>;
+
+const now = "2026-06-04T09:00:00+09:00";
+
+const workspace = {
+  id: WORKSPACE_ID,
+  workspaceKey: "qa-workspace",
+  name: "QA Workspace",
+  description: "E2E workspace",
+  status: "ACTIVE",
+  myRole: "OWNER",
+  createdAt: "2026-05-01T00:00:00+09:00",
+  updatedAt: now,
+};
+
+const secondaryWorkspace = {
+  id: 2,
+  workspaceKey: "ops-workspace",
+  name: "Ops Workspace",
+  description: "E2E secondary workspace",
+  status: "ACTIVE",
+  myRole: "OPERATOR",
+  createdAt: "2026-05-02T00:00:00+09:00",
+  updatedAt: now,
+};
+
+const packSummary = {
+  packId: PACK_ID,
+  workspaceId: WORKSPACE_ID,
+  name: "Generated API Pack",
+  description: "상담 로그에서 생성된 환불 자동화 팩",
+  status: "ACTIVE",
+  currentVersionId: VERSION_ID,
+  currentVersionNo: 1,
+  currentVersionPublishedAt: "2026-05-22T00:00:00+09:00",
+  createdAt: "2026-05-22T00:00:00+09:00",
+  updatedAt: now,
+};
+
+const idlePackSummary = {
+  packId: 2,
+  workspaceId: WORKSPACE_ID,
+  name: "검토 대기 팩",
+  description: "아직 운영 버전이 없는 도메인팩",
+  status: "DRAFT",
+  currentVersionId: undefined,
+  currentVersionNo: undefined,
+  createdAt: "2026-06-01T00:00:00+09:00",
+  updatedAt: now,
+};
+
+const summaryJson = JSON.stringify({
+  topic: "환불 자동화 팩",
+  generation: { source: "pipeline", clusterCount: 12 },
+  quality: { mappingRate: 0.82, outlierRate: 0.07, workflowSeparability: 0.76 },
+  review: { needsReviewCount: 3, topIssues: ["워크플로우 미매핑"] },
+});
+
+const packDetail = {
+  ...packSummary,
+  code: "PACK_REFUND",
+  versions: [
+    {
+      versionId: VERSION_ID,
+      packId: PACK_ID,
+      versionNo: 1,
+      lifecycleStatus: "PUBLISHED",
+      summaryJson,
+      description: "운영 중인 환불 상담 자동화 버전",
+      intentCount: 1,
+      slotCount: 1,
+      policyCount: 1,
+      riskCount: 1,
+      workflowCount: 1,
+      createdAt: "2026-05-22T00:00:00+09:00",
+      updatedAt: now,
+    },
+    {
+      versionId: 2,
+      packId: PACK_ID,
+      versionNo: 2,
+      lifecycleStatus: "PUBLISHED",
+      summaryJson: JSON.stringify({
+        topic: "환불 자동화 팩 v2",
+        generation: { source: "pipeline", clusterCount: 14 },
+        quality: { mappingRate: 0.88, outlierRate: 0.04, workflowSeparability: 0.81 },
+        review: { needsReviewCount: 1, topIssues: ["상담사 연결 조건 보강"] },
+      }),
+      description: "상담사 연결 조건을 보강한 운영 가능 버전",
+      intentCount: 1,
+      slotCount: 1,
+      policyCount: 1,
+      riskCount: 1,
+      workflowCount: 1,
+      createdAt: "2026-05-25T00:00:00+09:00",
+      updatedAt: now,
+    },
+    {
+      versionId: 3,
+      packId: PACK_ID,
+      versionNo: 3,
+      lifecycleStatus: "DRAFT",
+      summaryJson: JSON.stringify({
+        topic: "환불 자동화 팩 v3 검토본",
+        review: { topIssues: ["고액 환불 안내 문구 검토"] },
+      }),
+      description: "고액 환불 검토 흐름을 정리한 수정 검토본",
+      intentCount: 1,
+      slotCount: 1,
+      policyCount: 1,
+      riskCount: 1,
+      workflowCount: 1,
+      createdAt: "2026-05-28T00:00:00+09:00",
+      updatedAt: now,
+    },
+  ],
+};
+
+const versionDetail = {
+  ...packDetail.versions[0],
+  finalMessage: "환불 문의 처리를 기준으로 도메인팩을 구성했습니다.",
+};
+
+const deployableVersionDetail = {
+  ...packDetail.versions[1],
+  finalMessage: "상담사 연결 조건을 보강했습니다.",
+};
+
+const draftVersionDetail = {
+  ...packDetail.versions[2],
+  finalMessage: "고액 환불 검토 흐름을 정리했습니다.",
+};
+
+const intent = {
+  id: INTENT_ID,
+  domainPackVersionId: VERSION_ID,
+  intentCode: "INT_REFUND",
+  name: "환불 문의",
+  description: "고객이 결제 취소나 환불 가능 여부를 문의하는 상담 유형",
+  taxonomyLevel: 1,
+  parentIntentId: null,
+  status: "ACTIVE",
+  sourceClusterRef: JSON.stringify({
+    clusterId: 12,
+    clusterSize: 36,
+    canonicalIntent: "환불 문의",
+    keywords: ["환불", "취소", "결제"],
+    segmentIds: ["seg-1", "seg-2"],
+    source: "intent_discovery_v1",
+  }),
+  entryConditionJson: JSON.stringify({ requiredAnyTerms: ["환불", "취소"] }),
+  evidenceJson: JSON.stringify({
+    sampleSegmentTexts: [
+      "고객: 결제한 상품을 환불하고 싶어요.",
+      "상담사: 주문번호를 알려주시면 환불 가능 여부를 확인하겠습니다.",
+    ],
+  }),
+  metaJson: "{}",
+  createdAt: "2026-05-22T00:00:00+09:00",
+  updatedAt: now,
+};
+
+const slot = {
+  id: 301,
+  domainPackVersionId: VERSION_ID,
+  slotCode: "SLOT_ORDER_ID",
+  name: "주문번호",
+  description: "환불 대상 주문을 식별하는 번호",
+  dataType: "STRING",
+  isSensitive: false,
+  validationRuleJson: JSON.stringify({ pattern: "^ORD-" }),
+  defaultValueJson: "{}",
+  metaJson: "{}",
+  status: "ACTIVE",
+  createdAt: "2026-05-22T00:00:00+09:00",
+  updatedAt: now,
+};
+
+const policy = {
+  id: 101,
+  domainPackVersionId: VERSION_ID,
+  policyCode: "POL_REFUND",
+  name: "환불 정책",
+  description: "결제 후 7일 이내 미사용 주문은 자동 환불을 안내합니다.",
+  severity: "HIGH",
+  conditionJson: JSON.stringify({ daysSincePayment: { lte: 7 }, used: false }),
+  actionJson: JSON.stringify({ type: "REFUND_REVIEW" }),
+  evidenceJson: "[]",
+  metaJson: "{}",
+  status: "ACTIVE",
+  createdAt: "2026-05-22T00:00:00+09:00",
+  updatedAt: now,
+};
+
+const risk = {
+  id: 201,
+  domainPackVersionId: VERSION_ID,
+  riskCode: "RISK_FRAUD",
+  name: "부정 환불 위험",
+  description: "반복 환불 또는 고액 환불은 상담사 검토로 넘깁니다.",
+  riskLevel: "HIGH",
+  triggerConditionJson: JSON.stringify({ refundCount30d: { gte: 3 } }),
+  handlingActionJson: JSON.stringify({ type: "MANUAL_REVIEW" }),
+  evidenceJson: "[]",
+  metaJson: "{}",
+  status: "ACTIVE",
+  createdAt: "2026-05-22T00:00:00+09:00",
+  updatedAt: now,
+};
+
+const workflowGraph = {
+  direction: "LR",
+  nodes: [
+    { id: "start", type: "start", label: "문의 접수" },
+    { id: "check", type: "decision", label: "환불 조건 확인" },
+    { id: "done", type: "terminal", label: "환불 안내 완료" },
+  ],
+  edges: [
+    { id: "e1", source: "start", target: "check", label: "주문번호 확인" },
+    { id: "e2", source: "check", target: "done", label: "정책 충족" },
+  ],
+};
+
+const workflow = {
+  id: WORKFLOW_ID,
+  domainPackVersionId: VERSION_ID,
+  intentDefinitionId: INTENT_ID,
+  workflowCode: "WF_REFUND",
+  name: "환불 처리",
+  description: "주문번호를 확인하고 환불 정책에 따라 안내하는 workflow",
+  initialState: "start",
+  terminalStatesJson: JSON.stringify(["done"]),
+  graphJson: JSON.stringify(workflowGraph),
+  evidenceJson: "{}",
+  metaJson: "{}",
+  createdAt: "2026-05-22T00:00:00+09:00",
+  updatedAt: now,
+};
+
+type DomainPackComponentSection = "intents" | "slots" | "policies" | "risks" | "workflows";
+
+function componentPreviewData(versionId: number, section: DomainPackComponentSection) {
+  const suffix = versionId === 3 ? "고액 환불" : "상담사 연결";
+
+  if (section === "intents") {
+    return [{ ...intent, domainPackVersionId: versionId, name: `${suffix} 문의` }];
+  }
+
+  if (section === "slots") {
+    return [{ ...slot, domainPackVersionId: versionId, name: `${suffix} 주문번호` }];
+  }
+
+  if (section === "policies") {
+    return [{ ...policy, domainPackVersionId: versionId, name: `${suffix} 정책` }];
+  }
+
+  if (section === "risks") {
+    return [{ ...risk, domainPackVersionId: versionId, name: `${suffix} 위험` }];
+  }
+
+  return [{ ...workflow, domainPackVersionId: versionId, name: `${suffix} 검토 워크플로우` }];
+}
+
+const members = [
+  {
+    memberId: 1,
+    userId: 7,
+    name: "김상담",
+    email: "agent@example.com",
+    workspaceRole: "OPERATOR",
+    joinedAt: "2026-05-01T00:00:00+09:00",
+    accountStatus: "ACTIVE",
+  },
+  {
+    memberId: 2,
+    userId: 8,
+    name: "박리뷰",
+    email: "reviewer@example.com",
+    workspaceRole: "REVIEWER",
+    joinedAt: "2026-05-03T00:00:00+09:00",
+    accountStatus: "ACTIVE",
+  },
+];
+
+const subscription = {
+  id: 11,
+  workspaceId: WORKSPACE_ID,
+  planKey: "PRO",
+  status: "ACTIVE",
+  currentPeriodStart: "2026-06-01T00:00:00+09:00",
+  currentPeriodEnd: "2026-07-01T00:00:00+09:00",
+  cancelAtPeriodEnd: false,
+  customerKey: "customer-qa-workspace",
+  memberLimit: 20,
+  datasetUploadLimit: 100,
+  pipelineRunLimit: 50,
+};
+
+const payment = {
+  id: 7001,
+  orderId: "order-7001",
+  paymentKey: "pay_7001",
+  amount: 99000,
+  currency: "KRW",
+  status: "DONE",
+  method: "카드",
+  approvedAt: "2026-06-01T09:30:00+09:00",
+  receiptUrl: "https://receipt.example.test/pay_7001",
+  createdAt: "2026-06-01T09:29:30+09:00",
+};
+
+const billingOverview = {
+  subscription,
+  billingKey: {
+    id: 15,
+    cardCompany: "신한카드",
+    cardNumberMasked: "1234-****-****-5678",
+    status: "ACTIVE",
+  },
+  payments: [payment],
+  quotaUsages: [
+    { resource: "DATASET_UPLOAD", used: 4, limit: 100 },
+    { resource: "PIPELINE_RUN", used: 9, limit: 50 },
+  ],
+};
+
+const consultationSession = {
+  id: 601,
+  workspaceId: WORKSPACE_ID,
+  status: "COMPLETED",
+  channel: "WEB",
+  metaJson: JSON.stringify({
+    customerName: "김민지",
+    title: "김민지",
+    handoffReason: "환불 문의",
+    messageCount: 2,
+    lastMessagePreview: "주문번호를 알려주시면 환불 가능 여부를 확인하겠습니다.",
+    resolution: { label: "환불 문의", reason: "환불 가능 여부 안내 완료" },
+  }),
+  startedAt: "2026-06-04T09:00:00+09:00",
+  completedAt: "2026-06-04T09:08:00+09:00",
+  assignedCounselorId: 7,
+  responseMode: "AI_ASSIST_ONLY",
+};
+
+const followUpConsultationSession = {
+  id: 602,
+  workspaceId: WORKSPACE_ID,
+  status: "RESOLVED",
+  channel: "KAKAO",
+  metaJson: JSON.stringify({
+    customerName: "이준호",
+    title: "이준호",
+    handoffReason: "배송 문의",
+    messageCount: 3,
+    lastMessagePreview: "배송 예정일을 다시 안내했습니다.",
+    resolution: {
+      label: "배송 안내",
+      reason: "주소 변경 요청 확인",
+      followUpRequired: true,
+    },
+  }),
+  startedAt: "2026-06-03T13:00:00+09:00",
+  completedAt: "2026-06-03T13:12:00+09:00",
+  assignedCounselorId: 8,
+  responseMode: "AI_ASSIST_ONLY",
+};
+
+const consultationSessions = [consultationSession, followUpConsultationSession];
+
+const chatMessages = [
+  {
+    id: 701,
+    seqNo: 1,
+    senderRole: "CUSTOMER",
+    messageType: "TEXT",
+    content: "환불 가능한지 확인해주세요.",
+    createdAt: "2026-06-04T09:01:00+09:00",
+  },
+  {
+    id: 702,
+    seqNo: 2,
+    senderRole: "ASSISTANT",
+    messageType: "TEXT",
+    content: "주문번호를 알려주시면 환불 가능 여부를 확인하겠습니다.",
+    createdAt: "2026-06-04T09:01:20+09:00",
+  },
+];
+
+const olderChatMessages = [
+  {
+    id: 700,
+    seqNo: 0,
+    senderRole: "SYSTEM",
+    messageType: "TEXT",
+    content: "환불 상담 세션이 시작되었습니다.",
+    createdAt: "2026-06-04T09:00:30+09:00",
+  },
+];
+
+const simulationSession = {
+  id: SIMULATION_SESSION_ID,
+  workspaceId: WORKSPACE_ID,
+  status: "ACTIVE",
+  channel: "SIMULATION",
+  metaJson: JSON.stringify({ customerName: "시뮬레이션 고객" }),
+  startedAt: "2026-06-04T09:10:00+09:00",
+  assignedCounselorId: null,
+  responseMode: "AI_ACTIVE",
+};
+
+const simulationFeedback = {
+  id: 9901,
+  workspaceId: WORKSPACE_ID,
+  sessionId: SIMULATION_SESSION_ID,
+  chatMessageId: null,
+  feedbackType: "INTENT_MISMATCH",
+  description: "환불 문의가 배송 문의로 분류되는 경우가 있습니다.",
+  expectedBehavior: "환불 intent로 매칭해야 합니다.",
+  severity: "MEDIUM",
+  status: "OPEN",
+  createdBy: 7,
+  createdAt: now,
+  updatedAt: now,
+};
+
+const improvementCandidate = {
+  id: 9911,
+  workspaceId: WORKSPACE_ID,
+  domainPackVersionId: VERSION_ID,
+  feedbackId: simulationFeedback.id,
+  sessionId: SIMULATION_SESSION_ID,
+  chatMessageId: null,
+  candidateType: "INTENT_DESCRIPTION_EXAMPLE",
+  targetElementType: "INTENT",
+  targetElementId: INTENT_ID,
+  targetElementKey: "INT_REFUND",
+  beforeSummary: "환불 intent 예시가 결제 취소 중심입니다.",
+  afterSummary: "부분 환불과 반복 환불 표현을 예시에 추가합니다.",
+  evidenceSummary: "시뮬레이션 피드백 #9901",
+  status: "DRAFT",
+  createdBy: 7,
+  createdAt: now,
+  updatedAt: now,
+};
+
+function simulationDetail(messages = chatMessages) {
+  return {
+    session: simulationSession,
+    messages,
+    matchedWorkflow: {
+      intentCode: "INT_REFUND",
+      intentName: "환불 문의",
+      workflowCode: "WF_REFUND",
+      workflowName: "환불 처리",
+      currentState: "환불 조건 확인",
+      executionStatus: "RUNNING",
+    },
+    slotValues: { orderId: "ORD-20260604" },
+    slots: [{ key: "orderId", value: "ORD-20260604" }],
+    feedback: {
+      items: [simulationFeedback],
+      messageFeedbackCounts: { "702": 1 },
+    },
+  };
+}
+
+async function fulfillJson(route: Route, body: unknown, status = 200) {
+  await route.fulfill({
+    status,
+    contentType: "application/json",
+    body: JSON.stringify(body),
+  });
+}
+
+function installTrackedApiRoute(page: Page, seen: string[], handler: RouteHandler) {
+  return page.route("**/api/v1/**", async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const path = url.pathname.replace(/^\/api\/v1/, "");
+    const method = request.method();
+    seen.push(`${method} ${path}${url.search}`);
+
+    if (await handler(route, method, path, url)) {
+      return;
+    }
+
+    return fulfillJson(route, { code: "E2E_UNMOCKED", message: `${method} ${path}` }, 500);
+  });
+}
+
+function parseSessionMeta(session: typeof consultationSessions[number]) {
+  try {
+    return JSON.parse(session.metaJson) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+function filterConsultationSessions(url: URL) {
+  const status = url.searchParams.get("status") ?? "";
+  const keyword = (url.searchParams.get("keyword") ?? "").trim().toLowerCase();
+  const startedFrom = url.searchParams.get("startedFrom") ?? "";
+  const startedTo = url.searchParams.get("startedTo") ?? "";
+  const assignedCounselorId = url.searchParams.get("assignedCounselorId") ?? "";
+
+  return consultationSessions.filter((session) => {
+    const meta = parseSessionMeta(session);
+    const searchable = [
+      session.channel,
+      session.status,
+      meta.customerName,
+      meta.title,
+      meta.handoffReason,
+      meta.lastMessagePreview,
+    ]
+      .filter((value): value is string => typeof value === "string")
+      .join(" ")
+      .toLowerCase();
+    const startedDate = session.startedAt.slice(0, 10);
+    const matchesStatus = status ? session.status === status : true;
+    const matchesKeyword = keyword ? searchable.includes(keyword) : true;
+    const matchesStartedFrom = startedFrom ? startedDate >= startedFrom : true;
+    const matchesStartedTo = startedTo ? startedDate <= startedTo : true;
+    const matchesCounselor = assignedCounselorId
+      ? String(session.assignedCounselorId) === assignedCounselorId
+      : true;
+
+    return (
+      matchesStatus &&
+      matchesKeyword &&
+      matchesStartedFrom &&
+      matchesStartedTo &&
+      matchesCounselor
+    );
+  });
+}
+
+async function fulfillWorkspaceShell(route: Route, method: string, path: string): Promise<boolean> {
+  if (method === "GET" && path === "/workspaces") {
+    await fulfillJson(route, [workspace, secondaryWorkspace]);
+    return true;
+  }
+
+  if (method === "GET" && path === "/workspaces/1") {
+    await fulfillJson(route, workspace);
+    return true;
+  }
+
+  if (method === "GET" && path === "/workspaces/2") {
+    await fulfillJson(route, secondaryWorkspace);
+    return true;
+  }
+
+  return false;
+}
+
+async function fulfillDomainPackRead(route: Route, method: string, path: string): Promise<boolean> {
+  const domainPackWorkspacePrefix =
+    path.startsWith("/workspaces/1/domain-packs")
+      ? "/workspaces/1"
+      : path.startsWith("/workspaces/2/domain-packs")
+        ? "/workspaces/2"
+        : null;
+
+  if (method === "GET" && path === `${domainPackWorkspacePrefix}/domain-packs`) {
+    const summaries =
+      domainPackWorkspacePrefix === "/workspaces/1"
+        ? [packSummary, idlePackSummary]
+        : [{ ...packSummary, workspaceId: 2, name: "Ops Workflow Pack" }];
+    await fulfillJson(route, { data: summaries, status: 200 });
+    return true;
+  }
+
+  if (method === "GET" && path === `${domainPackWorkspacePrefix}/domain-packs/1`) {
+    await fulfillJson(route, {
+      data:
+        domainPackWorkspacePrefix === "/workspaces/1"
+          ? packDetail
+          : { ...packDetail, workspaceId: 2, name: "Ops Workflow Pack" },
+      status: 200,
+    });
+    return true;
+  }
+
+  if (method === "GET" && path === "/workspaces/1/domain-packs/2") {
+    await fulfillJson(route, {
+      data: {
+        ...idlePackSummary,
+        code: "PACK_PENDING",
+        versions: [],
+      },
+      status: 200,
+    });
+    return true;
+  }
+
+  if (method === "GET" && path === "/workspaces/1/domain-packs/1/versions/1") {
+    await fulfillJson(route, { data: versionDetail, status: 200 });
+    return true;
+  }
+
+  if (method === "GET" && path === "/workspaces/1/domain-packs/1/versions/2") {
+    await fulfillJson(route, { data: deployableVersionDetail, status: 200 });
+    return true;
+  }
+
+  if (method === "GET" && path === "/workspaces/1/domain-packs/1/versions/3") {
+    await fulfillJson(route, { data: draftVersionDetail, status: 200 });
+    return true;
+  }
+
+  if (method === "POST" && path === "/workspaces/1/domain-packs/1/versions/2/deploy") {
+    await fulfillJson(route, {
+      data: {
+        id: 2,
+        domainPackId: PACK_ID,
+        versionNo: 2,
+        lifecycleStatus: "PUBLISHED",
+        publishedAt: now,
+        updatedAt: now,
+      },
+      status: 200,
+    });
+    return true;
+  }
+
+  if (method === "POST" && path === "/workspaces/1/domain-packs/1/versions/3/activate") {
+    expect(route.request().postDataJSON()).toEqual({
+      description: "검토본 적용 메모",
+    });
+    await fulfillJson(route, {
+      data: {
+        id: 3,
+        domainPackId: PACK_ID,
+        versionNo: 3,
+        lifecycleStatus: "PUBLISHED",
+        description: "검토본 적용 메모",
+        publishedAt: now,
+        updatedAt: now,
+      },
+      status: 200,
+    });
+    return true;
+  }
+
+  if (method === "DELETE" && path === "/workspaces/1/domain-packs/1/versions/3/draft") {
+    await fulfillJson(route, { data: null, status: 200 });
+    return true;
+  }
+
+  const componentListMatch = path.match(
+    /^\/workspaces\/1\/domain-packs\/1\/versions\/([23])\/(intents|slots|policies|risks|workflows)$/,
+  );
+  if (method === "GET" && componentListMatch) {
+    const versionId = Number(componentListMatch[1]);
+    const section = componentListMatch[2] as DomainPackComponentSection;
+    await fulfillJson(route, { data: componentPreviewData(versionId, section), status: 200 });
+    return true;
+  }
+
+  if (method === "GET" && path === "/workspaces/1/domain-packs/1/versions/1/intents") {
+    await fulfillJson(route, { data: [intent], status: 200 });
+    return true;
+  }
+
+  if (method === "GET" && path === "/workspaces/1/domain-packs/1/versions/1/intents/501") {
+    await fulfillJson(route, { data: intent, status: 200 });
+    return true;
+  }
+
+  if (method === "GET" && path === "/workspaces/1/domain-packs/1/versions/1/intents/501/workflows") {
+    await fulfillJson(route, { data: [workflow], status: 200 });
+    return true;
+  }
+
+  if (method === "GET" && path === "/workspaces/1/domain-packs/1/versions/1/slots") {
+    await fulfillJson(route, { data: [slot], status: 200 });
+    return true;
+  }
+
+  if (method === "GET" && path === "/workspaces/1/domain-packs/1/versions/1/slots/301") {
+    await fulfillJson(route, { data: slot, status: 200 });
+    return true;
+  }
+
+  if (method === "GET" && path === "/workspaces/1/domain-packs/1/versions/1/policies") {
+    await fulfillJson(route, { data: [policy], status: 200 });
+    return true;
+  }
+
+  if (method === "GET" && path === "/workspaces/1/domain-packs/1/versions/1/policies/101") {
+    await fulfillJson(route, { data: policy, status: 200 });
+    return true;
+  }
+
+  if (method === "PATCH" && path === "/workspaces/1/domain-packs/1/versions/1/policies/101") {
+    const body = route.request().postDataJSON() as Record<string, unknown>;
+    await fulfillJson(route, {
+      data: {
+        ...policy,
+        ...body,
+        updatedAt: now,
+      },
+      status: 200,
+    });
+    return true;
+  }
+
+  if (
+    method === "PATCH" &&
+    path === "/workspaces/1/domain-packs/1/versions/1/policies/101/status"
+  ) {
+    const body = route.request().postDataJSON() as { status?: string };
+    await fulfillJson(route, {
+      data: {
+        ...policy,
+        status: body.status,
+        updatedAt: now,
+      },
+      status: 200,
+    });
+    return true;
+  }
+
+  if (method === "GET" && path === "/workspaces/1/domain-packs/1/versions/1/risks") {
+    await fulfillJson(route, { data: [risk], status: 200 });
+    return true;
+  }
+
+  if (method === "GET" && path === "/workspaces/1/domain-packs/1/versions/1/risks/201") {
+    await fulfillJson(route, { data: risk, status: 200 });
+    return true;
+  }
+
+  if (method === "PATCH" && path === "/workspaces/1/domain-packs/1/versions/1/risks/201") {
+    const body = route.request().postDataJSON() as Record<string, unknown>;
+    await fulfillJson(route, {
+      data: {
+        ...risk,
+        ...body,
+        updatedAt: now,
+      },
+      status: 200,
+    });
+    return true;
+  }
+
+  if (
+    method === "PATCH" &&
+    path === "/workspaces/1/domain-packs/1/versions/1/risks/201/status"
+  ) {
+    const body = route.request().postDataJSON() as { status?: string };
+    await fulfillJson(route, {
+      data: {
+        ...risk,
+        status: body.status,
+        updatedAt: now,
+      },
+      status: 200,
+    });
+    return true;
+  }
+
+  if (
+    method === "GET" &&
+    path === `${domainPackWorkspacePrefix}/domain-packs/1/versions/1/workflows`
+  ) {
+    await fulfillJson(route, { data: [workflow], status: 200 });
+    return true;
+  }
+
+  if (method === "GET" && path === "/workspaces/1/domain-packs/1/versions/1/workflows/401") {
+    await fulfillJson(route, { data: workflow, status: 200 });
+    return true;
+  }
+
+  if (
+    method === "GET" &&
+    path === "/workspaces/1/domain-packs/1/versions/1/workflows/401/transitions"
+  ) {
+    await fulfillJson(route, { data: [], status: 200 });
+    return true;
+  }
+
+  return false;
+}
+
+async function fulfillWorkspaceOperations(
+  route: Route,
+  method: string,
+  path: string,
+  url: URL,
+): Promise<boolean> {
+  if (method === "GET" && path === "/workspaces/1/members") {
+    const q = url.searchParams.get("q")?.toLowerCase() ?? "";
+    const role = url.searchParams.get("role") ?? "";
+    const filtered = members.filter((member) => {
+      const matchesSearch = q
+        ? `${member.name} ${member.email}`.toLowerCase().includes(q)
+        : true;
+      const matchesRole = role ? member.workspaceRole === role : true;
+      return matchesSearch && matchesRole;
+    });
+    await fulfillJson(route, { data: filtered, status: 200 });
+    return true;
+  }
+
+  if (method === "GET" && path === "/workspaces/1/consultation/metrics") {
+    await fulfillJson(route, {
+      workspaceId: WORKSPACE_ID,
+      periodStart: "2026-05-29T00:00:00+09:00",
+      periodEnd: now,
+      totalConsultationCount: 38,
+      completedConsultationCount: 31,
+      averageFirstResponseSeconds: 72,
+      averageLlmFirstResponseSeconds: 4,
+      averageHumanFirstResponseSeconds: 180,
+      llmHandledCount: 24,
+      humanInterventionCount: 7,
+      unresolvedSessionCount: 2,
+      comparison: null,
+      coverage: {
+        workflowMatchedCount: 29,
+        workflowMatchRate: 0.76,
+        intentClassificationSuccessCount: 31,
+        intentClassificationSuccessRate: 0.82,
+        lowConfidenceCount: 3,
+        lowConfidenceRate: 0.08,
+        unmatchedSessionCount: 4,
+        autoCompletedWorkflowCount: 18,
+        humanHandoffRate: 0.18,
+        llmOnlyProcessingRate: 0.64,
+        measurementStatus: "READY",
+        measurementMessage: "측정 가능",
+        trend: [{ date: "2026-06-04", totalConsultationCount: 8, workflowMatchedCount: 6, workflowMatchRate: 0.75 }],
+      },
+      handledTodayCount: 8,
+      llmHandledTodayCount: 6,
+      humanHandledTodayCount: 2,
+    });
+    return true;
+  }
+
+  if (method === "GET" && path === "/workspaces/1/dashboard/workflow-rankings") {
+    const topRanking = {
+      rank: 1,
+      workflowDefinitionId: WORKFLOW_ID,
+      domainPackId: PACK_ID,
+      domainPackVersionId: VERSION_ID,
+      workflowCode: "WF_REFUND",
+      workflowName: "환불 처리",
+      executionCount: 18,
+      shareRate: 0.47,
+      completedCount: 16,
+      failedCount: 1,
+      runningCount: 1,
+      completionRate: 0.89,
+      failureRate: 0.05,
+      averageHandlingSeconds: 210,
+      humanInterventionRate: 0.12,
+      changeRate: 0.18,
+      surging: true,
+      detailPath: `/workspaces/1/domain-packs/1/workflows/401?versionId=1`,
+    };
+    await fulfillJson(route, {
+      workspaceId: WORKSPACE_ID,
+      periodStart: "2026-05-29T00:00:00+09:00",
+      periodEnd: now,
+      totalConsultationCount: 38,
+      rankings: [topRanking],
+      topRankings: [topRanking],
+    });
+    return true;
+  }
+
+  if (method === "GET" && path === "/workspaces/1/dashboard/knowledge-pack-health") {
+    await fulfillJson(route, {
+      activeKnowledgePack: {
+        packId: PACK_ID,
+        packName: "Generated API Pack",
+        versionId: VERSION_ID,
+        versionNo: 1,
+        publishedAt: "2026-05-22T00:00:00+09:00",
+        createdAt: "2026-05-22T00:00:00+09:00",
+        sourcePipelineJobId: PIPELINE_JOB_ID,
+      },
+      lastLogUpload: {
+        datasetId: DATASET_ID,
+        datasetKey: "dataset-refund-log",
+        datasetName: "refund-log.zip",
+        datasetStatus: "READY",
+        uploadedAt: "2026-06-04T09:00:00+09:00",
+      },
+      lastKnowledgePackGeneration: {
+        pipelineJobId: PIPELINE_JOB_ID,
+        datasetId: DATASET_ID,
+        domainPackId: PACK_ID,
+        status: "WAITING_DOMAIN_CONFIRMATION",
+        requestedAt: now,
+        startedAt: now,
+        finishedAt: null,
+        lastErrorMessage: null,
+      },
+      pendingReviewCount: 1,
+    });
+    return true;
+  }
+
+  if (method === "GET" && path === "/workspaces/1/dashboard/action-recommendations") {
+    await fulfillJson(route, {
+      workspaceId: WORKSPACE_ID,
+      periodStart: "2026-05-29T00:00:00+09:00",
+      periodEnd: now,
+      recommendations: [
+        {
+          ruleCode: "PENDING_PIPELINE_REVIEW",
+          priority: 1,
+          title: "최신 도메인 후보 확정",
+          description: "파이프라인이 발견한 환불 도메인을 확정하세요.",
+          evidenceLabel: "대기 항목",
+          evidenceValue: "1개",
+          targetPath: `/workspaces/1/pipeline-jobs/${PIPELINE_JOB_ID}/review`,
+        },
+      ],
+    });
+    return true;
+  }
+
+  if (method === "GET" && path === "/workspaces/1/consultation/sessions") {
+    const page = Number(url.searchParams.get("page") ?? "0");
+    const size = Number(url.searchParams.get("size") ?? "20");
+    const filtered = filterConsultationSessions(url);
+    const pageSize = Number.isFinite(size) && size > 0 ? size : 20;
+    const currentPage = Number.isFinite(page) && page >= 0 ? page : 0;
+    const start = currentPage * pageSize;
+    await fulfillJson(route, {
+      content: filtered.slice(start, start + pageSize),
+      page: currentPage,
+      size: pageSize,
+      totalElements: filtered.length,
+      totalPages: Math.max(Math.ceil(filtered.length / pageSize), 1),
+    });
+    return true;
+  }
+
+  if (method === "GET" && path === "/consultation/sessions/601/messages") {
+    const requestedPage = Number(url.searchParams.get("page") ?? "0");
+    const currentPage = Number.isFinite(requestedPage) && requestedPage > 0 ? requestedPage : 0;
+    const content = currentPage === 1 ? olderChatMessages : chatMessages;
+    await fulfillJson(route, {
+      content,
+      page: currentPage,
+      size: 50,
+      totalElements: chatMessages.length + olderChatMessages.length,
+      totalPages: 2,
+    });
+    return true;
+  }
+
+  if (method === "GET" && path === "/workspaces/1/subscription") {
+    await fulfillJson(route, { data: subscription, status: 200 });
+    return true;
+  }
+
+  if (method === "GET" && path === "/workspaces/1/billing/overview") {
+    await fulfillJson(route, { data: billingOverview, status: 200 });
+    return true;
+  }
+
+  if (method === "POST" && path === "/workspaces/1/payments/pay_7001/cancel") {
+    expect(route.request().postDataJSON()).toMatchObject({ cancelReason: "품질 검증 환불" });
+    await fulfillJson(route, { data: { ...payment, status: "CANCELED" }, status: 200 });
+    return true;
+  }
+
+  if (method === "DELETE" && path === "/workspaces/1/subscription") {
+    await fulfillJson(route, {
+      data: { ...subscription, status: "CANCELED", cancelAtPeriodEnd: true },
+      status: 200,
+    });
+    return true;
+  }
+
+  if (method === "POST" && path === "/workspaces/1/billing/authorizations") {
+    expect(route.request().postDataJSON()).toMatchObject({
+      authKey: "auth-e2e",
+      customerKey: "customer-qa-workspace",
+    });
+    await fulfillJson(route, {
+      data: {
+        subscription,
+        billingKey: billingOverview.billingKey,
+      },
+      status: 200,
+    });
+    return true;
+  }
+
+  if (method === "POST" && path === "/workspaces/1/payments/confirm") {
+    expect(route.request().postDataJSON()).toMatchObject({
+      paymentKey: "payment-e2e",
+      orderId: "order-e2e",
+      amount: 99000,
+    });
+    await fulfillJson(route, { data: payment, status: 200 });
+    return true;
+  }
+
+  return false;
+}
+
+async function fulfillUploadAndReview(route: Route, method: string, path: string): Promise<boolean> {
+  if (method === "POST" && path === "/workspaces/1/datasets/uploads:init") {
+    await fulfillJson(route, {
+      datasetId: DATASET_ID,
+      datasetKey: "dataset-refund-log",
+      workspaceId: WORKSPACE_ID,
+      uploadUrl: "http://127.0.0.1:3000/e2e-upload/raw-log.zip",
+      objectKey: "raw/dataset-refund-log.zip",
+      contentType: "application/zip",
+      expiresInSeconds: 300,
+      serverSideEncryptionRequired: false,
+    });
+    return true;
+  }
+
+  if (method === "POST" && path === "/workspaces/1/datasets/uploads/77:complete") {
+    await fulfillJson(route, {
+      datasetId: DATASET_ID,
+      datasetKey: "dataset-refund-log",
+      workspaceId: WORKSPACE_ID,
+      objectKey: "raw/dataset-refund-log.zip",
+      sizeBytes: 24,
+      status: "READY",
+    });
+    return true;
+  }
+
+  if (method === "POST" && path === "/workspaces/1/datasets/77/pipeline-jobs/domain-pack-generation") {
+    await fulfillJson(route, {
+      data: { pipelineJobId: PIPELINE_JOB_ID, status: "WAITING_DOMAIN_CONFIRMATION" },
+      status: 200,
+    });
+    return true;
+  }
+
+  if (method === "GET" && path === "/workspaces/1/pipeline-jobs/900/review-checkpoint") {
+    await fulfillJson(route, {
+      pipelineJobId: PIPELINE_JOB_ID,
+      pipelineStatus: "WAITING_DOMAIN_CONFIRMATION",
+      reviewKind: "DOMAIN_CONFIRMATION",
+      tasks: [
+        {
+          id: 9101,
+          targetType: "DOMAIN_CANDIDATE",
+          status: "OPEN",
+          priority: "HIGH",
+          title: "환불/결제 도메인",
+          payload: {
+            displayName: "환불/결제 도메인",
+            confidence: 0.91,
+            description: "결제 취소, 환불 조건, 주문번호 확인 상담이 포함됩니다.",
+            evidenceTerms: ["환불", "취소", "결제", "주문번호"],
+          },
+        },
+      ],
+    });
+    return true;
+  }
+
+  if (method === "GET" && path === "/workspaces/1/pipeline-jobs/901/review-checkpoint") {
+    await fulfillJson(route, {
+      pipelineJobId: 901,
+      pipelineStatus: "WAITING_HUMAN_FEEDBACK",
+      reviewKind: "HUMAN_FEEDBACK",
+      tasks: [
+        {
+          id: 9201,
+          targetType: "FEEDBACK_PAIR",
+          status: "OPEN",
+          priority: "MEDIUM",
+          title: "환불과 배송 지연 경계",
+          payload: {
+            questionText: "두 상담을 같은 intent로 묶어도 되나요?",
+            reasonLabel: "클러스터 경계 확인",
+            sourceReviewContext: {
+              conversationId: "A-1",
+              summary: "고객이 결제 환불 가능 여부를 문의함",
+              action: "환불 확인",
+              object: "주문",
+              signals: ["환불", "결제"],
+              turns: [{ role: "customer", text: "결제 취소하고 싶어요." }],
+            },
+            targetReviewContext: {
+              conversationId: "B-1",
+              summary: "고객이 배송 지연으로 취소를 요청함",
+              action: "취소 요청",
+              object: "배송",
+              signals: ["배송", "취소"],
+              turns: [{ role: "customer", text: "배송이 늦어서 취소하고 싶어요." }],
+            },
+          },
+        },
+      ],
+    });
+    return true;
+  }
+
+  if (method === "POST" && path === "/workspaces/1/pipeline-jobs/900/review-checkpoint/domain-confirmation") {
+    expect(route.request().postDataJSON()).toEqual({ reviewTaskId: 9101 });
+    await fulfillJson(route, { data: { accepted: true }, status: 200 });
+    return true;
+  }
+
+  if (method === "POST" && path === "/workspaces/1/pipeline-jobs/901/review-checkpoint/human-feedback") {
+    expect(route.request().postDataJSON()).toEqual({
+      decisions: [{ reviewTaskId: 9201, decisionType: "cannot_link" }],
+    });
+    await fulfillJson(route, { data: { accepted: true }, status: 200 });
+    return true;
+  }
+
+  return false;
+}
+
+async function fulfillSimulation(route: Route, method: string, path: string): Promise<boolean> {
+  if (method === "GET" && path === "/workspaces/1/simulation/sessions") {
+    await fulfillJson(route, {
+      content: [simulationSession],
+      page: 0,
+      size: 20,
+      totalElements: 1,
+      totalPages: 1,
+    });
+    return true;
+  }
+
+  if (method === "POST" && path === "/workspaces/1/simulation/sessions") {
+    expect(route.request().postDataJSON()).toMatchObject({ customerName: "최시뮬" });
+    await fulfillJson(route, simulationDetail([]));
+    return true;
+  }
+
+  if (method === "GET" && path === "/workspaces/1/simulation/sessions/8801") {
+    await fulfillJson(route, simulationDetail());
+    return true;
+  }
+
+  if (method === "POST" && path === "/workspaces/1/simulation/sessions/8801/messages") {
+    expect(route.request().postDataJSON()).toEqual({ content: "환불 가능한가요?" });
+    await fulfillJson(route, simulationDetail(chatMessages));
+    return true;
+  }
+
+  if (method === "POST" && path === "/workspaces/1/simulation/sessions/8801/feedback") {
+    expect(route.request().postDataJSON()).toMatchObject({
+      chatMessageId: 702,
+      feedbackType: "MISSING_SLOT_QUESTION",
+      description: "분류가 흔들립니다.",
+      expectedBehavior: "환불 문의로 고정해야 합니다.",
+      severity: "HIGH",
+    });
+    await fulfillJson(route, simulationDetail(chatMessages));
+    return true;
+  }
+
+  if (method === "GET" && path === "/workspaces/1/simulation/feedback") {
+    await fulfillJson(route, {
+      content: [simulationFeedback],
+      page: 0,
+      size: 20,
+      totalElements: 1,
+      totalPages: 1,
+    });
+    return true;
+  }
+
+  if (
+    method === "POST" &&
+    path === "/workspaces/1/simulation/improvement-candidates/from-feedback/9901"
+  ) {
+    await fulfillJson(route, improvementCandidate);
+    return true;
+  }
+
+  if (method === "GET" && path === "/workspaces/1/simulation/improvement-candidates") {
+    await fulfillJson(route, {
+      content: [improvementCandidate],
+      page: 0,
+      size: 20,
+      totalElements: 1,
+      totalPages: 1,
+    });
+    return true;
+  }
+
+  if (method === "PATCH" && path === "/workspaces/1/simulation/improvement-candidates/9911/status") {
+    expect(route.request().postDataJSON()).toEqual({ status: "READY_FOR_REVIEW" });
+    await fulfillJson(route, { ...improvementCandidate, status: "READY_FOR_REVIEW" });
+    return true;
+  }
+
+  return false;
+}
+
+export async function installAppApiMocks(page: Page, seen: string[]) {
+  await page.route("**/e2e-upload/**", async (route) => {
+    seen.push(`${route.request().method()} /e2e-upload/raw-log.zip`);
+    await route.fulfill({ status: 200, body: "" });
+  });
+
+  await installTrackedApiRoute(page, seen, async (route, method, path, url) => {
+    if (await fulfillWorkspaceShell(route, method, path)) return true;
+    if (await fulfillDomainPackRead(route, method, path)) return true;
+    if (await fulfillWorkspaceOperations(route, method, path, url)) return true;
+    if (await fulfillUploadAndReview(route, method, path)) return true;
+    if (await fulfillSimulation(route, method, path)) return true;
+    return false;
+  });
+}
+
+const adminCustomerSummary = {
+  workspace: {
+    id: WORKSPACE_ID,
+    workspaceKey: "qa-workspace",
+    name: "QA Workspace",
+    description: "운영 검증용 고객사",
+    status: "ACTIVE",
+    createdAt: "2026-05-01T00:00:00+09:00",
+    updatedAt: now,
+  },
+  memberCount: 2,
+  billing: {
+    subscriptionStatus: "ACTIVE",
+    planName: "PRO",
+    currentPeriodEnd: "2026-07-01T00:00:00+09:00",
+    updatedAt: now,
+  },
+  latestUpload: {
+    datasetId: DATASET_ID,
+    datasetKey: "dataset-refund-log",
+    name: "refund-log.zip",
+    status: "READY",
+    uploadedAt: "2026-06-04T09:00:00+09:00",
+  },
+  latestPipelineJob: {
+    id: PIPELINE_JOB_ID,
+    jobType: "DOMAIN_PACK_GENERATION",
+    status: "WAITING_DOMAIN_CONFIRMATION",
+    requestedAt: now,
+    startedAt: now,
+    finishedAt: null,
+  },
+};
+
+const adminPipelineJob = {
+  pipelineJobId: 8001,
+  workspaceId: WORKSPACE_ID,
+  datasetId: DATASET_ID,
+  domainPackId: PACK_ID,
+  jobType: "DOMAIN_PACK_GENERATION",
+  status: "FAILED",
+  airflowDagId: "domain_pack_generation",
+  airflowRunId: "pipeline_job_8001",
+  requestedAt: now,
+  startedAt: now,
+  finishedAt: now,
+  queueLagSeconds: 32,
+  runningDurationSeconds: 410,
+  totalDurationSeconds: 442,
+  lagExceeded: false,
+  lastErrorMessage: "draft generation timeout",
+  retriedFromPipelineJobId: null,
+  retryPipelineJobId: null,
+};
+
+export async function installAdminApiMocks(page: Page, seen: string[]) {
+  await installTrackedApiRoute(page, seen, async (route, method, path) => {
+    if (method === "GET" && path === "/admin/customers") {
+      await fulfillJson(route, { content: [adminCustomerSummary], page: 0, size: 20, hasNext: false });
+      return true;
+    }
+
+    if (method === "GET" && path === "/admin/customers/1") {
+      await fulfillJson(route, {
+        workspace: adminCustomerSummary.workspace,
+        members: {
+          totalCount: 2,
+          ownerCount: 1,
+          adminCount: 0,
+          reviewerCount: 1,
+          operatorCount: 1,
+          recentMembers: members,
+        },
+        billing: adminCustomerSummary.billing,
+        latestUpload: adminCustomerSummary.latestUpload,
+        pipeline: {
+          totalCount: 3,
+          runningCount: 0,
+          succeededCount: 2,
+          failedCount: 1,
+          latestJob: adminCustomerSummary.latestPipelineJob,
+          recentJobs: [adminCustomerSummary.latestPipelineJob],
+        },
+      });
+      return true;
+    }
+
+    if (method === "GET" && path === "/admin/billing/customers") {
+      await fulfillJson(route, [
+        {
+          workspaceId: WORKSPACE_ID,
+          workspaceKey: "qa-workspace",
+          workspaceName: "QA Workspace",
+          subscription: {
+            status: "ACTIVE",
+            currentPeriodStart: "2026-06-01T00:00:00+09:00",
+            currentPeriodEnd: "2026-07-01T00:00:00+09:00",
+            nextBillingAt: "2026-07-01T00:00:00+09:00",
+            planName: "PRO",
+            planAmount: 99000,
+          },
+          recentPayment: {
+            id: payment.id,
+            amount: payment.amount,
+            status: "DONE",
+            approvedAt: payment.approvedAt,
+          },
+          failedStatus: null,
+        },
+      ]);
+      return true;
+    }
+
+    if (method === "POST" && path === "/admin/billing/payments/7001/refunds") {
+      expect(route.request().postDataJSON()).toEqual({ reason: "관리자 검증 환불" });
+      await fulfillJson(route, {
+        paymentId: payment.id,
+        workspaceId: WORKSPACE_ID,
+        refundAmount: payment.amount,
+        paymentStatus: "CANCELED",
+        transactionKey: "tx-refund-7001",
+        canceledAt: now,
+        reason: "관리자 검증 환불",
+      });
+      return true;
+    }
+
+    if (method === "GET" && path === "/admin/pipeline-jobs") {
+      await fulfillJson(route, {
+        data: {
+          items: [adminPipelineJob],
+          page: 0,
+          size: 20,
+          totalElements: 1,
+          totalPages: 1,
+        },
+        status: 200,
+      });
+      return true;
+    }
+
+    if (method === "POST" && path === "/admin/pipeline-jobs/8001/retry") {
+      await fulfillJson(route, {
+        data: {
+          sourcePipelineJobId: 8001,
+          retryPipelineJobId: 8002,
+          workspaceId: WORKSPACE_ID,
+          datasetId: DATASET_ID,
+          jobType: "DOMAIN_PACK_GENERATION",
+          status: "QUEUED",
+          airflowDagId: "domain_pack_generation",
+          airflowRunId: "pipeline_job_8002",
+          requestedAt: now,
+          startedAt: null,
+        },
+        status: 200,
+      });
+      return true;
+    }
+
+    if (method === "POST" && path === "/admin/super-admins") {
+      expect(route.request().postDataJSON()).toEqual({
+        name: "운영 관리자",
+        email: "super-admin@example.com",
+        password: "password123",
+      });
+      await fulfillJson(route, {
+        data: {
+          id: 91,
+          name: "운영 관리자",
+          email: "super-admin@example.com",
+          role: "SUPER_ADMIN",
+        },
+        status: 200,
+      });
+      return true;
+    }
+
+    return false;
+  });
+}
+
+export async function captureScreen(page: Page, testInfo: TestInfo, name: string) {
+  const dir = join(testInfo.config.rootDir, "test-results", "e2e-screens");
+  mkdirSync(dir, { recursive: true });
+  const filename = `${name.replace(/[^a-z0-9가-힣_-]+/gi, "-")}.png`;
+  const path = join(dir, filename);
+  await page.screenshot({ path, fullPage: true });
+  await testInfo.attach(name, { path, contentType: "image/png" });
+  return path;
+}

--- a/frontend/e2e/support/generated-api-auth.ts
+++ b/frontend/e2e/support/generated-api-auth.ts
@@ -1,5 +1,13 @@
 import type { Page } from "@playwright/test";
 
+type E2eUserRole = "OPERATOR" | "ADMIN" | "SUPER_ADMIN";
+
+interface InstallAuthOptions {
+  role?: E2eUserRole;
+  name?: string;
+  email?: string;
+}
+
 function encodeBase64Url(value: unknown): string {
   return Buffer.from(JSON.stringify(value))
     .toString("base64")
@@ -8,20 +16,28 @@ function encodeBase64Url(value: unknown): string {
     .replace(/=+$/g, "");
 }
 
-export function makeJwt(): string {
+export function makeJwt(role: E2eUserRole = "OPERATOR"): string {
   const header = encodeBase64Url({ alg: "none", typ: "JWT" });
-  const payload = encodeBase64Url({ exp: Math.floor(Date.now() / 1000) + 60 * 60 });
+  const payload = encodeBase64Url({
+    exp: Math.floor(Date.now() / 1000) + 60 * 60,
+    role,
+  });
   return `${header}.${payload}.e2e`;
 }
 
-export async function installAuth(page: Page) {
-  const token = makeJwt();
-  await page.addInitScript((accessToken) => {
+export async function installAuth(page: Page, options: InstallAuthOptions = {}) {
+  const role = options.role ?? "OPERATOR";
+  const token = makeJwt(role);
+  const user = {
+    id: role === "SUPER_ADMIN" ? 1 : 7,
+    email: options.email ?? (role === "SUPER_ADMIN" ? "admin@example.com" : "agent@example.com"),
+    name: options.name ?? (role === "SUPER_ADMIN" ? "관리자" : "상담사"),
+    role,
+  };
+
+  await page.addInitScript(({ accessToken, user }) => {
     window.localStorage.setItem("accessToken", accessToken);
     window.localStorage.setItem("refreshToken", "e2e-refresh-token");
-    window.localStorage.setItem(
-      "user",
-      JSON.stringify({ id: 7, email: "agent@example.com", name: "상담사", role: "OPERATOR" }),
-    );
-  }, token);
+    window.localStorage.setItem("user", JSON.stringify(user));
+  }, { accessToken: token, user });
 }

--- a/frontend/e2e/support/generated-api-mocks.ts
+++ b/frontend/e2e/support/generated-api-mocks.ts
@@ -10,6 +10,71 @@ import {
   workspace,
 } from "./generated-api-test-data";
 
+const queueSessions = [
+  {
+    ...consultationSession,
+    metaJson: JSON.stringify({
+      customerName: "김민지",
+      title: "환불 요청",
+      handoffReason: "환불 문의",
+      handoffRequired: true,
+      handoffAt: "2026-05-22T00:00:00Z",
+      lastMessagePreview: "주문 취소 후 환불이 아직 안 됐어요.",
+      lastMessageRole: "CUSTOMER",
+      lastMessageAt: "2026-05-22T00:05:00Z",
+    }),
+  },
+  {
+    id: 602,
+    status: "ACTIVE",
+    channel: "웹채팅",
+    metaJson: JSON.stringify({
+      customerName: "박준호",
+      title: "카드 결제 취소",
+      handoffReason: "카드 결제 취소 요청",
+      handoffRequired: true,
+      handoffAt: "2026-05-22T00:03:00Z",
+      lastMessagePreview: "카드 승인 취소가 가능한지 확인해주세요.",
+      lastMessageRole: "CUSTOMER",
+      lastMessageAt: "2026-05-22T00:08:00Z",
+    }),
+    startedAt: "2026-05-22T00:03:00Z",
+    assignedCounselorId: null,
+  },
+  {
+    id: 603,
+    status: "ACTIVE",
+    channel: "카카오톡",
+    metaJson: JSON.stringify({
+      customerName: "이서연",
+      title: "배송지 변경",
+      handoffReason: "배송지 변경 문의",
+      handoffRequired: false,
+      lastMessagePreview: "배송 주소를 다른 곳으로 바꾸고 싶어요.",
+      lastMessageRole: "CUSTOMER",
+      lastMessageAt: "2026-05-22T00:11:00Z",
+    }),
+    startedAt: "2026-05-22T00:07:00Z",
+    assignedCounselorId: null,
+  },
+  {
+    id: 604,
+    status: "ACTIVE",
+    channel: "이메일",
+    metaJson: JSON.stringify({
+      customerName: "최하늘",
+      title: "포인트 적립",
+      handoffReason: "포인트 적립 문의",
+      handoffRequired: false,
+      lastMessagePreview: "방금 결제했는데 포인트가 보이지 않아요.",
+      lastMessageRole: "CUSTOMER",
+      lastMessageAt: "2026-05-22T00:20:00Z",
+    }),
+    startedAt: "2026-05-22T00:18:00Z",
+    assignedCounselorId: 99,
+  },
+];
+
 async function fulfillJson(route: Route, body: unknown, status = 200) {
   await route.fulfill({
     status,
@@ -142,6 +207,28 @@ export async function installConsultationApiMocks(page: Page, seen: string[]) {
       return true;
     }
 
+    if (await fulfillDomainPackShell(route, method, path)) {
+      return true;
+    }
+
+    if (method === "GET" && path === "/workspaces/1/domain-packs/1/versions/1/workflows") {
+      await fulfillJson(route, { data: [workflow] });
+      return true;
+    }
+
+    if (method === "GET" && path === "/workspaces/1/domain-packs/1/versions/1/workflows/401") {
+      await fulfillJson(route, { data: workflow });
+      return true;
+    }
+
+    if (
+      method === "GET" &&
+      path === "/workspaces/1/domain-packs/1/versions/1/workflows/401/transitions"
+    ) {
+      await fulfillJson(route, { data: [] });
+      return true;
+    }
+
     if (method === "GET" && path === "/workspaces/1/consultation/metrics") {
       await fulfillJson(route, {
         data: {
@@ -160,29 +247,86 @@ export async function installConsultationApiMocks(page: Page, seen: string[]) {
     }
 
     if (method === "GET" && path === "/workspaces/1/consultation/queue") {
-      await fulfillJson(route, { data: [consultationSession] });
+      await fulfillJson(route, { data: queueSessions });
       return true;
     }
 
     if (method === "GET" && path === "/consultation/sessions/601/messages") {
-      await fulfillJson(route, {
-        data: [
-          {
-            id: 701,
-            seqNo: 1,
-            senderRole: "CUSTOMER",
-            messageType: "TEXT",
-            content: "generated 상담 메시지",
-            createdAt: "2026-05-22T00:01:00Z",
+      const url = new URL(route.request().url());
+      const page = url.searchParams.get("page") ?? "0";
+      if (page === "1") {
+        await fulfillJson(route, {
+          data: {
+            content: [
+              {
+                id: 700,
+                seqNo: 0,
+                senderRole: "SYSTEM",
+                messageType: "TEXT",
+                content: "상담 세션이 생성되었습니다.",
+                createdAt: "2026-05-22T00:00:10Z",
+              },
+            ],
+            page: 1,
+            size: 50,
+            totalElements: 2,
+            totalPages: 2,
           },
-        ],
+        });
+        return true;
+      }
+
+      await fulfillJson(route, {
+        data: {
+          content: [
+            {
+              id: 701,
+              seqNo: 1,
+              senderRole: "CUSTOMER",
+              messageType: "TEXT",
+              content: "generated 상담 메시지",
+              createdAt: "2026-05-22T00:01:00Z",
+            },
+          ],
+          page: 0,
+          size: 50,
+          totalElements: 2,
+          totalPages: 2,
+        },
+      });
+      return true;
+    }
+
+    if (method === "GET" && path === "/consultation/sessions/601/matched-workflow") {
+      await fulfillJson(route, {
+        sessionId: 601,
+        workspaceId: 1,
+        domainPackId: 1,
+        domainPackVersionId: 1,
+        executionId: 7001,
+        executionStatus: "RUNNING",
+        currentState: "환불 조건 확인",
+        workflowDefinitionId: 401,
+        workflowCode: "WF_REFUND",
+        workflowName: "환불 처리",
+        workflowDescription: "주문번호를 확인하고 환불 정책에 따라 안내합니다.",
+        graphJson: null,
+        initialState: "START",
+        terminalStates: ["DONE"],
+        intentCode: "INT_REFUND",
+        intentName: "환불 문의",
       });
       return true;
     }
 
     if (method === "PATCH" && path === "/consultation/sessions/601/status") {
-      expect(route.request().postDataJSON()).toEqual({ status: "COMPLETED" });
-      await fulfillJson(route, { data: { ...consultationSession, status: "COMPLETED" } });
+      expect(route.request().postDataJSON()).toEqual({
+        status: "RESOLVED",
+        resolutionOutcome: "FOLLOW_UP_REQUIRED",
+        resolutionReason: "배송사 확인 후 연락",
+        followUpRequired: true,
+      });
+      await fulfillJson(route, { data: { ...consultationSession, status: "RESOLVED" } });
       return true;
     }
 

--- a/frontend/e2e/user-chat.spec.ts
+++ b/frontend/e2e/user-chat.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 
+import { installAuth } from "./support/generated-api-auth";
 import { installMockStomp } from "./support/mock-stomp";
 
 test.describe("User demo chat", () => {
@@ -9,6 +10,29 @@ test.describe("User demo chat", () => {
 
   test.describe("Given a demo workspace chat entry point", () => {
     test.describe("When a user starts a chat and sends a message", () => {
+      test("Then blank customer names are blocked before any session request", async ({ page }) => {
+        const seen: string[] = [];
+
+        await page.route("**/api/v1/**", async (route) => {
+          const request = route.request();
+          const url = new URL(request.url());
+          const path = url.pathname.replace(/^\/api\/v1/, "");
+          seen.push(`${request.method()} ${path}`);
+          await route.fulfill({
+            status: 500,
+            contentType: "application/json",
+            body: JSON.stringify({ code: "E2E_UNEXPECTED_API", message: path }),
+          });
+        });
+
+        await page.goto("/demo/chat/42");
+        await page.getByTestId("chat-name-input").fill("   ");
+        await page.getByRole("button", { name: "미리보기 시작" }).click();
+
+        await expect(page.getByTestId("chat-name-error")).toHaveText("이름을 입력해 주세요.");
+        expect(seen).toEqual([]);
+      });
+
       test("Then the screen creates the session and renders the saved reply", async ({
         page,
       }) => {
@@ -95,14 +119,12 @@ test.describe("User demo chat", () => {
 
         await page.goto("/demo/chat/42");
         await page.getByTestId("chat-name-input").fill("김민지");
-        await page.getByRole("button", { name: "채팅 시작" }).click();
+        await page.getByRole("button", { name: "미리보기 시작" }).click();
 
         await expect(
           page.getByTestId("chat-conversation-screen"),
         ).toBeVisible();
-        await expect(
-          page.getByText("안녕하세요, 김민지님. 무엇을 도와드릴까요?"),
-        ).toBeVisible();
+        await expect(page.getByText("아직 메시지가 없습니다. 첫 메시지를 보내보세요!")).toBeVisible();
 
         await page.getByLabel("메시지 입력").fill("배송 문의입니다");
         await page.getByRole("button", { name: "메시지 보내기" }).click();
@@ -120,12 +142,177 @@ test.describe("User demo chat", () => {
       test("Then the legacy workspace URL redirects to the canonical chat URL", async ({
         page,
       }) => {
+        const seen: string[] = [];
+
+        await page.route("**/api/v1/**", async (route) => {
+          const request = route.request();
+          const url = new URL(request.url());
+          const path = url.pathname.replace(/^\/api\/v1/, "");
+          const method = request.method();
+          seen.push(`${method} ${path}`);
+
+          if (method === "POST" && path === "/workspaces/42/demo/chat-sessions") {
+            expect(request.postDataJSON()).toEqual({ customerName: "김민지" });
+            await route.fulfill({
+              status: 200,
+              contentType: "application/json",
+              body: JSON.stringify({
+                id: 78,
+                status: "OPEN",
+                channel: "DEMO",
+                startedAt: "2026-05-22T00:00:00Z",
+              }),
+            });
+            return;
+          }
+
+          if (method === "GET" && path === "/workspaces/42/demo/chat-sessions/78/messages") {
+            await route.fulfill({
+              status: 200,
+              contentType: "application/json",
+              body: JSON.stringify([]),
+            });
+            return;
+          }
+
+          await route.fulfill({
+            status: 500,
+            contentType: "application/json",
+            body: JSON.stringify({
+              code: "E2E_UNMOCKED",
+              message: `${method} ${path}`,
+            }),
+          });
+        });
+
         await page.goto(
           "/demo/workspaces/42/chat?name=%EA%B9%80%EB%AF%BC%EC%A7%80",
         );
 
         await expect(page).toHaveURL(/\/demo\/chat\/42\?name=/);
+        await expect(page.getByTestId("chat-conversation-screen")).toBeVisible();
+        await expect.poll(() => seen).toContain("POST /workspaces/42/demo/chat-sessions");
       });
+    });
+  });
+
+  test.describe("Given an authenticated workspace chat entry point", () => {
+    test("Then saved session restore, fresh session creation, and realtime send are verified", async ({
+      page,
+    }) => {
+      const seen: string[] = [];
+
+      await installAuth(page, { name: "김민지" });
+      await page.route("**/api/v1/**", async (route) => {
+        const request = route.request();
+        const url = new URL(request.url());
+        const path = url.pathname.replace(/^\/api\/v1/, "");
+        const method = request.method();
+        seen.push(`${method} ${path}${url.search}`);
+
+        if (method === "GET" && path === "/workspaces/1/chat/sessions/current") {
+          expect(url.searchParams.get("customerName")).toBe("김민지");
+          await route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify({
+              id: 88,
+              workspaceId: 1,
+              status: "OPEN",
+              channel: "WEB",
+              startedAt: "2026-06-04T09:00:00Z",
+            }),
+          });
+          return;
+        }
+
+        if (method === "POST" && path === "/workspaces/1/chat/sessions") {
+          expect(request.postDataJSON()).toEqual({ customerName: "김민지" });
+          await route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify({
+              id: 89,
+              workspaceId: 1,
+              status: "OPEN",
+              channel: "WEB",
+              startedAt: "2026-06-04T09:05:00Z",
+            }),
+          });
+          return;
+        }
+
+        if (method === "GET" && path === "/consultation/sessions/88/messages") {
+          await route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify([
+              {
+                id: 8801,
+                seqNo: 1,
+                senderRole: "ASSISTANT",
+                messageType: "TEXT",
+                content: "이전 상담을 이어서 도와드릴게요.",
+                createdAt: "2026-06-04T09:01:00Z",
+              },
+            ]),
+          });
+          return;
+        }
+
+        if (method === "GET" && path === "/consultation/sessions/89/messages") {
+          await route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify([]),
+          });
+          return;
+        }
+
+        await route.fulfill({
+          status: 500,
+          contentType: "application/json",
+          body: JSON.stringify({
+            code: "E2E_UNMOCKED",
+            message: `${method} ${path}`,
+          }),
+        });
+      });
+
+      await page.goto("/chat/1");
+
+      await expect(page.getByTestId("chat-conversation-screen")).toBeVisible();
+      await expect(page.getByTestId("chat-meta-strip")).toContainText("연결됨");
+      await expect(page.getByTestId("chat-session-reuse-note")).toContainText("김민지");
+      await expect(page.getByText("이전 상담을 이어서 도와드릴게요.")).toBeVisible();
+      expect(seen).toContain(
+        "GET /workspaces/1/chat/sessions/current?customerName=%EA%B9%80%EB%AF%BC%EC%A7%80",
+      );
+      expect(seen).toContain("GET /consultation/sessions/88/messages");
+
+      await page.getByTestId("chat-new-session-button").click();
+      await expect(page.getByText("아직 메시지가 없습니다. 첫 메시지를 보내보세요!")).toBeVisible();
+      await expect.poll(() => seen).toContain("POST /workspaces/1/chat/sessions");
+      await expect.poll(() => seen).toContain("GET /consultation/sessions/89/messages");
+
+      await page.getByLabel("메시지 입력").fill("환불 규정을 알려주세요");
+      await page.getByRole("button", { name: "메시지 보내기" }).click();
+      await expect(page.getByText("환불 규정을 알려주세요")).toBeVisible();
+      await expect(page.getByTestId("bot-typing-indicator")).toBeVisible();
+
+      const frames = await page.evaluate(() => {
+        const state = window as Window & { __e2eWsFrames?: string[] };
+        return state.__e2eWsFrames ?? [];
+      });
+      expect(
+        frames.some(
+          (frame) =>
+            frame.includes("SEND") &&
+            frame.includes("/app/chat.sendMessage") &&
+            frame.includes('"sessionId":89') &&
+            frame.includes("환불 규정을 알려주세요"),
+        ),
+      ).toBe(true);
     });
   });
 });

--- a/frontend/e2e/workspace-core.spec.ts
+++ b/frontend/e2e/workspace-core.spec.ts
@@ -1,0 +1,365 @@
+import { expect, test } from "@playwright/test";
+
+import { installAuth } from "./support/generated-api-auth";
+import { captureScreen, installAppApiMocks } from "./support/app-mocks";
+import { installMockStomp } from "./support/mock-stomp";
+
+function dateInputValue(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function dashboardRangeQuery(period: "today" | "7d" | "30d"): string {
+  const today = new Date();
+  const from = new Date(today);
+  if (period === "7d") {
+    from.setDate(today.getDate() - 6);
+  }
+  if (period === "30d") {
+    from.setDate(today.getDate() - 29);
+  }
+  return `from=${dateInputValue(from)}&to=${dateInputValue(today)}`;
+}
+
+function latestSeen(seen: string[], prefix: string): string {
+  return [...seen].reverse().find((entry) => entry.startsWith(prefix)) ?? "";
+}
+
+test.describe("Workspace core operator screens", () => {
+  let seen: string[];
+
+  test.beforeEach(async ({ page }) => {
+    seen = [];
+    await installAuth(page);
+    await installMockStomp(page);
+    await installAppApiMocks(page, seen);
+  });
+
+  test.describe("Given an authenticated workspace operator", () => {
+    test.describe("When they open the dashboard", () => {
+      test("Then KPI, health, recommendation, and workflow ranking data are rendered", async ({
+        page,
+      }, testInfo) => {
+        await page.goto("/workspaces/1/dashboard");
+
+        await expect(page.getByRole("heading", { name: "대시보드", exact: true })).toBeVisible();
+        await expect(page.getByText("총 상담")).toBeVisible();
+        await expect(page.getByText("최신 도메인 후보 확정")).toBeVisible();
+        await expect(page.getByText("환불 처리").first()).toBeVisible();
+        await expect(page.getByText("검토 후 운영 반영을 기다리고 있습니다.")).toBeVisible();
+        await captureScreen(page, testInfo, "workspace-dashboard");
+
+        const range = dashboardRangeQuery("7d");
+        expect(seen).toContain(`GET /workspaces/1/consultation/metrics?${range}`);
+        expect(seen).toContain(
+          `GET /workspaces/1/dashboard/action-recommendations?${range}`,
+        );
+        expect(seen).toContain("GET /workspaces/1/dashboard/knowledge-pack-health");
+        expect(seen).toContain(
+          `GET /workspaces/1/dashboard/workflow-rankings?${range}`,
+        );
+      });
+
+      test("Then compact filter controls update summaries, date queries, and action navigation", async ({
+        page,
+      }) => {
+        await page.goto("/workspaces/1/dashboard");
+
+        await page.getByRole("button", { name: "오늘" }).click();
+        await expect(page.getByLabel("대시보드 필터 요약")).toContainText("오늘");
+        await expect
+          .poll(() =>
+            seen.includes(
+              `GET /workspaces/1/consultation/metrics?${dashboardRangeQuery("today")}`,
+            ),
+          )
+          .toBe(true);
+
+        await page.getByLabel("운영 지식팩 버전 필터").selectOption("published");
+        await page.getByLabel("채널 필터").selectOption("email");
+        await page.getByLabel("워크플로우 상태 필터").selectOption("handoff");
+
+        const summary = page.getByLabel("대시보드 필터 요약");
+        await expect(summary).toContainText("운영 버전");
+        await expect(summary).toContainText("이메일");
+        await expect(summary).toContainText("상담원 연결");
+
+        await page.getByRole("button", { name: "사용자 지정" }).click();
+        await page.getByLabel("시작일").fill("2026-06-01");
+        await page.getByLabel("종료일").fill("2026-06-03");
+        await expect(summary).toContainText("2026-06-01 ~ 2026-06-03");
+        await expect
+          .poll(() =>
+            seen.includes("GET /workspaces/1/consultation/metrics?from=2026-06-01&to=2026-06-03"),
+          )
+          .toBe(true);
+
+        await page.getByRole("link", { name: /바로 보기/ }).click();
+        await expect(page).toHaveURL(/\/workspaces\/1\/pipeline-jobs\/900\/review/);
+        await expect(page.getByText("상담 도메인을 확정합니다.")).toBeVisible();
+      });
+    });
+
+    test.describe("When they search and open a workspace workflow", () => {
+      test("Then the workflow list settings and detail navigation are stable", async ({
+        page,
+      }, testInfo) => {
+        await page.goto("/workspaces/1/workflows");
+        await expect(page.getByTestId("workspace-workflows")).toBeVisible();
+
+        await page.getByTestId("workspace-workflows-search-input").fill("환불");
+        await page.getByTestId("workspace-workflows-search-item-401").click();
+        await expect(page.getByTestId("workspace-workflows-filter-chip")).toContainText("환불 처리");
+
+        await page.getByTestId("workspace-workflows-settings-toggle").click();
+        await expect(page.getByTestId("workspace-workflows-settings")).toBeVisible();
+        await captureScreen(page, testInfo, "workspace-workflows");
+
+        await page.getByTestId("workspace-workflows-card-401-open").click();
+        await expect(page).toHaveURL(
+          /\/workspaces\/1\/domain-packs\/1\/workflows\/401\?versionId=1/,
+        );
+        await expect(page.getByText("주문번호를 확인하고 환불 정책에 따라 안내")).toBeVisible();
+      });
+    });
+
+    test.describe("When they switch workspaces from the shell", () => {
+      test("Then the marker opens the workspace list and navigates with the selected workspace id", async ({
+        page,
+      }, testInfo) => {
+        await page.goto("/workspaces/1/dashboard");
+        await expect(page.getByTestId("workspace-marker")).toContainText("QA Workspace");
+
+        await page.getByTestId("workspace-marker").click();
+        await expect(page.getByTestId("workspace-marker-menu")).toBeVisible();
+        await expect(page.getByTestId("workspace-option-2")).toContainText("Ops Workspace");
+        await captureScreen(page, testInfo, "workspace-switcher");
+
+        await page.getByTestId("workspace-option-2").click();
+        await expect(page).toHaveURL(/\/workspaces\/2\/workflows$/);
+        await expect(page.getByTestId("workspace-marker")).toContainText("Ops Workspace");
+        await expect(page.getByTestId("workspace-workflows")).toContainText("환불 처리");
+        expect(seen).toContain("GET /workspaces/2");
+        expect(seen).toContain("GET /workspaces/2/domain-packs");
+        expect(seen).toContain("GET /workspaces/2/domain-packs/1");
+        expect(seen).toContain("GET /workspaces/2/domain-packs/1/versions/1/workflows");
+      });
+    });
+
+    test.describe("When they use the account menu", () => {
+      test("Then settings feedback and logout clear the authenticated session", async ({
+        page,
+      }, testInfo) => {
+        await page.goto("/workspaces/1/dashboard");
+
+        await page.getByTestId("account-menu-trigger").click();
+        await expect(page.getByTestId("account-menu-popover")).toBeVisible();
+        await captureScreen(page, testInfo, "workspace-account-menu");
+
+        await page.getByTestId("account-menu-settings").click();
+        await expect(page.getByText("설정 화면은 준비 중입니다.")).toBeVisible();
+
+        await page.getByTestId("account-menu-trigger").click();
+        await page.getByTestId("account-menu-logout").click();
+
+        await expect(page).toHaveURL(/\/login$/);
+        await expect(page.getByRole("button", { name: "시스템 로그인" })).toBeVisible();
+        await expect
+          .poll(() =>
+            page.evaluate(() => ({
+              accessToken: window.localStorage.getItem("accessToken"),
+              refreshToken: window.localStorage.getItem("refreshToken"),
+              user: window.localStorage.getItem("user"),
+            })),
+          )
+          .toEqual({ accessToken: null, refreshToken: null, user: null });
+      });
+    });
+
+    test.describe("When they filter workspace members", () => {
+      test("Then role and search filters drive the generated member endpoint", async ({ page }) => {
+        await page.goto("/workspaces/1/settings/members");
+        await expect(page.getByRole("heading", { name: "멤버" })).toBeVisible();
+        await expect(page.getByText("김상담")).toBeVisible();
+
+        await page.getByPlaceholder("이름 또는 이메일 검색").fill("리뷰");
+        await page.getByLabel("역할 필터").selectOption("REVIEWER");
+
+        await expect(page.getByText("박리뷰")).toBeVisible();
+        await expect(page.getByText("김상담")).toBeHidden();
+        expect(seen).toContain("GET /workspaces/1/members?q=%EB%A6%AC%EB%B7%B0&role=REVIEWER");
+
+        await page.getByPlaceholder("이름 또는 이메일 검색").fill("없는멤버");
+        await expect(page.getByTestId("workspace-members-empty")).toBeVisible();
+        expect(seen).toContain(
+          "GET /workspaces/1/members?q=%EC%97%86%EB%8A%94%EB%A9%A4%EB%B2%84&role=REVIEWER",
+        );
+
+        await page.getByLabel("역할 필터").selectOption("");
+        await expect(page.getByTestId("workspace-members-empty")).toBeVisible();
+        expect(seen).toContain("GET /workspaces/1/members?q=%EC%97%86%EB%8A%94%EB%A9%A4%EB%B2%84");
+      });
+    });
+
+    test.describe("When they review consultation history", () => {
+      test("Then search filters, empty state, detail navigation, and previous messages work", async ({
+        page,
+      }, testInfo) => {
+        await page.goto("/workspaces/1/consultation/history");
+
+        await expect(page.getByLabel("채팅 기록 목록")).toContainText("김민지");
+        await expect(page.getByLabel("채팅 기록 목록")).not.toContainText("이준호");
+        await expect(page.getByText("좌측 목록에서 세션을 선택해주세요")).toBeVisible();
+        expect(seen).toContain(
+          "GET /workspaces/1/consultation/sessions?status=COMPLETED&page=0&size=20",
+        );
+
+        await page.getByRole("textbox", { name: "상담 기록 검색" }).fill("배송");
+        await page.getByRole("button", { name: "검색어로 상담 기록 검색" }).click();
+        await expect(page.getByText("검색 조건에 맞는 상담 기록이 없습니다")).toBeVisible();
+        await expect
+          .poll(() =>
+            seen.some(
+              (entry) =>
+                entry.startsWith("GET /workspaces/1/consultation/sessions?") &&
+                entry.includes("status=COMPLETED") &&
+                entry.includes("keyword=%EB%B0%B0%EC%86%A1"),
+            ),
+          )
+          .toBe(true);
+
+        await page.getByLabel("검색 필터 초기화").click();
+        await expect(page.getByLabel("채팅 기록 목록")).toContainText("김민지");
+        await page.getByLabel("상태 필터").selectOption("ALL");
+        await page.getByRole("textbox", { name: "상담 기록 검색" }).fill("환불");
+        await page.getByRole("button", { name: "검색어로 상담 기록 검색" }).click();
+        await page.getByLabel("시작일 필터").fill("2026-06-01");
+        await page.getByLabel("종료일 필터").fill("2026-06-04");
+        await page.getByLabel("담당 상담사 필터").fill("7");
+
+        await expect
+          .poll(() =>
+            seen.some(
+              (entry) =>
+                entry.startsWith("GET /workspaces/1/consultation/sessions?") &&
+                !entry.includes("status=") &&
+                entry.includes("keyword=%ED%99%98%EB%B6%88") &&
+                entry.includes("startedFrom=2026-06-01") &&
+                entry.includes("startedTo=2026-06-04") &&
+                entry.includes("assignedCounselorId=7"),
+            ),
+          )
+          .toBe(true);
+
+        await page.getByRole("button", { name: /김민지/ }).click();
+        await expect(page).toHaveURL(/\/workspaces\/1\/consultation\/history\/601\?/);
+        await expect(page.getByLabel("채팅 메시지 내역")).toContainText("환불 가능한지 확인해주세요.");
+        await expect(page.getByText("2/3개 메시지")).toBeVisible();
+
+        await page.getByRole("button", { name: "이전 메시지 불러오기" }).click();
+        await expect(page.getByText("환불 상담 세션이 시작되었습니다.")).toBeVisible();
+        await expect(page.getByText("3/3개 메시지")).toBeVisible();
+        expect(seen).toContain("GET /consultation/sessions/601/messages?page=1&size=50");
+        await captureScreen(page, testInfo, "consultation-history");
+      });
+    });
+
+    test.describe("When they upload consultation logs and enter pipeline review", () => {
+      test("Then upload, generation, review navigation, and domain confirmation are verified", async ({
+        page,
+      }, testInfo) => {
+        await page.goto("/workspaces/1/upload");
+        await expect(page.getByRole("heading", { name: "상담 로그 업로드" })).toBeVisible();
+
+        await page.locator('input[type="file"]').setInputFiles({
+          name: "refund-log.zip",
+          mimeType: "application/zip",
+          buffer: Buffer.from("PK\u0003\u0004-e2e"),
+        });
+        await page.getByRole("button", { name: "처리 시작" }).click();
+        await expect(page.getByText("업로드 완료").first()).toBeVisible();
+        await page.getByRole("button", { name: "도메인팩 초안 생성 시작" }).click();
+        await expect(page.getByText("생성 요청 완료", { exact: true })).toBeVisible();
+        await page.getByRole("button", { name: "검토 화면으로 이동" }).click();
+
+        await expect(page).toHaveURL(/\/workspaces\/1\/pipeline-jobs\/900\/review/);
+        await expect(page.getByText("상담 도메인을 확정합니다.")).toBeVisible();
+        await expect(page.getByText("환불/결제 도메인")).toBeVisible();
+        await captureScreen(page, testInfo, "pipeline-domain-review");
+
+        await page.getByRole("button", { name: /환불\/결제 도메인/ }).click();
+        await expect
+          .poll(() =>
+            seen.includes(
+              "POST /workspaces/1/pipeline-jobs/900/review-checkpoint/domain-confirmation",
+            ),
+          )
+          .toBe(true);
+        expect(seen).toContain("POST /workspaces/1/datasets/uploads:init");
+        expect(seen).toContain("PUT /e2e-upload/raw-log.zip");
+        expect(seen).toContain("POST /workspaces/1/datasets/uploads/77:complete");
+        expect(seen).toContain(
+          "POST /workspaces/1/datasets/77/pipeline-jobs/domain-pack-generation",
+        );
+      });
+    });
+
+    test.describe("When they resolve a human feedback checkpoint", () => {
+      test("Then the decision draft is submitted for replay", async ({ page }) => {
+        await page.goto("/workspaces/1/pipeline-jobs/901/review");
+        await expect(page.getByText("애매한 클러스터 경계를 확인합니다.")).toBeVisible();
+
+        await page.getByRole("button", { name: "분리하기" }).click();
+        await page.getByRole("button", { name: "피드백 반영 후 replay" }).click();
+
+        await expect
+          .poll(() =>
+            seen.includes("POST /workspaces/1/pipeline-jobs/901/review-checkpoint/human-feedback"),
+          )
+          .toBe(true);
+      });
+    });
+
+    test.describe("When they run a simulation and save feedback", () => {
+      test("Then runtime state, feedback, and improvement candidate actions work", async ({
+        page,
+      }, testInfo) => {
+        await page.goto("/workspaces/1/simulation");
+        await expect(page.getByRole("heading", { name: "상담 시뮬레이션" })).toBeVisible();
+
+        await page.getByLabel("고객 이름").fill("최시뮬");
+        await page.getByLabel("시작 workflow 선택").selectOption("401");
+        await page.getByRole("button", { name: "세션 생성" }).click();
+        await expect(page.getByLabel("시뮬레이션 대화")).toContainText(
+          "환불 처리 기준으로 응답합니다.",
+        );
+
+        await page.getByPlaceholder("고객 역할 메시지 입력").fill("환불 가능한가요?");
+        await page.getByRole("button", { name: "전송" }).click();
+        await expect(page.getByText("주문번호를 알려주시면 환불 가능 여부")).toBeVisible();
+
+        await page.getByLabel("Turn 2 피드백 대상 선택").click();
+        await page.getByLabel("피드백 유형 선택").selectOption("MISSING_SLOT_QUESTION");
+        await page.getByLabel("피드백 심각도 선택").selectOption("HIGH");
+        await page.getByLabel("설명").fill("분류가 흔들립니다.");
+        await page.getByLabel("기대 응답/행동").fill("환불 문의로 고정해야 합니다.");
+        await page.getByRole("button", { name: "피드백 저장" }).click();
+        await expect(page.getByText("시뮬레이션 피드백을 남겼습니다.")).toBeVisible();
+        expect(seen).toContain(
+          "POST /workspaces/1/simulation/sessions/8801/feedback",
+        );
+
+        await page.getByRole("button", { name: "후보" }).click();
+        await expect(page.getByText("intent 설명/예시")).toBeVisible();
+        await page.getByRole("button", { name: "리뷰 요청" }).click();
+        await expect(page.getByText("개선 후보 상태를 변경했습니다.")).toBeVisible();
+        expect(latestSeen(seen, "PATCH /workspaces/1/simulation/improvement-candidates/9911/status")).toBe(
+          "PATCH /workspaces/1/simulation/improvement-candidates/9911/status",
+        );
+        await captureScreen(page, testInfo, "workspace-simulation");
+      });
+    });
+  });
+});

--- a/frontend/e2e/workspace-create.spec.ts
+++ b/frontend/e2e/workspace-create.spec.ts
@@ -77,12 +77,12 @@ test.describe("Workspace creation", () => {
 
         await page.goto("/workspaces");
         await expect(page.getByRole("heading", { name: "워크스페이스 생성" })).toBeVisible();
-        await page.getByLabel("이름").fill("QA Workspace");
+        await page.getByLabel("제목").fill("QA Workspace");
         await page.getByRole("button", { name: "생성" }).click();
 
-        await expect(page).toHaveURL(/\/workspaces\/777\/workflows/);
+        await expect(page).toHaveURL(/\/workspaces\/777\/upload/);
         await expect(page.getByText("워크스페이스를 생성했습니다.")).toBeVisible();
-        await expect(page.getByText("워크플로우")).toBeVisible();
+        await expect(page.getByRole("heading", { name: "상담 로그 업로드" })).toBeVisible();
         expect(seen).toContain("POST /workspaces");
       });
     });

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -23,5 +23,6 @@ export default defineConfig({
     command: "pnpm build && pnpm preview --host 127.0.0.1 --port 3000",
     url: "http://localhost:3000",
     reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
   },
 });

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -105,7 +105,7 @@ export function App() {
           <Route path="dashboard" element={<WorkspaceDashboardPage />} />
           <Route path="workflows" element={<WorkspaceWorkflowsPage />} />
           <Route path="simulation" element={<WorkspaceSimulationPage />} />
-          <Route path="pipeline" element={<Navigate to="upload" replace />} />
+          <Route path="pipeline" element={<Navigate to="../upload" replace />} />
           <Route path="consultation/history" element={<ChatHistoryPage />} />
           <Route path="consultation/history/:sessionId" element={<ChatHistoryPage />} />
           <Route path="consultation" element={<ConsultationPage />} />

--- a/frontend/src/entities/workflow/api/useListAllWorkspaceWorkflows.test.ts
+++ b/frontend/src/entities/workflow/api/useListAllWorkspaceWorkflows.test.ts
@@ -65,7 +65,7 @@ describe("useListAllWorkspaceWorkflows", () => {
     expect(mockedListDomainPacks).not.toHaveBeenCalled();
   });
 
-  it("모든 pack의 latest version 워크플로우를 평면 entry로 반환한다", async () => {
+  it("모든 pack의 운영 버전 워크플로우를 평면 entry로 반환한다", async () => {
     mockedListDomainPacks.mockResolvedValue({
       data: [
         { packId: 11, name: "CS Support" },
@@ -77,9 +77,11 @@ describe("useListAllWorkspaceWorkflows", () => {
         return Promise.resolve({
           data: {
             packId: 11,
+            currentVersionId: 51,
             versions: [
-              { versionId: 50, versionNo: 1 },
-              { versionId: 51, versionNo: 2 },
+              { versionId: 50, versionNo: 1, lifecycleStatus: "PUBLISHED" },
+              { versionId: 51, versionNo: 2, lifecycleStatus: "PUBLISHED" },
+              { versionId: 52, versionNo: 3, lifecycleStatus: "DRAFT" },
             ],
           },
         }) as never;
@@ -87,7 +89,8 @@ describe("useListAllWorkspaceWorkflows", () => {
       return Promise.resolve({
         data: {
           packId: 12,
-          versions: [{ versionId: 80, versionNo: 1 }],
+          currentVersionId: 80,
+          versions: [{ versionId: 80, versionNo: 1, lifecycleStatus: "PUBLISHED" }],
         },
       }) as never;
     });

--- a/frontend/src/entities/workflow/api/useListAllWorkspaceWorkflows.ts
+++ b/frontend/src/entities/workflow/api/useListAllWorkspaceWorkflows.ts
@@ -32,9 +32,19 @@ interface UseListAllWorkspaceWorkflowsParams {
   workspaceId: number | null;
 }
 
-function pickLatestVersionId(detail: DomainPackDetailResult | undefined): number | null {
+function pickWorkspaceWorkflowVersionId(detail: DomainPackDetailResult | undefined): number | null {
   if (!detail?.versions || detail.versions.length === 0) return null;
+  if (
+    typeof detail.currentVersionId === "number" &&
+    detail.versions.some((version) => version.versionId === detail.currentVersionId)
+  ) {
+    return detail.currentVersionId;
+  }
+
   const sorted = [...detail.versions].sort((a, b) => (b.versionNo ?? 0) - (a.versionNo ?? 0));
+  const published = sorted.find((version) => version.lifecycleStatus === "PUBLISHED");
+  if (published?.versionId != null) return published.versionId;
+
   return sorted[0]?.versionId ?? null;
 }
 
@@ -65,7 +75,7 @@ export function useListAllWorkspaceWorkflows({
 
   const packVersionPairs = packs.map((pack, idx) => {
     const detail = selectApiData<DomainPackDetailResult>(detailQueries[idx]?.data);
-    return { pack, versionId: pickLatestVersionId(detail) };
+    return { pack, versionId: pickWorkspaceWorkflowVersionId(detail) };
   });
 
   const workflowQueries = useQueries({

--- a/frontend/src/features/cancel-subscription/ui/CancelSubscriptionButton.test.tsx
+++ b/frontend/src/features/cancel-subscription/ui/CancelSubscriptionButton.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, within } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { toast } from "sonner";
 import { CancelSubscriptionButton } from "./CancelSubscriptionButton";
@@ -16,10 +16,10 @@ const mockToastSuccess = vi.mocked(toast.success);
 const mockToastError = vi.mocked(toast.error);
 
 function clickConfirmButton() {
-  fireEvent.click(screen.getByRole("button", { name: "해지" }));
-  const allButtons = screen.getAllByRole("button");
-  const confirmBtn = allButtons.find((b) => b.textContent === "해지" && b !== allButtons[0]);
-  if (confirmBtn) fireEvent.click(confirmBtn);
+  fireEvent.click(screen.getByRole("button", { name: "구독 해지" }));
+  fireEvent.click(
+    within(screen.getByRole("alertdialog")).getByRole("button", { name: "구독 해지" }),
+  );
 }
 
 describe("CancelSubscriptionButton", () => {
@@ -35,18 +35,18 @@ describe("CancelSubscriptionButton", () => {
 
   it("구독 해지 버튼을 렌더링한다", () => {
     render(<CancelSubscriptionButton workspaceId={1} />);
-    expect(screen.getByText("해지")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "구독 해지" })).toBeTruthy();
   });
 
   it("버튼 클릭 시 다이얼로그가 열린다", () => {
     render(<CancelSubscriptionButton workspaceId={1} />);
-    fireEvent.click(screen.getByRole("button", { name: "해지" }));
+    fireEvent.click(screen.getByRole("button", { name: "구독 해지" }));
     expect(screen.getByText("구독을 해지할까요?")).toBeTruthy();
   });
 
   it("다이얼로그의 닫기 버튼으로 닫힌다", () => {
     render(<CancelSubscriptionButton workspaceId={1} />);
-    fireEvent.click(screen.getByRole("button", { name: "해지" }));
+    fireEvent.click(screen.getByRole("button", { name: "구독 해지" }));
     fireEvent.click(screen.getByRole("button", { name: "닫기" }));
   });
 
@@ -56,7 +56,7 @@ describe("CancelSubscriptionButton", () => {
       isPending: true,
     } as never);
     render(<CancelSubscriptionButton workspaceId={1} />);
-    fireEvent.click(screen.getByRole("button", { name: "해지" }));
+    fireEvent.click(screen.getByRole("button", { name: "구독 해지" }));
     expect(screen.getByText("처리 중…")).toBeTruthy();
   });
 

--- a/frontend/src/features/cancel-subscription/ui/CancelSubscriptionButton.tsx
+++ b/frontend/src/features/cancel-subscription/ui/CancelSubscriptionButton.tsx
@@ -63,7 +63,7 @@ export function CancelSubscriptionButton({ workspaceId }: CancelSubscriptionButt
         className="h-11 rounded-full px-9! border-[var(--danger)] text-[var(--danger)] hover:border-[var(--danger)] hover:bg-[var(--danger-bg)] hover:text-[var(--danger)]"
         onClick={() => setOpen(true)}
       >
-        해지
+        구독 해지
       </Button>
       <AlertDialog open={open} onOpenChange={setOpen}>
         <AlertDialogContent>
@@ -82,7 +82,7 @@ export function CancelSubscriptionButton({ workspaceId }: CancelSubscriptionButt
               닫기
             </Button>
             <Button type="button" onClick={handleConfirm} disabled={cancel.isPending}>
-              {cancel.isPending ? "처리 중…" : "해지"}
+              {cancel.isPending ? "처리 중…" : "구독 해지"}
             </Button>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/frontend/src/features/consultation/ui/queue-panel.module.css
+++ b/frontend/src/features/consultation/ui/queue-panel.module.css
@@ -42,8 +42,8 @@
 }
 
 .searchBox:focus-within {
-  border-color: var(--ink);
-  box-shadow: var(--focus-ring);
+  border-color: rgba(0, 0, 0, 0.48);
+  box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.08);
 }
 
 .searchIcon {

--- a/frontend/src/features/update-policy/api/__tests__/useUpdatePolicy.test.ts
+++ b/frontend/src/features/update-policy/api/__tests__/useUpdatePolicy.test.ts
@@ -100,6 +100,37 @@ describe("useUpdatePolicy", () => {
     await waitFor(() => expect(toast.success).toHaveBeenCalledWith("응대 기준이 수정되었습니다."));
   });
 
+  it("성공 시 raw API response 형태로 저장된 목록 캐시도 갱신한다", async () => {
+    const updatedPolicy = { ...stubPolicy, name: "새 정책", severity: "CRITICAL" };
+    mockedUpdatePolicy.mockResolvedValue({
+      data: updatedPolicy,
+      status: 200,
+      headers: new Headers(),
+    });
+    const { wrapper, queryClient } = makeWrapperWithClient();
+    queryClient.setQueryData(policyKeys.list(1, 2, 3), {
+      data: [stubPolicy],
+      status: 200,
+    });
+    const { result } = renderHook(() => useUpdatePolicy(), { wrapper });
+
+    act(() => {
+      result.current.mutate({ ...params, body: { name: "새 정책" } });
+    });
+
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith("응대 기준이 수정되었습니다."));
+    expect(queryClient.getQueryData(policyKeys.list(1, 2, 3))).toEqual({
+      data: [
+        expect.objectContaining({
+          id: 4,
+          name: "새 정책",
+          severity: "CRITICAL",
+        }),
+      ],
+      status: 200,
+    });
+  });
+
   it("POLICY_NOT_EDITABLE 에러 시 전용 안내 메시지를 표시한다", async () => {
     mockedUpdatePolicy.mockRejectedValue(
       new ApiRequestError(400, "POLICY_NOT_EDITABLE", "수정 불가"),
@@ -176,6 +207,43 @@ describe("useUpdatePolicyStatus", () => {
       )?.status,
     ).toBe("INACTIVE");
     expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+
+  it("성공 시 raw API response 형태로 저장된 목록 캐시 상태도 갱신한다", async () => {
+    mockedUpdatePolicyStatus.mockResolvedValue({
+      data: {
+        ...stubPolicy,
+        description: undefined,
+        status: "INACTIVE",
+        updatedAt: "2026-04-17T10:00:00Z",
+      },
+      status: 200,
+      headers: new Headers(),
+    });
+    const { wrapper, queryClient } = makeWrapperWithClient();
+    const listKey = policyKeys.list(params.workspaceId, params.packId, params.versionId);
+    queryClient.setQueryData(listKey, {
+      data: [stubPolicy],
+      status: 200,
+    });
+
+    const { result } = renderHook(() => useUpdatePolicyStatus(), { wrapper });
+
+    act(() => {
+      result.current.mutate({ ...params, status: "INACTIVE" });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(queryClient.getQueryData(listKey)).toEqual({
+      data: [
+        expect.objectContaining({
+          id: 4,
+          status: "INACTIVE",
+          updatedAt: "2026-04-17T10:00:00Z",
+        }),
+      ],
+      status: 200,
+    });
   });
 
   it("POLICY_CODE_REFERENCED_BY_WORKFLOW 오류 시 rollback 후 전용 메시지를 표시한다", async () => {

--- a/frontend/src/features/update-policy/api/useUpdatePolicy.ts
+++ b/frontend/src/features/update-policy/api/useUpdatePolicy.ts
@@ -13,6 +13,10 @@ interface UpdatePolicyParams {
   body: UpdatePolicyRequest;
 }
 
+type PolicyListCache =
+  | PolicyDefinitionSummary[]
+  | ({ data?: PolicyDefinitionSummary[] } & Record<string, unknown>);
+
 export function useUpdatePolicy() {
   const queryClient = useQueryClient();
 
@@ -27,21 +31,9 @@ export function useUpdatePolicy() {
         policyQueryKeys.detail(workspaceId, packId, versionId, policyId),
         updatedPolicy,
       );
-      queryClient.setQueryData<PolicyDefinitionSummary[]>(
+      queryClient.setQueryData<PolicyListCache>(
         policyQueryKeys.list(workspaceId, packId, versionId),
-        (old) =>
-          old?.map((item) =>
-            item.id === policyId
-              ? {
-                  ...item,
-                  name: updatedPolicy.name,
-                  description: updatedPolicy.description,
-                  severity: updatedPolicy.severity,
-                  status: updatedPolicy.status,
-                  updatedAt: updatedPolicy.updatedAt,
-                }
-              : item,
-          ),
+        (old) => updatePolicyListCache(old, policyId, updatedPolicy),
       );
       toast.success("응대 기준이 수정되었습니다.");
     },
@@ -59,4 +51,32 @@ export function useUpdatePolicy() {
       toast.error(POLICY_ERROR_MESSAGES.UPDATE_FAILED);
     },
   });
+}
+
+function updatePolicyListCache<T extends PolicyListCache | undefined>(
+  old: T,
+  policyId: number,
+  updatedPolicy: PolicyDefinitionSummary,
+): T {
+  const updateItem = (item: PolicyDefinitionSummary): PolicyDefinitionSummary =>
+    item.id === policyId
+      ? {
+          ...item,
+          name: updatedPolicy.name,
+          description: updatedPolicy.description,
+          severity: updatedPolicy.severity,
+          status: updatedPolicy.status,
+          updatedAt: updatedPolicy.updatedAt,
+        }
+      : item;
+
+  if (Array.isArray(old)) {
+    return old.map(updateItem) as T;
+  }
+
+  if (old && typeof old === "object" && Array.isArray(old.data)) {
+    return { ...old, data: old.data.map(updateItem) } as T;
+  }
+
+  return old;
 }

--- a/frontend/src/features/update-policy/api/useUpdatePolicyStatus.ts
+++ b/frontend/src/features/update-policy/api/useUpdatePolicyStatus.ts
@@ -17,6 +17,13 @@ interface UpdatePolicyStatusParams {
   status: UpdatePolicyStatusRequest["status"];
 }
 
+type PolicyListCache =
+  | PolicyDefinitionSummary[]
+  | ({ data?: PolicyDefinitionSummary[] } & Record<string, unknown>);
+
+type PolicyStatusPatch = Pick<PolicyDefinitionSummary, "status"> &
+  Partial<Pick<PolicyDefinitionSummary, "updatedAt">>;
+
 export const UPDATE_POLICY_STATUS_MUTATION_KEY = ["updatePolicyStatus"] as const;
 
 export function useUpdatePolicyStatus() {
@@ -45,13 +52,13 @@ export function useUpdatePolicyStatus() {
       await queryClient.cancelQueries({ queryKey: listKey });
 
       const previousDetail = queryClient.getQueryData<PolicyDefinitionResponse>(detailKey);
-      const previousList = queryClient.getQueryData<PolicyDefinitionSummary[]>(listKey);
+      const previousList = queryClient.getQueryData<PolicyListCache>(listKey);
 
       queryClient.setQueryData<PolicyDefinitionResponse>(detailKey, (old) =>
         old ? { ...old, status } : old,
       );
-      queryClient.setQueryData<PolicyDefinitionSummary[]>(listKey, (old) =>
-        old?.map((item) => (item.id === policyId ? { ...item, status } : item)),
+      queryClient.setQueryData<PolicyListCache>(listKey, (old) =>
+        updatePolicyStatusListCache(old, policyId, { status }),
       );
 
       return { previousDetail, previousList, detailKey, listKey };
@@ -80,19 +87,35 @@ export function useUpdatePolicyStatus() {
         policyQueryKeys.detail(workspaceId, packId, versionId, policyId),
         updatedPolicy,
       );
-      queryClient.setQueryData<PolicyDefinitionSummary[]>(
+      queryClient.setQueryData<PolicyListCache>(
         policyQueryKeys.list(workspaceId, packId, versionId),
-        (old) =>
-          old?.map((item) =>
-            item.id === policyId
-              ? {
-                  ...item,
-                  status: updatedPolicy.status,
-                  updatedAt: updatedPolicy.updatedAt,
-                }
-              : item,
-          ),
+        (old) => updatePolicyStatusListCache(old, policyId, updatedPolicy),
       );
     },
   });
+}
+
+function updatePolicyStatusListCache<T extends PolicyListCache | undefined>(
+  old: T,
+  policyId: number,
+  patch: PolicyStatusPatch,
+): T {
+  const updateItem = (item: PolicyDefinitionSummary): PolicyDefinitionSummary =>
+    item.id === policyId
+      ? {
+          ...item,
+          status: patch.status,
+          updatedAt: patch.updatedAt ?? item.updatedAt,
+        }
+      : item;
+
+  if (Array.isArray(old)) {
+    return old.map(updateItem) as T;
+  }
+
+  if (old && typeof old === "object" && Array.isArray(old.data)) {
+    return { ...old, data: old.data.map(updateItem) } as T;
+  }
+
+  return old;
 }

--- a/frontend/src/features/update-policy/ui/PolicyEditForm.tsx
+++ b/frontend/src/features/update-policy/ui/PolicyEditForm.tsx
@@ -11,6 +11,7 @@ import { useUpdatePolicy } from "../api/useUpdatePolicy";
 import { UPDATE_POLICY_STATUS_MUTATION_KEY } from "../api/useUpdatePolicyStatus";
 import { PolicyJsonFields } from "./PolicyJsonFields";
 import { PolicyStatusToggle } from "./PolicyStatusToggle";
+import styles from "./policy-edit-form.module.css";
 import type { PolicyDefinition, UpdatePolicyRequest } from "@/entities/policy";
 
 const SEVERITY_OPTIONS = ["LOW", "MEDIUM", "HIGH", "CRITICAL"] as const;
@@ -76,7 +77,16 @@ export function PolicyEditForm({
 
   return (
     <Form {...form}>
-      <form onSubmit={form.handleSubmit(onSubmit)} className="flex w-full flex-col gap-4">
+      <form onSubmit={form.handleSubmit(onSubmit)} className={styles.form}>
+        <div className={styles.actionBar}>
+          <Button type="button" variant="outline" onClick={onClose} disabled={isAnyPending}>
+            취소
+          </Button>
+          <Button type="submit" disabled={isAnyPending}>
+            저장
+          </Button>
+        </div>
+
         {textFields.map((textField) => (
           <FormField
             key={textField.name}
@@ -143,7 +153,7 @@ export function PolicyEditForm({
 
         <PolicyJsonFields />
 
-        <div className="flex flex-row items-center justify-between border-t pt-4">
+        <div className={styles.statusRow}>
           <span className="text-sm font-medium leading-none">상태</span>
           <PolicyStatusToggle
             workspaceId={workspaceId}
@@ -153,15 +163,6 @@ export function PolicyEditForm({
             currentStatus={(policy.status ?? "INACTIVE") as "ACTIVE" | "INACTIVE"}
             disabled={isAnyPending}
           />
-        </div>
-
-        <div className="flex gap-2 justify-end border-t pt-4">
-          <Button type="button" variant="outline" onClick={onClose} disabled={isAnyPending}>
-            취소
-          </Button>
-          <Button type="submit" disabled={isAnyPending}>
-            저장
-          </Button>
         </div>
       </form>
     </Form>

--- a/frontend/src/features/update-policy/ui/PolicyJsonFields.tsx
+++ b/frontend/src/features/update-policy/ui/PolicyJsonFields.tsx
@@ -1,6 +1,7 @@
 import { useFormContext } from "react-hook-form";
 import { FormField, FormItem, FormLabel, FormControl, FormMessage } from "@/shared/ui/form";
 import { JsonTextarea } from "./JsonTextarea";
+import styles from "./policy-json-fields.module.css";
 import type { PolicyEditFormValues } from "../model/schema";
 
 const JSON_FIELDS: ReadonlyArray<
@@ -22,7 +23,7 @@ export function PolicyJsonFields() {
   const { control } = useFormContext<PolicyEditFormValues>();
 
   return (
-    <>
+    <div className={styles.grid}>
       {JSON_FIELDS.map((jsonField) => (
         <FormField
           key={jsonField.name}
@@ -39,6 +40,6 @@ export function PolicyJsonFields() {
           )}
         />
       ))}
-    </>
+    </div>
   );
 }

--- a/frontend/src/features/update-policy/ui/policy-edit-form.module.css
+++ b/frontend/src/features/update-policy/ui/policy-edit-form.module.css
@@ -1,0 +1,27 @@
+.form {
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.actionBar {
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding-bottom: 16px;
+  background: var(--bg-color);
+  border-bottom: 1px solid var(--glass-border);
+}
+
+.statusRow {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  border-top: 1px solid var(--glass-border);
+  padding-top: 16px;
+}

--- a/frontend/src/features/update-policy/ui/policy-json-fields.module.css
+++ b/frontend/src/features/update-policy/ui/policy-json-fields.module.css
@@ -1,0 +1,11 @@
+.grid {
+  display: grid;
+  gap: 16px;
+}
+
+@media (min-width: 960px) {
+  .grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    align-items: start;
+  }
+}

--- a/frontend/src/features/update-risk/api/useUpdateRisk.test.ts
+++ b/frontend/src/features/update-risk/api/useUpdateRisk.test.ts
@@ -31,7 +31,20 @@ function makeWrapper() {
     React.createElement(QueryClientProvider, { client: queryClient }, children);
 }
 
+function makeWrapperWithClient() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+
+  return { wrapper, queryClient };
+}
+
 const params = { workspaceId: 1, packId: 2, versionId: 3, riskId: 4 };
+const riskKeys = {
+  list: (...args: number[]) => ["risk", "list", ...args] as const,
+};
 
 const stubRisk = {
   id: 4,
@@ -72,6 +85,40 @@ describe("useUpdateRisk", () => {
     });
 
     await waitFor(() => expect(toast.success).toHaveBeenCalledWith("주의 사항이 수정되었습니다."));
+  });
+
+  it("성공 시 raw API response 형태로 저장된 목록 캐시도 갱신한다", async () => {
+    const updatedRisk = { ...stubRisk, name: "새 위험요소", riskLevel: "CRITICAL" };
+    mockedUpdateRisk.mockResolvedValue({
+      data: updatedRisk,
+      status: 200,
+      headers: new Headers(),
+    });
+    const { wrapper, queryClient } = makeWrapperWithClient();
+    queryClient.setQueryData(riskKeys.list(1, 2, 3), {
+      data: [stubRisk],
+      status: 200,
+    });
+    const { result } = renderHook(() => useUpdateRisk(), { wrapper });
+
+    act(() => {
+      result.current.mutate({
+        ...params,
+        body: { name: "새 위험요소", riskLevel: "CRITICAL" },
+      });
+    });
+
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith("주의 사항이 수정되었습니다."));
+    expect(queryClient.getQueryData(riskKeys.list(1, 2, 3))).toEqual({
+      data: [
+        expect.objectContaining({
+          id: 4,
+          name: "새 위험요소",
+          riskLevel: "CRITICAL",
+        }),
+      ],
+      status: 200,
+    });
   });
 
   it("수정 응답 data가 없으면 성공 처리하지 않고 실패 메시지를 표시한다", async () => {

--- a/frontend/src/features/update-risk/api/useUpdateRisk.ts
+++ b/frontend/src/features/update-risk/api/useUpdateRisk.ts
@@ -17,6 +17,10 @@ interface UpdateRiskParams {
   body: UpdateRiskRequest;
 }
 
+type RiskListCache =
+  | RiskDefinitionSummary[]
+  | ({ data?: RiskDefinitionSummary[] } & Record<string, unknown>);
+
 export function useUpdateRisk() {
   const queryClient = useQueryClient();
 
@@ -33,21 +37,9 @@ export function useUpdateRisk() {
         riskQueryKeys.detail(workspaceId, packId, versionId, riskId),
         updatedRisk,
       );
-      queryClient.setQueryData<RiskDefinitionSummary[]>(
+      queryClient.setQueryData<RiskListCache>(
         riskQueryKeys.list(workspaceId, packId, versionId),
-        (old) =>
-          old?.map((item) =>
-            item.id === riskId
-              ? {
-                  ...item,
-                  name: updatedRisk.name,
-                  description: updatedRisk.description,
-                  riskLevel: updatedRisk.riskLevel,
-                  status: updatedRisk.status,
-                  updatedAt: updatedRisk.updatedAt,
-                }
-              : item,
-          ),
+        (old) => updateRiskListCache(old, riskId, updatedRisk),
       );
       toast.success("주의 사항이 수정되었습니다.");
     },
@@ -65,4 +57,32 @@ export function useUpdateRisk() {
       toast.error(RISK_ERROR_MESSAGES.UPDATE_FAILED);
     },
   });
+}
+
+function updateRiskListCache<T extends RiskListCache | undefined>(
+  old: T,
+  riskId: number,
+  updatedRisk: RiskDefinitionSummary,
+): T {
+  const updateItem = (item: RiskDefinitionSummary): RiskDefinitionSummary =>
+    item.id === riskId
+      ? {
+          ...item,
+          name: updatedRisk.name,
+          description: updatedRisk.description,
+          riskLevel: updatedRisk.riskLevel,
+          status: updatedRisk.status,
+          updatedAt: updatedRisk.updatedAt,
+        }
+      : item;
+
+  if (Array.isArray(old)) {
+    return old.map(updateItem) as T;
+  }
+
+  if (old && typeof old === "object" && Array.isArray(old.data)) {
+    return { ...old, data: old.data.map(updateItem) } as T;
+  }
+
+  return old;
 }

--- a/frontend/src/features/update-risk/api/useUpdateRiskStatus.test.ts
+++ b/frontend/src/features/update-risk/api/useUpdateRiskStatus.test.ts
@@ -47,7 +47,7 @@ const stubRisk: RiskDefinition = {
   domainPackVersionId: 3,
   riskCode: "RISK_FRAUD",
   name: "사기 위험",
-  description: undefined as any,
+  description: null,
   riskLevel: "HIGH",
   triggerConditionJson: "{}",
   handlingActionJson: "{}",
@@ -66,8 +66,9 @@ describe("useUpdateRiskStatus", () => {
   });
 
   it("성공 시 detail/list query cache를 갱신한다", async () => {
+    const updatedRisk: RiskDefinition = { ...stubRisk, status: "INACTIVE" };
     mockedUpdateRiskStatus.mockResolvedValue({
-      data: { ...stubRisk, status: "INACTIVE" } as any,
+      data: updatedRisk,
       status: 200,
       headers: new Headers(),
     });
@@ -91,6 +92,74 @@ describe("useUpdateRiskStatus", () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(queryClient.getQueryData<RiskDefinition>(detailKey)?.status).toBe("INACTIVE");
     expect(queryClient.getQueryData<RiskSummary[]>(listKey)?.[0]?.status).toBe("INACTIVE");
+  });
+
+  it("성공 시 raw API response 형태로 저장된 목록 캐시 상태도 갱신한다", async () => {
+    const updatedRisk: RiskDefinition = {
+      ...stubRisk,
+      status: "INACTIVE",
+      updatedAt: "2026-04-17T10:00:00Z",
+    };
+    mockedUpdateRiskStatus.mockResolvedValue({
+      data: updatedRisk,
+      status: 200,
+      headers: new Headers(),
+    });
+    const { wrapper, queryClient } = makeWrapperWithClient();
+    const listKey = riskKeys.list(params.workspaceId, params.packId, params.versionId);
+    queryClient.setQueryData(listKey, {
+      data: [stubRisk],
+      status: 200,
+    });
+
+    const { result } = renderHook(() => useUpdateRiskStatus(), { wrapper });
+
+    act(() => {
+      result.current.mutate({ ...params, status: "INACTIVE" });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(queryClient.getQueryData(listKey)).toEqual({
+      data: [
+        expect.objectContaining({
+          id: 4,
+          status: "INACTIVE",
+          updatedAt: "2026-04-17T10:00:00Z",
+        }),
+      ],
+      status: 200,
+    });
+  });
+
+  it("상태 변경 응답 data가 없으면 rollback 후 실패 메시지를 표시한다", async () => {
+    mockedUpdateRiskStatus.mockResolvedValue({
+      data: undefined,
+      status: 200,
+      headers: new Headers(),
+    } as Awaited<ReturnType<typeof updateRiskStatus>>);
+    const { wrapper, queryClient } = makeWrapperWithClient();
+    const detailKey = riskKeys.detail(
+      params.workspaceId,
+      params.packId,
+      params.versionId,
+      params.riskId,
+    );
+    const listKey = riskKeys.list(params.workspaceId, params.packId, params.versionId);
+    queryClient.setQueryData<RiskDefinition>(detailKey, stubRisk);
+    queryClient.setQueryData<RiskSummary[]>(listKey, [stubRisk]);
+
+    const { result } = renderHook(() => useUpdateRiskStatus(), { wrapper });
+
+    act(() => {
+      result.current.mutate({ ...params, status: "INACTIVE" });
+    });
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(RISK_ERROR_MESSAGES.STATUS_FAILED),
+    );
+    expect(result.current.isError).toBe(true);
+    expect(queryClient.getQueryData<RiskDefinition>(detailKey)?.status).toBe("ACTIVE");
+    expect(queryClient.getQueryData<RiskSummary[]>(listKey)?.[0]?.status).toBe("ACTIVE");
   });
 
   it("RISK_NOT_EDITABLE 오류 시 rollback 후 전용 메시지를 표시한다", async () => {

--- a/frontend/src/features/update-risk/api/useUpdateRiskStatus.ts
+++ b/frontend/src/features/update-risk/api/useUpdateRiskStatus.ts
@@ -6,7 +6,7 @@ import type {
   RiskDefinitionSummary,
   UpdateRiskStatusRequest,
 } from "@/shared/api/generated/zod";
-import { ApiRequestError, riskQueryKeys, selectApiData } from "@/shared/api";
+import { ApiRequestError, requireApiData, riskQueryKeys } from "@/shared/api";
 import { RISK_ERROR_MESSAGES } from "./messages";
 
 interface UpdateRiskStatusParams {
@@ -16,6 +16,13 @@ interface UpdateRiskStatusParams {
   riskId: number;
   status: UpdateRiskStatusRequest["status"];
 }
+
+type RiskListCache =
+  | RiskDefinitionSummary[]
+  | ({ data?: RiskDefinitionSummary[] } & Record<string, unknown>);
+
+type RiskStatusPatch = Pick<RiskDefinitionSummary, "status"> &
+  Partial<Pick<RiskDefinitionSummary, "updatedAt">>;
 
 export const UPDATE_RISK_STATUS_MUTATION_KEY = ["updateRiskStatus"] as const;
 
@@ -32,7 +39,10 @@ export function useUpdateRiskStatus() {
       status,
     }: UpdateRiskStatusParams) => {
       const res = await updateRiskStatus(workspaceId, packId, versionId, riskId, { status });
-      return selectApiData(res);
+      return requireApiData<RiskDefinitionResponse>(
+        res,
+        "주의 사항 상태 변경 응답을 확인할 수 없습니다.",
+      );
     },
     onMutate: async ({ workspaceId, packId, versionId, riskId, status }) => {
       const detailKey = riskQueryKeys.detail(workspaceId, packId, versionId, riskId);
@@ -42,13 +52,13 @@ export function useUpdateRiskStatus() {
       await queryClient.cancelQueries({ queryKey: listKey });
 
       const previousDetail = queryClient.getQueryData<RiskDefinitionResponse>(detailKey);
-      const previousList = queryClient.getQueryData<RiskDefinitionSummary[]>(listKey);
+      const previousList = queryClient.getQueryData<RiskListCache>(listKey);
 
       queryClient.setQueryData<RiskDefinitionResponse>(detailKey, (old) =>
         old ? { ...old, status } : old,
       );
-      queryClient.setQueryData<RiskDefinitionSummary[]>(listKey, (old) =>
-        old?.map((item) => (item.id === riskId ? { ...item, status } : item)),
+      queryClient.setQueryData<RiskListCache>(listKey, (old) =>
+        updateRiskStatusListCache(old, riskId, { status }),
       );
 
       return { previousDetail, previousList, detailKey, listKey };
@@ -67,24 +77,39 @@ export function useUpdateRiskStatus() {
       toast.error(RISK_ERROR_MESSAGES.STATUS_FAILED);
     },
     onSuccess: (updatedRisk, { workspaceId, packId, versionId, riskId }) => {
-      if (!updatedRisk) return;
       queryClient.setQueryData(
         riskQueryKeys.detail(workspaceId, packId, versionId, riskId),
         updatedRisk,
       );
-      queryClient.setQueryData<RiskDefinitionSummary[]>(
+      queryClient.setQueryData<RiskListCache>(
         riskQueryKeys.list(workspaceId, packId, versionId),
-        (old) =>
-          old?.map((item) =>
-            item.id === riskId
-              ? {
-                  ...item,
-                  status: updatedRisk.status,
-                  updatedAt: updatedRisk.updatedAt,
-                }
-              : item,
-          ),
+        (old) => updateRiskStatusListCache(old, riskId, updatedRisk),
       );
     },
   });
+}
+
+function updateRiskStatusListCache<T extends RiskListCache | undefined>(
+  old: T,
+  riskId: number,
+  patch: RiskStatusPatch,
+): T {
+  const updateItem = (item: RiskDefinitionSummary): RiskDefinitionSummary =>
+    item.id === riskId
+      ? {
+          ...item,
+          status: patch.status,
+          updatedAt: patch.updatedAt ?? item.updatedAt,
+        }
+      : item;
+
+  if (Array.isArray(old)) {
+    return old.map(updateItem) as T;
+  }
+
+  if (old && typeof old === "object" && Array.isArray(old.data)) {
+    return { ...old, data: old.data.map(updateItem) } as T;
+  }
+
+  return old;
 }

--- a/frontend/src/features/update-risk/ui/RiskEditForm.tsx
+++ b/frontend/src/features/update-risk/ui/RiskEditForm.tsx
@@ -13,6 +13,7 @@ import { UPDATE_RISK_STATUS_MUTATION_KEY } from "../api/useUpdateRiskStatus";
 import { RiskJsonFields } from "./RiskJsonFields";
 import { RiskStatusToggle } from "./RiskStatusToggle";
 import type { RiskDefinition, RiskLevel, UpdateRiskRequest } from "@/entities/risk";
+import styles from "./risk-edit-form.module.css";
 
 const RISK_LEVEL_OPTIONS: ReadonlyArray<RiskLevel> = ["LOW", "MEDIUM", "HIGH", "CRITICAL"];
 
@@ -64,7 +65,16 @@ export function RiskEditForm({
 
   return (
     <Form {...form}>
-      <form onSubmit={form.handleSubmit(onSubmit)} className="flex w-full flex-col gap-4">
+      <form onSubmit={form.handleSubmit(onSubmit)} className={styles.form}>
+        <div className={styles.actionBar}>
+          <Button type="button" variant="outline" onClick={onClose} disabled={isAnyPending}>
+            취소
+          </Button>
+          <Button type="submit" disabled={isAnyPending}>
+            저장
+          </Button>
+        </div>
+
         <FormField
           control={form.control}
           name="name"
@@ -131,7 +141,7 @@ export function RiskEditForm({
 
         <RiskJsonFields />
 
-        <div className="flex flex-row items-center justify-between border-t pt-4">
+        <div className={styles.statusRow}>
           <span className="text-sm font-medium leading-none">상태</span>
           <RiskStatusToggle
             workspaceId={workspaceId}
@@ -141,15 +151,6 @@ export function RiskEditForm({
             currentStatus={(risk.status ?? "INACTIVE") as "ACTIVE" | "INACTIVE"}
             disabled={isAnyPending}
           />
-        </div>
-
-        <div className="flex gap-2 justify-end border-t pt-4">
-          <Button type="button" variant="outline" onClick={onClose} disabled={isAnyPending}>
-            취소
-          </Button>
-          <Button type="submit" disabled={isAnyPending}>
-            저장
-          </Button>
         </div>
       </form>
     </Form>

--- a/frontend/src/features/update-risk/ui/RiskJsonFields.tsx
+++ b/frontend/src/features/update-risk/ui/RiskJsonFields.tsx
@@ -2,6 +2,7 @@ import type { FieldPath } from "react-hook-form";
 import { useFormContext } from "react-hook-form";
 import { JsonFormField } from "@/shared/ui/json-form-field";
 import type { RiskEditFormValues } from "../model/schema";
+import styles from "./risk-json-fields.module.css";
 
 const JSON_FIELDS = [
   { name: "triggerConditionJson", label: "트리거 조건 JSON" },
@@ -16,7 +17,7 @@ export function RiskJsonFields() {
   const { control } = useFormContext<RiskEditFormValues>();
 
   return (
-    <>
+    <div className={styles.grid}>
       {JSON_FIELDS.map((jsonField) => (
         <JsonFormField<RiskEditFormValues>
           key={jsonField.name}
@@ -25,6 +26,6 @@ export function RiskJsonFields() {
           label={jsonField.label}
         />
       ))}
-    </>
+    </div>
   );
 }

--- a/frontend/src/features/update-risk/ui/risk-edit-form.module.css
+++ b/frontend/src/features/update-risk/ui/risk-edit-form.module.css
@@ -1,0 +1,27 @@
+.form {
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.actionBar {
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding-bottom: 16px;
+  background: var(--bg-color);
+  border-bottom: 1px solid var(--glass-border);
+}
+
+.statusRow {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  border-top: 1px solid var(--glass-border);
+  padding-top: 16px;
+}

--- a/frontend/src/features/update-risk/ui/risk-json-fields.module.css
+++ b/frontend/src/features/update-risk/ui/risk-json-fields.module.css
@@ -1,0 +1,11 @@
+.grid {
+  display: grid;
+  gap: 16px;
+}
+
+@media (min-width: 960px) {
+  .grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    align-items: start;
+  }
+}

--- a/frontend/src/pages/workspace/ui/WorkspaceDashboardPage.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceDashboardPage.tsx
@@ -761,6 +761,7 @@ function DashboardFilters({
             value={filters.domainPackVersion}
             onChange={(event) => updateFilter("domainPackVersion", event.target.value)}
             aria-label="운영 지식팩 버전 필터"
+            size="sm"
           >
             {DOMAIN_PACK_VERSION_OPTIONS.map((option) => (
               <NativeSelectOption key={option.value} value={option.value}>
@@ -775,6 +776,7 @@ function DashboardFilters({
             value={filters.channel}
             onChange={(event) => updateFilter("channel", event.target.value)}
             aria-label="채널 필터"
+            size="sm"
           >
             {CHANNEL_OPTIONS.map((option) => (
               <NativeSelectOption key={option.value} value={option.value}>
@@ -789,6 +791,7 @@ function DashboardFilters({
             value={filters.workflowStatus}
             onChange={(event) => updateFilter("workflowStatus", event.target.value)}
             aria-label="워크플로우 상태 필터"
+            size="sm"
           >
             {WORKFLOW_STATUS_OPTIONS.map((option) => (
               <NativeSelectOption key={option.value} value={option.value}>

--- a/frontend/src/pages/workspace/ui/WorkspaceSimulationPage.test.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceSimulationPage.test.tsx
@@ -557,6 +557,9 @@ describe("WorkspaceSimulationPage", () => {
     expect(screen.getByText("응답 문구")).toBeInTheDocument();
     expect(screen.getAllByText("기타")).toHaveLength(2);
     expect(screen.getByText("CUSTOM")).toBeInTheDocument();
+    expect(screen.getAllByText("초안").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("변경 전").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("근거").length).toBeGreaterThan(0);
   });
 
   it("개선 후보 목록 로드 실패를 토스트로 알린다", async () => {
@@ -627,7 +630,7 @@ describe("WorkspaceSimulationPage", () => {
         reason: "시뮬레이션 리뷰 승인",
       });
     });
-    expect(toast.success).toHaveBeenCalledWith("개선 후보를 draft version에 반영했습니다.");
+    expect(toast.success).toHaveBeenCalledWith("개선 후보를 초안 버전에 반영했습니다.");
     await waitFor(() => {
       expect(mockedSimulationApi.listImprovementCandidates).toHaveBeenCalledTimes(2);
       expect(mockedSimulationApi.listFeedback).toHaveBeenCalledTimes(2);

--- a/frontend/src/pages/workspace/ui/WorkspaceSimulationPage.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceSimulationPage.tsx
@@ -58,10 +58,10 @@ const FEEDBACK_SEVERITIES: Array<{ value: SimulationFeedbackSeverity; label: str
 ];
 
 const FEEDBACK_STATUSES: Array<{ value: SimulationFeedbackStatus | ""; label: string }> = [
-  { value: "OPEN", label: "OPEN" },
-  { value: "CANDIDATE_CREATED", label: "CANDIDATE_CREATED" },
-  { value: "RESOLVED", label: "RESOLVED" },
-  { value: "DISMISSED", label: "DISMISSED" },
+  { value: "OPEN", label: "열림" },
+  { value: "CANDIDATE_CREATED", label: "후보 생성" },
+  { value: "RESOLVED", label: "해결됨" },
+  { value: "DISMISSED", label: "보류됨" },
   { value: "", label: "전체" },
 ];
 
@@ -69,10 +69,10 @@ const CANDIDATE_STATUSES: Array<{
   value: SimulationImprovementCandidateStatus | "";
   label: string;
 }> = [
-  { value: "DRAFT", label: "DRAFT" },
-  { value: "READY_FOR_REVIEW", label: "READY_FOR_REVIEW" },
-  { value: "APPLIED", label: "APPLIED" },
-  { value: "REJECTED", label: "REJECTED" },
+  { value: "DRAFT", label: "초안" },
+  { value: "READY_FOR_REVIEW", label: "리뷰 대기" },
+  { value: "APPLIED", label: "반영됨" },
+  { value: "REJECTED", label: "반려됨" },
   { value: "", label: "전체" },
 ];
 
@@ -130,6 +130,18 @@ function slotEntries(detail: SimulationSessionDetail | null) {
 
 function feedbackTypeLabel(type: SimulationFeedbackType): string {
   return FEEDBACK_TYPES.find((item) => item.value === type)?.label ?? type;
+}
+
+function feedbackSeverityLabel(severity: SimulationFeedbackSeverity): string {
+  return FEEDBACK_SEVERITIES.find((item) => item.value === severity)?.label ?? severity;
+}
+
+function feedbackStatusLabel(status: SimulationFeedbackStatus): string {
+  return FEEDBACK_STATUSES.find((item) => item.value === status)?.label ?? status;
+}
+
+function candidateStatusLabel(status: SimulationImprovementCandidateStatus): string {
+  return CANDIDATE_STATUSES.find((item) => item.value === status)?.label ?? status;
 }
 
 function candidateTypeLabel(type: SimulationImprovementCandidate["candidateType"]): string {
@@ -540,7 +552,7 @@ export function WorkspaceSimulationPage() {
       await simulationApi.approveImprovementCandidate(parsedWorkspaceId, candidate.id, {
         reason: "시뮬레이션 리뷰 승인",
       });
-      toast.success("개선 후보를 draft version에 반영했습니다.");
+      toast.success("개선 후보를 초안 버전에 반영했습니다.");
       await Promise.all([reloadCandidates(), reloadFeedback()]);
     } catch {
       toast.error("개선 후보를 승인하지 못했습니다.");
@@ -1047,7 +1059,7 @@ export function WorkspaceSimulationPage() {
 
           <div className={styles.feedbackListPanel}>
             <div className={styles.feedbackPanelHeader}>
-              <h3>Workspace Feedback</h3>
+              <h3>워크스페이스 피드백</h3>
               <NativeSelect
                 value={feedbackStatusFilter}
                 onChange={(event) =>
@@ -1074,7 +1086,8 @@ export function WorkspaceSimulationPage() {
                       <div>
                         <strong>{feedbackTypeLabel(feedback.feedbackType)}</strong>
                         <span>
-                          {feedback.severity} · {feedback.status}
+                          {feedbackSeverityLabel(feedback.severity)} ·{" "}
+                          {feedbackStatusLabel(feedback.status)}
                         </span>
                       </div>
                       <Button
@@ -1097,7 +1110,7 @@ export function WorkspaceSimulationPage() {
 
           <div className={styles.feedbackListPanel}>
             <div className={styles.feedbackPanelHeader}>
-              <h3>Improvement Candidates</h3>
+              <h3>개선 후보</h3>
               <NativeSelect
                 value={candidateStatusFilter}
                 onChange={(event) =>
@@ -1126,28 +1139,31 @@ export function WorkspaceSimulationPage() {
                       <div>
                         <strong>{candidateTypeLabel(candidate.candidateType)}</strong>
                         <span>
-                          version #{candidate.domainPackVersionId} · {candidate.targetElementType}
+                          버전 #{candidate.domainPackVersionId} · 대상:{" "}
+                          {candidate.targetElementType}
                         </span>
                       </div>
-                      <span className={styles.statusPill}>{candidate.status}</span>
+                      <span className={styles.statusPill}>
+                        {candidateStatusLabel(candidate.status)}
+                      </span>
                     </div>
                     <dl className={styles.candidateSummary}>
                       <div>
-                        <dt>Before</dt>
+                        <dt>변경 전</dt>
                         <dd>{candidate.beforeSummary}</dd>
                       </div>
                       <div>
-                        <dt>After</dt>
+                        <dt>변경 후</dt>
                         <dd>{candidate.afterSummary}</dd>
                       </div>
                       <div>
-                        <dt>Evidence</dt>
+                        <dt>근거</dt>
                         <dd>
                           {candidate.evidenceSummary}
                           <span className={styles.evidenceMeta}>
-                            session #{candidate.sessionId}
-                            {candidate.chatMessageId ? ` · turn #${candidate.chatMessageId}` : ""}
-                            {candidate.feedbackId ? ` · feedback #${candidate.feedbackId}` : ""}
+                            세션 #{candidate.sessionId}
+                            {candidate.chatMessageId ? ` · 메시지 #${candidate.chatMessageId}` : ""}
+                            {candidate.feedbackId ? ` · 피드백 #${candidate.feedbackId}` : ""}
                           </span>
                         </dd>
                       </div>

--- a/frontend/src/pages/workspace/ui/simulation/workspace-simulation-page.module.css
+++ b/frontend/src/pages/workspace/ui/simulation/workspace-simulation-page.module.css
@@ -113,15 +113,19 @@
 
 .labGrid {
   display: grid;
-  min-height: 560px;
+  height: clamp(420px, calc(100dvh - 300px), 780px);
+  min-height: 0;
   grid-template-columns: minmax(220px, 280px) minmax(360px, 1fr) minmax(260px, 340px);
   gap: var(--s-4);
+  align-items: stretch;
+  overflow: hidden;
 }
 
 .sessionPane,
 .chatPane,
 .statePane {
   min-width: 0;
+  min-height: 0;
   border: 1px solid var(--line);
   border-radius: var(--r-3);
   background: var(--paper);
@@ -130,6 +134,12 @@
 .sessionPane,
 .statePane {
   padding: var(--s-4);
+}
+
+.sessionPane {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 }
 
 .chatPane {
@@ -144,6 +154,7 @@
 }
 
 .paneHeader {
+  flex-shrink: 0;
   justify-content: space-between;
 }
 
@@ -176,9 +187,13 @@
 
 .sessionList {
   display: flex;
+  min-height: 0;
   flex-direction: column;
   gap: var(--s-2);
   margin-top: var(--s-4);
+  overflow-y: auto;
+  padding-right: 2px;
+  scrollbar-gutter: stable;
 }
 
 .sessionItem {
@@ -232,6 +247,7 @@
   overflow-y: auto;
   padding: var(--s-5);
   background: var(--paper-2);
+  scrollbar-gutter: stable;
 }
 
 .emptyMessage {
@@ -312,6 +328,7 @@
 
 .composer {
   align-items: stretch;
+  flex-shrink: 0;
   padding: var(--s-4);
   border-top: 1px solid var(--line);
 }
@@ -410,6 +427,14 @@
   margin-top: var(--s-4);
 }
 
+.statePane {
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
+}
+
 .feedbackPanelHeader {
   display: flex;
   align-items: center;
@@ -418,10 +443,12 @@
 }
 
 .feedbackPanelHeader h3 {
+  flex: 0 0 auto;
   margin: 0;
   color: var(--ink);
   font-size: 14px;
   font-weight: 540;
+  white-space: nowrap;
 }
 
 .feedbackPanelHeader span {
@@ -694,6 +721,21 @@
 
   .labGrid {
     display: flex;
+    height: auto;
+    min-height: 0;
+    overflow: visible;
     flex-direction: column;
+  }
+
+  .sessionPane,
+  .chatPane,
+  .statePane {
+    max-height: none;
+    overflow: visible;
+  }
+
+  .sessionList,
+  .messageList {
+    overflow: visible;
   }
 }

--- a/frontend/src/pages/workspace/ui/workspace-dashboard-page.module.css
+++ b/frontend/src/pages/workspace/ui/workspace-dashboard-page.module.css
@@ -1,8 +1,8 @@
 .pageWrapper {
-  padding: var(--s-6) var(--s-8) var(--s-10);
+  padding: var(--s-5) var(--s-8) var(--s-8);
   display: flex;
   flex-direction: column;
-  gap: var(--s-5);
+  gap: var(--s-4);
 }
 
 .pageHeader {
@@ -38,15 +38,16 @@
   margin: var(--s-2) 0 0;
   color: var(--ink-2);
   font-size: 14px;
-  line-height: 1.6;
+  line-height: 1.5;
   letter-spacing: 0;
 }
 
 .filterBar {
-  display: flex;
-  flex-direction: column;
-  gap: var(--s-4);
-  padding: var(--s-5);
+  display: grid;
+  grid-template-columns: minmax(220px, 0.8fr) minmax(280px, 1fr) minmax(420px, 1.45fr);
+  align-items: end;
+  gap: var(--s-3);
+  padding: var(--s-4);
   border: 1px solid var(--line);
   border-radius: var(--r-3);
   background: var(--paper);
@@ -54,6 +55,7 @@
 
 .filterHeader {
   display: flex;
+  align-self: center;
   justify-content: space-between;
   gap: var(--s-3);
 }
@@ -78,18 +80,18 @@
   margin: var(--s-1) 0 0;
   color: var(--ink-2);
   font-size: 13px;
-  line-height: 1.6;
+  line-height: 1.45;
 }
 
 .periodControl {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--s-2);
+  gap: var(--s-1);
 }
 
 .segmentButton {
-  min-height: 36px;
-  padding: 0 var(--s-4);
+  min-height: 32px;
+  padding: 0 var(--s-3);
   border: 1px solid var(--line);
   border-radius: var(--r-pill);
   background: var(--paper);
@@ -116,7 +118,7 @@
 .selectGrid {
   display: grid;
   grid-template-columns: repeat(3, minmax(160px, 1fr));
-  gap: var(--s-3);
+  gap: var(--s-2);
 }
 
 .customDateGrid {
@@ -127,7 +129,7 @@
   display: flex;
   min-width: 0;
   flex-direction: column;
-  gap: var(--s-2);
+  gap: var(--s-1);
   color: var(--ink-2);
   font-size: 12px;
   font-weight: 540;
@@ -135,7 +137,7 @@
 }
 
 .field input[type="date"] {
-  height: 36px;
+  height: 32px;
   min-width: 0;
   border: 1px solid hsl(var(--input));
   border-radius: 6px;
@@ -155,12 +157,12 @@
 .filterSummary {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: var(--s-3);
+  gap: var(--s-2);
 }
 
 .summaryItem {
   min-width: 0;
-  padding: var(--s-4);
+  padding: var(--s-3);
   border: 1px solid var(--line-2);
   border-radius: var(--r-3);
   background: var(--paper-2);
@@ -168,34 +170,35 @@
 
 .summaryItem dt {
   color: var(--ink-3);
-  font-size: 12px;
+  font-size: 11px;
   font-weight: 450;
 }
 
 .summaryItem dd {
   margin: var(--s-1) 0 0;
   color: var(--ink);
-  font-size: 14px;
+  font-size: 13px;
   font-weight: 540;
+  overflow-wrap: anywhere;
 }
 
 .metricGrid {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: var(--s-3);
+  gap: var(--s-2);
 }
 
 .metricCard {
   min-width: 0;
-  min-height: 164px;
-  padding: var(--s-4);
+  min-height: 128px;
+  padding: var(--s-3);
   border: 1px solid var(--line);
   border-radius: var(--r-3);
   background: var(--paper);
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  gap: var(--s-3);
+  gap: var(--s-2);
 }
 
 .metricHeader {
@@ -217,7 +220,7 @@
 .metricValue {
   color: var(--ink);
   font-family: var(--sans);
-  font-size: 28px;
+  font-size: 24px;
   font-weight: 540;
   letter-spacing: 0;
   line-height: 1.1;
@@ -227,7 +230,7 @@
   margin: 0;
   color: var(--ink-2);
   font-size: 13px;
-  line-height: 1.55;
+  line-height: 1.45;
 }
 
 .coveragePanel,
@@ -235,8 +238,8 @@
 .hotpathPanel {
   display: flex;
   flex-direction: column;
-  gap: var(--s-4);
-  padding: var(--s-5);
+  gap: var(--s-3);
+  padding: var(--s-4);
   border: 1px solid var(--line);
   border-radius: var(--r-3);
   background: var(--paper);
@@ -414,14 +417,14 @@
 
 .recommendationCard {
   min-width: 0;
-  min-height: 196px;
+  min-height: 168px;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
   gap: var(--s-3);
   border: 1px solid var(--line);
   border-radius: var(--r-3);
-  padding: var(--s-4);
+  padding: var(--s-3);
   background: var(--paper-2);
   color: inherit;
   text-decoration: none;
@@ -439,7 +442,7 @@
 .recommendationCard h3 {
   margin: 0;
   color: var(--ink);
-  font-size: 16px;
+  font-size: 15px;
   font-weight: 540;
   line-height: 1.35;
   letter-spacing: 0;
@@ -449,12 +452,12 @@
   margin: 0;
   color: var(--ink-2);
   font-size: 13px;
-  line-height: 1.6;
+  line-height: 1.45;
 }
 
 .recommendationCard dl {
   margin: 0;
-  padding: var(--s-3);
+  padding: var(--s-2);
   border: 1px solid var(--line-2);
   border-radius: var(--r-3);
   background: var(--paper);
@@ -812,6 +815,12 @@
   .recommendationGrid,
   .hotpathTopGrid {
     grid-template-columns: 1fr;
+  }
+
+  .filterBar {
+    display: flex;
+    align-items: stretch;
+    flex-direction: column;
   }
 
   .coverageHeader {

--- a/frontend/src/shared/ui/sonner.tsx
+++ b/frontend/src/shared/ui/sonner.tsx
@@ -12,11 +12,12 @@ const Toaster = ({ ...props }: ToasterProps) => {
     <Sonner
       theme="light"
       className="toaster group"
-      position="top-right"
+      position="bottom-right"
       richColors
       closeButton
       expand
-      visibleToasts={5}
+      gap={8}
+      visibleToasts={2}
       icons={{
         success: <CircleCheckIcon className="size-4" />,
         info: <InfoIcon className="size-4" />,


### PR DESCRIPTION
## 변경 사항

- 인증, 관리자, 결제, 도메인팩, 워크스페이스, 상담, 데모/사용자 채팅의 핵심 사용자 흐름을 mock E2E로 확장했습니다.
- PR CI에 `frontend-e2e` job을 추가해 `frontend/**` 변경 시 mock E2E가 머지 게이트에 포함되도록 했습니다.
- `Live E2E` 수동 GitHub Actions workflow를 추가하고, 운영 대상 확인과 전용 계정 secret을 통해 live smoke를 실행하도록 했습니다.
- E2E 스크린샷에서 확인된 정책/리스크 편집 패널, 구독 해지 CTA, 시뮬레이션 개선 후보 패널 문구/레이아웃을 정리했습니다.
- 정책/리스크 업데이트 및 상태 변경 후 raw API response 형태의 목록 캐시도 갱신되도록 보강했습니다.

## 검증

- `actionlint .github/workflows/ci.yml .github/workflows/live-e2e.yml`
- `cd frontend && pnpm exec tsc -p tsconfig.e2e.json --noEmit`
- `cd frontend && pnpm exec playwright test --config=playwright.live.config.ts --list`
- `cd frontend && pnpm test` (265 files, 2006 tests)
- `cd frontend && pnpm e2e` (60 tests)

## 참고

- `Live E2E` workflow 실행에는 repository secrets `LIVE_E2E_EMAIL`, `LIVE_E2E_PASSWORD`가 필요합니다.
- 수동 live workflow는 기본 tier와 `@pollutes` tier를 항상 함께 실행하므로 운영 데이터 잔존 여부를 artifact의 `frontend/e2e/live/.cleanup/leftovers.log`로 확인해야 합니다.