### PR TITLE
test(frontend): improvement candidate 승인 반려 루프를 보장

### DIFF
--- a/.agent/specs/729.md
+++ b/.agent/specs/729.md
@@ -1,0 +1,99 @@
+# Improvement candidate 승인/반려 E2E 보강
+
+## Goal
+
+운영자가 simulation 화면의 improvement candidate를 승인 또는 반려해 Domain Pack 품질 개선 루프를 완료할 수 있음을 E2E로 보장한다.
+
+## Problem
+
+`frontend/e2e/workspace-core.spec.ts`는 simulation feedback 작성, improvement candidate 생성, `READY_FOR_REVIEW` 상태 요청까지 확인한다. 하지만 운영자가 리뷰 대기 후보를 실제로 승인하거나 반려하는 흐름, 반려 사유 필수 정책, 처리 중 중복 클릭 방지, 처리 후 후보 목록 갱신이 브라우저 수준에서 검증되지 않는다.
+
+## Scope
+
+- mocked Playwright simulation 시나리오에 `READY_FOR_REVIEW` 후보 승인/반려 흐름을 추가한다.
+- E2E mock fixture가 후보 상태 변경, 승인, 반려 이후 상태별 목록을 최신 상태로 반환하도록 만든다.
+- 승인 요청 중 해당 후보의 승인/반려 버튼이 비활성화됨을 검증한다.
+- 반려 사유가 없으면 반려 API를 호출하지 않고 사용자 피드백을 표시함을 검증한다.
+- 승인/반려 결과가 다른 후보에 잘못 적용되지 않도록 후보별 endpoint 호출과 목록 잔존 상태를 검증한다.
+- 컴포넌트 단위에서 반려 사유 누락 guard를 보강한다.
+
+## Non-goals
+
+- simulation page의 레이아웃, 문구, 디자인 토큰을 변경하지 않는다.
+- backend simulation/improvement-candidate API contract를 변경하지 않는다.
+- generated API client를 재생성하거나 수정하지 않는다.
+- 실제 live E2E가 운영 백엔드 데이터를 변경하는 approve/reject 시나리오는 추가하지 않는다.
+
+## Affected Paths
+
+- `frontend/e2e/workspace-core.spec.ts`
+- `frontend/e2e/support/app-mocks.ts`
+- `frontend/src/pages/workspace/ui/WorkspaceSimulationPage.tsx`
+- `frontend/src/pages/workspace/ui/WorkspaceSimulationPage.test.tsx`
+- `frontend/src/features/simulation/api/simulationApi.ts`
+
+## Requirements
+
+1. E2E는 simulation 화면에서 `READY_FOR_REVIEW` improvement candidate 목록을 볼 수 있어야 한다.
+2. E2E는 특정 후보 승인 시 `POST /api/v1/workspaces/{workspaceId}/simulation/improvement-candidates/{candidateId}/approve`가 해당 후보 id로만 호출됨을 확인해야 한다.
+3. 승인 처리 중 같은 후보의 승인/반려 버튼은 비활성화되어 중복 처리를 막아야 한다.
+4. 승인 성공 후 사용자는 후보가 초안 버전에 반영되었다는 피드백을 확인해야 한다.
+5. 승인 후 현재 필터의 후보 목록은 최신 상태로 갱신되어 승인된 후보가 리뷰 대기 목록에 남지 않아야 한다.
+6. 반려 사유가 없으면 반려 API를 호출하지 않고 사용자에게 사유 입력 필요 피드백을 보여야 한다.
+7. 반려 사유를 입력하면 `POST /api/v1/workspaces/{workspaceId}/simulation/improvement-candidates/{candidateId}/reject`가 해당 후보 id와 사유로 호출되어야 한다.
+8. 승인/반려 처리는 다른 후보의 상태나 endpoint 호출로 섞이면 안 된다.
+
+## API Integration
+
+| Method | Path                                                                                                        | Description                 |
+| ------ | ----------------------------------------------------------------------------------------------------------- | --------------------------- |
+| GET    | `/api/v1/workspaces/{workspaceId}/simulation/improvement-candidates?status=READY_FOR_REVIEW&page=0&size=20` | 리뷰 대기 후보 목록 조회    |
+| POST   | `/api/v1/workspaces/{workspaceId}/simulation/improvement-candidates/{candidateId}/approve`                  | 후보 승인 및 초안 버전 반영 |
+| POST   | `/api/v1/workspaces/{workspaceId}/simulation/improvement-candidates/{candidateId}/reject`                   | 사유 기반 후보 반려         |
+
+기존 `frontend/src/features/simulation/api/simulationApi.ts` wrapper의 approve/reject endpoint를 그대로 사용한다. API contract 변경은 없다.
+
+## Data Flow
+
+```text
+WorkspaceSimulationPage
+  -> candidateStatusFilter READY_FOR_REVIEW
+  -> simulationApi.listImprovementCandidates()
+  -> operator approve/reject click
+  -> candidate-specific pending id disables actions
+  -> simulationApi.approveImprovementCandidate() or rejectImprovementCandidate()
+  -> reloadFeedbackAndCandidates()
+  -> current filter list refresh
+  -> toast feedback
+```
+
+## Tests
+
+| 구분          | 방법                                                                                                                         | 도구                          |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------- | ----------------------------- |
+| 컴포넌트 회귀 | 반려 사유가 없을 때 reject API가 호출되지 않고 오류 toast가 표시됨을 검증                                                    | Vitest, React Testing Library |
+| E2E           | READY_FOR_REVIEW 후보 2개 중 하나를 승인하고 다른 하나를 반려하며 endpoint, disabled state, 목록 갱신, 사유 필수 정책을 검증 | Playwright                    |
+
+## Acceptance Criteria
+
+- `frontend/e2e/workspace-core.spec.ts`에 improvement candidate 승인/반려 E2E가 존재한다.
+- 승인 중 같은 후보의 승인/반려 버튼이 비활성화됨을 E2E가 확인한다.
+- 승인 성공 피드백으로 `개선 후보를 초안 버전에 반영했습니다.`가 표시됨을 E2E가 확인한다.
+- 승인된 후보는 `READY_FOR_REVIEW` 목록에서 제거되고 다른 후보는 남아 있음을 E2E가 확인한다.
+- 반려 사유 없이 반려하면 reject endpoint가 호출되지 않음을 E2E와 컴포넌트 테스트가 확인한다.
+- 반려 사유를 입력해 반려하면 해당 후보 id의 reject endpoint가 호출되고 목록이 최신 상태로 갱신됨을 E2E가 확인한다.
+- 승인/반려 endpoint 호출은 선택한 후보 id에만 발생한다.
+
+## Validation
+
+- `pnpm --dir frontend exec tsc --noEmit --project tsconfig.e2e.json`
+- `pnpm --dir frontend exec eslint e2e/support/app-mocks.ts e2e/workspace-core.spec.ts src/pages/workspace/ui/WorkspaceSimulationPage.test.tsx`
+- `pnpm --dir frontend test -- WorkspaceSimulationPage.test.tsx --run`
+- `pnpm --dir frontend e2e -- workspace-core.spec.ts`
+- `git diff --check`
+
+`pnpm run lint:frontend`는 전체 frontend baseline 확인용으로 실행하되, 변경 파일 밖의 기존 ESLint 오류가 있으면 PR 검증 결과에 별도로 기록한다.
+
+## Open Questions
+
+- 없음.

