### PR TITLE
test(frontend): 도메인팩 버전 운영 배포 전환을 보장

### DIFF
--- a/.agent/specs/720.md
+++ b/.agent/specs/720.md
@@ -1,0 +1,130 @@
+# Frontend E2E Spec: Domain Pack Version 운영 배포 확인
+
+## Goal
+
+운영자가 검토된 Domain Pack 버전을 배포할 때 대상 버전과 운영 전환을 확인하고, 완료 후 해당 버전이 현재 운영 버전으로 표시됨을 mocked E2E로 보장한다.
+
+## Issue Summary
+
+GitHub Issue #720은 Domain Pack Version 배포가 Critical E2E 시나리오로 검증되어야 한다고 요구한다. 기존 `frontend/e2e/domain-pack-core.spec.ts`에는 v2 배포 확인 dialog와 deploy API 호출 검증이 있으나, 배포 성공 후 mock fixture가 현재 운영 버전을 v2로 갱신하지 않아 UI가 운영 버전 전환을 신뢰할 수 있는지 확인하지 못한다.
+
+현재 `frontend/playwright.config.ts`는 mocked E2E 전체를 실행한다. 따라서 이 작업은 기존 `domain-pack-core` suite 안의 배포 시나리오를 Playwright `@critical` tag로 식별 가능하게 하고, 사용자에게 중요한 운영 전환 결과를 화면 기준으로 검증한다.
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A["Domain Pack v2 상세 진입"] --> B["대상 버전 번호와 설명 확인"]
+    B --> C["배포 버튼 클릭"]
+    C --> D["배포 확인 dialog 표시"]
+    D --> E{"운영자가 확정?"}
+    E -->|"No"| F["Deploy API 미호출"]
+    E -->|"Yes"| G["Deploy API 호출"]
+    G --> H["Pack/detail refetch"]
+    H --> I["v2가 현재 운영 버전으로 표시"]
+```
+
+## Design Diff
+
+| 영역 | As-is | To-be | 변경 내용 |
+| --- | --- | --- | --- |
+| E2E scenario | v2 배포 dialog와 deploy endpoint 호출만 확인 | Critical 배포 흐름에서 dialog의 대상 버전/운영 전환 정보와 완료 후 운영 버전 전환까지 확인 | 사용자 기대 결과 중심으로 검증 강화 |
+| Mock fixture | deploy 응답 후 pack 상세 refetch가 계속 `currentVersionId=1` 반환 | deploy 성공 후 workspace 1의 Domain Pack summary/detail이 `currentVersionId=2`, `currentVersionNo=2`를 반환 | 실제 배포 후 운영 버전 변경 계약을 mock에 반영 |
+| Workspace isolation | workspace 2 mock은 workspace 1 deploy state와 명시적으로 분리되지 않음 | workspace 1 deploy state만 변경하고 workspace 2 fixture는 기존 운영 버전 상태 유지 | 다른 workspace에 배포가 적용된 것처럼 보이지 않게 함 |
+
+## Component Tree
+
+```text
+frontend/e2e/domain-pack-core.spec.ts
+└─ Domain pack core read flows
+   └─ deploy operating candidate version @critical
+
+frontend/e2e/support/app-mocks.ts
+└─ installAppApiMocks
+   └─ fulfillDomainPackRead
+      ├─ GET pack list/detail
+      ├─ GET version detail
+      └─ POST version deploy
+```
+
+## API Integration
+
+테스트는 `frontend/e2e/support/app-mocks.ts`의 Playwright route mock만 사용한다.
+
+| Method | Path | 목적 |
+| --- | --- | --- |
+| `GET` | `/api/v1/workspaces/1/domain-packs/1` | 현재 운영 버전과 버전 목록 조회 |
+| `GET` | `/api/v1/workspaces/1/domain-packs/1/versions/2` | 배포 대상 v2 상세 조회 |
+| `POST` | `/api/v1/workspaces/1/domain-packs/1/versions/2/deploy` | 운영 버전 배포 확정 |
+
+## 수정 대상 파일
+
+| 파일 | 변경 유형 | 설명 |
+| --- | --- | --- |
+| `.agent/specs/720.md` | new | Issue #720 요구사항과 검증 기준 기록 |
+| `frontend/e2e/domain-pack-core.spec.ts` | update | Domain Pack Version 배포 Critical E2E assertions 강화 |
+| `frontend/e2e/support/app-mocks.ts` | update | deploy 후 current operating version을 v2로 반환하는 stateful mock 추가 |
+
+## State Management
+
+- 프로덕션 클라이언트 상태 관리는 변경하지 않는다.
+- E2E mock state는 `installAppApiMocks` 호출 단위로 초기화되어 테스트 간 공유되지 않는다.
+- deploy 확정 전에는 mock current version이 v1이다.
+- deploy 확정 후에는 workspace 1의 pack list/detail refetch만 v2를 현재 운영 버전으로 반환한다.
+- workspace 2 fixture는 workspace 1 deploy state를 공유하지 않는다.
+
+## Tests
+
+### Test Strategy
+
+| 구분 | 방법 | 도구 | 비고 |
+| --- | --- | --- | --- |
+| E2E 테스트 | Domain Pack summary 화면 조작 + API route mocking | Playwright | 핵심 사용자 시나리오 |
+| 정적 검증 | 변경 파일 TypeScript/ESLint 확인 | ESLint | frontend staged 파일 위험 확인 |
+
+### Test Environment & 사전 조건
+
+| 항목 | 값 |
+| --- | --- |
+| 환경 | `frontend/playwright.config.ts` preview mock 환경 |
+| API Mock | Playwright `page.route` |
+| 사전 조건 | workspace 1의 Domain Pack 1에 현재 운영 v1과 운영 가능 후보 v2가 존재 |
+
+### Test Scenarios
+
+| # | 시나리오 | 사전 조건 | 조작 | 기대 결과 |
+| --- | --- | --- | --- | --- |
+| 1 | 운영 가능 후보 버전 배포 | v2 상세 화면 표시 | 배포 버튼 클릭 후 dialog에서 배포 확정 | 성공 피드백이 보이고 v2가 현재 운영 버전으로 표시된다 |
+| 2 | 확정 전 실행 방지 | v2 상세 화면 표시 | 배포 버튼 클릭 후 dialog만 표시 | deploy API는 확정 버튼 전까지 호출되지 않는다 |
+| 3 | workspace/version isolation | workspace 1 pack v2 배포 | 배포 완료 후 화면 확인 | v1이 계속 배포중으로 보이지 않고, selected v2만 배포중/운영 중으로 표시된다 |
+
+## Acceptance Criteria
+
+- `.agent/specs/720.md` 파일명이 이슈 번호만 포함한다.
+- `frontend/e2e/domain-pack-core.spec.ts`의 version deploy 시나리오가 `@critical` tag로 식별된다.
+- 배포 확인 dialog는 대상 `v2`, 운영 전환(`현재 v1 → v2`), 변경 요약을 화면 기준으로 확인한다.
+- 확인 dialog에서 `배포하기`를 누르기 전에는 deploy endpoint가 호출되지 않는다.
+- deploy 성공 후 성공 피드백이 표시된다.
+- deploy 성공 후 버전 안전성 정보와 상세 패널은 v2를 현재 운영 버전으로 표시한다.
+- deploy 성공 후 v1 row가 `배포중`으로 표시되지 않는다.
+- deploy API 호출 여부는 보조 검증으로 유지한다.
+- E2E mock은 테스트 간 상태를 공유하지 않는다.
+
+## Non-goals
+
+- Backend deploy API contract, OpenAPI generated files, database schema는 변경하지 않는다.
+- Domain Pack 배포 UI 문구나 디자인을 변경하지 않는다.
+- live E2E 또는 실제 운영 백엔드 의존 테스트를 추가하지 않는다.
+- 별도 Critical-only CI job이나 package script를 추가하지 않는다.
+
+## Validation
+
+| 검증 | 목적 |
+| --- | --- |
+| `pnpm --dir frontend exec playwright test e2e/domain-pack-core.spec.ts --grep @critical` | Domain Pack 배포 Critical E2E만 좁게 검증 |
+| `pnpm --dir frontend e2e -- domain-pack-core.spec.ts` | Domain Pack mocked E2E 중 배포 Critical 흐름 검증 |
+| `pnpm --dir frontend exec eslint e2e/domain-pack-core.spec.ts e2e/support/app-mocks.ts` | 변경된 E2E TypeScript 파일 lint 확인 |
+
+## Open Questions
+
+- 없음.

--- a/frontend/e2e/domain-pack-core.spec.ts
+++ b/frontend/e2e/domain-pack-core.spec.ts
@@ -69,8 +69,8 @@ test.describe("Domain pack core read flows", () => {
       });
     });
 
-    test.describe("When they deploy an operating candidate version", () => {
-      test("Then the deploy confirmation calls the version deploy endpoint", async ({ page }) => {
+    test.describe("When they deploy an operating candidate version @critical", () => {
+      test("Then the deploy confirmation switches the operating version", async ({ page }) => {
         await page.goto("/workspaces/1/domain-packs/1?versionId=2");
 
         await expect(
@@ -81,10 +81,29 @@ test.describe("Domain pack core read flows", () => {
         await expect(page.getByText("상담사 연결 정책")).toBeVisible();
         await expect(page.getByText("상담사 연결 검토 워크플로우")).toBeVisible();
         await page.getByRole("button", { name: "배포", exact: true }).click();
-        await expect(page.getByRole("alertdialog")).toContainText("v2 버전을 배포할까요?");
+        const dialog = page.getByRole("alertdialog");
+        await expect(dialog).toContainText("v2 버전을 배포할까요?");
+        const versionInfo = dialog.getByLabel("대상 버전 정보");
+        await expect(versionInfo).toContainText("대상 버전");
+        await expect(versionInfo).toContainText("v2");
+        await expect(versionInfo).toContainText("운영 가능");
+        await expect(versionInfo).toContainText("현재 v1 → v2");
+        await expect(versionInfo).toContainText("환불 자동화 팩 v2");
+        expect(seen).not.toContain("POST /workspaces/1/domain-packs/1/versions/2/deploy");
         await page.getByRole("button", { name: "배포하기" }).click();
 
         await expect(page.getByText("도메인팩 버전이 배포되었습니다.")).toBeVisible();
+        const safety = page.getByLabel("버전 안전성 정보");
+        await expect(safety).toContainText("현재 v2 · 운영 중");
+        await expect(safety).toContainText("운영 구성요소");
+        await expect(safety).toContainText("현재 운영 중인 버전입니다.");
+        await expect(
+          page.getByRole("button", {
+            name: /v2[\s\S]*배포중[\s\S]*상담사 연결 조건을 보강한 운영 가능 버전/,
+          }),
+        ).toBeVisible();
+        await expect(page.getByRole("button", { name: "배포중", exact: true })).toBeDisabled();
+        await expect(page.getByRole("button", { name: /v1[\s\S]*배포중/ })).toHaveCount(0);
         expect(seen).toContain("POST /workspaces/1/domain-packs/1/versions/2/deploy");
       });
     });

--- a/frontend/e2e/support/app-mocks.ts
+++ b/frontend/e2e/support/app-mocks.ts
@@ -26,6 +26,11 @@ export const e2eIds = {
 
 type RouteHandler = (route: Route, method: string, path: string, url: URL) => Promise<boolean>;
 
+interface DomainPackMockState {
+  currentVersionId: number;
+  currentVersionNo: number;
+}
+
 const now = "2026-06-04T09:00:00+09:00";
 
 const workspace = {
@@ -160,6 +165,26 @@ const draftVersionDetail = {
   ...packDetail.versions[2],
   finalMessage: "고액 환불 검토 흐름을 정리했습니다.",
 };
+
+function buildWorkspacePackSummary(state: DomainPackMockState) {
+  return {
+    ...packSummary,
+    currentVersionId: state.currentVersionId,
+    currentVersionNo: state.currentVersionNo,
+    currentVersionPublishedAt:
+      state.currentVersionId === VERSION_ID ? packSummary.currentVersionPublishedAt : now,
+    updatedAt: state.currentVersionId === VERSION_ID ? packSummary.updatedAt : now,
+  };
+}
+
+function buildWorkspacePackDetail(state: DomainPackMockState) {
+  return {
+    ...packDetail,
+    ...buildWorkspacePackSummary(state),
+    code: packDetail.code,
+    versions: packDetail.versions,
+  };
+}
 
 const intent = {
   id: INTENT_ID,
@@ -652,17 +677,23 @@ async function fulfillWorkspaceShell(route: Route, method: string, path: string)
   return false;
 }
 
-async function fulfillDomainPackRead(route: Route, method: string, path: string): Promise<boolean> {
-  const domainPackWorkspacePrefix = path.startsWith("/workspaces/1/domain-packs")
-    ? "/workspaces/1"
-    : path.startsWith("/workspaces/2/domain-packs")
-      ? "/workspaces/2"
-      : null;
+async function fulfillDomainPackRead(
+  route: Route,
+  method: string,
+  path: string,
+  state: DomainPackMockState,
+): Promise<boolean> {
+  const domainPackWorkspacePrefix =
+    path.startsWith("/workspaces/1/domain-packs")
+      ? "/workspaces/1"
+      : path.startsWith("/workspaces/2/domain-packs")
+        ? "/workspaces/2"
+        : null;
 
   if (method === "GET" && path === `${domainPackWorkspacePrefix}/domain-packs`) {
     const summaries =
       domainPackWorkspacePrefix === "/workspaces/1"
-        ? [packSummary, idlePackSummary]
+        ? [buildWorkspacePackSummary(state), idlePackSummary]
         : [{ ...packSummary, workspaceId: 2, name: "Ops Workflow Pack" }];
     await fulfillJson(route, { data: summaries, status: 200 });
     return true;
@@ -672,7 +703,7 @@ async function fulfillDomainPackRead(route: Route, method: string, path: string)
     await fulfillJson(route, {
       data:
         domainPackWorkspacePrefix === "/workspaces/1"
-          ? packDetail
+          ? buildWorkspacePackDetail(state)
           : { ...packDetail, workspaceId: 2, name: "Ops Workflow Pack" },
       status: 200,
     });
@@ -707,6 +738,8 @@ async function fulfillDomainPackRead(route: Route, method: string, path: string)
   }
 
   if (method === "POST" && path === "/workspaces/1/domain-packs/1/versions/2/deploy") {
+    state.currentVersionId = 2;
+    state.currentVersionNo = 2;
     await fulfillJson(route, {
       data: {
         id: 2,
@@ -1431,6 +1464,10 @@ async function fulfillSimulation(
 }
 
 export async function installAppApiMocks(page: Page, seen: string[]) {
+  const domainPackState: DomainPackMockState = {
+    currentVersionId: VERSION_ID,
+    currentVersionNo: 1,
+  };
   const simulationState = createSimulationState();
 
   await page.route("**/e2e-upload/**", async (route) => {
@@ -1440,7 +1477,7 @@ export async function installAppApiMocks(page: Page, seen: string[]) {
 
   await installTrackedApiRoute(page, seen, async (route, method, path, url) => {
     if (await fulfillWorkspaceShell(route, method, path)) return true;
-    if (await fulfillDomainPackRead(route, method, path)) return true;
+    if (await fulfillDomainPackRead(route, method, path, domainPackState)) return true;
     if (await fulfillWorkspaceOperations(route, method, path, url)) return true;
     if (await fulfillUploadAndReview(route, method, path)) return true;
     if (await fulfillSimulation(route, method, path, simulationState)) return true;


### PR DESCRIPTION
Closes #720

## 변경 사항

- 이슈 720 요구사항과 acceptance criteria를 `.agent/specs/720.md`에 정리했습니다.
- `frontend/e2e/domain-pack-core.spec.ts`의 Domain Pack version deploy 시나리오를 `@critical` tag로 식별 가능하게 표시했습니다.
- 배포 확인 dialog에서 대상 v2, 운영 전환(`현재 v1 → v2`), 변경 요약을 확인하고, 확정 전 deploy API가 호출되지 않음을 검증합니다.
- deploy mock을 상태 기반으로 보강해 배포 성공 후 pack refetch가 v2를 현재 운영 버전으로 반환하고, 화면에서 v2가 `배포중`/`현재 v2 · 운영 중`으로 표시되는지 확인합니다.

## 검증

- `pnpm --dir frontend exec playwright test e2e/domain-pack-core.spec.ts --grep @critical` (1 passed)
- `pnpm --dir frontend e2e -- domain-pack-core.spec.ts` (13 passed)
- `pnpm --dir frontend exec eslint e2e/domain-pack-core.spec.ts e2e/support/app-mocks.ts`
- `git diff --check`

## 참고

- 구현 전 `DomainPackSummaryPage`, `SummaryDetailPanel`, `VersionSafetyBanner`, `VersionListPanel`, `frontend/e2e/domain-pack-core.spec.ts`, `frontend/e2e/support/app-mocks.ts`, `frontend/playwright.config.ts`의 기존 배포/summary/refetch 흐름을 확인했습니다.
- self-review 3회 수행: issue fidelity/behavior에서 dialog summary assertion 불일치를 수정했고, frontend integration boundary와 reviewer·CI risk 관점에서 남은 수정 사항은 없습니다.
- pre-commit hook은 repository-wide `pnpm run lint:frontend`가 이번 변경과 무관한 기존 frontend ESLint baseline 47건으로 실패해 통과하지 못했습니다. 변경 파일 대상 ESLint, Critical E2E, Domain Pack core E2E, diff whitespace check는 통과했습니다.