### PR TITLE
fix(frontend): 구독 환불과 해지 완료 상태를 즉시 반영

### DIFF
--- a/.agent/specs/719.md
+++ b/.agent/specs/719.md
@@ -1,0 +1,147 @@
+# Frontend E2E Spec: 구독 환불/해지 확인 절차와 완료 상태
+
+## Goal
+
+운영자가 워크스페이스 구독 화면에서 환불 또는 구독 해지를 실행할 때 확인 dialog를 거치고, 완료 후 해당 워크스페이스의 결제/구독 상태가 화면에 일관되게 반영됨을 E2E로 보장한다.
+
+## Issue Summary
+
+GitHub Issue #719는 활성 구독이 있는 workspace의 구독 화면에서 환불과 구독 해지가 실수로 즉시 실행되지 않아야 하며, 환불 사유 입력, 완료 피드백, 상태 반영, 다른 workspace 결제 상태와의 격리를 Critical E2E로 검증하라는 요구다.
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A["활성 구독 workspace의 구독 화면"] --> B["환불 버튼 클릭"]
+    B --> C{"환불 확인 dialog"}
+    C -->|"닫기 또는 확인 전"| D["환불 API 미호출"]
+    C -->|"사유 입력 후 환불 확인"| E["환불 요청 완료 피드백"]
+    E --> F["결제 상태가 취소됨으로 반영"]
+    F --> G["구독 해지 버튼 클릭"]
+    G --> H{"구독 해지 확인 dialog"}
+    H -->|"확인 전"| I["해지 API 미호출"]
+    H -->|"구독 해지 확인"| J["해지 완료 피드백"]
+    J --> K["구독 상태가 해지됨 또는 해지 예약으로 반영"]
+    K --> L["다른 workspace 구독 화면 이동"]
+    L --> M["다른 workspace의 결제/구독 상태만 표시"]
+```
+
+## Design Diff
+
+| 영역 | As-is | To-be | 변경 내용 |
+| --- | --- | --- | --- |
+| Billing E2E | 환불/해지 endpoint 호출을 주로 확인 | 확인 dialog, 사유 입력 유지/제출, 완료 피드백, 화면 상태 반영을 우선 확인 | 사용자 기대 결과 중심의 Critical E2E로 강화 |
+| Billing overview cache | 환불/해지 mutation 후 standalone payments/subscription query만 갱신 | BillingPage가 사용하는 overview query도 mutation 결과로 갱신 | 완료 후 결제/구독 상태가 즉시 일관되게 표시 |
+| Workspace isolation | 기본 workspace billing만 확인 | 다른 workspace billing fixture를 추가해 상태 섞임을 검증 | workspace별 billing context 회귀 방지 |
+
+## Component Tree
+
+```text
+frontend/e2e/billing.spec.ts
+└─ Billing screens E2E
+   └─ 환불/구독 해지 Critical scenario
+
+frontend/e2e/support/app-mocks.ts
+└─ installAppApiMocks
+   ├─ workspace 1 billing overview/refund/cancel mock
+   └─ workspace 2 billing overview mock
+
+frontend/src/pages/billing/ui/BillingPage.tsx
+└─ BillingPage
+   ├─ SubscriptionStatusCard
+   ├─ PaymentHistoryList
+   │  └─ RefundButton
+   └─ CancelSubscriptionButton
+
+frontend/src/features/cancel-subscription/api
+├─ useRefundPayment
+└─ useCancelSubscription
+```
+
+## API Integration
+
+테스트는 Playwright route mock을 사용하며 신규 API는 만들지 않는다.
+
+| Method | Path | 목적 |
+| --- | --- | --- |
+| `GET` | `/api/v1/workspaces` | workspace switcher와 shell context 조회 |
+| `GET` | `/api/v1/workspaces/{workspaceId}` | 현재 workspace marker 조회 |
+| `GET` | `/api/v1/workspaces/{workspaceId}/billing/overview` | 구독, 결제수단, 결제내역, quota 조회 |
+| `POST` | `/api/v1/workspaces/{workspaceId}/payments/{paymentKey}/cancel` | 환불 사유를 포함한 결제 환불 |
+| `DELETE` | `/api/v1/workspaces/{workspaceId}/subscription` | 구독 해지 |
+
+## 수정 대상 파일
+
+| 파일 | 변경 유형 | 설명 |
+| --- | --- | --- |
+| `.agent/specs/719.md` | new | Issue #719 요구사항과 검증 기준 기록 |
+| `frontend/e2e/billing.spec.ts` | modify | 환불/해지 Critical E2E를 사용자 기대 결과 중심으로 강화 |
+| `frontend/e2e/support/app-mocks.ts` | modify | workspace별 billing overview fixture와 mutation body 검증 보강 |
+| `frontend/src/features/cancel-subscription/api/useRefundPayment.ts` | modify | 환불 성공 시 billing overview 결제 상태 갱신 |
+| `frontend/src/features/cancel-subscription/api/useCancelSubscription.ts` | modify | 구독 해지 성공 시 billing overview 구독 상태 갱신 |
+| `frontend/src/features/cancel-subscription/api/useRefundPayment.test.tsx` | modify | 환불 mutation 후 overview cache 갱신 검증 |
+| `frontend/src/features/cancel-subscription/api/useCancelSubscription.test.tsx` | modify | 구독 해지 mutation 후 overview cache 갱신 검증 |
+| `frontend/src/features/cancel-subscription/ui/RefundButton.tsx` | modify | 환불 성공 payload를 상위 화면에 전달 |
+| `frontend/src/features/cancel-subscription/ui/CancelSubscriptionButton.tsx` | modify | 구독 해지 성공 payload를 상위 화면에 전달 |
+| `frontend/src/features/cancel-subscription/ui/RefundButton.test.tsx` | modify | 환불 성공 callback 전달 검증 |
+| `frontend/src/features/cancel-subscription/ui/CancelSubscriptionButton.test.tsx` | modify | 구독 해지 성공 callback 전달 검증 |
+| `frontend/src/pages/billing/ui/BillingPage.tsx` | modify | 이미 해지 또는 해지 예약된 구독의 중복 해지 CTA 노출 방지 |
+| `frontend/src/pages/billing/ui/BillingPage.test.tsx` | modify | 해지 예약/해지 완료 상태에서 해지 CTA 숨김 검증 |
+
+## State Management
+
+- 서버 상태는 기존 TanStack Query query key를 유지한다.
+- BillingPage는 `billingQueryKeys.overview(workspaceId)`로 결합된 billing read model을 표시한다.
+- 환불 성공 시 mutation 결과의 `PaymentResponse`를 overview의 `payments` 배열에 반영한다.
+- 구독 해지 성공 시 mutation 결과의 `SubscriptionResponse`를 overview의 `subscription`에 반영한다.
+- BillingPage는 mutation 성공 callback을 받아 즉시 표시 상태를 갱신하며, 성공 응답 body가 비어도 현재 화면의 결제/구독 정보를 기반으로 완료 상태를 표시한다.
+- workspace별 query key는 workspace id를 포함하므로 다른 workspace overview cache를 변경하지 않는다.
+
+## Tests
+
+### Test Strategy
+
+| 구분 | 방법 | 도구 | 비고 |
+| --- | --- | --- | --- |
+| Hook regression | mutation 성공 후 billing overview cache 갱신 확인 | Vitest, TanStack Query | BillingPage 상태 반영 회귀 방지 |
+| Button/Page regression | 성공 callback 전달, 빈 응답 fallback, 해지/예약 상태에서 중복 해지 CTA 숨김 확인 | Vitest, React Testing Library | 반복 실행 UX 방지 |
+| E2E Critical | 환불/해지 dialog, 완료 feedback, 상태 반영, workspace isolation 검증 | Playwright | Issue #719 핵심 사용자 시나리오 |
+
+### Test Scenarios
+
+| # | Given | When | Then |
+| --- | --- | --- | --- |
+| 1 | 활성 구독과 DONE 결제가 있는 workspace 1 구독 화면 | 환불 버튼을 클릭하지만 확인 전 | 환불 dialog가 표시되고 환불 API는 호출되지 않는다 |
+| 2 | 환불 dialog가 열린 상태 | 환불 사유를 입력하고 닫았다가 다시 열어 환불을 확인 | 입력한 사유가 유지되고 해당 사유로 환불 요청이 제출된다 |
+| 3 | 환불 요청이 성공 | 화면을 확인 | 완료 toast, 결제 상태 `취소됨`, 환불 CTA 제거가 표시된다 |
+| 4 | 활성 구독 workspace 1 | 구독 해지 버튼을 클릭하지만 확인 전 | 구독 해지 dialog가 표시되고 해지 API는 호출되지 않는다 |
+| 5 | 구독 해지 요청이 성공 | 화면을 확인 | 완료 toast, 구독 상태 `해지됨` 또는 해지 예약 정보, 중복 해지 CTA 제거가 표시된다 |
+| 6 | workspace 1에서 환불/해지를 완료한 뒤 | workspace 2 구독 화면으로 이동 | workspace 2의 결제수단/결제금액/구독 상태만 표시되고 workspace 1의 취소 상태가 섞이지 않는다 |
+
+## Acceptance Criteria
+
+- 환불과 구독 해지는 확인 dialog의 최종 확인 전까지 API를 호출하지 않는다.
+- 환불 사유가 입력되고, dialog 재오픈 후에도 유지되며, 제출 body에 명확히 포함된다.
+- 환불 성공 후 사용자는 완료 feedback과 결제 상태 `취소됨`을 볼 수 있고 같은 결제의 환불 CTA는 사라진다.
+- 구독 해지 성공 후 사용자는 완료 feedback과 해지된 구독 상태 또는 해지 예약 정보를 볼 수 있고 중복 해지 CTA는 사라진다.
+- 다른 workspace 구독 화면은 해당 workspace의 billing overview만 표시한다.
+- endpoint 호출 검증은 보조로 유지하되, E2E의 우선 단언은 화면상 확인 절차와 완료 상태다.
+
+## Non-goals
+
+- backend billing API contract, OpenAPI generated file, database schema는 변경하지 않는다.
+- Toss 결제 위젯, billing authorization redirect, one-off payment confirm/fail landing 정책은 변경하지 않는다.
+- 실제 운영 백엔드를 호출하는 live E2E는 추가하지 않는다.
+- 환불 금액 정책이나 부분 환불 UI는 이번 범위에 포함하지 않는다.
+
+## Validation
+
+| 검증 | 목적 |
+| --- | --- |
+| `pnpm --dir frontend test -- src/features/cancel-subscription/api/useRefundPayment.test.tsx src/features/cancel-subscription/api/useCancelSubscription.test.tsx src/features/cancel-subscription/ui/RefundButton.test.tsx src/features/cancel-subscription/ui/CancelSubscriptionButton.test.tsx src/pages/billing/ui/BillingPage.test.tsx --run` | 변경 hook/button/page 단위 회귀 검증 |
+| `pnpm --dir frontend e2e -- billing.spec.ts` | Billing Critical E2E 검증 |
+| `git diff --check` | 공백/패치 형식 확인 |
+
+## Open Questions
+
+- 없음. Issue의 미확인 세부 정책은 코드 기준으로 조사했고, 확인된 현재 정책만 테스트에 고정한다.

--- a/frontend/e2e/billing.spec.ts
+++ b/frontend/e2e/billing.spec.ts
@@ -3,6 +3,10 @@ import { expect, test } from "@playwright/test";
 import { installAuth } from "./support/generated-api-auth";
 import { captureScreen, installAppApiMocks } from "./support/app-mocks";
 
+function expectNoRequest(seen: string[], request: string) {
+  expect(seen).not.toContain(request);
+}
+
 test.describe("Billing screens", () => {
   let seen: string[];
 
@@ -14,28 +18,60 @@ test.describe("Billing screens", () => {
 
   test.describe("Given an active workspace subscription", () => {
     test.describe("When an operator opens billing and manages payments", () => {
-      test("Then refund and cancel subscription actions call the correct endpoints", async ({
+      test("Then refund and cancel subscription actions require confirmation and update visible billing state", async ({
         page,
       }, testInfo) => {
         await page.goto("/workspaces/1/billing");
+        const refundRequest = "POST /workspaces/1/payments/pay_7001/cancel";
+        const cancelRequest = "DELETE /workspaces/1/subscription";
+
         await expect(page.getByRole("heading", { name: "구독", level: 1 })).toBeVisible();
+        await expect(page.getByTestId("workspace-marker")).toContainText("QA Workspace");
         await expect(page.getByText("신한카드")).toBeVisible();
         await expect(page.getByText("99,000원")).toBeVisible();
         await captureScreen(page, testInfo, "billing-overview");
 
         await page.getByRole("button", { name: "환불" }).click();
         await expect(page.getByRole("alertdialog")).toContainText("결제를 환불할까요?");
+        expectNoRequest(seen, refundRequest);
         await page.getByPlaceholder("환불 사유를 입력해주세요").fill("품질 검증 환불");
+        await expect(page.getByPlaceholder("환불 사유를 입력해주세요")).toHaveValue("품질 검증 환불");
+        await page.getByRole("alertdialog").getByRole("button", { name: "닫기" }).click();
+        await expect(page.getByRole("alertdialog")).toBeHidden();
+        expectNoRequest(seen, refundRequest);
+
+        await page.getByRole("button", { name: "환불" }).click();
+        await expect(page.getByPlaceholder("환불 사유를 입력해주세요")).toHaveValue(
+          "품질 검증 환불",
+        );
         await page.getByRole("alertdialog").getByRole("button", { name: "환불" }).click();
         await expect(page.getByText("환불을 요청했습니다.")).toBeVisible();
+        await expect(page.getByText("취소됨")).toBeVisible();
+        await expect(page.getByRole("button", { name: "환불" })).toBeHidden();
 
         await page.getByRole("button", { name: "구독 해지" }).click();
         await expect(page.getByRole("alertdialog")).toContainText("구독을 해지할까요?");
+        expectNoRequest(seen, cancelRequest);
         await page.getByRole("alertdialog").getByRole("button", { name: "구독 해지" }).click();
         await expect(page.getByText("구독을 해지했습니다.")).toBeVisible();
+        await expect(page.getByText("해지됨")).toBeVisible();
+        await expect(page.getByText(/현재 주기 종료일/)).toBeVisible();
+        await expect(page.getByRole("button", { name: "구독 해지" })).toBeHidden();
 
-        expect(seen).toContain("POST /workspaces/1/payments/pay_7001/cancel");
-        expect(seen).toContain("DELETE /workspaces/1/subscription");
+        expect(seen).toContain(refundRequest);
+        expect(seen).toContain(cancelRequest);
+
+        await page.getByTestId("workspace-marker").click();
+        await page.getByTestId("workspace-option-2").click();
+        await expect(page).toHaveURL(/\/workspaces\/2\/workflows$/);
+        await page.goto("/workspaces/2/billing");
+        await expect(page.getByTestId("workspace-marker")).toContainText("Ops Workspace");
+        await expect(page.getByText("국민카드")).toBeVisible();
+        await expect(page.getByText("49,000원")).toBeVisible();
+        await expect(page.getByText("구독 중")).toBeVisible();
+        await expect(page.getByText("해지됨")).toBeHidden();
+        await expect(page.getByText("취소됨")).toBeHidden();
+        expect(seen).toContain("GET /workspaces/2/billing/overview");
       });
     });
   });

--- a/frontend/e2e/support/app-mocks.ts
+++ b/frontend/e2e/support/app-mocks.ts
@@ -385,6 +385,59 @@ const billingOverview = {
   ],
 };
 
+const secondarySubscription = {
+  ...subscription,
+  id: 22,
+  workspaceId: secondaryWorkspace.id,
+  customerKey: "customer-ops-workspace",
+};
+
+const secondaryPayment = {
+  ...payment,
+  id: 7002,
+  orderId: "order-7002",
+  paymentKey: "pay_7002",
+  amount: 49000,
+  status: "DONE",
+  receiptUrl: "https://receipt.example.test/pay_7002",
+};
+
+const secondaryBillingOverview = {
+  subscription: secondarySubscription,
+  billingKey: {
+    id: 25,
+    cardCompany: "국민카드",
+    cardNumberMasked: "9876-****-****-4321",
+    status: "ACTIVE",
+  },
+  payments: [secondaryPayment],
+  quotaUsages: [
+    { resource: "DATASET_UPLOAD", used: 1, limit: 100 },
+    { resource: "PIPELINE_RUN", used: 2, limit: 50 },
+  ],
+};
+
+function createBillingMockState() {
+  return {
+    workspaceOneOverview: {
+      ...billingOverview,
+      subscription: { ...subscription },
+      billingKey: { ...billingOverview.billingKey },
+      payments: [{ ...payment }],
+      quotaUsages: billingOverview.quotaUsages.map((quota) => ({ ...quota })),
+    },
+    workspaceTwoOverview: {
+      ...secondaryBillingOverview,
+      subscription: { ...secondarySubscription },
+      billingKey: { ...secondaryBillingOverview.billingKey },
+      payments: [{ ...secondaryPayment }],
+      quotaUsages: secondaryBillingOverview.quotaUsages.map((quota) => ({ ...quota })),
+    },
+  };
+}
+
+type BillingMockState = ReturnType<typeof createBillingMockState>;
+
 const consultationSession = {
   id: 601,
   workspaceId: WORKSPACE_ID,
@@ -1011,6 +1064,97 @@ async function fulfillDomainPackRead(
   return false;
 }
 
+async function fulfillBilling(
+  route: Route,
+  method: string,
+  path: string,
+  state: BillingMockState,
+): Promise<boolean> {
+  if (method === "GET" && path === "/plans") {
+    await fulfillJson(route, {
+      data: [
+        {
+          planKey: "pro_monthly",
+          name: "Pro (Monthly)",
+          amount: 29000,
+          currency: "KRW",
+          interval: "MONTH",
+          memberLimit: 3,
+          datasetUploadLimit: 10,
+          pipelineRunHourlyLimit: 1,
+          contactOnly: false,
+          unlimited: false,
+        },
+      ],
+      status: 200,
+    });
+    return true;
+  }
+
+  if (method === "GET" && path === "/workspaces/1/subscription") {
+    await fulfillJson(route, { data: state.workspaceOneOverview.subscription, status: 200 });
+    return true;
+  }
+
+  if (method === "GET" && path === "/workspaces/1/billing/overview") {
+    await fulfillJson(route, { data: state.workspaceOneOverview, status: 200 });
+    return true;
+  }
+
+  if (method === "GET" && path === "/workspaces/2/billing/overview") {
+    await fulfillJson(route, { data: state.workspaceTwoOverview, status: 200 });
+    return true;
+  }
+
+  if (method === "POST" && path === "/workspaces/1/payments/pay_7001/cancel") {
+    expect(route.request().postDataJSON()).toEqual({ cancelReason: "품질 검증 환불" });
+    const canceledPayment = { ...payment, status: "CANCELED" };
+    state.workspaceOneOverview = {
+      ...state.workspaceOneOverview,
+      payments: [canceledPayment],
+    };
+    await fulfillJson(route, { data: canceledPayment, status: 200 });
+    return true;
+  }
+
+  if (method === "DELETE" && path === "/workspaces/1/subscription") {
+    const canceledSubscription = { ...subscription, status: "CANCELED", cancelAtPeriodEnd: true };
+    state.workspaceOneOverview = {
+      ...state.workspaceOneOverview,
+      subscription: canceledSubscription,
+    };
+    await fulfillJson(route, { data: canceledSubscription, status: 200 });
+    return true;
+  }
+
+  if (method === "POST" && path === "/workspaces/1/billing/authorizations") {
+    expect(route.request().postDataJSON()).toMatchObject({
+      authKey: "auth-e2e",
+      customerKey: "customer-qa-workspace",
+    });
+    await fulfillJson(route, {
+      data: {
+        subscription: state.workspaceOneOverview.subscription,
+        billingKey: state.workspaceOneOverview.billingKey,
+      },
+      status: 200,
+    });
+    return true;
+  }
+
+  if (method === "POST" && path === "/workspaces/1/payments/confirm") {
+    expect(route.request().postDataJSON()).toMatchObject({
+      paymentKey: "payment-e2e",
+      orderId: "order-e2e",
+      amount: 99000,
+    });
+    await fulfillJson(route, { data: payment, status: 200 });
+    return true;
+  }
+
+  return false;
+}
+
 async function fulfillWorkspaceOperations(
   route: Route,
   method: string,
@@ -1185,60 +1329,6 @@ async function fulfillWorkspaceOperations(
       totalElements: chatMessages.length + olderChatMessages.length,
       totalPages: 2,
     });
-    return true;
-  }
-
-  if (method === "GET" && path === "/workspaces/1/subscription") {
-    await fulfillJson(route, { data: subscription, status: 200 });
-    return true;
-  }
-
-  if (method === "GET" && path === "/workspaces/1/billing/overview") {
-    await fulfillJson(route, { data: billingOverview, status: 200 });
-    return true;
-  }
-
-  if (method === "POST" && path === "/workspaces/1/payments/pay_7001/cancel") {
-    expect(route.request().postDataJSON()).toMatchObject({
-      cancelReason: "품질 검증 환불",
-    });
-    await fulfillJson(route, {
-      data: { ...payment, status: "CANCELED" },
-      status: 200,
-    });
-    return true;
-  }
-
-  if (method === "DELETE" && path === "/workspaces/1/subscription") {
-    await fulfillJson(route, {
-      data: { ...subscription, status: "CANCELED", cancelAtPeriodEnd: true },
-      status: 200,
-    });
-    return true;
-  }
-
-  if (method === "POST" && path === "/workspaces/1/billing/authorizations") {
-    expect(route.request().postDataJSON()).toMatchObject({
-      authKey: "auth-e2e",
-      customerKey: "customer-qa-workspace",
-    });
-    await fulfillJson(route, {
-      data: {
-        subscription,
-        billingKey: billingOverview.billingKey,
-      },
-      status: 200,
-    });
-    return true;
-  }
-
-  if (method === "POST" && path === "/workspaces/1/payments/confirm") {
-    expect(route.request().postDataJSON()).toMatchObject({
-      paymentKey: "payment-e2e",
-      orderId: "order-e2e",
-      amount: 99000,
-    });
-    await fulfillJson(route, { data: payment, status: 200 });
     return true;
   }
 
@@ -1611,6 +1701,7 @@ export async function installAppApiMocks(page: Page, seen: string[]) {
     currentVersionNo: 1,
   };
   const simulationState = createSimulationState();
+  const billingState = createBillingMockState();
 
   await page.route("**/e2e-upload/**", async (route) => {
     seen.push(`${route.request().method()} /e2e-upload/raw-log.zip`);
@@ -1620,6 +1711,7 @@ export async function installAppApiMocks(page: Page, seen: string[]) {
   await installTrackedApiRoute(page, seen, async (route, method, path, url) => {
     if (await fulfillWorkspaceShell(route, method, path)) return true;
     if (await fulfillDomainPackRead(route, method, path, domainPackState)) return true;
+    if (await fulfillBilling(route, method, path, billingState)) return true;
     if (await fulfillWorkspaceOperations(route, method, path, url)) return true;
     if (await fulfillUploadAndReview(route, method, path)) return true;
     if (await fulfillSimulation(route, method, path, url, simulationState)) return true;

--- a/frontend/src/features/cancel-subscription/api/useCancelSubscription.test.tsx
+++ b/frontend/src/features/cancel-subscription/api/useCancelSubscription.test.tsx
@@ -3,6 +3,8 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useCancelSubscription } from "./useCancelSubscription";
 import { cancelSubscription } from "@/shared/api/generated/endpoints/subscription-controller/subscription-controller";
+import { billingQueryKeys } from "@/shared/api";
+import type { BillingOverviewResponse } from "@/entities/billing";
 
 vi.mock(
   "@/shared/api/generated/endpoints/subscription-controller/subscription-controller",
@@ -16,8 +18,11 @@ vi.mock(
 
 const mockCancelSubscription = vi.mocked(cancelSubscription);
 
-function createWrapper() {
-  const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+function createQueryClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+}
+
+function createWrapper(qc = createQueryClient()) {
   return ({ children }: { children: React.ReactNode }) => (
     <QueryClientProvider client={qc}>{children}</QueryClientProvider>
   );
@@ -44,6 +49,31 @@ describe("useCancelSubscription", () => {
     });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(mockCancelSubscription).toHaveBeenCalledWith(1);
+  });
+
+  it("구독 해지 성공 시 billing overview 구독 상태를 갱신한다", async () => {
+    const queryClient = createQueryClient();
+    queryClient.setQueryData<BillingOverviewResponse>(billingQueryKeys.overview(1), {
+      subscription: { id: 1, workspaceId: 1, status: "ACTIVE", cancelAtPeriodEnd: false },
+      billingKey: undefined,
+      payments: [],
+      quotaUsages: [],
+    });
+    mockCancelSubscription.mockResolvedValue({
+      data: { id: 1, workspaceId: 1, status: "CANCELED", cancelAtPeriodEnd: true },
+    } as never);
+    const { result } = renderHook(() => useCancelSubscription(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    act(() => {
+      result.current.mutate({ workspaceId: 1 });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    const overview = queryClient.getQueryData<BillingOverviewResponse>(billingQueryKeys.overview(1));
+    expect(overview?.subscription?.status).toBe("CANCELED");
+    expect(overview?.subscription?.cancelAtPeriodEnd).toBe(true);
   });
 
   it("API 실패 시 isError 상태", async () => {

--- a/frontend/src/features/cancel-subscription/api/useCancelSubscription.ts
+++ b/frontend/src/features/cancel-subscription/api/useCancelSubscription.ts
@@ -2,7 +2,21 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { cancelSubscription } from "@/shared/api/generated/endpoints/subscription-controller/subscription-controller";
 import { billingQueryKeys, selectApiData } from "@/shared/api";
-import type { SubscriptionResponse } from "@/entities/billing";
+import type { BillingOverviewResponse, SubscriptionResponse } from "@/entities/billing";
+
+function replaceOverviewSubscription(
+  overview: BillingOverviewResponse | undefined,
+  updated: SubscriptionResponse,
+): BillingOverviewResponse | undefined {
+  if (!overview) {
+    return overview;
+  }
+
+  return {
+    ...overview,
+    subscription: updated,
+  };
+}
 
 /** DELETE /subscription — INCOMPLETE 는 즉시 해지, 그 외는 기간말 해지 예약(백엔드 규칙). */
 export function useCancelSubscription() {
@@ -14,7 +28,16 @@ export function useCancelSubscription() {
       return selectApiData(res) as SubscriptionResponse | undefined;
     },
     onSuccess: (updated, { workspaceId }) => {
-      queryClient.setQueryData(billingQueryKeys.subscription(workspaceId), updated ?? null);
+      if (updated) {
+        queryClient.setQueryData(billingQueryKeys.subscription(workspaceId), updated);
+        queryClient.setQueryData<BillingOverviewResponse | undefined>(
+          billingQueryKeys.overview(workspaceId),
+          (overview) => replaceOverviewSubscription(overview, updated),
+        );
+      } else {
+        void queryClient.invalidateQueries({ queryKey: billingQueryKeys.subscription(workspaceId) });
+        void queryClient.invalidateQueries({ queryKey: billingQueryKeys.overview(workspaceId) });
+      }
       void queryClient.invalidateQueries({ queryKey: billingQueryKeys.payments(workspaceId) });
     },
   });

--- a/frontend/src/features/cancel-subscription/api/useRefundPayment.test.tsx
+++ b/frontend/src/features/cancel-subscription/api/useRefundPayment.test.tsx
@@ -3,6 +3,8 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useRefundPayment } from "./useRefundPayment";
 import { cancelPayment } from "@/shared/api/generated/endpoints/payment-controller/payment-controller";
+import { billingQueryKeys } from "@/shared/api";
+import type { BillingOverviewResponse } from "@/entities/billing";
 
 vi.mock(
   "@/shared/api/generated/endpoints/payment-controller/payment-controller",
@@ -15,8 +17,11 @@ vi.mock(
 
 const mockCancelPayment = vi.mocked(cancelPayment);
 
-function createWrapper() {
-  const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+function createQueryClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+}
+
+function createWrapper(qc = createQueryClient()) {
   return ({ children }: { children: React.ReactNode }) => (
     <QueryClientProvider client={qc}>{children}</QueryClientProvider>
   );
@@ -45,6 +50,38 @@ describe("useRefundPayment", () => {
     });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(mockCancelPayment).toHaveBeenCalledWith(1, "pay-key-001", expect.objectContaining({ cancelReason: "고객 요청" }));
+  });
+
+  it("환불 성공 시 billing overview 결제 상태를 갱신한다", async () => {
+    const queryClient = createQueryClient();
+    queryClient.setQueryData<BillingOverviewResponse>(billingQueryKeys.overview(1), {
+      subscription: undefined,
+      billingKey: undefined,
+      payments: [
+        { id: 1, paymentKey: "pay-key-001", orderId: "order-001", status: "DONE" },
+        { id: 2, paymentKey: "pay-key-002", orderId: "order-002", status: "DONE" },
+      ],
+      quotaUsages: [],
+    });
+    mockCancelPayment.mockResolvedValue({
+      data: { id: 1, paymentKey: "pay-key-001", orderId: "order-001", status: "CANCELED" },
+    } as never);
+    const { result } = renderHook(() => useRefundPayment(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    act(() => {
+      result.current.mutate({
+        workspaceId: 1,
+        paymentKey: "pay-key-001",
+        cancelReason: "고객 요청",
+      });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    const overview = queryClient.getQueryData<BillingOverviewResponse>(billingQueryKeys.overview(1));
+    expect(overview?.payments?.[0].status).toBe("CANCELED");
+    expect(overview?.payments?.[1].status).toBe("DONE");
   });
 
   it("API 실패 시 isError 상태", async () => {

--- a/frontend/src/features/cancel-subscription/api/useRefundPayment.ts
+++ b/frontend/src/features/cancel-subscription/api/useRefundPayment.ts
@@ -2,7 +2,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { cancelPayment } from "@/shared/api/generated/endpoints/payment-controller/payment-controller";
 import { billingQueryKeys, selectApiData } from "@/shared/api";
-import type { PaymentResponse } from "@/entities/billing";
+import type { BillingOverviewResponse, PaymentResponse } from "@/entities/billing";
 
 interface RefundPaymentParams {
   workspaceId: number;
@@ -10,6 +10,34 @@ interface RefundPaymentParams {
   cancelReason: string;
   /** 미지정(undefined)이면 전액 환불. */
   cancelAmount?: number;
+}
+
+function isSamePayment(payment: PaymentResponse, updated: PaymentResponse): boolean {
+  return (
+    (payment.id !== undefined && payment.id === updated.id) ||
+    (payment.paymentKey !== undefined && payment.paymentKey === updated.paymentKey) ||
+    (payment.orderId !== undefined && payment.orderId === updated.orderId)
+  );
+}
+
+function replaceOverviewPayment(
+  overview: BillingOverviewResponse | undefined,
+  updated: PaymentResponse,
+): BillingOverviewResponse | undefined {
+  if (!overview) {
+    return overview;
+  }
+
+  const payments = overview.payments ?? [];
+  const hasPayment = payments.some((payment) => isSamePayment(payment, updated));
+  return {
+    ...overview,
+    payments: hasPayment
+      ? payments.map((payment) =>
+          isSamePayment(payment, updated) ? { ...payment, ...updated } : payment,
+        )
+      : [updated, ...payments],
+  };
 }
 
 /** POST /payments/{paymentKey}/cancel — 결제 환불(전액/부분). */
@@ -26,7 +54,13 @@ export function useRefundPayment() {
       const res = await cancelPayment(workspaceId, paymentKey, { cancelReason, cancelAmount });
       return selectApiData(res) as PaymentResponse | undefined;
     },
-    onSuccess: (_result, { workspaceId }) => {
+    onSuccess: (updated, { workspaceId }) => {
+      if (updated) {
+        queryClient.setQueryData<BillingOverviewResponse | undefined>(
+          billingQueryKeys.overview(workspaceId),
+          (overview) => replaceOverviewPayment(overview, updated),
+        );
+      }
       void queryClient.invalidateQueries({ queryKey: billingQueryKeys.payments(workspaceId) });
     },
   });

--- a/frontend/src/features/cancel-subscription/ui/CancelSubscriptionButton.test.tsx
+++ b/frontend/src/features/cancel-subscription/ui/CancelSubscriptionButton.test.tsx
@@ -69,12 +69,15 @@ describe("CancelSubscriptionButton", () => {
     );
   });
 
-  it("onSuccess: CANCELED 상태이면 해지 완료 토스트", () => {
-    render(<CancelSubscriptionButton workspaceId={1} />);
+  it("onSuccess: CANCELED 상태이면 해지 완료 토스트와 완료 콜백", () => {
+    const onCanceled = vi.fn();
+    render(<CancelSubscriptionButton workspaceId={1} onCanceled={onCanceled} />);
     clickConfirmButton();
     const { onSuccess } = mockMutate.mock.calls[0][1];
-    onSuccess({ id: 1, status: "CANCELED" });
+    const updated = { id: 1, status: "CANCELED" };
+    onSuccess(updated);
     expect(mockToastSuccess).toHaveBeenCalledWith("구독을 해지했습니다.");
+    expect(onCanceled).toHaveBeenCalledWith(updated);
   });
 
   it("onSuccess: 비CANCELED 상태이면 주기말 해지 토스트", () => {

--- a/frontend/src/features/cancel-subscription/ui/CancelSubscriptionButton.tsx
+++ b/frontend/src/features/cancel-subscription/ui/CancelSubscriptionButton.tsx
@@ -18,10 +18,11 @@ import styles from "./cancel-subscription.module.css";
 
 interface CancelSubscriptionButtonProps {
   workspaceId: number;
+  onCanceled?: (subscription: SubscriptionResponse | undefined) => void;
 }
 
 /** 구독 취소 CTA + 확인 다이얼로그. DELETE /subscription. */
-export function CancelSubscriptionButton({ workspaceId }: CancelSubscriptionButtonProps) {
+export function CancelSubscriptionButton({ workspaceId, onCanceled }: CancelSubscriptionButtonProps) {
   const [open, setOpen] = useState(false);
   const cancel = useCancelSubscription();
 
@@ -36,6 +37,7 @@ export function CancelSubscriptionButton({ workspaceId }: CancelSubscriptionButt
               : "현재 결제 주기가 끝나면 구독이 해지됩니다.",
           );
           setOpen(false);
+          onCanceled?.(updated);
         },
         onError: (error: unknown) => {
           if (error instanceof ApiRequestError) {

--- a/frontend/src/features/cancel-subscription/ui/RefundButton.test.tsx
+++ b/frontend/src/features/cancel-subscription/ui/RefundButton.test.tsx
@@ -90,14 +90,17 @@ describe("RefundButton", () => {
     );
   });
 
-  it("onSuccess: 환불 완료 토스트", () => {
-    render(<RefundButton workspaceId={1} payment={stubPayment} />);
+  it("onSuccess: 환불 완료 토스트와 완료 콜백", () => {
+    const onRefunded = vi.fn();
+    render(<RefundButton workspaceId={1} payment={stubPayment} onRefunded={onRefunded} />);
     fireEvent.click(screen.getByText("환불"));
     const allButtons = screen.getAllByRole("button");
     const confirmBtn = allButtons.find((b) => b.textContent === "환불");
     if (confirmBtn) fireEvent.click(confirmBtn);
     const { onSuccess } = mockMutate.mock.calls[0][1];
-    onSuccess();
+    const updated = { ...stubPayment, status: "CANCELED" };
+    onSuccess(updated);
     expect(vi.mocked(toast.success)).toHaveBeenCalledWith("환불을 요청했습니다.");
+    expect(onRefunded).toHaveBeenCalledWith(updated);
   });
 });

--- a/frontend/src/features/cancel-subscription/ui/RefundButton.tsx
+++ b/frontend/src/features/cancel-subscription/ui/RefundButton.tsx
@@ -20,10 +20,11 @@ import styles from "./cancel-subscription.module.css";
 interface RefundButtonProps {
   workspaceId: number;
   payment: PaymentResponse;
+  onRefunded?: (payment: PaymentResponse | undefined) => void;
 }
 
 /** 결제 환불 CTA + 사유 입력 다이얼로그. 전액 환불(cancelAmount 미전송). */
-export function RefundButton({ workspaceId, payment }: RefundButtonProps) {
+export function RefundButton({ workspaceId, payment, onRefunded }: RefundButtonProps) {
   const [open, setOpen] = useState(false);
   const [reason, setReason] = useState("고객 요청");
   const refund = useRefundPayment();
@@ -41,9 +42,10 @@ export function RefundButton({ workspaceId, payment }: RefundButtonProps) {
     refund.mutate(
       { workspaceId, paymentKey: payment.paymentKey, cancelReason: trimmed },
       {
-        onSuccess: () => {
+        onSuccess: (updated: PaymentResponse | undefined) => {
           toast.success("환불을 요청했습니다.");
           setOpen(false);
+          onRefunded?.(updated);
         },
         onError: (error: unknown) => {
           if (error instanceof ApiRequestError) {

--- a/frontend/src/pages/billing/ui/BillingPage.test.tsx
+++ b/frontend/src/pages/billing/ui/BillingPage.test.tsx
@@ -1,7 +1,9 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import type { ComponentProps } from "react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { useParams, useOutletContext, useLocation, Navigate } from "react-router-dom";
 import { useBillingOverview, usePlanCatalog } from "@/entities/billing";
+import { CancelSubscriptionButton, RefundButton } from "@/features/cancel-subscription";
 import { BillingPage } from "./BillingPage";
 
 vi.mock("react-router-dom", async (importOriginal) => {
@@ -40,7 +42,7 @@ vi.mock("@/features/pay-once", () => ({
 }));
 
 vi.mock("@/features/cancel-subscription", () => ({
-  CancelSubscriptionButton: vi.fn().mockReturnValue(null),
+  CancelSubscriptionButton: vi.fn().mockReturnValue("구독 해지"),
   RefundButton: vi.fn().mockReturnValue(null),
 }));
 
@@ -53,6 +55,8 @@ const mockUseOutletContext = vi.mocked(useOutletContext);
 const mockUseLocation = vi.mocked(useLocation);
 const mockUseBillingOverview = vi.mocked(useBillingOverview);
 const mockUsePlanCatalog = vi.mocked(usePlanCatalog);
+const mockCancelSubscriptionButton = vi.mocked(CancelSubscriptionButton);
+const mockRefundButton = vi.mocked(RefundButton);
 
 const baseSubscription = {
   id: 1,
@@ -257,6 +261,82 @@ describe("BillingPage", () => {
     setupDefaults({ data: { ...baseOverview, payments: [donePayment] } });
     render(<BillingPage />);
     expect(screen.getByText("결제 내역")).toBeTruthy();
+  });
+
+  it("활성 구독이면 구독 해지 CTA를 표시한다", () => {
+    setupDefaults();
+    render(<BillingPage />);
+    expect(screen.getByText("구독 해지")).toBeTruthy();
+  });
+
+  it("환불 완료 콜백 이후 결제 상태와 CTA를 갱신한다", () => {
+    setupDefaults({ data: { ...baseOverview, payments: [donePayment] } });
+    render(<BillingPage />);
+
+    const refundProps = mockRefundButton.mock.calls[0][0] as ComponentProps<typeof RefundButton>;
+    const refundButtonCallsBeforeCompletion = mockRefundButton.mock.calls.length;
+    act(() => {
+      refundProps.onRefunded?.(undefined);
+    });
+
+    expect(screen.getByText("취소됨")).toBeTruthy();
+    expect(mockRefundButton.mock.calls.length).toBe(refundButtonCallsBeforeCompletion);
+  });
+
+  it("구독 해지 완료 콜백 이후 해지 상태와 CTA를 갱신한다", () => {
+    setupDefaults();
+    render(<BillingPage />);
+
+    const cancelProps = mockCancelSubscriptionButton.mock.calls[0][0] as ComponentProps<
+      typeof CancelSubscriptionButton
+    >;
+    act(() => {
+      cancelProps.onCanceled?.({
+        ...baseSubscription,
+        status: "CANCELED",
+        cancelAtPeriodEnd: true,
+      });
+    });
+
+    expect(screen.getByText("해지됨")).toBeTruthy();
+    expect(screen.queryByText("구독 해지")).toBeNull();
+  });
+
+  it("구독 해지 완료 payload가 없으면 해지 예약 상태와 CTA를 갱신한다", () => {
+    setupDefaults();
+    render(<BillingPage />);
+
+    const cancelProps = mockCancelSubscriptionButton.mock.calls[0][0] as ComponentProps<
+      typeof CancelSubscriptionButton
+    >;
+    act(() => {
+      cancelProps.onCanceled?.(undefined);
+    });
+
+    expect(screen.getByText(/현재 주기 종료일/)).toBeTruthy();
+    expect(screen.queryByText("구독 해지")).toBeNull();
+  });
+
+  it("해지 예약 구독이면 중복 해지 CTA를 숨긴다", () => {
+    setupDefaults({
+      data: {
+        ...baseOverview,
+        subscription: { ...baseSubscription, status: "ACTIVE", cancelAtPeriodEnd: true },
+      },
+    });
+    render(<BillingPage />);
+    expect(screen.queryByText("구독 해지")).toBeNull();
+  });
+
+  it("해지 완료 구독이면 중복 해지 CTA를 숨긴다", () => {
+    setupDefaults({
+      data: {
+        ...baseOverview,
+        subscription: { ...baseSubscription, status: "CANCELED", cancelAtPeriodEnd: true },
+      },
+    });
+    render(<BillingPage />);
+    expect(screen.queryByText("구독 해지")).toBeNull();
   });
 
   it("quota 사용량과 한도 경고를 표시한다", () => {

--- a/frontend/src/pages/billing/ui/BillingPage.tsx
+++ b/frontend/src/pages/billing/ui/BillingPage.tsx
@@ -12,6 +12,7 @@ import {
   FREE_PLAN_KEY,
   type BillingKeyResponse,
   type PaymentResponse,
+  type SubscriptionResponse,
 } from "@/entities/billing";
 import {
   PlanComparison,
@@ -34,12 +35,44 @@ interface BillingLocationState {
   billingKey?: BillingKeyResponse;
 }
 
+interface SubscriptionOverride {
+  workspaceId: number;
+  subscription: SubscriptionResponse;
+}
+
+interface PaymentOverrides {
+  workspaceId: number;
+  payments: PaymentResponse[];
+}
+
+function isSamePayment(left: PaymentResponse, right: PaymentResponse): boolean {
+  return (
+    (left.id !== undefined && left.id === right.id) ||
+    (left.paymentKey !== undefined && left.paymentKey === right.paymentKey) ||
+    (left.orderId !== undefined && left.orderId === right.orderId)
+  );
+}
+
+function replacePayment(payments: PaymentResponse[], updated: PaymentResponse): PaymentResponse[] {
+  const hasPayment = payments.some((payment) => isSamePayment(payment, updated));
+  if (!hasPayment) {
+    return [updated, ...payments];
+  }
+  return payments.map((payment) =>
+    isSamePayment(payment, updated) ? { ...payment, ...updated } : payment,
+  );
+}
+
 export function BillingPage() {
   const { workspaceId } = useParams();
   const { setCrumbs } = useOutletContext<ShellContext>();
   const location = useLocation();
   const parsedWorkspaceId = parseRouteId(workspaceId);
   const [showPlans, setShowPlans] = useState(false);
+  const [subscriptionOverride, setSubscriptionOverride] = useState<SubscriptionOverride | null>(
+    null,
+  );
+  const [paymentOverrides, setPaymentOverrides] = useState<PaymentOverrides | null>(null);
 
   useEffect(() => {
     setCrumbs(["워크스페이스 설정", "구독"]);
@@ -49,11 +82,47 @@ export function BillingPage() {
   const overviewQuery = useBillingOverview(parsedWorkspaceId);
   const planCatalogQuery = usePlanCatalog();
   const overview = overviewQuery.data ?? null;
-  const subscription = overview?.subscription ?? null;
+  const activeSubscriptionOverride =
+    subscriptionOverride?.workspaceId === parsedWorkspaceId
+      ? subscriptionOverride.subscription
+      : null;
+  const activePaymentOverrides =
+    paymentOverrides?.workspaceId === parsedWorkspaceId ? paymentOverrides.payments : [];
+  const subscription = activeSubscriptionOverride ?? overview?.subscription ?? null;
   const showRegister = !subscription || subscription.status === "INCOMPLETE";
   const engaged = subscription?.status === "ACTIVE" || subscription?.status === "PAST_DUE";
-  const payments = overview?.payments ?? [];
+  const canCancelSubscription = engaged && !subscription?.cancelAtPeriodEnd;
+  const payments = activePaymentOverrides.reduce(
+    (currentPayments, updated) => replacePayment(currentPayments, updated),
+    overview?.payments ?? [],
+  );
   const quotaUsages = overview?.quotaUsages ?? [];
+
+  const handleRefundedPayment = (updated: PaymentResponse | undefined) => {
+    if (!updated) {
+      return;
+    }
+    if (parsedWorkspaceId === null) {
+      return;
+    }
+    setPaymentOverrides((current) => {
+      const currentPayments = current?.workspaceId === parsedWorkspaceId ? current.payments : [];
+      return {
+        workspaceId: parsedWorkspaceId,
+        payments: replacePayment(currentPayments, updated),
+      };
+    });
+  };
+
+  const handleCanceledSubscription = (updated: SubscriptionResponse | undefined) => {
+    if (!updated) {
+      return;
+    }
+    if (parsedWorkspaceId === null) {
+      return;
+    }
+    setSubscriptionOverride({ workspaceId: parsedWorkspaceId, subscription: updated });
+  };
 
   if (parsedWorkspaceId === null) {
     return <Navigate to="/workspaces" replace />;
@@ -233,7 +302,13 @@ export function BillingPage() {
                 payments={payments}
                 renderActions={(payment: PaymentResponse) =>
                   payment.status === "DONE" ? (
-                    <RefundButton workspaceId={parsedWorkspaceId} payment={payment} />
+                    <RefundButton
+                      workspaceId={parsedWorkspaceId}
+                      payment={payment}
+                      onRefunded={(updated) =>
+                        handleRefundedPayment(updated ?? { ...payment, status: "CANCELED" })
+                      }
+                    />
                   ) : null
                 }
               />
@@ -243,9 +318,18 @@ export function BillingPage() {
               </div>
             )}
 
-            <div className={styles.actionsBar}>
-              <CancelSubscriptionButton workspaceId={parsedWorkspaceId} />
-            </div>
+            {canCancelSubscription ? (
+              <div className={styles.actionsBar}>
+                <CancelSubscriptionButton
+                  workspaceId={parsedWorkspaceId}
+                  onCanceled={(updated) =>
+                    handleCanceledSubscription(
+                      updated ?? { ...subscription, cancelAtPeriodEnd: true },
+                    )
+                  }
+                />
+              </div>
+            ) : null}
           </div>
         ))}
     </div>


### PR DESCRIPTION
Closes #719

## 변경 사항

- 환불과 구독 해지가 확인 dialog의 최종 확인 이후에만 실행되고, 환불 사유가 그대로 제출되도록 Critical E2E를 강화했습니다.
- 환불/해지 성공 후 billing overview 화면이 즉시 `취소됨`, `해지됨` 또는 해지 예약 상태로 갱신되고 중복 CTA가 사라집니다.
- workspace별 billing mock 상태를 분리해 다른 workspace 구독/결제 상태가 섞이지 않음을 검증합니다.

## 검증

- `pnpm --dir frontend test -- src/features/cancel-subscription/api/useRefundPayment.test.tsx src/features/cancel-subscription/api/useCancelSubscription.test.tsx src/features/cancel-subscription/ui/RefundButton.test.tsx src/features/cancel-subscription/ui/CancelSubscriptionButton.test.tsx src/pages/billing/ui/BillingPage.test.tsx --run` (5 files, 49 tests)
- `pnpm --dir frontend exec eslint e2e/billing.spec.ts e2e/support/app-mocks.ts src/features/cancel-subscription/api/useRefundPayment.ts src/features/cancel-subscription/api/useRefundPayment.test.tsx src/features/cancel-subscription/api/useCancelSubscription.ts src/features/cancel-subscription/api/useCancelSubscription.test.tsx src/features/cancel-subscription/ui/RefundButton.tsx src/features/cancel-subscription/ui/RefundButton.test.tsx src/features/cancel-subscription/ui/CancelSubscriptionButton.tsx src/features/cancel-subscription/ui/CancelSubscriptionButton.test.tsx src/pages/billing/ui/BillingPage.tsx src/pages/billing/ui/BillingPage.test.tsx`
- `pnpm --dir frontend build`
- `pnpm --dir frontend e2e -- billing.spec.ts --workers=1` (6 passed)
- `git diff --check`

## 참고

- `pnpm --dir frontend lint`는 변경 파일 밖 기존 ESLint baseline 47건으로 실패합니다. 변경 파일 대상 ESLint와 API/FSD audits는 통과했습니다.