### PR TITLE
test(frontend): workspace 로딩 중 이전 계정 정보 비노출을 보장

### DIFF
--- a/.agent/specs/699.md
+++ b/.agent/specs/699.md
@@ -1,0 +1,115 @@
+# Frontend FSD Spec: workspace 로딩 중 이전 계정 정보 비노출
+
+## Goal
+
+현재 계정의 workspace 정보를 불러오는 동안 sidebar, header, 본문 어디에도 이전 계정의 workspace 이름이나 데이터가 표시되지 않음을 mocked E2E로 보장한다.
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A["이전 계정 workspace 화면을 본 브라우저"] --> B["로그아웃"]
+    B --> C["현재 계정으로 로그인"]
+    C --> D["현재 계정 workspace route 진입"]
+    D --> E["workspace 목록 또는 상세 응답 지연"]
+    E --> F["안전한 로딩 상태 표시"]
+    F --> G["이전 계정 workspace 이름과 데이터 비노출"]
+    G --> H["응답 완료 후 현재 계정 workspace만 표시"]
+```
+
+## Design Diff
+
+| 영역 | As-is | To-be | 변경 내용 |
+| --- | --- | --- | --- |
+| E2E 검증 | 이전 계정 route/history 재진입 후 권한 오류 화면에서 stale 데이터가 없는지 검증 | workspace 상세 응답이 지연되는 로딩 순간에도 stale workspace 이름과 데이터가 없는지 검증 | 느린 네트워크 fixture에서 P1 노출 회귀를 직접 관찰 |
+| Loading UI | `WorkspaceLayout`이 workspace 상세 로딩 중 안전 문구와 spinner를 표시 | 기존 안전 로딩 UI를 회귀 테스트로 고정 | `워크스페이스 정보를 불러오는 중입니다.` 상태에서 이전 계정 정보가 나타나지 않아야 함 |
+| Workspace marker | `WorkspaceMarker`가 workspace 목록 query로 현재 marker 이름을 계산 | 지연 응답 중 이전 계정 목록/상세 정보가 marker에 표시되지 않음을 검증 | API 호출 자체보다 화면 노출 여부를 우선 단언 |
+
+## Component Tree
+
+```text
+App
+└─ PrivateRoute
+   └─ WorkspaceLayout
+      ├─ useGetWorkspace
+      └─ OstoneShell
+         ├─ Sidebar
+         │  └─ WorkspaceMarker
+         │     └─ useListWorkspaces
+         ├─ Topbar
+         └─ loading body
+```
+
+## API Integration
+
+| Method | Path | Mock behavior |
+| --- | --- | --- |
+| `POST` | `/api/v1/auth/login` | 현재 계정 세션을 반환하고 mock account scope를 current로 전환 |
+| `GET` | `/api/v1/workspaces` | 로그인 destination 결정을 위한 첫 현재 계정 목록 응답은 즉시 반환하고, workspace 화면 marker가 재조회하는 후속 응답을 지연 |
+| `GET` | `/api/v1/workspaces/2` | 현재 계정 workspace 상세 응답을 지연시켜 shell loading 상태를 관찰 |
+| `GET` | `/api/v1/workspaces/1/*` | 이전 계정 화면을 먼저 렌더링하기 위한 기존 fixture 유지 |
+
+신규 API는 만들지 않는다. 테스트는 현재 제품 코드의 generated workspace controller 호출 흐름을 mock한다.
+
+## Data Flow
+
+```text
+previous account dashboard render
+  -> previous workspace name and pack visible
+  -> logout clears auth session and query cache
+  -> current account login
+  -> destination GET /workspaces resolves current workspace
+  -> navigate /workspaces/2/workflows
+  -> delayed subsequent GET /workspaces and delayed GET /workspaces/2
+  -> loading shell shows safe loading text only
+  -> delayed responses resolve
+  -> current workspace marker and empty workflows state render
+```
+
+## 수정 대상 파일
+
+| 파일 | 변경 유형 | 설명 |
+| --- | --- | --- |
+| `.agent/specs/699.md` | new | 이슈 요구사항과 검증 기준 기록 |
+| `frontend/e2e/navigation.spec.ts` | update | 느린 workspace 조회 중 이전 계정 workspace 정보가 보이지 않는 E2E 추가 |
+| `frontend/src/pages/workspace/ui/WorkspaceLayout.tsx` | inspect | workspace 상세 로딩 UI와 shell 구성 확인, 직접 수정은 새 E2E 실패 시에만 수행 |
+| `frontend/src/shared/ui/ostone/chrome/WorkspaceMarker.tsx` | inspect | marker가 workspace 목록 query로 이름을 계산하는 흐름 확인, 직접 수정은 새 E2E 실패 시에만 수행 |
+| `frontend/src/app/providers.tsx` | inspect | 인증 세션 변경 시 query cache 정리 흐름 확인, 직접 수정은 새 E2E 실패 시에만 수행 |
+
+## State Management
+
+- `saveAuthSession`과 `clearAuthSession`은 `AUTH_SESSION_CHANGED_EVENT`를 발생시키며, `AppProviders`는 이 이벤트에서 TanStack Query cache를 정리한다.
+- 별도 persisted selected workspace storage key는 확인되지 않았다.
+- 테스트는 이전 계정 화면을 먼저 렌더링해 query/UI state에 stale 데이터가 실제로 존재했던 조건을 만든다.
+- 현재 계정 로그인 후 workspace 목록과 상세 응답을 지연시키고, pending 상태의 DOM에서 이전 계정 workspace 이름과 pack 이름이 보이지 않는지 확인한다.
+
+## Tests
+
+| 구분 | 방법 | 도구 |
+| --- | --- | --- |
+| E2E 회귀 | 이전 계정 dashboard 표시 후 현재 계정 로그인, workspace 조회 지연 중 stale 데이터 비노출 검증 | Playwright mocked E2E |
+| 정적 검증 | 변경 diff와 포맷 확인 | `git diff --check` |
+
+## Acceptance Criteria
+
+- 브라우저가 이전 계정의 workspace 화면을 본 뒤에도 현재 계정 로그인 후 로딩 중 이전 workspace 이름이 sidebar, header, 본문에 나타나지 않는다.
+- 로딩 중 사용자는 현재 workspace 정보를 불러오는 중임을 알 수 있다.
+- 느린 `GET /workspaces`와 느린 `GET /workspaces/{id}` fixture에서도 이전 계정 pack/dashboard 데이터가 나타나지 않는다.
+- 조회가 끝나면 현재 계정 workspace marker와 현재 계정 화면만 표시된다.
+- 테스트는 API 호출 횟수보다 사용자에게 노출되는 텍스트를 우선 단언한다.
+
+## Non-Goals
+
+- Backend workspace membership API 또는 권한 정책을 변경하지 않는다.
+- 로그인 destination resolver의 stale workspace return-to 정책을 새로 변경하지 않는다.
+- live E2E나 실제 외부 계정 데이터에 의존하는 시나리오는 추가하지 않는다.
+- workspace 내부 dashboard, domain pack, billing 데이터 조회 정책을 변경하지 않는다.
+
+## Validation
+
+- `pnpm --dir frontend exec playwright test e2e/navigation.spec.ts --grep "current workspace loading"`
+- `git diff --check`
+
+## Open Questions
+
+- 없음. 이슈의 디스클레이머에 따라 세부 API 호출보다 로딩 중 화면 노출 여부를 기준으로 확정한다.

--- a/frontend/e2e/navigation.spec.ts
+++ b/frontend/e2e/navigation.spec.ts
@@ -27,6 +27,29 @@ const currentWorkspace = {
   updatedAt: "2026-06-04T09:00:00+09:00",
 };
 
+interface Deferred {
+  promise: Promise<void>;
+  resolve: () => void;
+}
+
+interface CrossAccountWorkspaceMockOptions {
+  delayCurrentWorkspaceLoading?: boolean;
+}
+
+interface CrossAccountWorkspaceMocks {
+  seen: string[];
+  releaseCurrentWorkspaceLoading: () => void;
+}
+
+function createDeferred(): Deferred {
+  let resolve: () => void = () => {};
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+
+  return { promise, resolve };
+}
+
 async function fulfillJson(route: Route, body: unknown, status = 200) {
   await route.fulfill({
     status,
@@ -35,9 +58,24 @@ async function fulfillJson(route: Route, body: unknown, status = 200) {
   });
 }
 
-async function installCrossAccountWorkspaceMocks(page: Page) {
+async function installCrossAccountWorkspaceMocks(
+  page: Page,
+  options: CrossAccountWorkspaceMockOptions = {},
+): Promise<CrossAccountWorkspaceMocks> {
   let account: AccountScope = "previous";
   const seen: string[] = [];
+  let currentWorkspaceListCount = 0;
+  const currentWorkspaceListLoading = options.delayCurrentWorkspaceLoading
+    ? createDeferred()
+    : null;
+  const currentWorkspaceDetailLoading = options.delayCurrentWorkspaceLoading
+    ? createDeferred()
+    : null;
+
+  const releaseCurrentWorkspaceLoading = () => {
+    currentWorkspaceListLoading?.resolve();
+    currentWorkspaceDetailLoading?.resolve();
+  };
 
   await page.route("**/api/v1/**", async (route) => {
     const request = route.request();
@@ -70,7 +108,16 @@ async function installCrossAccountWorkspaceMocks(page: Page) {
     }
 
     if (method === "GET" && path === "/workspaces") {
-      await fulfillJson(route, account === "previous" ? [previousWorkspace] : [currentWorkspace]);
+      if (account === "current") {
+        currentWorkspaceListCount += 1;
+        if (currentWorkspaceListCount > 1) {
+          await currentWorkspaceListLoading?.promise;
+        }
+      }
+      await fulfillJson(
+        route,
+        account === "previous" ? [previousWorkspace] : [currentWorkspace],
+      );
       return;
     }
 
@@ -88,6 +135,7 @@ async function installCrossAccountWorkspaceMocks(page: Page) {
     }
 
     if (method === "GET" && path === "/workspaces/2") {
+      await currentWorkspaceDetailLoading?.promise;
       await fulfillJson(route, currentWorkspace);
       return;
     }
@@ -176,7 +224,7 @@ async function installCrossAccountWorkspaceMocks(page: Page) {
     await fulfillJson(route, { code: "E2E_UNMOCKED", message: `${method} ${path}` }, 500);
   });
 
-  return seen;
+  return { seen, releaseCurrentWorkspaceLoading };
 }
 
 test.describe("Application navigation boundaries", () => {
@@ -240,7 +288,7 @@ test.describe("Application navigation boundaries", () => {
     test("When a different account logs in and navigates back, Then previous workspace data is not exposed", async ({
       page,
     }) => {
-      const seen = await installCrossAccountWorkspaceMocks(page);
+      const { seen } = await installCrossAccountWorkspaceMocks(page);
       await installAuth(page, {
         name: "이전 상담사",
         email: "previous@example.com",
@@ -284,6 +332,61 @@ test.describe("Application navigation boundaries", () => {
       await page.reload();
       await expect(page).toHaveURL(/\/workspaces\/1\/dashboard$/);
       await expect(page.getByText("접근 권한이 없습니다.")).toBeVisible();
+      await expect(page.getByText("Previous Account Workspace")).toHaveCount(0);
+      await expect(page.getByText("Previous Account Pack")).toHaveCount(0);
+    });
+
+    test("When current workspace loading is slow, Then stale workspace data stays hidden", async ({
+      page,
+    }) => {
+      const { seen, releaseCurrentWorkspaceLoading } =
+        await installCrossAccountWorkspaceMocks(page, {
+          delayCurrentWorkspaceLoading: true,
+        });
+      await installAuth(page, {
+        name: "이전 상담사",
+        email: "previous@example.com",
+      });
+
+      await page.goto("/workspaces/1/dashboard");
+      await expect(page.getByTestId("workspace-marker")).toContainText(
+        "Previous Account Workspace",
+      );
+      await expect(page.getByText("Previous Account Pack")).toBeVisible();
+
+      await page.getByTestId("account-menu-trigger").click();
+      await page.getByTestId("account-menu-logout").click();
+      await expect(page).toHaveURL(/\/login$/);
+
+      await page.getByLabel("이메일 주소").fill("current@example.com");
+      await page.getByLabel("비밀번호").fill("password123");
+      await page.getByRole("button", { name: "시스템 로그인" }).click();
+
+      try {
+        await expect(page).toHaveURL(/\/workspaces\/2\/workflows$/);
+        await expect(
+          page.getByText("워크스페이스 정보를 불러오는 중입니다."),
+        ).toBeVisible();
+        await expect(page.getByTestId("workspace-marker")).toContainText(
+          "워크스페이스 선택",
+        );
+        await expect(page.getByText("Previous Account Workspace")).toHaveCount(0);
+        await expect(page.getByText("Previous Account Pack")).toHaveCount(0);
+        await expect(page.getByText("총 상담")).toHaveCount(0);
+        expect(seen).toContain("current GET /workspaces/2");
+        expect(
+          seen.filter((entry) => entry === "current GET /workspaces").length,
+        ).toBeGreaterThan(1);
+      } finally {
+        releaseCurrentWorkspaceLoading();
+      }
+
+      await expect(page.getByTestId("workspace-marker")).toContainText(
+        "Current Account Workspace",
+      );
+      await expect(
+        page.getByRole("heading", { name: "워크플로우", level: 1 }),
+      ).toBeVisible();
       await expect(page.getByText("Previous Account Workspace")).toHaveCount(0);
       await expect(page.getByText("Previous Account Pack")).toHaveCount(0);
     });


### PR DESCRIPTION
Closes #699

## 변경 사항

- 이슈 699 요구사항과 acceptance criteria를 `.agent/specs/699.md`에 정리했습니다.
- `frontend/e2e/navigation.spec.ts`의 cross-account workspace fixture에 현재 계정 workspace loading 지연 옵션을 추가했습니다.
- 이전 계정 dashboard를 먼저 렌더링한 뒤 로그아웃하고, 현재 계정 로그인 후 `/workspaces/2/workflows`의 workspace 목록/상세 조회가 느린 동안 안전한 로딩 문구만 보이는지 검증합니다.
- 로딩 중 sidebar marker, header, 본문에 이전 계정 workspace 이름과 pack/dashboard 데이터가 나타나지 않고, 응답 완료 후 현재 계정 workspace만 표시되는지 확인합니다.

## 검증

- `pnpm --dir frontend exec playwright test e2e/navigation.spec.ts --grep "current workspace loading"` (1 passed)
- `pnpm --dir frontend exec playwright test e2e/navigation.spec.ts` (8 passed)
- `pnpm --dir frontend exec eslint e2e/navigation.spec.ts`
- `git diff --check`

## 참고

- 구현 전 `WorkspaceLayout`, `WorkspaceMarker`, `AppProviders`, 기존 cross-account navigation E2E 흐름을 확인했고, 제품 코드 변경 없이 mocked E2E 회귀 검증만 보강했습니다.
- spec review 2회 수행: issue fidelity와 Ostone repository compliance 관점에서 확인했고, `/workspaces` 지연 fixture 설명을 실제 동작에 맞게 정리했습니다.
- self-review 3회 수행: issue fidelity/behavior, frontend integration boundary, reviewer·CI risk 관점에서 확인했으며 남은 수정 사항은 없습니다.
- pre-commit hook의 `pnpm run lint:frontend`는 이번 변경과 무관한 기존 frontend ESLint baseline 47건으로 실패합니다. API/FSD audits와 변경 파일 대상 ESLint, targeted navigation E2E, 전체 navigation E2E는 통과했습니다.
- hook 실패는 repository-wide lint baseline 때문이라 변경 파일 대상 검증을 근거로 hook을 우회해 커밋했습니다.