### PR TITLE
refactor(ml): draft_generation artifact contract를 명시

### DIFF
--- a/.agent/specs/615.md
+++ b/.agent/specs/615.md
@@ -1,0 +1,89 @@
+# draft_generation artifact contract typed model 도입
+
+## Goal
+
+`draft_generation` stage가 입력 artifact와 workflow draft 처리 결과를 명시적인 typed contract로 다루도록 하여 stage 간 schema 변경을 빠르게 감지한다.
+
+## Problem
+
+`ml/src/pipeline/stages/draft_generation/main.py`는 `clusters.json`, `preprocessed_data.json`, workflow draft 처리 결과를 dict와 tuple 중심으로 전달한다. 특히 workflow processing 결과는 tuple unpacking 순서에 의존하므로 필드 추가나 순서 변경이 런타임 오류 또는 잘못된 metric 집계로 늦게 드러날 수 있다. 입력 artifact schema도 암묵적이어서 실패 메시지가 어느 artifact/field 문제인지 충분히 드러나지 않는다.
+
+## Scope
+
+- `draft_generation` 입력 artifact contract를 typed dataclass 기반 모델로 정리한다.
+- workflow processing 결과 구조를 명시적인 dataclass로 전환한다.
+- candidate output artifact는 기존 `candidate.json` JSON key와 downstream 호환성을 유지한다.
+- schema validation 실패 시 artifact 이름과 field path를 포함한 `PipelineStageError` 메시지를 제공한다.
+- `flow_splitting/clusters.json` 우선, 없으면 `intent_discovery/clusters.json`을 사용하는 기존 fallback 정책을 유지하고 코드상에서 명확히 드러낸다.
+- 대표 artifact fixture 기반 schema validation 테스트와 draft generation smoke test를 유지 또는 보강한다.
+
+## Non-goals
+
+- `candidate.json`의 외부 JSON schema version 또는 key 이름을 변경하지 않는다.
+- `publish_candidate` callback 계약, backend API 계약, database schema는 변경하지 않는다.
+- Pydantic 등 신규 runtime dependency를 추가하지 않는다.
+- draft generation 알고리즘, clustering, slot/policy/risk 추출 로직을 재설계하지 않는다.
+
+## Affected Paths
+
+- `ml/src/pipeline/stages/draft_generation/main.py`
+- `ml/src/pipeline/stages/draft_generation/contracts.py`
+- `ml/tests/stages/test_draft_generation_main.py`
+- `.agent/specs/615.md`
+
+## Stage Interface
+
+### Input
+
+| Artifact                 | 필드            | 타입                   | 설명                                                                                         |
+| ------------------------ | --------------- | ---------------------- | -------------------------------------------------------------------------------------------- |
+| `clusters.json`          | root            | object                 | `flow_splitting` 산출물이 있으면 우선 사용하고, 없으면 `intent_discovery` 산출물을 사용한다. |
+| `clusters.json`          | `clusters`      | list[object]           | workflow/intent draft 생성의 원천 cluster 목록이다.                                          |
+| `preprocessed_data.json` | root            | object                 | preprocessing stage 산출물이다.                                                              |
+| `preprocessed_data.json` | `conversations` | list[object]           | 대표 case hydration에 사용하는 conversation 목록이다.                                        |
+| `preprocessed_data.json` | `issueCaselets` | list[object], optional | 존재하면 conversation index에 caselet row로 병합한다.                                        |
+
+### Output
+
+| Artifact         | 필드                  | 타입         | 설명                                                                                 |
+| ---------------- | --------------------- | ------------ | ------------------------------------------------------------------------------------ |
+| `candidate.json` | `schemaVersion`       | str          | 기존 값 `"1.0"`을 유지한다.                                                          |
+| `candidate.json` | `domainPackDraft`     | object       | `packKey`, `packName`을 포함한다.                                                    |
+| `candidate.json` | `intentDraft.intents` | list[object] | 기존 intent draft JSON 형식을 유지한다.                                              |
+| `candidate.json` | `workflowDraft`       | object       | `slots`, `policies`, `risks`, `workflows`, `intentSlotBindings` list key를 유지한다. |
+| `candidate.json` | `evaluationInputs`    | object       | evaluation stage 입력 metric payload를 유지한다.                                     |
+
+## Requirements
+
+1. `clusters.json`과 `preprocessed_data.json` 로딩은 typed contract 생성 경로를 거쳐야 한다.
+2. schema validation 실패는 `PipelineStageError`로 발생해야 하며 artifact명과 field path를 포함해야 한다.
+3. `clusters.json` fallback은 `flow_splitting` 산출물이 없을 때만 `intent_discovery` 산출물을 사용하는 기존 정책을 유지해야 한다.
+4. workflow processing 결과는 tuple이 아니라 field 이름이 있는 dataclass로 반환되어야 한다.
+5. `workflowDraft` output은 typed contract를 거치되 기존 JSON list key를 그대로 직렬화해야 한다.
+6. `candidate.json` output은 기존 downstream `publish_candidate.validate_candidate`가 수용하는 형식을 유지해야 한다.
+7. 대표 정상 artifact와 schema validation 실패 artifact를 검증하는 테스트가 있어야 한다.
+8. 기존 draft generation smoke test는 통과해야 한다.
+
+## Data/API Impact
+
+- 외부 JSON artifact key와 schema version은 변경하지 않는다.
+- downstream `publish_candidate` 입력 형식은 변경하지 않는다.
+- 신규 dependency, DB migration, backend/frontend API 변경은 없다.
+
+## Acceptance Criteria
+
+- `draft_generation` stage가 정상 fixture에서 기존 `candidate.json` 구조를 생성한다.
+- malformed `clusters.json`의 `clusters` field가 list가 아니면 field path가 포함된 실패 메시지로 중단된다.
+- malformed `preprocessed_data.json`의 `conversations` field가 list가 아니면 field path가 포함된 실패 메시지로 중단된다.
+- workflow processing 결과 집계가 named dataclass field를 통해 수행되어 tuple 순서 의존이 제거된다.
+- 생성된 candidate artifact가 `publish_candidate.validate_candidate`를 통과한다.
+
+## Validation
+
+- `cd ml && uv run pytest tests/stages/test_draft_generation_main.py tests/stages/test_draft_generation_smoke.py`
+- 필요 시 `cd ml && uv run pytest`
+- diff 검토로 `candidate.json` JSON key 호환성과 신규 dependency 미추가 여부 확인
+
+## Open Questions
+
+- 없음. 이슈 본문과 현재 `draft_generation`/`publish_candidate` 계약으로 변경 범위를 결정하기에 충분하다.

