### PR TITLE
refactor(consultation): 운영자 상담 realtime 상태를 분리

### DIFF
--- a/.agent/specs/620.md
+++ b/.agent/specs/620.md
@@ -1,0 +1,124 @@
+# ConsultationPage realtime state 분리
+
+## Goal
+
+`ConsultationPage`가 상담 UI 조합에 집중하도록 상담 대기열 이벤트, 활성 세션 메시지 이벤트, pending message, assignment, workflow 표시 렌더링 책임을 분리한다.
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A[상담 화면 진입] --> B[워크스페이스 대기열 조회]
+    B --> C{상담 세션 선택}
+    C -->|없음| D[빈 대화 상태 표시]
+    C -->|있음| E[메시지 페이지 조회 및 채팅 구독]
+    E --> F{실시간 이벤트}
+    F -->|대기열 변경| G[대기열 항목 갱신 또는 제거]
+    F -->|고객 메시지| H[메시지 목록 반영 및 unread 표시]
+    F -->|상담사 echo| I[pending 메시지 전송 상태 확정]
+    F -->|assistant/system| J[매칭 workflow 표시 갱신]
+    H --> K[기존 상담 입력 흐름 유지]
+    I --> K
+    J --> K
+```
+
+## Design Diff
+
+| 영역 | As-is | To-be | 변경 내용 |
+|------|-------|-------|----------|
+| 실시간 연결 | `ConsultationPage.tsx` 내부에서 STOMP 연결과 topic 구독 처리 | page-local realtime hook에서 workspace queue/chat topic 구독 처리 | websocket/event handling 책임 분리 |
+| 메시지 상태 | 페이지 내부에서 메시지 목록, 이전 페이지, pending echo를 직접 관리 | 메시지 변환/정렬/pending 유틸과 hook 경계를 분리 | 메시지 list와 pending message 책임 명확화 |
+| assignment 상태 | 페이지 내부에서 배정/해제/실패 동기화 로직과 렌더링 혼재 | assignment 계산 유틸과 대화 헤더 렌더링 분리 | 사용자 흐름은 유지하면서 변경 범위 축소 |
+| workflow/input 렌더링 | 매칭 workflow bar, 상담 입력, 고객 상세가 페이지 JSX에 혼재 | conversation/detail pane 컴포넌트로 표시 책임 분리 | workflow execution 표시와 상담 입력 UI 경계 분리 |
+
+## Component Tree
+
+```text
+ConsultationPage
+├─ QueuePanel
+├─ ConsultationConversationPane
+│  ├─ ConversationHeader
+│  └─ ChatPanel
+├─ ConsultationDetailPane
+│  ├─ MatchedWorkflowBar | MatchedWorkflowBarSkeleton
+│  ├─ MessageDetailPanel
+│  └─ CustomerPanel
+├─ EndSessionModal
+└─ ReleaseAssignmentModal
+```
+
+## API Integration
+
+| API wrapper | Description |
+|-------------|-------------|
+| `frontend/src/features/consultation/api/consultationApi.ts` | 대기열, 메시지 페이지, 배정/해제, 상담 종료, metrics, 답변 초안 생성을 기존 wrapper로 유지 |
+| `frontend/src/features/consultation/api/consultationEvidenceApi.ts` | 선택 메시지의 Domain Pack 근거 조회 유지 |
+| `frontend/src/features/consultation/api/llmToolWorkflowApi.ts` | 매칭 workflow 표시 조회 유지 |
+
+## Data Flow
+
+```text
+ConsultationPage
+  -> useConsultationRealtime
+       -> workspace queue topic event
+       -> active chat topic event
+       -> STOMP sendTo for counselor messages
+  -> queue/session state helpers
+       -> QueuePanel props
+  -> active message/pending state helpers
+       -> ChatPanel props
+  -> workflow/detail render panes
+       -> MatchedWorkflowBar, MessageDetailPanel, CustomerPanel
+```
+
+## 수정 대상 파일
+
+| 파일 | 변경 유형 | 설명 |
+|------|----------|------|
+| `frontend/src/pages/consultation/ui/ConsultationPage.tsx` | modify | 페이지 orchestration 중심으로 축소 |
+| `frontend/src/pages/consultation/ui/model/useConsultationRealtime.ts` | new | STOMP 연결과 queue/chat topic 구독 분리 |
+| `frontend/src/pages/consultation/ui/model/consultationPageState.ts` | new | 메시지, queue, assignment 상태 계산 유틸 분리 |
+| `frontend/src/pages/consultation/ui/sections/ConsultationConversationPane.tsx` | new | active session header와 상담 입력 영역 렌더링 |
+| `frontend/src/pages/consultation/ui/sections/ConsultationDetailPane.tsx` | new | workflow execution 표시와 메시지/고객 상세 렌더링 |
+| `frontend/src/pages/consultation/ui/sections/ConsultationStatusRight.tsx` | new | topbar metrics 표시 렌더링 |
+| `frontend/src/pages/consultation/ui/ConsultationPage.test.tsx` | existing | 분리 후 상담 송수신, assignment, workflow 흐름 회귀 테스트 유지 |
+
+## State Management
+
+- 서버 상태는 기존 generated API wrapper와 `consultationApi`, `consultationEvidenceApi`, `getCurrentWorkflow`를 그대로 사용한다.
+- 클라이언트 상태는 page-local React state를 유지하되, 변환/정렬/assignment 계산과 STOMP 구독을 별도 모듈로 분리한다.
+- pending counselor message는 서버 echo 또는 서버 error/timeout으로만 `sent`/`failed` 상태로 전이한다.
+- queue event는 활성 세션 여부에 따라 unread 표시와 세션 제거 처리를 유지한다.
+
+## Tests
+
+### Test Strategy
+
+| 구분 | 방법 | 도구 | 비고 |
+|------|------|------|------|
+| 컴포넌트 회귀 | 기존 `ConsultationPage.test.tsx`로 회귀 검증 | Vitest + React Testing Library | loading/error/empty, 송수신, assignment, workflow 표시 |
+| generated API 회귀 | 기존 `ConsultationPage.generated-api.test.tsx` 유지 | Vitest | generated endpoint wrapper 연동 |
+| 로컬 검증 | frontend targeted test/build | pnpm | 변경 파일 중심 검증 후 필요 시 CI 스크립트 |
+
+### Test Scenarios
+
+| # | 시나리오 | 기대 결과 |
+|---|---------|----------|
+| 1 | 워크스페이스 없이 상담 화면 진입 | 대기열 빈 상태와 metrics empty 상태가 유지된다 |
+| 2 | 대기열 조회 실패 후 재시도 | error toast 중복 없이 retry로 대기열이 복구된다 |
+| 3 | 세션 선택 후 메시지 송신 | STOMP counselor endpoint로 전송되고 optimistic pending 메시지가 표시된다 |
+| 4 | 서버 echo 또는 timeout 수신 | pending 메시지가 sent 또는 failed로 전이된다 |
+| 5 | queue websocket upsert/remove 수신 | unread, active selection, URL root 이동 흐름이 유지된다 |
+| 6 | assistant/system 메시지 수신 | 매칭 workflow 표시가 재조회된다 |
+| 7 | 상담 배정/해제/종료 | 기존 confirmation, toast, queue 갱신, metrics refresh 흐름이 유지된다 |
+
+## Non-goals
+
+- 상담 API endpoint 또는 generated API 구조는 변경하지 않는다.
+- UI 디자인, 문구, 라우팅 URL은 변경하지 않는다.
+- 전역 상태 관리 도구를 새로 도입하지 않는다.
+- chat demo 이외의 workflow/runtime 화면은 변경하지 않는다.
+
+## Open Questions
+
+- 없음. 이슈는 내부 구조 분리와 기존 상담 데모 흐름 보존을 요구하며, API/UX 변경 요구는 포함하지 않는다.

--- a/frontend/src/pages/consultation/ui/ConsultationPage.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.tsx
@@ -1,23 +1,15 @@
 import React, { useState, useEffect, useCallback, useRef } from "react";
 import { useNavigate, useOutletContext, useParams } from "react-router-dom";
 import { toast } from "sonner";
-import { ApiRequestError } from "@/shared/api";
 import type { ShellContext } from "@/shared/ui/ostone/chrome";
-import { Dot, Mono, Avatar } from "@/shared/ui/ostone/atoms";
-import { useStomp, type ConnectionStatus } from "@/shared/lib/websocket";
+import { Mono } from "@/shared/ui/ostone/atoms";
 import { getAuthUser } from "@/shared/lib/auth";
 import { QueuePanel } from "../../../features/consultation/ui/QueuePanel";
-import type { QueueCustomer } from "../../../features/consultation/ui/QueuePanel";
-import { ChatPanel } from "../../../features/consultation/ui/ChatPanel";
 import type {
   ChatComposerDraft,
   ChatMessage as UiChatMessage,
 } from "../../../features/consultation/ui/ChatPanel";
-import {
-  normalizeChatSenderRole,
-  type ChatSenderRole,
-} from "../../../features/consultation/lib/chatRoleLabels";
-import { formatWaitDuration } from "../../../features/consultation/lib/formatWaitDuration";
+import { normalizeChatSenderRole } from "../../../features/consultation/lib/chatRoleLabels";
 import { sortMessagesByServerOrder } from "../../../features/consultation/lib/messageOrder";
 import { consultationApi } from "../../../features/consultation/api/consultationApi";
 import {
@@ -25,578 +17,49 @@ import {
   type MessageDomainPackElements,
 } from "../../../features/consultation/api/consultationEvidenceApi";
 import type {
-  ChatSession,
-  ConsultationSessionStatus,
   ConsultationMetrics,
   ConsultationQueueEvent,
   ResolutionOutcome,
 } from "../../../features/consultation/api/consultationApi";
 import {
-  CustomerPanel,
-  type CustomerExtractedInfo,
-  type CustomerInfo,
-  type CustomerOrderInfo,
-} from "./sections/CustomerPanel";
-import { MatchedWorkflowBar, MatchedWorkflowBarSkeleton } from "./sections/MatchedWorkflowBar";
-import { MessageDetailPanel } from "../../../features/consultation/ui/MessageDetailPanel";
-import {
   getCurrentWorkflow,
   type MatchedWorkflow,
 } from "../../../features/consultation/api/llmToolWorkflowApi";
+import { ConsultationConversationPane } from "./sections/ConsultationConversationPane";
+import { ConsultationDetailPane } from "./sections/ConsultationDetailPane";
+import { ConsultationStatusRight } from "./sections/ConsultationStatusRight";
+import {
+  COUNSELOR_MESSAGE_ACK_TIMEOUT_MS,
+  EMPTY_COMPOSER_DRAFT,
+  MESSAGE_PAGE_SIZE,
+  RESOLUTION_OUTCOME_OPTIONS,
+  dedupePrependMessages,
+  findResolutionOutcomeOption,
+  formatTime,
+  getAssignmentView,
+  getClaimSessionErrorMessage,
+  getComposerDraftReleaseWarning,
+  getResponseStatusLabel,
+  isCounselorEchoRole,
+  isCustomerMessageRole,
+  markMessageSending,
+  mergeMessagesById,
+  reconcileCounselorEchoMessage,
+  replaceAssignedQueueCustomer,
+  shouldRefreshMatchedWorkflow,
+  sortQueueCustomers,
+  toQueueCustomer,
+  toUiMessage,
+  type EndSessionModalState,
+  type MessagePaginationState,
+  type MetricsViewState,
+  type PendingMessage,
+  type QueueCustomerWithPanelData,
+  type RealtimeChatMessage,
+  type ReleaseAssignmentModalState,
+} from "./model/consultationPageState";
+import { useConsultationRealtime } from "./model/useConsultationRealtime";
 import styles from "./consultation-page.module.css";
-
-const formatTime = (isoString: string) => {
-  if (!isoString) return "";
-  const d = new Date(isoString);
-  return `${d.getHours().toString().padStart(2, "0")}:${d.getMinutes().toString().padStart(2, "0")}`;
-};
-
-type RealtimeChatMessage = {
-  id: string | number;
-  seqNo?: number | null;
-  senderRole: string;
-  content?: string | null;
-  createdAt?: string | null;
-  timestamp?: string | null;
-};
-
-type MessageLike = {
-  id?: string | number | null;
-  seqNo?: number | null;
-  senderRole?: string | null;
-  content?: string | null;
-  createdAt?: string | null;
-  timestamp?: string | null;
-};
-
-type PendingMessage = {
-  id: string;
-  sessionId: string;
-  content: string;
-  isNote: boolean;
-  timeoutId: ReturnType<typeof setTimeout>;
-  createdAt: number;
-};
-
-type SessionMeta = {
-  customerName?: string;
-  membershipTier?: string;
-  contact?: string;
-  email?: string;
-  customerInfo?: {
-    membershipTier?: string | null;
-    contact?: string | null;
-    email?: string | null;
-  };
-  orderInfo?: CustomerOrderInfo | null;
-  extractedInfo?: CustomerExtractedInfo | null;
-  handoffRequired?: boolean;
-  handoffReason?: string;
-  handoffAt?: string;
-  handoffNodeId?: string;
-  title?: string;
-  lastMessagePreview?: string;
-  lastMessageRole?: string;
-  lastMessageAt?: string;
-};
-
-type QueueCustomerPanelData = {
-  customerInfo: Pick<CustomerInfo, "membershipTier" | "contact" | "email">;
-  orderInfo: CustomerOrderInfo | null;
-  extractedInfo: CustomerExtractedInfo | null;
-};
-
-type QueueCustomerWithPanelData = QueueCustomer & QueueCustomerPanelData;
-
-const COUNSELOR_MESSAGE_ACK_TIMEOUT_MS = 8000;
-const MESSAGE_PAGE_SIZE = 50;
-const DEFAULT_RESPONSE_MODE = "AI_ACTIVE" as const;
-
-type MessagePaginationState = {
-  nextPage: number;
-  totalPages: number;
-  isLoadingPrevious: boolean;
-};
-
-const EMPTY_COMPOSER_DRAFT: ChatComposerDraft = {
-  input: "",
-  isNoteMode: false,
-};
-
-const getComposerDraftReleaseWarning = (draft: ChatComposerDraft) => {
-  if (!draft.input.trim()) return null;
-  return draft.isNoteMode
-    ? "메시지 입력창에 작성 중인 내부 메모가 있습니다."
-    : "메시지 입력창에 작성 중인 답변이 있습니다.";
-};
-
-type EndSessionModalState =
-  | { open: false }
-  | {
-      open: true;
-      sessionId: string;
-      customerName: string;
-      outcome: ResolutionOutcome | null;
-      reason: string;
-      isSubmitting: boolean;
-      error: string | null;
-    };
-
-type ReleaseAssignmentModalState =
-  | { open: false }
-  | {
-      open: true;
-      sessionId: string;
-      customerName: string;
-      isSubmitting: boolean;
-      error: string | null;
-    };
-
-type ResolutionOutcomeOption = {
-  value: ResolutionOutcome;
-  label: string;
-  description: string;
-  status: Extract<ConsultationSessionStatus, "RESOLVED" | "COMPLETED">;
-  followUpRequired: boolean;
-};
-
-const RESOLUTION_OUTCOME_OPTIONS: ResolutionOutcomeOption[] = [
-  {
-    value: "RESOLVED",
-    label: "해결됨",
-    description: "문제가 해결되어 상담 기록을 해결 상태로 남깁니다.",
-    status: "RESOLVED",
-    followUpRequired: false,
-  },
-  {
-    value: "CUSTOMER_LEFT",
-    label: "고객 이탈",
-    description: "고객 응답 없이 상담을 완전히 종료합니다.",
-    status: "COMPLETED",
-    followUpRequired: false,
-  },
-  {
-    value: "PENDING",
-    label: "보류",
-    description: "현재 상담은 대기열에서 제거하고 후속 확인 대상으로 남깁니다.",
-    status: "RESOLVED",
-    followUpRequired: true,
-  },
-  {
-    value: "FOLLOW_UP_REQUIRED",
-    label: "후속 연락 필요",
-    description: "상담 기록에 후속 연락 필요 여부를 명확히 남깁니다.",
-    status: "RESOLVED",
-    followUpRequired: true,
-  },
-];
-
-const findResolutionOutcomeOption = (outcome: ResolutionOutcome | null) =>
-  RESOLUTION_OUTCOME_OPTIONS.find((option) => option.value === outcome) ?? null;
-
-const toUiMessage = (message: MessageLike): UiChatMessage => {
-  const rawCreatedAt = message.createdAt ?? message.timestamp ?? null;
-  const displayCreatedAt = rawCreatedAt ?? new Date().toISOString();
-  return {
-    id: String(message.id ?? `message-${displayCreatedAt}-${message.content ?? ""}`),
-    ...(message.seqNo != null ? { seqNo: message.seqNo } : {}),
-    ...(rawCreatedAt != null ? { createdAt: rawCreatedAt } : {}),
-    senderRole: normalizeChatSenderRole(message.senderRole),
-    content: message.content ?? "",
-    timestamp: formatTime(displayCreatedAt),
-  };
-};
-
-const mergeMessagesById = (
-  currentMessages: UiChatMessage[],
-  nextMessages: UiChatMessage[],
-): UiChatMessage[] => {
-  const byId = new Map<string, UiChatMessage>();
-  [...currentMessages, ...nextMessages].forEach((message) => {
-    byId.set(message.id, message);
-  });
-  return sortMessagesByServerOrder(Array.from(byId.values()));
-};
-
-const shouldRefreshMatchedWorkflow = (role: ChatSenderRole) =>
-  role === "ASSISTANT" || role === "SYSTEM";
-
-const isCounselorEchoRole = (role: ChatSenderRole) =>
-  role === "COUNSELOR" || role === "AGENT" || role === "NOTE";
-
-const pendingRoleMatchesEcho = (pending: PendingMessage, role: ChatSenderRole) =>
-  pending.isNote ? role === "NOTE" : role === "COUNSELOR" || role === "AGENT";
-
-const hasSendingMessage = (messages: UiChatMessage[], pendingId: string) =>
-  messages.some((message) => message.id === pendingId && message.deliveryStatus === "sending");
-
-const findPendingEchoMatch = (
-  pendingMessages: Iterable<PendingMessage>,
-  messages: UiChatMessage[],
-  sessionId: string,
-  role: ChatSenderRole,
-  content: string,
-) =>
-  [...pendingMessages]
-    .filter(
-      (pending) =>
-        pending.sessionId === sessionId &&
-        pendingRoleMatchesEcho(pending, role) &&
-        pending.content === content &&
-        hasSendingMessage(messages, pending.id),
-    )
-    .sort((a, b) => a.createdAt - b.createdAt)[0];
-
-const reconcileCounselorEchoMessage = (
-  messages: UiChatMessage[],
-  pendingMessages: Map<string, PendingMessage>,
-  sessionId: string,
-  role: ChatSenderRole,
-  realtimeMessage: RealtimeChatMessage,
-) => {
-  const serverMessage = {
-    ...toUiMessage(realtimeMessage),
-    deliveryStatus: "sent" as const,
-  };
-  if (messages.some((message) => message.id === serverMessage.id)) {
-    return messages;
-  }
-
-  const pendingMatch = findPendingEchoMatch(
-    pendingMessages.values(),
-    messages,
-    sessionId,
-    role,
-    realtimeMessage.content ?? "",
-  );
-  if (!pendingMatch) {
-    return messages;
-  }
-
-  clearTimeout(pendingMatch.timeoutId);
-  pendingMessages.delete(pendingMatch.id);
-  return sortMessagesByServerOrder(
-    messages.map((message) => (message.id === pendingMatch.id ? serverMessage : message)),
-  );
-};
-
-const markMessageSending = (messages: UiChatMessage[], messageId: string) =>
-  messages.map((message) =>
-    message.id === messageId
-      ? {
-          ...message,
-          deliveryStatus: "sending" as const,
-          retryable: false,
-          errorMessage: undefined,
-          timestamp: formatTime(new Date().toISOString()),
-        }
-      : message,
-  );
-
-const calcWaitMinutes = (isoString: string) => {
-  if (!isoString) return 0;
-  const d = new Date(isoString);
-  const diffMs = new Date().getTime() - d.getTime();
-  return Math.max(0, Math.floor(diffMs / 60000));
-};
-
-const formatLastMessageTimeLabel = (isoString?: string | null) => {
-  if (!isoString) return "";
-  const d = new Date(isoString);
-  const timestamp = d.getTime();
-  if (Number.isNaN(timestamp)) return "";
-  const diffMinutes = Math.max(0, Math.floor((Date.now() - timestamp) / 60000));
-  return diffMinutes === 0 ? "방금 전" : `${formatWaitDuration(diffMinutes)} 전`;
-};
-
-const parseSessionMeta = (metaJson?: string | null): SessionMeta => {
-  try {
-    if (!metaJson) return {};
-    const meta = JSON.parse(metaJson) as SessionMeta;
-    return meta && typeof meta === "object" ? meta : {};
-  } catch (e) {
-    console.error("Failed to parse metaJson", e);
-    return {};
-  }
-};
-
-const normalizePanelText = (value?: string | null) => {
-  const normalized = value?.trim();
-  return normalized || undefined;
-};
-
-const buildCustomerPanelData = (meta: SessionMeta): QueueCustomerPanelData => ({
-  customerInfo: {
-    membershipTier: normalizePanelText(meta.customerInfo?.membershipTier ?? meta.membershipTier),
-    contact: normalizePanelText(meta.customerInfo?.contact ?? meta.contact),
-    email: normalizePanelText(meta.customerInfo?.email ?? meta.email),
-  },
-  orderInfo: meta.orderInfo ?? null,
-  extractedInfo: meta.extractedInfo ?? null,
-});
-
-const getSessionStatusLabel = (
-  status?: string | null,
-  assignedCounselorId?: number | null,
-  currentCounselorId?: number | null,
-  handoffRequired?: boolean,
-) => {
-  const prefix = handoffRequired ? "상담사 연결 요청 · " : "";
-  if (status === "COMPLETED") return "상담 종료";
-  if (status === "RESOLVED") return "해결됨";
-  if (assignedCounselorId && assignedCounselorId === currentCounselorId)
-    return `${prefix}내게 배정됨`;
-  if (assignedCounselorId) return `${prefix}다른 상담사 배정`;
-  if (status === "ACTIVE") return `${prefix}미배정`;
-  if (status === "OPEN") return `${prefix}미배정`;
-  return status ?? "상태 미확인";
-};
-
-type AssignmentView = {
-  label: string;
-  description: string;
-};
-
-const getAssignmentView = (
-  status?: string | null,
-  assignedCounselorId?: number | null,
-  currentCounselorId?: number | null,
-): AssignmentView => {
-  if (status === "COMPLETED" || status === "RESOLVED") {
-    return {
-      label: status === "RESOLVED" ? "해결됨" : "상담 종료",
-      description: "종료된 세션이므로 메시지를 보낼 수 없습니다.",
-    };
-  }
-
-  if (assignedCounselorId && assignedCounselorId === currentCounselorId) {
-    return {
-      label: "내게 배정됨",
-      description: "이 세션에 응답하고 내부 메모를 남길 수 있습니다.",
-    };
-  }
-
-  if (assignedCounselorId) {
-    return {
-      label: "다른 상담사 배정",
-      description: "다른 상담사가 응대 중인 세션이므로 메시지를 보낼 수 없습니다.",
-    };
-  }
-
-  return {
-    label: "미배정",
-    description: "배정받기 전에는 메시지와 내부 메모를 보낼 수 없습니다.",
-  };
-};
-
-const getResponseStatusLabel = (
-  status?: string | null,
-  assignedCounselorId?: number | null,
-) => {
-  if (status === "COMPLETED") return "상담 종료";
-  if (status === "RESOLVED") return "해결됨";
-  return assignedCounselorId ? "상담사 응대중" : "AI 응대";
-};
-
-const isCustomerMessageRole = (role?: string | null) => {
-  const normalizedRole = normalizeChatSenderRole(role);
-  return normalizedRole === "USER" || normalizedRole === "CUSTOMER";
-};
-
-const getQueueSortTime = (customer: QueueCustomer) => {
-  const timeSource =
-    customer.handoffRequired && customer.handoffAt
-      ? customer.handoffAt
-      : (customer.lastMessageAt ?? customer.startedAt);
-  if (!timeSource) return 0;
-  const timestamp = new Date(timeSource).getTime();
-  return Number.isNaN(timestamp) ? 0 : timestamp;
-};
-
-const toQueueCustomer = (
-  session: ChatSession,
-  currentCounselorId: number | null,
-  previous?: QueueCustomerWithPanelData,
-  options?: { hasUnread?: boolean },
-): QueueCustomerWithPanelData => {
-  const meta = parseSessionMeta(session.metaJson);
-  const panelData = buildCustomerPanelData(meta);
-  const hasSessionMetaJson = session.metaJson !== undefined && session.metaJson !== null;
-  const assignedCounselorId =
-    session.assignedCounselorId !== undefined
-      ? session.assignedCounselorId
-      : (previous?.assignedCounselorId ?? null);
-  const responseMode =
-    session.responseMode ??
-    previous?.responseMode ??
-    (assignedCounselorId ? "HUMAN_ACTIVE" : DEFAULT_RESPONSE_MODE);
-  const status = session.status !== undefined ? session.status : (previous?.status ?? null);
-  const startedAt = session.startedAt ?? previous?.startedAt ?? null;
-  const lastMessagePreview = meta.lastMessagePreview?.trim() || previous?.lastMessagePreview || "";
-  const lastMessageRole = meta.lastMessageRole ?? previous?.lastMessageRole;
-  const lastMessageAt = meta.lastMessageAt ?? previous?.lastMessageAt ?? null;
-  const handoffRequired = meta.handoffRequired ?? previous?.handoffRequired ?? false;
-  const handoffAt = meta.handoffAt ?? previous?.handoffAt ?? null;
-  const handoffNodeId = meta.handoffNodeId ?? previous?.handoffNodeId ?? null;
-  const lastMessageTimeLabel =
-    formatLastMessageTimeLabel(lastMessageAt) || previous?.lastMessageTimeLabel;
-
-  return {
-    id: String(session.id ?? previous?.id ?? ""),
-    name: meta.customerName?.trim() || previous?.name || "Unknown",
-    title: meta.title?.trim() || previous?.title || "",
-    channel: session.channel ?? previous?.channel ?? "",
-    handoffReason: meta.handoffReason ?? previous?.handoffReason ?? "",
-    handoffRequired,
-    handoffAt,
-    handoffNodeId,
-    waitMinutes: startedAt ? calcWaitMinutes(startedAt) : (previous?.waitMinutes ?? 0),
-    hasUnread: options?.hasUnread ?? previous?.hasUnread ?? false,
-    lastMessagePreview,
-    lastMessageRole,
-    lastMessageAt,
-    lastMessageTimeLabel,
-    status,
-    statusLabel: getSessionStatusLabel(
-      status,
-      assignedCounselorId,
-      currentCounselorId,
-      handoffRequired,
-    ),
-    assignedCounselorId,
-    responseMode,
-    startedAt,
-    customerInfo: {
-      membershipTier: hasSessionMetaJson
-        ? panelData.customerInfo.membershipTier
-        : previous?.customerInfo.membershipTier,
-      contact: hasSessionMetaJson ? panelData.customerInfo.contact : previous?.customerInfo.contact,
-      email: hasSessionMetaJson ? panelData.customerInfo.email : previous?.customerInfo.email,
-    },
-    orderInfo: hasSessionMetaJson ? panelData.orderInfo : (previous?.orderInfo ?? null),
-    extractedInfo: hasSessionMetaJson ? panelData.extractedInfo : (previous?.extractedInfo ?? null),
-  };
-};
-
-const sortQueueCustomers = (customers: QueueCustomerWithPanelData[]) =>
-  [...customers].sort((a, b) => {
-    const aIsHandoff = a.handoffRequired === true;
-    const bIsHandoff = b.handoffRequired === true;
-    if (aIsHandoff !== bIsHandoff) {
-      return aIsHandoff ? -1 : 1;
-    }
-    if (aIsHandoff && bIsHandoff) {
-      return getQueueSortTime(a) - getQueueSortTime(b);
-    }
-    return getQueueSortTime(b) - getQueueSortTime(a);
-  });
-
-const replaceAssignedQueueCustomer = (
-  customers: QueueCustomerWithPanelData[],
-  sessionId: string,
-  assignedSession: ChatSession,
-  currentCounselorId: number,
-) =>
-  sortQueueCustomers(
-    customers.map((customer) =>
-      customer.id === sessionId
-        ? toQueueCustomer(assignedSession, currentCounselorId, customer)
-        : customer,
-    ),
-  );
-
-const getClaimSessionErrorMessage = (error: unknown) => {
-  if (error instanceof ApiRequestError) {
-    switch (error.code) {
-      case "SESSION_ALREADY_ASSIGNED":
-        return "이미 다른 상담사에게 배정된 상담입니다.";
-      case "SESSION_NOT_ASSIGNABLE":
-        return "현재 배정할 수 없는 상담 상태입니다.";
-      case "SESSION_NOT_FOUND":
-        return "상담 세션을 찾을 수 없습니다.";
-      case "WORKSPACE_ACCESS_DENIED":
-      case "FORBIDDEN":
-        return "상담 배정 권한이 없습니다.";
-      default:
-        return "상담 세션 배정에 실패했습니다.";
-    }
-  }
-  return "상담 세션 배정에 실패했습니다.";
-};
-
-const dedupePrependMessages = (
-  olderMessages: UiChatMessage[],
-  currentMessages: UiChatMessage[],
-) => {
-  const existingIds = new Set(currentMessages.map((message) => message.id));
-  return [...olderMessages.filter((message) => !existingIds.has(message.id)), ...currentMessages];
-};
-
-const formatAverageFirstResponse = (seconds?: number | null) => {
-  if (seconds == null) return "--";
-  const minutes = Math.floor(seconds / 60);
-  const remainingSeconds = seconds % 60;
-  return minutes > 0 ? `${minutes}분 ${remainingSeconds}초` : `${remainingSeconds}초`;
-};
-
-const formatHandledTodayCount = (count?: number | null) => {
-  return count == null ? "--" : `${count}건`;
-};
-
-type MetricsViewState = "loading" | "error" | "empty" | "ready";
-
-type StatusRightProps = {
-  metricsViewState: MetricsViewState;
-  averageFirstResponseSeconds?: number | null;
-  handledTodayCount?: number | null;
-};
-
-const formatMetricValue = (
-  metricsViewState: MetricsViewState,
-  value: number | null | undefined,
-  formatter: (value?: number | null) => string,
-) => {
-  if (metricsViewState === "loading") return "로딩중";
-  if (metricsViewState === "error") return "오류";
-  if (metricsViewState === "empty") return "--";
-  return formatter(value);
-};
-
-const StatusRight = ({
-  metricsViewState,
-  averageFirstResponseSeconds,
-  handledTodayCount,
-}: StatusRightProps) => {
-  const averageLabel = formatMetricValue(
-    metricsViewState,
-    averageFirstResponseSeconds,
-    formatAverageFirstResponse,
-  );
-  const handledLabel = formatMetricValue(
-    metricsViewState,
-    handledTodayCount,
-    formatHandledTodayCount,
-  );
-
-  return (
-    <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
-      <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
-        <Dot tone="signal" />
-        <span style={{ fontSize: 12 }}>응대 가능</span>
-      </div>
-      <div style={{ width: 1, height: 16, background: "var(--line)" }} />
-      <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
-        <Mono style={{ fontSize: 11, color: "var(--ink-3)" }}>평균 첫응답</Mono>
-        <span style={{ fontSize: 14, fontWeight: 700 }}>{averageLabel}</span>
-      </div>
-      <div style={{ width: 1, height: 16, background: "var(--line)" }} />
-      <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
-        <Mono style={{ fontSize: 11, color: "var(--ink-3)" }}>오늘 처리</Mono>
-        <span style={{ fontSize: 14, fontWeight: 700 }}>{handledLabel}</span>
-      </div>
-    </div>
-  );
-};
 
 export const ConsultationPage: React.FC = () => {
   const { setTopbarRight, setCrumbs, workspace } = useOutletContext<ShellContext>();
@@ -657,8 +120,6 @@ export const ConsultationPage: React.FC = () => {
   const pendingMessagesRef = useRef<Map<string, PendingMessage>>(new Map());
   const tempCounterRef = useRef(0);
   const activeCustomerIdRef = useRef<string | null>(null);
-  const hasQueueLoadedRef = useRef(false);
-  const previousConnectionStatusRef = useRef<ConnectionStatus>("DISCONNECTED");
   const metricsErrorToastShownRef = useRef(false);
   const metricsRequestIdRef = useRef(0);
   const queueErrorToastShownRef = useRef(false);
@@ -711,8 +172,6 @@ export const ConsultationPage: React.FC = () => {
     [failPendingMessage],
   );
 
-  const { connectionStatus, subscribe, sendTo } = useStomp({ onServerError: handleServerError });
-
   const activeCustomer = queue.find((c) => c.id === activeCustomerId) || null;
   const activeCustomerName = activeCustomer?.name?.trim() || "Unknown";
   const activeCustomerInitial = activeCustomerName.charAt(0) || "?";
@@ -761,10 +220,6 @@ export const ConsultationPage: React.FC = () => {
   const activeResponseStatusLabel = activeCustomer
     ? getResponseStatusLabel(activeCustomer.status, activeCustomer.assignedCounselorId)
     : null;
-  const queueSyncNotice =
-    workspaceId && connectionStatus !== "CONNECTED"
-      ? "실시간 연결이 불안정합니다. 복구되면 대기열을 다시 동기화합니다."
-      : null;
 
   const clearActiveConversation = useCallback(() => {
     setActiveCustomerId(null);
@@ -827,12 +282,8 @@ export const ConsultationPage: React.FC = () => {
   }, [activeCustomerId]);
 
   useEffect(() => {
-    hasQueueLoadedRef.current = hasQueueLoaded;
-  }, [hasQueueLoaded]);
-
-  useEffect(() => {
     setTopbarRight(
-      <StatusRight
+      <ConsultationStatusRight
         metricsViewState={metricsViewState}
         averageFirstResponseSeconds={activeMetrics?.averageFirstResponseSeconds ?? null}
         handledTodayCount={activeMetrics?.handledTodayCount ?? null}
@@ -1023,17 +474,6 @@ export const ConsultationPage: React.FC = () => {
     void loadQueue();
   }, [loadQueue]);
 
-  useEffect(() => {
-    const previousStatus = previousConnectionStatusRef.current;
-    previousConnectionStatusRef.current = connectionStatus;
-
-    if (!workspaceId) return;
-    if (connectionStatus !== "CONNECTED" || previousStatus === "CONNECTED") return;
-    if (!hasQueueLoadedRef.current) return;
-
-    void loadQueue();
-  }, [connectionStatus, loadQueue, workspaceId]);
-
   const activateCustomer = useCallback((id: string) => {
     setActiveCustomerId(id);
     setSelectedMessageId(null);
@@ -1084,19 +524,6 @@ export const ConsultationPage: React.FC = () => {
     routeSessionIdParam,
     workspaceIdParam,
   ]);
-
-  useEffect(() => {
-    if (!workspaceId) return;
-
-    const unsubscribe = subscribe(
-      `/topic/workspaces.${workspaceId}.consultation.queue`,
-      handleQueueEvent,
-    );
-
-    return () => {
-      unsubscribe();
-    };
-  }, [handleQueueEvent, subscribe, workspaceId]);
 
   useEffect(() => {
     if (!activeCustomerId) {
@@ -1273,23 +700,20 @@ export const ConsultationPage: React.FC = () => {
     }
   }, [activeCustomerId, messagePagination, messagesCustomerId]);
 
-  useEffect(() => {
-    if (!activeCustomerId) return;
-
-    const topic = `/topic/chat.${activeCustomerId}`;
-    const unsubscribe = subscribe(topic, (raw) => {
+  const handleChatMessage = useCallback(
+    (raw: unknown, sessionId: string) => {
       const msg = raw as RealtimeChatMessage;
       const normalizedRole = normalizeChatSenderRole(msg.senderRole);
       if (shouldRefreshMatchedWorkflow(normalizedRole)) {
-        scheduleMatchedWorkflowRefresh(Number(activeCustomerId));
+        scheduleMatchedWorkflowRefresh(Number(sessionId));
       }
       if (isCounselorEchoRole(normalizedRole)) {
-        setMessagesCustomerId(activeCustomerId);
+        setMessagesCustomerId(sessionId);
         setMessages((prev) =>
           reconcileCounselorEchoMessage(
             prev,
             pendingMessagesRef.current,
-            activeCustomerId,
+            sessionId,
             normalizedRole,
             msg,
           ),
@@ -1297,21 +721,41 @@ export const ConsultationPage: React.FC = () => {
         return;
       }
       const msgId = String(msg.id);
-      setMessagesCustomerId(activeCustomerId);
+      setMessagesCustomerId(sessionId);
       setMessages((prev) => {
         if (prev.some((m) => m.id === msgId)) return prev;
         return sortMessagesByServerOrder([...prev, toUiMessage(msg)]);
       });
-    });
+    },
+    [scheduleMatchedWorkflowRefresh],
+  );
 
-    return () => {
-      unsubscribe();
-      if (workflowRefetchTimerRef.current) {
-        clearTimeout(workflowRefetchTimerRef.current);
-        workflowRefetchTimerRef.current = null;
-      }
-    };
-  }, [activeCustomerId, subscribe, scheduleMatchedWorkflowRefresh]);
+  const handleRealtimeReconnect = useCallback(() => {
+    void loadQueue();
+  }, [loadQueue]);
+
+  const handleChatUnsubscribe = useCallback(() => {
+    if (workflowRefetchTimerRef.current) {
+      clearTimeout(workflowRefetchTimerRef.current);
+      workflowRefetchTimerRef.current = null;
+    }
+  }, []);
+
+  const { connectionStatus, sendTo } = useConsultationRealtime({
+    workspaceId,
+    activeCustomerId,
+    hasQueueLoaded,
+    onQueueEvent: handleQueueEvent,
+    onChatMessage: handleChatMessage,
+    onServerError: handleServerError,
+    onReconnect: handleRealtimeReconnect,
+    onChatUnsubscribe: handleChatUnsubscribe,
+  });
+
+  const queueSyncNotice =
+    workspaceId && connectionStatus !== "CONNECTED"
+      ? "실시간 연결이 불안정합니다. 복구되면 대기열을 다시 동기화합니다."
+      : null;
 
   const registerPendingMessage = useCallback(
     (message: Omit<PendingMessage, "timeoutId">) => {
@@ -1673,151 +1117,61 @@ export const ConsultationPage: React.FC = () => {
         />
       </div>
 
-      <div className={styles.conversationPane}>
-        {activeCustomer && (
-          <div className={styles.conversationHeader}>
-            <div className={styles.conversationHeaderTop}>
-              <div className={styles.customerTitle}>
-                <Avatar initial={activeCustomerInitial} tone="warn" size={36} />
-                <div>
-                  <div className={styles.customerName}>{activeCustomerName} 고객</div>
-                  <Mono style={{ fontSize: 10, color: "var(--ink-3)" }}>
-                    {activeCustomer.channel ?? ""} ·{" "}
-                    {formatWaitDuration(activeCustomer.waitMinutes)} 대기 중
-                  </Mono>
-                </div>
-              </div>
-            </div>
-            <div className={styles.conversationActions}>
-              {activeResponseStatusLabel && (
-                <div
-                  className={styles.responseStatusBadge}
-                  role="status"
-                  aria-label="응대 상태"
-                  data-testid="conversation-response-status"
-                >
-                  {activeResponseStatusLabel}
-                </div>
-              )}
-              {isActiveSessionUnassigned && !isActiveSessionClosed && (
-                <button
-                  type="button"
-                  className={styles.claimButton}
-                  onClick={handleClaimSession}
-                  disabled={!currentCounselorId || isClaimingActiveSession}
-                >
-                  {isClaimingActiveSession ? "배정 중..." : "배정받기"}
-                </button>
-              )}
-              <button
-                className={styles.linkButton}
-                onClick={handleOpenReleaseAssignment}
-                disabled={!isAssignedToCurrentCounselor}
-              >
-                배정 해제
-              </button>
-              <button
-                onClick={handleOpenEndSession}
-                className={styles.dangerButton}
-                disabled={!isAssignedToCurrentCounselor}
-              >
-                상담 종료
-              </button>
-            </div>
-          </div>
-        )}
+      <ConsultationConversationPane
+        activeCustomer={activeCustomer}
+        activeCustomerId={activeCustomerId}
+        activeCustomerName={activeCustomerName}
+        activeCustomerInitial={activeCustomerInitial}
+        activeResponseStatusLabel={activeResponseStatusLabel}
+        activeAssignment={activeAssignment}
+        currentCounselorId={currentCounselorId}
+        isActiveSessionUnassigned={isActiveSessionUnassigned}
+        isActiveSessionClosed={isActiveSessionClosed}
+        isClaimingActiveSession={isClaimingActiveSession}
+        isAssignedToCurrentCounselor={isAssignedToCurrentCounselor}
+        messageInputDisabledReason={messageInputDisabledReason}
+        urlSessionUnavailable={urlSessionUnavailable}
+        visibleMessages={visibleMessages}
+        selectedMessageId={selectedMessageId}
+        hasPreviousMessages={hasPreviousMessages}
+        messagePagination={messagePagination}
+        matchedWorkflow={matchedWorkflow}
+        isDraftResponseLoading={isDraftResponseLoading}
+        activeComposerDraft={activeComposerDraft}
+        onClaimSession={handleClaimSession}
+        onOpenReleaseAssignment={handleOpenReleaseAssignment}
+        onOpenEndSession={handleOpenEndSession}
+        onSendMessage={handleSendMessage}
+        onRetryMessage={handleRetryMessage}
+        onSelectMessage={setSelectedMessageId}
+        onLoadPreviousMessages={handleLoadPreviousMessages}
+        onInsertDraftResponse={handleInsertDraftResponse}
+        onComposerDraftChange={(draft) => {
+          if (!activeCustomerId) return;
+          setComposerDrafts((prev) => ({ ...prev, [activeCustomerId]: draft }));
+        }}
+      />
 
-        <div className={styles.chatPanelSlot}>
-          {urlSessionUnavailable ? (
-            <div className={styles.urlSessionState} role="status" aria-live="polite">
-              <p className={styles.urlSessionTitle}>요청한 상담 세션을 찾을 수 없습니다</p>
-              <p className={styles.urlSessionText}>
-                상담이 종료되었거나 현재 대기열에서 접근할 수 없는 세션입니다.
-              </p>
-            </div>
-          ) : (
-            <ChatPanel
-              sessionId={activeCustomerId}
-              customerName={activeCustomer ? activeCustomerName : null}
-              channel={activeCustomer?.channel || null}
-              messages={visibleMessages}
-              onSendMessage={handleSendMessage}
-              onRetryMessage={handleRetryMessage}
-              selectedMessageId={selectedMessageId}
-              onSelectMessage={setSelectedMessageId}
-              sessionStatusLabel={activeResponseStatusLabel ?? activeAssignment?.label}
-              disabledReason={messageInputDisabledReason}
-              disabled={!isAssignedToCurrentCounselor}
-              hasPreviousMessages={hasPreviousMessages}
-              isLoadingPreviousMessages={messagePagination.isLoadingPrevious}
-              onLoadPreviousMessages={handleLoadPreviousMessages}
-              draftResponseAction={
-                matchedWorkflow && isAssignedToCurrentCounselor
-                  ? {
-                      isLoading: isDraftResponseLoading,
-                      onInsert: handleInsertDraftResponse,
-                    }
-                  : undefined
-              }
-              composerDraft={activeComposerDraft}
-              onComposerDraftChange={(draft) => {
-                if (!activeCustomerId) return;
-                setComposerDrafts((prev) => ({ ...prev, [activeCustomerId]: draft }));
-              }}
-            />
-          )}
-        </div>
-      </div>
-
-      <div className={styles.detailPane}>
-        {activeCustomerId && (isMatchedWorkflowLoading || matchedWorkflow) && (
-          <div className={styles.detailPaneTop}>
-            {matchedWorkflow ? (
-              <MatchedWorkflowBar workflow={matchedWorkflow} />
-            ) : (
-              <MatchedWorkflowBarSkeleton />
-            )}
-          </div>
-        )}
-        <div className={styles.detailPaneBody}>
-          {selectedMessage ? (
-            <MessageDetailPanel
-              message={selectedMessage}
-              domainPackElements={messageDomainPackElements}
-              isDomainPackElementsLoading={isMessageDomainPackElementsLoading}
-              domainPackElementsError={messageDomainPackElementsError}
-              onOpenDomainPackElement={(path) => navigate(path)}
-              onClose={() => setSelectedMessageId(null)}
-            />
-          ) : (
-            <CustomerPanel
-              customer={
-                activeCustomer
-                  ? {
-                      name: activeCustomerName,
-                      channel: activeCustomer.channel,
-                      handoffRequired: activeCustomer.handoffRequired,
-                      handoffReason: activeCustomer.handoffReason,
-                      handoffAt: activeCustomer.handoffAt,
-                      membershipTier: activeCustomer.customerInfo.membershipTier,
-                      contact: activeCustomer.customerInfo.contact,
-                      email: activeCustomer.customerInfo.email,
-                    }
-                  : null
-              }
-              orderInfo={activeCustomer?.orderInfo ?? null}
-              extractedInfo={activeCustomer?.extractedInfo ?? null}
-              memo={activeCustomerId ? memos[activeCustomerId] || "" : ""}
-              onMemoChange={(val) => {
-                if (activeCustomerId) {
-                  setMemos((prev) => ({ ...prev, [activeCustomerId]: val }));
-                }
-              }}
-              onMemoSave={isAssignedToCurrentCounselor ? handleSaveMemo : undefined}
-            />
-          )}
-        </div>
-      </div>
+      <ConsultationDetailPane
+        activeCustomer={activeCustomer}
+        activeCustomerId={activeCustomerId}
+        activeCustomerName={activeCustomerName}
+        selectedMessage={selectedMessage}
+        matchedWorkflow={matchedWorkflow}
+        isMatchedWorkflowLoading={isMatchedWorkflowLoading}
+        messageDomainPackElements={messageDomainPackElements}
+        isMessageDomainPackElementsLoading={isMessageDomainPackElementsLoading}
+        messageDomainPackElementsError={messageDomainPackElementsError}
+        memo={activeCustomerId ? memos[activeCustomerId] || "" : ""}
+        onMemoChange={(val) => {
+          if (activeCustomerId) {
+            setMemos((prev) => ({ ...prev, [activeCustomerId]: val }));
+          }
+        }}
+        onMemoSave={isAssignedToCurrentCounselor ? handleSaveMemo : undefined}
+        onOpenDomainPackElement={(path) => navigate(path)}
+        onCloseMessageDetail={() => setSelectedMessageId(null)}
+      />
 
       {endSessionModal.open && (
         <div className={styles.modalOverlay}>

--- a/frontend/src/pages/consultation/ui/model/consultationPageState.ts
+++ b/frontend/src/pages/consultation/ui/model/consultationPageState.ts
@@ -1,0 +1,527 @@
+import { ApiRequestError } from "@/shared/api";
+import type { QueueCustomer } from "../../../../features/consultation/ui/QueuePanel";
+import type {
+  ChatComposerDraft,
+  ChatMessage as UiChatMessage,
+} from "../../../../features/consultation/ui/ChatPanel";
+import {
+  normalizeChatSenderRole,
+  type ChatSenderRole,
+} from "../../../../features/consultation/lib/chatRoleLabels";
+import { formatWaitDuration } from "../../../../features/consultation/lib/formatWaitDuration";
+import { sortMessagesByServerOrder } from "../../../../features/consultation/lib/messageOrder";
+import type {
+  ChatSession,
+  ConsultationSessionStatus,
+  ResolutionOutcome,
+} from "../../../../features/consultation/api/consultationApi";
+
+type CustomerPanelInfo = {
+  membershipTier?: string | null;
+  contact?: string | null;
+  email?: string | null;
+};
+
+type CustomerOrderInfo = {
+  orderNumber?: string | null;
+  orderDate?: string | null;
+  paymentAmount?: string | null;
+  deliveryStatus?: string | null;
+};
+
+type CustomerExtractedInfo = {
+  cardNumber?: string | null;
+  refundAmount?: string | null;
+  refundReason?: string | null;
+  dueDate?: string | null;
+};
+
+export const COUNSELOR_MESSAGE_ACK_TIMEOUT_MS = 8000;
+export const MESSAGE_PAGE_SIZE = 50;
+
+const DEFAULT_RESPONSE_MODE = "AI_ACTIVE" as const;
+
+export const EMPTY_COMPOSER_DRAFT: ChatComposerDraft = {
+  input: "",
+  isNoteMode: false,
+};
+
+export type RealtimeChatMessage = {
+  id: string | number;
+  seqNo?: number | null;
+  senderRole: string;
+  content?: string | null;
+  createdAt?: string | null;
+  timestamp?: string | null;
+};
+
+export type MessageLike = {
+  id?: string | number | null;
+  seqNo?: number | null;
+  senderRole?: string | null;
+  content?: string | null;
+  createdAt?: string | null;
+  timestamp?: string | null;
+};
+
+export type PendingMessage = {
+  id: string;
+  sessionId: string;
+  content: string;
+  isNote: boolean;
+  timeoutId: ReturnType<typeof setTimeout>;
+  createdAt: number;
+};
+
+type SessionMeta = {
+  customerName?: string;
+  membershipTier?: string;
+  contact?: string;
+  email?: string;
+  customerInfo?: {
+    membershipTier?: string | null;
+    contact?: string | null;
+    email?: string | null;
+  };
+  orderInfo?: CustomerOrderInfo | null;
+  extractedInfo?: CustomerExtractedInfo | null;
+  handoffRequired?: boolean;
+  handoffReason?: string;
+  handoffAt?: string;
+  handoffNodeId?: string;
+  title?: string;
+  lastMessagePreview?: string;
+  lastMessageRole?: string;
+  lastMessageAt?: string;
+};
+
+type QueueCustomerPanelData = {
+  customerInfo: CustomerPanelInfo;
+  orderInfo: CustomerOrderInfo | null;
+  extractedInfo: CustomerExtractedInfo | null;
+};
+
+export type QueueCustomerWithPanelData = QueueCustomer & QueueCustomerPanelData;
+
+export type MessagePaginationState = {
+  nextPage: number;
+  totalPages: number;
+  isLoadingPrevious: boolean;
+};
+
+export type EndSessionModalState =
+  | { open: false }
+  | {
+      open: true;
+      sessionId: string;
+      customerName: string;
+      outcome: ResolutionOutcome | null;
+      reason: string;
+      isSubmitting: boolean;
+      error: string | null;
+    };
+
+export type ReleaseAssignmentModalState =
+  | { open: false }
+  | {
+      open: true;
+      sessionId: string;
+      customerName: string;
+      isSubmitting: boolean;
+      error: string | null;
+    };
+
+export type ResolutionOutcomeOption = {
+  value: ResolutionOutcome;
+  label: string;
+  description: string;
+  status: Extract<ConsultationSessionStatus, "RESOLVED" | "COMPLETED">;
+  followUpRequired: boolean;
+};
+
+export const RESOLUTION_OUTCOME_OPTIONS: ResolutionOutcomeOption[] = [
+  {
+    value: "RESOLVED",
+    label: "해결됨",
+    description: "문제가 해결되어 상담 기록을 해결 상태로 남깁니다.",
+    status: "RESOLVED",
+    followUpRequired: false,
+  },
+  {
+    value: "CUSTOMER_LEFT",
+    label: "고객 이탈",
+    description: "고객 응답 없이 상담을 완전히 종료합니다.",
+    status: "COMPLETED",
+    followUpRequired: false,
+  },
+  {
+    value: "PENDING",
+    label: "보류",
+    description: "현재 상담은 대기열에서 제거하고 후속 확인 대상으로 남깁니다.",
+    status: "RESOLVED",
+    followUpRequired: true,
+  },
+  {
+    value: "FOLLOW_UP_REQUIRED",
+    label: "후속 연락 필요",
+    description: "상담 기록에 후속 연락 필요 여부를 명확히 남깁니다.",
+    status: "RESOLVED",
+    followUpRequired: true,
+  },
+];
+
+export const findResolutionOutcomeOption = (outcome: ResolutionOutcome | null) =>
+  RESOLUTION_OUTCOME_OPTIONS.find((option) => option.value === outcome) ?? null;
+
+export const getComposerDraftReleaseWarning = (draft: ChatComposerDraft) => {
+  if (!draft.input.trim()) return null;
+  return draft.isNoteMode
+    ? "메시지 입력창에 작성 중인 내부 메모가 있습니다."
+    : "메시지 입력창에 작성 중인 답변이 있습니다.";
+};
+
+export const formatTime = (isoString: string) => {
+  if (!isoString) return "";
+  const d = new Date(isoString);
+  return `${d.getHours().toString().padStart(2, "0")}:${d.getMinutes().toString().padStart(2, "0")}`;
+};
+
+export const toUiMessage = (message: MessageLike): UiChatMessage => {
+  const rawCreatedAt = message.createdAt ?? message.timestamp ?? null;
+  const displayCreatedAt = rawCreatedAt ?? new Date().toISOString();
+  return {
+    id: String(message.id ?? `message-${displayCreatedAt}-${message.content ?? ""}`),
+    ...(message.seqNo != null ? { seqNo: message.seqNo } : {}),
+    ...(rawCreatedAt != null ? { createdAt: rawCreatedAt } : {}),
+    senderRole: normalizeChatSenderRole(message.senderRole),
+    content: message.content ?? "",
+    timestamp: formatTime(displayCreatedAt),
+  };
+};
+
+export const mergeMessagesById = (
+  currentMessages: UiChatMessage[],
+  nextMessages: UiChatMessage[],
+): UiChatMessage[] => {
+  const byId = new Map<string, UiChatMessage>();
+  [...currentMessages, ...nextMessages].forEach((message) => {
+    byId.set(message.id, message);
+  });
+  return sortMessagesByServerOrder(Array.from(byId.values()));
+};
+
+export const shouldRefreshMatchedWorkflow = (role: ChatSenderRole) =>
+  role === "ASSISTANT" || role === "SYSTEM";
+
+export const isCounselorEchoRole = (role: ChatSenderRole) =>
+  role === "COUNSELOR" || role === "AGENT" || role === "NOTE";
+
+const pendingRoleMatchesEcho = (pending: PendingMessage, role: ChatSenderRole) =>
+  pending.isNote ? role === "NOTE" : role === "COUNSELOR" || role === "AGENT";
+
+const hasSendingMessage = (messages: UiChatMessage[], pendingId: string) =>
+  messages.some((message) => message.id === pendingId && message.deliveryStatus === "sending");
+
+const findPendingEchoMatch = (
+  pendingMessages: Iterable<PendingMessage>,
+  messages: UiChatMessage[],
+  sessionId: string,
+  role: ChatSenderRole,
+  content: string,
+) =>
+  [...pendingMessages]
+    .filter(
+      (pending) =>
+        pending.sessionId === sessionId &&
+        pendingRoleMatchesEcho(pending, role) &&
+        pending.content === content &&
+        hasSendingMessage(messages, pending.id),
+    )
+    .sort((a, b) => a.createdAt - b.createdAt)[0];
+
+export const reconcileCounselorEchoMessage = (
+  messages: UiChatMessage[],
+  pendingMessages: Map<string, PendingMessage>,
+  sessionId: string,
+  role: ChatSenderRole,
+  realtimeMessage: RealtimeChatMessage,
+) => {
+  const serverMessage = {
+    ...toUiMessage(realtimeMessage),
+    deliveryStatus: "sent" as const,
+  };
+  if (messages.some((message) => message.id === serverMessage.id)) {
+    return messages;
+  }
+
+  const pendingMatch = findPendingEchoMatch(
+    pendingMessages.values(),
+    messages,
+    sessionId,
+    role,
+    realtimeMessage.content ?? "",
+  );
+  if (!pendingMatch) {
+    return messages;
+  }
+
+  clearTimeout(pendingMatch.timeoutId);
+  pendingMessages.delete(pendingMatch.id);
+  return sortMessagesByServerOrder(
+    messages.map((message) => (message.id === pendingMatch.id ? serverMessage : message)),
+  );
+};
+
+export const markMessageSending = (messages: UiChatMessage[], messageId: string) =>
+  messages.map((message) =>
+    message.id === messageId
+      ? {
+          ...message,
+          deliveryStatus: "sending" as const,
+          retryable: false,
+          errorMessage: undefined,
+          timestamp: formatTime(new Date().toISOString()),
+        }
+      : message,
+  );
+
+const calcWaitMinutes = (isoString: string) => {
+  if (!isoString) return 0;
+  const d = new Date(isoString);
+  const diffMs = new Date().getTime() - d.getTime();
+  return Math.max(0, Math.floor(diffMs / 60000));
+};
+
+const formatLastMessageTimeLabel = (isoString?: string | null) => {
+  if (!isoString) return "";
+  const d = new Date(isoString);
+  const timestamp = d.getTime();
+  if (Number.isNaN(timestamp)) return "";
+  const diffMinutes = Math.max(0, Math.floor((Date.now() - timestamp) / 60000));
+  return diffMinutes === 0 ? "방금 전" : `${formatWaitDuration(diffMinutes)} 전`;
+};
+
+const parseSessionMeta = (metaJson?: string | null): SessionMeta => {
+  try {
+    if (!metaJson) return {};
+    const meta = JSON.parse(metaJson) as SessionMeta;
+    return meta && typeof meta === "object" ? meta : {};
+  } catch (e) {
+    console.error("Failed to parse metaJson", e);
+    return {};
+  }
+};
+
+const normalizePanelText = (value?: string | null) => {
+  const normalized = value?.trim();
+  return normalized || undefined;
+};
+
+const buildCustomerPanelData = (meta: SessionMeta): QueueCustomerPanelData => ({
+  customerInfo: {
+    membershipTier: normalizePanelText(meta.customerInfo?.membershipTier ?? meta.membershipTier),
+    contact: normalizePanelText(meta.customerInfo?.contact ?? meta.contact),
+    email: normalizePanelText(meta.customerInfo?.email ?? meta.email),
+  },
+  orderInfo: meta.orderInfo ?? null,
+  extractedInfo: meta.extractedInfo ?? null,
+});
+
+const getSessionStatusLabel = (
+  status?: string | null,
+  assignedCounselorId?: number | null,
+  currentCounselorId?: number | null,
+  handoffRequired?: boolean,
+) => {
+  const prefix = handoffRequired ? "상담사 연결 요청 · " : "";
+  if (status === "COMPLETED") return "상담 종료";
+  if (status === "RESOLVED") return "해결됨";
+  if (assignedCounselorId && assignedCounselorId === currentCounselorId)
+    return `${prefix}내게 배정됨`;
+  if (assignedCounselorId) return `${prefix}다른 상담사 배정`;
+  if (status === "ACTIVE") return `${prefix}미배정`;
+  if (status === "OPEN") return `${prefix}미배정`;
+  return status ?? "상태 미확인";
+};
+
+export type AssignmentView = {
+  label: string;
+  description: string;
+};
+
+export const getAssignmentView = (
+  status?: string | null,
+  assignedCounselorId?: number | null,
+  currentCounselorId?: number | null,
+): AssignmentView => {
+  if (status === "COMPLETED" || status === "RESOLVED") {
+    return {
+      label: status === "RESOLVED" ? "해결됨" : "상담 종료",
+      description: "종료된 세션이므로 메시지를 보낼 수 없습니다.",
+    };
+  }
+
+  if (assignedCounselorId && assignedCounselorId === currentCounselorId) {
+    return {
+      label: "내게 배정됨",
+      description: "이 세션에 응답하고 내부 메모를 남길 수 있습니다.",
+    };
+  }
+
+  if (assignedCounselorId) {
+    return {
+      label: "다른 상담사 배정",
+      description: "다른 상담사가 응대 중인 세션이므로 메시지를 보낼 수 없습니다.",
+    };
+  }
+
+  return {
+    label: "미배정",
+    description: "배정받기 전에는 메시지와 내부 메모를 보낼 수 없습니다.",
+  };
+};
+
+export const getResponseStatusLabel = (
+  status?: string | null,
+  assignedCounselorId?: number | null,
+) => {
+  if (status === "COMPLETED") return "상담 종료";
+  if (status === "RESOLVED") return "해결됨";
+  return assignedCounselorId ? "상담사 응대중" : "AI 응대";
+};
+
+export const isCustomerMessageRole = (role?: string | null) => {
+  const normalizedRole = normalizeChatSenderRole(role);
+  return normalizedRole === "USER" || normalizedRole === "CUSTOMER";
+};
+
+const getQueueSortTime = (customer: QueueCustomer) => {
+  const timeSource =
+    customer.handoffRequired && customer.handoffAt
+      ? customer.handoffAt
+      : (customer.lastMessageAt ?? customer.startedAt);
+  if (!timeSource) return 0;
+  const timestamp = new Date(timeSource).getTime();
+  return Number.isNaN(timestamp) ? 0 : timestamp;
+};
+
+export const toQueueCustomer = (
+  session: ChatSession,
+  currentCounselorId: number | null,
+  previous?: QueueCustomerWithPanelData,
+  options?: { hasUnread?: boolean },
+): QueueCustomerWithPanelData => {
+  const meta = parseSessionMeta(session.metaJson);
+  const panelData = buildCustomerPanelData(meta);
+  const hasSessionMetaJson = session.metaJson !== undefined && session.metaJson !== null;
+  const assignedCounselorId =
+    session.assignedCounselorId !== undefined
+      ? session.assignedCounselorId
+      : (previous?.assignedCounselorId ?? null);
+  const responseMode =
+    session.responseMode ??
+    previous?.responseMode ??
+    (assignedCounselorId ? "HUMAN_ACTIVE" : DEFAULT_RESPONSE_MODE);
+  const status = session.status !== undefined ? session.status : (previous?.status ?? null);
+  const startedAt = session.startedAt ?? previous?.startedAt ?? null;
+  const lastMessagePreview = meta.lastMessagePreview?.trim() || previous?.lastMessagePreview || "";
+  const lastMessageRole = meta.lastMessageRole ?? previous?.lastMessageRole;
+  const lastMessageAt = meta.lastMessageAt ?? previous?.lastMessageAt ?? null;
+  const handoffRequired = meta.handoffRequired ?? previous?.handoffRequired ?? false;
+  const handoffAt = meta.handoffAt ?? previous?.handoffAt ?? null;
+  const handoffNodeId = meta.handoffNodeId ?? previous?.handoffNodeId ?? null;
+  const lastMessageTimeLabel =
+    formatLastMessageTimeLabel(lastMessageAt) || previous?.lastMessageTimeLabel;
+
+  return {
+    id: String(session.id ?? previous?.id ?? ""),
+    name: meta.customerName?.trim() || previous?.name || "Unknown",
+    title: meta.title?.trim() || previous?.title || "",
+    channel: session.channel ?? previous?.channel ?? "",
+    handoffReason: meta.handoffReason ?? previous?.handoffReason ?? "",
+    handoffRequired,
+    handoffAt,
+    handoffNodeId,
+    waitMinutes: startedAt ? calcWaitMinutes(startedAt) : (previous?.waitMinutes ?? 0),
+    hasUnread: options?.hasUnread ?? previous?.hasUnread ?? false,
+    lastMessagePreview,
+    lastMessageRole,
+    lastMessageAt,
+    lastMessageTimeLabel,
+    status,
+    statusLabel: getSessionStatusLabel(
+      status,
+      assignedCounselorId,
+      currentCounselorId,
+      handoffRequired,
+    ),
+    assignedCounselorId,
+    responseMode,
+    startedAt,
+    customerInfo: {
+      membershipTier: hasSessionMetaJson
+        ? panelData.customerInfo.membershipTier
+        : previous?.customerInfo.membershipTier,
+      contact: hasSessionMetaJson ? panelData.customerInfo.contact : previous?.customerInfo.contact,
+      email: hasSessionMetaJson ? panelData.customerInfo.email : previous?.customerInfo.email,
+    },
+    orderInfo: hasSessionMetaJson ? panelData.orderInfo : (previous?.orderInfo ?? null),
+    extractedInfo: hasSessionMetaJson ? panelData.extractedInfo : (previous?.extractedInfo ?? null),
+  };
+};
+
+export const sortQueueCustomers = (customers: QueueCustomerWithPanelData[]) =>
+  [...customers].sort((a, b) => {
+    const aIsHandoff = a.handoffRequired === true;
+    const bIsHandoff = b.handoffRequired === true;
+    if (aIsHandoff !== bIsHandoff) {
+      return aIsHandoff ? -1 : 1;
+    }
+    if (aIsHandoff && bIsHandoff) {
+      return getQueueSortTime(a) - getQueueSortTime(b);
+    }
+    return getQueueSortTime(b) - getQueueSortTime(a);
+  });
+
+export const replaceAssignedQueueCustomer = (
+  customers: QueueCustomerWithPanelData[],
+  sessionId: string,
+  assignedSession: ChatSession,
+  currentCounselorId: number,
+) =>
+  sortQueueCustomers(
+    customers.map((customer) =>
+      customer.id === sessionId
+        ? toQueueCustomer(assignedSession, currentCounselorId, customer)
+        : customer,
+    ),
+  );
+
+export const getClaimSessionErrorMessage = (error: unknown) => {
+  if (error instanceof ApiRequestError) {
+    switch (error.code) {
+      case "SESSION_ALREADY_ASSIGNED":
+        return "이미 다른 상담사에게 배정된 상담입니다.";
+      case "SESSION_NOT_ASSIGNABLE":
+        return "현재 배정할 수 없는 상담 상태입니다.";
+      case "SESSION_NOT_FOUND":
+        return "상담 세션을 찾을 수 없습니다.";
+      case "WORKSPACE_ACCESS_DENIED":
+      case "FORBIDDEN":
+        return "상담 배정 권한이 없습니다.";
+      default:
+        return "상담 세션 배정에 실패했습니다.";
+    }
+  }
+  return "상담 세션 배정에 실패했습니다.";
+};
+
+export const dedupePrependMessages = (
+  olderMessages: UiChatMessage[],
+  currentMessages: UiChatMessage[],
+) => {
+  const existingIds = new Set(currentMessages.map((message) => message.id));
+  return [...olderMessages.filter((message) => !existingIds.has(message.id)), ...currentMessages];
+};
+
+export type MetricsViewState = "loading" | "error" | "empty" | "ready";

--- a/frontend/src/pages/consultation/ui/model/useConsultationRealtime.ts
+++ b/frontend/src/pages/consultation/ui/model/useConsultationRealtime.ts
@@ -1,0 +1,68 @@
+import { useEffect, useRef } from "react";
+import { useStomp, type ConnectionStatus } from "@/shared/lib/websocket";
+
+type UseConsultationRealtimeParams = {
+  workspaceId: number | null;
+  activeCustomerId: string | null;
+  hasQueueLoaded: boolean;
+  onQueueEvent: (raw: unknown) => void;
+  onChatMessage: (raw: unknown, sessionId: string) => void;
+  onServerError: (error: unknown) => void;
+  onReconnect: () => void;
+  onChatUnsubscribe: () => void;
+};
+
+export function useConsultationRealtime({
+  workspaceId,
+  activeCustomerId,
+  hasQueueLoaded,
+  onQueueEvent,
+  onChatMessage,
+  onServerError,
+  onReconnect,
+  onChatUnsubscribe,
+}: UseConsultationRealtimeParams) {
+  const previousConnectionStatusRef = useRef<ConnectionStatus>("DISCONNECTED");
+  const { connectionStatus, subscribe, sendTo } = useStomp({ onServerError });
+
+  useEffect(() => {
+    const previousStatus = previousConnectionStatusRef.current;
+    previousConnectionStatusRef.current = connectionStatus;
+
+    if (!workspaceId) return;
+    if (connectionStatus !== "CONNECTED" || previousStatus === "CONNECTED") return;
+    if (!hasQueueLoaded) return;
+
+    onReconnect();
+  }, [connectionStatus, hasQueueLoaded, onReconnect, workspaceId]);
+
+  useEffect(() => {
+    if (!workspaceId) return;
+
+    const unsubscribe = subscribe(
+      `/topic/workspaces.${workspaceId}.consultation.queue`,
+      onQueueEvent,
+    );
+
+    return () => {
+      unsubscribe();
+    };
+  }, [onQueueEvent, subscribe, workspaceId]);
+
+  useEffect(() => {
+    if (!activeCustomerId) return;
+
+    const topic = `/topic/chat.${activeCustomerId}`;
+    const unsubscribe = subscribe(topic, (raw) => onChatMessage(raw, activeCustomerId));
+
+    return () => {
+      unsubscribe();
+      onChatUnsubscribe();
+    };
+  }, [activeCustomerId, onChatMessage, onChatUnsubscribe, subscribe]);
+
+  return {
+    connectionStatus,
+    sendTo,
+  };
+}

--- a/frontend/src/pages/consultation/ui/sections/ConsultationConversationPane.tsx
+++ b/frontend/src/pages/consultation/ui/sections/ConsultationConversationPane.tsx
@@ -1,0 +1,174 @@
+import React from "react";
+import { Avatar, Mono } from "@/shared/ui/ostone/atoms";
+import { formatWaitDuration } from "../../../../features/consultation/lib/formatWaitDuration";
+import { ChatPanel } from "../../../../features/consultation/ui/ChatPanel";
+import type {
+  ChatComposerDraft,
+  ChatMessage as UiChatMessage,
+} from "../../../../features/consultation/ui/ChatPanel";
+import type { MatchedWorkflow } from "../../../../features/consultation/api/llmToolWorkflowApi";
+import type {
+  AssignmentView,
+  MessagePaginationState,
+  QueueCustomerWithPanelData,
+} from "../model/consultationPageState";
+import styles from "../consultation-page.module.css";
+
+type ConsultationConversationPaneProps = {
+  activeCustomer: QueueCustomerWithPanelData | null;
+  activeCustomerId: string | null;
+  activeCustomerName: string;
+  activeCustomerInitial: string;
+  activeResponseStatusLabel: string | null;
+  activeAssignment: AssignmentView | null;
+  currentCounselorId: number | null;
+  isActiveSessionUnassigned: boolean;
+  isActiveSessionClosed: boolean;
+  isClaimingActiveSession: boolean;
+  isAssignedToCurrentCounselor: boolean;
+  messageInputDisabledReason?: string;
+  urlSessionUnavailable: boolean;
+  visibleMessages: UiChatMessage[];
+  selectedMessageId: string | null;
+  hasPreviousMessages: boolean;
+  messagePagination: MessagePaginationState;
+  matchedWorkflow: MatchedWorkflow | null;
+  isDraftResponseLoading: boolean;
+  activeComposerDraft: ChatComposerDraft;
+  onClaimSession: () => void;
+  onOpenReleaseAssignment: () => void;
+  onOpenEndSession: () => void;
+  onSendMessage: (content: string, isNote: boolean) => void;
+  onRetryMessage: (messageId: string) => void;
+  onSelectMessage: (messageId: string | null) => void;
+  onLoadPreviousMessages: () => Promise<void>;
+  onInsertDraftResponse: () => Promise<string>;
+  onComposerDraftChange: (draft: ChatComposerDraft) => void;
+};
+
+export const ConsultationConversationPane: React.FC<ConsultationConversationPaneProps> = ({
+  activeCustomer,
+  activeCustomerId,
+  activeCustomerName,
+  activeCustomerInitial,
+  activeResponseStatusLabel,
+  activeAssignment,
+  currentCounselorId,
+  isActiveSessionUnassigned,
+  isActiveSessionClosed,
+  isClaimingActiveSession,
+  isAssignedToCurrentCounselor,
+  messageInputDisabledReason,
+  urlSessionUnavailable,
+  visibleMessages,
+  selectedMessageId,
+  hasPreviousMessages,
+  messagePagination,
+  matchedWorkflow,
+  isDraftResponseLoading,
+  activeComposerDraft,
+  onClaimSession,
+  onOpenReleaseAssignment,
+  onOpenEndSession,
+  onSendMessage,
+  onRetryMessage,
+  onSelectMessage,
+  onLoadPreviousMessages,
+  onInsertDraftResponse,
+  onComposerDraftChange,
+}) => {
+  return (
+    <div className={styles.conversationPane}>
+      {activeCustomer && (
+        <div className={styles.conversationHeader}>
+          <div className={styles.conversationHeaderTop}>
+            <div className={styles.customerTitle}>
+              <Avatar initial={activeCustomerInitial} tone="warn" size={36} />
+              <div>
+                <div className={styles.customerName}>{activeCustomerName} 고객</div>
+                <Mono style={{ fontSize: 10, color: "var(--ink-3)" }}>
+                  {activeCustomer.channel ?? ""} ·{" "}
+                  {formatWaitDuration(activeCustomer.waitMinutes)} 대기 중
+                </Mono>
+              </div>
+            </div>
+          </div>
+          <div className={styles.conversationActions}>
+            {activeResponseStatusLabel && (
+              <div
+                className={styles.responseStatusBadge}
+                role="status"
+                aria-label="응대 상태"
+                data-testid="conversation-response-status"
+              >
+                {activeResponseStatusLabel}
+              </div>
+            )}
+            {isActiveSessionUnassigned && !isActiveSessionClosed && (
+              <button
+                type="button"
+                className={styles.claimButton}
+                onClick={onClaimSession}
+                disabled={!currentCounselorId || isClaimingActiveSession}
+              >
+                {isClaimingActiveSession ? "배정 중..." : "배정받기"}
+              </button>
+            )}
+            <button
+              className={styles.linkButton}
+              onClick={onOpenReleaseAssignment}
+              disabled={!isAssignedToCurrentCounselor}
+            >
+              배정 해제
+            </button>
+            <button
+              onClick={onOpenEndSession}
+              className={styles.dangerButton}
+              disabled={!isAssignedToCurrentCounselor}
+            >
+              상담 종료
+            </button>
+          </div>
+        </div>
+      )}
+
+      <div className={styles.chatPanelSlot}>
+        {urlSessionUnavailable ? (
+          <div className={styles.urlSessionState} role="status" aria-live="polite">
+            <p className={styles.urlSessionTitle}>요청한 상담 세션을 찾을 수 없습니다</p>
+            <p className={styles.urlSessionText}>
+              상담이 종료되었거나 현재 대기열에서 접근할 수 없는 세션입니다.
+            </p>
+          </div>
+        ) : (
+          <ChatPanel
+            sessionId={activeCustomerId}
+            customerName={activeCustomer ? activeCustomerName : null}
+            channel={activeCustomer?.channel || null}
+            messages={visibleMessages}
+            onSendMessage={onSendMessage}
+            onRetryMessage={onRetryMessage}
+            selectedMessageId={selectedMessageId}
+            onSelectMessage={onSelectMessage}
+            sessionStatusLabel={activeResponseStatusLabel ?? activeAssignment?.label}
+            disabledReason={messageInputDisabledReason}
+            disabled={!isAssignedToCurrentCounselor}
+            hasPreviousMessages={hasPreviousMessages}
+            isLoadingPreviousMessages={messagePagination.isLoadingPrevious}
+            onLoadPreviousMessages={onLoadPreviousMessages}
+            draftResponseAction={
+              matchedWorkflow && isAssignedToCurrentCounselor
+                ? {
+                    isLoading: isDraftResponseLoading,
+                    onInsert: onInsertDraftResponse,
+                  }
+                : undefined
+            }
+            composerDraft={activeComposerDraft}
+            onComposerDraftChange={onComposerDraftChange}
+          />
+        )}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/pages/consultation/ui/sections/ConsultationDetailPane.tsx
+++ b/frontend/src/pages/consultation/ui/sections/ConsultationDetailPane.tsx
@@ -1,0 +1,101 @@
+import React from "react";
+import type { ChatMessage as UiChatMessage } from "../../../../features/consultation/ui/ChatPanel";
+import { MessageDetailPanel } from "../../../../features/consultation/ui/MessageDetailPanel";
+import type { MessageDomainPackElements } from "../../../../features/consultation/api/consultationEvidenceApi";
+import type { MatchedWorkflow } from "../../../../features/consultation/api/llmToolWorkflowApi";
+import {
+  CustomerPanel,
+  type CustomerExtractedInfo,
+  type CustomerOrderInfo,
+} from "./CustomerPanel";
+import { MatchedWorkflowBar, MatchedWorkflowBarSkeleton } from "./MatchedWorkflowBar";
+import type { QueueCustomerWithPanelData } from "../model/consultationPageState";
+import styles from "../consultation-page.module.css";
+
+type ConsultationDetailPaneProps = {
+  activeCustomer: QueueCustomerWithPanelData | null;
+  activeCustomerId: string | null;
+  activeCustomerName: string;
+  selectedMessage: UiChatMessage | null;
+  matchedWorkflow: MatchedWorkflow | null;
+  isMatchedWorkflowLoading: boolean;
+  messageDomainPackElements?: MessageDomainPackElements;
+  isMessageDomainPackElementsLoading: boolean;
+  messageDomainPackElementsError: string | null;
+  memo: string;
+  onMemoChange: (value: string) => void;
+  onMemoSave?: () => void;
+  onOpenDomainPackElement: (path: string) => void;
+  onCloseMessageDetail: () => void;
+};
+
+const getCustomerPanelData = (
+  activeCustomer: QueueCustomerWithPanelData,
+  activeCustomerName: string,
+) => ({
+  name: activeCustomerName,
+  channel: activeCustomer.channel,
+  handoffRequired: activeCustomer.handoffRequired,
+  handoffReason: activeCustomer.handoffReason,
+  handoffAt: activeCustomer.handoffAt,
+  membershipTier: activeCustomer.customerInfo.membershipTier,
+  contact: activeCustomer.customerInfo.contact,
+  email: activeCustomer.customerInfo.email,
+});
+
+export const ConsultationDetailPane: React.FC<ConsultationDetailPaneProps> = ({
+  activeCustomer,
+  activeCustomerId,
+  activeCustomerName,
+  selectedMessage,
+  matchedWorkflow,
+  isMatchedWorkflowLoading,
+  messageDomainPackElements,
+  isMessageDomainPackElementsLoading,
+  messageDomainPackElementsError,
+  memo,
+  onMemoChange,
+  onMemoSave,
+  onOpenDomainPackElement,
+  onCloseMessageDetail,
+}) => {
+  const orderInfo: CustomerOrderInfo | null = activeCustomer?.orderInfo ?? null;
+  const extractedInfo: CustomerExtractedInfo | null = activeCustomer?.extractedInfo ?? null;
+
+  return (
+    <div className={styles.detailPane}>
+      {activeCustomerId && (isMatchedWorkflowLoading || matchedWorkflow) && (
+        <div className={styles.detailPaneTop}>
+          {matchedWorkflow ? (
+            <MatchedWorkflowBar workflow={matchedWorkflow} />
+          ) : (
+            <MatchedWorkflowBarSkeleton />
+          )}
+        </div>
+      )}
+      <div className={styles.detailPaneBody}>
+        {selectedMessage ? (
+          <MessageDetailPanel
+            message={selectedMessage}
+            domainPackElements={messageDomainPackElements}
+            isDomainPackElementsLoading={isMessageDomainPackElementsLoading}
+            domainPackElementsError={messageDomainPackElementsError}
+            onOpenDomainPackElement={onOpenDomainPackElement}
+            onClose={onCloseMessageDetail}
+          />
+        ) : (
+          <CustomerPanel
+            customer={
+              activeCustomer ? getCustomerPanelData(activeCustomer, activeCustomerName) : null
+            }
+            orderInfo={orderInfo}
+            extractedInfo={extractedInfo}
+            memo={memo}
+            onMemoChange={onMemoChange}
+            onMemoSave={onMemoSave}
+          />
+        )}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/pages/consultation/ui/sections/ConsultationStatusRight.tsx
+++ b/frontend/src/pages/consultation/ui/sections/ConsultationStatusRight.tsx
@@ -1,0 +1,66 @@
+import { Dot, Mono } from "@/shared/ui/ostone/atoms";
+import type { MetricsViewState } from "../model/consultationPageState";
+
+type ConsultationStatusRightProps = {
+  metricsViewState: MetricsViewState;
+  averageFirstResponseSeconds?: number | null;
+  handledTodayCount?: number | null;
+};
+
+const formatAverageFirstResponse = (seconds?: number | null) => {
+  if (seconds == null) return "--";
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  return minutes > 0 ? `${minutes}분 ${remainingSeconds}초` : `${remainingSeconds}초`;
+};
+
+const formatHandledTodayCount = (count?: number | null) => {
+  return count == null ? "--" : `${count}건`;
+};
+
+const formatMetricValue = (
+  metricsViewState: MetricsViewState,
+  value: number | null | undefined,
+  formatter: (value?: number | null) => string,
+) => {
+  if (metricsViewState === "loading") return "로딩중";
+  if (metricsViewState === "error") return "오류";
+  if (metricsViewState === "empty") return "--";
+  return formatter(value);
+};
+
+export const ConsultationStatusRight = ({
+  metricsViewState,
+  averageFirstResponseSeconds,
+  handledTodayCount,
+}: ConsultationStatusRightProps) => {
+  const averageLabel = formatMetricValue(
+    metricsViewState,
+    averageFirstResponseSeconds,
+    formatAverageFirstResponse,
+  );
+  const handledLabel = formatMetricValue(
+    metricsViewState,
+    handledTodayCount,
+    formatHandledTodayCount,
+  );
+
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+        <Dot tone="signal" />
+        <span style={{ fontSize: 12 }}>응대 가능</span>
+      </div>
+      <div style={{ width: 1, height: 16, background: "var(--line)" }} />
+      <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+        <Mono style={{ fontSize: 11, color: "var(--ink-3)" }}>평균 첫응답</Mono>
+        <span style={{ fontSize: 14, fontWeight: 700 }}>{averageLabel}</span>
+      </div>
+      <div style={{ width: 1, height: 16, background: "var(--line)" }} />
+      <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+        <Mono style={{ fontSize: 11, color: "var(--ink-3)" }}>오늘 처리</Mono>
+        <span style={{ fontSize: 14, fontWeight: 700 }}>{handledLabel}</span>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
Closes #620

## 변경 사항

- `ConsultationPage`의 대기열/메시지/배정/렌더링 보조 로직을 page-local state model과 section component로 분리했습니다.
- STOMP 연결, workspace queue topic, active chat topic 구독을 `useConsultationRealtime` hook으로 이동해 실시간 연결 책임을 페이지 본문에서 분리했습니다.
- 상담 입력 영역과 workflow/detail 패널 렌더링을 각각 `ConsultationConversationPane`, `ConsultationDetailPane`으로 나눠 기존 상담 흐름을 유지하면서 표시 책임을 명확히 했습니다.
- 이슈 620 스펙을 `.agent/specs/620.md`에 정리했습니다.

## 검증

- `git diff --check`
- `pnpm --dir frontend exec eslint src/pages/consultation/ui/ConsultationPage.tsx src/pages/consultation/ui/model/consultationPageState.ts src/pages/consultation/ui/model/useConsultationRealtime.ts src/pages/consultation/ui/sections/ConsultationConversationPane.tsx src/pages/consultation/ui/sections/ConsultationDetailPane.tsx src/pages/consultation/ui/sections/ConsultationStatusRight.tsx`
- `pnpm --dir frontend exec tsc -b --pretty false`
- `pnpm --dir frontend exec vp test src/pages/consultation/ui/ConsultationPage.test.tsx src/pages/consultation/ui/ConsultationPage.generated-api.test.tsx` (2 files / 80 tests passed)
- `pnpm --dir frontend build`

## 참고

- `pnpm --dir frontend lint`와 pre-commit의 `pnpm run lint:frontend`는 repository-wide 기존 ESLint baseline 48건으로 실패합니다. 이번 PR에서 변경한 TS/TSX 파일은 대상 지정 ESLint와 TypeScript, 테스트, production build로 통과 확인했습니다.