### PR TITLE
fix(consultation): 운영자 화면 메시지 순서 race condition 방지 (#557)

### DIFF
--- a/.agent/specs/557.md
+++ b/.agent/specs/557.md
@@ -1,0 +1,53 @@
+# 운영자 화면 메시지 순서 race condition 방지
+
+## Goal
+
+운영자 상담 화면(`ConsultationPage`)에서 사용자 메시지와 챗봇/상담사 응답이 항상 서버가 확정한 순서대로 표시되도록 하여, 거의 동시에 도착하거나 역순으로 도착하는 실시간 이벤트에서도 메시지 순서가 뒤바뀌지 않게 한다.
+
+## Problem
+
+운영자 화면은 REST 스냅샷, WebSocket 실시간 이벤트, optimistic(상담사 전송) 메시지를 함께 다룬다. 현재 정렬(`sortMessagesByServerOrder`)은 서버 `seqNo`가 양쪽 메시지에 모두 있을 때만 순서를 보장하고, 한쪽이라도 `seqNo`가 없으면 **도착(삽입) 순서로 fallback** 한다. 따라서 WebSocket 이벤트가 `seqNo` 없이 역순으로 도착하면 화면 순서가 그대로 뒤집힌다. 또한 `toUiMessage`가 raw `createdAt`을 버리고 표시용 `"HH:MM"` 값만 남겨서 시간 기반 fallback 자체가 불가능하며, 동일 `seqNo`·동일 시각에 대한 tie-breaker가 없다.
+
+## Scope
+
+- `frontend/src/features/consultation/lib/messageOrder.ts` (신규)
+- `frontend/src/features/consultation/lib/messageOrder.test.ts` (신규)
+- `frontend/src/features/consultation/ui/ChatPanel.tsx` (`ChatMessage` 타입에 정렬용 `createdAt` 추가)
+- `frontend/src/pages/consultation/ui/ConsultationPage.tsx` (`toUiMessage`에서 `createdAt` 보존, 정렬 로직을 공유 lib으로 이관)
+- `frontend/src/pages/consultation/ui/ConsultationPage.test.tsx` (회귀 테스트 추가)
+
+## Non-Goals
+
+- 사용자(고객) 채팅 화면 및 공유 모듈 `entities/chat/lib/chatMessageSync.ts`의 정렬 정비 → #670 에서 별도 진행한다.
+- 백엔드의 `seqNo` 채번/발급 로직은 변경하지 않는다(현행 서버 `seqNo`를 신뢰).
+- 메시지 페이지네이션(이전 메시지 로드) 및 WebSocket 연결/재연결 동작은 변경하지 않는다.
+
+## Current Contract
+
+| 영역 | 확인된 파일 | 현재 상태 |
+| --- | --- | --- |
+| 메시지 정렬 | `ConsultationPage.tsx` (`sortMessagesByServerOrder`) | `seqNo`가 양쪽에 있을 때만 순서 보장, 없으면 삽입 순서 fallback |
+| 메시지 변환 | `ConsultationPage.tsx` (`toUiMessage`) | raw `createdAt`을 버리고 `"HH:MM"` 표시값만 보존 |
+| 실시간 수신 | `ConsultationPage.tsx` (`/topic/chat.*` 구독) | 신규 메시지를 append 후 `sortMessagesByServerOrder`로 정렬 |
+| 메시지 타입 | `ChatPanel.tsx` (`ChatMessage`) | `seqNo?`는 있으나 `createdAt`은 없음 |
+
+## Design Diff
+
+| 영역 | As-is | To-be |
+| --- | --- | --- |
+| 정렬 기준 | `seqNo`(양쪽 존재 시) → 삽입 순서 | `seqNo` → `createdAt` → 안정 tie-breaker(원래 순서) |
+| `seqNo` 누락 | 삽입(도착) 순서로 fallback → 역순 도착 시 뒤집힘 | `createdAt`으로 안정 정렬, 둘 다 없으면 원래 순서 유지 |
+| `createdAt` 보존 | 표시값(`"HH:MM"`)만 남김 | 정렬용 raw ISO `createdAt`을 메시지에 보존(표시는 그대로) |
+| 정렬 위치 | `ConsultationPage` 내부 함수 | `features/consultation/lib/messageOrder.ts`로 이관(단위 테스트 가능) |
+
+## Requirements
+
+- 사용자 메시지와 AI/상담사 메시지는 서버가 확정한 `seqNo` 순서대로 표시된다.
+- WebSocket 이벤트가 `seqNo` 없이 역순으로 도착해도 `createdAt` 기준으로 안정적으로 정렬된다.
+- optimistic 메시지가 서버 echo와 병합될 때 순서가 뒤틀리지 않는다(`seqNo`·`createdAt`이 없는 메시지는 원래(전송) 순서를 유지).
+- 동일 `seqNo` 또는 동일 시각 메시지는 원래 순서를 유지하는 안정 tie-breaker를 가진다.
+
+## Test Plan
+
+- `messageOrder.test.ts`: `seqNo` 정렬 / `seqNo` 누락 시 `createdAt` fallback / 동일 `seqNo`·시각 안정성 / optimistic(둘 다 없음) 원래 순서 유지 / 역순 입력 안정 정렬.
+- `ConsultationPage.test.tsx`: `seqNo` 없는 실시간 메시지가 역순으로 도착해도 `createdAt` 순서대로 렌더링되는 회귀 테스트.

--- a/frontend/src/features/consultation/lib/messageOrder.test.ts
+++ b/frontend/src/features/consultation/lib/messageOrder.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { compareByServerOrder, sortMessagesByServerOrder } from "./messageOrder";
+
+type TestMessage = {
+  id: string;
+  seqNo?: number;
+  createdAt?: string;
+};
+
+const ids = (messages: TestMessage[]) => messages.map((message) => message.id);
+
+describe("sortMessagesByServerOrder", () => {
+  it("orders messages by server seqNo regardless of input order", () => {
+    const sorted = sortMessagesByServerOrder<TestMessage>([
+      { id: "c", seqNo: 3 },
+      { id: "a", seqNo: 1 },
+      { id: "b", seqNo: 2 },
+    ]);
+
+    expect(ids(sorted)).toEqual(["a", "b", "c"]);
+  });
+
+  it("falls back to createdAt when seqNo is missing and events arrive out of order", () => {
+    const sorted = sortMessagesByServerOrder<TestMessage>([
+      { id: "bot", createdAt: "2026-05-27T00:00:03+09:00" },
+      { id: "user", createdAt: "2026-05-27T00:00:02+09:00" },
+    ]);
+
+    expect(ids(sorted)).toEqual(["user", "bot"]);
+  });
+
+  it("places seqNo-confirmed messages before optimistic messages without seqNo", () => {
+    const sorted = sortMessagesByServerOrder<TestMessage>([
+      { id: "optimistic" },
+      { id: "server", seqNo: 10, createdAt: "2026-05-27T00:00:01+09:00" },
+    ]);
+
+    expect(ids(sorted)).toEqual(["server", "optimistic"]);
+  });
+
+  it("keeps original order for messages that share the same seqNo", () => {
+    const sorted = sortMessagesByServerOrder<TestMessage>([
+      { id: "first", seqNo: 5 },
+      { id: "second", seqNo: 5 },
+    ]);
+
+    expect(ids(sorted)).toEqual(["first", "second"]);
+  });
+
+  it("keeps original order for optimistic messages without seqNo or createdAt", () => {
+    const sorted = sortMessagesByServerOrder<TestMessage>([
+      { id: "sending-1" },
+      { id: "sending-2" },
+      { id: "sending-3" },
+    ]);
+
+    expect(ids(sorted)).toEqual(["sending-1", "sending-2", "sending-3"]);
+  });
+
+  it("uses createdAt as a tie-breaker when seqNo is equal", () => {
+    const sorted = sortMessagesByServerOrder<TestMessage>([
+      { id: "later", seqNo: 7, createdAt: "2026-05-27T00:00:05+09:00" },
+      { id: "earlier", seqNo: 7, createdAt: "2026-05-27T00:00:01+09:00" },
+    ]);
+
+    expect(ids(sorted)).toEqual(["earlier", "later"]);
+  });
+});
+
+describe("compareByServerOrder", () => {
+  it("returns 0 when neither seqNo nor createdAt distinguishes the messages", () => {
+    expect(compareByServerOrder({}, {})).toBe(0);
+  });
+
+  it("falls back to original order when createdAt is unparseable", () => {
+    expect(compareByServerOrder({ createdAt: "not-a-date" }, { createdAt: "also-bad" })).toBe(0);
+  });
+});

--- a/frontend/src/features/consultation/lib/messageOrder.ts
+++ b/frontend/src/features/consultation/lib/messageOrder.ts
@@ -1,0 +1,55 @@
+/**
+ * 운영자 상담 화면의 메시지 정렬 기준.
+ *
+ * 서버가 확정한 `seqNo`를 1순위로 사용하고, `seqNo`가 없으면 `createdAt`으로
+ * 안정 정렬한다. 둘 다 구분되지 않으면(같은 `seqNo`/같은 시각, 또는 optimistic
+ * 메시지처럼 둘 다 없는 경우) 원래(입력) 순서를 유지하는 안정 tie-breaker를 둔다.
+ * 이렇게 하면 WebSocket 이벤트가 역순으로 도착하거나 거의 동시에 도착해도
+ * 화면 순서가 뒤바뀌지 않는다.
+ */
+export interface ServerOrderableMessage {
+  seqNo?: number;
+  createdAt?: string;
+}
+
+// seqNo가 없는 메시지(optimistic 등)는 seqNo가 있는 서버 확정 메시지 뒤로 보낸다.
+const SEQ_NO_FALLBACK = Number.POSITIVE_INFINITY;
+
+const toComparableTime = (createdAt?: string): number => {
+  if (!createdAt) return Number.POSITIVE_INFINITY;
+  const time = new Date(createdAt).getTime();
+  return Number.isNaN(time) ? Number.POSITIVE_INFINITY : time;
+};
+
+/**
+ * 두 메시지의 서버 순서를 비교한다. 0이면 순서를 구분할 수 없으므로
+ * 호출 측에서 원래 순서를 안정 tie-breaker로 사용해야 한다.
+ */
+export const compareByServerOrder = (
+  a: ServerOrderableMessage,
+  b: ServerOrderableMessage,
+): number => {
+  const seqA = a.seqNo ?? SEQ_NO_FALLBACK;
+  const seqB = b.seqNo ?? SEQ_NO_FALLBACK;
+  if (seqA !== seqB) return seqA - seqB;
+
+  const timeA = toComparableTime(a.createdAt);
+  const timeB = toComparableTime(b.createdAt);
+  if (timeA !== timeB) return timeA - timeB;
+
+  return 0;
+};
+
+/**
+ * `seqNo → createdAt → 원래 순서` 기준으로 메시지를 안정 정렬한다.
+ */
+export const sortMessagesByServerOrder = <T extends ServerOrderableMessage>(
+  messages: T[],
+): T[] =>
+  messages
+    .map((message, index) => ({ message, index }))
+    .sort((a, b) => {
+      const byServerOrder = compareByServerOrder(a.message, b.message);
+      return byServerOrder !== 0 ? byServerOrder : a.index - b.index;
+    })
+    .map(({ message }) => message);

--- a/frontend/src/features/consultation/ui/ChatPanel.tsx
+++ b/frontend/src/features/consultation/ui/ChatPanel.tsx
@@ -12,6 +12,8 @@ export type MessageDeliveryStatus = "sending" | "sent" | "failed";
 export interface ChatMessage {
   id: string;
   seqNo?: number;
+  /** 서버 확정 순서 정렬용 raw ISO 타임스탬프. 표시에는 `timestamp`를 사용한다. */
+  createdAt?: string;
   senderRole: ChatSenderRole;
   content: string;
   timestamp: string;

--- a/frontend/src/pages/consultation/ui/ConsultationPage.test.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.test.tsx
@@ -2265,6 +2265,46 @@ describe("ConsultationPage", () => {
     });
   });
 
