### PR TITLE
test(frontend): 이전 계정 workspace context 격리 보장

### DIFF
--- a/.agent/specs/693.md
+++ b/.agent/specs/693.md
@@ -1,0 +1,157 @@
+# Frontend FSD Spec: 이전 계정 workspace context 격리
+
+## Goal
+
+로그인 직전 브라우저에 이전 계정의 workspace URL이나 auth storage가 남아 있어도, 로그인 후에는 현재 계정이 접근 가능한 workspace context만 사용한다.
+
+---
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A[시작: 브라우저에 이전 workspace URL 또는 auth storage 존재] --> B[현재 계정으로 로그인]
+    B --> C{Return-to 경로가 workspace 상세 경로인가?}
+    C -->|아니오| D[기존 허용 경로 정책 적용]
+    C -->|예| E[현재 계정의 workspace 목록 조회]
+    E --> F{해당 workspaceId 접근 가능?}
+    F -->|예| G[요청한 workspace 경로로 이동]
+    F -->|아니오| H[현재 계정 기본 workspace 시작 화면으로 이동]
+    D --> I[현재 계정 context 표시]
+    G --> I
+    H --> I
+```
+
+---
+
+## Design Diff
+
+### As-is vs To-be
+
+| 영역 | As-is | To-be | 변경 내용 |
+|------|-------|-------|----------|
+| 로그인 후 return-to | 허용 prefix의 `/workspaces/:id/...`를 그대로 사용 | workspace 상세 return-to는 현재 계정 workspace 목록에 포함될 때만 사용 | 이전 계정 workspace URL 재사용 방지 |
+| 기본 landing | return-to가 없을 때만 `GET /workspaces` 기준 기본 workspace 선택 | stale workspace return-to도 `GET /workspaces` 기준 fallback 가능 | 현재 계정의 안전한 시작 화면 보장 |
+| E2E 검증 | 정상 로그인 happy path 중심 | 이전 계정 URL/history/storage가 남은 상태에서 현재 계정 workspace만 표시 검증 | context isolation 회귀 방지 |
+
+---
+
+## Component Tree
+
+```text
+LoginPage
+└─ LoginForm
+   ├─ loginApi
+   ├─ saveAuthSession
+   └─ resolveAuthenticatedPostLoginDestination
+      ├─ resolveReturnToPostLoginDestination
+      └─ resolveDefaultPostLoginDestination
+
+WorkspaceRootRedirect
+└─ useListWorkspaces
+   └─ selectDefaultWorkspace
+```
+
+---
+
+## API Integration
+
+### Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/api/v1/auth/login` | 현재 계정 로그인 |
+| GET | `/api/v1/workspaces` | 현재 계정이 접근 가능한 workspace 목록 조회 및 stale workspaceId 검증 |
+
+신규 API는 만들지 않는다. Backend membership 판정은 기존 workspace 목록 API 응답을 기준으로 사용한다.
+
+---
+
+## 수정 대상 파일
+
+| 파일 | 변경 유형 | 설명 |
+|------|----------|------|
+| `frontend/src/features/auth/model/resolveDefaultPostLoginDestination.ts` | modify | 현재 계정 workspace 목록을 기준으로 post-login return-to와 fallback destination을 결정 |
+| `frontend/src/features/auth/ui/login-form/LoginForm.tsx` | modify | 로그인 성공 후 membership-aware resolver 사용 |
+| `frontend/src/features/auth/model/resolveDefaultPostLoginDestination.test.ts` | modify | stale workspace return-to와 접근 가능한 workspace return-to 검증 |
+| `frontend/src/features/auth/ui/login-form/LoginForm.test.tsx` | modify | 로그인 폼이 stale workspace URL 대신 현재 계정 기본 workspace로 이동하는지 검증 |
+| `frontend/e2e/auth-login.spec.ts` | modify | 이전 계정 URL/history/storage가 남은 브라우저에서 현재 계정 workspace만 노출되는 E2E 추가 |
+
+---
+
+## State Management
+
+### Auth storage
+
+- 확인된 auth storage key는 `frontend/src/shared/lib/auth.ts`의 `accessToken`, `refreshToken`, `user`다.
+- 로그인 성공 시 `saveAuthSession`은 현재 계정 토큰과 사용자 정보를 저장하고 legacy refresh token을 제거한다.
+- 별도의 persisted selected workspace storage key는 확인되지 않았다.
+
+### Navigation state
+
+- stale workspace context의 주요 재현 경로는 `PrivateRoute`가 `/login`으로 전달하는 `location.state.from`이다.
+- `/workspaces` 루트 return-to는 기존처럼 안전한 workspace 선택 화면으로 유지한다.
+- `/workspaces/:workspaceId/...` return-to는 현재 계정의 `GET /workspaces` 응답에 해당 id가 있을 때만 유지한다.
+
+---
+
+## Tests
+
+### Test Strategy
+
+| 구분 | 방법 | 도구 | 비고 |
+|------|------|------|------|
+| 단위 테스트 | destination resolver와 LoginForm navigation 검증 | Vitest + React Testing Library | 빠른 회귀 방지 |
+| E2E 테스트 | stale URL/history/storage 후 현재 계정 로그인 | Playwright mocked E2E | 화면상 context isolation 우선 검증 |
+
+### Test Scenarios
+
+#### Happy Path
+
+| # | 시나리오 | 사전 조건 | 조작 | 기대 결과 |
+|---|---------|---------|------|----------|
+| 1 | 접근 가능한 workspace return-to 유지 | 현재 계정 workspace 목록에 return-to workspaceId 포함 | 로그인 | 기존 return-to 경로로 이동 |
+| 2 | return-to 없음 | 현재 계정 ACTIVE workspace 존재 | 로그인 | 현재 계정 기본 workspace workflows 화면으로 이동 |
+
+#### Error & Edge Cases
+
+| # | 시나리오 | 조작 | 기대 결과 |
+|---|---------|------|----------|
+| 1 | 이전 계정 workspace return-to | `/workspaces/99/...`에서 로그인으로 이동 후 현재 계정 로그인 | `/workspaces/99/...`가 아니라 현재 계정 workspace로 이동 |
+| 2 | 이전 계정 auth storage 존재 | stale `accessToken`, `refreshToken`, `user`가 남은 상태에서 로그인 | 현재 계정 auth session으로 교체되고 이전 workspace 이름이 노출되지 않음 |
+| 3 | workspace 목록 조회 실패 | 로그인 후 workspace 목록 API 실패 | 기존 fallback인 `/workspaces`로 이동 |
+| 4 | 비운영자 admin return-to | OPERATOR가 `/admin/...` return-to로 로그인 | 현재 계정 기본 workspace로 이동 |
+
+---
+
+## Acceptance Criteria
+
+- 로그인 성공 후 OPERATOR 계정은 현재 계정 `GET /workspaces` 응답에 없는 `/workspaces/:id/...` return-to 경로로 이동하지 않는다.
+- stale workspace 이름, URL, 상담 데이터, Domain Pack 데이터가 화면에 노출되지 않는다.
+- 현재 계정의 workspace context가 URL, sidebar marker, 주요 화면 heading에서 일관되게 표시된다.
+- 권한 없는 workspace URL로 자동 redirect되지 않는다.
+- 사용자는 빈 화면이 아니라 현재 계정 기준의 안전한 시작 화면을 본다.
+- 신규 동작은 unit test와 mocked Playwright E2E로 검증한다.
+
+---
+
+## Non-goals
+
+- Backend workspace membership API 또는 권한 정책을 변경하지 않는다.
+- workspace별 persisted UI 설정 key를 새로 만들거나 삭제하지 않는다.
+- live E2E 계정, 운영 데이터, 실제 외부 인증 플로우는 이 이슈에서 다루지 않는다.
+- Domain Pack, 상담 기록, 결제 등 workspace 내부 화면의 데이터 조회 로직은 변경하지 않는다.
+
+---
+
+## Validation
+
+- `pnpm --dir frontend test -- resolveDefaultPostLoginDestination LoginForm --run`
+- `pnpm --dir frontend e2e -- auth-login.spec.ts`
+- 필요 시 `pnpm run ci:frontend`와 `pnpm run e2e:frontend`로 CI basic frontend 범위를 재현한다.
+
+---
+
+## Open Questions
+
+- 현재 코드 기준으로 별도의 selected workspace storage key는 확인되지 않았다. 이후 새 key가 도입되면 로그인 계정 전환 시 정리 대상인지 별도 이슈로 판단한다.

