### PR TITLE
feat(simulation): 시뮬레이션 우측 패널을 작업 탭으로 분리

### DIFF
--- a/.agent/specs/632.md
+++ b/.agent/specs/632.md
@@ -1,0 +1,108 @@
+# 시뮬레이션 우측 패널 탭 분리
+
+## Goal
+
+상담 시뮬레이션 화면의 우측 패널을 상태, 피드백, 개선 후보 작업으로 분리해 현재 runtime 확인과 후속 개선 작업을 쉽게 구분할 수 있게 한다.
+
+## Problem
+
+`frontend/src/pages/workspace/ui/WorkspaceSimulationPage.tsx`의 우측 `statePane`은 runtime state, 수집된 slot, 검증 케이스, 피드백 작성 폼, workspace feedback 목록, improvement candidates 목록을 한 흐름에 모두 렌더링한다. 우측 패널이 길어질수록 사용자는 현재 실험 상태, 피드백 작성, 후보 승인/반려 작업을 한 화면에서 구분하기 어렵다.
+
+## Scope
+
+- `frontend/src/pages/workspace/ui/WorkspaceSimulationPage.tsx`
+- `frontend/src/pages/workspace/ui/WorkspaceSimulationPage.test.tsx`
+- `frontend/src/pages/workspace/ui/simulation/workspace-simulation-page.module.css`
+- 기존 검증 케이스 섹션은 상태 탭 하단에 유지하되 저장/replay 동작은 변경하지 않는다.
+
+## Non-Goals
+
+- golden case replay 기능 범위는 변경하지 않는다.
+- 시뮬레이션 기반 대시보드 추천 기능은 변경하지 않는다.
+- 개선 후보 승인/반려 API 또는 상태 전이 로직은 변경하지 않는다.
+- backend API, database schema, generated API client는 변경하지 않는다.
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A["시뮬레이션 화면 진입"] --> B["세션 선택 또는 생성"]
+    B --> C["대화와 우측 패널 확인"]
+    C --> D{"우측 패널 탭"}
+    D -->|상태| E["Runtime State와 Slot 상태 확인"]
+    D -->|피드백| F["피드백 대상 선택, 작성, 목록 확인"]
+    D -->|개선 후보| G["후보 before/after 확인 및 승인/반려"]
+    C --> H["메시지 flag 클릭"]
+    H --> F
+```
+
+## Design Diff
+
+| 영역           | As-is                                                              | To-be                                                                              | 변경 내용                                   |
+| -------------- | ------------------------------------------------------------------ | ---------------------------------------------------------------------------------- | ------------------------------------------- |
+| 우측 패널 구조 | 모든 상태와 작업이 세로로 누적됨                                   | 상태, 피드백, 개선 후보 탭으로 분리                                                | 작업 맥락별 정보 밀도를 낮춘다              |
+| 상태 영역      | Runtime State, Slot, 검증 케이스, 피드백/후보가 같은 스크롤에 존재 | 상태 탭에 Runtime State와 Slot 상태를 우선 표시하고 검증 케이스 섹션은 하단에 유지 | 현재 실험 상태를 즉시 확인한다              |
+| 피드백 영역    | 작성 폼과 workspace feedback 목록이 다른 영역 사이에 묻힘          | 피드백 탭에 대상 선택, 작성 폼, workspace feedback 목록 배치                       | 메시지 flag 이후 작성 지점을 찾기 쉽게 한다 |
+| 후보 영역      | 후보 목록과 승인/반려가 피드백 아래에 이어짐                       | 개선 후보 탭에 후보 목록, 승인/반려, before/after 요약 배치                        | 후보 검토 작업을 독립적으로 수행한다        |
+| 반응형         | 1180px 이하에서 패널들이 세로로 전환됨                             | 동일 전환 안에서 탭 버튼과 탭 패널이 폭에 맞게 유지됨                              | 좁은 화면에서도 탭 구조가 깨지지 않는다     |
+
+## Component Tree
+
+```text
+WorkspaceSimulationPage
+├─ Session pane
+├─ Chat pane
+│  └─ MessageBubble
+└─ Simulation side pane
+   ├─ Tab list: 상태 / 피드백 / 개선 후보
+   ├─ 상태 tab panel
+   │  ├─ Runtime State
+   │  ├─ Slot panel
+   │  └─ Golden case panel
+   ├─ 피드백 tab panel
+   │  ├─ Feedback form
+   │  └─ Workspace feedback list
+   └─ 개선 후보 tab panel
+      └─ Improvement candidate list and actions
+```
+
+## State Management
+
+- 새 클라이언트 상태는 우측 패널의 active tab 값만 추가한다.
+- 메시지 flag 버튼을 누르면 기존 피드백 대상 선택 상태를 해당 메시지로 갱신하고 피드백 탭을 활성화한다.
+- 기존 세션 선택, 메시지 전송, 피드백 저장, 후보 생성/승인/반려, 검증 케이스 저장/replay 상태는 유지한다.
+
+## API Integration
+
+- 신규 API endpoint는 없다.
+- 기존 `simulationApi` 호출 계약과 query parameter 초기화(`feedbackStatus`, `candidateStatus`)는 유지한다.
+- generated API 파일은 변경하지 않는다.
+
+## Acceptance Criteria
+
+- 사용자는 우측 패널에서 상태, 피드백, 개선 후보 탭을 명확히 구분할 수 있다.
+- 상태 탭에는 runtime state와 slot 상태가 유지된다.
+- 피드백 탭에는 피드백 대상 선택, 작성 폼, workspace feedback 목록이 함께 표시된다.
+- 개선 후보 탭에는 후보 목록, 승인/반려 액션, before/after/근거 요약이 함께 표시된다.
+- 메시지 flag 액션은 피드백 대상을 선택하고 피드백 탭을 활성화한다.
+- 1180px 이하 레이아웃에서도 탭 버튼과 탭 패널이 한 열 레이아웃 안에서 유지된다.
+- 기존 세션 생성, 메시지 전송, 피드백 저장, 후보 생성/승인/반려 동작이 유지된다.
+
+## Tests
+
+| 구분       | 시나리오          | 기대 결과                                                                    |
+| ---------- | ----------------- | ---------------------------------------------------------------------------- |
+| Component  | 기본 렌더링       | 상태 탭에서 runtime state와 slot 값을 확인할 수 있다                         |
+| Component  | 메시지 flag 클릭  | 피드백 탭이 활성화되고 대상 선택 값이 해당 turn으로 설정된다                 |
+| Component  | 개선 후보 탭 선택 | 후보 목록, before/after 요약, 승인/반려 액션이 피드백 폼과 분리되어 표시된다 |
+| Regression | 기존 피드백 작성  | 피드백 저장 API payload가 유지된다                                           |
+| Regression | 기존 후보 액션    | 후보 생성, 리뷰 요청, 승인, 반려 API 호출이 유지된다                         |
+
+## Validation
+
+- `pnpm --dir frontend test -- WorkspaceSimulationPage.test.tsx --run`
+- `pnpm run ci:frontend`
+
+## Open Questions
+
+- 없음.

--- a/frontend/src/pages/workspace/ui/WorkspaceSimulationPage.test.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceSimulationPage.test.tsx
@@ -4,16 +4,25 @@ import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { toast } from "sonner";
 
 import { WorkspaceSimulationPage } from "./WorkspaceSimulationPage";
-import { simulationApi, type SimulationImprovementCandidate } from "@/features/simulation";
+import {
+  simulationApi,
+  type SimulationImprovementCandidate,
+} from "@/features/simulation";
 import { useListAllWorkspaceWorkflows } from "@/entities/workflow";
 
 const setCrumbs = vi.fn();
 
 vi.mock("react-router-dom", async () => {
-  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  const actual =
+    await vi.importActual<typeof import("react-router-dom")>(
+      "react-router-dom",
+    );
   return {
     ...actual,
-    useOutletContext: () => ({ setCrumbs, workspace: { id: 1, name: "CS Team" } }),
+    useOutletContext: () => ({
+      setCrumbs,
+      workspace: { id: 1, name: "CS Team" },
+    }),
   };
 });
 
@@ -213,11 +222,25 @@ function renderPage(path = "/workspaces/1/simulation") {
   render(
     <MemoryRouter initialEntries={[path]}>
       <Routes>
-        <Route path="/workspaces/:workspaceId/simulation" element={<WorkspaceSimulationPage />} />
-        <Route path="/workspaces" element={<div data-testid="workspace-root" />} />
+        <Route
+          path="/workspaces/:workspaceId/simulation"
+          element={<WorkspaceSimulationPage />}
+        />
+        <Route
+          path="/workspaces"
+          element={<div data-testid="workspace-root" />}
+        />
       </Routes>
     </MemoryRouter>,
   );
+}
+
+async function openFeedbackTab() {
+  fireEvent.click(await screen.findByRole("tab", { name: "피드백" }));
+}
+
+async function openCandidateTab() {
+  fireEvent.click(await screen.findByRole("tab", { name: "개선 후보" }));
 }
 
 beforeEach(() => {
@@ -245,8 +268,9 @@ beforeEach(() => {
     totalElements: 1,
     totalPages: 1,
   });
-  mockedSimulationApi.getSession.mockImplementation(async (_workspaceId, sessionId) =>
-    sessionId === otherSession.id ? otherDetail : detail,
+  mockedSimulationApi.getSession.mockImplementation(
+    async (_workspaceId, sessionId) =>
+      sessionId === otherSession.id ? otherDetail : detail,
   );
   mockedSimulationApi.createSession.mockResolvedValue(detail);
   mockedSimulationApi.createFeedback.mockResolvedValue(detail);
@@ -314,7 +338,9 @@ describe("WorkspaceSimulationPage", () => {
   it("세션 목록과 runtime 상태를 표시한다", async () => {
     renderPage();
 
-    expect(await screen.findByRole("heading", { name: "상담 시뮬레이션" })).toBeInTheDocument();
+    expect(
+      await screen.findByRole("heading", { name: "상담 시뮬레이션" }),
+    ).toBeInTheDocument();
     expect(await screen.findByText("테스트 고객")).toBeInTheDocument();
     expect(await screen.findByText("환불하고 싶어요")).toBeInTheDocument();
     expect(screen.getByText("환불 문의")).toBeInTheDocument();
@@ -324,10 +350,18 @@ describe("WorkspaceSimulationPage", () => {
   });
 
   it("대시보드 추천 query로 피드백과 개선 후보 상태 필터를 초기화한다", async () => {
-    renderPage("/workspaces/1/simulation?feedbackStatus=RESOLVED&candidateStatus=READY_FOR_REVIEW");
+    renderPage(
+      "/workspaces/1/simulation?feedbackStatus=RESOLVED&candidateStatus=READY_FOR_REVIEW",
+    );
 
-    expect(await screen.findByLabelText("피드백 상태 필터")).toHaveValue("RESOLVED");
-    expect(screen.getByLabelText("개선 후보 상태 필터")).toHaveValue("READY_FOR_REVIEW");
+    await openFeedbackTab();
+    expect(await screen.findByLabelText("피드백 상태 필터")).toHaveValue(
+      "RESOLVED",
+    );
+    await openCandidateTab();
+    expect(screen.getByLabelText("개선 후보 상태 필터")).toHaveValue(
+      "READY_FOR_REVIEW",
+    );
     await waitFor(() => {
       expect(mockedSimulationApi.listFeedback).toHaveBeenCalledWith(1, {
         status: "RESOLVED",
@@ -336,7 +370,9 @@ describe("WorkspaceSimulationPage", () => {
       });
     });
     await waitFor(() => {
-      expect(mockedSimulationApi.listImprovementCandidates).toHaveBeenCalledWith(1, {
+      expect(
+        mockedSimulationApi.listImprovementCandidates,
+      ).toHaveBeenCalledWith(1, {
         status: "READY_FOR_REVIEW",
         page: 0,
         size: 20,
@@ -363,9 +399,12 @@ describe("WorkspaceSimulationPage", () => {
   it("고객 메시지를 전송하고 응답을 화면에 반영한다", async () => {
     renderPage();
 
-    fireEvent.change(await screen.findByPlaceholderText("고객 역할 메시지 입력"), {
-      target: { value: "A-100 주문 환불이요" },
-    });
+    fireEvent.change(
+      await screen.findByPlaceholderText("고객 역할 메시지 입력"),
+      {
+        target: { value: "A-100 주문 환불이요" },
+      },
+    );
     fireEvent.click(screen.getByRole("button", { name: "전송" }));
 
     await waitFor(() => {
@@ -373,13 +412,20 @@ describe("WorkspaceSimulationPage", () => {
         content: "A-100 주문 환불이요",
       });
     });
-    expect(await screen.findByText("주문번호를 알려주세요.")).toBeInTheDocument();
+    expect(
+      await screen.findByText("주문번호를 알려주세요."),
+    ).toBeInTheDocument();
   });
 
   it("turn 단위 피드백을 작성하고 session 상세를 갱신한다", async () => {
     renderPage();
 
     fireEvent.click(await screen.findByLabelText("Turn 1 피드백 대상 선택"));
+    expect(screen.getByRole("tab", { name: "피드백" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(await screen.findByLabelText("피드백 대상 선택")).toHaveValue("1");
     fireEvent.change(screen.getByLabelText("피드백 유형 선택"), {
       target: { value: "MISSING_SLOT_QUESTION" },
     });
@@ -437,7 +483,9 @@ describe("WorkspaceSimulationPage", () => {
     await waitFor(() => {
       expect(screen.getByLabelText("피드백 대상 선택")).toHaveValue("session");
     });
-    expect(screen.getByLabelText("피드백 유형 선택")).toHaveValue("INTENT_MISMATCH");
+    expect(screen.getByLabelText("피드백 유형 선택")).toHaveValue(
+      "INTENT_MISMATCH",
+    );
     expect(screen.getByLabelText("피드백 심각도 선택")).toHaveValue("MEDIUM");
     expect(screen.getByLabelText("설명")).toHaveValue("");
     expect(screen.getByLabelText("기대 응답/행동")).toHaveValue("");
@@ -447,37 +495,51 @@ describe("WorkspaceSimulationPage", () => {
     renderPage();
 
     expect(await screen.findByText("환불하고 싶어요")).toBeInTheDocument();
+    await openFeedbackTab();
     fireEvent.change(await screen.findByLabelText("설명"), {
       target: { value: "주문번호를 묻지 않았습니다." },
     });
     fireEvent.change(screen.getByLabelText("기대 응답/행동"), {
       target: { value: "주문번호를 먼저 요청합니다." },
     });
-    mockedSimulationApi.listFeedback.mockRejectedValueOnce(new Error("refresh failed"));
+    mockedSimulationApi.listFeedback.mockRejectedValueOnce(
+      new Error("refresh failed"),
+    );
     fireEvent.click(screen.getByRole("button", { name: "피드백 저장" }));
 
     await waitFor(() => {
       expect(mockedSimulationApi.createFeedback).toHaveBeenCalled();
     });
-    expect(toast.success).toHaveBeenCalledWith("시뮬레이션 피드백을 남겼습니다.");
+    expect(toast.success).toHaveBeenCalledWith(
+      "시뮬레이션 피드백을 남겼습니다.",
+    );
     await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith("피드백 목록 새로고침에 실패했습니다.");
+      expect(toast.error).toHaveBeenCalledWith(
+        "피드백 목록 새로고침에 실패했습니다.",
+      );
     });
-    expect(toast.error).not.toHaveBeenCalledWith("시뮬레이션 피드백을 저장하지 못했습니다.");
+    expect(toast.error).not.toHaveBeenCalledWith(
+      "시뮬레이션 피드백을 저장하지 못했습니다.",
+    );
   });
 
   it("OPEN 피드백에서 개선 후보를 생성하고 목록을 새로고침한다", async () => {
     renderPage();
 
+    await openFeedbackTab();
     fireEvent.click(await screen.findByRole("button", { name: "후보" }));
 
     await waitFor(() => {
-      expect(mockedSimulationApi.createImprovementCandidate).toHaveBeenCalledWith(1, 900);
+      expect(
+        mockedSimulationApi.createImprovementCandidate,
+      ).toHaveBeenCalledWith(1, 900);
     });
     expect(toast.success).toHaveBeenCalledWith("개선 후보를 생성했습니다.");
     await waitFor(() => {
       expect(mockedSimulationApi.listFeedback).toHaveBeenCalledTimes(2);
-      expect(mockedSimulationApi.listImprovementCandidates).toHaveBeenCalledTimes(2);
+      expect(
+        mockedSimulationApi.listImprovementCandidates,
+      ).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -485,19 +547,26 @@ describe("WorkspaceSimulationPage", () => {
     renderPage();
 
     await screen.findByText("환불하고 싶어요");
+    await openFeedbackTab();
     mockedSimulationApi.listImprovementCandidates.mockRejectedValueOnce(
       new Error("refresh failed"),
     );
     fireEvent.click(screen.getByRole("button", { name: "후보" }));
 
     await waitFor(() => {
-      expect(mockedSimulationApi.createImprovementCandidate).toHaveBeenCalledWith(1, 900);
+      expect(
+        mockedSimulationApi.createImprovementCandidate,
+      ).toHaveBeenCalledWith(1, 900);
     });
     expect(toast.success).toHaveBeenCalledWith("개선 후보를 생성했습니다.");
     await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith("개선 후보 목록 새로고침에 실패했습니다.");
+      expect(toast.error).toHaveBeenCalledWith(
+        "개선 후보 목록 새로고침에 실패했습니다.",
+      );
     });
-    expect(toast.error).not.toHaveBeenCalledWith("개선 후보를 생성하지 못했습니다.");
+    expect(toast.error).not.toHaveBeenCalledWith(
+      "개선 후보를 생성하지 못했습니다.",
+    );
   });
 
   it("개선 후보 상태를 변경하고 후보 목록을 새로고침한다", async () => {
@@ -510,17 +579,28 @@ describe("WorkspaceSimulationPage", () => {
     });
     renderPage();
 
+    await openCandidateTab();
     fireEvent.click(await screen.findByRole("button", { name: "리뷰 요청" }));
 
     await waitFor(() => {
-      expect(mockedSimulationApi.updateImprovementCandidateStatus).toHaveBeenCalledWith(1, 1000, {
+      expect(
+        mockedSimulationApi.updateImprovementCandidateStatus,
+      ).toHaveBeenCalledWith(1, 1000, {
         status: "READY_FOR_REVIEW",
       });
     });
-    expect(toast.success).toHaveBeenCalledWith("개선 후보 상태를 변경했습니다.");
+    expect(toast.success).toHaveBeenCalledWith(
+      "개선 후보 상태를 변경했습니다.",
+    );
     await waitFor(() => {
-      expect(mockedSimulationApi.listImprovementCandidates).toHaveBeenCalledTimes(2);
+      expect(
+        mockedSimulationApi.listImprovementCandidates,
+      ).toHaveBeenCalledTimes(2);
     });
+    expect(screen.getByRole("tab", { name: "개선 후보" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
   });
 
   it("개선 후보 상태 변경 후 목록 새로고침 실패는 변경 실패로 처리하지 않는다", async () => {
@@ -533,22 +613,33 @@ describe("WorkspaceSimulationPage", () => {
     });
     renderPage();
 
-    const requestButton = await screen.findByRole("button", { name: "리뷰 요청" });
+    await openCandidateTab();
+    const requestButton = await screen.findByRole("button", {
+      name: "리뷰 요청",
+    });
     mockedSimulationApi.listImprovementCandidates.mockRejectedValueOnce(
       new Error("refresh failed"),
     );
     fireEvent.click(requestButton);
 
     await waitFor(() => {
-      expect(mockedSimulationApi.updateImprovementCandidateStatus).toHaveBeenCalledWith(1, 1000, {
+      expect(
+        mockedSimulationApi.updateImprovementCandidateStatus,
+      ).toHaveBeenCalledWith(1, 1000, {
         status: "READY_FOR_REVIEW",
       });
     });
-    expect(toast.success).toHaveBeenCalledWith("개선 후보 상태를 변경했습니다.");
+    expect(toast.success).toHaveBeenCalledWith(
+      "개선 후보 상태를 변경했습니다.",
+    );
     await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith("개선 후보 목록 새로고침에 실패했습니다.");
+      expect(toast.error).toHaveBeenCalledWith(
+        "개선 후보 목록 새로고침에 실패했습니다.",
+      );
     });
-    expect(toast.error).not.toHaveBeenCalledWith("개선 후보 상태를 변경하지 못했습니다.");
+    expect(toast.error).not.toHaveBeenCalledWith(
+      "개선 후보 상태를 변경하지 못했습니다.",
+    );
   });
 
   it("개선 후보 유형 라벨을 표시한다", async () => {
@@ -561,7 +652,10 @@ describe("WorkspaceSimulationPage", () => {
         candidateWithType(1005, "HANDOFF_CONDITION"),
         candidateWithType(1006, "RESPONSE_COPY"),
         candidateWithType(1007, "OTHER"),
-        candidateWithType(1008, "CUSTOM" as SimulationImprovementCandidate["candidateType"]),
+        candidateWithType(
+          1008,
+          "CUSTOM" as SimulationImprovementCandidate["candidateType"],
+        ),
       ],
       page: 0,
       size: 20,
@@ -570,13 +664,18 @@ describe("WorkspaceSimulationPage", () => {
     });
     renderPage();
 
+    await openCandidateTab();
+    expect(screen.getByRole("tab", { name: "개선 후보" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
     expect(await screen.findByText("intent 설명/예시")).toBeInTheDocument();
     expect(screen.getByText("policy 조건")).toBeInTheDocument();
     expect(screen.getByText("risk rule")).toBeInTheDocument();
     expect(screen.getByText("workflow 전이")).toBeInTheDocument();
     expect(screen.getByText("handoff 조건")).toBeInTheDocument();
     expect(screen.getByText("응답 문구")).toBeInTheDocument();
-    expect(screen.getAllByText("기타")).toHaveLength(2);
+    expect(screen.getAllByText("기타")).toHaveLength(1);
     expect(screen.getByText("CUSTOM")).toBeInTheDocument();
     expect(screen.getAllByText("초안").length).toBeGreaterThan(0);
     expect(screen.getAllByText("변경 전").length).toBeGreaterThan(0);
@@ -584,11 +683,15 @@ describe("WorkspaceSimulationPage", () => {
   });
 
   it("개선 후보 목록 로드 실패를 토스트로 알린다", async () => {
-    mockedSimulationApi.listImprovementCandidates.mockRejectedValueOnce(new Error("load failed"));
+    mockedSimulationApi.listImprovementCandidates.mockRejectedValueOnce(
+      new Error("load failed"),
+    );
     renderPage();
 
     await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith("개선 후보 목록을 불러오지 못했습니다.");
+      expect(toast.error).toHaveBeenCalledWith(
+        "개선 후보 목록을 불러오지 못했습니다.",
+      );
     });
   });
 
@@ -596,13 +699,16 @@ describe("WorkspaceSimulationPage", () => {
     renderPage();
 
     await screen.findByText("환불하고 싶어요");
+    await openFeedbackTab();
     mockedSimulationApi.createImprovementCandidate.mockRejectedValueOnce(
       new Error("create failed"),
     );
     fireEvent.click(screen.getByRole("button", { name: "후보" }));
 
     await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith("개선 후보를 생성하지 못했습니다.");
+      expect(toast.error).toHaveBeenCalledWith(
+        "개선 후보를 생성하지 못했습니다.",
+      );
     });
   });
 
@@ -616,14 +722,19 @@ describe("WorkspaceSimulationPage", () => {
     });
     renderPage();
 
-    const requestButton = await screen.findByRole("button", { name: "리뷰 요청" });
+    await openCandidateTab();
+    const requestButton = await screen.findByRole("button", {
+      name: "리뷰 요청",
+    });
     mockedSimulationApi.updateImprovementCandidateStatus.mockRejectedValueOnce(
       new Error("update failed"),
     );
     fireEvent.click(requestButton);
 
     await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith("개선 후보 상태를 변경하지 못했습니다.");
+      expect(toast.error).toHaveBeenCalledWith(
+        "개선 후보 상태를 변경하지 못했습니다.",
+      );
     });
   });
 
@@ -644,16 +755,23 @@ describe("WorkspaceSimulationPage", () => {
     });
     renderPage();
 
+    await openCandidateTab();
     fireEvent.click(await screen.findByRole("button", { name: "승인" }));
 
     await waitFor(() => {
-      expect(mockedSimulationApi.approveImprovementCandidate).toHaveBeenCalledWith(1, 1000, {
+      expect(
+        mockedSimulationApi.approveImprovementCandidate,
+      ).toHaveBeenCalledWith(1, 1000, {
         reason: "시뮬레이션 리뷰 승인",
       });
     });
-    expect(toast.success).toHaveBeenCalledWith("개선 후보를 초안 버전에 반영했습니다.");
+    expect(toast.success).toHaveBeenCalledWith(
+      "개선 후보를 초안 버전에 반영했습니다.",
+    );
     await waitFor(() => {
-      expect(mockedSimulationApi.listImprovementCandidates).toHaveBeenCalledTimes(2);
+      expect(
+        mockedSimulationApi.listImprovementCandidates,
+      ).toHaveBeenCalledTimes(2);
       expect(mockedSimulationApi.listFeedback).toHaveBeenCalledTimes(2);
     });
   });
@@ -675,13 +793,16 @@ describe("WorkspaceSimulationPage", () => {
     });
     renderPage();
 
+    await openCandidateTab();
     fireEvent.change(await screen.findByLabelText("개선 후보 반려 사유"), {
       target: { value: "근거가 부족합니다." },
     });
     fireEvent.click(screen.getByRole("button", { name: "반려" }));
 
     await waitFor(() => {
-      expect(mockedSimulationApi.rejectImprovementCandidate).toHaveBeenCalledWith(1, 1000, {
+      expect(
+        mockedSimulationApi.rejectImprovementCandidate,
+      ).toHaveBeenCalledWith(1, 1000, {
         reason: "근거가 부족합니다.",
       });
     });
@@ -724,14 +845,22 @@ describe("WorkspaceSimulationPage", () => {
     renderPage();
 
     await screen.findByText("환불하고 싶어요");
-    fireEvent.click(await screen.findByRole("button", { name: "환불 검증 replay" }));
+    fireEvent.click(
+      await screen.findByRole("button", { name: "환불 검증 replay" }),
+    );
 
     await waitFor(() => {
-      expect(mockedSimulationApi.replayGoldenCase).toHaveBeenCalledWith(1, 950, {
-        domainPackVersionId: 101,
-      });
+      expect(mockedSimulationApi.replayGoldenCase).toHaveBeenCalledWith(
+        1,
+        950,
+        {
+          domainPackVersionId: 101,
+        },
+      );
     });
-    expect(toast.success).toHaveBeenCalledWith("검증 케이스 replay가 통과했습니다.");
+    expect(toast.success).toHaveBeenCalledWith(
+      "검증 케이스 replay가 통과했습니다.",
+    );
   });
 
   it("최근 replay 실패 요약을 검증 케이스 목록에 표시한다", async () => {
@@ -751,7 +880,9 @@ describe("WorkspaceSimulationPage", () => {
 
     expect(await screen.findByText("FAIL")).toBeInTheDocument();
     expect(
-      screen.getByText("currentState expected collect_order_no but was handoff"),
+      screen.getByText(
+        "currentState expected collect_order_no but was handoff",
+      ),
     ).toBeInTheDocument();
   });
 
@@ -781,12 +912,15 @@ describe("WorkspaceSimulationPage", () => {
   it("개선 후보 상태 필터를 변경해 목록을 다시 조회한다", async () => {
     renderPage();
 
+    await openCandidateTab();
     fireEvent.change(await screen.findByLabelText("개선 후보 상태 필터"), {
       target: { value: "READY_FOR_REVIEW" },
     });
 
     await waitFor(() => {
-      expect(mockedSimulationApi.listImprovementCandidates).toHaveBeenCalledWith(1, {
+      expect(
+        mockedSimulationApi.listImprovementCandidates,
+      ).toHaveBeenCalledWith(1, {
         status: "READY_FOR_REVIEW",
         page: 0,
         size: 20,

--- a/frontend/src/pages/workspace/ui/WorkspaceSimulationPage.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceSimulationPage.tsx
@@ -1,5 +1,10 @@
 import { useEffect, useMemo, useState } from "react";
-import { Navigate, useOutletContext, useParams, useSearchParams } from "react-router-dom";
+import {
+  Navigate,
+  useOutletContext,
+  useParams,
+  useSearchParams,
+} from "react-router-dom";
 import {
   CheckCircleIcon,
   FlagIcon,
@@ -25,7 +30,10 @@ import {
   type SimulationImprovementCandidateStatus,
   type SimulationSessionDetail,
 } from "@/features/simulation";
-import type { ChatMessage, ChatSession } from "@/features/consultation/api/consultationApi";
+import type {
+  ChatMessage,
+  ChatSession,
+} from "@/features/consultation/api/consultationApi";
 import { parseRouteId } from "@/shared/lib/parseRouteId";
 import type { ShellContext } from "@/shared/ui/ostone/chrome";
 import { Button } from "@/shared/ui/button";
@@ -40,24 +48,31 @@ const PAGE_SIZE = 20;
 const DEFAULT_FEEDBACK_TYPE: SimulationFeedbackType = "INTENT_MISMATCH";
 const DEFAULT_FEEDBACK_SEVERITY: SimulationFeedbackSeverity = "MEDIUM";
 
-const FEEDBACK_TYPES: Array<{ value: SimulationFeedbackType; label: string }> = [
-  { value: "INTENT_MISMATCH", label: "잘못된 intent 매칭" },
-  { value: "MISSING_SLOT_QUESTION", label: "누락된 slot 질문" },
-  { value: "INAPPROPRIATE_RESPONSE", label: "부적절한 응답 문구" },
-  { value: "POLICY_CONDITION_MISSING", label: "policy 조건 누락" },
-  { value: "RISK_HANDOFF_REQUIRED", label: "risk/handoff 필요" },
-  { value: "WORKFLOW_BRANCH_ERROR", label: "workflow 분기 오류" },
-  { value: "OTHER", label: "기타" },
-];
+const FEEDBACK_TYPES: Array<{ value: SimulationFeedbackType; label: string }> =
+  [
+    { value: "INTENT_MISMATCH", label: "잘못된 intent 매칭" },
+    { value: "MISSING_SLOT_QUESTION", label: "누락된 slot 질문" },
+    { value: "INAPPROPRIATE_RESPONSE", label: "부적절한 응답 문구" },
+    { value: "POLICY_CONDITION_MISSING", label: "policy 조건 누락" },
+    { value: "RISK_HANDOFF_REQUIRED", label: "risk/handoff 필요" },
+    { value: "WORKFLOW_BRANCH_ERROR", label: "workflow 분기 오류" },
+    { value: "OTHER", label: "기타" },
+  ];
 
-const FEEDBACK_SEVERITIES: Array<{ value: SimulationFeedbackSeverity; label: string }> = [
+const FEEDBACK_SEVERITIES: Array<{
+  value: SimulationFeedbackSeverity;
+  label: string;
+}> = [
   { value: "LOW", label: "낮음" },
   { value: "MEDIUM", label: "보통" },
   { value: "HIGH", label: "높음" },
   { value: "CRITICAL", label: "긴급" },
 ];
 
-const FEEDBACK_STATUSES: Array<{ value: SimulationFeedbackStatus | ""; label: string }> = [
+const FEEDBACK_STATUSES: Array<{
+  value: SimulationFeedbackStatus | "";
+  label: string;
+}> = [
   { value: "OPEN", label: "열림" },
   { value: "CANDIDATE_CREATED", label: "후보 생성" },
   { value: "RESOLVED", label: "해결됨" },
@@ -76,9 +91,32 @@ const CANDIDATE_STATUSES: Array<{
   { value: "", label: "전체" },
 ];
 
-const ACTION_TYPES = ["ASK_SLOT", "ADVANCE", "ANSWER", "COMPLETED", "HANDOFF", "WAIT"] as const;
+const ACTION_TYPES = [
+  "ASK_SLOT",
+  "ADVANCE",
+  "ANSWER",
+  "COMPLETED",
+  "HANDOFF",
+  "WAIT",
+] as const;
 
-function readFeedbackStatusParam(searchParams: URLSearchParams): SimulationFeedbackStatus | "" {
+type SimulationSideTab = "state" | "feedback" | "candidates";
+
+const SIDE_TABS: Array<{ value: SimulationSideTab; label: string }> = [
+  { value: "state", label: "상태" },
+  { value: "feedback", label: "피드백" },
+  { value: "candidates", label: "개선 후보" },
+];
+
+function readInitialSideTab(searchParams: URLSearchParams): SimulationSideTab {
+  if (searchParams.has("candidateStatus")) return "candidates";
+  if (searchParams.has("feedbackStatus")) return "feedback";
+  return "state";
+}
+
+function readFeedbackStatusParam(
+  searchParams: URLSearchParams,
+): SimulationFeedbackStatus | "" {
   const value = searchParams.get("feedbackStatus");
   return FEEDBACK_STATUSES.some((status) => status.value === value)
     ? (value as SimulationFeedbackStatus | "")
@@ -141,7 +179,9 @@ function customerName(session: ChatSession | null): string {
 
 function slotEntries(detail: SimulationSessionDetail | null) {
   const values = detail?.slotValues ?? {};
-  return Object.entries(values).filter(([, value]) => value !== null && value !== undefined);
+  return Object.entries(values).filter(
+    ([, value]) => value !== null && value !== undefined,
+  );
 }
 
 function feedbackTypeLabel(type: SimulationFeedbackType): string {
@@ -149,18 +189,29 @@ function feedbackTypeLabel(type: SimulationFeedbackType): string {
 }
 
 function feedbackSeverityLabel(severity: SimulationFeedbackSeverity): string {
-  return FEEDBACK_SEVERITIES.find((item) => item.value === severity)?.label ?? severity;
+  return (
+    FEEDBACK_SEVERITIES.find((item) => item.value === severity)?.label ??
+    severity
+  );
 }
 
 function feedbackStatusLabel(status: SimulationFeedbackStatus): string {
-  return FEEDBACK_STATUSES.find((item) => item.value === status)?.label ?? status;
+  return (
+    FEEDBACK_STATUSES.find((item) => item.value === status)?.label ?? status
+  );
 }
 
-function candidateStatusLabel(status: SimulationImprovementCandidateStatus): string {
-  return CANDIDATE_STATUSES.find((item) => item.value === status)?.label ?? status;
+function candidateStatusLabel(
+  status: SimulationImprovementCandidateStatus,
+): string {
+  return (
+    CANDIDATE_STATUSES.find((item) => item.value === status)?.label ?? status
+  );
 }
 
-function candidateTypeLabel(type: SimulationImprovementCandidate["candidateType"]): string {
+function candidateTypeLabel(
+  type: SimulationImprovementCandidate["candidateType"],
+): string {
   switch (type) {
     case "INTENT_DESCRIPTION_EXAMPLE":
       return "intent 설명/예시";
@@ -183,7 +234,9 @@ function candidateTypeLabel(type: SimulationImprovementCandidate["candidateType"
   }
 }
 
-function replayStatusLabel(status?: SimulationGoldenCaseReplayStatus | null): string {
+function replayStatusLabel(
+  status?: SimulationGoldenCaseReplayStatus | null,
+): string {
   switch (status) {
     case "PASS":
       return "PASS";
@@ -194,7 +247,10 @@ function replayStatusLabel(status?: SimulationGoldenCaseReplayStatus | null): st
   }
 }
 
-function readExpectedField(goldenCase: SimulationGoldenCase, field: string): string | null {
+function readExpectedField(
+  goldenCase: SimulationGoldenCase,
+  field: string,
+): string | null {
   try {
     const parsed = JSON.parse(goldenCase.expectedJson);
     if (parsed && typeof parsed === "object" && field in parsed) {
@@ -216,7 +272,10 @@ export function WorkspaceSimulationPage() {
   const { workspaceId } = useParams();
   const [searchParams] = useSearchParams();
   const searchQuery = searchParams.toString();
-  const querySearchParams = useMemo(() => new URLSearchParams(searchQuery), [searchQuery]);
+  const querySearchParams = useMemo(
+    () => new URLSearchParams(searchQuery),
+    [searchQuery],
+  );
   const feedbackStatusFromQuery = useMemo(
     () => readFeedbackStatusParam(querySearchParams),
     [querySearchParams],
@@ -229,21 +288,30 @@ export function WorkspaceSimulationPage() {
   const { setCrumbs } = useOutletContext<ShellContext>();
   const [sessions, setSessions] = useState<ChatSession[]>([]);
   const [detail, setDetail] = useState<SimulationSessionDetail | null>(null);
-  const [selectedSessionId, setSelectedSessionId] = useState<number | null>(null);
+  const [selectedSessionId, setSelectedSessionId] = useState<number | null>(
+    null,
+  );
   const [customerNameInput, setCustomerNameInput] = useState("시뮬레이션 고객");
   const [workflowDefinitionId, setWorkflowDefinitionId] = useState("");
   const [messageInput, setMessageInput] = useState("");
   const [feedbackItems, setFeedbackItems] = useState<SimulationFeedback[]>([]);
-  const [feedbackStatusFilter, setFeedbackStatusFilter] = useState<SimulationFeedbackStatus | "">(
-    () => feedbackStatusFromQuery,
-  );
-  const [candidateItems, setCandidateItems] = useState<SimulationImprovementCandidate[]>([]);
+  const [feedbackStatusFilter, setFeedbackStatusFilter] = useState<
+    SimulationFeedbackStatus | ""
+  >(() => feedbackStatusFromQuery);
+  const [candidateItems, setCandidateItems] = useState<
+    SimulationImprovementCandidate[]
+  >([]);
   const [goldenCases, setGoldenCases] = useState<SimulationGoldenCase[]>([]);
   const [candidateStatusFilter, setCandidateStatusFilter] = useState<
     SimulationImprovementCandidateStatus | ""
   >(() => candidateStatusFromQuery);
+  const [activeSideTab, setActiveSideTab] = useState<SimulationSideTab>(() =>
+    readInitialSideTab(querySearchParams),
+  );
   const [feedbackTarget, setFeedbackTarget] = useState("session");
-  const [feedbackType, setFeedbackType] = useState<SimulationFeedbackType>(DEFAULT_FEEDBACK_TYPE);
+  const [feedbackType, setFeedbackType] = useState<SimulationFeedbackType>(
+    DEFAULT_FEEDBACK_TYPE,
+  );
   const [feedbackSeverity, setFeedbackSeverity] =
     useState<SimulationFeedbackSeverity>(DEFAULT_FEEDBACK_SEVERITY);
   const [feedbackDescription, setFeedbackDescription] = useState("");
@@ -260,16 +328,28 @@ export function WorkspaceSimulationPage() {
   const [isSending, setIsSending] = useState(false);
   const [isSubmittingFeedback, setIsSubmittingFeedback] = useState(false);
   const [isCreatingGoldenCase, setIsCreatingGoldenCase] = useState(false);
-  const [replayingGoldenCaseId, setReplayingGoldenCaseId] = useState<number | null>(null);
-  const [creatingCandidateId, setCreatingCandidateId] = useState<number | null>(null);
-  const [updatingCandidateId, setUpdatingCandidateId] = useState<number | null>(null);
-  const [candidateRejectReasons, setCandidateRejectReasons] = useState<Record<number, string>>({});
+  const [replayingGoldenCaseId, setReplayingGoldenCaseId] = useState<
+    number | null
+  >(null);
+  const [creatingCandidateId, setCreatingCandidateId] = useState<number | null>(
+    null,
+  );
+  const [updatingCandidateId, setUpdatingCandidateId] = useState<number | null>(
+    null,
+  );
+  const [candidateRejectReasons, setCandidateRejectReasons] = useState<
+    Record<number, string>
+  >({});
   const [error, setError] = useState<string | null>(null);
 
-  const workflows = useListAllWorkspaceWorkflows({ workspaceId: parsedWorkspaceId });
+  const workflows = useListAllWorkspaceWorkflows({
+    workspaceId: parsedWorkspaceId,
+  });
   const selectedWorkflow = useMemo(() => {
     const numericId = Number(workflowDefinitionId);
-    return workflows.entries.find((entry) => entry.workflowId === numericId) ?? null;
+    return (
+      workflows.entries.find((entry) => entry.workflowId === numericId) ?? null
+    );
   }, [workflowDefinitionId, workflows.entries]);
   const matched = detail?.matchedWorkflow ?? null;
 
@@ -285,11 +365,14 @@ export function WorkspaceSimulationPage() {
 
   const reloadCandidates = async (status = candidateStatusFilter) => {
     if (parsedWorkspaceId === null) return;
-    const page = await simulationApi.listImprovementCandidates(parsedWorkspaceId, {
-      status,
-      page: 0,
-      size: PAGE_SIZE,
-    });
+    const page = await simulationApi.listImprovementCandidates(
+      parsedWorkspaceId,
+      {
+        status,
+        page: 0,
+        size: PAGE_SIZE,
+      },
+    );
     setCandidateItems(page.content);
   };
 
@@ -310,7 +393,8 @@ export function WorkspaceSimulationPage() {
   useEffect(() => {
     setFeedbackStatusFilter(feedbackStatusFromQuery);
     setCandidateStatusFilter(candidateStatusFromQuery);
-  }, [candidateStatusFromQuery, feedbackStatusFromQuery]);
+    setActiveSideTab(readInitialSideTab(querySearchParams));
+  }, [candidateStatusFromQuery, feedbackStatusFromQuery, querySearchParams]);
 
   useEffect(() => {
     setFeedbackTarget("session");
@@ -378,7 +462,8 @@ export function WorkspaceSimulationPage() {
         if (active) setFeedbackItems(page.content);
       })
       .catch(() => {
-        if (active) toast.error("시뮬레이션 피드백 목록을 불러오지 못했습니다.");
+        if (active)
+          toast.error("시뮬레이션 피드백 목록을 불러오지 못했습니다.");
       })
       .finally(() => {
         if (active) setIsLoadingFeedback(false);
@@ -468,7 +553,10 @@ export function WorkspaceSimulationPage() {
   }
 
   const reloadSessions = async () => {
-    const page = await simulationApi.listSessions(parsedWorkspaceId, { page: 0, size: PAGE_SIZE });
+    const page = await simulationApi.listSessions(parsedWorkspaceId, {
+      page: 0,
+      size: PAGE_SIZE,
+    });
     setSessions(page.content);
   };
 
@@ -478,7 +566,9 @@ export function WorkspaceSimulationPage() {
     try {
       const created = await simulationApi.createSession(parsedWorkspaceId, {
         customerName: customerNameInput,
-        ...(workflowDefinitionId ? { workflowDefinitionId: Number(workflowDefinitionId) } : {}),
+        ...(workflowDefinitionId
+          ? { workflowDefinitionId: Number(workflowDefinitionId) }
+          : {}),
       });
       setDetail(created);
       setSelectedSessionId(created.session.id ?? null);
@@ -496,9 +586,13 @@ export function WorkspaceSimulationPage() {
     setIsSending(true);
     setError(null);
     try {
-      const nextDetail = await simulationApi.sendMessage(parsedWorkspaceId, detail.session.id, {
-        content,
-      });
+      const nextDetail = await simulationApi.sendMessage(
+        parsedWorkspaceId,
+        detail.session.id,
+        {
+          content,
+        },
+      );
       setDetail(nextDetail);
       setMessageInput("");
       await reloadSessions();
@@ -513,16 +607,21 @@ export function WorkspaceSimulationPage() {
     const description = feedbackDescription.trim();
     const expectedBehavior = feedbackExpectedBehavior.trim();
     if (!description || !expectedBehavior || detail?.session.id == null) return;
-    const chatMessageId = feedbackTarget === "session" ? null : Number.parseInt(feedbackTarget, 10);
+    const chatMessageId =
+      feedbackTarget === "session" ? null : Number.parseInt(feedbackTarget, 10);
     setIsSubmittingFeedback(true);
     try {
-      const nextDetail = await simulationApi.createFeedback(parsedWorkspaceId, detail.session.id, {
-        chatMessageId: Number.isNaN(chatMessageId) ? null : chatMessageId,
-        feedbackType,
-        description,
-        expectedBehavior,
-        severity: feedbackSeverity,
-      });
+      const nextDetail = await simulationApi.createFeedback(
+        parsedWorkspaceId,
+        detail.session.id,
+        {
+          chatMessageId: Number.isNaN(chatMessageId) ? null : chatMessageId,
+          feedbackType,
+          description,
+          expectedBehavior,
+          severity: feedbackSeverity,
+        },
+      );
       setDetail(nextDetail);
       setFeedbackDescription("");
       setFeedbackExpectedBehavior("");
@@ -542,8 +641,12 @@ export function WorkspaceSimulationPage() {
   const handleCreateCandidate = async (feedback: SimulationFeedback) => {
     setCreatingCandidateId(feedback.id);
     try {
-      await simulationApi.createImprovementCandidate(parsedWorkspaceId, feedback.id);
+      await simulationApi.createImprovementCandidate(
+        parsedWorkspaceId,
+        feedback.id,
+      );
       toast.success("개선 후보를 생성했습니다.");
+      setActiveSideTab("candidates");
       try {
         await Promise.all([reloadFeedback(), reloadCandidates()]);
       } catch {
@@ -562,9 +665,13 @@ export function WorkspaceSimulationPage() {
   ) => {
     setUpdatingCandidateId(candidate.id);
     try {
-      await simulationApi.updateImprovementCandidateStatus(parsedWorkspaceId, candidate.id, {
-        status,
-      });
+      await simulationApi.updateImprovementCandidateStatus(
+        parsedWorkspaceId,
+        candidate.id,
+        {
+          status,
+        },
+      );
       toast.success("개선 후보 상태를 변경했습니다.");
       try {
         await reloadCandidates();
@@ -578,12 +685,18 @@ export function WorkspaceSimulationPage() {
     }
   };
 
-  const handleApproveCandidate = async (candidate: SimulationImprovementCandidate) => {
+  const handleApproveCandidate = async (
+    candidate: SimulationImprovementCandidate,
+  ) => {
     setUpdatingCandidateId(candidate.id);
     try {
-      await simulationApi.approveImprovementCandidate(parsedWorkspaceId, candidate.id, {
-        reason: "시뮬레이션 리뷰 승인",
-      });
+      await simulationApi.approveImprovementCandidate(
+        parsedWorkspaceId,
+        candidate.id,
+        {
+          reason: "시뮬레이션 리뷰 승인",
+        },
+      );
       toast.success("개선 후보를 초안 버전에 반영했습니다.");
       await Promise.all([reloadCandidates(), reloadFeedback()]);
     } catch {
@@ -593,7 +706,9 @@ export function WorkspaceSimulationPage() {
     }
   };
 
-  const handleRejectCandidate = async (candidate: SimulationImprovementCandidate) => {
+  const handleRejectCandidate = async (
+    candidate: SimulationImprovementCandidate,
+  ) => {
     const reason = (candidateRejectReasons[candidate.id] ?? "").trim();
     if (!reason) {
       toast.error("반려 사유를 입력하세요.");
@@ -601,7 +716,11 @@ export function WorkspaceSimulationPage() {
     }
     setUpdatingCandidateId(candidate.id);
     try {
-      await simulationApi.rejectImprovementCandidate(parsedWorkspaceId, candidate.id, { reason });
+      await simulationApi.rejectImprovementCandidate(
+        parsedWorkspaceId,
+        candidate.id,
+        { reason },
+      );
       toast.success("개선 후보를 반려했습니다.");
       setCandidateRejectReasons((current) => {
         const next = { ...current };
@@ -620,7 +739,8 @@ export function WorkspaceSimulationPage() {
     if (detail?.session.id == null) return;
     if (
       messages.filter(
-        (message) => message.senderRole === "USER" || message.senderRole === "CUSTOMER",
+        (message) =>
+          message.senderRole === "USER" || message.senderRole === "CUSTOMER",
       ).length === 0
     ) {
       toast.error("고객 메시지가 있어야 검증 케이스로 저장할 수 있습니다.");
@@ -628,14 +748,18 @@ export function WorkspaceSimulationPage() {
     }
     setIsCreatingGoldenCase(true);
     try {
-      await simulationApi.createGoldenCase(parsedWorkspaceId, detail.session.id, {
-        name: optionalText(goldenCaseName),
-        expectedIntentCode: optionalText(matched?.intentCode),
-        expectedWorkflowCode: optionalText(matched?.workflowCode),
-        expectedCurrentState: optionalText(matched?.currentState),
-        expectedActionType: optionalText(expectedActionType),
-        expectedSlotValues: detail.slotValues ?? {},
-      });
+      await simulationApi.createGoldenCase(
+        parsedWorkspaceId,
+        detail.session.id,
+        {
+          name: optionalText(goldenCaseName),
+          expectedIntentCode: optionalText(matched?.intentCode),
+          expectedWorkflowCode: optionalText(matched?.workflowCode),
+          expectedCurrentState: optionalText(matched?.currentState),
+          expectedActionType: optionalText(expectedActionType),
+          expectedSlotValues: detail.slotValues ?? {},
+        },
+      );
       toast.success("검증 케이스를 저장했습니다.");
       try {
         await reloadGoldenCases();
@@ -657,9 +781,13 @@ export function WorkspaceSimulationPage() {
     }
     setReplayingGoldenCaseId(goldenCase.id);
     try {
-      const result = await simulationApi.replayGoldenCase(parsedWorkspaceId, goldenCase.id, {
-        domainPackVersionId: versionId,
-      });
+      const result = await simulationApi.replayGoldenCase(
+        parsedWorkspaceId,
+        goldenCase.id,
+        {
+          domainPackVersionId: versionId,
+        },
+      );
       toast.success(
         result.status === "PASS"
           ? "검증 케이스 replay가 통과했습니다."
@@ -680,9 +808,13 @@ export function WorkspaceSimulationPage() {
   const messages = detail?.messages ?? [];
   const slots = slotEntries(detail);
   const feedbackCounts = detail?.feedback?.messageFeedbackCounts ?? {};
-  const selectedFeedbackTarget = messages.find((message) => String(message.id) === feedbackTarget);
+  const selectedFeedbackTarget = messages.find(
+    (message) => String(message.id) === feedbackTarget,
+  );
   const selectedTargetLabel =
-    feedbackTarget === "session" ? "세션 전체" : `Turn ${selectedFeedbackTarget?.seqNo ?? ""}`;
+    feedbackTarget === "session"
+      ? "세션 전체"
+      : `Turn ${selectedFeedbackTarget?.seqNo ?? ""}`;
 
   return (
     <div className={styles.pageWrapper}>
@@ -691,7 +823,8 @@ export function WorkspaceSimulationPage() {
           <p className={styles.eyebrow}>Simulation Lab</p>
           <h1 className={styles.pageTitle}>상담 시뮬레이션</h1>
           <p className={styles.pageSubtitle}>
-            운영 중인 Domain Pack 기준으로 고객 문의를 시험하고 매칭된 workflow 상태를 확인합니다.
+            운영 중인 Domain Pack 기준으로 고객 문의를 시험하고 매칭된 workflow
+            상태를 확인합니다.
           </p>
         </div>
         <Button
@@ -712,7 +845,10 @@ export function WorkspaceSimulationPage() {
 
       {error ? <ErrorState message={error} /> : null}
 
-      <section className={styles.createPanel} aria-labelledby="simulation-create-title">
+      <section
+        className={styles.createPanel}
+        aria-labelledby="simulation-create-title"
+      >
         <div>
           <h2 id="simulation-create-title" className={styles.sectionTitle}>
             새 시뮬레이션
@@ -738,13 +874,20 @@ export function WorkspaceSimulationPage() {
           >
             <NativeSelectOption value="">자동 매칭</NativeSelectOption>
             {workflows.entries.map((workflow) => (
-              <NativeSelectOption key={workflow.workflowId} value={String(workflow.workflowId)}>
+              <NativeSelectOption
+                key={workflow.workflowId}
+                value={String(workflow.workflowId)}
+              >
                 {workflow.packName} · {workflow.name}
               </NativeSelectOption>
             ))}
           </NativeSelect>
         </label>
-        <Button type="button" onClick={handleCreateSession} disabled={isCreating}>
+        <Button
+          type="button"
+          onClick={handleCreateSession}
+          disabled={isCreating}
+        >
           <PlusIcon className={styles.buttonIcon} />
           <span>{isCreating ? "생성 중" : "세션 생성"}</span>
         </Button>
@@ -790,9 +933,12 @@ export function WorkspaceSimulationPage() {
         <section className={styles.chatPane} aria-label="시뮬레이션 대화">
           <div className={styles.paneHeader}>
             <div>
-              <h2 className={styles.sectionTitle}>{customerName(detail?.session ?? null)}</h2>
+              <h2 className={styles.sectionTitle}>
+                {customerName(detail?.session ?? null)}
+              </h2>
               <p className={styles.sectionDescription}>
-                {selectedWorkflow ? selectedWorkflow.name : "자동 매칭"} 기준으로 응답합니다.
+                {selectedWorkflow ? selectedWorkflow.name : "자동 매칭"}{" "}
+                기준으로 응답합니다.
               </p>
             </div>
             <span className={styles.channelBadge}>SIMULATION</span>
@@ -811,15 +957,29 @@ export function WorkspaceSimulationPage() {
             <>
               <div className={styles.messageList}>
                 {messages.length === 0 ? (
-                  <p className={styles.emptyMessage}>고객 메시지를 입력하면 응답이 생성됩니다.</p>
+                  <p className={styles.emptyMessage}>
+                    고객 메시지를 입력하면 응답이 생성됩니다.
+                  </p>
                 ) : (
                   messages.map((message, index) => (
                     <MessageBubble
-                      key={message.id ?? `${message.seqNo ?? index}-${message.createdAt ?? ""}`}
+                      key={
+                        message.id ??
+                        `${message.seqNo ?? index}-${message.createdAt ?? ""}`
+                      }
                       message={message}
-                      feedbackCount={message.id ? (feedbackCounts[String(message.id)] ?? 0) : 0}
+                      feedbackCount={
+                        message.id
+                          ? (feedbackCounts[String(message.id)] ?? 0)
+                          : 0
+                      }
                       onFeedbackClick={
-                        message.id ? () => setFeedbackTarget(String(message.id)) : undefined
+                        message.id
+                          ? () => {
+                              setFeedbackTarget(String(message.id));
+                              setActiveSideTab("feedback");
+                            }
+                          : undefined
                       }
                     />
                   ))
@@ -852,414 +1012,552 @@ export function WorkspaceSimulationPage() {
           )}
         </section>
 
-        <aside className={styles.statePane} aria-label="매칭 상태">
-          <h2 className={styles.sectionTitle}>Runtime State</h2>
-          <dl className={styles.stateList}>
-            <div>
-              <dt>Intent</dt>
-              <dd>{matched?.intentName ?? matched?.intentCode ?? "미매칭"}</dd>
-            </div>
-            <div>
-              <dt>Workflow</dt>
-              <dd>{matched?.workflowName ?? matched?.workflowCode ?? "미매칭"}</dd>
-            </div>
-            <div>
-              <dt>Current State</dt>
-              <dd>{matched?.currentState ?? "대기"}</dd>
-            </div>
-            <div>
-              <dt>Status</dt>
-              <dd>{matched?.executionStatus ?? detail?.session.status ?? "대기"}</dd>
-            </div>
-          </dl>
-
-          <div className={styles.slotPanel}>
-            <h3>수집된 Slot</h3>
-            {slots.length === 0 ? (
-              <p>아직 수집된 slot 값이 없습니다.</p>
-            ) : (
-              <ul>
-                {slots.map(([key, value]) => (
-                  <li key={key}>
-                    <span>{key}</span>
-                    <strong>{String(value)}</strong>
-                  </li>
-                ))}
-              </ul>
-            )}
+        <aside
+          className={styles.statePane}
+          aria-label="시뮬레이션 상태와 개선 작업"
+        >
+          <div
+            className={styles.sideTabList}
+            role="tablist"
+            aria-label="시뮬레이션 우측 패널"
+          >
+            {SIDE_TABS.map((tab) => (
+              <button
+                key={tab.value}
+                id={`simulation-side-tab-${tab.value}`}
+                type="button"
+                role="tab"
+                aria-selected={activeSideTab === tab.value}
+                aria-controls={`simulation-side-panel-${tab.value}`}
+                className={`${styles.sideTab} ${activeSideTab === tab.value ? styles.sideTabActive : ""}`}
+                onClick={() => setActiveSideTab(tab.value)}
+              >
+                {tab.label}
+              </button>
+            ))}
           </div>
 
-          <div className={styles.goldenCasePanel}>
-            <div className={styles.feedbackPanelHeader}>
-              <h3>검증 케이스</h3>
-              <span>{goldenCases.length}</span>
-            </div>
-            <label className={styles.feedbackField}>
-              <span>이름</span>
-              <input
-                value={goldenCaseName}
-                onChange={(event) => setGoldenCaseName(event.target.value)}
-                maxLength={255}
-                aria-label="검증 케이스 이름"
-              />
-            </label>
-            <label className={styles.feedbackField}>
-              <span>기대 action</span>
-              <NativeSelect
-                value={expectedActionType}
-                onChange={(event) => setExpectedActionType(event.target.value)}
-                aria-label="기대 action"
-              >
-                <NativeSelectOption value="">현재 replay에서 비교 안 함</NativeSelectOption>
-                {ACTION_TYPES.map((type) => (
-                  <NativeSelectOption key={type} value={type}>
-                    {type}
-                  </NativeSelectOption>
-                ))}
-              </NativeSelect>
-            </label>
-            <label className={styles.feedbackField}>
-              <span>Replay version</span>
-              <input
-                value={replayVersionId}
-                onChange={(event) => setReplayVersionId(event.target.value)}
-                inputMode="numeric"
-                aria-label="Replay version"
-              />
-            </label>
-            <Button
-              type="button"
-              onClick={handleCreateGoldenCase}
-              disabled={isCreatingGoldenCase || detail === null}
+          {activeSideTab === "state" ? (
+            <div
+              id="simulation-side-panel-state"
+              className={styles.sideTabPanel}
+              role="tabpanel"
+              aria-labelledby="simulation-side-tab-state"
             >
-              <CheckCircleIcon className={styles.buttonIcon} />
-              <span>{isCreatingGoldenCase ? "저장 중" : "등록"}</span>
-            </Button>
-            {isLoadingGoldenCases ? (
-              <p className={styles.feedbackMuted}>검증 케이스를 불러오는 중입니다.</p>
-            ) : goldenCases.length === 0 ? (
-              <p className={styles.feedbackMuted}>저장된 검증 케이스가 없습니다.</p>
-            ) : (
-              <ul className={styles.goldenCaseList}>
-                {goldenCases.map((goldenCase) => {
-                  const replayStatus = goldenCase.latestReplayResult?.status;
-                  const state = readExpectedField(goldenCase, "currentState");
-                  const action = readExpectedField(goldenCase, "actionType");
-                  return (
-                    <li key={goldenCase.id}>
-                      <div className={styles.feedbackRowHeader}>
-                        <div>
-                          <strong>{goldenCase.name}</strong>
-                          <span>
-                            version #{goldenCase.sourceDomainPackVersionId}
-                            {state ? ` · ${state}` : ""}
-                            {action ? ` · ${action}` : ""}
-                          </span>
-                        </div>
-                        <span
-                          className={`${styles.replayStatus} ${
-                            replayStatus === "PASS"
-                              ? styles.replayStatusPass
-                              : replayStatus === "FAIL"
-                                ? styles.replayStatusFail
-                                : ""
-                          }`}
-                        >
-                          {replayStatus === "FAIL" ? (
-                            <XCircleIcon className={styles.buttonIcon} />
-                          ) : replayStatus === "PASS" ? (
-                            <CheckCircleIcon className={styles.buttonIcon} />
-                          ) : (
-                            <PlayIcon className={styles.buttonIcon} />
-                          )}
-                          {replayStatusLabel(replayStatus)}
-                        </span>
-                      </div>
-                      {goldenCase.latestReplayResult?.failureSummary ? (
-                        <p className={styles.failureSummary}>
-                          {goldenCase.latestReplayResult.failureSummary}
-                        </p>
-                      ) : null}
-                      <div className={styles.candidateActions}>
-                        <Button
-                          type="button"
-                          variant="outline"
-                          size="sm"
-                          onClick={() => void handleReplayGoldenCase(goldenCase)}
-                          disabled={replayingGoldenCaseId === goldenCase.id}
-                          aria-label={`${goldenCase.name} replay`}
-                        >
-                          <PlayIcon className={styles.buttonIcon} />
-                          <span>
-                            {replayingGoldenCaseId === goldenCase.id ? "Replay 중" : "Replay"}
-                          </span>
-                        </Button>
-                      </div>
-                    </li>
-                  );
-                })}
-              </ul>
-            )}
-          </div>
+              <h2 className={styles.sectionTitle}>Runtime State</h2>
+              <dl className={styles.stateList}>
+                <div>
+                  <dt>Intent</dt>
+                  <dd>
+                    {matched?.intentName ?? matched?.intentCode ?? "미매칭"}
+                  </dd>
+                </div>
+                <div>
+                  <dt>Workflow</dt>
+                  <dd>
+                    {matched?.workflowName ?? matched?.workflowCode ?? "미매칭"}
+                  </dd>
+                </div>
+                <div>
+                  <dt>Current State</dt>
+                  <dd>{matched?.currentState ?? "대기"}</dd>
+                </div>
+                <div>
+                  <dt>Status</dt>
+                  <dd>
+                    {matched?.executionStatus ??
+                      detail?.session.status ??
+                      "대기"}
+                  </dd>
+                </div>
+              </dl>
 
-          <div className={styles.feedbackPanel}>
-            <div className={styles.feedbackPanelHeader}>
-              <h3>Feedback</h3>
-              <span>{selectedTargetLabel}</span>
-            </div>
-            <label className={styles.feedbackField}>
-              <span>대상</span>
-              <NativeSelect
-                value={feedbackTarget}
-                onChange={(event) => setFeedbackTarget(event.target.value)}
-                aria-label="피드백 대상 선택"
-              >
-                <NativeSelectOption value="session">세션 전체</NativeSelectOption>
-                {messages.map((message) => (
-                  <NativeSelectOption
-                    key={message.id ?? message.seqNo}
-                    value={String(message.id ?? "")}
-                    disabled={message.id == null}
+              <div className={styles.slotPanel}>
+                <h3>수집된 Slot</h3>
+                {slots.length === 0 ? (
+                  <p>아직 수집된 slot 값이 없습니다.</p>
+                ) : (
+                  <ul>
+                    {slots.map(([key, value]) => (
+                      <li key={key}>
+                        <span>{key}</span>
+                        <strong>{String(value)}</strong>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+
+              <div className={styles.goldenCasePanel}>
+                <div className={styles.feedbackPanelHeader}>
+                  <h3>검증 케이스</h3>
+                  <span>{goldenCases.length}</span>
+                </div>
+                <label className={styles.feedbackField}>
+                  <span>이름</span>
+                  <input
+                    value={goldenCaseName}
+                    onChange={(event) => setGoldenCaseName(event.target.value)}
+                    maxLength={255}
+                    aria-label="검증 케이스 이름"
+                  />
+                </label>
+                <label className={styles.feedbackField}>
+                  <span>기대 action</span>
+                  <NativeSelect
+                    value={expectedActionType}
+                    onChange={(event) =>
+                      setExpectedActionType(event.target.value)
+                    }
+                    aria-label="기대 action"
                   >
-                    Turn {message.seqNo} · {roleLabel(message.senderRole)}
-                  </NativeSelectOption>
-                ))}
-              </NativeSelect>
-            </label>
-            <label className={styles.feedbackField}>
-              <span>유형</span>
-              <NativeSelect
-                value={feedbackType}
-                onChange={(event) => setFeedbackType(event.target.value as SimulationFeedbackType)}
-                aria-label="피드백 유형 선택"
-              >
-                {FEEDBACK_TYPES.map((item) => (
-                  <NativeSelectOption key={item.value} value={item.value}>
-                    {item.label}
-                  </NativeSelectOption>
-                ))}
-              </NativeSelect>
-            </label>
-            <label className={styles.feedbackField}>
-              <span>심각도</span>
-              <NativeSelect
-                value={feedbackSeverity}
-                onChange={(event) =>
-                  setFeedbackSeverity(event.target.value as SimulationFeedbackSeverity)
-                }
-                aria-label="피드백 심각도 선택"
-              >
-                {FEEDBACK_SEVERITIES.map((item) => (
-                  <NativeSelectOption key={item.value} value={item.value}>
-                    {item.label}
-                  </NativeSelectOption>
-                ))}
-              </NativeSelect>
-            </label>
-            <label className={styles.feedbackField}>
-              <span>설명</span>
-              <textarea
-                value={feedbackDescription}
-                onChange={(event) => setFeedbackDescription(event.target.value)}
-                maxLength={2000}
-                rows={3}
-              />
-            </label>
-            <label className={styles.feedbackField}>
-              <span>기대 응답/행동</span>
-              <textarea
-                value={feedbackExpectedBehavior}
-                onChange={(event) => setFeedbackExpectedBehavior(event.target.value)}
-                maxLength={2000}
-                rows={3}
-              />
-            </label>
-            <Button
-              type="button"
-              onClick={handleSubmitFeedback}
-              disabled={
-                isSubmittingFeedback ||
-                detail === null ||
-                !feedbackDescription.trim() ||
-                !feedbackExpectedBehavior.trim()
-              }
+                    <NativeSelectOption value="">
+                      현재 replay에서 비교 안 함
+                    </NativeSelectOption>
+                    {ACTION_TYPES.map((type) => (
+                      <NativeSelectOption key={type} value={type}>
+                        {type}
+                      </NativeSelectOption>
+                    ))}
+                  </NativeSelect>
+                </label>
+                <label className={styles.feedbackField}>
+                  <span>Replay version</span>
+                  <input
+                    value={replayVersionId}
+                    onChange={(event) => setReplayVersionId(event.target.value)}
+                    inputMode="numeric"
+                    aria-label="Replay version"
+                  />
+                </label>
+                <Button
+                  type="button"
+                  onClick={handleCreateGoldenCase}
+                  disabled={isCreatingGoldenCase || detail === null}
+                >
+                  <CheckCircleIcon className={styles.buttonIcon} />
+                  <span>{isCreatingGoldenCase ? "저장 중" : "등록"}</span>
+                </Button>
+                {isLoadingGoldenCases ? (
+                  <p className={styles.feedbackMuted}>
+                    검증 케이스를 불러오는 중입니다.
+                  </p>
+                ) : goldenCases.length === 0 ? (
+                  <p className={styles.feedbackMuted}>
+                    저장된 검증 케이스가 없습니다.
+                  </p>
+                ) : (
+                  <ul className={styles.goldenCaseList}>
+                    {goldenCases.map((goldenCase) => {
+                      const replayStatus =
+                        goldenCase.latestReplayResult?.status;
+                      const state = readExpectedField(
+                        goldenCase,
+                        "currentState",
+                      );
+                      const action = readExpectedField(
+                        goldenCase,
+                        "actionType",
+                      );
+                      return (
+                        <li key={goldenCase.id}>
+                          <div className={styles.feedbackRowHeader}>
+                            <div>
+                              <strong>{goldenCase.name}</strong>
+                              <span>
+                                version #{goldenCase.sourceDomainPackVersionId}
+                                {state ? ` · ${state}` : ""}
+                                {action ? ` · ${action}` : ""}
+                              </span>
+                            </div>
+                            <span
+                              className={`${styles.replayStatus} ${
+                                replayStatus === "PASS"
+                                  ? styles.replayStatusPass
+                                  : replayStatus === "FAIL"
+                                    ? styles.replayStatusFail
+                                    : ""
+                              }`}
+                            >
+                              {replayStatus === "FAIL" ? (
+                                <XCircleIcon className={styles.buttonIcon} />
+                              ) : replayStatus === "PASS" ? (
+                                <CheckCircleIcon
+                                  className={styles.buttonIcon}
+                                />
+                              ) : (
+                                <PlayIcon className={styles.buttonIcon} />
+                              )}
+                              {replayStatusLabel(replayStatus)}
+                            </span>
+                          </div>
+                          {goldenCase.latestReplayResult?.failureSummary ? (
+                            <p className={styles.failureSummary}>
+                              {goldenCase.latestReplayResult.failureSummary}
+                            </p>
+                          ) : null}
+                          <div className={styles.candidateActions}>
+                            <Button
+                              type="button"
+                              variant="outline"
+                              size="sm"
+                              onClick={() =>
+                                void handleReplayGoldenCase(goldenCase)
+                              }
+                              disabled={replayingGoldenCaseId === goldenCase.id}
+                              aria-label={`${goldenCase.name} replay`}
+                            >
+                              <PlayIcon className={styles.buttonIcon} />
+                              <span>
+                                {replayingGoldenCaseId === goldenCase.id
+                                  ? "Replay 중"
+                                  : "Replay"}
+                              </span>
+                            </Button>
+                          </div>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                )}
+              </div>
+            </div>
+          ) : null}
+
+          {activeSideTab === "feedback" ? (
+            <div
+              id="simulation-side-panel-feedback"
+              className={styles.sideTabPanel}
+              role="tabpanel"
+              aria-labelledby="simulation-side-tab-feedback"
             >
-              <FlagIcon className={styles.buttonIcon} />
-              <span>{isSubmittingFeedback ? "저장 중" : "피드백 저장"}</span>
-            </Button>
-          </div>
-
-          <div className={styles.feedbackListPanel}>
-            <div className={styles.feedbackPanelHeader}>
-              <h3>워크스페이스 피드백</h3>
-              <NativeSelect
-                value={feedbackStatusFilter}
-                onChange={(event) =>
-                  setFeedbackStatusFilter(event.target.value as SimulationFeedbackStatus | "")
-                }
-                aria-label="피드백 상태 필터"
-              >
-                {FEEDBACK_STATUSES.map((item) => (
-                  <NativeSelectOption key={item.value || "ALL"} value={item.value}>
-                    {item.label}
-                  </NativeSelectOption>
-                ))}
-              </NativeSelect>
-            </div>
-            {isLoadingFeedback ? (
-              <p className={styles.feedbackMuted}>피드백을 불러오는 중입니다.</p>
-            ) : feedbackItems.length === 0 ? (
-              <p className={styles.feedbackMuted}>조건에 맞는 피드백이 없습니다.</p>
-            ) : (
-              <ul className={styles.feedbackList}>
-                {feedbackItems.map((feedback) => (
-                  <li key={feedback.id}>
-                    <div className={styles.feedbackRowHeader}>
-                      <div>
-                        <strong>{feedbackTypeLabel(feedback.feedbackType)}</strong>
-                        <span>
-                          {feedbackSeverityLabel(feedback.severity)} ·{" "}
-                          {feedbackStatusLabel(feedback.status)}
-                        </span>
-                      </div>
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        onClick={() => void handleCreateCandidate(feedback)}
-                        disabled={feedback.status !== "OPEN" || creatingCandidateId === feedback.id}
+              <div className={styles.feedbackPanel}>
+                <div className={styles.feedbackPanelHeader}>
+                  <h3>Feedback</h3>
+                  <span>{selectedTargetLabel}</span>
+                </div>
+                <label className={styles.feedbackField}>
+                  <span>대상</span>
+                  <NativeSelect
+                    value={feedbackTarget}
+                    onChange={(event) => setFeedbackTarget(event.target.value)}
+                    aria-label="피드백 대상 선택"
+                  >
+                    <NativeSelectOption value="session">
+                      세션 전체
+                    </NativeSelectOption>
+                    {messages.map((message) => (
+                      <NativeSelectOption
+                        key={message.id ?? message.seqNo}
+                        value={String(message.id ?? "")}
+                        disabled={message.id == null}
                       >
-                        <LightbulbIcon className={styles.buttonIcon} />
-                        <span>{creatingCandidateId === feedback.id ? "생성 중" : "후보"}</span>
-                      </Button>
-                    </div>
-                    <p>{feedback.description}</p>
-                  </li>
-                ))}
-              </ul>
-            )}
-          </div>
+                        Turn {message.seqNo} · {roleLabel(message.senderRole)}
+                      </NativeSelectOption>
+                    ))}
+                  </NativeSelect>
+                </label>
+                <label className={styles.feedbackField}>
+                  <span>유형</span>
+                  <NativeSelect
+                    value={feedbackType}
+                    onChange={(event) =>
+                      setFeedbackType(
+                        event.target.value as SimulationFeedbackType,
+                      )
+                    }
+                    aria-label="피드백 유형 선택"
+                  >
+                    {FEEDBACK_TYPES.map((item) => (
+                      <NativeSelectOption key={item.value} value={item.value}>
+                        {item.label}
+                      </NativeSelectOption>
+                    ))}
+                  </NativeSelect>
+                </label>
+                <label className={styles.feedbackField}>
+                  <span>심각도</span>
+                  <NativeSelect
+                    value={feedbackSeverity}
+                    onChange={(event) =>
+                      setFeedbackSeverity(
+                        event.target.value as SimulationFeedbackSeverity,
+                      )
+                    }
+                    aria-label="피드백 심각도 선택"
+                  >
+                    {FEEDBACK_SEVERITIES.map((item) => (
+                      <NativeSelectOption key={item.value} value={item.value}>
+                        {item.label}
+                      </NativeSelectOption>
+                    ))}
+                  </NativeSelect>
+                </label>
+                <label className={styles.feedbackField}>
+                  <span>설명</span>
+                  <textarea
+                    value={feedbackDescription}
+                    onChange={(event) =>
+                      setFeedbackDescription(event.target.value)
+                    }
+                    maxLength={2000}
+                    rows={3}
+                  />
+                </label>
+                <label className={styles.feedbackField}>
+                  <span>기대 응답/행동</span>
+                  <textarea
+                    value={feedbackExpectedBehavior}
+                    onChange={(event) =>
+                      setFeedbackExpectedBehavior(event.target.value)
+                    }
+                    maxLength={2000}
+                    rows={3}
+                  />
+                </label>
+                <Button
+                  type="button"
+                  onClick={handleSubmitFeedback}
+                  disabled={
+                    isSubmittingFeedback ||
+                    detail === null ||
+                    !feedbackDescription.trim() ||
+                    !feedbackExpectedBehavior.trim()
+                  }
+                >
+                  <FlagIcon className={styles.buttonIcon} />
+                  <span>
+                    {isSubmittingFeedback ? "저장 중" : "피드백 저장"}
+                  </span>
+                </Button>
+              </div>
 
-          <div className={styles.feedbackListPanel}>
-            <div className={styles.feedbackPanelHeader}>
-              <h3>개선 후보</h3>
-              <NativeSelect
-                value={candidateStatusFilter}
-                onChange={(event) =>
-                  setCandidateStatusFilter(
-                    event.target.value as SimulationImprovementCandidateStatus | "",
-                  )
-                }
-                aria-label="개선 후보 상태 필터"
-              >
-                {CANDIDATE_STATUSES.map((item) => (
-                  <NativeSelectOption key={item.value || "ALL"} value={item.value}>
-                    {item.label}
-                  </NativeSelectOption>
-                ))}
-              </NativeSelect>
-            </div>
-            {isLoadingCandidates ? (
-              <p className={styles.feedbackMuted}>개선 후보를 불러오는 중입니다.</p>
-            ) : candidateItems.length === 0 ? (
-              <p className={styles.feedbackMuted}>조건에 맞는 개선 후보가 없습니다.</p>
-            ) : (
-              <ul className={styles.candidateList}>
-                {candidateItems.map((candidate) => (
-                  <li key={candidate.id}>
-                    <div className={styles.feedbackRowHeader}>
-                      <div>
-                        <strong>{candidateTypeLabel(candidate.candidateType)}</strong>
-                        <span>
-                          버전 #{candidate.domainPackVersionId} · 대상:{" "}
-                          {candidate.targetElementType}
-                        </span>
-                      </div>
-                      <span className={styles.statusPill}>
-                        {candidateStatusLabel(candidate.status)}
-                      </span>
-                    </div>
-                    <dl className={styles.candidateSummary}>
-                      <div>
-                        <dt>변경 전</dt>
-                        <dd>{candidate.beforeSummary}</dd>
-                      </div>
-                      <div>
-                        <dt>변경 후</dt>
-                        <dd>{candidate.afterSummary}</dd>
-                      </div>
-                      <div>
-                        <dt>근거</dt>
-                        <dd>
-                          {candidate.evidenceSummary}
-                          <span className={styles.evidenceMeta}>
-                            세션 #{candidate.sessionId}
-                            {candidate.chatMessageId ? ` · 메시지 #${candidate.chatMessageId}` : ""}
-                            {candidate.feedbackId ? ` · 피드백 #${candidate.feedbackId}` : ""}
-                          </span>
-                        </dd>
-                      </div>
-                    </dl>
-                    {candidate.status === "DRAFT" ? (
-                      <div className={styles.candidateActions}>
-                        <Button
-                          type="button"
-                          variant="outline"
-                          size="sm"
-                          disabled={updatingCandidateId === candidate.id}
-                          onClick={() =>
-                            void handleCandidateStatusChange(candidate, "READY_FOR_REVIEW")
-                          }
-                        >
-                          <span>
-                            {updatingCandidateId === candidate.id ? "요청 중" : "리뷰 요청"}
-                          </span>
-                        </Button>
-                      </div>
-                    ) : null}
-                    {candidate.status === "READY_FOR_REVIEW" ? (
-                      <div className={styles.candidateReviewForm}>
-                        <input
-                          value={candidateRejectReasons[candidate.id] ?? ""}
-                          onChange={(event) =>
-                            setCandidateRejectReasons((current) => ({
-                              ...current,
-                              [candidate.id]: event.target.value,
-                            }))
-                          }
-                          maxLength={500}
-                          placeholder="반려 사유"
-                          aria-label="개선 후보 반려 사유"
-                        />
-                        <div className={styles.candidateActions}>
+              <div className={styles.feedbackListPanel}>
+                <div className={styles.feedbackPanelHeader}>
+                  <h3>워크스페이스 피드백</h3>
+                  <NativeSelect
+                    value={feedbackStatusFilter}
+                    onChange={(event) =>
+                      setFeedbackStatusFilter(
+                        event.target.value as SimulationFeedbackStatus | "",
+                      )
+                    }
+                    aria-label="피드백 상태 필터"
+                  >
+                    {FEEDBACK_STATUSES.map((item) => (
+                      <NativeSelectOption
+                        key={item.value || "ALL"}
+                        value={item.value}
+                      >
+                        {item.label}
+                      </NativeSelectOption>
+                    ))}
+                  </NativeSelect>
+                </div>
+                {isLoadingFeedback ? (
+                  <p className={styles.feedbackMuted}>
+                    피드백을 불러오는 중입니다.
+                  </p>
+                ) : feedbackItems.length === 0 ? (
+                  <p className={styles.feedbackMuted}>
+                    조건에 맞는 피드백이 없습니다.
+                  </p>
+                ) : (
+                  <ul className={styles.feedbackList}>
+                    {feedbackItems.map((feedback) => (
+                      <li key={feedback.id}>
+                        <div className={styles.feedbackRowHeader}>
+                          <div>
+                            <strong>
+                              {feedbackTypeLabel(feedback.feedbackType)}
+                            </strong>
+                            <span>
+                              {feedbackSeverityLabel(feedback.severity)} ·{" "}
+                              {feedbackStatusLabel(feedback.status)}
+                            </span>
+                          </div>
                           <Button
                             type="button"
                             variant="outline"
                             size="sm"
-                            disabled={updatingCandidateId === candidate.id}
-                            onClick={() => void handleRejectCandidate(candidate)}
+                            onClick={() => void handleCreateCandidate(feedback)}
+                            disabled={
+                              feedback.status !== "OPEN" ||
+                              creatingCandidateId === feedback.id
+                            }
                           >
-                            <span>반려</span>
-                          </Button>
-                          <Button
-                            type="button"
-                            size="sm"
-                            disabled={updatingCandidateId === candidate.id}
-                            onClick={() => void handleApproveCandidate(candidate)}
-                          >
-                            <span>승인</span>
+                            <LightbulbIcon className={styles.buttonIcon} />
+                            <span>
+                              {creatingCandidateId === feedback.id
+                                ? "생성 중"
+                                : "후보"}
+                            </span>
                           </Button>
                         </div>
-                      </div>
-                    ) : null}
-                    {candidate.decisionReason ? (
-                      <p className={styles.decisionReason}>결정 사유: {candidate.decisionReason}</p>
-                    ) : null}
-                  </li>
-                ))}
-              </ul>
-            )}
-          </div>
+                        <p>{feedback.description}</p>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            </div>
+          ) : null}
+
+          {activeSideTab === "candidates" ? (
+            <div
+              id="simulation-side-panel-candidates"
+              className={styles.sideTabPanel}
+              role="tabpanel"
+              aria-labelledby="simulation-side-tab-candidates"
+            >
+              <div className={styles.feedbackListPanel}>
+                <div className={styles.feedbackPanelHeader}>
+                  <h3>개선 후보</h3>
+                  <NativeSelect
+                    value={candidateStatusFilter}
+                    onChange={(event) =>
+                      setCandidateStatusFilter(
+                        event.target.value as
+                          | SimulationImprovementCandidateStatus
+                          | "",
+                      )
+                    }
+                    aria-label="개선 후보 상태 필터"
+                  >
+                    {CANDIDATE_STATUSES.map((item) => (
+                      <NativeSelectOption
+                        key={item.value || "ALL"}
+                        value={item.value}
+                      >
+                        {item.label}
+                      </NativeSelectOption>
+                    ))}
+                  </NativeSelect>
+                </div>
+                {isLoadingCandidates ? (
+                  <p className={styles.feedbackMuted}>
+                    개선 후보를 불러오는 중입니다.
+                  </p>
+                ) : candidateItems.length === 0 ? (
+                  <p className={styles.feedbackMuted}>
+                    조건에 맞는 개선 후보가 없습니다.
+                  </p>
+                ) : (
+                  <ul className={styles.candidateList}>
+                    {candidateItems.map((candidate) => (
+                      <li key={candidate.id}>
+                        <div className={styles.feedbackRowHeader}>
+                          <div>
+                            <strong>
+                              {candidateTypeLabel(candidate.candidateType)}
+                            </strong>
+                            <span>
+                              버전 #{candidate.domainPackVersionId} · 대상:{" "}
+                              {candidate.targetElementType}
+                            </span>
+                          </div>
+                          <span className={styles.statusPill}>
+                            {candidateStatusLabel(candidate.status)}
+                          </span>
+                        </div>
+                        <dl className={styles.candidateSummary}>
+                          <div>
+                            <dt>변경 전</dt>
+                            <dd>{candidate.beforeSummary}</dd>
+                          </div>
+                          <div>
+                            <dt>변경 후</dt>
+                            <dd>{candidate.afterSummary}</dd>
+                          </div>
+                          <div>
+                            <dt>근거</dt>
+                            <dd>
+                              {candidate.evidenceSummary}
+                              <span className={styles.evidenceMeta}>
+                                세션 #{candidate.sessionId}
+                                {candidate.chatMessageId
+                                  ? ` · 메시지 #${candidate.chatMessageId}`
+                                  : ""}
+                                {candidate.feedbackId
+                                  ? ` · 피드백 #${candidate.feedbackId}`
+                                  : ""}
+                              </span>
+                            </dd>
+                          </div>
+                        </dl>
+                        {candidate.status === "DRAFT" ? (
+                          <div className={styles.candidateActions}>
+                            <Button
+                              type="button"
+                              variant="outline"
+                              size="sm"
+                              disabled={updatingCandidateId === candidate.id}
+                              onClick={() =>
+                                void handleCandidateStatusChange(
+                                  candidate,
+                                  "READY_FOR_REVIEW",
+                                )
+                              }
+                            >
+                              <span>
+                                {updatingCandidateId === candidate.id
+                                  ? "요청 중"
+                                  : "리뷰 요청"}
+                              </span>
+                            </Button>
+                          </div>
+                        ) : null}
+                        {candidate.status === "READY_FOR_REVIEW" ? (
+                          <div className={styles.candidateReviewForm}>
+                            <input
+                              value={candidateRejectReasons[candidate.id] ?? ""}
+                              onChange={(event) =>
+                                setCandidateRejectReasons((current) => ({
+                                  ...current,
+                                  [candidate.id]: event.target.value,
+                                }))
+                              }
+                              maxLength={500}
+                              placeholder="반려 사유"
+                              aria-label="개선 후보 반려 사유"
+                            />
+                            <div className={styles.candidateActions}>
+                              <Button
+                                type="button"
+                                variant="outline"
+                                size="sm"
+                                disabled={updatingCandidateId === candidate.id}
+                                onClick={() =>
+                                  void handleRejectCandidate(candidate)
+                                }
+                              >
+                                <span>반려</span>
+                              </Button>
+                              <Button
+                                type="button"
+                                size="sm"
+                                disabled={updatingCandidateId === candidate.id}
+                                onClick={() =>
+                                  void handleApproveCandidate(candidate)
+                                }
+                              >
+                                <span>승인</span>
+                              </Button>
+                            </div>
+                          </div>
+                        ) : null}
+                        {candidate.decisionReason ? (
+                          <p className={styles.decisionReason}>
+                            결정 사유: {candidate.decisionReason}
+                          </p>
+                        ) : null}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            </div>
+          ) : null}
         </aside>
       </div>
     </div>
@@ -1272,14 +1570,23 @@ type MessageBubbleProps = Readonly<{
   onFeedbackClick?: () => void;
 }>;
 
-function MessageBubble({ message, feedbackCount, onFeedbackClick }: MessageBubbleProps) {
-  const isCustomer = message.senderRole === "USER" || message.senderRole === "CUSTOMER";
+function MessageBubble({
+  message,
+  feedbackCount,
+  onFeedbackClick,
+}: MessageBubbleProps) {
+  const isCustomer =
+    message.senderRole === "USER" || message.senderRole === "CUSTOMER";
   return (
-    <article className={`${styles.message} ${isCustomer ? styles.messageCustomer : ""}`}>
+    <article
+      className={`${styles.message} ${isCustomer ? styles.messageCustomer : ""}`}
+    >
       <div className={styles.messageMeta}>
         <span>{roleLabel(message.senderRole)}</span>
         <div className={styles.messageActions}>
-          {feedbackCount > 0 ? <span className={styles.feedbackBadge}>{feedbackCount}</span> : null}
+          {feedbackCount > 0 ? (
+            <span className={styles.feedbackBadge}>{feedbackCount}</span>
+          ) : null}
           {onFeedbackClick ? (
             <button
               type="button"

--- a/frontend/src/pages/workspace/ui/simulation/workspace-simulation-page.module.css
+++ b/frontend/src/pages/workspace/ui/simulation/workspace-simulation-page.module.css
@@ -115,7 +115,10 @@
   display: grid;
   height: clamp(420px, calc(100dvh - 300px), 780px);
   min-height: 0;
-  grid-template-columns: minmax(220px, 280px) minmax(360px, 1fr) minmax(260px, 340px);
+  grid-template-columns: minmax(220px, 280px) minmax(360px, 1fr) minmax(
+      260px,
+      340px
+    );
   gap: var(--s-4);
   align-items: stretch;
   overflow: hidden;
@@ -433,6 +436,60 @@
   overflow-y: auto;
   overscroll-behavior: contain;
   scrollbar-gutter: stable;
+}
+
+.sideTabList {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  flex-shrink: 0;
+  gap: var(--s-1);
+  margin-bottom: var(--s-4);
+  border: 1px solid var(--line);
+  border-radius: var(--r-pill);
+  background: var(--paper-2);
+  padding: 3px;
+}
+
+.sideTab {
+  min-width: 0;
+  min-height: 34px;
+  border: 1px solid transparent;
+  border-radius: var(--r-pill);
+  background: transparent;
+  color: var(--ink-2);
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 540;
+  letter-spacing: 0;
+  padding: 0 var(--s-2);
+  white-space: nowrap;
+}
+
+.sideTab:hover,
+.sideTab:focus-visible {
+  outline: none;
+  border-color: var(--ink);
+  color: var(--ink);
+  box-shadow: 0 0 0 3px rgb(0 0 0 / 10%);
+}
+
+.sideTabActive {
+  border-color: var(--ink);
+  background: var(--ink);
+  color: var(--paper);
+}
+
+.sideTabActive:hover,
+.sideTabActive:focus-visible {
+  color: var(--paper);
+}
+
+.sideTabPanel {
+  display: flex;
+  min-height: 0;
+  flex: 1;
+  flex-direction: column;
 }
 
 .feedbackPanelHeader {


### PR DESCRIPTION
Closes #632

## 변경 사항

- 상담 시뮬레이션 우측 패널을 `상태`, `피드백`, `개선 후보` 탭으로 분리했습니다.
- 상태 탭에는 runtime state, slot 상태, 기존 검증 케이스 영역을 유지했습니다.
- 피드백 탭에는 대상 선택, 작성 폼, 워크스페이스 피드백 목록을 모았습니다.
- 개선 후보 탭에는 후보 목록, before/after/근거 요약, 리뷰 요청/승인/반려 액션을 분리했습니다.
- 메시지 flag 액션은 해당 turn을 피드백 대상으로 선택하고 피드백 탭을 활성화하며, 피드백에서 후보 생성 성공 시 개선 후보 탭으로 이동합니다.
- 이슈 632 스펙을 `.agent/specs/632.md`에 정리했습니다.

## 검증

- `git diff --check`
- `pnpm --dir frontend test -- WorkspaceSimulationPage.test.tsx --run` (24 passed)
- `pnpm --dir frontend exec eslint src/pages/workspace/ui/WorkspaceSimulationPage.tsx src/pages/workspace/ui/WorkspaceSimulationPage.test.tsx`
- `pnpm run ci:frontend` (270 files, 2054 tests; coverage thresholds and production build passed)
- GitHub CI #1837: `spec-check`, `frontend`, `frontend-e2e`, `frontend-sonar`, `ci-gate` success

## 참고

- 커밋 pre-commit hook의 `pnpm run lint:frontend`는 repository-wide 기존 lint baseline 50건으로 실패합니다. 이 PR에서 변경한 파일은 별도 ESLint 명령으로 통과 확인했고, frontend CI 경로는 통과했습니다.