+  it("keeps createdAt order when seqNo-less realtime messages arrive out of order", async () => {
+    render(<ConsultationPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("김민지")).toBeInTheDocument();
+    });
+
+    const customerItem = screen.getByText("김민지").closest("div");
+    if (customerItem) customerItem.click();
+
+    await waitFor(() => {
+      expect(screen.getByText("환불 문의 드립니다.")).toBeInTheDocument();
+      expect(stompState.callbacks.has("/topic/chat.1")).toBe(true);
+    });
+
+    // 서버가 seqNo를 싣지 않은 채 챗봇 응답이 사용자 응답보다 먼저 도착(역순)해도
+    // createdAt 기준으로 사용자 응답이 먼저 렌더링되어야 한다.
+    act(() => {
+      stompState.callbacks.get("/topic/chat.1")?.({
+        id: 402,
+        senderRole: "ASSISTANT",
+        content: "역순 챗봇 메시지.",
+        createdAt: "2026-05-27T00:00:09+09:00",
+      });
+      stompState.callbacks.get("/topic/chat.1")?.({
+        id: 401,
+        senderRole: "CUSTOMER",
+        content: "역순 사용자 메시지.",
+        createdAt: "2026-05-27T00:00:08+09:00",
+      });
+    });
+
+    const messageList = screen.getByTestId("chat-message-list");
+    await waitFor(() => {
+      expect(messageList).toHaveTextContent(
+        /역순 사용자 메시지\.[\s\S]*역순 챗봇 메시지\./,
+      );
+    });
+  });
+
   it("handles counselor echo and replaces the pending optimistic message", async () => {
     const user = userEvent.setup();
     render(<ConsultationPage />, { wrapper: Wrapper });

--- a/frontend/src/pages/consultation/ui/ConsultationPage.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.tsx
@@ -18,6 +18,7 @@ import {
   type ChatSenderRole,
 } from "../../../features/consultation/lib/chatRoleLabels";
 import { formatWaitDuration } from "../../../features/consultation/lib/formatWaitDuration";
+import { sortMessagesByServerOrder } from "../../../features/consultation/lib/messageOrder";
 import { consultationApi } from "../../../features/consultation/api/consultationApi";
 import {
   consultationEvidenceApi,
@@ -194,30 +195,17 @@ const findResolutionOutcomeOption = (outcome: ResolutionOutcome | null) =>
   RESOLUTION_OUTCOME_OPTIONS.find((option) => option.value === outcome) ?? null;
 
 const toUiMessage = (message: MessageLike): UiChatMessage => {
-  const createdAt = message.createdAt ?? message.timestamp ?? new Date().toISOString();
+  const rawCreatedAt = message.createdAt ?? message.timestamp ?? null;
+  const displayCreatedAt = rawCreatedAt ?? new Date().toISOString();
   return {
-    id: String(message.id ?? `message-${createdAt}-${message.content ?? ""}`),
+    id: String(message.id ?? `message-${displayCreatedAt}-${message.content ?? ""}`),
     ...(message.seqNo != null ? { seqNo: message.seqNo } : {}),
+    ...(rawCreatedAt != null ? { createdAt: rawCreatedAt } : {}),
     senderRole: normalizeChatSenderRole(message.senderRole),
     content: message.content ?? "",
-    timestamp: formatTime(createdAt),
+    timestamp: formatTime(displayCreatedAt),
   };
 };
-
-const sortMessagesByServerOrder = (messages: UiChatMessage[]) =>
-  messages
-    .map((message, index) => ({ message, index }))
-    .sort((a, b) => {
-      const leftSeqNo = a.message.seqNo;
-      const rightSeqNo = b.message.seqNo;
-      if (leftSeqNo != null && rightSeqNo != null && leftSeqNo !== rightSeqNo) {
-        return leftSeqNo - rightSeqNo;
-      }
-      if (leftSeqNo != null && rightSeqNo == null) return -1;
-      if (leftSeqNo == null && rightSeqNo != null) return 1;
-      return a.index - b.index;
-    })
-    .map(({ message }) => message);
 
 const mergeMessagesById = (
   currentMessages: UiChatMessage[],


### PR DESCRIPTION
## 개요

운영자 상담 화면(`ConsultationPage`)에서 사용자 메시지와 챗봇/상담사 응답이 거의 동시에 또는 역순으로 도착할 때 표시 순서가 뒤바뀌는 race condition을 방지한다.

Closes #557

## 문제

기존 정렬(`sortMessagesByServerOrder`)은 서버 `seqNo`가 **양쪽 메시지에 모두** 있을 때만 순서를 보장하고, 한쪽이라도 `seqNo`가 없으면 **도착(삽입) 순서로 fallback** 했다. 따라서 WebSocket 이벤트가 `seqNo` 없이 역순으로 도착하면 화면 순서가 그대로 뒤집힌다. 또한 `toUiMessage`가 raw `createdAt`을 버리고 표시용 `"HH:MM"` 값만 남겨 시간 기반 fallback이 불가능했고, 동일 `seqNo`·동일 시각 tie-breaker도 없었다.

## 변경 사항

- 정렬 기준을 **`seqNo` → `createdAt` → 원래 순서(안정 tie-breaker)** 로 강화.
  - `seqNo`가 없으면 `createdAt`으로 안정 정렬 → 역순 도착에도 순서 보존.
  - 동일 `seqNo`/동일 시각이거나 `seqNo`·`createdAt`이 모두 없는 optimistic 메시지는 원래(전송) 순서 유지.
- 정렬 로직을 `features/consultation/lib/messageOrder.ts`로 이관해 단위 테스트가 가능하도록 분리.
- `toUiMessage`가 정렬용 raw ISO `createdAt`을 보존(표시는 기존 `"HH:MM"` 유지).
- `ChatPanel`의 `ChatMessage` 타입에 정렬용 `createdAt?` 추가.

## 테스트

- `messageOrder.test.ts` (신규, 8 케이스): `seqNo` 정렬 / `seqNo` 누락 시 `createdAt` fallback / `seqNo`-확정 메시지가 optimistic보다 앞 / 동일 `seqNo` 원래 순서 / optimistic 원래 순서 / 동일 `seqNo`일 때 `createdAt` tie-break / 파싱 불가 `createdAt` 처리.
- `ConsultationPage.test.tsx` (회귀 추가): `seqNo` 없는 실시간 메시지가 역순으로 도착해도 `createdAt` 순서대로 렌더링됨.
- `pnpm --dir frontend` 기준 `messageOrder`(8) + `ConsultationPage`(78) + `ConsultationPage.generated-api`/`ChatPanel`(32) 통과, `tsc -b` 통과.

## 범위 / 비고

- 사용자(고객) 채팅 화면 및 공유 모듈 `entities/chat/lib/chatMessageSync.ts`의 동일 결함은 별도 이슈 **#670** 에서 진행한다(본 PR 범위 제외).
- 백엔드 `seqNo` 채번 로직, 페이지네이션, WebSocket 연결 동작은 변경하지 않는다.
- 참고: 저장소 전체 대상 pre-commit `eslint .` 훅은 본 PR과 무관한 기존 lint 오류(`PackWorkflowListPage.tsx` 등)로 실패하지만, CI(`ci:frontend` = 테스트 + 빌드)에는 영향이 없으며 변경 파일은 lint-clean이다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 운영자 상담 화면의 메시지가 서버 확정 순서(시퀀스 번호 또는 생성 시간 기준)에 따라 일관되게 정렬되어 표시됩니다. 네트워크 지연으로 메시지 순서가 뒤바뀐 경우에도 올바르게 정렬됩니다.

* **Tests**
  * 메시지 정렬 기능의 다양한 시나리오에 대한 테스트 케이스가 추가되었습니다.

* **Documentation**
  * 메시지 정렬 요구사항 및 설계 변경이 문서화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->