### PR TITLE
feat(frontend): 파이프라인 리뷰 최신 상태 반영을 보장

### DIFF
--- a/.agent/specs/712.md
+++ b/.agent/specs/712.md
@@ -1,0 +1,105 @@
+# Frontend Spec: Pipeline Status Refresh
+
+## Goal
+
+운영자가 파이프라인 리뷰/진행 화면에서 같은 workspace와 pipeline job 맥락을 유지한 채 최신 상태를 재조회하고, 완료 또는 실패 상태에 맞는 다음 행동을 확인할 수 있게 한다.
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A["운영자가 pipeline job 리뷰 화면 진입"] --> B["초기 상태 조회"]
+    B --> C{"상태가 진행 중인가?"}
+    C -->|"Yes"| D["상태 새로고침 또는 자동 polling"]
+    D --> E["같은 workspace/job URL에서 최신 상태 반영"]
+    E --> F{"최신 상태"}
+    F -->|"완료"| G["도메인팩 관리/검토로 이어지는 행동 표시"]
+    F -->|"실패"| H["업로드 재시도와 현재 job 재조회 행동 표시"]
+    F -->|"계속 진행 중"| D
+    C -->|"No"| F
+```
+
+## Design Diff
+
+| 영역                      | As-is                                                                    | To-be                                                                                     | 변경 내용                                                |
+| ------------------------- | ------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| 파이프라인 리뷰 상태 조회 | 화면 진입 시 체크포인트를 조회하고 일부 상태에서 수동 재조회 버튼을 제공 | 진행 중인 체크포인트 없는 상태에서는 같은 query key로 주기 재조회하고, 수동 재조회도 유지 | 오래된 RUNNING/QUEUED 상태가 고정되어 보이지 않도록 보강 |
+| 완료 상태                 | 상태 카드가 도메인팩 관리 CTA를 표시                                     | 최신 SUCCEEDED 상태가 반영되면 같은 화면에서 완료 CTA 노출                                | workspace와 pipeline job route 유지                      |
+| 실패 상태                 | 상태 카드가 업로드 재시도 CTA와 현재 job 재조회 버튼을 표시              | 최신 FAILED 상태가 반영되면 성공 CTA 대신 실패 대응 CTA 노출                              | 실패 상태에서 성공 행동이 잘못 활성화되지 않도록 검증    |
+| E2E fixture               | 업로드 후 리뷰 진입과 체크포인트 액션은 검증됨                           | 진행 중 상태가 완료/실패로 바뀌는 fixture 기반 E2E를 추가                                 | 상태 전이 재현성을 확보                                  |
+
+## Component Tree
+
+```text
+PipelineReviewPage
+├─ status context panel
+└─ PipelineReviewCheckpointCard
+   ├─ StateActionCard
+   │  ├─ status copy
+   │  └─ refresh / next-action controls
+   ├─ Domain confirmation review
+   └─ Human feedback review
+```
+
+## API Integration
+
+| Method | Path                                                                               | Description                                          |
+| ------ | ---------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| GET    | `/api/v1/workspaces/{workspaceId}/pipeline-jobs/{pipelineJobId}/review-checkpoint` | pipeline job의 현재 체크포인트, 상태, 리뷰 작업 조회 |
+
+- 기존 generated endpoint `getCheckpoint`를 계속 사용한다.
+- 새 API, DTO, schema, OpenAPI generated code 변경은 없다.
+- React Query query key는 기존 `["pipeline-review-checkpoint", workspaceId, pipelineJobId]`를 유지한다.
+
+## 수정 대상 파일
+
+| 파일                                                                   | 변경 유형 | 설명                                                                            |
+| ---------------------------------------------------------------------- | --------- | ------------------------------------------------------------------------------- |
+| `frontend/src/features/pipeline-review/api/pipelineReviewApi.ts`       | modify    | 진행 중인 체크포인트 없는 상태에서 자동 재조회 여부를 판단하는 query 옵션 추가  |
+| `frontend/src/features/pipeline-review/api/pipelineReviewApi.test.tsx` | modify    | polling 판단과 generated API 위임 동작 검증                                     |
+| `frontend/src/pages/pipeline-review/ui/PipelineReviewPage.tsx`         | modify    | 페이지 수준 체크포인트 query에 자동 재조회를 적용                               |
+| `frontend/e2e/support/app-mocks.ts`                                    | modify    | 진행 중에서 완료/실패로 전이되는 pipeline review fixture 추가                   |
+| `frontend/e2e/workspace-core.spec.ts`                                  | modify    | 운영자가 재조회 후 최신 완료/실패 상태와 다음 행동을 확인하는 E2E 시나리오 추가 |
+
+## State Management
+
+- Server state는 TanStack Query로 유지한다.
+- `PipelineReviewPage`와 `PipelineReviewCheckpointCard`는 동일한 checkpoint query key를 공유하므로 페이지 수준 재조회 결과가 카드에도 반영되어야 한다.
+- 진행 중이면서 활성 리뷰 작업이 없는 상태는 자동 polling 대상이다.
+- `SUCCEEDED`, `FAILED`, `CANCELLED` 같은 최종 상태와 `DOMAIN_CONFIRMATION`, `HUMAN_FEEDBACK`처럼 운영자 입력을 기다리는 활성 리뷰 상태는 자동 polling을 멈춘다.
+- 수동 재조회 버튼은 기존처럼 `query.refetch()`를 호출해 staleTime과 무관하게 최신 상태를 요청해야 한다.
+
+## Tests
+
+### Test Strategy
+
+| 구분           | 방법                                      | 도구                           | 비고                                 |
+| -------------- | ----------------------------------------- | ------------------------------ | ------------------------------------ |
+| 훅 단위 테스트 | polling 판단과 query 옵션 검증            | Vitest + React Testing Library | 기존 `pipelineReviewApi` 테스트 확장 |
+| E2E 테스트     | mock fixture 상태 전이 후 UI/CTA/URL 검증 | Playwright                     | 완료/실패 전이를 안정적으로 재현     |
+
+### Test Scenarios
+
+| #   | Given                                                                     | When                         | Then                                                                                |
+| --- | ------------------------------------------------------------------------- | ---------------------------- | ----------------------------------------------------------------------------------- |
+| 1   | 운영자가 `/workspaces/1/pipeline-jobs/902/review`에서 RUNNING 상태를 본다 | 상태를 재조회한다            | 같은 URL에서 SUCCEEDED 상태와 도메인팩 관리 CTA가 표시된다                          |
+| 2   | 운영자가 `/workspaces/1/pipeline-jobs/903/review`에서 RUNNING 상태를 본다 | 상태를 재조회한다            | 같은 URL에서 FAILED 상태와 업로드 재시도 CTA가 표시되고, 성공 CTA는 노출되지 않는다 |
+| 3   | checkpoint query가 진행 중 상태를 받는다                                  | 자동 재조회 옵션이 켜져 있다 | polling interval이 활성화된다                                                       |
+| 4   | checkpoint query가 완료/실패/취소 또는 활성 리뷰 상태를 받는다            | 자동 재조회 옵션이 켜져 있다 | polling interval이 비활성화된다                                                     |
+
+## Non-goals
+
+- 새 백엔드 endpoint, schema, 권한 정책을 만들지 않는다.
+- Airflow 실제 상태 전이를 E2E에서 호출하지 않는다.
+- 리뷰 작업 제출 플로우 자체를 변경하지 않는다.
+- 도메인팩 승인 화면의 후속 workflow를 이 이슈에서 확장하지 않는다.
+
+## Validation Expectations
+
+- `pnpm --dir frontend test -- pipelineReviewApi PipelineReviewPage PipelineReviewCheckpointCard`
+- `pnpm --dir frontend e2e -- workspace-core.spec.ts`
+- 필요 시 `pnpm --dir frontend build`
+
+## Open Questions
+
+- 없음. 이 이슈의 기술 확인 메모는 구현 전 조사 결과로 기존 수동 refresh와 query 기반 화면 구조가 확인되었고, 안정적인 mock fixture로 전이 상태를 고정한다.

--- a/frontend/e2e/support/app-mocks.ts
+++ b/frontend/e2e/support/app-mocks.ts
@@ -35,6 +35,10 @@ export interface AppApiMockOptions {
   readonly uploadLatestPipelineJob?: "default" | "none";
 }
 
+interface PipelineReviewMockState {
+  pipelineReviewStatusRequests: Record<number, number>;
+}
+
 const now = "2026-06-04T09:00:00+09:00";
 
 const workspace = {
@@ -1351,6 +1355,7 @@ async function fulfillUploadAndReview(
   method: string,
   path: string,
   options: AppApiMockOptions,
+  state: PipelineReviewMockState,
 ): Promise<boolean> {
   if (method === "POST" && path === "/workspaces/1/datasets/uploads:init") {
     await fulfillJson(route, {
@@ -1480,6 +1485,16 @@ async function fulfillUploadAndReview(
     return true;
   }
 
+  if (method === "GET" && path === "/workspaces/1/pipeline-jobs/902/review-checkpoint") {
+    await fulfillJson(route, transitionCheckpoint(state, 902, "SUCCEEDED"));
+    return true;
+  }
+
+  if (method === "GET" && path === "/workspaces/1/pipeline-jobs/903/review-checkpoint") {
+    await fulfillJson(route, transitionCheckpoint(state, 903, "FAILED"));
+    return true;
+  }
+
   if (
     method === "POST" &&
     path === "/workspaces/1/pipeline-jobs/900/review-checkpoint/domain-confirmation"
@@ -1501,6 +1516,22 @@ async function fulfillUploadAndReview(
   }
 
   return false;
+}
+
+function transitionCheckpoint(
+  state: PipelineReviewMockState,
+  pipelineJobId: number,
+  finalStatus: "SUCCEEDED" | "FAILED",
+) {
+  const seenCount = state.pipelineReviewStatusRequests[pipelineJobId] ?? 0;
+  state.pipelineReviewStatusRequests[pipelineJobId] = seenCount + 1;
+
+  return {
+    pipelineJobId,
+    pipelineStatus: seenCount === 0 ? "RUNNING" : finalStatus,
+    reviewKind: null,
+    tasks: [],
+  };
 }
 
 async function fulfillSimulation(
@@ -1721,6 +1752,7 @@ export async function installAppApiMocks(
     currentVersionId: VERSION_ID,
     currentVersionNo: 1,
   };
+  const pipelineReviewState: PipelineReviewMockState = { pipelineReviewStatusRequests: {} };
   const simulationState = createSimulationState();
   const billingState = createBillingMockState();
 
@@ -1734,7 +1766,8 @@ export async function installAppApiMocks(
     if (await fulfillDomainPackRead(route, method, path, domainPackState)) return true;
     if (await fulfillBilling(route, method, path, billingState)) return true;
     if (await fulfillWorkspaceOperations(route, method, path, url)) return true;
-    if (await fulfillUploadAndReview(route, method, path, options)) return true;
+    if (await fulfillUploadAndReview(route, method, path, options, pipelineReviewState))
+      return true;
     if (await fulfillSimulation(route, method, path, url, simulationState)) return true;
     return false;
   });

--- a/frontend/e2e/workspace-core.spec.ts
+++ b/frontend/e2e/workspace-core.spec.ts
@@ -343,6 +343,50 @@ test.describe("Workspace core operator screens", () => {
       });
     });
 
+    test.describe("When they refresh pipeline review progress", () => {
+      test("Then the latest completion and failure actions replace the stale running state", async ({
+        page,
+      }) => {
+        await page.goto("/workspaces/1/pipeline-jobs/902/review");
+        await expect(page.getByLabel("파이프라인 리뷰 맥락")).toContainText("RUNNING");
+        await expect(page.getByText("활성 리뷰 체크포인트가 없습니다.")).toBeVisible();
+
+        await page.getByRole("button", { name: "상태 새로고침" }).click();
+
+        await expect(page).toHaveURL(/\/workspaces\/1\/pipeline-jobs\/902\/review/);
+        await expect(page.getByLabel("파이프라인 리뷰 맥락")).toContainText("파이프라인 완료");
+        await expect(page.getByText("리뷰 체크포인트가 완료되었습니다.")).toBeVisible();
+        await expect(page.getByRole("link", { name: "도메인팩 관리로 이동" })).toBeVisible();
+        await expect
+          .poll(
+            () =>
+              seen.filter(
+                (entry) => entry === "GET /workspaces/1/pipeline-jobs/902/review-checkpoint",
+              ).length,
+          )
+          .toBeGreaterThanOrEqual(2);
+
+        await page.goto("/workspaces/1/pipeline-jobs/903/review");
+        await expect(page.getByLabel("파이프라인 리뷰 맥락")).toContainText("RUNNING");
+
+        await page.getByRole("button", { name: "상태 새로고침" }).click();
+
+        await expect(page).toHaveURL(/\/workspaces\/1\/pipeline-jobs\/903\/review/);
+        await expect(page.getByLabel("파이프라인 리뷰 맥락")).toContainText("파이프라인 실패");
+        await expect(page.getByText("파이프라인이 실패했습니다.")).toBeVisible();
+        await expect(page.getByRole("link", { name: "업로드 다시 시작" })).toBeVisible();
+        await expect(page.getByRole("link", { name: "도메인팩 관리로 이동" })).toHaveCount(0);
+        await expect
+          .poll(
+            () =>
+              seen.filter(
+                (entry) => entry === "GET /workspaces/1/pipeline-jobs/903/review-checkpoint",
+              ).length,
+          )
+          .toBeGreaterThanOrEqual(2);
+      });
+    });
+
     test.describe("When they run a simulation and save feedback", () => {
       test("Then runtime state, feedback, and improvement candidate actions work", async ({
         page,

--- a/frontend/src/features/pipeline-review/api/pipelineReviewApi.test.tsx
+++ b/frontend/src/features/pipeline-review/api/pipelineReviewApi.test.tsx
@@ -8,6 +8,7 @@ import {
   submitFeedback,
 } from "@/shared/api/generated/endpoints/pipeline-review-controller/pipeline-review-controller";
 import {
+  shouldPollPipelineReviewCheckpoint,
   useConfirmPipelineDomain,
   usePipelineReviewCheckpoint,
   useSubmitPipelineFeedback,
@@ -40,6 +41,33 @@ beforeEach(() => {
 });
 
 describe("pipelineReviewApi", () => {
+  it.each([
+    ["RUNNING", null, true],
+    ["QUEUED", null, true],
+    ["WAITING_DOMAIN_CONFIRMATION", null, true],
+    ["WAITING_DOMAIN_CONFIRMATION", "DOMAIN_CONFIRMATION", false],
+    ["WAITING_HUMAN_FEEDBACK", "HUMAN_FEEDBACK", false],
+    ["SUCCEEDED", null, false],
+    ["FAILED", null, false],
+    ["CANCELLED", null, false],
+  ] as const)(
+    "returns the polling decision for status %s and review kind %s",
+    (pipelineStatus, reviewKind, expected) => {
+      expect(
+        shouldPollPipelineReviewCheckpoint({
+          pipelineJobId: 7,
+          pipelineStatus,
+          reviewKind,
+          tasks: [],
+        }),
+      ).toBe(expected);
+    },
+  );
+
+  it("polls until the first checkpoint payload is available when auto refresh is enabled", () => {
+    expect(shouldPollPipelineReviewCheckpoint()).toBe(true);
+  });
+
   it("delegates checkpoint query to generated getCheckpoint and unwraps data", async () => {
     const checkpoint = {
       pipelineJobId: 7,
@@ -57,6 +85,39 @@ describe("pipelineReviewApi", () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(mockedGetCheckpoint).toHaveBeenCalledWith(1, 7);
     expect(result.current.data).toEqual(checkpoint);
+  });
+
+  it("keeps polling active pipeline progress when auto refresh is enabled", async () => {
+    const runningCheckpoint = {
+      pipelineJobId: 7,
+      pipelineStatus: "RUNNING",
+      reviewKind: null,
+      tasks: [],
+    };
+    const succeededCheckpoint = {
+      pipelineJobId: 7,
+      pipelineStatus: "SUCCEEDED",
+      reviewKind: null,
+      tasks: [],
+    };
+    mockedGetCheckpoint
+      .mockResolvedValueOnce({
+        data: runningCheckpoint,
+        status: 200,
+      } as unknown as Awaited<ReturnType<typeof getCheckpoint>>)
+      .mockResolvedValueOnce({
+        data: succeededCheckpoint,
+        status: 200,
+      } as unknown as Awaited<ReturnType<typeof getCheckpoint>>);
+
+    const { result } = renderHook(
+      () => usePipelineReviewCheckpoint(1, 7, { autoRefresh: true, refetchIntervalMs: 100 }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.data).toEqual(runningCheckpoint));
+    await waitFor(() => expect(result.current.data).toEqual(succeededCheckpoint));
+    expect(mockedGetCheckpoint).toHaveBeenCalledTimes(2);
   });
 
   it("does not fetch checkpoint until ids are available", () => {

--- a/frontend/src/features/pipeline-review/api/pipelineReviewApi.ts
+++ b/frontend/src/features/pipeline-review/api/pipelineReviewApi.ts
@@ -57,6 +57,14 @@ export interface ReviewCheckpointView {
   tasks: ReviewTaskView[];
 }
 
+interface PipelineReviewCheckpointOptions {
+  autoRefresh?: boolean;
+  refetchIntervalMs?: number;
+}
+
+const FINAL_PIPELINE_STATUSES = new Set(["SUCCEEDED", "FAILED", "CANCELLED"]);
+const PIPELINE_REVIEW_AUTO_REFRESH_INTERVAL_MS = 5_000;
+
 const checkpointQueryKey = (workspaceId?: number, pipelineJobId?: number) =>
   ["pipeline-review-checkpoint", workspaceId, pipelineJobId] as const;
 
@@ -67,7 +75,23 @@ function requirePipelineReviewIds(workspaceId?: number, pipelineJobId?: number) 
   return { workspaceId, pipelineJobId };
 }
 
-export function usePipelineReviewCheckpoint(workspaceId?: number, pipelineJobId?: number) {
+export function shouldPollPipelineReviewCheckpoint(checkpoint?: ReviewCheckpointView): boolean {
+  if (!checkpoint) {
+    return true;
+  }
+  if (checkpoint.reviewKind) {
+    return false;
+  }
+  return !FINAL_PIPELINE_STATUSES.has(checkpoint.pipelineStatus);
+}
+
+export function usePipelineReviewCheckpoint(
+  workspaceId?: number,
+  pipelineJobId?: number,
+  options: PipelineReviewCheckpointOptions = {},
+) {
+  const refetchIntervalMs = options.refetchIntervalMs ?? PIPELINE_REVIEW_AUTO_REFRESH_INTERVAL_MS;
+
   return useQuery({
     queryKey: checkpointQueryKey(workspaceId, pipelineJobId),
     enabled: workspaceId != null && pipelineJobId != null,
@@ -79,6 +103,9 @@ export function usePipelineReviewCheckpoint(workspaceId?: number, pipelineJobId?
         "리뷰 체크포인트 응답을 확인할 수 없습니다.",
       );
     },
+    refetchInterval: options.autoRefresh
+      ? (query) => (shouldPollPipelineReviewCheckpoint(query.state.data) ? refetchIntervalMs : false)
+      : false,
   });
 }
 

--- a/frontend/src/pages/pipeline-review/ui/PipelineReviewPage.test.tsx
+++ b/frontend/src/pages/pipeline-review/ui/PipelineReviewPage.test.tsx
@@ -61,6 +61,7 @@ describe("PipelineReviewPage", () => {
     expect(screen.getByText("초안 생성 전에 파이프라인 입력을 확정합니다.")).toBeInTheDocument();
     expect(screen.getByText("사람 피드백 대기")).toBeInTheDocument();
     expect(screen.getByTestId("checkpoint-card")).toHaveTextContent("1:7");
+    expect(mockedUseCheckpoint).toHaveBeenCalledWith(1, 7, { autoRefresh: true });
     await waitFor(() => expect(screen.getByTestId("crumbs")).toHaveTextContent("Pipeline review"));
   });
 

--- a/frontend/src/pages/pipeline-review/ui/PipelineReviewPage.tsx
+++ b/frontend/src/pages/pipeline-review/ui/PipelineReviewPage.tsx
@@ -14,6 +14,7 @@ export function PipelineReviewPage() {
   const checkpointQuery = usePipelineReviewCheckpoint(
     parsedWorkspaceId ?? undefined,
     parsedPipelineJobId ?? undefined,
+    { autoRefresh: true },
   );
 
   useEffect(() => {


### PR DESCRIPTION
Closes #712

## 변경 사항

- 이슈 712 요구사항과 acceptance criteria를 `.agent/specs/712.md`에 정리했습니다.
- pipeline review checkpoint query가 활성 리뷰 작업이 없는 진행 중 상태에서 자동 재조회하고, 완료/실패/취소 또는 운영자 입력 대기 상태에서는 polling을 멈추도록 했습니다.
- 리뷰 화면이 자동 재조회 옵션을 사용하도록 연결하고, 페이지 테스트에서 해당 wiring과 자동 polling 전이를 고정했습니다.
- mocked workspace E2E에 `RUNNING -> SUCCEEDED`와 `RUNNING -> FAILED` 전이 fixture를 추가해 수동 새로고침 후 같은 job URL에서 완료/실패 CTA가 갱신되는지 검증했습니다.

## 검증

- `pnpm --dir frontend test -- pipelineReviewApi PipelineReviewPage PipelineReviewCheckpointCard` (3 files, 36 tests)
- `pnpm run test:frontend:coverage` (282 files, 2159 tests, statements 84.53%)
- `pnpm --dir frontend e2e -- workspace-core.spec.ts --grep "refresh pipeline review progress"` (13 passed)
- `git diff --check`

## 참고

- 구현 전 `pipelineReviewApi`, `PipelineReviewPage`, `PipelineReviewCheckpointCard`, `workspace-core.spec.ts`, `app-mocks.ts`, `frontend/DESIGN.md`, frontend FSD/API/test rules를 확인했습니다.
- self-review 3회 수행: issue fidelity/behavior 관점에서 page auto-refresh wiring 테스트 누락을 발견해 보강했고, frontend integration boundary와 reviewer·CI risk 관점에서 추가 수정 사항은 없었습니다. Sonar 신규 coverage 게이트 실패 후 자동 polling 전이 테스트를 추가하고 동일 관점으로 재검토했습니다. 이후 최신 `main` rebase 충돌은 E2E mock state와 simulation URL 인자를 함께 보존하도록 해결하고 동일 focused/coverage 검증을 재수행했습니다.
- 커밋 hook은 실행하지 않았습니다(`HUSKY=0`). 변경 범위는 위 검증 명령으로 확인했습니다.