--- a/frontend/e2e/auth-login.spec.ts
+++ b/frontend/e2e/auth-login.spec.ts
@@ -296,6 +296,146 @@ test.describe("Login screen", () => {
         expect(seen).toContain("GET /workspaces");
         expect(seen).not.toContain("GET /workspaces/1");
       });
+
+      test("Then stale workspace history is ignored for the current account", async ({ page }) => {
+        const seen: string[] = [];
+
+        await page.addInitScript(() => {
+          window.localStorage.setItem("accessToken", "stale-access-token");
+          window.localStorage.setItem("refreshToken", "stale-refresh-token");
+          window.localStorage.setItem(
+            "user",
+            JSON.stringify({
+              id: 99,
+              email: "previous@example.com",
+              name: "이전 상담사",
+              role: "OPERATOR",
+            }),
+          );
+        });
+
+        await page.route("**/api/v1/**", async (route) => {
+          const request = route.request();
+          const url = new URL(request.url());
+          const path = url.pathname.replace(/^\/api\/v1/, "");
+          const method = request.method();
+          seen.push(`${method} ${path}`);
+
+          if (method === "POST" && path === "/auth/refresh") {
+            await route.fulfill({
+              status: 401,
+              contentType: "application/json",
+              body: JSON.stringify({ code: "TOKEN_EXPIRED", message: "expired" }),
+            });
+            return;
+          }
+
+          if (method === "POST" && path === "/auth/login") {
+            await route.fulfill({
+              status: 200,
+              contentType: "application/json",
+              body: JSON.stringify({
+                data: {
+                  accessToken: makeJwt(),
+                  refreshToken: "current-refresh-token",
+                  tokenType: "Bearer",
+                  expiresIn: 3600,
+                  user: {
+                    id: 7,
+                    email: "agent@example.com",
+                    name: "현재 상담사",
+                    role: "OPERATOR",
+                  },
+                },
+              }),
+            });
+            return;
+          }
+
+          if (method === "GET" && path === "/workspaces") {
+            await route.fulfill({
+              status: 200,
+              contentType: "application/json",
+              body: JSON.stringify([
+                {
+                  id: 1,
+                  workspaceKey: "current-workspace",
+                  name: "Current Workspace",
+                  status: "ACTIVE",
+                  myRole: "OWNER",
+                },
+              ]),
+            });
+            return;
+          }
+
+          if (method === "GET" && path === "/workspaces/1") {
+            await route.fulfill({
+              status: 200,
+              contentType: "application/json",
+              body: JSON.stringify({
+                id: 1,
+                workspaceKey: "current-workspace",
+                name: "Current Workspace",
+                status: "ACTIVE",
+                myRole: "OWNER",
+              }),
+            });
+            return;
+          }
+
+          if (method === "GET" && path === "/workspaces/1/domain-packs") {
+            await route.fulfill({
+              status: 200,
+              contentType: "application/json",
+              body: JSON.stringify({ data: [] }),
+            });
+            return;
+          }
+
+          await route.fulfill({
+            status: 500,
+            contentType: "application/json",
+            body: JSON.stringify({ code: "E2E_UNMOCKED", message: `${method} ${path}` }),
+          });
+        });
+
+        await page.goto("/workspaces/99/domain-packs");
+        await expect(page).toHaveURL(/\/login$/);
+
+        await page.getByLabel("이메일 주소").fill("agent@example.com");
+        await page.getByLabel("비밀번호").fill("password123");
+        await page.getByRole("button", { name: "시스템 로그인" }).click();
+
+        await expect(page).toHaveURL(/\/workspaces\/1\/workflows$/);
+        await expect(page.getByRole("heading", { name: "워크플로우", level: 1 })).toBeVisible();
+        await expect(page.getByTestId("workspace-marker")).toContainText("Current Workspace");
+        await expect(page.getByText("이전 상담사")).toHaveCount(0);
+        await expect(page.getByText("Legacy Workspace")).toHaveCount(0);
+        await expect
+          .poll(() =>
+            page.evaluate(() => ({
+              accessToken: window.localStorage.getItem("accessToken"),
+              refreshToken: window.localStorage.getItem("refreshToken"),
+              user: window.localStorage.getItem("user"),
+            })),
+          )
+          .toEqual({
+            accessToken: expect.any(String),
+            refreshToken: null,
+            user: JSON.stringify({
+              id: 7,
+              email: "agent@example.com",
+              name: "현재 상담사",
+              role: "OPERATOR",
+            }),
+          });
+
+        expect(seen).toContain("POST /auth/refresh");
+        expect(seen).toContain("POST /auth/login");
+        expect(seen).toContain("GET /workspaces");
+        expect(seen).not.toContain("GET /workspaces/99");
+      });
     });
   });
 });