--- a/ml/src/pipeline/stages/draft_generation/contracts.py
+++ b/ml/src/pipeline/stages/draft_generation/contracts.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from pipeline.common.exceptions import PipelineStageError
+
+SCHEMA_VERSION = "1.0"
+
+
+@dataclass(frozen=True)
+class ClustersArtifact:
+    payload: dict[str, Any]
+    clusters: list[dict[str, Any]]
+    source_path: Path
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, Any], source_path: Path) -> ClustersArtifact:
+        clusters = _contract_required_list(payload, "clusters.json", "clusters", source_path)
+        typed_clusters = [
+            _contract_required_object(cluster, "clusters.json", f"clusters[{index}]", source_path)
+            for index, cluster in enumerate(clusters)
+        ]
+        return cls(payload=payload, clusters=typed_clusters, source_path=source_path)
+
+
+@dataclass(frozen=True)
+class PreprocessedArtifact:
+    conversations: list[dict[str, Any]]
+    issue_caselets: list[dict[str, Any]]
+    source_path: Path
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, Any], source_path: Path) -> PreprocessedArtifact:
+        conversations = _contract_required_list(payload, "preprocessed_data.json", "conversations", source_path)
+        typed_conversations = [
+            _contract_required_object(item, "preprocessed_data.json", f"conversations[{index}]", source_path)
+            for index, item in enumerate(conversations)
+        ]
+        caselets = payload.get("issueCaselets", [])
+        if caselets is None:
+            caselets = []
+        if not isinstance(caselets, list):
+            raise _contract_error("preprocessed_data.json", "issueCaselets", "must be a list when present", source_path)
+        typed_caselets = [
+            _contract_required_object(item, "preprocessed_data.json", f"issueCaselets[{index}]", source_path)
+            for index, item in enumerate(caselets)
+        ]
+        return cls(conversations=typed_conversations, issue_caselets=typed_caselets, source_path=source_path)
+
+    def conversation_index(self) -> dict[str, dict[str, Any]]:
+        index: dict[str, dict[str, Any]] = {}
+        for position, conversation in enumerate(self.conversations):
+            conversation_id = conversation.get("id")
+            if not isinstance(conversation_id, str) or not conversation_id:
+                raise _contract_error(
+                    "preprocessed_data.json",
+                    f"conversations[{position}].id",
+                    "must be a non-empty string",
+                    self.source_path,
+                )
+            index[conversation_id] = conversation
+        for position, caselet in enumerate(self.issue_caselets):
+            caselet_id = caselet.get("caseletId")
+            if not isinstance(caselet_id, str) or not caselet_id:
+                raise _contract_error(
+                    "preprocessed_data.json",
+                    f"issueCaselets[{position}].caseletId",
+                    "must be a non-empty string",
+                    self.source_path,
+                )
+            index[caselet_id] = _caselet_index_row(caselet)
+        return index
+
+
+@dataclass(frozen=True)
+class ProcessedWorkflow:
+    workflow: dict[str, Any]
+    keyword_count: int
+    exemplar_count: int
+    member_count: int
+    is_empty_evidence: bool
+    signal: dict[str, Any]
+    path_support: float
+    precision: float
+    specificity: float
+    graph_specific_metrics: dict[str, int | bool]
+
+
+@dataclass(frozen=True)
+class WorkflowDraftArtifact:
+    slots: list[dict[str, Any]]
+    policies: list[dict[str, Any]]
+    risks: list[dict[str, Any]]
+    workflows: list[dict[str, Any]]
+    intent_slot_bindings: list[dict[str, Any]]
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, Any], field_path: str = "workflowDraft") -> WorkflowDraftArtifact:
+        typed_lists = {
+            key: [
+                _contract_required_object(item, "candidate.json", f"{field_path}.{key}[{index}]", None)
+                for index, item in enumerate(
+                    _contract_required_list(payload, "candidate.json", f"{field_path}.{key}", None)
+                )
+            ]
+            for key in ("slots", "policies", "risks", "workflows", "intentSlotBindings")
+        }
+        return cls(
+            slots=typed_lists["slots"],
+            policies=typed_lists["policies"],
+            risks=typed_lists["risks"],
+            workflows=typed_lists["workflows"],
+            intent_slot_bindings=typed_lists["intentSlotBindings"],
+        )
+
+    def to_json_dict(self) -> dict[str, Any]:
+        return {
+            "slots": self.slots,
+            "policies": self.policies,
+            "risks": self.risks,
+            "workflows": self.workflows,
+            "intentSlotBindings": self.intent_slot_bindings,
+        }
+
+
+@dataclass(frozen=True)
+class DraftGenerationCandidateArtifact:
+    domain_pack_draft: dict[str, Any]
+    intents: list[dict[str, Any]]
+    workflow_draft: WorkflowDraftArtifact
+    evaluation_inputs: dict[str, Any]
+    schema_version: str = SCHEMA_VERSION
+
+    def to_json_dict(self) -> dict[str, Any]:
+        if self.schema_version != SCHEMA_VERSION:
+            raise PipelineStageError(f"candidate.json schemaVersion must be '{SCHEMA_VERSION}'.")
+        _contract_required_object(self.domain_pack_draft, "candidate.json", "domainPackDraft", None)
+        _contract_required_list({"intents": self.intents}, "candidate.json", "intentDraft.intents", None)
+        _contract_required_object(self.evaluation_inputs, "candidate.json", "evaluationInputs", None)
+        return {
+            "schemaVersion": self.schema_version,
+            "domainPackDraft": self.domain_pack_draft,
+            "intentDraft": {
+                "intents": self.intents,
+            },
+            "workflowDraft": self.workflow_draft.to_json_dict(),
+            "evaluationInputs": self.evaluation_inputs,
+        }
+
+
+def _contract_required_object(
+    value: object,
+    artifact_name: str,
+    field_path: str,
+    source_path: Path | None,
+) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    raise _contract_error(artifact_name, field_path, "must be a JSON object", source_path)
+
+
+def _contract_required_list(
+    payload: dict[str, Any],
+    artifact_name: str,
+    field_path: str,
+    source_path: Path | None,
+) -> list[Any]:
+    key = field_path.rsplit(".", maxsplit=1)[-1]
+    value = payload.get(key)
+    if isinstance(value, list):
+        return value
+    raise _contract_error(artifact_name, field_path, "must be a list", source_path)
+
+
+def _contract_error(
+    artifact_name: str,
+    field_path: str,
+    message: str,
+    source_path: Path | None,
+) -> PipelineStageError:
+    location = f": {source_path}" if source_path is not None else ""
+    return PipelineStageError(f"{artifact_name} field '{field_path}' {message}{location}")
+
+
+def _caselet_index_row(caselet: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": caselet.get("caseletId", ""),
+        "source_conversation_id": caselet.get("conversationId"),
+        "turn_start": caselet.get("turnStart"),
+        "turn_end": caselet.get("turnEnd"),
+        "evidence_turn_ids": caselet.get("evidenceTurnIds", []),
+        "canonical_text": caselet.get("canonicalText", ""),
+        "customer_problem_text": caselet.get("customerIssueText", ""),
+        "agent_resolution_text": caselet.get("agentResolutionText", ""),
+        "agent_action_text": caselet.get("agentActionText", ""),
+        "ended_status": caselet.get("outcome"),
+        "flow_events": caselet.get("flowEvents", []),
+        "action_object_frame": caselet.get("actionObjectFrame", {}),
+        "workflow_signal": caselet.get("workflowSignal", {}),
+        "source_quality_flags": caselet.get("sourceQualityFlags", []),
+        "filtered": caselet.get("filtered") is True,
+        "quality_score": caselet.get("qualityScore"),
+    }

