### PR TITLE
fix(infra): gpu asg desired capacity를 ecs 관리로 유지

### DIFF
--- a/infra/terraform/ecs-gpu.tf
+++ b/infra/terraform/ecs-gpu.tf
@@ -84,6 +84,10 @@ resource "aws_autoscaling_group" "gpu" {
   protect_from_scale_in     = false
 
   lifecycle {
+    # ECS capacity provider managed scaling owns desired capacity after creation.
+    # Terraform should not scale GPU hosts back to zero while stage tasks are pending.
+    ignore_changes = [desired_capacity]
+
     precondition {
       condition     = length(local.gpu_private_subnet_ids) > 0
       error_message = "gpu_instance_type must be offered in at least one selected private subnet availability zone."

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -370,7 +370,7 @@ variable "gpu_asg_max_size" {
 }
 
 variable "gpu_asg_desired_capacity" {
-  description = "Default desired capacity of the shared GPU Auto Scaling Group."
+  description = "Initial desired capacity of the shared GPU Auto Scaling Group. ECS capacity provider managed scaling owns runtime desired capacity."
   type        = number
   default     = 0
 }


### PR DESCRIPTION
## 변경 사항

- GPU Auto Scaling Group의 `desired_capacity`를 Terraform drift 감시 대상에서 제외했습니다.
- `gpu_asg_desired_capacity`는 생성 시 초기값으로만 쓰이고, 운영 중 desired capacity는 ECS capacity provider managed scaling이 유지하도록 설명을 정리했습니다.

## 배경

`representation` GPU stage가 pending 상태일 때 ECS capacity provider가 GPU ASG를 `0 -> 1`로 올리지만, GitHub Actions Terraform apply가 `TF_VAR_gpu_asg_desired_capacity=0`을 다시 적용하면서 ASG desired capacity를 0으로 되돌리는 이벤트가 CloudTrail에 반복 기록됐습니다. 이 변경 이후 Terraform은 ASG의 min/max와 launch template은 계속 관리하되, GPU stage 수요에 따른 runtime desired capacity는 ECS managed scaling이 소유합니다.

별도로 현재 `ap-northeast-2` 계정의 `Running On-Demand G and VT instances` quota가 0이라 `g6.2xlarge` launch 자체는 quota 증설 전까지 실패합니다. 이 PR은 quota가 준비된 뒤에도 Terraform apply가 scale-out을 되돌리지 않도록 막는 인프라 drift 수정을 다룹니다.

## 검증

- `terraform -chdir=infra/terraform fmt -check ecs-gpu.tf variables.tf`
- `terraform -chdir=infra/terraform validate`
- `git diff --check origin/main...HEAD`

## 참고

- repository-wide `terraform -chdir=infra/terraform fmt -check`는 이번 변경과 무관한 기존 `infra/terraform/secrets.tf` 정렬 차이로 실패합니다. 변경 파일 대상 fmt와 Terraform validate는 통과했습니다.