### PR TITLE
fix(ml): stage worker가 Python 표준 라이브러리를 읽도록 보장

### DIFF
--- a/ml/Dockerfile.cpu
+++ b/ml/Dockerfile.cpu
@@ -9,19 +9,26 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
 WORKDIR /app
 ENV UV_PYTHON=3.13
+ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
+ENV UV_CACHE_DIR=/app/.cache/uv
+ENV UV_LINK_MODE=copy
 ENV HF_HOME=/app/.cache/huggingface
 ENV TORCH_HOME=/app/.cache/torch
 ENV PYTHONPATH=/app/src
 
 COPY ml/pyproject.toml ml/uv.lock ml/README.md ./
 COPY ml/src/ml/ ./src/ml/
-RUN uv sync --python 3.13 --frozen --no-dev
+RUN mkdir -p "$UV_PYTHON_INSTALL_DIR" "$UV_CACHE_DIR" \
+    && uv sync --python 3.13 --frozen --no-dev \
+    && uv cache clean
 
 COPY ml/src/ ./src/
 
 RUN groupadd --system appgroup \
     && useradd --system --gid appgroup --home-dir /app appuser \
-    && chown -R appuser:appgroup /app
+    && chown -R appuser:appgroup /app "$UV_PYTHON_INSTALL_DIR"
 USER appuser
+
+RUN /app/.venv/bin/python -c "import encodings"
 
 ENTRYPOINT ["/app/.venv/bin/python", "-m", "pipeline.ecs_stage_worker"]

--- a/ml/Dockerfile.gpu
+++ b/ml/Dockerfile.gpu
@@ -24,7 +24,6 @@ COPY ml/src/ml/ ./src/ml/
 # Install runtime dependencies and the local BGE-M3 backend used in production.
 RUN mkdir -p "$UV_PYTHON_INSTALL_DIR" "$UV_CACHE_DIR" \
     && uv sync --python 3.13 --frozen --no-dev \
-    && uv pip install "FlagEmbedding>=1.3" "torch>=2.6" \
     && uv cache clean
 
 # Copy application code

--- a/ml/Dockerfile.gpu
+++ b/ml/Dockerfile.gpu
@@ -10,6 +10,9 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
 WORKDIR /app
 ENV UV_PYTHON=3.13
+ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
+ENV UV_CACHE_DIR=/app/.cache/uv
+ENV UV_LINK_MODE=copy
 ENV HF_HOME=/app/.cache/huggingface
 ENV TORCH_HOME=/app/.cache/torch
 ENV PYTHONPATH=/app/src
@@ -19,15 +22,19 @@ COPY ml/pyproject.toml ml/uv.lock ml/README.md ./
 COPY ml/src/ml/ ./src/ml/
 
 # Install runtime dependencies and the local BGE-M3 backend used in production.
-RUN uv sync --python 3.13 --frozen --no-dev \
-    && uv pip install "FlagEmbedding>=1.3" "torch>=2.6"
+RUN mkdir -p "$UV_PYTHON_INSTALL_DIR" "$UV_CACHE_DIR" \
+    && uv sync --python 3.13 --frozen --no-dev \
+    && uv pip install "FlagEmbedding>=1.3" "torch>=2.6" \
+    && uv cache clean
 
 # Copy application code
 COPY ml/src/ ./src/
 
 RUN groupadd --system appgroup && useradd --system --gid appgroup --home-dir /app appuser \
-    && chown -R appuser:appgroup /app
+    && chown -R appuser:appgroup /app "$UV_PYTHON_INSTALL_DIR"
 USER appuser
+
+RUN /app/.venv/bin/python -c "import encodings"
 
 # AWS credentials are provided through the ECS task role.
 ENTRYPOINT ["/app/.venv/bin/python", "-m", "pipeline.ecs_stage_worker"]


### PR DESCRIPTION
## 변경 사항

- ML CPU/GPU stage worker 이미지가 uv-managed Python을 appuser가 읽을 수 있는 `/opt/uv/python` 아래에 설치하도록 했습니다.
- venv 패키지를 uv cache에 의존하지 않도록 copy mode로 설치하고, build 후 uv cache를 비웁니다.
- 이미지 build 중 appuser 권한으로 `/app/.venv/bin/python -c "import encodings"`를 실행해 Python 표준 라이브러리 접근을 검증합니다.

## 배경

PR #750 배포 후 GPU stage task가 runtime uv cache 권한 문제는 통과했지만, CUDA 기반 GPU 이미지에서 직접 실행한 `/app/.venv/bin/python`이 `Fatal Python error: Failed to import encodings module` 및 `ModuleNotFoundError: No module named 'encodings'`로 종료됐습니다. CUDA 이미지에서 uv가 설치한 Python 표준 라이브러리 위치를 appuser가 안정적으로 읽을 수 있도록 고정합니다.

## 검증

- `git diff --check`
- `git diff --cached --check`
- 최소 CUDA/uv Docker build에서 `UV_PYTHON_INSTALL_DIR=/opt/uv/python`, `UV_CACHE_DIR=/app/.cache/uv`, `UV_LINK_MODE=copy`, `uv cache clean` 적용 후 appuser 권한의 `/app/.venv/bin/python -c "import encodings"` 통과

## 참고

- 전체 `ml/Dockerfile.gpu` 로컬 build는 macOS/Orbstack arm64 환경에서 `zlib-state` source build가 `cc` 부재로 중단되어 운영 x86_64 GPU 이미지 조건과 분리해 판단했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CPU 및 GPU Docker 빌드 프로세스의 의존성 관리를 최적화했습니다.
  * 컨테이너 빌드 중 캐시 정리 및 디렉터리 설정 절차를 개선했습니다.
  * Python 환경 설정의 권한 관리를 확대했습니다.
  * 빌드 시 Python 환경 검증 단계를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->