### PR TITLE
feat(dx): 프론트엔드 수동 API 호출 감사를 강제

### DIFF
--- a/.agent/specs/619.md
+++ b/.agent/specs/619.md
@@ -1,0 +1,134 @@
+# Frontend 수동 API 호출 감사 제한
+
+## Goal
+
+프론트엔드에서 `apiClient`/`customFetch` 직접 호출을 명시적 예외 목록으로 제한하여, generated API가 기본 경로라는 정책을 자동 검증 가능하게 만든다.
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A[개발자: 프론트엔드 API 코드 변경] --> B{generated endpoint 사용 가능?}
+    B -->|Yes| C[generated endpoint function/hook 사용]
+    B -->|No 또는 wrapper 목적 필요| D[수동 호출 예외 사유와 범위 기록]
+    C --> E[pnpm lint]
+    D --> E
+    E --> F{감사 스크립트 통과?}
+    F -->|Yes| G[ESLint 실행 및 PR 검토 진행]
+    F -->|No| H[누락된 예외 또는 신규 수동 호출 수정]
+    H --> E
+```
+
+## Design Diff
+
+### As-is vs To-be
+
+| 영역               | As-is                                             | To-be                                          | 변경 내용                               |
+| ------------------ | ------------------------------------------------- | ---------------------------------------------- | --------------------------------------- |
+| 수동 API 호출 관리 | `apiClient`/`customFetch` 사용 여부를 검색해야 함 | production source 수동 호출을 스크립트가 검사  | 신규 직접 호출이 lint 단계에서 드러남   |
+| 예외 사유          | 파일 주석에 흩어짐                                | allowlist에 파일, 호출 대상, 사유, 범위를 기록 | 기존 호출을 단계적으로 정리할 목록 제공 |
+| generated API 정책 | `frontend/README.md`에 문서화                     | `pnpm lint`가 정책 위반을 차단                 | 문서 정책을 개발 워크플로우에 연결      |
+
+## Component Tree
+
+UI 컴포넌트 변경은 없다.
+
+```text
+frontend/
+├─ scripts/
+│  ├─ audit-manual-api-calls.mjs
+│  └─ manual-api-call-allowlist.json
+├─ package.json
+└─ README.md
+```
+
+## API Integration
+
+새로운 backend HTTP API는 추가하지 않는다. 변경 범위는 프론트엔드 개발 도구와 문서다.
+
+### Manual Call Categories
+
+| 분류                    | 허용 목적                                                                                       |
+| ----------------------- | ----------------------------------------------------------------------------------------------- |
+| OpenAPI 미생성 endpoint | backend OpenAPI/Orval 생성물이 아직 없는 endpoint 호출                                          |
+| wrapper 목적            | unwrap/select, query key 표준화, toast/error mapping, optimistic update, response normalization |
+
+## Data Flow
+
+```text
+frontend/src production files
+        │
+        ▼
+audit-manual-api-calls.mjs
+        │  scans apiClient/customFetch call expressions
+        ▼
+manual-api-call-allowlist.json
+        │  compares file + callee + endpoint fingerprint + occurrence count
+        ▼
+pnpm lint
+```
+
+## 수정 대상 파일
+
+| 파일                                              | 변경 유형 | 설명                                                          |
+| ------------------------------------------------- | --------- | ------------------------------------------------------------- |
+| `frontend/scripts/audit-manual-api-calls.mjs`     | new       | production source의 수동 API 호출을 수집하고 allowlist와 비교 |
+| `frontend/scripts/manual-api-call-allowlist.json` | new       | 기존 예외 호출의 사유, 범위, 정리 분류 기록                   |
+| `frontend/package.json`                           | update    | `audit:api` 스크립트 추가 및 `lint` 선행 검증 연결            |
+| `frontend/README.md`                              | update    | 수동 API 예외 등록/검증 절차 문서화                           |
+
+## State Management
+
+클라이언트/서버 상태 변경은 없다.
+
+## Tests
+
+### Test Strategy
+
+| 구분        | 방법                | 도구             | 비고                                        |
+| ----------- | ------------------- | ---------------- | ------------------------------------------- |
+| 정적 검증   | 수동 API 호출 감사  | `pnpm audit:api` | allowlist 누락/과잉 항목 실패               |
+| 린트 통합   | 감사 후 ESLint 실행 | `pnpm lint`      | 신규 직접 호출을 lint 단계에서 노출         |
+| 테스트 통합 | 감사 후 Vitest 실행 | `pnpm test`      | CI형 테스트 실행에서도 수동 호출 drift 노출 |
+
+### Test Environment & 사전 조건
+
+| 항목      | 값                  |
+| --------- | ------------------- |
+| 실행 위치 | `frontend/`         |
+| 사전 조건 | `pnpm install` 완료 |
+
+### Test Scenarios
+
+#### Happy Path
+
+| #   | 시나리오            | 사전 조건                               | 조작                      | 기대 결과                    |
+| --- | ------------------- | --------------------------------------- | ------------------------- | ---------------------------- |
+| 1   | 기존 예외 호출 감사 | allowlist가 현재 production 호출과 일치 | `pnpm audit:api` 실행     | 성공하고 감사된 호출 수 출력 |
+| 2   | lint 통합           | 감사와 ESLint 모두 통과                 | `pnpm lint` 실행          | 감사 후 ESLint까지 성공      |
+| 3   | test 통합           | 감사와 Vitest 모두 통과                 | `pnpm test -- --run` 실행 | 감사 후 Vitest까지 성공      |
+
+#### Error & Edge Cases
+
+| #   | 시나리오            | 조작                                                    | 기대 결과                                          |
+| --- | ------------------- | ------------------------------------------------------- | -------------------------------------------------- |
+| 1   | 신규 수동 호출 추가 | allowlist 없이 `apiClient`/`customFetch` 직접 호출 추가 | 감사 스크립트가 파일/호출 정보를 출력하고 실패     |
+| 2   | stale allowlist     | 삭제된 수동 호출이 allowlist에 남음                     | 감사 스크립트가 사용되지 않은 예외를 출력하고 실패 |
+| 3   | 예외 설명 누락      | reason/scope/wrapperPurpose 누락                        | 감사 스크립트가 allowlist 형식 오류로 실패         |
+
+## Acceptance Criteria
+
+- generated endpoint가 있는지 여부와 관계없이 신규 `apiClient`/`customFetch` 직접 호출은 allowlist에 등록되지 않으면 `pnpm lint` 또는 `pnpm test`에서 드러난다.
+- 직접 호출 예외는 allowlist에 파일, 호출 대상, endpoint fingerprint, 사유, 범위, wrapper 목적을 남긴다.
+- 기존 수동 호출은 allowlist로 단계적 정리 목록을 제공한다.
+- generated 파일은 직접 수정하지 않는다.
+
+## Non-goals
+
+- 기존 수동 호출을 generated endpoint로 일괄 전환하지 않는다.
+- backend OpenAPI 생성물 또는 Orval 생성 파일을 갱신하지 않는다.
+- UI 동작, API 계약, 인증/인가 로직을 변경하지 않는다.
+
+## Open Questions
+
+- 기존 수동 호출 중 generated endpoint가 이미 생긴 항목을 어떤 우선순위로 제거할지는 후속 정리 이슈에서 결정한다.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -4,15 +4,16 @@
 
 ## Quick Commands
 
-| 목적          | 명령어         |
-| ------------- | -------------- |
-| 개발 서버     | `pnpm dev`     |
-| 빌드          | `pnpm build`   |
-| 테스트        | `pnpm test`    |
+| 목적          | 명령어                          |
+| ------------- | ------------------------------- |
+| 개발 서버     | `pnpm dev`                      |
+| 빌드          | `pnpm build`                    |
+| 테스트        | `pnpm test`                     |
 | 커버리지 검증 | `pnpm test -- --coverage --run` |
-| 린트          | `pnpm lint`    |
-| 포맷          | `pnpm format`  |
-| API 코드 생성 | `pnpm api:gen` |
+| API 감사      | `pnpm audit:api`                |
+| 린트          | `pnpm lint`                     |
+| 포맷          | `pnpm format`                   |
+| API 코드 생성 | `pnpm api:gen`                  |
 
 ## Coverage Gate
 
@@ -75,6 +76,17 @@ Orval `afterAllFilesWrite` hook이 `pnpm api:gen` 실행 시 자동 갱신하는
 - wrapper는 unwrap/select, query key 표준화, toast/error mapping, optimistic update, response normalization 목적일 때만 유지
 - 수동 endpoint 호출을 남길 때는 해당 파일에 OpenAPI 미생성 endpoint임을 주석으로 남김
 - generated 파일은 직접 수정하지 않고 backend OpenAPI 갱신 후 `pnpm api:gen`으로 재생성
+
+### 수동 API 호출 감사
+
+`pnpm lint`와 `pnpm test`는 본 작업 전에 `pnpm audit:api`를 실행해 production source의 `apiClient`/`customFetch` 직접 호출을 검사한다. 신규 직접 호출은 기본적으로 실패하며, generated endpoint로 전환할 수 없는 예외만 `scripts/manual-api-call-allowlist.json`에 파일, 호출 대상, endpoint fingerprint, 사유, 범위, wrapper 목적을 남긴다.
+
+예외를 추가해야 하는 경우:
+
+1. generated endpoint function/hook으로 대체 가능한지 먼저 확인한다.
+2. 대체할 수 없으면 해당 파일에 OpenAPI 미생성 endpoint 또는 wrapper 목적을 간단히 주석으로 남긴다.
+3. `pnpm audit:api` 실패 출력의 fingerprint를 allowlist에 등록한다.
+4. `pnpm lint`로 감사와 ESLint를 함께 확인한다.
 
 **예시**:
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,9 +9,10 @@
     "e2e": "playwright test",
     "e2e:live": "playwright test --config=playwright.live.config.ts --grep-invert @pollutes",
     "e2e:live:pollutes": "playwright test --config=playwright.live.config.ts --grep @pollutes",
-    "test": "vp test",
+    "test": "pnpm audit:api && vp test",
     "format": "vp fmt",
-    "lint": "eslint .",
+    "audit:api": "node scripts/audit-manual-api-calls.mjs",
+    "lint": "pnpm audit:api && eslint .",
     "preview": "vp preview",
     "api:gen": "orval --config orval.config.ts"
   },

--- a/frontend/scripts/audit-manual-api-calls.mjs
+++ b/frontend/scripts/audit-manual-api-calls.mjs
@@ -1,0 +1,314 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { Node, Project } from "ts-morph";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const frontendDir = resolve(scriptDir, "..");
+const tsconfigPath = resolve(frontendDir, "tsconfig.app.json");
+const allowlistPath = resolve(scriptDir, "manual-api-call-allowlist.json");
+
+const MANUAL_API_IMPORTS = new Set(["apiClient", "customFetch"]);
+const REQUIRED_ALLOWLIST_FIELDS = ["reason", "scope", "wrapperPurpose"];
+const IGNORED_FILE_PATTERNS = [
+  /\/src\/shared\/api\/generated\//,
+  /\/src\/shared\/api\/index\.ts$/,
+  /\/src\/shared\/api\/mutator\.ts$/,
+  /\/src\/test\//,
+  /\.test\.[cm]?[tj]sx?$/,
+  /\.spec\.[cm]?[tj]sx?$/,
+];
+
+function loadAllowlist() {
+  const raw = JSON.parse(readFileSync(allowlistPath, "utf8"));
+  if (!Array.isArray(raw.entries)) {
+    throw new Error(
+      "manual-api-call-allowlist.json must contain an entries array.",
+    );
+  }
+  return raw.entries;
+}
+
+function isManualApiImportModule(moduleSpecifier) {
+  return (
+    moduleSpecifier === "@/shared/api" ||
+    moduleSpecifier === "@/shared/api/mutator" ||
+    moduleSpecifier.endsWith("/shared/api") ||
+    moduleSpecifier.endsWith("/shared/api/mutator")
+  );
+}
+
+function isIgnoredFile(filePath) {
+  const normalized = filePath.replaceAll("\\", "/");
+  return IGNORED_FILE_PATTERNS.some((pattern) => pattern.test(normalized));
+}
+
+function endpointFingerprint(argument) {
+  if (!argument) {
+    return "<missing>";
+  }
+
+  if (
+    Node.isStringLiteral(argument) ||
+    Node.isNoSubstitutionTemplateLiteral(argument)
+  ) {
+    return argument.getLiteralText();
+  }
+
+  if (Node.isTemplateExpression(argument)) {
+    return argument
+      .getTemplateSpans()
+      .reduce(
+        (text, span) => `${text}\${}${span.getLiteral().getLiteralText()}`,
+        argument.getHead().getLiteralText(),
+      );
+  }
+
+  if (Node.isIdentifier(argument)) {
+    return `identifier:${argument.getText()}`;
+  }
+
+  return `<${argument.getKindName()}:${argument.getText().replace(/\s+/g, " ").slice(0, 120)}>`;
+}
+
+function httpMethodFromCustomFetch(callExpression) {
+  const options = callExpression.getArguments()[1];
+  if (!Node.isObjectLiteralExpression(options)) {
+    return "UNKNOWN";
+  }
+
+  const methodProperty = options.getProperty("method");
+  if (!Node.isPropertyAssignment(methodProperty)) {
+    return "UNKNOWN";
+  }
+
+  const initializer = methodProperty.getInitializer();
+  if (!initializer) {
+    return "UNKNOWN";
+  }
+
+  if (
+    Node.isStringLiteral(initializer) ||
+    Node.isNoSubstitutionTemplateLiteral(initializer)
+  ) {
+    return initializer.getLiteralText().toUpperCase();
+  }
+
+  return initializer.getText();
+}
+
+function collectManualApiBindings(sourceFile) {
+  const bindings = new Map();
+
+  for (const declaration of sourceFile.getImportDeclarations()) {
+    const moduleSpecifier = declaration.getModuleSpecifierValue();
+    if (!isManualApiImportModule(moduleSpecifier)) {
+      continue;
+    }
+
+    for (const namedImport of declaration.getNamedImports()) {
+      const importedName = namedImport.getName();
+      if (!MANUAL_API_IMPORTS.has(importedName)) {
+        continue;
+      }
+
+      bindings.set(
+        namedImport.getAliasNode()?.getText() ?? importedName,
+        importedName,
+      );
+    }
+  }
+
+  return bindings;
+}
+
+function collectOccurrences() {
+  const project = new Project({
+    tsConfigFilePath: tsconfigPath,
+    skipAddingFilesFromTsConfig: true,
+  });
+  project.addSourceFilesAtPaths(resolve(frontendDir, "src/**/*.{ts,tsx}"));
+
+  const occurrences = [];
+
+  for (const sourceFile of project.getSourceFiles()) {
+    const filePath = sourceFile.getFilePath();
+    if (isIgnoredFile(filePath)) {
+      continue;
+    }
+
+    const bindings = collectManualApiBindings(sourceFile);
+    if (bindings.size === 0) {
+      continue;
+    }
+
+    const file = relative(frontendDir, filePath);
+
+    sourceFile.forEachDescendant((node) => {
+      if (!Node.isCallExpression(node)) {
+        return;
+      }
+
+      const expression = node.getExpression();
+      const firstArgument = node.getArguments()[0];
+
+      if (
+        Node.isIdentifier(expression) &&
+        bindings.get(expression.getText()) === "customFetch"
+      ) {
+        occurrences.push({
+          file,
+          importName: "customFetch",
+          callee: "customFetch",
+          endpoint: endpointFingerprint(firstArgument),
+          httpMethod: httpMethodFromCustomFetch(node),
+          line: node.getStartLineNumber(),
+        });
+        return;
+      }
+
+      if (!Node.isPropertyAccessExpression(expression)) {
+        return;
+      }
+
+      const receiver = expression.getExpression();
+      if (
+        !Node.isIdentifier(receiver) ||
+        bindings.get(receiver.getText()) !== "apiClient"
+      ) {
+        return;
+      }
+
+      const method = expression.getName();
+      occurrences.push({
+        file,
+        importName: "apiClient",
+        callee: `apiClient.${method}`,
+        endpoint: endpointFingerprint(firstArgument),
+        httpMethod: method.toUpperCase(),
+        line: node.getStartLineNumber(),
+      });
+    });
+  }
+
+  return occurrences.sort((left, right) => {
+    const fileOrder = left.file.localeCompare(right.file);
+    return fileOrder === 0 ? left.line - right.line : fileOrder;
+  });
+}
+
+function occurrenceKey(occurrence) {
+  return [
+    occurrence.file,
+    occurrence.importName,
+    occurrence.callee,
+    occurrence.endpoint,
+  ].join("\u0000");
+}
+
+function displayOccurrence(occurrence) {
+  return `${occurrence.file}:${occurrence.line ?? "?"} ${occurrence.callee} ${occurrence.httpMethod} ${occurrence.endpoint}`;
+}
+
+function validateAllowlistEntry(entry, index) {
+  const prefix = `allowlist entry #${index + 1}`;
+  for (const field of ["file", "importName", "callee", "endpoint"]) {
+    if (typeof entry[field] !== "string" || entry[field].length === 0) {
+      throw new Error(`${prefix} is missing required string field "${field}".`);
+    }
+  }
+
+  for (const field of REQUIRED_ALLOWLIST_FIELDS) {
+    if (typeof entry[field] !== "string" || entry[field].trim().length === 0) {
+      throw new Error(
+        `${prefix} is missing required exception metadata "${field}".`,
+      );
+    }
+  }
+
+  if (
+    entry.occurrences !== undefined &&
+    (!Number.isInteger(entry.occurrences) || entry.occurrences < 1)
+  ) {
+    throw new Error(`${prefix} occurrences must be a positive integer.`);
+  }
+}
+
+function summarizeByKey(items, keySelector) {
+  return items.reduce((map, item) => {
+    const key = keySelector(item);
+    const previous = map.get(key);
+    if (previous) {
+      previous.count += item.occurrences ?? 1;
+      previous.items.push(item);
+    } else {
+      map.set(key, { count: item.occurrences ?? 1, items: [item] });
+    }
+    return map;
+  }, new Map());
+}
+
+function main() {
+  const allowlist = loadAllowlist();
+  allowlist.forEach(validateAllowlistEntry);
+
+  const occurrences = collectOccurrences();
+  const occurrenceCounts = summarizeByKey(occurrences, occurrenceKey);
+  const allowlistCounts = summarizeByKey(allowlist, occurrenceKey);
+
+  const unexpected = [];
+  for (const [key, occurrenceSummary] of occurrenceCounts) {
+    const allowlistSummary = allowlistCounts.get(key);
+    if (
+      !allowlistSummary ||
+      allowlistSummary.count !== occurrenceSummary.count
+    ) {
+      unexpected.push(...occurrenceSummary.items);
+    }
+  }
+
+  const stale = [];
+  for (const [key, allowlistSummary] of allowlistCounts) {
+    const occurrenceSummary = occurrenceCounts.get(key);
+    if (
+      !occurrenceSummary ||
+      occurrenceSummary.count !== allowlistSummary.count
+    ) {
+      stale.push(...allowlistSummary.items);
+    }
+  }
+
+  if (unexpected.length > 0 || stale.length > 0) {
+    console.error("Manual frontend API call audit failed.");
+    if (unexpected.length > 0) {
+      console.error("\nUnlisted or count-changed call sites:");
+      for (const occurrence of unexpected) {
+        console.error(`- ${displayOccurrence(occurrence)}`);
+      }
+    }
+
+    if (stale.length > 0) {
+      console.error("\nUnused or count-mismatched allowlist entries:");
+      for (const entry of stale) {
+        console.error(
+          `- ${entry.file} ${entry.callee} ${entry.endpoint} (occurrences: ${entry.occurrences ?? 1})`,
+        );
+      }
+    }
+
+    console.error(
+      "\nUse generated endpoints by default. If a manual call is still required, update scripts/manual-api-call-allowlist.json with a reason, scope, and wrapperPurpose.",
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(
+    `Manual frontend API call audit passed (${occurrences.length} call sites).`,
+  );
+}
+
+main();

--- a/frontend/scripts/manual-api-call-allowlist.json
+++ b/frontend/scripts/manual-api-call-allowlist.json
@@ -1,0 +1,233 @@
+{
+  "description": "Allowlist for production frontend apiClient/customFetch calls that are not yet served by generated Orval endpoints.",
+  "entries": [
+    {
+      "file": "src/entities/chat/api/chatApi.ts",
+      "importName": "customFetch",
+      "callee": "customFetch",
+      "endpoint": "/api/v1/workspaces/${}/chat/sessions/current?${}",
+      "reason": "OpenAPI generated endpoint is not available for current user chat session lookup.",
+      "scope": "User chat current-session read endpoint.",
+      "wrapperPurpose": "response normalization"
+    },
+    {
+      "file": "src/entities/chat/api/chatApi.ts",
+      "importName": "customFetch",
+      "callee": "customFetch",
+      "endpoint": "/api/v1/workspaces/${}/chat/sessions",
+      "reason": "OpenAPI generated endpoint is not available for creating a fresh user chat session.",
+      "scope": "User chat session create endpoint.",
+      "wrapperPurpose": "response normalization"
+    },
+    {
+      "file": "src/entities/chat/api/chatApi.ts",
+      "importName": "customFetch",
+      "callee": "customFetch",
+      "endpoint": "/api/v1/workspaces/${}/demo/chat-sessions",
+      "reason": "OpenAPI generated endpoint is not available for registering demo chat sessions.",
+      "scope": "Demo chat session create endpoint.",
+      "wrapperPurpose": "response normalization"
+    },
+    {
+      "file": "src/entities/chat/api/chatApi.ts",
+      "importName": "customFetch",
+      "callee": "customFetch",
+      "endpoint": "/api/v1/workspaces/${}/demo/chat-sessions/${}/messages",
+      "occurrences": 2,
+      "reason": "OpenAPI generated endpoint is not available for demo chat message send/read.",
+      "scope": "Demo chat session message read and send endpoints.",
+      "wrapperPurpose": "response normalization"
+    },
+    {
+      "file": "src/features/admin-billing/api/adminBillingApi.ts",
+      "importName": "apiClient",
+      "callee": "apiClient.get",
+      "endpoint": "/admin/billing/customers",
+      "reason": "OpenAPI generated endpoint is not available until the admin billing backend spec is regenerated.",
+      "scope": "Admin billing customer list endpoint.",
+      "wrapperPurpose": "query key standardization"
+    },
+    {
+      "file": "src/features/admin-billing/api/adminBillingApi.ts",
+      "importName": "apiClient",
+      "callee": "apiClient.post",
+      "endpoint": "/admin/billing/payments/${}/refunds",
+      "reason": "OpenAPI generated endpoint is not available until the admin billing backend spec is regenerated.",
+      "scope": "Admin billing payment refund endpoint.",
+      "wrapperPurpose": "toast/error mapping"
+    },
+    {
+      "file": "src/features/consultation/api/consultationApi.ts",
+      "importName": "customFetch",
+      "callee": "customFetch",
+      "endpoint": "identifier:url",
+      "occurrences": 3,
+      "reason": "Generated signatures do not expose the dashboard metric query parameters used by these reads.",
+      "scope": "Consultation metrics, workflow ranking, and bottleneck analysis computed URLs.",
+      "wrapperPurpose": "unwrap/select"
+    },
+    {
+      "file": "src/features/consultation/api/llmToolWorkflowApi.ts",
+      "importName": "customFetch",
+      "callee": "customFetch",
+      "endpoint": "/api/v1/consultation/sessions/${}/matched-workflow",
+      "reason": "OpenAPI generated endpoint is not available for matched workflow lookup.",
+      "scope": "Consultation matched-workflow sidebar read endpoint.",
+      "wrapperPurpose": "error mapping"
+    },
+    {
+      "file": "src/features/log-upload/api/rawFileUpload.ts",
+      "importName": "apiClient",
+      "callee": "apiClient.post",
+      "endpoint": "/workspaces/${}/datasets/uploads:init",
+      "reason": "OpenAPI generated endpoint is not available for raw object upload init.",
+      "scope": "Raw file upload init endpoint.",
+      "wrapperPurpose": "response normalization"
+    },
+    {
+      "file": "src/features/log-upload/api/rawFileUpload.ts",
+      "importName": "apiClient",
+      "callee": "apiClient.post",
+      "endpoint": "/workspaces/${}/datasets/uploads/${}:complete",
+      "reason": "OpenAPI generated endpoint is not available for raw object upload completion.",
+      "scope": "Raw file upload complete endpoint.",
+      "wrapperPurpose": "response normalization"
+    },
+    {
+      "file": "src/features/simulation/api/simulationApi.ts",
+      "importName": "customFetch",
+      "callee": "customFetch",
+      "endpoint": "/api/v1/workspaces/${}/simulation/sessions${}",
+      "reason": "OpenAPI generated endpoint is not available for simulation session listing.",
+      "scope": "Simulation session list endpoint.",
+      "wrapperPurpose": "unwrap/select"
+    },
+    {
+      "file": "src/features/simulation/api/simulationApi.ts",
+      "importName": "customFetch",
+      "callee": "customFetch",
+      "endpoint": "/api/v1/workspaces/${}/simulation/sessions",
+      "reason": "OpenAPI generated endpoint is not available for simulation session creation.",
+      "scope": "Simulation session create endpoint.",
+      "wrapperPurpose": "unwrap/select"
+    },
+    {
+      "file": "src/features/simulation/api/simulationApi.ts",
+      "importName": "customFetch",
+      "callee": "customFetch",
+      "endpoint": "/api/v1/workspaces/${}/simulation/sessions/${}",
+      "reason": "OpenAPI generated endpoint is not available for simulation session detail reads.",
+      "scope": "Simulation session detail endpoint.",
+      "wrapperPurpose": "unwrap/select"
+    },
+    {
+      "file": "src/features/simulation/api/simulationApi.ts",
+      "importName": "customFetch",
+      "callee": "customFetch",
+      "endpoint": "/api/v1/workspaces/${}/simulation/sessions/${}/messages",
+      "reason": "OpenAPI generated endpoint is not available for simulation message send.",
+      "scope": "Simulation session message endpoint.",
+      "wrapperPurpose": "unwrap/select"
+    },
+    {
+      "file": "src/features/simulation/api/simulationApi.ts",
+      "importName": "customFetch",
+      "callee": "customFetch",
+      "endpoint": "/api/v1/workspaces/${}/simulation/sessions/${}/feedback",
+      "reason": "OpenAPI generated endpoint is not available for simulation feedback creation.",
+      "scope": "Simulation session feedback endpoint.",
+      "wrapperPurpose": "unwrap/select"
+    },
+    {
+      "file": "src/features/simulation/api/simulationApi.ts",
+      "importName": "customFetch",
+      "callee": "customFetch",
+      "endpoint": "identifier:path",
+      "occurrences": 4,
+      "reason": "OpenAPI generated endpoints are not available for computed paginated simulation reads.",
+      "scope": "Simulation feedback, improvement-candidate, golden-case, and replay list endpoints.",
+      "wrapperPurpose": "unwrap/select"
+    },
+    {
+      "file": "src/features/simulation/api/simulationApi.ts",
+      "importName": "customFetch",
+      "callee": "customFetch",
+      "endpoint": "/api/v1/workspaces/${}/simulation/improvement-candidates/from-feedback/${}",
+      "reason": "OpenAPI generated endpoint is not available for creating improvement candidates from feedback.",
+      "scope": "Simulation improvement candidate create-from-feedback endpoint.",
+      "wrapperPurpose": "unwrap/select"
+    },
+    {
+      "file": "src/features/simulation/api/simulationApi.ts",
+      "importName": "customFetch",
+      "callee": "customFetch",
+      "endpoint": "/api/v1/workspaces/${}/simulation/improvement-candidates/${}",
+      "reason": "OpenAPI generated endpoint is not available for simulation improvement candidate detail reads.",
+      "scope": "Simulation improvement candidate detail endpoint.",
+      "wrapperPurpose": "unwrap/select"
+    },
+    {
+      "file": "src/features/simulation/api/simulationApi.ts",
+      "importName": "customFetch",
+      "callee": "customFetch",
+      "endpoint": "/api/v1/workspaces/${}/simulation/improvement-candidates/${}/status",
+      "reason": "OpenAPI generated endpoint is not available for simulation improvement candidate status updates.",
+      "scope": "Simulation improvement candidate status endpoint.",
+      "wrapperPurpose": "unwrap/select"
+    },
+    {
+      "file": "src/features/simulation/api/simulationApi.ts",
+      "importName": "customFetch",
+      "callee": "customFetch",
+      "endpoint": "/api/v1/workspaces/${}/simulation/improvement-candidates/${}/approve",
+      "reason": "OpenAPI generated endpoint is not available for simulation improvement candidate approval.",
+      "scope": "Simulation improvement candidate approval endpoint.",
+      "wrapperPurpose": "unwrap/select"
+    },
+    {
+      "file": "src/features/simulation/api/simulationApi.ts",
+      "importName": "customFetch",
+      "callee": "customFetch",
+      "endpoint": "/api/v1/workspaces/${}/simulation/improvement-candidates/${}/reject",
+      "reason": "OpenAPI generated endpoint is not available for simulation improvement candidate rejection.",
+      "scope": "Simulation improvement candidate rejection endpoint.",
+      "wrapperPurpose": "unwrap/select"
+    },
+    {
+      "file": "src/features/simulation/api/simulationApi.ts",
+      "importName": "customFetch",
+      "callee": "customFetch",
+      "endpoint": "/api/v1/workspaces/${}/simulation/sessions/${}/golden-cases",
+      "reason": "OpenAPI generated endpoint is not available for simulation golden case creation.",
+      "scope": "Simulation golden case create endpoint.",
+      "wrapperPurpose": "unwrap/select"
+    },
+    {
+      "file": "src/features/simulation/api/simulationApi.ts",
+      "importName": "customFetch",
+      "callee": "customFetch",
+      "endpoint": "/api/v1/workspaces/${}/simulation/golden-cases/${}/replays",
+      "reason": "OpenAPI generated endpoint is not available for simulation golden case replay creation.",
+      "scope": "Simulation golden case replay endpoint.",
+      "wrapperPurpose": "unwrap/select"
+    },
+    {
+      "file": "src/features/workspace-dashboard-health/api/workspaceDashboardHealthApi.ts",
+      "importName": "customFetch",
+      "callee": "customFetch",
+      "endpoint": "/api/v1/workspaces/${}/dashboard/knowledge-pack-health",
+      "reason": "OpenAPI is not generated for this dashboard read endpoint yet.",
+      "scope": "Workspace dashboard knowledge-pack health endpoint.",
+      "wrapperPurpose": "query key standardization"
+    },
+    {
+      "file": "src/features/workspace-dashboard-health/api/workspaceDashboardHealthApi.ts",
+      "importName": "customFetch",
+      "callee": "customFetch",
+      "endpoint": "/api/v1/workspaces/${}/dashboard/action-recommendations${}",
+      "reason": "OpenAPI is not generated for this dashboard read endpoint yet.",
+      "scope": "Workspace dashboard action recommendations endpoint.",
+      "wrapperPurpose": "query key standardization"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #619

## 변경 사항

- `frontend`의 `lint`와 `test` 스크립트가 먼저 `pnpm audit:api`를 실행하도록 연결했습니다.
- production `src`에서 `apiClient`/`customFetch` 호출을 TypeScript AST로 수집하고 allowlist와 비교하는 감사 스크립트를 추가했습니다.
- 기존 수동 API 호출 31개를 파일, 호출 대상, endpoint fingerprint, 사유, 범위, wrapper 목적이 포함된 allowlist로 정리했습니다.
- 이슈 619 스펙을 `.agent/specs/619.md`에 정리하고, `frontend/README.md`에 예외 등록 절차를 문서화했습니다.

## 검증

- `pnpm --dir frontend audit:api`
- `pnpm --dir frontend test -- --run src/shared/api/apiResponse.test.ts`
- `node --check frontend/scripts/audit-manual-api-calls.mjs`
- `pnpm exec prettier --check .agent/specs/619.md frontend/README.md frontend/package.json frontend/scripts/manual-api-call-allowlist.json frontend/scripts/audit-manual-api-calls.mjs`
- 커밋 pre-commit hook: lint-staged 대상 파일 없음

## 참고

- `pnpm --dir frontend lint`는 감사 단계 통과 후 repository-wide 기존 ESLint baseline 50건으로 실패합니다. 이 PR은 해당 기존 lint 위반을 수정하지 않습니다.