### PR TITLE
fix(deploy): airflow 배포 환경 변수를 보존

### DIFF
--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -67,6 +67,9 @@ jobs:
       backend_service_name: ${{ steps.tf_outputs.outputs.backend_service_name }}
       backend_task_definition_arn: ${{ steps.tf_outputs.outputs.backend_task_definition_arn }}
       airflow_init_task_definition_arn: ${{ steps.tf_outputs.outputs.airflow_init_task_definition_arn }}
+      airflow_apiserver_task_definition_arn: ${{ steps.tf_outputs.outputs.airflow_apiserver_task_definition_arn }}
+      airflow_scheduler_task_definition_arn: ${{ steps.tf_outputs.outputs.airflow_scheduler_task_definition_arn }}
+      airflow_dag_processor_task_definition_arn: ${{ steps.tf_outputs.outputs.airflow_dag_processor_task_definition_arn }}
       airflow_apiserver_service_name: ${{ steps.tf_outputs.outputs.airflow_apiserver_service_name }}
       airflow_scheduler_service_name: ${{ steps.tf_outputs.outputs.airflow_scheduler_service_name }}
       airflow_dag_processor_service_name: ${{ steps.tf_outputs.outputs.airflow_dag_processor_service_name }}
@@ -183,6 +186,9 @@ jobs:
             echo "backend_service_name=$(terraform output -raw backend_service_name)"
             echo "backend_task_definition_arn=$(terraform output -raw backend_task_definition_arn)"
             echo "airflow_init_task_definition_arn=$(terraform output -raw airflow_init_task_definition_arn)"
+            echo "airflow_apiserver_task_definition_arn=$(terraform output -raw airflow_apiserver_task_definition_arn)"
+            echo "airflow_scheduler_task_definition_arn=$(terraform output -raw airflow_scheduler_task_definition_arn)"
+            echo "airflow_dag_processor_task_definition_arn=$(terraform output -raw airflow_dag_processor_task_definition_arn)"
             echo "airflow_apiserver_service_name=$(terraform output -raw airflow_apiserver_service_name)"
             echo "airflow_scheduler_service_name=$(terraform output -raw airflow_scheduler_service_name)"
             echo "airflow_dag_processor_service_name=$(terraform output -raw airflow_dag_processor_service_name)"
@@ -519,6 +525,9 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECS_CLUSTER: ${{ needs.terraform.outputs.ecs_cluster_name }}
           AIRFLOW_INIT_TASK_DEFINITION: ${{ needs.terraform.outputs.airflow_init_task_definition_arn }}
+          AIRFLOW_API_TASK_DEFINITION: ${{ needs.terraform.outputs.airflow_apiserver_task_definition_arn }}
+          AIRFLOW_SCHEDULER_TASK_DEFINITION: ${{ needs.terraform.outputs.airflow_scheduler_task_definition_arn }}
+          AIRFLOW_DAG_PROCESSOR_TASK_DEFINITION: ${{ needs.terraform.outputs.airflow_dag_processor_task_definition_arn }}
           AIRFLOW_API_SERVICE: ${{ needs.terraform.outputs.airflow_apiserver_service_name }}
           AIRFLOW_SCHEDULER_SERVICE: ${{ needs.terraform.outputs.airflow_scheduler_service_name }}
           AIRFLOW_DAG_PROCESSOR_SERVICE: ${{ needs.terraform.outputs.airflow_dag_processor_service_name }}
@@ -556,17 +565,12 @@ jobs:
           update_service_image() {
             local service="$1"
             local container="$2"
+            local base_task_def_arn="$3"
             local repository="ostone/airflow"
             local image_uri="$ECR_REGISTRY/$repository:$IMAGE_TAG"
-            local task_def_arn
-            task_def_arn="$(aws ecs describe-services \
-              --cluster "$ECS_CLUSTER" \
-              --services "$service" \
-              --region ap-northeast-2 \
-              --query 'services[0].taskDefinition' \
-              --output text)"
+            test -n "$base_task_def_arn" || { echo "base task definition ARN is empty for $service"; exit 1; }
             aws ecs describe-task-definition \
-              --task-definition "$task_def_arn" \
+              --task-definition "$base_task_def_arn" \
               --region ap-northeast-2 \
               --query 'taskDefinition' > "task-definition-${service}.json"
             jq --arg image "$image_uri" --arg container "$container" '
@@ -597,9 +601,9 @@ jobs:
               --region ap-northeast-2
           }
 
-          update_service_image "$AIRFLOW_API_SERVICE" "airflow-apiserver"
-          update_service_image "$AIRFLOW_SCHEDULER_SERVICE" "airflow-scheduler"
-          update_service_image "$AIRFLOW_DAG_PROCESSOR_SERVICE" "airflow-dag-processor"
+          update_service_image "$AIRFLOW_API_SERVICE" "airflow-apiserver" "$AIRFLOW_API_TASK_DEFINITION"
+          update_service_image "$AIRFLOW_SCHEDULER_SERVICE" "airflow-scheduler" "$AIRFLOW_SCHEDULER_TASK_DEFINITION"
+          update_service_image "$AIRFLOW_DAG_PROCESSOR_SERVICE" "airflow-dag-processor" "$AIRFLOW_DAG_PROCESSOR_TASK_DEFINITION"
           aws ecs wait services-stable \
             --cluster "$ECS_CLUSTER" \
             --services "$AIRFLOW_API_SERVICE" "$AIRFLOW_SCHEDULER_SERVICE" "$AIRFLOW_DAG_PROCESSOR_SERVICE" \

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -268,6 +268,21 @@ output "airflow_init_task_definition_arn" {
   value       = aws_ecs_task_definition.airflow_init.arn
 }
 
+output "airflow_apiserver_task_definition_arn" {
+  description = "Airflow API server ECS task definition ARN."
+  value       = aws_ecs_task_definition.airflow_apiserver.arn
+}
+
+output "airflow_scheduler_task_definition_arn" {
+  description = "Airflow scheduler ECS task definition ARN."
+  value       = aws_ecs_task_definition.airflow_scheduler.arn
+}
+
+output "airflow_dag_processor_task_definition_arn" {
+  description = "Airflow DAG processor ECS task definition ARN."
+  value       = aws_ecs_task_definition.airflow_dag_processor.arn
+}
+
 output "embedding_model_cache_file_system_id" {
   description = "EFS file system ID for the embedding model cache."
   value       = aws_efs_file_system.embedding_model_cache.id


### PR DESCRIPTION
## 변경 사항

- Terraform이 생성한 Airflow apiserver, scheduler, dag processor task definition ARN을 배포 워크플로우 output으로 전달합니다.
- Airflow 이미지 배포 시 현재 ECS service에 붙은 task definition이 아니라 Terraform 기준 task definition을 복제해 이미지 태그만 교체하도록 했습니다.

## 확인 사항

- `actionlint .github/workflows/prod-deploy.yml`
- `terraform fmt -check infra/terraform/outputs.tf`
- `git diff --check -- .github/workflows/prod-deploy.yml infra/terraform/outputs.tf`