### PR TITLE
refactor(ml): publish_candidate callback 상태를 명시

### DIFF
--- a/.agent/specs/616.md
+++ b/.agent/specs/616.md
@@ -1,0 +1,94 @@
+# publish_candidate callback 상태 모델 분리
+
+## Goal
+
+`publish_candidate` stage가 Spring callback 진행 상태와 publish result artifact를 명시적인 typed model로 관리하도록 하여 retry/resume과 장애 분석 시 callback 상태 전이를 추적하기 쉽게 만든다.
+
+## Problem
+
+`ml/src/pipeline/stages/publish_candidate/main.py`는 Spring callback payload 생성, callback 실행, publish result JSON 갱신을 한 흐름에서 `dict` mutation 중심으로 처리한다. 이 구조에서는 성공한 callback 재사용, 실패한 callback 기록, callback disabled 상태가 어떤 artifact contract로 남는지 코드에서 분리해 확인하기 어렵고, payload contract 변경 여부도 fixture로 고정되어 있지 않다.
+
+## Scope
+
+- `publish_candidate` 결과 상태를 typed model로 정리한다.
+- Spring callback payload builder 책임과 stage result writer 책임을 분리한다.
+- retry/resume 시 이미 성공한 callback은 재호출하지 않고 저장된 domain pack context를 재사용하는 규칙을 모델 메서드로 드러낸다.
+- 기존 Spring callback payload key와 result artifact key를 유지한다.
+- callback payload fixture 기반 contract test를 추가한다.
+- success/failure/retry 상태별 publish candidate 테스트를 보강한다.
+
+## Non-goals
+
+- Spring backend callback endpoint, HTTP method, request/response contract를 변경하지 않는다.
+- `candidate.json` schema version 또는 draft artifact 구조를 변경하지 않는다.
+- Airflow DAG task 순서나 stage orchestration을 변경하지 않는다.
+- 신규 runtime dependency를 추가하지 않는다.
+- 다중 domain pack candidate publish를 다시 도입하지 않는다.
+
+## Affected Paths
+
+- `ml/src/pipeline/stages/publish_candidate/main.py`
+- `ml/src/pipeline/stages/publish_candidate/payloads.py`
+- `ml/src/pipeline/stages/publish_candidate/state.py`
+- `ml/tests/stages/test_publish_candidate_main.py`
+- `ml/tests/fixtures/publish_candidate/callback_payload_contract.json`
+- `.agent/specs/616.md`
+
+## Stage Interface
+
+### Input
+
+| Artifact           | 필드                            | 타입         | 설명                                          |
+| ------------------ | ------------------------------- | ------------ | --------------------------------------------- |
+| upstream manifest  | `payload.candidateArtifactPath` | str          | publish 대상 candidate artifact 경로이다.     |
+| candidate artifact | `domainPackDraft`               | object       | domain pack callback payload 생성에 사용한다. |
+| candidate artifact | `intentDraft.intents`           | list[object] | intent callback payload 생성에 사용한다.      |
+| candidate artifact | `workflowDraft`                 | object       | workflow callback payload 생성에 사용한다.    |
+
+### Output
+
+| Artifact                        | 필드                                               | 타입         | 설명                                                                                   |
+| ------------------------------- | -------------------------------------------------- | ------------ | -------------------------------------------------------------------------------------- |
+| `publish_candidate_result.json` | `publishStatus`                                    | str          | `PENDING`, `RUNNING`, `SUCCEEDED`, `FAILED`, `SKIPPED` 상태를 기록한다.                |
+| `publish_candidate_result.json` | `callbackResults`                                  | list[object] | callback type, external event id, HTTP status, response status/body, scope를 기록한다. |
+| `publish_candidate_result.json` | `domainPackId`, `domainPackVersionId`, `versionNo` | int/null     | domain pack callback 응답에서 얻은 Spring context이다.                                 |
+| `publish_candidate_result.json` | `failedCallbackType`                               | str/null     | 실패한 callback type을 기록한다.                                                       |
+| `publish_candidate_result.json` | `error`                                            | object/null  | callback 또는 stage 실패 원인을 기록한다.                                              |
+
+## Requirements
+
+1. publish result state는 typed model을 통해 생성, 로드, 변경, 직렬화되어야 한다.
+2. result artifact writer는 `main.py`의 callback payload builder와 분리되어야 한다.
+3. `domain-pack-drafts`, `intent-drafts`, `workflow-drafts` payload builder는 기존 JSON key와 value shape을 유지해야 한다.
+4. retry/resume 시 성공 기록이 남은 callback은 재호출하지 않아야 한다.
+5. retry/resume 시 `domainPackVersionId`는 저장된 result state 또는 성공한 domain pack callback 응답에서 복구되어야 한다.
+6. callback disabled 상태는 `SKIPPED`, `skipReason=CALLBACK_DISABLED`, empty `callbackResults`로 기록되어야 한다.
+7. callback response status가 허용 목록 밖이면 다음 callback을 호출하지 않고 `FAILED` state와 error object를 기록해야 한다.
+8. domain pack callback context를 복구할 수 없으면 `failedCallbackType=domain-pack-drafts`로 실패해야 한다.
+9. payload fixture contract test가 domain/intent/workflow callback payload를 검증해야 한다.
+10. success, failure, retry/resume 상태별 테스트가 result artifact와 callback 호출 순서를 검증해야 한다.
+
+## Data/API Impact
+
+- Spring callback payload contract는 유지한다.
+- `publish_candidate_result.json`의 기존 key는 유지한다.
+- 신규 DB migration, backend/frontend API 변경, Airflow DAG 변경은 없다.
+
+## Acceptance Criteria
+
+- `publish_candidate` 정상 실행 시 result artifact에 `SUCCEEDED`와 세 callback result가 기록된다.
+- 기존 domain pack callback 성공 기록이 있는 retry 실행은 `intent-drafts`, `workflow-drafts`만 호출한다.
+- domain pack callback response에 `domainPackVersionId`가 없으면 `FAILED`와 `failedCallbackType=domain-pack-drafts`가 기록된다.
+- 예상하지 못한 callback response status에서는 다음 callback이 호출되지 않는다.
+- callback disabled 실행은 기존처럼 `SKIPPED` manifest/result를 반환한다.
+- fixture 기반 callback payload contract test가 통과한다.
+
+## Validation
+
+- `cd ml && uv run pytest tests/stages/test_publish_candidate_main.py`
+- 필요 시 `cd ml && uv run pytest`
+- diff 검토로 Spring callback payload key, result artifact key, 신규 dependency 미추가 여부 확인
+
+## Open Questions
+
+- 없음. 이슈 본문과 현재 `publish_candidate` contract로 변경 범위를 결정하기에 충분하다.

--- a/ml/src/pipeline/stages/publish_candidate/main.py
+++ b/ml/src/pipeline/stages/publish_candidate/main.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import copy
-import hashlib
 import json
 from pathlib import Path
 from typing import Any, cast
