### PR TITLE
chore(frontend): 디자인 토큰 기준을 명확화

### DIFF
--- a/.agent/specs/638.md
+++ b/.agent/specs/638.md
@@ -1,0 +1,114 @@
+# Frontend FSD Spec: 디자인 토큰과 radius 기준 정리
+
+## Goal
+
+프론트엔드 리뉴얼 이후 함께 남아 있는 legacy token과 Ostone redesign token의 역할을 분리하고, 신규 UI가 사용할 색상, typography, radius 기준을 명확히 한다.
+
+## Issue Summary
+
+GitHub Issue #638은 `frontend/src/app/index.css`의 legacy 변수(`--text-primary`, `--bg-color`, `--radius-card`, `--radius-xl` 등)와 `frontend/src/shared/ui/ostone/tokens.css`의 redesign 변수(`--paper`, `--ink`, `--r-1`~`--r-3`, `--r-pill` 등)가 혼재되어 화면별 색상, 간격, radius, typography 기준이 달라질 위험을 다룬다.
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A["Frontend contributor starts UI work"] --> B{"Is the component part of redesigned UI?"}
+    B -->|"Yes"| C["Use tokens.css roles: paper, ink, line, r-*"]
+    B -->|"No, legacy slice"| D["Use existing legacy aliases only for compatibility"]
+    C --> E["Choose radius by component shape"]
+    D --> F["Avoid introducing new token families"]
+    E --> G["Run focused frontend verification"]
+    F --> G
+```
+
+## Design Diff
+
+| 영역 | As-is | To-be | 변경 내용 |
+| --- | --- | --- | --- |
+| Token source | `index.css` legacy token과 `tokens.css` redesign token이 병렬로 존재 | `tokens.css`를 redesign source of truth로 명시 | legacy app token은 compatibility alias로 남긴다 |
+| Radius 기준 | `--radius-card: 12px`, `--radius-xl`, `--r-1`~`--r-3`, hardcoded `12px`가 혼재 | card/panel/input은 `--r-3`, compact control은 `--r-2`, pill은 `--r-pill` 기준 | 문서와 일부 안전한 CSS 치환으로 기준을 고정한다 |
+| Hardcoded 색상/radius | 일부 공유 UI와 페이지 섹션에 raw `rgba(...)`, `12px`, `999px` 사용 | 토큰 역할이 명확한 항목부터 치환 | 광범위한 전면 교체는 후속 audit 대상으로 남긴다 |
+| 신규 컴포넌트 판단 기준 | 어느 token family를 써야 하는지 파일마다 다름 | `frontend/src/shared/ui/ostone/TOKENS.md`에서 역할과 사용 범위를 확인 | 신규 Ostone UI는 redesign token을 우선 사용한다 |
+
+## Component Tree
+
+이번 작업은 신규 화면이나 컴포넌트를 추가하지 않는다. 영향을 받는 frontend shared/style surface는 다음과 같다.
+
+```text
+frontend/src/app/index.css
+└─ legacy app alias tokens
+
+frontend/src/shared/ui/ostone/
+├─ tokens.css
+└─ TOKENS.md
+
+frontend/src/shared/ui/
+├─ button/button.module.css
+└─ input/input.module.css
+
+frontend/src/pages/consultation/ui/sections/
+└─ MatchedWorkflowBar.module.css
+```
+
+## API Integration
+
+API 변경은 없다. Orval generated API, query key, backend contract, 데이터 모델에는 영향이 없다.
+
+## Data Flow
+
+상태 관리나 서버 데이터 흐름 변경은 없다. 변경 범위는 CSS token resolution과 문서화에 한정한다.
+
+```text
+tokens.css
+  ↓ import
+index.css legacy aliases
+  ↓ cascade
+existing CSS modules and inline styles
+```
+
+## 수정 대상 파일
+
+| 파일 | 변경 유형 | 설명 |
+| --- | --- | --- |
+| `frontend/src/shared/ui/ostone/tokens.css` | modify | redesign token source of truth와 radius scale 역할을 명시 |
+| `frontend/src/app/index.css` | modify | legacy token을 redesign token compatibility alias로 연결 |
+| `frontend/src/shared/ui/ostone/TOKENS.md` | new | 신규 UI token 선택 기준, radius baseline, phased audit 기준 문서화 |
+| `frontend/src/shared/ui/button/button.module.css` | modify | shared button 색상/radius 중 token 대체 가능한 항목 치환 |
+| `frontend/src/shared/ui/input/input.module.css` | modify | shared input background/border/focus/radius를 token 기준으로 정리 |
+| `frontend/src/pages/consultation/ui/sections/MatchedWorkflowBar.module.css` | modify | hardcoded card/panel radius를 `--r-3`로 정리 |
+
+## State Management
+
+클라이언트 상태, 서버 상태, URL 상태 변경은 없다.
+
+## Acceptance Criteria
+
+- 새 UI에서 사용할 색상, radius, typography token 기준이 `frontend/src/shared/ui/ostone/TOKENS.md`에 명확히 기록된다.
+- legacy token을 유지하는 이유와 사용 범위가 문서화된다.
+- `frontend/src/app/index.css`의 legacy color/radius token은 가능한 범위에서 `frontend/src/shared/ui/ostone/tokens.css`의 redesign token을 참조한다.
+- card/panel/input/pill radius 기준이 문서와 구현에서 같은 token 이름으로 판단 가능하다.
+- hardcoded radius와 raw color의 전면 교체는 제외하고, 우선순위가 있는 phased audit 기준을 남긴다.
+- API, 라우팅, FSD import boundary 변경이 없어야 한다.
+
+## Non-goals
+
+- 대규모 시각 리디자인은 하지 않는다.
+- 모든 CSS 파일의 raw `rgba(...)`와 hardcoded radius를 한 번에 제거하지 않는다.
+- 개별 화면 UX 구조나 정보 설계는 변경하지 않는다.
+- backend, ML pipeline, database schema, generated API 파일은 변경하지 않는다.
+
+## Validation
+
+검증은 frontend 범위에서 수행한다.
+
+| 검증 | 목적 |
+| --- | --- |
+| `pnpm --dir frontend lint` | FSD import boundary, manual API audit, ESLint 확인 |
+| `pnpm --dir frontend build` | CSS token 변경이 production build를 깨지 않는지 확인 |
+
+시각 회귀는 변경 범위가 CSS token과 radius baseline이므로, PR 리뷰에서 shared button/input과 consultation matched workflow bar를 우선 확인한다.
+
+## Open Questions
+
+- 기존 legacy slice 전체를 redesign token으로 완전히 전환할 시점과 범위는 별도 이슈에서 결정한다.
+- raw alpha shadow와 overlay 값을 token화할지, 컴포넌트별 표현값으로 남길지는 후속 audit에서 판단한다.

--- a/frontend/src/app/index.css
+++ b/frontend/src/app/index.css
@@ -32,40 +32,40 @@
   --font-weight-body: 330;
   --font-weight-base: 340;
   --font-weight-heading: 540;
-  --bg-color: #ffffff;
-  --bg-secondary: rgba(0, 0, 0, 0.02);
-  --text-primary: #000000;
-  --text-secondary: rgba(0, 0, 0, 0.5);
-  --text-color: #000000;
-  --text-muted: rgba(0, 0, 0, 0.35);
-  --brand-primary: #000000;
-  --primary-color: #000000;
-  --primary-color-hover: #000000;
-  --secondary-color: rgba(0, 0, 0, 0.5);
-  --error-color: #b42318;
-  --success-color: #000000;
+  /* Legacy app aliases. New frontend code should use tokens from shared/ui/ostone/tokens.css. */
+  --bg-color: var(--paper);
+  --bg-secondary: var(--paper-2);
+  --text-primary: var(--ink);
+  --text-secondary: var(--ink-2);
+  --text-color: var(--ink);
+  --text-muted: var(--ink-3);
+  --brand-primary: var(--ink);
+  --primary-color: var(--ink);
+  --primary-color-hover: var(--ink);
+  --secondary-color: var(--ink-2);
+  --error-color: var(--danger);
+  --success-color: var(--signal-ink);
   --glass-dark: rgba(0, 0, 0, 0.08);
   --glass-dark-soft: rgba(0, 0, 0, 0.045);
   --glass-light: rgba(255, 255, 255, 0.16);
-  --glass-bg: #ffffff;
-  --glass-border: rgba(0, 0, 0, 0.08);
+  --glass-bg: var(--paper);
+  --glass-border: var(--line);
   --glass-shadow: none;
   --glass-blur: none;
   --shadow-card: 0 18px 36px rgba(0, 0, 0, 0.05);
   --shadow-card-hover: 0 34px 72px rgba(0, 0, 0, 0.09);
   --shadow-panel: 0 20px 48px rgba(0, 0, 0, 0.04);
   --shadow-button: 0 18px 36px rgba(0, 0, 0, 0.18);
-  --radius-sm: 2px;
-  --radius-md: 6px;
-  --radius-lg: 8px;
-  --radius-xl: 50px;
-  --radius-pill-row: 28px;
+  --radius-sm: var(--r-1);
+  --radius-md: var(--r-3);
+  --radius-lg: var(--r-3);
+  --radius-xl: var(--r-pill);
   --radius-full: 50%;
   --transition-fast: 0.15s ease-in-out;
   --transition-normal: 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  --hover-bg: rgba(0, 0, 0, 0.03);
-  --hover-border: rgba(0, 0, 0, 0.14);
-  --divider-subtle: rgba(0, 0, 0, 0.04);
+  --hover-bg: var(--paper-2);
+  --hover-border: var(--line);
+  --divider-subtle: var(--line-2);
   --app-header-height: 72px;
   --overlay-bg: rgba(0, 0, 0, 0.45);
   --focus-ring: 0 0 0 3px rgba(0, 0, 0, 0.12);
@@ -113,8 +113,8 @@
   --node-shadow: 0 1px 2px rgba(15, 23, 42, 0.04), 0 6px 14px rgba(15, 23, 42, 0.06);
   --node-shadow-active: 0 0 0 3px oklch(0.62 0.22 285 / 0.18), 0 6px 16px rgba(15, 23, 42, 0.1);
 
-  --radius-card: 12px;
-  --radius-pill: 999px;
+  --radius-card: var(--r-3);
+  --radius-pill: var(--r-pill);
 }
 
 * {

--- a/frontend/src/pages/consultation/ui/sections/MatchedWorkflowBar.module.css
+++ b/frontend/src/pages/consultation/ui/sections/MatchedWorkflowBar.module.css
@@ -2,7 +2,7 @@
   display: block;
   background: var(--paper);
   border: 1px solid var(--line);
-  border-radius: 12px;
+  border-radius: var(--r-3);
   transition:
     border-color 160ms ease,
     box-shadow 160ms ease,
@@ -28,7 +28,7 @@
   padding: 10px 14px;
   background: transparent;
   border: none;
-  border-radius: 12px;
+  border-radius: var(--r-3);
   cursor: pointer;
   font: inherit;
   color: inherit;
@@ -99,7 +99,7 @@
   margin: 0;
   padding: 8px 10px;
   border: 1px solid var(--line-2);
-  border-radius: 8px;
+  border-radius: var(--r-3);
   background: var(--paper-2);
   color: var(--ink);
   font-family: var(--sans);
@@ -128,7 +128,7 @@
 .graphSlot {
   height: 160px;
   background: var(--paper-2);
-  border-radius: 10px;
+  border-radius: var(--r-3);
   border: 1px solid var(--line-2);
   overflow: hidden;
   display: flex;
@@ -149,7 +149,7 @@
   padding: 10px 14px;
   background: var(--paper);
   border: 1px solid var(--line);
-  border-radius: 12px;
+  border-radius: var(--r-3);
 }
 
 .skeletonBar {

--- a/frontend/src/shared/ui/button/button.module.css
+++ b/frontend/src/shared/ui/button/button.module.css
@@ -4,7 +4,7 @@
   justify-content: center;
   gap: 8px;
   padding: 12px 24px;
-  border-radius: 50px;
+  border-radius: var(--r-pill);
   font-weight: 500;
   font-size: 0.95rem;
   letter-spacing: -0.1px;
@@ -36,12 +36,12 @@
 /* Variants */
 .primary {
   background-color: var(--primary-color);
-  color: white;
+  color: var(--paper);
   box-shadow: none;
 }
 
 .primary:hover:not(:disabled) {
-  background-color: rgba(0, 0, 0, 0.8);
+  background-color: var(--ink-2);
   transform: translateY(-1px);
   box-shadow: none;
 }
@@ -51,14 +51,14 @@
 }
 
 .secondary {
-  background-color: rgba(0, 0, 0, 0.05);
+  background-color: var(--paper-2);
   color: var(--text-primary);
-  border: 1px solid rgba(0, 0, 0, 0.1);
+  border: 1px solid var(--line);
 }
 
 .secondary:hover:not(:disabled) {
-  background-color: rgba(0, 0, 0, 0.1);
-  border-color: rgba(0, 0, 0, 0.2);
+  background-color: var(--paper-3);
+  border-color: var(--ink-3);
 }
 
 .secondary:focus-visible {
@@ -72,7 +72,7 @@
 
 .ghost:hover:not(:disabled) {
   color: var(--text-primary);
-  background-color: rgba(0, 0, 0, 0.05);
+  background-color: var(--paper-2);
 }
 
 .ghost:focus-visible {

--- a/frontend/src/shared/ui/input/input.module.css
+++ b/frontend/src/shared/ui/input/input.module.css
@@ -22,7 +22,7 @@
 .icon {
   position: absolute;
   left: 14px;
-  color: rgba(0, 0, 0, 0.35);
+  color: var(--ink-4);
   display: flex;
   align-items: center;
   pointer-events: none;
@@ -31,9 +31,9 @@
 .input {
   width: 100%;
   padding: 12px 14px;
-  background: rgba(255, 255, 255, 0.8);
-  border: 1px solid rgba(0, 0, 0, 0.15);
-  border-radius: 8px;
+  background: var(--paper);
+  border: 1px solid var(--line);
+  border-radius: var(--r-3);
   color: var(--text-primary);
   font-family: inherit;
   font-size: 0.95rem;
@@ -44,9 +44,9 @@
 
 .input:focus-visible {
   outline: none;
-  border-color: #000000;
-  box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.1);
-  background: #ffffff;
+  border-color: var(--ink);
+  box-shadow: var(--focus-ring);
+  background: var(--paper);
 }
 
 .hasIcon {
@@ -54,11 +54,11 @@
 }
 
 .input::placeholder {
-  color: rgba(0, 0, 0, 0.35);
+  color: var(--ink-4);
 }
 
 .input:hover:not(:focus) {
-  border-color: rgba(0, 0, 0, 0.2);
+  border-color: var(--ink-3);
 }
 
 .errorInput {
@@ -67,7 +67,7 @@
 
 .errorInput:focus-visible {
   border-color: var(--error-color);
-  box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--focus-ring);
   outline: none;
 }
 

--- a/frontend/src/shared/ui/ostone/TOKENS.md
+++ b/frontend/src/shared/ui/ostone/TOKENS.md
@@ -1,0 +1,61 @@
+# Ostone Frontend Tokens
+
+## Canonical Token Source
+
+`frontend/src/shared/ui/ostone/tokens.css` is the source of truth for redesigned frontend UI tokens.
+
+New frontend UI should prefer these token groups:
+
+| Role | Tokens | Usage |
+| --- | --- | --- |
+| Surface | `--paper`, `--paper-2`, `--paper-3` | Page, panel, card, row, input backgrounds |
+| Line | `--line`, `--line-2` | Borders, dividers, subtle separators |
+| Text | `--ink`, `--ink-2`, `--ink-3`, `--ink-4` | Primary text through muted metadata |
+| Signal | `--signal`, `--signal-ink`, `--signal-bg` | Positive or selected state accents |
+| Status | `--warn`, `--warn-bg`, `--danger`, `--danger-bg`, `--info`, `--info-bg` | Warning, error, and informational states |
+| Dark | `--dark-bg`, `--dark-bg-2`, `--dark-line`, `--dark-ink`, `--dark-ink-2`, `--dark-ink-3` | Dark shell and dark overlay surfaces |
+| Radius | `--r-1`, `--r-2`, `--r-3`, `--r-pill`, `--radius-pill-row` | Small controls, menus, panels, cards, pills, rows |
+| Spacing | `--s-1` through `--s-20` | 4px-based layout spacing |
+| Type | `--sans`, `--mono`, `--serif` plus `.t-*` primitives | Shared typography primitives |
+
+## Radius Baseline
+
+| UI shape | Token |
+| --- | --- |
+| Small inline detail | `--r-1` |
+| Menu, compact control, icon tile | `--r-2` |
+| Card, panel, dialog, input, preview container | `--r-3` |
+| Tab, CTA, badge, chip | `--r-pill` |
+| Dense row item | `--radius-pill-row` |
+
+Hardcoded `12px`, `16px`, or `999px` radius values should be replaced with one of these tokens when the component is already using the Ostone redesign surface tokens.
+
+## Typography Baseline
+
+Use `--sans` for product UI copy, form labels, panels, cards, and navigation. Use `--mono` for compact metadata, counters, technical labels, IDs, and uppercase eyebrows. `--serif` is currently an alias of `--sans`; do not introduce a new serif stack unless a separate design issue defines it.
+
+Shared type primitives:
+
+| Primitive | Usage |
+| --- | --- |
+| `.t-eyebrow` | Uppercase section labels and small technical signposts |
+| `.t-num` | Numeric values that should align across rows or cards |
+| `.t-title` | Compact card, panel, and section titles |
+| `.t-display` | Large expressive headings inside redesigned Ostone surfaces |
+
+## Legacy Alias Policy
+
+`frontend/src/app/index.css` keeps legacy app-level variables such as `--bg-color`, `--text-primary`, `--radius-card`, and `--radius-xl` for older screens. Those aliases now point back to the Ostone redesign tokens where the role is equivalent.
+
+Legacy aliases may remain when removing them would require broad screen rewrites. New components should not introduce additional uses of the legacy aliases unless they are maintaining an existing non-redesigned slice.
+
+## Phased Audit Notes
+
+This baseline intentionally does not rewrite every CSS module in one pass. Future cleanup should prioritize:
+
+1. Shared components under `frontend/src/shared/ui/`.
+2. Ostone shell components under `frontend/src/shared/ui/ostone/`.
+3. Frequently reused page sections under `frontend/src/pages/`.
+4. Feature-specific modules only when the feature is already being changed.
+
+When replacing raw `rgba(...)`, first check whether the value is a semantic surface, line, text, focus, shadow, overlay, or status value. Shadows and product-content visuals may keep raw alpha values when no token role exists.

--- a/frontend/src/shared/ui/ostone/tokens.css
+++ b/frontend/src/shared/ui/ostone/tokens.css
@@ -1,6 +1,6 @@
-/* ostone redesign — design tokens */
+/* ostone redesign — canonical design tokens */
 :root {
-  /* paper / ink palette — warm-cool neutral */
+  /* paper / ink palette */
   --paper: oklch(0.985 0.003 100);
   --paper-2: oklch(0.972 0.004 100);
   --paper-3: oklch(0.955 0.005 100);
@@ -37,7 +37,7 @@
   --mono: var(--font-mono);
   --serif: var(--font-sans);
 
-  /* radii — small, technical */
+  /* radius scale */
   --r-1: 2px;
   --r-2: 4px;
   --r-3: 6px;


### PR DESCRIPTION
Closes #638

## 변경 사항

- `frontend/src/shared/ui/ostone/tokens.css`를 redesign token 기준으로 명시하고, `frontend/src/app/index.css`의 legacy color/radius token을 가능한 범위에서 redesign token alias로 연결했습니다.
- 신규 Ostone UI가 사용할 surface, line, text, status, radius, spacing, typography token 기준과 phased audit 기준을 `frontend/src/shared/ui/ostone/TOKENS.md`에 정리했습니다.
- shared button/input과 consultation matched workflow bar의 hardcoded color/radius 중 token role이 명확한 항목을 token 기반으로 치환했습니다.
- 이슈 638 스펙을 `.agent/specs/638.md`에 정리했습니다.

## 검증

- `git diff --check`
- `pnpm --dir frontend build`

## 참고

- `pnpm --dir frontend lint`는 `audit:api`, `audit:fsd` 통과 후 repository-wide 기존 ESLint baseline 47건으로 실패합니다. 실패 파일은 이번 변경 파일이 아닌 workflow/auth/workspace/domain-pack 등 기존 lint 대상입니다.