### PR TITLE
refactor(domain-pack): draft component 저장 책임을 분리

### DIFF
--- a/.agent/specs/610.md
+++ b/.agent/specs/610.md
@@ -1,0 +1,85 @@
+# Backend Spec: draft component 저장 경로 분리
+
+## Goal
+
+`DomainPackDraftPersistenceService`가 draft version orchestration에 집중하도록 intent, slot/policy/risk/workflow/component 저장과 workflow graph mapping 책임을 분리한다.
+
+## Background
+
+Issue #610은 `DomainPackDraftPersistenceService`가 draft artifact parsing, component 저장, workflow node/edge mapping, matching profile enqueue를 한 클래스에서 처리해 Domain Pack schema 변경 시 영향 범위가 커지는 문제를 다룬다.
+
+현재 확인된 대상 파일:
+
+- `backend/src/main/java/com/init/domainpack/application/DomainPackDraftPersistenceService.java`
+- `backend/src/test/java/com/init/domainpack/application/DomainPackDraftPersistenceServiceTest.java`
+
+이슈 본문의 참고 위치는 `backend/src/main/java/com/init/domainpack/application/service/DomainPackDraftPersistenceService.java`였지만, 현재 저장소에서는 위 application package 경로가 실제 위치다.
+
+## Scope
+
+- `domain-pack` application 계층 안에서 draft component별 저장 또는 mapping 책임을 분리한다.
+- intent 저장, slot/policy/risk/workflow 저장, intent-slot binding 저장, workflow graph parsing/normalization 책임을 명확히 나눈다.
+- 기존 public use case 진입점인 `persistVersion`, `persistIntents`, `persist`, `persistWorkflowDraft`의 호출 계약과 transaction 경계는 유지한다.
+- workflow가 실제 저장된 경우에만 matching profile enqueue를 호출하는 현재 정책을 명시적으로 유지한다.
+
+## Non-goals
+
+- REST API, request/response DTO, OpenAPI contract는 변경하지 않는다.
+- PostgreSQL schema나 migration은 변경하지 않는다.
+- workflow graph validation rule 자체를 바꾸지 않는다.
+- matching profile build queue의 내부 구현이나 retry 정책은 변경하지 않는다.
+
+## Affected Modules
+
+- Bounded Context: `domain-pack`
+- Layer: `application`
+- External collaborator: `com.init.workflowruntime.application.matching.WorkflowMatchingProfileBuildRequestService`
+- Repositories:
+  - `DomainPackVersionRepository`
+  - `IntentDefinitionRepository`
+  - `SlotDefinitionRepository`
+  - `PolicyDefinitionRepository`
+  - `RiskDefinitionRepository`
+  - `WorkflowDefinitionRepository`
+  - `IntentSlotBindingRepository`
+
+## Expected Design
+
+```mermaid
+sequenceDiagram
+    participant svc as DomainPackDraftPersistenceService
+    participant intent as Intent Persister
+    participant mapper as Workflow Mapper
+    participant components as Component Persister
+    participant queue as Profile Build Request
+
+    svc->>svc: require draft version / create draft version
+    svc->>intent: save intents and parent links
+    svc->>mapper: parse graph and normalize workflow state fields
+    svc->>components: save slots, policies, risks, workflows, bindings
+    alt workflows were saved
+        svc->>queue: enqueue(versionId, source)
+    end
+```
+
+## Requirements
+
+1. `DomainPackDraftPersistenceService`는 draft version 생성/조회, component 저장 순서 결정, transaction boundary, enqueue source 선택만 담당한다.
+2. intent 저장 책임은 intent code 중복 skip, request 내 중복 검증, parent intent resolution, 저장 count 계산을 포함한다.
+3. component 저장 책임은 slot → policy → risk → workflow → intent-slot binding 순서를 유지한다.
+4. workflow mapping 책임은 `WorkflowGraphValidator` 기반 graph parsing, ACTION node `policyRef` 검증, `initialState`/`terminalStatesJson` normalization을 담당한다.
+5. `persistWorkflowDraft`는 submitted policy와 같은 draft version에 이미 존재하는 policy만 workflow `policyRef`로 허용한다.
+6. `persist`와 `persistWorkflowDraft`는 workflow 저장 건수가 1건 이상일 때만 `WorkflowMatchingProfileBuildRequestService.enqueue`를 호출한다.
+7. component 저장 중 예외가 발생하면 enqueue가 호출되지 않아야 하며, 기존 transaction rollback semantics를 해치지 않는다.
+
+## Validation
+
+- `DomainPackDraftPersistenceServiceTest` 또는 분리된 application-layer 단위 테스트에서 intent/slot/policy/risk/workflow 저장 책임을 검증한다.
+- draft artifact 샘플에 해당하는 수동 draft 저장 경로와 pipeline workflow draft callback 경로가 기존 result count를 유지하는지 검증한다.
+- workflow `policyRef`가 callback payload와 기존 DB policy 어디에도 없을 때 기존 예외가 유지되는지 검증한다.
+- workflow 저장이 없는 payload에서는 enqueue가 호출되지 않는지 검증한다.
+- 가능한 경우 `cd backend && ./gradlew test --tests com.init.domainpack.application.DomainPackDraftPersistenceServiceTest`로 targeted verification을 실행한다.
+
+## Open Questions
+
+- 없음. 이슈 범위는 내부 application-layer 책임 분리와 기존 동작 보존으로 충분히 구체화되어 있다.

