### PR TITLE
ci(dx): 테스트 커버리지 기준을 CI에서 강제

### DIFF
--- a/.agent/rules/testing.md
+++ b/.agent/rules/testing.md
@@ -12,20 +12,22 @@
 - **Integration (30%)**: Service + Repository, Controller + MockMvc
 - **E2E (10%)**: 핵심 사용자 시나리오 — 느리지만 신뢰성 높음
 
-## 커버리지 목표
+## 커버리지 목표와 CI 기준
 
-- **라인 커버리지**: 70% 이상 (캡스톤 현실 고려)
+- **장기 라인 커버리지 목표**: 70% 이상 (캡스톤 현실 고려)
 - **도메인 로직**: 90% 이상 (비즈니스 규칙은 반드시)
 - **새 코드**: 80% 이상 (레거시 제외)
+- **초기 CI baseline**: 레거시 공백 때문에 모듈별 현재 기준을 먼저 강제하고, 이후 coverage 개선 PR에서 상향한다.
 
 ### 커버리지 측정 절차
 
-| 스택              | 로컬 실행 명령                    | 생성되는 리포트                             |
-| ----------------- | --------------------------------- | ------------------------------------------- |
-| Backend (JaCoCo)  | `./gradlew test jacocoTestReport` | `build/reports/jacoco/test/html/index.html` |
-| Frontend (Vitest) | `vp test --coverage`              | `coverage/index.html`, `coverage/lcov.info` |
+| 스택              | 로컬 실행 명령                                           | CI 강제 기준                         | 생성되는 리포트                             |
+| ----------------- | -------------------------------------------------------- | ------------------------------------ | ------------------------------------------- |
+| Backend (JaCoCo)  | `./gradlew test jacocoTestCoverageVerification`          | line 90%, branch 70%                 | `build/reports/jacoco/test/jacocoTestReport.xml`, `build/reports/jacoco/test/html/index.html` |
+| Frontend (Vitest) | `pnpm test -- --coverage --run`                          | statements 80%, branches 70%, functions 75%, lines 80% | `coverage/index.html`, `coverage/lcov.info` |
+| ML (pytest-cov)   | `uv run pytest --cov=src --cov-report=term-missing`      | total 80% (`tool.coverage.report.fail_under`) | `coverage.xml`, terminal missing-line report |
 
-**PR 체크포인트**: CI에서 `./gradlew test jacocoTestCoverageVerification`(Backend) 및 `vp test --coverage`(Frontend) 통과 여부 확인. 커버리지 미달 시 빌드 실패로 처리한다.
+**PR 체크포인트**: CI에서 Backend `jacocoTestCoverageVerification`, Frontend Vitest coverage threshold, ML `fail_under = 80`이 실제로 실행된다. 커버리지 미달 시 빌드 실패로 처리하며, terminal 출력과 CI coverage artifact의 HTML/XML/LCOV 리포트에서 부족한 파일과 라인을 확인한다.
 
 ## Backend (JUnit 5 + Spring Boot Test)
 
