### PR TITLE
test(frontend): 워크스페이스 이름 검증 흐름을 보장

### DIFF
--- a/.agent/specs/697.md
+++ b/.agent/specs/697.md
@@ -1,0 +1,98 @@
+# Frontend FSD Spec: 워크스페이스 이름 검증 E2E
+
+## Goal
+
+신규 사용자가 유효하지 않은 워크스페이스 이름으로 생성할 수 없고, 같은 생성 화면에서 오류를 확인한 뒤 올바른 이름으로 수정해 생성 흐름을 이어갈 수 있음을 E2E로 보장한다.
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A[워크스페이스 진입] --> B{워크스페이스 존재?}
+    B -->|없음| C[워크스페이스 생성 다이얼로그 표시]
+    C --> D[유효하지 않은 이름 입력 후 생성]
+    D --> E[이름 오류 메시지 표시]
+    E --> F[생성 화면 유지]
+    F --> G[유효한 이름으로 수정 후 생성]
+    G --> H[워크스페이스 생성 후 온보딩 화면 이동]
+```
+
+## Design Diff
+
+| 영역 | As-is | To-be | 변경 내용 |
+| --- | --- | --- | --- |
+| 생성 입력 라벨 | 생성 다이얼로그의 이름 입력 라벨이 `제목`으로 표시됨 | `이름`으로 표시됨 | 오류 메시지와 백엔드 필드명에 맞춰 사용자 수정 대상이 명확해짐 |
+| E2E 검증 | 워크스페이스 생성 성공 경로만 검증 | invalid name 실패 후 valid name 재시도까지 검증 | 빈 값, 공백만 있는 값, 255자 초과 값을 API 호출 없이 차단하는지 확인 |
+
+## Component Tree
+
+```text
+WorkspaceRootRedirect
+└─ CreateWorkspaceDialog
+   ├─ name Input
+   ├─ field error alert
+   ├─ cancel Button
+   └─ submit Button
+```
+
+## API Integration
+
+| Method | Path | Description |
+| --- | --- | --- |
+| GET | `/api/v1/workspaces` | 접근 가능한 워크스페이스 목록 조회 |
+| POST | `/api/v1/workspaces` | 유효한 이름으로 워크스페이스 생성 |
+| GET | `/api/v1/workspaces/{id}` | 생성 후 이동 대상 워크스페이스 조회 |
+| GET | `/api/v1/workspaces/{id}/domain-packs` | 생성 후 온보딩 화면의 도메인팩 상태 조회 |
+
+유효하지 않은 이름은 클라이언트 폼 검증에서 차단하므로 `POST /api/v1/workspaces`가 발생하지 않아야 한다. 서버 정책은 `backend/src/main/java/com/init/workspace/presentation/dto/CreateWorkspaceRequest.java`의 `@NotBlank @Size(max = 255)`와 `backend/src/main/java/com/init/workspace/domain/model/Workspace.java`의 이름 가드 기준을 따른다.
+
+## Data Flow
+
+```text
+CreateWorkspaceDialog local name state
+  -> validateCreateWorkspaceForm(name, "")
+  -> invalid: fieldErrors.name + dialog 유지
+  -> valid: generated workspace-controller createWorkspace mutation
+  -> success: listWorkspaces cache 갱신 + /workspaces/{id}/upload 이동
+```
+
+## 수정 대상 파일
+
+| 파일 | 변경 유형 | 설명 |
+| --- | --- | --- |
+| `frontend/src/features/workspace/ui/CreateWorkspaceDialog.tsx` | update | 생성 입력 라벨을 이름 검증 문구와 같은 `이름`으로 정렬 |
+| `frontend/src/features/workspace/ui/CreateWorkspaceDialog.test.tsx` | update | 라벨 변경에 맞춰 컴포넌트 테스트 조회 기준 갱신 |
+| `frontend/e2e/workspace-create.spec.ts` | update | invalid name 실패와 valid name 재시도 E2E 추가 |
+| `.agent/specs/697.md` | new | 이슈 요구사항과 검증 기준 기록 |
+
+## State Management
+
+- 이름 입력값과 필드 오류는 `CreateWorkspaceDialog`의 로컬 상태로 유지한다.
+- invalid submit은 다이얼로그를 닫지 않고 `fieldErrors.name`만 갱신한다.
+- invalid submit 중에는 생성 mutation을 호출하지 않으므로 서버 상태나 TanStack Query cache를 변경하지 않는다.
+- valid submit 성공 시 기존처럼 워크스페이스 목록 cache를 갱신하고 성공 콜백으로 이동한다.
+
+## Tests
+
+| 구분 | 방법 | 도구 |
+| --- | --- | --- |
+| 컴포넌트 회귀 | 라벨 변경 후 생성 다이얼로그 테스트 유지 | Vitest, React Testing Library |
+| E2E | 빈 값, 공백 값, 255자 초과 값이 생성 API 없이 오류를 표시하고, 유효한 이름으로 수정하면 생성 흐름이 진행됨을 검증 | Playwright |
+
+## Acceptance Criteria
+
+- 워크스페이스 생성 화면의 이름 입력이 사용자에게 `이름`으로 표시된다.
+- 빈 값, 공백만 있는 값, 255자 초과 값 제출 시 워크스페이스가 생성되지 않는다.
+- invalid name 제출 후 사용자는 같은 생성 화면에 남아 이름 오류 메시지를 볼 수 있다.
+- invalid name 제출은 `POST /api/v1/workspaces`를 호출하지 않는다.
+- 유효한 이름으로 수정한 뒤 생성하면 기존 온보딩 이동 흐름을 계속 진행할 수 있다.
+
+## Non-Goals
+
+- 백엔드 workspace validation 정책을 변경하지 않는다.
+- workspace key 생성 알고리즘을 변경하지 않는다.
+- live E2E가 실제 운영 데이터에 invalid 요청을 보내는 시나리오는 추가하지 않는다.
+
+## Open Questions
+
+- 없음. 현재 확인된 정책은 이름 필수, 공백 불가, 255자 이하이다.

--- a/frontend/e2e/workspace-create.spec.ts
+++ b/frontend/e2e/workspace-create.spec.ts
@@ -1,6 +1,71 @@
-import { expect, test } from "@playwright/test";
+import { expect, type Page, test } from "@playwright/test";
 
 import { installAuth } from "./support/generated-api-auth";
+
+async function mockWorkspaceCreation(page: Page, seen: string[]) {
+  await page.route("**/api/v1/**", async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const path = url.pathname.replace(/^\/api\/v1/, "");
+    const method = request.method();
+    seen.push(`${method} ${path}`);
+
+    if (method === "GET" && path === "/workspaces") {
+      await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+      return;
+    }
+
+    if (method === "POST" && path === "/workspaces") {
+      const body = request.postDataJSON() as { name?: string; workspaceKey?: string };
+      expect(body.name).toBe("QA Workspace");
+      expect(body.workspaceKey).toMatch(/^qa-workspace-[a-z0-9]+$/);
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          data: {
+            id: 777,
+            workspaceKey: "qa-workspace",
+            name: "QA Workspace",
+            status: "ACTIVE",
+            myRole: "OWNER",
+          },
+        }),
+      });
+      return;
+    }
+
+    if (method === "GET" && path === "/workspaces/777") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: 777,
+          workspaceKey: "qa-workspace",
+          name: "QA Workspace",
+          status: "ACTIVE",
+          myRole: "OWNER",
+        }),
+      });
+      return;
+    }
+
+    if (method === "GET" && path === "/workspaces/777/domain-packs") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ data: [] }),
+      });
+      return;
+    }
+
+    await route.fulfill({
+      status: 500,
+      contentType: "application/json",
+      body: JSON.stringify({ code: "E2E_UNMOCKED", message: `${method} ${path}` }),
+    });
+  });
+}
 
 test.describe("Workspace creation", () => {
   test.beforeEach(async ({ page }) => {
@@ -8,76 +73,51 @@ test.describe("Workspace creation", () => {
   });
 
   test.describe("Given the operator has no workspace", () => {
-    test.describe("When the operator creates the first workspace", () => {
-      test("Then the workspace is created and opened", async ({ page }) => {
+    test.describe("When the operator submits invalid workspace names", () => {
+      test("Then creation is blocked until the name is corrected", async ({ page }) => {
         const seen: string[] = [];
-
-        await page.route("**/api/v1/**", async (route) => {
-          const request = route.request();
-          const url = new URL(request.url());
-          const path = url.pathname.replace(/^\/api\/v1/, "");
-          const method = request.method();
-          seen.push(`${method} ${path}`);
-
-          if (method === "GET" && path === "/workspaces") {
-            await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
-            return;
-          }
-
-          if (method === "POST" && path === "/workspaces") {
-            const body = request.postDataJSON() as { name?: string; workspaceKey?: string };
-            expect(body.name).toBe("QA Workspace");
-            expect(body.workspaceKey).toMatch(/^qa-workspace-[a-z0-9]+$/);
-            await route.fulfill({
-              status: 200,
-              contentType: "application/json",
-              body: JSON.stringify({
-                data: {
-                  id: 777,
-                  workspaceKey: "qa-workspace",
-                  name: "QA Workspace",
-                  status: "ACTIVE",
-                  myRole: "OWNER",
-                },
-              }),
-            });
-            return;
-          }
-
-          if (method === "GET" && path === "/workspaces/777") {
-            await route.fulfill({
-              status: 200,
-              contentType: "application/json",
-              body: JSON.stringify({
-                id: 777,
-                workspaceKey: "qa-workspace",
-                name: "QA Workspace",
-                status: "ACTIVE",
-                myRole: "OWNER",
-              }),
-            });
-            return;
-          }
-
-          if (method === "GET" && path === "/workspaces/777/domain-packs") {
-            await route.fulfill({
-              status: 200,
-              contentType: "application/json",
-              body: JSON.stringify({ data: [] }),
-            });
-            return;
-          }
-
-          await route.fulfill({
-            status: 500,
-            contentType: "application/json",
-            body: JSON.stringify({ code: "E2E_UNMOCKED", message: `${method} ${path}` }),
-          });
-        });
+        await mockWorkspaceCreation(page, seen);
 
         await page.goto("/workspaces");
         await expect(page.getByRole("heading", { name: "워크스페이스 생성" })).toBeVisible();
-        await page.getByLabel("제목").fill("QA Workspace");
+
+        const nameInput = page.getByLabel("이름");
+        const submitButton = page.getByRole("button", { name: "생성" });
+
+        await submitButton.click();
+        await expect(page.getByRole("alert")).toContainText("이름을 입력해주세요.");
+        await expect(nameInput).toHaveAttribute("aria-invalid", "true");
+        expect(seen).not.toContain("POST /workspaces");
+
+        await nameInput.fill("   ");
+        await submitButton.click();
+        await expect(page.getByRole("alert")).toContainText("이름을 입력해주세요.");
+        expect(seen).not.toContain("POST /workspaces");
+
+        await nameInput.fill("a".repeat(256));
+        await submitButton.click();
+        await expect(page.getByRole("alert")).toContainText("이름은 255자 이하여야 합니다.");
+        await expect(page).toHaveURL(/\/workspaces$/);
+        expect(seen).not.toContain("POST /workspaces");
+
+        await nameInput.fill("QA Workspace");
+        await submitButton.click();
+
+        await expect(page).toHaveURL(/\/workspaces\/777\/upload/);
+        await expect(page.getByText("워크스페이스를 생성했습니다.")).toBeVisible();
+        await expect(page.getByRole("heading", { name: "상담 로그 업로드" })).toBeVisible();
+        expect(seen).toContain("POST /workspaces");
+      });
+    });
+
+    test.describe("When the operator creates the first workspace", () => {
+      test("Then the workspace is created and opened", async ({ page }) => {
+        const seen: string[] = [];
+        await mockWorkspaceCreation(page, seen);
+
+        await page.goto("/workspaces");
+        await expect(page.getByRole("heading", { name: "워크스페이스 생성" })).toBeVisible();
+        await page.getByLabel("이름").fill("QA Workspace");
         await page.getByRole("button", { name: "생성" }).click();
 
         await expect(page).toHaveURL(/\/workspaces\/777\/upload/);

--- a/frontend/src/features/workspace/ui/CreateWorkspaceDialog.test.tsx
+++ b/frontend/src/features/workspace/ui/CreateWorkspaceDialog.test.tsx
@@ -89,7 +89,7 @@ function renderDialog() {
 }
 
 function submitWorkspaceName(name = "Support Team") {
-  fireEvent.change(screen.getByLabelText("제목"), { target: { value: name } });
+  fireEvent.change(screen.getByLabelText("이름"), { target: { value: name } });
   fireEvent.click(screen.getByRole("button", { name: "생성" }));
 }
 
@@ -259,7 +259,7 @@ describe("CreateWorkspaceDialog", () => {
 
     submitWorkspaceName();
     await waitFor(() => expect(screen.getByRole("button", { name: "생성 중..." })).toBeDisabled());
-    const form = screen.getByLabelText("제목").closest("form");
+    const form = screen.getByLabelText("이름").closest("form");
     if (!form) {
       throw new Error("workspace create form not found");
     }
@@ -290,11 +290,11 @@ describe("CreateWorkspaceDialog", () => {
 
   it("Dialog open 이벤트는 입력값을 유지하고 열림 상태를 전달한다", () => {
     const { onOpenChange } = renderDialog();
-    fireEvent.change(screen.getByLabelText("제목"), { target: { value: "Support Team" } });
+    fireEvent.change(screen.getByLabelText("이름"), { target: { value: "Support Team" } });
 
     fireEvent.click(screen.getByRole("button", { name: "mock keep dialog open" }));
 
-    expect(screen.getByLabelText("제목")).toHaveValue("Support Team");
+    expect(screen.getByLabelText("이름")).toHaveValue("Support Team");
     expect(onOpenChange).toHaveBeenCalledWith(true);
   });
 

--- a/frontend/src/features/workspace/ui/CreateWorkspaceDialog.tsx
+++ b/frontend/src/features/workspace/ui/CreateWorkspaceDialog.tsx
@@ -172,7 +172,7 @@ export function CreateWorkspaceDialog({
         </DialogHeader>
         <form className={styles.form} onSubmit={handleSubmit}>
           <div className={styles.field}>
-            <Label htmlFor="workspace-name">제목</Label>
+            <Label htmlFor="workspace-name">이름</Label>
             <Input
               id="workspace-name"
               className={styles.dialogInput}


### PR DESCRIPTION
Closes #697

## 변경 사항

- 워크스페이스 이름 검증 요구사항과 acceptance criteria를 `.agent/specs/697.md`에 정리했습니다.
- 워크스페이스 생성 다이얼로그의 입력 라벨을 `이름`으로 정리해 필드 오류 문구와 수정 대상이 일치하도록 했습니다.
- mocked Playwright E2E에서 빈 값, 공백만 있는 값, 255자 초과 이름이 생성 API 호출 없이 차단되고, 유효한 이름으로 수정하면 기존 온보딩 이동 흐름이 이어지는지 검증했습니다.

## 검증

- `pnpm --dir frontend test -- src/features/workspace/ui/CreateWorkspaceDialog.test.tsx src/entities/workspace/model/types.test.ts`
- `pnpm --dir frontend e2e -- workspace-create.spec.ts --project=chromium`
- `pnpm --dir frontend exec eslint src/features/workspace/ui/CreateWorkspaceDialog.tsx src/features/workspace/ui/CreateWorkspaceDialog.test.tsx e2e/workspace-create.spec.ts`
- `git diff --check`

## 참고

- `pnpm --dir frontend lint`와 pre-commit의 `pnpm run lint:frontend`는 repository-wide 기존 ESLint baseline 47건으로 실패합니다. 실패 파일은 이번 변경 파일이 아닌 workflow/auth/billing/domain-pack 등 기존 lint 대상입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 워크스페이스 이름 입력 필드에 유효성 검사 추가: 빈 값, 공백, 255자 초과 입력 시 폼 검증 오류 메시지 표시 및 생성 대화상자 유지

* **개선 사항**
  * 워크스페이스 생성 입력 필드 라벨을 "이름"으로 변경하여 사용자 인터페이스 명확화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->