### PR TITLE
feat(frontend): 상담 선택 요소의 접근성을 보장

### DIFF
--- a/.agent/specs/635.md
+++ b/.agent/specs/635.md
@@ -1,0 +1,113 @@
+# Frontend FSD Spec: 상담 선택 요소 접근성 개선
+
+## Goal
+
+상담 큐와 채팅 메시지 선택 요소를 네이티브 버튼 기반 인터랙션으로 정리하여 상담사가 키보드와 스크린리더에서 동일하게 선택 상태와 동작을 인지할 수 있게 한다.
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A[상담 화면 진입] --> B[상담 큐 확인]
+    B --> C{상담 선택}
+    C -->|Click| D[선택 상담 활성화]
+    C -->|Tab + Enter/Space| D
+    D --> E[메시지 목록 확인]
+    E --> F{메시지 선택}
+    F -->|Click| G[메시지 선택 표시]
+    F -->|Tab + Enter/Space| G
+    G --> H{같은 메시지 재선택}
+    H -->|Click 또는 Enter/Space| I[메시지 선택 해제]
+```
+
+## Design Diff
+
+### As-is vs To-be
+
+| 영역               | As-is                               | To-be                           | 변경 내용                                                       |
+| ------------------ | ----------------------------------- | ------------------------------- | --------------------------------------------------------------- |
+| 상담 큐 항목       | `div role="button"` + 수동 keydown  | 네이티브 `button`               | 기본 버튼 semantics와 Enter/Space 동작 사용                     |
+| 상담 큐 선택 상태  | `aria-current`를 custom role에 부여 | `button`에 `aria-current` 유지  | 현재 선택 상담이 스크린리더에 전달되도록 유지                   |
+| 메시지 선택        | `div role="button"` + 수동 keydown  | 메시지 본문 선택 `button`       | 메시지 선택 동작을 사용자 관점 role/name으로 검증 가능하게 변경 |
+| 메시지 선택 상태   | `aria-pressed`를 custom role에 부여 | 선택 버튼에 `aria-pressed` 유지 | 선택/해제 가능한 toggle 의미 유지                               |
+| 실패 메시지 재전송 | 선택 그룹 내부 재전송 버튼          | 선택 버튼과 재전송 버튼 분리    | 네이티브 버튼 중첩을 피하고 재전송 액션 독립성 유지             |
+
+## Component Tree
+
+```text
+ConsultationPage
+├─ QueuePanel
+│  ├─ 검색 input
+│  ├─ 필터 button group
+│  ├─ 정렬 button group
+│  └─ 상담 큐 button list
+└─ ChatPanel
+   ├─ 메시지 목록
+   │  ├─ 시스템/내부 메모 표시
+   │  └─ 선택 가능한 메시지 button
+   └─ 메시지 입력 영역
+```
+
+## API Integration
+
+API 계약 변경은 없다. `frontend/src/features/consultation/ui/QueuePanel.tsx`와 `frontend/src/features/consultation/ui/ChatPanel.tsx`의 DOM semantics 및 접근성 속성만 변경한다.
+
+## Data Flow
+
+```text
+QueuePanel
+└─ button 선택 -> onSelectCustomer(customerId)
+
+ChatPanel
+└─ message button 선택 -> onSelectMessage(messageId | null)
+```
+
+## 수정 대상 파일
+
+| 파일                                                           | 변경 유형 | 설명                                                                |
+| -------------------------------------------------------------- | --------- | ------------------------------------------------------------------- |
+| `frontend/src/features/consultation/ui/QueuePanel.tsx`         | modify    | 큐 아이템을 네이티브 버튼으로 전환                                  |
+| `frontend/src/features/consultation/ui/queue-panel.module.css` | modify    | 버튼 기본 스타일 제거 및 기존 행 레이아웃 유지                      |
+| `frontend/src/features/consultation/ui/ChatPanel.tsx`          | modify    | 메시지 선택 요소를 네이티브 버튼으로 전환하고 재전송 버튼 중첩 제거 |
+| `frontend/src/features/consultation/ui/chat-panel.module.css`  | modify    | 메시지 선택 버튼/그룹 레이아웃 유지                                 |
+| `frontend/src/features/consultation/ui/QueuePanel.test.tsx`    | modify    | role/name 기반 큐 선택 테스트로 변경                                |
+| `frontend/src/features/consultation/ui/ChatPanel.test.tsx`     | modify    | role/name 및 `aria-pressed` 기반 메시지 선택 테스트로 변경          |
+| `frontend/src/pages/consultation/ui/ConsultationPage.test.tsx`  | modify    | 페이지 통합 테스트의 큐/메시지 선택 쿼리를 role/name 기반으로 변경 |
+| `frontend/src/pages/consultation/ui/ConsultationPage.generated-api.test.tsx` | modify | generated API 통합 테스트의 큐 선택 쿼리를 role/name 기반으로 변경 |
+| `frontend/src/pages/consultation/ui/sections/Queue.tsx`         | modify    | section queue 항목을 네이티브 버튼으로 전환                         |
+| `frontend/src/pages/consultation/ui/sections/consultation-sections.test.tsx` | modify | section queue 키보드 테스트를 네이티브 버튼 동작 기준으로 변경 |
+| `frontend/e2e/consultation.spec.ts`                             | modify    | 상담 큐 E2E selector를 네이티브 button role 기준으로 변경           |
+
+## State Management
+
+새 상태는 추가하지 않는다. 기존 `activeCustomerId`, `selectedMessageId`, `onSelectCustomer`, `onSelectMessage` 계약을 유지한다.
+
+## Tests
+
+### Test Strategy
+
+| 구분            | 방법                       | 도구                           | 비고                                   |
+| --------------- | -------------------------- | ------------------------------ | -------------------------------------- |
+| 컴포넌트 테스트 | 사용자 관점 role/name 쿼리 | Vitest + React Testing Library | `closest('[role="button"]')` 의존 제거 |
+| 키보드 테스트   | focus 후 Enter/Space 입력  | `@testing-library/user-event`  | 네이티브 버튼 동작 검증                |
+
+### Test Scenarios
+
+| #   | 시나리오                       | 기대 결과                                            |
+| --- | ------------------------------ | ---------------------------------------------------- |
+| 1   | 큐 아이템 클릭                 | `onSelectCustomer(customerId)` 호출                  |
+| 2   | 큐 아이템 focus 후 Enter/Space | `onSelectCustomer(customerId)` 호출                  |
+| 3   | active 큐 아이템               | `aria-current="true"` 표현                           |
+| 4   | 메시지 클릭 또는 Enter/Space   | `onSelectMessage(messageId)` 호출                    |
+| 5   | 선택된 메시지 재선택           | `onSelectMessage(null)` 호출                         |
+| 6   | 실패 메시지 재전송 버튼 클릭   | `onRetryMessage(messageId)` 호출, 메시지 선택 미발생 |
+
+## Non-goals
+
+- 상담 큐 정렬/필터 로직은 변경하지 않는다.
+- 메시지 순서 race condition은 #557 범위로 유지한다.
+- API 응답, WebSocket 동기화, 채팅 전송 로직은 변경하지 않는다.
+
+## Open Questions
+
+- 없음. 이 이슈 범위에서는 semantic button 패턴으로 요구사항을 충족한다.

--- a/frontend/e2e/consultation.spec.ts
+++ b/frontend/e2e/consultation.spec.ts
@@ -81,7 +81,10 @@ test.describe("Consultation screen", () => {
       test("Then the visible sessions follow the selected controls", async ({ page }, testInfo) => {
         await page.goto("/workspaces/1/consultation");
 
-        const queueItems = page.locator("aside").locator('div[role="button"]');
+        const queueItems = page
+          .locator("aside")
+          .getByRole("button")
+          .filter({ hasText: /김민지|박준호|이서연|최하늘/ });
         await expect(page.getByText("연결 요청 2건 · 미배정 2건 · 진행 4건")).toBeVisible();
         await expect(queueItems.first()).toContainText("김민지");
 

--- a/frontend/src/features/consultation/ui/ChatPanel.test.tsx
+++ b/frontend/src/features/consultation/ui/ChatPanel.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { ChatPanel, type ChatMessage } from "./ChatPanel";
 
 const baseMessages: ChatMessage[] = [
@@ -37,6 +38,9 @@ const renderChatPanel = (messages: ChatMessage[] = baseMessages, sessionId = "se
       onSelectMessage={vi.fn()}
     />,
   );
+
+const getMessageButton = (messageContent: string) =>
+  screen.getByRole("button", { name: new RegExp(messageContent) });
 
 const setScrollMetrics = (
   element: HTMLElement,
@@ -270,8 +274,9 @@ describe("ChatPanel", () => {
     ).toBeInTheDocument();
   });
 
-  it("고객 메시지는 선택할 수 있고 키보드로도 선택된다", () => {
+  it("고객 메시지는 선택할 수 있고 키보드로도 선택된다", async () => {
     const onSelectMessage = vi.fn();
+    const user = userEvent.setup();
 
     render(
       <ChatPanel
@@ -294,13 +299,14 @@ describe("ChatPanel", () => {
     expect(screen.getByText("김민지")).toBeInTheDocument();
     expect(screen.getByText("환불 문의 드립니다.")).toBeInTheDocument();
 
-    const messageGroup = screen.getByText("환불 문의 드립니다.").closest('[role="button"]');
-    if (!messageGroup) throw new Error("message group not found");
+    const messageButton = getMessageButton("환불 문의 드립니다.");
+    expect(messageButton).toHaveAttribute("aria-pressed", "false");
 
-    fireEvent.click(messageGroup);
+    fireEvent.click(messageButton);
     expect(onSelectMessage).toHaveBeenLastCalledWith("customer-1");
 
-    fireEvent.keyDown(messageGroup, { key: "Enter" });
+    messageButton.focus();
+    await user.keyboard("{Enter}");
     expect(onSelectMessage).toHaveBeenLastCalledWith("customer-1");
   });
   it("시스템 메시지와 내부 메모를 렌더링하고 메모 모드로 전송한다", () => {
@@ -476,15 +482,16 @@ describe("ChatPanel", () => {
       />,
     );
 
-    const messageGroup = screen.getByText("환불 문의 드립니다.").closest('[role="button"]');
-    if (!messageGroup) throw new Error("message group not found");
+    const messageButton = getMessageButton("환불 문의 드립니다.");
+    expect(messageButton).toHaveAttribute("aria-pressed", "true");
 
-    fireEvent.click(messageGroup);
+    fireEvent.click(messageButton);
     expect(onSelectMessage).toHaveBeenCalledWith(null);
   });
 
-  it("메시지가 선택된 상태에서 Space 키를 누르면 선택이 해제된다", () => {
+  it("메시지가 선택된 상태에서 Space 키를 누르면 선택이 해제된다", async () => {
     const onSelectMessage = vi.fn();
+    const user = userEvent.setup();
 
     render(
       <ChatPanel
@@ -504,15 +511,17 @@ describe("ChatPanel", () => {
       />,
     );
 
-    const messageGroup = screen.getByText("환불 문의 드립니다.").closest('[role="button"]');
-    if (!messageGroup) throw new Error("message group not found");
+    const messageButton = getMessageButton("환불 문의 드립니다.");
+    expect(messageButton).toHaveAttribute("aria-pressed", "true");
 
-    fireEvent.keyDown(messageGroup, { key: " " });
+    messageButton.focus();
+    await user.keyboard(" ");
     expect(onSelectMessage).toHaveBeenCalledWith(null);
   });
 
-  it("메시지가 선택되지 않은 상태에서 Space 키를 누르면 메시지가 선택된다", () => {
+  it("메시지가 선택되지 않은 상태에서 Space 키를 누르면 메시지가 선택된다", async () => {
     const onSelectMessage = vi.fn();
+    const user = userEvent.setup();
 
     render(
       <ChatPanel
@@ -532,10 +541,11 @@ describe("ChatPanel", () => {
       />,
     );
 
-    const messageGroup = screen.getByText("환불 문의 드립니다.").closest('[role="button"]');
-    if (!messageGroup) throw new Error("message group not found");
+    const messageButton = getMessageButton("환불 문의 드립니다.");
+    expect(messageButton).toHaveAttribute("aria-pressed", "false");
 
-    fireEvent.keyDown(messageGroup, { key: " " });
+    messageButton.focus();
+    await user.keyboard(" ");
     expect(onSelectMessage).toHaveBeenCalledWith("msg-1");
   });
 

--- a/frontend/src/features/consultation/ui/ChatPanel.tsx
+++ b/frontend/src/features/consultation/ui/ChatPanel.tsx
@@ -246,6 +246,10 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
     }
   };
 
+  const handleMessageSelect = (messageId: string, isSelected: boolean) => {
+    onSelectMessage(isSelected ? null : messageId);
+  };
+
   const renderDeliveryMeta = (msg: ChatMessage, isAgent = false) => {
     if (msg.deliveryStatus === "sending") {
       return (
@@ -357,44 +361,31 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
               <div
                 key={msg.id}
                 className={`${styles.messageGroup} ${isAgent ? styles.messageGroupAgent : styles.messageGroupCustomer} ${isSelected ? styles.messageSelected : ""}`}
-                onClick={() => {
-                  if (isSelected) {
-                    onSelectMessage(null);
-                  } else {
-                    onSelectMessage(msg.id);
-                  }
-                }}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault();
-                    if (isSelected) {
-                      onSelectMessage(null);
-                    } else {
-                      onSelectMessage(msg.id);
-                    }
-                  }
-                }}
-                tabIndex={0}
-                role="button"
-                aria-pressed={isSelected}
               >
-                <div
-                  className={`${styles.msgAvatar} ${isAgent ? styles.msgAvatarAgent : styles.msgAvatarCustomer}`}
+                <button
+                  type="button"
+                  className={`${styles.messageSelectButton} ${isAgent ? styles.messageSelectButtonAgent : ""}`}
+                  onClick={() => handleMessageSelect(msg.id, isSelected)}
+                  aria-pressed={isSelected}
                 >
-                  {isAgent ? role.avatar : customerInitial}
-                </div>
-                <div>
                   <div
-                    className={`${styles.msgBubble} ${isAgent ? styles.msgBubbleAgent : styles.msgBubbleCustomer} ${msg.deliveryStatus === "sending" ? styles.msgBubbleSending : ""} ${msg.deliveryStatus === "failed" ? styles.msgBubbleFailed : ""}`}
+                    className={`${styles.msgAvatar} ${isAgent ? styles.msgAvatarAgent : styles.msgAvatarCustomer}`}
                   >
-                    {msg.content}
+                    {isAgent ? role.avatar : customerInitial}
                   </div>
-                  <div className={`${styles.msgTime} ${isAgent ? styles.msgTimeAgent : ""}`}>
-                    <span>{role.label} · </span>
-                    {msg.timestamp}
+                  <div>
+                    <div
+                      className={`${styles.msgBubble} ${isAgent ? styles.msgBubbleAgent : styles.msgBubbleCustomer} ${msg.deliveryStatus === "sending" ? styles.msgBubbleSending : ""} ${msg.deliveryStatus === "failed" ? styles.msgBubbleFailed : ""}`}
+                    >
+                      {msg.content}
+                    </div>
+                    <div className={`${styles.msgTime} ${isAgent ? styles.msgTimeAgent : ""}`}>
+                      <span>{role.label} · </span>
+                      {msg.timestamp}
+                    </div>
                   </div>
-                  {renderDeliveryMeta(msg, isAgent)}
-                </div>
+                </button>
+                {renderDeliveryMeta(msg, isAgent)}
               </div>
             );
           })}

--- a/frontend/src/features/consultation/ui/QueuePanel.test.tsx
+++ b/frontend/src/features/consultation/ui/QueuePanel.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { QueuePanel } from "./QueuePanel";
 
 type QueuePanelProps = Parameters<typeof QueuePanel>[0];
@@ -31,7 +32,7 @@ const renderQueuePanel = (props: Partial<QueuePanelProps> = {}) =>
   );
 
 const getQueueItem = (customerName: string) =>
-  screen.getByText(customerName).closest('[role="button"]') as HTMLElement;
+  screen.getByRole("button", { name: new RegExp(customerName) });
 
 const getFilterButton = (filterName: string) => {
   const element = screen.getAllByText(filterName).find((item) => item.closest("button"));
@@ -138,17 +139,21 @@ describe("QueuePanel", () => {
     expect(onSelect).toHaveBeenCalledWith("42");
   });
 
-  it("Enter 키로 onSelectCustomer가 호출된다", () => {
+  it("Enter 키로 onSelectCustomer가 호출된다", async () => {
     const onSelect = vi.fn();
+    const user = userEvent.setup();
     renderQueuePanel({ customers: [makeCustomer("5")], onSelectCustomer: onSelect });
-    fireEvent.keyDown(getQueueItem("고객5"), { key: "Enter" });
+    getQueueItem("고객5").focus();
+    await user.keyboard("{Enter}");
     expect(onSelect).toHaveBeenCalledWith("5");
   });
 
-  it("스페이스 키로 onSelectCustomer가 호출된다", () => {
+  it("스페이스 키로 onSelectCustomer가 호출된다", async () => {
     const onSelect = vi.fn();
+    const user = userEvent.setup();
     renderQueuePanel({ customers: [makeCustomer("7")], onSelectCustomer: onSelect });
-    fireEvent.keyDown(getQueueItem("고객7"), { key: " " });
+    getQueueItem("고객7").focus();
+    await user.keyboard(" ");
     expect(onSelect).toHaveBeenCalledWith("7");
   });
 

--- a/frontend/src/features/consultation/ui/QueuePanel.tsx
+++ b/frontend/src/features/consultation/ui/QueuePanel.tsx
@@ -268,19 +268,12 @@ export const QueuePanel: React.FC<QueuePanelProps> = ({
       const displayName = c.name?.trim() || "Unknown";
       const subject = c.lastMessagePreview?.trim() || c.title?.trim() || c.handoffReason;
       return (
-        <div
+        <button
           key={c.id}
-          role="button"
-          tabIndex={0}
+          type="button"
           aria-current={activeCustomerId === c.id ? "true" : undefined}
           className={`${styles.queueItem} ${activeCustomerId === c.id ? styles.queueItemActive : ""}`}
           onClick={() => onSelectCustomer(c.id)}
-          onKeyDown={(e) => {
-            if (e.key === "Enter" || e.key === " ") {
-              e.preventDefault();
-              onSelectCustomer(c.id);
-            }
-          }}
         >
           <div
             className={`${styles.customerAvatar} ${activeCustomerId === c.id ? styles.customerAvatarActive : ""}`}
@@ -306,7 +299,7 @@ export const QueuePanel: React.FC<QueuePanelProps> = ({
               <span className={styles.unreadDot} role="status" aria-label="읽지 않은 고객 메시지" />
             )}
           </div>
-        </div>
+        </button>
       );
     });
   };

--- a/frontend/src/features/consultation/ui/chat-panel.module.css
+++ b/frontend/src/features/consultation/ui/chat-panel.module.css
@@ -201,15 +201,33 @@
 
 .messageGroup {
   display: flex;
-  gap: 10px;
+  flex-direction: column;
+  gap: 0;
   max-width: 75%;
-  cursor: pointer;
   border-radius: var(--r-3);
   transition: background 0.15s;
   position: relative;
 }
 
-.messageGroup:focus-visible {
+.messageSelectButton {
+  display: flex;
+  gap: 10px;
+  width: 100%;
+  padding: 0;
+  border: 0;
+  border-radius: var(--r-3);
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+}
+
+.messageSelectButtonAgent {
+  flex-direction: row-reverse;
+}
+
+.messageSelectButton:focus-visible {
   outline: none;
   box-shadow: var(--focus-ring);
 }
@@ -235,7 +253,6 @@
 
 .messageGroupAgent {
   align-self: flex-end;
-  flex-direction: row-reverse;
 }
 
 .msgAvatar {
@@ -313,6 +330,14 @@
 .deliveryMetaAgent {
   justify-content: flex-end;
   text-align: right;
+}
+
+.messageGroupCustomer .deliveryMeta {
+  margin-left: 42px;
+}
+
+.messageGroupAgent .deliveryMeta {
+  margin-right: 42px;
 }
 
 .deliveryMetaFailed {

--- a/frontend/src/features/consultation/ui/queue-panel.module.css
+++ b/frontend/src/features/consultation/ui/queue-panel.module.css
@@ -192,9 +192,14 @@
   display: flex;
   align-items: center;
   gap: 12px;
+  width: 100%;
   padding: 14px 12px;
   border-radius: var(--radius-md);
+  background: transparent;
+  color: inherit;
   cursor: pointer;
+  font: inherit;
+  text-align: left;
   transition: all var(--transition-fast);
   border: 1px solid transparent;
   margin-bottom: 4px;

--- a/frontend/src/pages/consultation/ui/ConsultationPage.generated-api.test.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.generated-api.test.tsx
@@ -68,6 +68,9 @@ function Wrapper({ children }: { children: React.ReactNode }) {
   return <MemoryRouter>{children}</MemoryRouter>;
 }
 
+const findQueueCustomerButton = (customerName: string) =>
+  screen.findByRole("button", { name: new RegExp(customerName) });
+
 const assignedSession = {
   id: 1,
   status: "ACTIVE",
@@ -137,8 +140,7 @@ describe("ConsultationPage generated API integration", () => {
   it("상담 화면에서 고객 선택 시 generated 메시지 URL 응답을 렌더링한다", async () => {
     render(<ConsultationPage />, { wrapper: Wrapper });
 
-    const customerItem = await screen.findByText("김민지");
-    fireEvent.click(customerItem.closest('[role="button"]') ?? customerItem);
+    fireEvent.click(await findQueueCustomerButton("김민지"));
 
     expect(await screen.findByText("generated 상담 메시지")).toBeInTheDocument();
     expect(mocks.customFetch).toHaveBeenCalledWith("/api/v1/workspaces/2/consultation/queue", {
@@ -152,8 +154,7 @@ describe("ConsultationPage generated API integration", () => {
     async () => {
       render(<ConsultationPage />, { wrapper: Wrapper });
 
-      const customerItem = await screen.findByText("김민지");
-      fireEvent.click(customerItem.closest('[role="button"]') ?? customerItem);
+      fireEvent.click(await findQueueCustomerButton("김민지"));
       await screen.findByText("generated 상담 메시지");
 
       fireEvent.click(screen.getByRole("button", { name: "상담 종료" }));

--- a/frontend/src/pages/consultation/ui/ConsultationPage.test.tsx
+++ b/frontend/src/pages/consultation/ui/ConsultationPage.test.tsx
@@ -211,6 +211,12 @@ function Wrapper({ children }: { children: React.ReactNode }) {
   return <MemoryRouter>{children}</MemoryRouter>;
 }
 
+const getQueueCustomerButton = (customerName: string) =>
+  screen.getByRole("button", { name: new RegExp(customerName) });
+
+const getMessageSelectButton = (messageContent: string) =>
+  screen.getByRole("button", { name: new RegExp(messageContent) });
+
 function LocationProbe() {
   const location = useLocation();
   return <div data-testid="location">{location.pathname}</div>;
@@ -416,7 +422,7 @@ describe("ConsultationPage", () => {
       expect(screen.getByText("정세션")).toBeInTheDocument();
     });
 
-    const customerItem = screen.getByText("정세션").closest('[role="button"]');
+    const customerItem = getQueueCustomerButton("정세션");
     if (customerItem) {
       fireEvent.click(customerItem);
     }
@@ -534,7 +540,7 @@ describe("ConsultationPage", () => {
       expect(screen.getByText("환불 문의 드립니다.")).toBeInTheDocument();
     });
 
-    const messageItem = screen.getByText("환불 문의 드립니다.").closest('[role="button"]');
+    const messageItem = getMessageSelectButton("환불 문의 드립니다.");
     if (messageItem) {
       fireEvent.click(messageItem);
     }
@@ -569,7 +575,7 @@ describe("ConsultationPage", () => {
       expect(screen.getByText("환불 문의 드립니다.")).toBeInTheDocument();
     });
 
-    const messageItem = screen.getByText("환불 문의 드립니다.").closest('[role="button"]');
+    const messageItem = getMessageSelectButton("환불 문의 드립니다.");
     if (messageItem) {
       fireEvent.click(messageItem);
     }
@@ -643,7 +649,7 @@ describe("ConsultationPage", () => {
       expect(screen.getByText("김민지")).toBeInTheDocument();
     });
 
-    const customerItem = screen.getByText("김민지").closest('[role="button"]');
+    const customerItem = getQueueCustomerButton("김민지");
     if (customerItem) {
       fireEvent.click(customerItem);
     }
@@ -1029,7 +1035,7 @@ describe("ConsultationPage", () => {
       expect(screen.getByLabelText("읽지 않은 고객 메시지")).toBeInTheDocument();
     });
 
-    const customerItem = screen.getByText("박서연").closest('[role="button"]');
+    const customerItem = getQueueCustomerButton("박서연");
     if (customerItem) fireEvent.click(customerItem);
 
     await waitFor(() => {
@@ -1044,7 +1050,7 @@ describe("ConsultationPage", () => {
       expect(screen.getByText("김민지")).toBeInTheDocument();
     });
 
-    const customerItem = screen.getByText("김민지").closest('[role="button"]');
+    const customerItem = getQueueCustomerButton("김민지");
     if (customerItem) fireEvent.click(customerItem);
 
     await waitFor(() => {
@@ -1101,7 +1107,7 @@ describe("ConsultationPage", () => {
       expect(screen.getByText("김민지")).toBeInTheDocument();
     });
 
-    const customerItem = screen.getByText("김민지").closest('[role="button"]');
+    const customerItem = getQueueCustomerButton("김민지");
     if (customerItem) fireEvent.click(customerItem);
 
     await waitFor(() => {
@@ -1128,7 +1134,7 @@ describe("ConsultationPage", () => {
       expect(screen.getByText("김민지")).toBeInTheDocument();
     });
 
-    const customerItem = screen.getByText("김민지").closest("div");
+    const customerItem = getQueueCustomerButton("김민지");
     if (customerItem) {
       customerItem.click();
     }
@@ -1161,7 +1167,7 @@ describe("ConsultationPage", () => {
       expect(screen.getByText("김민지")).toBeInTheDocument();
     });
 
-    const customerItem = screen.getByText("김민지").closest('[role="button"]');
+    const customerItem = getQueueCustomerButton("김민지");
     if (customerItem) {
       fireEvent.click(customerItem);
     }
@@ -1196,7 +1202,7 @@ describe("ConsultationPage", () => {
       expect(screen.getByText("김민지")).toBeInTheDocument();
     });
 
-    const customerItem = screen.getByText("김민지").closest('[role="button"]');
+    const customerItem = getQueueCustomerButton("김민지");
     if (customerItem) {
       fireEvent.click(customerItem);
     }
@@ -1229,7 +1235,7 @@ describe("ConsultationPage", () => {
       expect(screen.getByText("김민지")).toBeInTheDocument();
     });
 
-    const customerItem = screen.getByText("김민지").closest('[role="button"]');
+    const customerItem = getQueueCustomerButton("김민지");
     if (customerItem) {
       fireEvent.click(customerItem);
     }
@@ -1269,7 +1275,7 @@ describe("ConsultationPage", () => {
       expect(screen.getByText("김민지")).toBeInTheDocument();
     });
 
-    const customerItem = screen.getByText("김민지").closest('[role="button"]');
+    const customerItem = getQueueCustomerButton("김민지");
     if (customerItem) {
       fireEvent.click(customerItem);
     }
@@ -1300,7 +1306,7 @@ describe("ConsultationPage", () => {
       expect(screen.getByText("김민지")).toBeInTheDocument();
     });
 
-    const customerItem = screen.getByText("김민지").closest('[role="button"]');
+    const customerItem = getQueueCustomerButton("김민지");
     if (customerItem) {
       fireEvent.click(customerItem);
     }
@@ -1356,7 +1362,7 @@ describe("ConsultationPage", () => {
       expect(screen.getByText("김민지")).toBeInTheDocument();
     });
 
-    const customerItem = screen.getByText("김민지").closest('[role="button"]');
+    const customerItem = getQueueCustomerButton("김민지");
     if (customerItem) {
       fireEvent.click(customerItem);
     }
@@ -1395,7 +1401,7 @@ describe("ConsultationPage", () => {
       expect(screen.getByText("김민지")).toBeInTheDocument();
     });
 
-    const customerItem = screen.getByText("김민지").closest('[role="button"]');
+    const customerItem = getQueueCustomerButton("김민지");
     if (customerItem) {
       fireEvent.click(customerItem);
     }
@@ -1419,7 +1425,7 @@ describe("ConsultationPage", () => {
       expect(screen.getByText("김민지")).toBeInTheDocument();
     });
 
-    const customerItem = screen.getByText("김민지").closest('[role="button"]');
+    const customerItem = getQueueCustomerButton("김민지");
     if (customerItem) {
       fireEvent.click(customerItem);
     }
@@ -1452,7 +1458,7 @@ describe("ConsultationPage", () => {
       expect(screen.getByText("김민지")).toBeInTheDocument();
     });
 
-    const customerItem = screen.getByText("김민지").closest('[role="button"]');
+    const customerItem = getQueueCustomerButton("김민지");
     if (customerItem) {
       fireEvent.click(customerItem);
     }
@@ -1476,7 +1482,7 @@ describe("ConsultationPage", () => {
       expect(screen.getByText("김민지")).toBeInTheDocument();
     });
 
-    const customerItem = screen.getByText("김민지").closest('[role="button"]');
+    const customerItem = getQueueCustomerButton("김민지");
     if (customerItem) {
       fireEvent.click(customerItem);
     }
@@ -1506,7 +1512,7 @@ describe("ConsultationPage", () => {
       expect(screen.getByText("김민지")).toBeInTheDocument();
     });
 
-    const customerItem = screen.getByText("김민지").closest('[role="button"]');
+    const customerItem = getQueueCustomerButton("김민지");
     if (customerItem) {
       fireEvent.click(customerItem);
     }
@@ -1519,7 +1525,7 @@ describe("ConsultationPage", () => {
     );
     await user.type(memo, "카드사 확인 필요");
 
-    const messageGroup = screen.getByText("환불 문의 드립니다.").closest('[role="button"]');
+    const messageGroup = getMessageSelectButton("환불 문의 드립니다.");
     if (!messageGroup) throw new Error("message group not found");
     fireEvent.click(messageGroup);
 
@@ -1552,7 +1558,7 @@ describe("ConsultationPage", () => {
       expect(screen.getByText("김민지")).toBeInTheDocument();
     });
 
-    const customerItem = screen.getByText("김민지").closest("div");
+    const customerItem = getQueueCustomerButton("김민지");
     if (customerItem) {
       customerItem.click();
     }
@@ -1574,7 +1580,7 @@ describe("ConsultationPage", () => {
       expect(screen.getByText("김민지")).toBeInTheDocument();
     });
 
-    const customerItem = screen.getByText("김민지").closest("div");
+    const customerItem = getQueueCustomerButton("김민지");
     if (customerItem) {
       customerItem.click();
     }
@@ -1613,7 +1619,7 @@ describe("ConsultationPage", () => {
       expect(screen.getByText("김민지")).toBeInTheDocument();
     });
 
-    const customerItem = screen.getByText("김민지").closest("div");
+    const customerItem = getQueueCustomerButton("김민지");
     if (customerItem) customerItem.click();
 
     await waitFor(() => {
@@ -1634,7 +1640,7 @@ describe("ConsultationPage", () => {
       expect(screen.getByText("김민지")).toBeInTheDocument();
     });
 
-    const customerItem = screen.getByText("김민지").closest("div");
+    const customerItem = getQueueCustomerButton("김민지");
     if (customerItem) customerItem.click();
 
     await waitFor(() => {
@@ -1650,7 +1656,7 @@ describe("ConsultationPage", () => {
       expect(screen.getByText("김민지")).toBeInTheDocument();
     });
 
-    const customerItem = screen.getByText("김민지").closest("div");
+    const customerItem = getQueueCustomerButton("김민지");
     if (customerItem) customerItem.click();
 
     const input = await screen.findByPlaceholderText("메시지를 입력하세요...");
@@ -1677,7 +1683,7 @@ describe("ConsultationPage", () => {
       expect(screen.getByText("김민지")).toBeInTheDocument();
     });
 
-    const customerItem = screen.getByText("김민지").closest("div");
+    const customerItem = getQueueCustomerButton("김민지");
     if (customerItem) customerItem.click();
 
     await waitFor(() => {
@@ -1715,7 +1721,7 @@ describe("ConsultationPage", () => {
       expect(screen.getByText("김민지")).toBeInTheDocument();
     });
 
-    const customerItem = screen.getByText("김민지").closest("div");
+    const customerItem = getQueueCustomerButton("김민지");
     if (customerItem) customerItem.click();
 
     await waitFor(() => {
@@ -1747,7 +1753,7 @@ describe("ConsultationPage", () => {
       expect(screen.getByText("김민지")).toBeInTheDocument();
     });
 
-    const customerItem = screen.getByText("김민지").closest("div");
+    const customerItem = getQueueCustomerButton("김민지");
     if (customerItem) customerItem.click();
 
     await waitFor(() => {
@@ -1781,7 +1787,7 @@ describe("ConsultationPage", () => {
       expect(screen.getByText("김민지")).toBeInTheDocument();
     });
 
-    const customerItem = screen.getByText("김민지").closest("div");
+    const customerItem = getQueueCustomerButton("김민지");
     if (customerItem) customerItem.click();
 
     await waitFor(() => {
@@ -1839,7 +1845,7 @@ describe("ConsultationPage", () => {
       expect(screen.getByText("김민지")).toBeInTheDocument();
     });
 
-    const customerItem = screen.getByText("김민지").closest("div");
+    const customerItem = getQueueCustomerButton("김민지");
     if (customerItem) customerItem.click();
 
     await waitFor(() => {
@@ -1867,7 +1873,7 @@ describe("ConsultationPage", () => {
       expect(screen.getByText("김민지")).toBeInTheDocument();
     });
 
-    const customerItem = screen.getByText("김민지").closest("div");
+    const customerItem = getQueueCustomerButton("김민지");
     if (customerItem) customerItem.click();
 
     await waitFor(() => {
@@ -1896,7 +1902,7 @@ describe("ConsultationPage", () => {
       expect(screen.getByText("김민지")).toBeInTheDocument();
     });
 
-    const customerItem = screen.getByText("김민지").closest("div");
+    const customerItem = getQueueCustomerButton("김민지");
     if (customerItem) customerItem.click();
 
     await waitFor(() => {
@@ -1927,7 +1933,7 @@ describe("ConsultationPage", () => {
       expect(screen.getByText("김민지")).toBeInTheDocument();
     });
 
-    const customerItem = screen.getByText("김민지").closest("div");
+    const customerItem = getQueueCustomerButton("김민지");
     if (customerItem) customerItem.click();
 
     await waitFor(() => {
@@ -2097,7 +2103,7 @@ describe("ConsultationPage", () => {
 
     vi.mocked(consultationApi.getMessagePage).mockRejectedValueOnce(new Error("DB Error"));
 
-    const customerItem = screen.getByText("김민지").closest("div");
+    const customerItem = getQueueCustomerButton("김민지");
     if (customerItem) {
       customerItem.click();
     }
@@ -2135,7 +2141,7 @@ describe("ConsultationPage", () => {
       expect(screen.getByText("홍길동")).toBeInTheDocument();
     });
 
-    const customerItem = screen.getByText("김민지").closest("div");
+    const customerItem = getQueueCustomerButton("김민지");
     if (customerItem) customerItem.click();
 
     await waitFor(() => {
@@ -2157,7 +2163,7 @@ describe("ConsultationPage", () => {
       totalPages: 0,
     });
 
-    const hongEl = screen.getByText("홍길동").closest("div");
+    const hongEl = getQueueCustomerButton("홍길동");
     if (hongEl) hongEl.click();
 
     await waitFor(() => {
@@ -2176,7 +2182,7 @@ describe("ConsultationPage", () => {
       expect(screen.getByText("김민지")).toBeInTheDocument();
     });
 
-    const customerItem = screen.getByText("김민지").closest("div");
+    const customerItem = getQueueCustomerButton("김민지");
     if (customerItem) customerItem.click();
 
     await waitFor(() => {
@@ -2202,7 +2208,7 @@ describe("ConsultationPage", () => {
       expect(screen.getByText("김민지")).toBeInTheDocument();
     });
 
-    const customerItem = screen.getByText("김민지").closest("div");
+    const customerItem = getQueueCustomerButton("김민지");
     if (customerItem) customerItem.click();
 
     await waitFor(() => {
@@ -2232,7 +2238,7 @@ describe("ConsultationPage", () => {
       expect(screen.getByText("김민지")).toBeInTheDocument();
     });
 
-    const customerItem = screen.getByText("김민지").closest("div");
+    const customerItem = getQueueCustomerButton("김민지");
     if (customerItem) customerItem.click();
 
     await waitFor(() => {
@@ -2272,7 +2278,7 @@ describe("ConsultationPage", () => {
       expect(screen.getByText("김민지")).toBeInTheDocument();
     });
 
-    const customerItem = screen.getByText("김민지").closest("div");
+    const customerItem = getQueueCustomerButton("김민지");
     if (customerItem) customerItem.click();
 
     await waitFor(() => {
@@ -2313,7 +2319,7 @@ describe("ConsultationPage", () => {
       expect(screen.getByText("김민지")).toBeInTheDocument();
     });
 
-    const customerItem = screen.getByText("김민지").closest("div");
+    const customerItem = getQueueCustomerButton("김민지");
     if (customerItem) customerItem.click();
 
     const input = await screen.findByPlaceholderText("메시지를 입력하세요...");
@@ -2347,7 +2353,7 @@ describe("ConsultationPage", () => {
       expect(screen.getByText("김민지")).toBeInTheDocument();
     });
 
-    const customerItem = screen.getByText("김민지").closest("div");
+    const customerItem = getQueueCustomerButton("김민지");
     if (customerItem) customerItem.click();
 
     const input = await screen.findByPlaceholderText("메시지를 입력하세요...");
@@ -2380,7 +2386,7 @@ describe("ConsultationPage", () => {
       expect(screen.getByText("김민지")).toBeInTheDocument();
     });
 
-    const customerItem = screen.getByText("김민지").closest("div");
+    const customerItem = getQueueCustomerButton("김민지");
     if (customerItem) customerItem.click();
 
     await waitFor(() => {
@@ -2410,7 +2416,7 @@ describe("ConsultationPage", () => {
       expect(screen.getByText("김민지")).toBeInTheDocument();
     });
 
-    const customerItem = screen.getByText("김민지").closest("div");
+    const customerItem = getQueueCustomerButton("김민지");
     if (customerItem) customerItem.click();
 
     await waitFor(() => {
@@ -2435,7 +2441,7 @@ describe("ConsultationPage", () => {
       expect(screen.getByText("김민지")).toBeInTheDocument();
     });
 
-    const customerItem = screen.getByText("김민지").closest("div");
+    const customerItem = getQueueCustomerButton("김민지");
     if (customerItem) customerItem.click();
 
     const textarea = await screen.findByPlaceholderText(
@@ -2454,7 +2460,7 @@ describe("ConsultationPage", () => {
       expect(screen.getByText("김민지")).toBeInTheDocument();
     });
 
-    const customerItem = screen.getByText("김민지").closest('[role="button"]');
+    const customerItem = getQueueCustomerButton("김민지");
     if (customerItem) fireEvent.click(customerItem);
 
     const textarea = await screen.findByPlaceholderText(

--- a/frontend/src/pages/consultation/ui/sections/Queue.tsx
+++ b/frontend/src/pages/consultation/ui/sections/Queue.tsx
@@ -26,23 +26,24 @@ export function Queue({
         const isActive = item.id === activeId;
         const displayName = item.name?.trim() || "Unknown";
         return (
-          <div
+          <button
             key={item.id}
+            type="button"
             onClick={() => onSelect?.(item.id)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" || e.key === " ") {
-                e.preventDefault();
-                onSelect?.(item.id);
-              }
-            }}
-            role="button"
-            tabIndex={0}
+            aria-current={isActive ? "true" : undefined}
             style={{
+              display: "block",
+              width: "100%",
               padding: "12px 14px 12px 16px",
+              borderTop: 0,
+              borderRight: 0,
               borderBottom: "1px solid var(--line)",
-              background: isActive ? "var(--paper-3)" : undefined,
               borderLeft: isActive ? "3px solid var(--signal)" : "3px solid transparent",
+              background: isActive ? "var(--paper-3)" : "transparent",
+              color: "inherit",
               cursor: "pointer",
+              font: "inherit",
+              textAlign: "left",
             }}
           >
             <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 6 }}>
@@ -67,7 +68,7 @@ export function Queue({
               <Mono style={{ fontSize: 10, color: "var(--ink-3)" }}>“{item.preview}”</Mono>
             </div>
             <Pill tone="signal">{item.topic}</Pill>
-          </div>
+          </button>
         );
       })}
     </div>

--- a/frontend/src/pages/consultation/ui/sections/consultation-sections.test.tsx
+++ b/frontend/src/pages/consultation/ui/sections/consultation-sections.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vite-plus/test";
 import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { Message, HandoffDivider } from "./Message";
 import { Queue } from "./Queue";
 import { DetectedItems } from "./DetectedItems";
@@ -110,7 +111,7 @@ describe("Queue", () => {
 
   it("applies active styles to active item", () => {
     render(<Queue items={items} activeId="c2" />);
-    const activeItem = screen.getByText("이성민").closest("div")?.parentElement;
+    const activeItem = screen.getByRole("button", { name: /이성민/ });
     expect(activeItem).toBeInTheDocument();
     expect(activeItem!.style.background).toBe("var(--paper-3)");
     expect(activeItem!.style.borderLeft).toBe("3px solid var(--signal)");
@@ -119,23 +120,27 @@ describe("Queue", () => {
   it("calls onSelect when item clicked", () => {
     const onSelect = vi.fn();
     render(<Queue items={items} onSelect={onSelect} />);
-    fireEvent.click(screen.getByText("김민지"));
+    fireEvent.click(screen.getByRole("button", { name: /김민지/ }));
     expect(onSelect).toHaveBeenCalledWith("c1");
   });
 
-  it("calls onSelect on Enter key on queue item", () => {
+  it("calls onSelect on Enter key on queue item", async () => {
+    const user = userEvent.setup();
     const onSelect = vi.fn();
     render(<Queue items={items} onSelect={onSelect} />);
-    const item = screen.getByText("김민지");
-    fireEvent.keyDown(item, { key: "Enter" });
+    const item = screen.getByRole("button", { name: /김민지/ });
+    item.focus();
+    await user.keyboard("{Enter}");
     expect(onSelect).toHaveBeenCalledWith("c1");
   });
 
-  it("calls onSelect on Space key on queue item", () => {
+  it("calls onSelect on Space key on queue item", async () => {
+    const user = userEvent.setup();
     const onSelect = vi.fn();
     render(<Queue items={items} onSelect={onSelect} />);
-    const item = screen.getByText("이성민");
-    fireEvent.keyDown(item, { key: " " });
+    const item = screen.getByRole("button", { name: /이성민/ });
+    item.focus();
+    await user.keyboard(" ");
     expect(onSelect).toHaveBeenCalledWith("c2");
   });
 });


### PR DESCRIPTION
Closes #635

## 변경 사항

- 상담 큐 항목을 네이티브 button 기반 선택 요소로 전환해 기존 클릭 영역과 현재 선택 표시를 유지하면서 키보드/보조기술 의미를 명확히 했습니다.
- 메시지 선택 영역을 네이티브 button으로 분리하고 `aria-pressed` 선택 상태를 제공하되, 재전송 버튼이 중첩 button이 되지 않도록 delivery meta를 선택 버튼 밖에 유지했습니다.
- 상담 큐와 메시지 선택 테스트를 role/name 기반 쿼리와 키보드 상호작용 검증으로 갱신했습니다.
- 상담 큐 E2E와 section queue 테스트도 네이티브 button role 기준으로 갱신했습니다.
- 이슈 635 스펙을 `.agent/specs/635.md`에 정리했습니다.

## 검증

- `git diff --check`
- `pnpm --dir frontend exec vp test run src/features/consultation/ui/QueuePanel.test.tsx src/features/consultation/ui/ChatPanel.test.tsx src/pages/consultation/ui/ConsultationPage.test.tsx src/pages/consultation/ui/ConsultationPage.generated-api.test.tsx src/pages/consultation/ui/sections/consultation-sections.test.tsx`
- `pnpm --dir frontend exec eslint src/features/consultation/ui/QueuePanel.tsx src/features/consultation/ui/ChatPanel.tsx src/features/consultation/ui/QueuePanel.test.tsx src/features/consultation/ui/ChatPanel.test.tsx src/pages/consultation/ui/ConsultationPage.test.tsx src/pages/consultation/ui/ConsultationPage.generated-api.test.tsx src/pages/consultation/ui/sections/Queue.tsx src/pages/consultation/ui/sections/consultation-sections.test.tsx e2e/consultation.spec.ts`
- `pnpm --dir frontend exec playwright test e2e/consultation.spec.ts`
- `pnpm run ci:frontend`
- `pnpm run e2e:frontend`

## 참고

- pre-commit hook의 `pnpm run lint:frontend`는 `audit:api`, `audit:fsd` 통과 후 repository-wide 기존 ESLint baseline 47건으로 실패했습니다. 실패 파일은 이번 변경 파일이 아닌 workflow/auth/workspace/domain-pack/billing 등 기존 lint 대상입니다.