### PR TITLE
refactor(ml): Airflow stage 실행 책임을 분리

### DIFF
--- a/.agent/specs/618.md
+++ b/.agent/specs/618.md
@@ -1,0 +1,101 @@
+# Airflow stage runner와 failure reporter 분리
+
+## Goal
+
+`domain_pack_generation` DAG가 task orchestration에 집중하도록 Airflow stage runner 선택/실행 책임과 실패 callback 보고 책임을 분리한다.
+
+## Problem
+
+`ml/src/dags/domain_pack_generation.py`가 DAG 구성, direct/ECS stage 실행 모드 선택, XCom 결과 payload 처리, direct 실행 실패 manifest 작성, Airflow 실패 callback payload 생성과 전송을 함께 담당한다. 이 구조에서는 stage 실행 런타임 변경이나 실패 보고 정책 변경이 DAG 파일 전체에 영향을 주고, direct/ECS 경계와 callback payload contract를 독립적으로 검증하기 어렵다.
+
+## Scope
+
+- `ml/src/dags/domain_pack_generation.py`
+- `ml/src/pipeline/airflow_stage_runner.py`
+- `ml/src/pipeline/airflow_failure_reporter.py`
+- `ml/src/pipeline/common/airflow_context.py`
+- `ml/tests/test_domain_pack_generation_dag.py`
+- `ml/tests/test_airflow_stage_runner.py`
+- `ml/tests/test_airflow_failure_reporter.py`
+
+## Non-Goals
+
+- DAG task 순서, task id, replay mode 분기, checkpoint callback 동작을 변경하지 않는다.
+- 개별 pipeline stage 구현이나 stage artifact schema를 변경하지 않는다.
+- ECS task 실행 세부 구현(`ml/src/pipeline/ecs_stage_task.py`)을 재설계하지 않는다.
+- Spring callback API 경로나 callback type을 변경하지 않는다.
+
+## DAG Diagram
+
+```mermaid
+flowchart TD
+    A[ingestion] --> B[preprocessing]
+    B --> C[representation]
+    C --> D[domain_candidate_generation]
+    D --> E[domain_confirmation_checkpoint]
+    E --> F[intent_discovery]
+    F --> G[flow_splitting]
+    G --> H[feedback_candidate_generation]
+    H --> I[human_feedback_checkpoint]
+    I --> J[draft_generation]
+    J --> K[evaluation]
+    K --> L[publish_candidate]
+```
+
+## Stage Interface
+
+### Input
+
+| 필드 | 타입 | 설명 |
+| --- | --- | --- |
+| `stage_name` | `str` | 실행할 pipeline stage 이름 |
+| `stage_context` | `StageContext` | Airflow DAG/run/task 및 workspace/dataset/job context |
+| `runtime_config` | `PipelineRuntimeConfig` | artifact store, backend callback, runtime profile 설정 |
+| `upstream_manifest_path` | `str \| None` | 이전 task XCom에서 전달된 manifest 경로 |
+| `stage_callable` | `Callable \| None` | direct 실행에서 사용할 stage `run()` 함수 |
+| `raw_object_key` | `str \| None` | ECS ingestion에 전달할 raw object key |
+
+### Output
+
+모든 stage runner는 Airflow XCom payload로 아래 contract를 유지한다.
+
+| 필드 | 타입 | 설명 |
+| --- | --- | --- |
+| `artifact_manifest_path` | `str` | 다음 task가 읽을 stage manifest 경로 또는 URI |
+
+## Design Diff
+
+| 영역 | As-is | To-be |
+| --- | --- | --- |
+| Stage runner 선택 | DAG 내부 `_stage_execution_mode()`와 `_run_stage()`가 direct/ECS 분기 처리 | `pipeline.airflow_stage_runner`가 실행 모드 검증, runner factory, direct/ECS runner를 담당 |
+| Direct 실행 | DAG가 stage callable 실행, manifest 작성, 실패 manifest 작성 처리 | `DirectStageRunner`가 direct 실행과 manifest/XCom contract 처리를 담당 |
+| ECS 실행 | DAG가 `run_stage_task()`를 직접 호출 | `EcsStageRunner`가 ECS task 경계를 담당 |
+| Failure callback | DAG가 실패 payload 구성과 callback 전송 처리 | `pipeline.airflow_failure_reporter`가 payload fixture 가능한 형태로 구성/전송 |
+| Airflow context 값 추출 | DAG 내부 helper에 고정 | `pipeline.common.airflow_context`에서 재사용 |
+
+## Requirements
+
+- `PIPELINE_STAGE_EXECUTION_MODE=direct`일 때 direct stage callable이 실행되고 기존 manifest/XCom payload contract가 유지된다.
+- `PIPELINE_STAGE_EXECUTION_MODE=ecs`일 때 ECS stage task 실행으로 위임되고 ingestion raw object key가 보존된다.
+- 잘못된 stage execution mode는 기존처럼 `PipelineConfigurationError`를 발생시킨다.
+- direct stage가 이미 `artifact_manifest_path`를 반환하면 새 manifest를 쓰지 않고 해당 XCom payload를 재사용한다.
+- direct stage 실패 시 기존처럼 실패 manifest를 쓰고 원 예외를 다시 발생시킨다.
+- Airflow failure callback payload는 `externalEventId`, `dagId`, `dagRunId`, `failedStage`, `reason`, `message`, `occurredAt`, `error` 필드를 유지한다.
+- callback 비활성화 또는 `pipeline_job_id` 누락 시 기존처럼 실패 callback 전송을 건너뛴다.
+
+## Acceptance Criteria
+
+- `domain_pack_generation` DAG import와 task dependency 테스트가 계속 통과한다.
+- direct/ECS 모드별 stage runner 선택 테스트가 존재한다.
+- direct runner의 XCom payload contract와 실패 manifest 작성 테스트가 존재한다.
+- failure callback payload fixture 검증 테스트가 존재한다.
+- DAG task 순서와 task id가 변경되지 않는다.
+
+## Validation
+
+- `cd ml && uv run pytest tests/test_domain_pack_generation_dag.py tests/test_airflow_stage_runner.py tests/test_airflow_failure_reporter.py`
+- `cd ml && uv run pytest tests/test_domain_pack_generation_dag.py`
+
+## Open Questions
+
+- 없음.

