### PR TITLE
refactor(review): checkpoint review 상태 전이 경계를 명확화

### DIFF
--- a/.agent/specs/613.md
+++ b/.agent/specs/613.md
@@ -1,0 +1,73 @@
+# pipeline checkpoint review orchestration 분리
+
+## Goal
+
+Pipeline review checkpoint callback 처리와 replay orchestration 책임을 분리해 기존 callback/replay API 계약은 유지하면서 review task 생성과 pipeline job 상태 전이 경계를 명확하게 한다.
+
+## Problem
+
+`backend/src/main/java/com/init/review/application/PipelineReviewCheckpointUseCase.java`가 webhook receipt 처리, checkpoint artifact 저장, review session/task 생성, review decision 저장, replay 요청 생성, pipeline job 상태 전이를 모두 담당한다. Review, pipeline-job, domain-pack 생성 트리거 경계가 한 use case에 집중되어 duplicate callback, replay 실패, checkpoint별 상태 전이 검증을 좁은 단위로 확인하기 어렵다.
+
+## Scope
+
+- checkpoint callback 수신/중복 처리/상태 전이 책임을 별도 application collaborator로 분리한다.
+- domain confirmation/human feedback review task 생성 정책을 별도 collaborator로 분리한다.
+- confirmed domain/feedback replay 요청 생성과 parent pipeline job RUNNING/FAILED 전이를 별도 collaborator로 분리한다.
+- `PipelineReviewCheckpointUseCase`의 public command/result record와 presentation/controller 계약은 유지한다.
+- callback 처리, review task 생성, replay 요청 생성, replay 실패, duplicate callback 상태 전이 테스트를 보강한다.
+
+## Non-goals
+
+- REST endpoint, request/response JSON, webhook path를 변경하지 않는다.
+- Airflow DAG run payload key나 `DomainPackGenerationTriggerCommand` 계약을 변경하지 않는다.
+- ReviewSession, ReviewTask, PipelineJob, PipelineArtifact DB schema를 변경하지 않는다.
+- 도메인 팩 초안 생성 알고리즘이나 ML pipeline artifact schema를 재설계하지 않는다.
+
+## Affected Paths
+
+- `backend/src/main/java/com/init/review/application/PipelineReviewCheckpointUseCase.java`
+- `backend/src/main/java/com/init/review/application/PipelineReviewCheckpointCallbackProcessor.java`
+- `backend/src/main/java/com/init/review/application/PipelineReviewTaskFactory.java`
+- `backend/src/main/java/com/init/review/application/PipelineReviewReplayOrchestrator.java`
+- `backend/src/main/java/com/init/review/application/PipelineReviewCheckpointJsonSupport.java`
+- `backend/src/test/java/com/init/review/application/PipelineReviewCheckpointUseCaseTest.java`
+- `backend/src/test/java/com/init/review/application/PipelineReviewCheckpointCallbackProcessorTest.java`
+- `backend/src/test/java/com/init/review/application/PipelineReviewTaskFactoryTest.java`
+- `backend/src/test/java/com/init/review/application/PipelineReviewReplayOrchestratorTest.java`
+- `.agent/specs/613.md`
+
+## Requirements
+
+1. `PipelineReviewCheckpointUseCase`는 기존 callback/replay API-facing command/result record를 유지해야 한다.
+2. checkpoint callback 처리는 webhook secret 검증, receipt 중복 처리, artifact 저장, review session 생성, pipeline job waiting 상태 전이를 한 collaborator에서 담당해야 한다.
+3. review task 생성 정책은 review kind별 payload array(`candidates`, `questions`)와 title/priority fallback을 별도 collaborator에서 담당해야 한다.
+4. replay orchestration은 upstream manifest path 탐색, Airflow trigger command 생성, parent job RUNNING 전이, trigger 실패 시 FAILED 전이를 별도 collaborator에서 담당해야 한다.
+5. domain confirmation callback은 기존처럼 `DOMAIN_CANDIDATES` artifact와 domain candidate review task를 만들고 `WAITING_DOMAIN_CONFIRMATION`으로 전이해야 한다.
+6. human feedback callback은 기존처럼 `FEEDBACK_QUESTIONS` artifact와 feedback pair review task를 만들고 `WAITING_HUMAN_FEEDBACK`으로 전이해야 한다.
+7. processed receipt가 있는 duplicate callback은 artifact/session/task/job 상태를 다시 변경하지 않고 `DUPLICATE_IGNORED`를 반환해야 한다.
+8. replay trigger 실패는 parent pipeline job 실패 상태를 새 트랜잭션 persistence service에 위임해야 한다.
+
+## Data/API Impact
+
+- 외부 REST API와 webhook callback request/response 계약 변경은 없다.
+- DB migration은 없다.
+- Airflow trigger command field와 replay run mode 값은 기존 값을 유지한다.
+
+## Acceptance Criteria
+
+- domain checkpoint callback 정상 처리 시 artifact/session/task가 생성되고 job 상태가 `WAITING_DOMAIN_CONFIRMATION`이 된다.
+- human feedback checkpoint callback 정상 처리 시 feedback review task가 생성되고 job 상태가 `WAITING_HUMAN_FEEDBACK`이 된다.
+- processed receipt duplicate callback은 추가 저장 없이 `DUPLICATE_IGNORED`를 반환한다.
+- domain confirmation 승인 시 `DOMAIN_CONFIRMED_REPLAY` trigger command가 생성되고 parent job이 `RUNNING`으로 전환된다.
+- feedback 제출 시 `FEEDBACK_REPLAY` trigger command가 생성되고 skip feedback checkpoint flag가 유지된다.
+- replay trigger 실패 시 parent job 실패 persistence가 호출된다.
+
+## Validation
+
+- `cd backend && ./gradlew test --tests 'com.init.review.application.*'`
+- `cd backend && ./gradlew test`
+- `git diff --check`
+
+## Open Questions
+
+- 없음. 이슈 본문과 현재 callback/replay 계약으로 구현 범위를 결정하기에 충분하다.

