### PR TITLE
feat(consultation): 메시지 상세에서 도메인팩 근거를 확인

### DIFF
--- a/.agent/specs/631.md
+++ b/.agent/specs/631.md
@@ -1,0 +1,119 @@
+# Frontend FSD Spec: 상담 메시지 상세 도메인팩 근거 연결
+
+## Goal
+
+상담사가 메시지를 선택했을 때 현재 상담 런타임에서 확인된 Slot/Policy/Risk 근거를 메시지 상세 패널에 표시한다.
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A[상담 세션 선택] --> B[메시지 목록 로드]
+    B --> C{메시지 선택?}
+    C -->|No| D[고객 정보 패널 표시]
+    C -->|Yes| E[메시지 상세 패널 표시]
+    E --> F[메시지 근거 조회]
+    F -->|Loading| G[근거 로딩 상태]
+    F -->|Success + Evidence| H[Slot/Policy/Risk 근거 표시]
+    F -->|Success + Empty| I[연결된 근거 없음 표시]
+    F -->|Error| J[패널 내부 오류 상태 표시]
+    H --> K{이동 경로 있음?}
+    K -->|Yes| L[도메인팩 섹션으로 이동]
+    K -->|No| H
+```
+
+## Design Diff
+
+| 영역             | As-is                                                                        | To-be                                               | 변경 내용                                              |
+| ---------------- | ---------------------------------------------------------------------------- | --------------------------------------------------- | ------------------------------------------------------ |
+| 메시지 상세 근거 | `MessageDetailPanel`이 props는 지원하지만 실제 상담 페이지에서 전달하지 않음 | 선택 메시지 기준으로 상담 런타임 근거를 조회해 전달 | `ConsultationPage`가 근거 로딩/성공/실패 상태를 관리   |
+| 빈 상태          | props 미전달 또는 빈 배열이 동일하게 빈 근거로 보임                          | 로딩, 실패, 근거 없음 상태를 구분                   | 패널 내부 상태 문구 분리                               |
+| 이동             | 근거 항목 클릭 경로 없음                                                     | 가능한 항목은 도메인팩 상세 섹션으로 이동           | pack/version/section 경로가 있는 경우 링크성 버튼 제공 |
+
+## Component Tree
+
+```text
+ConsultationPage
+├─ QueuePanel
+├─ ChatPanel
+└─ detailPane
+   ├─ MatchedWorkflowBar
+   └─ MessageDetailPanel
+      ├─ message header
+      ├─ evidence loading/error/empty state
+      ├─ SlotTagItem
+      ├─ PolicyTagItem
+      └─ RiskTagItem
+```
+
+## API Integration
+
+| Method | Path                                                                                  | Description                                                           |
+| ------ | ------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| GET    | `/api/v1/consultation/sessions/{sessionId}/messages/{messageId}/domain-pack-elements` | 선택 메시지가 속한 상담 세션의 최신 런타임 Slot/Policy/Risk 근거 조회 |
+
+`frontend/src/features/consultation/api/consultationEvidenceApi.ts`는 generated endpoint가 없는 상담 근거 조회만 `customFetch`로 호출한다. 응답은 `MessageDetailPanel`의 `domainPackElements` props 형태로 정규화한다.
+
+## Data Flow
+
+```text
+runtime workflow execution
+  ├─ slot_values_json
+  ├─ policy_snapshot_json
+  └─ risk_snapshot_json
+        ↓
+ConsultationEvidenceService
+        ↓
+ConsultationController evidence endpoint
+        ↓
+consultationEvidenceApi.getMessageDomainPackElements()
+        ↓
+ConsultationPage selectedMessage evidence state
+        ↓
+MessageDetailPanel domainPackElements/loading/error
+```
+
+## 수정 대상 파일
+
+| 파일                                                                                                    | 변경 유형 | 설명                                                          |
+| ------------------------------------------------------------------------------------------------------- | --------- | ------------------------------------------------------------- |
+| `backend/src/main/java/com/init/workflowruntime/application/ConsultationEvidenceService.java`           | new       | 메시지 소유권/워크스페이스 권한 검증 후 최신 런타임 근거 조회 |
+| `backend/src/main/java/com/init/workflowruntime/application/dto/MessageDomainPackElementsResponse.java` | new       | 메시지 상세 근거 응답 DTO                                     |
+| `backend/src/main/java/com/init/workflowruntime/presentation/ConsultationController.java`               | update    | 상담 메시지 근거 조회 endpoint 추가                           |
+| `frontend/src/features/consultation/api/consultationEvidenceApi.ts`                                     | new       | OpenAPI 미생성 endpoint 호출 및 패널 props 정규화             |
+| `frontend/src/features/consultation/ui/MessageDetailPanel.tsx`                                          | update    | loading/error 상태 및 근거 항목 이동 액션 표시                |
+| `frontend/src/pages/consultation/ui/ConsultationPage.tsx`                                               | update    | 선택 메시지별 근거 조회와 패널 전달                           |
+| `frontend/src/features/consultation/ui/MessageDetailPanel.test.tsx`                                     | update    | 연결/빈/로딩/실패/이동 상태 테스트                            |
+| `frontend/src/pages/consultation/ui/ConsultationPage.test.tsx`                                          | update    | 실제 상담 페이지에서 근거 조회 및 실패 degrade 테스트         |
+
+## State Management
+
+- `ConsultationPage`는 `activeCustomerId`, `selectedMessageId` 조합이 바뀌면 근거 조회 상태를 초기화한다.
+- 선택 메시지가 없거나 메시지 목록이 다른 세션으로 전환되면 근거 상태를 비운다.
+- 근거 조회 실패는 상담 화면 전체를 깨지 않으며 `MessageDetailPanel` 내부 오류 상태로만 표시한다.
+
+## Tests
+
+| 구분                    | 방법                                                     | 도구                          |
+| ----------------------- | -------------------------------------------------------- | ----------------------------- |
+| Backend unit/controller | service ownership/authz, controller parameter forwarding | JUnit 5, Mockito, MockMvc     |
+| Frontend component      | panel loading/error/empty/evidence/link behavior         | Vitest, React Testing Library |
+| Frontend page           | 메시지 선택 시 API 호출 및 실패 degrade                  | Vitest, React Testing Library |
+
+## Acceptance Criteria
+
+- 메시지 선택 시 관련 Slot/Policy/Risk 근거가 있으면 상세 패널에 표시된다.
+- 근거가 없는 경우 “연결된 근거 없음” 상태가 명확히 표시된다.
+- 근거 조회 로딩 상태와 실패 상태가 빈 상태와 구분된다.
+- 근거 조회 실패 시 상담 화면 전체가 깨지지 않는다.
+- pack/version/section 경로를 만들 수 있는 근거 항목은 도메인팩 상세 섹션으로 이동할 수 있다.
+
+## Non-goals
+
+- Slot/Policy/Risk 매칭 알고리즘 품질 개선은 다루지 않는다.
+- 메시지별 decision log 정밀 매핑 스키마를 새로 설계하지 않는다.
+- 상담 우측 컨텍스트 패널의 반응형 구조는 변경하지 않는다.
+
+## Open Questions
+
+- 현재 런타임 데이터 구조에서는 decision log가 개별 `chat_message.id`와 직접 연결되어 있지 않다. 이번 범위는 선택 메시지의 세션 소유권을 검증하고 최신 실행 근거를 표시하는 방식으로 제한한다.

--- a/backend/src/main/java/com/init/workflowruntime/application/ConsultationEvidenceService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/ConsultationEvidenceService.java
@@ -1,0 +1,354 @@
+package com.init.workflowruntime.application;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.NullNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.init.domainpack.domain.model.PolicyDefinition;
+import com.init.domainpack.domain.model.RiskDefinition;
+import com.init.domainpack.domain.model.SlotDefinition;
+import com.init.domainpack.domain.repository.PolicyDefinitionRepository;
+import com.init.domainpack.domain.repository.RiskDefinitionRepository;
+import com.init.domainpack.domain.repository.SlotDefinitionRepository;
+import com.init.shared.application.exception.InternalException;
+import com.init.shared.application.exception.NotFoundException;
+import com.init.workflowruntime.application.dto.MessageDomainPackElementsResponse;
+import com.init.workflowruntime.application.dto.MessageDomainPackElementsResponse.PolicyElement;
+import com.init.workflowruntime.application.dto.MessageDomainPackElementsResponse.RiskElement;
+import com.init.workflowruntime.application.dto.MessageDomainPackElementsResponse.SlotElement;
+import com.init.workflowruntime.domain.ChatMessage;
+import com.init.workflowruntime.domain.ChatMessageRepository;
+import com.init.workflowruntime.domain.ChatSession;
+import com.init.workflowruntime.domain.ChatSessionRepository;
+import com.init.workflowruntime.domain.WorkflowExecution;
+import com.init.workflowruntime.domain.WorkflowExecutionRepository;
+import com.init.workspace.application.exception.WorkspaceAccessDeniedException;
+import com.init.workspace.domain.repository.WorkspaceMemberRepository;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class ConsultationEvidenceService {
+
+  private static final String SIMULATION_CHANNEL = "SIMULATION";
+
+  private final ChatSessionRepository chatSessionRepository;
+  private final ChatMessageRepository chatMessageRepository;
+  private final WorkflowExecutionRepository workflowExecutionRepository;
+  private final SlotDefinitionRepository slotDefinitionRepository;
+  private final PolicyDefinitionRepository policyDefinitionRepository;
+  private final RiskDefinitionRepository riskDefinitionRepository;
+  private final WorkspaceMemberRepository workspaceMemberRepository;
+  private final ObjectMapper objectMapper;
+
+  public ConsultationEvidenceService(
+      ChatSessionRepository chatSessionRepository,
+      ChatMessageRepository chatMessageRepository,
+      WorkflowExecutionRepository workflowExecutionRepository,
+      SlotDefinitionRepository slotDefinitionRepository,
+      PolicyDefinitionRepository policyDefinitionRepository,
+      RiskDefinitionRepository riskDefinitionRepository,
+      WorkspaceMemberRepository workspaceMemberRepository,
+      ObjectMapper objectMapper) {
+    this.chatSessionRepository = chatSessionRepository;
+    this.chatMessageRepository = chatMessageRepository;
+    this.workflowExecutionRepository = workflowExecutionRepository;
+    this.slotDefinitionRepository = slotDefinitionRepository;
+    this.policyDefinitionRepository = policyDefinitionRepository;
+    this.riskDefinitionRepository = riskDefinitionRepository;
+    this.workspaceMemberRepository = workspaceMemberRepository;
+    this.objectMapper = objectMapper;
+  }
+
+  public MessageDomainPackElementsResponse getMessageDomainPackElements(
+      Long sessionId, Long messageId, Long userId) {
+    ChatSession session = findSession(sessionId);
+    validateWorkspaceMembership(session.getWorkspaceId(), userId);
+    validateOperationalSession(session);
+    validateMessageBelongsToSession(sessionId, messageId);
+
+    WorkflowExecution execution =
+        workflowExecutionRepository
+            .findTopByChatSessionIdOrderByStartedAtDescIdDesc(sessionId)
+            .orElse(null);
+
+    ObjectNode slotValues =
+        readObjectNode(execution != null ? execution.getSlotValuesJson() : "{}");
+    JsonNode policySnapshot =
+        readJsonNode(execution != null ? execution.getPolicySnapshotJson() : "{}", "{}");
+    JsonNode riskSnapshot =
+        readJsonNode(execution != null ? execution.getRiskSnapshotJson() : "{}", "{}");
+    JsonNode currentPolicy = policySnapshot.path("currentPolicy");
+    List<String> missingSlotCodes = textArray(currentPolicy.path("missingSlotCodes"));
+
+    return new MessageDomainPackElementsResponse(
+        session.getId(),
+        messageId,
+        session.getWorkspaceId(),
+        session.getDomainPackVersionId(),
+        execution != null ? execution.getId() : null,
+        execution != null ? execution.getCurrentState() : null,
+        buildSlots(session.getDomainPackVersionId(), slotValues, missingSlotCodes),
+        buildPolicies(session.getDomainPackVersionId(), policySnapshot),
+        buildRisks(session.getDomainPackVersionId(), riskSnapshot));
+  }
+
+  private List<SlotElement> buildSlots(
+      Long domainPackVersionId, ObjectNode slotValues, List<String> missingSlotCodes) {
+    return slotDefinitionRepository
+        .findAllByDomainPackVersionIdOrderBySlotCodeAsc(domainPackVersionId)
+        .stream()
+        .filter(slot -> SlotDefinition.STATUS_ACTIVE.equals(slot.getStatus()))
+        .filter(
+            slot ->
+                hasValue(slotValues, slot.getSlotCode())
+                    || missingSlotCodes.contains(slot.getSlotCode()))
+        .map(
+            slot -> {
+              JsonNode value = slotValues.path(slot.getSlotCode());
+              return new SlotElement(
+                  slot.getId(),
+                  slot.getSlotCode(),
+                  slot.getName(),
+                  hasValue(slotValues, slot.getSlotCode()),
+                  hasValue(slotValues, slot.getSlotCode()) ? formatSlotValue(slot, value) : null,
+                  null);
+            })
+        .toList();
+  }
+
+  private List<PolicyElement> buildPolicies(Long domainPackVersionId, JsonNode policySnapshot) {
+    Map<String, JsonNode> policyNodes = new LinkedHashMap<>();
+    addPolicyNode(policyNodes, policySnapshot.path("currentPolicy"));
+    addPolicyNodes(policyNodes, policySnapshot.path("hits"));
+    addPolicyNodes(policyNodes, policySnapshot.path("policyHits"));
+
+    List<PolicyElement> elements = new ArrayList<>();
+    for (Map.Entry<String, JsonNode> entry : policyNodes.entrySet()) {
+      String code = entry.getKey();
+      JsonNode node = entry.getValue();
+      PolicyDefinition definition =
+          policyDefinitionRepository
+              .findByDomainPackVersionIdAndPolicyCode(domainPackVersionId, code)
+              .orElse(null);
+      elements.add(
+          new PolicyElement(
+              definition != null ? definition.getId() : null,
+              code,
+              firstText(node, definition != null ? definition.getName() : code, "name"),
+              true,
+              node.path("matched").isMissingNode() || node.path("matched").asBoolean(true),
+              textOrNull(node.path("reason")),
+              textOrNull(node.path("nodeId")),
+              null));
+    }
+    return elements;
+  }
+
+  private List<RiskElement> buildRisks(Long domainPackVersionId, JsonNode riskSnapshot) {
+    List<JsonNode> riskNodes = new ArrayList<>();
+    collectRiskNodes(riskSnapshot, riskNodes);
+
+    Map<String, JsonNode> byCode = new LinkedHashMap<>();
+    for (JsonNode node : riskNodes) {
+      String code = firstText(node, null, "riskCode", "code", "riskRef");
+      if (code != null) {
+        byCode.putIfAbsent(code, node);
+      }
+    }
+
+    List<RiskElement> elements = new ArrayList<>();
+    for (Map.Entry<String, JsonNode> entry : byCode.entrySet()) {
+      String code = entry.getKey();
+      JsonNode node = entry.getValue();
+      RiskDefinition definition =
+          riskDefinitionRepository
+              .findByDomainPackVersionIdAndRiskCode(domainPackVersionId, code)
+              .orElse(null);
+      String level =
+          normalizeRiskLevel(
+              firstText(
+                  node,
+                  definition != null ? definition.getRiskLevel() : "LOW",
+                  "riskLevel",
+                  "level"));
+      elements.add(
+          new RiskElement(
+              definition != null ? definition.getId() : null,
+              code,
+              firstText(node, definition != null ? definition.getName() : code, "name"),
+              true,
+              level,
+              null));
+    }
+    return elements;
+  }
+
+  private ChatSession findSession(Long sessionId) {
+    return chatSessionRepository
+        .findById(sessionId)
+        .orElseThrow(
+            () -> new NotFoundException("SESSION_NOT_FOUND", "Session not found: " + sessionId));
+  }
+
+  private void validateMessageBelongsToSession(Long sessionId, Long messageId) {
+    ChatMessage message =
+        chatMessageRepository
+            .findById(messageId)
+            .orElseThrow(
+                () ->
+                    new NotFoundException("MESSAGE_NOT_FOUND", "Message not found: " + messageId));
+    if (!sessionId.equals(message.getChatSessionId())) {
+      throw new NotFoundException("MESSAGE_NOT_FOUND", "Message not found: " + messageId);
+    }
+  }
+
+  private void validateWorkspaceMembership(Long workspaceId, Long userId) {
+    workspaceMemberRepository
+        .findByWorkspaceIdAndUserId(workspaceId, userId)
+        .orElseThrow(() -> new WorkspaceAccessDeniedException("워크스페이스에 접근 권한이 없습니다."));
+  }
+
+  private void validateOperationalSession(ChatSession session) {
+    String channel = session.getChannel();
+    if (channel != null && channel.toUpperCase(Locale.ROOT).startsWith(SIMULATION_CHANNEL)) {
+      throw new NotFoundException("SESSION_NOT_FOUND", "Session not found: " + session.getId());
+    }
+  }
+
+  private void addPolicyNodes(Map<String, JsonNode> policyNodes, JsonNode nodes) {
+    if (!nodes.isArray()) {
+      return;
+    }
+    for (JsonNode node : nodes) {
+      addPolicyNode(policyNodes, node);
+    }
+  }
+
+  private void addPolicyNode(Map<String, JsonNode> policyNodes, JsonNode node) {
+    if (node == null || !node.isObject()) {
+      return;
+    }
+    String code = firstText(node, null, "policyCode", "code", "policyRef");
+    if (code != null) {
+      policyNodes.putIfAbsent(code, node);
+    }
+  }
+
+  private void collectRiskNodes(JsonNode node, List<JsonNode> result) {
+    if (node == null || node.isNull() || node.isMissingNode()) {
+      return;
+    }
+    if (node.isArray()) {
+      node.forEach(child -> collectRiskNodes(child, result));
+      return;
+    }
+    if (!node.isObject()) {
+      return;
+    }
+
+    if (firstText(node, null, "riskCode", "code", "riskRef") != null) {
+      result.add(node);
+    }
+    collectRiskNodes(node.path("hits"), result);
+    collectRiskNodes(node.path("riskHits"), result);
+  }
+
+  private List<String> textArray(JsonNode node) {
+    if (!node.isArray()) {
+      return List.of();
+    }
+    List<String> values = new ArrayList<>();
+    node.forEach(
+        item -> {
+          String value = textOrNull(item);
+          if (value != null) {
+            values.add(value);
+          }
+        });
+    return values;
+  }
+
+  private String firstText(JsonNode node, String fallback, String... fields) {
+    if (node == null || node.isMissingNode() || node.isNull()) {
+      return fallback;
+    }
+    for (String field : fields) {
+      String value = textOrNull(node.path(field));
+      if (value != null) {
+        return value;
+      }
+    }
+    return fallback;
+  }
+
+  private String textOrNull(JsonNode node) {
+    if (node == null || node.isMissingNode() || node.isNull()) {
+      return null;
+    }
+    String value = node.asText(null);
+    if (value == null || value.isBlank()) {
+      return null;
+    }
+    return value.trim();
+  }
+
+  private boolean hasValue(ObjectNode slotValues, String slotCode) {
+    return slotValues.hasNonNull(slotCode);
+  }
+
+  private String formatSlotValue(SlotDefinition slot, JsonNode value) {
+    if (Boolean.TRUE.equals(slot.getIsSensitive())) {
+      return "***";
+    }
+    if (value == null || value instanceof NullNode || value.isMissingNode()) {
+      return null;
+    }
+    if (value.isTextual() || value.isNumber() || value.isBoolean()) {
+      return value.asText();
+    }
+    try {
+      return objectMapper.writeValueAsString(value);
+    } catch (JsonProcessingException e) {
+      throw new InternalException("JSON_WRITE_FAILED", "Slot value cannot be serialized", e);
+    }
+  }
+
+  private String normalizeRiskLevel(String value) {
+    if (value == null || value.isBlank()) {
+      return "low";
+    }
+    return switch (value.trim().toUpperCase(Locale.ROOT)) {
+      case "HIGH", "CRITICAL" -> "high";
+      case "MEDIUM" -> "medium";
+      default -> "low";
+    };
+  }
+
+  private ObjectNode readObjectNode(String json) {
+    JsonNode node = readJsonNode(json, "{}");
+    if (node instanceof ObjectNode objectNode) {
+      return objectNode;
+    }
+    throw new InternalException("JSON_OBJECT_EXPECTED", "Stored JSON value must be an object");
+  }
+
+  private JsonNode readJsonNode(String json, String defaultJson) {
+    String source = json;
+    if (source == null || source.isBlank()) {
+      source = defaultJson;
+    }
+    try {
+      return objectMapper.readTree(source);
+    } catch (JsonProcessingException e) {
+      throw new InternalException("JSON_PARSE_FAILED", "Stored JSON value cannot be parsed", e);
+    }
+  }
+}

--- a/backend/src/main/java/com/init/workflowruntime/application/dto/MessageDomainPackElementsResponse.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/dto/MessageDomainPackElementsResponse.java
@@ -1,0 +1,31 @@
+package com.init.workflowruntime.application.dto;
+
+import java.util.List;
+
+public record MessageDomainPackElementsResponse(
+    Long sessionId,
+    Long messageId,
+    Long workspaceId,
+    Long domainPackVersionId,
+    Long executionId,
+    String currentState,
+    List<SlotElement> slots,
+    List<PolicyElement> policies,
+    List<RiskElement> risks) {
+
+  public record SlotElement(
+      Long id, String code, String name, boolean extracted, String value, String detailPath) {}
+
+  public record PolicyElement(
+      Long id,
+      String code,
+      String name,
+      boolean extracted,
+      boolean matched,
+      String reason,
+      String nodeId,
+      String detailPath) {}
+
+  public record RiskElement(
+      Long id, String code, String name, boolean extracted, String level, String detailPath) {}
+}

--- a/backend/src/main/java/com/init/workflowruntime/presentation/ConsultationController.java
+++ b/backend/src/main/java/com/init/workflowruntime/presentation/ConsultationController.java
@@ -1,6 +1,7 @@
 package com.init.workflowruntime.presentation;
 
 import com.init.shared.presentation.AuthenticationUtils;
+import com.init.workflowruntime.application.ConsultationEvidenceService;
 import com.init.workflowruntime.application.ConsultationService;
 import com.init.workflowruntime.application.CounselorDraftResponseService;
 import com.init.workflowruntime.application.LlmToolService;
@@ -11,6 +12,7 @@ import com.init.workflowruntime.application.dto.ChatMessageResponse;
 import com.init.workflowruntime.application.dto.ChatSessionResponse;
 import com.init.workflowruntime.application.dto.GenerateWorkflowAwareResponseResult;
 import com.init.workflowruntime.application.dto.LlmToolWorkflowResponse;
+import com.init.workflowruntime.application.dto.MessageDomainPackElementsResponse;
 import com.init.workflowruntime.application.dto.SendMessageRequest;
 import com.init.workflowruntime.application.dto.UpdateStatusRequest;
 import jakarta.validation.Valid;
@@ -33,6 +35,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ConsultationController {
 
   private final ConsultationService consultationService;
+  private final ConsultationEvidenceService consultationEvidenceService;
   private final LlmToolService llmToolService;
   private final CounselorDraftResponseService counselorDraftResponseService;
 
@@ -45,9 +48,11 @@ public class ConsultationController {
    */
   public ConsultationController(
       ConsultationService consultationService,
+      ConsultationEvidenceService consultationEvidenceService,
       LlmToolService llmToolService,
       CounselorDraftResponseService counselorDraftResponseService) {
     this.consultationService = consultationService;
+    this.consultationEvidenceService = consultationEvidenceService;
     this.llmToolService = llmToolService;
     this.counselorDraftResponseService = counselorDraftResponseService;
   }
@@ -82,6 +87,15 @@ public class ConsultationController {
       Authentication authentication) {
     Long userId = AuthenticationUtils.getUserId(authentication);
     return ResponseEntity.ok(consultationService.sendMessage(sessionId, request, userId));
+  }
+
+  /** 선택한 메시지의 상세 패널에 표시할 최신 도메인팩 근거 요소를 조회합니다. */
+  @GetMapping("/sessions/{sessionId}/messages/{messageId}/domain-pack-elements")
+  public ResponseEntity<MessageDomainPackElementsResponse> getMessageDomainPackElements(
+      @PathVariable Long sessionId, @PathVariable Long messageId, Authentication authentication) {
+    Long userId = AuthenticationUtils.getUserId(authentication);
+    return ResponseEntity.ok(
+        consultationEvidenceService.getMessageDomainPackElements(sessionId, messageId, userId));
   }
 
   /**

--- a/backend/src/test/java/com/init/workflowruntime/application/ConsultationEvidenceServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/ConsultationEvidenceServiceTest.java
@@ -1,0 +1,236 @@
+package com.init.workflowruntime.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.init.domainpack.domain.model.PolicyDefinition;
+import com.init.domainpack.domain.model.RiskDefinition;
+import com.init.domainpack.domain.model.SlotDefinition;
+import com.init.domainpack.domain.repository.PolicyDefinitionRepository;
+import com.init.domainpack.domain.repository.RiskDefinitionRepository;
+import com.init.domainpack.domain.repository.SlotDefinitionRepository;
+import com.init.shared.application.exception.NotFoundException;
+import com.init.workflowruntime.application.dto.MessageDomainPackElementsResponse;
+import com.init.workflowruntime.domain.ChatMessage;
+import com.init.workflowruntime.domain.ChatMessageRepository;
+import com.init.workflowruntime.domain.ChatSession;
+import com.init.workflowruntime.domain.ChatSessionRepository;
+import com.init.workflowruntime.domain.ChatSessionStatus;
+import com.init.workflowruntime.domain.WorkflowExecution;
+import com.init.workflowruntime.domain.WorkflowExecutionRepository;
+import com.init.workspace.application.exception.WorkspaceAccessDeniedException;
+import com.init.workspace.domain.model.WorkspaceMember;
+import com.init.workspace.domain.model.WorkspaceMemberRole;
+import com.init.workspace.domain.repository.WorkspaceMemberRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ConsultationEvidenceService")
+class ConsultationEvidenceServiceTest {
+
+  @Mock private ChatSessionRepository chatSessionRepository;
+  @Mock private ChatMessageRepository chatMessageRepository;
+  @Mock private WorkflowExecutionRepository workflowExecutionRepository;
+  @Mock private SlotDefinitionRepository slotDefinitionRepository;
+  @Mock private PolicyDefinitionRepository policyDefinitionRepository;
+  @Mock private RiskDefinitionRepository riskDefinitionRepository;
+  @Mock private WorkspaceMemberRepository workspaceMemberRepository;
+
+  private ConsultationEvidenceService service;
+
+  @BeforeEach
+  void setUp() {
+    service =
+        new ConsultationEvidenceService(
+            chatSessionRepository,
+            chatMessageRepository,
+            workflowExecutionRepository,
+            slotDefinitionRepository,
+            policyDefinitionRepository,
+            riskDefinitionRepository,
+            workspaceMemberRepository,
+            new ObjectMapper());
+  }
+
+  @Test
+  @DisplayName("메시지 상세 근거는 최신 실행 스냅샷의 slot/policy/risk를 도메인팩 정의명과 함께 반환한다")
+  void should_returnDomainPackElementsFromLatestWorkflowExecution() {
+    ChatSession session = createSession(1L, 2L, 3L, "WEB");
+    ChatMessage message = createMessage(100L, 1L);
+    WorkflowExecution execution = createExecution();
+    SlotDefinition orderNumber = createSlot(10L, "orderNumber", "주문 번호", false);
+    SlotDefinition refundReason = createSlot(11L, "refundReason", "환불 사유", false);
+    SlotDefinition cardLast4 = createSlot(12L, "cardLast4", "카드 끝자리", true);
+    PolicyDefinition refundPolicy = createPolicy(20L, "refund_policy", "환불 정책");
+    RiskDefinition highRefund = createRisk(30L, "high_refund", "고액 환불", "HIGH");
+
+    given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+    given(workspaceMemberRepository.findByWorkspaceIdAndUserId(2L, 7L))
+        .willReturn(Optional.of(WorkspaceMember.create(2L, 7L, WorkspaceMemberRole.OPERATOR)));
+    given(chatMessageRepository.findById(100L)).willReturn(Optional.of(message));
+    given(workflowExecutionRepository.findTopByChatSessionIdOrderByStartedAtDescIdDesc(1L))
+        .willReturn(Optional.of(execution));
+    given(slotDefinitionRepository.findAllByDomainPackVersionIdOrderBySlotCodeAsc(3L))
+        .willReturn(List.of(cardLast4, orderNumber, refundReason));
+    given(policyDefinitionRepository.findByDomainPackVersionIdAndPolicyCode(3L, "refund_policy"))
+        .willReturn(Optional.of(refundPolicy));
+    given(riskDefinitionRepository.findByDomainPackVersionIdAndRiskCode(3L, "high_refund"))
+        .willReturn(Optional.of(highRefund));
+
+    MessageDomainPackElementsResponse result = service.getMessageDomainPackElements(1L, 100L, 7L);
+
+    assertThat(result.sessionId()).isEqualTo(1L);
+    assertThat(result.messageId()).isEqualTo(100L);
+    assertThat(result.workspaceId()).isEqualTo(2L);
+    assertThat(result.domainPackVersionId()).isEqualTo(3L);
+    assertThat(result.executionId()).isEqualTo(50L);
+    assertThat(result.currentState()).isEqualTo("collect_refund_info");
+    assertThat(result.slots())
+        .extracting("id", "code", "name", "extracted", "value")
+        .containsExactly(
+            tuple(12L, "cardLast4", "카드 끝자리", true, "***"),
+            tuple(10L, "orderNumber", "주문 번호", true, "ORD-1"),
+            tuple(11L, "refundReason", "환불 사유", false, null));
+    assertThat(result.policies())
+        .extracting("id", "code", "name", "matched", "reason", "nodeId")
+        .containsExactly(tuple(20L, "refund_policy", "환불 정책", true, "조건 충족", "policy_check"));
+    assertThat(result.risks())
+        .extracting("id", "code", "name", "level")
+        .containsExactly(tuple(30L, "high_refund", "고액 환불", "high"));
+  }
+
+  @Test
+  @DisplayName("워크플로우 실행이 없어도 메시지 소유권 확인 후 빈 근거 목록을 반환한다")
+  void should_returnEmptyEvidence_when_executionDoesNotExist() {
+    ChatSession session = createSession(1L, 2L, 3L, "WEB");
+    ChatMessage message = createMessage(100L, 1L);
+
+    given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+    given(workspaceMemberRepository.findByWorkspaceIdAndUserId(2L, 7L))
+        .willReturn(Optional.of(WorkspaceMember.create(2L, 7L, WorkspaceMemberRole.OPERATOR)));
+    given(chatMessageRepository.findById(100L)).willReturn(Optional.of(message));
+    given(workflowExecutionRepository.findTopByChatSessionIdOrderByStartedAtDescIdDesc(1L))
+        .willReturn(Optional.empty());
+    given(slotDefinitionRepository.findAllByDomainPackVersionIdOrderBySlotCodeAsc(3L))
+        .willReturn(List.of());
+
+    MessageDomainPackElementsResponse result = service.getMessageDomainPackElements(1L, 100L, 7L);
+
+    assertThat(result.executionId()).isNull();
+    assertThat(result.currentState()).isNull();
+    assertThat(result.slots()).isEmpty();
+    assertThat(result.policies()).isEmpty();
+    assertThat(result.risks()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("다른 세션의 메시지는 찾을 수 없는 메시지처럼 처리한다")
+  void should_throwNotFound_when_messageBelongsToAnotherSession() {
+    ChatSession session = createSession(1L, 2L, 3L, "WEB");
+    ChatMessage message = createMessage(100L, 999L);
+
+    given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+    given(workspaceMemberRepository.findByWorkspaceIdAndUserId(2L, 7L))
+        .willReturn(Optional.of(WorkspaceMember.create(2L, 7L, WorkspaceMemberRole.OPERATOR)));
+    given(chatMessageRepository.findById(100L)).willReturn(Optional.of(message));
+
+    assertThatThrownBy(() -> service.getMessageDomainPackElements(1L, 100L, 7L))
+        .isInstanceOf(NotFoundException.class)
+        .hasMessageContaining("Message not found: 100");
+
+    verify(workflowExecutionRepository, never())
+        .findTopByChatSessionIdOrderByStartedAtDescIdDesc(1L);
+  }
+
+  @Test
+  @DisplayName("워크스페이스 멤버가 아니면 메시지 존재 여부를 노출하지 않고 거부한다")
+  void should_throwAccessDenied_beforeMessageLookup_when_notWorkspaceMember() {
+    ChatSession session = createSession(1L, 2L, 3L, "WEB");
+
+    given(chatSessionRepository.findById(1L)).willReturn(Optional.of(session));
+    given(workspaceMemberRepository.findByWorkspaceIdAndUserId(2L, 7L))
+        .willReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.getMessageDomainPackElements(1L, 100L, 7L))
+        .isInstanceOf(WorkspaceAccessDeniedException.class);
+
+    verify(chatMessageRepository, never()).findById(100L);
+    verify(workflowExecutionRepository, never())
+        .findTopByChatSessionIdOrderByStartedAtDescIdDesc(1L);
+  }
+
+  private ChatSession createSession(Long id, Long workspaceId, Long versionId, String channel) {
+    ChatSession session =
+        ChatSession.create(workspaceId, versionId, ChatSessionStatus.OPEN, channel, "{}");
+    ReflectionTestUtils.setField(session, "id", id);
+    return session;
+  }
+
+  private ChatMessage createMessage(Long id, Long sessionId) {
+    ChatMessage message = ChatMessage.create(sessionId, 1, "CUSTOMER", "TEXT", "환불 요청");
+    ReflectionTestUtils.setField(message, "id", id);
+    return message;
+  }
+
+  private WorkflowExecution createExecution() {
+    WorkflowExecution execution = WorkflowExecution.create(1L);
+    ReflectionTestUtils.setField(execution, "id", 50L);
+    execution.assignIntentWorkflow(40L, 60L, "collect_refund_info");
+    execution.replaceSlotValuesJson("{\"orderNumber\":\"ORD-1\",\"cardLast4\":\"1234\"}");
+    execution.replacePolicySnapshotJson(
+        """
+        {
+          "currentPolicy": {
+            "policyCode": "refund_policy",
+            "matched": true,
+            "missingSlotCodes": ["refundReason"],
+            "reason": "조건 충족",
+            "nodeId": "policy_check"
+          },
+          "hits": [{"policyCode": "refund_policy"}]
+        }
+        """);
+    execution.replaceRiskSnapshotJson(
+        """
+        {
+          "hits": [
+            {"riskCode": "high_refund", "riskLevel": "HIGH"}
+          ]
+        }
+        """);
+    return execution;
+  }
+
+  private SlotDefinition createSlot(Long id, String code, String name, boolean sensitive) {
+    SlotDefinition slot =
+        SlotDefinition.create(3L, code, name, "", "STRING", sensitive, "{}", null, "{}");
+    ReflectionTestUtils.setField(slot, "id", id);
+    return slot;
+  }
+
+  private PolicyDefinition createPolicy(Long id, String code, String name) {
+    PolicyDefinition policy =
+        PolicyDefinition.create(3L, code, name, "", "HIGH", "{}", "{}", "[]", "{}");
+    ReflectionTestUtils.setField(policy, "id", id);
+    return policy;
+  }
+
+  private RiskDefinition createRisk(Long id, String code, String name, String level) {
+    RiskDefinition risk = RiskDefinition.create(3L, code, name, "", level, "{}", "{}", "[]", "{}");
+    ReflectionTestUtils.setField(risk, "id", id);
+    return risk;
+  }
+}

--- a/backend/src/test/java/com/init/workflowruntime/presentation/ConsultationControllerTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/presentation/ConsultationControllerTest.java
@@ -16,6 +16,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.init.shared.application.exception.BadRequestException;
 import com.init.shared.application.exception.NotFoundException;
 import com.init.shared.infrastructure.security.JwtAuthenticationFilter;
+import com.init.workflowruntime.application.ConsultationEvidenceService;
 import com.init.workflowruntime.application.ConsultationService;
 import com.init.workflowruntime.application.CounselorDraftResponseService;
 import com.init.workflowruntime.application.LlmToolService;
@@ -26,6 +27,10 @@ import com.init.workflowruntime.application.dto.ChatMessageResponse;
 import com.init.workflowruntime.application.dto.ChatSessionResponse;
 import com.init.workflowruntime.application.dto.GenerateWorkflowAwareResponseResult;
 import com.init.workflowruntime.application.dto.LlmToolWorkflowResponse;
+import com.init.workflowruntime.application.dto.MessageDomainPackElementsResponse;
+import com.init.workflowruntime.application.dto.MessageDomainPackElementsResponse.PolicyElement;
+import com.init.workflowruntime.application.dto.MessageDomainPackElementsResponse.RiskElement;
+import com.init.workflowruntime.application.dto.MessageDomainPackElementsResponse.SlotElement;
 import com.init.workflowruntime.application.dto.SendMessageRequest;
 import com.init.workflowruntime.application.dto.UpdateStatusRequest;
 import com.init.workspace.application.exception.WorkspaceAccessDeniedException;
@@ -64,6 +69,10 @@ class ConsultationControllerTest {
   @SuppressWarnings("removal")
   @MockBean
   private ConsultationService consultationService;
+
+  @SuppressWarnings("removal")
+  @MockBean
+  private ConsultationEvidenceService consultationEvidenceService;
 
   @SuppressWarnings("removal")
   @MockBean
@@ -237,6 +246,43 @@ class ConsultationControllerTest {
         .perform(get("/api/v1/consultation/sessions/999/messages").principal(auth()))
         .andExpect(status().isNotFound())
         .andExpect(jsonPath("$.code").value("SESSION_NOT_FOUND"));
+  }
+
+  @Test
+  @DisplayName(
+      "GET /api/v1/consultation/sessions/{sessionId}/messages/{messageId}/domain-pack-elements - 메시지 근거 반환")
+  void should_도메인팩근거반환_when_메시지상세근거조회() throws Exception {
+    MessageDomainPackElementsResponse response =
+        new MessageDomainPackElementsResponse(
+            1L,
+            100L,
+            2L,
+            3L,
+            50L,
+            "collect_refund_info",
+            List.of(new SlotElement(10L, "orderNumber", "주문 번호", true, "ORD-1", null)),
+            List.of(
+                new PolicyElement(
+                    20L, "refund_policy", "환불 정책", true, true, "조건 충족", "policy_check", null)),
+            List.of(new RiskElement(30L, "high_refund", "고액 환불", true, "high", null)));
+    given(consultationEvidenceService.getMessageDomainPackElements(1L, 100L, 7L))
+        .willReturn(response);
+
+    mockMvc
+        .perform(
+            get("/api/v1/consultation/sessions/1/messages/100/domain-pack-elements")
+                .principal(auth()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.sessionId").value(1))
+        .andExpect(jsonPath("$.messageId").value(100))
+        .andExpect(jsonPath("$.executionId").value(50))
+        .andExpect(jsonPath("$.slots[0].name").value("주문 번호"))
+        .andExpect(jsonPath("$.slots[0].value").value("ORD-1"))
+        .andExpect(jsonPath("$.policies[0].matched").value(true))
+        .andExpect(jsonPath("$.policies[0].nodeId").value("policy_check"))
+        .andExpect(jsonPath("$.risks[0].level").value("high"));
+
+    verify(consultationEvidenceService).getMessageDomainPackElements(1L, 100L, 7L);
   }
 
   @Test

--- a/frontend/scripts/manual-api-call-allowlist.json
+++ b/frontend/scripts/manual-api-call-allowlist.json
@@ -67,6 +67,15 @@
       "wrapperPurpose": "unwrap/select"
     },
     {
+      "file": "src/features/consultation/api/consultationEvidenceApi.ts",
+      "importName": "customFetch",
+      "callee": "customFetch",
+      "endpoint": "/api/v1/consultation/sessions/${}/messages/${}/domain-pack-elements",
+      "reason": "OpenAPI generated endpoint is not available for consultation message domain pack evidence lookup.",
+      "scope": "Consultation message domain pack evidence read endpoint.",
+      "wrapperPurpose": "response normalization"
+    },
+    {
       "file": "src/features/consultation/api/llmToolWorkflowApi.ts",
       "importName": "customFetch",
       "callee": "customFetch",

--- a/frontend/src/features/consultation/api/consultationEvidenceApi.test.ts
+++ b/frontend/src/features/consultation/api/consultationEvidenceApi.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { customFetch } from "@/shared/api/mutator";
+import { consultationEvidenceApi } from "./consultationEvidenceApi";
+
+vi.mock("@/shared/api/mutator", () => ({
+  customFetch: vi.fn(),
+}));
+
+const mockedFetch = vi.mocked(customFetch);
+
+describe("consultationEvidenceApi", () => {
+  beforeEach(() => {
+    mockedFetch.mockReset();
+  });
+
+  it("normalizes message evidence and builds domain pack detail paths", async () => {
+    mockedFetch.mockResolvedValueOnce({
+      data: {
+        slots: [
+          {
+            id: 10,
+            code: "orderNumber",
+            name: "주문 번호",
+            extracted: true,
+            value: "ORD-1",
+          },
+        ],
+        policies: [
+          {
+            id: 20,
+            code: "refund_policy",
+            name: "환불 정책",
+            extracted: true,
+            matched: true,
+          },
+        ],
+        risks: [
+          {
+            id: 30,
+            code: "high_refund",
+            name: "고액 환불",
+            extracted: true,
+            level: "HIGH",
+          },
+        ],
+      },
+    });
+
+    const result = await consultationEvidenceApi.getMessageDomainPackElements(
+      1,
+      100,
+      {
+        workspaceId: 2,
+        packId: 4,
+        versionId: 8,
+      },
+    );
+
+    expect(mockedFetch).toHaveBeenCalledWith(
+      "/api/v1/consultation/sessions/1/messages/100/domain-pack-elements",
+      { method: "GET" },
+    );
+    expect(result).toEqual({
+      slots: [
+        {
+          name: "주문 번호",
+          extracted: true,
+          value: "ORD-1",
+          detailPath: "/workspaces/2/domain-packs/4/slots/10?versionId=8",
+        },
+      ],
+      policies: [
+        {
+          name: "환불 정책",
+          extracted: true,
+          matched: true,
+          detailPath: "/workspaces/2/domain-packs/4/policies/20?versionId=8",
+        },
+      ],
+      risks: [
+        {
+          name: "고액 환불",
+          extracted: true,
+          level: "high",
+          detailPath: "/workspaces/2/domain-packs/4/risks/30?versionId=8",
+        },
+      ],
+    });
+  });
+
+  it("keeps evidence unlinked when route context is incomplete", async () => {
+    mockedFetch.mockResolvedValueOnce({
+      slots: [{ code: "refundReason", extracted: false }],
+      policies: [],
+      risks: [],
+    });
+
+    const result = await consultationEvidenceApi.getMessageDomainPackElements(
+      1,
+      100,
+      {
+        workspaceId: 2,
+        packId: null,
+        versionId: null,
+      },
+    );
+
+    expect(result.slots).toEqual([
+      {
+        name: "refundReason",
+        extracted: false,
+        detailPath: undefined,
+      },
+    ]);
+  });
+});

--- a/frontend/src/features/consultation/api/consultationEvidenceApi.ts
+++ b/frontend/src/features/consultation/api/consultationEvidenceApi.ts
@@ -1,0 +1,147 @@
+import { domainPackSectionPath } from "@/shared/lib/domainPackRoutes";
+import { customFetch } from "@/shared/api/mutator";
+import { requireApiData } from "@/shared/api";
+
+export interface MessageEvidenceRouteContext {
+  workspaceId: number;
+  packId: number | null;
+  versionId: number | null;
+}
+
+export interface MessageDomainPackElements {
+  slots: Array<{
+    name: string;
+    extracted: boolean;
+    value?: string;
+    detailPath?: string;
+  }>;
+  policies: Array<{
+    name: string;
+    extracted: boolean;
+    matched: boolean;
+    detailPath?: string;
+  }>;
+  risks: Array<{
+    name: string;
+    extracted: boolean;
+    level: "low" | "medium" | "high";
+    detailPath?: string;
+  }>;
+}
+
+interface RawMessageDomainPackElementsResponse {
+  data?: RawMessageDomainPackElements;
+}
+
+interface RawMessageDomainPackElements {
+  slots?: RawSlotElement[];
+  policies?: RawPolicyElement[];
+  risks?: RawRiskElement[];
+}
+
+interface RawSlotElement {
+  id?: number | null;
+  code?: string | null;
+  name?: string | null;
+  extracted?: boolean;
+  value?: string | null;
+}
+
+interface RawPolicyElement {
+  id?: number | null;
+  code?: string | null;
+  name?: string | null;
+  extracted?: boolean;
+  matched?: boolean;
+}
+
+interface RawRiskElement {
+  id?: number | null;
+  code?: string | null;
+  name?: string | null;
+  extracted?: boolean;
+  level?: string | null;
+}
+
+function buildDetailPath(
+  routeContext: MessageEvidenceRouteContext | null,
+  section: "slots" | "policies" | "risks",
+  id?: number | null,
+) {
+  if (
+    !routeContext?.workspaceId ||
+    !routeContext.packId ||
+    !routeContext.versionId
+  ) {
+    return undefined;
+  }
+  return domainPackSectionPath(
+    routeContext.workspaceId,
+    routeContext.packId,
+    routeContext.versionId,
+    section,
+    id ?? undefined,
+  );
+}
+
+function normalizeRiskLevel(level?: string | null): "low" | "medium" | "high" {
+  if (level?.toLowerCase() === "high" || level?.toLowerCase() === "critical")
+    return "high";
+  if (level?.toLowerCase() === "medium") return "medium";
+  return "low";
+}
+
+function elementName(name?: string | null, code?: string | null) {
+  return name?.trim() || code?.trim() || "이름 없음";
+}
+
+function normalizeMessageDomainPackElements(
+  response: RawMessageDomainPackElements,
+  routeContext: MessageEvidenceRouteContext | null,
+): MessageDomainPackElements {
+  return {
+    slots: (response.slots ?? []).map((slot) => ({
+      name: elementName(slot.name, slot.code),
+      extracted: slot.extracted ?? false,
+      ...(slot.value ? { value: slot.value } : {}),
+      detailPath: buildDetailPath(routeContext, "slots", slot.id),
+    })),
+    policies: (response.policies ?? []).map((policy) => ({
+      name: elementName(policy.name, policy.code),
+      extracted: policy.extracted ?? true,
+      matched: policy.matched ?? false,
+      detailPath: buildDetailPath(routeContext, "policies", policy.id),
+    })),
+    risks: (response.risks ?? []).map((risk) => ({
+      name: elementName(risk.name, risk.code),
+      extracted: risk.extracted ?? true,
+      level: normalizeRiskLevel(risk.level),
+      detailPath: buildDetailPath(routeContext, "risks", risk.id),
+    })),
+  };
+}
+
+export const consultationEvidenceApi = {
+  getMessageDomainPackElements: async (
+    sessionId: number,
+    messageId: number,
+    routeContext: MessageEvidenceRouteContext | null = null,
+  ): Promise<MessageDomainPackElements> => {
+    // OpenAPI generated endpoints do not include this operator-only evidence endpoint yet.
+    const response = await customFetch<
+      RawMessageDomainPackElements | RawMessageDomainPackElementsResponse
+    >(
+      `/api/v1/consultation/sessions/${sessionId}/messages/${messageId}/domain-pack-elements`,
+      {
+        method: "GET",
+      },
+    );
+    return normalizeMessageDomainPackElements(
+      requireApiData<RawMessageDomainPackElements>(
+        response,
+        "메시지 도메인팩 근거 응답을 확인할 수 없습니다.",
+      ),
+      routeContext,
+    );
+  },
+};

--- a/frontend/src/features/consultation/ui/MessageDetailPanel.module.css
+++ b/frontend/src/features/consultation/ui/MessageDetailPanel.module.css
@@ -123,6 +123,17 @@
   color: var(--ink-4);
 }
 
+.domainLoadingIcon {
+  color: var(--ink-4);
+  animation: domainSpin 0.9s linear infinite;
+}
+
+@keyframes domainSpin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 .domainEmpty strong {
   display: block;
   margin-top: 10px;
@@ -158,6 +169,16 @@
 
 .tag:hover {
   filter: brightness(0.95);
+}
+
+.tagButton {
+  border: 0;
+  cursor: pointer;
+}
+
+.tagButton:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
 }
 
 .tagExtracted {

--- a/frontend/src/features/consultation/ui/MessageDetailPanel.test.tsx
+++ b/frontend/src/features/consultation/ui/MessageDetailPanel.test.tsx
@@ -58,9 +58,11 @@ describe("MessageDetailPanel", () => {
       />,
     );
 
-    expect(screen.getByText("연결된 도메인 팩 요소가 없습니다")).toBeInTheDocument();
+    expect(screen.getByText("연결된 근거 없음")).toBeInTheDocument();
     expect(
-      screen.getByText("확인 항목, 응대 기준, 주의 사항이 연결되면 이 영역에 표시됩니다."),
+      screen.getByText(
+        "확인 항목, 응대 기준, 주의 사항이 연결되면 이 영역에 표시됩니다.",
+      ),
     ).toBeInTheDocument();
     expect(screen.queryByText("가격 문의")).not.toBeInTheDocument();
   });
@@ -93,7 +95,9 @@ describe("MessageDetailPanel", () => {
       />,
     );
 
-    expect(screen.queryByTestId("message-domain-empty")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("message-domain-empty"),
+    ).not.toBeInTheDocument();
     expect(screen.getByText("가격 문의")).toBeInTheDocument();
     expect(screen.getByText("89,000원")).toBeInTheDocument();
     expect(screen.getByText("배송지 주소")).toBeInTheDocument();
@@ -101,6 +105,85 @@ describe("MessageDetailPanel", () => {
     expect(screen.getByText("환불 정책")).toBeInTheDocument();
     expect(screen.getByText("고객 불만 고조")).toBeInTheDocument();
     expect(screen.getByText("환불 요청")).toBeInTheDocument();
+  });
+
+  it("shows loading state while domain pack elements are being loaded", () => {
+    render(
+      <MessageDetailPanel
+        message={{
+          id: "1",
+          senderRole: "CUSTOMER",
+          content: "test",
+          timestamp: "12:00",
+        }}
+        isDomainPackElementsLoading
+        onClose={() => {}}
+      />,
+    );
+
+    expect(screen.getByTestId("message-domain-loading")).toHaveTextContent(
+      "근거를 불러오는 중입니다",
+    );
+    expect(
+      screen.queryByTestId("message-domain-empty"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows an in-panel error state when evidence loading fails", () => {
+    render(
+      <MessageDetailPanel
+        message={{
+          id: "1",
+          senderRole: "CUSTOMER",
+          content: "test",
+          timestamp: "12:00",
+        }}
+        domainPackElementsError="상담은 계속 진행할 수 있습니다."
+        onClose={() => {}}
+      />,
+    );
+
+    expect(screen.getByTestId("message-domain-error")).toHaveTextContent(
+      "근거를 불러오지 못했습니다",
+    );
+    expect(
+      screen.getByText("상담은 계속 진행할 수 있습니다."),
+    ).toBeInTheDocument();
+  });
+
+  it("calls domain pack navigation callback when a linked evidence tag is clicked", () => {
+    const onOpenDomainPackElement = vi.fn();
+
+    render(
+      <MessageDetailPanel
+        message={{
+          id: "1",
+          senderRole: "CUSTOMER",
+          content: "test",
+          timestamp: "12:00",
+        }}
+        domainPackElements={{
+          slots: [
+            {
+              name: "주문 번호",
+              extracted: true,
+              value: "ORD-1",
+              detailPath: "/workspaces/2/domain-packs/4/slots/10?versionId=8",
+            },
+          ],
+          policies: [],
+          risks: [],
+        }}
+        onOpenDomainPackElement={onOpenDomainPackElement}
+        onClose={() => {}}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /주문 번호/ }));
+
+    expect(onOpenDomainPackElement).toHaveBeenCalledWith(
+      "/workspaces/2/domain-packs/4/slots/10?versionId=8",
+    );
   });
 
   /* ─── Test 5: partially connected elements ─── */

--- a/frontend/src/features/consultation/ui/MessageDetailPanel.tsx
+++ b/frontend/src/features/consultation/ui/MessageDetailPanel.tsx
@@ -1,4 +1,9 @@
-import { FileSearch, MessageSquare } from "lucide-react";
+import {
+  AlertCircle,
+  FileSearch,
+  LoaderCircle,
+  MessageSquare,
+} from "lucide-react";
 import type { ReactNode } from "react";
 import { getChatRolePresentation } from "../lib/chatRoleLabels";
 import styles from "./MessageDetailPanel.module.css";
@@ -8,18 +13,27 @@ export interface SlotTag {
   name: string;
   extracted: boolean;
   value?: string;
+  detailPath?: string;
 }
 
 export interface PolicyTag {
   name: string;
   extracted: boolean;
   matched: boolean;
+  detailPath?: string;
 }
 
 export interface RiskTag {
   name: string;
   extracted: boolean;
   level: "low" | "medium" | "high";
+  detailPath?: string;
+}
+
+export interface DomainPackElements {
+  slots: SlotTag[];
+  policies: PolicyTag[];
+  risks: RiskTag[];
 }
 
 export interface MessageDetailPanelProps {
@@ -29,11 +43,10 @@ export interface MessageDetailPanelProps {
     content: string;
     timestamp: string;
   } | null;
-  domainPackElements?: {
-    slots: SlotTag[];
-    policies: PolicyTag[];
-    risks: RiskTag[];
-  };
+  domainPackElements?: DomainPackElements;
+  isDomainPackElementsLoading?: boolean;
+  domainPackElementsError?: string | null;
+  onOpenDomainPackElement?: (path: string) => void;
   onClose: () => void;
 }
 
@@ -65,48 +78,111 @@ function Section({
     <div className={styles.section}>
       <div className={styles.sectionTitle}>{title}</div>
       <div className={styles.tagList}>
-        {hasItems ? children : <span className={styles.sectionEmpty}>{emptyText}</span>}
+        {hasItems ? (
+          children
+        ) : (
+          <span className={styles.sectionEmpty}>{emptyText}</span>
+        )}
       </div>
     </div>
   );
 }
 
-function SlotTagItem({ slot }: { slot: SlotTag }) {
+function EvidenceTag({
+  className,
+  detailPath,
+  onOpen,
+  children,
+}: {
+  className: string;
+  detailPath?: string;
+  onOpen?: (path: string) => void;
+  children: ReactNode;
+}) {
+  if (detailPath && onOpen) {
+    return (
+      <button
+        type="button"
+        className={`${className} ${styles.tagButton}`}
+        onClick={() => onOpen(detailPath)}
+      >
+        {children}
+      </button>
+    );
+  }
+  return <span className={className}>{children}</span>;
+}
+
+function SlotTagItem({
+  slot,
+  onOpen,
+}: {
+  slot: SlotTag;
+  onOpen?: (path: string) => void;
+}) {
   const cls = slot.extracted
     ? `${styles.tag} ${styles.tagExtracted}`
     : `${styles.tag} ${styles.tagNotExtracted}`;
   return (
-    <span className={cls}>
+    <EvidenceTag className={cls} detailPath={slot.detailPath} onOpen={onOpen}>
       {slot.name}
       {slot.value && <span className={styles.tagValue}>{slot.value}</span>}
-    </span>
+    </EvidenceTag>
   );
 }
 
-function PolicyTagItem({ policy }: { policy: PolicyTag }) {
+function PolicyTagItem({
+  policy,
+  onOpen,
+}: {
+  policy: PolicyTag;
+  onOpen?: (path: string) => void;
+}) {
   const cls =
     policy.extracted && policy.matched
       ? `${styles.tag} ${styles.tagExtracted}`
       : `${styles.tag} ${styles.tagNotExtracted}`;
-  return <span className={cls}>{policy.name}</span>;
+  return (
+    <EvidenceTag className={cls} detailPath={policy.detailPath} onOpen={onOpen}>
+      {policy.name}
+    </EvidenceTag>
+  );
 }
 
-function RiskTagItem({ risk }: { risk: RiskTag }) {
+function RiskTagItem({
+  risk,
+  onOpen,
+}: {
+  risk: RiskTag;
+  onOpen?: (path: string) => void;
+}) {
   const cls = riskTagClass(risk);
-  return <span className={cls}>{risk.name}</span>;
+  return (
+    <EvidenceTag className={cls} detailPath={risk.detailPath} onOpen={onOpen}>
+      {risk.name}
+    </EvidenceTag>
+  );
 }
 
 /* ─── Component ─── */
 export function MessageDetailPanel({
   message,
   domainPackElements,
+  isDomainPackElementsLoading = false,
+  domainPackElementsError = null,
+  onOpenDomainPackElement,
   onClose,
 }: MessageDetailPanelProps) {
   const slots = domainPackElements?.slots ?? [];
   const policies = domainPackElements?.policies ?? [];
   const risks = domainPackElements?.risks ?? [];
-  const hasDomainPackElements = slots.length > 0 || policies.length > 0 || risks.length > 0;
-  const roleLabel = message ? getChatRolePresentation(message.senderRole).label : "";
+  const hasDomainPackElements =
+    !isDomainPackElementsLoading &&
+    !domainPackElementsError &&
+    (slots.length > 0 || policies.length > 0 || risks.length > 0);
+  const roleLabel = message
+    ? getChatRolePresentation(message.senderRole).label
+    : "";
 
   if (!message) {
     return (
@@ -129,31 +205,77 @@ export function MessageDetailPanel({
         <p className={styles.messagePreview}>{message.content}</p>
       </div>
 
-      {hasDomainPackElements ? (
+      {isDomainPackElementsLoading ? (
+        <div
+          className={styles.domainEmpty}
+          data-testid="message-domain-loading"
+          role="status"
+        >
+          <LoaderCircle size={28} className={styles.domainLoadingIcon} />
+          <strong>근거를 불러오는 중입니다</strong>
+          <p>선택한 메시지와 연결된 도메인팩 요소를 확인하고 있습니다.</p>
+        </div>
+      ) : domainPackElementsError ? (
+        <div
+          className={styles.domainEmpty}
+          data-testid="message-domain-error"
+          role="alert"
+        >
+          <AlertCircle size={28} className={styles.domainEmptyIcon} />
+          <strong>근거를 불러오지 못했습니다</strong>
+          <p>{domainPackElementsError}</p>
+        </div>
+      ) : hasDomainPackElements ? (
         <>
-          <Section title="확인 항목" emptyText="확인된 항목 없음" hasItems={slots.length > 0}>
+          <Section
+            title="확인 항목"
+            emptyText="확인된 항목 없음"
+            hasItems={slots.length > 0}
+          >
             {slots.map((slot) => (
-              <SlotTagItem key={slot.name} slot={slot} />
+              <SlotTagItem
+                key={`${slot.name}-${slot.detailPath ?? ""}`}
+                slot={slot}
+                onOpen={onOpenDomainPackElement}
+              />
             ))}
           </Section>
 
-          <Section title="응대 기준" emptyText="적용된 응대 기준 없음" hasItems={policies.length > 0}>
+          <Section
+            title="응대 기준"
+            emptyText="적용된 응대 기준 없음"
+            hasItems={policies.length > 0}
+          >
             {policies.map((policy) => (
-              <PolicyTagItem key={policy.name} policy={policy} />
+              <PolicyTagItem
+                key={`${policy.name}-${policy.detailPath ?? ""}`}
+                policy={policy}
+                onOpen={onOpenDomainPackElement}
+              />
             ))}
           </Section>
 
-          <Section title="주의 사항" emptyText="감지된 주의 사항 없음" hasItems={risks.length > 0}>
+          <Section
+            title="주의 사항"
+            emptyText="감지된 주의 사항 없음"
+            hasItems={risks.length > 0}
+          >
             {risks.map((risk) => (
-              <RiskTagItem key={risk.name} risk={risk} />
+              <RiskTagItem
+                key={`${risk.name}-${risk.detailPath ?? ""}`}
+                risk={risk}
+                onOpen={onOpenDomainPackElement}
+              />
             ))}
           </Section>
         </>
       ) : (
         <div className={styles.domainEmpty} data-testid="message-domain-empty">
           <FileSearch size={28} className={styles.domainEmptyIcon} />
-          <strong>연결된 도메인 팩 요소가 없습니다</strong>
-          <p>확인 항목, 응대 기준, 주의 사항이 연결되면 이 영역에 표시됩니다.</p>
+          <strong>연결된 근거 없음</strong>
+          <p>
+            확인 항목, 응대 기준, 주의 사항이 연결되면 이 영역에 표시됩니다.
+          </p>
         </div>
       )}
 

--- a/frontend/src/pages/consultation/ui/ConsultationPage.test.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.test.tsx
@@ -5,6 +5,7 @@ import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
 import "@testing-library/jest-dom/vitest";
 import { ConsultationPage } from "./ConsultationPage";
 import { consultationApi } from "../../../features/consultation/api/consultationApi";
+import { consultationEvidenceApi } from "../../../features/consultation/api/consultationEvidenceApi";
 import { getCurrentWorkflow } from "../../../features/consultation/api/llmToolWorkflowApi";
 import { toast } from "sonner";
 import { ApiRequestError } from "@/shared/api";
@@ -173,6 +174,14 @@ vi.mock("../../../features/consultation/api/consultationApi", () => ({
       Promise.resolve({
         content: "주문번호를 확인해주시면 환불 상태를 안내드리겠습니다.",
       }),
+    ),
+  },
+}));
+
+vi.mock("../../../features/consultation/api/consultationEvidenceApi", () => ({
+  consultationEvidenceApi: {
+    getMessageDomainPackElements: vi.fn(() =>
+      Promise.resolve({ slots: [], policies: [], risks: [] }),
     ),
   },
 }));
@@ -504,6 +513,73 @@ describe("ConsultationPage", () => {
     expect(screen.getByText("환불 문의 드립니다.")).toBeInTheDocument();
     expect(consultationApi.assignSession).not.toHaveBeenCalled();
     expect(screen.getByRole("button", { name: "배정받기" })).toBeInTheDocument();
+  });
+
+  it("loads selected message domain pack evidence into the detail panel", async () => {
+    vi.mocked(consultationEvidenceApi.getMessageDomainPackElements).mockResolvedValueOnce({
+      slots: [{ name: "주문 번호", extracted: true, value: "ORD-1" }],
+      policies: [{ name: "환불 정책", extracted: true, matched: true }],
+      risks: [{ name: "고액 환불", extracted: true, level: "high" }],
+    });
+
+    render(<ConsultationPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("김민지")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("김민지"));
+
+    await waitFor(() => {
+      expect(screen.getByText("환불 문의 드립니다.")).toBeInTheDocument();
+    });
+
+    const messageItem = screen.getByText("환불 문의 드립니다.").closest('[role="button"]');
+    if (messageItem) {
+      fireEvent.click(messageItem);
+    }
+
+    await waitFor(() => {
+      expect(consultationEvidenceApi.getMessageDomainPackElements).toHaveBeenCalledWith(1, 100, {
+        workspaceId: 2,
+        packId: null,
+        versionId: null,
+      });
+    });
+    expect(screen.getByText("주문 번호")).toBeInTheDocument();
+    expect(screen.getByText("ORD-1")).toBeInTheDocument();
+    expect(screen.getByText("환불 정책")).toBeInTheDocument();
+    expect(screen.getByText("고액 환불")).toBeInTheDocument();
+  });
+
+  it("keeps the consultation page usable when selected message evidence fails to load", async () => {
+    vi.mocked(consultationEvidenceApi.getMessageDomainPackElements).mockRejectedValueOnce(
+      new Error("evidence failed"),
+    );
+
+    render(<ConsultationPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("김민지")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("김민지"));
+
+    await waitFor(() => {
+      expect(screen.getByText("환불 문의 드립니다.")).toBeInTheDocument();
+    });
+
+    const messageItem = screen.getByText("환불 문의 드립니다.").closest('[role="button"]');
+    if (messageItem) {
+      fireEvent.click(messageItem);
+    }
+
+    await waitFor(() => {
+      expect(screen.getByTestId("message-domain-error")).toHaveTextContent(
+        "근거를 불러오지 못했습니다",
+      );
+    });
+    expect(screen.getByPlaceholderText("메시지를 입력하세요...")).toBeInTheDocument();
   });
 
   it("loads previous message pages from the top of the live chat", async () => {
@@ -1774,7 +1850,7 @@ describe("ConsultationPage", () => {
     fireEvent.click(messageEl);
 
     await waitFor(() => {
-      expect(screen.getByText("연결된 도메인 팩 요소가 없습니다")).toBeInTheDocument();
+      expect(screen.getByText("연결된 근거 없음")).toBeInTheDocument();
     });
 
     fireEvent.click(screen.getByText("닫기"));
@@ -1802,7 +1878,7 @@ describe("ConsultationPage", () => {
     fireEvent.click(messageEl);
 
     await waitFor(() => {
-      expect(screen.getByText("연결된 도메인 팩 요소가 없습니다")).toBeInTheDocument();
+      expect(screen.getByText("연결된 근거 없음")).toBeInTheDocument();
     });
 
     fireEvent.click(messageEl);
@@ -1832,7 +1908,7 @@ describe("ConsultationPage", () => {
     await user.keyboard("{Enter}");
 
     await waitFor(() => {
-      expect(screen.getByText("연결된 도메인 팩 요소가 없습니다")).toBeInTheDocument();
+      expect(screen.getByText("연결된 근거 없음")).toBeInTheDocument();
     });
 
     messageButton.focus();
@@ -1863,7 +1939,7 @@ describe("ConsultationPage", () => {
     await user.keyboard(" ");
 
     await waitFor(() => {
-      expect(screen.getByText("연결된 도메인 팩 요소가 없습니다")).toBeInTheDocument();
+      expect(screen.getByText("연결된 근거 없음")).toBeInTheDocument();
     });
   });
 
@@ -2070,7 +2146,7 @@ describe("ConsultationPage", () => {
     fireEvent.click(messageEl);
 
     await waitFor(() => {
-      expect(screen.getByText("연결된 도메인 팩 요소가 없습니다")).toBeInTheDocument();
+      expect(screen.getByText("연결된 근거 없음")).toBeInTheDocument();
     });
 
     vi.mocked(consultationApi.getMessagePage).mockResolvedValueOnce({
@@ -2086,7 +2162,7 @@ describe("ConsultationPage", () => {
 
     await waitFor(() => {
       expect(screen.getByText("고객 정보")).toBeInTheDocument();
-      expect(screen.queryByText("연결된 도메인 팩 요소가 없습니다")).not.toBeInTheDocument();
+      expect(screen.queryByText("연결된 근거 없음")).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/src/pages/consultation/ui/ConsultationPage.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.tsx
@@ -19,6 +19,10 @@ import {
 } from "../../../features/consultation/lib/chatRoleLabels";
 import { formatWaitDuration } from "../../../features/consultation/lib/formatWaitDuration";
 import { consultationApi } from "../../../features/consultation/api/consultationApi";
+import {
+  consultationEvidenceApi,
+  type MessageDomainPackElements,
+} from "../../../features/consultation/api/consultationEvidenceApi";
 import type {
   ChatSession,
   ConsultationSessionStatus,
@@ -636,6 +640,13 @@ export const ConsultationPage: React.FC = () => {
   const [memos, setMemos] = useState<Record<string, string>>({});
   const [composerDrafts, setComposerDrafts] = useState<Record<string, ChatComposerDraft>>({});
   const [selectedMessageId, setSelectedMessageId] = useState<string | null>(null);
+  const [messageDomainPackElements, setMessageDomainPackElements] =
+    useState<MessageDomainPackElements>();
+  const [isMessageDomainPackElementsLoading, setIsMessageDomainPackElementsLoading] =
+    useState(false);
+  const [messageDomainPackElementsError, setMessageDomainPackElementsError] = useState<
+    string | null
+  >(null);
   const [isQueueLoading, setIsQueueLoading] = useState(false);
   const [queueLoadError, setQueueLoadError] = useState<string | null>(null);
   const [matchedWorkflow, setMatchedWorkflow] = useState<MatchedWorkflow | null>(null);
@@ -773,6 +784,9 @@ export const ConsultationPage: React.FC = () => {
     setMessages([]);
     setMessagesCustomerId(null);
     setMessagePagination({ nextPage: 0, totalPages: 0, isLoadingPrevious: false });
+    setMessageDomainPackElements(undefined);
+    setIsMessageDomainPackElementsLoading(false);
+    setMessageDomainPackElementsError(null);
     setMatchedWorkflow(null);
     setIsMatchedWorkflowLoading(false);
     setIsDraftResponseLoading(false);
@@ -1175,6 +1189,66 @@ export const ConsultationPage: React.FC = () => {
       cancelled = true;
     };
   }, [activeCustomerId, clearPendingMessages]);
+
+  useEffect(() => {
+    if (!activeCustomerId || !selectedMessage) {
+      setMessageDomainPackElements(undefined);
+      setIsMessageDomainPackElementsLoading(false);
+      setMessageDomainPackElementsError(null);
+      return;
+    }
+
+    const sessionId = Number(activeCustomerId);
+    const messageId = Number(selectedMessage.id);
+    if (!Number.isInteger(sessionId) || !Number.isInteger(messageId)) {
+      setMessageDomainPackElements({ slots: [], policies: [], risks: [] });
+      setIsMessageDomainPackElementsLoading(false);
+      setMessageDomainPackElementsError(null);
+      return;
+    }
+
+    let cancelled = false;
+    setMessageDomainPackElements(undefined);
+    setIsMessageDomainPackElementsLoading(true);
+    setMessageDomainPackElementsError(null);
+
+    const routeWorkspaceId =
+      workspaceId ?? (workspacePathId ? Number.parseInt(workspacePathId, 10) : null);
+    void consultationEvidenceApi
+      .getMessageDomainPackElements(
+        sessionId,
+        messageId,
+        routeWorkspaceId
+          ? {
+              workspaceId: routeWorkspaceId,
+              packId: matchedWorkflow?.domainPackId ?? null,
+              versionId: matchedWorkflow?.domainPackVersionId ?? null,
+            }
+          : null,
+      )
+      .then((elements) => {
+        if (cancelled) return;
+        setMessageDomainPackElements(elements);
+        setMessageDomainPackElementsError(null);
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        console.error("Failed to load message domain pack elements:", error);
+        setMessageDomainPackElements({ slots: [], policies: [], risks: [] });
+        setMessageDomainPackElementsError(
+          "상담은 계속 진행할 수 있습니다. 잠시 후 메시지를 다시 선택해 주세요.",
+        );
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setIsMessageDomainPackElementsLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activeCustomerId, matchedWorkflow, selectedMessage, workspaceId, workspacePathId]);
 
   const handleLoadPreviousMessages = useCallback(async () => {
     if (
@@ -1721,6 +1795,10 @@ export const ConsultationPage: React.FC = () => {
           {selectedMessage ? (
             <MessageDetailPanel
               message={selectedMessage}
+              domainPackElements={messageDomainPackElements}
+              isDomainPackElementsLoading={isMessageDomainPackElementsLoading}
+              domainPackElementsError={messageDomainPackElementsError}
+              onOpenDomainPackElement={(path) => navigate(path)}
               onClose={() => setSelectedMessageId(null)}
             />
           ) : (


### PR DESCRIPTION
Closes #631

## 변경 사항

- 상담 메시지 상세 패널에서 선택한 메시지와 연결된 slot, policy, risk 근거를 불러오도록 연결했습니다.
- 근거 로딩, 근거 없음, 근거 조회 실패 상태를 구분해 표시하고 조회 실패 시에도 상담 화면 사용 흐름은 유지되도록 했습니다.
- 근거 요소에 domain pack version 경로를 구성할 수 있으면 상세 화면으로 이동할 수 있도록 클릭 동작을 연결했습니다.
- backend에 상담 세션/메시지 소유권을 검증한 뒤 최신 workflow execution의 runtime state에서 메시지 근거 요소를 반환하는 조회 API를 추가했습니다.
- 새 수동 API wrapper를 frontend API audit allowlist에 등록하고, 이슈 631 스펙을 `.agent/specs/631.md`에 정리했습니다.

## 검증

- `git diff --check`
- `pnpm exec prettier --check .agent/specs/631.md frontend/scripts/manual-api-call-allowlist.json`
- `pnpm --dir frontend audit:api`
- `cd backend && ./gradlew test --tests com.init.workflowruntime.application.ConsultationEvidenceServiceTest --tests com.init.workflowruntime.presentation.ConsultationControllerTest`
- `pnpm --dir frontend test -- consultationEvidenceApi.test.ts MessageDetailPanel.test.tsx ConsultationPage.test.tsx`
- `pnpm --dir frontend exec eslint src/features/consultation/api/consultationEvidenceApi.ts src/features/consultation/api/consultationEvidenceApi.test.ts src/features/consultation/ui/MessageDetailPanel.tsx src/features/consultation/ui/MessageDetailPanel.test.tsx src/pages/consultation/ui/ConsultationPage.tsx src/pages/consultation/ui/ConsultationPage.test.tsx`
- `pnpm run ci:frontend`
- `pnpm run format:backend:check`
- `cd backend && ./gradlew checkstyleMain checkstyleTest`

## 참고

- 최초 커밋 시 pre-commit hook은 backend staged 파일 절대경로가 Gradle 태스크 인자로 전달되어 실패했습니다. 이후 backend Spotless와 변경 frontend 파일 ESLint, frontend CI 경로를 별도로 통과 확인했습니다.