--- a/ml/src/dags/domain_pack_generation.py
+++ b/ml/src/dags/domain_pack_generation.py
@@ -1,19 +1,25 @@
 from __future__ import annotations
 
 import json
-import logging
 import os
 import shutil
 from collections.abc import Callable, Mapping
 from contextlib import contextmanager
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from pathlib import Path
-from traceback import format_exc
 from typing import Any
 
 from airflow.exceptions import AirflowSkipException
 from airflow.sdk import dag, get_current_context, task
 
+from pipeline.airflow_failure_reporter import notify_failure_callback
+from pipeline.airflow_stage_runner import (
+    STAGE_EXECUTION_MODE_ECS,
+    StageRunRequest,
+    create_stage_runner,
+    stage_execution_mode_from_env,
+)
+from pipeline.common.airflow_context import context_value, stage_context_from_airflow_context
 from pipeline.common.artifact_io import is_s3_uri, read_json_file, read_json_uri, write_json_uri
 from pipeline.common.artifacts import write_stage_manifest
 from pipeline.common.callbacks import post_callback
@@ -21,45 +27,22 @@ from pipeline.common.config import PipelineRuntimeConfig
 from pipeline.common.context import StageContext
 from pipeline.common.dag_defaults import default_dag_args
 from pipeline.common.exceptions import PipelineConfigurationError
-from pipeline.ecs_stage_task import run_stage_task
 from pipeline.ecs_stage_worker import STAGE_MODULES
-
-logger = logging.getLogger(__name__)
 
 RUN_MODE_INITIAL = "INITIAL"
 RUN_MODE_DOMAIN_CONFIRMED_REPLAY = "DOMAIN_CONFIRMED_REPLAY"
 RUN_MODE_FEEDBACK_REPLAY = "FEEDBACK_REPLAY"
 CALLBACK_DOMAIN_CONFIRMATION = "domain-confirmation-checkpoints"
 CALLBACK_HUMAN_FEEDBACK = "human-feedback-checkpoints"
-CALLBACK_FAILURE = "failures"
-STAGE_EXECUTION_MODE_DIRECT = "direct"
-STAGE_EXECUTION_MODE_ECS = "ecs"
 evaluation_run: Callable[[str], Mapping[str, object] | None] | None = None
 
 
 def _build_stage_context(stage_name: str) -> StageContext:
-    context = get_current_context()
-    return StageContext(
-        dag_id=context["dag"].dag_id,
-        run_id=context["run_id"],
-        stage_name=stage_name,
-        workspace_id=_context_value(context, "workspace_id"),
-        dataset_id=_context_value(context, "dataset_id"),
-        pipeline_job_id=_context_value(context, "pipeline_job_id"),
-    )
+    return stage_context_from_airflow_context(get_current_context(), stage_name)
 
 
 def _context_value(context: Mapping[str, object], key: str) -> str | None:
