### PR TITLE
ci(dx): backend와 ML 의존성 캐시 재사용

### DIFF
--- a/.agent/specs/624.md
+++ b/.agent/specs/624.md
@@ -1,0 +1,66 @@
+# CI 기본 job 의존성 캐시 적용
+
+## Goal
+
+Backend와 ML CI job에서 반복 의존성 다운로드를 줄이고, 캐시 hit/miss를 로그에서 확인할 수 있게 한다.
+
+## Problem
+
+Frontend CI는 pnpm 캐시를 사용하지만, `.github/workflows/ci.yml`의 `backend` 기본 job은 Gradle 의존성 캐시가 없고 `ml` 기본 job은 uv 의존성 캐시 전략이 드러나지 않는다. 또한 내부 PR에서 함께 실행되는 `backend-sonar`, `ml-sonar` job도 같은 의존성 setup 경로를 사용하므로, 같은 lockfile과 도구 버전으로 반복 실행되는 PR에서 의존성을 다시 내려받으면 피드백 시간이 길어지고 CI 비용이 증가한다.
+
+## Scope
+
+- `.github/workflows/ci.yml`의 `backend`, `backend-sonar` job에 Gradle dependency cache를 적용한다.
+- `.github/workflows/ci.yml`의 `ml`, `ml-sonar` job에 uv cache directory 캐시를 적용한다.
+- cache key는 해당 stack의 lockfile 또는 dependency definition과 tool version 기준을 포함한다.
+- cache hit/miss를 별도 로그 step에서 확인할 수 있게 한다.
+- 캐시 restore 실패는 build/test 실패로 이어지지 않게 한다.
+
+## Non-goals
+
+- Backend Gradle task, ML test command, application dependency version은 변경하지 않는다.
+- Frontend pnpm cache 정책은 변경하지 않는다.
+- GitHub Actions runner, Docker image, production deploy workflow는 변경하지 않는다.
+
+## Affected Paths
+
+- `.github/workflows/ci.yml`
+- `.agent/specs/624.md`
+- `backend/gradle.lockfile`
+- `backend/gradle/wrapper/gradle-wrapper.properties`
+- `ml/.python-version`
+- `ml/pyproject.toml`
+- `ml/uv.lock`
+
+## Requirements
+
+1. `backend`, `backend-sonar` job은 Gradle dependency cache를 restore/save 대상으로 사용해야 한다.
+2. Backend cache key는 Java tool version과 `backend/gradle.lockfile`, Gradle build files, Gradle wrapper properties 변경을 반영해야 한다.
+3. `ml`, `ml-sonar` job은 uv dependency cache directory를 restore/save 대상으로 사용해야 한다.
+4. ML cache key는 uv tool version과 Python pin, `ml/pyproject.toml`, `ml/uv.lock` 변경을 반영해야 한다.
+5. 각 job은 cache hit 여부를 로그에서 명시적으로 출력해야 한다.
+6. GitHub cache 서비스 문제나 cache miss는 기존 build/test command 실패로 취급하지 않아야 한다.
+7. 기존 `./gradlew testPg build -x test -x checkstyleMain -x checkstyleTest`, `uv sync`, `uv run pytest` 실행 의미는 유지해야 한다.
+
+## Data/API Impact
+
+- API 계약, database schema, migration 파일, runtime behavior는 변경하지 않는다.
+- CI workflow의 dependency restore/save 동작과 로그만 변경한다.
+
+## Acceptance Criteria
+
+- Backend만 변경한 PR에서 `backend`, `backend-sonar` job 로그에 Gradle cache restore와 hit 여부가 표시된다.
+- ML만 변경한 PR에서 `ml`, `ml-sonar` job 로그에 uv cache restore와 hit 여부가 표시된다.
+- `backend/gradle.lockfile` 또는 Gradle wrapper/build file 변경 시 backend cache key가 달라진다.
+- `ml/uv.lock`, `ml/pyproject.toml`, `ml/.python-version` 변경 시 ML cache key가 달라진다.
+- 캐시 restore 단계가 실패해도 이후 build/test 단계가 실행 가능한 상태로 남는다.
+
+## Validation
+
+- `.github/workflows/ci.yml` YAML parse 검증
+- cache key가 issue에서 요구한 lockfile/tool version 기준을 포함하는지 diff 검토
+- PR CI에서 backend/ML job의 cache 로그와 기존 build/test command 통과 여부 확인
+
+## Open Questions
+
+- 없음.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,20 @@ jobs:
           java-version: ${{ env.TOOL_JAVA_VERSION }}
           distribution: "temurin"
 
+      - name: Restore Gradle cache
+        id: backend-gradle-cache
+        uses: actions/cache@v4
+        continue-on-error: true
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-backend-java-${{ env.TOOL_JAVA_VERSION }}-${{ hashFiles('backend/gradle.lockfile', 'backend/**/*.gradle*', 'backend/gradle/wrapper/gradle-wrapper.properties') }}
+
+      - name: Log Gradle cache result
+        run: |
+          echo "Gradle cache hit: ${{ steps.backend-gradle-cache.outputs.cache-hit || 'false' }}"
+
       - name: Install pgvector extension
         run: docker exec "${{ job.services.postgres.id }}" psql -U postgres -d testdb -c "CREATE EXTENSION IF NOT EXISTS vector;"
 