@@ -12,21 +10,24 @@ from pipeline.common.config import PipelineRuntimeConfig
 from pipeline.common.context import StageContext
 from pipeline.common.exceptions import PipelineConfigurationError, PipelineStageError
 from pipeline.stages.preprocessing.io import read_stage_context
+from pipeline.stages.publish_candidate import payloads
+from pipeline.stages.publish_candidate.state import (
+    SUCCESS_RESPONSE_STATUSES,
+    DomainPackContextLost,
+    PublishCandidateResult,
+    PublishCandidateResultWriter,
+)
 
 SCHEMA_VERSION = "1.0"
 EVIDENCE_JSON_MAX_LEN = 5000
 _ALLOWED_EVIDENCE_TYPES = frozenset({"keyword", "exemplar_conv_id", "member_conv_id"})
-CALLBACK_DOMAIN_PACK = "domain-pack-drafts"
-CALLBACK_INTENT = "intent-drafts"
-CALLBACK_WORKFLOW = "workflow-drafts"
-SUCCESS_RESPONSE_STATUSES = {"CREATED", "DUPLICATE_IGNORED", "OK", "SUCCEEDED"}
-WORKFLOW_LIST_KEYS = (
-    "slots",
-    "policies",
-    "risks",
-    "workflows",
-    "intentSlotBindings",
-)
+CALLBACK_DOMAIN_PACK = payloads.CALLBACK_DOMAIN_PACK
+CALLBACK_INTENT = payloads.CALLBACK_INTENT
+CALLBACK_WORKFLOW = payloads.CALLBACK_WORKFLOW
+WORKFLOW_LIST_KEYS = payloads.WORKFLOW_LIST_KEYS
+build_domain_pack_payload = payloads.build_domain_pack_payload
+build_intent_payload = payloads.build_intent_payload
+build_workflow_payload = payloads.build_workflow_payload
 
 
 class PublishCandidateStageError(PipelineStageError):
@@ -35,61 +36,58 @@ class PublishCandidateStageError(PipelineStageError):
         self.manifest_payload = manifest_payload
 
 
-class DomainPackContextLost(PipelineStageError):
-    pass
-
-
 def run(upstream_manifest_path: str | None = None) -> dict[str, object]:
     runtime_config = PipelineRuntimeConfig.from_env()
     stage_context = read_stage_context(upstream_manifest_path, stage_name="publish_candidate")
     stage_dir = ensure_stage_directory(stage_context, runtime_config)
-    result_path = stage_dir / "publish_candidate_result.json"
-    result = _load_existing_result(result_path) or _initial_result(stage_context)
+    result_writer = PublishCandidateResultWriter(stage_dir / "publish_candidate_result.json")
+    result = result_writer.load() or PublishCandidateResult.initial(stage_context, SCHEMA_VERSION)
 
     try:
-        candidate_path = _prepare_candidate_input(upstream_manifest_path, result, result_path)
+        candidate_path = _prepare_candidate_input(upstream_manifest_path, result, result_writer)
         if runtime_config.callback_enabled:
             _validate_pipeline_job_id(stage_context.pipeline_job_id)
 
         candidate = _load_valid_candidate(candidate_path)
-        _surface_evaluation_review(candidate, result, result_path)
+        _surface_evaluation_review(candidate, result, result_writer)
 
-        if _skip_callbacks_if_disabled(runtime_config, result, result_path, candidate):
-            return _manifest_payload(result, result_path)
+        if _skip_callbacks_if_disabled(runtime_config, result, result_writer, candidate):
+            return result.manifest_payload(result_writer.path)
 
-        _mark_running(result, result_path)
-        _run_callbacks(candidate, result, result_path, stage_context, runtime_config)
-        _mark_succeeded(result, result_path)
-        return _manifest_payload(result, result_path)
+        result.mark_running()
+        result_writer.write(result)
+        _run_callbacks(candidate, result, result_writer, stage_context, runtime_config)
+        result.mark_succeeded()
+        result_writer.write(result)
+        return result.manifest_payload(result_writer.path)
     except PublishCandidateStageError:
         raise
     except PipelineCallbackError as exc:
-        result["publishStatus"] = "FAILED"
-        result["failedCallbackType"] = exc.callback_type
-        result["error"] = exc.to_error_object()
-        _write_result(result_path, result)
-        raise _stage_error(str(exc), result, result_path) from exc
+        result.mark_failed(exc.callback_type, exc.to_error_object())
+        result_writer.write(result)
+        raise _stage_error(str(exc), result, result_writer) from exc
     except (PipelineConfigurationError, PipelineStageError, OSError, json.JSONDecodeError, ValueError) as exc:
-        result["publishStatus"] = "FAILED"
-        result["failedCallbackType"] = CALLBACK_DOMAIN_PACK if isinstance(exc, DomainPackContextLost) else None
-        result["error"] = {
-            "type": type(exc).__name__,
-            "message": str(exc),
-            "responseBody": None,
-            "parsedResponseBody": None,
-        }
-        _write_result(result_path, result)
-        raise _stage_error(str(exc), result, result_path) from exc
+        result.mark_failed(
+            CALLBACK_DOMAIN_PACK if isinstance(exc, DomainPackContextLost) else None,
+            {
+                "type": type(exc).__name__,
+                "message": str(exc),
+                "responseBody": None,
+                "parsedResponseBody": None,
+            },
+        )
+        result_writer.write(result)
+        raise _stage_error(str(exc), result, result_writer) from exc
 
 
 def _prepare_candidate_input(
     upstream_manifest_path: str | None,
-    result: dict[str, Any],
-    result_path: Path,
+    result: PublishCandidateResult,
+    result_writer: PublishCandidateResultWriter,
 ) -> Path:
     candidate_path = _read_candidate_artifact_path(upstream_manifest_path)
-    result["candidateArtifactPath"] = str(candidate_path)
-    _write_result(result_path, result)
+    result.set_candidate_artifact_path(candidate_path)
+    result_writer.write(result)
     return candidate_path
 
 
@@ -99,7 +97,11 @@ def _load_valid_candidate(candidate_path: Path) -> dict[str, Any]:
     return candidate
 
 
-def _surface_evaluation_review(candidate: dict[str, Any], result: dict[str, Any], result_path: Path) -> None:
+def _surface_evaluation_review(
+    candidate: dict[str, Any],
+    result: PublishCandidateResult,
+    result_writer: PublishCandidateResultWriter,
+) -> None:
     if not _evaluation_blocked(candidate):
         return
 
