### PR TITLE
feat(dashboard): 운영 데이터 기준 대시보드 안내 제공

### DIFF
--- a/.agent/specs/633.md
+++ b/.agent/specs/633.md
@@ -1,0 +1,101 @@
+# Frontend FSD Spec: 대시보드 준비 문구와 Placeholder 정리
+
+## Goal
+
+워크스페이스 대시보드에서 구현 준비 상태를 암시하는 문구와 더 이상 의미 없는 placeholder 영역을 제거하고, 운영자가 현재 데이터 조건을 제품 화면의 정상 상태로 이해할 수 있게 한다.
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A[시작: 워크스페이스 대시보드 진입] --> B{운영 데이터 존재?}
+    B -->|있음| C[KPI, 추천 액션, 지식팩 건강도, 워크플로우 랭킹 표시]
+    B -->|일부만 있음| D[수집된 데이터 기준으로 표시 가능한 섹션 유지]
+    B -->|없음| E[상담 로그 업로드, 지식팩 검토, 시뮬레이션 CTA 표시]
+    B -->|오류| F[제품 용어의 오류 안내 표시]
+    C --> G[종료]
+    D --> G
+    E --> G
+    F --> G
+```
+
+## Design Diff
+
+### As-is vs To-be
+
+| 영역              | As-is                                        | To-be                                                                      | 변경 내용                                  |
+| ----------------- | -------------------------------------------- | -------------------------------------------------------------------------- | ------------------------------------------ |
+| 대시보드 subtitle | 필터와 배치 구조를 먼저 고정한다는 준비 문구 | 운영자가 상담 처리 흐름, 자동화 커버리지, 지식팩 상태를 확인하는 화면 설명 | 구현 준비 표현 제거                        |
+| partial 상태      | 후속 데이터 연결을 기다린다는 표현           | 선택 기간에 수집된 로그 기준으로 표시 가능한 데이터와 미집계 항목을 설명   | 데이터 없음과 미구현을 구분                |
+| empty 상태 CTA    | 상담 업로드, 지식팩 생성, 시뮬레이션 시작    | 상담 업로드, 지식팩 검토, 시뮬레이션 시작                                  | 실제 이동 경로와 운영자의 다음 행동을 맞춤 |
+| 하단 placeholder  | Metric/Chart/Table `DashboardSlot` 카드 노출 | 실제 데이터 섹션만 노출                                                    | 의미 없는 placeholder 제거                 |
+
+## Component Tree
+
+```
+WorkspaceDashboardPage
+├─ DashboardFilters
+├─ FilterSummary
+├─ ActionRecommendationsPanel
+├─ DashboardMetricsGrid
+├─ AutomationCoveragePanel
+├─ KnowledgePackHealthPanel
+├─ HotpathWorkflowRankingPanel
+└─ DashboardStatePanel
+```
+
+## API Integration
+
+### Endpoints
+
+이번 변경은 기존 대시보드 API 호출 방식을 바꾸지 않는다.
+
+| Method | Path                                                                                                    | Description                     |
+| ------ | ------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| GET    | 확인된 상위 경로: `frontend/src/features/consultation/api/consultationApi.ts`                           | 상담 KPI와 워크플로우 랭킹 조회 |
+| GET    | 확인된 상위 경로: `frontend/src/features/workspace-dashboard-health/api/workspaceDashboardHealthApi.ts` | 추천 액션 조회                  |
+
+## Data Flow
+
+기존 `WorkspaceDashboardPage`의 로컬 상태와 API 응답 흐름을 유지한다. `DashboardStatePanel`은 `loading`, `error`, `empty`, `partial` 상태를 그대로 받되, 화면 문구만 운영 데이터 조건 중심으로 정리한다.
+
+## 수정 대상 파일
+
+| 파일                                                                  | 변경 유형 | 설명                                                              |
+| --------------------------------------------------------------------- | --------- | ----------------------------------------------------------------- |
+| `frontend/src/pages/workspace/ui/WorkspaceDashboardPage.tsx`          | modify    | subtitle, 상태 문구, empty CTA label 정리 및 `DashboardSlot` 제거 |
+| `frontend/src/pages/workspace/ui/workspace-dashboard-page.module.css` | modify    | 제거된 slot placeholder 전용 스타일 정리                          |
+| `frontend/src/pages/workspace/ui/WorkspaceDashboardPage.test.tsx`     | modify    | 준비 문구와 placeholder가 렌더링되지 않는지 회귀 검증             |
+
+## State Management
+
+- 서버 상태: 기존 `consultationApi.getMetrics`, `consultationApi.getWorkflowRankings`, `fetchWorkspaceDashboardActionRecommendations` 호출을 유지한다.
+- 클라이언트 상태: 기존 필터 상태와 `DashboardDataState` 계산을 유지한다.
+- 신규 전역 상태나 query key는 추가하지 않는다.
+
+## Tests
+
+### Test Strategy
+
+| 구분                 | 방법                                                                      | 도구                          | 비고                              |
+| -------------------- | ------------------------------------------------------------------------- | ----------------------------- | --------------------------------- |
+| 컴포넌트 회귀 테스트 | 대시보드 렌더링 결과에서 준비 문구/placeholder 부재와 기존 섹션 유지 확인 | Vitest, React Testing Library | `WorkspaceDashboardPage.test.tsx` |
+| 수동 확인            | 화면에서 subtitle, partial/empty copy, CTA label 확인                     | 브라우저                      | 필요한 경우 로컬 Vite 화면 확인   |
+
+### Acceptance Criteria
+
+- 대시보드에 구현 준비 상태를 설명하는 문구가 보이지 않는다.
+- 데이터 없음은 기능 미구현이 아니라 선택 기간과 운영 로그 조건으로 설명된다.
+- `DashboardSlot` placeholder 카드가 렌더링되지 않는다.
+- empty CTA가 상담 업로드, 지식팩 검토, 시뮬레이션 시작 경로와 일치한다.
+- 기존 KPI, 자동화 커버리지, 추천 액션, 운영 지식팩 건강도, 핫패스 워크플로우 랭킹 렌더링은 유지된다.
+
+## Non-goals
+
+- 신규 KPI, 차트, 시뮬레이션 기반 추천 추가는 포함하지 않는다.
+- API contract, 라우팅 구조, generated API 파일은 변경하지 않는다.
+- 대시보드 레이아웃의 전면 재설계는 포함하지 않는다.
+
+## Open Questions
+
+- 없음. issue #633의 범위는 기존 화면에 남은 준비 문구와 placeholder 정리로 충분히 특정되어 있다.

--- a/frontend/src/pages/workspace/ui/WorkspaceDashboardPage.test.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceDashboardPage.test.tsx
@@ -5,12 +5,19 @@ import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { consultationApi } from "@/features/consultation/api/consultationApi";
 import { fetchWorkspaceDashboardActionRecommendations } from "@/features/workspace-dashboard-health/api/workspaceDashboardHealthApi";
 
-import { DashboardStatePanel, WorkspaceDashboardPage } from "./WorkspaceDashboardPage";
+import {
+  DashboardStatePanel,
+  WorkspaceDashboardPage,
+} from "./WorkspaceDashboardPage";
 
 const setCrumbs = vi.fn();
 const mockedGetMetrics = vi.mocked(consultationApi.getMetrics);
-const mockedGetWorkflowRankings = vi.mocked(consultationApi.getWorkflowRankings);
-const mockedFetchActionRecommendations = vi.mocked(fetchWorkspaceDashboardActionRecommendations);
+const mockedGetWorkflowRankings = vi.mocked(
+  consultationApi.getWorkflowRankings,
+);
+const mockedFetchActionRecommendations = vi.mocked(
+  fetchWorkspaceDashboardActionRecommendations,
+);
 
 const metricsResponse = {
   workspaceId: 1,
@@ -158,7 +165,8 @@ const actionRecommendationResponse = {
       priority: 95,
       sourceLabel: "시뮬레이션에서 발견됨",
       title: "개선 후보 생성",
-      description: "미처리 시뮬레이션 피드백이 있어 지식팩 개선 후보로 정리할 수 있습니다.",
+      description:
+        "미처리 시뮬레이션 피드백이 있어 지식팩 개선 후보로 정리할 수 있습니다.",
       evidenceLabel: "Open feedback",
       evidenceValue: "4건",
       targetPath: "/workspaces/1/simulation?feedbackStatus=OPEN",
@@ -171,18 +179,30 @@ function renderPage(path = "/workspaces/1/dashboard") {
   render(
     <MemoryRouter initialEntries={[path]}>
       <Routes>
-        <Route path="/workspaces/:workspaceId/dashboard" element={<WorkspaceDashboardPage />} />
-        <Route path="/workspaces" element={<div data-testid="workspace-root" />} />
+        <Route
+          path="/workspaces/:workspaceId/dashboard"
+          element={<WorkspaceDashboardPage />}
+        />
+        <Route
+          path="/workspaces"
+          element={<div data-testid="workspace-root" />}
+        />
       </Routes>
     </MemoryRouter>,
   );
 }
 
 vi.mock("react-router-dom", async () => {
-  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  const actual =
+    await vi.importActual<typeof import("react-router-dom")>(
+      "react-router-dom",
+    );
   return {
     ...actual,
-    useOutletContext: () => ({ setCrumbs, workspace: { id: 1, name: "CS Team" } }),
+    useOutletContext: () => ({
+      setCrumbs,
+      workspace: { id: 1, name: "CS Team" },
+    }),
   };
 });
 
@@ -193,9 +213,12 @@ vi.mock("@/features/consultation/api/consultationApi", () => ({
   },
 }));
 
-vi.mock("@/features/workspace-dashboard-health/api/workspaceDashboardHealthApi", () => ({
-  fetchWorkspaceDashboardActionRecommendations: vi.fn(),
-}));
+vi.mock(
+  "@/features/workspace-dashboard-health/api/workspaceDashboardHealthApi",
+  () => ({
+    fetchWorkspaceDashboardActionRecommendations: vi.fn(),
+  }),
+);
 
 vi.mock("sonner", () => ({
   toast: {
@@ -205,7 +228,9 @@ vi.mock("sonner", () => ({
 
 vi.mock("@/features/workspace-dashboard-health", () => ({
   KnowledgePackHealthPanel: ({ workspaceId }: { workspaceId: number }) => (
-    <section data-testid="knowledge-health-panel">workspace {workspaceId} health</section>
+    <section data-testid="knowledge-health-panel">
+      workspace {workspaceId} health
+    </section>
   ),
 }));
 
@@ -216,7 +241,9 @@ describe("WorkspaceDashboardPage", () => {
     mockedFetchActionRecommendations.mockReset();
     mockedGetMetrics.mockResolvedValue(metricsResponse);
     mockedGetWorkflowRankings.mockResolvedValue(workflowRankingResponse);
-    mockedFetchActionRecommendations.mockResolvedValue(actionRecommendationResponse);
+    mockedFetchActionRecommendations.mockResolvedValue(
+      actionRecommendationResponse,
+    );
   });
 
   it("잘못된 workspaceId면 /workspaces로 리다이렉트한다", () => {
@@ -230,7 +257,17 @@ describe("WorkspaceDashboardPage", () => {
   it("공통 필터와 상담 처리 KPI, 추천 액션, 운영 지식팩 건강도, 핫패스 랭킹을 표시한다", async () => {
     renderPage();
 
-    expect(screen.getByRole("heading", { name: "대시보드" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "대시보드" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "상담 처리 흐름, 자동화 커버리지, 운영 지식팩 상태를 한 화면에서 확인합니다.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/필터와 배치 구조를 먼저 고정합니다/),
+    ).not.toBeInTheDocument();
     expect(screen.getByLabelText("기간 필터")).toBeInTheDocument();
     expect(screen.getByLabelText("운영 지식팩 버전 필터")).toHaveValue("all");
     expect(screen.getByLabelText("채널 필터")).toHaveValue("all");
@@ -239,40 +276,66 @@ describe("WorkspaceDashboardPage", () => {
     expect(await screen.findByText("120")).toBeInTheDocument();
     expect(screen.getByText("1분 15초")).toBeInTheDocument();
     expect(screen.getByText("전 기간 +20.0%")).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "자동화 커버리지" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "자동화 커버리지" }),
+    ).toBeInTheDocument();
     expect(screen.getByText("계측 확인")).toBeInTheDocument();
     expect(screen.getByText("60.0%")).toBeInTheDocument();
     expect(screen.getByText("21.7%")).toBeInTheDocument();
     expect(screen.getByText("72.9%")).toBeInTheDocument();
     expect(screen.getByText("2026-05-29")).toBeInTheDocument();
-    expect(await screen.findByRole("heading", { name: "추천 액션" })).toBeInTheDocument();
+    expect(
+      await screen.findByRole("heading", { name: "추천 액션" }),
+    ).toBeInTheDocument();
     expect(screen.getByText("환불 처리 workflow 점검")).toBeInTheDocument();
     expect(screen.getByText("+33.3%")).toBeInTheDocument();
     expect(screen.getByText("시뮬레이션에서 발견됨")).toBeInTheDocument();
     expect(screen.getByText("4건")).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /환불 처리 workflow 점검/ })).toHaveAttribute(
+    expect(
+      screen.getByRole("link", { name: /환불 처리 workflow 점검/ }),
+    ).toHaveAttribute(
       "href",
       "/workspaces/1/domain-packs/11/workflows/100?versionId=22",
     );
-    expect(screen.getByRole("link", { name: /개선 후보 생성/ })).toHaveAttribute(
-      "href",
-      "/workspaces/1/simulation?feedbackStatus=OPEN",
+    expect(
+      screen.getByRole("link", { name: /개선 후보 생성/ }),
+    ).toHaveAttribute("href", "/workspaces/1/simulation?feedbackStatus=OPEN");
+    expect(screen.getByTestId("knowledge-health-panel")).toHaveTextContent(
+      "workspace 1 health",
     );
-    expect(screen.getByTestId("knowledge-health-panel")).toHaveTextContent("workspace 1 health");
-    expect(await screen.findByText("핫패스 워크플로우 랭킹")).toBeInTheDocument();
+    expect(
+      await screen.findByText("핫패스 워크플로우 랭킹"),
+    ).toBeInTheDocument();
     expect(screen.getByTestId("hotpath-top-1")).toHaveTextContent("환불 처리");
     expect(screen.getByTestId("hotpath-row-1")).toHaveTextContent("급증");
-    expect(screen.getAllByRole("link", { name: /환불 처리/ })[0]).toHaveAttribute(
+    expect(
+      screen.getAllByRole("link", { name: /환불 처리/ })[0],
+    ).toHaveAttribute(
       "href",
       "/workspaces/1/domain-packs/11/workflows/100?versionId=22",
     );
-    expect(screen.getByTestId("hotpath-row-2")).toHaveTextContent("상세 준비 중");
-    await waitFor(() => expect(mockedGetMetrics).toHaveBeenCalledWith(1, expect.any(Object)));
+    expect(screen.getByTestId("hotpath-row-2")).toHaveTextContent(
+      "상세 준비 중",
+    );
+    expect(
+      screen.queryByLabelText("대시보드 카드와 차트 배치 영역"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/연결될 자리입니다/)).not.toBeInTheDocument();
+    expect(screen.queryByTestId("dashboard-partial")).not.toBeInTheDocument();
     await waitFor(() =>
-      expect(mockedGetWorkflowRankings).toHaveBeenCalledWith(1, expect.any(Object)),
+      expect(mockedGetMetrics).toHaveBeenCalledWith(1, expect.any(Object)),
     );
     await waitFor(() =>
-      expect(mockedFetchActionRecommendations).toHaveBeenCalledWith(1, expect.any(Object)),
+      expect(mockedGetWorkflowRankings).toHaveBeenCalledWith(
+        1,
+        expect.any(Object),
+      ),
+    );
+    await waitFor(() =>
+      expect(mockedFetchActionRecommendations).toHaveBeenCalledWith(
+        1,
+        expect.any(Object),
+      ),
     );
   });
 
@@ -280,12 +343,18 @@ describe("WorkspaceDashboardPage", () => {
     renderPage();
 
     fireEvent.click(screen.getByRole("button", { name: "사용자 지정" }));
-    fireEvent.change(screen.getByLabelText("시작일"), { target: { value: "2026-06-01" } });
-    fireEvent.change(screen.getByLabelText("종료일"), { target: { value: "2026-06-03" } });
+    fireEvent.change(screen.getByLabelText("시작일"), {
+      target: { value: "2026-06-01" },
+    });
+    fireEvent.change(screen.getByLabelText("종료일"), {
+      target: { value: "2026-06-03" },
+    });
     fireEvent.change(screen.getByLabelText("운영 지식팩 버전 필터"), {
       target: { value: "published" },
     });
-    fireEvent.change(screen.getByLabelText("채널 필터"), { target: { value: "email" } });
+    fireEvent.change(screen.getByLabelText("채널 필터"), {
+      target: { value: "email" },
+    });
     fireEvent.change(screen.getByLabelText("워크플로우 상태 필터"), {
       target: { value: "handoff" },
     });
@@ -377,8 +446,16 @@ describe("WorkspaceDashboardPage", () => {
       "href",
       "/workspaces/1/domain-packs",
     );
-    expect(screen.getByTestId("dashboard-simulation-cta")).toHaveAttribute("href", "/demo/chat/1");
-    expect(screen.getByTestId("recommendation-empty")).toHaveTextContent("현재 큰 이상 없음");
+    expect(
+      screen.getByRole("link", { name: /지식팩 검토/ }),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("dashboard-simulation-cta")).toHaveAttribute(
+      "href",
+      "/demo/chat/1",
+    );
+    expect(screen.getByTestId("recommendation-empty")).toHaveTextContent(
+      "현재 큰 이상 없음",
+    );
   });
 
   it("상담 KPI가 실패해도 워크플로우 랭킹은 같은 화면에 남긴다", async () => {
@@ -386,8 +463,13 @@ describe("WorkspaceDashboardPage", () => {
 
     renderPage();
 
-    expect(await screen.findByText("핫패스 워크플로우 랭킹")).toBeInTheDocument();
+    expect(
+      await screen.findByText("핫패스 워크플로우 랭킹"),
+    ).toBeInTheDocument();
     expect(screen.getByTestId("hotpath-row-1")).toHaveTextContent("환불 처리");
+    expect(screen.getByTestId("dashboard-partial")).toHaveTextContent(
+      "일부 운영 데이터만 확인됩니다.",
+    );
     expect(screen.queryByTestId("dashboard-error")).not.toBeInTheDocument();
   });
 
@@ -412,5 +494,9 @@ describe("WorkspaceDashboardPage", () => {
       </MemoryRouter>,
     );
     expect(screen.getByTestId("dashboard-partial")).toBeInTheDocument();
+    expect(screen.getByTestId("dashboard-partial")).toHaveTextContent(
+      "일부 운영 데이터만 확인됩니다.",
+    );
+    expect(screen.queryByText(/후속 데이터 연결/)).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/workspace/ui/WorkspaceDashboardPage.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceDashboardPage.tsx
@@ -5,7 +5,6 @@ import {
   CheckCircle2Icon,
   FileUpIcon,
   FlaskConicalIcon,
-  PackagePlusIcon,
   RefreshCwIcon,
 } from "lucide-react";
 import { toast } from "sonner";
@@ -108,7 +107,10 @@ function toDateInputValue(date: Date): string {
   return `${year}-${month}-${day}`;
 }
 
-function buildMetricDateRange(filters: DashboardFilters): { from?: string; to?: string } {
+function buildMetricDateRange(filters: DashboardFilters): {
+  from?: string;
+  to?: string;
+} {
   if (filters.period === "custom") {
     return filters.customFrom && filters.customTo
       ? { from: filters.customFrom, to: filters.customTo }
@@ -145,9 +147,15 @@ function buildPeriodSummary(filters: DashboardFilters): string {
 function FilterSummary({ filters }: { filters: DashboardFilters }) {
   const summaryItems = [
     ["기간", buildPeriodSummary(filters)],
-    ["운영 지식팩", getOptionLabel(DOMAIN_PACK_VERSION_OPTIONS, filters.domainPackVersion)],
+    [
+      "운영 지식팩",
+      getOptionLabel(DOMAIN_PACK_VERSION_OPTIONS, filters.domainPackVersion),
+    ],
     ["채널", getOptionLabel(CHANNEL_OPTIONS, filters.channel)],
-    ["워크플로우", getOptionLabel(WORKFLOW_STATUS_OPTIONS, filters.workflowStatus)],
+    [
+      "워크플로우",
+      getOptionLabel(WORKFLOW_STATUS_OPTIONS, filters.workflowStatus),
+    ],
   ];
 
   return (
@@ -169,7 +177,10 @@ function formatCount(value: MetricValue, state: DashboardDataState): string {
   return new Intl.NumberFormat("ko-KR").format(value);
 }
 
-function formatDuration(seconds: MetricValue, state: DashboardDataState): string {
+function formatDuration(
+  seconds: MetricValue,
+  state: DashboardDataState,
+): string {
   if (state === "loading") return "로딩중";
   if (state === "error") return "--";
   if (typeof seconds !== "number" || !Number.isFinite(seconds)) return "--";
@@ -179,9 +190,16 @@ function formatDuration(seconds: MetricValue, state: DashboardDataState): string
   return remainder === 0 ? `${minutes}분` : `${minutes}분 ${remainder}초`;
 }
 
-function formatDelta(delta: number | null | undefined, state: DashboardDataState): string {
+function formatDelta(
+  delta: number | null | undefined,
+  state: DashboardDataState,
+): string {
   if (state === "loading") return "전 기간 계산 중";
-  if (state === "error" || typeof delta !== "number" || !Number.isFinite(delta)) {
+  if (
+    state === "error" ||
+    typeof delta !== "number" ||
+    !Number.isFinite(delta)
+  ) {
     return "전 기간 --";
   }
   const sign = delta > 0 ? "+" : "";
@@ -206,7 +224,9 @@ function hasMetricData(metrics: ConsultationMetrics | null): boolean {
   );
 }
 
-function hasWorkflowRankingData(rankings: WorkspaceWorkflowRankingResponse | null): boolean {
+function hasWorkflowRankingData(
+  rankings: WorkspaceWorkflowRankingResponse | null,
+): boolean {
   return (rankings?.rankings?.length ?? 0) > 0;
 }
 
@@ -368,7 +388,10 @@ function TopWorkflowCard({
   }
 
   return (
-    <article className={styles.hotpathCard} data-testid={`hotpath-top-${item.rank}`}>
+    <article
+      className={styles.hotpathCard}
+      data-testid={`hotpath-top-${item.rank}`}
+    >
       {body}
       <span className={styles.unavailableText}>상세 준비 중</span>
     </article>
@@ -382,7 +405,8 @@ function AutomationCoveragePanel({
   coverage: ConsultationCoverageMetrics | null | undefined;
   state: DashboardDataState;
 }) {
-  const needsInstrumentation = coverage?.measurementStatus === "NEEDS_INSTRUMENTATION";
+  const needsInstrumentation =
+    coverage?.measurementStatus === "NEEDS_INSTRUMENTATION";
   const measurementStatus =
     state === "loading" ? "LOADING" : (coverage?.measurementStatus ?? "EMPTY");
   const measurementLabel =
@@ -394,10 +418,16 @@ function AutomationCoveragePanel({
           ? "계측 확인"
           : "--";
   const trend = coverage?.trend ?? [];
-  const maxTrendTotal = Math.max(1, ...trend.map((point) => point.totalConsultationCount));
+  const maxTrendTotal = Math.max(
+    1,
+    ...trend.map((point) => point.totalConsultationCount),
+  );
 
   return (
-    <section className={styles.coveragePanel} aria-labelledby="automation-coverage-title">
+    <section
+      className={styles.coveragePanel}
+      aria-labelledby="automation-coverage-title"
+    >
       <div className={styles.coverageHeader}>
         <div>
           <span className={styles.panelEyebrow}>Automation Coverage</span>
@@ -408,7 +438,10 @@ function AutomationCoveragePanel({
             운영 지식팩이 실제 상담을 workflow로 얼마나 커버했는지 확인합니다.
           </p>
         </div>
-        <span className={styles.measurementBadge} data-status={measurementStatus}>
+        <span
+          className={styles.measurementBadge}
+          data-status={measurementStatus}
+        >
           {measurementLabel}
         </span>
       </div>
@@ -427,7 +460,10 @@ function AutomationCoveragePanel({
         />
         <CoverageMetricCard
           label="Intent Success"
-          value={formatPercent(coverage?.intentClassificationSuccessRate, state)}
+          value={formatPercent(
+            coverage?.intentClassificationSuccessRate,
+            state,
+          )}
           description={`${formatCount(coverage?.intentClassificationSuccessCount, state)}건의 intent 분류 성공`}
         />
         <CoverageMetricCard
@@ -519,7 +555,10 @@ function WorkflowRankingTable({
                 <td>#{item.rank}</td>
                 <td>
                   {item.detailPath ? (
-                    <Link to={item.detailPath} className={styles.workflowDetailLink}>
+                    <Link
+                      to={item.detailPath}
+                      className={styles.workflowDetailLink}
+                    >
                       {workflowName}
                     </Link>
                   ) : (
@@ -538,7 +577,9 @@ function WorkflowRankingTable({
                 <td>
                   <span className={styles.changeCell}>
                     {formatDelta(item.changeRate, state)}
-                    {item.surging ? <span className={styles.surgeBadge}>급증</span> : null}
+                    {item.surging ? (
+                      <span className={styles.surgeBadge}>급증</span>
+                    ) : null}
                   </span>
                 </td>
               </tr>
@@ -563,7 +604,10 @@ function HotpathWorkflowRankingPanel({
   const allRankings = rankings?.rankings ?? [];
 
   return (
-    <section className={styles.hotpathPanel} aria-labelledby="hotpath-ranking-title">
+    <section
+      className={styles.hotpathPanel}
+      aria-labelledby="hotpath-ranking-title"
+    >
       <div className={styles.panelHeader}>
         <div>
           <span className={styles.panelEyebrow}>HOTPATH</span>
@@ -571,7 +615,8 @@ function HotpathWorkflowRankingPanel({
             핫패스 워크플로우 랭킹
           </h2>
           <p className={styles.sectionDescription}>
-            선택 기간의 실행량과 전 기간 대비 증가율을 기준으로 우선 개선 대상을 확인합니다.
+            선택 기간의 실행량과 전 기간 대비 증가율을 기준으로 우선 개선 대상을
+            확인합니다.
           </p>
         </div>
         <span className={styles.totalBadge}>
@@ -588,13 +633,17 @@ function HotpathWorkflowRankingPanel({
       {!error && state === "loading" ? (
         <div className={styles.hotpathState} data-testid="hotpath-loading">
           <LoadingSpinner />
-          <p className={styles.stateText}>워크플로우 랭킹을 불러오는 중입니다.</p>
+          <p className={styles.stateText}>
+            워크플로우 랭킹을 불러오는 중입니다.
+          </p>
         </div>
       ) : null}
 
       {!error && state !== "loading" && allRankings.length === 0 ? (
         <div className={styles.hotpathState} data-testid="hotpath-empty">
-          <p className={styles.stateText}>선택 기간에 집계할 워크플로우 실행이 없습니다.</p>
+          <p className={styles.stateText}>
+            선택 기간에 집계할 워크플로우 실행이 없습니다.
+          </p>
         </div>
       ) : null}
 
@@ -616,12 +665,18 @@ function HotpathWorkflowRankingPanel({
   );
 }
 
-function ActionRecommendationCard({ item }: { item: WorkspaceDashboardActionRecommendation }) {
+function ActionRecommendationCard({
+  item,
+}: {
+  item: WorkspaceDashboardActionRecommendation;
+}) {
   return (
     <Link to={item.targetPath} className={styles.recommendationCard}>
       <span className={styles.recommendationMeta}>
         <span className={styles.sourceBadge}>{item.sourceLabel}</span>
-        <span className={styles.ruleBadge}>{item.ruleCode.replaceAll("_", " ")}</span>
+        <span className={styles.ruleBadge}>
+          {item.ruleCode.replaceAll("_", " ")}
+        </span>
       </span>
       <h3>{item.title}</h3>
       <p>{item.description}</p>
@@ -651,7 +706,10 @@ function ActionRecommendationsPanel({
   const items = recommendations?.recommendations ?? [];
 
   return (
-    <section className={styles.recommendationPanel} aria-labelledby="action-recommendation-title">
+    <section
+      className={styles.recommendationPanel}
+      aria-labelledby="action-recommendation-title"
+    >
       <div className={styles.panelHeader}>
         <div>
           <span className={styles.panelEyebrow}>Next Actions</span>
@@ -665,20 +723,29 @@ function ActionRecommendationsPanel({
       </div>
 
       {error ? (
-        <div className={styles.recommendationState} data-testid="recommendation-error">
+        <div
+          className={styles.recommendationState}
+          data-testid="recommendation-error"
+        >
           <ErrorState message={error} />
         </div>
       ) : null}
 
       {!error && state === "loading" ? (
-        <div className={styles.recommendationState} data-testid="recommendation-loading">
+        <div
+          className={styles.recommendationState}
+          data-testid="recommendation-loading"
+        >
           <LoadingSpinner />
           <p className={styles.stateText}>추천 액션을 계산하는 중입니다.</p>
         </div>
       ) : null}
 
       {!error && state !== "loading" && items.length === 0 ? (
-        <div className={styles.recommendationState} data-testid="recommendation-empty">
+        <div
+          className={styles.recommendationState}
+          data-testid="recommendation-empty"
+        >
           <CheckCircle2Icon aria-hidden="true" className={styles.panelIcon} />
           <p className={styles.stateText}>현재 큰 이상 없음</p>
         </div>
@@ -702,19 +769,26 @@ function DashboardFilters({
   filters: DashboardFilters;
   onChange: (filters: DashboardFilters) => void;
 }) {
-  const updateFilter = <K extends keyof DashboardFilters>(key: K, value: DashboardFilters[K]) => {
+  const updateFilter = <K extends keyof DashboardFilters>(
+    key: K,
+    value: DashboardFilters[K],
+  ) => {
     onChange({ ...filters, [key]: value });
   };
 
   return (
-    <section className={styles.filterBar} aria-labelledby="dashboard-filter-title">
+    <section
+      className={styles.filterBar}
+      aria-labelledby="dashboard-filter-title"
+    >
       <div className={styles.filterHeader}>
         <div>
           <h2 id="dashboard-filter-title" className={styles.sectionTitle}>
             공통 필터
           </h2>
           <p className={styles.sectionDescription}>
-            아래 카드와 차트가 같은 기준을 바라보도록 필터 상태를 먼저 고정합니다.
+            대시보드 섹션이 같은 기간과 운영 조건을 기준으로 집계되도록
+            설정합니다.
           </p>
         </div>
       </div>
@@ -743,7 +817,9 @@ function DashboardFilters({
             <input
               type="date"
               value={filters.customFrom}
-              onChange={(event) => updateFilter("customFrom", event.target.value)}
+              onChange={(event) =>
+                updateFilter("customFrom", event.target.value)
+              }
             />
           </label>
           <label className={styles.field}>
@@ -762,7 +838,9 @@ function DashboardFilters({
           <span>운영 지식팩 버전</span>
           <NativeSelect
             value={filters.domainPackVersion}
-            onChange={(event) => updateFilter("domainPackVersion", event.target.value)}
+            onChange={(event) =>
+              updateFilter("domainPackVersion", event.target.value)
+            }
             aria-label="운영 지식팩 버전 필터"
             size="sm"
           >
@@ -792,7 +870,9 @@ function DashboardFilters({
           <span>Workflow Status</span>
           <NativeSelect
             value={filters.workflowStatus}
-            onChange={(event) => updateFilter("workflowStatus", event.target.value)}
+            onChange={(event) =>
+              updateFilter("workflowStatus", event.target.value)
+            }
             aria-label="워크플로우 상태 필터"
             size="sm"
           >
@@ -808,33 +888,17 @@ function DashboardFilters({
   );
 }
 
-function DashboardSlot({
-  label,
-  title,
-  description,
-}: {
-  label: string;
-  title: string;
-  description: string;
-}) {
-  return (
-    <article className={styles.slotCard}>
-      <span className={styles.slotLabel}>{label}</span>
-      <h3>{title}</h3>
-      <p>{description}</p>
-      <div className={styles.slotPlaceholder} aria-hidden="true">
-        <span />
-        <span />
-        <span />
-      </div>
-    </article>
-  );
-}
-
-export function DashboardStatePanel({ state, workspaceId }: DashboardStatePanelProps) {
+export function DashboardStatePanel({
+  state,
+  workspaceId,
+}: DashboardStatePanelProps) {
   if (state === "loading") {
     return (
-      <section className={styles.statePanel} data-testid="dashboard-loading" aria-live="polite">
+      <section
+        className={styles.statePanel}
+        data-testid="dashboard-loading"
+        aria-live="polite"
+      >
         <LoadingSpinner />
         <p className={styles.stateText}>대시보드 데이터를 불러오는 중입니다.</p>
       </section>
@@ -853,9 +917,12 @@ export function DashboardStatePanel({ state, workspaceId }: DashboardStatePanelP
     return (
       <section className={styles.partialPanel} data-testid="dashboard-partial">
         <div>
-          <span className={styles.panelEyebrow}>METRICS CONNECTED</span>
-          <h2>상담 처리 요약 지표가 연결되었습니다.</h2>
-          <p>차트와 운영 주의 항목은 같은 필터 기준을 유지하며 후속 데이터 연결을 기다립니다.</p>
+          <span className={styles.panelEyebrow}>PARTIAL DATA</span>
+          <h2>일부 운영 데이터만 확인됩니다.</h2>
+          <p>
+            선택 기간에 수집된 상담 로그 기준으로 확인 가능한 지표를 먼저
+            표시합니다. 값이 없는 항목은 해당 운영 기록이 쌓이면 계산됩니다.
+          </p>
         </div>
         <RefreshCwIcon aria-hidden="true" className={styles.panelIcon} />
       </section>
@@ -868,25 +935,34 @@ export function DashboardStatePanel({ state, workspaceId }: DashboardStatePanelP
         <span className={styles.panelEyebrow}>GET STARTED</span>
         <h2>아직 대시보드에 표시할 운영 데이터가 없습니다.</h2>
         <p>
-          상담 로그를 업로드하고 운영 지식팩을 준비한 뒤, 시뮬레이션으로 워크플로우 흐름을
-          확인하세요.
+          상담 로그를 업로드하고 운영 지식팩 검토를 마친 뒤, 시뮬레이션으로
+          워크플로우 흐름을 확인하세요.
         </p>
       </div>
       <div className={styles.ctaGrid}>
         <Button asChild variant="default">
-          <Link to={`/workspaces/${workspaceId}/upload`} data-testid="dashboard-upload-cta">
+          <Link
+            to={`/workspaces/${workspaceId}/upload`}
+            data-testid="dashboard-upload-cta"
+          >
             <FileUpIcon aria-hidden="true" />
             상담 업로드
           </Link>
         </Button>
         <Button asChild variant="outline">
-          <Link to={`/workspaces/${workspaceId}/domain-packs`} data-testid="dashboard-pack-cta">
-            <PackagePlusIcon aria-hidden="true" />
-            지식팩 생성
+          <Link
+            to={`/workspaces/${workspaceId}/domain-packs`}
+            data-testid="dashboard-pack-cta"
+          >
+            <CheckCircle2Icon aria-hidden="true" />
+            지식팩 검토
           </Link>
         </Button>
         <Button asChild variant="outline">
-          <Link to={buildDemoChatPath(workspaceId)} data-testid="dashboard-simulation-cta">
+          <Link
+            to={buildDemoChatPath(workspaceId)}
+            data-testid="dashboard-simulation-cta"
+          >
             <FlaskConicalIcon aria-hidden="true" />
             시뮬레이션 시작
           </Link>
@@ -904,16 +980,24 @@ export function WorkspaceDashboardPage() {
   const [metrics, setMetrics] = useState<ConsultationMetrics | null>(null);
   const [isMetricsLoading, setIsMetricsLoading] = useState(false);
   const [metricsError, setMetricsError] = useState<string | null>(null);
-  const [workflowRankings, setWorkflowRankings] = useState<WorkspaceWorkflowRankingResponse | null>(
-    null,
-  );
-  const [isWorkflowRankingsLoading, setIsWorkflowRankingsLoading] = useState(false);
-  const [workflowRankingsError, setWorkflowRankingsError] = useState<string | null>(null);
+  const [workflowRankings, setWorkflowRankings] =
+    useState<WorkspaceWorkflowRankingResponse | null>(null);
+  const [isWorkflowRankingsLoading, setIsWorkflowRankingsLoading] =
+    useState(false);
+  const [workflowRankingsError, setWorkflowRankingsError] = useState<
+    string | null
+  >(null);
   const [actionRecommendations, setActionRecommendations] =
     useState<WorkspaceDashboardActionRecommendations | null>(null);
-  const [isActionRecommendationsLoading, setIsActionRecommendationsLoading] = useState(false);
-  const [actionRecommendationsError, setActionRecommendationsError] = useState<string | null>(null);
-  const metricDateRange = useMemo(() => buildMetricDateRange(filters), [filters]);
+  const [isActionRecommendationsLoading, setIsActionRecommendationsLoading] =
+    useState(false);
+  const [actionRecommendationsError, setActionRecommendationsError] = useState<
+    string | null
+  >(null);
+  const metricDateRange = useMemo(
+    () => buildMetricDateRange(filters),
+    [filters],
+  );
   const metricsState = useMemo<DashboardDataState>(() => {
     if (isMetricsLoading) return "loading";
     if (metricsError) return "error";
@@ -931,20 +1015,33 @@ export function WorkspaceDashboardPage() {
     if (actionRecommendationsError) return "error";
     if (hasActionRecommendationData(actionRecommendations)) return "partial";
     return "empty";
-  }, [isActionRecommendationsLoading, actionRecommendationsError, actionRecommendations]);
-  const dataState = useMemo<DashboardDataState>(() => {
+  }, [
+    isActionRecommendationsLoading,
+    actionRecommendationsError,
+    actionRecommendations,
+  ]);
+  const dataState = useMemo<DashboardDataState | null>(() => {
     const hasAnyData =
       hasMetricData(metrics) ||
       hasWorkflowRankingData(workflowRankings) ||
       hasActionRecommendationData(actionRecommendations);
     if (
-      (isMetricsLoading || isWorkflowRankingsLoading || isActionRecommendationsLoading) &&
+      (isMetricsLoading ||
+        isWorkflowRankingsLoading ||
+        isActionRecommendationsLoading) &&
       !hasAnyData
     ) {
       return "loading";
     }
-    if (hasAnyData) return "partial";
-    if (metricsError && workflowRankingsError && actionRecommendationsError) return "error";
+    if (metricsError && workflowRankingsError && actionRecommendationsError)
+      return "error";
+    if (
+      hasAnyData &&
+      (metricsError || workflowRankingsError || actionRecommendationsError)
+    ) {
+      return "partial";
+    }
+    if (hasAnyData) return null;
     return "empty";
   }, [
     isMetricsLoading,
@@ -984,7 +1081,10 @@ export function WorkspaceDashboardPage() {
       setIsMetricsLoading(true);
       setMetricsError(null);
       try {
-        const data = await consultationApi.getMetrics(parsedWorkspaceId, metricDateRange);
+        const data = await consultationApi.getMetrics(
+          parsedWorkspaceId,
+          metricDateRange,
+        );
         if (ignore) return;
         setMetrics(data);
       } catch (error) {
@@ -1036,7 +1136,10 @@ export function WorkspaceDashboardPage() {
         setActionRecommendations(data);
       } catch (error) {
         if (ignore) return;
-        console.error("Failed to load dashboard action recommendations:", error);
+        console.error(
+          "Failed to load dashboard action recommendations:",
+          error,
+        );
         setActionRecommendations(null);
         setActionRecommendationsError("추천 액션을 불러오지 못했습니다.");
         toast.error("추천 액션을 불러오지 못했습니다.");
@@ -1075,7 +1178,10 @@ export function WorkspaceDashboardPage() {
       setIsWorkflowRankingsLoading(true);
       setWorkflowRankingsError(null);
       try {
-        const data = await consultationApi.getWorkflowRankings(parsedWorkspaceId, metricDateRange);
+        const data = await consultationApi.getWorkflowRankings(
+          parsedWorkspaceId,
+          metricDateRange,
+        );
         if (ignore) return;
         setWorkflowRankings(data);
       } catch (error) {
@@ -1109,7 +1215,8 @@ export function WorkspaceDashboardPage() {
           <span className={styles.eyebrow}>Workspace Dashboard</span>
           <h1 className={styles.pageTitle}>대시보드</h1>
           <p className={styles.pageSubtitle}>
-            고객 상담 운영 지표가 연결될 공통 홈입니다. 필터와 배치 구조를 먼저 고정합니다.
+            상담 처리 흐름, 자동화 커버리지, 운영 지식팩 상태를 한 화면에서
+            확인합니다.
           </p>
         </div>
         <Button asChild variant="outline" size="sm">
@@ -1128,32 +1235,22 @@ export function WorkspaceDashboardPage() {
         error={actionRecommendationsError}
       />
       <DashboardMetricsGrid metrics={metrics} state={metricsState} />
-      <AutomationCoveragePanel coverage={metrics?.coverage} state={metricsState} />
+      <AutomationCoveragePanel
+        coverage={metrics?.coverage}
+        state={metricsState}
+      />
       <KnowledgePackHealthPanel workspaceId={parsedWorkspaceId} />
       <HotpathWorkflowRankingPanel
         rankings={workflowRankings}
         state={workflowRankingState}
         error={workflowRankingsError}
       />
-      <DashboardStatePanel state={dataState} workspaceId={parsedWorkspaceId} />
-
-      <section className={styles.slotGrid} aria-label="대시보드 카드와 차트 배치 영역">
-        <DashboardSlot
-          label="Metric"
-          title="상담 처리 KPI"
-          description="처리량, 평균 응답 시간, 완료율 카드가 연결될 자리입니다."
+      {dataState ? (
+        <DashboardStatePanel
+          state={dataState}
+          workspaceId={parsedWorkspaceId}
         />
-        <DashboardSlot
-          label="Chart"
-          title="워크플로우 흐름 추이"
-          description="기간 필터 기준으로 세션과 상태 변화 차트가 연결될 자리입니다."
-        />
-        <DashboardSlot
-          label="Table"
-          title="운영 주의 항목"
-          description="부분 데이터와 오류 상태에서도 같은 폭을 유지하는 목록 슬롯입니다."
-        />
-      </section>
+      ) : null}
     </div>
   );
 }

--- a/frontend/src/pages/workspace/ui/workspace-dashboard-page.module.css
+++ b/frontend/src/pages/workspace/ui/workspace-dashboard-page.module.css
@@ -44,7 +44,10 @@
 
 .filterBar {
   display: grid;
-  grid-template-columns: minmax(220px, 0.8fr) minmax(280px, 1fr) minmax(420px, 1.45fr);
+  grid-template-columns: minmax(220px, 0.8fr) minmax(280px, 1fr) minmax(
+      420px,
+      1.45fr
+    );
   align-items: end;
   gap: var(--s-3);
   padding: var(--s-4);
@@ -773,55 +776,6 @@
   color: var(--ink-3);
 }
 
-.slotGrid {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: var(--s-4);
-}
-
-.slotCard {
-  min-height: 220px;
-  padding: var(--s-5);
-  border: 1px solid var(--line);
-  border-radius: var(--r-3);
-  background: var(--paper);
-}
-
-.slotCard h3 {
-  margin: var(--s-3) 0 0;
-  color: var(--ink);
-  font-size: 17px;
-  font-weight: 540;
-  letter-spacing: 0;
-}
-
-.slotCard p {
-  margin: var(--s-2) 0 var(--s-5);
-  color: var(--ink-2);
-  font-size: 13px;
-  line-height: 1.6;
-}
-
-.slotPlaceholder {
-  display: grid;
-  gap: var(--s-2);
-}
-
-.slotPlaceholder span {
-  display: block;
-  height: 12px;
-  border-radius: var(--r-pill);
-  background: var(--paper-3);
-}
-
-.slotPlaceholder span:nth-child(2) {
-  width: 76%;
-}
-
-.slotPlaceholder span:nth-child(3) {
-  width: 52%;
-}
-
 @media (max-width: 960px) {
   .pageHeader,
   .emptyPanel,
@@ -833,7 +787,6 @@
   .filterSummary,
   .metricGrid,
   .coverageGrid,
-  .slotGrid,
   .recommendationGrid,
   .hotpathTopGrid {
     grid-template-columns: 1fr;


### PR DESCRIPTION
Closes #633

## 변경 사항

- 워크스페이스 대시보드 subtitle과 공통 필터 설명에서 구현 준비 상태를 암시하는 문구를 제거했습니다.
- 실제 KPI, 자동화 커버리지, 추천 액션, 운영 지식팩 건강도, 핫패스 랭킹이 붙은 화면에서 하단 placeholder 슬롯이 더 이상 렌더링되지 않도록 정리했습니다.
- 데이터 없음/부분 데이터 안내를 운영 로그 조건 중심 문구로 바꾸고, empty CTA를 상담 업로드 · 지식팩 검토 · 시뮬레이션 시작 흐름에 맞췄습니다.
- 이슈 633 스펙을 `.agent/specs/633.md`에 정리했습니다.

## 검증

- `pnpm --dir frontend test -- WorkspaceDashboardPage.test.tsx --run`
- `pnpm --dir frontend exec eslint src/pages/workspace/ui/WorkspaceDashboardPage.tsx src/pages/workspace/ui/WorkspaceDashboardPage.test.tsx`
- `pnpm exec prettier --check .agent/specs/633.md frontend/src/pages/workspace/ui/WorkspaceDashboardPage.tsx frontend/src/pages/workspace/ui/WorkspaceDashboardPage.test.tsx frontend/src/pages/workspace/ui/workspace-dashboard-page.module.css`
- `git diff --check`
- `pnpm run ci:frontend` (270 files, 2052 tests; coverage thresholds and production build passed)

## 참고

- 커밋 pre-commit hook의 `pnpm run lint:frontend`는 repository-wide 기존 lint baseline 50건으로 실패합니다. 이 PR에서 변경한 파일은 별도 ESLint 명령으로 통과 확인했고, frontend CI 경로는 통과했습니다.