@@ -200,6 +214,8 @@ jobs:
     needs: paths-filter
     if: ${{ github.event_name == 'workflow_dispatch' || needs.paths-filter.outputs.ml == 'true' }}
     runs-on: ubuntu-latest
+    env:
+      UV_CACHE_DIR: /tmp/.uv-cache
     steps:
       - uses: actions/checkout@v4
 
@@ -212,6 +228,18 @@ jobs:
         uses: astral-sh/setup-uv@v5
         with:
           version: ${{ env.TOOL_UV_VERSION }}
+
+      - name: Restore uv cache
+        id: ml-uv-cache
+        uses: actions/cache@v4
+        continue-on-error: true
+        with:
+          path: /tmp/.uv-cache
+          key: ${{ runner.os }}-uv-ml-${{ env.TOOL_UV_VERSION }}-${{ hashFiles('ml/.python-version', 'ml/pyproject.toml', 'ml/uv.lock') }}
+
+      - name: Log uv cache result
+        run: |
+          echo "uv cache hit: ${{ steps.ml-uv-cache.outputs.cache-hit || 'false' }}"
 
       - name: Sync dependencies
         working-directory: ./ml
@@ -243,13 +271,19 @@ jobs:
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
 
-      - name: Cache Gradle packages
+      - name: Restore Gradle cache
+        id: backend-sonar-gradle-cache
         uses: actions/cache@v4
+        continue-on-error: true
         with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('backend/**/*.gradle*', 'backend/**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-backend-sonar-java-${{ env.TOOL_JAVA_VERSION }}-${{ hashFiles('backend/gradle.lockfile', 'backend/**/*.gradle*', 'backend/gradle/wrapper/gradle-wrapper.properties') }}
+
+      - name: Log Gradle cache result
+        run: |
+          echo "Gradle cache hit: ${{ steps.backend-sonar-gradle-cache.outputs.cache-hit || 'false' }}"
 
       - name: Run backend SonarCloud analysis
         working-directory: ./backend
@@ -305,6 +339,8 @@ jobs:
     needs: paths-filter
     if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork != true) && needs.paths-filter.outputs.ml == 'true' }}
     runs-on: ubuntu-latest
+    env:
+      UV_CACHE_DIR: /tmp/.uv-cache
     steps:
       - uses: actions/checkout@v4
         with:
@@ -325,6 +361,18 @@ jobs:
         uses: astral-sh/setup-uv@v5
         with:
           version: ${{ env.TOOL_UV_VERSION }}
+
+      - name: Restore uv cache
+        id: ml-sonar-uv-cache
+        uses: actions/cache@v4
+        continue-on-error: true
+        with:
+          path: /tmp/.uv-cache
+          key: ${{ runner.os }}-uv-ml-sonar-${{ env.TOOL_UV_VERSION }}-${{ hashFiles('ml/.python-version', 'ml/pyproject.toml', 'ml/uv.lock') }}
+
+      - name: Log uv cache result
+        run: |
+          echo "uv cache hit: ${{ steps.ml-sonar-uv-cache.outputs.cache-hit || 'false' }}"
 
       - name: Sync dependencies
         working-directory: ./ml


### PR DESCRIPTION
Closes #624

## 변경 사항

- `backend`, `backend-sonar` job에 Java tool version과 Gradle lock/build/wrapper 파일을 기준으로 하는 Gradle cache를 적용했습니다.
- `ml`, `ml-sonar` job에 uv tool version과 Python pin, `pyproject.toml`, `uv.lock`을 기준으로 하는 uv cache directory 캐시를 적용했습니다.
- 각 cache restore step이 실패해도 기존 build/test 단계가 계속 실행되도록 하고, cache hit 여부를 별도 로그로 출력하도록 했습니다.
- 이슈 624 스펙을 `.agent/specs/624.md`에 정리했습니다.

## 검증

- `ruby -e 'require "psych"; Psych.load_file(".github/workflows/ci.yml"); puts "yaml ok"'`
- `git diff --check`
- `bash -lc 'BRANCH=$(git branch --show-current); if [[ "$BRANCH" =~ ^(feature|fix)/([0-9][0-9._-]*)-[^/]+$ ]]; then SPEC_FILE=".agent/specs/${BASH_REMATCH[2]}.md"; test -s "$SPEC_FILE" && echo "spec-check ok: $BRANCH -> $SPEC_FILE"; else echo "branch pattern failed: $BRANCH"; exit 1; fi'`
- `.github/workflows/ci.yml`의 `tool-version-check` Ruby script 로컬 실행
- `actionlint .github/workflows/ci.yml`
- 커밋 pre-commit hook: lint-staged 대상 파일 없음

## 참고

- cache key는 lockfile 또는 dependency definition이 바뀌면 exact key가 바뀌도록 구성했습니다.
- 새 cache step은 `actions/cache@v4`의 `continue-on-error`를 사용해 cache 서비스 문제가 CI 실패로 번지지 않도록 했습니다.