### PR TITLE
feat(frontend): 도메인팩 없는 워크스페이스의 업로드 진입을 보장

### DIFF
--- a/.agent/specs/691.md
+++ b/.agent/specs/691.md
@@ -1,0 +1,107 @@
+# Frontend E2E Spec: Domain Pack 없는 워크스페이스 업로드 시작
+
+## Goal
+
+운영자가 기존 계정으로 로그인했을 때 Domain Pack이 없는 기본 워크스페이스에 진입하고, 이전 계정의 데이터 없이 상담 로그 업로드를 시작할 수 있음을 E2E로 보장한다.
+
+## Issue Summary
+
+GitHub Issue #691은 운영자가 하나 이상의 워크스페이스에 속해 있고 기본 워크스페이스에 운영 중인 Domain Pack이 없을 때, 로그인 직후 접근 가능한 워크스페이스 컨텍스트와 업로드 시작 행동이 명확해야 한다는 Critical E2E 시나리오를 다룬다.
+
+현재 코드 기준 기본 로그인 목적지는 `frontend/src/features/auth/model/resolveDefaultPostLoginDestination.test.ts`에서 확인되는 `/workspaces/{id}/workflows`다. 따라서 이 작업은 초기 진입 정책을 업로드 화면으로 바꾸지 않고, 로그인 후 워크플로우 빈 상태에서 업로드로 이어지는 CTA와 E2E 검증을 추가한다.
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A["Login screen"] --> B["Submit valid operator credentials"]
+    B --> C["Default active workspace resolved"]
+    C --> D["Workspace workflows route"]
+    D --> E{"Any Domain Pack workflow?"}
+    E -->|"No"| F["No-workflow empty state"]
+    F --> G["Upload CTA visible"]
+    G --> H["Workspace upload screen"]
+    H --> I["Refresh preserves same workspace context"]
+```
+
+## Design Diff
+
+| 영역                | As-is                                                               | To-be                                                                                                 | 변경 내용                                                    |
+| ------------------- | ------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| Login E2E           | 로그인 성공 후 워크스페이스 워크플로우 진입만 확인                  | Domain Pack 없는 워크스페이스의 빈 상태, 업로드 CTA, 새로고침 컨텍스트 유지까지 확인                  | Critical 사용자 시나리오를 독립 mocked E2E로 고정            |
+| 워크플로우 빈 상태  | 도메인팩 관리 이동 CTA만 제공                                       | 상담 로그 업로드 CTA를 함께 제공                                                                      | Domain Pack이 없는 신규 워크스페이스의 다음 행동을 명확히 함 |
+| Workspace isolation | 기존 로그인 E2E에서 이전 workspace 데이터 부재를 직접 검증하지 않음 | 테스트 fixture에 이전 계정처럼 보이는 workspace/domain pack 데이터를 넣고 화면에 노출되지 않음을 검증 | 테스트 간 상태 공유와 이전 계정 데이터 회귀를 방지           |
+
+## Component Tree
+
+```text
+frontend/e2e/auth-login.spec.ts
+└─ Login screen E2E scenario
+
+frontend/src/pages/workspace/ui/WorkspaceWorkflowsPage.tsx
+└─ Empty workflow state
+   ├─ EmptyState
+   ├─ 상담 로그 업로드 CTA
+   └─ 도메인팩 관리 CTA
+
+frontend/src/pages/upload/ui/WorkspaceUploadPage.tsx
+└─ LogUploadForm
+```
+
+## API Integration
+
+테스트는 Playwright route mock을 사용한다.
+
+| Method | Path                                            | 목적                                            |
+| ------ | ----------------------------------------------- | ----------------------------------------------- |
+| `POST` | `/api/v1/auth/login`                            | 기존 운영자 로그인 성공                         |
+| `GET`  | `/api/v1/workspaces`                            | 접근 가능한 기본 workspace 목록 조회            |
+| `GET`  | `/api/v1/workspaces/{workspaceId}`              | shell/topbar workspace 이름 조회                |
+| `GET`  | `/api/v1/workspaces/{workspaceId}/domain-packs` | 기본 workspace가 Domain Pack 없는 상태임을 응답 |
+| `GET`  | `/api/v1/workspaces/{workspaceId}/subscription` | 업로드 화면 entitlement 조회                    |
+
+## 수정 대상 파일
+
+| 파일                                                                  | 변경 유형 | 설명                                                                  |
+| --------------------------------------------------------------------- | --------- | --------------------------------------------------------------------- |
+| `.agent/specs/691.md`                                                 | new       | Issue #691 요구사항과 검증 기준 기록                                  |
+| `frontend/src/pages/workspace/ui/WorkspaceWorkflowsPage.tsx`          | modify    | Domain Pack 없는 워크플로우 빈 상태에서 상담 로그 업로드 CTA 제공     |
+| `frontend/src/pages/workspace/ui/workspace-workflows-page.module.css` | modify    | 빈 상태 CTA 그룹 레이아웃 조정                                        |
+| `frontend/src/pages/workspace/ui/WorkspaceWorkflowsPage.test.tsx`     | modify    | 빈 상태 CTA 목적지 검증                                               |
+| `frontend/e2e/auth-login.spec.ts`                                     | modify    | 로그인부터 업로드 화면 및 refresh 컨텍스트 유지까지 Critical E2E 추가 |
+
+## State Management
+
+- 서버 상태는 기존 TanStack Query 흐름을 유지한다.
+- 로그인 세션은 기존 `localStorage` 저장 정책을 그대로 사용한다.
+- E2E는 각 테스트 안에서 API mock과 browser storage를 격리하여 다른 테스트 상태에 의존하지 않는다.
+- 새로고침 후에도 같은 workspace URL과 workspace marker가 유지되는지 화면 기준으로 검증한다.
+
+## Acceptance Criteria
+
+- 운영자가 로그인하면 기본 active workspace의 `/workspaces/{id}/workflows`로 진입한다.
+- Domain Pack이 없는 기본 workspace에서는 workspace 이름이 shell에 표시된다.
+- 이전 계정 또는 다른 workspace처럼 보이는 이름과 Domain Pack 데이터가 화면에 표시되지 않는다.
+- 워크플로우 빈 상태에서 상담 로그 업로드 CTA가 보이고 `/workspaces/{id}/upload`로 이동한다.
+- 업로드 화면에서 `상담 로그 업로드` 제목과 업로드 UI가 보인다.
+- 업로드 화면을 새로고침해도 같은 workspace context가 유지된다.
+- E2E는 mocked API만 사용하며 단독 실행해도 필요한 auth/workspace/domain-pack/subscription 상태를 자체 구성한다.
+
+## Non-goals
+
+- 로그인 후 기본 목적지를 업로드 화면으로 변경하지 않는다.
+- backend API contract, OpenAPI generated file, database schema는 변경하지 않는다.
+- 실제 파일 업로드 성공 플로우는 기존 업로드 E2E와 단위 테스트 범위로 두고, 이 시나리오에서는 업로드 시작 가능성까지만 검증한다.
+- live E2E나 운영 백엔드 데이터 의존 테스트를 추가하지 않는다.
+
+## Validation
+
+| 검증                                                                                                                                                              | 목적                                                      |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
+| `pnpm --dir frontend test -- src/pages/workspace/ui/WorkspaceWorkflowsPage.test.tsx --run`                                                                        | 빈 상태 CTA 단위 검증                                     |
+| `pnpm --dir frontend e2e -- auth-login.spec.ts`                                                                                                                   | 로그인 후 no-pack workspace 업로드 시작 Critical E2E 검증 |
+| `pnpm --dir frontend exec eslint e2e/auth-login.spec.ts src/pages/workspace/ui/WorkspaceWorkflowsPage.tsx src/pages/workspace/ui/WorkspaceWorkflowsPage.test.tsx` | 변경된 TypeScript 파일 ESLint 확인                        |
+
+## Open Questions
+
+- 없음.

--- a/frontend/e2e/auth-login.spec.ts
+++ b/frontend/e2e/auth-login.spec.ts
@@ -48,7 +48,7 @@ const workflow = {
   name: "환불 처리",
   description: "주문번호를 확인하고 환불 정책에 따라 안내하는 workflow",
   initialState: "start",
-  terminalStatesJson: "[\"done\"]",
+  terminalStatesJson: '["done"]',
   graphJson: null,
   evidenceJson: "{}",
   metaJson: "{}",
@@ -133,14 +133,20 @@ async function installLoginApiMocks(
     }
 
     seen.push(`UNMOCKED ${method} ${path}`);
-    await fulfillJson(route, { code: "E2E_UNMOCKED", message: `${method} ${path}` }, 500);
+    await fulfillJson(
+      route,
+      { code: "E2E_UNMOCKED", message: `${method} ${path}` },
+      500,
+    );
   });
 }
 
 test.describe("Login screen", () => {
   test.describe("Given a valid operator account", () => {
     test.describe("When the operator submits the login form", () => {
-      test("Then the app stores the auth session and enters the workspace", async ({ page }) => {
+      test("Then the app stores the auth session and enters the workspace", async ({
+        page,
+      }) => {
         const seen: string[] = [];
 
         await installLoginApiMocks(page, seen, "empty");
@@ -151,12 +157,18 @@ test.describe("Login screen", () => {
         await page.getByRole("button", { name: "시스템 로그인" }).click();
 
         await expect(page).toHaveURL(/\/workspaces\/1\/workflows/);
-        await expect(page.getByRole("heading", { name: "워크플로우", level: 1 })).toBeVisible();
+        await expect(
+          page.getByRole("heading", { name: "워크플로우", level: 1 }),
+        ).toBeVisible();
         await expect
-          .poll(() => page.evaluate(() => window.localStorage.getItem("accessToken")))
+          .poll(() =>
+            page.evaluate(() => window.localStorage.getItem("accessToken")),
+          )
           .toBeTruthy();
         expect(seen).toContain("POST /auth/login");
-        expect(seen.filter((entry) => entry.startsWith("UNMOCKED "))).toEqual([]);
+        expect(seen.filter((entry) => entry.startsWith("UNMOCKED "))).toEqual(
+          [],
+        );
       });
 
       test("Then an operator with an active domain pack lands on current workspace operations", async ({
@@ -185,26 +197,38 @@ test.describe("Login screen", () => {
         await page.getByRole("button", { name: "시스템 로그인" }).click();
 
         await expect(page).toHaveURL(/\/workspaces\/1\/workflows$/);
-        await expect(page.getByTestId("workspace-marker")).toContainText("QA Workspace");
-        await expect(page.getByRole("heading", { name: "워크플로우", level: 1 })).toBeVisible();
+        await expect(page.getByTestId("workspace-marker")).toContainText(
+          "QA Workspace",
+        );
+        await expect(
+          page.getByRole("heading", { name: "워크플로우", level: 1 }),
+        ).toBeVisible();
         await expect(page.getByTestId("workspace-workflows")).toBeVisible();
-        await expect(page.getByTestId("workspace-workflows-card-401")).toContainText(
-          "Generated API Pack",
-        );
-        await expect(page.getByTestId("workspace-workflows-card-401")).toContainText("환불 처리");
-        await expect(page.getByTestId("sidebar-link-dashboard")).toHaveAttribute(
-          "href",
-          "/workspaces/1/dashboard",
-        );
+        await expect(
+          page.getByTestId("workspace-workflows-card-401"),
+        ).toContainText("Generated API Pack");
+        await expect(
+          page.getByTestId("workspace-workflows-card-401"),
+        ).toContainText("환불 처리");
+        await expect(
+          page.getByTestId("sidebar-link-dashboard"),
+        ).toHaveAttribute("href", "/workspaces/1/dashboard");
         await expect(page.getByTestId("sidebar-domain-link")).toHaveAttribute(
           "href",
           "/workspaces/1/domain-packs",
         );
-        await expect(page.getByTestId("workspace-workflows-card-401-open")).toBeEnabled();
-        await expect(page.getByRole("heading", { name: "상담 로그 업로드" })).not.toBeVisible();
+        await expect(
+          page.getByTestId("workspace-workflows-card-401-open"),
+        ).toBeEnabled();
+        await expect(
+          page.getByRole("heading", { name: "상담 로그 업로드" }),
+        ).not.toBeVisible();
         await expect
           .poll(() =>
-            page.evaluate(() => JSON.parse(window.localStorage.getItem("user") ?? "{}").name),
+            page.evaluate(
+              () =>
+                JSON.parse(window.localStorage.getItem("user") ?? "{}").name,
+            ),
           )
           .toBe("상담사");
         await expect(page.getByText("이전 운영자")).toHaveCount(0);
@@ -214,8 +238,204 @@ test.describe("Login screen", () => {
         expect(seen).toContain("GET /workspaces");
         expect(seen).toContain("GET /workspaces/1/domain-packs");
         expect(seen).toContain("GET /workspaces/1/domain-packs/1");
-        expect(seen).toContain("GET /workspaces/1/domain-packs/1/versions/1/workflows");
-        expect(seen.filter((entry) => entry.startsWith("UNMOCKED "))).toEqual([]);
+        expect(seen).toContain(
+          "GET /workspaces/1/domain-packs/1/versions/1/workflows",
+        );
+        expect(seen.filter((entry) => entry.startsWith("UNMOCKED "))).toEqual(
+          [],
+        );
+      });
+
+      test("Then a workspace without domain packs exposes log upload and keeps context after refresh", async ({
+        page,
+      }) => {
+        const seen: string[] = [];
+        const workspace = {
+          id: 42,
+          workspaceKey: "empty-cs-workspace",
+          name: "신규 상담팀",
+          status: "ACTIVE",
+          myRole: "OWNER",
+          freeOnboardingStatus: "AVAILABLE",
+        };
+        const legacyWorkspace = {
+          id: 99,
+          workspaceKey: "legacy-workspace",
+          name: "이전 계정 워크스페이스",
+          status: "ARCHIVED",
+          myRole: "OWNER",
+          freeOnboardingStatus: "UNAVAILABLE",
+        };
+
+        await page.addInitScript(() => {
+          if (
+            window.sessionStorage.getItem("e2e-legacy-auth-seeded") === "true"
+          ) {
+            return;
+          }
+          window.sessionStorage.setItem("e2e-legacy-auth-seeded", "true");
+          window.localStorage.setItem("accessToken", "legacy-access-token");
+          window.localStorage.setItem("refreshToken", "legacy-refresh-token");
+          window.localStorage.setItem(
+            "user",
+            JSON.stringify({
+              id: 99,
+              email: "previous@example.com",
+              name: "이전 계정",
+              role: "OPERATOR",
+            }),
+          );
+        });
+
+        await page.route("**/api/v1/**", async (route) => {
+          const request = route.request();
+          const url = new URL(request.url());
+          const path = url.pathname.replace(/^\/api\/v1/, "");
+          const method = request.method();
+          seen.push(`${method} ${path}`);
+
+          if (method === "POST" && path === "/auth/login") {
+            expect(request.postDataJSON()).toEqual({
+              email: "operator@example.com",
+              password: "password123",
+            });
+            await fulfillJson(route, {
+              data: {
+                accessToken: makeJwt(),
+                refreshToken: "current-refresh-token",
+                tokenType: "Bearer",
+                expiresIn: 3600,
+                user: {
+                  id: 7,
+                  email: "operator@example.com",
+                  name: "신규 상담사",
+                  role: "OPERATOR",
+                },
+              },
+            });
+            return;
+          }
+
+          if (method === "GET" && path === "/workspaces") {
+            await fulfillJson(route, [workspace, legacyWorkspace]);
+            return;
+          }
+
+          if (method === "GET" && path === "/workspaces/42") {
+            await fulfillJson(route, workspace);
+            return;
+          }
+
+          if (method === "GET" && path === "/workspaces/42/domain-packs") {
+            await fulfillJson(route, { data: [] });
+            return;
+          }
+
+          if (method === "GET" && path === "/workspaces/99/domain-packs") {
+            await fulfillJson(route, {
+              data: [
+                {
+                  packId: 990,
+                  workspaceId: 99,
+                  name: "Legacy Domain Pack",
+                  currentVersionId: 9901,
+                  currentVersionNo: 1,
+                  status: "PUBLISHED",
+                },
+              ],
+            });
+            return;
+          }
+
+          if (method === "GET" && path === "/workspaces/42/subscription") {
+            await fulfillJson(
+              route,
+              {
+                code: "SUBSCRIPTION_NOT_FOUND",
+                message: "subscription not found",
+              },
+              404,
+            );
+            return;
+          }
+
+          seen.push(`UNMOCKED ${method} ${path}`);
+          await fulfillJson(
+            route,
+            {
+              code: "E2E_UNMOCKED",
+              message: `${method} ${path}`,
+            },
+            500,
+          );
+        });
+
+        await page.goto("/login");
+        await page.getByLabel("이메일 주소").fill("operator@example.com");
+        await page.getByLabel("비밀번호").fill("password123");
+        await page.getByRole("button", { name: "시스템 로그인" }).click();
+
+        await expect(page).toHaveURL(/\/workspaces\/42\/workflows$/);
+        await expect(page.getByTestId("workspace-marker")).toContainText(
+          "신규 상담팀",
+        );
+        await expect(
+          page.getByTestId("workspace-workflows-empty"),
+        ).toBeVisible();
+        await expect(page.getByText("이전 계정", { exact: true })).toBeHidden();
+        await expect(
+          page.getByText("이전 계정 워크스페이스", { exact: true }),
+        ).toBeHidden();
+        await expect(page.getByText("Legacy Domain Pack")).toBeHidden();
+
+        await page.getByRole("button", { name: "상담 로그 업로드" }).click();
+
+        await expect(page).toHaveURL(/\/workspaces\/42\/upload$/);
+        await expect(page.getByTestId("workspace-marker")).toContainText(
+          "신규 상담팀",
+        );
+        await expect(
+          page.getByRole("heading", { name: "상담 로그 업로드" }),
+        ).toBeVisible();
+        await expect(
+          page.getByText("파일을 클릭하거나 끌어다 놓으세요"),
+        ).toBeVisible();
+
+        await page.reload();
+
+        await expect(page).toHaveURL(/\/workspaces\/42\/upload$/);
+        await expect(page.getByTestId("workspace-marker")).toContainText(
+          "신규 상담팀",
+        );
+        await expect(
+          page.getByRole("heading", { name: "상담 로그 업로드" }),
+        ).toBeVisible();
+        await expect
+          .poll(() =>
+            page.evaluate(() => {
+              const user = JSON.parse(
+                window.localStorage.getItem("user") ?? "{}",
+              ) as {
+                name?: string;
+              };
+              return {
+                accessToken: window.localStorage.getItem("accessToken"),
+                refreshToken: window.localStorage.getItem("refreshToken"),
+                userName: user.name,
+              };
+            }),
+          )
+          .toEqual({
+            accessToken: expect.any(String),
+            refreshToken: null,
+            userName: "신규 상담사",
+          });
+        expect(seen).toContain("POST /auth/login");
+        expect(seen).toContain("GET /workspaces/42/domain-packs");
+        expect(seen).not.toContain("GET /workspaces/99/domain-packs");
+        expect(seen.filter((entry) => entry.startsWith("UNMOCKED "))).toEqual(
+          [],
+        );
       });
     });
   });

--- a/frontend/src/pages/workspace/ui/WorkspaceWorkflowsPage.test.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceWorkflowsPage.test.tsx
@@ -6,7 +6,10 @@ import { WorkspaceWorkflowsPage } from "./WorkspaceWorkflowsPage";
 
 const mockNavigate = vi.fn();
 vi.mock("react-router-dom", async () => {
-  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  const actual =
+    await vi.importActual<typeof import("react-router-dom")>(
+      "react-router-dom",
+    );
   return {
     ...actual,
     useNavigate: () => mockNavigate,
@@ -22,7 +25,12 @@ vi.mock("@/features/workflow-list", () => ({
   WorkflowListView: vi.fn(({ entries, onOpen }) => (
     <div data-testid="workflow-list-view">
       {entries.map(
-        (entry: { workflowId: number; name: string; packId: number; versionId: number }) => (
+        (entry: {
+          workflowId: number;
+          name: string;
+          packId: number;
+          versionId: number;
+        }) => (
           <button
             key={entry.workflowId}
             type="button"
@@ -41,8 +49,14 @@ function renderPage(path = "/workspaces/1/workflows") {
   render(
     <MemoryRouter initialEntries={[path]}>
       <Routes>
-        <Route path="/workspaces/:workspaceId/workflows" element={<WorkspaceWorkflowsPage />} />
-        <Route path="/workspaces" element={<div data-testid="workspace-root" />} />
+        <Route
+          path="/workspaces/:workspaceId/workflows"
+          element={<WorkspaceWorkflowsPage />}
+        />
+        <Route
+          path="/workspaces"
+          element={<div data-testid="workspace-root" />}
+        />
       </Routes>
     </MemoryRouter>,
   );
@@ -63,11 +77,17 @@ describe("WorkspaceWorkflowsPage", () => {
   it("loading 상태에서는 loading panel을 보여준다", () => {
     mockHook.mockReturnValue({ loading: true, error: null, entries: [] });
     renderPage();
-    expect(screen.getByTestId("workspace-workflows-loading")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("workspace-workflows-loading"),
+    ).toBeInTheDocument();
   });
 
   it("error 상태에서는 ErrorState를 보여준다", () => {
-    mockHook.mockReturnValue({ loading: false, error: "워크플로우 목록 조회 실패", entries: [] });
+    mockHook.mockReturnValue({
+      loading: false,
+      error: "워크플로우 목록 조회 실패",
+      entries: [],
+    });
     renderPage();
     expect(screen.getByTestId("workspace-workflows-error")).toBeInTheDocument();
     expect(screen.getByText("워크플로우 목록 조회 실패")).toBeInTheDocument();
@@ -102,7 +122,9 @@ describe("WorkspaceWorkflowsPage", () => {
     });
     renderPage();
     expect(screen.getByTestId("workflow-list-view")).toBeInTheDocument();
-    expect(screen.getByTestId("workspace-workflows-card-100")).toHaveTextContent("환불 처리");
+    expect(
+      screen.getByTestId("workspace-workflows-card-100"),
+    ).toHaveTextContent("환불 처리");
   });
 
   it("카드에서 열기(onOpen) 시 실제 packId/versionId/workflowId 경로로 navigate한다", () => {
@@ -135,7 +157,14 @@ describe("WorkspaceWorkflowsPage", () => {
     expect(mockNavigate).toHaveBeenCalledWith("/workspaces/1/domain-packs");
   });
 
-  it("empty state CTA 클릭 시 도메인팩 목록으로 이동한다", () => {
+  it("empty state 업로드 CTA 클릭 시 업로드 화면으로 이동한다", () => {
+    mockHook.mockReturnValue({ loading: false, error: null, entries: [] });
+    renderPage();
+    fireEvent.click(screen.getByText("상담 로그 업로드"));
+    expect(mockNavigate).toHaveBeenCalledWith("/workspaces/1/upload");
+  });
+
+  it("empty state 도메인팩 CTA 클릭 시 도메인팩 목록으로 이동한다", () => {
     mockHook.mockReturnValue({ loading: false, error: null, entries: [] });
     renderPage();
     fireEvent.click(screen.getByText("도메인팩으로 이동"));

--- a/frontend/src/pages/workspace/ui/WorkspaceWorkflowsPage.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceWorkflowsPage.tsx
@@ -1,8 +1,12 @@
-import { ArrowRightIcon } from "lucide-react";
+import { ArrowRightIcon, FileUpIcon } from "lucide-react";
 import { Navigate, useNavigate, useParams } from "react-router-dom";
 
 import { useListAllWorkspaceWorkflows } from "@/entities/workflow";
-import { domainPackListPath, domainPackSectionPath } from "@/shared/lib/domainPackRoutes";
+import {
+  domainPackListPath,
+  domainPackSectionPath,
+} from "@/shared/lib/domainPackRoutes";
+import { CTA_UPLOAD_LOGS } from "@/shared/lib/ctaLabels";
 import { parseRouteId } from "@/shared/lib/parseRouteId";
 import { Button } from "@/shared/ui/button";
 import { LoadingSpinner } from "@/shared/ui/ostone/atoms/LoadingSpinner";
@@ -25,7 +29,11 @@ export function WorkspaceWorkflowsPage() {
     return <Navigate to="/workspaces" replace />;
   }
 
-  const handleOpen = (entry: { packId: number; versionId: number; workflowId: number }) => {
+  const handleOpen = (entry: {
+    packId: number;
+    versionId: number;
+    workflowId: number;
+  }) => {
     navigate(
       domainPackSectionPath(
         parsedWorkspaceId,
@@ -41,6 +49,10 @@ export function WorkspaceWorkflowsPage() {
     navigate(domainPackListPath(parsedWorkspaceId));
   };
 
+  const handleOpenUpload = () => {
+    navigate(`/workspaces/${parsedWorkspaceId}/upload`);
+  };
+
   return (
     <div className={styles.pageWrapper}>
       <div className={styles.pageHeader}>
@@ -52,9 +64,14 @@ export function WorkspaceWorkflowsPage() {
       </div>
 
       {loading && (
-        <div className={styles.statePanel} data-testid="workspace-workflows-loading">
+        <div
+          className={styles.statePanel}
+          data-testid="workspace-workflows-loading"
+        >
           <LoadingSpinner />
-          <p className={styles.stateText}>워크플로우 목록을 불러오는 중입니다.</p>
+          <p className={styles.stateText}>
+            워크플로우 목록을 불러오는 중입니다.
+          </p>
         </div>
       )}
 
@@ -65,12 +82,21 @@ export function WorkspaceWorkflowsPage() {
       )}
 
       {!loading && !error && entries.length === 0 && (
-        <div className={styles.statePanel} data-testid="workspace-workflows-empty">
+        <div
+          className={styles.statePanel}
+          data-testid="workspace-workflows-empty"
+        >
           <EmptyState message="아직 등록된 워크플로우가 없습니다. 워크플로우는 도메인팩에서 생성하고 관리합니다." />
-          <Button variant="outline" size="sm" onClick={handleOpenDomainPacks}>
-            <span>도메인팩으로 이동</span>
-            <ArrowRightIcon className={styles.pageHeaderIcon} />
-          </Button>
+          <div className={styles.stateActions}>
+            <Button size="sm" onClick={handleOpenUpload}>
+              <FileUpIcon className={styles.pageHeaderIcon} />
+              <span>{CTA_UPLOAD_LOGS}</span>
+            </Button>
+            <Button variant="outline" size="sm" onClick={handleOpenDomainPacks}>
+              <span>도메인팩으로 이동</span>
+              <ArrowRightIcon className={styles.pageHeaderIcon} />
+            </Button>
+          </div>
         </div>
       )}
 

--- a/frontend/src/pages/workspace/ui/workspace-workflows-page.module.css
+++ b/frontend/src/pages/workspace/ui/workspace-workflows-page.module.css
@@ -41,6 +41,13 @@
   background: var(--paper-2);
 }
 
+.stateActions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: var(--s-2);
+}
+
 .stateText {
   color: var(--ink-2);
   line-height: 1.6;


### PR DESCRIPTION
Closes #691

## 변경 사항

- 이슈 691 요구사항과 acceptance criteria를 `.agent/specs/691.md`에 정리했습니다.
- 워크플로우 빈 상태에서 `상담 로그 업로드` CTA를 제공해 Domain Pack 없는 workspace에서도 업로드 화면으로 바로 진입할 수 있게 했습니다.
- 로그인 mocked E2E에서 stale auth storage, 이전 workspace, legacy Domain Pack fixture를 함께 구성하고 현재 workspace 이름, empty state, 업로드 화면 이동, 새로고침 후 workspace context 유지를 화면 기준으로 검증했습니다.
- 워크플로우 빈 상태 CTA 단위 테스트를 보강해 업로드/도메인팩 이동 목적지를 각각 고정했습니다.

## 검증

- `pnpm --dir frontend test -- src/pages/workspace/ui/WorkspaceWorkflowsPage.test.tsx --run`
- `pnpm --dir frontend exec eslint e2e/auth-login.spec.ts src/pages/workspace/ui/WorkspaceWorkflowsPage.tsx src/pages/workspace/ui/WorkspaceWorkflowsPage.test.tsx`
- `pnpm exec prettier --check .agent/specs/691.md frontend/e2e/auth-login.spec.ts frontend/src/pages/workspace/ui/WorkspaceWorkflowsPage.tsx frontend/src/pages/workspace/ui/WorkspaceWorkflowsPage.test.tsx frontend/src/pages/workspace/ui/workspace-workflows-page.module.css`
- `pnpm --dir frontend exec playwright test --config=playwright.691.tmp.config.ts auth-login.spec.ts` (로컬 3000 포트에 다른 worktree preview가 떠 있어 5174 임시 config로 검증, config는 커밋하지 않음)
- `git diff --check`

## 참고

- `pnpm --dir frontend lint`와 pre-commit의 `pnpm run lint:frontend`는 이번 변경과 무관한 기존 frontend ESLint baseline 47건으로 실패합니다. API/FSD audits와 변경 파일 대상 ESLint는 통과했습니다.