--- a/backend/src/main/java/com/init/review/application/PipelineReviewCheckpointCallbackProcessor.java
+++ b/backend/src/main/java/com/init/review/application/PipelineReviewCheckpointCallbackProcessor.java
@@ -1,0 +1,182 @@
+package com.init.review.application;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.init.pipelinejob.application.PipelineJobCallbackSupportService;
+import com.init.pipelinejob.application.exception.PipelineJobAlreadyFinalizedException;
+import com.init.pipelinejob.application.exception.PipelineJobNotFoundException;
+import com.init.pipelinejob.domain.model.PipelineArtifact;
+import com.init.pipelinejob.domain.model.PipelineJob;
+import com.init.pipelinejob.domain.model.WebhookReceipt;
+import com.init.pipelinejob.domain.repository.PipelineArtifactRepository;
+import com.init.pipelinejob.domain.repository.PipelineJobRepository;
+import com.init.review.domain.model.ReviewSession;
+import com.init.review.domain.repository.ReviewSessionRepository;
+import com.init.review.domain.repository.ReviewTaskRepository;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PipelineReviewCheckpointCallbackProcessor {
+
+  private static final String ARTIFACT_DOMAIN_CANDIDATES = "DOMAIN_CANDIDATES";
+  private static final String ARTIFACT_FEEDBACK_QUESTIONS = "FEEDBACK_QUESTIONS";
+  private static final String FIELD_UPSTREAM_MANIFEST_PATH = "upstreamManifestPath";
+
+  private final PipelineJobRepository pipelineJobRepository;
+  private final PipelineArtifactRepository pipelineArtifactRepository;
+  private final ReviewSessionRepository reviewSessionRepository;
+  private final ReviewTaskRepository reviewTaskRepository;
+  private final PipelineJobCallbackSupportService callbackSupportService;
+  private final PipelineReviewTaskFactory taskFactory;
+  private final PipelineReviewCheckpointJsonSupport jsonSupport;
+
+  public PipelineReviewCheckpointCallbackProcessor(
+      PipelineJobRepository pipelineJobRepository,
+      PipelineArtifactRepository pipelineArtifactRepository,
+      ReviewSessionRepository reviewSessionRepository,
+      ReviewTaskRepository reviewTaskRepository,
+      PipelineJobCallbackSupportService callbackSupportService,
+      PipelineReviewTaskFactory taskFactory,
+      PipelineReviewCheckpointJsonSupport jsonSupport) {
+    this.pipelineJobRepository = pipelineJobRepository;
+    this.pipelineArtifactRepository = pipelineArtifactRepository;
+    this.reviewSessionRepository = reviewSessionRepository;
+    this.reviewTaskRepository = reviewTaskRepository;
+    this.callbackSupportService = callbackSupportService;
+    this.taskFactory = taskFactory;
+    this.jsonSupport = jsonSupport;
+  }
+
+  public PipelineReviewCheckpointUseCase.CheckpointCallbackResult
+      receiveDomainConfirmationCheckpoint(
+          PipelineReviewCheckpointUseCase.CheckpointCallbackCommand command) {
+    return receiveCheckpoint(
+        command,
+        PipelineReviewCheckpointUseCase.WEBHOOK_TYPE_DOMAIN_CONFIRMATION,
+        ReviewSession.KIND_DOMAIN_CONFIRMATION,
+        ARTIFACT_DOMAIN_CANDIDATES,
+        PipelineJob.STATUS_WAITING_DOMAIN_CONFIRMATION);
+  }
+
+  public PipelineReviewCheckpointUseCase.CheckpointCallbackResult receiveHumanFeedbackCheckpoint(
+      PipelineReviewCheckpointUseCase.CheckpointCallbackCommand command) {
+    return receiveCheckpoint(
+        command,
+        PipelineReviewCheckpointUseCase.WEBHOOK_TYPE_HUMAN_FEEDBACK,
+        ReviewSession.KIND_HUMAN_FEEDBACK,
+        ARTIFACT_FEEDBACK_QUESTIONS,
+        PipelineJob.STATUS_WAITING_HUMAN_FEEDBACK);
+  }
+
+  private PipelineReviewCheckpointUseCase.CheckpointCallbackResult receiveCheckpoint(
+      PipelineReviewCheckpointUseCase.CheckpointCallbackCommand command,
+      String webhookType,
+      String reviewKind,
+      String artifactType,
+      String waitingStatus) {
+    callbackSupportService.validateWebhookSecret(command.providedWebhookSecret());
+    Optional<WebhookReceipt> existingReceipt =
+        callbackSupportService.findReceipt(command.externalEventId());
+    callbackSupportService.validateWebhookType(
+        existingReceipt.orElse(null), command.externalEventId(), webhookType);
+    if (callbackSupportService.isProcessed(existingReceipt.orElse(null))) {
+      return duplicateIgnored(command);
+    }
+    PipelineJob job = runningJob(command.jobId());
+    if (job.isFinalized()) {
+      throw new PipelineJobAlreadyFinalizedException(command.jobId());
+    }
+    WebhookReceipt receipt =
+        callbackSupportService.ensureReceivedReceipt(
+            command.jobId(),
+            command.externalEventId(),
+            webhookType,
+            command.requestHeadersJson(),
+            command.requestBodyJson(),
+            existingReceipt.orElse(null));
+    callbackSupportService.validateWebhookType(receipt, command.externalEventId(), webhookType);
+    if (callbackSupportService.isProcessed(receipt)) {
+      return duplicateIgnored(command);
+    }
+    return callbackSupportService.executeInTransactionOrMarkFailure(
+        command.jobId(),
+        command.externalEventId(),
+        () -> processCheckpoint(command, reviewKind, artifactType, waitingStatus));
+  }
+
+  private PipelineReviewCheckpointUseCase.CheckpointCallbackResult duplicateIgnored(
+      PipelineReviewCheckpointUseCase.CheckpointCallbackCommand command) {
+    return new PipelineReviewCheckpointUseCase.CheckpointCallbackResult(
+        "DUPLICATE_IGNORED", command.externalEventId());
+  }
+
+  private PipelineReviewCheckpointUseCase.CheckpointCallbackResult processCheckpoint(
+      PipelineReviewCheckpointUseCase.CheckpointCallbackCommand command,
+      String reviewKind,
+      String artifactType,
+      String waitingStatus) {
+    PipelineJob job = runningJob(command.jobId());
+    if (job.isFinalized()) {
+      throw new PipelineJobAlreadyFinalizedException(command.jobId());
+    }
+    OffsetDateTime now = callbackSupportService.now();
+    JsonNode artifactPayloadNode = jsonSupport.requireArtifactPayload(command.artifactPayload());
+    String artifactPayload = jsonSupport.toJson(artifactPayloadNode);
+    pipelineArtifactRepository.save(
+        PipelineArtifact.create(
+            job.getId(),
+            reviewKind.toLowerCase(),
+            artifactType,
+            command.artifactPath(),
+            null,
+            artifactPayload,
+            now));
+    ReviewSession session =
+        reviewSessionRepository.save(
+            ReviewSession.createPipelineCheckpoint(
+                job.getWorkspaceId(),
+                job.getId(),
+                job.getDatasetId(),
+                reviewKind,
+                titleFor(reviewKind),
+                "Pipeline checkpoint review",
+                summaryJson(command, reviewKind),
+                now));
+    reviewTaskRepository.saveAll(
+        taskFactory.createTasks(session.getId(), reviewKind, artifactPayloadNode, now));
+    markWaiting(job, waitingStatus, summaryJson(command, reviewKind));
+    callbackSupportService.savePipelineJobOrThrowConflict(job, command.jobId());
+    callbackSupportService.markReceiptProcessed(command.externalEventId(), now);
+    return new PipelineReviewCheckpointUseCase.CheckpointCallbackResult(
+        "CREATED", command.externalEventId());
+  }
+
+  private PipelineJob runningJob(Long jobId) {
+    return pipelineJobRepository
+        .findById(jobId)
+        .orElseThrow(() -> new PipelineJobNotFoundException(jobId));
+  }
+
+  private void markWaiting(PipelineJob job, String waitingStatus, String summaryJson) {
+    if (PipelineJob.STATUS_WAITING_DOMAIN_CONFIRMATION.equals(waitingStatus)) {
+      job.markAwaitingDomainConfirmation(summaryJson);
+    } else {
+      job.markAwaitingHumanFeedback(summaryJson);
+    }
+  }
+
+  private String titleFor(String reviewKind) {
+    return ReviewSession.KIND_DOMAIN_CONFIRMATION.equals(reviewKind) ? "상담 도메인 확정" : "클러스터링 피드백";
+  }
+
+  private String summaryJson(
+      PipelineReviewCheckpointUseCase.CheckpointCallbackCommand command, String reviewKind) {
+    ObjectNode summary = jsonSupport.objectNode();
+    summary.put("reviewKind", reviewKind);
+    summary.put(FIELD_UPSTREAM_MANIFEST_PATH, command.upstreamManifestPath());
+    summary.put("artifactPath", command.artifactPath());
+    return jsonSupport.toJson(summary);
+  }
+}

