### PR TITLE
fix(frontend): 도메인팩 상태 조회 실패를 안전하게 안내

### DIFF
--- a/.agent/specs/701.md
+++ b/.agent/specs/701.md
@@ -1,0 +1,116 @@
+# Frontend FSD Spec: Domain Pack 상태 조회 실패 오류 상태
+
+## Goal
+
+운영자가 workspace dashboard에 진입했을 때 Domain Pack 상태 조회가 실패하면 빈 상태나 운영 중 상태로 오해하지 않고, 안전한 오류 상태와 복구 행동을 확인할 수 있게 한다.
+
+## Issue Summary
+
+GitHub Issue #701은 Domain Pack 상태 조회 실패가 실제 Domain Pack 없음 또는 운영 중 상태로 보이면 안 된다는 P2 Critical E2E 후보다. 현재 코드 기준 workspace dashboard의 운영 지식팩 상태는 `KnowledgePackHealthPanel`이 `/api/v1/workspaces/{workspaceId}/dashboard/knowledge-pack-health`를 조회해 표시한다. 조회 실패 fixture와 빈 상태 fixture를 분리하고, 실패 시 현재 workspace context를 유지한 오류 상태와 재시도 행동을 사용자 시나리오로 고정한다.
+
+## User Flow Chart
+
+```mermaid
+flowchart TD
+    A["운영자가 workspace dashboard 진입"] --> B["Domain Pack 상태 조회 요청"]
+    B --> C{"조회 성공?"}
+    C -->|Yes + active pack| D["운영 지식팩 상태 표시"]
+    C -->|Yes + no pack| E["업로드/생성 CTA가 있는 빈 상태 안내"]
+    C -->|No| F["안전한 오류 상태 표시"]
+    F --> G["운영 중 pack 또는 빈 상태 문구 비노출"]
+    F --> H["다시 시도 버튼 제공"]
+    H --> B
+```
+
+## Design Diff
+
+| 영역 | As-is | To-be | 변경 내용 |
+| --- | --- | --- | --- |
+| 오류 UI | `KnowledgePackHealthPanel`이 오류 문구를 표시하지만 명시적 복구 행동은 없음 | 오류 문구와 `다시 시도` 버튼을 함께 표시 | 조회 실패 후 재시도 행동을 화면에서 바로 제공 |
+| 상태 구분 | mocked E2E가 정상 dashboard health fixture만 검증 | 조회 실패 fixture를 별도로 두고 빈 상태/운영 중 상태 문구가 보이지 않음을 검증 | 실패와 실제 Domain Pack 없음 상태를 테스트 데이터에서 분리 |
+| Workspace context | dashboard route는 현재 workspace URL을 유지 | 오류 상태에서도 `/workspaces/{id}/dashboard` context 유지 | 실패 때문에 잘못된 초기 화면 또는 다른 workspace 상태로 이동하지 않음 |
+
+## Component Tree
+
+```text
+WorkspaceDashboardPage
+└─ KnowledgePackHealthPanel
+   ├─ useWorkspaceDashboardHealth(workspaceId)
+   ├─ LoadingSpinner
+   ├─ ErrorState(onRetry)
+   └─ buildWorkspaceDashboardHealthView(success data)
+
+frontend/e2e/workspace-core.spec.ts
+└─ Workspace dashboard health failure scenario
+   └─ installAppApiMocks({ dashboardKnowledgePackHealth: "error" })
+```
+
+## API Integration
+
+테스트와 제품 코드는 기존 dashboard endpoint를 유지한다.
+
+| Method | Path | 목적 |
+| --- | --- | --- |
+| `GET` | `/api/v1/workspaces/{workspaceId}/dashboard/knowledge-pack-health` | 운영 지식팩 상태 조회 |
+| `GET` | `/api/v1/workspaces/{workspaceId}/consultation/metrics` | dashboard 본문 지표 유지 확인 |
+| `GET` | `/api/v1/workspaces/{workspaceId}/dashboard/action-recommendations` | dashboard 추천 액션 유지 확인 |
+| `GET` | `/api/v1/workspaces/{workspaceId}/dashboard/workflow-rankings` | dashboard workflow ranking 유지 확인 |
+
+신규 backend API, OpenAPI generated client, DB schema는 만들지 않는다. 해당 dashboard health endpoint는 아직 OpenAPI generated 함수가 없어 기존 `customFetch` wrapper를 유지한다.
+
+## Data Flow
+
+```text
+workspace route id
+  -> KnowledgePackHealthPanel
+  -> useWorkspaceDashboardHealth(workspaceId)
+     -> success: buildWorkspaceDashboardHealthView(data)
+     -> error: ErrorState(message, refetch)
+  -> user clicks 다시 시도
+     -> same workspace query refetch
+```
+
+## 수정 대상 파일
+
+| 파일 | 변경 유형 | 설명 |
+| --- | --- | --- |
+| `.agent/specs/701.md` | new | Issue #701 요구사항과 검증 기준 기록 |
+| `frontend/src/features/workspace-dashboard-health/ui/KnowledgePackHealthPanel.tsx` | modify | 조회 실패 시 `ErrorState`에 재시도 핸들러 전달 |
+| `frontend/src/features/workspace-dashboard-health/ui/KnowledgePackHealthPanel.test.tsx` | modify | 오류 상태의 재시도 버튼과 stale/빈 상태 비노출 검증 |
+| `frontend/e2e/support/app-mocks.ts` | modify | dashboard knowledge pack health 실패 fixture 옵션 추가 |
+| `frontend/e2e/workspace-core.spec.ts` | modify | Domain Pack 상태 조회 실패 시 안전한 오류 상태와 재시도 요청을 검증 |
+
+## State Management
+
+- TanStack Query key는 `["workspace-dashboard-health", workspaceId]` 형태를 유지한다.
+- `isError` 상태에서는 `data`가 남아 있어도 성공 view를 렌더링하지 않는다.
+- 재시도는 같은 workspace id로 `refetch`만 호출하며 route, workspace marker, dashboard filters를 변경하지 않는다.
+- 조회 실패 fixture는 빈 Domain Pack fixture가 아니라 HTTP 실패 응답으로 구성한다.
+
+## Acceptance Criteria
+
+- `GET /workspaces/{workspaceId}/dashboard/knowledge-pack-health` 실패 시 `운영 지식팩 상태를 불러오지 못했습니다.` 오류 상태가 보인다.
+- 오류 상태에는 `다시 시도` 버튼이 있고 클릭하면 같은 health endpoint를 다시 요청한다.
+- 오류 상태에서 `운영 지식팩 건강도`, `v1`, `Generated API Pack`, `운영 지식팩이 아직 반영되지 않았습니다.`, `상담 업로드`, `지식팩 생성`이 보이지 않는다.
+- dashboard URL과 workspace marker는 현재 workspace context를 유지한다.
+- 정상 dashboard health fixture와 빈 상태 fixture의 의미를 테스트에서 섞지 않는다.
+
+## Non-goals
+
+- Backend dashboard health API, authorization, schema, 또는 response contract를 변경하지 않는다.
+- workspace dashboard의 상담 KPI, 추천 액션, workflow ranking 동작을 변경하지 않는다.
+- Domain Pack list/detail 화면의 빈 상태 정책을 변경하지 않는다.
+- live E2E나 실제 외부 데이터에 의존하는 검증은 추가하지 않는다.
+
+## Validation
+
+| 검증 | 목적 |
+| --- | --- |
+| `pnpm --dir frontend test -- src/features/workspace-dashboard-health/ui/KnowledgePackHealthPanel.test.tsx --run` | health panel 오류/재시도 컴포넌트 회귀 검증 |
+| `pnpm --dir frontend e2e -- workspace-core.spec.ts --grep "Domain Pack 상태 조회가 실패"` | mocked E2E 사용자 시나리오 검증 |
+| `pnpm --dir frontend exec eslint e2e/workspace-core.spec.ts e2e/support/app-mocks.ts src/features/workspace-dashboard-health/ui/KnowledgePackHealthPanel.tsx src/features/workspace-dashboard-health/ui/KnowledgePackHealthPanel.test.tsx` | 변경 TypeScript 파일 lint 확인 |
+| `git diff --check` | 공백/패치 형식 확인 |
+
+## Open Questions
+
+- 없음. 이슈의 디스클레이머에 따라 API 세부 구현보다 사용자가 실패 상태를 오해하지 않는 화면 단언을 기준으로 확정한다.

