### PR TITLE
test(frontend): 도메인팩 승인 준비 blocker를 보장

### DIFF
--- a/.agent/specs/726.md
+++ b/.agent/specs/726.md
@@ -1,0 +1,68 @@
+# 승인 준비 blocker가 남은 Domain Pack 승인 차단 E2E
+
+## Goal
+
+운영자가 Domain Pack draft 버전을 승인하기 전에 승인 준비 blocker를 확인하고, blocker가 남아 있으면 승인 dialog나 activate 요청으로 진행할 수 없음을 Critical E2E로 보장한다.
+
+## Problem
+
+현재 `frontend/src/features/domain-pack-summary-read/ui/DomainPackApprovalCard.tsx`와 `frontend/src/features/domain-pack-summary-read/model/useDomainPackApprovalReadiness.ts`는 blocker 계산과 카드 단위 동작을 다루지만, 실제 Domain Pack summary route에서 approval readiness gate가 브라우저 흐름으로 검증되지 않는다. 이슈 #726은 미검토 Intent, 최신 버전 아님, readiness 조회 실패 같은 blocker가 승인 가능 상태로 오해되지 않아야 한다는 P1 E2E Critical 요구사항이다.
+
+## Scope
+
+- Domain Pack summary 화면의 draft 승인 경로에서 승인 준비 상태 카드를 노출한다.
+- draft 승인은 기존 `POST /api/v1/workspaces/{workspaceId}/domain-packs/{packId}/versions/{versionId}/activate` 호출을 사용하되, readiness가 ready가 아닐 때는 UI에서 호출할 수 없어야 한다.
+- 미검토 Intent blocker는 blocker 메시지와 `Intent 검토하기` action path를 제공해야 한다.
+- mocked Playwright E2E는 draft v3에 미검토 Intent가 남은 fixture를 사용해 approval dialog 미노출, activate 요청 미호출, Intent 검토 화면 이동을 검증한다.
+- readiness 조회 실패는 기존 hook/card fail-closed 단위 테스트를 유지하고, 이번 E2E는 action path가 있는 blocker 흐름에 집중한다.
+
+## Non-goals
+
+- Backend activate API 정책이나 database schema를 변경하지 않는다.
+- generated OpenAPI client를 직접 수정하지 않는다.
+- deploy 가능한 PUBLISHED version의 배포 흐름을 변경하지 않는다.
+- Intent 승인/반려 화면 자체의 상세 동작을 새로 구현하지 않는다.
+
+## Affected Paths
+
+- `frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.tsx`
+- `frontend/src/features/domain-pack-summary-read/ui/DomainPackApprovalCard.tsx`
+- `frontend/src/features/domain-pack-summary-read/model/useDomainPackApprovalReadiness.ts`
+- `frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.tsx`
+- `frontend/e2e/domain-pack-core.spec.ts`
+- `frontend/e2e/support/app-mocks.ts`
+
+## Requirements
+
+1. Domain Pack summary route에서 DRAFT version을 볼 때 approval readiness gate가 활성화되어야 한다.
+2. 선택 version이 pack 내 최신 DRAFT이고 미검토 Intent가 남아 있으면 blocker 메시지를 표시해야 한다.
+3. blocker가 있는 상태에서 승인 버튼은 disabled 상태여야 한다.
+4. blocker가 있는 상태에서 approval dialog는 열리지 않아야 한다.
+5. blocker가 있는 상태에서 activate API 요청은 발생하지 않아야 한다.
+6. `Intent 검토하기` action은 같은 workspace/pack/version의 Intent 목록 화면으로 이동해야 한다.
+7. readiness 조회 실패는 ready 상태로 취급하지 않고 서버 blocker와 재시도 action을 제공하는 기존 fail-closed 동작을 유지해야 한다.
+
+## Data/API Impact
+
+- production API contract 변경은 없다.
+- mocked E2E fixture에서 `GET /workspaces/1/domain-packs/1/versions/3/intents`가 DRAFT Intent를 반환하도록 조정한다.
+- activate endpoint는 기존 mock을 유지하되 blocker E2E에서는 호출되지 않음을 검증한다.
+
+## Acceptance Criteria
+
+- `frontend/e2e/domain-pack-core.spec.ts`에 approval readiness blocker Critical E2E가 존재한다.
+- blocker E2E는 draft v3 summary에서 `승인 준비 상태`, blocker 문구, disabled `승인` 버튼을 검증한다.
+- blocker E2E는 `POST /workspaces/1/domain-packs/1/versions/3/activate`가 발생하지 않음을 검증한다.
+- blocker E2E는 `Intent 검토하기` 클릭 후 `/workspaces/1/domain-packs/1/intents?versionId=3`으로 이동함을 검증한다.
+- 기존 deploy E2E와 draft discard 흐름은 계속 동작한다.
+
+## Validation Expectations
+
+- `pnpm --dir frontend test -- SummaryDetailPanel.test.tsx DomainPackApprovalCard.test.tsx useDomainPackApprovalReadiness.test.ts --run`
+- `pnpm --dir frontend exec eslint e2e/domain-pack-core.spec.ts e2e/support/app-mocks.ts src/features/domain-pack-summary-read/ui/SummaryDetailPanel.tsx src/features/domain-pack-summary-read/ui/SummaryDetailPanel.test.tsx src/pages/domain-pack/ui/DomainPackSummaryPage.tsx`
+- `pnpm --dir frontend exec playwright test e2e/domain-pack-core.spec.ts --grep @critical`
+- `git diff --check`
+
+## Open Questions
+
+- Backend activate가 미검토 Intent까지 최종 차단해야 하는지는 이슈 본문에서 별도 구현 범위로 확정되지 않았다. 이번 PR은 현재 frontend readiness gate와 E2E Critical 회귀 보장에 집중한다.

