### PR TITLE
fix(frontend): 파일 없이 업로드 처리를 시작하지 않도록 보장

### DIFF
--- a/.agent/specs/704.md
+++ b/.agent/specs/704.md
@@ -1,0 +1,159 @@
+# Frontend FSD Spec: 파일 미선택 상태 처리 시작 방지
+
+## Goal
+
+상담 로그 업로드 화면에서 파일을 선택하지 않은 운영자가 처리 시작 흐름을 진행할 수 없고, 먼저 파일을 선택해야 한다는 상태를 명확히 확인할 수 있게 한다.
+
+---
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A["상담 로그 업로드 화면 진입"] --> B{"파일 선택됨?"}
+    B -->|No| C["처리 시작 비활성 상태와 파일 선택 안내 표시"]
+    C --> D["운영자가 파일 선택"]
+    B -->|Yes| E["파일명과 크기 미리보기 표시"]
+    D --> E
+    E --> F["처리 시작 클릭"]
+    F --> G["dataset upload init/transfer/complete 요청"]
+    G --> H["자동 파이프라인 상태 또는 검토 이동 표시"]
+```
+
+---
+
+## Design Diff
+
+### As-is vs To-be
+
+| 영역                  | As-is                                          | To-be                                                             | 변경 내용                                                                   |
+| --------------------- | ---------------------------------------------- | ----------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| 파일 미선택 idle 상태 | 업로드 박스만 표시되고 `처리 시작` 액션은 없음 | `처리 시작` 액션을 비활성으로 표시하고 파일 선택 안내를 함께 표시 | 운영자가 현재 처리 시작이 막힌 이유를 화면에서 즉시 확인                    |
+| 처리 시작 가능 조건   | 파일 선택 후에만 버튼 렌더링                   | 파일 선택 전에는 disabled, 파일 선택 후에는 enabled               | 파일 없이 dataset/pipeline 요청이 발생하지 않는 조건을 UI와 테스트에서 명시 |
+| 이전 업로드 완료 상태 | 새 파일 선택 또는 초기화 시 상태 reset         | 기존 reset 동작 유지                                              | 이전 업로드 완료 상태가 현재 선택 상태로 오인되지 않게 유지                 |
+
+---
+
+## Component Tree
+
+```text
+WorkspaceUploadPage
+└─ LogUploadForm
+   ├─ FileUploader
+   ├─ filePreview / pendingAction
+   │  └─ Button(처리 시작)
+   ├─ PipelineJobStatusPanel
+   └─ generationPanel
+```
+
+---
+
+## API Integration
+
+### Endpoints
+
+| Method | Path                                                                                    | Description                                         |
+| ------ | --------------------------------------------------------------------------------------- | --------------------------------------------------- |
+| POST   | `/workspaces/{workspaceId}/datasets/uploads:init`                                       | 파일 선택 후 처리 시작 시 raw dataset 업로드 초기화 |
+| PUT    | presigned upload URL                                                                    | 파일 선택 후 처리 시작 시 raw file 전송             |
+| POST   | `/workspaces/{workspaceId}/datasets/uploads/{datasetId}:complete`                       | 파일 선택 후 업로드 완료 처리                       |
+| GET    | `/workspaces/{workspaceId}/datasets/{datasetId}/pipeline-jobs/latest?jobType=INGESTION` | 업로드 완료 후 자동 파이프라인 상태 조회            |
+| POST   | `/workspaces/{workspaceId}/datasets/{datasetId}/pipeline-jobs/domain-pack-generation`   | 자동 파이프라인이 없을 때 수동 생성 fallback        |
+
+파일이 선택되지 않은 상태에서는 위 endpoint가 호출되지 않아야 한다.
+
+---
+
+## Data Flow
+
+```text
+LogUploadForm local state
+├─ file: File | null
+├─ status: idle | uploading | success
+├─ uploadedDataset: UploadedDataset | null
+└─ generationStatus
+
+file === null
+└─ 처리 시작 disabled + 파일 선택 안내
+
+file !== null && status === idle
+└─ 파일 미리보기 + 처리 시작 enabled
+   └─ useRawFileUpload.start()
+```
+
+---
+
+## 수정 대상 파일
+
+| 파일                                                             | 변경 유형 | 설명                                                                              |
+| ---------------------------------------------------------------- | --------- | --------------------------------------------------------------------------------- |
+| `frontend/src/features/log-upload/ui/LogUploadForm.tsx`          | modify    | 파일 미선택 상태의 비활성 처리 시작 액션과 안내 문구 표시                         |
+| `frontend/src/features/log-upload/ui/log-upload-form.module.css` | modify    | 파일 미선택/선택 액션 영역 스타일 추가                                            |
+| `frontend/src/features/log-upload/ui/LogUploadForm.test.tsx`     | modify    | 파일 미선택 상태의 disabled 처리 시작 및 upload 미호출 검증                       |
+| `frontend/e2e/workspace-core.spec.ts`                            | modify    | 파일 미선택 상태에서 dataset/pipeline 요청이 발생하지 않는 E2E 회귀 시나리오 추가 |
+
+---
+
+## State Management
+
+- 서버 상태 또는 전역 상태를 추가하지 않는다.
+- 파일 선택 여부는 기존 `LogUploadForm`의 `file` local state로 판단한다.
+- 파일 선택 전 `처리 시작`은 disabled 상태여야 하며 click handler가 upload를 시작하지 않아야 한다.
+- 파일 선택 후에는 기존 `handleUpload(file)` 흐름을 유지한다.
+- 새 파일 선택 또는 초기화 시 기존 `uploadedDataset`, `generationStatus`, upload mutation reset 동작을 유지한다.
+
+---
+
+## Tests
+
+### Test Strategy
+
+| 구분            | 방법                                                         | 도구                           | 비고                     |
+| --------------- | ------------------------------------------------------------ | ------------------------------ | ------------------------ |
+| 컴포넌트 테스트 | 파일 미선택/선택 상태 UI와 upload 호출 여부 검증             | Vitest + React Testing Library | `LogUploadForm.test.tsx` |
+| E2E 테스트      | 업로드 화면에서 파일 없이 처리 시작 불가 및 요청 미발생 검증 | Playwright                     | `workspace-core.spec.ts` |
+
+### Test Environment & 사전 조건
+
+| 항목      | 값                                                        |
+| --------- | --------------------------------------------------------- |
+| 환경      | `frontend` package test/e2e                               |
+| API Mock  | `frontend/e2e/support/app-mocks.ts`                       |
+| 사전 조건 | 인증된 workspace operator가 `/workspaces/1/upload`에 진입 |
+
+### Test Scenarios
+
+#### Happy Path
+
+| #   | 시나리오            | 사전 조건                   | 조작                              | 기대 결과                                                          |
+| --- | ------------------- | --------------------------- | --------------------------------- | ------------------------------------------------------------------ |
+| 1   | 파일 선택 후 업로드 | 운영자가 업로드 화면에 있음 | ZIP 파일 선택 후 `처리 시작` 클릭 | 기존 upload init/transfer/complete와 파이프라인 검토 흐름이 유지됨 |
+
+#### Error & Edge Cases
+
+| #   | 시나리오                   | 조작                                   | 기대 결과                                                                                |
+| --- | -------------------------- | -------------------------------------- | ---------------------------------------------------------------------------------------- |
+| 1   | 파일 미선택 상태           | 업로드 화면 진입 후 파일을 고르지 않음 | `처리 시작`은 disabled이고 파일 선택 안내가 보이며 dataset/pipeline 요청이 발생하지 않음 |
+| 2   | 이전 업로드 완료 후 초기화 | `다른 파일 업로드` 클릭                | 이전 dataset/pipeline 상태가 사라지고 파일 미선택 안내 상태로 돌아감                     |
+
+#### 반응형 & 접근성
+
+| #   | 확인 항목     | 기대 결과                                                        |
+| --- | ------------- | ---------------------------------------------------------------- |
+| 1   | 키보드 탐색   | disabled `처리 시작`은 실행되지 않고 파일 input은 계속 사용 가능 |
+| 2   | 스크린 리더   | 파일 선택 안내 텍스트가 버튼 주변 문맥으로 읽힘                  |
+| 3   | 모바일 뷰포트 | 파일 미선택 안내와 버튼이 세로 레이아웃에서 겹치지 않음          |
+
+---
+
+## Non-goals
+
+- 백엔드 upload, dataset, pipeline job API 계약은 변경하지 않는다.
+- ZIP 파일 정책과 파일 크기 제한은 변경하지 않는다.
+- 업로드 완료 이후 자동 파이프라인/수동 생성 fallback 정책은 변경하지 않는다.
+
+---
+
+## Open Questions
+
+- 없음. 이슈는 버튼 비활성화 또는 submit-time validation 중 하나를 허용하며, 본 변경은 비활성화 방식을 따른다.

--- a/frontend/e2e/workspace-core.spec.ts
+++ b/frontend/e2e/workspace-core.spec.ts
@@ -267,6 +267,30 @@ test.describe("Workspace core operator screens", () => {
     });
 
     test.describe("When they upload consultation logs and enter pipeline review", () => {
+      test("Then processing stays disabled and no upload request is sent without a file", async ({
+        page,
+      }) => {
+        await page.goto("/workspaces/1/upload");
+        await expect(page.getByRole("heading", { name: "상담 로그 업로드" })).toBeVisible();
+
+        const startButton = page.getByRole("button", { name: "처리 시작" });
+        await expect(startButton).toBeDisabled();
+        await expect(page.getByText("파일을 먼저 선택해 주세요.")).toBeVisible();
+        await expect(
+          page.getByText("처리 시작 전에 ZIP 상담 로그 파일이 필요합니다."),
+        ).toBeVisible();
+        await expect(page.locator('input[type="file"]')).toBeEnabled();
+        await expect(page).toHaveURL(/\/workspaces\/1\/upload$/);
+
+        expect(seen).not.toContain("POST /workspaces/1/datasets/uploads:init");
+        expect(seen).not.toContain("PUT /e2e-upload/raw-log.zip");
+        expect(
+          seen.some((entry) =>
+            entry.includes("/pipeline-jobs/domain-pack-generation"),
+          ),
+        ).toBe(false);
+      });
+
       test("Then upload, generation, review navigation, and domain confirmation are verified", async ({
         page,
       }, testInfo) => {

--- a/frontend/src/features/log-upload/ui/LogUploadForm.test.tsx
+++ b/frontend/src/features/log-upload/ui/LogUploadForm.test.tsx
@@ -277,12 +277,28 @@ describe("LogUploadForm", () => {
     expect(screen.getByTestId("uploader-disabled")).toHaveTextContent("false");
   });
 
+  it("keeps processing disabled until a file is selected", () => {
+    render(<LogUploadForm workspaceId={1} />, { wrapper: MemoryRouter });
+
+    expect(screen.getByText("파일을 먼저 선택해 주세요.")).toBeInTheDocument();
+    expect(
+      screen.getByText("처리 시작 전에 ZIP 상담 로그 파일이 필요합니다."),
+    ).toBeInTheDocument();
+
+    const startButton = screen.getByRole("button", { name: "처리 시작" });
+    expect(startButton).toBeDisabled();
+
+    fireEvent.click(startButton);
+
+    expect(mockUploadStart).not.toHaveBeenCalled();
+  });
+
   it("shows file preview and Start Processing button after selecting a file", () => {
     render(<LogUploadForm workspaceId={1} />, { wrapper: MemoryRouter });
     const file = new File(["test"], "test.zip", { type: "application/zip" });
     const input = screen.getByTestId("file-input");
     fireEvent.change(input, { target: { files: [file] } });
-    expect(screen.getByText("처리 시작")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "처리 시작" })).toBeEnabled();
     expect(screen.getByText("test.zip")).toBeInTheDocument();
   });
 

--- a/frontend/src/features/log-upload/ui/LogUploadForm.tsx
+++ b/frontend/src/features/log-upload/ui/LogUploadForm.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import React, { useId, useRef, useState } from "react";
 import { toast } from "sonner";
 import { useNavigate } from "react-router-dom";
 
@@ -96,6 +96,7 @@ export const LogUploadForm: React.FC<LogUploadFormProps> = ({
   isEntitlementLoading = false,
 }) => {
   const navigate = useNavigate();
+  const fileRequiredMessageId = useId();
   const [file, setFile] = useState<File | null>(null);
   const [status, setStatus] = useState<UploadStatus>("idle");
   const [uploadedDataset, setUploadedDataset] =
@@ -297,15 +298,34 @@ export const LogUploadForm: React.FC<LogUploadFormProps> = ({
         />
       </div>
 
-      {status === "idle" && file && (
-        <div className={styles.filePreview}>
-          <div className={styles.fileInfo}>
-            <span className={styles.fileName}>{file.name}</span>
-            <span className={styles.fileSize}>
-              {(file.size / 1024 / 1024).toFixed(2)} MB
-            </span>
-          </div>
-          <Button onClick={() => handleUpload(file)} disabled={isUploadBlocked}>
+      {status === "idle" && (
+        <div
+          className={`${styles.filePreview} ${file ? "" : styles.emptyFilePreview}`}
+        >
+          {file ? (
+            <div className={styles.fileInfo}>
+              <span className={styles.fileName}>{file.name}</span>
+              <span className={styles.fileSize}>
+                {(file.size / 1024 / 1024).toFixed(2)} MB
+              </span>
+            </div>
+          ) : (
+            <div className={styles.fileInfo}>
+              <span className={styles.fileName}>
+                파일을 먼저 선택해 주세요.
+              </span>
+              <span className={styles.fileSize} id={fileRequiredMessageId}>
+                처리 시작 전에 ZIP 상담 로그 파일이 필요합니다.
+              </span>
+            </div>
+          )}
+          <Button
+            onClick={() => {
+              if (file) handleUpload(file);
+            }}
+            disabled={!file || isUploadBlocked}
+            aria-describedby={file ? undefined : fileRequiredMessageId}
+          >
             처리 시작
           </Button>
         </div>

--- a/frontend/src/features/log-upload/ui/log-upload-form.module.css
+++ b/frontend/src/features/log-upload/ui/log-upload-form.module.css
@@ -55,6 +55,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 16px;
   padding: 16px 20px;
   background: rgba(0, 0, 0, 0.02);
   border-radius: var(--radius-md);
@@ -62,10 +63,16 @@
   animation: fade-in 0.3s ease;
 }
 
+.emptyFilePreview {
+  background: #ffffff;
+  border-color: rgba(0, 0, 0, 0.12);
+}
+
 .fileInfo {
   display: flex;
   flex-direction: column;
   gap: 4px;
+  min-width: 0;
 }
 
 .fileName {


### PR DESCRIPTION
Closes #704

## 변경 사항

- 이슈 704 요구사항과 acceptance criteria를 `.agent/specs/704.md`에 정리했습니다.
- 상담 로그 업로드 화면의 파일 미선택 idle 상태에서도 `처리 시작` 액션을 비활성으로 표시하고, 먼저 ZIP 파일을 선택해야 한다는 안내를 함께 노출합니다.
- 파일이 선택되지 않은 상태에서는 click handler가 upload 흐름을 시작하지 않도록 보호하고, 파일 선택 후에는 기존 업로드/파이프라인 검토 흐름을 유지합니다.
- 업로드 화면 컴포넌트 테스트와 mocked workspace E2E로 파일 미선택 상태의 dataset/pipeline 요청 미발생을 고정했습니다.

## 검증

- `pnpm --dir frontend test -- src/features/log-upload/ui/LogUploadForm.test.tsx --run` (1 file, 22 tests)
- `pnpm --dir frontend exec eslint src/features/log-upload/ui/LogUploadForm.tsx src/features/log-upload/ui/LogUploadForm.test.tsx e2e/workspace-core.spec.ts`
- `pnpm exec prettier --check .agent/specs/704.md frontend/src/features/log-upload/ui/LogUploadForm.test.tsx frontend/src/features/log-upload/ui/LogUploadForm.tsx frontend/src/features/log-upload/ui/log-upload-form.module.css`
- `pnpm --dir frontend build`
- `pnpm --dir frontend exec playwright test e2e/workspace-core.spec.ts -g "processing stays disabled"` (1 passed, 직접 빌드한 preview 서버 재사용)
- `pnpm --dir frontend exec playwright test e2e/workspace-core.spec.ts -g "upload, generation, review navigation"` (1 passed, 직접 빌드한 preview 서버 재사용)

## 참고

- 구현 전 `LogUploadForm`, `FileUploader`, `WorkspaceUploadPage`, 기존 `LogUploadForm.test.tsx`, `workspace-core.spec.ts`, `app-mocks.ts`, `frontend/DESIGN.md`, frontend FSD/API/test rules를 확인했습니다.
- spec review 2회 수행: issue fidelity와 Ostone repository compliance 관점에서 확인했고, affected paths와 검증 기준을 최종 diff에 맞췄습니다.
- self-review 3회 수행: Round 1에서 파일 미선택/선택/이전 업로드 reset 흐름을 확인했고, Round 2에서 FSD/API 통합과 변경 파일 lint를 확인했으며, Round 3에서 의도치 않은 E2E 전체 formatter churn을 발견해 되돌린 뒤 targeted 검증을 재수행했습니다.
- `CI=1 pnpm --dir frontend exec playwright test e2e/workspace-core.spec.ts -g "processing stays disabled"`는 로컬 port 3000에 다른 worktree preview가 떠 있던 상태와 Playwright webServer 재시작 충돌로 실패했으며, 해당 preview를 종료하고 이 worktree에서 직접 빌드한 preview 서버를 재사용한 focused E2E는 통과했습니다.
- `pnpm --dir frontend lint`와 pre-commit hook의 `pnpm run lint:frontend`는 이번 변경과 무관한 기존 frontend ESLint baseline 47건으로 실패합니다. 변경 파일 대상 ESLint, API/FSD audits, targeted unit/E2E, build, formatting check는 통과했습니다.
- hook 실패는 repository-wide lint baseline 때문이라 변경 파일 대상 검증을 근거로 hook을 우회해 커밋했습니다.