@@ -118,9 +120,8 @@ def _surface_evaluation_review(candidate: dict[str, Any], result: dict[str, Any]
     if review_reasons:
         summary["qualityReviewReasons"] = review_reasons
     domain_pack_draft["summaryJson"] = json.dumps(summary, ensure_ascii=False)
-    result["evaluationGateStatus"] = "NEEDS_HUMAN_REVIEW"
-    result["evaluationGateReason"] = "evaluationSummary.passed=false"
-    _write_result(result_path, result)
+    result.mark_evaluation_needs_human_review()
+    result_writer.write(result)
 
 
 def _parse_json_object(value: object) -> dict[str, Any]:
@@ -141,58 +142,20 @@ def _string_list(value: object) -> list[str]:
 
 def _skip_callbacks_if_disabled(
     runtime_config: PipelineRuntimeConfig,
-    result: dict[str, Any],
-    result_path: Path,
+    result: PublishCandidateResult,
+    result_writer: PublishCandidateResultWriter,
     candidate: dict[str, Any],
 ) -> bool:
     if runtime_config.callback_enabled:
         return False
 
-    result.update(
-        {
-            "publishStatus": "SKIPPED",
-            "skipReason": "CALLBACK_DISABLED",
-            "domainPackId": None,
-            "domainPackVersionId": None,
-            "versionNo": None,
-            "candidateCount": len(_candidate_items(candidate)),
-            "domainPackContexts": {},
-            "failedCallbackType": None,
-            "callbackResults": [],
-            "error": None,
-        }
-    )
-    _write_result(result_path, result)
+    result.mark_skipped(len(_candidate_items(candidate)))
+    result_writer.write(result)
     return True
 
 
-def _mark_running(result: dict[str, Any], result_path: Path) -> None:
-    result["publishStatus"] = "RUNNING"
-    result["error"] = None
-    result["failedCallbackType"] = None
-    _write_result(result_path, result)
-
-
-def _mark_succeeded(result: dict[str, Any], result_path: Path) -> None:
-    result["publishStatus"] = "SUCCEEDED"
-    result["failedCallbackType"] = None
-    result["error"] = None
-    _write_result(result_path, result)
-
-
 def build_external_event_id(dag_id: str, run_id: str, callback_type: str, scope: str | None = None) -> str:
-    scoped_callback = f"{callback_type}:{scope}" if scope else callback_type
-    candidate = f"{dag_id}:{run_id}:{scoped_callback}"
-    if len(candidate) <= 255:
-        return candidate
-    canonical_payload = json.dumps(
-        {"callback_type": callback_type, "dag_id": dag_id, "run_id": run_id, "scope": scope},
-        ensure_ascii=False,
-        separators=(",", ":"),
-        sort_keys=True,
-    )
-    digest = hashlib.sha256(canonical_payload.encode("utf-8")).hexdigest()
-    return f"airflow:{callback_type}:{digest}"
+    return payloads.build_external_event_id(dag_id, run_id, callback_type, scope)
 
 
 def load_candidate(candidate_path: Path) -> dict[str, Any]:
@@ -309,126 +272,30 @@ def _validate_workflow_intent_codes(
             raise PipelineStageError(f"workflow references unknown intentCode: {intent_code}")
 
 
-def build_domain_pack_payload(
-    candidate: dict[str, Any],
-    stage_context: StageContext,
-    scope: str | None = None,
-) -> dict[str, object]:
-    domain_pack_draft = _required_object(candidate, "domainPackDraft")
-    return {
-        "externalEventId": build_external_event_id(
-            stage_context.dag_id,
-            stage_context.run_id,
-            CALLBACK_DOMAIN_PACK,
-            scope,
-        ),
-        "packKey": domain_pack_draft["packKey"],
-        "packName": domain_pack_draft["packName"],
-        "summaryJson": domain_pack_draft.get("summaryJson"),
-    }
-
-
-def build_intent_payload(
-    candidate: dict[str, Any],
-    stage_context: StageContext,
-    domain_pack_version_id: int,
-    scope: str | None = None,
-) -> dict[str, object]:
-    intent_draft = _required_object(candidate, "intentDraft")
-    return {
-        "externalEventId": build_external_event_id(
-            stage_context.dag_id,
-            stage_context.run_id,
-            CALLBACK_INTENT,
-            scope,
-        ),
-        "domainPackVersionId": domain_pack_version_id,
-        "intents": copy.deepcopy(intent_draft["intents"]),
-    }
-
-
-def build_workflow_payload(
-    candidate: dict[str, Any],
-    stage_context: StageContext,
-    domain_pack_version_id: int,
-    scope: str | None = None,
-    final_callback: bool = True,
-) -> dict[str, object]:
-    workflow_draft = _required_object(candidate, "workflowDraft")
-    payload: dict[str, object] = {
-        "externalEventId": build_external_event_id(
-            stage_context.dag_id,
-            stage_context.run_id,
-            CALLBACK_WORKFLOW,
-            scope,
-        ),
-        "domainPackVersionId": domain_pack_version_id,
-        "finalCallback": final_callback,
-    }
-    for key in WORKFLOW_LIST_KEYS:
-        payload[key] = copy.deepcopy(workflow_draft.get(key) or [])
-    return payload
-
-
 def apply_domain_pack_response(
     result: dict[str, Any],
     parsed_response_body: object | None,
     scope: str | None = None,
 ) -> None:
-    if not isinstance(parsed_response_body, dict):
-        raise DomainPackContextLost("domain-pack-drafts response body must be a JSON object.")
-
-    domain_pack_id = _int_or_none(parsed_response_body.get("domainPackId"))
-    domain_pack_version_id = _int_or_none(parsed_response_body.get("domainPackVersionId"))
-    version_no = _int_or_none(parsed_response_body.get("versionNo"))
-    if domain_pack_version_id is None:
-        raise DomainPackContextLost("domain-pack-drafts response did not include domainPackVersionId.")
-
-    result["domainPackId"] = domain_pack_id
-    result["domainPackVersionId"] = domain_pack_version_id
-    result["versionNo"] = version_no
-    if scope is not None:
-        contexts = result.get("domainPackContexts")
-        if not isinstance(contexts, dict):
-            contexts = {}
-        contexts[scope] = {
-            "domainPackId": domain_pack_id,
-            "domainPackVersionId": domain_pack_version_id,
-            "versionNo": version_no,
-        }
-        result["domainPackContexts"] = contexts
-
-
-def _domain_pack_version_id(result: dict[str, Any], scope: str | None) -> int | None:
-    if scope is None:
-        return _int_or_none(result.get("domainPackVersionId"))
-    contexts = result.get("domainPackContexts")
-    if isinstance(contexts, dict):
-        context = contexts.get(scope)
-        if isinstance(context, dict):
-            return _int_or_none(context.get("domainPackVersionId"))
-    for callback in reversed(_callback_results(result)):
-        if callback.get("type") != CALLBACK_DOMAIN_PACK or callback.get("scope") != scope:
-            continue
-        parsed = callback.get("parsedResponseBody")
-        if isinstance(parsed, dict):
-            return _int_or_none(parsed.get("domainPackVersionId"))
-    return None
+    state = PublishCandidateResult.from_payload(result)
+    state.apply_domain_pack_response(parsed_response_body, scope)
+    result.clear()
+    result.update(state.to_payload())
 
 
 def _run_callbacks(
     candidate: dict[str, Any],
-    result: dict[str, Any],
-    result_path: Path,
+    result: PublishCandidateResult,
+    result_writer: PublishCandidateResultWriter,
     stage_context: StageContext,
     runtime_config: PipelineRuntimeConfig,
 ) -> None:
     _candidate_items(candidate)
-    result["candidateCount"] = 1
+    result.candidate_count = 1
     _run_candidate_callbacks(
         candidate,
         result,
-        result_path,
+        result_writer,
         stage_context,
         runtime_config,
         None,
@@ -438,43 +305,44 @@ def _run_callbacks(
 
 def _run_candidate_callbacks(
     candidate: dict[str, Any],
-    result: dict[str, Any],
-    result_path: Path,
+    result: PublishCandidateResult,
+    result_writer: PublishCandidateResultWriter,
     stage_context: StageContext,
     runtime_config: PipelineRuntimeConfig,
     scope: str | None,
     *,
     final_callback: bool,
 ) -> None:
-    if not _has_successful_callback(result, CALLBACK_DOMAIN_PACK, scope):
+    if not result.has_successful_callback(CALLBACK_DOMAIN_PACK, scope):
         domain_payload = build_domain_pack_payload(candidate, stage_context, scope)
         domain_response = _post_callback(domain_payload, CALLBACK_DOMAIN_PACK, stage_context, runtime_config)
         _validate_callback_response(domain_response)
-        _append_callback_result(result, domain_response.to_result_entry(), scope)
-        apply_domain_pack_response(result, domain_response.parsed_response_body, scope)
-        _write_result(result_path, result)
+        result.append_callback_response(domain_response, scope)
+        result.apply_domain_pack_response(domain_response.parsed_response_body, scope)
+        result_writer.write(result)
 
-    domain_pack_version_id = _domain_pack_version_id(result, scope)
+    domain_pack_version_id = result.domain_pack_version_id_for(scope)
     if domain_pack_version_id is None:
-        result["publishStatus"] = "FAILED"
-        result["failedCallbackType"] = CALLBACK_DOMAIN_PACK
-        result["error"] = {
-            "type": "DomainPackContextLost",
-            "message": "domainPackVersionId is unavailable after domain-pack-drafts callback.",
-            "responseBody": None,
-            "parsedResponseBody": None,
-        }
-        _write_result(result_path, result)
-        raise _stage_error("Domain pack callback context was lost.", result, result_path)
+        result.mark_failed(
+            CALLBACK_DOMAIN_PACK,
+            {
+                "type": "DomainPackContextLost",
+                "message": "domainPackVersionId is unavailable after domain-pack-drafts callback.",
+                "responseBody": None,
+                "parsedResponseBody": None,
+            },
+        )
+        result_writer.write(result)
+        raise _stage_error("Domain pack callback context was lost.", result, result_writer)
 
-    if not _has_successful_callback(result, CALLBACK_INTENT, scope):
+    if not result.has_successful_callback(CALLBACK_INTENT, scope):
         intent_payload = build_intent_payload(candidate, stage_context, domain_pack_version_id, scope)
         intent_response = _post_callback(intent_payload, CALLBACK_INTENT, stage_context, runtime_config)
         _validate_callback_response(intent_response)
-        _append_callback_result(result, intent_response.to_result_entry(), scope)
-        _write_result(result_path, result)
+        result.append_callback_response(intent_response, scope)
+        result_writer.write(result)
 
-    if not _has_successful_callback(result, CALLBACK_WORKFLOW, scope):
+    if not result.has_successful_callback(CALLBACK_WORKFLOW, scope):
         workflow_payload = build_workflow_payload(
             candidate,
             stage_context,
@@ -484,8 +352,8 @@ def _run_candidate_callbacks(
         )
         workflow_response = _post_callback(workflow_payload, CALLBACK_WORKFLOW, stage_context, runtime_config)
         _validate_callback_response(workflow_response)
-        _append_callback_result(result, workflow_response.to_result_entry(), scope)
-        _write_result(result_path, result)
+        result.append_callback_response(workflow_response, scope)
+        result_writer.write(result)
 
 
 def _post_callback(
@@ -502,29 +370,6 @@ def _post_callback(
         runtime_config.airflow_webhook_secret or "",
         runtime_config.callback_timeout_seconds,
     )
-
-
-def _initial_result(stage_context: StageContext) -> dict[str, Any]:
-    return {
-        "schemaVersion": SCHEMA_VERSION,
-        "publishStatus": "PENDING",
-        "pipelineContext": {
-            "dagId": stage_context.dag_id,
-            "runId": stage_context.run_id,
-            "pipelineJobId": stage_context.pipeline_job_id,
-            "workspaceId": stage_context.workspace_id,
-            "datasetId": stage_context.dataset_id,
-        },
-        "candidateArtifactPath": None,
-        "domainPackId": None,
-        "domainPackVersionId": None,
-        "versionNo": None,
-        "candidateCount": 0,
-        "domainPackContexts": {},
-        "failedCallbackType": None,
-        "callbackResults": [],
-        "error": None,
-    }
 
 
 def _read_candidate_artifact_path(upstream_manifest_path: str | None) -> Path:
@@ -546,58 +391,12 @@ def _read_candidate_artifact_path(upstream_manifest_path: str | None) -> Path:
     return manifest_path.parent / candidate_path
 
 
-def _load_existing_result(result_path: Path) -> dict[str, Any] | None:
-    if not result_path.exists():
-        return None
-    result = json.loads(result_path.read_text(encoding="utf-8"))
-    if not isinstance(result, dict):
-        raise PipelineStageError(f"Existing publish result must be a JSON object: {result_path}")
-    return cast(dict[str, Any], result)
-
-
-def _write_result(result_path: Path, result: dict[str, Any]) -> None:
-    result_path.write_text(json.dumps(result, indent=2, ensure_ascii=False), encoding="utf-8")
-
-
-def _manifest_payload(result: dict[str, Any], result_path: Path) -> dict[str, object]:
-    callbacks = []
-    for callback in _callback_results(result):
-        callbacks.append(
-            {
-                "type": callback.get("type"),
-                "scope": callback.get("scope"),
-                "external_event_id": callback.get("externalEventId"),
-                "http_status": callback.get("httpStatus"),
-                "response_status": callback.get("responseStatus"),
-            }
-        )
-
-    return {
-        "status": _manifest_status(result),
-        "candidate_artifact_path": result.get("candidateArtifactPath"),
-        "publish_result_path": str(result_path.resolve()),
-        "domain_pack_id": result.get("domainPackId"),
-        "domain_pack_version_id": result.get("domainPackVersionId"),
-        "domain_pack_contexts": result.get("domainPackContexts"),
-        "candidate_count": result.get("candidateCount"),
-        "version_no": result.get("versionNo"),
-        "callbacks": callbacks,
-        "failed_callback_type": result.get("failedCallbackType"),
-        "publish_status": result.get("publishStatus"),
-    }
-
-
-def _manifest_status(result: dict[str, Any]) -> str:
-    publish_status = result.get("publishStatus")
-    if publish_status == "SUCCEEDED":
-        return "completed"
-    if publish_status == "FAILED":
-        return "failed"
-    return str(publish_status).lower()
-
-
-def _stage_error(message: str, result: dict[str, Any], result_path: Path) -> PublishCandidateStageError:
-    return PublishCandidateStageError(message, _manifest_payload(result, result_path))
+def _stage_error(
+    message: str,
+    result: PublishCandidateResult,
+    result_writer: PublishCandidateResultWriter,
+) -> PublishCandidateStageError:
+    return PublishCandidateStageError(message, result.manifest_payload(result_writer.path))
 
 
 def _evaluation_blocked(candidate: dict[str, Any]) -> bool:
@@ -605,32 +404,6 @@ def _evaluation_blocked(candidate: dict[str, Any]) -> bool:
     if isinstance(evaluation_summary, dict) and evaluation_summary.get("passed") is False:
         return True
     return any(_evaluation_blocked(item) for item in _candidate_items(candidate) if item is not candidate)
-
-
-def _has_successful_callback(result: dict[str, Any], callback_type: str, scope: str | None = None) -> bool:
-    for callback in _callback_results(result):
-        if callback.get("type") != callback_type:
-            continue
-        if callback.get("scope") != scope:
-            continue
-        http_status = _int_or_none(callback.get("httpStatus"))
-        response_status = callback.get("responseStatus")
-        if http_status is None or http_status < 200 or http_status >= 300:
-            continue
-        if response_status in SUCCESS_RESPONSE_STATUSES:
-            return True
-    return False
-
-
-def _append_callback_result(
-    result: dict[str, Any],
-    callback_result: dict[str, object],
-    scope: str | None = None,
-) -> None:
-    callback_result["scope"] = scope
-    callbacks = _callback_results(result)
-    callbacks.append(callback_result)
-    result["callbackResults"] = callbacks
 
 
 def _validate_callback_response(response: CallbackResponse) -> None:
@@ -646,13 +419,6 @@ def _validate_callback_response(response: CallbackResponse) -> None:
         response_body_truncated=response.response_body_truncated,
         parsed_response_body=response.parsed_response_body,
     )
-
-
-def _callback_results(result: dict[str, Any]) -> list[dict[str, Any]]:
-    callback_results = result.get("callbackResults")
-    if not isinstance(callback_results, list):
-        return []
-    return [callback for callback in callback_results if isinstance(callback, dict)]
 
 
 def _candidate_items(candidate: dict[str, Any]) -> list[dict[str, Any]]:

--- a/ml/src/pipeline/stages/publish_candidate/payloads.py
+++ b/ml/src/pipeline/stages/publish_candidate/payloads.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from typing import Any, cast
+
+from pipeline.common.context import StageContext
+from pipeline.common.exceptions import PipelineStageError
+
+CALLBACK_DOMAIN_PACK = "domain-pack-drafts"
+CALLBACK_INTENT = "intent-drafts"
+CALLBACK_WORKFLOW = "workflow-drafts"
+WORKFLOW_LIST_KEYS = (
+    "slots",
+    "policies",
+    "risks",
+    "workflows",
+    "intentSlotBindings",
+)
+
+
+def build_external_event_id(dag_id: str, run_id: str, callback_type: str, scope: str | None = None) -> str:
+    scoped_callback = f"{callback_type}:{scope}" if scope else callback_type
+    candidate = f"{dag_id}:{run_id}:{scoped_callback}"
+    if len(candidate) <= 255:
+        return candidate
+    canonical_payload = json.dumps(
+        {"callback_type": callback_type, "dag_id": dag_id, "run_id": run_id, "scope": scope},
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    digest = hashlib.sha256(canonical_payload.encode("utf-8")).hexdigest()
+    return f"airflow:{callback_type}:{digest}"
+
+
+def build_domain_pack_payload(
+    candidate: dict[str, Any],
+    stage_context: StageContext,
+    scope: str | None = None,
+) -> dict[str, object]:
+    domain_pack_draft = _required_object(candidate, "domainPackDraft")
+    return {
+        "externalEventId": build_external_event_id(
+            stage_context.dag_id,
+            stage_context.run_id,
+            CALLBACK_DOMAIN_PACK,
+            scope,
+        ),
+        "packKey": domain_pack_draft["packKey"],
+        "packName": domain_pack_draft["packName"],
+        "summaryJson": domain_pack_draft.get("summaryJson"),
+    }
+
+
+def build_intent_payload(
+    candidate: dict[str, Any],
+    stage_context: StageContext,
+    domain_pack_version_id: int,
+    scope: str | None = None,
+) -> dict[str, object]:
+    intent_draft = _required_object(candidate, "intentDraft")
+    return {
+        "externalEventId": build_external_event_id(
+            stage_context.dag_id,
+            stage_context.run_id,
+            CALLBACK_INTENT,
+            scope,
+        ),
+        "domainPackVersionId": domain_pack_version_id,
+        "intents": copy.deepcopy(intent_draft["intents"]),
+    }
+
+
+def build_workflow_payload(
+    candidate: dict[str, Any],
+    stage_context: StageContext,
+    domain_pack_version_id: int,
+    scope: str | None = None,
+    final_callback: bool = True,
+) -> dict[str, object]:
+    workflow_draft = _required_object(candidate, "workflowDraft")
+    payload: dict[str, object] = {
+        "externalEventId": build_external_event_id(
+            stage_context.dag_id,
+            stage_context.run_id,
+            CALLBACK_WORKFLOW,
+            scope,
+        ),
+        "domainPackVersionId": domain_pack_version_id,
+        "finalCallback": final_callback,
+    }
+    for key in WORKFLOW_LIST_KEYS:
+        payload[key] = copy.deepcopy(workflow_draft.get(key) or [])
+    return payload
+
+
+def _required_object(payload: dict[str, Any], key: str) -> dict[str, Any]:
+    value = payload.get(key)
+    if not isinstance(value, dict):
+        raise PipelineStageError(f"{key} must be a JSON object.")
+    return cast(dict[str, Any], value)

--- a/ml/src/pipeline/stages/publish_candidate/state.py
+++ b/ml/src/pipeline/stages/publish_candidate/state.py
@@ -1,0 +1,352 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, cast
+
+from pipeline.common.callbacks import CallbackResponse
+from pipeline.common.context import StageContext
+from pipeline.common.exceptions import PipelineStageError
+
+SUCCESS_RESPONSE_STATUSES = {"CREATED", "DUPLICATE_IGNORED", "OK", "SUCCEEDED"}
+
+
+class DomainPackContextLost(PipelineStageError):
+    pass
+
+
+@dataclass
+class CallbackResult:
+    type: str
+    external_event_id: str | None
+    endpoint: str | None
+    http_status: int | None
+    response_status: str | None
+    response_body: str | None = None
+    response_body_truncated: bool = False
+    parsed_response_body: object | None = None
+    scope: str | None = None
+
+    @classmethod
+    def from_response(cls, response: CallbackResponse, scope: str | None) -> CallbackResult:
+        return cls(
+            type=response.callback_type,
+            external_event_id=response.external_event_id,
+            endpoint=response.endpoint,
+            http_status=response.http_status,
+            response_status=response.response_status,
+            response_body=response.response_body,
+            response_body_truncated=response.response_body_truncated,
+            parsed_response_body=response.parsed_response_body,
+            scope=scope,
+        )
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, Any]) -> CallbackResult:
+        return cls(
+            type=str(payload.get("type")),
+            external_event_id=_optional_str(payload.get("externalEventId")),
+            endpoint=_optional_str(payload.get("endpoint")),
+            http_status=_int_or_none(payload.get("httpStatus")),
+            response_status=_optional_str(payload.get("responseStatus")),
+            response_body=_optional_str(payload.get("responseBody")),
+            response_body_truncated=bool(payload.get("responseBodyTruncated", False)),
+            parsed_response_body=payload.get("parsedResponseBody"),
+            scope=_optional_str(payload.get("scope")),
+        )
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            "type": self.type,
+            "externalEventId": self.external_event_id,
+            "endpoint": self.endpoint,
+            "httpStatus": self.http_status,
+            "responseStatus": self.response_status,
+            "responseBody": self.response_body,
+            "responseBodyTruncated": self.response_body_truncated,
+            "parsedResponseBody": self.parsed_response_body,
+            "scope": self.scope,
+        }
+
+    def to_manifest_entry(self) -> dict[str, object]:
+        return {
+            "type": self.type,
+            "scope": self.scope,
+            "external_event_id": self.external_event_id,
+            "http_status": self.http_status,
+            "response_status": self.response_status,
+        }
+
+    def is_successful(self, callback_type: str, scope: str | None) -> bool:
+        if self.type != callback_type or self.scope != scope:
+            return False
+        if self.http_status is None or self.http_status < 200 or self.http_status >= 300:
+            return False
+        return self.response_status in SUCCESS_RESPONSE_STATUSES
+
+
+@dataclass
+class DomainPackContext:
+    domain_pack_id: int | None
+    domain_pack_version_id: int | None
+    version_no: int | None
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, Any]) -> DomainPackContext:
+        return cls(
+            domain_pack_id=_int_or_none(payload.get("domainPackId")),
+            domain_pack_version_id=_int_or_none(payload.get("domainPackVersionId")),
+            version_no=_int_or_none(payload.get("versionNo")),
+        )
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            "domainPackId": self.domain_pack_id,
+            "domainPackVersionId": self.domain_pack_version_id,
+            "versionNo": self.version_no,
+        }
+
+
+@dataclass
+class PublishCandidateResult:
+    schema_version: str
+    publish_status: str
+    pipeline_context: dict[str, object]
+    candidate_artifact_path: str | None = None
+    domain_pack_id: int | None = None
+    domain_pack_version_id: int | None = None
+    version_no: int | None = None
+    candidate_count: int = 0
+    domain_pack_contexts: dict[str, DomainPackContext] = field(default_factory=dict)
+    failed_callback_type: str | None = None
+    callback_results: list[CallbackResult] = field(default_factory=list)
+    error: dict[str, object] | None = None
+    evaluation_gate_status: str | None = None
+    evaluation_gate_reason: str | None = None
+    skip_reason: str | None = None
+    extra_fields: dict[str, object] = field(default_factory=dict)
+
+    @classmethod
+    def initial(cls, stage_context: StageContext, schema_version: str) -> PublishCandidateResult:
+        return cls(
+            schema_version=schema_version,
+            publish_status="PENDING",
+            pipeline_context={
+                "dagId": stage_context.dag_id,
+                "runId": stage_context.run_id,
+                "pipelineJobId": stage_context.pipeline_job_id,
+                "workspaceId": stage_context.workspace_id,
+                "datasetId": stage_context.dataset_id,
+            },
+            domain_pack_contexts={},
+        )
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, Any]) -> PublishCandidateResult:
+        callback_results = payload.get("callbackResults")
+        domain_pack_contexts = payload.get("domainPackContexts")
+        pipeline_context = payload.get("pipelineContext")
+        known_keys = {
+            "schemaVersion",
+            "publishStatus",
+            "pipelineContext",
+            "candidateArtifactPath",
+            "domainPackId",
+            "domainPackVersionId",
+            "versionNo",
+            "candidateCount",
+            "domainPackContexts",
+            "failedCallbackType",
+            "callbackResults",
+            "error",
+            "evaluationGateStatus",
+            "evaluationGateReason",
+            "skipReason",
+        }
+        return cls(
+            schema_version=str(payload.get("schemaVersion", "1.0")),
+            publish_status=str(payload.get("publishStatus", "PENDING")),
+            pipeline_context=cast(dict[str, object], pipeline_context) if isinstance(pipeline_context, dict) else {},
+            candidate_artifact_path=_optional_str(payload.get("candidateArtifactPath")),
+            domain_pack_id=_int_or_none(payload.get("domainPackId")),
+            domain_pack_version_id=_int_or_none(payload.get("domainPackVersionId")),
+            version_no=_int_or_none(payload.get("versionNo")),
+            candidate_count=_int_or_none(payload.get("candidateCount")) or 0,
+            domain_pack_contexts=_parse_domain_pack_contexts(domain_pack_contexts),
+            failed_callback_type=_optional_str(payload.get("failedCallbackType")),
+            callback_results=_parse_callback_results(callback_results),
+            error=cast(dict[str, object], payload.get("error")) if isinstance(payload.get("error"), dict) else None,
+            evaluation_gate_status=_optional_str(payload.get("evaluationGateStatus")),
+            evaluation_gate_reason=_optional_str(payload.get("evaluationGateReason")),
+            skip_reason=_optional_str(payload.get("skipReason")),
+            extra_fields={key: value for key, value in payload.items() if key not in known_keys},
+        )
+
+    def to_payload(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "schemaVersion": self.schema_version,
+            "publishStatus": self.publish_status,
+            "pipelineContext": self.pipeline_context,
+            "candidateArtifactPath": self.candidate_artifact_path,
+            "domainPackId": self.domain_pack_id,
+            "domainPackVersionId": self.domain_pack_version_id,
+            "versionNo": self.version_no,
+            "candidateCount": self.candidate_count,
+            "domainPackContexts": {scope: context.to_payload() for scope, context in self.domain_pack_contexts.items()},
+            "failedCallbackType": self.failed_callback_type,
+            "callbackResults": [callback.to_payload() for callback in self.callback_results],
+            "error": self.error,
+        }
+        if self.evaluation_gate_status is not None:
+            payload["evaluationGateStatus"] = self.evaluation_gate_status
+        if self.evaluation_gate_reason is not None:
+            payload["evaluationGateReason"] = self.evaluation_gate_reason
+        if self.skip_reason is not None:
+            payload["skipReason"] = self.skip_reason
+        payload.update(self.extra_fields)
+        return payload
+
+    def set_candidate_artifact_path(self, candidate_path: Path) -> None:
+        self.candidate_artifact_path = str(candidate_path)
+
+    def mark_evaluation_needs_human_review(self) -> None:
+        self.evaluation_gate_status = "NEEDS_HUMAN_REVIEW"
+        self.evaluation_gate_reason = "evaluationSummary.passed=false"
+
+    def mark_skipped(self, candidate_count: int) -> None:
+        self.publish_status = "SKIPPED"
+        self.skip_reason = "CALLBACK_DISABLED"
+        self.domain_pack_id = None
+        self.domain_pack_version_id = None
+        self.version_no = None
+        self.candidate_count = candidate_count
+        self.domain_pack_contexts = {}
+        self.failed_callback_type = None
+        self.callback_results = []
+        self.error = None
+
+    def mark_running(self) -> None:
+        self.publish_status = "RUNNING"
+        self.error = None
+        self.failed_callback_type = None
+
+    def mark_succeeded(self) -> None:
+        self.publish_status = "SUCCEEDED"
+        self.failed_callback_type = None
+        self.error = None
+
+    def mark_failed(self, failed_callback_type: str | None, error: dict[str, object]) -> None:
+        self.publish_status = "FAILED"
+        self.failed_callback_type = failed_callback_type
+        self.error = error
+
+    def append_callback_response(self, response: CallbackResponse, scope: str | None) -> None:
+        self.callback_results.append(CallbackResult.from_response(response, scope))
+
+    def has_successful_callback(self, callback_type: str, scope: str | None = None) -> bool:
+        return any(callback.is_successful(callback_type, scope) for callback in self.callback_results)
+
+    def apply_domain_pack_response(self, parsed_response_body: object | None, scope: str | None = None) -> None:
+        if not isinstance(parsed_response_body, dict):
+            raise DomainPackContextLost("domain-pack-drafts response body must be a JSON object.")
+
+        domain_pack_id = _int_or_none(parsed_response_body.get("domainPackId"))
+        domain_pack_version_id = _int_or_none(parsed_response_body.get("domainPackVersionId"))
+        version_no = _int_or_none(parsed_response_body.get("versionNo"))
+        if domain_pack_version_id is None:
+            raise DomainPackContextLost("domain-pack-drafts response did not include domainPackVersionId.")
+
+        self.domain_pack_id = domain_pack_id
+        self.domain_pack_version_id = domain_pack_version_id
+        self.version_no = version_no
+        if scope is not None:
+            self.domain_pack_contexts[scope] = DomainPackContext(
+                domain_pack_id=domain_pack_id,
+                domain_pack_version_id=domain_pack_version_id,
+                version_no=version_no,
+            )
+
+    def domain_pack_version_id_for(self, scope: str | None) -> int | None:
+        if scope is None:
+            return self.domain_pack_version_id
+        context = self.domain_pack_contexts.get(scope)
+        if context is not None:
+            return context.domain_pack_version_id
+        for callback in reversed(self.callback_results):
+            if callback.type != "domain-pack-drafts" or callback.scope != scope:
+                continue
+            parsed = callback.parsed_response_body
+            if isinstance(parsed, dict):
+                return _int_or_none(parsed.get("domainPackVersionId"))
+        return None
+
+    def manifest_payload(self, result_path: Path) -> dict[str, object]:
+        return {
+            "status": self.manifest_status(),
+            "candidate_artifact_path": self.candidate_artifact_path,
+            "publish_result_path": str(result_path.resolve()),
+            "domain_pack_id": self.domain_pack_id,
+            "domain_pack_version_id": self.domain_pack_version_id,
+            "domain_pack_contexts": {
+                scope: context.to_payload() for scope, context in self.domain_pack_contexts.items()
+            },
+            "candidate_count": self.candidate_count,
+            "version_no": self.version_no,
+            "callbacks": [callback.to_manifest_entry() for callback in self.callback_results],
+            "failed_callback_type": self.failed_callback_type,
+            "publish_status": self.publish_status,
+        }
+
+    def manifest_status(self) -> str:
+        if self.publish_status == "SUCCEEDED":
+            return "completed"
+        if self.publish_status == "FAILED":
+            return "failed"
+        return self.publish_status.lower()
+
+
+@dataclass(frozen=True)
+class PublishCandidateResultWriter:
+    path: Path
+
+    def load(self) -> PublishCandidateResult | None:
+        if not self.path.exists():
+            return None
+        result = json.loads(self.path.read_text(encoding="utf-8"))
+        if not isinstance(result, dict):
+            raise PipelineStageError(f"Existing publish result must be a JSON object: {self.path}")
+        return PublishCandidateResult.from_payload(result)
+
+    def write(self, result: PublishCandidateResult) -> None:
+        self.path.write_text(json.dumps(result.to_payload(), indent=2, ensure_ascii=False), encoding="utf-8")
+
+
+def _parse_callback_results(value: object) -> list[CallbackResult]:
+    if not isinstance(value, list):
+        return []
+    return [CallbackResult.from_payload(callback) for callback in value if isinstance(callback, dict)]
+
+
+def _parse_domain_pack_contexts(value: object) -> dict[str, DomainPackContext]:
+    if not isinstance(value, dict):
+        return {}
+    return {
+        str(scope): DomainPackContext.from_payload(context)
+        for scope, context in value.items()
+        if isinstance(context, dict)
+    }
+
+
+def _optional_str(value: object) -> str | None:
+    return value if isinstance(value, str) else None
+
+
+def _int_or_none(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.isdecimal():
+        return int(value)
+    return None

--- a/ml/tests/fixtures/publish_candidate/callback_payload_contract.json
+++ b/ml/tests/fixtures/publish_candidate/callback_payload_contract.json
@@ -1,0 +1,86 @@
+{
+  "domain-pack-drafts": {
+    "externalEventId": "domain_pack_generation:manual__run:domain-pack-drafts",
+    "packKey": "refund-pack",
+    "packName": "Refund Pack",
+    "summaryJson": "{\"clusterCount\":1}"
+  },
+  "intent-drafts": {
+    "externalEventId": "domain_pack_generation:manual__run:intent-drafts",
+    "domainPackVersionId": 101,
+    "intents": [
+      {
+        "intentCode": "refund_request",
+        "name": "Refund request",
+        "description": "Customer asks for a refund.",
+        "taxonomyLevel": 1,
+        "parentIntentCode": null,
+        "sourceClusterRef": "{}",
+        "entryConditionJson": "{}",
+        "evidenceJson": "[]",
+        "metaJson": "{}",
+        "representativeCases": [
+          {
+            "conversationId": "conv_001",
+            "canonicalText": "환불 요청합니다",
+            "customerProblemText": "환불",
+            "endedStatus": "resolved"
+          }
+        ]
+      }
+    ]
+  },
+  "workflow-drafts": {
+    "externalEventId": "domain_pack_generation:manual__run:workflow-drafts",
+    "domainPackVersionId": 101,
+    "finalCallback": true,
+    "slots": [
+      {
+        "slotCode": "order_id",
+        "name": "Order ID",
+        "description": "Target order.",
+        "dataType": "STRING",
+        "isSensitive": false,
+        "validationRuleJson": "{}",
+        "defaultValueJson": null,
+        "metaJson": "{}"
+      }
+    ],
+    "policies": [
+      {
+        "policyCode": "refund_policy_default",
+        "name": "Refund policy",
+        "description": "Default refund policy.",
+        "severity": "HIGH",
+        "conditionJson": "{}",
+        "actionJson": "{}",
+        "evidenceJson": "[]",
+        "metaJson": "{}"
+      }
+    ],
+    "risks": [],
+    "workflows": [
+      {
+        "workflowCode": "refund_flow",
+        "name": "Refund flow",
+        "description": "Refund workflow.",
+        "graphJson": "{\"nodes\":[],\"edges\":[]}",
+        "evidenceJson": "[]",
+        "metaJson": "{}",
+        "intentCode": "refund_request",
+        "isPrimary": true,
+        "routeConditionJson": "{}"
+      }
+    ],
+    "intentSlotBindings": [
+      {
+        "intentCode": "refund_request",
+        "slotCode": "order_id",
+        "isRequired": true,
+        "collectionOrder": 1,
+        "promptHint": "Order ID?",
+        "conditionJson": "{}"
+      }
+    ]
+  }
+}

--- a/ml/tests/stages/test_publish_candidate_main.py
+++ b/ml/tests/stages/test_publish_candidate_main.py
@@ -265,6 +265,65 @@ def test_workflow_payload_includes_domain_pack_version_id() -> None:
     assert payload["externalEventId"] == "domain_pack_generation:manual__run:workflow-drafts"
 
 
+def test_callback_payload_contract_matches_fixture() -> None:
+    fixture_path = Path(__file__).parents[1] / "fixtures" / "publish_candidate" / "callback_payload_contract.json"
+    expected = json.loads(fixture_path.read_text(encoding="utf-8"))
+
+    actual = {
+        "domain-pack-drafts": publish.build_domain_pack_payload(_candidate(), _stage_context()),
+        "intent-drafts": publish.build_intent_payload(_candidate(), _stage_context(), 101),
+        "workflow-drafts": publish.build_workflow_payload(_candidate(), _stage_context(), 101),
+    }
+
+    assert actual == expected
+
+
+def test_publish_success_writes_result_state(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    manifest_path, _candidate_path = _write_publish_inputs(tmp_path)
+    artifact_root = tmp_path / "artifacts"
+    monkeypatch.setenv("PIPELINE_ARTIFACT_ROOT", str(artifact_root))
+    monkeypatch.setenv("PIPELINE_BACKEND_BASE_URL", "http://backend:8080")
+
+    def fake_post_callback(
+        backend_base_url: str,
+        job_id: str,
+        callback_type: str,
+        payload: dict[str, object],
+        _webhook_secret: str,
+        _timeout_seconds: float,
+    ) -> CallbackResponse:
+        body: dict[str, object] = {"status": "CREATED"}
+        if callback_type == "domain-pack-drafts":
+            body.update({"domainPackId": 7, "domainPackVersionId": 101, "versionNo": 3})
+        return CallbackResponse(
+            callback_type=callback_type,
+            external_event_id=cast(str, payload["externalEventId"]),
+            endpoint=f"{backend_base_url}/{job_id}/{callback_type}",
+            http_status=201,
+            response_status="CREATED",
+            response_body=json.dumps(body),
+            response_body_truncated=False,
+            parsed_response_body=body,
+        )
+
+    monkeypatch.setattr(publish, "post_callback", fake_post_callback)
+
+    payload = publish.run(str(manifest_path))
+
+    result_path = Path(cast(str, payload["publish_result_path"]))
+    result = json.loads(result_path.read_text(encoding="utf-8"))
+    assert payload["status"] == "completed"
+    assert result["publishStatus"] == "SUCCEEDED"
+    assert result["domainPackVersionId"] == 101
+    assert result["failedCallbackType"] is None
+    assert result["error"] is None
+    assert [callback["type"] for callback in result["callbackResults"]] == [
+        "domain-pack-drafts",
+        "intent-drafts",
+        "workflow-drafts",
+    ]
+
+
 def test_retry_reuses_existing_domain_pack_context(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     manifest_path, _candidate_path = _write_publish_inputs(tmp_path)
     artifact_root = tmp_path / "artifacts"
@@ -416,9 +475,7 @@ def test_unexpected_callback_status_fails_before_next_callback(monkeypatch: pyte
     assert result["error"]["parsedResponseBody"] == {"status": "WEIRD", "domainPackVersionId": 101}
 
 
-def test_evaluation_blocked_surfaces_needs_human_review(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_evaluation_blocked_surfaces_needs_human_review(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     candidate = _candidate()
     candidate["evaluationSummary"] = {
         "passed": False,


### PR DESCRIPTION
Closes #616

## 변경 사항

- `publish_candidate` Spring callback payload builder를 `payloads.py`로 분리하고 기존 domain/intent/workflow payload contract를 유지했습니다.
- publish result artifact 상태를 `state.py`의 typed model과 writer로 분리해 `RUNNING`, `SUCCEEDED`, `FAILED`, `SKIPPED` 전이를 명시했습니다.
- retry/resume 시 성공한 callback을 재호출하지 않고 저장된 domain pack context 또는 callback response에서 `domainPackVersionId`를 복구하도록 정리했습니다.
- callback payload fixture 기반 contract test와 success result state 테스트를 추가하고 기존 failure/retry/disabled 테스트를 유지했습니다.
- 이슈 616 스펙을 `.agent/specs/616.md`에 정리했습니다.

## 검증

- `git diff --check`
- `pnpm exec prettier --check .agent/specs/616.md ml/tests/fixtures/publish_candidate/callback_payload_contract.json`
- `cd ml && uv run ruff check src/pipeline/stages/publish_candidate/main.py src/pipeline/stages/publish_candidate/payloads.py src/pipeline/stages/publish_candidate/state.py tests/stages/test_publish_candidate_main.py`
- `cd ml && uv run ruff format --check src/pipeline/stages/publish_candidate/main.py src/pipeline/stages/publish_candidate/payloads.py src/pipeline/stages/publish_candidate/state.py tests/stages/test_publish_candidate_main.py`
- `cd ml && uv run mypy src/pipeline/stages/publish_candidate tests/stages/test_publish_candidate_main.py`
- `cd ml && uv run pytest tests/stages/test_publish_candidate_main.py` (41 passed)
- `pnpm run ci:ml` (662 passed, 2 skipped; coverage 83.28%)

## 참고

- 커밋 pre-commit hook의 `pnpm run lint:ml`은 repository-wide 기존 ruff baseline 위반으로 실패했습니다. 실패 항목은 이번 변경 파일이 아닌 `src/pipeline/stages/evaluation/main.py`, `src/pipeline/stages/flow_splitting/*`의 기존 import 정리 문제입니다. 이번 PR에서 변경한 ML 파일은 대상 지정 ruff/mypy와 `ci:ml`로 통과를 확인했습니다.