--- a/frontend/e2e/domain-pack-core.spec.ts
+++ b/frontend/e2e/domain-pack-core.spec.ts
@@ -147,8 +147,8 @@ test.describe("Domain pack core read flows", () => {
       });
     });
 
-    test.describe("When they apply and discard a draft version", () => {
-      test("Then the draft action dialogs send the selected version operations", async ({
+    test.describe("When approval readiness has blockers on a draft version @critical", () => {
+      test("Then approval is blocked and the blocker action opens Intent review", async ({
         page,
       }, testInfo) => {
         await page.goto("/workspaces/1/domain-packs/1?versionId=3");
@@ -160,17 +160,28 @@ test.describe("Domain pack core read flows", () => {
         ).toBeVisible();
         await expect(page.getByText("고액 환불 정책")).toBeVisible();
         await expect(page.getByText("고액 환불 검토 워크플로우")).toBeVisible();
-        await captureScreen(page, testInfo, "domain-pack-draft-actions");
 
-        await page.getByRole("button", { name: "적용", exact: true }).click();
-        await expect(page.getByRole("alertdialog")).toContainText(
-          "검토 중인 v3 수정버전을 적용할까요?",
+        const approval = page.getByRole("region", { name: "승인 준비 상태" });
+        await expect(approval).toBeVisible();
+        await expect(approval).toContainText("차단됨");
+        await expect(approval).toContainText(
+          "승인 또는 반려되지 않은 Intent가 1개 남아 있습니다.",
         );
-        await page.getByLabel("변경사항 정리").fill("검토본 적용 메모");
-        await page.getByRole("button", { name: "적용하기" }).click();
-        await expect(page.getByText("초안 수정버전이 적용되었습니다.")).toBeVisible();
-        expect(seen).toContain("POST /workspaces/1/domain-packs/1/versions/3/activate");
+        await expect(approval.getByRole("button", { name: "승인", exact: true })).toBeDisabled();
+        await expect(page.getByRole("alertdialog")).toHaveCount(0);
+        expect(seen).not.toContain("POST /workspaces/1/domain-packs/1/versions/3/activate");
+        await captureScreen(page, testInfo, "domain-pack-approval-blockers");
 
+        await approval.getByRole("button", { name: /Intent 검토하기/ }).click();
+        await expect(page).toHaveURL(/\/workspaces\/1\/domain-packs\/1\/intents\?versionId=3/);
+        await expect(page.getByText("고액 환불 문의")).toBeVisible();
+        expect(seen).toContain("GET /workspaces/1/domain-packs/1/versions/3/intents");
+        expect(seen).not.toContain("POST /workspaces/1/domain-packs/1/versions/3/activate");
+      });
+    });
+
+    test.describe("When they discard a draft version", () => {
+      test("Then the discard dialog removes the selected draft", async ({ page }) => {
         await page.goto("/workspaces/1/domain-packs/1?versionId=3");
         await page.getByRole("button", { name: "삭제", exact: true }).click();
         await expect(page.getByRole("alertdialog")).toContainText(

--- a/frontend/e2e/support/app-mocks.ts
+++ b/frontend/e2e/support/app-mocks.ts
@@ -298,7 +298,14 @@ function componentPreviewData(versionId: number, section: DomainPackComponentSec
   const suffix = versionId === 3 ? "고액 환불" : "상담사 연결";
 
   if (section === "intents") {
-    return [{ ...intent, domainPackVersionId: versionId, name: `${suffix} 문의` }];
+    return [
+      {
+        ...intent,
+        domainPackVersionId: versionId,
+        name: `${suffix} 문의`,
+        status: versionId === 3 ? "DRAFT" : intent.status,
+      },
+    ];
   }
 
   if (section === "slots") {

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.test.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { QueryClient, QueryClientProvider, type UseQueryResult } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router-dom";
 import type { DomainPackVersionDetail } from "@/entities/domain-pack";
 import { ApiRequestError } from "@/shared/api";
 import { SummaryDetailPanel } from "./SummaryDetailPanel";
@@ -66,7 +67,11 @@ const publishedDetail: DomainPackVersionDetail = {
 
 function renderSummaryDetailPanel(ui: React.ReactElement) {
   const queryClient = new QueryClient();
-  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>{ui}</MemoryRouter>
+    </QueryClientProvider>,
+  );
 }
 
 describe("SummaryDetailPanel", () => {
@@ -375,6 +380,29 @@ describe("SummaryDetailPanel", () => {
     expect(screen.getByRole("button", { name: "적용" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "삭제" })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "배포" })).not.toBeInTheDocument();
+  });
+
+  it("승인 준비 gate가 활성화된 DRAFT 버전은 적용 버튼 대신 승인 준비 상태를 표시한다", () => {
+    renderSummaryDetailPanel(
+      <SummaryDetailPanel
+        query={makeQuery({ data: stubDetail })}
+        wsId={1}
+        packId={2}
+        versions={[
+          { versionId: 3, versionNo: 1, lifecycleStatus: "DRAFT" },
+          { versionId: 4, versionNo: 2, lifecycleStatus: "DRAFT" },
+        ]}
+        approvalReadinessEnabled
+        onApplyDraft={vi.fn()}
+        onDiscardDraft={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("승인 준비 상태")).toBeInTheDocument();
+    expect(screen.getByText("최신 버전만 승인할 수 있습니다.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "승인" })).toBeDisabled();
+    expect(screen.queryByRole("button", { name: "적용" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "삭제" })).toBeInTheDocument();
   });
 
   it("DRAFT 버전에서는 제공된 action callback의 버튼만 표시한다", () => {

--- a/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.tsx
+++ b/frontend/src/features/domain-pack-summary-read/ui/SummaryDetailPanel.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import type { UseQueryResult } from "@tanstack/react-query";
-import type { DomainPackVersionDetail } from "@/entities/domain-pack";
+import type { DomainPackVersionDetail, DomainPackVersionSummary } from "@/entities/domain-pack";
 import { ApiRequestError } from "@/shared/api";
 import { Button } from "@/shared/ui/button";
 import { ErrorState } from "@/shared/ui/ostone/atoms/ErrorState";
@@ -15,6 +15,7 @@ import {
 import { SummaryJsonCard } from "./SummaryJsonCard";
 import { ComponentCountGrid } from "./ComponentCountGrid";
 import { useDomainPackRevisionSummary } from "../model/useDomainPackRevisionSummary";
+import { useDomainPackApprovalReadiness } from "../model/useDomainPackApprovalReadiness";
 import {
   buildActionSummary,
   formatCurrentVersionLabel,
@@ -23,6 +24,7 @@ import {
   formatVersionNo,
   normalizeDescription,
 } from "../model/versionFormat";
+import { DomainPackApprovalCard } from "./DomainPackApprovalCard";
 import styles from "./SummaryDetailPanel.module.css";
 
 interface SummaryDetailPanelProps {
@@ -34,6 +36,8 @@ interface SummaryDetailPanelProps {
   deployingVersionId?: number | null;
   applyingVersionId?: number | null;
   discardingVersionId?: number | null;
+  versions?: DomainPackVersionSummary[];
+  approvalReadinessEnabled?: boolean;
   onDeploy?: (versionId: number) => void;
   onApplyDraft?: (versionId: number, description?: string) => void;
   onDiscardDraft?: (versionId: number) => void;
@@ -48,6 +52,8 @@ export function SummaryDetailPanel({
   deployingVersionId = null,
   applyingVersionId = null,
   discardingVersionId = null,
+  versions = [],
+  approvalReadinessEnabled = false,
   onDeploy,
   onApplyDraft,
   onDiscardDraft,
@@ -71,11 +77,23 @@ export function SummaryDetailPanel({
     onApplyDraft != null && versionId != null && isDraftVersion && !isApplying && !isDiscarding;
   const canDiscardDraft =
     onDiscardDraft != null && versionId != null && isDraftVersion && !isApplying && !isDiscarding;
+  const shouldUseApprovalReadiness =
+    approvalReadinessEnabled && isDraftVersion && versionId != null && onApplyDraft != null;
+  const shouldRenderDraftActions =
+    isDraftVersion &&
+    versionId != null &&
+    (onDiscardDraft != null || (onApplyDraft != null && !shouldUseApprovalReadiness));
   const revisionSummaryState = useDomainPackRevisionSummary({
     workspaceId: wsId,
     packId,
     versionId,
     summaryJson: v?.summaryJson,
+  });
+  const approvalReadiness = useDomainPackApprovalReadiness({
+    workspaceId: wsId,
+    packId,
+    version: approvalReadinessEnabled ? v : undefined,
+    versions,
   });
 
   const handleConfirmDeploy = () => {
@@ -87,6 +105,10 @@ export function SummaryDetailPanel({
     if (!canApplyDraft) return;
     onApplyDraft(versionId, normalizeDescription(applyDescription));
     setApplyDialogOpen(false);
+  };
+  const handleConfirmApproval = () => {
+    if (!canApplyDraft || versionId == null || !approvalReadiness.ready) return;
+    onApplyDraft?.(versionId);
   };
   const handleConfirmDiscard = () => {
     if (!canDiscardDraft) return;
@@ -150,7 +172,7 @@ export function SummaryDetailPanel({
         </div>
         <div className={styles.metaSide}>
           {v.description ? <p className={styles.versionDescription}>{v.description}</p> : null}
-          {isDraftVersion && versionId != null && (onApplyDraft || onDiscardDraft) ? (
+          {shouldRenderDraftActions ? (
             <div className={styles.deployActions}>
               {onDiscardDraft && (
                 <button
@@ -164,7 +186,7 @@ export function SummaryDetailPanel({
                   {isDiscarding ? "삭제 중..." : "삭제"}
                 </button>
               )}
-              {onApplyDraft && (
+              {onApplyDraft && !shouldUseApprovalReadiness && (
                 <button
                   type="button"
                   className={styles.deployButton}
@@ -196,6 +218,16 @@ export function SummaryDetailPanel({
           ) : null}
         </div>
       </div>
+
+      {shouldUseApprovalReadiness && (
+        <DomainPackApprovalCard
+          readiness={approvalReadiness}
+          isActivating={isApplying}
+          isPublished={false}
+          onApprove={handleConfirmApproval}
+          onRetryReadiness={approvalReadiness.retry}
+        />
+      )}
 
       <AlertDialog
         open={isDeployDialogOpen}

--- a/frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.tsx
+++ b/frontend/src/pages/domain-pack/ui/DomainPackSummaryPage.tsx
@@ -294,6 +294,8 @@ function DomainPackSummaryPageContent({
             packId={packId}
             currentVersionId={currentVersionId}
             currentVersionNo={currentVersionNo}
+            versions={pack?.versions ?? []}
+            approvalReadinessEnabled
             deployingVersionId={
               deployMutation.isPending ? deployMutation.variables?.versionId : null
             }


### PR DESCRIPTION
Closes #726

## 변경 사항

- 이슈 726 요구사항과 acceptance criteria를 `.agent/specs/726.md`에 정리했습니다.
- Domain Pack summary의 DRAFT 버전 승인 경로에서 approval readiness gate를 노출하고, blocker가 남아 있으면 기존 activate 요청 경로로 진행할 수 없도록 막았습니다.
- 미검토 Intent blocker가 남은 draft fixture를 구성하고, `Intent 검토하기` action이 같은 workspace/pack/version의 Intent 검토 화면으로 이동함을 Critical E2E로 보장했습니다.
- readiness gate가 활성화된 summary panel에서는 legacy `적용` 버튼 대신 승인 준비 카드가 승인 액션을 소유하도록 했고, `삭제` 흐름은 유지했습니다.

## 검증

- `pnpm --dir frontend test -- SummaryDetailPanel.test.tsx DomainPackApprovalCard.test.tsx useDomainPackApprovalReadiness.test.ts --run` (3 files, 47 tests)
- `pnpm --dir frontend test -- DomainPackSummaryPage.test.tsx --run` (1 file, 36 tests)
- `pnpm --dir frontend exec eslint e2e/domain-pack-core.spec.ts e2e/support/app-mocks.ts src/features/domain-pack-summary-read/ui/SummaryDetailPanel.tsx src/features/domain-pack-summary-read/ui/SummaryDetailPanel.test.tsx src/pages/domain-pack/ui/DomainPackSummaryPage.tsx`
- `pnpm --dir frontend exec playwright test e2e/domain-pack-core.spec.ts --grep @critical` (8 passed)
- `git diff --check`
- `git diff --cached --check`

## 참고

- 구현 전 `SummaryDetailPanel`, `DomainPackApprovalCard`, `useDomainPackApprovalReadiness`, `DomainPackSummaryPage`, `domain-pack-core.spec.ts`, `app-mocks.ts`, `frontend/DESIGN.md`, frontend FSD/API/test rules를 확인했습니다.
- spec review 2회 수행: issue fidelity와 Ostone repository compliance 관점에서 확인했고, affected paths와 검증 기준을 최종 diff에 맞췄습니다.
- self-review 3회 수행: Round 1에서 spec validation command mismatch를 수정했고, Round 2에서 page wiring과 version-list readiness dependency를 확인했으며, Round 3에서 blocker E2E가 dialog 미노출, activate 미호출, Intent 검토 이동을 함께 고정하는지 점검했습니다.
- `pnpm --dir frontend lint`와 pre-commit hook의 `pnpm run lint:frontend`는 이번 변경과 무관한 기존 frontend ESLint baseline 47건으로 실패합니다. 변경 파일 대상 ESLint, targeted unit/E2E, diff whitespace checks는 통과했습니다.
- hook 실패는 repository-wide lint baseline 때문이라 변경 파일 대상 검증을 근거로 우회해 커밋했습니다.