--- a/frontend/e2e/support/app-mocks.ts
+++ b/frontend/e2e/support/app-mocks.ts
@@ -508,6 +508,23 @@ const simulationReplayResult = {
 
 type SimulationReplayResultMock = typeof simulationReplayResult;
 
+type SimulationCandidateStatus = "DRAFT" | "READY_FOR_REVIEW" | "APPLIED" | "REJECTED";
+
+type SimulationCandidateMock = Omit<
+  typeof improvementCandidate,
+  "status" | "targetElementId" | "targetElementKey"
+> & {
+  targetElementId: number | null;
+  targetElementKey: string | null;
+  reviewSessionId: number | null;
+  reviewTaskId: number | null;
+  appliedDomainPackVersionId: number | null;
+  decisionReason: string | null;
+  decidedBy: number | null;
+  decidedAt: string | null;
+  status: SimulationCandidateStatus;
+};
+
 type SimulationGoldenCaseMock = {
   id: number;
   workspaceId: number;
@@ -525,13 +542,89 @@ type SimulationGoldenCaseMock = {
 type SimulationMockState = {
   messages: typeof chatMessages;
   goldenCases: SimulationGoldenCaseMock[];
+  candidates: SimulationCandidateMock[];
 };
+
+function buildSimulationCandidate(
+  overrides: Partial<SimulationCandidateMock> = {},
+): SimulationCandidateMock {
+  return {
+    ...improvementCandidate,
+    reviewSessionId: null,
+    reviewTaskId: null,
+    appliedDomainPackVersionId: null,
+    decisionReason: null,
+    decidedBy: null,
+    decidedAt: null,
+    status: "DRAFT",
+    ...overrides,
+  };
+}
+
+const draftImprovementCandidate = buildSimulationCandidate();
+
+const approvalImprovementCandidate = buildSimulationCandidate({
+  id: 9912,
+  candidateType: "SLOT_QUESTION",
+  targetElementType: "SLOT",
+  targetElementId: slot.id,
+  targetElementKey: slot.slotCode,
+  beforeSummary: "부분 환불 문의는 주문번호 확인 질문으로 이어지지 않습니다.",
+  afterSummary: "부분 환불 문의도 주문번호를 먼저 확인하도록 질문을 보강합니다.",
+  evidenceSummary: "시뮬레이션 피드백 #9902",
+  status: "READY_FOR_REVIEW",
+  reviewSessionId: 9201,
+  reviewTaskId: 9301,
+});
+
+const rejectionImprovementCandidate = buildSimulationCandidate({
+  id: 9913,
+  candidateType: "HANDOFF_CONDITION",
+  targetElementType: "HANDOFF",
+  targetElementId: null,
+  targetElementKey: "refund_handoff",
+  beforeSummary: "고액 환불을 모두 상담사에게 넘기도록 제안합니다.",
+  afterSummary: "고액 환불 handoff 조건을 완화합니다.",
+  evidenceSummary: "시뮬레이션 피드백 #9903",
+  status: "READY_FOR_REVIEW",
+  reviewSessionId: 9202,
+  reviewTaskId: 9302,
+});
 
 function createSimulationState(): SimulationMockState {
   return {
     messages: chatMessages,
     goldenCases: [],
+    candidates: [
+      { ...draftImprovementCandidate },
+      { ...approvalImprovementCandidate },
+      { ...rejectionImprovementCandidate },
+    ],
   };
+}
+
+function upsertSimulationCandidate(
+  state: SimulationMockState,
+  candidate: SimulationCandidateMock,
+) {
+  const withoutCandidate = state.candidates.filter((item) => item.id !== candidate.id);
+  state.candidates = [...withoutCandidate, { ...candidate }];
+}
+
+function updateSimulationCandidate(
+  state: SimulationMockState,
+  candidateId: number,
+  updates: Partial<SimulationCandidateMock>,
+) {
+  const current = state.candidates.find((candidate) => candidate.id === candidateId);
+  if (!current) {
+    throw new Error(`Unknown simulation candidate: ${candidateId}`);
+  }
+  const updated = { ...current, ...updates };
+  state.candidates = state.candidates.map((candidate) =>
+    candidate.id === candidateId ? updated : candidate,
+  );
+  return updated;
 }
 
 function simulationDetail(messages: typeof chatMessages = chatMessages) {
@@ -1274,6 +1367,7 @@ async function fulfillSimulation(
   route: Route,
   method: string,
   path: string,
+  url: URL,
   state: SimulationMockState,
 ): Promise<boolean> {
   if (method === "GET" && path === "/workspaces/1/simulation/sessions") {
@@ -1398,32 +1492,80 @@ async function fulfillSimulation(
     method === "POST" &&
     path === "/workspaces/1/simulation/improvement-candidates/from-feedback/9901"
   ) {
-    await fulfillJson(route, improvementCandidate);
+    upsertSimulationCandidate(state, draftImprovementCandidate);
+    await fulfillJson(route, draftImprovementCandidate);
     return true;
   }
 
   if (method === "GET" && path === "/workspaces/1/simulation/improvement-candidates") {
+    const status = url.searchParams.get("status") as SimulationCandidateStatus | null;
+    const candidates = status
+      ? state.candidates.filter((candidate) => candidate.status === status)
+      : state.candidates;
     await fulfillJson(route, {
-      content: [improvementCandidate],
+      content: candidates,
       page: 0,
       size: 20,
-      totalElements: 1,
-      totalPages: 1,
+      totalElements: candidates.length,
+      totalPages: candidates.length === 0 ? 0 : 1,
     });
     return true;
   }
 
-  if (
-    method === "PATCH" &&
-    path === "/workspaces/1/simulation/improvement-candidates/9911/status"
-  ) {
-    expect(route.request().postDataJSON()).toEqual({
-      status: "READY_FOR_REVIEW",
+  const statusMatch = path.match(
+    /^\/workspaces\/1\/simulation\/improvement-candidates\/(\d+)\/status$/,
+  );
+  if (method === "PATCH" && statusMatch) {
+    const candidateId = Number(statusMatch[1]);
+    const body = route.request().postDataJSON() as { status?: SimulationCandidateStatus };
+    expect(body.status).toBe("READY_FOR_REVIEW");
+    const updated = updateSimulationCandidate(state, candidateId, {
+      status: body.status,
+      updatedAt: now,
     });
-    await fulfillJson(route, {
-      ...improvementCandidate,
-      status: "READY_FOR_REVIEW",
+    await fulfillJson(route, updated);
+    return true;
+  }
+
+  const approveMatch = path.match(
+    /^\/workspaces\/1\/simulation\/improvement-candidates\/(\d+)\/approve$/,
+  );
+  if (method === "POST" && approveMatch) {
+    const candidateId = Number(approveMatch[1]);
+    const body = route.request().postDataJSON() as { reason?: string };
+    await new Promise((resolve) => {
+      setTimeout(resolve, 150);
     });
+    const updated = updateSimulationCandidate(state, candidateId, {
+      status: "APPLIED",
+      appliedDomainPackVersionId: 2,
+      decisionReason: body.reason ?? null,
+      decidedBy: 7,
+      decidedAt: now,
+      updatedAt: now,
+    });
+    await fulfillJson(route, updated);
+    return true;
+  }
+
+  const rejectMatch = path.match(
+    /^\/workspaces\/1\/simulation\/improvement-candidates\/(\d+)\/reject$/,
+  );
+  if (method === "POST" && rejectMatch) {
+    const candidateId = Number(rejectMatch[1]);
+    const body = route.request().postDataJSON() as { reason?: string };
+    expect(body.reason).toBeTruthy();
+    await new Promise((resolve) => {
+      setTimeout(resolve, 150);
+    });
+    const updated = updateSimulationCandidate(state, candidateId, {
+      status: "REJECTED",
+      decisionReason: body.reason ?? null,
+      decidedBy: 7,
+      decidedAt: now,
+      updatedAt: now,
+    });
+    await fulfillJson(route, updated);
     return true;
   }
 
@@ -1443,7 +1585,7 @@ export async function installAppApiMocks(page: Page, seen: string[]) {
     if (await fulfillDomainPackRead(route, method, path)) return true;
     if (await fulfillWorkspaceOperations(route, method, path, url)) return true;
     if (await fulfillUploadAndReview(route, method, path)) return true;
-    if (await fulfillSimulation(route, method, path, simulationState)) return true;
+    if (await fulfillSimulation(route, method, path, url, simulationState)) return true;
     return false;
   });
 }

--- a/frontend/e2e/workspace-core.spec.ts
+++ b/frontend/e2e/workspace-core.spec.ts
@@ -386,6 +386,69 @@ test.describe("Workspace core operator screens", () => {
         ).toBe("PATCH /workspaces/1/simulation/improvement-candidates/9911/status");
         await captureScreen(page, testInfo, "workspace-simulation");
       });
+
+      test("Then improvement candidates can be approved and rejected into the quality loop", async ({
+        page,
+      }) => {
+        await page.goto("/workspaces/1/simulation?candidateStatus=READY_FOR_REVIEW");
+        await expect(page.getByRole("heading", { name: "상담 시뮬레이션" })).toBeVisible();
+        await expect(page.getByRole("tab", { name: "개선 후보" })).toHaveAttribute(
+          "aria-selected",
+          "true",
+        );
+        await expect(page.getByLabel("개선 후보 상태 필터")).toHaveValue("READY_FOR_REVIEW");
+
+        const approvalCard = page.locator("li").filter({
+          hasText: "부분 환불 문의도 주문번호를 먼저 확인하도록 질문을 보강합니다.",
+        });
+        const rejectionCard = page.locator("li").filter({
+          hasText: "고액 환불 handoff 조건을 완화합니다.",
+        });
+        await expect(approvalCard).toBeVisible();
+        await expect(rejectionCard).toBeVisible();
+
+        const approveButton = approvalCard.getByRole("button", { name: "승인" });
+        await approveButton.click();
+        await expect(approveButton).toBeDisabled();
+        await expect(approvalCard.getByRole("button", { name: "반려" })).toBeDisabled();
+        await expect(page.getByText("개선 후보를 초안 버전에 반영했습니다.")).toBeVisible();
+        await expect(approvalCard).toHaveCount(0);
+        await expect(rejectionCard).toBeVisible();
+        expect(
+          seen.filter(
+            (entry) =>
+              entry === "POST /workspaces/1/simulation/improvement-candidates/9912/approve",
+          ),
+        ).toHaveLength(1);
+        expect(
+          seen.some(
+            (entry) =>
+              entry === "POST /workspaces/1/simulation/improvement-candidates/9913/approve",
+          ),
+        ).toBe(false);
+
+        const rejectPath = "POST /workspaces/1/simulation/improvement-candidates/9913/reject";
+        const rejectCountBefore = seen.filter((entry) => entry === rejectPath).length;
+        await rejectionCard.getByRole("button", { name: "반려" }).click();
+        await expect(page.getByText("반려 사유를 입력하세요.")).toBeVisible();
+        expect(seen.filter((entry) => entry === rejectPath)).toHaveLength(rejectCountBefore);
+
+        await rejectionCard.getByLabel("개선 후보 반려 사유").fill("근거가 부족합니다.");
+        const rejectButton = rejectionCard.getByRole("button", { name: "반려" });
+        await rejectButton.click();
+        await expect(rejectButton).toBeDisabled();
+        await expect(page.getByText("개선 후보를 반려했습니다.")).toBeVisible();
+        await expect(page.getByText("조건에 맞는 개선 후보가 없습니다.")).toBeVisible();
+        expect(seen.filter((entry) => entry === rejectPath)).toHaveLength(
+          rejectCountBefore + 1,
+        );
+        expect(
+          seen.some(
+            (entry) =>
+              entry === "POST /workspaces/1/simulation/improvement-candidates/9912/reject",
+          ),
+        ).toBe(false);
+      });
     });
   });
 });

--- a/frontend/src/pages/workspace/ui/WorkspaceSimulationPage.test.tsx
+++ b/frontend/src/pages/workspace/ui/WorkspaceSimulationPage.test.tsx
@@ -834,6 +834,30 @@ describe("WorkspaceSimulationPage", () => {
     });
   });
 
