### PR TITLE
fix(domain-pack): Intent 대표 문장에 내부 벡터값이 노출되지 않도록 정리 (#554)

### DIFF
--- a/.agent/specs/554.md
+++ b/.agent/specs/554.md
@@ -1,0 +1,59 @@
+# Intent 대표 문장에 내부 벡터값이 노출되지 않도록 정리
+
+## Goal
+
+Intent 상세의 대표 문장 영역에는 사람이 읽을 수 있는 상담 발화만 표시되도록 하여, embedding/vector 같은 내부 숫자 배열이 운영자에게 노출되지 않게 한다.
+
+## Problem
+
+Intent 상세의 대표 문장은 `evidenceJson`에서 `sampleSegmentTexts`, `sampleIntentPhrases`, `representativeCases`, `sourceRefs` 순서로 근거를 읽어 구성한다. evidence item에서 추출한 텍스트가 embedding/vector(숫자 배열 형태)일 경우, 사람이 읽을 수 없는 내부 숫자 값이 그대로 대표 문장으로 표시된다. 대표 문장은 운영자가 상담 유형을 검토하는 핵심 근거이므로 상담 발화만 표시되어야 한다.
+
+## Scope
+
+- `frontend/src/entities/intent/ui/IntentDetailPanel.tsx`
+- `frontend/src/entities/intent/ui/IntentDetailPanel.test.tsx`
+
+## Non-Goals
+
+- 백엔드 `evidenceJson` 생성/저장 로직을 변경하지 않는다.
+- 관련 키워드(cluster scope)·JSON 보기 등 대표 문장 외 영역의 표시 로직을 변경하지 않는다.
+- 상담 ID 등 ID 참조(`sourceRefs`, `unit_id` 등)의 기존 표시 동작을 변경하지 않는다.
+
+## Current Contract
+
+| 영역 | 확인된 파일 | 현재 상태 |
+| --- | --- | --- |
+| 대표 문장 추출 | `IntentDetailPanel.tsx` (`buildEvidenceLines`) | evidence 근거를 순서대로 읽어 최대 5개 라인으로 구성 |
+| evidence 라인 변환 | `IntentDetailPanel.tsx` (`evidenceItemToLine`) | string/record에서 텍스트를 추출하되 숫자 배열/vector 형태를 거르는 가드가 없음 |
+| 빈 상태 | `IntentDetailPanel.tsx` (`EvidenceReference`) | 라인이 없으면 "대표 문장이 없습니다." 표시 (이미 구현됨) |
+
+## Design Diff
+
+| 영역 | As-is | To-be |
+| --- | --- | --- |
+| 대표 문장 필터 | `null`이 아닌 라인을 모두 표시 | `null`이 아니고 사람이 읽을 수 있는 텍스트만 표시 |
+| 벡터/embedding 처리 | stringify된 벡터·지수 표기 숫자 배열이 그대로 노출 | 숫자 토큰만으로 이루어진 다중 토큰 또는 단일 실수(소수점/지수)는 대표 문장에서 제외 |
+| ID 참조 | turn 라벨과 함께 표시 | 동일하게 유지 (단일 정수·콜론 포함 ID는 제외하지 않음) |
+
+## Requirements
+
+- 대표 문장 영역에는 사람이 읽을 수 있는 문장만 표시한다.
+- 숫자 배열 또는 embedding 형태(`[0.1, 0.2, ...]`, `1.2e-5 3.4e-6` 등)는 대표 문장으로 표시하지 않는다.
+- 근거에 표시할 문장이 없으면 "대표 문장이 없습니다." 안내를 표시한다.
+- 기존 정상 `evidenceJson` 케이스(`sampleSegmentTexts`, `sampleIntentPhrases`, `representativeCases`, `sourceRefs`)는 그대로 대표 문장을 표시한다.
+
+## Acceptance Criteria
+
+- [ ] 대표 문장 영역에는 사람이 읽을 수 있는 문장만 표시된다.
+- [ ] 숫자 배열 또는 embedding 값은 대표 문장으로 표시되지 않는다.
+- [ ] 근거 데이터에 문장이 없으면 "대표 문장이 없습니다." 안내가 표시된다.
+- [ ] 기존 정상 evidenceJson 케이스는 그대로 대표 문장을 표시한다.
+- [ ] 대표 문장 추출 케이스가 테스트로 검증된다.
+
+## Validation
+
+- `cd frontend && pnpm test -- run src/entities/intent/ui/IntentDetailPanel.test.tsx`
+
+## Open Questions
+
+- 없음.

--- a/frontend/src/entities/intent/ui/IntentDetailPanel.test.tsx
+++ b/frontend/src/entities/intent/ui/IntentDetailPanel.test.tsx
@@ -390,6 +390,44 @@ describe("IntentDetailPanel", () => {
     expect(screen.getByText("order_id: 12345 확인 요청")).toBeInTheDocument();
   });
 
+  it("embedding/vector 형태 값은 대표 문장으로 표시하지 않는다", () => {
+    mockedUseIntentDetail.mockReturnValue(
+      readyDetail({
+        ...stubDetail,
+        evidenceJson: JSON.stringify({
+          sampleSegmentTexts: [
+            "[0.1234, -0.5678, 0.9012]",
+            "0.0012 3.4e-5 -1.2e-6",
+            [0.11, 0.22, 0.33],
+            "고객: 카드 분실 신고하고 싶어요",
+          ],
+        }),
+      }),
+    );
+
+    renderPanel();
+
+    expect(screen.getByText("대표 문장")).toBeInTheDocument();
+    expect(screen.getByText("카드 분실 신고하고 싶어요")).toBeInTheDocument();
+    expect(screen.queryByText("[0.1234, -0.5678, 0.9012]")).not.toBeInTheDocument();
+    expect(screen.queryByText("0.0012 3.4e-5 -1.2e-6")).not.toBeInTheDocument();
+  });
+
+  it("근거에 사람이 읽을 수 있는 문장이 없으면 빈 상태를 표시한다", () => {
+    mockedUseIntentDetail.mockReturnValue(
+      readyDetail({
+        ...stubDetail,
+        evidenceJson: JSON.stringify({
+          sampleSegmentTexts: ["[0.1, 0.2, 0.3]", "1.5e-4, -2.6e-5"],
+        }),
+      }),
+    );
+
+    renderPanel();
+
+    expect(screen.getByText("대표 문장이 없습니다.")).toBeInTheDocument();
+  });
+
   it("JSON 탭에서 JSON 타입별 메타 정보를 표시한다", () => {
     mockedUseIntentDetail.mockReturnValue(
       readyDetail({

--- a/frontend/src/entities/intent/ui/IntentDetailPanel.tsx
+++ b/frontend/src/entities/intent/ui/IntentDetailPanel.tsx
@@ -425,8 +425,6 @@ function buildEvidenceLines(raw: string): EvidenceLine[] {
     .slice(0, 5);
 }
 
-const NUMERIC_TOKEN = /^[+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$/;
-
 // 대표 문장은 운영자가 읽는 상담 발화여야 한다. embedding/vector처럼
 // 숫자 배열로만 이루어진 값은 대표 문장이 아니므로 제외한다.
 // (상담 ID 등 ID 참조는 turn 라벨과 함께 표시되는 기존 동작이므로 유지한다.)
@@ -436,12 +434,17 @@ function isHumanReadableText(text: string): boolean {
   return !looksLikeNumericVector(trimmed);
 }
 
+// Number 변환으로 숫자 토큰을 판별한다. 정규식 기반 검사는 ReDoS 위험이 있어 피한다.
+function isNumericToken(token: string): boolean {
+  return token.length > 0 && Number.isFinite(Number(token));
+}
+
 function looksLikeNumericVector(text: string): boolean {
   const inner = text.replace(/^\[/, "").replace(/\]$/, "").trim();
   if (!inner) return false;
   const tokens = inner.split(/[,\s]+/).filter(Boolean);
   if (tokens.length === 0) return false;
-  if (!tokens.every((token) => NUMERIC_TOKEN.test(token))) return false;
+  if (!tokens.every(isNumericToken)) return false;
   // 다중 숫자 토큰은 벡터/배열, 단일 토큰이라도 소수점/지수를 포함하면
   // embedding 성분이다. 단일 정수는 상담 ID 등일 수 있으므로 제외하지 않는다.
   return tokens.length >= 2 || /[.eE]/.test(tokens[0]);

--- a/frontend/src/entities/intent/ui/IntentDetailPanel.tsx
+++ b/frontend/src/entities/intent/ui/IntentDetailPanel.tsx
@@ -421,8 +421,30 @@ function buildEvidenceLines(raw: string): EvidenceLine[] {
 
   return sourceItems
     .map((item, index) => evidenceItemToLine(item, index))
-    .filter((line): line is EvidenceLine => line !== null)
+    .filter((line): line is EvidenceLine => line !== null && isHumanReadableText(line.text))
     .slice(0, 5);
+}
+
+const NUMERIC_TOKEN = /^[+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$/;
+
+// 대표 문장은 운영자가 읽는 상담 발화여야 한다. embedding/vector처럼
+// 숫자 배열로만 이루어진 값은 대표 문장이 아니므로 제외한다.
+// (상담 ID 등 ID 참조는 turn 라벨과 함께 표시되는 기존 동작이므로 유지한다.)
+function isHumanReadableText(text: string): boolean {
+  const trimmed = text.trim();
+  if (!trimmed) return false;
+  return !looksLikeNumericVector(trimmed);
+}
+
+function looksLikeNumericVector(text: string): boolean {
+  const inner = text.replace(/^\[/, "").replace(/\]$/, "").trim();
+  if (!inner) return false;
+  const tokens = inner.split(/[,\s]+/).filter(Boolean);
+  if (tokens.length === 0) return false;
+  if (!tokens.every((token) => NUMERIC_TOKEN.test(token))) return false;
+  // 다중 숫자 토큰은 벡터/배열, 단일 토큰이라도 소수점/지수를 포함하면
+  // embedding 성분이다. 단일 정수는 상담 ID 등일 수 있으므로 제외하지 않는다.
+  return tokens.length >= 2 || /[.eE]/.test(tokens[0]);
 }
 
 function resolveEvidenceSourceItems(parsed: unknown): unknown[] {


### PR DESCRIPTION
## 개요

Resolves #554

Intent 상세의 **대표 문장** 영역에 실제 상담 발화가 아니라 embedding/vector(내부 숫자 배열)처럼 보이는 값이 노출되는 문제를 수정한다. 대표 문장은 운영자가 상담 유형을 검토하는 핵심 근거이므로, 사람이 읽을 수 있는 상담 발화만 표시되어야 한다.

## 문제 배경

대표 문장은 `evidenceJson`에서 다음 순서로 근거를 읽어 구성한다.

`sampleSegmentTexts` → `sampleIntentPhrases` → `representativeCases` → `sourceRefs`

기존 추출 로직(`evidenceItemToLine`)은 `readString`으로 문자열 필드만 읽기 때문에 **순수 number 배열**은 걸러졌지만, 아래 형태는 그대로 대표 문장으로 노출될 수 있었다.

- stringify된 벡터 문자열: `"[0.1234, -0.5678, 0.9012]"`
- 지수 표기 숫자 나열: `"0.0012 3.4e-5 -1.2e-6"`

이런 값은 `readString`을 통과하므로 화면에 내부 숫자 배열이 그대로 보였다.

## 코드 로직 수정 내용

### `frontend/src/entities/intent/ui/IntentDetailPanel.tsx`

1. **최종 필터 한 곳에서 일괄 검증**
   `buildEvidenceLines`의 마지막 `filter`에 `isHumanReadableText(line.text)` 조건을 추가했다. string 경로와 record 경로 모두 결국 이 필터를 거치므로, 두 경로 중복 가드 없이 한 지점에서 안전하게 차단된다.

   ```ts
   return sourceItems
     .map((item, index) => evidenceItemToLine(item, index))
     .filter((line): line is EvidenceLine => line !== null && isHumanReadableText(line.text))
     .slice(0, 5);
   ```

2. **embedding/vector 판별 헬퍼 추가**
   - `isHumanReadableText`: 빈 문자열과 벡터 형태를 제외한다.
   - `looksLikeNumericVector`: 양 끝 대괄호를 제거한 뒤 콤마/공백으로 토큰화하여, **모든 토큰이 숫자(소수점·부호·지수 표기 포함)** 인지 검사한다. 지수 표기(`e`/`E`)까지 숫자로 인식하므로 `1.2e-5` 같은 값도 정확히 걸러진다.

   ```ts
   const NUMERIC_TOKEN = /^[+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$/;

   function looksLikeNumericVector(text: string): boolean {
     const inner = text.replace(/^\[/, "").replace(/\]$/, "").trim();
     if (!inner) return false;
     const tokens = inner.split(/[,\s]+/).filter(Boolean);
     if (tokens.length === 0) return false;
     if (!tokens.every((token) => NUMERIC_TOKEN.test(token))) return false;
     // 다중 숫자 토큰은 벡터/배열, 단일 토큰이라도 소수점/지수를 포함하면 embedding 성분이다.
     return tokens.length >= 2 || /[.eE]/.test(tokens[0]);
   }
   ```

3. **ID 참조 기존 동작 보존**
   `sourceRefs`의 `source_id`(`"200002"`)나 `unit_id`(`"90811:0:1"`) 같은 ID 참조는 turn 라벨(`상담 ID`, `근거 ID`)과 함께 표시되는 의도된 기능이다. 단일 정수와 콜론 포함 ID는 벡터로 판정되지 않도록 하여 기존 표시 동작을 그대로 유지했다.

4. **빈 상태(empty state)**
   문장이 하나도 없으면 기존 `EvidenceReference`의 `대표 문장이 없습니다.` 안내가 그대로 노출된다. (별도 추가 구현 없음)

## 테스트

### `frontend/src/entities/intent/ui/IntentDetailPanel.test.tsx`

- **embedding/vector 형태 값은 대표 문장으로 표시하지 않는다**: stringify된 벡터, 지수 표기 숫자, number 배열을 섞은 입력에서 사람이 읽을 수 있는 문장만 표시되는지 검증.
- **근거에 사람이 읽을 수 있는 문장이 없으면 빈 상태를 표시한다**: 모든 근거가 벡터일 때 `대표 문장이 없습니다.` 노출 검증.

전체 테스트 결과: **18 passed (18)**

## 성공 기준 체크

- [x] 대표 문장 영역에는 사람이 읽을 수 있는 문장만 표시된다.
- [x] 숫자 배열 또는 embedding 값은 대표 문장으로 표시되지 않는다.
- [x] 근거 데이터에 문장이 없으면 `대표 문장이 없습니다` 안내가 표시된다.
- [x] 기존 정상 evidenceJson 케이스는 그대로 대표 문장을 표시한다.
- [x] 대표 문장 추출 케이스가 테스트로 검증된다.

## 검증 방법

```bash
cd frontend && pnpm test -- run src/entities/intent/ui/IntentDetailPanel.test.tsx
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 대표 문장 추출 시 벡터·숫자 배열처럼 보이는 항목을 제외하도록 필터링 개선

* **Tests**
  * 벡터형 텍스트 제외 동작과 대표 문장 부재 시 빈 상태 메시지 표시를 검증하는 테스트 2개 추가

* **Documentation**
  * 대표 문장 표시 기준 및 수용 기준 체크리스트 문서화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->