--- a/backend/src/main/java/com/init/review/application/PipelineReviewCheckpointJsonSupport.java
+++ b/backend/src/main/java/com/init/review/application/PipelineReviewCheckpointJsonSupport.java
@@ -1,0 +1,61 @@
+package com.init.review.application;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.init.shared.application.exception.BadRequestException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PipelineReviewCheckpointJsonSupport {
+
+  private final ObjectMapper objectMapper;
+
+  public PipelineReviewCheckpointJsonSupport(ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  public ObjectNode objectNode() {
+    return objectMapper.createObjectNode();
+  }
+
+  public ArrayNode arrayNode() {
+    return objectMapper.createArrayNode();
+  }
+
+  public JsonNode requireArtifactPayload(JsonNode artifactPayload) {
+    if (artifactPayload == null || artifactPayload.isNull()) {
+      throw new BadRequestException(
+          "CHECKPOINT_ARTIFACT_PAYLOAD_REQUIRED", "artifactPayload는 필수입니다.");
+    }
+    return artifactPayload;
+  }
+
+  public String toJson(JsonNode node) {
+    try {
+      return objectMapper.writeValueAsString(node);
+    } catch (JsonProcessingException ex) {
+      throw new IllegalStateException("JSON serialization failed.", ex);
+    }
+  }
+
+  public JsonNode readJson(String value) {
+    try {
+      return objectMapper.readTree(value == null || value.isBlank() ? "{}" : value);
+    } catch (JsonProcessingException ex) {
+      throw new BadRequestException("INVALID_JSON", "JSON payload가 올바르지 않습니다.", ex);
+    }
+  }
+
+  public String text(JsonNode node, String fieldName) {
+    JsonNode value = node.path(fieldName);
+    return value.isMissingNode() || value.isNull() ? "" : value.asText("");
+  }
+
+  public double number(JsonNode node, String fieldName) {
+    JsonNode value = node.path(fieldName);
+    return value.isNumber() ? value.asDouble() : 0.0;
+  }
+}

--- a/backend/src/main/java/com/init/review/application/PipelineReviewCheckpointUseCase.java
+++ b/backend/src/main/java/com/init/review/application/PipelineReviewCheckpointUseCase.java
@@ -1,21 +1,13 @@
 package com.init.review.application;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.init.pipelinejob.application.DomainPackGenerationTriggerCommand;
-import com.init.pipelinejob.application.DomainPackGenerationTriggerPort;
-import com.init.pipelinejob.application.PipelineJobCallbackSupportService;
 import com.init.pipelinejob.application.WorkspaceMembershipPort;
-import com.init.pipelinejob.application.exception.AirflowTriggerFailedException;
-import com.init.pipelinejob.application.exception.PipelineJobAlreadyFinalizedException;
 import com.init.pipelinejob.application.exception.PipelineJobNotFoundException;
 import com.init.pipelinejob.application.exception.PipelineJobWorkspaceAccessDeniedException;
 import com.init.pipelinejob.domain.model.PipelineArtifact;
 import com.init.pipelinejob.domain.model.PipelineJob;
-import com.init.pipelinejob.domain.model.WebhookReceipt;
 import com.init.pipelinejob.domain.repository.PipelineArtifactRepository;
 import com.init.pipelinejob.domain.repository.PipelineJobRepository;
 import com.init.review.domain.model.ReviewDecision;
@@ -29,7 +21,6 @@ import com.init.shared.application.exception.NotFoundException;
 import com.init.shared.application.quota.WorkspaceQuotaValidator;
 import java.time.Clock;
 import java.time.OffsetDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -46,13 +37,10 @@ public class PipelineReviewCheckpointUseCase {
   public static final String WEBHOOK_TYPE_DOMAIN_CONFIRMATION =
       "DOMAIN_CONFIRMATION_CHECKPOINT_CALLBACK";
   public static final String WEBHOOK_TYPE_HUMAN_FEEDBACK = "HUMAN_FEEDBACK_CHECKPOINT_CALLBACK";
-  private static final String ARTIFACT_DOMAIN_CANDIDATES = "DOMAIN_CANDIDATES";
   private static final String ARTIFACT_CONFIRMED_DOMAIN_PROFILE = "CONFIRMED_DOMAIN_PROFILE";
-  private static final String ARTIFACT_FEEDBACK_QUESTIONS = "FEEDBACK_QUESTIONS";
   private static final String ARTIFACT_FEEDBACK_CONSTRAINTS = "FEEDBACK_CONSTRAINTS";
   private static final String FIELD_CONFIDENCE = "confidence";
   private static final String FIELD_DISPLAY_NAME = "displayName";
-  private static final String FIELD_UPSTREAM_MANIFEST_PATH = "upstreamManifestPath";
   private static final Set<String> ALLOWED_REVIEW_ROLES = Set.of("OWNER", "ADMIN", "OPERATOR");
 
   private final PipelineJobRepository pipelineJobRepository;
@@ -60,12 +48,11 @@ public class PipelineReviewCheckpointUseCase {
   private final ReviewSessionRepository reviewSessionRepository;
   private final ReviewTaskRepository reviewTaskRepository;
   private final ReviewDecisionRepository reviewDecisionRepository;
-  private final PipelineJobCallbackSupportService callbackSupportService;
-  private final PipelineJobFailurePersistenceService failurePersistenceService;
-  private final DomainPackGenerationTriggerPort triggerPort;
+  private final PipelineReviewCheckpointCallbackProcessor callbackProcessor;
+  private final PipelineReviewReplayOrchestrator replayOrchestrator;
   private final WorkspaceMembershipPort workspaceMembershipPort;
   private final WorkspaceQuotaValidator workspaceQuotaValidator;
-  private final ObjectMapper objectMapper;
+  private final PipelineReviewCheckpointJsonSupport jsonSupport;
   private final Clock clock;
 
   public PipelineReviewCheckpointUseCase(
@@ -74,47 +61,35 @@ public class PipelineReviewCheckpointUseCase {
       ReviewSessionRepository reviewSessionRepository,
       ReviewTaskRepository reviewTaskRepository,
       ReviewDecisionRepository reviewDecisionRepository,
-      PipelineJobCallbackSupportService callbackSupportService,
-      PipelineJobFailurePersistenceService failurePersistenceService,
-      DomainPackGenerationTriggerPort triggerPort,
+      PipelineReviewCheckpointCallbackProcessor callbackProcessor,
+      PipelineReviewReplayOrchestrator replayOrchestrator,
       WorkspaceMembershipPort workspaceMembershipPort,
       WorkspaceQuotaValidator workspaceQuotaValidator,
-      ObjectMapper objectMapper,
+      PipelineReviewCheckpointJsonSupport jsonSupport,
       Clock clock) {
     this.pipelineJobRepository = pipelineJobRepository;
     this.pipelineArtifactRepository = pipelineArtifactRepository;
     this.reviewSessionRepository = reviewSessionRepository;
     this.reviewTaskRepository = reviewTaskRepository;
     this.reviewDecisionRepository = reviewDecisionRepository;
-    this.callbackSupportService = callbackSupportService;
-    this.failurePersistenceService = failurePersistenceService;
-    this.triggerPort = triggerPort;
+    this.callbackProcessor = callbackProcessor;
+    this.replayOrchestrator = replayOrchestrator;
     this.workspaceMembershipPort = workspaceMembershipPort;
     this.workspaceQuotaValidator = workspaceQuotaValidator;
-    this.objectMapper = objectMapper;
+    this.jsonSupport = jsonSupport;
     this.clock = clock;
   }
 
   @Transactional
   public CheckpointCallbackResult receiveDomainConfirmationCheckpoint(
       CheckpointCallbackCommand command) {
-    return receiveCheckpoint(
-        command,
-        WEBHOOK_TYPE_DOMAIN_CONFIRMATION,
-        ReviewSession.KIND_DOMAIN_CONFIRMATION,
-        ARTIFACT_DOMAIN_CANDIDATES,
-        PipelineJob.STATUS_WAITING_DOMAIN_CONFIRMATION);
+    return callbackProcessor.receiveDomainConfirmationCheckpoint(command);
   }
 
   @Transactional
   public CheckpointCallbackResult receiveHumanFeedbackCheckpoint(
       CheckpointCallbackCommand command) {
-    return receiveCheckpoint(
-        command,
-        WEBHOOK_TYPE_HUMAN_FEEDBACK,
-        ReviewSession.KIND_HUMAN_FEEDBACK,
-        ARTIFACT_FEEDBACK_QUESTIONS,
-        PipelineJob.STATUS_WAITING_HUMAN_FEEDBACK);
+    return callbackProcessor.receiveHumanFeedbackCheckpoint(command);
   }
 
   @Transactional
@@ -131,13 +106,13 @@ public class PipelineReviewCheckpointUseCase {
     requireWorkspace(session, command.workspaceId());
     ReviewTask selectedTask =
         openTaskForSession(session, command.reviewTaskId(), ReviewTask.TARGET_DOMAIN_CANDIDATE);
-    JsonNode candidate = readJson(selectedTask.getTargetRefJson());
-    ObjectNode profile = objectMapper.createObjectNode();
+    JsonNode candidate = jsonSupport.readJson(selectedTask.getTargetRefJson());
+    ObjectNode profile = jsonSupport.objectNode();
     profile.put("schemaVersion", "confirmed-domain-profile.v1");
-    profile.put("candidateId", text(candidate, "candidateId"));
-    profile.put("confirmedDomain", text(candidate, FIELD_DISPLAY_NAME));
-    profile.put(FIELD_DISPLAY_NAME, text(candidate, FIELD_DISPLAY_NAME));
-    profile.put(FIELD_CONFIDENCE, number(candidate, FIELD_CONFIDENCE));
+    profile.put("candidateId", jsonSupport.text(candidate, "candidateId"));
+    profile.put("confirmedDomain", jsonSupport.text(candidate, FIELD_DISPLAY_NAME));
+    profile.put(FIELD_DISPLAY_NAME, jsonSupport.text(candidate, FIELD_DISPLAY_NAME));
+    profile.put(FIELD_CONFIDENCE, jsonSupport.number(candidate, FIELD_CONFIDENCE));
     profile.set("evidenceTerms", candidate.path("evidenceTerms"));
     profile.set("evidenceConversationIds", candidate.path("evidenceConversationIds"));
     profile.set("domainLexicon", candidate.path("suggestedDomainLexicon"));
@@ -155,7 +130,7 @@ public class PipelineReviewCheckpointUseCase {
             "CONFIRMED_DOMAIN",
             command.reason(),
             command.userId(),
-            toJson(profile),
+            jsonSupport.toJson(profile),
             now));
     List<ReviewTask> remainingTasks =
         openTasksForSession(session, ReviewTask.TARGET_DOMAIN_CANDIDATE).stream()
@@ -173,9 +148,9 @@ public class PipelineReviewCheckpointUseCase {
                 ARTIFACT_CONFIRMED_DOMAIN_PROFILE,
                 null,
                 null,
-                toJson(profile),
+                jsonSupport.toJson(profile),
                 now));
-    triggerReplay(job, "DOMAIN_CONFIRMED_REPLAY", artifact.getPayloadJson(), null, false);
+    replayOrchestrator.triggerDomainConfirmedReplay(job, artifact.getPayloadJson());
     return ReviewCheckpointResult.of(session.getId(), "DOMAIN_CONFIRMED_REPLAY_TRIGGERED");
   }
 
@@ -208,11 +183,11 @@ public class PipelineReviewCheckpointUseCase {
       throw new BadRequestException(
           "FEEDBACK_DECISIONS_INCOMPLETE", "모든 열린 피드백 문항에 답변해야 replay를 시작할 수 있습니다.");
     }
-    ArrayNode constraints = objectMapper.createArrayNode();
+    ArrayNode constraints = jsonSupport.arrayNode();
     OffsetDateTime now = OffsetDateTime.now(clock);
     for (FeedbackDecisionInput decision : decisionsByTaskId.values()) {
       ReviewTask task = openFeedbackTasks.get(decision.reviewTaskId());
-      JsonNode question = readJson(task.getTargetRefJson());
+      JsonNode question = jsonSupport.readJson(task.getTargetRefJson());
       task.resolve(command.userId(), now);
       reviewTaskRepository.save(task);
       String decisionType = normalizeFeedbackDecision(decision.decisionType());
@@ -224,13 +199,13 @@ public class PipelineReviewCheckpointUseCase {
               decisionType,
               decision.reason(),
               command.userId(),
-              toJson(decisionPayload(decisionType, question)),
+              jsonSupport.toJson(decisionPayload(decisionType, question)),
               now);
       savedDecision = reviewDecisionRepository.save(savedDecision);
       if (!"unsure".equals(decisionType)) {
         ObjectNode constraint = constraints.addObject();
-        constraint.put("sourceId", text(question, "sourceId"));
-        constraint.put("targetId", text(question, "targetId"));
+        constraint.put("sourceId", jsonSupport.text(question, "sourceId"));
+        constraint.put("targetId", jsonSupport.text(question, "targetId"));
         constraint.put("type", decisionType);
         constraint.put("confidence", 1.0);
         constraint.put("scope", "intent");
@@ -238,7 +213,7 @@ public class PipelineReviewCheckpointUseCase {
         constraint.put("decisionId", savedDecision.getId());
       }
     }
-    ObjectNode payload = objectMapper.createObjectNode();
+    ObjectNode payload = jsonSupport.objectNode();
     payload.put("schemaVersion", "feedback-constraints.v1");
     payload.put("resolvedBy", command.userId());
     payload.set("constraints", constraints);
@@ -252,14 +227,9 @@ public class PipelineReviewCheckpointUseCase {
                 ARTIFACT_FEEDBACK_CONSTRAINTS,
                 null,
                 null,
-                toJson(payload),
+                jsonSupport.toJson(payload),
                 now));
-    triggerReplay(
-        job,
-        "FEEDBACK_REPLAY",
-        latestArtifactJsonOrNull(job.getId(), ARTIFACT_CONFIRMED_DOMAIN_PROFILE),
-        artifact.getPayloadJson(),
-        true);
+    replayOrchestrator.triggerFeedbackReplay(job, artifact.getPayloadJson());
     return ReviewCheckpointResult.of(session.getId(), "FEEDBACK_REPLAY_TRIGGERED");
   }
 
@@ -288,193 +258,10 @@ public class PipelineReviewCheckpointUseCase {
                         task.getStatus(),
                         task.getPriority(),
                         task.getTitle(),
-                        readJson(task.getTargetRefJson())))
+                        jsonSupport.readJson(task.getTargetRefJson())))
             .toList();
     return new ReviewCheckpointView(
         pipelineJobId, job.getStatus(), session.get().getReviewKind(), tasks);
