### PR TITLE
fix(auth): 신규 사용자가 stale workspace 경로에 진입하지 않도록 보장

### DIFF
--- a/.agent/specs/695.md
+++ b/.agent/specs/695.md
@@ -1,0 +1,118 @@
+# 신규 사용자의 stale workspace URL 로그인 방지
+
+## Goal
+
+소속 워크스페이스가 없는 신규 사용자가 이전 계정의 workspace URL 기록을 통해 로그인하더라도, 이전 workspace 화면이나 데이터 대신 첫 workspace 생성 화면으로 안내한다.
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A[시작: 이전 계정의 workspace URL 진입] --> B{인증됨?}
+    B -->|No| C[로그인 화면]
+    C --> D[신규 계정 로그인 성공]
+    D --> E[현재 계정 workspace 목록 조회]
+    E --> F{workspace 존재?}
+    F -->|No| G[/workspaces 이동]
+    G --> H[워크스페이스 생성 화면 표시]
+    F -->|Yes| I{return-to workspace가 현재 계정 소속인가?}
+    I -->|Yes| J[return-to workspace 경로 복귀]
+    I -->|No| K[현재 계정 기본 workspace로 이동]
+```
+
+## Problem
+
+로그인 화면은 `PrivateRoute`가 넘긴 return-to 경로를 허용된 route prefix 기준으로 우선 사용한다. 이 때문에 브라우저에 이전 계정의 `/workspaces/{workspaceId}/...` 기록이 남아 있으면, 새로 로그인한 사용자에게도 해당 workspace 경로가 재사용될 수 있다. 소속 workspace가 0개인 신규 사용자는 `/workspaces` 루트에서 제공되는 생성 화면으로 가야 하지만, 현재 흐름은 stale workspace 상세 route를 먼저 열어 오류 상태 또는 이전 계정 문맥 재사용 위험을 만든다.
+
+## Scope
+
+- `frontend/src/features/auth/model/resolveDefaultPostLoginDestination.ts`
+- `frontend/src/features/auth/model/resolveDefaultPostLoginDestination.test.ts`
+- `frontend/src/features/auth/ui/login-form/LoginForm.tsx`
+- `frontend/src/features/auth/ui/login-form/LoginForm.test.tsx`
+- `frontend/e2e/auth-login.spec.ts`
+
+## Non-Goals
+
+- 워크스페이스 생성 UI의 문구, 레이아웃, 생성 후 이동 경로는 변경하지 않는다.
+- 백엔드 workspace membership API contract는 변경하지 않는다.
+- 인증 토큰 저장/갱신 방식은 변경하지 않는다.
+- demo chat route의 비인증/legacy redirect 동작은 변경하지 않는다.
+
+## Current Contract
+
+| 영역 | 확인된 파일 | 현재 상태 |
+| --- | --- | --- |
+| 보호 route return-to | `frontend/src/shared/ui/PrivateRoute.tsx` | 미인증 사용자를 `/login`으로 보내며 `state.from`에 원래 위치를 저장 |
+| 로그인 후 목적지 | `frontend/src/features/auth/ui/login-form/LoginForm.tsx` | 허용된 return-to가 있으면 workspace membership 조회 없이 우선 이동 |
+| 기본 목적지 | `frontend/src/features/auth/model/resolveDefaultPostLoginDestination.ts` | workspace 목록을 조회해 기본 workspace workflows 또는 `/workspaces` 반환 |
+| 빈 workspace 화면 | `frontend/src/pages/workspace/ui/WorkspaceRootRedirect.tsx` | workspace 목록이 비어 있으면 `CreateWorkspaceDialog` 표시 |
+
+## Design Diff
+
+| 영역 | As-is | To-be |
+| --- | --- | --- |
+| workspace-scoped return-to | prefix가 허용되면 그대로 사용 | 로그인한 사용자의 workspace 목록에 포함된 ID일 때만 사용 |
+| workspace 0개 신규 사용자 | stale `/workspaces/{id}/...`로 이동 가능 | `/workspaces`로 이동해 생성 화면 표시 |
+| 다른 계정 workspace ID | 상세 route 진입 후 오류/문맥 재사용 위험 | 현재 계정의 기본 workspace 또는 `/workspaces`로 대체 |
+| E2E 검증 | 기본 로그인 후 workspace 진입만 확인 | stale workspace URL + workspace 0개 신규 계정 시 생성 화면 확인 |
+
+## Requirements
+
+1. 로그인 성공 후 비관리자 사용자의 return-to가 `/workspaces/{workspaceId}` 하위 경로이면 현재 계정의 workspace 목록을 조회한다.
+2. return-to workspace ID가 현재 계정 workspace 목록에 없으면 해당 경로를 사용하지 않는다.
+3. 현재 계정 workspace 목록이 비어 있으면 `/workspaces`로 이동해 `WorkspaceRootRedirect`의 생성 화면이 표시되어야 한다.
+4. 현재 계정 workspace가 존재하고 return-to workspace ID가 소속 workspace이면 기존처럼 return-to 경로와 query string을 유지한다.
+5. workspace root(`/workspaces`) return-to는 생성 화면 또는 기본 workspace redirect가 처리할 수 있도록 유지한다.
+6. 일반 사용자는 `/admin` return-to를 사용할 수 없고 기존처럼 role 기준 기본 목적지로 이동한다.
+
+## API Integration
+
+| Method | Path | Description |
+| --- | --- | --- |
+| GET | `/api/v1/workspaces` | 로그인 후 현재 계정의 workspace membership 목록 확인 |
+
+기존 generated endpoint인 `listWorkspaces`를 사용한다. OpenAPI generated 파일은 직접 수정하지 않는다.
+
+## State Management
+
+- 서버 상태: 로그인 직후 `listWorkspaces` 응답을 일회성으로 사용해 목적지를 결정한다.
+- 클라이언트 상태: 별도 store를 추가하지 않는다.
+- `/workspaces` 진입 후 생성 화면 표시 여부는 기존 `WorkspaceRootRedirect`와 TanStack Query hook이 처리한다.
+
+## Tests
+
+### Test Strategy
+
+| 구분 | 방법 | 도구 |
+| --- | --- | --- |
+| 단위 테스트 | 로그인 목적지 resolver가 stale workspace 경로를 걸러내는지 검증 | Vitest |
+| 컴포넌트 테스트 | `LoginForm`이 stale workspace return-to와 workspace 0개 응답에서 `/workspaces`로 이동하는지 검증 | React Testing Library |
+| E2E 테스트 | 브라우저가 이전 workspace URL에서 로그인 화면으로 이동한 뒤 신규 계정 로그인 시 생성 화면을 보는지 검증 | Playwright |
+
+### Test Scenarios
+
+| # | Given | When | Then |
+| --- | --- | --- | --- |
+| 1 | workspace가 없는 신규 사용자와 stale `/workspaces/1/upload` 기록 | 로그인 | `/workspaces`에서 `워크스페이스 생성` 화면 표시 |
+| 2 | 현재 계정에 workspace 4가 있고 return-to가 `/workspaces/4/upload?tab=logs` | 로그인 | 기존 return-to 경로 유지 |
+| 3 | 현재 계정에 workspace 7만 있고 return-to가 `/workspaces/4/upload` | 로그인 | `/workspaces/7/workflows`로 이동 |
+| 4 | 일반 사용자 return-to가 `/admin` | 로그인 | role 기준 기본 목적지 사용 |
+
+## Acceptance Criteria
+
+- 신규 사용자는 이전 계정 workspace URL 기록이 남아 있어도 로그인 후 workspace 생성 화면을 본다.
+- stale workspace route의 workspace 상세 API가 호출되지 않는다.
+- 이전 계정의 workspace 이름, sidebar 상태, domain pack/upload/consultation 화면은 노출되지 않는다.
+- workspace 0개 상태가 오류 화면으로 보이지 않는다.
+- 기존 정상 return-to와 기본 workspace 로그인 흐름은 유지된다.
+
+## Validation
+
+- `cd frontend && pnpm test -- resolveDefaultPostLoginDestination LoginForm`
+- `cd frontend && pnpm e2e -- auth-login.spec.ts`
+- 필요 시 `cd frontend && pnpm lint`
+
+## Open Questions
+
+- 없음.

--- a/frontend/e2e/auth-login.spec.ts
+++ b/frontend/e2e/auth-login.spec.ts
@@ -150,7 +150,11 @@ test.describe("Login screen", () => {
           }
 
           if (method === "GET" && path === "/workspaces") {
-            await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+            await route.fulfill({
+              status: 200,
+              contentType: "application/json",
+              body: JSON.stringify([]),
+            });
             return;
           }
 

--- a/frontend/e2e/auth-login.spec.ts
+++ b/frontend/e2e/auth-login.spec.ts
@@ -101,6 +101,81 @@ test.describe("Login screen", () => {
           .toBeTruthy();
         expect(seen).toContain("POST /auth/login");
       });
+
+      test("Then a workspace-less account sees the workspace creation screen instead of a stale workspace", async ({
+        page,
+      }) => {
+        const seen: string[] = [];
+
+        await page.route("**/api/v1/**", async (route) => {
+          const request = route.request();
+          const url = new URL(request.url());
+          const path = url.pathname.replace(/^\/api\/v1/, "");
+          const method = request.method();
+          seen.push(`${method} ${path}`);
+
+          if (method === "POST" && path === "/auth/refresh") {
+            await route.fulfill({
+              status: 401,
+              contentType: "application/json",
+              body: JSON.stringify({ code: "UNAUTHORIZED", message: "인증이 필요합니다." }),
+            });
+            return;
+          }
+
+          if (method === "POST" && path === "/auth/login") {
+            expect(request.postDataJSON()).toEqual({
+              email: "new-agent@example.com",
+              password: "password123",
+            });
+            await route.fulfill({
+              status: 200,
+              contentType: "application/json",
+              body: JSON.stringify({
+                data: {
+                  accessToken: makeJwt(),
+                  refreshToken: "refresh-token",
+                  tokenType: "Bearer",
+                  expiresIn: 3600,
+                  user: {
+                    id: 9,
+                    email: "new-agent@example.com",
+                    name: "신규 상담사",
+                    role: "OPERATOR",
+                  },
+                },
+              }),
+            });
+            return;
+          }
+
+          if (method === "GET" && path === "/workspaces") {
+            await route.fulfill({ status: 200, contentType: "application/json", body: "[]" });
+            return;
+          }
+
+          await route.fulfill({
+            status: 500,
+            contentType: "application/json",
+            body: JSON.stringify({ code: "E2E_UNMOCKED", message: `${method} ${path}` }),
+          });
+        });
+
+        await page.goto("/workspaces/1/upload");
+        await expect(page).toHaveURL(/\/login$/);
+
+        await page.getByLabel("이메일 주소").fill("new-agent@example.com");
+        await page.getByLabel("비밀번호").fill("password123");
+        await page.getByRole("button", { name: "시스템 로그인" }).click();
+
+        await expect(page).toHaveURL(/\/workspaces$/);
+        await expect(page.getByRole("heading", { name: "워크스페이스 생성" })).toBeVisible();
+        await expect(page.getByText("QA Workspace")).not.toBeVisible();
+        expect(seen).toContain("POST /auth/refresh");
+        expect(seen).toContain("POST /auth/login");
+        expect(seen).toContain("GET /workspaces");
+        expect(seen).not.toContain("GET /workspaces/1");
+      });
     });
   });
 });

--- a/frontend/src/features/auth/model/resolveDefaultPostLoginDestination.test.ts
+++ b/frontend/src/features/auth/model/resolveDefaultPostLoginDestination.test.ts
@@ -2,7 +2,10 @@ import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import { listWorkspaces } from "@/shared/api/generated/endpoints/workspace-controller/workspace-controller";
 import type { WorkspaceResponse } from "@/shared/api/generated/zod";
 import { DEFAULT_POST_LOGIN_PATH } from "./resolvePostLoginDestination";
-import { resolveDefaultPostLoginDestination } from "./resolveDefaultPostLoginDestination";
+import {
+  resolveAuthenticatedPostLoginDestination,
+  resolveDefaultPostLoginDestination,
+} from "./resolveDefaultPostLoginDestination";
 
 vi.mock("@/shared/api/generated/endpoints/workspace-controller/workspace-controller", () => ({
   listWorkspaces: vi.fn(),
@@ -57,5 +60,58 @@ describe("resolveDefaultPostLoginDestination", () => {
     mockedListWorkspaces.mockRejectedValueOnce(new Error("network error"));
 
     await expect(resolveDefaultPostLoginDestination()).resolves.toBe(DEFAULT_POST_LOGIN_PATH);
+  });
+
+  it("현재 계정에 소속된 workspace return-to는 query string과 함께 유지한다", async () => {
+    mockedListWorkspaces.mockResolvedValueOnce(
+      listResponse([{ id: 4, name: "Current", status: "ACTIVE" }]),
+    );
+
+    await expect(
+      resolveAuthenticatedPostLoginDestination({
+        from: { pathname: "/workspaces/4/upload", search: "?tab=logs" },
+      }),
+    ).resolves.toBe("/workspaces/4/upload?tab=logs");
+  });
+
+  it("workspace가 없는 계정의 stale workspace return-to는 /workspaces fallback으로 보낸다", async () => {
+    mockedListWorkspaces.mockResolvedValueOnce(listResponse([]));
+
+    await expect(
+      resolveAuthenticatedPostLoginDestination({
+        from: { pathname: "/workspaces/1/upload" },
+      }),
+    ).resolves.toBe(DEFAULT_POST_LOGIN_PATH);
+  });
+
+  it("다른 계정 workspace return-to는 현재 계정 기본 workspace로 대체한다", async () => {
+    mockedListWorkspaces.mockResolvedValueOnce(
+      listResponse([{ id: 7, name: "Current", status: "ACTIVE" }]),
+    );
+
+    await expect(
+      resolveAuthenticatedPostLoginDestination({
+        from: { pathname: "/workspaces/4/upload" },
+      }),
+    ).resolves.toBe("/workspaces/7/workflows");
+  });
+
+  it("demo return-to는 workspace 조회 없이 유지한다", async () => {
+    await expect(
+      resolveAuthenticatedPostLoginDestination({
+        from: { pathname: "/demo/chat/1", search: "?preview=true" },
+      }),
+    ).resolves.toBe("/demo/chat/1?preview=true");
+    expect(mockedListWorkspaces).not.toHaveBeenCalled();
+  });
+
+  it("일반 사용자의 admin return-to는 role 기준 기본 목적지로 대체한다", async () => {
+    mockedListWorkspaces.mockResolvedValueOnce(listResponse([]));
+
+    await expect(
+      resolveAuthenticatedPostLoginDestination({
+        from: { pathname: "/admin/super-admins" },
+      }),
+    ).resolves.toBe(DEFAULT_POST_LOGIN_PATH);
   });
 });

--- a/frontend/src/features/auth/model/resolveDefaultPostLoginDestination.ts
+++ b/frontend/src/features/auth/model/resolveDefaultPostLoginDestination.ts
@@ -3,22 +3,95 @@ import { selectApiData } from "@/shared/api";
 import { listWorkspaces } from "@/shared/api/generated/endpoints/workspace-controller/workspace-controller";
 import type { WorkspaceResponse } from "@/shared/api/generated/zod";
 import { isSuperAdminRole } from "@/shared/lib/auth";
-import { DEFAULT_POST_LOGIN_PATH } from "./resolvePostLoginDestination";
+import { parseRouteId } from "@/shared/lib/parseRouteId";
+import {
+  DEFAULT_POST_LOGIN_PATH,
+  resolveReturnToPostLoginDestination,
+} from "./resolvePostLoginDestination";
+
+const WORKSPACE_ROUTE_PREFIX = `${DEFAULT_POST_LOGIN_PATH}/`;
+
+async function listCurrentWorkspaces(): Promise<WorkspaceResponse[] | null> {
+  try {
+    const response = await listWorkspaces();
+    return selectApiData<WorkspaceResponse[]>(response) ?? [];
+  } catch {
+    return null;
+  }
+}
+
+function resolveDefaultWorkspaceDestination(workspaces: readonly WorkspaceResponse[]): string {
+  const workspace = selectDefaultWorkspace(workspaces);
+
+  return typeof workspace?.id === "number"
+    ? `/workspaces/${workspace.id}/workflows`
+    : DEFAULT_POST_LOGIN_PATH;
+}
+
+function getWorkspaceDestinationId(destination: string): number | null {
+  if (!destination.startsWith(WORKSPACE_ROUTE_PREFIX)) {
+    return null;
+  }
+
+  const workspaceIdSegment = destination.slice(WORKSPACE_ROUTE_PREFIX.length).split(/[/?#]/)[0];
+  return parseRouteId(workspaceIdSegment);
+}
+
+function isWorkspaceRootDestination(destination: string): boolean {
+  return (
+    destination === DEFAULT_POST_LOGIN_PATH || destination.startsWith(`${DEFAULT_POST_LOGIN_PATH}?`)
+  );
+}
+
+function canUseWorkspaceDestination(
+  destination: string,
+  workspaces: readonly WorkspaceResponse[],
+): boolean {
+  if (isWorkspaceRootDestination(destination)) {
+    return true;
+  }
+
+  const workspaceId = getWorkspaceDestinationId(destination);
+  return workspaceId !== null && workspaces.some((workspace) => workspace.id === workspaceId);
+}
 
 export async function resolveDefaultPostLoginDestination(role?: string | null): Promise<string> {
   if (isSuperAdminRole(role)) {
     return "/admin";
   }
 
-  try {
-    const response = await listWorkspaces();
-    const workspaces = selectApiData<WorkspaceResponse[]>(response) ?? [];
-    const workspace = selectDefaultWorkspace(workspaces);
-
-    return typeof workspace?.id === "number"
-      ? `/workspaces/${workspace.id}/workflows`
-      : DEFAULT_POST_LOGIN_PATH;
-  } catch {
+  const workspaces = await listCurrentWorkspaces();
+  if (workspaces === null) {
     return DEFAULT_POST_LOGIN_PATH;
   }
+
+  return resolveDefaultWorkspaceDestination(workspaces);
+}
+
+export async function resolveAuthenticatedPostLoginDestination(
+  state: unknown,
+  role?: string | null,
+): Promise<string> {
+  const returnToDestination = resolveReturnToPostLoginDestination(state);
+
+  if (isSuperAdminRole(role)) {
+    return returnToDestination?.startsWith("/admin") ? returnToDestination : "/admin";
+  }
+
+  if (returnToDestination !== null && !returnToDestination.startsWith("/admin")) {
+    if (!returnToDestination.startsWith(DEFAULT_POST_LOGIN_PATH)) {
+      return returnToDestination;
+    }
+
+    const workspaces = await listCurrentWorkspaces();
+    if (workspaces === null) {
+      return DEFAULT_POST_LOGIN_PATH;
+    }
+
+    return canUseWorkspaceDestination(returnToDestination, workspaces)
+      ? returnToDestination
+      : resolveDefaultWorkspaceDestination(workspaces);
+  }
+
+  return resolveDefaultPostLoginDestination(role);
 }

--- a/frontend/src/features/auth/ui/login-form/LoginForm.test.tsx
+++ b/frontend/src/features/auth/ui/login-form/LoginForm.test.tsx
@@ -89,7 +89,11 @@ describe("LoginForm", () => {
     expect(localStorage.getItem("refreshToken")).toBeNull();
   });
 
-  it("허용된 return-to 경로가 있으면 워크스페이스 조회 없이 해당 경로를 우선한다", async () => {
+  it("현재 계정 workspace return-to 경로가 있으면 해당 경로를 우선한다", async () => {
+    mockedListWorkspaces.mockResolvedValueOnce(
+      listResponse([{ id: 4, name: "Current", status: "ACTIVE" }]),
+    );
+
     renderLoginForm({
       from: { pathname: "/workspaces/4/upload", search: "?tab=logs" },
     });
@@ -98,7 +102,21 @@ describe("LoginForm", () => {
     await waitFor(() => {
       expect(screen.getByTestId("location")).toHaveTextContent("/workspaces/4/upload?tab=logs");
     });
-    expect(mockedListWorkspaces).not.toHaveBeenCalled();
+    expect(mockedListWorkspaces).toHaveBeenCalledTimes(1);
+  });
+
+  it("workspace가 없는 신규 사용자의 stale workspace return-to는 /workspaces로 보낸다", async () => {
+    mockedListWorkspaces.mockResolvedValueOnce(listResponse([]));
+
+    renderLoginForm({
+      from: { pathname: "/workspaces/4/upload" },
+    });
+    await submitLoginForm();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("location")).toHaveTextContent("/workspaces");
+    });
+    expect(mockedListWorkspaces).toHaveBeenCalledTimes(1);
   });
 
   it("기본 워크스페이스를 확인할 수 없으면 /workspaces fallback으로 이동한다", async () => {

--- a/frontend/src/features/auth/ui/login-form/LoginForm.tsx
+++ b/frontend/src/features/auth/ui/login-form/LoginForm.tsx
@@ -5,9 +5,8 @@ import { toast } from "sonner";
 import { Input } from "../../../../shared/ui/input/Input";
 import { Button } from "../../../../shared/ui/button/Button";
 import { loginApi } from "../../api/authApi";
-import { resolveDefaultPostLoginDestination } from "../../model/resolveDefaultPostLoginDestination";
-import { resolveReturnToPostLoginDestination } from "../../model/resolvePostLoginDestination";
-import { isSuperAdminRole, saveAuthSession } from "../../../../shared/lib/auth";
+import { resolveAuthenticatedPostLoginDestination } from "../../model/resolveDefaultPostLoginDestination";
+import { saveAuthSession } from "../../../../shared/lib/auth";
 import { ApiRequestError } from "../../../../shared/api";
 import styles from "./login-form.module.css";
 
@@ -66,13 +65,7 @@ export const LoginForm: React.FC = () => {
         },
       );
 
-      const returnToDestination = resolveReturnToPostLoginDestination(location.state);
-      const requiresDefaultDestination =
-        returnToDestination === null ||
-        (!isSuperAdminRole(role) && returnToDestination.startsWith("/admin"));
-      const destination = requiresDefaultDestination
-        ? await resolveDefaultPostLoginDestination(role)
-        : returnToDestination;
+      const destination = await resolveAuthenticatedPostLoginDestination(location.state, role);
       navigate(destination, { replace: true });
     } catch (err) {
       if (err instanceof ApiRequestError) {


### PR DESCRIPTION
Closes #695

## 변경 사항

- 로그인 후 `/workspaces/{workspaceId}` return-to 경로를 현재 로그인한 계정의 workspace 목록에 포함된 ID일 때만 유지하도록 했습니다.
- 소속 workspace가 없는 신규 사용자는 stale workspace URL 대신 `/workspaces`로 이동해 기존 `워크스페이스 생성` 화면을 보도록 했습니다.
- 현재 계정에 다른 workspace가 있는 경우 stale workspace 경로를 현재 계정의 기본 workspace 경로로 대체합니다.
- 이슈 695 스펙을 `.agent/specs/695.md`에 정리하고, resolver/component/E2E 회귀 테스트를 보강했습니다.

## 검증

- `pnpm --dir frontend test -- resolveDefaultPostLoginDestination LoginForm`
- `pnpm --dir frontend e2e -- auth-login.spec.ts`
- `pnpm --dir frontend exec eslint src/features/auth/model/resolveDefaultPostLoginDestination.ts src/features/auth/model/resolveDefaultPostLoginDestination.test.ts src/features/auth/ui/login-form/LoginForm.tsx src/features/auth/ui/login-form/LoginForm.test.tsx e2e/auth-login.spec.ts`
- `pnpm --dir frontend audit:api`
- `pnpm --dir frontend audit:fsd`
- `git diff --check`

## 참고

- `pnpm --dir frontend lint`와 pre-commit의 `pnpm run lint:frontend`는 repository-wide 기존 ESLint baseline 47건으로 실패합니다. 이번 변경 파일 대상 ESLint와 API/FSD audits는 통과했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 로그인 후 이전 계정의 유효하지 않은 워크스페이스 URL로 접근하는 문제 해결. 워크스페이스가 없는 사용자는 이제 워크스페이스 생성 화면으로 올바르게 리다이렉트됩니다.

* **설명서**
  * 로그인 후 워크스페이스 라우팅 요구사항 및 검증 시나리오 문서화

* **테스트**
  * 워크스페이스 없는 계정 시나리오 및 로그인 후 목적지 결정 로직에 대한 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->