--- a/ml/src/pipeline/stages/draft_generation/main.py
+++ b/ml/src/pipeline/stages/draft_generation/main.py
@@ -14,6 +14,13 @@ from pipeline.common.config import PipelineRuntimeConfig
 from pipeline.common.context import StageContext
 from pipeline.common.exceptions import PipelineStageError
 from pipeline.common.logging import get_stage_logger
+from pipeline.stages.draft_generation.contracts import (
+    ClustersArtifact,
+    DraftGenerationCandidateArtifact,
+    PreprocessedArtifact,
+    ProcessedWorkflow,
+    WorkflowDraftArtifact,
+)
 from pipeline.stages.draft_generation.description_enrichment import enrich_candidate_descriptions
 from pipeline.stages.draft_generation.knowledge_extraction import (
     build_evidence_based_slot_draft,
@@ -280,8 +287,9 @@ def run(upstream_manifest_path: str | None = None) -> dict[str, object]:
 
     logger.info("draft_generation.start %s", stage_context)
 
-    clusters_payload = _read_clusters(runtime_config, stage_context)
-    clusters = clusters_payload.get("clusters") or []
+    clusters_artifact = _read_clusters(runtime_config, stage_context)
+    clusters_payload = clusters_artifact.payload
+    clusters = clusters_artifact.clusters
     logger.info("draft_generation.cluster_loaded cluster_count=%d", len(clusters))
 
     preprocessed_index = _read_preprocessed_index(runtime_config, stage_context)
@@ -350,7 +358,7 @@ def run(upstream_manifest_path: str | None = None) -> dict[str, object]:
     return {"candidateArtifactPath": str(candidate_path), "artifact_manifest_path": str(manifest)}
 
 
-def _read_clusters(runtime_config: PipelineRuntimeConfig, stage_context: StageContext) -> dict[str, Any]:
+def _read_clusters(runtime_config: PipelineRuntimeConfig, stage_context: StageContext) -> ClustersArtifact:
     flow_split_path = _upstream_stage_dir("flow_splitting", runtime_config, stage_context) / DEFAULT_CLUSTERS_ARTIFACT
     clusters_path = (
         flow_split_path
@@ -365,7 +373,7 @@ def _read_clusters(runtime_config: PipelineRuntimeConfig, stage_context: StageCo
         raise PipelineStageError(f"Failed to read clusters.json: {clusters_path}") from exc
     if not isinstance(payload, dict):
         raise PipelineStageError(f"clusters.json must be a JSON object: {clusters_path}")
-    return payload
+    return ClustersArtifact.from_payload(payload, clusters_path)
 
 
 def _read_preprocessed_index(
@@ -383,37 +391,7 @@ def _read_preprocessed_index(
         raise PipelineStageError(f"Failed to read preprocessed_data.json: {preprocessed_path}") from exc
     if not isinstance(data, dict):
         raise PipelineStageError(f"preprocessed_data.json must be a JSON object: {preprocessed_path}")
-    conversations = data.get("conversations")
-    if not isinstance(conversations, list):
-        raise PipelineStageError(f"preprocessed_data.json conversations must be a list: {preprocessed_path}")
-    index = {conv["id"]: conv for conv in conversations if isinstance(conv, dict) and "id" in conv}
-    caselets = data.get("issueCaselets")
-    if isinstance(caselets, list):
-        for caselet in caselets:
-            if isinstance(caselet, dict) and isinstance(caselet.get("caseletId"), str):
-                index[str(caselet["caseletId"])] = _caselet_index_row(caselet)
-    return index
-
-
-def _caselet_index_row(caselet: dict[str, Any]) -> dict[str, Any]:
-    return {
-        "id": caselet.get("caseletId", ""),
-        "source_conversation_id": caselet.get("conversationId"),
-        "turn_start": caselet.get("turnStart"),
-        "turn_end": caselet.get("turnEnd"),
-        "evidence_turn_ids": caselet.get("evidenceTurnIds", []),
-        "canonical_text": caselet.get("canonicalText", ""),
-        "customer_problem_text": caselet.get("customerIssueText", ""),
-        "agent_resolution_text": caselet.get("agentResolutionText", ""),
-        "agent_action_text": caselet.get("agentActionText", ""),
-        "ended_status": caselet.get("outcome"),
-        "flow_events": caselet.get("flowEvents", []),
-        "action_object_frame": caselet.get("actionObjectFrame", {}),
-        "workflow_signal": caselet.get("workflowSignal", {}),
-        "source_quality_flags": caselet.get("sourceQualityFlags", []),
-        "filtered": caselet.get("filtered") is True,
-        "quality_score": caselet.get("qualityScore"),
-    }
+    return PreprocessedArtifact.from_payload(data, preprocessed_path).conversation_index()
 
 
 def _upstream_stage_dir(
@@ -1183,7 +1161,7 @@ def _process_cluster_entry(
     slot_names_by_code: dict[str, str] | None = None,
     risk_refs: list[str] | None = None,
     risk_names_by_code: dict[str, str] | None = None,
-) -> tuple[dict[str, Any], int, int, int, bool, dict[str, Any], float, float, float, dict[str, int | bool]] | None:
+) -> ProcessedWorkflow | None:
     if not isinstance(cluster, dict):
         return None
     cluster_id = cluster.get("cluster_id")
@@ -1289,17 +1267,17 @@ def _process_cluster_entry(
             "needs_review" if cluster.get("needs_human_review") is True or review_only_reasons else "auto_acceptable"
         ),
     }
-    return (
-        workflow,
-        kw_count,
-        ex_count,
-        mb_count,
-        not evidence_items,
-        signal,
-        workflow_path_support,
-        workflow_precision,
-        workflow_specificity,
-        graph_specific_metrics,
+    return ProcessedWorkflow(
+        workflow=workflow,
+        keyword_count=kw_count,
+        exemplar_count=ex_count,
+        member_count=mb_count,
+        is_empty_evidence=not evidence_items,
+        signal=signal,
+        path_support=workflow_path_support,
+        precision=workflow_precision,
+        specificity=workflow_specificity,
+        graph_specific_metrics=graph_specific_metrics,
     )
 
 
@@ -1914,48 +1892,36 @@ def _build_workflow_draft(
         )
         if result is None:
             continue
-        (
-            workflow,
-            kw,
-            ex,
-            mb,
-            is_empty,
-            signal,
-            path_support,
-            workflow_precision,
-            workflow_specificity,
-            graph_specific_metrics,
-        ) = result
-        workflows.append(workflow)
-        keyword_total += kw
-        exemplar_total += ex
-        member_total += mb
-        empty_evidence_count += is_empty
-        workflow_path_support_total += path_support
-        workflow_precision_total += workflow_precision
-        workflow_specificity_total += workflow_specificity
-        route_condition_count += _has_route_condition(workflow)
-        workflows_with_specific_nodes += bool(graph_specific_metrics["has_specific_node"])
-        workflows_with_slot_refs += bool(graph_specific_metrics["has_slot_ref"])
+        workflows.append(result.workflow)
+        keyword_total += result.keyword_count
+        exemplar_total += result.exemplar_count
+        member_total += result.member_count
+        empty_evidence_count += result.is_empty_evidence
+        workflow_path_support_total += result.path_support
+        workflow_precision_total += result.precision
+        workflow_specificity_total += result.specificity
+        route_condition_count += _has_route_condition(result.workflow)
+        workflows_with_specific_nodes += bool(result.graph_specific_metrics["has_specific_node"])
+        workflows_with_slot_refs += bool(result.graph_specific_metrics["has_slot_ref"])
         workflows_requiring_slot_refs += bool(slot_refs)
-        workflows_with_policy_control += bool(graph_specific_metrics["has_policy_control"])
-        workflows_with_risk_refs += bool(graph_specific_metrics["has_risk_ref"])
+        workflows_with_policy_control += bool(result.graph_specific_metrics["has_policy_control"])
+        workflows_with_risk_refs += bool(result.graph_specific_metrics["has_risk_ref"])
         workflows_requiring_risk_refs += bool(risk_refs)
-        review_only_count += _is_review_only_workflow(workflow)
-        action_node_total += int(graph_specific_metrics["action_node_count"])
-        specific_action_node_total += int(graph_specific_metrics["specific_action_node_count"])
+        review_only_count += _is_review_only_workflow(result.workflow)
+        action_node_total += int(result.graph_specific_metrics["action_node_count"])
+        specific_action_node_total += int(result.graph_specific_metrics["specific_action_node_count"])
         workflow_count += 1
-        identify_count += bool(signal.get("requires_user_identification"))
-        payment_count += bool(signal.get("requires_payment_check"))
-        escalation_count += bool(signal.get("has_escalation_cases"))
+        identify_count += bool(result.signal.get("requires_user_identification"))
+        payment_count += bool(result.signal.get("requires_payment_check"))
+        escalation_count += bool(result.signal.get("has_escalation_cases"))
 
-    draft = {
-        "slots": [],
-        "policies": [] if policy_refs_by_cluster is not None else [_default_dummy_policy()],
-        "risks": [],
-        "workflows": workflows,
-        "intentSlotBindings": [],
-    }
+    draft = WorkflowDraftArtifact(
+        slots=[],
+        policies=[] if policy_refs_by_cluster is not None else [_default_dummy_policy()],
+        risks=[],
+        workflows=workflows,
+        intent_slot_bindings=[],
+    )
     workflow_metrics = {
         "workflow_count": workflow_count,
         "workflow_with_identify_count": identify_count,
@@ -1982,7 +1948,7 @@ def _build_workflow_draft(
         "review_only_workflow_count": review_only_count,
         "low_support_workflow_rate": review_only_count / workflow_count if workflow_count else 0.0,
     }
-    return draft, workflow_metrics
+    return draft.to_json_dict(), workflow_metrics
 
 
 def _cluster_workflow_events(
@@ -2173,15 +2139,13 @@ def _build_candidate(
         "packKey": pack_key,
         "packName": pack_name,
     }
-    return {
-        "schemaVersion": "1.0",
-        "domainPackDraft": domain_pack_draft,
-        "intentDraft": {
-            "intents": intents,
-        },
-        "workflowDraft": workflow_draft,
-        "evaluationInputs": evaluation_inputs or {},
-    }
+    candidate = DraftGenerationCandidateArtifact(
+        domain_pack_draft=domain_pack_draft,
+        intents=intents,
+        workflow_draft=WorkflowDraftArtifact.from_payload(workflow_draft),
+        evaluation_inputs=evaluation_inputs or {},
+    )
+    return candidate.to_json_dict()
 
 
 def _write_candidate(

--- a/ml/tests/stages/test_draft_generation_main.py
+++ b/ml/tests/stages/test_draft_generation_main.py
@@ -19,6 +19,7 @@ from pipeline.stages.draft_generation.main import (
     _evaluation_inputs,
     _hydrate_case,
     _label_metrics,
+    _process_cluster_entry,
     _read_clusters,
     _read_preprocessed_index,
     _resolve_cases_per_intent,
@@ -336,9 +337,53 @@ def test_read_clusters_success(tmp_path: Path) -> None:
     clusters_dir = runtime_config.artifact_root / "dag" / "run1" / "intent_discovery"
     _write_clusters(clusters_dir, [{"cluster_id": 0, "exemplar_conv_ids": ["c1"]}])
 
-    payload = _read_clusters(runtime_config, context)
+    artifact = _read_clusters(runtime_config, context)
 
-    assert len(payload["clusters"]) == 1
+    assert len(artifact.clusters) == 1
+    assert artifact.payload["clusters"] == artifact.clusters
+    assert artifact.source_path == clusters_dir / "clusters.json"
+
+
+def test_read_clusters_prefers_flow_splitting_artifact(tmp_path: Path) -> None:
+    runtime_config = _runtime_config(tmp_path)
+    context = _stage_context()
+    intent_dir = runtime_config.artifact_root / "dag" / "run1" / "intent_discovery"
+    flow_dir = runtime_config.artifact_root / "dag" / "run1" / "flow_splitting"
+    _write_clusters(intent_dir, [{"cluster_id": 0, "exemplar_conv_ids": ["intent"]}])
+    _write_clusters(flow_dir, [{"cluster_id": 1, "exemplar_conv_ids": ["flow"]}])
+
+    artifact = _read_clusters(runtime_config, context)
+
+    assert artifact.clusters[0]["cluster_id"] == 1
+    assert artifact.source_path == flow_dir / "clusters.json"
+
+
+def test_read_clusters_raises_with_field_path_when_clusters_is_not_list(tmp_path: Path) -> None:
+    runtime_config = _runtime_config(tmp_path)
+    context = _stage_context()
+    clusters_dir = runtime_config.artifact_root / "dag" / "run1" / "intent_discovery"
+    clusters_dir.mkdir(parents=True)
+    (clusters_dir / "clusters.json").write_text(
+        json.dumps({"schema_version": "1.0", "clusters": {"cluster_id": 0}}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(PipelineStageError, match=r"clusters\.json field 'clusters' must be a list"):
+        _read_clusters(runtime_config, context)
+
+
+def test_read_clusters_raises_with_field_path_when_cluster_item_is_not_object(tmp_path: Path) -> None:
+    runtime_config = _runtime_config(tmp_path)
+    context = _stage_context()
+    clusters_dir = runtime_config.artifact_root / "dag" / "run1" / "intent_discovery"
+    clusters_dir.mkdir(parents=True)
+    (clusters_dir / "clusters.json").write_text(
+        json.dumps({"schema_version": "1.0", "clusters": [{"cluster_id": 0}, "bad"]}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(PipelineStageError, match=r"clusters\.json field 'clusters\[1\]' must be a JSON object"):
+        _read_clusters(runtime_config, context)
 
 
 def test_read_preprocessed_index_success(tmp_path: Path) -> None:
@@ -350,6 +395,40 @@ def test_read_preprocessed_index_success(tmp_path: Path) -> None:
     index = _read_preprocessed_index(runtime_config, context)
 
     assert set(index.keys()) == {"c1", "c2"}
+
+
+def test_read_preprocessed_index_raises_with_field_path_when_conversations_is_not_list(tmp_path: Path) -> None:
+    runtime_config = _runtime_config(tmp_path)
+    context = _stage_context()
+    preprocessed_dir = runtime_config.artifact_root / "dag" / "run1" / "preprocessing"
+    preprocessed_dir.mkdir(parents=True)
+    (preprocessed_dir / "preprocessed_data.json").write_text(
+        json.dumps({"schema_version": "1.0", "conversations": {"id": "c1"}}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        PipelineStageError,
+        match=r"preprocessed_data\.json field 'conversations' must be a list",
+    ):
+        _read_preprocessed_index(runtime_config, context)
+
+
+def test_read_preprocessed_index_raises_with_field_path_when_conversation_id_is_missing(tmp_path: Path) -> None:
+    runtime_config = _runtime_config(tmp_path)
+    context = _stage_context()
+    preprocessed_dir = runtime_config.artifact_root / "dag" / "run1" / "preprocessing"
+    preprocessed_dir.mkdir(parents=True)
+    (preprocessed_dir / "preprocessed_data.json").write_text(
+        json.dumps({"schema_version": "1.0", "conversations": [{"canonical_text": "text"}]}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        PipelineStageError,
+        match=r"preprocessed_data\.json field 'conversations\[0\]\.id' must be a non-empty string",
+    ):
+        _read_preprocessed_index(runtime_config, context)
 
 
 def test_resolve_cases_per_intent_default(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -737,6 +816,19 @@ def test_build_workflow_draft_single_cluster() -> None:
     assert meta["sampleReviewReasonCodes"] == ["weak_label_sample"]
     assert meta["reviewReasonCodes"] == []
     assert meta["reviewOnlyCandidate"] is True
+
+
+def test_process_cluster_entry_returns_named_workflow_result() -> None:
+    result = _process_cluster_entry({"cluster_id": 0, "suggested_name": "환불 문의", "workflow_signal": {}})
+
+    assert result is not None
+    assert result.workflow["workflowCode"] == "WORKFLOW_0"
+    assert result.keyword_count == 0
+    assert result.exemplar_count == 0
+    assert result.member_count == 0
+    assert result.is_empty_evidence is True
+    assert result.path_support == 0.0
+    assert "has_specific_node" in result.graph_specific_metrics
 
 
 def test_route_condition_uses_core_terms_without_dialogue_fillers() -> None:


### PR DESCRIPTION
Closes #615

## 변경 사항

- `draft_generation` 입력 artifact와 candidate/workflow draft 경계를 dataclass 기반 contract로 분리했습니다.
- `clusters.json` fallback 정책은 `flow_splitting` 우선, 없으면 `intent_discovery` 사용으로 유지하면서 typed artifact로 전달되도록 했습니다.
- `preprocessed_data.json`과 `clusters.json` schema 오류가 artifact명과 field path를 포함한 `PipelineStageError`로 드러나도록 했습니다.
- workflow processing 결과를 tuple unpacking 대신 `ProcessedWorkflow` field 기반 집계로 바꿨습니다.
- 이슈 615 스펙을 `.agent/specs/615.md`에 정리하고 schema validation/fallback/typed result 테스트를 보강했습니다.

## 검증

- `git diff --check`
- `pnpm exec prettier --check .agent/specs/615.md`
- `cd ml && uv run ruff check src/pipeline/stages/draft_generation/contracts.py src/pipeline/stages/draft_generation/main.py tests/stages/test_draft_generation_main.py tests/stages/test_draft_generation_smoke.py`
- `cd ml && uv run mypy src/pipeline/stages/draft_generation/contracts.py src/pipeline/stages/draft_generation/main.py`
- `cd ml && uv run pytest tests/stages/test_draft_generation_main.py tests/stages/test_draft_generation_smoke.py` (63 passed)
- `cd ml && uv run pytest` (650 passed, 2 skipped)

## 참고

- 커밋 pre-commit의 `pnpm run lint:ml`은 repository-wide 기존 ruff baseline 위반으로 실패합니다. 이 PR에서 변경한 파일은 위의 대상 지정 ruff/mypy 명령과 전체 ML pytest로 통과를 확인했습니다.