### PR TITLE
test(frontend): 결제 success callback 중복 처리를 보장

### DIFF
--- a/.agent/specs/727.md
+++ b/.agent/specs/727.md
@@ -1,0 +1,61 @@
+# 결제 success callback 중복 orderId 재진입 E2E 보강
+
+## Goal
+
+외부 결제 성공 callback URL이 같은 `orderId`로 다시 열리거나 새로고침되어도, 브라우저 수준에서 결제 confirm이 중복 실행되지 않음을 E2E로 보장한다.
+
+## Problem
+
+`frontend/src/pages/billing/ui/BillingSuccessPage.tsx`는 widget 결제 성공 복귀 시 `frontend/src/features/pay-once/lib/orderGuard.ts`의 `sessionStorage` 기반 처리 완료 표식을 확인한다. 단위 테스트는 이미 처리된 `orderId` 분기를 다루지만, 실제 브라우저에서 첫 성공 처리 후 같은 success URL에 재진입했을 때 query 정리, API 호출 차단, 구독 화면 복귀가 함께 동작하는지는 E2E로 확인되지 않는다.
+
+## Scope
+
+- `frontend/e2e/billing.spec.ts`의 mocked Playwright billing 시나리오에 중복 `orderId` 재진입 테스트를 추가한다.
+- 첫 widget success 진입은 기존처럼 `POST /workspaces/1/payments/confirm`을 1회 호출해야 한다.
+- 같은 브라우저 세션에서 동일 success URL에 다시 진입하면 처리 완료 표식 때문에 confirm API를 다시 호출하지 않아야 한다.
+- 중복 재진입 사용자는 기존 처리 완료 안내를 확인할 수 있어야 한다.
+- 중복 재진입 후에도 URL의 `paymentKey`, `orderId`, `amount` query가 남지 않고 `/workspaces/1/billing`으로 replace 이동해야 한다.
+
+## Non-goals
+
+- `BillingSuccessPage`의 사용자 인터페이스 문구나 레이아웃을 변경하지 않는다.
+- billing, payment backend API contract나 mock fixture payload를 변경하지 않는다.
+- `orderGuard` 저장 방식과 저장 key를 변경하지 않는다.
+- Toss SDK request flow 자체를 새로 테스트하지 않는다.
+
+## Affected Paths
+
+- `frontend/e2e/billing.spec.ts`
+- `frontend/src/pages/billing/ui/BillingSuccessPage.tsx`
+- `frontend/src/features/pay-once/lib/orderGuard.ts`
+- `frontend/e2e/support/app-mocks.ts`
+
+## Requirements
+
+1. E2E는 widget success URL에 최초 진입했을 때 결제 confirm endpoint가 정확히 1회 호출됨을 확인해야 한다.
+2. E2E는 같은 `orderId`의 success URL에 다시 진입했을 때 confirm endpoint 호출 수가 증가하지 않음을 확인해야 한다.
+3. E2E는 중복 재진입 후 사용자가 이미 처리된 결제 안내를 확인할 수 있음을 확인해야 한다.
+4. E2E는 중복 재진입 후 사용자가 구독 화면 heading을 볼 수 있음을 확인해야 한다.
+5. E2E는 중복 재진입 후 현재 URL에 민감 결제 query인 `paymentKey`, `orderId`, `amount`가 남지 않음을 확인해야 한다.
+6. 테스트는 기존 mocked E2E route와 `seen` API 호출 추적 배열을 재사용해야 한다.
+
+## Data/API Impact
+
+- API, generated client, database schema, runtime product code contract 변경은 없다.
+- Playwright mocked API 호출 관찰만 추가한다.
+
+## Acceptance Criteria
+
+- `frontend/e2e/billing.spec.ts`에 같은 `orderId`로 success callback을 두 번 여는 회귀 테스트가 존재한다.
+- 테스트는 첫 success 처리 후 confirm 호출 수가 1임을 검증한다.
+- 테스트는 두 번째 success 처리 후 confirm 호출 수가 계속 1임을 검증한다.
+- 테스트는 두 번째 success 처리 후 `이미 처리된 결제입니다.` 안내를 검증한다.
+- 테스트는 두 번째 진입 이후 `/workspaces/1/billing`으로 복귀하고 결제 query가 URL에 남지 않음을 검증한다.
+
+## Validation
+
+- `cd frontend && pnpm e2e -- billing.spec.ts`
+
+## Open Questions
+
+- 없음.

