### PR TITLE
fix(frontend): 계정 전환 뒤 workspace 캐시 노출을 방지

### DIFF
--- a/.agent/specs/694.md
+++ b/.agent/specs/694.md
@@ -1,0 +1,144 @@
+# Frontend Spec: 로그인 후 뒤로가기 workspace 캐시 노출 방지
+
+## Goal
+
+같은 브라우저 탭에서 다른 계정으로 다시 로그인한 뒤 브라우저 뒤로가기를 눌러도 이전 계정의 workspace 화면, marker, 본문 데이터가 노출되지 않도록 한다.
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A[이전 계정 workspace 화면 방문] --> B[로그아웃]
+    B --> C[다른 계정으로 로그인]
+    C --> D[현재 계정 기본 workspace 화면 진입]
+    D --> E[브라우저 뒤로가기]
+    E --> F{이전 workspace 접근 가능?}
+    F -->|No| G[권한 없음 상태 표시]
+    F -->|Yes| H[현재 세션 기준으로 새로 조회한 화면 표시]
+    G --> I[이전 계정 workspace 이름과 데이터 미노출]
+    H --> I
+```
+
+## Design Diff
+
+### As-is vs To-be
+
+| 영역 | As-is | To-be | 변경 내용 |
+|------|-------|-------|----------|
+| 세션 전환 | 로그인/로그아웃 시 localStorage 인증 값만 변경한다. | 로그인/로그아웃 같은 인증 세션 변경 시 TanStack Query 캐시도 정리한다. | 이전 계정의 workspace query 결과가 새 계정 화면에서 재사용되지 않는다. |
+| 뒤로가기 | 히스토리에 남은 `/workspaces/{id}/*` 경로가 이전 계정 캐시를 재사용할 수 있다. | 뒤로가기 후 workspace 상세를 현재 계정 기준으로 다시 판정한다. | 403이면 기존 `ErrorState` 기반 권한 없음 상태를 보여준다. |
+| 사용자 표시 | workspace marker와 본문이 이전 계정 데이터를 가리킬 수 있다. | marker와 본문 모두 현재 계정 권한에 맞는 데이터만 표시한다. | workspace marker, dashboard/workflow 본문 간 불일치를 방지한다. |
+
+## Component Tree
+
+```
+AppProviders
+└─ QueryClientProvider
+   └─ auth session change listener
+      └─ queryClient.clear()
+
+LoginForm
+└─ saveAuthSession()
+   └─ auth session change event
+
+AccountMenu / useLogout / PrivateRoute / ApiClient
+└─ clearAuthSession()
+   └─ auth session change event
+
+WorkspaceLayout
+└─ useGetWorkspace(workspaceId)
+   ├─ success: OstoneShell + Outlet
+   └─ 403 WORKSPACE_ACCESS_DENIED: ErrorState("접근 권한이 없습니다.")
+```
+
+## API Integration
+
+### Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/v1/workspaces` | 현재 계정의 workspace 목록 조회 |
+| GET | `/api/v1/workspaces/{workspaceId}` | 현재 계정 기준 workspace 상세 및 접근 권한 확인 |
+| POST | `/api/v1/auth/login` | 새 인증 세션 생성 |
+
+### Generated API
+
+- workspace 조회는 기존 `frontend/src/shared/api/generated/endpoints/workspace-controller/workspace-controller.ts` hook/function을 계속 사용한다.
+- generated 파일은 직접 수정하지 않는다.
+
+## Data Flow
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ Auth session mutation                                    │
+│  - saveAuthSession 또는 clearAuthSession                 │
+└─────────────────────────────────────────────────────────┘
+                           │
+                           ▼
+┌─────────────────────────────────────────────────────────┐
+│ Shared auth event                                        │
+│  - 브라우저 탭 내부에 세션 변경 알림                     │
+└─────────────────────────────────────────────────────────┘
+                           │
+                           ▼
+┌─────────────────────────────────────────────────────────┐
+│ AppProviders                                             │
+│  - TanStack Query 캐시 정리                              │
+└─────────────────────────────────────────────────────────┘
+                           │
+                           ▼
+┌─────────────────────────────────────────────────────────┐
+│ Workspace route                                          │
+│  - 뒤로가기 URL도 현재 계정 기준 API 응답으로 렌더링     │
+└─────────────────────────────────────────────────────────┘
+```
+
+## 수정 대상 파일
+
+| 파일 | 변경 유형 | 설명 |
+|------|----------|------|
+| `frontend/src/shared/lib/auth.ts` | modify | 인증 세션 저장/삭제 시 세션 변경 이벤트를 발생시킨다. |
+| `frontend/src/app/providers.tsx` | modify | 세션 변경 이벤트를 구독해 QueryClient 캐시를 정리한다. |
+| `frontend/src/app/providers.test.tsx` | modify | 세션 변경 이벤트 발생 시 query cache가 정리되는지 검증한다. |
+| `frontend/e2e/navigation.spec.ts` | modify | 교차 계정 로그인 후 뒤로가기 시 이전 workspace 데이터가 노출되지 않는 E2E를 추가한다. |
+
+## State Management
+
+- 인증 값은 기존 localStorage/memory fallback 저장 방식을 유지한다.
+- 서버 상태 캐시는 세션 경계를 넘겨 재사용하지 않는다.
+- 세션 변경 이벤트는 같은 탭의 React tree와 auth 저장 유틸 사이를 연결하는 클라이언트 내부 신호로만 사용한다.
+
+## Tests
+
+### Test Strategy
+
+| 구분 | 방법 | 도구 | 비고 |
+|------|------|------|------|
+| 단위 테스트 | auth 세션 변경 이벤트 후 query cache 정리 검증 | Vitest | cache clearing 회귀 방지 |
+| E2E 테스트 | 이전 계정 workspace 방문 → 로그아웃 → 다른 계정 로그인 → 브라우저 뒤로가기 | Playwright | 사용자 시나리오 검증 |
+
+### Test Scenarios
+
+| # | Given | When | Then |
+|---|-------|------|------|
+| 1 | 이전 계정으로 `/workspaces/1/dashboard`를 방문해 workspace query가 캐시에 남아 있다. | 로그아웃 후 다른 계정으로 로그인하고 브라우저 뒤로가기를 누른다. | `/workspaces/1/dashboard`는 현재 계정 기준으로 403 처리되고 이전 workspace 이름/본문 데이터가 보이지 않는다. |
+| 2 | 새 계정의 workspace 목록에는 `/workspaces/2`만 있다. | 로그인 직후 기본 workspace 화면으로 이동한다. | marker와 URL은 현재 계정 workspace를 기준으로 표시된다. |
+
+## Non-goals
+
+- 서버의 workspace 권한 정책을 변경하지 않는다.
+- 로그인 후 return-to 허용 경로 정책을 변경하지 않는다.
+- workspace 선택 UI나 권한 없음 화면 디자인을 새로 만들지 않는다.
+- 브라우저 전체 storage clearing 정책을 추가하지 않는다.
+
+## Acceptance Criteria
+
+- 로그인 성공 또는 로그아웃으로 인증 세션이 바뀌면 기존 TanStack Query 캐시가 비워진다.
+- 브라우저 history에 이전 계정의 workspace URL이 있어도 뒤로가기 후 이전 계정 workspace 이름이 marker나 breadcrumb에 노출되지 않는다.
+- 권한 없는 workspace 상세 URL은 기존 `WORKSPACE_ACCESS_DENIED` 매핑에 따라 "접근 권한이 없습니다."를 표시한다.
+- 화면의 workspace marker와 본문 데이터가 서로 다른 workspace를 가리키지 않는다.
+- 새 회귀 테스트는 앞으로가기/새로고침과 동일한 정책 판단에 사용할 수 있도록 현재 계정 기준 API 응답만 신뢰한다.
+
+## Open Questions
+
+- 없음. 권한 없는 workspace의 최종 화면은 현재 구현된 `ErrorState` 기반 차단 화면을 유지한다.

--- a/frontend/e2e/navigation.spec.ts
+++ b/frontend/e2e/navigation.spec.ts
@@ -1,7 +1,183 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page, type Route } from "@playwright/test";
 
-import { installAuth } from "./support/generated-api-auth";
+import { installAuth, makeJwt } from "./support/generated-api-auth";
 import { captureScreen, installAdminApiMocks, installAppApiMocks } from "./support/app-mocks";
+
+type AccountScope = "previous" | "current";
+
+const previousWorkspace = {
+  id: 1,
+  workspaceKey: "previous-workspace",
+  name: "Previous Account Workspace",
+  description: "이전 계정 workspace",
+  status: "ACTIVE",
+  myRole: "OWNER",
+  createdAt: "2026-06-01T00:00:00+09:00",
+  updatedAt: "2026-06-04T09:00:00+09:00",
+};
+
+const currentWorkspace = {
+  id: 2,
+  workspaceKey: "current-workspace",
+  name: "Current Account Workspace",
+  description: "현재 계정 workspace",
+  status: "ACTIVE",
+  myRole: "OWNER",
+  createdAt: "2026-06-02T00:00:00+09:00",
+  updatedAt: "2026-06-04T09:00:00+09:00",
+};
+
+async function fulfillJson(route: Route, body: unknown, status = 200) {
+  await route.fulfill({
+    status,
+    contentType: "application/json",
+    body: JSON.stringify(body),
+  });
+}
+
+async function installCrossAccountWorkspaceMocks(page: Page) {
+  let account: AccountScope = "previous";
+  const seen: string[] = [];
+
+  await page.route("**/api/v1/**", async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const path = url.pathname.replace(/^\/api\/v1/, "");
+    const method = request.method();
+    seen.push(`${account} ${method} ${path}${url.search}`);
+
+    if (method === "POST" && path === "/auth/login") {
+      expect(request.postDataJSON()).toEqual({
+        email: "current@example.com",
+        password: "password123",
+      });
+      account = "current";
+      await fulfillJson(route, {
+        data: {
+          accessToken: makeJwt(),
+          refreshToken: "current-refresh-token",
+          tokenType: "Bearer",
+          expiresIn: 3600,
+          user: {
+            id: 22,
+            email: "current@example.com",
+            name: "현재 상담사",
+            role: "OPERATOR",
+          },
+        },
+      });
+      return;
+    }
+
+    if (method === "GET" && path === "/workspaces") {
+      await fulfillJson(route, account === "previous" ? [previousWorkspace] : [currentWorkspace]);
+      return;
+    }
+
+    if (method === "GET" && path === "/workspaces/1") {
+      if (account === "previous") {
+        await fulfillJson(route, previousWorkspace);
+        return;
+      }
+      await fulfillJson(
+        route,
+        { code: "WORKSPACE_ACCESS_DENIED", message: "접근 권한이 없습니다." },
+        403,
+      );
+      return;
+    }
+
+    if (method === "GET" && path === "/workspaces/2") {
+      await fulfillJson(route, currentWorkspace);
+      return;
+    }
+
+    if (method === "GET" && path === "/workspaces/2/domain-packs") {
+      await fulfillJson(route, { data: [], status: 200 });
+      return;
+    }
+
+    if (method === "GET" && path === "/workspaces/1/consultation/metrics") {
+      await fulfillJson(route, {
+        workspaceId: 1,
+        periodStart: "2026-05-29T00:00:00+09:00",
+        periodEnd: "2026-06-04T09:00:00+09:00",
+        totalConsultationCount: 7,
+        completedConsultationCount: 6,
+        averageFirstResponseSeconds: 42,
+        averageLlmFirstResponseSeconds: 3,
+        averageHumanFirstResponseSeconds: 120,
+        llmHandledCount: 5,
+        humanInterventionCount: 1,
+        unresolvedSessionCount: 0,
+        comparison: null,
+        coverage: {
+          workflowMatchedCount: 6,
+          workflowMatchRate: 0.85,
+          intentClassificationSuccessCount: 6,
+          intentClassificationSuccessRate: 0.85,
+          lowConfidenceCount: 0,
+          lowConfidenceRate: 0,
+          unmatchedSessionCount: 1,
+          autoCompletedWorkflowCount: 5,
+          humanHandoffRate: 0.14,
+          llmOnlyProcessingRate: 0.71,
+          measurementStatus: "READY",
+          measurementMessage: "측정 가능",
+          trend: [],
+        },
+        handledTodayCount: 2,
+        llmHandledTodayCount: 2,
+        humanHandledTodayCount: 0,
+      });
+      return;
+    }
+
+    if (method === "GET" && path === "/workspaces/1/dashboard/workflow-rankings") {
+      await fulfillJson(route, {
+        workspaceId: 1,
+        periodStart: "2026-05-29T00:00:00+09:00",
+        periodEnd: "2026-06-04T09:00:00+09:00",
+        totalConsultationCount: 7,
+        rankings: [],
+        topRankings: [],
+      });
+      return;
+    }
+
+    if (method === "GET" && path === "/workspaces/1/dashboard/knowledge-pack-health") {
+      await fulfillJson(route, {
+        activeKnowledgePack: {
+          packId: 1,
+          packName: "Previous Account Pack",
+          versionId: 1,
+          versionNo: 1,
+          publishedAt: "2026-06-01T00:00:00+09:00",
+          createdAt: "2026-06-01T00:00:00+09:00",
+          sourcePipelineJobId: null,
+        },
+        lastLogUpload: null,
+        lastKnowledgePackGeneration: null,
+        pendingReviewCount: 0,
+      });
+      return;
+    }
+
+    if (method === "GET" && path === "/workspaces/1/dashboard/action-recommendations") {
+      await fulfillJson(route, {
+        workspaceId: 1,
+        periodStart: "2026-05-29T00:00:00+09:00",
+        periodEnd: "2026-06-04T09:00:00+09:00",
+        recommendations: [],
+      });
+      return;
+    }
+
+    await fulfillJson(route, { code: "E2E_UNMOCKED", message: `${method} ${path}` }, 500);
+  });
+
+  return seen;
+}
 
 test.describe("Application navigation boundaries", () => {
   test.describe("Given no authenticated session", () => {
@@ -57,6 +233,59 @@ test.describe("Application navigation boundaries", () => {
         )
         .toEqual({ accessToken: null, refreshToken: null, user: null });
       expect(seen).toEqual(["POST /auth/refresh"]);
+    });
+  });
+
+  test.describe("Given browser history includes another account's workspace URL", () => {
+    test("When a different account logs in and navigates back, Then previous workspace data is not exposed", async ({
+      page,
+    }) => {
+      const seen = await installCrossAccountWorkspaceMocks(page);
+      await installAuth(page, {
+        name: "이전 상담사",
+        email: "previous@example.com",
+      });
+
+      await page.goto("/workspaces/1/dashboard");
+      await expect(page.getByTestId("workspace-marker")).toContainText(
+        "Previous Account Workspace",
+      );
+      await expect(page.getByText("Previous Account Pack")).toBeVisible();
+
+      await page.getByTestId("account-menu-trigger").click();
+      await page.getByTestId("account-menu-logout").click();
+      await expect(page).toHaveURL(/\/login$/);
+
+      await page.getByLabel("이메일 주소").fill("current@example.com");
+      await page.getByLabel("비밀번호").fill("password123");
+      await page.getByRole("button", { name: "시스템 로그인" }).click();
+
+      await expect(page).toHaveURL(/\/workspaces\/2\/workflows$/);
+      await expect(page.getByTestId("workspace-marker")).toContainText(
+        "Current Account Workspace",
+      );
+
+      await page.goBack();
+      await expect(page).toHaveURL(/\/workspaces\/1\/dashboard$/);
+      await expect(page.getByText("접근 권한이 없습니다.")).toBeVisible();
+      await expect(page.getByText("Previous Account Workspace")).toHaveCount(0);
+      await expect(page.getByText("Previous Account Pack")).toHaveCount(0);
+      await expect(page.getByText("총 상담")).toHaveCount(0);
+      expect(seen).toContain("current GET /workspaces/1");
+
+      await page.goForward();
+      await expect(page).toHaveURL(/\/workspaces\/2\/workflows$/);
+      await expect(page.getByTestId("workspace-marker")).toContainText(
+        "Current Account Workspace",
+      );
+
+      await page.goBack();
+      await expect(page.getByText("접근 권한이 없습니다.")).toBeVisible();
+      await page.reload();
+      await expect(page).toHaveURL(/\/workspaces\/1\/dashboard$/);
+      await expect(page.getByText("접근 권한이 없습니다.")).toBeVisible();
+      await expect(page.getByText("Previous Account Workspace")).toHaveCount(0);
+      await expect(page.getByText("Previous Account Pack")).toHaveCount(0);
     });
   });
 

--- a/frontend/src/app/providers.test.tsx
+++ b/frontend/src/app/providers.test.tsx
@@ -1,5 +1,17 @@
-import { describe, expect, it } from "vitest";
-import { queryClientConfig } from "./queryClient";
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AUTH_SESSION_CHANGED_EVENT } from "@/shared/lib/auth";
+import { AppProviders } from "./providers";
+import { queryClient, queryClientConfig } from "./queryClient";
+
+beforeEach(() => {
+  queryClient.clear();
+});
+
+afterEach(() => {
+  cleanup();
+  queryClient.clear();
+});
 
 describe("queryClientConfig", () => {
   it("도메인 팩 변경이 명시적 새로고침 없이 반영되도록 자동 refetch를 활성화한다", () => {
@@ -17,5 +29,18 @@ describe("queryClientConfig", () => {
     expect(queries?.staleTime).toBe(60 * 1000);
     expect(queries?.retry).toBe(0);
     expect(mutations?.retry).toBe(0);
+  });
+
+  it("인증 세션이 바뀌면 이전 계정의 query cache를 정리한다", () => {
+    render(
+      <AppProviders>
+        <div>app</div>
+      </AppProviders>,
+    );
+    queryClient.setQueryData(["workspaces", 1], { id: 1, name: "Previous Workspace" });
+
+    window.dispatchEvent(new Event(AUTH_SESSION_CHANGED_EVENT));
+
+    expect(queryClient.getQueryData(["workspaces", 1])).toBeUndefined();
   });
 });

--- a/frontend/src/app/providers.tsx
+++ b/frontend/src/app/providers.tsx
@@ -1,7 +1,19 @@
-import type { ReactNode } from "react";
+import { useEffect, type ReactNode } from "react";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { queryClient } from "./queryClient";
+import { AUTH_SESSION_CHANGED_EVENT } from "@/shared/lib/auth";
 
 export function AppProviders({ children }: { children: ReactNode }) {
+  useEffect(() => {
+    const clearSessionScopedCache = () => {
+      queryClient.clear();
+    };
+
+    window.addEventListener(AUTH_SESSION_CHANGED_EVENT, clearSessionScopedCache);
+    return () => {
+      window.removeEventListener(AUTH_SESSION_CHANGED_EVENT, clearSessionScopedCache);
+    };
+  }, []);
+
   return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
 }

--- a/frontend/src/shared/lib/auth.ts
+++ b/frontend/src/shared/lib/auth.ts
@@ -2,6 +2,7 @@ const ACCESS_TOKEN_KEY = "accessToken";
 const LEGACY_REFRESH_TOKEN_KEY = "refreshToken";
 const USER_KEY = "user";
 export const SUPER_ADMIN_ROLE = "SUPER_ADMIN";
+export const AUTH_SESSION_CHANGED_EVENT = "ostone:auth-session-changed";
 
 const memoryStorage = new Map<string, string>();
 
@@ -39,6 +40,14 @@ function removeAuthValue(key: string): void {
   memoryStorage.delete(key);
 }
 
+function notifyAuthSessionChanged(): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  window.dispatchEvent(new Event(AUTH_SESSION_CHANGED_EVENT));
+}
+
 export interface AuthUser {
   id: number;
   email: string;
@@ -56,6 +65,7 @@ export function saveAuthSession(tokens: AuthTokens, user: AuthUser): void {
   setAuthValue(ACCESS_TOKEN_KEY, tokens.accessToken);
   removeAuthValue(LEGACY_REFRESH_TOKEN_KEY);
   setAuthValue(USER_KEY, JSON.stringify(user));
+  notifyAuthSessionChanged();
 }
 
 export function saveAuthTokens(tokens: AuthTokens): void {
@@ -67,6 +77,7 @@ export function clearAuthSession(): void {
   removeAuthValue(ACCESS_TOKEN_KEY);
   removeAuthValue(LEGACY_REFRESH_TOKEN_KEY);
   removeAuthValue(USER_KEY);
+  notifyAuthSessionChanged();
 }
 
 export function getAccessToken(): string | null {


### PR DESCRIPTION
Closes #694

## 변경 사항

- 로그인/로그아웃으로 인증 세션이 바뀔 때 TanStack Query 캐시를 정리해 이전 계정 workspace query 결과가 새 세션에서 재사용되지 않도록 했습니다.
- auth 저장 유틸은 세션 변경 이벤트만 발생시키고, AppProviders가 해당 이벤트를 구독해 앱 계층에서 QueryClient cache를 비우도록 연결했습니다.
- 브라우저 history에 이전 계정 workspace URL이 남아 있는 상태에서 다른 계정 로그인 후 뒤로가기/앞으로가기/새로고침을 수행해도 이전 workspace marker와 본문 데이터가 노출되지 않는 mocked Playwright E2E를 추가했습니다.
- 이슈 694 스펙을 `.agent/specs/694.md`에 정리했습니다.

## 검증

- `pnpm --dir frontend exec eslint src/shared/lib/auth.ts src/app/providers.tsx src/app/providers.test.tsx e2e/navigation.spec.ts`
- `pnpm --dir frontend exec vp test src/app/providers.test.tsx src/shared/lib/auth.test.ts`
- `pnpm --dir frontend exec playwright test e2e/navigation.spec.ts --grep "different account"`
- `pnpm run ci:frontend`
- `pnpm run e2e:frontend`
- `git diff --check`
- rebase 후 `pnpm --dir frontend exec eslint e2e/navigation.spec.ts src/shared/lib/auth.ts src/app/providers.tsx src/app/providers.test.tsx`
- rebase 후 `pnpm --dir frontend exec vp test src/app/providers.test.tsx src/shared/lib/auth.test.ts`

## 참고

- pre-commit의 repository-wide `pnpm run lint:frontend`는 이번 변경과 무관한 기존 frontend ESLint baseline 47건으로 실패했습니다. 변경 파일 대상 ESLint, API/FSD audits, frontend CI, mocked E2E는 통과했습니다.