### PR TITLE
test(frontend): Domain Pack 보유 워크스페이스 로그인 운영 진입 보장

### DIFF
--- a/.agent/specs/692.md
+++ b/.agent/specs/692.md
@@ -1,0 +1,188 @@
+# Frontend E2E Spec: Domain Pack 보유 워크스페이스 로그인 운영 진입
+
+## Goal
+
+운영자가 active 또는 published Domain Pack이 있는 워크스페이스에 로그인하면 현재 계정의 워크스페이스 운영 화면으로 진입하고, 빈 업로드 시작 화면이나 이전 계정의 워크스페이스 정보가 보이지 않음을 E2E로 검증한다.
+
+---
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A[시작: 로그인 화면] --> B[운영자 이메일과 비밀번호 입력]
+    B --> C[로그인 API 성공]
+    C --> D[현재 계정의 워크스페이스 목록 조회]
+    D --> E{ACTIVE 워크스페이스 존재?}
+    E -->|Yes| F[기본 워크스페이스 workflows 화면 진입]
+    E -->|No| G[워크스페이스 fallback]
+    F --> H{Domain Pack 운영 버전 존재?}
+    H -->|Yes| I[워크스페이스 이름과 workflow 운영 정보 표시]
+    H -->|No| J[workflow 빈 상태 표시]
+    I --> K[종료]
+    J --> K
+    G --> K
+```
+
+---
+
+## Design Diff
+
+### As-is vs To-be
+
+| 영역 | As-is | To-be | 변경 내용 |
+|------|-------|-------|----------|
+| 로그인 E2E | 로그인 성공 후 workspace workflows 진입과 세션 저장만 검증 | active/published Domain Pack이 있는 workspace의 운영 시작 화면까지 검증 | 현재 workspace 이름, Domain Pack 기반 workflow 정보, stale workspace 미노출, upload 화면 미진입을 함께 확인 |
+| API fixture | 로그인 테스트가 빈 Domain Pack 목록만 고정 | Domain Pack 목록, 상세, version workflow 목록을 현재 화면 분기와 맞춰 구성 | 하드코딩된 단일 문구보다 화면이 실제로 호출하는 API 흐름을 검증 |
+| 사용자 기대 | 다음 업무 이동 가능 여부가 단위/기존 E2E에 흩어짐 | workflow 화면의 dashboard/domain pack 내비게이션과 workflow 상세 진입 액션이 로그인 플로우에서 확인됨 | 운영 시작 화면으로서의 진입 안정성을 E2E로 보강 |
+
+---
+
+## Component Tree
+
+```text
+LoginPage
+└─ LoginForm
+   └─ resolveDefaultPostLoginDestination
+      └─ listWorkspaces
+
+WorkspaceLayout
+├─ OstoneShell
+│  ├─ WorkspaceMarker
+│  ├─ Sidebar
+│  └─ Topbar
+└─ WorkspaceWorkflowsPage
+   └─ WorkflowListView
+      └─ WorkflowRow
+```
+
+---
+
+## API Integration
+
+### Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/api/v1/auth/login` | 운영자 로그인 |
+| GET | `/api/v1/workspaces` | 로그인 후 기본 워크스페이스 결정 및 shell workspace marker 조회 |
+| GET | `/api/v1/workspaces/{workspaceId}` | WorkspaceLayout 현재 워크스페이스 조회 |
+| GET | `/api/v1/workspaces/{workspaceId}/domain-packs` | workspace workflow 목록 구성을 위한 Domain Pack 목록 조회 |
+| GET | `/api/v1/workspaces/{workspaceId}/domain-packs/{packId}` | 운영 버전 확인을 위한 Domain Pack 상세 조회 |
+| GET | `/api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/workflows` | 운영 시작 화면 workflow 목록 조회 |
+
+### Query Key Pattern
+
+기존 generated endpoint와 query key를 그대로 사용한다.
+
+- `frontend/src/features/auth/model/resolveDefaultPostLoginDestination.ts`
+- `frontend/src/entities/workflow/api/useListAllWorkspaceWorkflows.ts`
+- `frontend/src/shared/api/generated/endpoints/workspace-controller/workspace-controller.ts`
+- `frontend/src/shared/api/generated/endpoints/domain-pack-controller/domain-pack-controller.ts`
+- `frontend/src/shared/api/generated/endpoints/workflow-definition-controller/workflow-definition-controller.ts`
+
+---
+
+## Data Flow
+
+```text
+LoginForm submit
+  -> loginApi
+  -> saveAuthSession
+  -> resolveDefaultPostLoginDestination
+  -> listWorkspaces
+  -> navigate /workspaces/{workspaceId}/workflows
+  -> WorkspaceLayout fetches workspace
+  -> WorkspaceWorkflowsPage
+       -> listDomainPacks
+       -> getDomainPack
+       -> listWorkflows
+  -> WorkflowListView renders pack/workflow operating data
+```
+
+---
+
+## 수정 대상 파일
+
+| 파일 | 변경 유형 | 설명 |
+|------|----------|------|
+| `.agent/specs/692.md` | new | 이슈 692 요구사항과 검증 기준 문서화 |
+| `frontend/e2e/auth-login.spec.ts` | update | Domain Pack 보유 workspace 로그인 운영 진입 E2E 추가 |
+
+---
+
+## State Management
+
+- 새 클라이언트 상태는 추가하지 않는다.
+- 로그인 성공 후 `saveAuthSession`이 localStorage의 auth session을 현재 계정 정보로 갱신한다.
+- E2E는 이전 계정 흔적을 localStorage에 사전 주입한 뒤 현재 계정 로그인 결과로 덮어쓰이고, 화면에는 현재 workspace만 노출되는지 확인한다.
+
+---
+
+## Tests
+
+### Test Strategy
+
+| 구분 | 방법 | 도구 | 비고 |
+|------|------|------|------|
+| E2E 테스트 | 로그인 폼 조작 + API route mocking | Playwright | 핵심 사용자 시나리오 |
+| 로컬 검증 | auth-login spec 단독 실행 | `pnpm e2e auth-login.spec.ts` | preview mock 환경 |
+
+### Test Environment & 사전 조건
+
+| 항목 | 값 |
+|------|---|
+| 환경 | `frontend/playwright.config.ts` preview mock 환경 |
+| API Mock | Playwright `page.route("**/api/v1/**")` |
+| 사전 조건 | 현재 계정에 ACTIVE workspace가 있고 해당 workspace에 PUBLISHED version workflow가 있는 Domain Pack이 존재 |
+
+### Test Scenarios
+
+#### Happy Path
+
+| # | 시나리오 | 사전 조건 | 조작 | 기대 결과 |
+|---|---------|---------|------|----------|
+| 1 | Domain Pack 보유 workspace 로그인 | 현재 계정 workspace에 active/published Domain Pack과 workflow 존재 | 로그인 화면에서 이메일/비밀번호 입력 후 시스템 로그인 | `/workspaces/1/workflows` 진입, 현재 workspace 이름과 Domain Pack 기반 workflow 표시 |
+| 2 | 운영 다음 업무 이동 가능성 | workflows 화면 진입 완료 | 화면의 주요 navigation과 workflow row action 확인 | dashboard/domain pack 이동 링크와 workflow 상세 진입 액션이 현재 workspace 기준으로 표시 |
+
+#### Error & Edge Cases
+
+| # | 시나리오 | 조작 | 기대 결과 |
+|---|---------|------|----------|
+| 1 | 이전 계정 흔적 존재 | 로그인 전 localStorage에 이전 사용자 session 값 주입 | 로그인 후 이전 workspace 이름과 `/workspaces/999` URL이 보이지 않음 |
+| 2 | upload start 오진입 방지 | Domain Pack fixture가 active/published 상태 | 로그인 후 상담 로그 업로드 heading과 `/upload` URL이 보이지 않음 |
+
+#### 반응형 & 접근성
+
+| # | 확인 항목 | 기대 결과 |
+|---|---------|----------|
+| 1 | 접근 가능한 로그인 입력 | `이메일 주소`, `비밀번호`, `시스템 로그인` label/role로 조작 가능 |
+| 2 | 운영 화면 heading | `워크플로우` heading이 role 기반으로 조회 가능 |
+| 3 | workspace marker | 현재 workspace 이름이 shell marker에 표시 |
+
+---
+
+## Non-goals
+
+- 로그인 후 기본 진입 화면 정책 자체를 변경하지 않는다. 현재 코드에서 기본 운영 시작 화면은 `/workspaces/{id}/workflows`이다.
+- 실제 운영 백엔드를 호출하는 live E2E를 추가하지 않는다.
+- Domain Pack 생성, publish, activate 절차를 이 테스트에서 수행하지 않는다.
+- OpenAPI generated 파일은 직접 수정하지 않는다.
+
+---
+
+## Acceptance Criteria
+
+- `.agent/specs/692.md` 파일명이 이슈 번호만 포함한다.
+- `frontend/e2e/auth-login.spec.ts`에 Domain Pack 보유 workspace 로그인 시나리오가 추가된다.
+- 테스트는 로그인 후 현재 workspace 이름과 Domain Pack 기반 workflow 정보를 확인한다.
+- 테스트는 빈 업로드 시작 화면으로 보내지지 않았음을 URL과 heading으로 확인한다.
+- 테스트는 이전 계정 workspace 이름 또는 `/workspaces/999` URL이 노출되지 않음을 확인한다.
+- 테스트는 unmocked API가 발생하면 실패하도록 구성한다.
+
+---
+
+## Open Questions
+
+- 제품 정책상 기본 운영 시작 화면이 향후 dashboard로 변경되면 `resolveDefaultPostLoginDestination`과 이 E2E의 기대 URL을 함께 갱신해야 한다.
+- active Domain Pack과 published Domain Pack의 백엔드 응답 status/lifecycle 용어가 추가로 정규화되면 fixture 명칭을 실제 API 계약에 맞춰 조정해야 한다.