-    dag_run = context.get("dag_run")
-    conf = getattr(dag_run, "conf", None)
-    if isinstance(conf, Mapping) and conf.get(key) not in (None, ""):
-        return str(conf[key])
-
-    params = context.get("params")
-    if isinstance(params, Mapping) and params.get(key) not in (None, ""):
-        return str(params[key])
-
-    return None
+    return context_value(context, key)
 
 
 def _run_mode() -> str:
@@ -114,10 +97,7 @@ def _conf_json_file(key: str, filename: str) -> str | None:
 
 
 def _stage_execution_mode() -> str:
-    value = os.getenv("PIPELINE_STAGE_EXECUTION_MODE", STAGE_EXECUTION_MODE_DIRECT).strip().lower()
-    if value not in {STAGE_EXECUTION_MODE_DIRECT, STAGE_EXECUTION_MODE_ECS}:
-        raise PipelineConfigurationError("PIPELINE_STAGE_EXECUTION_MODE must be one of: direct, ecs.")
-    return value
+    return stage_execution_mode_from_env()
 
 
 def _run_stage(
@@ -127,64 +107,24 @@ def _run_stage(
 ) -> dict[str, str]:
     stage_context = _build_stage_context(stage_name)
     runtime_config = PipelineRuntimeConfig.from_env()
-    if _stage_execution_mode() == STAGE_EXECUTION_MODE_ECS:
-        return run_stage_task(
-            stage_name,
-            stage_context,
-            runtime_config,
-            upstream_manifest_path,
-            raw_object_key=_raw_object_key_for_stage(stage_name),
-        )
-    if stage_callable is None:
+    execution_mode = _stage_execution_mode()
+    if stage_callable is None and execution_mode != STAGE_EXECUTION_MODE_ECS:
         stage_callable = _stage_callable(stage_name)
-    manifest_payload: dict[str, object] = {
-        "backend_base_url": runtime_config.backend_base_url,
-        "upstream_manifest_path": upstream_manifest_path,
-    }
-    try:
-        stage_result = stage_callable(upstream_manifest_path)
-    except Exception as exc:
-        manifest_payload.update(_manifest_payload_from_exception(exc))
-        manifest_payload["status"] = "failed"
-        manifest_payload["error"] = {
-            "type": type(exc).__name__,
-            "message": str(exc),
-            "traceback": format_exc(),
-        }
-        try:
-            write_stage_manifest(stage_context, runtime_config, manifest_payload)
-        except Exception:
-            logger.exception("Failed to write failure manifest for stage '%s'", stage_name)
-        raise
-    else:
-        if stage_result is not None:
-            artifact_manifest_path = _artifact_manifest_path_from(stage_result)
-            if artifact_manifest_path is not None:
-                return {"artifact_manifest_path": artifact_manifest_path}
-            manifest_payload.update(stage_result)
-        manifest_payload["status"] = "completed"
-        manifest_path: Path = write_stage_manifest(stage_context, runtime_config, manifest_payload)
-    return {"artifact_manifest_path": str(manifest_path)}
+    request = StageRunRequest(
+        stage_name=stage_name,
+        stage_context=stage_context,
+        runtime_config=runtime_config,
+        upstream_manifest_path=upstream_manifest_path,
+        stage_callable=stage_callable,
+        raw_object_key=_raw_object_key_for_stage(stage_name),
+    )
+    return create_stage_runner(execution_mode).run(request)
 
 
 def _raw_object_key_for_stage(stage_name: str) -> str | None:
     if stage_name != "ingestion":
         return None
     return _conf_value("object_key") or _conf_value("objectKey")
-
-
-def _manifest_payload_from_exception(exc: BaseException) -> dict[str, object]:
-    manifest_payload = getattr(exc, "manifest_payload", None)
-    if isinstance(manifest_payload, Mapping):
-        return dict(manifest_payload)
-    return {}
-
-
-def _artifact_manifest_path_from(stage_result: Mapping[str, object]) -> str | None:
-    artifact_manifest_path = stage_result.get("artifact_manifest_path")
-    if isinstance(artifact_manifest_path, str) and artifact_manifest_path:
-        return artifact_manifest_path
-    return None
 
 
 def _passthrough_manifest_from_conf() -> dict[str, str]:
@@ -369,55 +309,6 @@ def _require_pipeline_job_id(value: str | None) -> str:
     return value
 
 
-def _notify_failure_callback(context: Mapping[str, object]) -> None:
-    try:
-        runtime_config = PipelineRuntimeConfig.from_env()
-        if not runtime_config.callback_enabled:
-            return
-        pipeline_job_id = _context_value(context, "pipeline_job_id")
-        if not pipeline_job_id:
-            logger.warning("Skip failure callback because pipeline_job_id is missing.")
-            return
-        dag = context.get("dag")
-        dag_run = context.get("dag_run")
-        task_instance = context.get("task_instance")
-        exception = context.get("exception")
-        dag_id = str(getattr(dag, "dag_id", "") or _context_value(context, "dag_id") or "")
-        dag_run_id = str(getattr(dag_run, "run_id", "") or context.get("run_id") or "")
-        failed_stage = str(getattr(task_instance, "task_id", "") or "unknown")
-        reason = type(exception).__name__ if exception is not None else "TaskFailed"
-        message = str(exception).strip() if exception is not None else "Airflow task failed."
-        post_callback(
-            runtime_config.backend_base_url,
-            pipeline_job_id,
-            CALLBACK_FAILURE,
-            {
-                "externalEventId": _failure_external_event_id(dag_id, dag_run_id, failed_stage),
-                "dagId": dag_id,
-                "dagRunId": dag_run_id,
-                "failedStage": failed_stage,
-                "reason": reason[:100] or "TaskFailed",
-                "message": message[:5000] or "Airflow task failed.",
-                "occurredAt": datetime.now(timezone.utc).isoformat(),
-                "error": {
-                    "type": reason,
-                    "message": message,
-                },
-            },
-            runtime_config.airflow_webhook_secret or "",
-            runtime_config.callback_timeout_seconds,
-        )
-    except Exception:
-        logger.exception("Failed to send pipeline failure callback.")
-
-
-def _failure_external_event_id(dag_id: str, dag_run_id: str, failed_stage: str) -> str:
-    value = f"{dag_id}:{dag_run_id}:{failed_stage}:{CALLBACK_FAILURE}"
-    if len(value) <= 255:
-        return value
-    return f"{dag_id[:48]}:{dag_run_id[:120]}:{failed_stage[:48]}:{CALLBACK_FAILURE}"
-
-
 def _run_evaluation_stage(upstream_manifest_path: str | None) -> Mapping[str, object] | None:
     if upstream_manifest_path is None:
         raise PipelineConfigurationError("evaluation stage requires an upstream manifest path.")
@@ -447,7 +338,7 @@ def _stage_callable(stage_name: str) -> Callable[[str | None], Mapping[str, obje
     dagrun_timeout=timedelta(hours=2),
     max_active_runs=int(os.getenv("PIPELINE_DAG_MAX_ACTIVE_RUNS", "4")),
     max_active_tasks=int(os.getenv("PIPELINE_DAG_MAX_ACTIVE_TASKS", "1")),
-    on_failure_callback=_notify_failure_callback,
+    on_failure_callback=notify_failure_callback,
     params={
         "workspace_id": "local-workspace",
         "dataset_id": "local-dataset",

--- a/ml/src/pipeline/airflow_failure_reporter.py
+++ b/ml/src/pipeline/airflow_failure_reporter.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from datetime import datetime, timezone
+
+from pipeline.common.airflow_context import context_value
+from pipeline.common.callbacks import post_callback
+from pipeline.common.config import PipelineRuntimeConfig
+
+logger = logging.getLogger(__name__)
+
+CALLBACK_FAILURE = "failures"
+
+
+def notify_failure_callback(context: Mapping[str, object]) -> None:
+    try:
+        runtime_config = PipelineRuntimeConfig.from_env()
+        if not runtime_config.callback_enabled:
+            return
+        pipeline_job_id = context_value(context, "pipeline_job_id")
+        if not pipeline_job_id:
+            logger.warning("Skip failure callback because pipeline_job_id is missing.")
+            return
+        post_callback(
+            runtime_config.backend_base_url,
+            pipeline_job_id,
+            CALLBACK_FAILURE,
+            build_failure_callback_payload(context),
+            runtime_config.airflow_webhook_secret or "",
+            runtime_config.callback_timeout_seconds,
+        )
+    except Exception:
+        logger.exception("Failed to send pipeline failure callback.")
+
+
+def build_failure_callback_payload(
+    context: Mapping[str, object],
+    *,
+    occurred_at: datetime | None = None,
+) -> dict[str, object]:
+    dag_id = _dag_id_from_context(context)
+    dag_run_id = _dag_run_id_from_context(context)
+    failed_stage = _failed_stage_from_context(context)
+    exception = context.get("exception")
+    reason = type(exception).__name__ if exception is not None else "TaskFailed"
+    message = str(exception).strip() if exception is not None else "Airflow task failed."
+    occurred_at = occurred_at or datetime.now(timezone.utc)
+    return {
+        "externalEventId": failure_external_event_id(dag_id, dag_run_id, failed_stage),
+        "dagId": dag_id,
+        "dagRunId": dag_run_id,
+        "failedStage": failed_stage,
+        "reason": reason[:100] or "TaskFailed",
+        "message": message[:5000] or "Airflow task failed.",
+        "occurredAt": occurred_at.isoformat(),
+        "error": {
+            "type": reason,
+            "message": message,
+        },
+    }
+
+
+def failure_external_event_id(dag_id: str, dag_run_id: str, failed_stage: str) -> str:
+    value = f"{dag_id}:{dag_run_id}:{failed_stage}:{CALLBACK_FAILURE}"
+    if len(value) <= 255:
+        return value
+    return f"{dag_id[:48]}:{dag_run_id[:120]}:{failed_stage[:48]}:{CALLBACK_FAILURE}"
+
+
+def _dag_id_from_context(context: Mapping[str, object]) -> str:
+    dag = context.get("dag")
+    return str(getattr(dag, "dag_id", "") or context_value(context, "dag_id") or "")
+
+
+def _dag_run_id_from_context(context: Mapping[str, object]) -> str:
+    dag_run = context.get("dag_run")
+    return str(getattr(dag_run, "run_id", "") or context.get("run_id") or "")
+
+
+def _failed_stage_from_context(context: Mapping[str, object]) -> str:
+    task_instance = context.get("task_instance")
+    return str(getattr(task_instance, "task_id", "") or "unknown")

--- a/ml/src/pipeline/airflow_stage_runner.py
+++ b/ml/src/pipeline/airflow_stage_runner.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from traceback import format_exc
+
+from pipeline.common.artifacts import write_stage_manifest
+from pipeline.common.config import PipelineRuntimeConfig
+from pipeline.common.context import StageContext
+from pipeline.common.exceptions import PipelineConfigurationError
+from pipeline.ecs_stage_task import run_stage_task
+
+logger = logging.getLogger(__name__)
+
+STAGE_EXECUTION_MODE_DIRECT = "direct"
+STAGE_EXECUTION_MODE_ECS = "ecs"
+SUPPORTED_STAGE_EXECUTION_MODES = {STAGE_EXECUTION_MODE_DIRECT, STAGE_EXECUTION_MODE_ECS}
+StageCallable = Callable[[str | None], Mapping[str, object] | None]
+StageXComPayload = dict[str, str]
+
+
+@dataclass(frozen=True)
+class StageRunRequest:
+    stage_name: str
+    stage_context: StageContext
+    runtime_config: PipelineRuntimeConfig
+    upstream_manifest_path: str | None = None
+    stage_callable: StageCallable | None = None
+    raw_object_key: str | None = None
+
+
+class DirectStageRunner:
+    def run(self, request: StageRunRequest) -> StageXComPayload:
+        if request.stage_callable is None:
+            raise PipelineConfigurationError(f"{request.stage_name} requires a direct stage callable.")
+
+        manifest_payload: dict[str, object] = {
+            "backend_base_url": request.runtime_config.backend_base_url,
+            "upstream_manifest_path": request.upstream_manifest_path,
+        }
+        try:
+            stage_result = request.stage_callable(request.upstream_manifest_path)
+        except Exception as exc:
+            manifest_payload.update(_manifest_payload_from_exception(exc))
+            manifest_payload["status"] = "failed"
+            manifest_payload["error"] = {
+                "type": type(exc).__name__,
+                "message": str(exc),
+                "traceback": format_exc(),
+            }
+            try:
+                write_stage_manifest(request.stage_context, request.runtime_config, manifest_payload)
+            except Exception:
+                logger.exception("Failed to write failure manifest for stage '%s'", request.stage_name)
+            raise
+
+        if stage_result is not None:
+            artifact_manifest_path = _artifact_manifest_path_from(stage_result)
+            if artifact_manifest_path is not None:
+                return stage_xcom_payload(artifact_manifest_path)
+            manifest_payload.update(stage_result)
+        manifest_payload["status"] = "completed"
+        manifest_path: Path = write_stage_manifest(request.stage_context, request.runtime_config, manifest_payload)
+        return stage_xcom_payload(str(manifest_path))
+
+
+class EcsStageRunner:
+    def run(self, request: StageRunRequest) -> StageXComPayload:
+        return run_stage_task(
+            request.stage_name,
+            request.stage_context,
+            request.runtime_config,
+            request.upstream_manifest_path,
+            raw_object_key=request.raw_object_key,
+        )
+
+
+def stage_execution_mode_from_env() -> str:
+    value = os.getenv("PIPELINE_STAGE_EXECUTION_MODE", STAGE_EXECUTION_MODE_DIRECT).strip().lower()
+    if value not in SUPPORTED_STAGE_EXECUTION_MODES:
+        raise PipelineConfigurationError("PIPELINE_STAGE_EXECUTION_MODE must be one of: direct, ecs.")
+    return value
+
+
+def create_stage_runner(execution_mode: str | None = None) -> DirectStageRunner | EcsStageRunner:
+    mode = stage_execution_mode_from_env() if execution_mode is None else execution_mode.strip().lower()
+    if mode == STAGE_EXECUTION_MODE_DIRECT:
+        return DirectStageRunner()
+    if mode == STAGE_EXECUTION_MODE_ECS:
+        return EcsStageRunner()
+    raise PipelineConfigurationError("PIPELINE_STAGE_EXECUTION_MODE must be one of: direct, ecs.")
+
+
+def stage_xcom_payload(artifact_manifest_path: str) -> StageXComPayload:
+    if not artifact_manifest_path:
+        raise PipelineConfigurationError("stage runner must return a non-empty artifact_manifest_path.")
+    return {"artifact_manifest_path": artifact_manifest_path}
+
+
+def _manifest_payload_from_exception(exc: BaseException) -> dict[str, object]:
+    manifest_payload = getattr(exc, "manifest_payload", None)
+    if isinstance(manifest_payload, Mapping):
+        return dict(manifest_payload)
+    return {}
+
+
+def _artifact_manifest_path_from(stage_result: Mapping[str, object]) -> str | None:
+    artifact_manifest_path = stage_result.get("artifact_manifest_path")
+    if isinstance(artifact_manifest_path, str) and artifact_manifest_path:
+        return artifact_manifest_path
+    return None

--- a/ml/src/pipeline/common/airflow_context.py
+++ b/ml/src/pipeline/common/airflow_context.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from pipeline.common.context import StageContext
+
+
+def context_value(context: Mapping[str, object], key: str) -> str | None:
+    dag_run = context.get("dag_run")
+    conf = getattr(dag_run, "conf", None)
+    if isinstance(conf, Mapping) and conf.get(key) not in (None, ""):
+        return str(conf[key])
+
+    params = context.get("params")
+    if isinstance(params, Mapping) and params.get(key) not in (None, ""):
+        return str(params[key])
+
+    return None
+
+
+def stage_context_from_airflow_context(context: Mapping[str, object], stage_name: str) -> StageContext:
+    dag = context["dag"]
+    return StageContext(
+        dag_id=str(getattr(dag, "dag_id")),
+        run_id=str(context["run_id"]),
+        stage_name=stage_name,
+        workspace_id=context_value(context, "workspace_id"),
+        dataset_id=context_value(context, "dataset_id"),
+        pipeline_job_id=context_value(context, "pipeline_job_id"),
+    )

--- a/ml/tests/test_airflow_failure_reporter.py
+++ b/ml/tests/test_airflow_failure_reporter.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from pipeline.airflow_failure_reporter import build_failure_callback_payload, failure_external_event_id
+
+
+def test_failure_callback_payload_matches_contract() -> None:
+    occurred_at = datetime(2026, 6, 5, 12, 30, tzinfo=timezone.utc)
+    context = {
+        "dag": type("Dag", (), {"dag_id": "domain_pack_generation"})(),
+        "dag_run": type("DagRun", (), {"run_id": "manual__2026-06-05"})(),
+        "task_instance": type("TaskInstance", (), {"task_id": "draft_generation"})(),
+        "exception": ValueError("invalid draft payload"),
+    }
+
+    assert build_failure_callback_payload(context, occurred_at=occurred_at) == {
+        "externalEventId": "domain_pack_generation:manual__2026-06-05:draft_generation:failures",
+        "dagId": "domain_pack_generation",
+        "dagRunId": "manual__2026-06-05",
+        "failedStage": "draft_generation",
+        "reason": "ValueError",
+        "message": "invalid draft payload",
+        "occurredAt": "2026-06-05T12:30:00+00:00",
+        "error": {
+            "type": "ValueError",
+            "message": "invalid draft payload",
+        },
+    }
+
+
+def test_failure_callback_payload_uses_task_failed_defaults() -> None:
+    payload = build_failure_callback_payload({}, occurred_at=datetime(2026, 6, 5, tzinfo=timezone.utc))
+
+    assert payload["failedStage"] == "unknown"
+    assert payload["reason"] == "TaskFailed"
+    assert payload["message"] == "Airflow task failed."
+    assert payload["error"] == {"type": "TaskFailed", "message": "Airflow task failed."}
+
+
+def test_failure_external_event_id_is_bounded() -> None:
+    external_event_id = failure_external_event_id("d" * 120, "r" * 220, "s" * 120)
+
+    assert len(external_event_id) <= 255
+    assert external_event_id.endswith(":failures")
+
+
+def test_failure_callback_payload_falls_back_to_context_run_id_and_params() -> None:
+    context: dict[str, Any] = {
+        "run_id": "manual__fallback",
+        "params": {"dag_id": "domain_pack_generation"},
+    }
+
+    payload = build_failure_callback_payload(context, occurred_at=datetime(2026, 6, 5, tzinfo=timezone.utc))
+
+    assert payload["dagId"] == "domain_pack_generation"
+    assert payload["dagRunId"] == "manual__fallback"

--- a/ml/tests/test_airflow_stage_runner.py
+++ b/ml/tests/test_airflow_stage_runner.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from pipeline.airflow_stage_runner import (
+    DirectStageRunner,
+    EcsStageRunner,
+    StageRunRequest,
+    create_stage_runner,
+    stage_execution_mode_from_env,
+)
+from pipeline.common.config import PipelineRuntimeConfig
+from pipeline.common.context import StageContext
+from pipeline.common.exceptions import PipelineConfigurationError
+
+
+def test_stage_runner_factory_selects_direct_and_ecs(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("PIPELINE_STAGE_EXECUTION_MODE", raising=False)
+    assert isinstance(create_stage_runner(), DirectStageRunner)
+
+    monkeypatch.setenv("PIPELINE_STAGE_EXECUTION_MODE", "ecs")
+    assert stage_execution_mode_from_env() == "ecs"
+    assert isinstance(create_stage_runner(), EcsStageRunner)
+
+    with pytest.raises(PipelineConfigurationError, match="direct, ecs"):
+        create_stage_runner("unknown")
+
+
+def test_direct_stage_runner_merges_stage_payload_into_manifest(tmp_path: Path) -> None:
+    def stage_callable(_upstream_manifest_path: str | None) -> dict[str, Any]:
+        return {"candidateArtifactPath": "/tmp/publish_candidate_input.json"}
+
+    result = DirectStageRunner().run(
+        StageRunRequest(
+            stage_name="evaluation",
+            stage_context=_stage_context("evaluation"),
+            runtime_config=_runtime_config(tmp_path),
+            stage_callable=stage_callable,
+        )
+    )
+
+    manifest = json.loads(Path(result["artifact_manifest_path"]).read_text(encoding="utf-8"))
+    assert manifest["payload"]["status"] == "completed"
+    assert manifest["payload"]["candidateArtifactPath"] == "/tmp/publish_candidate_input.json"
+
+
+def test_direct_stage_runner_reuses_existing_manifest_path(tmp_path: Path) -> None:
+    result = DirectStageRunner().run(
+        StageRunRequest(
+            stage_name="evaluation",
+            stage_context=_stage_context("evaluation"),
+            runtime_config=_runtime_config(tmp_path),
+            stage_callable=lambda _path: {"artifact_manifest_path": "/tmp/existing.json"},
+        )
+    )
+
+    assert result == {"artifact_manifest_path": "/tmp/existing.json"}
+    assert not (tmp_path / "dag").exists()
+
+
+def test_direct_stage_runner_writes_failure_manifest(tmp_path: Path) -> None:
+    class StageFailure(RuntimeError):
+        manifest_payload = {"publish_status": "FAILED", "failed_callback_type": "intent-drafts"}
+
+    def failing_stage(_path: str | None) -> None:
+        raise StageFailure("callback failed")
+
+    with pytest.raises(StageFailure):
+        DirectStageRunner().run(
+            StageRunRequest(
+                stage_name="publish_candidate",
+                stage_context=_stage_context("publish_candidate"),
+                runtime_config=_runtime_config(tmp_path),
+                upstream_manifest_path="/tmp/upstream.json",
+                stage_callable=failing_stage,
+            )
+        )
+
+    manifest_path = tmp_path / "dag" / "run" / "publish_candidate" / "manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["payload"]["status"] == "failed"
+    assert manifest["payload"]["publish_status"] == "FAILED"
+    assert manifest["payload"]["failed_callback_type"] == "intent-drafts"
+    assert manifest["payload"]["error"]["type"] == "StageFailure"
+
+
+def test_ecs_stage_runner_delegates_to_stage_task(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    calls: dict[str, object] = {}
+
+    def fake_run_stage_task(
+        stage_name: str,
+        stage_context: StageContext,
+        runtime_config: PipelineRuntimeConfig,
+        upstream_manifest_path: str | None,
+        raw_object_key: str | None = None,
+    ) -> dict[str, str]:
+        calls["stage_name"] = stage_name
+        calls["stage_context"] = stage_context
+        calls["runtime_config"] = runtime_config
+        calls["upstream_manifest_path"] = upstream_manifest_path
+        calls["raw_object_key"] = raw_object_key
+        return {"artifact_manifest_path": "s3://artifacts/dag/run/ingestion/manifest.json"}
+
+    monkeypatch.setattr("pipeline.airflow_stage_runner.run_stage_task", fake_run_stage_task)
+
+    request = StageRunRequest(
+        stage_name="ingestion",
+        stage_context=_stage_context("ingestion"),
+        runtime_config=_runtime_config(tmp_path),
+        upstream_manifest_path=None,
+        raw_object_key="completed/workspaces/1/raw.zip",
+    )
+
+    assert EcsStageRunner().run(request) == {"artifact_manifest_path": "s3://artifacts/dag/run/ingestion/manifest.json"}
+    assert calls["stage_name"] == "ingestion"
+    assert calls["stage_context"] == request.stage_context
+    assert calls["runtime_config"] == request.runtime_config
+    assert calls["upstream_manifest_path"] is None
+    assert calls["raw_object_key"] == "completed/workspaces/1/raw.zip"
+
+
+def _runtime_config(tmp_path: Path) -> PipelineRuntimeConfig:
+    return PipelineRuntimeConfig(
+        artifact_root=tmp_path,
+        backend_base_url="http://backend:8080",
+        callback_enabled=False,
+    )
+
+
+def _stage_context(stage_name: str) -> StageContext:
+    return StageContext(
+        dag_id="dag",
+        run_id="run",
+        stage_name=stage_name,
+        workspace_id="1",
+        dataset_id="2",
+        pipeline_job_id="3",
+    )

--- a/ml/tests/test_domain_pack_generation_dag.py
+++ b/ml/tests/test_domain_pack_generation_dag.py
@@ -165,7 +165,12 @@ def test_ecs_ingestion_stage_forwards_conf_object_key(
         calls["upstream_manifest_path"] = upstream_manifest_path
         return {"artifact_manifest_path": "/tmp/manifest.json"}
 
-    monkeypatch.setattr(dag_module, "run_stage_task", fake_run_stage_task)
+    monkeypatch.setattr("pipeline.airflow_stage_runner.run_stage_task", fake_run_stage_task)
+    monkeypatch.setattr(
+        dag_module,
+        "_stage_callable",
+        lambda stage_name: pytest.fail(f"ECS mode must not resolve direct stage callable: {stage_name}"),
+    )
 
     assert dag_module._run_stage("ingestion") == {"artifact_manifest_path": "/tmp/manifest.json"}
     assert calls == {


### PR DESCRIPTION
Closes #618

## 변경 사항

- `domain_pack_generation` DAG의 direct/ECS stage 실행 분기를 `pipeline.airflow_stage_runner`로 분리했습니다.
- direct 실행의 manifest/XCom payload 처리와 ECS task 위임 경계를 runner별로 나누고, ingestion raw object key 전달 동작을 보존했습니다.
- Airflow 실패 callback payload 구성과 전송을 `pipeline.airflow_failure_reporter`로 분리했습니다.
- Airflow context 값 추출을 공통 helper로 정리하고, 이슈 618 스펙을 `.agent/specs/618.md`에 추가했습니다.
- direct/ECS runner 선택, XCom payload contract, failure manifest, failure callback payload fixture 테스트를 추가했습니다.

## 검증

- `git diff --check`
- `cd ml && uv run ruff check src/dags/domain_pack_generation.py src/pipeline/airflow_stage_runner.py src/pipeline/airflow_failure_reporter.py src/pipeline/common/airflow_context.py tests/test_domain_pack_generation_dag.py tests/test_airflow_stage_runner.py tests/test_airflow_failure_reporter.py`
- `cd ml && uv run ruff format --check src/dags/domain_pack_generation.py src/pipeline/airflow_stage_runner.py src/pipeline/airflow_failure_reporter.py src/pipeline/common/airflow_context.py tests/test_domain_pack_generation_dag.py tests/test_airflow_stage_runner.py tests/test_airflow_failure_reporter.py`
- `cd ml && uv run mypy src/pipeline/airflow_stage_runner.py src/pipeline/airflow_failure_reporter.py src/pipeline/common/airflow_context.py`
- `cd ml && uv run pytest tests/test_domain_pack_generation_dag.py tests/test_airflow_stage_runner.py tests/test_airflow_failure_reporter.py` (38 passed)
- `cd ml && uv run pytest` (653 passed, 2 skipped)
- `pnpm run ci:ml` (653 passed, 2 skipped; coverage 83.08%)

## 참고

- `pnpm run lint:ml`, `pnpm run format:ml:check`, `pnpm run typecheck:ml`은 현재 repository-wide 기존 baseline 위반으로 실패합니다. 이 PR에서 변경한 파일은 위의 대상 지정 ruff/mypy 명령과 `ci:ml`로 통과를 확인했습니다.