@@ -167,4 +169,4 @@ describe("LoginForm", () => {
 ## 검증 방법
 
 - **PR 리뷰**: `.agent/rules/code-review.md` 테스트 체크리스트 참조
-- **CI**: `./gradlew test` (Backend), `vp test` (Frontend)
+- **CI**: Backend `./gradlew test jacocoTestCoverageVerification testPg build -x checkstyleMain -x checkstyleTest`, Frontend `pnpm test -- --coverage --run && pnpm build`, ML `uv run pytest --cov=src --cov-report=term-missing --cov-report=xml:coverage.xml`

--- a/.agent/specs/623.md
+++ b/.agent/specs/623.md
@@ -1,0 +1,100 @@
+# 623. 테스트 커버리지 기준 CI 반영
+
+## Goal
+
+테스트 커버리지 기준을 문서상의 목표에만 두지 않고 backend, frontend, ML의 실제 빌드 설정과 CI에서 실패 조건으로 강제한다.
+
+## Issue Summary
+
+- Issue: GitHub #623 `[DX] 테스트 커버리지 기준을 실제 빌드 설정에 반영`
+- Labels: `enhancement`, `dx`
+- Branch: `feature/623-coverage-gates`
+- Scope: build configuration, CI, and developer documentation
+
+## Current State
+
+| Area | Verified path | As-is |
+| --- | --- | --- |
+| Backend | `backend/build.gradle.kts` | JaCoCo plugin and report task exist, but no `jacocoTestCoverageVerification` violation rule is enforced. |
+| Frontend | `frontend/vite.config.ts` | Vitest coverage reporting exists, but no coverage threshold is configured. |
+| ML | `ml/pyproject.toml` | `tool.coverage.report.fail_under = 80` exists, but the main CI ML job runs plain `uv run pytest`. |
+| CI | `.github/workflows/ci.yml` | Backend/frontend/ml test jobs do not consistently invoke coverage gates. |
+| Docs | `.agent/rules/testing.md`, `README.md`, `backend/README.md`, `frontend/README.md`, `ml/README.md` | Coverage target, local/CI commands, and report evidence are not aligned across modules. |
+
+## Requirements
+
+1. Backend must define a JaCoCo coverage verification rule in `backend/build.gradle.kts`.
+2. Frontend must define Vitest coverage thresholds in `frontend/vite.config.ts`.
+3. ML must keep the existing `fail_under = 80` threshold and invoke pytest with coverage in CI.
+4. CI must run the coverage-producing commands so threshold misses fail PR checks.
+5. CI must upload coverage report artifacts so reviewers can inspect failing files or areas.
+6. Documentation must state module-specific enforced baselines, report locations, and the policy for raising baselines.
+7. Initial baselines must avoid unexpectedly blocking active development while still making coverage regressions visible.
+
+## Non-goals
+
+- No product runtime behavior changes.
+- No attempt to raise all modules immediately to the long-term 70% line coverage goal.
+- No test suite rewrites or new application tests unless required to make the coverage gate executable.
+- No changes to SonarCloud quality gate administration outside repository files.
+
+## Design
+
+### Backend
+
+Add `jacocoTestCoverageVerification` with bundle-level baseline limits and wire it into `check`.
+
+| Metric | Initial gate |
+| --- | --- |
+| line covered ratio | 90% |
+| branch covered ratio | 70% |
+
+The backend gate uses the same broad exclusion intent already documented for Sonar coverage: application bootstrap, config, DTO/entity-like objects, infrastructure wiring, and command carrier objects are not the first coverage baseline target. The measured filtered baseline is line 92.92% and branch 75.97%.
+
+### Frontend
+
+Add Vitest global thresholds in `frontend/vite.config.ts`.
+
+| Metric | Initial gate |
+| --- | --- |
+| statements | 80% |
+| branches | 70% |
+| functions | 75% |
+| lines | 80% |
+
+The measured baseline before configuring thresholds is statements 83.99%, branches 77.3%, functions 79.89%, lines 85.59%, so this starts below the current suite while leaving room for normal refactors.
+
+### ML
+
+Keep `ml/pyproject.toml` `fail_under = 80` as the source of truth. Update CI and docs to run pytest with `--cov=src` so the existing threshold is enforced outside Sonar-only coverage collection.
+
+## CI Contract
+
+| Job | Required command |
+| --- | --- |
+| backend | `./gradlew test jacocoTestCoverageVerification testPg build -x checkstyleMain -x checkstyleTest` |
+| frontend | `pnpm test -- --coverage --run` before `pnpm build` |
+| ml | `uv run pytest --cov=src --cov-report=term-missing --cov-report=xml:coverage.xml` |
+
+Coverage failure must fail the relevant CI job. Terminal output or uploaded HTML/XML/LCOV coverage artifacts must identify the file or area with insufficient coverage.
+
+## Acceptance Criteria
+
+- [ ] Backend CI fails when `jacocoTestCoverageVerification` is below the configured baseline.
+- [ ] Frontend CI fails when Vitest coverage thresholds are below the configured baseline.
+- [ ] ML CI fails when total coverage is below `fail_under = 80`.
+- [ ] CI uploads module coverage artifacts even when a coverage gate fails.
+- [ ] Module README or testing rules document the enforced numbers and how to inspect failures.
+- [ ] `.agent/specs/623.md` exists for branch-pattern spec check.
+
+## Validation Plan
+
+- Backend: `cd backend && ./gradlew test jacocoTestCoverageVerification` when Java 21 is available.
+- Frontend: `cd frontend && pnpm test -- --coverage --run`.
+- ML: `cd ml && uv run pytest --cov=src --cov-report=term-missing --cov-report=xml:coverage.xml`.
+- Repository diff review: confirm only coverage settings, CI, docs, and this spec changed.
+
+## Open Questions
+
+- Backend baseline can be raised further after CI confirms the same filtered JaCoCo ratio under the shared GitHub Actions Java 21 environment.
+- Per-package or changed-code-only coverage gates remain future work because the issue only requires module-level CI enforcement.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
 
       - name: Build Backend with PostgreSQL test DB
         working-directory: ./backend
-        run: ./gradlew testPg build -x test -x checkstyleMain -x checkstyleTest
+        run: ./gradlew test jacocoTestCoverageVerification testPg build -x checkstyleMain -x checkstyleTest
         env:
           SPRING_DATASOURCE_URL: jdbc:postgresql://localhost:5432/testdb
           SPRING_DATASOURCE_USERNAME: postgres
@@ -167,6 +167,17 @@ jobs:
           SPRING_DATASOURCE_DRIVER_CLASS_NAME: org.postgresql.Driver
           SPRING_LIQUIBASE_ENABLED: "true"
           SPRING_JPA_HIBERNATE_DDL_AUTO: validate
+
+      - name: Upload backend coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-coverage
+          path: |
+            backend/build/reports/jacoco/test/jacocoTestReport.xml
+            backend/build/reports/jacoco/test/html/
+          if-no-files-found: ignore
+
   frontend:
     needs: paths-filter
     if: ${{ github.event_name == 'workflow_dispatch' || needs.paths-filter.outputs.frontend == 'true' }}
@@ -190,7 +201,15 @@ jobs:
 
       - name: Run tests
         working-directory: ./frontend
-        run: pnpm test
+        run: pnpm test -- --coverage --run
+
+      - name: Upload frontend coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-coverage
+          path: frontend/coverage/
+          if-no-files-found: ignore
 
       - name: Build
         working-directory: ./frontend
@@ -219,7 +238,15 @@ jobs:
 
       - name: Run tests
         working-directory: ./ml
-        run: uv run pytest
+        run: uv run pytest --cov=src --cov-report=term-missing --cov-report=xml:coverage.xml
+
+      - name: Upload ML coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ml-coverage
+          path: ml/coverage.xml
+          if-no-files-found: ignore
 
   backend-sonar:
     needs: paths-filter

--- a/README.md
+++ b/README.md
@@ -430,9 +430,9 @@ Backend는 `local` 프로필에서 springdoc 기반 OpenAPI 문서/Swagger UI를
 
 | 모듈 | 빌드 | 테스트 |
 | --- | --- | --- |
-| Backend | `(cd backend && ./gradlew build)` | H2: `(cd backend && ./gradlew test)` / PostgreSQL: `(cd backend && ./gradlew testPg)` |
-| Frontend | `(cd frontend && pnpm build)` | `(cd frontend && pnpm test)` |
-| ML | `(cd ml && uv sync)` | `(cd ml && uv run pytest)` |
+| Backend | `(cd backend && ./gradlew build)` | H2: `(cd backend && ./gradlew test jacocoTestCoverageVerification)` / PostgreSQL: `(cd backend && ./gradlew testPg)` |
+| Frontend | `(cd frontend && pnpm build)` | `(cd frontend && pnpm test -- --coverage --run)` |
+| ML | `(cd ml && uv sync)` | `(cd ml && uv run pytest --cov=src --cov-report=term-missing)` |
 
 전체 커맨드·프로필·Docker 세부 사항은 [`AGENTS.md`](AGENTS.md), 모듈별 상세는 각 모듈 README를 참조한다.
 
@@ -443,10 +443,11 @@ Backend는 `local` 프로필에서 springdoc 기반 OpenAPI 문서/Swagger UI를
 ### CI
 
 - **paths-filter**: 변경 파일에 따라 관련 모듈만 빌드/테스트한다.
-  - `backend`: `./gradlew testPg build -x test -x checkstyleMain -x checkstyleTest` (PostgreSQL/Liquibase 테스트 후 CI 속도 최적화용 체크스타일 스킵)
-  - `frontend`: `pnpm install --frozen-lockfile && pnpm test && pnpm build`
-  - `ml`: `uv sync && uv run pytest`
+  - `backend`: `./gradlew test jacocoTestCoverageVerification testPg build -x checkstyleMain -x checkstyleTest` (H2 coverage gate와 PostgreSQL/Liquibase 재현 테스트를 함께 실행)
+  - `frontend`: `pnpm install --frozen-lockfile && pnpm test -- --coverage --run && pnpm build`
+  - `ml`: `uv sync && uv run pytest --cov=src --cov-report=term-missing --cov-report=xml:coverage.xml`
 - **spec-check**: `feature/*`, `fix/*`, `spec/*` 브랜치는 `.agent/specs/{이슈번호}.md` 스펙 파일을 필수 검증한다.
+- **coverage baseline**: Backend line 90% / branch 70%, Frontend statements 80% / branches 70% / functions 75% / lines 80%, ML total 80%를 CI에서 강제한다. 장기 목표는 `.agent/rules/testing.md`의 70%+ 라인 커버리지와 새 코드 80% 기준이며, baseline은 coverage 개선 PR에서 점진적으로 상향한다. CI는 각 모듈의 coverage artifact를 업로드해 실패한 파일/영역을 확인할 수 있게 한다.
 - Backend의 빠른 로컬 테스트(`./gradlew test` 또는 `./gradlew testH2`)는 H2 인메모리(`jdbc:h2:mem:testdb`)를 사용하고 Liquibase를 비활성화한다.
 - Backend의 CI 재현 테스트(`./gradlew testPg`)는 PostgreSQL/pgvector DB에 연결하고 Liquibase를 활성화한 뒤 Hibernate `ddl-auto=validate`로 검증한다. 기본 로컬 연결값은 `jdbc:postgresql://localhost:5432/testdb`, `postgres/postgres`이며 `SPRING_DATASOURCE_URL`, `SPRING_DATASOURCE_USERNAME`, `SPRING_DATASOURCE_PASSWORD`로 덮어쓸 수 있다.
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -43,6 +43,9 @@ infrastructure/  → JPA Repository, External Client, Config
 # 테스트
 ./gradlew test
 
+# H2 테스트 + JaCoCo coverage gate
+./gradlew test jacocoTestCoverageVerification
+
 # CI와 같은 PostgreSQL/Liquibase 조건 테스트
 ./gradlew testPg
 
@@ -88,9 +91,10 @@ Liquibase로 스키마 관리됩니다.
 ## 테스트 DB 전략
 
 - `./gradlew test`와 `./gradlew testH2`는 빠른 단위/슬라이스 검증용 경로입니다. `src/test/resources/application.yml`의 H2 인메모리 DB를 사용하고 Liquibase를 비활성화합니다.
+- `./gradlew test jacocoTestCoverageVerification`은 H2 테스트 결과로 JaCoCo line 90% / branch 70% baseline을 검증합니다. `build/reports/jacoco/test/jacocoTestReport.xml`과 `build/reports/jacoco/test/html/index.html`에서 커버리지 파일별 근거를 확인할 수 있습니다.
 - `./gradlew testPg`는 통합/CI 재현용 경로입니다. PostgreSQL/pgvector DB에 연결하고 Liquibase를 활성화한 뒤 Hibernate `ddl-auto=validate`로 검증합니다.
 - `testPg`의 기본 연결값은 `jdbc:postgresql://localhost:5432/testdb`, `postgres/postgres`입니다. 다른 DB를 사용할 때는 `SPRING_DATASOURCE_URL`, `SPRING_DATASOURCE_USERNAME`, `SPRING_DATASOURCE_PASSWORD`를 지정합니다.
-- CI backend job은 `pgvector/pgvector:pg16` 서비스에 `vector` extension을 만든 뒤 `./gradlew testPg build -x test -x checkstyleMain -x checkstyleTest`를 실행합니다.
+- CI backend job은 `pgvector/pgvector:pg16` 서비스에 `vector` extension을 만든 뒤 `./gradlew test jacocoTestCoverageVerification testPg build -x checkstyleMain -x checkstyleTest`를 실행합니다.
 
 ```bash
 docker run --rm --name ostone-test-pg -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=testdb -p 5432:5432 -d pgvector/pgvector:pg16

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -117,12 +117,54 @@ jacoco {
     toolVersion = "0.8.12"
 }
 
+val jacocoCoverageExclusions = listOf(
+    "**/*Application.class",
+    "**/config/**",
+    "**/dto/**",
+    "**/entity/**",
+    "**/infrastructure/**",
+    "**/application/**/*Command.class",
+)
+
 tasks.jacocoTestReport {
     reports {
         xml.required.set(true)
-        html.required.set(false)
+        html.required.set(true)
     }
     dependsOn(tasks.test)
+    classDirectories.setFrom(
+        files(
+            sourceSets.main.get().output.classesDirs.map {
+                fileTree(it) {
+                    exclude(jacocoCoverageExclusions)
+                }
+            },
+        ),
+    )
+}
+
+tasks.jacocoTestCoverageVerification {
+    dependsOn(tasks.jacocoTestReport)
+    classDirectories.setFrom(tasks.jacocoTestReport.get().classDirectories)
+    violationRules {
+        rule {
+            element = "BUNDLE"
+            limit {
+                counter = "LINE"
+                value = "COVEREDRATIO"
+                minimum = "0.90".toBigDecimal()
+            }
+            limit {
+                counter = "BRANCH"
+                value = "COVEREDRATIO"
+                minimum = "0.70".toBigDecimal()
+            }
+        }
+    }
+}
+
+tasks.check {
+    dependsOn(tasks.jacocoTestCoverageVerification)
 }
 
 sonar {

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -9,9 +9,14 @@
 | 개발 서버     | `pnpm dev`     |
 | 빌드          | `pnpm build`   |
 | 테스트        | `pnpm test`    |
+| 커버리지 검증 | `pnpm test -- --coverage --run` |
 | 린트          | `pnpm lint`    |
 | 포맷          | `pnpm format`  |
 | API 코드 생성 | `pnpm api:gen` |
+
+## Coverage Gate
+
+Vitest coverage는 `vite.config.ts`에서 statements 80%, branches 70%, functions 75%, lines 80% baseline을 강제한다. CI의 frontend job은 `pnpm test -- --coverage --run`을 실행하므로 threshold 미달 시 실패하며, 부족한 파일과 라인은 터미널 coverage table과 `coverage/lcov.info`에서 확인한다.
 
 ## API Codegen Workflow
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -39,7 +39,13 @@ export default defineConfig({
     exclude: ["**/node_modules/**", "**/dist/**", "**/e2e/**"],
     coverage: {
       provider: "v8",
-      reporter: ["lcov", "text"],
+      reporter: ["html", "lcov", "text"],
+      thresholds: {
+        statements: 80,
+        branches: 70,
+        functions: 75,
+        lines: 80,
+      },
       include: ["src/**/*.{ts,tsx}"],
       exclude: [
         "node_modules/",

--- a/ml/README.md
+++ b/ml/README.md
@@ -27,11 +27,15 @@ docker compose up -d airflow-init airflow-apiserver airflow-scheduler airflow-da
 `ml/` 디렉터리에서:
 
 ```bash
-uv sync && uv run pytest && uv run ruff check . && uv run ruff format . && uv run mypy .
+uv sync && uv run pytest --cov=src --cov-report=term-missing && uv run ruff check . && uv run ruff format . && uv run mypy .
 ```
 
 - 위 명령으로 공유 `postgres`도 함께 기동
 - backend/frontend까지 포함한 전체 스택은 루트 `README.md` 참고
+
+## Coverage Gate
+
+ML 테스트 커버리지는 `pyproject.toml`의 `tool.coverage.report.fail_under = 80`을 기준으로 한다. CI는 `uv run pytest --cov=src --cov-report=term-missing --cov-report=xml:coverage.xml`을 실행해 기준을 강제하고, 실패 시 terminal missing-line report와 `coverage.xml`에서 부족한 영역을 확인한다.
 
 ## Parsed Consultation Dataset
 


### PR DESCRIPTION
Closes #623

## 변경 사항

- backend JaCoCo `jacocoTestCoverageVerification`에 line 90% / branch 70% baseline을 정의하고 `check`에 연결했습니다.
- frontend Vitest coverage에 statements 80% / branches 70% / functions 75% / lines 80% threshold와 HTML/LCOV/text reporter를 설정했습니다.
- CI의 backend/frontend/ml 테스트 job이 coverage gate를 실제로 실행하도록 바꾸고, 실패 시 확인할 coverage artifact를 업로드하도록 했습니다.
- ML은 기존 `pyproject.toml`의 `fail_under = 80` 기준을 유지하되 CI에서 `--cov=src`로 실행해 기준이 강제되도록 했습니다.
- 이슈 623 스펙과 README/testing rule에 모듈별 baseline, report 위치, baseline 상향 정책을 정리했습니다.

## 검증

- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "ci yaml ok"'`
- `JAVA_HOME=/Users/owen/.cache/codex-runtimes/jdk21/Contents/Home PATH=/Users/owen/.cache/codex-runtimes/jdk21/Contents/Home/bin:$PATH GRADLE_USER_HOME=/tmp/ostone-gradle-623 ./gradlew --no-daemon --no-watch-fs test jacocoTestCoverageVerification`
- `cd frontend && pnpm test -- --coverage --run` (270 files, 2046 tests; statements 83.99%, branches 77.3%, functions 79.89%, lines 85.59%)
- `cd frontend && pnpm build`
- `cd ml && uv run pytest --cov=src --cov-report=term-missing --cov-report=xml:coverage.xml` (644 passed, 2 skipped; total coverage 82.93%)
- 커밋 pre-commit hook: `cd frontend && pnpm run lint`, `cd frontend && pnpm run format`

## 참고

- 로컬 기본 shell은 Java 17이므로 backend Gradle 검증은 Java 21 runtime과 별도 `GRADLE_USER_HOME`을 명시해 실행했습니다.
- Backend baseline은 JaCoCo report에서 확인한 filtered coverage line 92.92% / branch 75.97% 아래로 설정했습니다.