### PR TITLE
fix(ml): stage worker가 런타임 캐시 권한에 막히지 않도록 보장

### DIFF
--- a/ml/Dockerfile.cpu
+++ b/ml/Dockerfile.cpu
@@ -24,4 +24,4 @@ RUN groupadd --system appgroup \
     && chown -R appuser:appgroup /app
 USER appuser
 
-ENTRYPOINT ["uv", "run", "python", "-m", "pipeline.ecs_stage_worker"]
+ENTRYPOINT ["/app/.venv/bin/python", "-m", "pipeline.ecs_stage_worker"]

--- a/ml/Dockerfile.gpu
+++ b/ml/Dockerfile.gpu
@@ -30,4 +30,4 @@ RUN groupadd --system appgroup && useradd --system --gid appgroup --home-dir /ap
 USER appuser
 
 # AWS credentials are provided through the ECS task role.
-ENTRYPOINT ["uv", "run", "python", "-m", "pipeline.ecs_stage_worker"]
+ENTRYPOINT ["/app/.venv/bin/python", "-m", "pipeline.ecs_stage_worker"]


### PR DESCRIPTION
## 변경 사항

- ML CPU/GPU stage worker 이미지가 runtime에 `uv run`을 다시 호출하지 않고, 빌드 시 생성된 `/app/.venv/bin/python`으로 worker를 직접 실행하도록 했습니다.
- GPU stage 컨테이너가 `/app/.cache/uv` 생성 권한 문제로 시작 직후 종료되는 경로를 제거했습니다.

## 배경

GPU quota 승인 후 `representation` 태스크가 `ostone-prod-gpu-capacity-provider`에 정상 배치됐지만, `ml-stage-gpu` 컨테이너가 `Failed to initialize cache at .cache/uv` 및 `/app/.cache/uv: Permission denied`로 즉시 종료됐습니다. 이 변경 이후 stage worker는 runtime uv cache 초기화에 의존하지 않고 이미지에 포함된 가상환경 Python으로 실행됩니다.

## 검증

- `git diff --check -- ml/Dockerfile.cpu ml/Dockerfile.gpu`
- `git diff --check HEAD~1..HEAD`