--- a/frontend/e2e/billing.spec.ts
+++ b/frontend/e2e/billing.spec.ts
@@ -65,6 +65,33 @@ test.describe("Billing screens", () => {
         await expect(page.getByRole("heading", { name: "구독", level: 1 })).toBeVisible();
         expect(seen).toContain("POST /workspaces/1/payments/confirm");
       });
+
+      test("Then a repeated orderId does not confirm the payment again", async ({ page }) => {
+        const successUrl =
+          "/billing/success?workspaceId=1&flow=widget&paymentKey=payment-e2e&orderId=order-e2e&amount=99000";
+
+        await page.goto(successUrl);
+        await expect(page).toHaveURL(/\/workspaces\/1\/billing/);
+
+        const confirmCallsAfterFirstEntry = seen.filter(
+          (entry) => entry === "POST /workspaces/1/payments/confirm",
+        );
+        expect(confirmCallsAfterFirstEntry).toHaveLength(1);
+
+        await page.goto(successUrl);
+
+        await expect(page).toHaveURL(/\/workspaces\/1\/billing/);
+        await expect(page.getByRole("heading", { name: "구독", level: 1 })).toBeVisible();
+        await expect(page.getByText("이미 처리된 결제입니다.")).toBeVisible();
+        expect(page.url()).not.toContain("paymentKey=");
+        expect(page.url()).not.toContain("orderId=");
+        expect(page.url()).not.toContain("amount=");
+
+        const confirmCallsAfterSecondEntry = seen.filter(
+          (entry) => entry === "POST /workspaces/1/payments/confirm",
+        );
+        expect(confirmCallsAfterSecondEntry).toHaveLength(1);
+      });
     });
   });
 


### PR DESCRIPTION
Closes #727

## 변경 사항

- 이슈 727 요구사항과 acceptance criteria를 `.agent/specs/727.md`에 정리했습니다.
- mocked billing E2E에서 widget success callback을 같은 `orderId`로 두 번 진입하는 시나리오를 추가했습니다.
- 첫 진입 후 `POST /workspaces/1/payments/confirm`이 1회 호출되고, 같은 success URL 재진입 후에는 호출 수가 늘지 않음을 검증합니다.
- 중복 재진입 시 `이미 처리된 결제입니다.` 안내, 구독 화면 복귀, `paymentKey`/`orderId`/`amount` query 제거를 함께 확인합니다.

## 검증

- `pnpm e2e -- billing.spec.ts` (frontend, 6 passed)
- `pnpm exec eslint e2e/billing.spec.ts`
- `git diff --check`

## 참고

- 구현 전 `BillingSuccessPage`, `orderGuard`, billing E2E mock의 기존 sessionStorage 가드와 API 호출 추적 패턴을 확인했고, 제품 코드/API fixture 변경 없이 회귀 E2E만 보강했습니다.
- self-review 3회 수행: issue fidelity/behavior, frontend integration boundary, reviewer·CI risk 관점에서 확인했으며 남은 수정 사항은 없습니다.
- `pnpm lint`와 pre-commit의 `pnpm run lint:frontend`는 이번 변경과 무관한 기존 frontend ESLint baseline 47건으로 실패합니다. API/FSD audits와 변경 파일 대상 ESLint는 통과했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Tests**
  * 결제 완료 페이지 재접근 시 중복 결제 방지 동작을 검증하는 E2E 테스트 추가
  * 동일 주문번호로 성공 페이지에 재진입해도 결제 확인 API가 중복 호출되지 않음을 보장
  * 민감한 결제 정보가 URL에서 제거되고 올바른 페이지로 이동하는지 확인

* **Documentation**
  * 결제 중복 진입 시나리오 E2E 테스트 스펙 문서 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->