--- a/frontend/e2e/support/app-mocks.ts
+++ b/frontend/e2e/support/app-mocks.ts
@@ -34,6 +34,7 @@ interface DomainPackMockState {
 export interface AppApiMockOptions {
   readonly uploadLatestPipelineJob?: "default" | "none";
   readonly domainPackGenerationFailureAttempts?: number;
+  readonly dashboardKnowledgePackHealth?: "default" | "error";
 }
 
 interface PipelineReviewMockState {
@@ -1177,6 +1178,7 @@ async function fulfillWorkspaceOperations(
   method: string,
   path: string,
   url: URL,
+  options: AppApiMockOptions,
 ): Promise<boolean> {
   if (method === "GET" && path === "/workspaces/1/members") {
     const q = url.searchParams.get("q")?.toLowerCase() ?? "";
@@ -1266,6 +1268,18 @@ async function fulfillWorkspaceOperations(
   }
 
   if (method === "GET" && path === "/workspaces/1/dashboard/knowledge-pack-health") {
+    if (options.dashboardKnowledgePackHealth === "error") {
+      await fulfillJson(
+        route,
+        {
+          code: "E2E_DASHBOARD_HEALTH_ERROR",
+          message: "운영 지식팩 상태 조회 실패",
+        },
+        500,
+      );
+      return true;
+    }
+
     await fulfillJson(route, {
       activeKnowledgePack: {
         packId: PACK_ID,
@@ -1785,7 +1799,7 @@ export async function installAppApiMocks(
     if (await fulfillWorkspaceShell(route, method, path)) return true;
     if (await fulfillDomainPackRead(route, method, path, domainPackState)) return true;
     if (await fulfillBilling(route, method, path, billingState)) return true;
-    if (await fulfillWorkspaceOperations(route, method, path, url)) return true;
+    if (await fulfillWorkspaceOperations(route, method, path, url, options)) return true;
     if (await fulfillUploadAndReview(route, method, path, options, pipelineReviewState))
       return true;
     if (await fulfillSimulation(route, method, path, url, simulationState)) return true;

--- a/frontend/e2e/workspace-core.spec.ts
+++ b/frontend/e2e/workspace-core.spec.ts
@@ -591,3 +591,46 @@ test.describe("Workspace core operator screens", () => {
     });
   });
 });
+
+test.describe("Workspace dashboard Domain Pack health failure", () => {
+  let seen: string[];
+
+  test.beforeEach(async ({ page }) => {
+    seen = [];
+    await installAuth(page);
+    await installMockStomp(page);
+    await installAppApiMocks(page, seen, {
+      dashboardKnowledgePackHealth: "error",
+    });
+  });
+
+  test("When Domain Pack 상태 조회가 실패하면 안전한 오류와 재시도만 보여준다 @critical", async ({
+    page,
+  }) => {
+    await page.goto("/workspaces/1/dashboard");
+
+    await expect(page).toHaveURL(/\/workspaces\/1\/dashboard$/);
+    await expect(page.getByTestId("workspace-marker")).toContainText("QA Workspace");
+    await expect(page.getByRole("heading", { name: "대시보드", exact: true })).toBeVisible();
+
+    const errorPanel = page.getByTestId("knowledge-health-error");
+    await expect(errorPanel).toContainText("운영 지식팩 상태를 불러오지 못했습니다.");
+    await expect(errorPanel.getByRole("button", { name: "다시 시도" })).toBeVisible();
+
+    await expect(page.getByRole("heading", { name: "운영 지식팩 건강도" })).toHaveCount(0);
+    await expect(page.getByText("v1", { exact: true })).toHaveCount(0);
+    await expect(page.getByText("Generated API Pack")).toHaveCount(0);
+    await expect(page.getByText("운영 지식팩이 아직 반영되지 않았습니다.")).toHaveCount(0);
+    await expect(errorPanel.getByRole("link", { name: /상담 업로드/ })).toHaveCount(0);
+    await expect(errorPanel.getByRole("link", { name: /지식팩 생성/ })).toHaveCount(0);
+
+    const healthRequest = "GET /workspaces/1/dashboard/knowledge-pack-health";
+    await expect.poll(() => seen.filter((entry) => entry === healthRequest).length).toBe(1);
+
+    await errorPanel.getByRole("button", { name: "다시 시도" }).click();
+
+    await expect
+      .poll(() => seen.filter((entry) => entry === healthRequest).length)
+      .toBeGreaterThan(1);
+  });
+});

--- a/frontend/src/features/workspace-dashboard-health/ui/KnowledgePackHealthPanel.test.tsx
+++ b/frontend/src/features/workspace-dashboard-health/ui/KnowledgePackHealthPanel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { describe, expect, it, vi } from "vitest";
 
@@ -66,16 +66,38 @@ describe("KnowledgePackHealthPanel", () => {
     );
   });
 
-  it("error 상태를 표시한다", () => {
+  it("error 상태에서는 stale 운영 상태 대신 재시도 가능한 오류 상태만 표시한다", () => {
+    const refetch = vi.fn();
     mockedUseWorkspaceDashboardHealth.mockReturnValue({
       isLoading: false,
       isError: true,
-      data: undefined,
+      data: {
+        activeKnowledgePack: {
+          packId: 11,
+          packName: "CS Pack",
+          versionId: 12,
+          versionNo: 4,
+          publishedAt: "2026-06-01T10:00:00Z",
+          createdAt: "2026-06-01T09:00:00Z",
+        },
+        lastLogUpload: null,
+        lastKnowledgePackGeneration: null,
+        pendingReviewCount: 0,
+      },
+      refetch,
     } as ReturnType<typeof useWorkspaceDashboardHealth>);
 
     renderPanel();
 
     expect(screen.getByTestId("knowledge-health-error")).toBeInTheDocument();
+    expect(screen.getByText("운영 지식팩 상태를 불러오지 못했습니다.")).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "운영 지식팩 건강도" })).not.toBeInTheDocument();
+    expect(screen.queryByText("v4")).not.toBeInTheDocument();
+    expect(screen.queryByText("CS Pack")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "다시 시도" }));
+
+    expect(refetch).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/frontend/src/features/workspace-dashboard-health/ui/KnowledgePackHealthPanel.tsx
+++ b/frontend/src/features/workspace-dashboard-health/ui/KnowledgePackHealthPanel.tsx
@@ -44,7 +44,10 @@ export function KnowledgePackHealthPanel({ workspaceId }: KnowledgePackHealthPan
   if (healthQuery.isError || !healthQuery.data) {
     return (
       <section className={styles.panel} data-testid="knowledge-health-error">
-        <ErrorState message="운영 지식팩 상태를 불러오지 못했습니다." />
+        <ErrorState
+          message="운영 지식팩 상태를 불러오지 못했습니다."
+          onRetry={() => healthQuery.refetch()}
+        />
       </section>
     );
   }


### PR DESCRIPTION
Closes #701

## 변경 사항

- 이슈 701 요구사항과 acceptance criteria를 `.agent/specs/701.md`에 정리했습니다.
- workspace dashboard의 운영 지식팩 상태 조회 실패 시 `다시 시도`가 가능한 오류 상태를 표시하도록 했습니다.
- 조회 실패 fixture를 실제 빈 Domain Pack 상태와 분리하고, 실패 상태에서 stale 운영 지식팩 이름/버전과 빈 상태 CTA가 보이지 않음을 mocked Critical E2E로 보장했습니다.
- 재시도는 현재 workspace context와 dashboard URL을 유지한 채 같은 health endpoint를 다시 요청합니다.

## 검증

- `pnpm --dir frontend test -- src/features/workspace-dashboard-health/ui/KnowledgePackHealthPanel.test.tsx --run` (1 file, 3 tests; API/FSD audits passed)
- `pnpm --dir frontend exec eslint e2e/workspace-core.spec.ts e2e/support/app-mocks.ts src/features/workspace-dashboard-health/ui/KnowledgePackHealthPanel.tsx src/features/workspace-dashboard-health/ui/KnowledgePackHealthPanel.test.tsx`
- `pnpm --dir frontend exec playwright test workspace-core.spec.ts --grep "Domain Pack 상태 조회가 실패" --config <고포트 임시 config>` (1 passed; 로컬 port 3000이 다른 프로젝트 Next 서버에서 점유되어 고포트 preview config로 실행 후 제거)
- `git diff --check`
- GitHub Actions CI #1981: `spec-check`, `paths-filter`, `scripts-test`, `tool-version-check`, `frontend`, `frontend-e2e`, `openapi-drift`, `frontend-sonar`, `ci-gate` success

## 참고

- 구현 전 `KnowledgePackHealthPanel`, `useWorkspaceDashboardHealth`, `buildWorkspaceDashboardHealthView`, 기존 `workspace-core.spec.ts`, `app-mocks.ts`, `frontend/DESIGN.md`, frontend FSD/API/test rules를 확인했습니다.
- spec review 2회 수행: issue fidelity와 Ostone repository compliance 관점에서 확인했고, 파일명/브랜치/affected paths와 검증 기준을 최종 diff에 맞췄습니다.
- self-review 3회 수행: Round 1에서 stale version label(`v1`) 비노출 assertion을 보강했고, Round 2에서 FSD/API 통합과 mock routing을 확인했으며, Round 3에서 untracked artifacts, 경로, validation claim, retry/accessibility risk를 재확인했습니다.
- main 최신화 중 E2E mock option 충돌은 기존 `domainPackGenerationFailureAttempts`와 신규 `dashboardKnowledgePackHealth` 옵션을 함께 보존하는 방식으로 해결했고, 변경 파일 ESLint/unit/focused E2E를 재실행했습니다.
- pre-commit hook의 `pnpm run lint:frontend`는 API/FSD audit 통과 후 변경 파일 밖 기존 frontend ESLint baseline 47건으로 실패했습니다. 변경 파일 대상 ESLint, focused unit/E2E, staged diff checks와 CI green을 근거로 hook을 우회해 커밋했습니다.