### PR TITLE
test(frontend): policy/risk JSON 저장 가드를 Critical E2E로 보장

### DIFF
--- a/.agent/specs/722.md
+++ b/.agent/specs/722.md
@@ -1,0 +1,99 @@
+# Frontend E2E Spec: policy/risk JSON 저장 가드 Critical 편입
+
+## Goal
+
+운영자가 Domain Pack의 응대 기준(policy) 또는 주의 사항(risk)을 수정할 때 잘못된 JSON이 저장되지 않고, 같은 화면에서 오류를 확인한 뒤 유효한 JSON으로 저장할 수 있음을 Critical E2E로 보장한다.
+
+## Issue Summary
+
+GitHub Issue #722는 policy/risk 상세 편집 패널에서 조건, 액션, 근거, 메타 JSON 입력이 잘못되었을 때 저장 요청이 실행되지 않아야 한다는 사용자 시나리오를 다룬다. 기존 `frontend/e2e/domain-pack-core.spec.ts`에는 policy/risk invalid JSON 차단과 valid save 테스트가 있으므로, 이 작업은 해당 흐름을 Critical 그룹으로 명시하고 필드별 오류 메시지 검증을 보강한다.
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A["Domain Pack policy/risk list"] --> B["Open detail panel"]
+    B --> C["Open edit panel"]
+    C --> D{"JSON input valid?"}
+    D -->|"No"| E["Show field-specific JSON error"]
+    E --> F["Keep edit panel open"]
+    F --> C
+    D -->|"Yes"| G["Send update request"]
+    G --> H["Show save feedback and updated detail"]
+```
+
+## Design Diff
+
+| 영역                  | As-is                                                                                | To-be                                                            | 변경 내용                                                               |
+| --------------------- | ------------------------------------------------------------------------------------ | ---------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| Critical E2E grouping | policy/risk edit tests exist in `domain-pack-core.spec.ts` without a Critical marker | policy/risk edit describe group is marked with `[@critical]`     | Playwright title grep로 Critical 시나리오를 선별할 수 있게 함           |
+| Invalid JSON E2E      | policy 조건 JSON, risk 트리거 조건 JSON만 화면 오류를 확인                           | policy/risk의 조건/액션/근거/메타 JSON 필드별 오류 메시지를 확인 | 사용자가 어떤 JSON이 잘못되었는지 같은 편집 화면에서 확인 가능함을 고정 |
+| PATCH guard           | invalid JSON에서 update PATCH 미발생만 보조 확인                                     | 필드별 invalid 저장 시 update PATCH 미발생을 유지                | 잘못된 운영 기준 저장 방지 회귀를 보강                                  |
+| 상태 변경 분리        | policy/risk status switch가 각 endpoint로 요청되는지 확인                            | 반대 타입 status endpoint가 호출되지 않는지도 확인               | policy/risk 상태 변경이 서로 다른 항목에 적용되지 않음을 보조 검증      |
+
+## Component Tree
+
+```text
+frontend/e2e/domain-pack-core.spec.ts
+└─ Domain pack core read flows
+   └─ Given generated domain packs in a workspace
+      └─ [@critical] Policy/risk JSON edit safeguards
+         ├─ When they edit a policy from the detail panel
+         └─ When they edit a risk from the detail panel
+```
+
+## API Integration
+
+테스트는 기존 Playwright mock과 API 호출 추적 배열을 사용한다.
+
+| Method  | Path                                                                 | 목적                    |
+| ------- | -------------------------------------------------------------------- | ----------------------- |
+| `GET`   | `/api/v1/workspaces/1/domain-packs/1/versions/1/policies`            | policy 목록 조회        |
+| `GET`   | `/api/v1/workspaces/1/domain-packs/1/versions/1/policies/101`        | policy 상세 조회        |
+| `PATCH` | `/api/v1/workspaces/1/domain-packs/1/versions/1/policies/101`        | 유효한 policy 수정 저장 |
+| `PATCH` | `/api/v1/workspaces/1/domain-packs/1/versions/1/policies/101/status` | policy 상태 변경        |
+| `GET`   | `/api/v1/workspaces/1/domain-packs/1/versions/1/risks`               | risk 목록 조회          |
+| `GET`   | `/api/v1/workspaces/1/domain-packs/1/versions/1/risks/201`           | risk 상세 조회          |
+| `PATCH` | `/api/v1/workspaces/1/domain-packs/1/versions/1/risks/201`           | 유효한 risk 수정 저장   |
+| `PATCH` | `/api/v1/workspaces/1/domain-packs/1/versions/1/risks/201/status`    | risk 상태 변경          |
+
+## 수정 대상 파일
+
+| 파일                                    | 변경 유형 | 설명                                                                                                      |
+| --------------------------------------- | --------- | --------------------------------------------------------------------------------------------------------- |
+| `.agent/specs/722.md`                   | new       | Issue #722 요구사항과 검증 기준 기록                                                                      |
+| `frontend/e2e/domain-pack-core.spec.ts` | modify    | policy/risk JSON validation, valid save, status 분리 흐름을 Critical E2E로 명시하고 필드별 오류 검증 보강 |
+
+## State Management
+
+- 제품 상태 관리와 generated API client는 변경하지 않는다.
+- E2E는 기존 `installAuth`, `installAppApiMocks`, `seen` 호출 추적을 그대로 사용한다.
+- invalid JSON 검증은 편집 패널을 닫지 않고 각 필드 값을 유효한 JSON으로 되돌린 뒤 다음 필드를 검증한다.
+
+## Acceptance Criteria
+
+- policy/risk 편집 E2E는 Playwright title grep으로 식별 가능한 `[@critical]` 그룹 아래에 있다.
+- policy 편집에서 조건 JSON, 액션 JSON, 근거 JSON, 메타 JSON이 잘못된 구조일 때 각각 사용자 오류 메시지가 보인다.
+- risk 편집에서 트리거 조건 JSON, 처리 액션 JSON, 근거 JSON, 메타 JSON이 잘못된 구조일 때 각각 사용자 오류 메시지가 보인다.
+- invalid JSON 저장 시 policy/risk update PATCH 요청은 발생하지 않는다.
+- valid JSON 저장 시 저장 완료 피드백과 상세 패널의 변경된 이름을 확인한다.
+- policy 상태 변경 테스트는 risk status endpoint를 호출하지 않음을 확인한다.
+- risk 상태 변경 테스트는 policy status endpoint를 호출하지 않음을 확인한다.
+
+## Non-goals
+
+- backend API contract, OpenAPI generated file, database schema는 변경하지 않는다.
+- policy/risk 편집 UI 문구나 validation schema를 변경하지 않는다.
+- 별도의 Playwright Critical 전용 config나 CI job을 추가하지 않는다.
+- live E2E 또는 운영 백엔드 의존 테스트를 추가하지 않는다.
+
+## Validation
+
+| 검증                                                                                 | 목적                                         |
+| ------------------------------------------------------------------------------------ | -------------------------------------------- |
+| `cd frontend && pnpm exec playwright test domain-pack-core.spec.ts --grep @critical` | Critical policy/risk JSON 편집 시나리오 실행 |
+| `cd frontend && pnpm exec eslint e2e/domain-pack-core.spec.ts`                       | 변경된 E2E TypeScript lint 확인              |
+
+## Open Questions
+
+- 없음. 현재 저장 차단 기준은 기존 policy/risk edit schema의 사용자 메시지를 따른다.

--- a/frontend/e2e/domain-pack-core.spec.ts
+++ b/frontend/e2e/domain-pack-core.spec.ts
@@ -1,7 +1,46 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 
 import { installAuth } from "./support/generated-api-auth";
 import { captureScreen, installAppApiMocks } from "./support/app-mocks";
+
+const POLICY_UPDATE_ENTRY =
+  "PATCH /workspaces/1/domain-packs/1/versions/1/policies/101";
+const POLICY_STATUS_ENTRY =
+  "PATCH /workspaces/1/domain-packs/1/versions/1/policies/101/status";
+const RISK_UPDATE_ENTRY =
+  "PATCH /workspaces/1/domain-packs/1/versions/1/risks/201";
+const RISK_STATUS_ENTRY =
+  "PATCH /workspaces/1/domain-packs/1/versions/1/risks/201/status";
+
+interface JsonValidationCase {
+  label: string;
+  invalidValue: string;
+  validValue: string;
+  message: string;
+}
+
+async function expectJsonValidationBlocksUpdate(
+  page: Page,
+  seen: string[],
+  updateEntry: string,
+  cases: JsonValidationCase[],
+) {
+  for (const fieldCase of cases) {
+    const updateCountBefore = seen.filter(
+      (entry) => entry === updateEntry,
+    ).length;
+
+    await page.getByLabel(fieldCase.label).fill(fieldCase.invalidValue);
+    await page.getByRole("button", { name: "저장" }).click();
+
+    await expect(page.getByText(fieldCase.message)).toBeVisible();
+    expect(seen.filter((entry) => entry === updateEntry)).toHaveLength(
+      updateCountBefore,
+    );
+
+    await page.getByLabel(fieldCase.label).fill(fieldCase.validValue);
+  }
+}
 
 test.describe("Domain pack core read flows", () => {
   let seen: string[];
@@ -148,183 +187,307 @@ test.describe("Domain pack core read flows", () => {
       });
     });
 
-    test.describe("When they edit a policy from the detail panel", () => {
-      test("Then invalid JSON is blocked before the policy update request", async ({ page }) => {
-        await page.goto("/workspaces/1/domain-packs/1/policies?versionId=1");
-        await page.getByRole("button", { name: /POL_REFUND/ }).click();
-        await expect(page.getByLabel("응대 기준 상세")).toContainText("환불 정책");
+    test.describe("[@critical] Policy/risk JSON edit safeguards", () => {
+      test.describe("When they edit a policy from the detail panel", () => {
+        test("Then invalid JSON is blocked before the policy update request", async ({
+          page,
+        }) => {
+          await page.goto("/workspaces/1/domain-packs/1/policies?versionId=1");
+          await page.getByRole("button", { name: /POL_REFUND/ }).click();
+          await expect(page.getByLabel("응대 기준 상세")).toContainText(
+            "환불 정책",
+          );
 
-        await page.getByRole("button", { name: /POL_REFUND 응대 기준 수정/ }).click();
-        await expect(page.getByLabel("응대 기준 수정")).toBeVisible();
+          await page
+            .getByRole("button", { name: /POL_REFUND 응대 기준 수정/ })
+            .click();
+          await expect(page.getByLabel("응대 기준 수정")).toBeVisible();
 
-        await page.getByLabel("조건 JSON").fill("[]");
-        await page.getByRole("button", { name: "저장" }).click();
-        await expect(page.getByText("적용 조건 JSON은 객체여야 합니다.")).toBeVisible();
-        expect(
-          seen.some(
-            (entry) => entry === "PATCH /workspaces/1/domain-packs/1/versions/1/policies/101",
-          ),
-        ).toBe(false);
+          await expectJsonValidationBlocksUpdate(
+            page,
+            seen,
+            POLICY_UPDATE_ENTRY,
+            [
+              {
+                label: "조건 JSON",
+                invalidValue: "[]",
+                validValue: "{}",
+                message: "적용 조건 JSON은 객체여야 합니다.",
+              },
+              {
+                label: "액션 JSON",
+                invalidValue: "[]",
+                validValue: "{}",
+                message: "응대 방법 JSON은 객체여야 합니다.",
+              },
+              {
+                label: "근거 JSON",
+                invalidValue: "{}",
+                validValue: "[]",
+                message: "근거 JSON은 배열이어야 합니다.",
+              },
+              {
+                label: "메타 JSON",
+                invalidValue: "[]",
+                validValue: "{}",
+                message: "추가 정보 JSON은 객체여야 합니다.",
+              },
+            ],
+          );
+        });
+
+        test("Then a valid save updates the policy detail", async ({
+          page,
+        }, testInfo) => {
+          await page.goto("/workspaces/1/domain-packs/1/policies?versionId=1");
+          await page.getByRole("button", { name: /POL_REFUND/ }).click();
+
+          await page
+            .getByRole("button", { name: /POL_REFUND 응대 기준 수정/ })
+            .click();
+          await expect(page.getByLabel("응대 기준 수정")).toBeVisible();
+          await captureScreen(page, testInfo, "policy-edit-panel");
+
+          await page.getByLabel("이름 *").fill("고액 환불 정책");
+          await page.getByLabel("설명").fill("고액 환불은 검토 후 안내합니다.");
+          await page
+            .getByLabel("조건 JSON")
+            .fill(JSON.stringify({ amount: { gte: 100000 } }, null, 2));
+          await page
+            .getByLabel("액션 JSON")
+            .fill(JSON.stringify({ type: "MANUAL_REVIEW" }, null, 2));
+          await page
+            .getByLabel("근거 JSON")
+            .fill(JSON.stringify([{ segmentId: "seg-99" }], null, 2));
+          await page
+            .getByLabel("메타 JSON")
+            .fill(JSON.stringify({ source: "e2e" }, null, 2));
+          const updateRequest = page.waitForRequest(
+            (request) =>
+              request.method() === "PATCH" &&
+              request
+                .url()
+                .includes(
+                  "/workspaces/1/domain-packs/1/versions/1/policies/101",
+                ),
+          );
+          await page.getByRole("button", { name: "저장" }).click();
+          const requestBody = (await updateRequest).postDataJSON();
+
+          expect(requestBody).toEqual(
+            expect.objectContaining({
+              name: "고액 환불 정책",
+              description: "고액 환불은 검토 후 안내합니다.",
+              conditionJson: JSON.stringify(
+                { amount: { gte: 100000 } },
+                null,
+                2,
+              ),
+              actionJson: JSON.stringify({ type: "MANUAL_REVIEW" }, null, 2),
+              evidenceJson: JSON.stringify([{ segmentId: "seg-99" }], null, 2),
+              metaJson: JSON.stringify({ source: "e2e" }, null, 2),
+            }),
+          );
+
+          await expect(
+            page.getByText("응대 기준이 수정되었습니다."),
+          ).toBeVisible();
+          await expect(page.getByLabel("응대 기준 상세")).toContainText(
+            "고액 환불 정책",
+          );
+          expect(seen).toContain(POLICY_UPDATE_ENTRY);
+        });
+
+        test("Then the status switch updates request body and detail state", async ({
+          page,
+        }) => {
+          await page.goto("/workspaces/1/domain-packs/1/policies?versionId=1");
+          await page.getByRole("button", { name: /POL_REFUND/ }).click();
+
+          await page
+            .getByRole("button", { name: /POL_REFUND 응대 기준 수정/ })
+            .click();
+          const statusSwitch = page.getByRole("switch", {
+            name: "응대 기준 상태",
+          });
+          await expect(statusSwitch).toBeChecked();
+
+          const statusRequest = page.waitForRequest(
+            (request) =>
+              request.method() === "PATCH" &&
+              request
+                .url()
+                .includes(
+                  "/workspaces/1/domain-packs/1/versions/1/policies/101/status",
+                ),
+          );
+          await statusSwitch.click();
+          const requestBody = (await statusRequest).postDataJSON();
+
+          expect(requestBody).toEqual({ status: "INACTIVE" });
+          await expect(statusSwitch).not.toBeChecked();
+          await page.getByRole("button", { name: "취소" }).click();
+          await expect(page.getByLabel("응대 기준 상세")).toContainText(
+            "사용 안 함",
+          );
+          expect(seen).toContain(POLICY_STATUS_ENTRY);
+          expect(seen).not.toContain(RISK_STATUS_ENTRY);
+        });
       });
 
-      test("Then a valid save updates the policy detail", async ({ page }, testInfo) => {
-        await page.goto("/workspaces/1/domain-packs/1/policies?versionId=1");
-        await page.getByRole("button", { name: /POL_REFUND/ }).click();
+      test.describe("When they edit a risk from the detail panel", () => {
+        test("Then invalid JSON is blocked before the risk update request", async ({
+          page,
+        }) => {
+          await page.goto("/workspaces/1/domain-packs/1/risks?versionId=1");
+          await page.getByRole("button", { name: /RISK_FRAUD/ }).click();
+          await expect(page.getByLabel("주의 사항 상세")).toContainText(
+            "부정 환불 위험",
+          );
 
-        await page.getByRole("button", { name: /POL_REFUND 응대 기준 수정/ }).click();
-        await expect(page.getByLabel("응대 기준 수정")).toBeVisible();
-        await captureScreen(page, testInfo, "policy-edit-panel");
+          await page
+            .getByRole("button", { name: /RISK_FRAUD 주의 사항 수정/ })
+            .click();
+          await expect(page.getByLabel("주의 사항 수정")).toBeVisible();
 
-        await page.getByLabel("이름 *").fill("고액 환불 정책");
-        await page.getByLabel("설명").fill("고액 환불은 검토 후 안내합니다.");
-        await page
-          .getByLabel("조건 JSON")
-          .fill(JSON.stringify({ amount: { gte: 100000 } }, null, 2));
-        await page
-          .getByLabel("액션 JSON")
-          .fill(JSON.stringify({ type: "MANUAL_REVIEW" }, null, 2));
-        await page
-          .getByLabel("근거 JSON")
-          .fill(JSON.stringify([{ segmentId: "seg-99" }], null, 2));
-        await page.getByLabel("메타 JSON").fill(JSON.stringify({ source: "e2e" }, null, 2));
-        const updateRequest = page.waitForRequest(
-          (request) =>
-            request.method() === "PATCH" &&
-            request.url().includes("/workspaces/1/domain-packs/1/versions/1/policies/101"),
-        );
-        await page.getByRole("button", { name: "저장" }).click();
-        const requestBody = (await updateRequest).postDataJSON();
+          await expectJsonValidationBlocksUpdate(
+            page,
+            seen,
+            RISK_UPDATE_ENTRY,
+            [
+              {
+                label: "트리거 조건 JSON",
+                invalidValue: "[]",
+                validValue: "{}",
+                message: "감지 조건 JSON은 객체여야 합니다.",
+              },
+              {
+                label: "처리 액션 JSON",
+                invalidValue: "[]",
+                validValue: "{}",
+                message: "응대 방법 JSON은 객체여야 합니다.",
+              },
+              {
+                label: "근거 JSON",
+                invalidValue: "{}",
+                validValue: "[]",
+                message: "근거 JSON은 배열이어야 합니다.",
+              },
+              {
+                label: "메타 JSON",
+                invalidValue: "[]",
+                validValue: "{}",
+                message: "추가 정보 JSON은 객체여야 합니다.",
+              },
+            ],
+          );
+        });
 
-        expect(requestBody).toEqual(
-          expect.objectContaining({
-            name: "고액 환불 정책",
-            description: "고액 환불은 검토 후 안내합니다.",
-            conditionJson: JSON.stringify({ amount: { gte: 100000 } }, null, 2),
-            actionJson: JSON.stringify({ type: "MANUAL_REVIEW" }, null, 2),
-            evidenceJson: JSON.stringify([{ segmentId: "seg-99" }], null, 2),
-            metaJson: JSON.stringify({ source: "e2e" }, null, 2),
-          }),
-        );
+        test("Then a valid save updates the risk detail", async ({
+          page,
+        }, testInfo) => {
+          await page.goto("/workspaces/1/domain-packs/1/risks?versionId=1");
+          await page.getByRole("button", { name: /RISK_FRAUD/ }).click();
 
-        await expect(page.getByText("응대 기준이 수정되었습니다.")).toBeVisible();
-        await expect(page.getByLabel("응대 기준 상세")).toContainText("고액 환불 정책");
-        expect(seen).toContain("PATCH /workspaces/1/domain-packs/1/versions/1/policies/101");
-      });
+          await page
+            .getByRole("button", { name: /RISK_FRAUD 주의 사항 수정/ })
+            .click();
+          await expect(page.getByLabel("주의 사항 수정")).toBeVisible();
+          await captureScreen(page, testInfo, "risk-edit-panel");
 
-      test("Then the status switch updates request body and detail state", async ({ page }) => {
-        await page.goto("/workspaces/1/domain-packs/1/policies?versionId=1");
-        await page.getByRole("button", { name: /POL_REFUND/ }).click();
+          await page.getByLabel("이름 *").fill("고액 환불 위험");
+          await page
+            .getByLabel("설명")
+            .fill("고액 환불은 상담사 검토로 전환합니다.");
+          await page
+            .getByLabel("트리거 조건 JSON")
+            .fill(JSON.stringify({ amount: { gte: 100000 } }, null, 2));
+          await page
+            .getByLabel("처리 액션 JSON")
+            .fill(JSON.stringify({ type: "MANUAL_REVIEW" }, null, 2));
+          await page
+            .getByLabel("근거 JSON")
+            .fill(JSON.stringify([{ segmentId: "risk-seg-99" }], null, 2));
+          await page
+            .getByLabel("메타 JSON")
+            .fill(JSON.stringify({ source: "e2e" }, null, 2));
+          const updateRequest = page.waitForRequest(
+            (request) =>
+              request.method() === "PATCH" &&
+              request
+                .url()
+                .includes("/workspaces/1/domain-packs/1/versions/1/risks/201"),
+          );
+          await page.getByRole("button", { name: "저장" }).click();
+          const requestBody = (await updateRequest).postDataJSON();
 
-        await page.getByRole("button", { name: /POL_REFUND 응대 기준 수정/ }).click();
-        const statusSwitch = page.getByRole("switch", { name: "응대 기준 상태" });
-        await expect(statusSwitch).toBeChecked();
+          expect(requestBody).toEqual(
+            expect.objectContaining({
+              name: "고액 환불 위험",
+              description: "고액 환불은 상담사 검토로 전환합니다.",
+              triggerConditionJson: JSON.stringify(
+                { amount: { gte: 100000 } },
+                null,
+                2,
+              ),
+              handlingActionJson: JSON.stringify(
+                { type: "MANUAL_REVIEW" },
+                null,
+                2,
+              ),
+              evidenceJson: JSON.stringify(
+                [{ segmentId: "risk-seg-99" }],
+                null,
+                2,
+              ),
+              metaJson: JSON.stringify({ source: "e2e" }, null, 2),
+            }),
+          );
 
-        const statusRequest = page.waitForRequest(
-          (request) =>
-            request.method() === "PATCH" &&
-            request
-              .url()
-              .includes("/workspaces/1/domain-packs/1/versions/1/policies/101/status"),
-        );
-        await statusSwitch.click();
-        const requestBody = (await statusRequest).postDataJSON();
+          await expect(
+            page.getByText("주의 사항이 수정되었습니다."),
+          ).toBeVisible();
+          await expect(page.getByLabel("주의 사항 상세")).toContainText(
+            "고액 환불 위험",
+          );
+          expect(seen).toContain(RISK_UPDATE_ENTRY);
+        });
 
-        expect(requestBody).toEqual({ status: "INACTIVE" });
-        await expect(statusSwitch).not.toBeChecked();
-        await page.getByRole("button", { name: "취소" }).click();
-        await expect(page.getByLabel("응대 기준 상세")).toContainText("사용 안 함");
-        expect(seen).toContain(
-          "PATCH /workspaces/1/domain-packs/1/versions/1/policies/101/status",
-        );
-      });
-    });
+        test("Then the status switch updates request body and detail state", async ({
+          page,
+        }) => {
+          await page.goto("/workspaces/1/domain-packs/1/risks?versionId=1");
+          await page.getByRole("button", { name: /RISK_FRAUD/ }).click();
 
-    test.describe("When they edit a risk from the detail panel", () => {
-      test("Then invalid JSON is blocked before the risk update request", async ({ page }) => {
-        await page.goto("/workspaces/1/domain-packs/1/risks?versionId=1");
-        await page.getByRole("button", { name: /RISK_FRAUD/ }).click();
-        await expect(page.getByLabel("주의 사항 상세")).toContainText("부정 환불 위험");
+          await page
+            .getByRole("button", { name: /RISK_FRAUD 주의 사항 수정/ })
+            .click();
+          const statusSwitch = page.getByRole("switch", {
+            name: "주의 사항 상태",
+          });
+          await expect(statusSwitch).toBeChecked();
 
-        await page.getByRole("button", { name: /RISK_FRAUD 주의 사항 수정/ }).click();
-        await expect(page.getByLabel("주의 사항 수정")).toBeVisible();
+          const statusRequest = page.waitForRequest(
+            (request) =>
+              request.method() === "PATCH" &&
+              request
+                .url()
+                .includes(
+                  "/workspaces/1/domain-packs/1/versions/1/risks/201/status",
+                ),
+          );
+          await statusSwitch.click();
+          const requestBody = (await statusRequest).postDataJSON();
 
-        await page.getByLabel("트리거 조건 JSON").fill("[]");
-        await page.getByRole("button", { name: "저장" }).click();
-        await expect(page.getByText("감지 조건 JSON은 객체여야 합니다.")).toBeVisible();
-        expect(
-          seen.some(
-            (entry) => entry === "PATCH /workspaces/1/domain-packs/1/versions/1/risks/201",
-          ),
-        ).toBe(false);
-      });
-
-      test("Then a valid save updates the risk detail", async ({ page }, testInfo) => {
-        await page.goto("/workspaces/1/domain-packs/1/risks?versionId=1");
-        await page.getByRole("button", { name: /RISK_FRAUD/ }).click();
-
-        await page.getByRole("button", { name: /RISK_FRAUD 주의 사항 수정/ }).click();
-        await expect(page.getByLabel("주의 사항 수정")).toBeVisible();
-        await captureScreen(page, testInfo, "risk-edit-panel");
-
-        await page.getByLabel("이름 *").fill("고액 환불 위험");
-        await page.getByLabel("설명").fill("고액 환불은 상담사 검토로 전환합니다.");
-        await page
-          .getByLabel("트리거 조건 JSON")
-          .fill(JSON.stringify({ amount: { gte: 100000 } }, null, 2));
-        await page
-          .getByLabel("처리 액션 JSON")
-          .fill(JSON.stringify({ type: "MANUAL_REVIEW" }, null, 2));
-        await page
-          .getByLabel("근거 JSON")
-          .fill(JSON.stringify([{ segmentId: "risk-seg-99" }], null, 2));
-        await page.getByLabel("메타 JSON").fill(JSON.stringify({ source: "e2e" }, null, 2));
-        const updateRequest = page.waitForRequest(
-          (request) =>
-            request.method() === "PATCH" &&
-            request.url().includes("/workspaces/1/domain-packs/1/versions/1/risks/201"),
-        );
-        await page.getByRole("button", { name: "저장" }).click();
-        const requestBody = (await updateRequest).postDataJSON();
-
-        expect(requestBody).toEqual(
-          expect.objectContaining({
-            name: "고액 환불 위험",
-            description: "고액 환불은 상담사 검토로 전환합니다.",
-            triggerConditionJson: JSON.stringify({ amount: { gte: 100000 } }, null, 2),
-            handlingActionJson: JSON.stringify({ type: "MANUAL_REVIEW" }, null, 2),
-            evidenceJson: JSON.stringify([{ segmentId: "risk-seg-99" }], null, 2),
-            metaJson: JSON.stringify({ source: "e2e" }, null, 2),
-          }),
-        );
-
-        await expect(page.getByText("주의 사항이 수정되었습니다.")).toBeVisible();
-        await expect(page.getByLabel("주의 사항 상세")).toContainText("고액 환불 위험");
-        expect(seen).toContain("PATCH /workspaces/1/domain-packs/1/versions/1/risks/201");
-      });
-
-      test("Then the status switch updates request body and detail state", async ({ page }) => {
-        await page.goto("/workspaces/1/domain-packs/1/risks?versionId=1");
-        await page.getByRole("button", { name: /RISK_FRAUD/ }).click();
-
-        await page.getByRole("button", { name: /RISK_FRAUD 주의 사항 수정/ }).click();
-        const statusSwitch = page.getByRole("switch", { name: "주의 사항 상태" });
-        await expect(statusSwitch).toBeChecked();
-
-        const statusRequest = page.waitForRequest(
-          (request) =>
-            request.method() === "PATCH" &&
-            request.url().includes("/workspaces/1/domain-packs/1/versions/1/risks/201/status"),
-        );
-        await statusSwitch.click();
-        const requestBody = (await statusRequest).postDataJSON();
-
-        expect(requestBody).toEqual({ status: "INACTIVE" });
-        await expect(statusSwitch).not.toBeChecked();
-        await page.getByRole("button", { name: "취소" }).click();
-        await expect(page.getByLabel("주의 사항 상세")).toContainText("사용 안 함");
-        expect(seen).toContain(
-          "PATCH /workspaces/1/domain-packs/1/versions/1/risks/201/status",
-        );
+          expect(requestBody).toEqual({ status: "INACTIVE" });
+          await expect(statusSwitch).not.toBeChecked();
+          await page.getByRole("button", { name: "취소" }).click();
+          await expect(page.getByLabel("주의 사항 상세")).toContainText(
+            "사용 안 함",
+          );
+          expect(seen).toContain(RISK_STATUS_ENTRY);
+          expect(seen).not.toContain(POLICY_STATUS_ENTRY);
+        });
       });
     });
 


### PR DESCRIPTION
Closes #722

## 변경 사항

- 이슈 722 요구사항과 acceptance criteria를 `.agent/specs/722.md`에 정리했습니다.
- `frontend/e2e/domain-pack-core.spec.ts`의 policy/risk edit 그룹을 `[@critical]` marker로 선택 실행 가능하게 표시했습니다.
- policy/risk 조건/액션/근거/메타 JSON 오류 메시지를 필드별로 검증하고, invalid save에서 update PATCH가 발생하지 않음을 확인합니다.
- 유효한 저장 피드백과 상세 반영, policy/risk status endpoint 분리 검증도 함께 보강했습니다.

## 검증

- `cd frontend && pnpm exec eslint e2e/domain-pack-core.spec.ts`
- `cd frontend && pnpm exec playwright test domain-pack-core.spec.ts --grep @critical` (6 passed)
- `git diff --check`
- `git diff --cached --check`

## 참고

- 구현 전 `frontend/e2e/domain-pack-core.spec.ts`, policy/risk edit schema와 form, `frontend/playwright.config.ts`, live E2E의 `@pollutes` tag 패턴, `frontend/DESIGN.md`, frontend test/FSD rules를 확인했습니다.
- spec review 2회 수행: issue fidelity와 Ostone repository compliance 관점에서 확인했고, 검증 명령을 실제 frontend cwd 실행 형태로 정리했습니다.
- self-review 3회 수행: issue fidelity/behavior 관점에서 불필요한 formatter churn을 되돌렸고, frontend integration boundary와 reviewer·CI risk 관점에서 남은 수정 사항은 없습니다.
- 커밋 hook은 실행하지 않았습니다(`HUSKY=0`). 변경 범위는 위 변경 파일 대상 검증과 staged diff check로 확인했습니다.