--- a/frontend/e2e/auth-login.spec.ts
+++ b/frontend/e2e/auth-login.spec.ts
@@ -1,6 +1,141 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page, type Route } from "@playwright/test";
 
 import { makeJwt } from "./support/generated-api-auth";
+
+const workspace = {
+  id: 1,
+  workspaceKey: "qa-workspace",
+  name: "QA Workspace",
+  status: "ACTIVE",
+  myRole: "OWNER",
+};
+
+const activePackSummary = {
+  packId: 1,
+  workspaceId: 1,
+  name: "Generated API Pack",
+  description: "상담 로그에서 생성된 환불 자동화 팩",
+  status: "ACTIVE",
+  currentVersionId: 1,
+  currentVersionNo: 1,
+};
+
+const activePackDetail = {
+  ...activePackSummary,
+  code: "PACK_REFUND",
+  versions: [
+    {
+      versionId: 1,
+      packId: 1,
+      versionNo: 1,
+      lifecycleStatus: "PUBLISHED",
+      summaryJson: "{}",
+      description: "운영 중인 환불 상담 자동화 버전",
+      intentCount: 1,
+      slotCount: 1,
+      policyCount: 1,
+      riskCount: 1,
+      workflowCount: 1,
+    },
+  ],
+};
+
+const workflow = {
+  id: 401,
+  domainPackVersionId: 1,
+  intentDefinitionId: 501,
+  workflowCode: "WF_REFUND",
+  name: "환불 처리",
+  description: "주문번호를 확인하고 환불 정책에 따라 안내하는 workflow",
+  initialState: "start",
+  terminalStatesJson: "[\"done\"]",
+  graphJson: null,
+  evidenceJson: "{}",
+  metaJson: "{}",
+};
+
+type DomainPackMode = "empty" | "active";
+
+async function fulfillJson(route: Route, body: unknown, status = 200) {
+  await route.fulfill({
+    status,
+    contentType: "application/json",
+    body: JSON.stringify(body),
+  });
+}
+
+async function installLoginApiMocks(
+  page: Page,
+  seen: string[],
+  domainPackMode: DomainPackMode,
+) {
+  await page.route("**/api/v1/**", async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const path = url.pathname.replace(/^\/api\/v1/, "");
+    const method = request.method();
+    seen.push(`${method} ${path}`);
+
+    if (method === "POST" && path === "/auth/login") {
+      expect(request.postDataJSON()).toEqual({
+        email: "agent@example.com",
+        password: "password123",
+      });
+      await fulfillJson(route, {
+        data: {
+          accessToken: makeJwt(),
+          refreshToken: "refresh-token",
+          tokenType: "Bearer",
+          expiresIn: 3600,
+          user: {
+            id: 7,
+            email: "agent@example.com",
+            name: "상담사",
+            role: "OPERATOR",
+          },
+        },
+      });
+      return;
+    }
+
+    if (method === "GET" && path === "/workspaces") {
+      await fulfillJson(route, [workspace]);
+      return;
+    }
+
+    if (method === "GET" && path === "/workspaces/1") {
+      await fulfillJson(route, workspace);
+      return;
+    }
+
+    if (method === "GET" && path === "/workspaces/1/domain-packs") {
+      const packs = domainPackMode === "active" ? [activePackSummary] : [];
+      await fulfillJson(route, { data: packs });
+      return;
+    }
+
+    if (
+      domainPackMode === "active" &&
+      method === "GET" &&
+      path === "/workspaces/1/domain-packs/1"
+    ) {
+      await fulfillJson(route, { data: activePackDetail });
+      return;
+    }
+
+    if (
+      domainPackMode === "active" &&
+      method === "GET" &&
+      path === "/workspaces/1/domain-packs/1/versions/1/workflows"
+    ) {
+      await fulfillJson(route, { data: [workflow] });
+      return;
+    }
+
+    seen.push(`UNMOCKED ${method} ${path}`);
+    await fulfillJson(route, { code: "E2E_UNMOCKED", message: `${method} ${path}` }, 500);
+  });
+}
 
 test.describe("Login screen", () => {
   test.describe("Given a valid operator account", () => {
@@ -8,86 +143,7 @@ test.describe("Login screen", () => {
       test("Then the app stores the auth session and enters the workspace", async ({ page }) => {
         const seen: string[] = [];
 
-        await page.route("**/api/v1/**", async (route) => {
-          const request = route.request();
-          const url = new URL(request.url());
-          const path = url.pathname.replace(/^\/api\/v1/, "");
-          const method = request.method();
-          seen.push(`${method} ${path}`);
-
-          if (method === "POST" && path === "/auth/login") {
-            expect(request.postDataJSON()).toEqual({
-              email: "agent@example.com",
-              password: "password123",
-            });
-            await route.fulfill({
-              status: 200,
-              contentType: "application/json",
-              body: JSON.stringify({
-                data: {
-                  accessToken: makeJwt(),
-                  refreshToken: "refresh-token",
-                  tokenType: "Bearer",
-                  expiresIn: 3600,
-                  user: {
-                    id: 7,
-                    email: "agent@example.com",
-                    name: "상담사",
-                    role: "OPERATOR",
-                  },
-                },
-              }),
-            });
-            return;
-          }
-
-          if (method === "GET" && path === "/workspaces") {
-            await route.fulfill({
-              status: 200,
-              contentType: "application/json",
-              body: JSON.stringify([
-                {
-                  id: 1,
-                  workspaceKey: "qa-workspace",
-                  name: "QA Workspace",
-                  status: "ACTIVE",
-                  myRole: "OWNER",
-                },
-              ]),
-            });
-            return;
-          }
-
-          if (method === "GET" && path === "/workspaces/1") {
-            await route.fulfill({
-              status: 200,
-              contentType: "application/json",
-              body: JSON.stringify({
-                id: 1,
-                workspaceKey: "qa-workspace",
-                name: "QA Workspace",
-                status: "ACTIVE",
-                myRole: "OWNER",
-              }),
-            });
-            return;
-          }
-
-          if (method === "GET" && path === "/workspaces/1/domain-packs") {
-            await route.fulfill({
-              status: 200,
-              contentType: "application/json",
-              body: JSON.stringify({ data: [] }),
-            });
-            return;
-          }
-
-          await route.fulfill({
-            status: 500,
-            contentType: "application/json",
-            body: JSON.stringify({ code: "E2E_UNMOCKED", message: `${method} ${path}` }),
-          });
-        });
+        await installLoginApiMocks(page, seen, "empty");
 
         await page.goto("/login");
         await page.getByLabel("이메일 주소").fill("agent@example.com");
@@ -100,6 +156,66 @@ test.describe("Login screen", () => {
           .poll(() => page.evaluate(() => window.localStorage.getItem("accessToken")))
           .toBeTruthy();
         expect(seen).toContain("POST /auth/login");
+        expect(seen.filter((entry) => entry.startsWith("UNMOCKED "))).toEqual([]);
+      });
+
+      test("Then an operator with an active domain pack lands on current workspace operations", async ({
+        page,
+      }) => {
+        const seen: string[] = [];
+
+        await page.addInitScript(() => {
+          window.localStorage.setItem("accessToken", "legacy-access-token");
+          window.localStorage.setItem("refreshToken", "legacy-refresh-token");
+          window.localStorage.setItem(
+            "user",
+            JSON.stringify({
+              id: 999,
+              email: "legacy@example.com",
+              name: "이전 운영자",
+              role: "OPERATOR",
+            }),
+          );
+        });
+        await installLoginApiMocks(page, seen, "active");
+
+        await page.goto("/login");
+        await page.getByLabel("이메일 주소").fill("agent@example.com");
+        await page.getByLabel("비밀번호").fill("password123");
+        await page.getByRole("button", { name: "시스템 로그인" }).click();
+
+        await expect(page).toHaveURL(/\/workspaces\/1\/workflows$/);
+        await expect(page.getByTestId("workspace-marker")).toContainText("QA Workspace");
+        await expect(page.getByRole("heading", { name: "워크플로우", level: 1 })).toBeVisible();
+        await expect(page.getByTestId("workspace-workflows")).toBeVisible();
+        await expect(page.getByTestId("workspace-workflows-card-401")).toContainText(
+          "Generated API Pack",
+        );
+        await expect(page.getByTestId("workspace-workflows-card-401")).toContainText("환불 처리");
+        await expect(page.getByTestId("sidebar-link-dashboard")).toHaveAttribute(
+          "href",
+          "/workspaces/1/dashboard",
+        );
+        await expect(page.getByTestId("sidebar-domain-link")).toHaveAttribute(
+          "href",
+          "/workspaces/1/domain-packs",
+        );
+        await expect(page.getByTestId("workspace-workflows-card-401-open")).toBeEnabled();
+        await expect(page.getByRole("heading", { name: "상담 로그 업로드" })).not.toBeVisible();
+        await expect
+          .poll(() =>
+            page.evaluate(() => JSON.parse(window.localStorage.getItem("user") ?? "{}").name),
+          )
+          .toBe("상담사");
+        await expect(page.getByText("이전 운영자")).toHaveCount(0);
+        await expect(page.getByText("Legacy Workspace")).toHaveCount(0);
+        expect(page.url()).not.toContain("/workspaces/999");
+        expect(seen).toContain("POST /auth/login");
+        expect(seen).toContain("GET /workspaces");
+        expect(seen).toContain("GET /workspaces/1/domain-packs");
+        expect(seen).toContain("GET /workspaces/1/domain-packs/1");
+        expect(seen).toContain("GET /workspaces/1/domain-packs/1/versions/1/workflows");
+        expect(seen.filter((entry) => entry.startsWith("UNMOCKED "))).toEqual([]);
       });
     });
   });


### PR DESCRIPTION
Closes #692

## 변경 사항

- 이슈 692 요구사항과 acceptance criteria를 `.agent/specs/692.md`에 정리했습니다.
- 로그인 E2E의 API mock을 공통 helper로 정리하고, active/published Domain Pack이 있는 workspace 로그인 시 `/workspaces/{id}/workflows` 운영 화면에 진입하는 시나리오를 추가했습니다.
- 현재 workspace 이름, Domain Pack 기반 workflow 정보, dashboard/domain pack 이동 링크, workflow 상세 진입 액션, stale session 덮어쓰기, upload 화면 미진입을 함께 검증합니다.
- 예상하지 못한 API 호출이 발생하면 request log에 `UNMOCKED`로 남기고 테스트가 실패하도록 보강했습니다.

## 검증

- `pnpm --dir frontend build`
- `pnpm --dir frontend e2e auth-login.spec.ts`
- `pnpm --dir frontend exec eslint e2e/auth-login.spec.ts`
- `git diff --cached --check`

## 참고

- `pnpm --dir frontend lint`와 pre-commit의 `pnpm run lint:frontend`는 이번 변경과 무관한 기존 frontend ESLint baseline 47건으로 실패합니다. API/FSD audits와 변경 파일 대상 ESLint는 통과했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * 운영자 로그인 시 Domain Pack 기반 화면 표시 검증 기준 문서 추가

* **Tests**
  * 로그인 후 활성 Domain Pack에 따른 올바른 워크플로우 데이터 표시 검증 강화
  * 이전 워크스페이스 정보 노출 방지 검증 시나리오 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->