### PR TITLE
fix(domain-pack): Policy/Risk 목록-상세 모바일 전환 기준을 보장

### DIFF
--- a/.agent/specs/629.md
+++ b/.agent/specs/629.md
@@ -1,0 +1,109 @@
+# Frontend FSD Spec: Policy/Risk 목록-상세 반응형 전환 기준 정리
+
+## Goal
+
+Policy/Risk 초안 상세 화면에서 일반 데스크톱/노트북 폭은 목록과 상세를 함께 보여주고, 좁은 화면에서만 목록 또는 상세 단일 화면 탐색으로 전환한다.
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A["Policy/Risk 목록 화면 진입"] --> B{"화면 폭"}
+    B -->|"768px 이상"| C["목록과 상세를 같은 화면에 표시"]
+    B -->|"767px 이하"| D["목록 단일 화면 표시"]
+    D --> E["항목 선택"]
+    E --> F["상세 단일 화면 표시"]
+    F --> G["목록 버튼"]
+    G --> D
+```
+
+## Design Diff
+
+### As-is vs To-be
+
+| 영역 | As-is | To-be | 변경 내용 |
+| --- | --- | --- | --- |
+| Policy 목록-상세 breakpoint | 이슈 기준 1599px 이하에서 단일 화면 전환 가능 | 767px 이하에서만 단일 화면 전환 | 1440px급 노트북에서 목록과 상세를 동시에 유지 |
+| Risk 목록-상세 breakpoint | 이슈 기준 1599px 이하에서 단일 화면 전환 가능 | 767px 이하에서만 단일 화면 전환 | Policy와 동일한 기준 적용 |
+| 좁은 화면 복귀 | 상세에서 목록으로 돌아가는 명시적 동선 필요 | 상세 선택 상태에서 모바일 전용 목록 버튼 제공 | 선택 없는 section URL로 replace 이동 |
+| 포커스 흐름 | 목록 복귀 후 포커스 기준 불명확 | 목록 영역으로 프로그램 포커스 이동 | 키보드 사용자가 복귀 지점을 잃지 않도록 보조 |
+
+## Component Tree
+
+```text
+PolicyDraftReadPage
+├─ OstoneShell
+└─ pageWrapper
+   ├─ backButton (선택 상태에서 렌더링, CSS로 모바일에서만 표시)
+   └─ twoPane
+      ├─ listSlot -> PolicyListPanel
+      └─ detailSlot -> PolicyDetailPanel / PolicyEditPanel
+
+RiskDraftReadPage
+├─ OstoneShell
+└─ pageWrapper
+   ├─ backButton (선택 상태에서 렌더링, CSS로 모바일에서만 표시)
+   └─ twoPane
+      ├─ listSlot -> RiskListPanel
+      └─ detailSlot -> RiskDetailPanel / RiskEditPanel
+```
+
+## API Integration
+
+이번 변경은 레이아웃과 클라이언트 라우팅만 다룬다. Backend API, generated endpoint, query key, 서버 상태 계약은 변경하지 않는다.
+
+## Data Flow
+
+```text
+URL route param(policyId/riskId)
+  -> hasSelection 계산
+  -> 768px 이상: listSlot + detailSlot 동시 표시
+  -> 767px 이하: hasSelection 여부로 listSlot/detailSlot 중 하나만 표시
+  -> 목록 버튼: /policies 또는 /risks section URL로 replace 이동
+```
+
+## 수정 대상 파일
+
+| 파일 | 변경 유형 | 설명 |
+| --- | --- | --- |
+| `frontend/src/pages/domain-pack/ui/PolicyDraftReadPage.tsx` | update | 선택된 정책 상세에서 목록 URL로 돌아가는 버튼과 목록 포커스 이동 추가 |
+| `frontend/src/pages/domain-pack/ui/RiskDraftReadPage.tsx` | update | 선택된 위험요소 상세에서 목록 URL로 돌아가는 버튼과 목록 포커스 이동 추가 |
+| `frontend/src/pages/domain-pack/ui/policy-draft-read-page.module.css` | update | Policy 단일 화면 전환 기준을 모바일 폭으로 유지하고 목록 버튼 focus-visible 보강 |
+| `frontend/src/pages/domain-pack/ui/risk-draft-read-page.module.css` | update | Risk 단일 화면 전환 기준을 모바일 폭으로 유지 |
+| `frontend/src/pages/domain-pack/ui/PolicyDraftReadPage.test.tsx` | update | 정책 상세의 목록 버튼 URL replace 동작 검증 |
+| `frontend/src/pages/domain-pack/ui/RiskDraftReadPage.test.tsx` | update | 위험요소 상세의 목록 버튼 URL replace 동작 검증 |
+| `frontend/src/pages/domain-pack/ui/DomainPackDraftReadBreakpoints.test.ts` | new | Policy/Risk breakpoint가 767px 기준이며 1599/1500px 기준으로 회귀하지 않는지 검증 |
+
+## State Management
+
+- 추가 서버 상태는 없다.
+- `PolicyDraftReadPage`, `RiskDraftReadPage` 내부에 목록 복귀 후 포커스를 한 번 이동하기 위한 로컬 boolean state를 둔다.
+- 선택 상태와 상세 URL은 기존 route param 기반 흐름을 유지한다.
+
+## Tests
+
+### Test Strategy
+
+| 구분 | 방법 | 도구 | 비고 |
+| --- | --- | --- | --- |
+| 페이지 컴포넌트 테스트 | 목록 버튼 클릭 시 section URL로 replace 이동 확인 | Vitest + React Testing Library | URL 파라미터 유지 확인 |
+| CSS 회귀 테스트 | Policy/Risk CSS breakpoint 기준 확인 | Vitest | 1599/1500px 기준 재발 방지 |
+| 수동 QA | 1440px, 767px 이하 화면 폭에서 목록/상세 표시 확인 | 브라우저 또는 Playwright | 실제 CSS 적용 확인 |
+
+### Acceptance Criteria
+
+- 1440px급 화면에서 `PolicyDraftReadPage`는 목록과 상세를 동시에 표시한다.
+- 1440px급 화면에서 `RiskDraftReadPage`는 목록과 상세를 동시에 표시한다.
+- 767px 이하 좁은 화면에서는 선택 전 목록, 선택 후 상세 단일 화면 탐색을 유지한다.
+- 상세 단일 화면에서 목록 버튼을 누르면 `versionId`를 유지한 선택 없는 목록 URL로 이동한다.
+- 목록/상세 전환 중 선택 상태와 URL 파라미터가 깨지지 않는다.
+
+## Non-goals
+
+- Policy/Risk JSON 표시 방식 개선은 다루지 않는다.
+- Slot/Policy/Risk 진입성 전반 개선은 다루지 않는다.
+- Backend API, DB schema, generated API 변경은 다루지 않는다.
+
+## Open Questions
+
+- 없음. 이슈의 확인 내용과 현재 `frontend/DESIGN.md` breakpoint 기준으로 767px 이하를 단일 화면 전환 기준으로 삼는다.

--- a/frontend/src/pages/domain-pack/ui/DomainPackDraftReadBreakpoints.test.ts
+++ b/frontend/src/pages/domain-pack/ui/DomainPackDraftReadBreakpoints.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+function readCss(fileName: string): string {
+  return readFileSync(new URL(fileName, import.meta.url), "utf8");
+}
+
+describe("Domain Pack draft read responsive breakpoints", () => {
+  it("Policy/Risk 목록-상세 전환은 모바일 폭에서만 적용한다", () => {
+    const policyCss = readCss("./policy-draft-read-page.module.css");
+    const riskCss = readCss("./risk-draft-read-page.module.css");
+
+    expect(policyCss).toContain("@media (max-width: 767px)");
+    expect(riskCss).toContain("@media (max-width: 767px)");
+    expect(policyCss).not.toMatch(/15(?:99|00)px/);
+    expect(riskCss).not.toMatch(/15(?:99|00)px/);
+  });
+});

--- a/frontend/src/pages/domain-pack/ui/PolicyDraftReadPage.test.tsx
+++ b/frontend/src/pages/domain-pack/ui/PolicyDraftReadPage.test.tsx
@@ -83,6 +83,17 @@ describe("PolicyDraftReadPage", () => {
     });
   });
 
+  it("정책 상세에서 목록 버튼을 누르면 선택 없는 목록 URL로 replace한다", () => {
+    navigate.mockReset();
+    renderPage("/workspaces/1/domain-packs/7/policies/3?versionId=101");
+
+    fireEvent.click(screen.getByRole("button", { name: "목록" }));
+
+    expect(navigate).toHaveBeenCalledWith("/workspaces/1/domain-packs/7/policies?versionId=101", {
+      replace: true,
+    });
+  });
+
   it("잘못된 URL 파라미터면 alert를 표시한다", () => {
     renderPage("/workspaces/abc/domain-packs/7/policies?versionId=101");
 

--- a/frontend/src/pages/domain-pack/ui/PolicyDraftReadPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/PolicyDraftReadPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { usePackDetail } from "@/features/domain-pack-summary-read";
 import { PolicyDetailPanel, PolicyListPanel } from "@/features/policy-draft-read/ui";
@@ -24,6 +24,8 @@ export function PolicyDraftReadPage() {
   const [search] = useSearchParams();
   const navigate = useNavigate();
   const [editingPolicy, setEditingPolicy] = useState<EditingPolicyState | null>(null);
+  const listSlotRef = useRef<HTMLDivElement>(null);
+  const shouldFocusListRef = useRef(false);
 
   const wsId = parseRouteId(workspaceId);
   const pId = parseRouteId(packId);
@@ -37,6 +39,13 @@ export function PolicyDraftReadPage() {
   }).data;
   const packName = packDetail?.name ?? `PACK · ${pId ?? "?"}`;
   const versionNo = packDetail?.versions?.find((v) => v.versionId === vId)?.versionNo ?? vId ?? 0;
+  const hasSelection = selectedPolicyId !== null;
+
+  useEffect(() => {
+    if (!shouldFocusListRef.current || hasSelection) return;
+    listSlotRef.current?.focus();
+    shouldFocusListRef.current = false;
+  }, [hasSelection]);
 
   if (wsId === null || pId === null || vId === null || hasInvalidPolicyId) {
     return (
@@ -58,11 +67,16 @@ export function PolicyDraftReadPage() {
     navigate(path);
   };
 
-  const hasSelection = selectedPolicyId !== null;
   const activeEditingPolicyId =
     editingPolicy?.routeKey === routeKey && editingPolicy.policyId === selectedPolicyId
       ? editingPolicy.policyId
       : null;
+
+  const handleBackToList = () => {
+    setEditingPolicy(null);
+    shouldFocusListRef.current = true;
+    navigate(domainPackSectionPath(wsId, pId, vId, "policies"), { replace: true });
+  };
 
   const crumbs: Crumb[] = buildDomainPackCrumbs({
     wsId,
@@ -79,8 +93,18 @@ export function PolicyDraftReadPage() {
   return (
     <OstoneShell active="policy" crumbs={crumbs} topbarRight={topbarRight}>
       <div className={styles.pageWrapper}>
+        {hasSelection && (
+          <button type="button" className={styles.backButton} onClick={handleBackToList}>
+            목록
+          </button>
+        )}
         <div className={`${styles.twoPane} ${hasSelection ? styles.hasSelection : ""}`}>
-          <div className={styles.listSlot}>
+          <div
+            ref={listSlotRef}
+            className={styles.listSlot}
+            tabIndex={-1}
+            aria-label="응대 기준 목록 영역"
+          >
             <PolicyListPanel
               workspaceId={wsId}
               packId={pId}

--- a/frontend/src/pages/domain-pack/ui/RiskDraftReadPage.test.tsx
+++ b/frontend/src/pages/domain-pack/ui/RiskDraftReadPage.test.tsx
@@ -80,6 +80,17 @@ describe("RiskDraftReadPage", () => {
     });
   });
 
+  it("위험요소 상세에서 목록 버튼을 누르면 선택 없는 목록 URL로 replace한다", () => {
+    navigate.mockReset();
+    renderPage("/workspaces/1/domain-packs/7/risks/3?versionId=101");
+
+    fireEvent.click(screen.getByRole("button", { name: "목록" }));
+
+    expect(navigate).toHaveBeenCalledWith("/workspaces/1/domain-packs/7/risks?versionId=101", {
+      replace: true,
+    });
+  });
+
   it("수정 버튼을 누르면 편집 패널로 전환하고 닫을 수 있다", () => {
     renderPage("/workspaces/1/domain-packs/7/risks/4?versionId=101");
 

--- a/frontend/src/pages/domain-pack/ui/RiskDraftReadPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/RiskDraftReadPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { usePackDetail } from "@/features/domain-pack-summary-read";
 import { RiskDetailPanel, RiskListPanel } from "@/features/risk-draft-read/ui";
@@ -24,6 +24,8 @@ export function RiskDraftReadPage() {
   const [search] = useSearchParams();
   const navigate = useNavigate();
   const [editingRisk, setEditingRisk] = useState<EditingRiskState | null>(null);
+  const listSlotRef = useRef<HTMLDivElement>(null);
+  const shouldFocusListRef = useRef(false);
 
   const wsId = parseRouteId(workspaceId);
   const pId = parseRouteId(packId);
@@ -37,6 +39,13 @@ export function RiskDraftReadPage() {
   }).data;
   const packName = packDetail?.name ?? `PACK · ${pId ?? "?"}`;
   const versionNo = packDetail?.versions?.find((v) => v.versionId === vId)?.versionNo ?? vId ?? 0;
+  const hasSelection = selectedRiskId !== null;
+
+  useEffect(() => {
+    if (!shouldFocusListRef.current || hasSelection) return;
+    listSlotRef.current?.focus();
+    shouldFocusListRef.current = false;
+  }, [hasSelection]);
 
   if (wsId === null || pId === null || vId === null || hasInvalidRiskId) {
     return (
@@ -48,11 +57,16 @@ export function RiskDraftReadPage() {
     );
   }
 
-  const hasSelection = selectedRiskId !== null;
   const activeEditingRiskId =
     editingRisk?.routeKey === routeKey && editingRisk.riskId === selectedRiskId
       ? editingRisk.riskId
       : null;
+
+  const handleBackToList = () => {
+    setEditingRisk(null);
+    shouldFocusListRef.current = true;
+    navigate(domainPackSectionPath(wsId, pId, vId, "risks"), { replace: true });
+  };
 
   const crumbs: Crumb[] = buildDomainPackCrumbs({
     wsId,
@@ -69,8 +83,18 @@ export function RiskDraftReadPage() {
   return (
     <OstoneShell active="risk" crumbs={crumbs} topbarRight={topbarRight}>
       <div className={styles.pageWrapper}>
+        {hasSelection && (
+          <button type="button" className={styles.backButton} onClick={handleBackToList}>
+            목록
+          </button>
+        )}
         <div className={`${styles.twoPane} ${hasSelection ? styles.hasSelection : ""}`}>
-          <div className={styles.listSlot}>
+          <div
+            ref={listSlotRef}
+            className={styles.listSlot}
+            tabIndex={-1}
+            aria-label="주의 사항 목록 영역"
+          >
             <RiskListPanel
               workspaceId={wsId}
               packId={pId}

--- a/frontend/src/pages/domain-pack/ui/policy-draft-read-page.module.css
+++ b/frontend/src/pages/domain-pack/ui/policy-draft-read-page.module.css
@@ -93,6 +93,11 @@
   align-self: stretch;
 }
 
+.listSlot:focus {
+  outline: none;
+  box-shadow: inset 0 0 0 2px rgb(0 0 0 / 0.08);
+}
+
 .detailSlot {
   flex: 1;
 }
@@ -139,6 +144,11 @@
     text-transform: uppercase;
     cursor: pointer;
     flex-shrink: 0;
+  }
+
+  .backButton:focus-visible {
+    outline: none;
+    box-shadow: var(--focus-ring);
   }
 }
 

--- a/frontend/src/pages/domain-pack/ui/risk-draft-read-page.module.css
+++ b/frontend/src/pages/domain-pack/ui/risk-draft-read-page.module.css
@@ -93,6 +93,11 @@
   align-self: stretch;
 }
 
+.listSlot:focus {
+  outline: none;
+  box-shadow: inset 0 0 0 2px rgb(0 0 0 / 0.08);
+}
+
 .detailSlot {
   flex: 1;
 }


### PR DESCRIPTION
Closes #629

## 변경 사항

- Policy/Risk 초안 상세 화면에서 선택 상태일 때 모바일 전용 `목록` 버튼을 제공해 선택 없는 목록 URL로 돌아가도록 했습니다.
- 목록 복귀 후 list 영역으로 포커스를 이동해 좁은 화면에서 상세 단일 화면 탐색 후 복귀 지점을 유지하도록 했습니다.
- Policy/Risk 목록-상세 CSS가 767px 이하에서만 단일 화면으로 전환되는지 검증하는 회귀 테스트를 추가했습니다.
- 이슈 629 스펙을 `.agent/specs/629.md`에 정리했습니다.

## 검증

- `git diff --cached --check`
- `pnpm --dir frontend exec vp test --run src/pages/domain-pack/ui/PolicyDraftReadPage.test.tsx src/pages/domain-pack/ui/RiskDraftReadPage.test.tsx src/pages/domain-pack/ui/DomainPackDraftReadBreakpoints.test.ts`
- `pnpm --dir frontend exec eslint src/pages/domain-pack/ui/PolicyDraftReadPage.tsx src/pages/domain-pack/ui/RiskDraftReadPage.tsx src/pages/domain-pack/ui/PolicyDraftReadPage.test.tsx src/pages/domain-pack/ui/RiskDraftReadPage.test.tsx src/pages/domain-pack/ui/DomainPackDraftReadBreakpoints.test.ts`
- `pnpm --dir frontend build`
- Browser smoke: 1440px에서 Policy/Risk 목록+상세 동시 표시, 390px 선택 상세에서 목록 버튼 표시, Risk 목록 복귀 시 `versionId` 유지와 목록 영역 포커스 확인

## 참고

- `pnpm --dir frontend lint`와 pre-commit의 `pnpm run lint:frontend`는 repository-wide 기존 ESLint baseline 47건으로 실패합니다. 이번 변경 파일은 대상 지정 ESLint로 통과 확인했습니다.
- 브라우저 smoke 중 backend는 실행하지 않아 `/api/v1/*` proxy `ECONNREFUSED` 로그가 발생했지만, 레이아웃/URL/focus 검증에 필요한 frontend route는 렌더링되었습니다.