--- a/frontend/src/features/auth/model/resolveDefaultPostLoginDestination.test.ts
+++ b/frontend/src/features/auth/model/resolveDefaultPostLoginDestination.test.ts
@@ -96,6 +96,29 @@ describe("resolveDefaultPostLoginDestination", () => {
     ).resolves.toBe("/workspaces/7/workflows");
   });
 
+  it("이전 계정 domain pack return-to는 현재 계정 기본 workspace로 대체한다", async () => {
+    mockedListWorkspaces.mockResolvedValueOnce(
+      listResponse([{ id: 7, name: "Current", status: "ACTIVE" }]),
+    );
+
+    await expect(
+      resolveAuthenticatedPostLoginDestination({
+        from: { pathname: "/workspaces/99/domain-packs", search: "?versionId=1" },
+      }),
+    ).resolves.toBe("/workspaces/7/workflows");
+  });
+
+  it("workspace 루트 return-to는 현재 계정 workspace 목록 확인 뒤 유지한다", async () => {
+    mockedListWorkspaces.mockResolvedValueOnce(listResponse([]));
+
+    await expect(
+      resolveAuthenticatedPostLoginDestination({
+        from: { pathname: "/workspaces", search: "?tab=logs" },
+      }),
+    ).resolves.toBe("/workspaces?tab=logs");
+    expect(mockedListWorkspaces).toHaveBeenCalledTimes(1);
+  });
+
   it("demo return-to는 workspace 조회 없이 유지한다", async () => {
     await expect(
       resolveAuthenticatedPostLoginDestination({

--- a/frontend/src/features/auth/ui/login-form/LoginForm.test.tsx
+++ b/frontend/src/features/auth/ui/login-form/LoginForm.test.tsx
@@ -89,6 +89,18 @@ describe("LoginForm", () => {
     expect(localStorage.getItem("refreshToken")).toBeNull();
   });
 
+  it("허용된 비-workspace return-to 경로가 있으면 워크스페이스 조회 없이 해당 경로를 우선한다", async () => {
+    renderLoginForm({
+      from: { pathname: "/demo/chat/4", search: "?preview=true" },
+    });
+    await submitLoginForm();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("location")).toHaveTextContent("/demo/chat/4?preview=true");
+    });
+    expect(mockedListWorkspaces).not.toHaveBeenCalled();
+  });
+
   it("현재 계정 workspace return-to 경로가 있으면 해당 경로를 우선한다", async () => {
     mockedListWorkspaces.mockResolvedValueOnce(
       listResponse([{ id: 4, name: "Current", status: "ACTIVE" }]),
@@ -115,6 +127,22 @@ describe("LoginForm", () => {
 
     await waitFor(() => {
       expect(screen.getByTestId("location")).toHaveTextContent("/workspaces");
+    });
+    expect(mockedListWorkspaces).toHaveBeenCalledTimes(1);
+  });
+
+  it("이전 계정 workspace return-to 경로면 현재 계정 기본 workspace로 이동한다", async () => {
+    mockedListWorkspaces.mockResolvedValueOnce(
+      listResponse([{ id: 7, name: "Active", status: "ACTIVE" }]),
+    );
+
+    renderLoginForm({
+      from: { pathname: "/workspaces/99/domain-packs", search: "?versionId=1" },
+    });
+    await submitLoginForm();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("location")).toHaveTextContent("/workspaces/7/workflows");
     });
     expect(mockedListWorkspaces).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
Closes #693

## 변경 사항

- 이슈 693 요구사항과 acceptance criteria를 `.agent/specs/693.md`에 정리했습니다.
- stale workspace URL/history/auth storage가 남은 브라우저에서 현재 계정으로 로그인하는 mocked Playwright E2E를 추가했습니다.
- E2E에서 현재 계정 workspace 화면 진입, workspace marker/heading 일관성, 이전 계정 사용자·workspace 이름 미노출, stale workspace id 미조회, auth session 교체를 화면 중심으로 검증합니다.
- resolver/LoginForm 회귀 테스트에 이전 계정 domain pack return-to가 현재 계정 기본 workspace로 대체되는 경로를 보강했습니다.

## 검증

- `pnpm --dir frontend test -- resolveDefaultPostLoginDestination LoginForm --run`
- `pnpm --dir frontend e2e -- auth-login.spec.ts`
- `pnpm --dir frontend exec eslint e2e/auth-login.spec.ts src/features/auth/model/resolveDefaultPostLoginDestination.test.ts src/features/auth/ui/login-form/LoginForm.test.tsx`
- `git diff --check origin/main...HEAD`

## 참고

- `main`에 먼저 반영된 로그인 후 workspace destination 검증 로직 위에 이슈 693의 계정 전환/화면 노출 회귀 검증을 추가했습니다.