### PR TITLE
refactor(workflow-runtime): 시뮬레이션 개선 후보 승인 책임을 분리

### DIFF
--- a/.agent/specs/611.md
+++ b/.agent/specs/611.md
@@ -1,0 +1,107 @@
+# simulation improvement candidate 승인 흐름 분리
+
+## Goal
+
+`SimulationImprovementCandidateService`에 결합된 승인/반려, review task, draft patch, feedback/profile enqueue 책임을 분리하여 승인 흐름 변경 리스크를 낮춘다.
+
+## Problem
+
+`backend/src/main/java/com/init/workflowruntime/application/SimulationImprovementCandidateService.java`가 후보 조회와 상태 변경뿐 아니라 review task 생성, 승인/반려 decision 기록, domain pack draft patch 적용, feedback 상태 기록, workflow matching profile rebuild enqueue까지 함께 처리한다. 승인 정책과 draft 변경 정책이 한 서비스에 모여 있어 작은 정책 변경도 후보 상태 전이와 draft 반영 경로를 함께 건드리게 된다.
+
+## Scope
+
+- 후보 조회, workspace 검증, 기본 create/list/get/updateStatus API orchestration은 기존 application service에 유지한다.
+- 승인/반려 terminal 상태 전이와 feedback 기록 책임을 application 계층의 별도 collaborator로 분리한다.
+- review task 생성/조회와 review decision 기록 책임을 별도 collaborator로 분리한다.
+- draft domain pack version 선택, clone, target element description patch 책임을 별도 collaborator로 분리한다.
+- 승인 성공 시 profile rebuild enqueue는 필수 승인 단계로 유지하며, enqueue 실패 시 후보/feedback terminal 상태를 저장하지 않는 정책을 명확히 한다.
+- 승인/반려 API response DTO, HTTP endpoint, 상태 전이 결과는 기존 동작을 유지한다.
+
+## Non-goals
+
+- 새로운 API endpoint, request/response field, database schema를 추가하지 않는다.
+- draft patch operation 범위를 description update 외로 확장하지 않는다.
+- review 도메인 모델, workflow matching profile worker, embedding 생성 정책을 변경하지 않는다.
+- frontend 화면이나 generated API를 변경하지 않는다.
+
+## Affected Paths
+
+- `backend/src/main/java/com/init/workflowruntime/application/SimulationImprovementCandidateService.java`
+- `backend/src/main/java/com/init/workflowruntime/application/SimulationImprovementCandidateDecisionService.java`
+- `backend/src/main/java/com/init/workflowruntime/application/SimulationImprovementCandidateReviewTaskService.java`
+- `backend/src/main/java/com/init/workflowruntime/application/SimulationImprovementDraftPatchService.java`
+- `backend/src/test/java/com/init/workflowruntime/application/SimulationImprovementCandidateServiceTest.java`
+- `.agent/specs/611.md`
+
+## Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    actor c as Client
+    participant svc as Candidate Service
+    participant decision as Decision Service
+    participant review as Review Task Service
+    participant patch as Draft Patch Service
+    participant repo as Repositories
+
+    c ->> svc: approve/reject command
+    svc ->> repo: validate membership and load candidate/feedback
+    alt approve
+        svc ->> decision: approve(candidate, feedback)
+        decision ->> patch: apply draft patch
+        patch ->> repo: lock/clone draft version and update target
+        decision ->> repo: enqueue profile rebuild
+        decision ->> review: record approved decision
+        review ->> repo: resolve task and save decision
+        decision ->> repo: mark candidate APPLIED and feedback RESOLVED
+    else reject
+        svc ->> decision: reject(candidate, feedback)
+        decision ->> review: record rejected decision
+        review ->> repo: resolve task and save decision
+        decision ->> repo: mark candidate REJECTED and feedback DISMISSED
+    end
+    svc -->> c: existing SimulationImprovementCandidateResponse
+```
+
+## Requirements
+
+1. 승인/반려 endpoint는 기존 `SimulationImprovementCandidateResponse` shape과 상태 값을 유지해야 한다.
+2. workspace membership 검증과 후보/feedback workspace 검증은 기존과 동일하게 승인/반려 처리 전에 수행해야 한다.
+3. `READY_FOR_REVIEW`가 아니거나 열린 review task가 없는 후보는 승인/반려할 수 없어야 한다.
+4. review task 생성과 재사용 정책은 `READY_FOR_REVIEW` status update 흐름에서 기존과 동일해야 한다.
+5. draft patch는 기존 target type별 description update 정책과 source id → draft code resolve fallback을 유지해야 한다.
+6. published source version 승인 시 기존 draft가 있으면 잠그고, 없으면 `SIMULATION_REVIEW` source type draft를 clone해야 한다.
+7. draft target을 찾지 못하거나 unsupported target이면 candidate, feedback, review decision, profile enqueue가 terminal 승인 상태로 저장되지 않아야 한다.
+8. profile rebuild enqueue 실패는 승인 실패로 처리하며 candidate `APPLIED`와 feedback `RESOLVED` 저장을 진행하지 않아야 한다.
+9. 반려는 draft patch와 profile enqueue를 수행하지 않고 review decision, candidate `REJECTED`, feedback `DISMISSED`만 처리해야 한다.
+
+## Data/API Impact
+
+- REST API path, request, response 변경은 없다.
+- PostgreSQL schema와 migration 변경은 없다.
+- review decision payload schemaVersion과 draft patch JSON key는 기존 값을 유지한다.
+- profile rebuild enqueue trigger type은 `SIMULATION_CANDIDATE_APPLIED`를 유지한다.
+
+## Tests
+
+- `SimulationImprovementCandidateServiceTest`에서 승인, 반려, 재승인 방지, review task 재사용, draft clone/patch, draft patch 실패 상태 보존을 유지 또는 보강한다.
+- profile rebuild enqueue 실패 시 candidate/feedback terminal 상태 저장이 진행되지 않는 테스트를 추가한다.
+- 분리된 collaborator는 기존 service-level test에서 실제 instance로 연결해 public 승인/반려 흐름의 integration 단위로 검증한다.
+
+## Acceptance Criteria
+
+- `SimulationImprovementCandidateService`는 조회/검증/orchestration 중심으로 축소되고 draft patch와 review decision 세부 로직을 직접 갖지 않는다.
+- 승인 성공 시 기존처럼 draft target description이 갱신되고 후보는 `APPLIED`, feedback은 `RESOLVED`가 된다.
+- 반려 성공 시 후보는 `REJECTED`, feedback은 `DISMISSED`가 된다.
+- 이미 처리된 review task나 READY가 아닌 후보는 기존 에러 정책으로 거절된다.
+- draft target missing 실패와 profile enqueue 실패가 candidate/feedback terminal 저장으로 이어지지 않는다.
+
+## Validation
+
+- `./gradlew test --tests com.init.workflowruntime.application.SimulationImprovementCandidateServiceTest`
+- `./gradlew test`
+- `git diff --check`
+
+## Open Questions
+
+- 없음. 이슈 본문이 API 호환, 상태 전이 보존, 책임 분리, 실패 정책 명확화 범위를 결정하기에 충분하다.

--- a/backend/src/main/java/com/init/workflowruntime/application/SimulationImprovementCandidateDecisionService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/SimulationImprovementCandidateDecisionService.java
@@ -1,0 +1,78 @@
+package com.init.workflowruntime.application;
+
+import com.init.domainpack.domain.model.DomainPackVersion;
+import com.init.workflowruntime.application.matching.WorkflowMatchingProfileBuildRequestService;
+import com.init.workflowruntime.domain.SimulationFeedback;
+import com.init.workflowruntime.domain.SimulationFeedbackRepository;
+import com.init.workflowruntime.domain.SimulationImprovementCandidate;
+import com.init.workflowruntime.domain.SimulationImprovementCandidateRepository;
+import java.time.Clock;
+import java.time.OffsetDateTime;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class SimulationImprovementCandidateDecisionService {
+
+  private static final String PROFILE_TRIGGER_SIMULATION_CANDIDATE_APPLIED =
+      "SIMULATION_CANDIDATE_APPLIED";
+
+  private final SimulationImprovementCandidateRepository candidateRepository;
+  private final SimulationFeedbackRepository feedbackRepository;
+  private final SimulationImprovementCandidateReviewTaskService reviewTaskService;
+  private final SimulationImprovementDraftPatchService draftPatchService;
+  private final WorkflowMatchingProfileBuildRequestService profileBuildRequestService;
+  private final Clock clock;
+
+  public SimulationImprovementCandidateDecisionService(
+      SimulationImprovementCandidateRepository candidateRepository,
+      SimulationFeedbackRepository feedbackRepository,
+      SimulationImprovementCandidateReviewTaskService reviewTaskService,
+      SimulationImprovementDraftPatchService draftPatchService,
+      WorkflowMatchingProfileBuildRequestService profileBuildRequestService,
+      Clock clock) {
+    this.candidateRepository = candidateRepository;
+    this.feedbackRepository = feedbackRepository;
+    this.reviewTaskService = reviewTaskService;
+    this.draftPatchService = draftPatchService;
+    this.profileBuildRequestService = profileBuildRequestService;
+    this.clock = clock;
+  }
+
+  public SimulationImprovementCandidate approve(
+      Long workspaceId,
+      Long userId,
+      String reason,
+      SimulationImprovementCandidate candidate,
+      SimulationFeedback feedback) {
+    reviewTaskService.requireOpenReviewTask(candidate);
+    DomainPackVersion draftVersion =
+        draftPatchService.applyDraftPatch(workspaceId, userId, candidate);
+    enqueueRequiredProfileBuild(draftVersion.getId());
+    OffsetDateTime now = OffsetDateTime.now(clock);
+    reviewTaskService.recordApproval(candidate, userId, reason, draftVersion.getId(), now);
+    candidate.markApplied(draftVersion.getId(), userId, reason, now);
+    feedback.markResolved();
+    feedbackRepository.save(feedback);
+    return candidateRepository.save(candidate);
+  }
+
+  public SimulationImprovementCandidate reject(
+      Long userId,
+      String reason,
+      SimulationImprovementCandidate candidate,
+      SimulationFeedback feedback) {
+    OffsetDateTime now = OffsetDateTime.now(clock);
+    reviewTaskService.recordRejection(candidate, userId, reason, now);
+    candidate.markRejected(userId, reason, now);
+    feedback.markDismissed();
+    feedbackRepository.save(feedback);
+    return candidateRepository.save(candidate);
+  }
+
+  private void enqueueRequiredProfileBuild(Long draftVersionId) {
+    profileBuildRequestService.enqueue(
+        draftVersionId, PROFILE_TRIGGER_SIMULATION_CANDIDATE_APPLIED);
+  }
+}

--- a/backend/src/main/java/com/init/workflowruntime/application/SimulationImprovementCandidateReviewTaskService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/SimulationImprovementCandidateReviewTaskService.java
@@ -1,0 +1,220 @@
+package com.init.workflowruntime.application;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.init.review.domain.model.ReviewDecision;
+import com.init.review.domain.model.ReviewSession;
+import com.init.review.domain.model.ReviewTask;
+import com.init.review.domain.repository.ReviewDecisionRepository;
+import com.init.review.domain.repository.ReviewSessionRepository;
+import com.init.review.domain.repository.ReviewTaskRepository;
+import com.init.shared.application.exception.BadRequestException;
+import com.init.shared.application.exception.NotFoundException;
+import com.init.workflowruntime.domain.SimulationImprovementCandidate;
+import com.init.workflowruntime.domain.SimulationImprovementCandidateStatus;
+import java.time.Clock;
+import java.time.OffsetDateTime;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class SimulationImprovementCandidateReviewTaskService {
+
+  private static final String REVIEW_PRIORITY_NORMAL = "NORMAL";
+
+  private final ReviewSessionRepository reviewSessionRepository;
+  private final ReviewTaskRepository reviewTaskRepository;
+  private final ReviewDecisionRepository reviewDecisionRepository;
+  private final ObjectMapper objectMapper;
+  private final Clock clock;
+
+  public SimulationImprovementCandidateReviewTaskService(
+      ReviewSessionRepository reviewSessionRepository,
+      ReviewTaskRepository reviewTaskRepository,
+      ReviewDecisionRepository reviewDecisionRepository,
+      ObjectMapper objectMapper,
+      Clock clock) {
+    this.reviewSessionRepository = reviewSessionRepository;
+    this.reviewTaskRepository = reviewTaskRepository;
+    this.reviewDecisionRepository = reviewDecisionRepository;
+    this.objectMapper = objectMapper;
+    this.clock = clock;
+  }
+
+  @Transactional
+  public ReviewTask ensureReviewTask(SimulationImprovementCandidate candidate, Long userId) {
+    if (candidate.getReviewTaskId() != null) {
+      return reviewTaskRepository
+          .findById(candidate.getReviewTaskId())
+          .orElseThrow(
+              () ->
+                  new NotFoundException(
+                      "SIMULATION_REVIEW_TASK_NOT_FOUND",
+                      "Simulation review task not found: " + candidate.getReviewTaskId()));
+    }
+    OffsetDateTime now = OffsetDateTime.now(clock);
+    ReviewSession session =
+        reviewSessionRepository
+            .findFirstByWorkspaceIdAndDomainPackVersionIdAndReviewKindAndStatusOrderByOpenedAtDesc(
+                candidate.getWorkspaceId(),
+                candidate.getDomainPackVersionId(),
+                ReviewSession.KIND_SIMULATION_IMPROVEMENT,
+                ReviewSession.STATUS_OPEN)
+            .orElseGet(
+                () ->
+                    reviewSessionRepository.save(
+                        ReviewSession.createDomainPackReview(
+                            candidate.getWorkspaceId(),
+                            candidate.getDomainPackVersionId(),
+                            ReviewSession.KIND_SIMULATION_IMPROVEMENT,
+                            "시뮬레이션 개선 후보 검토",
+                            "READY_FOR_REVIEW 상태의 시뮬레이션 개선 후보를 " + "승인 또는 반려합니다.",
+                            userId,
+                            reviewSessionMeta(candidate),
+                            now)));
+    return reviewTaskRepository
+        .findFirstByReviewSessionIdAndTargetTypeAndTargetIdOrderByIdDesc(
+            session.getId(), ReviewTask.TARGET_SIMULATION_IMPROVEMENT_CANDIDATE, candidate.getId())
+        .orElseGet(
+            () ->
+                reviewTaskRepository.save(
+                    ReviewTask.create(
+                        session.getId(),
+                        ReviewTask.TARGET_SIMULATION_IMPROVEMENT_CANDIDATE,
+                        candidate.getId(),
+                        reviewTargetRef(candidate),
+                        candidate.getAfterSummary(),
+                        REVIEW_PRIORITY_NORMAL,
+                        candidate.getDraftPatchJson(),
+                        now)));
+  }
+
+  @Transactional
+  public void recordApproval(
+      SimulationImprovementCandidate candidate,
+      Long userId,
+      String reason,
+      Long appliedDomainPackVersionId,
+      OffsetDateTime decidedAt) {
+    recordDecision(candidate, userId, reason, "APPROVED", appliedDomainPackVersionId, decidedAt);
+  }
+
+  @Transactional
+  public void recordRejection(
+      SimulationImprovementCandidate candidate,
+      Long userId,
+      String reason,
+      OffsetDateTime decidedAt) {
+    recordDecision(candidate, userId, reason, "REJECTED", null, decidedAt);
+  }
+
+  private void recordDecision(
+      SimulationImprovementCandidate candidate,
+      Long userId,
+      String reason,
+      String decision,
+      Long appliedDomainPackVersionId,
+      OffsetDateTime decidedAt) {
+    ReviewTask task = requireOpenReviewTask(candidate);
+    task.resolve(userId, decidedAt);
+    reviewTaskRepository.save(task);
+    reviewDecisionRepository.save(
+        ReviewDecision.create(
+            task.getReviewSessionId(),
+            ReviewTask.TARGET_SIMULATION_IMPROVEMENT_CANDIDATE,
+            candidate.getId(),
+            decision,
+            reason,
+            userId,
+            decisionPayload(candidate, appliedDomainPackVersionId),
+            decidedAt));
+  }
+
+  public ReviewTask requireOpenReviewTask(SimulationImprovementCandidate candidate) {
+    if (candidate.getStatus() != SimulationImprovementCandidateStatus.READY_FOR_REVIEW) {
+      throw new BadRequestException(
+          "SIMULATION_CANDIDATE_NOT_READY", "READY_FOR_REVIEW 후보만 승인 또는 반려할 수 있습니다.");
+    }
+    if (candidate.getReviewTaskId() == null) {
+      throw new BadRequestException(
+          "SIMULATION_REVIEW_TASK_REQUIRED", "후보에 연결된 review task가 없습니다.");
+    }
+    ReviewTask task =
+        reviewTaskRepository
+            .findById(candidate.getReviewTaskId())
+            .orElseThrow(
+                () ->
+                    new NotFoundException(
+                        "SIMULATION_REVIEW_TASK_NOT_FOUND",
+                        "Simulation review task not found: " + candidate.getReviewTaskId()));
+    if (!ReviewTask.STATUS_OPEN.equals(task.getStatus())) {
+      throw new BadRequestException("SIMULATION_REVIEW_TASK_RESOLVED", "이미 처리된 review task입니다.");
+    }
+    return task;
+  }
+
+  private String reviewSessionMeta(SimulationImprovementCandidate candidate) {
+    ObjectNode root = objectMapper.createObjectNode();
+    root.put("schemaVersion", "simulation-improvement-review-session.v1");
+    root.put("source", "simulation");
+    root.put("domainPackVersionId", candidate.getDomainPackVersionId());
+    return toJson(root);
+  }
+
+  private String reviewTargetRef(SimulationImprovementCandidate candidate) {
+    ObjectNode root = objectMapper.createObjectNode();
+    root.put("schemaVersion", "simulation-improvement-review-task.v1");
+    root.put("candidateId", candidate.getId());
+    root.put("feedbackId", candidate.getFeedbackId());
+    root.put("simulationSessionId", candidate.getChatSessionId());
+    if (candidate.getChatMessageId() != null) {
+      root.put("simulationTurnId", candidate.getChatMessageId());
+    }
+    root.put("candidateType", candidate.getCandidateType().name());
+    root.put("targetElementType", candidate.getTargetElementType().name());
+    if (candidate.getTargetElementId() != null) {
+      root.put("targetElementId", candidate.getTargetElementId());
+    }
+    if (candidate.getTargetElementKey() != null) {
+      root.put("targetElementKey", candidate.getTargetElementKey());
+    }
+    root.put("beforeSummary", candidate.getBeforeSummary());
+    root.put("afterSummary", candidate.getAfterSummary());
+    root.put("evidenceSummary", candidate.getEvidenceSummary());
+    return toJson(root);
+  }
+
+  private String decisionPayload(
+      SimulationImprovementCandidate candidate, Long appliedDomainPackVersionId) {
+    ObjectNode root = objectMapper.createObjectNode();
+    root.put("schemaVersion", "simulation-improvement-review-decision.v1");
+    root.put("candidateId", candidate.getId());
+    root.put("feedbackId", candidate.getFeedbackId());
+    if (appliedDomainPackVersionId != null) {
+      root.put("appliedDomainPackVersionId", appliedDomainPackVersionId);
+    }
+    root.set("draftPatch", readObject(candidate.getDraftPatchJson()));
+    return toJson(root);
+  }
+
+  private ObjectNode readObject(String json) {
+    try {
+      if (json == null || json.isBlank() || !objectMapper.readTree(json).isObject()) {
+        return objectMapper.createObjectNode();
+      }
+      return (ObjectNode) objectMapper.readTree(json);
+    } catch (JsonProcessingException e) {
+      return objectMapper.createObjectNode();
+    }
+  }
+
+  private String toJson(ObjectNode node) {
+    try {
+      return objectMapper.writeValueAsString(node);
+    } catch (JsonProcessingException e) {
+      throw new BadRequestException("JSON_SERIALIZATION_FAILED", "review payload 직렬화에 실패했습니다.", e);
+    }
+  }
+}

--- a/backend/src/main/java/com/init/workflowruntime/application/SimulationImprovementCandidateService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/SimulationImprovementCandidateService.java
@@ -3,28 +3,7 @@ package com.init.workflowruntime.application;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.init.domainpack.application.DomainPackDraftSourceType;
-import com.init.domainpack.application.DomainPackVersionCloneCommand;
-import com.init.domainpack.application.DomainPackVersionCloneResult;
-import com.init.domainpack.application.DomainPackVersionCloneService;
-import com.init.domainpack.domain.model.DomainPackVersion;
-import com.init.domainpack.domain.model.IntentDefinition;
-import com.init.domainpack.domain.model.PolicyDefinition;
-import com.init.domainpack.domain.model.RiskDefinition;
-import com.init.domainpack.domain.model.SlotDefinition;
-import com.init.domainpack.domain.model.WorkflowDefinition;
-import com.init.domainpack.domain.repository.DomainPackVersionRepository;
-import com.init.domainpack.domain.repository.IntentDefinitionRepository;
-import com.init.domainpack.domain.repository.PolicyDefinitionRepository;
-import com.init.domainpack.domain.repository.RiskDefinitionRepository;
-import com.init.domainpack.domain.repository.SlotDefinitionRepository;
-import com.init.domainpack.domain.repository.WorkflowDefinitionRepository;
-import com.init.review.domain.model.ReviewDecision;
-import com.init.review.domain.model.ReviewSession;
 import com.init.review.domain.model.ReviewTask;
-import com.init.review.domain.repository.ReviewDecisionRepository;
-import com.init.review.domain.repository.ReviewSessionRepository;
-import com.init.review.domain.repository.ReviewTaskRepository;
 import com.init.shared.application.exception.BadRequestException;
 import com.init.shared.application.exception.NotFoundException;
 import com.init.workflowruntime.application.command.ApproveSimulationImprovementCandidateCommand;
@@ -33,7 +12,6 @@ import com.init.workflowruntime.application.command.RejectSimulationImprovementC
 import com.init.workflowruntime.application.command.UpdateSimulationImprovementCandidateStatusCommand;
 import com.init.workflowruntime.application.dto.SimulationImprovementCandidatePageResponse;
 import com.init.workflowruntime.application.dto.SimulationImprovementCandidateResponse;
-import com.init.workflowruntime.application.matching.WorkflowMatchingProfileBuildRequestService;
 import com.init.workflowruntime.domain.ChatSession;
 import com.init.workflowruntime.domain.ChatSessionRepository;
 import com.init.workflowruntime.domain.DomainPage;
@@ -50,10 +28,7 @@ import com.init.workflowruntime.domain.SimulationImprovementCandidateTargetType;
 import com.init.workflowruntime.domain.SimulationImprovementCandidateType;
 import com.init.workspace.application.exception.WorkspaceAccessDeniedException;
 import com.init.workspace.domain.repository.WorkspaceMemberRepository;
-import java.time.Clock;
-import java.time.OffsetDateTime;
 import java.util.Locale;
-import java.util.Optional;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -65,61 +40,30 @@ public class SimulationImprovementCandidateService {
   private static final int DEFAULT_PAGE_SIZE = 20;
   private static final int MAX_PAGE_SIZE = 100;
   private static final int GENERATED_SUMMARY_MAX_LENGTH = 2000;
-  private static final String REVIEW_PRIORITY_NORMAL = "NORMAL";
 
   private final SimulationFeedbackRepository feedbackRepository;
   private final SimulationImprovementCandidateRepository candidateRepository;
   private final ChatSessionRepository chatSessionRepository;
   private final WorkspaceMemberRepository workspaceMemberRepository;
-  private final DomainPackVersionRepository domainPackVersionRepository;
-  private final DomainPackVersionCloneService domainPackVersionCloneService;
-  private final IntentDefinitionRepository intentDefinitionRepository;
-  private final SlotDefinitionRepository slotDefinitionRepository;
-  private final PolicyDefinitionRepository policyDefinitionRepository;
-  private final RiskDefinitionRepository riskDefinitionRepository;
-  private final WorkflowDefinitionRepository workflowDefinitionRepository;
-  private final ReviewSessionRepository reviewSessionRepository;
-  private final ReviewTaskRepository reviewTaskRepository;
-  private final ReviewDecisionRepository reviewDecisionRepository;
-  private final WorkflowMatchingProfileBuildRequestService profileBuildRequestService;
+  private final SimulationImprovementCandidateReviewTaskService reviewTaskService;
+  private final SimulationImprovementCandidateDecisionService decisionService;
   private final ObjectMapper objectMapper;
-  private final Clock clock;
 
   public SimulationImprovementCandidateService(
       SimulationFeedbackRepository feedbackRepository,
       SimulationImprovementCandidateRepository candidateRepository,
       ChatSessionRepository chatSessionRepository,
       WorkspaceMemberRepository workspaceMemberRepository,
-      DomainPackVersionRepository domainPackVersionRepository,
-      DomainPackVersionCloneService domainPackVersionCloneService,
-      IntentDefinitionRepository intentDefinitionRepository,
-      SlotDefinitionRepository slotDefinitionRepository,
-      PolicyDefinitionRepository policyDefinitionRepository,
-      RiskDefinitionRepository riskDefinitionRepository,
-      WorkflowDefinitionRepository workflowDefinitionRepository,
-      ReviewSessionRepository reviewSessionRepository,
-      ReviewTaskRepository reviewTaskRepository,
-      ReviewDecisionRepository reviewDecisionRepository,
-      WorkflowMatchingProfileBuildRequestService profileBuildRequestService,
-      ObjectMapper objectMapper,
-      Clock clock) {
+      SimulationImprovementCandidateReviewTaskService reviewTaskService,
+      SimulationImprovementCandidateDecisionService decisionService,
+      ObjectMapper objectMapper) {
     this.feedbackRepository = feedbackRepository;
     this.candidateRepository = candidateRepository;
     this.chatSessionRepository = chatSessionRepository;
     this.workspaceMemberRepository = workspaceMemberRepository;
-    this.domainPackVersionRepository = domainPackVersionRepository;
-    this.domainPackVersionCloneService = domainPackVersionCloneService;
-    this.intentDefinitionRepository = intentDefinitionRepository;
-    this.slotDefinitionRepository = slotDefinitionRepository;
-    this.policyDefinitionRepository = policyDefinitionRepository;
-    this.riskDefinitionRepository = riskDefinitionRepository;
-    this.workflowDefinitionRepository = workflowDefinitionRepository;
-    this.reviewSessionRepository = reviewSessionRepository;
-    this.reviewTaskRepository = reviewTaskRepository;
-    this.reviewDecisionRepository = reviewDecisionRepository;
-    this.profileBuildRequestService = profileBuildRequestService;
+    this.reviewTaskService = reviewTaskService;
+    this.decisionService = decisionService;
     this.objectMapper = objectMapper;
-    this.clock = clock;
   }
 
   @Transactional
@@ -169,7 +113,7 @@ public class SimulationImprovementCandidateService {
           "INVALID_CANDIDATE_REVIEW_STATUS",
           "READY_FOR_REVIEW 전이만 상태 변경 endpoint에서 지원합니다. 승인/반려 endpoint를 사용하세요.");
     }
-    ReviewTask task = ensureReviewTask(candidate, command.userId());
+    ReviewTask task = reviewTaskService.ensureReviewTask(candidate, command.userId());
     candidate.submitForReview(task.getReviewSessionId(), task.getId());
     return SimulationImprovementCandidateResponse.from(candidateRepository.save(candidate));
   }
@@ -182,27 +126,9 @@ public class SimulationImprovementCandidateService {
     validateCandidateWorkspace(command.workspaceId(), candidate);
     SimulationFeedback feedback = findFeedbackForUpdate(candidate.getFeedbackId());
     validateFeedbackWorkspace(command.workspaceId(), feedback);
-    ReviewTask task = requireReviewTask(candidate);
-    DomainPackVersion draftVersion =
-        applyDraftPatch(command.workspaceId(), command.userId(), candidate);
-    OffsetDateTime now = OffsetDateTime.now(clock);
-    task.resolve(command.userId(), now);
-    reviewTaskRepository.save(task);
-    reviewDecisionRepository.save(
-        ReviewDecision.create(
-            task.getReviewSessionId(),
-            ReviewTask.TARGET_SIMULATION_IMPROVEMENT_CANDIDATE,
-            candidate.getId(),
-            "APPROVED",
-            command.reason(),
-            command.userId(),
-            decisionPayload(candidate, draftVersion.getId()),
-            now));
-    candidate.markApplied(draftVersion.getId(), command.userId(), command.reason(), now);
-    feedback.markResolved();
-    feedbackRepository.save(feedback);
-    profileBuildRequestService.enqueue(draftVersion.getId(), "SIMULATION_CANDIDATE_APPLIED");
-    return SimulationImprovementCandidateResponse.from(candidateRepository.save(candidate));
+    return SimulationImprovementCandidateResponse.from(
+        decisionService.approve(
+            command.workspaceId(), command.userId(), command.reason(), candidate, feedback));
   }
 
   @Transactional
@@ -213,24 +139,8 @@ public class SimulationImprovementCandidateService {
     validateCandidateWorkspace(command.workspaceId(), candidate);
     SimulationFeedback feedback = findFeedbackForUpdate(candidate.getFeedbackId());
     validateFeedbackWorkspace(command.workspaceId(), feedback);
-    ReviewTask task = requireReviewTask(candidate);
-    OffsetDateTime now = OffsetDateTime.now(clock);
-    task.resolve(command.userId(), now);
-    reviewTaskRepository.save(task);
-    reviewDecisionRepository.save(
-        ReviewDecision.create(
-            task.getReviewSessionId(),
-            ReviewTask.TARGET_SIMULATION_IMPROVEMENT_CANDIDATE,
-            candidate.getId(),
-            "REJECTED",
-            command.reason(),
-            command.userId(),
-            decisionPayload(candidate, null),
-            now));
-    candidate.markRejected(command.userId(), command.reason(), now);
-    feedback.markDismissed();
-    feedbackRepository.save(feedback);
-    return SimulationImprovementCandidateResponse.from(candidateRepository.save(candidate));
+    return SimulationImprovementCandidateResponse.from(
+        decisionService.reject(command.userId(), command.reason(), candidate, feedback));
   }
 
   private SimulationImprovementCandidateResponse createNewCandidate(
@@ -256,325 +166,6 @@ public class SimulationImprovementCandidateService {
     return SimulationImprovementCandidateResponse.from(saved);
   }
 
-  private ReviewTask ensureReviewTask(SimulationImprovementCandidate candidate, Long userId) {
-    if (candidate.getReviewTaskId() != null) {
-      return reviewTaskRepository
-          .findById(candidate.getReviewTaskId())
-          .orElseThrow(
-              () ->
-                  new NotFoundException(
-                      "SIMULATION_REVIEW_TASK_NOT_FOUND",
-                      "Simulation review task not found: " + candidate.getReviewTaskId()));
-    }
-    OffsetDateTime now = OffsetDateTime.now(clock);
-    ReviewSession session =
-        reviewSessionRepository
-            .findFirstByWorkspaceIdAndDomainPackVersionIdAndReviewKindAndStatusOrderByOpenedAtDesc(
-                candidate.getWorkspaceId(),
-                candidate.getDomainPackVersionId(),
-                ReviewSession.KIND_SIMULATION_IMPROVEMENT,
-                ReviewSession.STATUS_OPEN)
-            .orElseGet(
-                () ->
-                    reviewSessionRepository.save(
-                        ReviewSession.createDomainPackReview(
-                            candidate.getWorkspaceId(),
-                            candidate.getDomainPackVersionId(),
-                            ReviewSession.KIND_SIMULATION_IMPROVEMENT,
-                            "시뮬레이션 개선 후보 검토",
-                            "READY_FOR_REVIEW 상태의 시뮬레이션 개선 후보를 승인 또는 반려합니다.",
-                            userId,
-                            reviewSessionMeta(candidate),
-                            now)));
-    return reviewTaskRepository
-        .findFirstByReviewSessionIdAndTargetTypeAndTargetIdOrderByIdDesc(
-            session.getId(), ReviewTask.TARGET_SIMULATION_IMPROVEMENT_CANDIDATE, candidate.getId())
-        .orElseGet(
-            () ->
-                reviewTaskRepository.save(
-                    ReviewTask.create(
-                        session.getId(),
-                        ReviewTask.TARGET_SIMULATION_IMPROVEMENT_CANDIDATE,
-                        candidate.getId(),
-                        reviewTargetRef(candidate),
-                        candidate.getAfterSummary(),
-                        REVIEW_PRIORITY_NORMAL,
-                        candidate.getDraftPatchJson(),
-                        now)));
-  }
-
-  private ReviewTask requireReviewTask(SimulationImprovementCandidate candidate) {
-    if (candidate.getStatus() != SimulationImprovementCandidateStatus.READY_FOR_REVIEW) {
-      throw new BadRequestException(
-          "SIMULATION_CANDIDATE_NOT_READY", "READY_FOR_REVIEW 후보만 승인 또는 반려할 수 있습니다.");
-    }
-    if (candidate.getReviewTaskId() == null) {
-      throw new BadRequestException(
-          "SIMULATION_REVIEW_TASK_REQUIRED", "후보에 연결된 review task가 없습니다.");
-    }
-    ReviewTask task =
-        reviewTaskRepository
-            .findById(candidate.getReviewTaskId())
-            .orElseThrow(
-                () ->
-                    new NotFoundException(
-                        "SIMULATION_REVIEW_TASK_NOT_FOUND",
-                        "Simulation review task not found: " + candidate.getReviewTaskId()));
-    if (!ReviewTask.STATUS_OPEN.equals(task.getStatus())) {
-      throw new BadRequestException("SIMULATION_REVIEW_TASK_RESOLVED", "이미 처리된 review task입니다.");
-    }
-    return task;
-  }
-
-  private DomainPackVersion applyDraftPatch(
-      Long workspaceId, Long userId, SimulationImprovementCandidate candidate) {
-    DomainPackVersion sourceVersion =
-        domainPackVersionRepository
-            .findByIdForUpdate(candidate.getDomainPackVersionId())
-            .orElseThrow(
-                () ->
-                    new NotFoundException(
-                        "DOMAIN_PACK_VERSION_NOT_FOUND",
-                        "Domain pack version not found: " + candidate.getDomainPackVersionId()));
-    DomainPackVersion draftVersion =
-        resolveDraftVersion(workspaceId, userId, sourceVersion, candidate);
-    applyDescriptionPatch(candidate, draftVersion.getId());
-    return draftVersion;
-  }
-
-  private DomainPackVersion resolveDraftVersion(
-      Long workspaceId,
-      Long userId,
-      DomainPackVersion sourceVersion,
-      SimulationImprovementCandidate candidate) {
-    if (DomainPackVersion.STATUS_DRAFT.equals(sourceVersion.getLifecycleStatus())) {
-      return sourceVersion;
-    }
-    DomainPackVersion draft =
-        domainPackVersionRepository
-            .findFirstByDomainPackIdAndLifecycleStatusOrderByVersionNoDesc(
-                sourceVersion.getDomainPackId(), DomainPackVersion.STATUS_DRAFT)
-            .orElseGet(
-                () -> {
-                  DomainPackVersionCloneResult result =
-                      domainPackVersionCloneService.cloneVersion(
-                          new DomainPackVersionCloneCommand(
-                              workspaceId,
-                              sourceVersion.getDomainPackId(),
-                              sourceVersion,
-                              userId,
-                              DomainPackDraftSourceType.SIMULATION_REVIEW,
-                              "simulation improvement candidate #" + candidate.getId()));
-                  return domainPackVersionRepository
-                      .findByIdForUpdate(result.draftVersionId())
-                      .orElseThrow(
-                          () ->
-                              new NotFoundException(
-                                  "DOMAIN_PACK_VERSION_NOT_FOUND",
-                                  "Domain pack version not found: " + result.draftVersionId()));
-                });
-    if (!DomainPackVersion.STATUS_DRAFT.equals(draft.getLifecycleStatus())) {
-      throw new BadRequestException("DOMAIN_PACK_VERSION_NOT_DRAFT", "DRAFT version에만 반영할 수 있습니다.");
-    }
-    return domainPackVersionRepository
-        .findByIdForUpdate(draft.getId())
-        .orElseThrow(
-            () ->
-                new NotFoundException(
-                    "DOMAIN_PACK_VERSION_NOT_FOUND",
-                    "Domain pack version not found: " + draft.getId()));
-  }
-
-  private void applyDescriptionPatch(
-      SimulationImprovementCandidate candidate, Long draftVersionId) {
-    switch (candidate.getTargetElementType()) {
-      case INTENT -> applyIntentPatch(candidate, draftVersionId);
-      case SLOT -> applySlotPatch(candidate, draftVersionId);
-      case POLICY -> applyPolicyPatch(candidate, draftVersionId);
-      case RISK_RULE -> applyRiskPatch(candidate, draftVersionId);
-      case WORKFLOW, HANDOFF, RESPONSE -> applyWorkflowPatch(candidate, draftVersionId);
-      case UNKNOWN -> throw unsupportedTarget(candidate);
-    }
-  }
-
-  private void applyIntentPatch(SimulationImprovementCandidate candidate, Long draftVersionId) {
-    IntentDefinition intent =
-        resolveIntent(candidate, draftVersionId).orElseThrow(() -> targetNotFound(candidate));
-    intent.reviseDefinition(
-        intent.getName(),
-        candidate.getAfterSummary(),
-        intent.getTaxonomyLevel(),
-        intent.getEntryConditionJson(),
-        intent.getMetaJson());
-    intentDefinitionRepository.save(intent);
-  }
-
-  private void applySlotPatch(SimulationImprovementCandidate candidate, Long draftVersionId) {
-    SlotDefinition slot =
-        resolveSlot(candidate, draftVersionId).orElseThrow(() -> targetNotFound(candidate));
-    slot.updateFields(
-        slot.getName(),
-        candidate.getAfterSummary(),
-        slot.getIsSensitive(),
-        slot.getValidationRuleJson(),
-        slot.getDefaultValueJson(),
-        slot.getMetaJson());
-    slotDefinitionRepository.save(slot);
-  }
-
-  private void applyPolicyPatch(SimulationImprovementCandidate candidate, Long draftVersionId) {
-    PolicyDefinition policy =
-        resolvePolicy(candidate, draftVersionId).orElseThrow(() -> targetNotFound(candidate));
-    policy.updateFields(
-        policy.getName(),
-        candidate.getAfterSummary(),
-        policy.getSeverity(),
-        policy.getConditionJson(),
-        policy.getActionJson(),
-        policy.getEvidenceJson(),
-        policy.getMetaJson());
-    policyDefinitionRepository.save(policy);
-  }
-
-  private void applyRiskPatch(SimulationImprovementCandidate candidate, Long draftVersionId) {
-    RiskDefinition risk =
-        resolveRisk(candidate, draftVersionId).orElseThrow(() -> targetNotFound(candidate));
-    risk.updateFields(
-        risk.getName(),
-        candidate.getAfterSummary(),
-        risk.getRiskLevel(),
-        risk.getTriggerConditionJson(),
-        risk.getHandlingActionJson(),
-        risk.getEvidenceJson(),
-        risk.getMetaJson());
-    riskDefinitionRepository.save(risk);
-  }
-
-  private void applyWorkflowPatch(SimulationImprovementCandidate candidate, Long draftVersionId) {
-    WorkflowDefinition workflow =
-        resolveWorkflow(candidate, draftVersionId).orElseThrow(() -> targetNotFound(candidate));
-    workflow.updateGraph(
-        workflow.getName(),
-        candidate.getAfterSummary(),
-        workflow.getGraphJson(),
-        workflow.getInitialState(),
-        workflow.getTerminalStatesJson());
-    workflowDefinitionRepository.save(workflow);
-  }
-
-  private Optional<IntentDefinition> resolveIntent(
-      SimulationImprovementCandidate candidate, Long draftVersionId) {
-    String key = candidate.getTargetElementKey();
-    if (key == null && candidate.getTargetElementId() != null) {
-      key =
-          intentDefinitionRepository
-              .findByIdAndDomainPackVersionId(
-                  candidate.getTargetElementId(), candidate.getDomainPackVersionId())
-              .map(IntentDefinition::getIntentCode)
-              .orElse(null);
-    }
-    if (key != null) {
-      return intentDefinitionRepository.findByDomainPackVersionIdAndIntentCode(draftVersionId, key);
-    }
-    return candidate.getTargetElementId() == null
-        ? Optional.empty()
-        : intentDefinitionRepository.findByIdAndDomainPackVersionId(
-            candidate.getTargetElementId(), draftVersionId);
-  }
-
-  private Optional<SlotDefinition> resolveSlot(
-      SimulationImprovementCandidate candidate, Long draftVersionId) {
-    String key = candidate.getTargetElementKey();
-    if (key == null && candidate.getTargetElementId() != null) {
-      key =
-          slotDefinitionRepository
-              .findByIdAndDomainPackVersionId(
-                  candidate.getTargetElementId(), candidate.getDomainPackVersionId())
-              .map(SlotDefinition::getSlotCode)
-              .orElse(null);
-    }
-    if (key != null) {
-      return slotDefinitionRepository.findByDomainPackVersionIdAndSlotCode(draftVersionId, key);
-    }
-    return candidate.getTargetElementId() == null
-        ? Optional.empty()
-        : slotDefinitionRepository.findByIdAndDomainPackVersionId(
-            candidate.getTargetElementId(), draftVersionId);
-  }
-
-  private Optional<PolicyDefinition> resolvePolicy(
-      SimulationImprovementCandidate candidate, Long draftVersionId) {
-    String key = candidate.getTargetElementKey();
-    if (key == null && candidate.getTargetElementId() != null) {
-      key =
-          policyDefinitionRepository
-              .findByIdAndDomainPackVersionId(
-                  candidate.getTargetElementId(), candidate.getDomainPackVersionId())
-              .map(PolicyDefinition::getPolicyCode)
-              .orElse(null);
-    }
-    if (key != null) {
-      return policyDefinitionRepository.findByDomainPackVersionIdAndPolicyCode(draftVersionId, key);
-    }
-    return candidate.getTargetElementId() == null
-        ? Optional.empty()
-        : policyDefinitionRepository.findByIdAndDomainPackVersionId(
-            candidate.getTargetElementId(), draftVersionId);
-  }
-
-  private Optional<RiskDefinition> resolveRisk(
-      SimulationImprovementCandidate candidate, Long draftVersionId) {
-    String key = candidate.getTargetElementKey();
-    if (key == null && candidate.getTargetElementId() != null) {
-      key =
-          riskDefinitionRepository
-              .findByIdAndDomainPackVersionId(
-                  candidate.getTargetElementId(), candidate.getDomainPackVersionId())
-              .map(RiskDefinition::getRiskCode)
-              .orElse(null);
-    }
-    if (key != null) {
-      return riskDefinitionRepository.findByDomainPackVersionIdAndRiskCode(draftVersionId, key);
-    }
-    return candidate.getTargetElementId() == null
-        ? Optional.empty()
-        : riskDefinitionRepository.findByIdAndDomainPackVersionId(
-            candidate.getTargetElementId(), draftVersionId);
-  }
-
-  private Optional<WorkflowDefinition> resolveWorkflow(
-      SimulationImprovementCandidate candidate, Long draftVersionId) {
-    String key = candidate.getTargetElementKey();
-    if (key == null && candidate.getTargetElementId() != null) {
-      key =
-          workflowDefinitionRepository
-              .findByIdAndDomainPackVersionId(
-                  candidate.getTargetElementId(), candidate.getDomainPackVersionId())
-              .map(WorkflowDefinition::getWorkflowCode)
-              .orElse(null);
-    }
-    if (key != null) {
-      return workflowDefinitionRepository.findByDomainPackVersionIdAndWorkflowCode(
-          draftVersionId, key);
-    }
-    return candidate.getTargetElementId() == null
-        ? Optional.empty()
-        : workflowDefinitionRepository.findByIdAndDomainPackVersionId(
-            candidate.getTargetElementId(), draftVersionId);
-  }
-
-  private BadRequestException targetNotFound(SimulationImprovementCandidate candidate) {
-    return new BadRequestException(
-        "SIMULATION_CANDIDATE_TARGET_NOT_FOUND",
-        "개선 후보를 반영할 draft 대상 요소를 찾을 수 없습니다: " + candidate.getId());
-  }
-
-  private BadRequestException unsupportedTarget(SimulationImprovementCandidate candidate) {
-    return new BadRequestException(
-        "SIMULATION_CANDIDATE_TARGET_UNSUPPORTED",
-        "변경 대상 요소를 명시해야 승인할 수 있습니다: " + candidate.getId());
-  }
-
   private String buildDraftPatchJson(SimulationImprovementCandidate candidate) {
     ObjectNode root = objectMapper.createObjectNode();
     root.put("schemaVersion", "simulation-candidate-draft-patch.v1");
@@ -590,61 +181,6 @@ public class SimulationImprovementCandidateService {
     root.put("afterSummary", candidate.getAfterSummary());
     root.put("evidenceSummary", candidate.getEvidenceSummary());
     return toJson(root);
-  }
-
-  private String reviewSessionMeta(SimulationImprovementCandidate candidate) {
-    ObjectNode root = objectMapper.createObjectNode();
-    root.put("schemaVersion", "simulation-improvement-review-session.v1");
-    root.put("source", "simulation");
-    root.put("domainPackVersionId", candidate.getDomainPackVersionId());
-    return toJson(root);
-  }
-
-  private String reviewTargetRef(SimulationImprovementCandidate candidate) {
-    ObjectNode root = objectMapper.createObjectNode();
-    root.put("schemaVersion", "simulation-improvement-review-task.v1");
-    root.put("candidateId", candidate.getId());
-    root.put("feedbackId", candidate.getFeedbackId());
-    root.put("simulationSessionId", candidate.getChatSessionId());
-    if (candidate.getChatMessageId() != null) {
-      root.put("simulationTurnId", candidate.getChatMessageId());
-    }
-    root.put("candidateType", candidate.getCandidateType().name());
-    root.put("targetElementType", candidate.getTargetElementType().name());
-    if (candidate.getTargetElementId() != null) {
-      root.put("targetElementId", candidate.getTargetElementId());
-    }
-    if (candidate.getTargetElementKey() != null) {
-      root.put("targetElementKey", candidate.getTargetElementKey());
-    }
-    root.put("beforeSummary", candidate.getBeforeSummary());
-    root.put("afterSummary", candidate.getAfterSummary());
-    root.put("evidenceSummary", candidate.getEvidenceSummary());
-    return toJson(root);
-  }
-
-  private String decisionPayload(
-      SimulationImprovementCandidate candidate, Long appliedDomainPackVersionId) {
-    ObjectNode root = objectMapper.createObjectNode();
-    root.put("schemaVersion", "simulation-improvement-review-decision.v1");
-    root.put("candidateId", candidate.getId());
-    root.put("feedbackId", candidate.getFeedbackId());
-    if (appliedDomainPackVersionId != null) {
-      root.put("appliedDomainPackVersionId", appliedDomainPackVersionId);
-    }
-    root.set("draftPatch", readObject(candidate.getDraftPatchJson()));
-    return toJson(root);
-  }
-
-  private ObjectNode readObject(String json) {
-    try {
-      if (json == null || json.isBlank() || !objectMapper.readTree(json).isObject()) {
-        return objectMapper.createObjectNode();
-      }
-      return (ObjectNode) objectMapper.readTree(json);
-    } catch (JsonProcessingException e) {
-      return objectMapper.createObjectNode();
-    }
   }
 
   private String toJson(ObjectNode node) {

--- a/backend/src/main/java/com/init/workflowruntime/application/SimulationImprovementDraftPatchService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/SimulationImprovementDraftPatchService.java
@@ -1,0 +1,304 @@
+package com.init.workflowruntime.application;
+
+import com.init.domainpack.application.DomainPackDraftSourceType;
+import com.init.domainpack.application.DomainPackVersionCloneCommand;
+import com.init.domainpack.application.DomainPackVersionCloneResult;
+import com.init.domainpack.application.DomainPackVersionCloneService;
+import com.init.domainpack.domain.model.DomainPackVersion;
+import com.init.domainpack.domain.model.IntentDefinition;
+import com.init.domainpack.domain.model.PolicyDefinition;
+import com.init.domainpack.domain.model.RiskDefinition;
+import com.init.domainpack.domain.model.SlotDefinition;
+import com.init.domainpack.domain.model.WorkflowDefinition;
+import com.init.domainpack.domain.repository.DomainPackVersionRepository;
+import com.init.domainpack.domain.repository.IntentDefinitionRepository;
+import com.init.domainpack.domain.repository.PolicyDefinitionRepository;
+import com.init.domainpack.domain.repository.RiskDefinitionRepository;
+import com.init.domainpack.domain.repository.SlotDefinitionRepository;
+import com.init.domainpack.domain.repository.WorkflowDefinitionRepository;
+import com.init.shared.application.exception.BadRequestException;
+import com.init.shared.application.exception.NotFoundException;
+import com.init.workflowruntime.domain.SimulationImprovementCandidate;
+import java.util.Optional;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class SimulationImprovementDraftPatchService {
+
+  private final DomainPackVersionRepository domainPackVersionRepository;
+  private final DomainPackVersionCloneService domainPackVersionCloneService;
+  private final IntentDefinitionRepository intentDefinitionRepository;
+  private final SlotDefinitionRepository slotDefinitionRepository;
+  private final PolicyDefinitionRepository policyDefinitionRepository;
+  private final RiskDefinitionRepository riskDefinitionRepository;
+  private final WorkflowDefinitionRepository workflowDefinitionRepository;
+
+  public SimulationImprovementDraftPatchService(
+      DomainPackVersionRepository domainPackVersionRepository,
+      DomainPackVersionCloneService domainPackVersionCloneService,
+      IntentDefinitionRepository intentDefinitionRepository,
+      SlotDefinitionRepository slotDefinitionRepository,
+      PolicyDefinitionRepository policyDefinitionRepository,
+      RiskDefinitionRepository riskDefinitionRepository,
+      WorkflowDefinitionRepository workflowDefinitionRepository) {
+    this.domainPackVersionRepository = domainPackVersionRepository;
+    this.domainPackVersionCloneService = domainPackVersionCloneService;
+    this.intentDefinitionRepository = intentDefinitionRepository;
+    this.slotDefinitionRepository = slotDefinitionRepository;
+    this.policyDefinitionRepository = policyDefinitionRepository;
+    this.riskDefinitionRepository = riskDefinitionRepository;
+    this.workflowDefinitionRepository = workflowDefinitionRepository;
+  }
+
+  @Transactional
+  public DomainPackVersion applyDraftPatch(
+      Long workspaceId, Long userId, SimulationImprovementCandidate candidate) {
+    DomainPackVersion sourceVersion =
+        domainPackVersionRepository
+            .findByIdForUpdate(candidate.getDomainPackVersionId())
+            .orElseThrow(
+                () ->
+                    new NotFoundException(
+                        "DOMAIN_PACK_VERSION_NOT_FOUND",
+                        "Domain pack version not found: " + candidate.getDomainPackVersionId()));
+    DomainPackVersion draftVersion =
+        resolveDraftVersion(workspaceId, userId, sourceVersion, candidate);
+    applyDescriptionPatch(candidate, draftVersion.getId());
+    return draftVersion;
+  }
+
+  private DomainPackVersion resolveDraftVersion(
+      Long workspaceId,
+      Long userId,
+      DomainPackVersion sourceVersion,
+      SimulationImprovementCandidate candidate) {
+    if (DomainPackVersion.STATUS_DRAFT.equals(sourceVersion.getLifecycleStatus())) {
+      return sourceVersion;
+    }
+    DomainPackVersion draft =
+        domainPackVersionRepository
+            .findFirstByDomainPackIdAndLifecycleStatusOrderByVersionNoDesc(
+                sourceVersion.getDomainPackId(), DomainPackVersion.STATUS_DRAFT)
+            .orElseGet(
+                () -> {
+                  DomainPackVersionCloneResult result =
+                      domainPackVersionCloneService.cloneVersion(
+                          new DomainPackVersionCloneCommand(
+                              workspaceId,
+                              sourceVersion.getDomainPackId(),
+                              sourceVersion,
+                              userId,
+                              DomainPackDraftSourceType.SIMULATION_REVIEW,
+                              "simulation improvement candidate #" + candidate.getId()));
+                  return domainPackVersionRepository
+                      .findByIdForUpdate(result.draftVersionId())
+                      .orElseThrow(
+                          () ->
+                              new NotFoundException(
+                                  "DOMAIN_PACK_VERSION_NOT_FOUND",
+                                  "Domain pack version not found: " + result.draftVersionId()));
+                });
+    if (!DomainPackVersion.STATUS_DRAFT.equals(draft.getLifecycleStatus())) {
+      throw new BadRequestException("DOMAIN_PACK_VERSION_NOT_DRAFT", "DRAFT version에만 반영할 수 있습니다.");
+    }
+    return domainPackVersionRepository
+        .findByIdForUpdate(draft.getId())
+        .orElseThrow(
+            () ->
+                new NotFoundException(
+                    "DOMAIN_PACK_VERSION_NOT_FOUND",
+                    "Domain pack version not found: " + draft.getId()));
+  }
+
+  private void applyDescriptionPatch(
+      SimulationImprovementCandidate candidate, Long draftVersionId) {
+    switch (candidate.getTargetElementType()) {
+      case INTENT -> applyIntentPatch(candidate, draftVersionId);
+      case SLOT -> applySlotPatch(candidate, draftVersionId);
+      case POLICY -> applyPolicyPatch(candidate, draftVersionId);
+      case RISK_RULE -> applyRiskPatch(candidate, draftVersionId);
+      case WORKFLOW, HANDOFF, RESPONSE -> applyWorkflowPatch(candidate, draftVersionId);
+      case UNKNOWN -> throw unsupportedTarget(candidate);
+    }
+  }
+
+  private void applyIntentPatch(SimulationImprovementCandidate candidate, Long draftVersionId) {
+    IntentDefinition intent =
+        resolveIntent(candidate, draftVersionId).orElseThrow(() -> targetNotFound(candidate));
+    intent.reviseDefinition(
+        intent.getName(),
+        candidate.getAfterSummary(),
+        intent.getTaxonomyLevel(),
+        intent.getEntryConditionJson(),
+        intent.getMetaJson());
+    intentDefinitionRepository.save(intent);
+  }
+
+  private void applySlotPatch(SimulationImprovementCandidate candidate, Long draftVersionId) {
+    SlotDefinition slot =
+        resolveSlot(candidate, draftVersionId).orElseThrow(() -> targetNotFound(candidate));
+    slot.updateFields(
+        slot.getName(),
+        candidate.getAfterSummary(),
+        slot.getIsSensitive(),
+        slot.getValidationRuleJson(),
+        slot.getDefaultValueJson(),
+        slot.getMetaJson());
+    slotDefinitionRepository.save(slot);
+  }
+
+  private void applyPolicyPatch(SimulationImprovementCandidate candidate, Long draftVersionId) {
+    PolicyDefinition policy =
+        resolvePolicy(candidate, draftVersionId).orElseThrow(() -> targetNotFound(candidate));
+    policy.updateFields(
+        policy.getName(),
+        candidate.getAfterSummary(),
+        policy.getSeverity(),
+        policy.getConditionJson(),
+        policy.getActionJson(),
+        policy.getEvidenceJson(),
+        policy.getMetaJson());
+    policyDefinitionRepository.save(policy);
+  }
+
+  private void applyRiskPatch(SimulationImprovementCandidate candidate, Long draftVersionId) {
+    RiskDefinition risk =
+        resolveRisk(candidate, draftVersionId).orElseThrow(() -> targetNotFound(candidate));
+    risk.updateFields(
+        risk.getName(),
+        candidate.getAfterSummary(),
+        risk.getRiskLevel(),
+        risk.getTriggerConditionJson(),
+        risk.getHandlingActionJson(),
+        risk.getEvidenceJson(),
+        risk.getMetaJson());
+    riskDefinitionRepository.save(risk);
+  }
+
+  private void applyWorkflowPatch(SimulationImprovementCandidate candidate, Long draftVersionId) {
+    WorkflowDefinition workflow =
+        resolveWorkflow(candidate, draftVersionId).orElseThrow(() -> targetNotFound(candidate));
+    workflow.updateGraph(
+        workflow.getName(),
+        candidate.getAfterSummary(),
+        workflow.getGraphJson(),
+        workflow.getInitialState(),
+        workflow.getTerminalStatesJson());
+    workflowDefinitionRepository.save(workflow);
+  }
+
+  private Optional<IntentDefinition> resolveIntent(
+      SimulationImprovementCandidate candidate, Long draftVersionId) {
+    String key = candidate.getTargetElementKey();
+    if (key == null && candidate.getTargetElementId() != null) {
+      key =
+          intentDefinitionRepository
+              .findByIdAndDomainPackVersionId(
+                  candidate.getTargetElementId(), candidate.getDomainPackVersionId())
+              .map(IntentDefinition::getIntentCode)
+              .orElse(null);
+    }
+    if (key != null) {
+      return intentDefinitionRepository.findByDomainPackVersionIdAndIntentCode(draftVersionId, key);
+    }
+    return candidate.getTargetElementId() == null
+        ? Optional.empty()
+        : intentDefinitionRepository.findByIdAndDomainPackVersionId(
+            candidate.getTargetElementId(), draftVersionId);
+  }
+
+  private Optional<SlotDefinition> resolveSlot(
+      SimulationImprovementCandidate candidate, Long draftVersionId) {
+    String key = candidate.getTargetElementKey();
+    if (key == null && candidate.getTargetElementId() != null) {
+      key =
+          slotDefinitionRepository
+              .findByIdAndDomainPackVersionId(
+                  candidate.getTargetElementId(), candidate.getDomainPackVersionId())
+              .map(SlotDefinition::getSlotCode)
+              .orElse(null);
+    }
+    if (key != null) {
+      return slotDefinitionRepository.findByDomainPackVersionIdAndSlotCode(draftVersionId, key);
+    }
+    return candidate.getTargetElementId() == null
+        ? Optional.empty()
+        : slotDefinitionRepository.findByIdAndDomainPackVersionId(
+            candidate.getTargetElementId(), draftVersionId);
+  }
+
+  private Optional<PolicyDefinition> resolvePolicy(
+      SimulationImprovementCandidate candidate, Long draftVersionId) {
+    String key = candidate.getTargetElementKey();
+    if (key == null && candidate.getTargetElementId() != null) {
+      key =
+          policyDefinitionRepository
+              .findByIdAndDomainPackVersionId(
+                  candidate.getTargetElementId(), candidate.getDomainPackVersionId())
+              .map(PolicyDefinition::getPolicyCode)
+              .orElse(null);
+    }
+    if (key != null) {
+      return policyDefinitionRepository.findByDomainPackVersionIdAndPolicyCode(draftVersionId, key);
+    }
+    return candidate.getTargetElementId() == null
+        ? Optional.empty()
+        : policyDefinitionRepository.findByIdAndDomainPackVersionId(
+            candidate.getTargetElementId(), draftVersionId);
+  }
+
+  private Optional<RiskDefinition> resolveRisk(
+      SimulationImprovementCandidate candidate, Long draftVersionId) {
+    String key = candidate.getTargetElementKey();
+    if (key == null && candidate.getTargetElementId() != null) {
+      key =
+          riskDefinitionRepository
+              .findByIdAndDomainPackVersionId(
+                  candidate.getTargetElementId(), candidate.getDomainPackVersionId())
+              .map(RiskDefinition::getRiskCode)
+              .orElse(null);
+    }
+    if (key != null) {
+      return riskDefinitionRepository.findByDomainPackVersionIdAndRiskCode(draftVersionId, key);
+    }
+    return candidate.getTargetElementId() == null
+        ? Optional.empty()
+        : riskDefinitionRepository.findByIdAndDomainPackVersionId(
+            candidate.getTargetElementId(), draftVersionId);
+  }
+
+  private Optional<WorkflowDefinition> resolveWorkflow(
+      SimulationImprovementCandidate candidate, Long draftVersionId) {
+    String key = candidate.getTargetElementKey();
+    if (key == null && candidate.getTargetElementId() != null) {
+      key =
+          workflowDefinitionRepository
+              .findByIdAndDomainPackVersionId(
+                  candidate.getTargetElementId(), candidate.getDomainPackVersionId())
+              .map(WorkflowDefinition::getWorkflowCode)
+              .orElse(null);
+    }
+    if (key != null) {
+      return workflowDefinitionRepository.findByDomainPackVersionIdAndWorkflowCode(
+          draftVersionId, key);
+    }
+    return candidate.getTargetElementId() == null
+        ? Optional.empty()
+        : workflowDefinitionRepository.findByIdAndDomainPackVersionId(
+            candidate.getTargetElementId(), draftVersionId);
+  }
+
+  private BadRequestException targetNotFound(SimulationImprovementCandidate candidate) {
+    return new BadRequestException(
+        "SIMULATION_CANDIDATE_TARGET_NOT_FOUND",
+        "개선 후보를 반영할 draft 대상 요소를 찾을 수 없습니다: " + candidate.getId());
+  }
+
+  private BadRequestException unsupportedTarget(SimulationImprovementCandidate candidate) {
+    return new BadRequestException(
+        "SIMULATION_CANDIDATE_TARGET_UNSUPPORTED",
+        "변경 대상 요소를 명시해야 승인할 수 있습니다: " + candidate.getId());
+  }
+}

--- a/backend/src/test/java/com/init/workflowruntime/application/SimulationImprovementCandidateServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/SimulationImprovementCandidateServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -102,28 +103,47 @@ class SimulationImprovementCandidateServiceTest {
   @Mock private WorkflowMatchingProfileBuildRequestService profileBuildRequestService;
 
   private SimulationImprovementCandidateService service;
+  private SimulationImprovementDraftPatchService draftPatchService;
+  private SimulationImprovementCandidateReviewTaskService reviewTaskService;
+  private SimulationImprovementCandidateDecisionService decisionService;
 
   @BeforeEach
   void setUp() {
-    service =
-        new SimulationImprovementCandidateService(
-            feedbackRepository,
-            candidateRepository,
-            chatSessionRepository,
-            workspaceMemberRepository,
+    ObjectMapper objectMapper = new ObjectMapper();
+    Clock clock = Clock.systemDefaultZone();
+    reviewTaskService =
+        new SimulationImprovementCandidateReviewTaskService(
+            reviewSessionRepository,
+            reviewTaskRepository,
+            reviewDecisionRepository,
+            objectMapper,
+            clock);
+    draftPatchService =
+        new SimulationImprovementDraftPatchService(
             domainPackVersionRepository,
             domainPackVersionCloneService,
             intentDefinitionRepository,
             slotDefinitionRepository,
             policyDefinitionRepository,
             riskDefinitionRepository,
-            workflowDefinitionRepository,
-            reviewSessionRepository,
-            reviewTaskRepository,
-            reviewDecisionRepository,
+            workflowDefinitionRepository);
+    decisionService =
+        new SimulationImprovementCandidateDecisionService(
+            candidateRepository,
+            feedbackRepository,
+            reviewTaskService,
+            draftPatchService,
             profileBuildRequestService,
-            new ObjectMapper(),
-            Clock.systemDefaultZone());
+            clock);
+    service =
+        new SimulationImprovementCandidateService(
+            feedbackRepository,
+            candidateRepository,
+            chatSessionRepository,
+            workspaceMemberRepository,
+            reviewTaskService,
+            decisionService,
+            objectMapper);
   }
 
   @Test
@@ -578,6 +598,66 @@ class SimulationImprovementCandidateServiceTest {
   }
 
   @Test
+  @DisplayName("approve: profile rebuild enqueue 실패 시 후보와 feedback을 terminal 상태로 저장하지 않는다")
+  void shouldNotPersistApprovalStateWhenProfileEnqueueFails() {
+    givenMembership();
+    SimulationFeedback feedback =
+        withFeedbackId(feedback(SimulationFeedbackType.MISSING_SLOT_QUESTION), FEEDBACK_ID);
+    feedback.markCandidateCreated();
+    SimulationImprovementCandidate candidate =
+        withCandidateId(
+            SimulationImprovementCandidate.create(
+                WORKSPACE_ID,
+                VERSION_ID,
+                FEEDBACK_ID,
+                SESSION_ID,
+                2L,
+                new SimulationImprovementCandidateDraft(
+                    SimulationImprovementCandidateType.SLOT_QUESTION,
+                    SimulationImprovementCandidateTargetType.SLOT,
+                    null,
+                    "order_number",
+                    "주문번호를 묻지 않았습니다.",
+                    "주문번호를 먼저 요청합니다.",
+                    "simulation feedback #900"),
+                USER_ID),
+            1000L);
+    candidate.submitForReview(2000L, 3000L);
+    DomainPackVersion draftVersion =
+        DomainPackVersion.ofForTest(VERSION_ID, 50L, DomainPackVersion.STATUS_DRAFT);
+    SlotDefinition slot =
+        SlotDefinition.create(
+            VERSION_ID, "order_number", "주문번호", "기존 설명", "STRING", false, "{}", null, "{}");
+    ReviewTask task = reviewTask(2000L, candidate.getId(), 3000L);
+
+    given(candidateRepository.findById(1000L)).willReturn(Optional.of(candidate));
+    given(feedbackRepository.findByIdForUpdate(FEEDBACK_ID)).willReturn(Optional.of(feedback));
+    given(reviewTaskRepository.findById(3000L)).willReturn(Optional.of(task));
+    given(domainPackVersionRepository.findByIdForUpdate(VERSION_ID))
+        .willReturn(Optional.of(draftVersion));
+    given(slotDefinitionRepository.findByDomainPackVersionIdAndSlotCode(VERSION_ID, "order_number"))
+        .willReturn(Optional.of(slot));
+    willThrow(new IllegalStateException("profile enqueue failed"))
+        .given(profileBuildRequestService)
+        .enqueue(VERSION_ID, "SIMULATION_CANDIDATE_APPLIED");
+
+    assertThatThrownBy(
+            () ->
+                service.approve(
+                    new ApproveSimulationImprovementCandidateCommand(
+                        WORKSPACE_ID, USER_ID, 1000L, "반영합니다.")))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("profile enqueue failed");
+
+    assertThat(candidate.getStatus())
+        .isEqualTo(SimulationImprovementCandidateStatus.READY_FOR_REVIEW);
+    assertThat(feedback.getStatus()).isEqualTo(SimulationFeedbackStatus.CANDIDATE_CREATED);
+    verify(candidateRepository, never()).save(any());
+    verify(feedbackRepository, never()).save(any());
+    verifyNoInteractions(reviewDecisionRepository);
+  }
+
+  @Test
   @DisplayName("approve: INTENT 후보를 draft intent description에 반영한다")
   void shouldApproveIntentCandidate() {
     SimulationImprovementCandidate candidate =
@@ -935,6 +1015,30 @@ class SimulationImprovementCandidateServiceTest {
                         WORKSPACE_ID, USER_ID, 1000L, null)))
         .isInstanceOf(BadRequestException.class)
         .hasMessageContaining("READY_FOR_REVIEW 후보");
+  }
+
+  @Test
+  @DisplayName("approve: 이미 APPLIED 처리된 후보는 다시 승인할 수 없다")
+  void shouldRejectApproveWhenCandidateAlreadyApplied() {
+    givenMembership();
+    SimulationFeedback feedback =
+        withFeedbackId(feedback(SimulationFeedbackType.OTHER), FEEDBACK_ID);
+    feedback.markCandidateCreated();
+    SimulationImprovementCandidate candidate = withCandidateId(candidate(feedback), 1000L);
+    candidate.submitForReview(2000L, 3000L);
+    candidate.markApplied(VERSION_ID, USER_ID, "이미 반영됨", OffsetDateTime.now());
+    given(candidateRepository.findById(1000L)).willReturn(Optional.of(candidate));
+    given(feedbackRepository.findByIdForUpdate(FEEDBACK_ID)).willReturn(Optional.of(feedback));
+
+    assertThatThrownBy(
+            () ->
+                service.approve(
+                    new ApproveSimulationImprovementCandidateCommand(
+                        WORKSPACE_ID, USER_ID, 1000L, null)))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining("READY_FOR_REVIEW 후보");
+
+    verifyNoInteractions(domainPackVersionRepository, profileBuildRequestService);
   }
 
   @Test


### PR DESCRIPTION
Closes #611

## 변경 사항
- 시뮬레이션 개선 후보 승인/반려 상태 전이를 전담 서비스로 분리했습니다.
- review task 생성/결정 기록과 domain pack draft patch 적용 책임을 각각 별도 서비스로 분리했습니다.
- 승인 시 profile rebuild enqueue 실패가 후보/피드백 상태 저장과 review decision 기록으로 이어지지 않도록 기존 트랜잭션 결과를 테스트로 고정했습니다.

## 검증
- `git diff --check`
- `docker run --rm -v /Users/owen/.codex/worktrees/3480/ostone/backend:/workspace -v /Users/owen/.gradle:/root/.gradle -w /workspace eclipse-temurin:21-jdk ./gradlew spotlessCheck`
- `docker run --rm -v /Users/owen/.codex/worktrees/3480/ostone/backend:/workspace -v /Users/owen/.gradle:/root/.gradle -w /workspace eclipse-temurin:21-jdk ./gradlew test --tests com.init.workflowruntime.application.SimulationImprovementCandidateServiceTest`

## 참고
- 로컬 호스트에는 Java 21 toolchain이 없어 backend 검증은 `eclipse-temurin:21-jdk` 컨테이너에서 실행했습니다.
- pre-commit hook은 staged Java 절대 경로가 `pnpm run format:backend:check`를 통해 Gradle task 인자로 전달되어 실패했습니다. 동일한 Spotless 검사는 위 Docker 환경에서 통과했습니다.