--- a/backend/src/main/java/com/init/domainpack/application/DomainPackDraftComponentPersister.java
+++ b/backend/src/main/java/com/init/domainpack/application/DomainPackDraftComponentPersister.java
@@ -1,0 +1,156 @@
+package com.init.domainpack.application;
+
+import static com.init.domainpack.application.DomainPackDraftPersistenceSupport.indexByCode;
+import static com.init.domainpack.application.DomainPackDraftPersistenceSupport.requireByCode;
+
+import com.init.domainpack.domain.model.IntentDefinition;
+import com.init.domainpack.domain.model.IntentSlotBinding;
+import com.init.domainpack.domain.model.PolicyDefinition;
+import com.init.domainpack.domain.model.RiskDefinition;
+import com.init.domainpack.domain.model.SlotDefinition;
+import com.init.domainpack.domain.model.WorkflowDefinition;
+import com.init.domainpack.domain.repository.IntentSlotBindingRepository;
+import com.init.domainpack.domain.repository.PolicyDefinitionRepository;
+import com.init.domainpack.domain.repository.RiskDefinitionRepository;
+import com.init.domainpack.domain.repository.SlotDefinitionRepository;
+import com.init.domainpack.domain.repository.WorkflowDefinitionRepository;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Service;
+
+@Service
+class DomainPackDraftComponentPersister {
+
+  private final SlotDefinitionRepository slotDefinitionRepository;
+  private final PolicyDefinitionRepository policyDefinitionRepository;
+  private final RiskDefinitionRepository riskDefinitionRepository;
+  private final WorkflowDefinitionRepository workflowDefinitionRepository;
+  private final IntentSlotBindingRepository intentSlotBindingRepository;
+
+  DomainPackDraftComponentPersister(
+      SlotDefinitionRepository slotDefinitionRepository,
+      PolicyDefinitionRepository policyDefinitionRepository,
+      RiskDefinitionRepository riskDefinitionRepository,
+      WorkflowDefinitionRepository workflowDefinitionRepository,
+      IntentSlotBindingRepository intentSlotBindingRepository) {
+    this.slotDefinitionRepository = slotDefinitionRepository;
+    this.policyDefinitionRepository = policyDefinitionRepository;
+    this.riskDefinitionRepository = riskDefinitionRepository;
+    this.workflowDefinitionRepository = workflowDefinitionRepository;
+    this.intentSlotBindingRepository = intentSlotBindingRepository;
+  }
+
+  SavedDraftComponents save(
+      Long domainPackVersionId,
+      Map<String, IntentDefinition> intentsByCode,
+      DraftComponentsInput components) {
+    List<SlotDefinition> savedSlots =
+        slotDefinitionRepository.saveAll(
+            components.slots().stream()
+                .map(slot -> createSlot(domainPackVersionId, slot))
+                .toList());
+    Map<String, SlotDefinition> slotsByCode = indexByCode(savedSlots, SlotDefinition::getSlotCode);
+
+    List<PolicyDefinition> savedPolicies =
+        policyDefinitionRepository.saveAll(
+            components.policies().stream()
+                .map(policy -> createPolicy(domainPackVersionId, policy))
+                .toList());
+
+    List<RiskDefinition> savedRisks =
+        riskDefinitionRepository.saveAll(
+            components.risks().stream()
+                .map(risk -> createRisk(domainPackVersionId, risk))
+                .toList());
+
+    List<WorkflowDefinition> savedWorkflows =
+        workflowDefinitionRepository.saveAll(
+            components.workflows().stream()
+                .map(workflow -> createWorkflow(domainPackVersionId, intentsByCode, workflow))
+                .toList());
+
+    List<IntentSlotBinding> savedIntentSlotBindings =
+        intentSlotBindingRepository.saveAll(
+            components.intentSlotBindings().stream()
+                .map(binding -> createIntentSlotBinding(intentsByCode, slotsByCode, binding))
+                .toList());
+
+    return new SavedDraftComponents(
+        savedSlots.size(),
+        savedPolicies.size(),
+        savedRisks.size(),
+        savedWorkflows.size(),
+        savedIntentSlotBindings.size());
+  }
+
+  private SlotDefinition createSlot(Long domainPackVersionId, SlotInput slot) {
+    return SlotDefinition.create(
+        domainPackVersionId,
+        slot.slotCode(),
+        slot.name(),
+        slot.description(),
+        slot.dataType(),
+        slot.isSensitive(),
+        slot.validationRuleJson(),
+        slot.defaultValueJson(),
+        slot.metaJson());
+  }
+
+  private PolicyDefinition createPolicy(Long domainPackVersionId, PolicyInput policy) {
+    return PolicyDefinition.create(
+        domainPackVersionId,
+        policy.policyCode(),
+        policy.name(),
+        policy.description(),
+        policy.severity(),
+        policy.conditionJson(),
+        policy.actionJson(),
+        policy.evidenceJson(),
+        policy.metaJson());
+  }
+
+  private RiskDefinition createRisk(Long domainPackVersionId, RiskInput risk) {
+    return RiskDefinition.create(
+        domainPackVersionId,
+        risk.riskCode(),
+        risk.name(),
+        risk.description(),
+        risk.riskLevel(),
+        risk.triggerConditionJson(),
+        risk.handlingActionJson(),
+        risk.evidenceJson(),
+        risk.metaJson());
+  }
+
+  private WorkflowDefinition createWorkflow(
+      Long domainPackVersionId,
+      Map<String, IntentDefinition> intentsByCode,
+      WorkflowInput workflow) {
+    return WorkflowDefinition.create(
+        domainPackVersionId,
+        workflow.workflowCode(),
+        workflow.name(),
+        workflow.description(),
+        workflow.graphJson(),
+        workflow.initialState(),
+        workflow.terminalStatesJson(),
+        workflow.evidenceJson(),
+        workflow.metaJson(),
+        requireByCode(intentsByCode, workflow.intentCode(), "intent").getId(),
+        workflow.isPrimary(),
+        workflow.routeConditionJson());
+  }
+
+  private IntentSlotBinding createIntentSlotBinding(
+      Map<String, IntentDefinition> intentsByCode,
+      Map<String, SlotDefinition> slotsByCode,
+      IntentSlotBindingInput binding) {
+    return IntentSlotBinding.create(
+        requireByCode(intentsByCode, binding.intentCode(), "intent").getId(),
+        requireByCode(slotsByCode, binding.slotCode(), "slot").getId(),
+        binding.isRequired(),
+        binding.collectionOrder(),
+        binding.promptHint(),
+        binding.conditionJson());
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/application/DomainPackDraftInputMapper.java
+++ b/backend/src/main/java/com/init/domainpack/application/DomainPackDraftInputMapper.java
@@ -1,0 +1,203 @@
+package com.init.domainpack.application;
+
+import static com.init.domainpack.application.DomainPackDraftPersistenceSupport.safeList;
+
+import java.util.List;
+
+final class DomainPackDraftInputMapper {
+
+  private DomainPackDraftInputMapper() {}
+
+  static DraftComponentsInput fromCreateCommand(CreateDomainPackDraftCommand command) {
+    return new DraftComponentsInput(
+        toSlotInputs(command.slots()),
+        toPolicyInputs(command.policies()),
+        toRiskInputs(command.risks()),
+        toWorkflowInputs(command.workflows()),
+        toIntentSlotBindingInputs(command.intentSlotBindings()));
+  }
+
+  static DraftComponentsInput fromWorkflowCallback(
+      List<AddWorkflowDraftToVersionCommand.SlotDraft> slots,
+      List<AddWorkflowDraftToVersionCommand.PolicyDraft> policies,
+      List<AddWorkflowDraftToVersionCommand.RiskDraft> risks,
+      List<AddWorkflowDraftToVersionCommand.WorkflowDraft> workflows,
+      List<AddWorkflowDraftToVersionCommand.IntentSlotBindingDraft> intentSlotBindings) {
+    return new DraftComponentsInput(
+        toSlotInputsFromWorkflowCallback(slots),
+        toPolicyInputsFromWorkflowCallback(policies),
+        toRiskInputsFromWorkflowCallback(risks),
+        toWorkflowInputsFromWorkflowCallback(workflows),
+        toIntentSlotBindingInputsFromWorkflowCallback(intentSlotBindings));
+  }
+
+  private static List<SlotInput> toSlotInputs(List<CreateDomainPackDraftCommand.SlotDraft> slots) {
+    return safeList(slots).stream()
+        .map(
+            slot ->
+                new SlotInput(
+                    slot.slotCode(),
+                    slot.name(),
+                    slot.description(),
+                    slot.dataType(),
+                    slot.isSensitive(),
+                    slot.validationRuleJson(),
+                    slot.defaultValueJson(),
+                    slot.metaJson()))
+        .toList();
+  }
+
+  private static List<SlotInput> toSlotInputsFromWorkflowCallback(
+      List<AddWorkflowDraftToVersionCommand.SlotDraft> slots) {
+    return safeList(slots).stream()
+        .map(
+            slot ->
+                new SlotInput(
+                    slot.slotCode(),
+                    slot.name(),
+                    slot.description(),
+                    slot.dataType(),
+                    slot.isSensitive(),
+                    slot.validationRuleJson(),
+                    slot.defaultValueJson(),
+                    slot.metaJson()))
+        .toList();
+  }
+
+  private static List<PolicyInput> toPolicyInputs(
+      List<CreateDomainPackDraftCommand.PolicyDraft> policies) {
+    return safeList(policies).stream()
+        .map(
+            policy ->
+                new PolicyInput(
+                    policy.policyCode(),
+                    policy.name(),
+                    policy.description(),
+                    policy.severity(),
+                    policy.conditionJson(),
+                    policy.actionJson(),
+                    policy.evidenceJson(),
+                    policy.metaJson()))
+        .toList();
+  }
+
+  private static List<PolicyInput> toPolicyInputsFromWorkflowCallback(
+      List<AddWorkflowDraftToVersionCommand.PolicyDraft> policies) {
+    return safeList(policies).stream()
+        .map(
+            policy ->
+                new PolicyInput(
+                    policy.policyCode(),
+                    policy.name(),
+                    policy.description(),
+                    policy.severity(),
+                    policy.conditionJson(),
+                    policy.actionJson(),
+                    policy.evidenceJson(),
+                    policy.metaJson()))
+        .toList();
+  }
+
+  private static List<RiskInput> toRiskInputs(List<CreateDomainPackDraftCommand.RiskDraft> risks) {
+    return safeList(risks).stream()
+        .map(
+            risk ->
+                new RiskInput(
+                    risk.riskCode(),
+                    risk.name(),
+                    risk.description(),
+                    risk.riskLevel(),
+                    risk.triggerConditionJson(),
+                    risk.handlingActionJson(),
+                    risk.evidenceJson(),
+                    risk.metaJson()))
+        .toList();
+  }
+
+  private static List<RiskInput> toRiskInputsFromWorkflowCallback(
+      List<AddWorkflowDraftToVersionCommand.RiskDraft> risks) {
+    return safeList(risks).stream()
+        .map(
+            risk ->
+                new RiskInput(
+                    risk.riskCode(),
+                    risk.name(),
+                    risk.description(),
+                    risk.riskLevel(),
+                    risk.triggerConditionJson(),
+                    risk.handlingActionJson(),
+                    risk.evidenceJson(),
+                    risk.metaJson()))
+        .toList();
+  }
+
+  private static List<WorkflowInput> toWorkflowInputs(
+      List<CreateDomainPackDraftCommand.WorkflowDraft> workflows) {
+    return safeList(workflows).stream()
+        .map(
+            workflow ->
+                new WorkflowInput(
+                    workflow.workflowCode(),
+                    workflow.name(),
+                    workflow.description(),
+                    workflow.graphJson(),
+                    workflow.initialState(),
+                    workflow.terminalStatesJson(),
+                    workflow.evidenceJson(),
+                    workflow.metaJson(),
+                    workflow.intentCode(),
+                    workflow.isPrimary(),
+                    workflow.routeConditionJson()))
+        .toList();
+  }
+
+  private static List<WorkflowInput> toWorkflowInputsFromWorkflowCallback(
+      List<AddWorkflowDraftToVersionCommand.WorkflowDraft> workflows) {
+    return safeList(workflows).stream()
+        .map(
+            workflow ->
+                new WorkflowInput(
+                    workflow.workflowCode(),
+                    workflow.name(),
+                    workflow.description(),
+                    workflow.graphJson(),
+                    null,
+                    null,
+                    workflow.evidenceJson(),
+                    workflow.metaJson(),
+                    workflow.intentCode(),
+                    workflow.isPrimary(),
+                    workflow.routeConditionJson()))
+        .toList();
+  }
+
+  private static List<IntentSlotBindingInput> toIntentSlotBindingInputs(
+      List<CreateDomainPackDraftCommand.IntentSlotBindingDraft> bindings) {
+    return safeList(bindings).stream()
+        .map(
+            binding ->
+                new IntentSlotBindingInput(
+                    binding.intentCode(),
+                    binding.slotCode(),
+                    binding.isRequired(),
+                    binding.collectionOrder(),
+                    binding.promptHint(),
+                    binding.conditionJson()))
+        .toList();
+  }
+
+  private static List<IntentSlotBindingInput> toIntentSlotBindingInputsFromWorkflowCallback(
+      List<AddWorkflowDraftToVersionCommand.IntentSlotBindingDraft> bindings) {
+    return safeList(bindings).stream()
+        .map(
+            binding ->
+                new IntentSlotBindingInput(
+                    binding.intentCode(),
+                    binding.slotCode(),
+                    binding.isRequired(),
+                    binding.collectionOrder(),
+                    binding.promptHint(),
+                    binding.conditionJson()))
+        .toList();
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/application/DomainPackDraftIntentPersister.java
+++ b/backend/src/main/java/com/init/domainpack/application/DomainPackDraftIntentPersister.java
@@ -1,0 +1,110 @@
+package com.init.domainpack.application;
+
+import static com.init.domainpack.application.DomainPackDraftPersistenceSupport.ensureUnique;
+import static com.init.domainpack.application.DomainPackDraftPersistenceSupport.indexByCode;
+import static com.init.domainpack.application.DomainPackDraftPersistenceSupport.requireByCode;
+import static com.init.domainpack.application.DomainPackDraftPersistenceSupport.safeList;
+
+import com.init.domainpack.application.exception.DomainPackDraftRequestInvalidException;
+import com.init.domainpack.domain.model.IntentDefinition;
+import com.init.domainpack.domain.repository.IntentDefinitionRepository;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Service;
+
+@Service
+class DomainPackDraftIntentPersister {
+
+  private final IntentDefinitionRepository intentDefinitionRepository;
+
+  DomainPackDraftIntentPersister(IntentDefinitionRepository intentDefinitionRepository) {
+    this.intentDefinitionRepository = intentDefinitionRepository;
+  }
+
+  PersistedDraftIntents addIntents(Long domainPackVersionId, List<IntentDraft> intents) {
+    List<IntentDraft> safeIntents = safeList(intents);
+    ensureUnique(safeIntents, IntentDraft::intentCode, "intentCode");
+
+    List<IntentDraft> newIntents =
+        safeIntents.stream()
+            .filter(
+                intent ->
+                    !intentDefinitionRepository.existsByDomainPackVersionIdAndIntentCode(
+                        domainPackVersionId, intent.intentCode()))
+            .toList();
+    int skippedCount = safeIntents.size() - newIntents.size();
+
+    List<IntentDefinition> savedIntents = saveAll(domainPackVersionId, newIntents);
+    long totalCount = intentDefinitionRepository.countByDomainPackVersionId(domainPackVersionId);
+    return new PersistedDraftIntents(savedIntents, skippedCount, (int) totalCount);
+  }
+
+  List<IntentDefinition> saveAll(Long domainPackVersionId, List<IntentDraft> intents) {
+    List<IntentDraft> safeIntents = safeList(intents);
+    List<IntentDefinition> savedIntents =
+        intentDefinitionRepository.saveAllAndFlush(
+            safeIntents.stream().map(intent -> createIntent(domainPackVersionId, intent)).toList());
+    return linkParentIntents(domainPackVersionId, savedIntents, safeIntents);
+  }
+
+  Map<String, IntentDefinition> findByVersionIdIndexed(Long domainPackVersionId) {
+    return indexByCode(
+        intentDefinitionRepository.findByDomainPackVersionId(domainPackVersionId),
+        IntentDefinition::getIntentCode);
+  }
+
+  private IntentDefinition createIntent(Long domainPackVersionId, IntentDraft intent) {
+    return IntentDefinition.create(
+        domainPackVersionId,
+        intent.intentCode(),
+        intent.name(),
+        intent.description(),
+        intent.taxonomyLevel(),
+        intent.sourceClusterRef(),
+        intent.entryConditionJson(),
+        intent.evidenceJson(),
+        intent.metaJson());
+  }
+
+  private List<IntentDefinition> linkParentIntents(
+      Long domainPackVersionId, List<IntentDefinition> savedIntents, List<IntentDraft> drafts) {
+    Map<String, IntentDefinition> intentsByCode =
+        indexByCode(savedIntents, IntentDefinition::getIntentCode);
+
+    boolean hasParentIntent = false;
+    for (IntentDraft draft : drafts) {
+      if (draft.parentIntentCode() == null || draft.parentIntentCode().isBlank()) {
+        continue;
+      }
+      hasParentIntent = true;
+      IntentDefinition child = requireByCode(intentsByCode, draft.intentCode(), "intent");
+      IntentDefinition parent =
+          resolveParentIntent(domainPackVersionId, intentsByCode, draft.parentIntentCode());
+      if (parent == null) {
+        throw new DomainPackDraftRequestInvalidException(
+            "parentIntentCode를 찾을 수 없습니다. intentCode="
+                + draft.intentCode()
+                + ", parentIntentCode="
+                + draft.parentIntentCode());
+      }
+      child.assignParent(parent.getId());
+    }
+    if (!hasParentIntent) {
+      return savedIntents;
+    }
+    return intentDefinitionRepository.saveAllAndFlush(savedIntents);
+  }
+
+  private IntentDefinition resolveParentIntent(
+      Long domainPackVersionId,
+      Map<String, IntentDefinition> intentsByCode,
+      String parentIntentCode) {
+    IntentDefinition parent = intentsByCode.get(parentIntentCode);
+    if (parent != null) {
+      return parent;
+    }
+    return intentDefinitionRepository
+        .findByDomainPackVersionIdAndIntentCode(domainPackVersionId, parentIntentCode)
+        .orElse(null);
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/application/DomainPackDraftPersistenceService.java
+++ b/backend/src/main/java/com/init/domainpack/application/DomainPackDraftPersistenceService.java
@@ -1,32 +1,17 @@
 package com.init.domainpack.application;
 
+import static com.init.domainpack.application.DomainPackDraftPersistenceSupport.indexByCode;
+
 import com.init.domainpack.application.exception.DomainPackDraftRequestInvalidException;
 import com.init.domainpack.application.exception.DomainPackVersionNotDraftException;
 import com.init.domainpack.application.exception.DomainPackVersionNotFoundException;
-import com.init.domainpack.application.exception.WorkflowActionNodePolicyRefNotFoundException;
 import com.init.domainpack.domain.model.DomainPackVersion;
 import com.init.domainpack.domain.model.IntentDefinition;
-import com.init.domainpack.domain.model.IntentSlotBinding;
-import com.init.domainpack.domain.model.PolicyDefinition;
-import com.init.domainpack.domain.model.RiskDefinition;
-import com.init.domainpack.domain.model.SlotDefinition;
-import com.init.domainpack.domain.model.WorkflowDefinition;
 import com.init.domainpack.domain.repository.DomainPackVersionRepository;
-import com.init.domainpack.domain.repository.IntentDefinitionRepository;
-import com.init.domainpack.domain.repository.IntentSlotBindingRepository;
-import com.init.domainpack.domain.repository.PolicyDefinitionRepository;
-import com.init.domainpack.domain.repository.RiskDefinitionRepository;
-import com.init.domainpack.domain.repository.SlotDefinitionRepository;
-import com.init.domainpack.domain.repository.WorkflowDefinitionRepository;
 import com.init.workflowruntime.application.matching.WorkflowMatchingProfileBuildRequestService;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,34 +20,25 @@ import org.springframework.transaction.annotation.Transactional;
 public class DomainPackDraftPersistenceService {
 
   private final DomainPackVersionRepository domainPackVersionRepository;
-  private final IntentDefinitionRepository intentDefinitionRepository;
-  private final SlotDefinitionRepository slotDefinitionRepository;
-  private final PolicyDefinitionRepository policyDefinitionRepository;
-  private final RiskDefinitionRepository riskDefinitionRepository;
-  private final WorkflowDefinitionRepository workflowDefinitionRepository;
-  private final IntentSlotBindingRepository intentSlotBindingRepository;
   private final DomainPackVersionCloneService domainPackVersionCloneService;
   private final WorkflowMatchingProfileBuildRequestService profileBuildRequestService;
+  private final DomainPackDraftIntentPersister intentPersister;
+  private final DomainPackDraftWorkflowMapper workflowMapper;
+  private final DomainPackDraftComponentPersister componentPersister;
 
   public DomainPackDraftPersistenceService(
       DomainPackVersionRepository domainPackVersionRepository,
-      IntentDefinitionRepository intentDefinitionRepository,
-      SlotDefinitionRepository slotDefinitionRepository,
-      PolicyDefinitionRepository policyDefinitionRepository,
-      RiskDefinitionRepository riskDefinitionRepository,
-      WorkflowDefinitionRepository workflowDefinitionRepository,
-      IntentSlotBindingRepository intentSlotBindingRepository,
       DomainPackVersionCloneService domainPackVersionCloneService,
-      WorkflowMatchingProfileBuildRequestService profileBuildRequestService) {
+      WorkflowMatchingProfileBuildRequestService profileBuildRequestService,
+      DomainPackDraftIntentPersister intentPersister,
+      DomainPackDraftWorkflowMapper workflowMapper,
+      DomainPackDraftComponentPersister componentPersister) {
     this.domainPackVersionRepository = domainPackVersionRepository;
-    this.intentDefinitionRepository = intentDefinitionRepository;
-    this.slotDefinitionRepository = slotDefinitionRepository;
-    this.policyDefinitionRepository = policyDefinitionRepository;
-    this.riskDefinitionRepository = riskDefinitionRepository;
-    this.workflowDefinitionRepository = workflowDefinitionRepository;
-    this.intentSlotBindingRepository = intentSlotBindingRepository;
     this.domainPackVersionCloneService = domainPackVersionCloneService;
     this.profileBuildRequestService = profileBuildRequestService;
+    this.intentPersister = intentPersister;
+    this.workflowMapper = workflowMapper;
+    this.componentPersister = componentPersister;
   }
 
   /** DRAFT 버전만 생성한다 (intent/slot/policy 등은 저장하지 않음). Airflow 파이프라인 콜백의 1단계에서 사용한다. */
@@ -84,80 +60,23 @@ public class DomainPackDraftPersistenceService {
   public AddIntentsToDraftVersionResult persistIntents(
       Long domainPackVersionId, List<IntentDraft> intents) {
     DomainPackVersion version = requireDraftVersion(domainPackVersionId);
-    List<IntentDraft> safeIntents = safeList(intents);
-    ensureUnique(safeIntents, IntentDraft::intentCode, "intentCode");
+    PersistedDraftIntents persistedIntents =
+        intentPersister.addIntents(domainPackVersionId, intents);
 
-    List<IntentDraft> newIntents =
-        safeIntents.stream()
-            .filter(
-                intent ->
-                    !intentDefinitionRepository.existsByDomainPackVersionIdAndIntentCode(
-                        domainPackVersionId, intent.intentCode()))
-            .toList();
-    int skippedCount = safeIntents.size() - newIntents.size();
-
-    List<IntentDefinition> savedIntents =
-        intentDefinitionRepository.saveAllAndFlush(
-            newIntents.stream()
-                .map(
-                    intent ->
-                        IntentDefinition.create(
-                            domainPackVersionId,
-                            intent.intentCode(),
-                            intent.name(),
-                            intent.description(),
-                            intent.taxonomyLevel(),
-                            intent.sourceClusterRef(),
-                            intent.entryConditionJson(),
-                            intent.evidenceJson(),
-                            intent.metaJson()))
-                .toList());
-    Map<String, IntentDefinition> intentsByCode =
-        indexByCode(savedIntents, IntentDefinition::getIntentCode);
-
-    boolean hasParentIntent = false;
-    for (IntentDraft draft : newIntents) {
-      if (draft.parentIntentCode() == null || draft.parentIntentCode().isBlank()) {
-        continue;
-      }
-      hasParentIntent = true;
-      IntentDefinition child = requireByCode(intentsByCode, draft.intentCode(), "intent");
-      IntentDefinition parent =
-          resolveParentIntent(domainPackVersionId, intentsByCode, draft.parentIntentCode());
-      if (parent == null) {
-        throw new DomainPackDraftRequestInvalidException(
-            "parentIntentCode를 찾을 수 없습니다. intentCode="
-                + draft.intentCode()
-                + ", parentIntentCode="
-                + draft.parentIntentCode());
-      }
-      child.assignParent(parent.getId());
-    }
-    if (hasParentIntent) {
-      intentDefinitionRepository.saveAllAndFlush(savedIntents);
-    }
-
-    long totalCount = intentDefinitionRepository.countByDomainPackVersionId(domainPackVersionId);
     return new AddIntentsToDraftVersionResult(
         domainPackVersionId,
         version.getDomainPackId(),
-        savedIntents.size(),
-        skippedCount,
-        (int) totalCount);
+        persistedIntents.savedIntents().size(),
+        persistedIntents.skippedIntentCount(),
+        persistedIntents.totalIntentCount());
   }
 
   /** UI에서 수동으로 전체 draft를 한 번에 저장할 때 사용한다. */
   @Transactional
   public CreateDomainPackDraftResult persist(CreateDomainPackDraftCommand command) {
-    DraftComponentsInput components =
-        new DraftComponentsInput(
-            toSlotInputs(command.slots()),
-            toPolicyInputs(command.policies()),
-            toRiskInputs(command.risks()),
-            toWorkflowInputs(command.workflows()),
-            toIntentSlotBindingInputs(command.intentSlotBindings()));
+    DraftComponentsInput components = DomainPackDraftInputMapper.fromCreateCommand(command);
     List<WorkflowInput> validatedWorkflows =
-        validateDraftPayload(
+        workflowMapper.validateDraftPayload(
             new DraftPayload(
                 command.intents(),
                 components.slots(),
@@ -177,47 +96,12 @@ public class DomainPackDraftPersistenceService {
                 command.summaryJson()));
 
     List<IntentDefinition> savedIntents =
-        intentDefinitionRepository.saveAllAndFlush(
-            safeList(command.intents()).stream()
-                .map(
-                    intent ->
-                        IntentDefinition.create(
-                            savedVersion.getId(),
-                            intent.intentCode(),
-                            intent.name(),
-                            intent.description(),
-                            intent.taxonomyLevel(),
-                            intent.sourceClusterRef(),
-                            intent.entryConditionJson(),
-                            intent.evidenceJson(),
-                            intent.metaJson()))
-                .toList());
+        intentPersister.saveAll(savedVersion.getId(), command.intents());
     Map<String, IntentDefinition> intentsByCode =
         indexByCode(savedIntents, IntentDefinition::getIntentCode);
 
-    boolean hasParentIntent = false;
-    for (IntentDraft draft : safeList(command.intents())) {
-      if (draft.parentIntentCode() == null || draft.parentIntentCode().isBlank()) {
-        continue;
-      }
-      hasParentIntent = true;
-      IntentDefinition child = requireByCode(intentsByCode, draft.intentCode(), "intent");
-      IntentDefinition parent = intentsByCode.get(draft.parentIntentCode());
-      if (parent == null) {
-        throw new DomainPackDraftRequestInvalidException(
-            "parentIntentCode를 찾을 수 없습니다. intentCode="
-                + draft.intentCode()
-                + ", parentIntentCode="
-                + draft.parentIntentCode());
-      }
-      child.assignParent(parent.getId());
-    }
-    if (hasParentIntent) {
-      savedIntents = intentDefinitionRepository.saveAllAndFlush(savedIntents);
-    }
-
     SavedDraftComponents savedComponents =
-        saveDraftComponents(
+        componentPersister.save(
             savedVersion.getId(),
             intentsByCode,
             new DraftComponentsInput(
@@ -226,9 +110,7 @@ public class DomainPackDraftPersistenceService {
                 components.risks(),
                 validatedWorkflows,
                 components.intentSlotBindings()));
-    if (savedComponents.addedWorkflowCount() > 0) {
-      profileBuildRequestService.enqueue(savedVersion.getId(), "DRAFT_IMPORT");
-    }
+    enqueueWorkflowProfileBuild(savedVersion.getId(), savedComponents, "DRAFT_IMPORT");
 
     return CreateDomainPackDraftResult.from(
         savedVersion,
@@ -250,49 +132,24 @@ public class DomainPackDraftPersistenceService {
       List<AddWorkflowDraftToVersionCommand.IntentSlotBindingDraft> intentSlotBindings) {
     DomainPackVersion version = requireDraftVersion(domainPackVersionId);
     DraftComponentsInput components =
-        new DraftComponentsInput(
-            toSlotInputsFromWorkflowCallback(slots),
-            toPolicyInputsFromWorkflowCallback(policies),
-            toRiskInputsFromWorkflowCallback(risks),
-            toWorkflowInputsFromWorkflowCallback(workflows),
-            toIntentSlotBindingInputsFromWorkflowCallback(intentSlotBindings));
+        DomainPackDraftInputMapper.fromWorkflowCallback(
+            slots, policies, risks, workflows, intentSlotBindings);
     validateNonEmptyWorkflowDraft(components);
 
-    ensureDraftPayloadUnique(
-        List.of(),
-        components.slots(),
-        components.intentSlotBindings(),
-        components.policies(),
-        components.risks(),
-        components.workflows());
-    List<ParsedWorkflowInput> parsedWorkflows = parseWorkflowInputs(components.workflows());
-    Set<String> submittedPolicyCodes =
-        components.policies().stream().map(PolicyInput::policyCode).collect(Collectors.toSet());
-    Set<String> existingPolicyCodes =
-        findExistingPolicyCodes(domainPackVersionId, collectWorkflowPolicyRefs(parsedWorkflows));
-    Set<String> allowedPolicyCodes =
-        Stream.concat(submittedPolicyCodes.stream(), existingPolicyCodes.stream())
-            .collect(Collectors.toSet());
     List<WorkflowInput> validatedWorkflows =
-        validateParsedWorkflows(parsedWorkflows, components.policies(), allowedPolicyCodes);
+        workflowMapper.validateWorkflowDraft(domainPackVersionId, components);
 
-    Map<String, IntentDefinition> intentsByCode =
-        indexByCode(
-            intentDefinitionRepository.findByDomainPackVersionId(domainPackVersionId),
-            IntentDefinition::getIntentCode);
     SavedDraftComponents savedComponents =
-        saveDraftComponents(
+        componentPersister.save(
             domainPackVersionId,
-            intentsByCode,
+            intentPersister.findByVersionIdIndexed(domainPackVersionId),
             new DraftComponentsInput(
                 components.slots(),
                 components.policies(),
                 components.risks(),
                 validatedWorkflows,
                 components.intentSlotBindings()));
-    if (savedComponents.addedWorkflowCount() > 0) {
-      profileBuildRequestService.enqueue(domainPackVersionId, "WORKFLOW_DRAFT_IMPORT");
-    }
+    enqueueWorkflowProfileBuild(domainPackVersionId, savedComponents, "WORKFLOW_DRAFT_IMPORT");
 
     return new AddWorkflowDraftToVersionResult(
         domainPackVersionId,
@@ -302,182 +159,6 @@ public class DomainPackDraftPersistenceService {
         savedComponents.addedRiskCount(),
         savedComponents.addedWorkflowCount(),
         savedComponents.addedIntentSlotBindingCount());
-  }
-
-  private SavedDraftComponents saveDraftComponents(
-      Long domainPackVersionId,
-      Map<String, IntentDefinition> intentsByCode,
-      DraftComponentsInput components) {
-    List<SlotDefinition> savedSlots =
-        slotDefinitionRepository.saveAll(
-            components.slots().stream()
-                .map(
-                    slot ->
-                        SlotDefinition.create(
-                            domainPackVersionId,
-                            slot.slotCode(),
-                            slot.name(),
-                            slot.description(),
-                            slot.dataType(),
-                            slot.isSensitive(),
-                            slot.validationRuleJson(),
-                            slot.defaultValueJson(),
-                            slot.metaJson()))
-                .toList());
-    Map<String, SlotDefinition> slotsByCode = indexByCode(savedSlots, SlotDefinition::getSlotCode);
-
-    List<PolicyDefinition> savedPolicies =
-        policyDefinitionRepository.saveAll(
-            components.policies().stream()
-                .map(
-                    policy ->
-                        PolicyDefinition.create(
-                            domainPackVersionId,
-                            policy.policyCode(),
-                            policy.name(),
-                            policy.description(),
-                            policy.severity(),
-                            policy.conditionJson(),
-                            policy.actionJson(),
-                            policy.evidenceJson(),
-                            policy.metaJson()))
-                .toList());
-
-    List<RiskDefinition> savedRisks =
-        riskDefinitionRepository.saveAll(
-            components.risks().stream()
-                .map(
-                    risk ->
-                        RiskDefinition.create(
-                            domainPackVersionId,
-                            risk.riskCode(),
-                            risk.name(),
-                            risk.description(),
-                            risk.riskLevel(),
-                            risk.triggerConditionJson(),
-                            risk.handlingActionJson(),
-                            risk.evidenceJson(),
-                            risk.metaJson()))
-                .toList());
-
-    List<WorkflowDefinition> savedWorkflows =
-        workflowDefinitionRepository.saveAll(
-            components.workflows().stream()
-                .map(
-                    workflow ->
-                        WorkflowDefinition.create(
-                            domainPackVersionId,
-                            workflow.workflowCode(),
-                            workflow.name(),
-                            workflow.description(),
-                            workflow.graphJson(),
-                            workflow.initialState(),
-                            workflow.terminalStatesJson(),
-                            workflow.evidenceJson(),
-                            workflow.metaJson(),
-                            requireByCode(intentsByCode, workflow.intentCode(), "intent").getId(),
-                            workflow.isPrimary(),
-                            workflow.routeConditionJson()))
-                .toList());
-
-    List<IntentSlotBinding> savedIntentSlotBindings =
-        intentSlotBindingRepository.saveAll(
-            components.intentSlotBindings().stream()
-                .map(
-                    binding ->
-                        IntentSlotBinding.create(
-                            requireByCode(intentsByCode, binding.intentCode(), "intent").getId(),
-                            requireByCode(slotsByCode, binding.slotCode(), "slot").getId(),
-                            binding.isRequired(),
-                            binding.collectionOrder(),
-                            binding.promptHint(),
-                            binding.conditionJson()))
-                .toList());
-
-    return new SavedDraftComponents(
-        savedSlots.size(),
-        savedPolicies.size(),
-        savedRisks.size(),
-        savedWorkflows.size(),
-        savedIntentSlotBindings.size());
-  }
-
-  private List<WorkflowInput> validateDraftPayload(
-      DraftPayload payload, Set<String> allowedPolicyCodes) {
-    ensureDraftPayloadUnique(
-        payload.intents(),
-        payload.slots(),
-        payload.intentSlotBindings(),
-        payload.policies(),
-        payload.risks(),
-        payload.workflows());
-    return validateParsedWorkflows(
-        parseWorkflowInputs(safeList(payload.workflows())), payload.policies(), allowedPolicyCodes);
-  }
-
-  private record DraftPayload(
-      List<IntentDraft> intents,
-      List<SlotInput> slots,
-      List<IntentSlotBindingInput> intentSlotBindings,
-      List<PolicyInput> policies,
-      List<RiskInput> risks,
-      List<WorkflowInput> workflows) {}
-
-  private void ensureDraftPayloadUnique(
-      List<IntentDraft> intents,
-      List<SlotInput> slots,
-      List<IntentSlotBindingInput> intentSlotBindings,
-      List<PolicyInput> policies,
-      List<RiskInput> risks,
-      List<WorkflowInput> workflows) {
-    ensureUnique(safeList(intents), IntentDraft::intentCode, "intentCode");
-    ensureUnique(safeList(slots), SlotInput::slotCode, "slotCode");
-    ensureUnique(safeList(policies), PolicyInput::policyCode, "policyCode");
-    ensureUnique(safeList(risks), RiskInput::riskCode, "riskCode");
-    ensureUnique(safeList(workflows), WorkflowInput::workflowCode, "workflowCode");
-    ensureUnique(
-        safeList(intentSlotBindings),
-        binding -> binding.intentCode() + "::" + binding.slotCode(),
-        "intentSlotBinding");
-  }
-
-  private List<WorkflowInput> validateParsedWorkflows(
-      List<ParsedWorkflowInput> workflows,
-      List<PolicyInput> policies,
-      Set<String> allowedPolicyCodes) {
-    Set<String> submittedPolicyCodes =
-        safeList(policies).stream().map(PolicyInput::policyCode).collect(Collectors.toSet());
-    Set<String> policyCodes =
-        Stream.concat(submittedPolicyCodes.stream(), allowedPolicyCodes.stream())
-            .collect(Collectors.toSet());
-    return workflows.stream().map(w -> validateAndNormalizeWorkflow(w, policyCodes)).toList();
-  }
-
-  private WorkflowInput validateAndNormalizeWorkflow(
-      ParsedWorkflowInput parsedWorkflow, Set<String> allowedPolicyCodes) {
-    WorkflowInput workflow = parsedWorkflow.workflow();
-    WorkflowGraphValidator.ParsedGraph graph = parsedWorkflow.graph();
-    graph.nodes().stream()
-        .filter(n -> "ACTION".equals(n.type()))
-        .map(WorkflowGraphValidator.GraphNode::policyRef)
-        .filter(ref -> !allowedPolicyCodes.contains(ref))
-        .findFirst()
-        .ifPresent(
-            ref -> {
-              throw new WorkflowActionNodePolicyRefNotFoundException(ref);
-            });
-    return new WorkflowInput(
-        workflow.workflowCode(),
-        workflow.name(),
-        workflow.description(),
-        workflow.graphJson(),
-        WorkflowGraphValidator.extractInitialState(graph),
-        WorkflowGraphValidator.extractTerminalStatesJson(graph),
-        workflow.evidenceJson(),
-        workflow.metaJson(),
-        workflow.intentCode(),
-        workflow.isPrimary(),
-        workflow.routeConditionJson());
   }
 
   private void validateNonEmptyWorkflowDraft(DraftComponentsInput components) {
@@ -490,317 +171,11 @@ public class DomainPackDraftPersistenceService {
     }
   }
 
-  private Set<String> collectWorkflowPolicyRefs(List<ParsedWorkflowInput> workflows) {
-    return workflows.stream()
-        .flatMap(workflow -> workflow.graph().nodes().stream())
-        .filter(node -> "ACTION".equals(node.type()))
-        .map(WorkflowGraphValidator.GraphNode::policyRef)
-        .collect(Collectors.toSet());
-  }
-
-  private List<ParsedWorkflowInput> parseWorkflowInputs(List<WorkflowInput> workflows) {
-    return workflows.stream()
-        .map(
-            workflow ->
-                new ParsedWorkflowInput(
-                    workflow,
-                    WorkflowGraphValidator.parseAndValidate(
-                        workflow.graphJson(), workflow.workflowCode())))
-        .toList();
-  }
-
-  private Set<String> findExistingPolicyCodes(Long domainPackVersionId, Set<String> policyCodes) {
-    if (policyCodes.isEmpty()) {
-      return Set.of();
+  private void enqueueWorkflowProfileBuild(
+      Long domainPackVersionId, SavedDraftComponents savedComponents, String source) {
+    if (savedComponents.addedWorkflowCount() > 0) {
+      profileBuildRequestService.enqueue(domainPackVersionId, source);
     }
-    return policyDefinitionRepository.findExistingPolicyCodesByVersionIdAndCodes(
-        domainPackVersionId, policyCodes);
-  }
-
-  private List<SlotInput> toSlotInputs(List<CreateDomainPackDraftCommand.SlotDraft> slots) {
-    return safeList(slots).stream()
-        .map(
-            slot ->
-                new SlotInput(
-                    slot.slotCode(),
-                    slot.name(),
-                    slot.description(),
-                    slot.dataType(),
-                    slot.isSensitive(),
-                    slot.validationRuleJson(),
-                    slot.defaultValueJson(),
-                    slot.metaJson()))
-        .toList();
-  }
-
-  private List<SlotInput> toSlotInputsFromWorkflowCallback(
-      List<AddWorkflowDraftToVersionCommand.SlotDraft> slots) {
-    return safeList(slots).stream()
-        .map(
-            slot ->
-                new SlotInput(
-                    slot.slotCode(),
-                    slot.name(),
-                    slot.description(),
-                    slot.dataType(),
-                    slot.isSensitive(),
-                    slot.validationRuleJson(),
-                    slot.defaultValueJson(),
-                    slot.metaJson()))
-        .toList();
-  }
-
-  private List<PolicyInput> toPolicyInputs(
-      List<CreateDomainPackDraftCommand.PolicyDraft> policies) {
-    return safeList(policies).stream()
-        .map(
-            policy ->
-                new PolicyInput(
-                    policy.policyCode(),
-                    policy.name(),
-                    policy.description(),
-                    policy.severity(),
-                    policy.conditionJson(),
-                    policy.actionJson(),
-                    policy.evidenceJson(),
-                    policy.metaJson()))
-        .toList();
-  }
-
-  private List<PolicyInput> toPolicyInputsFromWorkflowCallback(
-      List<AddWorkflowDraftToVersionCommand.PolicyDraft> policies) {
-    return safeList(policies).stream()
-        .map(
-            policy ->
-                new PolicyInput(
-                    policy.policyCode(),
-                    policy.name(),
-                    policy.description(),
-                    policy.severity(),
-                    policy.conditionJson(),
-                    policy.actionJson(),
-                    policy.evidenceJson(),
-                    policy.metaJson()))
-        .toList();
-  }
-
-  private List<RiskInput> toRiskInputs(List<CreateDomainPackDraftCommand.RiskDraft> risks) {
-    return safeList(risks).stream()
-        .map(
-            risk ->
-                new RiskInput(
-                    risk.riskCode(),
-                    risk.name(),
-                    risk.description(),
-                    risk.riskLevel(),
-                    risk.triggerConditionJson(),
-                    risk.handlingActionJson(),
-                    risk.evidenceJson(),
-                    risk.metaJson()))
-        .toList();
-  }
-
-  private List<RiskInput> toRiskInputsFromWorkflowCallback(
-      List<AddWorkflowDraftToVersionCommand.RiskDraft> risks) {
-    return safeList(risks).stream()
-        .map(
-            risk ->
-                new RiskInput(
-                    risk.riskCode(),
-                    risk.name(),
-                    risk.description(),
-                    risk.riskLevel(),
-                    risk.triggerConditionJson(),
-                    risk.handlingActionJson(),
-                    risk.evidenceJson(),
-                    risk.metaJson()))
-        .toList();
-  }
-
-  private List<WorkflowInput> toWorkflowInputs(
-      List<CreateDomainPackDraftCommand.WorkflowDraft> workflows) {
-    return safeList(workflows).stream()
-        .map(
-            workflow ->
-                new WorkflowInput(
-                    workflow.workflowCode(),
-                    workflow.name(),
-                    workflow.description(),
-                    workflow.graphJson(),
-                    workflow.initialState(),
-                    workflow.terminalStatesJson(),
-                    workflow.evidenceJson(),
-                    workflow.metaJson(),
-                    workflow.intentCode(),
-                    workflow.isPrimary(),
-                    workflow.routeConditionJson()))
-        .toList();
-  }
-
-  private List<WorkflowInput> toWorkflowInputsFromWorkflowCallback(
-      List<AddWorkflowDraftToVersionCommand.WorkflowDraft> workflows) {
-    return safeList(workflows).stream()
-        .map(
-            workflow ->
-                new WorkflowInput(
-                    workflow.workflowCode(),
-                    workflow.name(),
-                    workflow.description(),
-                    workflow.graphJson(),
-                    null,
-                    null,
-                    workflow.evidenceJson(),
-                    workflow.metaJson(),
-                    workflow.intentCode(),
-                    workflow.isPrimary(),
-                    workflow.routeConditionJson()))
-        .toList();
-  }
-
-  private List<IntentSlotBindingInput> toIntentSlotBindingInputs(
-      List<CreateDomainPackDraftCommand.IntentSlotBindingDraft> bindings) {
-    return safeList(bindings).stream()
-        .map(
-            binding ->
-                new IntentSlotBindingInput(
-                    binding.intentCode(),
-                    binding.slotCode(),
-                    binding.isRequired(),
-                    binding.collectionOrder(),
-                    binding.promptHint(),
-                    binding.conditionJson()))
-        .toList();
-  }
-
-  private List<IntentSlotBindingInput> toIntentSlotBindingInputsFromWorkflowCallback(
-      List<AddWorkflowDraftToVersionCommand.IntentSlotBindingDraft> bindings) {
-    return safeList(bindings).stream()
-        .map(
-            binding ->
-                new IntentSlotBindingInput(
-                    binding.intentCode(),
-                    binding.slotCode(),
-                    binding.isRequired(),
-                    binding.collectionOrder(),
-                    binding.promptHint(),
-                    binding.conditionJson()))
-        .toList();
-  }
-
-  private record DraftComponentsInput(
-      List<SlotInput> slots,
-      List<PolicyInput> policies,
-      List<RiskInput> risks,
-      List<WorkflowInput> workflows,
-      List<IntentSlotBindingInput> intentSlotBindings) {}
-
-  private record SlotInput(
-      String slotCode,
-      String name,
-      String description,
-      String dataType,
-      Boolean isSensitive,
-      String validationRuleJson,
-      String defaultValueJson,
-      String metaJson) {}
-
-  private record PolicyInput(
-      String policyCode,
-      String name,
-      String description,
-      String severity,
-      String conditionJson,
-      String actionJson,
-      String evidenceJson,
-      String metaJson) {}
-
-  private record RiskInput(
-      String riskCode,
-      String name,
-      String description,
-      String riskLevel,
-      String triggerConditionJson,
-      String handlingActionJson,
-      String evidenceJson,
-      String metaJson) {}
-
-  private record WorkflowInput(
-      String workflowCode,
-      String name,
-      String description,
-      String graphJson,
-      String initialState,
-      String terminalStatesJson,
-      String evidenceJson,
-      String metaJson,
-      String intentCode,
-      Boolean isPrimary,
-      String routeConditionJson) {}
-
-  private record IntentSlotBindingInput(
-      String intentCode,
-      String slotCode,
-      Boolean isRequired,
-      Integer collectionOrder,
-      String promptHint,
-      String conditionJson) {}
-
-  private record ParsedWorkflowInput(
-      WorkflowInput workflow, WorkflowGraphValidator.ParsedGraph graph) {}
-
-  private record SavedDraftComponents(
-      int addedSlotCount,
-      int addedPolicyCount,
-      int addedRiskCount,
-      int addedWorkflowCount,
-      int addedIntentSlotBindingCount) {}
-
-  private <T> List<T> safeList(List<T> list) {
-    return list == null ? List.of() : list;
-  }
-
-  private <T> void ensureUnique(List<T> items, Function<T, String> keyExtractor, String fieldName) {
-    Map<String, Boolean> seen = new LinkedHashMap<>();
-    for (T item : items) {
-      String key = keyExtractor.apply(item);
-      if (key == null || key.isBlank()) {
-        throw new DomainPackDraftRequestInvalidException(fieldName + "는 비어 있을 수 없습니다.");
-      }
-      if (seen.put(key, Boolean.TRUE) != null) {
-        throw new DomainPackDraftRequestInvalidException(
-            "중복된 " + fieldName + " 값이 존재합니다. value=" + key);
-      }
-    }
-  }
-
-  private <T> Map<String, T> indexByCode(List<T> items, Function<T, String> codeExtractor) {
-    Map<String, T> indexed = new LinkedHashMap<>();
-    for (T item : items) {
-      indexed.put(codeExtractor.apply(item), item);
-    }
-    return indexed;
-  }
-
-  private <T> T requireByCode(Map<String, T> indexed, String code, String resourceName) {
-    T resource = indexed.get(code);
-    if (resource == null) {
-      throw new DomainPackDraftRequestInvalidException(
-          resourceName + " 참조를 찾을 수 없습니다. code=" + Objects.toString(code));
-    }
-    return resource;
-  }
-
-  private IntentDefinition resolveParentIntent(
-      Long domainPackVersionId,
-      Map<String, IntentDefinition> intentsByCode,
-      String parentIntentCode) {
-    IntentDefinition parent = intentsByCode.get(parentIntentCode);
-    if (parent != null) {
-      return parent;
-    }
-    return intentDefinitionRepository
-        .findByDomainPackVersionIdAndIntentCode(domainPackVersionId, parentIntentCode)
-        .orElse(null);
   }
 
   private DomainPackVersion requireDraftVersion(Long domainPackVersionId) {

--- a/backend/src/main/java/com/init/domainpack/application/DomainPackDraftPersistenceSupport.java
+++ b/backend/src/main/java/com/init/domainpack/application/DomainPackDraftPersistenceSupport.java
@@ -1,0 +1,48 @@
+package com.init.domainpack.application;
+
+import com.init.domainpack.application.exception.DomainPackDraftRequestInvalidException;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+
+final class DomainPackDraftPersistenceSupport {
+
+  private DomainPackDraftPersistenceSupport() {}
+
+  static <T> List<T> safeList(List<T> list) {
+    return list == null ? List.of() : list;
+  }
+
+  static <T> void ensureUnique(List<T> items, Function<T, String> keyExtractor, String fieldName) {
+    Map<String, Boolean> seen = new LinkedHashMap<>();
+    for (T item : items) {
+      String key = keyExtractor.apply(item);
+      if (key == null || key.isBlank()) {
+        throw new DomainPackDraftRequestInvalidException(fieldName + "는 비어 있을 수 없습니다.");
+      }
+      if (seen.put(key, Boolean.TRUE) != null) {
+        throw new DomainPackDraftRequestInvalidException(
+            "중복된 " + fieldName + " 값이 존재합니다. value=" + key);
+      }
+    }
+  }
+
+  static <T> Map<String, T> indexByCode(List<T> items, Function<T, String> codeExtractor) {
+    Map<String, T> indexed = new LinkedHashMap<>();
+    for (T item : items) {
+      indexed.put(codeExtractor.apply(item), item);
+    }
+    return indexed;
+  }
+
+  static <T> T requireByCode(Map<String, T> indexed, String code, String resourceName) {
+    T resource = indexed.get(code);
+    if (resource == null) {
+      throw new DomainPackDraftRequestInvalidException(
+          resourceName + " 참조를 찾을 수 없습니다. code=" + Objects.toString(code));
+    }
+    return resource;
+  }
+}

--- a/backend/src/main/java/com/init/domainpack/application/DomainPackDraftWorkflowMapper.java
+++ b/backend/src/main/java/com/init/domainpack/application/DomainPackDraftWorkflowMapper.java
@@ -1,0 +1,141 @@
+package com.init.domainpack.application;
+
+import static com.init.domainpack.application.DomainPackDraftPersistenceSupport.ensureUnique;
+import static com.init.domainpack.application.DomainPackDraftPersistenceSupport.safeList;
+
+import com.init.domainpack.application.exception.WorkflowActionNodePolicyRefNotFoundException;
+import com.init.domainpack.domain.repository.PolicyDefinitionRepository;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.springframework.stereotype.Service;
+
+@Service
+class DomainPackDraftWorkflowMapper {
+
+  private final PolicyDefinitionRepository policyDefinitionRepository;
+
+  DomainPackDraftWorkflowMapper(PolicyDefinitionRepository policyDefinitionRepository) {
+    this.policyDefinitionRepository = policyDefinitionRepository;
+  }
+
+  List<WorkflowInput> validateDraftPayload(DraftPayload payload, Set<String> allowedPolicyCodes) {
+    ensureDraftPayloadUnique(
+        payload.intents(),
+        payload.slots(),
+        payload.intentSlotBindings(),
+        payload.policies(),
+        payload.risks(),
+        payload.workflows());
+    return validateParsedWorkflows(
+        parseWorkflowInputs(safeList(payload.workflows())), payload.policies(), allowedPolicyCodes);
+  }
+
+  List<WorkflowInput> validateWorkflowDraft(
+      Long domainPackVersionId, DraftComponentsInput components) {
+    ensureDraftPayloadUnique(
+        List.of(),
+        components.slots(),
+        components.intentSlotBindings(),
+        components.policies(),
+        components.risks(),
+        components.workflows());
+    List<ParsedWorkflowInput> parsedWorkflows = parseWorkflowInputs(components.workflows());
+    Set<String> submittedPolicyCodes =
+        components.policies().stream().map(PolicyInput::policyCode).collect(Collectors.toSet());
+    Set<String> existingPolicyCodes =
+        findExistingPolicyCodes(domainPackVersionId, collectWorkflowPolicyRefs(parsedWorkflows));
+    Set<String> allowedPolicyCodes =
+        Stream.concat(submittedPolicyCodes.stream(), existingPolicyCodes.stream())
+            .collect(Collectors.toSet());
+    return validateParsedWorkflows(parsedWorkflows, components.policies(), allowedPolicyCodes);
+  }
+
+  private void ensureDraftPayloadUnique(
+      List<IntentDraft> intents,
+      List<SlotInput> slots,
+      List<IntentSlotBindingInput> intentSlotBindings,
+      List<PolicyInput> policies,
+      List<RiskInput> risks,
+      List<WorkflowInput> workflows) {
+    ensureUnique(safeList(intents), IntentDraft::intentCode, "intentCode");
+    ensureUnique(safeList(slots), SlotInput::slotCode, "slotCode");
+    ensureUnique(safeList(policies), PolicyInput::policyCode, "policyCode");
+    ensureUnique(safeList(risks), RiskInput::riskCode, "riskCode");
+    ensureUnique(safeList(workflows), WorkflowInput::workflowCode, "workflowCode");
+    ensureUnique(
+        safeList(intentSlotBindings),
+        binding -> binding.intentCode() + "::" + binding.slotCode(),
+        "intentSlotBinding");
+  }
+
+  private List<WorkflowInput> validateParsedWorkflows(
+      List<ParsedWorkflowInput> workflows,
+      List<PolicyInput> policies,
+      Set<String> allowedPolicyCodes) {
+    Set<String> submittedPolicyCodes =
+        safeList(policies).stream().map(PolicyInput::policyCode).collect(Collectors.toSet());
+    Set<String> policyCodes =
+        Stream.concat(submittedPolicyCodes.stream(), allowedPolicyCodes.stream())
+            .collect(Collectors.toSet());
+    return workflows.stream().map(w -> validateAndNormalizeWorkflow(w, policyCodes)).toList();
+  }
+
+  private WorkflowInput validateAndNormalizeWorkflow(
+      ParsedWorkflowInput parsedWorkflow, Set<String> allowedPolicyCodes) {
+    WorkflowInput workflow = parsedWorkflow.workflow();
+    WorkflowGraphValidator.ParsedGraph graph = parsedWorkflow.graph();
+    graph.nodes().stream()
+        .filter(n -> "ACTION".equals(n.type()))
+        .map(WorkflowGraphValidator.GraphNode::policyRef)
+        .filter(ref -> !allowedPolicyCodes.contains(ref))
+        .findFirst()
+        .ifPresent(
+            ref -> {
+              throw new WorkflowActionNodePolicyRefNotFoundException(ref);
+            });
+    return new WorkflowInput(
+        workflow.workflowCode(),
+        workflow.name(),
+        workflow.description(),
+        workflow.graphJson(),
+        WorkflowGraphValidator.extractInitialState(graph),
+        WorkflowGraphValidator.extractTerminalStatesJson(graph),
+        workflow.evidenceJson(),
+        workflow.metaJson(),
+        workflow.intentCode(),
+        workflow.isPrimary(),
+        workflow.routeConditionJson());
+  }
+
+  private Set<String> collectWorkflowPolicyRefs(List<ParsedWorkflowInput> workflows) {
+    return workflows.stream()
+        .flatMap(workflow -> workflow.graph().nodes().stream())
+        .filter(node -> "ACTION".equals(node.type()))
+        .map(WorkflowGraphValidator.GraphNode::policyRef)
+        .collect(Collectors.toSet());
+  }
+
+  private List<ParsedWorkflowInput> parseWorkflowInputs(List<WorkflowInput> workflows) {
+    return workflows.stream()
+        .map(
+            workflow ->
+                new ParsedWorkflowInput(
+                    workflow,
+                    WorkflowGraphValidator.parseAndValidate(
+                        workflow.graphJson(), workflow.workflowCode())))
+        .toList();
+  }
+
+  private Set<String> findExistingPolicyCodes(Long domainPackVersionId, Set<String> policyCodes) {
+    if (policyCodes.isEmpty()) {
+      return Set.of();
+    }
+    return policyDefinitionRepository.findExistingPolicyCodesByVersionIdAndCodes(
+        domainPackVersionId, policyCodes);
+  }
+
+  private record ParsedWorkflowInput(
+      WorkflowInput workflow, WorkflowGraphValidator.ParsedGraph graph) {}
+}

--- a/backend/src/main/java/com/init/domainpack/application/DraftComponentsInput.java
+++ b/backend/src/main/java/com/init/domainpack/application/DraftComponentsInput.java
@@ -1,0 +1,10 @@
+package com.init.domainpack.application;
+
+import java.util.List;
+
+record DraftComponentsInput(
+    List<SlotInput> slots,
+    List<PolicyInput> policies,
+    List<RiskInput> risks,
+    List<WorkflowInput> workflows,
+    List<IntentSlotBindingInput> intentSlotBindings) {}

--- a/backend/src/main/java/com/init/domainpack/application/DraftPayload.java
+++ b/backend/src/main/java/com/init/domainpack/application/DraftPayload.java
@@ -1,0 +1,11 @@
+package com.init.domainpack.application;
+
+import java.util.List;
+
+record DraftPayload(
+    List<IntentDraft> intents,
+    List<SlotInput> slots,
+    List<IntentSlotBindingInput> intentSlotBindings,
+    List<PolicyInput> policies,
+    List<RiskInput> risks,
+    List<WorkflowInput> workflows) {}

--- a/backend/src/main/java/com/init/domainpack/application/IntentSlotBindingInput.java
+++ b/backend/src/main/java/com/init/domainpack/application/IntentSlotBindingInput.java
@@ -1,0 +1,9 @@
+package com.init.domainpack.application;
+
+record IntentSlotBindingInput(
+    String intentCode,
+    String slotCode,
+    Boolean isRequired,
+    Integer collectionOrder,
+    String promptHint,
+    String conditionJson) {}

--- a/backend/src/main/java/com/init/domainpack/application/PersistedDraftIntents.java
+++ b/backend/src/main/java/com/init/domainpack/application/PersistedDraftIntents.java
@@ -1,0 +1,7 @@
+package com.init.domainpack.application;
+
+import com.init.domainpack.domain.model.IntentDefinition;
+import java.util.List;
+
+record PersistedDraftIntents(
+    List<IntentDefinition> savedIntents, int skippedIntentCount, int totalIntentCount) {}

--- a/backend/src/main/java/com/init/domainpack/application/PolicyInput.java
+++ b/backend/src/main/java/com/init/domainpack/application/PolicyInput.java
@@ -1,0 +1,11 @@
+package com.init.domainpack.application;
+
+record PolicyInput(
+    String policyCode,
+    String name,
+    String description,
+    String severity,
+    String conditionJson,
+    String actionJson,
+    String evidenceJson,
+    String metaJson) {}

--- a/backend/src/main/java/com/init/domainpack/application/RiskInput.java
+++ b/backend/src/main/java/com/init/domainpack/application/RiskInput.java
@@ -1,0 +1,11 @@
+package com.init.domainpack.application;
+
+record RiskInput(
+    String riskCode,
+    String name,
+    String description,
+    String riskLevel,
+    String triggerConditionJson,
+    String handlingActionJson,
+    String evidenceJson,
+    String metaJson) {}

--- a/backend/src/main/java/com/init/domainpack/application/SavedDraftComponents.java
+++ b/backend/src/main/java/com/init/domainpack/application/SavedDraftComponents.java
@@ -1,0 +1,8 @@
+package com.init.domainpack.application;
+
+record SavedDraftComponents(
+    int addedSlotCount,
+    int addedPolicyCount,
+    int addedRiskCount,
+    int addedWorkflowCount,
+    int addedIntentSlotBindingCount) {}

--- a/backend/src/main/java/com/init/domainpack/application/SlotInput.java
+++ b/backend/src/main/java/com/init/domainpack/application/SlotInput.java
@@ -1,0 +1,11 @@
+package com.init.domainpack.application;
+
+record SlotInput(
+    String slotCode,
+    String name,
+    String description,
+    String dataType,
+    Boolean isSensitive,
+    String validationRuleJson,
+    String defaultValueJson,
+    String metaJson) {}

--- a/backend/src/main/java/com/init/domainpack/application/WorkflowInput.java
+++ b/backend/src/main/java/com/init/domainpack/application/WorkflowInput.java
@@ -1,0 +1,14 @@
+package com.init.domainpack.application;
+
+record WorkflowInput(
+    String workflowCode,
+    String name,
+    String description,
+    String graphJson,
+    String initialState,
+    String terminalStatesJson,
+    String evidenceJson,
+    String metaJson,
+    String intentCode,
+    Boolean isPrimary,
+    String routeConditionJson) {}

--- a/backend/src/test/java/com/init/domainpack/application/CreateDomainPackDraftUseCaseTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/CreateDomainPackDraftUseCaseTest.java
@@ -97,17 +97,25 @@ class CreateDomainPackDraftUseCaseTest {
 
   @BeforeEach
   void setUp() {
-    domainPackDraftPersistenceService =
-        new DomainPackDraftPersistenceService(
-            domainPackVersionRepository,
-            intentDefinitionRepository,
+    DomainPackDraftIntentPersister intentPersister =
+        new DomainPackDraftIntentPersister(intentDefinitionRepository);
+    DomainPackDraftWorkflowMapper workflowMapper =
+        new DomainPackDraftWorkflowMapper(policyDefinitionRepository);
+    DomainPackDraftComponentPersister componentPersister =
+        new DomainPackDraftComponentPersister(
             slotDefinitionRepository,
             policyDefinitionRepository,
             riskDefinitionRepository,
             workflowDefinitionRepository,
-            intentSlotBindingRepository,
+            intentSlotBindingRepository);
+    domainPackDraftPersistenceService =
+        new DomainPackDraftPersistenceService(
+            domainPackVersionRepository,
             domainPackVersionCloneService,
-            profileBuildRequestService);
+            profileBuildRequestService,
+            intentPersister,
+            workflowMapper,
+            componentPersister);
     useCase =
         new CreateDomainPackDraftUseCase(
             domainPackRepository,

--- a/backend/src/test/java/com/init/domainpack/application/DomainPackDraftPersistenceServiceTest.java
+++ b/backend/src/test/java/com/init/domainpack/application/DomainPackDraftPersistenceServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -25,11 +26,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -46,9 +48,33 @@ class DomainPackDraftPersistenceServiceTest {
   @Mock private RiskDefinitionRepository riskDefinitionRepository;
   @Mock private WorkflowDefinitionRepository workflowDefinitionRepository;
   @Mock private IntentSlotBindingRepository intentSlotBindingRepository;
+  @Mock private DomainPackVersionCloneService domainPackVersionCloneService;
   @Mock private WorkflowMatchingProfileBuildRequestService profileBuildRequestService;
 
-  @InjectMocks private DomainPackDraftPersistenceService service;
+  private DomainPackDraftPersistenceService service;
+
+  @BeforeEach
+  void setUp() {
+    DomainPackDraftIntentPersister intentPersister =
+        new DomainPackDraftIntentPersister(intentDefinitionRepository);
+    DomainPackDraftWorkflowMapper workflowMapper =
+        new DomainPackDraftWorkflowMapper(policyDefinitionRepository);
+    DomainPackDraftComponentPersister componentPersister =
+        new DomainPackDraftComponentPersister(
+            slotDefinitionRepository,
+            policyDefinitionRepository,
+            riskDefinitionRepository,
+            workflowDefinitionRepository,
+            intentSlotBindingRepository);
+    service =
+        new DomainPackDraftPersistenceService(
+            domainPackVersionRepository,
+            domainPackVersionCloneService,
+            profileBuildRequestService,
+            intentPersister,
+            workflowMapper,
+            componentPersister);
+  }
 
   @Test
   @DisplayName("기존 DB에 있는 부모 intent를 참조해 child intent를 추가 저장할 수 있다")
@@ -216,6 +242,89 @@ class DomainPackDraftPersistenceServiceTest {
     assertThat(result.addedWorkflowCount()).isEqualTo(1);
     assertThat(result.addedIntentSlotBindingCount()).isEqualTo(1);
     verify(intentDefinitionRepository, never()).saveAllAndFlush(any());
+    verify(profileBuildRequestService).enqueue(101L, "WORKFLOW_DRAFT_IMPORT");
+  }
+
+  @Test
+  @DisplayName("workflow draft component는 slot, policy, risk, workflow, binding 순서로 저장한다")
+  void persistWorkflowDraft_savesComponentsInStableOrder() {
+    DomainPackVersion version =
+        DomainPackVersion.ofForTest(101L, 7L, DomainPackVersion.STATUS_DRAFT);
+    IntentDefinition existingIntent =
+        IntentDefinition.create(101L, "refund_request", "환불 요청", null, 1, null, null, null, null);
+    ReflectionTestUtils.setField(existingIntent, "id", 55L);
+
+    given(domainPackVersionRepository.findById(101L)).willReturn(Optional.of(version));
+    given(
+            policyDefinitionRepository.findExistingPolicyCodesByVersionIdAndCodes(
+                101L, Set.of("refund_policy_default")))
+        .willReturn(Set.of());
+    given(intentDefinitionRepository.findByDomainPackVersionId(101L))
+        .willReturn(List.of(existingIntent));
+    given(slotDefinitionRepository.saveAll(any())).willAnswer(this::saveAllWithIds);
+    given(policyDefinitionRepository.saveAll(any())).willAnswer(this::saveAllWithIds);
+    given(riskDefinitionRepository.saveAll(any())).willAnswer(this::saveAllWithIds);
+    given(workflowDefinitionRepository.saveAll(any())).willAnswer(this::saveAllWithIds);
+    given(intentSlotBindingRepository.saveAll(any())).willAnswer(this::saveAllWithIds);
+
+    service.persistWorkflowDraft(
+        101L,
+        List.of(
+            new AddWorkflowDraftToVersionCommand.SlotDraft(
+                "order_id", "주문번호", null, "STRING", false, null, null, null)),
+        List.of(
+            new AddWorkflowDraftToVersionCommand.PolicyDraft(
+                "refund_policy_default", "기본 환불 정책", null, "HIGH", null, null, null, null)),
+        List.of(
+            new AddWorkflowDraftToVersionCommand.RiskDraft(
+                "fraud_high_amount", "고액 사기 위험", null, "HIGH", null, null, null, null)),
+        List.of(validWorkflowDraft("refund_policy_default")),
+        List.of(
+            new AddWorkflowDraftToVersionCommand.IntentSlotBindingDraft(
+                "refund_request", "order_id", true, 1, "주문번호를 알려주세요.", null)));
+
+    InOrder inOrder =
+        inOrder(
+            slotDefinitionRepository,
+            policyDefinitionRepository,
+            riskDefinitionRepository,
+            workflowDefinitionRepository,
+            intentSlotBindingRepository);
+    inOrder.verify(slotDefinitionRepository).saveAll(any());
+    inOrder.verify(policyDefinitionRepository).saveAll(any());
+    inOrder.verify(riskDefinitionRepository).saveAll(any());
+    inOrder.verify(workflowDefinitionRepository).saveAll(any());
+    inOrder.verify(intentSlotBindingRepository).saveAll(any());
+  }
+
+  @Test
+  @DisplayName("workflow 저장 건수가 없으면 matching profile enqueue를 호출하지 않는다")
+  void persistWorkflowDraft_withoutWorkflow_doesNotEnqueueProfileBuild() {
+    DomainPackVersion version =
+        DomainPackVersion.ofForTest(101L, 7L, DomainPackVersion.STATUS_DRAFT);
+
+    given(domainPackVersionRepository.findById(101L)).willReturn(Optional.of(version));
+    given(intentDefinitionRepository.findByDomainPackVersionId(101L)).willReturn(List.of());
+    given(slotDefinitionRepository.saveAll(any())).willAnswer(this::saveAllWithIds);
+    given(policyDefinitionRepository.saveAll(any())).willAnswer(this::saveAllWithIds);
+    given(riskDefinitionRepository.saveAll(any())).willAnswer(this::saveAllWithIds);
+    given(workflowDefinitionRepository.saveAll(any())).willAnswer(this::saveAllWithIds);
+    given(intentSlotBindingRepository.saveAll(any())).willAnswer(this::saveAllWithIds);
+
+    AddWorkflowDraftToVersionResult result =
+        service.persistWorkflowDraft(
+            101L,
+            List.of(
+                new AddWorkflowDraftToVersionCommand.SlotDraft(
+                    "order_id", "주문번호", null, "STRING", false, null, null, null)),
+            List.of(),
+            List.of(),
+            List.of(),
+            List.of());
+
+    assertThat(result.addedSlotCount()).isEqualTo(1);
+    assertThat(result.addedWorkflowCount()).isZero();
+    verify(profileBuildRequestService, never()).enqueue(any(), any());
   }
 
   @Test
@@ -273,6 +382,7 @@ class DomainPackDraftPersistenceServiceTest {
                     List.of(validWorkflowDraft("missing_policy")),
                     List.of()))
         .isInstanceOf(WorkflowActionNodePolicyRefNotFoundException.class);
+    verify(profileBuildRequestService, never()).enqueue(any(), any());
   }
 
   @Test
@@ -319,13 +429,19 @@ class DomainPackDraftPersistenceServiceTest {
                             "missing_intent", "order_id", true, 1, null, null))))
         .isInstanceOf(
             com.init.domainpack.application.exception.DomainPackDraftRequestInvalidException.class);
+    verify(profileBuildRequestService, never()).enqueue(any(), any());
   }
 
   private AddWorkflowDraftToVersionCommand.WorkflowDraft validWorkflowDraft(String policyRef) {
     String graphJson =
-        """
-        {"nodes":[{"id":"start","type":"START"},{"id":"answer","type":"ACTION","policyRef":"%s"},{"id":"terminal","type":"TERMINAL"}],"edges":[{"id":"e1","from":"start","to":"answer"},{"id":"e2","from":"answer","to":"terminal"}]}
-        """
+        ("{\"nodes\":["
+                + "{\"id\":\"start\",\"type\":\"START\"},"
+                + "{\"id\":\"answer\",\"type\":\"ACTION\",\"policyRef\":\"%s\"},"
+                + "{\"id\":\"terminal\",\"type\":\"TERMINAL\"}"
+                + "],\"edges\":["
+                + "{\"id\":\"e1\",\"from\":\"start\",\"to\":\"answer\"},"
+                + "{\"id\":\"e2\",\"from\":\"answer\",\"to\":\"terminal\"}"
+                + "]}")
             .formatted(policyRef);
     return new AddWorkflowDraftToVersionCommand.WorkflowDraft(
         "refund_flow", "환불 플로우", null, graphJson, null, null, "refund_request", true, null);


### PR DESCRIPTION
Closes #610

## 변경 사항

- `DomainPackDraftPersistenceService`를 draft version 생성/조회, transaction boundary, component 저장 순서, matching profile enqueue 정책을 조율하는 역할로 축소했습니다.
- draft 입력 변환, intent 저장/parent 연결, workflow graph parsing·normalization, slot/policy/risk/workflow/binding 저장 책임을 application-layer collaborator로 분리했습니다.
- workflow 저장 건수가 있을 때만 matching profile build enqueue가 호출되도록 기존 정책을 명시하고, component 저장 실패 경로에서는 enqueue가 호출되지 않도록 테스트를 보강했습니다.
- 이슈 610 스펙을 `.agent/specs/610.md`에 정리했습니다.

## 검증

- `git diff --check`
- `JAVA_HOME="$(mise where java@temurin-21)" ./gradlew spotlessCheck`
- `JAVA_HOME="$(mise where java@temurin-21)" ./gradlew test --tests com.init.domainpack.application.DomainPackDraftPersistenceServiceTest --tests com.init.domainpack.application.CreateDomainPackDraftUseCaseTest`
- `JAVA_HOME="$(mise where java@temurin-21)" ./gradlew testH2`
- `JAVA_HOME="$(mise where java@temurin-21)" ./gradlew checkstyleMain checkstyleTest`

## 참고

- 커밋 pre-commit hook의 `pnpm run format:backend:check`는 staged Java 파일 절대경로가 Gradle 태스크 인자로 전달되어 실패했습니다. 동일 포맷 검사는 위의 `spotlessCheck`로 통과 확인했습니다.
- `checkstyleMain checkstyleTest`는 성공 종료했지만 저장소 기존 warning-only baseline을 함께 출력합니다.