-  }
-
-  private CheckpointCallbackResult receiveCheckpoint(
-      CheckpointCallbackCommand command,
-      String webhookType,
-      String reviewKind,
-      String artifactType,
-      String waitingStatus) {
-    callbackSupportService.validateWebhookSecret(command.providedWebhookSecret());
-    Optional<WebhookReceipt> existingReceipt =
-        callbackSupportService.findReceipt(command.externalEventId());
-    callbackSupportService.validateWebhookType(
-        existingReceipt.orElse(null), command.externalEventId(), webhookType);
-    if (callbackSupportService.isProcessed(existingReceipt.orElse(null))) {
-      return new CheckpointCallbackResult("DUPLICATE_IGNORED", command.externalEventId());
-    }
-    PipelineJob job = runningJob(command.jobId());
-    if (job.isFinalized()) {
-      throw new PipelineJobAlreadyFinalizedException(command.jobId());
-    }
-    WebhookReceipt receipt =
-        callbackSupportService.ensureReceivedReceipt(
-            command.jobId(),
-            command.externalEventId(),
-            webhookType,
-            command.requestHeadersJson(),
-            command.requestBodyJson(),
-            existingReceipt.orElse(null));
-    if (callbackSupportService.isProcessed(receipt)) {
-      return new CheckpointCallbackResult("DUPLICATE_IGNORED", command.externalEventId());
-    }
-    return callbackSupportService.executeInTransactionOrMarkFailure(
-        command.jobId(),
-        command.externalEventId(),
-        () -> processCheckpoint(command, reviewKind, artifactType, waitingStatus));
-  }
-
-  private CheckpointCallbackResult processCheckpoint(
-      CheckpointCallbackCommand command,
-      String reviewKind,
-      String artifactType,
-      String waitingStatus) {
-    PipelineJob job = runningJob(command.jobId());
-    OffsetDateTime now = callbackSupportService.now();
-    JsonNode artifactPayloadNode = requireArtifactPayload(command.artifactPayload());
-    String artifactPayload = toJson(artifactPayloadNode);
-    pipelineArtifactRepository.save(
-        PipelineArtifact.create(
-            job.getId(),
-            reviewKind.toLowerCase(),
-            artifactType,
-            command.artifactPath(),
-            null,
-            artifactPayload,
-            now));
-    ReviewSession session =
-        reviewSessionRepository.save(
-            ReviewSession.createPipelineCheckpoint(
-                job.getWorkspaceId(),
-                job.getId(),
-                job.getDatasetId(),
-                reviewKind,
-                titleFor(reviewKind),
-                "Pipeline checkpoint review",
-                summaryJson(command, reviewKind),
-                now));
-    reviewTaskRepository.saveAll(tasksFor(session.getId(), reviewKind, artifactPayloadNode, now));
-    if (PipelineJob.STATUS_WAITING_DOMAIN_CONFIRMATION.equals(waitingStatus)) {
-      job.markAwaitingDomainConfirmation(summaryJson(command, reviewKind));
-    } else {
-      job.markAwaitingHumanFeedback(summaryJson(command, reviewKind));
-    }
-    callbackSupportService.savePipelineJobOrThrowConflict(job, command.jobId());
-    callbackSupportService.markReceiptProcessed(command.externalEventId(), now);
-    return new CheckpointCallbackResult("CREATED", command.externalEventId());
-  }
-
-  private List<ReviewTask> tasksFor(
-      Long sessionId, String reviewKind, JsonNode artifactPayload, OffsetDateTime now) {
-    List<ReviewTask> tasks = new ArrayList<>();
-    String arrayName =
-        ReviewSession.KIND_DOMAIN_CONFIRMATION.equals(reviewKind) ? "candidates" : "questions";
-    JsonNode rows = artifactPayload.path(arrayName);
-    if (!rows.isArray()) {
-      return tasks;
-    }
-    for (JsonNode row : rows) {
-      String title =
-          ReviewSession.KIND_DOMAIN_CONFIRMATION.equals(reviewKind)
-              ? text(row, "displayName")
-              : text(row, "questionText");
-      tasks.add(
-          ReviewTask.create(
-              sessionId,
-              ReviewSession.KIND_DOMAIN_CONFIRMATION.equals(reviewKind)
-                  ? ReviewTask.TARGET_DOMAIN_CANDIDATE
-                  : ReviewTask.TARGET_FEEDBACK_PAIR,
-              toJson(row),
-              title.isBlank() ? titleFor(reviewKind) : title,
-              text(row, "priority").isBlank() ? "NORMAL" : text(row, "priority"),
-              "{}",
-              now));
-    }
-    return tasks;
-  }
-
-  private void triggerReplay(
-      PipelineJob parentJob,
-      String runMode,
-      String confirmedDomainProfileJson,
-      String feedbackConstraintsJson,
-      boolean skipFeedbackCheckpoint) {
-    String upstreamManifestPath = upstreamManifestPath(parentJob);
-    String dagRunId = "pipeline_job_" + parentJob.getId() + "_" + runMode.toLowerCase();
-    try {
-      triggerPort.trigger(
-          new DomainPackGenerationTriggerCommand(
-              parentJob.getWorkspaceId(),
-              parentJob.getDatasetId(),
-              parentJob.getId(),
-              dagRunId,
-              "",
-              runMode,
-              parentJob.getId(),
-              upstreamManifestPath,
-              null,
-              null,
-              confirmedDomainProfileJson,
-              feedbackConstraintsJson,
-              skipFeedbackCheckpoint));
-      parentJob.markRunning(
-          replaySummaryJson(
-              runMode, upstreamManifestPath, confirmedDomainProfileJson, feedbackConstraintsJson));
-      pipelineJobRepository.saveAndFlush(parentJob);
-    } catch (AirflowTriggerFailedException ex) {
-      failurePersistenceService.markFailed(parentJob, ex.getMessage(), OffsetDateTime.now(clock));
-      throw ex;
-    }
-  }
-
-  private JsonNode requireArtifactPayload(JsonNode artifactPayload) {
-    if (artifactPayload == null || artifactPayload.isNull()) {
-      throw new BadRequestException(
-          "CHECKPOINT_ARTIFACT_PAYLOAD_REQUIRED", "artifactPayload는 필수입니다.");
-    }
-    return artifactPayload;
-  }
-
-  private String upstreamManifestPath(PipelineJob job) {
-    JsonNode summary = readJson(job.getResultSummaryJson());
-    String value = text(summary, FIELD_UPSTREAM_MANIFEST_PATH);
-    if (!value.isBlank()) {
-      return value;
-    }
-    value = text(summary, "upstream_manifest_path");
-    if (!value.isBlank()) {
-      return value;
-    }
-    JsonNode meta = latestArtifactPayload(job.getId(), ARTIFACT_DOMAIN_CANDIDATES);
-    value = text(meta, FIELD_UPSTREAM_MANIFEST_PATH);
-    if (!value.isBlank()) {
-      return value;
-    }
-    throw new BadRequestException(
-        "REPLAY_UPSTREAM_MISSING", "Replay upstream manifest path가 없습니다.");
-  }
-
-  private JsonNode latestArtifactPayload(Long pipelineJobId, String artifactType) {
-    return pipelineArtifactRepository
-        .findByPipelineJobIdAndArtifactTypeOrderByCreatedAtDesc(pipelineJobId, artifactType)
-        .stream()
-        .findFirst()
-        .map(artifact -> readJson(artifact.getPayloadJson()))
-        .orElse(objectMapper.createObjectNode());
-  }
-
-  private String latestArtifactJsonOrNull(Long pipelineJobId, String artifactType) {
-    return pipelineArtifactRepository
-        .findByPipelineJobIdAndArtifactTypeOrderByCreatedAtDesc(pipelineJobId, artifactType)
-        .stream()
-        .findFirst()
-        .map(PipelineArtifact::getPayloadJson)
-        .orElse(null);
   }
 
   private ReviewSession openSession(Long pipelineJobId, String kind, boolean requireOpen) {
@@ -536,10 +323,6 @@ public class PipelineReviewCheckpointUseCase {
         .orElseThrow(() -> new PipelineJobNotFoundException(jobId));
   }
 
-  private String titleFor(String reviewKind) {
-    return ReviewSession.KIND_DOMAIN_CONFIRMATION.equals(reviewKind) ? "상담 도메인 확정" : "클러스터링 피드백";
-  }
-
   private String reviewKindForStatus(String status) {
     if (PipelineJob.STATUS_WAITING_DOMAIN_CONFIRMATION.equals(status)) {
       return ReviewSession.KIND_DOMAIN_CONFIRMATION;
@@ -548,31 +331,6 @@ public class PipelineReviewCheckpointUseCase {
       return ReviewSession.KIND_HUMAN_FEEDBACK;
     }
     return "";
-  }
-
-  private String summaryJson(CheckpointCallbackCommand command, String reviewKind) {
-    ObjectNode summary = objectMapper.createObjectNode();
-    summary.put("reviewKind", reviewKind);
-    summary.put(FIELD_UPSTREAM_MANIFEST_PATH, command.upstreamManifestPath());
-    summary.put("artifactPath", command.artifactPath());
-    return toJson(summary);
-  }
-
-  private String replaySummaryJson(
-      String runMode,
-      String upstreamManifestPath,
-      String confirmedDomainProfileJson,
-      String feedbackConstraintsJson) {
-    ObjectNode summary = objectMapper.createObjectNode();
-    summary.put("runMode", runMode);
-    summary.put(FIELD_UPSTREAM_MANIFEST_PATH, upstreamManifestPath);
-    if (confirmedDomainProfileJson != null) {
-      summary.set("confirmedDomainProfile", readJson(confirmedDomainProfileJson));
-    }
-    if (feedbackConstraintsJson != null) {
-      summary.set("feedbackConstraints", readJson(feedbackConstraintsJson));
-    }
-    return toJson(summary);
   }
 
   private String normalizeFeedbackDecision(String decisionType) {
@@ -587,36 +345,10 @@ public class PipelineReviewCheckpointUseCase {
   }
 
   private ObjectNode decisionPayload(String decisionType, JsonNode question) {
-    ObjectNode payload = objectMapper.createObjectNode();
+    ObjectNode payload = jsonSupport.objectNode();
     payload.put("decisionType", decisionType);
     payload.set("question", question);
     return payload;
-  }
-
-  private String toJson(JsonNode node) {
-    try {
-      return objectMapper.writeValueAsString(node);
-    } catch (JsonProcessingException ex) {
-      throw new IllegalStateException("JSON serialization failed.", ex);
-    }
-  }
-
-  private JsonNode readJson(String value) {
-    try {
-      return objectMapper.readTree(value == null || value.isBlank() ? "{}" : value);
-    } catch (JsonProcessingException ex) {
-      throw new BadRequestException("INVALID_JSON", "JSON payload가 올바르지 않습니다.", ex);
-    }
-  }
-
-  private String text(JsonNode node, String fieldName) {
-    JsonNode value = node.path(fieldName);
-    return value.isMissingNode() || value.isNull() ? "" : value.asText("");
-  }
-
-  private double number(JsonNode node, String fieldName) {
-    JsonNode value = node.path(fieldName);
-    return value.isNumber() ? value.asDouble() : 0.0;
   }
 
   public record CheckpointCallbackCommand(

--- a/backend/src/main/java/com/init/review/application/PipelineReviewReplayOrchestrator.java
+++ b/backend/src/main/java/com/init/review/application/PipelineReviewReplayOrchestrator.java
@@ -1,0 +1,147 @@
+package com.init.review.application;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.init.pipelinejob.application.DomainPackGenerationTriggerCommand;
+import com.init.pipelinejob.application.DomainPackGenerationTriggerPort;
+import com.init.pipelinejob.application.exception.AirflowTriggerFailedException;
+import com.init.pipelinejob.domain.model.PipelineArtifact;
+import com.init.pipelinejob.domain.model.PipelineJob;
+import com.init.pipelinejob.domain.repository.PipelineArtifactRepository;
+import com.init.pipelinejob.domain.repository.PipelineJobRepository;
+import com.init.shared.application.exception.BadRequestException;
+import java.time.Clock;
+import java.time.OffsetDateTime;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PipelineReviewReplayOrchestrator {
+
+  private static final String ARTIFACT_DOMAIN_CANDIDATES = "DOMAIN_CANDIDATES";
+  private static final String ARTIFACT_CONFIRMED_DOMAIN_PROFILE = "CONFIRMED_DOMAIN_PROFILE";
+  private static final String FIELD_UPSTREAM_MANIFEST_PATH = "upstreamManifestPath";
+
+  private final PipelineArtifactRepository pipelineArtifactRepository;
+  private final PipelineJobRepository pipelineJobRepository;
+  private final PipelineJobFailurePersistenceService failurePersistenceService;
+  private final DomainPackGenerationTriggerPort triggerPort;
+  private final PipelineReviewCheckpointJsonSupport jsonSupport;
+  private final Clock clock;
+
+  public PipelineReviewReplayOrchestrator(
+      PipelineArtifactRepository pipelineArtifactRepository,
+      PipelineJobRepository pipelineJobRepository,
+      PipelineJobFailurePersistenceService failurePersistenceService,
+      DomainPackGenerationTriggerPort triggerPort,
+      PipelineReviewCheckpointJsonSupport jsonSupport,
+      Clock clock) {
+    this.pipelineArtifactRepository = pipelineArtifactRepository;
+    this.pipelineJobRepository = pipelineJobRepository;
+    this.failurePersistenceService = failurePersistenceService;
+    this.triggerPort = triggerPort;
+    this.jsonSupport = jsonSupport;
+    this.clock = clock;
+  }
+
+  public void triggerDomainConfirmedReplay(
+      PipelineJob parentJob, String confirmedDomainProfileJson) {
+    triggerReplay(parentJob, "DOMAIN_CONFIRMED_REPLAY", confirmedDomainProfileJson, null, false);
+  }
+
+  public void triggerFeedbackReplay(PipelineJob parentJob, String feedbackConstraintsJson) {
+    triggerReplay(
+        parentJob,
+        "FEEDBACK_REPLAY",
+        latestArtifactJsonOrNull(parentJob.getId(), ARTIFACT_CONFIRMED_DOMAIN_PROFILE),
+        feedbackConstraintsJson,
+        true);
+  }
+
+  private void triggerReplay(
+      PipelineJob parentJob,
+      String runMode,
+      String confirmedDomainProfileJson,
+      String feedbackConstraintsJson,
+      boolean skipFeedbackCheckpoint) {
+    String upstreamManifestPath = upstreamManifestPath(parentJob);
+    String dagRunId = "pipeline_job_" + parentJob.getId() + "_" + runMode.toLowerCase();
+    try {
+      triggerPort.trigger(
+          new DomainPackGenerationTriggerCommand(
+              parentJob.getWorkspaceId(),
+              parentJob.getDatasetId(),
+              parentJob.getId(),
+              dagRunId,
+              "",
+              runMode,
+              parentJob.getId(),
+              upstreamManifestPath,
+              null,
+              null,
+              confirmedDomainProfileJson,
+              feedbackConstraintsJson,
+              skipFeedbackCheckpoint));
+      parentJob.markRunning(
+          replaySummaryJson(
+              runMode, upstreamManifestPath, confirmedDomainProfileJson, feedbackConstraintsJson));
+      pipelineJobRepository.saveAndFlush(parentJob);
+    } catch (AirflowTriggerFailedException ex) {
+      failurePersistenceService.markFailed(parentJob, ex.getMessage(), OffsetDateTime.now(clock));
+      throw ex;
+    }
+  }
+
+  private String upstreamManifestPath(PipelineJob job) {
+    JsonNode summary = jsonSupport.readJson(job.getResultSummaryJson());
+    String value = jsonSupport.text(summary, FIELD_UPSTREAM_MANIFEST_PATH);
+    if (!value.isBlank()) {
+      return value;
+    }
+    value = jsonSupport.text(summary, "upstream_manifest_path");
+    if (!value.isBlank()) {
+      return value;
+    }
+    JsonNode meta = latestArtifactPayload(job.getId(), ARTIFACT_DOMAIN_CANDIDATES);
+    value = jsonSupport.text(meta, FIELD_UPSTREAM_MANIFEST_PATH);
+    if (!value.isBlank()) {
+      return value;
+    }
+    throw new BadRequestException(
+        "REPLAY_UPSTREAM_MISSING", "Replay upstream manifest path가 없습니다.");
+  }
+
+  private JsonNode latestArtifactPayload(Long pipelineJobId, String artifactType) {
+    return pipelineArtifactRepository
+        .findByPipelineJobIdAndArtifactTypeOrderByCreatedAtDesc(pipelineJobId, artifactType)
+        .stream()
+        .findFirst()
+        .map(artifact -> jsonSupport.readJson(artifact.getPayloadJson()))
+        .orElse(jsonSupport.objectNode());
+  }
+
+  private String latestArtifactJsonOrNull(Long pipelineJobId, String artifactType) {
+    return pipelineArtifactRepository
+        .findByPipelineJobIdAndArtifactTypeOrderByCreatedAtDesc(pipelineJobId, artifactType)
+        .stream()
+        .findFirst()
+        .map(PipelineArtifact::getPayloadJson)
+        .orElse(null);
+  }
+
+  private String replaySummaryJson(
+      String runMode,
+      String upstreamManifestPath,
+      String confirmedDomainProfileJson,
+      String feedbackConstraintsJson) {
+    ObjectNode summary = jsonSupport.objectNode();
+    summary.put("runMode", runMode);
+    summary.put(FIELD_UPSTREAM_MANIFEST_PATH, upstreamManifestPath);
+    if (confirmedDomainProfileJson != null) {
+      summary.set("confirmedDomainProfile", jsonSupport.readJson(confirmedDomainProfileJson));
+    }
+    if (feedbackConstraintsJson != null) {
+      summary.set("feedbackConstraints", jsonSupport.readJson(feedbackConstraintsJson));
+    }
+    return jsonSupport.toJson(summary);
+  }
+}

--- a/backend/src/main/java/com/init/review/application/PipelineReviewTaskFactory.java
+++ b/backend/src/main/java/com/init/review/application/PipelineReviewTaskFactory.java
@@ -1,0 +1,66 @@
+package com.init.review.application;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.init.review.domain.model.ReviewSession;
+import com.init.review.domain.model.ReviewTask;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PipelineReviewTaskFactory {
+
+  private final PipelineReviewCheckpointJsonSupport jsonSupport;
+
+  public PipelineReviewTaskFactory(PipelineReviewCheckpointJsonSupport jsonSupport) {
+    this.jsonSupport = jsonSupport;
+  }
+
+  public List<ReviewTask> createTasks(
+      Long sessionId, String reviewKind, JsonNode artifactPayload, OffsetDateTime now) {
+    List<ReviewTask> tasks = new ArrayList<>();
+    JsonNode rows = artifactPayload.path(arrayName(reviewKind));
+    if (!rows.isArray()) {
+      return tasks;
+    }
+    for (JsonNode row : rows) {
+      String title = title(row, reviewKind);
+      tasks.add(
+          ReviewTask.create(
+              sessionId,
+              targetType(reviewKind),
+              jsonSupport.toJson(row),
+              title.isBlank() ? titleFor(reviewKind) : title,
+              priority(row),
+              "{}",
+              now));
+    }
+    return tasks;
+  }
+
+  private String arrayName(String reviewKind) {
+    return ReviewSession.KIND_DOMAIN_CONFIRMATION.equals(reviewKind) ? "candidates" : "questions";
+  }
+
+  private String targetType(String reviewKind) {
+    return ReviewSession.KIND_DOMAIN_CONFIRMATION.equals(reviewKind)
+        ? ReviewTask.TARGET_DOMAIN_CANDIDATE
+        : ReviewTask.TARGET_FEEDBACK_PAIR;
+  }
+
+  private String title(JsonNode row, String reviewKind) {
+    return ReviewSession.KIND_DOMAIN_CONFIRMATION.equals(reviewKind)
+        ? jsonSupport.text(row, "displayName")
+        : jsonSupport.text(row, "questionText");
+  }
+
+  private String priority(JsonNode row) {
+    String priority = jsonSupport.text(row, "priority");
+    return priority.isBlank() ? "NORMAL" : priority;
+  }
+
+  private String titleFor(String reviewKind) {
+    return ReviewSession.KIND_DOMAIN_CONFIRMATION.equals(reviewKind) ? "상담 도메인 확정" : "클러스터링 피드백";
+  }
+}

--- a/backend/src/test/java/com/init/review/application/PipelineReviewCheckpointCallbackProcessorTest.java
+++ b/backend/src/test/java/com/init/review/application/PipelineReviewCheckpointCallbackProcessorTest.java
@@ -1,0 +1,186 @@
+package com.init.review.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.init.pipelinejob.application.PipelineJobCallbackSupportService;
+import com.init.pipelinejob.domain.model.PipelineArtifact;
+import com.init.pipelinejob.domain.model.PipelineJob;
+import com.init.pipelinejob.domain.model.WebhookReceipt;
+import com.init.pipelinejob.domain.repository.PipelineArtifactRepository;
+import com.init.pipelinejob.domain.repository.PipelineJobRepository;
+import com.init.review.domain.model.ReviewSession;
+import com.init.review.domain.model.ReviewTask;
+import com.init.review.domain.repository.ReviewSessionRepository;
+import com.init.review.domain.repository.ReviewTaskRepository;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PipelineReviewCheckpointCallbackProcessor")
+class PipelineReviewCheckpointCallbackProcessorTest {
+
+  private static final OffsetDateTime NOW = OffsetDateTime.parse("2026-06-01T01:00:00Z");
+
+  @Mock private PipelineJobRepository pipelineJobRepository;
+  @Mock private PipelineArtifactRepository pipelineArtifactRepository;
+  @Mock private ReviewSessionRepository reviewSessionRepository;
+  @Mock private ReviewTaskRepository reviewTaskRepository;
+  @Mock private PipelineJobCallbackSupportService callbackSupportService;
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+  private PipelineReviewCheckpointCallbackProcessor processor;
+
+  @BeforeEach
+  void setUp() {
+    PipelineReviewCheckpointJsonSupport jsonSupport =
+        new PipelineReviewCheckpointJsonSupport(objectMapper);
+    processor =
+        new PipelineReviewCheckpointCallbackProcessor(
+            pipelineJobRepository,
+            pipelineArtifactRepository,
+            reviewSessionRepository,
+            reviewTaskRepository,
+            callbackSupportService,
+            new PipelineReviewTaskFactory(jsonSupport),
+            jsonSupport);
+  }
+
+  @Test
+  @DisplayName("processed receipt가 있는 duplicate callback은 상태를 변경하지 않는다")
+  void receiveCheckpoint_processedReceipt_returnsDuplicateIgnoredWithoutMutation() {
+    WebhookReceipt receipt =
+        WebhookReceipt.receive(
+            7L,
+            "evt-dup",
+            PipelineReviewCheckpointUseCase.WEBHOOK_TYPE_DOMAIN_CONFIRMATION,
+            "{}",
+            "{}",
+            NOW);
+    receipt.markProcessed(NOW);
+
+    given(callbackSupportService.findReceipt("evt-dup")).willReturn(Optional.of(receipt));
+    given(callbackSupportService.isProcessed(receipt)).willReturn(true);
+
+    PipelineReviewCheckpointUseCase.CheckpointCallbackResult result =
+        processor.receiveDomainConfirmationCheckpoint(
+            command("evt-dup", "domain_pack_generation", "run-1", objectMapper.createObjectNode()));
+
+    assertThat(result.status()).isEqualTo("DUPLICATE_IGNORED");
+    verify(pipelineJobRepository, never()).findById(any());
+    verify(pipelineArtifactRepository, never()).save(any(PipelineArtifact.class));
+    verify(reviewSessionRepository, never()).save(any(ReviewSession.class));
+    verify(reviewTaskRepository, never()).saveAll(any());
+  }
+
+  @Test
+  @DisplayName("human feedback callback은 feedback task를 만들고 job을 feedback 대기로 전환한다")
+  void receiveHumanFeedbackCheckpoint_createsFeedbackTasksAndWaitingStatus() throws Exception {
+    PipelineJob job = job(PipelineJob.STATUS_RUNNING);
+    JsonNode payload =
+        objectMapper.readTree(
+            """
+            {
+              "upstreamManifestPath": "/artifacts/domain-replay/manifest.json",
+              "questions": [
+                {"sourceId": "c1", "targetId": "c2", "questionText": "같은 업무인가?"}
+              ]
+            }
+            """);
+    WebhookReceipt receipt =
+        WebhookReceipt.receive(
+            7L,
+            "evt-feedback",
+            PipelineReviewCheckpointUseCase.WEBHOOK_TYPE_HUMAN_FEEDBACK,
+            "{}",
+            "{}",
+            NOW);
+
+    given(pipelineJobRepository.findById(7L)).willReturn(Optional.of(job));
+    given(callbackSupportService.findReceipt("evt-feedback")).willReturn(Optional.empty());
+    given(
+            callbackSupportService.ensureReceivedReceipt(
+                eq(7L),
+                eq("evt-feedback"),
+                eq(PipelineReviewCheckpointUseCase.WEBHOOK_TYPE_HUMAN_FEEDBACK),
+                eq("{}"),
+                eq("{}"),
+                eq(null)))
+        .willReturn(receipt);
+    given(callbackSupportService.now()).willReturn(NOW);
+    given(pipelineArtifactRepository.save(any(PipelineArtifact.class)))
+        .willAnswer(invocation -> invocation.getArgument(0));
+    given(reviewSessionRepository.save(any(ReviewSession.class)))
+        .willAnswer(
+            invocation -> {
+              ReviewSession session = invocation.getArgument(0);
+              ReflectionTestUtils.setField(session, "id", 56L);
+              return session;
+            });
+    given(
+            callbackSupportService.executeInTransactionOrMarkFailure(
+                eq(7L), eq("evt-feedback"), any()))
+        .willAnswer(invocation -> invocation.<Supplier<?>>getArgument(2).get());
+
+    PipelineReviewCheckpointUseCase.CheckpointCallbackResult result =
+        processor.receiveHumanFeedbackCheckpoint(
+            command("evt-feedback", "domain_pack_generation", "run-2", payload));
+
+    ArgumentCaptor<Iterable<ReviewTask>> tasksCaptor = ArgumentCaptor.forClass(Iterable.class);
+    verify(reviewTaskRepository).saveAll(tasksCaptor.capture());
+    List<ReviewTask> tasks = toList(tasksCaptor.getValue());
+
+    assertThat(result.status()).isEqualTo("CREATED");
+    assertThat(job.getStatus()).isEqualTo(PipelineJob.STATUS_WAITING_HUMAN_FEEDBACK);
+    assertThat(tasks).hasSize(1);
+    assertThat(tasks.getFirst().getTargetType()).isEqualTo(ReviewTask.TARGET_FEEDBACK_PAIR);
+    assertThat(tasks.getFirst().getTitle()).isEqualTo("같은 업무인가?");
+  }
+
+  private PipelineReviewCheckpointUseCase.CheckpointCallbackCommand command(
+      String eventId, String dagId, String dagRunId, JsonNode artifactPayload) {
+    return new PipelineReviewCheckpointUseCase.CheckpointCallbackCommand(
+        7L,
+        "secret",
+        eventId,
+        dagId,
+        dagRunId,
+        "REPLAY",
+        null,
+        "/artifacts/domain-replay/manifest.json",
+        "/artifacts/feedback_questions.json",
+        artifactPayload,
+        "{}",
+        "{}");
+  }
+
+  private PipelineJob job(String status) {
+    PipelineJob job = PipelineJob.createDomainPackGeneration(1L, 3L, 9L, "{}", NOW.minusHours(1));
+    ReflectionTestUtils.setField(job, "id", 7L);
+    ReflectionTestUtils.setField(job, "status", status);
+    return job;
+  }
+
+  private List<ReviewTask> toList(Iterable<ReviewTask> tasks) {
+    if (tasks instanceof List<ReviewTask> list) {
+      return list;
+    }
+    return List.of();
+  }
+}

--- a/backend/src/test/java/com/init/review/application/PipelineReviewCheckpointUseCaseTest.java
+++ b/backend/src/test/java/com/init/review/application/PipelineReviewCheckpointUseCaseTest.java
@@ -72,6 +72,8 @@ class PipelineReviewCheckpointUseCaseTest {
 
   @BeforeEach
   void setUp() {
+    PipelineReviewCheckpointJsonSupport jsonSupport =
+        new PipelineReviewCheckpointJsonSupport(objectMapper);
     useCase =
         new PipelineReviewCheckpointUseCase(
             pipelineJobRepository,
@@ -79,12 +81,24 @@ class PipelineReviewCheckpointUseCaseTest {
             reviewSessionRepository,
             reviewTaskRepository,
             reviewDecisionRepository,
-            callbackSupportService,
-            failurePersistenceService,
-            triggerPort,
+            new PipelineReviewCheckpointCallbackProcessor(
+                pipelineJobRepository,
+                pipelineArtifactRepository,
+                reviewSessionRepository,
+                reviewTaskRepository,
+                callbackSupportService,
+                new PipelineReviewTaskFactory(jsonSupport),
+                jsonSupport),
+            new PipelineReviewReplayOrchestrator(
+                pipelineArtifactRepository,
+                pipelineJobRepository,
+                failurePersistenceService,
+                triggerPort,
+                jsonSupport,
+                CLOCK),
             workspaceMembershipPort,
             workspaceQuotaValidator,
-            objectMapper,
+            jsonSupport,
             CLOCK);
   }
 

--- a/backend/src/test/java/com/init/review/application/PipelineReviewReplayOrchestratorTest.java
+++ b/backend/src/test/java/com/init/review/application/PipelineReviewReplayOrchestratorTest.java
@@ -1,0 +1,144 @@
+package com.init.review.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.init.pipelinejob.application.DomainPackGenerationTriggerCommand;
+import com.init.pipelinejob.application.DomainPackGenerationTriggerPort;
+import com.init.pipelinejob.application.DomainPackGenerationTriggerResult;
+import com.init.pipelinejob.application.exception.AirflowTriggerFailedException;
+import com.init.pipelinejob.domain.model.PipelineArtifact;
+import com.init.pipelinejob.domain.model.PipelineJob;
+import com.init.pipelinejob.domain.repository.PipelineArtifactRepository;
+import com.init.pipelinejob.domain.repository.PipelineJobRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PipelineReviewReplayOrchestrator")
+class PipelineReviewReplayOrchestratorTest {
+
+  private static final Clock CLOCK =
+      Clock.fixed(Instant.parse("2026-06-01T01:00:00Z"), ZoneOffset.UTC);
+  private static final OffsetDateTime NOW = OffsetDateTime.now(CLOCK);
+
+  @Mock private PipelineArtifactRepository pipelineArtifactRepository;
+  @Mock private PipelineJobRepository pipelineJobRepository;
+  @Mock private PipelineJobFailurePersistenceService failurePersistenceService;
+  @Mock private DomainPackGenerationTriggerPort triggerPort;
+
+  private PipelineReviewReplayOrchestrator orchestrator;
+
+  @BeforeEach
+  void setUp() {
+    orchestrator =
+        new PipelineReviewReplayOrchestrator(
+            pipelineArtifactRepository,
+            pipelineJobRepository,
+            failurePersistenceService,
+            triggerPort,
+            new PipelineReviewCheckpointJsonSupport(new ObjectMapper()),
+            CLOCK);
+  }
+
+  @Test
+  @DisplayName("domain confirmation replay는 trigger command를 만들고 parent job을 RUNNING으로 되돌린다")
+  void triggerDomainConfirmedReplay_triggersAirflowAndMarksRunning() {
+    PipelineJob job =
+        job(
+            PipelineJob.STATUS_WAITING_DOMAIN_CONFIRMATION,
+            "{\"upstreamManifestPath\":\"/artifacts/initial/manifest.json\"}");
+    given(triggerPort.trigger(any(DomainPackGenerationTriggerCommand.class)))
+        .willReturn(new DomainPackGenerationTriggerResult("domain_pack_generation", "run-2"));
+
+    orchestrator.triggerDomainConfirmedReplay(job, "{\"confirmedDomain\":\"카드 상담\"}");
+
+    ArgumentCaptor<DomainPackGenerationTriggerCommand> triggerCaptor =
+        ArgumentCaptor.forClass(DomainPackGenerationTriggerCommand.class);
+    verify(triggerPort).trigger(triggerCaptor.capture());
+    verify(pipelineJobRepository).saveAndFlush(job);
+
+    assertThat(job.getStatus()).isEqualTo(PipelineJob.STATUS_RUNNING);
+    assertThat(triggerCaptor.getValue().runMode()).isEqualTo("DOMAIN_CONFIRMED_REPLAY");
+    assertThat(triggerCaptor.getValue().parentPipelineJobId()).isEqualTo(7L);
+    assertThat(triggerCaptor.getValue().confirmedDomainProfileJson()).contains("카드 상담");
+    assertThat(triggerCaptor.getValue().skipFeedbackCheckpoint()).isFalse();
+  }
+
+  @Test
+  @DisplayName("feedback replay는 confirmed profile artifact를 함께 전달하고 feedback checkpoint를 건너뛴다")
+  void triggerFeedbackReplay_usesConfirmedProfileArtifactAndSkipFlag() {
+    PipelineJob job =
+        job(
+            PipelineJob.STATUS_WAITING_HUMAN_FEEDBACK,
+            "{\"upstreamManifestPath\":\"/artifacts/domain-replay/manifest.json\"}");
+    PipelineArtifact confirmedProfile =
+        PipelineArtifact.create(
+            7L,
+            "domain_confirmation",
+            "CONFIRMED_DOMAIN_PROFILE",
+            null,
+            null,
+            "{\"confirmedDomain\":\"카드 상담\"}",
+            NOW);
+
+    given(
+            pipelineArtifactRepository.findByPipelineJobIdAndArtifactTypeOrderByCreatedAtDesc(
+                7L, "CONFIRMED_DOMAIN_PROFILE"))
+        .willReturn(List.of(confirmedProfile));
+    given(triggerPort.trigger(any(DomainPackGenerationTriggerCommand.class)))
+        .willReturn(new DomainPackGenerationTriggerResult("domain_pack_generation", "run-3"));
+
+    orchestrator.triggerFeedbackReplay(job, "{\"constraints\":[]}");
+
+    ArgumentCaptor<DomainPackGenerationTriggerCommand> triggerCaptor =
+        ArgumentCaptor.forClass(DomainPackGenerationTriggerCommand.class);
+    verify(triggerPort).trigger(triggerCaptor.capture());
+
+    assertThat(triggerCaptor.getValue().runMode()).isEqualTo("FEEDBACK_REPLAY");
+    assertThat(triggerCaptor.getValue().confirmedDomainProfileJson()).contains("카드 상담");
+    assertThat(triggerCaptor.getValue().feedbackConstraintsJson()).contains("constraints");
+    assertThat(triggerCaptor.getValue().skipFeedbackCheckpoint()).isTrue();
+  }
+
+  @Test
+  @DisplayName("Airflow replay trigger 실패 시 parent job 실패 persistence에 위임한다")
+  void triggerDomainConfirmedReplay_triggerFailure_marksParentJobFailed() {
+    PipelineJob job =
+        job(
+            PipelineJob.STATUS_WAITING_DOMAIN_CONFIRMATION,
+            "{\"upstreamManifestPath\":\"/artifacts/initial/manifest.json\"}");
+    given(triggerPort.trigger(any(DomainPackGenerationTriggerCommand.class)))
+        .willThrow(new AirflowTriggerFailedException(7L, "airflow offline"));
+
+    assertThatThrownBy(
+            () -> orchestrator.triggerDomainConfirmedReplay(job, "{\"confirmedDomain\":\"카드 상담\"}"))
+        .isInstanceOf(AirflowTriggerFailedException.class);
+
+    verify(failurePersistenceService).markFailed(eq(job), eq("airflow offline"), eq(NOW));
+  }
+
+  private PipelineJob job(String status, String summaryJson) {
+    PipelineJob job = PipelineJob.createDomainPackGeneration(1L, 3L, 9L, "{}", NOW.minusHours(1));
+    ReflectionTestUtils.setField(job, "id", 7L);
+    ReflectionTestUtils.setField(job, "status", status);
+    ReflectionTestUtils.setField(job, "resultSummaryJson", summaryJson);
+    return job;
+  }
+}

--- a/backend/src/test/java/com/init/review/application/PipelineReviewTaskFactoryTest.java
+++ b/backend/src/test/java/com/init/review/application/PipelineReviewTaskFactoryTest.java
@@ -1,0 +1,70 @@
+package com.init.review.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.init.review.domain.model.ReviewSession;
+import com.init.review.domain.model.ReviewTask;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("PipelineReviewTaskFactory")
+class PipelineReviewTaskFactoryTest {
+
+  private static final OffsetDateTime NOW = OffsetDateTime.parse("2026-06-01T01:00:00Z");
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+  private final PipelineReviewTaskFactory taskFactory =
+      new PipelineReviewTaskFactory(new PipelineReviewCheckpointJsonSupport(objectMapper));
+
+  @Test
+  @DisplayName("domain confirmation payload를 domain candidate review task로 변환한다")
+  void createTasks_domainConfirmation_createsCandidateTasks() throws Exception {
+    JsonNode payload =
+        objectMapper.readTree(
+            """
+            {
+              "candidates": [
+                {"candidateId": "card", "displayName": "카드 상담", "priority": "HIGH"},
+                {"candidateId": "misc"}
+              ]
+            }
+            """);
+
+    List<ReviewTask> tasks =
+        taskFactory.createTasks(55L, ReviewSession.KIND_DOMAIN_CONFIRMATION, payload, NOW);
+
+    assertThat(tasks).hasSize(2);
+    assertThat(tasks.getFirst().getReviewSessionId()).isEqualTo(55L);
+    assertThat(tasks.getFirst().getTargetType()).isEqualTo(ReviewTask.TARGET_DOMAIN_CANDIDATE);
+    assertThat(tasks.getFirst().getTitle()).isEqualTo("카드 상담");
+    assertThat(tasks.getFirst().getPriority()).isEqualTo("HIGH");
+    assertThat(tasks.get(1).getTitle()).isEqualTo("상담 도메인 확정");
+    assertThat(tasks.get(1).getPriority()).isEqualTo("NORMAL");
+  }
+
+  @Test
+  @DisplayName("human feedback payload를 feedback pair review task로 변환한다")
+  void createTasks_humanFeedback_createsFeedbackTasks() throws Exception {
+    JsonNode payload =
+        objectMapper.readTree(
+            """
+            {
+              "questions": [
+                {"sourceId": "c1", "targetId": "c2", "questionText": "같은 업무인가?"}
+              ]
+            }
+            """);
+
+    List<ReviewTask> tasks =
+        taskFactory.createTasks(56L, ReviewSession.KIND_HUMAN_FEEDBACK, payload, NOW);
+
+    assertThat(tasks).hasSize(1);
+    assertThat(tasks.getFirst().getTargetType()).isEqualTo(ReviewTask.TARGET_FEEDBACK_PAIR);
+    assertThat(tasks.getFirst().getTitle()).isEqualTo("같은 업무인가?");
+    assertThat(tasks.getFirst().getTargetRefJson()).contains("\"sourceId\":\"c1\"");
+  }
+}


### PR DESCRIPTION
Closes #613

## 변경 사항

- `PipelineReviewCheckpointUseCase`의 public command/result record와 controller-facing 계약은 유지하면서 checkpoint callback 처리를 `PipelineReviewCheckpointCallbackProcessor`로 분리했습니다.
- domain confirmation/human feedback artifact payload에서 review task를 만드는 정책을 `PipelineReviewTaskFactory`로 분리했습니다.
- confirmed domain/feedback replay trigger, upstream manifest lookup, parent pipeline job RUNNING/FAILED 전이를 `PipelineReviewReplayOrchestrator`로 분리했습니다.
- checkpoint/replay JSON 읽기와 직렬화 경계를 `PipelineReviewCheckpointJsonSupport`로 정리했습니다.
- 이슈 613 스펙을 `.agent/specs/613.md`에 정리하고 callback duplicate, feedback checkpoint, review task 생성, replay trigger/failure 테스트를 보강했습니다.

## 검증

- `git diff --check`
- `docker run --rm -v /Users/owen/.codex/worktrees/8d24/ostone/backend:/workspace -v /Users/owen/.gradle:/root/.gradle -w /workspace eclipse-temurin:21-jdk ./gradlew spotlessCheck`
- `docker run --rm -v /Users/owen/.codex/worktrees/8d24/ostone/backend:/workspace -v /Users/owen/.gradle:/root/.gradle -w /workspace eclipse-temurin:21-jdk ./gradlew test --tests 'com.init.review.application.*'`
- `docker run --rm -v /Users/owen/.codex/worktrees/8d24/ostone/backend:/workspace -v /Users/owen/.gradle:/root/.gradle -w /workspace eclipse-temurin:21-jdk ./gradlew test`

## 참고

- 로컬 호스트에는 Gradle이 요구하는 Java 21 toolchain이 없어 `eclipse-temurin:21-jdk` 컨테이너에서 backend 검증을 실행했습니다.
- 커밋 pre-commit hook의 `pnpm run format:backend:check`는 staged Java 파일 절대경로가 Gradle 태스크 인자로 전달되어 실패했습니다. 동일 포맷 검사는 위의 `spotlessCheck`로 통과 확인했습니다.