### PR TITLE
refactor(workflow-runtime): 매칭 JSON fallback 관측성을 보장

### DIFF
--- a/.agent/specs/608.md
+++ b/.agent/specs/608.md
@@ -1,0 +1,74 @@
+# Workflow Runtime 매칭 책임 분리
+
+## Goal
+
+`WorkflowMatchingService`가 담당하던 매칭 오케스트레이션, 후보 조회, 점수 산정, decision 기록, metric, JSON fallback 책임을 분리해 기존 매칭 결과는 유지하면서 route/intent JSON parse 실패를 관측 가능하게 만든다.
+
+## Problem
+
+현재 `WorkflowMatchingService`는 세션 조회, redaction, signal guard, query embedding, 후보 검색, rerank, decision 기록, metric 처리를 한 클래스에서 수행한다. 또한 route/intent 조건 JSON이나 workflow meta JSON을 파싱할 때 실패하면 빈 객체로 조용히 대체되어, 매칭 품질 저하가 JSON 입력 문제인지 점수 산정 문제인지 추적하기 어렵다.
+
+## Scope
+
+- `backend/src/main/java/com/init/workflowruntime/application/matching/WorkflowMatchingService.java`는 매칭 유스케이스 오케스트레이션 중심으로 유지한다.
+- matching core, profile candidate provider, decision recorder, metric 책임을 `backend/src/main/java/com/init/workflowruntime/application/matching/` 내부 collaborator로 분리한다.
+- route/intent 조건 JSON 및 matching profile text 생성에 쓰이는 JSON parse fallback 정책을 공통화한다.
+- JSON parse 실패 시 raw JSON을 노출하지 않고 로그와 metric으로 fallback 발생 source를 관측할 수 있게 한다.
+- 기존 matching result status, selected workflow/intent, decision log 기록 의미는 보존한다.
+- `backend/src/test/java/com/init/workflowruntime/application/matching/`의 단위 테스트로 기존 동작과 malformed JSON fallback 관측을 확인한다.
+
+## Non-goals
+
+- 매칭 점수 가중치, threshold 기본값, 후보 조회 SQL, embedding provider/model을 변경하지 않는다.
+- `runtime.workflow_match_decision` 테이블 스키마나 저장 payload 계약을 변경하지 않는다.
+- workflow runtime presentation API, WebSocket, workflow execution 동작을 변경하지 않는다.
+- frontend 또는 ML pipeline 코드는 변경하지 않는다.
+
+## Affected Paths
+
+- `backend/src/main/java/com/init/workflowruntime/application/matching/WorkflowMatchingService.java`
+- `backend/src/main/java/com/init/workflowruntime/application/matching/WorkflowMatchingProfileTextFactory.java`
+- `backend/src/main/java/com/init/workflowruntime/application/matching/WorkflowMatchingCore.java`
+- `backend/src/main/java/com/init/workflowruntime/application/matching/WorkflowMatchingEvaluation.java`
+- `backend/src/main/java/com/init/workflowruntime/application/matching/WorkflowMatchingJsonParser.java`
+- `backend/src/main/java/com/init/workflowruntime/application/matching/WorkflowMatchingMetrics.java`
+- `backend/src/main/java/com/init/workflowruntime/application/matching/WorkflowMatchingProfileCandidateProvider.java`
+- `backend/src/main/java/com/init/workflowruntime/application/matching/WorkflowMatchingTextSignals.java`
+- `backend/src/main/java/com/init/workflowruntime/application/matching/WorkflowMatchDecisionRecorder.java`
+- `backend/src/test/java/com/init/workflowruntime/application/matching/WorkflowMatchingServiceTest.java`
+- `backend/src/test/java/com/init/workflowruntime/application/matching/WorkflowMatchingProfileTextFactoryTest.java`
+- `backend/src/test/java/com/init/workflowruntime/application/matching/WorkflowMatchingProfileBuildWorkerTest.java`
+
+## Requirements
+
+1. `WorkflowMatchingService.match(...)`는 기존처럼 embedding 비활성화, insufficient context, profile missing, successful matching, runtime error fallback을 처리해야 한다.
+2. 후보 count, query embedding cache, nearest active search, lexical search query 생성은 profile candidate provider 책임으로 분리되어야 한다.
+3. rerank, route/intent entry condition 평가, confusion type 결정, final result decision은 matching core 책임으로 분리되어야 한다.
+4. decision log JSON 직렬화와 failure reason 결정은 decision recorder 책임으로 분리되어야 한다.
+5. matching metric 증가는 metric 전용 collaborator로 분리되어야 한다.
+6. route/intent JSON parse 실패는 빈 객체 fallback을 유지하되, fallback source를 로그와 `workflow_matching.json_fallback` metric tag로 남겨야 한다.
+7. malformed JSON fallback 때문에 전체 match가 ERROR로 끝나면 안 되며, 기존 scoring fallback 의미와 decision log 기록은 유지되어야 한다.
+
+## Data/API Impact
+
+- REST API, WebSocket API, DB schema 변경은 없다.
+- `runtime.workflow_match_decision` 기록 필드와 기존 JSON payload 구조는 유지한다.
+- 새로운 metric `workflow_matching.json_fallback{source=...}`가 추가된다.
+
+## Acceptance Criteria
+
+- `WorkflowMatchingService` 생성자와 본문에서 profile repository, decision repository, `ObjectMapper`, `MeterRegistry`, `Clock` 세부 책임이 직접 섞이지 않는다.
+- route/intent JSON parse 실패 시 match는 fallback으로 계속 진행하고, JSON fallback metric이 증가한다.
+- `WorkflowMatchingProfileTextFactory`도 동일 parser를 사용해 malformed JSON을 조용히 삼키지 않는다.
+- 기존 `WorkflowMatchingServiceTest`의 주요 matching 시나리오가 계속 통과한다.
+- JSON parse 실패 케이스를 확인하는 단위 테스트가 추가된다.
+
+## Validation
+
+- `cd backend && ./gradlew test --tests com.init.workflowruntime.application.matching.WorkflowMatchingServiceTest --tests com.init.workflowruntime.application.matching.WorkflowMatchingProfileTextFactoryTest`
+- `cd backend && ./gradlew test --tests com.init.workflowruntime.application.matching.*`
+- `git diff --check`
+
+## Open Questions
+
+- 없음. 이슈 본문과 참고 위치만으로 backend application-layer refactor 범위와 fallback 관측 요구가 결정된다.

--- a/backend/src/main/java/com/init/workflowruntime/application/matching/WorkflowMatchDecisionRecorder.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/matching/WorkflowMatchDecisionRecorder.java
@@ -1,0 +1,180 @@
+package com.init.workflowruntime.application.matching;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.init.workflowruntime.domain.ChatSession;
+import com.init.workflowruntime.infrastructure.persistence.WorkflowMatchDecisionJdbcRepository;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.stereotype.Component;
+
+@Component
+public class WorkflowMatchDecisionRecorder {
+
+  private final EmbeddingProperties properties;
+  private final WorkflowMatchDecisionJdbcRepository decisionRepository;
+  private final ObjectMapper objectMapper;
+
+  public WorkflowMatchDecisionRecorder(
+      EmbeddingProperties properties,
+      WorkflowMatchDecisionJdbcRepository decisionRepository,
+      ObjectMapper objectMapper) {
+    this.properties = properties;
+    this.decisionRepository = decisionRepository;
+    this.objectMapper = objectMapper;
+  }
+
+  public void recordDecision(
+      ChatSession session,
+      String textHash,
+      WorkflowMatchResult result,
+      List<WorkflowMatchCandidate> ranked) {
+    Optional<WorkflowMatchCandidate> selected =
+        "CONFIDENT".equals(result.status())
+            ? result.candidates().stream().findFirst()
+            : Optional.empty();
+    Optional<WorkflowMatchCandidate> top = ranked.stream().findFirst();
+    decisionRepository.record(
+        session.getId(),
+        session.getDomainPackVersionId(),
+        selected.map(WorkflowMatchCandidate::workflowDefinitionId).orElse(null),
+        selected.map(WorkflowMatchCandidate::intentDefinitionId).orElse(null),
+        result.status(),
+        top.map(WorkflowMatchCandidate::confidence).orElse(0.0),
+        textHash,
+        profileVersion(ranked),
+        properties.providerOrDefault(),
+        properties.modelOrDefault(),
+        properties.bedrockRegionOrDefault(),
+        thresholdJson(),
+        scoreBreakdownJson(top.orElse(null)),
+        candidatesJson(ranked),
+        failureReason(result, top.orElse(null)));
+  }
+
+  public void recordNoCandidate(ChatSession session, String textHash, String reason) {
+    decisionRepository.record(
+        session.getId(),
+        session.getDomainPackVersionId(),
+        null,
+        null,
+        "UNKNOWN",
+        0.0,
+        textHash,
+        null,
+        properties.providerOrDefault(),
+        properties.modelOrDefault(),
+        properties.bedrockRegionOrDefault(),
+        thresholdJson(),
+        "{}",
+        "[]",
+        reason);
+  }
+
+  public void recordError(ChatSession session, String textHash, RuntimeException e) {
+    decisionRepository.record(
+        session.getId(),
+        session.getDomainPackVersionId(),
+        null,
+        null,
+        "ERROR",
+        0.0,
+        textHash,
+        null,
+        properties.providerOrDefault(),
+        properties.modelOrDefault(),
+        properties.bedrockRegionOrDefault(),
+        thresholdJson(),
+        "{}",
+        "[]",
+        e.getClass().getSimpleName());
+  }
+
+  private String failureReason(WorkflowMatchResult result, WorkflowMatchCandidate top) {
+    if ("CONFIDENT".equals(result.status())) {
+      return null;
+    }
+    if (top != null && top.autoRunBlockReason() != null) {
+      return top.autoRunBlockReason();
+    }
+    if (top != null && top.confusionType() != null) {
+      return "confusion_" + top.confusionType();
+    }
+    if ("AMBIGUOUS".equals(result.status())) {
+      return "below_confident_threshold_or_margin";
+    }
+    if ("UNKNOWN".equals(result.status())) {
+      return "below_ambiguous_threshold";
+    }
+    return null;
+  }
+
+  private String thresholdJson() {
+    ObjectNode node = objectMapper.createObjectNode();
+    node.put("confidentThreshold", properties.confidentThresholdOrDefault());
+    node.put("ambiguousThreshold", properties.ambiguousThresholdOrDefault());
+    node.put("confidentMargin", properties.confidentMarginOrDefault());
+    node.put("semanticFloor", properties.semanticFloorOrDefault());
+    node.put("routeEvidenceFloor", properties.routeEvidenceFloorOrDefault());
+    node.put("lexicalEvidenceFloor", properties.lexicalEvidenceFloorOrDefault());
+    node.put("autoRunReplayFitnessThreshold", properties.autoRunReplayFitnessThresholdOrDefault());
+    return node.toString();
+  }
+
+  private String scoreBreakdownJson(WorkflowMatchCandidate candidate) {
+    ObjectNode node = objectMapper.createObjectNode();
+    if (candidate == null) {
+      return node.toString();
+    }
+    node.put("semanticScore", candidate.semanticScore());
+    node.put("routeScore", candidate.routeScore());
+    node.put("lexicalScore", candidate.lexicalScore());
+    node.put("lexicalSearchScore", candidate.lexicalSearchScore());
+    node.put("qualityScore", candidate.qualityScore());
+    node.put("operationalPriorScore", candidate.operationalPriorScore());
+    node.put("confidence", candidate.confidence());
+    node.put("autoRunEligible", candidate.autoRunEligible());
+    node.put("blocked", candidate.blocked());
+    if (candidate.autoRunBlockReason() != null) {
+      node.put("autoRunBlockReason", candidate.autoRunBlockReason());
+    }
+    if (candidate.confusionType() != null) {
+      node.put("confusionType", candidate.confusionType());
+    }
+    return node.toString();
+  }
+
+  private String candidatesJson(List<WorkflowMatchCandidate> candidates) {
+    ArrayNode array = objectMapper.createArrayNode();
+    for (WorkflowMatchCandidate candidate : candidates.stream().limit(5).toList()) {
+      ObjectNode node = objectMapper.createObjectNode();
+      node.put("workflowDefinitionId", candidate.workflowDefinitionId());
+      node.put("intentDefinitionId", candidate.intentDefinitionId());
+      node.put("intentCode", candidate.intentCode());
+      node.put("workflowCode", candidate.workflowCode());
+      node.put("profileVersion", candidate.profileVersion());
+      node.put("confidence", candidate.confidence());
+      node.put("semanticScore", candidate.semanticScore());
+      node.put("routeScore", candidate.routeScore());
+      node.put("lexicalScore", candidate.lexicalScore());
+      node.put("lexicalSearchScore", candidate.lexicalSearchScore());
+      node.put("qualityScore", candidate.qualityScore());
+      node.put("operationalPriorScore", candidate.operationalPriorScore());
+      node.put("autoRunEligible", candidate.autoRunEligible());
+      node.put("blocked", candidate.blocked());
+      if (candidate.autoRunBlockReason() != null) {
+        node.put("autoRunBlockReason", candidate.autoRunBlockReason());
+      }
+      if (candidate.confusionType() != null) {
+        node.put("confusionType", candidate.confusionType());
+      }
+      array.add(node);
+    }
+    return array.toString();
+  }
+
+  private String profileVersion(List<WorkflowMatchCandidate> ranked) {
+    return ranked.isEmpty() ? null : ranked.get(0).profileVersion();
+  }
+}