+  it("반려 사유가 없으면 READY_FOR_REVIEW 개선 후보를 반려하지 않는다", async () => {
+    mockedSimulationApi.listImprovementCandidates.mockResolvedValue({
+      content: [
+        {
+          ...candidate,
+          status: "READY_FOR_REVIEW",
+          reviewSessionId: 200,
+          reviewTaskId: 300,
+        },
+      ],
+      page: 0,
+      size: 20,
+      totalElements: 1,
+      totalPages: 1,
+    });
+    renderPage();
+
+    await openCandidateTab();
+    fireEvent.click(await screen.findByRole("button", { name: "반려" }));
+
+    expect(toast.error).toHaveBeenCalledWith("반려 사유를 입력하세요.");
+    expect(mockedSimulationApi.rejectImprovementCandidate).not.toHaveBeenCalled();
+  });
+
   it("READY_FOR_REVIEW 개선 후보를 반려하고 사유를 전달한다", async () => {
     mockedSimulationApi.listImprovementCandidates.mockResolvedValue({
       content: [


### PR DESCRIPTION
Closes #729

## 변경 사항

- 이슈 729 요구사항과 acceptance criteria를 `.agent/specs/729.md`에 정리했습니다.
- mocked simulation E2E에 `READY_FOR_REVIEW` improvement candidate 승인/반려 루프를 추가했습니다.
- 승인 중 동일 후보의 승인/반려 버튼 비활성화, 승인 후 리뷰 대기 목록 갱신, 다른 후보 오적용 방지를 검증합니다.
- 반려 사유 누락 시 reject endpoint를 호출하지 않는 guard를 컴포넌트 테스트와 E2E로 고정했습니다.
- Playwright simulation mock을 후보 상태별 조회, 승인, 반려 이후 최신 상태를 반환하는 page-local state fixture로 보강했습니다.

## 검증

- `pnpm --dir frontend exec tsc --noEmit --project tsconfig.e2e.json`
- `pnpm --dir frontend exec eslint e2e/support/app-mocks.ts e2e/workspace-core.spec.ts src/pages/workspace/ui/WorkspaceSimulationPage.test.tsx`
- `pnpm --dir frontend test -- WorkspaceSimulationPage.test.tsx --run` (1 file, 27 tests)
- `pnpm --dir frontend e2e -- workspace-core.spec.ts` (11 passed)
- `git diff --check`
- `git diff --cached --check`

## 참고

- 구현 전 `WorkspaceSimulationPage`, `WorkspaceSimulationPage.test.tsx`, `simulationApi`, 기존 `workspace-core.spec.ts`, `app-mocks.ts`, `frontend/DESIGN.md`, frontend FSD/API/test rules를 확인했습니다.
- spec review 2회 수행: issue fidelity와 Ostone repository compliance 관점에서 확인했고, 검증 명령을 실제 통과 기준과 full lint baseline 기록으로 정리했습니다.
- self-review 3회 수행: Round 1에서 empty filtered candidate list의 `totalPages` mock을 수정했고, Round 2/3에서 frontend integration boundary와 reviewer·CI risk 관점의 추가 수정 사항은 없었습니다.
- `pnpm run lint:frontend`는 이번 변경과 무관한 기존 frontend ESLint baseline 47건으로 실패합니다. API/FSD audits, 변경 파일 대상 ESLint, targeted unit/E2E, diff whitespace check는 통과했습니다.
- pre-commit hook은 repository-wide `pnpm run lint:frontend` baseline 실패 때문에 통과하지 못해 변경 파일 대상 검증을 근거로 우회해 커밋했습니다.