### PR TITLE
feat(frontend): 보조 데이터 오류가 패널 안에서 안내되도록 보장

### DIFF
--- a/.agent/specs/637.md
+++ b/.agent/specs/637.md
@@ -1,0 +1,177 @@
+# Frontend FSD Spec: 보조 데이터 오류 표시와 toast 정책 정리
+
+## Goal
+
+대시보드와 시뮬레이션 화면에서 보조 데이터 로드 실패는 패널 내부 오류로 안내하고, 사용자가 직접 실행한 중요한 액션 실패만 toast로 즉시 알린다.
+
+---
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A[화면 진입] --> B{주요 데이터 로드}
+    B -->|성공| C[주요 화면 표시]
+    B -->|실패| D[화면 단위 오류 상태 표시]
+    C --> E{보조 패널 로드}
+    E -->|성공| F[패널 데이터 표시]
+    E -->|실패| G[패널 내부 오류와 재시도 표시]
+    C --> H{사용자 액션 실행}
+    H -->|성공| I[성공 toast 또는 화면 갱신]
+    H -->|실패| J[실패 toast 표시]
+    I --> K{후속 보조 목록 새로고침}
+    K -->|실패| G
+```
+
+---
+
+## Design Diff
+
+### As-is vs To-be
+
+| 영역                       | As-is                                                                  | To-be                             | 변경 내용                                                     |
+| -------------------------- | ---------------------------------------------------------------------- | --------------------------------- | ------------------------------------------------------------- |
+| 대시보드 보조 패널         | 추천 액션/워크플로우 랭킹 로드 실패 시 패널 오류와 toast가 함께 노출됨 | 패널 내부 오류 상태만 노출        | 보조 패널 실패로 여러 toast가 연속 표시되지 않도록 정리       |
+| 대시보드 전체 실패         | 모든 대시보드 요청 실패 시 화면 하단의 오류 상태가 표시됨              | 화면 단위 오류 상태로 유지        | passive load 실패는 toast 없이 화면 상태로 표현               |
+| 시뮬레이션 보조 목록       | 피드백/개선 후보/검증 케이스 목록 로드 실패가 toast로 표시됨           | 각 목록 영역에 오류와 재시도 제공 | 보조 목록 실패를 작업 흐름을 가로막지 않는 panel error로 전환 |
+| 사용자 액션 실패           | 세션 생성, 메시지 전송, 저장, 승인, 반려, replay 실패가 toast로 표시됨 | 유지                              | 사용자가 방금 실행한 action 실패는 즉시 인지 가능해야 함      |
+| 액션 후 후속 새로고침 실패 | primary action 성공 뒤 보조 목록 새로고침 실패도 toast로 표시됨        | 관련 패널 오류로 표시             | 성공 toast와 보조 오류 toast가 연속되는 상황을 줄임           |
+
+---
+
+## Component Tree
+
+```text
+WorkspaceDashboardPage
+├─ DashboardFilters
+├─ ActionRecommendationsPanel
+│  └─ ErrorState
+├─ DashboardMetricsGrid
+├─ AutomationCoveragePanel
+├─ KnowledgePackHealthPanel
+├─ HotpathWorkflowRankingPanel
+│  └─ ErrorState
+└─ DashboardStatePanel
+
+WorkspaceSimulationPage
+├─ sessionPane
+├─ chatPane
+└─ statePane
+   ├─ Runtime State
+   │  └─ GoldenCasePanel
+   │     └─ ErrorState(onRetry)
+   ├─ FeedbackPanel
+   │  └─ FeedbackListPanel
+   │     └─ ErrorState(onRetry)
+   └─ CandidatesPanel
+      └─ ErrorState(onRetry)
+```
+
+---
+
+## API Integration
+
+### Endpoints
+
+| Method         | Path                                                                                          | Description                                                  |
+| -------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| GET            | 확인됨: `frontend/src/features/consultation/api/consultationApi.ts`                           | 대시보드 지표와 워크플로우 랭킹 조회                         |
+| GET            | 확인됨: `frontend/src/features/workspace-dashboard-health/api/workspaceDashboardHealthApi.ts` | 대시보드 추천 액션 조회                                      |
+| GET/POST/PATCH | 확인됨: `frontend/src/features/simulation/api/simulationApi.ts`                               | 시뮬레이션 세션, 피드백, 개선 후보, 검증 케이스 조회 및 액션 |
+
+### Error Policy
+
+| 오류 유형                                     | 표시 정책                                       |
+| --------------------------------------------- | ----------------------------------------------- |
+| fatal screen load failure                     | 화면 단위 `ErrorState` 또는 기존 전체 오류 상태 |
+| secondary panel load failure                  | 해당 패널 내부 `ErrorState`와 `다시 시도`       |
+| user-triggered primary action failure         | `toast.error` 유지                              |
+| user-triggered action success                 | 기존 `toast.success` 유지                       |
+| action success 이후 secondary refresh failure | 관련 패널 내부 `ErrorState`                     |
+
+---
+
+## Data Flow
+
+```text
+Page load
+  -> passive data request
+  -> success: panel data state
+  -> failure: panel error state, no toast
+
+User action
+  -> mutation/request
+  -> success: success toast where already expected
+  -> failure: error toast
+  -> secondary refresh failure: panel error state
+```
+
+---
+
+## 수정 대상 파일
+
+| 파일                                                                              | 변경 유형 | 설명                                                                      |
+| --------------------------------------------------------------------------------- | --------- | ------------------------------------------------------------------------- |
+| `frontend/src/pages/workspace/ui/WorkspaceDashboardPage.tsx`                      | modify    | passive dashboard load failure toast 제거, 기존 패널 오류 상태 유지       |
+| `frontend/src/pages/workspace/ui/WorkspaceDashboardPage.test.tsx`                 | modify    | 보조/전체 load failure가 toast를 발생시키지 않는지 검증                   |
+| `frontend/src/pages/workspace/ui/WorkspaceSimulationPage.tsx`                     | modify    | 피드백/개선 후보/검증 케이스 목록 오류 상태와 재시도 추가                 |
+| `frontend/src/pages/workspace/ui/WorkspaceSimulationPage.test.tsx`                | modify    | 보조 목록 실패가 패널 오류로 표시되고 action 실패 toast는 유지되는지 검증 |
+| `frontend/src/pages/workspace/ui/simulation/workspace-simulation-page.module.css` | modify    | 보조 패널 오류 상태 레이아웃 추가                                         |
+
+---
+
+## State Management
+
+### Local UI State
+
+- `feedbackError`, `candidateError`, `goldenCaseError`를 시뮬레이션 페이지 내부 상태로 관리한다.
+- passive load 성공 시 해당 오류 상태를 해제한다.
+- passive load 실패 시 목록을 비우고 관련 오류 상태를 설정한다.
+- 재시도 버튼은 기존 list API를 다시 호출한다.
+
+---
+
+## Tests
+
+### Test Strategy
+
+| 구분        | 방법                       | 도구                    | 비고                               |
+| ----------- | -------------------------- | ----------------------- | ---------------------------------- |
+| 통합 테스트 | 페이지 렌더링 + mocked API | Vitest, Testing Library | 대시보드/시뮬레이션 오류 정책 검증 |
+| 수동 확인   | 필요 시 브라우저 확인      | Vite dev server         | 이번 범위는 상태 전환 테스트 중심  |
+
+### Test Scenarios
+
+#### Error & Edge Cases
+
+| #   | 시나리오                                                        | 기대 결과                                                              |
+| --- | --------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| 1   | 대시보드 passive load 요청들이 실패                             | 패널/화면 오류가 표시되고 toast는 호출되지 않음                        |
+| 2   | 시뮬레이션 피드백 목록 로드 실패                                | 피드백 패널에 오류와 재시도 버튼이 표시되고 toast는 호출되지 않음      |
+| 3   | 시뮬레이션 개선 후보 목록 로드 실패                             | 개선 후보 패널에 오류와 재시도 버튼이 표시되고 toast는 호출되지 않음   |
+| 4   | 시뮬레이션 검증 케이스 목록 로드 실패                           | 검증 케이스 패널에 오류와 재시도 버튼이 표시되고 toast는 호출되지 않음 |
+| 5   | 세션 생성/메시지 전송/피드백 저장/후보 승인 등 사용자 액션 실패 | 기존 실패 toast 유지                                                   |
+| 6   | 액션 성공 후 보조 목록 새로고침 실패                            | 성공 toast는 유지되고 보조 오류는 패널 내부에 표시                     |
+
+### 반응형 & 접근성
+
+| #   | 확인 항목       | 기대 결과                                               |
+| --- | --------------- | ------------------------------------------------------- |
+| 1   | 키보드 탐색     | 패널 내부 `다시 시도` 버튼이 포커스 가능                |
+| 2   | 스크린 리더     | `ErrorState` 메시지와 버튼 텍스트가 읽힘                |
+| 3   | 모바일 레이아웃 | 기존 단일 컬럼 전환에서 오류 상태가 목록 영역 안에 유지 |
+
+---
+
+## Non-goals
+
+- API 에러 메시지 표준화 전체 개편은 하지 않는다.
+- 백엔드 에러 코드 체계는 변경하지 않는다.
+- 모든 화면의 toast 정책을 전역 유틸리티로 추상화하지 않는다.
+- generated API 파일은 직접 수정하지 않는다.
+
+---
+
+## Open Questions
+
+- 다른 workspace 하위 화면에도 동일 정책을 확장할지는 후속 이슈에서 판단한다.

--- a/frontend/src/pages/workspace/ui/WorkspaceDashboardPage.test.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceDashboardPage.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { toast } from "sonner";
 
 import { consultationApi } from "@/features/consultation/api/consultationApi";
 import { fetchWorkspaceDashboardActionRecommendations } from "@/features/workspace-dashboard-health/api/workspaceDashboardHealthApi";
@@ -18,6 +19,7 @@ const mockedGetWorkflowRankings = vi.mocked(
 const mockedFetchActionRecommendations = vi.mocked(
   fetchWorkspaceDashboardActionRecommendations,
 );
+const mockedToastError = vi.mocked(toast.error);
 
 const metricsResponse = {
   workspaceId: 1,
@@ -236,6 +238,7 @@ vi.mock("@/features/workspace-dashboard-health", () => ({
 
 describe("WorkspaceDashboardPage", () => {
   beforeEach(() => {
+    mockedToastError.mockReset();
     mockedGetMetrics.mockReset();
     mockedGetWorkflowRankings.mockReset();
     mockedFetchActionRecommendations.mockReset();
@@ -471,6 +474,29 @@ describe("WorkspaceDashboardPage", () => {
       "일부 운영 데이터만 확인됩니다.",
     );
     expect(screen.queryByTestId("dashboard-error")).not.toBeInTheDocument();
+  });
+
+  it("passive load 실패는 화면 상태로 표시하고 toast를 띄우지 않는다", async () => {
+    mockedGetMetrics.mockRejectedValueOnce(new Error("metrics failed"));
+    mockedGetWorkflowRankings.mockRejectedValueOnce(
+      new Error("rankings failed"),
+    );
+    mockedFetchActionRecommendations.mockRejectedValueOnce(
+      new Error("recommendations failed"),
+    );
+
+    renderPage();
+
+    expect(
+      await screen.findByText("대시보드 데이터를 불러오지 못했습니다."),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("recommendation-error")).toHaveTextContent(
+      "추천 액션을 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.",
+    );
+    expect(screen.getByTestId("hotpath-error")).toHaveTextContent(
+      "워크플로우 랭킹을 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.",
+    );
+    expect(mockedToastError).not.toHaveBeenCalled();
   });
 
   it("loading, error, partial 상태 패널이 같은 shell 영역에서 렌더링된다", () => {

--- a/frontend/src/pages/workspace/ui/WorkspaceDashboardPage.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceDashboardPage.tsx
@@ -7,7 +7,6 @@ import {
   FlaskConicalIcon,
   RefreshCwIcon,
 } from "lucide-react";
-import { toast } from "sonner";
 
 import { consultationApi } from "@/features/consultation/api/consultationApi";
 import type {
@@ -1092,7 +1091,6 @@ export function WorkspaceDashboardPage() {
         console.error("Failed to load dashboard metrics:", error);
         setMetrics(null);
         setMetricsError("대시보드 지표를 불러오지 못했습니다.");
-        toast.error("대시보드 지표를 불러오지 못했습니다.");
       } finally {
         if (!ignore) {
           setIsMetricsLoading(false);
@@ -1141,8 +1139,9 @@ export function WorkspaceDashboardPage() {
           error,
         );
         setActionRecommendations(null);
-        setActionRecommendationsError("추천 액션을 불러오지 못했습니다.");
-        toast.error("추천 액션을 불러오지 못했습니다.");
+        setActionRecommendationsError(
+          "추천 액션을 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.",
+        );
       } finally {
         if (!ignore) {
           setIsActionRecommendationsLoading(false);
@@ -1188,8 +1187,9 @@ export function WorkspaceDashboardPage() {
         if (ignore) return;
         console.error("Failed to load workflow rankings:", error);
         setWorkflowRankings(null);
-        setWorkflowRankingsError("워크플로우 랭킹을 불러오지 못했습니다.");
-        toast.error("워크플로우 랭킹을 불러오지 못했습니다.");
+        setWorkflowRankingsError(
+          "워크플로우 랭킹을 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.",
+        );
       } finally {
         if (!ignore) {
           setIsWorkflowRankingsLoading(false);

--- a/frontend/src/pages/workspace/ui/WorkspaceSimulationPage.test.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceSimulationPage.test.tsx
@@ -514,13 +514,57 @@ describe("WorkspaceSimulationPage", () => {
       "시뮬레이션 피드백을 남겼습니다.",
     );
     await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith(
-        "피드백 목록 새로고침에 실패했습니다.",
-      );
+      expect(
+        screen.getByText("시뮬레이션 피드백 목록을 불러오지 못했습니다."),
+      ).toBeInTheDocument();
     });
+    expect(toast.error).not.toHaveBeenCalledWith(
+      "시뮬레이션 피드백 목록을 불러오지 못했습니다.",
+    );
     expect(toast.error).not.toHaveBeenCalledWith(
       "시뮬레이션 피드백을 저장하지 못했습니다.",
     );
+  });
+
+  it("피드백 목록 로드 실패는 패널 내부 오류와 재시도를 제공한다", async () => {
+    mockedSimulationApi.listFeedback.mockRejectedValueOnce(
+      new Error("load failed"),
+    );
+    renderPage();
+
+    await openFeedbackTab();
+    expect(
+      await screen.findByText("시뮬레이션 피드백 목록을 불러오지 못했습니다."),
+    ).toBeInTheDocument();
+    expect(toast.error).not.toHaveBeenCalledWith(
+      "시뮬레이션 피드백 목록을 불러오지 못했습니다.",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "다시 시도" }));
+
+    expect(
+      await screen.findByText("주문번호를 묻지 않았습니다."),
+    ).toBeInTheDocument();
+  });
+
+  it("검증 케이스 목록 로드 실패는 패널 내부 오류로 표시한다", async () => {
+    mockedSimulationApi.listGoldenCases.mockRejectedValueOnce(
+      new Error("load failed"),
+    );
+    renderPage();
+
+    expect(
+      await screen.findByText("검증 케이스 목록을 불러오지 못했습니다."),
+    ).toBeInTheDocument();
+    expect(toast.error).not.toHaveBeenCalledWith(
+      "검증 케이스 목록을 불러오지 못했습니다.",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "다시 시도" }));
+
+    expect(
+      await screen.findByText("저장된 검증 케이스가 없습니다."),
+    ).toBeInTheDocument();
   });
 
   it("OPEN 피드백에서 개선 후보를 생성하고 목록을 새로고침한다", async () => {
@@ -560,10 +604,13 @@ describe("WorkspaceSimulationPage", () => {
     });
     expect(toast.success).toHaveBeenCalledWith("개선 후보를 생성했습니다.");
     await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith(
-        "개선 후보 목록 새로고침에 실패했습니다.",
-      );
+      expect(
+        screen.getByText("개선 후보 목록을 불러오지 못했습니다."),
+      ).toBeInTheDocument();
     });
+    expect(toast.error).not.toHaveBeenCalledWith(
+      "개선 후보 목록을 불러오지 못했습니다.",
+    );
     expect(toast.error).not.toHaveBeenCalledWith(
       "개선 후보를 생성하지 못했습니다.",
     );
@@ -633,10 +680,13 @@ describe("WorkspaceSimulationPage", () => {
       "개선 후보 상태를 변경했습니다.",
     );
     await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith(
-        "개선 후보 목록 새로고침에 실패했습니다.",
-      );
+      expect(
+        screen.getByText("개선 후보 목록을 불러오지 못했습니다."),
+      ).toBeInTheDocument();
     });
+    expect(toast.error).not.toHaveBeenCalledWith(
+      "개선 후보 목록을 불러오지 못했습니다.",
+    );
     expect(toast.error).not.toHaveBeenCalledWith(
       "개선 후보 상태를 변경하지 못했습니다.",
     );
@@ -682,17 +732,25 @@ describe("WorkspaceSimulationPage", () => {
     expect(screen.getAllByText("근거").length).toBeGreaterThan(0);
   });
 
-  it("개선 후보 목록 로드 실패를 토스트로 알린다", async () => {
+  it("개선 후보 목록 로드 실패는 패널 내부 오류와 재시도를 제공한다", async () => {
     mockedSimulationApi.listImprovementCandidates.mockRejectedValueOnce(
       new Error("load failed"),
     );
     renderPage();
 
-    await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith(
-        "개선 후보 목록을 불러오지 못했습니다.",
-      );
-    });
+    await openCandidateTab();
+    expect(
+      await screen.findByText("개선 후보 목록을 불러오지 못했습니다."),
+    ).toBeInTheDocument();
+    expect(toast.error).not.toHaveBeenCalledWith(
+      "개선 후보 목록을 불러오지 못했습니다.",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "다시 시도" }));
+
+    expect(
+      await screen.findByText("조건에 맞는 개선 후보가 없습니다."),
+    ).toBeInTheDocument();
   });
 
   it("개선 후보 생성 실패를 토스트로 알린다", async () => {

--- a/frontend/src/pages/workspace/ui/WorkspaceSimulationPage.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceSimulationPage.tsx
@@ -91,6 +91,10 @@ const CANDIDATE_STATUSES: Array<{
   { value: "", label: "전체" },
 ];
 
+const FEEDBACK_LIST_ERROR = "시뮬레이션 피드백 목록을 불러오지 못했습니다.";
+const CANDIDATE_LIST_ERROR = "개선 후보 목록을 불러오지 못했습니다.";
+const GOLDEN_CASE_LIST_ERROR = "검증 케이스 목록을 불러오지 못했습니다.";
+
 const ACTION_TYPES = [
   "ASK_SLOT",
   "ADVANCE",
@@ -302,6 +306,9 @@ export function WorkspaceSimulationPage() {
     SimulationImprovementCandidate[]
   >([]);
   const [goldenCases, setGoldenCases] = useState<SimulationGoldenCase[]>([]);
+  const [feedbackError, setFeedbackError] = useState<string | null>(null);
+  const [candidateError, setCandidateError] = useState<string | null>(null);
+  const [goldenCaseError, setGoldenCaseError] = useState<string | null>(null);
   const [candidateStatusFilter, setCandidateStatusFilter] = useState<
     SimulationImprovementCandidateStatus | ""
   >(() => candidateStatusFromQuery);
@@ -355,34 +362,62 @@ export function WorkspaceSimulationPage() {
 
   const reloadFeedback = async (status = feedbackStatusFilter) => {
     if (parsedWorkspaceId === null) return;
-    const page = await simulationApi.listFeedback(parsedWorkspaceId, {
-      status,
-      page: 0,
-      size: PAGE_SIZE,
-    });
-    setFeedbackItems(page.content);
+    setFeedbackError(null);
+    try {
+      const page = await simulationApi.listFeedback(parsedWorkspaceId, {
+        status,
+        page: 0,
+        size: PAGE_SIZE,
+      });
+      setFeedbackItems(page.content);
+    } catch (error) {
+      console.error("Failed to load simulation feedback list:", error);
+      setFeedbackItems([]);
+      setFeedbackError(FEEDBACK_LIST_ERROR);
+      throw error;
+    }
   };
 
   const reloadCandidates = async (status = candidateStatusFilter) => {
     if (parsedWorkspaceId === null) return;
-    const page = await simulationApi.listImprovementCandidates(
-      parsedWorkspaceId,
-      {
-        status,
-        page: 0,
-        size: PAGE_SIZE,
-      },
-    );
-    setCandidateItems(page.content);
+    setCandidateError(null);
+    try {
+      const page = await simulationApi.listImprovementCandidates(
+        parsedWorkspaceId,
+        {
+          status,
+          page: 0,
+          size: PAGE_SIZE,
+        },
+      );
+      setCandidateItems(page.content);
+    } catch (error) {
+      console.error("Failed to load simulation improvement candidates:", error);
+      setCandidateItems([]);
+      setCandidateError(CANDIDATE_LIST_ERROR);
+      throw error;
+    }
   };
 
   const reloadGoldenCases = async () => {
     if (parsedWorkspaceId === null) return;
-    const page = await simulationApi.listGoldenCases(parsedWorkspaceId, {
-      page: 0,
-      size: PAGE_SIZE,
-    });
-    setGoldenCases(page.content);
+    setGoldenCaseError(null);
+    try {
+      const page = await simulationApi.listGoldenCases(parsedWorkspaceId, {
+        page: 0,
+        size: PAGE_SIZE,
+      });
+      setGoldenCases(page.content);
+    } catch (error) {
+      console.error("Failed to load simulation golden cases:", error);
+      setGoldenCases([]);
+      setGoldenCaseError(GOLDEN_CASE_LIST_ERROR);
+      throw error;
+    }
+  };
+
+  const reloadFeedbackAndCandidates = async () => {
+    await Promise.allSettled([reloadFeedback(), reloadCandidates()]);
   };
 
   useEffect(() => {
@@ -452,6 +487,7 @@ export function WorkspaceSimulationPage() {
 
     let active = true;
     setIsLoadingFeedback(true);
+    setFeedbackError(null);
     simulationApi
       .listFeedback(parsedWorkspaceId, {
         status: feedbackStatusFilter,
@@ -461,9 +497,11 @@ export function WorkspaceSimulationPage() {
       .then((page) => {
         if (active) setFeedbackItems(page.content);
       })
-      .catch(() => {
-        if (active)
-          toast.error("시뮬레이션 피드백 목록을 불러오지 못했습니다.");
+      .catch((error) => {
+        if (!active) return;
+        console.error("Failed to load simulation feedback list:", error);
+        setFeedbackItems([]);
+        setFeedbackError(FEEDBACK_LIST_ERROR);
       })
       .finally(() => {
         if (active) setIsLoadingFeedback(false);
@@ -479,6 +517,7 @@ export function WorkspaceSimulationPage() {
 
     let active = true;
     setIsLoadingCandidates(true);
+    setCandidateError(null);
     simulationApi
       .listImprovementCandidates(parsedWorkspaceId, {
         status: candidateStatusFilter,
@@ -488,8 +527,14 @@ export function WorkspaceSimulationPage() {
       .then((page) => {
         if (active) setCandidateItems(page.content);
       })
-      .catch(() => {
-        if (active) toast.error("개선 후보 목록을 불러오지 못했습니다.");
+      .catch((error) => {
+        if (!active) return;
+        console.error(
+          "Failed to load simulation improvement candidates:",
+          error,
+        );
+        setCandidateItems([]);
+        setCandidateError(CANDIDATE_LIST_ERROR);
       })
       .finally(() => {
         if (active) setIsLoadingCandidates(false);
@@ -505,13 +550,17 @@ export function WorkspaceSimulationPage() {
 
     let active = true;
     setIsLoadingGoldenCases(true);
+    setGoldenCaseError(null);
     simulationApi
       .listGoldenCases(parsedWorkspaceId, { page: 0, size: PAGE_SIZE })
       .then((page) => {
         if (active) setGoldenCases(page.content);
       })
-      .catch(() => {
-        if (active) toast.error("검증 케이스 목록을 불러오지 못했습니다.");
+      .catch((error) => {
+        if (!active) return;
+        console.error("Failed to load simulation golden cases:", error);
+        setGoldenCases([]);
+        setGoldenCaseError(GOLDEN_CASE_LIST_ERROR);
       })
       .finally(() => {
         if (active) setIsLoadingGoldenCases(false);
@@ -626,11 +675,7 @@ export function WorkspaceSimulationPage() {
       setFeedbackDescription("");
       setFeedbackExpectedBehavior("");
       toast.success("시뮬레이션 피드백을 남겼습니다.");
-      try {
-        await reloadFeedback();
-      } catch {
-        toast.error("피드백 목록 새로고침에 실패했습니다.");
-      }
+      await reloadFeedback().catch(() => undefined);
     } catch {
       toast.error("시뮬레이션 피드백을 저장하지 못했습니다.");
     } finally {
@@ -647,11 +692,7 @@ export function WorkspaceSimulationPage() {
       );
       toast.success("개선 후보를 생성했습니다.");
       setActiveSideTab("candidates");
-      try {
-        await Promise.all([reloadFeedback(), reloadCandidates()]);
-      } catch {
-        toast.error("개선 후보 목록 새로고침에 실패했습니다.");
-      }
+      await reloadFeedbackAndCandidates();
     } catch {
       toast.error("개선 후보를 생성하지 못했습니다.");
     } finally {
@@ -673,11 +714,7 @@ export function WorkspaceSimulationPage() {
         },
       );
       toast.success("개선 후보 상태를 변경했습니다.");
-      try {
-        await reloadCandidates();
-      } catch {
-        toast.error("개선 후보 목록 새로고침에 실패했습니다.");
-      }
+      await reloadCandidates().catch(() => undefined);
     } catch {
       toast.error("개선 후보 상태를 변경하지 못했습니다.");
     } finally {
@@ -698,7 +735,7 @@ export function WorkspaceSimulationPage() {
         },
       );
       toast.success("개선 후보를 초안 버전에 반영했습니다.");
-      await Promise.all([reloadCandidates(), reloadFeedback()]);
+      await reloadFeedbackAndCandidates();
     } catch {
       toast.error("개선 후보를 승인하지 못했습니다.");
     } finally {
@@ -727,7 +764,7 @@ export function WorkspaceSimulationPage() {
         delete next[candidate.id];
         return next;
       });
-      await Promise.all([reloadCandidates(), reloadFeedback()]);
+      await reloadFeedbackAndCandidates();
     } catch {
       toast.error("개선 후보를 반려하지 못했습니다.");
     } finally {
@@ -761,11 +798,7 @@ export function WorkspaceSimulationPage() {
         },
       );
       toast.success("검증 케이스를 저장했습니다.");
-      try {
-        await reloadGoldenCases();
-      } catch {
-        toast.error("검증 케이스 목록 새로고침에 실패했습니다.");
-      }
+      await reloadGoldenCases().catch(() => undefined);
     } catch {
       toast.error("검증 케이스를 저장하지 못했습니다.");
     } finally {
@@ -793,11 +826,7 @@ export function WorkspaceSimulationPage() {
           ? "검증 케이스 replay가 통과했습니다."
           : "검증 케이스 replay가 실패했습니다.",
       );
-      try {
-        await reloadGoldenCases();
-      } catch {
-        toast.error("검증 케이스 목록 새로고침에 실패했습니다.");
-      }
+      await reloadGoldenCases().catch(() => undefined);
     } catch {
       toast.error("검증 케이스 replay를 실행하지 못했습니다.");
     } finally {
@@ -1142,6 +1171,15 @@ export function WorkspaceSimulationPage() {
                   <p className={styles.feedbackMuted}>
                     검증 케이스를 불러오는 중입니다.
                   </p>
+                ) : goldenCaseError ? (
+                  <div className={styles.secondaryErrorState}>
+                    <ErrorState
+                      message={goldenCaseError}
+                      onRetry={() => {
+                        void reloadGoldenCases().catch(() => undefined);
+                      }}
+                    />
+                  </div>
                 ) : goldenCases.length === 0 ? (
                   <p className={styles.feedbackMuted}>
                     저장된 검증 케이스가 없습니다.
@@ -1358,6 +1396,15 @@ export function WorkspaceSimulationPage() {
                   <p className={styles.feedbackMuted}>
                     피드백을 불러오는 중입니다.
                   </p>
+                ) : feedbackError ? (
+                  <div className={styles.secondaryErrorState}>
+                    <ErrorState
+                      message={feedbackError}
+                      onRetry={() => {
+                        void reloadFeedback().catch(() => undefined);
+                      }}
+                    />
+                  </div>
                 ) : feedbackItems.length === 0 ? (
                   <p className={styles.feedbackMuted}>
                     조건에 맞는 피드백이 없습니다.
@@ -1438,6 +1485,15 @@ export function WorkspaceSimulationPage() {
                   <p className={styles.feedbackMuted}>
                     개선 후보를 불러오는 중입니다.
                   </p>
+                ) : candidateError ? (
+                  <div className={styles.secondaryErrorState}>
+                    <ErrorState
+                      message={candidateError}
+                      onRetry={() => {
+                        void reloadCandidates().catch(() => undefined);
+                      }}
+                    />
+                  </div>
                 ) : candidateItems.length === 0 ? (
                   <p className={styles.feedbackMuted}>
                     조건에 맞는 개선 후보가 없습니다.

--- a/frontend/src/pages/workspace/ui/simulation/workspace-simulation-page.module.css
+++ b/frontend/src/pages/workspace/ui/simulation/workspace-simulation-page.module.css
@@ -563,6 +563,18 @@
   line-height: 1.6;
 }
 
+.secondaryErrorState {
+  display: flex;
+  min-height: 132px;
+  align-items: center;
+  justify-content: center;
+  border: 1px dashed var(--line);
+  border-radius: var(--r-3);
+  background: var(--paper);
+  padding: var(--s-4);
+  text-align: center;
+}
+
 .feedbackList {
   display: grid;
   gap: var(--s-2);

--- a/frontend/src/shared/ui/sonner.module.css
+++ b/frontend/src/shared/ui/sonner.module.css
@@ -1,0 +1,8 @@
+.passiveSuccessToast {
+  pointer-events: none;
+}
+
+.passiveSuccessToast [data-button],
+.passiveSuccessToast [data-close-button] {
+  pointer-events: auto;
+}

--- a/frontend/src/shared/ui/sonner.tsx
+++ b/frontend/src/shared/ui/sonner.tsx
@@ -7,7 +7,12 @@ import {
 } from "lucide-react";
 import { Toaster as Sonner, type ToasterProps } from "sonner";
 
-const Toaster = ({ ...props }: ToasterProps) => {
+import { cn } from "../lib/utils";
+import styles from "./sonner.module.css";
+
+const Toaster = ({ toastOptions, ...props }: ToasterProps) => {
+  const toastClassNames = toastOptions?.classNames;
+
   return (
     <Sonner
       theme="light"
@@ -33,6 +38,13 @@ const Toaster = ({ ...props }: ToasterProps) => {
           "--border-radius": "var(--radius)",
         } as React.CSSProperties
       }
+      toastOptions={{
+        ...toastOptions,
+        classNames: {
+          ...toastClassNames,
+          success: cn(styles.passiveSuccessToast, toastClassNames?.success),
+        },
+      }}
       {...props}
     />
   );


### PR DESCRIPTION
Closes #637

## 변경 사항

- 대시보드 passive load 실패가 toast를 연속으로 띄우지 않고 화면/패널 오류 상태로 안내되도록 정리했습니다.
- 시뮬레이션의 피드백, 개선 후보, 검증 케이스 목록 실패를 각 패널 내부 오류와 재시도로 표시하도록 했습니다.
- 사용자 직접 액션의 성공 toast와 실패 toast는 유지하고, 액션 성공 뒤 보조 목록 새로고침 실패는 관련 패널 오류로 표시합니다.
- 이슈 637 스펙을 `.agent/specs/637.md`에 정리했습니다.

## 검증

- `git diff --check`
- `pnpm --dir frontend test -- WorkspaceDashboardPage.test.tsx WorkspaceSimulationPage.test.tsx`

## 참고

- commit pre-commit hook의 `pnpm run lint:frontend`는 `audit:api`, `audit:fsd` 통과 후 repository-wide 기존 ESLint baseline 47건으로 실패했습니다. 실패 파일은 이번 변경 파일이 아닌 workflow/auth/workspace/domain-pack/billing 등 기존 lint 대상입니다.