--- a/backend/src/main/java/com/init/workflowruntime/application/matching/WorkflowMatchingCore.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/matching/WorkflowMatchingCore.java
@@ -1,0 +1,457 @@
+package com.init.workflowruntime.application.matching;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import org.springframework.stereotype.Component;
+
+@Component
+public class WorkflowMatchingCore {
+
+  private static final String MATCH_FAILURE_MESSAGE =
+      "요청하신 업무를 정확히 확인하지 못했습니다. 어떤 업무인지 조금 더 자세히 알려주세요.";
+
+  private final EmbeddingProperties properties;
+  private final WorkflowMatchingJsonParser jsonParser;
+  private final WorkflowMatchingTextSignals textSignals;
+
+  public WorkflowMatchingCore(
+      EmbeddingProperties properties,
+      WorkflowMatchingJsonParser jsonParser,
+      WorkflowMatchingTextSignals textSignals) {
+    this.properties = properties;
+    this.jsonParser = jsonParser;
+    this.textSignals = textSignals;
+  }
+
+  public WorkflowMatchingEvaluation evaluate(
+      List<WorkflowMatchingProfileCandidate> nearest, String redactedText) {
+    List<WorkflowMatchCandidate> ranked =
+        withConfusionTypes(
+            nearest.stream()
+                .map(candidate -> rerank(candidate, redactedText))
+                .sorted(Comparator.comparing(WorkflowMatchCandidate::confidence).reversed())
+                .toList());
+    return new WorkflowMatchingEvaluation(decide(ranked), ranked);
+  }
+
+  private WorkflowMatchResult decide(List<WorkflowMatchCandidate> ranked) {
+    if (ranked.isEmpty()) {
+      return WorkflowMatchResult.unknown(MATCH_FAILURE_MESSAGE);
+    }
+    WorkflowMatchCandidate top = ranked.get(0);
+    if (top.blocked()) {
+      return WorkflowMatchResult.blocked(MATCH_FAILURE_MESSAGE, ranked.stream().limit(3).toList());
+    }
+    WorkflowMatchCandidate second = ranked.size() > 1 ? ranked.get(1) : null;
+    double margin = second == null ? 1.0 : top.confidence() - second.confidence();
+    if (top.confidence() >= properties.confidentThresholdOrDefault()
+        && margin >= properties.confidentMarginOrDefault()
+        && top.autoRunEligible()) {
+      return WorkflowMatchResult.confident(top);
+    }
+    if (top.confidence() >= properties.ambiguousThresholdOrDefault()) {
+      return WorkflowMatchResult.ambiguous(
+          buildConfirmationQuestion(ranked), ranked.stream().limit(3).toList());
+    }
+    return WorkflowMatchResult.unknown(MATCH_FAILURE_MESSAGE);
+  }
+
+  private WorkflowMatchCandidate rerank(
+      WorkflowMatchingProfileCandidate candidate, String redactedText) {
+    RouteScore routeScore =
+        routeScore(
+            candidate.routeConditionJson(), candidate.intentEntryConditionJson(), redactedText);
+    double semanticScore = VectorUtils.clamp01(candidate.semanticScore());
+    double lexicalSearchScore = VectorUtils.clamp01(candidate.lexicalSearchScore());
+    double lexicalScore =
+        Math.max(lexicalScore(candidate.profileText(), redactedText), lexicalSearchScore);
+    JsonNode workflowMeta =
+        jsonParser.readTreeOrEmptyObject(candidate.workflowMetaJson(), "workflow_meta");
+    double qualityScore = qualityScore(candidate.qualityJson(), workflowMeta);
+    double operationalPriorScore = VectorUtils.clamp01(candidate.operationalPriorScore());
+    boolean workflowQualityEligible = autoRunEligible(workflowMeta);
+    String autoRunBlockReason =
+        autoRunBlockReason(routeScore, semanticScore, lexicalScore, workflowQualityEligible);
+    boolean autoRunEligible = autoRunBlockReason == null;
+    double baseConfidence =
+        VectorUtils.clamp01(
+            (semanticScore * 0.50)
+                + (routeScore.score() * 0.20)
+                + (lexicalScore * 0.15)
+                + (qualityScore * 0.10)
+                + (routeScore.confidence() * 0.03)
+                + (operationalPriorScore * 0.02));
+    double confidence = routeScore.blocked() ? Math.min(baseConfidence, 0.01) : baseConfidence;
+    return new WorkflowMatchCandidate(
+        candidate.workflowDefinitionId(),
+        candidate.intentDefinitionId(),
+        candidate.intentCode(),
+        candidate.intentName(),
+        candidate.workflowCode(),
+        candidate.workflowName(),
+        candidate.profileVersion(),
+        confidence,
+        semanticScore,
+        routeScore.score(),
+        lexicalScore,
+        lexicalSearchScore,
+        qualityScore,
+        operationalPriorScore,
+        autoRunEligible,
+        routeScore.blocked(),
+        autoRunBlockReason,
+        null);
+  }
+
+  private List<WorkflowMatchCandidate> withConfusionTypes(List<WorkflowMatchCandidate> ranked) {
+    if (ranked.isEmpty()) {
+      return ranked;
+    }
+    WorkflowMatchCandidate second = ranked.size() > 1 ? ranked.get(1) : null;
+    String topConfusionType = confusionType(ranked.get(0), second);
+    return ranked.stream()
+        .map(
+            candidate ->
+                withConfusionType(candidate, candidate == ranked.get(0) ? topConfusionType : null))
+        .toList();
+  }
+
+  private WorkflowMatchCandidate withConfusionType(
+      WorkflowMatchCandidate candidate, String confusionType) {
+    if (confusionType == null) {
+      return candidate;
+    }
+    return new WorkflowMatchCandidate(
+        candidate.workflowDefinitionId(),
+        candidate.intentDefinitionId(),
+        candidate.intentCode(),
+        candidate.intentName(),
+        candidate.workflowCode(),
+        candidate.workflowName(),
+        candidate.profileVersion(),
+        candidate.confidence(),
+        candidate.semanticScore(),
+        candidate.routeScore(),
+        candidate.lexicalScore(),
+        candidate.lexicalSearchScore(),
+        candidate.qualityScore(),
+        candidate.operationalPriorScore(),
+        candidate.autoRunEligible(),
+        candidate.blocked(),
+        candidate.autoRunBlockReason(),
+        confusionType);
+  }
+
+  private String confusionType(WorkflowMatchCandidate top, WorkflowMatchCandidate second) {
+    if (second == null) {
+      return null;
+    }
+    double margin = top.confidence() - second.confidence();
+    if (margin >= properties.confidentMarginOrDefault()) {
+      return null;
+    }
+    if (top.intentDefinitionId().equals(second.intentDefinitionId())) {
+      return "same_intent_workflow_overlap";
+    }
+    if (Math.abs(top.semanticScore() - second.semanticScore()) < 0.05
+        && Math.abs(top.lexicalScore() - second.lexicalScore()) < 0.10) {
+      return "cross_intent_semantic_overlap";
+    }
+    if (top.semanticScore() >= properties.semanticFloorOrDefault()
+        && top.routeScore() < properties.routeEvidenceFloorOrDefault()
+        && second.routeScore() >= properties.routeEvidenceFloorOrDefault()) {
+      return "semantic_route_conflict";
+    }
+    return "low_margin";
+  }
+
+  private RouteScore routeScore(
+      String routeConditionJson, String intentEntryConditionJson, String text) {
+    RouteScore route =
+        routeScore(jsonParser.readTreeOrEmptyObject(routeConditionJson, "route_condition"), text);
+    RouteScore intentEntry =
+        routeScore(
+            jsonParser.readTreeOrEmptyObject(intentEntryConditionJson, "intent_entry_condition"),
+            text);
+    if (!route.evidencePresent()) {
+      return intentEntry;
+    }
+    if (!intentEntry.evidencePresent()) {
+      return route;
+    }
+    return new RouteScore(
+        VectorUtils.clamp01((route.score() * 0.70) + (intentEntry.score() * 0.30)),
+        route.blocked() || intentEntry.blocked(),
+        route.requiredSatisfied() && intentEntry.requiredSatisfied(),
+        true,
+        Math.max(route.confidence(), intentEntry.confidence()));
+  }
+
+  private RouteScore routeScore(JsonNode route, String text) {
+    if (!route.isObject()) {
+      return new RouteScore(0.0, false, true, false, 0.0);
+    }
+    String normalizedText = textSignals.normalizeForMatch(text);
+    if (containsAnyActiveNegative(route.path("negativeTerms"), normalizedText)) {
+      return new RouteScore(0.0, true, false, hasRouteTerms(route), routeConfidence(route));
+    }
+    double required = termGroupCoverage(route.path("requiredTerms"), normalizedText);
+    double requiredAny = requiredAnyCoverage(route.path("requiredAnyTerms"), normalizedText);
+    double optional = termGroupCoverage(route.path("optionalTerms"), normalizedText);
+    boolean hasRequired = hasItems(route.path("requiredTerms"));
+    boolean hasRequiredAny = hasItems(route.path("requiredAnyTerms"));
+    boolean requiredSatisfied =
+        (!hasRequired || required >= 1.0) && (!hasRequiredAny || requiredAny > 0.0);
+    double requiredScore =
+        hasRequired && hasRequiredAny
+            ? (required * 0.70) + (requiredAny * 0.30)
+            : Math.max(required, requiredAny);
+    double score =
+        hasRequired || hasRequiredAny ? (requiredScore * 0.75) + (optional * 0.25) : optional;
+    return new RouteScore(
+        VectorUtils.clamp01(score),
+        false,
+        requiredSatisfied,
+        hasRouteTerms(route),
+        routeConfidence(route));
+  }
+
+  private double lexicalScore(String profileText, String text) {
+    Set<String> tokens = textSignals.lexicalTokens(text);
+    Set<String> profileTokens = textSignals.lexicalTokens(profileText);
+    int total = 0;
+    int matched = 0;
+    for (String token : tokens) {
+      total++;
+      if (matchesAnyProfileToken(token, profileTokens)) {
+        matched++;
+      }
+    }
+    return total == 0 ? 0.0 : VectorUtils.clamp01((double) matched / total);
+  }
+
+  private double qualityScore(String qualityJson, JsonNode workflowMeta) {
+    JsonNode quality = jsonParser.readTreeOrEmptyObject(qualityJson, "quality");
+    double score = quality.path("isPrimary").asBoolean(false) ? 0.7 : 0.5;
+    double confidence = workflowMeta.path("workflowConfidence").asDouble(0.0);
+    if (confidence > 0.0) {
+      score = Math.max(score, confidence);
+    }
+    return VectorUtils.clamp01(score);
+  }
+
+  private String autoRunBlockReason(
+      RouteScore routeScore,
+      double semanticScore,
+      double lexicalScore,
+      boolean workflowQualityEligible) {
+    if (routeScore.blocked()) {
+      return "negative_route_term";
+    }
+    if (!workflowQualityEligible) {
+      return "workflow_quality_gate";
+    }
+    if (!routeScore.requiredSatisfied()) {
+      return "missing_required_route_terms";
+    }
+    if (semanticScore < properties.semanticFloorOrDefault()) {
+      return "semantic_below_floor";
+    }
+    boolean routeEvidence = routeScore.score() >= properties.routeEvidenceFloorOrDefault();
+    boolean lexicalEvidence = lexicalScore >= properties.lexicalEvidenceFloorOrDefault();
+    if (!routeEvidence && !lexicalEvidence) {
+      return routeScore.evidencePresent() ? "weak_route_evidence" : "insufficient_lexical_evidence";
+    }
+    return null;
+  }
+
+  private boolean autoRunEligible(JsonNode workflowMeta) {
+    JsonNode matching = workflowMeta.path("matching");
+    if (matching.isObject() && matching.has("autoRunEligible")) {
+      return matching.path("autoRunEligible").asBoolean(false);
+    }
+    if (workflowMeta.has("autoRunEligible")) {
+      return workflowMeta.path("autoRunEligible").asBoolean(false);
+    }
+    return replayQualityEligible(workflowMeta);
+  }
+
+  private boolean replayQualityEligible(JsonNode meta) {
+    if (meta.path("needsHumanReview").asBoolean(false)
+        || meta.path("reviewOnlyCandidate").asBoolean(false)
+        || hasItems(meta.path("blockReasons"))
+        || hasItems(meta.path("reviewOnlyReasonCodes"))) {
+      return false;
+    }
+    double replayFitness = numeric(meta, "workflowReplayFitness", "workflow_replay_fitness");
+    double precision = numeric(meta, "workflowPrecision", "workflow_precision");
+    double threshold = properties.autoRunReplayFitnessThresholdOrDefault();
+    if (replayFitness <= 0.0) {
+      return false;
+    }
+    return replayFitness >= threshold && (precision <= 0.0 || precision >= 0.55);
+  }
+
+  private boolean hasItems(JsonNode node) {
+    return node.isArray() && !node.isEmpty();
+  }
+
+  private double numeric(JsonNode node, String... fields) {
+    for (String field : fields) {
+      JsonNode value = node.path(field);
+      if (value.isNumber()) {
+        return value.asDouble();
+      }
+    }
+    return 0.0;
+  }
+
+  private String buildConfirmationQuestion(List<WorkflowMatchCandidate> ranked) {
+    if (ranked.size() < 2) {
+      return "어떤 업무를 도와드리면 될까요?";
+    }
+    return "%s와 %s 중 어떤 문의에 가까울까요?"
+        .formatted(ranked.get(0).intentName(), ranked.get(1).intentName());
+  }
+
+  private boolean containsAnyActiveNegative(JsonNode terms, String normalizedText) {
+    for (TermGroup group : termGroups(terms)) {
+      for (String term : group.alternatives()) {
+        if (matchesTerm(normalizedText, term) && !isNegatedMention(normalizedText, term)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  private double termGroupCoverage(JsonNode terms, String normalizedText) {
+    List<TermGroup> groups = termGroups(terms);
+    if (groups.isEmpty()) {
+      return 0.0;
+    }
+    long matched = groups.stream().filter(group -> matchesTermGroup(normalizedText, group)).count();
+    return (double) matched / groups.size();
+  }
+
+  private double requiredAnyCoverage(JsonNode terms, String normalizedText) {
+    List<TermGroup> groups = termGroups(terms);
+    if (groups.isEmpty()) {
+      return 0.0;
+    }
+    return groups.stream().anyMatch(group -> matchesTermGroup(normalizedText, group)) ? 1.0 : 0.0;
+  }
+
+  private boolean matchesTermGroup(String normalizedText, TermGroup group) {
+    return group.alternatives().stream().anyMatch(term -> matchesTerm(normalizedText, term));
+  }
+
+  private List<TermGroup> termGroups(JsonNode terms) {
+    if (!terms.isArray() || terms.isEmpty()) {
+      return List.of();
+    }
+    return java.util.stream.StreamSupport.stream(terms.spliterator(), false)
+        .map(this::termGroup)
+        .filter(group -> !group.alternatives().isEmpty())
+        .toList();
+  }
+
+  private TermGroup termGroup(JsonNode node) {
+    Set<String> alternatives = new LinkedHashSet<>();
+    if (node.isTextual()) {
+      addTerm(alternatives, node.asText());
+    } else if (node.isArray()) {
+      node.forEach(value -> addTerm(alternatives, value.asText("")));
+    } else if (node.isObject()) {
+      addTerm(alternatives, node.path("term").asText(""));
+      addTerm(alternatives, node.path("value").asText(""));
+      addTermArray(alternatives, node.path("terms"));
+      addTermArray(alternatives, node.path("aliases"));
+      addTermArray(alternatives, node.path("anyOf"));
+    }
+    return new TermGroup(alternatives);
+  }
+
+  private void addTermArray(Set<String> terms, JsonNode values) {
+    if (!values.isArray()) {
+      return;
+    }
+    values.forEach(value -> addTerm(terms, value.asText("")));
+  }
+
+  private void addTerm(Set<String> terms, String value) {
+    String normalized = textSignals.normalizeForMatch(value);
+    if (normalized.length() >= 2) {
+      terms.add(normalized);
+    }
+  }
+
+  private boolean matchesTerm(String normalizedText, String term) {
+    if (term.isBlank()) {
+      return false;
+    }
+    for (String variant : textSignals.lexicalSearchVariants(term)) {
+      String normalizedVariant = textSignals.normalizeForMatch(variant);
+      if (!normalizedVariant.isBlank() && normalizedText.contains(normalizedVariant)) {
+        return true;
+      }
+    }
+    String compactText = normalizedText.replace(" ", "");
+    String compactTerm = term.replace(" ", "");
+    return compactTerm.length() >= 2 && compactText.contains(compactTerm);
+  }
+
+  private boolean isNegatedMention(String normalizedText, String term) {
+    int index = normalizedText.indexOf(term);
+    while (index >= 0) {
+      int from = Math.max(0, index - 8);
+      int to = Math.min(normalizedText.length(), index + term.length() + 12);
+      String context = normalizedText.substring(from, to).replace(" ", "");
+      if (context.contains(term.replace(" ", "") + "말고")
+          || context.contains(term.replace(" ", "") + "아니")
+          || context.contains(term.replace(" ", "") + "하지않")
+          || context.contains(term.replace(" ", "") + "하지마")) {
+        return true;
+      }
+      index = normalizedText.indexOf(term, index + term.length());
+    }
+    return false;
+  }
+
+  private boolean matchesAnyProfileToken(String token, Set<String> profileTokens) {
+    for (String profileToken : profileTokens) {
+      if (token.equals(profileToken)
+          || (token.length() >= 3 && profileToken.startsWith(token))
+          || (profileToken.length() >= 2 && token.startsWith(profileToken))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private boolean hasRouteTerms(JsonNode route) {
+    return hasItems(route.path("requiredTerms"))
+        || hasItems(route.path("requiredAnyTerms"))
+        || hasItems(route.path("optionalTerms"));
+  }
+
+  private double routeConfidence(JsonNode route) {
+    JsonNode confidence = route.path("confidence");
+    if (confidence.isNumber()) {
+      return VectorUtils.clamp01(confidence.asDouble());
+    }
+    return hasRouteTerms(route) ? 0.5 : 0.0;
+  }
+
+  private record TermGroup(Set<String> alternatives) {}
+
+  private record RouteScore(
+      double score,
+      boolean blocked,
+      boolean requiredSatisfied,
+      boolean evidencePresent,
+      double confidence) {}
+}

--- a/backend/src/main/java/com/init/workflowruntime/application/matching/WorkflowMatchingEvaluation.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/matching/WorkflowMatchingEvaluation.java
@@ -1,0 +1,6 @@
+package com.init.workflowruntime.application.matching;
+
+import java.util.List;
+
+public record WorkflowMatchingEvaluation(
+    WorkflowMatchResult result, List<WorkflowMatchCandidate> rankedCandidates) {}

--- a/backend/src/main/java/com/init/workflowruntime/application/matching/WorkflowMatchingJsonParser.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/matching/WorkflowMatchingJsonParser.java
@@ -1,0 +1,39 @@
+package com.init.workflowruntime.application.matching;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class WorkflowMatchingJsonParser {
+
+  private static final Logger log = LoggerFactory.getLogger(WorkflowMatchingJsonParser.class);
+
+  private final ObjectMapper objectMapper;
+  private final MeterRegistry meterRegistry;
+
+  public WorkflowMatchingJsonParser(ObjectMapper objectMapper, MeterRegistry meterRegistry) {
+    this.objectMapper = objectMapper;
+    this.meterRegistry = meterRegistry;
+  }
+
+  public JsonNode readTreeOrEmptyObject(String json, String source) {
+    if (json == null || json.isBlank()) {
+      return objectMapper.createObjectNode();
+    }
+    try {
+      return objectMapper.readTree(json);
+    } catch (JsonProcessingException e) {
+      log.warn(
+          "Workflow matching JSON fallback applied. source={}, error={}",
+          source,
+          e.getOriginalMessage());
+      meterRegistry.counter("workflow_matching.json_fallback", "source", source).increment();
+      return objectMapper.createObjectNode();
+    }
+  }
+}

--- a/backend/src/main/java/com/init/workflowruntime/application/matching/WorkflowMatchingMetrics.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/matching/WorkflowMatchingMetrics.java
@@ -1,0 +1,36 @@
+package com.init.workflowruntime.application.matching;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import org.springframework.stereotype.Component;
+
+@Component
+public class WorkflowMatchingMetrics {
+
+  private final MeterRegistry meterRegistry;
+
+  public WorkflowMatchingMetrics(MeterRegistry meterRegistry) {
+    this.meterRegistry = meterRegistry;
+  }
+
+  public Timer.Sample startMatchTimer() {
+    return Timer.start(meterRegistry);
+  }
+
+  public void stopMatchTimer(Timer.Sample sample) {
+    sample.stop(meterRegistry.timer("workflow_matching.match.latency"));
+  }
+
+  public void recordInsufficientContext() {
+    meterRegistry.counter("workflow_matching.insufficient_context").increment();
+    recordResult("UNKNOWN");
+  }
+
+  public void recordProfileMissing() {
+    meterRegistry.counter("workflow_matching.profile_missing").increment();
+  }
+
+  public void recordResult(String status) {
+    meterRegistry.counter("workflow_matching.result", "status", status).increment();
+  }
+}

--- a/backend/src/main/java/com/init/workflowruntime/application/matching/WorkflowMatchingProfileCandidateProvider.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/matching/WorkflowMatchingProfileCandidateProvider.java
@@ -1,0 +1,83 @@
+package com.init.workflowruntime.application.matching;
+
+import com.init.workflowruntime.infrastructure.persistence.WorkflowMatchingProfileJdbcRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Component;
+
+@Component
+public class WorkflowMatchingProfileCandidateProvider {
+
+  private static final int MAX_CACHE_SIZE = 1_000;
+
+  private final EmbeddingProperties properties;
+  private final EmbeddingClient embeddingClient;
+  private final WorkflowMatchingProfileJdbcRepository profileRepository;
+  private final WorkflowMatchingTextSignals textSignals;
+  private final Clock clock;
+  private final Map<String, CachedEmbedding> queryEmbeddingCache = new ConcurrentHashMap<>();
+
+  public WorkflowMatchingProfileCandidateProvider(
+      EmbeddingProperties properties,
+      EmbeddingClient embeddingClient,
+      WorkflowMatchingProfileJdbcRepository profileRepository,
+      WorkflowMatchingTextSignals textSignals,
+      Clock clock) {
+    this.properties = properties;
+    this.embeddingClient = embeddingClient;
+    this.profileRepository = profileRepository;
+    this.textSignals = textSignals;
+    this.clock = clock;
+  }
+
+  public boolean hasActiveProfiles(Long domainPackVersionId) {
+    return profileRepository.countActiveProfiles(domainPackVersionId) > 0;
+  }
+
+  public List<WorkflowMatchingProfileCandidate> findCandidates(
+      Long domainPackVersionId, String textHash, String redactedText) {
+    String embeddingLiteral = VectorUtils.toVectorLiteral(queryEmbedding(textHash, redactedText));
+    return profileRepository.findNearestActive(
+        domainPackVersionId,
+        embeddingLiteral,
+        textSignals.lexicalSearchQuery(redactedText),
+        properties.topKOrDefault());
+  }
+
+  private float[] queryEmbedding(String textHash, String redactedText) {
+    Instant now = Instant.now(clock);
+    CachedEmbedding cached = queryEmbeddingCache.get(textHash);
+    if (cached != null && cached.expiresAt().isAfter(now)) {
+      return cached.embedding();
+    }
+    float[] embedding = embeddingClient.embed(redactedText, EmbeddingInputType.SEARCH_QUERY);
+    VectorUtils.requireCohereDimension(embedding);
+    if (queryEmbeddingCache.size() > MAX_CACHE_SIZE) {
+      queryEmbeddingCache.clear();
+    }
+    queryEmbeddingCache.put(
+        textHash, new CachedEmbedding(embedding, now.plus(properties.queryCacheTtlOrDefault())));
+    return embedding;
+  }
+
+  private static final class CachedEmbedding {
+    private final float[] embedding;
+    private final Instant expiresAt;
+
+    private CachedEmbedding(float[] embedding, Instant expiresAt) {
+      this.embedding = embedding;
+      this.expiresAt = expiresAt;
+    }
+
+    private float[] embedding() {
+      return embedding;
+    }
+
+    private Instant expiresAt() {
+      return expiresAt;
+    }
+  }
+}

--- a/backend/src/main/java/com/init/workflowruntime/application/matching/WorkflowMatchingProfileTextFactory.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/matching/WorkflowMatchingProfileTextFactory.java
@@ -1,7 +1,6 @@
 package com.init.workflowruntime.application.matching;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.init.domainpack.domain.model.IntentDefinition;
 import com.init.domainpack.domain.model.WorkflowDefinition;
 import java.util.LinkedHashSet;
@@ -12,10 +11,10 @@ import org.springframework.stereotype.Component;
 public class WorkflowMatchingProfileTextFactory {
 
   private static final int MAX_PROFILE_TEXT_CHARS = 12_000;
-  private final ObjectMapper objectMapper;
+  private final WorkflowMatchingJsonParser jsonParser;
 
-  public WorkflowMatchingProfileTextFactory(ObjectMapper objectMapper) {
-    this.objectMapper = objectMapper;
+  public WorkflowMatchingProfileTextFactory(WorkflowMatchingJsonParser jsonParser) {
+    this.jsonParser = jsonParser;
   }
 
   public String build(IntentDefinition intent, WorkflowDefinition workflow) {
@@ -53,7 +52,7 @@ public class WorkflowMatchingProfileTextFactory {
   }
 
   private void appendRouteTerms(StringBuilder builder, Set<String> lexicalTerms, String json) {
-    JsonNode route = readTree(json);
+    JsonNode route = jsonParser.readTreeOrEmptyObject(json, "profile_route_condition");
     appendArray(builder, lexicalTerms, "route_required_terms", route.path("requiredTerms"));
     appendArray(builder, lexicalTerms, "route_required_any_terms", route.path("requiredAnyTerms"));
     appendArray(builder, lexicalTerms, "route_optional_terms", route.path("optionalTerms"));
@@ -62,7 +61,7 @@ public class WorkflowMatchingProfileTextFactory {
 
   private void appendIntentEntryTerms(
       StringBuilder builder, Set<String> lexicalTerms, String json) {
-    JsonNode entry = readTree(json);
+    JsonNode entry = jsonParser.readTreeOrEmptyObject(json, "profile_intent_entry_condition");
     appendArray(builder, lexicalTerms, "intent_entry_required_terms", entry.path("requiredTerms"));
     appendArray(
         builder, lexicalTerms, "intent_entry_required_any_terms", entry.path("requiredAnyTerms"));
@@ -72,7 +71,7 @@ public class WorkflowMatchingProfileTextFactory {
 
   private void appendEvidence(
       StringBuilder builder, Set<String> lexicalTerms, String label, String json) {
-    JsonNode evidence = readTree(json);
+    JsonNode evidence = jsonParser.readTreeOrEmptyObject(json, "profile_evidence");
     if (!evidence.isArray()) {
       return;
     }
@@ -85,7 +84,7 @@ public class WorkflowMatchingProfileTextFactory {
   }
 
   private void appendWorkflowSteps(StringBuilder builder, Set<String> lexicalTerms, String json) {
-    JsonNode graph = readTree(json);
+    JsonNode graph = jsonParser.readTreeOrEmptyObject(json, "profile_graph");
     Set<String> steps = new LinkedHashSet<>();
     collectWorkflowStepText(steps, graph.path("nodes"));
     collectWorkflowStepText(steps, graph.path("states"));
@@ -94,7 +93,7 @@ public class WorkflowMatchingProfileTextFactory {
   }
 
   private void appendQualityHints(StringBuilder builder, String json) {
-    JsonNode meta = readTree(json);
+    JsonNode meta = jsonParser.readTreeOrEmptyObject(json, "profile_meta");
     appendNumber(builder, "workflow_replay_fitness", meta, "workflowReplayFitness");
     appendNumber(builder, "workflow_precision", meta, "workflowPrecision");
     appendNumber(builder, "workflow_confidence", meta, "workflowConfidence");
@@ -223,16 +222,5 @@ public class WorkflowMatchingProfileTextFactory {
   private String textField(JsonNode node, String field) {
     JsonNode value = node.path(field);
     return value.isTextual() ? value.asText() : null;
-  }
-
-  private JsonNode readTree(String json) {
-    if (json == null || json.isBlank()) {
-      return objectMapper.createObjectNode();
-    }
-    try {
-      return objectMapper.readTree(json);
-    } catch (Exception e) {
-      return objectMapper.createObjectNode();
-    }
   }
 }

--- a/backend/src/main/java/com/init/workflowruntime/application/matching/WorkflowMatchingService.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/matching/WorkflowMatchingService.java
@@ -1,104 +1,43 @@
 package com.init.workflowruntime.application.matching;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.init.workflowruntime.domain.ChatSession;
 import com.init.workflowruntime.domain.ChatSessionRepository;
-import com.init.workflowruntime.infrastructure.persistence.WorkflowMatchDecisionJdbcRepository;
-import com.init.workflowruntime.infrastructure.persistence.WorkflowMatchingProfileJdbcRepository;
-import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
-import java.time.Clock;
-import java.time.Instant;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import org.springframework.stereotype.Service;
 
 @Service
 public class WorkflowMatchingService {
 
-  private static final int MAX_CACHE_SIZE = 1_000;
   private static final String CLARIFICATION_MESSAGE = "어떤 내용으로 문의하시려는지 조금 더 자세히 말씀해 주세요.";
-  private static final Set<String> LEXICAL_STOP_WORDS =
-      Set.of(
-          "고객",
-          "고객님",
-          "사용자",
-          "문의",
-          "문의하고",
-          "요청",
-          "요청하고",
-          "확인",
-          "확인하고",
-          "처리",
-          "처리하고",
-          "관련",
-          "하고",
-          "싶어요",
-          "합니다",
-          "해주세요",
-          "가능",
-          "가능한가",
-          "어떻게",
-          "무엇",
-          "무슨",
-          "어떤",
-          "그럼",
-          "그리고",
-          "근데",
-          "상담",
-          "도움",
-          "도와주세요",
-          "가능한가요",
-          "가능해요",
-          "user",
-          "assistant",
-          "system",
-          "counselor");
-  private static final Set<String> LOW_SIGNAL_TERMS =
-      Set.of(
-          "안녕", "안녕하세요", "안녕하십니까", "하이", "헬로", "hello", "hi", "네", "넵", "예", "응", "음", "아", "오",
-          "와", "감사", "감사합니다", "고마워", "고맙습니다");
+  private static final String MATCH_FAILURE_MESSAGE =
+      "요청하신 업무를 정확히 확인하지 못했습니다. 어떤 업무인지 조금 더 자세히 알려주세요.";
 
   private final EmbeddingProperties properties;
-  private final EmbeddingClient embeddingClient;
   private final SensitiveTextRedactor redactor;
   private final ChatSessionRepository chatSessionRepository;
-  private final WorkflowMatchingProfileJdbcRepository profileRepository;
-  private final WorkflowMatchDecisionJdbcRepository decisionRepository;
-  private final ObjectMapper objectMapper;
-  private final MeterRegistry meterRegistry;
-  private final Clock clock;
-  private final Map<String, CachedEmbedding> queryEmbeddingCache = new ConcurrentHashMap<>();
+  private final WorkflowMatchingProfileCandidateProvider candidateProvider;
+  private final WorkflowMatchingCore matchingCore;
+  private final WorkflowMatchDecisionRecorder decisionRecorder;
+  private final WorkflowMatchingMetrics metrics;
+  private final WorkflowMatchingTextSignals textSignals;
 
   public WorkflowMatchingService(
       EmbeddingProperties properties,
-      EmbeddingClient embeddingClient,
       SensitiveTextRedactor redactor,
       ChatSessionRepository chatSessionRepository,
-      WorkflowMatchingProfileJdbcRepository profileRepository,
-      WorkflowMatchDecisionJdbcRepository decisionRepository,
-      ObjectMapper objectMapper,
-      MeterRegistry meterRegistry,
-      Clock clock) {
+      WorkflowMatchingProfileCandidateProvider candidateProvider,
+      WorkflowMatchingCore matchingCore,
+      WorkflowMatchDecisionRecorder decisionRecorder,
+      WorkflowMatchingMetrics metrics,
+      WorkflowMatchingTextSignals textSignals) {
     this.properties = properties;
-    this.embeddingClient = embeddingClient;
     this.redactor = redactor;
     this.chatSessionRepository = chatSessionRepository;
-    this.profileRepository = profileRepository;
-    this.decisionRepository = decisionRepository;
-    this.objectMapper = objectMapper;
-    this.meterRegistry = meterRegistry;
-    this.clock = clock;
+    this.candidateProvider = candidateProvider;
+    this.matchingCore = matchingCore;
+    this.decisionRecorder = decisionRecorder;
+    this.metrics = metrics;
+    this.textSignals = textSignals;
   }
 
   public boolean isEnabled() {
@@ -111,7 +50,7 @@ public class WorkflowMatchingService {
       return WorkflowMatchResult.unavailable();
     }
 
-    Timer.Sample sample = Timer.start(meterRegistry);
+    Timer.Sample sample = metrics.startMatchTimer();
     ChatSession session =
         chatSessionRepository
             .findById(sessionId)
@@ -120,746 +59,40 @@ public class WorkflowMatchingService {
                     new IllegalArgumentException(
                         "Session not found for workflow matching: " + sessionId));
     String redactedText =
-        redactor.redact(nullToEmpty(latestUserMessage) + "\n" + nullToEmpty(conversationContext));
+        redactor.redact(
+            textSignals.nullToEmpty(latestUserMessage)
+                + "\n"
+                + textSignals.nullToEmpty(conversationContext));
     String textHash = VectorUtils.sha256(redactedText);
 
     try {
-      if (lacksIntentSignal(latestUserMessage, conversationContext)) {
-        recordNoCandidate(session, textHash, "insufficient_context");
-        meterRegistry.counter("workflow_matching.insufficient_context").increment();
-        meterRegistry.counter("workflow_matching.result", "status", "UNKNOWN").increment();
+      if (textSignals.lacksIntentSignal(latestUserMessage, conversationContext)) {
+        decisionRecorder.recordNoCandidate(session, textHash, "insufficient_context");
+        metrics.recordInsufficientContext();
         return WorkflowMatchResult.unknown(CLARIFICATION_MESSAGE);
       }
 
-      int activeProfiles = profileRepository.countActiveProfiles(session.getDomainPackVersionId());
-      if (activeProfiles == 0) {
-        recordNoCandidate(session, textHash, "profile_missing");
-        meterRegistry.counter("workflow_matching.profile_missing").increment();
+      if (!candidateProvider.hasActiveProfiles(session.getDomainPackVersionId())) {
+        decisionRecorder.recordNoCandidate(session, textHash, "profile_missing");
+        metrics.recordProfileMissing();
         return WorkflowMatchResult.unknown("아직 이 도메인팩의 매칭 프로필이 준비되지 않았습니다.");
       }
 
-      String embeddingLiteral = VectorUtils.toVectorLiteral(queryEmbedding(textHash, redactedText));
-      List<WorkflowMatchingProfileCandidate> nearest =
-          profileRepository.findNearestActive(
-              session.getDomainPackVersionId(),
-              embeddingLiteral,
-              lexicalSearchQuery(redactedText),
-              properties.topKOrDefault());
-      List<WorkflowMatchCandidate> ranked =
-          withConfusionTypes(
-              nearest.stream()
-                  .map(candidate -> rerank(candidate, redactedText))
-                  .sorted(Comparator.comparing(WorkflowMatchCandidate::confidence).reversed())
-                  .toList());
-
-      WorkflowMatchResult result = decide(ranked);
-      recordDecision(session, textHash, result, ranked);
-      meterRegistry.counter("workflow_matching.result", "status", result.status()).increment();
-      return result;
+      WorkflowMatchingEvaluation evaluation =
+          matchingCore.evaluate(
+              candidateProvider.findCandidates(
+                  session.getDomainPackVersionId(), textHash, redactedText),
+              redactedText);
+      decisionRecorder.recordDecision(
+          session, textHash, evaluation.result(), evaluation.rankedCandidates());
+      metrics.recordResult(evaluation.result().status());
+      return evaluation.result();
     } catch (RuntimeException e) {
-      recordError(session, textHash, e);
-      meterRegistry.counter("workflow_matching.result", "status", "ERROR").increment();
-      return WorkflowMatchResult.unknown("요청하신 업무를 정확히 확인하지 못했습니다. 어떤 업무인지 조금 더 자세히 알려주세요.");
+      decisionRecorder.recordError(session, textHash, e);
+      metrics.recordResult("ERROR");
+      return WorkflowMatchResult.unknown(MATCH_FAILURE_MESSAGE);
     } finally {
-      sample.stop(meterRegistry.timer("workflow_matching.match.latency"));
+      metrics.stopMatchTimer(sample);
     }
   }
-
-  private boolean lacksIntentSignal(String latestUserMessage, String conversationContext) {
-    String latest = normalizeForMatch(latestUserMessage);
-    if (latest.isBlank()) {
-      return !hasIntentSignal(conversationContext);
-    }
-    if (isLowSignalUtterance(latest)) {
-      return !hasIntentSignal(conversationContext);
-    }
-    return !hasIntentSignal(latestUserMessage) && !hasIntentSignal(conversationContext);
-  }
-
-  private boolean hasIntentSignal(String value) {
-    return lexicalTokens(value).stream().anyMatch(token -> !LOW_SIGNAL_TERMS.contains(token));
-  }
-
-  private boolean isLowSignalUtterance(String normalizedText) {
-    String compact = normalizedText.replace(" ", "");
-    if (LOW_SIGNAL_TERMS.contains(compact)) {
-      return true;
-    }
-    Set<String> tokens = rawTokens(normalizedText);
-    return !tokens.isEmpty() && tokens.stream().allMatch(LOW_SIGNAL_TERMS::contains);
-  }
-
-  private WorkflowMatchResult decide(List<WorkflowMatchCandidate> ranked) {
-    if (ranked.isEmpty()) {
-      return WorkflowMatchResult.unknown("요청하신 업무를 정확히 확인하지 못했습니다. 어떤 업무인지 조금 더 자세히 알려주세요.");
-    }
-    WorkflowMatchCandidate top = ranked.get(0);
-    if (top.blocked()) {
-      return WorkflowMatchResult.blocked(
-          "요청하신 업무를 정확히 확인하지 못했습니다. 어떤 업무인지 조금 더 자세히 알려주세요.", ranked.stream().limit(3).toList());
-    }
-    WorkflowMatchCandidate second = ranked.size() > 1 ? ranked.get(1) : null;
-    double margin = second == null ? 1.0 : top.confidence() - second.confidence();
-    if (top.confidence() >= properties.confidentThresholdOrDefault()
-        && margin >= properties.confidentMarginOrDefault()
-        && top.autoRunEligible()) {
-      return WorkflowMatchResult.confident(top);
-    }
-    if (top.confidence() >= properties.ambiguousThresholdOrDefault()) {
-      return WorkflowMatchResult.ambiguous(
-          buildConfirmationQuestion(ranked), ranked.stream().limit(3).toList());
-    }
-    return WorkflowMatchResult.unknown("요청하신 업무를 정확히 확인하지 못했습니다. 어떤 업무인지 조금 더 자세히 알려주세요.");
-  }
-
-  private WorkflowMatchCandidate rerank(
-      WorkflowMatchingProfileCandidate candidate, String redactedText) {
-    RouteScore routeScore =
-        routeScore(
-            candidate.routeConditionJson(), candidate.intentEntryConditionJson(), redactedText);
-    double semanticScore = VectorUtils.clamp01(candidate.semanticScore());
-    double lexicalSearchScore = VectorUtils.clamp01(candidate.lexicalSearchScore());
-    double lexicalScore =
-        Math.max(lexicalScore(candidate.profileText(), redactedText), lexicalSearchScore);
-    double qualityScore = qualityScore(candidate.qualityJson(), candidate.workflowMetaJson());
-    double operationalPriorScore = VectorUtils.clamp01(candidate.operationalPriorScore());
-    boolean workflowQualityEligible = autoRunEligible(candidate.workflowMetaJson());
-    String autoRunBlockReason =
-        autoRunBlockReason(routeScore, semanticScore, lexicalScore, workflowQualityEligible);
-    boolean autoRunEligible = autoRunBlockReason == null;
-    double baseConfidence =
-        VectorUtils.clamp01(
-            (semanticScore * 0.50)
-                + (routeScore.score() * 0.20)
-                + (lexicalScore * 0.15)
-                + (qualityScore * 0.10)
-                + (routeScore.confidence() * 0.03)
-                + (operationalPriorScore * 0.02));
-    double confidence = routeScore.blocked() ? Math.min(baseConfidence, 0.01) : baseConfidence;
-    return new WorkflowMatchCandidate(
-        candidate.workflowDefinitionId(),
-        candidate.intentDefinitionId(),
-        candidate.intentCode(),
-        candidate.intentName(),
-        candidate.workflowCode(),
-        candidate.workflowName(),
-        candidate.profileVersion(),
-        confidence,
-        semanticScore,
-        routeScore.score(),
-        lexicalScore,
-        lexicalSearchScore,
-        qualityScore,
-        operationalPriorScore,
-        autoRunEligible,
-        routeScore.blocked(),
-        autoRunBlockReason,
-        null);
-  }
-
-  private List<WorkflowMatchCandidate> withConfusionTypes(List<WorkflowMatchCandidate> ranked) {
-    if (ranked.isEmpty()) {
-      return ranked;
-    }
-    WorkflowMatchCandidate second = ranked.size() > 1 ? ranked.get(1) : null;
-    String topConfusionType = confusionType(ranked.get(0), second);
-    return ranked.stream()
-        .map(
-            candidate ->
-                withConfusionType(candidate, candidate == ranked.get(0) ? topConfusionType : null))
-        .toList();
-  }
-
-  private WorkflowMatchCandidate withConfusionType(
-      WorkflowMatchCandidate candidate, String confusionType) {
-    if (confusionType == null) {
-      return candidate;
-    }
-    return new WorkflowMatchCandidate(
-        candidate.workflowDefinitionId(),
-        candidate.intentDefinitionId(),
-        candidate.intentCode(),
-        candidate.intentName(),
-        candidate.workflowCode(),
-        candidate.workflowName(),
-        candidate.profileVersion(),
-        candidate.confidence(),
-        candidate.semanticScore(),
-        candidate.routeScore(),
-        candidate.lexicalScore(),
-        candidate.lexicalSearchScore(),
-        candidate.qualityScore(),
-        candidate.operationalPriorScore(),
-        candidate.autoRunEligible(),
-        candidate.blocked(),
-        candidate.autoRunBlockReason(),
-        confusionType);
-  }
-
-  private String confusionType(WorkflowMatchCandidate top, WorkflowMatchCandidate second) {
-    if (second == null) {
-      return null;
-    }
-    double margin = top.confidence() - second.confidence();
-    if (margin >= properties.confidentMarginOrDefault()) {
-      return null;
-    }
-    if (top.intentDefinitionId().equals(second.intentDefinitionId())) {
-      return "same_intent_workflow_overlap";
-    }
-    if (Math.abs(top.semanticScore() - second.semanticScore()) < 0.05
-        && Math.abs(top.lexicalScore() - second.lexicalScore()) < 0.10) {
-      return "cross_intent_semantic_overlap";
-    }
-    if (top.semanticScore() >= properties.semanticFloorOrDefault()
-        && top.routeScore() < properties.routeEvidenceFloorOrDefault()
-        && second.routeScore() >= properties.routeEvidenceFloorOrDefault()) {
-      return "semantic_route_conflict";
-    }
-    return "low_margin";
-  }
-
-  private RouteScore routeScore(
-      String routeConditionJson, String intentEntryConditionJson, String text) {
-    RouteScore route = routeScore(readTree(routeConditionJson), text);
-    RouteScore intentEntry = routeScore(readTree(intentEntryConditionJson), text);
-    if (!route.evidencePresent()) {
-      return intentEntry;
-    }
-    if (!intentEntry.evidencePresent()) {
-      return route;
-    }
-    return new RouteScore(
-        VectorUtils.clamp01((route.score() * 0.70) + (intentEntry.score() * 0.30)),
-        route.blocked() || intentEntry.blocked(),
-        route.requiredSatisfied() && intentEntry.requiredSatisfied(),
-        true,
-        Math.max(route.confidence(), intentEntry.confidence()));
-  }
-
-  private RouteScore routeScore(JsonNode route, String text) {
-    if (!route.isObject()) {
-      return new RouteScore(0.0, false, true, false, 0.0);
-    }
-    String normalizedText = normalizeForMatch(text);
-    if (containsAnyActiveNegative(route.path("negativeTerms"), normalizedText)) {
-      return new RouteScore(0.0, true, false, hasRouteTerms(route), routeConfidence(route));
-    }
-    double required = termGroupCoverage(route.path("requiredTerms"), normalizedText);
-    double requiredAny = requiredAnyCoverage(route.path("requiredAnyTerms"), normalizedText);
-    double optional = termGroupCoverage(route.path("optionalTerms"), normalizedText);
-    boolean hasRequired = hasItems(route.path("requiredTerms"));
-    boolean hasRequiredAny = hasItems(route.path("requiredAnyTerms"));
-    boolean requiredSatisfied =
-        (!hasRequired || required >= 1.0) && (!hasRequiredAny || requiredAny > 0.0);
-    double requiredScore =
-        hasRequired && hasRequiredAny
-            ? (required * 0.70) + (requiredAny * 0.30)
-            : Math.max(required, requiredAny);
-    double score =
-        hasRequired || hasRequiredAny ? (requiredScore * 0.75) + (optional * 0.25) : optional;
-    return new RouteScore(
-        VectorUtils.clamp01(score),
-        false,
-        requiredSatisfied,
-        hasRouteTerms(route),
-        routeConfidence(route));
-  }
-
-  private double lexicalScore(String profileText, String text) {
-    Set<String> tokens = lexicalTokens(text);
-    Set<String> profileTokens = lexicalTokens(profileText);
-    int total = 0;
-    int matched = 0;
-    for (String token : tokens) {
-      total++;
-      if (matchesAnyProfileToken(token, profileTokens)) {
-        matched++;
-      }
-    }
-    return total == 0 ? 0.0 : VectorUtils.clamp01((double) matched / total);
-  }
-
-  private double qualityScore(String qualityJson, String workflowMetaJson) {
-    JsonNode quality = readTree(qualityJson);
-    JsonNode workflowMeta = readTree(workflowMetaJson);
-    double score = quality.path("isPrimary").asBoolean(false) ? 0.7 : 0.5;
-    double confidence = workflowMeta.path("workflowConfidence").asDouble(0.0);
-    if (confidence > 0.0) {
-      score = Math.max(score, confidence);
-    }
-    return VectorUtils.clamp01(score);
-  }
-
-  private String autoRunBlockReason(
-      RouteScore routeScore,
-      double semanticScore,
-      double lexicalScore,
-      boolean workflowQualityEligible) {
-    if (routeScore.blocked()) {
-      return "negative_route_term";
-    }
-    if (!workflowQualityEligible) {
-      return "workflow_quality_gate";
-    }
-    if (!routeScore.requiredSatisfied()) {
-      return "missing_required_route_terms";
-    }
-    if (semanticScore < properties.semanticFloorOrDefault()) {
-      return "semantic_below_floor";
-    }
-    boolean routeEvidence = routeScore.score() >= properties.routeEvidenceFloorOrDefault();
-    boolean lexicalEvidence = lexicalScore >= properties.lexicalEvidenceFloorOrDefault();
-    if (!routeEvidence && !lexicalEvidence) {
-      return routeScore.evidencePresent() ? "weak_route_evidence" : "insufficient_lexical_evidence";
-    }
-    return null;
-  }
-
-  private boolean autoRunEligible(String workflowMetaJson) {
-    JsonNode meta = readTree(workflowMetaJson);
-    JsonNode matching = meta.path("matching");
-    if (matching.isObject() && matching.has("autoRunEligible")) {
-      return matching.path("autoRunEligible").asBoolean(false);
-    }
-    if (meta.has("autoRunEligible")) {
-      return meta.path("autoRunEligible").asBoolean(false);
-    }
-    return replayQualityEligible(meta);
-  }
-
-  private boolean replayQualityEligible(JsonNode meta) {
-    if (meta.path("needsHumanReview").asBoolean(false)
-        || meta.path("reviewOnlyCandidate").asBoolean(false)
-        || hasItems(meta.path("blockReasons"))
-        || hasItems(meta.path("reviewOnlyReasonCodes"))) {
-      return false;
-    }
-    double replayFitness = numeric(meta, "workflowReplayFitness", "workflow_replay_fitness");
-    double precision = numeric(meta, "workflowPrecision", "workflow_precision");
-    double threshold = properties.autoRunReplayFitnessThresholdOrDefault();
-    if (replayFitness <= 0.0) {
-      return false;
-    }
-    return replayFitness >= threshold && (precision <= 0.0 || precision >= 0.55);
-  }
-
-  private boolean hasItems(JsonNode node) {
-    return node.isArray() && !node.isEmpty();
-  }
-
-  private double numeric(JsonNode node, String... fields) {
-    for (String field : fields) {
-      JsonNode value = node.path(field);
-      if (value.isNumber()) {
-        return value.asDouble();
-      }
-    }
-    return 0.0;
-  }
-
-  private float[] queryEmbedding(String textHash, String redactedText) {
-    Instant now = Instant.now(clock);
-    CachedEmbedding cached = queryEmbeddingCache.get(textHash);
-    if (cached != null && cached.expiresAt().isAfter(now)) {
-      return cached.embedding();
-    }
-    float[] embedding = embeddingClient.embed(redactedText, EmbeddingInputType.SEARCH_QUERY);
-    VectorUtils.requireCohereDimension(embedding);
-    if (queryEmbeddingCache.size() > MAX_CACHE_SIZE) {
-      queryEmbeddingCache.clear();
-    }
-    queryEmbeddingCache.put(
-        textHash, new CachedEmbedding(embedding, now.plus(properties.queryCacheTtlOrDefault())));
-    return embedding;
-  }
-
-  private void recordDecision(
-      ChatSession session,
-      String textHash,
-      WorkflowMatchResult result,
-      List<WorkflowMatchCandidate> ranked) {
-    Optional<WorkflowMatchCandidate> selected =
-        "CONFIDENT".equals(result.status())
-            ? result.candidates().stream().findFirst()
-            : Optional.empty();
-    Optional<WorkflowMatchCandidate> top = ranked.stream().findFirst();
-    decisionRepository.record(
-        session.getId(),
-        session.getDomainPackVersionId(),
-        selected.map(WorkflowMatchCandidate::workflowDefinitionId).orElse(null),
-        selected.map(WorkflowMatchCandidate::intentDefinitionId).orElse(null),
-        result.status(),
-        top.map(WorkflowMatchCandidate::confidence).orElse(0.0),
-        textHash,
-        profileVersion(ranked),
-        properties.providerOrDefault(),
-        properties.modelOrDefault(),
-        properties.bedrockRegionOrDefault(),
-        thresholdJson(),
-        scoreBreakdownJson(top.orElse(null)),
-        candidatesJson(ranked),
-        failureReason(result, top.orElse(null)));
-  }
-
-  private String failureReason(WorkflowMatchResult result, WorkflowMatchCandidate top) {
-    if ("CONFIDENT".equals(result.status())) {
-      return null;
-    }
-    if (top != null && top.autoRunBlockReason() != null) {
-      return top.autoRunBlockReason();
-    }
-    if (top != null && top.confusionType() != null) {
-      return "confusion_" + top.confusionType();
-    }
-    if ("AMBIGUOUS".equals(result.status())) {
-      return "below_confident_threshold_or_margin";
-    }
-    if ("UNKNOWN".equals(result.status())) {
-      return "below_ambiguous_threshold";
-    }
-    return null;
-  }
-
-  private void recordNoCandidate(ChatSession session, String textHash, String reason) {
-    decisionRepository.record(
-        session.getId(),
-        session.getDomainPackVersionId(),
-        null,
-        null,
-        "UNKNOWN",
-        0.0,
-        textHash,
-        null,
-        properties.providerOrDefault(),
-        properties.modelOrDefault(),
-        properties.bedrockRegionOrDefault(),
-        thresholdJson(),
-        "{}",
-        "[]",
-        reason);
-  }
-
-  private void recordError(ChatSession session, String textHash, RuntimeException e) {
-    decisionRepository.record(
-        session.getId(),
-        session.getDomainPackVersionId(),
-        null,
-        null,
-        "ERROR",
-        0.0,
-        textHash,
-        null,
-        properties.providerOrDefault(),
-        properties.modelOrDefault(),
-        properties.bedrockRegionOrDefault(),
-        thresholdJson(),
-        "{}",
-        "[]",
-        e.getClass().getSimpleName());
-  }
-
-  private String buildConfirmationQuestion(List<WorkflowMatchCandidate> ranked) {
-    if (ranked.size() < 2) {
-      return "어떤 업무를 도와드리면 될까요?";
-    }
-    return "%s와 %s 중 어떤 문의에 가까울까요?"
-        .formatted(ranked.get(0).intentName(), ranked.get(1).intentName());
-  }
-
-  private boolean containsAnyActiveNegative(JsonNode terms, String normalizedText) {
-    for (TermGroup group : termGroups(terms)) {
-      for (String term : group.alternatives()) {
-        if (matchesTerm(normalizedText, term) && !isNegatedMention(normalizedText, term)) {
-          return true;
-        }
-      }
-    }
-    return false;
-  }
-
-  private double termGroupCoverage(JsonNode terms, String normalizedText) {
-    List<TermGroup> groups = termGroups(terms);
-    if (groups.isEmpty()) {
-      return 0.0;
-    }
-    long matched = groups.stream().filter(group -> matchesTermGroup(normalizedText, group)).count();
-    return (double) matched / groups.size();
-  }
-
-  private double requiredAnyCoverage(JsonNode terms, String normalizedText) {
-    List<TermGroup> groups = termGroups(terms);
-    if (groups.isEmpty()) {
-      return 0.0;
-    }
-    return groups.stream().anyMatch(group -> matchesTermGroup(normalizedText, group)) ? 1.0 : 0.0;
-  }
-
-  private boolean matchesTermGroup(String normalizedText, TermGroup group) {
-    return group.alternatives().stream().anyMatch(term -> matchesTerm(normalizedText, term));
-  }
-
-  private List<TermGroup> termGroups(JsonNode terms) {
-    if (!terms.isArray() || terms.isEmpty()) {
-      return List.of();
-    }
-    return java.util.stream.StreamSupport.stream(terms.spliterator(), false)
-        .map(this::termGroup)
-        .filter(group -> !group.alternatives().isEmpty())
-        .toList();
-  }
-
-  private TermGroup termGroup(JsonNode node) {
-    Set<String> alternatives = new LinkedHashSet<>();
-    if (node.isTextual()) {
-      addTerm(alternatives, node.asText());
-    } else if (node.isArray()) {
-      node.forEach(value -> addTerm(alternatives, value.asText("")));
-    } else if (node.isObject()) {
-      addTerm(alternatives, node.path("term").asText(""));
-      addTerm(alternatives, node.path("value").asText(""));
-      addTermArray(alternatives, node.path("terms"));
-      addTermArray(alternatives, node.path("aliases"));
-      addTermArray(alternatives, node.path("anyOf"));
-    }
-    return new TermGroup(alternatives);
-  }
-
-  private void addTermArray(Set<String> terms, JsonNode values) {
-    if (!values.isArray()) {
-      return;
-    }
-    values.forEach(value -> addTerm(terms, value.asText("")));
-  }
-
-  private void addTerm(Set<String> terms, String value) {
-    String normalized = normalizeForMatch(value);
-    if (normalized.length() >= 2) {
-      terms.add(normalized);
-    }
-  }
-
-  private boolean matchesTerm(String normalizedText, String term) {
-    if (term.isBlank()) {
-      return false;
-    }
-    for (String variant : lexicalSearchVariants(term)) {
-      String normalizedVariant = normalizeForMatch(variant);
-      if (!normalizedVariant.isBlank() && normalizedText.contains(normalizedVariant)) {
-        return true;
-      }
-    }
-    String compactText = normalizedText.replace(" ", "");
-    String compactTerm = term.replace(" ", "");
-    return compactTerm.length() >= 2 && compactText.contains(compactTerm);
-  }
-
-  private boolean isNegatedMention(String normalizedText, String term) {
-    int index = normalizedText.indexOf(term);
-    while (index >= 0) {
-      int from = Math.max(0, index - 8);
-      int to = Math.min(normalizedText.length(), index + term.length() + 12);
-      String context = normalizedText.substring(from, to).replace(" ", "");
-      if (context.contains(term.replace(" ", "") + "말고")
-          || context.contains(term.replace(" ", "") + "아니")
-          || context.contains(term.replace(" ", "") + "하지않")
-          || context.contains(term.replace(" ", "") + "하지마")) {
-        return true;
-      }
-      index = normalizedText.indexOf(term, index + term.length());
-    }
-    return false;
-  }
-
-  private JsonNode readTree(String json) {
-    if (json == null || json.isBlank()) {
-      return objectMapper.createObjectNode();
-    }
-    try {
-      return objectMapper.readTree(json);
-    } catch (Exception e) {
-      return objectMapper.createObjectNode();
-    }
-  }
-
-  private String thresholdJson() {
-    ObjectNode node = objectMapper.createObjectNode();
-    node.put("confidentThreshold", properties.confidentThresholdOrDefault());
-    node.put("ambiguousThreshold", properties.ambiguousThresholdOrDefault());
-    node.put("confidentMargin", properties.confidentMarginOrDefault());
-    node.put("semanticFloor", properties.semanticFloorOrDefault());
-    node.put("routeEvidenceFloor", properties.routeEvidenceFloorOrDefault());
-    node.put("lexicalEvidenceFloor", properties.lexicalEvidenceFloorOrDefault());
-    node.put("autoRunReplayFitnessThreshold", properties.autoRunReplayFitnessThresholdOrDefault());
-    return node.toString();
-  }
-
-  private String scoreBreakdownJson(WorkflowMatchCandidate candidate) {
-    ObjectNode node = objectMapper.createObjectNode();
-    if (candidate == null) {
-      return node.toString();
-    }
-    node.put("semanticScore", candidate.semanticScore());
-    node.put("routeScore", candidate.routeScore());
-    node.put("lexicalScore", candidate.lexicalScore());
-    node.put("lexicalSearchScore", candidate.lexicalSearchScore());
-    node.put("qualityScore", candidate.qualityScore());
-    node.put("operationalPriorScore", candidate.operationalPriorScore());
-    node.put("confidence", candidate.confidence());
-    node.put("autoRunEligible", candidate.autoRunEligible());
-    node.put("blocked", candidate.blocked());
-    if (candidate.autoRunBlockReason() != null) {
-      node.put("autoRunBlockReason", candidate.autoRunBlockReason());
-    }
-    if (candidate.confusionType() != null) {
-      node.put("confusionType", candidate.confusionType());
-    }
-    return node.toString();
-  }
-
-  private String candidatesJson(List<WorkflowMatchCandidate> candidates) {
-    ArrayNode array = objectMapper.createArrayNode();
-    for (WorkflowMatchCandidate candidate : candidates.stream().limit(5).toList()) {
-      ObjectNode node = objectMapper.createObjectNode();
-      node.put("workflowDefinitionId", candidate.workflowDefinitionId());
-      node.put("intentDefinitionId", candidate.intentDefinitionId());
-      node.put("intentCode", candidate.intentCode());
-      node.put("workflowCode", candidate.workflowCode());
-      node.put("profileVersion", candidate.profileVersion());
-      node.put("confidence", candidate.confidence());
-      node.put("semanticScore", candidate.semanticScore());
-      node.put("routeScore", candidate.routeScore());
-      node.put("lexicalScore", candidate.lexicalScore());
-      node.put("lexicalSearchScore", candidate.lexicalSearchScore());
-      node.put("qualityScore", candidate.qualityScore());
-      node.put("operationalPriorScore", candidate.operationalPriorScore());
-      node.put("autoRunEligible", candidate.autoRunEligible());
-      node.put("blocked", candidate.blocked());
-      if (candidate.autoRunBlockReason() != null) {
-        node.put("autoRunBlockReason", candidate.autoRunBlockReason());
-      }
-      if (candidate.confusionType() != null) {
-        node.put("confusionType", candidate.confusionType());
-      }
-      array.add(node);
-    }
-    return array.toString();
-  }
-
-  private String profileVersion(List<WorkflowMatchCandidate> ranked) {
-    return ranked.isEmpty() ? null : ranked.get(0).profileVersion();
-  }
-
-  private String nullToEmpty(String value) {
-    return value == null ? "" : value;
-  }
-
-  private Set<String> lexicalTokens(String value) {
-    Set<String> tokens = new LinkedHashSet<>();
-    Arrays.stream(nullToEmpty(value).toLowerCase(Locale.ROOT).split("[^0-9a-z가-힣]+"))
-        .filter(token -> token.length() >= 2)
-        .filter(token -> !LEXICAL_STOP_WORDS.contains(token))
-        .forEach(tokens::add);
-    return tokens;
-  }
-
-  private Set<String> rawTokens(String value) {
-    Set<String> tokens = new LinkedHashSet<>();
-    Arrays.stream(nullToEmpty(value).toLowerCase(Locale.ROOT).split("[^0-9a-z가-힣]+"))
-        .filter(token -> !token.isBlank())
-        .forEach(tokens::add);
-    return tokens;
-  }
-
-  private String normalizeForMatch(String value) {
-    return nullToEmpty(value)
-        .toLowerCase(Locale.ROOT)
-        .replaceAll("[^0-9a-z가-힣]+", " ")
-        .trim()
-        .replaceAll("\\s+", " ");
-  }
-
-  private boolean matchesAnyProfileToken(String token, Set<String> profileTokens) {
-    for (String profileToken : profileTokens) {
-      if (token.equals(profileToken)
-          || (token.length() >= 3 && profileToken.startsWith(token))
-          || (profileToken.length() >= 2 && token.startsWith(profileToken))) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  private String lexicalSearchQuery(String text) {
-    return lexicalTokens(text).stream()
-        .flatMap(token -> lexicalSearchVariants(token).stream())
-        .distinct()
-        .limit(12)
-        .map(this::quoteWebsearchTerm)
-        .reduce((left, right) -> left + " OR " + right)
-        .orElse("");
-  }
-
-  private Set<String> lexicalSearchVariants(String token) {
-    Set<String> variants = new LinkedHashSet<>();
-    variants.add(token);
-    if (token.endsWith("하고싶어요") && token.length() >= 7) {
-      variants.add(token.substring(0, token.length() - 5));
-    }
-    if (token.endsWith("하고") && token.length() >= 4) {
-      variants.add(token.substring(0, token.length() - 2));
-    }
-    if (token.endsWith("해요") && token.length() >= 4) {
-      variants.add(token.substring(0, token.length() - 2));
-    }
-    if (token.endsWith("합니다") && token.length() >= 5) {
-      variants.add(token.substring(0, token.length() - 3));
-    }
-    return variants;
-  }
-
-  private String quoteWebsearchTerm(String term) {
-    return "\"" + term.replace("\"", " ") + "\"";
-  }
-
-  private boolean hasRouteTerms(JsonNode route) {
-    return hasItems(route.path("requiredTerms"))
-        || hasItems(route.path("requiredAnyTerms"))
-        || hasItems(route.path("optionalTerms"));
-  }
-
-  private double routeConfidence(JsonNode route) {
-    JsonNode confidence = route.path("confidence");
-    if (confidence.isNumber()) {
-      return VectorUtils.clamp01(confidence.asDouble());
-    }
-    return hasRouteTerms(route) ? 0.5 : 0.0;
-  }
-
-  private static final class CachedEmbedding {
-    private final float[] embedding;
-    private final Instant expiresAt;
-
-    private CachedEmbedding(float[] embedding, Instant expiresAt) {
-      this.embedding = embedding;
-      this.expiresAt = expiresAt;
-    }
-
-    private float[] embedding() {
-      return embedding;
-    }
-
-    private Instant expiresAt() {
-      return expiresAt;
-    }
-  }
-
-  private record TermGroup(Set<String> alternatives) {}
-
-  private record RouteScore(
-      double score,
-      boolean blocked,
-      boolean requiredSatisfied,
-      boolean evidencePresent,
-      double confidence) {}
 }

--- a/backend/src/main/java/com/init/workflowruntime/application/matching/WorkflowMatchingTextSignals.java
+++ b/backend/src/main/java/com/init/workflowruntime/application/matching/WorkflowMatchingTextSignals.java
@@ -1,0 +1,137 @@
+package com.init.workflowruntime.application.matching;
+
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Locale;
+import java.util.Set;
+import org.springframework.stereotype.Component;
+
+@Component
+public class WorkflowMatchingTextSignals {
+
+  private static final Set<String> LEXICAL_STOP_WORDS =
+      Set.of(
+          "고객",
+          "고객님",
+          "사용자",
+          "문의",
+          "문의하고",
+          "요청",
+          "요청하고",
+          "확인",
+          "확인하고",
+          "처리",
+          "처리하고",
+          "관련",
+          "하고",
+          "싶어요",
+          "합니다",
+          "해주세요",
+          "가능",
+          "가능한가",
+          "어떻게",
+          "무엇",
+          "무슨",
+          "어떤",
+          "그럼",
+          "그리고",
+          "근데",
+          "상담",
+          "도움",
+          "도와주세요",
+          "가능한가요",
+          "가능해요",
+          "user",
+          "assistant",
+          "system",
+          "counselor");
+  private static final Set<String> LOW_SIGNAL_TERMS =
+      Set.of(
+          "안녕", "안녕하세요", "안녕하십니까", "하이", "헬로", "hello", "hi", "네", "넵", "예", "응", "음", "아", "오",
+          "와", "감사", "감사합니다", "고마워", "고맙습니다");
+
+  public String nullToEmpty(String value) {
+    return value == null ? "" : value;
+  }
+
+  public boolean lacksIntentSignal(String latestUserMessage, String conversationContext) {
+    String latest = normalizeForMatch(latestUserMessage);
+    if (latest.isBlank()) {
+      return !hasIntentSignal(conversationContext);
+    }
+    if (isLowSignalUtterance(latest)) {
+      return !hasIntentSignal(conversationContext);
+    }
+    return !hasIntentSignal(latestUserMessage) && !hasIntentSignal(conversationContext);
+  }
+
+  public Set<String> lexicalTokens(String value) {
+    Set<String> tokens = new LinkedHashSet<>();
+    Arrays.stream(nullToEmpty(value).toLowerCase(Locale.ROOT).split("[^0-9a-z가-힣]+"))
+        .filter(token -> token.length() >= 2)
+        .filter(token -> !LEXICAL_STOP_WORDS.contains(token))
+        .forEach(tokens::add);
+    return tokens;
+  }
+
+  public String lexicalSearchQuery(String text) {
+    return lexicalTokens(text).stream()
+        .flatMap(token -> lexicalSearchVariants(token).stream())
+        .distinct()
+        .limit(12)
+        .map(this::quoteWebsearchTerm)
+        .reduce((left, right) -> left + " OR " + right)
+        .orElse("");
+  }
+
+  public Set<String> lexicalSearchVariants(String token) {
+    Set<String> variants = new LinkedHashSet<>();
+    variants.add(token);
+    if (token.endsWith("하고싶어요") && token.length() >= 7) {
+      variants.add(token.substring(0, token.length() - 5));
+    }
+    if (token.endsWith("하고") && token.length() >= 4) {
+      variants.add(token.substring(0, token.length() - 2));
+    }
+    if (token.endsWith("해요") && token.length() >= 4) {
+      variants.add(token.substring(0, token.length() - 2));
+    }
+    if (token.endsWith("합니다") && token.length() >= 5) {
+      variants.add(token.substring(0, token.length() - 3));
+    }
+    return variants;
+  }
+
+  public String normalizeForMatch(String value) {
+    return nullToEmpty(value)
+        .toLowerCase(Locale.ROOT)
+        .replaceAll("[^0-9a-z가-힣]+", " ")
+        .trim()
+        .replaceAll("\\s+", " ");
+  }
+
+  private boolean hasIntentSignal(String value) {
+    return lexicalTokens(value).stream().anyMatch(token -> !LOW_SIGNAL_TERMS.contains(token));
+  }
+
+  private boolean isLowSignalUtterance(String normalizedText) {
+    String compact = normalizedText.replace(" ", "");
+    if (LOW_SIGNAL_TERMS.contains(compact)) {
+      return true;
+    }
+    Set<String> tokens = rawTokens(normalizedText);
+    return !tokens.isEmpty() && tokens.stream().allMatch(LOW_SIGNAL_TERMS::contains);
+  }
+
+  private Set<String> rawTokens(String value) {
+    Set<String> tokens = new LinkedHashSet<>();
+    Arrays.stream(nullToEmpty(value).toLowerCase(Locale.ROOT).split("[^0-9a-z가-힣]+"))
+        .filter(token -> !token.isBlank())
+        .forEach(tokens::add);
+    return tokens;
+  }
+
+  private String quoteWebsearchTerm(String term) {
+    return "\"" + term.replace("\"", " ") + "\"";
+  }
+}

--- a/backend/src/test/java/com/init/workflowruntime/application/matching/WorkflowMatchingProfileBuildWorkerTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/matching/WorkflowMatchingProfileBuildWorkerTest.java
@@ -51,7 +51,7 @@ class WorkflowMatchingProfileBuildWorkerTest {
             profileRepository,
             workflowDefinitionRepository,
             intentDefinitionRepository,
-            new WorkflowMatchingProfileTextFactory(new ObjectMapper()),
+            profileTextFactory(),
             new ObjectMapper(),
             meterRegistry);
   }
@@ -67,7 +67,7 @@ class WorkflowMatchingProfileBuildWorkerTest {
             profileRepository,
             workflowDefinitionRepository,
             intentDefinitionRepository,
-            new WorkflowMatchingProfileTextFactory(new ObjectMapper()),
+            profileTextFactory(),
             new ObjectMapper(),
             meterRegistry);
 
@@ -198,5 +198,10 @@ class WorkflowMatchingProfileBuildWorkerTest {
         0.65,
         0.50,
         0.30);
+  }
+
+  private WorkflowMatchingProfileTextFactory profileTextFactory() {
+    return new WorkflowMatchingProfileTextFactory(
+        new WorkflowMatchingJsonParser(new ObjectMapper(), meterRegistry));
   }
 }

--- a/backend/src/test/java/com/init/workflowruntime/application/matching/WorkflowMatchingProfileTextFactoryTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/matching/WorkflowMatchingProfileTextFactoryTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.init.domainpack.domain.model.IntentDefinition;
 import com.init.domainpack.domain.model.WorkflowDefinition;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -12,7 +13,8 @@ import org.junit.jupiter.api.Test;
 class WorkflowMatchingProfileTextFactoryTest {
 
   private final WorkflowMatchingProfileTextFactory factory =
-      new WorkflowMatchingProfileTextFactory(new ObjectMapper());
+      new WorkflowMatchingProfileTextFactory(
+          new WorkflowMatchingJsonParser(new ObjectMapper(), new SimpleMeterRegistry()));
 
   @Test
   @DisplayName("raw JSON dump 대신 route/evidence/quality를 구조화한 profile text를 만든다")
@@ -55,5 +57,41 @@ class WorkflowMatchingProfileTextFactoryTest {
     assertThat(text).contains("workflow_steps: start, 주문 확인");
     assertThat(text).contains("workflow_replay_fitness: 0.82");
     assertThat(text).contains("lexical_terms:");
+  }
+
+  @Test
+  @DisplayName("profile text 생성 중 malformed JSON은 빈 객체 fallback과 metric으로 관측한다")
+  void should_recordJsonFallbackMetric_when_profileJsonIsMalformed() {
+    SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+    WorkflowMatchingProfileTextFactory textFactory =
+        new WorkflowMatchingProfileTextFactory(
+            new WorkflowMatchingJsonParser(new ObjectMapper(), meterRegistry));
+    IntentDefinition intent =
+        IntentDefinition.create(
+            101L, "refund_request", "환불 요청", "고객이 결제 환불을 요청한다.", 1, "{}", "{bad-json", "[]", "{}");
+    WorkflowDefinition workflow =
+        WorkflowDefinition.create(
+            101L,
+            "refund_flow",
+            "환불 접수",
+            "환불 가능 여부를 확인하고 접수한다.",
+            "{}",
+            "start",
+            "[]",
+            "[]",
+            "{}",
+            10L,
+            true,
+            "{}");
+
+    String text = textFactory.build(intent, workflow);
+
+    assertThat(text).contains("intent_code: refund_request");
+    assertThat(
+            meterRegistry
+                .counter(
+                    "workflow_matching.json_fallback", "source", "profile_intent_entry_condition")
+                .count())
+        .isEqualTo(1.0);
   }
 }

--- a/backend/src/test/java/com/init/workflowruntime/application/matching/WorkflowMatchingServiceTest.java
+++ b/backend/src/test/java/com/init/workflowruntime/application/matching/WorkflowMatchingServiceTest.java
@@ -37,21 +37,32 @@ class WorkflowMatchingServiceTest {
   @Mock private WorkflowMatchingProfileJdbcRepository profileRepository;
   @Mock private WorkflowMatchDecisionJdbcRepository decisionRepository;
 
+  private SimpleMeterRegistry meterRegistry;
   private WorkflowMatchingService service;
 
   @BeforeEach
   void setUp() {
+    meterRegistry = new SimpleMeterRegistry();
+    ObjectMapper objectMapper = new ObjectMapper();
+    WorkflowMatchingTextSignals textSignals = new WorkflowMatchingTextSignals();
+    WorkflowMatchingJsonParser jsonParser =
+        new WorkflowMatchingJsonParser(objectMapper, meterRegistry);
     service =
         new WorkflowMatchingService(
             embeddingProperties(),
-            embeddingClient,
             new SensitiveTextRedactor(),
             chatSessionRepository,
-            profileRepository,
-            decisionRepository,
-            new ObjectMapper(),
-            new SimpleMeterRegistry(),
-            Clock.fixed(Instant.parse("2026-05-31T00:00:00Z"), ZoneOffset.UTC));
+            new WorkflowMatchingProfileCandidateProvider(
+                embeddingProperties(),
+                embeddingClient,
+                profileRepository,
+                textSignals,
+                Clock.fixed(Instant.parse("2026-05-31T00:00:00Z"), ZoneOffset.UTC)),
+            new WorkflowMatchingCore(embeddingProperties(), jsonParser, textSignals),
+            new WorkflowMatchDecisionRecorder(
+                embeddingProperties(), decisionRepository, objectMapper),
+            new WorkflowMatchingMetrics(meterRegistry),
+            textSignals);
   }
 
   @Test
@@ -522,6 +533,88 @@ class WorkflowMatchingServiceTest {
             eq("{}"),
             eq("[]"),
             eq("profile_missing"));
+  }
+
+  @Test
+  @DisplayName("route JSON parse 실패는 fallback metric을 남기고 매칭을 계속한다")
+  void should_recordJsonFallbackMetricAndContinueMatching_when_routeJsonIsMalformed() {
+    givenSession();
+    given(profileRepository.countActiveProfiles(101L)).willReturn(1);
+    given(embeddingClient.embed(anyString(), eq(EmbeddingInputType.SEARCH_QUERY)))
+        .willReturn(vector(1.0f, 0.0f));
+    given(profileRepository.findNearestActive(eq(101L), anyString(), anyString(), eq(30)))
+        .willReturn(
+            List.of(
+                candidate(
+                    20L,
+                    10L,
+                    "refund_request",
+                    "환불 요청",
+                    "refund_flow",
+                    "환불 접수",
+                    0.96,
+                    "{bad-json",
+                    "{\"workflowReplayFitness\":0.90,\"workflowPrecision\":0.80,"
+                        + "\"workflowConfidence\":0.90}")));
+
+    WorkflowMatchResult result = service.match(1L, "환불하고 싶어요", "");
+
+    assertThat(result.status()).isEqualTo("CONFIDENT");
+    assertThat(
+            meterRegistry
+                .counter("workflow_matching.json_fallback", "source", "route_condition")
+                .count())
+        .isEqualTo(1.0);
+    verify(decisionRepository)
+        .record(
+            eq(1L),
+            eq(101L),
+            eq(20L),
+            eq(10L),
+            eq("CONFIDENT"),
+            eq(result.candidates().getFirst().confidence()),
+            anyString(),
+            eq("profile-v1"),
+            eq("bedrock"),
+            eq("cohere.embed-v4:0"),
+            eq("ap-northeast-2"),
+            anyString(),
+            anyString(),
+            anyString(),
+            eq(null));
+  }
+
+  @Test
+  @DisplayName("intent entry JSON parse 실패는 fallback metric을 남기고 매칭을 계속한다")
+  void should_recordJsonFallbackMetricAndContinueMatching_when_intentEntryJsonIsMalformed() {
+    givenSession();
+    given(profileRepository.countActiveProfiles(101L)).willReturn(1);
+    given(embeddingClient.embed(anyString(), eq(EmbeddingInputType.SEARCH_QUERY)))
+        .willReturn(vector(1.0f, 0.0f));
+    given(profileRepository.findNearestActive(eq(101L), anyString(), anyString(), eq(30)))
+        .willReturn(
+            List.of(
+                candidateWithEntryCondition(
+                    20L,
+                    10L,
+                    "refund_request",
+                    "환불 요청",
+                    "refund_flow",
+                    "환불 접수",
+                    0.96,
+                    "{bad-json",
+                    "{}",
+                    "{\"workflowReplayFitness\":0.90,\"workflowPrecision\":0.80,"
+                        + "\"workflowConfidence\":0.90}")));
+
+    WorkflowMatchResult result = service.match(1L, "환불하고 싶어요", "");
+
+    assertThat(result.status()).isEqualTo("CONFIDENT");
+    assertThat(
+            meterRegistry
+                .counter("workflow_matching.json_fallback", "source", "intent_entry_condition")
+                .count())
+        .isEqualTo(1.0);
   }
 
   private void givenSession() {


### PR DESCRIPTION
Closes #608

## 변경 사항

- `WorkflowMatchingService`를 세션 조회와 매칭 오케스트레이션 중심으로 축소하고, matching core, profile candidate provider, decision recorder, metric 책임을 application-layer collaborator로 분리했습니다.
- route/intent entry condition, workflow meta, profile text 생성 JSON parse fallback을 `WorkflowMatchingJsonParser`로 공통화했습니다.
- malformed JSON fallback 시 raw JSON을 노출하지 않고 source tag 기반 로그와 `workflow_matching.json_fallback` metric으로 관측 가능하게 했습니다.
- 기존 matching result와 decision log 기록 의미를 유지하면서 route/intent JSON parse 실패 케이스 테스트를 보강했습니다.
- 이슈 608 스펙을 `.agent/specs/608.md`에 정리했습니다.

## 검증

- `git diff --check`
- `pnpm exec prettier --check .agent/specs/608.md`
- `docker run --rm -v /Users/owen/.codex/worktrees/e2ee/ostone/backend:/workspace -v /Users/owen/.gradle:/root/.gradle -w /workspace eclipse-temurin:21-jdk ./gradlew test --tests 'com.init.workflowruntime.application.matching.*'`
- `docker run --rm -v /Users/owen/.codex/worktrees/e2ee/ostone/backend:/workspace -v /Users/owen/.gradle:/root/.gradle -w /workspace eclipse-temurin:21-jdk ./gradlew spotlessCheck`

## 참고

- 로컬 호스트에는 Gradle이 요구하는 Java 21 toolchain이 없어 `eclipse-temurin:21-jdk` 컨테이너에서 backend 검증을 실행했습니다.
- 커밋 pre-commit hook의 `pnpm run format:backend:check`는 staged Java 파일 절대경로가 Gradle 태스크 인자로 전달되어 실패했습니다. 동일 포맷 검사는 위의 `spotlessCheck`로 통과 확인했습니다.